### PR TITLE
fix for bug CRM-14767

### DIFF
--- a/templates/CRM/Contact/Form/Edit/Address/street_address.tpl
+++ b/templates/CRM/Contact/Form/Edit/Address/street_address.tpl
@@ -35,7 +35,7 @@
         </td>
     </tr>
 
-    {if $parseStreetAddress eq 1 && $action eq 2}
+    {if $parseStreetAddress eq 1 && ($action eq 1 || $action eq 2)}
            <tr id="addressElements_{$blockId}" class=hiddenElement>
                <td>
                   {$form.address.$blockId.street_number.label}<br />


### PR DESCRIPTION
When Street parsing is on and you add a new inline address it is not possible to edit the individual street fields

See https://issues.civicrm.org/jira/browse/CRM-14767
