### PR TITLE
api_v3_MessageTemplatesTest - Fix regression

### DIFF
--- a/tests/phpunit/api/v3/MessageTemplatesTest.php
+++ b/tests/phpunit/api/v3/MessageTemplatesTest.php
@@ -73,7 +73,6 @@ class api_v3_MessageTemplatesTest extends CiviUnitTestCase {
    *
    */
   public function testGet() {
-    $this->createTestEntity();
     $result = $this->callAPIAndDocument('MessageTemplates', 'get', $this->params, __FUNCTION__, __FILE__);
     $this->assertEquals(1, $result['count'], 'In line ' . __LINE__);
     $this->assertNotNull($result['values'][$result['id']]['id'], 'In line ' . __LINE__);


### PR DESCRIPTION
Note that the test called createTestObject() (once in setup(), once in the
testGet()) but expected only one object to get created.  This doesn't make
sense to me -- sounds more like a bug.
