### PR TITLE
CRM-14310 - Fix issue with custom validation not firing on Event Info an...

### DIFF
--- a/CRM/Event/Form/ManageEvent/TabHeader.php
+++ b/CRM/Event/Form/ManageEvent/TabHeader.php
@@ -137,6 +137,10 @@ WHERE      e.id = %1
         $class = strtolower(basename(CRM_Utils_Array::value('action', $attributes)));
         break;
 
+      case 'EventInfo':
+        $class = 'settings';
+        break;
+
       case 'ScheduleReminders':
         $class = 'reminder';
         $new = !empty($_GET['new']) ? '&new=1' : '';


### PR DESCRIPTION
...d

Settings page.

This commit makes both custom validation work and allows the form the reload with the values that were attempted to be submitted, rather than the previously successfully submitted values.
