### PR TITLE
CRM-14325 - adding participants to event from manage groups

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -222,7 +222,10 @@ class CRM_Event_Form_Participant extends CRM_Contact_Form_Task {
     // check the current path, if search based, then dont get participantID
     // CRM-5792
     $path = CRM_Utils_System::currentPath();
-    if (strpos($path, 'civicrm/contact/search') === 0) {
+    if (
+      strpos($path, 'civicrm/contact/search') === 0 ||
+      strpos($path, 'civicrm/group/search') === 0
+      ) {
       $this->_id = NULL;
     }
     else {


### PR DESCRIPTION
If default search profile is set, you cannot reliably add participants
to an event when doing so from the manage group interface.

---
- CRM-14325: when default search profile is set, can't reliably add contacts to event from manage group page
  http://issues.civicrm.org/jira/browse/CRM-14325
