### PR TITLE
CRM-14470 - Prevent users from adding two 'is_primary' fields of the same field type

### DIFF
--- a/CRM/UF/Form/Field.php
+++ b/CRM/UF/Form/Field.php
@@ -714,7 +714,7 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
   }
 
   /**
-   * validation rule to prevent multiple fields of primary location type and the same communication type.
+   * Validation rule to prevent multiple fields of primary location type within the same communication type.
    *
    * @param Array   $fields            Submitted fields
    * @param String  $profileFieldName  Group Id.
@@ -729,6 +729,7 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
     $checkPrimary = array('phone' => 'civicrm_phone.phone', 'phone_and_ext' => 'civicrm_phone.phone');
     $whereCheck = NULL;
     $primaryOfSameTypeFound = NULL;
+    $fieldID = empty($fields['field_id']) ? 0 : $fields['field_id'];
     // Is this a primary location type field of interest
     if (array_key_exists($profileFieldName, $checkPrimary)) {
       $whereCheck = $checkPrimary[$profileFieldName];
@@ -740,8 +741,9 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
 
       foreach ($groupFields as $groupField) {
         // if it is a phone
-        if ($groupField['where'] == $whereCheck && is_null($groupField['location_type_id'])) {
+        if ($groupField['where'] == $whereCheck && is_null($groupField['location_type_id']) && $groupField['field_id']  != $fieldID) {
           $primaryOfSameTypeFound = $groupField['title'];
+          break;
         }
       }
       if ($primaryOfSameTypeFound) {
@@ -813,9 +815,7 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
     // Get list of fields already in the group
     $groupFields = CRM_Core_BAO_UFGroup::getFields($fields['group_id'], FALSE, NULL, NULL, NULL, TRUE, NULL, TRUE);
     // Check if we already added a primary field of the same communication type
-    if (empty($fields['field_id'])) {
-      self::formRulePrimaryCheck($fields, $profileFieldName, $groupFields, $errors);
-    }
+    self::formRulePrimaryCheck($fields, $profileFieldName, $groupFields, $errors);
 
     //check profile is configured for double option process
     //adding group field, email field should be present in the group

--- a/templates/CRM/UF/Form/Field.hlp
+++ b/templates/CRM/UF/Form/Field.hlp
@@ -1,3 +1,18 @@
+{htxt id='field_name_0-title'}
+{ts}Field Name{/ts}
+{/htxt}
+{htxt id='field_name_0'}
+  {capture assign="ltURL"}{crmURL p="civicrm/admin/locationType" q="reset=1"}{/capture}
+  <p>
+    {ts}Choose the field to add to the profile.{/ts}<br/>
+    <strong>{ts}Restrictions:{/ts}</strong><br/>
+    {ts}Only one field of each communication type (EG. phone) can use the primary location type.{/ts}
+  </p>
+  <p>
+    {ts 1=$ltURL}When you choose the primary location type the collected data will use the default location type from the <a href="%1">Location types</a> setup.{/ts}
+  </p>
+{/htxt}
+
 {htxt id='label-title'}
   {ts}Field Label{/ts}
 {/htxt}

--- a/templates/CRM/UF/Form/Field.tpl
+++ b/templates/CRM/UF/Form/Field.tpl
@@ -34,7 +34,7 @@
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
   <table class="form-layout-compressed">
     <tr class="crm-uf-field-form-block-field_name">
-      <td class="label">{$form.field_name.label}</td>
+      <td class="label">{$form.field_name.label} {help id='field_name_0'}</td>
       <td>{$form.field_name.html}<br />
         <span class="description">&nbsp;{ts}Select the type of CiviCRM record and the field you want to include in this Profile.{/ts}</span></td>
     </tr>


### PR DESCRIPTION
Prevent users from adding two fields of the same field type (eg. phone) with location type 'is_primary'.
