### PR TITLE
CRM-13986 - CRM_Core_Invoke - Handle HTML and WS requests differently

### DIFF
--- a/CRM/Core/Invoke.php
+++ b/CRM/Core/Invoke.php
@@ -117,8 +117,13 @@ class CRM_Core_Invoke {
       $kernel = new AppKernel('dev', true);
       $kernel->loadClassCache();
       $response = $kernel->handle(Symfony\Component\HttpFoundation\Request::createFromGlobals());
-      // $response->send();
-      return $response->getContent();
+      if (preg_match(':^text/html:', $response->headers->get('Content-Type'))) {
+        // let the CMS handle the trappings
+        return $response->getContent();
+      } else {
+        $response->send();
+        exit();
+      }
     }
   }
   /**


### PR DESCRIPTION
For HTML, use the CMS's output mechanism (with its theming, etc) For web
services (or any non-HTML content), use Symfony's output mechanism
