### PR TITLE
CRM-12562 Mis-named array item check in Batch.php was causing batch upda...

### DIFF
--- a/CRM/Event/Form/Task/Batch.php
+++ b/CRM/Event/Form/Task/Batch.php
@@ -201,7 +201,7 @@ class CRM_Event_Form_Task_Batch extends CRM_Event_Form_Task {
           }
         }
         else {
-          if ($field['name'] == 'participant_role_id') {
+          if ($field['name'] == 'participant_role') {
             $field['is_multiple'] = TRUE;
           }
           // handle non custom fields


### PR DESCRIPTION
...te to set participant role profile field as is_multiple (conditional on line 204 was checking for participant_role_id instead of participant_role).

---
- CRM-12562: Batch Update Participant Roles Not Set, Not Checkboxes, Data Overwritten
  http://issues.civicrm.org/jira/browse/CRM-12562
