### PR TITLE
CRM-14281 call hook_civicrm_config() in loadbootstrap()

### DIFF
--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -640,6 +640,10 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
     }
 
     jimport('joomla.application.cli');
+    
+    // CRM-14281 Joomla wasn't available during bootstrap, so hook_civicrm_config never executes.
+    $config = CRM_Core_Config::singleton();
+    CRM_Utils_Hook::config($config);
 
     return TRUE;
   }


### PR DESCRIPTION
---
- CRM-14281: hook_civicrm_config does not get called when using Joomla bootstrap
  http://issues.civicrm.org/jira/browse/CRM-14281
