### PR TITLE
CRM-14389 membership api - add test for fix + alter to 'correct fix'

### DIFF
--- a/api/v3/Membership.php
+++ b/api/v3/Membership.php
@@ -187,32 +187,21 @@ function civicrm_api3_membership_get($params) {
   $activeOnly = $membershipTypeId = $membershipType = NULL;
 
   $contactID = CRM_Utils_Array::value('contact_id', $params);
-  if (!empty($params['filters']) && is_array($params['filters'])) {
-    $activeOnly = CRM_Utils_Array::value('is_current', $params['filters'], FALSE);
+  if (!empty($params['filters']) && is_array($params['filters']) && isset($params['filters']['is_current'])) {
+    $activeOnly = $params['filters']['is_current'];
+    unset($params['filters']['is_current']);
   }
   $activeOnly = CRM_Utils_Array::value('active_only', $params, $activeOnly);
-
-  //@todo replace this by handling in API layer - we should have enough info to do this
-  // between pseudoconstant & fk - see comments in format_params
-  $membershipTypeId = CRM_Utils_Array::value('membership_type_id', $params);
-  if (!$membershipTypeId) {
-    $membershipType = CRM_Utils_Array::value('membership_type', $params);
-    if ($membershipType) {
-      $membershipTypeId = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipType',
-          $membershipType, 'id', 'name'
-      );
-    }
+  if($activeOnly && empty($params['status_id'])) {
+    $params['status_id'] = array('IN' => CRM_Member_BAO_MembershipStatus::getMembershipStatusCurrent());
   }
-
-  if (CRM_Utils_Array::value('contact_id', $params) && !is_array($params['contact_id'])) {
-    $membershipValues = _civicrm_api3_membership_get_customv2behaviour($params, $membershipTypeId, $activeOnly );
+  $options = _civicrm_api3_get_options_from_params($params, TRUE,'membership', 'get');
+  if($options['is_count']) {
+    return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
   }
-  else {
-    //legacy behaviour only ever worked when contact_id passed in - use standard api function otherwise
-    $membershipValues = _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params, FALSE);
-  }
+  $membershipValues = _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params, FALSE);
 
-  $options = _civicrm_api3_get_options_from_params($params, TRUE,'membership','get');
+
   $return = $options['return'];
   if(empty($membershipValues) ||
     (!empty($return)

--- a/api/v3/examples/Membership/Create.php
+++ b/api/v3/examples/Membership/Create.php
@@ -5,14 +5,14 @@
  */
 function membership_create_example(){
 $params = array(
-  'contact_id' => 30,
-  'membership_type_id' => 48,
+  'contact_id' => 31,
+  'membership_type_id' => 50,
   'join_date' => '2009-01-21',
   'start_date' => '2009-01-21',
   'end_date' => '2009-12-21',
   'source' => 'Payment',
   'is_override' => 1,
-  'status_id' => 31,
+  'status_id' => 32,
   'custom_1' => 'custom string',
 );
 
@@ -43,13 +43,13 @@ function membership_create_expectedresult(){
   'values' => array(
       '1' => array(
           'id' => '1',
-          'contact_id' => '30',
-          'membership_type_id' => '48',
+          'contact_id' => '31',
+          'membership_type_id' => '50',
           'join_date' => '20090121000000',
           'start_date' => '2013-07-29 00:00:00',
           'end_date' => '2013-08-04 00:00:00',
           'source' => 'Payment',
-          'status_id' => '31',
+          'status_id' => '32',
           'is_override' => '1',
           'owner_membership_id' => '',
           'max_related' => '',

--- a/api/v3/examples/Membership/Get.php
+++ b/api/v3/examples/Membership/Get.php
@@ -5,7 +5,7 @@
  */
 function membership_get_example(){
 $params = array(
-  'membership_type_id' => 19,
+  'membership_type_id' => 21,
 );
 
 try{
@@ -35,13 +35,13 @@ function membership_get_expectedresult(){
   'values' => array(
       '1' => array(
           'id' => '1',
-          'contact_id' => '14',
-          'membership_type_id' => '19',
+          'contact_id' => '15',
+          'membership_type_id' => '21',
           'join_date' => '2009-01-21',
           'start_date' => '2013-07-29 00:00:00',
           'end_date' => '2013-08-04 00:00:00',
           'source' => 'Payment',
-          'status_id' => '17',
+          'status_id' => '18',
           'is_override' => '1',
           'is_test' => 0,
           'is_pay_later' => 0,

--- a/api/v3/examples/Membership/Update.php
+++ b/api/v3/examples/Membership/Update.php
@@ -5,14 +5,14 @@
  */
 function membership_update_example(){
 $params = array(
-  'contact_id' => 36,
-  'membership_type_id' => 60,
+  'contact_id' => 37,
+  'membership_type_id' => 62,
   'join_date' => '2009-01-21',
   'start_date' => '2009-01-21',
   'end_date' => '2009-12-21',
   'source' => 'Payment',
   'is_override' => 1,
-  'status_id' => 37,
+  'status_id' => 38,
   'custom_1' => 'custom string',
 );
 
@@ -43,13 +43,13 @@ function membership_update_expectedresult(){
   'values' => array(
       '1' => array(
           'id' => '1',
-          'contact_id' => '36',
-          'membership_type_id' => '60',
+          'contact_id' => '37',
+          'membership_type_id' => '62',
           'join_date' => '20090121000000',
           'start_date' => '2013-07-29 00:00:00',
           'end_date' => '2013-08-04 00:00:00',
           'source' => 'Payment',
-          'status_id' => '37',
+          'status_id' => '38',
           'is_override' => '1',
           'owner_membership_id' => '',
           'max_related' => '',

--- a/api/v3/examples/Membership/filterIsCurrent.php
+++ b/api/v3/examples/Membership/filterIsCurrent.php
@@ -5,7 +5,7 @@
  */
 function membership_get_example(){
 $params = array(
-  'contact_id' => 17,
+  'contact_id' => 18,
   'filters' => array(
       'is_current' => 1,
     ),
@@ -38,23 +38,16 @@ function membership_get_expectedresult(){
   'values' => array(
       '1' => array(
           'id' => '1',
-          'membership_id' => '1',
-          'contact_id' => '17',
-          'membership_contact_id' => '17',
-          'membership_type_id' => '25',
+          'contact_id' => '18',
+          'membership_type_id' => '27',
           'join_date' => '2009-01-21',
           'start_date' => '2013-07-29 00:00:00',
-          'membership_start_date' => '2009-01-21',
           'end_date' => '2013-08-04 00:00:00',
-          'membership_end_date' => '2009-12-21',
           'source' => 'Payment',
-          'membership_source' => 'Payment',
-          'status_id' => '20',
+          'status_id' => '21',
           'is_override' => '1',
           'is_test' => 0,
-          'member_is_test' => 0,
           'is_pay_later' => 0,
-          'member_is_pay_later' => 0,
           'membership_name' => 'General',
           'relationship_name' => 'Child of',
         ),

--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -208,7 +208,6 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
    * Test civicrm_membership_get with params not array.
    * Gets treated as contact_id, memberships expected.
    */
-
   function testGetWithParamsMemberShipTypeId() {
     $result = $this->callAPISuccess($this->_entity, 'create', $this->_params);
     $params = array(
@@ -229,7 +228,32 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     $this->assertEquals($result['is_override'], 1, "In line " . __LINE__);
     $this->assertEquals($result['id'], $membership['id']);
   }
+  /**
+   * Test civicrm_membership_get with params not array.
+   * Gets treated as contact_id, memberships expected.
+   */
+  function testGetWithParamsMemberShipTypeIdContactID() {
+    $params = $this->_params;
+    $this->callAPISuccess($this->_entity, 'create', $params);
+    $params['membership_type_id'] = $this->_membershipTypeID2;
+    $this->callAPISuccess($this->_entity, 'create', $params);
+    $this->callAPISuccessGetCount('membership', array('contact_id' => $this->_contactID), 2);
+    $params = array(
+      'membership_type_id' => $this->_membershipTypeID,
+      'contact_id' => $this->_contactID,
+    );
+    $result = $this->callAPISuccess('membership', 'getsingle', $params);
+    $this->assertEquals($result['contact_id'], $this->_contactID);
+    $this->assertEquals($result['membership_type_id'], $this->_membershipTypeID);
 
+    $params = array(
+      'membership_type_id' => $this->_membershipTypeID2,
+      'contact_id' => $this->_contactID,
+    );
+    $result = $this->callAPISuccess('membership', 'getsingle', $params);
+    $this->assertEquals($result['contact_id'], $this->_contactID);
+    $this->assertEquals($result['membership_type_id'], $this->_membershipTypeID2);
+  }
   /**
    * check with complete array + custom field
    * Note that the test is written on purpose without any
@@ -317,8 +341,8 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
 
     $membership = $this->callAPISuccess('membership', 'get', $params);
     $result = $membership['values'][$this->_membershipID];
-    $this->assertEquals($membership['values'][$this->_membershipID]['status_id'], $this->_membershipStatusID, "In line " . __LINE__);
-    $this->assertEquals($membership['values'][$this->_membershipID]['contact_id'], $this->_contactID, "In line " . __LINE__);
+    $this->assertEquals($membership['values'][$this->_membershipID]['status_id'], $this->_membershipStatusID);
+    $this->assertEquals($membership['values'][$this->_membershipID]['contact_id'], $this->_contactID);
     $params = array(
       'contact_id' => $this->_contactID,
       'filters' => array(
@@ -328,8 +352,8 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
 
     $membership = $this->callAPIAndDocument('membership', 'get', $params, __FUNCTION__, __FILE__, $description, $subfile);
     $result = $membership['values'][$this->_membershipID];
-    $this->assertEquals($membership['values'][$this->_membershipID]['status_id'], $this->_membershipStatusID, "In line " . __LINE__);
-    $this->assertEquals($membership['values'][$this->_membershipID]['contact_id'], $this->_contactID, "In line " . __LINE__);
+    $this->assertEquals($membership['values'][$this->_membershipID]['status_id'], $this->_membershipStatusID);
+    $this->assertEquals($membership['values'][$this->_membershipID]['contact_id'], $this->_contactID);
 
 
     $result = $this->callAPISuccess('Membership', 'Delete', array(


### PR DESCRIPTION
---
- CRM-14389: Get memberships api ignores membership_type_id if contact_id is present
  https://issues.civicrm.org/jira/browse/CRM-14389
