### PR TITLE
CRM-11836 Event Registrant is forced to select a Payment type when there...

### DIFF
--- a/templates/CRM/Event/Form/Registration/Register.tpl
+++ b/templates/CRM/Event/Form/Registration/Register.tpl
@@ -215,7 +215,7 @@
       var payment_processor = cj("div.payment_processor-section");
       var payment_information = cj("div#payment_information");
 
-      if (isMultiple && cj("#additional_participants").val()) {
+      if (isMultiple && cj("#additional_participants").val() && cj('#pricevalue').text() !== symbol + " 0.00") {
         flag = 0;
       }
 


### PR DESCRIPTION
... is no fee if pay later enabled

---
- CRM-11836: Event Registrant is forced to select a Payment type when there is no fee if pay later enabled
  https://issues.civicrm.org/jira/browse/CRM-11836
