### PR TITLE
CRM-14327 : Tab page refresh

### DIFF
--- a/js/crm.ajax.js
+++ b/js/crm.ajax.js
@@ -365,10 +365,6 @@
             $el.crmSnippet('option', 'block') && $el.unblock();
             $el.trigger('crmFormSuccess', response);
 
-            // refresh the active tab to show effect for saved data
-            var $activeTab = $("#mainTabContainer .ui-tabs-active");
-            CRM.tabHeader.resetTab($activeTab);
-
             // Reset form for e.g. "save and new"
             if (response.userContext && settings.refreshAction && $.inArray(response.buttonName, settings.refreshAction) >= 0) {
               $el.crmSnippet('option', 'url', response.userContext).crmSnippet('refresh');

--- a/js/crm.ajax.js
+++ b/js/crm.ajax.js
@@ -364,6 +364,11 @@
           if (response.status !== 'form_error') {
             $el.crmSnippet('option', 'block') && $el.unblock();
             $el.trigger('crmFormSuccess', response);
+
+            // refresh the active tab to show effect for saved data
+            var $activeTab = $("#mainTabContainer .ui-tabs-active");
+            CRM.tabHeader.resetTab($activeTab);
+
             // Reset form for e.g. "save and new"
             if (response.userContext && settings.refreshAction && $.inArray(response.buttonName, settings.refreshAction) >= 0) {
               $el.crmSnippet('option', 'url', response.userContext).crmSnippet('refresh');

--- a/templates/CRM/common/TabHeader.js
+++ b/templates/CRM/common/TabHeader.js
@@ -63,6 +63,14 @@ CRM.$(function($) {
       $.each(data.updateTabs, CRM.tabHeader.resetTab);
     }
   });
+
+  $(document).on('crmFormSuccess', function(e) {
+    // refresh the active tab to show effect for saved data
+    var $activeTab = $("#mainTabContainer .ui-tabs-active");
+    if (typeof($activeTab) != 'undefined') {
+      CRM.tabHeader.resetTab($activeTab);
+    }
+  });
 });
 (function($) {
   // Utility functions


### PR DESCRIPTION
possible fix for point 1 of #comment-58811 (this root cause of issue is tab page doesn't get refreshed after multiple 'save and new' of any entity tab form)

Following tested for Contribution and Multi custom data tabs:
- A tab consists of record listing and a button to add new record.
- click on add new record and fill details and click on 'save and new' [the record gets saved and record listing gets refreshed and a fresh form gets displayed]
- click on 'save' or 'save and new' button the form details gets saved but the record listing doesn't gets updated. Later when user closes the dialog upon form submission through 'save and new' click, he finds old records listed and not the new one.

The fix:
added tab reset code on crmFormSuccess event trigger. There was one more suitable point at which that would have taken place, but due to a condition <code> $.isPlainObject(data.updateTabs)</code> it won't get executed. Upon looking more into the use of 'updateTabs', it occurred to me that its a right thing for this code to not get executed(i.e not fulfilling above condition).
