### PR TITLE
CRM-14265 add event custom fields to advanced search … 

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1733,7 +1733,7 @@ SELECT IF( EXISTS(SELECT name FROM civicrm_contact_type WHERE name like %1), 1, 
       // add field information
       foreach ($value['fields'] as $k => $properties) {
         $properties['element_name'] = "custom_{$k}_-{$groupCount}";
-        if (isset($properties['customValue']) && !CRM_Utils_system::isNull($properties['customValue'])) {
+        if (isset($properties['customValue']) && !CRM_Utils_System::isNull($properties['customValue'])) {
           if (isset($properties['customValue'][$groupCount])) {
             $properties['element_name'] = "custom_{$k}_{$properties['customValue'][$groupCount]['id']}";
             $formattedGroupTree[$key]['table_id'] = $properties['customValue'][$groupCount]['id'];

--- a/CRM/Core/BAO/CustomQuery.php
+++ b/CRM/Core/BAO/CustomQuery.php
@@ -104,7 +104,7 @@ class CRM_Core_BAO_CustomQuery {
 
   /**
    * This stores custom data group types and tables that it extends
-   *
+   * @todo add comments explaining why survey & campaign are missing from this
    * @var array
    * @static
    */
@@ -272,44 +272,23 @@ SELECT label, value
         $joinTable = 'contact_a';
       }
       elseif ($field['extends'] == 'civicrm_contribution') {
-        $joinTable = 'civicrm_contribution';
+        $joinTable = $field['extends'];
       }
-      elseif ($field['extends'] == 'civicrm_participant') {
-        $joinTable = 'civicrm_participant';
+      elseif (in_array($field['extends'], self::$extendsMap)) {
+        $joinTable = $field['extends'];
       }
-      elseif ($field['extends'] == 'civicrm_membership') {
-        $joinTable = 'civicrm_membership';
+      else {
+        return;
       }
-      elseif ($field['extends'] == 'civicrm_pledge') {
-        $joinTable = 'civicrm_pledge';
+      $this->_tables[$name] = "\nLEFT JOIN $name ON $name.entity_id = $joinTable.id";
+      if ($this->_ids[$id]) {
+        $this->_whereTables[$name] = $this->_tables[$name];
       }
-      elseif ($field['extends'] == 'civicrm_activity') {
-        $joinTable = 'civicrm_activity';
+      if ($joinTable != 'contact_a') {
+         $this->_whereTables[$joinTable] = $this->_tables[$joinTable] = 1;
       }
-      elseif ($field['extends'] == 'civicrm_relationship') {
-        $joinTable = 'civicrm_relationship';
-      }
-      elseif ($field['extends'] == 'civicrm_grant') {
-        $joinTable = 'civicrm_grant';
-      }
-      elseif ($field['extends'] == 'civicrm_address') {
-        $joinTable = 'civicrm_address';
-      }
-      elseif ($field['extends'] == 'civicrm_case') {
-        $joinTable = 'civicrm_case';
-      }
-
-      if ($joinTable) {
-        $this->_tables[$name] = "\nLEFT JOIN $name ON $name.entity_id = $joinTable.id";
-        if ($this->_ids[$id]) {
-          $this->_whereTables[$name] = $this->_tables[$name];
-        }
-        if ($joinTable != 'contact_a') {
-          $this->_whereTables[$joinTable] = $this->_tables[$joinTable] = 1;
-        }
-        elseif ($this->_contactSearch) {
-          CRM_Contact_BAO_Query::$_openedPanes[ts('Custom Fields')] = TRUE;
-        }
+      elseif ($this->_contactSearch) {
+        CRM_Contact_BAO_Query::$_openedPanes[ts('Custom Fields')] = TRUE;
       }
     }
   }

--- a/CRM/Event/BAO/Query.php
+++ b/CRM/Event/BAO/Query.php
@@ -586,7 +586,8 @@ class CRM_Event_BAO_Query {
     $form->addRule('participant_fee_amount_low', ts('Please enter a valid money value.'), 'money');
     $form->addRule('participant_fee_amount_high', ts('Please enter a valid money value.'), 'money');
     // add all the custom  searchable fields
-    $extends = array('Participant');
+    $extends = array('Participant', 'Event');
+    //@todo CRM-14265 I have added Event here - there remains a question as to whether & how they should be visually separated
     $groupDetails = CRM_Core_BAO_CustomGroup::getGroupDetail(NULL, TRUE, $extends);
     if ($groupDetails) {
       $form->assign('participantGroupTree', $groupDetails);

--- a/CRM/Event/BAO/Query.php
+++ b/CRM/Event/BAO/Query.php
@@ -211,7 +211,7 @@ class CRM_Event_BAO_Query {
       if (substr($query->_params[$id][0], 0, 6) == 'event_' ||
         substr($query->_params[$id][0], 0, 12) == 'participant_'
       ) {
-        if ($query->_mode == CRM_Contact_BAO_QUERY::MODE_CONTACTS) {
+        if ($query->_mode == CRM_Contact_BAO_Query::MODE_CONTACTS) {
           $query->_useDistinct = TRUE;
         }
         $grouping = $query->_params[$id][3];
@@ -557,14 +557,14 @@ class CRM_Event_BAO_Query {
     $form->assign('dataURLEventType', $dataURLEventType);
     $form->assign('dataURLEventFee', $dataURLEventFee);
 
-    $eventId        = &$form->add('text', 'event_name', ts('Event Name'));
-    $eventType      = &$form->add('text', 'event_type', ts('Event Type'));
-    $participantFee = &$form->add('text', 'participant_fee_level', ts('Fee Level'));
+    $form->add('text', 'event_name', ts('Event Name'));
+    $form->add('text', 'event_type', ts('Event Type'));
+    $form->add('text', 'participant_fee_level', ts('Fee Level'));
 
     //elements for assigning value operation
-    $eventNameId      = &$form->add('hidden', 'event_id', '', array('id' => 'event_id'));
-    $eventTypeId      = &$form->add('hidden', 'event_type_id', '', array('id' => 'event_type_id'));
-    $participantFeeId = &$form->add('hidden', 'participant_fee_id', '', array('id' => 'participant_fee_id'));
+    $form->add('hidden', 'event_id', '', array('id' => 'event_id'));
+    $form->add('hidden', 'event_type_id', '', array('id' => 'event_type_id'));
+    $form->add('hidden', 'participant_fee_id', '', array('id' => 'participant_fee_id'));
 
     CRM_Core_Form_Date::buildDateRange($form, 'event', 1, '_start_date_low', '_end_date_high', ts('From'), FALSE);
 


### PR DESCRIPTION
Add event custom fields to advanced search  

Note that I haven't included the commit for it but adding address & group is facilitated by this. The problem is that there is no logical place for the group custom data.

This commit adds Group & Address custom data to advanced search - but Group custom data fields sit in the main panes
https://github.com/fuzionnz/civicrm-core/commit/eebebe56be1bcc336304bee93f7288f6d4ad2cda
