### PR TITLE
CRM-13434 - use empty instead of Array::value

### DIFF
--- a/CRM/Core/Block.php
+++ b/CRM/Core/Block.php
@@ -422,9 +422,9 @@ class CRM_Core_Block {
       CRM_Core_DAO::$_nullObject,
       CRM_Core_DAO::$_nullObject
     );
-    
+
     foreach ($values as $key => $val) {
-      if (CRM_Utils_Array::value('title', $val)) {
+      if (!empty($val['title'])) {
         $values[$key]['name'] = CRM_Utils_Array::value('name', $val, $val['title']);
       }
     }


### PR DESCRIPTION
---
- CRM-13434: Send more through hook_civicrm_links
  http://issues.civicrm.org/jira/browse/CRM-13434
