### PR TITLE
CRM-13213 : updated joomla cms code for fetching UF locale

### DIFF
--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -564,7 +564,7 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
   function getUFLocale() {
     if (defined('_JEXEC')) {
       $conf = JFactory::getConfig();
-      $locale = $conf->getValue('config.language');
+      $locale = $conf->get('language');
       return str_replace('-', '_', $locale);
     }
     return NULL;


### PR DESCRIPTION
In joomla 3.1, JFactory config method <code>$conf->getValue('config.language');</code> is no longer in use.

So, to maintain joomla 2.5.x / 3.x compatibility :  <code>$conf->get('language')</code> method is used. 

Joomla cms usage of the same method can be seen in : <code>joomla-root/libraries/joomla/factory.php</code> (did some modifications to the patch submitted WRT to this).
