### PR TITLE
CRM-10397 Pay Later Improvements

### DIFF
--- a/CRM/Contribute/Form/ContributionPage/Amount.php
+++ b/CRM/Contribute/Form/ContributionPage/Amount.php
@@ -137,10 +137,7 @@ SELECT id
       CRM_Core_DAO::getAttribute('CRM_Contribute_DAO_ContributionPage', 'pay_later_text'),
       FALSE
     );
-    $this->addElement('textarea', 'pay_later_receipt', ts('Pay later instructions'),
-      CRM_Core_DAO::getAttribute('CRM_Contribute_DAO_ContributionPage', 'pay_later_receipt'),
-      FALSE
-    );
+    $this->addWysiwyg('pay_later_receipt', ts('Pay Later Instructions'), CRM_Core_DAO::getAttribute('CRM_Contribute_DAO_ContributionPage', 'pay_later_receipt'));
     
     //add partial payment options
 

--- a/CRM/Core/HTMLInputCoder.php
+++ b/CRM/Core/HTMLInputCoder.php
@@ -96,6 +96,7 @@ class CRM_Core_HTMLInputCoder implements API_Wrapper {
         'bcc_id',
         'premiums_intro_text',
         'honor_block_text',
+        'pay_later_text',
         'pay_later_receipt',
         'label', // This is needed for FROM Email Address configuration. dgg
         'url',  // This is needed for navigation items urls

--- a/CRM/Event/Form/ManageEvent/Fee.php
+++ b/CRM/Event/Form/ManageEvent/Fee.php
@@ -271,10 +271,7 @@ class CRM_Event_Form_ManageEvent_Fee extends CRM_Event_Form_ManageEvent {
       CRM_Core_DAO::getAttribute('CRM_Event_DAO_Event', 'pay_later_text'),
       FALSE
     );
-    $this->addElement('textarea', 'pay_later_receipt', ts('Pay Later Instructions'),
-      CRM_Core_DAO::getAttribute('CRM_Event_DAO_Event', 'pay_later_receipt'),
-      FALSE
-    );
+    $this->addWysiwyg('pay_later_receipt', ts('Pay Later Instructions'), CRM_Core_DAO::getAttribute('CRM_Event_DAO_Event', 'pay_later_receipt'));
 
     $this->add('text', 'fee_label', ts('Fee Label'));
 

--- a/templates/CRM/Contribute/Form/ContributionPage/Amount.tpl
+++ b/templates/CRM/Contribute/Form/ContributionPage/Amount.tpl
@@ -65,7 +65,7 @@
             <table class="form-layout">
                 <tr class="crm-contribution-contributionpage-amount-form-block-pay_later_text"><th scope="row" class="label">{$form.pay_later_text.label} <span class="marker" title="This field is required.">*</span> {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_contribution_page' field='pay_later_text' id=$contributionPageID}{/if}</th>
                 <td>{$form.pay_later_text.html|crmAddClass:big}<br />
-                    <span class="description">{ts}Text displayed next to the checkbox for the 'pay later' option on the contribution form.{/ts}</span></td></tr>
+                    <span class="description">{ts}Text displayed next to the checkbox for the 'pay later' option on the contribution form. You may include HTML formatting tags.{/ts}</span></td></tr>
                 <tr class="crm-contribution-contributionpage-amount-form-block-pay_later_receipt"><th scope="row" class="label">{$form.pay_later_receipt.label} <span class="marker" title="This field is required.">*</span> {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_contribution_page' field='pay_later_receipt' id=$contributionPageID}{/if}</th>
                 <td>{$form.pay_later_receipt.html|crmAddClass:big}<br />
                   <span class="description">{ts}Instructions added to Confirmation and Thank-you pages, as well as the confirmation email, when the user selects the 'pay later' option (e.g. 'Mail your check to ... within 3 business days.').{/ts}</span></td></tr>

--- a/templates/CRM/Event/Form/ManageEvent/Fee.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Fee.tpl
@@ -94,7 +94,7 @@
             </tr>
             <tr>
                <td>&nbsp;</td>
-               <td class="description">{ts}Text displayed next to the checkbox for the 'pay later' option on the contribution form.{/ts}</td>
+               <td class="description">{ts}Text displayed next to the checkbox for the 'pay later' option on the contribution form. You may include HTML formatting tags.{/ts}</td>
             </tr>
             <tr class="crm-event-manage-fee-form-block-pay_later_receipt">
                <td class="label">{$form.pay_later_receipt.label}<span class="marker"> *</span> </td>


### PR DESCRIPTION
Added "pay_later_text" under skippedFields so that it can support HTML tags and used wysiwig editor for Pay Later Instructions of Event and Contribution Page. 
