### PR TITLE
CRM-14990: Round two.

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -161,12 +161,7 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup {
     }
 
     if (array_key_exists('is_reserved', $params)) {
-      if (in_array($params['is_reserved'], array(TRUE, 1, '1'), TRUE)) {
-        $is_reserved = 1;
-      } else {
-        $is_reserved = 0;
-      }
-      $group->is_reserved = $is_reserved;
+      $group->is_reserved = $params['is_reserved'] ? 1 : 0;
     }
     $op = isset($params['id']) ? 'edit' : 'create';
     CRM_Utils_Hook::pre($op, 'CustomGroup', CRM_Utils_Array::value('id', $params), $params);

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -160,14 +160,14 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup {
       }
     }
 
-    $is_reserved = CRM_Utils_Array::value('is_reserved', $params, 0);
-    if (in_array($is_reserved, array(TRUE, 1, '1'), TRUE)) {
-      $is_reserved = 1;
-    } else {
-      $is_reserved = 0;
+    if (array_key_exists('is_reserved', $params)) {
+      if (in_array($params['is_reserved'], array(TRUE, 1, '1'), TRUE)) {
+        $is_reserved = 1;
+      } else {
+        $is_reserved = 0;
+      }
+      $group->is_reserved = $is_reserved;
     }
-    $group->is_reserved = $is_reserved;
-
     $op = isset($params['id']) ? 'edit' : 'create';
     CRM_Utils_Hook::pre($op, 'CustomGroup', CRM_Utils_Array::value('id', $params), $params);
 

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -168,6 +168,9 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup {
     }
     $group->is_reserved = $is_reserved;
 
+    $op = isset($params['id']) ? 'edit' : 'create';
+    CRM_Utils_Hook::pre($op, 'CustomGroup', CRM_Utils_Array::value('id', $params), $params);
+
     // enclose the below in a transaction
     $transaction = new CRM_Core_Transaction();
 


### PR DESCRIPTION
Follow-up to #3669. Adds pre- hook and doesn't always overwrite is_reserved. FYI: @eileenmcnaughton, @davecivicrm.

I don't think we need to update `_civicrm_api3_custom_group_create_spec` since we aren't providing/forcing a default; if no value is provided the database default of 0 wins.
