### PR TITLE
-- CRM-13037 fix for Navigating among tabs produces wrong popups

### DIFF
--- a/CRM/Profile/Form/Edit.php
+++ b/CRM/Profile/Form/Edit.php
@@ -63,6 +63,7 @@ class CRM_Profile_Form_Edit extends CRM_Profile_Form {
     $this->_mode = CRM_Profile_Form::MODE_CREATE;
 
     $this->_onPopupClose = CRM_Utils_Request::retrieve('onPopupClose', 'String', $this);
+    $this->assign('onPopupClose', $this->_onPopupClose);
 
     //set the context for the profile
     $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this);

--- a/CRM/Profile/Page/MultipleRecordFieldsListing.php
+++ b/CRM/Profile/Page/MultipleRecordFieldsListing.php
@@ -75,21 +75,21 @@ class CRM_Profile_Page_MultipleRecordFieldsListing extends CRM_Core_Page_Basic {
       $links[CRM_Core_Action::VIEW] = array(
         'name' => ts('View'),
         'url' => 'civicrm/profile/view',
-        'qs' => "id=%%id%%&recordId=%%recordId%%&gid=%%gid%%&multiRecord={$view}&snippet=1&context=multiProfileDialog",
+        'qs' => "reset=1&id=%%id%%&recordId=%%recordId%%&gid=%%gid%%&multiRecord={$view}&snippet=1&context=multiProfileDialog&onPopupClose=%%onPopupClose%%",
         'title' => ts('View %1', array( 1 => $this->_customGroupTitle . ' record')),
       );
 
       $links[CRM_Core_Action::UPDATE] = array(
         'name' => ts('Edit'),
         'url' => 'civicrm/profile/edit',
-        'qs' => "id=%%id%%&recordId=%%recordId%%&gid=%%gid%%&multiRecord={$update}&snippet=1&context=multiProfileDialog",
+        'qs' => "reset=1&id=%%id%%&recordId=%%recordId%%&gid=%%gid%%&multiRecord={$update}&snippet=1&context=multiProfileDialog&onPopupClose=%%onPopupClose%%",
         'title' => ts('Edit %1', array( 1 => $this->_customGroupTitle . ' record')),
       );
 
       $links[CRM_Core_Action::DELETE] = array(
         'name' => ts('Delete'),
         'url' => 'civicrm/profile/edit',
-        'qs' => "id=%%id%%&recordId=%%recordId%%&gid=%%gid%%&multiRecord={$delete}&snippet=1&context=multiProfileDialog",
+        'qs' => "reset=1&id=%%id%%&recordId=%%recordId%%&gid=%%gid%%&multiRecord={$delete}&snippet=1&context=multiProfileDialog&onPopupClose=%%onPopupClose%%",
         'title' => ts('Delete %1', array( 1 => $this->_customGroupTitle . ' record')),
       );
 
@@ -112,6 +112,7 @@ class CRM_Profile_Page_MultipleRecordFieldsListing extends CRM_Core_Page_Basic {
   function run() {
     // get the requested action, default to 'browse'
     $action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, FALSE);
+    $this->_onPopupClose = CRM_Utils_Request::retrieve('onPopupClose', 'String', $this);
 
     // assign vars to templates
     $this->assign('action', $action);
@@ -229,7 +230,7 @@ class CRM_Profile_Page_MultipleRecordFieldsListing extends CRM_Core_Page_Basic {
                $customValue = "";
              }
              $actionParams = array('recordId' => $recId, 'gid' => $this->_profileId,
-               'id' => $this->_contactId);
+               'id' => $this->_contactId, 'onPopupClose' => $this->_onPopupClose);
              if ($pageCheckSum) {
                $actionParams['cs'] = $pageCheckSum;
              }

--- a/templates/CRM/Profile/Page/MultipleRecordFieldsListing.tpl
+++ b/templates/CRM/Profile/Page/MultipleRecordFieldsListing.tpl
@@ -96,7 +96,7 @@
         if (!cj(this).attr('jshref')) {
           cj(this).attr('jshref', cj(this).attr('href'));
           cj(this).attr('href', '#browseValues');
-	}
+        }
       });
 
       cj(".crm-profile-name-" + profileName + " .action-item").click(function () {

--- a/templates/CRM/Profile/Page/MultipleRecordFieldsListing.tpl
+++ b/templates/CRM/Profile/Page/MultipleRecordFieldsListing.tpl
@@ -62,7 +62,7 @@
   {/if}
 
   {if !$reachedMax}
-    <a accesskey="N" href="{crmURL p='civicrm/profile/edit' q="id=`$contactId`&multiRecord=add&gid=`$gid`&snippet=1&context=multiProfileDialog"}"
+    <a accesskey="N" href="{crmURL p='civicrm/profile/edit' q="reset=1&id=`$contactId`&multiRecord=add&gid=`$gid`&snippet=1&context=multiProfileDialog&onPopupClose=`$onPopupClose`"}"
        class="button action-item"><span><div class="icon add-icon"></div>{ts}Add New Record{/ts}</span></a>
   {/if}
 {/if}
@@ -91,12 +91,15 @@
         }});
       }
 
+      var profileName = {/literal}"{$ufGroupName}"{literal};
       cj('.action-item').each(function () {
-        cj(this).attr('jshref', cj(this).attr('href'));
-        cj(this).attr('href', '#browseValues');
+        if (!cj(this).attr('jshref')) {
+          cj(this).attr('jshref', cj(this).attr('href'));
+          cj(this).attr('href', '#browseValues');
+	}
       });
 
-      cj(".action-item").click(function () {
+      cj(".crm-profile-name-" + profileName + " .action-item").click(function () {
         dataURL = cj(this).attr('jshref');
         dialogTitle = cj(this).attr('title');
         formDialog(dataURL, dialogTitle);


### PR DESCRIPTION
---
- CRM-13037:
  http://issues.civicrm.org/jira/browse/CRM-13037

The wrong popup was getting generated because all the tabs had "Add new record" button with class as "action-item" and there was a condition in js as follows:
   cj('.action-item').each(function () {
          cj(this).attr('jshref', cj(this).attr('href'));
          cj(this).attr('href', '#browseValues');
      });
So,  when we navigate from 1 tab to other, suppose from career tab to visa tab, career tab will have both href and jshref as #browseValues as the above condition will be called for all the elements with class "action-item". I restricted it by putting an if condition to check if jshref is already set for the element. If not then run the above condition. Then after fixing this, there was another bug. The lastly loaded ajax form of a tab was getting displayed in dialog box of all the tabs. This was because the profile form with a particular Id is not generated in a dialog until we pass reset=1 in its url path. So, I added that and assigned & added onPopupClose(as onPopupClose value is lost after reset=1 is passed) functionality in its url for proper redirection to the tab.
