### PR TITLE
CRMDOC - Change various CRMDOCxx links to plain CRMDOC

### DIFF
--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -201,7 +201,7 @@ class CRM_Core_Resources {
    * From javascript:
    * CRM.myNamespace.foo // "bar"
    *
-   * @see http://wiki.civicrm.org/confluence/display/CRMDOC43/Javascript+Reference
+   * @see http://wiki.civicrm.org/confluence/display/CRMDOC/Javascript+Reference
    *
    * @param $settings array
    * @return CRM_Core_Resources

--- a/README.txt
+++ b/README.txt
@@ -56,4 +56,4 @@ http://forum.civicrm.org/index.php/board,20.0.html
 
 Installing the latest developmental code requires some special steps. Full
 instructions are on the wiki:
-http://wiki.civicrm.org/confluence/display/CRMDOC43/Github+for+CiviCRM
+http://wiki.civicrm.org/confluence/display/CRMDOC/Github+for+CiviCRM

--- a/templates/CRM/common/jsortable.tpl
+++ b/templates/CRM/common/jsortable.tpl
@@ -26,7 +26,7 @@
 {literal}
 <script type="text/javascript">
 cj( function( ) {
-// for date sorting see http://wiki.civicrm.org/confluence/display/CRMDOC42/Sorting+Date+Fields+in+dataTables+Widget
+// for date sorting see http://wiki.civicrm.org/confluence/display/CRMDOC/Sorting+Date+Fields+in+dataTables+Widget
 var useAjax = {/literal}{if $useAjax}1{else}0{/if}{literal};
 
 var sourceUrl = '';

--- a/tests/phpunit/WebTest/Release/InstallScript.php
+++ b/tests/phpunit/WebTest/Release/InstallScript.php
@@ -29,7 +29,7 @@ require_once 'ReleaseTestCase.php';
 // name of the class doesn't end with Test on purpose - this way this
 // webtest is not picked up by the suite, since it needs to run
 // on specially prepare sandbox
-// more details: http://wiki.civicrm.org/confluence/display/CRMDOC40/Release+testing+script+documentation
+// more details: http://wiki.civicrm.org/confluence/display/CRMDOC/Release+testing+script
 class WebTest_Release_InstallScript extends WebTest_Release_ReleaseTestCase {
 
   protected function setUp() {

--- a/tests/phpunit/WebTest/Release/ReleaseTestCase.php
+++ b/tests/phpunit/WebTest/Release/ReleaseTestCase.php
@@ -29,7 +29,7 @@ require_once 'CiviTest/CiviSeleniumTestCase.php';
 // name of the class doesn't end with Test on purpose - this way this
 // webtest is not picked up by the suite, since it needs to run
 // on specially prepare sandbox
-// more details: http://wiki.civicrm.org/confluence/display/CRMDOC40/Release+testing+script+documentation
+// more details: http://wiki.civicrm.org/confluence/display/CRMDOC/Release+testing+script
 class WebTest_Release_ReleaseTestCase extends CiviSeleniumTestCase {
 
   /**

--- a/tests/phpunit/WebTest/Release/UpgradeScript.php
+++ b/tests/phpunit/WebTest/Release/UpgradeScript.php
@@ -29,7 +29,7 @@ require_once 'ReleaseTestCase.php';
 // name of the class doesn't end with Test on purpose - this way this
 // webtest is not picked up by the suite, since it needs to run
 // on specially prepare sandbox
-// more details: http://wiki.civicrm.org/confluence/display/CRMDOC40/Release+testing+script+documentation
+// more details: http://wiki.civicrm.org/confluence/display/CRMDOC/Release+testing+script
 class WebTest_Release_UpgradeScript extends WebTest_Release_ReleaseTestCase {
 
   protected function setUp() {

--- a/tools/extensions/org.civicrm.sms.clickatell/info.xml
+++ b/tools/extensions/org.civicrm.sms.clickatell/info.xml
@@ -6,7 +6,7 @@
   <description>Clickatell integration allows delivering short message service (SMS) messages through its Clickatell Gateway to mobile phone users.</description>
   <urls>
     <url desc="Main Extension Page">http://civicrm.org</url>
-    <url desc="Documentation">http://wiki.civicrm.org/confluence/display/CRMDOC43/Setting+up+a+SMS+Provider+for+CiviSMS</url>
+    <url desc="Documentation">http://wiki.civicrm.org/confluence/display/CRMDOC/Setting+up+a+SMS+Provider+for+CiviSMS</url>
     <url desc="Support">http://forum.civicrm.org</url>
     <url desc="Licensing">http://civicrm.org/licensing</url>
   </urls>

--- a/tools/extensions/org.civicrm.sms.twilio/info.xml
+++ b/tools/extensions/org.civicrm.sms.twilio/info.xml
@@ -6,7 +6,7 @@
   <description>Twilio integration allows delivering short message service (SMS) messages through its Twilio Gateway to mobile phone users.</description>
   <urls>
     <url desc="Main Extension Page">http://civicrm.org</url>
-    <url desc="Documentation">http://wiki.civicrm.org/confluence/display/CRMDOC43/Setting+up+a+SMS+Provider+for+CiviSMS</url>
+    <url desc="Documentation">http://wiki.civicrm.org/confluence/display/CRMDOC/Setting+up+a+SMS+Provider+for+CiviSMS</url>
     <url desc="Support">http://forum.civicrm.org</url>
     <url desc="Licensing">http://civicrm.org/licensing</url>
   </urls>


### PR DESCRIPTION
Most of the source comments with documentation links should reflect current version.

For the "incremental upgrade" messages, I left the CRMDOCxx URLs in tact
because these messages could actually be version specific.
