### PR TITLE
CRM-14605 - Add define(CIVICRM_WEBTEST)

### DIFF
--- a/tests/phpunit/CiviTest/CiviSeleniumTestCase.php
+++ b/tests/phpunit/CiviTest/CiviSeleniumTestCase.php
@@ -32,6 +32,7 @@ require_once 'PHPUnit/Extensions/SeleniumTestCase.php';
  */
 define('CIVICRM_SETTINGS_PATH', __DIR__ . '/civicrm.settings.dist.php');
 define('CIVICRM_SETTINGS_LOCAL_PATH', __DIR__ . '/civicrm.settings.local.php');
+define('CIVICRM_WEBTEST', 1);
 
 if (file_exists(CIVICRM_SETTINGS_LOCAL_PATH)) {
   require_once CIVICRM_SETTINGS_LOCAL_PATH;


### PR DESCRIPTION
This can be used by CiviTest/civicrm.settings*.php to select different 
configuration options for web-tests and unit-tests.
