### PR TITLE
CRM-14137 - further PR on returning report_template metadata in getrows api action

### DIFF
--- a/CRM/Report/Form/Case/Demographics.php
+++ b/CRM/Report/Form/Case/Demographics.php
@@ -68,8 +68,10 @@ class CRM_Report_Form_Case_Demographics extends CRM_Report_Form {
         ),
         'filters' =>
         array(
-          'sort_name' =>
-          array('title' => ts('Contact Name')),
+          'sort_name' => array(
+            'title' => ts('Contact Name'),
+            'operatorType' => CRM_Report_Form::OP_STRING,
+          ),
           'contact_type' =>
           array('title' => ts('Contact Type'),
             'operatorType' => CRM_Report_Form::OP_SELECT,
@@ -321,7 +323,7 @@ where (cg.extends='Contact' OR cg.extends='Individual' OR cg.extends_entity_colu
             $from     = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
             $to       = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
 
-            $clause = $this->dateClause($field['dbAlias'], $relative, $from, $to, CRM_Utils_type::T_DATE);
+            $clause = $this->dateClause($field['dbAlias'], $relative, $from, $to, CRM_Utils_Type::T_DATE);
           }
           else {
             $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);

--- a/api/v3/ReportTemplate.php
+++ b/api/v3/ReportTemplate.php
@@ -88,8 +88,8 @@ function civicrm_api3_report_template_delete($params) {
  */
 function civicrm_api3_report_template_getrows($params) {
   civicrm_api3_verify_one_mandatory($params, NULL, array('report_id', 'instance_id'));
-  list($rows, $instance, $labels) = _civicrm_api3_report_template_getrows($params);
-  return civicrm_api3_create_success($rows, $params, 'report_template', 'getrows', CRM_Core_DAO::$_nullObject, $labels);
+  list($rows, $instance, $metadata) = _civicrm_api3_report_template_getrows($params);
+  return civicrm_api3_create_success($rows, $params, 'report_template', 'getrows', CRM_Core_DAO::$_nullObject, $metadata);
 }
 
 function _civicrm_api3_report_template_getrows($params) {
@@ -118,21 +118,29 @@ function _civicrm_api3_report_template_getrows($params) {
   $reportInstance->setOffsetValue($options['offset']);
   $reportInstance->beginPostProcessCommon();
   $sql = $reportInstance->buildQuery();
-  $rows = $metadata = array();
+  $rows = $metadata = $requiredMetadata  = array();
   $reportInstance->buildRows($sql, $rows);
-  $metadata['title'] = $reportInstance->getTitle();
-  foreach ($reportInstance->_columnHeaders as $key => $header) {
-    //would be better just to expect reports to provide titles but reports are not consistent
-    //NB I think these are already translated
-    $metadata['labels'][$key] = !empty($header['title']) ? $header['title'] : '';
+  $requiredMetadata = array();
+  if(isset($params['options']) && !empty($params['options']['metadata'])) {
+    $requiredMetadata = $params['options']['metadata'];
+    if(in_array('title', $requiredMetadata)) {
+      $metadata['metadata']['title'] = $reportInstance->getTitle();
+    }
+    if(in_array('labels', $requiredMetadata)) {
+      foreach ($reportInstance->_columnHeaders as $key => $header) {
+        //would be better just to expect reports to provide titles but reports are not consistent so we anticipate empty
+        //NB I think these are already translated
+        $metadata['metadata']['labels'][$key] = !empty($header['title']) ? $header['title'] : '';
+      }
+    }
   }
   return array($rows, $reportInstance, $metadata);
 }
 
 function civicrm_api3_report_template_getstatistics($params) {
-  list($rows, $reportInstance, $labels) = _civicrm_api3_report_template_getrows($params);
+  list($rows, $reportInstance, $metadata) = _civicrm_api3_report_template_getrows($params);
   $stats = $reportInstance->statistics($rows);
-  return civicrm_api3_create_success($stats, $params, 'report_template');
+  return civicrm_api3_create_success($stats, $params, 'report_template', 'getstatistics', CRM_Core_DAO::$_nullObject, $metadata);
 }
 /**
  * Retrieve rows from a report template

--- a/api/v3/examples/ReportTemplate/Getrows.php
+++ b/api/v3/examples/ReportTemplate/Getrows.php
@@ -6,6 +6,12 @@
 function report_template_getrows_example(){
 $params = array(
   'report_id' => 'contact/summary',
+  'options' => array(
+      'metadata' => array(
+          '0' => 'labels',
+          '1' => 'title',
+        ),
+    ),
 );
 
 try{
@@ -47,13 +53,15 @@ function report_template_getrows_expectedresult(){
           'civicrm_country_name' => 'United States',
         ),
     ),
-  'title' => '',
-  'labels' => array(
-      'civicrm_contact_sort_name' => 'Contact Name',
-      'civicrm_contact_id' => 'Internal Contact ID',
-      'civicrm_address_street_address' => 'Street Address',
-      'civicrm_address_city' => 'City',
-      'civicrm_country_name' => 'Country',
+  'metadata' => array(
+      'title' => 'ERROR: Title is not Set',
+      'labels' => array(
+          'civicrm_contact_sort_name' => 'Contact Name',
+          'civicrm_contact_id' => 'Internal Contact ID',
+          'civicrm_address_street_address' => 'Street Address',
+          'civicrm_address_city' => 'City',
+          'civicrm_country_name' => 'Country',
+        ),
     ),
 );
 

--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -182,7 +182,6 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
         'contribute/lybunt' => 'same as sybunt - fatals on force url & test identifies why',
         'event/income' => 'I do no understant why but error is Call to undefined method CRM_Report_Form_Event_Income::from() in CRM/Report/Form.php on line 2120',
         'contact/relationship' => '(see contribute/repeat), property declaration issue, Undefined property: CRM_Report_Form_Contact_Relationship::$relationType in /Contact/Relationship.php(486):',
-        'case/demographics' => 'Undefined index: operatorType Case/Demographics.php(319)',
         'activitySummary' => 'Undefined index: group_bys_freq m/ActivitySummary.php(191)',
         'event/incomesummary' => 'Undefined index: title, Report/Form/Event/IncomeCountSummary.php(187)',
         'logging/contact/summary' => '(likely to be test releated) probably logging off Undefined index: Form/Contact/LoggingSummary.php(231): PHP',

--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -117,8 +117,9 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
     $description = "Retrieve rows from a report template (optionally providing the instance_id)";
     $result = $this->callAPIAndDocument('report_template', 'getrows', array(
       'report_id' => 'contact/summary',
+      'options' => array('metadata' => array('labels', 'title'))
     ), __FUNCTION__, __FILE__, $description, 'Getrows', 'getrows');
-    $this->assertEquals('Contact Name', $result['labels']['civicrm_contact_sort_name']);
+    $this->assertEquals('Contact Name', $result['metadata']['labels']['civicrm_contact_sort_name']);
 
     //the second part of this test has been commented out because it relied on the db being reset to
     // it's base state


### PR DESCRIPTION
- we resolved to return metadata as it's own field under $result
