### PR TITLE
Crm 14681 : Import Contacts no longer checks contact type, instead contact type is changed.

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -663,7 +663,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
     //fixed CRM-4148
     //now we create new contact in update/fill mode also.
     $contactID = NULL;
-    if ($createNewContact || $this->_updateWithId) {
+    if ($createNewContact || ($this->_retCode != CRM_Import_Parser::NO_MATCH && $this->_updateWithId)) {
 
       //CRM-4430, don't carry if not submitted.
       foreach (array('prefix_id', 'suffix_id', 'gender_id') as $name) {


### PR DESCRIPTION
the issue: errorCode was rightly getting set to no_match for incompatibly contact type contacts during a particular type of contact import. But somehow a new contact was getting created and contact type was getting updated wrongly.

the fix: stopped execution for the new contact creation for non_match contacts with the help of errorCode. 
