### PR TITLE
-- CRM-13570 fix

### DIFF
--- a/templates/CRM/Price/Form/PriceSet.tpl
+++ b/templates/CRM/Price/Form/PriceSet.tpl
@@ -30,7 +30,7 @@
 
     {foreach from=$priceSet.fields item=element key=field_id}
         {* Skip 'Admin' visibility price fields since this tpl is used in online registration. *}
-        {if $element.visibility EQ 'public' || $context eq 'standalone' || $context eq 'search' || $context eq 'participant' || $context eq 'dashboard' || $action eq 1024}
+        {if $element.visibility EQ 'public' || $context eq 'standalone' || $context eq 'advanced' || $context eq 'search' || $context eq 'participant' || $context eq 'dashboard' || $action eq 1024}
             <div class="crm-section {$element.name}-section">
             {if ($element.html_type eq 'CheckBox' || $element.html_type == 'Radio') && $element.options_per_line}
               {assign var="element_name" value="price_"|cat:$field_id}


### PR DESCRIPTION
---
- CRM-13570: Admin-only price set fields not available when adding multiple contacts to event from advanced search results
  http://issues.civicrm.org/jira/browse/CRM-13570

The price fields were restricted from getting displayed as "advanced" context was not included in the if condition.
