### PR TITLE
CRM-13768 - enable_component - Use same logic when toggling components via API/web

### DIFF
--- a/CRM/Admin/Form/Setting/Component.php
+++ b/CRM/Admin/Form/Setting/Component.php
@@ -108,19 +108,7 @@ class CRM_Admin_Form_Setting_Component extends CRM_Admin_Form_Setting {
   public function postProcess() {
     $params = $this->controller->exportValues($this->_name);
 
-    // if CiviCase is being enabled,
-    // load the case related sample data
-    if (in_array('CiviCase', $params['enableComponents']) &&
-      !in_array('CiviCase', $this->_defaults['enableComponents'])
-    ) {
-      $config = CRM_Core_Config::singleton();
-      CRM_Admin_Form_Setting_Component::loadCaseSampleData($config->dsn, $config->sqlDir . 'case_sample.mysql');
-      CRM_Admin_Form_Setting_Component::loadCaseSampleData($config->dsn, $config->sqlDir . 'case_sample1.mysql');
-      if (!CRM_Case_BAO_Case::createCaseViews()) {
-        $msg = ts("Could not create the MySQL views for CiviCase. Your mysql user needs to have the 'CREATE VIEW' permission");
-        CRM_Core_Error::fatal($msg);
-      }
-    }
+    CRM_Case_Info::onToggleComponents($this->_defaults['enableComponents'], $params['enableComponents'], NULL);
     parent::commonProcess($params);
 
     // reset navigation when components are enabled / disabled

--- a/CRM/Case/Info.php
+++ b/CRM/Case/Info.php
@@ -152,5 +152,29 @@ class CRM_Case_Info extends CRM_Core_Component_Info {
       }
     }
   }
+
+  /**
+   * (Setting Callback)
+   * Respond to changes in the "enable_components" setting
+   *
+   * If CiviCase is being enabled, load the case related sample data
+   *
+   * @param array $oldValue List of component names
+   * @param array $newValue List of component names
+   * @param array $metadata Specification of the setting (per *.settings.php)
+   */
+  public static function onToggleComponents($oldValue, $newValue, $metadata) {
+    if (in_array('CiviCase', $newValue) &&
+      !in_array('CiviCase', $oldValue)
+    ) {
+      $config = CRM_Core_Config::singleton();
+      CRM_Admin_Form_Setting_Component::loadCaseSampleData($config->dsn, $config->sqlDir . 'case_sample.mysql');
+      CRM_Admin_Form_Setting_Component::loadCaseSampleData($config->dsn, $config->sqlDir . 'case_sample1.mysql');
+      if (!CRM_Case_BAO_Case::createCaseViews()) {
+        $msg = ts("Could not create the MySQL views for CiviCase. Your mysql user needs to have the 'CREATE VIEW' permission");
+        CRM_Core_Error::fatal($msg);
+      }
+    }
+  }
 }
 

--- a/CRM/Core/BAO/Setting.php
+++ b/CRM/Core/BAO/Setting.php
@@ -292,6 +292,8 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
   /**
    * Store an item in the setting table
    *
+   * _setItem() is the common logic shared by setItem() and setItems().
+   *
    * @param object $value (required) The value that will be serialized and stored
    * @param string $group (required) The group name of the item
    * @param string $name  (required) The name of the setting
@@ -311,12 +313,52 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
     $createdID   = NULL,
     $domainID    = NULL
   ) {
+    $fields = array();
+    $fieldsToSet = self::validateSettingsInput(array($name => $value), $fields);
+    //We haven't traditionally validated inputs to setItem, so this breaks things.
+    //foreach ($fieldsToSet as $settingField => &$settingValue) {
+    //  self::validateSetting($settingValue, $fields['values'][$settingField]);
+    //}
+
+    return self::_setItem($fields['values'][$name], $value, $group, $name, $componentID, $contactID, $createdID, $domainID);
+  }
+
+  /**
+   * Store an item in a setting table
+   *
+   * _setItem() is the common logic shared by setItem() and setItems().
+   *
+   * @param array $metadata metadata describing this field
+   * @param $value
+   * @param $group
+   * @param $name
+   * @param null $componentID
+   * @param null $contactID
+   * @param null $createdID
+   * @param null $domainID
+   */
+  static function _setItem(
+    $metadata,
+    $value,
+    $group,
+    $name,
+    $componentID = NULL,
+    $contactID   = NULL,
+    $createdID   = NULL,
+    $domainID    = NULL
+  ) {
     if (empty($domainID)) {
       $domainID = CRM_Core_Config::domainID();
     }
 
     $dao = self::dao($group, $name, $componentID, $contactID, $domainID);
     $dao->find(TRUE);
+
+    if (isset($metadata['on_change'])) {
+      foreach ($metadata['on_change'] as $callback) {
+        call_user_func($callback, unserialize($dao->value), $value, $metadata);
+      }
+    }
 
     if (CRM_Utils_System::isNull($value)) {
       $dao->value = 'null';
@@ -366,6 +408,8 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
    *  'config_key' = the config key is different to the settings key - e.g. debug where there was a conflict
    *  'legacy_key' = rename from config or setting with this name
    *
+   * _setItem() is the common logic shared by setItem() and setItems().
+   *
    * @param array $params (required) An api formatted array of keys and values
    * @domains array an array of domains to get settings for. Default is the current domain
    * @return void
@@ -393,7 +437,8 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
       $result[$domainID] = array();
       foreach ($fieldsToSet as $name => $value) {
         if(empty($fields['values'][$name]['config_only'])){
-          CRM_Core_BAO_Setting::setItem(
+          CRM_Core_BAO_Setting::_setItem(
+            $fields['values'][$name],
             $value,
             $fields['values'][$name]['group_name'],
             $name,

--- a/CRM/Core/BAO/Setting.php
+++ b/CRM/Core/BAO/Setting.php
@@ -235,7 +235,7 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
    * @static
    * @access public
    */
-  static function getItems(&$params, $domains = null, $settingsToReturn) {
+  static function getItems(&$params, $domains = NULL, $settingsToReturn) {
     $originalDomain = CRM_Core_Config::domainID();
     if (empty($domains)) {
       $domains[] = $originalDomain;
@@ -273,7 +273,7 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
             $fields['values'][$name]['group_name'],
             $name,
             CRM_Utils_Array::value('component_id', $params),
-            null,
+            NULL,
             CRM_Utils_Array::value('contact_id', $params),
             $domainID
           );
@@ -372,7 +372,7 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
    * @static
    * @access public
    */
-  static function setItems(&$params, $domains = null) {
+  static function setItems(&$params, $domains = NULL) {
     $originalDomain = CRM_Core_Config::domainID();
     if (empty($domains)) {
       $domains[] = $originalDomain;
@@ -489,7 +489,7 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
       $value = CRM_Core_DAO::VALUE_SEPARATOR . implode(CRM_Core_DAO::VALUE_SEPARATOR,$value) . CRM_Core_DAO::VALUE_SEPARATOR;
     }
     if (empty($fieldSpec['validate_callback'])) {
-      return true;
+      return TRUE;
     }
     else {
       list($class,$fn) = explode('::',$fieldSpec['validate_callback']);
@@ -575,10 +575,10 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
    * - help_text
    */
   static function getSettingSpecification(
-    $componentID = null,
+    $componentID = NULL,
     $filters = array(),
-    $domainID = null,
-    $profile = null
+    $domainID = NULL,
+    $profile = NULL
   ) {
     $cacheString = 'settingsMetadata_' . $domainID . '_' . $profile;
     foreach ($filters as $filterField => $filterString) {
@@ -685,7 +685,7 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
    *
    * Note that where the key name is being changed the 'legacy_key' will give us the old name
    */
-  static function convertConfigToSetting($name, $domainID = null) {
+  static function convertConfigToSetting($name, $domainID = NULL) {
     // we have to force this here in case more than one domain is in play.
     // whenever there is a possibility of more than one domain we must force it
     $config = CRM_Core_Config::singleton();
@@ -700,7 +700,7 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
     } else {
       $values = array();
     }
-    $spec = self::getSettingSpecification(null, array('name' => $name), $domainID);
+    $spec = self::getSettingSpecification(NULL, array('name' => $name), $domainID);
     $configKey = CRM_Utils_Array::value('config_key', $spec[$name], CRM_Utils_Array::value('legacy_key', $spec[$name], $name));
     //if the key is set to config_only we don't need to do anything
     if(empty($spec[$name]['config_only'])){
@@ -806,7 +806,7 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
     self::setItem($optionValue, $group, $name);
   }
 
-  static function fixAndStoreDirAndURL(&$params, $domainID = null) {
+  static function fixAndStoreDirAndURL(&$params, $domainID = NULL) {
     if (self::isUpgradeFromPreFourOneAlpha1()) {
       return;
     }

--- a/api/v3/Setting.php
+++ b/api/v3/Setting.php
@@ -85,7 +85,7 @@ function _civicrm_api3_setting_getfields_spec(&$params) {
  * Note that is not in place as yet
  */
 function civicrm_api3_setting_getdefaults(&$params){
-  $settings = civicrm_api('setting','getfields', $params);
+  $settings = civicrm_api3('setting','getfields', $params);
   $domains = _civicrm_api3_setting_getDomainArray($params);
   $defaults = array();
   foreach ($domains as $domainID){
@@ -158,7 +158,7 @@ function _civicrm_api3_setting_revert_spec(&$params) {
  * Revert settings to defaults
  */
 function civicrm_api3_setting_fill(&$params){
-  $defaults = civicrm_api('setting','getdefaults', $params);
+  $defaults = civicrm_api3('setting','getdefaults', $params);
   $domains = _civicrm_api3_setting_getDomainArray($params);
   $result = array();
   foreach ($domains as $domainID){
@@ -166,7 +166,7 @@ function civicrm_api3_setting_fill(&$params){
       'version' => $params['version'],
       'domain_id' => $domainID
     );
-    $existing = civicrm_api('setting','get', $apiArray);
+    $existing = civicrm_api3('setting','get', $apiArray);
     $valuesToFill = array_diff_key($defaults['values'][$domainID], $existing['values'][$domainID]);
     if(!empty($valuesToFill)){
       $result = array_merge($result, civicrm_api('setting', 'create', $valuesToFill + $apiArray));

--- a/settings/Core.setting.php
+++ b/settings/Core.setting.php
@@ -626,6 +626,9 @@ When enabled, statistics about your CiviCRM installation are reported anonymousl
     'is_contact' => 0,
     'description' => null,
     'help_text'   => null,
+    'on_change' => array(
+      array('CRM_Case_Info', 'onToggleComponents')
+    ),
   ),
 
   'disable_core_css' => array(

--- a/tests/phpunit/CRM/Core/BAO/SettingTest.php
+++ b/tests/phpunit/CRM/Core/BAO/SettingTest.php
@@ -202,5 +202,74 @@ class CRM_Core_BAO_SettingTest extends CiviUnitTestCase {
   }
    */
 
+  /**
+   * Ensure that on_change callbacks fire.
+   *
+   * Note: api_v3_SettingTest::testOnChange and CRM_Core_BAO_SettingTest::testOnChange
+   * are very similar, but they exercise different codepaths. The first uses the API
+   * and setItems [plural]; the second uses setItem [singular].
+   */
+  function testOnChange() {
+    global $_testOnChange_hookCalls;
+    $this->setMockSettingsMetaData(array(
+      'onChangeExample' => array(
+        'group_name' => 'CiviCRM Preferences',
+        'group' => 'core',
+        'name' => 'onChangeExample',
+        'type' => 'Array',
+        'quick_form_type' => 'Element',
+        'html_type' => 'advmultiselect',
+        'default' => array('CiviEvent', 'CiviContribute'),
+        'add' => '4.4',
+        'title' => 'List of Components',
+        'is_domain' => '1',
+        'is_contact' => 0,
+        'description' => NULL,
+        'help_text' => NULL,
+        'on_change' => array( // list of callbacks
+          array(__CLASS__, '_testOnChange_onChangeExample')
+        ),
+      ),
+    ));
+
+    // set initial value
+    $_testOnChange_hookCalls = array('count' => 0);
+    CRM_Core_BAO_Setting::setItem(
+      array('First', 'Value'),
+      'CiviCRM Preferences',
+      'onChangeExample'
+    );
+    $this->assertEquals(1, $_testOnChange_hookCalls['count']);
+    $this->assertEquals(array('First', 'Value'), $_testOnChange_hookCalls['newValue']);
+    $this->assertEquals('List of Components', $_testOnChange_hookCalls['metadata']['title']);
+
+    // change value
+    $_testOnChange_hookCalls = array('count' => 0);
+    CRM_Core_BAO_Setting::setItem(
+      array('Second', 'Value'),
+      'CiviCRM Preferences',
+      'onChangeExample'
+    );
+    $this->assertEquals(1, $_testOnChange_hookCalls['count']);
+    $this->assertEquals(array('First', 'Value'), $_testOnChange_hookCalls['oldValue']);
+    $this->assertEquals(array('Second', 'Value'), $_testOnChange_hookCalls['newValue']);
+    $this->assertEquals('List of Components', $_testOnChange_hookCalls['metadata']['title']);
+  }
+
+  /**
+   * Mock callback for a setting's on_change handler
+   *
+   * @param $oldValue
+   * @param $newValue
+   * @param $metadata
+   */
+  static function _testOnChange_onChangeExample($oldValue, $newValue, $metadata) {
+    global $_testOnChange_hookCalls;
+    $_testOnChange_hookCalls['count']++;
+    $_testOnChange_hookCalls['oldValue'] = $oldValue;
+    $_testOnChange_hookCalls['newValue'] = $newValue;
+    $_testOnChange_hookCalls['metadata'] = $metadata;
+  }
+
 }
 

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -2267,6 +2267,30 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
     }
   }
 
+  /**
+   * Temporarily alter the settings-metadata to add a mock setting.
+   *
+   * WARNING: The setting metadata will disappear on the next cache-clear.
+   *
+   * @param $extras
+   * @return void
+   */
+  function setMockSettingsMetaData($extras) {
+    CRM_Core_BAO_Setting::$_cache = array();
+    $this->callAPISuccess('system','flush', array());
+    CRM_Core_BAO_Setting::$_cache = array();
+
+    CRM_Utils_Hook::singleton()->setHook('civicrm_alterSettingsMetaData', function (&$metadata, $domainId, $profile) use ($extras) {
+      $metadata = array_merge($metadata, $extras);
+    });
+
+    $fields = $this->callAPISuccess('setting', 'getfields', array());
+    foreach ($extras as $key => $spec) {
+      $this->assertNotEmpty($spec['title']);
+      $this->assertEquals($spec['title'], $fields['values'][$key]['title']);
+    }
+  }
+
   function financialAccountDelete($name) {
     $financialAccount = new CRM_Financial_DAO_FinancialAccount();
     $financialAccount->name = $name;


### PR DESCRIPTION
The problem in CRM-13768 is that the activation-logic for CiviCase was wrapped up inside the administration forms (CRM_Admin_Form_Setting_Component::postProcess), and the activation-logic would not be called if one toggled CiviCase using the Setting API. This PR addresses the problem with a few steps:
1. Add support for using callbacks whenever a setting is changed
2. Move CiviCase activation logic out of the form layer (to somewhere more re-usable)
3. Call CiviCase activation logic whenever one changes the "enabled components" setting
