### PR TITLE
ts() usage fixes.

### DIFF
--- a/CRM/Admin/Page/Extensions.php
+++ b/CRM/Admin/Page/Extensions.php
@@ -164,9 +164,7 @@ class CRM_Admin_Page_Extensions extends CRM_Core_Page_Basic {
       try {
         $obj = $mapper->keyToInfo($key);
       } catch (CRM_Extension_Exception $ex) {
-        CRM_Core_Session::setStatus(ts('Failed to read extension (%1). Please refresh the extension list.', array(
-          1 => $key,
-        )));
+        CRM_Core_Session::setStatus(ts('Failed to read extension (%1). Please refresh the extension list.', array(1 => $key)));
         continue;
       }
 

--- a/CRM/Campaign/Form/Survey/Questions.php
+++ b/CRM/Campaign/Form/Survey/Questions.php
@@ -83,7 +83,7 @@ class CRM_Campaign_Form_Survey_Questions extends CRM_Campaign_Form_Survey {
           array(
             1 => $activityTypes[$subTypeId],
             2 => CRM_Utils_System::url('civicrm/admin/custom/group', 'action=add&reset=1'),
-            3 => '_blank',
+            3 => '_blank'
           )
         )
       );

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -2506,7 +2506,7 @@ SELECT  id
         $mergeActSubject = ts("Case %1 reassigned client from %2 to %3. New Case ID is %4.",
           array(
             1 => $otherCaseId, 2 => $otherContactDisplayName,
-            3 => $mainContactDisplayName, 4 => $mainCaseId,
+            3 => $mainContactDisplayName, 4 => $mainCaseId
           )
         );
       }
@@ -2515,7 +2515,7 @@ SELECT  id
         $mergeActSubject = ts("Case %1 copied from contact id %2 to contact id %3 via merge. New Case ID is %4.",
           array(
             1 => $otherCaseId, 2 => $otherContactId,
-            3 => $mainContactId, 4 => $mainCaseId,
+            3 => $mainContactId, 4 => $mainCaseId
           )
         );
       }

--- a/CRM/Case/Form/Activity/ChangeCaseStatus.php
+++ b/CRM/Case/Form/Activity/ChangeCaseStatus.php
@@ -141,8 +141,7 @@ class CRM_Case_Form_Activity_ChangeCaseStatus {
         // FIXME: Is there an existing function?
         $query = 'UPDATE civicrm_relationship SET end_date=NULL WHERE id=%1';
         foreach ($rels as $relId => $relData) {
-          $relParams = array(1 => array($relId, 'Integer'),
-          );
+          $relParams = array(1 => array($relId, 'Integer'));
           CRM_Core_DAO::executeQuery($query, $relParams);
         }
       }
@@ -153,8 +152,9 @@ class CRM_Case_Form_Activity_ChangeCaseStatus {
     $activity->priority_id = $params['priority_id'];
 
     if ($activity->subject == 'null') {
-      $activity->subject = ts('Case status changed from %1 to %2', array(1 => CRM_Utils_Array::value($form->_defaults['case_status_id'], $form->_caseStatus),
-          2 => CRM_Utils_Array::value($params['case_status_id'], $form->_caseStatus),
+      $activity->subject = ts('Case status changed from %1 to %2', array(
+          1 => CRM_Utils_Array::value($form->_defaults['case_status_id'], $form->_caseStatus),
+          2 => CRM_Utils_Array::value($params['case_status_id'], $form->_caseStatus)
         )
       );
       $activity->save();

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2711,7 +2711,7 @@ WHERE  id IN ( $groupIDs )
           LEFT JOIN civicrm_tag {$tActTable} ON ( {$etActTable}.tag_id = {$tActTable}.id  )";
 
       $this->_where[$grouping][] = "({$tTable}.name $op '". $value . "' OR {$tCaseTable}.name $op '". $value . "' OR {$tActTable}.name $op '". $value . "')";
-      $this->_qill[$grouping][] = ts('Tag '.$tagTypesText[2].' %1 ', array( 1 => $op)) . ' ' . $value;
+      $this->_qill[$grouping][] = ts('Tag %1 %2 ', array(1 => $tagTypesText[2], 2 => $op)) . ' ' . $value;
     } else {
       $etTable = "`civicrm_entity_tag-" . $value . "`";
       $tTable = "`civicrm_tag-" . $value . "`";
@@ -2786,7 +2786,7 @@ WHERE  id IN ( $groupIDs )
       else {
         $this->_where[$grouping][] = "({$etTable}.tag_id $op (". $value . ") OR {$etCaseTable}.tag_id $op (". $value . ") OR {$etActTable}.tag_id $op (". $value . "))";
       }
-      $this->_qill[$grouping][] = ts('Tag %1 '.$tagTypesText[2], array( 1 => $op)) . ' ' . $names;
+      $this->_qill[$grouping][] = ts('Tag %1 %2', array(1 => $op, 2 => $tagTypesText[2])) . ' ' . $names;
     } else {
       $this->_tables[$etTable] =
         $this->_whereTables[$etTable] =

--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -677,9 +677,7 @@ class CRM_Core_Config extends CRM_Core_Config_Variables {
       }
       if (!empty($modules_with_perms)) {
         CRM_Core_Session::setStatus(
-          ts('Some modules define permissions, but the CMS cannot store them: %1', array(
-            1 => implode(', ', $modules_with_perms),
-          )),
+          ts('Some modules define permissions, but the CMS cannot store them: %1', array(1 => implode(', ', $modules_with_perms))),
           ts('Permission Error'),
           'error'
         );

--- a/CRM/Financial/BAO/FinancialTypeAccount.php
+++ b/CRM/Financial/BAO/FinancialTypeAccount.php
@@ -140,10 +140,10 @@ class CRM_Financial_BAO_FinancialTypeAccount extends CRM_Financial_DAO_EntityFin
 
     if ($check) {
       if ($name[1] == 'PremiumsProduct' || $name[1] == 'Product') {
-        CRM_Core_Session::setStatus( ts('You cannot remove an account with a '.$relationValues[$financialTypeAccountId].'relationship while the Financial Type is used for a Premium.'));
+        CRM_Core_Session::setStatus(ts('You cannot remove an account with a %1 relationship while the Financial Type is used for a Premium.', array(1 => $relationValues[$financialTypeAccountId])));
       }
       else {
-        CRM_Core_Session::setStatus( ts('You cannot remove an account with a '.$relationValues[$financialTypeAccountId].'relationship because it is being referenced by one or more of the following types of records: Contributions, Contribution Pages, or Membership Types. Consider disabling this type instead if you no longer want it used.') );
+        CRM_Core_Session::setStatus(ts('You cannot remove an account with a %1 relationship because it is being referenced by one or more of the following types of records: Contributions, Contribution Pages, or Membership Types. Consider disabling this type instead if you no longer want it used.', array(1 => $relationValues[$financialTypeAccountId])));
       }
       return CRM_Utils_System::redirect( CRM_Utils_System::url( 'civicrm/admin/financial/financialType/accounts', "reset=1&action=browse&aid={$accountId}" ));
     }

--- a/CRM/Mailing/Selector/Event.php
+++ b/CRM/Mailing/Selector/Event.php
@@ -123,11 +123,7 @@ class CRM_Mailing_Selector_Event extends CRM_Core_Selector_Base implements CRM_C
   function getPagerParams($action, &$params) {
     $params['csvString'] = NULL;
     $params['rowCount']  = CRM_Utils_Pager::ROWCOUNT;
-    $params['status']    = ts('%1 %%StatusMessage%%', array(
-      1 =>
-        $this->eventToTitle(),
-      ));
-
+    $params['status']    = ts('%1 %%StatusMessage%%', array(1 => $this->eventToTitle()));
     $params['buttonTop'] = 'PagerTopButton';
     $params['buttonBottom'] = 'PagerBottomButton';
   }

--- a/CRM/Member/Form/Task/PickProfile.php
+++ b/CRM/Member/Form/Task/PickProfile.php
@@ -76,7 +76,7 @@ class CRM_Member_Form_Task_PickProfile extends CRM_Member_Form_Task {
     $validate = FALSE;
     //validations
     if (count($this->_memberIds) > $this->_maxMembers) {
-      CRM_Core_Session::setStatus(ts("The maximum number of members you can select for Batch Update is {$this->_maxMembers}. You have selected " . count($this->_memberIds) . ". Please select fewer members from your search results and try again."), ts('Batch Update Error'), 'error');
+      CRM_Core_Session::setStatus(ts("The maximum number of members you can select for Batch Update is %1. You have selected %2. Please select fewer members from your search results and try again.", array(1 => $this->_maxMembers, 2 => count($this->_memberIds))), ts('Batch Update Error'), 'error');
       $validate = TRUE;
     }
 
@@ -98,7 +98,7 @@ class CRM_Member_Form_Task_PickProfile extends CRM_Member_Form_Task {
     $profiles = CRM_Core_BAO_UFGroup::getProfiles($types, TRUE);
 
     if (empty($profiles)) {
-      CRM_Core_Session::setStatus(ts("You will need to create a Profile containing the {$types[0]} fields you want to edit before you can use Batch Update via Profile. Navigate to Administer CiviCRM >> CiviCRM Profile to configure a Profile. Consult the online Administrator documentation for more information."), ts('Batch Update Error'), 'error');
+      CRM_Core_Session::setStatus(ts("You will need to create a Profile containing the %1 fields you want to edit before you can use Batch Update via Profile. Navigate to Administer CiviCRM >> CiviCRM Profile to configure a Profile. Consult the online Administrator documentation for more information.", array(1 => $types[0])), ts('Batch Update Error'), 'error');
       CRM_Utils_System::redirect($this->_userContext);
     }
 

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -2257,13 +2257,7 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
             if ($from || $to) {
               $statistics['filters'][] = array(
                 'title' => $field['title'],
-                'value' => ts(
-                  "Between %1 and %2",
-                  array(
-                    1 => $from,
-                    2 => $to,
-                  )
-                ),
+                'value' => ts("Between %1 and %2", array(1 => $from, 2 => $to)),
               );
             }
             elseif (in_array($rel = CRM_Utils_Array::value("{$fieldName}_relative", $this->_params),

--- a/CRM/Report/Form/Contribute/Detail.php
+++ b/CRM/Report/Form/Contribute/Detail.php
@@ -718,11 +718,10 @@ class CRM_Report_Form_Contribute_Detail extends CRM_Report_Form {
       if ($showsumcontribs) {
         $totalandsum = array();
         foreach ($totals as $key => $total) {
-          $totalandsumvals = array(
+          $totalandsum[$key] = ts("%1 contributions: %2", array(
             1 => $total,
-            2 => CRM_Utils_Money::format($sumcontribs[$key]),
-          );
-          $totalandsum[$key] = ts("%1 contributions: %2", $totalandsumvals);
+            2 => CRM_Utils_Money::format($sumcontribs[$key])
+          ));
         }
         $this->assign('sectionTotals', $totalandsum);
       }

--- a/CRM/Report/Form/Extended.php
+++ b/CRM/Report/Form/Extended.php
@@ -1215,9 +1215,7 @@ WHERE 	line_item_civireport.id IS NOT NULL
   function alterCountryID($value, &$row, $selectedfield, $criteriaFieldName) {
     $url = CRM_Utils_System::url(CRM_Utils_System::currentPath(), "reset=1&force=1&{$criteriaFieldName}_op=in&{$criteriaFieldName}_value={$value}", $this->_absoluteUrl);
     $row[$selectedfield . '_link'] = $url;
-    $row[$selectedfield . '_hover'] = ts("%1 for this country.", array(
-        1 => $value,
-      ));
+    $row[$selectedfield . '_hover'] = ts("%1 for this country.", array(1 => $value));
     $countries =  CRM_Core_PseudoConstant::country($value, FALSE);
     if(!is_array($countries)){
       return $countries;
@@ -1227,9 +1225,7 @@ WHERE 	line_item_civireport.id IS NOT NULL
   function alterCountyID($value, &$row,$selectedfield, $criteriaFieldName) {
     $url = CRM_Utils_System::url(CRM_Utils_System::currentPath(), "reset=1&force=1&{$criteriaFieldName}_op=in&{$criteriaFieldName}_value={$value}", $this->_absoluteUrl);
     $row[$selectedfield . '_link'] = $url;
-    $row[$selectedfield . '_hover'] = ts("%1 for this county.", array(
-        1 => $value,
-      ));
+    $row[$selectedfield . '_hover'] = ts("%1 for this county.", array(1 => $value));
     $counties = CRM_Core_PseudoConstant::county($value, FALSE);
     if(!is_array($counties)){
       return $counties;
@@ -1239,9 +1235,7 @@ WHERE 	line_item_civireport.id IS NOT NULL
   function alterStateProvinceID($value, &$row, $selectedfield, $criteriaFieldName) {
     $url = CRM_Utils_System::url(CRM_Utils_System::currentPath(), "reset=1&force=1&{$criteriaFieldName}_op=in&{$criteriaFieldName}_value={$value}", $this->_absoluteUrl);
     $row[$selectedfield . '_link'] = $url;
-    $row[$selectedfield . '_hover'] = ts("%1 for this state.", array(
-        1 => $value,
-      ));
+    $row[$selectedfield . '_hover'] = ts("%1 for this state.", array(1 => $value));
 
     $states =  CRM_Core_PseudoConstant::stateProvince($value, FALSE);
     if(!is_array($states)){

--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -394,7 +394,7 @@ SET    version = '$version'
                array(
                  1 => $minPhpVersion,
                  2 => $phpVersion,
-                 3 => $latestVer,
+                 3 => $latestVer
                ));
     }
 
@@ -407,7 +407,7 @@ SET    version = '$version'
     if (CRM_Core_DAO::getGlobalSetting('thread_stack', 0) < (1024*self::MINIMUM_THREAD_STACK)) {
       $error = ts('CiviCRM %1 requires MySQL thread stack >= %2k', array(
         1 => $latestVer,
-        2 => self::MINIMUM_THREAD_STACK,
+        2 => self::MINIMUM_THREAD_STACK
       ));
     }
 

--- a/CRM/Upgrade/Incremental/php/FourThree.php
+++ b/CRM/Upgrade/Incremental/php/FourThree.php
@@ -99,10 +99,10 @@ class CRM_Upgrade_Incremental_php_FourThree {
       }
       list($context, $orgName) = self::createDomainContacts();
       if ($context == 'added') {
-        $postUpgradeMessage .= '<br />' . ts("A new organization contact has been added as the default domain contact using the information from your Organization Address and Contact Info settings: '{$orgName}'.");
+        $postUpgradeMessage .= '<br />' . ts("A new organization contact has been added as the default domain contact using the information from your Organization Address and Contact Info settings: '%1'.", array(1 => $orgName));
       }
       elseif ($context == 'merged') {
-        $postUpgradeMessage .= '<br />' . ts("The existing organization contact record for '{$orgName}' has been marked as the default domain contact, and has been updated with information from your Organization Address and Contact Info settings.");
+        $postUpgradeMessage .= '<br />' . ts("The existing organization contact record for '%1' has been marked as the default domain contact, and has been updated with information from your Organization Address and Contact Info settings.", array(1 => $orgName));
       }
 
       $providerExists = CRM_Core_DAO::singleValueQuery("SELECT id FROM civicrm_sms_provider LIMIT 1");
@@ -199,10 +199,7 @@ WHERE ceft.entity_id IS NULL;";
     $maxId = CRM_Core_DAO::singleValueQuery('SELECT coalesce(max(id),0) FROM civicrm_contact');
     for ($startId = $minId; $startId <= $maxId; $startId += self::BATCH_SIZE) {
       $endId = $startId + self::BATCH_SIZE - 1;
-      $title = ts('Upgrade timestamps (%1 => %2)', array(
-                 1 => $startId,
-                 2 => $endId,
-               ));
+      $title = ts('Upgrade timestamps (%1 => %2)', array(1 => $startId, 2 => $endId));
       $this->addTask($title, 'convertTimestamps', $startId, $endId);
     }
 

--- a/CRM/Upgrade/Incremental/php/FourTwo.php
+++ b/CRM/Upgrade/Incremental/php/FourTwo.php
@@ -55,7 +55,7 @@ class CRM_Upgrade_Incremental_php_FourTwo {
     if ($rev == '4.2.alpha1') {
       $tables = array('civicrm_contribution_page','civicrm_event','civicrm_group','civicrm_contact');
       if (!CRM_Core_DAO::schemaRequiresRebuilding($tables)){
-        $errors = ts("The upgrade has identified some schema integrity issues in the database. It seems some of your constraints are missing. You will have to rebuild your schema before re-trying the upgrade. Please refer to ".CRM_Utils_System::docURL2("Ensuring Schema Integrity on Upgrades", FALSE, "Ensuring Schema Integrity on Upgrades", NULL, NULL, "wiki"));
+        $errors = ts("The upgrade has identified some schema integrity issues in the database. It seems some of your constraints are missing. You will have to rebuild your schema before re-trying the upgrade. Please refer to %1.", array(1 => CRM_Utils_System::docURL2("Ensuring Schema Integrity on Upgrades", FALSE, "Ensuring Schema Integrity on Upgrades", NULL, NULL, "wiki")));
         CRM_Core_Error::fatal($errors);
         return FALSE;
       }
@@ -100,14 +100,14 @@ ORDER BY mp.contribution_id, mp.membership_id";
       // note: error conditions are also checked in upgrade_4_2_beta2()
       if (!defined('CIVICRM_SETTINGS_PATH')) {
         $preUpgradeMessage .= '<br />' . ts('Could not determine path to civicrm.settings.php. Please manually locate it and add these lines at the bottom: <pre>%1</pre>', array(
-          1 => self::SETTINGS_SNIPPET,
+          1 => self::SETTINGS_SNIPPET
         ));
       } elseif (preg_match(self::SETTINGS_SNIPPET_PATTERN, file_get_contents(CIVICRM_SETTINGS_PATH))) {
         // OK, nothing to do
       } elseif (!is_writable(CIVICRM_SETTINGS_PATH)) {
         $preUpgradeMessage .= '<br />' . ts('The settings file (%1) must be updated. Please make it writable or manually add these lines:<pre>%2</pre>', array(
           1 => CIVICRM_SETTINGS_PATH,
-          2 => self::SETTINGS_SNIPPET,
+          2 => self::SETTINGS_SNIPPET
         ));
       }
     }

--- a/CRM/Utils/Geocode/Yahoo.php
+++ b/CRM/Utils/Geocode/Yahoo.php
@@ -166,11 +166,10 @@ class CRM_Utils_Geocode_Yahoo {
           if (strpos($new_pc_complete, $current_pc_complete) !== 0) {
             // Don't bother anonymous users with the message - they can't change a form they just submitted anyway
             if(CRM_Utils_System::isUserLoggedIn()) {
-              $ts_args =  array(
+              $msg = ts('The Yahoo Geocoding system returned a different postal code (%1) than the one you entered (%2). If you want the Yahoo value, please delete the current postal code and save again.', array(
                 1 => $ret['postal'],
                 2 => $current_pc_suffix ? "$current_pc-$current_pc_suffix" : $current_pc
-            );
-              $msg = ts('The Yahoo Geocoding system returned a different postal code (%1) than the one you entered (%2). If you want the Yahoo value, please delete the current postal code and save again.', $ts_args);
+              ));
             
               CRM_Core_Session::setStatus($msg, ts('Postal Code Mismatch'), 'error');
             }

--- a/CRM/Utils/Migrate/Import.php
+++ b/CRM/Utils/Migrate/Import.php
@@ -78,7 +78,7 @@ class CRM_Utils_Migrate_Import {
               array(
                 1 => $keyName,
                 2 => $dao->$keyName,
-                3 => $dao->__table,
+                3 => $dao->__table
               )
             ), '', 'info');
           return FALSE;
@@ -364,7 +364,7 @@ AND        f.column_name = %2
                 array(
                   1 => $profileField->field_name,
                   2 => $tableName,
-                  3 => $columnName,
+                  3 => $columnName
                 )
               ) . "<br />");
           }

--- a/templates/CRM/Case/Form/CaseView.tpl
+++ b/templates/CRM/Case/Form/CaseView.tpl
@@ -93,10 +93,10 @@
       <span class="crm-case-summary-label">{ts}Case Subject{/ts}:</span>&nbsp;{$caseDetails.case_subject}
     </td>
     <td class="crm-case-caseview-case_type label">
-      <span class="crm-case-summary-label">{ts}Case Type{/ts}:</span>&nbsp;{$caseDetails.case_type}&nbsp;<a href="{crmURL p='civicrm/case/activity' q="action=add&reset=1&cid=`$contactId`&caseid=`$caseId`&selectedChild=activity&atype=`$changeCaseTypeId`"}" title={ts}"Change case type (creates activity record)"{/ts}><span class="icon edit-icon"></span></a>
+      <span class="crm-case-summary-label">{ts}Case Type{/ts}:</span>&nbsp;{$caseDetails.case_type}&nbsp;<a href="{crmURL p='civicrm/case/activity' q="action=add&reset=1&cid=`$contactId`&caseid=`$caseId`&selectedChild=activity&atype=`$changeCaseTypeId`"}" title="{ts}Change case type (creates activity record){/ts}"><span class="icon edit-icon"></span></a>
     </td>
     <td class="crm-case-caseview-case_status label">
-      <span class="crm-case-summary-label">{ts}Status{/ts}:</span>&nbsp;{$caseDetails.case_status}&nbsp;<a href="{crmURL p='civicrm/case/activity' q="action=add&reset=1&cid=`$contactId`&caseid=`$caseId`&selectedChild=activity&atype=`$changeCaseStatusId`"}" title={ts}"Change case status (creates activity record)"{/ts}><span class="icon edit-icon"></span></a>
+      <span class="crm-case-summary-label">{ts}Status{/ts}:</span>&nbsp;{$caseDetails.case_status}&nbsp;<a href="{crmURL p='civicrm/case/activity' q="action=add&reset=1&cid=`$contactId`&caseid=`$caseId`&selectedChild=activity&atype=`$changeCaseStatusId`"}" title="{ts}Change case status (creates activity record){/ts}"><span class="icon edit-icon"></span></a>
     </td>
     <td class="crm-case-caseview-case_start_date label">
       <span class="crm-case-summary-label">{ts}Start Date{/ts}:</span>&nbsp;{$caseDetails.case_start_date|crmDate}&nbsp;<a href="{crmURL p='civicrm/case/activity' q="action=add&reset=1&cid=`$contactId`&caseid=`$caseId`&selectedChild=activity&atype=`$changeCaseStartDateId`"}" title="{ts}Change case start date (creates activity record){/ts}"><span class="icon edit-icon"></span></a>


### PR DESCRIPTION
c.f. http://wiki.civicrm.org/confluence/display/CRMDOC43/Internationalisation+for+Developers

NB: perhaps half of the fixes are related to a trailing comma in the array. The wiki page has a comment about this (tl;dr: the php-extractor has bugs, we should upgrade to Drupal's potx?).
