### PR TITLE
CRM-14151 add hacky-handling to receive date like other date fields in c...

### DIFF
--- a/CRM/Core/Payment/BaseIPN.php
+++ b/CRM/Core/Payment/BaseIPN.php
@@ -502,6 +502,7 @@ LIMIT 1;";
     $contribution->trxn_id = $input['trxn_id'];
     $contribution->receive_date = CRM_Utils_Date::isoToMysql($contribution->receive_date);
     $contribution->thankyou_date = CRM_Utils_Date::isoToMysql($contribution->thankyou_date);
+    $contribution->receipt_date = CRM_Utils_Date::isoToMysql($contribution->receipt_date);
     $contribution->cancel_date = 'null';
 
     if (CRM_Utils_Array::value('check_number', $input)) {


### PR DESCRIPTION
...ompletetransaction function to mitigate DAO->find() followed by DAO->save() fatalling on date fields .. sometimes

---
- CRM-14151: BaseIPN fails when receipt_date is set
  http://issues.civicrm.org/jira/browse/CRM-14151
