### PR TITLE
CRM-13600 CiviMail form - allow CiviMails from advanced search for users...

### DIFF
--- a/CRM/Mailing/Form/Group.php
+++ b/CRM/Mailing/Form/Group.php
@@ -315,6 +315,9 @@ class CRM_Mailing_Form_Group extends CRM_Contact_Form_Task {
 
     $this->assign('groupCount', count($groups));
     $this->assign('mailingCount', count($mailings));
+    if(count($groups) == 0 && count($mailings) == 0 && !$this->_searchBasedMailing) {
+      CRM_Core_Error::statusBounce("To send a mailing, you must have a valid group of recipients - either at least one group that's a Mailing List or at least one previous mailing or start from a search");
+    }
   }
 
   public function postProcess() {

--- a/templates/CRM/Mailing/Form/Group.tpl
+++ b/templates/CRM/Mailing/Form/Group.tpl
@@ -23,12 +23,7 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-{if $groupCount == 0 and $mailingCount == 0}
-  <div class="status">
-  <div class="icon inform-icon"></div>
-        {ts}To send a mailing, you must have a valid group of recipients - either at least one group that's a Mailing List or at least one previous mailing.{/ts}
-  </div>
-{else}
+
 <div class="crm-block crm-form-block crm-mailing-group-form-block">
 {include file="CRM/common/WizardHeader.tpl"}
 
@@ -51,7 +46,7 @@
     </tr>
   </table>
 
-
+{if ($groupCount > 0|| $mailingCount > 0)}
 <div id="id-additional" class="form-item">
 <div class="crm-accordion-wrapper ">
  <div class="crm-accordion-header">
@@ -78,7 +73,7 @@
   {/strip}
  </div><!-- /.crm-accordion-body -->
 </div><!-- /.crm-accordion-wrapper -->
-
+{/if}
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl"}</div>
 </div>
 
@@ -93,4 +88,4 @@ cj(function() {
 {* include jscript to warn if unsaved form field changes *}
 {include file="CRM/common/formNavigate.tpl"}
 </div>
-{/if}
+


### PR DESCRIPTION
... with no group view permissions (ACL hook based permissions)

---
- CRM-13600: Contacts with access to no mailing groups cannot do search based CiviMails
  http://issues.civicrm.org/jira/browse/CRM-13600
