### PR TITLE
CRM-15036 - force emailed social media image URLs to use HTTP.

### DIFF
--- a/templates/CRM/common/SocialNetwork.tpl
+++ b/templates/CRM/common/SocialNetwork.tpl
@@ -36,10 +36,10 @@
         {if $emailMode eq true}
             {*use images for email*}
             <a href="http://twitter.com/share?url={$url}&amp;text={$title}" id="crm_tweet">
-                <img title="Twitter Tweet Button" src="{$config->userFrameworkResourceURL}/i/tweet.png" width="55px" height="20px"  alt="Tweet Button">
+                <img title="Twitter Tweet Button" src="{$config->userFrameworkResourceURL|replace:'https://':'http://'}/i/tweet.png" width="55px" height="20px"  alt="Tweet Button">
             </a>
             <a href="http://www.facebook.com/plugins/like.php?href={$url}" target="_blank">
-                <img title="Facebook Like Button" src="{$config->userFrameworkResourceURL}/i/fblike.png" alt="Facebook Button" />
+                <img title="Facebook Like Button" src="{$config->userFrameworkResourceURL|replace:'https://':'http://'}/i/fblike.png" alt="Facebook Button" />
             </a>
         {else}
             {*use advanced buttons for pages*}


### PR DESCRIPTION
---
- CRM-15036: Social media image URLs should always use HTTP in emails
  https://issues.civicrm.org/jira/browse/CRM-15036
