### PR TITLE
CRM-12499 Modify cms to WordPress translatePermission to make cms:admini...

### DIFF
--- a/CRM/Contact/Page/View.php
+++ b/CRM/Contact/Page/View.php
@@ -345,6 +345,7 @@ class CRM_Contact_Page_View extends CRM_Core_Page {
     $config = CRM_Core_Config::singleton();
     $session = CRM_Core_Session::singleton();
     $uid = CRM_Core_BAO_UFMatch::getUFId($cid);
+    $userRecordUrl = NULL;
     if ($uid) {
       if ($config->userSystem->is_drupal == '1' &&
         ($session->get('userID') == $cid || CRM_Core_Permission::checkAnyPerm(array('cms:administer users', 'cms:view user account')))
@@ -361,8 +362,11 @@ class CRM_Contact_Page_View extends CRM_Core_Page {
           $userRecordUrl = $config->userFrameworkBaseURL . "index.php?option=com_admin&view=profile&layout=edit&id=" . $uid;
         }
       }
-      else {
-        $userRecordUrl = NULL;
+      // For WordPress, provide link to user profile is contact belongs to logged in user OR user has administrator role
+      elseif ($config->userFramework == 'WordPress' &&
+        ($session->get('userID') == $cid || CRM_Core_Permission::checkAnyPerm(array('cms:administer users')))
+        ) {
+          $userRecordUrl = $config->userFrameworkBaseURL . "wp-admin/user-edit.php?user_id=" . $uid;
       }
       $obj->assign('userRecordUrl', $userRecordUrl);
       $obj->assign('userRecordId', $uid);

--- a/CRM/Core/Permission/WordPress.php
+++ b/CRM/Core/Permission/WordPress.php
@@ -46,8 +46,9 @@ class CRM_Core_Permission_WordPress extends CRM_Core_Permission_Base {
    * @access public
    */
   function check($str) {
+    // Generic cms 'administer users' role tranlates to 'administrator' WordPress role 
     $str = $this->translatePermission($str, 'WordPress', array(
-      'view user account' => 'administrator',
+      'administer users' => 'administrator',
     ));
     if ($str == CRM_Core_Permission::ALWAYS_DENY_PERMISSION) {
       return FALSE;


### PR DESCRIPTION
...ster users translate to WordPress administrator role. Add logic to contact view to handle WordPress access to user id and user profile url.

---
- CRM-12499: Allow users with 'access user profiles' to access $userRecordUrl
  http://issues.civicrm.org/jira/browse/CRM-12499
