### PR TITLE
CRM-15169

### DIFF
--- a/CRM/Report/Form/Contribute/HouseholdSummary.php
+++ b/CRM/Report/Form/Contribute/HouseholdSummary.php
@@ -243,7 +243,7 @@ class CRM_Report_Form_Contribute_HouseholdSummary extends CRM_Report_Form {
               }
             }
             else {
-              $select[] = "{$table['alias']}.{$fieldName} as {$tableName}_{$fieldName}";
+              $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
 
               $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = CRM_Utils_Array::value('title', $field);
               $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);

--- a/CRM/Report/Form/Contribute/OrganizationSummary.php
+++ b/CRM/Report/Form/Contribute/OrganizationSummary.php
@@ -244,7 +244,7 @@ class CRM_Report_Form_Contribute_OrganizationSummary extends CRM_Report_Form {
               }
             }
             else {
-              $select[] = "{$table['alias']}.{$fieldName} as {$tableName}_{$fieldName}";
+              $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
 
               $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = CRM_Utils_Array::value('title', $field);
               $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);

--- a/CRM/Report/Form/Contribute/Repeat.php
+++ b/CRM/Report/Form/Contribute/Repeat.php
@@ -464,7 +464,7 @@ LEFT JOIN civicrm_temp_civireport_repeat2 {$this->_aliases['civicrm_contribution
    *
    * @return array
    */
-  function formRule($fields, $files, $self) {
+  static function formRule($fields, $files, $self) {
 
     $errors = $checkDate = $errorCount = array();
 
@@ -492,6 +492,7 @@ LEFT JOIN civicrm_temp_civireport_repeat2 {$this->_aliases['civicrm_contribution
 
     $idMapping = array(
       'id' => ts('Contact'),
+      'exposed_id' => ts('Contact'),
       'country_id' => ts('Country'),
       'state_province_id' => ts('State/Province'),
       'contribution_source' => ts('Contribution Source'),


### PR DESCRIPTION
CRM-15169 additional fix related to warnings in Repeat Contribution report and DB error on selecting Contact Id as a criteria for previewing Household and Organisation Summary Report.
