### PR TITLE
minor bug fix : when we edit a membership and change its membership type...

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -158,7 +158,7 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
           'source_contact_id' => $membershipLog['modified_id'],
           'target_contact_id' => $membership->contact_id,
           'source_record_id' => $membership->id,
-          'activity_type_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Change Membership Status'),
+          'activity_type_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Change Membership Type'),
           'status_id' => 2,
           'priority_id' => 2,
           'activity_date_time' => date('Y-m-d H:i:s'),


### PR DESCRIPTION
minor bug fix : when we edit a membership and change its membership type - instead of 'change membership type' activity, 'change membership status' activity was getting recorded .

detected this bug by running : WebTest_Member_EditMembershipTest.testEditMembershipActivityTypes webtest
