### PR TITLE
CRM-13428 - to maintain uniform approach of pdf receipt sending process kept receipt file name same as done in other cases (like contribution / event online receipts)

### DIFF
--- a/CRM/Contribute/Form/AdditionalInfo.php
+++ b/CRM/Contribute/Form/AdditionalInfo.php
@@ -506,12 +506,10 @@ class CRM_Contribute_Form_AdditionalInfo {
         'toName' => $contributorDisplayName,
         'toEmail' => $contributorEmail,
         'isTest' => $form->_mode == 'test',
+        'PDFFilename' => 'receipt.pdf',
       )
     );
 
     return $sendReceipt;
   }
-
 }
-
-

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1693,6 +1693,7 @@ loadCampaign( {$this->_eID}, {$eventCampaigns} );
           'valueName' => 'event_offline_receipt',
           'contactId' => $contactID,
           'isTest' => (bool) CRM_Utils_Array::value('is_test', $this->_defaultValues),
+          'PDFFilename' => 'eventReceipt.pdf',
         );
 
         // try to send emails only if email id is present


### PR DESCRIPTION
The PR submitted by reporter for CRM-13428 - https://github.com/civicrm/civicrm-core/pull/1670  uses <code>ts()</code> function , 

to maintain uniform approach of pdf receipt sending process - kept receipt file name same as done in other cases (like contribution / event online receipts) i.e. not using <code> ts()</code> function
