### PR TITLE
Amend CRM-12995 fix

### DIFF
--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -613,8 +613,8 @@ class CRM_Utils_Token {
 
     $str = preg_replace_callback(
       self::tokenRegex($key),
-      function ($matches) use(&$contact, $key, $html, $escapeSmarty) {
-        return CRM_Utils_Token::getContactTokenReplacement($matches[1], $contact, $key, $html, $escapeSmarty);
+      function ($matches) use(&$contact, $html, $returnBlankToken, $escapeSmarty) {
+        return CRM_Utils_Token::getContactTokenReplacement($matches[1], $contact, $html, $returnBlankToken, $escapeSmarty);
       },
       $str
     );


### PR DESCRIPTION
The regression introduced in 8bab0eb08b9862b49b02e914321bd15c0aca487e
(mismerge of patch for http://issues.civicrm.org/jira/browse/CRM-12172 )
was fixed in 14c8cdaa39005e0752e8beca670faa470b2147ce only partially.

This commit adds the rest of the necessary fix to fully undo the
original regression.

(Note: I have not really tested the effect of the amended fix, as I
don't know in what situations it shows -- I only discovered this in the
code while looking for another regression... It's a pretty obvious
change though.)
