### PR TITLE
CRM-13426 fix - Fatal error on search that includes a smart group created by custom search

### DIFF
--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -491,7 +491,7 @@ WHERE  civicrm_group_contact.status = 'Added'
       $result = CRM_Core_DAO::executeQuery($insertSql);
       CRM_Core_DAO::executeQuery(
         "INSERT IGNORE INTO civicrm_group_contact_cache (contact_id, group_id)
-        SELECT DISTINCT id, group_id FROM $tempTable
+        SELECT DISTINCT $idName, group_id FROM $tempTable
       ");
       CRM_Core_DAO::executeQuery(" DROP TABLE $tempTable");
     }


### PR DESCRIPTION
Upon Custom search result usually contact_id attribute is used in build query, but this doesn't reflect in the query for  civicrm_group_contact_cache insertion as it always select id which then results into a "DB Error: Unkown Column id" during creating a Smart Group on that result.

 Fix contain the usage of $idName which rightfully contain the name 'contact_id' and is safe to use as I checked.     
