### PR TITLE
--CRM-12970, fixed for more then one discount set

### DIFF
--- a/CRM/Event/Form/ManageEvent/Fee.php
+++ b/CRM/Event/Form/ManageEvent/Fee.php
@@ -160,6 +160,7 @@ class CRM_Event_Form_ManageEvent_Fee extends CRM_Event_Form_ManageEvent {
       }
       //CRM-12970
       ksort($defaults['discounted_value']);
+      ksort($defaults['discounted_label']);
       $rowCount = 1;
       foreach ($defaults['discounted_label'] as $key => $value) {
         if ($key != $rowCount) {


### PR DESCRIPTION
---
- CRM-12970: civicrm_price_field_value not removed for discount price set
  http://issues.civicrm.org/jira/browse/CRM-12970
