### PR TITLE
Core bug due to due to Civi/Listeners.

### DIFF
--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -278,9 +278,12 @@ abstract class CRM_Utils_Hook {
    * @access public
    */
   static function post($op, $objectName, $objectId, &$objectRef) {
-    $event = new \Civi\Core\Event\PostEvent($op, $objectName, $objectId, $objectRef);
-    \Civi\Core\Container::singleton()->get('dispatcher')->dispatch("hook_civicrm_post", $event);
-    \Civi\Core\Container::singleton()->get('dispatcher')->dispatch("hook_civicrm_post::$objectName", $event);
+    //skipping update if operation is delete.
+    if ($op != 'delete') {
+      $event = new \Civi\Core\Event\PostEvent($op, $objectName, $objectId, $objectRef);
+      \Civi\Core\Container::singleton()->get('dispatcher')->dispatch("hook_civicrm_post", $event);
+      \Civi\Core\Container::singleton()->get('dispatcher')->dispatch("hook_civicrm_post::$objectName", $event);
+    }
     return self::singleton()->invoke(4, $op, $objectName, $objectId, $objectRef, self::$_nullObject, self::$_nullObject, 'civicrm_post');
   }
 


### PR DESCRIPTION
When a change related to `Case` occurs Post hook gets called which inturn calls `fireCaseChange` function in `Civi\CCase` in which case updation takes place due to Civi/Listeners.
The same happens for deletion.

Therefore the delete api for `Case` ie `api_v3_CaseTest.testCaseDelete` used to break since the related `Case` is already deleted from the DB.
Hence skipping the call to update when operation is `delete`.
