### PR TITLE
api_v3_SyntaxConformanceTest - Work-around problem with MembershipBlock

### DIFF
--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -428,6 +428,13 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
           'definition',
         )
       ),
+      'MembershipBlock' => array(
+        'cant_update' => array(
+          // The fake/auto-generated values leave us unable to properly cleanup fake data
+          'entity_type',
+          'entity_id',
+        )
+      ),
       'Pledge' => array(
         'cant_update' => array(
           'pledge_original_installment_amount',


### PR DESCRIPTION
It appears that -- during the course of executing testCreateSingleValueAlter('MembershipBlock') -- it calls createTestOject to create two MembershipBlocks linked to two ContributionPages. tearDown() tries to delete these four test-objects by calling deleteTestObject. However, the order of the deletes is invalid because the FK's have been rearranged by testCreateSingleValueAlter, so we get:

```
DELETE FROM civicrm_contribution_page  
WHERE (  civicrm_contribution_page.id = 1 )  
[nativecode=1451 ** Cannot delete or update a parent row: a foreign key constraint fails
(`d45test_ihhvp`.`civicrm_membership_block`, CONSTRAINT
`FK_civicrm_membership_block_entity_id` FOREIGN KEY (`entity_id`) REFERENCES
`civicrm_contribution_page` (`id`))]
```

This patch is the simplest thing (ie it tells testCreateSingleValueAlter not to mess-around with the entity_id FK). However, it might also work to set ON DELETE (CASCADE | SET NULL) for the FK. (In that case, the deletion-order might not matter anymore.) However, I'm not familiar enough with this FK to know the right ON DELETE behavior, so... I've just done the simplest thing.
