### PR TITLE
CRM-13919 - Add form rule to prevent fatal error when user enters a dupl...

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -938,6 +938,17 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       && $financialType = CRM_Contribute_BAO_Contribution::validateFinancialType($fields['financial_type_id'])) {
       $errors['financial_type_id'] = ts("Financial Account of account relationship of 'Expense Account is' is not configured for Financial Type : ") . $financialType;  
     }
+    
+    // $trxn_id must be unique CRM-13919
+    if (!empty($fields['trxn_id'])) {
+      $query = 'select count(*) from civicrm_contribution where trxn_id = %1 and id != %2';
+      $tCnt = CRM_Core_DAO::singleValueQuery($query, array(1 => array($fields['trxn_id'], 'String'),
+          2 => array((int)$self->_id, 'Integer'),
+        ));
+      if ($tCnt) {
+        $errors['trxn_id'] = ts('Transaction ID\'s must be unique. Transaction \'%1\' already exists in your database.', array(1 => $fields['trxn_id']));
+      }      
+    }
 
     $errors = array_merge($errors, $softErrors);
     return $errors;


### PR DESCRIPTION
...ice trxn_id (there is a unique index on that column in civicrm_contribution table).

---
- CRM-13919: Fatal error when user accidentally uses duplicate transaction # while recording a contrib.
  http://issues.civicrm.org/jira/browse/CRM-13919
