### PR TITLE
cleanup activity tests, examples, api

### DIFF
--- a/api/v3/Activity.php
+++ b/api/v3/Activity.php
@@ -204,11 +204,6 @@ function _civicrm_api3_activity_create_spec(&$params) {
       'api.default' => 'user_contact_id',
   );
 
-  $params['activity_status_id'] = array(
-    'name' => 'status_id',
-    'title' => 'Status Id',
-    'type' => 1,
-  );
 }
 
 /**
@@ -399,26 +394,6 @@ SELECT  count(*)
   ) {
     return civicrm_api3_create_error('Invalid Activity Type ID');
   }
-
-  // check for activity status is passed in
-  // note this should all be removed in favour of wrapper layer validation
-  // needs testing
-  if (isset($params['activity_status_id'])) {
-    $activityStatus = CRM_Core_PseudoConstant::activityStatus();
-
-    if (is_numeric($params['activity_status_id']) && !array_key_exists($params['activity_status_id'], $activityStatus)) {
-      return civicrm_api3_create_error('Invalid Activity Status');
-    }
-    elseif (!is_numeric($params['activity_status_id'])) {
-      $statusId = array_search($params['activity_status_id'], $activityStatus);
-
-      if (!is_numeric($statusId)) {
-        return civicrm_api3_create_error('Invalid Activity Status');
-      }
-    }
-  }
-
-
 
   // check for activity duration minutes
   // this should be validated @ the wrapper layer not here

--- a/api/v3/examples/Activity/ContactRefCustomField.php
+++ b/api/v3/examples/Activity/ContactRefCustomField.php
@@ -4,7 +4,7 @@
  demonstrates create with Contact Reference Custom Field
  */
 function activity_create_example(){
-$params = array( 
+$params = array(
   'source_contact_id' => 17,
   'activity_type_id' => '44',
   'subject' => 'test activity type id',
@@ -28,13 +28,13 @@ $params = array(
  */
 function activity_create_expectedresult(){
 
-  $expectedResult = array( 
+  $expectedResult = array(
   'is_error' => 0,
   'version' => 3,
   'count' => 1,
   'id' => 1,
-  'values' => array( 
-      '1' => array( 
+  'values' => array(
+      '1' => array(
           'id' => '1',
           'source_record_id' => '',
           'activity_type_id' => '44',

--- a/api/v3/examples/Activity/ContactRefCustomFieldGet.php
+++ b/api/v3/examples/Activity/ContactRefCustomFieldGet.php
@@ -4,7 +4,7 @@
  Get with Contact Ref Custom Field
  */
 function activity_create_example(){
-$params = array( 
+$params = array(
   'source_contact_id' => 17,
   'activity_type_id' => '44',
   'subject' => 'test activity type id',
@@ -28,13 +28,13 @@ $params = array(
  */
 function activity_create_expectedresult(){
 
-  $expectedResult = array( 
+  $expectedResult = array(
   'is_error' => 0,
   'version' => 3,
   'count' => 1,
   'id' => 1,
-  'values' => array( 
-      '1' => array( 
+  'values' => array(
+      '1' => array(
           'id' => '1',
           'activity_type_id' => '44',
           'subject' => 'test activity type id',

--- a/api/v3/examples/Activity/DateTimeHigh.php
+++ b/api/v3/examples/Activity/DateTimeHigh.php
@@ -4,7 +4,7 @@
  demonstrates _high filter (at time of writing doesn't work if contact_id is set
  */
 function activity_get_example(){
-$params = array( 
+$params = array(
   'source_contact_id' => 17,
   'version' => 3,
   'filter.activity_date_time_high' => '20120101000000',
@@ -21,13 +21,13 @@ $params = array(
  */
 function activity_get_expectedresult(){
 
-  $expectedResult = array( 
+  $expectedResult = array(
   'is_error' => 0,
   'version' => 3,
   'count' => 1,
   'id' => 1,
-  'values' => array( 
-      '0' => array( 
+  'values' => array(
+      '0' => array(
           'id' => '1',
           'activity_type_id' => '44',
           'subject' => 'Make-it-Happen Meeting',

--- a/api/v3/examples/Activity/DateTimeLow.php
+++ b/api/v3/examples/Activity/DateTimeLow.php
@@ -4,7 +4,7 @@
  demonstrates _low filter (at time of writing doesn't work if contact_id is set
  */
 function activity_get_example(){
-$params = array( 
+$params = array(
   'version' => 3,
   'filter.activity_date_time_low' => '20120101000000',
   'sequential' => 1,
@@ -20,13 +20,13 @@ $params = array(
  */
 function activity_get_expectedresult(){
 
-  $expectedResult = array( 
+  $expectedResult = array(
   'is_error' => 0,
   'version' => 3,
   'count' => 1,
   'id' => 2,
-  'values' => array( 
-      '0' => array( 
+  'values' => array(
+      '0' => array(
           'id' => '2',
           'activity_type_id' => '44',
           'subject' => 'Make-it-Happen Meeting',

--- a/api/v3/examples/Activity/GetTargetandAssignee.php
+++ b/api/v3/examples/Activity/GetTargetandAssignee.php
@@ -4,7 +4,7 @@
  Example demonstrates setting & retrieving the target & source
  */
 function activity__example(){
-$params = array( 
+$params = array(
   'source_contact_id' => 17,
   'subject' => 'Make-it-Happen Meeting',
   'activity_date_time' => '20110316',
@@ -29,13 +29,13 @@ $params = array(
  */
 function activity__expectedresult(){
 
-  $expectedResult = array( 
+  $expectedResult = array(
   'is_error' => 0,
   'version' => 3,
   'count' => 1,
   'id' => 1,
-  'values' => array( 
-      '1' => array( 
+  'values' => array(
+      '1' => array(
           'id' => '1',
           'source_record_id' => '',
           'activity_type_id' => '1',

--- a/api/v3/examples/Activity/ReturnAssigneeContact.php
+++ b/api/v3/examples/Activity/ReturnAssigneeContact.php
@@ -4,12 +4,12 @@
  Function demonstrates getting asignee_contact_id & using it to get the contact
  */
 function activity_get_example(){
-$params = array( 
+$params = array(
   'activity_id' => 1,
   'version' => 3,
   'sequential' => 1,
   'return.assignee_contact_id' => 1,
-  'api.contact.get' => array( 
+  'api.contact.get' => array(
       'id' => '$value.source_contact_id',
     ),
 );
@@ -24,13 +24,13 @@ $params = array(
  */
 function activity_get_expectedresult(){
 
-  $expectedResult = array( 
+  $expectedResult = array(
   'is_error' => 0,
   'version' => 3,
   'count' => 1,
   'id' => 1,
-  'values' => array( 
-      '0' => array( 
+  'values' => array(
+      '0' => array(
           'id' => '1',
           'activity_type_id' => '44',
           'subject' => 'test activity type id',
@@ -44,20 +44,20 @@ function activity_get_expectedresult(){
           'is_auto' => 0,
           'is_current_revision' => '1',
           'is_deleted' => 0,
-          'assignee_contact_id' => array( 
+          'assignee_contact_id' => array(
               '0' => '19',
             ),
           'source_contact_id' => '17',
-          'api.contact.get' => array( 
+          'api.contact.get' => array(
               'is_error' => 0,
-              'undefined_fields' => array( 
+              'undefined_fields' => array(
                   '0' => 'api.has_parent',
                 ),
               'version' => 3,
               'count' => 1,
               'id' => 17,
-              'values' => array( 
-                  '0' => array( 
+              'values' => array(
+                  '0' => array(
                       'contact_id' => '17',
                       'contact_type' => 'Individual',
                       'contact_sub_type' => '',

--- a/api/v3/examples/ActivityCreate.php
+++ b/api/v3/examples/ActivityCreate.php
@@ -4,7 +4,7 @@
  
  */
 function activity_create_example(){
-$params = array( 
+$params = array(
   'source_contact_id' => 17,
   'activity_type_id' => '44',
   'subject' => 'test activity type id',
@@ -28,13 +28,13 @@ $params = array(
  */
 function activity_create_expectedresult(){
 
-  $expectedResult = array( 
+  $expectedResult = array(
   'is_error' => 0,
   'version' => 3,
   'count' => 1,
   'id' => 1,
-  'values' => array( 
-      '1' => array( 
+  'values' => array(
+      '1' => array(
           'id' => '1',
           'source_record_id' => '',
           'activity_type_id' => '44',

--- a/api/v3/examples/ActivityDelete.php
+++ b/api/v3/examples/ActivityDelete.php
@@ -4,7 +4,7 @@
  
  */
 function activity_delete_example(){
-$params = array( 
+$params = array(
   'id' => 1,
   'version' => 3,
 );
@@ -19,7 +19,7 @@ $params = array(
  */
 function activity_delete_expectedresult(){
 
-  $expectedResult = array( 
+  $expectedResult = array(
   'is_error' => 0,
   'version' => 3,
   'count' => 1,

--- a/api/v3/examples/ActivityGet.php
+++ b/api/v3/examples/ActivityGet.php
@@ -4,7 +4,7 @@
  
  */
 function activity_get_example(){
-$params = array( 
+$params = array(
   'contact_id' => 17,
   'activity_type_id' => '44',
   'version' => 3,
@@ -22,13 +22,13 @@ $params = array(
  */
 function activity_get_expectedresult(){
 
-  $expectedResult = array( 
+  $expectedResult = array(
   'is_error' => 0,
   'version' => 3,
   'count' => 1,
   'id' => 1,
-  'values' => array( 
-      '0' => array( 
+  'values' => array(
+      '0' => array(
           'source_contact_id' => '17',
           'id' => '1',
           'activity_type_id' => '44',

--- a/api/v3/examples/ActivityGetfields.php
+++ b/api/v3/examples/ActivityGetfields.php
@@ -4,7 +4,7 @@
  
  */
 function activity_getfields_example(){
-$params = array( 
+$params = array(
   'version' => 3,
   'action' => 'create',
 );
@@ -19,17 +19,17 @@ $params = array(
  */
 function activity_getfields_expectedresult(){
 
-  $expectedResult = array( 
+  $expectedResult = array(
   'is_error' => 0,
   'version' => 3,
-  'count' => 28,
-  'values' => array( 
-      'source_record_id' => array( 
+  'count' => 27,
+  'values' => array(
+      'source_record_id' => array(
           'name' => 'source_record_id',
           'type' => 1,
           'title' => 'Source Record',
         ),
-      'activity_type_id' => array( 
+      'activity_type_id' => array(
           'name' => 'activity_type_id',
           'type' => 1,
           'title' => 'Activity Type ID',
@@ -37,14 +37,14 @@ function activity_getfields_expectedresult(){
           'import' => true,
           'where' => 'civicrm_activity.activity_type_id',
           'headerPattern' => '/(activity.)?type(.id$)/i',
-          'pseudoconstant' => array( 
+          'pseudoconstant' => array(
               'optionGroupName' => 'activity_type',
             ),
-          'api.aliases' => array( 
+          'api.aliases' => array(
               '0' => 'activity_type',
             ),
         ),
-      'activity_date_time' => array( 
+      'activity_date_time' => array(
           'name' => 'activity_date_time',
           'type' => 12,
           'title' => 'Activity Date',
@@ -53,49 +53,49 @@ function activity_getfields_expectedresult(){
           'headerPattern' => '/(activity.)?date(.time$)?/i',
           'export' => true,
         ),
-      'phone_id' => array( 
+      'phone_id' => array(
           'name' => 'phone_id',
           'type' => 1,
           'title' => 'Phone (called) ID',
           'FKClassName' => 'CRM_Core_DAO_Phone',
         ),
-      'phone_number' => array( 
+      'phone_number' => array(
           'name' => 'phone_number',
           'type' => 2,
           'title' => 'Phone (called) Number',
           'maxlength' => 64,
           'size' => 30,
         ),
-      'priority_id' => array( 
+      'priority_id' => array(
           'name' => 'priority_id',
           'type' => 1,
           'title' => 'Priority',
-          'pseudoconstant' => array( 
+          'pseudoconstant' => array(
               'optionGroupName' => 'priority',
             ),
-          'api.aliases' => array( 
+          'api.aliases' => array(
               '0' => 'priority',
             ),
         ),
-      'parent_id' => array( 
+      'parent_id' => array(
           'name' => 'parent_id',
           'type' => 1,
           'title' => 'Parent Activity Id',
           'FKClassName' => 'CRM_Activity_DAO_Activity',
         ),
-      'is_auto' => array( 
+      'is_auto' => array(
           'name' => 'is_auto',
           'type' => 16,
           'title' => 'Auto',
         ),
-      'relationship_id' => array( 
+      'relationship_id' => array(
           'name' => 'relationship_id',
           'type' => 1,
           'title' => 'Relationship Id',
           'default' => 'UL',
           'FKClassName' => 'CRM_Contact_DAO_Relationship',
         ),
-      'is_current_revision' => array( 
+      'is_current_revision' => array(
           'name' => 'is_current_revision',
           'type' => 16,
           'title' => 'Is this activity a current revision in versioning chain?',
@@ -104,18 +104,18 @@ function activity_getfields_expectedresult(){
           'headerPattern' => '/(is.)?(current.)?(revision|version(ing)?)/i',
           'export' => true,
         ),
-      'original_id' => array( 
+      'original_id' => array(
           'name' => 'original_id',
           'type' => 1,
           'title' => 'Original Activity ID ',
           'FKClassName' => 'CRM_Activity_DAO_Activity',
         ),
-      'weight' => array( 
+      'weight' => array(
           'name' => 'weight',
           'type' => 1,
           'title' => 'Weight',
         ),
-      'id' => array( 
+      'id' => array(
           'name' => 'id',
           'type' => 1,
           'title' => 'Activity ID',
@@ -124,11 +124,11 @@ function activity_getfields_expectedresult(){
           'where' => 'civicrm_activity.id',
           'export' => true,
           'uniqueName' => 'activity_id',
-          'api.aliases' => array( 
+          'api.aliases' => array(
               '0' => 'activity_id',
             ),
         ),
-      'subject' => array( 
+      'subject' => array(
           'name' => 'subject',
           'type' => 2,
           'title' => 'Subject',
@@ -140,7 +140,7 @@ function activity_getfields_expectedresult(){
           'export' => true,
           'uniqueName' => 'activity_subject',
         ),
-      'duration' => array( 
+      'duration' => array(
           'name' => 'duration',
           'type' => 1,
           'title' => 'Duration',
@@ -150,7 +150,7 @@ function activity_getfields_expectedresult(){
           'export' => true,
           'uniqueName' => 'activity_duration',
         ),
-      'location' => array( 
+      'location' => array(
           'name' => 'location',
           'type' => 2,
           'title' => 'Location',
@@ -162,7 +162,7 @@ function activity_getfields_expectedresult(){
           'export' => true,
           'uniqueName' => 'activity_location',
         ),
-      'details' => array( 
+      'details' => array(
           'name' => 'details',
           'type' => 32,
           'title' => 'Details',
@@ -174,22 +174,22 @@ function activity_getfields_expectedresult(){
           'export' => true,
           'uniqueName' => 'activity_details',
         ),
-      'status_id' => array( 
+      'status_id' => array(
           'name' => 'status_id',
           'type' => 1,
           'title' => 'Activity Status Id',
           'import' => true,
           'where' => 'civicrm_activity.status_id',
           'headerPattern' => '/(activity.)?status(.label$)?/i',
-          'pseudoconstant' => array( 
+          'pseudoconstant' => array(
               'optionGroupName' => 'activity_status',
             ),
           'uniqueName' => 'activity_status_id',
-          'api.aliases' => array( 
+          'api.aliases' => array(
               '0' => 'status',
             ),
         ),
-      'is_test' => array( 
+      'is_test' => array(
           'name' => 'is_test',
           'type' => 16,
           'title' => 'Test',
@@ -199,20 +199,20 @@ function activity_getfields_expectedresult(){
           'export' => true,
           'uniqueName' => 'activity_is_test',
         ),
-      'medium_id' => array( 
+      'medium_id' => array(
           'name' => 'medium_id',
           'type' => 1,
           'title' => 'Activity Medium',
           'default' => 'UL',
-          'pseudoconstant' => array( 
+          'pseudoconstant' => array(
               'optionGroupName' => 'encounter_medium',
             ),
           'uniqueName' => 'activity_medium_id',
-          'api.aliases' => array( 
+          'api.aliases' => array(
               '0' => 'medium',
             ),
         ),
-      'result' => array( 
+      'result' => array(
           'name' => 'result',
           'type' => 2,
           'title' => 'Result',
@@ -220,7 +220,7 @@ function activity_getfields_expectedresult(){
           'size' => 45,
           'uniqueName' => 'activity_result',
         ),
-      'is_deleted' => array( 
+      'is_deleted' => array(
           'name' => 'is_deleted',
           'type' => 16,
           'title' => 'Activity is in the Trash',
@@ -230,7 +230,7 @@ function activity_getfields_expectedresult(){
           'export' => true,
           'uniqueName' => 'activity_is_deleted',
         ),
-      'campaign_id' => array( 
+      'campaign_id' => array(
           'name' => 'campaign_id',
           'type' => 1,
           'title' => 'Campaign ID',
@@ -240,41 +240,36 @@ function activity_getfields_expectedresult(){
           'FKClassName' => 'CRM_Campaign_DAO_Campaign',
           'uniqueName' => 'activity_campaign_id',
         ),
-      'engagement_level' => array( 
+      'engagement_level' => array(
           'name' => 'engagement_level',
           'type' => 1,
           'title' => 'Engagement Index',
           'import' => true,
           'where' => 'civicrm_activity.engagement_level',
           'export' => true,
-          'pseudoconstant' => array( 
+          'pseudoconstant' => array(
               'optionGroupName' => 'engagement_index',
             ),
           'uniqueName' => 'activity_engagement_level',
         ),
-      'source_contact_id' => array( 
+      'source_contact_id' => array(
           'name' => 'source_contact_id',
           'title' => 'Activity Source Contact',
           'type' => 1,
           'FKClassName' => 'CRM_Activity_DAO_ActivityContact',
           'api.default' => 'user_contact_id',
         ),
-      'assignee_contact_id' => array( 
+      'assignee_contact_id' => array(
           'name' => 'assignee_id',
           'title' => 'assigned to',
           'type' => 1,
           'FKClassName' => 'CRM_Activity_DAO_ActivityContact',
         ),
-      'target_contact_id' => array( 
+      'target_contact_id' => array(
           'name' => 'target_id',
           'title' => 'Activity Target',
           'type' => 1,
           'FKClassName' => 'CRM_Activity_DAO_ActivityContact',
-        ),
-      'activity_status_id' => array( 
-          'name' => 'status_id',
-          'title' => 'Status Id',
-          'type' => 1,
         ),
     ),
 );

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -594,6 +594,12 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
     );
   }
 
+/**
+ * check that api returned 'is_error' => 0
+ * else provide full message
+ * @param array $apiResult api result
+ * @param string $prefix extra test to add to message
+ */
   function assertAPISuccess($apiResult, $prefix = '') {
     if (!empty($prefix)) {
       $prefix .= ': ';
@@ -601,10 +607,22 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
     $this->assertEquals(0, $apiResult['is_error'], $prefix . (empty($apiResult['error_message']) ? '' : $apiResult['error_message']));
   }
 
+  /**
+   * check that api returned 'is_error' => 1
+   * else provide full message
+   * @param array $apiResult api result
+   * @param string $prefix extra test to add to message
+   */
+  function assertAPIFailure($apiResult, $prefix = '') {
+    if (!empty($prefix)) {
+      $prefix .= ': ';
+    }
+    $this->assertEquals(1, $apiResult['is_error'], "api call should have failed but it succeeded " . $prefix . (print_r($apiResult, TRUE)));
+  }
+
   function assertType($expected, $actual, $message = '') {
     return $this->assertInternalType($expected, $actual, $message);
   }
-
   /**
    * Generic function to create Organisation, to be used in test cases
    *

--- a/tests/phpunit/api/v3/ActivityTest.php
+++ b/tests/phpunit/api/v3/ActivityTest.php
@@ -134,9 +134,7 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
   function testActivityCreateEmpty() {
     $params = array('version' => $this->_apiversion);
     $result = civicrm_api('activity', 'create', $params);
-    $this->assertEquals($result['is_error'], 1,
-      "In line " . __LINE__
-    );
+    $this->assertAPIFailure($result);
   }
 
   /**
@@ -150,9 +148,7 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
     );
 
     $result = civicrm_api('activity', 'create', $params);
-    $this->assertEquals($result['is_error'], 1,
-      "In line " . __LINE__
-    );
+    $this->assertAPIFailure($result);
   }
 
   /**
@@ -175,9 +171,7 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
     );
 
     $result = civicrm_api('activity', 'create', $params);
-    $this->assertEquals($result['is_error'], 1,
-      "In line " . __LINE__
-    );
+    $this->assertAPIFailure($result);;
   }
 
   /**
@@ -248,7 +242,9 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
   //}
 
   /**
-   * check with incorrect required fields
+   * Ensure that an invalid activity type causes failure
+   * oddly enough this test was failing because the creation of the invalid type
+   * got added to the set up routine. Probably a mis-fix on a test
    */
   function testActivityCreateWithNonNumericActivityTypeId() {
     $params = array(
@@ -259,15 +255,12 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
       'location' => 'Pensulvania',
       'details' => 'a test activity',
       'status_id' => 1,
-      'activity_type_id' => 'Test activity type',
+      'activity_type_id' => 'Invalid Test activity type',
       'version' => $this->_apiversion,
     );
 
     $result = civicrm_api('activity', 'create', $params);
-
-    $this->assertEquals($result['is_error'], 1,
-      "In line " . __LINE__
-    );
+    $this->assertAPIFailure($result);
   }
 
   /**
@@ -287,10 +280,7 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
     );
 
     $result = civicrm_api('activity', 'create', $params);
-
-    $this->assertEquals($result['is_error'], 1,
-      "In line " . __LINE__
-    );
+    $this->assertAPIFailure($result);
   }
 
   function testActivityCreateWithInvalidPriority() {
@@ -308,11 +298,13 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
     );
 
     $result = civicrm_api('activity', 'create', $params);
-    $this->assertEquals($result['is_error'], 1, "In line " . __LINE__);
+    $this->assertAPIFailure($result);
     $this->assertEquals("'44' is not a valid option for field priority_id", $result['error_message']);
     $this->assertEquals(2001, $result['error_code']);
     $this->assertEquals('priority_id', $result['error_field']);
   }
+
+
 
   function testActivityCreateWithValidStringPriority() {
     $params = array(
@@ -329,7 +321,7 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
     );
 
     $result = civicrm_api('activity', 'create', $params);
-    $this->assertEquals($result['is_error'], 0, "In line " . __LINE__);
+    $this->assertAPISuccess($result);
     $this->assertEquals(1, $result['values'][$result['id']]['priority_id']);
   }
 
@@ -348,7 +340,7 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
     );
 
     $result = civicrm_api('activity', 'create', $params);
-    $this->assertEquals($result['is_error'], 1, "In line " . __LINE__);
+    $this->assertAPIFailure($result);
     $this->assertEquals("'ergUrgent' is not a valid option for field priority_id", $result['error_message']);
   }
 
@@ -399,9 +391,7 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
 
     $result = civicrm_api('activity', 'create', $params);
     //todo test target & assignee are set
-    $this->assertEquals($result['is_error'], 0,
-      "Error message: " . CRM_Utils_Array::value('error_message', $result) . ' in line ' . __LINE__
-    );
+    $this->assertAPISuccess($result);
 
     //$this->assertEquals($result['values'][$result['id']]['source_contact_id'], 17, 'in line ' . __LINE__);
     $result = civicrm_api('activity', 'get', array('id' => $result['id'], 'version' => $this->_apiversion));
@@ -434,9 +424,7 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
 
     $result = civicrm_api('activity', 'create', $params);
     //todo test target & assignee are set
-    $this->assertEquals($result['is_error'], 0,
-      "Error message: " . CRM_Utils_Array::value('error_message', $result) . ' in line ' . __LINE__
-    );
+    $this->assertAPISuccess($result);
 
     $this->documentMe($params, $result, __FUNCTION__, __FILE__, $description, $subfile);
     $result = civicrm_api('activity', 'get', array('id' => $result['id'], 'version' => $this->_apiversion, 'return.assignee_contact_id' => 1, 'return.target_contact_id' => 1));
@@ -572,10 +560,32 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
 
     $result = civicrm_api('activity', 'create', $params);
 
-    $this->assertEquals($result['is_error'], 1,
-      "In line " . __LINE__
-    );
+    $this->assertAPIFailure($result);
   }
+
+  /**
+   *  Test civicrm_activity_create() with an invalid text status_id
+   */
+  function testActivityCreateSupportActivityStatus() {
+
+    $params = array(
+      'source_contact_id' => 17,
+      'subject' => 'Discussion on Apis for v3',
+      'activity_date_time' => date('Ymd'),
+      'duration' => 120,
+      'location' => 'Pensulvania',
+      'details' => 'a test activity',
+      'activity_status_id' => 'Invalid',
+      'activity_name' => 'Test activity type',
+      'version' => $this->_apiversion,
+    );
+
+    $result = civicrm_api('activity', 'create', $params);
+
+    $this->assertAPIFailure($result);
+    $this->assertEquals("'Invalid' is not a valid option for field status_id", $result['error_message']);
+  }
+
 
   /**
    *  Test civicrm_activity_create() with valid parameters,
@@ -597,15 +607,12 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
     );
 
     $result = civicrm_api('activity', 'create', $params);
-    $this->assertEquals($result['is_error'], 0,
-      "Error message: " . CRM_Utils_Array::value('error_message', $result) . ' in line ' . __LINE__
-    );
+    $this->assertAPISuccess($result);
     $this->assertEquals($result['values'][$result['id']]['duration'], 120, 'in line ' . __LINE__);
     $this->assertEquals($result['values'][$result['id']]['subject'], 'Make-it-Happen Meeting', 'in line ' . __LINE__);
     $this->assertEquals($result['values'][$result['id']]['activity_date_time'], date('Ymd') . '000000', 'in line ' . __LINE__);
     $this->assertEquals($result['values'][$result['id']]['location'], 'Pensulvania', 'in line ' . __LINE__);
     $this->assertEquals($result['values'][$result['id']]['details'], 'a test activity', 'in line ' . __LINE__);
-    $this->assertEquals($result['values'][$result['id']]['status_id'], 'Scheduled', 'in line ' . __LINE__);
   }
 
   /**
@@ -614,7 +621,7 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
   function testActivityGetEmpty() {
     $params = array('version' => $this->_apiversion);
     $result = civicrm_api('activity', 'get', $params);
-    $this->assertEquals(0, $result['is_error'], 'In line ' . __LINE__);
+    $this->assertAPISuccess($result);
   }
 
   /**
@@ -827,7 +834,7 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
     $result = civicrm_api('activity', 'get', $params, TRUE);
     $this->assertAPISuccess($result, 'in line ' . __LINE__);
     $this->documentMe($params, $result, __FUNCTION__, __FILE__);
-    $this->assertEquals(0, $result['is_error'], "Error message: " . CRM_Utils_Array::value('error_message', $result));
+    $this->assertAPISuccess($result);
     $this->assertEquals("custom string", $result['values'][0]['custom_' . $ids['custom_field_id']], ' in line ' . __LINE__);
 
     $this->assertEquals($this->test_activity_type_value, $result['values'][0]['activity_type_id'], 'In line ' . __LINE__);
@@ -841,9 +848,7 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
   function testDeleteActivityForEmptyParams() {
     $params = array('version' => $this->_apiversion);
     $result = civicrm_api('activity', 'delete', $params);
-    $this->assertEquals($result['is_error'], 1,
-      "In line " . __LINE__
-    );
+    $this->assertAPIFailure($result);
   }
 
   /**
@@ -855,9 +860,7 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
       'version' => $this->_apiversion,
     );
     $result = civicrm_api('activity', 'delete', $params);
-    $this->assertEquals($result['is_error'], 1,
-      "In line " . __LINE__
-    );
+    $this->assertAPIFailure($result);
   }
 
   /**
@@ -866,9 +869,7 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
   function testDeleteActivityWithoutActivityType() {
     $params = array('id' => 1);
     $result = civicrm_api('activity', 'delete', $params);
-    $this->assertEquals($result['is_error'], 1,
-      "In line " . __LINE__
-    );
+    $this->assertAPIFailure($result);
   }
 
   /**
@@ -881,9 +882,7 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
     );
 
     $result = civicrm_api('activity', 'delete', $params);
-    $this->assertEquals($result['is_error'], 1,
-      "In line " . __LINE__
-    );
+    $this->assertAPIFailure($result);
   }
 
   /**
@@ -902,17 +901,6 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
   }
 
   /**
-   * check with empty array
-   */
-  function testActivityUpdateEmpty() {
-    $params = array();
-    $result = civicrm_api('activity', 'create', $params);
-    $this->assertEquals($result['is_error'], 1,
-      "In line " . __LINE__
-    );
-  }
-
-  /**
    * check if required fields are not passed
    */
   function testActivityUpdateWithoutRequired() {
@@ -922,9 +910,7 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
     );
 
     $result = civicrm_api('activity', 'create', $params);
-    $this->assertEquals($result['is_error'], 1,
-      "In line " . __LINE__
-    );
+    $this->assertAPIFailure($result);
   }
 
   /**
@@ -938,9 +924,7 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
     );
 
     $result = civicrm_api('activity', 'create', $params);
-    $this->assertEquals($result['is_error'], 1,
-      "In line " . __LINE__
-    );
+    $this->assertAPIFailure($result);
   }
 
   /**
@@ -955,9 +939,7 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
     );
 
     $result = civicrm_api('activity', 'create', $params);
-    $this->assertEquals($result['is_error'], 1,
-      "In line " . __LINE__
-    );
+    $this->assertAPIFailure($result);
   }
 
   /**
@@ -974,7 +956,7 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
     );
 
     $result = civicrm_api('activity', 'create', $params);
-    $this->assertEquals($result['is_error'], 1, "In line " . __LINE__);
+    $this->assertAPIFailure($result);
     $this->assertEquals($result['error_message'], 'Invalid Activity Id', "In line " . __LINE__);
   }
 
@@ -1032,9 +1014,7 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
     $result = civicrm_api('activity', 'create', $params);
 
     $activityId = $result['id'];
-    $this->assertEquals(0, $result['is_error'],
-      "Error message: " . CRM_Utils_Array::value('error_message', $result)
-    );
+    $this->assertAPISuccess($result);
     $result = civicrm_api($this->_entity, 'get', array('return.custom_' . $ids['custom_field_id'] => 1, 'version' => 3, 'id' => $result['id']));
     $this->assertEquals("custom string", $result['values'][$result['id']]['custom_' . $ids['custom_field_id']], ' in line ' . __LINE__);
     $this->assertEquals("2009-10-18 00:00:00", $result['values'][$result['id']]['activity_date_time'], ' in line ' . __LINE__);
@@ -1054,9 +1034,7 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
       'version' => $this->_apiversion,
     );
     $result = civicrm_api('Activity', 'Create', $params);
-    $this->assertEquals(0, $result['is_error'],
-      "Error message: " . CRM_Utils_Array::value('error_message', $result)
-    );
+    $this->assertAPISuccess($result);
 
     $result = civicrm_api($this->_entity, 'get', array('return.custom_' . $ids['custom_field_id'] => 1, 'version' => 3, 'id' => $result['id']));
     $this->assertEquals("Updated my test data", $result['values'][$result['id']]['custom_' . $ids['custom_field_id']], ' in line ' . __LINE__);
@@ -1141,9 +1119,7 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
     $params['target_contact_id'] = array($contact4 => $contact4);
 
     $result = civicrm_api('activity', 'create', $params);
-    $this->assertEquals(0, $result['is_error'],
-      "Error message: " . CRM_Utils_Array::value('error_message', $result)
-    );
+    $this->assertAPISuccess($result);
 
     $this->assertEquals($activityId, $result['id'], ' in line ' . __LINE__);
 
@@ -1307,46 +1283,20 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
   }
 
   /**
-   * check civicrm_activities_contact_get() with empty array
-   */
-  function testActivityContactGetEmpty() {
-    $params = array();
-    $result = civicrm_api('activity', 'get', $params);
-    $this->assertEquals($result['is_error'], 1, "In line " . __LINE__);
-  }
-
-  /**
-   *  Test  civicrm_activity_contact_get() with missing source_contact_id
-   */
-  function testActivitiesContactGetWithInvalidParameter() {
-    $params = NULL;
-    $result = civicrm_api('activity', 'get', $params);
-    $this->assertEquals($result['is_error'], 1,
-      "In line " . __LINE__
-    );
-  }
-
-  /**
    *  Test civicrm_activity_contact_get() with invalid Contact Id
    */
   function testActivitiesContactGetWithInvalidContactId() {
     $params = array('contact_id' => NULL);
     $result = civicrm_api('activity', 'get', $params);
-    $this->assertEquals($result['is_error'], 1,
-      "In line " . __LINE__
-    );
+    $this->assertAPIFailure($result);
 
     $params = array('contact_id' => 'contact');
     $result = civicrm_api('activity', 'get', $params);
-    $this->assertEquals($result['is_error'], 1,
-      "In line " . __LINE__
-    );
+    $this->assertAPIFailure($result);
 
     $params = array('contact_id' => 2.4);
     $result = civicrm_api('activity', 'get', $params);
-    $this->assertEquals($result['is_error'], 1,
-      "In line " . __LINE__
-    );
+    $this->assertAPIFailure($result);
   }
 
   /**
@@ -1367,7 +1317,7 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
       'version' => $this->_apiversion,
     );
     $result = civicrm_api('activity', 'get', $params);
-    $this->assertEquals($result['is_error'], 0, 'in line ' . __LINE__);
+    $this->assertAPISuccess($result);
     $this->assertEquals($result['count'], 0, 'in line ' . __LINE__);
   }
 


### PR DESCRIPTION
fix includes removing 'activity_status_id' from _spec & adding testing that api alias mechanism works without that, removing pointless tests, using assertAPIFailure & assertAPISuccess and removing trailing spaces from generated tests (now the template no longer has them, API test class passes after this although it does not address prob when class is run as part of suite
