### PR TITLE
Include Event ID in participant export

### DIFF
--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -760,9 +760,19 @@ GROUP BY  participant.event_id
           'name' => 'participant_role',
         ));
 
+      //CRM-13595 add event id to participant export
+      $eventid = array(
+        'event_id' => array('title' => 'Event ID',
+          'name' => 'event_id',
+        ));
+      $eventtitle = array(
+        'event_title' => array('title' => 'Event Title',
+          'name' => 'event_title',
+        ));
+
       $discountFields  = CRM_Core_DAO_Discount::export();
 
-      $fields = array_merge($participantFields, $participantStatus, $participantRole, $noteField, $discountFields);
+      $fields = array_merge($participantFields, $participantStatus, $participantRole, $eventid, $eventtitle, $noteField, $discountFields);
 
       // add custom data
       $fields = array_merge($fields, CRM_Core_BAO_CustomField::getFieldsForImport('Participant'));

--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -222,8 +222,9 @@ class CRM_Export_BAO_Export {
         }
         else {
           //hack to fix component fields
+          //revert mix of event_id and title
           if ($fieldName == 'event_id') {
-            $returnProperties['event_title'] = 1;
+            $returnProperties['event_id'] = 1;
           }
           else if (
             $exportMode == CRM_Export_Form_Select::EVENT_EXPORT &&


### PR DESCRIPTION
Currently the Event ID is not available for the participant export.
Since the Event ID it is one of the required matching fields for
participant import it seems reasonable to also include it in the export.
