### PR TITLE
-- CRM-12914 made email addresses clickable in profile search results

### DIFF
--- a/CRM/Profile/Selector/Listings.php
+++ b/CRM/Profile/Selector/Listings.php
@@ -306,6 +306,7 @@ class CRM_Profile_Selector_Listings extends CRM_Core_Selector_Base implements CR
           'name' => ts('Name'),
           'sort' => 'sort_name',
           'direction' => CRM_Utils_Sort::ASCENDING,
+          'field_name' => 'sort_name',
         ),
       );
 
@@ -357,6 +358,7 @@ class CRM_Profile_Selector_Listings extends CRM_Core_Selector_Base implements CR
             'name' => $field['title'],
             'sort' => $name,
             'direction' => $direction,
+            'field_name' => CRM_Core_BAO_UFField::isValidFieldName($name) ? $name : $fieldName,
           );
 
           $direction = CRM_Utils_Sort::DONTCARE;
@@ -583,7 +585,7 @@ class CRM_Profile_Selector_Listings extends CRM_Core_Selector_Base implements CR
         $showProfileOverlay
       );
       if ($result->sort_name) {
-        $row['sort_name'] = $result->sort_name;
+        $row[] = $result->sort_name;
         $empty = FALSE;
       }
       else {

--- a/templates/CRM/Profile/Page/Listings.tpl
+++ b/templates/CRM/Profile/Page/Listings.tpl
@@ -73,8 +73,12 @@
       {counter start=0 skip=1 print=false}
       {foreach from=$rows item=row name=listings}
       <tr id="row-{$smarty.foreach.listings.iteration}" class="{cycle values="odd-row,even-row"}">
-      {foreach from=$row item=value}
-        <td>{$value}</td>
+      {foreach from=$row key=index item=value}
+        {if $columnHeaders.$index.field_name}
+          <td class="crm-{$columnHeaders.$index.field_name}">{$value}</td>
+        {else}
+          <td>{$value}</td>
+        {/if}
       {/foreach}
       </tr>
       {/foreach}


### PR DESCRIPTION
---
- CRM-12914: Make email addresses clickable in search results
  http://issues.civicrm.org/jira/browse/CRM-12914
1. Added 'field_name' property in the columnheader and used CRM_Core_BAO_UFField::isValidFieldName function to check if its value matches civicrm_uf_field.field_name. Used 'sort_name' as 'field_name' for sort_name as it is a concatenated combination of first name and last name.
2. Removed the key 'sort_name' from $row[] in https://github.com/ravishnair/civicrm-core/compare/CiviHR#L0L586 to match the index values of the columnheaders with that of rows. Also, I checked and found that this key value was not being used anywhere and also this change won't affect any other searches.
3. Used the index value of $rows to identify its matching columnHeader and assigned its value of field_name property to the class attribute.
