### PR TITLE
-- fixes for CRM-12941, CRM-12863 & CRM-12824

### DIFF
--- a/CRM/Profile/Form/Edit.php
+++ b/CRM/Profile/Form/Edit.php
@@ -62,6 +62,9 @@ class CRM_Profile_Form_Edit extends CRM_Profile_Form {
   function preProcess() {
     $this->_mode = CRM_Profile_Form::MODE_CREATE;
 
+    $this->_tabDisplay = CRM_Utils_Request::retrieve('tabDisplay', 'String', $this);
+    $this->assign('tabDisplay', $this->_tabDisplay);
+
     //set the context for the profile
     $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this);
 
@@ -213,6 +216,12 @@ SELECT module
         //passing the post url to template so the popup form does
         //proper redirection and proccess form errors if any
         $popupRedirect = CRM_Utils_System::url('civicrm/profile/edit', $urlParams, FALSE, NULL, FALSE);
+
+        if ($this->_tabDisplay) {
+          $popupRedirect = CRM_Utils_System::url('civicrm/contact/view', 
+            "reset=1&cid={$this->_id}&selectedChild=custom_{$this->_customGroupId}", FALSE, NULL, FALSE);
+        }
+
         $this->assign('urlParams', $urlParams);
         $this->assign('postUrl', $popupRedirect);
       }

--- a/templates/CRM/Profile/Page/MultipleRecordFieldsListing.tpl
+++ b/templates/CRM/Profile/Page/MultipleRecordFieldsListing.tpl
@@ -24,7 +24,7 @@
  +--------------------------------------------------------------------+
 *}
 {if $showListing}
-  <h1>{ts}{$customGroupTitle}{/ts}</h1>
+  {if !$tabDisplay}<h1>{ts}{$customGroupTitle}{/ts}</h1>{/if}
   {if $records and $headers}
     {include file="CRM/common/jsortable.tpl"}
     <div id="browseValues">
@@ -94,7 +94,11 @@
     <div class="messages status no-popup">
       <div class="icon inform-icon"></div>
       &nbsp;
-      {ts}No multi-record entries found. Note: check is Include in multi-record listing property of the fields you want to display in listings{/ts}
+      {if $tabDisplay}
+        {ts 1=$customGroupTitle}No records of type '%1' found.{/ts}
+      {else}
+        {ts}No multi-record entries found. Note: check is Include in multi-record listing property of the fields you want to display in listings{/ts}
+      {/if}
     </div>
   {/if}
 


### PR DESCRIPTION
---
- CRM-12941: Redirect to proper contact tab after saving profile
  http://issues.civicrm.org/jira/browse/CRM-12941
- CRM-12863: Hide profile titles in HR tabs
  http://issues.civicrm.org/jira/browse/CRM-12863
- CRM-12824: Override message for empty tabs
  http://issues.civicrm.org/jira/browse/CRM-12824

The fix in this PR is for CiviHR functionality which also includes the CiviHR PR https://github.com/civicrm/civihr/pull/22. The Profile form redirection works for the Edit and Delete link for now. Once PR https://github.com/civicrm/civicrm-core/pull/1032 is merged(Add New record popup), it will also work for create mode.
