### PR TITLE
webtest issues(fixed)

### DIFF
--- a/tests/phpunit/CiviTest/CiviSeleniumTestCase.php
+++ b/tests/phpunit/CiviTest/CiviSeleniumTestCase.php
@@ -1166,7 +1166,7 @@ class CiviSeleniumTestCase extends PHPUnit_Extensions_SeleniumTestCase {
     $this->waitForPageToLoad($this->getTimeoutMsec());
   }
 
-  function webtestAddMembershipType($period_type = 'rolling', $duration_interval = 1, $duration_unit = 'year', $auto_renew = 'no') {
+  function webtestAddMembershipType($period_type = 'Rolling', $duration_interval = 1, $duration_unit = 'year', $auto_renew = 'no') {
     $membershipTitle = substr(sha1(rand()), 0, 7);
     $membershipOrg = $membershipTitle . ' memorg';
     $this->webtestAddOrganization($membershipOrg, TRUE);
@@ -1202,10 +1202,7 @@ class CiviSeleniumTestCase extends PHPUnit_Extensions_SeleniumTestCase {
         break;
     }
 
-    $this->type('member_of_contact', $membershipTitle);
-    $this->click('member_of_contact');
-    $this->waitForElementPresent("css=div.ac_results-inner li");
-    $this->click("css=div.ac_results-inner li");
+    $this->select2('member_of_contact_id',$membershipTitle);
 
     $this->type('minimum_fee', '100');
     $this->select('financial_type_id', "value={$memTypeParams['financial_type']}");

--- a/tests/phpunit/WebTest/Contact/AddTest.php
+++ b/tests/phpunit/WebTest/Contact/AddTest.php
@@ -368,7 +368,7 @@ class WebTest_Contact_AddTest extends CiviSeleniumTestCase {
     $this->click("tagGroup");
 
     // select group
-    $this->select("crmasmSelect0", "label=$groupName");
+    $this->select("group", "label=$groupName");
 
     $this->click("tag[{$this->webtestGetValidEntityID('Tag')}]");
 

--- a/tests/phpunit/WebTest/Contact/ContactTagTest.php
+++ b/tests/phpunit/WebTest/Contact/ContactTagTest.php
@@ -112,9 +112,9 @@ class WebTest_Contact_ContactTagTest extends CiviSeleniumTestCase {
     $this->waitForElementPresent("css=div#tagtree");
 
     //add Tagset to contact
-    $this->click("//div[@id='Tag']/div[3]/div[1]/ul/li[1]/input");
-    $this->type("//div[@id='Tag']/div[3]/div[1]/ul/li[1]/input", 'tagset1');
-    $this->typeKeys("//div[@id='Tag']/div[3]/div[1]/ul/li[1]/input", 'tagset1');
+    $this->click("//div[@id='Tag']/div[2]/div[1]/div/ul/li[1]/input");
+    $this->type("//div[@id='Tag']/div[2]/div[1]/div/ul/li[1]/input", 'tagset1');
+    $this->typeKeys("//div[@id='Tag']/div[2]/div[1]/div/ul/li[1]/input", 'tagset1');
 
     // ...waiting for drop down with results to show up...
     $this->waitForElementPresent("css=div.token-input-dropdown-facebook");
@@ -123,10 +123,10 @@ class WebTest_Contact_ContactTagTest extends CiviSeleniumTestCase {
     // ...need to use mouseDownAt on first result (which is a li element), click does not work
     $this->mouseDownAt("css=li.token-input-dropdown-item2-facebook");
 
-    $this->waitForElementPresent("//div[@id='Tag']/div[3]/div[1]/ul/li[1]/span");
-    $this->click("//div[@id='Tag']/div[3]/div[1]/ul/li[2]/input");
-    $this->type("//div[@id='Tag']/div[3]/div[1]/ul/li[2]/input", 'tagset2');
-    $this->typeKeys("//div[@id='Tag']/div[3]/div[1]/ul/li[2]/input", 'tagset2');
+    //$this->waitForElementPresent("//div[@id='Tag']/div[3]/div[1]/ul/li[1]/span");
+    $this->click("//div[@id='Tag']/div[2]/div[1]/div/ul/li[2]/input");
+    $this->type("//div[@id='Tag']/div[2]/div[1]/div/ul/li[2]/input", 'tagset2');
+    $this->typeKeys("//div[@id='Tag']/div[2]/div[1]/div/ul/li[2]/input", 'tagset2');
 
     // ...waiting for drop down with results to show up...
     $this->waitForElementPresent("css=div.token-input-dropdown-facebook");
@@ -135,7 +135,7 @@ class WebTest_Contact_ContactTagTest extends CiviSeleniumTestCase {
     // ...need to use mouseDownAt on first result (which is a li element), click does not work
     $this->mouseDownAt("css=li.token-input-dropdown-item2-facebook");
 
-    $this->click("//div[@id='Tag']/div[3]/div[1]/ul/li");
+    $this->click("//div[@id='Tag']/div[2]/div[1]/div/ul/li");
 
     // Type search name in autocomplete.
     $this->click("css=input#sort_name_navigation");
@@ -143,10 +143,10 @@ class WebTest_Contact_ContactTagTest extends CiviSeleniumTestCase {
     $this->typeKeys("css=input#sort_name_navigation", $firstName);
 
     // Wait for result list.
-    $this->waitForElementPresent("css=div.ac_results-inner li");
+    $this->waitForElementPresent("//*[@id='ui-id-1']/li[1]/a");
 
     // Visit contact summary page.
-    $this->click("css=div.ac_results-inner li");
+    $this->click("//*[@id='ui-id-1']/li[1]/a");
     $this->waitForPageToLoad($this->getTimeoutMsec());
     $this->waitForText('tags', "tagset1, tagset2");
   }

--- a/tests/phpunit/WebTest/Contact/SearchBuilderTest.php
+++ b/tests/phpunit/WebTest/Contact/SearchBuilderTest.php
@@ -83,7 +83,7 @@ class WebTest_Contact_SearchBuilderTest extends CiviSeleniumTestCase {
     $this->type("first_name", "$firstName");
     $this->type("middle_name", "mid$firstName");
     $this->type("last_name", "adv$firstName");
-    $this->select("contact_sub_type", "label=- $Subtype");
+    $this->select("contact_sub_type", "label=$Subtype");
     $this->type("email_1_email", "$firstName@advsearch.co.in");
     $this->type("phone_1_phone", "123456789");
     $this->type("external_identifier", "extid$firstName");


### PR DESCRIPTION
Following changes were made in files to solve webtest issues.
1) Civicrm 4.5 uses select2 element so called the function that handles select2 elements also UI contain 'Rolling' period type so changed default parameter of function. (WebTest_Contact_SearchBuilderTest.testSearchBuilderMembershipType).

2)Select fied id changed in 4.5. (WebTest_Contact_AddTest.testOrganizationAdd).

3)Hierarchy was not followed to enter tag set. Search name autocomplete id was incorrect. (WebTest_Contact_ContactTagTest.testTagSetContact).

4)Contact subtype was not matching due to additional character " - ". (WebTest_Contact_SearchBuilderTest.testSearchBuilderRLIKE).
