### PR TITLE
CRM-13682 option for page breaks before report section headers

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -957,7 +957,7 @@ class CRM_Report_Form extends CRM_Core_Form {
         $this->addElement('select', "order_bys[{$i}][column]", ts('Order by Column'), $options);
         $this->addElement('select', "order_bys[{$i}][order]", ts('Order by Order'), array('ASC' => 'Ascending', 'DESC' => 'Descending'));
         $this->addElement('checkbox', "order_bys[{$i}][section]", ts('Order by Section'), FALSE, array('id' => "order_by_section_$i"));
-        $this->addElement('checkbox', "order_bys[{$i}][pageBreak]", ts('Page Break'), FALSE, array('id' => "order_by_section_$i"));
+        $this->addElement('checkbox', "order_bys[{$i}][pageBreak]", ts('Page Break'), FALSE, array('id' => "order_by_pagebreak_$i"));
       }
     }
   }

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -957,6 +957,7 @@ class CRM_Report_Form extends CRM_Core_Form {
         $this->addElement('select', "order_bys[{$i}][column]", ts('Order by Column'), $options);
         $this->addElement('select', "order_bys[{$i}][order]", ts('Order by Order'), array('ASC' => 'Ascending', 'DESC' => 'Descending'));
         $this->addElement('checkbox', "order_bys[{$i}][section]", ts('Order by Section'), FALSE, array('id' => "order_by_section_$i"));
+        $this->addElement('checkbox', "order_bys[{$i}][pageBreak]", ts('Page Break'), FALSE, array('id' => "order_by_section_$i"));
       }
     }
   }
@@ -2152,6 +2153,7 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
 
           // Record any section headers for assignment to the template
           if (CRM_Utils_Array::value('section', $orderBy)) {
+            $orderByField['pageBreak'] = CRM_Utils_Array::value('pageBreak', $orderBy);
             $this->_sections[$orderByField['tplField']] = $orderByField;
           }
         }

--- a/css/print.css
+++ b/css/print.css
@@ -74,6 +74,10 @@ table.form-layout td, table.form-layout th {
    border-top       : 2px groove #DCDCDC;
 }
 
+#crm-container table.report-layout tr.crm-report-sectionHeader.page-break {
+  page-break-before: always;
+}
+
 #crm-container .report-label {
     text-align       : right;
     font-weight      : bold;

--- a/templates/CRM/Report/Form/Criteria.tpl
+++ b/templates/CRM/Report/Form/Criteria.tpl
@@ -134,6 +134,17 @@
 
             // hide and display the appropriate blocks as directed by the php code
             on_load_init_blocks( showRows, hideBlocks, '' );
+            
+            cj('input[id^="order_by_section_"]').click(disPageBreak).each(disPageBreak);
+            
+            function disPageBreak() {
+              if (!cj(this).attr('checked')) {
+                cj(this).parent('td').next('td').children('input[id^="order_by_pagebreak_"]').attr({checked: false, disabled: "disabled"});
+              }
+              else {
+                cj(this).parent('td').next('td').children('input[id^="order_by_pagebreak_"]').attr({disabled: false});
+              }
+            }
 
             function hideRow(i) {
                 showHideRow(i);
@@ -141,7 +152,7 @@
                 cj('select#order_by_column_'+ i).val('');
                 cj('select#order_by_order_'+ i).val('ASC');
                 cj('input#order_by_section_'+ i).attr('checked', false);
-                cj('input#order_by_pageBreak_'+ i).attr('checked', false);
+                cj('input#order_by_pagebreak_'+ i).attr('checked', false);
             }
 
             {/literal}

--- a/templates/CRM/Report/Form/Criteria.tpl
+++ b/templates/CRM/Report/Form/Criteria.tpl
@@ -99,6 +99,7 @@
         <th> Column</th>
         <th> Order</th>
         <th> Section Header / Group By</th>
+        <th> Page Break</th>
         </tr>
 
   {section name=rowLoop start=1 loop=6}
@@ -112,6 +113,7 @@
         <td> {$form.order_bys.$index.column.html}</td>
         <td> {$form.order_bys.$index.order.html}</td>
         <td> {$form.order_bys.$index.section.html}</td>
+        <td> {$form.order_bys.$index.pageBreak.html}</td>
   </tr>
         {/section}
         </table>
@@ -139,6 +141,7 @@
                 cj('select#order_by_column_'+ i).val('');
                 cj('select#order_by_order_'+ i).val('ASC');
                 cj('input#order_by_section_'+ i).attr('checked', false);
+                cj('input#order_by_pageBreak_'+ i).attr('checked', false);
             }
 
             {/literal}

--- a/templates/CRM/Report/Form/Layout/Table.tpl
+++ b/templates/CRM/Report/Form/Layout/Table.tpl
@@ -81,13 +81,13 @@
                         {$l}assign var=printValue value=$row.{$column}{$r}
                     {$l}/if{$r}
 
-                    <tr><th colspan="{$columnCount}">
+                    <tr class="crm-report-sectionHeader crm-report-sectionHeader-{$h}{if $section.pageBreak} page-break{/if}"><th colspan="{$columnCount}">
                         <h{$h}>{$section.title}: {$l}$printValue|default:"<em>none</em>"{$r}
                             ({$l}sectionTotal key=$row.{$column} depth={$smarty.foreach.sections.index}{$r})
                         </h{$h}>
                     </th></tr>
                     {if $smarty.foreach.sections.last}
-                        <tr>{$l}$tableHeader{$r}</tr>
+                        <tr class="crm-report-sectionCols">{$l}$tableHeader{$r}</tr>
                     {/if}
                 {$l}/if{$r}
             {/foreach}


### PR DESCRIPTION
This adds a checkbox to the Order by Columns section to allow a page break before a section header when printing the report. (The page break doesn't appear in the PDF, probably because DOMPDF doesn't recognize the CSS.)
