### PR TITLE
gitignore - Hide CRM/Core/AllCoreTables.php under 4.3. (The file isn't u...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ CRM/Contact/DAO/RelationshipType.php
 CRM/Contact/DAO/SavedSearch.php
 CRM/Contact/DAO/SubscriptionHistory.php
 CRM/Contribute/DAO
+CRM/Core/AllCoreTables.php
 CRM/Core/DAO/.listAll.php
 CRM/Core/DAO/listAll.php
 CRM/Core/DAO/ActionLog.php


### PR DESCRIPTION
...sed in 4.3, but it comes up when switching back and forth between the 4.3 and 4.4 codebases.)
