### PR TITLE
-- CRM-11737 fix for anonymous user

### DIFF
--- a/CRM/PCP/Form/PCPAccount.php
+++ b/CRM/PCP/Form/PCPAccount.php
@@ -108,16 +108,14 @@ class CRM_PCP_Form_PCPAccount extends CRM_Core_Form {
   }
 
   function setDefaultValues() {
-    if (!$this->_contactID) {
-      return;
+    if ($this->_contactID) {
+      foreach ($this->_fields as $name => $dontcare) {
+        $fields[$name] = 1;
+      }
+      
+      CRM_Core_BAO_UFGroup::setProfileDefaults($this->_contactID, $fields, $this->_defaults);
     }
     $stateCountryMap = array();
-    foreach ($this->_fields as $name => $dontcare) {
-      $fields[$name] = 1;
-    }
-
-    CRM_Core_BAO_UFGroup::setProfileDefaults($this->_contactID, $fields, $this->_defaults);
-
     //set custom field defaults
     foreach ($this->_fields as $name => $field) {
       if ($customFieldID = CRM_Core_BAO_CustomField::getKeyID($name)) {


### PR DESCRIPTION
---
- CRM-11737: PCP Account profile: state/country ajax not enabled
  http://issues.civicrm.org/jira/browse/CRM-11737

In case of anonymous user, the break still persisted because within the setDefaultValues function, there was a condition to check if the contactID was set. If not set, the function would return directly. So, the fix made for this issue was not getting executed.
