### PR TITLE
CRM-13805 - Set a status alert if cURL is not installed.

### DIFF
--- a/CRM/Utils/HttpClient.php
+++ b/CRM/Utils/HttpClient.php
@@ -108,14 +108,17 @@ class CRM_Utils_HttpClient {
   /**
    * Send an HTTP GET for a remote resource
    *
-   * @param string $remoteFile URL of a .zip file
-   * @param string $localFile path at which to store the .zip file
+   * @param string $remoteFile URL of remote file
    * @return array array(0 => STATUS_OK|STATUS_DL_ERROR, 1 => string)
    */
   public function get($remoteFile) {
     // Download extension zip file ...
     if (!function_exists('curl_init')) {
-      //CRM_Core_Error::fatal('Cannot install this extension - curl is not installed!');
+      // CRM-13805
+      CRM_Core_Session::setStatus(
+        ts('As a result, actions like retrieving the CiviCRM news feed will fail. Talk to your server administrator or hosting company to rectify this.'),
+        ts('Curl is not installed')
+      );
       return array(self::STATUS_DL_ERROR, NULL);
     }
 


### PR DESCRIPTION
---
- CRM-13805: Fetching CiviCRM News fails silently if cURL is not installed
  http://issues.civicrm.org/jira/browse/CRM-13805
