### PR TITLE
api/v3/utils - Redo 16404fbb4 for preventing fatal error

### DIFF
--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -539,7 +539,11 @@ function _civicrm_api3_dao_set_filter(&$dao, $params, $unique = TRUE, $entity) {
     }
     else {
       if ($unique) {
-        $allfields[$field]['name'] = $params[$field];
+        $daoFieldName = $allfields[$field]['name'];
+        if (empty($daoFieldName)) {
+          throw new API_Exception("Failed to determine field name for \"$field\"");
+        }
+        $dao->{$daoFieldName} = $params[$field];
       }
       else {
         $dao->$field = $params[$field];


### PR DESCRIPTION
16404fbb4 attempted to fix a regression but was based on a flawed identification of the problem. I believe that api/v3/utils was doing the right thing, but it was given bad information. The new commit restores api/v3/utils to its old behavior but provides but error checking.
