### PR TITLE
-- fixed for CRM-10146, Restricted the creation of same membership and activity again.

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -231,7 +231,7 @@ class CRM_Contact_BAO_Contact extends CRM_Contact_DAO_Contact {
       // create current employer
       if (isset($params['employer_id'])) {
         CRM_Contact_BAO_Contact_Utils::createCurrentEmployerRelationship($contact->id,
-          $params['employer_id']
+          $params['employer_id'], $employerId
         );
       }
       elseif ($params['current_employer']) {


### PR DESCRIPTION
As per Eileen's comment, i have handled the checking downstream to stop the calling of relatedMemberships() function by checking employer id is same as the existing employer id. Introduced the new parameter as per need.
