### PR TITLE
Webtest Fixes

### DIFF
--- a/tests/phpunit/WebTest/Campaign/MailingTest.php
+++ b/tests/phpunit/WebTest/Campaign/MailingTest.php
@@ -209,7 +209,7 @@ class WebTest_Campaign_MailingTest extends CiviSeleniumTestCase {
     //----------end New Mailing-------------
 
     //check redirected page to Scheduled and Sent Mailings and  verify for mailing name
-    $this->assertElementContainsText('page-title', "Scheduled and Sent Mailings");
+    $this->assertElementContainsText('page-title', "Find Mailings");
     $this->assertElementContainsText('Search', "Mailing $mailingName Webtest");
 
     //--------- mail delivery verification---------

--- a/tests/phpunit/WebTest/Event/MultiprofileEventTest.php
+++ b/tests/phpunit/WebTest/Event/MultiprofileEventTest.php
@@ -364,7 +364,7 @@ class WebTest_Event_MultiprofileEventTest extends CiviSeleniumTestCase {
 
     $profilefield = array(
       'middle_name' => 'middle_name',
-      'gender' => 'gender',
+      'gender_id' => 'gender_id',
     );
     $location = 0;
     $type = "Individual";
@@ -627,7 +627,7 @@ class WebTest_Event_MultiprofileEventTest extends CiviSeleniumTestCase {
     $this->type("custom_" . $customId[2], "lname_custom1");
 
     $this->type("middle_name", "xyz");
-    $this->click("name=gender value=2");
+    $this->click("name=gender_id value=2");
     $this->select("participant_role", "value=2");
 
     $this->click("_qf_Register_upload-bottom");
@@ -705,7 +705,7 @@ class WebTest_Event_MultiprofileEventTest extends CiviSeleniumTestCase {
     $this->type("custom_" . $customId[2], "lname_custom1");
 
     $this->type("middle_name", "xyz");
-    $this->click("name=gender value=2");
+    $this->click("name=gender_id value=2");
     $this->select("participant_role", "value=2");
 
     $this->click("_qf_Register_upload-bottom");

--- a/tests/phpunit/WebTest/Mailing/MailingTest.php
+++ b/tests/phpunit/WebTest/Mailing/MailingTest.php
@@ -167,7 +167,7 @@ class WebTest_Mailing_MailingTest extends CiviSeleniumTestCase {
     //----------end New Mailing-------------
 
     //check redirected page to Scheduled and Sent Mailings and  verify for mailing name
-    $this->assertElementContainsText('page-title', "Scheduled and Sent Mailings");
+    $this->assertElementContainsText('page-title', "Find Mailings");
     $this->assertElementContainsText("xpath=//table[@class='selector']/tbody//tr//td", "Mailing $mailingName Webtest");
 
     //--------- mail delivery verification---------


### PR DESCRIPTION
Fixed the following Webtests:
1) WebTest_Campaign_MailingTest::testCreateCampaign (failure result due to the page title change for "Scheduled and Unscheduled Mailing" to "Find Mailing" in CRM-13382)
2) WebTest_Event_MultiprofileEventTest::testAnoumyousRegisterPage
3) Failure: WebTest_Mailing_MailingTest::testAddMailing
4) Failure: WebTest_Mailing_MailingTest::testAdvanceSearchAndReportCheck
