### PR TITLE
CRM-13248 fix

### DIFF
--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -612,6 +612,12 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
         }
         elseif (CRM_Utils_Array::value('is_primary', $value)) {
           CRM_Core_Payment_Form::mapParams($this->_bltID, $value, $value, TRUE);
+          // payment email param can be empty for _bltID mapping
+          // thus provide mapping for it with a different email value
+          if (empty($value['email'])) {
+            $value['email'] = CRM_Utils_Array::valueByRegexKey('/^email-/', $value);
+          }
+
           if (is_object($payment)) {
             $result = $payment->doDirectPayment($value);
           }

--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -622,5 +622,18 @@ class CRM_Utils_Array {
     $elementArray = array_combine($keys, array_values($elementArray));
     return $elementArray;
   }
+
+  /*
+   * function to get value of first matched
+   * regex key element of an array
+   */
+  static function valueByRegexKey($regexKey, $list, $default = NULL) {
+    if (is_array($list) && $regexKey) {
+      $matches = preg_grep($regexKey, array_keys($list));
+      $key = reset($matches);
+      return ($key && array_key_exists($key, $list)) ? $list[$key] : $default;
+    }
+    return $default;
+  }
 }
 


### PR DESCRIPTION
The issue :
Payment prams mapping doesn't properly map 'email' field, this is because :  during payment params mapping _blID (billing loc type id) is passed in mapParams() function, but the email field provided in the event registration profiles can be of different location type other than billing, so the passed email field value is not maaped.

These payment params are eventually used for authorize net payment and causes 'email is required' processor error.

The fix : 
After the mapping checked if the mapping is done for email payment param, if its not done, get the first email field value provided in profile and pass map that value to payment param

 for this introduced a crm_utils_array function which searches the value WRT key regex passed as argument
