### PR TITLE
CRM-12783 - Get content via HTTPS

### DIFF
--- a/CRM/Core/CommunityMessages.php
+++ b/CRM/Core/CommunityMessages.php
@@ -30,7 +30,7 @@
  */
 class CRM_Core_CommunityMessages {
 
-  const DEFAULT_MESSAGES_URL = 'http://alert.civicrm.org/alert?prot=1&ver={ver}&uf={uf}&sid={sid}&lang={lang}&co={co}';
+  const DEFAULT_MESSAGES_URL = 'https://alert.civicrm.org/alert?prot=1&ver={ver}&uf={uf}&sid={sid}&lang={lang}&co={co}';
   const DEFAULT_PERMISSION = 'administer CiviCRM';
 
   /**

--- a/CRM/Dashlet/Page/Blog.php
+++ b/CRM/Dashlet/Page/Blog.php
@@ -38,7 +38,9 @@
  */
 class CRM_Dashlet_Page_Blog extends CRM_Core_Page {
 
-  const CHECK_TIMEOUT = 5, CACHE_DAYS = 1;
+  const CHECK_TIMEOUT = 5;
+  const CACHE_DAYS = 1;
+  const BLOG_URL = 'https://civicrm.org/blog/feed';
 
   /**
    * List blog articles as dashlet
@@ -85,14 +87,18 @@ class CRM_Dashlet_Page_Blog extends CRM_Core_Page {
   /**
    * Parse rss feed and cache results
    *
-   * @return array
+   * @return array|NULL array of blog items; or NULL if not available
    *
    * @access private
    */
   private function _getFeed() {
-    ini_set('default_socket_timeout', self::CHECK_TIMEOUT);
-    $feed = @simplexml_load_file('http://civicrm.org/blog/feed');
-    ini_restore('default_socket_timeout');
+    $httpClient = new CRM_Utils_HttpClient(self::CHECK_TIMEOUT);
+    list ($status, $rawFeed) = $httpClient->get(self::BLOG_URL);
+    if ($status !== CRM_Utils_HttpClient::STATUS_OK) {
+      return NULL;
+    }
+    $feed = @simplexml_load_string($rawFeed);
+
     $blog = array();
     if ($feed && !empty($feed->channel->item)) {
       foreach ($feed->channel->item as $item) {

--- a/CRM/Extension/Container/Basic.php
+++ b/CRM/Extension/Container/Basic.php
@@ -109,7 +109,6 @@ class CRM_Extension_Container_Basic implements CRM_Extension_Container_Interface
       );
     }
     if (empty($this->baseUrl)) {
-      dpm($this);
       $errors[] = array(
         'title' => ts('Invalid Base URL'),
         'message' => ts('An extension container has been defined with a blank URL.'),

--- a/CRM/Utils/HttpClient.php
+++ b/CRM/Utils/HttpClient.php
@@ -50,9 +50,9 @@ class CRM_Utils_HttpClient {
   protected static $singleton;
 
   /**
-   * @var int
+   * @var int|NULL seconds; or NULL to use system default
    */
-  protected $timeout;
+  protected $connectionTimeout;
 
   public static function singleton() {
     if (!self::$singleton) {
@@ -61,8 +61,8 @@ class CRM_Utils_HttpClient {
     return self::$singleton;
   }
 
-  public function __construct($timeout = 10) {
-    $this->timeout = $timeout;
+  public function __construct($connectionTimeout = NULL) {
+    $this->connectionTimeout = $connectionTimeout;
   }
 
   /**
@@ -190,6 +190,9 @@ class CRM_Utils_HttpClient {
     curl_setopt($ch, CURLOPT_ENCODING, 'gzip');
     curl_setopt($ch, CURLOPT_VERBOSE, 0);
     curl_setopt($ch, CURLOPT_FOLLOWLOCATION, TRUE);
+    if ($this->connectionTimeout !== NULL) {
+      curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $this->connectionTimeout);
+    }
     if (preg_match('/^https:/', $remoteFile) && $caConfig->isEnableSSL()) {
       curl_setopt_array($ch, $caConfig->toCurlOptions());
     }

--- a/tests/phpunit/CRM/Extension/BrowserTest.php
+++ b/tests/phpunit/CRM/Extension/BrowserTest.php
@@ -12,28 +12,28 @@ class CRM_Extension_BrowserTest extends CiviUnitTestCase {
   }
 
   function testDisabled() {
-    $browser = new CRM_Extension_Browser(FALSE, '/index.html', '/itd/oesn/tmat/ter');
+    $browser = new CRM_Extension_Browser(FALSE, '/index.html', 'file:///itd/oesn/tmat/ter');
     $this->assertEquals(FALSE, $browser->isEnabled());
     $this->assertEquals(array(), $browser->checkRequirements());
     $this->assertEquals(array(), $browser->getExtensions());
   }
 
   function testCheckRequirements_BadCachedir_false() {
-    $browser = new CRM_Extension_Browser(dirname(__FILE__) .'/dataset/good-repository', '/index.html', FALSE);
+    $browser = new CRM_Extension_Browser('file://' . dirname(__FILE__) .'/dataset/good-repository', '/index.html', FALSE);
     $this->assertEquals(TRUE, $browser->isEnabled());
     $reqs = $browser->checkRequirements();
     $this->assertEquals(1, count($reqs));
   }
 
   function testCheckRequirements_BadCachedir_nonexistent() {
-    $browser = new CRM_Extension_Browser(dirname(__FILE__) .'/dataset/good-repository', '/index.html', '/tot/all/yin/v/alid');
+    $browser = new CRM_Extension_Browser('file://' . dirname(__FILE__) .'/dataset/good-repository', '/index.html', '/tot/all/yin/v/alid');
     $this->assertEquals(TRUE, $browser->isEnabled());
     $reqs = $browser->checkRequirements();
     $this->assertEquals(1, count($reqs));
   }
 
   function testGetExtensions_good() {
-    $browser = new CRM_Extension_Browser(dirname(__FILE__) .'/dataset/good-repository', '/index.html', $this->createTempDir('ext-cache-'));
+    $browser = new CRM_Extension_Browser('file://' . dirname(__FILE__) .'/dataset/good-repository', '/index.html', $this->createTempDir('ext-cache-'));
     $this->assertEquals(TRUE, $browser->isEnabled());
     $this->assertEquals(array(), $browser->checkRequirements());
     $exts = $browser->getExtensions();
@@ -47,7 +47,7 @@ class CRM_Extension_BrowserTest extends CiviUnitTestCase {
   }
 
   function testGetExtension_good() {
-    $browser = new CRM_Extension_Browser(dirname(__FILE__) .'/dataset/good-repository', '/index.html', $this->createTempDir('ext-cache-'));
+    $browser = new CRM_Extension_Browser('file://' . dirname(__FILE__) .'/dataset/good-repository', '/index.html', $this->createTempDir('ext-cache-'));
     $this->assertEquals(TRUE, $browser->isEnabled());
     $this->assertEquals(array(), $browser->checkRequirements());
 
@@ -57,7 +57,7 @@ class CRM_Extension_BrowserTest extends CiviUnitTestCase {
   }
 
   function testGetExtension_nonexistent() {
-    $browser = new CRM_Extension_Browser(dirname(__FILE__) .'/dataset/good-repository', '/index.html', $this->createTempDir('ext-cache-'));
+    $browser = new CRM_Extension_Browser('file://' . dirname(__FILE__) .'/dataset/good-repository', '/index.html', $this->createTempDir('ext-cache-'));
     $this->assertEquals(TRUE, $browser->isEnabled());
     $this->assertEquals(array(), $browser->checkRequirements());
 


### PR DESCRIPTION
When fetching backend content (including the blog feed, the community-message, and the list of extensions), use HTTPS.
