### PR TITLE
CRM-13068: load .mo files from l10n/xx_XX/LC_MESSAGES/civicrm.mo

### DIFF
--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -78,10 +78,20 @@ class CRM_Core_I18n {
       }
 
       // Otherwise, use PHP-gettext
+      // we support both the old file hierarchy format and the new:
+      // pre-4.5:  civicrm/l10n/xx_XX/civicrm.mo
+      // post-4.5: civicrm/l10n/xx_XX/LC_MESSAGES/civicrm.mo
       require_once 'PHPgettext/streams.php';
       require_once 'PHPgettext/gettext.php';
 
-      $streamer = new FileReader($config->gettextResourceDir . $locale . DIRECTORY_SEPARATOR . 'civicrm.mo');
+      $mo_file = $config->gettextResourceDir . $locale . DIRECTORY_SEPARATOR . 'LC_MESSAGES' . DIRECTORY_SEPARATOR . 'civicrm.mo';
+
+      if (! file_exists($mo_file)) {
+        // fallback to pre-4.5 mode
+        $mo_file = $config->gettextResourceDir . $locale . DIRECTORY_SEPARATOR . 'civicrm.mo';
+      }
+
+      $streamer = new FileReader($mo_file);
       $this->_phpgettext = new gettext_reader($streamer);
     }
   }

--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -252,6 +252,20 @@ define( 'CIVICRM_MEMCACHE_PREFIX', '' );
 // define('CIVICRM_LANGUAGE_MAPPING_ZH', 'zh_TW');
 
 /**
+ * Native gettext improves performance of localized CiviCRM installations
+ * significantly. However, your host must enable the locale (language).
+ * On most GNU/Linux, Unix or MacOSX systems, you may view them with
+ * the command line by typing: "locale -a".
+ *
+ * On Debian or Ubuntu, you may reconfigure locales with:
+ * # dpkg-reconfigure locales
+ *
+ * For more information:
+ * http://wiki.civicrm.org/confluence/x/YABFBQ
+ */
+// define('CIVICRM_GETTEXT_NATIVE', 1);
+
+/**
  * Configure MySQL to throw more errors when encountering unusual SQL expressions.
  *
  * If undefined, the value is determined automatically. For CiviCRM tarballs, it defaults


### PR DESCRIPTION
Since 4.3, CiviCRM supports two gettext implementations: phpgettext
(default) and native gettext. The performance of native gettext is
much better, but requires a specific file hierarchy and that the
operating system has support for the locale (dpkg-reconfigure locale).

Now that the release scripts package the files as:
l10n/xx_XX/LC_MESSAGES/civicrm.mo, instead of
l10n/xx_XX/civicrm.mo, we needed to modify phpgettext to load the
files from the new directory. However, we also support the old
hierarchy as a fallback, so that we do not break the build scripts
of people who do not use phpgettext.
