### PR TITLE
CRM_Core_DAO::createTestObject - Handle dates and timestamps differently

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1361,12 +1361,18 @@ SELECT contact_id
               break;
 
             case CRM_Utils_Type::T_DATE:
-            case CRM_Utils_Type::T_TIMESTAMP:
-            case CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME:
               $object->$dbName = '19700101';
               if($dbName == 'end_date') {
                 // put this in the future
                 $object->$dbName = '20200101';
+              }
+              break;
+            case CRM_Utils_Type::T_TIMESTAMP:
+            case CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME:
+              $object->$dbName = '19700101010101';
+              if($dbName == 'end_date') {
+                // put this in the future
+                $object->$dbName = '20200101010101';
               }
               break;
 


### PR DESCRIPTION
With the old code, api_v3_ACLPermissionTest (when called as part of
api_v3_AllTests) passes on my local MAMP install but fails on Debian and
Ubuntu.
