### PR TITLE
Code tidy up

### DIFF
--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -119,7 +119,7 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
    * @access public
    * @static
    */
-  static function sendMail($contactID, &$values, $isTest = FALSE, $returnMessageText = FALSE, $fieldTypes = NULL) {
+  static function sendMail($contactID, $values, $isTest = FALSE, $returnMessageText = FALSE, $fieldTypes = NULL) {
     $gIds = $params = array();
     $email = NULL;
     if (isset($values['custom_pre_id'])) {
@@ -348,6 +348,7 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
         list($ccDisplayName, $ccEmail) = CRM_Contact_BAO_Contact_Location::getEmailDetails($values['related_contact']);
         $ccMailId = "{$ccDisplayName} <{$ccEmail}>";
 
+        //@todo - this is the only place in this function where  $values is altered - but I can't find any evidence it is used
         $values['cc_receipt'] = !empty($values['cc_receipt']) ? ($values['cc_receipt'] . ',' . $ccMailId) : $ccMailId;
 
         // reset primary-email in the template


### PR DESCRIPTION
The actual code change in this is to slightly reduce the extent by which arrays are passed by reference & variables are set with unknown implications

In this case the variables involved are

$form_>_values['contribution_id'] 
$form_values['cc_recur']

I couldn't find evidence of the second being used & the first doesn't seem to be set when called from a membership context & the other time it is called is right at the end of the post_process hook.

I guess there is some risk postProcess hooks could rely on it though? but then ??????
