### PR TITLE
Fix broken subtype icon CRM-12054

### DIFF
--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -752,7 +752,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
           $result->contact_id
         );
 
-        $row['contact_type_orig'] = $result->contact_type;
+        $row['contact_type_orig'] = $result->contact_sub_type ? $result->contact_sub_type : $result->contact_type;
         $row['contact_sub_type']  = $result->contact_sub_type ?
           CRM_Contact_BAO_ContactType::contactTypePairs(FALSE, $result->contact_sub_type, ', ') : $result->contact_sub_type;
         $row['contact_id'] = $result->contact_id;
@@ -861,16 +861,8 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
       // allow components to add more actions
       CRM_Core_Component::searchAction($row, $row['contact_id']);
 
-      $contactType = null;
-      if ( CRM_Utils_Array::value('contact_sub_type', $row) ) {
-        $contactType = $row['contact_sub_type'];
-    }
-      elseif ( CRM_Utils_Array::value('contact_type_orig', $row) ) {
-        $contactType = $row['contact_type_orig'];
-  }
-
-      if ( $contactType ) {
-        $row['contact_type'] = CRM_Contact_BAO_Contact_Utils::getImage($contactType,
+      if (!empty($row['contact_type_orig'])) {
+        $row['contact_type'] = CRM_Contact_BAO_Contact_Utils::getImage($row['contact_type_orig'],
           FALSE, $row['contact_id']);
       }
     }


### PR DESCRIPTION
There always seems to be some confusion about the fact that contact type names and labels are not interchangeable. In a demo environment they are always the same and therefore code that mixes them up will seem to work. It might be good to include with our sample data some mismatched names/labels so it can actually be unit-tested. 
