### PR TITLE
CRM-14197 store contribution id in line item table for data accessibility

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2561,6 +2561,12 @@ WHERE  contribution_id = %1 ";
       $entityTable = 'civicrm_participant';
       $additionalParticipantId = CRM_Event_BAO_Participant::getAdditionalParticipantIds($entityId);
     }
+    elseif (!empty($params['membership_id'])) {
+      //so far $params['membership_id'] should only be set coming in from membershipBAO::create so the situation where multiple memberships
+      // are created off one contribution should be handled elsewhere
+      $entityId = $params['membership_id'];
+      $entityTable = 'civicrm_membership';
+    }
     else {
       $entityId = $params['contribution']->id;
       $entityTable = 'civicrm_contribution';

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -2741,6 +2741,7 @@ WHERE      civicrm_membership.is_test = 0";
       'contact_id', 'total_amount', 'receive_date', 'financial_type_id',
       'payment_instrument_id', 'trxn_id', 'invoice_id', 'is_test',
       'contribution_status_id', 'check_number', 'campaign_id', 'is_pay_later',
+      'membership_id',
     );
     foreach ($recordContribution as $f) {
       $contributionParams[$f] = CRM_Utils_Array::value($f, $params);

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1574,16 +1574,17 @@ WHERE   id IN ( ' . implode(' , ', array_keys($membershipType)) . ' )';
           $lineItems[$itemId]['line_total'] = $params['total_amount'];
           $lineItems[$itemId]['id'] = $itemId;
           $lineItem[$priceSetId] = $lineItems;
-          CRM_Price_BAO_LineItem::processPriceSet($params['contribution_id'], $lineItem);
+          $contributionBAO = new CRM_Contribute_BAO_Contribution();
+          $contributionBAO->id = $params['contribution_id'];
+          $contributionBAO->find();
+          CRM_Price_BAO_LineItem::processPriceSet($params['contribution_id'], $lineItem, $contributionBAO, 'civicrm_membership');
 
           //create new soft-credit record, CRM-13981
           $softParams['contribution_id'] = $params['contribution_id'];
-          $dao = new CRM_Contribute_DAO_Contribution();
-          $dao->id = $params['contribution_id'];
-          $dao->find();
-          while ($dao->fetch()) {
-            $softParams['currency'] = $dao->currency;
-            $softParams['amount'] = $dao->total_amount;
+
+          while ($contributionBAO->fetch()) {
+            $softParams['currency'] = $contributionBAO->currency;
+            $softParams['amount'] = $contributionBAO->total_amount;
           }
           CRM_Contribute_BAO_ContributionSoft::add($softParams);
         }

--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -311,6 +311,10 @@ AND li.entity_id = {$entityId}
       foreach ($values as $line) {
         $line['entity_table'] = $entityTable;
         $line['entity_id'] = $entityId;
+        if(!empty($line['membership_type_id'])) {
+          $entityTable == 'civicrm_membership';
+          $line['contribution_id'] = $contributionDetails->id;
+        }
         if ($entityTable == 'civicrm_contribution') {
           $line['contribution_id'] = $entityId;
         }

--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -119,6 +119,7 @@ AND li.entity_id = {$entityId}
     $selectClause = "
       SELECT    li.id,
       li.label,
+      li.contribution_id,
       li.qty,
       li.unit_price,
       li.line_total,
@@ -177,6 +178,7 @@ AND li.entity_id = {$entityId}
         'html_type' => $dao->html_type,
         'description' => $dao->description,
         'entity_id' => $entityId,
+        'contribution_id' => $dao->contribution_id,
         'financial_type_id' => $dao->financial_type_id,
         'membership_type_id' => $dao->membership_type_id,
         'membership_num_terms' => $dao->membership_num_terms,
@@ -309,6 +311,12 @@ AND li.entity_id = {$entityId}
       foreach ($values as $line) {
         $line['entity_table'] = $entityTable;
         $line['entity_id'] = $entityId;
+        if ($entityTable == 'civicrm_contribution') {
+          $line['contribution_id'] = $entityId;
+        }
+        else {
+          $line['contribution_id'] = $contributionDetails->id;
+        }
         // if financial type is not set and if price field value is NOT NULL
         // get financial type id of price field value
         if (!empty($line['price_field_value_id']) && empty($line['financial_type_id'])) {

--- a/CRM/Upgrade/Incremental/sql/4.5.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.5.alpha1.mysql.tpl
@@ -521,7 +521,9 @@ WHERE co.id IS NULL;
 
 -- CRM-14197 Add contribution_id to civicrm_line_item
 
-ALTER TABLE civicrm_line_item ADD contribution_id INT(10) NULL AFTER entity_id;
+ALTER TABLE civicrm_line_item ADD contribution_id INT(10) COMMENT 'Formal (academic or similar) title in front of name. (Prof., Dr. etc.)' NULL AFTER entity_id;
+
+-- FK to civicrm_contribution
 
 ALTER TABLE civicrm_line_item
 ADD CONSTRAINT `FK_civicrm_contribution_id` FOREIGN KEY (`contribution_id`) REFERENCES civicrm_contribution (`id`) ON DELETE SET NULL;

--- a/CRM/Upgrade/Incremental/sql/4.5.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.5.alpha1.mysql.tpl
@@ -528,6 +528,10 @@ ALTER TABLE civicrm_line_item ADD contribution_id INT(10) COMMENT 'Contribution 
 ALTER TABLE civicrm_line_item
 ADD CONSTRAINT `FK_civicrm_contribution_id` FOREIGN KEY (`contribution_id`) REFERENCES civicrm_contribution (`id`) ON DELETE SET NULL;
 
+ALTER TABLE `civicrm_line_item`
+DROP INDEX `UI_line_item_value`,
+ADD UNIQUE INDEX `UI_line_item_value` (`entity_table`, `entity_id`, `contribution_id`, `price_field_value_id`, `price_field_id`);
+
 -- store contribution id for participant records
 UPDATE  civicrm_line_item li LEFT JOIN civicrm_participant_payment pp ON pp.participant_id = li.entity_id
 SET li.contribution_id = pp.contribution_id

--- a/CRM/Upgrade/Incremental/sql/4.5.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.5.alpha1.mysql.tpl
@@ -519,3 +519,10 @@ WHERE co.id IS NULL;
     WHERE v.name = 'Awaiting Information';
 {/if}
 
+-- CRM-14197 Add contribution_id to civicrm_line_item
+
+ALTER TABLE civicrm_line_item ADD contribution_id INT(10) NULL AFTER entity_id;
+
+ALTER TABLE civicrm_line_item
+ADD CONSTRAINT `FK_civicrm_contribution_id` FOREIGN KEY (`contribution_id`) REFERENCES civicrm_contribution (`id`) ON DELETE SET NULL;
+

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -396,6 +396,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
 
     $lineItems = $this->callAPISuccess('line_item','get',array(
       'entity_id' => $contribution['id'],
+      'contribution_id' => $contribution['id'],
       'entity_table' => 'civicrm_contribution',
       'sequential' => 1,
     ));
@@ -424,18 +425,13 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $this->assertEquals($contribution['values'][$contribution['id']]['contribution_status_id'], 1, 'In line ' . __LINE__);
     $lineItems = $this->callAPISuccess('line_item','get',array(
       'entity_id' => $contribution['id'],
+      'contribution_id' => $contribution['id'],
       'entity_table' => 'civicrm_contribution',
       'sequential' => 1,
       ));
     $this->assertEquals(1, $lineItems['count']);
     $this->assertEquals($contribution['id'], $lineItems['values'][0]['entity_id']);
-    $this->assertEquals($contribution['id'], $lineItems['values'][0]['entity_id']);
-    $lineItems = $this->callAPISuccess('line_item','get',array(
-      'entity_id' => $contribution['id'],
-      'entity_table' => 'civicrm_contribution',
-      'sequential' => 1,
-    ));
-    $this->assertEquals(1, $lineItems['count']);
+    $this->assertEquals($contribution['id'], $lineItems['values'][0]['contribution_id']);
     $this->_checkFinancialRecords($contribution, 'offline');
     $this->contributionGetnCheck($params, $contribution['id']);
   }
@@ -694,10 +690,11 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       ));
     $this->assertEquals(1, $lineItems['count']);
     $this->assertEquals($contribution['id'], $lineItems['values'][0]['entity_id']);
-    $this->assertEquals($contribution['id'], $lineItems['values'][0]['entity_id']);
+    $this->assertEquals($contribution['id'], $lineItems['values'][0]['contribution_id']);
     $lineItems = $this->callAPISuccess('line_item','get',array(
 
         'entity_id' => $contribution['id'],
+        'contribution_id' => $contribution['id'],
         'entity_table' => 'civicrm_contribution',
         'sequential' => 1,
     ));

--- a/xml/schema/Price/LineItem.xml
+++ b/xml/schema/Price/LineItem.xml
@@ -38,6 +38,18 @@
     <add>1.7</add>
   </dynamicForeignKey>
   <field>
+    <name>contribution_id</name>
+    <type>int unsigned</type>
+    <comment>FK to civicrm_contribution</comment>
+    <add>4.5</add>
+  </field>
+  <foreignKey>
+    <name>contribution_id</name>
+    <table>civicrm_contribution</table>
+    <key>id</key>
+    <onDelete>SET NULL</onDelete>
+  </foreignKey>
+  <field>
     <name>price_field_id</name>
     <type>int unsigned</type>
     <comment>FK to civicrm_price_field</comment>


### PR DESCRIPTION
This replaces https://github.com/civicrm/civicrm-core/pull/2976

This will mean it is possible to access line item data directly from contribution table. The membership payment & participant payment tables are redundant with this although removing them will be separate as we are trying to get the 'smallest chunk' that stands alone
