### PR TITLE
Crm 13067 bao prep - standardisation of bao inputs

### DIFF
--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -705,7 +705,7 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
           );
 
           // make contribution entry
-          CRM_Member_BAO_Membership::recordMembershipContribution( $value, CRM_Core_DAO::$_nullArray, $membership->id );
+          CRM_Member_BAO_Membership::recordMembershipContribution( array_merge($value, array('membership_id' => $membership->id)));
         }
         else {
           $membership = CRM_Member_BAO_Membership::create($value, CRM_Core_DAO::$_nullArray);

--- a/CRM/Core/BAO/Note.php
+++ b/CRM/Core/BAO/Note.php
@@ -131,8 +131,8 @@ class CRM_Core_BAO_Note extends CRM_Core_DAO_Note {
    * note object. the params array could contain additional unused name/value
    * pairs
    *
-   * @param array $params  (reference ) an assoc array of name/value pairs
-   * @param array $ids  associated array with note id
+   * @param array $params  (reference) an assoc array of name/value pairs
+   * @param array $ids (deprecated) associated array with note id - preferably set $params['id']
    *
    * @return object $note CRM_Core_BAO_Note object
    * @access public

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -322,7 +322,7 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
 
     //record contribution for this membership
     if (CRM_Utils_Array::value('contribution_status_id', $params) && !CRM_Utils_Array::value('relate_contribution_id', $params)) {
-      $params['contribution'] = self::recordMembershipContribution( array_merge($params, array('membership_id' => $membership->id), $ids);
+      $params['contribution'] = self::recordMembershipContribution( array_merge($params, array('membership_id' => $membership->id)), $ids);
     }
 
     //insert payment record for this membership

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -322,7 +322,7 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
 
     //record contribution for this membership
     if (CRM_Utils_Array::value('contribution_status_id', $params) && !CRM_Utils_Array::value('relate_contribution_id', $params)) {
-      $params['contribution'] = self::recordMembershipContribution( $params, $ids, $membership->id );
+      $params['contribution'] = self::recordMembershipContribution( array_merge($params, array('membership_id' => $membership->id), $ids);
     }
 
     //insert payment record for this membership
@@ -579,9 +579,9 @@ INNER JOIN  civicrm_membership_type type ON ( type.id = membership.membership_ty
   static function del($membershipId) {
     //delete related first and then delete parent.
     self::deleteRelatedMemberships($membershipId);
-    return self::deleteMembership($membershipId);    
+    return self::deleteMembership($membershipId);
   }
-  
+
   /**
    * Function to delete membership.
    *
@@ -2676,13 +2676,13 @@ WHERE      civicrm_membership.is_test = 0";
    * Function to record contribution record associated with membership
    *
    * @param array  $params array of submitted params
-   * @param array  $ids    array of ids
-   * @param object $membershipId  membership id
+   * @param array  $ids (param in process of being removed - try to use params)   array of ids
    *
    * @return void
    * @static
    */
-  static function recordMembershipContribution( &$params, &$ids, $membershipId ) {
+  static function recordMembershipContribution( &$params, $ids = array()) {
+    $membershipId = $params['membership_id'];
     $contributionParams = array();
     $config = CRM_Core_Config::singleton();
     $contributionParams['currency'] = $config->defaultCurrency;

--- a/CRM/Member/BAO/MembershipType.php
+++ b/CRM/Member/BAO/MembershipType.php
@@ -131,7 +131,7 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
    * @param int $membershipTypeId
    * @static
    */
-  static function del($membershipTypeId, $skipRedirect = FALSE) {
+  static function del($membershipTypeId) {
     //check dependencies
     $check      = FALSE;
     $status     = array();
@@ -150,8 +150,6 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
       }
     }
     if ($check) {
-
-
       $cnt = 1;
       $message = ts('This membership type cannot be deleted due to following reason(s):');
       if (in_array('Membership', $status)) {
@@ -175,8 +173,7 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
     //fix for membership type delete api
     $result = FALSE;
     if ($membershipType->find(TRUE)) {
-      $membershipType->delete();
-      $result = TRUE;
+      return $membershipType->delete();
     }
 
     return $result;

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -778,9 +778,7 @@ WHERE   id IN ( ' . implode(' , ', array_keys($membershipType)) . ' )';
       }
       $formValues['contact_id'] = $this->_contactID;
 
-      CRM_Member_BAO_Membership::recordMembershipContribution( $formValues,
-        CRM_Core_DAO::$_nullArray,
-        $renewMembership->id );
+      CRM_Member_BAO_Membership::recordMembershipContribution( array_merge($formValues, array('membership_id' => $renewMembership->id);
     }
 
     if (CRM_Utils_Array::value('send_receipt', $formValues)) {

--- a/CRM/Upgrade/Incremental/sql/4.4.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.4.alpha1.mysql.tpl
@@ -123,7 +123,7 @@ SELECT @option_group_id_addroptions := max(id) from civicrm_option_group where n
 UPDATE civicrm_option_value
   SET {localize field="label"}label = '{ts escape="sql"}Supplemental Address 1{/ts}'{/localize}
   WHERE name = 'supplemental_address_1' AND option_group_id = @option_group_id_addroptions;
-  
+
 UPDATE civicrm_option_value
   SET {localize field="label"}label = '{ts escape="sql"}Supplemental Address 2{/ts}'{/localize}
   WHERE name = 'supplemental_address_2' AND option_group_id = @option_group_id_addroptions;
@@ -137,5 +137,13 @@ ALTER TABLE civicrm_survey
   ADD is_share TINYINT( 4 ) NULL DEFAULT '1' COMMENT 'Can people share the petition through social media?';
 
 -- CRM-12439
-ALTER TABLE `civicrm_uf_group` 
+ALTER TABLE `civicrm_uf_group`
   ADD `description` TEXT CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL DEFAULT NULL COMMENT 'Optional verbose description of the profile.' AFTER `title`;
+
+--CRM-13142
+UPDATE
+  civicrm_uf_field uf
+  INNER JOIN
+  civicrm_uf_group ug ON uf.uf_group_id = ug.id AND ug.is_reserved = 1 AND name = 'membership_batch_entry'
+SET uf.is_reserved = 0
+WHERE uf.field_name IN ('join_date', 'membership_start_date', 'membership_end_date');

--- a/api/v3/Membership.php
+++ b/api/v3/Membership.php
@@ -141,6 +141,7 @@ function civicrm_api3_membership_create($params) {
  */
 function _civicrm_api3_membership_create_spec(&$params) {
   $params['contact_id']['api.required'] = 1;
+  $params['join_date']['api.default'] = 'now';
   $params['skipStatusCal'] = array('title' => 'skip status calculation. By default this is 0 if id is not set and 1 if it is set');
 }
 /**

--- a/api/v3/MembershipPayment.php
+++ b/api/v3/MembershipPayment.php
@@ -47,24 +47,7 @@
  * @access public
  */
 function civicrm_api3_membership_payment_create($params) {
-
-  $transaction = new CRM_Core_Transaction();
-
-
-  $mpDAO = new CRM_Member_DAO_MembershipPayment();
-  $mpDAO->copyValues($params);
-  $result = $mpDAO->save();
-
-  if (is_a($result, 'CRM_Core_Error')) {
-    $transaction->rollback();
-    return civicrm_api3_create_error($result->_errors[0]['message']);
-  }
-
-  $transaction->commit();
-
-  _civicrm_api3_object_to_array($mpDAO, $mpArray[$mpDAO->id]);
-
-  return civicrm_api3_create_success($mpArray, $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
 }
 
 /**
@@ -90,8 +73,6 @@ function _civicrm_api3_membership_payment_create_spec(&$params) {
  * @access public
  */
 function civicrm_api3_membership_payment_get($params) {
-
-
   return _civicrm_api3_basic_get('CRM_Member_DAO_MembershipPayment', $params);
 }
 

--- a/api/v3/MembershipType.php
+++ b/api/v3/MembershipType.php
@@ -105,7 +105,6 @@ function civicrm_api3_membership_type_get($params) {
  * {getfields MembershipType_delete}
  */
 function civicrm_api3_membership_type_delete($params) {
-  $memberDelete = CRM_Member_BAO_MembershipType::del($params['id'], 1);
-  return $memberDelete ? civicrm_api3_create_success($memberDelete) : civicrm_api3_create_error('Error while deleting membership type. id : ' . $params['id']);
+  return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
 }
 

--- a/api/v3/examples/Membership/filterIsCurrent.php
+++ b/api/v3/examples/Membership/filterIsCurrent.php
@@ -41,7 +41,7 @@ function membership_get_expectedresult(){
           'membership_id' => '1',
           'contact_id' => '13',
           'membership_contact_id' => '13',
-          'membership_type_id' => '11',
+          'membership_type_id' => '21',
           'join_date' => '2009-01-21',
           'start_date' => '2009-01-21',
           'membership_start_date' => '2009-01-21',

--- a/api/v3/examples/MembershipCreate.php
+++ b/api/v3/examples/MembershipCreate.php
@@ -6,7 +6,7 @@
 function membership_create_example(){
 $params = array(
   'contact_id' => 25,
-  'membership_type_id' => 22,
+  'membership_type_id' => 42,
   'join_date' => '2009-01-21',
   'start_date' => '2009-01-21',
   'end_date' => '2009-12-21',
@@ -44,7 +44,7 @@ function membership_create_expectedresult(){
       '1' => array(
           'id' => '1',
           'contact_id' => '25',
-          'membership_type_id' => '22',
+          'membership_type_id' => '42',
           'join_date' => '20090121000000',
           'start_date' => '20090121000000',
           'end_date' => '20091221000000',

--- a/api/v3/examples/MembershipGet.php
+++ b/api/v3/examples/MembershipGet.php
@@ -5,7 +5,7 @@
  */
 function membership_get_example(){
 $params = array(
-  'membership_type_id' => 8,
+  'membership_type_id' => 15,
 );
 
 try{
@@ -36,7 +36,7 @@ function membership_get_expectedresult(){
       '1' => array(
           'id' => '1',
           'contact_id' => '10',
-          'membership_type_id' => '8',
+          'membership_type_id' => '15',
           'join_date' => '2009-01-21',
           'start_date' => '2009-01-21',
           'end_date' => '2009-12-21',

--- a/api/v3/examples/MembershipUpdate.php
+++ b/api/v3/examples/MembershipUpdate.php
@@ -6,7 +6,7 @@
 function membership_update_example(){
 $params = array(
   'contact_id' => 31,
-  'membership_type_id' => 28,
+  'membership_type_id' => 54,
   'join_date' => '2009-01-21',
   'start_date' => '2009-01-21',
   'end_date' => '2009-12-21',
@@ -44,7 +44,7 @@ function membership_update_expectedresult(){
       '1' => array(
           'id' => '1',
           'contact_id' => '31',
-          'membership_type_id' => '28',
+          'membership_type_id' => '54',
           'join_date' => '20090121000000',
           'start_date' => '20090121000000',
           'end_date' => '20091221000000',

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -943,7 +943,7 @@ function _civicrm_api3_basic_create($bao_name, &$params, $entity = NULL) {
   else {
     $values = array();
     _civicrm_api3_object_to_array($bao, $values[$bao->id]);
-    return civicrm_api3_create_success($values, $params, NULL, 'create', $bao);
+    return civicrm_api3_create_success($values, $params, $entity, 'create', $bao);
   }
 }
 

--- a/tests/phpunit/CRM/Batch/Form/EntryTest.php
+++ b/tests/phpunit/CRM/Batch/Form/EntryTest.php
@@ -57,6 +57,19 @@ class CRM_Batch_Form_EntryTest extends CiviUnitTestCase {
    * @var String
    */
   protected $_contactID2 = NULL;
+
+  /**
+   * Contact id used in test function
+   * @var String
+   */
+  protected $_contactID3 = NULL;
+
+  /**
+   * Contact id used in test function
+   * @var String
+   */
+  protected $_contactID4 = NULL;
+
   /**
    * Describe test class
    * @return array
@@ -112,6 +125,9 @@ class CRM_Batch_Form_EntryTest extends CiviUnitTestCase {
       'contact_type' => 'Individual',
     );
     $this->_contactID2 = $this->individualCreate($contact2Params);
+    $this->_contactID3 = $this->individualCreate(array('first_name' => 'bobby', 'email' => 'c@d.com'));
+    $this->_contactID4 = $this->individualCreate(array('first_name' => 'bobbynita', 'email' => 'c@de.com'));
+
     $session = CRM_Core_Session::singleton();
     $session->set('dateTypes', 1);
 
@@ -141,7 +157,22 @@ class CRM_Batch_Form_EntryTest extends CiviUnitTestCase {
     $params = $this->getMembershipData();
     $this->assertTrue($form->testProcessMembership($params));
     $result = $this->callAPISuccess('membership', 'get', array());
-    $this->assertEquals(2, $result['count']);
+    $this->assertEquals(3, $result['count']);
+
+    //check start dates #1 should default to 1 Jan this year, #2 should be as entered
+    $this->assertEquals(date('Y-m-d', strtotime('first day of January this year')), $result['values'][1]['start_date']);
+    $this->assertEquals('2013-02-03', $result['values'][2]['start_date']);
+
+    //check start dates #1 should default to 1 Jan this year, #2 should be as entered
+    $this->assertEquals(date('Y-m-d', strtotime('last day of December this year')), $result['values'][1]['end_date']);
+    $this->assertEquals(date('Y-m-d', strtotime('last day of December this year')), $result['values'][2]['end_date']);
+    $this->assertEquals('2013-12-01', $result['values'][3]['end_date']);
+
+    //check start dates #1 should default to 1 Jan this year, #2 should be as entered
+    $this->assertEquals(date('Y-m-d', strtotime('07/22/2013')), $result['values'][1]['join_date']);
+    $this->assertEquals(date('Y-m-d', strtotime('07/03/2013')), $result['values'][2]['join_date']);
+    $this->assertEquals(date('Y-m-d', strtotime('now')), $result['values'][3]['join_date']);
+
   }
 
   /*
@@ -156,8 +187,12 @@ class CRM_Batch_Form_EntryTest extends CiviUnitTestCase {
     */
     return array(
       'batch_id' => 4,
-      'primary_profiles' => array(1 => NULL, 2 => NULL),
-      'primary_contact_select_id' => Array (1 => $this->_contactID, 2 => $this->_contactID2),
+      'primary_profiles' => array(1 => NULL, 2 => NULL, 3 => NULL),
+      'primary_contact_select_id' => Array (
+        1 => $this->_contactID,
+        2 => $this->_contactID2,
+        3 => $this->_contactID3,
+        ),
       'field' => array(
         1 => array(
           'membership_type' => Array (0 => 1, 1 => 1),// (I was unable to determine what these both mean but both are refered to in code
@@ -176,7 +211,7 @@ class CRM_Batch_Form_EntryTest extends CiviUnitTestCase {
       2 => array(
         'membership_type' => Array (0 => 1, 1 => 1 ),
         'join_date' => '07/03/2013',
-        'membership_start_date' => NULL,
+        'membership_start_date' => '02/03/2013',
         'membership_end_date' => NULL,
         'membership_source' => NULL,
         'financial_type' => 2,
@@ -186,9 +221,26 @@ class CRM_Batch_Form_EntryTest extends CiviUnitTestCase {
         'payment_instrument' => NULL,
         'check_number' => NULL,
         'contribution_status_id' => 1,
-       )
+       ),
+        // no join date, coded end date
+       3 => array(
+         'membership_type' => Array (0 => 1, 1 => 1 ),
+         'join_date' => NULL,
+         'membership_start_date' => NULL,
+         'membership_end_date' => '2013-12-01',
+         'membership_source' => NULL,
+         'financial_type' => 2,
+         'total_amount' => 1,
+         'receive_date' => '07/17/2013',
+         'receive_date_time' => NULL,
+         'payment_instrument' => NULL,
+         'check_number' => NULL,
+         'contribution_status_id' => 1,
+       ),
+
       ),
       'actualBatchTotal' => 0,
+
     );
   }
 }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -866,9 +866,8 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
    *
    * @return int    id of Individual created
    */
-  function individualCreate($params = NULL) {
-    if ($params === NULL) {
-      $params = array(
+  function individualCreate($params = array()) {
+    $params = array_merge(array(
         'first_name' => 'Anthony',
         'middle_name' => 'J.',
         'last_name' => 'Anderson',
@@ -876,8 +875,8 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
         'suffix_id' => 3,
         'email' => 'anthony_anderson@civicrm.org',
         'contact_type' => 'Individual',
-      );
-    }
+      ),$params);
+
     return $this->_contactCreate($params);
   }
 

--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -39,6 +39,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
   protected $_apiversion;
   protected $_contactID;
   protected $_membershipTypeID;
+  protected $_membershipTypeID2;
   protected $_membershipStatusID;
   protected $__membershipID;
   protected $_entity;
@@ -51,9 +52,9 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     $this->_apiversion = 3;
     $this->_contactID = $this->individualCreate();
     $this->_membershipTypeID = $this->membershipTypeCreate(array('member_of_contact_id' => $this->_contactID));
+    $this->_membershipTypeID2 = $this->membershipTypeCreate(array('period_type' => 'fixed','fixed_period_start_day' => '301', 'fixed_period_rollover_day' => '1111'));
     $this->_membershipStatusID = $this->membershipStatusCreate('test status');
 
-    require_once 'CRM/Member/PseudoConstant.php';
     CRM_Member_PseudoConstant::membershipType(NULL, TRUE);
     CRM_Member_PseudoConstant::membershipStatus(NULL, NULL, 'name', TRUE);
     CRM_Core_PseudoConstant::activityType(TRUE, TRUE, TRUE, 'name');
@@ -80,6 +81,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
       TRUE
     );
     $this->membershipStatusDelete($this->_membershipStatusID);
+    $this->membershipTypeDelete(array('id' => $this->_membershipTypeID2));
     $this->membershipTypeDelete(array('id' => $this->_membershipTypeID));
     $this->contactDelete($this->_contactID);
 
@@ -307,7 +309,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
    */
   function testGetWithRelationship() {
     $membershipOrgId = $this->organizationCreate(NULL);
-    $memberContactId = $this->individualCreate(NULL);
+    $memberContactId = $this->individualCreate();
 
     $relTypeParams = array(
       'name_a_b' => 'Relation 1',
@@ -660,6 +662,84 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     ));
   }
 
-  ///////////////// civicrm_membership_delete methods
+  /**
+   * Test that if membership join date is not set it defaults to today
+   */
+  function testEmptyJoinDate() {
+    unset($this->_params['join_date'], $this->_params['is_override']);
+    $result = $this->callAPISuccess($this->_entity, 'create', $this->_params);
+    $result = $this->callAPISuccess($this->_entity, 'getsingle', array('id' => $result['id']));
+    $this->assertEquals(date('Y-m-d', strtotime('now')), $result['join_date']);
+    $this->assertEquals('2009-01-21', $result['start_date']);
+    $this->assertEquals('2009-12-21', $result['end_date']);
+  }
+  /**
+   * Test that if membership start date is not set it defaults to correct end date
+   *  - fixed
+   */
+  function testEmptyStartDateFixed() {
+    unset($this->_params['start_date'], $this->_params['is_override']);
+    $this->_params['membership_type_id'] = $this->_membershipTypeID2;
+    $result = $this->callAPISuccess($this->_entity, 'create', $this->_params);
+    $result = $this->callAPISuccess($this->_entity, 'getsingle', array('id' => $result['id']));
+    $this->assertEquals('2009-01-21', $result['join_date']);
+    $this->assertEquals('2008-03-01', $result['start_date']);
+    $this->assertEquals('2009-12-21', $result['end_date']);
+  }
+
+  /**
+   * Test that if membership start date is not set it defaults to correct end date
+   *  - fixed
+   */
+  function testEmptyStartDateRolling() {
+    unset($this->_params['start_date'], $this->_params['is_override']);
+    $result = $this->callAPISuccess($this->_entity, 'create', $this->_params);
+    $result = $this->callAPISuccess($this->_entity, 'getsingle', array('id' => $result['id']));
+    $this->assertEquals('2009-01-21', $result['join_date']);
+    $this->assertEquals('2009-01-21', $result['start_date']);
+    $this->assertEquals('2009-12-21', $result['end_date']);
+  }
+  /**
+   * Test that if membership end date is not set it defaults to correct end date
+   *  - rolling
+   */
+  function testEmptyEndDateFixed() {
+    unset($this->_params['start_date'], $this->_params['is_override'], $this->_params['end_date']);
+    $this->_params['membership_type_id'] = $this->_membershipTypeID2;
+    $result = $this->callAPISuccess($this->_entity, 'create', $this->_params);
+    $result = $this->callAPISuccess($this->_entity, 'getsingle', array('id' => $result['id']));
+    $this->assertEquals('2009-01-21', $result['join_date']);
+    $this->assertEquals('2008-03-01', $result['start_date']);
+    $this->assertEquals('2010-02-28', $result['end_date']);
+  }
+  /**
+   * Test that if membership end date is not set it defaults to correct end date
+   *  - rolling
+   */
+  function testEmptyEndDateRolling() {
+    unset($this->_params['is_override'], $this->_params['end_date']);
+    $this->_params['membership_type_id'] = $this->_membershipTypeID;
+    $result = $this->callAPISuccess($this->_entity, 'create', $this->_params);
+    $result = $this->callAPISuccess($this->_entity, 'getsingle', array('id' => $result['id']));
+    $this->assertEquals('2009-01-21', $result['join_date']);
+    $this->assertEquals('2009-01-21', $result['start_date']);
+    $this->assertEquals('2010-01-20', $result['end_date']);
+  }
+
+
+  /**
+   * Test that if datesdate are not set they not over-ridden if id is passed in
+   */
+   function testMembershipDatesNotOverridden() {
+    $result = $this->callAPISuccess($this->_entity, 'create', $this->_params);
+    unset($this->_params['end_date'], $this->_params['start_date']);
+    $this->_params['id'] = $result['id'];
+    $this->callAPISuccess($this->_entity, 'create', $this->_params);
+    $result = $this->callAPISuccess($this->_entity, 'getsingle', array('id' => $result['id']));
+    $this->assertEquals('2009-01-21', $result['join_date']);
+    $this->assertEquals('2009-01-21', $result['start_date']);
+    $this->assertEquals('2009-12-21', $result['end_date']);
+
+   }
 }
 


### PR DESCRIPTION
CRM-13067 is a fairly significant restructure of 'membership payment related action moved to the membership payment bao & available through api & form layer in a standardised way).

I think that it is not achievable for 4.4 but am working on some tidy up commits that cause the various create functions to follow the standards agreed per http://wiki.civicrm.org/confluence/display/CRM/Database+layer

In particular when we discussed this we agreed that ids would be passed in the params array (which is available via the api) rather than as ids (which needs to be hard-coded into the api layer - & is inconsistently done leading to inconsistentcies between api & bao / form behaviour). 

We have been making the ids arrays optional for a while & this does more of that. I want to sync the api & bao behaviour so I can write tests for the api to ensure behaviour doesn't change as I chip away at this
