### PR TITLE
CRM-15210 fix fatal on merge exports of non primary addresses

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -901,7 +901,7 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
               if (is_object($relDAO) && $relationField == 'id') {
                 $row[$field . $relationField] = $relDAO->contact_id;
               }
-              elseif ( is_object( $relDAO ) && is_array( $relationValue ) && $relationField == 'location' ) {
+              elseif (is_array( $relationValue ) && $relationField == 'location') {
                 foreach ($relationValue as $ltype => $val) {
                   foreach (array_keys($val) as $fld) {
                     $type = explode('-', $fld);


### PR DESCRIPTION
The relationship check is preventing the fields from being transformed
to the correct field names in contacts not-to-be-merged
The possibility of the object not existing is adequately handled further down in the
function. The check was added during svn-days but after 4.2.4
I no longer seem to be able to access what commit introduced it
