### PR TITLE
-- fix for wrong pagetitle getting displayed for mailing pages

### DIFF
--- a/CRM/Mailing/Page/Browse.php
+++ b/CRM/Mailing/Page/Browse.php
@@ -128,6 +128,8 @@ class CRM_Mailing_Page_Browse extends CRM_Core_Page {
     $this->preProcess();
 
     $newArgs = func_get_args();
+    // since we want only first function argument
+    $newArgs = $newArgs[0];
     if (isset($_GET['runJobs']) || CRM_Utils_Array::value('2', $newArgs) == 'queue') {
       $config = CRM_Core_Config::singleton();
       CRM_Mailing_BAO_Job::runJobs_pre($config->mailerJobSize);


### PR DESCRIPTION
Fix for wrong pageTitle that was getting displayed in mailing pages which was found while running webtests.
