### PR TITLE
CRM-12925 - Search Builder - Allow CRM_Contact_BAO_Query_Hook to influence options

### DIFF
--- a/CRM/Contact/BAO/Query/Hook.php
+++ b/CRM/Contact/BAO/Query/Hook.php
@@ -80,6 +80,12 @@ class CRM_Contact_BAO_Query_Hook {
     return $extFields;
   }
 
+  public function alterSearchBuilderOptions(&$apiEntities, &$fieldOptions) {
+    foreach (self::getSearchQueryObjects() as $obj) {
+      $obj->alterSearchBuilderOptions($apiEntities, $fieldOptions);
+    }
+  }
+
   public function alterSearchQuery(&$query, $fnName) {
     foreach (self::getSearchQueryObjects() as $obj) {
       $obj->$fnName($query);

--- a/CRM/Contact/BAO/Query/Interface.php
+++ b/CRM/Contact/BAO/Query/Interface.php
@@ -68,8 +68,14 @@ abstract class CRM_Contact_BAO_Query_Interface {
   /**
    * Describe options for available for use in the search-builder.
    *
+   * The search builder determines its options by examining the API metadata corresponding to each
+   * search field. This approach assumes that each field has a unique-name (ie that the field's
+   * unique-name in the API matches the unique-name in the search-builder).
+   *
    * @param array $apiEntities list of entities whose options should be automatically scanned using API metadata
    * @param array $fieldOptions keys are field unique-names; values describe how to lookup the options
+   *   For boolean options, use value "yesno". For pseudoconstants/FKs, use the name of an API entity
+   *   from which the metadata of the field may be queried. (Yes - that is a mouthful.)
    * @void
    */
   public function alterSearchBuilderOptions(&$apiEntities, &$fieldOptions) {

--- a/CRM/Contact/BAO/Query/Interface.php
+++ b/CRM/Contact/BAO/Query/Interface.php
@@ -64,4 +64,14 @@ abstract class CRM_Contact_BAO_Query_Interface {
   public function setAdvancedSearchPaneTemplatePath(&$paneTemplatePathArray, $type) {
     return NULL;
   }
+
+  /**
+   * Describe options for available for use in the search-builder.
+   *
+   * @param array $apiEntities list of entities whose options should be automatically scanned using API metadata
+   * @param array $fieldOptions keys are field unique-names; values describe how to lookup the options
+   * @void
+   */
+  public function alterSearchBuilderOptions(&$apiEntities, &$fieldOptions) {
+  }
 }

--- a/CRM/Contact/Form/Search/Builder.php
+++ b/CRM/Contact/Form/Search/Builder.php
@@ -433,10 +433,11 @@ class CRM_Contact_Form_Search_Builder extends CRM_Contact_Form_Search {
       'membership_type' => 'membership',
     );
     $entities = array('contact', 'activity', 'participant', 'pledge', 'member', 'contribution');
+    CRM_Contact_BAO_Query_Hook::singleton()->alterSearchBuilderOptions($entities, $options);
     foreach ($entities as $entity) {
       $fields = civicrm_api($entity, 'getfields', array('version' => 3));
       foreach ($fields['values'] as $field => $info) {
-        if (!empty($info['options']) || !empty($info['pseudoconstant']) || !empty($info['option_group_id'])) {
+        if (!empty($info['options']) || !empty($info['pseudoconstant']) || !empty($info['option_group_id']) || !empty($info['enumValues'])) {
           $options[$field] = $entity;
           if (substr($field, -3) == '_id') {
             $options[substr($field, 0, -3)] = $entity;


### PR DESCRIPTION
Note: There was previously a patch to Builder::fields() which allowed CRM_Contact_BAO_Query_Hook to influence list of fields. This extends the same technique to Builder::fieldOptions().

I'm not excited about exposing the current data-structures ($apiEntities or $fieldOptions) to other developers, but the change seems expedient.

Aside: This also fixes display of "enum" fields in the search-builder.
