### PR TITLE
Webtest fix for CRM-12378 comment : WebTest_Member_StandaloneAddTest.testAjaxCus...

### DIFF
--- a/tests/phpunit/CiviTest/CiviSeleniumTestCase.php
+++ b/tests/phpunit/CiviTest/CiviSeleniumTestCase.php
@@ -1837,7 +1837,7 @@ class CiviSeleniumTestCase extends PHPUnit_Extensions_SeleniumTestCase {
         $elementType = CRM_Utils_Array::value('type', $customData['triggerElement'], 'select');
         $elementName = CRM_Utils_Array::value('name', $customData['triggerElement']);
         if ($beforeTriggering) {
-          eval($beforeTriggering);
+          call_user_func($beforeTriggering);
         }
         if ($elementType == 'select') {
           //reset the select box, so triggering of ajax only happens

--- a/tests/phpunit/CiviTest/CiviSeleniumTestCase.php
+++ b/tests/phpunit/CiviTest/CiviSeleniumTestCase.php
@@ -1821,9 +1821,10 @@ class CiviSeleniumTestCase extends PHPUnit_Extensions_SeleniumTestCase {
 
                                      which uses the entity info as its selection value
    * @param array  $pageUrl          the url which on which the ajax custom group load takes place
+   * @param $beforeTriggering        code to execute before actual element triggering
    * @return void
    */
-  function customFieldSetLoadOnTheFlyCheck($customSets, $pageUrl) {
+  function customFieldSetLoadOnTheFlyCheck($customSets, $pageUrl, $beforeTriggering = NULL) {
     //add the custom set
     $return = $this->addCustomGroupField($customSets);
 
@@ -1835,6 +1836,9 @@ class CiviSeleniumTestCase extends PHPUnit_Extensions_SeleniumTestCase {
         list($entity, $entityData) = explode('_', $entityType);
         $elementType = CRM_Utils_Array::value('type', $customData['triggerElement'], 'select');
         $elementName = CRM_Utils_Array::value('name', $customData['triggerElement']);
+        if ($beforeTriggering) {
+          eval($beforeTriggering);
+        }
         if ($elementType == 'select') {
           //reset the select box, so triggering of ajax only happens
           //WRT input of value in this function

--- a/tests/phpunit/WebTest/Campaign/CampaignDescriptionTest.php
+++ b/tests/phpunit/WebTest/Campaign/CampaignDescriptionTest.php
@@ -85,6 +85,8 @@ class WebTest_Campaign_CampaignDescriptionTest extends CiviSeleniumTestCase {
 
   function testAjaxCustomGroupLoad() {
     $this->webtestLogin();
+
+    $this->enableComponents(array('CiviCampaign'));
     $triggerElement = array('name' => 'campaign_type_id', 'type' => 'select');
     $customSets = array(
       array('entity' => 'Campaign', 'subEntity' => 'Referral Program', 'triggerElement' => $triggerElement),

--- a/tests/phpunit/WebTest/Member/StandaloneAddTest.php
+++ b/tests/phpunit/WebTest/Member/StandaloneAddTest.php
@@ -174,7 +174,12 @@ class WebTest_Member_StandaloneAddTest extends CiviSeleniumTestCase {
 
     //case where we should fire certain
     //ui actions which helps triggering possible
-    $beforeTriggering = "\$this->select('membership_type_id_0', 'value=1');";
+    $test = $this;
+    $beforeTriggering = function() use ($test) {
+      $test->select('membership_type_id_0', 'value=1');
+    };
+
+    $this->customFieldSetLoadOnTheFlyCheck($customSets, $pageUrl, $beforeTriggering);
     $this->customFieldSetLoadOnTheFlyCheck($customSets, $pageUrl, $beforeTriggering);
   }
 }

--- a/tests/phpunit/WebTest/Member/StandaloneAddTest.php
+++ b/tests/phpunit/WebTest/Member/StandaloneAddTest.php
@@ -171,6 +171,10 @@ class WebTest_Member_StandaloneAddTest extends CiviSeleniumTestCase {
     );
 
     $pageUrl = array('url' => 'member/add', 'args' => 'reset=1&action=add&context=standalone');
-    $this->customFieldSetLoadOnTheFlyCheck($customSets, $pageUrl);
+
+    //case where we should fire certain
+    //ui actions which helps triggering possible
+    $beforeTriggering = "\$this->select('membership_type_id_0', 'value=1');";
+    $this->customFieldSetLoadOnTheFlyCheck($customSets, $pageUrl, $beforeTriggering);
   }
 }


### PR DESCRIPTION
In some cases their is a requirement of executing certain ui procedure e.g selecting certain element value before actual action on element which is responsible for custom data to load.
