### PR TITLE
-- CRM-13557 suppressed invalid fields during manual merge

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1495,9 +1495,13 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
    */
   static function getContactFields() {
     $contactFields = CRM_Contact_DAO_Contact::fields();
-    unset($contactFields['id']);
-    unset($contactFields['hash']);
-
+    $invalidFields = array('api_key', 'contact_is_deleted', 'created_date', 'hash', 'id', 'modified_date', 'preferred_language', 
+      'primary_contact_id', 'user_unique_id');
+    foreach ($contactFields as $field => $value) {
+      if (in_array($field, $invalidFields)) {
+        unset($contactFields[$field]);
+      }
+    }
     return array_keys($contactFields);
   }
 

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1496,6 +1496,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
   static function getContactFields() {
     $contactFields = CRM_Contact_DAO_Contact::fields();
     unset($contactFields['id']);
+    unset($contactFields['hash']);
 
     return array_keys($contactFields);
   }


### PR DESCRIPTION
---
- CRM-13557: Contact Hash is appearing on manual merge screen and should be suppressed
  http://issues.civicrm.org/jira/browse/CRM-13557

The regression was introduced after this commit https://github.com/civicrm/civicrm-core/commit/16254ae1 a part of PR https://github.com/civicrm/civicrm-core/pull/537 in which the validFields array was removed and getContactFields() function was created which returns the fields obtained from CRM_Contact_DAO_Contact::fields(). So, this function lists all Contact fields except for the "id" field which is unset within the function. So, hash and some other invalid fields which was not part of the validField array also gets displayed during manual merge. I have suppressed those fields in this PR.
