### PR TITLE
CRM-12280 fixes to civicrm.css to prevent force compatibility mode in IE...

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -388,7 +388,7 @@
 
 .crm-container fieldset legend {
   display: block;
-  font-family: helvetica;
+  font-family: Arial, Helvetica, sans-serif;
   font-size: 14px;
   font-weight: bold;
   padding: 4px;
@@ -773,7 +773,7 @@
   /* h3 used as table header for civicrm */
   background-color: #CDE8FE;
   font-size: 15px;
-  font-family: Helvetica, Arial, Sans;
+  font-family: Helvetica, Arial, sans-serif;
   font-weight: bold;
   color: #121A2D;
   padding: 4px 6px;
@@ -1250,7 +1250,7 @@
   height: auto;
   margin: 0 1px;
   padding: 2px 5px;
-  font-family: Helvetica;
+  font-family: Helvetica, Arial, sans-serif; 
 }
 
 .crm-container #alpha-filter a {


### PR DESCRIPTION
...9

---
- CRM-12280: "Compatibility mode" forced in IE9 (Joomla version)
  http://issues.civicrm.org/jira/browse/CRM-12280
