### PR TITLE
CRM-15142 - "Strict warning" when Manually executing Scheduled job

### DIFF
--- a/CRM/Campaign/BAO/Survey.php
+++ b/CRM/Campaign/BAO/Survey.php
@@ -327,8 +327,12 @@ SELECT  survey.id    as id,
         );
       }
     }
-
-    return $activityTypes[$cacheKey];
+    if (!empty($activityTypes[$cacheKey])) {
+      return $activityTypes[$cacheKey];
+    }
+    else {
+      return;
+    }
   }
 
   /**
@@ -1052,11 +1056,13 @@ INNER JOIN  civicrm_survey survey ON ( activity.source_record_id = survey.id )
    *
    * @return array success message
    */
-  public function releaseRespondent($params) {
+  public static function releaseRespondent($params) {
     $activityStatus = CRM_Core_PseudoConstant::activityStatus('name');
     $reserveStatusId = array_search('Scheduled', $activityStatus);
     $surveyActivityTypes = CRM_Campaign_BAO_Survey::getSurveyActivityType();
-    $surveyActivityTypesIds = array_keys($surveyActivityTypes);
+    if (!empty($surveyActivityTypes) && is_array($surveyActivityTypes)) {
+      $surveyActivityTypesIds = array_keys($surveyActivityTypes);
+    }
 
     //retrieve all survey activities related to reserve action.
     $releasedCount = 0;

--- a/CRM/Core/Component.php
+++ b/CRM/Core/Component.php
@@ -240,8 +240,12 @@ class CRM_Core_Component {
    */
   static function getComponentID($componentName) {
     $info = self::_info();
-
-    return $info[$componentName]->componentID;
+    if (!empty($info[$componentName])) {
+      return $info[$componentName]->componentID;
+    }
+    else {
+      return;
+    }
   }
 
   /**

--- a/CRM/Event/BAO/ParticipantStatusType.php
+++ b/CRM/Event/BAO/ParticipantStatusType.php
@@ -119,7 +119,7 @@ class CRM_Event_BAO_ParticipantStatusType extends CRM_Event_DAO_ParticipantStatu
    *
    * @return array
    */
-  public function process($params) {
+  public static function process($params) {
 
     $returnMessages = array();
 


### PR DESCRIPTION
## https://issues.civicrm.org/jira/browse/CRM-15142

Fixed following notices coming on Manually executing Scheduled jobs particularly (Update Participant Statuses, Process Survey Respondents )

Strict warning: Non-static method CRM_Event_BAO_ParticipantStatusType::process() should not be called statically in CRM_Event_BAO_ParticipantStatusType::process() (line 405 of /home/web/src/civicrm/api/v3/Job.php).

Strict warning: Non-static method CRM_Campaign_BAO_Survey::releaseRespondent() should not be called statically in CRM_Campaign_BAO_Survey::releaseRespondent() (line 456 of /home/web/src/civicrm/api/v3/Job.php).
Notice: Undefined index: CiviCampaign in CRM_Core_Component::getComponentID() (line 244 of /home/web/src/civicrm/CRM/Core/Component.php).
Notice: Trying to get property of non-object in CRM_Core_Component::getComponentID() (line 244 of /home/web/src/civicrm/CRM/Core/Component.php).
Notice: Undefined index: label_ in CRM_Campaign_BAO_Survey::getSurveyActivityType() (line 331 of /home/web/src/civicrm/CRM/Campaign/BAO/Survey.php).
Warning: array_keys() expects parameter 1 to be array, null given in CRM_Campaign_BAO_Survey::releaseRespondent() (line 1059 of /home/web/src/civicrm/CRM/Campaign/BAO/Survey.php).
