### PR TITLE
Fix a bug in CRM_Mailing_BAO_Mailing::add() with wrong class instantiation

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1482,7 +1482,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
       CRM_Utils_Hook::pre('create', 'Mailing', NULL, $params);
     }
 
-    $mailing            = new CRM_Mailing_DAO_Mailing();
+    $mailing            = new static();
     $mailing->id        = $id;
     $mailing->domain_id = CRM_Utils_Array::value('domain_id', $params, CRM_Core_Config::domainID());
 


### PR DESCRIPTION
The DAO was being instantiated instead of the BAO. This likely affects all branches.
