### PR TITLE
CRM-13012 Run api_v3_SyntaxConformanceAllEntitiesTest with hrjob API's

### DIFF
--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -62,6 +62,8 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
     $this->onlyIDNonZeroCount['get'] = array('ActivityType', 'Entity', 'Domain','Setting');
     $this->deprecatedAPI = array('Location', 'ActivityType', 'SurveyRespondant');
     $this->deletableTestObjects = array();
+    //restrict extension fields that requires no update
+    $this->extensionEntitiesWithoutUpdate = array();
   }
 
   function tearDown() {
@@ -612,6 +614,11 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
   public function testCreateSingleValueAlter($entityName) {
     if (in_array($entityName, $this->toBeImplemented['create'])) {
       // $this->markTestIncomplete("civicrm_api3_{$Entity}_create to be implemented");
+      return;
+    }
+
+    //restrict extension fields that requires no update
+    if (!empty($this->extensionEntitiesWithoutUpdate) && in_array($entityName, $this->extensionEntitiesWithoutUpdate)) {
       return;
     }
 

--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -90,11 +90,11 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
 
   public static function entities_get() {
     // all the entities, beside the ones flagged
-    return api_v3_SyntaxConformanceTest::entities(api_v3_SyntaxConformanceTest::toBeSkipped_get(TRUE));
+    return api_v3_SyntaxConformanceTest::entities(static::toBeSkipped_get(TRUE));
   }
 
   public static function entities_create() {
-    return api_v3_SyntaxConformanceTest::entities(api_v3_SyntaxConformanceTest::toBeSkipped_create(TRUE));
+    return api_v3_SyntaxConformanceTest::entities(static::toBeSkipped_create(TRUE));
   }
 
   public static function entities_updatesingle() {
@@ -102,7 +102,7 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
   }
 
   public static function entities_delete() {
-    return api_v3_SyntaxConformanceTest::entities(api_v3_SyntaxConformanceTest::toBeSkipped_delete(TRUE));
+    return api_v3_SyntaxConformanceTest::entities(static::toBeSkipped_delete(TRUE));
   }
 
   public static function toBeSkipped_get($sequential = FALSE) {

--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -62,8 +62,6 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
     $this->onlyIDNonZeroCount['get'] = array('ActivityType', 'Entity', 'Domain','Setting');
     $this->deprecatedAPI = array('Location', 'ActivityType', 'SurveyRespondant');
     $this->deletableTestObjects = array();
-    //restrict extension fields that requires no update
-    $this->extensionEntitiesWithoutUpdate = array();
   }
 
   function tearDown() {
@@ -100,7 +98,7 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
   }
 
   public static function entities_updatesingle() {
-    return api_v3_SyntaxConformanceTest::entities(api_v3_SyntaxConformanceTest::toBeSkipped_updatesingle(TRUE));
+    return api_v3_SyntaxConformanceTest::entities(static::toBeSkipped_updatesingle(TRUE));
   }
 
   public static function entities_delete() {
@@ -614,11 +612,6 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
   public function testCreateSingleValueAlter($entityName) {
     if (in_array($entityName, $this->toBeImplemented['create'])) {
       // $this->markTestIncomplete("civicrm_api3_{$Entity}_create to be implemented");
-      return;
-    }
-
-    //restrict extension fields that requires no update
-    if (!empty($this->extensionEntitiesWithoutUpdate) && in_array($entityName, $this->extensionEntitiesWithoutUpdate)) {
       return;
     }
 


### PR DESCRIPTION
Used static keyword so that in case if any test class extends api_v3_SyntaxConformanceTest class, and we need the function toBeSkipped_updatesingle in child class to override the function in parent class.
