### PR TITLE
CRM-14143 - Fix group selector display when showOrgInfo is true - multi-...

### DIFF
--- a/templates/CRM/Group/Form/Search.tpl
+++ b/templates/CRM/Group/Form/Search.tpl
@@ -289,6 +289,9 @@ function showChildren( parent_id, showOrgInfo, group_id, levelClass) {
             }
             appendHTML += "<td>" + val.group_type + "</td>";
             appendHTML += "<td>" + val.visibility + "</td>";
+						if (showOrgInfo) {
+							appendHTML += "<td>" + val.org_info + "</td>";
+						}
             appendHTML += "<td>" + val.links + "</td>";
             appendHTML += "</tr>";
           });


### PR DESCRIPTION
...site enabled.

---
- CRM-14143: Sub-group display off when multi-site enabled
  http://issues.civicrm.org/jira/browse/CRM-14143
