### PR TITLE
CRM-13800 Prevent people from enabling contribution amounts when there's a membership price set

### DIFF
--- a/CRM/Contribute/Form/ContributionPage.php
+++ b/CRM/Contribute/Form/ContributionPage.php
@@ -210,6 +210,25 @@ class CRM_Contribute_Form_ContributionPage extends CRM_Core_Form {
       $this->freeze();
       $this->addElement('button', 'done', ts('Done'), array('onclick' => "location.href='civicrm/admin/custom/group?reset=1&action=browse'"));
     }
+    
+    // don't show option for contribution amounts section if membership price set
+    // this flag is sent to template
+    
+    $membershipBlock = new CRM_Member_DAO_MembershipBlock();
+    $membershipBlock->entity_table = 'civicrm_contribution_page';
+    $membershipBlock->entity_id = $this->_id;
+    $membershipBlock->is_active = 1;
+    $hasMembershipBlk = FALSE;
+    if ($membershipBlock->find(TRUE) && 
+      ($setID = CRM_Price_BAO_PriceSet::getFor('civicrm_contribution_page', $this->_id, NULL, 1))
+    ) {
+      $extends = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $setID, 'extends');
+      if ($extends && $extends == CRM_Core_Component::getComponentID('CiviMember')) {
+        $hasMembershipBlk = TRUE;
+      }
+    }
+    // set value in DOM that membership price set exists
+    CRM_Core_Resources::singleton()->addSetting(array('memberPriceset' => $hasMembershipBlk));
   }
 
   /**

--- a/templates/CRM/Contribute/Form/ContributionPage/Amount.tpl
+++ b/templates/CRM/Contribute/Form/ContributionPage/Amount.tpl
@@ -232,9 +232,12 @@
   if ( ! amount_block[0].checked || priceSetID ) {
      if ( !priceSetID ) {
        cj('#priceSet').hide();
+       if (CRM.memberPriceset) {
+         cj(".crm-contribution-contributionpage-amount-form-block-amount_block_is_active td").html('<span class="description">{/literal}{ts}You cannot enable the Contribution Amounts section when a Membership Price Set is in use. (See the Memberships tab above.) Membership Price Sets may include additional fields for non-membership options that require an additional fee (e.g. magazine subscription) or an additional voluntary contribution.</span>{/ts}{literal}');
+       }
      }
      cj('#amountFields').hide();
-        }
+  }
 
   cj(function() {
     payLater('is_pay_later');


### PR DESCRIPTION
If someone has a membership price set enabled on a contribution page, they still see the checkbox to enable the contribution amounts section. Checking that box displays an error on validation, but it's a cruel trick to let someone check something they won't be allowed to check.

I made a little change to hide and explain it if there's a membership price set in use.
