### PR TITLE
CRM-12217 fix : the sixth parameter for getFieldsForImport function was ...

### DIFF
--- a/CRM/Core/BAO/UFField.php
+++ b/CRM/Core/BAO/UFField.php
@@ -865,8 +865,7 @@ SELECT  id
     $subTypes = CRM_Contact_BAO_ContactType::subTypeInfo();
     foreach ($subTypes as $name => $val) {
       //custom fields for sub type
-      $subTypeFields = CRM_Core_BAO_CustomField::getFieldsForImport($name);
-
+      $subTypeFields = CRM_Core_BAO_CustomField::getFieldsForImport($name, FALSE, FALSE, FALSE, TRUE, TRUE);
       if (array_key_exists($val['parent'], $fields)) {
         $fields[$name] = $fields[$val['parent']] + $subTypeFields;
       }


### PR DESCRIPTION
CRM_Core_BAO_CustomField::getFieldsForImport method consists of sixth parameter $withMultiple which was not set to TRUE , hence as this method was used to populate subtype custom fields list, on profile fields configuration page - fields combo box didn't populated sub type multi-record custom fields. 
