### PR TITLE
Specify location of jstree css and improve menu-editing theme

### DIFF
--- a/js/view/crm.designer.js
+++ b/js/view/crm.designer.js
@@ -329,7 +329,8 @@
         themes: {
           "theme": 'classic',
           "dots": false,
-          "icons": false
+          "icons": false,
+          "url": CRM.config.resourceBase + 'packages/jquery/plugins/jstree/themes/classic/style.css'
         },
         'plugins': ['themes', 'json_data', 'ui', 'search']
       }).bind('loaded.jstree', function () {

--- a/templates/CRM/Admin/Page/Navigation.tpl
+++ b/templates/CRM/Admin/Page/Navigation.tpl
@@ -43,6 +43,14 @@
     <div class="spacer"></div>
   </div>
   {literal}
+  <style type="text/css">
+    #navigation-tree li {
+      font-weight: normal;
+    }
+    #navigation-tree > ul > li {
+      font-weight: bold;
+    }
+  </style>
   <script type="text/javascript">
     cj(function () {
     cj("#navigation-tree").jstree({
@@ -54,6 +62,12 @@
         url : {/literal}"{crmURL p='civicrm/ajax/menu' h=0 q='key='}{crmKey name='civicrm/ajax/menu'}"{literal}
       }
     },
+    themes: {
+      "theme": 'classic',
+      "dots": true,
+      "icons": false,
+      "url": CRM.config.resourceBase + 'packages/jquery/plugins/jstree/themes/classic/style.css'
+    },
     rules : {
       droppable : [ "tree-drop" ],
       multiple : true,
@@ -64,7 +78,6 @@
       move: {
         check_move: function(m) {
           var homeMenuId = {/literal}"{$homeMenuId}"{literal};
-
           if ( cj( m.r[0] ).attr('id').replace("node_","") == homeMenuId ||
             cj( m.o[0] ).attr('id').replace("node_","") == homeMenuId ) {
             return false;

--- a/templates/CRM/Tag/Form/Tag.tpl
+++ b/templates/CRM/Tag/Form/Tag.tpl
@@ -85,7 +85,10 @@
       });
 
       //load js tree.
-      cj("#tagtree").jstree({"plugins" : ["themes", "html_data"]});
+      cj("#tagtree").jstree({
+        "plugins" : ["themes", "html_data"],
+        "themes": {"url": CRM.config.resourceBase + 'packages/jquery/plugins/jstree/themes/default/style.css'}
+      });
 
       {/literal}
       {if $permission neq 'edit'}


### PR DESCRIPTION
Needed to specify the location of jstree's css explicitly since the path changes during drupal's js aggregation.
While I was at it, applied what we learned in the profile editor work to make the menu editor look less funky.
