### PR TITLE
CRM-13735

### DIFF
--- a/CRM/Utils/OpenFlashChart.php
+++ b/CRM/Utils/OpenFlashChart.php
@@ -106,7 +106,7 @@ class CRM_Utils_OpenFlashChart {
         // FIXME: for bars > 2, we'll need to come out with other colors
         $bars[$barCount]->colour( '#BF3B69');
       }
-      
+
       if ($barKey = CRM_Utils_Array::value($barCount, CRM_Utils_Array::value('barKeys', $params))) {
         $bars[$barCount]->key($barKey,12);
       }
@@ -123,6 +123,11 @@ class CRM_Utils_OpenFlashChart {
 
     // create x axis label obj.
     $xLabels = new x_axis_labels();
+    // set_labels function requires xValues array of string or x_axis_label
+    // type casting array to string
+    array_walk($xValues, function(&$value, $index) {
+        $value = (string)$value;
+      });
     $xLabels->set_labels($xValues);
 
     // set angle for labels.
@@ -429,7 +434,7 @@ class CRM_Utils_OpenFlashChart {
       foreach ($rows['multiValue'] as $key => $val) {
         $graph[$key] = array_combine($dateKeys, $rows['multiValue'][$key]);
       }
-      $chartData = 
+      $chartData =
         array(
           'legend' => "$legend " . CRM_Utils_Array::value('legend', $rows, ts('Contribution')) . ' ' . ts('Summary'),
           'values' => $graph[0],

--- a/CRM/Utils/OpenFlashChart.php
+++ b/CRM/Utils/OpenFlashChart.php
@@ -124,7 +124,7 @@ class CRM_Utils_OpenFlashChart {
     // create x axis label obj.
     $xLabels = new x_axis_labels();
     // set_labels function requires xValues array of string or x_axis_label
-    // type casting array to string
+    // so type casting array values to string values
     array_walk($xValues, function(&$value, $index) {
         $value = (string)$value;
       });


### PR DESCRIPTION
for contribution summary display using bar chart, while receive date grouping (Frequency selection) done by 'Year' : the chart labels are integers, this was causing chart to not appear during 'Year' grouping (Frequency selection) for receive date. 

checked the function definition of <code>$xLabels->set_labels($xValues); </code> inside <code>packages/OpenFlashChart/php-ofc-library/ofc_x_axis_labels.php </code> file which states <code>  @param $labels as an array of [x_axis_label or string]</code>
