### PR TITLE
CRM-12243 check if premiums_nothankyou_label column exists before adding...

### DIFF
--- a/CRM/Upgrade/Incremental/php/FourThree.php
+++ b/CRM/Upgrade/Incremental/php/FourThree.php
@@ -261,7 +261,6 @@ WHERE ceft.entity_id IS NULL;";
   }
 
   function upgrade_4_3_beta5($rev) {
-    $this->addTask(ts('Upgrade DB to 4.3.beta5: SQL'), 'task_4_3_x_runSql', $rev);
     // CRM-12205
     if (
       CRM_Core_DAO::checkTableExists('log_civicrm_financial_trxn') &&
@@ -269,6 +268,13 @@ WHERE ceft.entity_id IS NULL;";
     ) {
       CRM_Core_DAO::executeQuery('ALTER TABLE `log_civicrm_financial_trxn` CHANGE `trxn_id` `trxn_id` VARCHAR(255) NULL DEFAULT NULL');
     }
+    // CRM-12142 - some sites didn't get this column added yet, and sites which installed 4.3 from scratch will already have it
+    if (
+      !CRM_Core_DAO::checkFieldExists('civicrm_premiums', 'premiums_nothankyou_label')
+    ) {
+       CRM_Core_DAO::executeQuery('ALTER TABLE `civicrm_premiums` ADD COLUMN premiums_nothankyou_label varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL COMMENT "Label displayed for No Thank-you option in premiums block (e.g. No thank you)"');
+    }    
+    $this->addTask(ts('Upgrade DB to 4.3.beta5: SQL'), 'task_4_3_x_runSql', $rev);
   }
 
   //CRM-11636

--- a/CRM/Upgrade/Incremental/sql/4.3.beta4.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.3.beta4.mysql.tpl
@@ -1,18 +1,3 @@
--- CRM-12142
-{if !$multilingual}
-  ALTER TABLE `civicrm_premiums`
-    ADD COLUMN premiums_nothankyou_label varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL COMMENT 'Label displayed for No Thank-you
- option in premiums block (e.g. No thank you)';
-
--- Also need to populate default text for premiums_nothankyou_label
-  UPDATE `civicrm_premiums` SET premiums_nothankyou_label = '{ts escape="sql"}No thank-you{/ts}';
-{else}
-  {foreach from=$locales item=locale}
-    UPDATE `civicrm_premiums` SET premiums_nothankyou_label_{$locale} = '{ts escape="sql"}No thank-you{/ts}';	   
-  {/foreach}
-{/if}
-
-
 -- CRM-12151
 ALTER TABLE civicrm_option_value
   DROP INDEX index_option_group_id_value,

--- a/CRM/Upgrade/Incremental/sql/4.3.beta5.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.3.beta5.mysql.tpl
@@ -1,1 +1,9 @@
-# empty sql file as a placeholder
+-- CRM-12142
+-- Populate default text for premiums_nothankyou_label
+{if !$multilingual}
+  UPDATE `civicrm_premiums` SET premiums_nothankyou_label = '{ts escape="sql"}No thank-you{/ts}';
+{else}
+  {foreach from=$locales item=locale}
+    UPDATE `civicrm_premiums` SET premiums_nothankyou_label_{$locale} = '{ts escape="sql"}No thank-you{/ts}';	   
+  {/foreach}
+{/if}

--- a/CRM/Upgrade/Incremental/sql/4.3.beta5.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.3.beta5.mysql.tpl
@@ -1,9 +1,3 @@
 -- CRM-12142
 -- Populate default text for premiums_nothankyou_label
-{if !$multilingual}
-  UPDATE `civicrm_premiums` SET premiums_nothankyou_label = '{ts escape="sql"}No thank-you{/ts}';
-{else}
-  {foreach from=$locales item=locale}
-    UPDATE `civicrm_premiums` SET premiums_nothankyou_label_{$locale} = '{ts escape="sql"}No thank-you{/ts}';	   
-  {/foreach}
-{/if}
+UPDATE `civicrm_premiums` SET {localize field="premiums_nothankyou_label"}premiums_nothankyou_label = '{ts escape="sql"}No thank-you{/ts}'{/localize};


### PR DESCRIPTION
... it. Move update sql statement to beta5 mysql.

---
- CRM-12243: Beta 4 upgrade fails with duplicate column error if site was originally installed as a 4.3 site
  http://issues.civicrm.org/jira/browse/CRM-12243
