### PR TITLE
CRM-12570 fix

### DIFF
--- a/templates/CRM/Form/validate.tpl
+++ b/templates/CRM/Form/validate.tpl
@@ -73,10 +73,10 @@ cj(function($) {
     $("#{$form.formName}").validate(params);
     {literal}
     // Call any post-initialization callbacks
-    if (CRM.validate && CRM.validate.functions) {
-      for (var i in CRM.validate.functions) {
-        CRM.validate.functions[i]();
-      }
+    if (CRM.validate && CRM.validate.functions.length) {
+      $.each(CRM.validate.functions, function(i, func) {
+        func();
+      });
     }
     {/literal}
   {/if}


### PR DESCRIPTION
The issue was the 'for .. in' loop was wrongly executing variables (defined in mootools-core.js which was loaded by joomla CMS) although 'CRM.validate.functions' array (being looped) didn't had assignments of these variables, thus a TypeError of this is not a function was thrown.

Followed the suggestions given by coleman on CRM-12570 comments, and used JQuery's .each method, this rightly only takes up values defined in array thats being looped. Also there is no need to use an additional condition inside the '.each' method looping.
