### PR TITLE
CRM-13960 - import - ensure empty fields don't throw validation errors

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -1891,8 +1891,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
 
     //now format custom data.
     foreach ($params as $key => $field) {
-        if (!isset($field)){
-        //      if ($field == NULL || $field === '') {
+      if (!isset($field) || empty($field)){
         unset($params[$key]);
         continue;
       }


### PR DESCRIPTION
---
- CRM-13960: importing an empty custom data value for bolean type results in validation error
  http://issues.civicrm.org/jira/browse/CRM-13960
