### PR TITLE
CRM-12696 fix: re-structured CRM_Contact_Form_Edit_Address::fixStateSele...

### DIFF
--- a/CRM/Contact/Form/Edit/Address.php
+++ b/CRM/Contact/Form/Edit/Address.php
@@ -205,6 +205,9 @@ class CRM_Contact_Form_Edit_Address {
         }
       }
       else {
+        if ($name == 'state_province_id') {
+          $stateCountryMap[$blockId]['state_province'] = "address_{$blockId}_{$name}";
+        }
         $form->addElement('select',
           "address[$blockId][$name]",
           $title,
@@ -392,16 +395,12 @@ class CRM_Contact_Form_Edit_Address {
         $countryID = CRM_Utils_Array::value(0, $form->getElementValue($countryElementName));
       }
     }
-
     $stateTitle = ts('State/Province');
     if (isset($form->_fields[$stateElementName]['title'])) {
       $stateTitle = $form->_fields[$stateElementName]['title'];
     }
 
-    if ($countryID &&
-      isset($form->_elementIndex[$stateElementName])
-    ) {
-
+    if (isset($form->_elementIndex[$stateElementName])) {
       $submittedValState = $form->getSubmitValue($stateElementName);
       if ($submittedValState) {
         $stateID = $submittedValState;
@@ -412,7 +411,10 @@ class CRM_Contact_Form_Edit_Address {
       else {
         $stateID = CRM_Utils_Array::value(0, $form->getElementValue($stateElementName));
       }
-
+    }
+    if ($countryID &&
+      isset($form->_elementIndex[$stateElementName])
+    ) {
       $stateSelect = &$form->addElement('select',
         $stateElementName,
         $stateTitle,
@@ -420,30 +422,28 @@ class CRM_Contact_Form_Edit_Address {
           '' => ts('- select -')) +
         CRM_Core_PseudoConstant::stateProvinceForCountry($countryID)
       );
+    }
+    if ($stateID &&
+      isset($form->_elementIndex[$stateElementName]) &&
+      isset($form->_elementIndex[$countyElementName])
+    ) {
+      $form->addElement('select',
+        $countyElementName,
+        ts('County'),
+        array(
+          '' => ts('- select -')) +
+        CRM_Core_PseudoConstant::countyForState($stateID)
+      );
+    }
 
-
-      if ($stateID &&
-        isset($form->_elementIndex[$stateElementName]) &&
-        isset($form->_elementIndex[$countyElementName])
-      ) {
-        $form->addElement('select',
-          $countyElementName,
-          ts('County'),
-          array(
-            '' => ts('- select -')) +
-          CRM_Core_PseudoConstant::countyForState($stateID)
-        );
-      }
-
-      // CRM-7296 freeze the select for state if address is shared with household
-      // CRM-9070 freeze the select for state if it is view only
-      if (isset($form->_fields) &&
-          CRM_Utils_Array::value($stateElementName, $form->_fields) &&
-          (CRM_Utils_Array::value('is_shared', $form->_fields[$stateElementName]) ||
-          CRM_Utils_Array::value('is_view', $form->_fields[$stateElementName]))
-      ) {
-        $stateSelect->freeze();
-      }
+    // CRM-7296 freeze the select for state if address is shared with household
+    // CRM-9070 freeze the select for state if it is view only
+    if (isset($form->_fields) &&
+      CRM_Utils_Array::value($stateElementName, $form->_fields) &&
+      (CRM_Utils_Array::value('is_shared', $form->_fields[$stateElementName]) ||
+        CRM_Utils_Array::value('is_view', $form->_fields[$stateElementName]))
+    ) {
+      $stateSelect->freeze();
     }
   }
 
@@ -514,7 +514,6 @@ class CRM_Contact_Form_Edit_Address {
           foreach ($parseFields as $field) {
             $addressValues["{$field}_{$cnt}"] = CRM_Utils_Array::value($field, $address);
           }
-
           // don't load fields, use js to populate.
           foreach (array('street_number', 'street_name', 'street_unit') as $f) {
             if (isset($address[$f])) {

--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -666,28 +666,29 @@ ORDER BY civicrm_address.is_primary DESC, civicrm_address.location_type_id DESC,
 
   static function fixAllStateSelects(&$form, $defaults, $batchFieldNames = false) {
     $config = CRM_Core_Config::singleton();
-
     $map = null;
     if (is_array($batchFieldNames)) {
       $map = $batchFieldNames;
     }
-    else if (!empty($config->stateCountryMap)) {
+    elseif (!empty($config->stateCountryMap)) {
       $map = $config->stateCountryMap;
     }
-
     if (!empty($map)) {
       foreach ($map as $index => $match) {
-        if (
-          array_key_exists('state_province', $match) &&
-          array_key_exists('country', $match)
+        if (array_key_exists('state_province', $match)
+          || array_key_exists('country', $match)
+          || array_key_exists('county', $match)
         ) {
+          $countryElementName = CRM_Utils_Array::value('country', $match);
+          $stateProvinceElementName = CRM_Utils_Array::value('state_province', $match);
+          $countyElementName = CRM_Utils_Array::value('county', $match);
           CRM_Contact_Form_Edit_Address::fixStateSelect(
             $form,
-            $match['country'],
-            $match['state_province'],
-            CRM_Utils_Array::value('county', $match),
-            CRM_Utils_Array::value($match['country'], $defaults),
-            CRM_Utils_Array::value($match['state_province'], $defaults)
+            $countryElementName,
+            $stateProvinceElementName,
+            $countyElementName,
+            CRM_Utils_Array::value($countryElementName, $defaults),
+            CRM_Utils_Array::value($stateProvinceElementName, $defaults)
           );
         }
         else {


### PR DESCRIPTION
Previously, country address option was neccessary to be enabled for county selection(which actually depends on state).

So, after this re-structuring, even if country address field is disabled in civi, selecting state and corresponding county will be possible accross various civicrm forms i.e. profiles, contact add/edit, online contribution profiles, online event profiles, batch updates, pcp account form, etc.
