### PR TITLE
CRM_Core_CodeGen_Util_Template - Fix warning

### DIFF
--- a/CRM/Core/CodeGen/Util/Template.php
+++ b/CRM/Core/CodeGen/Util/Template.php
@@ -53,7 +53,9 @@ class CRM_Core_CodeGen_Util_Template {
    * @param string $outpath full path to the desired output file
    */
   function runConcat($inputs, $outpath) {
-    unlink($outpath);
+    if (file_exists($outpath)) {
+      unlink($outpath);
+    }
     foreach ($inputs as $infile) {
       // FIXME: does not beautify.  Document.
       file_put_contents($outpath, $this->smarty->fetch($infile) ."\n", FILE_APPEND);


### PR DESCRIPTION
Example warning: "PHP Warning:  unlink(../sql/civicrm_data.da_DK.mysql): No such file or directory in /home/webeditor/jenkins-node/workspace/buildkit-demos.civicrm.org/build/d7-sandbox/sites/all/modules/civicrm/CRM/Core/CodeGen/Util/Template.php on line 56"
