### PR TITLE
Moved "Top of page" profile below introductory text.

### DIFF
--- a/templates/CRM/Event/Form/Registration/Register.tpl
+++ b/templates/CRM/Event/Form/Registration/Register.tpl
@@ -71,6 +71,10 @@
         <p>{$event.intro_text}</p>
       </div>
     {/if}
+
+    {* Display "Top of page" profile immediately after the introductory text *}
+    {include file="CRM/UF/Form/Block.tpl" fields=$customPre}
+
     {include file="CRM/common/cidzero.tpl"}
     {if $pcpSupporterText}
       <div class="crm-section pcpSupporterText-section">
@@ -137,7 +141,6 @@
     {* User account registration option. Displays if enabled for one of the profiles on this page. *}
     {include file="CRM/common/CMSUser.tpl"}
 
-    {include file="CRM/UF/Form/Block.tpl" fields=$customPre}
 
     {if $form.payment_processor.label}
       <fieldset class="crm-group payment_options-group" style="display:none;">

--- a/templates/CRM/Event/Form/Registration/Register.tpl
+++ b/templates/CRM/Event/Form/Registration/Register.tpl
@@ -72,9 +72,6 @@
       </div>
     {/if}
 
-    {* Display "Top of page" profile immediately after the introductory text *}
-    {include file="CRM/UF/Form/Block.tpl" fields=$customPre}
-
     {include file="CRM/common/cidzero.tpl"}
     {if $pcpSupporterText}
       <div class="crm-section pcpSupporterText-section">
@@ -94,6 +91,12 @@
         <div class="clear"></div>
       </div>
     {/if}
+
+    {* User account registration option. Displays if enabled for one of the profiles on this page. *}
+    {include file="CRM/common/CMSUser.tpl"}
+
+    {* Display "Top of page" profile immediately after the introductory text *}
+    {include file="CRM/UF/Form/Block.tpl" fields=$customPre}
 
     {if $priceSet}
       {if ! $quickConfig}<fieldset id="priceset" class="crm-group priceset-group">
@@ -137,10 +140,6 @@
         </div>
       </fieldset>
     {/if}
-
-    {* User account registration option. Displays if enabled for one of the profiles on this page. *}
-    {include file="CRM/common/CMSUser.tpl"}
-
 
     {if $form.payment_processor.label}
       <fieldset class="crm-group payment_options-group" style="display:none;">


### PR DESCRIPTION
The page documentation says that "Top of page" profile fields will appear "immediately after the introductory message." This commit fixes the display to align with this documentation and use cases where users want the text to appear where stated. Previously, the text would appear under price sets, which wasn't intuitive or in alignment with on screen documentation.
