### PR TITLE
Crm 12733

### DIFF
--- a/CRM/Case/XMLProcessor/Process.php
+++ b/CRM/Case/XMLProcessor/Process.php
@@ -120,7 +120,8 @@ class CRM_Case_XMLProcessor_Process extends CRM_Case_XMLProcessor {
   }
 
   function processStandardTimeline($activitySetXML, &$params) {
-    if ('Change Case Type' == CRM_Utils_Array::value('activityTypeName', $params)) {
+    if ('Change Case Type' == CRM_Utils_Array::value('activityTypeName', $params)
+      && CRM_Utils_Array::value('resetTimeline', $params, TRUE)) {
       // delete all existing activities which are non-empty
       $this->deleteEmptyActivity($params);
     }


### PR DESCRIPTION
the approach i followed is : when a case type is being changed and 'reset timeline option' is set to 'no' the previous case type timeline activities will not be deleted and the new case type timeline activities will be created 
