### PR TITLE
CRM-12634 Simplified fix using crmURL.

### DIFF
--- a/CRM/Upgrade/Page/Upgrade.php
+++ b/CRM/Upgrade/Page/Upgrade.php
@@ -54,9 +54,6 @@ class CRM_Upgrade_Page_Upgrade extends CRM_Core_Page {
     $template->assign('pageTitle', ts('Upgrade CiviCRM to Version %1',
       array(1 => $latestVer)
     ));
-    $template->assign('menuRebuildURL',
-      CRM_Utils_System::url('civicrm/menu/rebuild', 'reset=1')
-    );
     $template->assign('cancelURL',
       CRM_Utils_System::url('civicrm/dashboard', 'reset=1')
     );

--- a/templates/CRM/common/success.tpl
+++ b/templates/CRM/common/success.tpl
@@ -67,6 +67,6 @@
         <h3>Important Notes</h3>
         <p>{$afterUpgradeMessage}</p>
       {/if}
-      <p><a href="{$menuRebuildURL}" title="{ts}CiviCRM home page{/ts}" style="text-decoration: underline;">{ts}Return to CiviCRM home page.{/ts}</a></p>
+      <p><a href="{crmURL p='civicrm/dashboard' q='reset=1'}" title="{ts}CiviCRM home page{/ts}" style="text-decoration: underline;">{ts}Return to CiviCRM home page.{/ts}</a></p>
     </div>
 {/if}


### PR DESCRIPTION
---
- CRM-12634: Return to home page link on upgrade finish page doesn't need to rebuild menus
  http://issues.civicrm.org/jira/browse/CRM-12634
