### PR TITLE
WebTestFixes related to testCreateCampaign

### DIFF
--- a/tests/phpunit/CiviTest/CiviSeleniumTestCase.php
+++ b/tests/phpunit/CiviTest/CiviSeleniumTestCase.php
@@ -1877,13 +1877,23 @@ class CiviSeleniumTestCase extends PHPUnit_Extensions_SeleniumTestCase {
   /**
    * function to type and select first occurance of autocomplete
    */
-  function select2($fieldName,$label) {
-    $this->clickAt("//*[@id='$fieldName']/../div/a");
-    $this->waitForElementPresent("//*[@id='select2-drop']/div/input");
-    $this->keyDown("//*[@id='select2-drop']/div/input", " ");
-    $this->type("//*[@id='select2-drop']/div/input", $label);
-    $this->typeKeys("//*[@id='select2-drop']/div/input", $label);
-    $this->waitForElementPresent("//*[@class='select2-result-label']");
-    $this->clickAt("//*[@class='select2-results']/li[1]");
+  function select2($fieldName,$label, $multiple = FALSE) {
+    if ($multiple) {
+      $this->clickAt("//*[@id='$fieldName']/../div/ul/li[1]");
+      $this->keyDown("//*[@id='$fieldName']/../div/ul/li[1]/input", " ");
+      $this->type("//*[@id='$fieldName']/../div/ul/li[1]/input", $label);
+      $this->typeKeys("//*[@id='$fieldName']/../div/ul/li[1]/input", $label);
+      $this->waitForElementPresent("//*[@class='select2-result-label']");
+      $this->clickAt("//*[@class='select2-results']/li[1]/div");
+    }
+    else {
+      $this->clickAt("//*[@id='$fieldName']/../div/a");
+      $this->waitForElementPresent("//*[@id='select2-drop']/div/input");
+      $this->keyDown("//*[@id='select2-drop']/div/input", " ");
+      $this->type("//*[@id='select2-drop']/div/input", $label);
+      $this->typeKeys("//*[@id='select2-drop']/div/input", $label);
+      $this->waitForElementPresent("//*[@class='select2-result-label']");
+      $this->clickAt("//*[@class='select2-results']/li[1]");
+    }
   }
 }

--- a/tests/phpunit/WebTest/Campaign/ActivityTest.php
+++ b/tests/phpunit/WebTest/Campaign/ActivityTest.php
@@ -61,7 +61,7 @@ class WebTest_Campaign_ActivityTest extends CiviSeleniumTestCase {
     // add to group
     $this->select("group_id", "label=$groupName");
     $this->click("_qf_GroupContact_next");
-    $this->waitForPageToLoad($this->getTimeoutMsec());
+    $this->waitForElementPresent('link=Remove');
 
     $firstName2 = substr(sha1(rand()), 0, 7);
     $this->webtestAddContact($firstName2, "John", "$firstName2.john@example.org");
@@ -74,7 +74,7 @@ class WebTest_Campaign_ActivityTest extends CiviSeleniumTestCase {
     // add to group
     $this->select("group_id", "label=$groupName");
     $this->click("_qf_GroupContact_next");
-    $this->waitForPageToLoad($this->getTimeoutMsec());
+    $this->waitForElementPresent('link=Remove');
 
     $this->openCiviPage('campaign/add', 'reset=1', '_qf_Campaign_upload-bottom');
 
@@ -130,28 +130,19 @@ class WebTest_Campaign_ActivityTest extends CiviSeleniumTestCase {
     $this->waitForElementPresent("_qf_Activity_upload");
 
     // ...and verifying if the page contains properly formatted display name for chosen contact.
-    $this->assertElementContainsText('css=tr.crm-activity-form-block-target_contact_id td ul li.token-input-token-facebook','Anderson, ' . $firstName2, 'Contact not found in line ' . __LINE__);
+    $this->waitForElementPresent("//*[@id='s2id_target_contact_id']");
+    $this->assertElementContainsText('//*[@id="s2id_target_contact_id"]/ul/li[1]/div', 'Anderson, ' . $firstName2, 'Contact not found in line ' . __LINE__);
 
     // Now we're filling the "Assigned To" field.
     // Typing contact's name into the field (using typeKeys(), not type()!)...
-    $this->click("css=tr.crm-activity-form-block-assignee_contact_id input#token-input-assignee_contact_id");
-    $this->type("css=tr.crm-activity-form-block-assignee_contact_id input#token-input-assignee_contact_id", $firstName1);
-    $this->typeKeys("css=tr.crm-activity-form-block-assignee_contact_id input#token-input-assignee_contact_id", $firstName1);
-
-    // ...waiting for drop down with results to show up...
-    $this->waitForElementPresent("css=div.token-input-dropdown-facebook");
-    $this->waitForElementPresent("css=li.token-input-dropdown-item2-facebook");
-
-    // ...need to use mouseDownAt on first result (which is a li element), click does not work
-    $this->mouseDownAt("css=li.token-input-dropdown-item2-facebook");
-    // ...again, waiting for the box with contact name to show up...
-    $this->waitForElementPresent("css=tr.crm-activity-form-block-assignee_contact_id td ul li span.token-input-delete-token-facebook");
+    $this->select2("assignee_contact_id", $firstName1, TRUE);
 
     // ...and verifying if the page contains properly formatted display name for chosen contact.
-    $this->assertElementContainsText('css=tr.crm-activity-form-block-assignee_contact_id td ul li.token-input-token-facebook', 'Summerson, ' . $firstName1, 'Contact not found in line ' . __LINE__);
+    $this->waitForElementPresent("//*[@id='s2id_assignee_contact_id']");
+    $this->assertElementContainsText('//*[@id="s2id_assignee_contact_id"]/ul/li[1]/div', 'Summerson, ' . $firstName1, 'Contact not found in line ' . __LINE__);
 
     // Since we're here, let's check if screen help is being displayed properly
-    // $this->assertTrue($this->isTextPresent("A copy of this activity will be emailed to each Assignee"));
+    //$this->assertTrue($this->isTextPresent("A copy of this activity will be emailed to each Assignee"));
 
     // Putting the contents into subject field - assigning the text to variable, it'll come in handy later
     $subject = "This is subject of test activity being added through activity tab of contact summary screen.";
@@ -192,7 +183,7 @@ class WebTest_Campaign_ActivityTest extends CiviSeleniumTestCase {
     $this->type("followup_activity_subject", "This is subject of schedule follow-up activity");
 
     // Clicking save.
-    $this->clickLink("_qf_Activity_upload");
+    $this->clickLink("_qf_Activity_upload",'link=View',FALSE);
 
     // Is status message correct?
     $this->waitForText('crm-notification-container', $subject);

--- a/tests/phpunit/WebTest/Campaign/MailingTest.php
+++ b/tests/phpunit/WebTest/Campaign/MailingTest.php
@@ -63,7 +63,7 @@ class WebTest_Campaign_MailingTest extends CiviSeleniumTestCase {
     // add to group
     $this->select("group_id", "label=$groupName");
     $this->click("_qf_GroupContact_next");
-    $this->waitForPageToLoad($this->getTimeoutMsec());
+    $this->waitForElementPresent('link=Remove');
 
     $this->openCiviPage('campaign/add', 'reset=1', '_qf_Campaign_upload-bottom');
 

--- a/tests/phpunit/WebTest/Campaign/MembershipTest.php
+++ b/tests/phpunit/WebTest/Campaign/MembershipTest.php
@@ -51,7 +51,7 @@ class WebTest_Campaign_MembershipTest extends CiviSeleniumTestCase {
     // add to group
     $this->select("group_id", "label=$groupName");
     $this->click("_qf_GroupContact_next");
-    $this->waitForPageToLoad($this->getTimeoutMsec());
+    $this->waitForElementPresent('link=Remove');
 
     $firstName2 = substr(sha1(rand()), 0, 7);
     $this->webtestAddContact($firstName2, "John", "$firstName2.john@example.org");
@@ -64,7 +64,7 @@ class WebTest_Campaign_MembershipTest extends CiviSeleniumTestCase {
     // add to group
     $this->select("group_id", "label=$groupName");
     $this->click("_qf_GroupContact_next");
-    $this->waitForPageToLoad($this->getTimeoutMsec());
+    $this->waitForElementPresent('link=Remove');
 
     // Enable CiviCampaign module if necessary
     $this->enableComponents(array('CiviCampaign'));
@@ -146,7 +146,7 @@ class WebTest_Campaign_MembershipTest extends CiviSeleniumTestCase {
 
     // Clicking save.
     $this->click("_qf_Membership_upload");
-    $this->waitForPageToLoad($this->getTimeoutMsec());
+    $this->waitForElementPresent('link=View');
 
     // page was loaded
     $this->waitForTextPresent($sourceText);

--- a/tests/phpunit/WebTest/Campaign/OfflineContributionTest.php
+++ b/tests/phpunit/WebTest/Campaign/OfflineContributionTest.php
@@ -51,7 +51,7 @@ class WebTest_Campaign_OfflineContributionTest extends CiviSeleniumTestCase {
     // add to group
     $this->select("group_id", "label=$groupName");
     $this->click("_qf_GroupContact_next");
-    $this->waitForPageToLoad($this->getTimeoutMsec());
+    $this->waitForElementPresent('link=Remove');
 
     $firstName2 = substr(sha1(rand()), 0, 7);
     $this->webtestAddContact($firstName2, "John", "$firstName2.john@example.org");
@@ -64,7 +64,7 @@ class WebTest_Campaign_OfflineContributionTest extends CiviSeleniumTestCase {
     // add to group
     $this->select("group_id", "label=$groupName");
     $this->click("_qf_GroupContact_next");
-    $this->waitForPageToLoad($this->getTimeoutMsec());
+    $this->waitForElementPresent('link=Remove');
 
     // Enable CiviCampaign module if necessary
     $this->enableComponents(array('CiviCampaign'));
@@ -168,7 +168,10 @@ class WebTest_Campaign_OfflineContributionTest extends CiviSeleniumTestCase {
     $this->type("trxn_id", "P20901X1" . rand(100, 10000));
 
     // soft credit
-    $this->webtestFillAutocomplete("{$softCreditLname}, {$softCreditFname}", 'soft_credit_contact_1');
+    $this->click("xpath=id('Contribution')/div[2]/div[@id='softCredit']/div[1]");
+    $this->type("soft_credit_amount_1", "50");
+    $this->waitForElementPresent("soft_credit_contact_id_1");
+    $this->webtestFillAutocomplete("{$softCreditLname}, {$softCreditFname}", 'soft_credit_contact_id_1');
 
     //Additional Detail section
     $this->click("AdditionalDetail");
@@ -181,15 +184,6 @@ class WebTest_Campaign_OfflineContributionTest extends CiviSeleniumTestCase {
     $this->type("invoice_id", time());
     $this->webtestFillDate('thankyou_date');
 
-    //Honoree section
-    $this->click("Honoree");
-    $this->waitForElementPresent("honor_email");
-
-    $this->click("CIVICRM_QFID_1_2");
-    $this->select("honor_prefix_id", "label=Ms.");
-    $this->type("honor_first_name", "Foo");
-    $this->type("honor_last_name", "Bar");
-    $this->type("honor_email", "foo@bar.com");
 
     //Premium section
     $this->click("Premium");
@@ -200,15 +194,14 @@ class WebTest_Campaign_OfflineContributionTest extends CiviSeleniumTestCase {
 
     // Clicking save.
     $this->click("_qf_Contribution_upload-bottom");
-    $this->waitForPageToLoad($this->getTimeoutMsec());
 
     // Is status message correct?
-    $this->waitForText('crm-notification-container', "The contribution record has been saved");
+    $this->waitForText('crm-notification-container', "The contribution record has been saved.");
 
-    $this->waitForElementPresent("xpath=//div[@id='Contributions']//table/tbody/tr/td[8]/span/a[text()='View']");
+    $this->waitForElementPresent("xpath=//*[@id='Search']//div[2]//table[2]/tbody/tr/td[8]/span/a[text()='View']");
 
     // click through to the Contribution view screen
-    $this->click("xpath=//div[@id='Contributions']//table/tbody/tr/td[8]/span/a[text()='View']");
+    $this->click("xpath=//*[@id='Search']//div[2]//table[2]/tbody/tr/td[8]/span/a[text()='View']");
     $this->waitForElementPresent('_qf_ContributionView_cancel-bottom');
 
     // verify Contribution created
@@ -228,7 +221,7 @@ class WebTest_Campaign_OfflineContributionTest extends CiviSeleniumTestCase {
 
       $this->type('sort_name', $firstName);
       $this->click("_qf_Search_refresh");
-      $this->waitForElementPresent("_qf_Search_next_print");
+      $this->waitForElementPresent("xpath=//div[@id='contributionSearch']/table/tbody/tr/td[11]/span/a[text()='Edit']");
       $this->click("xpath=//div[@id='contributionSearch']/table/tbody/tr/td[11]/span/a[text()='Edit']");
       $this->waitForElementPresent("_qf_Contribution_cancel-bottom");
       $this->assertTrue($this->isTextPresent("$campaignTitle"));
@@ -264,15 +257,11 @@ class WebTest_Campaign_OfflineContributionTest extends CiviSeleniumTestCase {
 
     // click save
     $this->click("_qf_Campaign_upload-bottom");
-    $this->waitForPageToLoad($this->getTimeoutMsec());
-
-    $this->assertTrue($this->isTextPresent("Campaign $pastCampaignTitle has been saved."),
-      "Status message didn't show up after saving campaign!"
-    );
+    $this->waitForElementPresent("//*[@id='crm-notification-container']");
+    $this->waitForText('crm-notification-container', "Campaign $pastCampaignTitle has been saved.");
 
     $this->waitForElementPresent("link=Add Campaign");
-
-    $this->waitForElementPresent("Campaigns");
+    $this->waitForElementPresent("link=Campaigns");
     $this->click("search_form_campaign");
     $this->type("campaign_title", $pastCampaignTitle);
     $this->click("xpath=//div[@class='crm-accordion-body']/table/tbody/tr[4]/td/a[text()='Search']");


### PR DESCRIPTION
The break was due to the multiselect on activity add which is not handled properly.
Therefore added an additional param called 'multiple=FALSE' param in select2 function in CiviSeleniumTestCase to handle multiselect.
Also other element error break resolved.
