### PR TITLE
CRM-12233 Label for newly create quick config price fields for membershi...

### DIFF
--- a/CRM/Member/Form/MembershipBlock.php
+++ b/CRM/Member/Form/MembershipBlock.php
@@ -371,7 +371,7 @@ class CRM_Member_Form_MembershipBlock extends CRM_Contribute_Form_ContributionPa
         CRM_Price_BAO_Field::retrieve($editedFieldParams, $editedResults);
         if (!CRM_Utils_Array::value('id', $editedResults)) {
           $fieldParams['name'] = strtolower(CRM_Utils_String::munge('Membership Amount', '_', 245));
-          $fieldParams['label'] = CRM_Utils_Array::value('new_title', $params) ? $params['new_title'] : ts('Membership Amount');
+          $fieldParams['label'] = CRM_Utils_Array::value('new_title', $params) ? $params['new_title'] : ts('Membership');
           if (!CRM_Utils_Array::value('mem_price_field_id', $params)) {
             CRM_Utils_Weight::updateOtherWeights('CRM_Price_DAO_Field', 0, 1, array('price_set_id' => $priceSetID));
           }


### PR DESCRIPTION
...p block should be Membership, not Membership Amount. Leaving the price_field.name as membership_amount since that's clearer as a machine name.

---
- CRM-12233: Online membership signup - contribution amounts field should not be required + various notices
  http://issues.civicrm.org/jira/browse/CRM-12233
