### PR TITLE
CRM-14379

### DIFF
--- a/CRM/Price/Form/Option.php
+++ b/CRM/Price/Form/Option.php
@@ -82,6 +82,9 @@ class CRM_Price_Form_Option extends CRM_Core_Form {
    * @access public
    */
   function setDefaultValues() {
+    if ($this->_action == CRM_Core_Action::DELETE) {
+      return;
+    }
     $defaults = array();
 
     if (isset($this->_oid)) {


### PR DESCRIPTION
done a different fix then the patch provided on the issue : http://issues.civicrm.org/jira/secure/attachment/23271/CRM_Price_Form_Option.patch .

The fix : we don't require the code execution of setDefaultValues while  DELETE action is performed, hence returned the control of execution from setDefaultValues while DELETE action.
