### PR TITLE
Clarify switch between price set and manual membership (CRM-12575)

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -117,7 +117,7 @@
         {/if}
 
         {if $ppID}{ts}<a href='#' onclick='adjustPayment();'>adjust payment amount</a>{/ts}{help id="adjust-payment-amount"}{/if}
-        <br /><span class="description">{ts}Actual amount given by contributor.{/ts}</span>
+        <br /><span class="description">{ts}Actual amount given by contributor.{/ts}{if $hasPriceSets} {ts}Alternatively, you can use a price set.{/ts}{/if}</span>
       </td>
     </tr>
 
@@ -572,6 +572,8 @@ function buildAmount( priceSetId ) {
     // show/hide price set amount and total amount.
     cj("#totalAmountORPriceSet").show( );
     cj("#totalAmount").show( );
+    var choose = "{/literal}{ts}Choose price set{/ts}{literal}";
+    cj("#price_set_id option[value='']").html( choose );
 
     //we might want to build recur block.
     if (cj("#is_recur")) buildRecurBlock( null );
@@ -600,6 +602,8 @@ function buildAmount( priceSetId ) {
 
   cj( "#totalAmountORPriceSet" ).hide( );
   cj( "#totalAmount").hide( );
+  var manual = "{/literal}{ts}Manual contribution amount{/ts}{literal}";
+  cj("#price_set_id option[value='']").html( manual );
 }
 
 function adjustPayment( ) {

--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -106,7 +106,7 @@
               {/if}
             {/if}
             {if $member_is_test} {ts}(test){/ts}{/if}<br />
-            <span class="description">{ts}Select Membership Organization and then Membership Type.{/ts}</span>
+            <span class="description">{ts}Select Membership Organization and then Membership Type.{/ts}{if $hasPriceSets} {ts}Alternatively, you can use a price set.{/ts}{/if}</span>
           </td>
         </tr>
         <tr id="maxRelated" class="crm-membership-form-block-max_related">
@@ -629,6 +629,8 @@
 
         // show/hide price set amount and total amount.
         cj( "#mem_type_id").show( );
+        var choose = "{/literal}{ts}Choose price set{/ts}{literal}";
+        cj("#price_set_id option[value='']").html( choose );
         cj( "#totalAmountORPriceSet" ).show( );
         cj('#total_amount').removeAttr("readonly");
         cj( "#num_terms_row").show( );
@@ -658,6 +660,8 @@
 
       cj( "#totalAmountORPriceSet" ).hide( );
       cj( "#mem_type_id" ).hide( );
+      var manual = "{/literal}{ts}Manual membership and price{/ts}{literal}";
+      cj("#price_set_id option[value='']").html( manual );
       cj( "#num_terms_row" ).hide( );
       cj(".crm-membership-form-block-financial_type_id-mode").hide();
     }


### PR DESCRIPTION
When site admins create a new membership, they don't often understand the distinction between the "old" way of choosing the membership type versus using a price set.  They'll try things out, and once they choose a price set, it's not at all clear that the way to go back to the other method and not use a price set is to select "Choose a price set".

This is a small change to the buildAmount function that's called when the price set field changes.  It rewrites the option "Choose price set" to "Manual membership and price" when a price set is selected, and it sets it back to "Choose price set" when none is selected.

In the process, I added a piece to the field description explaining that you can choose to pick a price set instead of membership organization and type.  A ton of first-timers don't get that, and they select an organization, type, and price set each time.
