### PR TITLE
CRM-13072 Remove (deprecated) entity_tag_display as attempting to update...

### DIFF
--- a/api/v3/EntityTag.php
+++ b/api/v3/EntityTag.php
@@ -73,39 +73,6 @@ function _civicrm_api3_entity_tag_get_spec(&$params) {
 
 /**
  *
- * @param <type> $params
- *
- * @return <type>
- * @todo EM 7 Jan 2011 - believe this should be deleted
- * @deprecated
- */
-function civicrm_api3_entity_tag_display($params) {
-
-  civicrm_api3_verify_one_mandatory($params, NULL, array('entity_id', 'contact_id'));
-
-  $entityID = NULL;
-  $entityTable = 'civicrm_contact';
-
-  if (!($entityID = CRM_Utils_Array::value('entity_id', $params))) {
-    $entityID = CRM_Utils_Array::value('contact_id', $params);
-  }
-
-
-  if (CRM_Utils_Array::value('entity_table', $params)) {
-    $entityTable = $params['entity_table'];
-  }
-
-  $values = CRM_Core_BAO_EntityTag::getTag($entityID, $entityTable);
-  $result = array();
-  $tags   = CRM_Core_PseudoConstant::get('CRM_Core_DAO_EntityTag', 'tag_id', array('onlyActive' => FALSE));
-  foreach ($values as $v) {
-    $result[] = $tags[$v];
-  }
-  return implode(',', $result);
-}
-
-/**
- *
  * @param array $params
  *
  * @return array

--- a/tests/phpunit/api/v3/EntityTagTest.php
+++ b/tests/phpunit/api/v3/EntityTagTest.php
@@ -306,57 +306,7 @@ class api_v3_EntityTagTest extends CiviUnitTestCase {
     $this->assertEquals($result['not_removed'], 1);
   }
 
-  ///////////////// civicrm_entity_tag_display methods
-  function testEntityTagDisplayWithContactId() {
-    $entityTagParams = array(
-      'contact_id' => $this->_individualID,
-      'tag_id' => $this->_tagID,
-      'version' => $this->_apiversion,
-    );
-    $this->entityTagAdd($entityTagParams);
-
-    $params = array(
-      'contact_id' => $this->_individualID,
-      'version' => $this->_apiversion,
-    );
-
-    $result = civicrm_api3_entity_tag_display($params);
-    $this->assertEquals($this->_tag['values'][$this->_tag['id']]['name'], $result);
-  }
-
   ///////////////// civicrm_tag_entities_get methods
-
-
-
-  ///////////////// civicrm_entity_tag_common methods
-  function testCommonAddEmptyParams() {
-    $params = array(
-      'version' => $this->_apiversion,
-    );
-    $individualEntity = _civicrm_api3_entity_tag_common($params, 'add');
-    $this->assertEquals($individualEntity['is_error'], 1);
-    $this->assertEquals($individualEntity['error_message'], 'contact_id is a required field');
-  }
-
-  function testCommonAddWithoutTagID() {
-    $params = array(
-      'contact_id' => $this->_individualID,
-      'version' => $this->_apiversion,
-    );
-    $individualEntity = _civicrm_api3_entity_tag_common($params, 'add');
-    $this->assertEquals($individualEntity['is_error'], 1);
-    $this->assertEquals($individualEntity['error_message'], 'tag_id is a required field');
-  }
-
-  function testCommonAddWithoutContactID() {
-    $params = array(
-      'tag_id' => $this->_tagID,
-      'version' => $this->_apiversion,
-    );
-    $individualEntity = _civicrm_api3_entity_tag_common($params, 'add');
-    $this->assertEquals($individualEntity['is_error'], 1);
-    $this->assertEquals($individualEntity['error_message'], 'contact_id is a required field');
-  }
 
   function testCommonContactEntityTagAdd() {
     $params = array(


### PR DESCRIPTION
... the test reveals it has never worked via the api, I don't know what it should do, it's just a v2 hang-over & it is not called directly

Conflicts:

```
tests/phpunit/api/v3/EntityTagTest.php
```

---
- CRM-13072: Make PHPunit tests, api functions & BAO functions in the tests standards & E-notice compliant,
  http://issues.civicrm.org/jira/browse/CRM-13072
