### PR TITLE
CRM-14080 default to now

### DIFF
--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -83,6 +83,7 @@ function _civicrm_api3_contribution_create_spec(&$params) {
   $params['contact_id']['api.required'] = 1;
   $params['total_amount']['api.required'] = 1;
   $params['payment_instrument_id']['api.aliases'] = array('payment_instrument');
+  $params['receive_date']['api.default'] = 'now';
   $params['payment_processor'] = array(
     'name' => 'payment_processor',
     'title' => 'Payment Processor ID',


### PR DESCRIPTION
---
- CRM-14080: Have noticed there is no default on received_date on contribution.create - should default to now
  http://issues.civicrm.org/jira/browse/CRM-14080
