### PR TITLE
CRM-12691 remove references to Create PCP URL from help files since the ...

### DIFF
--- a/templates/CRM/Contribute/Form/ContributionPage/PCP.hlp
+++ b/templates/CRM/Contribute/Form/ContributionPage/PCP.hlp
@@ -28,12 +28,6 @@
 {/htxt}
 {htxt id="id-pcp_intro_help"}
 {ts}When Personal Campaign Pages are enabled, constituents will see a link inviting them to create their own fundraising page after making a contribution.{/ts}
-{if $config->userSystem->is_drupal}
-    {ts}You can also place additional links (or menu items) allowing constituents to create their own fundraising pages using the following URL:{/ts}<br /><br />
-    <strong>{crmURL a=true p='civicrm/contribute/campaign' q="action=add&reset=1&pageId=`$params.pageId`&component=contribute"}</strong></dd>
-{elseif $config->userFramework EQ 'Joomla'}
-    {ts}You can also create front-end links (or menu items) allowing constituents to create their own fundraising pages using the Menu Manager. Select <strong>Contributions &raquo; Personal Campaign Pages</strong> and then select this contribution page.{/ts}
-{/if}
 {/htxt}
 
 {htxt id="id-approval_needed-title"}
@@ -79,12 +73,4 @@
 {/htxt}
 {htxt id="id-link_text"}
 {ts}Text for the link inviting constituents to create a Personal Contribution Page. This link will appear on the Contribution Thank-you page as well as on each Personal Campaign Page.{/ts}
-<p>
-{if $config->userSystem->is_drupal}
-    {ts}When Personal Campaign Pages are enabled, you can also place additional links (or menu items) inviting constituents to create personal fundraising pages using the following URL:{/ts}<br /><br />
-    <strong>{crmURL a=true p='civicrm/contribute/campaign' q="action=add&reset=1&pageId=`$params.pageId`&component=contribute"}</strong></dd>
-{elseif $config->userFramework EQ 'Joomla'}
-    {ts}When Personal Campaign Pages are enabled, you can create front-end links inviting constituents to create personal fundraising pages using the Menu Manager. Select <strong>Contributions &raquo; Personal Campaign Pages</strong> and then select this contribution page.{/ts}
-{/if}
-</p>
 {/htxt}

--- a/templates/CRM/PCP/Form/Contribute.hlp
+++ b/templates/CRM/PCP/Form/Contribute.hlp
@@ -28,12 +28,6 @@
 {/htxt}
 {htxt id="id-pcp_intro_help"}
 {ts}When Personal Campaign Pages are enabled, constituents will see a link inviting them to create their own fundraising page after making a contribution.  Contributions from people who come in through a Personal Campaign Page are recorded as "soft credits" for the supporter who created that campaign page.{/ts}
-{if $config->userSystem->is_drupal}
-    {ts}You can also place additional links (or menu items) allowing constituents to create their own fundraising pages using the following URL:{/ts}<br /><br />
-    <strong>{crmURL a=true p='civicrm/contribute/campaign' q="action=add&reset=1&pageId=`$params.pageId`&component=contribute"}</strong></dd>
-{elseif $config->userFramework EQ 'Joomla'}
-    {ts}You can also create front-end links (or menu items) allowing constituents to create their own fundraising pages using the Menu Manager. Select <strong>Contributions &raquo; Personal Campaign Pages</strong> and then select this contribution page.{/ts}
-{/if}
 {/htxt}
 
 {htxt id="id-approval_needed-title"}
@@ -79,12 +73,4 @@
 {/htxt}
 {htxt id="id-link_text"}
 {ts}Text for the link inviting constituents to create a Personal Contribution Page. This link will appear on the Contribution Thank-you page as well as on each Personal Campaign Page.{/ts}
-<p>
-{if $config->userSystem->is_drupal}
-    {ts}When Personal Campaign Pages are enabled, you can also place additional links (or menu items) inviting constituents to create personal fundraising pages using the following URL:{/ts}<br /><br />
-    <strong>{crmURL a=true p='civicrm/contribute/campaign' q="action=add&reset=1&pageId=`$params.pageId`&component=contribute"}</strong></dd>
-{elseif $config->userFramework EQ 'Joomla'}
-    {ts}When Personal Campaign Pages are enabled, you can create front-end links inviting constituents to create personal fundraising pages using the Menu Manager. Select <strong>Contributions &raquo; Personal Campaign Pages</strong> and then select this contribution page.{/ts}
-{/if}
-</p>
 {/htxt}

--- a/templates/CRM/PCP/Form/Contribute.tpl
+++ b/templates/CRM/PCP/Form/Contribute.tpl
@@ -33,4 +33,4 @@
 <div id="help">
 {ts}Allow constituents to create their own personal fundraising pages linked to this contribution page.{/ts} {help id="id-pcp_intro_help"}
 </div>
-{include file="CRM/PCP/Form/PCP.tpl" context="Contribute"}
+{include file="CRM/PCP/Form/PCP.tpl" context="contribute"}

--- a/templates/CRM/PCP/Form/Event.hlp
+++ b/templates/CRM/PCP/Form/Event.hlp
@@ -28,12 +28,6 @@
 {/htxt}
 {htxt id="id-pcp_intro_help"}
 {ts}Personal Campaign Pages provide your constituents with the ability to promote this event or a related fundraising effort. When Personal Campaign Pages are enabled constituents will see a link after registering for this event which invites them to create their own page to promote the event (or promote a related online contribution page). Event registration fees (or contributions) from people who come in through a Personal Campaign Page are recorded as "soft credits" for the supporter who created that campaign page.{/ts}
-{if $config->userSystem->is_drupal}
-    {ts}You can also place additional links (or menu items) allowing constituents to create their own fundraising pages using the following URL:{/ts}<br /><br />
-    <strong>{crmURL a=true p='civicrm/contribute/campaign' q="action=add&reset=1&pageId=`$params.pageId`&component=event"}</strong></dd>
-{elseif $config->userFramework EQ 'Joomla'}
-    {ts}You can also create front-end links (or menu items) allowing constituents to create their own fundraising pages using the Menu Manager. Select <strong>Contributions &raquo; Personal Campaign Pages</strong> and then select this event.{/ts}
-{/if}
 {/htxt}
 
 {htxt id="id-approval_needed-title"}
@@ -79,14 +73,6 @@
 {/htxt}
 {htxt id="id-link_text"}
 {ts}Text for the link inviting constituents to create a Personal Campaign Page. This link will appear on the Event registration Thank-you page as well as on each Personal Campaign Page.{/ts}
-<p>
-{if $config->userSystem->is_drupal}
-    {ts}When Personal Campaign Pages are enabled, you can also place additional links (or menu items) inviting constituents to create personal campaign pages using the following URL:{/ts}<br /><br />
-    <strong>{crmURL a=true p='civicrm/contribute/campaign' q="action=add&reset=1&pageId=`$params.pageId`&component=event"}</strong></dd>
-{elseif $config->userFramework EQ 'Joomla'}
-    {ts}When Personal Campaign Pages are enabled, you can create front-end links inviting constituents to create personal fundraising pages using the Menu Manager. Select <strong>Contributions &raquo; Personal Campaign Pages</strong> and then select this event.{/ts}
-{/if}
-</p>
 {/htxt}
 
 {htxt id="id-target_entity_type-title"}

--- a/templates/CRM/PCP/Form/Event.tpl
+++ b/templates/CRM/PCP/Form/Event.tpl
@@ -33,4 +33,4 @@
 <div id="help">
 {ts}Allow constituents to create their own personal fundraising pages linked to this event.{/ts} {help id="id-pcp_intro_help"}
 </div>
-{include file="CRM/PCP/Form/PCP.tpl" context="Event"}
+{include file="CRM/PCP/Form/PCP.tpl" context="event" pageId=`$eventId`}

--- a/templates/CRM/PCP/Form/PCP.tpl
+++ b/templates/CRM/PCP/Form/PCP.tpl
@@ -75,7 +75,17 @@
      </tr>
      <tr class="crm-contribution-contributionpage-pcp-form-block-link_text">
         <td class="label">{$form.link_text.label}</td>
-        <td>{$form.link_text.html|crmAddClass:huge} {help id="id-link_text"}</td>
+        <td>
+          {$form.link_text.html|crmAddClass:huge} {help id="id-link_text"}<br />
+          <span class="description">
+            {if $config->userSystem->is_drupal || $config->userFramework EQ 'WordPress'}
+              {ts}You can also place additional links (or menu items) allowing constituents to create their own fundraising pages using the following URL:{/ts}<br />
+              <em>{crmURL a=true p='civicrm/contribute/campaign' q="action=add&reset=1&pageId=`$pageId`&component=`$context`"}</em>
+            {elseif $config->userFramework EQ 'Joomla'}
+              {ts}You can also create front-end links (or menu items) allowing constituents to create their own fundraising pages using the Menu Manager. Select <strong>Contributions &raquo; Personal Campaign Pages</strong> and then select this event.{/ts}
+            {/if}
+          </span>
+        </td>
      </tr>
   </table>
 {/crmRegion}

--- a/templates/CRM/PCP/Form/PCP.tpl
+++ b/templates/CRM/PCP/Form/PCP.tpl
@@ -80,7 +80,7 @@
           <span class="description">
             {if $config->userSystem->is_drupal || $config->userFramework EQ 'WordPress'}
               {ts}You can also place additional links (or menu items) allowing constituents to create their own fundraising pages using the following URL:{/ts}<br />
-              <em>{crmURL a=true p='civicrm/contribute/campaign' q="action=add&reset=1&pageId=`$pageId`&component=`$context`"}</em>
+              <em>{crmURL a=1 fe=1 p='civicrm/contribute/campaign' q="action=add&reset=1&pageId=`$pageId`&component=`$context`"}</em>
             {elseif $config->userFramework EQ 'Joomla'}
               {ts}You can also create front-end links (or menu items) allowing constituents to create their own fundraising pages using the Menu Manager. Select <strong>Contributions &raquo; Personal Campaign Pages</strong> and then select this event.{/ts}
             {/if}

--- a/templates/CRM/PCP/Page/PCP.hlp
+++ b/templates/CRM/PCP/Page/PCP.hlp
@@ -30,5 +30,14 @@
 <p>{ts}Personal Campaign Pages (PCPs) allow your constituents to create their own fundraising page for your organization. This means that a donor, after donating to your organization, can elect to create a page with her own photo, text, and personal information. She can then send a link to the page to her friends, soliciting support for your organization. This is a powerful way to widely and quickly spread the message about your campaign.{/ts}</p>
 
 <p>{ts}When someone donates through a personal campaign page, a soft credit is given to the owner of the page to recognize the role she played in the contribution. CiviContribute has a section that allows you to administer all of the PCPs for your organization. You can require approval before a PCP goes 'live', and disable or delete any campaign pages you don't approve of.{/ts} {docURL page="user/contributions/personal-campaign-pages"}</p>
+
+<p>
+{if $config->userSystem->is_drupal || $config->userFramework EQ 'WordPress'}
+  {ts}You can also place additional links (or menu items) allowing constituents to create their own fundraising pages using the following URL:{/ts}<br />
+  <em>{crmURL a=true p='civicrm/contribute/campaign' q="action=add&reset=1&pageId=<id of contribution page or event>&component=<contribute or event>"}</em>
+{elseif $config->userFramework EQ 'Joomla'}
+  {ts}You can also create front-end links (or menu items) allowing constituents to create their own fundraising pages using the Menu Manager. Select <strong>Contributions &raquo; Personal Campaign Pages</strong> and then select this event.{/ts}
+{/if}
+<p>
 {/htxt} 
 

--- a/templates/CRM/PCP/Page/PCP.hlp
+++ b/templates/CRM/PCP/Page/PCP.hlp
@@ -34,7 +34,7 @@
 <p>
 {if $config->userSystem->is_drupal || $config->userFramework EQ 'WordPress'}
   {ts}You can also place additional links (or menu items) allowing constituents to create their own fundraising pages using the following URL:{/ts}<br />
-  <em>{crmURL a=true p='civicrm/contribute/campaign' q="action=add&reset=1&pageId=<id of contribution page or event>&component=<contribute or event>"}</em>
+  <em>{crmURL a=1 fe=1 p='civicrm/contribute/campaign' q="action=add&reset=1&pageId=<id of contribution page or event>&component=<contribute or event>"}</em>
 {elseif $config->userFramework EQ 'Joomla'}
   {ts}You can also create front-end links (or menu items) allowing constituents to create their own fundraising pages using the Menu Manager. Select <strong>Contributions &raquo; Personal Campaign Pages</strong> and then select this event.{/ts}
 {/if}


### PR DESCRIPTION
...page id was not available. Add this info inline to the forms, and generically to the Manage PCP page. Also added the example URL for WordPress, which was missing.

---
- CRM-12691: Create PCP link is hard to discover and link in user guide is incomplete
  http://issues.civicrm.org/jira/browse/CRM-12691
