### PR TITLE
CRM-13890 - Test fixes (unit tests were coded against the buggy behavior...

### DIFF
--- a/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
@@ -213,7 +213,7 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $values = array();
     $this->assertFalse(empty($this->objects['event']));
     $msg = $this->IPN->sendMail($this->input, $this->ids, $this->objects, $values, False,True);
-    $this->assertContains('registration has been received and your status has been updated to registered', $msg['body']);
+    $this->assertContains('registration has been received and your status has been updated to Attended.', $msg['body']);
     $this->assertContains('Annual CiviCRM meet', $msg['html']);
   }
 

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -1236,7 +1236,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $mut->checkMailLog(array(
       'Annual CiviCRM meet',
       'Event',
-      'This letter is a confirmation that your registration has been received and your status has been updated to registered for the following',
+      'This letter is a confirmation that your registration has been received and your status has been updated to Registered.',
     ));
   $mut->stop();
 


### PR DESCRIPTION
... where real status was not included in output).

---
- CRM-13890: Participant status is not being passed to message template for online event registration
  http://issues.civicrm.org/jira/browse/CRM-13890
