### PR TITLE
CRM-10935

### DIFF
--- a/CRM/Contact/BAO/Contact/Permission.php
+++ b/CRM/Contact/BAO/Contact/Permission.php
@@ -252,7 +252,7 @@ AND    $operationClause LIMIT 1";
         return FALSE;
       }
     }
-    if ($contactID == $selectedContactID) {
+    if ($contactID == $selectedContactID && CRM_Core_Permission::check('edit my contact')) {
       return TRUE;
     }
     else {

--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -206,9 +206,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
 
         // check for permissions
         $session = CRM_Core_Session::singleton();
-        if ($session->get('userID') != $this->_contactId &&
-          !CRM_Contact_BAO_Contact_Permission::allow($this->_contactId, CRM_Core_Permission::EDIT)
-        ) {
+        if (!CRM_Contact_BAO_Contact_Permission::allow($this->_contactId, CRM_Core_Permission::EDIT)) {
           CRM_Core_Error::statusBounce(ts('You do not have the necessary permission to edit this contact.'));
         }
 

--- a/CRM/Contact/Page/View.php
+++ b/CRM/Contact/Page/View.php
@@ -203,7 +203,7 @@ class CRM_Contact_Page_View extends CRM_Core_Page {
       'isDeleted' => $isDeleted,
     );
 
-    if (($session->get('userID') == $this->_contactId) ||
+    if (
       CRM_Contact_BAO_Contact_Permission::allow($this->_contactId, CRM_Core_Permission::EDIT)
     ) {
       $recentOther['editUrl'] = CRM_Utils_System::url('civicrm/contact/add', "reset=1&action=update&cid={$this->_contactId}");
@@ -286,7 +286,7 @@ class CRM_Contact_Page_View extends CRM_Core_Page {
     // things easier in dashboard
     $session = CRM_Core_Session::singleton();
 
-    if ($session->get('userID') == $contactID) {
+    if ($session->get('userID') == $contactID && CRM_Core_Permission::check('edit my contact')) {
       $page->assign('permission', 'edit');
       $page->_permission = CRM_Core_Permission::EDIT;
       // deleted contacts’ stuff should be (at best) only viewable

--- a/CRM/Contact/Page/View.php
+++ b/CRM/Contact/Page/View.php
@@ -203,9 +203,7 @@ class CRM_Contact_Page_View extends CRM_Core_Page {
       'isDeleted' => $isDeleted,
     );
 
-    if (
-      CRM_Contact_BAO_Contact_Permission::allow($this->_contactId, CRM_Core_Permission::EDIT)
-    ) {
+    if (CRM_Contact_BAO_Contact_Permission::allow($this->_contactId, CRM_Core_Permission::EDIT)) {
       $recentOther['editUrl'] = CRM_Utils_System::url('civicrm/contact/add', "reset=1&action=update&cid={$this->_contactId}");
     }
 


### PR DESCRIPTION
CRM-10935 Fixing a number of pages and forms that were ignoring the 'edit my contact' permission due to hard-coded conditionals allowing a user to edit their own contact record regardless of permissions.
