### PR TITLE
CRM-15166 crmCaseType - Tighten control over "Standard Timeline" and "Open Case"

### DIFF
--- a/js/angular-crmCaseType.js
+++ b/js/angular-crmCaseType.js
@@ -129,7 +129,7 @@
     $scope.activityTypes = apiCalls.actTypes.values;
     $scope.activityTypeNames = _.pluck(apiCalls.actTypes.values, 'name');
     $scope.relationshipTypeNames = _.pluck(apiCalls.relTypes.values, CRM.crmCaseType.REL_TYPE_CNAME); // CRM_Case_XMLProcessor::REL_TYPE_CNAME
-    $scope.locks = {caseTypeName: true};
+    $scope.locks = {caseTypeName: true, activitySetName: true};
 
     $scope.workflows = {
       'timeline': 'Timeline',

--- a/js/angular-crmCaseType.js
+++ b/js/angular-crmCaseType.js
@@ -232,6 +232,14 @@
       }
     };
 
+    $scope.isActivityRemovable = function(activitySet, activity) {
+      if (activitySet.name == 'standard_timeline' && activity.name == 'Open Case') {
+        return false;
+      } else {
+        return true;
+      }
+    };
+
     $scope.isValidName = function(name) {
       return !name || name.match(/^[a-zA-Z0-9_]+$/);
     };

--- a/partials/crmCaseType/activitySetDetails.html
+++ b/partials/crmCaseType/activitySetDetails.html
@@ -13,7 +13,9 @@ Required vars: activitySet
   <tr>
     <td class="label">Name</td>
     <td>
-      <input type="text" name="name" ng-model="activitySet.name"/><!-- FIXME lock -->
+      <input type="text" name="name" ng-model="activitySet.name" ng-disabled="locks.activitySetName" />
+      <a crm-ui-lock binding="locks.activitySetName"></a>
+
     </td>
   </tr>
   <tr>

--- a/partials/crmCaseType/edit.html
+++ b/partials/crmCaseType/edit.html
@@ -27,6 +27,7 @@ Required vars: caseType
       <li ng-repeat="activitySet in caseType.definition.activitySets">
         <a href="#acttab-{{$index}}">{{ activitySet.label }}</a>
         <span class="ui-icon ui-icon-trash" title="Remove"
+          ng-hide="activitySet.name == 'standard_timeline'"
           ng-click="removeItem(caseType.definition.activitySets, activitySet)">Remove</span>
         <!-- Weird spacing:
         <a class="crm-hover-button" ng-click="removeItem(caseType.definition.activitySets, activitySet)">

--- a/partials/crmCaseType/timelineTable.html
+++ b/partials/crmCaseType/timelineTable.html
@@ -63,7 +63,9 @@ Required vars: activitySet
       </select>
     </td>
     <td>
-      <a class="crm-hover-button" ng-click="removeItem(activitySet.activityTypes, activity)">
+      <a class="crm-hover-button"
+         ng-show="isActivityRemovable(activitySet, activity)"
+         ng-click="removeItem(activitySet.activityTypes, activity)">
         <span class="icon delete-icon" title="Remove"></span>
       </a>
     </td>


### PR DESCRIPTION
These changes encourage the admin to preserve a few elements of the default
CaseType definition - but the GUI should still be able to open/save unusual
CaseTypes.

Also, it's possible to override things if you really work at it. For
example, if you unlock and rename "standard_timeline", then you can delete
"Open Case" or delete the entire activity-set.  Of course, you take your
fate into your own hands when you unlock that.)
