### PR TITLE
CRM-14092 - CRM_Utils_Check_Security::isBrowseable - Fix warning

### DIFF
--- a/CRM/Utils/Check/Security.php
+++ b/CRM/Utils/Check/Security.php
@@ -261,7 +261,7 @@ class CRM_Utils_Check_Security {
 
     // this could be a new system with uploads yet -- so we'll make a file
     file_put_contents("$dir/$file", "delete me");
-    $content = file_get_contents("$url");
+    $content = @file_get_contents("$url");
     if (stristr($content, $file)) {
       $result = TRUE;
     }


### PR DESCRIPTION
We don't care if there's an HTTP 404 when checking for browsability -- 
because 404 is another of saying "not browseable!"
