### PR TITLE
CRM-12322 remove multisite specific ACL portion 

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -500,15 +500,6 @@ class CRM_Core_Permission {
     $session = CRM_Core_Session::singleton();
     $contactID = $session->get('userID');
 
-    if (self::isMultisiteEnabled()) {
-      // For multisite just check if there are contacts in acl_contact_cache table for now.
-      // FixMe: so even if a user in multisite has very limited permission could still
-      // see search / contact navigation options for example.
-      return CRM_Contact_BAO_Contact_Permission::hasContactsInCache(CRM_Core_Permission::VIEW,
-        $contactID
-      );
-    }
-
     //check for acl.
     $aclPermission = self::getPermission();
     if (in_array($aclPermission, array(


### PR DESCRIPTION
I don't know if this is a complete fix to CRM-12322 but it seems to improve it & based on the code I can understand that
1) the multisite clause says ' if user does not have any entries in acl_contact_cache, don't build the menu properly. I'm not sure when the menu is built but this seems to explain the somewhat 'unreliable' nature of the menu bug - as even after the cache is populated the menu doesn't instantly come right.

2) without this clause there is a clause further down to deal with ACLhook usage - which is what ACL Multisite is. This seems to deal adequately with the ACL scenario & simply looks to see an ACL hook is being applied. I assume this was added after the multisite check was put in

3) code is simplified by removing this block which is good.
