### PR TITLE
Make it possible to hide the pref mail format in a buildForm hook

### DIFF
--- a/templates/CRM/Contact/Form/Edit/CommunicationPreferences.tpl
+++ b/templates/CRM/Contact/Form/Edit/CommunicationPreferences.tpl
@@ -110,10 +110,11 @@
         </tr>
         <tr>
             <td>{$form.is_opt_out.html} {$form.is_opt_out.label} {help id="id-optOut" file="CRM/Contact/Form/Contact.hlp"}</td>
-            <td>{$form.preferred_mail_format.label} &nbsp;
-                {$form.preferred_mail_format.html} {help id="id-emailFormat" file="CRM/Contact/Form/Contact.hlp"}
-            </td>
-
+            {if !empty($form.preferred_mail_format)}
+                <td>{$form.preferred_mail_format.label} &nbsp;
+                    {$form.preferred_mail_format.html} {help id="id-emailFormat" file="CRM/Contact/Form/Contact.hlp"}
+                </td>
+            {/if}
         </tr>
     </table>
  </div><!-- /.crm-accordion-body -->

--- a/templates/CRM/Contact/Form/Inline/CommunicationPreferences.tpl
+++ b/templates/CRM/Contact/Form/Inline/CommunicationPreferences.tpl
@@ -60,6 +60,8 @@
           {$form.preferred_language.html}
         </div>
       </div>
+
+      {if !empty($form.preferred_mail_format)}
       <div class="crm-summary-row">
         <div class="crm-label">
           {$form.preferred_mail_format.label}
@@ -68,6 +70,7 @@
           {$form.preferred_mail_format.html} {help id="id-emailFormat" file="CRM/Contact/Form/Contact.hlp"}
         </div>
       </div>
+      {/if}
 
       {if !empty($form.email_greeting_id)}
       <div class="crm-summary-row">


### PR DESCRIPTION
 (in the 'Page' tpl, we can hide it using CSS).

For a lot of non-tech orgs, this field is just clutter.
