### PR TITLE
CRM-15011 - phpunit - Fixes for using normal phpunit

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,27 @@
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+         beStrictAboutTestsThatDoNotTestAnything="false"
+         bootstrap="tests/phpunit/CiviTest/bootstrap.php"
+>
+  <testsuites>
+    <testsuite name="CiviCRM Test Suite">
+      <directory>./tests/phpunit/</directory>
+    </testsuite>
+  </testsuites>
+
+  <filter>
+    <whitelist>
+      <directory suffix=".php">./CRM</directory>
+      <directory suffix=".php">./Civi</directory>
+      <directory suffix=".php">./api</directory>
+    </whitelist>
+  </filter>
+</phpunit>
+

--- a/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
@@ -285,7 +285,7 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
   function testGetActivitiesCountforAdminDashboard() {
     $op = new PHPUnit_Extensions_Database_Operation_Insert();
     $op->execute($this->_dbconn,
-      new PHPUnit_Extensions_Database_DataSet_FlatXMLDataSet(
+      $this->createFlatXMLDataSet(
         dirname(__FILE__) . '/activities_for_dashboard_count.xml'
       )
     );
@@ -314,7 +314,7 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
   function testGetActivitiesCountforNonAdminDashboard() {
     $op = new PHPUnit_Extensions_Database_Operation_Insert();
     $op->execute($this->_dbconn,
-      new PHPUnit_Extensions_Database_DataSet_FlatXMLDataSet(
+      $this->createFlatXMLDataSet(
         dirname(__FILE__) . '/activities_for_dashboard_count.xml'
       )
     );
@@ -344,7 +344,7 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
   function testGetActivitiesCountforContactSummary() {
     $op = new PHPUnit_Extensions_Database_Operation_Insert();
     $op->execute($this->_dbconn,
-      new PHPUnit_Extensions_Database_DataSet_FlatXMLDataSet(
+      $this->createFlatXMLDataSet(
         dirname(__FILE__) . '/activities_for_dashboard_count.xml'
       )
     );
@@ -373,7 +373,7 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
   function testGetActivitiesCountforContactSummaryWithNoActivities() {
     $op = new PHPUnit_Extensions_Database_Operation_Insert();
     $op->execute($this->_dbconn,
-      new PHPUnit_Extensions_Database_DataSet_FlatXMLDataSet(
+      $this->createFlatXMLDataSet(
         dirname(__FILE__) . '/activities_for_dashboard_count.xml'
       )
     );
@@ -401,7 +401,7 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
   function testGetActivitiesforAdminDashboard() {
     $op = new PHPUnit_Extensions_Database_Operation_Insert();
     $op->execute($this->_dbconn,
-      new PHPUnit_Extensions_Database_DataSet_FlatXMLDataSet(
+      $this->createFlatXMLDataSet(
         dirname(__FILE__) . '/activities_for_dashboard_count.xml'
       )
     );
@@ -436,7 +436,7 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
   function testGetActivitiesforNonAdminDashboard() {
     $op = new PHPUnit_Extensions_Database_Operation_Insert();
     $op->execute($this->_dbconn,
-      new PHPUnit_Extensions_Database_DataSet_FlatXMLDataSet(
+      $this->createFlatXMLDataSet(
         dirname(__FILE__) . '/activities_for_dashboard_count.xml'
       )
     );
@@ -479,7 +479,7 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
   function testGetActivitiesforContactSummary() {
     $op = new PHPUnit_Extensions_Database_Operation_Insert();
     $op->execute($this->_dbconn,
-      new PHPUnit_Extensions_Database_DataSet_FlatXMLDataSet(
+      $this->createFlatXMLDataSet(
         dirname(__FILE__) . '/activities_for_dashboard_count.xml'
       )
     );
@@ -534,7 +534,7 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
   function testGetActivitiesforContactSummaryWithNoActivities() {
     $op = new PHPUnit_Extensions_Database_Operation_Insert();
     $op->execute($this->_dbconn,
-      new PHPUnit_Extensions_Database_DataSet_FlatXMLDataSet(
+      $this->createFlatXMLDataSet(
         dirname(__FILE__) . '/activities_for_dashboard_count.xml'
       )
     );

--- a/tests/phpunit/CRM/Contact/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTest.php
@@ -47,7 +47,7 @@ class CRM_Contact_BAO_QueryTest extends CiviUnitTestCase {
   function testSearch($fv, $count, $ids, $full) {
     $op = new PHPUnit_Extensions_Database_Operation_Insert();
     $op->execute($this->_dbconn,
-      new PHPUnit_Extensions_Database_DataSet_FlatXMLDataSet(
+      $this->createFlatXMLDataSet(
         dirname(__FILE__) . '/queryDataset.xml'
       )
     );

--- a/tests/phpunit/CRM/Contact/Form/Search/Custom/GroupTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Search/Custom/GroupTest.php
@@ -101,7 +101,7 @@ class CRM_Contact_Form_Search_Custom_GroupTest extends CiviUnitTestCase {
     // echo "testCount\n";
     $op = new PHPUnit_Extensions_Database_Operation_Insert();
     $op->execute($this->_dbconn,
-      new PHPUnit_Extensions_Database_DataSet_FlatXMLDataSet(
+      $this->createFlatXMLDataSet(
         dirname(__FILE__) . '/dataset.xml'
       )
     );
@@ -132,7 +132,7 @@ class CRM_Contact_Form_Search_Custom_GroupTest extends CiviUnitTestCase {
     // echo "testAll\n";
     $op = new PHPUnit_Extensions_Database_Operation_Insert();
     $op->execute($this->_dbconn,
-      new PHPUnit_Extensions_Database_DataSet_FlatXMLDataSet(
+      $this->createFlatXMLDataSet(
         dirname(__FILE__) . '/dataset.xml'
       )
     );
@@ -163,7 +163,7 @@ class CRM_Contact_Form_Search_Custom_GroupTest extends CiviUnitTestCase {
     // echo "testContactIDs\n";
     $op = new PHPUnit_Extensions_Database_Operation_Insert();
     $op->execute($this->_dbconn,
-      new PHPUnit_Extensions_Database_DataSet_FlatXMLDataSet(
+      $this->createFlatXMLDataSet(
         dirname(__FILE__) . '/dataset.xml'
       )
     );

--- a/tests/phpunit/CRM/Core/BAO/IMTest.php
+++ b/tests/phpunit/CRM/Core/BAO/IMTest.php
@@ -69,7 +69,7 @@ class CRM_Core_BAO_IMTest extends CiviUnitTestCase {
     $op = new PHPUnit_Extensions_Database_Operation_Insert;
     $op->execute(
       $this->_dbconn,
-      new PHPUnit_Extensions_Database_DataSet_FlatXMLDataSet(dirname(__FILE__) . '/dataset/im_test.xml')
+      $this->createFlatXMLDataSet(dirname(__FILE__) . '/dataset/im_test.xml')
     );
 
     $contactId = 69;

--- a/tests/phpunit/CRM/Mailing/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Mailing/BAO/QueryTest.php
@@ -53,7 +53,7 @@ class CRM_Mailing_BAO_QueryTest extends CiviUnitTestCase {
   function testSearch($fv, $count, $ids, $full) {
     $op = new PHPUnit_Extensions_Database_Operation_Insert();
     $op->execute($this->_dbconn,
-      new PHPUnit_Extensions_Database_DataSet_FlatXMLDataSet(
+      $this->createFlatXMLDataSet(
         dirname(__FILE__) . '/queryDataset.xml'
       )
     );

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -199,7 +199,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
     //  Insert test data
     $op = new PHPUnit_Extensions_Database_Operation_Insert();
     $op->execute($this->_dbconn,
-      new PHPUnit_Extensions_Database_DataSet_FlatXMLDataSet(
+      $this->createFlatXMLDataSet(
         dirname(__FILE__) . '/dataset/data.xml'
       )
     );

--- a/tests/phpunit/CRM/Utils/DeprecatedUtilsTest.php
+++ b/tests/phpunit/CRM/Utils/DeprecatedUtilsTest.php
@@ -50,12 +50,12 @@ class CRM_Utils_DeprecatedUtilsTest extends CiviUnitTestCase {
     //  Insert a row in civicrm_contact creating individual contact
     $op = new PHPUnit_Extensions_Database_Operation_Insert();
     $op->execute($this->_dbconn,
-        new PHPUnit_Extensions_Database_DataSet_XMLDataSet(
+        $this->createXMLDataSet(
             dirname(__FILE__) . '/../../api/v3/dataset/contact_17.xml'
         )
     );
     $op->execute($this->_dbconn,
-        new PHPUnit_Extensions_Database_DataSet_XMLDataSet(
+        $this->createXMLDataSet(
             dirname(__FILE__) . '/../../api/v3/dataset/email_contact_17.xml'
         )
     );
@@ -82,12 +82,12 @@ class CRM_Utils_DeprecatedUtilsTest extends CiviUnitTestCase {
     //  Insert a row in civicrm_contact creating individual contact
     $op = new PHPUnit_Extensions_Database_Operation_Insert();
     $op->execute($this->_dbconn,
-        new PHPUnit_Extensions_Database_DataSet_XMLDataSet(
+        $this->createXMLDataSet(
             dirname(__FILE__) . '/../../api/v3/dataset/contact_17.xml'
         )
     );
     $op->execute($this->_dbconn,
-        new PHPUnit_Extensions_Database_DataSet_XMLDataSet(
+        $this->createXMLDataSet(
             dirname(__FILE__) . '/../../api/v3/dataset/email_contact_17.xml'
         )
     );

--- a/tests/phpunit/CiviTest/CiviSeleniumTestCase.php
+++ b/tests/phpunit/CiviTest/CiviSeleniumTestCase.php
@@ -25,8 +25,6 @@
  +--------------------------------------------------------------------+
 */
 
-require_once 'PHPUnit/Extensions/SeleniumTestCase.php';
-
 /**
  *  Include configuration
  */

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -386,7 +386,7 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
     $xmlFiles = glob($fixturesDir . '/*.xml');
     foreach ($xmlFiles as $xmlFixture) {
       $op = new PHPUnit_Extensions_Database_Operation_Insert();
-      $dataset = new PHPUnit_Extensions_Database_DataSet_XMLDataSet($xmlFixture);
+      $dataset = $this->createXMLDataSet($xmlFixture);
       $this->_tablesToTruncate = array_merge($this->_tablesToTruncate, $dataset->getTableNames());
       $op->execute($this->_dbconn, $dataset);
     }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -39,11 +39,6 @@ require_once CIVICRM_SETTINGS_PATH;
 /**
  *  Include class definitions
  */
-require_once 'PHPUnit/Extensions/Database/TestCase.php';
-require_once 'PHPUnit/Framework/TestResult.php';
-require_once 'PHPUnit/Extensions/Database/DataSet/FlatXmlDataSet.php';
-require_once 'PHPUnit/Extensions/Database/DataSet/XmlDataSet.php';
-require_once 'PHPUnit/Extensions/Database/DataSet/QueryDataSet.php';
 require_once 'tests/phpunit/Utils.php';
 require_once 'api/api.php';
 require_once 'CRM/Financial/BAO/FinancialType.php';

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -433,6 +433,8 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
    */
   protected function tearDown() {
     error_reporting(E_ALL & ~E_NOTICE);
+    $session = CRM_Core_Session::singleton();
+    $session->set('userID', NULL);
     $tablesToTruncate = array('civicrm_contact');
     $this->quickCleanup($tablesToTruncate);
     $this->cleanTempDirs();

--- a/tests/phpunit/CiviTest/bootstrap.php
+++ b/tests/phpunit/CiviTest/bootstrap.php
@@ -1,0 +1,33 @@
+<?php
+// ADAPTED FROM tools/scripts/phpunit
+
+$GLOBALS['base_dir'] = dirname(dirname(dirname(__DIR__)));
+$tests_dir = $GLOBALS['base_dir']  . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'phpunit';
+$civi_pkgs_dir = $GLOBALS['base_dir'] .   DIRECTORY_SEPARATOR . 'packages';
+ini_set('safe_mode', 0);
+ini_set('include_path',
+        "{$GLOBALS['base_dir']}" . PATH_SEPARATOR .
+        "$tests_dir"            . PATH_SEPARATOR .
+        "$civi_pkgs_dir"        . PATH_SEPARATOR
+        . ini_get( 'include_path') );
+
+#  Relying on system timezone setting produces a warning,
+#  doing the following prevents the warning message
+if ( file_exists( '/etc/timezone' ) ) {
+    $timezone = trim( file_get_contents( '/etc/timezone' ) );
+    if ( ini_set('date.timezone', $timezone ) === false ) {
+        echo "ini_set( 'date.timezone', '$timezone' ) failed\n";
+    }
+}
+
+# Crank up the memory
+ini_set('memory_limit', '2G');
+
+require_once $GLOBALS['base_dir'] . '/packages/vendor/autoload.php';
+
+/*
+require $GLOBALS['base_dir'] . DIRECTORY_SEPARATOR .
+        'packages' . DIRECTORY_SEPARATOR .
+        'PHPUnit' . DIRECTORY_SEPARATOR .
+        'Autoload.php';
+*/

--- a/tests/phpunit/HelloTest.php
+++ b/tests/phpunit/HelloTest.php
@@ -39,8 +39,6 @@
  * UR DOIN IT RIGHT!
  */
 
-require_once 'PHPUnit/Framework/TestCase.php';
-
 /**
  * Class HelloTest
  */

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -871,7 +871,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     //  Insert a row in civicrm_contact creating individual contact
     $op = new PHPUnit_Extensions_Database_Operation_Insert();
     $op->execute($this->_dbconn,
-      new PHPUnit_Extensions_Database_DataSet_XMLDataSet(
+      $this->createXMLDataSet(
         dirname(__FILE__) . '/dataset/contact_ind.xml'
       )
     );
@@ -902,10 +902,10 @@ class api_v3_ContactTest extends CiviUnitTestCase {
       $this->assertEquals($value, $getResult['values'][23][$key]);
     }
     //  Check updated civicrm_contact against expected
-    $expected = new PHPUnit_Extensions_Database_DataSet_XMLDataSet(
+    $expected = $this->createXMLDataSet(
       dirname(__FILE__) . '/dataset/contact_ind_upd.xml'
     );
-    $actual = new PHPUnit_Extensions_Database_DataSet_QueryDataset(
+    $actual = new PHPUnit_Extensions_Database_DataSet_QueryDataSet(
       $this->_dbconn
     );
     $actual->addTable('civicrm_contact');
@@ -919,7 +919,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     //  Insert a row in civicrm_contact creating organization contact
     $op = new PHPUnit_Extensions_Database_Operation_Insert();
     $op->execute($this->_dbconn,
-      new PHPUnit_Extensions_Database_DataSet_XMLDataSet(
+      $this->createXMLDataSet(
         dirname(__FILE__) . '/dataset/contact_org.xml'
       )
     );
@@ -935,10 +935,10 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     $this->callAPISuccess('Contact', 'Update', $params);
 
     //  Check updated civicrm_contact against expected
-    $expected = new PHPUnit_Extensions_Database_DataSet_XMLDataSet(
+    $expected = $this->createXMLDataSet(
       dirname(__FILE__) . '/dataset/contact_org_upd.xml'
     );
-    $actual = new PHPUnit_Extensions_Database_DataSet_QueryDataset(
+    $actual = new PHPUnit_Extensions_Database_DataSet_QueryDataSet(
       $this->_dbconn
     );
     $actual->addTable('civicrm_contact');
@@ -952,7 +952,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     //  Insert a row in civicrm_contact creating household contact
     $op = new PHPUnit_Extensions_Database_Operation_Insert();
     $op->execute($this->_dbconn,
-      new PHPUnit_Extensions_Database_DataSet_XMLDataSet(
+      $this->createXMLDataSet(
         dirname(__FILE__) . '/dataset/contact_hld.xml'
       )
     );
@@ -985,7 +985,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     //  Insert a row in civicrm_contact creating individual contact
     $op = new PHPUnit_Extensions_Database_Operation_Insert();
     $op->execute($this->_dbconn,
-      new PHPUnit_Extensions_Database_DataSet_XMLDataSet(
+      $this->createXMLDataSet(
         dirname(__FILE__) . '/dataset/contact_ind.xml'
       )
     );
@@ -1109,12 +1109,12 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     //  Insert a row in civicrm_contact creating individual contact
     $op = new PHPUnit_Extensions_Database_Operation_Insert();
     $op->execute($this->_dbconn,
-      new PHPUnit_Extensions_Database_DataSet_XMLDataSet(
+      $this->createXMLDataSet(
         dirname(__FILE__) . '/dataset/contact_17.xml'
       )
     );
     $op->execute($this->_dbconn,
-      new PHPUnit_Extensions_Database_DataSet_XMLDataSet(
+      $this->createXMLDataSet(
         dirname(__FILE__) . '/dataset/email_contact_17.xml'
       )
     );
@@ -1140,7 +1140,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     //  Insert a row in civicrm_contact creating contact 17
     $op = new PHPUnit_Extensions_Database_Operation_Insert();
     $op->execute($this->_dbconn,
-      new PHPUnit_Extensions_Database_DataSet_XMLDataSet(
+      $this->createXMLDataSet(
         dirname(__FILE__) . '/dataset/contact_17.xml'
       )
     );
@@ -1159,7 +1159,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     //  Insert a row in civicrm_contact creating contact 17
     $op = new PHPUnit_Extensions_Database_Operation_Insert();
     $op->execute($this->_dbconn,
-      new PHPUnit_Extensions_Database_DataSet_XMLDataSet(dirname(__FILE__) . '/dataset/contact_17.xml'
+      $this->createXMLDataSet(dirname(__FILE__) . '/dataset/contact_17.xml'
       )
     );
 
@@ -1683,7 +1683,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     //  Insert a row in civicrm_contact creating contact 17
     $op = new PHPUnit_Extensions_Database_Operation_Insert();
     $op->execute($this->_dbconn,
-      new PHPUnit_Extensions_Database_DataSet_XMLDataSet(
+      $this->createXMLDataSet(
         dirname(__FILE__) . '/dataset/contact_17.xml'
       )
     );

--- a/tests/phpunit/api/v3/GroupNestingTest.php
+++ b/tests/phpunit/api/v3/GroupNestingTest.php
@@ -50,7 +50,7 @@ class api_v3_GroupNestingTest extends CiviUnitTestCase {
     //  from_email_address group
     $op = new PHPUnit_Extensions_Database_Operation_Insert();
     $op->execute($this->_dbconn,
-      new PHPUnit_Extensions_Database_DataSet_XMLDataSet(
+      $this->createXMLDataSet(
         dirname(__FILE__) . '/dataset/group_admins.xml'
       )
     );
@@ -59,7 +59,7 @@ class api_v3_GroupNestingTest extends CiviUnitTestCase {
     //  from_email_address group
     $op = new PHPUnit_Extensions_Database_Operation_Insert();
     $op->execute($this->_dbconn,
-      new PHPUnit_Extensions_Database_DataSet_XMLDataSet(
+      $this->createXMLDataSet(
         dirname(__FILE__) . '/dataset/group_subscribers.xml'
       )
     );
@@ -68,7 +68,7 @@ class api_v3_GroupNestingTest extends CiviUnitTestCase {
     //  from_email_address group
     $op = new PHPUnit_Extensions_Database_Operation_Insert();
     $op->execute($this->_dbconn,
-      new PHPUnit_Extensions_Database_DataSet_XMLDataSet(
+      $this->createXMLDataSet(
         dirname(__FILE__) . '/dataset/group_nesting.xml'
       )
     );

--- a/tests/phpunit/api/v3/MailingContactTest.php
+++ b/tests/phpunit/api/v3/MailingContactTest.php
@@ -133,13 +133,13 @@ class api_v3_MailingContactTest extends CiviUnitTestCase {
         $op = new PHPUnit_Extensions_Database_Operation_Insert();
         //Create the User
         $op->execute($this->_dbconn,
-          new PHPUnit_Extensions_Database_DataSet_XMLDataSet(
+          $this->createXMLDataSet(
             dirname(__FILE__) . '/dataset/mailing_contact.xml'
           )
         );
         //~ Create the Mailing and connections to the user
         $op->execute($this->_dbconn,
-          new PHPUnit_Extensions_Database_DataSet_XMLDataSet(
+          $this->createXMLDataSet(
             dirname(__FILE__) . '/dataset/mailing_delivered.xml'
           )
         );
@@ -168,13 +168,13 @@ class api_v3_MailingContactTest extends CiviUnitTestCase {
         $op = new PHPUnit_Extensions_Database_Operation_Insert();
         //Create the User
         $op->execute($this->_dbconn,
-          new PHPUnit_Extensions_Database_DataSet_XMLDataSet(
+          $this->createXMLDataSet(
             dirname(__FILE__) . '/dataset/mailing_contact.xml'
           )
         );
         //~ Create the Mailing and connections to the user
         $op->execute($this->_dbconn,
-          new PHPUnit_Extensions_Database_DataSet_XMLDataSet(
+          $this->createXMLDataSet(
             dirname(__FILE__) . '/dataset/mailing_bounced.xml'
           )
         );

--- a/tests/phpunit/api/v3/ProfileTest.php
+++ b/tests/phpunit/api/v3/ProfileTest.php
@@ -758,7 +758,7 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
     // @TODO: Create profile with custom fields
     $op = new PHPUnit_Extensions_Database_Operation_Insert();
     $op->execute($this->_dbconn,
-      new PHPUnit_Extensions_Database_DataSet_FlatXMLDataSet(
+      $this->createFlatXMLDataSet(
         dirname(__FILE__) . '/dataset/uf_group_contact_activity_26.xml'
       )
     );

--- a/tests/phpunit/api/v3/UFFieldTest.php
+++ b/tests/phpunit/api/v3/UFFieldTest.php
@@ -60,7 +60,7 @@ class api_v3_UFFieldTest extends CiviUnitTestCase {
     $op = new PHPUnit_Extensions_Database_Operation_Insert;
     $op->execute(
       $this->_dbconn,
-      new PHPUnit_Extensions_Database_DataSet_FlatXMLDataSet(dirname(__FILE__) . '/dataset/uf_group_test.xml')
+      $this->createFlatXMLDataSet(dirname(__FILE__) . '/dataset/uf_group_test.xml')
     );
 
     $this->callAPISuccess('uf_field', 'getfields', array('cache_clear' => 1));

--- a/tests/phpunit/api/v3/UFJoinTest.php
+++ b/tests/phpunit/api/v3/UFJoinTest.php
@@ -59,7 +59,7 @@ class api_v3_UFJoinTest extends CiviUnitTestCase {
     $op = new PHPUnit_Extensions_Database_Operation_Insert;
     $op->execute(
       $this->_dbconn,
-      new PHPUnit_Extensions_Database_DataSet_FlatXMLDataSet(dirname(__FILE__) . '/dataset/uf_group_test.xml')
+      $this->createFlatXMLDataSet(dirname(__FILE__) . '/dataset/uf_group_test.xml')
     );
   }
 

--- a/tests/phpunit/api/v3/UFMatchTest.php
+++ b/tests/phpunit/api/v3/UFMatchTest.php
@@ -62,7 +62,7 @@ class api_v3_UFMatchTest extends CiviUnitTestCase {
     $op = new PHPUnit_Extensions_Database_Operation_Insert;
     $op->execute(
       $this->_dbconn,
-      new PHPUnit_Extensions_Database_DataSet_FlatXMLDataSet(dirname(__FILE__) . '/dataset/uf_group_test.xml')
+      $this->createFlatXMLDataSet(dirname(__FILE__) . '/dataset/uf_group_test.xml')
     );
 
     $this->_params = array(


### PR DESCRIPTION
This PR focuses on cleanups that maintain support for Civi's bundled (modified) phpunit while also allowing standalone phpunit.

However: if you try to use standalone phpunit, it still doesn't _quite_ work because packages/PHPUnit creates conflicts. One can work around that locally for now (until we switch).
