### PR TITLE
CRM test Fix 4.5beta5 For ActivityTest

### DIFF
--- a/tests/phpunit/CRM/Activity/BAO/activities_for_dashboard_count.xml
+++ b/tests/phpunit/CRM/Activity/BAO/activities_for_dashboard_count.xml
@@ -516,11 +516,6 @@
     />
     <civicrm_activity_contact
         activity_id="3"
-        contact_id="8"
-        record_type_id="3"
-    />
-    <civicrm_activity_contact
-        activity_id="3"
         contact_id="9"
         record_type_id="3"
     />


### PR DESCRIPTION
Since we are loading only one target contact per activity, removing contact_id = 8 from activity_id = 3, which loads contact_id 9 as target contact and asserts fine for testGetActivitiesforContactSummary() and testGetActivitiesforNonAdminDashboard() in CRM_Activity_BAO_ActivityTest.
