### PR TITLE
gitify: Setup pre-commit hook

### DIFF
--- a/bin/gitify
+++ b/bin/gitify
@@ -39,7 +39,7 @@ function do_hookify() {
   HOOK_DIR="$2"
   if [ -n "$CIVICRM_GIT_HOOKS" ]; then
     echo "[[Install recommended hooks ($TGT)]]"
-    for HOOK in commit-msg post-checkout post-merge pre-commit prepare-commit-msg ;do
+    for HOOK in commit-msg post-checkout post-merge pre-commit prepare-commit-msg post-commit pre-rebase post-rewrite ;do
           cat << TMPL > "$TGT/.git/hooks/$HOOK"
 #!/bin/bash
 if [ -f "\$GIT_DIR/${HOOK_DIR}/${HOOK}" ]; then

--- a/bin/gitify
+++ b/bin/gitify
@@ -32,6 +32,27 @@ function do_gitify() {
   rm -rf "$TMP"
 }
 
+## add hook shims to a repo
+## usage: do_hookify <repo-path> <relative-hook-path>
+function do_hookify() {
+  TGT="$1"
+  HOOK_DIR="$2"
+  if [ -n "$CIVICRM_GIT_HOOKS" ]; then
+    echo "[[Install recommended hooks ($TGT)]]"
+    for HOOK in commit-msg post-checkout post-merge pre-commit prepare-commit-msg ;do
+          cat << TMPL > "$TGT/.git/hooks/$HOOK"
+#!/bin/bash
+if [ -f "\$GIT_DIR/${HOOK_DIR}/${HOOK}" ]; then
+  source "\$GIT_DIR/${HOOK_DIR}/${HOOK}"
+fi
+TMPL
+      chmod +x "$TGT/.git/hooks/$HOOK"
+    done
+  else
+    echo "[[Skip hook installation ($TGT) -- use \"--hooks\" to enable]]"
+  fi
+}
+
 ## usage: do_svnify <repo-url> <existing-dir>
 function do_svnify() {
   REPO="$1"
@@ -51,9 +72,9 @@ function do_svnify() {
 }
 
 function check_dep() {
-  if [ -z `which git` ]; then
+  if [ -z "`which git`" ]; then
     echo "command not found: git"
-    exit
+    exit 3
   fi
 }
 
@@ -61,18 +82,44 @@ function check_dep() {
 
 set -e
 
-CIVICRM_CMS="$1"
-GIT_BASE_URL="$2"
-CIVICRM_ROOT="$3"
-CIVICRM_L10N="$4"
+CIVICRM_CMS=""
+GIT_BASE_URL=""
+CIVICRM_ROOT=""
+CIVICRM_L10N=""
+CIVICRM_GIT_HOOKS=""
 CIVICRM_BRANCH="master"
+
+while [ -n "$1" ]; do
+  if [ "$1" == "--l10n" ]; then
+    CIVICRM_L10N="$1"
+  elif [ "$1" == "--hooks" ]; then
+    CIVICRM_GIT_HOOKS="$1"
+  elif [ -z "$CIVICRM_CMS" ]; then
+    ## First arg
+    CIVICRM_CMS="$1"
+  elif [ -z "$GIT_BASE_URL" ]; then
+    ## Second arg
+    GIT_BASE_URL="$1"
+  elif [ -z "$CIVICRM_ROOT" ]; then
+    ## Third arg
+    CIVICRM_ROOT="$1"
+  else
+    echo "unrecognized argument: $1"
+    exit 2
+  fi
+  shift
+done
+
 if [ -z "$CIVICRM_ROOT" -o ! -d "$CIVICRM_ROOT" -o -z "$GIT_BASE_URL" -o -z "$CIVICRM_CMS" ]; then
   echo "Convert a directory into a set of CiviCRM git clones"
-  echo "usage: $0 <Drupal|Drupal6|Joomla|WordPress|all> <git-base-url> <existing-civicrm-root> [--l10n]"
+  echo "usage: $0 <Drupal|Drupal6|Joomla|WordPress|all> <git-base-url> <existing-civicrm-root> [--l10n] [--hooks]"
   echo "  <cms-name>: one of: Drupal|Drupal6|Joomla|WordPress|all"
   echo "  <git-base-url>: a base URL shared by the desiried git repos (e.g. git://github.com/civicrm)"
   echo "  <existing-civicrm-root>: the main directory containing CiviCRM"
-  echo "  [l10n]: optionally fetch localization data; currently requires svn"
+  echo "  --l10n: optionally fetch localization data; currently requires svn"
+  echo "  --hooks: optionally install recommended git hooks; the hooks are mostly"
+  echo "           tested with git CLI under Linux and OSX; they haven't been"
+  echo "           tested with git GUIs or Windows"
   echo ""
   echo "Note: If pointing to a pre-existing directory, your local changes may be replaced by"
   echo "the pristine code from git/svn. If you've made changes, then make sure there's a backup!"
@@ -90,24 +137,33 @@ fi
 
 check_dep
 do_gitify "${GIT_BASE_URL}/civicrm-core.git" "$CIVICRM_ROOT" -b "${CIVICRM_BRANCH}"
+do_hookify "$CIVICRM_ROOT" "../tools/scripts/git"
 do_gitify "${GIT_BASE_URL}/civicrm-packages.git" "$CIVICRM_ROOT/packages" -b "${CIVICRM_BRANCH}"
+do_hookify "$CIVICRM_ROOT/packages" "../../tools/scripts/git"
 case "$CIVICRM_CMS" in
   Drupal)
     do_gitify "${GIT_BASE_URL}/civicrm-drupal.git" "$CIVICRM_ROOT/drupal" -b "7.x-${CIVICRM_BRANCH}"
+    do_hookify "$CIVICRM_ROOT/drupal" "../../tools/scripts/git"
     ;;
   Drupal6)
     do_gitify "${GIT_BASE_URL}/civicrm-drupal.git" "$CIVICRM_ROOT/drupal" -b "6.x-${CIVICRM_BRANCH}"
+    do_hookify "$CIVICRM_ROOT/drupal" "../../tools/scripts/git"
     ;;
   Joomla)
     do_gitify "${GIT_BASE_URL}/civicrm-joomla.git" "$CIVICRM_ROOT/joomla" -b "${CIVICRM_BRANCH}"
+    do_hookify "$CIVICRM_ROOT/joomla" "../../tools/scripts/git"
     ;;
   WordPress)
     do_gitify "${GIT_BASE_URL}/civicrm-wordpress.git" "$CIVICRM_ROOT/WordPress" -b "${CIVICRM_BRANCH}"
+    do_hookify "$CIVICRM_ROOT/WordPress" "../../tools/scripts/git"
     ;;
   all)
     do_gitify "${GIT_BASE_URL}/civicrm-drupal.git" "$CIVICRM_ROOT/drupal" -b "7.x-${CIVICRM_BRANCH}"
+    do_hookify "$CIVICRM_ROOT/drupal" "../../tools/scripts/git"
     do_gitify "${GIT_BASE_URL}/civicrm-joomla.git" "$CIVICRM_ROOT/joomla" -b "${CIVICRM_BRANCH}"
+    do_hookify "$CIVICRM_ROOT/joomla" "../../tools/scripts/git"
     do_gitify "${GIT_BASE_URL}/civicrm-wordpress.git" "$CIVICRM_ROOT/WordPress" -b "${CIVICRM_BRANCH}"
+    do_hookify "$CIVICRM_ROOT/WordPress" "../../tools/scripts/git"
     ;;
   *)
     echo "Unrecognized CMS: $CIVICRM_CMS"

--- a/tools/scripts/git/commit-msg
+++ b/tools/scripts/git/commit-msg
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Note: This shell script should be designed and tested for cross-platform use
+
+# Reserved for future use

--- a/tools/scripts/git/post-checkout
+++ b/tools/scripts/git/post-checkout
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Note: This shell script should be designed and tested for cross-platform use
+
+# Reserved for future use

--- a/tools/scripts/git/post-merge
+++ b/tools/scripts/git/post-merge
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Note: This shell script should be designed and tested for cross-platform use
+
+# Reserved for future use

--- a/tools/scripts/git/pre-commit
+++ b/tools/scripts/git/pre-commit
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Note: This shell script should be designed and tested for cross-platform use
+
+# URL: https://github.com/totten/git-php-syntax-checker/
+# Author: Remigijus Jarmalavičius <remigijus@jarmalavicius.lt> 
+# Author: Vytautas Povilaitis <php-checker@vytux.lt>
+# License: GPLv3
+
+ROOT_DIR="$(pwd)/"
+LIST=$(git diff-index --cached --name-only --diff-filter=ACMR HEAD)
+ERRORS_BUFFER=""
+for file in $LIST
+do
+    EXTENSION=$(echo "$file" | grep  -E ".php$|.module$|.inc$|.install$")
+    if [ "$EXTENSION" != "" ]; then
+        ERRORS=$(php -l $ROOT_DIR$file 2>&1 | grep "Parse error")
+        if [ "$ERRORS" != "" ]; then
+            if [ "$ERRORS_BUFFER" != "" ]; then
+                ERRORS_BUFFER="$ERRORS_BUFFER\n$ERRORS"
+            else
+                ERRORS_BUFFER="$ERRORS"
+            fi
+            echo "Syntax errors found in file: $file "
+        fi
+    fi
+done
+if [ "$ERRORS_BUFFER" != "" ]; then
+    echo 
+    echo "These errors were found in try-to-commit files: "
+    echo -e $ERRORS_BUFFER
+    echo 
+    echo "Can't commit, fix errors first."
+    exit 1
+else
+    echo "Commited successfully."
+fi

--- a/tools/scripts/git/prepare-commit-msg
+++ b/tools/scripts/git/prepare-commit-msg
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Note: This shell script should be designed and tested for cross-platform use
+
+# Reserved for future use


### PR DESCRIPTION
Automatically setup pre-commit hook on new installations (if gitify is called with "--hooks). The hook validates that PHP files are well-formed using "php -l".

To update existing installations, simply rerun gitify with the original arguments.

This includes stubs for some other hooks. For more description of available git hooks, see http://git-scm.com/book/en/Customizing-Git-Git-Hooks
