### PR TITLE
CRM-12321 - SqlGroupTest - Test prefetching more directly.

### DIFF
--- a/CRM/Utils/Cache/SqlGroup.php
+++ b/CRM/Utils/Cache/SqlGroup.php
@@ -96,6 +96,10 @@ class CRM_Utils_Cache_SqlGroup implements CRM_Utils_Cache_Interface {
     return $this->frontCache[$key];
   }
 
+  function getFromFrontCache($key, $default = NULL) {
+    return CRM_Utils_Array::value($key, $this->frontCache, $default);
+  }
+
   function delete($key) {
     CRM_Core_BAO_Cache::deleteGroup($this->group, $key);
     unset($this->frontCache[$key]);


### PR DESCRIPTION
When multi-tier caching was introduced, testPrefetch regressed because it
relied on side-effects from having totally independent caches -- but the
multi-tier cache added extra, unforeseen sharing between SqlGroup instances.
In reality, prefetching works. This revision tests prefetch more directly
to workaround the changed assumptions.

---
- CRM-12321: Multi-tier caching causes multiple test regressions
  http://issues.civicrm.org/jira/browse/CRM-12321
