### PR TITLE
CRM-12170 : fix for header shift and incorrect showing of contact type i...

### DIFF
--- a/templates/CRM/Contact/Form/Selector.tpl
+++ b/templates/CRM/Contact/Form/Selector.tpl
@@ -133,7 +133,7 @@
               </td>
            {else}
               {foreach from=$row item=value key=key}
-                {if ($key neq "checkbox") and ($key neq "action") and ($key neq "contact_type") and ($key neq "contact_sub_type") and ($key neq "status") and ($key neq "sort_name") and ($key neq "contact_id")}
+                {if ($key neq "checkbox") and ($key neq "action") and ($key neq "contact_type") and ($key neq "contact_sub_type") and ($key neq "status") and ($key neq "sort_name") and ($key neq "contact_id") and ($key neq "contact_type_orig")}
                  <td>{$value}&nbsp;</td>
                 {/if}
               {/foreach}


### PR DESCRIPTION
added a condition to not include the contact type in the listing of search builder result, it solves the Header shift issue.
