### PR TITLE
found a bug while runing test case WebTest_Contact_InlineFieldsEditTest ...

### DIFF
--- a/CRM/Contact/Form/Inline/CustomData.php
+++ b/CRM/Contact/Form/Inline/CustomData.php
@@ -62,8 +62,9 @@ class CRM_Contact_Form_Inline_CustomData extends CRM_Contact_Form_Inline {
     $this->_groupID = CRM_Utils_Request::retrieve('groupID', 'Positive', $this, TRUE, NULL, $_REQUEST);
     $this->assign('customGroupId', $this->_groupID);
     $customRecId = CRM_Utils_Request::retrieve('customRecId', 'Positive', $this, FALSE, 1, $_REQUEST);
+    $cgcount = CRM_Utils_Request::retrieve('cgcount', 'Positive', $this, FALSE, 1, $_REQUEST);
     $subType = CRM_Contact_BAO_Contact::getContactSubType($this->_contactId, ',');
-    CRM_Custom_Form_CustomData::preProcess($this, null, $subType, $customRecId,
+    CRM_Custom_Form_CustomData::preProcess($this, null, $subType, $cgcount,
       $this->_contactType, $this->_contactId);
   }
 

--- a/CRM/Contact/Page/Inline/CustomData.php
+++ b/CRM/Contact/Page/Inline/CustomData.php
@@ -53,6 +53,7 @@ class CRM_Contact_Page_Inline_CustomData extends CRM_Core_Page {
     $contactId = CRM_Utils_Request::retrieve('cid', 'Positive', CRM_Core_DAO::$_nullObject, TRUE, NULL, $_REQUEST);
     $cgId = CRM_Utils_Request::retrieve('groupID', 'Positive', CRM_Core_DAO::$_nullObject, TRUE, NULL, $_REQUEST);
     $customRecId = CRM_Utils_Request::retrieve('customRecId', 'Positive', CRM_Core_DAO::$_nullObject, FALSE, 1, $_REQUEST);
+    $cgcount = CRM_Utils_Request::retrieve('cgcount', 'Positive', CRM_Core_DAO::$_nullObject, FALSE, 1, $_REQUEST);
 
     //custom groups Inline
     $entityType    = CRM_Contact_BAO_Contact::getContactType($contactId);
@@ -62,8 +63,13 @@ class CRM_Contact_Page_Inline_CustomData extends CRM_Core_Page {
       );
     $details = CRM_Core_BAO_CustomGroup::buildCustomDataView($this, $groupTree);
     //get the fields of single custom group record
-    $fields = CRM_Utils_Array::value($customRecId, $details[$cgId]);
-
+    if ($customRecId == 1) {
+      $fields = reset($details[$cgId]);
+    }
+    else {
+      $fields = CRM_Utils_Array::value($customRecId, $details[$cgId]);
+    }
+    $this->assign('cgcount', $cgcount);
     $this->assign('customRecId', $customRecId);
     $this->assign('contactId', $contactId);
     $this->assign('customGroupId', $cgId);
@@ -71,7 +77,7 @@ class CRM_Contact_Page_Inline_CustomData extends CRM_Core_Page {
 
     // check logged in user permission
     CRM_Contact_Page_View::checkUserPermission($this, $contactId);
-    
+
     // finally call parent
     parent::run();
   }

--- a/templates/CRM/Contact/Page/View/CustomDataFieldView.tpl
+++ b/templates/CRM/Contact/Page/View/CustomDataFieldView.tpl
@@ -23,7 +23,7 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-<div id="custom-set-content-{$customGroupId}" {if $permission EQ 'edit'} class="crm-inline-edit" data-edit-params='{ldelim}"cid": "{$contactId}", "class_name": "CRM_Contact_Form_Inline_CustomData", "groupID": "{$customGroupId}", "customRecId": "{$customRecId}"{rdelim}'{/if}>
+<div id="custom-set-content-{$customGroupId}" {if $permission EQ 'edit'} class="crm-inline-edit" data-edit-params='{ldelim}"cid": "{$contactId}", "class_name": "CRM_Contact_Form_Inline_CustomData", "groupID": "{$customGroupId}", "customRecId": "{$customRecId}", "cgcount" : "{$cgcount}"{rdelim}'{/if}>
   <div class="crm-clear crm-inline-block-content" {if $permission EQ 'edit'}title="{ts}Edit{/ts}"{/if}>
     {if $permission EQ 'edit'}
       <div class="crm-edit-help">

--- a/templates/CRM/Contact/Page/View/CustomDataView.tpl
+++ b/templates/CRM/Contact/Page/View/CustomDataView.tpl
@@ -26,6 +26,7 @@
 {* Custom Data view mode*}
 {assign var="customGroupCount" value = 1}
 {foreach from=$viewCustomData item=customValues key=customGroupId}
+  {assign var="cgcount" value=1}
   {assign var="count" value=$customGroupCount%2}
   {if ($count eq $side) or $skipTitle }
     {foreach from=$customValues item=cd_edit key=cvID}
@@ -37,9 +38,10 @@
           {assign var='cvID' value='-1'}
         {/if}
         <div class="crm-summary-block" id="custom-set-block-{$customGroupId}-{$cvID}">
-          {include file="CRM/Contact/Page/View/CustomDataFieldView.tpl" customGroupId=$customGroupId customRecId=$cvID}
+          {include file="CRM/Contact/Page/View/CustomDataFieldView.tpl" customGroupId=$customGroupId customRecId=$cvID cgcount=$cgcount}
         </div>
       </div>
+      {assign var="cgcount" value=$cgcount+1}
     {/foreach}
   {/if}
   {assign var="customGroupCount" value = $customGroupCount+1}


### PR DESCRIPTION
While editing the inline custom field, the form loads and user inputs values and saves it.

When the user second time edits the custom field inline, the edit form fields loads with no values populated. This minor break was due to CRM-12235 issue fix.

This fix introduces the variable named $cgcount which is used while editing the form for custom fields inline and modified use of $customRecId so that both multi-record fields and single-record fields inline editing handled properly.

Checked this issue, by running WebTest_Contact_InlineFieldsEditTest this test. Also checked with adding new contacts, and adding custom fields to it along with multi-valued custom fields, also with different set of custom fields - all working fine.
