### PR TITLE
make group_id be id (after the opposite was done)

### DIFF
--- a/api/v3/Group.php
+++ b/api/v3/Group.php
@@ -108,6 +108,9 @@ function civicrm_api3_group_get($params) {
     $returnProperties['id'] = 1;
     $returnProperties = array_keys($returnProperties);
   }
+  if (CRM_Utils_Array::value('group_id', $inputParams)) {
+    $inputParams['id'] = $inputParams['group_id'];
+  }
   $groupObjects = CRM_Contact_BAO_Group::getGroups($inputParams, $returnProperties, $sort, $offset, $rowCount);
   if (empty($groupObjects)) {
     return civicrm_api3_create_success(FALSE);

--- a/api/v3/Group.php
+++ b/api/v3/Group.php
@@ -97,7 +97,7 @@ function _civicrm_api3_group_create_spec(&$params) {
  */
 function civicrm_api3_group_get($params) {
 
-  $options          = _civicrm_api3_get_options_from_params($params, TRUE, 'get');
+  $options          = _civicrm_api3_get_options_from_params($params, TRUE, 'group', 'get');
   $sort             = CRM_Utils_Array::value('sort', $options, NULL);
   $offset           = CRM_Utils_Array::value('offset', $options);
   $rowCount         = CRM_Utils_Array::value('limit', $options);


### PR DESCRIPTION
To fix CRM-12146. Param "id" is set to "group_id" by _civicrm_api3_get_options_from_params--this copies it back.
