### PR TITLE
GenCode - Add an optional caching mode.

### DIFF
--- a/xml/GenCode.php
+++ b/xml/GenCode.php
@@ -193,7 +193,7 @@ class CRM_GenCode_Main {
    *
    */
   function main() {
-    if (!empty($this->digestPath) && file_exists($this->digestPath)) {
+    if (!empty($this->digestPath) && file_exists($this->digestPath) && $this->hasExpectedFiles()) {
       if ($this->getDigest() === file_get_contents($this->digestPath)) {
         echo "GenCode has previously executed. To force execution, please (a) omit CIVICRM_GENCODE_DIGEST\n";
         echo "or (b) remove {$this->digestPath} or (c) call GenCode with new parameters.\n";
@@ -1085,7 +1085,7 @@ Alternatively you can get a version of CiviCRM that matches your PHP version
     if ($this->digest === NULL) {
       $srcDir = CRM_GenCode_Util_File::findCoreSourceDir();
       $files = CRM_GenCode_Util_File::findManyFiles(array(
-        array("$srcDir/CRM/Core/CodeGen", '*.php'),
+        // array("$srcDir/CRM/Core/CodeGen", '*.php'),
         array("$srcDir/xml", "*.php"),
         array("$srcDir/xml", "*.tpl"),
         array("$srcDir/xml", "*.xml"),
@@ -1107,5 +1107,21 @@ Alternatively you can get a version of CiviCRM that matches your PHP version
       $this->digest = md5($properties);
     }
     return $this->digest;
+  }
+
+  function getExpectedFiles() {
+    return array(
+      $this->sqlCodePath . '/civicrm.mysql',
+      $this->phpCodePath . '/CRM/Contact/DAO/Contact.php',
+    );
+  }
+
+  function hasExpectedFiles() {
+    foreach ($this->getExpectedFiles() as $file) {
+      if (!file_exists($file)) {
+        return FALSE;
+      }
+    }
+    return TRUE;
   }
 }


### PR DESCRIPTION
If CIVICRM_GENCODE_DIGEST is set, then GenCode will write out a digest of all
its inputs & templates. If someone tries to rerun with the same inputs, then
GenCode will do nothing.
