### PR TITLE
CRM-14439 - Fix WP breadcrumbs by forcibly pre-computing them with "wp-admin/admin.php"

### DIFF
--- a/CRM/Core/Invoke.php
+++ b/CRM/Core/Invoke.php
@@ -483,13 +483,13 @@ class CRM_Core_Invoke {
     $config = CRM_Core_Config::singleton();
     $config->clearModuleList();
 
+    // also cleanup all caches
+    $config->cleanupCaches($sessionReset || CRM_Utils_Request::retrieve('sessionReset', 'Boolean', CRM_Core_DAO::$_nullObject, FALSE, 0, 'GET'));
+
     CRM_Core_Menu::store();
 
     // also reset navigation
     CRM_Core_BAO_Navigation::resetNavigation();
-
-    // also cleanup all caches
-    $config->cleanupCaches($sessionReset || CRM_Utils_Request::retrieve('sessionReset', 'Boolean', CRM_Core_DAO::$_nullObject, FALSE, 0, 'GET'));
 
     // also cleanup module permissions
     $config->cleanupPermissions();

--- a/CRM/Core/Menu.php
+++ b/CRM/Core/Menu.php
@@ -460,7 +460,12 @@ class CRM_Core_Menu {
         $crumbs[] = array(
           'title' => $menu[$currentPath]['title'],
           'url' => CRM_Utils_System::url($currentPath,
-            'reset=1' . $urlVar, FALSE
+            'reset=1' . $urlVar,
+            FALSE, // absolute
+            NULL, // fragment
+            TRUE, // htmlize
+            FALSE, // frontend
+            TRUE // forceBackend; CRM-14439 work-around; acceptable for now because we don't display breadcrumbs on frontend
           ),
         );
       }


### PR DESCRIPTION
Note: The notion of this fix is that one can run the System.flush API (via setup.sh), and any
breadcrumbs will be set correctly. Subsequent requests to clear the cache should be done through
the same API or by a logged-in admin, so it reduces the odds of hitting the problematic case (where the breadcrumb's are recomputed while processing a frontend page request).

The main source of risk in this patch is that order of operations in
CRM_Core_Invoke::rebuildMenuAndCaches changes (which is used by install/upgrade for core+extensions on all CMSs).
