### PR TITLE
Activity followup_date time format should use localization settings.

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -762,7 +762,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
     $this->addDateTime('activity_date_time', ts('Date'), TRUE, array('formatType' => 'activityDateTime'));
 
     //add followup date
-    $this->addDateTime('followup_date', ts('in'));
+    $this->addDateTime('followup_date', ts('in'), FALSE, array('formatType' => 'activityDateTime'));
 
     //autocomplete url
     $dataUrl = CRM_Utils_System::url("civicrm/ajax/rest",


### PR DESCRIPTION
When creating a new Activity, the followup_date time format is always 12H, even if localization settings indicate 24h.
