### PR TITLE
CRM-13946: Backport PR #2185: set default database connection to UTF-8

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -196,6 +196,7 @@ class CRM_Core_DAO extends DB_DataObject {
    */
   function initialize() {
     $this->_connect();
+    $this->query("SET NAMES utf8");
   }
 
   /**


### PR DESCRIPTION
https://issues.civicrm.org/jira/browse/CRM-13946
PR #2185
