### PR TITLE
minor bug found during execution of WebTest_Contact_AddTest::testHouseho...

### DIFF
--- a/api/v3/Group.php
+++ b/api/v3/Group.php
@@ -105,6 +105,7 @@ function civicrm_api3_group_get($params) {
   $inputParams      = CRM_Utils_Array::value('input_params', $options, array());
   if(is_array($returnProperties) && !empty($returnProperties)){
     // group function takes $returnProperties in non standard format & doesn't add id
+    unset($returnProperties['group_id']);
     $returnProperties['id'] = 1;
     $returnProperties = array_keys($returnProperties);
   }


### PR DESCRIPTION
The following error is thrown while executing mentioned test case : 

WebTest_Contact_AddTest::testHouseholdAdd
Civicrm api error.
Failed asserting that false is true.

/home/tests/devel-suite/tests/phpunit/CiviTest/CiviSeleniumTestCase.php:189
/home/tests/devel-suite/tests/phpunit/CiviTest/CiviSeleniumTestCase.php:236
/home/tests/devel-suite/tests/phpunit/WebTest/Contact/AddTest.php:264
/home/tests/devel-suite/tools/scripts/phpunit:75

The api error is thrown because : 'DB Fatal error 'group_id' field not found error' is thrown while executing civicrm_api3_group_get api. This happens as the $returnProperties(used in same api) contains 'group_id' as key, which later is used by CRM_Contact_BAO_Group::getGroups which builts a wrong query.

In commit : unset the wrongly built 'group_id' property at position where $returnProperties is initialized with correct 'id' property . 
