### PR TITLE
implemented patch and fixed bulk email name change possibility

### DIFF
--- a/CRM/Activity/BAO/Query.php
+++ b/CRM/Activity/BAO/Query.php
@@ -58,7 +58,8 @@ class CRM_Activity_BAO_Query {
     }
 
     if (!empty($query->_returnProperties['activity_type'])) {
-      $query->_select['activity_type'] = "activity_type.label as activity_type";
+      $query->_select['activity_type'] = "activity_type.label as activity_type,
+        civicrm_activity.activity_type_id as activity_type_id";
       $query->_element['activity_type'] = 1;
       $query->_tables['civicrm_activity'] = 1;
       $query->_tables['activity_type'] = 1;
@@ -538,6 +539,7 @@ class CRM_Activity_BAO_Query {
         'sort_name' => 1,
         'display_name' => 1,
         'activity_type' => 1,
+        'activity_type_id' => 1,
         'activity_subject' => 1,
         'activity_date_time' => 1,
         'activity_duration' => 1,

--- a/CRM/Activity/Selector/Search.php
+++ b/CRM/Activity/Selector/Search.php
@@ -252,6 +252,8 @@ class CRM_Activity_Selector_Search extends CRM_Core_Selector_Base implements CRM
     $sourceID = CRM_Utils_Array::key('Activity Source', $activityContacts);
     $assigneeID = CRM_Utils_Array::key('Activity Assignees', $activityContacts);
     $targetID = CRM_Utils_Array::key('Activity Targets', $activityContacts);
+    //get all activity types
+    $activityTypes = CRM_Core_PseudoConstant::activityType(TRUE, TRUE, FALSE, 'name', TRUE);    
 
     while ($result->fetch()) {
       $row = array();
@@ -286,12 +288,11 @@ class CRM_Activity_Selector_Search extends CRM_Core_Selector_Base implements CRM
         $result->contact_sub_type : $result->contact_type, FALSE, $result->contact_id
       );
       $accessMailingReport = FALSE;
-      $activityType        = CRM_Core_PseudoConstant::activityType(TRUE, TRUE, FALSE, 'label', TRUE);
-      $activityTypeId      = CRM_Utils_Array::key($row['activity_type'], $activityType);
+      $activityTypeId      = $row['activity_type_id'];
       if ($row['activity_is_test']) {
         $row['activity_type'] = $row['activity_type'] . " (test)";
       }
-      $bulkActivityTypeID = CRM_Utils_Array::key('Bulk Email', CRM_Core_PseudoConstant::activityType(TRUE, TRUE, FALSE, 'name', TRUE));
+      $bulkActivityTypeID = CRM_Utils_Array::key('Bulk Email', $activityTypes);
       $row['mailingId'] = '';
       if (
         $accessCiviMail &&

--- a/CRM/Activity/Selector/Search.php
+++ b/CRM/Activity/Selector/Search.php
@@ -286,12 +286,12 @@ class CRM_Activity_Selector_Search extends CRM_Core_Selector_Base implements CRM
         $result->contact_sub_type : $result->contact_type, FALSE, $result->contact_id
       );
       $accessMailingReport = FALSE;
-      $activityType        = CRM_Core_PseudoConstant::activityType(TRUE, TRUE, FALSE, 'name', TRUE);
+      $activityType        = CRM_Core_PseudoConstant::activityType(TRUE, TRUE, FALSE, 'label', TRUE);
       $activityTypeId      = CRM_Utils_Array::key($row['activity_type'], $activityType);
       if ($row['activity_is_test']) {
         $row['activity_type'] = $row['activity_type'] . " (test)";
       }
-      $bulkActivityTypeID = CRM_Utils_Array::key('Bulk Email', $activityType);
+      $bulkActivityTypeID = CRM_Utils_Array::key('Bulk Email', CRM_Core_PseudoConstant::activityType(TRUE, TRUE, FALSE, 'name', TRUE));
       $row['mailingId'] = '';
       if (
         $accessCiviMail &&


### PR DESCRIPTION
Change the call to look for the "label" instead of "name" which was suggested in the patch. Also fixed the issue of the "bulk email" activity being renamed. The bulk email id is now getting made based on the orginal name of the activity and not the rename.
