### PR TITLE
Add tools/scripts/merge-forward

### DIFF
--- a/tools/scripts/merge-forward
+++ b/tools/scripts/merge-forward
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -e
+
+RELPATH="$1"
+REMOTE="$2"
+MAINTBRANCH="$3"
+DEVBRANCH="$4"
+TMPBRANCH=$MAINTBRANCH-$DEVBRANCH-$(date "+%Y-%m-%d-%H-%M-%S")
+
+if [ -z "$RELPATH" -o  -z "$REMOTE" -o  -z "$MAINTBRANCH" -o  -z "$DEVBRANCH" ] ; then
+  PROG=$(basename $0)
+  echo "Merge any changes from the maintenance-branch into the development-branch."
+  echo "If there are no conflicts, then push the changes."
+  echo ""
+  echo "Usage: $PROG <relpath> <remote> <maintenance-branch> <development-branch>"
+  echo ""
+  echo "Example: $PROG drupal upstream 7.x-4.3 7.x-master"
+  exit 1
+fi
+
+pushd "$RELPATH" >> /dev/null
+  TMPFILE=$(mktemp)
+
+  set -x
+  git fetch $REMOTE
+  git checkout -b $TMPBRANCH $REMOTE/$DEVBRANCH
+  git merge $REMOTE/$MAINTBRANCH | tee $TMPFILE
+  set +x
+
+  if grep -q CONFLICT "$TMPFILE" ; then
+    echo ""
+    echo "==> Conflicted merge. Please resolve conflicts and then push with:"
+    echo ""
+    echo "git push $REMOTE $TMPBRANCH:$DEVBRANCH"
+  elif grep -q "Already up-to-date." "$TMPFILE" ; then
+    echo ""
+    echo "==> No update needed"
+    echo ""
+  else
+    echo ""
+    echo "==> Clean merge; proceeding with push"
+    echo ""
+    set -x
+    git push $REMOTE $TMPBRANCH:$DEVBRANCH
+    git fetch $REMOTE
+    git checkout $REMOTE/$DEVBRANCH
+    git branch -d $TMPBRANCH
+    set +x
+  fi
+
+  /bin/rm -f "$TMPFILE"
+popd  >> /dev/null


### PR DESCRIPTION
Add script for merging changes from the maintenance branch (4.3) to the main development branch (master). Examples:

```
./tools/scripts/merge-forward packages upstream 4.3 master
./tools/scripts/merge-forward joomla upstream 4.3 master    
./tools/scripts/merge-forward WordPress upstream 4.3 master    
./tools/scripts/merge-forward drupal upstream 7.x-4.3 7.x-master    
./tools/scripts/merge-forward drupal upstream 6.x-4.3 6.x-master    
./tools/scripts/merge-forward . upstream 4.3 master    
```

If there are no conflicts or no changes, then the script is automatic. If there are conflicts, then they must be resolved and the new changes pushed.

(Note: I also played around with integrating this functionality into givi so that all repos could be merged with a single command. It proved difficult to provide a developer-experience that was easy to use/understand -- i.e. putting merge-forward into givi required either a lot of code or a lot of questions/options for the developer. The current approach requires a few more commands but should feel trivial in the usual cases and comprehensible in the hard cases.)
