### PR TITLE
CRM-14822 add checkbox handling to api custom fields

### DIFF
--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -982,7 +982,9 @@ function formatCheckBoxField(&$checkboxFieldValue, $customFieldLabel, $entity) {
   }
   elseif (stristr($checkboxFieldValue, ',')) {
     $formatValue = TRUE;
-    //lets see if we should separate it
+    //lets see if we should separate it - we do this near the end so we
+    // ensure we have already checked that the comma is not part of a legitimate match
+    // and of course, we don't make any changes if we don't now have matches
     $possibleValues = explode(',', $checkboxFieldValue);
   }
   else {

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -921,6 +921,14 @@ function _civicrm_api3_custom_format_params($params, &$values, $extends, $entity
  * We will only alter the value if we are sure that changing it will make it correct - if it appears wrong but does not appear to have a clear fix we
  * don't touch - lots of very cautious code in here
  *
+ * The resulting array should look like
+ * array(
+ *  'key' => 1,
+ *  'key1' => 1,
+ * );
+ *
+ * OR one or more keys wrapped in a CRM_Core_DAO::VALUE_SEPARATOR - either it accepted by the receiving function
+ *
  * @todo - we are probably skipping handling disabled options as presumably getoptions is not giving us them. This should be non-regressive but might
  * be fixed in future
  *
@@ -928,10 +936,6 @@ function _civicrm_api3_custom_format_params($params, &$values, $extends, $entity
  * @param $customFieldLabel
  * @param $entity
  *
- * @internal param $fields
- * @internal param $customFieldID
- * @internal param $checkCheckBoxField
- * @return string
  */
 function formatCheckBoxField(&$checkboxFieldValue, $customFieldLabel, $entity) {
 


### PR DESCRIPTION
This fixes several logged issues as well as ongoing customer & forum complaints to do with the api not handling checkboxes correctly - the new code is only called for custom fields of type CheckBox - no other flows are touched & all the possible formats for checkboxes (ie. the one that already worked & the api-consistent ones) are heavily tested in the new tests (as well as pre-existing ones)

if ($checkCheckBoxField && $fields['custom_' . $customFieldID]['html_type'] == 'CheckBox') {
