### PR TITLE
CRM-13913 - WordReplacement - is_active default

### DIFF
--- a/CRM/Upgrade/Incremental/sql/4.5.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.5.alpha1.mysql.tpl
@@ -58,3 +58,7 @@ ALTER TABLE `civicrm_mapping_field`
 ALTER TABLE civicrm_group
   ADD COLUMN `modified_id` INT(10) unsigned DEFAULT NULL COMMENT 'FK to contact table, modifier of the group.',
   ADD CONSTRAINT `FK_civicrm_group_modified_id` FOREIGN KEY (`modified_id`) REFERENCES `civicrm_contact`(`id`) ON DELETE SET NULL;
+
+-- CRM-13913
+ALTER TABLE civicrm_word_replacement
+  ALTER COLUMN `is_active` SET DEFAULT 1;

--- a/api/v3/WordReplacement.php
+++ b/api/v3/WordReplacement.php
@@ -71,7 +71,6 @@ function civicrm_api3_word_replacement_create($params) {
  * @param array $params array or parameters determined by getfields
  */
 function _civicrm_api3_word_replacement_create_spec(&$params) {
-  $params['is_active']['api.default'] = 1;
   unset($params['version']);
 }
 

--- a/xml/schema/Core/WordReplacement.xml
+++ b/xml/schema/Core/WordReplacement.xml
@@ -37,6 +37,7 @@
     <name>is_active</name>
     <title>Word Replacement is Active</title>
     <type>boolean</type>
+    <default>1</default>
     <comment>Is this entry active?</comment>
     <add>4.4</add>
   </field>


### PR DESCRIPTION
Use schema-based default instead of API-based default
