### PR TITLE
CRM-12259 suppress Master Address Belongs To from list of fields

### DIFF
--- a/CRM/Core/BAO/UFField.php
+++ b/CRM/Core/BAO/UFField.php
@@ -849,6 +849,7 @@ SELECT  id
 
     // Internal field not exposed to forms
     unset($fields['Contact']['contact_type']);
+    unset($fields['Contact']['master_id']);
 
     // convert phone extension in to psedo-field phone + phone extension
     //unset extension


### PR DESCRIPTION
Suppress Master Address Belongs To from list of fields available to profiles
As discussed with Kurund.

---
- CRM-12259: Bulk update with shared address fails
  http://issues.civicrm.org/jira/browse/CRM-12259
