### PR TITLE
Update CheckoutAJAX.php

### DIFF
--- a/CRM/Event/Cart/Page/CheckoutAJAX.php
+++ b/CRM/Event/Cart/Page/CheckoutAJAX.php
@@ -8,12 +8,10 @@ class CRM_Event_Cart_Page_CheckoutAJAX {
 
     $cart = CRM_Event_Cart_BAO_Cart::find_by_id($_GET['cart_id']);
 
-    //XXX security
-    $participant = CRM_Event_Cart_BAO_MerParticipant::create(array(
-        'cart_id' => $cart->id,
-        'contact_id' => CRM_Event_Cart_Form_Cart::find_or_create_contact(),
-        'event_id' => $event_id,
-      ));
+	  $params_array = array('cart_id' => $cart->id, 'contact_id' => CRM_Event_Cart_Form_Cart::find_or_create_contact(), 'event_id' => $event_id);
+
+    //XXX security?
+    $participant = CRM_Event_Cart_BAO_MerParticipant::create($params_array);
     $participant->save();
 
     $form = new CRM_Core_Form();


### PR DESCRIPTION
Fix for Fatal Error: Cannot pass parameter 1 by reference line 16 of modules/civicrm/CRM/Event/Cart/Page/CheckoutAJAX.php
