### PR TITLE
CRM-14528 http test returned 301 redirect to https://civicrm.org

### DIFF
--- a/tests/phpunit/CRM/Utils/HttpClientTest.php
+++ b/tests/phpunit/CRM/Utils/HttpClientTest.php
@@ -2,8 +2,8 @@
 require_once 'CiviTest/CiviUnitTestCase.php';
 class CRM_Utils_HttpClientTest extends CiviUnitTestCase {
 
-  const VALID_HTTP_URL = 'http://civicrm.org/INSTALL.mysql.txt';
-  const VALID_HTTP_REGEX = '/MySQL/';
+  const VALID_HTTP_URL = 'http://sandbox.civicrm.org/';
+  const VALID_HTTP_REGEX = '/<html/';
   const VALID_HTTPS_URL = 'https://civicrm.org/INSTALL.mysql.txt';
   const VALID_HTTPS_REGEX = '/MySQL/';
   const SELF_SIGNED_HTTPS_URL = 'https://self-signed.onebitwise.com:4443/';


### PR DESCRIPTION
---
- CRM-14528: CRM_Utils_HttpClientTest gets redirect instead of expected file
  https://issues.civicrm.org/jira/browse/CRM-14528
