### PR TITLE
Case update API doesn't return the correct values

### DIFF
--- a/api/v3/Case.php
+++ b/api/v3/Case.php
@@ -338,8 +338,9 @@ function civicrm_api3_case_update($params) {
   $case = array();
 
   _civicrm_api3_object_to_array($dao, $case);
+  $values[$dao->id] = $case;
 
-  return civicrm_api3_create_success($case, $params, 'case', 'update', $dao);
+  return civicrm_api3_create_success($values, $params, 'case', 'update', $dao);
 }
 
 /**


### PR DESCRIPTION
See https://issues.civicrm.org/jira/browse/CRM-15268

The case api update action did not return the correct values. It did not wrap the return values in an array for values. 
