### PR TITLE
Removal of copy icon and is_default expose in edit form of Soft Credit t...

### DIFF
--- a/CRM/Admin/Form/Options.php
+++ b/CRM/Admin/Form/Options.php
@@ -280,6 +280,7 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
       'case_type',
       'payment_instrument',
       'communication_style',
+      'soft_credit_type',
     );
 
     if (in_array($this->_gName, $showIsDefaultGroups)) {

--- a/templates/CRM/Batch/Form/Entry.tpl
+++ b/templates/CRM/Batch/Form/Entry.tpl
@@ -57,10 +57,12 @@
       {/if}
       {foreach from=$fields item=field key=fieldName}
         <div class="crm-grid-cell">
+          {if $field.name|substr:0:11 ne 'soft_credit'}
           <img src="{$config->resourceBase}i/copy.png"
                alt="{ts 1=$field.title}Click to copy %1 from row one to all rows.{/ts}"
                fname="{$field.name}" class="action-icon"
-               title="{ts}Click here to copy the value in row one to ALL rows.{/ts}"/>{$field.title}
+               title="{ts}Click here to copy the value in row one to ALL rows.{/ts}"/>
+          {/if}{$field.title}
         </div>
       {/foreach}
     </div>


### PR DESCRIPTION
Fixes contain -

1.Exposed is_default in Soft Credit edit form.
2.Removed the copy icon from the column header of Soft Credit in Batch Data Entry of Contribution and Membership.
