### PR TITLE
Shorter cache duration for versionCheck

### DIFF
--- a/CRM/Utils/VersionCheck.php
+++ b/CRM/Utils/VersionCheck.php
@@ -41,8 +41,8 @@ class CRM_Utils_VersionCheck {
     LOCALFILE_NAME = 'civicrm-version.php',
     // relative to $config->uploadDir
     CACHEFILE_NAME = 'latest-version-cache.txt',
-    // cachefile expiry time (in seconds) - a week
-    CACHEFILE_EXPIRE = 604800;
+    // cachefile expiry time (in seconds) - one day
+    CACHEFILE_EXPIRE = 86400;
 
   /**
    * We only need one instance of this object, so we use the


### PR DESCRIPTION
Now that we display the latest version in the footer, a week seems like a really long time to cache this. We released 4.3.1 five days ago and sites are still showing 4.3.0 as the latest.
