### PR TITLE
 CRM-12330 - Caching bugs in api setting code

### DIFF
--- a/CRM/Core/BAO/ConfigSetting.php
+++ b/CRM/Core/BAO/ConfigSetting.php
@@ -53,6 +53,7 @@ class CRM_Core_BAO_ConfigSetting {
     self::add($params);
     $cache = CRM_Utils_Cache::singleton();
     $cache->delete('CRM_Core_Config');
+    $cache->delete('CRM_Core_Config' . CRM_Core_Config::domainID());
     $config = CRM_Core_Config::singleton(TRUE, TRUE);
   }
 

--- a/CRM/Core/BAO/Domain.php
+++ b/CRM/Core/BAO/Domain.php
@@ -114,6 +114,7 @@ class CRM_Core_BAO_Domain extends CRM_Core_DAO_Domain {
   static function resetDomain(){
     CRM_Core_Config::domainID(null, true);
     self::getDomain(null, true);
+    CRM_Core_Config::singleton(TRUE, TRUE);
   }
 
   static function version( $skipUsingCache = false ) {

--- a/CRM/Core/BAO/Domain.php
+++ b/CRM/Core/BAO/Domain.php
@@ -101,6 +101,7 @@ class CRM_Core_BAO_Domain extends CRM_Core_DAO_Domain {
   static function setDomain($domainID){
     CRM_Core_Config::domainID($domainID);
     self::getDomain($domainID);
+    CRM_Core_Config::singleton(TRUE, TRUE);
   }
 
   /**

--- a/CRM/Core/BAO/Setting.php
+++ b/CRM/Core/BAO/Setting.php
@@ -214,16 +214,23 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
    * @access public
    */
   static function getItems(&$params, $domains = null, $settingsToReturn) {
+    $originalDomain = CRM_Core_Config::domainID();
     if (empty($domains)) {
-      $domains[] = CRM_Core_Config::domainID();
+      $domains[] = $originalDomain;
     }
     if (!empty($settingsToReturn) && !is_array($settingsToReturn)) {
       $settingsToReturn = array($settingsToReturn);
     }
-    $config = CRM_Core_Config::singleton();
+    $reloadConfig = FALSE;
+
     $fields = $result = array();
     $fieldsToGet = self::validateSettingsInput(array_flip($settingsToReturn), $fields, FALSE);
     foreach ($domains as $domain) {
+      CRM_Core_BAO_Domain::setDomain($domain);
+      if($domain != $originalDomain){
+        $reloadConfig = TRUE;
+      }
+      $config = CRM_Core_Config::singleton($reloadConfig, $reloadConfig);
       $result[$domain] = array();
       foreach ($fieldsToGet as $name => $value) {
         if(!empty($fields['values'][$name]['prefetch'])){
@@ -248,6 +255,7 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
           // e.g for revert of fill actions
           $result[$domain][$name] = $setting;
         }
+        CRM_Core_BAO_Domain::resetDomain();
       }
     }
     return $result;

--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -184,8 +184,7 @@ class CRM_Core_Config extends CRM_Core_Config_Variables {
 
       // first, attempt to get configuration object from cache
       $cache = CRM_Utils_Cache::singleton();
-      self::$_singleton = $cache->get('CRM_Core_Config');
-
+      self::$_singleton = $cache->get('CRM_Core_Config' . CRM_Core_Config::domainID());
       // if not in cache, fire off config construction
       if (!self::$_singleton) {
         self::$_singleton = new CRM_Core_Config;
@@ -199,7 +198,7 @@ class CRM_Core_Config extends CRM_Core_Config_Variables {
           // retrieve and overwrite stuff from the settings file
           self::$_singleton->setCoreVariables();
         }
-        $cache->set('CRM_Core_Config', self::$_singleton);
+        $cache->set('CRM_Core_Config' . CRM_Core_Config::domainID(), self::$_singleton);
       }
       else {
         // we retrieve the object from memcache, so we now initialize the objects

--- a/api/v3/examples/Setting/CreateAllDomains.php
+++ b/api/v3/examples/Setting/CreateAllDomains.php
@@ -8,7 +8,6 @@ $params = array(
   'version' => 3,
   'domain_id' => 'all',
   'uniq_email_per_site' => 1,
-  'debug' => 1,
 );
 
   $result = civicrm_api( 'setting','create',$params );
@@ -35,11 +34,6 @@ function setting_create_expectedresult(){
       '3' => array( 
           'uniq_email_per_site' => '1',
         ),
-    ),
-  'xdebug' => array( 
-      'peakMemory' => 127711392,
-      'memory' => 123061848,
-      'timeIndex' => '1357.0696148872',
     ),
 );
 

--- a/api/v3/examples/SettingGetfields.php
+++ b/api/v3/examples/SettingGetfields.php
@@ -21,7 +21,7 @@ function setting_getfields_expectedresult(){
   $expectedResult = array( 
   'is_error' => 0,
   'version' => 3,
-  'count' => 72,
+  'count' => 73,
   'values' => array( 
       'address_standardization_provider' => array( 
           'group_name' => 'Address Preferences',
@@ -258,7 +258,7 @@ function setting_getfields_expectedresult(){
           'group' => 'core',
           'name' => 'address_format',
           'type' => 'String',
-          'html_type' => 'Text',
+          'html_type' => 'TextArea',
           'default' => '{contact.address_name}
 {contact.street_address}
 {contact.supplemental_address_1}
@@ -381,6 +381,9 @@ function setting_getfields_expectedresult(){
           'name' => 'contact_autocomplete_options',
           'type' => 'String',
           'html_type' => 'checkboxes',
+          'pseudoconstant' => array( 
+              'optionGroupName' => 'contact_autocomplete_options',
+            ),
           'default' => array( 
               '0' => '1',
               '1' => '2',
@@ -615,6 +618,27 @@ When enabled, statistics about your CiviCRM installation are reported anonymousl
           'is_contact' => 0,
           'description' => '',
           'help_text' => '',
+        ),
+      'communityMessagesUrl' => array( 
+          'group_name' => 'CiviCRM Preferences',
+          'group' => 'core',
+          'name' => 'communityMessagesUrl',
+          'prefetch' => 0,
+          'config_only' => 1,
+          'type' => 'String',
+          'quick_form_type' => 'Element',
+          'html_type' => 'Text',
+          'html_attributes' => array( 
+              'size' => 64,
+              'maxlength' => 128,
+            ),
+          'default' => '*default*',
+          'add' => '4.3',
+          'title' => 'Community Messages URL',
+          'is_domain' => 1,
+          'is_contact' => 0,
+          'description' => 'Service providing CiviCRM community messages',
+          'help_text' => 'Use "*default*" for the system default or override with a custom URL',
         ),
       'resCacheCode' => array( 
           'group_name' => 'CiviCRM Preferences',

--- a/tests/phpunit/CRM/Core/BAO/SettingTest.php
+++ b/tests/phpunit/CRM/Core/BAO/SettingTest.php
@@ -130,16 +130,9 @@ class CRM_Core_BAO_SettingTest extends CiviUnitTestCase {
     $checkresult = CRM_Core_DAO::singleValueQuery($checkSQL);
     $this->assertEquals(1, $checkresult, "Check that maxAttachments has been saved to database not just stored in config");
     $sql = " DELETE FROM civicrm_setting WHERE name = 'max_attachments'";
+    CRM_Core_DAO::executeQuery($sql);
+
     $currentDomain = CRM_Core_Config::domainID();
-<<<<<<< Updated upstream
-
-    CRM_Core_DAO::executeQuery($sql);
-    CRM_Core_BAO_Setting::inCache('CiviCRM Preferences', 'max_attachments', NULL, NULL, TRUE, $currentDomain, TRUE);
-    CRM_Core_BAO_Setting::updateSettingsFromMetaData();
-=======
->>>>>>> Stashed changes
-
-    CRM_Core_DAO::executeQuery($sql);
     // we are setting up an artificial situation here as we are trying to drive out
     // previous memory of this setting so we need to flush it out
     $cachekey =  CRM_Core_BAO_Setting::inCache('CiviCRM Preferences', 'max_attachments', NULL, NULL, TRUE, $currentDomain);

--- a/tests/phpunit/CRM/Core/BAO/SettingTest.php
+++ b/tests/phpunit/CRM/Core/BAO/SettingTest.php
@@ -121,19 +121,30 @@ class CRM_Core_BAO_SettingTest extends CiviUnitTestCase {
    *
    **/
   function testConvertAndFillSettings() {
-    $sql = " DELETE FROM civicrm_setting WHERE name = 'max_attachments'";
-    CRM_Core_DAO::executeQuery($sql);
-
     $settings = array('maxAttachments' => 6);
     CRM_Core_BAO_ConfigSetting::add($settings);
     $config = CRM_Core_Config::singleton(TRUE, TRUE);
     $this->assertEquals(6, $config->maxAttachments);
-    $checkSQL = "SELECT  count(*) FROM civicrm_domain WHERE config_backend LIKE '%Max%' AND id = 1
+    $checkSQL = "SELECT  count(*) FROM civicrm_domain WHERE config_backend LIKE '%\"maxAttachments\";i:6%' AND id = 1
     ";
     $checkresult = CRM_Core_DAO::singleValueQuery($checkSQL);
     $this->assertEquals(1, $checkresult, "Check that maxAttachments has been saved to database not just stored in config");
-    CRM_Core_BAO_Setting::updateSettingsFromMetaData();
+    $sql = " DELETE FROM civicrm_setting WHERE name = 'max_attachments'";
+    $currentDomain = CRM_Core_Config::domainID();
+<<<<<<< Updated upstream
 
+    CRM_Core_DAO::executeQuery($sql);
+    CRM_Core_BAO_Setting::inCache('CiviCRM Preferences', 'max_attachments', NULL, NULL, TRUE, $currentDomain, TRUE);
+    CRM_Core_BAO_Setting::updateSettingsFromMetaData();
+=======
+>>>>>>> Stashed changes
+
+    CRM_Core_DAO::executeQuery($sql);
+    // we are setting up an artificial situation here as we are trying to drive out
+    // previous memory of this setting so we need to flush it out
+    $cachekey =  CRM_Core_BAO_Setting::inCache('CiviCRM Preferences', 'max_attachments', NULL, NULL, TRUE, $currentDomain);
+    CRM_Core_BAO_Setting::flushCache($cachekey);
+    CRM_Core_BAO_Setting::updateSettingsFromMetaData();
     //check current domain
     $value = civicrm_api('setting', 'getvalue', array(
       'version' => 3,

--- a/tests/phpunit/api/v3/SettingTest.php
+++ b/tests/phpunit/api/v3/SettingTest.php
@@ -511,6 +511,7 @@ class api_v3_SettingTest extends CiviUnitTestCase {
     $result = civicrm_api('setting', 'get', $params);
     $this->assertAPISuccess($result, "in line " . __LINE__);
     $this->assertArrayHasKey('tag_unconfirmed', $result['values'][$dom['id']]);
+    $this->assertArrayHasKey('extensionsDir', $result['values'][$dom['id']]);
     $this->assertEquals('Unconfirmed', $result['values'][$dom['id']]['tag_unconfirmed']);
   }
 }

--- a/tests/phpunit/api/v3/SettingTest.php
+++ b/tests/phpunit/api/v3/SettingTest.php
@@ -248,7 +248,6 @@ class api_v3_SettingTest extends CiviUnitTestCase {
     $params = array('version' => $this->_apiversion,
         'domain_id' => 'all',
         'uniq_email_per_site' => 1,
-      'debug' =>1,
     );
     $result = civicrm_api('setting', 'create', $params);
     $description = "shows setting a variable for all domains";
@@ -343,12 +342,39 @@ class api_v3_SettingTest extends CiviUnitTestCase {
     $settings = civicrm_api('setting', 'get', array(
       'name' => 'defaultCurrency',
       'version' => $this->_apiversion,
-      'sequential' => 1,
-      'debug' => 1)
+      'sequential' => 1,)
     );
     $this->assertAPISuccess($settings);
     $this->assertEquals('USD', $settings['values'][0]['defaultCurrency']);
   }
+
+  /**
+   * setting api should set & fetch settings stored in config as well as those in settings table
+   */
+  function testGetSetConfigSettingMultipleDomains() {
+    $settings = civicrm_api('setting', 'create', array(
+      'defaultCurrency' => 'USD',
+      'version' => $this->_apiversion,
+      'domain_id' => $this->_currentDomain)
+    );
+    $settings = civicrm_api('setting', 'create', array(
+      'defaultCurrency' => 'CAD',
+      'version' => $this->_apiversion,
+      'domain_id' => $this->_domainID2)
+    );
+    $this->assertAPISuccess($settings);
+    $settings = civicrm_api('setting', 'get', array(
+      'return' => 'defaultCurrency',
+      'version' => $this->_apiversion,
+      'domain_id' => 'all',
+      )
+    );
+    $this->assertEquals('USD', $settings['values'][$this->_currentDomain]['defaultCurrency']);
+    $this->assertEquals('CAD', $settings['values'][$this->_domainID2]['defaultCurrency'],
+      "second domain (id {$this->_domainID2} ) should be set to CAD. First dom was {$this->_currentDomain} & was USD");
+
+  }
+
 /*
  * Use getValue against a config setting
  */

--- a/tests/phpunit/api/v3/SettingTest.php
+++ b/tests/phpunit/api/v3/SettingTest.php
@@ -327,7 +327,9 @@ class api_v3_SettingTest extends CiviUnitTestCase {
     );
     $result = civicrm_api('setting', 'create', $params);
     $this->assertAPISuccess($result, "in line " . __LINE__);
-    $config = CRM_Core_Config::singleton();
+    CRM_Core_BAO_Domain::setDomain($this->_domainID2);
+    $config = CRM_Core_Config::singleton(TRUE, TRUE);
+    CRM_Core_BAO_Domain::resetDomain();
     $this->assertTrue($config->debug == 1);
     // this should NOT be stored in the settings table now - only in config
     $sql = " SELECT count(*) as c FROM civicrm_setting WHERE name LIKE '%debug%'";

--- a/tools/bin/scripts/memcache.php
+++ b/tools/bin/scripts/memcache.php
@@ -8,6 +8,6 @@ define('CIVICRM_USE_MEMCACHE', 1);
 $config = &CRM_Core_Config::singleton();
 $cache = &CRM_Utils_Cache::singleton();
 
-$cache->set('CRM_Core_Config', $config);
-CRM_Core_Error::debug('get', $cache->get('CRM_Core_Config'));
+$cache->set('CRM_Core_Config' .CRM_Core_Config::domainID(), $config);
+CRM_Core_Error::debug('get', $cache->get('CRM_Core_Config' . CRM_Core_Config::domainID()));
 


### PR DESCRIPTION
Various fixes around domain keys in cache strings, removing ids, extra test, don't fetch default if item not set with civicrm-api setting.get
