### PR TITLE
CRM-13434 make create.new.shorcuts work for name or title

### DIFF
--- a/CRM/Core/Block.php
+++ b/CRM/Core/Block.php
@@ -422,6 +422,12 @@ class CRM_Core_Block {
       CRM_Core_DAO::$_nullObject,
       CRM_Core_DAO::$_nullObject
     );
+    
+    foreach ($values as $key => $val) {
+      if (CRM_Utils_Array::value('title', $val)) {
+        $values[$key]['name'] = CRM_Utils_Array::value('name', $val, $val['title']);
+      }
+    }
 
     self::setProperty(self::CREATE_NEW, 'templateValues', array('shortCuts' => $values));
   }


### PR DESCRIPTION
Unlike all the others, the Create New shortcuts call the label "titie" instead of "name".  In order to be backwards-compatible for old extensions that use hook_civicrm_links, "title" should work, but "name" should take priority so it's consistent with everything else.
