### PR TITLE
CRM-13726, Contribution, Event billing blocks, - Only add same as above

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -337,10 +337,10 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     $this->buildCustom($this->_values['custom_pre_id'], 'customPre');
     $this->buildCustom($this->_values['custom_post_id'], 'customPost');
 
-    if (!empty($this->_fields)) {
+    if (!empty($this->_fields) && !empty($this->_values['custom_pre_id'])) {
       $profileAddressFields = array();
       foreach ($this->_fields as $key => $value) {
-        CRM_Core_BAO_UFField::assignAddressField($key, $profileAddressFields);
+        CRM_Core_BAO_UFField::assignAddressField($key, $profileAddressFields, array('uf_group_id' => $this->_values['custom_pre_id']));
       }
       $this->set('profileAddressFields', $profileAddressFields);
     }

--- a/CRM/Core/BAO/UFField.php
+++ b/CRM/Core/BAO/UFField.php
@@ -788,13 +788,15 @@ SELECT  id
    * http://issues.civicrm.org/jira/browse/CRM-5869
    *
    * @param string $key Field key - e.g. street_address-Primary, first_name
-   * @param $profileAddressFields
-   * @params array $profileAddressFields array of profile fields that relate to address fields
+   * @param array $profileAddressFields array of profile fields that relate to address fields
+   * @param array $profileFilter filter to apply to profile fields - expected usage is to only fill based on
+   * the bottom profile per CRM-13726
    */
-  static function assignAddressField($key, &$profileAddressFields) {
+  static function assignAddressField($key, &$profileAddressFields, $profileFilter) {
     $billing_id = CRM_Core_BAO_LocationType::getBilling();
     list($prefixName, $index) = CRM_Utils_System::explode('-', $key, 2);
 
+    $profileFields = civicrm_api3('uf_field', 'get', array_merge($profileFilter, array('is_active' => 1, 'return' => 'field_name')));
     //check for valid fields ( fields that are present in billing block )
     $validBillingFields = array(
       'first_name',
@@ -807,8 +809,15 @@ SELECT  id
       'postal_code',
       'country'
     );
+    $validProfileFields = array();
 
-    if (!in_array($prefixName, $validBillingFields)) {
+    foreach ($profileFields['values'] as $field) {
+      if(in_array($field['field_name'], $validBillingFields)) {
+        $validProfileFields[] = $field['field_name'];
+      }
+    }
+
+    if (!in_array($prefixName, $validProfileFields) ) {
       return;
     }
 

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -321,10 +321,10 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
     $this->buildCustom($this->_values['custom_pre_id'], 'customPre');
     $this->buildCustom($this->_values['custom_post_id'], 'customPost');
 
-    if (!empty($this->_fields)) {
+    if (!empty($this->_fields) && !empty($this->_values['custom_pre_id'])) {
       $profileAddressFields = array();
       foreach ($this->_fields as $key => $value) {
-        CRM_Core_BAO_UFField::assignAddressField($key, $profileAddressFields);
+        CRM_Core_BAO_UFField::assignAddressField($key, $profileAddressFields, array('id' => $this->_values['custom_pre_id']));
       }
       $this->set('profileAddressFields', $profileAddressFields);
     }


### PR DESCRIPTION
checkbox if there is an address above

Conflicts:
    CRM/Contribute/Form/Contribution/Main.php
    CRM/Core/BAO/UFField.php
    CRM/Event/Form/Registration.php

---
- CRM-13726: Only show 'billing addres is same as above' checkbox if there is an address above
  http://issues.civicrm.org/jira/browse/CRM-13726
