### PR TITLE
Core bug related to Civi/Listener

### DIFF
--- a/Civi/CCase/Events.php
+++ b/Civi/CCase/Events.php
@@ -55,7 +55,7 @@ class Events {
         throw new \CRM_Core_Exception("CRM_Case_Listener does not support entity {$event->entity}");
     }
 
-    if ($caseId && !isset(self::$isActive[$caseId])) {
+    if ($caseId && !isset(self::$isActive[$caseId]) && $event->action != 'delete') {
       self::$isActive[$caseId] = 1;
       $analyzer = new \Civi\CCase\Analyzer($caseId);
       \CRM_Utils_Hook::caseChange($analyzer);


### PR DESCRIPTION
When a change related to Case occurs Post hook gets called which inturn calls fireCaseChange function in Civi\CCase in which case updation takes place due to Civi/Listeners.
The same happens for deletion.

Therefore the delete api for Case ie api_v3_CaseTest.testCaseDelete used to break since the related Case is already deleted from the DB.
Hence skipping the update part when operation is delete.
