### PR TITLE
Fix spelling and capitalization of Contact ID and External ID

### DIFF
--- a/CRM/Campaign/Form/Campaign.php
+++ b/CRM/Campaign/Form/Campaign.php
@@ -240,8 +240,8 @@ class CRM_Campaign_Form_Campaign extends CRM_Core_Form {
     // add campaign status
     $this->addSelect('status_id');
 
-    // add External Identifire Element
-    $this->add('text', 'external_identifier', ts('External Id'),
+    // add External Identifier Element
+    $this->add('text', 'external_identifier', ts('External ID'),
       CRM_Core_DAO::getAttribute('CRM_Campaign_DAO_Campaign', 'external_identifier'), FALSE
     );
 

--- a/CRM/Campaign/Form/Campaign.php
+++ b/CRM/Campaign/Form/Campaign.php
@@ -136,7 +136,7 @@ class CRM_Campaign_Form_Campaign extends CRM_Core_Form {
    *
    * @access public
    *
-   * @return void
+   * @return array
    */
   function setDefaultValues() {
     $defaults = $this->_values;
@@ -246,16 +246,14 @@ class CRM_Campaign_Form_Campaign extends CRM_Core_Form {
     );
 
     // add Campaign Parent Id
-    $campaigns = CRM_Campaign_BAO_Campaign::getCampaigns(CRM_Utils_Array::value('parent_id', $this->_values),
-      $this->_campaignId
-    );
+    $campaigns = CRM_Campaign_BAO_Campaign::getCampaigns(CRM_Utils_Array::value('parent_id', $this->_values), $this->_campaignId);
     if (!empty($campaigns)) {
-      $this->addElement('select', 'parent_id', ts('Parent Id'),
-        array(
-          '' => ts('- select Parent -')) + $campaigns
+      $this->addElement('select', 'parent_id', ts('Parent ID'),
+        array('' => ts('- select Parent -')) + $campaigns,
+        array('class' => 'crm-select2')
       );
     }
-$groups = CRM_Core_PseudoConstant::nestedGroup();
+    $groups = CRM_Core_PseudoConstant::nestedGroup();
     //get the campaign groups.
     $this->add('select', 'includeGroups',
       ts('Include Group(s)'),
@@ -304,7 +302,7 @@ $groups = CRM_Core_PseudoConstant::nestedGroup();
    * @param $files
    * @param $errors
    *
-   * @return void
+   * @return bool|array
    * @access public
    * @see valid_date
    */

--- a/CRM/Contact/Form/Edit/Household.php
+++ b/CRM/Contact/Form/Edit/Household.php
@@ -68,7 +68,7 @@ class CRM_Contact_Form_Edit_Household {
     }
 
     if ( !$inlineEditMode ) {
-      $form->add('text', 'external_identifier', ts('External Id'), $attributes['external_identifier'], FALSE);
+      $form->add('text', 'external_identifier', ts('External ID'), $attributes['external_identifier'], FALSE);
       $form->addRule('external_identifier',
         ts('External ID already exists in Database.'),
         'objectExists',

--- a/CRM/Contact/Form/Edit/Individual.php
+++ b/CRM/Contact/Form/Edit/Individual.php
@@ -128,7 +128,7 @@ class CRM_Contact_Form_Edit_Individual {
       $form->assign('checkSimilar', $checkSimilar);
 
       //External Identifier Element
-      $form->add('text', 'external_identifier', ts('External Id'),
+      $form->add('text', 'external_identifier', ts('External ID'),
         CRM_Core_DAO::getAttribute('CRM_Contact_DAO_Contact', 'external_identifier'), FALSE
       );
 

--- a/CRM/Contact/Form/Edit/Organization.php
+++ b/CRM/Contact/Form/Edit/Organization.php
@@ -77,7 +77,7 @@ class CRM_Contact_Form_Edit_Organization {
     }
 
     if ( !$inlineEditMode ) {
-      $form->add('text', 'external_identifier', ts('External Id'), CRM_Core_DAO::getAttribute('CRM_Contact_DAO_Contact', 'external_identifier'), FALSE);
+      $form->add('text', 'external_identifier', ts('External ID'), CRM_Core_DAO::getAttribute('CRM_Contact_DAO_Contact', 'external_identifier'), FALSE);
       $form->addRule('external_identifier',
         ts('External ID already exists in Database.'),
         'objectExists',

--- a/CRM/Contact/Form/Merge.php
+++ b/CRM/Contact/Form/Merge.php
@@ -334,7 +334,10 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
 
     CRM_Dedupe_Merger::moveAllBelongings($this->_cid, $this->_oid, $formValues);
 
-    CRM_Core_Session::setStatus(ts('Contact id %1 has been updated and contact id %2 has been deleted.', array(1 => $this->_cid, 2 => $this->_oid)), ts('Contacts Merged'), 'success');
+    $name = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $this->_cid, 'display_name');
+    $message = '<ul><li>' . ts('%1 has been updated.', array(1 => $name)) . '</li><li>' . ts('Contact ID %1 has been deleted.', array(1 => $this->_oid)) . '</li></ul>';
+    CRM_Core_Session::setStatus($message, ts('Contacts Merged'), 'success');
+
     $url = CRM_Utils_System::url('civicrm/contact/view', "reset=1&cid={$this->_cid}");
     if (!empty($formValues['_qf_Merge_submit'])) {
       $listParamsURL = "reset=1&action=update&rgid={$this->_rgid}";

--- a/CRM/Contact/Form/Search/Custom/ContribSYBNT.php
+++ b/CRM/Contact/Form/Search/Custom/ContribSYBNT.php
@@ -45,7 +45,7 @@ class CRM_Contact_Form_Search_Custom_ContribSYBNT implements CRM_Contact_Form_Se
     $this->_permissionedComponent = 'CiviContribute';
 
     $this->_columns = array(
-      ts('Contact Id') => 'contact_id',
+      ts('Contact ID') => 'contact_id',
       ts('Name') => 'display_name',
       ts('Donation Count') => 'donation_count',
       ts('Donation Amount') => 'donation_amount',

--- a/CRM/Contact/Form/Search/Custom/ContributionAggregate.php
+++ b/CRM/Contact/Form/Search/Custom/ContributionAggregate.php
@@ -47,7 +47,7 @@ class CRM_Contact_Form_Search_Custom_ContributionAggregate implements CRM_Contac
      */
 
     $this->_columns = array(
-      ts('Contact Id') => 'contact_id',
+      ts('Contact ID') => 'contact_id',
       ts('Name') => 'sort_name',
       ts('Donation Count') => 'donation_count',
       ts('Donation Amount') => 'donation_amount',

--- a/CRM/Contact/Form/Search/Custom/DateAdded.php
+++ b/CRM/Contact/Form/Search/Custom/DateAdded.php
@@ -46,7 +46,7 @@ class CRM_Contact_Form_Search_Custom_DateAdded extends CRM_Contact_Form_Search_C
     $this->_excludeGroups = CRM_Utils_Array::value('excludeGroups', $formValues, array());
 
     $this->_columns = array(
-      ts('Contact Id') => 'contact_id',
+      ts('Contact ID') => 'contact_id',
       ts('Contact Type') => 'contact_type',
       ts('Name') => 'sort_name',
       ts('Date Added') => 'date_added',

--- a/CRM/Contact/Form/Search/Custom/EmployerListing.php
+++ b/CRM/Contact/Form/Search/Custom/EmployerListing.php
@@ -46,7 +46,7 @@ class CRM_Contact_Form_Search_Custom_EmployerListing implements CRM_Contact_Form
      * Define the columns for search result rows
      */
     $this->_columns = array(
-      ts('Contact Id') => 'contact_id',
+      ts('Contact ID') => 'contact_id',
       ts('Individual Name') => 'sort_name',
       ts('Individual State') => 'indState',
       ts('Employer') => 'employer',

--- a/CRM/Contact/Form/Search/Custom/FullText.php
+++ b/CRM/Contact/Form/Search/Custom/FullText.php
@@ -346,7 +346,7 @@ WHERE      t.table_name = 'Activity' AND
    */
   function &columns() {
     $this->_columns = array(
-      ts('Contact Id') => 'contact_id',
+      ts('Contact ID') => 'contact_id',
       ts('Name') => 'sort_name',
     );
 

--- a/CRM/Contact/Form/Search/Custom/Group.php
+++ b/CRM/Contact/Form/Search/Custom/Group.php
@@ -51,7 +51,7 @@ class CRM_Contact_Form_Search_Custom_Group
   function __construct(&$formValues) {
     $this->_formValues = $formValues;
     $this->_columns = array(
-      ts('Contact Id') => 'contact_id',
+      ts('Contact ID') => 'contact_id',
       ts('Contact Type') => 'contact_type',
       ts('Name') => 'sort_name',
       ts('Group Name') => 'gname',

--- a/CRM/Contact/Form/Search/Custom/MultipleValues.php
+++ b/CRM/Contact/Form/Search/Custom/MultipleValues.php
@@ -54,7 +54,7 @@ class CRM_Contact_Form_Search_Custom_MultipleValues extends CRM_Contact_Form_Sea
     $this->_tag = CRM_Utils_Array::value('tag', $this->_formValues);
 
     $this->_columns = array(
-      ts('Contact Id') => 'contact_id',
+      ts('Contact ID') => 'contact_id',
       ts('Contact Type') => 'contact_type',
       ts('Name') => 'sort_name',
     );

--- a/CRM/Contact/Form/Search/Custom/PostalMailing.php
+++ b/CRM/Contact/Form/Search/Custom/PostalMailing.php
@@ -40,7 +40,7 @@ class CRM_Contact_Form_Search_Custom_PostalMailing extends CRM_Contact_Form_Sear
     parent::__construct($formValues);
 
     $this->_columns = array(
-      ts('Contact Id') => 'contact_id',
+      ts('Contact ID') => 'contact_id',
       ts('Address') => 'address',
       ts('Contact Type') => 'contact_type',
       ts('Name') => 'sort_name',

--- a/CRM/Contact/Form/Search/Custom/PriceSet.php
+++ b/CRM/Contact/Form/Search/Custom/PriceSet.php
@@ -223,7 +223,7 @@ AND    p.entity_id    = e.id
 
   function setColumns() {
     $this->_columns = array(
-      ts('Contact Id') => 'contact_id',
+      ts('Contact ID') => 'contact_id',
       ts('Participant Id') => 'participant_id',
       ts('Name') => 'display_name',
     );

--- a/CRM/Contact/Form/Search/Custom/RandomSegment.php
+++ b/CRM/Contact/Form/Search/Custom/RandomSegment.php
@@ -43,7 +43,7 @@ class CRM_Contact_Form_Search_Custom_RandomSegment extends CRM_Contact_Form_Sear
     parent::__construct($formValues);
 
     $this->_columns = array(
-      ts('Contact Id') => 'contact_id',
+      ts('Contact ID') => 'contact_id',
       ts('Contact Type') => 'contact_type',
       ts('Name') => 'sort_name',
       ts('Email') => 'email',

--- a/CRM/Contact/Form/Search/Custom/Sample.php
+++ b/CRM/Contact/Form/Search/Custom/Sample.php
@@ -49,7 +49,7 @@ class CRM_Contact_Form_Search_Custom_Sample extends CRM_Contact_Form_Search_Cust
     }
 
     $this->_columns = array(
-      ts('Contact Id') => 'contact_id',
+      ts('Contact ID') => 'contact_id',
       ts('Contact Type') => 'contact_type',
       ts('Name') => 'sort_name',
       ts('State') => 'state_province',

--- a/CRM/Contact/Form/Search/Custom/TagContributions.php
+++ b/CRM/Contact/Form/Search/Custom/TagContributions.php
@@ -48,7 +48,7 @@ class CRM_Contact_Form_Search_Custom_TagContributions implements CRM_Contact_For
      * Define the columns for search result rows
      */
     $this->_columns = array(
-      ts('Contact Id') => 'contact_id',
+      ts('Contact ID') => 'contact_id',
       ts('Full Name') => 'sort_name',
       ts('First Name') => 'first_name',
       ts('Last Name') => 'last_name',

--- a/CRM/Contact/Form/Search/Custom/ZipCodeRange.php
+++ b/CRM/Contact/Form/Search/Custom/ZipCodeRange.php
@@ -40,7 +40,7 @@ class CRM_Contact_Form_Search_Custom_ZipCodeRange extends CRM_Contact_Form_Searc
     parent::__construct($formValues);
 
     $this->_columns = array(
-      ts('Contact Id') => 'contact_id',
+      ts('Contact ID') => 'contact_id',
       ts('Name') => 'sort_name',
       ts('Email') => 'email',
       ts('Zip') => 'postal_code',

--- a/CRM/Contact/Form/Task/Batch.php
+++ b/CRM/Contact/Form/Task/Batch.php
@@ -234,7 +234,7 @@ class CRM_Contact_Form_Task_Batch extends CRM_Contact_Form_Task {
       foreach ($field as $fieldName => $fieldValue) {
         if ($fieldName == 'external_identifier') {
           if (in_array($fieldValue, $externalIdentifiers)) {
-            $errors["field[$componentId][external_identifier]"] = ts('Duplicate value for External Identifier.');
+            $errors["field[$componentId][external_identifier]"] = ts('Duplicate value for External ID.');
           }
           else {
             $externalIdentifiers[$componentId] = $fieldValue;

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -380,7 +380,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
       /* If it's a dupe,external Identifier  */
 
       if ($externalDupe = CRM_Utils_Array::value($externalID, $this->_allExternalIdentifiers)) {
-        $errorMessage = ts('External Identifier conflicts with record %1', array(1 => $externalDupe));
+        $errorMessage = ts('External ID conflicts with record %1', array(1 => $externalDupe));
         array_unshift($values, $errorMessage);
         $importRecordParams = array(
           $statusFieldName => 'ERROR',
@@ -487,7 +487,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
 
       if ($internalCid = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $params['external_identifier'], 'id', 'external_identifier')) {
         if ($internalCid != CRM_Utils_Array::value('id', $params)) {
-          $errorMessage = ts('External Identifier already exists in database.');
+          $errorMessage = ts('External ID already exists in Database.');
           array_unshift($values, $errorMessage);
           $importRecordParams = array(
             $statusFieldName => 'ERROR',

--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -358,7 +358,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
     }
 
     if ($output == CRM_Core_Selector_Controller::EXPORT) {
-      $csvHeaders = array(ts('Contact Id'), ts('Contact Type'));
+      $csvHeaders = array(ts('Contact ID'), ts('Contact Type'));
       foreach ($this->getColHeads($action, $output) as $column) {
         if (array_key_exists('name', $column)) {
           $csvHeaders[] = $column['name'];

--- a/CRM/Contribute/Import/Form/MapField.php
+++ b/CRM/Contribute/Import/Form/MapField.php
@@ -200,7 +200,7 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
     $fieldsArray = CRM_Dedupe_BAO_Rule::dedupeRuleFields($ruleParams);
 
     $softCreditFields['contact_id'] = ts('Contact ID');
-    $softCreditFields['external_identifier'] = ts('External Identifier');
+    $softCreditFields['external_identifier'] = ts('External ID');
     $softCreditFields['email'] = ts('Email');
 
     $sel2['soft_credit'] = $softCreditFields;

--- a/CRM/Event/Import/Form/MapField.php
+++ b/CRM/Event/Import/Form/MapField.php
@@ -339,7 +339,7 @@ class CRM_Event_Import_Form_MapField extends CRM_Import_Form_MapField {
             }
             else {
               $errors['_qf_default'] .= ts('Missing required contact matching fields.') . " $fieldMessage " . ts('(Sum of all weights should be greater than or equal to threshold: %1).', array(
-                1 => $threshold)) . ' ' . ts('Or Provide Contact Id or External Identifier.') . '<br />';
+                1 => $threshold)) . ' ' . ts('Or Provide Contact ID or External ID.') . '<br />';
             }
           }
           elseif (!in_array('event_title', $importKeys)) {

--- a/CRM/Pledge/Selector/Search.php
+++ b/CRM/Pledge/Selector/Search.php
@@ -438,7 +438,7 @@ class CRM_Pledge_Selector_Search extends CRM_Core_Selector_Base {
 
       if (!$this->_single) {
         $pre = array(
-          array('desc' => ts('Contact Id')),
+          array('desc' => ts('Contact ID')),
           array(
             'name' => ts('Name'),
             'sort' => 'sort_name',

--- a/CRM/Upgrade/3.1.alpha1.msg_template/message_templates/contribution_dupalert_html.tpl
+++ b/CRM/Upgrade/3.1.alpha1.msg_template/message_templates/contribution_dupalert_html.tpl
@@ -47,7 +47,7 @@ Duplicate Matching Rules for your site.{/ts}</p>
      </tr>
      <tr>
       <td {$labelStyle}>
-       {ts}Organization Contact Id{/ts}
+       {ts}Organization Contact ID{/ts}
       </td>
       <td {$valueStyle}>
        {$onBehalfID}

--- a/CRM/Upgrade/3.1.alpha1.msg_template/message_templates/contribution_dupalert_text.tpl
+++ b/CRM/Upgrade/3.1.alpha1.msg_template/message_templates/contribution_dupalert_text.tpl
@@ -4,7 +4,7 @@ Duplicate Matching Rules for your site.{/ts}
 
 {ts}Organization Name{/ts}: {$onBehalfName}
 {ts}Organization Email{/ts}: {$onBehalfEmail}
-{ts}Organization Contact Id{/ts}: {$onBehalfID}
+{ts}Organization Contact ID{/ts}: {$onBehalfID}
 
 {ts}If you think this may be a duplicate contact which should be merged with an existing record -
 Go to "CiviCRM >> Administer CiviCRM >> Find and Merge Duplicate Contacts". Use the strict

--- a/CRM/Upgrade/3.1.alpha2.msg_template/message_templates/contribution_dupalert_html.tpl
+++ b/CRM/Upgrade/3.1.alpha2.msg_template/message_templates/contribution_dupalert_html.tpl
@@ -47,7 +47,7 @@ Duplicate Matching Rules for your site.{/ts}</p>
      </tr>
      <tr>
       <td {$labelStyle}>
-       {ts}Organization Contact Id{/ts}
+       {ts}Organization Contact ID{/ts}
       </td>
       <td {$valueStyle}>
        {$onBehalfID}

--- a/CRM/Upgrade/4.4.alpha1.msg_template/message_templates/contribution_dupalert_html.tpl
+++ b/CRM/Upgrade/4.4.alpha1.msg_template/message_templates/contribution_dupalert_html.tpl
@@ -47,7 +47,7 @@ Duplicate Matching Rules for your site.{/ts}</p>
      </tr>
      <tr>
       <td {$labelStyle}>
-       {ts}Organization Contact Id{/ts}
+       {ts}Organization Contact ID{/ts}
       </td>
       <td {$valueStyle}>
        {$onBehalfID}

--- a/CRM/Upgrade/4.4.alpha1.msg_template/message_templates/contribution_dupalert_text.tpl
+++ b/CRM/Upgrade/4.4.alpha1.msg_template/message_templates/contribution_dupalert_text.tpl
@@ -4,7 +4,7 @@ Duplicate Matching Rules for your site.{/ts}
 
 {ts}Organization Name{/ts}: {$onBehalfName}
 {ts}Organization Email{/ts}: {$onBehalfEmail}
-{ts}Organization Contact Id{/ts}: {$onBehalfID}
+{ts}Organization Contact ID{/ts}: {$onBehalfID}
 
 {ts}If you think this may be a duplicate contact which should be merged with an existing record -
 Go to "Contacts >> Find and Merge Duplicate Contacts". Use the strict

--- a/CRM/Utils/DeprecatedUtils.php
+++ b/CRM/Utils/DeprecatedUtils.php
@@ -415,7 +415,9 @@ function _civicrm_api3_deprecated_formatted_param($params, &$values, $create = F
               $contact->external_identifier = $externalId;
               $errorMsg = NULL;
               if (!$contact->find(TRUE)) {
-                $errorMsg = $contactId ? ts("Soft Credit ContactID - $contactId doesn't exist. Row was skipped.") : ts("Provided Soft Credit External Identifier - $externalIddoesn't exist. Row was skipped.");
+                $field = $contactId ? ts('Contact ID') : ts('External ID');
+                $errorMsg = ts("Soft Credit %1 - %2 doesn't exist. Row was skipped.",
+                  array(1 => $field, 2 => $contactId ? $contactId : $externalId));
               }
 
               if ($errorMsg) {

--- a/tests/extensions/test.extension.manager.searchtest/main.php
+++ b/tests/extensions/test.extension.manager.searchtest/main.php
@@ -67,7 +67,7 @@ class test_extension_manager_searchtest extends CRM_Contact_Form_Search_Custom_B
   function &columns() {
     // return by reference
     $columns = array(
-      ts('Contact Id') => 'contact_id',
+      ts('Contact ID') => 'contact_id',
       ts('Contact Type') => 'contact_type',
       ts('Name') => 'sort_name',
       ts('State') => 'state_province',

--- a/tools/extensions/org.civicrm.search.multivalue/MultiValue.php
+++ b/tools/extensions/org.civicrm.search.multivalue/MultiValue.php
@@ -56,7 +56,7 @@ class org_civicrm_search_multivalue extends CRM_Contact_Form_Search_Custom_Basei
       NULL, -1
     );
 
-    $this->_columns = array(ts('Contact Id') => 'contact_id',
+    $this->_columns = array(ts('Contact ID') => 'contact_id',
       ts('Contact Type') => 'contact_type',
       ts('Name') => 'sort_name',
     );

--- a/xml/schema/Campaign/Campaign.xml
+++ b/xml/schema/Campaign/Campaign.xml
@@ -131,7 +131,7 @@
   <field>
        <name>external_identifier</name>
        <type>varchar</type>
-       <title>Campaign External Identifier</title>
+       <title>Campaign External ID</title>
        <length>32</length>
        <headerPattern>/external\s?id/i</headerPattern>
        <dataPattern>/^\d{11,}$/</dataPattern>

--- a/xml/templates/message_templates/contribution_dupalert_html.tpl
+++ b/xml/templates/message_templates/contribution_dupalert_html.tpl
@@ -47,7 +47,7 @@ Duplicate Matching Rules for your site.{/ts}</p>
      </tr>
      <tr>
       <td {$labelStyle}>
-       {ts}Organization Contact Id{/ts}
+       {ts}Organization Contact ID{/ts}
       </td>
       <td {$valueStyle}>
        {$onBehalfID}

--- a/xml/templates/message_templates/contribution_dupalert_text.tpl
+++ b/xml/templates/message_templates/contribution_dupalert_text.tpl
@@ -4,7 +4,7 @@ Duplicate Matching Rules for your site.{/ts}
 
 {ts}Organization Name{/ts}: {$onBehalfName}
 {ts}Organization Email{/ts}: {$onBehalfEmail}
-{ts}Organization Contact Id{/ts}: {$onBehalfID}
+{ts}Organization Contact ID{/ts}: {$onBehalfID}
 
 {ts}If you think this may be a duplicate contact which should be merged with an existing record -
 Go to "Contacts >> Find and Merge Duplicate Contacts". Use the strict


### PR DESCRIPTION
This should make things a bit more consistent and easier on translaters.
