### PR TITLE
CRM-13757 Paypal Pro IPN - fix type on recurring_payment_id (Closes)

### DIFF
--- a/CRM/Core/Payment/PayPalProIPN.php
+++ b/CRM/Core/Payment/PayPalProIPN.php
@@ -207,7 +207,7 @@ class CRM_Core_Payment_PayPalProIPN extends CRM_Core_Payment_BaseIPN {
       case 'recurring_payment_profile_created':
         $recur->create_date = $now;
         $recur->contribution_status_id = 2;
-        $recur->processor_id = $this->retrieve('recurring_payment_id', 'Integer');
+        $recur->processor_id = $this->retrieve('recurring_payment_id', 'String');
         $recur->trxn_id = $recur->processor_id;
         $subscriptionPaymentStatus = CRM_Core_Payment::RECURRING_PAYMENT_START;
         $sendNotification = TRUE;


### PR DESCRIPTION
---
- CRM-13757: Paypal pro ipn - 'recurring_payment_id' incorrectly typed as an integer
  http://issues.civicrm.org/jira/browse/CRM-13757
