### PR TITLE
Enable participant roles to be changed from counted to not counted (CRM-13761)

### DIFF
--- a/CRM/Admin/Form/Options.php
+++ b/CRM/Admin/Form/Options.php
@@ -395,9 +395,13 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
         }
       }
 
-      // set db value of filter in params if filter is non editable
-      if ($this->_id && !array_key_exists('filter', $params) && !$this->_gName == 'participant_role') {
-        $params['filter'] = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionValue', $this->_id, 'filter', 'id');
+      // set value of filter if not present in params
+      if ($this->_id && !array_key_exists('filter', $params)) {
+        if ($this->_gName == 'participant_role') {
+          $params['filter'] = 0;
+        } else {
+          $params['filter'] = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionValue', $this->_id, 'filter', 'id');
+        }
       }
 
       $groupParams = array('name' => ($this->_gName));


### PR DESCRIPTION
This patch fixes a bug on the Participant Role Options page (Administer -> CiviEvent -> Participant Roles) which prevents you from changing a participant role from being counted to not being counted. See <a href="http://issues.civicrm.org/jira/browse/CRM-13761">CRM-13761</a>.
