### PR TITLE
fix for : js break when adding new participant through contact screen

### DIFF
--- a/templates/CRM/Event/Form/Participant.tpl
+++ b/templates/CRM/Event/Form/Participant.tpl
@@ -332,6 +332,10 @@
     {if $participantId}
       {include file="CRM/Contribute/Page/PaymentInfo.tpl" show='event-payment'}
     {/if}
+
+    {*include custom data js file*}
+    {include file="CRM/common/customData.tpl"}
+
     <script type="text/javascript">
       {literal}
       cj(function($) {
@@ -553,9 +557,6 @@
       });
     </script>
     {/literal}
-
-    {*include custom data js file*}
-    {include file="CRM/common/customData.tpl"}
 
     {* jscript to warn if unsaved form field changes *}
     {include file="CRM/common/formNavigate.tpl"}


### PR DESCRIPTION
Details for replication : 
-  click on 'Add Register Participant' button in the Events Tab of User Contact Page.
-  issue error : <code>TypeError: CRM.buildCustomData is not a function
              CRM.buildCustomData( 'Participant', 'null', 'null' ); </code>
- This is generated because the function invoke is made prior to the function declaration.
- As a result it breaks all subsequent js in the 'Register Participant' dialog box and the flow breaks.

fix : to declare the function (i.e to include the common/customData.tpl) above the invoke.
causing commit : https://github.com/civicrm/civicrm-core/commit/1beb268a63e70974a25de6f08812575f7f11d778#diff-122c31296531d2f3f77a8920f8f6488bL599 
