### PR TITLE
CRM-12738 - Handle ampersands in REST API params.

### DIFF
--- a/api/class.api.php
+++ b/api/class.api.php
@@ -123,8 +123,10 @@ class civicrm_api3 {
     echo "Calling static method '$name' " . implode(', ', $arguments) . "\n";
   }
 
-  function remoteCall($entity, $action, $params = array(
-    )) {
+  function remoteCall($entity, $action, $params = array()) {
+    foreach ($params as &$param) {
+      $param = str_replace('&', urlencode('&'), $param);
+    }   
     $fields = "key={$this->key}&api_key={$this->api_key}";
     $query = $this->uri . "&entity=$entity&action=$action";
     foreach ($params as $k => $v) {


### PR DESCRIPTION
Should be reviewed in case we need to pick up other special characters. Pretty sure I recall testing a more general solution and finding that I needed to _not_ just urlencode() the values in $params.
