### PR TITLE
CRM-14816 Order Rows widget is broken again

### DIFF
--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -511,7 +511,8 @@ class CRM_Core_Resources {
         $this->addStyleUrl($config->customCSSURL, 99, $region);
       }
       if (!CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME, 'disable_core_css')) {
-        $this->addStyleFile('civicrm', 'css/civicrm.css', -99, $region);
+        $this->addStyleFile('civicrm', 'css/civicrm.css', -99, $region)
+        ->addStyleFile('civicrm', 'packages/jquery/plugins/DataTables/media/css/jquery.dataTables.min.css', -99, $region);
       }
     }
     return $this;

--- a/templates/CRM/common/jsortable.tpl
+++ b/templates/CRM/common/jsortable.tpl
@@ -76,8 +76,8 @@ eval('tableId =[' + tableId + ']');
                     sortColumn += '[' + count + ', "asc" ],';
                 }
                 sortId   = getRowId(tdObject, cj(this).attr('id') +' hiddenElement' );
-                sortEnabled = false;
-                columns += '{ "sType": \'' + stype + '\', "fnRender": function (oObj) { return oObj.aData[' + sortId + ']; },"bUseRendered": false},';
+                sortEnabled = true;
+                columns += '{ "render": function ( data, type, row ) { return "<div style=\'display:none\'>"+ data +"</div>" + row[sortId] ; }, "targets": sortColumn,"bUseRendered": false},';
             break;
             case 'nosort':
                 columns += '{ "bSortable": false, "sClass": "'+ getElementClass( this ) +'"},';


### PR DESCRIPTION
---
- CRM-14816: Order Rows widget is broken again
  https://issues.civicrm.org/jira/browse/CRM-14816

The jquery lib for Datatable.js had been changed to 1.10 from 1.8.
Hence the ordering icon were not shown in the table.
