### PR TITLE
Crm 13490

### DIFF
--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -591,7 +591,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
     }
 
     if (array_key_exists('Address', $this->_editOptions)) {
-      $this->addFormRule(array('CRM_Contact_Form_Edit_Address', 'formRule'));
+      $this->addFormRule(array('CRM_Contact_Form_Edit_Address', 'formRule'), $this);
     }
 
     if (array_key_exists('CommunicationPreferences', $this->_editOptions)) {

--- a/CRM/Contact/Form/Domain.php
+++ b/CRM/Contact/Form/Domain.php
@@ -207,7 +207,7 @@ class CRM_Contact_Form_Domain extends CRM_Core_Form {
   static function formRule($fields) {
     $errors = array();
     // check for state/country mapping
-    CRM_Contact_Form_Edit_Address::formRule($fields, $errors);
+    $errors = CRM_Contact_Form_Edit_Address::formRule($fields, CRM_Core_DAO::$_nullArray, CRM_Core_DAO::$_nullObject);
 
     //fix for CRM-3552,
     //as we use "fromName"<emailaddresss> format for domain email.

--- a/CRM/Contact/Form/Edit/Address.php
+++ b/CRM/Contact/Form/Edit/Address.php
@@ -274,12 +274,11 @@ class CRM_Contact_Form_Edit_Address {
       // And we can't set it to 'address_' because we want to set it in a slightly different format.
       CRM_Core_BAO_CustomGroup::buildQuickForm($form, $groupTree, FALSE, 'dnc_');
 
-      // detach required rule for custom data.
       // during contact editing : if no address is filled
       // required custom data must not produce 'required' form rule error
       // more handling done in formRule func
       if (!$inlineEdit) {
-        CRM_Core_BAO_Address::detachRequiredRule(&$form, $groupTree);
+        CRM_Contact_Form_Edit_Address::storeRequiredCustomDataInfo($form, $groupTree);
       }
 
       $template     = CRM_Core_Smarty::singleton();
@@ -331,23 +330,36 @@ class CRM_Contact_Form_Edit_Address {
     // check for state/county match if not report error to user.
     if (CRM_Utils_Array::value('address', $fields) && is_array($fields['address'])) {
       foreach ($fields['address'] as $instance => $addressValues) {
+
         if (CRM_Utils_System::isNull($addressValues)) {
+          // DETACH 'required' form rule error to
+          // custom data only if address data not exists upon submission
+          if (!empty($customDataRequiredFields)) {
+            foreach($customDataRequiredFields as $customElementName) {
+              $elementName = "address[$instance][$customElementName]";
+              if ($self->getElementError($elementName)) {
+                // set element error to none
+                $self->setElementError($elementName, NULL);
+              }
+            }
+          }
           continue;
         }
 
-        // attach 'required' form rule error to
-        // custom data only if address data exists i.e. user intended to fill address
-        // but forgot to fill in required fields
-        if (!empty($customDataRequiredFields) && CRM_Core_BAO_Address::dataExists($addressValues)) {
-          foreach($customDataRequiredFields as $elementName) {
-            if (!CRM_Utils_Array::value($elementName, $addressValues)) {
-              $label = $self->getElement("address[$instance][$elementName]")->getLabel();
-              $errors["address[$instance][$elementName]"] = ts('%1 is required field', array(1 => $label));
+        // DETACH 'required' form rule error to
+        // custom data only if address data not exists upon submission
+        if (!empty($customDataRequiredFields) && !CRM_Core_BAO_Address::dataExists($addressValues)) {
+          foreach($customDataRequiredFields as $customElementName) {
+            $elementName = "address[$instance][$customElementName]";
+            if ($self->getElementError($elementName)) {
+              // set element error to none
+              $self->setElementError($elementName, NULL);
             }
           }
         }
 
         $countryId = CRM_Utils_Array::value('country_id', $addressValues);
+
         $stateProvinceId = CRM_Utils_Array::value('state_province_id', $addressValues);
 
         //do check for mismatch countries
@@ -572,5 +584,29 @@ class CRM_Contact_Form_Edit_Address {
       // end of parse address functionality
     }
   }
-}
 
+
+  static function storeRequiredCustomDataInfo(&$form, $groupTree) {
+    if (CRM_Utils_System::getClassName($form) == 'CRM_Contact_Form_Contact') {
+      $requireOmission = NULL;
+      foreach ($groupTree as $csId => $csVal) {
+        // only process Address entity fields
+        if ($csVal['extends'] != 'Address') {
+          continue;
+        }
+
+        foreach ($csVal['fields'] as $cdId => $cdVal) {
+          if ($cdVal['is_required']) {
+            $elementName = $cdVal['element_name'];
+            if (in_array($elementName, $form->_required)) {
+              // store the omitted rule for a element, to be used later on
+              $requireOmission .= $cdVal['element_custom_name'] . ',';
+            }
+          }
+        }
+      }
+
+      $form->_addressRequireOmission = rtrim($requireOmission, ',');
+    }
+  }
+}

--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -1198,4 +1198,33 @@ SELECT is_primary,
     }
     return CRM_Core_PseudoConstant::get(__CLASS__, $fieldName, $params, $context);
   }
+
+  /**
+   * CRM-13490 : helper function to detach required rule for address custom data
+   */
+  static function detachRequiredRule(&$form, $groupTree) {
+    if (CRM_Utils_System::getClassName($form) == 'CRM_Contact_Form_Contact') {
+      $requireOmission = NULL;
+      foreach ($groupTree as $csId => $csVal) {
+        // only process Address entity fields
+        if ($csVal['extends'] != 'Address') {
+          continue;
+        }
+
+        foreach ($csVal['fields'] as $cdId => $cdVal) {
+          if ($cdVal['is_required']) {
+            // unset-ing of required rule done here, also store the element name whose required rule is been removed
+            $elementName = $cdVal['element_name'];
+            if (in_array($elementName, $form->_required)) {
+              $form->_required = array_diff($form->_required, array($elementName));
+              // store the omitted rule for a element, to be used later on
+              $requireOmission = $cdVal['element_custom_name'] . ',';
+            }
+          }
+        }
+      }
+
+      $form->_addressRequireOmission = rtrim($requireOmission, ',');
+    }
+  }
 }

--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -1198,33 +1198,4 @@ SELECT is_primary,
     }
     return CRM_Core_PseudoConstant::get(__CLASS__, $fieldName, $params, $context);
   }
-
-  /**
-   * CRM-13490 : helper function to detach required rule for address custom data
-   */
-  static function detachRequiredRule(&$form, $groupTree) {
-    if (CRM_Utils_System::getClassName($form) == 'CRM_Contact_Form_Contact') {
-      $requireOmission = NULL;
-      foreach ($groupTree as $csId => $csVal) {
-        // only process Address entity fields
-        if ($csVal['extends'] != 'Address') {
-          continue;
-        }
-
-        foreach ($csVal['fields'] as $cdId => $cdVal) {
-          if ($cdVal['is_required']) {
-            // unset-ing of required rule done here, also store the element name whose required rule is been removed
-            $elementName = $cdVal['element_name'];
-            if (in_array($elementName, $form->_required)) {
-              $form->_required = array_diff($form->_required, array($elementName));
-              // store the omitted rule for a element, to be used later on
-              $requireOmission = $cdVal['element_custom_name'] . ',';
-            }
-          }
-        }
-      }
-
-      $form->_addressRequireOmission = rtrim($requireOmission, ',');
-    }
-  }
 }

--- a/CRM/Event/Form/ManageEvent/Location.php
+++ b/CRM/Event/Form/ManageEvent/Location.php
@@ -165,7 +165,7 @@ class CRM_Event_Form_ManageEvent_Location extends CRM_Event_Form_ManageEvent {
    */
   static function formRule($fields) {
     // check for state/country mapping
-    $errors = CRM_Contact_Form_Edit_Address::formRule($fields);
+    $errors = CRM_Contact_Form_Edit_Address::formRule($fields, CRM_Core_DAO::$_nullArray, CRM_Core_DAO::$_nullObject);
 
     return empty($errors) ? TRUE : $errors;
   }


### PR DESCRIPTION
There are 2 cases which are taken care by this fix : 

Create a custom data sets of 'address' type and mark the fields as required.

CASE 1
While creating a new contact : 
- Just enter first_name and last_name and try to save - current behavior is form throws 'required' form rule error for custom field.
- After this fix, the contact will get saved, as the user intension was not to fill address.

CASE 2
Consider a contact having a address to it : 
- Current behavior : Edit the contact, delete the address, and try saving contact, it will throw required form rule error for deleted address.
- After this fix, upon following above steps no form rule error will raise.
