### PR TITLE
distmaker cleanup

### DIFF
--- a/distmaker/distmaker.sh
+++ b/distmaker/distmaker.sh
@@ -28,6 +28,7 @@ set -e
 P=`dirname $0`
 # Current dir
 ORIGPWD=`pwd`
+source "$P/dists/common.sh"
 
 # Set no actions by default
 D5PACK=0
@@ -156,16 +157,11 @@ case $1 in
 esac
 
 ## Make sure we have the right branch or tag
-pushd "$DM_SOURCEDIR"
-git checkout "$DM_REF_CORE"
-popd
-pushd "$DM_SOURCEDIR/packages"
-git checkout "$DM_REF_PACKAGES"
-popd
+dm_git_checkout "$DM_SOURCEDIR" "$DM_REF_CORE"
+dm_git_checkout "$DM_SOURCEDIR/packages" "$DM_REF_PACKAGES"
+
 ## in theory, this shouldn't matter, but GenCode is CMS-dependent, and we've been doing our past builds based on D7
-pushd "$DM_SOURCEDIR/drupal"
-git checkout "$DM_REF_DRUPAL"
-popd
+dm_git_checkout "$DM_SOURCEDIR/drupal" "$DM_REF_DRUPAL"
 
 # Before anything - regenerate DAOs
 
@@ -181,26 +177,31 @@ fi
 
 if [ "$D56PACK" = 1 ]; then
 	echo; echo "Packaging for Drupal6, PHP5 version"; echo;
+	dm_git_checkout "$DM_SOURCEDIR/drupal" "$DM_REF_DRUPAL6"
 	bash $P/dists/drupal6_php5.sh
 fi
 
 if [ "$D5PACK" = 1 ]; then
 	echo; echo "Packaging for Drupal7, PHP5 version"; echo;
+	dm_git_checkout "$DM_SOURCEDIR/drupal" "$DM_REF_DRUPAL"
 	bash $P/dists/drupal_php5.sh
 fi
 
 if [ "$SKPACK" = 1 ]; then
 	echo; echo "Packaging for Drupal7, PHP5 StarterKit version"; echo;
+	dm_git_checkout "$DM_SOURCEDIR/drupal" "$DM_REF_DRUPAL"
 	bash $P/dists/drupal_sk_php5.sh
 fi
 
 if [ "$J5PACK" = 1 ]; then
 	echo; echo "Packaging for Joomla, PHP5 version"; echo;
+	dm_git_checkout "$DM_SOURCEDIR/joomla" "$DM_REF_JOOMLA"
 	bash $P/dists/joomla_php5.sh
 fi
 
 if [ "$WP5PACK" = 1 ]; then
 	echo; echo "Packaging for Wordpress, PHP5 version"; echo;
+	dm_git_checkout "$DM_SOURCEDIR/WordPress" "$DM_REF_WORDPRESS"
 	bash $P/dists/wordpress_php5.sh
 fi
 

--- a/distmaker/distmaker.sh
+++ b/distmaker/distmaker.sh
@@ -81,10 +81,16 @@ check_conf()
 	else
 		source "$P/distmaker.conf"
 		export DM_SOURCEDIR DM_GENFILESDIR DM_TMPDIR DM_TARGETDIR DM_PHP DM_RSYNC DM_ZIP DM_VERSION DM_REF_CORE DM_REF_DRUPAL DM_REF_DRUPAL6 DM_REF_JOOMLA DM_REF_WORDPRESS DM_REF_PACKAGES
-		for k in "$DM_SOURCEDIR" "$DM_GENFILESDIR" "$DM_TARGETDIR" "$DM_TMPDIR"; do
-			if [ ! -d "$k" ] ; then
+		if [ ! -d "$DM_SOURCEDIR" ]; then
+			echo; echo "ERROR! " DM_SOURCEDIR "directory not found!"; echo "(if you get empty directory name, it might mean that one of necessary variables is not set)"; echo;
+		fi
+		for k in "$DM_GENFILESDIR" "$DM_TARGETDIR" "$DM_TMPDIR"; do
+			if [ -z "$k" ] ; then
 				echo; echo "ERROR! " $k "directory not found!"; echo "(if you get empty directory name, it might mean that one of necessary variables is not set)"; echo;
 				exit 1
+			fi
+			if [ ! -d "$k" ]; then
+				mkdir -p "$k"
 			fi
 		done
 	fi

--- a/distmaker/distmaker.sh
+++ b/distmaker/distmaker.sh
@@ -29,17 +29,6 @@ P=`dirname $0`
 # Current dir
 ORIGPWD=`pwd`
 
-# List of files to exclude from all tarballs
-DM_EXCLUDES=".git .svn packages/_ORIGINAL_ packages/SeleniumRC packages/PHPUnit packages/PhpDocumentor packages/SymfonyComponents packages/amavisd-new packages/git-footnote"
-for DM_EXCLUDE in $DM_EXCLUDES ; do
-  DM_EXCLUDES_RSYNC="--exclude=${DM_EXCLUDE} ${DM_EXCLUDES_RSYNC}"
-done
-## Note: These small folders have items that previously were not published,
-## but there's no real cost to including them, and excluding them seems
-## likely to cause confusion as the codebase evolves:
-##   packages/Files packages/PHP packages/Text
-export DM_EXCLUDES DM_EXCLUDES_RSYNC
-
 # Set no actions by default
 D5PACK=0
 D56PACK=0

--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+## Delete/create a dir
+## usage: dm_reset_dirs <path1> <path2> ...
+function dm_reset_dirs() {
+  for d in "$@" ; do
+    [ -d "$d" ] && rm -rf "$d"
+  done
+
+  mkdir -p "$@"
+}
+
 ## Copy files from one dir into another dir
 ## usage: dm_install_dir <from-dir> <to-dir>
 function dm_install_dir() {

--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -9,7 +9,7 @@ function dm_install_dir() {
   if [ ! -d "$to" ]; then
     mkdir -p "$to"
   fi
-  rsync -avC --exclude=.git --exclude=.svn "$from/./"  "$to/./"
+  $DM_RSYNC -avC --exclude=.git --exclude=.svn "$from/./"  "$to/./"
 }
 
 ## Copy listed files
@@ -75,8 +75,13 @@ function dm_install_packages() {
     excludes_rsync="--exclude=${exclude} ${excludes_rsync}"
   done
 
+  ## Note: These small folders have items that previously were not published,
+  ## but there's no real cost to including them, and excluding them seems
+  ## likely to cause confusion as the codebase evolves:
+  ##   packages/Files packages/PHP packages/Text
+
   [ ! -d "$to" ] && mkdir "$to"
-  rsync -avC $excludes_rsync --include=core "$repo/./" "$to/./"
+  $DM_RSYNC -avC $excludes_rsync --include=core "$repo/./" "$to/./"
 }
 
 ## Copy Drupal-integration module

--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -100,12 +100,6 @@ function dm_install_drupal() {
   local repo="$1"
   local to="$2"
   dm_install_dir "$repo" "$to"
-}
-
-## TODO: Merge this into dm_install_drupal; use on all Drupal releases
-## usage: dm_install_drupal_info <to_path>
-function dm_install_drupal_info() {
-  local to="$1"
 
   # set full version in .info files
   local MODULE_DIRS=`find "$to" -type f -name "*.info"`

--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -63,3 +63,18 @@ function dm_install_core() {
   rm -rf $to/sql/civicrm_*.??_??.mysql
   set -e
 }
+
+## Copy all packages
+## usage: dm_install_packages <packages_repo_path> <to_path>
+function dm_install_packages() {
+  local repo="$1"
+  local to="$2"
+
+  local excludes_rsync=""
+  for exclude in .git .svn _ORIGINAL_ SeleniumRC PHPUnit PhpDocumentor SymfonyComponents amavisd-new git-footnote ; do
+    excludes_rsync="--exclude=${exclude} ${excludes_rsync}"
+  done
+
+  [ ! -d "$to" ] && mkdir "$to"
+  rsync -avC $excludes_rsync --include=core "$repo/./" "$to/./"
+}

--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -9,7 +9,7 @@ function dm_install_dir() {
   if [ ! -d "$to" ]; then
     mkdir -p "$to"
   fi
-  rsync -va "$from/./"  "$to/./"
+  rsync -avC --exclude=.git --exclude=.svn "$from/./"  "$to/./"
 }
 
 ## Copy listed files
@@ -84,14 +84,7 @@ function dm_install_packages() {
 function dm_install_drupal() {
   local repo="$1"
   local to="$2"
-
-  local excludes_rsync=""
-  for exclude in .git .svn ; do
-    excludes_rsync="--exclude=${exclude} ${excludes_rsync}"
-  done
-
-  [ ! -d "$to" ] && mkdir "$to"
-  rsync -avC $excludes_rsync "$repo/./" "$to/./"
+  dm_install_dir "$repo" "$to"
 }
 
 ## TODO: Merge this into dm_install_drupal; use on all Drupal releases
@@ -117,14 +110,7 @@ function dm_install_drupal_info() {
 function dm_install_joomla() {
   local repo="$1"
   local to="$2"
-
-  local excludes_rsync=""
-  for exclude in .git .svn ; do
-    excludes_rsync="--exclude=${exclude} ${excludes_rsync}"
-  done
-
-  [ ! -d "$to" ] && mkdir "$to"
-  rsync -avC $excludes_rsync "$repo/./" "$to/./"
+  dm_install_dir "$repo" "$to"
 }
 
 ## Generate civicrm-version.php

--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -78,3 +78,36 @@ function dm_install_packages() {
   [ ! -d "$to" ] && mkdir "$to"
   rsync -avC $excludes_rsync --include=core "$repo/./" "$to/./"
 }
+
+## Copy Drupal-integration module
+## usage: dm_install_drupal <drupal_repo_path> <to_path>
+function dm_install_drupal() {
+  local repo="$1"
+  local to="$2"
+
+  local excludes_rsync=""
+  for exclude in .git .svn ; do
+    excludes_rsync="--exclude=${exclude} ${excludes_rsync}"
+  done
+
+  [ ! -d "$to" ] && mkdir "$to"
+  rsync -avC $excludes_rsync "$repo/./" "$to/./"
+}
+
+## TODO: Merge this into dm_install_drupal; use on all Drupal releases
+## usage: dm_install_drupal_info <to_path>
+function dm_install_drupal_info() {
+  local to="$1"
+
+  # set full version in .info files
+  local MODULE_DIRS=`find "$to" -type f -name "*.info"`
+  for INFO in $MODULE_DIRS; do
+    if [ $(uname) = "Darwin" ]; then
+      ## BSD sed
+      sed -i '' "s/version = [1-9.]*/version = $DM_VERSION/g" $INFO
+    else
+      ## GNU sed
+      sed -i'' "s/version = [1-9.]*/version = $DM_VERSION/g" $INFO
+    fi
+  done
+}

--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -113,6 +113,13 @@ function dm_install_joomla() {
   dm_install_dir "$repo" "$to"
 }
 
+## usage: dm_install_l10n <l10n_repo_path> <to_path>
+function dm_install_l10n() {
+  local repo="$1"
+  local to="$2"
+  dm_install_dir "$repo" "$to"
+}
+
 ## Generate civicrm-version.php
 ## usage: dm_generate_version <file> <ufname>
 function dm_generate_version() {

--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -125,6 +125,14 @@ function dm_install_l10n() {
   dm_install_dir "$repo" "$to"
 }
 
+##  usage: dm_install_wordpress <wp_repo_path> <to_path>
+function dm_install_wordpress() {
+  local repo="$1"
+  local to="$2"
+  dm_install_dir "$repo" "$to"
+  dm_remove_files "$to" civicrm.config.php.wordpress .gitignore
+}
+
 ## Generate civicrm-version.php
 ## usage: dm_generate_version <file> <ufname>
 function dm_generate_version() {

--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -111,3 +111,19 @@ function dm_install_drupal_info() {
     fi
   done
 }
+
+## Generate civicrm-version.php
+## usage: dm_generate_version <file> <ufname>
+function dm_generate_version() {
+  local to="$1"
+  local ufname="$2"
+
+  # final touch
+  echo "<?php
+function civicrmVersion( ) {
+  return array( 'version'  => '$DM_VERSION',
+                'cms'      => '$ufname',
+                'revision' => '$DM_REVISION' );
+}
+" > "$to"
+}

--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -112,6 +112,21 @@ function dm_install_drupal_info() {
   done
 }
 
+## Copy Joomla-integration module
+## usage: dm_install_joomla <joomla_repo_path> <to_path>
+function dm_install_joomla() {
+  local repo="$1"
+  local to="$2"
+
+  local excludes_rsync=""
+  for exclude in .git .svn ; do
+    excludes_rsync="--exclude=${exclude} ${excludes_rsync}"
+  done
+
+  [ ! -d "$to" ] && mkdir "$to"
+  rsync -avC $excludes_rsync "$repo/./" "$to/./"
+}
+
 ## Generate civicrm-version.php
 ## usage: dm_generate_version <file> <ufname>
 function dm_generate_version() {

--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -126,6 +126,12 @@ function dm_install_joomla() {
   local repo="$1"
   local to="$2"
   dm_install_dir "$repo" "$to"
+
+  ## Before this change, the zip file included the joomla-integration
+  ## modules twice. The two were basically identical -- except that
+  ## one included .gitignore and the omitted it. We'll now omit it
+  ## consistently.
+  rm -f "$to/.gitignore"
 }
 
 ## usage: dm_install_l10n <l10n_repo_path> <to_path>

--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -174,3 +174,12 @@ function civicrmVersion( ) {
 }
 " > "$to"
 }
+
+## Perform a hard checkout on a given report
+## usage: dm_git_checkout <repo_path> <tree-ish>
+function dm_git_checkout() {
+  pushd "$1"
+    git checkout .
+    git checkout "$2"
+  popd
+}

--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -145,8 +145,18 @@ function dm_install_l10n() {
 function dm_install_wordpress() {
   local repo="$1"
   local to="$2"
-  dm_install_dir "$repo" "$to"
-  dm_remove_files "$to" civicrm.config.php.wordpress .gitignore
+
+  if [ ! -d "$to" ]; then
+    mkdir -p "$to"
+  fi
+  $DM_RSYNC -avC \
+    --exclude=.git \
+    --exclude=.svn \
+    --exclude=civicrm.config.php.wordpress \
+    --exclude=.gitignore \
+    --exclude=civicrm \
+    "$repo/./"  "$to/./"
+  ## Need --exclude=civicrm for self-building on WP site
 }
 
 ## Generate civicrm-version.php

--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+## Copy files from one dir into another dir
+## usage: dm_install_dir <from-dir> <to-dir>
+function dm_install_dir() {
+  local from="$1"
+  local to="$2"
+
+  if [ ! -d "$to" ]; then
+    mkdir -p "$to"
+  fi
+  rsync -va "$from/./"  "$to/./"
+}
+
+## Copy listed files
+## usage: dm_install_files <from-dir> <to-dir> <file1> <file2>...
+function dm_install_files() {
+  local from="$1"
+  shift
+  local to="$1"
+  shift
+
+  for file in "$@" ; do
+    [ -f "$from/$file" ] && cp -f "$from/$file" "$to/$file"
+  done
+}
+
+## usage: dm_remove_files <directory> <file1> <file2>...
+function dm_remove_files() {
+  local tgt="$1"
+  shift
+
+  for file in "$@" ; do
+    [ -f "$tgt/$file" ] && rm -f "$tgt/$file"
+  done
+}
+
+## Copy all core files
+## usage: dm_install_core <core_repo_path> <to_path>
+function dm_install_core() {
+  local repo="$1"
+  local to="$2"
+
+  for dir in css i js PEAR templates bin CRM api extern Reports install settings Civi ; do
+    [ -d "$repo/$dir" ] && dm_install_dir "$repo/$dir" "$to/$dir"
+  done
+
+  dm_install_files "$repo" "$to" {agpl-3.0,agpl-3.0.exception,gpl,README,CONTRIBUTORS}.txt
+
+  mkdir -p "$to/sql"
+  pushd "$repo" >> /dev/null
+    dm_install_files "$repo" "$to" sql/civicrm*.mysql sql/case_sample*.mysql sql/counties.US.sql.gz
+    ## TODO: for master, remove counties.US.SQL.gz
+  popd >> /dev/null
+
+  if [ -d $to/bin ] ; then
+    rm -f $to/bin/setup.sh
+    rm -f $to/bin/setup.php4.sh
+    rm -f $to/bin/setup.bat
+  fi
+
+  set +e
+  rm -rf $to/sql/civicrm_*.??_??.mysql
+  set -e
+}

--- a/distmaker/dists/drupal6_php5.sh
+++ b/distmaker/dists/drupal6_php5.sh
@@ -41,15 +41,7 @@ dm_install_drupal "$SRC/drupal" "$TRG/drupal"
 
 # copy docs
 cp $SRC/drupal/civicrm.config.php.drupal $TRG/civicrm.config.php
-
-# final touch
-echo "<?php
-function civicrmVersion( ) {
-  return array( 'version'  => '$DM_VERSION',
-                'cms'      => 'Drupal6',
-                'revision' => '$DM_REVISION' );
-}
-" > $TRG/civicrm-version.php
+dm_generate_version "$TRG/civicrm-version.php" Drupal6
 
 # gen tarball
 cd $TRG/..

--- a/distmaker/dists/drupal6_php5.sh
+++ b/distmaker/dists/drupal6_php5.sh
@@ -37,10 +37,7 @@ fi
 # copy all the stuff
 dm_install_core "$SRC" "$TRG"
 dm_install_packages "$SRC/packages" "$TRG/packages"
-for CODE in drupal; do
-  echo $CODE
-  [ -d $SRC/$CODE ] && $RSYNCCOMMAND $SRC/$CODE $TRG
-done
+dm_install_drupal "$SRC/drupal" "$TRG/drupal"
 
 # copy docs
 cp $SRC/drupal/civicrm.config.php.drupal $TRG/civicrm.config.php

--- a/distmaker/dists/drupal6_php5.sh
+++ b/distmaker/dists/drupal6_php5.sh
@@ -36,7 +36,8 @@ fi
 
 # copy all the stuff
 dm_install_core "$SRC" "$TRG"
-for CODE in packages drupal; do
+dm_install_packages "$SRC/packages" "$TRG/packages"
+for CODE in drupal; do
   echo $CODE
   [ -d $SRC/$CODE ] && $RSYNCCOMMAND $SRC/$CODE $TRG
 done

--- a/distmaker/dists/drupal6_php5.sh
+++ b/distmaker/dists/drupal6_php5.sh
@@ -14,12 +14,6 @@ fi
 SRC=$DM_SOURCEDIR
 TRG=$DM_TMPDIR/civicrm
 
-# checkout the right code revisions
-pushd "$DM_SOURCEDIR/drupal"
-git checkout .
-git checkout "$DM_REF_DRUPAL6"
-popd
-
 # copy all the stuff
 dm_reset_dirs "$TRG"
 cp $SRC/drupal/civicrm.config.php.drupal $TRG/civicrm.config.php

--- a/distmaker/dists/drupal6_php5.sh
+++ b/distmaker/dists/drupal6_php5.sh
@@ -1,25 +1,18 @@
 #!/bin/bash
 set -ex
 
-# This script assumes
-# that DAOs are generated
-# and all the necessary conversions had place!
-
 P=`dirname $0`
 CFFILE=$P/../distmaker.conf
-
 if [ ! -f $CFFILE ] ; then
 	echo "NO DISTMAKER.CONF FILE!"
 	exit 1
 else
 	. $CFFILE
 fi
-
 . "$P/common.sh"
 
 SRC=$DM_SOURCEDIR
 TRG=$DM_TMPDIR/civicrm
-
 
 # checkout the right code revisions
 pushd "$DM_SOURCEDIR/drupal"
@@ -28,9 +21,7 @@ git checkout "$DM_REF_DRUPAL6"
 popd
 
 # make sure and clean up before
-if [ -d $TRG ] ; then
-	rm -rf $TRG/*
-fi
+[ -d $TRG ] && rm -rf $TRG/*
 
 # copy all the stuff
 dm_install_core "$SRC" "$TRG"

--- a/distmaker/dists/drupal6_php5.sh
+++ b/distmaker/dists/drupal6_php5.sh
@@ -17,8 +17,6 @@ fi
 
 . "$P/common.sh"
 
-RSYNCOPTIONS="-avC $DM_EXCLUDES_RSYNC --include=core"
-RSYNCCOMMAND="$DM_RSYNC $RSYNCOPTIONS"
 SRC=$DM_SOURCEDIR
 TRG=$DM_TMPDIR/civicrm
 

--- a/distmaker/dists/drupal6_php5.sh
+++ b/distmaker/dists/drupal6_php5.sh
@@ -20,17 +20,13 @@ git checkout .
 git checkout "$DM_REF_DRUPAL6"
 popd
 
-# make sure and clean up before
-[ -d $TRG ] && rm -rf $TRG/*
-
 # copy all the stuff
+dm_reset_dirs "$TRG"
+cp $SRC/drupal/civicrm.config.php.drupal $TRG/civicrm.config.php
+dm_generate_version "$TRG/civicrm-version.php" Drupal6
 dm_install_core "$SRC" "$TRG"
 dm_install_packages "$SRC/packages" "$TRG/packages"
 dm_install_drupal "$SRC/drupal" "$TRG/drupal"
-
-# copy docs
-cp $SRC/drupal/civicrm.config.php.drupal $TRG/civicrm.config.php
-dm_generate_version "$TRG/civicrm-version.php" Drupal6
 
 # gen tarball
 cd $TRG/..

--- a/distmaker/dists/drupal6_php5.sh
+++ b/distmaker/dists/drupal6_php5.sh
@@ -15,6 +15,8 @@ else
 	. $CFFILE
 fi
 
+. "$P/common.sh"
+
 RSYNCOPTIONS="-avC $DM_EXCLUDES_RSYNC --include=core"
 RSYNCCOMMAND="$DM_RSYNC $RSYNCOPTIONS"
 SRC=$DM_SOURCEDIR
@@ -23,6 +25,7 @@ TRG=$DM_TMPDIR/civicrm
 
 # checkout the right code revisions
 pushd "$DM_SOURCEDIR/drupal"
+git checkout .
 git checkout "$DM_REF_DRUPAL6"
 popd
 
@@ -32,38 +35,13 @@ if [ -d $TRG ] ; then
 fi
 
 # copy all the stuff
-for CODE in css i js packages PEAR templates bin CRM api drupal extern Reports install settings; do
+dm_install_core "$SRC" "$TRG"
+for CODE in packages drupal; do
   echo $CODE
   [ -d $SRC/$CODE ] && $RSYNCCOMMAND $SRC/$CODE $TRG
 done
 
-# delete any setup.sh or setup.php4.sh if present
-if [ -d $TRG/bin ] ; then
-  rm -f $TRG/bin/setup.sh
-  rm -f $TRG/bin/setup.php4.sh
-  rm -f $TRG/bin/setup.bat
-fi
-
-
-# copy selected sqls
-if [ ! -d $TRG/sql ] ; then
-	mkdir $TRG/sql
-fi
-
-for F in $SRC/sql/civicrm*.mysql $SRC/sql/counties.US.sql.gz $SRC/sql/case_sample*.mysql; do
-	cp $F $TRG/sql
-done
-
-set +e
-rm -rf $TRG/sql/civicrm_*.??_??.mysql
-set -e
-
 # copy docs
-cp $SRC/agpl-3.0.txt $TRG
-cp $SRC/gpl.txt $TRG
-cp $SRC/README.txt $TRG
-cp $SRC/CONTRIBUTORS.txt $TRG
-cp $SRC/agpl-3.0.exception.txt $TRG
 cp $SRC/drupal/civicrm.config.php.drupal $TRG/civicrm.config.php
 
 # final touch

--- a/distmaker/dists/drupal_php5.sh
+++ b/distmaker/dists/drupal_php5.sh
@@ -40,19 +40,10 @@ dm_install_drupal "$SRC/drupal" "$TRG/drupal"
 dm_install_drupal_info "$DM_SOURCEDIR/drupal"
 
 cp $SRC/drupal/civicrm.config.php.drupal $TRG/civicrm.config.php
-
-# final touch
-echo "<?php
-function civicrmVersion( ) {
-  return array( 'version'  => '$DM_VERSION',
-                'cms'      => 'Drupal',
-                'revision' => '$DM_REVISION' );
-}
-" > $TRG/civicrm-version.php
+dm_generate_version "$TRG/civicrm-version.php" Drupal
 
 # gen tarball
 cd $TRG/..
-
 tar czf $DM_TARGETDIR/civicrm-$DM_VERSION-drupal.tar.gz civicrm
 
 # clean up

--- a/distmaker/dists/drupal_php5.sh
+++ b/distmaker/dists/drupal_php5.sh
@@ -35,7 +35,8 @@ fi
 
 # copy all the stuff
 dm_install_core "$SRC" "$TRG"
-for CODE in packages drupal; do
+dm_install_packages "$SRC/packages" "$TRG/packages"
+for CODE in drupal; do
   echo $CODE
   [ -d $SRC/$CODE ] && $RSYNCCOMMAND $SRC/$CODE $TRG
 done

--- a/distmaker/dists/drupal_php5.sh
+++ b/distmaker/dists/drupal_php5.sh
@@ -20,17 +20,14 @@ git checkout .
 git checkout "$DM_REF_DRUPAL"
 popd
 
-# make sure and clean up before
-[ -d $TRG ] && rm -rf $TRG/*
-
 # copy all the stuff
+dm_reset_dirs "$TRG"
+cp $SRC/drupal/civicrm.config.php.drupal $TRG/civicrm.config.php
+dm_generate_version "$TRG/civicrm-version.php" Drupal
 dm_install_core "$SRC" "$TRG"
 dm_install_packages "$SRC/packages" "$TRG/packages"
 dm_install_drupal "$SRC/drupal" "$TRG/drupal"
 dm_install_drupal_info "$DM_SOURCEDIR/drupal"
-
-cp $SRC/drupal/civicrm.config.php.drupal $TRG/civicrm.config.php
-dm_generate_version "$TRG/civicrm-version.php" Drupal
 
 # gen tarball
 cd $TRG/..

--- a/distmaker/dists/drupal_php5.sh
+++ b/distmaker/dists/drupal_php5.sh
@@ -1,20 +1,14 @@
 #!/bin/bash
 set -ex
 
-# This script assumes
-# that DAOs are generated
-# and all the necessary conversions had place!
-
 P=`dirname $0`
 CFFILE=$P/../distmaker.conf
-
 if [ ! -f $CFFILE ] ; then
 	echo "NO DISTMAKER.CONF FILE!"
 	exit 1
 else
 	. $CFFILE
 fi
-
 . "$P/common.sh"
 
 SRC=$DM_SOURCEDIR
@@ -27,9 +21,7 @@ git checkout "$DM_REF_DRUPAL"
 popd
 
 # make sure and clean up before
-if [ -d $TRG ] ; then
-	rm -rf $TRG/*
-fi
+[ -d $TRG ] && rm -rf $TRG/*
 
 # copy all the stuff
 dm_install_core "$SRC" "$TRG"

--- a/distmaker/dists/drupal_php5.sh
+++ b/distmaker/dists/drupal_php5.sh
@@ -36,25 +36,10 @@ fi
 # copy all the stuff
 dm_install_core "$SRC" "$TRG"
 dm_install_packages "$SRC/packages" "$TRG/packages"
-for CODE in drupal; do
-  echo $CODE
-  [ -d $SRC/$CODE ] && $RSYNCCOMMAND $SRC/$CODE $TRG
-done
+dm_install_drupal "$SRC/drupal" "$TRG/drupal"
+dm_install_drupal_info "$DM_SOURCEDIR/drupal"
 
 cp $SRC/drupal/civicrm.config.php.drupal $TRG/civicrm.config.php
-
-# set full version in .info files
-MODULE_DIRS=`find "$DM_SOURCEDIR/drupal" -type f -name "*.info"`
-for INFO in $MODULE_DIRS; do
-  if [ $(uname) = "Darwin" ]; then
-    ## BSD sed
-    sed -i '' "s/version = [1-9.]*/version = $DM_VERSION/g" $INFO
-  else
-    ## GNU sed
-    sed -i'' "s/version = [1-9.]*/version = $DM_VERSION/g" $INFO
-  fi
-done
-
 
 # final touch
 echo "<?php
@@ -67,6 +52,7 @@ function civicrmVersion( ) {
 
 # gen tarball
 cd $TRG/..
+
 tar czf $DM_TARGETDIR/civicrm-$DM_VERSION-drupal.tar.gz civicrm
 
 # clean up

--- a/distmaker/dists/drupal_php5.sh
+++ b/distmaker/dists/drupal_php5.sh
@@ -21,7 +21,6 @@ dm_generate_version "$TRG/civicrm-version.php" Drupal
 dm_install_core "$SRC" "$TRG"
 dm_install_packages "$SRC/packages" "$TRG/packages"
 dm_install_drupal "$SRC/drupal" "$TRG/drupal"
-dm_install_drupal_info "$DM_SOURCEDIR/drupal"
 
 # gen tarball
 cd $TRG/..

--- a/distmaker/dists/drupal_php5.sh
+++ b/distmaker/dists/drupal_php5.sh
@@ -17,8 +17,6 @@ fi
 
 . "$P/common.sh"
 
-RSYNCOPTIONS="-avC $DM_EXCLUDES_RSYNC --include=core"
-RSYNCCOMMAND="$DM_RSYNC $RSYNCOPTIONS"
 SRC=$DM_SOURCEDIR
 TRG=$DM_TMPDIR/civicrm
 

--- a/distmaker/dists/drupal_php5.sh
+++ b/distmaker/dists/drupal_php5.sh
@@ -14,12 +14,6 @@ fi
 SRC=$DM_SOURCEDIR
 TRG=$DM_TMPDIR/civicrm
 
-# checkout the right code revisions
-pushd "$DM_SOURCEDIR/drupal"
-git checkout .
-git checkout "$DM_REF_DRUPAL"
-popd
-
 # copy all the stuff
 dm_reset_dirs "$TRG"
 cp $SRC/drupal/civicrm.config.php.drupal $TRG/civicrm.config.php

--- a/distmaker/dists/drupal_php5.sh
+++ b/distmaker/dists/drupal_php5.sh
@@ -15,6 +15,8 @@ else
 	. $CFFILE
 fi
 
+. "$P/common.sh"
+
 RSYNCOPTIONS="-avC $DM_EXCLUDES_RSYNC --include=core"
 RSYNCCOMMAND="$DM_RSYNC $RSYNCOPTIONS"
 SRC=$DM_SOURCEDIR
@@ -22,6 +24,7 @@ TRG=$DM_TMPDIR/civicrm
 
 # checkout the right code revisions
 pushd "$DM_SOURCEDIR/drupal"
+git checkout .
 git checkout "$DM_REF_DRUPAL"
 popd
 
@@ -31,38 +34,12 @@ if [ -d $TRG ] ; then
 fi
 
 # copy all the stuff
-for CODE in css i js packages PEAR templates bin CRM api drupal extern Reports install settings; do
+dm_install_core "$SRC" "$TRG"
+for CODE in packages drupal; do
   echo $CODE
   [ -d $SRC/$CODE ] && $RSYNCCOMMAND $SRC/$CODE $TRG
 done
 
-# delete any setup.sh or setup.php4.sh if present
-if [ -d $TRG/bin ] ; then
-  rm -f $TRG/bin/setup.sh
-  rm -f $TRG/bin/setup.php4.sh
-  rm -f $TRG/bin/setup.bat
-fi
-
-
-# copy selected sqls
-if [ ! -d $TRG/sql ] ; then
-	mkdir $TRG/sql
-fi
-
-for F in $SRC/sql/civicrm*.mysql $SRC/sql/counties.US.sql.gz $SRC/sql/case_sample*.mysql; do
-	cp $F $TRG/sql
-done
-
-set +e
-rm -rf $TRG/sql/civicrm_*.??_??.mysql
-set -e
-
-# copy docs
-cp $SRC/agpl-3.0.txt $TRG
-cp $SRC/gpl.txt $TRG
-cp $SRC/README.txt $TRG
-cp $SRC/CONTRIBUTORS.txt $TRG
-cp $SRC/agpl-3.0.exception.txt $TRG
 cp $SRC/drupal/civicrm.config.php.drupal $TRG/civicrm.config.php
 
 # set full version in .info files

--- a/distmaker/dists/drupal_sk_php5.sh
+++ b/distmaker/dists/drupal_sk_php5.sh
@@ -34,7 +34,8 @@ fi
 
 # copy all the stuff
 dm_install_core "$SRC" "$TRG"
-for CODE in packages drupal; do
+dm_install_packages "$SRC/packages" "$TRG/packages"
+for CODE in drupal; do
   echo $CODE
   [ -d $SRC/$CODE ] && $RSYNCCOMMAND $SRC/$CODE $TRG
 done

--- a/distmaker/dists/drupal_sk_php5.sh
+++ b/distmaker/dists/drupal_sk_php5.sh
@@ -35,10 +35,7 @@ fi
 # copy all the stuff
 dm_install_core "$SRC" "$TRG"
 dm_install_packages "$SRC/packages" "$TRG/packages"
-for CODE in drupal; do
-  echo $CODE
-  [ -d $SRC/$CODE ] && $RSYNCCOMMAND $SRC/$CODE $TRG
-done
+dm_install_drupal "$SRC/drupal" "$TRG/drupal"
 
 # delete packages that distributions on Drupal.org repalce if present
 # also delete stuff that we dont really use and should not be included

--- a/distmaker/dists/drupal_sk_php5.sh
+++ b/distmaker/dists/drupal_sk_php5.sh
@@ -1,20 +1,14 @@
 #!/bin/bash
 set -ex
 
-# This script assumes
-# that DAOs are generated
-# and all the necessary conversions had place!
-
 P=`dirname $0`
 CFFILE=$P/../distmaker.conf
-
 if [ ! -f $CFFILE ] ; then
 	echo "NO DISTMAKER.CONF FILE!"
 	exit 1
 else
 	. $CFFILE
 fi
-
 . "$P/common.sh"
 
 SRC=$DM_SOURCEDIR
@@ -26,9 +20,7 @@ git checkout "$DM_REF_DRUPAL"
 popd
 
 # make sure and clean up before
-if [ -d $TRG ] ; then
-	rm -rf $TRG/*
-fi
+[ -d $TRG ] && rm -rf $TRG/*
 
 # copy all the stuff
 dm_install_core "$SRC" "$TRG"

--- a/distmaker/dists/drupal_sk_php5.sh
+++ b/distmaker/dists/drupal_sk_php5.sh
@@ -19,10 +19,10 @@ pushd "$DM_SOURCEDIR/drupal"
 git checkout "$DM_REF_DRUPAL"
 popd
 
-# make sure and clean up before
-[ -d $TRG ] && rm -rf $TRG/*
-
 # copy all the stuff
+dm_reset_dirs "$TRG"
+cp $SRC/drupal/civicrm.config.php.drupal $TRG/civicrm.config.php
+dm_generate_version "$TRG/civicrm-version.php" Drupal
 dm_install_core "$SRC" "$TRG"
 dm_install_packages "$SRC/packages" "$TRG/packages"
 dm_install_drupal "$SRC/drupal" "$TRG/drupal"
@@ -34,12 +34,6 @@ rm -rf $TRG/packages/IDS
 rm -rf $TRG/packages/jquery
 rm -rf $TRG/packages/ckeditor
 rm -rf $TRG/packages/tinymce
-rm -rf $TRG/joomla
-rm -rf $TRG/WordPress
-
-# copy docs
-cp $SRC/drupal/civicrm.config.php.drupal $TRG/civicrm.config.php
-dm_generate_version "$TRG/civicrm-version.php" Drupal
 
 # gen tarball
 cd $TRG/..

--- a/distmaker/dists/drupal_sk_php5.sh
+++ b/distmaker/dists/drupal_sk_php5.sh
@@ -17,8 +17,6 @@ fi
 
 . "$P/common.sh"
 
-RSYNCOPTIONS="-avC $DM_EXCLUDES_RSYNC --include=core"
-RSYNCCOMMAND="$DM_RSYNC $RSYNCOPTIONS"
 SRC=$DM_SOURCEDIR
 TRG=$DM_TMPDIR/civicrm
 

--- a/distmaker/dists/drupal_sk_php5.sh
+++ b/distmaker/dists/drupal_sk_php5.sh
@@ -14,11 +14,6 @@ fi
 SRC=$DM_SOURCEDIR
 TRG=$DM_TMPDIR/civicrm
 
-# checkout the right code revisions
-pushd "$DM_SOURCEDIR/drupal"
-git checkout "$DM_REF_DRUPAL"
-popd
-
 # copy all the stuff
 dm_reset_dirs "$TRG"
 cp $SRC/drupal/civicrm.config.php.drupal $TRG/civicrm.config.php

--- a/distmaker/dists/drupal_sk_php5.sh
+++ b/distmaker/dists/drupal_sk_php5.sh
@@ -49,15 +49,7 @@ rm -rf $TRG/WordPress
 
 # copy docs
 cp $SRC/drupal/civicrm.config.php.drupal $TRG/civicrm.config.php
-
-# final touch
-echo "<?php
-function civicrmVersion( ) {
-  return array( 'version'  => '$DM_VERSION',
-                'cms'      => 'Drupal',
-                'revision' => '$DM_REVISION' );
-}
-" > $TRG/civicrm-version.php
+dm_generate_version "$TRG/civicrm-version.php" Drupal
 
 # gen tarball
 cd $TRG/..

--- a/distmaker/dists/drupal_sk_php5.sh
+++ b/distmaker/dists/drupal_sk_php5.sh
@@ -15,6 +15,8 @@ else
 	. $CFFILE
 fi
 
+. "$P/common.sh"
+
 RSYNCOPTIONS="-avC $DM_EXCLUDES_RSYNC --include=core"
 RSYNCCOMMAND="$DM_RSYNC $RSYNCOPTIONS"
 SRC=$DM_SOURCEDIR
@@ -31,17 +33,11 @@ if [ -d $TRG ] ; then
 fi
 
 # copy all the stuff
-for CODE in css i js packages PEAR templates bin CRM api drupal extern Reports install settings; do
+dm_install_core "$SRC" "$TRG"
+for CODE in packages drupal; do
   echo $CODE
   [ -d $SRC/$CODE ] && $RSYNCCOMMAND $SRC/$CODE $TRG
 done
-
-# delete any setup.sh or setup.php4.sh if present
-if [ -d $TRG/bin ] ; then
-  rm -f $TRG/bin/setup.sh
-  rm -f $TRG/bin/setup.php4.sh
-  rm -f $TRG/bin/setup.bat
-fi
 
 # delete packages that distributions on Drupal.org repalce if present
 # also delete stuff that we dont really use and should not be included
@@ -53,25 +49,7 @@ rm -rf $TRG/packages/tinymce
 rm -rf $TRG/joomla
 rm -rf $TRG/WordPress
 
-# copy selected sqls
-if [ ! -d $TRG/sql ] ; then
-	mkdir $TRG/sql
-fi
-
-for F in $SRC/sql/civicrm*.mysql $SRC/sql/counties.US.sql.gz $SRC/sql/case_sample*.mysql; do
-	cp $F $TRG/sql
-done
-
-set +e
-rm -rf $TRG/sql/civicrm_*.??_??.mysql
-set -e
-
 # copy docs
-cp $SRC/agpl-3.0.txt $TRG
-cp $SRC/gpl.txt $TRG
-cp $SRC/README.txt $TRG
-cp $SRC/CONTRIBUTORS.txt $TRG
-cp $SRC/agpl-3.0.exception.txt $TRG
 cp $SRC/drupal/civicrm.config.php.drupal $TRG/civicrm.config.php
 
 # final touch

--- a/distmaker/dists/joomla_php5.sh
+++ b/distmaker/dists/joomla_php5.sh
@@ -14,11 +14,6 @@ fi
 SRC=$DM_SOURCEDIR
 TRG=$DM_TMPDIR/civicrm
 
-# checkout the right code revisions
-pushd "$DM_SOURCEDIR/joomla"
-git checkout "$DM_REF_JOOMLA"
-popd
-
 # copy all the rest of the stuff
 dm_reset_dirs "$TRG" "$DM_TMPDIR/com_civicrm"
 cp $SRC/civicrm.config.php $TRG

--- a/distmaker/dists/joomla_php5.sh
+++ b/distmaker/dists/joomla_php5.sh
@@ -1,20 +1,14 @@
 #!/bin/bash
 set -ex
 
-# This script assumes
-# that DAOs are generated
-# and all the necessary conversions had place!
-
 P=`dirname $0`
 CFFILE=$P/../distmaker.conf
-
 if [ ! -f $CFFILE ] ; then
 	echo "NO DISTMAKER.CONF FILE!"
 	exit 1
 else
 	. $CFFILE
 fi
-
 . "$P/common.sh"
 
 SRC=$DM_SOURCEDIR
@@ -26,9 +20,7 @@ git checkout "$DM_REF_JOOMLA"
 popd
 
 # make sure and clean up before
-if [ -d $TRG ] ; then
-	rm -rf $TRG/*
-fi
+[ -d $TRG ] && rm -rf $TRG/*
 
 # copy all the rest of the stuff
 dm_install_core "$SRC" "$TRG"

--- a/distmaker/dists/joomla_php5.sh
+++ b/distmaker/dists/joomla_php5.sh
@@ -26,8 +26,6 @@ popd
 dm_install_core "$SRC" "$TRG"
 dm_install_packages "$SRC/packages" "$TRG/packages"
 dm_install_joomla "$SRC/joomla" "$TRG/joomla"
-
-# copy docs
 cp $SRC/civicrm.config.php $TRG
 dm_generate_version "$TRG/civicrm-version.php" Joomla
 

--- a/distmaker/dists/joomla_php5.sh
+++ b/distmaker/dists/joomla_php5.sh
@@ -34,7 +34,8 @@ fi
 
 # copy all the rest of the stuff
 dm_install_core "$SRC" "$TRG"
-for CODE in packages joomla ; do
+dm_install_packages "$SRC/packages" "$TRG/packages"
+for CODE in joomla ; do
   echo $CODE
   [ -d $SRC/$CODE ] && $RSYNCCOMMAND $SRC/$CODE $TRG
 done

--- a/distmaker/dists/joomla_php5.sh
+++ b/distmaker/dists/joomla_php5.sh
@@ -17,8 +17,6 @@ fi
 
 . "$P/common.sh"
 
-RSYNCOPTIONS="-avC $DM_EXCLUDES_RSYNC --include=core"
-RSYNCCOMMAND="$DM_RSYNC $RSYNCOPTIONS"
 SRC=$DM_SOURCEDIR
 TRG=$DM_TMPDIR/civicrm
 

--- a/distmaker/dists/joomla_php5.sh
+++ b/distmaker/dists/joomla_php5.sh
@@ -20,50 +20,25 @@ git checkout "$DM_REF_JOOMLA"
 popd
 
 # copy all the rest of the stuff
-dm_reset_dirs "$TRG"
+dm_reset_dirs "$TRG" "$DM_TMPDIR/com_civicrm"
 cp $SRC/civicrm.config.php $TRG
 dm_generate_version "$TRG/civicrm-version.php" Joomla
 dm_install_core "$SRC" "$TRG"
 dm_install_packages "$SRC/packages" "$TRG/packages"
+
+## WTF: It's so good we'll install it twice!
+## (The first is probably extraneous, but there could be bugs dependent on it.)
 dm_install_joomla "$SRC/joomla" "$TRG/joomla"
+dm_install_joomla "$SRC/joomla" "$DM_TMPDIR/com_civicrm"
+
+## joomla 3.0 likes admin.civicrm.php to be called civicrm.php; keep both names
+cp "$SRC/joomla/admin/admin.civicrm.php" "$DM_TMPDIR/com_civicrm/admin/civicrm.php"
 
 # gen zip file
 cd $DM_TMPDIR;
 
-mkdir com_civicrm
-mkdir com_civicrm/admin
-mkdir com_civicrm/site
-mkdir com_civicrm/site/elements
-mkdir com_civicrm/admin/civicrm
-mkdir com_civicrm/admin/language
-mkdir com_civicrm/admin/language/en-GB
-mkdir com_civicrm/admin/helpers
-mkdir com_civicrm/admin/plugins
-
-# copying back end code to admin folder
-cp civicrm/joomla/script.civicrm.php             com_civicrm/
-cp civicrm/joomla/admin/admin.civicrm.php        com_civicrm/admin
-cp civicrm/joomla/admin/config.xml               com_civicrm/admin
-cp civicrm/joomla/admin/configure.php            com_civicrm/admin
-cp civicrm/joomla/admin/license.civicrm.txt      com_civicrm/admin
-cp civicrm/joomla/admin/toolbar.civicrm.php      com_civicrm/admin
-cp civicrm/joomla/admin/toolbar.civicrm.html.php com_civicrm/admin
-cp -r -p civicrm/joomla/admin/helpers/*          com_civicrm/admin/helpers
-cp -r -p civicrm/joomla/admin/plugins/*          com_civicrm/admin/plugins
-cp civicrm/joomla/admin/language/en-GB/*         com_civicrm/admin/language/en-GB
-
-# joomla 3.0 like admin.civicrm.php to be called civicrm.php
-# lets keep both versions there
-cp com_civicrm/admin/admin.civicrm.php com_civicrm/admin/civicrm.php
-
-# copying front end code
-cp civicrm/joomla/site/civicrm.html.php      com_civicrm/site
-cp civicrm/joomla/site/civicrm.php           com_civicrm/site
-cp -r civicrm/joomla/site/views              com_civicrm/site
-cp -r -p civicrm/joomla/site/elements/*      com_civicrm/site/elements
-
 # generate alt version of package
-cp -r -p civicrm/* com_civicrm/admin/civicrm
+cp -r -p civicrm com_civicrm/admin/civicrm
 $DM_PHP $DM_SOURCEDIR/distmaker/utils/joomlaxml.php $DM_SOURCEDIR com_civicrm $DM_VERSION alt
 $DM_ZIP -q -r -9 $DM_TARGETDIR/civicrm-$DM_VERSION-joomla-alt.zip com_civicrm
 rm -rf com_civicrm/admin/civicrm

--- a/distmaker/dists/joomla_php5.sh
+++ b/distmaker/dists/joomla_php5.sh
@@ -35,10 +35,7 @@ fi
 # copy all the rest of the stuff
 dm_install_core "$SRC" "$TRG"
 dm_install_packages "$SRC/packages" "$TRG/packages"
-for CODE in joomla ; do
-  echo $CODE
-  [ -d $SRC/$CODE ] && $RSYNCCOMMAND $SRC/$CODE $TRG
-done
+dm_install_joomla "$SRC/joomla" "$TRG/joomla"
 
 # copy docs
 cp $SRC/civicrm.config.php $TRG

--- a/distmaker/dists/joomla_php5.sh
+++ b/distmaker/dists/joomla_php5.sh
@@ -42,15 +42,7 @@ done
 
 # copy docs
 cp $SRC/civicrm.config.php $TRG
-
-# final touch
-echo "<?php
-function civicrmVersion( ) {
-  return array( 'version'  => '$DM_VERSION',
-                'cms'      => 'Joomla',
-                'revision' => '$DM_REVISION' );
-}
-" > $TRG/civicrm-version.php
+dm_generate_version "$TRG/civicrm-version.php" Joomla
 
 # gen zip file
 cd $DM_TMPDIR;

--- a/distmaker/dists/joomla_php5.sh
+++ b/distmaker/dists/joomla_php5.sh
@@ -62,24 +62,15 @@ cp civicrm/joomla/site/civicrm.php           com_civicrm/site
 cp -r civicrm/joomla/site/views              com_civicrm/site
 cp -r -p civicrm/joomla/site/elements/*      com_civicrm/site/elements
 
-# copy civicrm code
-cp -r -p civicrm/* com_civicrm/admin/civicrm
-
-# generate alt version of civicrm.xml
-$DM_PHP $DM_SOURCEDIR/distmaker/utils/joomlaxml.php $DM_SOURCEDIR com_civicrm $DM_VERSION alt
-
 # generate alt version of package
+cp -r -p civicrm/* com_civicrm/admin/civicrm
+$DM_PHP $DM_SOURCEDIR/distmaker/utils/joomlaxml.php $DM_SOURCEDIR com_civicrm $DM_VERSION alt
 $DM_ZIP -q -r -9 $DM_TARGETDIR/civicrm-$DM_VERSION-joomla-alt.zip com_civicrm
-
-# delete the civicrm directory
 rm -rf com_civicrm/admin/civicrm
 
 # generate zip version of civicrm.xml
 $DM_PHP $DM_SOURCEDIR/distmaker/utils/joomlaxml.php $DM_SOURCEDIR com_civicrm $DM_VERSION zip
-
 $DM_ZIP -q -r -9 com_civicrm/admin/civicrm.zip civicrm
-
-# generate zip within zip file
 $DM_ZIP -q -r -9 $DM_TARGETDIR/civicrm-$DM_VERSION-joomla.zip com_civicrm -x 'com_civicrm/admin/civicrm'
 
 # clean up

--- a/distmaker/dists/joomla_php5.sh
+++ b/distmaker/dists/joomla_php5.sh
@@ -19,15 +19,13 @@ pushd "$DM_SOURCEDIR/joomla"
 git checkout "$DM_REF_JOOMLA"
 popd
 
-# make sure and clean up before
-[ -d $TRG ] && rm -rf $TRG/*
-
 # copy all the rest of the stuff
+dm_reset_dirs "$TRG"
+cp $SRC/civicrm.config.php $TRG
+dm_generate_version "$TRG/civicrm-version.php" Joomla
 dm_install_core "$SRC" "$TRG"
 dm_install_packages "$SRC/packages" "$TRG/packages"
 dm_install_joomla "$SRC/joomla" "$TRG/joomla"
-cp $SRC/civicrm.config.php $TRG
-dm_generate_version "$TRG/civicrm-version.php" Joomla
 
 # gen zip file
 cd $DM_TMPDIR;

--- a/distmaker/dists/joomla_php5.sh
+++ b/distmaker/dists/joomla_php5.sh
@@ -15,6 +15,8 @@ else
 	. $CFFILE
 fi
 
+. "$P/common.sh"
+
 RSYNCOPTIONS="-avC $DM_EXCLUDES_RSYNC --include=core"
 RSYNCCOMMAND="$DM_RSYNC $RSYNCOPTIONS"
 SRC=$DM_SOURCEDIR
@@ -31,36 +33,13 @@ if [ -d $TRG ] ; then
 fi
 
 # copy all the rest of the stuff
-for CODE in css i install js packages PEAR templates bin joomla CRM api extern Reports settings; do
+dm_install_core "$SRC" "$TRG"
+for CODE in packages joomla ; do
   echo $CODE
   [ -d $SRC/$CODE ] && $RSYNCCOMMAND $SRC/$CODE $TRG
 done
 
-# delete any setup.sh or setup.php4.sh if present
-if [ -d $TRG/bin ] ; then
-  rm -f $TRG/bin/setup.sh
-  rm -f $TRG/bin/setup.php4.sh
-  rm -f $TRG/bin/setup.bat
-fi
-
-# copy selected sqls
-if [ ! -d $TRG/sql ] ; then
-	mkdir $TRG/sql
-fi
-for F in $SRC/sql/civicrm*.mysql $SRC/sql/counties.US.sql.gz $SRC/sql/case_sample*.mysql; do
-	cp $F $TRG/sql
-done
-
-set +e
-rm -rf $TRG/sql/civicrm_*.??_??.mysql
-set -e
-
 # copy docs
-cp $SRC/agpl-3.0.txt $TRG
-cp $SRC/gpl.txt $TRG
-cp $SRC/README.txt $TRG
-cp $SRC/CONTRIBUTORS.txt $TRG
-cp $SRC/agpl-3.0.exception.txt $TRG
 cp $SRC/civicrm.config.php $TRG
 
 # final touch

--- a/distmaker/dists/l10n.sh
+++ b/distmaker/dists/l10n.sh
@@ -14,10 +14,8 @@ fi
 SRC=$DM_SOURCEDIR
 TRG=$DM_TMPDIR/civicrm
 
-# make sure and clean up before
-[ -d $TRG ] && rm -rf $TRG/*
-
 # copy all the stuff
+dm_reset_dirs "$TRG"
 dm_install_l10n "$SRC/l10n" "$TRG/l10n"
 
 [ ! -d $TRG/sql ] && mkdir $TRG/sql

--- a/distmaker/dists/l10n.sh
+++ b/distmaker/dists/l10n.sh
@@ -19,17 +19,15 @@ TRG=$DM_TMPDIR/civicrm
 
 # copy all the stuff
 dm_install_l10n "$SRC/l10n" "$TRG/l10n"
-dm_install_files "$SRC" "$TRG" {agpl-3.0,agpl-3.0.exception,gpl,README,CONTRIBUTORS}.txt
 
-# copy selected sqls
 [ ! -d $TRG/sql ] && mkdir $TRG/sql
-for F in $SRC/sql/civicrm*.mysql $SRC/sql/case_sample*.mysql; do
+for F in $SRC/sql/civicrm_*.??_??.mysql; do
 	cp $F $TRG/sql
 done
 
 # gen tarball
 cd $TRG/..
-tar czf $DM_TARGETDIR/civicrm-$DM_VERSION-l10n.tar.gz --exclude '*.po' --exclude pot civicrm/l10n civicrm/sql/civicrm_*.??_??.mysql
+tar czf $DM_TARGETDIR/civicrm-$DM_VERSION-l10n.tar.gz --exclude '*.po' --exclude pot civicrm
 
 # clean up
 rm -rf $TRG

--- a/distmaker/dists/l10n.sh
+++ b/distmaker/dists/l10n.sh
@@ -1,29 +1,21 @@
 #!/bin/bash
 set -ex
 
-# This script assumes
-# that DAOs are generated
-# and all the necessary conversions had place!
-
 P=`dirname $0`
 CFFILE=$P/../distmaker.conf
-
 if [ ! -f $CFFILE ] ; then
 	echo "NO DISTMAKER.CONF FILE!"
 	exit 1
 else
 	. $CFFILE
 fi
-
 . "$P/common.sh"
 
 SRC=$DM_SOURCEDIR
 TRG=$DM_TMPDIR/civicrm
 
 # make sure and clean up before
-if [ -d $TRG ] ; then
-	rm -rf $TRG/*
-fi
+[ -d $TRG ] && rm -rf $TRG/*
 
 # copy all the stuff
 dm_install_l10n "$SRC/l10n" "$TRG/l10n"

--- a/distmaker/dists/l10n.sh
+++ b/distmaker/dists/l10n.sh
@@ -15,6 +15,8 @@ else
 	. $CFFILE
 fi
 
+. "$P/common.sh"
+
 RSYNCOPTIONS="-avC $DM_EXCLUDES_RSYNC --include=core"
 RSYNCCOMMAND="$DM_RSYNC $RSYNCOPTIONS"
 SRC=$DM_SOURCEDIR
@@ -26,11 +28,7 @@ if [ -d $TRG ] ; then
 fi
 
 # copy all the stuff
-for CODE in l10n; do
-  echo $CODE
-  [ -d $SRC/$CODE ] && $RSYNCCOMMAND $SRC/$CODE $TRG
-done
-
+dm_install_l10n "$SRC/l10n" "$TRG/l10n"
 
 # copy selected sqls
 if [ ! -d $TRG/sql ] ; then

--- a/distmaker/dists/l10n.sh
+++ b/distmaker/dists/l10n.sh
@@ -17,8 +17,6 @@ fi
 
 . "$P/common.sh"
 
-RSYNCOPTIONS="-avC $DM_EXCLUDES_RSYNC --include=core"
-RSYNCCOMMAND="$DM_RSYNC $RSYNCOPTIONS"
 SRC=$DM_SOURCEDIR
 TRG=$DM_TMPDIR/civicrm
 

--- a/distmaker/dists/l10n.sh
+++ b/distmaker/dists/l10n.sh
@@ -19,22 +19,13 @@ TRG=$DM_TMPDIR/civicrm
 
 # copy all the stuff
 dm_install_l10n "$SRC/l10n" "$TRG/l10n"
+dm_install_files "$SRC" "$TRG" {agpl-3.0,agpl-3.0.exception,gpl,README,CONTRIBUTORS}.txt
 
 # copy selected sqls
-if [ ! -d $TRG/sql ] ; then
-	mkdir $TRG/sql
-fi
-
-for F in $SRC/sql/civicrm*.mysql $SRC/sql/counties.US.sql.gz $SRC/sql/case_sample*.mysql; do
+[ ! -d $TRG/sql ] && mkdir $TRG/sql
+for F in $SRC/sql/civicrm*.mysql $SRC/sql/case_sample*.mysql; do
 	cp $F $TRG/sql
 done
-
-# copy docs
-cp $SRC/agpl-3.0.txt $TRG
-cp $SRC/gpl.txt $TRG
-cp $SRC/README.txt $TRG
-cp $SRC/CONTRIBUTORS.txt $TRG
-cp $SRC/agpl-3.0.exception.txt $TRG
 
 # gen tarball
 cd $TRG/..

--- a/distmaker/dists/wordpress_php5.sh
+++ b/distmaker/dists/wordpress_php5.sh
@@ -14,11 +14,6 @@ fi
 SRC=$DM_SOURCEDIR
 TRG=$DM_TMPDIR/civicrm
 
-# checkout the right code revisions
-pushd "$DM_SOURCEDIR/WordPress"
-git checkout "$DM_REF_WORDPRESS"
-popd
-
 # copy all the stuff
 dm_reset_dirs "$TRG" "$TRG/civicrm/civicrm"
 cp $SRC/WordPress/civicrm.config.php.wordpress $TRG/civicrm/civicrm/civicrm.config.php

--- a/distmaker/dists/wordpress_php5.sh
+++ b/distmaker/dists/wordpress_php5.sh
@@ -19,19 +19,17 @@ pushd "$DM_SOURCEDIR/WordPress"
 git checkout "$DM_REF_WORDPRESS"
 popd
 
-# make sure and clean up before
-[ -d $TRG ] && rm -rf $TRG/*
-[ ! -d $TRG/civicrm/civicrm ] && mkdir -p $TRG/civicrm/civicrm
-
 # copy all the stuff
+dm_reset_dirs "$TRG" "$TRG/civicrm/civicrm"
+cp $SRC/WordPress/civicrm.config.php.wordpress $TRG/civicrm/civicrm/civicrm.config.php
+dm_generate_version "$TRG/civicrm/civicrm/civicrm-version.php" Wordpress
 dm_install_core "$SRC" "$TRG/civicrm/civicrm"
 dm_install_packages "$SRC/packages" "$TRG/civicrm/civicrm/packages"
 dm_install_wordpress "$SRC/WordPress" "$TRG/civicrm"
-cp $SRC/WordPress/civicrm.config.php.wordpress $TRG/civicrm/civicrm/civicrm.config.php
-dm_generate_version "$TRG/civicrm/civicrm/civicrm-version.php" Wordpress
 
 # gen tarball
 cd $TRG
 $DM_ZIP -r -9 $DM_TARGETDIR/civicrm-$DM_VERSION-wordpress.zip *
+
 # clean up
 rm -rf $TRG

--- a/distmaker/dists/wordpress_php5.sh
+++ b/distmaker/dists/wordpress_php5.sh
@@ -26,11 +26,7 @@ popd
 # copy all the stuff
 dm_install_core "$SRC" "$TRG/civicrm/civicrm"
 dm_install_packages "$SRC/packages" "$TRG/civicrm/civicrm/packages"
-
-for F in $SRC/WordPress/*; do
-	cp $F $TRG/civicrm
-done
-rm -f $TRG/civicrm/civicrm.config.php.wordpress
+dm_install_wordpress "$SRC/WordPress" "$TRG/civicrm"
 
 # copy docs
 cp $SRC/WordPress/civicrm.config.php.wordpress $TRG/civicrm/civicrm/civicrm.config.php

--- a/distmaker/dists/wordpress_php5.sh
+++ b/distmaker/dists/wordpress_php5.sh
@@ -27,8 +27,6 @@ popd
 dm_install_core "$SRC" "$TRG/civicrm/civicrm"
 dm_install_packages "$SRC/packages" "$TRG/civicrm/civicrm/packages"
 dm_install_wordpress "$SRC/WordPress" "$TRG/civicrm"
-
-# copy docs
 cp $SRC/WordPress/civicrm.config.php.wordpress $TRG/civicrm/civicrm/civicrm.config.php
 dm_generate_version "$TRG/civicrm/civicrm/civicrm-version.php" Wordpress
 

--- a/distmaker/dists/wordpress_php5.sh
+++ b/distmaker/dists/wordpress_php5.sh
@@ -1,20 +1,14 @@
 #!/bin/bash
 set -ex
 
-# This script assumes
-# that DAOs are generated
-# and all the necessary conversions had place!
-
 P=`dirname $0`
 CFFILE=$P/../distmaker.conf
-
 if [ ! -f $CFFILE ] ; then
 	echo "NO DISTMAKER.CONF FILE!"
 	exit 1
 else
 	. $CFFILE
 fi
-
 . "$P/common.sh"
 
 SRC=$DM_SOURCEDIR
@@ -26,21 +20,8 @@ git checkout "$DM_REF_WORDPRESS"
 popd
 
 # make sure and clean up before
-if [ -d $TRG ] ; then
-	rm -rf $TRG/*
-fi
-
-if [ ! -d $TRG ] ; then
-	mkdir $TRG
-fi
-
-if [ ! -d $TRG/civicrm ] ; then
-	mkdir $TRG/civicrm
-fi
-
-if [ ! -d $TRG/civicrm/civicrm ] ; then
-	mkdir $TRG/civicrm/civicrm
-fi
+[ -d $TRG ] && rm -rf $TRG/*
+[ ! -d $TRG/civicrm/civicrm ] && mkdir -p $TRG/civicrm/civicrm
 
 # copy all the stuff
 dm_install_core "$SRC" "$TRG/civicrm/civicrm"

--- a/distmaker/dists/wordpress_php5.sh
+++ b/distmaker/dists/wordpress_php5.sh
@@ -46,10 +46,7 @@ fi
 
 # copy all the stuff
 dm_install_core "$SRC" "$TRG/civicrm/civicrm"
-for CODE in packages ; do
-  echo $CODE
-  [ -d $SRC/$CODE ] && $RSYNCCOMMAND $SRC/$CODE $TRG/civicrm/civicrm
-done
+dm_install_packages "$SRC/packages" "$TRG/civicrm/civicrm/packages"
 
 for F in $SRC/WordPress/*; do
 	cp $F $TRG/civicrm

--- a/distmaker/dists/wordpress_php5.sh
+++ b/distmaker/dists/wordpress_php5.sh
@@ -55,15 +55,7 @@ rm -f $TRG/civicrm/civicrm.config.php.wordpress
 
 # copy docs
 cp $SRC/WordPress/civicrm.config.php.wordpress $TRG/civicrm/civicrm/civicrm.config.php
-
-# final touch
-echo "<?php
-function civicrmVersion( ) {
-  return array( 'version'  => '$DM_VERSION',
-                'cms'      => 'Wordpress',
-                'revision' => '$DM_REVISION' );
-}
-" > $TRG/civicrm/civicrm/civicrm-version.php
+dm_generate_version "$TRG/civicrm/civicrm/civicrm-version.php" Wordpress
 
 # gen tarball
 cd $TRG

--- a/distmaker/dists/wordpress_php5.sh
+++ b/distmaker/dists/wordpress_php5.sh
@@ -17,8 +17,6 @@ fi
 
 . "$P/common.sh"
 
-RSYNCOPTIONS="-avC $DM_EXCLUDES_RSYNC --include=core"
-RSYNCCOMMAND="$DM_RSYNC $RSYNCOPTIONS"
 SRC=$DM_SOURCEDIR
 TRG=$DM_TMPDIR/civicrm
 

--- a/distmaker/dists/wordpress_php5.sh
+++ b/distmaker/dists/wordpress_php5.sh
@@ -15,6 +15,8 @@ else
 	. $CFFILE
 fi
 
+. "$P/common.sh"
+
 RSYNCOPTIONS="-avC $DM_EXCLUDES_RSYNC --include=core"
 RSYNCCOMMAND="$DM_RSYNC $RSYNCOPTIONS"
 SRC=$DM_SOURCEDIR
@@ -43,30 +45,11 @@ if [ ! -d $TRG/civicrm/civicrm ] ; then
 fi
 
 # copy all the stuff
-for CODE in css i js packages PEAR templates bin CRM api extern Reports install settings; do
+dm_install_core "$SRC" "$TRG/civicrm/civicrm"
+for CODE in packages ; do
   echo $CODE
   [ -d $SRC/$CODE ] && $RSYNCCOMMAND $SRC/$CODE $TRG/civicrm/civicrm
 done
-
-# delete any setup.sh or setup.php4.sh if present
-if [ -d $TRG/civicrm/civicrm/bin ] ; then
-  rm -f $TRG/civicrm/civicrm/bin/setup.sh
-  rm -f $TRG/civicrm/civicrm/bin/setup.php4.sh
-  rm -f $TRG/civicrm/civicrm/bin/setup.bat
-fi
-
-# copy selected sqls
-if [ ! -d $TRG/civicrm/civicrm/sql ] ; then
-	mkdir $TRG/civicrm/civicrm/sql
-fi
-
-for F in $SRC/sql/civicrm*.mysql $SRC/sql/counties.US.sql.gz $SRC/sql/case_sample*.mysql; do
-	cp $F $TRG/civicrm/civicrm/sql
-done
-
-set +e
-rm -rf $TRG/civicrm/civicrm/sql/civicrm_*.??_??.mysql
-set -e
 
 for F in $SRC/WordPress/*; do
 	cp $F $TRG/civicrm
@@ -74,9 +57,6 @@ done
 rm -f $TRG/civicrm/civicrm.config.php.wordpress
 
 # copy docs
-cp $SRC/agpl-3.0.txt $TRG/civicrm/civicrm
-cp $SRC/gpl.txt $TRG/civicrm/civicrm
-cp $SRC/README.txt $TRG/civicrm/civicrm
 cp $SRC/WordPress/civicrm.config.php.wordpress $TRG/civicrm/civicrm/civicrm.config.php
 
 # final touch


### PR DESCRIPTION
1. Reduce massive code duplication so that we mortals can understand
2. Allow running individual *.sh build scripts without switching branches
