### PR TITLE
CRM-12084 fix : Upgrade verifyPreDBState - check for orphaned contribution records 

### DIFF
--- a/sql/civicrm_generated.mysql
+++ b/sql/civicrm_generated.mysql
@@ -392,7 +392,7 @@ UNLOCK TABLES;
 
 LOCK TABLES `civicrm_domain` WRITE;
 /*!40000 ALTER TABLE `civicrm_domain` DISABLE KEYS */;
-INSERT INTO `civicrm_domain` (`id`, `name`, `description`, `config_backend`, `version`, `contact_id`, `locales`, `locale_custom_strings`) VALUES (1,'Default Domain Name',NULL,NULL,'4.3.beta2',1,NULL,NULL);
+INSERT INTO `civicrm_domain` (`id`, `name`, `description`, `config_backend`, `version`, `contact_id`, `locales`, `locale_custom_strings`) VALUES (1,'Default Domain Name',NULL,NULL,'4.3.beta3',1,NULL,NULL);
 /*!40000 ALTER TABLE `civicrm_domain` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/xml/version.xml
+++ b/xml/version.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="iso-8859-1" ?>
 <version>
-    <version_no>4.3.beta2</version_no>
+    <version_no>4.3.beta3</version_no>
 </version>


### PR DESCRIPTION
added check to display a message to user before upgrade : if contribution records consists of contact_id not present in civicrm_contact table

commit also consists of change in version from 4.3.beta2 to 4.3.beta3
