### PR TITLE
CRM-14765 - CRM_Utils_System::createDefaultCrudLink

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -510,6 +510,42 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
   }
 
   /**
+   * @param array $crudLinkSpec with keys:
+   *  - action: int, CRM_Core_Action::UPDATE or CRM_Core_Action::VIEW [default: VIEW]
+   *  - entity_table: string, eg "civicrm_contact"
+   *  - entity_id: int
+   * @return array|NULL NULL if unavailable, or an array. array has keys:
+   *  - path: string
+   *  - query: string
+   *  - title: string
+   * @see CRM_Utils_System::createDefaultCrudLink
+   */
+  public function createDefaultCrudLink($crudLinkSpec) {
+    switch ($crudLinkSpec['action']) {
+      case CRM_Core_Action::VIEW:
+        return array(
+          'title' => $this->display_name,
+          'path' => 'civicrm/contact/view',
+          'query' => array(
+            'reset' => 1,
+            'cid' => $this->id,
+          ),
+        );
+      case CRM_Core_Action::UPDATE:
+        return array(
+          'title' => $this->display_name,
+          'path' => 'civicrm/contact/add',
+          'query' => array(
+            'reset' => 1,
+            'action' => 'update',
+            'cid' => $this->id,
+          ),
+        );
+    }
+    return NULL;
+  }
+
+  /**
    *
    * Get the values for pseudoconstants for name->value and reverse.
    *

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -1694,4 +1694,27 @@ abstract class CRM_Utils_Hook {
       'civicrm_caseChange'
     );
   }
+
+  /**
+   * Generate a default CRUD URL for an entity
+   *
+   * @param array $spec with keys:
+   *   - action: int, eg CRM_Core_Action::VIEW or CRM_Core_Action::UPDATE
+   *   - entity_table: string
+   *   - entity_id: int
+   * @param CRM_Core_DAO $bao
+   * @param array $link to define the link, add these keys to $link:
+   *  - title: string
+   *  - path: string
+   *  - query: array
+   *  - url: string (used in lieu of "path"/"query")
+   *      Note: if making "url" CRM_Utils_System::url(), set $htmlize=false
+   * @return mixed
+   */
+  static function crudLink($spec, $bao, &$link) {
+    return self::singleton()->invoke(3, $spec, $bao, $link,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      'civicrm_crudLink'
+    );
+  }
 }


### PR DESCRIPTION
Add helper for creating hyperlinks to entities based on the 
entity-type/entity-id/desired-action. The link is determined by the entity's
BAO or by hook.
