### PR TITLE
CRM-13143 contact reference field issue fix : the referencing for customIdObj was incorrect i.e. it was refering to corrupt element object, thus 'id' value was not getting stored in the correct element object so the formRule error was thrown of 'Invalid C

### DIFF
--- a/templates/CRM/Custom/Form/ContactReference.tpl
+++ b/templates/CRM/Custom/Form/ContactReference.tpl
@@ -37,8 +37,8 @@ cj( function( ) {
         customObj.autocomplete( url,
             { width : 250, selectFirst : false, elementId: custom,  matchContains: true, formatResult: {/literal}validate{$element_name|replace:']':''|replace:'[':'_'|replace:'-':'_'}{literal}
             }).result(
-                function(event, data ) {
-                    customIdObj.val( data[1] );
+                function(event, data) {
+                  cj(custom_id).val(data[1]);
                 }
         );
         customObj.click( function( ) {


### PR DESCRIPTION
While rendering contact reference custom field, two fields get rendered - actual field (e.g. custom_7_-1) and its corresponding 'id' field (e.g. custom_7_-1_id).

The issue: 
1) Visiting 'new contribution' form.
2) Select 'financial type' select box - this triggers ajax for custom data set load / rendering.
3) In 4.3.x 'custom field values retaining mechanism' exists which executes during step 2 proccessing.
     - In step 3, custom group elements are being 'detach' ed and later a 'replaceWith' call is used to store the proviously detached values.
5) After step 4, when we select a contact in the field, its corresponding 'id' element field is not populated with value of selected contact.
     -  this is due to wrong referencing for customIdObj (/div/input[3]) which is used to store the id value. It actually should be considered from parent of the form i.e. from /html/body/.../div/input[3] .

The difference in contact custom field working for v4.3.x and v4.2.x was existance of step 3. 

The fix: just used the custom_id which consists of 'id' element name for the contact field for storing the id value in the field.
