### PR TITLE
CRM-13709 fix - World Region filter doesn't work on Advance Search

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -1928,6 +1928,7 @@ class CRM_Contact_BAO_Query {
       }
     }
     elseif ($name === 'world_region') {
+      $field['where'] = 'civicrm_worldregion.id';
       $this->optionValueQuery(
         $name, $op, $value, $grouping,
         CRM_Core_PseudoConstant::worldRegion(),


### PR DESCRIPTION
http://issues.civicrm.org/jira/browse/CRM-13709
