### PR TITLE
CRM-14994 Fix activity type values

### DIFF
--- a/CRM/Upgrade/Incremental/sql/4.5.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.5.alpha1.mysql.tpl
@@ -182,7 +182,7 @@ VALUES
 -- new activity types required for partial payments
 SELECT @option_group_id_act     := max(id) from civicrm_option_group where name = 'activity_type';
 SELECT @option_group_id_act_wt  := MAX(weight) FROM civicrm_option_value WHERE option_group_id = @option_group_id_act;
-SELECT @option_group_id_act_val := MAX(value) FROM civicrm_option_value WHERE option_group_id = @option_group_id_act;
+SELECT @option_group_id_act_val := MAX(ROUND(value)) FROM civicrm_option_value WHERE option_group_id = @option_group_id_act;
 SELECT @contributeCompId := max(id) FROM civicrm_component where name = 'CiviContribute';
 
 INSERT INTO


### PR DESCRIPTION
The 'value' column in the civicrm_option_value table is a varchar(512) so max() selects (in my database) '9' rather than '72'.

Looking at previous upgrade scripts that add an activity_type, the max(value) should be max(round(value)) so 'value' is treated as an integer.

This pull request assumes that changing the 4.5.alpha1 upgrade script is kosher. If not, perhaps the change should be be that the activity types 'Payment', 'Refund', and 'Change Registration' are UPDATEd in 4.5.beta2 to have better 'value' values.
