### PR TITLE
Upgrade

### DIFF
--- a/CRM/Upgrade/Incremental/php/FourThree.php
+++ b/CRM/Upgrade/Incremental/php/FourThree.php
@@ -517,13 +517,13 @@ UPDATE civicrm_line_item li
        LEFT JOIN civicrm_participant cp
               ON (li.entity_id = cp.id AND li.entity_table = 'civicrm_participant')
        LEFT JOIN civicrm_event ce
-              ON ce.id = cp.event_id
+              ON ce.id = cp.event_id AND ce.financial_type_id
 SET    li.financial_type_id = CASE
          WHEN (con.contribution_page_id IS NULL || li.price_field_value_id IS NULL) AND cp.id IS NULL THEN
            con.financial_type_id
          WHEN (con.contribution_page_id IS NOT NULL AND cp.id IS NULL) || (cp.id IS NOT NULL AND  li.price_field_value_id IS NOT NULL) THEN
            cpfv.financial_type_id
-         WHEN cp.id IS NOT NULL AND  li.price_field_value_id IS NULL THEN
+         WHEN ce.id IS NOT NULL AND  li.price_field_value_id IS NULL THEN
            ce.financial_type_id
        END";
     CRM_Core_DAO::executeQuery($updateLineItemSql, $queryParams);


### PR DESCRIPTION
I was having trouble upgrading the woolman.org database, turns out due to the nonstandard way we record some event payments.
This makes the upgrade script slightly more forgiving and at least now we don't have a fatal error.
