### PR TITLE
button to swap activity targets & assignees

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -2581,6 +2581,10 @@ div.grippie {
   background-position: -3px -161px;
 }
 
+.crm-container .swap-target-assignee-icon {
+  background-position: -82px -81px;
+}
+
 #crm-container .geotag {
   padding: 2px 0 2px 20px !important;
   background: url('../i/geotag_16.png') left center no-repeat;

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -2581,7 +2581,7 @@ div.grippie {
   background-position: -3px -161px;
 }
 
-.crm-container .swap-target-assignee-icon {
+.crm-container .swap-icon {
   background-position: -82px -81px;
 }
 

--- a/templates/CRM/Activity/Form/Activity.tpl
+++ b/templates/CRM/Activity/Form/Activity.tpl
@@ -155,7 +155,7 @@
     <tr class="crm-activity-form-block-swap_target_assignee">
       <td class="label"></td>
       <td>
-        <a class="button" id="swap_target_assignee">
+        <a href="#" class="button" id="swap_target_assignee">
           <span>
             <div class="icon swap-target-assignee-icon"></div>{ts}Swap Target and Assignee Contacts{/ts}
           </span>
@@ -336,6 +336,7 @@
             cj(targets).each( function() {
               cj('#assignee_contact_id').tokenInput("add", this);
             });
+            return false;
           });
         </script>
       {/literal}

--- a/templates/CRM/Activity/Form/Activity.tpl
+++ b/templates/CRM/Activity/Form/Activity.tpl
@@ -157,7 +157,7 @@
       <td>
         <a href="#" class="button" id="swap_target_assignee">
           <span>
-            <div class="icon swap-target-assignee-icon"></div>{ts}Swap Target and Assignee Contacts{/ts}
+            <div class="icon swap-icon"></div>{ts}Swap Target and Assignee Contacts{/ts}
           </span>
         </div>
       </td>

--- a/templates/CRM/Activity/Form/Activity.tpl
+++ b/templates/CRM/Activity/Form/Activity.tpl
@@ -150,6 +150,19 @@
       </td>
     {/if}
   </tr>
+  
+  {if $action neq 4}
+    <tr class="crm-activity-form-block-swap_target_assignee">
+      <td class="label"></td>
+      <td>
+        <a class="button" id="swap_target_assignee">
+          <span>
+            <div class="icon swap-target-assignee-icon"></div>{ts}Swap Target and Assignee Contacts{/ts}
+          </span>
+        </div>
+      </td>
+    </tr>
+  {/if}
 
   <tr class="crm-activity-form-block-assignee_contact_id">
     {if $action eq 4}
@@ -310,6 +323,18 @@
               if ( cj(this).children( ).find('span.crm-error').text( ).length > 0 ) {
                 cj(this).parent('.collapsed').crmAccordionToggle();
               }
+            });
+          });
+          cj('#swap_target_assignee').click( function() {
+            var assignees = cj('input#assignee_contact_id').tokenInput("get");
+            var targets = cj('input#contact_1').tokenInput("get");
+            cj('#assignee_contact_id').tokenInput("clear");
+            cj('#contact_1').tokenInput("clear");
+            cj(assignees).each( function() {
+              cj('#contact_1').tokenInput("add", this);
+            });
+            cj(targets).each( function() {
+              cj('#assignee_contact_id').tokenInput("add", this);
             });
           });
         </script>


### PR DESCRIPTION
This button on the add/edit activity form takes the target ("with") contact(s) and puts them in the assignee box and vice-versa.

Requires https://github.com/civicrm/civicrm-packages/pull/7
