### PR TITLE
CRM-13859 - set database connection to UTF-8

### DIFF
--- a/install/civicrm.php
+++ b/install/civicrm.php
@@ -123,6 +123,7 @@ function civicrm_source($dsn, $fileName, $lineMode = FALSE) {
   if (PEAR::isError($db)) {
     die("Cannot open $dsn: " . $db->getMessage());
   }
+  $db->query("SET NAMES utf8");
 
   if (!$lineMode) {
     $string = file_get_contents($fileName);


### PR DESCRIPTION
Make sure the install sql files are imported with UTF-8 as encoding
