### PR TITLE
mk-drupal-test-site - When writing out setup.conf, include CIVISOURCEDIR

### DIFF
--- a/tools/scripts/mk-drupal-test-site
+++ b/tools/scripts/mk-drupal-test-site
@@ -96,6 +96,7 @@ popd
 ## Create CiviCRM config
 cat > "$CIVI_ROOT/bin/setup.conf" << EOF
   SVNROOT="$CIVI_ROOT"
+  CIVISOURCEDIR="$CIVI_ROOT"
   SCHEMA=schema/Schema.xml
   DBNAME="$DB_NAME"
   DBUSER="$DB_USER"


### PR DESCRIPTION
mk-drupal-test-site - When writing out setup.conf, include both the old SVNROOT and the new CIVISOURCEDIR
