### PR TITLE
CRM-14931 - CRM.loadPage - Dialogs should respect statusBounce

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -834,7 +834,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
     }
     $session->setStatus($status, $title);
     if (CRM_Utils_Array::value('snippet', $_REQUEST) === CRM_Core_Smarty::PRINT_JSON) {
-      CRM_Core_Page_AJAX::returnJsonResponse(array('status' => 'error'));
+      CRM_Core_Page_AJAX::returnJsonResponse(array('status' => 'error', 'crmBounceUrl' => $redirect));
     }
     CRM_Utils_System::redirect($redirect);
   }

--- a/js/crm.ajax.js
+++ b/js/crm.ajax.js
@@ -211,7 +211,9 @@
     _onFailure: function(data) {
       this.options.block && this.element.unblock();
       this.element.trigger('crmAjaxFail', data);
-      CRM.alert(ts('Unable to reach the server. Please refresh this page in your browser and try again.'), ts('Network Error'), 'error');
+      if (! data.crmPreventWarning) {
+        CRM.alert(ts('Unable to reach the server. Please refresh this page in your browser and try again.'), ts('Network Error'), 'error');
+      }
     },
     _formatUrl: function(url) {
       // Strip hash
@@ -294,6 +296,12 @@
       $(settings.target).on('dialogclose', function() {
         if ($(this).attr('data-unsaved-changes') !== 'true') {
           $(this).crmSnippet('destroy').dialog('destroy').remove();
+        }
+      });
+      $(settings.target).on('crmAjaxFail', function(event, data) {
+        if (typeof(data) == 'object' && data.crmBounceUrl) {
+          data.crmPreventWarning = true;
+          $(event.target).dialog('close');
         }
       });
     }


### PR DESCRIPTION
When a dialog requests a page that sends a status-bounce, show the alert and
close the dialog.  I'm not sure if this policy is overly broad (I don't
know all the ways in which CRM.loadPage gets used), but it feels like
an improvement on the "Manage Case" screen.

It's still not ideal -- an empty dialog briefly flashes on the screen while
the AJAX request is sent.  But we do need _some_ visual feedback about the
pending AJAX request, and that's currently what we have.
