### PR TITLE
Use TCPDF from within Create PDF Letter action

### DIFF
--- a/CRM/Contact/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contact/Form/Task/PDFLetterCommon.php
@@ -179,6 +179,16 @@ class CRM_Contact_Form_Task_PDFLetterCommon {
         NULL,
         FALSE
       );
+          
+       if ($form->_caseId) {
+         $ccid = CRM_Core_DAO::getFieldValue('CRM_Case_DAO_CaseContact', $form->_caseId,
+           'contact_id', 'case_id'
+         );
+         $cancelURL = CRM_Utils_System::url('civicrm/contact/view/case',
+           "&reset=1&action=view&cid={$ccid}&id={$form->_caseId}"
+         );
+       }
+ 
       if ($form->get('action') == CRM_Core_Action::VIEW) {
         $form->addButtons(array(
             array(
@@ -435,6 +445,15 @@ class CRM_Contact_Form_Task_PDFLetterCommon {
       );
       CRM_Activity_BAO_ActivityContact::create($activityTargetParams);
     }
+       
+    if (isset($form->_caseId) && is_numeric($form->_caseId)) {
+       // if case-id is found the file the activity on the case
+       $caseParams = array(
+         'activity_id' => empty($activity->id) ? $activityIds[$contactId] : $activity->id,
+         'case_id' => $form->_caseId,
+       );
+       CRM_Case_BAO_Case::processCaseActivity($caseParams);
+     }
   }
 
   static function formatMessage(&$message) {

--- a/CRM/Contact/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contact/Form/Task/PDFLetterCommon.php
@@ -104,6 +104,7 @@ class CRM_Contact_Form_Task_PDFLetterCommon {
       FALSE,
       array('onChange' => "selectPaper( this.value ); showUpdateFormatChkBox();")
     );
+    
     $form->add('static', 'paper_dimensions', NULL, ts('Width x Height'));
     $form->add(
       'select',
@@ -149,6 +150,18 @@ class CRM_Contact_Form_Task_PDFLetterCommon {
       array('size' => 8, 'maxlength' => 8, 'onkeyup' => "showUpdateFormatChkBox();"),
       TRUE
     );
+    
+    $config = CRM_Core_Config::singleton();
+     if ($config->wkhtmltopdfPath == false) {
+    $form->add(
+      'text',
+      'stationery',
+      ts('Stationery (relative path to PDF you wish to use as the background)'),
+      array('size' => 25, 'maxlength' => 900, 'onkeyup' => "showUpdateFormatChkBox();"),
+      FALSE
+    );
+    }
+    
     $form->add('checkbox', 'bind_format', ts('Always use this Page Format with the selected Template'));
     $form->add('checkbox', 'update_format', ts('Update Page Format (this will affect all templates that use this format)'));
 
@@ -464,4 +477,3 @@ class CRM_Contact_Form_Task_PDFLetterCommon {
     $message = implode($newLineOperators['p']['oper'], $htmlMsg);
   }
 }
-

--- a/CRM/Core/BAO/PdfFormat.php
+++ b/CRM/Core/BAO/PdfFormat.php
@@ -53,6 +53,11 @@ class CRM_Core_BAO_PdfFormat extends CRM_Core_DAO_OptionValue {
       'type' => CRM_Utils_Type::T_STRING,
       'default' => 'letter',
     ),
+    'stationery' => array(
+       'name' => 'stationery',
+       'type' =>CRM_Utils_Type::T_STRING,
+       'default' => '',
+    ),
     'orientation' => array(
       'name' => 'orientation',
       'type' => CRM_Utils_Type::T_STRING,

--- a/CRM/Utils/PDF/Utils.php
+++ b/CRM/Utils/PDF/Utils.php
@@ -62,6 +62,14 @@ class CRM_Utils_PDF_Utils {
     $r           = CRM_Core_BAO_PdfFormat::getValue('margin_right', $format);
     $b           = CRM_Core_BAO_PdfFormat::getValue('margin_bottom', $format);
     $l           = CRM_Core_BAO_PdfFormat::getValue('margin_left', $format);
+    $stationery_path_partial  = CRM_Core_BAO_PdfFormat::getValue('stationery', $format);
+     
+   
+    if( strlen(  $stationery_path_partial)) {
+	    $doc_root = $_SERVER['DOCUMENT_ROOT'];
+	    $stationery_path = $doc_root."/".$stationery_path_partial; 
+	    
+	    }
     $margins     = array($metric,$t,$r,$b,$l);
 
     $config = CRM_Core_Config::singleton();
@@ -101,8 +109,60 @@ class CRM_Utils_PDF_Utils {
       return self::_html2pdf_wkhtmltopdf($paper_size, $orientation, $margins, $html, $output, $fileName);
     }
     else {
-      return self::_html2pdf_dompdf($paper_size, $orientation, $html, $output, $fileName);
+   //   return self::_html2pdf_dompdf($paper_size, $orientation, $html, $output, $fileName);
+      
+      return self::_html2pdf_tcpdf($paper_size, $orientation, $margins, $html, $output, $fileName,  $stationery_path);
     }
+  }
+
+  static function _html2pdf_tcpdf($paper_size, $orientation, $margins, $html, $output, $fileName, $stationery_path) {
+    // Documentation on the TCPDF library can be found at: http://www.tcpdf.org
+    // This function also uses the FPDI library documented at: http://www.setasign.com/products/fpdi/about/
+    // Syntax borrowed from https://github.com/jake-mw/CDNTaxReceipts/blob/master/cdntaxreceipts.functions.inc
+    require_once 'tcpdf/tcpdf.php';
+    require_once('FPDI/fpdi.php'); // This library is only in the 'packages' area as of version 4.5
+    require_once('FPDF.php'); 
+    
+    $paper_size_arr  = array( $paper_size[2], $paper_size[3]);
+   
+ // print_r(  $paper_size_arr ); 
+  $pdf = new FPDF($orientation, 'pt', $paper_size_arr, 'UTF-8', FALSE);
+  $pdf->Open();
+  
+ 
+  
+  if (is_readable($stationery_path)){
+   $pdf->SetStationery( $stationery_path ) ; 
+   }
+   
+  $pdf->SetAuthor('');
+  $pdf->SetKeywords('CiviCRM.org'); 
+  $pdf->setPageUnit( $margins[0] ) ;  
+  $pdf->SetMargins($margins[4], $margins[1], $margins[2], true);
+
+  $pdf->setJPEGQuality('100');
+  $pdf->SetAutoPageBreak(true, $margins[3]);
+
+  $pdf->AddPage();
+    
+   $ln = true ; 
+   $fill = false ; 
+   $reset_parm = false;
+   $cell = false;
+   $align = '' ;
+//print $html;
+   // output the HTML content
+   $pdf->writeHTML($html, $ln, $fill, $reset_parm, $cell, $align);
+ 
+  // reset pointer to the last page
+  $pdf->lastPage();
+
+  // close and output the PDF
+  $pdf->Close();
+  $pdf_file =  'CiviLetter'.'.pdf';
+  $pdf->Output($pdf_file, 'D');
+  CRM_Utils_System::civiExit(1);    
+  
   }
 
   static function _html2pdf_dompdf($paper_size, $orientation, $html, $output, $fileName) {
@@ -314,4 +374,3 @@ class CRM_Utils_PDF_Utils {
     }
   }
 }
-

--- a/templates/CRM/Contact/Form/Task/PDFLetterCommon.tpl
+++ b/templates/CRM/Contact/Form/Task/PDFLetterCommon.tpl
@@ -72,6 +72,12 @@
         <td class="label-left">{$form.margin_left.label}</td><td>{$form.margin_left.html}</td>
         <td class="label-left">{$form.margin_right.label}</td><td>{$form.margin_right.html}</td>
       </tr>
+    
+      <tr>
+        <td class="label-left">{$form.stationery.label}</td><td>{$form.stationery.html}</td>
+         <td colspan="2">&nbsp;</td>
+      </tr>
+      
     </table>
         <div id="bindFormat">{$form.bind_format.html}&nbsp;{$form.bind_format.label}</div>
         <div id="updateFormat" style="display: none">{$form.update_format.html}&nbsp;{$form.update_format.label}</div>
@@ -276,4 +282,3 @@ function showSaveDetails(chkbox)  {
 
 </script>
 {/literal}
-


### PR DESCRIPTION
TCPDF is already used to create PDF files for Mailing Labels and Name Badges. This was added to the action "Create PDF Letter" as well.  If CiviCRM is configured to use wkhtmltopdf, then TCPDF is not used for Create PDF Letter.  
