### PR TITLE
CRM-15163 - CRM_Utils_Check_Security - Windows support

### DIFF
--- a/CRM/Utils/Check/Security.php
+++ b/CRM/Utils/Check/Security.php
@@ -88,7 +88,7 @@ class CRM_Utils_Check_Security {
     $config = CRM_Core_Config::singleton();
 
     $log = CRM_Core_Error::createDebugLogger();
-    $log_filename = $log->_filename;
+    $log_filename = str_replace('\\', '/', $log->_filename);
 
     $filePathMarker = $this->getFilePathMarker();
 
@@ -287,7 +287,7 @@ class CRM_Utils_Check_Security {
     $config = CRM_Core_Config::singleton();
 
     list ($heuristicBaseUrl, $ignore) = explode($filePathMarker, $config->imageUploadURL);
-    list ($ignore, $heuristicSuffix) = explode($filePathMarker, $targetDir);
+    list ($ignore, $heuristicSuffix) = explode($filePathMarker, str_replace('\\', '/', $targetDir));
     return $heuristicBaseUrl . $filePathMarker . $heuristicSuffix;
   }
 }


### PR DESCRIPTION
On Windows-PHP setups, paths may have a mix of back-slashes and
forward-slashes.  For this security check, we'll normalize to
forward-slashses to simplify the path manipulation.
