### PR TITLE
CRM-14622 Set value of file field textbox to NULL

### DIFF
--- a/CRM/Core/Page/AJAX/Location.php
+++ b/CRM/Core/Page/AJAX/Location.php
@@ -203,6 +203,10 @@ class CRM_Core_Page_AJAX_Location {
               $elements["onbehalf_{$key}"]['value'] = $defaults[$key];
               $elements["onbehalf_{$key}"]['id'] = $defaults["{$key}_id"];
             }
+            elseif ($htmlType == 'File') {
+              $elements["onbehalf_{$key}"]['type'] = $htmlType;
+              $elements["onbehalf_{$key}"]['value'] = '';
+            }
             else {
               $elements["onbehalf_{$key}"]['type'] = $htmlType;
               $elements["onbehalf_{$key}"]['value'] = $defaults[$key];


### PR DESCRIPTION
---
- CRM-14622: File fields on 'On Behalf of' profiles cause javascipt to break.
  https://issues.civicrm.org/jira/browse/CRM-14622
