### PR TITLE
minor fix for 'Tag Merge UI break'  found during qa of CRM-12153 

### DIFF
--- a/templates/CRM/Admin/Page/Tag.tpl
+++ b/templates/CRM/Admin/Page/Tag.tpl
@@ -111,8 +111,8 @@ cj("#mergeTagDialog").hide( );
 cj( function() {
     cj('.merge_tag').click(function(){
         var row_id = cj(this).closest('tr').attr('id');
-        var tagId = row_id.split('_');
-        mergeTag( tagId[2] );
+        var tagId = row_id.split('-');
+        mergeTag(tagId[1]);
     });
 });
 
@@ -168,7 +168,7 @@ function mergeTag( fromId ) {
 
                 /* send synchronous request so that disabling any actions for slow servers*/
         var postUrl = {/literal}"{crmURL p='civicrm/ajax/mergeTags' h=0 }"{literal};
-        var data    = '{fromId:'+ fromId + ',toId:'+ toId + ",key:{/literal}{crmKey name='civicrm/ajax/mergeTags'}{literal}}";
+        var data    = {fromId: fromId, toId: toId, key:{/literal}"{crmKey name='civicrm/ajax/mergeTags'}"{literal}};
                 cj.ajax({ type     : "POST",
             url      : postUrl,
             data     : data,


### PR DESCRIPTION
found UI break while merging tags through UI.

visit civicrm/admin/tag?reset=1.
- make sure you have alteast 2 tags, click on merge link beside a tag row.
- a popup will appear with a auto-complete field, start filling the field with a tag name, the tag listing appears to be broken on that field.

After fixing fixing above bug:
- go foward after doing same steps mentioned above and click on 'ok' .
- the tags are still not merged, and Invalid type defination fatal error is shown in firefox console during executing ajax url for merging tags.
  This happens because the 'post data' passing happens to be a single string and thus undefined is caught by the type defination of a post param checking for Integer, which generates error.
