### PR TITLE
CRM-14813 Online event rego receipt - no credit card details shown

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1139,9 +1139,16 @@ WHERE civicrm_event.is_active = 1
             'email' => $email,
             'confirm_email_text' => CRM_Utils_Array::value('confirm_email_text', $values['event']),
             'isShowLocation' => CRM_Utils_Array::value('is_show_location', $values['event']),
-            'contributeMode' => NULL,
+            'contributeMode' => CRM_Utils_Array::value('contributeMode', $template->_tpl_vars),
             'participantID' => $participantId,
             'conference_sessions' => $sessions,
+            'credit_card_number' =>
+                CRM_Utils_System::mungeCreditCard(
+                    CRM_Utils_Array::value('credit_card_number', $participantParams)),
+            'credit_card_exp_date' =>
+                CRM_Utils_Date::mysqlToIso(
+                    CRM_Utils_Date::format(
+                        CRM_Utils_Array::value('credit_card_exp_date', $participantParams))),
           ));
 
         // CRM-13890 : NOTE wait list condition need to be given so that


### PR DESCRIPTION
Fix contributeMode, munge credit_card_number, and format credit_card_exp_date.

I'm not sure that $template->_tpl_vars is the best or the standard place from which to retrieve the contributeMode.

The editing of the credit card number and expiry date are replicated from the equivalent CiviContribute code.
