### PR TITLE
CRM-13601 fix -  Multilingual upgrade 4.3.5 to 4.4 beta throws up an err...

### DIFF
--- a/CRM/Upgrade/Incremental/php/FourFour.php
+++ b/CRM/Upgrade/Incremental/php/FourFour.php
@@ -82,7 +82,7 @@ class CRM_Upgrade_Incremental_php_FourFour {
 
     // add new 'data' column in civicrm_batch
     $query = 'ALTER TABLE civicrm_batch ADD data LONGTEXT NULL COMMENT "cache entered data"';
-    CRM_Core_DAO::executeQuery($query);
+    CRM_Core_DAO::executeQuery($query, array(), TRUE, NULL, FALSE, FALSE);
 
     // check if batch entry data exists in civicrm_cache table
     $query = 'SELECT path, data FROM civicrm_cache WHERE group_name = "batch entry"';

--- a/CRM/Upgrade/Incremental/sql/4.4.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.4.alpha1.mysql.tpl
@@ -137,8 +137,13 @@ ALTER TABLE civicrm_survey
   ADD is_share TINYINT( 4 ) NULL DEFAULT '1' COMMENT 'Can people share the petition through social media?';
 
 -- CRM-12439
-ALTER TABLE `civicrm_uf_group`
-  ADD `description` TEXT CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL DEFAULT NULL COMMENT 'Optional verbose description of the profile.' AFTER `title`;
+{if $multilingual}
+  ALTER TABLE `civicrm_uf_group`
+    ADD `description` TEXT CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL DEFAULT NULL COMMENT 'Optional verbose description of the profile.' AFTER `group_type`;
+{else}
+  ALTER TABLE `civicrm_uf_group`
+    ADD `description` TEXT CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL DEFAULT NULL COMMENT 'Optional verbose description of the profile.' AFTER `title`;
+{/if}
 
 --CRM-13142
 UPDATE


### PR DESCRIPTION
On 4.3.5 to 4.4 beta4 multilingual upgrade it throws error on two sequential scenarios -
1) First at 4.4.aplha1 upgrade phase, description field of uf_group table is appended after 'title' which in multilingual case is not appropriate as it changed to title_{$locale} also description field is not a multilingual field for uf_group in 4.4. So changes are done accordingly.
2) Next at 4.4.beta1 for civicrm_batch table $i18nRewrite parameter is not passed to ignore multilingual table changes. As a result of which it results into a DB Error:  civicrm_batch_{locale} is not a Base table. 
