### PR TITLE
Notice Fixes on Contribution Reports

### DIFF
--- a/CRM/Report/Form/Contribute/History.php
+++ b/CRM/Report/Form/Contribute/History.php
@@ -501,11 +501,12 @@ class CRM_Report_Form_Contribute_History extends CRM_Report_Form {
     $this->customDataFrom();
     $this->groupBy();
 
+    $sql = NULL;
     $rows = array();
 
     // build array of result based on column headers. This method also allows
     // modifying column headers before using it to build result set i.e $rows.
-    $this->buildRows($rows);
+    $this->buildRows($sql, $rows);
 
     // format result set.
     $this->formatDisplay($rows, FALSE);
@@ -529,7 +530,7 @@ class CRM_Report_Form_Contribute_History extends CRM_Report_Form {
   /**
    * @param $rows
    */
-  function buildRows(&$rows) {
+  function buildRows($sql, &$rows) {
     $contactIds = array();
 
     $addWhere = '';

--- a/CRM/Report/Form/Contribute/OrganizationSummary.php
+++ b/CRM/Report/Form/Contribute/OrganizationSummary.php
@@ -351,7 +351,7 @@ class CRM_Report_Form_Contribute_OrganizationSummary extends CRM_Report_Form {
     //hack filter display for relationship type
     $type = substr($this->_params['relationship_type_id_value'], -3);
     foreach ($statistics['filters'] as $id => $value) {
-      if ($value['title'] == 'Relationship Type') {
+      if ($value['title'] == 'Relationship Type' && !empty($id)) {
         $statistics['filters'][$id]['value'] = 'Is equal to ' . $this->relationTypes[$this->relationshipId . '_' . $type];
       }
     }
@@ -387,7 +387,7 @@ class CRM_Report_Form_Contribute_OrganizationSummary extends CRM_Report_Form {
     $this->relationTypes = $relationTypes = array();
 
     $params = array('contact_type_b' => 'Organization', 'version' => 3);
-    $typesA = &civicrm_api('relationship_type', 'get', $params);
+    $typesA = civicrm_api('relationship_type', 'get', $params);
 
     if (empty($typesA['is_error'])) {
       foreach ($typesA['values'] as $rel) {
@@ -396,7 +396,7 @@ class CRM_Report_Form_Contribute_OrganizationSummary extends CRM_Report_Form {
     }
 
     $params = array('contact_type_a' => 'Organization', 'version' => 3);
-    $typesB = &civicrm_api('relationship_type', 'get', $params);
+    $typesB = civicrm_api('relationship_type', 'get', $params);
 
     if (empty($typesB['is_error'])) {
       foreach ($typesB['values'] as $rel) {


### PR DESCRIPTION
## Following notice Fixes on Contribution Reports namely "Contributions by Organization" and " Contribution Aggregate by Relationship"

Strict warning: Only variables should be assigned by reference in CRM_Report_Form_Contribute_OrganizationSummary->validRelationships() (line 390 of /home/web/src/civicrm/CRM/Report/Form/Contribute/OrganizationSummary.php).
Strict warning: Only variables should be assigned by reference in CRM_Report_Form_Contribute_OrganizationSummary->validRelationships() (line 399 of /home/web/src/civicrm/CRM/Report/Form/Contribute/OrganizationSummary.php).
Notice: Undefined index: 4_b_a in CRM_Report_Form_Contribute_OrganizationSummary->statistics() (line 355 of /home/web/src/civicrm/CRM/Report/Form/Contribute/OrganizationSummary.php).

Strict warning: Declaration of CRM_Report_Form_Contribute_History::buildRows() should be compatible with CRM_Report_Form::buildRows($sql, &$rows) in require_once() (line 36 of /home/web/src/civicrm/CRM/Report/Form/Contribute/History.php).
