### PR TITLE
CRM-13115 fix

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -544,8 +544,8 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
             $this->_params[$v] = $frequencyUnits[$this->_params[$v]];
           }
         }
-        if ($v == "amount") {
-          $this->_params[$v] = CRM_Utils_Money::format($this->_params[$v], ' ');
+        if ($v == "amount" && $this->_params[$v] === 0) {
+          $this->_params[$v] = CRM_Utils_Money::format($this->_params[$v], NULL, NULL, TRUE);
         }
         $this->assign($v, $this->_params[$v]);
       }


### PR DESCRIPTION
in here : 

the  <code> if ($v == "amount") { </code> condition was coded in <code> function assignToTemplate() </code>to display 'contribution section' in email receipts for 'zero amount contribution' (so that line item entries can be displayed) relates to issue CRM-12771

Done a little modification to achieve the above pupose : 
now the code converts only zero amount value into money format. 
