### PR TITLE
CRM-14522 remove incorrect FK

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1255,9 +1255,11 @@ SELECT contact_id
     return self::escapeString($string);
   }
 
-  //Creates a test object, including any required objects it needs via recursion
-  //createOnly: only create in database, do not store or return the objects (useful for perf testing)
-  //ONLY USE FOR TESTING
+  /**
+   * Creates a test object, including any required objects it needs via recursion
+   *createOnly: only create in database, do not store or return the objects (useful for perf testing)
+   *ONLY USE FOR TESTING
+   */
   static function createTestObject(
     $daoName,
     $params = array(),
@@ -1435,9 +1437,10 @@ SELECT contact_id
     else return $objects;
   }
 
-  //deletes the this object plus any dependent objects that are associated with it
-  //ONLY USE FOR TESTING
-
+  /**
+   * deletes the this object plus any dependent objects that are associated with it
+   * ONLY USE FOR TESTING
+   */
   static function deleteTestObjects($daoName, $params = array(
     )) {
     //this is a test function  also backtrace is set for the test suite it sometimes unsets itself

--- a/CRM/Upgrade/Incremental/php/FourFive.php
+++ b/CRM/Upgrade/Incremental/php/FourFive.php
@@ -44,8 +44,11 @@ class CRM_Upgrade_Incremental_php_FourFive {
    * Note: This function is called iteratively for each upcoming
    * revision to the database.
    *
-   * @param $postUpgradeMessage string, alterable
+   * @param $preUpgradeMessage
    * @param $rev string, a version number, e.g. '4.4.alpha1', '4.4.beta3', '4.4.0'
+   * @param null $currentVer
+   *
+   * @internal param string $postUpgradeMessage , alterable
    * @return void
    */
   function setPreUpgradeMessage(&$preUpgradeMessage, $rev, $currentVer = NULL) {
@@ -77,6 +80,8 @@ class CRM_Upgrade_Incremental_php_FourFive {
   /**
    * Add defaults for the newly introduced name fields configuration in 'contact_edit_options' setting
    *
+   * @param CRM_Queue_TaskContext $ctx
+   *
    * @return bool TRUE for success
    */
   static function addNameFieldOptions(CRM_Queue_TaskContext $ctx) {
@@ -105,7 +110,7 @@ class CRM_Upgrade_Incremental_php_FourFive {
   }
 
   /**
-   * Syntatic sugar for adding a task which (a) is in this class and (b) has
+   * Syntactic sugar for adding a task which (a) is in this class and (b) has
    * a high priority.
    *
    * After passing the $funcName, you can also pass parameters that will go to

--- a/CRM/Upgrade/Incremental/php/FourFour.php
+++ b/CRM/Upgrade/Incremental/php/FourFour.php
@@ -46,8 +46,11 @@ class CRM_Upgrade_Incremental_php_FourFour {
    * Note: This function is called iteratively for each upcoming
    * revision to the database.
    *
-   * @param $postUpgradeMessage string, alterable
+   * @param $preUpgradeMessage
    * @param $rev string, a version number, e.g. '4.4.alpha1', '4.4.beta3', '4.4.0'
+   * @param null $currentVer
+   *
+   * @internal param string $postUpgradeMessage , alterable
    * @return void
    */
   function setPreUpgradeMessage(&$preUpgradeMessage, $rev, $currentVer = NULL) {
@@ -296,7 +299,7 @@ ALTER TABLE civicrm_dashboard
   END;
     ";
     CRM_Core_DAO::executeQuery($query, array(), TRUE, NULL, FALSE, FALSE);
- 
+
     // CRM-13998 : missing alter statements for civicrm_report_instance
     $this->addTask(ts('Confirm civicrm_report_instance sql table for upgrades'), 'updateReportInstanceTable');
 
@@ -414,6 +417,8 @@ WHERE       source_contact_id IS NOT NULL";
   /**
    * Migrate word-replacements from $config to civicrm_word_replacement
    *
+   * @param CRM_Queue_TaskContext $ctx
+   *
    * @return bool TRUE for success
    * @see http://issues.civicrm.org/jira/browse/CRM-13187
    */
@@ -442,6 +447,9 @@ CREATE TABLE IF NOT EXISTS `civicrm_word_replacement` (
    * and bad configurations, we change the constraint name from "UI_find"
    * (the original name in 4.4.0) to "UI_domain_find" (the new name in
    * 4.4.1).
+   *
+   * @param CRM_Queue_TaskContext $ctx
+   * @param $rev
    *
    * @return bool TRUE for success
    * @see http://issues.civicrm.org/jira/browse/CRM-13655
@@ -565,13 +573,13 @@ CREATE TABLE IF NOT EXISTS `civicrm_word_replacement` (
     CRM_Core_BAO_WordReplacement::rebuild();
   }
 
-  
+
   /***
    * CRM-13998 missing alter statements for civicrm_report_instance
    ***/
   public function updateReportInstanceTable() {
 
-    // add civicrm_report_instance.name 
+    // add civicrm_report_instance.name
 
     $sql = "SELECT count(*) FROM information_schema.columns "
       . "WHERE table_schema = database() AND table_name = 'civicrm_report_instance' AND COLUMN_NAME = 'name' ";
@@ -583,7 +591,7 @@ CREATE TABLE IF NOT EXISTS `civicrm_word_replacement` (
       $res = CRM_Core_DAO::executeQuery($sql);
     }
 
-    // add civicrm_report_instance args 
+    // add civicrm_report_instance args
 
     $sql = "SELECT count(*) FROM information_schema.columns WHERE table_schema = database() AND table_name = 'civicrm_report_instance' AND COLUMN_NAME = 'args' ";
 

--- a/xml/schema/Core/MessageTemplate.xml
+++ b/xml/schema/Core/MessageTemplate.xml
@@ -84,18 +84,10 @@
   <field>
       <name>pdf_format_id</name>
       <type>int unsigned</type>
-      <comment>FK to civicrm_option_value containing PDF Page Format.</comment>
+      <comment>a pseudo-FK to civicrm_option_value containing PDF Page Format.</comment>
       <pseudoconstant>
         <optionGroupName>pdf_format</optionGroupName>
-        <keyColumn>id</keyColumn>
       </pseudoconstant>
       <add>3.4</add>
   </field>
-  <foreignKey>
-      <name>pdf_format_id</name>
-      <table>civicrm_option_value</table>
-      <key>id</key>
-      <onDelete>SET NULL</onDelete>
-      <add>3.4</add>
-  </foreignKey>
 </table>


### PR DESCRIPTION
@totten  - don't want to disturb you right now just for this - but what is best way to remove FK_civicrm_msg_template_pdf_format_id from civicrm_message_template in the upgrade script (feel free just to add as a commit :-))

I feel like there is special code around FKS. BTW - you DID introduce this bug - so you should help fix - it was in that really buggy commit you did with the message 'Import from svn'
