### PR TITLE
CRM-14249 - fix fatal error when anonymous user accesses civicrm/mailing...

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1110,6 +1110,11 @@ ORDER BY   civicrm_email.is_bulkmail DESC
     if ($contactDetails) {
       $contact = $contactDetails;
     }
+    elseif ($contactId === 0) {
+      //anonymous user
+      $contact = array();
+      CRM_Utils_Hook::tokenValues($contact, $contactId, $job_id);
+    }
     else {
       $params = array(array('contact_id', '=', $contactId, 0, 0));
       list($contact, $_) = CRM_Contact_BAO_Query::apiQuery($params);


### PR DESCRIPTION
.../view.

---
- CRM-14249: Can't view public mailings when logged out
  http://issues.civicrm.org/jira/browse/CRM-14249
