### PR TITLE
-- fix for CRM-12514

### DIFF
--- a/CRM/Activity/Form/Search.php
+++ b/CRM/Activity/Form/Search.php
@@ -336,6 +336,10 @@ class CRM_Activity_Form_Search extends CRM_Core_Form {
       $this->_formValues['activity_type_id'][$activity_type_id] = 1;
     }
 
+    if (!CRM_Utils_Array::value('activity_survey_id', $this->_formValues) && ($surveyID = $this->get('surveyID'))) {
+      $this->_formValues['activity_survey_id'] = $surveyID;
+    }
+
     if (!CRM_Utils_Array::value('activity_test', $this->_formValues)) {
       $this->_formValues["activity_test"] = 0;
     }
@@ -459,6 +463,7 @@ class CRM_Activity_Form_Search extends CRM_Core_Form {
     );
     if ($survey) {
       $this->_formValues['activity_survey_id'] = $survey;
+      $this->set('surveyID', $survey);
     }
     $cid = CRM_Utils_Request::retrieve('cid', 'Positive', $this);
 


### PR DESCRIPTION
The bug is because the condition for 'activity_survey_id' was missing in $queryParams as the surveyID was going empty. This is because its value is taken from url when the petition activity search is done using which it lists out all the relevant petition activities. But, after we select all records(ts_all) radio button & "Export Activities" task and click on Go, the surveyID no longer persists thus resulting in all activities in the export file. I have made the fix by setting the value when it is taken from the url and getting it & assigning it to 'activity_survey_id' which will take the value and build the $queryParams.
