### PR TITLE
CRM-13591 : fixed condition check for display value returning function for custom fields (i.e used for returning appropriate val for Yes/No fields)

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1180,7 +1180,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
           if ($value) {
             $display = ts('Yes');
           }
-          elseif ($value === '0') {
+          elseif ((string)$value === '0') {
             $display = ts('No');
           }
         }
@@ -1345,7 +1345,6 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
           $display = $value;
         }
     }
-
     return $display ? $display : $value;
   }
 

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1538,7 +1538,10 @@ WHERE  id = $cfID
                 if ($dao->data_type == 'Int' ||
                   $dao->data_type == 'Boolean'
                 ) {
-                  $customVal = (int )($params[$name]);
+                  $v = $params[$name];
+                  if (!CRM_Utils_System::isNull($v)) {
+                    $customVal = (int)$v;
+                  }
                 }
                 elseif ($dao->data_type == 'Float') {
                   $customVal = (float )($params[$name]);


### PR DESCRIPTION
Now the following is achieved : 
- If user selects 'Yes' option, profile view for this field displays 'Yes' value.
- If user selects 'No' option, profile view for this field displays 'No' value.
- If user selects neither 'Yes' nor 'No', profile view displays nothing (blank) .

Also checked for civicrm/profile/view display, the behavior is same as above. 

The fix : Did typecasting to 'string' for equality check as : <code>$value</code> (i.e. 0 or 1) coming in the function as arg can be 'string' (in case of profile view page) or 'integer' (in case of event registration confirm page)
