### PR TITLE
-- fix for CRM-13461

### DIFF
--- a/CRM/Core/Payment/BaseIPN.php
+++ b/CRM/Core/Payment/BaseIPN.php
@@ -468,6 +468,9 @@ LIMIT 1;";
 
       $values['custom_pre_id'] = $custom_pre_id;
       $values['custom_post_id'] = $custom_post_ids;
+      //for tasks 'Change Participant Status' and 'Batch Update Participants Via Profile' case
+      //and cases involving status updation through ipn
+      $values['totalAmount'] = $input['amount'];
 
       $contribution->source = ts('Online Event Registration') . ': ' . $values['event']['title'];
 


### PR DESCRIPTION
---
- CRM-13461: Total amount missing from event confirmation mail
  http://issues.civicrm.org/jira/browse/CRM-13461

Total amount is not getting displayed on the receipt and this bug is because the $totalAmount variable in event online message template does not get populated as its value is not assigned from any means in the following two cases(In normal case, its assigned to the template from the thankyou page of event registration)
This bug is replicable in the following two cases:
1. When we update a participant status by using either 'Change Participant Status' and 'Batch Update Participants Via Profile' from the task actions.
2. When we try to update the status by running the postIPN script for events when the status is pending.
So, in either cases, "totalAmount" template value is not assigned thus causing its value to display empty on receipts. So, I have handled the bug within completeTransaction function of BaseIPN.php as this function would be called only in the above two cases. So, there won't be any conflict wrt "totalAmount" template value between the normal case(i.e. when the value is assigned from the form) and our case.
