### PR TITLE
Remove patch to disable mails from PHP/drush

### DIFF
--- a/tools/scripts/mk-drupal-test-site
+++ b/tools/scripts/mk-drupal-test-site
@@ -89,7 +89,7 @@ fi
 
 # NB: Avoid sending e-mails for the site installation
 # On hosts without sendmail (ex: demo sites), this causes the installation to fail.
-php -d sendmail_path=`which true` `which drush` site-install -y \
+drush site-install -y \
   --db-url="mysql://${DB_USER}:${DB_PASS}@${DB_HOST}/${DB_NAME}" \
   --account-name="$ADMIN_USER" \
   --account-pass="$ADMIN_PASS" \


### PR DESCRIPTION
Instead rely that the host will have a php.ini directive disabling sendmail. See: https://test.civicrm.org/job/CiviCRM-master-git/108/LABEL=debian6,SUITE=api_v3_AllTests/
