### PR TITLE
api_v3_GroupOrganizationTest - Fix error

### DIFF
--- a/tests/phpunit/api/v3/GroupOrganizationTest.php
+++ b/tests/phpunit/api/v3/GroupOrganizationTest.php
@@ -99,17 +99,18 @@ class api_v3_GroupOrganizationTest extends CiviUnitTestCase {
    * Test civicrm_group_organization_get with group_id.
    */
   public function testGroupOrganizationGetWithGroupId() {
-
-    $params = array(
+    $createParams = array(
       'organization_id' => $this->_orgID,
-      'group_id' => $this->_groupID,      'sequential' => 1,
+      'group_id' => $this->_groupID,
     );
-    $result = $this->callAPISuccess('group_organization', 'create', $params);
+    $createResult = $this->callAPISuccess('group_organization', 'create', $createParams);
 
-    $paramsGet = array('organization_id' => $result['values'][0]['organization_id']);
-
-    $result = $this->callAPISuccess('group_organization', 'get', $params);
-    $this->assertAPISuccess($result);
+    $getParams = array(
+      'group_id' => $this->_groupID,
+      'sequential' => 1,
+    );
+    $getResult = $this->callAPISuccess('group_organization', 'get', $getParams);
+    $this->assertEquals($createResult['values'], $getResult['values'][0]);
   }
 
   /**


### PR DESCRIPTION
Was producing error because expression
($result['values'][0]['organization_id']) was invalid.  The test content 
didn't meet the description/name and seemed weird.
