### PR TITLE
CRM-11801 - authnet sending receipt should be configurable.

### DIFF
--- a/CRM/Core/Payment/AuthorizeNet.php
+++ b/CRM/Core/Payment/AuthorizeNet.php
@@ -55,7 +55,8 @@ class CRM_Core_Payment_AuthorizeNet extends CRM_Core_Payment {
     $this->_setParam('paymentType', 'AIM');
     $this->_setParam('md5Hash', $paymentProcessor['signature']);
 
-    $this->_setParam('emailCustomer', 'TRUE');
+    $emailCustomer = CRM_Core_BAO_Setting::getItem('CiviCRM Preferences', 'authnet_email_receipt', NULL, TRUE); 
+    $this->_setParam('emailCustomer', $emailCustomer);
     $this->_setParam('timestamp', time());
     srand(time());
     $this->_setParam('sequence', rand(1, 1000));


### PR DESCRIPTION
This is the first step toward a more complete solution: allows us
to set whether or not sending a receipt should override the
authnet setting by placing a line in civicrm.settings.php.

---
- CRM-11801: Authorize.net sending 2 receipts
  https://issues.civicrm.org/jira/browse/CRM-11801
