### PR TITLE
CRM-12556 - api/v3 - Identify contacts by user name

### DIFF
--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -107,6 +107,17 @@ abstract class CRM_Utils_System_Base {
   public abstract function getLoginURL($destination = '');
 
   /**
+   * Determine the native ID of the CMS user
+   *
+   * @param $username
+   * @return int|NULL
+   */
+  function getUfId($username) {
+    $className = get_class($this);
+    throw new CRM_Core_Exception("Not implemented: {$className}->getUfId");
+  }
+
+  /**
    * Set a init session with user object
    *
    * @param array $data  array with user specific data

--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -659,6 +659,20 @@ AND    u.status = 1
   */
 
   /**
+   * Determine the native ID of the CMS user
+   *
+   * @param $username
+   * @return int|NULL
+   */
+  function getUfId($username) {
+    $user = user_load_by_name($username);
+    if (empty($user->uid)) {
+      return NULL;
+    }
+    return $user->uid;
+  }
+
+  /**
    * Set a message in the UF to display to a user
    *
    * @param string $message the message to set

--- a/CRM/Utils/System/Drupal6.php
+++ b/CRM/Utils/System/Drupal6.php
@@ -590,6 +590,20 @@ SELECT name, mail
   */
 
   /**
+   * Determine the native ID of the CMS user
+   *
+   * @param $username
+   * @return int|NULL
+   */
+  function getUfId($username) {
+    $user = user_load(array('name' => $username));
+    if (empty($user->uid)) {
+      return NULL;
+    }
+    return $user->uid;
+  }
+
+  /**
    * Set a message in the UF to display to a user
    *
    * @param string $message the message to set

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -1470,14 +1470,14 @@ function _civicrm_api3_swap_out_aliases(&$apiRequest) {
  */
 function _civicrm_api3_validate_integer(&$params, &$fieldName, &$fieldInfo, $entity) {
   //if fieldname exists in params
-  if (CRM_Utils_Array::value($fieldname, $params)) {
+  if (CRM_Utils_Array::value($fieldName, $params)) {
     // if value = 'user_contact_id' (or similar), replace value with contact id
-    if (!is_numeric($params[$fieldname])) {
-      $realContactId = _civicrm_api3_resolve_contactID($params[$fieldname]);
+    if (!is_numeric($params[$fieldName])) {
+      $realContactId = _civicrm_api3_resolve_contactID($params[$fieldName]);
       if (!is_numeric($realContactId)) {
-        throw new API_Exception("\"$fieldname\" \"{$params[$fieldname]}\" cannot be resolved to a contact ID", 2002, array('error_field' => $fieldname,"type"=>"integer"));
+        throw new API_Exception("\"$fieldName\" \"{$params[$fieldName]}\" cannot be resolved to a contact ID", 2002, array('error_field' => $fieldName,"type"=>"integer"));
       }
-      $params[$fieldname] = $realContactId;
+      $params[$fieldName] = $realContactId;
     }
     if (!empty($fieldInfo['pseudoconstant']) || !empty($fieldInfo['options'])) {
       _civicrm_api3_api_match_pseudoconstant($params, $entity, $fieldName, $fieldInfo);

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -1472,10 +1472,10 @@ function _civicrm_api3_validate_integer(&$params, &$fieldName, &$fieldInfo, $ent
   //if fieldname exists in params
   if (CRM_Utils_Array::value($fieldname, $params)) {
     // if value = 'user_contact_id' (or similar), replace value with contact id
-    if (!is_integer($params[$fieldname])) {
+    if (!is_numeric($params[$fieldname])) {
       $realContactId = _civicrm_api3_resolve_contactID($params[$fieldname]);
       if (!is_numeric($realContactId)) {
-        throw new API_Exception("\"$fieldname\" cannot be resolved to a contact ID", 2002, array('error_field' => $fieldname,"type"=>"integer"));
+        throw new API_Exception("\"$fieldname\" \"{$params[$fieldname]}\" cannot be resolved to a contact ID", 2002, array('error_field' => $fieldname,"type"=>"integer"));
       }
       $params[$fieldname] = $realContactId;
     }
@@ -1531,6 +1531,7 @@ function  _civicrm_api3_resolve_contactID($contactIdExpr) {
 
     return $contactID;
   }
+  return NULL;
 }
 
 function _civicrm_api3_validate_html(&$params, &$fieldName, &$fieldInfo) {

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -86,7 +86,8 @@ class api_v3_ContactTest extends CiviUnitTestCase {
       'civicrm_contribution',
       'civicrm_line_item',
       'civicrm_website',
-      'civicrm_relationship'
+      'civicrm_relationship',
+      'civicrm_uf_match',
     );
 
     $this->quickCleanup($tablesToTruncate);
@@ -1374,6 +1375,62 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
     // delete the contact
     civicrm_api('contact', 'delete', $contact);
+  }
+
+  /**
+   * Test for Contact.get id=@user:username
+   */
+  function testContactGetByUsername() {
+    // setup - create contact with a uf-match
+    $cid = $this->individualCreate(array(
+      'contact_type' => 'Individual',
+      'first_name' => 'testGetByUsername',
+      'last_name' => 'testGetByUsername',
+    ));
+
+    $ufMatchParams = array(
+      'domain_id' => CRM_Core_Config::domainID(),
+      'uf_id' => 99,
+      'uf_name' => 'the-email-matching-key-is-not-really-the-username',
+      'contact_id' => $cid,
+    );
+    $ufMatch = CRM_Core_BAO_UFMatch::create($ufMatchParams);
+    $this->assertTrue(is_numeric($ufMatch->id));
+
+    // setup - mock the calls to CRM_Utils_System_*::getUfId
+    $userSystem = $this->getMock('CRM_Utils_System_UnitTests', array('getUfId'));
+    $userSystem->expects($this->once())
+      ->method('getUfId')
+      ->with($this->equalTo('exampleUser'))
+      ->will($this->returnValue(99));
+    CRM_Core_Config::singleton()->userSystem = $userSystem;
+
+    // perform a lookup
+    $result = $this->callAPISuccess('Contact', 'get', array(
+      'version' => 3,
+      'id' => '@user:exampleUser',
+    ));
+    $this->assertEquals('testGetByUsername', $result['values'][$cid]['first_name']);
+  }
+
+  /**
+   * Test for Contact.get id=@user:username (with an invalid username)
+   */
+  function testContactGetByUnknownUsername() {
+    // setup - mock the calls to CRM_Utils_System_*::getUfId
+    $userSystem = $this->getMock('CRM_Utils_System_UnitTests', array('getUfId'));
+    $userSystem->expects($this->once())
+      ->method('getUfId')
+      ->with($this->equalTo('exampleUser'))
+      ->will($this->returnValue(NULL));
+    CRM_Core_Config::singleton()->userSystem = $userSystem;
+
+    // perform a lookup
+    $result = $this->callAPIFailure('Contact', 'get', array(
+      'version' => 3,
+      'id' => '@user:exampleUser',
+    ));
+    $this->assertRegExp('/cannot be resolved to a contact ID/', $result['error_message']);
   }
 
   /**


### PR DESCRIPTION
(Resubmit https://github.com/civicrm/civicrm-core/pull/709 based on upstream/master)

Per IRC discussion, this addresses http://issues.civicrm.org/jira/browse/CRM-12556 by introducing an API feature that translates an expression "@user:admin" to a contact ID. This seemed like a useful generalization of the problem from CRM-12556.
