### PR TITLE
Remove unused T_BOOL constant

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1317,7 +1317,7 @@ SELECT contact_id
             continue;
           }
           // Pick an option value if needed
-          if ($value['type'] !== CRM_Utils_Type::T_BOOL) {
+          if ($value['type'] !== CRM_Utils_Type::T_BOOLEAN) {
             $options = $daoName::buildOptions($dbName, 'create');
             if ($options) {
               $object->$dbName = key($options);
@@ -1332,7 +1332,7 @@ SELECT contact_id
               $object->$dbName = $counter;
               break;
 
-            case CRM_Utils_Type::T_BOOL:
+            case CRM_Utils_Type::T_BOOLEAN:
               if (isset($value['default'])) {
                 $object->$dbName = $value['default'];
               }

--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -1230,7 +1230,6 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
     if (isset($query->_fields[$field]['type'])) {
       switch ($query->_fields[$field]['type']) {
         case CRM_Utils_Type::T_INT:
-        case CRM_Utils_Type::T_BOOL:
         case CRM_Utils_Type::T_BOOLEAN:
           $sqlColumns[$fieldName] = "$fieldName varchar(16)";
           break;

--- a/CRM/Utils/Type.php
+++ b/CRM/Utils/Type.php
@@ -39,7 +39,6 @@ class CRM_Utils_Type {
     T_ENUM       = 2,
     T_DATE       = 4,
     T_TIME       = 8,
-    T_BOOL       = 16,
     T_BOOLEAN    = 16,
     T_TEXT       = 32,
     T_LONGTEXT   = 32,

--- a/api/v3/CustomField.php
+++ b/api/v3/CustomField.php
@@ -92,7 +92,7 @@ function _civicrm_api3_custom_field_create_spec(&$params) {
   $params['option_type'] = array(
     'title' => 'This (boolean) field tells the BAO to create an option group for the field if the field type is appropriate',
     'api.default' => 1,
-    'type' => CRM_Utils_Type::T_BOOL,
+    'type' => CRM_Utils_Type::T_BOOLEAN,
   );
   $params['data_type']['api.default'] = 'String';
   $params['is_active']['api.default'] = 1;

--- a/api/v3/UFField.php
+++ b/api/v3/UFField.php
@@ -114,7 +114,7 @@ function civicrm_api3_uf_field_create($params) {
 function _civicrm_api3_uf_field_create_spec(&$params) {
   $params['option.autoweight'] = array(
     'title' => "Automatically adjust weights in UFGroup to align with UFField",
-    'type' => CRM_Utils_Type::T_BOOL
+    'type' => CRM_Utils_Type::T_BOOLEAN
   );
 }
 

--- a/tests/phpunit/api/v3/GrantTest.php
+++ b/tests/phpunit/api/v3/GrantTest.php
@@ -144,7 +144,6 @@ class api_v3_GrantTest extends CiviUnitTestCase {
           }
           break;
 
-        case CRM_Utils_Type::T_BOOL:
         case CRM_Utils_Type::T_BOOLEAN:
           // probably created with a 1
           $entity[$field] = 0;

--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -700,7 +700,6 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
           }
           break;
 
-        case CRM_Utils_Type::T_BOOL:
         case CRM_Utils_Type::T_BOOLEAN:
           // probably created with a 1
           $entity[$fieldName] = '0';


### PR DESCRIPTION
This constant was only used in a couple places and seems to be deprecated in favor of T_BOOLEAN.
Seems to be safe to remove it.
