### PR TITLE
Honor role fixes on personal campaign pages

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -528,7 +528,8 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
         $elements[]  = &$this->createElement('radio', NULL, '', ts('Include my name and message'), 0, $extraOption);
         $elements[]  = &$this->createElement('radio', NULL, '', ts('List my contribution anonymously'), 1, $extraOption);
         $this->addGroup($elements, 'pcp_is_anonymous', NULL, '&nbsp;&nbsp;&nbsp;');
-        $this->_defaults['pcp_is_anonymous'] = 0;
+        $this->setDefaults(array('pcp_display_in_roll' => 1));
+        $this->setDefaults(array('pcp_is_anonymous' => 1));
 
         $this->add('text', 'pcp_roll_nickname', ts('Name'), array('maxlength' => 30));
         $this->add('textarea', 'pcp_personal_note', ts('Personal Note'), array('style' => 'height: 3em; width: 40em;'));

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -517,18 +517,22 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
         $this->assign('pcpSupporterText', $pcp_supporter_text);
       }
       $this->assign('pcp', TRUE);
-      $this->add('checkbox', 'pcp_display_in_roll', ts('Show my contribution in the public honor roll'), NULL, NULL,
-        array('onclick' => "showHideByValue('pcp_display_in_roll','','nameID|nickID|personalNoteID','block','radio',false); pcpAnonymous( );")
-      );
-      $extraOption = array('onclick' => "return pcpAnonymous( );");
-      $elements    = array();
-      $elements[]  = &$this->createElement('radio', NULL, '', ts('Include my name and message'), 0, $extraOption);
-      $elements[]  = &$this->createElement('radio', NULL, '', ts('List my contribution anonymously'), 1, $extraOption);
-      $this->addGroup($elements, 'pcp_is_anonymous', NULL, '&nbsp;&nbsp;&nbsp;');
-      $this->_defaults['pcp_is_anonymous'] = 0;
+      $prms = array('id' => $this->_pcpId);
+      CRM_Core_DAO::commonRetrieve('CRM_PCP_DAO_PCP', $prms, $pcpInfo);
+      if ($pcpInfo['is_honor_roll']) {
+        $this->add('checkbox', 'pcp_display_in_roll', ts('Show my contribution in the public honor roll'), NULL, NULL,
+          array('onclick' => "showHideByValue('pcp_display_in_roll','','nameID|nickID|personalNoteID','block','radio',false); pcpAnonymous( );")
+        );
+        $extraOption = array('onclick' => "return pcpAnonymous( );");
+        $elements    = array();
+        $elements[]  = &$this->createElement('radio', NULL, '', ts('Include my name and message'), 0, $extraOption);
+        $elements[]  = &$this->createElement('radio', NULL, '', ts('List my contribution anonymously'), 1, $extraOption);
+        $this->addGroup($elements, 'pcp_is_anonymous', NULL, '&nbsp;&nbsp;&nbsp;');
+        $this->_defaults['pcp_is_anonymous'] = 0;
 
-      $this->add('text', 'pcp_roll_nickname', ts('Name'), array('maxlength' => 30));
-      $this->add('textarea', 'pcp_personal_note', ts('Personal Note'), array('style' => 'height: 3em; width: 40em;'));
+        $this->add('text', 'pcp_roll_nickname', ts('Name'), array('maxlength' => 30));
+        $this->add('textarea', 'pcp_personal_note', ts('Personal Note'), array('style' => 'height: 3em; width: 40em;'));
+      }
     }
 
     //we have to load confirm contribution button in template


### PR DESCRIPTION
When you are making a donation via a personal campaign page in which the honor role check box is not checked, you are still given the option to have your name listed in the honor role. This check box should not be visible if the PCP does not have honor role checked.

In addition, the default is to not have your donation listed. The default should be to have your donation listed (but anonymously) with the option to change to have your name included. That both preserves privacy and maximizes the outreach opportunity for having donations scroll by in the honor role.

See: http://issues.civicrm.org/jira/browse/CRM-13795

This pull request is against 4.4 and supersedes the one against master (https://github.com/civicrm/civicrm-core/pull/2025#issuecomment-28746542)
