### PR TITLE
CRM-12464 - Pseudoconstant - Skip default condition in validate context

### DIFF
--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -303,7 +303,8 @@ class CRM_Core_PseudoConstant {
       $pseudoconstant = $fieldSpec['pseudoconstant'];
       // Merge params with schema defaults
       $params += array(
-        'condition' => CRM_Utils_Array::value('condition', $pseudoconstant, array()),
+        // Skip default condition in validate context
+        'condition' => $context == 'validate' ? array() : CRM_Utils_Array::value('condition', $pseudoconstant, array()),
         'keyColumn' => CRM_Utils_Array::value('keyColumn', $pseudoconstant),
         'labelColumn' => CRM_Utils_Array::value('labelColumn', $pseudoconstant),
       );


### PR DESCRIPTION
Fix for past-campaign issue noticed by eileen in https://github.com/civicrm/civicrm-core/pull/2267
