### PR TITLE
CRM-13563 fix: exclude the 'save and new' button on form for group search context

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -924,7 +924,11 @@ loadCampaign( {$this->_eID}, {$eventCampaigns} );
     );
 
     $path = CRM_Utils_System::currentPath();
-    if (strpos($path, 'civicrm/contact/search') !== 0) {
+    $excludeForPaths = array(
+      'civicrm/contact/search',
+      'civicrm/group/search'
+    );
+    if (!in_array($path, $excludeForPaths)) {
       $buttons[] = array(
         'type' => 'upload',
         'name' => ts('Save and New'),
@@ -932,6 +936,7 @@ loadCampaign( {$this->_eID}, {$eventCampaigns} );
         'js' => $confirmJS,
       );
     }
+
     $buttons[] = array(
       'type' => 'cancel',
       'name' => ts('Cancel'),


### PR DESCRIPTION
did a bit of code improvement as well

---
- CRM-13563: Registering a group of contacts for an event from Manage group option gets error when "Save and New" button is selected.
  http://issues.civicrm.org/jira/browse/CRM-13563
