### PR TITLE
CRM_Report_Form - Use consistent capitalization (title-case)

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -999,7 +999,7 @@ class CRM_Report_Form extends CRM_Core_Form {
       $this->assign('group', TRUE);
     }
 
-    $label = ts('Add these Contacts to Group');
+    $label = ts('Add These Contacts to Group');
     $this->addElement('submit', $this->_groupButtonName, $label, array('onclick' => 'return checkGroup();'));
 
     $this->addChartOptions();


### PR DESCRIPTION
Any of these formulations would be acceptable alternatives to status quo:
- Title case: "Add These Contacts to Group"
- Simplified title case: "Add These Contacts To Group"
- Sentence case: "Add these contacts to group"
