### PR TITLE
CRM-13434 Send more through hook_civicrm_links

### DIFF
--- a/CRM/ACL/Page/ACL.php
+++ b/CRM/ACL/Page/ACL.php
@@ -236,8 +236,15 @@ ORDER BY entity_id
         $action -= CRM_Core_Action::DISABLE;
       }
 
-      $acl[$dao->id]['action'] = CRM_Core_Action::formLink(self::links(), $action,
-        array('id' => $dao->id)
+      $acl[$dao->id]['action'] = CRM_Core_Action::formLink(
+        self::links(),
+        $action,
+        array('id' => $dao->id),
+        ts('more'),
+        FALSE,
+        'ACL.manage.action',
+        'ACL',
+        $dao->id
       );
     }
     $this->assign('rows', $acl);

--- a/CRM/ACL/Page/ACLBasic.php
+++ b/CRM/ACL/Page/ACLBasic.php
@@ -169,8 +169,15 @@ ORDER BY entity_id
         // form all action links
         $action = array_sum(array_keys($this->links()));
 
-        $acl[$dao->entity_id]['action'] = CRM_Core_Action::formLink(self::links(), $action,
-          array('id' => $dao->entity_id)
+        $acl[$dao->entity_id]['action'] = CRM_Core_Action::formLink(
+          self::links(),
+          $action,
+          array('id' => $dao->entity_id),
+          ts('more'),
+          FALSE,
+          'aclRole.manage.action',
+          'ACLRole',
+          $dao->entity_id
         );
       }
       elseif (CRM_Utils_Array::value($dao->object_table, $permissions)) {

--- a/CRM/ACL/Page/EntityRole.php
+++ b/CRM/ACL/Page/EntityRole.php
@@ -181,8 +181,15 @@ class CRM_ACL_Page_EntityRole extends CRM_Core_Page_Basic {
         $action -= CRM_Core_Action::DISABLE;
       }
 
-      $entityRoles[$dao->id]['action'] = CRM_Core_Action::formLink(self::links(), $action,
-        array('id' => $dao->id)
+      $entityRoles[$dao->id]['action'] = CRM_Core_Action::formLink(
+        self::links(),
+        $action,
+        array('id' => $dao->id),
+        ts('more'),
+        FALSE,
+        'entityRole.manage.action',
+        'EntityRole',
+        $dao->id
       );
     }
     $this->assign('rows', $entityRoles);

--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -2512,7 +2512,12 @@ INNER JOIN  civicrm_option_group grp ON ( grp.id = val.option_group_id AND grp.n
             'cid' => $params['contact_id'],
             'cxt' => $context,
             'caseid' => CRM_Utils_Array::value('case_id', $values),
-          )
+          ),
+          ts('more'),
+          FALSE,
+          'activity.tab.row',
+          'Activity',
+          $values['activity_id']
         );
       }
     }

--- a/CRM/Activity/Selector/Activity.php
+++ b/CRM/Activity/Selector/Activity.php
@@ -422,7 +422,12 @@ class CRM_Activity_Selector_Activity extends CRM_Core_Selector_Base implements C
             'cid' => $this->_contactId,
             'cxt' => $this->_context,
             'caseid' => CRM_Utils_Array::value('case_id', $row),
-          )
+          ),
+          ts('more'),
+          FALSE,
+          'activity.selector.action',
+          'Activity',
+          $row['activity_id']
         );
       }
 

--- a/CRM/Activity/Selector/Search.php
+++ b/CRM/Activity/Selector/Search.php
@@ -320,7 +320,12 @@ class CRM_Activity_Selector_Search extends CRM_Core_Selector_Base implements CRM
           'id' => $result->activity_id,
           'cid' => $contactId,
           'cxt' => $this->_context,
-        )
+        ),
+        ts('more'),
+        FALSE,
+        'activity.selector.row',
+        'Activity',
+        $result->activity_id
       );
 
       //carry campaign to selector.

--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -207,8 +207,12 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
     $this->assign('tokenUrl', $tokenUrl);
     $this->add('text', 'recipient_manual_id', ts('Manual Recipients'));
 
-    $this->addElement('select', 'group_id', ts('Group'),
-      CRM_Core_PseudoConstant::staticGroup()
+    $this->addElement(
+      'select',
+      'group_id',
+      ts('Group'),
+      // CRM-13577
+      CRM_Core_PseudoConstant::group()
     );
 
     CRM_Mailing_BAO_Mailing::commonCompose($this);

--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -207,12 +207,8 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
     $this->assign('tokenUrl', $tokenUrl);
     $this->add('text', 'recipient_manual_id', ts('Manual Recipients'));
 
-    $this->addElement(
-      'select',
-      'group_id',
-      ts('Group'),
-      // CRM-13577
-      CRM_Core_PseudoConstant::group()
+    $this->addElement('select', 'group_id', ts('Group'),
+      CRM_Core_PseudoConstant::staticGroup() 
     );
 
     CRM_Mailing_BAO_Mailing::commonCompose($this);

--- a/CRM/Admin/Page/ContactType.php
+++ b/CRM/Admin/Page/ContactType.php
@@ -127,7 +127,12 @@ class CRM_Admin_Page_ContactType extends CRM_Core_Page_Basic {
         }
       }
       $rows[$key]['action'] = CRM_Core_Action::formLink(self::links(), $mask,
-        array('id' => $value['id'])
+        array('id' => $value['id']),
+        ts('more'),
+        FALSE,
+        'contactType.manage.action',
+        'ContactType',
+        $value['id']
       );
     }
     $this->assign('rows', $rows);

--- a/CRM/Admin/Page/EventTemplate.php
+++ b/CRM/Admin/Page/EventTemplate.php
@@ -125,7 +125,12 @@ class CRM_Admin_Page_EventTemplate extends CRM_Core_Page_Basic {
 
       //add action links.
       $allEventTemplates[$eventTemplate->id]['action'] = CRM_Core_Action::formLink(self::links(), $action,
-        array('id' => $eventTemplate->id)
+        array('id' => $eventTemplate->id),
+        ts('more'),
+        FALSE,
+        'eventTemplate.manage.action',
+        'Event',
+        $eventTemplate->id
       );
     }
     $this->assign('rows', $allEventTemplates);

--- a/CRM/Admin/Page/Extensions.php
+++ b/CRM/Admin/Page/Extensions.php
@@ -197,8 +197,15 @@ class CRM_Admin_Page_Extensions extends CRM_Core_Page_Basic {
         array(
           'id' => $row['id'],
           'key' => $obj->key,
-        )
+        ),
+        ts('more'),
+        FALSE,
+        'extension.local.action',
+        'Extension',
+        $row['id']
       );
+      // Key would be better to send, but it's not an integer.  Moreover, sending the
+      // values to hook_civicrm_links means that you can still get at the key
 
       $localExtensionRows[$row['id']] = $row;
     }
@@ -215,7 +222,12 @@ class CRM_Admin_Page_Extensions extends CRM_Core_Page_Basic {
         array(
           'id' => $row['id'],
           'key' => $row['key'],
-        )
+        ),
+        ts('more'),
+        FALSE,
+        'extension.remote.action',
+        'Extension',
+        $row['id']
       );
       $remoteExtensionRows[$row['id']] = $row;
     }

--- a/CRM/Admin/Page/Job.php
+++ b/CRM/Admin/Page/Job.php
@@ -177,7 +177,12 @@ class CRM_Admin_Page_Job extends CRM_Core_Page_Basic {
       }
 
       $job->action = CRM_Core_Action::formLink(self::links(), $action,
-        array('id' => $job->id)
+        array('id' => $job->id),
+        ts('more'),
+        FALSE,
+        'job.manage.action',
+        'Job',
+        $job->id
       );
       $rows[] = get_object_vars($job);
     }

--- a/CRM/Admin/Page/LabelFormats.php
+++ b/CRM/Admin/Page/LabelFormats.php
@@ -137,7 +137,13 @@ class CRM_Admin_Page_LabelFormats extends CRM_Core_Page_Basic {
 
       $format['groupName'] = ts('Mailing Label');
       $format['action'] = CRM_Core_Action::formLink(self::links(), $action,
-        array('id' => $format['id'], 'group' => 'label_format'));
+        array('id' => $format['id'], 'group' => 'label_format'),
+        ts('more'),
+        FALSE,
+        'labelFormat.manage.action',
+        'LabelFormat',
+        $format['id']
+      );
     }
 
     // Add action links to each of the Label Formats

--- a/CRM/Admin/Page/MailSettings.php
+++ b/CRM/Admin/Page/MailSettings.php
@@ -116,7 +116,12 @@ class CRM_Admin_Page_MailSettings extends CRM_Core_Page_Basic {
 
       //add action links.
       $allMailSettings[$mailSetting->id]['action'] = CRM_Core_Action::formLink(self::links(), $action,
-        array('id' => $mailSetting->id)
+        array('id' => $mailSetting->id),
+        ts('more'),
+        FALSE,
+        'mailSetting.manage.action',
+        'MailSetting',
+        $mailSetting->id
       );
     }
 

--- a/CRM/Admin/Page/MessageTemplates.php
+++ b/CRM/Admin/Page/MessageTemplates.php
@@ -155,7 +155,13 @@ class CRM_Admin_Page_MessageTemplates extends CRM_Core_Page_Basic {
       $values['action'] = CRM_Core_Action::formLink($links, $action, array(
         'id' => $object->id,
           'orig_id' => CRM_Utils_Array::value($object->id, $this->_revertible),
-        ));
+        ),
+        ts('more'),
+        FALSE,
+        'messageTemplate.manage.action',
+        'MessageTemplate',
+        $object->id
+      );
     }
     else {
       $action &= ~CRM_Core_Action::REVERT;

--- a/CRM/Admin/Page/OptionValue.php
+++ b/CRM/Admin/Page/OptionValue.php
@@ -205,7 +205,12 @@ class CRM_Admin_Page_OptionValue extends CRM_Core_Page_Basic {
       }
 
       $optionValue[$dao->id]['action'] = CRM_Core_Action::formLink(self::links(), $action,
-        array('id' => $dao->id, 'gid' => $this->_gid)
+        array('id' => $dao->id, 'gid' => $this->_gid),
+        ts('more'),
+        FALSE,
+        'optionValue.admin.actions',
+        'optionValue',
+        $dao->id
       );
     }
 

--- a/CRM/Admin/Page/ParticipantStatus.php
+++ b/CRM/Admin/Page/ParticipantStatus.php
@@ -92,7 +92,16 @@ class CRM_Admin_Page_ParticipantStatus extends CRM_Core_Page_Basic {
         }
       }
       $action -= $dao->is_active ? CRM_Core_Action::ENABLE : CRM_Core_Action::DISABLE;
-      $statusTypes[$dao->id]['action'] = CRM_Core_Action::formLink(self::links(), $action, array('id' => $dao->id));
+      $statusTypes[$dao->id]['action'] = CRM_Core_Action::formLink(
+        self::links(),
+        $action,
+        array('id' => $dao->id),
+        ts('more'),
+        FALSE,
+        'participantStatusType.manage.action',
+        'ParticipantStatusType',
+        $dao->id
+      );
       $statusTypes[$dao->id]['visibility'] = $visibilities[$dao->visibility_id];
     }
     $this->assign('rows', $statusTypes);

--- a/CRM/Admin/Page/PaymentProcessor.php
+++ b/CRM/Admin/Page/PaymentProcessor.php
@@ -149,7 +149,12 @@ class CRM_Admin_Page_PaymentProcessor extends CRM_Core_Page_Basic {
       }
 
       $paymentProcessor[$dao->id]['action'] = CRM_Core_Action::formLink(self::links(), $action,
-        array('id' => $dao->id)
+        array('id' => $dao->id),
+        ts('more'),
+        FALSE,
+        'paymentProcessor.manage.action',
+        'PaymentProcessor',
+        $dao->id
       );
       $paymentProcessor[$dao->id]['financialAccount'] = CRM_Financial_BAO_FinancialTypeAccount::getFinancialAccount($dao->id, 'civicrm_payment_processor');
     }

--- a/CRM/Admin/Page/PdfFormats.php
+++ b/CRM/Admin/Page/PdfFormats.php
@@ -124,7 +124,16 @@ class CRM_Admin_Page_PdfFormats extends CRM_Core_Page_Basic {
     // Add action links to each of the PDF Page Formats
     $action = array_sum(array_keys($this->links()));
     foreach ($pdfFormatList as & $format) {
-      $format['action'] = CRM_Core_Action::formLink(self::links(), $action, array('id' => $format['id']));
+      $format['action'] = CRM_Core_Action::formLink(
+        self::links(),
+        $action,
+        array('id' => $format['id']),
+        ts('more'),
+        FALSE,
+        'pdfFormat.manage.action',
+        'PdfFormat',
+        $format['id']
+      );
     }
 
     // Order Label Formats by weight

--- a/CRM/Admin/Page/Persistent.php
+++ b/CRM/Admin/Page/Persistent.php
@@ -119,7 +119,12 @@ class CRM_Admin_Page_Persistent extends CRM_Core_Page {
       if ($daoResult->is_config == 1) {
         $values[$daoResult->id]['action'] = CRM_Core_Action::formLink(self::customizeActionLinks(),
           NULL,
-          array('id' => $daoResult->id)
+          array('id' => $daoResult->id),
+          ts('more'),
+          FALSE,
+          'persistent.config.actions',
+          'Persistent',
+          $daoResult->id
         );
         $values[$daoResult->id]['data'] = implode(',', unserialize($daoResult->data));
         $configCustomization[$daoResult->id] = $values[$daoResult->id];
@@ -127,7 +132,12 @@ class CRM_Admin_Page_Persistent extends CRM_Core_Page {
       if ($daoResult->is_config == 0) {
         $values[$daoResult->id]['action'] = CRM_Core_Action::formLink(self::stringActionLinks(),
           NULL,
-          array('id' => $daoResult->id)
+          array('id' => $daoResult->id),
+          ts('more'),
+          FALSE,
+          'persistent.row.actions',
+          'Persistent',
+          $daoResult->id
         );
         $configStrings[$daoResult->id] = $values[$daoResult->id];
       }

--- a/CRM/Admin/Page/ScheduleReminders.php
+++ b/CRM/Admin/Page/ScheduleReminders.php
@@ -143,7 +143,16 @@ class CRM_Admin_Page_ScheduleReminders extends CRM_Core_Page_Basic {
         else {
           $action -= CRM_Core_Action::DISABLE;
         }
-        $format['action'] = CRM_Core_Action::formLink(self::links(), $action, array('id' => $format['id']));
+        $format['action'] = CRM_Core_Action::formLink(
+          self::links(),
+          $action,
+          array('id' => $format['id']),
+          ts('more'),
+          FALSE,
+          'actionSchedule.manage.action',
+          'ActionSchedule',
+          $format['id']
+        );
       }
     }
 

--- a/CRM/Batch/BAO/Batch.php
+++ b/CRM/Batch/BAO/Batch.php
@@ -326,7 +326,12 @@ class CRM_Batch_BAO_Batch extends CRM_Batch_DAO_Batch {
       $values['action'] = CRM_Core_Action::formLink(
         $newLinks,
         $action,
-        $tokens
+        $tokens),
+        ts('more'),
+        FALSE,
+        'batch.selector.row',
+        'Batch',
+        $object->id
       );
       $results[$object->id] = $values;
     }

--- a/CRM/Campaign/Page/Campaign.php
+++ b/CRM/Campaign/Page/Campaign.php
@@ -110,7 +110,12 @@ class CRM_Campaign_Page_Campaign extends CRM_Core_Page {
           $action -= CRM_Core_Action::DISABLE;
         }
         $campaigns[$cmpid]['action'] = CRM_Core_Action::formLink(self::actionLinks(), $action,
-          array('id' => $campaign['id'])
+          array('id' => $campaign['id']),
+          ts('more'),
+          FALSE,
+          'campaign.selector.row',
+          'Campaign',
+          $campaign['id']
         );
       }
     }

--- a/CRM/Campaign/Page/DashBoard.php
+++ b/CRM/Campaign/Page/DashBoard.php
@@ -241,7 +241,12 @@ class CRM_Campaign_Page_DashBoard extends CRM_Core_Page {
         }
         $campaignsData[$cmpid]['action'] = CRM_Core_Action::formLink(self::campaignActionLinks(),
           $action,
-          array('id' => $campaign['id'])
+          array('id' => $campaign['id']),
+          ts('more'),
+          FALSE,
+          'campaign.dashboard.row',
+          'Campaign',
+          $campaign['id']
         );
       }
     }
@@ -321,7 +326,12 @@ class CRM_Campaign_Page_DashBoard extends CRM_Core_Page {
         }
         $surveysData[$sid]['action'] = CRM_Core_Action::formLink(self::surveyActionLinks($surveysData[$sid]['activity_type']),
           $action,
-          array('id' => $sid)
+          array('id' => $sid),
+          ts('more'),
+          FALSE,
+          'survey.dashboard.row',
+          'Survey',
+          $sid
         );
 
         if (CRM_Utils_Array::value('activity_type', $surveysData[$sid]) != 'Petition') {
@@ -402,7 +412,12 @@ class CRM_Campaign_Page_DashBoard extends CRM_Core_Page {
 
         $petitionsData[$pid]['action'] = CRM_Core_Action::formLink(self::petitionActionLinks(),
           $action,
-          array('id' => $pid)
+          array('id' => $pid),
+          ts('more'),
+          FALSE,
+          'petition.dashboard.row',
+          'Petition',
+          $pid
         );
       }
     }

--- a/CRM/Campaign/Page/Survey.php
+++ b/CRM/Campaign/Page/Survey.php
@@ -96,7 +96,16 @@ class CRM_Campaign_Page_Survey extends CRM_Core_Page {
           $action -= CRM_Core_Action::DISABLE;
         }
 
-        $surveys[$sid]['action'] = CRM_Core_Action::formLink($this->actionLinks(), $action, array('id' => $sid));
+        $surveys[$sid]['action'] = CRM_Core_Action::formLink(
+          $this->actionLinks(),
+          $action,
+          array('id' => $sid),
+          ts('more'),
+          FALSE,
+          'survey.selector.row',
+          'Survey',
+          $sid
+        );
       }
     }
 

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -780,7 +780,12 @@ AND civicrm_case.status_id != $closedId";
               'id' => $result->case_id,
               'cid' => $result->contact_id,
               'cxt' => $context,
-            )
+            ),
+            ts('more'),
+            FALSE,
+            'case.actions.primary',
+            'Case',
+            $result->case_id
           );
           $casesList[$result->case_id]['moreActions'] = CRM_Core_Action::formLink($actions['moreActions'],
             $mask,
@@ -790,7 +795,10 @@ AND civicrm_case.status_id != $closedId";
               'cxt' => $context,
             ),
             ts('more'),
-            TRUE
+            TRUE,
+            'case.actions.more',
+            'Case',
+            $result->case_id
           );
         }
         elseif ($field == 'case_status') {

--- a/CRM/Case/Selector/Search.php
+++ b/CRM/Case/Selector/Search.php
@@ -342,7 +342,12 @@ class CRM_Case_Selector_Search extends CRM_Core_Selector_Base {
           'id' => $result->case_id,
           'cid' => $result->contact_id,
           'cxt' => $this->_context,
-        )
+        ),
+        ts('more'),
+        FALSE,
+        'case.selector.actions',
+        'Case',
+        $result->case_id
       );
       $row['moreActions'] = CRM_Core_Action::formLink(CRM_Utils_Array::value('moreActions', $links),
         $mask, array(
@@ -351,7 +356,10 @@ class CRM_Case_Selector_Search extends CRM_Core_Selector_Base {
           'cxt' => $this->_context,
         ),
         ts('more'),
-        TRUE
+        TRUE,
+        'case.selector.moreActions',
+        'Case',
+        $result->case_id
       );
 
       $row['contact_type'] = CRM_Contact_BAO_Contact_Utils::getImage($result->contact_sub_type ?

--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -859,7 +859,12 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
           array(
             'id' => $object->id,
             'ssid' => $object->saved_search_id,
-          )
+          ),
+          ts('more'),
+          FALSE,
+          'group.selector.row',
+          'Group',
+          $object->id
         );
 
         // If group has children, add class for link to view children

--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -1084,7 +1084,15 @@ LEFT JOIN  civicrm_country ON (civicrm_address.country_id = civicrm_country.id)
             }
           }
 
-          $values[$rid]['action'] = CRM_Core_Action::formLink($links, $mask, $replace);
+          $values[$rid]['action'] = CRM_Core_Action::formLink(
+            $links, 
+            $mask, 
+            $replace,
+            ts('more'),
+            FALSE,
+            'relationship.selector.row',
+            'Relationship',
+            $rid);
           unset($links[CRM_Core_Action::MAX_ACTION]);
         }
       }

--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -762,7 +762,12 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
         CRM_Core_Action::DELETE,
         array(
           'id' => $this->_contactId,
-        )
+        ),
+        ts('more'),
+        FALSE,
+        'contact.image.delete',
+        'Contact',
+        $this->_contactId
       );
       $this->assign('deleteURL', $deleteURL);
     }

--- a/CRM/Contact/Page/DedupeRules.php
+++ b/CRM/Contact/Page/DedupeRules.php
@@ -164,7 +164,16 @@ class CRM_Contact_Page_DedupeRules extends CRM_Core_Page_Basic {
         unset($links[CRM_Core_Action::DELETE]);
       }
 
-      $ruleGroups[$dao->contact_type][$dao->id]['action'] = CRM_Core_Action::formLink($links, $action, array('id' => $dao->id));
+      $ruleGroups[$dao->contact_type][$dao->id]['action'] = CRM_Core_Action::formLink(
+        $links,
+        $action,
+        array('id' => $dao->id),
+        ts('more'),
+        FALSE,
+        'dedupeRule.manage.action',
+        'DedupeRule',
+        $dao->id
+      );
       CRM_Dedupe_DAO_RuleGroup::addDisplayEnums($ruleGroups[$dao->contact_type][$dao->id]);
     }
 

--- a/CRM/Contact/Page/SavedSearch.php
+++ b/CRM/Contact/Page/SavedSearch.php
@@ -104,7 +104,16 @@ class CRM_Contact_Page_SavedSearch extends CRM_Core_Page {
 
           $action        = array_sum(array_keys(self::links()));
           $action        = $action & CRM_Core_Action::mask($permissions);
-          $row['action'] = CRM_Core_Action::formLink(self::links(), $action, array('id' => $row['id']));
+          $row['action'] = CRM_Core_Action::formLink(
+            self::links(),
+            $action,
+            array('id' => $row['id']),
+            ts('more'),
+            FALSE,
+            'savedSearch.manage.action',
+            'SavedSearch',
+            $row['id']
+          );
 
           $rows[] = $row;
         }

--- a/CRM/Contact/Page/View.php
+++ b/CRM/Contact/Page/View.php
@@ -390,9 +390,11 @@ class CRM_Contact_Page_View extends CRM_Core_Page {
     }
 
     // See if other modules want to add links to the activtity bar
-    $hookLinks = CRM_Utils_Hook::links('view.contact.activity',
+    $hookLinks = array();
+    CRM_Utils_Hook::links('view.contact.activity',
       'Contact',
       $cid,
+      $hookLinks,
       CRM_Core_DAO::$_nullObject,
       CRM_Core_DAO::$_nullObject
     );

--- a/CRM/Contact/Page/View/Note.php
+++ b/CRM/Contact/Page/View/Note.php
@@ -118,7 +118,12 @@ class CRM_Contact_Page_View_Note extends CRM_Core_Page {
           array(
             'id' => $note->id,
             'cid' => $this->_contactId,
-          )
+          ),
+          ts('more'),
+          FALSE,
+          'note.selector.row',
+          'Note',
+          $note->id
         );
         $contact = new CRM_Contact_DAO_Contact();
         $contact->id = $note->contact_id;
@@ -141,7 +146,12 @@ class CRM_Contact_Page_View_Note extends CRM_Core_Page {
         'id' => $note->id,
         'pid' => $note->entity_id,
         'cid' => $note->entity_id,
-      )
+      ),
+      ts('more'),
+      FALSE,
+      'note.comment.action',
+      'Note',
+      $note->id
     );
     $this->assign('commentAction', $commentAction);
   }

--- a/CRM/Contact/Page/View/UserDashBoard.php
+++ b/CRM/Contact/Page/View/UserDashBoard.php
@@ -243,7 +243,7 @@ class CRM_Contact_Page_View_UserDashBoard extends CRM_Core_Page {
           CRM_Core_Action::DISABLE => array(
               'name' => ts('Disable'),
               'url' => 'civicrm/contact/view/rel',
-              'qs' => 'action=disable&reset=1&cid=%%cid%%&id=%%id%%&rtype=%%rtype%%&selectedChild=rel%%&context=dashboard',
+              'qs' => 'action=disable&reset=1&cid=%%cid%%&id=%%id%%&rtype=%%rtype%%&selectedChild=rel&context=dashboard',
               'extra' => 'onclick = "return confirm(\'' . $disableExtra . '\');"',
               'title' => ts('Disable Relationship'),
             ),
@@ -256,6 +256,7 @@ class CRM_Contact_Page_View_UserDashBoard extends CRM_Core_Page {
       'Contact',
       CRM_Core_DAO::$_nullObject,
       self::$_links,
+      CRM_Core_DAO::$_nullObject,
       CRM_Core_DAO::$_nullObject
     );
     return self::$_links;

--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -731,7 +731,16 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
               'title' => ts('Permanently Delete Contact'),
             );
           }
-          $row['action'] = CRM_Core_Action::formLink($links, NULL, array('id' => $result->contact_id));
+          $row['action'] = CRM_Core_Action::formLink(
+            $links,
+            NULL,
+            array('id' => $result->contact_id),
+            ts('more'),
+            FALSE,
+            'contact.selector.row',
+            'Contact',
+            $result->contact_id
+          );
         }
         elseif ((is_numeric(CRM_Utils_Array::value('geo_code_1', $row))) ||
           ($config->mapGeoCoding &&
@@ -739,10 +748,28 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
             CRM_Utils_Array::value('state_province', $row)
           )
         ) {
-          $row['action'] = CRM_Core_Action::formLink($links, $mask, array('id' => $result->contact_id));
+          $row['action'] = CRM_Core_Action::formLink(
+            $links,
+            $mask,
+            array('id' => $result->contact_id),
+            ts('more'),
+            FALSE,
+            'contact.selector.row',
+            'Contact',
+            $result->contact_id
+          );
         }
         else {
-          $row['action'] = CRM_Core_Action::formLink($links, $mapMask, array('id' => $result->contact_id));
+          $row['action'] = CRM_Core_Action::formLink(
+            $links,
+            $mapMask,
+            array('id' => $result->contact_id),
+            ts('more'),
+            FALSE,
+            'contact.selector.row',
+            'Contact',
+            $result->contact_id
+          );
         }
 
         // allow components to add more actions
@@ -848,7 +875,16 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
             'title' => ts('Permanently Delete Contact'),
           );
         }
-        $row['action'] = CRM_Core_Action::formLink($links, NULL, array('id' => $row['contact_id']));
+        $row['action'] = CRM_Core_Action::formLink(
+          $links,
+          null,
+          array('id' => $row['contact_id']),
+          ts('more'),
+          FALSE,
+          'contact.selector.actions',
+          'Contact',
+          $row['contact_id']
+        );
       }
       elseif ((is_numeric(CRM_Utils_Array::value('geo_code_1', $row))) ||
         ($config->mapGeoCoding &&
@@ -856,10 +892,28 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
           CRM_Utils_Array::value('state_province', $row)
         )
       ) {
-        $row['action'] = CRM_Core_Action::formLink($links, $mask, array('id' => $row['contact_id']));
+        $row['action'] = CRM_Core_Action::formLink(
+          $links,
+          $mask,
+          array('id' => $row['contact_id']),
+          ts('more'),
+          FALSE,
+          'contact.selector.actions',
+          'Contact',
+          $row['contact_id']
+        );
       }
       else {
-        $row['action'] = CRM_Core_Action::formLink($links, $mapMask, array('id' => $row['contact_id']));
+        $row['action'] = CRM_Core_Action::formLink(
+          $links,
+          $mapMask,
+          array('id' => $row['contact_id']),
+          ts('more'),
+          FALSE,
+          'contact.selector.actions',
+          'Contact',
+          $row['contact_id']
+        );
       }
 
       // allow components to add more actions

--- a/CRM/Contact/Selector/Custom.php
+++ b/CRM/Contact/Selector/Custom.php
@@ -332,7 +332,12 @@ class CRM_Contact_Selector_Custom extends CRM_Contact_Selector {
         $row['checkbox'] = CRM_Core_Form::CB_PREFIX . $contactID;
         $row['action'] = CRM_Core_Action::formLink($links,
           $mask,
-          array('id' => $contactID)
+          array('id' => $contactID),
+          ts('more'),
+          FALSE,
+          'contact.custom.actions',
+          'Contact',
+          $contactID
         );
         $row['contact_id'] = $contactID;
 
@@ -406,7 +411,12 @@ class CRM_Contact_Selector_Custom extends CRM_Contact_Selector {
     foreach ($rows as $id => & $row) {
       $row['action'] = CRM_Core_Action::formLink($links,
         $mask,
-        array('id' => $row['contact_id'])
+        array('id' => $row['contact_id']),
+        ts('more'),
+        FALSE,
+        'contact.custom.actions',
+        'Contact',
+        $row['contact_id']
       );
     }
   }

--- a/CRM/Contribute/Page/ContributionPage.php
+++ b/CRM/Contribute/Page/ContributionPage.php
@@ -487,7 +487,10 @@ ORDER BY title asc
         $action,
         array('id' => $dao->id),
         ts('Configure'),
-        TRUE
+        TRUE,
+        'contributionpage.configure.actions',
+        'ContributionPage',
+        $dao->id
       );
 
       //build the contributions links.
@@ -495,7 +498,10 @@ ORDER BY title asc
         $action,
         array('id' => $dao->id),
         ts('Contributions'),
-        TRUE
+        TRUE,
+        'contributionpage.contributions.search',
+        'ContributionPage',
+        $dao->id
       );
 
       //build the online contribution links.
@@ -503,7 +509,10 @@ ORDER BY title asc
         $action,
         array('id' => $dao->id),
         ts('Links'),
-        TRUE
+        TRUE,
+        'contributionpage.online.links',
+        'ContributionPage',
+        $dao->id
       );
 
       //build the normal action links.
@@ -511,7 +520,10 @@ ORDER BY title asc
         $action,
         array('id' => $dao->id),
         ts('more'),
-        TRUE
+        TRUE,
+        'contributionpage.action.links',
+        'ContributionPage',
+        $dao->id
       );
 
       //show campaigns on selector.

--- a/CRM/Contribute/Page/ManagePremiums.php
+++ b/CRM/Contribute/Page/ManagePremiums.php
@@ -165,7 +165,12 @@ class CRM_Contribute_Page_ManagePremiums extends CRM_Core_Page_Basic {
 
       $premiums[$dao->id]['action'] = CRM_Core_Action::formLink(self::links(),
         $action,
-        array('id' => $dao->id)
+        array('id' => $dao->id)),
+        ts('more'),
+        FALSE,
+        'premium.manage.row',
+        'Premium',
+        $dao->id
       );
            //Financial Type
                 if( !empty( $dao->financial_type_id )  ){

--- a/CRM/Contribute/Page/Premium.php
+++ b/CRM/Contribute/Page/Premium.php
@@ -167,7 +167,12 @@ class CRM_Contribute_Page_Premium extends CRM_Core_Page_Basic {
         $action = array_sum(array_keys($this->links()));
 
         $premiums[$dao->product_id]['action'] = CRM_Core_Action::formLink(self::links(), $action,
-          array('id' => $pageID, 'pid' => $dao->id)
+          array('id' => $pageID, 'pid' => $dao->id),
+          ts('more'),
+          FALSE,
+          'premium.contributionpage.row',
+          'Premium',
+          $dao->id
         );
         //Financial Type
         if (!empty($dao->financial_type_id)) {

--- a/CRM/Contribute/Page/Tab.php
+++ b/CRM/Contribute/Page/Tab.php
@@ -193,7 +193,12 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
               'cid' => $this->_contactId,
               'crid' => $ids,
               'cxt' => 'contribution',
-            )
+            ),
+            ts('more'),
+            FALSE,
+            'contribution.selector.recurring',
+            'Contribution',
+            $ids
           );
         }
       }
@@ -220,7 +225,12 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
             'cxt' => 'contribution',
             'contributionType' => $honorId['type_id'],
             'honorId' => $this->_contactId,
-          )
+          ),
+          ts('more'),
+          FALSE,
+          'contribution.selector.honoree',
+          'Contribution',
+          $ids
         );
       }
 

--- a/CRM/Contribute/Page/UserDashboard.php
+++ b/CRM/Contribute/Page/UserDashboard.php
@@ -111,7 +111,12 @@ class CRM_Contribute_Page_UserDashboard extends CRM_Contact_Page_View_UserDashBo
           'cid' => $this->_contactId,
           'crid' => $values['id'],
           'cxt' => 'contribution',
-        )
+        ),
+        ts('more'),
+        FALSE,
+        'contribution.dashboard.recurring',
+        'Contribution',
+        $values['id']
       );
 
       $recurIDs[] = $values['id'];

--- a/CRM/Contribute/Selector/Search.php
+++ b/CRM/Contribute/Selector/Search.php
@@ -379,7 +379,12 @@ class CRM_Contribute_Selector_Search extends CRM_Core_Selector_Base implements C
           $qfKey,
           $componentContext
         ),
-        $mask, $actions
+        $mask, $actions,
+        ts('more'),
+        FALSE,
+        'contribution.selector.row',
+        'Contribution',
+        $result->contribution_id
       );
 
       $row['contact_type'] = CRM_Contact_BAO_Contact_Utils::getImage($result->contact_sub_type ?

--- a/CRM/Core/Action.php
+++ b/CRM/Core/Action.php
@@ -217,16 +217,23 @@ class CRM_Core_Action {
       return NULL;
     }
 
+    // make links indexed sequentially instead of by bitmask
+    // otherwise it's next to impossible to reliably add new ones
+    $seqLinks = array();
+    foreach ($links as $bit => $link) {
+      $link['bit'] = $bit;
+      $seqLinks[] = $link;
+    }
 
     if ($op && $objectName && $objectId) {
-      CRM_Utils_Hook::links($op, $objectName, $objectId, $links, $mask);
+      CRM_Utils_Hook::links($op, $objectName, $objectId, $seqLinks, $mask, $values);
     }
 
     $url = array();
 
     $firstLink = TRUE;
-    foreach ($links as $m => $link) {
-      if (!$mask || ($mask & $m)) {
+    foreach ($seqLinks as $link) {
+      if (!$mask || !array_key_exists('bit', $link) || ($mask & $link['bit'])) {
         $extra = isset($link['extra']) ? self::replace($link['extra'], $values) : NULL;
 
         $frontend = (isset($link['fe'])) ? TRUE : FALSE;

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -748,7 +748,12 @@ ORDER BY civicrm_custom_group.weight,
               'id' => $fileDAO->id,
               'eid' => $dao->$entityIDName,
               'fid' => $fieldID,
-            )
+            ),
+            ts('more'),
+            FALSE,
+            'file.manage.delete',
+            'File',
+            $fileDAO->id
           );
           $customValue['deleteURLArgs'] = CRM_Core_BAO_File::deleteURLArgs($table, $dao->$entityIDName, $fileDAO->id);
           $customValue['fileName'] = CRM_Utils_File::cleanFileName(basename($fileDAO->uri));

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -1759,7 +1759,12 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
         CRM_Core_Action::DELETE,
         array('id' => $form->get('id'),
           'gid' => $form->get('gid'),
-        )
+        ),
+        ts('more'),
+        FALSE,
+        'contact.profileimage.delete',
+        'Contact',
+        $form->get('id')
       );
       $form->assign('deleteURL', $deleteURL);
     }

--- a/CRM/Core/Block.php
+++ b/CRM/Core/Block.php
@@ -419,6 +419,7 @@ class CRM_Core_Block {
       NULL,
       CRM_Core_DAO::$_nullObject,
       $values,
+      CRM_Core_DAO::$_nullObject,
       CRM_Core_DAO::$_nullObject
     );
 

--- a/CRM/Core/OptionValue.php
+++ b/CRM/Core/OptionValue.php
@@ -146,7 +146,12 @@ class CRM_Core_OptionValue {
           'id' => $dao->id,
           'gid' => $optionGroupID,
           'value' => $dao->value,
-        )
+        ),
+        ts('more'),
+        FALSE,
+        'optionValue.row.actions',
+        'optionValue',
+        $dao->id
       );
 
       if (CRM_Utils_Array::value('component_id', $optionValue[$dao->id])) {

--- a/CRM/Custom/Page/Field.php
+++ b/CRM/Custom/Page/Field.php
@@ -177,7 +177,12 @@ class CRM_Custom_Page_Field extends CRM_Core_Page {
         array(
           'id' => $customFieldBAO->id,
           'gid' => $this->_gid,
-        )
+        ),
+        ts('more'),
+        FALSE,
+        'customField.row.actions',
+        'CustomField',
+        $customFieldBAO->id
       );
     }
 

--- a/CRM/Custom/Page/Group.php
+++ b/CRM/Custom/Page/Group.php
@@ -227,7 +227,12 @@ class CRM_Custom_Page_Group extends CRM_Core_Page {
       }
       $customGroup[$dao->id]['order'] = $customGroup[$dao->id]['weight'];
       $customGroup[$dao->id]['action'] = CRM_Core_Action::formLink(self::actionLinks(), $action,
-        array('id' => $dao->id)
+        array('id' => $dao->id),
+        ts('more'),
+        FALSE,
+        'customGroup.row.actions',
+        'CustomGroup',
+        $dao->id
       );
     }
 

--- a/CRM/Custom/Page/Option.php
+++ b/CRM/Custom/Page/Option.php
@@ -217,7 +217,12 @@ ORDER BY weight, label
           'id' => $dao->id,
           'fid' => $this->_fid,
           'gid' => $this->_gid,
-        )
+        ),
+        ts('more'),
+        FALSE,
+        'customOption.row.actions',
+        'customOption',
+        $dao->id
       );
     }
 

--- a/CRM/Event/Form/ManageEvent/ScheduleReminders.php
+++ b/CRM/Event/Form/ManageEvent/ScheduleReminders.php
@@ -74,7 +74,12 @@ class CRM_Event_Form_ManageEvent_ScheduleReminders extends CRM_Event_Form_Manage
           $format['action'] = CRM_Core_Action::formLink(
             $links,
             $action,
-            array('id' => $format['id'])
+            array('id' => $format['id'])),
+            ts('more'),
+            FALSE,
+            'event.reminder.list',
+            'Event',
+            $this->_id
           );
         }
         $this->assign('rows', $reminderList);

--- a/CRM/Event/Page/ManageEvent.php
+++ b/CRM/Event/Page/ManageEvent.php
@@ -323,7 +323,10 @@ ORDER BY start_date desc
           $action,
           array('id' => $dao->id),
           ts('more'),
-          TRUE
+          TRUE,
+          'event.manage.list',
+          'Event',
+          $dao->id
         );
 
         $params = array(

--- a/CRM/Event/Selector/Search.php
+++ b/CRM/Event/Selector/Search.php
@@ -367,7 +367,12 @@ class CRM_Event_Selector_Search extends CRM_Core_Selector_Base implements CRM_Co
           'id' => $result->participant_id,
           'cid' => $result->contact_id,
           'cxt' => $this->_context,
-        )
+        ),
+        ts('more'),
+        FALSE,
+        'participant.selector.row',
+        'Participant',
+        $result->participant_id
       );
 
 

--- a/CRM/Financial/Page/AJAX.php
+++ b/CRM/Financial/Page/AJAX.php
@@ -377,19 +377,58 @@ class CRM_Financial_Page_AJAX {
         if (isset($notPresent)) {
           $js = "enableActions('x')";
           $row[$financialItem->id]['check'] = "<input type='checkbox' id='mark_x_". $financialItem->id."' name='mark_x_". $financialItem->id."' value='1' onclick={$js}></input>";
-          $row[$financialItem->id]['action'] = CRM_Core_Action::formLink(CRM_Financial_Form_BatchTransaction::links(), null, array('id' => $financialItem->id, 'contid' => $financialItem->contributionID, 'cid' => $financialItem->contact_id));
+          $row[$financialItem->id]['action'] = CRM_Core_Action::formLink(
+            CRM_Financial_Form_BatchTransaction::links(),
+            null,
+            array(
+              'id' => $financialItem->id,
+              'contid' => $financialItem->contributionID,
+              'cid' => $financialItem->contact_id
+            ),
+            ts('more'),
+            FALSE,
+            'financialItem.batch.row',
+            'FinancialItem',
+            $financialItem->id
+          );
         }
         else {
           $js = "enableActions('y')";
           $row[$financialItem->id]['check'] = "<input type='checkbox' id='mark_y_". $financialItem->id."' name='mark_y_". $financialItem->id."' value='1' onclick={$js}></input>";
-          $row[$financialItem->id]['action'] = CRM_Core_Action::formLink(CRM_Financial_Page_BatchTransaction::links(), null, array('id' => $financialItem->id, 'contid' => $financialItem->contributionID, 'cid' => $financialItem->contact_id));
+          $row[$financialItem->id]['action'] = CRM_Core_Action::formLink(
+            CRM_Financial_Page_BatchTransaction::links(),
+            null,
+            array(
+              'id' => $financialItem->id,
+              'contid' => $financialItem->contributionID,
+              'cid' => $financialItem->contact_id
+            ),
+            ts('more'),
+            FALSE,
+            'financialItem.batch.row',
+            'FinancialItem',
+            $financialItem->id
+          );
         }
       }
       else {
         $row[$financialItem->id]['check'] = NULL;
         $links = CRM_Financial_Page_BatchTransaction::links();
         unset($links['remove']);
-        $row[$financialItem->id]['action'] = CRM_Core_Action::formLink($links, null, array('id' => $financialItem->id, 'contid' => $financialItem->contributionID, 'cid' => $financialItem->contact_id));
+        $row[$financialItem->id]['action'] = CRM_Core_Action::formLink(
+          $links,
+          null,
+          array(
+            'id' => $financialItem->id,
+            'contid' => $financialItem->contributionID,
+            'cid' => $financialItem->contact_id
+          ),
+          ts('more'),
+          FALSE,
+          'financialItem.batch.row',
+          'FinancialItem',
+          $financialItem->id
+        );
       }
       $row[$financialItem->id]['contact_type'] = CRM_Contact_BAO_Contact_Utils::getImage(CRM_Utils_Array::value('contact_sub_type',$row[$financialItem->id]) ? CRM_Utils_Array::value('contact_sub_type',$row[$financialItem->id]) : CRM_Utils_Array::value('contact_type',$row[$financialItem->id]) ,false, $financialItem->contact_id);
       $financialitems = $row;

--- a/CRM/Financial/Page/FinancialAccount.php
+++ b/CRM/Financial/Page/FinancialAccount.php
@@ -156,7 +156,13 @@ class CRM_Financial_Page_FinancialAccount extends CRM_Core_Page_Basic {
       }
 
       $contributionType[$dao->id]['action'] = CRM_Core_Action::formLink(self::links(), $action,
-        array('id' => $dao->id));
+        array('id' => $dao->id),
+        ts('more'),
+        FALSE,
+        'financialAccount.manage.action',
+        'FinancialAccount',
+        $dao->id
+      );
     }
     $this->assign('rows', $contributionType);
   }

--- a/CRM/Financial/Page/FinancialType.php
+++ b/CRM/Financial/Page/FinancialType.php
@@ -182,7 +182,13 @@ class CRM_Financial_Page_FinancialType extends CRM_Core_Page_Basic {
       }
 
       $financialType[$dao->id]['action'] = CRM_Core_Action::formLink(self::links(), $action,
-        array('id' => $dao->id));
+        array('id' => $dao->id),
+        ts('more'),
+        FALSE,
+        'financialType.manage.action',
+        'FinancialType',
+        $dao->id
+      );
     }
     $this->assign('rows', $financialType);
   }

--- a/CRM/Financial/Page/FinancialTypeAccount.php
+++ b/CRM/Financial/Page/FinancialTypeAccount.php
@@ -178,7 +178,12 @@ class CRM_Financial_Page_FinancialTypeAccount extends CRM_Core_Page {
           array(
             'id' => $dao->id,
             'aid'=> $dao->entity_id,
-          )
+          ),
+          ts('more'),
+          FALSE,
+          'financialTypeAccount.manage.action',
+          'FinancialTypeAccount',
+          $dao->id
         );
       }
       $this->assign('rows', $financialType);

--- a/CRM/Grant/Selector/Search.php
+++ b/CRM/Grant/Selector/Search.php
@@ -312,7 +312,12 @@ class CRM_Grant_Selector_Search extends CRM_Core_Selector_Base implements CRM_Co
           'id' => $result->grant_id,
           'cid' => $result->contact_id,
           'cxt' => $this->_context,
-        )
+        ),
+        ts('more'),
+        FALSE,
+        'grant.selector.row',
+        'Grant',
+        $result->grant_id
       );
 
       $row['contact_type'] = CRM_Contact_BAO_Contact_Utils::getImage($result->contact_sub_type ?

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -2030,7 +2030,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
       ) as $key) {
       $url          = 'mailing/detail';
       $reportFilter = "reset=1&mailing_id_value={$mailing_id}";
-      $searchFilter = "force=1&mailing_id={$mailing_id}";
+      $searchFilter = "force=1&mailing_id=%%mid%%";
       switch ($key) {
         case 'delivered':
           $reportFilter .= "&delivery_status_value=successful";
@@ -2077,7 +2077,16 @@ ORDER BY   civicrm_email.is_bulkmail DESC
       if (array_key_exists(CRM_Core_Action::ADVANCED, $actionLinks)) {
         $actionLinks[CRM_Core_Action::ADVANCED]['qs'] = $searchFilter;
       }
-      $report['event_totals']['actionlinks'][$key] = CRM_Core_Action::formLink($actionLinks, $action, array());
+      $report['event_totals']['actionlinks'][$key] = CRM_Core_Action::formLink(
+        $actionLinks,
+        $action,
+        array('mid' => $mailing_id),
+        ts('more'),
+        FALSE,
+        'mailing.report.action',
+        'Mailing',
+        $mailing_id
+      );
     }
 
     return $report;
@@ -2794,19 +2803,31 @@ AND        m.id = %1
         CRM_Core_Action::VIEW => array(
           'name' => ts('View'),
           'url' => 'civicrm/mailing/view',
-          'qs' => "reset=1&id={$values['mailing_id']}",
+          'qs' => "reset=1&id=%%mid%%",
           'title' => ts('View Mailing'),
           'class' => 'crm-mailing-view',
         ),
         CRM_Core_Action::BROWSE => array(
           'name' => ts('Mailing Report'),
           'url' => 'civicrm/mailing/report',
-          'qs' => "mid={$values['mailing_id']}&reset=1&cid={$params['contact_id']}&context=mailing",
+          'qs' => "mid=%%mid%%&reset=1&cid=%%cid%%&context=mailing",
           'title' => ts('View Mailing Report'),
         )
       );
 
-      $contactMailings[$mailingId]['links'] = CRM_Core_Action::formLink($actionLinks);
+      $contactMailings[$mailingId]['links'] = CRM_Core_Action::formLink(
+        $actionLinks,
+        null,
+        array(
+          'mid' => $values['mailing_id'],
+          'cid' => $params['contact_id'],
+        ),
+        ts('more'),
+        FALSE,
+        'mailing.contact.action',
+        'Mailing',
+        $values['mailing_id']
+      );
     }
 
     return $contactMailings;

--- a/CRM/Mailing/Selector/Search.php
+++ b/CRM/Mailing/Selector/Search.php
@@ -308,7 +308,13 @@ class CRM_Mailing_Selector_Search extends CRM_Core_Selector_Base implements CRM_
 
       $row['action'] = CRM_Core_Action::formLink(
         self::links($qfKey, $this->_context),
-        $mask, $actions
+        $mask, 
+        $actions,
+        ts('more'),
+        FALSE,
+        'contact.mailing.row',
+        'Contact',
+        $result->contact_id
       );
       $row['contact_type'] = CRM_Contact_BAO_Contact_Utils::getImage($result->contact_sub_type ?
         $result->contact_sub_type : $result->contact_type, FALSE, $result->contact_id

--- a/CRM/Member/Form/MembershipView.php
+++ b/CRM/Member/Form/MembershipView.php
@@ -286,7 +286,12 @@ SELECT r.id, c.id as cid, c.display_name as name, c.job_title as comment,
                 'id' => CRM_Utils_Request::retrieve('id', 'Positive', $this),
                 'cid' => $row['cid'],
                 'mid' => $row['mid'],
-              )
+              ),
+              ts('more'),
+              FALSE,
+              'membership.relationship.action',
+              'Relationship',
+              CRM_Utils_Request::retrieve('id', 'Positive', $this)
             );
           }
           else {
@@ -296,7 +301,12 @@ SELECT r.id, c.id as cid, c.display_name as name, c.job_title as comment,
                   'id' => CRM_Utils_Request::retrieve('id', 'Positive', $this),
                   'cid' => $row['cid'],
                   'rid' => $row['cid'],
-                )
+                ),
+                ts('more'),
+                FALSE,
+                'membership.relationship.action',
+                'Relationship',
+                CRM_Utils_Request::retrieve('id', 'Positive', $this)
               );
             }
           }

--- a/CRM/Member/Page/MembershipStatus.php
+++ b/CRM/Member/Page/MembershipStatus.php
@@ -158,7 +158,12 @@ class CRM_Member_Page_MembershipStatus extends CRM_Core_Page_Basic {
           $action -= CRM_Core_Action::DISABLE;
         }
         $membershipStatus[$dao->id]['action'] = CRM_Core_Action::formLink(self::links(), $action,
-          array('id' => $dao->id)
+          array('id' => $dao->id),
+          ts('more'),
+          FALSE,
+          'membershipStatus.manage.action',
+          'MembershipStatus',
+          $dao->id
         );
       }
       if ($startEvent = CRM_Utils_Array::value('start_event', $membershipStatus[$dao->id])) {

--- a/CRM/Member/Page/MembershipType.php
+++ b/CRM/Member/Page/MembershipType.php
@@ -152,7 +152,12 @@ class CRM_Member_Page_MembershipType extends CRM_Core_Page {
         }
         $membershipType[$dao->id]['order'] = $membershipType[$dao->id]['weight'];
         $membershipType[$dao->id]['action'] = CRM_Core_Action::formLink(self::links(), $action,
-          array('id' => $dao->id)
+          array('id' => $dao->id),
+          ts('more'),
+          FALSE,
+          'membershipType.manage.action',
+          'MembershipType',
+          $dao->id
         );
       }
     }

--- a/CRM/Member/Page/Tab.php
+++ b/CRM/Member/Page/Tab.php
@@ -122,7 +122,12 @@ class CRM_Member_Page_Tab extends CRM_Core_Page {
           array(
             'id' => $dao->id,
             'cid' => $this->_contactId,
-          )
+          ),
+          ts('more'),
+          FALSE,
+          'membership.tab.row',
+          'Membership',
+          $dao->id
         );
       }
       else {
@@ -131,7 +136,12 @@ class CRM_Member_Page_Tab extends CRM_Core_Page {
           array(
             'id' => $dao->id,
             'cid' => $this->_contactId,
-          )
+          ),
+          ts('more'),
+          FALSE,
+          'membership.tab.row',
+          'Membership',
+          $dao->id
         );
       }
 
@@ -177,7 +187,12 @@ class CRM_Member_Page_Tab extends CRM_Core_Page {
         array(
           'id' => $value['id'],
           'cid' => $this->_contactId,
-        )
+        ),
+        ts('more'),
+        FALSE,
+        'membershipType.organization.action',
+        'MembershipType',
+        $value['id']
       );
     }
 

--- a/CRM/Member/Selector/Search.php
+++ b/CRM/Member/Selector/Search.php
@@ -397,7 +397,12 @@ class CRM_Member_Selector_Search extends CRM_Core_Selector_Base implements CRM_C
             'id' => $result->membership_id,
             'cid' => $result->contact_id,
             'cxt' => $this->_context,
-          )
+          ),
+          ts('more'),
+          FALSE,
+          'membership.selector.row',
+          'Membership',
+          $result->membership_id
         );
       }
       else {
@@ -406,7 +411,12 @@ class CRM_Member_Selector_Search extends CRM_Core_Selector_Base implements CRM_C
             'id' => $result->membership_id,
             'cid' => $result->contact_id,
             'cxt' => $this->_context,
-          )
+          ),
+          ts('more'),
+          FALSE,
+          'membership.selector.row',
+          'Membership',
+          $result->membership_id
         );
       }
 

--- a/CRM/PCP/BAO/PCP.php
+++ b/CRM/PCP/BAO/PCP.php
@@ -159,7 +159,8 @@ ORDER BY page_type, page_id";
       else {
         $mask -= CRM_Core_Action::DISABLE;
       }
-      $action = CRM_Core_Action::formLink($pcpLink, $mask, $replace);
+      $action = CRM_Core_Action::formLink($pcpLink, $mask, $replace, ts('more'),
+        FALSE, 'pcp.dashboard.active', 'PCP', $pcpInfoDao->id);
       $component = $pcpInfoDao->page_type;
       $pageTitle = CRM_Utils_Array::value($pcpInfoDao->page_id, $$component);
 
@@ -206,7 +207,8 @@ ORDER BY target_entity_type, target_entity_id
         );
       }
       $pcpLink = $links['add'];
-      $action = CRM_Core_Action::formLink($pcpLink, $mask, $replace);
+      $action = CRM_Core_Action::formLink($pcpLink, $mask, $replace, ts('more'),
+        FALSE, 'pcp.dashboard.other', "{$pcpBlockDao->target_entity_type}_PCP", $pcpBlockDao->target_entity_id);
       $component = $pcpBlockDao->target_entity_type;
       $pageTitle = CRM_Utils_Array::value($pcpBlockDao->target_entity_id, $$component);
       $pcpBlock[] = array(

--- a/CRM/PCP/Page/PCP.php
+++ b/CRM/PCP/Page/PCP.php
@@ -320,7 +320,7 @@ class CRM_PCP_Page_PCP extends CRM_Core_Page_Basic {
         'page_url' => $pageUrl,
         'page_type' => $page_type,
         'action' => CRM_Core_Action::formLink(self::links(), $action,
-          array('id' => $pcp->id)
+          array('id' => $pcp->id), ts('more'), FALSE, 'contributionpage.pcp.list', 'PCP', $pcp->id
         ),
         'title' => $pcp->title,
         'class' => $class,

--- a/CRM/Pledge/Selector/Search.php
+++ b/CRM/Pledge/Selector/Search.php
@@ -348,7 +348,12 @@ class CRM_Pledge_Selector_Search extends CRM_Core_Selector_Base {
           'id' => $result->pledge_id,
           'cid' => $result->contact_id,
           'cxt' => $this->_context,
-        )
+        ),
+        ts('more'),
+        FALSE,
+        'pledge.selector.row',
+        'Pledge',
+        $result->pledge_id
       );
 
 

--- a/CRM/Price/Page/Field.php
+++ b/CRM/Price/Page/Field.php
@@ -172,11 +172,18 @@ class CRM_Price_Page_Field extends CRM_Core_Page {
       $htmlTypes = CRM_Price_BAO_PriceField::htmlTypes();
       $priceField[$priceFieldBAO->id]['html_type'] = $htmlTypes[$priceField[$priceFieldBAO->id]['html_type']];
       $priceField[$priceFieldBAO->id]['order'] = $priceField[$priceFieldBAO->id]['weight'];
-      $priceField[$priceFieldBAO->id]['action'] = CRM_Core_Action::formLink(self::actionLinks(), $action,
+      $priceField[$priceFieldBAO->id]['action'] = CRM_Core_Action::formLink(
+        self::actionLinks(),
+        $action,
         array(
           'fid' => $priceFieldBAO->id,
           'sid' => $this->_sid,
-        )
+        ),
+        ts('more'),
+        FALSE,
+        'priceField.row.actions',
+        'PriceField',
+        $priceFieldBAO->id
       );
     }
 

--- a/CRM/Price/Page/Option.php
+++ b/CRM/Price/Page/Option.php
@@ -162,7 +162,12 @@ class CRM_Price_Page_Option extends CRM_Core_Page {
           'oid' => $id,
           'fid' => $this->_fid,
           'sid' => $this->_sid,
-        )
+        ),
+        ts('more'),
+        FALSE,
+        'priceFieldValue.row.actions',
+        'PriceFieldValue',
+        $id
       );
     }
     // Add order changing widget to selector

--- a/CRM/Price/Page/Set.php
+++ b/CRM/Price/Page/Set.php
@@ -300,7 +300,12 @@ class CRM_Price_Page_Set extends CRM_Core_Page {
         $actionLinks[CRM_Core_Action::BROWSE]['name'] = 'View Price Fields';
       }
       $priceSet[$dao->id]['action'] = CRM_Core_Action::formLink($actionLinks, $action,
-        array('sid' => $dao->id)
+        array('sid' => $dao->id),
+        ts('more'),
+        FALSE,
+        'priceSet.row.actions',
+        'PriceSet',
+        $dao->id
       );
     }
     $this->assign('rows', $priceSet);

--- a/CRM/Profile/Page/MultipleRecordFieldsListing.php
+++ b/CRM/Profile/Page/MultipleRecordFieldsListing.php
@@ -234,8 +234,16 @@ class CRM_Profile_Page_MultipleRecordFieldsListing extends CRM_Core_Page_Basic {
              if ($pageCheckSum) {
                $actionParams['cs'] = $pageCheckSum;
              }
-             $value['action'] =
-               CRM_Core_Action::formLink($links, $linkAction, $actionParams);
+             $value['action'] = CRM_Core_Action::formLink(
+               $links,
+               $linkAction,
+               $actionParams,
+               ts('more'),
+               FALSE,
+               'profile.multiValue.row',
+               'customValue',
+               $fieldId // not ideal, but the one thing not sent in $actionParams
+             );
            }
          }
        }

--- a/CRM/Profile/Selector/Listings.php
+++ b/CRM/Profile/Selector/Listings.php
@@ -698,7 +698,12 @@ class CRM_Profile_Selector_Listings extends CRM_Core_Selector_Base implements CR
 
       $row[] = CRM_Core_Action::formLink($newLinks,
         $mask,
-        $params
+        $params,
+        ts('more'),
+        FALSE,
+        'profile.selector.row',
+        'Contact',
+        $result->contact_id
       );
 
       if (!$empty) {

--- a/CRM/SMS/Page/Provider.php
+++ b/CRM/SMS/Page/Provider.php
@@ -147,7 +147,12 @@ class CRM_SMS_Page_Provider extends CRM_Core_Page_Basic {
       $provider['api_type'] = $apiTypes[$provider['api_type']];
 
       $provider['action'] = CRM_Core_Action::formLink(self::links(), $action,
-        array('id' => $provider['id'])
+        array('id' => $provider['id']),
+        ts('more'),
+        FALSE,
+        'sms.provider.row',
+        'SMSProvider',
+        $provider['id']
       );
       $rows[] = $provider;
     }

--- a/CRM/UF/Page/Field.php
+++ b/CRM/UF/Page/Field.php
@@ -171,7 +171,12 @@ class CRM_UF_Page_Field extends CRM_Core_Page {
         array(
           'id' => $ufFieldBAO->id,
           'gid' => $this->_gid,
-        )
+        ),
+        ts('more'),
+        FALSE,
+        'ufField.row.actions',
+        'UFField',
+        $ufFieldBAO->id
       );
     }
 

--- a/CRM/UF/Page/Group.php
+++ b/CRM/UF/Page/Group.php
@@ -362,7 +362,12 @@ class CRM_UF_Page_Group extends CRM_Core_Page {
       $ufGroup[$id]['group_type'] = $groupTypesString;
 
       $ufGroup[$id]['action'] = CRM_Core_Action::formLink(self::actionLinks(), $action,
-        array('id' => $id)
+        array('id' => $id),
+        ts('more'),
+        FALSE,
+        'ufGroup.row.actions',
+        'UFGroup',
+        $id
       );
       //get the "Used For" from uf_join
       $ufGroup[$id]['module'] = implode(', ', CRM_Core_BAO_UFGroup::getUFJoinRecord($id, TRUE));

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -242,7 +242,7 @@ abstract class CRM_Utils_Hook {
    * @param int    $mask       (optional) the bitmask to show/hide links
    * @param array  $values     (optional) the values to fill the links
    *
-   * @return array|null        an array of arrays, each element is a tuple consisting of id, url, img, title, weight
+   * @return null  the return value is ignored
    *
    * @access public
    */

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -87,19 +87,19 @@ abstract class CRM_Utils_Hook {
   }
 
   abstract function invoke($numParams,
-    &$arg1, &$arg2, &$arg3, &$arg4, &$arg5,
+    &$arg1, &$arg2, &$arg3, &$arg4, &$arg5, &$arg6,
     $fnSuffix
   );
 
   function commonInvoke($numParams,
-    &$arg1, &$arg2, &$arg3, &$arg4, &$arg5,
+    &$arg1, &$arg2, &$arg3, &$arg4, &$arg5, &$arg6,
     $fnSuffix, $fnPrefix
   ) {
 
     $this->commonBuildModuleList($fnPrefix);
 
     return $this->runHooks($this->commonCiviModules, $fnSuffix,
-      $numParams, $arg1, $arg2, $arg3, $arg4, $arg5
+      $numParams, $arg1, $arg2, $arg3, $arg4, $arg5, $arg6
     );
   }
 
@@ -127,7 +127,7 @@ abstract class CRM_Utils_Hook {
   }
 
   function runHooks($civiModules, $fnSuffix, $numParams,
-    &$arg1, &$arg2, &$arg3, &$arg4, &$arg5
+    &$arg1, &$arg2, &$arg3, &$arg4, &$arg5, &$arg6
   ) {
     // $civiModules is *not* passed by reference because runHooks
     // must be reentrant. PHP is finicky about running
@@ -164,6 +164,10 @@ abstract class CRM_Utils_Hook {
               $fResult = $fnName($arg1, $arg2, $arg3, $arg4, $arg5);
               break;
 
+            case 6:
+              $fResult = $fnName($arg1, $arg2, $arg3, $arg4, $arg5, $arg6);
+              break;
+              
             default:
               CRM_Core_Error::fatal(ts('Invalid hook invocation'));
               break;
@@ -208,7 +212,7 @@ abstract class CRM_Utils_Hook {
    * @access public
    */
   static function pre($op, $objectName, $id, &$params) {
-    return self::singleton()->invoke(4, $op, $objectName, $id, $params, $op, 'civicrm_pre');
+    return self::singleton()->invoke(4, $op, $objectName, $id, $params, self::$_nullObject, self::$_nullObject, 'civicrm_pre');
   }
 
   /**
@@ -224,7 +228,7 @@ abstract class CRM_Utils_Hook {
    * @access public
    */
   static function post($op, $objectName, $objectId, &$objectRef) {
-    return self::singleton()->invoke(4, $op, $objectName, $objectId, $objectRef, $op, 'civicrm_post');
+    return self::singleton()->invoke(4, $op, $objectName, $objectId, $objectRef, self::$_nullObject, self::$_nullObject, 'civicrm_post');
   }
 
   /**
@@ -234,14 +238,16 @@ abstract class CRM_Utils_Hook {
    * @param string $op         the type of operation being performed
    * @param string $objectName the name of the object
    * @param int    $objectId   the unique identifier for the object
-   * @params array $links      (optional ) the links array (introduced in v3.2)
+   * @param array  $links      (optional) the links array (introduced in v3.2)
+   * @param int    $mask       (optional) the bitmask to show/hide links
+   * @param array  $values     (optional) the values to fill the links
    *
    * @return array|null        an array of arrays, each element is a tuple consisting of id, url, img, title, weight
    *
    * @access public
    */
-  static function links($op, $objectName, &$objectId, &$links, &$mask = NULL) {
-    return self::singleton()->invoke(5, $op, $objectName, $objectId, $links, $mask, 'civicrm_links');
+  static function links($op, $objectName, &$objectId, &$links, &$mask = NULL, &$values = array()) {
+    return self::singleton()->invoke(6, $op, $objectName, $objectId, $links, $mask, $values, 'civicrm_links');
   }
 
   /**
@@ -254,7 +260,7 @@ abstract class CRM_Utils_Hook {
    * @return null the return value is ignored
    */
   static function buildForm($formName, &$form) {
-    return self::singleton()->invoke(2, $formName, $form, $formName, $formName, $formName, 'civicrm_buildForm');
+    return self::singleton()->invoke(2, $formName, $form, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_buildForm');
   }
 
   /**
@@ -267,7 +273,7 @@ abstract class CRM_Utils_Hook {
    * @return null the return value is ignored
    */
   static function postProcess($formName, &$form) {
-    return self::singleton()->invoke(2, $formName, $form, $formName, $formName, $formName, 'civicrm_postProcess');
+    return self::singleton()->invoke(2, $formName, $form, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_postProcess');
   }
 
   /**
@@ -284,7 +290,7 @@ abstract class CRM_Utils_Hook {
    * @access public
    */
   static function validate($formName, &$fields, &$files, &$form) {
-    return self::singleton()->invoke(4, $formName, $fields, $files, $form, $formName, 'civicrm_validate');
+    return self::singleton()->invoke(4, $formName, $fields, $files, $form, self::$_nullObject, self::$_nullObject, 'civicrm_validate');
   }
 
   /**
@@ -302,7 +308,7 @@ abstract class CRM_Utils_Hook {
    * @access public
    */
   static function validateForm($formName, &$fields, &$files, &$form, &$errors) {
-    return self::singleton()->invoke(5, $formName, $fields, $files, $form, $errors, 'civicrm_validateForm');
+    return self::singleton()->invoke(5, $formName, $fields, $files, $form, $errors, self::$_nullObject, 'civicrm_validateForm');
   }
 
   /**
@@ -317,7 +323,7 @@ abstract class CRM_Utils_Hook {
    * @access public
    */
   static function custom($op, $groupID, $entityID, &$params) {
-    return self::singleton()->invoke(4, $op, $groupID, $entityID, $params, $op, 'civicrm_custom');
+    return self::singleton()->invoke(4, $op, $groupID, $entityID, $params, self::$_nullObject, self::$_nullObject, 'civicrm_custom');
   }
 
   /**
@@ -334,7 +340,7 @@ abstract class CRM_Utils_Hook {
    * @access public
    */
   static function aclWhereClause($type, &$tables, &$whereTables, &$contactID, &$where) {
-    return self::singleton()->invoke(5, $type, $tables, $whereTables, $contactID, $where, 'civicrm_aclWhereClause');
+    return self::singleton()->invoke(5, $type, $tables, $whereTables, $contactID, $where, self::$_nullObject, 'civicrm_aclWhereClause');
   }
 
   /**
@@ -351,7 +357,7 @@ abstract class CRM_Utils_Hook {
    * @access public
    */
   static function aclGroup($type, $contactID, $tableName, &$allGroups, &$currentGroups) {
-    return self::singleton()->invoke(5, $type, $contactID, $tableName, $allGroups, $currentGroups, 'civicrm_aclGroup');
+    return self::singleton()->invoke(5, $type, $contactID, $tableName, $allGroups, $currentGroups, self::$_nullObject, 'civicrm_aclGroup');
   }
 
   /**
@@ -364,7 +370,7 @@ abstract class CRM_Utils_Hook {
    */
   static function xmlMenu(&$files) {
     return self::singleton()->invoke(1, $files,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_xmlMenu'
     );
   }
@@ -379,7 +385,7 @@ abstract class CRM_Utils_Hook {
    */
   static function managed(&$entities) {
     return self::singleton()->invoke(1, $entities,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_managed'
     );
   }
@@ -396,7 +402,7 @@ abstract class CRM_Utils_Hook {
    */
   static function dashboard($contactID, &$contentPlacement = self::DASHBOARD_BELOW) {
     $retval = self::singleton()->invoke(2, $contactID, $contentPlacement,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_dashboard'
     );
 
@@ -422,7 +428,7 @@ abstract class CRM_Utils_Hook {
    */
   static function recent(&$recentArray) {
     return self::singleton()->invoke(1, $recentArray,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_recent'
     );
   }
@@ -439,7 +445,7 @@ abstract class CRM_Utils_Hook {
    */
   static function buildAmount($pageType, &$form, &$amount) {
     return self::singleton()->invoke(3, $pageType, $form, $amount, self::$_nullObject,
-      self::$_nullObject, 'civicrm_buildAmount');
+      self::$_nullObject, self::$_nullObject, 'civicrm_buildAmount');
   }
 
   /**
@@ -452,7 +458,7 @@ abstract class CRM_Utils_Hook {
    */
   static function buildStateProvinceForCountry($countryID, &$states) {
     return self::singleton()->invoke(2, $countryID, $states,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_buildStateProvinceForCountry'
     );
   }
@@ -468,7 +474,7 @@ abstract class CRM_Utils_Hook {
    */
   static function tabs(&$tabs, $contactID) {
     return self::singleton()->invoke(2, $tabs, $contactID,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_tabs'
+      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_tabs'
     );
   }
 
@@ -484,7 +490,7 @@ abstract class CRM_Utils_Hook {
    */
   static function tabset($tabsetName, &$tabs, $context) {
     return self::singleton()->invoke(3, $tabsetName, $tabs,
-      $context, self::$_nullObject, self::$_nullObject, 'civicrm_tabset'
+      $context, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_tabset'
     );
   }
 
@@ -498,7 +504,7 @@ abstract class CRM_Utils_Hook {
    */
   static function tokens(&$tokens) {
     return self::singleton()->invoke(1, $tokens,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_tokens'
+      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_tokens'
     );
   }
 
@@ -521,7 +527,7 @@ abstract class CRM_Utils_Hook {
     $tokens    = array(),
     $className = NULL
   ) {
-    return self::singleton()->invoke(5, $details, $contactIDs, $jobID, $tokens, $className, 'civicrm_tokenValues');
+    return self::singleton()->invoke(5, $details, $contactIDs, $jobID, $tokens, $className, self::$_nullObject, 'civicrm_tokenValues');
   }
 
   /**
@@ -535,7 +541,7 @@ abstract class CRM_Utils_Hook {
    */
   static function pageRun(&$page) {
     return self::singleton()->invoke(1, $page,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_pageRun'
     );
   }
@@ -552,7 +558,7 @@ abstract class CRM_Utils_Hook {
    */
   static function copy($objectName, &$object) {
     return self::singleton()->invoke(2, $objectName, $object,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_copy'
     );
   }
@@ -569,7 +575,7 @@ abstract class CRM_Utils_Hook {
    *
    **/
   static function unsubscribeGroups($op, $mailingId, $contactId, &$groups, &$baseGroups) {
-    return self::singleton()->invoke(5, $op, $mailingId, $contactId, $groups, $baseGroups, 'civicrm_unsubscribeGroups');
+    return self::singleton()->invoke(5, $op, $mailingId, $contactId, $groups, $baseGroups, self::$_nullObject, 'civicrm_unsubscribeGroups');
   }
 
   /**
@@ -587,7 +593,7 @@ abstract class CRM_Utils_Hook {
    */
   static function customFieldOptions($customFieldID, &$options, $detailedFormat = FALSE) {
     return self::singleton()->invoke(3, $customFieldID, $options, $detailedFormat,
-      self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_customFieldOptions'
     );
   }
@@ -609,14 +615,14 @@ abstract class CRM_Utils_Hook {
    */
   static function searchTasks($objectType, &$tasks) {
     return self::singleton()->invoke(2, $objectType, $tasks,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_searchTasks'
     );
   }
 
   static function eventDiscount(&$form, &$params) {
     return self::singleton()->invoke(2, $form, $params,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_eventDiscount'
     );
   }
@@ -630,7 +636,7 @@ abstract class CRM_Utils_Hook {
    */
   static function mailingGroups(&$form, &$groups, &$mailings) {
     return self::singleton()->invoke(3, $form, $groups, $mailings,
-      self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_mailingGroups'
     );
   }
@@ -647,7 +653,7 @@ abstract class CRM_Utils_Hook {
    */
   static function membershipTypeValues(&$form, &$membershipTypes) {
     return self::singleton()->invoke(2, $form, $membershipTypes,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_membershipTypeValues'
     );
   }
@@ -664,7 +670,7 @@ abstract class CRM_Utils_Hook {
    */
   static function summary($contactID, &$content, &$contentPlacement = self::SUMMARY_BELOW) {
     return self::singleton()->invoke(3, $contactID, $content, $contentPlacement,
-      self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_summary'
     );
   }
@@ -689,7 +695,7 @@ abstract class CRM_Utils_Hook {
    */
   static function contactListQuery(&$query, $name, $context, $id) {
     return self::singleton()->invoke(4, $query, $name, $context, $id,
-      self::$_nullObject,
+      self::$_nullObject, self::$_nullObject,
       'civicrm_contactListQuery'
     );
   }
@@ -716,7 +722,7 @@ abstract class CRM_Utils_Hook {
     &$cookedParams
   ) {
     return self::singleton()->invoke(3, $paymentObj, $rawParams, $cookedParams,
-      self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_alterPaymentProcessorParams'
     );
   }
@@ -730,7 +736,7 @@ abstract class CRM_Utils_Hook {
    */
   static function alterMailParams(&$params, $context = NULL) {
     return self::singleton()->invoke(2, $params, $context,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_alterMailParams'
     );
   }
@@ -746,7 +752,7 @@ abstract class CRM_Utils_Hook {
    */
   static function caseSummary($caseID) {
     return self::singleton()->invoke(1, $caseID,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_caseSummary'
     );
   }
@@ -758,7 +764,7 @@ abstract class CRM_Utils_Hook {
    * @return void
    */
   static function caseTypes(&$caseTypes) {
-    return self::singleton()->invoke(1, $caseTypes, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_caseTypes');
+    return self::singleton()->invoke(1, $caseTypes, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_caseTypes');
   }
 
   /**
@@ -769,14 +775,14 @@ abstract class CRM_Utils_Hook {
    */
   static function config(&$config) {
     return self::singleton()->invoke(1, $config,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_config'
     );
   }
 
   static function enableDisable($recordBAO, $recordID, $isActive) {
     return self::singleton()->invoke(3, $recordBAO, $recordID, $isActive,
-      self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_enableDisable'
     );
   }
@@ -791,7 +797,7 @@ abstract class CRM_Utils_Hook {
    */
   static function optionValues(&$options, $name) {
     return self::singleton()->invoke(2, $options, $name,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_optionValues'
     );
   }
@@ -804,7 +810,7 @@ abstract class CRM_Utils_Hook {
    */
   static function navigationMenu(&$params) {
     return self::singleton()->invoke(1, $params,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_navigationMenu'
     );
   }
@@ -821,7 +827,7 @@ abstract class CRM_Utils_Hook {
    * @access public
    */
   static function merge($type, &$data, $mainId = NULL, $otherId = NULL, $tables = NULL) {
-    return self::singleton()->invoke(5, $type, $data, $mainId, $otherId, $tables, 'civicrm_merge');
+    return self::singleton()->invoke(5, $type, $data, $mainId, $otherId, $tables, self::$_nullObject, 'civicrm_merge');
   }
 
   /**
@@ -833,7 +839,7 @@ abstract class CRM_Utils_Hook {
    */
   static function notePrivacy(&$noteValues) {
     return self::singleton()->invoke(1, $noteValues,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_notePrivacy'
     );
   }
@@ -851,7 +857,7 @@ abstract class CRM_Utils_Hook {
    */
   static function export(&$exportTempTable, &$headerRows, &$sqlColumns, &$exportMode) {
     return self::singleton()->invoke(4, $exportTempTable, $headerRows, $sqlColumns, $exportMode,
-      self::$_nullObject,
+      self::$_nullObject, self::$_nullObject,
       'civicrm_export'
     );
   }
@@ -867,7 +873,7 @@ abstract class CRM_Utils_Hook {
    */
   static function dupeQuery($obj, $type, &$query) {
     return self::singleton()->invoke(3, $obj, $type, $query,
-      self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_dupeQuery'
     );
   }
@@ -884,7 +890,7 @@ abstract class CRM_Utils_Hook {
    * @access public
    */
   static function emailProcessor($type, &$params, $mail, &$result, $action = NULL) {
-    return self::singleton()->invoke(5, $type, $params, $mail, $result, $action, 'civicrm_emailProcessor');
+    return self::singleton()->invoke(5, $type, $params, $mail, $result, $action, self::$_nullObject, 'civicrm_emailProcessor');
   }
 
   /**
@@ -907,7 +913,7 @@ abstract class CRM_Utils_Hook {
    */
   static function import($object, $usage, &$objectRef, &$params) {
     return self::singleton()->invoke(4, $object, $usage, $objectRef, $params,
-      self::$_nullObject,
+      self::$_nullObject, self::$_nullObject,
       'civicrm_import'
     );
   }
@@ -923,7 +929,7 @@ abstract class CRM_Utils_Hook {
    */
   static function alterAPIPermissions($entity, $action, &$params, &$permissions) {
     return self::singleton()->invoke(4, $entity, $action, $params, $permissions,
-      self::$_nullObject,
+      self::$_nullObject, self::$_nullObject,
       'civicrm_alterAPIPermissions'
     );
   }
@@ -931,7 +937,7 @@ abstract class CRM_Utils_Hook {
   static function postSave(&$dao) {
     $hookName = 'civicrm_postSave_' . $dao->getTableName();
     return self::singleton()->invoke(1, $dao,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       $hookName
     );
   }
@@ -944,7 +950,7 @@ abstract class CRM_Utils_Hook {
    */
   static function summaryActions(&$actions, $contactID = NULL) {
     return self::singleton()->invoke(2, $actions, $contactID,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_summaryActions'
     );
   }
@@ -969,7 +975,7 @@ abstract class CRM_Utils_Hook {
    */
   static function searchColumns($objectName, &$headers, &$rows, &$selector) {
     return self::singleton()->invoke(4, $objectName, $headers, $rows, $selector,
-      self::$_nullObject,
+      self::$_nullObject, self::$_nullObject,
       'civicrm_searchColumns'
     );
   }
@@ -985,7 +991,7 @@ abstract class CRM_Utils_Hook {
    */
   static function buildUFGroupsForModule($moduleName, &$ufGroups) {
     return self::singleton()->invoke(2, $moduleName, $ufGroups,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_buildUFGroupsForModule'
     );
   }
@@ -1008,7 +1014,7 @@ abstract class CRM_Utils_Hook {
    */
   static function emailProcessorContact($email, $contactID, &$result) {
     return self::singleton()->invoke(3, $email, $contactID, $result,
-      self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_emailProcessorContact'
     );
   }
@@ -1047,7 +1053,7 @@ abstract class CRM_Utils_Hook {
   static function alterMailingLabelParams(&$args) {
     return self::singleton()->invoke(1, $args,
       self::$_nullObject, self::$_nullObject,
-      self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_alterMailingLabelParams'
     );
   }
@@ -1064,7 +1070,7 @@ abstract class CRM_Utils_Hook {
    */
   static function alterContent(&$content, $context, $tplName, &$object) {
     return self::singleton()->invoke(4, $content, $context, $tplName, $object,
-      self::$_nullObject,
+      self::$_nullObject, self::$_nullObject,
       'civicrm_alterContent'
     );
   }
@@ -1082,7 +1088,7 @@ abstract class CRM_Utils_Hook {
    */
   static function alterTemplateFile($formName, &$form, $context, &$tplName) {
     return self::singleton()->invoke(4, $formName, $form, $context, $tplName,
-      self::$_nullObject,
+      self::$_nullObject, self::$_nullObject,
       'civicrm_alterTemplateFile'
     );
   }
@@ -1102,7 +1108,7 @@ abstract class CRM_Utils_Hook {
    */
   static function triggerInfo(&$info, $tableName = NULL) {
     return self::singleton()->invoke(2, $info, $tableName,
-      self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject,
       self::$_nullObject,
       'civicrm_triggerInfo'
     );
@@ -1116,7 +1122,7 @@ abstract class CRM_Utils_Hook {
   static function install() {
     return self::singleton()->invoke(0, self::$_nullObject,
       self::$_nullObject, self::$_nullObject,
-      self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_install'
     );
   }
@@ -1129,7 +1135,7 @@ abstract class CRM_Utils_Hook {
   static function uninstall() {
     return self::singleton()->invoke(0, self::$_nullObject,
       self::$_nullObject, self::$_nullObject,
-      self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_uninstall'
     );
   }
@@ -1142,7 +1148,7 @@ abstract class CRM_Utils_Hook {
   static function enable() {
     return self::singleton()->invoke(0, self::$_nullObject,
       self::$_nullObject, self::$_nullObject,
-      self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_enable'
     );
   }
@@ -1155,7 +1161,7 @@ abstract class CRM_Utils_Hook {
   static function disable() {
     return self::singleton()->invoke(0, self::$_nullObject,
       self::$_nullObject, self::$_nullObject,
-      self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_disable'
     );
   }
@@ -1163,7 +1169,7 @@ abstract class CRM_Utils_Hook {
   static function alterReportVar($varType, &$var, &$object) {
     return self::singleton()->invoke(3, $varType, $var, $object,
       self::$_nullObject,
-      self::$_nullObject,
+      self::$_nullObject, self::$_nullObject,
       'civicrm_alterReportVar'
     );
   }
@@ -1180,7 +1186,7 @@ abstract class CRM_Utils_Hook {
    */
   static function upgrade($op, CRM_Queue_Queue $queue = NULL) {
     return self::singleton()->invoke(2, $op, $queue,
-      self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject,
       self::$_nullObject,
       'civicrm_upgrade'
     );
@@ -1195,7 +1201,7 @@ abstract class CRM_Utils_Hook {
   static function postEmailSend(&$params) {
     return self::singleton()->invoke(1, $params,
       self::$_nullObject, self::$_nullObject,
-      self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_postEmailSend'
     );
   }
@@ -1208,7 +1214,7 @@ abstract class CRM_Utils_Hook {
   static function alterSettingsFolders(&$settingsFolders) {
     return self::singleton()->invoke(1, $settingsFolders,
         self::$_nullObject, self::$_nullObject,
-        self::$_nullObject, self::$_nullObject,
+        self::$_nullObject, self::$_nullObject, self::$_nullObject,
         'civicrm_alterSettingsFolders'
     );
   }
@@ -1223,7 +1229,7 @@ abstract class CRM_Utils_Hook {
   static function alterSettingsMetaData(&$settingsMetaData, $domainID, $profile) {
     return self::singleton()->invoke(3, $settingsMetaData,
         $domainID, $profile,
-        self::$_nullObject, self::$_nullObject,
+        self::$_nullObject, self::$_nullObject, self::$_nullObject,
         'civicrm_alterSettingsMetaData'
     );
   }
@@ -1239,7 +1245,7 @@ abstract class CRM_Utils_Hook {
   static function apiWrappers(&$wrappers, $apiRequest) {
     return self::singleton()
       ->invoke(2, $wrappers, $apiRequest, self::$_nullObject, self::$_nullObject, self::$_nullObject,
-      'civicrm_apiWrappers'
+      self::$_nullObject, 'civicrm_apiWrappers'
     );
   }
 
@@ -1253,7 +1259,7 @@ abstract class CRM_Utils_Hook {
    */
   static function cron($jobManager) {
     return self::singleton()->invoke(1,
-      $jobManager, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $jobManager, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_cron'
     );
   }
@@ -1270,7 +1276,7 @@ abstract class CRM_Utils_Hook {
    */
   static function permission(&$permissions) {
     return self::singleton()->invoke(1, $permissions,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_permission'
     );
   }
@@ -1289,7 +1295,7 @@ abstract class CRM_Utils_Hook {
    */
   static function entityTypes(&$entityTypes) {
     return self::singleton()->invoke(1, $entityTypes, self::$_nullObject, self::$_nullObject,
-      self::$_nullObject, self::$_nullObject, 'civicrm_entityTypes'
+      self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_entityTypes'
     );
   }
 
@@ -1301,7 +1307,7 @@ abstract class CRM_Utils_Hook {
    */
   static function buildProfile($name) {
     return self::singleton()->invoke(1, $name, self::$_nullObject, self::$_nullObject, self::$_nullObject,
-      self::$_nullObject, 'civicrm_buildProfile');
+      self::$_nullObject, self::$_nullObject, 'civicrm_buildProfile');
   }
 
   /**
@@ -1312,7 +1318,7 @@ abstract class CRM_Utils_Hook {
    */
   static function validateProfile($name) {
     return self::singleton()->invoke(1, $name, self::$_nullObject, self::$_nullObject, self::$_nullObject,
-      self::$_nullObject, 'civicrm_validateProfile');
+      self::$_nullObject, self::$_nullObject, 'civicrm_validateProfile');
   }
 
   /**
@@ -1323,7 +1329,7 @@ abstract class CRM_Utils_Hook {
    */
   static function processProfile($name) {
     return self::singleton()->invoke(1, $name, self::$_nullObject, self::$_nullObject, self::$_nullObject,
-      self::$_nullObject, 'civicrm_processProfile');
+      self::$_nullObject, self::$_nullObject, 'civicrm_processProfile');
   }
 
   /**
@@ -1334,7 +1340,7 @@ abstract class CRM_Utils_Hook {
    */
   static function viewProfile($name) {
     return self::singleton()->invoke(1, $name, self::$_nullObject, self::$_nullObject, self::$_nullObject,
-      self::$_nullObject, 'civicrm_viewProfile');
+      self::$_nullObject, self::$_nullObject, 'civicrm_viewProfile');
   }
 
   /**
@@ -1345,7 +1351,7 @@ abstract class CRM_Utils_Hook {
    */
   static function searchProfile($name) {
     return self::singleton()->invoke(1, $name, self::$_nullObject, self::$_nullObject, self::$_nullObject,
-      self::$_nullObject, 'civicrm_searchProfile');
+      self::$_nullObject, self::$_nullObject, 'civicrm_searchProfile');
   }
 
   /**
@@ -1359,7 +1365,7 @@ abstract class CRM_Utils_Hook {
    */
   static function alterBarcode( &$data, $type = 'barcode', $context = 'name_badge' ) {
     return self::singleton()->invoke(3, $data, $type, $context, self::$_nullObject,
-      self::$_nullObject, 'civicrm_alterBarcode');
+      self::$_nullObject, self::$_nullObject, 'civicrm_alterBarcode');
   }
 
   /**
@@ -1375,7 +1381,7 @@ abstract class CRM_Utils_Hook {
    */
   static function alterMail(&$mailer, $driver, $params) {
     return self::singleton()
-      ->invoke(3, $mailer, $driver, $params, self::$_nullObject, self::$_nullObject, 'civicrm_alterMailer');
+      ->invoke(3, $mailer, $driver, $params, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_alterMailer');
   }
 
   /**
@@ -1386,6 +1392,6 @@ abstract class CRM_Utils_Hook {
    * @return void
    */
   static function queryObjects(&$queryObjects, $type = 'Contact') {
-    return self::singleton()->invoke(2, $queryObjects, $type, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_queryObjects');
+    return self::singleton()->invoke(2, $queryObjects, $type, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_queryObjects');
   }
 }

--- a/CRM/Utils/Hook/Drupal.php
+++ b/CRM/Utils/Hook/Drupal.php
@@ -56,14 +56,14 @@ class CRM_Utils_Hook_Drupal extends CRM_Utils_Hook {
   private $drupalModules = NULL;
 
   function invoke($numParams,
-                  &$arg1, &$arg2, &$arg3, &$arg4, &$arg5,
+                  &$arg1, &$arg2, &$arg3, &$arg4, &$arg5, &$arg6,
                   $fnSuffix
   ) {
 
     $this->buildModuleList();
 
     return $this->runHooks($this->allModules, $fnSuffix,
-      $numParams, $arg1, $arg2, $arg3, $arg4, $arg5
+      $numParams, $arg1, $arg2, $arg3, $arg4, $arg5, $arg6
     );
   }
 

--- a/CRM/Utils/Hook/Drupal6.php
+++ b/CRM/Utils/Hook/Drupal6.php
@@ -55,14 +55,14 @@ class CRM_Utils_Hook_Drupal6 extends CRM_Utils_Hook {
   private $drupalModules = NULL;
 
   function invoke($numParams,
-    &$arg1, &$arg2, &$arg3, &$arg4, &$arg5,
+    &$arg1, &$arg2, &$arg3, &$arg4, &$arg5, &$arg6,
     $fnSuffix
   ) {
 
     $this->buildModuleList();
 
     return $this->runHooks($this->allModules, $fnSuffix,
-      $numParams, $arg1, $arg2, $arg3, $arg4, $arg5
+      $numParams, $arg1, $arg2, $arg3, $arg4, $arg5, $arg6
     );
   }
 

--- a/CRM/Utils/Hook/Joomla.php
+++ b/CRM/Utils/Hook/Joomla.php
@@ -35,7 +35,7 @@
  */
 class CRM_Utils_Hook_Joomla extends CRM_Utils_Hook {
   function invoke($numParams,
-                  &$arg1, &$arg2, &$arg3, &$arg4, &$arg5,
+                  &$arg1, &$arg2, &$arg3, &$arg4, &$arg5, &$arg6
                   $fnSuffix
   ) {
     // ensure that we are running in a joomla context
@@ -60,10 +60,10 @@ class CRM_Utils_Hook_Joomla extends CRM_Utils_Hook {
         }
       }
 
-      $result = $app->triggerEvent($fnSuffix, array(&$arg1, &$arg2, &$arg3, &$arg4, &$arg5));
+      $result = $app->triggerEvent($fnSuffix, array(&$arg1, &$arg2, &$arg3, &$arg4, &$arg5, &$arg6));
 
       $moduleResult = $this->commonInvoke($numParams,
-        $arg1, $arg2, $arg3, $arg4, $arg5,
+        $arg1, $arg2, $arg3, $arg4, $arg5, $arg6,
         $fnSuffix, 'joomla');
       if (!empty($moduleResult) && is_array($moduleResult)) {
         if (empty($result)) {

--- a/CRM/Utils/Hook/Soap.php
+++ b/CRM/Utils/Hook/Soap.php
@@ -35,7 +35,7 @@
  */
 class CRM_Utils_Hook_Soap extends CRM_Utils_Hook {
   function invoke($numParams,
-    &$arg1, &$arg2, &$arg3, &$arg4, &$arg5,
+    &$arg1, &$arg2, &$arg3, &$arg4, &$arg5, &$arg6,
     $fnSuffix
   ) {
     // suppress all hok calls during soap

--- a/CRM/Utils/Hook/UnitTests.php
+++ b/CRM/Utils/Hook/UnitTests.php
@@ -61,19 +61,19 @@ class CRM_Utils_Hook_UnitTests extends CRM_Utils_Hook {
   }
 
   function invoke($numParams,
-    &$arg1, &$arg2, &$arg3, &$arg4, &$arg5,
+    &$arg1, &$arg2, &$arg3, &$arg4, &$arg5, &$arg6,
     $fnSuffix) {
 
-    $params = array( &$arg1, &$arg2, &$arg3, &$arg4, &$arg5);
+    $params = array( &$arg1, &$arg2, &$arg3, &$arg4, &$arg5, &$arg6);
 
     if ($this->civiModules === NULL) {
       $this->civiModules = array();
       $this->requireCiviModules($this->civiModules);
     }
-    $this->runHooks($this->civiModules, $fnSuffix, $numParams, $arg1, $arg2, $arg3, $arg4, $arg5);
+    $this->runHooks($this->civiModules, $fnSuffix, $numParams, $arg1, $arg2, $arg3, $arg4, $arg5, $arg6);
 
     if ($this->mockObject && is_callable(array($this->mockObject, $fnSuffix))) {
-      call_user_func(array($this->mockObject, $fnSuffix), $arg1, $arg2, $arg3, $arg4, $arg5);
+      call_user_func(array($this->mockObject, $fnSuffix), $arg1, $arg2, $arg3, $arg4, $arg5, $arg6);
     }
     if (!empty($this->adhocHooks[$fnSuffix])) {
       call_user_func_array($this->adhocHooks[$fnSuffix], $params );

--- a/CRM/Utils/Hook/WordPress.php
+++ b/CRM/Utils/Hook/WordPress.php
@@ -34,11 +34,11 @@
  */
 class CRM_Utils_Hook_WordPress extends CRM_Utils_Hook {
   function invoke($numParams,
-    &$arg1, &$arg2, &$arg3, &$arg4, &$arg5,
+    &$arg1, &$arg2, &$arg3, &$arg4, &$arg5, &$arg6,
     $fnSuffix
   ) {
     return $this->commonInvoke($numParams,
-      $arg1, $arg2, $arg3, $arg4, $arg5,
+      $arg1, $arg2, $arg3, $arg4, $arg5, $arg6,
       $fnSuffix, 'wordpress'
     );
   }

--- a/templates/CRM/Activity/Form/ActivityLinks.tpl
+++ b/templates/CRM/Activity/Form/ActivityLinks.tpl
@@ -47,11 +47,11 @@
 {if $hookLinks}
    {foreach from=$hookLinks item=link}
     <li>
-        <a href="{$link.url}">
+        <a href="{$link.url}"{if $link.title} title="{$link.title}"{/if}>
           {if $link.img}
                 <img src="{$link.img}" alt="{$link.title}" />&nbsp;
           {/if}
-          {$link.title}
+          {$link.name}
         </a>
     </li>
    {/foreach}


### PR DESCRIPTION
There are tons of places action links in CiviCRM, but practically none can be altered through hook_civicrm_links.  This change does several things:
- It provides the relevant information (operation, object name, and object ID) to hook_civicrm_links to meet the promise of what that hook is trying to do for all the action links I could find.
- It passes the fill-in values for the URLs to the hook (requiring changes to the hook structure to allow a 6th argument).  Otherwise, it's hard to get enough context in many places or to edit the links in a meaningful way.
- It indexes the links sequentially instead of by binary values that are filtered by bitmask.  The old method was making it next to impossible to be sure an added link won't be filtered out or overwrite another link.  This has the side benefit of allowing you to add additional links that show or hide based on the bitmask.
