### PR TITLE
CRM-14798 - Case Type Name

### DIFF
--- a/CRM/Case/BAO/CaseType.php
+++ b/CRM/Case/BAO/CaseType.php
@@ -70,6 +70,9 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType {
     if (!$nameParam && empty($params['id'])) {
       $params['name'] = CRM_Utils_String::titleToVar($params['title']);
     }
+    if (!empty($params['name']) && !CRM_Case_BAO_CaseType::isValidName($params['name'])) {
+      throw new CRM_Core_Exception("Cannot create caseType with malformed name [{$params['name']}]");
+    }
 
     // function to format definition column
     if (isset($params['definition']) && is_array($params['definition'])) {
@@ -307,5 +310,15 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType {
     $caseType = new CRM_Case_DAO_CaseType();
     $caseType->id = $caseTypeId;
     return $caseType->delete();
+  }
+
+  /**
+   * Determine if a case-type name is well-formed
+   *
+   * @param string $caseType
+   * @return bool
+   */
+  static function isValidName($caseType) {
+    return preg_match('/^[a-zA-Z0-9_]+$/',  $caseType);
   }
 }

--- a/CRM/Case/XMLProcessor.php
+++ b/CRM/Case/XMLProcessor.php
@@ -54,9 +54,23 @@ class CRM_Case_XMLProcessor {
   }
 
   /**
-   * @param $caseType
+   * This function was previously used to convert a case-type's
+   * machine-name to a file-name. However, it's mind-boggling
+   * that the file-name might be a munged version of the
+   * machine-name (which is itself a munged version of the
+   * display-name), and naming is now a more visible issue (since
+   * the overhaul of CaseType admin UI).
    *
-   * @return mixed|string
+   * Usage note: This is called externally by civix stubs as a
+   * sort of side-ways validation of the case-type's name
+   * (validation which was needed because of the unintuitive
+   * double-munge). We should update civix templates and then
+   * remove this function in Civi 4.6 or 5.0.
+   *
+   * @param string $caseType
+   * @return string
+   * @deprecated
+   * @see CRM_Case_BAO_CaseType::isValidName
    */
   public static function mungeCaseType($caseType) {
     // trim all spaces from $caseType

--- a/CRM/Case/XMLRepository.php
+++ b/CRM/Case/XMLRepository.php
@@ -84,7 +84,10 @@ class CRM_Case_XMLRepository {
       return simplexml_load_string($definition);
     }
 
-    $caseType = CRM_Case_XMLProcessor::mungeCaseType($caseType);
+    if (!CRM_Case_BAO_CaseType::isValidName($caseType)) {
+      // perhaps caller provider a the label instead of the name?
+      throw new CRM_Core_Exception("Cannot load caseType with malformed name [$caseType]");
+    }
 
     if (!CRM_Utils_Array::value($caseType, $this->xml)) {
       // first check custom templates directory

--- a/CRM/Upgrade/Snapshot/V4p2/Case/XMLProcessor.php
+++ b/CRM/Upgrade/Snapshot/V4p2/Case/XMLProcessor.php
@@ -1,0 +1,26 @@
+<?php
+
+class CRM_Upgrade_Snapshot_V4p2_Case_XMLProcessor {
+  /**
+   * @param string $caseType
+   * @return string
+   * @see CRM_Case_XMLProcessor::mungeCaseType
+   */
+  public static function mungeCaseType($caseType) {
+    $caseType = str_replace('_', ' ', $caseType);
+    $caseType = self::_munge(ucwords($caseType), '', 0);
+    return $caseType;
+  }
+
+  static function _munge($name, $char = '_', $len = 63) {
+    $name = preg_replace('/[^a-zA-Z0-9]+/', $char, trim($name));
+    if ($len) {
+      // lets keep variable names short
+      return substr($name, 0, $len);
+    }
+    else {
+      return $name;
+    }
+  }
+
+}

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -331,6 +331,9 @@ input.crm-form-entityref {
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr = '#ffffff', endColorstr = '#eeeeee', GradientType = 0);
   background-image: linear-gradient(top, #fff 0%, #eee 50%);
 }
+.crm-container input.crm-form-text.ng-invalid {
+    border: 1px solid #FF0000;
+}
 .crm-container input.crm-form-text,
 .crm-container input.dateplugin {
   border: 1px solid #999;

--- a/js/angular-crmCaseType.js
+++ b/js/angular-crmCaseType.js
@@ -251,7 +251,8 @@
     var updateCaseTypeName = function () {
       if (!$scope.caseType.id && $scope.locks.caseTypeName) {
         // Should we do some filtering? Lowercase? Strip whitespace?
-        $scope.caseType.name = $scope.caseType.title;
+        var t = $scope.caseType.title ? $scope.caseType.title : '';
+        $scope.caseType.name = t.replace(/ /g, '_').replace(/[^a-zA-Z0-9_]/g, '').toLowerCase();
       }
     };
     $scope.$watch('locks.caseTypeName', updateCaseTypeName);

--- a/partials/crmCaseType/caseTypeDetails.html
+++ b/partials/crmCaseType/caseTypeDetails.html
@@ -15,7 +15,12 @@ The original form used table layout; don't know if we have an alternative, CSS-b
   <tr>
     <td class="label">Name</td>
     <td>
-      <input type="text" ng-model="caseType.name" ng-disabled="locks.caseTypeName" class="big crm-form-text"/>
+      <input
+        type="text"
+        ng-model="caseType.name"
+        ng-disabled="locks.caseTypeName"
+        ng-pattern="/^[a-zA-Z0-9_]+$/"
+        class="big crm-form-text"/>
       <a crm-ui-lock binding="locks.caseTypeName" class="crm-hover-button"></a>
     </td>
   </tr>

--- a/tests/phpunit/api/v3/CaseTypeTest.php
+++ b/tests/phpunit/api/v3/CaseTypeTest.php
@@ -103,6 +103,22 @@ class api_v3_CaseTypeTest extends CiviUnitTestCase {
   }
 
   /**
+   * Create a case with an invalid name
+   */
+  function testCaseTypeCreate_invalidName() {
+    // Create Case Type
+    $params = array(
+      'title' => 'Application',
+      'name' => 'Appl ication', // spaces are not allowed
+      'is_active' => 1,
+      'weight' => 4,
+    );
+
+    $this->callAPIFailure('CaseType', 'create', $params);
+  }
+
+
+  /**
    * Test update (create with id) function with valid parameters
    */
   function testCaseTypeUpdate() {


### PR DESCRIPTION
(Note: I expect this to be a little controversial / require some discussion
or changes.)

Prior to this, the naming for a case-type flowed more or less like:
1. The admin makes up a display-name (title/label)
2. That title is munged via CRM_Utils_String::titleToVar to produce a machine-name
3. That machine-name is munged via CRM_Case_XMLProcessor::mungeCaseType to produce a file-name
4. The admin goes back to rename his file to match the double-munged version.

As we begin allowing more varied dataflows for managing CaseType XML files
and CaseType DB records, it becomes more important for the naming behavior
to intuitive. 

This PR fixes the handling of case-type name in the UI -- and gives the
admin/developer more meaningful freedom to specify the name of the case-type
without any back/forth over filenames.
