### PR TITLE
CRM-14798 - Allow loading CiviCase XML files even if case-type name is malformed

### DIFF
--- a/CRM/Case/BAO/CaseType.php
+++ b/CRM/Case/BAO/CaseType.php
@@ -70,8 +70,10 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType {
     if (!$nameParam && empty($params['id'])) {
       $params['name'] = CRM_Utils_String::titleToVar($params['title']);
     }
-    if (!empty($params['name']) && !CRM_Case_BAO_CaseType::isValidName($params['name'])) {
-      throw new CRM_Core_Exception("Cannot create caseType with malformed name [{$params['name']}]");
+
+    // Old case-types (pre-4.5) may keep their ucky names, but new case-types must satisfy isValidName()
+    if (empty($params['id']) && !empty($params['name']) && !CRM_Case_BAO_CaseType::isValidName($params['name'])) {
+      throw new CRM_Core_Exception("Cannot create new case-type with malformed name [{$params['name']}]");
     }
 
     // function to format definition column

--- a/CRM/Case/XMLRepository.php
+++ b/CRM/Case/XMLRepository.php
@@ -84,16 +84,21 @@ class CRM_Case_XMLRepository {
       return simplexml_load_string($definition);
     }
 
-    if (!CRM_Case_BAO_CaseType::isValidName($caseType)) {
-      // perhaps caller provider a the label instead of the name?
-      throw new CRM_Core_Exception("Cannot load caseType with malformed name [$caseType]");
-    }
+    // TODO In 4.6 or 5.0, remove support for weird machine-names
+    //if (!CRM_Case_BAO_CaseType::isValidName($caseType)) {
+    //  // perhaps caller provider a the label instead of the name?
+    //  throw new CRM_Core_Exception("Cannot load caseType with malformed name [$caseType]");
+    //}
 
     if (!CRM_Utils_Array::value($caseType, $this->xml)) {
-      // Search for a file based directly on the $caseType name
-      $fileName = $this->findXmlFile($caseType);
+      $fileName = NULL;
 
-      // For backward compatibility, also search for double-mungd file names
+      if (CRM_Case_BAO_CaseType::isValidName($caseType)) {
+        // Search for a file based directly on the $caseType name
+        $fileName = $this->findXmlFile($caseType);
+      }
+
+      // For backward compatibility, also search for double-munged file names
       // TODO In 4.6 or 5.0, remove support for loading double-munged file names
       if (!$fileName || !file_exists($fileName)) {
         $fileName = $this->findXmlFile(CRM_Case_XMLProcessor::mungeCaseType($caseType));


### PR DESCRIPTION
For case-types registered via GUI in old (pre-4.5) versions, the
autogenerated machine names were often ucky, and there was no way to clean
them up.  We'll allow backward-compatibility in 4.5 -- and also provide
warnings/tools to facilitate cleanup.
