### PR TITLE
-- CRM-12941, CRM-12863 & CRM-12824 changes made as per the comments

### DIFF
--- a/CRM/Profile/Form/Edit.php
+++ b/CRM/Profile/Form/Edit.php
@@ -62,8 +62,7 @@ class CRM_Profile_Form_Edit extends CRM_Profile_Form {
   function preProcess() {
     $this->_mode = CRM_Profile_Form::MODE_CREATE;
 
-    $this->_tabDisplay = CRM_Utils_Request::retrieve('tabDisplay', 'String', $this);
-    $this->assign('tabDisplay', $this->_tabDisplay);
+    $this->_onPopupClose = CRM_Utils_Request::retrieve('onPopupClose', 'String', $this);
 
     //set the context for the profile
     $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this);
@@ -217,7 +216,7 @@ SELECT module
         //proper redirection and proccess form errors if any
         $popupRedirect = CRM_Utils_System::url('civicrm/profile/edit', $urlParams, FALSE, NULL, FALSE);
 
-        if ($this->_tabDisplay) {
+        if ($this->_onPopupClose == 'redirectToTab') {
           $popupRedirect = CRM_Utils_System::url('civicrm/contact/view', 
             "reset=1&cid={$this->_id}&selectedChild=custom_{$this->_customGroupId}", FALSE, NULL, FALSE);
         }

--- a/CRM/Profile/Form/Edit.php
+++ b/CRM/Profile/Form/Edit.php
@@ -214,9 +214,10 @@ SELECT module
 
         //passing the post url to template so the popup form does
         //proper redirection and proccess form errors if any
-        $popupRedirect = CRM_Utils_System::url('civicrm/profile/edit', $urlParams, FALSE, NULL, FALSE);
-
-        if ($this->_onPopupClose == 'redirectToTab') {
+        if (!isset($this->_onPopupClose) || $this->_onPopupClose == 'redirectToProfile') {
+          $popupRedirect = CRM_Utils_System::url('civicrm/profile/edit', $urlParams, FALSE, NULL, FALSE);
+        }
+        elseif ($this->_onPopupClose == 'redirectToTab') {
           $popupRedirect = CRM_Utils_System::url('civicrm/contact/view', 
             "reset=1&cid={$this->_id}&selectedChild=custom_{$this->_customGroupId}", FALSE, NULL, FALSE);
         }

--- a/templates/CRM/Profile/Page/MultipleRecordFieldsListing.tpl
+++ b/templates/CRM/Profile/Page/MultipleRecordFieldsListing.tpl
@@ -24,7 +24,7 @@
  +--------------------------------------------------------------------+
 *}
 {if $showListing}
-  {if !$tabDisplay}<h1>{ts}{$customGroupTitle}{/ts}</h1>{/if}
+  <h1>{ts}{$customGroupTitle}{/ts}</h1>
   {if $records and $headers}
     {include file="CRM/common/jsortable.tpl"}
     <div id="browseValues">
@@ -56,11 +56,7 @@
     <div class="messages status no-popup">
       <div class="icon inform-icon"></div>
       &nbsp;
-      {if $tabDisplay}
-        {ts 1=$customGroupTitle}No records of type '%1' found.{/ts}
-      {else}
-        {ts}No multi-record entries found. Note: check is Include in multi-record listing property of the fields you want to display in listings{/ts}
-      {/if}
+      {ts 1=$customGroupTitle}No records of type '%1' found.{/ts}
     </div>
     <div id='profile-dialog' class="hiddenElement"></div>
   {/if}


### PR DESCRIPTION
---
- CRM-12941: Redirect to proper contact tab after saving profile
  http://issues.civicrm.org/jira/browse/CRM-12941
- CRM-12863: Hide profile titles in HR tabs
  http://issues.civicrm.org/jira/browse/CRM-12863
- CRM-12824: Override message for empty tabs
  http://issues.civicrm.org/jira/browse/CRM-12824
1. Made use of 'onPopupClose' to judge the redirection with its value as 'redirectToTab'. Also, handled the url(civicrm/profile/view) with conditions checking if onPopupClose is not set or if its value is 'redirectToProfile'.
2. Removed the tabDisplay condition that restricted the display of profile title. Will work on it after  CRM-12865 is done.
3. Removed the old message that was getting displayed for the empty records case. Now, the new message will be displayed in both tab and standalone mode.

This fix also includes CiviHR PR https://github.com/civicrm/civihr/pull/24
