### PR TITLE
Webtest fix for new contribution record and membership.

### DIFF
--- a/tests/phpunit/WebTest/Contribute/StandaloneAddTest.php
+++ b/tests/phpunit/WebTest/Contribute/StandaloneAddTest.php
@@ -126,6 +126,9 @@ class WebTest_Contribute_StandaloneAddTest extends CiviSeleniumTestCase {
 
     // Clicking save.
     $this->click("_qf_Contribution_upload");
+    // Ask for confirmation to send a receipt to the contributor on 'is_email_reciept' check
+    $this->assertTrue((bool)preg_match("/^Click OK to save this contribution record AND send a receipt to the contributor now./",$this->getConfirmation()));
+    $this->chooseOkOnNextConfirmation();
     $this->waitForPageToLoad($this->getTimeoutMsec());
 
     // Is status message correct?

--- a/tests/phpunit/WebTest/Member/StandaloneAddTest.php
+++ b/tests/phpunit/WebTest/Member/StandaloneAddTest.php
@@ -71,7 +71,7 @@ class WebTest_Member_StandaloneAddTest extends CiviSeleniumTestCase {
 
     // fill in Status Override?
     // fill in Record Membership Payment?
-
+    $this->click("send_receipt");
     $this->click("_qf_Membership_upload");
 
     //View Membership


### PR DESCRIPTION
Fixed web test for standalone contribution and standalone membership signup. 
Same issue is already handled for standalone event registration.
