### PR TITLE
CRM-14148 cope with half hour timezones

### DIFF
--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -201,7 +201,7 @@ abstract class CRM_Utils_System_Base {
         return false;
       }
 
-      $timeZoneOffset = sprintf("%02d:%02d", $tz / 3600, ($tz/60)%60 );
+      $timeZoneOffset = sprintf("%02d:%02d", $tz / 3600, abs(($tz/60)%60));
 
       if($timeZoneOffset > 0){
         $timeZoneOffset = '+' . $timeZoneOffset;


### PR DESCRIPTION
---
- CRM-14148: Timezones with partial hours cause core crash
  http://issues.civicrm.org/jira/browse/CRM-14148

Per suggestion from Tobias - seems to make sense
