### PR TITLE
CRM Test Fixes

### DIFF
--- a/tests/phpunit/CRM/Contact/BAO/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ContactTest.php
@@ -546,7 +546,7 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
     //take the common contact params
     $params = $this->contactParams();
     $params['note'] = 'test note';
-    $params['create_employer'] = 'Yahoo';
+    $params['create_employer'] = 1;
 
     //create the contact with given params.
     $contact = CRM_Contact_BAO_Contact::create($params);
@@ -615,7 +615,7 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
     $this->assertEquals(1, $values['relationship']['totalCount'], 'Check for total relationship count');
     foreach ($values['relationship']['data'] as $key => $val) {
       //Now check values of Relationship organization.
-      $this->assertEquals($params['create_employer'], $val['name'], 'Check for organization');
+      $this->assertEquals($params['create_employer'], $val['id'], 'Check for organization');
       //Now check values of Relationship type.
       $this->assertEquals('Employee of', $val['relation'], 'Check for relationship type');
       //delete the organization.

--- a/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
@@ -155,8 +155,8 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
     $fields = array(
       'groupId' => $customGroup->id,
       'label' => 'Throwaway Field',
-      'data_type' => 'Memo',
-      'html_type' => 'TextArea',
+      'dataType' => 'Memo',
+      'htmlType' => 'TextArea',
     );
 
     $customField = Custom::createField(array(), $fields);

--- a/tests/phpunit/CRM/Core/PseudoConstantTest.php
+++ b/tests/phpunit/CRM/Core/PseudoConstantTest.php
@@ -277,6 +277,10 @@ class CRM_Core_PseudoConstantTest extends CiviUnitTestCase {
           'sample' => array('USD' => 'US Dollar'),
           'max' => 200,
         ),
+        array(
+          'fieldName' => 'soft_credit_type_id',
+          'sample' => 'In Honor of',
+        ),
       ),
       'CRM_Contribute_DAO_Product' => array(
         array(
@@ -346,12 +350,6 @@ class CRM_Core_PseudoConstantTest extends CiviUnitTestCase {
           'fieldName' => 'mapping_type_id',
           'sample' => 'Search Builder',
           'max' => 15,
-        ),
-      ),
-      'CRM_Pledge_DAO_Pledge' => array(
-        array(
-          'fieldName' => 'honor_type_id',
-          'sample' => 'In Honor of',
         ),
       ),
       'CRM_Core_DAO_Phone' => array(
@@ -528,10 +526,6 @@ class CRM_Core_PseudoConstantTest extends CiviUnitTestCase {
         array(
           'fieldName' => 'contribution_status_id',
           'sample' => 'Completed',
-        ),
-        array(
-          'fieldName' => 'honor_type_id',
-          'sample' => 'In Honor of',
         ),
       ),
       'CRM_Contribute_DAO_ContributionPage' => array(

--- a/tests/phpunit/CRM/Utils/Migrate/fixtures/Activity-text.xml
+++ b/tests/phpunit/CRM/Utils/Migrate/fixtures/Activity-text.xml
@@ -32,6 +32,7 @@
       <is_active>1</is_active>
       <is_view>0</is_view>
       <column_name>name1_1</column_name>
+      <in_selector>0</in_selector>
       <custom_group_name>example</custom_group_name>
     </CustomField>
   </CustomFields>

--- a/tests/phpunit/CRM/Utils/Migrate/fixtures/ActivityMeeting-text.xml
+++ b/tests/phpunit/CRM/Utils/Migrate/fixtures/ActivityMeeting-text.xml
@@ -34,6 +34,7 @@
       <is_active>1</is_active>
       <is_view>0</is_view>
       <column_name>name1_1</column_name>
+      <in_selector>0</in_selector>
       <custom_group_name>example</custom_group_name>
     </CustomField>
   </CustomFields>

--- a/tests/phpunit/CRM/Utils/Migrate/fixtures/Contact-select.xml
+++ b/tests/phpunit/CRM/Utils/Migrate/fixtures/Contact-select.xml
@@ -31,6 +31,7 @@
       <is_active>1</is_active>
       <is_view>0</is_view>
       <column_name>our_select_field_1</column_name>
+      <in_selector>0</in_selector>
       <option_group_name>our_select_field_20130818044104</option_group_name>
       <custom_group_name>example</custom_group_name>
     </CustomField>

--- a/tests/phpunit/CRM/Utils/Migrate/fixtures/Contact-text.xml
+++ b/tests/phpunit/CRM/Utils/Migrate/fixtures/Contact-text.xml
@@ -32,6 +32,7 @@
       <is_active>1</is_active>
       <is_view>0</is_view>
       <column_name>name1_1</column_name>
+      <in_selector>0</in_selector>
       <custom_group_name>example</custom_group_name>
     </CustomField>
   </CustomFields>

--- a/tests/phpunit/CRM/Utils/Migrate/fixtures/Individual-text.xml
+++ b/tests/phpunit/CRM/Utils/Migrate/fixtures/Individual-text.xml
@@ -32,6 +32,7 @@
       <is_active>1</is_active>
       <is_view>0</is_view>
       <column_name>name1_1</column_name>
+      <in_selector>0</in_selector>
       <custom_group_name>example</custom_group_name>
     </CustomField>
   </CustomFields>

--- a/tests/phpunit/CRM/Utils/Migrate/fixtures/IndividualStudent-text.xml
+++ b/tests/phpunit/CRM/Utils/Migrate/fixtures/IndividualStudent-text.xml
@@ -34,6 +34,7 @@
       <is_active>1</is_active>
       <is_view>0</is_view>
       <column_name>name1_1</column_name>
+      <in_selector>0</in_selector>
       <custom_group_name>example</custom_group_name>
     </CustomField>
   </CustomFields>


### PR DESCRIPTION
Fixes contain CRM Tests failures 4.5alpha1 release for 
1. CRM_Core_BAO_CustomFieldTest.testDeleteCustomfield
2. CRM_Core_PseudoConstantTest.testOptionValues
3. CRM_Utils_Migrate_ImportExportTest : All Functions
4. CRM_Contact_BAO_ContactTest.testRetrieve 
