### PR TITLE
CRM-14367 make pdf option dependent on site setting

### DIFF
--- a/CRM/Contribute/Form/Task/PDFLetter.php
+++ b/CRM/Contribute/Form/Task/PDFLetter.php
@@ -128,9 +128,11 @@ class CRM_Contribute_Form_Task_PDFLetter extends CRM_Contribute_Form_Task {
       '' => ts('Generate PDFs for printing (only)'),
       'email' => ts('Send emails where possible. Generate printable PDFs for contacts who cannot receive email.'),
       'both' => ts('Send emails where possible. Generate printable PDFs for all contacts.'),
-      'pdfemail' => ts('Send emails with an attached PDF where possible. Generate printable PDFs for contacts who cannot receive email.'),
-      'pdfemail_both' => ts('Send emails with an attached PDF where possible. Generate printable PDFs for all contacts.'),
     );
+    if(CRM_Core_Config::singleton()->doNotAttachPDFReceipt)  {
+      $emailOptions['pdfemail'] = ts('Send emails with an attached PDF where possible. Generate printable PDFs for contacts who cannot receive email.');
+      $emailOptions['pdfemail_both'] = ts('Send emails with an attached PDF where possible. Generate printable PDFs for all contacts.');
+    }
     $this->addElement('select', 'email_options', ts('Print and email options'), $emailOptions, array(), "<br/>", FALSE);
 
     $this->addButtons(array(


### PR DESCRIPTION
@davecivicrm here is the patch for #2 in your fixes on the pdf letter options. I am leaving this for you to merge or not because I have a couple of misgivings about it

1) the replacement of the pdf library done by others on the sprint seems to me to mitigate the performance issues that brought about the setting in the first place

2) the setting description is 
If enabled, CiviCRM sends PDF receipt as an attachment during event signup or online contribution. which seems a little misleading & could be set for reasons other than the performance issue

Having said that - I am not strongly one way or the other - so merge or reject this PR as you see fit
