### PR TITLE
CRM-13630 fix - Minimum contribution amount check for Premiums fails whe...

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/PremiumBlock.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/PremiumBlock.tpl
@@ -188,11 +188,8 @@
             amount = 0;
           }
 
-          // next, check for contribution amount price sets
-          check_price_set('.contribution_amount-content input[type="radio"]');
-
-          // next, check for membership level price set
-          check_price_set('.membership_amount-content input[type="radio"]');
+          // next, check for membership/contribution level price set
+          check_price_set('#priceset input[type="radio"]');
 
           // make sure amount is a number at this point
           if(!amount) amount = 0;
@@ -219,8 +216,7 @@
           });
         }
         cj('.other_amount-content input').change(update_premiums);
-        cj('.contribution_amount-content input[type="radio"]').click(update_premiums);
-        cj('.membership_amount-content input[type="radio"]').click(update_premiums);
+        cj('#priceset input[type="radio"]').click(update_premiums);
         update_premiums();
 
         // build a list of price sets


### PR DESCRIPTION
Its hardcoding this time - reason of which it perfectly works when we use manual membership type options instead of existing membership type price-set as in later case the id changes to ".{Price-set name}-content" instead of ".contribution_amount-content" in former case. To avoid this dependency "#priceset" class is being used and it is acting on premium smoothly. This issue also persist in case of using existing Contribution type price-set for the same reason mentioned (check the diff). 
         In addition in case of 'other contribution amount/without price-set' no changes required as the id doesn't change.    
