### PR TITLE
fix for : CRM-12130

### DIFF
--- a/CRM/Extension/Mapper.php
+++ b/CRM/Extension/Mapper.php
@@ -235,6 +235,10 @@ class CRM_Extension_Mapper {
    */
   public function keyToUrl($key) {
     if ($key == 'civicrm') {
+      if (empty($this->civicrmUrl)) {
+        $config = CRM_Core_Config::singleton();
+        return rtrim($config->resourceBase, '/');
+      }
       return $this->civicrmUrl;
     }
 

--- a/CRM/Extension/Mapper.php
+++ b/CRM/Extension/Mapper.php
@@ -235,6 +235,8 @@ class CRM_Extension_Mapper {
    */
   public function keyToUrl($key) {
     if ($key == 'civicrm') {
+      // CRM-12130 Workaround: If the domain's config_backend is NULL at the start of the request,
+      // then the Mapper is wrongly constructed with an empty value for $this->civicrmUrl.
       if (empty($this->civicrmUrl)) {
         $config = CRM_Core_Config::singleton();
         return rtrim($config->resourceBase, '/');


### PR DESCRIPTION
The script files take wrong url because when CRM_Core_Resources::singleton()->addCoreResources(); invokes at line 293 (Wordpress/civicrm.php), which internally calls CRM_Core_Resources::getUrl function which returns blank. Due to this the script file inclusion url is wrong.
