### PR TITLE
CRM-13158 adding event_type variable to event/info page.

### DIFF
--- a/CRM/Event/Page/EventInfo.php
+++ b/CRM/Event/Page/EventInfo.php
@@ -88,6 +88,9 @@ class CRM_Event_Page_EventInfo extends CRM_Core_Page {
       CRM_Core_Error::fatal(ts('The page you requested is currently unavailable.'));
     }
 
+    // Add Event Type to $values in case folks want to display it
+    $values['event']['event_type'] = CRM_Utils_Array::value($values['event']['event_type_id'], CRM_Event_PseudoConstant::eventType());
+    
     $this->assign('isShowLocation', CRM_Utils_Array::value('is_show_location', $values['event']));
 
     // show event fees.


### PR DESCRIPTION
---
- CRM-13158: Event Type label should be available for Event Info pages
  http://issues.civicrm.org/jira/browse/CRM-13158
