### PR TITLE
Set full version in Drupal .info files

### DIFF
--- a/distmaker/dists/drupal_php5.sh
+++ b/distmaker/dists/drupal_php5.sh
@@ -65,6 +65,13 @@ cp $SRC/CONTRIBUTORS.txt $TRG
 cp $SRC/agpl-3.0.exception.txt $TRG
 cp $SRC/drupal/civicrm.config.php.drupal $TRG/civicrm.config.php
 
+# set full version in .info files
+MODULE_DIRS=`find "$DM_SOURCEDIR/drupal" -type f -name "*.info"`
+for INFO in $MODULE_DIRS; do
+  sed -i "s/version = [1-9.]*/version = $DM_VERSION/g" $INFO
+done
+
+
 # final touch
 echo "<?php
 function civicrmVersion( ) {


### PR DESCRIPTION
Hi,

This little patch to distmaker/dists/drupal_php5.sh will rewrite the version strings in the Drupal modules' .info files to include the full version, rather than just the major version. While drupal.org doesn't support releases with MAJOR.MINOR.PATCH version strings in its release packaging scripts, since we aren't hosting the modules on d.o, this should not be an issue.

Regards, C
