### PR TITLE
CRM-12867

### DIFF
--- a/CRM/Logging/ReportSummary.php
+++ b/CRM/Logging/ReportSummary.php
@@ -209,10 +209,36 @@ class CRM_Logging_ReportSummary extends CRM_Report_Form {
       }
     }
 
+    // add computed log_type column so that we can do a group by after that, which will help
+    // alterDisplay() counts sync with pager counts
+    $sql = "SELECT DISTINCT log_type FROM civicrm_temp_civireport_logsummary";
+    $dao = CRM_Core_DAO::executeQuery($sql);
+    $replaceWith = array();
+    while($dao->fetch()){
+      $type = $this->getLogType($dao->log_type);
+      if (!array_key_exists($type,$replaceWith)) 
+        $replaceWith[$type] = array();
+      $replaceWith[$type][] = $dao->log_type;
+    }
+    foreach ($replaceWith as $type => $tables) {
+      if (!empty($tables)) {
+        $replaceWith[$type] = implode("','", $tables);
+      }
+    }
+    
+    $sql = "ALTER TABLE civicrm_temp_civireport_logsummary ADD COLUMN log_civicrm_entity_log_type_label varchar(64)";
+    CRM_Core_DAO::executeQuery($sql);
+    foreach ($replaceWith as $type => $in) {
+      $sql = "UPDATE civicrm_temp_civireport_logsummary SET log_civicrm_entity_log_type_label='{$type}', log_date=log_date WHERE log_type IN('$in')";
+      CRM_Core_DAO::executeQuery($sql);
+    }
+
+    // note the group by columns are same as that used in alterDisplay as $newRows - $key
     $this->limit();
     $sql = "{$this->_select}
 FROM civicrm_temp_civireport_logsummary entity_log_civireport
-ORDER BY entity_log_civireport.log_date DESC {$this->_limit}";
+GROUP BY log_civicrm_entity_log_date, log_civicrm_entity_log_type_label, log_civicrm_entity_log_conn_id, log_civicrm_entity_log_user_id, log_civicrm_entity_altered_contact_id
+ORDER BY log_civicrm_entity_log_date DESC {$this->_limit}";
     $sql = str_replace('modified_contact_civireport.display_name', 'entity_log_civireport.altered_contact',   $sql);
     $sql = str_replace('modified_contact_civireport.id',           'entity_log_civireport.altered_contact_id', $sql);
     $sql = str_replace(array('modified_contact_civireport.', 'altered_by_contact_civireport.'), 'entity_log_civireport.', $sql);

--- a/CRM/Report/Form/Contact/LoggingSummary.php
+++ b/CRM/Report/Form/Contact/LoggingSummary.php
@@ -206,7 +206,7 @@ class CRM_Report_Form_Contact_LoggingSummary extends CRM_Logging_ReportSummary {
         $row['log_civicrm_entity_log_type'] . '_' .
         $row['log_civicrm_entity_log_conn_id'] . '_' .
         $row['log_civicrm_entity_log_user_id'] . '_' .
-        $row['log_civicrm_entity_id'];
+        $row['log_civicrm_entity_altered_contact_id'];
       $newRows[$key] = $row;
 
       unset($row['log_civicrm_entity_log_user_id']);


### PR DESCRIPTION
Problem was that in alterDisplay we try to suppress some rows, concluding duplicate or repetition. Final count (displayed in stats) is different from those present in temp table (displayed as pager) and therefore a mismatch.
The included fix does a group by on temp table so $rows in php and number of records in temp table match.

Another fix was made to consider group by of 'altered_contact_id' instead of 'entity_id' which gave better / less-repetitive results.
For example - just an email update of a contact - updates contact, email and custom (assuming 1 custom table) tables - a total of 3 tables. And the log report would show the update logs 3 times instead of 1.

---
- CRM-12867:  Changelog enhanced summary report: pagination erroneous count
  http://issues.civicrm.org/jira/browse/CRM-12867
