### PR TITLE
CRM-14367 add group by and send by email options to pdf letter task from

### DIFF
--- a/CRM/Contact/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contact/Form/Task/PDFLetterCommon.php
@@ -413,6 +413,7 @@ class CRM_Contact_Form_Task_PDFLetterCommon {
     $activityContacts = CRM_Core_OptionGroup::values('activity_contacts', FALSE, FALSE, FALSE, NULL, 'name');
     $targetID = CRM_Utils_Array::key('Activity Targets', $activityContacts);
 
+    //@todo why are we using $form->_contactIds here & contactIds above - need comment
     foreach ($form->_contactIds as $contactId) {
       $activityTargetParams = array(
         'activity_id' => empty($activity->id) ? $activityIds[$contactId] : $activity->id,

--- a/CRM/Contribute/Form/Task/PDFLetter.php
+++ b/CRM/Contribute/Form/Task/PDFLetter.php
@@ -59,7 +59,6 @@ class CRM_Contribute_Form_Task_PDFLetter extends CRM_Contribute_Form_Task {
   function preProcess() {
     $this->skipOnHold = $this->skipDeceased = FALSE;
     CRM_Contact_Form_Task_PDFLetterCommon::preProcess($this);
-
     // store case id if present
     $this->_caseId = CRM_Utils_Request::retrieve('caseid', 'Positive', $this, FALSE);
 
@@ -113,8 +112,26 @@ class CRM_Contribute_Form_Task_PDFLetter extends CRM_Contribute_Form_Task {
     $this->add('checkbox', 'thankyou_update', ts('Update thank-you dates for these contributions'), FALSE);
 
     // Group options for tokens are not yet implemented. dgg
-    $options = array(ts('Contact'), ts('Recurring'));
-    $this->addRadio('is_group_by', ts('Grouping contributions in one letter based on'), $options, array('allowClear' => TRUE), "<br/>", FALSE);
+    $options = array(
+      '' => ts('No Grouping'),
+      'contact_id' => ts('Contact'),
+      'contribution_recur_id' => ts('Recurring'),
+      'financial_type_id' => ts('Financial Type'),
+      'campaign_id' => ts('Campaign'),
+      'payment_instrument_id' => 'Payment Instrument',
+    );
+    $this->addElement('select', 'group_by', ts('Grouping contributions in one letter based on'), $options, array(), "<br/>", FALSE);
+    // this was going to be free-text but I opted for radio options in case there was a script injection risk
+    $separatorOptions = array('comma' => 'Comma', 'td' => 'Table Cell' );
+    $this->addElement('select', 'group_by_separator', ts('Separator for fields in Grouped Contributions'), $separatorOptions);
+    $emailOptions = array(
+      '' => ts('Generate PDFs for printing (only)'),
+      'email' => ts('Send as email where possible. Only generate printable PDF for remainder'),
+      'both' => ts('Send as email where possible And generate printable PDF for all'),
+      'pdfemail' => ts('Send pdf in email where possible. Only generate printable PDF for remainder'),
+      'pdfemail_both' => ts('Send pdf in email where possible And generate printable PDF for all'),
+    );
+    $this->addElement('select', 'email_options', ts('PDF by email options'), $emailOptions, array(), "<br/>", FALSE);
 
     $this->addButtons(array(
         array(
@@ -139,9 +156,6 @@ class CRM_Contribute_Form_Task_PDFLetter extends CRM_Contribute_Form_Task {
    * @return void
    */
   public function postProcess() {
-    // TODO: rewrite using contribution token and one letter by contribution
-    $this->setContactIDs();
-
     CRM_Contribute_Form_Task_PDFLetterCommon::postProcess($this);
   }
 }

--- a/CRM/Contribute/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contribute/Form/Task/PDFLetterCommon.php
@@ -14,98 +14,94 @@ class CRM_Contribute_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDF
    * @return void
    */
   static function postProcess(&$form) {
-
     list($formValues, $categories, $html_message, $messageToken, $returnProperties) = self::processMessageTemplate($form);
-
+    if(!empty($formValues['email_options'])) {
+      $returnProperties['email'] = $returnProperties['on_hold'] = $returnProperties['is_deceased'] = $returnProperties['do_not_email'] = 1;
+      $emailParams = array(
+        'subject'   => $formValues['subject']
+      );
+      $isPDF = FALSE;
+      if(stristr($formValues['email_options'], 'pdfemail')) {
+        $isPDF = TRUE;
+      }
+    }
     // update dates ?
     $receipt_update  = isset($formValues['receipt_update']) ? $formValues['receipt_update'] : FALSE;
     $thankyou_update = isset($formValues['thankyou_update']) ? $formValues['thankyou_update'] : FALSE;
     $nowDate         = date('YmdHis');
-    $receipts        = 0;
-    $thanks          = 0;
+    $receipts = $thanks = $emailed = 0;
     $updateStatus    = '';
+    $task = 'CRM_Contribution_Form_Task_PDFLetterCommon';
+    $realSeparator = ', ';
+    //the original thinking was mutliple options - but we are going with only 2 (comma & td) for now in case
+    // there are security (& UI) issues we need to think through
+    if(isset($formValues['group_by_separator'])) {
+      if($formValues['group_by_separator'] == 'td') {
+        $realSeparator = "</td><td>";
+      }
+    }
+    $separator = '****~~~~';// a placeholder in case the separator is common in the string - e.g ', '
+
+    $groupBy = $formValues['group_by'];
 
     // skip some contacts ?
     $skipOnHold = isset($form->skipOnHold) ? $form->skipOnHold : FALSE;
     $skipDeceased = isset($form->skipDeceased) ? $form->skipDeceased : TRUE;
 
-    $contributionIDs = $form->getVar('_contributionIds');
-    if ($form->_includesSoftCredits) {
-      $contributionIDs = $form->getVar('_contributionContactIds');
-    }
-
-    foreach ($contributionIDs as $item => $contributionId) {
-      // get contact information
-      if ($form->_includesSoftCredits) {
-        list($contactId) = explode('-', $item);
-        $contactId = (int) $contactId;
-      } else {
-        $contactId = civicrm_api("Contribution", "getvalue", array('version' => '3', 'id' => $contributionId, 'return' => 'contact_id'));
-      }
-      $params = array('contact_id' => $contactId);
-
-      list($contact) = CRM_Utils_Token::getTokenDetails($params,
-        $returnProperties,
-        $skipOnHold,
-        $skipDeceased,
-        NULL,
-        $messageToken,
-        'CRM_Contribution_Form_Task_PDFLetterCommon'
-      );
-      if (civicrm_error($contact)) {
-        $notSent[] = $contributionId;
-        continue;
+    list($notSent, $contributions, $contacts) = self::buildContributionArray($groupBy, $form, $returnProperties, $skipOnHold, $skipDeceased, $messageToken, $task, $separator);
+    $html = array();
+    foreach ($contributions as $contributionId => $contribution) {
+      $contact = &$contacts[$contribution['contact_id']];
+      $grouped = $groupByID = 0;
+      if($groupBy) {
+        $groupByID = empty($contribution[$groupBy]) ? 0 : $contribution[$groupBy];
+        $contribution = $contact['combined'][$groupBy][$groupByID];
+        $grouped = TRUE;
       }
 
-      // get contribution information
-      $params = array('contribution_id' => $contributionId);
-      $contribution = CRM_Utils_Token::getContributionTokenDetails($params,
-        $returnProperties,
-        NULL,
-        $messageToken,
-        'CRM_Contribution_Form_Task_PDFLetterCommon'
-      );
-      if (civicrm_error($contribution)) {
-        $notSent[] = $contributionId;
-        continue;
+      self::assignCombinedContributionValues($contact, $contributions, $groupBy, $groupByID);
+
+      if(empty($groupBy) || empty($contact['is_sent'][$groupBy][$groupByID])) {
+        $html[$contributionId] = str_replace($separator, $realSeparator, self::resolveTokens($html_message, $contact, $contribution, $messageToken, $html, $categories, $grouped, $separator));
+        $contact['is_sent'][$groupBy][$groupByID] = TRUE;
+        if(!empty($formValues['email_options'])) {
+          if(self::emailLetter($contact, $html[$contributionId], $isPDF, $formValues, $emailParams)) {
+            $emailed ++;
+            if(!stristr($formValues['email_options'], 'both')) {
+              unset($html[$contributionId]);
+            }
+          }
+        }
       }
-
-      $tokenHtml = CRM_Utils_Token::replaceContactTokens($html_message, $contact[$contactId], TRUE, $messageToken);
-      $tokenHtml = CRM_Utils_Token::replaceContributionTokens($tokenHtml, $contribution[$contributionId], TRUE, $messageToken);
-      $tokenHtml = CRM_Utils_Token::replaceHookTokens($tokenHtml, $contact[$contactId], $categories, TRUE);
-
-      if (defined('CIVICRM_MAIL_SMARTY') && CIVICRM_MAIL_SMARTY) {
-        $smarty = CRM_Core_Smarty::singleton();
-        // also add the tokens to the template
-        $smarty->assign_by_ref('contact', $contact);
-        $tokenHtml = $smarty->fetch("string:$tokenHtml");
-      }
-
-      $html[] = $tokenHtml;
 
       // update dates (do it for each contribution including grouped recurring contribution)
+      //@todo - the 2 calls below bypass all hooks. Using the api would possibly be slower than one call but not than 2
       if ($receipt_update) {
         $result = CRM_Core_DAO::setFieldValue('CRM_Contribute_DAO_Contribution', $contributionId, 'receipt_date', $nowDate);
-        // We can't use CRM_Core_Error::fatal here because the api error elevates the exception level. FIXME. dgg
         if ($result) {
           $receipts++;
-      }
+        }
       }
       if ($thankyou_update) {
         $result = CRM_Core_DAO::setFieldValue('CRM_Contribute_DAO_Contribution', $contributionId, 'thankyou_date', $nowDate);
-        // We can't use CRM_Core_Error::fatal here because the api error elevates the exception level. FIXME. dgg
         if ($result) {
           $thanks++;
+        }
       }
     }
-    }
-
+    //createActivities requires both $form->_contactIds and $contacts -
+    //@todo - figure out why
+    $form->_contactIds = array_keys($contacts);
     self::createActivities($form, $html_message, $form->_contactIds);
-
-    CRM_Utils_PDF_Utils::html2pdf($html, "CiviLetter.pdf", FALSE, $formValues);
+    if(!empty($html)) {
+      CRM_Utils_PDF_Utils::html2pdf($html, "CiviLetter.pdf", FALSE, $formValues);
+    }
 
     $form->postProcessHook();
 
+    if ($emailed) {
+      $updateStatus = ts('Receipts have been emailed to %1 contributions.', array(1 => $emailed));
+    }
     if ($receipts) {
       $updateStatus = ts('Receipt date has been updated for %1 contributions.', array(1 => $receipts));
     }
@@ -116,9 +112,194 @@ class CRM_Contribute_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDF
     if ($updateStatus) {
       CRM_Core_Session::setStatus($updateStatus);
     }
-
-    CRM_Utils_System::civiExit(1);
+    if(!empty($html)) {
+      // ie. we have only sent emails - lets no show a white screen
+      CRM_Utils_System::civiExit(1);
+    }
   }
-  //end of function
+
+/**
+ * @param contact
+ * @param smarty
+ * @param html
+ *
+
+ /**
+  *
+  * @param unknown $html_message
+  * @param array $contact
+  * @param array $contribution
+  * @param array $messageToken
+  * @param string $html
+  * @param array $categories
+  * @param bool $grouped Does this letter represent more than one contribution
+  * @param string $separator What is the preferred letter separator
+  * @return string
+  */
+ private static function resolveTokens($html_message, $contact, $contribution, $messageToken, $html, $categories, $grouped, $separator) {
+   $tokenHtml = CRM_Utils_Token::replaceContactTokens($html_message, $contact, TRUE, $messageToken);
+   if($grouped) {
+     $tokenHtml = CRM_Utils_Token::replaceMultipleContributionTokens($separator, $tokenHtml, $contribution, TRUE, $messageToken);
+   }
+   else {
+     // no change to normal behaviour to avoid risk of breakage
+     $tokenHtml = CRM_Utils_Token::replaceContributionTokens($tokenHtml, $contribution, TRUE, $messageToken);
+   }
+   $tokenHtml = CRM_Utils_Token::replaceHookTokens($tokenHtml, $contact, $categories, TRUE);
+   if (defined('CIVICRM_MAIL_SMARTY') && CIVICRM_MAIL_SMARTY) {
+      $smarty = CRM_Core_Smarty::singleton();
+      // also add the tokens to the template
+      $smarty->assign_by_ref('contact', $contact);
+      $tokenHtml = $smarty->fetch("string:$tokenHtml");
+    }
+    return $tokenHtml;
+  }
+
+  /**
+   * Generate the contribution array from the form, we fill in the contact details and determine any aggregation
+   * around contact_id of contribution_recur_id
+   *
+   * @param unknown $groupBy
+   * @param unknown $form
+   * @param unknown $returnProperties
+   * @param unknown $skipOnHold
+   * @param unknown $skipDeceased
+   * @param unknown $messageToken
+   * @param unknown $task
+   * @return multitype:Ambigous <boolean, multitype:> multitype:unknown  multitype:
+   */
+  static function buildContributionArray($groupBy, $form, $returnProperties, $skipOnHold, $skipDeceased, $messageToken, $task, $separator) {
+    $contributions = $contacts = $notSent = array();
+    $contributionIDs = $form->getVar('_contributionIds');
+    if ($form->_includesSoftCredits) {
+      //@todo - comment on what is stored there
+      $contributionIDs = $form->getVar('_contributionContactIds');
+    }
+    foreach ($contributionIDs as $item => $contributionId) {
+      try {
+        // get contribution information
+        $params = array('contribution_id' => $contributionId);
+        $contribution = CRM_Utils_Token::getContributionTokenDetails(array('contribution_id' => $contributionId),
+          $returnProperties,
+          NULL,
+          $messageToken,
+          $task
+        );
+        $contribution = $contributions[$contributionId] = $contribution[$contributionId];
+        if ($form->_includesSoftCredits) {
+          //@todo find out why this happens & add comments
+          list($contactID) = explode('-', $item);
+          $contactID = (int) $contactId;
+         } else {
+           $contactID = $contribution['contact_id'];
+        }
+        if(!isset($contacts[$contactID])) {
+          list($contact) = CRM_Utils_Token::getTokenDetails(array('contact_id' => $contactID),
+            $returnProperties,
+            $skipOnHold,
+            $skipDeceased,
+            NULL,
+            $messageToken,
+            $task
+          );
+          $contacts[$contactID] = $contact[$contactID];
+          $contacts[$contactID]['contact_aggregate'] = 0;
+          $contacts[$contactID]['combined'] = $contacts[$contactID]['contribution_ids'] = array();
+        }
+
+        $contacts[$contactID]['contact_aggregate'] += $contribution['total_amount'];
+        $groupByID = empty($contribution[$groupBy]) ? 0 : $contribution[$groupBy];
+
+        $contacts[$contactID]['contribution_ids'][$groupBy][$groupByID][$contributionId] = TRUE;
+        if(!isset($contacts[$contactID]['combined'][$groupBy]) || isset($contacts[$contactID]['combined'][$groupByID])) {
+          $contacts[$contactID]['combined'][$groupBy][$groupByID] = $contribution;
+          $contacts[$contactID]['aggregates'][$groupBy][$groupByID] = $contribution['total_amount'];
+        }
+        else {
+          $contacts[$contactID]['combined'][$groupBy][$groupByID] = self::combineContributions($contacts[$contactID]['combined'][$groupBy][$groupByID], $contribution, $separator);
+          $contacts[$contactID]['aggregates'][$groupBy][$groupByID] += $contribution['total_amount'];
+        }
+      }
+      catch(Exception $e) {
+        $notSent[] = $contributionId;
+      }
+    }
+    return array($notSent, $contributions, $contacts);
+  }
+
+  /**
+   * We combine the contributions by adding the contribution to each field with the separator in
+   * between the existing value and the new one. We put the separator there even if empty so it is clear what the
+   * value for previous contributions was
+   * @param unknown $existing
+   * @param unknown $contribution
+   * @param unknown $separator
+   */
+  static function combineContributions($existing, $contribution, $separator) {
+    foreach ($contribution as $field => $value) {
+      if(!isset($existing[$field])) {
+        $existing[$field] = '';
+      }
+      $existing[$field] .= $separator . $value;
+    }
+    return $existing;
+  }
+
+  /**
+   * We are going to retrieve the combined contribution and if smarty mail is enabled we
+   * will also assign an array of contributions for this contact to the smarty template
+   * @param array $contact
+   * @param array $contributions
+   */
+  static function assignCombinedContributionValues($contact, $contributions, $groupBy, $groupByID) {
+    if (!defined('CIVICRM_MAIL_SMARTY') || !CIVICRM_MAIL_SMARTY) {
+      return;
+    }
+    CRM_Core_Smarty::singleton()->assign('contact_aggregate', $contact['contact_aggregate']);
+    CRM_Core_Smarty::singleton()->assign('contributions', array_intersect_key($contributions, $contact['contribution_ids'][$groupBy][$groupByID]));
+    CRM_Core_Smarty::singleton()->assign('contribution_aggregate', $contact['aggregates'][$groupBy][$groupByID]);
+
+  }
+
+  /**
+   * Send pdf by email
+   * @param array $contact
+   * @param string $html
+   */
+  static function emailLetter($contact, $html, $is_pdf, $format = array(), $params = array()) {
+    try {
+      if(empty($contact['email'])) {
+        return FALSE;
+      }
+      $mustBeEmpty = array('do_not_email', 'is_deceased', 'on_hold');
+      foreach ($mustBeEmpty as $emptyField) {
+        if(!empty($contact[$emptyField])) {
+          return FALSE;
+        }
+      }
+
+      $defaults = array(
+        'toName' => $contact['display_name'],
+        'toEmail' => $contact['email'],
+        'subject' => ts('Thank you for your contribution/s'),
+        'text' => '',
+        'html' => $html,
+      );
+      if(empty($params['from'])) {
+        $emails = CRM_Core_BAO_Email::getFromEmail();
+        $emails = array_keys($emails);
+        $defaults['from'] = array_pop($emails);
+      }
+      if($is_pdf) {
+        $defaults['html'] = ts('Please see attached');
+        $defaults['attachments'] = array(CRM_Utils_Mail::appendPDF('ThankYou.pdf', $html, $format));
+      }
+      $params = array_merge($defaults);
+      return CRM_Utils_Mail::send($params);
+    }
+    catch (CRM_Core_Exception $e) {
+      return FALSE;
+    }
+  }
 }
 

--- a/CRM/Core/BAO/MessageTemplate.php
+++ b/CRM/Core/BAO/MessageTemplate.php
@@ -493,29 +493,10 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate {
         $params['PDFFilename'] &&
         $params['html']
       ) {
-        $pdf_filename = $config->templateCompileDir . CRM_Utils_File::makeFileName($params['PDFFilename']);
-
-        //FIXME : CRM-7894
-        //xmlns attribute is required in XHTML but it is invalid in HTML,
-        //Also the namespace "xmlns=http://www.w3.org/1999/xhtml" is default,
-        //and will be added to the <html> tag even if you do not include it.
-        $html = preg_replace('/(<html)(.+?xmlns=["\'].[^\s]+["\'])(.+)?(>)/', '\1\3\4', $params['html']);
-
-        file_put_contents($pdf_filename, CRM_Utils_PDF_Utils::html2pdf($html,
-            $params['PDFFilename'],
-            TRUE,
-            $format
-          )
-        );
-
         if (empty($params['attachments'])) {
           $params['attachments'] = array();
         }
-        $params['attachments'][] = array(
-          'fullPath' => $pdf_filename,
-          'mime_type' => 'application/pdf',
-          'cleanName' => $params['PDFFilename'],
-        );
+        $params['attachments'][] = CRM_Utils_Mail::appendPDF($params['PDFFilename'], $params['html'], $format);
       }
 
       $sent = CRM_Utils_Mail::send($params);

--- a/CRM/Utils/Mail.php
+++ b/CRM/Utils/Mail.php
@@ -166,7 +166,7 @@ class CRM_Utils_Mail {
     // Mail_smtp and Mail_sendmail mailers require Bcc anc Cc emails
     // be included in both $to and $headers['Cc', 'Bcc']
     if (get_class($mailer) != "Mail_mail") {
-        //get emails from headers, since these are 
+        //get emails from headers, since these are
         //combination of name and email addresses.
         if (!empty($headers['Cc'])) {
             $to[] = CRM_Utils_Array::value( 'Cc', $headers );
@@ -363,6 +363,35 @@ class CRM_Utils_Mail {
     }
 
     return $name;
+  }
+
+  /**
+   *
+   * @param string $fileName
+   * @param string $html
+   * @param string $format
+   *
+   * @return array $attachments
+   */
+  static function appendPDF($fileName, $html, $format = NULL) {
+    $pdf_filename = CRM_Core_Config::singleton()->templateCompileDir . CRM_Utils_File::makeFileName($fileName);
+
+    //FIXME : CRM-7894
+    //xmlns attribute is required in XHTML but it is invalid in HTML,
+    //Also the namespace "xmlns=http://www.w3.org/1999/xhtml" is default,
+    //and will be added to the <html> tag even if you do not include it.
+    $html = preg_replace('/(<html)(.+?xmlns=["\'].[^\s]+["\'])(.+)?(>)/', '\1\3\4', $html);
+
+    file_put_contents($pdf_filename, CRM_Utils_PDF_Utils::html2pdf($html,
+      $fileName,
+      TRUE,
+      $format)
+    );
+    return array(
+      'fullPath' => $pdf_filename,
+      'mime_type' => 'application/pdf',
+      'cleanName' => $fileName,
+    );
   }
 }
 

--- a/templates/CRM/Contribute/Form/Task/PDFLetter.tpl
+++ b/templates/CRM/Contribute/Form/Task/PDFLetter.tpl
@@ -37,7 +37,18 @@
     <table class="form-layout-compressed">
       <tr><td class="label-left">{$form.thankyou_update.html} {$form.thankyou_update.label}</td><td></td></tr>
       <tr><td class="label-left">{$form.receipt_update.html} {$form.receipt_update.label}</td><td></td></tr>
-      <!--tr><td class="label-left">{$form.is_group_by.label}</td><td>{$form.is_group_by.html}</td></tr-->
+      <tr>
+        <td class="label-left">{$form.group_by.label}</td>
+        <td>{$form.group_by.html}</td>
+      </tr>
+      <tr>
+        <td class="label-left">{$form.group_by_separator.label}</td>
+        <td>{$form.group_by_separator.html}</td>
+      </tr>
+      <tr>
+        <td class="label-left">{$form.email_options.label}</td>
+        <td>{$form.email_options.html}</td>
+      </tr>
     </table>
   </div><!-- /.crm-accordion-body -->
 </div><!-- /.crm-accordion-wrapper -->


### PR DESCRIPTION
contribution search
CRM-14367, preliminary tidy up + re-enable options

---
- CRM-14367: Add ability to group contribution letters by contact (& possibly recurring contribution)
  http://issues.civicrm.org/jira/browse/CRM-14367

CRM-14367 - early return for no known token

---
- CRM-14367: Add ability to group contribution letters by contact (& possibly recurring contribution)
  http://issues.civicrm.org/jira/browse/CRM-14367

fix static function, comment fixes

CRM-14367 add options to send thank you letter - grouping, separator, email as option

---
- CRM-14367: Add ability to group contribution letters by contact (& possibly recurring contribution)
  http://issues.civicrm.org/jira/browse/CRM-14367

CRM-14367 - don't white screen when no pdfs

---
- CRM-14367: Add ability to group contribution letters by contact (& possibly recurring contribution)
  http://issues.civicrm.org/jira/browse/CRM-14367

CRM-14367 - always apply aggregates

---
- CRM-14367: Add ability to group contribution letters by contact (& possibly recurring contribution)
  http://issues.civicrm.org/jira/browse/CRM-14367

assign aggregrates for grouped & non-grouped as no real performance hit & more predictable

send mails as pdf instead

CRM-14367 - add pdf options

---
- CRM-14367: Add ability to group contribution letters by contact (& possibly recurring contribution)
  http://issues.civicrm.org/jira/browse/CRM-14367

Conflicts:
    CRM/Contribute/Form/Task/PDFLetter.php
    CRM/Contribute/Form/Task/PDFLetterCommon.php
    CRM/Utils/Token.php
    templates/CRM/Contribute/Form/Task/PDFLetter.tpl
