### PR TITLE
-- CRM test fix

### DIFF
--- a/CRM/Utils/Money.php
+++ b/CRM/Utils/Money.php
@@ -81,7 +81,7 @@ class CRM_Utils_Money {
       $currencySymbolName = CRM_Core_PseudoConstant::get('CRM_Contribute_DAO_Contribution', 'currency', array('labelColumn' => 'name'));
       $currencySymbol = CRM_Core_PseudoConstant::get('CRM_Contribute_DAO_Contribution', 'currency');
 
-      self::$_currencySymbols = array_combine($currencySymbolName, $currencySymbol);
+      self::$_currencySymbols = array_intersect_key($currencySymbol, $currencySymbolName);
     }
 
     if (!$currency) {


### PR DESCRIPTION
array_combine was taking the keys of $currencySymbolName and values of $currencySymbol but the keys of these two arrays are not in the same order i.e. $currencySymbolName keys were in alphabetic order while $currencySymbol keys were in random order. so, wrong currency symbol was getting selected i.e. for USD, kr was getting selected instead of $ so it resulted for 2 CRM tests to fail
