### PR TITLE
CRM-12556 - Set admin API key for new test sites

### DIFF
--- a/tools/scripts/mk-drupal-test-site
+++ b/tools/scripts/mk-drupal-test-site
@@ -124,6 +124,8 @@ class CiviSeleniumSettings {
 	var \$password = 'demo';
 	var \$adminUsername = '${ADMIN_USER}';
 	var \$adminPassword = '${ADMIN_PASS}';
+	var \$adminApiKey = 'apikey${ADMIN_PASS}';
+	var \$siteKey = '${SITE_KEY}';
         var \$UFemail = 'noreply@civicrm.org';
 	function __construct() {
 		\$this->fullSandboxPath = \$this->sandboxURL . \$this->sandboxPATH;
@@ -141,4 +143,5 @@ drush -l "${SITE_URL}" -y pm-enable civicrm
 drush -l "${SITE_URL}" -y pm-enable civicrm_webtest
 drush -l "${SITE_URL}" -y user-create --password=demo --mail='demo@example.com' demo
 drush -l "${SITE_URL}" -y user-add-role civicrm_webtest_user demo
+drush -l "${SITE_URL}" -y -u "$ADMIN_USER" civicrm-api contact.create id=user_contact_id api_key="apikey$ADMIN_PASS"
 popd


### PR DESCRIPTION
## Depends on https://github.com/civicrm/civicrm-drupal/pull/18
- CRM-12556: Assign api_key for a user via command-line
  http://issues.civicrm.org/jira/browse/CRM-12556
