### PR TITLE
CRM-12413 - Return an error when api-key does not have an associated CMS user

### DIFF
--- a/CRM/Utils/REST.php
+++ b/CRM/Utils/REST.php
@@ -681,6 +681,11 @@ class CRM_Utils_REST {
     if ($uid) {
       CRM_Utils_System::loadBootStrap(array('uid' => $uid), TRUE, FALSE);
     }
+    else {
+      $err = array('error_message' => 'no CMS user associated with given api-key', 'is_error' => 1);
+      echo self::output($err);
+      CRM_Utils_System::civiExit();
+    }
   }
 }
 


### PR DESCRIPTION
- CRM-12413: CiviCRM does not error on an api-key given through the REST interface that is not connected to a CMS user
  http://issues.civicrm.org/jira/browse/CRM-12413
