### PR TITLE
Fix issue with reports creating invalid URLs when updated.

### DIFF
--- a/CRM/Report/BAO/ReportInstance.php
+++ b/CRM/Report/BAO/ReportInstance.php
@@ -191,7 +191,7 @@ class CRM_Report_BAO_ReportInstance extends CRM_Report_DAO_ReportInstance {
       if (empty($params['id']) && empty($params['instance_id']) && !empty($navigationParams['id'])) {
         unset($navigationParams['id']);
       }
-      $navigationParams['url'] = "civicrm/report/instance/{$instance->id}&reset=1";
+      $navigationParams['url'] = "civicrm/report/instance/{$instance->id}?reset=1";
       $navigation = CRM_Core_BAO_Navigation::add($navigationParams);
 
       if (!empty($navigationParams['is_active'])) {


### PR DESCRIPTION
When updating a report, if the Report Settings is set to "Include Report in
Navigation Menu", the navigation url that is created is formatted like
/civicrm/report/instance/1_reset_1, which is incorrect. The correct URL
should be /civicrm/report/instance/1?reset=1.
