### PR TITLE
CRM-13711 fix - Price-set validation break in noAmount and noLabel case ...

### DIFF
--- a/CRM/Price/Form/Field.php
+++ b/CRM/Price/Form/Field.php
@@ -564,7 +564,7 @@ class CRM_Price_Form_Field extends CRM_Core_Form {
         }
         $_showHide->addToTemplate();
 
-        if ($countemptyrows == 11) {
+        if ($countemptyrows == 15) {
           $errors['option_label[1]'] = $errors['option_amount[1]'] = ts('Label and value cannot be empty.');
           $_flagOption = 1;
         }


### PR DESCRIPTION
...for non Text type price field

http://issues.civicrm.org/jira/browse/CRM-13711

I think this should go in 4.4 as it is a clear bug, a probable regression with a very small & sensible seeming fix
