### PR TITLE
Core Bug related to foreign key referencing not defined for civicrm_entity_tag table

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -205,6 +205,9 @@ WHERE
       while ($dao->fetch()) {
         $cidRefs[$dao->table_name][] = $dao->column_name;
       }
+
+      // FixME for time being adding below line statically as no Foreign key constraint defined for table 'civicrm_entity_tag'
+      $cidRefs['civicrm_entity_tag'][] = 'entity_id';
       $dao->free();
 
       // Allow hook_civicrm_merge() to adjust $cidRefs


### PR DESCRIPTION
While working on Webtest (WebTest_Contact_MergeContactsTest.testIndividualAdd) I encountered an issue related to core. 
While Merging contacts if the one of the contact contain Tag that was not able to merge to another contact result of Tag option is not displayed on screen.  
On debug I found that there was no reference for civicrm_entity_tag.entity_id and henceforth result into improper/incorrect merge.
Please refer this image:http://snag.gy/LmhmD.jpg
