### PR TITLE
Profile editor: Fetch pre/post help for custom fields

### DIFF
--- a/js/model/crm.designer.js
+++ b/js/model/crm.designer.js
@@ -60,7 +60,7 @@
       name = this.get('fieldName').split('_');
       if (name[0] === 'custom') {
         CRM.api('custom_field', 'getsingle', {id: name[1]}, {success: function(field) {
-          ufFieldModel.set(field);
+          ufFieldModel.set(_.pick(field, 'help_pre', 'help_post', 'is_required'));
         }});
       }
       return ufFieldModel;

--- a/js/model/crm.designer.js
+++ b/js/model/crm.designer.js
@@ -41,7 +41,7 @@
      * @return {CRM.UF.UFFieldModel} or null (if the field is not addable)
      */
     addToUFCollection: function(ufFieldCollection, addOptions) {
-      var paletteFieldModel = this;
+      var name, paletteFieldModel = this;
       var ufFieldModel = paletteFieldModel.createUFFieldModel(ufFieldCollection.getRel('ufGroupModel'));
       ufFieldModel.set('uf_group_id', ufFieldCollection.uf_group_id);
       if (!ufFieldCollection.isAddable(ufFieldModel)) {
@@ -55,6 +55,14 @@
         return null;
       }
       ufFieldCollection.add(ufFieldModel, addOptions);
+      // Load metadata and set defaults
+      // TODO: currently only works for custom fields
+      name = this.get('fieldName').split('_');
+      if (name[0] === 'custom') {
+        CRM.api('custom_field', 'getsingle', {id: name[1]}, {success: function(field) {
+          ufFieldModel.set(field);
+        }});
+      }
       return ufFieldModel;
     },
     createUFFieldModel: function(ufGroupModel) {

--- a/js/view/crm.designer.js
+++ b/js/view/crm.designer.js
@@ -678,10 +678,16 @@
         fields: fields
       });
       this.form.on('change', this.onFormChange, this);
+      this.model.on('change', this.onModelChange, this);
     },
     render: function() {
       this.$el.html(this.form.render().el);
       this.onFormChange();
+    },
+    onModelChange: function() {
+      $.each(this.form.fields, function(i, field) {
+        this.form.setValue(field.key, this.model.get(field.key));
+      });
     },
     onFormChange: function() {
       this.form.commit();


### PR DESCRIPTION
I thought this would be simple (loading the pre/post help for custom fields the way the old quickform profile editor does). But the form wasn't updating when the model did, so I had to add a change handler for that. Seems like a strange shortcoming of backbone.forms that I had to do that.
But you'll be proud of me Tim that I did it the MVC way and not the much easier (for me) dom-manipulation way.
