### PR TITLE
CRM-14386 fix for : form rule validation notifications not shown

### DIFF
--- a/templates/CRM/Form/body.tpl
+++ b/templates/CRM/Form/body.tpl
@@ -33,7 +33,7 @@
   <div>{$form.hidden}</div>
 {/if}
 
-{if $snippet neq 'json' and !$suppressForm and count($form.errors) gt 0}
+{if ($snippet eq 0 or $snippet neq 'json') and !$suppressForm and count($form.errors) gt 0}
    <div class="messages crm-error">
        <div class="icon red-icon alert-icon"></div>
      {ts}Please correct the following errors in the form fields below:{/ts}


### PR DESCRIPTION
Reproducible by following : Visit New Individual screen and without filling any details, save the form, the expected validation notification for 'email or first name and last name are required' doesn't appear.

The bug : somehow assigned value for <code>$snippet = 0 </code> fails this :  <code> $snippet neq 'json' </code>  check.

The fix : verified the numeric values and noticed this only happens for snippet = 0 value, so made some minor modifications to the condition.
