### PR TITLE
give errors and alerts slightly more attention

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -3690,6 +3690,17 @@ div.m ul#civicrm-menu,
   max-height: 600px;
   overflow: auto;
 }
+
+#crm-container div.ui-notify-message-style.alert {
+  background-color: rgba(50, 30, 0, 0.898);
+  border: 3px solid #CC4400;
+}
+
+#crm-container div.ui-notify-message-style.error {
+  background-color: rgba(50, 0, 0, 0.898);
+  border: 3px solid #CC0000;
+}
+
 #crm-container div.ui-notify-message h1 {
   font-size: 14px;
   margin: 0;


### PR DESCRIPTION
Users are getting used to ignoring pop-up messages, since most are success confirmations.  I've put together a couple of CSS adjustments to add a red border and tint to the error popups and a orange border and tint to the alert popups.  These should help those messages stand out a little better.
