### PR TITLE
CRM-12684 fix: if custom data's profile field weight order is against to the order of its creation then the issue replicates

### DIFF
--- a/templates/CRM/Profile/Page/MultipleRecordFieldsListing.tpl
+++ b/templates/CRM/Profile/Page/MultipleRecordFieldsListing.tpl
@@ -32,25 +32,24 @@
       <div id="browseValues">
         <div>
         {strip}
-          <table id="records" class="display">
-	   <thead>
-               <tr>
+        <table id="records" class="display">
+	  <thead>
+            <tr>
           {foreach from=$headers key=recId item=head}
              <th>{ts}{$head}{/ts}</th>
-         {/foreach}
+          {/foreach}
              <th></th>
              </tr>
-           </thead>
-     {foreach from=$records key=recId item=rows}   
-       <tr class="{cycle values="odd-row,even-row"}">     
-         {foreach from=$rows item=row}
-            {foreach from=$row item=val key=ids}
-              <td>{$val}</td>
-            {/foreach}
-         {/foreach}
-       </tr>
-     {/foreach}
-          </table>
+          </thead>
+          {foreach from=$records key=recId item=rows}   
+            <tr class="{cycle values="odd-row,even-row"}">
+              {foreach from=$headers key=hrecId item=head}
+	        <td>{$rows.$hrecId}</td>
+              {/foreach}
+              <td>{$rows.action}</td>
+            </tr>
+          {/foreach}
+         </table>
         {/strip}
        </div>
       </div>

--- a/templates/CRM/Profile/Page/MultipleRecordFieldsListing.tpl
+++ b/templates/CRM/Profile/Page/MultipleRecordFieldsListing.tpl
@@ -33,7 +33,7 @@
         <div>
         {strip}
         <table id="records" class="display">
-	  <thead>
+          <thead>
             <tr>
           {foreach from=$headers key=recId item=head}
              <th>{ts}{$head}{/ts}</th>
@@ -44,7 +44,7 @@
           {foreach from=$records key=recId item=rows}   
             <tr class="{cycle values="odd-row,even-row"}">
               {foreach from=$headers key=hrecId item=head}
-	        <td>{$rows.$hrecId}</td>
+                <td>{$rows.$hrecId}</td>
               {/foreach}
               <td>{$rows.action}</td>
             </tr>


### PR DESCRIPTION
what was happening is: 
the row header of the multirecord listing table was getting build according to weight order configured in profile fields settings which is correct, but the rows were getting built according to order of custom data creation.
