### PR TITLE
CRM-12803

### DIFF
--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -385,7 +385,7 @@ WHERE  id = %1
     // done
     // we allow hidden groups here since we dont know if the caller wants to evaluate an
     // hidden group
-    if (!$force && !self::shouldGroupBeRefreshed($groupID, FALSE, TRUE)) {
+    if (!$force && !self::shouldGroupBeRefreshed($groupID, TRUE)) {
       $lock->release();
       return;
     }


### PR DESCRIPTION
Problem was due to group-contact-cache not getting populated, as  CRM/Contact/BAO/GroupContactCache::shouldGroupBeRefreshed() was called incorrectly with 3 arguments instead of 2 setting includeHiddenGroup option to FALSE.
Responsible Commit - https://github.com/civicrm/civicrm-core/commit/4f53db5ad6dd6d9a7ebdbe9af27a96d836ba4506 and https://github.com/civicrm/civicrm-core/commit/abdb260721d75b81c61dfd1697a4c134a3cbee7f
Responsible Issue - http://issues.civicrm.org/jira/browse/CRM-12466  
