### PR TITLE
CRM-14413 - Dedupe hooks to make custom rules manageable thru UI + a flip hook

### DIFF
--- a/CRM/Contact/Form/DedupeRules.php
+++ b/CRM/Contact/Form/DedupeRules.php
@@ -288,6 +288,7 @@ UPDATE civicrm_dedupe_rule_group
 
     // also create an index for this dedupe rule
     // CRM-3837
+    CRM_Utils_Hook::dupeQuery($ruleDao, 'dedupeIndexes', $tables);
     CRM_Core_BAO_SchemaHandler::createIndexes($tables, 'dedupe_index', $substrLenghts);
 
     //need to clear cache of deduped contacts

--- a/CRM/Dedupe/BAO/RuleGroup.php
+++ b/CRM/Dedupe/BAO/RuleGroup.php
@@ -108,6 +108,7 @@ class CRM_Dedupe_BAO_RuleGroup extends CRM_Dedupe_DAO_RuleGroup {
         }
       }
     }
+    CRM_Utils_Hook::dupeQuery(CRM_Core_DAO::$_nullObject, 'supportedFields', $fields);
     return $fields[$requestedType];
   }
 

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -622,8 +622,9 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
         CRM_Utils_Hook::merge('flip', $dupes, $dupes['dstID'], $dupes['srcID']);
         $mainId = $dupes['dstID'];
         $otherId = $dupes['srcID'];
-        // make sure that $mainId is the one with lower id number
-        if ($autoFlip && ($mainId > $otherId)) {
+        $isAutoFlip = CRM_Utils_Array::value('auto_flip', $dupes, $autoFlip);
+        // if we can, make sure that $mainId is the one with lower id number
+        if ($isAutoFlip && ($mainId > $otherId)) {
           $mainId = $dupes['srcID'];
           $otherId = $dupes['dstID'];
         }

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -619,6 +619,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
 
     while (!empty($dupePairs)) {
       foreach ($dupePairs as $dupes) {
+        CRM_Utils_Hook::merge('flip', $dupes, $dupes['dstID'], $dupes['srcID']);
         $mainId = $dupes['dstID'];
         $otherId = $dupes['srcID'];
         // make sure that $mainId is the one with lower id number


### PR DESCRIPTION
The patch adds new calls to existing dedupe hooks, which helps make custom dedupe rules manageable through UI, and also be able to combine with other rule fields using threshold mechanism. The hooks are:

CRM_Utils_Hook::dupeQuery($ruleDao, 'dedupeIndexes', $tables);
// allows one to suppress / decide indexing for new custom rules.

CRM_Utils_Hook::dupeQuery(CRM_Core_DAO::$_nullObject, 'supportedFields', $fields);
// allows one to make custom rules populate in the list of core rule fields.

CRM_Utils_Hook::merge('flip', $dupes, $dupes['dstID'], $dupes['srcID']);
// allows one to implement complex biasing decisions on which contact to keep or merge into.

Can update docs when accepted.
