### PR TITLE
CRM-12173 Modified approach to use profile ID instead of title to avoid ...

### DIFF
--- a/templates/CRM/UF/Form/Block.tpl
+++ b/templates/CRM/UF/Form/Block.tpl
@@ -44,7 +44,7 @@
         {/if}
 
         {if $mode ne 8 && $action ne 1028 && $action ne 4}
-        <fieldset><legend>{$field.groupTitle}</legend>
+        <fieldset class="crm-profile crm-profile-id-{$field.group_id}"><legend>{$field.groupTitle}</legend>
         {/if}
 
         {if $form.formName eq 'Confirm' OR $form.formName eq 'ThankYou'}


### PR DESCRIPTION
...possible issues w/ special and non-latin characters in profile title string. Also ID is likely more stable than title.
