### PR TITLE
CRM-14675 fix - Strict warning: Non-static method CRM_Event_BAO_Event::g...

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -2043,7 +2043,7 @@ LEFT  JOIN  civicrm_price_field_value value ON ( value.id = lineItem.price_field
    *
    * @return $defaults an array of custom data defaults.
    */
-  public function getTemplateDefaultValues($templateId) {
+  static function getTemplateDefaultValues($templateId) {
     $defaults = array();
     if (!$templateId) {
       return $defaults;


### PR DESCRIPTION
...etTemplateDefaultValues() should not be called statically, assuming $this from incompatible context in CRM_Event_Form_ManageEvent_EventInfo->postProcess() (line 309

https://issues.civicrm.org/jira/browse/CRM-14675
