### PR TITLE
 crm-12976-fix : using 'strtr' while placeholder replacement mechanism

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1004,13 +1004,7 @@ FROM   civicrm_domain
       }
     }
 
-    // CRM-11582
-    foreach($tr as $key => $value) {
-      $key   = preg_quote($key);
-      $value = preg_quote($value);
-      $query = preg_replace("/$key\b/", $value, $query);
-    }
-    return $query;
+    return strtr($query, $tr);
   }
 
   static function freeResult($ids = NULL) {


### PR DESCRIPTION
CRM-12976 : after the discussion on issue 'strtr' and also a test case that denotes where the 'strstr' could fail.
