### PR TITLE
CRM-14120 e-notice error due to returning NULL not by reference,

### DIFF
--- a/CRM/Event/PseudoConstant.php
+++ b/CRM/Event/PseudoConstant.php
@@ -97,10 +97,10 @@ class CRM_Event_PseudoConstant extends CRM_Core_PseudoConstant {
    *
    * @access public
    *
-   * @return array - array reference of all events if any
+   * @return array - array of all events if any
    * @static
    */
-  public static function &event($id = NULL, $all = FALSE, $condition = NULL) {
+  public static function event($id = NULL, $all = FALSE, $condition = NULL) {
     $key = "{$id}_{$all}_{$condition}";
 
     if (!isset(self::$event[$key])) {


### PR DESCRIPTION
 From what I recall php lazy copying means that we don't lose any performance benefit by not returning as a reference

---
- CRM-14120: Notice Notice: Only variable references should be returned by reference in event() (line 122 of /srv/www/womenslibrary.org.uk/sites/all/modules/civicrm/CRM/Event/PseudoConstant.php).
  http://issues.civicrm.org/jira/browse/CRM-14120
