### PR TITLE
CRM-14971 - Fix resizing of contact images

### DIFF
--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -443,7 +443,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
     CRM_Contact_Form_Edit_Address::setDefaultValues( $defaults, $this );
 
     if (CRM_Utils_Array::value('image_URL', $defaults)) {
-      list($imageWidth, $imageHeight) = getimagesize($defaults['image_URL']);
+      list($imageWidth, $imageHeight) = getimagesize(CRM_Utils_String::unstupifyUrl($defaults['image_URL']));
       list($imageThumbWidth, $imageThumbHeight) = CRM_Contact_BAO_Contact::getThumbSize($imageWidth, $imageHeight);
       $this->assign('imageWidth', $imageWidth);
       $this->assign('imageHeight', $imageHeight);

--- a/CRM/Contact/Page/View.php
+++ b/CRM/Contact/Page/View.php
@@ -167,7 +167,7 @@ class CRM_Contact_Page_View extends CRM_Core_Page {
         $image_URL = str_replace('http://', 'https://', $image_URL);
       }
 
-      list($imageWidth, $imageHeight) = getimagesize($image_URL);
+      list($imageWidth, $imageHeight) = getimagesize(CRM_Utils_String::unstupifyUrl($image_URL));
       list($imageThumbWidth, $imageThumbHeight) = CRM_Contact_BAO_Contact::getThumbSize($imageWidth, $imageHeight);
       $this->assign("imageWidth", $imageWidth);
       $this->assign("imageHeight", $imageHeight);

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -1111,7 +1111,7 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
               }
             }
             elseif ($name == 'image_URL') {
-              list($width, $height) = getimagesize($details->$name);
+              list($width, $height) = getimagesize(CRM_Utils_String::unstupifyUrl($details->$name));
               list($thumbWidth, $thumbHeight) = CRM_Contact_BAO_Contact::getThumbSize($width, $height);
 
               $image_URL = '<img src="' . $details->$name . '" height= ' . $thumbHeight . ' width= ' . $thumbWidth . '  />';

--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -551,7 +551,7 @@ class CRM_Profile_Form extends CRM_Core_Form {
     }
 
     if (CRM_Utils_Array::value('image_URL', $this->_defaults)) {
-      list($imageWidth, $imageHeight) = getimagesize($this->_defaults['image_URL']);
+      list($imageWidth, $imageHeight) = getimagesize(CRM_Utils_String::unstupifyUrl($this->_defaults['image_URL']));
       list($imageThumbWidth, $imageThumbHeight) = CRM_Contact_BAO_Contact::getThumbSize($imageWidth, $imageHeight);
       $this->assign("imageWidth", $imageWidth);
       $this->assign("imageHeight", $imageHeight);

--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -652,6 +652,17 @@ class CRM_Utils_String {
     }
   }
 
-
+  /**
+   * Many parts of the codebase have a convention of internally passing around
+   * HTML-encoded URLs. This effectively means that "&" is replaced by "&amp;"
+   * (because most other odd characters are %-escaped in URLs; and %-escaped
+   * strings don't need any extra escaping in HTML).
+   *
+   * @param string $url URL with HTML entities
+   * @return string URL without HTML entities
+   */
+  public static function unstupifyUrl($htmlUrl) {
+    return str_replace('&amp;', '&', $htmlUrl);
+  }
 }
 


### PR DESCRIPTION
---
- CRM-14971: Contact image URLs broken in WordPress after upgrade to 4.4.6
  https://issues.civicrm.org/jira/browse/CRM-14971
