### PR TITLE
Readability on createActivites

### DIFF
--- a/CRM/Contact/Form/Task/PDF.php
+++ b/CRM/Contact/Form/Task/PDF.php
@@ -74,9 +74,7 @@ class CRM_Contact_Form_Task_PDF extends CRM_Contact_Form_Task {
       // in search context 'id' is the default profile id for search display
       // CRM-11227
       $this->_activityId = CRM_Utils_Request::retrieve('id', 'Positive', $this, FALSE);
-    }
 
-    if ($cid) {
       CRM_Contact_Form_Task_PDFLetterCommon::preProcessSingle($this, $cid);
       $this->_single = TRUE;
       $this->_cid = $cid;


### PR DESCRIPTION
I was trying to debug something on target create & couldn't make sense of this fn so I interpreted it & found that most of it was easily removed. I have tested on a single contact & search results & activity is created (although on master it was not visible on the contact tab either before or after the changes.

NB it would be testable if the relevant formValues were passed in rather than the form
