### PR TITLE
Only throw error when employers are involved.

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -226,13 +226,18 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
           $this->_defaultMemTypeId = $membership->membership_type_id;
           if ($membership->contact_id != $this->_contactID) {
             $employers = CRM_Contact_BAO_Relationship::getPermissionedEmployer($this->_userID);
-            if (array_key_exists($membership->contact_id, $employers)) {
-              $this->_membershipContactID = $membership->contact_id;
-              $this->assign('membershipContactID', $this->_membershipContactID);
-              $this->assign('membershipContactName', $employers[$this->_membershipContactID]['name']);
+            if (!empty($employers)) {
+              if (array_key_exists($membership->contact_id, $employers)) {
+                $this->_membershipContactID = $membership->contact_id;
+                $this->assign('membershipContactID', $this->_membershipContactID);
+                $this->assign('membershipContactName', $employers[$this->_membershipContactID]['name']);
+              }
+              else {
+                CRM_Core_Session::setStatus(ts("Oops. The membership you're trying to renew appears to be invalid. Contact your site administrator if you need assistance. If you continue, you will be issued a new membership."), ts('Membership Invalid'), 'alert');
+              }
             }
             else {
-              CRM_Core_Session::setStatus(ts("Oops. The membership you're trying to renew appears to be invalid. Contact your site administrator if you need assistance. If you continue, you will be issued a new membership."), ts('Membership Invalid'), 'alert');
+              $this->_membershipContactID = $membership->contact_id;
             }
           }
         }


### PR DESCRIPTION
When a Contact (user) renews a membership that is a related membership (i.e. the primary contact is for instnace, a Household.

The code passes this conditional:

``` php
if ($membership->contact_id != $this->_contactID) { 
```

However, ti does not pass this conditional:

``` php
if (array_key_exists($membership->contact_id, $employers)) { 
```

I've added an initial check that checks to see if the employers array is empty or not, if it is empty, it assigns the membership contact id and moves on without error, if it is not empty it follows the normal flow.

This bug also effects 4.3.x as well, so please merge into that branch too. :)

Thanks!
