### PR TITLE
Handle JSON decode errors in API requests, throw synthetic error.

### DIFF
--- a/api/class.api.php
+++ b/api/class.api.php
@@ -179,23 +179,21 @@ class civicrm_api3 {
         return $res;
       }
       curl_close($ch);
-      $res = json_decode($result);
-      if (!$res) {
-        $res = new stdClass;
-        $res->is_error = 1;
-        $res->error_message = "not a valid json returned by the server";
-        $res->level = "json_decode";
-        $res->row_result = $result;
-        
-      }
-      return $res;
     }
     else {
       // Should be discouraged, because the API credentials and data
       // are submitted as GET data, increasing chance of exposure..
       $result = file_get_contents($query . '&' . $fields);
-      return json_decode($result);
     }
+    if (!$res = json_decode($result)) {
+      $res = new stdClass;
+      $res->is_error = 1;
+      $res->error_message = 'Unable to parse returned JSON';
+      $res->level = 'json_decode';
+      $res->error = array('Unable to parse returned JSON' => $result);
+      $res->row_result = $result;
+    }
+    return $res;
   }
 
   function call($entity, $action = 'Get', $params = array()) {

--- a/api/class.api.php
+++ b/api/class.api.php
@@ -173,11 +173,22 @@ class civicrm_api3 {
       if (curl_errno($ch)) {
         $res = new stdClass;
         $res->is_error = 1;
+        $res->error_message = curl_error($ch);
+        $res->level = "cURL";
         $res->error = array('cURL error' => curl_error($ch));
         return $res;
       }
       curl_close($ch);
-      return json_decode($result);
+      $res = json_decode($result);
+      if (!$res) {
+        $res = new stdClass;
+        $res->is_error = 1;
+        $res->error_message = "not a valid json returned by the server";
+        $res->level = "json_decode";
+        $res->row_result = $result;
+        
+      }
+      return $res;
     }
     else {
       // Should be discouraged, because the API credentials and data


### PR DESCRIPTION
Moves the json_decode() error handling below where it is in xavier's version, so it applies for both cURL and file_get_contents().
