### PR TITLE
CRM-12288

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1431,7 +1431,8 @@ INNER JOIN civicrm_contact contact ON ac.contact_id = contact.id
         $tokenText,
         $tokenHtml,
         $smsParams,
-        $activityID
+        $activityID,
+        $userID
       );
 
       if (PEAR::isError($sendResult)) {
@@ -1471,7 +1472,8 @@ INNER JOIN civicrm_contact contact ON ac.contact_id = contact.id
     &$tokenText,
     &$tokenHtml,
     $smsParams = array(),
-    $activityID
+    $activityID,
+    $userID = null
   ) {
     $toDoNotSms = "";
     $toPhoneNumber = "";
@@ -1507,7 +1509,7 @@ INNER JOIN civicrm_contact contact ON ac.contact_id = contact.id
     $smsParams['parent_activity_id'] = $activityID;
 
     $providerObj = CRM_SMS_Provider::singleton(array('provider_id' => $smsParams['provider_id']));
-    $sendResult = $providerObj->send($recipient, $smsParams, $message, NULL);
+    $sendResult = $providerObj->send($recipient, $smsParams, $message, NULL, $userID);
     if (PEAR::isError($sendResult)) {
       return $sendResult;
     }

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -593,11 +593,11 @@ ORDER BY civicrm_custom_group.weight,
         }
       }
       if ($entityID && !empty($singleFieldTables)) {
-        self::buildEntityTreeSingleFields(&$groupTree, $entityID, $entitySingleSelectClauses, $singleFieldTables);
+        self::buildEntityTreeSingleFields($groupTree, $entityID, $entitySingleSelectClauses, $singleFieldTables);
       }
       $multipleFieldTablesWithEntityData = array_keys($entityMultipleSelectClauses);
       if(!empty($multipleFieldTablesWithEntityData)){
-        self::buildEntityTreeMultipleFields(&$groupTree, $entityID, $entityMultipleSelectClauses, $multipleFieldTablesWithEntityData);
+        self::buildEntityTreeMultipleFields($groupTree, $entityID, $entityMultipleSelectClauses, $multipleFieldTablesWithEntityData);
       }
 
    }
@@ -647,7 +647,7 @@ ORDER BY civicrm_custom_group.weight,
       FROM $fromSQL
       WHERE first.entity_id = $entityID
     ";
-    self::buildTreeEntityDataFromQuery(&$groupTree, $query, $singleFieldTablesWithEntityData);
+    self::buildTreeEntityDataFromQuery($groupTree, $query, $singleFieldTablesWithEntityData);
   }
 
   /**
@@ -668,7 +668,7 @@ ORDER BY civicrm_custom_group.weight,
         FROM $table
         WHERE entity_id = $entityID
       ";
-      self::buildTreeEntityDataFromQuery(&$groupTree, $query, array($table));
+      self::buildTreeEntityDataFromQuery($groupTree, $query, array($table));
     }
   }
 

--- a/CRM/SMS/Provider.php
+++ b/CRM/SMS/Provider.php
@@ -43,7 +43,7 @@ abstract class CRM_SMS_Provider {
    * @static
    */
   static private $_singleton = array();
-  CONST MAX_SMS_CHAR = 160;
+  CONST MAX_SMS_CHAR = 460;
 
   /**
    * singleton function used to manage this object
@@ -113,12 +113,15 @@ abstract class CRM_SMS_Provider {
   }
 
   function createActivity($apiMsgID, $message, $headers = array(
-    ), $jobID = NULL) {
+    ), $jobID = NULL, $userID = NULL) {
     if ($jobID) {
       $sql = "
 SELECT scheduled_id FROM civicrm_mailing m
 INNER JOIN civicrm_mailing_job mj ON mj.mailing_id = m.id AND mj.id = %1";
       $sourceContactID = CRM_Core_DAO::singleValueQuery($sql, array(1 => array($jobID, 'Integer')));
+    }
+    elseif($userID) {
+      $sourceContactID=$userID;
     }
     else {
       $session = CRM_Core_Session::singleton();
@@ -132,14 +135,13 @@ INNER JOIN civicrm_mailing_job mj ON mj.mailing_id = m.id AND mj.id = %1";
       return false;
     }
 
-    $activityTypeID = CRM_Core_OptionGroup::getValue('activity_type', 'SMS', 'name');
+    $activityTypeID = CRM_Core_OptionGroup::getValue('activity_type', 'SMS delivery', 'name');
     // note: lets not pass status here, assuming status will be updated by callback
     $activityParams = array(
       'source_contact_id' => $sourceContactID,
       'target_contact_id' => $headers['contact_id'],
       'activity_type_id' => $activityTypeID,
       'activity_date_time' => date('YmdHis'),
-      'subject' => 'SMS Sent',
       'details' => $message,
       'result' => $apiMsgID,
     );
@@ -162,7 +164,7 @@ INNER JOIN civicrm_mailing_job mj ON mj.mailing_id = m.id AND mj.id = %1";
   function processInbound($from, $body, $to = NULL, $trackID = NULL) {
     $formatFrom   = $this->formatPhone($this->stripPhone($from), $like, "like");
     $escapedFrom  = CRM_Utils_Type::escape($formatFrom, 'String');
-    $fromContactID = CRM_Core_DAO::singleValueQuery('SELECT contact_id FROM civicrm_phone WHERE phone LIKE "' . $escapedFrom . '"');
+    $fromContactID = CRM_Core_DAO::singleValueQuery('SELECT contact_id FROM civicrm_phone JOIN civicrm_contact ON civicrm_contact.id = civicrm_phone.contact_id WHERE !civicrm_contact.is_deleted AND phone LIKE "%' . $escapedFrom . '"');
 
     if (! $fromContactID) {
       // unknown mobile sender -- create new contact
@@ -191,7 +193,7 @@ INNER JOIN civicrm_mailing_job mj ON mj.mailing_id = m.id AND mj.id = %1";
 
     if ($to) {
       $to = CRM_Utils_Type::escape($to, 'String');
-      $toContactID = CRM_Core_DAO::singleValueQuery('SELECT contact_id FROM civicrm_phone WHERE phone LIKE "' . $to . '"');
+      $toContactID = CRM_Core_DAO::singleValueQuery('SELECT contact_id FROM civicrm_phone JOIN civicrm_contact ON civicrm_contact.id = civicrm_phone.contact_id WHERE !civicrm_contact.is_deleted AND phone LIKE "%' . $to . '"');
     }
     else {
       $toContactID = $fromContactID;
@@ -199,7 +201,7 @@ INNER JOIN civicrm_mailing_job mj ON mj.mailing_id = m.id AND mj.id = %1";
 
     if ($fromContactID) {
       $actStatusIDs = array_flip(CRM_Core_OptionGroup::values('activity_status'));
-      $activityTypeID = CRM_Core_OptionGroup::getValue('activity_type', 'SMS', 'name');
+      $activityTypeID = CRM_Core_OptionGroup::getValue('activity_type', 'Inbound SMS', 'name');
 
       // note: lets not pass status here, assuming status will be updated by callback
       $activityParams = array(
@@ -207,7 +209,6 @@ INNER JOIN civicrm_mailing_job mj ON mj.mailing_id = m.id AND mj.id = %1";
         'target_contact_id' => $fromContactID,
         'activity_type_id' => $activityTypeID,
         'activity_date_time' => date('YmdHis'),
-        'subject' => 'SMS Received',
         'status_id' => $actStatusIDs['Completed'],
         'details' => $body,
         'phone_number' => $from

--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -122,7 +122,7 @@ class CRM_Upgrade_Form extends CRM_Core_Form {
 
     if (!array_key_exists($versionName, $incrementalPhpObject)) {
       $className = "CRM_Upgrade_Incremental_php_{$versionName}";
-      $incrementalPhpObject['$versionName'] = new $className();
+      $incrementalPhpObject[$versionName] = new $className();
     }
     return $incrementalPhpObject[$versionName];
   }

--- a/CRM/Upgrade/Incremental/sql/4.4.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.4.alpha1.mysql.tpl
@@ -32,3 +32,22 @@ VALUES (@bounceTypeID, 'X-HmXmrOriginalRecipient');
 -- CRM-12716
 UPDATE civicrm_custom_field SET text_length = NULL WHERE html_type = 'TextArea' AND text_length = 255;
 
+-- CRM-12288
+
+SELECT @option_group_id_activity_type := max(id) from civicrm_option_group where name = 'activity_type';
+SELECT @max_val    := MAX(ROUND(op.value)) FROM civicrm_option_value op WHERE op.option_group_id  = @option_group_id_activity_type;
+SELECT @max_wt     := max(weight) from civicrm_option_value where option_group_id=@option_group_id_activity_type;
+
+INSERT INTO civicrm_option_value
+   (option_group_id, {localize field='label'}label{/localize}, {localize field='description'}description{/localize}, value, name, weight, filter, component_id)
+VALUES
+   (@option_group_id_activity_type, {localize}'Inbound SMS'{/localize},{localize}'Inbound SMS'{/localize}, (SELECT @max_val := @max_val+1), 'Inbound SMS', (SELECT @max_wt := @max_wt+1), 1, NULL),
+   (@option_group_id_activity_type, {localize}'SMS delivery'{/localize},{localize}'SMS delivery'{/localize}, (SELECT @max_val := @max_val+1), 'SMS delivery', (SELECT @max_wt := @max_wt+1), 1, NULL);
+
+{if $multilingual}
+  {foreach from=$locales item=locale}
+    UPDATE civicrm_option_value SET label_{$locale} ='Outbound SMS' WHERE name = 'SMS' and option_group_id = @option_group_id_activity_type;
+  {/foreach}
+{else}
+  UPDATE civicrm_option_value SET label ='Outbound SMS' WHERE name = 'SMS' and option_group_id = @option_group_id_activity_type;
+{/if}

--- a/tools/extensions/org.civicrm.sms.clickatell/org_civicrm_sms_clickatell.php
+++ b/tools/extensions/org.civicrm.sms.clickatell/org_civicrm_sms_clickatell.php
@@ -222,7 +222,7 @@ class org_civicrm_sms_clickatell extends CRM_SMS_Provider {
    * @return mixed true on sucess or PEAR_Error object
    * @access public
    */
-  function send($recipients, $header, $message, $jobID = NULL) {
+  function send($recipients, $header, $message, $jobID = NULL, $userID = NULL) {
     if ($this->_apiType == 'http') {
       $postDataArray = array( );
       $url = $this->formURLPostData("/http/sendmsg", $postDataArray);
@@ -230,8 +230,12 @@ class org_civicrm_sms_clickatell extends CRM_SMS_Provider {
       if (array_key_exists('from', $this->_providerInfo['api_params'])) {
         $postDataArray['from'] = $this->_providerInfo['api_params']['from'];
       }
+      if (array_key_exists('concat', $this->_providerInfo['api_params'])) {
+        $postDataArray['concat'] = $this->_providerInfo['api_params']['concat'];
+      }
+      //TODO:
       $postDataArray['to']   = $header['To'];
-      $postDataArray['text'] = substr($message, 0, 160); // max of 160 characters, is probably not multi-lingual
+      $postDataArray['text'] = substr($message, 0, 460); // max of 460 characters, is probably not multi-lingual
       if (array_key_exists('mo', $this->_providerInfo['api_params'])) {
         $postDataArray['mo'] = $this->_providerInfo['api_params']['mo'];
       }
@@ -280,7 +284,7 @@ class org_civicrm_sms_clickatell extends CRM_SMS_Provider {
       $send = explode(":", $response['data']);
 
       if ($send[0] == "ID") {
-        $this->createActivity($send[1], $message, $header, $jobID);
+        $this->createActivity($send[1], $message, $header, $jobID, $userID);
         return $send[1];
       }
       else {

--- a/tools/extensions/org.civicrm.sms.twilio/org_civicrm_sms_twilio.php
+++ b/tools/extensions/org.civicrm.sms.twilio/org_civicrm_sms_twilio.php
@@ -145,7 +145,7 @@ class org_civicrm_sms_twilio extends CRM_SMS_Provider {
    * @return mixed SID on success or PEAR_Error object
    * @access public
    */
-  function send($recipients, $header, $message, $jobID = NULL) {
+  function send($recipients, $header, $message, $jobID = NULL, $userID = NULL) {
     if ($this->_apiType == 'http') {
       $from = '';
       if (array_key_exists('From', $this->_providerInfo['api_params'])) {
@@ -170,7 +170,7 @@ class org_civicrm_sms_twilio extends CRM_SMS_Provider {
       }
 
       $sid = $twilioMessage->sid;
-      $this->createActivity($sid, $message, $header, $jobID);
+      $this->createActivity($sid, $message, $header, $jobID, $userID);
       return $sid;
     }
   }

--- a/xml/templates/civicrm_data.tpl
+++ b/xml/templates/civicrm_data.tpl
@@ -299,7 +299,7 @@ VALUES
    (@option_group_id_act, '{ts escape="sql"}Meeting{/ts}',                            1, 'Meeting', NULL, 0, NULL, 1, NULL,                       				                                                0, 1, 1, NULL, NULL),
    (@option_group_id_act, '{ts escape="sql"}Phone Call{/ts}',                         2, 'Phone Call',          NULL, 0, NULL, 2, NULL,                                                          				0, 1, 1, NULL, NULL),
    (@option_group_id_act, '{ts escape="sql"}Email{/ts}',                              3, 'Email',               NULL, 1, NULL, 3, '{ts escape="sql"}Email sent.{/ts}',                                                          0, 1, 1, NULL, NULL),
-   (@option_group_id_act, '{ts escape="sql"}Text Message (SMS){/ts}',                 4, 'SMS',                 NULL, 1, NULL, 4, '{ts escape="sql"}Text message (SMS) sent.{/ts}',                                             0, 1, 1, NULL, NULL),
+   (@option_group_id_act, '{ts escape="sql"}Outbound SMS{/ts}',                       4, 'SMS',                 NULL, 1, NULL, 4, '{ts escape="sql"}Text message (SMS) sent.{/ts}',                                             0, 1, 1, NULL, NULL),
    (@option_group_id_act, '{ts escape="sql"}Event Registration{/ts}',                 5, 'Event Registration',  NULL, 1, NULL, 5, '{ts escape="sql"}Online or offline event registration.{/ts}',                                0, 1, 1, @eventCompId, NULL),
    (@option_group_id_act, '{ts escape="sql"}Contribution{/ts}',                       6, 'Contribution',        NULL, 1, NULL, 6, '{ts escape="sql"}Online or offline contribution.{/ts}',                                      0, 1, 1, @contributeCompId, NULL),
    (@option_group_id_act, '{ts escape="sql"}Membership Signup{/ts}',                  7, 'Membership Signup',   NULL, 1, NULL, 7, '{ts escape="sql"}Online or offline membership signup.{/ts}',                                 0, 1, 1, @memberCompId, NULL),
@@ -352,6 +352,10 @@ VALUES
    (@option_group_id_act, '{ts escape="sql"}Export Accounting Batch{/ts}', 41, 'Export Accounting Batch', NULL, 1, 0, 41, 'Export Accounting Batch', 0, 1, 1, @contributeCompId, NULL),
    (@option_group_id_act, '{ts escape="sql"}Create Batch{/ts}', 42, 'Create Batch', NULL, 1, 0, 42, 'Create Batch', 0, 1, 1, @contributeCompId, NULL),
    (@option_group_id_act, '{ts escape="sql"}Edit Batch{/ts}', 43, 'Edit Batch', NULL, 1, 0, 43, 'Edit Batch', 0, 1, 1, @contributeCompId, NULL),
+
+-- new sms options
+   (@option_group_id_act, '{ts escape="sql"}SMS delivery{/ts}', 44, 'SMS delivery', NULL, 1, NULL, 44, '{ts escape="sql"}SMS delivery.{/ts}', 0, 1, 1, NULL, NULL),
+   (@option_group_id_act, '{ts escape="sql"}Inbound SMS{/ts}',  45, 'Inbound SMS', NULL, 1, NULL,  45, '{ts escape="sql"}Inbound SMS.{/ts}', 0, 1, 1, NULL, NULL),
 
    (@option_group_id_gender, '{ts escape="sql"}Female{/ts}',      1, 'Female',      NULL, 0, NULL, 1, NULL, 0, 0, 1, NULL, NULL),
    (@option_group_id_gender, '{ts escape="sql"}Male{/ts}',        2, 'Male',        NULL, 0, NULL, 2, NULL, 0, 0, 1, NULL, NULL),


### PR DESCRIPTION
1. Added patches manually from https://github.com/civicrm/civicrm-core/pull/325 (as the PR can't be merged cleanly) except the code w.r.t "$default_country_code='44' which i'm assuming will be fixed as part of CRM-12291.
2. Fixed install and migrate / upgrade scripts (with multilingual) considering 'Inbound SMS', 'SMS delivery' and 'Outbound SMS'.
3. Also fixed twilio extension (in addition to clickatell) to consider $userID.
4. Made fixes to address php fatal error (php 5.4):
   PHP Fatal error:  Call-time pass-by-reference has been removed in /home/deepak/gitrepos/civicrm/CRM/Core/BAO/CustomGroup.php

Which was also responsible for drush extension installation failure.
1. Fixed errors halting upgrade to v4.4.alpah1 (in CRM/Upgrade/Form.php).

---
- CRM-12288: Improvements to SMS interactions when using mass SMS and Clickatell
  http://issues.civicrm.org/jira/browse/CRM-12288
