### PR TITLE
CRM-14815 subscriptionURL() doesn't add checksum when called from CLI

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -350,59 +350,72 @@ abstract class CRM_Core_Payment {
    * @return string
    */
   function subscriptionURL($entityID = NULL, $entity = NULL, $action = 'cancel') {
-    if ($action == 'cancel') {
-      $url = 'civicrm/contribute/unsubscribe';
+    // Set URL
+    switch ($action) {
+      case 'cancel' :
+        $url = 'civicrm/contribute/unsubscribe';
+        break;
+
+      case 'billing' :
+        //in notify mode don't return the update billing url
+        if ($this->_paymentProcessor['billing_mode'] == self::BILLING_MODE_NOTIFY) {
+          return NULL;
+        }
+      	$url = 'civicrm/contribute/updatebilling';
+        break;
+
+      case 'update' :
+        $url = 'civicrm/contribute/updaterecur';
+        break;
     }
-    elseif ($action == 'billing') {
-      //in notify mode don't return the update billing url
-      if ($this->_paymentProcessor['billing_mode'] == self::BILLING_MODE_NOTIFY) {
-        return NULL;
-      }
-      $url = 'civicrm/contribute/updatebilling';
-    }
-    elseif ($action == 'update') {
-      $url = 'civicrm/contribute/updaterecur';
-    }
+
     $session       = CRM_Core_Session::singleton();
     $userId        = $session->get('userID');
-    $checksumValue = "";
+    $contactID     = 0;
+    $checksumValue = '';
+    $entityArg     = '';
 
-    if ($entityID && $entity == 'membership') {
-      if (!$userId) {
-        $contactID     = CRM_Core_DAO::getFieldValue("CRM_Member_DAO_Membership", $entityID, "contact_id");
-        $checksumValue = CRM_Contact_BAO_Contact_Utils::generateChecksum($contactID, NULL, 'inf');
-        $checksumValue = "&cs={$checksumValue}";
-      }
-      return CRM_Utils_System::url($url, "reset=1&mid={$entityID}{$checksumValue}", TRUE, NULL, FALSE, TRUE);
-    }
+    // Find related Contact
+    if ($entityID) {
+      switch ($entity) {
+        case 'membership' :
+          $contactID = CRM_Core_DAO::getFieldValue("CRM_Member_DAO_Membership", $entityID, "contact_id");
+          $entityArg = 'mid';
+          break;
 
-    if ($entityID && $entity == 'contribution') {
-      if (!$userId) {
-        $contactID     = CRM_Core_DAO::getFieldValue("CRM_Contribute_DAO_Contribution", $entityID, "contact_id");
-        $checksumValue = CRM_Contact_BAO_Contact_Utils::generateChecksum($contactID, NULL, 'inf');
-        $checksumValue = "&cs={$checksumValue}";
-      }
-      return CRM_Utils_System::url($url, "reset=1&coid={$entityID}{$checksumValue}", TRUE, NULL, FALSE, TRUE);
-    }
+        case 'contribution' :
+          $contactID = CRM_Core_DAO::getFieldValue("CRM_Contribute_DAO_Contribution", $entityID, "contact_id");
+          $entityArg = 'coid';
+          break;
 
-    if ($entityID && $entity == 'recur') {
-      if (!$userId) {
-        $sql = "
+        case 'recur' :
+          $sql = "
     SELECT con.contact_id
       FROM civicrm_contribution_recur rec
 INNER JOIN civicrm_contribution con ON ( con.contribution_recur_id = rec.id )
      WHERE rec.id = %1
   GROUP BY rec.id";
-        $contactID     = CRM_Core_DAO::singleValueQuery($sql, array(1 => array($entityID, 'Integer')));
-        $checksumValue = CRM_Contact_BAO_Contact_Utils::generateChecksum($contactID, NULL, 'inf');
-        $checksumValue = "&cs={$checksumValue}";
+          $contactID = CRM_Core_DAO::singleValueQuery($sql, array(1 => array($entityID, 'Integer')));
+          $entityArg = 'crid';
+          break;
       }
-      return CRM_Utils_System::url($url, "reset=1&crid={$entityID}{$checksumValue}", TRUE, NULL, FALSE, TRUE);
     }
 
+    // Add entity arguments
+    if ($entityArg != '') {
+      // Add checksum argument
+      if ($contactID != 0 && $userId != $contactID) {
+        $checksumValue = '&cs=' . CRM_Contact_BAO_Contact_Utils::generateChecksum($contactID, NULL, 'inf');
+      }
+      return CRM_Utils_System::url($url, "reset=1&{$entityArg}={$entityID}{$checksumValue}", TRUE, NULL, FALSE, TRUE);
+    }
+
+    // Else login URL
     if ($this->isSupported('accountLoginURL')) {
       return $this->accountLoginURL();
     }
+
+    // Else default
     return $this->_paymentProcessor['url_recur'];
   }
 }


### PR DESCRIPTION
CRM_Core_Payment.php::subscriptionURL() fails to add a checksum to the URL in certain cases. This URL is sent to a contact who is making a recurring payment etc. It is sent to the contact via email and allows them temporary access to cancel/edit the contribution/membership.

Currently the only time a checksum is added is if the userID stored in the Session is zero (an anonymous user).

But this doesn't work when the URL is being generated in a Job. When a Job is invoked via CLI the Job requires a user context for permissioning. In this case the userID is non-zero, but different to the contactID associated with the contribution.

(I suspect this issue also affects back-office people generating the email on behalf of a contact.)

The fix is ...

 1) Add a checksum if the $contactId and $userId are different
 2) Calculate the $contactId even in the case where the $userId is non-zero
 3) Refactor the code using switch statements and comments to improve readability
