### PR TITLE
CRM-14478 - Add generic API, "getrefcount"

### DIFF
--- a/CRM/Case/Info.php
+++ b/CRM/Case/Info.php
@@ -128,6 +128,41 @@ class CRM_Case_Info extends CRM_Core_Component_Info {
     );
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getReferenceCounts($dao) {
+    $result = array();
+    if ($dao instanceof CRM_Core_DAO_OptionValue) {
+      /** @var $dao CRM_Core_DAO_OptionValue */
+      $activity_type_gid = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', 'activity_type', 'id', 'name');
+      if ($activity_type_gid == $dao->option_group_id) {
+        $count = CRM_Case_XMLRepository::singleton()
+          ->getActivityReferenceCount($dao->name);
+        if ($count > 0) {
+          $result[] = array(
+            'name' => 'casetypexml:activities',
+            'type' => 'casetypexml',
+            'count' => $count,
+          );
+        }
+      }
+    }
+    elseif ($dao instanceof CRM_Contact_DAO_RelationshipType) {
+      /** @var $dao CRM_Contact_DAO_RelationshipType */
+      $count = CRM_Case_XMLRepository::singleton()
+        ->getRelationshipReferenceCount($dao->{CRM_Case_XMLProcessor::REL_TYPE_CNAME});
+      if ($count > 0) {
+        $result[] = array(
+          'name' => 'casetypexml:relationships',
+          'type' => 'casetypexml',
+          'count' => $count,
+        );
+      }
+    }
+    return $result;
+  }
+
   // docs inherited from interface
   public function getUserDashboardElement() {
     return array();

--- a/CRM/Case/XMLProcessor.php
+++ b/CRM/Case/XMLProcessor.php
@@ -34,6 +34,16 @@
  */
 class CRM_Case_XMLProcessor {
 
+  /**
+   * Relationship-types have four name fields (name_a_b, name_b_a, label_a_b,
+   * label_b_a), but CiviCase XML refers to reltypes by a single name.
+   * REL_TYPE_CNAME identifies the canonical name field as used by CiviCase XML.
+   *
+   * This appears to be "label_b_a", but IMHO "name_b_a" would be more
+   * sensible.
+   */
+  const REL_TYPE_CNAME = 'label_b_a';
+
   public function retrieve($caseType) {
     return CRM_Case_XMLRepository::singleton()->retrieve($caseType);
   }
@@ -61,7 +71,7 @@ class CRM_Case_XMLProcessor {
 
       $relationshipTypes = array();
       foreach ($relationshipInfo as $id => $info) {
-        $relationshipTypes[$id] = $info['label_b_a'];
+        $relationshipTypes[$id] = $info[CRM_Case_XMLProcessor::REL_TYPE_CNAME];
       }
     }
 

--- a/CRM/Case/XMLProcessor/Process.php
+++ b/CRM/Case/XMLProcessor/Process.php
@@ -253,6 +253,52 @@ class CRM_Case_XMLProcessor_Process extends CRM_Case_XMLProcessor {
     return $result;
   }
 
+  /**
+   * @param SimpleXMLElement $caseTypeXML
+   * @return array<string> symbolic activity-type names
+   */
+  function getDeclaredActivityTypes($caseTypeXML) {
+    $result = array();
+
+    if ($caseTypeXML->ActivityTypes && $caseTypeXML->ActivityTypes->ActivityType) {
+      foreach ($caseTypeXML->ActivityTypes->ActivityType as $activityTypeXML) {
+        $result[] = (string) $activityTypeXML->name;
+      }
+    }
+
+    if ($caseTypeXML->ActivitySets && $caseTypeXML->ActivitySets->ActivitySet) {
+      foreach ($caseTypeXML->ActivitySets->ActivitySet as $activitySetXML) {
+        if ($activitySetXML->ActivityTypes && $activitySetXML->ActivityTypes->ActivityType) {
+          foreach ($activitySetXML->ActivityTypes->ActivityType as $activityTypeXML) {
+            $result[] = (string) $activityTypeXML->name;
+          }
+        }
+      }
+    }
+
+    $result = array_unique($result);
+    sort($result);
+    return $result;
+  }
+
+  /**
+   * @param SimpleXMLElement $caseTypeXML
+   * @return array<string> symbolic relationship-type names
+   */
+  function getDeclaredRelationshipTypes($caseTypeXML) {
+    $result = array();
+
+    if ($caseTypeXML->CaseRoles && $caseTypeXML->CaseRoles->RelationshipType) {
+      foreach ($caseTypeXML->CaseRoles->RelationshipType as $relTypeXML) {
+        $result[] = (string) $relTypeXML->name;
+      }
+    }
+
+    $result = array_unique($result);
+    sort($result);
+    return $result;
+  }
+
   function deleteEmptyActivity(&$params) {
     $activityContacts = CRM_Core_OptionGroup::values('activity_contacts', FALSE, FALSE, FALSE, NULL, 'name');
     $targetID = CRM_Utils_Array::key('Activity Targets', $activityContacts);

--- a/CRM/Case/XMLRepository.php
+++ b/CRM/Case/XMLRepository.php
@@ -53,7 +53,7 @@ class CRM_Case_XMLRepository {
 
   /**
    * @param bool $fresh
-   * @return CRM_Case_XMLProcessor
+   * @return CRM_Case_XMLRepository
    */
   public static function singleton($fresh = FALSE) {
     if (!self::$singleton || $fresh) {
@@ -65,7 +65,8 @@ class CRM_Case_XMLRepository {
   /**
    * @param array<String,SimpleXMLElement> $xml
    */
-  public function __construct($xml = array()) {
+  public function __construct($allCaseTypes = NULL, $xml = array()) {
+    $this->allCaseTypes = $allCaseTypes;
     $this->xml = $xml;
   }
 
@@ -153,4 +154,53 @@ class CRM_Case_XMLRepository {
     }
     return $this->hookCache;
   }
+
+  /**
+   * @return array<string> symbolic names of case-types
+   */
+  public function getAllCaseTypes() {
+    if ($this->allCaseTypes === NULL) {
+      $this->allCaseTypes = CRM_Case_PseudoConstant::caseType("name");
+    }
+    return $this->allCaseTypes;
+  }
+
+  /**
+   * Determine the number of times a particular activity-type is
+   * referenced in CiviCase XML.
+   *
+   * @param string $activityType symbolic-name of an activity type
+   * @return int
+   */
+  function getActivityReferenceCount($activityType) {
+    $p = new CRM_Case_XMLProcessor_Process();
+    $count = 0;
+    foreach ($this->getAllCaseTypes() as $caseTypeName) {
+      $caseTypeXML = $this->retrieve($caseTypeName);
+      if (in_array($activityType, $p->getDeclaredActivityTypes($caseTypeXML))) {
+        $count++;
+      }
+    }
+    return $count;
+  }
+
+  /**
+   * Determine the number of times a particular activity-type is
+   * referenced in CiviCase XML.
+   *
+   * @param string $relationshipTypeName symbolic-name of a relationship-type
+   * @return int
+   */
+  function getRelationshipReferenceCount($relationshipTypeName) {
+    $p = new CRM_Case_XMLProcessor_Process();
+    $count = 0;
+    foreach ($this->getAllCaseTypes() as $caseTypeName) {
+      $caseTypeXML = $this->retrieve($caseTypeName);
+      if (in_array($relationshipTypeName, $p->getDeclaredRelationshipTypes($caseTypeXML))) {
+        $count++;
+      }
+    }
+    return $count;
+  }
+
 }

--- a/CRM/Core/Component/Info.php
+++ b/CRM/Core/Component/Info.php
@@ -172,6 +172,19 @@ abstract class CRM_Core_Component_Info {
   abstract public function getPermissions($getAllUnconditionally = FALSE);
 
   /**
+   * Determine how many other records refer to a given record
+   *
+   * @param CRM_Core_DAO $dao the item for which we want a reference count
+   * @return array each item in the array is an array with keys:
+   *   - name: string, eg "sql:civicrm_email:contact_id"
+   *   - type: string, eg "sql"
+   *   - count: int, eg "5" if there are 5 email addresses that refer to $dao
+   */
+  public function getReferenceCounts($dao) {
+    return array();
+  }
+
+  /**
    * Provides information about user dashboard element
    * offered by this component.
    *

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -238,7 +238,7 @@ class CRM_Core_DAO extends DB_DataObject {
    * @static
    * @access public
    *
-   * @return array of CRM_Core_EntityReference
+   * @return array of CRM_Core_Reference_Interface
    */
   static function getReferenceColumns() {
     return array();
@@ -1741,7 +1741,7 @@ SELECT contact_id
 
     $occurrences = array();
     foreach ($links as $refSpec) {
-      /** @var $refSpec CRM_Core_EntityReference */
+      /** @var $refSpec CRM_Core_Reference_Interface */
       $daoName = CRM_Core_DAO_AllCoreTables::getClassForTable($refSpec->getReferenceTable());
       $result = $refSpec->findReferences($this);
       while ($result->fetch()) {
@@ -1775,9 +1775,8 @@ SELECT contact_id
       $daoTableName = $daoClassName::getTableName();
 
       foreach ($links as $refSpec) {
-        if ($refSpec->getTargetTable() === $tableName
-              or $refSpec->isGeneric()
-        ) {
+        /** @var $refSpec CRM_Core_Reference_Interface */
+        if ($refSpec->matchesTargetTable($tableName)) {
           $refsFound[] = $refSpec;
         }
       }

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1741,22 +1741,9 @@ SELECT contact_id
 
     $occurrences = array();
     foreach ($links as $refSpec) {
-      $refColumn = $refSpec->getReferenceKey();
-      $targetColumn = $refSpec->getTargetKey();
-      $params = array(1 => array($this->$targetColumn, 'String'));
-      $sql = <<<EOS
-SELECT id
-FROM {$refSpec->getReferenceTable()}
-WHERE {$refColumn} = %1
-EOS;
-      if ($refSpec->isGeneric()) {
-        $params[2] = array(static::getTableName(), 'String');
-        $sql .= <<<EOS
-    AND {$refSpec->getTypeColumn()} = %2
-EOS;
-      }
+      /** @var $refSpec CRM_Core_EntityReference */
       $daoName = CRM_Core_DAO_AllCoreTables::getClassForTable($refSpec->getReferenceTable());
-      $result = self::executeQuery($sql, $params, TRUE, $daoName);
+      $result = $refSpec->findReferences($this);
       while ($result->fetch()) {
         $obj = new $daoName();
         $obj->id = $result->id;

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1779,6 +1779,21 @@ SELECT contact_id
     return $occurrences;
   }
 
+  function getReferenceCounts() {
+    $links = self::getReferencesToTable(static::getTableName());
+
+    $counts = array();
+    foreach ($links as $refSpec) {
+      /** @var $refSpec CRM_Core_Reference_Interface */
+      $count = $refSpec->getReferenceCount($this);
+      if ($count['count'] != 0) {
+        $counts[] = $count;
+      }
+    }
+
+    return $counts;
+  }
+
   /**
    * List all tables which have hard foreign keys to this table.
    *

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1791,6 +1791,12 @@ SELECT contact_id
       }
     }
 
+    foreach (CRM_Core_Component::getEnabledComponents() as $component) {
+      /** @var $component CRM_Core_Component_Info */
+      $counts = array_merge($counts, $component->getReferenceCounts($this));
+    }
+    CRM_Utils_Hook::referenceCounts($this, $counts);
+
     return $counts;
   }
 

--- a/CRM/Core/Reference/Basic.php
+++ b/CRM/Core/Reference/Basic.php
@@ -59,4 +59,24 @@ EOS;
     $result = CRM_Core_DAO::executeQuery($sql, $params, TRUE, $daoName);
     return $result;
   }
+
+  public function getReferenceCount($targetDao) {
+    $targetColumn = $this->getTargetKey();
+    $params = array(
+      1 => array($targetDao->$targetColumn, 'String')
+    );
+    $sql = <<<EOS
+SELECT count(id)
+FROM {$this->getReferenceTable()}
+WHERE {$this->getReferenceKey()} = %1
+EOS;
+
+    return array(
+      'name' => implode(':', array('sql', $this->getReferenceTable(), $this->getReferenceKey())),
+      'type' => get_class($this),
+      'table' => $this->getReferenceTable(),
+      'key' => $this->getReferenceKey(),
+      'count' => CRM_Core_DAO::singleValueQuery($sql, $params)
+    );
+  }
 }

--- a/CRM/Core/Reference/Dynamic.php
+++ b/CRM/Core/Reference/Dynamic.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Description of a one-way link between two entities
+ *
+ * This is a generic, soft-foreign key based on a pair of columns (entity_id, entity_table).
+ */
+class CRM_Core_Reference_Dynamic extends CRM_Core_Reference_Basic {
+
+  public function matchesTargetTable($tableName) {
+    return TRUE;
+  }
+
+  /**
+   * Create a query to find references to a particular record
+   *
+   * @param CRM_Core_DAO $targetDao the instance for which we want references
+   * @return CRM_Core_DAO a query-handle (like the result of CRM_Core_DAO::executeQuery)
+   */
+  public function findReferences($targetDao) {
+    $refColumn = $this->getReferenceKey();
+    $targetColumn = $this->getTargetKey();
+
+    $params = array(
+      1 => array($targetDao->$targetColumn, 'String'),
+
+      // If anyone complains about $targetDao::getTableName(), then could use
+      // "{get_class($targetDao)}::getTableName();"
+      2 => array($targetDao::getTableName(), 'String'),
+    );
+
+    $sql = <<<EOS
+SELECT id
+FROM {$this->getReferenceTable()}
+WHERE {$refColumn} = %1
+AND {$this->getTypeColumn()} = %2
+EOS;
+
+    $daoName = CRM_Core_DAO_AllCoreTables::getClassForTable($this->getReferenceTable());
+    $result = CRM_Core_DAO::executeQuery($sql, $params, TRUE, $daoName);
+    return $result;
+  }
+}

--- a/CRM/Core/Reference/Dynamic.php
+++ b/CRM/Core/Reference/Dynamic.php
@@ -40,4 +40,31 @@ EOS;
     $result = CRM_Core_DAO::executeQuery($sql, $params, TRUE, $daoName);
     return $result;
   }
+
+  public function getReferenceCount($targetDao) {
+    $targetColumn = $this->getTargetKey();
+    $params = array(
+      1 => array($targetDao->$targetColumn, 'String'),
+
+      // If anyone complains about $targetDao::getTableName(), then could use
+      // "{get_class($targetDao)}::getTableName();"
+      2 => array($targetDao::getTableName(), 'String'),
+    );
+
+    $sql = <<<EOS
+SELECT count(id)
+FROM {$this->getReferenceTable()}
+WHERE {$this->getReferenceKey()} = %1
+AND {$this->getTypeColumn()} = %2
+EOS;
+
+    return array(
+      'name' => implode(':', array('sql', $this->getReferenceTable(), $this->getReferenceKey())),
+      'type' => get_class($this),
+      'table' => $this->getReferenceTable(),
+      'key' => $this->getReferenceKey(),
+      'count' => CRM_Core_DAO::singleValueQuery($sql, $params)
+    );
+  }
+
 }

--- a/CRM/Core/Reference/Interface.php
+++ b/CRM/Core/Reference/Interface.php
@@ -19,4 +19,14 @@ interface CRM_Core_Reference_Interface {
    * @return CRM_Core_DAO|NULL a query-handle (like the result of CRM_Core_DAO::executeQuery)
    */
   public function findReferences($targetDao);
+
+  /**
+   * Create a query to find references to a particular record
+   *
+   * @param CRM_Core_DAO $targetDao the instance for which we want references
+   * @return array a record describing the reference; must include the keys:
+   *  - 'type': string (not necessarily unique)
+   *  - 'count': int
+   */
+  public function getReferenceCount($targetDao);
 }

--- a/CRM/Core/Reference/Interface.php
+++ b/CRM/Core/Reference/Interface.php
@@ -1,0 +1,22 @@
+<?php
+interface CRM_Core_Reference_Interface {
+  public function getReferenceTable();
+
+  public function getReferenceKey();
+
+  /**
+   * Determine if a given table is a target of this reference.
+   *
+   * @param string $tableName
+   * @return bool
+   */
+  public function matchesTargetTable($tableName);
+
+  /**
+   * Create a query to find references to a particular record
+   *
+   * @param CRM_Core_DAO $targetDao the instance for which we want references
+   * @return CRM_Core_DAO a query-handle (like the result of CRM_Core_DAO::executeQuery)
+   */
+  public function findReferences($targetDao);
+}

--- a/CRM/Core/Reference/Interface.php
+++ b/CRM/Core/Reference/Interface.php
@@ -16,7 +16,7 @@ interface CRM_Core_Reference_Interface {
    * Create a query to find references to a particular record
    *
    * @param CRM_Core_DAO $targetDao the instance for which we want references
-   * @return CRM_Core_DAO a query-handle (like the result of CRM_Core_DAO::executeQuery)
+   * @return CRM_Core_DAO|NULL a query-handle (like the result of CRM_Core_DAO::executeQuery)
    */
   public function findReferences($targetDao);
 }

--- a/CRM/Core/Reference/OptionValue.php
+++ b/CRM/Core/Reference/OptionValue.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * Description of a one-way link between an option-value and an entity
+ */
+class CRM_Core_Reference_OptionValue extends CRM_Core_Reference_Basic {
+  /**
+   * @var string option-group-name
+   */
+  protected $targetOptionGroupName;
+
+  /**
+   * @var int|NULL null if not yet loaded
+   */
+  protected $targetOptionGroupId;
+
+  function __construct($refTable, $refKey, $targetTable = NULL, $targetKey = 'id', $optionGroupName) {
+    parent::__construct($refTable, $refKey, $targetTable, $targetKey, NULL);
+    $this->targetOptionGroupName = $optionGroupName;
+  }
+
+  public function findReferences($targetDao) {
+    if (! ($targetDao instanceof CRM_Core_DAO_OptionValue)) {
+      throw new CRM_Core_Exception("Mismatched reference: expected OptionValue but received " . get_class($targetDao));
+    }
+    if ($targetDao->option_group_id == $this->getTargetOptionGroupId()) {
+      return parent::findReferences($targetDao);
+    } else {
+      return NULL;
+    }
+  }
+
+  public function getTargetOptionGroupId() {
+    if ($this->targetOptionGroupId === NULL) {
+      $this->targetOptionGroupId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', $this->targetOptionGroupName, 'id', 'name');
+    }
+    return $this->targetOptionGroupId;
+  }
+}

--- a/CRM/Core/Reference/OptionValue.php
+++ b/CRM/Core/Reference/OptionValue.php
@@ -30,6 +30,17 @@ class CRM_Core_Reference_OptionValue extends CRM_Core_Reference_Basic {
     }
   }
 
+  public function getReferenceCount($targetDao) {
+    if (! ($targetDao instanceof CRM_Core_DAO_OptionValue)) {
+      throw new CRM_Core_Exception("Mismatched reference: expected OptionValue but received " . get_class($targetDao));
+    }
+    if ($targetDao->option_group_id == $this->getTargetOptionGroupId()) {
+      return parent::getReferenceCount($targetDao);
+    } else {
+      return NULL;
+    }
+  }
+
   public function getTargetOptionGroupId() {
     if ($this->targetOptionGroupId === NULL) {
       $this->targetOptionGroupId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', $this->targetOptionGroupName, 'id', 'name');

--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -706,9 +706,9 @@ class CRM_Utils_Array {
       $node = &$result;
       foreach ($keys as $key) {
         if (is_array($record)) {
-          $keyvalue = $record[$key];
+          $keyvalue = isset($record[$key]) ? $record[$key] : NULL;
         } else {
-          $keyvalue = $record->{$key};
+          $keyvalue = isset($record->{$key}) ? $record->{$key} : NULL;
         }
         if (isset($node[$keyvalue]) && !is_array($node[$keyvalue])) {
           $node[$keyvalue] = array();

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -457,6 +457,23 @@ abstract class CRM_Utils_Hook {
   }
 
   /**
+   * Determine how many other records refer to a given record
+   *
+   * @param CRM_Core_DAO $dao the item for which we want a reference count
+   * @param array $refCounts each item in the array is an array with keys:
+   *   - name: string, eg "sql:civicrm_email:contact_id"
+   *   - type: string, eg "sql"
+   *   - count: int, eg "5" if there are 5 email addresses that refer to $dao
+   * @return void
+   */
+  static function referenceCounts($dao, &$refCounts) {
+    return self::singleton()->invoke(2, $dao, $refCounts,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      'civicrm_referenceCounts'
+    );
+  }
+
+  /**
    * This hook is called when building the amount structure for a Contribution or Event Page
    *
    * @param int    $pageType - is this a contribution or event page

--- a/api/v3/Generic.php
+++ b/api/v3/Generic.php
@@ -52,7 +52,7 @@ function civicrm_api3_generic_getfields($apiRequest) {
   // defaults based on data model and API policy
   switch ($action) {
     case 'getfields':
-      $values = _civicrm_api_get_fields($entity, false, $apiRequest['params']);
+      $values = _civicrm_api_get_fields($entity, FALSE, $apiRequest['params']);
       return civicrm_api3_create_success($values, $apiRequest['params'], $entity, 'getfields');
     case 'create':
     case 'update':
@@ -203,6 +203,36 @@ function civicrm_api3_generic_getvalue($apiRequest) {
   }
 
   return civicrm_api3_create_error("missing param return=field you want to read the value of", array('error_type' => 'mandatory_missing', 'missing_param' => 'return'));
+}
+
+function _civicrm_api3_generic_getrefcount_spec(&$params) {
+  $params['id']['api.required'] = 1;
+}
+
+/**
+ * API to determine if a record is in-use
+ *
+ * @param array $apiRequest api request as an array
+ *
+ * @throws API_Exception
+ * @return array API result (int 0 or 1)
+ */
+function civicrm_api3_generic_getrefcount($apiRequest) {
+  $entityToClassMap = CRM_Core_DAO_AllCoreTables::daoToClass();
+  if (!isset($entityToClassMap[$apiRequest['entity']])) {
+    throw new API_Exception("The entity '{$apiRequest['entity']}' is unknown or unsupported by 'getrefcount'. Consider implementing this API.", 'getrefcount_unsupported');
+  }
+  $daoClass = $entityToClassMap[$apiRequest['entity']];
+
+  /* @var $dao CRM_Core_DAO */
+  $dao = new $daoClass();
+  $dao->id = $apiRequest['params']['id'];
+  if ($dao->find(TRUE)) {
+    return civicrm_api3_create_success($dao->getReferenceCounts());
+  }
+  else {
+    return civicrm_api3_create_success(array());
+  }
 }
 
 /**

--- a/tests/phpunit/CRM/Case/XMLRepositoryTest.php
+++ b/tests/phpunit/CRM/Case/XMLRepositoryTest.php
@@ -1,0 +1,162 @@
+<?php
+
+require_once 'CiviTest/CiviUnitTestCase.php';
+
+class CRM_Case_XMLRepositoryTest extends CiviUnitTestCase {
+  protected $fixtures = array();
+
+  protected function setUp() {
+    parent::setUp();
+    $this->fixtures['CaseTypeWithSingleActivityType'] = '
+<CaseType>
+  <name>CaseTypeWithSingleActivityType</name>
+  <ActivityTypes>
+    <ActivityType>
+      <name>Single Activity Type</name>
+      <max_instances>1</max_instances>
+    </ActivityType>
+  </ActivityTypes>
+</CaseType>
+    ';
+    $this->fixtures['CaseTypeWithTwoActivityTypes'] = '
+<CaseType>
+  <name>CaseTypeWithTwoActivityTypes</name>
+  <ActivityTypes>
+    <ActivityType>
+      <name>First Activity Type</name>
+      <max_instances>1</max_instances>
+    </ActivityType>
+    <ActivityType>
+      <name>Second Activity Type</name>
+    </ActivityType>
+  </ActivityTypes>
+</CaseType>
+    ';
+    $this->fixtures['CaseTypeWithThreeActivityTypes'] = '
+<CaseType>
+  <name>CaseTypeWithThreeActivityTypes</name>
+  <ActivityTypes>
+    <ActivityType>
+      <name>First Activity Type</name>
+      <max_instances>1</max_instances>
+    </ActivityType>
+    <ActivityType>
+      <name>Second Activity Type</name>
+    </ActivityType>
+    <ActivityType>
+      <name>Third Activity Type</name>
+    </ActivityType>
+  </ActivityTypes>
+</CaseType>
+    ';
+    $this->fixtures['CaseTypeWithSingleRole'] = '
+<CaseType>
+  <name>CaseTypeWithSingleRole</name>
+  <CaseRoles>
+    <RelationshipType>
+        <name>Single Role</name>
+        <creator>1</creator>
+    </RelationshipType>
+ </CaseRoles>
+</CaseType>
+    ';
+    $this->fixtures['CaseTypeWithTwoRoles'] = '
+<CaseType>
+  <name>CaseTypeWithTwoRoles</name>
+  <CaseRoles>
+    <RelationshipType>
+        <name>First Role</name>
+        <creator>1</creator>
+    </RelationshipType>
+    <RelationshipType>
+        <name>Second Role</name>
+    </RelationshipType>
+ </CaseRoles>
+</CaseType>
+    ';
+    $this->fixtures['CaseTypeWithThreeRoles'] = '
+<CaseType>
+  <name>CaseTypeWithThreeRoles</name>
+  <CaseRoles>
+    <RelationshipType>
+        <name>First Role</name>
+        <creator>1</creator>
+    </RelationshipType>
+    <RelationshipType>
+        <name>Second Role</name>
+    </RelationshipType>
+    <RelationshipType>
+        <name>Third Role</name>
+    </RelationshipType>
+ </CaseRoles>
+</CaseType>
+    ';
+
+  }
+
+  function testGetActivityReferenceCount_1() {
+    $repo = new CRM_Case_XMLRepository(
+      array('CaseTypeWithSingleActivityType'),
+      array(
+        'CaseTypeWithSingleActivityType' => new SimpleXMLElement($this->fixtures['CaseTypeWithSingleActivityType']),
+        /* noise: */
+        'CaseTypeWithSingleRole' => new SimpleXMLElement($this->fixtures['CaseTypeWithSingleRole']),
+      )
+    );
+
+    $this->assertEquals(1, $repo->getActivityReferenceCount('Single Activity Type'));
+    $this->assertEquals(0, $repo->getActivityReferenceCount('First Activity Type'));
+    $this->assertEquals(0, $repo->getActivityReferenceCount('Second Activity Type'));
+    $this->assertEquals(0, $repo->getActivityReferenceCount('Third Activity Type'));
+  }
+
+  function testGetActivityReferenceCount_23() {
+    $repo = new CRM_Case_XMLRepository(
+      array('CaseTypeWithTwoActivityTypes', 'CaseTypeWithThreeActivityTypes'),
+      array(
+        'CaseTypeWithTwoActivityTypes' => new SimpleXMLElement($this->fixtures['CaseTypeWithTwoActivityTypes']),
+        'CaseTypeWithThreeActivityTypes' => new SimpleXMLElement($this->fixtures['CaseTypeWithThreeActivityTypes']),
+        /* noise: */
+        'CaseTypeWithSingleRole' => new SimpleXMLElement($this->fixtures['CaseTypeWithSingleRole']),
+      )
+    );
+
+    $this->assertEquals(0, $repo->getActivityReferenceCount('Single Activity Type'));
+    $this->assertEquals(2, $repo->getActivityReferenceCount('First Activity Type'));
+    $this->assertEquals(2, $repo->getActivityReferenceCount('Second Activity Type'));
+    $this->assertEquals(1, $repo->getActivityReferenceCount('Third Activity Type'));
+  }
+
+  function testGetRoleReferenceCount_1() {
+    $repo = new CRM_Case_XMLRepository(
+      array('CaseTypeWithSingleRole', 'CaseTypeWithSingleActivityType'),
+      array(
+        'CaseTypeWithSingleRole' => new SimpleXMLElement($this->fixtures['CaseTypeWithSingleRole']),
+        /* noise: */
+        'CaseTypeWithSingleActivityType' => new SimpleXMLElement($this->fixtures['CaseTypeWithSingleActivityType']),
+      )
+    );
+
+    $this->assertEquals(1, $repo->getRelationshipReferenceCount('Single Role'));
+    $this->assertEquals(0, $repo->getRelationshipReferenceCount('First Role'));
+    $this->assertEquals(0, $repo->getRelationshipReferenceCount('Second Role'));
+    $this->assertEquals(0, $repo->getRelationshipReferenceCount('Third Role'));
+  }
+
+  function testGetRoleReferenceCount_23() {
+    $repo = new CRM_Case_XMLRepository(
+      array('CaseTypeWithTwoRoles', 'CaseTypeWithThreeRoles', 'CaseTypeWithSingleActivityType'),
+      array(
+        'CaseTypeWithTwoRoles' => new SimpleXMLElement($this->fixtures['CaseTypeWithTwoRoles']),
+        'CaseTypeWithThreeRoles' => new SimpleXMLElement($this->fixtures['CaseTypeWithThreeRoles']),
+        /* noise: */
+        'CaseTypeWithSingleActivityType' => new SimpleXMLElement($this->fixtures['CaseTypeWithSingleActivityType']),
+      )
+    );
+
+    $this->assertEquals(0, $repo->getRelationshipReferenceCount('Single Role'));
+    $this->assertEquals(2, $repo->getRelationshipReferenceCount('First Role'));
+    $this->assertEquals(2, $repo->getRelationshipReferenceCount('Second Role'));
+    $this->assertEquals(1, $repo->getRelationshipReferenceCount('Third Role'));
+  }
+}

--- a/tests/phpunit/CRM/Core/DAOTest.php
+++ b/tests/phpunit/CRM/Core/DAOTest.php
@@ -21,7 +21,7 @@ class CRM_Core_DAOTest extends CiviUnitTestCase {
     $contactRef = $refsByTarget['civicrm_contact'];
     $this->assertEquals('contact_id', $contactRef->getReferenceKey());
     $this->assertEquals('id', $contactRef->getTargetKey());
-    $this->assertEquals(FALSE, $contactRef->isGeneric());
+    $this->assertEquals('CRM_Core_Reference_Basic', get_class($contactRef));
   }
 
   function testGetReferencesToTable() {
@@ -35,7 +35,7 @@ class CRM_Core_DAOTest extends CiviUnitTestCase {
     $this->assertEquals('entity_id', $genericRef->getReferenceKey());
     $this->assertEquals('entity_table', $genericRef->getTypeColumn());
     $this->assertEquals('id', $genericRef->getTargetKey());
-    $this->assertEquals(TRUE, $genericRef->isGeneric());
+    $this->assertEquals('CRM_Core_Reference_Dynamic', get_class($genericRef));
   }
 
   function testFindReferences() {

--- a/tests/phpunit/CRM/Core/DAOTest.php
+++ b/tests/phpunit/CRM/Core/DAOTest.php
@@ -69,50 +69,6 @@ class CRM_Core_DAOTest extends CiviUnitTestCase {
     $this->assertEquals($contact->id, $refDao->contact_id);
   }
 
-  function testGetReferenceCounts() {
-    $result = $this->callAPISuccess('Contact', 'create', array(
-      'first_name' => 'Testily',
-      'last_name' => 'McHaste',
-      'contact_type' => 'Individual',
-      'api.Email.replace' => array(
-        'values' => array(
-          array(
-            'email' => 'spam@dev.null',
-            'is_primary' => 0,
-            'location_type_id' => 1,
-          )
-        ),
-      ),
-      'api.Phone.replace' => array(
-        'values' => array(
-          array(
-            'phone' => '234-567-0001',
-            'is_primary' => 1,
-            'location_type_id' => 1,
-          ),
-          array(
-            'phone' => '234-567-0002',
-            'is_primary' => 0,
-            'location_type_id' => 1,
-          ),
-        ),
-      ),
-    ));
-
-    $dao = new CRM_Contact_BAO_Contact();
-    $dao->id = $result['id'];
-    $this->assertTrue((bool) $dao->find(TRUE));
-
-    $refCounts = $dao->getReferenceCounts();
-    $this->assertTrue(is_array($refCounts));
-    $refCountsIdx = CRM_Utils_Array::index(array('name'), $refCounts);
-    $this->assertEquals(1, $refCountsIdx['sql:civicrm_email:contact_id']['count']);
-    $this->assertEquals('civicrm_email', $refCountsIdx['sql:civicrm_email:contact_id']['table']);
-    $this->assertEquals(2, $refCountsIdx['sql:civicrm_phone:contact_id']['count']);
-    $this->assertEquals('civicrm_phone', $refCountsIdx['sql:civicrm_phone:contact_id']['table']);
-    $this->assertTrue(!isset($refCountsIdx['sql:civicrm_address:contact_id']));
-  }
-
   function composeQueryExamples() {
     $cases = array();
     // $cases[] = array('Input-SQL', 'Input-Params', 'Expected-SQL');

--- a/tests/phpunit/CRM/Utils/ArrayTest.php
+++ b/tests/phpunit/CRM/Utils/ArrayTest.php
@@ -57,12 +57,18 @@ class CRM_Utils_ArrayTest extends CiviUnitTestCase {
       'familiar' => TRUE,
       'value' => 'Hey'
     );
+    $inputs[] = array(
+      'msgid' => 'greeting',
+      'familiar' => TRUE,
+      'value' => 'Universal greeting'
+    );
 
     $byLangMsgid = CRM_Utils_Array::index(array('lang', 'msgid'), $inputs);
     $this->assertEquals($inputs[4], $byLangMsgid['en']['greeting']);
     $this->assertEquals($inputs[1], $byLangMsgid['en']['parting']);
     $this->assertEquals($inputs[2], $byLangMsgid['fr']['greeting']);
     $this->assertEquals($inputs[3], $byLangMsgid['fr']['parting']);
+    $this->assertEquals($inputs[5], $byLangMsgid[NULL]['greeting']);
   }
 
   function testCollect() {

--- a/xml/templates/dao.tpl
+++ b/xml/templates/dao.tpl
@@ -137,17 +137,17 @@ class {$table.className} extends CRM_Core_DAO {ldelim}
      *
      * @static
      * @access public
-     * @return array of CRM_Core_EntityReference
+     * @return array of CRM_Core_Reference_Interface
      */
     static function getReferenceColumns() {ldelim}
       if (!self::$_links) {ldelim}
         self::$_links = array(
 {foreach from=$table.foreignKey item=foreign}
-          new CRM_Core_EntityReference(self::getTableName(), '{$foreign.name}', '{$foreign.table}', '{$foreign.key}'),
+          new CRM_Core_Reference_Basic(self::getTableName(), '{$foreign.name}', '{$foreign.table}', '{$foreign.key}'),
 {/foreach}
 
 {foreach from=$table.dynamicForeignKey item=foreign}
-          new CRM_Core_EntityReference(self::getTableName(), '{$foreign.idColumn}', NULL, '{$foreign.key|default:'id'}', '{$foreign.typeColumn}'),
+          new CRM_Core_Reference_Dynamic(self::getTableName(), '{$foreign.idColumn}', NULL, '{$foreign.key|default:'id'}', '{$foreign.typeColumn}'),
 {/foreach}
         );
       {rdelim}

--- a/xml/templates/dao.tpl
+++ b/xml/templates/dao.tpl
@@ -141,15 +141,14 @@ class {$table.className} extends CRM_Core_DAO {ldelim}
      */
     static function getReferenceColumns() {ldelim}
       if (!self::$_links) {ldelim}
-        self::$_links = array(
+        self::$_links = static::createReferenceColumns(__CLASS__);
 {foreach from=$table.foreignKey item=foreign}
-          new CRM_Core_Reference_Basic(self::getTableName(), '{$foreign.name}', '{$foreign.table}', '{$foreign.key}'),
+        self::$_links[] = new CRM_Core_Reference_Basic(self::getTableName(), '{$foreign.name}', '{$foreign.table}', '{$foreign.key}');
 {/foreach}
 
 {foreach from=$table.dynamicForeignKey item=foreign}
-          new CRM_Core_Reference_Dynamic(self::getTableName(), '{$foreign.idColumn}', NULL, '{$foreign.key|default:'id'}', '{$foreign.typeColumn}'),
+        self::$_links[] = new CRM_Core_Reference_Dynamic(self::getTableName(), '{$foreign.idColumn}', NULL, '{$foreign.key|default:'id'}', '{$foreign.typeColumn}');
 {/foreach}
-        );
       {rdelim}
       return self::$_links;
     {rdelim}


### PR DESCRIPTION
For example: Before deciding whether to delete RelationshipType 123, we can see how many usages there are by calling:

``` php
$result = civicrm_api3('RelationshipType', 'getrefcount', array(
  'id' => 123,
));
```

Internally, this borrows from / refactors the pre-existing CRM_Core_DAO::findReferences() and introduces a sibling function, CRM_Core_DAO::getReferenceCount(). As before, this counts references in standard SQL FK's and dynamic SQL FK's. It adds support for option-value FK's like "civicrm_activity.activity_type_id".

FIXME: It does not yet count references stored in CiviCase XML.
