### PR TITLE
CRM-14747 - Profiles - Fixed error caused by profile fields with empty labels

### DIFF
--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -958,7 +958,6 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
     $websiteTypes  = CRM_Core_PseudoConstant::get('CRM_Core_DAO_Website', 'website_type_id');
 
     $multipleFields = array('url');
-    $nullIndex = $nullValueIndex = ' ';
 
     //start of code to set the default values
     foreach ($fields as $name => $field) {
@@ -972,18 +971,12 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
         continue;
       }
 
+      // Create a unique, non-empty index for each field.
       $index = $field['title'];
-      //handle for the label not set for the field
-      if (empty($field['title'])) {
-        $index = $nullIndex;
-        $nullIndex .= $nullIndex;
-      }
+      if ($index === '') $index = ' ';
+      while (array_key_exists($index, $values))
+        $index .= ' ';
 
-      //handle the case to avoid re-write where the profile field labels are the same
-      if (array_key_exists($index, $values)) {
-        $index .= $nullValueIndex;
-        $nullValueIndex .= $nullValueIndex;
-      }
       $params[$index] = $values[$index] = '';
       $customFieldName = NULL;
       // hack for CRM-665

--- a/CRM/Profile/Page/Dynamic.php
+++ b/CRM/Profile/Page/Dynamic.php
@@ -321,16 +321,15 @@ class CRM_Profile_Page_Dynamic extends CRM_Core_Page {
       $profileFields = array();
       $labels = array();
 
-      //CRM-14338
-      $nullValueIndex = ' ';
       foreach ($fields as $name => $field) {
-        if ( isset($labels[$field['title']]) ) {
-          $labels[$field['title'].$nullValueIndex] = preg_replace('/\s+|\W+/', '_', $name);
-          $nullValueIndex .= $nullValueIndex;
-        }
-        else {
-          $labels[$field['title']] = preg_replace('/\s+|\W+/', '_', $name);
-        }
+        //CRM-14338
+        // Create a unique, non-empty index for each field.
+        $index = $field['title'];
+        if ($index === '') $index = ' ';
+        while (array_key_exists($index, $labels))
+          $index .= ' ';
+
+        $labels[$index] = preg_replace('/\s+|\W+/', '_', $name);
       }
 
       foreach ($values as $title => $value) {


### PR DESCRIPTION
This patch fixes an error that occurred when viewing a profile in which one or more fields had empty labels.

The function CRM_Profile_Page_Dynamic::run() is used to view a profile. It calls CRM_Core_BAO_UFGroup::getValues to create an array of field values ($values). It then creates an array of field labels ($labels). It expects the indexes of these two arrays to match up. However, there was a mismatch in the code that generated the indexes for these arrays: The indexes are based on the field labels, and the two functions handled empty labels differently. So if one or more labels were empty, the indexes didn't match, which caused an error.

This patch fixes the problem by using the same code to generate the indexes for both arrays.

---
- CRM-14747:
  https://issues.civicrm.org/jira/browse/CRM-14747
