### PR TITLE
Payprocc

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -101,18 +101,8 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
 
     $this->_onbehalf = FALSE;
     if (CRM_Utils_Array::value('is_for_organization', $this->_values)) {
-      $urlParams = "&id={$this->_id}&qfKey={$this->controller->_key}";
-      $this->assign('urlParams', $urlParams);
-      $this->_onbehalf = CRM_Utils_Array::value('onbehalf', $_GET);
-
+      $this->_onbehalf = TRUE;
       CRM_Contribute_Form_Contribution_OnBehalfOf::preProcess($this);
-      if (CRM_Utils_Array::value('hidden_onbehalf_profile', $_POST) &&
-        (CRM_Utils_Array::value('is_for_organization', $_POST) ||
-          CRM_Utils_Array::value('is_for_organization', $this->_values) == 2
-        )
-      ) {
-        CRM_Contribute_Form_Contribution_OnBehalfOf::buildQuickForm($this);
-      }
     }
 
     if (CRM_Utils_Array::value('id', $this->_pcpInfo) &&
@@ -388,8 +378,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       $this->_onBehalfRequired = 1;
     }
     if ($this->_onbehalf) {
-      $this->assign('onbehalf', TRUE);
-      return CRM_Contribute_Form_Contribution_OnBehalfOf::buildQuickForm($this);
+      CRM_Contribute_Form_Contribution_OnBehalfOf::buildQuickForm($this);
     }
 
     $this->applyFilter('__ALL__', 'trim');

--- a/CRM/Core/Payment/ProcessorForm.php
+++ b/CRM/Core/Payment/ProcessorForm.php
@@ -102,13 +102,14 @@ class CRM_Core_Payment_ProcessorForm {
 
       CRM_Core_Error::fatal(ts('This contribution page is configured to support separate contribution and membership payments. This %1 plugin does not currently support multiple simultaneous payments, or the option to "Execute real-time monetary transactions" is disabled. Please contact the site administrator and notify them of this error',
           array(1 => $form->_paymentProcessor['payment_processor_type'])
-        ));
+        )
+      );
     }
 
     $profileAddressFields = $form->get('profileAddressFields');
-    if (!empty( $profileAddressFields)){
+    if (!empty( $profileAddressFields)) {
       $form->assign('profileAddressFields', $profileAddressFields);
-  }
+    }
   }
 
   static function buildQuickform(&$form) {

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -68,7 +68,8 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
    */
   public $_skipDupeRegistrationCheck = FALSE;
 
-  protected $_ppType;
+  public $_ppType;
+  public $_snippet;
 
   /**
    * Function to set variables up before form is built
@@ -78,24 +79,10 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
    */
   function preProcess() {
     parent::preProcess();
-    $this->_ppType = CRM_Utils_Array::value('type', $_GET);
-    $this->assign('ppType', FALSE);
-    if ($this->_ppType) {
-      $this->assign('ppType', TRUE);
-      return CRM_Core_Payment_ProcessorForm::preProcess($this);
-    }
 
-    //get payPal express id and make it available to template
-    $paymentProcessors = $this->get('paymentProcessors');
-    $this->assign('payPalExpressId', 0);
-    if (!empty($paymentProcessors)) {
-      foreach ($paymentProcessors as $ppId => $values) {
-        $payPalExpressId = ($values['payment_processor_type'] == 'PayPal_Express') ? $values['id'] : 0;
-        $this->assign('payPalExpressId', $payPalExpressId);
-        if ($payPalExpressId) {
-          break;
-        }
-      }
+    CRM_Contribute_Form_Contribution_Main::preProcessPaymentOptions($this);
+    if ($this->_snippet) {
+      return;
     }
 
     //CRM-4320.
@@ -156,7 +143,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
    * @return None
    */
   function setDefaultValues() {
-    if ($this->_ppType && !($this->_paymentProcessor['billing_mode'] & CRM_Core_Payment::BILLING_MODE_FORM)) {
+    if ($this->_ppType && $this->_snippet && !($this->_paymentProcessor['billing_mode'] & CRM_Core_Payment::BILLING_MODE_FORM)) {
       // see function comment block for explanation of this
       return;
     }
@@ -344,8 +331,13 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
    * @access public
    */
   public function buildQuickForm() {
+    // Build payment processor form
     if ($this->_ppType) {
-      return CRM_Core_Payment_ProcessorForm::buildQuickForm($this);
+      CRM_Core_Payment_ProcessorForm::buildQuickForm($this);
+      // Return if we are in an ajax callback
+      if ($this->_snippet) {
+        return;
+      }
     }
 
     $contactID = parent::getContactID();
@@ -554,7 +546,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
    */
   static public function buildAmount(&$form, $required = TRUE, $discountId = NULL) {
     //if payment done, no need to build the fee block.
-    if (isset($form->_paymentId) && $form->_paymentId) {
+    if (!empty($form->_paymentId)) {
       //fix to diaplay line item in update mode.
       $form->assign('priceSet', isset($form->_priceSet) ? $form->_priceSet : NULL);
       return;

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -52,9 +52,7 @@
     {/if}
   {/if}
 
-{* Callback snippet: Load on-behalf profile *}
-{elseif $onbehalf and $snippet}
-  {include file=CRM/Contribute/Form/Contribution/OnBehalfOf.tpl}
+{* Main Form *}  
 {else}
   {literal}
   <script type="text/javascript">
@@ -181,8 +179,9 @@
   {/if}
 
   {if $is_for_organization}
-  <div id='onBehalfOfOrg' class="crm-section"></div>
-  {include file=CRM/Contribute/Form/Contribution/OnBehalfOf.tpl}
+  <div id='onBehalfOfOrg' class="crm-section">
+    {include file=CRM/Contribute/Form/Contribution/OnBehalfOf.tpl}
+  </div>
   {/if}
 
   {* User account registration option. Displays if enabled for one of the profiles on this page. *}

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -23,7 +23,8 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-{if $ppType}
+{* Callback snippet: Load payment processor *}
+{if $ppType and $snippet}
 {include file="CRM/Core/BillingBlock.tpl" context="front-end"}
   {if $is_monetary}
   {* Put PayPal Express button after customPost block since it's the submit button in this case. *}
@@ -51,7 +52,8 @@
     {/if}
   {/if}
 
-{elseif $onbehalf}
+{* Callback snippet: Load on-behalf profile *}
+{elseif $onbehalf and $snippet}
   {include file=CRM/Contribute/Form/Contribution/OnBehalfOf.tpl}
 {else}
   {literal}
@@ -294,7 +296,12 @@
   </fieldset>
   {/if}
 
-  <div id="billing-payment-block"></div>
+  <div id="billing-payment-block">
+    {* If we have a payment processor, load it - otherwise it happens via ajax *}
+    {if $ppType}
+      {include file="CRM/Contribute/Form/Contribution/Main.tpl" snippet=4}
+    {/if}
+  </div>
   {include file="CRM/common/paymentBlock.tpl"}
 
   <div class="crm-group custom_post_profile-group">

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -273,7 +273,8 @@
   {/if}
 
   {if $form.payment_processor.label}
-  <fieldset class="crm-group payment_options-group">
+  {* PP selection only works with JS enabled, so we hide it initially *}
+  <fieldset class="crm-group payment_options-group" style="display:none;">
     <legend>{ts}Payment Options{/ts}</legend>
     <div class="crm-section payment_processor-section">
       <div class="label">{$form.payment_processor.label}</div>

--- a/templates/CRM/Contribute/Form/Contribution/OnBehalfOf.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/OnBehalfOf.tpl
@@ -23,7 +23,13 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-{* This file provides the HTML for the on-behalf-of form. Can also be used for related contact edit form. *}
+{**
+ * This file provides the HTML for the on-behalf-of form. 
+ * Also used for related contact edit form.
+ * FIXME: This is way more complex than it needs to be
+ * FIXME: About 1% of this javascript is needed for contribution forms
+ * FIXME: Why are we not just using the dynamic form tpl to display this profile?
+ *}
 
 {if $buildOnBehalfForm or $onBehalfRequired}
 <fieldset id="for_organization" class="for_organization-group">
@@ -127,19 +133,13 @@
 
 {literal}
 <script type="text/javascript">
-  var reset            = {/literal}"{$reset}"{literal};
-  var onBehalfRequired = {/literal}"{$onBehalfRequired}"{literal};
-  var mainDisplay      = {/literal}"{$mainDisplay}"{literal};
-  var mode             = {/literal}"{$mode}"{literal};
   cj( "div#id-onbehalf-orgname-help").hide( );
 
-  if (mainDisplay) {
-    showOnBehalf(false);
-  }
+  showOnBehalf({/literal}"{$onBehalfRequired}"{literal});
 
   cj( "#mode" ).hide( );
   cj( "#mode" ).attr( 'checked', 'checked' );
-  if ( cj( "#mode" ).attr( 'checked' ) && !reset ) {
+  if ( cj( "#mode" ).attr( 'checked' ) && !{/literal}"{$reset}"{literal} ) {
     $text = ' {/literal}{ts escape="js"}Use existing organization{/ts}{literal} ';
     cj( "#createNewOrg" ).text( $text );
     cj( "#mode" ).removeAttr( 'checked' );
@@ -147,29 +147,28 @@
 
 function showOnBehalf(onBehalfRequired) {
   if ( cj( "#is_for_organization" ).attr( 'checked' ) || onBehalfRequired ) {
-    cj( "#for_organization" ).html( '' );
-    var urlPath = {/literal}"{crmURL p=$urlPath h=0 q='snippet=4&onbehalf=1'}"{literal};
-    urlPath     = urlPath  + {/literal}"{$urlParams}"{literal};
-    if ( mode == 'test' ) {
-      urlPath = urlPath  + '&action=preview';
+    var urlPath = {/literal}"{crmURL p=$urlPath h=0 q='snippet=4&onbehalf=1'}";
+    urlPath += "{$urlParams}";
+    {if $mode eq 'test'}
+      urlPath += '&action=preview';
+    {/if}
+    {if $reset}
+      urlPath += '&reset={$reset}';
+    {/if}{literal}
+    cj("#onBehalfOfOrg").show();
+    if (cj("#onBehalfOfOrg *").length < 1) {
+      cj.ajax({
+        url     : urlPath,
+        global  : false,
+        async   : false,
+        success : function ( content ) {
+          cj( "#onBehalfOfOrg" ).html( content );
+        }
+      });
     }
-    if ( reset ) {
-      urlPath = urlPath + '&reset=' + reset;
-    }
-
-    cj.ajax({
-      url     : urlPath,
-      async   : false,
-      global  : false,
-      success : function ( content ) {
-        cj( "#onBehalfOfOrg" ).html( content );
-      }
-    });
   }
   else {
-    cj( "#onBehalfOfOrg" ).html('');
-    cj( "#for_organization" ).html( '' );
-    return;
+    cj("#onBehalfOfOrg").hide();
   }
 }
 
@@ -193,14 +192,13 @@ function resetValues( filter ) {
 
 function createNew( ) {
   if (cj("#mode").attr('checked')) {
-    textMessage = ' {/literal}{ts escape="js"}Use existing organization{/ts}{literal} ';
+    var textMessage = ' {/literal}{ts escape="js"}Use existing organization{/ts}{literal} ';
     cj("#onbehalf_organization_name").removeAttr('readonly');
     cj("#mode").removeAttr('checked');
-
     resetValues( false );
   }
   else {
-    textMessage = ' {/literal}{ts escape="js"}Enter a new organization{/ts}{literal} ';
+    var textMessage = ' {/literal}{ts escape="js"}Enter a new organization{/ts}{literal} ';
     cj("#mode").attr('checked', 'checked');
     setOrgName( );
   }

--- a/templates/CRM/Event/Form/Registration/Register.tpl
+++ b/templates/CRM/Event/Form/Registration/Register.tpl
@@ -23,7 +23,8 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-{if $ppType}
+{* Callback snippet: Load payment processor *}
+{if $ppType and $snippet}
   {include file="CRM/Core/BillingBlock.tpl" context="front-end"}
 
 <div id="paypalExpress">
@@ -144,7 +145,7 @@
 {include file="CRM/UF/Form/Block.tpl" fields=$customPre}
 
 {if $form.payment_processor.label}
-<fieldset class="crm-group payment_options-group">
+<fieldset class="crm-group payment_options-group" style="display:none;">
   <legend>{ts}Payment Options{/ts}</legend>
   <div class="crm-section payment_processor-section">
     <div class="label">{$form.payment_processor.label}</div>
@@ -154,7 +155,12 @@
 </fieldset>
 {/if}
 
-<div id="billing-payment-block"></div>
+<div id="billing-payment-block">
+  {* If we have a payment processor, load it - otherwise it happens via ajax *}
+  {if $ppType}
+    {include file="CRM/Event/Form/Registration/Register.tpl" snippet=4}
+  {/if}
+</div>
 {include file="CRM/common/paymentBlock.tpl"}
 
 {include file="CRM/UF/Form/Block.tpl" fields=$customPost}

--- a/templates/CRM/common/paymentBlock.tpl
+++ b/templates/CRM/common/paymentBlock.tpl
@@ -60,6 +60,8 @@ function buildPaymentBlock( type ) {
 }
 
 cj( function() {
+    cj('.crm-group.payment_options-group').show();
+
     cj('input[name="payment_processor"]').change( function() {
         buildPaymentBlock( cj(this).val() );
     });

--- a/templates/CRM/common/paymentBlock.tpl
+++ b/templates/CRM/common/paymentBlock.tpl
@@ -60,18 +60,6 @@ function buildPaymentBlock( type ) {
 }
 
 cj( function() {
-    var processorTypeObj = cj('input[name="payment_processor"]');
-
-    if ( processorTypeObj.attr('type') == 'hidden' ) {
-        var processorTypeValue = processorTypeObj.val( );
-    } else {
-        var processorTypeValue = processorTypeObj.filter(':checked').val();
-    }
-
-    if ( processorTypeValue ) {
-        buildPaymentBlock( processorTypeValue );
-    }
-
     cj('input[name="payment_processor"]').change( function() {
         buildPaymentBlock( cj(this).val() );
     });


### PR DESCRIPTION
OK, I have fixed contribution and event pages to not rely on javascript for their basic functionality.
Because it is so late in the pre-release cycle we need to thoroughly test this. I have done quite a bit and all looks good but could use a second (or third) pair of eyes to double-check the following are all still working correctly:
- Paid events with single and multiple processors
- Unpaid events
- Contribution forms with single and multiple processors
- Contribution forms with an "on behalf of" organization profile (test both required and optional settings)
- Contribution forms for free memberships or 100% discounts
- PayPal standard/express
