### PR TITLE
CRM-13973 : fix for #comment-58346

### DIFF
--- a/js/crm.ajax.js
+++ b/js/crm.ajax.js
@@ -311,7 +311,7 @@
         ajaxForm: {},
         autoClose: true,
         validate: true,
-        refreshAction: ['next_new', 'submit_savenext'],
+        refreshAction: ['next_new', 'submit_savenext', 'upload_new'],
         cancelButton: '.cancel',
         openInline: 'a.open-inline, a.button, a.action-item',
         onCancel: function(event) {},


### PR DESCRIPTION
the issue raised due to :

while performing 'save and new' button action from within a popup, inside the code we have checked for a 'condition', and after successfully meeting that condition we open a 'new form' (via redirection) inside the popup.

This condition is like : <code>response.userContext && settings.refreshAction && $.inArray(response.buttonName, settings.refreshAction) >= 0 </code> , in which <code>$.inArray(response.buttonName, settings.refreshAction) </code> condition is not met and hence the redirection or new form load doesn't take place.

The fix: defined a new value 'upload_new' to settings.refreshAction as this value is return after every 'save and new' button click.
