### PR TITLE
CRM-13998 Upgrade is missing alter statements for civicrm_report_instance

### DIFF
--- a/CRM/Upgrade/Incremental/sql/4.4.4.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.4.4.mysql.tpl
@@ -1,1 +1,4 @@
 {* file to handle db changes in 4.4.4 during upgrade *}
+
+{* update comment for civicrm_report_instance.grouprole *)
+ALTER TABLE civicrm_report_instance MODIFY grouprole varchar(1024) COLLATE utf8_unicode_ci DEFAULT NULL COMMENT 'role required to be able to run this instance';


### PR DESCRIPTION
---
- CRM-13998: Upgrade is missing alter statements for civicrm_report_instance
  http://issues.civicrm.org/jira/browse/CRM-13998
