### PR TITLE
CRM-14421 : financial_type_id of contribution was not getting passed, so...

### DIFF
--- a/CRM/Core/BAO/FinancialTrxn.php
+++ b/CRM/Core/BAO/FinancialTrxn.php
@@ -365,14 +365,22 @@ WHERE ceft.entity_id = %1";
     if (!$amount) {
       return FALSE;
     }
-    $financialAccount = CRM_Contribute_PseudoConstant::financialAccountType($params['financial_type_id'], $expenseTypeId);
+    $contributionId = isset($params['contribution']->id) ? $params['contribution']->id : $params['contribution_id'];
+    if (empty($params['financial_type_id'])) {
+      $financialTypeId = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $contributionId, 'financial_type_id', 'id');
+    }
+    else {
+      $financialTypeId = $params['financial_type_id'];
+    }
+    $financialAccount = CRM_Contribute_PseudoConstant::financialAccountType($financialTypeId, $expenseTypeId);
+
     $params['trxnParams']['from_financial_account_id'] = $params['to_financial_account_id'];
     $params['trxnParams']['to_financial_account_id'] = $financialAccount;
     $params['trxnParams']['total_amount'] = $amount;
     $params['trxnParams']['fee_amount'] =
       $params['trxnParams']['net_amount'] = 0;
     $params['trxnParams']['status_id'] = CRM_Core_OptionGroup::getValue('contribution_status','Completed','name');
-    $params['trxnParams']['contribution_id'] = isset($params['contribution']->id) ? $params['contribution']->id : $params['contribution_id'];
+    $params['trxnParams']['contribution_id'] = $contributionId;
     $trxn = self::create($params['trxnParams']);
     if (empty($params['entity_id'])) {
       $financialTrxnID = CRM_Core_BAO_FinancialTrxn::getFinancialTrxnId($params['trxnParams']['contribution_id'], 'DESC');


### PR DESCRIPTION
financial_type_id of contribution was not getting passed, so a notice and a fatal error, this type id is necessary for recording financial_trxn record further in the process for recording fees.
