### PR TITLE
CRM-11658 - distmaker - Centralize exclude list; exclude various files that originated in SVN's "tools/packages"

### DIFF
--- a/distmaker/distmaker.sh
+++ b/distmaker/distmaker.sh
@@ -29,6 +29,17 @@ P=`dirname $0`
 # Current dir
 ORIGPWD=`pwd`
 
+# List of files to exclude from all tarballs
+DM_EXCLUDES=".git .svn packages/_ORIGINAL_ packages/SeleniumRC packages/PHPUnit packages/PhpDocumentor packages/SymfonyComponents packages/amavisd-new"
+for DM_EXCLUDE in $DM_EXCLUDES ; do
+  DM_EXCLUDES_RSYNC="--exclude=${DM_EXCLUDE} ${DM_EXCLUDES_RSYNC}"
+done
+## Note: These small folders have items that previously were not published,
+## but there's no real cost to including them, and excluding them seems
+## likely to cause confusion as the codebase evolves:
+##   packages/Files packages/PHP packages/Text
+export DM_EXCLUDES DM_EXCLUDES_RSYNC
+
 # Set no actions by default
 D5PACK=0
 D56PACK=0

--- a/distmaker/dists/drupal6_php5.sh
+++ b/distmaker/dists/drupal6_php5.sh
@@ -15,10 +15,11 @@ else
 	. $CFFILE
 fi
 
-RSYNCOPTIONS="-avC --exclude=svn --exclude=.git --exclude=_ORIGINAL_ --include=core"
+RSYNCOPTIONS="-avC $DM_EXCLUDES_RSYNC --include=core"
 RSYNCCOMMAND="$DM_RSYNC $RSYNCOPTIONS"
 SRC=$DM_SOURCEDIR
 TRG=$DM_TMPDIR/civicrm
+
 
 # checkout the right code revisions
 pushd "$DM_SOURCEDIR/drupal"

--- a/distmaker/dists/drupal_php5.sh
+++ b/distmaker/dists/drupal_php5.sh
@@ -15,7 +15,7 @@ else
 	. $CFFILE
 fi
 
-RSYNCOPTIONS="-avC --exclude=svn --exclude=.git --exclude=_ORIGINAL_ --include=core"
+RSYNCOPTIONS="-avC $DM_EXCLUDES_RSYNC --include=core"
 RSYNCCOMMAND="$DM_RSYNC $RSYNCOPTIONS"
 SRC=$DM_SOURCEDIR
 TRG=$DM_TMPDIR/civicrm

--- a/distmaker/dists/drupal_sk_php5.sh
+++ b/distmaker/dists/drupal_sk_php5.sh
@@ -15,7 +15,7 @@ else
 	. $CFFILE
 fi
 
-RSYNCOPTIONS="-avC --exclude=svn --exclude=.git --exclude=_ORIGINAL_ --include=core"
+RSYNCOPTIONS="-avC $DM_EXCLUDES_RSYNC --include=core"
 RSYNCCOMMAND="$DM_RSYNC $RSYNCOPTIONS"
 SRC=$DM_SOURCEDIR
 TRG=$DM_TMPDIR/civicrm

--- a/distmaker/dists/joomla_php5.sh
+++ b/distmaker/dists/joomla_php5.sh
@@ -15,7 +15,7 @@ else
 	. $CFFILE
 fi
 
-RSYNCOPTIONS="-avC --exclude=svn --exclude=.git --exclude=_ORIGINAL_ --include=core"
+RSYNCOPTIONS="-avC $DM_EXCLUDES_RSYNC --include=core"
 RSYNCCOMMAND="$DM_RSYNC $RSYNCOPTIONS"
 SRC=$DM_SOURCEDIR
 TRG=$DM_TMPDIR/civicrm

--- a/distmaker/dists/l10n.sh
+++ b/distmaker/dists/l10n.sh
@@ -15,7 +15,7 @@ else
 	. $CFFILE
 fi
 
-RSYNCOPTIONS="-avC --exclude=svn --exclude=.git --include=core"
+RSYNCOPTIONS="-avC $DM_EXCLUDES_RSYNC --include=core"
 RSYNCCOMMAND="$DM_RSYNC $RSYNCOPTIONS"
 SRC=$DM_SOURCEDIR
 TRG=$DM_TMPDIR/civicrm

--- a/distmaker/dists/wordpress_php5.sh
+++ b/distmaker/dists/wordpress_php5.sh
@@ -15,7 +15,7 @@ else
 	. $CFFILE
 fi
 
-RSYNCOPTIONS="-avC --exclude=svn --exclude=.git --exclude=_ORIGINAL_ --include=core"
+RSYNCOPTIONS="-avC $DM_EXCLUDES_RSYNC --include=core"
 RSYNCCOMMAND="$DM_RSYNC $RSYNCOPTIONS"
 SRC=$DM_SOURCEDIR
 TRG=$DM_TMPDIR/civicrm


### PR DESCRIPTION
@kurund
