### PR TITLE
CRM-11966 : CiviCRM gives whitescreen on all pages if HTML_PURIFIER module is enabled

### DIFF
--- a/CRM/Core/ClassLoader.php
+++ b/CRM/Core/ClassLoader.php
@@ -85,30 +85,10 @@ class CRM_Core_ClassLoader {
     // we do this to prevent a autoloader errors with joomla / 3rd party packages
     // use absolute path since we dont know the content of include_path as yet
     // CRM-11304
-
-    // since HTML Purifier could potentially be loaded / used by other modules / components
-    // lets check it its already loaded
-    // we also check if the bootstrap file exists since during install of a drupal distro profile
-    // the files might not exists, in which case we skip loading the file
-    // if you change the below, please test on Joomla and also PCP pages
-    $includeHTMLPurifier = TRUE;
-    $htmlPurifierPath = "$civicrm_base_path/packages/IDS/vendors/htmlpurifier/HTMLPurifier/Bootstrap.php";
-    if (
-      class_exists('HTMLPurifier_Bootstrap') ||
-      !file_exists($htmlPurifierPath)
-    ) {
-      $includeHTMLPurifier = FALSE;
-    }
-    else {
-      require_once $htmlPurifierPath;
-    }
-
     // TODO Remove this autoloader. For civicrm-core and civicrm-packages, the composer autoloader works fine.
     // Extensions rely on include_path-based autoloading
     spl_autoload_register(array($this, 'loadClass'), TRUE, $prepend);
-    if ($includeHTMLPurifier) {
-      spl_autoload_register(array('HTMLPurifier_Bootstrap', 'autoload'), TRUE, $prepend);
-    }
+    $this->initHtmlPurifier($prepend);
 
     $this->_registered = TRUE;
     $packages_path = implode(DIRECTORY_SEPARATOR, array($civicrm_base_path, 'packages'));
@@ -120,6 +100,50 @@ class CRM_Core_ClassLoader {
     $include_paths = implode(PATH_SEPARATOR, $include_paths);
     set_include_path($include_paths . PATH_SEPARATOR . get_include_path());
     require_once "$civicrm_base_path/packages/vendor/autoload.php";
+  }
+
+  function initHtmlPurifier($prepend) {
+    if (class_exists('HTMLPurifier_Bootstrap')) {
+      // HTMLPurifier is already initialized, e.g. by the Drupal module.
+      return;
+    }
+
+    $htmlPurifierPath = $this->getHtmlPurifierPath();
+
+    if (FALSE === $htmlPurifierPath) {
+      // No HTMLPurifier available, e.g. during installation.
+      return;
+    }
+    require_once $htmlPurifierPath;
+    spl_autoload_register(array('HTMLPurifier_Bootstrap', 'autoload'), TRUE, $prepend);
+  }
+
+  /**
+   * @return string|false
+   *   Path to the file where the class HTMLPurifier_Bootstrap is defined, or
+   *   FALSE, if such a file does not exist.
+   */
+  private function getHtmlPurifierPath() {
+    if (function_exists('libraries_get_path')
+      && ($path = libraries_get_path('htmlpurifier'))
+      && file_exists($file = $path . '/library/HTMLPurifier/Bootstrap.php')
+    ) {
+      // We are in Drupal 7, and the HTMLPurifier module is installed.
+      // Use Drupal's HTMLPurifier path, to avoid conflicts.
+      // @todo Verify that we are really in Drupal 7, and not in some other
+      // environment that happens to provide a 'libraries_get_path()' function.
+      return $file;
+    }
+
+    // we do this to prevent a autoloader errors with joomla / 3rd party packages
+    // Use absolute path, since we don't know the content of include_path yet.
+    // CRM-11304
+    $file = dirname(__FILE__) . '/../../packages/IDS/vendors/htmlpurifier/HTMLPurifier/Bootstrap.php';
+    if (file_exists($file)) {
+      return $file;
+    }
+
+    return FALSE;
   }
 
   /**


### PR DESCRIPTION
CRM-11966 : rework on patch provided in here :- https://github.com/civicrm/civicrm-core/pull/2652

There were quit a few changes after #2652 PR was submitted and hence it got stale. 
Reworked on this patch and sending this PR.
