### PR TITLE
Fix query for mariadb

### DIFF
--- a/CRM/Event/BAO/Query.php
+++ b/CRM/Event/BAO/Query.php
@@ -378,9 +378,9 @@ class CRM_Event_BAO_Query {
             ' ' .
             implode(' ' . ts('or') . ' ', $names);
           $query->_where[$grouping][] =
-            " civicrm_participant.role_id REGEXP '[[:<:]]" .
-            implode('[[:>:]]|[[:<:]]', array_keys($val)) .
-            "[[:>:]]' ";
+            " civicrm_participant.role_id REGEXP '\\b" .
+            implode('\\b|\\b', array_keys($val)) .
+            "\\b' ";
 
           $query->_tables['civicrm_participant'] =
             $query->_whereTables['civicrm_participant'] = 1;


### PR DESCRIPTION
Mariadb's regex library doesn't support the [[:>:]] tokens so use \b instead.
