### PR TITLE
CRM-13880 - Fix testContributionCreateExample to reflect change in contr...

### DIFF
--- a/api/v3/examples/ContributionCreate.php
+++ b/api/v3/examples/ContributionCreate.php
@@ -46,7 +46,7 @@ function contribution_create_expectedresult(){
           'contact_id' => '1',
           'financial_type_id' => '1',
           'contribution_page_id' => '1',
-          'payment_instrument_id' => '',
+          'payment_instrument_id' => '4',
           'receive_date' => '20120511000000',
           'non_deductible_amount' => '',
           'total_amount' => '100',

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -644,7 +644,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $this->assertAPISuccess($result);
     $contributionId = $result['id'];
     $expectedResult = contribution_create_expectedresult();
-    $this->checkArrayEquals($result, $expectedResult);
+    $this->checkArrayEquals($expectedResult, $result);
     $this->contributionDelete($contributionId);
   }
 


### PR DESCRIPTION
...ibution create api to set payment_instrument automatically if not provided in params

---
- CRM-13880: Make payment instrument required for all contribution, event registration and membership forms
  http://issues.civicrm.org/jira/browse/CRM-13880
