### PR TITLE
CRM-12378 a new webtest helper function introduction which can help dete...

### DIFF
--- a/tests/phpunit/WebTest/Activity/StandaloneAddTest.php
+++ b/tests/phpunit/WebTest/Activity/StandaloneAddTest.php
@@ -162,5 +162,16 @@ class WebTest_Activity_StandaloneAddTest extends CiviSeleniumTestCase {
       )
     );
   }
-}
 
+  function testAjaxCustomGroupLoad() {
+    $this->webtestLogin();
+    $triggerElement = array('name' => 'activity_type_id', 'type' => 'select');
+    $customSets = array(
+      array('entity' => 'Activity', 'subEntity' => 'Interview', 'triggerElement' => $triggerElement),
+      array('entity' => 'Activity', 'subEntity' => 'Meeting', 'triggerElement' => $triggerElement)
+    );
+
+    $pageUrl = array('url' => 'activity', 'args' => 'reset=1&action=add&context=standalone');
+    $this->customFieldSetLoadOnTheFlyCheck($customSets, $pageUrl);
+  }
+}

--- a/tests/phpunit/WebTest/Campaign/CampaignDescriptionTest.php
+++ b/tests/phpunit/WebTest/Campaign/CampaignDescriptionTest.php
@@ -82,5 +82,16 @@ class WebTest_Campaign_CampaignDescriptionTest extends CiviSeleniumTestCase {
     $fetchedVaue = $this->getValue('description');
     $this->assertEquals($campaignDescription, $fetchedVaue);
   }
-}
 
+  function testAjaxCustomGroupLoad() {
+    $this->webtestLogin();
+    $triggerElement = array('name' => 'campaign_type_id', 'type' => 'select');
+    $customSets = array(
+      array('entity' => 'Campaign', 'subEntity' => 'Referral Program', 'triggerElement' => $triggerElement),
+      array('entity' => 'Campaign', 'subEntity' => 'Constituent Engagement', 'triggerElement' => $triggerElement)
+    );
+
+    $pageUrl = array('url' => 'campaign/add', 'args' => 'reset=1');
+    $this->customFieldSetLoadOnTheFlyCheck($customSets, $pageUrl);
+  }
+}

--- a/tests/phpunit/WebTest/Case/AddCaseTest.php
+++ b/tests/phpunit/WebTest/Case/AddCaseTest.php
@@ -140,6 +140,21 @@ class WebTest_Case_AddCaseTest extends CiviSeleniumTestCase {
     $this->_testSearchbyDate($firstName, $lastName, "this.year");
   }
 
+  function testAjaxCustomGroupLoad() {
+    $this->webtestLogin();
+
+    // Enable CiviCase module if necessary
+    $this->enableComponents("CiviCase");
+
+    $triggerElement = array('name' => 'case_type_id', 'type' => 'select');
+    $customSets = array(
+      array('entity' => 'Case', 'subEntity' => 'Housing Support', 'triggerElement' => $triggerElement),
+    );
+
+    $pageUrl = array('url' => 'case/add', 'args' => "reset=1&action=add&atype=13&context=standalone");
+    $this->customFieldSetLoadOnTheFlyCheck($customSets, $pageUrl);
+  }
+
   function _testVerifyCaseSummary($validateStrings, $activityTypes) {
     $this->assertStringsPresent($validateStrings);
     foreach ($activityTypes as $aType) {

--- a/tests/phpunit/WebTest/Contact/RelationshipAddTest.php
+++ b/tests/phpunit/WebTest/Contact/RelationshipAddTest.php
@@ -352,5 +352,22 @@ class WebTest_Contact_RelationshipAddTest extends CiviSeleniumTestCase {
     );
     $this->assertTrue($this->isTextPresent($params['label_a_b']));
   }
-}
 
+  function testAjaxCustomGroupLoad() {
+    $this->webtestLogin();
+
+    //create a New Individual
+    $firstName = substr(sha1(rand()), 0, 7);
+    $this->webtestAddContact($firstName, "Anderson", "$firstName@anderson.name");
+    $contactId = explode('cid=', $this->getLocation());
+
+    $triggerElement = array('name' => 'relationship_type_id', 'type' => 'select');
+    $customSets = array(
+      array('entity' => 'Relationship', 'subEntity' => 'Partner of', 'triggerElement' => $triggerElement),
+      array('entity' => 'Relationship', 'subEntity' => 'Spouse of', 'triggerElement' => $triggerElement)
+    );
+
+    $pageUrl = array('url' => 'contact/view/rel', 'args' => "cid={$contactId[1]}&action=add&reset=1");
+    $this->customFieldSetLoadOnTheFlyCheck($customSets, $pageUrl);
+  }
+}

--- a/tests/phpunit/WebTest/Contribute/StandaloneAddTest.php
+++ b/tests/phpunit/WebTest/Contribute/StandaloneAddTest.php
@@ -177,5 +177,16 @@ class WebTest_Contribute_StandaloneAddTest extends CiviSeleniumTestCase {
       $this->verifyText("xpath=id('Search')/div[2]/table[2]/tbody/tr[2]/td[$value]", preg_quote($label));
     }
   }
-}
 
+  function testAjaxCustomGroupLoad() {
+    $this->webtestLogin();
+    $triggerElement = array('name' => 'financial_type_id', 'type' => 'select');
+    $customSets = array(
+      array('entity' => 'Contribution', 'subEntity' => 'Donation', 'triggerElement' => $triggerElement),
+      array('entity' => 'Contribution', 'subEntity' => 'Member Dues', 'triggerElement' => $triggerElement)
+    );
+
+    $pageUrl = array('url' => 'contribute/add', 'args' => 'reset=1&action=add&context=standalone');
+    $this->customFieldSetLoadOnTheFlyCheck($customSets, $pageUrl);
+  }
+}

--- a/tests/phpunit/WebTest/Event/AddEventTest.php
+++ b/tests/phpunit/WebTest/Event/AddEventTest.php
@@ -310,6 +310,18 @@ class WebTest_Event_AddEventTest extends CiviSeleniumTestCase {
     $this->assertNotChecked('is_pay_later');
   }
 
+  function testAjaxCustomGroupLoad() {
+    $this->webtestLogin();
+
+    $triggerElement = array('name' => 'event_type_id', 'type' => 'select');
+    $customSets = array(
+      array('entity' => 'Event', 'subEntity' => 'Conference', 'triggerElement' => $triggerElement),
+    );
+
+    $pageUrl = array('url' => 'event/add', 'args' => "reset=1&action=add");
+    $this->customFieldSetLoadOnTheFlyCheck($customSets, $pageUrl);
+  }
+
   function _testAddEventInfo($eventTitle, $eventDescription) {
     $this->waitForElementPresent("_qf_EventInfo_upload-bottom");
 

--- a/tests/phpunit/WebTest/Event/AddParticipationTest.php
+++ b/tests/phpunit/WebTest/Event/AddParticipationTest.php
@@ -372,6 +372,18 @@ class WebTest_Event_AddParticipationTest extends CiviSeleniumTestCase {
 }
   }
 
+  function testAjaxCustomGroupLoad() {
+    $this->webtestLogin();
+
+    $customSets = array(
+      array('entity' => 'ParticipantEventName', 'subEntity' => 'Fall Fundraiser Dinner',
+        'triggerElement' => array('name' => "event_id", 'type' => "select")),
+      array('entity' => 'ParticipantRole', 'subEntity' => 'Attendee','triggerElement' => array('type' => "checkbox"))
+    );
+    $pageUrl = array('url' => "participant/add", 'args' => "reset=1&action=add&context=standalone");
+    $this->customFieldSetLoadOnTheFlyCheck($customSets, $pageUrl);
+  }
+
   function _fillParticipantDetails($firstName, $lastName, $processorId) {
     $this->select("id=profiles_1", "label=New Individual");
     $this->waitForElementPresent('_qf_Edit_next');
@@ -386,4 +398,3 @@ class WebTest_Event_AddParticipationTest extends CiviSeleniumTestCase {
     $this->webtestAddBillingDetails();
   }
 }
-

--- a/tests/phpunit/WebTest/Grant/CustomFieldsetTest.php
+++ b/tests/phpunit/WebTest/Grant/CustomFieldsetTest.php
@@ -109,5 +109,20 @@ class WebTest_Grant_CustomFieldsetTest extends CiviSeleniumTestCase {
      )
     );
   }
-}
 
+  function testAjaxCustomGroupLoad() {
+    $this->webtestLogin();
+
+    // Enable CiviGrant module if necessary
+    $this->enableComponents("CiviGrant");
+
+    $triggerElement = array('name' => 'grant_type_id', 'type' => 'select');
+    $customSets = array(
+      array('entity' => 'Grant', 'subEntity' => 'Emergency', 'triggerElement' => $triggerElement),
+      array('entity' => 'Grant', 'subEntity' => 'Family Support', 'triggerElement' => $triggerElement)
+    );
+
+    $pageUrl = array('url' => 'grant/add', 'args' => 'reset=1&action=add&context=standalone');
+    $this->customFieldSetLoadOnTheFlyCheck($customSets, $pageUrl);
+  }
+}

--- a/tests/phpunit/WebTest/Member/StandaloneAddTest.php
+++ b/tests/phpunit/WebTest/Member/StandaloneAddTest.php
@@ -161,5 +161,16 @@ class WebTest_Member_StandaloneAddTest extends CiviSeleniumTestCase {
     );
     $this->webtestVerifyTabularData($expected);
   }
-}
 
+  function testAjaxCustomGroupLoad() {
+    $this->webtestLogin();
+    $triggerElement = array('name' => 'membership_type_id_1', 'type' => 'select');
+    $customSets = array(
+      array('entity' => 'Membership', 'subEntity' => 'General', 'triggerElement' => $triggerElement),
+      array('entity' => 'Membership', 'subEntity' => 'Student', 'triggerElement' => $triggerElement)
+    );
+
+    $pageUrl = array('url' => 'member/add', 'args' => 'reset=1&action=add&context=standalone');
+    $this->customFieldSetLoadOnTheFlyCheck($customSets, $pageUrl);
+  }
+}


### PR DESCRIPTION
added a helper function 'customFieldSetLoadOnTheFlyCheck', which will do a check for custom field rendering which happen 'on the fly' i.e. through ajax callback.

So, now if a entity supports such a 'on the fly' rendering, you can use this function by passing necessary arguments to it in the entity specific test.

in this commit, done entity specific handling which supports such on the fly custom field rendering.
