### PR TITLE
CRM-14135: Making Custom Membership Fields in profiles apply to all purchased Memberships.

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -736,7 +736,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
           }
         }
       }
-
       $contactID = CRM_Contact_BAO_Contact::createProfileContact(
         $params,
         $fields,


### PR DESCRIPTION
The case here is that you can actually purchase multiple memberships using price sets. What was happening was happening is that only the last membership would actually get the custom field value while the others you purchased wouldn't.

Since we don't want to make a giant architecture change in how the form works and ask for a custom profile field for memberships for each membership, it seems a compromise of applying the single value to all memberships purchased will work and satisfy the use case in CRM-14135.
