### PR TITLE
CRM-13573 : fix to process search criteria on page load as well

### DIFF
--- a/templates/CRM/Group/Form/Search.tpl
+++ b/templates/CRM/Group/Form/Search.tpl
@@ -91,7 +91,7 @@
 {literal}
 <script type="text/javascript">
 cj( function() {
-  buildGroupSelector( false );
+  buildGroupSelector( true );
   cj('#_qf_Search_refresh').click( function() {
     buildGroupSelector( true );
   });
@@ -99,7 +99,9 @@ cj( function() {
 
 function buildGroupSelector( filterSearch ) {
     if ( filterSearch ) {
-        crmGroupSelector.fnDestroy();
+        if (typeof crmGroupSelector !== 'undefined') {
+          crmGroupSelector.fnDestroy();
+        }
         var parentsOnly = 0;
         var ZeroRecordText = '<div class="status messages">{/literal}{ts escape="js"}No matching Groups found for your search criteria. Suggestions:{/ts}{literal}<div class="spacer"></div><ul><li>{/literal}{ts escape="js"}Check your spelling.{/ts}{literal}</li><li>{/literal}{ts escape="js"}Try a different spelling or use fewer letters.{/ts}{literal}</li><li>{/literal}{ts escape="js"}Make sure you have enough privileges in the access control system.{/ts}{literal}</li></ul></div>';
     } else {


### PR DESCRIPTION
the issue : 
- on the 'manage groups' page display UI, we have a search filter form and below it is result listing display.
- this search form consists of group status (enabled/disabled) checkbox criteria, of which 'enabled' is checked by default. But if we intially visit 'manage groups' page, the result lising also shows 'disabled'  groups. (this is due to search filter not been processed during result listing.)

the fix : 
- The search criteria processing works fine (while we click search button), the problem was with criteria not been processed on load of the page, so enabled it by passing 'true' arg <code>buildGroupSelector( true ); </code> on document ready event 

---
- CRM-13573: Manage Groups display shows disabled groups on initial display - but disabled groups option is NOT selected
  http://issues.civicrm.org/jira/browse/CRM-13573
