### PR TITLE
 	CRM-12869 This is a temporary fix from Eileen which prevents the over-writing of email address

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1357,12 +1357,12 @@ WHERE   id IN ( ' . implode(' , ', array_keys($membershipType)) . ' )';
           $formValues['preserveDBName'] = TRUE;
         }
       }
-      //here we are setting up the billing contact - if different from the member they are already created
-      // but they will get billing details assigned
-      CRM_Contact_BAO_Contact::createProfileContact($formValues, $fields,
-        $this->_contributorContactID, NULL, NULL, $ctype
-      );
-
+      if ($this->_contributorContactID == $this->_contactID) {
+        //see CRM-12869 for discussion of why we don't do this for separate payee payments
+        CRM_Contact_BAO_Contact::createProfileContact($formValues, $fields,
+          $this->_contributorContactID, NULL, NULL, $ctype
+        );
+      }
 
       // add all the additioanl payment params we need
       $this->_params["state_province-{$this->_bltID}"] = $this->_params["billing_state_province-{$this->_bltID}"] = CRM_Core_PseudoConstant::stateProvinceAbbreviation($this->_params["billing_state_province_id-{$this->_bltID}"]);


### PR DESCRIPTION
However it also prevents the billing address from being saved for the payee, and requires the user to know that they need to manually replace the default billing field values (which are prefilled with data for the person being given the membership) with the payer's data (name and address). In general I do not think this "Record payment from a different contact' feature is production-ready (even though it is part of 4.3). Selecting a different payer should reload the billing name address fields with the payer info in order for this be usable IMO.
