### PR TITLE
CRM-12846, fix for test case failure - civipledge wasn't enabled by default

### DIFF
--- a/settings/Core.setting.php
+++ b/settings/Core.setting.php
@@ -605,7 +605,7 @@ When enabled, statistics about your CiviCRM installation are reported anonymousl
       'style' => 'width:150px',
       'class' => 'advmultiselect',
     ),
-    'default' => array('CiviEvent', 'CiviContribute', 'CiviMember', 'CiviMail', 'CiviReport', 'CiviCase'),
+    'default' => array('CiviEvent', 'CiviContribute', 'CiviMember', 'CiviMail', 'CiviReport', 'CiviPledge'),
     'add'   => '4.4',
     'title' => 'Enable Components',
     'is_domain' => '1',


### PR DESCRIPTION
---
- CRM-12846: API support for toggling components by storing 'enableComponents' config in settings table
  http://issues.civicrm.org/jira/browse/CRM-12846
