### PR TITLE
grant xml fixes, make grant_type exportable so it's available to api, ad...

### DIFF
--- a/xml/schema/Grant/Grant.xml
+++ b/xml/schema/Grant/Grant.xml
@@ -61,6 +61,7 @@
   </field>
   <field>
     <name>money_transfer_date</name>
+    <uniqueName>grant_money_transfer_date</uniqueName>
     <title>Grant Money transfer date</title>
     <type>date</type>
     <comment>Date on which grant money transfer was made.</comment>
@@ -101,7 +102,7 @@
     <html>
       <type>Select</type>
     </html>
-    <export>false</export>
+    <export>true</export>
     <required>true</required>
     <comment>Type of grant. Implicit FK to civicrm_option_value in grant_type option_group.</comment>
     <add>1.8</add>


### PR DESCRIPTION
...d unique name for grant_money_transfer_date
 @joemurray - I was tinkering with grant stuff & grant_type_id doesn't work because it doesn't have  'export' set to TRUE

The other one is a bit more arguable - both your extension & elsewhere the uniquename 'grant_money_transfer_date' is used - but it's not in the schema. It could be changed to never refer to the grant_ version - but the grant schema uses the uniquenames quite a bit so there is internal consistency in adding it

Note that both of these inhibit using profile api to create & update grants
