### PR TITLE
 Keep input fields from overflowing viewport 

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -4249,7 +4249,7 @@ span.crm-status-icon {
   padding: 5px;
   border-radius: 3px;
   vertical-align: middle;
-  max-width: 100;
+  max-width: 100%;
 }
 
 #crm-container.crm-public .label {

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -4249,6 +4249,7 @@ span.crm-status-icon {
   padding: 5px;
   border-radius: 3px;
   vertical-align: middle;
+  max-width: 100;
 }
 
 #crm-container.crm-public .label {


### PR DESCRIPTION
Small change to keep input fields within the window.
