### PR TITLE
CRM-13326: email can be up to 254 characters long

### DIFF
--- a/CRM/Upgrade/Incremental/sql/4.4.beta1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.4.beta1.mysql.tpl
@@ -4,3 +4,6 @@ INSERT INTO civicrm_state_province (id, country_id, abbreviation, name) VALUES
 (NULL, 1229, "FL", "Florida"),
 (NULL, 1229, "RN", "Rio Negro"),
 (NULL, 1229, "SJ", "San Jose");
+
+ALTER TABLE civicrm_email
+MODIFY email VARCHAR(254);

--- a/xml/schema/Core/Email.xml
+++ b/xml/schema/Core/Email.xml
@@ -51,7 +51,7 @@
   <field>
        <name>email</name>
        <type>varchar</type>
-       <length>64</length>
+       <length>254</length>
        <size>MEDIUM</size>
        <import>true</import>
        <headerPattern>/e.?mail/i</headerPattern>


### PR DESCRIPTION
In accordance with current IETF recommendations.  For a good overview, see
http://en.wikipedia.org/wiki/Email_address
