### PR TITLE
CRM-13710 fix - Required prices sets still required even when not active

### DIFF
--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -802,6 +802,7 @@ WHERE  id = %1";
 
     $priceSet           = self::getSetDetail($priceSetId, TRUE, $validFieldsOnly);
     $form->_priceSet    = CRM_Utils_Array::value($priceSetId, $priceSet);
+    $validPriceFieldIds = array_keys($form->_priceSet['fields']);
     $form->_quickConfig = $quickConfig = 0;
     if (CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $priceSetId, 'is_quick_config')) {
       $quickConfig = 1;
@@ -831,7 +832,7 @@ WHERE  id = %1";
     // call the hook.
     CRM_Utils_Hook::buildAmount($component, $form, $feeBlock);
 
-    foreach ($feeBlock as $field) {
+    foreach ($feeBlock as $id => $field) {
       if (CRM_Utils_Array::value('visibility', $field) == 'public' ||
         !$validFieldsOnly
       ) {
@@ -842,7 +843,7 @@ WHERE  id = %1";
             $form->assign('ispricelifetime', TRUE);
           }
         }
-        if (!is_array($options)) {
+        if (!is_array($options) || !in_array($id, $validPriceFieldIds)) {
           continue;
         }
         CRM_Price_BAO_PriceField::addQuickFormElement($form,


### PR DESCRIPTION
Issue was occurring because the priceset form element which we are assigning to template is not the same on which the formRule is performing validation instead using $form->_values['fee'] which I found that it contains the DAO object values of the priceset used where in-activeness check is not performed unlike $priceSet = self::getSetDetail($priceSetId, TRUE, $validFieldsOnly) which we are currently using. My changes is syncing the two variables to act like one. 
