### PR TITLE
CRM-12845 CRM_Utils_Migrate - Handle CustomGroup subtypes

### DIFF
--- a/CRM/Utils/Migrate/Export.php
+++ b/CRM/Utils/Migrate/Export.php
@@ -478,10 +478,19 @@ class CRM_Utils_Migrate_Export {
             $types = explode(CRM_Core_DAO::VALUE_SEPARATOR, substr($object->$name, 1, -1));
             $values = array();
             foreach ($types as $type) {
-              $values[] = $this->_xml['optionValue']['idNameMap']["$key.{$type}"];
+              if (in_array($key, array('activity_type', 'event_type'))) {
+                $ogID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', $key, 'id', 'name');
+                $ovParams = array('option_group_id' => $ogID, 'value' => $type);
+                CRM_Core_BAO_OptionValue::retrieve($ovParams, $oValue);
+                $values[] = $oValue['name'];
+              }
+              else {
+                $relTypeName = CRM_Core_DAO::getFieldValue('CRM_Contact_BAO_RelationshipType', $type, 'name_a_b', 'id');
+                $values[] = $relTypeName;
+              }
             }
             $value = implode(',', $values);
-            $keyValues['extends_entity_column_value_option_value'] = $value;
+            $object->extends_entity_column_value = $value;
           }
           else {
             echo "This extension: {$object->extends} is not yet handled";

--- a/CRM/Utils/Migrate/Export.php
+++ b/CRM/Utils/Migrate/Export.php
@@ -461,10 +461,7 @@ class CRM_Utils_Migrate_Export {
       if (isset($object->$name) && $object->$name !== NULL) {
         // hack for extends_entity_column_value
         if ($name == 'extends_entity_column_value') {
-          if ($object->extends == 'Event' ||
-            $object->extends == 'Activity' ||
-            $object->extends == 'Relationship'
-          ) {
+          if (in_array($object->extends, array('Event', 'Activity', 'Relationship', 'Individual', 'Organization', 'Household'))) {
             if ($object->extends == 'Event') {
               $key = 'event_type';
             }
@@ -474,21 +471,27 @@ class CRM_Utils_Migrate_Export {
             elseif ($object->extends == 'Relationship') {
               $key = 'relationship_type';
             }
-            $keyValues['extends_entity_column_value_option_group'] = $key;
             $types = explode(CRM_Core_DAO::VALUE_SEPARATOR, substr($object->$name, 1, -1));
             $values = array();
-            foreach ($types as $type) {
-              if (in_array($key, array('activity_type', 'event_type'))) {
-                $ogID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', $key, 'id', 'name');
-                $ovParams = array('option_group_id' => $ogID, 'value' => $type);
-                CRM_Core_BAO_OptionValue::retrieve($ovParams, $oValue);
-                $values[] = $oValue['name'];
-              }
-              else {
-                $relTypeName = CRM_Core_DAO::getFieldValue('CRM_Contact_BAO_RelationshipType', $type, 'name_a_b', 'id');
-                $values[] = $relTypeName;
+            if (in_array($object->extends, array('Individual', 'Organization', 'Household'))) {
+              $key = 'contact_type';
+              $values = $types;
+            }
+            else {
+              foreach ($types as $type) {
+                if (in_array($key, array('activity_type', 'event_type'))) {
+                  $ogID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', $key, 'id', 'name');
+                  $ovParams = array('option_group_id' => $ogID, 'value' => $type);
+                  CRM_Core_BAO_OptionValue::retrieve($ovParams, $oValue);
+                  $values[] = $oValue['name'];
+                }
+                else {
+                  $relTypeName = CRM_Core_DAO::getFieldValue('CRM_Contact_BAO_RelationshipType', $type, 'name_a_b', 'id');
+                  $values[] = $relTypeName;
+                }
               }
             }
+            $keyValues['extends_entity_column_value_option_group'] = $key;
             $value = implode(',', $values);
             $object->extends_entity_column_value = $value;
           }

--- a/CRM/Utils/Migrate/Import.php
+++ b/CRM/Utils/Migrate/Import.php
@@ -194,8 +194,8 @@ WHERE      v.option_group_id = %1
 
         // fix extends stuff if it exists
         if (isset($customGroupXML->extends_entity_column_value_option_group) &&
-          isset($customGroupXML->extends_entity_column_value)
-            ) {
+          isset($customGroupXML->extends_entity_column_value)) {
+          $valueIDs = array();
           $optionValues = explode(",", $customGroupXML->extends_entity_column_value);
           $optValues = implode("','", $optionValues);
           if (trim($customGroup->extends) != 'Participant') {
@@ -204,6 +204,9 @@ WHERE      v.option_group_id = %1
                 $relTypeId = CRM_Core_DAO::getFieldValue('CRM_Contact_BAO_RelationshipType', $value, 'id', 'name_a_b');
                 $valueIDs[] = $relTypeId;
               }
+            }
+            elseif (in_array($customGroup->extends, array('Individual', 'Organization', 'Household'))) {
+              $valueIDs = $optionValues;
             }
             else {
               $sql = "
@@ -221,7 +224,6 @@ AND        v.name IN ('$optValues')
               );
               $dao = & CRM_Core_DAO::executeQuery($sql, $params);
 
-              $valueIDs = array();
               while ($dao->fetch()) {
                 $valueIDs[] = $dao->value;
               }

--- a/CRM/Utils/Migrate/Import.php
+++ b/CRM/Utils/Migrate/Import.php
@@ -194,35 +194,44 @@ WHERE      v.option_group_id = %1
 
         // fix extends stuff if it exists
         if (isset($customGroupXML->extends_entity_column_value_option_group) &&
-          isset($customGroupXML->extends_entity_column_value_option_value)
-        ) {
-          $optValues = explode(",", $customGroupXML->extends_entity_column_value_option_value);
-          $optValues = implode("','", $optValues);
+          isset($customGroupXML->extends_entity_column_value)
+            ) {
+          $optionValues = explode(",", $customGroupXML->extends_entity_column_value);
+          $optValues = implode("','", $optionValues);
           if (trim($customGroup->extends) != 'Participant') {
-            $sql = "
+            if ($customGroup->extends == 'Relationship') {
+              foreach ($optionValues as $key => $value) {
+                $relTypeId = CRM_Core_DAO::getFieldValue('CRM_Contact_BAO_RelationshipType', $value, 'id', 'name_a_b');
+                $valueIDs[] = $relTypeId;
+              }
+            }
+            else {
+              $sql = "
 SELECT     v.value
 FROM       civicrm_option_value v
 INNER JOIN civicrm_option_group g ON g.id = v.option_group_id
 WHERE      g.name = %1
-AND        v.name IN (%2)
+AND        v.name IN ('$optValues')
 ";
-            $params = array(
-              1 => array(
-                (string ) $customGroupXML->extends_entity_column_value_option_group,
-                'String',
-              ),
-              2 => array((string ) $optValues, 'String'),
-            );
-            $dao = & CRM_Core_DAO::executeQuery($sql, $params);
+              $params = array(
+                1 => array(
+                  (string ) $customGroupXML->extends_entity_column_value_option_group,
+                  'String',
+                ),
+              );
+              $dao = & CRM_Core_DAO::executeQuery($sql, $params);
 
-            $valueIDs = array();
-            while ($dao->fetch()) {
-              $valueIDs[] = $dao->value;
+              $valueIDs = array();
+              while ($dao->fetch()) {
+                $valueIDs[] = $dao->value;
+              }
             }
             if (!empty($valueIDs)) {
               $customGroup->extends_entity_column_value = CRM_Core_DAO::VALUE_SEPARATOR . implode(CRM_Core_DAO::VALUE_SEPARATOR,
                 $valueIDs
               ) . CRM_Core_DAO::VALUE_SEPARATOR;
+
+              unset($valueIDs);
 
               // Note: No need to set extends_entity_column_id here.
 


### PR DESCRIPTION
1. Based on the component to which the custom group extends, extends_entity_column_value will have its subType optionValue(value of name_a_b column in case of relationship type) "name" as its value instead of "value" during export since name's are unique and will be the same. Use of "value" can result in conflicts.
2. During the processing of import, the "name" will be taken from extends_entity_column_value and its corresponding value would be found. This value will be passed as the entry for "extends_entity_column_value" column of civicrm_custom_group. This will help in avoiding conflicts.
3. Also, did some handling to support Contact subtypes for customGroup xml import and export.
