### PR TITLE
CRM_Utils_Array::value array_key_exists error

### DIFF
--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -49,7 +49,7 @@ class CRM_Utils_Array {
    */
   static function value($key, $list, $default = NULL) {
     if (is_array($list)) {
-      return array_key_exists($key, $list) ? $list[$key] : $default;
+      return (isset($list[$key]) || @array_key_exists($key, $list)) ? $list[$key] : $default;
     }
     return $default;
   }


### PR DESCRIPTION
Changed CRM_Utils_Array::value to use isset() and only array_key_exists() when it returns false (eg. the value is null). isset() also casts the $key variable properly where as array_key_exists() throws a warning if it is not a string or integer.

This is a real problem in the Rest API, as the PHP error message is returned with the JSON response and does not get parsed properly.

Turning Debugging off in the System Settings and removing the debug parameter from the query string did not fix things either.
