### PR TITLE
-- CRM-13012 changes as per comment in the issue

### DIFF
--- a/tests/phpunit/CiviTest/CiviTestSuite.php
+++ b/tests/phpunit/CiviTest/CiviTestSuite.php
@@ -191,8 +191,10 @@ class CiviTestSuite extends PHPUnit_Framework_TestSuite {
         foreach (array_diff($newClassNames,
           $oldClassNames
                  ) as $name) {
-          if (preg_match('/Test$/', $name)) {
-            $addTestSuites[] = $name;
+          if (strpos($fileInfo->getRealPath(), str_replace('_', '/', $name) . ".php") !== FALSE) {
+            if (preg_match('/Test$/', $name)) {
+              $addTestSuites[] = $name;
+            }
           }
         }
       }


### PR DESCRIPTION
---
- CRM-13012: Run api_v3_SyntaxConformanceAllEntitiesTest with hrjob API's
  http://issues.civicrm.org/jira/browse/CRM-13012

As per comment in the issue, for api_v3_AllTests, instead of using string manipulation by removing "get_declared_classes", what I did is, after array_diff($newClassNames, $oldClassNames) lists out the array of newly declared classes, each element of the array will be checked as a substring in the filePath of the file. 
eg. api/v3/SyntaxConformanceTest.php substring (obtained after performing str_replace on each element i.e. className of the array) will be checked for its existence in the filePath of the file using strpos. If the substring is found, then this class will get added under $addTestSuites.
