### PR TITLE
CRM-12367 : http://forum.civicrm.org/index.php/topic,28397.msg121403.html#msg121403

### DIFF
--- a/CRM/Core/I18n/SchemaStructure_4_3_1.php
+++ b/CRM/Core/I18n/SchemaStructure_4_3_1.php
@@ -1,0 +1,232 @@
+<?php
+/*
++--------------------------------------------------------------------+
+| CiviCRM version 4.3                                                |
++--------------------------------------------------------------------+
+| Copyright CiviCRM LLC (c) 2004-2013                                |
++--------------------------------------------------------------------+
+| This file is a part of CiviCRM.                                    |
+|                                                                    |
+| CiviCRM is free software; you can copy, modify, and distribute it  |
+| under the terms of the GNU Affero General Public License           |
+| Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+|                                                                    |
+| CiviCRM is distributed in the hope that it will be useful, but     |
+| WITHOUT ANY WARRANTY; without even the implied warranty of         |
+| MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+| See the GNU Affero General Public License for more details.        |
+|                                                                    |
+| You should have received a copy of the GNU Affero General Public   |
+| License and the CiviCRM Licensing Exception along                  |
+| with this program; if not, contact CiviCRM LLC                     |
+| at info[AT]civicrm[DOT]org. If you have questions about the        |
+| GNU Affero General Public License or the licensing of CiviCRM,     |
+| see the CiviCRM license FAQ at http://civicrm.org/licensing        |
++--------------------------------------------------------------------+
+*/
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2013
+ * $Id$
+ *
+ */
+class CRM_Core_I18n_SchemaStructure_4_3_1
+{
+  static function &columns()
+  {
+    static $result = null;
+    if (!$result) {
+      $result = array(
+        'civicrm_location_type' => array(
+          'display_name' => "varchar(64)",
+        ) ,
+        'civicrm_option_group' => array(
+          'title' => "varchar(255)",
+          'description' => "varchar(255)",
+        ) ,
+        'civicrm_contact_type' => array(
+          'label' => "varchar(64)",
+          'description' => "text",
+        ) ,
+        'civicrm_batch' => array(
+          'title' => "varchar(64)",
+          'description' => "text",
+        ) ,
+        'civicrm_premiums' => array(
+          'premiums_intro_title' => "varchar(255)",
+          'premiums_intro_text' => "text",
+          'premiums_nothankyou_label' => "varchar(255)",
+        ) ,
+        'civicrm_membership_status' => array(
+          'label' => "varchar(128)",
+        ) ,
+        'civicrm_survey' => array(
+          'thankyou_title' => "varchar(255)",
+          'thankyou_text' => "text",
+        ) ,
+        'civicrm_participant_status_type' => array(
+          'label' => "varchar(255)",
+        ) ,
+        'civicrm_tell_friend' => array(
+          'title' => "varchar(255)",
+          'intro' => "text",
+          'suggested_message' => "text",
+          'thankyou_title' => "varchar(255)",
+          'thankyou_text' => "text",
+        ) ,
+        'civicrm_custom_group' => array(
+          'title' => "varchar(64)",
+          'help_pre' => "text",
+          'help_post' => "text",
+        ) ,
+        'civicrm_custom_field' => array(
+          'label' => "varchar(255)",
+          'help_pre' => "text",
+          'help_post' => "text",
+        ) ,
+        'civicrm_option_value' => array(
+          'label' => "varchar(255)",
+          'description' => "text",
+        ) ,
+        'civicrm_group' => array(
+          'title' => "varchar(64)",
+        ) ,
+        'civicrm_contribution_page' => array(
+          'title' => "varchar(255)",
+          'intro_text' => "text",
+          'pay_later_text' => "text",
+          'pay_later_receipt' => "text",
+          'initial_amount_label' => "varchar(255)",
+          'initial_amount_help_text' => "text",
+          'thankyou_title' => "varchar(255)",
+          'thankyou_text' => "text",
+          'thankyou_footer' => "text",
+          'for_organization' => "text",
+          'receipt_from_name' => "varchar(255)",
+          'receipt_text' => "text",
+          'footer_text' => "text",
+          'honor_block_title' => "varchar(255)",
+          'honor_block_text' => "text",
+        ) ,
+        'civicrm_product' => array(
+          'name' => "varchar(255)",
+          'description' => "text",
+          'options' => "text",
+        ) ,
+        'civicrm_membership_type' => array(
+          'name' => "varchar(128)",
+          'description' => "varchar(255)",
+        ) ,
+        'civicrm_membership_block' => array(
+          'new_title' => "varchar(255)",
+          'new_text' => "text",
+          'renewal_title' => "varchar(255)",
+          'renewal_text' => "text",
+        ) ,
+        'civicrm_price_set' => array(
+          'title' => "varchar(255)",
+          'help_pre' => "text",
+          'help_post' => "text",
+        ) ,
+        'civicrm_dashboard' => array(
+          'label' => "varchar(255)",
+        ) ,
+        'civicrm_uf_group' => array(
+          'title' => "varchar(64)",
+          'help_pre' => "text",
+          'help_post' => "text",
+        ) ,
+        'civicrm_uf_field' => array(
+          'help_post' => "text",
+          'help_pre' => "text",
+          'label' => "varchar(255)",
+        ) ,
+        'civicrm_price_field' => array(
+          'label' => "varchar(255)",
+          'help_pre' => "text",
+          'help_post' => "text",
+        ) ,
+        'civicrm_price_field_value' => array(
+          'label' => "varchar(255)",
+          'description' => "text",
+        ) ,
+        'civicrm_pcp_block' => array(
+          'link_text' => "varchar(255)",
+        ) ,
+        'civicrm_event' => array(
+          'title' => "varchar(255)",
+          'summary' => "text",
+          'description' => "text",
+          'registration_link_text' => "varchar(255)",
+          'event_full_text' => "text",
+          'fee_label' => "varchar(255)",
+          'intro_text' => "text",
+          'footer_text' => "text",
+          'confirm_title' => "varchar(255)",
+          'confirm_text' => "text",
+          'confirm_footer_text' => "text",
+          'confirm_email_text' => "text",
+          'confirm_from_name' => "varchar(255)",
+          'thankyou_title' => "varchar(255)",
+          'thankyou_text' => "text",
+          'thankyou_footer_text' => "text",
+          'pay_later_text' => "text",
+          'pay_later_receipt' => "text",
+          'initial_amount_label' => "varchar(255)",
+          'initial_amount_help_text' => "text",
+          'waitlist_text' => "text",
+          'approval_req_text' => "text",
+          'template_title' => "varchar(255)",
+        ) ,
+      );
+    }
+    return $result;
+  }
+  static function &indices()
+  {
+    static $result = null;
+    if (!$result) {
+      $result = array(
+        'civicrm_custom_group' => array(
+          'UI_title_extends' => array(
+            'name' => 'UI_title_extends',
+            'field' => array(
+              'title',
+              'extends',
+            ) ,
+            'unique' => 1,
+          ) ,
+        ) ,
+        'civicrm_custom_field' => array(
+          'UI_label_custom_group_id' => array(
+            'name' => 'UI_label_custom_group_id',
+            'field' => array(
+              'label',
+              'custom_group_id',
+            ) ,
+            'unique' => 1,
+          ) ,
+        ) ,
+        'civicrm_group' => array(
+          'UI_title' => array(
+            'name' => 'UI_title',
+            'field' => array(
+              'title',
+            ) ,
+            'unique' => 1,
+          ) ,
+        ) ,
+      );
+    }
+    return $result;
+  }
+  static function &tables()
+  {
+    static $result = null;
+    if (!$result) {
+      $result = array_keys(self::columns());
+    }
+    return $result;
+  }
+}

--- a/CRM/Upgrade/Incremental/php/FourThree.php
+++ b/CRM/Upgrade/Incremental/php/FourThree.php
@@ -274,7 +274,9 @@ WHERE     ceft.entity_id IS NULL;
       CRM_Core_DAO::executeQuery('ALTER TABLE `log_civicrm_financial_trxn` CHANGE `trxn_id` `trxn_id` VARCHAR(255) NULL DEFAULT NULL');
     }
     // CRM-12142 - some sites didn't get this column added yet, and sites which installed 4.3 from scratch will already have it
-    if (
+    // CRM-12367 - add this column to single lingual sites only
+    $upgrade = new CRM_Upgrade_Form();
+    if (!$upgrade->multilingual &&
       !CRM_Core_DAO::checkFieldExists('civicrm_premiums', 'premiums_nothankyou_label')
     ) {
       $query = "
@@ -282,7 +284,7 @@ ALTER TABLE civicrm_premiums
 ADD COLUMN   premiums_nothankyou_label varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL
   COMMENT 'Label displayed for No Thank-you option in premiums block (e.g. No thank you)'
 ";
-      CRM_Core_DAO::executeQuery($query);
+      CRM_Core_DAO::executeQuery($query, array(), TRUE, NULL, FALSE, FALSE);
     }
     $this->addTask(ts('Upgrade DB to 4.3.beta5: SQL'), 'task_4_3_x_runSql', $rev);
   }


### PR DESCRIPTION
The issue :

When a upgrade is done from 4.2.9 to 4.3.x, at 4.3.alpha1 (line no: 58) a new column adding named premiums_nothankyou_label is been done inside civicrm_premiums table. This is handled only for multi-lingual, so to handle the missed out simple upgrade handling (of adding this column), the code was done in CRM_Upgrade_Incremental_php_FourThree::upgrade_4_3_beta5 line no. 287. 

```
- During the simple upgrade from 4.2.9 to 4.3.x this works properly and the DB is correctly upgraded.

- The process happens during multi-lingual upgrade : the intended column is created in 4.3.alpha1 upgrade script, and later on also excutes 'CRM_Upgrade_Incremental_php_FourThree::upgrade_4_3_beta5 (line no. 287)' query. Which executes CRM_Core_DAO::executeQuery with 6 paramter i.e $i18nRewrite = TRUE, which translates 'civicrm_premiums' table in query to a lingual table (civicrm_premiums_en_US) and excutes the query - but since 'civicrm_premiums_en_US' is a VIEW a DB ERROR is thrown.
```

The fix :

What we should do is to execute 'CRM_Upgrade_Incremental_php_FourThree::upgrade_4_3_beta5 (line no. 287)' query only for simple upgrade as we are already executing the handling for column creation in 4.3.alpha1 for multi-lingual upgrade.

Also introduced CRM/Core/I18n/SchemaStructure_4_3_1.php this file, as after upgrade : the VIEWS (multi-lingual tables) whose base table is civicrm_premiums didn't consist of column 'premiums_nothankyou_label', after this introduction the triggerRebuild takes up this file and creates a correct VIEW.
