### PR TITLE
Test fixes / enotice compliance

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1550,11 +1550,15 @@ AND civicrm_membership.is_test = %2";
 
     //decide status here, if needed.
     $updateStatusId = NULL;
-
+    $membershipID = NULL;
+    //@todo would be better to accept $membershipID as an FN param & make form layer responsible for extracting it
+    if(isset($form->_membershipId)) {
+      $membershipID = $form->_membershipId;
+    }
     // CRM-7297 - allow membership type to be be changed during renewal so long as the parent org of new membershipType
     // is the same as the parent org of an existing membership of the contact
     $currentMembership = CRM_Member_BAO_Membership::getContactMembership($contactID, $membershipTypeID,
-      $is_test, $form->_membershipId, TRUE
+      $is_test, $membershipID, TRUE
     );
     if ($currentMembership) {
       $activityType = 'Membership Renewal';

--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -519,7 +519,7 @@ class CRM_Utils_Array {
         } else {
           $keyvalue = $record->{$key};
         }
-        if (!is_array($node[$keyvalue])) {
+        if (isset($node[$keyvalue]) && !is_array($node[$keyvalue])) {
           $node[$keyvalue] = array();
         }
         $node = &$node[$keyvalue];

--- a/CRM/Utils/DeprecatedUtils.php
+++ b/CRM/Utils/DeprecatedUtils.php
@@ -1341,6 +1341,9 @@ function _civicrm_api3_deprecated_contact_check_params(
 
 
     // contact_type has a limited number of valid values
+    if(empty($params['contact_type'])) {
+      return civicrm_api3_create_error("No Contact Type");
+    }
     $fields = CRM_Utils_Array::value($params['contact_type'], $required);
     if ($fields == NULL) {
       return civicrm_api3_create_error("Invalid Contact Type: {$params['contact_type']}");

--- a/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
@@ -3,10 +3,6 @@ require_once 'CiviTest/CiviUnitTestCase.php';
 require_once 'CiviTest/Contact.php';
 require_once 'CiviTest/Custom.php';
 class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
-  //@todo make BAO enotice compliant  & remove the line below
-  // WARNING - NEVER COPY & PASTE $_eNoticeCompliant = FALSE
-  // new test classes should be compliant.
-  public $_eNoticeCompliant = FALSE;
   function get_info() {
     return array(
       'name' => 'Custom Field BAOs',

--- a/tests/phpunit/CRM/Core/BAO/PhoneTest.php
+++ b/tests/phpunit/CRM/Core/BAO/PhoneTest.php
@@ -31,10 +31,6 @@ require_once 'CiviTest/Contact.php';
 require_once 'CiviTest/Custom.php';
 require_once 'CiviTest/Event.php';
 class CRM_Core_BAO_PhoneTest extends CiviUnitTestCase {
-  //@todo make BAO enotice compliant  & remove the line below
-  // WARNING - NEVER COPY & PASTE $_eNoticeCompliant = FALSE
-  // new test classes should be compliant.
-  public $_eNoticeCompliant = FALSE;
   function get_info() {
     return array(
       'name' => 'Phone BAOs',

--- a/tests/phpunit/CRM/Core/ErrorTest.php
+++ b/tests/phpunit/CRM/Core/ErrorTest.php
@@ -31,10 +31,6 @@ require_once 'CiviTest/CiviUnitTestCase.php';
  * Tests for linking to resource files
  */
 class CRM_Core_ErrorTest extends CiviUnitTestCase {
-  //@todo make BAO enotice compliant  & remove the line below
-  // WARNING - NEVER COPY & PASTE $_eNoticeCompliant = FALSE
-  // new test classes should be compliant.
-  public $_eNoticeCompliant = FALSE;
   function get_info() {
     return array(
       'name'    => 'Errors',

--- a/tests/phpunit/CRM/Event/BAO/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/BAO/ParticipantTest.php
@@ -32,10 +32,6 @@ require_once 'CiviTest/Contact.php';
 require_once 'CiviTest/Event.php';
 require_once 'CiviTest/Participant.php';
 class CRM_Event_BAO_ParticipantTest extends CiviUnitTestCase {
-  //@todo make BAO enotice compliant  & remove the line below
-  // WARNING - NEVER COPY & PASTE $_eNoticeCompliant = FALSE
-  // new test classes should be compliant.
-  public $_eNoticeCompliant = FALSE;
   function get_info() {
     return array(
       'name' => 'Participant BAOs',
@@ -103,6 +99,7 @@ class CRM_Event_BAO_ParticipantTest extends CiviUnitTestCase {
   function testgetValuesWithValidParams() {
     $participantId = Participant::create($this->_contactId, $this->_eventId);
     $params = array('id' => $participantId);
+    $values = $ids = array();
 
     $fetchParticipant = CRM_Event_BAO_Participant::getValues($params, $values, $ids);
     $compareValues = $fetchParticipant[$participantId];
@@ -118,11 +115,15 @@ class CRM_Event_BAO_ParticipantTest extends CiviUnitTestCase {
       'source' => 'Event_' . $this->_eventId,
       'contact_id' => $this->_contactId,
       'id' => $participantId,
+      'campaign_id' => NULL,
       'fee_level' => NULL,
       'fee_amount' => NULL,
       'registered_by_id' => NULL,
       'discount_id' => NULL,
       'fee_currency' => NULL,
+      'discount_amount' => NULL,
+      'cart_id' => NULL,
+      'must_wait' => NULL,
     );
 
     foreach ($compareValues as $key => $value) {
@@ -349,7 +350,7 @@ class CRM_Event_BAO_ParticipantTest extends CiviUnitTestCase {
 
     $paramsSet['title'] = 'Price Set';
     $paramsSet['name'] = CRM_Utils_String::titleToVar('Price Set');
-    $paramsSet['is_active'] = CRM_Utils_Array::value('is_active', $params, FALSE);
+    $paramsSet['is_active'] = FALSE;
     $paramsSet['extends'] = 1;
 
     $priceset = CRM_Price_BAO_PriceSet::create($paramsSet);

--- a/tests/phpunit/CRM/Member/BAO/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipTest.php
@@ -34,10 +34,6 @@ require_once 'CiviTest/Membership.php';
 require_once 'CRM/Core/Controller.php';
 
 class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
-  //@todo make BAO enotice compliant  & remove the line below
-  // WARNING - NEVER COPY & PASTE $_eNoticeCompliant = FALSE
-  // new test classes should be compliant.
-  public $_eNoticeCompliant = FALSE;
   function get_info() {
     return array(
       'name' => 'Membership BAOs',
@@ -211,6 +207,7 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
       'contact_id', 'Database check for created membership.'
     );
     $params = array('id' => $membershipId);
+    $values = array();
     CRM_Member_BAO_Membership::retrieve($params, $values);
     $this->assertEquals($values['id'], $membershipId, 'Verify membership record is retrieved.');
 
@@ -239,6 +236,7 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
     );
 
     $params = array('id' => $membershipId1);
+    $values1 = array();
     CRM_Member_BAO_Membership::retrieve($params, $values1);
     $membership = array($membershipId1 => $values1);
 
@@ -260,6 +258,7 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
     );
 
     $params = array('id' => $membershipId2);
+    $values2 = array();
     CRM_Member_BAO_Membership::retrieve($params, $values2);
     $membership[$membershipId2] = $values2;
 

--- a/tests/phpunit/CRM/Member/Import/Parser/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Import/Parser/MembershipTest.php
@@ -34,8 +34,6 @@ require_once 'CiviTest/Membership.php';
  *  @package   CiviCRM
  */
 class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
-
-  public $_eNoticeCompliant = TRUE;
   /**
    * Membership type name used in test function
    * @var String
@@ -87,6 +85,7 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
       'fixed_period_start_day' => 101,
       'fixed_period_rollover_day' => 1231
     );
+    $ids = array();
     $membershipType = CRM_Member_BAO_MembershipType::add($params, $ids);
     $this->_membershipTypeID = $membershipType->id;
 

--- a/tests/phpunit/CRM/UF/Page/ProfileEditorTest.php
+++ b/tests/phpunit/CRM/UF/Page/ProfileEditorTest.php
@@ -2,10 +2,6 @@
 require_once 'CiviTest/CiviUnitTestCase.php';
 
 class CRM_UF_Page_ProfileEditorTest extends CiviUnitTestCase {
-  //@todo make BAO enotice compliant  & remove the line below
-  // WARNING - NEVER COPY & PASTE $_eNoticeCompliant = FALSE
-  // new test classes should be compliant.
-  public $_eNoticeCompliant = FALSE;
   function setUp() {
     parent::setUp();
   }
@@ -24,24 +20,24 @@ class CRM_UF_Page_ProfileEditorTest extends CiviUnitTestCase {
     }
 
     $this->assertEquals('Individual', $schema['IndividualModel']['schema']['first_name']['civiFieldType']);
-    $this->assertEmpty($schema['IndividualModel']['schema']['first_name']['civiIsLocation']);
-    $this->assertEmpty($schema['IndividualModel']['schema']['first_name']['civiIsPhone']);
+    $this->assertTrue(empty($schema['IndividualModel']['schema']['first_name']['civiIsLocation']));
+    $this->assertTrue(empty($schema['IndividualModel']['schema']['first_name']['civiIsPhone']));
 
     $this->assertEquals('Contact', $schema['IndividualModel']['schema']['street_address']['civiFieldType']);
     $this->assertNotEmpty($schema['IndividualModel']['schema']['street_address']['civiIsLocation']);
-    $this->assertEmpty($schema['IndividualModel']['schema']['street_address']['civiIsPhone']);
+    $this->assertTrue(empty($schema['IndividualModel']['schema']['street_address']['civiIsPhone']));
 
     $this->assertEquals('Contact', $schema['IndividualModel']['schema']['phone_and_ext']['civiFieldType']);
     $this->assertNotEmpty($schema['IndividualModel']['schema']['phone_and_ext']['civiIsLocation']);
     $this->assertNotEmpty($schema['IndividualModel']['schema']['phone_and_ext']['civiIsPhone']);
 
     $this->assertEquals('Activity', $schema['ActivityModel']['schema']['activity_subject']['civiFieldType']);
-    $this->assertEmpty($schema['ActivityModel']['schema']['activity_subject']['civiIsLocation']);
-    $this->assertEmpty($schema['ActivityModel']['schema']['activity_subject']['civiIsPhone']);
+    $this->assertTrue(empty($schema['ActivityModel']['schema']['activity_subject']['civiIsLocation']));
+    $this->assertTrue(empty($schema['ActivityModel']['schema']['activity_subject']['civiIsPhone']));
 
     // don't mix up contacts and activities
-    $this->assertEmpty($schema['IndividualModel']['schema']['activity_subject']);
-    $this->assertEmpty($schema['ActivityModel']['schema']['street_address']);
+    $this->assertTrue(empty($schema['IndividualModel']['schema']['activity_subject']));
+    $this->assertTrue(empty($schema['ActivityModel']['schema']['street_address']));
 
   }
 }

--- a/tests/phpunit/CRM/Utils/ArrayTest.php
+++ b/tests/phpunit/CRM/Utils/ArrayTest.php
@@ -1,10 +1,6 @@
 <?php
 require_once 'CiviTest/CiviUnitTestCase.php';
 class CRM_Utils_ArrayTest extends CiviUnitTestCase {
-  //@todo make BAO enotice compliant  & remove the line below
-  // WARNING - NEVER COPY & PASTE $_eNoticeCompliant = FALSE
-  // new test classes should be compliant.
-  public $_eNoticeCompliant = FALSE;
   function testBreakReference() {
     // Get a reference and make a change
     $fooRef1 = self::returnByReference();

--- a/tests/phpunit/CRM/Utils/DeprecatedUtilsTest.php
+++ b/tests/phpunit/CRM/Utils/DeprecatedUtilsTest.php
@@ -4,10 +4,6 @@ require_once 'CiviTest/CiviUnitTestCase.php';
 require_once 'CRM/Utils/DeprecatedUtils.php';
 
 class CRM_Utils_DeprecatedUtilsTest extends CiviUnitTestCase {
-  //@todo make BAO enotice compliant  & remove the line below
-  // WARNING - NEVER COPY & PASTE $_eNoticeCompliant = FALSE
-  // new test classes should be compliant.
-  public $_eNoticeCompliant = FALSE;
 
   function get_info() {
     return array(

--- a/tests/phpunit/CRM/Utils/Migrate/ImportExportTest.php
+++ b/tests/phpunit/CRM/Utils/Migrate/ImportExportTest.php
@@ -2,7 +2,6 @@
 require_once 'CiviTest/CiviUnitTestCase.php';
 class CRM_Utils_Migrate_ImportExportTest extends CiviUnitTestCase {
   protected $_apiversion;
-  public $_eNoticeCompliant = TRUE;
 
   function setUp() {
     $this->_apiversion = 3;

--- a/tests/phpunit/CRM/Utils/StringTest.php
+++ b/tests/phpunit/CRM/Utils/StringTest.php
@@ -1,10 +1,6 @@
 <?php
 require_once 'CiviTest/CiviUnitTestCase.php';
 class CRM_Utils_StringTest extends CiviUnitTestCase {
-  //@todo make BAO enotice compliant  & remove the line below
-  // WARNING - NEVER COPY & PASTE $_eNoticeCompliant = FALSE
-  // new test classes should be compliant.
-  public $_eNoticeCompliant = FALSE;
   function get_info() {
     return array(
       'name' => 'String Test',
@@ -80,8 +76,8 @@ class CRM_Utils_StringTest extends CiviUnitTestCase {
       $actual = array();
       CRM_Utils_String::extractName($case['full_name'], $actual);
       $this->assertEquals($actual['first_name'], $case['first_name']);
-      $this->assertEquals($actual['last_name'], $case['last_name']);
-      $this->assertEquals($actual['middle_name'], $case['middle_name']);
+      $this->assertEquals(CRM_Utils_Array::value('last_name', $actual), CRM_Utils_Array::value('last_name', $case));
+      $this->assertEquals(CRM_Utils_Array::value('middle_name', $actual), CRM_Utils_Array::value('middle_name', $case));
     }
   }
 

--- a/tests/phpunit/api/v3/ACLCachingTest.php
+++ b/tests/phpunit/api/v3/ACLCachingTest.php
@@ -38,7 +38,7 @@ require_once 'CiviTest/CiviUnitTestCase.php';
 class api_v3_ACLCachingTest extends CiviUnitTestCase {
   protected $_apiversion = 3;
   protected $_params;
-  public $_eNoticeCompliant = TRUE;
+
   public $DBResetRequired = FALSE;
 
   function setUp() {

--- a/tests/phpunit/api/v3/ACLPermissionTest.php
+++ b/tests/phpunit/api/v3/ACLPermissionTest.php
@@ -40,7 +40,7 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
   protected $hookClass = NULL;
   public $DBResetRequired = FALSE;
 
-  public $_eNoticeCompliant = TRUE;
+
 
   protected $_entity;
 

--- a/tests/phpunit/api/v3/APITest.php
+++ b/tests/phpunit/api/v3/APITest.php
@@ -35,7 +35,7 @@ require_once 'CiviTest/CiviUnitTestCase.php';
  */
 class api_v3_APITest extends CiviUnitTestCase {
   public $DBResetRequired = FALSE;
-  public $_eNoticeCompliant = TRUE;
+
 
   protected $_apiversion =3;
 

--- a/tests/phpunit/api/v3/APIWrapperTest.php
+++ b/tests/phpunit/api/v3/APIWrapperTest.php
@@ -36,7 +36,7 @@ require_once 'api/Wrapper.php';
  */
 class api_v3_APIWrapperTest extends CiviUnitTestCase {
   public $DBResetRequired = FALSE;
-  public $_eNoticeCompliant = TRUE;
+
 
   protected $_apiversion = 3;
 

--- a/tests/phpunit/api/v3/ActionScheduleTest.php
+++ b/tests/phpunit/api/v3/ActionScheduleTest.php
@@ -38,7 +38,7 @@ class api_v3_ActionScheduleTest extends CiviUnitTestCase {
   protected $_entity = 'action_schedule';
   protected $_apiversion = 3;
 
-  public $_eNoticeCompliant = TRUE;
+
 
   /**
    *  Test setup for every test

--- a/tests/phpunit/api/v3/ActivityTypeTest.php
+++ b/tests/phpunit/api/v3/ActivityTypeTest.php
@@ -35,7 +35,7 @@ require_once 'CiviTest/CiviUnitTestCase.php';
 
 class api_v3_ActivityTypeTest extends CiviUnitTestCase {
   protected $_apiversion;
-  public $_eNoticeCompliant = TRUE;
+
 
   function get_info() {
     return array(

--- a/tests/phpunit/api/v3/AddressTest.php
+++ b/tests/phpunit/api/v3/AddressTest.php
@@ -38,7 +38,7 @@ class api_v3_AddressTest extends CiviUnitTestCase {
   protected $_contactID;
   protected $_locationType;
   protected $_params;
-  public $_eNoticeCompliant = TRUE;
+
   protected $_entity;
 
   function setUp() {

--- a/tests/phpunit/api/v3/BatchTest.php
+++ b/tests/phpunit/api/v3/BatchTest.php
@@ -33,7 +33,7 @@ require_once 'CiviTest/CiviUnitTestCase.php';
  *  @package CiviCRM_APIv3
  */
 class api_v3_BatchTest extends CiviUnitTestCase {
-  public $_eNoticeCompliant = TRUE;
+
   protected $_params = array();
   protected $_entity = 'batch';
 

--- a/tests/phpunit/api/v3/CampaignTest.php
+++ b/tests/phpunit/api/v3/CampaignTest.php
@@ -31,7 +31,7 @@ class api_v3_CampaignTest extends CiviUnitTestCase {
   protected $_apiversion;
   protected $params;
   protected $id;
-  public $_eNoticeCompliant = TRUE;
+
   public $DBResetRequired = FALSE;
 
   function setUp() {

--- a/tests/phpunit/api/v3/CaseTest.php
+++ b/tests/phpunit/api/v3/CaseTest.php
@@ -47,7 +47,7 @@ class api_v3_CaseTest extends CiviUnitTestCase {
   protected $caseStatusGroup;
   protected $caseTypeGroup;
   protected $optionValues;
-  public $_eNoticeCompliant = TRUE;
+
   /**
    *  Test setup for every test
    *

--- a/tests/phpunit/api/v3/ConstantTest.php
+++ b/tests/phpunit/api/v3/ConstantTest.php
@@ -42,7 +42,7 @@ require_once 'CiviTest/CiviUnitTestCase.php';
  */
 class api_v3_ConstantTest extends CiviUnitTestCase {
   protected $_apiversion = 3;
-  public $_eNoticeCompliant = TRUE;
+
 
   /**
    *  Constructor

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -46,7 +46,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
   protected $_apiversion;
   protected $_entity;
   protected $_params;
-  public $_eNoticeCompliant = TRUE;
+
   protected $_contactID;
   protected $_financialTypeId =1;
 

--- a/tests/phpunit/api/v3/ContactTypeTest.php
+++ b/tests/phpunit/api/v3/ContactTypeTest.php
@@ -32,7 +32,7 @@
 require_once 'CiviTest/CiviUnitTestCase.php';
 class api_v3_ContactTypeTest extends CiviUnitTestCase {
   protected $_apiversion;
-  public $_eNoticeCompliant = TRUE;
+
   function setUp() {
     parent::setUp();
     $this->_apiversion = 3;

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -43,7 +43,7 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
   protected $contactIds = array();
   protected $_entity = 'contribution_page';
   protected $contribution_result = null;
-  public $_eNoticeCompliant = TRUE;
+
   public $DBResetRequired = TRUE;
   public function setUp() {
     parent::setUp();

--- a/tests/phpunit/api/v3/ContributionRecurTest.php
+++ b/tests/phpunit/api/v3/ContributionRecurTest.php
@@ -41,7 +41,7 @@ class api_v3_ContributionRecurTest extends CiviUnitTestCase {
   protected $params;
   protected $ids = array();
   protected $_entity = 'contribution_recur';
-  public $_eNoticeCompliant = TRUE;
+
   public $DBResetRequired = FALSE;
 
   function setUp() {

--- a/tests/phpunit/api/v3/ContributionSoftTest.php
+++ b/tests/phpunit/api/v3/ContributionSoftTest.php
@@ -48,7 +48,7 @@ class api_v3_ContributionSoftTest extends CiviUnitTestCase {
   protected $_entity = 'Contribution';
   public $debug = 0;
   protected $_params;
-  public $_eNoticeCompliant = TRUE;
+
 
   function setUp() {
     parent::setUp();

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -48,7 +48,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
   protected $_entity = 'Contribution';
   public $debug = 0;
   protected $_params;
-  public $_eNoticeCompliant = TRUE;
+
   function setUp() {
     parent::setUp();
 

--- a/tests/phpunit/api/v3/CustomFieldTest.php
+++ b/tests/phpunit/api/v3/CustomFieldTest.php
@@ -38,7 +38,7 @@ require_once 'tests/phpunit/CiviTest/CiviUnitTestCase.php';
  */
 class api_v3_CustomFieldTest extends CiviUnitTestCase {
   protected $_apiversion;
-  public $_eNoticeCompliant = TRUE;
+
   function get_info() {
     return array(
       'name' => 'Custom Field Create',

--- a/tests/phpunit/api/v3/CustomGroupTest.php
+++ b/tests/phpunit/api/v3/CustomGroupTest.php
@@ -39,7 +39,7 @@ class api_v3_CustomGroupTest extends CiviUnitTestCase {
   protected $_apiversion = 3;
   protected $_entity;
   protected $_params;
-  public $_eNoticeCompliant = TRUE;
+
   public $DBResetRequired = TRUE;
 
   function get_info() {

--- a/tests/phpunit/api/v3/CustomSearchTest.php
+++ b/tests/phpunit/api/v3/CustomSearchTest.php
@@ -4,7 +4,7 @@ require_once 'CiviTest/CiviUnitTestCase.php';
 
 class api_v3_CustomSearchTest extends CiviUnitTestCase {
   protected $_apiversion;
-  public $_eNoticeCompliant = TRUE;
+
   function setUp() {
     $this->_apiversion = 3;
     parent::setUp();

--- a/tests/phpunit/api/v3/CustomValueContactTypeTest.php
+++ b/tests/phpunit/api/v3/CustomValueContactTypeTest.php
@@ -39,7 +39,7 @@ class api_v3_CustomValueContactTypeTest extends CiviUnitTestCase {
   protected $_apiversion =3;
   protected $CustomGroupIndividual;
   protected $individualStudent;
-  public $_eNoticeCompliant = TRUE;
+
 
   function get_info() {
     return array(

--- a/tests/phpunit/api/v3/CustomValueTest.php
+++ b/tests/phpunit/api/v3/CustomValueTest.php
@@ -31,7 +31,7 @@ class api_v3_CustomValueTest extends CiviUnitTestCase {
   protected $individual;
   protected $params;
   protected $ids;
-  public $_eNoticeCompliant = TRUE;
+
   public $DBResetRequired = FALSE;
 
   function setUp() {

--- a/tests/phpunit/api/v3/DomainTest.php
+++ b/tests/phpunit/api/v3/DomainTest.php
@@ -44,7 +44,7 @@ class api_v3_DomainTest extends CiviUnitTestCase {
 
   protected $_apiversion = 3;
   protected $params;
-  public $_eNoticeCompliant = TRUE;
+
 
   /**
    *  Constructor

--- a/tests/phpunit/api/v3/EmailTest.php
+++ b/tests/phpunit/api/v3/EmailTest.php
@@ -32,7 +32,7 @@ class api_v3_EmailTest extends CiviUnitTestCase {
   protected $_locationType;
   protected $_entity;
   protected $_params;
-  public $_eNoticeCompliant = TRUE;
+
   function setUp() {
     $this->_apiversion = 3;
     $this->_entity = 'Email';

--- a/tests/phpunit/api/v3/EntityTagTest.php
+++ b/tests/phpunit/api/v3/EntityTagTest.php
@@ -45,7 +45,7 @@ class api_v3_EntityTagTest extends CiviUnitTestCase {
   protected $_apiversion = 3;
   protected $_tag;
   protected $_entity = 'entity_tag';
-  public $_eNoticeCompliant = TRUE;
+
 
   function setUp() {
     parent::setUp();

--- a/tests/phpunit/api/v3/EventTest.php
+++ b/tests/phpunit/api/v3/EventTest.php
@@ -32,7 +32,7 @@ class api_v3_EventTest extends CiviUnitTestCase {
   protected $_params;
   protected $_apiversion;
   protected $_entity;
-  public $_eNoticeCompliant = TRUE;
+
   function get_info() {
     return array(
       'name' => 'Event Create',

--- a/tests/phpunit/api/v3/GrantTest.php
+++ b/tests/phpunit/api/v3/GrantTest.php
@@ -40,7 +40,7 @@ class api_v3_GrantTest extends CiviUnitTestCase {
   protected $params;
   protected $ids = array();
   protected $_entity = 'Grant';
-  public $_eNoticeCompliant = TRUE;
+
   public $DBResetRequired = FALSE;
 
   function setUp() {

--- a/tests/phpunit/api/v3/GroupContactTest.php
+++ b/tests/phpunit/api/v3/GroupContactTest.php
@@ -34,7 +34,6 @@ class api_v3_GroupContactTest extends CiviUnitTestCase {
   protected $_contactId1;
   protected $_apiversion = 3;
   protected $_groupId1;
-  public $_eNoticeCompliant = True;
 
   function get_info() {
     return array(

--- a/tests/phpunit/api/v3/GroupNestingTest.php
+++ b/tests/phpunit/api/v3/GroupNestingTest.php
@@ -35,7 +35,6 @@ require_once 'CiviTest/CiviUnitTestCase.php';
  */
 class api_v3_GroupNestingTest extends CiviUnitTestCase {
   protected $_apiversion;
-  public $_eNoticeCompliant = True;
 
   /**
    * Sets up the fixture, for example, opens a network connection.

--- a/tests/phpunit/api/v3/GroupOrganizationTest.php
+++ b/tests/phpunit/api/v3/GroupOrganizationTest.php
@@ -35,7 +35,6 @@ require_once 'CiviTest/CiviUnitTestCase.php';
  */
 class api_v3_GroupOrganizationTest extends CiviUnitTestCase {
   protected $_apiversion;
-  public $_eNoticeCompliant = True;
 
   function get_info() {
     return array(

--- a/tests/phpunit/api/v3/GroupTest.php
+++ b/tests/phpunit/api/v3/GroupTest.php
@@ -36,7 +36,6 @@ require_once 'CiviTest/CiviUnitTestCase.php';
 class api_v3_GroupTest extends CiviUnitTestCase {
   protected $_apiversion;
   protected $_groupID;
-  public $_eNoticeCompliant = True;
 
   function get_info() {
     return array(

--- a/tests/phpunit/api/v3/ImTest.php
+++ b/tests/phpunit/api/v3/ImTest.php
@@ -40,7 +40,7 @@ class api_v3_ImTest extends CiviUnitTestCase {
   protected $params;
   protected $id;
   protected $_entity;
-  public $_eNoticeCompliant = TRUE;
+
   public $DBResetRequired = FALSE;
 
   function setUp() {

--- a/tests/phpunit/api/v3/JobTest.php
+++ b/tests/phpunit/api/v3/JobTest.php
@@ -38,7 +38,7 @@
 require_once 'CiviTest/CiviUnitTestCase.php';
 class api_v3_JobTest extends CiviUnitTestCase {
   protected $_apiversion = 3;
-  public $_eNoticeCompliant = TRUE;
+
   public $DBResetRequired = FALSE;
   public $_entity = 'Job';
   public $_params = array();

--- a/tests/phpunit/api/v3/LineItemTest.php
+++ b/tests/phpunit/api/v3/LineItemTest.php
@@ -34,7 +34,7 @@ class api_v3_LineItemTest extends CiviUnitTestCase {
   protected $contactIds = array();
   protected $_entity = 'line_item';
   protected $contribution_result = null;
-  public $_eNoticeCompliant = TRUE;
+
   public $DBResetRequired = TRUE;
   protected $_financialTypeId = 1;
 

--- a/tests/phpunit/api/v3/LocBlockTest.php
+++ b/tests/phpunit/api/v3/LocBlockTest.php
@@ -29,7 +29,7 @@ require_once 'CiviTest/CiviUnitTestCase.php';
 class api_v3_LocBlockTest extends CiviUnitTestCase {
   protected $_apiversion = 3;
   protected $_entity = 'loc_block';
-  public $_eNoticeCompliant = TRUE;
+
   public function setUp() {
     parent::setUp();
   }

--- a/tests/phpunit/api/v3/MailingGroupTest.php
+++ b/tests/phpunit/api/v3/MailingGroupTest.php
@@ -36,7 +36,7 @@ class api_v3_MailingGroupTest extends CiviUnitTestCase {
   protected $_groupID;
   protected $_email;
   protected $_apiversion;
-  public $_eNoticeCompliant = TRUE;
+
 
   function get_info() {
     return array(

--- a/tests/phpunit/api/v3/MailingTest.php
+++ b/tests/phpunit/api/v3/MailingTest.php
@@ -37,7 +37,7 @@ class api_v3_MailingTest extends CiviUnitTestCase {
   protected $_apiversion = 3;
   protected $_params = array();
   protected $_entity = 'Mailing';
-  public $_eNoticeCompliant = TRUE;
+
 
   function get_info() {
     return array(

--- a/tests/phpunit/api/v3/MembershipStatusTest.php
+++ b/tests/phpunit/api/v3/MembershipStatusTest.php
@@ -32,7 +32,7 @@ class api_v3_MembershipStatusTest extends CiviUnitTestCase {
   protected $_contributionTypeID;
   protected $_membershipTypeID;
   protected $_membershipStatusID;
-  public $_eNoticeCompliant = TRUE;
+
   protected $_apiversion =3;
 
   function get_info() {

--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -44,7 +44,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
   protected $__membershipID;
   protected $_entity;
   protected $_params;
-  public $_eNoticeCompliant = TRUE;
+
 
   public function setUp() {
     //  Connect to the database

--- a/tests/phpunit/api/v3/MembershipTypeTest.php
+++ b/tests/phpunit/api/v3/MembershipTypeTest.php
@@ -32,7 +32,7 @@ class api_v3_MembershipTypeTest extends CiviUnitTestCase {
   protected $_contributionTypeID;
   protected $_apiversion;
   protected $_entity = 'MembershipType';
-  public $_eNoticeCompliant = TRUE;
+
 
   function get_info() {
     return array(

--- a/tests/phpunit/api/v3/NoteTest.php
+++ b/tests/phpunit/api/v3/NoteTest.php
@@ -38,7 +38,7 @@ class api_v3_NoteTest extends CiviUnitTestCase {
   protected $_params;
   protected $_noteID;
   protected $_note;
-  public $_eNoticeCompliant = TRUE;
+
 
   function __construct() {
     parent::__construct();

--- a/tests/phpunit/api/v3/OptionGroupTest.php
+++ b/tests/phpunit/api/v3/OptionGroupTest.php
@@ -28,7 +28,7 @@
 require_once 'CiviTest/CiviUnitTestCase.php';
 class api_v3_OptionGroupTest extends CiviUnitTestCase {
   protected $_apiversion = 3;
-  public $_eNoticeCompliant = TRUE;
+
   protected $_entity = 'OptionGroup';
 
   function setUp() {

--- a/tests/phpunit/api/v3/OptionValueTest.php
+++ b/tests/phpunit/api/v3/OptionValueTest.php
@@ -29,7 +29,7 @@ require_once 'CiviTest/CiviUnitTestCase.php';
 
 class api_v3_OptionValueTest extends CiviUnitTestCase {
   protected $_apiversion = 3;
-  public $_eNoticeCompliant = TRUE;
+
   function setUp() {
     parent::setUp();
   }

--- a/tests/phpunit/api/v3/ParticipantPaymentTest.php
+++ b/tests/phpunit/api/v3/ParticipantPaymentTest.php
@@ -44,7 +44,7 @@ class api_v3_ParticipantPaymentTest extends CiviUnitTestCase {
   protected $_eventID;
   protected $_participantPaymentID;
   protected $_contributionTypeId;
-  public $_eNoticeCompliant = TRUE;
+
 
   function get_info() {
     return array(

--- a/tests/phpunit/api/v3/ParticipantStatusTypeTest.php
+++ b/tests/phpunit/api/v3/ParticipantStatusTypeTest.php
@@ -31,7 +31,7 @@ class api_v3_ParticipantStatusTypeTest extends CiviUnitTestCase {
   protected $_apiversion;
   protected $params;
   protected $id;
-  public $_eNoticeCompliant = TRUE;
+
 
   public $DBResetRequired = FALSE;
 

--- a/tests/phpunit/api/v3/PaymentProcessorTest.php
+++ b/tests/phpunit/api/v3/PaymentProcessorTest.php
@@ -35,7 +35,7 @@ class api_v3_PaymentProcessorTest extends CiviUnitTestCase {
   protected $_paymentProcessorType;
   protected $_apiversion = 3;
   protected $_params;
-  public $_eNoticeCompliant = TRUE;
+
   function get_info() {
     return array(
       'name' => 'PaymentProcessor Create',

--- a/tests/phpunit/api/v3/PaymentProcessorTypeTest.php
+++ b/tests/phpunit/api/v3/PaymentProcessorTypeTest.php
@@ -34,7 +34,7 @@ require_once 'CiviTest/CiviUnitTestCase.php';
 class api_v3_PaymentProcessorTypeTest extends CiviUnitTestCase {
   protected $_ppTypeID;
   protected $_apiversion;
-  public $_eNoticeCompliant = TRUE;
+
   function get_info() {
     return array(
       'name' => 'PaymentProcessorType Create',

--- a/tests/phpunit/api/v3/PhoneTest.php
+++ b/tests/phpunit/api/v3/PhoneTest.php
@@ -40,7 +40,7 @@ class api_v3_PhoneTest extends CiviUnitTestCase {
   protected $_contactID;
   protected $_locationType;
   protected $_params;
-  public $_eNoticeCompliant = TRUE;
+
 
   function setUp() {
     $this->_apiversion = 3;

--- a/tests/phpunit/api/v3/PriceFieldTest.php
+++ b/tests/phpunit/api/v3/PriceFieldTest.php
@@ -32,7 +32,7 @@ class api_v3_PriceFieldTest extends CiviUnitTestCase {
   protected $id = 0;
   protected $priceSetID = 0;
   protected $_entity = 'price_field';
-  public $_eNoticeCompliant = TRUE;
+
   public $DBResetRequired = TRUE;
 
   public function setUp() {

--- a/tests/phpunit/api/v3/PriceFieldValueTest.php
+++ b/tests/phpunit/api/v3/PriceFieldValueTest.php
@@ -33,7 +33,7 @@ class api_v3_PriceFieldValueTest extends CiviUnitTestCase {
   protected $id = 0;
   protected $priceSetID = 0;
   protected $_entity = 'price_field_value';
-  public $_eNoticeCompliant = TRUE;
+
   public $DBResetRequired = TRUE;
 
   public function setUp() {

--- a/tests/phpunit/api/v3/PriceSetTest.php
+++ b/tests/phpunit/api/v3/PriceSetTest.php
@@ -33,7 +33,7 @@ class api_v3_PriceSetTest extends CiviUnitTestCase {
   protected $id = 0;
   protected $contactIds = array();
   protected $_entity = 'price_set';
-  public $_eNoticeCompliant = TRUE;
+
   public $DBResetRequired = TRUE;
   public function setUp() {
     parent::setUp();

--- a/tests/phpunit/api/v3/RelationshipTest.php
+++ b/tests/phpunit/api/v3/RelationshipTest.php
@@ -46,7 +46,7 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
   protected $_customGroupId = NULL;
   protected $_customFieldId = NULL;
   protected $_params;
-  public $_eNoticeCompliant = TRUE;
+
   protected $_entity;
   function get_info() {
     return array(

--- a/tests/phpunit/api/v3/RelationshipTypeTest.php
+++ b/tests/phpunit/api/v3/RelationshipTypeTest.php
@@ -63,7 +63,7 @@ class api_v3_RelationshipTypeTest extends CiviUnitTestCase {
   protected $_cId_b;
   protected $_relTypeID;
   protected $_apiversion = 3;
-  public $_eNoticeCompliant = TRUE;
+
   function get_info() {
     return array(
       'name' => 'RelationshipType Create',

--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -37,7 +37,7 @@ require_once 'CiviTest/CiviUnitTestCase.php';
 
 class api_v3_ReportTemplateTest extends CiviUnitTestCase {
   protected $_apiversion = 3;
-  public $_eNoticeCompliant = TRUE;
+
   function setUp() {
     parent::setUp();
     $this->_sethtmlGlobals();

--- a/tests/phpunit/api/v3/SettingTest.php
+++ b/tests/phpunit/api/v3/SettingTest.php
@@ -47,7 +47,7 @@ class api_v3_SettingTest extends CiviUnitTestCase {
   protected $_currentDomain;
   protected $_domainID2;
   protected $_domainID3;
-  public $_eNoticeCompliant = TRUE;
+
   function __construct() {
     parent::__construct();
 

--- a/tests/phpunit/api/v3/SurveyRespondantTest.php
+++ b/tests/phpunit/api/v3/SurveyRespondantTest.php
@@ -30,7 +30,7 @@ require_once 'CiviTest/CiviUnitTestCase.php';
 class api_v3_SurveyRespondantTest extends CiviUnitTestCase {
   protected $_apiversion =3;
   protected $params;
-  public $_eNoticeCompliant = TRUE;
+
 
   function setUp() {
     $phoneBankActivity = $this->callAPISuccess('Option_value', 'Get', array('label' => 'PhoneBank', 'sequential' => 1));

--- a/tests/phpunit/api/v3/SurveyTest.php
+++ b/tests/phpunit/api/v3/SurveyTest.php
@@ -52,7 +52,7 @@ class api_v3_SurveyTest extends CiviUnitTestCase {
   protected $params;
   protected $entity = 'survey';
   public $DBResetRequired = FALSE;
-  public $_eNoticeCompliant = TRUE;
+
 
   function setUp() {
     $phoneBankActivityTypeID = $this->callAPISuccessGetValue('Option_value', array('label' => 'PhoneBank', 'return' => 'id'), 'integer');

--- a/tests/phpunit/api/v3/SystemTest.php
+++ b/tests/phpunit/api/v3/SystemTest.php
@@ -63,7 +63,7 @@ class api_v3_SystemTest extends CiviUnitTestCase {
 
   const TEST_CACHE_GROUP = 'SystemTest';
   const TEST_CACHE_PATH = 'api/v3/system';
-  public $_eNoticeCompliant = TRUE;
+
   /**
    *  Constructor
    *

--- a/tests/phpunit/api/v3/TagTest.php
+++ b/tests/phpunit/api/v3/TagTest.php
@@ -48,7 +48,7 @@ class api_v3_TagTest extends CiviUnitTestCase {
   protected $tag = array();
 
   protected $tagID;
-  public $_eNoticeCompliant = TRUE;
+
   function setUp() {
     parent::setUp();
     $this->tag = $this->tagCreate();

--- a/tests/phpunit/api/v3/UFFieldTest.php
+++ b/tests/phpunit/api/v3/UFFieldTest.php
@@ -42,7 +42,7 @@ class api_v3_UFFieldTest extends CiviUnitTestCase {
   protected $_apiversion = 3;
   protected $_params;
   protected $_entity = 'uf_field';
-  public $_eNoticeCompliant = TRUE;
+
 
   protected function setUp() {
     parent::setUp();

--- a/tests/phpunit/api/v3/UFJoinTest.php
+++ b/tests/phpunit/api/v3/UFJoinTest.php
@@ -42,7 +42,7 @@ class api_v3_UFJoinTest extends CiviUnitTestCase {
   protected $_ufFieldId;
   protected $_contactId = 69;
   protected $_apiversion;
-  public $_eNoticeCompliant = TRUE;
+
   protected function setUp() {
     parent::setUp();
     //  Truncate the tables

--- a/tests/phpunit/api/v3/UFMatchTest.php
+++ b/tests/phpunit/api/v3/UFMatchTest.php
@@ -44,7 +44,7 @@ class api_v3_UFMatchTest extends CiviUnitTestCase {
   protected $_apiversion;
   protected $_params = array();
 
-  public $_eNoticeCompliant = TRUE;
+
 
   protected function setUp() {
     parent::setUp();

--- a/tests/phpunit/api/v3/UtilsTest.php
+++ b/tests/phpunit/api/v3/UtilsTest.php
@@ -36,7 +36,7 @@ require_once 'CRM/Utils/DeprecatedUtils.php';
 class api_v3_UtilsTest extends CiviUnitTestCase {
   protected $_apiversion = 3;
   public $DBResetRequired = FALSE;
-  public $_eNoticeCompliant = TRUE;
+
   public $_contactID = 1;
 
   /**

--- a/tests/phpunit/api/v3/WebsiteTest.php
+++ b/tests/phpunit/api/v3/WebsiteTest.php
@@ -40,7 +40,7 @@ class api_v3_WebsiteTest extends CiviUnitTestCase {
   protected $params;
   protected $id;
   protected $_entity;
-  public $_eNoticeCompliant = TRUE;
+
   public $DBResetRequired = FALSE;
 
   function setUp() {


### PR DESCRIPTION
top 3 files are non tests so bear eyeballing - rest should 'test themselves'

@totten with this PR the ONLY unit tests that are not e-Notice compliant are the extensions ones - which I don't really understand well enough to fix :-(

NB probably worth merging to master because I hate thinking about all the effort people are putting into fixing unit tests on master that are now fixed in 4.4....
