### PR TITLE
WebTest Core Bug

### DIFF
--- a/CRM/Core/Form/Tag.php
+++ b/CRM/Core/Form/Tag.php
@@ -141,7 +141,8 @@ class CRM_Core_Form_Tag {
       // in that case we create empty tagset params so that below logic works and tagset are
       // deleted correctly
       foreach ($form->_tagsetInfo as $tagsetName => $tagsetInfo) {
-        $tagsetId = substr($tagsetName, strlen('parentId_'));
+        $tagsetId = explode('parentId_', $tagsetName);
+        $tagsetId = $tagsetId[1];
         if (empty($params[$tagsetId])) {
           $params[$tagsetId] = '';
         }


### PR DESCRIPTION
Fix for CRM bug which resulted in Webtests failures -
- After adding two Tagset used for Contact, a New Contact cannot be created by New Individual Page
  Similarly for Case, Activity etc.
- $tagsetName consist of contacttaglistparentID_$id for contact from which 'id' is not retrieved correctly, hence the use of explode function.
  Affected Webtest Failures - 
  WebTest_Contact_TagSetSearchTest::testTagSetSearch
  WebTest_Export_ContactTest :: All functions
  WebTest_Generic_CheckDashboardTest
  WebTest_Import_ContactCustomDataTest
