### PR TITLE
CRM-13447 (closes) include domain_id in job load criteria

### DIFF
--- a/CRM/Core/JobManager.php
+++ b/CRM/Core/JobManager.php
@@ -151,6 +151,7 @@ class CRM_Core_JobManager {
     $jobs = array();
     $dao = new CRM_Core_DAO_Job();
     $dao->orderBy('name');
+    $dao->domain_id = CRM_Core_Config::domainID();
     $dao->find();
     while ($dao->fetch()) {
       $temp = array();


### PR DESCRIPTION
---
- CRM-13447: Scheduled jobs should only run for relevant domain (they are stored by domain_id but don't always respect it)
  http://issues.civicrm.org/jira/browse/CRM-13447
