### PR TITLE
CRM-12942  fix

### DIFF
--- a/CRM/Custom/Form/Group.php
+++ b/CRM/Custom/Form/Group.php
@@ -352,12 +352,8 @@ class CRM_Custom_Form_Group extends CRM_Core_Form {
     $this->addElement('checkbox', 'is_active', ts('Is this Custom Data Set active?'));
 
     // does this set have multiple record?
-    $multiple = $this->addElement('checkbox',
-      'is_multiple',
-      ts('Does this Custom Field Set allow multiple records?'),
-      NULL,
-      array('onclick' => "showRange();")
-    );
+    $multiple = $this->addElement('checkbox', 'is_multiple',
+      ts('Does this Custom Field Set allow multiple records?'), NULL);
 
     // $min_multiple = $this->add('text', 'min_multiple', ts('Minimum number of multiple records'), $attributes['min_multiple'] );
     // $this->addRule('min_multiple', ts('is a numeric field') , 'numeric');

--- a/CRM/Custom/Form/Group.php
+++ b/CRM/Custom/Form/Group.php
@@ -288,9 +288,8 @@ class CRM_Custom_Form_Group extends CRM_Core_Form {
       'extends',
       ts('Used For'),
       array(
-        'onClick' => 'showHideStyle();',
         'name' => 'extends[0]',
-        'style' => 'vertical-align: top;',
+        'style' => 'vertical-align: top;'
       ),
       TRUE
     );

--- a/templates/CRM/Custom/Form/Group.tpl
+++ b/templates/CRM/Custom/Form/Group.tpl
@@ -85,94 +85,105 @@
 {$initHideBlocks}
 {literal}
 <script type="text/Javascript">
+cj(function($) {
 
-showHideStyle( );
-cj('#extends_0').change(function() {
   showHideStyle();
-});
-var  isGroupEmpty = "{/literal}{$isGroupEmpty}{literal}";
+  cj('#extends_0').change(function() {
+    showHideStyle();
+  });
 
-if ( isGroupEmpty ) {
-     showRange( true );
-}
-
-function showHideStyle() {
-  var isShow  = false;
-  var extend  = cj('#extends_0 :selected').val();
-
-  var contactTypes    = {/literal}{$contactTypes}{literal};
-  var showStyle       = "{/literal}{$showStyle}{literal}";
-  var showMultiple    = "{/literal}{$showMultiple}{literal}";
-  var showMaxMultiple = "{/literal}{$showMaxMultiple}{literal}";
-
-  if (cj.inArray(extend, contactTypes) >= 0) {
-    isShow  = true;
+  var  isGroupEmpty = "{/literal}{$isGroupEmpty}{literal}";
+  if (isGroupEmpty) {
+    showRange(true);
   }
-  if (isShow) {
-    cj("tr#style").show();
-    cj("tr#is_multiple").show();
-  } else {
-    cj("tr#style").hide();
-    cj("tr#is_multiple").hide();
-    cj("tr#multiple").hide();
-  }
+  cj('#is_multiple').click(function() {
+    showRange();
+  });
 
-  if (showStyle) {
-    cj("tr#style").show();
-  }
+  function showHideStyle() {
+    var isShow  = false;
+    var extend  = cj('#extends_0').val();
 
-  if (showMultiple) {
-    cj("tr#style").show();
-    cj("tr#is_multiple").show();
-  }
+    var contactTypes    = {/literal}{$contactTypes}{literal};
+    var showStyle       = "{/literal}{$showStyle}{literal}";
+    var showMultiple    = "{/literal}{$showMultiple}{literal}";
+    var showMaxMultiple = "{/literal}{$showMaxMultiple}{literal}";
 
-  if (!showMaxMultiple) {
-    cj("tr#multiple").hide();
-  } else if(cj( '#is_multiple').attr('checked')) {
-    cj("tr#multiple").show();
-  }
-}
-
-function showRange( onFormLoad )
-{
-    if( cj("#is_multiple :checked").length ) {
-        cj("tr#multiple").show();
-        cj("select#style option[value='Tab']").attr("selected", "selected");
-    } else {
-        cj("tr#multiple").hide();
-        if ( !onFormLoad ) {
-            cj("select#style option[value='Inline']").attr("selected", "selected");
-        }
+    if (cj.inArray(extend, contactTypes) >= 0) {
+      isShow  = true;
     }
-}
 
-// In update mode, when 'extends' is set to an option which doesn't have
-// any options in 2nd selector (for subtypes)  -
-var subtypes = document.getElementById('extends_1');
-if ( subtypes ) {
-     if ( subtypes.options.length <= 0 ) {
-          subtypes.style.display = 'none';
-     } else {
-          subtypes.style.display = 'inline';
-     }
-}
-
-function warnDataLoss( )
-{
-   var submittedSubtypes = cj('#extends_1').val();
-   var defaultSubtypes   = {/literal}{$defaultSubtypes}{literal};
-
-   var warning = false;
-   cj.each(defaultSubtypes, function(index, subtype) {
-      if ( cj.inArray(subtype, submittedSubtypes) < 0 ) {
-         warning = true;
+    if (isShow) {
+      cj("tr#style").show();
+      cj("tr#is_multiple").show();
+      if (cj('#is_multiple :checked').length) {
+        cj("tr#multiple").show();
       }
-   });
+    }
+    else {
+      cj("tr#style").hide();
+      cj("tr#is_multiple").hide();
+      cj("tr#multiple").hide();
+    }
 
-   if ( warning ) {
-      return confirm( 'One or more subtypes has been un-selected from the list. Any custom data associated with un-selected subtype would be removed. Click OK to proceed.' );
-   }
-   return true;
+    if (showStyle) {
+      cj("tr#style").show();
+    }
+
+    if (showMultiple) {
+      cj("tr#style").show();
+      cj("tr#is_multiple").show();
+    }
+
+    if (!showMaxMultiple) {
+      cj("tr#multiple").hide();
+    }
+    else if(cj( '#is_multiple').attr('checked')) {
+      cj("tr#multiple").show();
+    }
+  }
+
+  function showRange(onFormLoad) {
+    if(cj("#is_multiple :checked").length) {
+      cj("tr#multiple").show();
+      cj("select#style option[value='Tab']").attr("selected", "selected");
+    }
+    else {
+      cj("tr#multiple").hide();
+      if (!onFormLoad) {
+        cj("select#style option[value='Inline']").attr("selected", "selected");
+      }
+    }
+  }
+
+  // In update mode, when 'extends' is set to an option which doesn't have
+  // any options in 2nd selector (for subtypes)  -
+  var subtypes = document.getElementById('extends_1');
+  if (subtypes) {
+    if (subtypes.options.length <= 0) {
+      subtypes.style.display = 'none';
+    }
+    else {
+      subtypes.style.display = 'inline';
+    }
+  }
+});
+
+function warnDataLoss() {
+  var submittedSubtypes = cj('#extends_1').val();
+  var defaultSubtypes   = {/literal}{$defaultSubtypes}{literal};
+
+  var warning = false;
+  cj.each(defaultSubtypes, function(index, subtype) {
+    if (cj.inArray(subtype, submittedSubtypes) < 0) {
+      warning = true;
+    }
+  });
+
+  if (warning) {
+    return confirm( 'One or more subtypes has been un-selected from the list. Any custom data associated with un-selected subtype would be removed. Click OK to proceed.' );
+  }
+  return true;
 }
 </script>
 {/literal}

--- a/templates/CRM/Custom/Form/Group.tpl
+++ b/templates/CRM/Custom/Form/Group.tpl
@@ -87,49 +87,50 @@
 <script type="text/Javascript">
 
 showHideStyle( );
-
+cj('#extends_0').change(function() {
+  showHideStyle();
+});
 var  isGroupEmpty = "{/literal}{$isGroupEmpty}{literal}";
 
 if ( isGroupEmpty ) {
      showRange( true );
 }
 
-function showHideStyle()
-{
-  var isShow          = false;
-  var extend          = document.getElementById("extends_0").value;
-    var contactTypes    = {/literal}'{$contactTypes}'{literal};
-    var showStyle       = "{/literal}{$showStyle}{literal}";
-    var showMultiple    = "{/literal}{$showMultiple}{literal}";
-    var showMaxMultiple = "{/literal}{$showMaxMultiple}{literal}";
+function showHideStyle() {
+  var isShow  = false;
+  var extend  = cj('#extends_0 :selected').val();
 
-    eval('var contactTypes = ' + contactTypes);
+  var contactTypes    = {/literal}{$contactTypes}{literal};
+  var showStyle       = "{/literal}{$showStyle}{literal}";
+  var showMultiple    = "{/literal}{$showMultiple}{literal}";
+  var showMaxMultiple = "{/literal}{$showMaxMultiple}{literal}";
 
-    if ( cj.inArray(extend, contactTypes) >= 0 ) {
-        isShow  = true;
-    }
-  if( isShow  ) {
-        cj("tr#style").show();
-        cj("tr#is_multiple").show();
+  if (cj.inArray(extend, contactTypes) >= 0) {
+    isShow  = true;
+  }
+  if (isShow) {
+    cj("tr#style").show();
+    cj("tr#is_multiple").show();
   } else {
-        cj("tr#style").hide();
-        cj("tr#is_multiple").hide();
-     }
+    cj("tr#style").hide();
+    cj("tr#is_multiple").hide();
+    cj("tr#multiple").hide();
+  }
 
-    if ( showStyle ) {
-        cj("tr#style").show();
-    }
+  if (showStyle) {
+    cj("tr#style").show();
+  }
 
-    if ( showMultiple ) {
-        cj("tr#style").show();
-        cj("tr#is_multiple").show();
-    }
+  if (showMultiple) {
+    cj("tr#style").show();
+    cj("tr#is_multiple").show();
+  }
 
-    if ( !showMaxMultiple ) {
-         cj("tr#multiple").hide();
-    } else if( cj( '#is_multiple').attr('checked') ) {
-         cj("tr#multiple").show();
-    }
+  if (!showMaxMultiple) {
+    cj("tr#multiple").hide();
+  } else if(cj( '#is_multiple').attr('checked')) {
+    cj("tr#multiple").show();
+  }
 }
 
 function showRange( onFormLoad )


### PR DESCRIPTION
the visibility of 'allow multiple records?' and 'Tab/Inline' preference was dependent on element 'Used For' (extends_0)  'onclick' event. 

Now the display of these elements depends on 'change' event of 'Used For' selection.

did a bit of clean up as well (removal of eval, etc).
