### PR TITLE
Fixes CRM-13979 by moving the status update out of the BAO layer.

### DIFF
--- a/CRM/Admin/Form/Tag.php
+++ b/CRM/Admin/Form/Tag.php
@@ -166,7 +166,9 @@ class CRM_Admin_Form_Tag extends CRM_Admin_Form {
 
     if ($this->_action == CRM_Core_Action::DELETE) {
       if ($this->_id > 0) {
+        $tag = civicrm_api3('tag', 'getsingle', array('id' => $this->_id));
         CRM_Core_BAO_Tag::del($this->_id);
+        CRM_Core_Session::setStatus(ts('The tag \'%1\' has been deleted.', array(1 => $tag->name)), ts('Deleted'), 'success');
       }
     }
     else {

--- a/CRM/Core/BAO/Tag.php
+++ b/CRM/Core/BAO/Tag.php
@@ -286,7 +286,6 @@ class CRM_Core_BAO_Tag extends CRM_Core_DAO_Tag {
 
     if ($tag->delete()) {
       CRM_Utils_Hook::post('delete', 'Tag', $id, $tag);
-      CRM_Core_Session::setStatus(ts('Selected tag has been deleted successfuly.'), ts('Tag Deleted'), 'success');
       return TRUE;
     }
     return FALSE;


### PR DESCRIPTION
When the Tag_BAO layer calls setStatus it removes the developer's control over status messages. Instead, the burden should always be placed on the calling context to set the appropriate status, if necessary. 

I ran into this when our AJAX call that used the civicrm_api to delete a tag was generating status messages on the next page (because the api in turn used the BAO layer). By the time the user loads another page, these message are no longer relevant and can become confusing.

See: http://issues.civicrm.org/jira/browse/CRM-13979
