### PR TITLE
Webtest fixes - Related to Search Builder

### DIFF
--- a/tests/phpunit/WebTest/Contact/SearchBuilderTest.php
+++ b/tests/phpunit/WebTest/Contact/SearchBuilderTest.php
@@ -241,7 +241,7 @@ class WebTest_Contact_SearchBuilderTest extends CiviSeleniumTestCase {
     if ($loc) {
       $this->select("mapper_{$set}_{$row}_2", "label=$loc");
     }
-    $this->select("operator_{$set}_{$row}", "label=$op");
+    $this->select("operator_{$set}_{$row}", "value=$op");
     if (is_array($value)) {
       $this->waitForElementPresent("css=#crm_search_value_{$set}_{$row} select option + option");
       foreach ($value as $val) {


### PR DESCRIPTION
Fixes following WebTests -
1) Error: WebTest_Contact_SearchBuilderTest::testSearchBuilderRLIKE
2) Error: WebTest_Contact_SearchBuilderTest::testSearchBuilderContacts
3) Error: WebTest_Contact_SearchBuilderTest::testSearchBuilderfinancialType
4) Error: WebTest_Contact_SearchBuilderTest::testSearchBuilderMembershipType 
