### PR TITLE
Crm 14317 comment fix

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -380,6 +380,12 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
       }
     }
 
+    // rectify params to what proximity search expects if there is a value for prox_distance
+    // CRM-7021
+    if (!empty($params)) {
+      CRM_Contact_BAO_ProximityQuery::fixInputParams($params);
+    }
+
     $query = new CRM_Contact_BAO_Query($params, $returnProperties, NULL,
       FALSE, FALSE, $queryMode,
       FALSE, TRUE, TRUE, NULL, $queryOperator


### PR DESCRIPTION
applied Atif's fix patch for the fixing the comment issue.

the BAO method <code>CRM_Contact_BAO_ProximityQuery::fixInputParams($params);</code> to modify the params used for proximity search is done while searching the contact but not while exporting the contacts. That's the reason it was working on searching and not while actual export.
