### PR TITLE
CRM-14221 - Improving Payment Express/DPS payment processor strict stand...

### DIFF
--- a/CRM/Core/Payment/PaymentExpress.php
+++ b/CRM/Core/Payment/PaymentExpress.php
@@ -69,7 +69,7 @@ class CRM_Core_Payment_PaymentExpress extends CRM_Core_Payment {
    * @static
    *
    */
-  static function &singleton($mode, &$paymentProcessor) {
+  static function &singleton($mode = 'test', &$paymentProcessor, &$paymentForm = NULL, $force = FALSE) {
     $processorName = $paymentProcessor['name'];
     if (self::$_singleton[$processorName] === NULL) {
       self::$_singleton[$processorName] = new CRM_Core_Payment_PaymentExpress($mode, $paymentProcessor);

--- a/CRM/Core/Payment/PaymentExpressIPN.php
+++ b/CRM/Core/Payment/PaymentExpressIPN.php
@@ -91,7 +91,7 @@ class CRM_Core_Payment_PaymentExpressIPN extends CRM_Core_Payment_BaseIPN {
    * @return object
    * @static
    */
-  static function &singleton($mode, $component, &$paymentProcessor) {
+  static function &singleton($mode = 'test', &$paymentProcessor, &$paymentForm = NULL, $force = FALSE) {
     if (self::$_singleton === NULL) {
       self::$_singleton = new CRM_Core_Payment_PaymentExpressIPN($mode, $paymentProcessor);
     }

--- a/CRM/Core/Payment/PaymentExpressUtils.php
+++ b/CRM/Core/Payment/PaymentExpressUtils.php
@@ -34,50 +34,49 @@
  */
 class CRM_Core_Payment_PaymentExpressUtils {
 
-function _valueXml($element, $value = NULL) {
-  $nl = "\n";
+  static function _valueXml($element, $value = NULL) {
+    $nl = "\n";
 
-  if (is_array($element)) {
-    $xml = '';
-    foreach ($element as $elem => $value) {
-        $xml .= self::_valueXml($elem, $value);
+    if (is_array($element)) {
+      $xml = '';
+      foreach ($element as $elem => $value) {
+          $xml .= self::_valueXml($elem, $value);
+      }
+      return $xml;
     }
-    return $xml;
+    return "<" . $element . ">" . $value . "</" . $element . ">" . $nl;
   }
-  return "<" . $element . ">" . $value . "</" . $element . ">" . $nl;
-}
 
-function _xmlElement($xml, $name) {
-  $value = preg_replace('/.*<' . $name . '[^>]*>(.*)<\/' . $name . '>.*/', '\1', $xml);
-  return $value;
-}
-
-function _xmlAttribute($xml, $name) {
-  $value = preg_replace('/<.*' . $name . '="([^"]*)".*>/', '\1', $xml);
-  return $value != $xml ? $value : NULL;
-}
-
-function &_initCURL($query, $url) {
-  $curl = curl_init();
-
-  curl_setopt($curl, CURLOPT_URL, $url);
-  curl_setopt($curl, CURLOPT_FRESH_CONNECT, TRUE);
-  curl_setopt($curl, CURLOPT_POST, TRUE);
-  curl_setopt($curl, CURLOPT_POSTFIELDS, $query);
-  curl_setopt($curl, CURLOPT_POSTFIELDSIZE, 0);
-  curl_setopt($curl, CURLOPT_TIMEOUT, 30);
-  curl_setopt($curl, CURLOPT_RETURNTRANSFER, TRUE);
-  if (ini_get('open_basedir') == '' && ini_get('safe_mode') == 'Off') {
-    curl_setopt($curl, CURLOPT_FOLLOWLOCATION, FALSE);
+  static function _xmlElement($xml, $name) {
+    $value = preg_replace('/.*<' . $name . '[^>]*>(.*)<\/' . $name . '>.*/', '\1', $xml);
+    return $value;
   }
-  curl_setopt($curl, CURLOPT_HEADER, 0);
-  curl_setopt($curl, CURLOPT_SSLVERSION, 3);
 
-  if (strtoupper(substr(@php_uname('s'), 0, 3)) === 'WIN') {
-    curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME, 'verifySSL'));
-    curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME, 'verifySSL') ? 2 : 0);
+  static function _xmlAttribute($xml, $name) {
+    $value = preg_replace('/<.*' . $name . '="([^"]*)".*>/', '\1', $xml);
+    return $value != $xml ? $value : NULL;
   }
-  return $curl;
-}
+
+  static function &_initCURL($query, $url) {
+    $curl = curl_init();
+
+    curl_setopt($curl, CURLOPT_URL, $url);
+    curl_setopt($curl, CURLOPT_FRESH_CONNECT, TRUE);
+    curl_setopt($curl, CURLOPT_POST, TRUE);
+    curl_setopt($curl, CURLOPT_POSTFIELDS, $query);
+    curl_setopt($curl, CURLOPT_TIMEOUT, 30);
+    curl_setopt($curl, CURLOPT_RETURNTRANSFER, TRUE);
+    if (ini_get('open_basedir') == '' && ini_get('safe_mode') == 'Off') {
+      curl_setopt($curl, CURLOPT_FOLLOWLOCATION, FALSE);
+    }
+    curl_setopt($curl, CURLOPT_HEADER, 0);
+    curl_setopt($curl, CURLOPT_SSLVERSION, 3);
+
+    if (strtoupper(substr(@php_uname('s'), 0, 3)) === 'WIN') {
+      curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME, 'verifySSL'));
+      curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME, 'verifySSL') ? 2 : 0);
+    }
+    return $curl;
+  }
 
 }


### PR DESCRIPTION
...ards compatibility

I'm running a fairly recent version of PHP, and have strict standards turned on.. so the Payment Express component was spewing warnings and errors about non-static functions being called statically and the singleton function not being compatible with its parent.

The solution, make the CRM_Core_Payment_PaymentExpressUtils functions static, and change the definition of the CRM_Core_Payment_PaymentExpress and CRM_Core_Payment_PaymentExpressIPN singleton() functions to match that in CRM_Core_Payment

I also discovered an undefined CURL option in CRM_Core_Payment_PaymentExpressUtils that was being set - This doesn't do anything and causes a warning so I removed it.
