### PR TITLE
Fix for CRM-12428

### DIFF
--- a/CRM/Upgrade/Incremental/php/FourTwo.php
+++ b/CRM/Upgrade/Incremental/php/FourTwo.php
@@ -485,6 +485,7 @@ WHERE     cpse.price_set_id IS NULL";
       $fieldParams['option_label'] = $optionValue['label'];
       $fieldParams['option_amount'] = $optionValue['value'];
       $fieldParams['option_weight'] = $optionValue['weight'];
+      $fieldParams['is_quick_config'] = $setParams['is_quick_config']; 
       if ($defaultAmount = CRM_Core_DAO::getFieldValue($daoName[$addTo[0]][0], $addTo[2], $defaultAmountColumn)) {
         $fieldParams['default_option'] = array_search($defaultAmount, $optionValue['amount_id']);
       }

--- a/CRM/Upgrade/Incremental/sql/4.2.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.2.alpha1.mysql.tpl
@@ -244,6 +244,15 @@ INSERT INTO civicrm_country (name,iso_code,region_id,is_province_abbreviated) VA
 INSERT INTO civicrm_country (name,iso_code,region_id,is_province_abbreviated) VALUES("Sint Maarten (Dutch Part)", "SX", @region_id, 0);
 INSERT INTO civicrm_country (name,iso_code,region_id,is_province_abbreviated) VALUES("Bonaire, Saint Eustatius and Saba", "BQ", @region_id, 0);
 
+-- CRM-12428
+{if $multilingual}
+    {foreach from=$locales item=locale}
+    	ALTER TABLE `civicrm_price_field_value` CHANGE label_{$locale} label_{$locale} VARCHAR(255)  NULL DEFAULT NULL;
+    {/foreach}
+{else}
+	ALTER TABLE `civicrm_price_field_value` CHANGE `label` `label` VARCHAR(255)  NULL DEFAULT NULL;
+{/if}
+
 -- CRM-9714 create a default price set for contribution and membership
 ALTER TABLE `civicrm_price_set`
 ADD         `is_quick_config` TINYINT(4) NOT NULL DEFAULT '0'


### PR DESCRIPTION
v3.3.beta1 - had label required (NOT NULL) for fresh installations, but optional (NULL) for upgrades [refer 3.3.bat1.mysql create table structure].

4.2.alpha1 - When upgrade passes through v4.2.alpha1 stage / script :
Eileen's patch would work cleanly for installations that upgraded to v3.3.x (gone though v3.3.beta1 script). 
Eileen's patch would still FAIL for v3.3.x fresh installations, as label would be a required field at DB level and following code fails at DB level:
CRM_Upgrade_Snapshot_V4p2_Price_BAO_FieldValue::create($options, $optionsIds); 

v4.2.3 - makes label column optional for both fresh installs and upgrades per CRM-11014

An appropriate solution would be to make label column optional at v4.2.alpha1 level itself in addition to Eileen's patch.
