### PR TITLE
CRM-14278 : fix, removed extra check for radio/checkbox related 0 amount checking, instead applied the condition for zero amount checking directly on the final total price value.

### DIFF
--- a/templates/CRM/Event/Form/Registration/Register.tpl
+++ b/templates/CRM/Event/Form/Registration/Register.tpl
@@ -214,8 +214,7 @@
         flag = 0;
       }
 
-      if (((cj('#priceset input:checked').attr('data-amount') == 0) ||
-        (cj('#pricevalue').text() == symbol + " 0.00" )) && flag) {
+      if ((cj('#pricevalue').text() == symbol + " 0.00") && flag) {
         cj(".payment_options-group").hide();
         cj("div.payment_processor-section").hide();
         cj("div#payment_information").hide();


### PR DESCRIPTION
CRM-14278 : fix, removed extra check for radio/checkbox related 0 amount checking, instead applied the condition for zero amount checking directly on the final total price value.
