### PR TITLE
CRM-14489 - Removed protocol from language domain if it exists.

### DIFF
--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -863,8 +863,8 @@ AND    u.status = 1
         if ($urlType == LOCALE_LANGUAGE_NEGOTIATION_URL_DOMAIN) {
           if (isset($language->domain) && $language->domain) {
             if ($addLanguagePart) {
-              $cleaned_url = preg_replace('#^https?://#', '', $language->domain);
-              $url = (CRM_Utils_System::isSSL() ? 'https' : 'http') . '://' . $cleaned_url . base_path();
+              $cleanedUrl = preg_replace('#^https?://#', '', $language->domain);
+              $url = (CRM_Utils_System::isSSL() ? 'https' : 'http') . '://' . $cleanedUrl . base_path();
             }
             if ($removeLanguagePart && defined('CIVICRM_UF_BASEURL')) {
               $url = str_replace('\\', '/', $url);

--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -863,7 +863,8 @@ AND    u.status = 1
         if ($urlType == LOCALE_LANGUAGE_NEGOTIATION_URL_DOMAIN) {
           if (isset($language->domain) && $language->domain) {
             if ($addLanguagePart) {
-              $url = (CRM_Utils_System::isSSL() ? 'https' : 'http') . '://' . $language->domain . base_path();
+              $cleaned_url = preg_replace('#^https?://#', '', $language->domain);
+              $url = (CRM_Utils_System::isSSL() ? 'https' : 'http') . '://' . $cleaned_url . base_path();
             }
             if ($removeLanguagePart && defined('CIVICRM_UF_BASEURL')) {
               $url = str_replace('\\', '/', $url);


### PR DESCRIPTION
On a Drupal multilingual site if the "Language Domain" setting of the current Drupal locale contains the protocol then the function languageNegotiationURL in CRM_Utils_System_Drupal.php duplicates it.

Without this fix then for an input $url = "https://domain.com" and $language->domain = "https://domain.com" it will return "https://https://domain.com" 
