### PR TITLE
More accurate warning text

### DIFF
--- a/templates/CRM/Admin/Form/CaseType.tpl
+++ b/templates/CRM/Admin/Form/CaseType.tpl
@@ -30,7 +30,7 @@
 {if $action eq 8}
   <div class="messages status no-popup">
      <div class="icon inform-icon"></div>
-        {ts}WARNING: Deleting this option will result in the loss of all case records which use the option.{/ts} {ts}This may mean the loss of a substantial amount of data, and the action cannot be undone.{/ts} {ts}Do you want to continue?{/ts}
+        {ts}WARNING: Deleting this option will result in loss of type information for all case records which use the option.{/ts} {ts}This may mean the loss of a substantial amount of data, and the action cannot be undone.{/ts} {ts}Do you want to continue?{/ts}
       </div>
 {else}
   <table class="form-layout-compressed">


### PR DESCRIPTION
If a case type is deleted, linked case.case_type_id data will be set to
null, rather than cascade deleted.  Update the warning to reflect this.
