### PR TITLE
Modified dao.tpl to fix Gencode's DAO generation

### DIFF
--- a/xml/templates/dao.tpl
+++ b/xml/templates/dao.tpl
@@ -211,7 +211,7 @@ class {$table.className} extends CRM_Core_DAO {ldelim}
                       'rule'      => '{$field.rule}',
 {/if} {* field.rule *}
 {if $field.default}
-                          'default'   => '{$field.default|substring:1:-1}',
+                         'default'   => '{if ($field.default[0]=="'" or $field.default[0]=='"')}{$field.default|substring:1:-1}{else}{$field.default}{/if}',
 {/if} {* field.default *}
 {if $field.enumValues}
                           'enumValues' => '{$field.enumValues}',


### PR DESCRIPTION
GenCode was creating bad default values if the default was not
surrounded by a string delimiter (CRM-13289)
