### PR TITLE
Refactored Participant.php

### DIFF
--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -966,7 +966,8 @@ WHERE  civicrm_participant.id = {$participantId}
       $eventLevel = implode(', ', explode(CRM_Core_DAO::VALUE_SEPARATOR,
           substr($eventLevel, 1, -1)
         ));
-      if ($pos = strrpos($eventLevel, '(multiple participants)', 0)) {
+      $pos = strrpos($eventLevel, '(multiple participants)', 0);
+      if ($pos) {
         $eventLevel = substr_replace($eventLevel, "", $pos - 3, 1);
       }
     }
@@ -1460,7 +1461,8 @@ UPDATE  civicrm_participant
       return $mailSent;
     }
 
-    if ($toEmail = CRM_Utils_Array::value('email', $contactDetails)) {
+    $toEmail = CRM_Utils_Array::value('email', $contactDetails);
+    if ($toEmail) {
 
       $contactId = $participantValues['contact_id'];
       $participantName = $contactDetails['display_name'];
@@ -1469,7 +1471,8 @@ UPDATE  civicrm_participant
       $checksumValue = NULL;
       if ($mailType == 'Confirm' && !$participantValues['registered_by_id']) {
         $checksumLife = 'inf';
-        if ($endDate = CRM_Utils_Array::value('end_date', $eventDetails)) {
+        $endDate = CRM_Utils_Array::value('end_date', $eventDetails);
+        if ($endDate) {
           $checksumLife = (CRM_Utils_Date::unixTime($endDate) - time()) / (60 * 60);
         }
         $checksumValue = CRM_Contact_BAO_Contact_Utils::generateChecksum($contactId, NULL, $checksumLife);


### PR DESCRIPTION
Commuted assigns in if statements to assigns that are then checked in if statements.
Set appropriate names for these vars.

These were in breach of CiviCRM coding standards. These were found while investigating https://issues.civicrm.org/jira/browse/CRM-14434.
