### PR TITLE
CRM-14986 fix DB error on date find + save

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -249,7 +249,7 @@ SELECT r.payment_processor_id
       $recur->save();
 
       $dao = CRM_Contribute_BAO_ContributionRecur::getSubscriptionDetails($recurId);
-      if ($dao->recur_id) {
+      if ($dao && $dao->recur_id) {
         $details = CRM_Utils_Array::value('details', $activityParams);
         if ($dao->auto_renew && $dao->membership_id) {
           // its auto-renewal membership mode

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
@@ -1,0 +1,91 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.4                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2013                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*/
+
+require_once 'CiviTest/CiviUnitTestCase.php';
+class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
+  protected $_params = array();
+
+  function setUp() {
+    parent::setUp();
+    $this->_ids['payment_processor'] = $this->paymentProcessorCreate();
+    $this->_params = array(
+      'contact_id' => $this->individualCreate(),
+      'amount' => 3.00,
+      'frequency_unit' => 'week',
+      'frequency_interval' => 1,
+      'installments' => 2,
+      'start_date' => 'yesterday',
+      'create_date' => 'yesterday',
+      'modified_date' => 'yesterday',
+      'cancel_date' => NULL,
+      'end_date' => '+ 2 weeks',
+      'processor_id' => '643411460836',
+      'trxn_id' => 'e0d0808e26f3e661c6c18eb7c039d363',
+      'invoice_id' => 'e0d0808e26f3e661c6c18eb7c039d363',
+      'contribution_status_id' => 1,
+      'is_test' => 0,
+      'cycle_day' => 1,
+      'next_sched_contribution_date' => '+ 1 week',
+      'failure_count' => 0,
+      'failure_retry_date' => NULL,
+      'auto_renew' => 0,
+      'currency' => 'USD',
+      'payment_processor_id' => $this->_ids['payment_processor'],
+      'is_email_receipt' => 1,
+      'financial_type_id' => 1,
+      'payment_instrument_id' => 1,
+      'campaign_id' => NULL,
+    );
+  }
+
+  function teardown() {
+    $this->quickCleanup(array('civicrm_contribution_recur', 'civicrm_payment_processor'));
+  }
+
+  /**
+   * test that an object can be retrieved & saved (per CRM-14986)
+   * this has been causing a DB error so we are checking for absence of error
+   */
+  function testFindSave() {
+    $contributionRecur = $this->callAPISuccess('contribution_recur', 'create', $this->_params);
+    $dao = new CRM_Contribute_BAO_ContributionRecur();
+    $dao->id = $contributionRecur['id'];
+    $dao->find(TRUE);
+    $dao->is_email_receipt = 0;
+    $dao->save();
+  }
+
+  /**
+   * test cancellation works per CRM-14986
+   * we are checking for absence of error
+   */
+  function testCancelRecur() {
+    $contributionRecur = $this->callAPISuccess('contribution_recur', 'create', $this->_params);
+    CRM_Contribute_BAO_ContributionRecur::cancelRecurContribution($contributionRecur['id'], CRM_Core_DAO::$_nullObject);
+  }
+
+}


### PR DESCRIPTION
this is manefesting in the failure to save contributions, however, it has been a recurrent problem
that the format used for date fields on ->find does not match the requirement of ->save
hence we see in the ContributionRecur class 3 lines like
->modified_date = CRM_Utils_Date::isoToMysql(->modified_date);
which exist simply to format the date fields for re-save.
The end_date & next_scheduled_date were missed - resulting in fatals when this function
is used
It seems kind of crazy to keep solving this problem in the form & BAO layer
so this commit is tests only & there is a commit on the packages dir
that alters the DAO->update fn to check for the presence of a '-' & do the isoToMysql there
instead.
