### PR TITLE
Add event start date to participant report (CRM-13069)

### DIFF
--- a/CRM/Report/Form/Event/ParticipantListing.php
+++ b/CRM/Report/Form/Event/ParticipantListing.php
@@ -214,9 +214,9 @@ class CRM_Report_Form_Event_ParticipantListing extends CRM_Report_Form_Event {
       'civicrm_event' =>
       array(
         'dao' => 'CRM_Event_DAO_Event',
-        'fields' =>
-        array(
+        'fields' => array(
           'event_type_id' => array('title' => ts('Event Type')),
+          'event_start_date' => array('title' => ts('Event Start Date')),
         ),
         'grouping' => 'event-fields',
         'filters' =>
@@ -226,6 +226,10 @@ class CRM_Report_Form_Event_ParticipantListing extends CRM_Report_Form_Event {
             'title' => ts('Event Type'),
             'operatorType' => CRM_Report_Form::OP_MULTISELECT,
             'options' => CRM_Core_OptionGroup::values('event_type'),
+          ),
+          'event_start_date' => array(
+            'title' => ts('Event Start Date'),
+            'operatorType' => CRM_Report_Form::OP_DATE,
           ),
         ),
         'order_bys' =>


### PR DESCRIPTION
The participant report doesn't allow for filtering by event start date.  If you have frequent events, this is a problem--the list of events is cumbersome.  Also, there's no good way to say you want people who came to events last month without regard to when they signed up.

This pull request simply adds event start date as a field to display and a filter.
