### PR TITLE
CRM-12417 format activity date during import

### DIFF
--- a/CRM/Activity/Import/Parser/Activity.php
+++ b/CRM/Activity/Import/Parser/Activity.php
@@ -256,7 +256,10 @@ class CRM_Activity_Import_Parser_Activity extends CRM_Activity_Import_Parser {
 
     foreach ($params as $key => $val) {
       if ($customFieldID = CRM_Core_BAO_CustomField::getKeyID($key)) {
-        if ($customFields[$customFieldID]['data_type'] == 'Date') {
+        if ($key == 'activity_date_time' && $val) {
+          $params[$key] = CRM_Utils_Date::formatDate($val, $dateType);
+        }
+        elseif ($customFields[$customFieldID]['data_type'] == 'Date') {
           CRM_Import_Parser_Contact::formatCustomDate($params, $params, $dateType, $key);
         }
         elseif ($customFields[$customFieldID]['data_type'] == 'Boolean') {


### PR DESCRIPTION
format activity date during import; this reverts:
https://fisheye2.atlassian.com/browse/~br=trunk/CiviCRM/trunk/CRM/Activity/Import/Parser/Activity.php?r2=45745&r1=45739

which was an unnecessary change and introduced a regression bug (http://issues.civicrm.org/jira/browse/CRM-11904)
