### PR TITLE
CRM-11984 fix OG Sync for D6 users

### DIFF
--- a/CRM/Utils/System/Drupal6.php
+++ b/CRM/Utils/System/Drupal6.php
@@ -906,22 +906,24 @@ SELECT name, mail
     return $loginURL;
   }
 
-  /*
+  /**
    * Wrapper for og_membership creation
+   *
+   * @param integer $ogID Organic Group ID
+   * @param integer $drupalID drupal User ID
    */
   function og_membership_create($ogID, $drupalID){
-    $group_membership = og_membership_create($ogID, 'user', $drupalID, array('is_active' => 1));
-    $group_membership->save();
+    og_save_subscription( $ogID, $drupalID, array( 'is_active' => 1 ) );
   }
 
   /**
    * Wrapper for og_membership deletion
+   *
+   * @param integer $ogID Organic Group ID
+   * @param integer $drupalID drupal User ID
    */
   function og_membership_delete($ogID, $drupalID) {
-    $membership = og_get_group_membership($ogID, 'user', $drupalID);
-    if ($membership) {
-      og_membership_delete($membership->id);
-    }
+      og_delete_subscription( $ogID, $drupalID );
   }
 
   /**


### PR DESCRIPTION
This takes advantage of the OOP restructure of OG create & delete functions to make it work again in d6 (revert to the original D6 function which still works as opposed to various d7 variants)
