### PR TITLE
-- CRM-12823 created a popup for "Add New Record"

### DIFF
--- a/templates/CRM/Profile/Form/Dynamic.tpl
+++ b/templates/CRM/Profile/Form/Dynamic.tpl
@@ -28,13 +28,14 @@
 {if ($context eq 'multiProfileDialog')}
 {literal}
 <script type="text/javascript">
-cj(function() {
+cj(function($) {
+  $('#profile-dialog .crm-container-snippet #Edit').validate(CRM.validate.params);
   var formOptions = {
     beforeSubmit:  proccessMultiRecordForm //pre-submit callback
   };
 
   //binding the callback to snippet profile form
-  cj('.crm-container-snippet #Edit').ajaxForm(formOptions);
+  $('.crm-container-snippet #Edit').ajaxForm(formOptions);
 });
 
 // pre-submit callback
@@ -55,10 +56,7 @@ function proccessMultiRecordForm(formData, jqForm, options) {
 
     //if there is any form error show the dialog
     //else redirect to post url
-    if (cj(response).find('.crm-error').html()) {
-      cj('#profile-dialog').show().html(response);
-    }
-    else {
+    if (!cj(response).find('.crm-error').html()) {
       window.location = '{/literal}{$postUrl}{literal}';
     }
 
@@ -69,6 +67,7 @@ function proccessMultiRecordForm(formData, jqForm, options) {
 }
 </script>
 {/literal}
+{include file="CRM/Form/validate.tpl"}
 {/if}
 {if $deleteRecord}
 <div class="messages status no-popup">

--- a/templates/CRM/Profile/Page/MultipleRecordFieldsListing.tpl
+++ b/templates/CRM/Profile/Page/MultipleRecordFieldsListing.tpl
@@ -52,54 +52,55 @@
       </div>
     </div>
     <div id='profile-dialog' class="hiddenElement"></div>
-    {literal}
-      <script type='text/javascript'>
-        cj(function () {
-          function formDialog(dataURL, dialogTitle) {
-            cj.ajax({
-              url: dataURL,
-              success: function (content) {
-                cj('#profile-dialog').show().html(content).dialog({
-                  title: dialogTitle,
-                  modal: true,
-                  width: 680,
-                  overlay: {
-                    opacity: 0.5,
-                    background: "black"
-                  },
-
-                  close: function (event, ui) {
-                    cj('#profile-dialog').html('');
-                  }
-                });
-                cj('.action-link').hide();
-                cj('#profile-dialog #crm-profile-block .edit-value label').css('display', 'inline');
-              }});
-          }
-
-          cj('.action-item').each(function () {
-            cj(this).attr('jshref', cj(this).attr('href'));
-            cj(this).attr('href', '#browseValues');
-          });
-
-          cj(".action-item").click(function () {
-            dataURL = cj(this).attr('jshref');
-            dialogTitle = cj(this).attr('title');
-            formDialog(dataURL, dialogTitle);
-          });
-        });
-      </script>
-    {/literal}
   {elseif !$records}
     <div class="messages status no-popup">
       <div class="icon inform-icon"></div>
       &nbsp;
       {ts}No multi-record entries found. Note: check is Include in multi-record listing property of the fields you want to display in listings{/ts}
     </div>
+    <div id='profile-dialog' class="hiddenElement"></div>
   {/if}
 
   {if !$reachedMax}
-    <a accesskey="N" href="{crmURL p='civicrm/profile/edit' q="id=`$contactId`&multiRecord=add&gid=`$gid`"}"
-       class="button"><span><div class="icon add-icon"></div>{ts}Add New Record{/ts}</span></a>
+    <a accesskey="N" href="{crmURL p='civicrm/profile/edit' q="id=`$contactId`&multiRecord=add&gid=`$gid`&snippet=1&context=multiProfileDialog"}"
+       class="button action-item"><span><div class="icon add-icon"></div>{ts}Add New Record{/ts}</span></a>
   {/if}
 {/if}
+{literal}
+  <script type='text/javascript'>
+    cj(function () {
+      function formDialog(dataURL, dialogTitle) {
+        cj.ajax({
+          url: dataURL,
+          success: function (content) {
+            cj('#profile-dialog').show().html(content).dialog({
+              title: dialogTitle,
+              modal: true,
+              width: 680,
+              overlay: {
+                opacity: 0.5,
+                background: "black"
+              },
+
+            close: function (event, ui) {
+              cj('#profile-dialog').html('');
+            }
+          });
+          cj('.action-link').hide();
+          cj('#profile-dialog #crm-profile-block .edit-value label').css('display', 'inline');
+        }});
+      }
+
+      cj('.action-item').each(function () {
+        cj(this).attr('jshref', cj(this).attr('href'));
+        cj(this).attr('href', '#browseValues');
+      });
+
+      cj(".action-item").click(function () {
+        dataURL = cj(this).attr('jshref');
+        dialogTitle = cj(this).attr('title');
+        formDialog(dataURL, dialogTitle);
+      });
+    });
+    </script>
+  {/literal}


### PR DESCRIPTION
---
- CRM-12823: "Add" should use same popup as "Edit" in multi-row custom data tables
  http://issues.civicrm.org/jira/browse/CRM-12823
1. The js for dialog box i.e. the formDialog js function in the code, was getting called only when $records was set. So, in a case where there is no records and we have the "Add new Record" button, the js wouldn't be called. So, in the fix I placed the js function outside the "if" condition so that its accessible in both cases. And I added the class "action-item" for "Add New Record" button so that the js function would be called on its click. And in the href, I added the snippet as 1 and context as "multiProfileDialog" so that the validation js and ajax call from the file Dynamic.tpl file will be called same as the case when we click on "Edit" link.
2. After clicking on the "Add New Record" button, the page gets redirected to the profile edit mode page instead of the contact tab page. Same is the case when we click on edit link and on cancel button. The fix for that is not included in this PR. I am working on that.
