### PR TITLE
CRM-15002 - Link Cases - Fix fatal error

### DIFF
--- a/CRM/Case/Form/Activity/LinkCases.php
+++ b/CRM/Case/Form/Activity/LinkCases.php
@@ -47,17 +47,22 @@ class CRM_Case_Form_Activity_LinkCases {
     if (!isset($form->_caseId)) {
       CRM_Core_Error::fatal(ts('Case Id not found.'));
     }
+    if (count($form->_caseId) != 1) {
+      CRM_Core_Resources::fatal(ts('Expected one case-type'));
+    }
+
+    $caseId = CRM_Utils_Array::first($form->_caseId);
 
     $form->assign('clientID', $form->_currentlyViewedContactId);
-    $form->assign('caseTypeLabel', CRM_Case_BAO_Case::getCaseType($form->_caseId));
+    $form->assign('caseTypeLabel', CRM_Case_BAO_Case::getCaseType($caseId));
 
     // get the related cases for given case.
     $relatedCases = $form->get('relatedCases');
     if (!isset($relatedCases)) {
-      $relatedCases = CRM_Case_BAO_Case::getRelatedCases($form->_caseId, $form->_currentlyViewedContactId);
+      $relatedCases = CRM_Case_BAO_Case::getRelatedCases($caseId, $form->_currentlyViewedContactId);
       $form->set('relatedCases', empty($relatedCases) ? FALSE : $relatedCases);
     }
-    $excludeCaseIds = array($form->_caseId);
+    $excludeCaseIds = array($caseId);
     if (is_array($relatedCases) && !empty($relatedCases)) {
       $excludeCaseIds = array_merge($excludeCaseIds, array_keys($relatedCases));
     }
@@ -101,7 +106,8 @@ class CRM_Case_Form_Activity_LinkCases {
     $errors = array();
 
     $linkCaseId = CRM_Utils_Array::value('link_to_case_id', $values);
-    if ($linkCaseId == $form->_caseId) {
+    assert('is_numeric($linkeCaseId)');
+    if ($linkCaseId == CRM_Utils_Array::first($form->_caseId)) {
       $errors['link_to_case'] = ts('Please select some other case to link.');
     }
 

--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -943,5 +943,18 @@ class CRM_Utils_Array {
 
     return $results;
   }
+
+  /**
+   * Get the first elemnet of an array
+   *
+   * @param array $array
+   * @return mixed|NULL
+   */
+  static function first($array) {
+    foreach ($array as $value) {
+      return $value;
+    }
+    return NULL;
+  }
 }
 


### PR DESCRIPTION
Note: In my setup, the "Link Cases" screen doesn't seem to _work_ correctly
-- because it's not showing a field for the related case. However, it's not
producing the fatal related to $form->_caseId.
