### PR TITLE
CRM-14092 - Restrict browsing of imageUploadDir via imageUploadURL

### DIFF
--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -400,6 +400,30 @@ HTACCESS;
   }
 
   /**
+   * Restrict remote users from browsing the given directory.
+   *
+   * @param $publicDir
+   */
+  static function restrictBrowsing($publicDir) {
+    // base dir
+    $nobrowse = realpath($publicDir) . '/index.html';
+    if (!file_exists($nobrowse)) {
+      @file_put_contents($nobrowse, '');
+    }
+
+    // child dirs
+    $dir = new RecursiveDirectoryIterator($publicDir);
+    foreach ($dir as $name => $object) {
+      if (is_dir($name) && $name != '..') {
+        $nobrowse = realpath($name) . '/index.html';
+        if (!file_exists($nobrowse)) {
+          @file_put_contents($nobrowse, '');
+        }
+      }
+    }
+  }
+
+  /**
    * Create the base file path from which all our internal directories are
    * offset. This is derived from the template compile directory set
    */


### PR DESCRIPTION
Previously, it attempted to restrict browsing of uploadDir and
configAndLogDir.  However, this is extraneoous because we have other checks
to ensure that those directories are inaccessible.  However, imageUploadDir
is different because we want to expose its file -- we just don't want to
expose a listing of them.

This commit also breaks out checkDirectoriesAreNotBrowseable() into
three functions.

---
- CRM-14092:
  http://issues.civicrm.org/jira/browse/CRM-14092
