### PR TITLE
CRM-10935 - CRM/Core/xml/Menu/Contact.xml - Fix malformed permissions

### DIFF
--- a/CRM/Core/xml/Menu/Contact.xml
+++ b/CRM/Core/xml/Menu/Contact.xml
@@ -81,9 +81,7 @@
      <path>civicrm/contact/add</path>
      <title>New Contact</title>
      <access_callback>CRM_Core_Permission::checkMenu</access_callback>
-     <access_arguments>access CiviCRM</access_arguments>
-     <access_arguments>edit my contact</access_arguments>
-     <access_arguments>view my contact</access_arguments>
+     <access_arguments>access CiviCRM;edit my contact;view my contact</access_arguments>
      <page_callback>CRM_Contact_Form_Contact</page_callback>
      <page_arguments>addSequence=1</page_arguments>
   </item>
@@ -145,9 +143,7 @@
      <path_arguments>cid=%%cid%%</path_arguments>
      <title>Contact Summary</title>
      <access_callback>CRM_Core_Permission::checkMenu</access_callback>
-     <access_arguments>access CiviCRM</access_arguments>
-     <access_arguments>edit my contact</access_arguments>
-     <access_arguments>view my contact</access_arguments>
+     <access_arguments>access CiviCRM;edit my contact;view my contact</access_arguments>
      <page_callback>CRM_Contact_Page_View_Summary</page_callback>
   </item>
   <item>


### PR DESCRIPTION
---
- CRM-10935: Create new Core Permission - CiviCRM: Access own Contact or both "CiviCRM: View own Contact"  and "CiviCRM: Edit own Contact"
  http://issues.civicrm.org/jira/browse/CRM-10935
