### PR TITLE
CRM-13690 - CiviMail - prevent html2text treating mailing tokens as rela...

### DIFF
--- a/tests/phpunit/CRM/Utils/HtmlToTextTest.php
+++ b/tests/phpunit/CRM/Utils/HtmlToTextTest.php
@@ -17,7 +17,17 @@ mailto tags. This is also a really long long line
 Links:
 ------
 [1] http://www.example.com
-'
+',
+    '
+<p>
+A <a href="{action.do_something}">token</a>
+is not treated as a relative URL' => '
+A token [1] is not treated as a relative URL
+
+Links:
+------
+[1] {action.do_something}
+',
   );
 
   function get_info() {


### PR DESCRIPTION
...tive URLs

---
- CRM-13690: html2text fails to convert Mailing token links
  http://issues.civicrm.org/jira/browse/CRM-13690
