### PR TITLE
CRM-15037 Added assertion for standalone contribution and membership web...

### DIFF
--- a/tests/phpunit/WebTest/Contribute/StandaloneAddTest.php
+++ b/tests/phpunit/WebTest/Contribute/StandaloneAddTest.php
@@ -95,7 +95,7 @@ class WebTest_Contribute_StandaloneAddTest extends CiviSeleniumTestCase {
     $this->waitForElementPresent("check_number");
     $this->type("check_number", "check #1041");
     $this->click("is_email_receipt");
-
+    $this->assertTrue($this->isChecked("is_email_receipt"), 'Send Receipt checkbox should be checked.');
     $this->type("trxn_id", "P20901X1" . rand(100, 10000));
 
     // soft credit

--- a/tests/phpunit/WebTest/Member/StandaloneAddTest.php
+++ b/tests/phpunit/WebTest/Member/StandaloneAddTest.php
@@ -72,6 +72,7 @@ class WebTest_Member_StandaloneAddTest extends CiviSeleniumTestCase {
     // fill in Status Override?
     // fill in Record Membership Payment?
     $this->click("send_receipt");
+    $this->assertTrue($this->isChecked("send_receipt"), 'Send Confirmation and Receipt checkbox should be checked.');
     $this->click("_qf_Membership_upload");
 
     //View Membership


### PR DESCRIPTION
Checked assertion for standalone membership and contribution when "Send Receipt and confirmation" checkbox is checked.
