### PR TITLE
CRM-12391: PHP Strict Warning messages observed in SMS Provider configuration and Send SMS action

### DIFF
--- a/CRM/Contact/Form/Task/SMSCommon.php
+++ b/CRM/Contact/Form/Task/SMSCommon.php
@@ -393,11 +393,13 @@ class CRM_Contact_Form_Task_SMSCommon {
     $smsParams = $thisValues;
     unset($smsParams['text_message']);
     $smsParams['provider_id'] = $fromSmsProviderId;
+    $contactIds = array_keys($form->_contactDetails);
+    $allContactIds = array_keys($form->_allContactDetails);
 
     list($sent, $activityId) = CRM_Activity_BAO_Activity::sendSMS($formattedContactDetails,
       $thisValues,
       $smsParams,
-      array_keys($form->_contactDetails)
+      $contactIds
     );
 
     if ($sent) {
@@ -406,13 +408,13 @@ class CRM_Contact_Form_Task_SMSCommon {
     }
 
     //Display the name and number of contacts for those sms is not sent.
-    $smsNotSent = array_diff_assoc($form->_allContactDetails, $form->_contactDetails);
+    $smsNotSent = array_diff_assoc($allContactIds, $contactIds);
 
     if (!empty($smsNotSent)) {
       $not_sent = array();
-      foreach ($smsNotSent as $contactId => $values) {
-        $displayName    = $values['display_name'];
-        $phone          = $values['phone'];
+      foreach ($smsNotSent as $index => $contactId) {
+        $displayName    = $form->_allContactDetails[$contactId]['display_name'];
+        $phone          = $form->_allContactDetails[$contactId]['phone'];
         $contactViewUrl = CRM_Utils_System::url('civicrm/contact/view', "reset=1&cid=$contactId");
         $not_sent[] = "<a href='$contactViewUrl' title='$phone'>$displayName</a>";
       }

--- a/CRM/SMS/Provider.php
+++ b/CRM/SMS/Provider.php
@@ -159,7 +159,7 @@ INNER JOIN civicrm_mailing_job mj ON mj.mailing_id = m.id AND mj.id = %1";
     return $value;
   }
 
-  function inbound($from, $body, $to = NULL, $trackID = NULL) {
+  function record_inbound_msg($from, $body, $to = NULL, $trackID = NULL) {
   	$formatFrom   = $this->formatPhone($this->stripPhone($from), $like, "like"); 
     $escapedFrom  = CRM_Utils_Type::escape($formatFrom, 'String');
     $fromContactID = CRM_Core_DAO::singleValueQuery('SELECT contact_id FROM civicrm_phone WHERE phone LIKE "' . $escapedFrom . '"');

--- a/tools/extensions/org.civicrm.sms.clickatell/org_civicrm_sms_clickatell.php
+++ b/tools/extensions/org.civicrm.sms.clickatell/org_civicrm_sms_clickatell.php
@@ -385,7 +385,7 @@ class org_civicrm_sms_clickatell extends CRM_SMS_Provider {
     $fromPhone = $this->retrieve('from', 'String');
     $fromPhone = $this->formatPhone($this->stripPhone($fromPhone), $like, "like");
 
-    return parent::inbound($fromPhone, $this->retrieve('text', 'String'), NULL, $this->retrieve('moMsgId', 'String'));
+    return parent::record_inbound_msg($fromPhone, $this->retrieve('text', 'String'), NULL, $this->retrieve('moMsgId', 'String'));
   }
 
   /**

--- a/tools/extensions/org.civicrm.sms.twilio/org_civicrm_sms_twilio.php
+++ b/tools/extensions/org.civicrm.sms.twilio/org_civicrm_sms_twilio.php
@@ -183,7 +183,7 @@ class org_civicrm_sms_twilio extends CRM_SMS_Provider {
   function inbound() {
     $like      = "";
     $fromPhone = $this->retrieve('From', 'String');
-    return parent::inbound($fromPhone, $this->retrieve('Body', 'String'), NULL, $this->retrieve('SmsSid', 'String'));
+    return parent::record_inbound_msg($fromPhone, $this->retrieve('Body', 'String'), NULL, $this->retrieve('SmsSid', 'String'));
   }
   
   /**


### PR DESCRIPTION
From http://issues.civicrm.org/jira/browse/CRM-12391

While working with CiviSMS, I observed a few different PHP strict warning messages.

1) Function signature mismatch on the inbound function

2) Error thrown when passing the array_keys($form->_contactDetails) into sendSMS

3) Unable to cast from array to string in $smsNotSent = array_diff_assoc call

I committed my changes to a private branch on GitHub: https://github.com/mmikitka/civicrm-core/tree/fix_twilio_sms_php_warnings
