### PR TITLE
CRM-13365 - Removed the extra closing DIV

### DIFF
--- a/templates/CRM/Profile/Form/Dynamic.tpl
+++ b/templates/CRM/Profile/Form/Dynamic.tpl
@@ -234,9 +234,7 @@ function checkResponse(responseText, statusText, xhr, $form) {
         {/if}
       {/if}{* end of main if field name if *}
     {/foreach}
-    </div><!-- end form-layout-compressed for last profile --> {* closing main form layout div when all the fields are built*}
-
-
+   
     {if $isCaptcha && ( $mode eq 8 || $mode eq 4 || $mode eq 1 ) }
       {include file='CRM/common/ReCAPTCHA.tpl'}
       <script type="text/javascript">cj('.recaptcha_label').attr('width', '140px');</script>


### PR DESCRIPTION
## This issue was in IE 8 and removed the extra closing div to fix this issue
- CRM-13365: Popups should work in Internet Explorer
  http://issues.civicrm.org/jira/browse/CRM-13365
