### PR TITLE
CRM-13079 Add logic to MembershipBlock formRule to verify that the numbe...

### DIFF
--- a/CRM/Member/Form/MembershipBlock.php
+++ b/CRM/Member/Form/MembershipBlock.php
@@ -270,6 +270,10 @@ class CRM_Member_Form_MembershipBlock extends CRM_Contribute_Form_ContributionPa
         if (array_sum($membershipType) == 0) {
           $errors['membership_type'] = ts('Please select at least one Membership Type to include in the Membership section of this page.');
         }
+        elseif (array_sum($membershipType) > CRM_Price_Form_Field::NUM_OPTION) {
+          // for CRM-13079
+          $errors['membership_type'] = ts('You cannot select more than %1 choices. For more complex functionality, please use a Price Set.', array(1 => CRM_Price_Form_Field::NUM_OPTION));
+        }
       }
 
       //for CRM-1302
@@ -280,7 +284,7 @@ class CRM_Member_Form_MembershipBlock extends CRM_Contribute_Form_ContributionPa
       }
 
       //give error if default is selected for an unchecked membership type
-      if (isset($params['membership_type_default']) && !$params['membership_type'][$params['membership_type_default']]) {
+      if (!empty($params['membership_type_default']) && !$params['membership_type'][$params['membership_type_default']]) {
         $errors['membership_type_default'] = ts('Can\'t set default option for an unchecked membership type.');
       }
 

--- a/CRM/Price/Form/Field.php
+++ b/CRM/Price/Form/Field.php
@@ -41,7 +41,7 @@ class CRM_Price_Form_Field extends CRM_Core_Form {
   /**
    * Constants for number of options for data types of multiple option.
    */
-  CONST NUM_OPTION = 11;
+  CONST NUM_OPTION = 15;
 
   /**
    * the custom set id saved to the session for an update

--- a/templates/CRM/Price/Form/Field.tpl
+++ b/templates/CRM/Price/Form/Field.tpl
@@ -50,7 +50,7 @@
 
     var radioOption, checkBoxOption;
 
-    for (var i=1; i<=11; i++) {
+    for (var i=1; i<=15; i++) {
       radioOption = 'radio'+i;
       checkBoxOption = 'checkbox'+i
       if (html_type_name == 'Radio' || html_type_name == 'CheckBox' || html_type_name == 'Select') {

--- a/templates/CRM/Price/Form/OptionFields.tpl
+++ b/templates/CRM/Price/Form/OptionFields.tpl
@@ -28,7 +28,7 @@
         {if $useForMember}
             {ts}Fill in a row for each membership type you want to offer as an option (click 'another choice' for each additional choice). Click the help icon for more info on membership price sets.{/ts} {help id="id-member-price-options"}
         {else}
-            {ts}Enter up to ten (10) multiple choice options in this table (click 'another choice' for each additional choice). If you need more than ten options, you can create an unlimited number of additional choices using the Edit Price Options link after saving this new field. Enter a description of the option in the 'Label' column, and the associated price in the 'Amount' column. Click the 'Default' radio button to the left of an option if you want that to be selected by default.{/ts}
+            {ts}Enter up to fifteen (15) multiple choice options in this table (click 'another choice' for each additional choice). If you need more than ten options, you can create an unlimited number of additional choices using the Edit Price Options link after saving this new field. Enter a description of the option in the 'Label' column, and the associated price in the 'Amount' column. Click the 'Default' radio button to the left of an option if you want that to be selected by default.{/ts}
         {/if}
     </div>
   {strip}
@@ -51,7 +51,7 @@
       <th>{ts}Active?{/ts}</th>
     </tr>
 
-  {section name=rowLoop start=1 loop=12}
+  {section name=rowLoop start=1 loop=16}
   {assign var=index value=$smarty.section.rowLoop.index}
   <tr id="optionField_{$index}" class="form-item {cycle values="odd-row,even-row"}">
         <td>


### PR DESCRIPTION
...r of enabled membership types is not greater than max allowed in the underlying CRM_Price_Field NUM_OPTION constant. Prevents silent failure. Also bump up the constant to 15 from 11.

---
- CRM-13079: hard limit on number of options for price field; no warning/error
  http://issues.civicrm.org/jira/browse/CRM-13079
