### PR TITLE
CRM-12639-minor-fix-for-state-name-display : state abbreviations were getting displayed instead of state names

### DIFF
--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -660,6 +660,9 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
           $greeting = $property . '_display';
           $row[$property] = $result->$greeting;
         }
+        elseif ($property == 'state_province') {
+          $row[$property] = $result->state_province_name;
+        }
         elseif (isset($pseudoconstants[$property])) {
           $row[$property] = CRM_Utils_Array::value(
             $result->{$pseudoconstants[$property]['dbName']},


### PR DESCRIPTION
CRM-12639-minor-fix-for-state-name-display : state abbreviations were getting displayed instead of state names for searches 
