### PR TITLE
CRM-12499 - Allow CMS-specific permission expressions

### DIFF
--- a/CRM/Contact/Page/View.php
+++ b/CRM/Contact/Page/View.php
@@ -340,14 +340,14 @@ class CRM_Contact_Page_View extends CRM_Core_Page {
    * Add urls for display in the actions menu
    */
   static function addUrls(&$obj, $cid) {
+    // TODO rewrite without so many hard-coded CMS bits; use abstractions like CRM_Core_Permission::check('cms:...') and CRM_Utils_System
+
     $config = CRM_Core_Config::singleton();
     $session = CRM_Core_Session::singleton();
     $uid = CRM_Core_BAO_UFMatch::getUFId($cid);
     if ($uid) {
-      // To do: we should also allow drupal users with CRM_Core_Permission::check( 'view user profiles' ) true to access $userRecordUrl
-      // but this is currently returning false regardless of permission set for the role. dgg
       if ($config->userSystem->is_drupal == '1' &&
-        ($session->get('userID') == $cid || CRM_Core_Permission::check('administer users'))
+        ($session->get('userID') == $cid || CRM_Core_Permission::checkAnyPerm(array('cms:administer users', 'cms:view user account')))
       ) {
         $userRecordUrl = CRM_Utils_System::url('user/' . $uid);
       }

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -54,6 +54,16 @@ class CRM_Core_Permission {
   CONST EDIT = 1, VIEW = 2, DELETE = 3, CREATE = 4, SEARCH = 5, ALL = 6, ADMIN = 7;
 
   /**
+   * A placeholder permission which always fails
+   */
+  const ALWAYS_DENY_PERMISSION = "*always deny*";
+
+  /**
+   * A placeholder permission which always fails
+   */
+  const ALWAYS_ALLOW_PERMISSION = "*always allow*";
+
+  /**
    * get the current permission of this user
    *
    * @return string the permission of the user (edit or view or null)

--- a/CRM/Core/Permission/Base.php
+++ b/CRM/Core/Permission/Base.php
@@ -39,6 +39,28 @@
 class CRM_Core_Permission_Base {
 
   /**
+   * Translate permission
+   *
+   * @param string $name e.g. "administer CiviCRM", "cms:access user record", "Drupal:administer content", "Joomla:action:com_asset"
+   * @param string $nativePrefix
+   * @param array $map array($portableName => $nativeName)
+   * @return NULL|string a permission name
+   */
+  public function translatePermission($perm, $nativePrefix, $map) {
+    list ($civiPrefix, $name) = CRM_Utils_String::parsePrefix(':', $perm, NULL);
+    switch ($civiPrefix) {
+      case $nativePrefix:
+        return $name; // pass through
+      case 'cms':
+        return CRM_Utils_Array::value($name, $map, CRM_Core_Permission::ALWAYS_DENY_PERMISSION);
+      case NULL:
+        return $name;
+      default:
+        return CRM_Core_Permission::ALWAYS_DENY_PERMISSION;
+    }
+  }
+
+  /**
    * get the current permission of this user
    *
    * @return string the permission of the user (edit or view or null)

--- a/CRM/Core/Permission/Drupal.php
+++ b/CRM/Core/Permission/Drupal.php
@@ -73,6 +73,7 @@ class CRM_Core_Permission_Drupal extends CRM_Core_Permission_DrupalBase{
   function check($str, $contactID = NULL) {
     $str = $this->translatePermission($str, 'Drupal', array(
       'view user account' => 'access user profiles',
+      'administer users' => 'administer users',
     ));
     if ($str == CRM_Core_Permission::ALWAYS_DENY_PERMISSION) {
       return FALSE;

--- a/CRM/Core/Permission/Drupal.php
+++ b/CRM/Core/Permission/Drupal.php
@@ -62,6 +62,29 @@ class CRM_Core_Permission_Drupal extends CRM_Core_Permission_DrupalBase{
   protected $_editPermissionedGroups;
 
 
+  /**
+   * given a permission string, check for access requirements
+   *
+   * @param string $str the permission to check
+   *
+   * @return boolean true if yes, else false
+   * @access public
+   */
+  function check($str, $contactID = NULL) {
+    $str = $this->translatePermission($str, 'Drupal', array(
+      'view user account' => 'access user profiles',
+    ));
+    if ($str == CRM_Core_Permission::ALWAYS_DENY_PERMISSION) {
+      return FALSE;
+    }
+    if ($str == CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION) {
+      return TRUE;
+    }
+    if (function_exists('user_access')) {
+      return user_access($str) ? TRUE : FALSE;
+    }
+    return TRUE;
+  }
 
   /**
    * Given a roles array, check for access requirements

--- a/CRM/Core/Permission/Drupal6.php
+++ b/CRM/Core/Permission/Drupal6.php
@@ -62,6 +62,30 @@ class CRM_Core_Permission_Drupal6 extends CRM_Core_Permission_DrupalBase {
   protected $_editPermissionedGroups;
 
   /**
+   * given a permission string, check for access requirements
+   *
+   * @param string $str the permission to check
+   *
+   * @return boolean true if yes, else false
+   * @access public
+   */
+  function check($str, $contactID = NULL) {
+    $str = $this->translatePermission($str, 'Drupal6', array(
+      'view user account' => 'access user profiles',
+    ));
+    if ($str == CRM_Core_Permission::ALWAYS_DENY_PERMISSION) {
+      return FALSE;
+    }
+    if ($str == CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION) {
+      return TRUE;
+    }
+    if (function_exists('user_access')) {
+      return user_access($str) ? TRUE : FALSE;
+    }
+    return TRUE;
+  }
+
+  /**
    * Given a roles array, check for access requirements
    *
    * @param array $array the roles to check

--- a/CRM/Core/Permission/Drupal6.php
+++ b/CRM/Core/Permission/Drupal6.php
@@ -72,6 +72,7 @@ class CRM_Core_Permission_Drupal6 extends CRM_Core_Permission_DrupalBase {
   function check($str, $contactID = NULL) {
     $str = $this->translatePermission($str, 'Drupal6', array(
       'view user account' => 'access user profiles',
+      'administer users' => 'administer users',
     ));
     if ($str == CRM_Core_Permission::ALWAYS_DENY_PERMISSION) {
       return FALSE;

--- a/CRM/Core/Permission/DrupalBase.php
+++ b/CRM/Core/Permission/DrupalBase.php
@@ -215,21 +215,6 @@ class CRM_Core_Permission_DrupalBase extends CRM_Core_Permission_Base {
     return NULL;
   }
 
-  /**
-   * given a permission string, check for access requirements
-   *
-   * @param string $str the permission to check
-   *
-   * @return boolean true if yes, else false
-   * @access public
-   */
-  function check($str, $contactID = NULL) {
-    if (function_exists('user_access')) {
-      return user_access($str) ? TRUE : FALSE;
-    }
-    return TRUE;
-  }
-
   function getContactEmails($uids) {
     if (empty($uids)) {
       return '';

--- a/CRM/Core/Permission/WordPress.php
+++ b/CRM/Core/Permission/WordPress.php
@@ -46,6 +46,16 @@ class CRM_Core_Permission_WordPress extends CRM_Core_Permission_Base {
    * @access public
    */
   function check($str) {
+    $str = $this->translatePermission($str, 'WordPress', array(
+      'view user account' => 'administrator',
+    ));
+    if ($str == CRM_Core_Permission::ALWAYS_DENY_PERMISSION) {
+      return FALSE;
+    }
+    if ($str == CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION) {
+      return TRUE;
+    }
+
     // for administrators give them all permissions
     if (!function_exists('current_user_can')) {
       return TRUE;

--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -631,5 +631,24 @@ class CRM_Utils_String {
     return $result;
   }
 
+  /**
+   * Examples:
+   * "admin foo" => array(NULL,"admin foo")
+   * "cms:admin foo" => array("cms", "admin foo")
+   *
+   * @param string $string e.g. "view all contacts". Syntax: "[prefix:]name"
+   * @return array (0 => string|NULL $prefix, 1 => string $value)
+   */
+  public static function parsePrefix($delim, $string, $defaultPrefix = NULL) {
+    $pos = strpos($string, $delim);
+    if ($pos === FALSE) {
+      return array($defaultPrefix, $string);
+    }
+    else {
+      return array(substr($string, 0, $pos), substr($string, 1+$pos));
+    }
+  }
+
+
 }
 

--- a/tests/phpunit/CRM/Core/Permission/BaseTest.php
+++ b/tests/phpunit/CRM/Core/Permission/BaseTest.php
@@ -1,0 +1,39 @@
+<?php
+
+require_once 'CiviTest/CiviUnitTestCase.php';
+
+class CRM_Core_Permission_BaseTest extends CiviUnitTestCase {
+
+  /**
+   * @return array (0 => input to translatePermission, 1 => expected output from translatePermission)
+   */
+  public function translateData() {
+    $cases = array();
+
+    $cases[] = array("administer CiviCRM", "administer CiviCRM");
+    $cases[] = array("cms:universal name", "local name");
+    $cases[] = array("cms:universal name2", "local name2");
+    $cases[] = array("cms:unknown universal name", CRM_Core_Permission::ALWAYS_DENY_PERMISSION);
+    $cases[] = array("myruntime:foo", "foo");
+    $cases[] = array("otherruntime:foo", CRM_Core_Permission::ALWAYS_DENY_PERMISSION);
+    $cases[] = array("otherruntime:foo:bar", CRM_Core_Permission::ALWAYS_DENY_PERMISSION);
+    $cases[] = array(CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION, CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION);
+
+    return $cases;
+  }
+
+  /**
+   * @dataProvider translateData
+   * @param string $input the name of a permission which should be translated
+   * @param string $expected the name of an actual permission (based on translation matrix for "runtime")
+   */
+  public function testTranslate($input, $expected) {
+    $perm = new CRM_Core_Permission_Base();
+    $actual = $perm->translatePermission($input, "myruntime", array(
+      'universal name' => 'local name',
+      'universal name2' => 'local name2',
+      'gunk' => 'gunky',
+    ));
+    $this->assertEquals($expected, $actual);
+  }
+}

--- a/tests/phpunit/CRM/Core/Permission/GenericTest.php
+++ b/tests/phpunit/CRM/Core/Permission/GenericTest.php
@@ -1,0 +1,38 @@
+<?php
+
+require_once 'CiviTest/CiviUnitTestCase.php';
+
+class CRM_Core_Permission_GenericTest extends CiviUnitTestCase {
+
+  /**
+   * @return array of CRM_Core_Permission_Base
+   */
+  public function permissionClasses() {
+    $cases = array();
+
+    $cases[] = array('CRM_Core_Permission_Drupal');
+    $cases[] = array('CRM_Core_Permission_Drupal6');
+    $cases[] = array('CRM_Core_Permission_Joomla');
+    $cases[] = array('CRM_Core_Permission_WordPress');
+
+    return $cases;
+  }
+
+  /**
+   * @dataProvider permissionClasses
+   * @param string $providerClass
+   */
+  public function testAlwaysDenyPermission($providerClass) {
+    $provider = new $providerClass();
+    $this->assertEquals(FALSE, $provider->check(CRM_Core_Permission::ALWAYS_DENY_PERMISSION));
+  }
+
+  /**
+   * @dataProvider permissionClasses
+   * @param string $providerClass
+   */
+  public function testAlwaysAllowPermission($providerClass) {
+    $provider = new $providerClass();
+    $this->assertEquals(TRUE, $provider->check(CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION));
+  }
+}

--- a/tests/phpunit/CRM/Core/Permission/JoomlaTest.php
+++ b/tests/phpunit/CRM/Core/Permission/JoomlaTest.php
@@ -1,0 +1,38 @@
+<?php
+
+require_once 'CiviTest/CiviUnitTestCase.php';
+
+class CRM_Core_Permission_JoomlaTest extends CiviUnitTestCase {
+
+  /**
+   * @return array (0 => input to translatePermission, 1 => expected output from translatePermission)
+   */
+  public function translateData() {
+    $cases = array();
+
+    $cases[] = array("administer CiviCRM", array("civicrm.administer_civicrm", "com_civicrm"));
+    // TODO $cases[] = array("cms:universal name", "local name");
+    // TODO $cases[] = array("cms:universal name2", "local name2");
+    $cases[] = array("cms:unknown universal name", CRM_Core_Permission::ALWAYS_DENY_PERMISSION);
+    $cases[] = array(
+      "Joomla:civicrmplusplus.extragood:com_civicrmplusplus",
+      array("civicrmplusplus.extragood", "com_civicrmplusplus")
+    );
+    $cases[] = array("otherruntime:foo", CRM_Core_Permission::ALWAYS_DENY_PERMISSION);
+    $cases[] = array(CRM_Core_Permission::ALWAYS_DENY_PERMISSION, CRM_Core_Permission::ALWAYS_DENY_PERMISSION);
+    $cases[] = array(CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION, CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION);
+
+    return $cases;
+  }
+
+  /**
+   * @dataProvider translateData
+   * @param string $input the name of a permission which should be translated
+   * @param string $expected the name of an actual permission (based on translation matrix for "runtime")
+   */
+  public function testTranslate($input, $expected) {
+    $perm = new CRM_Core_Permission_Joomla();
+    $actual = $perm->translateJoomlaPermission($input);
+    $this->assertEquals($expected, $actual);
+  }
+}

--- a/tests/phpunit/CRM/Utils/StringTest.php
+++ b/tests/phpunit/CRM/Utils/StringTest.php
@@ -104,5 +104,22 @@ class CRM_Utils_StringTest extends CiviUnitTestCase {
       $this->assertRegExp('/^[12345678]+$/', $actual);
     }
   }
+
+  public function parsePrefixData() {
+    $cases = array();
+    $cases[] = array('administer CiviCRM', NULL, array(NULL, 'administer CiviCRM'));
+    $cases[] = array('administer CiviCRM', 'com_civicrm', array('com_civicrm', 'administer CiviCRM'));
+    $cases[] = array('Drupal:access user profiles', NULL, array('Drupal', 'access user profiles'));
+    $cases[] = array('Joomla:component:perm', NULL, array('Joomla', 'component:perm'));
+    return $cases;
+  }
+
+  /**
+   * @dataProvider parsePrefixData
+   */
+  public function testParsePrefix($input, $defaultPrefix, $expected) {
+    $actual = CRM_Utils_String::parsePrefix(':', $input, $defaultPrefix);
+    $this->assertEquals($expected, $actual);
+  }
 }
 


### PR DESCRIPTION
PR #621 broached the issue of referencing CMS-specific permissions from core code, but the practice is potentially confusing and not generally safe (e.g. the same business permission could be represented by different permission-names, and the same permission-name could represent different business-permissions).

This PR introduces a prefixing notation for permissions. More detailed specs are at: http://wiki.civicrm.org/confluence/display/CRMDOC43/Permission+Reference#PermissionReference-Advanced:CheckCMSPermissions%28CiviCRM4.4+%29

I've manually tested under Joomla (which has the most complex permission-checking) and D7 (which was the template for others) -- but haven't manually test D6/WP. There are several new unit-tests, though.

I'm submitting this PR against 4.3 because the original issue and PR (CRM-12499, #621) were filed against 4.3. However, I'm a little nervous -- the patch pushes the limit of an acceptable patch-size for a 4.3.x point-release.

Whoever reviews this: if we want to move it to 4.4, then I'll do that. If you think it's OK on 4.3, then that's fine, too.
