### PR TITLE
CRM-13344 fix - Unable to import Contact's gender,prefix and suffix in update/fill case

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -662,7 +662,8 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
 
     //fixed CRM-4148
     //now we create new contact in update/fill mode also.
-    if ($createNewContact) {
+    $contactID = NULL;
+    if ($createNewContact || $this->_updateWithId) {
 
       //CRM-4430, don't carry if not submitted.
       foreach (array('prefix_id', 'suffix_id', 'gender_id') as $name) {
@@ -673,10 +674,12 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
           }
         }
       }
-      $newContact = $this->createContact($formatted, $contactFields, $onDuplicate, NULL, TRUE, $this->_dedupeRuleGroupID);
+      if ($this->_updateWithId && !empty($params['id'])) {
+        $contactID = $params['id'];
+      }
+      $newContact = $this->createContact($formatted, $contactFields, $onDuplicate, $contactID, TRUE, $this->_dedupeRuleGroupID);
     }
 
-    $contactID = NULL;
     if (isset($newContact) && is_object($newContact) && ($newContact instanceof CRM_Contact_BAO_Contact)) {
       $relationship = TRUE;
       $newContact = clone($newContact);


### PR DESCRIPTION
This PR fixes:
1) Unable to import Contact's gender,prefix and suffix in update/fill case
2) Resolve webtest failures  WebTest_Import_ContactSubtypeTest::testIndividualSubtypeImport and WebTest_Import_ContactTest::testIndividualImport 
