### PR TITLE
-- fixed for CRM-12680, line items were not created properly when trying...

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1374,7 +1374,12 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
         unset($submittedValues[$key]);
       }
     }
-
+     
+    // CRM-12680 set $_lineItem if its not set
+    if (empty($this->_lineItem) && !empty($lineItem)) {
+      $this->_lineItem = $lineItem;
+    }
+    
     //Get the rquire fields value only.
     $params = $this->_params = $submittedValues;
 


### PR DESCRIPTION
... to submit credit card contribution

---
- CRM-12680: Contribution of multiple financial types in single field creates unbalanced transaction
  http://issues.civicrm.org/jira/browse/CRM-12680
