### PR TITLE
CRM-14411 - Fix PHP notice caused by static calls to non-static methods.

### DIFF
--- a/CRM/Financial/Page/AJAX.php
+++ b/CRM/Financial/Page/AJAX.php
@@ -43,7 +43,7 @@ class CRM_Financial_Page_AJAX {
    * $financialAccountType array with key account relationship and value financial account type option groups
    *
    */
-  function jqFinancial($config) {
+  static function jqFinancial($config) {
     if (!isset($_GET['_value']) ||
       empty($_GET['_value'])) {
       CRM_Utils_System::civiExit();
@@ -91,7 +91,7 @@ class CRM_Financial_Page_AJAX {
     CRM_Utils_System::civiExit();
   }
 
-  function jqFinancialRelation($config) {
+  static function jqFinancialRelation($config) {
     if (!isset($_GET['_value']) ||
       empty($_GET['_value'])) {
       CRM_Utils_System::civiExit();
@@ -148,7 +148,7 @@ class CRM_Financial_Page_AJAX {
     CRM_Utils_System::civiExit();
   }
 
-  function jqFinancialType($config) {
+  static function jqFinancialType($config) {
     if (! isset($_GET['_value']) ||
       empty($_GET['_value'])) {
       CRM_Utils_System::civiExit();


### PR DESCRIPTION
Fix PHP notice caused by static calls to non-static methods. See comments on issue for how to reproduce.
