### PR TITLE
Fix hard crash of test-suite due to syntax error

### DIFF
--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -384,7 +384,7 @@ function civicrm_api3_contribution_completetransaction(&$params) {
     if(!$contribution->loadRelatedObjects($input, $ids, FALSE, TRUE)){
       throw new API_Exception('failed to load related objects');
     }
-    elseif ($contribution['contribution_status_id'] == CRM_Core_OptionGroup::getValue('contribution_status', 'Completed', 'name')) {
+    elseif ($contribution->contribution_status_id == CRM_Core_OptionGroup::getValue('contribution_status', 'Completed', 'name')) {
       throw new API_Exception(ts('Contribution already completed'));
     }
     $objects = $contribution->_relatedObjects;


### PR DESCRIPTION
Note: This is _only_ a syntax fix. I don't what's supposed to be going on,
and there are other tests which fails... but at least they don't
crash the test-suite.

Original change was: 9e2ee07bf82624fe50070e14ccc6aa39ffa1b7d9
