### PR TITLE
Add config setting to disable mandatory tokens check in mailings

### DIFF
--- a/CRM/Admin/Form/Preferences/Mailing.php
+++ b/CRM/Admin/Form/Preferences/Mailing.php
@@ -99,6 +99,13 @@ class CRM_Admin_Form_Preferences_Mailing extends CRM_Admin_Form_Preferences {
           'weight' => 8,
           'description' => NULL,
         ),
+        'disable_mandatory_tokens_check' =>
+        array(
+          'html_type' => 'checkbox',
+          'title' => ts('Disable check for mandatory tokens'),
+          'weight' => 9,
+          'description' => ts('Don\'t check for presence of mandatory tokens (domain address; unsubscribe/opt-out) before sending mailings. WARNING: Mandatory tokens are a safe-guard which facilitate compliance with the US CAN-SPAM Act. They should only be disabled if your organization adopts other mechanisms for compliance or if your organization is not subject to CAN-SPAM.'),
+        ),
       ),
     );
 

--- a/CRM/Mailing/Form/Upload.php
+++ b/CRM/Mailing/Form/Upload.php
@@ -613,12 +613,14 @@ class CRM_Mailing_Form_Upload extends CRM_Core_Form {
 
       /* First look for missing tokens */
 
-      $err = CRM_Utils_Token::requiredTokens($str);
-      if ($err !== TRUE) {
-        foreach ($err as $token => $desc) {
-          $dataErrors[] = '<li>' . ts('This message is missing a required token - {%1}: %2',
-            array(1 => $token, 2 => $desc)
-          ) . '</li>';
+      if (!CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::MAILING_PREFERENCES_NAME, 'disable_mandatory_tokens_check')) {
+        $err = CRM_Utils_Token::requiredTokens($str);
+        if ($err !== TRUE) {
+          foreach ($err as $token => $desc) {
+            $dataErrors[] = '<li>' . ts('This message is missing a required token - {%1}: %2',
+              array(1 => $token, 2 => $desc)
+            ) . '</li>';
+          }
         }
       }
 

--- a/settings/Mailing.setting.php
+++ b/settings/Mailing.setting.php
@@ -136,4 +136,18 @@ return array(
     'description' => 'When CiviMail is enabled, users who "subscribe" to a group from a profile Group(s) checkbox will receive a confirmation email. They must respond (opt-in) before they are added to the group.',
     'help_text' => null,
   ),
+  'disable_mandatory_tokens_check' => array(
+    'group_name' => 'Mailing Preferences',
+    'group' => 'mailing',
+    'name' => 'disable_mandatory_tokens_check',
+    'type' => 'Integer',
+    'html_type' => 'checkbox',
+    'default' => 0,
+    'add' => '4.4',
+    'title' => 'Disable check for mandatory tokens',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => 'Don\'t check for presence of mandatory tokens (domain address; unsubscribe/opt-out) before sending mailings. WARNING: Mandatory tokens are a safe-guard which facilitate compliance with the US CAN-SPAM Act. They should only be disabled if your organization adopts other mechanisms for compliance or if your organization is not subject to CAN-SPAM.',
+    'help_text' => null,
+  ),
   );


### PR DESCRIPTION
As per a previous discussion (with Lobo IIRC), add a configuration
setting to disable the check for presence of mandatory tokens when
sending mailings.

This setting is implemented as a negative option, i.e. ticking the
option disables the check. We could also reverse the logic, so that
ticking the option enables the check instead; and set it to on by
default on installation and upgrade. However, this would complicate the
patch considerably -- and I'm not even sure it would really be
preferable to have it work that way around...
