### PR TITLE
add and remove labels for report role advmultiselect buttons

### DIFF
--- a/CRM/Report/Form/Instance.php
+++ b/CRM/Report/Form/Instance.php
@@ -121,7 +121,7 @@ class CRM_Report_Form_Instance {
         foreach ($user_roles_array as $key => $value) {
           $user_roles[$value] = $value;
         }
-        $form->addElement('advmultiselect',
+        $grouprole = &$form->addElement('advmultiselect',
           'grouprole',
           ts('ACL Group/Role'),
           $user_roles,
@@ -131,6 +131,8 @@ class CRM_Report_Form_Instance {
             'class' => 'advmultiselect',
           )
         );
+        $grouprole->setButtonAttributes('add', array('value' => ts('Add >>')));
+        $grouprole->setButtonAttributes('remove', array('value' => ts('<< Remove')));
       }
     }
 


### PR DESCRIPTION
In report settings, the role advanced multi-select buttons are just "<<" and ">>", which makes them ambiguous when the field is condensed for narrow screens (with the source box above the included box).  I added "add" and "remove" as it's done with all other advanced multi-selects.
