### PR TITLE
CRM-10606 Remove specific code for upgrade from 2.0 to 2.1

### DIFF
--- a/CRM/Core/BAO/ConfigSetting.php
+++ b/CRM/Core/BAO/ConfigSetting.php
@@ -236,16 +236,6 @@ class CRM_Core_BAO_ConfigSetting {
         }
       }
 
-      // since language field won't be present before upgrade.
-      if (CRM_Core_Config::isUpgradeMode()) {
-        // dont add if its empty
-        if (!empty($defaults)) {
-          // retrieve directory and url preferences also
-          CRM_Core_BAO_Setting::retrieveDirectoryAndURLPreferences($defaults);
-        }
-        return;
-      }
-
       // check if there are any locale strings
       if ($domain->locale_custom_strings) {
         $defaults['localeCustomStrings'] = unserialize($domain->locale_custom_strings);


### PR DESCRIPTION
cf. http://issues.civicrm.org/jira/browse/CRM-10606

I removed some old code to allow upgrade from 2.0 to 2.1 (when first version of multilingual was introduced). This piece of code create problems in multilingual civi migration (with aegir/drush anyway).

It seems very unlikelly that someone do the migration from version prior than 2.1 to 4.3 directly so i think we can safely remove this code.
