### PR TITLE
CRM-14171: Give configuration warning if Anonymous role is granted inappropriate permissions

### DIFF
--- a/CRM/ACL/Form/WordPress/Permissions.php
+++ b/CRM/ACL/Form/WordPress/Permissions.php
@@ -143,7 +143,7 @@ class CRM_ACL_Form_WordPress_Permissions extends CRM_Core_Form {
         }
         if (!empty($warningPermissionNames)) {
           CRM_Core_Session::setStatus(
-            ts('The %1 role was assigned one or more permission that may prove dangerous for users of that role to have. Please reconsider assigning %2 to them.', array( 1 => $wp_roles->role_names[$role], 2 => implode(', ', $warningPermissionNames))),
+            ts('The %1 role was assigned one or more permissions that may prove dangerous for users of that role to have. Please reconsider assigning %2 to them.', array( 1 => $wp_roles->role_names[$role], 2 => implode(', ', $warningPermissionNames))),
             ts('Unsafe Permission Settings')
           );
         }

--- a/CRM/ACL/Form/WordPress/Permissions.php
+++ b/CRM/ACL/Form/WordPress/Permissions.php
@@ -129,6 +129,25 @@ class CRM_ACL_Form_WordPress_Permissions extends CRM_Core_Form {
           $roleObj->add_cap($key);
         }
       }
+
+      if ($role == 'anonymous_user') {
+        // Get the permissions into a format that matches what we get from WP
+        $allWarningPermissions = CRM_Core_Permission::getAnonymousPermissionsWarnings();
+        foreach ($allWarningPermissions  as $key => $permission) {
+          $allWarningPermissions[$key] = CRM_utils_String::munge(strtolower($permission));
+        }
+        $warningPermissions = array_intersect($allWarningPermissions, array_keys($rolePermissions));
+        $warningPermissionNames = array();
+        foreach ($warningPermissions as $permission) {
+          $warningPermissionNames[$permission] = $permissionsArray[$permission];
+        }
+        if (!empty($warningPermissionNames)) {
+          CRM_Core_Session::setStatus(
+            ts('The %1 role was assigned one or more permission that may prove dangerous for users of that role to have. Please reconsider assigning %2 to them.', array( 1 => $wp_roles->role_names[$role], 2 => implode(', ', $warningPermissionNames))),
+            ts('Unsafe Permission Settings')
+          );
+        }
+      }
     }
 
     // FIXME
@@ -170,4 +189,3 @@ class CRM_ACL_Form_WordPress_Permissions extends CRM_Core_Form {
     return $perms_array;
   }
 }
-

--- a/CRM/Contribute/Info.php
+++ b/CRM/Contribute/Info.php
@@ -62,6 +62,11 @@ class CRM_Contribute_Info extends CRM_Core_Component_Info {
     );
   }
 
+  public function getAnonymousPermissionWarnings() {
+    return array(
+      'access CiviContribute',
+    );
+  }
 
   // docs inherited from interface
   public function getUserDashboardElement() {

--- a/CRM/Core/Component/Info.php
+++ b/CRM/Core/Component/Info.php
@@ -137,6 +137,16 @@ abstract class CRM_Core_Component_Info {
   }
 
   /**
+   * Provides permissions that are unwise for Anonymous Roles to have
+   *
+   * @return array list of permissions
+   * @see CRM_Component_Info::getPermissions
+   */
+  public function getAnonymousPermissionWarnings() {
+    return array();
+  }
+
+  /**
    * Provides permissions that are used by component.
    * Needs to be implemented in component's information
    * class.

--- a/CRM/Event/Info.php
+++ b/CRM/Event/Info.php
@@ -64,6 +64,12 @@ class CRM_Event_Info extends CRM_Core_Component_Info {
     );
   }
 
+  public function getAnonymousPermissionWarnings() {
+    return array(
+      'access CiviEvent',
+    );
+  }
+
   // docs inherited from interface
   public function getUserDashboardElement() {
     return array('name' => ts('Events'),


### PR DESCRIPTION
Basically this is both Word Press and the base layout for this implementation. WordPress's Access Control is managed by CiviCRM. We will warn the user after they submit the form just to let them know that what they are doing is allowed but most likely is wrong.

![screenshot](http://content.screencast.com/users/talkitivewizard/folders/Jing/media/81e91406-507e-4ab9-8fd5-29d3c22f3d58/00000165.png)
