### PR TITLE
CRM-14445: Updating the option_group table with an is_locked column

### DIFF
--- a/CRM/Admin/Page/Options.php
+++ b/CRM/Admin/Page/Options.php
@@ -73,6 +73,14 @@ class CRM_Admin_Page_Options extends CRM_Core_Page_Basic {
   static $_gId = NULL;
 
   /**
+   * A boolean determining if you can add options to this group in the GUI
+   *
+   * @var boolean
+   * @static
+   */
+  static $_isLocked = FALSE;
+
+  /**
    * Obtains the group name from url string or id from $_GET['gid'].
    * Sets the title.
    *
@@ -88,6 +96,7 @@ class CRM_Admin_Page_Options extends CRM_Core_Page_Basic {
     elseif (!self::$_gName && !empty($_GET['gid'])) {
       self::$_gId = $_GET['gid'];
       self::$_gName = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', self::$_gId, 'name');
+      self::$_isLocked = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', self::$_gId, 'is_locked');
       $breadCrumb = array(
         'title' => ts('Option Groups'),
         'url' => CRM_Utils_System::url('civicrm/admin/options', 'reset=1'),
@@ -147,6 +156,7 @@ class CRM_Admin_Page_Options extends CRM_Core_Page_Basic {
     if (self::$_gName == 'participant_role') {
       $this->assign('showCounted', TRUE);
     }
+    $this->assign('isLocked', self::$_isLocked);
     $config = CRM_Core_Config::singleton();
     if (self::$_gName == 'activity_type') {
       $this->assign('showComponent', TRUE);

--- a/CRM/Upgrade/Incremental/sql/4.5.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.5.alpha1.mysql.tpl
@@ -273,3 +273,8 @@ ALTER TABLE `civicrm_mail_settings`
 ALTER TABLE `civicrm_mailing`
   ADD COLUMN `hash` varchar(16) COLLATE utf8_unicode_ci DEFAULT NULL COMMENT 'Key for validating requests related to this mailing.',
   ADD INDEX `index_hash` (`hash`);
+
+-- CRM-14445
+ALTER TABLE `civicrm_option_group`
+  ADD COLUMN `is_locked` int(1) DEFAULT 0 COMMENT 'A lock to remove the ability to add new options via the UI';
+UPDATE `civicrm_option_group` SET is_locked = 1 WHERE name = 'contribution_status';

--- a/templates/CRM/Admin/Page/Options.tpl
+++ b/templates/CRM/Admin/Page/Options.tpl
@@ -70,7 +70,7 @@
 
 <div class="crm-content-block crm-block">
 {if $rows}
-{if $action ne 1 and $action ne 2}
+{if $action ne 1 and $action ne 2 and $isLocked ne 1}
     <div class="action-link">
         <a href="{crmURL p="civicrm/admin/options/$gName" q='action=add&reset=1'}" class="button new-option"><span><div class="icon add-icon"></div>{ts 1=$gLabel}Add %1{/ts}</span></a>
     </div>
@@ -153,7 +153,7 @@
         {include file="CRM/common/crmeditable.tpl"}
         {/strip}
 
-        {if $action ne 1 and $action ne 2}
+        {if $action ne 1 and $action ne 2 and $isLocked ne 1}
             <div class="action-link">
                 <a href="{crmURL p="civicrm/admin/options/$gName" q='action=add&reset=1'}" class="button new-option"><span><div class="icon add-icon"></div>{ts 1=$gLabel}Add %1{/ts}</span></a>
             </div>


### PR DESCRIPTION
This is to add discouragement from updating certain option sets via the UI. In this case we are doing it for contribution Statuses.
