### PR TITLE
givi - When pasting in PR URLs for review, accept more URLs

### DIFF
--- a/bin/givi
+++ b/bin/givi
@@ -43,7 +43,7 @@ class PullRequest {
    */
   public static function get($url, $repos) {
     foreach ($repos as $repo => $relPath) {
-      if (preg_match("/^https:\/\/github.com\/(.*)\/(civicrm-{$repo})\/pull\/([0-9]+)$/", $url, $matches)) {
+      if (preg_match("/^https:\/\/github.com\/(.*)\/(civicrm-{$repo})\/pull\/([0-9]+)(|\/commits|\/files)$/", $url, $matches)) {
         list ($full, $githubUser, $githubRepo, $githubPr) = $matches;
 
         $pr = new PullRequest();


### PR DESCRIPTION
When pasting in PR URLs for review, accept URLs from the "Commits..." and "Files Changed" tabs
