### PR TITLE
Crm 15148

### DIFF
--- a/CRM/ACL/API.php
+++ b/CRM/ACL/API.php
@@ -178,10 +178,17 @@ class CRM_ACL_API {
     $contactID      = NULL,
     $tableName      = 'civicrm_saved_search',
     $allGroups      = NULL,
-    $includedGroups = NULL
+    $includedGroups = NULL,
+    $flush = FALSE
   ) {
-    static $cache = array();
 
+    static $cache = array();
+    //@todo this is pretty hacky!!!
+    //adding a way for unit tests to flush the cache
+    if ($flush) {
+      $cache = array();
+      return;
+    }
     if (!$contactID) {
       $session = CRM_Core_Session::singleton();
       $contactID = NULL;

--- a/CRM/ACL/BAO/ACL.php
+++ b/CRM/ACL/BAO/ACL.php
@@ -538,7 +538,7 @@ SELECT      $acl.*
       $rule->query($query);
 
       while ($rule->fetch()) {
-        $results[$rule->id] = &$rule->toArray();
+        $results[$rule->id] = $rule->toArray();
       }
     }
 

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -518,7 +518,8 @@ function _civicrm_api3_get_query_object($params, $mode, $entity) {
 
   $newParams = CRM_Contact_BAO_Query::convertFormValues($inputParams);
   $query = new CRM_Contact_BAO_Query($newParams, $returnProperties, NULL,
-    FALSE, FALSE, $mode
+    FALSE, FALSE, $mode,
+    empty($params['check_permissions'])
   );
   list($select, $from, $where, $having) = $query->query();
 

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -2523,6 +2523,67 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
     );
   }
 
+  /**
+   * Set up an acl allowing contact to see 2 specified groups
+   *  - $this->_permissionedGroup & $this->_permissionedDisbaledGroup
+   *
+   *  You need to have precreated these groups & created the user e.g
+   *  $this->createLoggedInUser();
+   *   $this->_permissionedDisabledGroup = $this->groupCreate(array('title' => 'pick-me-disabled', 'is_active' => 0, 'name' => 'pick-me-disabled'));
+   *   $this->_permissionedGroup = $this->groupCreate(array('title' => 'pick-me-active', 'is_active' => 1, 'name' => 'pick-me-active'));
+   *
+   */
+  function setupACL() {
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = array('access CiviCRM');
+    $optionGroupID = $this->callAPISuccessGetValue('option_group', array('return' => 'id', 'name' => 'acl_role'));
+    $optionValue = $this->callAPISuccess('option_value', 'create', array('option_group_id' => $optionGroupID,
+      'label' => 'pick me',
+      'value' => 55,
+    ));
+
+
+    CRM_Core_DAO::executeQuery("
+      TRUNCATE civicrm_acl_cache
+    ");
+
+    CRM_Core_DAO::executeQuery("
+      TRUNCATE civicrm_acl_contact_cache
+    ");
+
+
+    CRM_Core_DAO::executeQuery("
+    INSERT INTO civicrm_acl_entity_role (
+    `acl_role_id`, `entity_table`, `entity_id`
+    ) VALUES (55, 'civicrm_group', {$this->_permissionedGroup});
+    ");
+
+    CRM_Core_DAO::executeQuery("
+    INSERT INTO civicrm_acl (
+    `name`, `entity_table`, `entity_id`, `operation`, `object_table`, `object_id`, `is_active`
+    )
+    VALUES (
+    'view picked', 'civicrm_group', $this->_permissionedGroup , 'Edit', 'civicrm_saved_search', {$this->_permissionedGroup}, 1
+    );
+    ");
+
+    CRM_Core_DAO::executeQuery("
+    INSERT INTO civicrm_acl (
+    `name`, `entity_table`, `entity_id`, `operation`, `object_table`, `object_id`, `is_active`
+    )
+    VALUES (
+    'view picked', 'civicrm_group',  $this->_permissionedGroup, 'Edit', 'civicrm_saved_search', {$this->_permissionedDisabledGroup}, 1
+    );
+    ");
+    $this->_loggedInUser = CRM_Core_Session::singleton()->get('userID');
+    $this->callAPISuccess('group_contact', 'create', array(
+      'group_id' => $this->_permissionedGroup,
+      'contact_id' => $this->_loggedInUser,
+    ));
+    //flush cache
+    CRM_ACL_BAO_Cache::resetCache();
+      CRM_ACL_API::groupPermission('whatever', 9999, NULL, 'civicrm_saved_search', NULL, NULL, TRUE);
+  }
+
 /**
  * Create an instance of the paypal processor
  * @todo this isn't a great place to put it - but really it belongs on a class that extends

--- a/tests/phpunit/api/v3/ACLPermissionTest.php
+++ b/tests/phpunit/api/v3/ACLPermissionTest.php
@@ -277,10 +277,10 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
    * @dataProvider entities
    * confirm that with check permissions we don't get entities
    */
-  function testEntitiesGetCoreACLLimitingHookCheck($entity) {
+  function testEntitiesGetCoreACLLimitingCheck($entity) {
+    $this->markTestIncomplete('this does not work in 4.4 but can be enabled in 4.5 or a security release of 4.4 including the important security fix CRM-14877');
     $this->setupCoreACL();
     $this->setUpEntities($entity);
-    $this->hookClass->setHook('civicrm_aclWhereClause', array($this, 'aclWhereHookNoResults'));
     $result = $this->callAPISuccess($entity, 'get', array(
       'check_permissions' => 1,
       'return' => 'contact_id',

--- a/tests/phpunit/api/v3/ACLPermissionTest.php
+++ b/tests/phpunit/api/v3/ACLPermissionTest.php
@@ -62,6 +62,14 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
     CRM_Utils_Hook::singleton()->reset();
     $tablesToTruncate = array(
       'civicrm_contact',
+      'civicrm_group_contact',
+      'civicrm_group',
+      'civicrm_acl',
+      'civicrm_acl_cache',
+      'civicrm_acl_entity_role',
+      'civicrm_acl_contact_cache',
+      'civicrm_contribution',
+      'civicrm_participant',
     );
     $this->quickCleanup($tablesToTruncate);
     $config = CRM_Core_Config::singleton();
@@ -97,7 +105,7 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
    * Function tests that deleted contacts are not returned
    */
   function testContactGetPermissionHookNoDeleted() {
-    $result = $this->callAPISuccess('contact', 'create', array('id' => 2, 'is_deleted' => 1));
+    $this->callAPISuccess('contact', 'create', array('id' => 2, 'is_deleted' => 1));
     $this->hookClass->setHook('civicrm_aclWhereClause', array($this, 'aclWhereHookAllResults'));
     $result = $this->callAPISuccess('contact', 'get', array(
       'check_permissions' => 1,
@@ -229,6 +237,94 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
     );
   }
 
+  function setupCoreACL() {
+    $this->createLoggedInUser();
+    $this->_permissionedDisabledGroup = $this->groupCreate(array('title' => 'pick-me-disabled', 'is_active' => 0, 'name' => 'pick-me-disabled'));
+    $this->_permissionedGroup = $this->groupCreate(array('title' => 'pick-me-active', 'is_active' => 1, 'name' => 'pick-me-active'));
+    $this->setupACL();
+  }
+  /**
+   * @dataProvider entities
+   * confirm that without check permissions we still get 2 contacts returned
+   */
+  function testEntitiesGetHookLimitingHookNoCheck($entity) {
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = array();
+    $this->setUpEntities($entity);
+    $this->hookClass->setHook('civicrm_aclWhereClause', array($this, 'aclWhereHookNoResults'));
+    $result = $this->callAPISuccess($entity, 'get', array(
+      'check_permissions' => 0,
+      'return' => 'contact_id',
+    ));
+    $this->assertEquals(2, $result['count']);
+  }
+
+  /**
+   * @dataProvider entities
+   * confirm that without check permissions we still get 2 entities returned
+   */
+  function testEntitiesGetCoreACLLimitingHookNoCheck($entity) {
+    $this->setupCoreACL();
+    //CRM_Core_Config::singleton()->userPermissionClass->permissions = array();
+    $this->setUpEntities($entity);
+    $this->hookClass->setHook('civicrm_aclWhereClause', array($this, 'aclWhereHookNoResults'));
+    $result = $this->callAPISuccess($entity, 'get', array(
+      'check_permissions' => 0,
+      'return' => 'contact_id',
+    ));
+    $this->assertEquals(2, $result['count']);
+  }
+  /**
+   * @dataProvider entities
+   * confirm that with check permissions we don't get entities
+   */
+  function testEntitiesGetCoreACLLimitingHookCheck($entity) {
+    $this->setupCoreACL();
+    $this->setUpEntities($entity);
+    $this->hookClass->setHook('civicrm_aclWhereClause', array($this, 'aclWhereHookNoResults'));
+    $result = $this->callAPISuccess($entity, 'get', array(
+      'check_permissions' => 1,
+      'return' => 'contact_id',
+    ));
+    $this->assertEquals(0, $result['count']);
+  }
+
+
+  /**
+   * @dataProvider entities
+   * Function tests that an empty where hook returns no results
+   */
+  function testEntityGetNoResultsHook($entity) {
+    $this->markTestIncomplete('hook acls only work with contacts so far');
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = array();
+    $this->setUpEntities($entity);
+    $this->hookClass->setHook('civicrm_aclWhereClause', array($this, 'aclWhereHookNoResults'));
+    $result = $this->callAPISuccess($entity, 'get', array(
+      'check_permission' => 1,
+    ));
+    $this->assertEquals(0, $result['count']);
+  }
+
+  /**
+   * @return array
+   */
+  public static function entities() {
+    return array(array('contribution'), array('participant'),);// @todo array('pledge' => 'pledge')
+  }
+
+  /**
+   * Create 2 entities
+   */
+  public function setUpEntities($entity) {
+    $baoObj = new CRM_Core_DAO();
+    $baoObj->createTestObject( _civicrm_api3_get_BAO($entity), array(), 2, 0);
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = array(
+      'access CiviCRM',
+      'access CiviContribute',
+      'access CiviEvent',
+      'view event participants',
+    );
+  }
+
   /**
    * no results returned
    */
@@ -248,7 +344,4 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
   function aclWhereOnlySecond($type, &$tables, &$whereTables, &$contactID, &$where) {
     $where = " contact_a.id > 1";
   }
-
-
 }
-


### PR DESCRIPTION
Note the first 3 commits are backports of test framework to allow for testing (cherry-picked so shouldn't cause merge problems). The one line fix in the last commit is the actual fix - all the rest of the changes are to set-up the tests.

Note also the tests identify that core ACL permissions but not hook ACL permissions are applied to contribution searches - there is a test marked incomplete that tests for hook ACLs. This is slightly different to expected - I wasn't aware any ACLs worked on contribution.get, participant.get, pledge.get.

Not sure if it's worth logging an issue to get the hook ACLs working unless there is commitment / $ to fix
