### PR TITLE
CRM_Utils_Check_Env::checkMysqlTime - Be more forgiving

### DIFF
--- a/CRM/Utils/Check/Env.php
+++ b/CRM/Utils/Check/Env.php
@@ -51,11 +51,11 @@ class CRM_Utils_Check_Env {
 
     $phpNow = date('Y-m-d H:i');
     $sqlNow = CRM_Core_DAO::singleValueQuery("SELECT date_format(now(), '%Y-%m-%d %H:%i')");
-    if ($phpNow != $sqlNow) {
+    if (!CRM_Utils_Time::isEqual($phpNow, $sqlNow, 2.5 * 60)) {
       $messages[] = new CRM_Utils_Check_Message(
         'checkMysqlTime',
         ts('Timestamps reported by MySQL (eg "%2") and PHP (eg "%3" ) are mismatched.<br /><a href="%1">Read more about this warning</a>', array(
-          1 => CRM_Utils_System::getWikiBaseURL()  . 'checkMysqlTime',
+          1 => CRM_Utils_System::getWikiBaseURL() . 'checkMysqlTime',
           2 => $sqlNow,
           3 => $phpNow,
         )),

--- a/CRM/Utils/Time.php
+++ b/CRM/Utils/Time.php
@@ -86,5 +86,19 @@ class CRM_Utils_Time {
   static function resetTime() {
     self::$_delta = 0;
   }
+
+  /**
+   * Approximate time-comparison. $a and $b are considered equal if they
+   * are within $threshold seconds of each other.
+   *
+   * @param string $a time which can be parsed by strtotime
+   * @param string $b time which can be parsed by strtotime
+   * @param int $threshold maximum allowed difference (in seconds)
+   * @return bool
+   */
+  static function isEqual($a, $b, $threshold = 0) {
+    $diff = strtotime($b) - strtotime($a);
+    return (abs($diff) <= $threshold);
+  }
 }
 

--- a/tests/phpunit/CRM/Utils/TimeTest.php
+++ b/tests/phpunit/CRM/Utils/TimeTest.php
@@ -1,0 +1,32 @@
+<?php
+
+require_once 'CiviTest/CiviUnitTestCase.php';
+
+class CRM_Utils_TimeTest extends CiviUnitTestCase {
+  public function equalCases() {
+    $cases = array(); // array(0 => $timeA, 1 => $timeB, 2 => $threshold, 3 => $expectedResult)
+    $cases[] = array('2012-04-01 12:00:00', '2012-04-01 12:00:00', 0, 1);
+    $cases[] = array('2012-04-01 12:00:00', '2012-04-01 12:00:01', 0, 0);
+    $cases[] = array('2012-04-01 12:00:00', '2012-04-01 12:00:50', 60, 1);
+    $cases[] = array('2012-04-01 12:00:00', '2012-04-01 12:01:02', 60, 0);
+    $cases[] = array('2012-04-01 12:00', '2012-04-01 12:01', 0, 0);
+    $cases[] = array('2012-04-01 12:00', '2012-04-01 12:01', 60, 1);
+    $cases[] = array('2012-04-01 12:00', '2012-04-01 12:01', 120, 1);
+    return $cases;
+  }
+
+  /**
+   * @param string $timeA
+   * @param string $timeB
+   * @param int $threshold
+   * @param bool $expectedResult
+   * @dataProvider equalCases
+   */
+  function testEquals($timeA, $timeB, $threshold, $expectedResult) {
+    $actual = CRM_Utils_Time::isEqual($timeA, $timeB, $threshold);
+    $this->assertEquals($expectedResult, $actual);
+
+    $actual = CRM_Utils_Time::isEqual($timeB, $timeA, $threshold);
+    $this->assertEquals($expectedResult, $actual);
+  }
+}


### PR DESCRIPTION
Per lcdweb, differences of 1-2 min are acceptable. This check was originally
created because some PHP/MySQL systems have different TZ's and show
differences of several hours.
