### PR TITLE
CRM-10760 : adding lcMessages to CRM.config setting so that can be used inside .js file

### DIFF
--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -463,6 +463,7 @@ class CRM_Core_Resources {
       $settings = array(
         'userFramework' => $config->userFramework,
         'resourceBase' => $config->resourceBase,
+        'lcMessages' => $config->lcMessages,
       );
       $this->addSetting(array('config' => $settings));
 


### PR DESCRIPTION
The issue for 'delay' (property of autocomplete field) breaking is due to introduction of  <code>onChange(0, true);</code> which you can see at <code>line no. 202 packages/jquery/plugins/jquery.autocomplete.js </code> also a warning comment has been put above that code snippet about 'delay' break .

This code was introduced for http://issues.civicrm.org/jira/browse/CRM-6135 issue break fix (chinese character search not triggering) .

This PR including one more PR sent inside packages repo ( https://github.com/civicrm/civicrm-packages/pull/30 )- combines the fix for this issue :  For fixing checked if the 'chinese' language is selected by default in multi-lingual site and if it is then only expose <code> onChange(0, true); </code> for execution.
