### PR TITLE
CRM-12628 rename non-standard MailingGroup DAO instead of hack. Also add...

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -108,11 +108,11 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing {
     $storeRecipients = FALSE,
     $dedupeEmail = FALSE,
     $mode = NULL) {
-    $mailingGroup = new CRM_Mailing_DAO_Group();
+    $mailingGroup = new CRM_Mailing_DAO_MailingGroup();
 
     $mailing = CRM_Mailing_BAO_Mailing::getTableName();
     $job     = CRM_Mailing_BAO_Job::getTableName();
-    $mg      = CRM_Mailing_DAO_Group::getTableName();
+    $mg      = CRM_Mailing_DAO_MailingGroup::getTableName();
     $eq      = CRM_Mailing_Event_DAO_Queue::getTableName();
     $ed      = CRM_Mailing_Event_DAO_Delivered::getTableName();
     $eb      = CRM_Mailing_Event_DAO_Bounce::getTableName();
@@ -517,7 +517,7 @@ ORDER BY   i.contact_id, i.{$tempColumn}
   }
 
   private function _getMailingGroupIds($type = 'Include') {
-    $mailingGroup = new CRM_Mailing_DAO_Group();
+    $mailingGroup = new CRM_Mailing_DAO_MailingGroup();
     $group = CRM_Contact_DAO_Group::getTableName();
     if (!isset($thi->sid)) {
       // we're just testing tokens, so return any group
@@ -1404,8 +1404,8 @@ ORDER BY   civicrm_email.is_bulkmail DESC
     if (!isset($this->id)) {
       return array();
     }
-    $mg      = new CRM_Mailing_DAO_Group();
-    $mgtable = CRM_Mailing_DAO_Group::getTableName();
+    $mg      = new CRM_Mailing_DAO_MailingGroup();
+    $mgtable = CRM_Mailing_DAO_MailingGroup::getTableName();
     $group   = CRM_Contact_BAO_Group::getTableName();
 
     $mg->query("SELECT      $group.title as name FROM $mgtable
@@ -1564,7 +1564,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
     $mailingTableName = CRM_Mailing_BAO_Mailing::getTableName();
 
     /* Create the mailing group record */
-    $mg = new CRM_Mailing_DAO_Group();
+    $mg = new CRM_Mailing_DAO_MailingGroup();
     foreach (array('groups', 'mailings') as $entity) {
       foreach (array('include', 'exclude', 'base') as $type) {
         if (isset($params[$entity]) &&
@@ -1634,7 +1634,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
 
     $t = array(
       'mailing' => self::getTableName(),
-      'mailing_group' => CRM_Mailing_DAO_Group::getTableName(),
+      'mailing_group' => CRM_Mailing_DAO_MailingGroup::getTableName(),
       'group' => CRM_Contact_BAO_Group::getTableName(),
       'job' => CRM_Mailing_BAO_Job::getTableName(),
       'queue' => CRM_Mailing_Event_BAO_Queue::getTableName(),
@@ -2196,7 +2196,7 @@ LEFT JOIN civicrm_mailing_group g ON g.mailing_id   = m.id
   public function &getRows($offset, $rowCount, $sort, $additionalClause = NULL, $additionalParams = NULL) {
     $mailing = self::getTableName();
     $job     = CRM_Mailing_BAO_Job::getTableName();
-    $group   = CRM_Mailing_DAO_Group::getTableName();
+    $group   = CRM_Mailing_DAO_MailingGroup::getTableName();
     $session = CRM_Core_Session::singleton();
 
     $mailingACL = self::mailingACL();
@@ -2531,7 +2531,7 @@ LEFT JOIN civicrm_mailing_group g ON g.mailing_id   = m.id
    * @access public
    */
   public function searchMailingIDs() {
-    $group = CRM_Mailing_DAO_Group::getTableName();
+    $group = CRM_Mailing_DAO_MailingGroup::getTableName();
     $mailing = self::getTableName();
 
     $query = "

--- a/CRM/Mailing/Event/BAO/Resubscribe.php
+++ b/CRM/Mailing/Event/BAO/Resubscribe.php
@@ -69,7 +69,7 @@ class CRM_Mailing_Event_BAO_Resubscribe {
     $transaction = new CRM_Core_Transaction();
 
     $do = new CRM_Core_DAO();
-    $mg = CRM_Mailing_DAO_Group::getTableName();
+    $mg = CRM_Mailing_DAO_MailingGroup::getTableName();
     $job = CRM_Mailing_BAO_Job::getTableName();
     $mailing = CRM_Mailing_BAO_Mailing::getTableName();
     $group = CRM_Contact_BAO_Group::getTableName();

--- a/CRM/Mailing/Event/BAO/Unsubscribe.php
+++ b/CRM/Mailing/Event/BAO/Unsubscribe.php
@@ -131,7 +131,7 @@ WHERE  email = %2
     $transaction = new CRM_Core_Transaction();
 
     $do = new CRM_Core_DAO();
-    $mgObject = new CRM_Mailing_DAO_Group();
+    $mgObject = new CRM_Mailing_DAO_MailingGroup();
     $mg = $mgObject->getTableName();
     $jobObject = new CRM_Mailing_BAO_Job();
     $job = $jobObject->getTableName();

--- a/CRM/Mailing/Form/Group.php
+++ b/CRM/Mailing/Form/Group.php
@@ -121,7 +121,7 @@ class CRM_Mailing_Form_Group extends CRM_Contact_Form_Task {
       $defaults['campaign_id'] = $mailing->campaign_id;
       $defaults['dedupe_email'] = $mailing->dedupe_email;
 
-      $dao = new CRM_Mailing_DAO_Group();
+      $dao = new CRM_Mailing_DAO_MailingGroup();
 
       $mailingGroups = array(
         'civicrm_group' => array( ),
@@ -449,7 +449,7 @@ class CRM_Mailing_Form_Group extends CRM_Contact_Form_Task {
 
       // delete previous includes/excludes, if mailing already existed
       foreach (array('groups', 'mailings') as $entity) {
-        $mg               = new CRM_Mailing_DAO_Group();
+        $mg               = new CRM_Mailing_DAO_MailingGroup();
         $mg->mailing_id   = $ids['mailing_id'];
         $mg->entity_table = ($entity == 'groups') ? $groupTableName : $mailingTableName;
         $mg->find();

--- a/CRM/SMS/Form/Group.php
+++ b/CRM/SMS/Form/Group.php
@@ -83,7 +83,7 @@ class CRM_SMS_Form_Group extends CRM_Contact_Form_Task {
         $this->set('mailing_id', $mailingID);
       }
 
-      $dao = new CRM_Mailing_DAO_Group();
+      $dao = new CRM_Mailing_DAO_MailingGroup();
 
       $mailingGroups = array();
       $dao->mailing_id = $mailingID;
@@ -269,7 +269,7 @@ class CRM_SMS_Form_Group extends CRM_Contact_Form_Task {
       // delete previous includes/excludes, if mailing already existed
       foreach (array(
         'groups', 'mailings') as $entity) {
-        $mg               = new CRM_Mailing_DAO_Group();
+        $mg               = new CRM_Mailing_DAO_MailingGroup();
         $mg->mailing_id   = $ids['mailing_id'];
         $mg->entity_table = ($entity == 'groups') ? $groupTableName : $mailingTableName;
         $mg->find();

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -293,17 +293,6 @@ function _civicrm_api3_get_DAO($name) {
   if(strtolower($name) == 'im'){
     return 'CRM_Core_BAO_IM';
   }
-  if(strtolower($name) == 'group'){
-    //    CRM-12628
-    //@todo we have to do this because the naming convention of MailingGroup is
-    // wrong & it clobbers group
-    return 'CRM_Contact_BAO_Group';
-  }
-
-  if(strtolower($name) == 'mailing_group' || $name == 'MailingGroup'){
-    //    CRM-12628
-    return 'CRM_Mailing_BAO_Group';
-  }
   return CRM_Core_DAO_AllCoreTables::getFullName(_civicrm_api_get_camel_name($name, 3));
 }
 

--- a/sql/GenerateMailing.php
+++ b/sql/GenerateMailing.php
@@ -81,7 +81,7 @@ for ($i = 1; $i <= $numGroups; $i++) {
   $job->status         = 'Complete';
   $job->save();
 
-  $group               = new CRM_Mailing_DAO_Group();
+  $group               = new CRM_Mailing_DAO_MailingGroup();
   $group->mailing_id   = $mailing->id;
   $group->group_type   = 'Include';
   $group->entity_table = 'civicrm_group';

--- a/xml/schema/Mailing/MailingGroup.xml
+++ b/xml/schema/Mailing/MailingGroup.xml
@@ -2,7 +2,7 @@
 
 <table>
   <base>CRM/Mailing</base>
-  <class>Group</class>
+  <class>MailingGroup</class>
   <name>civicrm_mailing_group</name>
   <comment>Stores information about the groups that participate in this mailing..</comment>
   <archive>true</archive>

--- a/xml/schema/Mailing/files.xml
+++ b/xml/schema/Mailing/files.xml
@@ -4,7 +4,7 @@
 
 <xi:include href="Component.xml"     parse="xml" />
 <xi:include href="Mailing.xml"       parse="xml" />
-<xi:include href="Group.xml"         parse="xml" />
+<xi:include href="MailingGroup.xml"  parse="xml" />
 <xi:include href="TrackableURL.xml"  parse="xml" />
 <xi:include href="Job.xml"           parse="xml" />
 <xi:include href="Recipients.xml"    parse="xml" />


### PR DESCRIPTION
... BAO for standardisation

This is because the Mailing Group BAO was walloping the Group BAO due to the distinct name of both being 'Group'
