### PR TITLE
Membership dash counts fixed but no good search

### DIFF
--- a/CRM/Activity/Form/Search.php
+++ b/CRM/Activity/Form/Search.php
@@ -435,7 +435,58 @@ class CRM_Activity_Form_Search extends CRM_Core_Form {
     if (!empty($this->_defaults)) {
       $this->setDefaults($this->_defaults);
     }
-
+        
+    // Added for membership search
+    
+    $signupType = CRM_Utils_Request::retrieve('signupType', 'Positive',
+      CRM_Core_DAO::$_nullObject
+    );
+    
+    if ($signupType) {
+      //$this->_formValues['activity_type_id'] = array();
+    
+      $activityTypes = CRM_Core_PseudoConstant::activityType(TRUE, FALSE, FALSE, 'name');
+      $signup = CRM_Utils_Array::key('Membership Renewal', $activityTypes);
+      $renew = CRM_Utils_Array::key('Membership Signup', $activityTypes);
+      
+      switch ($signupType) {
+        case 3: // signups and renewals
+          $this->_formValues['activity_type_id'][$renew] = 1;
+          $this->_defaults['activity_type_id'][$renew] = 1;
+        case 1: // signups only
+          $this->_formValues['activity_type_id'][$signup] = 1;
+          $this->_defaults['activity_type_id'][$signup] = 1;
+          break;
+          
+        case 2: // renewals only
+          $this->_formValues['activity_type_id'][$renew] = 1;
+          $this->_defaults['activity_type_id'][$renew] = 1;
+          break;
+      }
+    }
+    
+    $dateLow = CRM_Utils_Request::retrieve('dateLow', 'Positive',
+      CRM_Core_DAO::$_nullObject
+    );
+    
+    if ($dateLow) {
+      $this->_formValues['activity_date_low'] = $dateLow;
+      $this->_defaults['activity_date_low'] = $dateLow;
+    }
+    
+    $dateHigh = CRM_Utils_Request::retrieve('dateHigh', 'Positive',
+      CRM_Core_DAO::$_nullObject
+    );
+    
+    if ($dateHigh) {
+      // Activity date time assumes midnight at the beginning of the date
+      // This sets it to almost midnight at the end of the date
+      if ($dateHigh <= 99999999) {
+        $dateHigh = 1000000 * $dateHigh + 235959;
+      }
+      $this->_formValues['activity_date_high'] = $dateHigh;
+      $this->_defaults['activity_date_high'] = $dateHigh;
+    } 
   }
 
   function getFormValues() {

--- a/CRM/Activity/Form/Search.php
+++ b/CRM/Activity/Form/Search.php
@@ -396,6 +396,12 @@ class CRM_Activity_Form_Search extends CRM_Core_Form {
     if (!$this->_force) {
       return;
     }
+
+    $this->_formValues['activity_role'] = 1;
+    $this->_formValues['activity_contact_name'] = '';
+    $this->_defaults['activity_role'] = 1;
+    $this->_defaults['activity_contact_name'] = '';
+
     $status = CRM_Utils_Request::retrieve('status', 'String', $this);
     if ($status) {
       $this->_formValues['activity_status'] = $status;
@@ -431,10 +437,6 @@ class CRM_Activity_Form_Search extends CRM_Core_Form {
         $this->_single = TRUE;
       }
     }
-
-    if (!empty($this->_defaults)) {
-      $this->setDefaults($this->_defaults);
-    }
         
     // Added for membership search
     
@@ -446,8 +448,9 @@ class CRM_Activity_Form_Search extends CRM_Core_Form {
       //$this->_formValues['activity_type_id'] = array();
     
       $activityTypes = CRM_Core_PseudoConstant::activityType(TRUE, FALSE, FALSE, 'name');
-      $signup = CRM_Utils_Array::key('Membership Renewal', $activityTypes);
-      $renew = CRM_Utils_Array::key('Membership Signup', $activityTypes);
+
+      $renew = CRM_Utils_Array::key('Membership Renewal', $activityTypes);
+      $signup = CRM_Utils_Array::key('Membership Signup', $activityTypes);
       
       switch ($signupType) {
         case 3: // signups and renewals
@@ -465,28 +468,38 @@ class CRM_Activity_Form_Search extends CRM_Core_Form {
       }
     }
     
-    $dateLow = CRM_Utils_Request::retrieve('dateLow', 'Positive',
+    $dateLow = CRM_Utils_Request::retrieve('dateLow', 'String',
       CRM_Core_DAO::$_nullObject
     );
     
     if ($dateLow) {
+      $dateLow = date('m/d/Y', strtotime($dateLow));
+      $this->_formValues['activity_date_relative'] = 0;
+      $this->_defaults['activity_date_relative'] = 0;
       $this->_formValues['activity_date_low'] = $dateLow;
       $this->_defaults['activity_date_low'] = $dateLow;
     }
     
-    $dateHigh = CRM_Utils_Request::retrieve('dateHigh', 'Positive',
+    $dateHigh = CRM_Utils_Request::retrieve('dateHigh', 'String',
       CRM_Core_DAO::$_nullObject
     );
     
     if ($dateHigh) {
       // Activity date time assumes midnight at the beginning of the date
       // This sets it to almost midnight at the end of the date
-      if ($dateHigh <= 99999999) {
+   /*   if ($dateHigh <= 99999999) {
         $dateHigh = 1000000 * $dateHigh + 235959;
-      }
+      } */
+      $dateHigh = date('m/d/Y', strtotime($dateHigh));
+      $this->_formValues['activity_date_relative'] = 0;
+      $this->_defaults['activity_date_relative'] = 0;
       $this->_formValues['activity_date_high'] = $dateHigh;
       $this->_defaults['activity_date_high'] = $dateHigh;
     } 
+
+    if (!empty($this->_defaults)) {
+      $this->setDefaults($this->_defaults);
+    }
   }
 
   function getFormValues() {

--- a/CRM/Member/Page/DashBoard.php
+++ b/CRM/Member/Page/DashBoard.php
@@ -288,65 +288,65 @@ class CRM_Member_Page_DashBoard extends CRM_Core_Page {
 
     $totalCount['premonth']['new'] = array(
       'count' => $newCountPreMonth,
-      'url' => CRM_Utils_System::url('civicrm/activity/search',
-        "reset=1&force=1&signupType=1&dateLow=$preMonth&dateHigh=$preMonthEnd"
-      ),
+      //'url' => CRM_Utils_System::url('civicrm/activity/search',
+      //  "reset=1&force=1&signupType=1&dateLow=$preMonth&dateHigh=$preMonthEnd"
+      //),
     );
 
     $totalCount['premonth']['renew'] = array(
       'count' => $renewCountPreMonth,
-      'url' => CRM_Utils_System::url('civicrm/activity/search',
-        "reset=1&force=1&signupType=2&dateLow=$preMonth&dateHigh=$preMonthEnd"
-      ),
+      //'url' => CRM_Utils_System::url('civicrm/activity/search',
+      //  "reset=1&force=1&signupType=2&dateLow=$preMonth&dateHigh=$preMonthEnd"
+      //),
     );
 
     $totalCount['premonth']['total'] = array(
       'count' => $totalCountPreMonth,
-      'url' => CRM_Utils_System::url('civicrm/activity/search',
-        "reset=1&force=1&signupType=3&dateLow=$preMonth&dateHigh=$preMonthEnd"
-      ),
+      //'url' => CRM_Utils_System::url('civicrm/activity/search',
+      //  "reset=1&force=1&signupType=3&dateLow=$preMonth&dateHigh=$preMonthEnd"
+      //),
     );
 
     $totalCount['month']['new'] = array(
       'count' => $newCountMonth,
-      'url' => CRM_Utils_System::url('civicrm/activity/search',
-        "reset=1&force=1&signupType=1&dateLow=$monthStart&dateHigh=$ymd"
-      ),
+      //'url' => CRM_Utils_System::url('civicrm/activity/search',
+      //  "reset=1&force=1&signupType=1&dateLow=$monthStart&dateHigh=$ymd"
+      //),
     );
 
     $totalCount['month']['renew'] = array(
       'count' => $renewCountMonth,
-      'url' => CRM_Utils_System::url('civicrm/activity/search',
-        "reset=1&force=1&signupType=2&dateLow=$monthStart&dateHigh=$ymd"
-      ),
+      //'url' => CRM_Utils_System::url('civicrm/activity/search',
+      //  "reset=1&force=1&signupType=2&dateLow=$monthStart&dateHigh=$ymd"
+      //),
     );
 
     $totalCount['month']['total'] = array(
       'count' => $totalCountMonth,
-      'url' => CRM_Utils_System::url('civicrm/activity/search',
-        "reset=1&force=1&signupType=3&dateLow=$monthStart&dateHigh=$ymd"
-      ),
+      //'url' => CRM_Utils_System::url('civicrm/activity/search',
+      //  "reset=1&force=1&signupType=3&dateLow=$monthStart&dateHigh=$ymd"
+      //),
     );
 
     $totalCount['year']['new'] = array(
       'count' => $newCountYear,
-      'url' => CRM_Utils_System::url('civicrm/activity/search',
-        "reset=1&force=1&signupType=1&dateLow=$yearStart&dateHigh=$ymd"
-      ),
+      //'url' => CRM_Utils_System::url('civicrm/activity/search',
+      //  "reset=1&force=1&signupType=1&dateLow=$yearStart&dateHigh=$ymd"
+      //),
     );
 
     $totalCount['year']['renew'] = array(
       'count' => $renewCountYear,
-      'url' => CRM_Utils_System::url('civicrm/activity/search',
-        "reset=1&force=1&signupType=2&dateLow=$yearStart&dateHigh=$ymd"
-      ),
+      //'url' => CRM_Utils_System::url('civicrm/activity/search',
+      //  "reset=1&force=1&signupType=2&dateLow=$yearStart&dateHigh=$ymd"
+      //),
     );
 
     $totalCount['year']['total'] = array(
       'count' => $totalCountYear,
-      'url' => CRM_Utils_System::url('civicrm/activity/search',
-        "reset=1&force=1&signupType=3&dateLow=$yearStart&dateHigh=$ymd"
-      ),
+      //'url' => CRM_Utils_System::url('civicrm/activity/search',
+      //  "reset=1&force=1&signupType=3&dateLow=$yearStart&dateHigh=$ymd"
+      //),
     );
 
     $totalCount['current']['total'] = array(
@@ -377,7 +377,7 @@ class CRM_Member_Page_DashBoard extends CRM_Core_Page {
     //LCD add owner values
     $totalCount['premonth_owner']['premonth_owner'] = array(
       'count' => $totalCountPreMonth_owner,
-      'url' => CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&status=$status&start=$preMonth&end=$preMonthEnd&owner=1"),
+    //  'url' => CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&status=$status&start=$preMonth&end=$preMonthEnd&owner=1"),
     );
 
     $totalCount['month_owner']['month_owner'] = array(
@@ -412,7 +412,7 @@ class CRM_Member_Page_DashBoard extends CRM_Core_Page {
     $this->assign('totalCount', $totalCount);
     $this->assign('month', date('F', $monthStartTs));
     $this->assign('year', date('Y', $monthStartTs));
-    $this->assign('premonth', date('F', $preMonthYear));
+    $this->assign('premonth', date('F', strtotime($preMonth)));
     $this->assign('currentMonth', date('F'));
     $this->assign('currentYear', date('Y'));
     $this->assign('isCurrent', $isCurrentMonth);

--- a/templates/CRM/Member/Page/DashBoard.tpl
+++ b/templates/CRM/Member/Page/DashBoard.tpl
@@ -58,41 +58,96 @@
 
     {foreach from=$membershipSummary item=row}
         <tr>
-      <td><strong>{$row.month.total.name}</strong></td>
-            {if $preMonth}
-                <td class="label"><a href="{$row.premonth.new.url}" title="view details">{$row.premonth.new.count}</a></td>
-                <td class="label"><a href="{$row.premonth.renew.url}" title="view details">{$row.premonth.renew.count}</a>
-    </td>
-                <td class="label">
-        <a href="{$row.premonth.total.url}" title="view details">{$row.premonth.total.count}</a>&nbsp;
-        [ <a href="{$row.premonth_owner.premonth_owner.url}" title="view details">
-        {$row.premonth_owner.premonth_owner.count}</a> ]
-    </td>
-            {/if}
-
-      <td class="label"><a href="{$row.month.new.url}" title="view details">{$row.month.new.count}</a></td>
-            <td class="label"><a href="{$row.month.renew.url}" title="view details">{$row.month.renew.count}</a></td>
-            <td class="label"><a href="{$row.month.total.url}" title="view details">{$row.month.total.count}</a>&nbsp;
-          [ <a href="{$row.month_owner.month_owner.url}" title="view details">
-    {$row.month_owner.month_owner.count}</a> ]
-      </td>
-
-            <td class="label"><a href="{$row.year.new.url}" title="view details">{$row.year.new.count}</a></td>
-            <td class="label"><a href="{$row.year.renew.url}" title="view details">{$row.year.renew.count}</a></td>
-            <td class="label"><a href="{$row.year.total.url}" title="view details">{$row.year.total.count}</a>&nbsp;
-        [ <a href="{$row.year_owner.year_owner.url}" title="view details">{$row.year_owner.year_owner.count}</a> ]
-      </td>
+            <td><strong>{$row.month.total.name}</strong></td>
+          {if $preMonth}
+            <td class="label">
+              {if $row.premonth.new.url}<a href="{$row.premonth.new.url}" title="view details">{$row.premonth.new.count}</a>
+              {else}{$row.premonth.new.count}{/if}
+            </td>
+            <td class="label">
+              {if $row.premonth.renew.url}<a href="{$row.premonth.renew.url}" title="view details">{$row.premonth.renew.count}</a>
+              {else}{$row.premonth.renew.count}{/if}
+            </td>
+            <td class="label">
+              {if $row.premonth.total.url}
+                <a href="{$row.premonth.total.url}" title="view details">{$row.premonth.total.count}</a>
+              {else}
+                {$row.premonth.total.count}
+              {/if}&nbsp;[ 
+              {if $row.premonth_owner.premonth_owner.url}
+                <a href="{$row.premonth_owner.premonth_owner.url}" title="view details">{$row.premonth_owner.premonth_owner.count}</a>
+              {else}
+                {$row.premonth_owner.premonth_owner.count}
+              {/if}]
+            </td>
+          {/if}
 
             <td class="label">
-                {if $isCurrent}
-        <a href="{$row.current.total.url}" title="view details">{$row.current.total.count}</a>&nbsp;
-                    [ <a href="{$row.current_owner.current_owner.url}" title="view details">
-        {$row.current_owner.current_owner.count}</a> ]
+              {if $row.month.new.url}<a href="{$row.month.new.url}" title="view details">{$row.month.new.count}</a>
+              {else}{$row.month.new.count}{/if}
+            </td>
+            <td class="label">
+              {if $row.month.renew.url}<a href="{$row.month.renew.url}" title="view details">{$row.month.renew.count}</a>
+              {else}{$row.month.renew.count}{/if}
+            </td>
+            <td class="label">
+              {if $row.month.total.url}
+                <a href="{$row.month.total.url}" title="view details">{$row.month.total.count}</a>
+              {else}
+                {$row.month.total.count}
+              {/if}&nbsp;[ 
+              {if $row.month_owner.month_owner.url}
+                <a href="{$row.month_owner.month_owner.url}" title="view details">{$row.month_owner.month_owner.count}</a>
+              {else}
+                {$row.month_owner.month_owner.count}
+              {/if}]
+            </td>
+
+            <td class="label">
+              {if $row.year.new.url}<a href="{$row.year.new.url}" title="view details">{$row.year.new.count}</a>
+              {else}{$row.year.new.count}{/if}
+            </td>
+            <td class="label">
+              {if $row.year.renew.url}<a href="{$row.year.renew.url}" title="view details">{$row.year.renew.count}</a>
+              {else}{$row.year.renew.count}{/if}
+            </td>
+            <td class="label">
+              {if $row.year.total.url}
+                <a href="{$row.year.total.url}" title="view details">{$row.year.total.count}</a>
+              {else}
+                {$row.year.total.count}
+              {/if}&nbsp;[ 
+              {if $row.year_owner.year_owner.url}
+                <a href="{$row.year_owner.year_owner.url}" title="view details">{$row.year_owner.year_owner.count}</a>
+              {else}
+                {$row.year_owner.year_owner.count}
+              {/if}]
+            </td>
+
+            <td class="label">
+              {if $isCurrent}
+                {if $row.current.total.url}
+                  <a href="{$row.current.total.url}" title="view details">{$row.current.total.count}</a>
                 {else}
-                    <a href="{$row.total.total.url}" title="view details">{$row.total.total.count}</a>&nbsp;
-                    [ <a href="{$row.total_owner.total_owner.url}" title="view details">
-        {$row.total_owner.total_owner.count}</a> ]
-                {/if}
+                  {$row.current.total.count}
+                {/if}&nbsp;[
+                {if $row.current_owner.current_owner.url}
+                  <a href="{$row.current_owner.current_owner.url}" title="view details">{$row.current_owner.current_owner.count}</a>
+                {else}
+                  {$row.current_owner.current_owner.count}
+                {/if} ]
+              {else}
+                {if $row.total.total.url}
+                  <a href="{$row.total.total.url}" title="view details">{$row.total.total.count}</a>
+                {else}
+                  {$row.total.total.count}
+                {/if}&nbsp;[
+                {if $row.total_owner.total_owner.url}
+                  <a href="{$row.total_owner.total_owner.url}" title="view details">{$row.total_owner.total_owner.count}</a>
+                {else}
+                  {$row.total_owner.total_owner.count}
+                {/if} ]
+              {/if}
             </td> {* member/search?reset=1&force=1&membership_type_id=1&current=1 *}
         </tr>
     {/foreach}
@@ -106,7 +161,13 @@
        <a href="{$totalCount.premonth.renew.url}" title="view details">{$totalCount.premonth.renew.count}</a></td>
            <td class="label">
        <a href="{$totalCount.premonth.total.url}" title="view details">{$totalCount.premonth.total.count}</a>
-       [ <a href="{$totalCount.premonth_owner.premonth_owner.url}" title="view details">{$totalCount.premonth_owner.premonth_owner.count}</a> ]
+       [
+       {if $totalCount.premonth_owner.premonth_owner.url}
+        <a href="{$totalCount.premonth_owner.premonth_owner.url}" title="view details">{$totalCount.premonth_owner.premonth_owner.count}</a>
+       {else}
+         {$totalCount.premonth_owner.premonth_owner.count}
+       {/if}
+       ]
      </td>
         {/if}
 
@@ -116,8 +177,13 @@
     <a href="{$totalCount.month.renew.url}" title="view details">{$totalCount.month.renew.count}</a></td>
         <td class="label">
     <a href="{$totalCount.month.total.url}" title="view details">{$totalCount.month.total.count}</a>
-    [ <a href="{$totalCount.month_owner.month_owner.url}" title="view details">
-    {$totalCount.month_owner.month_owner.count}</a> ]
+       [
+       {if $totalCount.month_owner.month_owner.url}
+        <a href="{$totalCount.month_owner.month_owner.url}" title="view details">{$totalCount.month_owner.month_owner.count}</a>
+       {else}
+         {$totalCount.month_owner.month_owner.count}
+       {/if}
+       ]
   </td>
         <td class="label">
     <a href="{$totalCount.year.new.url}" title="view details">{$totalCount.year.new.count}</a></td>
@@ -125,8 +191,13 @@
     <a href="{$totalCount.year.renew.url}" title="view details">{$totalCount.year.renew.count}</a></td>
         <td class="label">
     <a href="{$totalCount.year.total.url}" title="view details">{$totalCount.year.total.count}</a>
-    [ <a href="{$totalCount.year_owner.year_owner.url}" title="view details">{$totalCount.year_owner.year_owner.count}
-    </a> ]
+       [
+       {if $totalCount.year_owner.year_owner.url}
+        <a href="{$totalCount.year_owner.year_owner.url}" title="view details">{$totalCount.year_owner.year_owner.count}</a>
+       {else}
+         {$totalCount.year_owner.year_owner.count}
+       {/if}
+       ]
   </td>
 
         <td class="label">

--- a/templates/CRM/Member/Page/DashBoard.tpl
+++ b/templates/CRM/Member/Page/DashBoard.tpl
@@ -155,64 +155,96 @@
     <tr class="columnfooter">
         <td><strong>{ts}Totals (all types){/ts}</strong></td>
         {if $preMonth}
-           <td class="label">
-       <a href="{$totalCount.premonth.new.url}" title="view details">{$totalCount.premonth.new.count}</a></td>
-           <td class="label">
-       <a href="{$totalCount.premonth.renew.url}" title="view details">{$totalCount.premonth.renew.count}</a></td>
-           <td class="label">
-       <a href="{$totalCount.premonth.total.url}" title="view details">{$totalCount.premonth.total.count}</a>
-       [
-       {if $totalCount.premonth_owner.premonth_owner.url}
-        <a href="{$totalCount.premonth_owner.premonth_owner.url}" title="view details">{$totalCount.premonth_owner.premonth_owner.count}</a>
-       {else}
-         {$totalCount.premonth_owner.premonth_owner.count}
-       {/if}
-       ]
-     </td>
+            <td class="label">
+              {if $totalCount.premonth.new.url}<a href="{$totalCount.premonth.new.url}" title="view details">{$totalCount.premonth.new.count}</a>
+              {else}{$totalCount.premonth.new.count}{/if}
+            </td>
+            <td class="label">
+              {if $totalCount.premonth.renew.url}<a href="{$totalCount.premonth.renew.url}" title="view details">{$totalCount.premonth.renew.count}</a>
+              {else}{$totalCount.premonth.renew.count}{/if}
+            </td>
+            <td class="label">
+              {if $totalCount.premonth.total.url}
+                <a href="{$totalCount.premonth.total.url}" title="view details">{$totalCount.premonth.total.count}</a>
+              {else}
+                {$totalCount.premonth.total.count}
+              {/if}&nbsp;[ 
+              {if $totalCount.premonth_owner.premonth_owner.url}
+                <a href="{$totalCount.premonth_owner.premonth_owner.url}" title="view details">{$totalCount.premonth_owner.premonth_owner.count}</a>
+              {else}
+                {$totalCount.premonth_owner.premonth_owner.count}
+              {/if}]
+            </td>
         {/if}
 
-        <td class="label">
-    <a href="{$totalCount.month.new.url}" title="view details">{$totalCount.month.new.count}</a></td>
-        <td class="label">
-    <a href="{$totalCount.month.renew.url}" title="view details">{$totalCount.month.renew.count}</a></td>
-        <td class="label">
-    <a href="{$totalCount.month.total.url}" title="view details">{$totalCount.month.total.count}</a>
-       [
-       {if $totalCount.month_owner.month_owner.url}
-        <a href="{$totalCount.month_owner.month_owner.url}" title="view details">{$totalCount.month_owner.month_owner.count}</a>
-       {else}
-         {$totalCount.month_owner.month_owner.count}
-       {/if}
-       ]
-  </td>
-        <td class="label">
-    <a href="{$totalCount.year.new.url}" title="view details">{$totalCount.year.new.count}</a></td>
-        <td class="label">
-    <a href="{$totalCount.year.renew.url}" title="view details">{$totalCount.year.renew.count}</a></td>
-        <td class="label">
-    <a href="{$totalCount.year.total.url}" title="view details">{$totalCount.year.total.count}</a>
-       [
-       {if $totalCount.year_owner.year_owner.url}
-        <a href="{$totalCount.year_owner.year_owner.url}" title="view details">{$totalCount.year_owner.year_owner.count}</a>
-       {else}
-         {$totalCount.year_owner.year_owner.count}
-       {/if}
-       ]
-  </td>
+            <td class="label">
+              {if $totalCount.month.new.url}<a href="{$totalCount.month.new.url}" title="view details">{$totalCount.month.new.count}</a>
+              {else}{$totalCount.month.new.count}{/if}
+            </td>
+            <td class="label">
+              {if $totalCount.month.renew.url}<a href="{$totalCount.month.renew.url}" title="view details">{$totalCount.month.renew.count}</a>
+              {else}{$totalCount.month.renew.count}{/if}
+            </td>
+            <td class="label">
+              {if $totalCount.month.total.url}
+                <a href="{$totalCount.month.total.url}" title="view details">{$totalCount.month.total.count}</a>
+              {else}
+                {$totalCount.month.total.count}
+              {/if}&nbsp;[ 
+              {if $totalCount.month_owner.month_owner.url}
+                <a href="{$totalCount.month_owner.month_owner.url}" title="view details">{$totalCount.month_owner.month_owner.count}</a>
+              {else}
+                {$totalCount.month_owner.month_owner.count}
+              {/if}]
+            </td>
 
-        <td class="label">
-            {if $isCurrent}
-    <a href="{$row.total.total.url}" title="view details">{$totalCount.current.total.count}</a>&nbsp;
-    [ <a href="{$row.total_owner.total_owner.url}" title="view details">
-    {$totalCount.current_owner.current_owner.count}</a> ]
+            <td class="label">
+              {if $totalCount.year.new.url}<a href="{$totalCount.year.new.url}" title="view details">{$totalCount.year.new.count}</a>
+              {else}{$totalCount.year.new.count}{/if}
+            </td>
+            <td class="label">
+              {if $totalCount.year.renew.url}<a href="{$totalCount.year.renew.url}" title="view details">{$totalCount.year.renew.count}</a>
+              {else}{$totalCount.year.renew.count}{/if}
+            </td>
+            <td class="label">
+              {if $totalCount.year.total.url}
+                <a href="{$totalCount.year.total.url}" title="view details">{$totalCount.year.total.count}</a>
+              {else}
+                {$totalCount.year.total.count}
+              {/if}&nbsp;[ 
+              {if $totalCount.year_owner.year_owner.url}
+                <a href="{$totalCount.year_owner.year_owner.url}" title="view details">{$totalCount.year_owner.year_owner.count}</a>
+              {else}
+                {$totalCount.year_owner.year_owner.count}
+              {/if}]
+            </td>
 
-            {else}
-    <a href="{$totalCount.total.url}" title="view details">{$totalCount.total.total.count}</a>&nbsp;
-    [ <a href="{$totalCount.total_owner.total_owner.url}" title="view details">
-    {$totalCount.total_owner.total_owner.count}</a> ]
+            <td class="label">
+              {if $isCurrent}
+                {if $row.total.total.url}
+                  <a href="{$row.total.total.url}" title="view details">{$totalCount.current.total.count}</a>
+                {else}
+                  {$totalCount.current.total.count}
+                {/if}&nbsp;[
+                {if $row.total_owner.total_owner.url}
+                  <a href="{$row.total_owner.total_owner.url}" title="view details">{$totalCount.current_owner.current_owner.count}</a>
+                {else}
+                  {$totalCount.current_owner.current_owner.count}
+                {/if} ]
+              {else}
+                {if $totalCount.total.url}
+                  <a href="{$totalCount.total.url}" title="view details">{$totalCount.total.total.count}</a>
+                {else}
+                  {$totalCount.total.total.count}
+                {/if}&nbsp;[
+                {if $totalCount.total_owner.total_owner.url}
+                  <a href="{$totalCount.total_owner.total_owner.url}" title="view details">{$totalCount.total_owner.total_owner.count}</a>
+                {else}
+                  {$totalCount.total_owner.total_owner.count}
+                {/if} ]
+              {/if}
+            </td>
 
-            {/if}
-        </td> {* member/search?reset=1&force=1&current=1 *}
     </tr>
     <tr><td colspan='11'>
       Primary member counts (those who "own" the membership rather than receiving via relationship) are in [brackets].


### PR DESCRIPTION
This fixes the membership dashboard counts for CRM-12500.  However, in doing so, it removes all links to searches.  The rationale is that no existing search accurately displays the number of new or renewing members in a given period.  The membership search shows the original join date and the start date of the contiguous membership period.  The activity search should theoretically work for displaying membership signup and membership renewal activities, but it isn't working for that, even in a plain vanilla search (this may be a separate problem).

Long run, there should be a search on the membership log table, presumably from the membership search.  In the meantime, I think it's preferable to give accurate counts without links than to give inaccurate counts with links to inaccurate search results.
