### PR TITLE
CRM-12874

### DIFF
--- a/CRM/Core/I18n/PseudoConstant.php
+++ b/CRM/Core/I18n/PseudoConstant.php
@@ -51,7 +51,7 @@ class CRM_Core_I18n_PseudoConstant {
       }
       // hand-crafted enforced overrides for language variants
       // NB: when adding support for a regional override for a new language below, update
-      // relevant comments in templates/CRM/common/civicrm.settings.php.tpl as well
+      // relevant comments in templates/CRM/common/civicrm.settings.php.template as well
       $longForShortMapping['zh'] = defined("CIVICRM_LANGUAGE_MAPPING_ZH") ? CIVICRM_LANGUAGE_MAPPING_ZH : 'zh_CN';
       $longForShortMapping['en'] = defined("CIVICRM_LANGUAGE_MAPPING_EN") ? CIVICRM_LANGUAGE_MAPPING_EN : 'en_US';
       $longForShortMapping['fr'] = defined("CIVICRM_LANGUAGE_MAPPING_FR") ? CIVICRM_LANGUAGE_MAPPING_FR : 'fr_FR';

--- a/install/civicrm.php
+++ b/install/civicrm.php
@@ -216,7 +216,7 @@ function civicrm_config(&$config) {
 
   $params['siteKey'] = md5(uniqid('', TRUE) . $params['baseURL']);
 
-  $str = file_get_contents($tplPath . 'civicrm.settings.php.tpl');
+  $str = file_get_contents($tplPath . 'civicrm.settings.php.template');
   foreach ($params as $key => $value) {
     $str = str_replace('%%' . $key . '%%', $value, $str);
   }

--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -26,7 +26,7 @@
 */
 
 /**
- * CiviCRM Configuration File
+ * CiviCRM Configuration File.
  */
 
 /**

--- a/tools/scripts/mk-drupal-test-site
+++ b/tools/scripts/mk-drupal-test-site
@@ -112,7 +112,7 @@ done
 
 ln -s "$CIVI_ROOT" "sites/$SITE_URL/modules/civicrm"
 
-cat "$CIVI_ROOT/templates/CRM/common/civicrm.settings.php.tpl" \
+cat "$CIVI_ROOT/templates/CRM/common/civicrm.settings.php.template" \
   | sed "s;%%baseURL%%;http://${SITE_URL};" \
   | sed "s;%%cms%%;Drupal;" \
   | sed "s;%%CMSdbHost%%;${DB_HOST};" \


### PR DESCRIPTION
Renamed it to civicrm.settings.php.template

---
- CRM-12874: Rename civicrm.settings.php.tpl so it isn't in the same suffix as Smarty templates
  http://issues.civicrm.org/jira/browse/CRM-12874
