### PR TITLE
CRM-12258 Default processor appears first in radio button set. Set defau...

### DIFF
--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -234,6 +234,15 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       CRM_Core_BAO_UFGroup::setProfileDefaults($contactID, $fields, $this->_defaults);
     }
 
+    // Set default payment processor as default payment_processor radio button value
+    if (!empty($this->_paymentProcessors)) {
+      foreach ($this->_paymentProcessors as $pid => $value) {
+        if (CRM_Utils_Array::value('is_default', $value)) {
+          $this->_defaults['payment_processor'] = $pid;
+        }
+      }
+    }
+
     //if event is monetary and pay later is enabled and payment
     //processor is not available then freeze the pay later checkbox with
     //default check

--- a/CRM/Financial/BAO/PaymentProcessor.php
+++ b/CRM/Financial/BAO/PaymentProcessor.php
@@ -219,9 +219,25 @@ class CRM_Financial_BAO_PaymentProcessor extends CRM_Financial_DAO_PaymentProces
       $payments[$payment['id']] = $payment;
     }
 
-    asort($payments);
+    uasort($payments, 'self::defaultComparison');
     return $payments;
   }
+
+  /**
+   * compare 2 payment processors to see which should go first based on is_default
+   * (sort function for sortDefaultFirst)
+   * @param array $processor1
+   * @param array_type $processor2
+   * @return number
+   */
+    static function defaultComparison($processor1, $processor2){
+      $p1 = CRM_Utils_Array::value('is_default', $processor1);
+      $p2 = CRM_Utils_Array::value('is_default', $processor2);
+      if ($p1 == $p2) {
+        return 0;
+      }
+      return ($p1 > $p2) ? -1 : 1;
+    }
 
   /**
    * Function to build payment processor details


### PR DESCRIPTION
...lt processor as default for payment_processor radio button event registration form.

---
- CRM-12258: Default payment processor should appear first in Payment Method radio button for online contribution page and online event registration
  http://issues.civicrm.org/jira/browse/CRM-12258
