### PR TITLE
CRM-12865 - Define regions, CSS classes, and hooks for profile forms

### DIFF
--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -256,13 +256,17 @@ class CRM_Profile_Form extends CRM_Core_Form {
     }
     $this->_isContactActivityProfile = CRM_Core_BAO_UFField::checkContactActivityProfileType($this->_gid);
 
-    //get values for captch and dupe update.
+    //get values for ufGroupName, captch and dupe update.
+    $this->assign('ufGroupName', 'unknown'); // override later (if possible)
     if ($this->_gid) {
       $dao = new CRM_Core_DAO_UFGroup();
       $dao->id = $this->_gid;
       if ($dao->find(TRUE)) {
         $this->_isUpdateDupe = $dao->is_update_dupe;
         $this->_isAddCaptcha = $dao->add_captcha;
+        if (!empty($dao->name)) {
+          $this->assign('ufGroupName', $dao->name);
+        }
       }
       $dao->free();
     }

--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -67,6 +67,13 @@ class CRM_Profile_Form extends CRM_Core_Form {
   protected $_gid;
 
   /**
+   * The group id that we are editing
+   *
+   * @var string
+   */
+  protected $_ufGroupName = 'unknown';
+
+  /**
    * The group id that we are passing in url
    *
    * @var int
@@ -257,7 +264,6 @@ class CRM_Profile_Form extends CRM_Core_Form {
     $this->_isContactActivityProfile = CRM_Core_BAO_UFField::checkContactActivityProfileType($this->_gid);
 
     //get values for ufGroupName, captch and dupe update.
-    $this->assign('ufGroupName', 'unknown'); // override later (if possible)
     if ($this->_gid) {
       $dao = new CRM_Core_DAO_UFGroup();
       $dao->id = $this->_gid;
@@ -265,11 +271,12 @@ class CRM_Profile_Form extends CRM_Core_Form {
         $this->_isUpdateDupe = $dao->is_update_dupe;
         $this->_isAddCaptcha = $dao->add_captcha;
         if (!empty($dao->name)) {
-          $this->assign('ufGroupName', $dao->name);
+          $this->_ufGroupName = $dao->name;
         }
       }
       $dao->free();
     }
+    $this->assign('ufGroupName', $this->_ufGroupName);
 
     $gids = empty($this->_profileIds) ? $this->_gid : $this->_profileIds;
 
@@ -577,6 +584,18 @@ class CRM_Profile_Form extends CRM_Core_Form {
    * @access public
    */
   public function buildQuickForm() {
+    switch ($this->_mode) {
+      case self::MODE_CREATE:
+      case self::MODE_EDIT:
+      case self::MODE_REGISTER:
+        CRM_Utils_Hook::buildProfile($this->_ufGroupName);
+        break;
+      case self::MODE_SEARCH:
+        CRM_Utils_Hook::searchProfile($this->_ufGroupName);
+        break;
+      default:
+    }
+
     //lets have single status message, CRM-4363
     $return = FALSE;
     $statusMessage = NULL;
@@ -872,6 +891,8 @@ class CRM_Profile_Form extends CRM_Core_Form {
    * @static
    */
   static function formRule($fields, $files, $form) {
+    CRM_Utils_Hook::validateProfile($form->_ufGroupName);
+
     $errors = array();
     // if no values, return
     if (empty($fields)) {
@@ -1070,6 +1091,7 @@ class CRM_Profile_Form extends CRM_Core_Form {
         return;
       }
     }
+    CRM_Utils_Hook::processProfile($this->_ufGroupName);
     if (CRM_Utils_Array::value('image_URL', $params)) {
       CRM_Contact_BAO_Contact::processImageParams($params);
     }

--- a/CRM/Profile/Page/Dynamic.php
+++ b/CRM/Profile/Page/Dynamic.php
@@ -334,6 +334,7 @@ class CRM_Profile_Page_Dynamic extends CRM_Core_Page {
 
     $name = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_UFGroup', $this->_gid, 'name');
     $this->assign('ufGroupName', $name);
+    CRM_Utils_Hook::viewProfile($name);
 
     if (strtolower($name) == 'summary_overlay') {
       $template->assign('overlayProfile', TRUE);

--- a/CRM/Profile/Page/Dynamic.php
+++ b/CRM/Profile/Page/Dynamic.php
@@ -333,6 +333,7 @@ class CRM_Profile_Page_Dynamic extends CRM_Core_Page {
     }
 
     $name = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_UFGroup', $this->_gid, 'name');
+    $this->assign('ufGroupName', $name);
 
     if (strtolower($name) == 'summary_overlay') {
       $template->assign('overlayProfile', TRUE);

--- a/CRM/Profile/Page/Listings.php
+++ b/CRM/Profile/Page/Listings.php
@@ -283,6 +283,7 @@ class CRM_Profile_Page_Listings extends CRM_Core_Page {
     $this->preProcess();
 
     $this->assign('recentlyViewed', FALSE);
+    $this->assign('ufGroupName', 'unknown'); // override later (if possible)
 
     if ($this->_gid) {
       $ufgroupDAO = new CRM_Core_DAO_UFGroup();
@@ -296,6 +297,9 @@ class CRM_Profile_Page_Listings extends CRM_Core_Page {
       // set the title of the page
       if ($ufgroupDAO->title) {
         CRM_Utils_System::setTitle($ufgroupDAO->title);
+      }
+      if ($ufgroupDAO->name) {
+        $this->assign('ufGroupName', $ufgroupDAO->name);
       }
     }
 

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -1235,4 +1235,54 @@ abstract class CRM_Utils_Hook {
     return self::singleton()->invoke(1, $entityTypes, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_entityTypes'
     );
   }
+
+  /**
+   * This hook is called while preparing a profile form
+   *
+   * @param string $name
+   * @return void
+   */
+  static function buildProfile($name) {
+    return self::singleton()->invoke(1, $name, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_buildProfile');
+  }
+
+  /**
+   * This hook is called while validating a profile form submission
+   *
+   * @param string $name
+   * @return void
+   */
+  static function validateProfile($name) {
+    return self::singleton()->invoke(1, $name, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_validateProfile');
+  }
+
+  /**
+   * This hook is called processing a valid profile form submission
+   *
+   * @param string $name
+   * @return void
+   */
+  static function processProfile($name) {
+    return self::singleton()->invoke(1, $name, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_processProfile');
+  }
+
+  /**
+   * This hook is called while preparing a read-only profile screen
+   *
+   * @param string $name
+   * @return void
+   */
+  static function viewProfile($name) {
+    return self::singleton()->invoke(1, $name, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_viewProfile');
+  }
+
+  /**
+   * This hook is called while preparing a list of contacts (based on a profile)
+   *
+   * @param string $name
+   * @return void
+   */
+  static function searchProfile($name) {
+    return self::singleton()->invoke(1, $name, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_searchProfile');
+  }
 }

--- a/templates/CRM/Profile/Form/Dynamic.tpl
+++ b/templates/CRM/Profile/Form/Dynamic.tpl
@@ -23,6 +23,9 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
+<div class="crm-profile-name-{$ufGroupName}">
+{crmRegion name=profile-form-`$ufGroupName`}
+
 {* Profile forms when embedded in CMS account create (mode=1) or
     cms account edit (mode=8) or civicrm/profile (mode=4) pages *}
 {if ($context eq 'multiProfileDialog')}
@@ -374,3 +377,5 @@ cj(document).ready(function(){
 </script>
 {/literal}
 
+{/crmRegion}
+</div> {* end crm-profile-NAME *}

--- a/templates/CRM/Profile/Page/Dynamic.tpl
+++ b/templates/CRM/Profile/Page/Dynamic.tpl
@@ -29,6 +29,8 @@
         {include file="CRM/Profile/Page/Overlay.tpl"}
     {else}
         <div id="crm-container" class="crm-container" lang="{$config->lcMessages|truncate:2:"":true}" xml:lang="{$config->lcMessages|truncate:2:"":true}">
+            <div class="crm-profile-name-{$ufGroupName}">
+            {crmRegion name=profile-view-`$ufGroupName`}
             {foreach from=$profileFields item=field key=rowName}
               <div id="row-{$rowName}" class="crm-section {$rowName}-section">
                 <div class="label">
@@ -40,6 +42,8 @@
                  <div class="clear"></div>
               </div>
             {/foreach}
+            {/crmRegion}
+            </div>
         </div>
     {/if}
 {/if} 

--- a/templates/CRM/Profile/Page/Listings.tpl
+++ b/templates/CRM/Profile/Page/Listings.tpl
@@ -23,6 +23,10 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
+
+<div class="crm-profile-name-{$ufGroupName}">
+{crmRegion name=profile-search-`$ufGroupName`}
+
 {* make sure there are some fields in the selector *}
 {if ! empty( $columnHeaders ) || $isReset }
 
@@ -90,3 +94,6 @@
     </div>
 {/if}
 </div>
+
+{/crmRegion}
+</div>{* crm-profile-name-NAME *}


### PR DESCRIPTION
With this revision, the following can be used:
- civicrm/profile
  - CSS: form#Search .crm-profile-name-{NAME}
  - Region: profile-search-{NAME}
  - Hooks: searchProfile($name)
- civicrm/profile/create:
  - CSS: form#Edit .crm-profile-name-{NAME}
  - Region: profile-form-{NAME}
  - Hooks: buildProfile($name), validateProfile($name), processProfile($name)
- civicrm/profile/edit:
  - CSS: form#Edit .crm-profile-name-{NAME}
  - Region: profile-form-{NAME}
  - Hooks: buildProfile($name), validateProfile($name), processProfile($name)
- civicrm/profile/view:
  - CSS: .crm-profile-view .crm-profile-name-{NAME}
  - Region: profile-view-{NAME}
  - Hooks: viewProfile($name)
- civicrm/event/register:
  - CSS: .crm-event-register-form-block .crm-profile-name-{NAME}
- civicrm/contribute/transact:
  - CSS: .crm-contribution-main-form-block .crm-profile-name-{NAME}

---
- CRM-12865: Define hook/CSS/region names for profile forms
  http://issues.civicrm.org/jira/browse/CRM-12865
