### PR TITLE
CRM-13141 restructured code to handle empty 200 result from public exten...

### DIFF
--- a/CRM/Extension/Browser.php
+++ b/CRM/Extension/Browser.php
@@ -217,29 +217,27 @@ class CRM_Extension_Browser {
       return array();
     }
 
+    $exts = array();
     list ($status, $extdir) = CRM_Utils_HttpClient::singleton()->get($this->getRepositoryUrl() . $this->indexPath);
     if ($extdir === FALSE || $status !== CRM_Utils_HttpClient::STATUS_OK) {
       CRM_Core_Session::setStatus(ts('The CiviCRM public extensions directory at %1 could not be contacted - please check your webserver can make external HTTP requests or contact CiviCRM team on <a href="http://forum.civicrm.org/">CiviCRM forum</a>.<br />', array(1 => $this->getRepositoryUrl())), ts('Connection Error'), 'error');
-    }
+    } else if (empty($exts)) {
+      // CRM-13141 There may not be any compatible extensions available for the requested CiviCRM version + CMS. If so, $extdir is empty so just return a notification.
+      $config = CRM_Core_Config::singleton();
+      CRM_Core_Session::setStatus(ts('There are currently no extensions on the CiviCRM public extension directory which are compatible with version %2 (<a href="%1">requested extensions from here</a>). If you want to install an extension which is not marked as compatible, you may be able to <a href="%3">download and install extensions manually</a> (depending on access to your web server).<br />', array(1 => $this->getRepositoryUrl(), 2 => $config->civiVersion, 3 => 'http://wiki.civicrm.org/confluence/display/CRMDOC/Extensions')), ts('No Extensions Available for this Version'), 'info');
+    } else {
+      $lines = explode("\n", $extdir);
 
-    $lines = explode("\n", $extdir);
-
-    foreach ($lines as $ln) {
-      if (preg_match("@\<li\>(.*)\</li\>@i", $ln, $out)) {
-        // success
-        $extsRaw[] = $out;
-        $key = strip_tags($out[1]);
-        if (substr($key, -4) == '.xml') {
-          $exts[] = array('key' => substr($key, 0, -4));
+      foreach ($lines as $ln) {
+        if (preg_match("@\<li\>(.*)\</li\>@i", $ln, $out)) {
+          // success
+          $extsRaw[] = $out;
+          $key = strip_tags($out[1]);
+          if (substr($key, -4) == '.xml') {
+            $exts[] = array('key' => substr($key, 0, -4));
+          }
         }
       }
-    }
-
-    if (empty($exts)) {
-      if ($extdir !== FALSE) {
-        CRM_Core_Session::setStatus(ts('Could not retrieve a list of extensions from the CiviCRM public directory at %1 - please contact CiviCRM team on <a href="http://forum.civicrm.org/">CiviCRM forum</a>.<br />', array(1 => $this->getRepositoryUrl())), ts('Failed Fetching List'), 'error');
-      }
-      $exts = array();
     }
 
     ini_restore('allow_url_fopen');

--- a/CRM/Extension/Browser.php
+++ b/CRM/Extension/Browser.php
@@ -221,10 +221,6 @@ class CRM_Extension_Browser {
     list ($status, $extdir) = CRM_Utils_HttpClient::singleton()->get($this->getRepositoryUrl() . $this->indexPath);
     if ($extdir === FALSE || $status !== CRM_Utils_HttpClient::STATUS_OK) {
       CRM_Core_Session::setStatus(ts('The CiviCRM public extensions directory at %1 could not be contacted - please check your webserver can make external HTTP requests or contact CiviCRM team on <a href="http://forum.civicrm.org/">CiviCRM forum</a>.<br />', array(1 => $this->getRepositoryUrl())), ts('Connection Error'), 'error');
-    } else if (empty($exts)) {
-      // CRM-13141 There may not be any compatible extensions available for the requested CiviCRM version + CMS. If so, $extdir is empty so just return a notification.
-      $config = CRM_Core_Config::singleton();
-      CRM_Core_Session::setStatus(ts('There are currently no extensions on the CiviCRM public extension directory which are compatible with version %2 (<a href="%1">requested extensions from here</a>). If you want to install an extension which is not marked as compatible, you may be able to <a href="%3">download and install extensions manually</a> (depending on access to your web server).<br />', array(1 => $this->getRepositoryUrl(), 2 => $config->civiVersion, 3 => 'http://wiki.civicrm.org/confluence/display/CRMDOC/Extensions')), ts('No Extensions Available for this Version'), 'info');
     } else {
       $lines = explode("\n", $extdir);
 
@@ -238,6 +234,12 @@ class CRM_Extension_Browser {
           }
         }
       }
+    }
+
+    // CRM-13141 There may not be any compatible extensions available for the requested CiviCRM version + CMS. If so, $extdir is empty so just return a notification.
+    if (empty($exts)) {
+      $config = CRM_Core_Config::singleton();
+      CRM_Core_Session::setStatus(ts('There are currently no extensions on the CiviCRM public extension directory which are compatible with version %2 (<a href="%1">requested extensions from here</a>). If you want to install an extension which is not marked as compatible, you may be able to <a href="%3">download and install extensions manually</a> (depending on access to your web server).<br />', array(1 => $this->getRepositoryUrl(), 2 => $config->civiVersion, 3 => 'http://wiki.civicrm.org/confluence/display/CRMDOC/Extensions')), ts('No Extensions Available for this Version'), 'info');
     }
 
     ini_restore('allow_url_fopen');


### PR DESCRIPTION
...sions directory.

---
- CRM-13141: Manage Extensions throws an erroneous fatal error - Failed Fetching List - when there are no extensions available for a particular install version
  http://issues.civicrm.org/jira/browse/CRM-13141
