### PR TITLE
CRM-13023 - API Case - Allow Get method to be called with no parameters ...

### DIFF
--- a/api/v3/Case.php
+++ b/api/v3/Case.php
@@ -192,25 +192,6 @@ function _civicrm_api3_case_delete_spec(&$params) {
 function civicrm_api3_case_get($params) {
   $options = _civicrm_api3_get_options_from_params($params);
 
-  // Get by id
-  $caseId = CRM_Utils_Array::value('id', $params);
-  if ($caseId) {
-    // Validate param
-    if (!is_numeric($caseId)) {
-      return civicrm_api3_create_error('Invalid parameter: case_id. Must provide a numeric value.');
-    }
-    // For historic reasons we always return these when an id is provided
-    $options['return'] = array('contacts' => 1, 'activities' => 1);
-    $case = _civicrm_api3_case_read($caseId, $options);
-
-    if ($case) {
-      return civicrm_api3_create_success(array($caseId => $case), $params, 'case', 'get');
-    }
-    else {
-      return civicrm_api3_create_success(array(), $params, 'case', 'get');
-    }
-  }
-
   //search by client
   if (!empty($params['contact_id'])) {
     $ids = array();
@@ -260,6 +241,12 @@ SELECT DISTINCT case_id
       $cases[$dao->case_id] = _civicrm_api3_case_read($dao->case_id, $options);
     }
     return civicrm_api3_create_success($cases, $params, 'case', 'get');
+  }
+
+  // For historic reasons we always return these when an id is provided
+  $caseId = CRM_Utils_Array::value('id', $params);
+  if ($caseId) {
+    $options['return'] = array('contacts' => 1, 'activities' => 1);
   }
 
   $foundcases =  _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params, TRUE, 'Case');

--- a/api/v3/Case.php
+++ b/api/v3/Case.php
@@ -190,10 +190,6 @@ function _civicrm_api3_case_delete_spec(&$params) {
  * @todo Erik Hommel 16 dec 2010 check if all DB fields are returned
  */
 function civicrm_api3_case_get($params) {
-  civicrm_api3_verify_mandatory($params, NULL, array(
-    array('case_id', 'contact_id', 'activity_id', 'contact_id')
-  ));
-
   $options = _civicrm_api3_get_options_from_params($params);
 
   // Get by id
@@ -265,6 +261,16 @@ SELECT DISTINCT case_id
     }
     return civicrm_api3_create_success($cases, $params, 'case', 'get');
   }
+
+  $foundcases =  _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params, TRUE, 'Case');
+  $cases = array();
+  foreach ($foundcases['values'] as $foundcase) {
+      if ($case = _civicrm_api3_case_read($foundcase['id'], $options)) {
+        $cases[$foundcase['id']] = $case;
+      }
+    }
+
+  return civicrm_api3_create_success($cases, $params, 'case', 'get');
 }
 
 /**

--- a/tests/phpunit/api/v3/CaseTest.php
+++ b/tests/phpunit/api/v3/CaseTest.php
@@ -362,6 +362,50 @@ class api_v3_CaseTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test get function based on subject
+   */
+  function testCaseGetBySubject() {
+    // Create Case
+    $result = $this->callAPISuccess('case', 'create', $this->_params);
+    $id = $result['id'];
+
+    // Store result for later
+    $case = $this->callAPISuccess('case', 'getsingle', array('id' => $id));
+
+    // Fetch case based on client contact id
+    $result = $this->callAPISuccess('case', 'get', array('subject' => $this->_params['subject'], 'return' => array('activities', 'contacts')));
+    $this->assertAPIArrayComparison($result['values'][$id], $case);
+  }
+
+  /**
+   * Test get function based on wrong subject
+   */
+  function testCaseGetByWrongSubject() {
+    // Create Case
+    $result = $this->callAPISuccess('case', 'create', $this->_params);
+    $id = $result['id'];
+
+    // Append 'wrong' to subject so that it is no longer the same
+    $result = $this->callAPISuccess('case', 'get', array('subject' => $this->_params['subject'] . 'wrong', 'return' => array('activities', 'contacts')));
+    $this->assertEquals(0, $result['count'], 'in line ' . __LINE__);
+  }
+
+  /**
+   * Test get function with no criteria
+   */
+  function testCaseGetNoCriteria() {
+    // Create Case
+    $result = $this->callAPISuccess('case', 'create', $this->_params);
+    $id = $result['id'];
+
+    // Store result for later
+    $case = $this->callAPISuccess('case', 'getsingle', array('id' => $id));
+
+    $result = $this->callAPISuccess('case', 'get', array('return' => array('activities', 'contacts')));
+    $this->assertAPIArrayComparison($result['values'][$id], $case);
+  }
+
+  /**
    *  Test activity api create for case activities
    */
   function testCaseActivityCreate() {


### PR DESCRIPTION
...or with entity fields as normal

Includes the following changes:
- Removed the verification for the mandatory parameters
- If none of the previous parameters are found it calls the standard _civicrm_api3_basic_get method to get the Case based on the field values provided in $params.
- Then use the _civicrm_api3_case_read method to get the case details so they match the format returned by the other branches of the get method.

---
- CRM-13023: API Case Entity and Get Action can not be called without search fields
  http://issues.civicrm.org/jira/browse/CRM-13023
