### PR TITLE
CRM-12811 fix : passed 'GET' in $method argument for CRM_Utils_Request::retrieve which is being invoked from inside the function CRM_Core_BAO_CustomGroup::extractGetParams

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1412,7 +1412,7 @@ SELECT $select
       }
       foreach ($group['fields'] as $key => $field) {
         $fieldName = 'custom_' . $key;
-        $value = CRM_Utils_Request::retrieve($fieldName, 'String', $form);
+        $value = CRM_Utils_Request::retrieve($fieldName, 'String', $form, FALSE, NULL, 'GET');
 
         if ($value) {
           $valid = FALSE;
@@ -1461,7 +1461,7 @@ SELECT $select
             if (!empty($value)) {
               $time = NULL;
               if (CRM_Utils_Array::value('time_format', $field)) {
-                $time = CRM_Utils_Request::retrieve($fieldName . '_time', 'String', $form);
+                $time = CRM_Utils_Request::retrieve($fieldName . '_time', 'String', $form, FALSE, NULL, 'GET');
               }
               list($value, $time) = CRM_Utils_Date::setDateDefaults($value . ' ' . $time);
               if (CRM_Utils_Array::value('time_format', $field)) {


### PR DESCRIPTION
CRM_Core_BAO_CustomGroup::extractGetParams function is used in Event online registration and online contribution forms specifically to set default values which are passed in URL as GET parameter.

The notices were thrown cause : 
 the checkbox element is initialized as array in $_POST, and since the CRM_Utils_Request::retrieve uses $method = 'REQUEST' by default, checkbox array in $_POST was getting processed.
