### PR TITLE
CRM-13638 : verified and applied patch, just a minor modification done

### DIFF
--- a/templates/CRM/Activity/Form/Activity.tpl
+++ b/templates/CRM/Activity/Form/Activity.tpl
@@ -135,7 +135,7 @@
       {elseif $action neq 4}
       <td class="label">{ts}With Contact{/ts}</td>
       <td class="view-value">
-        {include file="CRM/Contact/Form/NewContact.tpl" noLabel=true skipBreak=true multiClient=true}
+        {include file="CRM/Contact/Form/NewContact.tpl" noLabel=true skipBreak=true multiClient=true parent="activity"}
         {if $action eq 1}
         <br/>
         {$form.is_multi_activity.html}&nbsp;{$form.is_multi_activity.label} {help id="id-is_multi_activity"}

--- a/templates/CRM/Contact/Form/NewContact.tpl
+++ b/templates/CRM/Contact/Form/NewContact.tpl
@@ -24,7 +24,7 @@
  +--------------------------------------------------------------------+
 *}
 {* template for adding form elements for selecting existing or creating new contact*}
-{if !in_array($context, array('search','advanced', 'builder')) }
+{if !in_array($context, array('search','advanced', 'builder')) || $parent eq 'activity'}
   {assign var='fldName' value=$prefix|cat:'contact'}
   {assign var='profSelect' value=$prefix|cat:'profiles'}
 


### PR DESCRIPTION
the minor modification in the patch consists removing of <code> || ($context == 'search') </code> condition as it negates <code> !in_array($context, array('search', .....)) </code> condition in same 'if' statement

---
- CRM-13638: Saving an Activity record from Search causes "With Contact" field value to be deleted
  http://issues.civicrm.org/jira/browse/CRM-13638
