### PR TITLE
CRM-12700 optional fifth parameter to CRM_Utils_Money::format allows cal...

### DIFF
--- a/CRM/Utils/Money.php
+++ b/CRM/Utils/Money.php
@@ -49,15 +49,16 @@ class CRM_Utils_Money {
    * %C - the currency ISO code (e.g., 'USD') if provided
    * %c - the currency symbol (e.g., '$') if available
    *
-   * @param float  $amount    the monetary amount to display (1234.56)
-   * @param string $currency  the three-letter ISO currency code ('USD')
-   * @param string $format    the desired currency format
+   * @param float  $amount      the monetary amount to display (1234.56)
+   * @param string $currency    the three-letter ISO currency code ('USD')
+   * @param string $format      the desired currency format
+   * @param string $valueFormat the desired monetary value display format (e.g. '%!i')
    *
    * @return string  formatted monetary string
    *
    * @static
    */
-  static function format($amount, $currency = NULL, $format = NULL, $onlyNumber = FALSE) {
+  static function format($amount, $currency = NULL, $format = NULL, $onlyNumber = FALSE, $valueFormat = NULL) {
 
     if (CRM_Utils_System::isNull($amount)) {
       return '';
@@ -68,11 +69,15 @@ class CRM_Utils_Money {
     if (!$format) {
       $format = $config->moneyformat;
     }
-
+    
+    if (!$valueFormat) {
+      $valueFormat = $config->moneyvalueformat;
+    }
+     
     if ($onlyNumber) {
       // money_format() exists only in certain PHP install (CRM-650)
       if (is_numeric($amount) and function_exists('money_format')) {
-        $amount = money_format($config->moneyvalueformat, $amount);
+        $amount = money_format($valueFormat, $amount);
       }
       return $amount;
     }
@@ -85,16 +90,12 @@ class CRM_Utils_Money {
       $currency = $config->defaultCurrency;
     }
 
-    if (!$format) {
-      $format = $config->moneyformat;
-    }
-
     // money_format() exists only in certain PHP install (CRM-650)
     // setlocale() affects native gettext (CRM-11054, CRM-9976)
     if (is_numeric($amount) && function_exists('money_format')) {
       $lc = setlocale(LC_MONETARY, 0);
       setlocale(LC_MONETARY, 'en_US.utf8', 'en_US', 'en_US.utf8', 'en_US', 'C');
-      $amount = money_format($config->moneyvalueformat, $amount);
+      $amount = money_format($valueFormat, $amount);
       setlocale(LC_MONETARY, $lc);
     }
 


### PR DESCRIPTION
...ler to override default money_value_format. Also removed redundant code on lines 88-91.

---
- CRM-12700: Allow monetary value (not amount) format override
  http://issues.civicrm.org/jira/browse/CRM-12700
