### PR TITLE
-- fix for CRM-10993

### DIFF
--- a/CRM/Core/BAO/File.php
+++ b/CRM/Core/BAO/File.php
@@ -374,6 +374,7 @@
      // add attachments
      for ($i = 1; $i <= $numAttachments; $i++) {
        $form->addElement('file', "attachFile_$i", ts('Attach File'), 'size=30 maxlength=60');
+       $form->addUploadElement("attachFile_$i");
        $form->setMaxFileSize($maxFileSize * 1024 * 1024);
        $form->addRule("attachFile_$i",
          ts('File size should be less than %1 MByte(s)',


### PR DESCRIPTION
This issue is replicable for the case of Activity and Case as well. The patch provided is Grant specific. I have made a generic fix. The break was because the attachment file elements were not getting set in $uploadNames array, when "File" custom field is enabled. $uploadNames array for the attachment is built in "addUploadAction" function of Controller.php where a condition is checked " if (empty($uploadNames))" and then $uploadNames is set. But, when custom field of type "field" is enabled for any of these components, $uploadNames array is set beforehand(it is set because CRM_Core_Form->addUploadElement is called while building "File" custom fields) and the empty($uploadNames) condition goes false, thus resulting in the attachment upload elements not getting set in $uploadNames. This fix works for all the components.
