### PR TITLE
Fixes auto-increment in OptionValue BAO (CRM-12133)

### DIFF
--- a/CRM/Core/BAO/OptionValue.php
+++ b/CRM/Core/BAO/OptionValue.php
@@ -111,7 +111,7 @@ class CRM_Core_BAO_OptionValue extends CRM_Core_DAO_OptionValue {
      }
      $bao->selectAdd();
      $bao->whereAdd("value REGEXP '^[0-9]+$'");
-     $bao->selectAdd('(ROUND(COALESCE(MAX(value),0)) +1) as nextvalue');
+     $bao->selectAdd('(ROUND(COALESCE(MAX(CONVERT(value, UNSIGNED)),0)) +1) as nextvalue');
      $bao->find(TRUE);
      return $bao->nextvalue;
   }


### PR DESCRIPTION
When creating an OptionValue, you can omit the value field, and it should automatically be assigned next highest integer value within the OptionGroup. However, this auto-increment feature is broken in CiviCRM 4.3 beta 5. It works up until a value of 10 and then it gets stuck on 10. This is because the function CRM_Core_BAO_OptionValue::getDefaultValue() is using string comparison instead of numeric comparison when calculating the highest current value, so '9' appears larger than '10'.

This commit changes that function to use integer comparison instead of string comparison. This fixes the problem with [CRM-12133](http://issues.civicrm.org/jira/browse/CRM-12133).
