### PR TITLE
CRM-12062 : minor bug found by failing test case WebTest_Event_AddEventTest::testAddPaidEventNoTemplate

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -1230,7 +1230,7 @@ WHERE  v.option_group_id = g.id
       }
     }
     // check if user has permission, CRM-12062
-    else if (CRM_Contact_BAO_Contact_Permission::allow($tempID)) {
+    else if ($tempID && CRM_Contact_BAO_Contact_Permission::allow($tempID)) {
       return $tempID;
     }
 


### PR DESCRIPTION
encountered a minor bug while running WebTest_Event_AddEventTest::testAddPaidEventNoTemplate : 

when a logged in / authenticated user(in my case admin user) visits event registration page with url (civicrm/event/register?id=9&reset=1 - with no 'cid' parameter) a fatal error occurs.

Its backtrace : 
#0 /home/pratik/git/civicrm/CRM/Core/Error.php(308): CRM_Core_Error::backtrace()
#1 /home/pratik/git/civicrm/CRM/Core/DAO.php(754): CRM_Core_Error::fatal()
#2 /home/pratik/git/civicrm/CRM/Contact/BAO/Contact/Permission.php(52): CRM_Core_DAO::getFieldValue("CRM_Contact_DAO_Contact", NULL, "is_deleted")
#3 /home/pratik/git/civicrm/CRM/Event/Form/Registration.php(1233): CRM_Contact_BAO_Contact_Permission::allow(NULL)
#4 /home/pratik/git/civicrm/CRM/Event/Form/Registration/Register.php(1394): CRM_Event_Form_Registration->getContactID()
#5 /home/pratik/git/civicrm/CRM/Event/Form/Registration/Register.php(122): CRM_Event_Form_Registration_Register->checkRegistration(NULL, Object(CRM_Event_Form_Registration_Register))
#6 /home/pratik/git/civicrm/CRM/Core/Form.php(336): CRM_Event_Form_Registration_Register->preProcess()

If the url civicrm/event/register?id=9&reset=1 doesn't have 'cid' parameter following happens :
- $tempID is set to null inside function CRM_Event_Form_Registration::getContactID().
- cause of this null $tempID set : the above invokation(in bactrace) happens which leads to fatal error 

this error only occurs if we don't add a 'cid' parameter in url civicrm/event/register?id=9&reset=1
