### PR TITLE
CRM-11881 fix - State/Province required-ness fix if Country doesn't contain it on CiviProfile

### DIFF
--- a/CRM/Contribute/Form/Contribution/OnBehalfOf.php
+++ b/CRM/Contribute/Form/Contribution/OnBehalfOf.php
@@ -152,7 +152,6 @@ class CRM_Contribute_Form_Contribution_OnBehalfOf {
     }
 
     $stateCountryMap = array();
-    $locationTypeId = null;
     foreach ($profileFields as $name => $field) {
       if (in_array($field['field_type'], $fieldTypes)) {
         list($prefixName, $index) = CRM_Utils_System::explode('-', $name, 2);

--- a/CRM/Contribute/Form/Contribution/OnBehalfOf.php
+++ b/CRM/Contribute/Form/Contribution/OnBehalfOf.php
@@ -73,7 +73,7 @@ class CRM_Contribute_Form_Contribution_OnBehalfOf {
       if (!empty($form->_membershipContactID) && $contactID != $form->_membershipContactID) {
         // renewal case - membership being renewed may or may not be for organization
         if (!empty($form->_employers) && array_key_exists($form->_membershipContactID, $form->_employers)) {
-          // if _membershipContactID belongs to employers list, we can say: 
+          // if _membershipContactID belongs to employers list, we can say:
           $form->_relatedOrganizationFound = TRUE;
         }
       } else if (!empty($form->_employers)) {
@@ -152,6 +152,7 @@ class CRM_Contribute_Form_Contribution_OnBehalfOf {
     }
 
     $stateCountryMap = array();
+    $location_type_id = null;
     foreach ($profileFields as $name => $field) {
       if (in_array($field['field_type'], $fieldTypes)) {
         list($prefixName, $index) = CRM_Utils_System::explode('-', $name, 2);
@@ -162,6 +163,14 @@ class CRM_Contribute_Form_Contribution_OnBehalfOf {
           }
 
           $stateCountryMap[$index][$prefixName] = 'onbehalf[' . $name . ']';
+
+          if (count($form->_submitValues)) {
+            $location_type_id = $field['location_type_id'];
+            if(!empty($form->_submitValues['onbehalf']["country-{$location_type_id}"]) &&
+              $prefixName == "state_province") {
+              $field['is_required'] = CRM_Core_Payment_Form::checkRequiredStateProvince($form, "country-{$location_type_id}", TRUE);
+            }
+          }
         }
         elseif (in_array($prefixName, array(
           'organization_name', 'email')) &&

--- a/CRM/Contribute/Form/Contribution/OnBehalfOf.php
+++ b/CRM/Contribute/Form/Contribution/OnBehalfOf.php
@@ -152,7 +152,7 @@ class CRM_Contribute_Form_Contribution_OnBehalfOf {
     }
 
     $stateCountryMap = array();
-    $location_type_id = null;
+    $locationTypeId = null;
     foreach ($profileFields as $name => $field) {
       if (in_array($field['field_type'], $fieldTypes)) {
         list($prefixName, $index) = CRM_Utils_System::explode('-', $name, 2);
@@ -165,10 +165,10 @@ class CRM_Contribute_Form_Contribution_OnBehalfOf {
           $stateCountryMap[$index][$prefixName] = 'onbehalf[' . $name . ']';
 
           if (count($form->_submitValues)) {
-            $location_type_id = $field['location_type_id'];
-            if(!empty($form->_submitValues['onbehalf']["country-{$location_type_id}"]) &&
+            $locationTypeId = $field['location_type_id'];
+            if (!empty($form->_submitValues['onbehalf']["country-{$locationTypeId}"]) &&
               $prefixName == "state_province") {
-              $field['is_required'] = CRM_Core_Payment_Form::checkRequiredStateProvince($form, "country-{$location_type_id}", TRUE);
+              $field['is_required'] = CRM_Core_Payment_Form::checkRequiredStateProvince($form, "country-{$locationTypeId}", TRUE);
             }
           }
         }

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -714,12 +714,12 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
               }
               else {
                 if (count($this->_submitValues)) {
-                  $location_type_id = $field['location_type_id'];
-                  if (array_key_exists("country-{$location_type_id}", $fields) &&
-                  array_key_exists("state_province-{$location_type_id}", $fields) &&
-                    !empty($this->_submitValues["country-{$location_type_id}"])) {
+                  $locationTypeId = $field['location_type_id'];
+                  if (array_key_exists("country-{$locationTypeId}", $fields) &&
+                  array_key_exists("state_province-{$locationTypeId}", $fields) &&
+                    !empty($this->_submitValues["country-{$locationTypeId}"])) {
                     $field['is_required'] =
-                      CRM_Core_Payment_Form::checkRequiredStateProvince($this, "country-{$location_type_id}");
+                      CRM_Core_Payment_Form::checkRequiredStateProvince($this, "country-{$locationTypeId}");
                   }
                 }
               }

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -689,7 +689,6 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
 
         CRM_Core_BAO_Address::checkContactSharedAddressFields($fields, $contactID);
         $addCaptcha = FALSE;
-        $location_type_id = NULL;
         foreach ($fields as $key => $field) {
           if ($viewOnly &&
             isset($field['data_type']) &&

--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -680,6 +680,21 @@ class CRM_Profile_Form extends CRM_Core_Form {
       return FALSE;
     }
 
+    if (count($this->_submitValues)) {
+      $location_type_id = null;
+      foreach ($this->_fields as $field) {
+        if (!empty($field['location_type_id'])) {
+          $location_type_id = $field['location_type_id'];
+        }
+        if (array_key_exists("country-{$location_type_id}", $this->_fields) &&
+          array_key_exists("state_province-{$location_type_id}", $this->_fields) &&
+          !empty($this->_submitValues["country-{$location_type_id}"])) {
+          $this->_fields["state_province-{$location_type_id}"]['is_required'] =
+            CRM_Core_Payment_Form::checkRequiredStateProvince($this, "country-{$location_type_id}");
+        }
+      }
+    }
+
     $this->assign('id', $this->_id);
     $this->assign('mode', $this->_mode);
     $this->assign('action', $this->_action);

--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -681,16 +681,16 @@ class CRM_Profile_Form extends CRM_Core_Form {
     }
 
     if (count($this->_submitValues)) {
-      $location_type_id = null;
+      $locationTypeId = null;
       foreach ($this->_fields as $field) {
         if (!empty($field['location_type_id'])) {
-          $location_type_id = $field['location_type_id'];
+          $locationTypeId = $field['location_type_id'];
         }
-        if (array_key_exists("country-{$location_type_id}", $this->_fields) &&
-          array_key_exists("state_province-{$location_type_id}", $this->_fields) &&
-          !empty($this->_submitValues["country-{$location_type_id}"])) {
-          $this->_fields["state_province-{$location_type_id}"]['is_required'] =
-            CRM_Core_Payment_Form::checkRequiredStateProvince($this, "country-{$location_type_id}");
+        if (array_key_exists("country-{$locationTypeId}", $this->_fields) &&
+          array_key_exists("state_province-{$locationTypeId}", $this->_fields) &&
+          !empty($this->_submitValues["country-{$locationTypeId}"])) {
+          $this->_fields["state_province-{$locationTypeId}"]['is_required'] =
+            CRM_Core_Payment_Form::checkRequiredStateProvince($this, "country-{$locationTypeId}");
         }
       }
     }


### PR DESCRIPTION
Currently it is not possible to write formrule on state-province required-ness as its scope is limited to CRM_Core_Form. So the alternative is to change is_required attribute of state/province field in buildquickForm after submit on the basis of a function checkRequiredStateProvince() used by billing block. Also I have to bring some changes in the function to also consider onBehalf profile as in this case $_submitValues has values of On Behalf of profile in separate index 'onbehalf' otherwise its a usual profile. The patch solves the State/Province requiredness issue on CiviProfiles including 'On Behalf of' and the same issue on profile create/edit mode (CRM-10185)
