### PR TITLE
CRM-14370 - Expose generic CRUD API for Doctrine entities (as APIv4)

### DIFF
--- a/Civi/API/GetSetMethodNormalizer.php
+++ b/Civi/API/GetSetMethodNormalizer.php
@@ -1,0 +1,247 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Civi\API;
+
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Exception\RuntimeException;
+use Symfony\Component\Serializer\Normalizer\SerializerAwareNormalizer;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+
+/**
+ * Converts between objects with getter and setter methods and arrays.
+ *
+ * The normalization process looks at all public methods and calls the ones
+ * which have a name starting with get and take no parameters. The result is a
+ * map from property names (method name stripped of the get prefix and converted
+ * to lower case) to property values. Property values are normalized through the
+ * serializer.
+ *
+ * The denormalization first looks at the constructor of the given class to see
+ * if any of the parameters have the same name as one of the properties. The
+ * constructor is then called with all parameters or an exception is thrown if
+ * any required parameters were not present as properties. Then the denormalizer
+ * walks through the given map of property names to property values to see if a
+ * setter method exists for any of the properties. If a setter exists it is
+ * called with the property value. No automatic denormalization of the value
+ * takes place.
+ *
+ * NOTE: This is a forked version which adds support for updating $context['target']
+ * instead of instantiating new objects.
+ *
+ * @author Nils Adermann <naderman@naderman.de>
+ */
+class GetSetMethodNormalizer extends SerializerAwareNormalizer implements NormalizerInterface, DenormalizerInterface
+{
+  protected $callbacks = array();
+  protected $ignoredAttributes = array();
+  protected $camelizedAttributes = array();
+
+  /**
+   * Set normalization callbacks
+   *
+   * @param array $callbacks help normalize the result
+   *
+   * @throws InvalidArgumentException if a non-callable callback is set
+   */
+  public function setCallbacks(array $callbacks)
+  {
+    foreach ($callbacks as $attribute => $callback) {
+      if (!is_callable($callback)) {
+        throw new InvalidArgumentException(sprintf('The given callback for attribute "%s" is not callable.', $attribute));
+      }
+    }
+    $this->callbacks = $callbacks;
+  }
+
+  /**
+   * Set ignored attributes for normalization
+   *
+   * @param array $ignoredAttributes
+   */
+  public function setIgnoredAttributes(array $ignoredAttributes)
+  {
+    $this->ignoredAttributes = $ignoredAttributes;
+  }
+
+  /**
+   * Set attributes to be camelized on denormalize
+   *
+   * @param array $camelizedAttributes
+   */
+  public function setCamelizedAttributes(array $camelizedAttributes)
+  {
+    $this->camelizedAttributes = $camelizedAttributes;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function normalize($object, $format = NULL, array $context = array())
+  {
+    $reflectionObject = new \ReflectionObject($object);
+    $reflectionMethods = $reflectionObject->getMethods(\ReflectionMethod::IS_PUBLIC);
+
+    $attributes = array();
+    foreach ($reflectionMethods as $method) {
+      if ($this->isGetMethod($method)) {
+        $attributeName = lcfirst(substr($method->name, 3));
+
+        if (in_array($attributeName, $this->ignoredAttributes)) {
+          continue;
+        }
+
+        $attributeValue = $method->invoke($object);
+        if (array_key_exists($attributeName, $this->callbacks)) {
+          $attributeValue = call_user_func($this->callbacks[$attributeName], $attributeValue);
+        }
+        if (NULL !== $attributeValue && !is_scalar($attributeValue)) {
+          $attributeValue = $this->serializer->normalize($attributeValue, $format);
+        }
+
+        $attributes[$attributeName] = $attributeValue;
+      }
+    }
+
+    return $attributes;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function denormalize($data, $class, $format = NULL, array $context = array())
+  {
+    list($data, $object) = $this->createInstance($class, $data, $context);
+
+    foreach ($data as $attribute => $value) {
+      $setter = 'set'.$this->formatAttribute($attribute);
+
+      if (method_exists($object, $setter)) {
+        $object->$setter($value);
+      }
+    }
+
+    return $object;
+  }
+
+  public function createInstance($class, $data, $context = array()) {
+    if (isset($context['target'])) {
+      return array($data, $context['target']);
+    }
+
+    $reflectionClass = new \ReflectionClass($class);
+    $constructor = $reflectionClass->getConstructor();
+
+    if ($constructor) {
+      $constructorParameters = $constructor->getParameters();
+
+      $params = array();
+      foreach ($constructorParameters as $constructorParameter) {
+        $paramName = lcfirst($this->formatAttribute($constructorParameter->name));
+
+        if (isset($data[$paramName])) {
+          $params[] = $data[$paramName];
+          // don't run set for a parameter passed to the constructor
+          unset($data[$paramName]);
+        }
+        elseif (!$constructorParameter->isOptional()) {
+          throw new RuntimeException(
+            'Cannot create an instance of ' . $class .
+              ' from serialized data because its constructor requires ' .
+              'parameter "' . $constructorParameter->name .
+              '" to be present.');
+        }
+      }
+
+      $object = $reflectionClass->newInstanceArgs($params);
+      return array($data, $object);
+    }
+    else {
+      $object = new $class;
+      return array($data, $object);
+    }
+  }
+
+  /**
+   * Format attribute name to access parameters or methods
+   * As option, if attribute name is found on camelizedAttributes array
+   * returns attribute name in camelcase format
+   *
+   * @param string $attributeName
+   * @return string
+   */
+  protected function formatAttribute($attributeName)
+  {
+    if (in_array($attributeName, $this->camelizedAttributes)) {
+      return preg_replace_callback(
+        '/(^|_|\.)+(.)/', function ($match) {
+          return ('.' === $match[1] ? '_' : '').strtoupper($match[2]);
+        }, $attributeName
+      );
+    }
+
+    return $attributeName;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function supportsNormalization($data, $format = NULL)
+  {
+    return is_object($data) && $this->supports(get_class($data));
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function supportsDenormalization($data, $type, $format = NULL)
+  {
+    return $this->supports($type);
+  }
+
+  /**
+   * Checks if the given class has any get{Property} method.
+   *
+   * @param string $class
+   *
+   * @return Boolean
+   */
+  private function supports($class)
+  {
+    $class = new \ReflectionClass($class);
+    $methods = $class->getMethods(\ReflectionMethod::IS_PUBLIC);
+    foreach ($methods as $method) {
+      if ($this->isGetMethod($method)) {
+        return TRUE;
+      }
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Checks if a method's name is get.* and can be called without parameters.
+   *
+   * @param \ReflectionMethod $method the method to check
+   *
+   * @return Boolean whether the method is a getter.
+   */
+  private function isGetMethod(\ReflectionMethod $method)
+  {
+    return (
+      0 === strpos($method->name, 'get') &&
+        3 < strlen($method->name) &&
+        0 === $method->getNumberOfRequiredParameters()
+    );
+  }
+}

--- a/Civi/API/Provider/DoctrineCrudProvider.php
+++ b/Civi/API/Provider/DoctrineCrudProvider.php
@@ -1,0 +1,223 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.4                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2013                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*/
+
+namespace Civi\API\Provider;
+use Civi\API\Events;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * This class manages the loading of API's using strict file+function naming
+ * conventions.
+ */
+class DoctrineCrudProvider implements EventSubscriberInterface, ProviderInterface {
+  public static function getSubscribedEvents() {
+    return array(
+      Events::RESOLVE => array(
+        array('onApiResolve', Events::W_MIDDLE),
+      ),
+      Events::RESPOND => array(
+        array('onApiRespond', Events::W_MIDDLE),
+      ),
+    );
+  }
+
+  /**
+   * @var \Civi\API\Registry
+   */
+  private $apiRegistry;
+
+  /**
+   * @var array<string>
+   */
+  private $supportedActions;
+
+  /**
+   * @var \Symfony\Component\Serializer\Serializer
+   */
+  private $serializer;
+
+  /**
+   * @param \Civi\API\Registry $apiRegistry
+   */
+  public function __construct($apiRegistry) {
+    $this->apiRegistry = $apiRegistry;
+    $this->supportedActions = array('create', 'get', 'delete');
+    $this->serializer = new \Symfony\Component\Serializer\Serializer(
+      array(new \Civi\API\GetSetMethodNormalizer()),
+      array(new \Symfony\Component\Serializer\Encoder\JsonEncoder())
+    );
+  }
+
+  public function onApiResolve(\Civi\API\Event\ResolveEvent $event) {
+    $apiRequest = $event->getApiRequest();
+    if ($apiRequest['version'] != 4) {
+      return;
+    }
+
+    $entityClass = $this->apiRegistry->getClassByName($apiRequest['entity']);
+    if ($entityClass && in_array($apiRequest['action'], $this->supportedActions)) {
+      $em = $this->getEntityManager();
+      $identifier = $em->getClassMetadata($entityClass)->getIdentifierFieldNames();
+      if ($identifier !== array('id')) {
+        throw new \API_Exception("DoctrineCrudProvider only supports identifier column 'id'");
+      }
+
+      $apiRequest['doctrineClass'] = $entityClass;
+      $event->setApiRequest($apiRequest);
+      $event->setApiProvider($this);
+      $event->stopPropagation();
+    }
+  }
+
+  public function onApiRespond(\Civi\API\Event\RespondEvent $event) {
+    $apiRequest = $event->getApiRequest();
+    $apiResponse = $event->getResponse();
+    if ($apiRequest['version'] == 4 && !civicrm_error($apiResponse)) {
+      $this->getEntityManager()->flush();
+    }
+  }
+
+  /**
+   * {inheritdoc}
+   */
+  public function invoke($apiRequest) {
+    switch ($apiRequest['action']) {
+      case 'create':
+        return $this->createItem($apiRequest);
+      case 'delete':
+        return $this->deleteItem($apiRequest);
+      case 'get':
+        return $this->getItems($apiRequest);
+      default:
+        // We shouldn't get here because onApiResolve() checks $this->supportedActions
+        throw new \API_Exception("Unsupported action (" . $apiRequest['action'] . ']');
+    }
+  }
+
+  /**
+   * {inheritdoc}
+   */
+  function getEntityNames($version) {
+    return $version == 4 ? $this->apiRegistry->getNames() : array();
+  }
+
+  /**
+   * {inheritdoc}
+   */
+  public function getActionNames($version, $entity) {
+    if ($version != 4) {
+      return array();
+    }
+    $entityClass = $this->apiRegistry->getClassByName($entity);
+    return $entityClass ? $this->supportedActions : array();
+  }
+
+  public function createItem($apiRequest) {
+    $em = $this->getEntityManager();
+
+    if (empty($apiRequest['data']['id'])) {
+      $obj = $this->serializer->denormalize($apiRequest['data'], $apiRequest['doctrineClass']);
+      $em->persist($obj);
+    }
+    else {
+      $obj = $em->find($apiRequest['doctrineClass'], $apiRequest['data']['id']);
+      if (!$obj) {
+        throw new \API_Exception("Requested item does not exist", "not-found");
+      }
+      $context = array('target' => $obj);
+      $obj = $this->serializer->denormalize($apiRequest['data'], $apiRequest['doctrineClass'], NULL, $context);
+    }
+
+    return civicrm_api3_create_success(
+      array(array('id' => $obj->getId()))
+    );
+  }
+
+  public function getItems($apiRequest) {
+    $em = $this->getEntityManager();
+    $qb = $em->createQueryBuilder()
+      ->from($apiRequest['doctrineClass'], 'e')
+      ->select('e');
+    foreach ($apiRequest['data'] as $key => $value) {
+      if (preg_match('/^[a-zA-Z][a-zA-Z0-9_]*$/', $key)) {
+        $qb->andWhere($qb->expr()->eq("e.$key", ":$key"));
+        $qb->setParameter("$key", $value);
+      }
+      else {
+        throw new \API_Exception("Malformed data key [$key]");
+      }
+    }
+    $query = $qb->getQuery();
+
+    $values = array();
+
+    foreach ($query->getResult() as $itemObj) {
+      $itemArray = $this->serializer->normalize($itemObj);
+      $values[$itemArray['id']] = $itemArray;
+    }
+
+    return civicrm_api3_create_success($values);
+  }
+
+  /**
+   * @return \Doctrine\ORM\EntityManager
+   */
+  public function getEntityManager() {
+    return \CRM_DB_EntityManager::singleton();
+  }
+
+  public function deleteItem($apiRequest) {
+    if (array_keys($apiRequest['data']->getArray()) == 'id') {
+      throw new \API_Exception("Deletion supports only id. Received unexpected keys.", array(
+        'keys' => array_keys($apiRequest['data']->getArray())
+      ));
+    }
+
+    $em = $this->getEntityManager();
+    $item = $em->find($apiRequest['doctrineClass'], $apiRequest['data']['id']);
+    if ($item) {
+      $em->remove($item);
+    }
+
+    // Return success as long as post-condition is OK ("$id does not exist")
+    return civicrm_api3_create_success(array());
+  }
+
+  /**
+   * @param \Civi\API\Registry $apiRegistry
+   */
+  public function setApiRegistry($apiRegistry) {
+    $this->apiRegistry = $apiRegistry;
+  }
+
+  /**
+   * @return \Civi\API\Registry
+   */
+  public function getApiRegistry() {
+    return $this->apiRegistry;
+  }
+}

--- a/Civi/API/Registry.php
+++ b/Civi/API/Registry.php
@@ -1,6 +1,9 @@
 <?php
 namespace Civi\API;
 
+/**
+ * A registry of API-enabled Doctrine entities
+ */
 class Registry {
   /**
    * @var array (string $name => string $className)
@@ -56,6 +59,13 @@ class Registry {
       $this->names[$anno->name] = $class;
       $this->slugs[$anno->slug] = $class;
     }
+  }
+
+  /**
+   * @return array<string>
+   */
+  public function getNames() {
+    return array_keys($this->names);
   }
 
   /**

--- a/Civi/API/Subscriber/AnnotationPermissionCheck.php
+++ b/Civi/API/Subscriber/AnnotationPermissionCheck.php
@@ -1,0 +1,98 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.4                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2013                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*/
+
+namespace Civi\API\Subscriber;
+use Civi\API\Events;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * For any API requests that correspond to a Doctrine entity ($apiRequest['doctrineClass']), check
+ * permissions specified in Civi\API\Annotation\Permission.
+ */
+class AnnotationPermissionCheck implements EventSubscriberInterface {
+  public static function getSubscribedEvents() {
+    return array(
+      Events::AUTHORIZE => array(
+        array('onApiAuthorize', Events::W_MIDDLE),
+      ),
+    );
+  }
+
+  /**
+   * @var \Doctrine\Common\Annotations\Reader
+   */
+  private $annotationReader;
+
+  /**
+   * @var array (string $className => array(string $action => string $permission))
+   */
+  private $cache;
+
+  /**
+   * @var callable
+   */
+  private $permChecker;
+
+  /**
+   * @param \Doctrine\Common\Annotations\Reader $annotationReader
+   * @param callable $permChecker a function which returns TRUE if the current user has a given permission
+   */
+  public function __construct($annotationReader, $permChecker = array('CRM_Core_Permission', 'check')) {
+    $this->annotationReader = $annotationReader;
+    $this->permChecker = $permChecker;
+    $this->cache = array();
+  }
+
+  public function onApiAuthorize(\Civi\API\Event\AuthorizeEvent $event) {
+    $apiRequest = $event->getApiRequest();
+    if (!isset($apiRequest['doctrineClass'])) {
+      return;
+    }
+
+    $perm = $this
+      ->getAnnotation($apiRequest['doctrineClass'])
+      ->getPermission($apiRequest['action']);
+    if (call_user_func($this->permChecker, $perm)) {
+      $event->authorize();
+      $event->stopPropagation();
+    }
+  }
+
+  /**
+   * @param string $class
+   * @return \Civi\API\Annotation\Permission|NULL
+   */
+  public function getAnnotation($class) {
+    if (!array_key_exists($class, $this->cache)) {
+      $this->cache[$class] = $this->annotationReader->getClassAnnotation(new \ReflectionClass($class), 'Civi\API\Annotation\Permission');
+    }
+    else {
+      $this->cache[$class] = new \Civi\API\Annotation\Permission(array());
+    }
+    return $this->cache[$class];
+  }
+}

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,8 @@
     "doctrine/orm": "2.4.*",
     "symfony/dependency-injection": "2.3.*",
     "symfony/http-foundation": "2.3.*",
-    "jms/serializer": "~0.13@dev"
+    "jms/serializer": "~0.13@dev",
+    "symfony/event-dispatcher": "2.3.*",
+    "symfony/serializer": "2.3.*"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -3,7 +3,7 @@
         "This file locks the dependencies of your project to a known state",
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
     ],
-    "hash": "da9c5360c513c5808fac32f0e966a431",
+    "hash": "daecbb5d76e762759e8f056601290200",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -937,6 +937,62 @@
             "time": "2014-03-01 17:25:29"
         },
         {
+            "name": "symfony/event-dispatcher",
+            "version": "2.3.x-dev",
+            "target-dir": "Symfony/Component/EventDispatcher",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/EventDispatcher.git",
+                "reference": "15645237c6ff70e74a28e8836362d82492765055"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/15645237c6ff70e74a28e8836362d82492765055",
+                "reference": "15645237c6ff70e74a28e8836362d82492765055",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "symfony/dependency-injection": "~2.0"
+            },
+            "suggest": {
+                "symfony/dependency-injection": "",
+                "symfony/http-kernel": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony EventDispatcher Component",
+            "homepage": "http://symfony.com",
+            "time": "2014-02-11 10:29:24"
+        },
+        {
             "name": "symfony/http-foundation",
             "version": "2.3.x-dev",
             "target-dir": "Symfony/Component/HttpFoundation",
@@ -987,6 +1043,55 @@
             "description": "Symfony HttpFoundation Component",
             "homepage": "http://symfony.com",
             "time": "2014-03-25 16:54:15"
+        },
+        {
+            "name": "symfony/serializer",
+            "version": "2.3.x-dev",
+            "target-dir": "Symfony/Component/Serializer",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Serializer.git",
+                "reference": "a8054b90bb9890fab14ba2d086be2528cd9ab006"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Serializer/zipball/a8054b90bb9890fab14ba2d086be2528cd9ab006",
+                "reference": "a8054b90bb9890fab14ba2d086be2528cd9ab006",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Serializer\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Serializer Component",
+            "homepage": "http://symfony.com",
+            "time": "2014-03-26 07:21:50"
         }
     ],
     "packages-dev": [

--- a/tests/phpunit/Civi/API/Page/RESTTest.php
+++ b/tests/phpunit/Civi/API/Page/RESTTest.php
@@ -35,6 +35,7 @@ class RESTTest extends \CiviUnitTestCase {
   private $fixtures;
 
   function setUp() {
+    $this->markTestIncomplete('This test was originally written for Hateoas but then removed. Keeping around as an example for future work.');
     $this->maxWorldRegionID = \CRM_Core_DAO::singleValueQuery('SELECT max(id) FROM civicrm_worldregion');
     $this->fixtures['Middle East'] = array(
       'id' => 3,

--- a/tests/phpunit/Civi/API/Provider/DoctrineCrudProviderTest.php
+++ b/tests/phpunit/Civi/API/Provider/DoctrineCrudProviderTest.php
@@ -1,0 +1,248 @@
+<?php
+namespace Civi\API\Provider;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Doctrine\Common\Collections\Criteria;
+
+require_once 'CiviTest/CiviUnitTestCase.php';
+
+/**
+ * This class ensures that the Doctrine<->API bindings support their major features. They do not
+ *perform detailed verification of each entity's API.
+ *
+ * As an example, the tests manipulate the Worldregion entity.
+ */
+class DoctrineCrudProviderTest extends \CiviUnitTestCase {
+
+  /**
+   * @var array(string $table => int $id)
+   */
+  private $maxIds;
+
+  /**
+   * @var array (string $name => mixed $value);
+   */
+  private $fixtures;
+
+  function setUp() {
+    $this->_apiversion = 4;
+    $this->quickCleanup(array('civicrm_contact'));
+    $this->maxIds['civicrm_worldregion'] = \CRM_Core_DAO::singleValueQuery('SELECT max(id) FROM civicrm_worldregion');
+    $this->maxIds['civicrm_location_type'] = \CRM_Core_DAO::singleValueQuery('SELECT max(id) FROM civicrm_location_type');
+    $this->fixtures['Middle East'] = array(
+      'id' => 3,
+      'name' => 'Middle East and North Africa',
+    );
+
+    $this->setPermissions(array('access AJAX API', 'access CiviCRM', 'administer CiviCRM'));
+  }
+
+  function tearDown() {
+    foreach ($this->maxIds as $table => $maxId) {
+      \CRM_Core_DAO::executeQuery("DELETE FROM $table WHERE id > %1", array(
+        1 => array($maxId, 'Positive')
+      ));
+    }
+    parent::tearDown();
+  }
+
+  function testGetItem_ById() {
+    $result = $this->callAPISuccess('Worldregion', 'get', array('id' => 3));
+    $this->assertEquals($this->fixtures['Middle East'], $result['values'][3]);
+  }
+
+  function testGetItem_ByName() {
+    $result = $this->callAPISuccess('Worldregion', 'get', array('name' => 'Middle East and North Africa'));
+    $this->assertEquals($this->fixtures['Middle East'], $result['values'][3]);
+  }
+
+  function testGetItem_ByRelationId() {
+    $contacts = array();
+    for ($i = 0; $i < 4; $i++) {
+      $contacts[] = civicrm_api3('Contact', 'create', array(
+        'contact_type' => 'Individual',
+        'first_name' => "Example{$i}",
+        'last_name' => "Example{$i}",
+        'api.email.create' => array(
+          array('location_type_id' => 'Home', 'email' => "home{$i}@example.com"),
+          array('location_type_id' => 'Work', 'email' => "work{$i}@example.com"),
+        ),
+      ));
+    }
+    $result = $this->callAPISuccess('Email', 'get', array('contact' => $contacts[2]['id']));
+    $emails = \CRM_Utils_Array::collect('email', array_values($result['values']));
+    $this->assertEquals(array('home2@example.com', 'work2@example.com'), $emails);
+  }
+
+  function testGetItem_InsufficientPermission() {
+    $this->setPermissions(array('access AJAX API')); // missing: access CiviCRM
+    $result = $this->callAPIFailure('Worldregion', 'get', array('id' => 3));
+    $this->assertEquals('unauthorized', $result['error_code']);
+  }
+
+  function testGetCollection() {
+    $result = $this->callAPISuccess('Worldregion', 'get', array());
+    $this->assertEquals(6, count($result['values']));
+    foreach ($result['values'] as $country) {
+      $this->assertTrue(isset($country['id']) && is_numeric($country['id']));
+      $this->assertTrue(isset($country['name']) && is_string($country['name']));
+    }
+    $this->assertContains($this->fixtures['Middle East'], $result['values']);
+  }
+
+  function testGetCollection_InsufficientPermission() {
+    $this->setPermissions(array('access AJAX API')); // missing: access CiviCRM
+    $result = $this->callAPIFailure('Worldregion', 'get', array());
+    $this->assertEquals('unauthorized', $result['error_code']);
+  }
+
+  function testCreateItem() {
+    $this->assertDBQuery(0, 'SELECT count(*) FROM civicrm_worldregion WHERE name = "Middle Earth"');
+
+    $result = $this->callAPISuccess('Worldregion', 'create', array(
+      'name' => 'Middle Earth',
+    ));
+    $this->assertEquals(1, count($result['values']));
+
+    $this->assertDBQuery(1, 'SELECT count(*) FROM civicrm_worldregion WHERE name = "Middle Earth"');
+  }
+
+  function testCreateItem_InsufficientPermission() {
+    $this->assertDBQuery(0, 'SELECT count(*) FROM civicrm_worldregion WHERE name = "Middle Earth"');
+
+    $this->setPermissions(array('access AJAX API', 'access CiviCRM')); // missing: administer CiviCRM
+    $result = $this->callAPIFailure('Worldregion', 'create', array(
+      'name' => 'Middle Earth',
+    ));
+    $this->assertEquals('unauthorized', $result['error_code']);
+
+    $this->assertDBQuery(0, 'SELECT count(*) FROM civicrm_worldregion WHERE name = "Middle Earth"');
+  }
+
+  function testDeleteItem() {
+    $region = $this->createMiddleEarth();
+    $this->assertDBQuery(1, 'SELECT count(*) FROM civicrm_worldregion WHERE name = "Middle Earth"');
+
+    $result = $this->callAPISuccess('Worldregion', 'delete', array('id' => $region->getId()));
+    $this->assertEquals(0, count($result['values']));
+    $this->assertDBQuery(0, 'SELECT count(*) FROM civicrm_worldregion WHERE name = "Middle Earth"');
+  }
+
+  function testDeleteItem_InsufficientPermission() {
+    $region = $this->createMiddleEarth();
+    $this->assertDBQuery(1, 'SELECT count(*) FROM civicrm_worldregion WHERE name = "Middle Earth"');
+
+    $this->setPermissions(array('access AJAX API', 'access CiviCRM')); // missing: administer CiviCRM
+    $result = $this->callAPIFailure('Worldregion', 'delete', array(
+      'id' => $region->getId()
+    ));
+    $this->assertEquals('unauthorized', $result['error_code']);
+
+    $this->assertDBQuery(1, 'SELECT count(*) FROM civicrm_worldregion WHERE name = "Middle Earth"');
+  }
+
+  function testUpdateItem() {
+    $item = $this->createCampusLocationType();
+    $this->assertDBQuery(1, 'SELECT count(*) FROM civicrm_location_type WHERE display_name = "Campus"');
+    $id = $item->getId();
+
+    $result = $this->callAPISuccess('LocationType', 'create', array(
+      'id' => $id,
+      'displayName' => 'On Campus',
+    ));
+
+    $this->assertEquals(1, count($result['values']));
+    $this->assertDBQuery(0, 'SELECT count(*) FROM civicrm_location_type WHERE display_name = "Campus"');
+    $this->assertDBQuery(1, 'SELECT count(*) FROM civicrm_location_type WHERE display_name = "On Campus"');
+  }
+
+  function testUpdateItem_InsufficientPermission() {
+    $region = $this->createMiddleEarth();
+    $this->assertDBQuery(1, 'SELECT count(*) FROM civicrm_worldregion WHERE name = "Middle Earth"');
+    $this->assertDBQuery(0, 'SELECT count(*) FROM civicrm_worldregion WHERE name = "OhNoes"');
+
+    $this->setPermissions(array('access AJAX API', 'access CiviCRM')); // missing: administer CiviCRM
+    $result = $this->callAPIFailure('Worldregion', 'create', array(
+      'id' => $region->getId(),
+      'name' => 'OhNoes',
+    ));
+    $this->assertEquals('unauthorized', $result['error_code']);
+
+    $this->assertDBQuery(1, 'SELECT count(*) FROM civicrm_worldregion WHERE name = "Middle Earth"');
+    $this->assertDBQuery(0, 'SELECT count(*) FROM civicrm_worldregion WHERE name = "OhNoes"');
+  }
+
+  function testUpdateItem_InvalidID() {
+    $result = $this->callAPIFailure('Worldregion', 'create', array(
+      'id' => 123456789,
+      'name' => 'OhNoes',
+    ));
+    $this->assertEquals(\API_Exception::NOT_IMPLEMENTED, $result['error_code']);
+    $this->assertDBQuery(0, 'SELECT count(*) FROM civicrm_worldregion WHERE name = "OhNoes"');
+  }
+
+  function testGetEntityNames() {
+    $dp = new DoctrineCrudProvider(\Civi\Core\Container::singleton()->get('civi_api_registry'));
+    $this->assertSubset(array('Worldregion', 'LocationType'), $dp->getEntityNames(4));
+    $this->assertEquals(array(), $dp->getEntityNames(3));
+
+    $result = $this->callAPISuccess('Entity', 'get', array('version' => 4));
+    $this->assertSubset(array('Worldregion', 'LocationType'), $result['values']);
+
+    // The following is likely to break if someone independently adds "Worldregion" to APIv3,
+    // but it's good for the moment to ensure that DoctrineCrudProvider doesn't bleed out to APIv3.
+    $result = $this->callAPISuccess('Entity', 'get', array('version' => 3));
+    $this->assertFalse(in_array('Worldregion', $result['values']));
+  }
+
+  function testGetActionNames() {
+    $dp = new DoctrineCrudProvider(\Civi\Core\Container::singleton()->get('civi_api_registry'));
+    $this->assertEquals(array(), $dp->getActionNames(3, 'Worldregion'));
+    $this->assertSubset(array('create', 'get', 'delete'), $dp->getActionNames(4, 'Worldregion'));
+
+    $result = $this->callAPISuccess('Worldregion', 'getactions', array('version' => 4));
+    $this->assertSubset(array('create', 'get', 'delete'), $result['values']);
+  }
+
+  /**
+   * @param array<string> $perms
+   */
+  function setPermissions($perms) {
+    $config = \CRM_Core_Config::singleton();
+    $config->userPermissionClass->permissions = $perms;
+  }
+
+  /**
+   * @return \Civi\Core\LocationType
+   */
+  function createCampusLocationType() {
+    $item = new \Civi\Core\LocationType();
+    $item->setName("Campus");
+    $item->setDescription("On-campus address");
+    $item->setDisplayName("Campus");
+    $item->setIsActive(TRUE);
+    $item->setVcardName('CAMPUS');
+    $em = \CRM_DB_EntityManager::singleton();
+    $em->persist($item);
+    $em->flush();
+    return $item;
+  }
+
+  /**
+   * @return \Civi\Core\Worldregion
+   */
+  function createMiddleEarth() {
+    $region = new \Civi\Core\Worldregion();
+    $region->setName('Middle Earth');
+    $em = \CRM_DB_EntityManager::singleton();
+    $em->persist($region);
+    $em->flush();
+    return $region;
+  }
+
+  function assertSubset($expectedSubset, $superset) {
+    $message = 'Expect that (' . implode(',', $expectedSubset) . ') is a subset of (' . implode(',', $superset) . ')';
+    $this->assertTrue(\CRM_Utils_Array::isSubset($expectedSubset, $superset), $message);
+  }
+
+}


### PR DESCRIPTION
Most of the logic is handled by DoctrineCrudProvider, although permissions are handled by AnnotationPermissionCheck.

This is a resubmission of https://github.com/civicrm/civicrm-core/pull/2801 now that the API kernel has been merged into 4.5.
