### PR TITLE
CRM-13913 - api/v3/WordReplacement - Set default (is_active=1)

### DIFF
--- a/api/v3/WordReplacement.php
+++ b/api/v3/WordReplacement.php
@@ -71,6 +71,7 @@ function civicrm_api3_word_replacement_create($params) {
  * @param array $params array or parameters determined by getfields
  */
 function _civicrm_api3_word_replacement_create_spec(&$params) {
+  $params['is_active']['api.default'] = 1;
   unset($params['version']);
 }
 


### PR DESCRIPTION
---
- CRM-13913: WordReplacements created via API should default to enabled
  http://issues.civicrm.org/jira/browse/CRM-13913
