### PR TITLE
Fixed CRM-14545. "Contribution Amounts Label" is respected even when used for memberships.

### DIFF
--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -295,9 +295,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
           $extra = array('onclick' => 'useAmountOther();');
         }
 
-        // if seperate membership payment is used with quick config priceset then change the other amount label
         if (!empty($qf->_membershipBlock) && !empty($qf->_quickConfig) && $field->name == 'other_amount' && empty($qf->_contributionAmount)) {
-          $label = ts('Additional Contribution');
           $useRequired = 0;
         }
         elseif (!empty($fieldOptions[$optionKey]['label'])) {      //check for label.


### PR DESCRIPTION
---
- CRM-14545: Contribution page does not respect "Contribution Amounts Label" when page is also used for memberships
  https://issues.civicrm.org/jira/browse/CRM-14545
