### PR TITLE
CRM-13066 - batch delete broken - fix

### DIFF
--- a/CRM/Batch/BAO/Batch.php
+++ b/CRM/Batch/BAO/Batch.php
@@ -165,10 +165,6 @@ class CRM_Batch_BAO_Batch extends CRM_Batch_DAO_Batch {
    * @access public
    */
   static function deleteBatch($batchId) {
-    //delete batch entries from cache
-    $cacheKeyString = CRM_Batch_BAO_Batch::getCacheKeyForBatch($batchId);
-    CRM_Core_BAO_Cache::deleteGroup('batch entry', $cacheKeyString, FALSE);
-
     // delete entry from batch table
     $batch = new CRM_Batch_DAO_Batch();
     $batch->id = $batchId;


### PR DESCRIPTION
Batch delete is broken because the getCacheKeyForBatch() no longer exist, and there is a call made to this function from crm_batch_bao_batch::delete() method.

The getCacheKeyForBatch() was deleted with PR - https://github.com/civicrm/civicrm-core/pull/1545.
