### PR TITLE
Membership dashboard is wrong (CRM-12500)

### DIFF
--- a/CRM/Activity/Form/Search.php
+++ b/CRM/Activity/Form/Search.php
@@ -446,6 +446,7 @@ class CRM_Activity_Form_Search extends CRM_Core_Form {
 
   function fixFormValues() {
     if (!$this->_force) {
+//     print_r($this->_formValues); die();
       return;
     }
     $status = CRM_Utils_Request::retrieve('status', 'String', $this);
@@ -479,6 +480,58 @@ class CRM_Activity_Form_Search extends CRM_Core_Form {
         // also assign individual mode to the template
         $this->_single = TRUE;
       }
+    }
+    
+    // Added for membership search
+    
+    $signupType = CRM_Utils_Request::retrieve('signupType', 'Positive',
+      CRM_Core_DAO::$_nullObject
+    );
+    
+    if ($signupType) {
+      //$this->_formValues['activity_type_id'] = array();
+    
+      $activityTypes = CRM_Core_PseudoConstant::activityType(TRUE, FALSE, FALSE, 'name');
+      $signup = CRM_Utils_Array::key('Membership Renewal', $activityTypes);
+      $renew = CRM_Utils_Array::key('Membership Signup', $activityTypes);
+      
+      switch ($signupType) {
+        case 3: // signups and renewals
+          $this->_formValues['activity_type_id'][$renew] = 1;
+          $this->_defaults['activity_type_id'][$renew] = 1;
+        case 1: // signups only
+          $this->_formValues['activity_type_id'][$signup] = 1;
+          $this->_defaults['activity_type_id'][$signup] = 1;
+          break;
+          
+        case 2: // renewals only
+          $this->_formValues['activity_type_id'][$renew] = 1;
+          $this->_defaults['activity_type_id'][$renew] = 1;
+          break;
+      }
+    }
+    
+    $dateLow = CRM_Utils_Request::retrieve('dateLow', 'Positive',
+      CRM_Core_DAO::$_nullObject
+    );
+    
+    if ($dateLow) {
+          $this->_formValues['activity_date_low'] = $dateLow;
+          $this->_defaults['activity_date_low'] = $dateLow;
+    }
+    
+    $dateHigh = CRM_Utils_Request::retrieve('dateHigh', 'Positive',
+      CRM_Core_DAO::$_nullObject
+    );
+    
+    if ($dateHigh) {
+      // Activity date time assumes midnight at the beginning of the date
+      // This sets it to almost midnight at the end of the date
+      if ($dateHigh <= 99999999) {
+        $dateHigh = 1000000 * $dateHigh + 235959;
+      }
+      $this->_formValues['activity_date_high'] = $dateHigh;
+      $this->_defaults['activity_date_high'] = $dateHigh;
     }
   }
 

--- a/CRM/Activity/Form/Search.php
+++ b/CRM/Activity/Form/Search.php
@@ -446,7 +446,6 @@ class CRM_Activity_Form_Search extends CRM_Core_Form {
 
   function fixFormValues() {
     if (!$this->_force) {
-//     print_r($this->_formValues); die();
       return;
     }
     $status = CRM_Utils_Request::retrieve('status', 'String', $this);

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1085,11 +1085,9 @@ INNER JOIN  civicrm_membership_type type ON ( type.id = membership.membership_ty
 
   /**
    * Function to get membership joins/renewals for a specified membership
-   * type.  Specifically, retrieves a count of memberships whose start_date
-   * is within a specified date range.  Dates match the regexp
-   * "yyyy(mm(dd)?)?".  Omitted portions of a date match the earliest start
-   * date or latest end date, i.e., 200803 is March 1st as a start date and
-   * March 31st as an end date.
+   * type.  Specifically, retrieves a count of memberships whose "Membership
+   * Signup" or "Membership Renewal" activity falls in the given date range.
+   * Dates match the pattern "yyyy-mm-dd".
    *
    * @param int    $membershipTypeId  membership type id
    * @param int    $startDate         date on which to start counting
@@ -1116,10 +1114,6 @@ INNER JOIN  civicrm_membership_type type ON ( type.id = membership.membership_ty
       return 0;
     }
 
-    // Clean up dates to use with activity_date_time
-    $startDate = substr($startDate, 0, 4) . '-' . substr($startDate, 4, 2) . '-' . substr($startDate, 6, 2);
-    $endDate = substr($endDate, 0, 4) . '-' . substr($endDate, 4, 2) . '-' . substr($endDate, 6, 2);
-
     $query = "
     SELECT  COUNT(DISTINCT membership.id) as member_count
       FROM  civicrm_membership membership
@@ -1144,7 +1138,7 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = membership.contact_id AND 
 
   /**
    * Function to get a count of membership for a specified membership type,
-   * optionally for a specified date.  The date must have the form yyyymmdd.
+   * optionally for a specified date.  The date must have the form yyyy-mm-dd.
    *
    * If $date is omitted, this function counts as a member anyone whose
    * membership status_id indicates they're a current member.
@@ -1164,8 +1158,8 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = membership.contact_id AND 
    *         $date.
    */
   public static function getMembershipCount($membershipTypeId, $date = NULL, $isTest = 0, $isOwner = 0) {
-    if (!is_null($date) && !preg_match('/^\d{8}$/', $date)) {
-      CRM_Core_Error::fatal(ts('Invalid date "%1" (must have form yyyymmdd).', array(1 => $date)));
+    if (!CRM_Utils_Rule::date($date)) {
+      CRM_Core_Error::fatal(ts('Invalid date "%1" (must have form yyyy-mm-dd).', array(1 => $date)));
     }
 
     $params = array(1 => array($membershipTypeId, 'Integer'),
@@ -1180,7 +1174,6 @@ AND civicrm_membership.is_test = %2";
       $query .= " AND civicrm_membership_status.is_current_member = 1";
     }
     else {
-      $date = substr($date, 0, 4) . '-' . substr($date, 4, 2) . '-' . substr($date, 6, 2);
       $query .= " AND civicrm_membership.start_date <= '$date' AND civicrm_membership_status.is_current_member = 1";
     }
     // LCD
@@ -2324,11 +2317,8 @@ LEFT JOIN civicrm_membership mem ON ( cr.id = mem.contribution_recur_id )
   /**
    * Function to get membership joins for a specified membership
    * type.  Specifically, retrieves a count of still current memberships whose
-   * join_date and start_date
-   * are within a specified date range.  Dates match the regexp
-   * "yyyy(mm(dd)?)?".  Omitted portions of a date match the earliest start
-   * date or latest end date, i.e., 200803 is March 1st as a start date and
-   * March 31st as an end date.
+   * join_date and start_date are within a specified date range.  Dates match
+   * the pattern "yyyy-mm-dd".
    *
    * @param int    $membershipTypeId  membership type id
    * @param int    $startDate         date on which to start counting
@@ -2352,10 +2342,6 @@ LEFT JOIN civicrm_membership mem ON ( cr.id = mem.contribution_recur_id )
       return 0;
     }
 
-    // Clean up dates to use with activity_date_time
-    $startDate = substr($startDate, 0, 4) . '-' . substr($startDate, 4, 2) . '-' . substr($startDate, 6, 2);
-    $endDate = substr($endDate, 0, 4) . '-' . substr($endDate, 4, 2) . '-' . substr($endDate, 6, 2);
-
     $query = "
     SELECT  COUNT(DISTINCT membership.id) as member_count
       FROM  civicrm_membership membership
@@ -2378,12 +2364,9 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = membership.contact_id AND 
 
   /**
    * Function to get membership renewals for a specified membership
-   * type.  Specifically, retrieves a count of still current memberships whose
-   * join_date is before and start_date
-   * is within a specified date range.  Dates match the regexp
-   * "yyyy(mm(dd)?)?".  Omitted portions of a date match the earliest start
-   * date or latest end date, i.e., 200803 is March 1st as a start date and
-   * March 31st as an end date.
+   * type.  Specifically, retrieves a count of still current memberships
+   * whose join_date is before and start_date is within a specified date 
+   * range.  Dates match the pattern "yyyy-mm-dd".
    *
    * @param int    $membershipTypeId  membership type id
    * @param int    $startDate         date on which to start counting
@@ -2406,10 +2389,6 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = membership.contact_id AND 
     if (!self::$_renewalActType) {
       return 0;
     }
-    
-    // Clean up dates to use with activity_date_time
-    $startDate = substr($startDate, 0, 4) . '-' . substr($startDate, 4, 2) . '-' . substr($startDate, 6, 2);
-    $endDate = substr($endDate, 0, 4) . '-' . substr($endDate, 4, 2) . '-' . substr($endDate, 6, 2);
     
     $query = "
     SELECT  COUNT(DISTINCT membership.id) as member_count

--- a/CRM/Member/Page/DashBoard.php
+++ b/CRM/Member/Page/DashBoard.php
@@ -49,17 +49,18 @@ class CRM_Member_Page_DashBoard extends CRM_Core_Page {
   function preProcess() {
     CRM_Utils_System::setTitle(ts('CiviMember'));
     $membershipSummary = array();
-    $preMonth          = CRM_Utils_Date::customFormat(date("Y-m-d", mktime(0, 0, 0, date("m") - 1, 01, date("Y"))), '%Y%m%d');
-    $preMonthEnd       = CRM_Utils_Date::customFormat(date("Y-m-t", mktime(0, 0, 0, date("m") - 1, 01, date("Y"))), '%Y%m%d');
-    $prePreMonthEnd    = CRM_Utils_Date::customFormat(date("Y-m-t", mktime(0, 0, 0, date("m") - 2, 01, date("Y"))), '%Y%m%d');
+    $preMonth = date("Y-m-d", mktime(0, 0, 0, date("m") - 1, 01, date("Y")));
+    $preMonthEnd = date("Y-m-t", mktime(0, 0, 0, date("m") - 1, 01, date("Y")));
 
     $preMonthYear = mktime(0, 0, 0, substr($preMonth, 4, 2), 1, substr($preMonth, 0, 4));
 
-    $today          = getdate();
-    $date           = CRM_Utils_Date::getToday();
+    $today = getdate();
+    $date = CRM_Utils_Date::getToday();
     $isCurrentMonth = 0;
 
+    // You can force the dashboard to display based upon a certain date
     $ym = CRM_Utils_Array::value('date', $_GET);
+
     if ($ym) {
       if (preg_match('/^\d{6}$/', $ym) == 0 ||
         !checkdate(substr($ym, 4, 2), 1, substr($ym, 0, 4)) ||
@@ -69,34 +70,22 @@ class CRM_Member_Page_DashBoard extends CRM_Core_Page {
       }
 
       $isPreviousMonth = 0;
-      $isCurrentMonth  = substr($ym, 0, 4) == $today['year'] && substr($ym, 4, 2) == $today['mon'];
-      $ymd             = date('Ymd', mktime(0, 0, -1, substr($ym, 4, 2) + 1, 1, substr($ym, 0, 4)));
-      $monthStartTs    = mktime(0, 0, 0, substr($ym, 4, 2), 1, substr($ym, 0, 4));
-      $current         = CRM_Utils_Date::customFormat($date, '%Y%m%d');
+      $isCurrentMonth = substr($ym, 0, 4) == $today['year'] && substr($ym, 4, 2) == $today['mon'];
+      $ymd = date('Y-m-d', mktime(0, 0, -1, substr($ym, 4, 2) + 1, 1, substr($ym, 0, 4)));
+      $monthStartTs = mktime(0, 0, 0, substr($ym, 4, 2), 1, substr($ym, 0, 4));
+      $current = CRM_Utils_Date::customFormat($date, '%Y-%m-%d');
+      $ym = substr($ym, 0, 4) . '-' . substr($ym, 4, 2);
     }
     else {
-      $ym              = sprintf("%04d%02d", $today['year'], $today['mon']);
-      $ymd             = sprintf("%04d%02d%02d", $today['year'], $today['mon'], $today['mday']);
-      $monthStartTs    = mktime(0, 0, 0, $today['mon'], 1, $today['year']);
-      $current         = NULL;
-      $isCurrentMonth  = 1;
+      $ym = sprintf("%04d-%02d", $today['year'], $today['mon']);
+      $ymd = sprintf("%04d-%02d-%02d", $today['year'], $today['mon'], $today['mday']);
+      $monthStartTs = mktime(0, 0, 0, $today['mon'], 1, $today['year']);
+      $current = CRM_Utils_Date::customFormat($date, '%Y-%m-%d');
+      $isCurrentMonth = 1;
       $isPreviousMonth = 1;
     }
-    $monthStart = $ym . '01';
-    $yearStart = substr($ym, 0, 4) . '0101';
-
-    // $preMonthStart is the day before $monthStart
-    $preMonthStart = CRM_Utils_Date::customFormat(date("Y-m-t",
-        mktime(0, 0, 0, substr($ym, 4, 2) - 1, 01, substr($ym, 0, 4))
-      ),
-      '%Y%m%d'
-    );
-    // $preYearStart is the day before $yearStart
-    $preYearStart = CRM_Utils_Date::customFormat(date("Y-m-t",
-        mktime(0, 0, 0, 12, 31, substr($ym, 0, 4) - 1)
-      ),
-      '%Y%m%d'
-    );
+    $monthStart = $ym . '-01';
+    $yearStart = substr($ym, 0, 4) . '-01-01';
 
     $membershipTypes = CRM_Member_BAO_MembershipType::getMembershipTypes(FALSE);
     // added
@@ -175,11 +164,17 @@ class CRM_Member_Page_DashBoard extends CRM_Core_Page {
     $status = CRM_Member_BAO_MembershipStatus::getMembershipStatusCurrent();
     $status = implode(',', $status);
 
+    /* Disabled for lack of appropriate search
+       
+       The Membership search isn't able to properly filter by join or renewal events.
+       Until that works properly, the subtotals shouldn't get links.
+
     foreach ($membershipSummary as $typeID => $details) {
       foreach ($details as $key => $value) {
         switch ($key) {
           case 'premonth':
-            $membershipSummary[$typeID][$key]['new']['url'] = CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&status=$status&type=$typeID&join=$preMonth&joinEnd=$preMonthEnd&start=$preMonth&end=$preMonthEnd");
+            $membershipSummary[$typeID][$key]['new']['url'] = CRM_Utils_System::url('civicrm/activity/search', "reset=1&force=1&signupType=1&dateLow=
+            status=$status&type=$typeID&join=$preMonth&joinEnd=$preMonthEnd&start=$preMonth&end=$preMonthEnd");
             $membershipSummary[$typeID][$key]['renew']['url'] = CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&status=$status&type=$typeID&joinEnd=$prePreMonthEnd&start=$preMonth&end=$preMonthEnd");
             $membershipSummary[$typeID][$key]['total']['url'] = CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&status=$status&type=$typeID&start=$preMonth&end=$preMonthEnd");
             break;
@@ -243,8 +238,26 @@ class CRM_Member_Page_DashBoard extends CRM_Core_Page {
         }
       }
     }
-    // LCD debug
-    //CRM_Core_Error::debug($membershipSummary);
+    */
+    
+    // Temporary replacement for current totals column
+    
+    foreach ($membershipSummary as $typeID => $details) {
+      if (!$isCurrentMonth) {
+        $membershipSummary[$typeID]['total']['total']['url'] = CRM_Utils_System::url('civicrm/member/search',
+          "reset=1&force=1&start=&end=$ymd&status=$status&type=$typeID"
+        );
+        $membershipSummary[$typeID]['total_owner']['total_owner']['url'] = CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&start=&end=$ymd&status=$status&type=$typeID&owner=1");
+      }
+      else {
+        $membershipSummary[$typeID]['total']['total']['url'] = CRM_Utils_System::url('civicrm/member/search',
+          "reset=1&force=1&status=$status"
+        );
+        $membershipSummary[$typeID]['total_owner']['total_owner']['url'] = CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&status=$status&owner=1");
+      }
+      $membershipSummary[$typeID]['current']['total']['url'] = CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&status=$status&type=$typeID");
+      $membershipSummary[$typeID]['current_owner']['current_owner']['url'] = CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&status=$status&type=$typeID&owner=1");
+    }
 
     $totalCount = array();
 
@@ -276,64 +289,64 @@ class CRM_Member_Page_DashBoard extends CRM_Core_Page {
 
     $totalCount['premonth']['new'] = array(
       'count' => $newCountPreMonth,
-      'url' => CRM_Utils_System::url('civicrm/member/search',
-        "reset=1&force=1&status=$status&join=$preMonth&joinEnd=$preMonthEnd&start=$preMonth&end=$preMonthEnd"
+      'url' => CRM_Utils_System::url('civicrm/activity/search',
+        "reset=1&force=1&signupType=1&dateLow=$preMonth&dateHigh=$preMonthEnd"
       ),
     );
 
     $totalCount['premonth']['renew'] = array(
       'count' => $renewCountPreMonth,
-      'url' => CRM_Utils_System::url('civicrm/member/search',
-        "reset=1&force=1&status=$status&joinEnd=$prePreMonthEnd&start=$preMonth&end=$preMonthEnd"
+      'url' => CRM_Utils_System::url('civicrm/activity/search',
+        "reset=1&force=1&signupType=2&dateLow=$preMonth&dateHigh=$preMonthEnd"
       ),
     );
 
     $totalCount['premonth']['total'] = array(
       'count' => $totalCountPreMonth,
-      'url' => CRM_Utils_System::url('civicrm/member/search',
-        "reset=1&force=1&status=$status&start=$preMonth&end=$preMonthEnd"
+      'url' => CRM_Utils_System::url('civicrm/activity/search',
+        "reset=1&force=1&signupType=3&dateLow=$preMonth&dateHigh=$preMonthEnd"
       ),
     );
 
     $totalCount['month']['new'] = array(
       'count' => $newCountMonth,
-      'url' => CRM_Utils_System::url('civicrm/member/search',
-        "reset=1&force=1&status=$status&join=$monthStart&joinEnd=$ymd&start=$monthStart&end=$ymd"
+      'url' => CRM_Utils_System::url('civicrm/activity/search',
+        "reset=1&force=1&signupType=1&dateLow=$monthStart&dateHigh=$ymd"
       ),
     );
 
     $totalCount['month']['renew'] = array(
       'count' => $renewCountMonth,
-      'url' => CRM_Utils_System::url('civicrm/member/search',
-        "reset=1&force=1&status=$status&joinEnd=$preMonthStart&start=$monthStart&end=$ymd"
+      'url' => CRM_Utils_System::url('civicrm/activity/search',
+        "reset=1&force=1&signupType=2&dateLow=$monthStart&dateHigh=$ymd"
       ),
     );
 
     $totalCount['month']['total'] = array(
       'count' => $totalCountMonth,
-      'url' => CRM_Utils_System::url('civicrm/member/search',
-        "reset=1&force=1&status=$status&start=$monthStart&end=$ymd"
+      'url' => CRM_Utils_System::url('civicrm/activity/search',
+        "reset=1&force=1&signupType=3&dateLow=$monthStart&dateHigh=$ymd"
       ),
     );
 
     $totalCount['year']['new'] = array(
       'count' => $newCountYear,
-      'url' => CRM_Utils_System::url('civicrm/member/search',
-        "reset=1&force=1&status=$status&join=$yearStart&joinEnd=$ymd&start=$yearStart&end=$ymd"
+      'url' => CRM_Utils_System::url('civicrm/activity/search',
+        "reset=1&force=1&signupType=1&dateLow=$yearStart&dateHigh=$ymd"
       ),
     );
 
     $totalCount['year']['renew'] = array(
       'count' => $renewCountYear,
-      'url' => CRM_Utils_System::url('civicrm/member/search',
-        "reset=1&force=1&status=$status&joinEnd=$preYearStart&start=$yearStart&end=$ymd"
+      'url' => CRM_Utils_System::url('civicrm/activity/search',
+        "reset=1&force=1&signupType=2&dateLow=$yearStart&dateHigh=$ymd"
       ),
     );
 
     $totalCount['year']['total'] = array(
       'count' => $totalCountYear,
-      'url' => CRM_Utils_System::url('civicrm/member/search',
-        "reset=1&force=1&status=$status&start=$yearStart&end=$ymd"
+      'url' => CRM_Utils_System::url('civicrm/activity/search',
+        "reset=1&force=1&signupType=3&dateLow=$yearStart&dateHigh=$ymd"
       ),
     );
 
@@ -360,36 +373,38 @@ class CRM_Member_Page_DashBoard extends CRM_Core_Page {
       );
     }
 
+    // Activity search also unable to handle owner vs. inherited
+    
     //LCD add owner values
     $totalCount['premonth_owner']['premonth_owner'] = array(
       'count' => $totalCountPreMonth_owner,
-      'url' => CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&status=$status&start=$preMonth&end=$preMonthEnd&owner=1"),
+    //  'url' => CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&status=$status&start=$preMonth&end=$preMonthEnd&owner=1"),
     );
 
     $totalCount['month_owner']['month_owner'] = array(
       'count' => $totalCountMonth_owner,
-      'url' => CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&status=$status&start=$monthStart&end=$ymd&owner=1"),
+    //  'url' => CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&status=$status&start=$monthStart&end=$ymd&owner=1"),
     );
 
     $totalCount['year_owner']['year_owner'] = array(
       'count' => $totalCountYear_owner,
-      'url' => CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&status=$status&start=$yearStart&end=$ymd&owner=1"),
+    //  'url' => CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&status=$status&start=$yearStart&end=$ymd&owner=1"),
     );
 
     $totalCount['current_owner']['current_owner'] = array(
       'count' => $totalCountCurrent_owner,
-      'url' => CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&status=$status&owner=1"),
+    //  'url' => CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&status=$status&owner=1"),
     );
 
     $totalCount['total_owner']['total_owner'] = array(
       'count' => $totalCountTotal_owner,
-      'url' => CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&status=$status&owner=1"),
+    //  'url' => CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&status=$status&owner=1"),
     );
 
     if (!$isCurrentMonth) {
       $totalCount['total_owner']['total_owner'] = array(
         'count' => $totalCountTotal_owner,
-        'url' => CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&status=$status&start=&end=$ymd&owner=1"),
+     //   'url' => CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&status=$status&start=&end=$ymd&owner=1"),
       );
     }
     //LCD end

--- a/templates/CRM/Member/Page/DashBoard.tpl
+++ b/templates/CRM/Member/Page/DashBoard.tpl
@@ -58,41 +58,96 @@
 
     {foreach from=$membershipSummary item=row}
         <tr>
-      <td><strong>{$row.month.total.name}</strong></td>
-            {if $preMonth}
-                <td class="label"><a href="{$row.premonth.new.url}" title="view details">{$row.premonth.new.count}</a></td>
-                <td class="label"><a href="{$row.premonth.renew.url}" title="view details">{$row.premonth.renew.count}</a>
-    </td>
-                <td class="label">
-        <a href="{$row.premonth.total.url}" title="view details">{$row.premonth.total.count}</a>&nbsp;
-        [ <a href="{$row.premonth_owner.premonth_owner.url}" title="view details">
-        {$row.premonth_owner.premonth_owner.count}</a> ]
-    </td>
-            {/if}
-
-      <td class="label"><a href="{$row.month.new.url}" title="view details">{$row.month.new.count}</a></td>
-            <td class="label"><a href="{$row.month.renew.url}" title="view details">{$row.month.renew.count}</a></td>
-            <td class="label"><a href="{$row.month.total.url}" title="view details">{$row.month.total.count}</a>&nbsp;
-          [ <a href="{$row.month_owner.month_owner.url}" title="view details">
-    {$row.month_owner.month_owner.count}</a> ]
-      </td>
-
-            <td class="label"><a href="{$row.year.new.url}" title="view details">{$row.year.new.count}</a></td>
-            <td class="label"><a href="{$row.year.renew.url}" title="view details">{$row.year.renew.count}</a></td>
-            <td class="label"><a href="{$row.year.total.url}" title="view details">{$row.year.total.count}</a>&nbsp;
-        [ <a href="{$row.year_owner.year_owner.url}" title="view details">{$row.year_owner.year_owner.count}</a> ]
-      </td>
+            <td><strong>{$row.month.total.name}</strong></td>
+          {if $preMonth}
+            <td class="label">
+              {if $row.premonth.new.url}<a href="{$row.premonth.new.url}" title="view details">{$row.premonth.new.count}</a>
+              {else}{$row.premonth.new.count}{/if}
+            </td>
+            <td class="label">
+              {if $row.premonth.renew.url}<a href="{$row.premonth.renew.url}" title="view details">{$row.premonth.renew.count}</a>
+              {else}{$row.premonth.renew.count}{/if}
+            </td>
+            <td class="label">
+              {if $row.premonth.total.url}
+                <a href="{$row.premonth.total.url}" title="view details">{$row.premonth.total.count}</a>
+              {else}
+                {$row.premonth.total.count}
+              {/if}&nbsp;[ 
+              {if $row.premonth_owner.premonth_owner.url}
+                <a href="{$row.premonth_owner.premonth_owner.url}" title="view details">{$row.premonth_owner.premonth_owner.count}</a>
+              {else}
+                {$row.premonth_owner.premonth_owner.count}
+              {/if}]
+            </td>
+          {/if}
 
             <td class="label">
-                {if $isCurrent}
-        <a href="{$row.current.total.url}" title="view details">{$row.current.total.count}</a>&nbsp;
-                    [ <a href="{$row.current_owner.current_owner.url}" title="view details">
-        {$row.current_owner.current_owner.count}</a> ]
+              {if $row.month.new.url}<a href="{$row.month.new.url}" title="view details">{$row.month.new.count}</a>
+              {else}{$row.month.new.count}{/if}
+            </td>
+            <td class="label">
+              {if $row.month.renew.url}<a href="{$row.month.renew.url}" title="view details">{$row.month.renew.count}</a>
+              {else}{$row.month.renew.count}{/if}
+            </td>
+            <td class="label">
+              {if $row.month.total.url}
+                <a href="{$row.month.total.url}" title="view details">{$row.month.total.count}</a>
+              {else}
+                {$row.month.total.count}
+              {/if}&nbsp;[ 
+              {if $row.month_owner.month_owner.url}
+                <a href="{$row.month_owner.month_owner.url}" title="view details">{$row.month_owner.month_owner.count}</a>
+              {else}
+                {$row.month_owner.month_owner.count}
+              {/if}]
+            </td>
+
+            <td class="label">
+              {if $row.year.new.url}<a href="{$row.year.new.url}" title="view details">{$row.year.new.count}</a>
+              {else}{$row.year.new.count}{/if}
+            </td>
+            <td class="label">
+              {if $row.year.renew.url}<a href="{$row.year.renew.url}" title="view details">{$row.year.renew.count}</a>
+              {else}{$row.year.renew.count}{/if}
+            </td>
+            <td class="label">
+              {if $row.year.total.url}
+                <a href="{$row.year.total.url}" title="view details">{$row.year.total.count}</a>
+              {else}
+                {$row.year.total.count}
+              {/if}&nbsp;[ 
+              {if $row.year_owner.year_owner.url}
+                <a href="{$row.year_owner.year_owner.url}" title="view details">{$row.year_owner.year_owner.count}</a>
+              {else}
+                {$row.year_owner.year_owner.count}
+              {/if}]
+            </td>
+
+            <td class="label">
+              {if $isCurrent}
+                {if $row.current.total.url}
+                  <a href="{$row.current.total.url}" title="view details">{$row.current.total.count}</a>
                 {else}
-                    <a href="{$row.total.total.url}" title="view details">{$row.total.total.count}</a>&nbsp;
-                    [ <a href="{$row.total_owner.total_owner.url}" title="view details">
-        {$row.total_owner.total_owner.count}</a> ]
-                {/if}
+                  {$row.current.total.count}
+                {/if}&nbsp;[
+                {if $row.current_owner.current_owner.url}
+                  <a href="{$row.current_owner.current_owner.url}" title="view details">{$row.current_owner.current_owner.count}</a>
+                {else}
+                  {$row.current_owner.current_owner.count}
+                {/if} ]
+              {else}
+                {if $row.total.total.url}
+                  <a href="{$row.total.total.url}" title="view details">{$row.total.total.count}</a>
+                {else}
+                  {$row.total.total.count}
+                {/if}&nbsp;[
+                {if $row.total_owner.total_owner.url}
+                  <a href="{$row.total_owner.total_owner.url}" title="view details">{$row.total_owner.total_owner.count}</a>
+                {else}
+                  {$row.total_owner.total_owner.count}
+                {/if} ]
+              {/if}
             </td> {* member/search?reset=1&force=1&membership_type_id=1&current=1 *}
         </tr>
     {/foreach}
@@ -106,7 +161,13 @@
        <a href="{$totalCount.premonth.renew.url}" title="view details">{$totalCount.premonth.renew.count}</a></td>
            <td class="label">
        <a href="{$totalCount.premonth.total.url}" title="view details">{$totalCount.premonth.total.count}</a>
-       [ <a href="{$totalCount.premonth_owner.premonth_owner.url}" title="view details">{$totalCount.premonth_owner.premonth_owner.count}</a> ]
+       [
+       {if $totalCount.premonth_owner.premonth_owner.url}
+        <a href="{$totalCount.premonth_owner.premonth_owner.url}" title="view details">{$totalCount.premonth_owner.premonth_owner.count}</a>
+       {else}
+         {$totalCount.premonth_owner.premonth_owner.count}
+       {/if}
+       ]
      </td>
         {/if}
 
@@ -116,8 +177,13 @@
     <a href="{$totalCount.month.renew.url}" title="view details">{$totalCount.month.renew.count}</a></td>
         <td class="label">
     <a href="{$totalCount.month.total.url}" title="view details">{$totalCount.month.total.count}</a>
-    [ <a href="{$totalCount.month_owner.month_owner.url}" title="view details">
-    {$totalCount.month_owner.month_owner.count}</a> ]
+       [
+       {if $totalCount.month_owner.month_owner.url}
+        <a href="{$totalCount.month_owner.month_owner.url}" title="view details">{$totalCount.month_owner.month_owner.count}</a>
+       {else}
+         {$totalCount.month_owner.month_owner.count}
+       {/if}
+       ]
   </td>
         <td class="label">
     <a href="{$totalCount.year.new.url}" title="view details">{$totalCount.year.new.count}</a></td>
@@ -125,8 +191,13 @@
     <a href="{$totalCount.year.renew.url}" title="view details">{$totalCount.year.renew.count}</a></td>
         <td class="label">
     <a href="{$totalCount.year.total.url}" title="view details">{$totalCount.year.total.count}</a>
-    [ <a href="{$totalCount.year_owner.year_owner.url}" title="view details">{$totalCount.year_owner.year_owner.count}
-    </a> ]
+       [
+       {if $totalCount.year_owner.year_owner.url}
+        <a href="{$totalCount.year_owner.year_owner.url}" title="view details">{$totalCount.year_owner.year_owner.count}</a>
+       {else}
+         {$totalCount.year_owner.year_owner.count}
+       {/if}
+       ]
   </td>
 
         <td class="label">


### PR DESCRIPTION
Stoob noticed that the counts of new and renewing members were very wrong in the membership dashboard.  The issue is that a "new" membership was one with the start date and join date in the given period, and a "renewing" membership was one with the start date in the period and an earlier join date.  Since implementing membership upgrades, this has been incorrect.

For now, this fix relies on the "Membership Signup" and "Membership Renewal" activities.  civicrm_membership_log may be a good long-run solution, but it doesn't distinguish between a renewal increasing the end date versus an upgrade increasing the end date.  Upgrading from a 1-year membership to a 2-year membership isn't a renewal.

The links to the membership search won't generally return accurate results, so they have been either disabled or replaced by links to an activity search.  (Activity search is able to look at new or renewing memberships in a time period, but not filter by membership type.)

There should be an effort to get this working correctly in 4.4; this is a stopgap to at least make sure we're displaying accurate information.
