### PR TITLE
CRM-13667

### DIFF
--- a/CRM/Core/BAO/CMSUser.php
+++ b/CRM/Core/BAO/CMSUser.php
@@ -160,9 +160,7 @@ class CRM_Core_BAO_CMSUser {
       $contactMatching = 0;
 
       global $wpdb;
-      $wpUserIds = $wpdb->get_col(
-        $wpdb->prepare("SELECT $wpdb->users.ID FROM $wpdb->users")
-      );
+      $wpUserIds = $wpdb->get_col("SELECT $wpdb->users.ID FROM $wpdb->users");
 
       foreach ($wpUserIds as $wpUserId) {
         $wpUserData = get_userdata($wpUserId);


### PR DESCRIPTION
as per the patch mentioned in forum link : http://forum.civicrm.org/index.php/topic,29754.0.html 

This warning was introduced after wordpress 3.5 release : 

http://make.wordpress.org/core/2012/12/12/php-warning-missing-argument-2-for-wpdb-prepare/
http://wordpress.org/support/topic/warning-missing-argument-2-for-wpdbprepare-3

---
- CRM-13667: WP Sync Users Error
  http://issues.civicrm.org/jira/browse/CRM-13667
