### PR TITLE
CRM-12277 Add info to Batch status change message to let users now that ...

### DIFF
--- a/templates/CRM/Event/Form/Task/Batch.tpl
+++ b/templates/CRM/Event/Form/Task/Batch.tpl
@@ -29,6 +29,9 @@
     {if $context EQ 'statusChange'} {* Update Participant Status task *}
         {ts}Update the status for each participant individually, OR change all statuses to:{/ts}
         {$form.status_change.html}  {help id="id-status_change"}
+        <div class="status">
+          {ts}Participants whose status is changed FROM Pending Pay Later TO Registered or Attended will receive a confirmation email and their payment status will be set to completed. If this is not what you want to do, you can change their participant status by editing their event registration record directly.{/ts}
+        </div>
         {if $notifyingStatuses}
           <div class="status">
             {ts 1=$notifyingStatuses}Participants whose status is changed TO any of the following will be automatically notified via email: %1.{/ts}


### PR DESCRIPTION
...notifications will be sent for Pending Pay Later to Attended or Registered updates.

---
- CRM-12277: Notify batch Change Participant Status users that changing status FROM Pay Later TO Attended or Registered triggers email notification and payment status update
  http://issues.civicrm.org/jira/browse/CRM-12277
