### PR TITLE
CRM-13742 conditional display of invite to create your own PCP after com...

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -508,7 +508,13 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     }
     if ($this->_pcpId) {
       if ($pcpSupporter = CRM_PCP_BAO_PCP::displayName($this->_pcpId)) {
-        $this->assign('pcpSupporterText', ts('This contribution is being made thanks to effort of <strong>%1</strong>, who supports our campaign. You can support it as well - once you complete the donation, you will be able to create your own Personal Campaign Page!', array(1 => $pcpSupporter)));
+        $pcp_supporter_text = ts('This contribution is being made thanks to effort of <strong>%1</strong>, who supports our campaign. ', array(1 => $pcpSupporter));
+        // Only tell people that can also create a PCP if the contribution page has a non-empty value in the "Create Personal Campaign Page link" field.
+        $text = CRM_PCP_BAO_PCP::getPcpBlockStatus($this->_id, 'contribute');
+        if(!empty($text)) {
+          $pcp_supporter_text .= "You can support it as well - once you complete the donation, you will be able to create your own Personal Campaign Page!";
+        }
+        $this->assign('pcpSupporterText', $pcp_supporter_text);
       }
       $this->assign('pcp', TRUE);
       $this->add('checkbox', 'pcp_display_in_roll', ts('Show my contribution in the public honor roll'), NULL, NULL,

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -456,9 +456,6 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
     $this->assign('bltID', $this->_bltID);
     $isShowLocation = CRM_Utils_Array::value('is_show_location', $this->_values['event']);
     $this->assign('isShowLocation', $isShowLocation);
-    if ($pcpId && $pcpSupporter = CRM_PCP_BAO_PCP::displayName($pcpId)) {
-      $this->assign('pcpSupporterText', ts('This event registration is being made thanks to effort of <strong>%1</strong>, who supports our campaign. You can support it as well - once you complete the registration, you will be able to create your own Personal Campaign Page!', array(1 => $pcpSupporter)));
-    }
     //CRM-6907
     $config->defaultCurrency = CRM_Utils_Array::value('currency', $this->_values['event'],
       $config->defaultCurrency

--- a/templates/CRM/Contribute/Form/ContributionPage/PCP.hlp
+++ b/templates/CRM/Contribute/Form/ContributionPage/PCP.hlp
@@ -72,5 +72,5 @@
   {ts}Personal Contribution Link{/ts}
 {/htxt}
 {htxt id="id-link_text"}
-{ts}Text for the link inviting constituents to create a Personal Contribution Page. This link will appear on the Contribution Thank-you page as well as on each Personal Campaign Page.{/ts}
+{ts}Text for the link inviting constituents to create a Personal Contribution Page. This link will appear on the Contribution Thank-you page as well as on each Personal Campaign Page. Leave blank if you do not want constituents to be prompted to create their own Personal Campaign Pages.{/ts}
 {/htxt}

--- a/templates/CRM/PCP/Form/Contribute.hlp
+++ b/templates/CRM/PCP/Form/Contribute.hlp
@@ -72,5 +72,5 @@
   {ts}Personal Contribution Link{/ts}
 {/htxt}
 {htxt id="id-link_text"}
-{ts}Text for the link inviting constituents to create a Personal Contribution Page. This link will appear on the Contribution Thank-you page as well as on each Personal Campaign Page.{/ts}
+{ts}Text for the link inviting constituents to create a Personal Contribution Page. This link will appear on the Contribution Thank-you page as well as on each Personal Campaign Page. Leave blank if you do not want constituents to be prompted to create their own Personal Campaign Pages.{/ts}
 {/htxt}

--- a/templates/CRM/PCP/Form/Event.hlp
+++ b/templates/CRM/PCP/Form/Event.hlp
@@ -72,7 +72,7 @@
   {ts}Link Text{/ts}
 {/htxt}
 {htxt id="id-link_text"}
-{ts}Text for the link inviting constituents to create a Personal Campaign Page. This link will appear on the Event registration Thank-you page as well as on each Personal Campaign Page.{/ts}
+{ts}Text for the link inviting constituents to create a Personal Campaign Page. This link will appear on the Event registration Thank-you page as well as on each Personal Campaign Page. Leave blank if you do not want constituents to be prompted to create their own Personal Campaign Pages.{/ts}
 {/htxt}
 
 {htxt id="id-target_entity_type-title"}


### PR DESCRIPTION
...pleting a contribution or event registration as a supporter. Removed redundant code in CRM/Event/Form/Registration.php (pcpSupporterText assigned in buildPcp() for event pages). Fixed query in getPcpBlockStatus which only worked for contribution_page PCPs, not for event pages.

---
- CRM-13742: PCP message should not always promise ability to create your own PCP
  http://issues.civicrm.org/jira/browse/CRM-13742
