### PR TITLE
CRM-12273 - use default contribution for price set for contributions when upgrade 

### DIFF
--- a/CRM/Upgrade/Incremental/php/FourTwo.php
+++ b/CRM/Upgrade/Incremental/php/FourTwo.php
@@ -442,6 +442,10 @@ WHERE     cpse.price_set_id IS NULL";
       CRM_Core_OptionGroup::getAssoc($options['optionGroup'], $optionValue);
       if (empty($optionValue))
         return;
+    }else{
+      //CRM-12273
+      //if options group is empty then return, contribution should be default price set
+      return;
     }
 
     if (! CRM_Core_DAO::getFieldValue('CRM_Upgrade_Snapshot_V4p2_Price_BAO_Set', $pageTitle, 'id', 'name', true)) {
@@ -629,8 +633,22 @@ WHERE     cpf.price_set_id = %1
       }
       else {
         $sql .= "AND cpfv.amount = %2";
+
+        //CRM-12273
+        //check if price_set_id is exist, if not use the default contribution amount
+        if(isset($result->price_set_id)){
+          $priceSetId = $result->price_set_id;
+        }else{
+          $defaultPriceSets = CRM_Price_BAO_Set::getDefaultPriceSet();
+          foreach ($defaultPriceSets as $key => $pSet) {
+            if($pSet['name'] == 'contribution_amount'){
+              $priceSetId = $pSet['setID'];
+            }
+          }
+        }
+
         $params = array(
-          '1' => array($result->price_set_id, 'Integer'),
+          '1' => array($priceSetId, 'Integer'),
           '2' => array($result->total_amount, 'String'),
         );
         $res = CRM_Core_DAO::executeQuery($sql, $params);
@@ -647,7 +665,7 @@ WHERE     cpf.price_set_id = %1
         }
         else {
           $params = array(
-            'price_set_id' => $result->price_set_id,
+            'price_set_id' => $priceSetId,
             'name' => 'other_amount',
           );
           $defaults = array();
@@ -660,7 +678,7 @@ WHERE     cpf.price_set_id = %1
           }
           else {
             $lineParams['price_field_id'] =
-              CRM_Core_DAO::getFieldValue('CRM_Upgrade_Snapshot_V4p2_Price_DAO_Field', $result->price_set_id, 'id', 'price_set_id');
+              CRM_Core_DAO::getFieldValue('CRM_Upgrade_Snapshot_V4p2_Price_DAO_Field', $priceSetId, 'id', 'price_set_id');
             $lineParams['label'] = 'Contribution Amount';
           }
           $lineParams['qty'] = 1;

--- a/CRM/Upgrade/Incremental/php/FourTwo.php
+++ b/CRM/Upgrade/Incremental/php/FourTwo.php
@@ -442,7 +442,8 @@ WHERE     cpse.price_set_id IS NULL";
       CRM_Core_OptionGroup::getAssoc($options['optionGroup'], $optionValue);
       if (empty($optionValue))
         return;
-    }else{
+    }
+    else{
       //CRM-12273
       //if options group is empty then return, contribution should be default price set
       return;
@@ -636,12 +637,13 @@ WHERE     cpf.price_set_id = %1
 
         //CRM-12273
         //check if price_set_id is exist, if not use the default contribution amount
-        if(isset($result->price_set_id)){
+        if (isset($result->price_set_id)){
           $priceSetId = $result->price_set_id;
-        }else{
+        }
+        else{
           $defaultPriceSets = CRM_Price_BAO_Set::getDefaultPriceSet();
           foreach ($defaultPriceSets as $key => $pSet) {
-            if($pSet['name'] == 'contribution_amount'){
+            if ($pSet['name'] == 'contribution_amount'){
               $priceSetId = $pSet['setID'];
             }
           }


### PR DESCRIPTION
This commit for getting price set default contribution amount when convert contributions that belong the contribution page that doen't set option amount or allow other amount. 

NOTE this fix is for normal contribution only not membership type contribution.
