### PR TITLE
CRM-13690 - CiviMail - prevent html2text treating mailing tokens as relative URLs

### DIFF
--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -402,7 +402,7 @@ class CRM_Utils_String {
   /**
    * Convert a HTML string into a text one using html2text
    *
-   * @param string $html  the tring to be converted
+   * @param string $html  the string to be converted
    *
    * @return string       the converted string
    * @access public
@@ -410,8 +410,11 @@ class CRM_Utils_String {
    */
   static function htmlToText($html) {
     require_once 'packages/html2text/rcube_html2text.php';
-    $converter = new rcube_html2text($html);
-    return $converter->get_text();
+    $token_html = preg_replace('!\{([a-z_.]+)\}!i', 'token:{$1}', $html);
+    $converter = new rcube_html2text($token_html);
+    $token_text = $converter->get_text();
+    $text = preg_replace('!token\:\{([a-z_.]+)\}!i', '{$1}', $token_text);
+    return $text;
   }
 
   static function extractName($string, &$params) {


### PR DESCRIPTION
When sending a CiviMail with no text part, the text part is generated from the HTML part using the html2text package.

This conversion occurs before token replacement, so html2text has to process links of the form "{action.forward}". html2text thinks these are relative links so it prefixes them giving "http://example.org/{action.forward}". The token processing then converts this to "http://example.org/http://example.org/civicrm/mailing/forward?..." which is invalid. 

What it does is...
- Convert tokens in the HTML to a format html2text thinks is an absolute URL ("{action.unsubscribeUrl}" -> "token:{action.unsubscribeUrl}")
- Run html2text over that
- Convert the Text to undo the first step ("token:{action.unsubscribeUrl}" -> "{action.unsubscribeUrl}")
- Return the Text

Can someone who knows the token code better than I check ...
- The regular expressions for recognising tokens are OK
- The change doesn't interfere with other parts of the HTML (eg, "{" in CSS)
