### PR TITLE
views-upgrade-error : helper method to detect upgrade mode. this is used in civicrm.views.inc

### DIFF
--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1815,6 +1815,15 @@ class CRM_Utils_System {
     }
     return $cache;
   }
+
+  static function isInUpgradeMode() {
+    $args = explode('/', $_GET['q']);
+    $upgradeInProcess = CRM_Core_Session::singleton()->get('isUpgradePending');
+    if ((isset($args[1]) && $args[1] == 'upgrade') || $upgradeInProcess) {
+      return TRUE;
+    }
+    else {
+      return FALSE;
+    }
+  }
 }
-
-


### PR DESCRIPTION
the issue: can replicated only after enabling drupal module 'entity', after which when we try to upgrade the DB (4.4.5 -> 4.5), 'entity' module accesses 'cache data from views', this causes 'views' to trigger 'civicrm data alter hook' and this ultimately communicates with database with (4.5 version) BAO's.

As the code base is latest and DB is of older version,  new schema (like new column addition) related code gets executed by any BAO function invokation, and since the column is absent error is thrown.  

the fix: we would stop the module level data access from Database (as there are strong possibilities of DB structure changes). Thus introduced a helper method which identifies the system mode.
