### PR TITLE
CRM-13302 - php 5.3 error fix

### DIFF
--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -375,7 +375,8 @@ WHERE  table_schema IN ('{$this->db}', '{$civiDB}')";
     // NOTE: we consider only those columns for modifications where there is a spec change, and that the column definition 
     // wasn't deliberately modified by fixTimeStampAndNotNullSQL() method.
     foreach ($civiTableSpecs as $col => $colSpecs) {
-      if (!empty(array_diff($civiTableSpecs[$col], $logTableSpecs[$col])) && $col != 'id') {
+      $specDiff = array_diff($civiTableSpecs[$col], $logTableSpecs[$col]);
+      if (!empty($specDiff) && $col != 'id') {
         // ignore 'id' column for any spec changes, to avoid any auto-increment mysql errors
         if ($civiTableSpecs[$col]['DATA_TYPE'] != $logTableSpecs[$col]['DATA_TYPE']) {
           // if data-type is different, surely consider the column 


### PR DESCRIPTION
Error: Can't use function return value in write context in
/var/lib/jenkins/workspace/CiviCRM-4.3-WebTest-git/LABEL/ubuntu1204/SUITE/WebTest_AllTests/civicrm/CRM/Logging/Schema.php,
line 378

Note: this worked with php 5.5 & 5.4.
