### PR TITLE
HR-345 Fix for profile selector edit link

### DIFF
--- a/CRM/Core/BAO/UFField.php
+++ b/CRM/Core/BAO/UFField.php
@@ -142,7 +142,7 @@ class CRM_Core_BAO_UFField extends CRM_Core_DAO_UFField {
     $ufField->field_name = $params['field_name'][1];
     if ($params['field_name'][1] == 'url') {
       $ufField->website_type_id = CRM_Utils_Array::value(2, $params['field_name'], NULL);
-    } 
+    }
     else {
       $ufField->location_type_id = (CRM_Utils_Array::value(2, $params['field_name'])) ? $params['field_name'][2] : 'NULL';
     }
@@ -219,7 +219,7 @@ WHERE cf.id IN (" . $customFieldIds . ") AND is_multiple = 1 LIMIT 0,1";
     $locationTypeId = NULL;
     if ($params['field_name'][1] == 'url') {
       $ufField->website_type_id = CRM_Utils_Array::value(2, $params['field_name']);
-    } 
+    }
     else {
       $locationTypeId = CRM_Utils_Array::value(2, $params['field_name']);
       $ufField->website_type_id = NULL;
@@ -929,12 +929,7 @@ SELECT  id
           'name' => 'contribution_note',
           'title' => ts('Contribution Note'),
         );
-        if ($gid && CRM_Core_DAO::getFieldValue('CRM_Core_DAO_UFGroup', $gid, 'name') == 'contribution_batch_entry') {
-          $fields['Contribution'] = array_merge($contribFields, self::getContribBatchEntryFields());
-        }
-        else {
-          $fields['Contribution'] = $contribFields;
-        }
+        $fields['Contribution'] = array_merge($contribFields, self::getContribBatchEntryFields());
       }
     }
 
@@ -1093,6 +1088,10 @@ SELECT  id
         'soft_credit' => array(
           'name' => 'soft_credit',
           'title' => ts('Soft Credit'),
+        ),
+        'soft_credit_type' => array(
+          'name' => 'soft_credit_type',
+          'title' => ts('Soft Credit Type'),
         ),
         'product_name' => array(
           'name' => 'product_name',

--- a/CRM/Event/Form/ManageEvent/Registration.php
+++ b/CRM/Event/Form/ManageEvent/Registration.php
@@ -374,8 +374,8 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
     $configs['allowCoreTypes'][] = 'Individual';
     $configs['allowCoreTypes'][] = 'Participant';
 
-    $configs['profileEntities'][] = array('entity_name' => 'individual_entity', 'entity_type' => 'IndividualModel');
-    $configs['profileEntities'][] = array('entity_name' => 'participant_entity', 'entity_type' => 'ParticipantModel');
+    $configs['profileEntities'][] = array('entity_name' => 'individual_1', 'entity_type' => 'IndividualModel');
+    $configs['profileEntities'][] = array('entity_name' => 'participant_1', 'entity_type' => 'ParticipantModel');
 
    return $configs;
   }

--- a/js/model/crm.uf.js
+++ b/js/model/crm.uf.js
@@ -689,6 +689,11 @@
       // set proper entity model based on selected profile
       var contactTypes = ['Individual', 'Household', 'Organization'];
       var profileType = ufGroupModel.get('group_type') || '';
+
+      // check if selected profile have subtype defined eg: ["Individual,Contact,Case", "caseType:7"]
+      if (_.isArray(profileType) && profileType[0]) {
+        profileType = profileType[0];
+      }
       profileType = profileType.split(',');
 
       var ufEntityModel;
@@ -706,7 +711,7 @@
 
       var newUfEntityModels = [];
       _.each(allEntityModels, function (values) {
-        if (values.entity_name == 'contact_1') {
+        if (entityType && values.entity_name == 'contact_1') {
           values.entity_type = entityType;
         }
         newUfEntityModels.push(new CRM.UF.UFEntityModel(values));


### PR DESCRIPTION
The Edit/Copy link of profile selector on Manage Event/Contribution page was broken.
In Event profile selector, the entity name needed to be changed, otherwise not a single profile was loading for edit/copy action.
While on Contribution's Include Profile tab, "Contribution bulk entry" profile was not loading properly giving error:-
Failed to locate field: contribution_1.soft_credit_type
Failed to locate field: contribution_1.send_receipt
This was because getSchema($entityTypes) from CRM/UF/Form/ProfileEditor.php is getting called while form build, hence $gid can not be set, due to which getContribBatchEntryFields() function was not getting called for edit action. So removed the condition to check for $gid.
Also "soft_credit_type" field was not defined in the function. So added that.
The main reason for profile edit link was not working for profiles of type other than individual, is that the ufEntityModel was set undefined as profiles are not of type Individual/Organization/Household rather 'Contact and other model like Participant/Contribution' etc.
So while setting UFGroupModel, for conatct_1 entity name, entity_type was setting null and not IndividualModel. So put the condition to check if entityType is defined.
