### PR TITLE
CRM-13114 - Revert "Added missing menu row in edit profile"

### DIFF
--- a/CRM/Core/xml/Menu/Profile.xml
+++ b/CRM/Core/xml/Menu/Profile.xml
@@ -17,14 +17,6 @@
      <weight>0</weight>
   </item>
   <item>
-     <path>civicrm/profile/edit</path>
-     <title>CiviCRM Profile Edit</title>
-     <access_callback>1</access_callback>
-     <page_callback>CRM_Core_Invoke::profile</page_callback>
-     <is_public>false</is_public>
-     <weight>0</weight>
-  </item>
-  <item>
      <path>civicrm/profile/view</path>
      <page_callback>CRM_Profile_Page_View</page_callback>
      <is_public>true</is_public>


### PR DESCRIPTION
This reverts commit a6bf231033983407abd6d60054af559c9bf32d4f.

See also:
- https://github.com/civicrm/civicrm-core/pull/1530 (discussion)
- https://github.com/civicrm/civihr/issues/131 (alternative approach)
