### PR TITLE
Billing block not shown consistently, easier report filtering on memberships

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -1433,6 +1433,11 @@ class CRM_Report_Form extends CRM_Core_Form {
       // belongs to more than one tag, results duplicate
       // entries.
       $clause = $this->whereTagClause($field, $value, $op);
+    }elseif(!empty($field['membership_org']) && $clause) {
+    
+      $clause = $this->whereMembershipOrgClause($field, $value, $op);
+    }else if(!empty($field['membership_type']) && $clause) {
+      $clause = $this->whereMembershipTypeClause($field, $value, $op);
     }
 
     return $clause;
@@ -2782,6 +2787,52 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
                           WHERE entity_table = 'civicrm_contact' AND {$clause} ) ";
   }
 
+
+
+function whereMembershipOrgClause($field, $value, $op) {
+    
+    $sqlOp = $this->getSQLOperator($op);
+    if (!is_array($value)) {
+      $value = array($value);
+    }
+    
+    $tmp_membership_org_sql_list = implode(', ', $value) ; 
+								
+								
+    return " {$this->_aliases['civicrm_contact']}.id {$sqlOp} (
+                          SELECT DISTINCT mem.contact_id
+								 FROM civicrm_membership mem 
+								 LEFT JOIN civicrm_membership_status mem_status ON mem.status_id = mem_status.id
+								 LEFT JOIN civicrm_membership_type mt ON mem.membership_type_id = mt.id 
+								 WHERE 
+								 mt.member_of_contact_id IN (".$tmp_membership_org_sql_list.")
+								 AND mt.is_active = '1'
+								 AND mem_status.is_current_member = '1'
+					 			AND mem_status.is_active = '1' )  ";
+  }
+  
+  
+  
+  function whereMembershipTypeClause($field, $value, $op) {
+    
+    $sqlOp = $this->getSQLOperator($op);
+    if (!is_array($value)) {
+      $value = array($value);
+    }
+   
+$tmp_membership_sql_list  = implode(', ', $value) ; 
+    return " {$this->_aliases['civicrm_contact']}.id {$sqlOp} (
+                          SELECT DISTINCT mem.contact_id
+								 FROM civicrm_membership mem 
+								 LEFT JOIN civicrm_membership_status mem_status ON mem.status_id = mem_status.id 
+								 LEFT JOIN civicrm_membership_type mt ON mem.membership_type_id = mt.id 
+								  WHERE mem.membership_type_id IN (".$tmp_membership_sql_list.")
+								  AND mt.is_active = '1'
+								  AND mem_status.is_current_member = '1'
+								  AND mem_status.is_active = '1' ) ";
+  }
+  
+  
   function buildACLClause($tableAlias = 'contact_a') {
     list($this->_aclFrom, $this->_aclWhere) = CRM_Contact_BAO_Contact_Permission::cacheClause($tableAlias);
   }

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -440,6 +440,23 @@
     }
     cj('#priceset input[type="radio"]').change(updatePriceSetHighlight);
     updatePriceSetHighlight();
+    
+    function toggleBillingBlockIfFree(){
+    var total_amount_tmp =  $(this).data('raw-total'); 
+    
+    // Hide billing questions if this is free
+    if(  total_amount_tmp == 0 ){
+        cj("#billing-payment-block").hide(); 
+    }else{
+    	cj("#billing-payment-block").show(); 
+    }
+  }
+    
+     CRM.$('#pricevalue').each( toggleBillingBlockIfFree);
+    
+    $('#priceset input').on('change', function() {
+      CRM.$('#pricevalue').each( toggleBillingBlockIfFree);
+    });
   });
   {/literal}
 </script>

--- a/templates/CRM/Price/Form/Calculate.tpl
+++ b/templates/CRM/Price/Form/Calculate.tpl
@@ -211,6 +211,7 @@ function display( totalfee ) {
     scriptfee   = totalfee;
     scriptarray = price;
     cj('#total_amount').val( totalfee );
+    cj('#pricevalue').data('raw-total', totalfee ) ;
 
     ( totalfee < 0 ) ? cj('table#pricelabel').addClass('disabled') : cj('table#pricelabel').removeClass('disabled');
 


### PR DESCRIPTION
The May 2, 2014 changes were worked on during the code sprint. It solves the issue where the billing block is not shown consistently. 

The June 14 change makes it very easy to have report filters on membership organizations and/or membership types, following the existing structure for easy filtering on groups and tags.

See JIRA issue: https://issues.civicrm.org/jira/browse/CRM-14857
