### PR TITLE
Every call to Error::ignoreException() should have matching call to setCallback()

### DIFF
--- a/CRM/Admin/Form/Setting/Smtp.php
+++ b/CRM/Admin/Form/Setting/Smtp.php
@@ -170,6 +170,7 @@ class CRM_Admin_Form_Setting_Smtp extends CRM_Admin_Form_Setting {
 
         CRM_Core_Error::ignoreException();
         $result = $mailer->send($toEmail, $headers, $message);
+        CRM_Core_Error::setCallback();
         if (!is_a($result, 'PEAR_Error')) {
           CRM_Core_Session::setStatus($testMailStatusMsg . ts('Your %1 settings are correct. A test email has been sent to your email address.', array(1 => strtoupper($mailerName))), ts("Mail Sent"), "success");
         }

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -3095,17 +3095,20 @@ WHERE id IN (' . implode(',', $copiedActivityIds) . ')';
    * Used during case component enablement and during ugprade
    */
   static function createCaseViews() {
+    $dao = new CRM_Core_DAO();
+
     $sql = self::createCaseViewsQuery('upcoming');
     CRM_Core_Error::ignoreException();
-    $dao = new CRM_Core_DAO();
     $dao->query($sql);
+    CRM_Core_Error::setCallback();
     if (PEAR::getStaticProperty('DB_DataObject', 'lastError')) {
-      CRM_Core_Error::setCallback();
       return FALSE;
     }
 
     // Above error doesn't get caught?
+    CRM_Core_Error::ignoreException();
     $doublecheck = $dao->singleValueQuery("SELECT count(id) FROM civicrm_view_case_activity_upcoming");
+    CRM_Core_Error::setCallback();
     if (is_null($doublecheck)) {
       return FALSE;
     }
@@ -3113,13 +3116,15 @@ WHERE id IN (' . implode(',', $copiedActivityIds) . ')';
     $sql = self::createCaseViewsQuery('recent');
     CRM_Core_Error::ignoreException();
     $dao->query($sql);
+    CRM_Core_Error::setCallback();
     if (PEAR::getStaticProperty('DB_DataObject', 'lastError')) {
-      CRM_Core_Error::setCallback();
       return FALSE;
     }
 
     // Above error doesn't get caught?
+    CRM_Core_Error::ignoreException();
     $doublecheck = $dao->singleValueQuery("SELECT count(id) FROM civicrm_view_case_activity_recent");
+    CRM_Core_Error::setCallback();
     if (is_null($doublecheck)) {
       return FALSE;
     }


### PR DESCRIPTION
After observing an upgrade problem that was logged but not reported as an error, I investigated a bit about how that could happen. Various spots in the code suspend error reporting while they run error-prone operations -- most of them restore the error-handler afterward, but a couple don't (consistently) do so. The PR addresses this.

This PR has not been tested. Submitting PR to solicit feedback form folks who know more about why error-reporting was suspended in CRM_Case_BAO_Case and CrM_Admin_Form_Setting_Smtp.
