### PR TITLE
CRM-12503

### DIFF
--- a/CRM/Campaign/Info.php
+++ b/CRM/Campaign/Info.php
@@ -53,7 +53,7 @@ class CRM_Campaign_Info extends CRM_Core_Component_Info {
 
 
   // docs inherited from interface
-  public function getPermissions() {
+  public function getPermissions($getAllUnconditionally = FALSE) {
     return array(
       'administer CiviCampaign',
       'manage campaign',

--- a/CRM/Case/Info.php
+++ b/CRM/Case/Info.php
@@ -53,7 +53,7 @@ class CRM_Case_Info extends CRM_Core_Component_Info {
   }
 
   // docs inherited from interface
-  public function getPermissions() {
+  public function getPermissions($getAllUnconditionally = FALSE) {
     return array(
       'delete in CiviCase',
       'administer CiviCase',

--- a/CRM/Contribute/Info.php
+++ b/CRM/Contribute/Info.php
@@ -53,7 +53,7 @@ class CRM_Contribute_Info extends CRM_Core_Component_Info {
   }
 
   // docs inherited from interface
-  public function getPermissions() {
+  public function getPermissions($getAllUnconditionally = FALSE) {
     return array(
       'access CiviContribute',
       'edit contributions',

--- a/CRM/Core/Component/Info.php
+++ b/CRM/Core/Component/Info.php
@@ -131,11 +131,13 @@ abstract class CRM_Core_Component_Info {
    * Needs to be implemented in component's information
    * class.
    *
+   * NOTE: if using conditionally permission return,
+   * implementation of $getAllUnconditionally is required.
    * @return array|null collection of permissions, null if none
    * @access public
    *
    */
-  abstract public function getPermissions();
+  abstract public function getPermissions($getAllUnconditionally = FALSE);
 
   /**
    * Provides information about user dashboard element

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -540,7 +540,8 @@ class CRM_Core_Permission {
     if (empty($allCompPermissions)) {
       $components = CRM_Core_Component::getComponents();
       foreach ($components as $name => $comp) {
-        $allCompPermissions[$name] = $comp->getPermissions();
+        //get all permissions of each components unconditionally
+        $allCompPermissions[$name] = $comp->getPermissions(TRUE);
       }
     }
 

--- a/CRM/Event/Info.php
+++ b/CRM/Event/Info.php
@@ -52,7 +52,7 @@ class CRM_Event_Info extends CRM_Core_Component_Info {
   }
 
   // docs inherited from interface
-  public function getPermissions() {
+  public function getPermissions($getAllUnconditionally = FALSE) {
     return array(
       'access CiviEvent',
       'edit event participants',

--- a/CRM/Grant/Info.php
+++ b/CRM/Grant/Info.php
@@ -54,7 +54,7 @@ class CRM_Grant_Info extends CRM_Core_Component_Info {
 
 
   // docs inherited from interface
-  public function getPermissions() {
+  public function getPermissions($getAllUnconditionally = FALSE) {
     return array(
       'access CiviGrant',
       'edit grants',

--- a/CRM/Mailing/Info.php
+++ b/CRM/Mailing/Info.php
@@ -78,7 +78,7 @@ class CRM_Mailing_Info extends CRM_Core_Component_Info {
   }
 
   // docs inherited from interface
-  public function getPermissions() {
+  public function getPermissions($getAllUnconditionally = FALSE) {
     $permissions = array(
       'access CiviMail',
       'access CiviMail subscribe/unsubscribe pages',
@@ -86,7 +86,7 @@ class CRM_Mailing_Info extends CRM_Core_Component_Info {
       'view public CiviMail content',
     );
 
-    if (self::workflowEnabled()) {
+    if (self::workflowEnabled() || $getAllUnconditionally) {
       $permissions[] = 'create mailings';
       $permissions[] = 'schedule mailings';
       $permissions[] = 'approve mailings';

--- a/CRM/Member/Info.php
+++ b/CRM/Member/Info.php
@@ -53,7 +53,7 @@ class CRM_Member_Info extends CRM_Core_Component_Info {
 
 
   // docs inherited from interface
-  public function getPermissions() {
+  public function getPermissions($getAllUnconditionally = FALSE) {
     return array(
       'access CiviMember',
       'edit memberships',

--- a/CRM/Pledge/Info.php
+++ b/CRM/Pledge/Info.php
@@ -53,7 +53,7 @@ class CRM_Pledge_Info extends CRM_Core_Component_Info {
 
 
   // docs inherited from interface
-  public function getPermissions() {
+  public function getPermissions($getAllUnconditionally = FALSE) {
     return array(
       'access CiviPledge',
       'edit pledges',

--- a/CRM/Report/Info.php
+++ b/CRM/Report/Info.php
@@ -55,7 +55,7 @@ class CRM_Report_Info extends CRM_Core_Component_Info {
 
 
   // docs inherited from interface
-  public function getPermissions() {
+  public function getPermissions($getAllUnconditionally = FALSE) {
     return array('access CiviReport', 'access Report Criteria', 'administer reserved reports', 'administer Reports');
   }
 


### PR DESCRIPTION
Why this issue raised:
1) During navigation building : permission check of each menu item takes place, also along with that component name is fetched with the help of permission of menu item, and that component name is used for checking weather the component is enabled or disabled.

2) Component name is evaluated with the help of menu item permission by using CRM_Core_Permission::getComponentName function: 
- while 'Mailings' menu item check, the permissions for it like 'create mailings,approve mailings,schedule mailings' return NULL as component name instead of returning 'CiviMail', thus the component active check is skipped and the menu item is displayed.

The fix:
- inside the CRM_Core_Permission::getComponentName($permission), to get component permissions CRM_{componentName}_Info::getPermissions is used.
  
  Introducing a new '$getAllUnconditionally' argument and handling this argument inside in CRM_{componentName}_Info::getPermissions makes it possible to return 'all' (including conditional) permissions.
