### PR TITLE
-- fixed for CRM-12142

### DIFF
--- a/CRM/Upgrade/Incremental/sql/4.3.beta4.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.3.beta4.mysql.tpl
@@ -1,0 +1,5 @@
+-- CRM-12142
+{if !$multilingual}
+  ALTER TABLE `civicrm_premiums` 
+    ADD COLUMN premiums_nothankyou_label varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL COMMENT 'Label displayed for No Thank-you option in premiums block (e.g. No thank you)';
+{/if}


### PR DESCRIPTION
premiums_nothankyou_label field was not created in 4.3.alpha1, only incase of multi-lingual is created.
