### PR TITLE
CRM-13861 : instead of strpos check on 'title' of profile lets do a check on profile's group type so that no translation specific issue arise

### DIFF
--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -1510,7 +1510,8 @@ AND cc.sort_name LIKE '%$name%'";
     } else {
       $contactTypes = array();
       foreach ($contactProfiles as $key => $value) {
-        if (strpos($value, $leftType) !== FALSE) {
+        $groupTypes = CRM_Core_BAO_UFGroup::profileGroups($key);
+        if (in_array($leftType, $groupTypes)) {
           $contactTypes = array($key => $value);
         }
       }


### PR DESCRIPTION
The fix is for the second point mentioned in issue description and WRT http://issues.civicrm.org/jira/browse/CRM-13861#comment-54537 comment.

In this code snippet we are doing a check for the purpose to show appropriate profile respecting the relationship type selected . We were doing this check using <code>strpos</code> function using 'title' of the profile. Hence this will break if database will have internationalized version of DB e.g spanish data in the DB . 

So improved checking to be done with the profile's group type rather then its 'title' .
