### PR TITLE
upgrade-fix : droping foriegn key for pdf_format_id of msg_template table (4.4.5 -> 4.5)

### DIFF
--- a/CRM/Upgrade/Incremental/sql/4.5.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.5.alpha1.mysql.tpl
@@ -288,10 +288,6 @@ ALTER TABLE `civicrm_option_group`
 
 UPDATE `civicrm_option_group` SET is_locked = 1 WHERE name IN ('contribution_status','activity_contacts','advanced_search_options','auto_renew_options','contact_autocomplete_options','batch_status','batch_type','batch_mode','contact_edit_options','contact_reference_options','contact_smart_group_display','contact_view_options','financial_item_status','mapping_type','pcp_status','user_dashboard_options','tag_used_for');
 
-
--- CRM-14522
-ALTER TABLE `civicrm_msg_template` DROP FOREIGN KEY `FK_civicrm_msg_template_pdf_format_id`;
-
 -- CRM-14449
 CREATE TABLE IF NOT EXISTS `civicrm_system_log` (
 `id` INT(11) NOT NULL AUTO_INCREMENT COMMENT 'Primary Key: ID.',


### PR DESCRIPTION
the issue:

4.5 upgrade consists of sql statement used for : dropping foreign key of pdf_format_id column of msg_template table and this is done by using 'FK_civicrm_msg_template_pdf_format_id' constraint name.

there is one scenario for this constraint name to be different i.e. 'pdf_format_id' : this is if the DB to be upgraded has been gone though 3.4.2 upgrade process execution (which consists of creation of pdf_format_id column). So, during this upgrade to 4.5, sql error is thrown as  'FK_civicrm_msg_template_pdf_format_id' doesn't exists.

the fix : checking the information schema for appropriate foreign key name and drop the key according.
