### PR TITLE
CRM-12463 QA fix

### DIFF
--- a/templates/CRM/Contribute/Form/SoftCredit.js
+++ b/templates/CRM/Contribute/Form/SoftCredit.js
@@ -34,7 +34,7 @@ cj(function($) {
         'className=CRM_Contact_Page_AJAX&fnName=getContactList&json=1&context=contact&id=' + $(this).val());
       $.ajax({
         url     : dataUrl,
-	async   : false,
+        async   : false,
         success : function(html){
           htmlText = html.split( '|' , 2);
           $('#soft_credit_contact_' + rowCnt).val(htmlText[0]);

--- a/templates/CRM/Contribute/Form/SoftCredit.js
+++ b/templates/CRM/Contribute/Form/SoftCredit.js
@@ -34,6 +34,7 @@ cj(function($) {
         'className=CRM_Contact_Page_AJAX&fnName=getContactList&json=1&context=contact&id=' + $(this).val());
       $.ajax({
         url     : dataUrl,
+	async   : false,
         success : function(html){
           htmlText = html.split( '|' , 2);
           $('#soft_credit_contact_' + rowCnt).val(htmlText[0]);
@@ -54,6 +55,21 @@ cj(function($) {
     $('#soft-credit-row-' + row).hide().find('input').val('');
     $('input[name="soft_credit_contact_select_id['+row+']"]').val('');
     return false;
+  });
+
+  $('input[name^="soft_credit_contact["]').change(function(){
+    var rowNum = $(this).attr('id').replace('soft_credit_contact_','');
+    var totalAmount = Number($('#total_amount').val());
+    //assign total amount as default soft credit amount
+    $('#soft_credit_amount_'+ rowNum).val(totalAmount);
+    if (rowNum > 1) {
+      var scAmount = Number($('#soft_credit_amount_'+ (rowNum - 1)).val());
+      if (scAmount < totalAmount) {
+	//if user enters less than the total amount and adds another soft credit row, 
+	//the soft credit amount default will be left empty 
+        $('#soft_credit_amount_'+ rowNum).val(''); 
+      }
+    }
   });
 
 });


### PR DESCRIPTION
Fix for the following points:
1. The default values getting jumbled up and getting populated in the wrong autocomplete box of "Select Contact" field each time we refresh the page.
2. Soft credit amount will default to total amount of contribution.
3. If user enters less than total amount of contribution AND adds another soft credit row, the soft credit amount default will be left empty (to allow for "variable splits")
