### PR TITLE
CRM-13995 - Add is_object check to prevent notices.

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -871,7 +871,7 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
                 }
               }
               // CRM-13995
-              elseif (in_array($relationField, array(
+              elseif (is_object($relDAO) && in_array($relationField, array(
                 'email_greeting', 'postal_greeting', 'addressee'))) {
                 //special case for greeting replacement
                 $fldValue = "{$relationField}_display";


### PR DESCRIPTION
---
- CRM-13995: contact export when merging households: some household fields missing
  http://issues.civicrm.org/jira/browse/CRM-13995
