### PR TITLE
CRM-14101 - Unauthenticated/anonymous users can register for events even when Drupal permissions should stop them

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -336,9 +336,7 @@ class CRM_Core_Permission {
     if (!empty($permissionedEvents)) {
       return array_search($eventID, $permissionedEvents) === FALSE ? NULL : $eventID;
     }
-    else {
-      return $eventID;
-    }
+    return NULL;
   }
 
   static function eventClause($type = CRM_Core_Permission::VIEW, $prefix = NULL) {
@@ -552,7 +550,6 @@ class CRM_Core_Permission {
       'delete all manual batches' => $prefix . ts('delete all manual batches'),
       'export own manual batches' => $prefix . ts('export own manual batches'),
       'export all manual batches' => $prefix . ts('export all manual batches'),
-      'administer payment processors' => $prefix . ts('administer payment processors'),
     );
 
     return $permissions;


### PR DESCRIPTION
The previous fix done in this commit: https://github.com/civicrm/civicrm-core/commit/d551c85d

was to prevent a notice but also gave anon users (or other users) permission for an event

http://issues.civicrm.org/jira/browse/CRM-14101
