### PR TITLE
CRM-12741 : did event template handing while price set deletion i.e appr...

### DIFF
--- a/CRM/Admin/Page/AJAX.php
+++ b/CRM/Admin/Page/AJAX.php
@@ -93,6 +93,7 @@ class CRM_Admin_Page_AJAX {
             $comps = array(
               'Event' => 'civicrm_event',
               'Contribution' => 'civicrm_contribution_page',
+              'EventTemplate' => 'civicrm_event_template'
             );
             $contexts = array();
             foreach ($comps as $name => $table) {

--- a/CRM/Price/BAO/Set.php
+++ b/CRM/Price/BAO/Set.php
@@ -201,7 +201,7 @@ WHERE     cpf.price_set_id = %1";
       switch ($table) {
         case 'civicrm_event':
           $ids = implode(',', $entities);
-          $queryString = "SELECT ce.id as id, ce.title as title, ce.is_public as isPublic, ce.start_date as startDate, ce.end_date as endDate, civicrm_option_value.label as eventType
+          $queryString = "SELECT ce.id as id, ce.title as title, ce.is_public as isPublic, ce.start_date as startDate, ce.end_date as endDate, civicrm_option_value.label as eventType, ce.is_template as isTemplate, ce.template_title as templateTitle
 FROM       civicrm_event ce
 LEFT JOIN  civicrm_option_value ON
            ( ce.event_type_id = civicrm_option_value.value )
@@ -209,16 +209,22 @@ LEFT JOIN  civicrm_option_group ON
            ( civicrm_option_group.id = civicrm_option_value.option_group_id )
 WHERE
          civicrm_option_group.name = 'event_type' AND
-           ( ce.is_template IS NULL OR ce.is_template = 0) AND
            ce.id IN ($ids) AND
            ce.is_active = 1;";
           $crmDAO = CRM_Core_DAO::executeQuery($queryString);
           while ($crmDAO->fetch()) {
-            $usedBy[$table][$crmDAO->id]['title'] = $crmDAO->title;
-            $usedBy[$table][$crmDAO->id]['eventType'] = $crmDAO->eventType;
-            $usedBy[$table][$crmDAO->id]['startDate'] = $crmDAO->startDate;
-            $usedBy[$table][$crmDAO->id]['endDate'] = $crmDAO->endDate;
-            $usedBy[$table][$crmDAO->id]['isPublic'] = $crmDAO->isPublic;
+            if ($crmDAO->isTemplate) {
+              $usedBy['civicrm_event_template'][$crmDAO->id]['title'] = $crmDAO->templateTitle;
+              $usedBy['civicrm_event_template'][$crmDAO->id]['eventType'] = $crmDAO->eventType;
+              $usedBy['civicrm_event_template'][$crmDAO->id]['isPublic'] = $crmDAO->isPublic;
+            }
+            else {
+              $usedBy[$table][$crmDAO->id]['title'] = $crmDAO->title;
+              $usedBy[$table][$crmDAO->id]['eventType'] = $crmDAO->eventType;
+              $usedBy[$table][$crmDAO->id]['startDate'] = $crmDAO->startDate;
+              $usedBy[$table][$crmDAO->id]['endDate'] = $crmDAO->endDate;
+              $usedBy[$table][$crmDAO->id]['isPublic'] = $crmDAO->isPublic;
+            }
           }
           break;
 

--- a/CRM/Price/Page/Field.php
+++ b/CRM/Price/Page/Field.php
@@ -248,6 +248,7 @@ class CRM_Price_Page_Field extends CRM_Core_Page {
       $comps = array(
         'Event' => 'civicrm_event',
         'Contribution' => 'civicrm_contribution_page',
+        'EventTemplate' => 'civicrm_event_template'
       );
       $priceSetContexts = array();
       foreach ($comps as $name => $table) {

--- a/CRM/Price/Page/Set.php
+++ b/CRM/Price/Page/Set.php
@@ -181,6 +181,7 @@ class CRM_Price_Page_Set extends CRM_Core_Page {
           $comps = array(
             'Event' => 'civicrm_event',
             'Contribution' => 'civicrm_contribution_page',
+            'EventTemplate' => 'civicrm_event_template'
           );
           $priceSetContexts = array();
           foreach ($comps as $name => $table) {

--- a/templates/CRM/Price/Page/Field.tpl
+++ b/templates/CRM/Price/Page/Field.tpl
@@ -34,10 +34,10 @@
     <div id="price_set_used_by" class="messages status no-popup">
       <div class="icon inform-icon"></div>
         {if $action eq 8}
-            {ts 1=$usedPriceSetTitle}Unable to delete the '%1' Price Field - it is currently in use by one or more active events or contribution pages or contributions.{/ts}
+            {ts 1=$usedPriceSetTitle}Unable to delete the '%1' Price Field - it is currently in use by one or more active events or contribution pages or contributions  or event templates.{/ts}
          {/if}
 
-        {if $usedBy.civicrm_event or $usedBy.civicrm_contribution_page}
+        {if $usedBy.civicrm_event or $usedBy.civicrm_contribution_page or $usedBy.civicrm_event_template}
             {include file="CRM/Price/Page/table.tpl"}
         {/if}
     </div>

--- a/templates/CRM/Price/Page/Set.tpl
+++ b/templates/CRM/Price/Page/Set.tpl
@@ -39,10 +39,10 @@
     <div id="price_set_used_by" class="messages status no-popup">
        <div class="icon inform-icon"></div>
         {if $action eq 8}
-            {ts 1=$usedPriceSetTitle}Unable to delete the '%1' price set - it is currently in use by one or more active events or contribution pages or contributions.{/ts}
+            {ts 1=$usedPriceSetTitle}Unable to delete the '%1' price set - it is currently in use by one or more active events or contribution pages or contributions or event templates.{/ts}
         {/if}
 
-      {if $usedBy.civicrm_event or $usedBy.civicrm_contribution_page}
+      {if $usedBy.civicrm_event or $usedBy.civicrm_contribution_page or $usedBy.civicrm_event_template}
             {include file="CRM/Price/Page/table.tpl"}
         {/if}
     </div>

--- a/templates/CRM/Price/Page/table.tpl
+++ b/templates/CRM/Price/Page/table.tpl
@@ -72,4 +72,26 @@
       {/foreach}
 </table>
 {/if}
+{if $context EQ "EventTemplate"}
+  {if $action eq 8}
+    {ts}If you no longer want to use this price set, click the event template title below, and modify the fees for that event.{/ts}
+  {else}
+    {ts}This price set is used by the event template(s) listed below. Click the event template title to change or remove the price set.{/ts}
+  {/if}
+  <br /><br />
+<table class="report">
+  <thead class="sticky">
+    <th scope="col">{ts}Event Template Name{/ts}</th>
+    <th scope="col">{ts}Type{/ts}</th>
+    <th scope="col">{ts}Public{/ts}</th>
+  </thead>
+  {foreach from=$usedBy.civicrm_event_template item=eventTemplate key=id}
+    <tr>
+      <td><a href="{crmURL p="civicrm/event/manage/fee" q="action=update&reset=1&id=`$id`"}" title="{ts}Change or remove the price set used for this event template.{/ts}">{$eventTemplate.title}</a></td>
+      <td>{$eventTemplate.eventType}</td>
+      <td>{if $eventTemplate.isPublic}{ts}Yes{/ts}{else}{ts}No{/ts}{/if}</td>
+    </tr>
+  {/foreach}
+</table>
+{/if}
 {/foreach}


### PR DESCRIPTION
when a price set is configured for a event or contribution, and if we try deleting it, it does not get deleted and throws a messge to user showing the entities (event / contribution) attached to it in proper format with links for editing the fee / amount section of it.

the issue :
if a price set is used for a event template, and that is being deleted by user, no message is shown to user, and civi attempts to delete the price set which throws a DB contraint violation error as civicrm_price_set_entity foreign key is linked to that price set.

handled civicrm_event_template while price set getting deleted just like as event or contribution and a proper message is shown to user.
