### PR TITLE
CRM-13139 - CRM_Utils_REST - Accept empty JSON objects ("{}")

### DIFF
--- a/CRM/Utils/REST.php
+++ b/CRM/Utils/REST.php
@@ -378,7 +378,7 @@ class CRM_Utils_REST {
 
     if (array_key_exists('json', $_REQUEST) &&  $_REQUEST['json'][0] == "{") {
       $params = json_decode($_REQUEST['json'], TRUE);
-      if(empty($params)) {
+      if($params === NULL) {
         echo json_encode(array('is_error' => 1, 'error_message', 'Unable to decode supplied JSON.'));
         CRM_Utils_System::civiExit();
       }


### PR DESCRIPTION
Note: When the "json" parameter includes malformed JSON (eg "{") or an empty
string (""), the behavior is unchanged. This only affects a well-formed empty-obect.

---
- CRM-13139: REST API: json_decode() fails for empty input
  http://issues.civicrm.org/jira/browse/CRM-13139
