### PR TITLE
CRM-12151

### DIFF
--- a/CRM/Upgrade/Incremental/php/FourThree.php
+++ b/CRM/Upgrade/Incremental/php/FourThree.php
@@ -454,7 +454,7 @@ WHERE      cog.name = 'payment_instrument'
     CRM_Core_DAO::executeQuery($sql);
 
     //CRM-12141
-    $sql = "ALTER TABLE {$tempTableName1} ADD INDEX index_instrument_id (instrument_id);";
+    $sql = "ALTER TABLE {$tempTableName1} ADD INDEX index_instrument_id (instrument_id(200));";
     CRM_Core_DAO::executeQuery($sql);
 
     //create temp table to process completed / cancelled contribution


### PR DESCRIPTION
---
- CRM-12151: MySQL max_key_length error installing CiviCRM 4.2.8 on stock OSX MySQL
  http://issues.civicrm.org/jira/browse/CRM-12151
