### PR TITLE
3 months of events & don't default to sending receipt for past events (CRM-13189)

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1788,7 +1788,7 @@ SELECT  display_name
       $component = 'Membership';
     }
     elseif ($activity->__table == 'civicrm_participant') {
-      $event = CRM_Event_BAO_Event::getEvents(TRUE, $activity->event_id, TRUE, FALSE);
+      $event = CRM_Event_BAO_Event::getEvents(1, $activity->event_id, TRUE, FALSE);
 
       $roles = CRM_Event_PseudoConstant::participantRole();
       $status = CRM_Event_PseudoConstant::participantStatus();

--- a/CRM/Contact/Form/Search/Custom/EventAggregate.php
+++ b/CRM/Contact/Form/Search/Custom/EventAggregate.php
@@ -74,7 +74,7 @@ class CRM_Contact_Form_Search_Custom_EventAggregate extends CRM_Contact_Form_Sea
     foreach ($event_type as $eventId => $eventName) {
       $form->addElement('checkbox', "event_type_id[$eventId]", 'Event Type', $eventName);
     }
-    $events = CRM_Event_BAO_Event::getEvents(TRUE);
+    $events = CRM_Event_BAO_Event::getEvents(1);
     $form->add('select', 'event_id', ts('Event Name'), array('' => ts('- select -')) + $events);
 
     $form->addDate('start_date', ts('Payments Date From'), FALSE, array('formatType' => 'custom'));

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -254,14 +254,16 @@ class CRM_Event_BAO_Event extends CRM_Event_DAO_Event {
   /**
    * Function to get current/future Events
    *
-   * @param $all              boolean true if events all are required else returns current and future events
+   * @param $all              int     0 returns current and future events
+   *                                  1 if events all are required
+   *                                  2 returns events since 3 months ago
    * @param $id               int     id of a specific event to return
    * @param $isActive         boolean true if you need only active events
    * @param $checkPermission  boolean true if you need to check permission else false
    *
    * @static
    */
-  static function getEvents($all = FALSE,
+  static function getEvents($all = 0,
     $id              = FALSE,
     $isActive        = TRUE,
     $checkPermission = TRUE
@@ -274,9 +276,15 @@ WHERE  ( civicrm_event.is_template IS NULL OR civicrm_event.is_template = 0 )";
     if ($id) {
       $query .= " AND `id` = {$id}";
     }
-    elseif (!$all) {
+    elseif ($all == 0) {
+      // find only events ending in the future
       $endDate = date('YmdHis');
       $query .= " AND ( `end_date` >= {$endDate} OR end_date IS NULL )";
+    }
+    elseif ($all == 2) {
+      // find only events starting in the last 3 months
+      $startDate = date('YmdHis', strtotime('3 months ago'));
+      $query .= " AND ( `start_date` >= {$startDate} OR start_date IS NULL )";
     }
     if ($isActive) {
       $query .= " AND civicrm_event.is_active = 1";

--- a/CRM/Event/Form/EventFees.php
+++ b/CRM/Event/Form/EventFees.php
@@ -78,7 +78,7 @@ class CRM_Event_Form_EventFees {
 
     if ($form->_eventId) {
       //get receipt text and financial type
-      $returnProperities = array( 'confirm_email_text', 'financial_type_id', 'campaign_id' );
+      $returnProperities = array( 'confirm_email_text', 'financial_type_id', 'campaign_id', 'start_date' );
       $details = array();
       CRM_Core_DAO::commonRetrieveAll('CRM_Event_DAO_Event', 'id', $form->_eventId, $details, $returnProperities);
       if ( CRM_Utils_Array::value( 'financial_type_id', $details[$form->_eventId] ) ) {
@@ -121,7 +121,8 @@ class CRM_Event_Form_EventFees {
 
     //CRM-11601 we should keep the record contribution
     //true by default while adding participant
-     if ($form->_action == CRM_Core_Action::ADD && !$form->_mode && $form->_isPaidEvent) {
+     if ($form->_action == CRM_Core_Action::ADD && !$form->_mode && $form->_isPaidEvent
+       && strtotime(CRM_Utils_Array::value('start_date', $details[$form->_eventId])) >= time()) {
       $defaults[$form->_pId]['record_contribution'] = 1;
     }
 

--- a/CRM/Event/Form/EventFees.php
+++ b/CRM/Event/Form/EventFees.php
@@ -110,7 +110,7 @@ class CRM_Event_Form_EventFees {
       $defaults[$form->_pId]['send_receipt'] = 0;
     }
     else {
-      $defaults[$form->_pId]['send_receipt'] = 1;
+      $defaults[$form->_pId]['send_receipt'] = (strtotime(CRM_Utils_Array::value('start_date', $details[$form->_eventId])) >= time()) ? 1 : 0;
       if ($form->_eventId && CRM_Utils_Array::value('confirm_email_text', $details[$form->_eventId])) {
         //set receipt text
         $defaults[$form->_pId]['receipt_text'] = $details[$form->_eventId]['confirm_email_text'];
@@ -121,8 +121,7 @@ class CRM_Event_Form_EventFees {
 
     //CRM-11601 we should keep the record contribution
     //true by default while adding participant
-     if ($form->_action == CRM_Core_Action::ADD && !$form->_mode && $form->_isPaidEvent
-       && strtotime(CRM_Utils_Array::value('start_date', $details[$form->_eventId])) >= time()) {
+     if ($form->_action == CRM_Core_Action::ADD && !$form->_mode && $form->_isPaidEvent) {
       $defaults[$form->_pId]['record_contribution'] = 1;
     }
 

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -751,13 +751,14 @@ SELECT civicrm_custom_group.name as name,
     if ( $this->_eID ) {
       $eventEndDate = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event', $this->_eID,'end_date');
     }
-    $this->assign('past', FALSE);
+    $this->assign('past', 0);
     if ($this->_action & CRM_Core_Action::UPDATE) {
-      $events = CRM_Event_BAO_Event::getEvents(TRUE, FALSE, FALSE);
+      $events = CRM_Event_BAO_Event::getEvents(1, FALSE, FALSE);
     }
     elseif ($this->getElementValue('past_event') || (isset($eventEndDate) && (CRM_Utils_Date::currentDBDate() > CRM_Utils_Date::processDate($eventEndDate)))) {
-      $events = CRM_Event_BAO_Event::getEvents(TRUE);
-      $this->assign('past', TRUE);
+      $pastval = $this->getElementValue('past_event');
+      $events = CRM_Event_BAO_Event::getEvents($pastval);
+      $this->assign('past', $pastval);
     }
     else {
       $events = CRM_Event_BAO_Event::getEvents();

--- a/CRM/Event/Page/AJAX.php
+++ b/CRM/Event/Page/AJAX.php
@@ -119,7 +119,8 @@ GROUP BY cv.label";
   }
 
   function eventList() {
-    $events = CRM_Event_BAO_Event::getEvents(TRUE);
+    $listparams = CRM_Utils_Array::value('listall', $_REQUEST, 1);
+    $events = CRM_Event_BAO_Event::getEvents($listparams);
 
     $elements = array(array('name' => ts('- select -'),
         'value' => '',

--- a/templates/CRM/Event/Form/Participant.tpl
+++ b/templates/CRM/Event/Form/Participant.tpl
@@ -216,9 +216,10 @@
           {/if}
           <tr class="crm-participant-form-block-event_id">
             <td class="label">{$form.event_id.label}</td><td class="view-value bold">{$form.event_id.html}&nbsp;
-            {if $action eq 1 && !$past }
-              <br /><a href="#" onclick="buildSelect('event_id'); return false;"
-                       id='past-event'>&raquo; {ts}Include past event(s) in this select list.{/ts}</a>
+            {if $action eq 1 && $past neq 1 }<span id='past-event-section'>
+              <br />&raquo; {ts}Include past event(s) in this select list:{/ts}
+              {if !$past}<a href="#" onclick="buildSelect('event_id', 2); return false;" class='3-mo-past-event'>{ts}past three months{/ts}</a> <span class='3-mo-past-event'>|</span>{/if}
+              <a href="#" onclick="buildSelect('event_id', 1); return false;">{ts}all{/ts}</a></span>
             {/if}
             {if $is_test}
               {ts}(test){/ts}
@@ -285,17 +286,22 @@
     {literal}
     <script type="text/javascript">
     // event select
-    function buildSelect( selectID ) {
+    function buildSelect( selectID, listallVal ) {
       var elementID = '#' + selectID;
       cj( elementID ).html('');
       var postUrl = "{/literal}{crmURL p='civicrm/ajax/eventlist' h=0}{literal}";
-      cj.post( postUrl, null, function ( response ) {
+      cj.post( postUrl, {listall:listallVal}, function ( response ) {
         response = eval( response );
         for (i = 0; i < response.length; i++) {
           cj( elementID ).get(0).add(new Option(response[i].name, response[i].value), document.all ? i : null);
         }
-        cj('#past-event').hide( );
-        cj('input[name="past_event"]').val(1);
+        if (listallVal == 1) {
+          cj('#past-event-section').hide( );
+        }
+        else {
+          cj('.3-mo-past-event').hide( );
+        }
+        cj('input[name="past_event"]').val(listallVal);
         cj("#feeBlock").html( '' );
       });
     }

--- a/templates/CRM/Event/Form/Participant.tpl
+++ b/templates/CRM/Event/Form/Participant.tpl
@@ -216,10 +216,8 @@
           {/if}
           <tr class="crm-participant-form-block-event_id">
             <td class="label">{$form.event_id.label}</td><td class="view-value bold">{$form.event_id.html}&nbsp;
-            {if $action eq 1 && $past neq 1 }<span id='past-event-section'>
-              <br />&raquo; {ts}Include past event(s) in this select list:{/ts}
-              {if !$past}<a href="#" onclick="buildSelect('event_id', 2); return false;" class='3-mo-past-event'>{ts}past three months{/ts}</a> <span class='3-mo-past-event'>|</span>{/if}
-              <a href="#" onclick="buildSelect('event_id', 1); return false;">{ts}all{/ts}</a></span>
+            {if $action eq 1}<span id='past-event-section'>
+              <br />&raquo; <span id="showing-event-info"></span>
             {/if}
             {if $is_test}
               {ts}(test){/ts}
@@ -295,15 +293,28 @@
         for (i = 0; i < response.length; i++) {
           cj( elementID ).get(0).add(new Option(response[i].name, response[i].value), document.all ? i : null);
         }
-        if (listallVal == 1) {
-          cj('#past-event-section').hide( );
-        }
-        else {
-          cj('.3-mo-past-event').hide( );
-        }
+        getShowEventInfo(listallVal);
         cj('input[name="past_event"]').val(listallVal);
         cj("#feeBlock").html( '' );
       });
+    }
+
+    {/literal}
+    {if $action eq 1}getShowEventInfo({$past});{/if}
+    {literal}
+
+    function getShowEventInfo (listallVal) {
+      switch(listallVal) {
+        case 1:
+          cj('#showing-event-info').html({/literal}'{ts}Showing all events: show{/ts}'{literal}+' <a href="#" onclick="buildSelect(\'event_id\', 0); return false;">'+{/literal}'{ts}current and future{/ts}'{literal}+'</a> | <a href="#" onclick="buildSelect(\'event_id\', 2); return false;">'+{/literal}'{ts}past three months{/ts}'{literal}+'</a>');
+          break;
+        case 2:
+          cj('#showing-event-info').html({/literal}'{ts}Showing events since three months ago: show{/ts}'{literal}+' <a href="#" onclick="buildSelect(\'event_id\', 0); return false;">'+{/literal}'{ts}current and future{/ts}'{literal}+'</a> | <a href="#" onclick="buildSelect(\'event_id\', 1); return false;">'+{/literal}'{ts}all{/ts}'{literal}+'</a>');
+          break;
+        default:
+          cj('#showing-event-info').html({/literal}'{ts}Showing current and future events: show{/ts}'{literal}+' <a href="#" onclick="buildSelect(\'event_id\', 2); return false;">'+{/literal}'{ts}past three months{/ts}'{literal}+'</a> | <a href="#" onclick="buildSelect(\'event_id\', 1); return false;">'+{/literal}'{ts}all{/ts}'{literal}+'</a>');
+          break;
+      }
     }
     {/literal}
 


### PR DESCRIPTION
Many organizations need to register people to past events, but they have enough events that showing all events becomes really cumbersome.  This adds the option to only show events beginning within the past three months when doing a backend participant registration.

Meanwhile, this fixes a small irritating thing where recording a payment for a past event defaults to sending a receipt--most people are aware they already attended!
