### PR TITLE
Clarify warning for creating duplicate membership

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -215,12 +215,11 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
               "reset=1&action=renew&cid={$this->_contactID}&id={$hasMembership['id']}&context=membership&selectedChild=member"
             );
           }
+          $andEndDate = '';
           if (CRM_Utils_Array::value('membership_end_date', $hasMembership)) {
-            CRM_Core_Session::setStatus(ts('This contact has an existing %1 membership record with %2 status and end date of %3. <a href="%4">Click here if you want to renew this membership</a> (rather than creating a new membership record). <a href="%5">Click here to view all existing and / or expired memberships for this contact.</a>', array(1 => $hasMembership['membership_type'], 2 => $hasMembership['membership_status'], 3 => CRM_Utils_Date::customformat($hasMembership['membership_end_date']), 4 => $renewUrl, 5 => $membershipTab)), '', 'alert');
+            $andEndDate = ts(" and end date of %1", array(1 => CRM_Utils_Date::customformat($hasMembership['membership_end_date'])));
           }
-          else {
-            CRM_Core_Session::setStatus(ts('This contact has an existing %1 membership record with %2 status. <a href="%3">Click here if you want to renew this membership</a> (rather than creating a new membership record). <a href="%4">Click here to view all existing and / or expired memberships for this contact.</a>', array(1 => $hasMembership['membership_type'], 2 => $hasMembership['membership_status'], 3 => $renewUrl, 4 => $membershipTab)), '', 'alert');
-          }
+          CRM_Core_Session::setStatus(ts('This contact has an existing %1 membership record with %2 status%3.<ul><li><a href="%4">Renew the existing membership instead</a></li><li><a href="%5">View all existing and / or expired memberships for this contact</a></li></ul>', array(1 => $hasMembership['membership_type'], 2 => $hasMembership['membership_status'], 3 => $andEndDate, 4 => $renewUrl, 5 => $membershipTab)), 'Creating Additional Membership', 'alert');
         }
       }
     }

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -235,6 +235,26 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
           $resources->addScriptFile('civicrm', 'templates/CRM/Member/Form/Membership.js');
         }
       }
+      else { 
+        $resources = CRM_Core_Resources::singleton();
+        $resources->addScriptFile('civicrm', 'templates/CRM/Member/Form/MembershipStandalone.js');
+        $statuses = array();
+        $membershipStatus = new CRM_Member_DAO_MembershipStatus();
+        $membershipStatus->is_current_member = 1;
+        $membershipStatus->find();
+        $membershipStatus->selectAdd();
+        $membershipStatus->selectAdd('id');
+        while ($membershipStatus->fetch()) {
+          $statuses[$membershipStatus->id] = $membershipStatus->label;
+        }
+        $membershipStatus->free();
+        $passthru = array(
+          'typeorgs' => CRM_Member_BAO_MembershipType::getMembershipTypeOrganization(),
+          'memtypes' => CRM_Member_BAO_MembershipType::getMembershipTypes(false),
+          'statuses' => $statuses,
+        );
+        $resources->addSetting(array('existingMems' => $passthru));
+      }
     }
 
     // when custom data is included in this page

--- a/templates/CRM/Member/Form/Membership.js
+++ b/templates/CRM/Member/Form/Membership.js
@@ -1,0 +1,17 @@
+cj(function($) {
+  checkExistingMemOrg();
+
+  $("select[name='membership_type_id[0]']").change(function() { checkExistingMemOrg(); });
+
+  function checkExistingMemOrg () {
+    var selectedorg = $("select[name='membership_type_id[0]']").val();
+    if (selectedorg in CRM.existingMems.memberorgs) {
+      var andEndDate = '';
+      var endDate = CRM.existingMems.memberorgs[selectedorg].membership_end_date;
+      if (endDate) {
+        andEndDate = ts(" and end date of %1", {1:endDate});
+      }
+      CRM.alert(ts('This contact has an existing %1 membership record with %2 status%3.<ul><li><a href="%4">Renew the existing membership instead</a></li><li><a href="%5">View all existing and / or expired memberships for this contact</a></li></ul>', {1:CRM.existingMems.memberorgs[selectedorg].membership_type, 2:CRM.existingMems.memberorgs[selectedorg].membership_status, 3:andEndDate, 4:CRM.existingMems.memberorgs[selectedorg].renewUrl, 5:CRM.existingMems.memberorgs[selectedorg].membershipTab}), ts('Duplicate Membership?'), 'alert');
+    }
+  }
+});

--- a/templates/CRM/Member/Form/Membership.js
+++ b/templates/CRM/Member/Form/Membership.js
@@ -1,7 +1,7 @@
 cj(function($) {
   checkExistingMemOrg();
 
-  $("select[name='membership_type_id[0]']").change(function() { checkExistingMemOrg(); });
+  $("select[name='membership_type_id[0]']").change( checkExistingMemOrg );
 
   function checkExistingMemOrg () {
     var selectedorg = $("select[name='membership_type_id[0]']").val();
@@ -9,7 +9,7 @@ cj(function($) {
       var andEndDate = '';
       var endDate = CRM.existingMems.memberorgs[selectedorg].membership_end_date;
       if (endDate) {
-        andEndDate = ts(" and end date of %1", {1:endDate});
+        andEndDate = ' ' + ts("and end date of %1", {1:endDate});
       }
       CRM.alert(ts('This contact has an existing %1 membership record with %2 status%3.<ul><li><a href="%4">Renew the existing membership instead</a></li><li><a href="%5">View all existing and / or expired memberships for this contact</a></li></ul>', {1:CRM.existingMems.memberorgs[selectedorg].membership_type, 2:CRM.existingMems.memberorgs[selectedorg].membership_status, 3:andEndDate, 4:CRM.existingMems.memberorgs[selectedorg].renewUrl, 5:CRM.existingMems.memberorgs[selectedorg].membershipTab}), ts('Duplicate Membership?'), 'alert');
     }

--- a/templates/CRM/Member/Form/MembershipStandalone.js
+++ b/templates/CRM/Member/Form/MembershipStandalone.js
@@ -1,0 +1,47 @@
+cj(function($) {
+  memberResults = new Array;
+  $("input[name='contact[1]']").result( function() {
+    var contact_id = cj("input[name='contact_select_id[1]']").val();
+    CRM.api('Membership', 'get', {'sequential': 1, 'contact_id': contact_id},
+      {success: function(data) {
+        if (data['values']) {
+          memberResults = data['values'];
+          checkExistingMemOrg();
+        }
+      }});
+      });
+      
+  checkExistingMemOrg();
+
+  $("select[name='membership_type_id[0]']").change(function() { checkExistingMemOrg(); });
+
+  function checkExistingMemOrg () {
+    if (memberResults) {
+      var selectedorg = $("select[name='membership_type_id[0]']").val();
+      $.each(memberResults, function() {
+        if (this['membership_type_id'] in CRM.existingMems.typeorgs) {
+          if (CRM.existingMems.typeorgs[this['membership_type_id']] == selectedorg) {
+            if(this['status_id'] in CRM.existingMems.statuses) {
+              var membership_status = CRM.existingMems.statuses[this['status_id']];
+              var andEndDate = '';
+              var endDate = this.membership_end_date;
+              if (endDate) {
+                andEndDate = ts(" and end date of %1", {1:endDate});
+              }
+              
+              var renewUrl = CRM.url('civicrm/contact/view/membership',
+                "reset=1&action=renew&cid="+this.contact_id+"&id="+this['id']+"&context=membership&selectedChild=member"
+              );
+
+              var membershipTab = CRM.url('civicrm/contact/view',
+                "reset=1&force=1&cid="+this.contact_id+"&selectedChild=member"
+              );
+              
+              CRM.alert(ts('This contact has an existing %1 membership record with %2 status%3.<ul><li><a href="%4">Renew the existing membership instead</a></li><li><a href="%5">View all existing and / or expired memberships for this contact</a></li></ul>', {1:CRM.existingMems.memtypes[this.membership_type_id], 2:membership_status, 3:andEndDate, 4:renewUrl, 5:membershipTab}), ts('Duplicate Membership?'), 'alert');
+            }
+          }
+        }
+      });
+    }
+  }
+});

--- a/templates/CRM/Member/Form/MembershipStandalone.js
+++ b/templates/CRM/Member/Form/MembershipStandalone.js
@@ -9,11 +9,11 @@ cj(function($) {
           checkExistingMemOrg();
         }
       }});
-      });
+    });
       
   checkExistingMemOrg();
 
-  $("select[name='membership_type_id[0]']").change(function() { checkExistingMemOrg(); });
+  $("select[name='membership_type_id[0]']").change( checkExistingMemOrg );
 
   function checkExistingMemOrg () {
     if (memberResults) {
@@ -26,7 +26,7 @@ cj(function($) {
               var andEndDate = '';
               var endDate = this.membership_end_date;
               if (endDate) {
-                andEndDate = ts(" and end date of %1", {1:endDate});
+                andEndDate = ' ' + ts("and end date of %1", {1:endDate});
               }
               
               var renewUrl = CRM.url('civicrm/contact/view/membership',


### PR DESCRIPTION
This simplifies the wording of the warning upon creating a new membership for a contact that already has one, and it delays the warning until selecting a membership organization.
