### PR TITLE
CRM-14193 - CiviMail - Add option to default 'dedupe e-mails' setting to...

### DIFF
--- a/CRM/Admin/Form/Preferences/Mailing.php
+++ b/CRM/Admin/Form/Preferences/Mailing.php
@@ -106,6 +106,13 @@ class CRM_Admin_Form_Preferences_Mailing extends CRM_Admin_Form_Preferences {
           'weight' => 9,
           'description' => ts('Don\'t check for presence of mandatory tokens (domain address; unsubscribe/opt-out) before sending mailings. WARNING: Mandatory tokens are a safe-guard which facilitate compliance with the US CAN-SPAM Act. They should only be disabled if your organization adopts other mechanisms for compliance or if your organization is not subject to CAN-SPAM.'),
         ),
+        'dedupe_email_default' =>          
+        array(
+          'html_type' => 'checkbox',
+          'title' => ts('CiviMail dedupes e-mail addresses by default'),
+          'weight' => 10,
+          'description' => NULL,
+        ),
       ),
     );
 

--- a/CRM/Mailing/Form/Group.php
+++ b/CRM/Mailing/Form/Group.php
@@ -100,6 +100,10 @@ class CRM_Mailing_Form_Group extends CRM_Contact_Form_Task {
     $continue = CRM_Utils_Request::retrieve('continue', 'String', $this, FALSE, NULL);
 
     $defaults = array();
+    $defaults['dedupe_email'] = CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::MAILING_PREFERENCES_NAME,
+      'dedupe_email_default', NULL, FALSE
+    );
+
     if ($this->_mailingID) {
       // check that the user has permission to access mailing id
       CRM_Mailing_BAO_Mailing::checkPermission($this->_mailingID);

--- a/settings/Mailing.setting.php
+++ b/settings/Mailing.setting.php
@@ -149,5 +149,19 @@ return array(
     'is_contact' => 0,
     'description' => 'Don\'t check for presence of mandatory tokens (domain address; unsubscribe/opt-out) before sending mailings. WARNING: Mandatory tokens are a safe-guard which facilitate compliance with the US CAN-SPAM Act. They should only be disabled if your organization adopts other mechanisms for compliance or if your organization is not subject to CAN-SPAM.',
     'help_text' => null,
+  ) 
+  'dedupe_email_default' => array(
+    'group_name' => 'Mailing Preferences',
+    'group' => 'mailing',
+    'name' => 'dedupe_email_default',
+    'type' => 'Integer',
+    'html_type' => 'checkbox',
+    'default' => 1,
+    'add' => '4.5',
+    'title' => 'CiviMail dedupes e-mail addresses by default',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => 'Set the "dedupe e-mail" option when sending a new mailing to "true" by default.',
+    'help_text' => null,
   ),
   );


### PR DESCRIPTION
... true

---
- CRM-14193: Add option to default Civimail "dedupe e-mail" setting to true
  http://issues.civicrm.org/jira/browse/CRM-14193
