### PR TITLE
CRM-15019 - avoid validation error on register date if not using ISO

### DIFF
--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -299,6 +299,10 @@ class CRM_Event_Import_Parser_Participant extends CRM_Event_Import_Parser {
             $params[$key] = CRM_Utils_String::strtoboolstr($val);
           }
         }
+        if($key == 'participant_register_date') {
+          CRM_Utils_Date::convertToDefaultDate($params, $dateType, 'participant_register_date');
+          $formatted['participant_register_date'] = CRM_Utils_Date::processDate($params['participant_register_date']);
+        }
       }
     }
 


### PR DESCRIPTION
date format.

---
- CRM-15019: Importing participant record with register date in a format other than YYYY-MM-DD results in validation error
  https://issues.civicrm.org/jira/browse/CRM-15019
