### PR TITLE
CRM_Extension_Container_Basic - Display warning if no resource URL is defined

### DIFF
--- a/CRM/Extension/Container/Basic.php
+++ b/CRM/Extension/Container/Basic.php
@@ -136,6 +136,16 @@ class CRM_Extension_Container_Basic implements CRM_Extension_Container_Interface
    * {@inheritdoc}
    */
   public function getResUrl($key) {
+    if (! $this->baseUrl) {
+      CRM_Core_Session::setStatus(
+        ts('Failed to determine URL for extension (%1). Please update <a href="%2">Resource URLs</a>.',
+          array(
+            1 => $key,
+            2 => CRM_Utils_System::url('civicrm/admin/setting/url', 'reset=1'),
+          )
+        )
+      );
+    }
     return $this->baseUrl . $this->getRelUrl($key);
   }
 


### PR DESCRIPTION
We've received a few support requests where an administrator has activated an extension but finds things are broken because the "Resource URL" is not configured.

We currently provide a warning if this option is not configured, but the warning only appears on "Administer => System => Manage Extensions => Add New". However, if you are developing an extension (or installed the code via CLI), then you never look at that screen, so you never see the warning.

This patch displays a warning on any page -- but only if there's an extension which actually tries to create a URL based on the invalid setting.
