### PR TITLE
Webtest Core bugs

### DIFF
--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -1000,7 +1000,7 @@ SELECT id
     $buttonName = $this->controller->getButtonName();
     $session = CRM_Core_Session::singleton();
     if ($buttonName == $this->getButtonName('next', 'new')) {
-      $msg += '<p>' . ts("Ready to add another.") . '</p>';
+      $msg .= '<p>' . ts("Ready to add another.") . '</p>';
       $session->replaceUserContext(CRM_Utils_System::url('civicrm/admin/custom/group/field/add',
           'reset=1&action=add&gid=' . $this->_gid
         ));

--- a/templates/CRM/Contact/Form/Selector.tpl
+++ b/templates/CRM/Contact/Form/Selector.tpl
@@ -172,6 +172,9 @@ function countSelections(obj) {
       label.prepend('<span>' + obj.getCount + '</span> ');
     }
     else {
+      if(obj.getCount > 0) {
+        cj('input[name=radio_ts][value=ts_sel]').prop('checked', true);
+      }
       cj('span', label).html(obj.getCount);
     }
     toggleTaskAction(obj.getCount);
@@ -180,7 +183,7 @@ function countSelections(obj) {
 function toggleContactSelection(name, qfKey, selection) {
   var url = CRM.url('civicrm/ajax/markSelection');
   var params = {qfKey: qfKey};
-  if (!(cj('#' + name).is(':checked'))) {
+  if( cj('#' + name + ":checked").length == 0) {
     params.action = 'unselect';
     params.state = 'unchecked';
   }


### PR DESCRIPTION
Fix for CRM bugs which resulted in Webtests failures -
1) No notification on clicking of "Save and New" button while adding custom fields.
2) In Advanced Search Page, after the search button is clicked, the toggleselect checkbox which checks all the contact listed doesn't display the contact count in the radio button displayed above(nor does it selects the radio button).
Affected Webtests failures are -
WebTest_Contact_DeceasedContactsAdvancedSearchTest.testDeceasedContactsAdvanceSearch
WebTest_Contact_TaskActionAddToGroupTest:: All Functions
WebTest_Contact_ContactReferenceFieldTest.testContactReferenceField
