### PR TITLE
CRM-13889 - api_v3_DashboardContact - Fix validation

### DIFF
--- a/CRM/Core/BAO/Dashboard.php
+++ b/CRM/Core/BAO/Dashboard.php
@@ -42,12 +42,13 @@ class CRM_Core_BAO_Dashboard extends CRM_Core_DAO_Dashboard {
    * Get the list of dashlets enabled by admin
    *
    * @param boolean $all all or only active
+   * @param boolean $checkPermission all or only authorized for the current user
    *
    * @return array $widgets  array of dashlets
    * @access public
    * @static
    */
-  static function getDashlets($all = TRUE) {
+  static function getDashlets($all = TRUE, $checkPermission = TRUE) {
     $dashlets = array();
     $dao = new CRM_Core_DAO_Dashboard();
 
@@ -59,7 +60,7 @@ class CRM_Core_BAO_Dashboard extends CRM_Core_DAO_Dashboard {
 
     $dao->find();
     while ($dao->fetch()) {
-      if (!self::checkPermission($dao->permission, $dao->permission_operator)) {
+      if ($checkPermission && !self::checkPermission($dao->permission, $dao->permission_operator)) {
         continue;
       }
 

--- a/api/v3/DashboardContact.php
+++ b/api/v3/DashboardContact.php
@@ -86,9 +86,9 @@ function _civicrm_api3_dashboard_contact_create_spec(&$params) {
 function _civicrm_api3_dashboard_contact_check_params(&$params) {
   $dashboard_id = CRM_Utils_Array::value('dashboard_id', $params);
   if ($dashboard_id) {
-    $allDashlets = CRM_Core_BAO_Dashboard::getDashlets();
+    $allDashlets = CRM_Core_BAO_Dashboard::getDashlets(TRUE, CRM_Utils_Array::value('check_permissions', $params, 0));
     if (!isset($allDashlets[$dashboard_id])) {
-      return civicrm_api3_create_error('Invalid Dashboard ID');
+      return civicrm_api3_create_error('Invalid or inaccessible dashboard ID');
     }
   }
   return NULL;


### PR DESCRIPTION
The validation of dashboard_id implicitly involved a permission-check. This 
permission-check would be wrong in some cases (eg running a drush script 
without any particular user), but it could be right in other cases (eg 
issuing an AJAX call).
