### PR TITLE
fix contact subtype unset during domain update, CRM-14087

### DIFF
--- a/CRM/Contact/Form/Domain.php
+++ b/CRM/Contact/Form/Domain.php
@@ -60,6 +60,13 @@ class CRM_Contact_Form_Domain extends CRM_Core_Form {
   protected $_fromEmailId = NULL;
 
   /**
+   * default location type fields
+   *
+   * @var array
+   */
+  protected $_locationDefaults = array();
+
+  /**
    * how many locationBlocks should we display?
    *
    * @var int
@@ -93,7 +100,6 @@ class CRM_Contact_Form_Domain extends CRM_Core_Form {
   function setDefaultValues() {
     $defaults  = array();
     $params    = array();
-    $locParams = array();
 
     if (isset($this->_id)) {
       $params['id'] = $this->_id;
@@ -115,7 +121,7 @@ class CRM_Contact_Form_Domain extends CRM_Core_Form {
 
       unset($params['id']);
       $locParams = array('contact_id' => $domainDefaults['contact_id']);
-      $defaults = CRM_Core_BAO_Location::getValues($locParams);
+      $this->_locationDefaults = $defaults = CRM_Core_BAO_Location::getValues($locParams);
 
       $config = CRM_Core_Config::singleton();
       if (!isset($defaults['address'][1]['country_id'])) {
@@ -244,9 +250,27 @@ class CRM_Contact_Form_Domain extends CRM_Core_Form {
 
     $defaultLocationType = CRM_Core_BAO_LocationType::getDefault();
 
-    $params['address'][1]['location_type_id'] = $defaultLocationType->id;
-    $params['phone'][1]['location_type_id'] = $defaultLocationType->id;
-    $params['email'][1]['location_type_id'] = $defaultLocationType->id;
+    if (isset($this->_locationDefaults['address'][1]['location_type_id'])) {
+      $params['address'][1]['location_type_id'] = $this->_locationDefaults['address'][1]['location_type_id'];
+    }
+    else {
+      $params['address'][1]['location_type_id'] = $defaultLocationType->id;
+    }
+
+    if (isset($this->_locationDefaults['phone'][1]['location_type_id'])) {
+      $params['phone'][1]['location_type_id'] = $this->_locationDefaults['phone'][1]['location_type_id'];
+    }
+    else {
+      $params['phone'][1]['location_type_id'] = $defaultLocationType->id;
+    }
+
+    if (isset($this->_locationDefaults['email'][1]['location_type_id'])) {
+      $params['email'][1]['location_type_id'] = $this->_locationDefaults['email'][1]['location_type_id'];
+    }
+    else {
+      $params['email'][1]['location_type_id'] = $defaultLocationType->id;
+    }
+
     $params += array('contact_id' => $this->_contactId);
     $contactParams = array (
       'sort_name'    => $domain->name,

--- a/CRM/Contact/Form/Domain.php
+++ b/CRM/Contact/Form/Domain.php
@@ -237,7 +237,6 @@ class CRM_Contact_Form_Domain extends CRM_Core_Form {
    * @access public
    */
   public function postProcess() {
-    $params = array();
     $params = $this->exportValues();
     $params['entity_id'] = $this->_id;
     $params['entity_table'] = CRM_Core_BAO_Domain::getTableName();
@@ -245,7 +244,6 @@ class CRM_Contact_Form_Domain extends CRM_Core_Form {
 
     $defaultLocationType = CRM_Core_BAO_LocationType::getDefault();
 
-    $location = array();
     $params['address'][1]['location_type_id'] = $defaultLocationType->id;
     $params['phone'][1]['location_type_id'] = $defaultLocationType->id;
     $params['email'][1]['location_type_id'] = $defaultLocationType->id;
@@ -256,10 +254,15 @@ class CRM_Contact_Form_Domain extends CRM_Core_Form {
       'legal_name'   => $domain->name,
       'organization_name' => $domain->name,
       'contact_id' => $this->_contactId,
+      'contact_type' => 'Organization',
     );
-    CRM_Contact_BAO_Contact::add($contactParams);
-    $location = CRM_Core_BAO_Location::create($params, TRUE);
 
+    if ($this->_contactId) {
+      $contactParams['contact_sub_type'] = CRM_Contact_BAO_Contact::getContactSubType($this->_contactId);
+    }
+
+    CRM_Contact_BAO_Contact::add($contactParams);
+    CRM_Core_BAO_Location::create($params, TRUE);
 
     CRM_Core_BAO_Domain::edit($params, $this->_id);
 


### PR DESCRIPTION
---
- CRM-14087: Updating default organization's address/phone wipes out the contact sub-type
  http://issues.civicrm.org/jira/browse/CRM-14087
