### PR TITLE
CRM-13885 follow up, set timezone when running cron

### DIFF
--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -175,11 +175,41 @@ abstract class CRM_Utils_System_Base {
     }
   }
 
+
   /**
    * Get timezone from CMS
    * @return boolean|string
    */
+  /**
+   * Get timezone from Drupal
+   * @return boolean|string
+   */
   function getTimeZoneOffset(){
+    $timezone = $this->getTimeZoneString();
+    if($timezone){
+      $tzObj = new DateTimeZone($timezone);
+      $dateTime = new DateTime("now", $tzObj);
+      $tz = $tzObj->getOffset($dateTime);
+
+      if(empty($tz)){
+        return false;
+      }
+
+      $timeZoneOffset = sprintf("%02d:%02d", $tz / 3600, ($tz/60)%60 );
+
+      if($timeZoneOffset > 0){
+        $timeZoneOffset = '+' . $timeZoneOffset;
+      }
+      return $timeZoneOffset;
+    }
+  }
+
+  /**
+   * Over-ridable function to get timezone as a string eg.
+   * @return string Timezone e.g. 'America/Los_Angeles'
+   */
+  function getTimeZoneString() {
+    return NULL;
   }
 }
 

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -433,6 +433,11 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
     }
 
     require_once ($cmsRootPath . DIRECTORY_SEPARATOR . 'wp-load.php');
+    $wpUserTimezone = get_option('timezone_string');
+    if ($wpUserTimezone) {
+      date_default_timezone_set($wpUserTimezone);
+      CRM_Core_Config::singleton()->userSystem->setMySQLTimeZone();
+    }
     return true;
   }
 
@@ -621,6 +626,14 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
     else {
       return 'Unknown';
     }
+  }
+
+  /**
+   * get timezone as a string
+   * @return string Timezone e.g. 'America/Los_Angeles'
+   */
+  function getTimeZoneString() {
+    return get_option('timezone_string');
   }
 }
 


### PR DESCRIPTION
Without setting timezone it may send reminders out based on an incorrect timezone assumption - e.g. sending after an event has completed. This has been somewhat intermittantly reported which is confusing as it would seem to affect a large portion of WP sites outside the UK

---
- CRM-12523: Wordpress timezone settings not carried to CiviCRM
  http://issues.civicrm.org/jira/browse/CRM-12523
