### PR TITLE
--CRM-13446, fixed Upgrade code for fatal error if civicrm_financial_acc...

### DIFF
--- a/CRM/Upgrade/Incremental/php/FourThree.php
+++ b/CRM/Upgrade/Incremental/php/FourThree.php
@@ -1101,6 +1101,7 @@ AND cli.entity_table = 'civicrm_contribution' AND cli.id IN (" . implode(',', $v
    * @return bool TRUE for success
    */
   function task_4_3_x_checkConstraints(CRM_Queue_TaskContext $ctx) {
+    CRM_Core_DAO::executeQuery('ALTER TABLE `civicrm_financial_account` CHANGE `contact_id` `contact_id` INT( 10 ) UNSIGNED NULL DEFAULT NULL');
     $config = CRM_Core_Config::singleton();
     $dbname  = DB::parseDSN($config->dsn);
     $constraintArray = array(


### PR DESCRIPTION
...ount.contact_id is NOT NULL by default.

---
- CRM-13446: Add ON DELETE Options for constraints fails
  http://issues.civicrm.org/jira/browse/CRM-13446
