### PR TITLE
CRM-14036_fix

### DIFF
--- a/CRM/Upgrade/Incremental/php/FourFour.php
+++ b/CRM/Upgrade/Incremental/php/FourFour.php
@@ -215,6 +215,38 @@ VALUES {$insertStatus}";
   }
 
   function upgrade_4_4_4($rev) {
+    $fkConstraint = array();
+    if (!CRM_Core_DAO::checkFKConstraintInFormat('civicrm_activity_contact', 'activity_id')) {
+      $fkConstraint[] = "ADD CONSTRAINT `FK_civicrm_activity_contact_activity_id` FOREIGN KEY (`activity_id`) REFERENCES `civicrm_activity` (`id`) ON DELETE CASCADE";
+    }
+    if (!CRM_Core_DAO::checkFKConstraintInFormat('civicrm_activity_contact', 'contact_id')) {
+      $fkConstraint[] = "ADD CONSTRAINT `FK_civicrm_activity_contact_contact_id` FOREIGN KEY (`contact_id`) REFERENCES `civicrm_contact` (`id`) ON DELETE CASCADE;
+";
+    }
+
+    if (!empty($fkConstraint)) {
+      $fkConstraint = implode(',', $fkConstraint);
+      $sql = "ALTER TABLE `civicrm_activity_contact`
+{$fkConstraint}
+";
+      // CRM-14036 : delete entries of un-mapped contacts
+        CRM_Core_DAO::executeQuery("DELETE ac FROM civicrm_activity_contact ac
+LEFT JOIN civicrm_contact c
+ON c.id = ac.contact_id
+WHERE c.id IS NULL;
+");
+        // delete entries of un-mapped activities
+        CRM_Core_DAO::executeQuery("DELETE ac FROM civicrm_activity_contact ac
+LEFT JOIN civicrm_activity a
+ON a.id = ac.activity_id
+WHERE a.id IS NULL;
+");
+
+      CRM_Core_DAO::executeQuery("SET FOREIGN_KEY_CHECKS=0;");
+      CRM_Core_DAO::executeQuery($sql);
+      CRM_Core_DAO::executeQuery("SET FOREIGN_KEY_CHECKS=1;");
+    }
+
     // task to process sql
     $this->addTask(ts('Upgrade DB to %1: SQL', array(1 => '4.4.4')), 'task_4_4_x_runSql', $rev);
 


### PR DESCRIPTION
In upgrade we were not adding constraint rule for civicrm_activity_contact table. That the reason why contacts are being deleted without deletion of civicrm_activity_contact entries. 

handled upgrade so that, foreign key constraint rule exists and also deleted un-mapped records WRT contact_id and activity_id.
