### PR TITLE
api_v3_SyntaxConformanceTest - Fix hard failure

### DIFF
--- a/CRM/Core/CodeGen/Specification.php
+++ b/CRM/Core/CodeGen/Specification.php
@@ -279,6 +279,7 @@ class CRM_Core_CodeGen_Specification {
         $field['sqlType'] = 'decimal(' . $length . ')';
         $field['phpType'] = 'float';
         $field['crmType'] = 'CRM_Utils_Type::T_MONEY';
+        $field['precision'] = $length;
         break;
 
       case 'float':

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1339,7 +1339,12 @@ SELECT contact_id
             case CRM_Utils_Type::T_INT:
             case CRM_Utils_Type::T_FLOAT:
             case CRM_Utils_Type::T_MONEY:
-              $object->$dbName = $counter;
+              if (isset($value['precision'])) {
+                // $object->$dbName = CRM_Utils_Number::createRandomDecimal($value['precision']);
+                $object->$dbName = CRM_Utils_Number::createTruncatedDecimal($counter, $value['precision']);
+              } else {
+                $object->$dbName = $counter;
+              }
               break;
 
             case CRM_Utils_Type::T_BOOLEAN:

--- a/CRM/Utils/Number.php
+++ b/CRM/Utils/Number.php
@@ -1,0 +1,40 @@
+<?php
+class CRM_Utils_Number {
+  /**
+   * Create a random number with a given precision
+   *
+   * @param array $precision (int $significantDigits, int $postDecimalDigits)
+   * @link https://dev.mysql.com/doc/refman/5.1/en/fixed-point-types.html
+   */
+  static function createRandomDecimal($precision) {
+    list ($sigFigs, $decFigs) = $precision;
+    $rand = rand(0, pow(10, $sigFigs) - 1);
+    return $rand / pow(10, $decFigs);
+  }
+
+  /**
+   * Given a number, coerce it to meet the precision requirement. If possible, it should
+   * keep the number as-is. If necessary, this may drop the least-significant digits
+   * and/or move the decimal place.
+   *
+   * @param int|float $keyValue
+   * @param array $precision (int $significantDigits, int $postDecimalDigits)
+   * @return float
+   * @link https://dev.mysql.com/doc/refman/5.1/en/fixed-point-types.html
+   */
+  static function createTruncatedDecimal($keyValue, $precision) {
+    list ($sigFigs, $decFigs) = $precision;
+    $sign = ($keyValue < 0) ? '-1' : 1;
+    $val = str_replace('.', '', abs($keyValue)); // ex: -123.456 ==> 123456
+    $val = substr($val, 0, $sigFigs); // ex: 123456 => 1234
+
+    // Move any extra digits after decimal
+    $extraFigs = strlen($val) - ($sigFigs - $decFigs);
+    if ($extraFigs > 0) {
+      return $sign * $val / pow(10, $extraFigs); // ex: 1234 => 1.234
+    }
+    else {
+      return $sign * $val;
+    }
+  }
+}

--- a/tests/phpunit/CRM/Utils/NumberTest.php
+++ b/tests/phpunit/CRM/Utils/NumberTest.php
@@ -1,0 +1,59 @@
+<?php
+require_once 'CiviTest/CiviUnitTestCase.php';
+class CRM_Utils_NumberTest extends CiviUnitTestCase {
+
+  function randomDecimalCases() {
+    $cases = array();
+    // array(array $precision, int $expectedMinInclusive, int $expectedMaxExclusive)
+    $cases[] = array(array(1, 0), 0, 10);
+    $cases[] = array(array(5, 2), 0, 1000);
+    $cases[] = array(array(10, 8), 0, 100);
+    return $cases;
+  }
+
+  /**
+   * @param array $precision
+   * @param int $expectedMinInclusive
+   * @param int $expectedMaxExclusive
+   * @dataProvider randomDecimalCases
+   */
+  function testCreateRandomDecimal($precision, $expectedMinInclusive, $expectedMaxExclusive) {
+    list ($sigFigs, $decFigs) = $precision;
+    for ($i = 0; $i < 10; $i++) {
+      $decimal = CRM_Utils_Number::createRandomDecimal($precision);
+      // print "Assert $decimal between $expectedMinInclusive and $expectedMaxExclusive\n";
+      $this->assertTrue(($expectedMinInclusive <= $decimal) && ($decimal < $expectedMaxExclusive), "Assert $decimal between $expectedMinInclusive and $expectedMaxExclusive");
+      if (strpos($decimal, '.') === FALSE) {
+        $decimal .= '.';
+      }
+      list ($before, $after) = explode('.', $decimal);
+      $this->assertTrue(strlen($before) + strlen($after) <= $sigFigs, "Assert $decimal [$before;$after] has <= $sigFigs sigFigs");
+      $this->assertTrue(strlen($after) <= $decFigs, "Assert $decimal [$before;$after] has <= $decFigs decFigs");
+    }
+  }
+
+  function truncDecimalCases() {
+    $cases = array();
+    // array($value, $precision, $expectedValue)
+    $cases[] = array(523, array(1,0), 5);
+    $cases[] = array(523, array(5,2), 523);
+    $cases[] = array(523, array(10,8), 52.3);
+    $cases[] = array(12345, array(3,3), 0.123);
+    $cases[] = array(0.12345, array(10,0), 12345);
+    $cases[] = array(-123.45, array(4,2), -12.34);
+    return $cases;
+  }
+
+  /**
+   * @param $value
+   * @param $precision
+   * @param $expectedValue
+   * @dataProvider truncDecimalCases
+   */
+  function testCreateTruncatedDecimal($value, $precision, $expectedValue) {
+    list ($sigFigs, $decFigs) = $precision;
+    $this->assertEquals($expectedValue, CRM_Utils_Number::createTruncatedDecimal($value, $precision),
+      "assert createTruncatedValue($value, ($sigFigs,$decFigs)) == $expectedValue"
+    );
+  }
+}

--- a/xml/templates/dao.tpl
+++ b/xml/templates/dao.tpl
@@ -183,6 +183,9 @@ class {$table.className} extends CRM_Core_DAO {ldelim}
 {if $field.length}
                       'maxlength' => {$field.length},
 {/if} {* field.length *}
+{if $field.precision}
+                      'precision'      => array({$field.precision}),
+{/if}
 {if $field.size}
                       'size'      => {$field.size},
 {/if} {* field.size *}


### PR DESCRIPTION
The arbitrarily generated value of "tax_rate" violates the MySQL precision 
constraints. This commit ensures that the arbitrarily chosen values meet the
constraint (while trying to preserve the old series of generated numbers for
most use-cases).
