### PR TITLE
CRM-13564 "Could not find a valid session key" after create activity in custom search

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -415,18 +415,16 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
         $urlParams .= "&qfKey=$qfKey";
       }
       $path = CRM_Utils_System::currentPath();
-      if ($this->_compContext == 'advanced' ||
-        $path == 'civicrm/contact/search/advanced'
-      ) {
+      if ($this->_compContext == 'advanced' ) {
         $urlString = 'civicrm/contact/search/advanced';
       }
+      elseif ($path == 'civicrm/contact/search'
+        || $path == 'civicrm/contact/search/advanced'
+        || $path == 'civicrm/contact/search/custom') {
+        $urlString = $path;
+      }
       else {
-        if ($path == 'civicrm/contact/search') {
-          $urlString = 'civicrm/contact/search';
-        }
-        else {
-          $urlString = 'civicrm/activity/search';
-        }
+        $urlString = 'civicrm/activity/search';
       }
       $this->assign('searchKey', $qfKey);
     }


### PR DESCRIPTION
When you go to a custom search, get results, select a few contacts, and run Record activity for Contacts, the activity gets saved okay, but you end back with an error:

Sorry but we are not able to provide this at the moment.
We can't load the requested web page. This page requires cookies to be enabled in your browser settings. Please check this setting and enable cookies (if they are not enabled). Then try again. If this error persists, contact the site adminstrator for assistance.

Site Administrators: This error may indicate that users are accessing this page using a domain or URL other than the configured Base URL. EXAMPLE: Base URL is http://example.org, but some users are accessing the page via http://www.example.org or a domain alias like http://myotherexample.org.

Error type: Could not find a valid session key.

It turns out that the new activity form returns you to civicrm/activity/search instead of civicrm/contact/search/custom.
