### PR TITLE
CRM-13014 - CRM_Utils_System::userLoginFinalize - Disable due to syntax errors

### DIFF
--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -129,8 +129,9 @@ abstract class CRM_Utils_System_Base {
    * Perform an post login activities required by the UF -
    * e.g. for drupal: records a watchdog message about the new session, saves the login timestamp, calls hook_user op 'login' and generates a new session.
    * @param array $edit: The array of form values submitted by the user.
-   */
+   *
   function userLoginFinalize($edit = array()){
   }
+  */
 }
 

--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -656,10 +656,11 @@ AND    u.status = 1
    * Perform an post login activities required by the UF -
    * e.g. for drupal: records a watchdog message about the new session, saves the login timestamp, calls hook_user op 'login' and generates a new session.
    * @param array $edit: The array of form values submitted by the user.
-   */
+   *
   function userLoginFinalize($edit = array()){
     user_login_finalize(&$edit);
   }
+  */
 
   /**
    * Set a message in the UF to display to a user

--- a/CRM/Utils/System/Drupal6.php
+++ b/CRM/Utils/System/Drupal6.php
@@ -587,10 +587,11 @@ SELECT name, mail
    * Perform an post login activities required by the UF -
    * e.g. for drupal : records a watchdog message about the new session, saves the login timestamp, calls hook_user op 'login' and generates a new session.
    * @param array $edit: The array of form values submitted by the user.
-   */
+   *
   function userLoginFinalize($edit = array()){
     user_authenticate_finalize(&$edit);
   }
+  */
 
   /**
    * Set a message in the UF to display to a user


### PR DESCRIPTION
---
- CRM-13014: CiviMobile fatal on non-d7 -Need a UF function for login authenticate
  http://issues.civicrm.org/jira/browse/CRM-13014
