### PR TITLE
CRM-14084 - Fix for Search by participant role does not work in Search Builder

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -5231,6 +5231,7 @@ AND   displayRelType.is_active = 1
       return;
     }
     $values = array();
+    $sep = CRM_Core_DAO::VALUE_SEPARATOR;
     foreach ($this->_pseudoConstantsSelect as $key => $value) {
       if (!empty($this->_pseudoConstantsSelect[$key]['sorting'])) {
         continue;
@@ -5250,6 +5251,13 @@ AND   displayRelType.is_active = 1
         }
         elseif ($value['pseudoField'] == 'state_province_abbreviation') {
           $dao->$key = CRM_Core_PseudoConstant::stateProvinceAbbreviation($val);
+        }
+        elseif ($value['pseudoField'] == 'participant_role') {
+          $viewRoles = array();
+          foreach (explode($sep, $val) as $k => $v) {
+            $viewRoles[] = CRM_Event_PseudoConstant::participantRole($v);
+          }
+          $dao->$key = implode(', ', $viewRoles);
         }
         else {
           $labels = CRM_Core_OptionGroup::values($value['pseudoField']);

--- a/CRM/Event/BAO/Query.php
+++ b/CRM/Event/BAO/Query.php
@@ -129,23 +129,20 @@ class CRM_Event_BAO_Query {
         $query->_whereTables['participant_status'] = 1;
       }
 
-      //add role
-      if (!empty($query->_returnProperties['participant_role'])) {
+      //add participant_role and participant_role_id
+      if (!empty($query->_returnProperties['participant_role']) || !empty($query->_returnProperties['participant_role_id'])) {
         $query->_select['participant_role'] = "participant_role.label as participant_role";
-        $query->_element['participant_role'] = 1;
-        $query->_tables['civicrm_participant'] = 1;
-        $query->_tables['participant_role'] = 1;
-        $query->_whereTables['civicrm_participant'] = 1;
-        $query->_whereTables['participant_role'] = 1;
-      }
-
-      if (!empty($query->_returnProperties['participant_role_id'])) {
         $query->_select['participant_role_id'] = "civicrm_participant.role_id as participant_role_id";
+        $query->_element['participant_role'] = 1;
         $query->_element['participant_role_id'] = 1;
         $query->_tables['civicrm_participant'] = 1;
         $query->_tables['participant_role'] = 1;
         $query->_whereTables['civicrm_participant'] = 1;
         $query->_whereTables['participant_role'] = 1;
+        $query->_pseudoConstantsSelect['participant_role'] = array(
+          'pseudoField' => 'participant_role',
+          'idCol' => 'participant_role_id',
+        );
       }
 
       //add register date
@@ -348,6 +345,7 @@ class CRM_Event_BAO_Query {
         $query->_tables['civicrm_participant'] = $query->_whereTables['civicrm_participant'] = 1;
         return;
 
+      case 'participant_role':
       case 'participant_role_id':
         $val = array();
         if (is_array($value)) {


### PR DESCRIPTION
Added _pseudoConstantsSelect key to query built by CRM_Event_BAO_Query.php.
Added corresponding section to convertToPseudoNames function that is very similar to that used in CRM_Event_Selector_Search.php for participant roles.
