### PR TITLE
Easy to run tests.

### DIFF
--- a/CRM/DB/MySQLRAMServer.php
+++ b/CRM/DB/MySQLRAMServer.php
@@ -1,0 +1,155 @@
+<?php
+
+class CRM_DB_MySQLRAMServer {
+  public $paths;
+  public $mysqld_base_command;
+
+  function __construct($civicrm_db_settings, $options = array()) {
+    $this->civicrm_db_settings = $civicrm_db_settings;
+    $this->base_path = CRM_Utils_Array::value($options, 'base_path', getcwd());
+    $this->port = CRM_Utils_Array::value($options, 'port', 3307);
+    $this->paths = self::paths($this->base_path);
+    $this->mysqld_base_command = "mysqld --no-defaults --tmpdir={$this->paths['tmp_dir']} --datadir={$this->paths['mysql_data_dir']} --port={$this->port} --socket={$this->paths['mysql_socket']} --pid-file={$this->paths['pid_file']}";
+  }
+
+  function launch_mysqld() {
+    if (!file_exists($this->paths['pid_file'])) {
+      $this->run_command("{$this->mysqld_base_command} > {$this->paths['tmp_dir']}/mysql-drupal-test.log 2>&1 &");
+    }
+  }
+
+  function clean() {
+    $this->kill();
+    if ($this->ram_disk_is_mounted()) {
+      $this->unmount_ram_disk();
+    }
+  }
+
+  static function paths($base_path) {
+    $paths = array();
+    $paths['base_dir'] = $base_path;
+    $paths['tmpfs_dir'] = "{$paths['base_dir']}/tmpfs";
+    $paths['pid_file'] = "{$paths['tmpfs_dir']}/mysqld.pid";
+    $paths['setup_done'] = "{$paths['tmpfs_dir']}/setup_done";
+    $paths['mysql_data_dir'] = "{$paths['tmpfs_dir']}/mysql";
+    $paths['mysql_socket'] = "{$paths['tmpfs_dir']}/mysqld.sock";
+    $paths['tmp_dir'] = "/tmp";
+    return $paths;
+  }
+
+  function kill() {
+    if (file_exists($this->paths['pid_file'])) {
+      $pid_file = CRM_Utils_File::open($this->paths['pid_file'], 'r');
+      $pid = CRM_Utils_File::fgets($pid_file);
+      $result = @posix_kill($pid, SIGTERM);
+      if ($result === FALSE) {
+        $error_info = error_get_last();
+        throw new Exception("Error killing mysqld at pid $pid: " . print_r($error_info, TRUE));
+      }
+      $i = 0;
+      while (file_exists($this->paths['pid_file']) && $i < 10) {
+        $i++;
+        sleep(1);
+      }
+      if ($i == 10) {
+        throw new Exception("Tried to kill mysqld at pid $pid, but the pid file hasn't gone away after 10 seconds. Please clear out pid file if daemon is dead.");
+      }
+    }
+  }
+
+  function ram_disk_is_mounted() {
+    $result = $this->run_command("stat -f -c '%T' {$this->paths['tmpfs_dir']}");
+    if (trim($result[0]) != 'tmpfs') {
+      return FALSE;
+    }
+    return TRUE;
+  }
+
+  function run() {
+    $setup_done = FALSE;
+    if (is_dir($this->paths['tmpfs_dir'])) {
+      if (file_exists($this->paths['setup_done'])) {
+        $setup_done = TRUE;
+      }
+    }
+    if ($setup_done) {
+      $this->launch_mysqld();
+    }
+    else {
+      $this->setup();
+    }
+    print("********************************************************************************\n");
+    print(" There is now a MySQL server running on a RAM disc on port {$this->port}\n");
+    print("*******************************************************************************\n");
+  }
+
+  function run_command($command, $options = array()) {
+    $options['print_command'] = true;
+    return CRM_Utils_Shell::run($command, $options);
+  }
+
+  function setup() {
+    $this->run_command("rm -rf {$this->paths['tmpfs_dir']}/*");
+    if (!is_dir($this->paths['tmpfs_dir'])) {
+      mkdir($this->paths['tmpfs_dir'], 0755, TRUE);
+    }
+    if (!$this->ram_disk_is_mounted()) {
+      $this->run_command("sudo mount -t tmpfs -o size=500m tmpfs {$this->paths['tmpfs_dir']}");
+      $uid = getmyuid();
+      $gid = getmygid();
+      $this->run_command("sudo chown $uid:$gid {$this->paths['tmpfs_dir']}");
+      $this->run_command("chmod 0755 {$this->paths['tmpfs_dir']}");
+    }
+    if (!is_dir($this->paths['tmp_dir'])) {
+      mkdir($this->paths['tmp_dir'], 0755, TRUE);
+    }
+    $temp_file_path = CRM_Utils_Path::join($this->paths['tmp_dir'], "apparmor-usr.sbin.mysqld");
+    $lines = array (
+      "{$this->paths['tmpfs_dir']}/ r,\n",
+      "{$this->paths['tmpfs_dir']}/** rwk,\n",
+    );
+    if (file_exists("/etc/apparmor.d/local/usr.sbin.mysqld")) {
+      if (CRM_Utils_File::appendLines("/etc/apparmor.d/local/usr.sbin.mysqld", $temp_file_path, $lines)) {
+        $this->run_command("sudo cp /etc/apparmor.d/local/usr.sbin.mysqld /etc/apparmor.d/local/usr.sbin.mysqld.orig");
+        $this->run_command("sudo mv $temp_file_path /etc/apparmor.d/local/usr.sbin.mysqld");
+        $this->run_command("sudo /etc/init.d/apparmor restart", array('throw_exception_on_nonzero' => FALSE));
+      }
+    }
+    if (!is_dir($this->paths['mysql_data_dir'])) {
+      mkdir($this->paths['mysql_data_dir'], 0755, TRUE);
+    }
+    $mysql_system_dir_path = "{$this->paths['mysql_data_dir']}/mysql";
+    if (!is_dir($mysql_system_dir_path)) {
+      mkdir($mysql_system_dir_path, 0755, TRUE);
+    }
+    $this->run_command("echo \"use mysql;\" > {$this->paths['tmp_dir']}/install_mysql.sql");
+    $this->run_command("cat /usr/share/mysql/mysql_system_tables.sql /usr/share/mysql/mysql_system_tables_data.sql >> {$this->paths['tmp_dir']}/install_mysql.sql");
+    $this->run_command("{$this->mysqld_base_command} --log-warnings=0 --bootstrap --loose-skip-innodb --max_allowed_packet=8M --default-storage-engine=myisam --net_buffer_length=16K < {$this->paths['tmp_dir']}/install_mysql.sql");
+    $this->run_command("{$this->mysqld_base_command} > {$this->paths['tmp_dir']}/mysql-drupal-test.log 2>&1 &");
+    $setup_done_file = fopen($this->paths['setup_done'], "w");
+    fwrite($setup_done_file, "Done!!\n");
+    fclose($setup_done_file);
+    $this->wait_for_mysql_server(); 
+    $i = 0;
+    if (!file_exists($this->paths['mysql_socket']) or $i > 9) {
+      $i++;
+      sleep(1);
+    }
+    if ($i == 9) {
+      throw new Exception("There was a problem starting the MySQLRAM server. We expect to see a socket file at {$this->path['mysql_socket']} but it hasn't appeared after 10 waiting seconds.");
+    }
+  }
+
+  function wait_for_mysql_server() {
+    $result = CRM_Utils_Network::waitForServiceStartup('127.0.0.1', $this->port, 10);
+    if ($result === FALSE) {
+      throw new Exception("Error trying to connect to mysqld at 127.0.0.1:{$this->port}, gave up after 10 seconds.");
+    }
+  }
+
+  function unmount_ram_disk() {
+    if (is_dir($this->paths['tmpfs_dir'])) {
+      $this->run_command("sudo umount {$this->paths['tmpfs_dir']}");
+    }
+  }
+}

--- a/CRM/DB/Settings.php
+++ b/CRM/DB/Settings.php
@@ -1,0 +1,89 @@
+<?php
+
+class CRM_DB_InvalidSettings extends Exception {};
+
+class CRM_DB_Settings {
+  public static $cividsn_to_settings_name = array(
+    'database' => 'database',
+    'hostspec' => 'host',
+    'password' => 'password',
+    'port' => 'port',
+    'username' => 'username',
+  );
+  public $database;
+  public $driver;
+  public $host;
+  public $password;
+  public $port;
+  public static $settings_to_pdo_options = array(
+    'host' => 'host',
+    'port' => 'port',
+    'database' => 'dbname',
+    'socket_path' => 'unix_socket',
+  );
+  public $socket_path;
+  public $username;
+
+  function __construct($settings_array = NULL) {
+    if ($settings_array == NULL) {
+      $civi_dsn = getenv('CIVICRM_TEST_DSN');
+      if ($civi_dsn !== FALSE) {
+        $this->loadFromCiviDSN($civi_dsn);
+      } else {
+        throw new CRM_DB_InvalidSettings("You must either provide a settings array or define CIVICRM_TEST_DSN in the environment.");
+      }
+    } else {
+      $this->loadFromSettingsArray($settings_array);
+    }
+  }
+
+  function loadFromCiviDSN($civi_dsn) {
+    require_once("DB.php");
+    $parsed_dsn = DB::parseDSN('CIVICRM_TEST_DSN');
+    foreach (static::$cividsn_to_settings_name as $key => $value) {
+      if (array_key_exists($key, $parsed_dsn)) {
+        $this->$value = $parsed_dsn[$key];
+      }
+    }
+  }
+
+  function loadFromSettingsArray($settings_array) {
+    foreach ($settings_array as $key => $value) {
+      $this->$key = $value;
+    }
+  }
+
+  function toCiviDSN() {
+    $civi_dsn = "mysql://{$this->username}:{$this->password}@{$this->host}";
+    if ($this->port !== NULL) {
+      $civi_dsn = "$civi_dsn:{$this->port}";
+    }
+    $civi_dsn = "$civi_dsn/{$this->database}?new_link=true";
+    return $civi_dsn;
+  }
+
+  function toDrupalDSN() {
+    $drupal_dsn = "{$this->driver}://{$this->username}:{$this->password}@{$this->host}";
+    if ($this->port !== NULL) {
+      $drupal_dsn = "$drupal_dsn:{$this->port}";
+    }
+    $drupal_dsn = "$drupal_dsn/{$this->database}";
+    return $drupal_dsn;
+  }
+
+  function toPDODSN($options = array()) {
+    $pdo_dsn = "{$this->driver}:";
+    $pdo_dsn_options = array();
+    $settings_to_pdo_options = static::$settings_to_pdo_options;
+    if (CRM_Utils_Array::fetch('no_database', $options, FALSE)) {
+      unset($settings_to_pdo_options['database']);
+    }
+    foreach ($settings_to_pdo_options as $settings_name => $pdo_name) {
+      if ($this->$settings_name !== NULL) {
+        $pdo_dsn_options[] = "{$pdo_name}={$this->$settings_name}";
+      }
+    }
+    $pdo_dsn .= implode(';', $pdo_dsn_options);
+    return $pdo_dsn;
+  }
+}

--- a/CRM/Tests/Runner.php
+++ b/CRM/Tests/Runner.php
@@ -1,0 +1,329 @@
+<?php
+
+class CRM_Tests_Runner {
+  const DRUPAL_SOURCE_URL = "http://ftp.drupal.org/files/projects/drupal-7.23.tar.gz";
+  const TEST_SITE_URL = "http://civicrm-tests.local/";
+  public $base_path;
+  public $civicrm_db_settings;
+  public $drupal_db_settinsg;
+  public $db = NULL;
+  public $phpunit_args;
+  public $settings_file_path;
+  public $use_mysql_ram_sever;
+  public $use_selenium;
+
+  function __construct($options = array()) {
+    $this->base_path = CRM_Utils_Array::fetch('base_path', $options, getcwd());
+    $this->tmp_path = CRM_Utils_Path::join($this->base_path, "..", "tmp");
+    CRM_Utils_Path::mkdir_p_if_not_exists($this->tmp_path);
+    $this->tmp_path = realpath($this->tmp_path);
+    $this->drupal_path = CRM_Utils_Path::join($this->tmp_path, 'drupal');
+    $this->phpunit_args = CRM_Utils_Array::fetch('php-unit', $options, 'AllTests');
+    $this->settings_file_path = CRM_Utils_Path::join($this->base_path, 'tests', 'phpunit', 'CiviTest', 'civicrm.settings.local.php');
+    $this->use_mysql_ram_server = CRM_Utils_Array::fetch('mysql-ram-server', $options, FALSE);
+    $this->use_selenium = !CRM_Utils_Array::fetch('no-selenium', $options, FALSE);
+  }
+
+  function build_db_files() {
+    $orig_dir = CRM_Utils_Dir::getcwd();
+    $xml_dir_path = CRM_Utils_Path::join($this->base_path, 'xml');
+    $this->shell("php GenCode.php", array('directory' => $xml_dir_path));
+  }
+
+  function clean() {
+    $this->mysql_ram_server = new CRM_DB_MySQLRAMServer($this->civicrm_db_settings, $this->mysql_ram_server_options());
+    $this->mysql_ram_server->clean();
+    unlink(CRM_Utils_Path::join($this->base_path, 'sql', 'civicrm.mysql'));
+    $this->shell("rm -r {$this->tmp_path}");
+  }
+
+  function clear_database() {
+    $this->db->exec("DROP DATABASE IF EXISTS {$this->civicrm_db_settings->database}");
+    $this->db->exec("CREATE DATABASE {$this->civicrm_db_settings->database}");
+  }
+
+  function connect_to_db() {
+    if ($this->db == NULL) {
+      $this->db = new PDO($this->civicrm_db_settings->toPDODSN(array('no_database' => TRUE)), $this->civicrm_db_settings->username, $this->civicrm_db_settings->password);
+      $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    }
+    return $this->db;
+  }
+
+  function fetch_civicrm_drupal() {
+    $this->shell("git clone https://github.com/civicrm/civicrm-drupal.git drupal");
+  }
+
+  function install_drupal() {
+    $civicrm_drupal_path = CRM_Utils_Path::join($this->base_path, 'drupal');
+    if (!file_exists($civicrm_drupal_path)) {
+      $this->fetch_civicrm_drupal();
+    }
+    $canary_file_path = CRM_Utils_Path::join($this->drupal_path, 'index.php');
+    if (!file_exists($canary_file_path)) {
+      $this->unpack_drupal();
+      $this->setup_apache();
+    }
+    $drupal_settings_path = CRM_Utils_Path::join($this->drupal_path, 'sites', 'default', 'settings.php');
+    if (!file_exists($drupal_settings_path)) {
+      $this->setup_drupal_settings();
+    }
+    $civicrm_settings_path = CRM_Utils_Path::join($this->drupal_path, 'sites', 'default', 'civicrm.settings.php');
+    if (!file_exists($civicrm_settings_path)) {
+      $this->setup_civicrm_drupal_module();
+    }
+  }
+
+  function load_civicrm_database() {
+    $this->mysql_base_command = "mysql -u '{$this->civicrm_db_settings->username}' --password='{$this->civicrm_db_settings->password}' -h {$this->civicrm_db_settings->host}";
+    if ($this->civicrm_db_settings->port) {
+      $this->mysql_base_command .= " -P {$this->civicrm_db_settings->port}";
+    }
+    $this->mysql_base_command .= " {$this->civicrm_db_settings->database}";
+    $this->mysql_load_from_file_path(CRM_Utils_Path::join($this->base_path, 'sql', 'civicrm.mysql'));
+    $this->mysql_load_from_file_path(CRM_Utils_Path::join($this->base_path, 'sql', 'civicrm_generated.mysql'));
+  }
+
+  function mysql_ram_server_options() {
+    return array(
+      'base_path' => $this->base_path,
+    );
+  }
+
+  function mysql_load_from_file_path($file_path) {
+    $this->shell("{$this->mysql_base_command} < $file_path");
+  }
+
+  function run() {
+    if (!file_exists($this->settings_file_path)) {
+      $settings_file = CRM_Utils_File::open($this->settings_file_path, 'w');
+      $host = 'localhost';
+      $port = '3306';
+      if ($this->use_mysql_ram_server) {
+        $host = '127.0.0.1';
+        $port = '3307';
+      }
+      $settings_file_contents = <<<EOS
+<?php
+\$civicrm_database_settings = array(
+  'database' => 'civicrm_tests_dev',
+  'driver' => 'mysql',
+  'host' => '$host',
+  'password' => '',
+  'port' => $port,
+  'username' => 'root',
+);
+EOS;
+      CRM_Utils_File::write($settings_file, $settings_file_contents);
+      CRM_Utils_File::close($settings_file);
+    }
+    require_once($this->settings_file_path);
+    $this->civicrm_db_settings = new CRM_DB_Settings($civicrm_database_settings);
+    $civicrm_database_settings['database'] = 'civicrm_tests_drupal';
+    $this->drupal_db_settings = new CRM_DB_Settings($civicrm_database_settings);
+    if ($this->use_mysql_ram_server) {
+      $this->start_mysql_ram_server();
+    }
+    if (!file_exists(CRM_Utils_Path::join($this->base_path, "sql", "civicrm.mysql"))) {
+      $this->build_db_files();
+    }
+    $this->connect_to_db();
+    $this->clear_database();
+    $this->load_civicrm_database();
+    if ($this->use_selenium) {
+      $this->install_drupal();
+      $this->setup_selenium();
+    }
+    $this->run_tests();
+  }
+
+  function run_tests() {
+    $command = "./tools/scripts/phpunit AllTests";
+    $GLOBALS['base_dir'] = $this->base_path;
+    $include_paths = array();
+    $include_paths[] = $this->base_path;
+    $include_paths[] = CRM_Utils_Path::join($this->base_path, 'tests', 'phpunit');
+    $include_paths[] = CRM_Utils_Path::join($this->base_path, 'packages');
+    ini_set('safe_mode', 0);
+    ini_set('include_path', implode(PATH_SEPARATOR, $include_paths) . PATH_SEPARATOR . ini_get('include_path'));
+    #  Relying on system timezone setting produces a warning,
+    #  doing the following prevents the warning message
+    if ( file_exists( '/etc/timezone' ) ) {
+      $timezone = trim( file_get_contents( '/etc/timezone' ) );
+      if ( ini_set('date.timezone', $timezone ) === false ) {
+        echo "ini_set( 'date.timezone', '$timezone' ) failed\n";
+      }
+    }
+    ini_set('memory_limit', '2G');
+    error_reporting( E_ALL );
+    require 'PHPUnit/TextUI/Command.php';
+    define('PHPUnit_MAIN_METHOD', 'PHPUnit_TextUI_Command::main');
+    $autoloader_path = CRM_Utils_Path::join($this->base_path, 'packages', 'PHPUnit', 'Autoload.php');
+    require_once($autoloader_path);
+    $phpunit_args = array('phpunit');
+    $phpunit_args = array_merge($phpunit_args, explode(' ', $this->phpunit_args));
+    $_SERVER['argv'] = $phpunit_args;
+    $phpunit_command = new PHPUnit_TextUI_Command();
+    $this->db = NULL;
+    $phpunit_command->run($phpunit_args, TRUE);
+  }
+
+  function setup_selenium() {
+    $selenium_settings_file_path = CRM_Utils_Path::join($this->base_path, 'tests', 'phpunit', 'CiviTest', 'CiviSeleniumSettings.php');
+    if (!file_exists($selenium_settings_file_path)) {
+      $selenium_settings_template_file_path = CRM_Utils_Path::join($this->base_path, 'tests', 'phpunit', 'CiviTest', 'CiviSeleniumSettings.php.txt');
+      $result = copy($selenium_settings_template_file_path, $selenium_settings_file_path);
+      if ($result === FALSE) {
+        throw new Exception("Error copying '$selenium_settings_template_file_path' to '$selenium_settings_file_path': " . print_r(error_get_last(), TRUE));
+      }
+    }
+    $selenium_base_path = CRM_Utils_Path::join($this->base_path, 'packages', 'SeleniumRC');
+    $selenium_firefox_profile_path = CRM_Utils_Path::join($selenium_base_path, 'BrowserProfiles', 'firefox');
+    $selenium_jar_path = CRM_Utils_Path::join($selenium_base_path, 'selenium-server', 'selenium-server-standalone-2.35.0.jar');
+    $selenium_cmd = "java -jar $selenium_jar_path -firefoxProfileTemplate $selenium_firefox_profile_path > selenium.log 2>&1";
+    print("$selenium_cmd\n");
+    $this->selenium_pid = pcntl_fork();
+    if ($this->selenium_pid == -1)
+    {
+      $errno = posix_get_last_error();
+      throw new Exception("Error forking off selenium: $errno: " . posix_strerror($errno) . "\n");
+    }
+    elseif ($this->selenium_pid == 0)
+    {
+      $cmd = '/bin/sh';
+      $args = array('-c', $selenium_cmd);
+      pcntl_exec($cmd, $args);
+      throw new Execption("Error executing '$cmd' " . implode(' ', $args));
+    }
+    $result = CRM_Utils_Network::waitForServiceStartup('127.0.0.1', 4444, 10);
+    if ($result === FALSE) {
+      throw new Exception("Error launching Selenium server, expected to see it on port 4444, but can't connect to it. Check selenium.log for details.");
+    }
+    print("********************************************************************************\n");
+    print(" There is now a Selenium server on port 4444.\n");
+    print("********************************************************************************\n");
+  }
+
+  function setup_apache() {
+    $url_components = parse_url(self::TEST_SITE_URL);
+    $apache_settings = <<<EOS
+<VirtualHost *:80>
+  DocumentRoot {$this->drupal_path}
+  ServerName {$url_components['host']}
+</VirtualHost>
+EOS;
+    $apache_settings_path = CRM_Utils_Path::join($this->tmp_path, 'civicrm-test.apache.conf');
+    $result = file_put_contents($apache_settings_path, $apache_settings);
+    if ($result === FALSE) {
+      throw new Exception("Error creating example apache file at '$apache_settings_path': " . print_r(error_get_last, TRUE));
+    }
+    print("********************************************************************************\n");
+    print(" You need to have an HTTP server that can serve PHP from:\n {$this->drupal_path}\n\n at the URL:\n " . self::TEST_SITE_URL . "\n\n");
+    print(" We have provided a sample Apache configuration file at:\n {$apache_settings_path}\n\n");
+    print(" You may also need to add this to your /etc/hosts file:\n 127.0.0.1 {$url_components['host']}\n");
+    print("********************************************************************************\n");
+  }
+
+  function setup_civicrm_drupal_module() {
+    $civicrm_module_path = CRM_Utils_Path::join($this->drupal_path, 'sites', 'all', 'modules', 'civicrm');
+    if (file_exists($civicrm_module_path)) {
+      if (!is_link($civicrm_module_path)) {
+        throw new Exception("We expect $civicrm_module_path to be a link to {$this->base_path}, but it isn't a symlink.");
+      }
+    } else {
+      $result = symlink($this->base_path, $civicrm_module_path);
+      if ($result === FALSE) {
+        throw new Exception("Error creating symlink to {$civicrm_module_path} from {$this->base_path}: " . print_r(error_get_last(), TRUE));
+      }
+    }
+    $template_values = array(
+      'cms' => 'Drupal',
+      'CMSdbUser' => $this->drupal_db_settings->username,
+      'CMSdbPass' => $this->drupal_db_settings->password,
+      'CMSdbHost' => "{$this->drupal_db_settings->host}:{$this->drupal_db_settings->port}",
+      'CMSdbName' => $this->drupal_db_settings->database,
+      'dbUser' => $this->civicrm_db_settings->username,
+      'dbPass' => $this->civicrm_db_settings->password,
+      'dbHost' => "{$this->civicrm_db_settings->host}:{$this->civicrm_db_settings->port}",
+      'dbName' => $this->civicrm_db_settings->database,
+      'crmRoot' => $this->base_path,
+      'templateCompileDir' => CRM_Utils_Path::join($this->tmp_path, 'templates_c'),
+      'baseURL' => self::TEST_SITE_URL,
+      'siteKey' => 'phpunittestfakekey',
+    );
+    $settings_template = new CRM_Utils_SettingsTemplate($this->base_path, $template_values);
+    $civicrm_settings_path = CRM_Utils_Path::join($this->drupal_path, 'sites', 'default', 'civicrm.settings.php');
+    $settings_template->install($civicrm_settings_path);
+    $command = "drush -y pm-enable civicrm";
+    $this->shell($command, array('directory' => $this->drupal_path, 'throw_exception_on_nonzero' => FALSE));
+  }
+
+  function setup_drupal_settings() {
+    $drupal_dsn = $this->drupal_db_settings->toDrupalDSN();
+    $drush_install_cmd = "drush -y site-install standard --db-url='{$drupal_dsn}' --site-name='CiviCRM Tests' --account-name=admin --account-pass=admin";
+    $this->shell($drush_install_cmd, array('directory' => $this->drupal_path));
+    $drupal_settings_path = CRM_Utils_Path::join($this->drupal_path, 'sites', 'default');
+    $result = chmod($drupal_settings_path, 0755);
+    if ($result === FALSE) {
+      throw new Exception("Error settings permissions on $drupal_settings_path to 0755: " . print_r(error_get_last, TRUE));
+    }
+  }
+
+  function shell($cmd, $options = array()) {
+    /*
+     * We can't rely on autoload because if CRM_Utils_Shell isn't already
+     * loaded here, the chdir will mess the paths up and the autoloader
+     * won't be able to find it.
+     */
+    require_once('CRM/Utils/Shell.php');
+    $orig_dir_path = NULL;
+    if (array_key_exists('directory', $options)) {
+      $exec_dir_path = $options['directory'];
+      unset($options['directory']);
+      $orig_dir_path = getcwd();
+      CRM_Utils_Dir::chdir($exec_dir_path);
+    }
+    $options['print_command'] = TRUE;
+    try {
+      $result = CRM_Utils_Shell::run($cmd, $options);
+    } catch (Exception $e) {
+      if ($orig_dir_path != NULL) {
+        CRM_Utils_Dir::chdir($orig_dir_path);
+      }
+      throw $e;
+    }
+    if ($orig_dir_path != NULL) {
+      CRM_Utils_Dir::chdir($orig_dir_path);
+    }
+    return $result;
+  }
+
+  function start_mysql_ram_server() {
+    $this->mysql_ram_server = new CRM_DB_MySQLRAMServer($this->civicrm_db_settings, $this->mysql_ram_server_options());
+    $this->mysql_ram_server->run();
+  }
+
+  function unpack_drupal() {
+    $url_components = parse_url(self::DRUPAL_SOURCE_URL);
+    $file_name = basename($url_components['path']);
+    $target_path = CRM_Utils_Path::join($this->tmp_path, $file_name);
+    if (!file_exists($target_path)) {
+      print("Downloading Drupal from " . self::DRUPAL_SOURCE_URL . "\n");
+      $result = file_get_contents(self::DRUPAL_SOURCE_URL);
+      if ($result === FALSE) {
+        throw new Exception("Error downloading Drupal from " . self::DRUPAL_SOURCE_URL . ": " . print_r(error_get_last(), TRUE));
+      }
+      $result = file_put_contents($target_path, $result);
+      if ($result === FALSE) {
+        throw new Exception("Error creating Drupal source file {$target_path}: " . print_r(error_get_last(), TRUE));
+      }
+    }
+    $this->shell("tar --directory={$this->tmp_path} -xzf {$target_path}");
+    $drupal_dir_name = preg_replace("/\.tar\.gz$/", "", $file_name);
+    $unpacked_dir_path = CRM_Utils_Path::join($this->tmp_path, $drupal_dir_name);
+    $result = rename($unpacked_dir_path, $this->drupal_path);
+    if ($result === FALSE) {
+      throw new Exception("Error renaming {$upacked_dir_path} to {$this->drupal_path}: " . print_r(error_get_last(), TRUE));
+    }
+  }
+}

--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -635,5 +635,21 @@ class CRM_Utils_Array {
     }
     return $default;
   }
+
+  /*
+   * Similar to the value method, but this one will throw an exception 
+   * if you give it bad arguments.
+   */
+  static function fetch($key, $array, $default = NULL) {
+    if (is_array($array)) {
+      if (array_key_exists($key, $array)) {
+        return $array[$key];
+      } else {
+        return $default;
+      }
+    } else {
+      throw Exception("CRM_Utils_Array::fetch expects an array as the second argument, but you passed (" . print_r($key, TRUE) . ", " . print_r($array, TRUE) . ", " . print_r($default, TRUE) . ")");
+    }
+  }
 }
 

--- a/CRM/Utils/Dir.php
+++ b/CRM/Utils/Dir.php
@@ -1,0 +1,19 @@
+<?php
+
+class CRM_Utils_Dir {
+  static function getcwd() {
+    $result = getcwd();
+    if ($result === FALSE) {
+      throw new Exception("Error getting current working directory: " . print_r(error_get_last(), TRUE));
+    }
+    return $result;
+  }
+
+  static function chdir($directory_path) {
+    $result = chdir($directory_path);
+    if ($result === FALSE) {
+      throw new Exception("Error changing to $directory_path: " . print_r(error_get_last(), TRUE));
+    }
+    return $result;
+  }
+}

--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -604,5 +604,69 @@ HTACCESS;
     }
     return TRUE;
   }
+
+  static function appendLines($file_path, $new_file_path, $lines_to_write) {
+    $added = FALSE;
+    $lines_written = array();
+    $orig_file = fopen($file_path, 'r');
+    $new_file = fopen($new_file_path, 'w');
+    while (($line = fgets($orig_file)) !== FALSE) {
+      foreach ($lines_to_write as $line_to_write) {
+        if (trim($line) == trim($line_to_write)) {
+          $lines_written[] = $line;
+        }
+      }
+      fwrite($new_file, $line);
+    }
+    foreach ($lines_to_write as $line_to_write) {
+      if (!in_array($line_to_write, $lines_written)) {
+        fwrite($new_file, $line_to_write);
+        $added = TRUE;
+      }
+    }
+    fclose($orig_file);
+    fclose($new_file);
+    return $added;
+  }
+
+  static function close($handle) {
+    $result = @fclose($handle);
+    if ($result === FALSE) {
+      throw new Exception("Error closing " . print_r($handle, TRUE) . ": " . print_r(error_get_last(), TRUE));
+    }
+    return $result;
+  }
+
+  static function fgets($handle) {
+    $result = @fgets($handle);
+    if ($result === FALSE) {
+      throw new Exception("Error calling fgets on " . print_r($handle, TRUE) . ": " . print_r(error_get_last(), TRUE));
+    }
+    return $result;
+  }
+
+  static function open($file_path, $mode, $use_include_path = false) {
+    $result = @fopen($file_path, $mode, $use_include_path);
+    if ($result === FALSE) {
+      throw new Exception("Error opening $file_path with mode $mode: " . print_r(error_get_last(), TRUE));
+    }
+    return $result;
+  }
+
+  static function read($handle, $length) {
+    $result = @fread($handle, $length);
+    if ($result === FALSE) {
+      throw new Exception("Error reading from " . print_r($handle, TRUE) . ": " . print_r(error_get_last(), TRUE));
+    }
+    return $result;
+  }
+
+  static function write($handle, $string) {
+    $result = @fwrite($handle, $string);
+    if ($result === FALSE) {
+      throw new Exception("Error writing '$string' to " . print_r($handle, TRUE) . ": " . print_r(error_get_last(), TRUE));
+    }
+    return $result;
+  }
 }
 

--- a/CRM/Utils/Path.php
+++ b/CRM/Utils/Path.php
@@ -1,0 +1,29 @@
+<?php
+
+class CRM_Utils_Path {
+  static function join() {
+    $path_parts = array();
+    $args = func_get_args();
+    foreach ($args as $arg) {
+      if (is_array($arg)) {
+        $path_parts = array_merge($path_parts, $arg);
+      } else {
+        $path_parts[] = $arg;
+      }
+    }
+    return implode(DIRECTORY_SEPARATOR, $path_parts);
+  }
+
+  static function mkdir_p_if_not_exists($path) {
+    if (file_exists($path)) {
+      if (!is_dir($path)) {
+        throw new Exception("Trying to make a directory at '$path', but there is already a file there with the same name.");
+      }
+    } else {
+      $result = @mkdir($path, 0777, TRUE);
+      if ($result === FALSE) {
+        throw new Exception("Error trying to create directory '$path': " . print_r(error_get_last(), TRUE));
+      }
+    }
+  }
+}

--- a/CRM/Utils/SettingsTemplate.php
+++ b/CRM/Utils/SettingsTemplate.php
@@ -1,0 +1,27 @@
+<?php
+
+class CRM_Utils_SettingsTemplate {
+  public $template_path;
+  public $template_values;
+
+  function __construct($base_path, $template_values) {
+    $this->template_path = CRM_Utils_Path::join($base_path, 'templates', 'CRM', 'common', 'civicrm.settings.php.template');
+    $this->template_values = $template_values;
+  }
+
+  function install($target_path) {
+    $template_file = CRM_Utils_File::open($this->template_path, 'r');
+    $file_size = filesize($this->template_path);
+    if ($file_size === FALSE) {
+      throw new Exception("Couldn't get size of template file '{$this->template_path}': " . print_r(error_get_last(), TRUE));
+    }
+    $template_contents = CRM_Utils_File::read($template_file, $file_size);
+    CRM_Utils_File::close($template_file);
+    foreach ($this->template_values as $key => $value) {
+      $template_contents = str_replace('%%' . $key . '%%', $value, $template_contents);
+    }
+    $target_file = CRM_Utils_File::open($target_path, 'w');
+    CRM_Utils_File::write($target_file, $template_contents);
+    CRM_Utils_File::close($target_file);
+  }
+}

--- a/CRM/Utils/Shell.php
+++ b/CRM/Utils/Shell.php
@@ -1,0 +1,75 @@
+<?php
+
+class CRM_Utils_Shell {
+  static function run($command, $options = array()) {
+    $options['throw_exception_on_nonzero'] = CRM_Utils_Array::fetch('throw_exception_on_nonzero', $options, TRUE);
+    $options['print_command'] = CRM_Utils_Array::fetch('print_command', $options, FALSE);
+    $options['input'] = CRM_Utils_Array::fetch('input', $options);
+    if ($options['print_command']) {
+      print("$command\n");
+    }
+    $descriptors_spec = array (
+      0 => array('pipe', 'r'),
+      1 => array('pipe', 'w'),
+      2 => array('pipe', 'w'),
+    );
+    $process = proc_open($command, $descriptors_spec, $pipes);
+    if ($process === FALSE) {
+      throw new \Exception("Unable to proc_open($command).");
+    } 
+    stream_set_blocking($pipes[1], FALSE);
+    if ($options['input']) {
+      fwrite($pipes[0], $options['input']);
+      fclose($pipes[0]);
+    }
+    $stdout_data = '';
+    $stderr_data = '';
+    $stdout_done = FALSE;
+    $stderr_done = FALSE;
+    while (!$stdout_done && !$stderr_done) {
+      $read_streams = array($pipes[1], $pipes[2]);
+      $write_streams = null;
+      $exceptions = null;
+      $result = stream_select($read_streams, $write_streams, $exceptions, 5);
+      if ($result === FALSE) {
+        throw new \Exception("Error running stream_select on pipe.");
+      }
+      if ($result > 0) { 
+        foreach ($read_streams as $read_stream) {
+          if ($read_stream == $pipes[1]) {
+            $result = fgets($read_stream);
+            if ($result === FALSE) {
+              if (!feof($read_stream)) {
+                throw new \Exception("Error reading from proc_open($command) stderr stream.");
+              } else {
+                $stdout_done = TRUE;
+              }
+            } else {
+              $stdout_data .= $result;
+            }
+          } elseif ($read_stream == $pipes[2]) {
+            $result = fgets($read_stream);
+            if ($result === FALSE) {
+              if (!feof($read_stream)) {
+                throw new \Exception("Error reading from proc_open($command) stderr stream.");
+              } else {
+                $stderr_done = TRUE;
+              }
+            } else {
+              $stderr_data .= $result;
+            }
+          }
+        }
+      } else {
+        break;
+      }
+    }
+    fclose($pipes[1]);
+    fclose($pipes[2]);
+    $return_value = proc_close($process);
+    if ($return_value != 0 && $options['throw_exception_on_nonzero']) {
+      throw new \Exception("Error running '$command'. Non-zero return value ($return_value)\nstdout:\n$stdout_data\nstderr\n$stderr_data");
+    }
+    return array($stdout_data, $stderr_data);
+  }
+}

--- a/tests/phpunit/CiviTest/CiviSeleniumSettings.php.txt
+++ b/tests/phpunit/CiviTest/CiviSeleniumSettings.php.txt
@@ -16,17 +16,17 @@ class CiviSeleniumSettings {
    */
   var $rcPort = 4444;
 
-  var $sandboxURL = 'http://devel.drupal.tests.dev.civicrm.org';
+  var $sandboxURL = 'http://civicrm-tests.local';
 
   var $sandboxPATH = '';
 
-  var $username = 'demo';
+  var $username = 'admin';
 
-  var $password = 'demo';
+  var $password = 'admin';
 
-  var $adminUsername = 'USERNAME';
+  var $adminUsername = 'admin';
   
-  var $adminPassword = 'PASSWORD';
+  var $adminPassword = 'admin';
 
   var $adminApiKey = NULL; // civicrm_contact.api_key for admin
 

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -30,12 +30,8 @@
  *  Include configuration
  */
 define('CIVICRM_SETTINGS_PATH', __DIR__ . '/civicrm.settings.dist.php');
-define('CIVICRM_SETTINGS_LOCAL_PATH', __DIR__ . '/civicrm.settings.local.php');
-
-if (file_exists(CIVICRM_SETTINGS_LOCAL_PATH)) {
-  require_once CIVICRM_SETTINGS_LOCAL_PATH;
-}
 require_once CIVICRM_SETTINGS_PATH;
+
 /**
  *  Include class definitions
  */
@@ -139,18 +135,11 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
     // we need full error reporting
     error_reporting(E_ALL & ~E_NOTICE);
 
-    if (!empty($GLOBALS['mysql_db'])) {
-      self::$_dbName = $GLOBALS['mysql_db'];
-    }
-    else {
-      self::$_dbName = 'civicrm_tests_dev';
-    }
+    global $civicrm_db_settings;
+    self::$_dbName = $civicrm_db_settings->database;
 
     //  create test database
-    self::$utils = new Utils($GLOBALS['mysql_host'],
-      $GLOBALS['mysql_user'],
-      $GLOBALS['mysql_pass']
-    );
+    self::$utils = new Utils($civicrm_db_settings);
 
     // also load the class loader
     require_once 'CRM/Core/ClassLoader.php';

--- a/tests/phpunit/CiviTest/civicrm.settings.dist.php
+++ b/tests/phpunit/CiviTest/civicrm.settings.dist.php
@@ -6,45 +6,6 @@
 
 //--- you shouldn't have to modify anything under this line, but might want to put the compiled templates CIVICRM_TEMPLATE_COMPILEDIR in a different folder than our default location ----------
 
-if ( ! defined( 'CIVICRM_DSN' ) && ! empty( $GLOBALS['mysql_user'] ) ) {
-  $dbName = ! empty( $GLOBALS['mysql_db'] ) ? $GLOBALS['mysql_db'] : 'civicrm_tests_dev';
-  if ( empty( $GLOBALS['mysql_pass'] ) && $GLOBALS['mysql_pass_need_password'] ) {
-    $GLOBALS['mysql_pass'] = PHPUnit_TextUI_Command::getPassword( 'Password' );
-  }
-  define( 'CIVICRM_DSN'          , "mysql://{$GLOBALS['mysql_user']}:{$GLOBALS['mysql_pass']}@{$GLOBALS['mysql_host']}/{$dbName}?new_link=true" );
-}
-
-
-if (!defined("CIVICRM_DSN")) {
-  $dsn= getenv("CIVICRM_TEST_DSN");
-  if (!empty ($dsn)) {
-    define("CIVICRM_DSN",$dsn);
-  } else {
-    echo "\nFATAL: no DB connection configured (CIVICRM_DSN). \nYou can either create/edit " . __DIR__ . "/civicrm.settings.local.php\n";
-    if (strtoupper(substr(PHP_OS, 0, 3)) !== 'WIN') {
-      echo "OR set it in your shell:\n \$export CIVICRM_TEST_DSN=mysql://db_username:db_password@localhost/civicrm_tests_dev \n";
-    } else {
-      echo "OR set it in your shell:\n SETX CIVICRM_TEST_DSN mysql://db_username:db_password@localhost/civicrm_tests_dev \n
-      (you will need to open a new command shell before it takes effect)";
-    }
-echo "\n\n
-If you haven't done so already, you need to create (once) a database dedicated to the unit tests:
-mysql -uroot -p
-create database civicrm_tests_dev;
-grant ALL on civicrm_tests_dev.* to db_username@localhost identified by 'db_password';
-grant SUPER on *.* to db_username@localhost identified by 'db_password';\n";
-    die ("");
-  }
-}
-
-
-require_once "DB.php";
-$dsninfo = DB::parseDSN(CIVICRM_DSN);
-
-$GLOBALS['mysql_host'] = $dsninfo['hostspec'];
-$GLOBALS['mysql_user'] = $dsninfo['username'];
-$GLOBALS['mysql_pass'] = $dsninfo['password'];
-$GLOBALS['mysql_db'] = $dsninfo['database'];
 
 
 /**
@@ -147,3 +108,41 @@ if ($memLimit >= 0 and $memLimit < 67108864) {
 
 require_once 'CRM/Core/ClassLoader.php';
 CRM_Core_ClassLoader::singleton()->register();
+
+global $civicrm_db_settings;
+$civicrm_database_settings = NULL;
+$civicrm_local_settings_path = CRM_Utils_Path::join(__DIR__, 'civicrm.settings.local.php');
+if (file_exists($civicrm_local_settings_path)) {
+  include($civicrm_local_settings_path);
+}
+try {
+  $civicrm_db_settings = new CRM_DB_Settings($civicrm_database_settings);
+} catch (CRM_DB_InvalidSettings $e) {
+  echo "\nFATAL: no DB connection configured (CIVICRM_DSN). \nYou can either create/edit " . __DIR__ . "/civicrm.settings.local.php\n";
+  if (strtoupper(substr(PHP_OS, 0, 3)) !== 'WIN') {
+    echo "OR set it in your shell:\n \$export CIVICRM_TEST_DSN=mysql://db_username:db_password@localhost/civicrm_tests_dev \n";
+  } else {
+    echo "OR set it in your shell:\n SETX CIVICRM_TEST_DSN mysql://db_username:db_password@localhost/civicrm_tests_dev \n
+      (you will need to open a new command shell before it takes effect)";
+  }
+  echo "\n\n
+If you haven't done so already, you need to create (once) a database dedicated to the unit tests:
+mysql -uroot -p
+create database civicrm_tests_dev;
+grant ALL on civicrm_tests_dev.* to db_username@localhost identified by 'db_password';
+grant SUPER on *.* to db_username@localhost identified by 'db_password';\n";
+  die ("");
+}
+
+
+if ( ! defined( 'CIVICRM_DSN' ) && ! empty( $GLOBALS['mysql_user'] ) ) {
+  $dbName = ! empty( $GLOBALS['mysql_db'] ) ? $GLOBALS['mysql_db'] : 'civicrm_tests_dev';
+  if ( empty( $GLOBALS['mysql_pass'] ) && $GLOBALS['mysql_pass_need_password'] ) {
+    $GLOBALS['mysql_pass'] = PHPUnit_TextUI_Command::getPassword( 'Password' );
+  }
+  define( 'CIVICRM_DSN'          , "mysql://{$GLOBALS['mysql_user']}:{$GLOBALS['mysql_pass']}@{$GLOBALS['mysql_host']}/{$dbName}?new_link=true" );
+}
+
+if (!defined("CIVICRM_DSN")) {
+  define("CIVICRM_DSN", $civicrm_db_settings->toCiviDSN());
+}

--- a/tests/phpunit/Utils.php
+++ b/tests/phpunit/Utils.php
@@ -1,5 +1,5 @@
 <?php
-// vim: set si ai expandtab tabstop=4 shiftwidth=4 softtabstop=4:
+// vim: set si ai expandtab tabstop=8 shiftwidth=2 softtabstop=2:
 
 /**
  *  File for the Utils class
@@ -45,15 +45,13 @@ class Utils {
   /**
    *  Construct an object for this database
    */
-  public function __construct($host, $user, $pass) {
+  public function __construct($civicrm_db_settings) {
+    $dsn = $civicrm_db_settings->toPDODSN();
     try {
-      $this->pdo = new PDO("mysql:host={$host}",
-        $user, $pass,
-        array(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => TRUE)
-      );
+      $this->pdo = new PDO($dsn, $civicrm_db_settings->username, $civicrm_db_settings->password, array(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => TRUE));
     }
     catch(PDOException$e) {
-      echo "Can't connect to MySQL server:" . PHP_EOL . $e->getMessage() . PHP_EOL;
+      echo "Can't connect to MySQL server using '$dsn' with user '{$civicrm_db_settings->username}' and pass '{$civicrm_db_settigs->password}':" . PHP_EOL . $e->getMessage() . PHP_EOL;
       exit(1);
     }
   }

--- a/tests/run.php
+++ b/tests/run.php
@@ -1,0 +1,41 @@
+#!/usr/bin/env php
+<?php
+
+$civicrm_source_dir_path = dirname(__DIR__);
+$autoloader_path = implode(DIRECTORY_SEPARATOR, array('CRM', 'Core', 'ClassLoader.php'));
+require_once($autoloader_path);
+CRM_Core_ClassLoader::singleton()->register();
+require_once(CRM_Utils_Path::join($civicrm_source_dir_path, "packages", "optionparser", "lib", "OptionParser.php"));
+
+$option_parser = new OptionParser();
+$option_parser->addRule('h|help', 'Display this help message');
+$option_parser->addRule('m|mysql-ram-server', 'Start a MySQL daemon backed by a RAM disk that will be used for the tests');
+$option_parser->addRule('s|no-selenium', 'Don\'t try and use Selenium.');
+$option_parser->addRule('p|php-unit::', 'Arguments to be passed to phpunit. If there are any spaces, enclose this whole option value in single quotes.');
+$option_parser->addRule('c|clean', 'Clean up any daemons and files that running the tests created.');
+
+function usage($option_parser) {
+  $stderr = fopen('php://stderr', 'w');
+  fwrite($stderr, "Usage: " . $option_parser->getProgramName() . " [options]\n");
+  fwrite($stderr, $option_parser->getUsage());
+}
+
+try {
+  $option_parser->parse();
+  $options = $option_parser->getAllOptions();
+  $options['base_path'] = $civicrm_source_dir_path;
+  $tests = new CRM_Tests_Runner($options);
+  if ($option_parser->help) {
+    usage($option_parser);
+  } elseif ($option_parser->clean) {
+    $tests->clean();
+  } else {
+    $tests->run();
+  }
+} catch (InvalidOption $e) {
+  $stderr = fopen('php://stderr', 'w');
+  fwrite($stderr, $e->getMessage() . "\n");
+  fwrite($stderr, "\n");
+  usage($option_parser);
+}
+


### PR DESCRIPTION
Made a new script (./tests/run.php) that when run out the civicrm-core
repository can setup most eveything needed to run tests and then run the
tests. For the unit tests, it should just run with no dependencies, but for
the Web (Selenium) tests, there are the following requirements:
drush
firefox
apache (or some other HTTP server)

With all that available, it will download and setup Drupal and suggest Apache
settings.

This was developed on Ubuntu, but I would like to get it working on other
platforms.

Run it with -h to see the options.
