### PR TITLE
CRM-13242, fixed quill for contact type

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2551,10 +2551,12 @@ class CRM_Contact_BAO_Query {
         $this->_where[$grouping][] = "contact_a.contact_type $op (" . implode(',', $clause) . ')';
       }
       else {
+        $quill = $clause;
         $type = array_pop($clause);
         $this->_where[$grouping][] = "contact_a.contact_type $op $type";
       }
-      $this->_qill[$grouping][] = ts('Contact Type') . ' - ' . implode(' ' . ts('or') . ' ', $clause);
+
+      $this->_qill[$grouping][] = ts('Contact Type') . ' - ' . implode(' ' . ts('or') . ' ', $quill);
 
       if (!empty($subTypes)) {
         $this->includeContactSubTypes($subTypes, $grouping);


### PR DESCRIPTION
---
- CRM-13242: != Operator Doesn't Work for Contact Type in Search Builder
  http://issues.civicrm.org/jira/browse/CRM-13242
