### PR TITLE
CRM-14900 use INSERT ignore for states - this is primarily about copy & ...

### DIFF
--- a/CRM/Upgrade/Incremental/sql/3.0.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/3.0.alpha1.mysql.tpl
@@ -534,7 +534,7 @@
 
     -- State / province
     -- CRM-4534 CRM-4686 CRM-4769
-        INSERT INTO civicrm_state_province
+        INSERT IGNORE INTO civicrm_state_province
             (id, name, abbreviation, country_id)
         VALUES
             (5218,  'Distrito Federal', 'DIF', 1140),

--- a/CRM/Upgrade/Incremental/sql/3.0.beta4.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/3.0.beta4.mysql.tpl
@@ -23,7 +23,7 @@
         WHERE civicrm_navigation.name= 'New Grant';
 
 -- CRM-5048
-INSERT INTO civicrm_state_province (id,    country_id, abbreviation, name) VALUES
+INSERT IGNORE INTO civicrm_state_province (id,    country_id, abbreviation, name) VALUES
                                    (10010, 1107,       "Bar",        "Barletta-Andria-Trani"),
                                    (10011, 1107,       "Fer",        "Fermo"),
                                    (10012, 1107,       "Mon",        "Monza e Brianza");

--- a/CRM/Upgrade/Incremental/sql/3.1.5.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/3.1.5.mysql.tpl
@@ -23,10 +23,11 @@ UPDATE civicrm_state_province SET name = 'Keelung City'     WHERE id = 4864;
 
 -- Create additional Taiwan provinces
 SELECT @country_id := id from civicrm_country where name = 'Taiwan';
-INSERT INTO civicrm_state_province ( country_id, abbreviation, name ) VALUES
+INSERT IGNORE INTO civicrm_state_province ( country_id, abbreviation, name ) VALUES
 ( @country_id, 'TXG', 'Taichung City'  ),
 ( @country_id, 'KHH', 'Kaohsiung City' ),
 ( @country_id, 'TPE', 'Taipei City'    ),
 ( @country_id, 'CYI', 'Chiayi City'    ),
 ( @country_id, 'HSZ', 'Hsinchu City'   ),
 ( @country_id, 'TNN', 'Tainan City'    );
+

--- a/CRM/Upgrade/Incremental/sql/3.1.beta5.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/3.1.beta5.mysql.tpl
@@ -1,7 +1,7 @@
 -- CRM-5628
 SELECT @country_id := id from civicrm_country where name = 'Haiti';
 
-INSERT INTO civicrm_state_province ( country_id, abbreviation, name ) VALUES
+INSERT IGNORE INTO civicrm_state_province ( country_id, abbreviation, name ) VALUES
 ( @country_id,  'AR',  'Artibonite' ),
 ( @country_id,  'CE',  'Centre'     ),
 ( @country_id,  'NI',  'Nippes'     ),

--- a/CRM/Upgrade/Incremental/sql/3.2.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/3.2.alpha1.mysql.tpl
@@ -272,7 +272,7 @@ VALUES
    (@option_group_id_mt, {localize}'Export Activities'{/localize},  @max_val+1, 'Export Activity', NULL, 0, 0, @max_wt+1, 0, 1, 1);
 
 -- CRM-6063
-   INSERT INTO civicrm_state_province
+   INSERT IGNORE INTO civicrm_state_province
         (`name`, `abbreviation`, `country_id` )
    VALUES
         ( 'Andorra la Vella', '07', 1005 ),

--- a/CRM/Upgrade/Incremental/sql/3.2.alpha3.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/3.2.alpha3.mysql.tpl
@@ -107,7 +107,7 @@ ALTER TABLE `civicrm_contact` MODIFY COLUMN `is_deleted` boolean NOT NULL DEFAUL
 
 DELETE FROM `civicrm_state_province` WHERE `name` IN ('Freeport', 'Fresh Creek', 'Governor\'s Harbour' , 'Green Turtle Cay', 'Harbour Island', 'High Rock', 'Kemps Bay', 'Marsh Harbour','Nicholls Town and Berry Islands' ,'Rock Sound','Sandy Point','San Salvador and Rum Cay','Bandundu', 'Bas-Congo' ,'Haut-Congo', 'Kasai-Occidental','Katanga', 'Orientale' );
 
-INSERT INTO civicrm_state_province
+INSERT IGNORE INTO civicrm_state_province
         (`name`, `abbreviation`, `country_id` )
    VALUES
         ( 'Abaco Islands', 'AB',1212),

--- a/CRM/Upgrade/Incremental/sql/3.4.1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/3.4.1.mysql.tpl
@@ -56,7 +56,7 @@ ALTER TABLE civicrm_custom_field MODIFY start_date_years INT(10);
 ALTER TABLE civicrm_custom_field MODIFY end_date_years INT(10);
 
 -- CRM-8009
-INSERT INTO civicrm_state_province
+INSERT IGNORE INTO civicrm_state_province
   (`name`, `abbreviation`, `country_id` )
 VALUES
   ( 'Toledo' , 'TO', '1198' ),

--- a/CRM/Upgrade/Incremental/sql/4.1.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.1.alpha1.mysql.tpl
@@ -18,7 +18,7 @@ ADD UNIQUE INDEX UI_name ( name );
 DELETE FROM civicrm_currency WHERE name = 'EEK';
 
 -- CRM-8769
-INSERT INTO civicrm_state_province
+INSERT IGNORE INTO civicrm_state_province
   (`name`, `abbreviation`, `country_id`)
 VALUES
   ('Metropolitan Manila' , 'MNL', '1170');

--- a/CRM/Upgrade/Incremental/sql/4.4.beta1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.4.beta1.mysql.tpl
@@ -1,6 +1,6 @@
 {* file to handle db changes in 4.4.beta1 during upgrade *}
 -- CRM-13314 Added States for Uruguay
-INSERT INTO civicrm_state_province (id, country_id, abbreviation, name) VALUES
+INSERT IGNORE INTO civicrm_state_province (id, country_id, abbreviation, name) VALUES
 (NULL, 1229, "FL", "Florida"),
 (NULL, 1229, "RN", "Rio Negro"),
 (NULL, 1229, "SJ", "San Jose");


### PR DESCRIPTION
...paste protection

(will do 4.5 ones after). 
Note the reason for this is that sites legitimately alter their states & countries in between upgrades  & it should not be cause for updgrade failure
