### PR TITLE
CRM-15232 fix - LIne items are missing from receipts when using a price ...

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1336,6 +1336,8 @@ AND civicrm_membership.is_test = %2";
         }
         $form->_values['lineItem'] = $form->_lineItem;
         $form->assign('lineItem', $form->_lineItem);
+
+        $form->_values['priceSetID'] = $form->_priceSetId;
       }
     }
 


### PR DESCRIPTION
...set with multiple membership organization price fields

https://issues.civicrm.org/jira/browse/CRM-15232
