### PR TITLE
CRM-14971 - Contact image URLs should go through WP frontend

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -943,7 +943,7 @@ WHERE id={$id}; ";
 
     if (in_array($params[$imageIndex]['type'], $mimeType)) {
       $photo = basename($params[$imageIndex]['name']);
-      $params[$imageIndex] =  CRM_Utils_System::url('civicrm/contact/imagefile', 'photo='.$photo, TRUE);
+      $params[$imageIndex] =  CRM_Utils_System::url('civicrm/contact/imagefile', 'photo='.$photo, TRUE, NULL, TRUE, TRUE);
       return TRUE;
     }
     else {

--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -522,11 +522,11 @@ SET    version = '$version'
    * Perform an incremental version update
    *
    * @param $rev string, the target (intermediate) revision e.g '3.2.alpha1'
-   * @param $currentVer string, the original revision
+   * @param $originalVer string, the original revision
    * @param $latestVer string, the target (final) revision
    * @param $postUpgradeMessageFile string, path of a modifiable file which lists the post-upgrade messages
    */
-  static function doIncrementalUpgradeStep(CRM_Queue_TaskContext$ctx, $rev, $currentVer, $latestVer, $postUpgradeMessageFile) {
+  static function doIncrementalUpgradeStep(CRM_Queue_TaskContext$ctx, $rev, $originalVer, $latestVer, $postUpgradeMessageFile) {
     $upgrade = new CRM_Upgrade_Form();
 
     $phpFunctionName = 'upgrade_' . str_replace('.', '_', $rev);
@@ -568,7 +568,7 @@ SET    version = '$version'
 
       if (is_callable(array(
         $versionObject, $phpFunctionName))) {
-        $versionObject->$phpFunctionName($rev);
+        $versionObject->$phpFunctionName($rev, $originalVer, $latestVer);
       }
       else {
         $upgrade->processSQL($rev);

--- a/CRM/Upgrade/Incremental/php/FourFour.php
+++ b/CRM/Upgrade/Incremental/php/FourFour.php
@@ -348,7 +348,7 @@ AND image_URL IS NOT NULL
         $config = CRM_Core_Config::singleton();
         $fullpath = $config->customFileUploadDir.$photo;
           if (file_exists($fullpath)){
-            $newimageurl =  CRM_Utils_System::url('civicrm/contact/imagefile', 'photo='.$photo, TRUE);
+            $newimageurl =  CRM_Utils_System::url('civicrm/contact/imagefile', 'photo='.$photo, TRUE, NULL, TRUE, TRUE);
             $sql = 'UPDATE civicrm_contact SET image_url=%1 WHERE id=%2';
             $params = array(
               1 => array($newimageurl, 'String'),

--- a/CRM/Upgrade/Incremental/php/FourFour.php
+++ b/CRM/Upgrade/Incremental/php/FourFour.php
@@ -325,19 +325,23 @@ ALTER TABLE civicrm_dashboard
     }
   }
 
+  function upgrade_4_4_7($rev, $originalVer, $latestVer) {
+    // For WordPress/Joomla(?), cleanup broken image_URL from 4.4.6 upgrades - https://issues.civicrm.org/jira/browse/CRM-14971
+    $exBackendUrl = CRM_Utils_System::url('civicrm/contact/imagefile', 'photo=XXX', TRUE); // URL formula from 4.4.6 upgrade
+    $exFrontendUrl = CRM_Utils_System::url('civicrm/contact/imagefile', 'photo=XXX', TRUE, NULL, TRUE, TRUE);
+    if ($originalVer == '4.4.6' && $exBackendUrl != $exFrontendUrl) {
+      $minId = CRM_Core_DAO::singleValueQuery('SELECT coalesce(min(id),0) FROM civicrm_contact WHERE image_URL IS NOT NULL');
+      $maxId = CRM_Core_DAO::singleValueQuery('SELECT coalesce(max(id),0) FROM civicrm_contact WHERE image_URL IS NOT NULL');
+      for ($startId = $minId; $startId <= $maxId; $startId += self::BATCH_SIZE) {
+        $endId = $startId + self::BATCH_SIZE - 1;
+        $title = ts('Upgrade image_urls (%1 => %2)', array(1 => $startId, 2 => $endId));
+        $this->addTask($title, 'cleanupBackendImageUrls', $startId, $endId);
+      }
+    }
+  }
+
   static function upgradeImageUrls(CRM_Queue_TaskContext $ctx, $startId, $endId){
-    $sql = "
-SELECT id, image_url
-FROM civicrm_contact
-WHERE 1
-AND id BETWEEN %1 AND %2
-AND image_URL IS NOT NULL
-";
-    $params = array(
-      1 => array($startId, 'Integer'),
-      2 => array($endId, 'Integer'),
-    );
-    $dao = CRM_Core_DAO::executeQuery($sql, $params, TRUE, NULL, FALSE, FALSE);
+    $dao = self::findContactImageUrls($startId, $endId);
     $failures = array();
     while ($dao->fetch()){
       $imageURL = $dao->image_url;
@@ -348,13 +352,10 @@ AND image_URL IS NOT NULL
         $config = CRM_Core_Config::singleton();
         $fullpath = $config->customFileUploadDir.$photo;
           if (file_exists($fullpath)){
-            $newimageurl =  CRM_Utils_System::url('civicrm/contact/imagefile', 'photo='.$photo, TRUE, NULL, TRUE, TRUE);
-            $sql = 'UPDATE civicrm_contact SET image_url=%1 WHERE id=%2';
-            $params = array(
-              1 => array($newimageurl, 'String'),
-              2 => array($dao->id, 'Integer'),
-            );
-            $updatedao = CRM_Core_DAO::executeQuery($sql, $params);
+            // For anyone who upgraded 4.4.6 release (eg 4.4.0=>4.4.6), the $newImageUrl incorrectly used backend URLs.
+            // For anyone who skipped 4.4.6 (eg 4.4.0=>4.4.7), the $newImageUrl correctly uses frontend URLs
+            self::setContactImageUrl($dao->id,
+              CRM_Utils_System::url('civicrm/contact/imagefile', 'photo='.$photo, TRUE, NULL, TRUE, TRUE));
           }
           else{
             $failures[$dao->id] = $dao->image_url;
@@ -366,6 +367,67 @@ AND image_URL IS NOT NULL
       }
     CRM_Core_Error::debug_var('imageUrlsNotUpgraded', $failures);
     return TRUE;
+  }
+
+  /**
+   * For WordPress/Joomla(?) sites which upgraded to 4.4.6, find back-end image_URLs
+   * (e.g. "http://example.com/wp-admin/admin.php?page=CiviCRM&amp;q=civicrm/contact/imagefile&amp;photo=123.jpg")
+   * and convert them to front-end URLs
+   * (e.g. "http://example.com/?page=CiviCRM&amp;q=civicrm/contact/imagefile&amp;photo=123.jpg").
+   *
+   * @param CRM_Queue_TaskContext $ctx
+   * @param $startId
+   * @param $endId
+   * @return bool
+   */
+  static function cleanupBackendImageUrls(CRM_Queue_TaskContext $ctx, $startId, $endId) {
+    $dao = self::findContactImageUrls($startId, $endId);
+    while ($dao->fetch()) {
+      $imageUrl = str_replace('&amp;', '&', $dao->image_url);
+      if (preg_match(":civicrm/contact/imagefile.*photo=:", $imageUrl)) {
+        // looks like one of ours
+        $imageUrlParts = parse_url($imageUrl);
+        parse_str($imageUrlParts['query'], $imageUrlQuery);
+        self::setContactImageUrl($dao->id,
+          CRM_Utils_System::url('civicrm/contact/imagefile', 'photo='.$imageUrlQuery['photo'], TRUE, NULL, TRUE, TRUE));
+      }
+    }
+    return TRUE;
+  }
+
+  /**
+   * @param int $startId
+   * @param int $endId
+   * @return CRM_Core_DAO columns include "id" and "image_URL"
+   */
+  public static function findContactImageUrls($startId, $endId) {
+    $sql = "
+SELECT id, image_url
+FROM civicrm_contact
+WHERE 1
+AND id BETWEEN %1 AND %2
+AND image_URL IS NOT NULL
+";
+
+    $params = array(
+      1 => array($startId, 'Integer'),
+      2 => array($endId, 'Integer'),
+    );
+    $dao = CRM_Core_DAO::executeQuery($sql, $params, TRUE, NULL, FALSE, FALSE);
+    return $dao;
+  }
+
+  /**
+   * @param int $cid
+   * @param string $newImageUrl
+   */
+  public static function setContactImageUrl($cid, $newImageUrl) {
+    $sql = 'UPDATE civicrm_contact SET image_url=%1 WHERE id=%2';
+    $params = array(
+      1 => array($newImageUrl, 'String'),
+      2 => array($cid, 'Integer'),
+    );
+    $updatedao = CRM_Core_DAO::executeQuery($sql, $params);
   }
 
   /**


### PR DESCRIPTION
---
- CRM-14971: Contact image URLs broken in WordPress after upgrade to 4.4.6
  https://issues.civicrm.org/jira/browse/CRM-14971
