### PR TITLE
Fix JMS metadata complaining of no date class.

### DIFF
--- a/CRM/Core/CodeGen/EntitySpecification.php
+++ b/CRM/Core/CodeGen/EntitySpecification.php
@@ -6,6 +6,9 @@
 class CRM_Core_CodeGen_EntitySpecification {
   public $tables;
   public $database;
+  public static $phpTypeToJmsType = array(
+    'date' => 'datetime',
+  );
 
   protected $classNames;
 
@@ -255,7 +258,7 @@ class CRM_Core_CodeGen_EntitySpecification {
 
       $field['columnType'] = $field['phpType'];
 
-      $field['jmsType'] = '@JMS\Type("' . $field['phpType'] . '")';
+      $field['jmsType'] = '@JMS\Type("' . CRM_Utils_Array::value($field['phpType'], static::$phpTypeToJmsType, $field['phpType']) . '")';
 
       $field['columnJoin'] = '';
 

--- a/Civi/ACL/Cache.php
+++ b/Civi/ACL/Cache.php
@@ -84,7 +84,7 @@ class Cache extends \Civi\Core\Entity {
   /**
    * @var date
    *
-   * @JMS\Type("date")
+   * @JMS\Type("datetime")
    * @ORM\Column(name="modified_date", type="date", nullable=true)
    * 
    */

--- a/Civi/CCase/CCase.php
+++ b/Civi/CCase/CCase.php
@@ -84,7 +84,7 @@ class CCase extends \Civi\Core\Entity {
   /**
    * @var date
    *
-   * @JMS\Type("date")
+   * @JMS\Type("datetime")
    * @ORM\Column(name="start_date", type="date", nullable=true)
    * 
    */
@@ -93,7 +93,7 @@ class CCase extends \Civi\Core\Entity {
   /**
    * @var date
    *
-   * @JMS\Type("date")
+   * @JMS\Type("datetime")
    * @ORM\Column(name="end_date", type="date", nullable=true)
    * 
    */

--- a/Civi/Contact/Contact.php
+++ b/Civi/Contact/Contact.php
@@ -417,7 +417,7 @@ class Contact extends \Civi\Core\Entity {
   /**
    * @var date
    *
-   * @JMS\Type("date")
+   * @JMS\Type("datetime")
    * @ORM\Column(name="birth_date", type="date", nullable=true)
    * 
    */
@@ -435,7 +435,7 @@ class Contact extends \Civi\Core\Entity {
   /**
    * @var date
    *
-   * @JMS\Type("date")
+   * @JMS\Type("datetime")
    * @ORM\Column(name="deceased_date", type="date", nullable=true)
    * 
    */

--- a/Civi/Contact/Relationship.php
+++ b/Civi/Contact/Relationship.php
@@ -93,7 +93,7 @@ class Relationship extends \Civi\Core\Entity {
   /**
    * @var date
    *
-   * @JMS\Type("date")
+   * @JMS\Type("datetime")
    * @ORM\Column(name="start_date", type="date", nullable=true)
    * 
    */
@@ -102,7 +102,7 @@ class Relationship extends \Civi\Core\Entity {
   /**
    * @var date
    *
-   * @JMS\Type("date")
+   * @JMS\Type("datetime")
    * @ORM\Column(name="end_date", type="date", nullable=true)
    * 
    */

--- a/Civi/Contribute/ContributionProduct.php
+++ b/Civi/Contribute/ContributionProduct.php
@@ -102,7 +102,7 @@ class ContributionProduct extends \Civi\Core\Entity {
   /**
    * @var date
    *
-   * @JMS\Type("date")
+   * @JMS\Type("datetime")
    * @ORM\Column(name="fulfilled_date", type="date", nullable=true)
    * 
    */
@@ -111,7 +111,7 @@ class ContributionProduct extends \Civi\Core\Entity {
   /**
    * @var date
    *
-   * @JMS\Type("date")
+   * @JMS\Type("datetime")
    * @ORM\Column(name="start_date", type="date", nullable=true)
    * 
    */
@@ -120,7 +120,7 @@ class ContributionProduct extends \Civi\Core\Entity {
   /**
    * @var date
    *
-   * @JMS\Type("date")
+   * @JMS\Type("datetime")
    * @ORM\Column(name="end_date", type="date", nullable=true)
    * 
    */

--- a/Civi/Core/ActionSchedule.php
+++ b/Civi/Core/ActionSchedule.php
@@ -309,7 +309,7 @@ class ActionSchedule extends \Civi\Core\Entity {
   /**
    * @var date
    *
-   * @JMS\Type("date")
+   * @JMS\Type("datetime")
    * @ORM\Column(name="absolute_date", type="date", nullable=true)
    * 
    */

--- a/Civi/Core/Discount.php
+++ b/Civi/Core/Discount.php
@@ -93,7 +93,7 @@ class Discount extends \Civi\Core\Entity {
   /**
    * @var date
    *
-   * @JMS\Type("date")
+   * @JMS\Type("datetime")
    * @ORM\Column(name="start_date", type="date", nullable=true)
    * 
    */
@@ -102,7 +102,7 @@ class Discount extends \Civi\Core\Entity {
   /**
    * @var date
    *
-   * @JMS\Type("date")
+   * @JMS\Type("datetime")
    * @ORM\Column(name="end_date", type="date", nullable=true)
    * 
    */

--- a/Civi/Core/Note.php
+++ b/Civi/Core/Note.php
@@ -102,7 +102,7 @@ class Note extends \Civi\Core\Entity {
   /**
    * @var date
    *
-   * @JMS\Type("date")
+   * @JMS\Type("datetime")
    * @ORM\Column(name="modified_date", type="date", nullable=true)
    * 
    */

--- a/Civi/Grant/Grant.php
+++ b/Civi/Grant/Grant.php
@@ -75,7 +75,7 @@ class Grant extends \Civi\Core\Entity {
   /**
    * @var date
    *
-   * @JMS\Type("date")
+   * @JMS\Type("datetime")
    * @ORM\Column(name="application_received_date", type="date", nullable=true)
    * 
    */
@@ -84,7 +84,7 @@ class Grant extends \Civi\Core\Entity {
   /**
    * @var date
    *
-   * @JMS\Type("date")
+   * @JMS\Type("datetime")
    * @ORM\Column(name="decision_date", type="date", nullable=true)
    * 
    */
@@ -93,7 +93,7 @@ class Grant extends \Civi\Core\Entity {
   /**
    * @var date
    *
-   * @JMS\Type("date")
+   * @JMS\Type("datetime")
    * @ORM\Column(name="money_transfer_date", type="date", nullable=true)
    * 
    */
@@ -102,7 +102,7 @@ class Grant extends \Civi\Core\Entity {
   /**
    * @var date
    *
-   * @JMS\Type("date")
+   * @JMS\Type("datetime")
    * @ORM\Column(name="grant_due_date", type="date", nullable=true)
    * 
    */

--- a/Civi/Member/Membership.php
+++ b/Civi/Member/Membership.php
@@ -84,7 +84,7 @@ class Membership extends \Civi\Core\Entity {
   /**
    * @var date
    *
-   * @JMS\Type("date")
+   * @JMS\Type("datetime")
    * @ORM\Column(name="join_date", type="date", nullable=true)
    * 
    */
@@ -93,7 +93,7 @@ class Membership extends \Civi\Core\Entity {
   /**
    * @var date
    *
-   * @JMS\Type("date")
+   * @JMS\Type("datetime")
    * @ORM\Column(name="start_date", type="date", nullable=true)
    * 
    */
@@ -102,7 +102,7 @@ class Membership extends \Civi\Core\Entity {
   /**
    * @var date
    *
-   * @JMS\Type("date")
+   * @JMS\Type("datetime")
    * @ORM\Column(name="end_date", type="date", nullable=true)
    * 
    */

--- a/Civi/Member/MembershipLog.php
+++ b/Civi/Member/MembershipLog.php
@@ -84,7 +84,7 @@ class MembershipLog extends \Civi\Core\Entity {
   /**
    * @var date
    *
-   * @JMS\Type("date")
+   * @JMS\Type("datetime")
    * @ORM\Column(name="start_date", type="date", nullable=true)
    * 
    */
@@ -93,7 +93,7 @@ class MembershipLog extends \Civi\Core\Entity {
   /**
    * @var date
    *
-   * @JMS\Type("date")
+   * @JMS\Type("datetime")
    * @ORM\Column(name="end_date", type="date", nullable=true)
    * 
    */
@@ -111,7 +111,7 @@ class MembershipLog extends \Civi\Core\Entity {
   /**
    * @var date
    *
-   * @JMS\Type("date")
+   * @JMS\Type("datetime")
    * @ORM\Column(name="modified_date", type="date", nullable=true)
    * 
    */

--- a/Civi/SMS/History.php
+++ b/Civi/SMS/History.php
@@ -84,7 +84,7 @@ class History extends \Civi\Core\Entity {
   /**
    * @var date
    *
-   * @JMS\Type("date")
+   * @JMS\Type("datetime")
    * @ORM\Column(name="sent_date", type="date", nullable=true)
    * 
    */


### PR DESCRIPTION
The JMS metadata library currently used to handle serialization for the new
REST API was erroring out on fields that are set as a date class as the
metadata library has no date class. To fix this, I've modified the code that
generates the JMS metadata for determining which class to use for a field to
set the JMS type to datetime if the php type is set to date, which corrects
the problem.
