### PR TITLE
CRM-14972 fix test-exposed bug in separate membership payment

### DIFF
--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -2346,7 +2346,7 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
       'civicrm_membership_type',
       'civicrm_membership_payment',
       'civicrm_membership_log',
-      'civicrm_membership_status',
+      'civicrm_membership_block',
       'civicrm_event',
       'civicrm_participant',
       'civicrm_participant_payment',


### PR DESCRIPTION
PR extends testing so specifically ensure a separate membership payment is created when appropriate.

I DO think that we should move the separate membership payment off the membership block & onto price field config & work to dissolve the membership blocks into the price set config (it would simplify the code while giving more powerful functionality as separate payments would apply to price set memberships too) . However, it's hard to see that working until we improve the UI on pricesets - eg. like the way profiles are embedded into the forms. I feel like if that were there all the other steps would seem easy & logical

It may cause regression in other tests as I decided to remove membership_status table from those truncated when cleaning up financial entities. I think this makes sense as there is 'set up' data in that table - e.g Pending status - which should be there through all tests. Will check for other failures & adjust their tear down function.
