### PR TITLE
CRM-14286 - Contact mailings tab should show opens and clicks for curren...

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -2742,8 +2742,8 @@ AND        m.id = %1
 
     //CRM-12814
     if (!empty($mailings)) {
-      $openCounts = CRM_Mailing_Event_BAO_Opened::getMailingTotalCount(array_keys($mailings));
-      $clickCounts = CRM_Mailing_Event_BAO_TrackableURLOpen::getMailingTotalCount(array_keys($mailings));
+      $openCounts = CRM_Mailing_Event_BAO_Opened::getMailingContactCount(array_keys($mailings), $params['contact_id']);
+      $clickCounts = CRM_Mailing_Event_BAO_TrackableURLOpen::getMailingContactCount(array_keys($mailings), $params['contact_id']);
     }
 
     // format params and add links
@@ -2760,8 +2760,10 @@ AND        m.id = %1
         "reset=1&cid={$values['creator_id']}");
 
       //CRM-12814
-      $contactMailings[$mailingId]['openstats'] = ts('Opens') . ': ' . $openCounts[$values['mailing_id']] .
-        '<br />' . ts('Clicks') . ': ' . $clickCounts[$values['mailing_id']];
+      $contactMailings[$mailingId]['openstats'] = "Opens: ".
+        CRM_Utils_Array::value($values['mailing_id'], $openCounts, 0).
+        "<br />Clicks: ".
+        CRM_Utils_Array::value($values['mailing_id'], $clickCounts, 0);
 
       $actionLinks = array(
         CRM_Core_Action::VIEW => array(

--- a/CRM/Mailing/Event/BAO/Opened.php
+++ b/CRM/Mailing/Event/BAO/Opened.php
@@ -160,6 +160,47 @@ class CRM_Mailing_Event_BAO_Opened extends CRM_Mailing_Event_DAO_Opened {
   }
 
   /**
+   * Get opened count for each mailing for a given set of mailing IDs and a specific contact
+   *
+   * @param int $mailingIDs   IDs of the mailing (comma separated)
+   * @param int $contactID    ID of the contact
+   *
+   * @return array            Count per mailing ID
+   * @access public
+   * @static
+   */
+  public static function getMailingContactCount($mailingIDs, $contactID) {
+    $dao = new CRM_Core_DAO();
+    $openedCount = array();
+
+    $open = self::getTableName();
+    $queue = CRM_Mailing_Event_BAO_Queue::getTableName();
+    $job = CRM_Mailing_BAO_MailingJob::getTableName();
+    $mailingIDs = implode(',', $mailingIDs);
+
+    $query = "
+      SELECT $job.mailing_id as mailingID, COUNT($open.id) as opened
+      FROM $open
+      INNER JOIN $queue
+        ON  $open.event_queue_id = $queue.id
+        AND $queue.contact_id = $contactID
+      INNER JOIN $job
+        ON  $queue.job_id = $job.id
+        AND $job.is_test = 0
+      WHERE $job.mailing_id IN ({$mailingIDs})
+      GROUP BY civicrm_mailing_job.mailing_id
+    ";
+
+    $dao->query($query);
+
+    while ( $dao->fetch() ) {
+      $openedCount[$dao->mailingID] = $dao->opened;
+    }
+
+    return $openedCount;
+  }
+
+  /**
    * Get rows for the event browser
    *
    * @param int $mailing_id       ID of the mailing

--- a/templates/CRM/Mailing/Page/Tab.tpl
+++ b/templates/CRM/Mailing/Page/Tab.tpl
@@ -30,7 +30,7 @@
     <tr>
       <th class='crm-mailing-contact-subject'>{ts}Subject{/ts}</th>
       <th class='crm-mailing-contact_created'>{ts}Added By{/ts}</th>
-      <th class='crm-contact-activity_contact nosort'>{ts}With{/ts}</th>
+      <th class='crm-contact-activity_contact nosort'>{ts}Recipients{/ts}</th>
       <th class='crm-mailing-contact-date'>{ts}Date{/ts}</th>
       <th class='crm-mailing_openstats'>{ts}Opens/ Clicks{/ts}</th>
       <th class='crm-mailing-contact-links nosort'>&nbsp;</th>


### PR DESCRIPTION
...tly viewed contact. This commit cannot be backported to 4.3 without adjustment  since CRM_Mailing_BAO_Job has been renamed to CRM_Mailing_BAO_MailingJob as of 4.4.

---
- CRM-14286: Contact Mailings tab selector should show Open and Click activity specfic to the currently viewed contact
  http://issues.civicrm.org/jira/browse/CRM-14286
