### PR TITLE
CRM-13625 fix - Twitter text references thankyou page with session, not ...

### DIFF
--- a/templates/CRM/common/SocialNetwork.tpl
+++ b/templates/CRM/common/SocialNetwork.tpl
@@ -45,7 +45,7 @@
             {*use advanced buttons for pages*}
             <div class="label">
                 <iframe allowtransparency="true" frameborder="0" scrolling="no"
-                src="//platform.twitter.com/widgets/tweet_button.html?text={$title}&amp;url={$url}" 
+                src="//platform.twitter.com/widgets/tweet_button.html?text={$title}&amp;url={$url|urlencode}"
                 style="width:100px; height:20px;">
                 </iframe>
             </div>


### PR DESCRIPTION
As per the usage of url parameter for tweeting, it should pass url-encoded link otherwise as in current situation it carries the current page url instead. For the same reason in our case it replaces with Event Thankyou page url. 
          Still a minor issue persist  after changes as urlencoded & is not transformed back to & but &amp; instead. Also replacing it with original symbol in url-encoded value is not of much help. 

Reference: https://dev.twitter.com/docs/intents 
