### PR TITLE
CRM-14704 : newly added target contact ids won't have any effect of activity creation

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -933,11 +933,6 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
       $this->_activityId
     );
 
-    // format target params
-    if (!$this->_single) {
-      $params['target_contact_id'] = $this->_contactIds;
-    }
-
     $activity = array();
     if (!empty($params['is_multi_activity']) &&
       !CRM_Utils_Array::crmIsEmptyArray($params['target_contact_id'])


### PR DESCRIPTION
removal of <code>target_contact_id</code> overriding with selected <code>contactIds</code> code, as we now (in 4.5) support editable target_contact_id upon 'record activities for contacts'
