### PR TITLE
CRM-14816 - Order Rows widget is broken again

### DIFF
--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -607,6 +607,7 @@ class CRM_Core_Resources {
       "packages/jquery/plugins/jquery.timeentry$min.js",
 
       "packages/jquery/plugins/DataTables/media/js/jquery.dataTables$min.js",
+      "packages/jquery/plugins/DataTables/media/css/jquery.dataTables$min.css",
 
       "packages/jquery/plugins/jquery.validate$min.js",
       "packages/jquery/plugins/jquery.ui.datepicker.validation.pack.js",

--- a/templates/CRM/common/jsortable.tpl
+++ b/templates/CRM/common/jsortable.tpl
@@ -76,8 +76,8 @@ eval('tableId =[' + tableId + ']');
                     sortColumn += '[' + count + ', "asc" ],';
                 }
                 sortId   = getRowId(tdObject, cj(this).attr('id') +' hiddenElement' );
-                sortEnabled = false;
-                columns += '{ "sType": \'' + stype + '\', "fnRender": function (oObj) { return oObj.aData[' + sortId + ']; },"bUseRendered": false},';
+                sortEnabled = true;
+                columns += '{ "render": function ( data, type, row ) { return "<div style=\'display:none\'>"+ data +"</div>" + row[sortId] ; }, "targets": sortColumn,"bUseRendered": false},';
             break;
             case 'nosort':
                 columns += '{ "bSortable": false, "sClass": "'+ getElementClass( this ) +'"},';


### PR DESCRIPTION
https://issues.civicrm.org/jira/browse/CRM-14816

The jquery lib for Datatable.js had been changed to 1.10 from 1.8.
Hence the ordering icon were not shown in the table.
Since the function used to display the ordering is deprecated `fnRender` in the latest version.
