### PR TITLE
CRM-13965-qa-fixes

### DIFF
--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -735,6 +735,9 @@ WHERE reminder.action_schedule_id = %1 AND reminder.action_date_time IS NULL
             $balancePay = CRM_Utils_Money::format($balancePay);
             $entityTokenParams["{$tokenEntity}." . $field] = $balancePay;
           }
+          elseif ($field == 'fee_amount') {
+            $entityTokenParams["{$tokenEntity}." . $field] = CRM_Utils_Money::format($dao->$field);
+          }
           else {
             $entityTokenParams["{$tokenEntity}." . $field] = $dao->$field;
           }

--- a/templates/CRM/Event/Form/Participant.tpl
+++ b/templates/CRM/Event/Form/Participant.tpl
@@ -345,8 +345,15 @@
         var $form = $('form#{/literal}{$form.formName}{literal}');
 
         // don't show cart related statuses if it's disabled
-        var pendingInCartStatusId = {/literal}{$pendingInCartStatusId}{literal};
-        $("#status_id option[value='" + pendingInCartStatusId + "']").remove();
+        {/literal}{if !$enableCart}{literal}
+          var pendingInCartStatusId = {/literal}{$pendingInCartStatusId}{literal};
+          $("#status_id option[value='" + pendingInCartStatusId + "']").remove();
+        {/literal}{/if}{literal}
+
+        {/literal}{if $action eq 1}{literal}
+          var pendingRefundStatusId = {/literal}{$pendingRefundStatusId}{literal};
+          $("#status_id option[value='" + pendingRefundStatusId + "']").remove();
+        {/literal}{/if}{literal}
 
         // Handle event selection
         $('#event_id', $form).change(function() {


### PR DESCRIPTION
fix for bugs mentioned in comment http://issues.civicrm.org/jira/browse/CRM-13965?focusedCommentId=58223#comment-58223

for point no. 5 fix : suppressed the 'Pending refund' status option when the ADD action is performed.

Checked for all amount tokens (used mostly for contributions, memeberships, events), all are using conversions, except for the one dgg mentioned in comment (this has been fixed in this PR).
