### PR TITLE
drop report temp tables on db clean up.

### DIFF
--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -728,9 +728,12 @@ class CRM_Core_Config extends CRM_Core_Config_Variables {
 SELECT TABLE_NAME as tableName
 FROM   INFORMATION_SCHEMA.TABLES
 WHERE  TABLE_SCHEMA = %1
-AND    ( TABLE_NAME LIKE 'civicrm_import_job_%'
-OR       TABLE_NAME LIKE 'civicrm_export_temp%'
-OR       TABLE_NAME LIKE 'civicrm_task_action_temp%' )
+AND
+  ( TABLE_NAME LIKE 'civicrm_import_job_%'
+  OR       TABLE_NAME LIKE 'civicrm_export_temp%'
+  OR       TABLE_NAME LIKE 'civicrm_task_action_temp%'
+  OR       TABLE_NAME LIKE 'civicrm_report_temp%'
+  )
 ";
 
     $params = array(1 => array($dao->database(), 'String'));


### PR DESCRIPTION
This helps where TEMPORARY tables are a bit limiting due to their join restrictions or the desire to retain them for when the data doesn't go stale that quickly
