### PR TITLE
CRM-13762 - CiviReport - Add postal code suffix to CiviReport address fi...

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -3124,6 +3124,10 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
           array('title' => ts('Postal Code'),
             'default' => CRM_Utils_Array::value('postal_code', $defaults, FALSE),
           ),
+          'postal_code_suffix' =>
+          array('title' => ts('Postal Code Suffix'),
+            'default' => CRM_Utils_Array::value('postal_code_suffix', $defaults, FALSE),
+          ),
           'county_id' =>
           array('title' => ts('County'),
             'default' => CRM_Utils_Array::value('county_id', $defaults, FALSE),


### PR DESCRIPTION
...elds

---
- CRM-13762: fucntion addAddressFields in CiviReport doesn't include Postal Code Suffix
  http://issues.civicrm.org/jira/browse/CRM-13762
