### PR TITLE
Start the session on rest.php

### DIFF
--- a/extern/rest.php
+++ b/extern/rest.php
@@ -29,6 +29,7 @@ require_once '../civicrm.config.php';
 require_once 'CRM/Core/Config.php';
 $config = CRM_Core_Config::singleton();
 
+session_start();
 require_once 'CRM/Utils/REST.php';
 $rest = new CRM_Utils_REST();
 


### PR DESCRIPTION
Trust me, I lost hours and hours on that one: civi needs a session otherwise it's going to fail in random ways at random places (eg. if you add an employer on a contact create AND you want to add a related phone chaining the api it will fail creating the api)

session_start() seems to be the way it's done in various other places (in external or bin). Is this the proper way?
X+
