### PR TITLE
Participant BAO can accept role IDs in an array

### DIFF
--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -106,6 +106,11 @@ class CRM_Event_BAO_Participant extends CRM_Event_DAO_Participant {
       $params['fee_amount'] = CRM_Utils_Rule::cleanMoney($params['fee_amount']);
     }
 
+    // ensure that role ids are encoded as a string
+    if (is_array($params['role_id'])) {
+      $params['role_id'] = implode(CRM_Core_DAO::VALUE_SEPARATOR, $params['role_id']);
+    }
+
     $participantBAO = new CRM_Event_BAO_Participant;
     if (CRM_Utils_Array::value('id', $params)) {
       $participantBAO->id = CRM_Utils_Array::value('id', $params);


### PR DESCRIPTION
This patch allows the Participant BAO to accept role IDs in an array. This fixes the problem of the Participant API not being able to accept multiple roles (<a href="http://issues.civicrm.org/jira/browse/CRM-13884">CRM-13884</a>).

When multiple roles are supplied to the Participant API as a delimiter-separated string of role IDs, the API automatically explodes that string into an array (in _civicrm_api3_api_match_pseudoconstant). This is then supplied to the Participant BAO (CRM_Event_BAO_Participant) which causes errors because the BAO is expecting a delimiter-separated string of role IDs, not an array.

With this patch, the Participant BAO accepts an array of role IDs in the same way that the Contact BAO accepts an array of contact sub-types: by checking if the parameter is supplied as an array, and if so, imploding it into a delimiter-separated string.

This solution is in keeping with the comment in _civicrm_api3_api_match_pseudoconstant (the function which, for better or worse, explodes the string of role IDs into an array) which states: "Better yet would be to... ensure that every dao/bao can handle array input".
