### PR TITLE
CRM-13779 - CiviEvent - fire skipPaymentMethod on select boxes

### DIFF
--- a/templates/CRM/Event/Form/Registration/Register.tpl
+++ b/templates/CRM/Event/Form/Registration/Register.tpl
@@ -227,7 +227,7 @@
       }
     }
 
-    cj('#priceset input').change(function () {
+    cj('#priceset input, #priceset select').change(function () {
       skipPaymentMethod();
     });
 


### PR DESCRIPTION
---
- CRM-13779: Events with Price Sets with only Select boxes don't allow payment
  http://issues.civicrm.org/jira/browse/CRM-13779
