### PR TITLE
-- CRM-13338 minor fix to populate profile defaults in live contribution page

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -188,6 +188,11 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
         }
         $fields[$name] = 1;
       }
+
+      if (!empty($fields)) {
+        CRM_Core_BAO_UFGroup::setProfileDefaults($contactID, $fields, $this->_defaults); 
+      }
+
       $billingDefaults = $this->getProfileDefaults('Billing', $contactID);
       $this->_defaults = array_merge($this->_defaults, $billingDefaults);
     }


### PR DESCRIPTION
---
- CRM-13338: Profile field defaults not getting populated in contribution live page
  http://issues.civicrm.org/jira/browse/CRM-13338
