### PR TITLE
CoreBug Related Changes

### DIFF
--- a/templates/CRM/Event/Form/ManageEvent/Registration.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Registration.tpl
@@ -421,11 +421,11 @@ invert              = 0
 
         var addtlPartc = $(this).data('addtlPartc');
 
-        if (addtlPartc) {
-            profileBottomCount++;
+        if ($(this).closest("tr").attr("class").indexOf("additional_custom_post") > -1 || addtlPartc) {
+            profileBottomCountAdd++
             urlPath = CRM.url('civicrm/event/manage/registration', { addProfileBottomAdd: 1, addProfileNumAdd: profileBottomCountAdd, snippet: 4 } ) ;
         } else {
-            profileBottomCountAdd++;
+            profileBottomCount++;
             urlPath = CRM.url('civicrm/event/manage/registration', { addProfileBottom: 1 , addProfileNum : profileBottomCount, snippet: 4 } ) ;
         }
 


### PR DESCRIPTION
The attribute 'addtlPartc' value always remained  zero on first load and therefore condition to check IF('Additional Profile') used to break and the flow always continued with the ELSE part.

Therefore checking for the appropriate class name while adding 'Additional Profile'.
