### PR TITLE
CRM-11801 - allow user to *not* override authnet's setting on sending re...

### DIFF
--- a/CRM/Core/Payment/AuthorizeNet.php
+++ b/CRM/Core/Payment/AuthorizeNet.php
@@ -55,7 +55,8 @@ class CRM_Core_Payment_AuthorizeNet extends CRM_Core_Payment {
     $this->_setParam('paymentType', 'AIM');
     $this->_setParam('md5Hash', $paymentProcessor['signature']);
 
-    $this->_setParam('emailCustomer', 'TRUE');
+    $emailCustomer = CRM_Core_BAO_Setting::getItem('CiviCRM Preferences', 'authnet_email_receipt_override', NULL, TRUE);
+    $this->_setParam('emailCustomer', $emailCustomer);
     $this->_setParam('timestamp', time());
     srand(time());
     $this->_setParam('sequence', rand(1, 1000));
@@ -347,7 +348,9 @@ class CRM_Core_Payment_AuthorizeNet extends CRM_Core_Payment {
     $fields = array();
     $fields['x_login'] = $this->_getParam('apiLogin');
     $fields['x_tran_key'] = $this->_getParam('paymentKey');
-    $fields['x_email_customer'] = $this->_getParam('emailCustomer');
+    if($this->_getParam('emailCustomer')) {
+      $fields['x_email_customer'] = $this->_getParam('emailCustomer');
+    }
     $fields['x_first_name'] = $this->_getParam('billing_first_name');
     $fields['x_last_name'] = $this->_getParam('billing_last_name');
     $fields['x_address'] = $this->_getParam('street_address');


### PR DESCRIPTION
...ceipt

With this setting in place, you can add the following to
civicrm.settings.php to use the receipt sending configuration of
authnet. That way you can configure authnet _not_ to send receipt if you
want. Otherwise, civicrm will always instruct authnet to send receipts.

global $civicrm_setting;
$civicrm_setting["CiviCRM Preferences"]["authnet_email_receipt_override"] = FALSE;

---
- CRM-11801: Authorize.net sending 2 receipts
  https://issues.civicrm.org/jira/browse/CRM-11801
