### PR TITLE
CRM-13130, fixed notices and using Avery 5395 as default for layout form...

### DIFF
--- a/CRM/Badge/BAO/Badge.php
+++ b/CRM/Badge/BAO/Badge.php
@@ -128,6 +128,7 @@ class CRM_Badge_BAO_Badge {
   public function generateLabel($formattedRow) {
     switch ($formattedRow['labelFormat']) {
       case 'Avery 5395':
+      default:
         self::labelAvery5395($formattedRow);
         break;
     }

--- a/CRM/Core/BAO/LabelFormat.php
+++ b/CRM/Core/BAO/LabelFormat.php
@@ -511,6 +511,9 @@ class CRM_Core_BAO_LabelFormat extends CRM_Core_DAO_OptionValue {
     // serialize label format fields into a single string to store in the 'value' column of the Option Value table
     $v = json_decode($this->value, TRUE);
     foreach (self::$optionValueFields as $name => $field) {
+      if (!isset($v[$name])) {
+        $v[$name] = NULL;
+      }
       $v[$name] = self::getValue($name, $values, $v[$name]);
     }
     $this->value = json_encode($v);


### PR DESCRIPTION
...at

---
- CRM-13130: New Label Format entries do not store the 'name' property in values colum, and produce blank name badges
  http://issues.civicrm.org/jira/browse/CRM-13130
