### PR TITLE
CRM-13397 disable button on Contribution_Main form after click to prevent multiple submits

### DIFF
--- a/CRM/Contact/Form/Task/EmailCommon.php
+++ b/CRM/Contact/Form/Task/EmailCommon.php
@@ -270,7 +270,7 @@ class CRM_Contact_Form_Task_EmailCommon {
     }
 
     $form->addFormRule(array('CRM_Contact_Form_Task_EmailCommon', 'formRule'), $form);
-    CRM_Core_Resources::singleton()->addScriptFile('civicrm', 'templates/CRM/Contact/Form/Task/EmailCommon.js');
+    CRM_Core_Resources::singleton()->addScriptFile('civicrm', 'templates/CRM/Core/Form.js');
   }
 
   /**

--- a/CRM/Contact/Form/Task/EmailCommon.php
+++ b/CRM/Contact/Form/Task/EmailCommon.php
@@ -121,6 +121,8 @@ class CRM_Contact_Form_Task_EmailCommon {
    *
    * @access public
    *
+   * @param $form
+   *
    * @return void
    */
   static function buildQuickForm(&$form) {
@@ -271,6 +273,7 @@ class CRM_Contact_Form_Task_EmailCommon {
 
     $form->addFormRule(array('CRM_Contact_Form_Task_EmailCommon', 'formRule'), $form);
     CRM_Core_Resources::singleton()->addScriptFile('civicrm', 'templates/CRM/Core/Form.js');
+    CRM_Core_Resources::singleton()->addScriptFile('civicrm', 'templates/CRM/Contact/Form/Task/EmailCommon.js');
   }
 
   /**
@@ -306,6 +309,8 @@ class CRM_Contact_Form_Task_EmailCommon {
    * process the form after the input has been submitted and validated
    *
    * @access public
+   *
+   * @param $form
    *
    * @return None
    */

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -494,7 +494,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
             'name' => $contribButton,
             'spacing' => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
             'isDefault' => TRUE,
-            'js' => array('onclick' => "return submitOnce(this,'" . $this->_name . "','" . ts('Processing') . "');"),
           ),
           array(
             'type' => 'back',
@@ -557,6 +556,8 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $this->setDefaults($defaults);
 
     $this->freeze();
+
+    parent::buildQuickForm();
   }
 
   /**

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -556,6 +556,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     }
 
     $this->addFormRule(array('CRM_Contribute_Form_Contribution_Main', 'formRule'), $this);
+    parent::buildQuickForm();
   }
 
   /**

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -285,7 +285,14 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    * @return void
    *
    */
-  function buildQuickForm() {}
+  function buildQuickForm() {
+    // @todo less cautious approach would be to add this to addButtons.
+    // it would be good to make this switch at the early stage of a release cycle.
+    // @ the moment of the 106 uses of parent::buildQuickForm only a handle are direct descendents
+    // of this class - including the contribution forms per CRM-13397 & the (tested) sms provider form.
+    //(I checked maybe another 20 directly that weren't & was also able to rule out about 40 more by virtue of common patterns
+    CRM_Core_Resources::singleton()->addScriptFile('civicrm', 'templates/CRM/Core/Form.js');
+  }
 
   /**
    * This virtual function is used to set the default values of
@@ -398,10 +405,10 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       $js = CRM_Utils_Array::value('js', $button);
       $isDefault = CRM_Utils_Array::value('isDefault', $button, FALSE);
       if ($isDefault) {
-        $attrs = array('class' => 'form-submit default');
+        $attrs = array('class' => 'form-submit default crm-form-button-' . $button['type']);
       }
       else {
-        $attrs = array('class' => 'form-submit');
+        $attrs = array('class' => 'form-submit crm-form-button-' . $button['type']);
       }
 
       if ($js) {

--- a/js/Common.js
+++ b/js/Common.js
@@ -396,8 +396,13 @@ function unselectRadio(fieldName, form) {
  * @return null
  */
 var submitcount = 0;
-/* Changes button label on submit, and disables button after submit for newer browsers.
- Puts up alert for older browsers. */
+/**
+ * @deprecated
+ * Changes button label on submit, and disables button after submit for newer browsers.
+ * Puts up alert for older browsers.
+ * @todo CRM-13397 replaces this with an alternate (jquery) mechanism - to use the jquery mechanism add
+ * parent::buildQuickForm to make buttons 'protected'
+ * */
 function submitOnce(obj, formId, procText) {
   // if named button clicked, change text
   if (obj.value != null) {

--- a/templates/CRM/Contact/Form/Task/EmailCommon.js
+++ b/templates/CRM/Contact/Form/Task/EmailCommon.js
@@ -2,17 +2,4 @@ cj(function ($) {
   //do not copy & paste this - find a way to generalise it
   'use strict';
    $().crmAccordions();
-<<<<<<< HEAD
-  // NOTE: Might be safer to say $('[name=_qf_Email_upload]')
-   $('.form-submit').not('.cancel').on("click", function() {
-     $('.form-submit').not('.cancel').attr({value: ts('Processing')});
-     // CRM-13449 : setting a 0 ms timeout is needed 
-     // for some browsers like chrome. Used for purpose of
-     // submit the form and stop accidental multiple clicks
-     setTimeout(function(){
-       $('.form-submit').not('.cancel').attr({disabled: 'disabled'});
-     }, 0);
-   });
-=======
->>>>>>> CRM-13379 js, contribution form - generalise  button double submit protection and add to contribution.main to prevent double submits where people have no confirm page
 });

--- a/templates/CRM/Contact/Form/Task/EmailCommon.js
+++ b/templates/CRM/Contact/Form/Task/EmailCommon.js
@@ -2,6 +2,7 @@ cj(function ($) {
   //do not copy & paste this - find a way to generalise it
   'use strict';
    $().crmAccordions();
+<<<<<<< HEAD
   // NOTE: Might be safer to say $('[name=_qf_Email_upload]')
    $('.form-submit').not('.cancel').on("click", function() {
      $('.form-submit').not('.cancel').attr({value: ts('Processing')});
@@ -12,4 +13,6 @@ cj(function ($) {
        $('.form-submit').not('.cancel').attr({disabled: 'disabled'});
      }, 0);
    });
+=======
+>>>>>>> CRM-13379 js, contribution form - generalise  button double submit protection and add to contribution.main to prevent double submits where people have no confirm page
 });

--- a/templates/CRM/Core/Form.js
+++ b/templates/CRM/Core/Form.js
@@ -1,0 +1,15 @@
+cj(function ($) {
+  'use strict';
+  $('.form-submit').on("click", function() {
+    $('.form-submit').attr({value: ts('Processing'), disabled : 'disabled'});
+    $('.crm-form-button-back ').closest('span').hide();
+    $('.crm-form-button-cancel').closest('span').hide();
+    // CRM-13449 : setting a 0 ms timeout is needed
+    // for some browsers like chrome. Used for purpose of
+    // submit the form and stop accidental multiple clicks
+    setTimeout(function(){
+      $('.form-submit').not('.cancel').attr({disabled: 'disabled'});
+    }, 0);
+  });
+});
+


### PR DESCRIPTION
@totten @colemanw this is building on previous discussions about disabling the form buttons.

The extra commits will hopefully drop out of the log once the other PR I have is pulled (or this could be pulled instead - the test & whitespace fixes are unrelated)
