### PR TITLE
Fix doctrine handling of UTF-8 fields.

### DIFF
--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -159,6 +159,8 @@ class Container {
   public function createEntityManager($config) {
     $dbSettings = new \CRM_DB_Settings();
     $em = EntityManager::create($dbSettings->toDoctrineArray(), $config);
+    $event_manager = $em->getEventManager();
+    $event_manager->addEventSubscriber(new \Doctrine\DBAL\Event\Listeners\MysqlSessionInit('utf8', 'utf8_unicode_ci'));
     return $em;
   }
 


### PR DESCRIPTION
We ran into an issue using the new REST API where some records weren't
returning due to incorrect encoding. It turned out that the field values for
the doctrine objects being returned weren't properly encoded for UTF-8.  This
commit fixes that.
