### PR TITLE
CRM-11948 - Apply patch for running with a remote Selenium server. 

### DIFF
--- a/CRM/Utils/Network.php
+++ b/CRM/Utils/Network.php
@@ -1,0 +1,81 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.3                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2013                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*/
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2013
+ * $Id: $
+ *
+ */
+
+/**
+ * Simple static helpers for network operations
+ */
+class CRM_Utils_Network {
+  /**
+   * Try connecting to a TCP service; if it fails, retry. Repeat until serverStartupTimeOut elapses.
+   *
+   * @param int $serverStartupTimeOut seconds
+   * @param float $interval seconds to wait in between pollings
+   * @return bool TRUE if service is online
+   */
+  public static function waitForServiceStartup($host, $port, $serverStartupTimeOut, $interval = 0.333) {
+    $start = time();
+    $end = $start + $serverStartupTimeOut;
+    $found = FALSE;
+    $interval_usec = (int) 1000000 * $interval;
+
+    while (!$found && $end >= time()) {
+      $found = self::checkService($host, $port, $end - time());
+      if ($found) {
+        return TRUE;
+      }
+      usleep($interval_usec);
+    }
+    return FALSE;
+  }
+
+  /**
+   * Check whether a TCP service is available on $host and $port
+   */
+  public static function checkService($host, $port, $serverConnectionTimeOut) {
+    $old_error_reporting = error_reporting();
+    error_reporting($old_error_reporting & ~E_WARNING);
+    try {
+      $fh = fsockopen($host, $port, $errno, $errstr, $serverConnectionTimeOut);
+      if ($fh) {
+        fclose($fh);
+        error_reporting($old_error_reporting);
+        return TRUE;
+      }
+    } catch (Exception $e) {
+    }
+    error_reporting($old_error_reporting);
+    return FALSE;
+  }
+}

--- a/tests/phpunit/CiviTest/CiviSeleniumSettings.php.txt
+++ b/tests/phpunit/CiviTest/CiviSeleniumSettings.php.txt
@@ -6,6 +6,16 @@ class CiviSeleniumSettings {
 
   var $browser = '*firefox';
 
+  /**
+   * @var string SeleniumRC host name
+   */
+  var $rcHost = 'localhost';
+
+  /**
+   * @var int SeleniumRC port number
+   */
+  var $rcPort = 4444;
+
   var $sandboxURL = 'http://devel.drupal.tests.dev.civicrm.org';
 
   var $sandboxPATH = '';
@@ -24,6 +34,16 @@ class CiviSeleniumSettings {
    * @var int seconds
    */
   var $timeout = 30;
+
+  /**
+   * @var int|NULL seconds to wait for SeleniumRC to become available
+   *
+   * If you have custom scripts which launch Selenium and PHPUnit in tandem, then
+   * Selenium may initialize somewhat slowly. Set $serverStartupTimeOut to wait
+   * for Selenium to startup. If you launch Selenium independently or otherwise
+   * prefer to fail immediately, then leave the default value NULL.
+   */
+  var $serverStartupTimeOut = NULL;
 
   function __construct() {
     $this->fullSandboxPath = $this->sandboxURL . $this->sandboxPATH;

--- a/tests/phpunit/CiviTest/CiviSeleniumTestCase.php
+++ b/tests/phpunit/CiviTest/CiviSeleniumTestCase.php
@@ -69,6 +69,17 @@ class CiviSeleniumTestCase extends PHPUnit_Extensions_SeleniumTestCase {
 
     require_once 'CiviSeleniumSettings.php';
     $this->settings = new CiviSeleniumSettings();
+    if (property_exists($this->settings, 'serverStartupTimeOut') && $this->settings->serverStartupTimeOut) {
+      global $CiviSeleniumTestCase_polled;
+      if (!$CiviSeleniumTestCase_polled) {
+        $CiviSeleniumTestCase_polled = TRUE;
+        CRM_Utils_Network::waitForServiceStartup(
+          $this->drivers[0]->getHost(),
+          $this->drivers[0]->getPort(),
+          $this->settings->serverStartupTimeOut
+        );
+      }
+    }
 
     // autoload
     require_once 'CRM/Core/ClassLoader.php';
@@ -84,6 +95,12 @@ class CiviSeleniumTestCase extends PHPUnit_Extensions_SeleniumTestCase {
     // Make sure that below strings have path separator at the end
     $this->setBrowserUrl($this->settings->sandboxURL);
     $this->sboxPath = $this->settings->sandboxPATH;
+    if (property_exists($this->settings, 'rcHost') && $this->settings->rcHost) {
+      $this->setHost($this->settings->rcHost);
+    }
+    if (property_exists($this->settings, 'rcPort') && $this->settings->rcPort) {
+      $this->setPort($this->settings->rcPort);
+    }
   }
 
   protected function tearDown() {


### PR DESCRIPTION
(This isn't currently/strictly needed for CRM-11948 but was previously written for it -- and it's come up in other contexts.)

---
- CRM-11948: Run WebTests under Jenkins
  http://issues.civicrm.org/jira/browse/CRM-11948
