### PR TITLE
--fixed for CRM-12155

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -772,7 +772,13 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
       $logDAO->entity_table = 'civicrm_contact';
       $logDAO->entity_id = $id;
       $logDAO->delete();
+      
+      // delete contact participants CRM-12155
+      CRM_Event_BAO_Participant::deleteContactParticipant($id);
 
+      // delete contact contributions CRM-12155
+      CRM_Contribute_BAO_Contribution::deleteContactContribution($id);
+      
       // do activity cleanup, CRM-5604
       CRM_Activity_BAO_Activity::cleanupActivity($id);
 

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2963,4 +2963,23 @@ WHERE  contribution_id = %1 ";
       $errors['contribution_status_id'] = ts("Cannot change contribution status from %1 to %2.", array(1 => $contributionStatuses[$values['contribution_status_id']], 2 => $contributionStatuses[$fields['contribution_status_id']]));
     }
   }
+
+  /**
+   * Function to delete contribution of contact
+   *
+   * CRM-12155
+   *
+   * @param integer $contactId contact id 
+   *
+   * @access public
+   * @static
+   */
+  static function deleteContactContribution($contactId) {
+    $contribution = new CRM_Contribute_DAO_Contribution();
+    $contribution->contact_id = $contactId;
+    $contribution->find();
+    while ($contribution->fetch()) {
+      self::deleteContribution($contribution->id);
+    }
+  }
 }

--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -1759,5 +1759,24 @@ WHERE cpf.price_set_id = %1 AND cpfv.label LIKE %2";
     }
     return;
   }
+
+  /**
+   * Function to delete participants of contact
+   *
+   * CRM-12155
+   *
+   * @param integer $contactId contact id 
+   *
+   * @access public
+   * @static
+   */
+  static function deleteContactParticipant($contactId) {
+    $participant = new CRM_Event_DAO_Participant();
+    $participant->contact_id = $contactId;
+    $participant->find();
+    while ($participant->fetch()) {
+      self::deleteParticipant($participant->id);
+    }
+  }
 }
 


### PR DESCRIPTION
Initially when contact was deleted permanently contribution, membership and participants rows get deleted for contact because of ON DELETE CASCADE, its related rows for contribution, participant were not deleted since there was no BAO handling for contribution and participant.
