### PR TITLE
minor api test fixes WRT https://test.civicrm.org/job/CiviCRM-4.3-git/LABEL=...

### DIFF
--- a/tests/phpunit/api/v3/CustomSearchTest.php
+++ b/tests/phpunit/api/v3/CustomSearchTest.php
@@ -26,7 +26,7 @@ class api_v3_CustomSearchTest extends CiviUnitTestCase {
     $this->assertDBQuery(1, 'SELECT count(*) FROM civicrm_option_value
       WHERE name = "CRM_Contact_Form_Search_Custom_Examplez"
       AND label = "CRM_Contact_Form_Search_Custom_Examplez"
-      AND option_group_id = 24');
+      AND option_group_id = 25');
     $this->assertDBQuery(1, 'SELECT is_active FROM civicrm_option_value
       WHERE name = "CRM_Contact_Form_Search_Custom_Examplez"');
 
@@ -41,7 +41,7 @@ class api_v3_CustomSearchTest extends CiviUnitTestCase {
     $this->assertDBQuery(1, 'SELECT count(*) FROM civicrm_option_value
       WHERE name = "CRM_Contact_Form_Search_Custom_Examplez"
       AND label = "CRM_Contact_Form_Search_Custom_Examplez"
-      AND option_group_id = 24');
+      AND option_group_id = 25');
     $this->assertDBQuery(0, 'SELECT is_active FROM civicrm_option_value
       WHERE name = "CRM_Contact_Form_Search_Custom_Examplez"');
 
@@ -56,7 +56,7 @@ class api_v3_CustomSearchTest extends CiviUnitTestCase {
     $this->assertDBQuery(1, 'SELECT count(*) FROM civicrm_option_value
       WHERE name = "CRM_Contact_Form_Search_Custom_Examplez"
       AND label = "CRM_Contact_Form_Search_Custom_Examplez"
-      AND option_group_id = 24');
+      AND option_group_id = 25');
     $this->assertDBQuery(1, 'SELECT is_active FROM civicrm_option_value
       WHERE name = "CRM_Contact_Form_Search_Custom_Examplez"');
 

--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -61,7 +61,7 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
     $this->assertEquals(7, $result['values'][$entityId]['component_id'], 'In line ' . __LINE__);
     $this->assertDBQuery(1, 'SELECT count(*) FROM civicrm_option_value
       WHERE name = "CRM_Report_Form_Examplez"
-      AND option_group_id = 40 ');
+      AND option_group_id = 41 ');
     $this->assertDBQuery(1, 'SELECT is_active FROM civicrm_option_value
       WHERE name = "CRM_Report_Form_Examplez"');
 
@@ -75,7 +75,7 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
     $this->assertEquals(1, $result['count'], 'In line ' . __LINE__);
     $this->assertDBQuery(1, 'SELECT count(*) FROM civicrm_option_value
       WHERE name = "CRM_Report_Form_Examplez"
-      AND option_group_id = 40');
+      AND option_group_id = 41');
     $this->assertDBQuery(1, 'SELECT count(*) FROM civicrm_option_value
       WHERE name = "CRM_Report_Form_Examplez"
       AND component_id IS NULL');
@@ -90,7 +90,7 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
     $this->assertEquals(1, $result['count'], 'In line ' . __LINE__);
     $this->assertDBQuery(1, 'SELECT count(*) FROM civicrm_option_value
       WHERE name = "CRM_Report_Form_Examplez"
-      AND option_group_id = 40');
+      AND option_group_id = 41');
     $this->assertDBQuery(0, 'SELECT is_active FROM civicrm_option_value
       WHERE name = "CRM_Report_Form_Examplez"');
 
@@ -104,7 +104,7 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
     $this->assertEquals(1, $result['count'], 'In line ' . __LINE__);
     $this->assertDBQuery(1, 'SELECT count(*) FROM civicrm_option_value
       WHERE name = "CRM_Report_Form_Examplez"
-      AND option_group_id = 40');
+      AND option_group_id = 41');
     $this->assertDBQuery(1, 'SELECT is_active FROM civicrm_option_value
       WHERE name = "CRM_Report_Form_Examplez"');
 


### PR DESCRIPTION
these api tests were failing due to inccorect option_group_id in WHERE clause of sql query whose result is being checked by assertDBQuery, tests work after correcting the ids.

their was addition in option_group records which resulted in change of ids.
now given proper group ids of 'custom_search' and 'report_template' groups needed for test case. (verified with xml/templates/civicrm_data.tpl)
