### PR TITLE
-- fix for CRM-13417

### DIFF
--- a/CRM/Contact/Form/DedupeRules.php
+++ b/CRM/Contact/Form/DedupeRules.php
@@ -265,6 +265,25 @@ UPDATE civicrm_dedupe_rule_group
         if (!isset($substrLenghts[$table])) {
           $substrLenghts[$table] = array();
         }
+
+        //CRM-13417 to avoid fatal error "Incorrect prefix key; the used key part isn't a string, the used length is longer than the key part, or the storage engine doesn't support unique prefix keys, 1089"
+        $daoObj = new CRM_Core_DAO();
+        $database = $daoObj->database();
+        $schemaQuery = "SELECT * FROM INFORMATION_SCHEMA.COLUMNS
+          WHERE TABLE_SCHEMA = '{$database}' AND
+          TABLE_NAME = '{$table}' AND COLUMN_NAME = '{$field}';";
+        $dao = CRM_Core_DAO::executeQuery($schemaQuery);
+
+        while ($dao->fetch()) {
+          // set the length to null for all the fields where prefix length is not supported. eg. int,tinyint,date,enum etc dataTypes.
+          if ($dao->COLUMN_NAME == $field && !in_array($dao->DATA_TYPE, array('char', 'varchar', 'binary', 'varbinary', 'text', 'blob'))) {
+            $length = NULL;
+          }
+          elseif ($dao->COLUMN_NAME == $field && !empty($dao->CHARACTER_MAXIMUM_LENGTH) && ($length > $dao->CHARACTER_MAXIMUM_LENGTH)) {
+            //set the length to CHARACTER_MAXIMUM_LENGTH in case the length provided by the user is greater than the limit
+            $length = $dao->CHARACTER_MAXIMUM_LENGTH;
+          }
+        }
         $substrLenghts[$table][$field] = $length;
       }
     }

--- a/CRM/Contact/Form/DedupeRules.php
+++ b/CRM/Contact/Form/DedupeRules.php
@@ -237,6 +237,8 @@ UPDATE civicrm_dedupe_rule_group
     $substrLenghts = array();
 
     $tables = array();
+    $daoObj = new CRM_Core_DAO();
+    $database = $daoObj->database();
     for ($count = 0; $count < self::RULES_COUNT; $count++) {
       if (!CRM_Utils_Array::value("where_$count", $values)) {
         continue;
@@ -267,14 +269,12 @@ UPDATE civicrm_dedupe_rule_group
         }
 
         //CRM-13417 to avoid fatal error "Incorrect prefix key; the used key part isn't a string, the used length is longer than the key part, or the storage engine doesn't support unique prefix keys, 1089"
-        $daoObj = new CRM_Core_DAO();
-        $database = $daoObj->database();
         $schemaQuery = "SELECT * FROM INFORMATION_SCHEMA.COLUMNS
           WHERE TABLE_SCHEMA = '{$database}' AND
           TABLE_NAME = '{$table}' AND COLUMN_NAME = '{$field}';";
         $dao = CRM_Core_DAO::executeQuery($schemaQuery);
 
-        while ($dao->fetch()) {
+        if ($dao->fetch()) {
           // set the length to null for all the fields where prefix length is not supported. eg. int,tinyint,date,enum etc dataTypes.
           if ($dao->COLUMN_NAME == $field && !in_array($dao->DATA_TYPE, array('char', 'varchar', 'binary', 'varbinary', 'text', 'blob'))) {
             $length = NULL;


### PR DESCRIPTION
---
- CRM-13417: Dedupe Rule Creation error trapping fails on length selections for substrings of numeric fields or out of range numbers for text fields
  http://issues.civicrm.org/jira/browse/CRM-13417

The fatal error that was coming up was 
"Incorrect prefix key; the used key part isn't a string, the used length is longer than the key part, or
the storage engine doesn't support unique prefix keys, 1089".
This is a mysql error that comes up when prefix indexes with a specified length are created for non-string column i.e. column with datatypes date,int,tinyint,etc. So, when user enters length for the fields with these datatypes, mysql error occurs which is because of "the used key part isn't a string" part of the error. The other bug in case of varchar and text datatypes was that when user enters the length greater than the length(CHARACTER_MAXIMUM_LENGTH) of the column, it will generate the same error as above while creating the index. This time the error would be because of "the used length is longer than the key part".

This fix will check for the datatypes of the column. As per http://dev.mysql.com/doc/refman/5.6/en/create-index.html, prefix indexes with length are only supported by datatypes 'char', 'varchar', 'binary', 'varbinary', 'text', 'blob'. So, if user has entered the length and the datatype of the field is not one of these dataTypes, $length would be made equal to NULL. And for the other bug, if user enters a value greater than the length(CHARACTER_MAXIMUM_LENGTH) of the column, $length will be assigned the value equal to 'CHARACTER_MAXIMUM_LENGTH'. 
