### PR TITLE
CRM-13714 - Display fatal error for Joomla 3.x

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -330,6 +330,9 @@ class CRM_Core_Error extends PEAR_ErrorStack {
         echo CRM_Utils_System::theme($content);
       }
     }
+    else {
+      echo CRM_Utils_System::theme($content);
+    }
 
     self::abend(CRM_Core_Error::FATAL_ERROR);
   }


### PR DESCRIPTION
the previous patch messed up the fatal error display for drupal and wp. This patch fixes that

http://issues.civicrm.org/jira/browse/CRM-13714
