### PR TITLE
Added option to use semicolon as seperator for the import+export scripts

### DIFF
--- a/bin/cli.class.php
+++ b/bin/cli.class.php
@@ -46,6 +46,7 @@ class civicrm_cli {
   var $_action = NULL;
   var $_output = FALSE;
   var $_joblog = FALSE;
+  var $_semicolon = FALSE;
   var $_config;
 
   // optional arguments
@@ -173,6 +174,9 @@ class civicrm_cli {
       }
       elseif ($arg == '-j' || $arg == '--joblog') {
         $this->_joblog = TRUE;
+      }
+      elseif ($arg == '-sem' || $arg == '--semicolon') {
+        $this->_semicolon = TRUE;
       }
       else {
         while(list($short, $long) = each ($this->_additional_arguments)) {
@@ -327,6 +331,9 @@ class civicrm_cli_csv_exporter extends civicrm_cli {
   }
 
   function run() {
+  	if($this->_semicolon)
+  		$this->separator = ';';
+  	
     $out = fopen("php://output", 'w');
     fputcsv($out, $this->columns, $this->separator, '"');
 

--- a/bin/cli.class.php
+++ b/bin/cli.class.php
@@ -331,8 +331,8 @@ class civicrm_cli_csv_exporter extends civicrm_cli {
   }
 
   function run() {
-  	if($this->_semicolon)
-  		$this->separator = ';';
+    if($this->_semicolon)
+  	  $this->separator = ';';
   	
     $out = fopen("php://output", 'w');
     fputcsv($out, $this->columns, $this->separator, '"');


### PR DESCRIPTION
I thought this is pretty useful.
You just add -sem or --semicolon as parameter, and the exported data will be separated by semicolons

(this is the second try, as I somehow fucked up the old pull request #4046)
