### PR TITLE
CRM-13900 - Fix back to report URL.

### DIFF
--- a/CRM/Mailing/Page/Event.php
+++ b/CRM/Mailing/Page/Event.php
@@ -79,7 +79,7 @@ class CRM_Mailing_Page_Event extends CRM_Core_Page {
       $backUrlTitle = ts('Back to Mailing');
     }
     else {
-      $backUrl = CRM_Utils_System::url('civicrm/mailing', 'reset=1');
+      $backUrl = CRM_Utils_System::url('civicrm/mailing/report', "reset=1&mid={$mailing_id}");
       $backUrlTitle = ts('Back to Report');
     }
 


### PR DESCRIPTION
---
- CRM-13900: Back to Report listing in Mailing Event reports has the wrong URL
  http://issues.civicrm.org/jira/browse/CRM-13900
