### PR TITLE
CRM-14077 - contact/address - county field should populate with counties...

### DIFF
--- a/CRM/Contact/Form/Edit/Address.php
+++ b/CRM/Contact/Form/Edit/Address.php
@@ -468,7 +468,7 @@ class CRM_Contact_Form_Edit_Address {
         $counties = CRM_Core_PseudoConstant::countyForState($stateID);
       }
       else {
-        $counties = CRM_Core_PseudoConstant::country();
+        $counties = CRM_Core_PseudoConstant::county();
       }
 
       $form->addElement('select', $countyElementName, ts('County'), array('' => ts('- select -')) + $counties);


### PR DESCRIPTION
... not countries

---
- CRM-14077: County drop down is populated with countries instead
  http://issues.civicrm.org/jira/browse/CRM-14077
