### PR TITLE
fix for CRM-13237 : we are currently not updating contribution activity while editing contributions, thats why the campaign id doesn't get saved in activity record during contribution edits

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -296,6 +296,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
       CRM_Activity_BAO_Activity::addActivity($contribution, 'Offline');
     }
     else {
+      // CRM-13237 : if activity record found, update it with campaign id of contribution
       CRM_Core_DAO::setFieldValue('CRM_Activity_BAO_Activity', $activity->id, 'campaign_id', $contribution->campaign_id);
     }
 

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -292,8 +292,11 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
       'Contribution',
       'name'
     );
-    if (!$activity->find()) {
+    if (!$activity->find(TRUE)) {
       CRM_Activity_BAO_Activity::addActivity($contribution, 'Offline');
+    }
+    else {
+      CRM_Core_DAO::setFieldValue('CRM_Activity_BAO_Activity', $activity->id, 'campaign_id', $contribution->campaign_id);
     }
 
     // Handle soft credit and / or link to personal campaign page


### PR DESCRIPTION
If the activity of contribution in process is found : using the activity id update the activity with the current contribution campaign id
