### PR TITLE
CRM-12747 : component access permission defining way for end developer

### DIFF
--- a/CRM/Contact/Form/Search/Custom.php
+++ b/CRM/Contact/Form/Search/Custom.php
@@ -81,6 +81,12 @@ class CRM_Contact_Form_Search_Custom extends CRM_Contact_Form_Search {
 
     // instantiate the new class
     $this->_customClass = new $this->_customSearchClass( $this->_formValues );
+
+    // CRM-12747
+    if (isset($this->_customClass->_permissionedComponent) &&
+      !self::isPermissioned($this->_customClass->_permissionedComponent)) {
+      CRM_Utils_System::permissionDenied();
+    }
   }
 
   function setDefaultValues() {
@@ -132,5 +138,23 @@ class CRM_Contact_Form_Search_Custom extends CRM_Contact_Form_Search {
   public function getTitle() {
     return ts('Custom Search');
   }
-}
 
+  function isPermissioned($components) {
+    if (empty($components)) {
+      return TRUE;
+    }
+    if (is_array($components)) {
+      foreach ($components as $component) {
+        if (!CRM_Core_Permission::access($component)) {
+          return FALSE;
+        }
+      }
+    }
+    else {
+      if (!CRM_Core_Permission::access($components)) {
+        return FALSE;
+      }
+    }
+    return TRUE;
+  }
+}

--- a/CRM/Contact/Form/Search/Custom/ContribSYBNT.php
+++ b/CRM/Contact/Form/Search/Custom/ContribSYBNT.php
@@ -34,8 +34,12 @@
  */
 class CRM_Contact_Form_Search_Custom_ContribSYBNT implements CRM_Contact_Form_Search_Interface {
 
-  protected $_formValues; function __construct(&$formValues) {
+  protected $_formValues;
+  public $_permissionedComponent;
+
+  function __construct(&$formValues) {
     $this->_formValues = $formValues;
+    $this->_permissionedComponent = 'CiviContribute';
 
     $this->_columns = array(
       ts('Contact Id') => 'contact_id',

--- a/CRM/Contact/Form/Search/Custom/ContributionAggregate.php
+++ b/CRM/Contact/Form/Search/Custom/ContributionAggregate.php
@@ -34,18 +34,24 @@
  */
 class CRM_Contact_Form_Search_Custom_ContributionAggregate implements CRM_Contact_Form_Search_Interface {
 
-  protected $_formValues; function __construct(&$formValues) {
-    $this->_formValues = $formValues;
+  protected $_formValues;
+  public $_permissionedComponent;
 
+  function __construct(&$formValues) {
+    $this->_formValues = $formValues;
     /**
      * Define the columns for search result rows
      */
+
     $this->_columns = array(
       ts('Contact Id') => 'contact_id',
       ts('Name') => 'sort_name',
       ts('Donation Count') => 'donation_count',
       ts('Donation Amount') => 'donation_amount',
     );
+
+    // define component access permission needed
+    $this->_permissionedComponent = 'CiviContribute';
   }
 
   function buildForm(&$form) {

--- a/CRM/Contact/Form/Search/Custom/EventAggregate.php
+++ b/CRM/Contact/Form/Search/Custom/EventAggregate.php
@@ -34,8 +34,12 @@
  */
 class CRM_Contact_Form_Search_Custom_EventAggregate extends CRM_Contact_Form_Search_Custom_Base implements CRM_Contact_Form_Search_Interface {
 
-  protected $_formValues; function __construct(&$formValues) {
+  protected $_formValues;
+  public $_permissionedComponent;
+
+  function __construct(&$formValues) {
     $this->_formValues = $formValues;
+    $this->_permissionedComponent = array('CiviContribute', 'CiviEvent');
 
     /**
      * Define the columns for search result rows

--- a/CRM/Contact/Form/Search/Custom/PriceSet.php
+++ b/CRM/Contact/Form/Search/Custom/PriceSet.php
@@ -36,7 +36,10 @@ class CRM_Contact_Form_Search_Custom_PriceSet extends CRM_Contact_Form_Search_Cu
 
   protected $_eventID = NULL;
 
-  protected $_tableName = NULL; function __construct(&$formValues) {
+  protected $_tableName = NULL;
+  public $_permissionedComponent;
+
+  function __construct(&$formValues) {
     parent::__construct($formValues);
 
     $this->_eventID = CRM_Utils_Array::value('event_id',
@@ -47,9 +50,11 @@ class CRM_Contact_Form_Search_Custom_PriceSet extends CRM_Contact_Form_Search_Cu
 
     if ($this->_eventID) {
       $this->buildTempTable();
-
       $this->fillTable();
     }
+
+    // define component access permission needed
+    $this->_permissionedComponent = 'CiviEvent';
   }
 
   function __destruct() {

--- a/CRM/Contact/Form/Search/Custom/TagContributions.php
+++ b/CRM/Contact/Form/Search/Custom/TagContributions.php
@@ -34,8 +34,12 @@
  */
 class CRM_Contact_Form_Search_Custom_TagContributions implements CRM_Contact_Form_Search_Interface {
 
-  protected $_formValues; function __construct(&$formValues) {
+  protected $_formValues;
+  public $_permissionedComponent;
+
+  function __construct(&$formValues) {
     $this->_formValues = $formValues;
+    $this->_permissionedComponent = 'CiviContribute';
 
     /**
      * Define the columns for search result rows


### PR DESCRIPTION
defined a optional property, so that if any end developer wants its search based on certain components, can define its name and if one doesn't want, don't define it.

used CRM_Core_Permission::access for this check.
