### PR TITLE
CRM-13716 - MailingJob still uses civicrm_activity_target (for multiple bulk emails)

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -2689,7 +2689,7 @@ WHERE  civicrm_mailing_job.id = %1
     return TRUE;
   }
 
-  private function addMultipleEmails($mailingID) {
+  private static function addMultipleEmails($mailingID) {
     $sql = "
 INSERT INTO civicrm_mailing_recipients
     (mailing_id, email_id, contact_id)


### PR DESCRIPTION
Fix static function notice

http://issues.civicrm.org/jira/browse/CRM-13716
