### PR TITLE
php 5.4, notice fixes

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -195,6 +195,7 @@ class CRM_Report_Form extends CRM_Core_Form {
   protected $_sections = NULL;
   protected $_autoIncludeIndexedFieldsAsOrderBys = 0;
   protected $_absoluteUrl = FALSE;
+  protected $_grandFlag   = FALSE;
 
   /**
    * Flag to indicate if result-set is to be stored in a class variable which could be retrieved using getResultSet() method.
@@ -1614,7 +1615,6 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
     }
     $lastRow = array_pop($rows);
 
-    $this->_grandFlag = FALSE;
     foreach ($this->_columnHeaders as $fld => $val) {
       if (!in_array($fld, $this->_statFields)) {
         if (!$this->_grandFlag) {

--- a/CRM/Report/Form/Contribute/Summary.php
+++ b/CRM/Report/Form/Contribute/Summary.php
@@ -123,7 +123,7 @@ class CRM_Report_Form_Contribute_Summary extends CRM_Report_Form {
         'fields' =>
         array(
           'contribution_source' => array('title' => ts('Source'),
-      ),
+          ),
           'currency' =>
           array('required' => TRUE,
             'no_display' => TRUE,
@@ -227,7 +227,6 @@ class CRM_Report_Form_Contribute_Summary extends CRM_Report_Form {
         'operatorType' => CRM_Report_Form::OP_MULTISELECT,
         'options' => $this->activeCampaigns,
       );
-      $this->_columns['civicrm_contribution']['grouping']['campaign_id'] = 'contri-fields';
       $this->_columns['civicrm_contribution']['group_bys']['campaign_id'] = array('title' => ts('Campaign'));
     }
 


### PR DESCRIPTION
```
Warning: Illegal string offset 'campaign_id' in CRM_Report_Form_Contribute_Summary->__construct() (line 227 of /home/lobo/www/drupal-7.15/sites/crm_43/modules/civicrm/CRM/Report/Form/Contribute/Summary.php).
Notice: Undefined property: CRM_Report_Form_Contribute_Summary::$_grandFlag in CRM_Report_Form->statistics() (line 2193 of/home/lobo/www/drupal-7.15/sites/crm_43/modules/civicrm/CRM/Report/Form.php).
```
