### PR TITLE
CRM-13695 - cli - set $_SERVER['HTTP_HOST'] from CIVICRM_UF_BASEURL

### DIFF
--- a/bin/cli.class.php
+++ b/bin/cli.class.php
@@ -204,6 +204,15 @@ class civicrm_cli {
     CRM_Core_ClassLoader::singleton()->register();
 
     $this->_config = CRM_Core_Config::singleton();
+    
+    // HTTP_HOST will be 'localhost' unless overwritten with the -s argument.
+    // Now we have a Config object, we can set it from the Base URL.
+    if ($_SERVER['HTTP_HOST'] == 'localhost') {
+        $_SERVER['HTTP_HOST'] = preg_replace(
+                '!^https?://([^/]+)/$!i', 
+                '$1',
+                $this->_config->userFrameworkBaseURL);
+    }
 
     $class = 'CRM_Utils_System_' . $this->_config->userFramework;
 


### PR DESCRIPTION
 The issue I found is that the html2text package uses $_SERVER['HTTP__HOST']. Tinkering with packages seems to be a bad idea (and a number of them refer to $_SERVER['HTTP__HOST'] such as dompdf, html2text, kcfinder, Net, Pager, and tcpdf). The best bet is to change cli.class.php to default $_SERVER['HTTP__HOST'] to the server name contained in the CIVICRM_UF_BASEURL, rather than 'localhost' as is currently done. That would minimise the need to use the -s parameter.

See http://forum.civicrm.org/index.php/topic,30462.0.html
