### PR TITLE
CRM-12928 fixes

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -193,7 +193,7 @@ class CRM_Dedupe_Merger {
       // foreign keys referencing civicrm_contact(id)
       $cidRefs = array(
         'civicrm_acl_cache' => array('contact_id'),
-        'civicrm_activity' => array('source_contact_id'),
+        'civicrm_activity' => array('source_record_id'),
         'civicrm_activity_contact' => array('contact_id'),
         'civicrm_case_contact' => array('contact_id'),
         'civicrm_contact' => array('primary_contact_id'),


### PR DESCRIPTION
---
- CRM-12928: Merge contacts fatal error: Unknown column 'source_contact_id' in 'where clause (related to activity restructure)
  http://issues.civicrm.org/jira/browse/CRM-12928
