### PR TITLE
fix for notice found while QA of CRM-12348, and added a missing execute ...

### DIFF
--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -123,7 +123,7 @@ AND     ( g.cache_date IS NULL OR
     }
 
     if (!empty($refreshGroupIDs)) {
-      $refreshGroupIDString = CRM_Core_DAO::escapeString(implode(', ', $refreshGroupIDString));
+      $refreshGroupIDString = CRM_Core_DAO::escapeString(implode(', ', $refreshGroupIDs));
       $time  = CRM_Utils_Date::getUTCTime('YmdHis', $smartGroupCacheTimeout * 60);
       $query = "
 UPDATE civicrm_group g
@@ -131,6 +131,7 @@ SET    g.refresh_date = $time
 WHERE  g.id IN ( {$refreshGroupIDString} )
 AND    g.refresh_date IS NULL
 ";
+      CRM_Core_DAO::executeQuery($query);
     }
 
     if (empty($processGroupIDs)) {


### PR DESCRIPTION
1)The variable was incorrect which is been imploded, and thus throws notices (this variable is used to build WHERE clause of query).

2)I observed that after the $query initialization, the execute statement was missing.

The above two points are been fixed in this commit.
