### PR TITLE
-- Batch transaction page minor fix(Query Syntax error)

### DIFF
--- a/CRM/Batch/BAO/Batch.php
+++ b/CRM/Batch/BAO/Batch.php
@@ -710,7 +710,7 @@ LEFT JOIN civicrm_contribution_soft ON civicrm_contribution_soft.contribution_id
     }
     if (!empty($query->_where[0])) {
       $where = implode(' AND ', $query->_where[0]) .
-        "AND civicrm_entity_batch.batch_id IS NULL
+        " AND civicrm_entity_batch.batch_id IS NULL
          AND civicrm_entity_financial_trxn.entity_table = 'civicrm_contribution'";
       $searchValue = TRUE;
     }


### PR DESCRIPTION
The query gave a syntax error as there was no space before AND in a query that was appended to the main query during the usage of search in batch transaction page.
