### PR TITLE
GenCode, etal - WordPress fixes

### DIFF
--- a/bin/setup.conf.txt
+++ b/bin/setup.conf.txt
@@ -42,3 +42,9 @@ DBLOAD=
 # cumbersome during development. To speed it up,
 # list the desired locales.
 # export CIVICRM_LOCALES=en_US,fr_FR
+
+# GenCode produces some CMS-specific config files
+# If omitted, defaults to drupal.
+GENCODE_CMS=""
+# GENCODE_CMS=drupal
+# GENCODE_CMS=wordpress

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -49,7 +49,7 @@ fi
 # checkout, not packaged code
 if [ -d "$CALLEDPATH/../xml" ]; then
   cd "$CALLEDPATH/../xml"
-  "$PHP5PATH"php GenCode.php $SCHEMA
+  "$PHP5PATH"php GenCode.php $SCHEMA '' $GENCODE_CMS
 fi
 
 # someone might want to use empty password for development,

--- a/distmaker/dists/drupal_php5.sh
+++ b/distmaker/dists/drupal_php5.sh
@@ -68,7 +68,13 @@ cp $SRC/drupal/civicrm.config.php.drupal $TRG/civicrm.config.php
 # set full version in .info files
 MODULE_DIRS=`find "$DM_SOURCEDIR/drupal" -type f -name "*.info"`
 for INFO in $MODULE_DIRS; do
-  sed -i "s/version = [1-9.]*/version = $DM_VERSION/g" $INFO
+  if [ $(uname) = "Darwin" ]; then
+    ## BSD sed
+    sed -i '' "s/version = [1-9.]*/version = $DM_VERSION/g" $INFO
+  else
+    ## GNU sed
+    sed -i'' "s/version = [1-9.]*/version = $DM_VERSION/g" $INFO
+  fi
 done
 
 

--- a/distmaker/dists/wordpress_php5.sh
+++ b/distmaker/dists/wordpress_php5.sh
@@ -71,12 +71,13 @@ set -e
 for F in $SRC/WordPress/*; do
 	cp $F $TRG/civicrm
 done
+rm -f $TRG/civicrm/civicrm.config.php.wordpress
 
 # copy docs
 cp $SRC/agpl-3.0.txt $TRG/civicrm/civicrm
 cp $SRC/gpl.txt $TRG/civicrm/civicrm
 cp $SRC/README.txt $TRG/civicrm/civicrm
-cp $SRC/civicrm.config.php $TRG/civicrm/civicrm
+cp $SRC/WordPress/civicrm.config.php.wordpress $TRG/civicrm/civicrm/civicrm.config.php
 
 # final touch
 echo "<?php


### PR DESCRIPTION
Allow running GenCode and setup.sh on a WordPress-only installation (with WordPress's directory structure).

Depends: https://github.com/civicrm/civicrm-wordpress/pull/29
