### PR TITLE
CRM-13878 fix

### DIFF
--- a/CRM/Contribute/BAO/Query.php
+++ b/CRM/Contribute/BAO/Query.php
@@ -97,6 +97,7 @@ class CRM_Contribute_BAO_Query {
       $query->_select['contribution_note'] = "civicrm_note.note as contribution_note";
       $query->_element['contribution_note'] = 1;
       $query->_tables['contribution_note'] = 1;
+      $query->_tables['civicrm_contribution'] = 1;
     }
 
     if (!empty($query->_returnProperties['contribution_batch'])) {


### PR DESCRIPTION
The patch provided in the issue is a good attempt to fix it, but provided a different solution after a bit of inspection:

The bug was <code>civicrm_contribution</code> table was not getting included in the from() clause function, the reason was, query building mechanism didn't consisted of table inclusion code for contribution table while contributon_note was included in the SELECT clause.

The fix: added inclusion.
