### PR TITLE
CRM-14530 - Dedupe - Stops contribution data from being lost when mergin...

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -360,15 +360,6 @@ DELETE membership1.* FROM civicrm_membership membership1
              AND membership1.contact_id = {$mainId}
              AND membership2.contact_id = {$otherId} ";
       }
-      if ($mode == 'payment') {
-        $sqls[] = "
-DELETE contribution.* FROM civicrm_contribution contribution
-INNER JOIN  civicrm_membership_payment payment ON payment.contribution_id = contribution.id
-INNER JOIN  civicrm_membership membership1 ON membership1.id = payment.membership_id
-            AND membership1.contact_id = {$mainId}
-INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = membership2.membership_type_id
-            AND membership2.contact_id = {$otherId}";
-      }
       break;
 
       case 'civicrm_uf_match':


### PR DESCRIPTION
...g two memberships with identical type

Modifies Merger.php, removing code that would delete contribution data when merging two memberships
with identical type even if the user had specified that they wanted contributions to be carried over
to the main contact.
