### PR TITLE
Fatal error: Maximum execution time of 30 seconds exceeded in civicrm/packages/IDS/Converter.php on line 319 

### DIFF
--- a/templates/CRM/Contact/Form/Relationship.tpl
+++ b/templates/CRM/Contact/Form/Relationship.tpl
@@ -473,8 +473,15 @@ function checkSelected( ) {
 }
 
 function submitAjaxData() {
+    var total_checked = new Array();
+    cj.each(contact_checked, function(index, value) {
+      if (typeof value !== "undefined") {
+        total_checked.push(value);
+      }
+    });
+    contact_checked = total_checked;
     cj('#store_contacts').val( contact_checked.toString() );
-    if ( useEmployer )  {
+    if ( useEmployer ) {
         cj('#store_employers').val( employer_checked.toString() );
     }
     return true;


### PR DESCRIPTION
I get the Following Fatal PHP Error when I attempt to add a relationship (Individual to a Houseshold):

 Fatal error: Maximum execution time of 30 seconds exceeded in civicrm/packages/IDS/Converter.php on line 319

I get the error at this URL:
civicrm/contact/view/rel

I also tested adding the relationship in reverse (Household to an Individual), however, I received the same error.

For more information please see:
http://issues.civicrm.org/jira/browse/CRM-12673

Thanks! 
