### PR TITLE
CRM-12926 : convert the flash to image and upload the image

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -3361,5 +3361,35 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
       }
     }
   }
+
+  /* function used for showing charts on print screen */
+  static function uploadChartImage() {
+    // upload strictly for '.png' images
+    $name = CRM_Utils_Request::retrieve('name', 'String', CRM_Core_DAO::$_nullObject, FALSE, NULL, 'GET');
+    if (preg_match('/\.png$/', trim($name))) {
+      //
+      // POST data is usually string data, but we are passing a RAW .png
+      // so PHP is a bit confused and $_POST is empty. But it has saved
+      // the raw bits into $HTTP_RAW_POST_DATA
+      //
+      $httpRawPostData = $GLOBALS['HTTP_RAW_POST_DATA'];
+
+      // prepare the directory
+      $config = CRM_Core_Config::singleton();
+      $defaultPath = str_replace('/persist/contribute/' , '/persist/', $config->imageUploadDir) . '/openFlashChart/';
+      if (!file_exists($defaultPath)) {
+        mkdir($defaultPath, 0777, TRUE);
+      }
+
+      // full path to the saved image including filename
+      $destination = $defaultPath . basename($name);
+
+      //write and save
+      $jfh = fopen($destination, 'w') or die("can't open file");
+      fwrite($jfh, $httpRawPostData);
+      fclose($jfh);
+      CRM_Utils_System::civiExit();
+    }
+  }
 }
 

--- a/CRM/Report/xml/Menu/Report.xml
+++ b/CRM/Report/xml/Menu/Report.xml
@@ -70,4 +70,9 @@
      <adminGroup>CiviReport</adminGroup>
      <icon>admin/small/report_list.gif</icon>
   </item>
+  <item>
+     <path>civicrm/report/chart</path>
+     <page_callback>CRM_Report_Form::uploadChartImage</page_callback>
+     <access_arguments>access CiviReport</access_arguments>
+  </item> 
 </menu>

--- a/templates/CRM/Report/Form.tpl
+++ b/templates/CRM/Report/Form.tpl
@@ -23,7 +23,9 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-{include file="CRM/common/crmeditable.tpl"}
+{if $outputMode neq 'print'}
+  {include file="CRM/common/crmeditable.tpl"}
+{/if} 
 {* this div is being used to apply special css *}
     {if $section eq 1}
     <div class="crm-block crm-content-block crm-report-layoutGraph-form-block">

--- a/templates/CRM/Report/Form/Layout/Graph.tpl
+++ b/templates/CRM/Report/Form/Layout/Graph.tpl
@@ -48,21 +48,16 @@
 {literal}
 <script type="text/javascript">
    cj( function( ) {
-      buildChart( );
+     buildChart( );
 
-      var resourceURL = "{/literal}{$config->userFrameworkResourceURL}{literal}";
-      var uploadURL   = "{/literal}{$uploadURL|cat:$chartId}{literal}.png";
-      var uploadDir   = "{/literal}{$config->imageUploadDir|replace:'/persist/contribute/':'/persist/'|cat:'openFlashChart/'}{literal}";
+     cj("input[id$='submit_print'],input[id$='submit_pdf']").bind('click', function(e){
+       // image creator php file path and append image name
+       var url = CRM.url('civicrm/report/chart', 'name=' + '{/literal}{$chartId}{literal}' + '.png');
 
-      cj("input[id$='submit_print'],input[id$='submit_pdf']").bind('click', function(){
-        var url = resourceURL +'packages/OpenFlashChart/php-ofc-library/ofc_upload_image.php';  // image creator php file path
-           url += '?name={/literal}{$chartId}{literal}.png';                                    // append image name
-           url += '&defaultPath=' + uploadDir;                                                  // append directory path
-
-        //fetch object
-        swfobject.getObjectById("open_flash_chart_{/literal}{$uniqueId}{literal}").post_image( url, true, false );
-        });
-    });
+       //fetch object and 'POST' image
+       swfobject.getObjectById("open_flash_chart_{/literal}{$uniqueId}{literal}").post_image(url, true, false);
+     });
+   });
 
   function buildChart( ) {
      var chartData = {/literal}{$openFlashChartData}{literal};


### PR DESCRIPTION
The charts display on print screen was failing as the process of converting 'flash to image' was failing and the src of img url on print screen was false as no image was created for that src path.

The 'flash to image' convertion issue : 
This was working fine until the OpenFlashChart package was updated and some more updates for security reasons were done, in this update 'packages/OpenFlashChart/php-ofc-library/ofc_upload_image.php' file was removed.

The fix : reused some of the code from 'ofc_upload_image.php' and improved it and made it more tighter restricting it to '.png' files and mentioning the image creation directory path inside this image uploading code.
