### PR TITLE
CRM-14126 - Wrap CURLOPT_FOLLOWLOCATION in a check for open_basedir and safe_mode

### DIFF
--- a/CRM/Core/Payment/Elavon.php
+++ b/CRM/Core/Payment/Elavon.php
@@ -193,7 +193,9 @@ class CRM_Core_Payment_Elavon extends CRM_Core_Payment {
     // set this for debugging -look for output in apache error log
     //curl_setopt ($ch,CURLOPT_VERBOSE,1 );
     // ensures any Location headers are followed
-    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
+    if (ini_get('open_basedir') == '' && ini_get('safe_mode') == 'Off') {
+      curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
+    }
 
     /**********************************************************
      * Send the data out over the wire

--- a/CRM/Core/Payment/FirstData.php
+++ b/CRM/Core/Payment/FirstData.php
@@ -222,7 +222,9 @@ class CRM_Core_Payment_FirstData extends CRM_Core_Payment {
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
     curl_setopt($ch, CURLOPT_TIMEOUT, 36000);
     // ensures any Location headers are followed
-    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
+    if (ini_get('open_basedir') == '' && ini_get('safe_mode') == 'Off') {
+      curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
+    }
 
     // Send the data out over the wire
     //--------------------------------

--- a/CRM/Core/Payment/PayflowPro.php
+++ b/CRM/Core/Payment/PayflowPro.php
@@ -484,7 +484,9 @@ class CRM_Core_Payment_PayflowPro extends CRM_Core_Payment {
     // return into a variable
     curl_setopt($ch, CURLOPT_TIMEOUT, 90);
     // times out after 90 secs
-    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 0);
+    if (ini_get('open_basedir') == '' && ini_get('safe_mode') == 'Off') {
+      curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 0);
+    }
     curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME, 'verifySSL'));
     // this line makes it work under https
     curl_setopt($ch, CURLOPT_POSTFIELDS, $payflow_query);

--- a/CRM/Core/Payment/PaymentExpressUtils.php
+++ b/CRM/Core/Payment/PaymentExpressUtils.php
@@ -67,7 +67,9 @@ function &_initCURL($query, $url) {
   curl_setopt($curl, CURLOPT_POSTFIELDSIZE, 0);
   curl_setopt($curl, CURLOPT_TIMEOUT, 30);
   curl_setopt($curl, CURLOPT_RETURNTRANSFER, TRUE);
-  curl_setopt($curl, CURLOPT_FOLLOWLOCATION, FALSE);
+  if (ini_get('open_basedir') == '' && ini_get('safe_mode') == 'Off') {
+    curl_setopt($curl, CURLOPT_FOLLOWLOCATION, FALSE);
+  }
   curl_setopt($curl, CURLOPT_HEADER, 0);
   curl_setopt($curl, CURLOPT_SSLVERSION, 3);
 

--- a/CRM/Utils/HttpClient.php
+++ b/CRM/Utils/HttpClient.php
@@ -189,7 +189,9 @@ class CRM_Utils_HttpClient {
     curl_setopt($ch, CURLOPT_HEADER, FALSE);
     curl_setopt($ch, CURLOPT_ENCODING, 'gzip');
     curl_setopt($ch, CURLOPT_VERBOSE, 0);
-    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, TRUE);
+    if (ini_get('open_basedir') == '' && ini_get('safe_mode') == 'Off') {
+      curl_setopt($ch, CURLOPT_FOLLOWLOCATION, TRUE);
+    }
     if ($this->connectionTimeout !== NULL) {
       curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $this->connectionTimeout);
     }

--- a/tools/extensions/org.civicrm.sms.clickatell/org_civicrm_sms_clickatell.php
+++ b/tools/extensions/org.civicrm.sms.clickatell/org_civicrm_sms_clickatell.php
@@ -133,7 +133,9 @@ class org_civicrm_sms_clickatell extends CRM_SMS_Provider {
     curl_setopt($this->_ch, CURLOPT_TIMEOUT, 20);
     curl_setopt($this->_ch, CURLOPT_VERBOSE, 1);
     curl_setopt($this->_ch, CURLOPT_FAILONERROR, 1);
-    curl_setopt($this->_ch, CURLOPT_FOLLOWLOCATION, 1);
+    if (ini_get('open_basedir') == '' && ini_get('safe_mode') == 'Off') {
+      curl_setopt($this->_ch, CURLOPT_FOLLOWLOCATION, 1);
+    }
     curl_setopt($this->_ch, CURLOPT_COOKIEJAR, "/dev/null");
     curl_setopt($this->_ch, CURLOPT_SSL_VERIFYHOST, 2);
     curl_setopt($this->_ch, CURLOPT_USERAGENT, 'CiviCRM - http://civicrm.org/');


### PR DESCRIPTION
---
- CRM-14126: HttpClient.php library used by CiviCRM issues a PHP warning when open_basedir is set
  http://issues.civicrm.org/jira/browse/CRM-14126
