### PR TITLE
crm-13730 

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -4160,7 +4160,7 @@ civicrm_relationship.start_date > {$today}
       $convertedVals = $query->convertToPseudoNames($dao, TRUE);
 
       if (!empty($convertedVals)) {
-        $val = array_merge_recursive($val, $convertedVals);
+        $val = array_replace_recursive($val, $convertedVals);
       }
       $values[$dao->contact_id] = $val;
     }


### PR DESCRIPTION
was not able to reproduce the issue mentioned in description, but was able to replicate bug mentioned in http://issues.civicrm.org/jira/browse/CRM-13730?focusedCommentId=54176 . 

the proper array formation was not taking place, this array ultimately was being used to compute the default values, which resulted in the issue mentioned in comment.

the improper array formation is due to the <code>array_merge_recursive </code> function's feature : <code>If, however, the arrays have the same numeric key, the later value will not overwrite the original value, but will be appended. </code> . Source to it :  http://us2.php.net/array_merge_recursive .

The alternative function is <code>array_replace_recursive</code> . 
