### PR TITLE
CRM-15032 - change 4.4.0.mysql.tpl to UTF-8 encoding.

### DIFF
--- a/CRM/Upgrade/Incremental/sql/4.4.0.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.4.0.mysql.tpl
@@ -1,9 +1,9 @@
 {* file to handle db changes in 4.4.0 during upgrade *}
 -- CRM-13571
-UPDATE civicrm_state_province SET name = 'Møre og Romsdal' WHERE name = 'Møre ag Romsdal';
+UPDATE civicrm_state_province SET name = 'MÃ¸re og Romsdal' WHERE name = 'MÃ¸re ag Romsdal';
 
 -- CRM-13604
 UPDATE civicrm_state_province SET name = 'Alta Verapaz' WHERE name = 'Alta Verapez';
 UPDATE civicrm_state_province SET name = 'Baja Verapaz' WHERE name = 'Baja Verapez';
 UPDATE civicrm_state_province SET name = 'Retalhuleu' WHERE name = 'Reta.thuleu';
-UPDATE civicrm_state_province SET name = 'Sololá' WHERE name = 'Solol6';
+UPDATE civicrm_state_province SET name = 'SololÃ¡' WHERE name = 'Solol6';


### PR DESCRIPTION
---
- CRM-15032: 4.4.0.mysql.tpl has Latin-1 encoding, should be UTF-8
  https://issues.civicrm.org/jira/browse/CRM-15032
