### PR TITLE
CRM-12446 : support for extension translation (with native gettext only, for now)

### DIFF
--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -229,6 +229,14 @@ class CRM_Core_I18n {
       $context = NULL;
     }
 
+    // gettext domain for extensions
+    $domain_changed = FALSE;
+    if (isset($params['domain'])) {
+      if ($this->setGettextDomain($params['domain'])) {
+        $domain_changed = TRUE;
+      }
+    }
+
     // do all wildcard translations first
     $config = CRM_Core_Config::singleton();
     $stringTable = CRM_Utils_Array::value($config->lcMessages,
@@ -303,6 +311,10 @@ class CRM_Core_I18n {
       $text = addcslashes($text, "'");
     }
 
+    if ($domain_changed) {
+      $this->setGettextDomain('civicrm');
+    }
+
     return $text;
   }
 
@@ -358,6 +370,41 @@ class CRM_Core_I18n {
       elseif ((string ) $key == 'title') {
         $array[$key] = ts($value, array('context' => 'menu'));
       }
+    }
+  }
+
+  /**
+   * Binds a gettext domain, wrapper over bindtextdomain().
+   *
+   * @param  $key Key of the extension (can be 'civicrm', or 'org.example.foo').
+   *
+   * @return void
+   */
+  function setGettextDomain($key) {
+    static $cache = array();
+
+    // It's only necessary to find once
+    if (! isset($cache[$key])) {
+      $config = CRM_Core_Config::singleton();
+
+      try {
+        $mapper = CRM_Extension_System::singleton()->getMapper();
+        $path = $mapper->keyToBasePath($key);
+        $info = $mapper->keyToInfo($key);
+        $domain = $info->file;
+
+        bindtextdomain($domain, $path . DIRECTORY_SEPARATOR . 'l10n');
+        bind_textdomain_codeset($domain, 'UTF-8');
+        $cache[$key] = $domain;
+      }
+      catch (CRM_Extension_Exception $e) {
+        // There's not much we can do at this point
+        $cache[$key] = FALSE;
+      }
+    }
+
+    if (isset($cache[$key]) && $cache[$key]) {
+      textdomain($cache[$key]);
     }
   }
 


### PR DESCRIPTION
This will not have an impact on existing 4.3 installations, and will encourage adoption of the new method.
