### PR TITLE
CRM-14500 Fix related to reminder sent on merging Contacts

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -222,6 +222,7 @@ class CRM_Dedupe_Merger {
         'civicrm_uf_match' => array('contact_id'),
         'civicrm_uf_group' => array('created_id'),
         'civicrm_pledge' => array('contact_id'),
+        'civicrm_action_log' => array('contact_id'),
       );
 
       $cidRefs += self::getMultiValueCustomSets('cidRefs');


### PR DESCRIPTION
---
- CRM-14500: Some references to old contact aren't being updated when merging contacts
  https://issues.civicrm.org/jira/browse/CRM-14500
