### PR TITLE
CRM-13771 : faced a fatal error while reproducing this issue, fix done is handling of import error improvement which occurs when the data being imported is not a valid one

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -1038,6 +1038,18 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
         }
 
         if (civicrm_error($newContact)) {
+          if (!CRM_Utils_Array::value('params', $newContact['error_message'])) {
+            // different kind of error other than DUPLICATE
+            $errorMessage = $newContact['error_message'];
+            array_unshift($values, $errorMessage);
+            $importRecordParams = array(
+              $statusFieldName => 'ERROR',
+              "${statusFieldName}Msg" => $errorMessage,
+            );
+            $this->updateImportRecord($values[count($values) - 1], $importRecordParams);
+            return CRM_Import_Parser::ERROR;
+          }
+
           $contactID = $newContact['error_message']['params'][0];
           if (!in_array($contactID, $this->_newContacts)) {
             $this->_newContacts[] = $contactID;


### PR DESCRIPTION
When following steps are being done, a fatal error "Fatal error: Cannot use string offset as an array in /full_path_to/v44/CRM/Contact/Import/Parser/Contact.php" : 
1) Create a custom data field of type Integer.
2) Create a contact with first_name, last_name and email fields saved.
3) Create a .csv file consisting of mapping of first_name, last_name and newly created custom field respectively, this file should also have 2 contact records out of which a record should be the one created on 'step 2' and other one should not exists in civicrm database. Also the value for custom field should be empty i.e just a comma at the end.
4) Now visit the import screen and select this .csv file, also select 'Update' as Duplicate option for import.
5) Now perform the import wizard steps, in the mapping step map first_name, last_name, email, integer_type_custom_field and continue to Import.

Fix did is : handling any error other than the duplicate error which (in this scenario) as invalid custom field value . 
