### PR TITLE
CRM-12737 - Return a CiviCRM-looking error if we hit a cURL error.

### DIFF
--- a/api/class.api.php
+++ b/api/class.api.php
@@ -140,6 +140,13 @@ class civicrm_api3 {
 
       //execute post
       $result = curl_exec($ch);
+      // CiviCRM expects to get back a CiviCRM error object.
+      if (curl_errno($ch)) {
+          $res = new stdClass;
+          $res->is_error = 1;
+          $res->error = array('cURL error' => curl_error($ch));
+          return $res;
+      }      
       curl_close($ch);
       return json_decode($result);
       // not good, all in get when should be in post.


### PR DESCRIPTION
Handle cURL errors by synthesising a CiviCRM error object. 

This is API so we can't depend on having CRM_Core_Error::createError() available.
