### PR TITLE
CRM-12386

### DIFF
--- a/install/civicrm.php
+++ b/install/civicrm.php
@@ -187,23 +187,21 @@ function civicrm_config(&$config) {
   );
 
   $params['baseURL'] = isset($config['base_url']) ? $config['base_url'] : civicrm_cms_base();
-  if ($installType == 'drupal' &&
-    version_compare(VERSION, '7.0-rc1') >= 0
-  ) {
-    $params['cms']       = 'Drupal';
-    $params['CMSdbUser'] = addslashes($config['drupal']['username']);
-    $params['CMSdbPass'] = addslashes($config['drupal']['password']);
-    $params['CMSdbHost'] = $config['drupal']['server'];
-    $params['CMSdbName'] = addslashes($config['drupal']['database']);
-  }
-  elseif ($installType == 'drupal' &&
-    version_compare(VERSION, '6.0') >= 0
-  ) {
-    $params['cms']       = 'Drupal6';
-    $params['CMSdbUser'] = addslashes($config['drupal']['username']);
-    $params['CMSdbPass'] = addslashes($config['drupal']['password']);
-    $params['CMSdbHost'] = $config['drupal']['server'];
-    $params['CMSdbName'] = addslashes($config['drupal']['database']);
+  if ($installType == 'drupal') {
+    if (version_compare(VERSION, '7.0-rc1') >= 0) {
+      $params['cms']       = 'Drupal';
+      $params['CMSdbUser'] = addslashes($config['drupal']['username']);
+      $params['CMSdbPass'] = addslashes($config['drupal']['password']);
+      $params['CMSdbHost'] = $config['drupal']['server'];
+      $params['CMSdbName'] = addslashes($config['drupal']['database']);
+    }
+    elseif (version_compare(VERSION, '6.0') >= 0) {
+      $params['cms']       = 'Drupal6';
+      $params['CMSdbUser'] = addslashes($config['drupal']['username']);
+      $params['CMSdbPass'] = addslashes($config['drupal']['password']);
+      $params['CMSdbHost'] = $config['drupal']['server'];
+      $params['CMSdbName'] = addslashes($config['drupal']['database']);
+    }
   }
   else {
     $params['cms']       = 'WordPress';
@@ -211,6 +209,9 @@ function civicrm_config(&$config) {
     $params['CMSdbPass'] = addslashes(DB_PASSWORD);
     $params['CMSdbHost'] = DB_HOST;
     $params['CMSdbName'] = addslashes(DB_NAME);
+
+    // CRM-12386
+    $params['crmRoot'] = addslashes($params['crmRoot']);
   }
 
   $params['siteKey'] = md5(uniqid('', TRUE) . $params['baseURL']);


### PR DESCRIPTION
---
- CRM-12386: Ensure civicrm_root is escaped in WP install script
  http://issues.civicrm.org/jira/browse/CRM-12386
