### PR TITLE
Render line breaks in event registration Note field (CRM-12561)

### DIFF
--- a/templates/CRM/Event/Form/ParticipantView.tpl
+++ b/templates/CRM/Event/Form/ParticipantView.tpl
@@ -112,7 +112,7 @@
     {/if}
     {foreach from=$note item="rec"}
       {if $rec }
-            <tr><td class="label">{ts}Note{/ts}</td><td>{$rec}</td></tr>
+            <tr><td class="label">{ts}Note{/ts}</td><td>{$rec|nl2br}</td></tr>
       {/if}
     {/foreach}
     </table>


### PR DESCRIPTION
When you view an event registration in the CiviCRM UI, line breaks in the note are not rendered, so all the lines of text run into one long line, which can be confusing.

To reproduce this bug, go to a contact's Events tab, add an event registration, enter a few lines of text in the Notes field, and then view the participant record that has been created. The line breaks will be missing from the Note field.

This update fixes the problem by applying the nl2br smarty modifier to the note field in templates/CRM/Event/Form/ParticipantView.tpl. (This is how it's done on the Notes tab for contacts - in templates/CRM/Contact/Page/View/Note.tpl.)
