### PR TITLE
Include gender & age in Constituent Summary Report

### DIFF
--- a/templates/CRM/Report/Form/Contact/Summary.tpl
+++ b/templates/CRM/Report/Form/Contact/Summary.tpl
@@ -23,4 +23,13 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
+
+{literal}
+<script type="text/javascript">
+  CRM.$(function($) {
+    $('#birth_date_from, #birth_date_to').attr({startOffset: '200', endoffset: '0'});
+  });
+</script>
+{/literal}
+
 {include file="CRM/Report/Form.tpl"}


### PR DESCRIPTION
This is a follow up of issue CRM-13279 which was resolved for the Participant Listing report only. In the Constituent Summary Report the gender and age are missing from selectable fields, order-by and filter. The fix follows the same pattern as the one for issue CRM-13279
