### PR TITLE
CRM-14995 contributions disappearing on pledge edit

### DIFF
--- a/CRM/Core/BAO/Domain.php
+++ b/CRM/Core/BAO/Domain.php
@@ -207,6 +207,7 @@ class CRM_Core_BAO_Domain extends CRM_Core_DAO_Domain {
   /**
    * @param bool $skipFatal
    *
+   * @return array name & email for domain
    * @throws Exception
    */
   static function getNameAndEmail($skipFatal = FALSE) {

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -429,7 +429,7 @@ class CRM_Core_Permission {
    * check permissions for delete and edit actions
    *
    * @param string $module component name.
-   * @param $action action to be check across component
+   * @param integer $action action to be check across component
    *
    *
    * @return bool

--- a/CRM/Pledge/BAO/Pledge.php
+++ b/CRM/Pledge/BAO/Pledge.php
@@ -300,6 +300,12 @@ class CRM_Pledge_BAO_Pledge extends CRM_Pledge_DAO_Pledge {
 
   /**
    * function to get the amount details date wise.
+   *
+   * @param string $status
+   * @param string $startDate
+   * @param string $endDate
+   *
+   * @return array|null
    */
   static function getTotalAmountAndCount($status = NULL, $startDate = NULL, $endDate = NULL) {
     $where = array();
@@ -441,7 +447,7 @@ GROUP BY  currency
    *
    * @param int $honorId In Honor of Contact ID
    *
-   * @return return the list of pledge fields
+   * @return array return the list of pledge fields
    *
    * @access public
    * @static
@@ -612,7 +618,7 @@ GROUP BY  currency
       $receiptFrom = $params['from_email_id'];
     }
     elseif ($userID = $session->get('userID')) {
-      //check for loged in user.
+      //check for logged in user.
       list($userName, $userEmail) = CRM_Contact_BAO_Contact_Location::getEmailDetails($userID);
     }
     else {
@@ -1080,6 +1086,7 @@ SELECT  pledge.contact_id              as contact_id,
    * & recreating so we want to block that if appropriate
    *
    * @param integer $pledgeID
+   * @param integer $pledgeStatusID
    * @return bool do financial transactions exist for this pledge?
    */
    static function pledgeHasFinancialTransactions($pledgeID, $pledgeStatusID) {
@@ -1105,6 +1112,7 @@ SELECT  pledge.contact_id              as contact_id,
     if (!in_array($statusID, self::getNonTransactionalStatus())) {
       return TRUE;
     }
+    return FALSE;
   }
 
   /**

--- a/CRM/Pledge/BAO/Pledge.php
+++ b/CRM/Pledge/BAO/Pledge.php
@@ -1073,5 +1073,56 @@ SELECT  pledge.contact_id              as contact_id,
     }
     return $paymentIDs;
   }
+
+  /**
+   * Is this pledge free from financial transactions (this is important to know as we allow editing
+   * when no transactions have taken place - the editing process currently involves deleting all pledge payments & contributions
+   * & recreating so we want to block that if appropriate
+   *
+   * @param integer $pledgeID
+   * @return bool do financial transactions exist for this pledge?
+   */
+   static function pledgeHasFinancialTransactions($pledgeID, $pledgeStatusID) {
+    if (empty($pledgeStatusID)) {
+      //why would this happen? If we can see where it does then we can see if we should look it up
+      //but assuming from form code it CAN be empty
+      return TRUE;
+    }
+    if (self::isTransactedStatus($pledgeStatusID)) {
+      return TRUE;
+    }
+
+    return civicrm_api3('pledge_payment', 'getcount', array('pledge_id' => $pledgeID, 'status_id' => array('IN' => self::getTransactionalStatus())));
+    }
+
+  /**
+   * Does this pledge / pledge payment status mean that a financial transaction has taken place?
+   * @param int $statusID pledge status id
+   *
+   * @return bool is it a transactional status?
+   */
+  protected static function isTransactedStatus($statusID) {
+    if (!in_array($statusID, self::getNonTransactionalStatus())) {
+      return TRUE;
+    }
+  }
+
+  /**
+   * Get array of non transactional statuses
+   * @return array non transactional status ids
+   */
+  protected static function getNonTransactionalStatus() {
+    $paymentStatus = CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name');
+    return array_flip(array_intersect($paymentStatus, array('Overdue', 'Pending')));
+  }
+
+  /**
+   * Get array of non transactional statuses
+   * @return array non transactional status ids
+   */
+  protected static function getTransactionalStatus() {
+    $paymentStatus = CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name');
+    return array_diff(array_flip($paymentStatus), self::getNonTransactionalStatus());
+  }
 }
 

--- a/CRM/Pledge/Form/Pledge.php
+++ b/CRM/Pledge/Form/Pledge.php
@@ -115,7 +115,6 @@ class CRM_Pledge_Form_Pledge extends CRM_Core_Form {
 
     //build custom data
     CRM_Custom_Form_CustomData::preProcess($this, NULL, NULL, 1, 'Pledge', $this->_id);
-
     $this->_values = array();
     // current pledge id
     if ($this->_id) {
@@ -126,36 +125,7 @@ class CRM_Pledge_Form_Pledge extends CRM_Core_Form {
       $params = array('id' => $this->_id);
       CRM_Pledge_BAO_Pledge::getValues($params, $this->_values);
 
-      $paymentStatusTypes = CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name');
-
-      //check for pending pledge.
-      if (CRM_Utils_Array::value('status_id', $this->_values) ==
-        array_search('Pending', $paymentStatusTypes)
-      ) {
-        $this->_isPending = TRUE;
-      }
-      elseif (CRM_Utils_Array::value('status_id', $this->_values) ==
-        array_search('Overdue', $paymentStatusTypes)
-      ) {
-
-        $allPledgePayments = array();
-        CRM_Core_DAO::commonRetrieveAll('CRM_Pledge_DAO_PledgePayment',
-          'pledge_id',
-          $this->_id,
-          $allPledgePayments,
-          array('status_id')
-        );
-
-        foreach ($allPledgePayments as $key => $value) {
-          $allStatus[$value['id']] = $paymentStatusTypes[$value['status_id']];
-        }
-
-        if (count(array_count_values($allStatus)) <= 2) {
-          if (CRM_Utils_Array::value('Pending', array_count_values($allStatus))) {
-            $this->_isPending = TRUE;
-          }
-        }
-      }
+      $this->_isPending = (CRM_Pledge_BAO_Pledge::pledgeHasFinancialTransactions($this->_id, CRM_Utils_Array::value('status_id', $this->_values))) ? FALSE : T;
     }
 
     //get the pledge frequency units.
@@ -163,6 +133,7 @@ class CRM_Pledge_Form_Pledge extends CRM_Core_Form {
 
     $this->_fromEmails = CRM_Core_BAO_Email::getFromEmail();
   }
+
 
   /**
    * This function sets the default values for the form.

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -253,7 +253,7 @@ abstract class CRM_Utils_Hook {
    *
    * @param string $op         the type of operation being performed
    * @param string $objectName the name of the object
-   * @param object $id         the object id if available
+   * @param int $id         the object id if available
    * @param array  $params     the parameters used for object creation / editing
    *
    * @return null the return value is ignored


### PR DESCRIPTION
This PR tightens the definition of whether a pledge is editable. Previous logic said "if there are only 2 pledge payment statuses associated with a pledge & 1 is Pending then it is editable (implicitly the other status must be Overdue). This PR makes the 2 acceptable statuses explicit & any other statues will result in the pledge not being editable (via the form which is really the only way to cause the contributions to be deleted)
