### PR TITLE
CRM-12308 Removed reference to a non-existent template. Checked that $in...

### DIFF
--- a/templates/CRM/Event/Form/Registration/Register.tpl
+++ b/templates/CRM/Event/Form/Registration/Register.tpl
@@ -101,9 +101,6 @@
         </div>
     {/if}
 {/if}
-{if $initialPayment}
-  {include file="CRM/Price/Form/InitialPayment.tpl" extends="Contribution" paymentMode='online'}
-{/if}
 {if $pcp && $is_honor_roll }
     <fieldset class="crm-group pcp-group">
         <div class="crm-section pcp-section">


### PR DESCRIPTION
...itialPayment which triggers the include is not declared anywhere in the codebase. This was cruft left-over from partial payment functionality which is partially implemented under CiviAcocounts branch and then removed.

---
- CRM-12308: Missing template file
  http://issues.civicrm.org/jira/browse/CRM-12308
