### PR TITLE
CRM-14590 - Custom fields for a particular role are not being saved in backend registrations.

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1738,7 +1738,7 @@ SELECT id
       // rename this file to go into the secure directory
       if (!rename($fName, $config->customFileUploadDir . $filename)) {
         CRM_Core_Error::statusBounce(ts('Could not move custom file to custom upload directory'));
-        break;
+        return;
       }
 
       if ($customValueId) {


### PR DESCRIPTION
Also cleaned up a spelling error.
EG. "if (($this->_lineItem || !isset($params['proceSetId']))"  proceSetId should be priceSetId.

Also moved getting $this->_params['participant_role_id'] out of the if statement since it was used elsewhere. This gets rid of the notice on line 1152.
