### PR TITLE
CRM-15060 - don't load entire contacts table when reserving for survey.

### DIFF
--- a/CRM/Campaign/BAO/Survey.php
+++ b/CRM/Campaign/BAO/Survey.php
@@ -793,7 +793,7 @@ INNER JOIN  civicrm_contact contact_a ON ( activityTarget.contact_id = contact_a
         $voterLinks['reserve'] = array(
           'name' => 'reserve',
           'url' => 'civicrm/survey/search',
-          'qs' => 'sid=%%id%%&reset=1&op=reserve&force=1',
+          'qs' => 'sid=%%id%%&reset=1&op=reserve',
           'title' => ts('Reserve Respondents'),
         );
       }


### PR DESCRIPTION
---
- CRM-15060: reserving survey respondents causes wait while entire database query is executed
  https://issues.civicrm.org/jira/browse/CRM-15060
