### PR TITLE
fix for CRM-12404 : "Supporter profile is not set for this Personal Camp...

### DIFF
--- a/CRM/PCP/Form/PCPAccount.php
+++ b/CRM/PCP/Form/PCPAccount.php
@@ -64,7 +64,7 @@ class CRM_PCP_Form_PCPAccount extends CRM_Core_Form {
     $this->_component = CRM_Utils_Request::retrieve('component', 'String', $this);
     $this->_id        = CRM_Utils_Request::retrieve('id', 'Positive', $this);
 
-    if (!$this->_pageId && $config->userFrameworkFrontend) {
+    if (!$this->_pageId && $config->userFramework == 'Joomla' && $config->userFrameworkFrontend) {
       $this->_pageId = $this->_id;
     }
 


### PR DESCRIPTION
- This part of issue raised due to removal of joomla frontend condition in file CRM/PCP/Form/PCPAccount.php during CRM-12111 issue fix (https://github.com/civicrm/civicrm-core/commit/254825102cec74c5679ba6dc56bc4ab1a3d883b7#diff-1).
- This condition was primarily coded for fixing a forum issue http://forum.civicrm.org/index.php/topic,17647.0/topicseen.html which seems to be a joomla specific issue.
  The patch coded for same is follows: https://fisheye2.atlassian.com/browse/CiviCRM/branches/v3.3/CRM/Contribute/Form/PCP/PCPAccount.php?r2=31560

Re-introducing the joomla frontend condition doesn't break CRM-12111 issue (in which it was removed). as well as solves the current issue.

NOTE: this is a part-1 fix for CRM-12404, for the second fix i filed a seperate pull request (https://github.com/civicrm/civicrm-wordpress/pull/14) which was against wordpress repo.
