### PR TITLE
-- fix for CRM-12310

### DIFF
--- a/CRM/Report/Form/Member/Detail.php
+++ b/CRM/Report/Form/Member/Detail.php
@@ -77,7 +77,6 @@ class CRM_Report_Form_Member_Detail extends CRM_Report_Form {
           ),
           'first_name' =>
           array('title' => ts('First Name'),
-            'no_repeat' => TRUE,
           ),
           'id' =>
           array(
@@ -86,7 +85,6 @@ class CRM_Report_Form_Member_Detail extends CRM_Report_Form {
           ),
           'last_name' =>
           array('title' => ts('Last Name'),
-            'no_repeat' => TRUE,
           ),
           'id' =>
           array(


### PR DESCRIPTION
---
- CRM-12310: Missing First Name, Last Name sporadically in Membership Detail Report
  http://issues.civicrm.org/jira/browse/CRM-12310

The First Name and Last Name were missing because these columns had "no_repeat" parameter set for them. So, its like if the column already has a row value say "abc", then this won't be repeated again in any other rows. In the screenshot attached in issue CRM-12310, the first name "Sandy" and last name "Jones" already appeared once in the previous rows, so it isn't visible in other rows. This seems like a regression, so I have removed "no_repeat" from first name and last name columns.
