### PR TITLE
worked on CRM-12589: load noconflict.js at the end of the civicrm scope,

### DIFF
--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -466,7 +466,7 @@ class CRM_Core_Resources {
       $this->addSetting(array('config' => $settings));
 
       // Give control of jQuery back to the CMS - this loads last
-      $this->addScriptFile('civicrm', 'js/noconflict.js', 9999, $region, FALSE);
+      $this->addScriptFile('civicrm', 'js/noconflict.js', 9999, 'page-footer', FALSE);
 
       $this->addCoreStyles($region);
     }


### PR DESCRIPTION
i.e in "page-footer". problem was with tinymce which was being loaded
after noonflict.js and it failed in joomla 2.x which does not include
jquery. It worked in other CMS because they include jquery.js
