### PR TITLE
Revert "Fix DAO to properly enforce desired collation"

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -207,7 +207,7 @@ class CRM_Core_DAO extends DB_DataObject {
    */
   function initialize() {
     $this->_connect();
-    $this->query("SET NAMES utf8 COLLATE utf8_unicode_ci");
+    $this->query("SET NAMES utf8");
   }
 
   /**


### PR DESCRIPTION
Reverts civicrm/civicrm-core#3799

The change caused multiple regressions, e.g.
- api_v3_ContactTest.testContactGetBirthDate
- api_v3_ContactTest.testContactGetDeceasedDate
- api_v3_JobTest.testCallSendReminderLimitTo  
- CRM_Core_BAO_ActionScheduleTest.testMembershipEndDate_Match
