### PR TITLE
Patch - CRM-14953

### DIFF
--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -470,14 +470,14 @@
     {if $context eq 'standalone' and $outBound_option != 2 }
     {literal}
     CRM.$(function($) {
-      cj("#contact_1").blur( function( ) {
+      cj("#contact_id").change( function( ) {
         checkEmail( );
       } );
       checkEmail( );
     });
 
     function checkEmail( ) {
-      var contactID = cj("input[name='contact_select_id[1]']").val();
+      var contactID = cj("#contact_id").val();
       if ( contactID ) {
         var postUrl = "{/literal}{crmURL p='civicrm/ajax/checkemail' h=0}{literal}";
         cj.post( postUrl, {contact_id: contactID},

--- a/templates/CRM/Member/Form/MembershipStandalone.js
+++ b/templates/CRM/Member/Form/MembershipStandalone.js
@@ -1,14 +1,12 @@
 CRM.$(function($) {
   memberResults = new Array;
-  $("input[name='contact[1]']").result( function() {
-    var contact_id = cj("input[name='contact_select_id[1]']").val();
+    var contact_id = cj("#contact_id").val();
     CRM.api('Membership', 'get', {'sequential': 1, 'contact_id': contact_id},
       {success: function(data) {
         if (data['values']) {
           memberResults = data['values'];
           checkExistingMemOrg();
         }
-      }});
     });
       
   checkExistingMemOrg();


### PR DESCRIPTION
Fixed the following related CRM-14953.
1) On selecting contact for membaeship, the 'email-receipt' row remains hidden so user can not send receipt.
2) On selecting price set for membership, financial type does not pre-fill.
