### PR TITLE
CRM-14101 - Unauthenticated/anonymous users can register for events even when Drupal permissions should stop them

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -336,9 +336,7 @@ class CRM_Core_Permission {
     if (!empty($permissionedEvents)) {
       return array_search($eventID, $permissionedEvents) === FALSE ? NULL : $eventID;
     }
-    else {
-      return $eventID;
-    }
+    return NULL;
   }
 
   static function eventClause($type = CRM_Core_Permission::VIEW, $prefix = NULL) {


### PR DESCRIPTION
http://issues.civicrm.org/jira/browse/CRM-14101
