### PR TITLE
CRM-12877 - Fixes for single-value alteration

### DIFF
--- a/CRM/Report/BAO/ReportInstance.php
+++ b/CRM/Report/BAO/ReportInstance.php
@@ -68,7 +68,9 @@ class CRM_Report_BAO_ReportInstance extends CRM_Report_DAO_ReportInstance {
       );
     }
 
-    $params['is_reserved'] = CRM_Utils_Array::value('is_reserved', $params, FALSE);
+    if (!isset($params['id'])) {
+      $params['is_reserved'] = CRM_Utils_Array::value('is_reserved', $params, FALSE);
+    }
 
     $instanceID = CRM_Utils_Array::value('id', $params);
     if (CRM_Utils_Array::value('instance_id', $params)) {
@@ -90,7 +92,7 @@ class CRM_Report_BAO_ReportInstance extends CRM_Report_DAO_ReportInstance {
     }
 
     // explicitly set to null if params value is empty
-    if (empty($params['grouprole'])) {
+    if (!$instanceID && empty($params['grouprole'])) {
       $instance->grouprole = 'null';
     }
 
@@ -130,8 +132,12 @@ class CRM_Report_BAO_ReportInstance extends CRM_Report_DAO_ReportInstance {
    * @static
    */
   static function &create(&$params) {
-    $params['header']    = CRM_Utils_Array::value('report_header',$params);
-    $params['footer']    = CRM_Utils_Array::value('report_footer',$params);
+    if (isset($params['report_header'])) {
+      $params['header']    = CRM_Utils_Array::value('report_header',$params);
+    }
+    if (isset($params['report_footer'])) {
+      $params['footer']    = CRM_Utils_Array::value('report_footer',$params);
+    }
 
     // build navigation parameters
     if (CRM_Utils_Array::value('is_navigation', $params)) {

--- a/CRM/Report/BAO/ReportInstance.php
+++ b/CRM/Report/BAO/ReportInstance.php
@@ -100,14 +100,17 @@ class CRM_Report_BAO_ReportInstance extends CRM_Report_DAO_ReportInstance {
       $instance->id = $instanceID;
     }
 
-    if ($reportID = CRM_Utils_Array::value('report_id', $params)) {
-      $instance->report_id = $reportID;
-    } else if ($instanceID) {
-      $instance->report_id = CRM_Report_Utils_Report::getValueFromUrl($instanceID);
-    } else {
-      // just take it from current url
-      $instance->report_id = CRM_Report_Utils_Report::getValueFromUrl();
+    if (! $instanceID) {
+      if ($reportID = CRM_Utils_Array::value('report_id', $params)) {
+        $instance->report_id = $reportID;
+      } else if ($instanceID) {
+        $instance->report_id = CRM_Report_Utils_Report::getValueFromUrl($instanceID);
+      } else {
+        // just take it from current url
+        $instance->report_id = CRM_Report_Utils_Report::getValueFromUrl();
+      }
     }
+
     $instance->save();
 
     if ($instanceID) {

--- a/tests/phpunit/api/v3/SyntaxConformanceAllEntitiesTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceAllEntitiesTest.php
@@ -734,7 +734,11 @@ class api_v3_SyntaxConformanceAllEntitiesTest extends CiviUnitTestCase {
       );
 
       $checkEntity = civicrm_api($entityName, 'getsingle', $checkParams);
-      $this->assertEquals($entity, $checkEntity, "changing field $fieldName\n" . print_r($entity,TRUE) );//. print_r($checkEntity,true) .print_r($checkParams,true) . print_r($update,true) . print_r($updateParams, TRUE));
+      $this->assertEquals($entity, $checkEntity, "changing field $fieldName\n" .
+        print_r($entity, TRUE)
+        //print_r(array('update-params' => $updateParams, 'update-result' => $update, 'getsingle-params' => $checkParams, 'getsingle-result' => $checkEntity, 'expected entity' => $entity), TRUE)
+      );
+
     }
     $baoObj->deleteTestObjects($baoString);
     $baoObj->free();


### PR DESCRIPTION
testCreateSingleValue has been failing because ReportInstance::add() and ReportInstance::create() apply hard defaults to some fields. If the API caller doesn't explicitly pass in the default, then he generally intends for the field to be left alone -- but the hard-defaults will cause it to trample the existing data in the field. The changes here soften the defaults (so that they only apply to new reports).

I know this code has been refactored and may be shared with report UI code, but I don't know that code so well, so it may good for someone else to think about whether this is safe.
