### PR TITLE
CRM-13472 fix for - the total number of amount and count didn't matched with its corresponding search result because the receive date value varied in sql queries for both cases

### DIFF
--- a/CRM/Contribute/Page/DashBoard.php
+++ b/CRM/Contribute/Page/DashBoard.php
@@ -69,8 +69,12 @@ class CRM_Contribute_Page_DashBoard extends CRM_Core_Page {
         $now = $yearNow;
       }
 
+      // appending end date i.e $now with time
+      // to also calculate records of end date till mid-night
+      $nowWithTime = $now . '235959';
+
       foreach ($status as $s) {
-        ${$aName}[$s] = CRM_Contribute_BAO_Contribution::getTotalAmountAndCount($s, $$dName, $now);
+        ${$aName}[$s] = CRM_Contribute_BAO_Contribution::getTotalAmountAndCount($s, $$dName, $nowWithTime);
         ${$aName}[$s]['url'] = CRM_Utils_System::url('civicrm/contribute/search',
           "reset=1&force=1&status=1&start={$$dName}&end=$now&test=0"
         );


### PR DESCRIPTION
issue : the total amount shown was 'n/a' (NULL) on the layout page as the sql query used for its calculation didn't consist of appropriate receive date value in WHERE clause. (i.e. end point value for receive date was 20130930)

 But proper WHERE clause was getting build for contribution search page (i.e. end point value for receive date was 20130930235959)

Due to this the records varied for contribution dashboard and search page that opens up after clicking the 'view details..' link mentioned in image attached to the issue.

fixed the issue by passing proper end point date value for calculating contribution total amount and count .
