### PR TITLE
-- fixed table reference checks for financial_type_id before deleting, CRM-12470

### DIFF
--- a/CRM/Financial/BAO/FinancialType.php
+++ b/CRM/Financial/BAO/FinancialType.php
@@ -148,6 +148,38 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType {
           'table'  => 'civicrm_pledge',
           'column' => 'financial_type_id',
         ),
+        array(
+          'table'  => 'civicrm_grant',
+          'column' => 'financial_type_id',
+        ),
+        array(
+          'table'  => 'civicrm_product',
+          'column' => 'financial_type_id',
+        ),
+        array(
+          'table'  => 'civicrm_event',
+          'column' => 'financial_type_id',
+        ),
+        array(
+          'table'  => 'civicrm_premiums_product',
+          'column' => 'financial_type_id',
+        ),
+        array(
+          'table'  => 'civicrm_price_set',
+          'column' => 'financial_type_id',
+        ),
+        array(
+          'table'  => 'civicrm_price_field_value',
+          'column' => 'financial_type_id',
+        ),
+        array(
+          'table'  => 'civicrm_line_item',
+          'column' => 'financial_type_id',
+        ),
+        array(
+          'table'  => 'civicrm_contribution_product ',
+          'column' => 'financial_type_id',
+        ),
       );
 
     $errors = array();


### PR DESCRIPTION
---
- CRM-12470: Creating new financial type without AR account leads to unbalanced transactions
  http://issues.civicrm.org/jira/browse/CRM-12470
