### PR TITLE
CRM-14973 - CRM_Core_Menu::buildAdminLinks - Force backend URLs

### DIFF
--- a/CRM/Core/Menu.php
+++ b/CRM/Core/Menu.php
@@ -315,7 +315,13 @@ class CRM_Core_Menu {
             ',' => '_', '/' => '_',
           )
         ),
-        'url' => CRM_Utils_System::url($path, $query, FALSE),
+        'url' => CRM_Utils_System::url($path, $query, 
+            FALSE, // absolute
+            NULL, // fragment
+            TRUE, // htmlize
+            FALSE, // frontend
+            TRUE // forceBackend; CRM-14439 work-around; acceptable for now because we don't display breadcrumbs on frontend
+        ),
         'icon' => CRM_Utils_Array::value('icon', $item),
         'extra' => CRM_Utils_Array::value('extra', $item),
       );


### PR DESCRIPTION
---
- CRM-14973: Administration console does not work in WordPress
  https://issues.civicrm.org/jira/browse/CRM-14973
