### PR TITLE
--fixed for CRM-12511

### DIFF
--- a/CRM/Upgrade/Incremental/sql/4.3.beta4.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.3.beta4.mysql.tpl
@@ -21,5 +21,5 @@ cpfv.financial_type_id = cmt.financial_type_id,
     cpfv.description_{$locale} = cmt.description_{$locale},
   {/foreach}
 {/if}
-cpfv.amount = cmt.minimum_fee	
+cpfv.amount = IFNULL(cmt.minimum_fee, 0.00)	
 WHERE cps.is_quick_config = 1 AND cpfv.membership_type_id IS NOT NULL;


### PR DESCRIPTION
added a condition to check if cmt.minimum_fee is null if so then set it to 0.00.

---
- CRM-12511: Upgrade error where DB has some membership types with minimum_fee IS NULL
  http://issues.civicrm.org/jira/browse/CRM-12511
