### PR TITLE
CRM-15248 - footer.tpl - For front-end users, redact point-release.

### DIFF
--- a/CRM/Core/Smarty/plugins/function.crmVersion.php
+++ b/CRM/Core/Smarty/plugins/function.crmVersion.php
@@ -48,7 +48,7 @@ function smarty_function_crmVersion($params, &$smarty) {
   $redact = !CRM_Core_Permission::check('access CiviCRM');
   if ($redact) {
     $parts = explode('.', $version);
-    $version = $parts[0] . '.' . $parts[1];
+    $version = $parts[0] . '.' . $parts[1] . '.x';
   }
 
   if (isset($params['assign'])) {

--- a/CRM/Core/Smarty/plugins/function.crmVersion.php
+++ b/CRM/Core/Smarty/plugins/function.crmVersion.php
@@ -1,8 +1,9 @@
-{*
+<?php
+/*
  +--------------------------------------------------------------------+
  | CiviCRM version 4.4                                                |
  +--------------------------------------------------------------------+
- | Copyright CiviCRM LLC (c) 2004-2013                                |
+ | Copyright CiviCRM LLC (c) 2004-2014                                |
  +--------------------------------------------------------------------+
  | This file is a part of CiviCRM.                                    |
  |                                                                    |
@@ -22,22 +23,38 @@
  | GNU Affero General Public License or the licensing of CiviCRM,     |
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
-*}
-{include file="CRM/common/accesskeys.tpl"}
-{if !empty($contactId)}
-  {include file="CRM/common/contactFooter.tpl"}
-{/if}
+*/
 
-<div class="crm-footer" id="civicrm-footer">
-  {crmVersion assign=version}
-  {ts 1=$version}Powered by CiviCRM %1.{/ts}
-  {if !empty($newer_civicrm_version)}
-    <span class="status">{ts 1=$newer_civicrm_version}A newer version (%1){/ts}
-    <a href="http://civicrm.org/download">{ts}is available for download{/ts}</a>.</span>
-  {/if}
-  {ts 1='http://www.gnu.org/licenses/agpl-3.0.html'}CiviCRM is openly available under the <a href='%1'>GNU AGPL License</a>.{/ts}<br/>
-  <a href="http://civicrm.org/download">{ts}Download CiviCRM.{/ts}</a> &nbsp; &nbsp;
-  <a href="http://issues.civicrm.org/jira/browse/CRM?report=com.atlassian.jira.plugin.system.project:roadmap-panel">{ts}View issues and report bugs.{/ts}</a> &nbsp; &nbsp;
-  {docURL page="" text="Online documentation."}
-</div>
-{include file="CRM/common/notifications.tpl"}
+/**
+ *
+ * @package CRM
+ * @copyright TTTP
+ * $Id$
+ *
+ */
+
+/**
+ * Display the CiviCRM version
+ *
+ * @code
+ * The version is {crmVersion}.
+ *
+ * {crmVersion redact=auto assign=ver}The version is {$ver}.
+ * @endcode
+ */
+function smarty_function_crmVersion($params, &$smarty) {
+  $version = CRM_Utils_System::version();
+
+  $redact = !CRM_Core_Permission::check('access CiviCRM');
+  if ($redact) {
+    $parts = explode('.', $version);
+    $version = $parts[0] . '.' . $parts[1];
+  }
+
+  if (isset($params['assign'])) {
+    $smarty->assign($params['assign'], $version);
+  }
+  else {
+    return $version;
+  }
+}


### PR DESCRIPTION
On one hand, giving a precise version can help attackers match their targets
with exploits.  On the other hand, giving some kind of version indication is
useful for support and marketing.  This PR attempts to balance the interests
by giving a precise version ("Powered by CiviCRM 4.4.6") to users with
permission "access CiviCRM" while giving a coarse-version ("Powered by
CiviCRM 4.4") to anyone else.
