### PR TITLE
CRM/Admin/Form/ScheduleReminders - Less stupid field ordering

### DIFF
--- a/templates/CRM/Admin/Form/ScheduleReminders.tpl
+++ b/templates/CRM/Admin/Form/ScheduleReminders.tpl
@@ -52,9 +52,6 @@
         <td class="right"></td>
         <td colspan="3">{$form.start_action_offset.html}&nbsp;&nbsp;&nbsp;{$form.start_action_unit.html}&nbsp;&nbsp;&nbsp;{$form.start_action_condition.html}&nbsp;&nbsp;&nbsp;{$form.start_action_date.html}</td>
     </tr>
-    <tr id="recordActivity" class="crm-scheduleReminder-form-block-record_activity"><td class="label" width="20%">{$form.record_activity.label}</td>
-        <td>{$form.record_activity.html}</td>
-    </tr>
     <tr id="relativeDateRepeat" class="crm-scheduleReminder-form-block-is_repeat"><td class="label" width="20%">{$form.is_repeat.label}</td>
         <td>{$form.is_repeat.html}&nbsp;&nbsp;<span class="description">{ts}Enable repetition.{/ts}</span></td>
     </tr>
@@ -108,6 +105,10 @@
         <tr class="crm-scheduleReminder-form-block-active">
            <td class="label"></td>
            <td>{$form.is_active.html}&nbsp;{$form.is_active.label}</td>
+        </tr>
+        <tr id="recordActivity" class="crm-scheduleReminder-form-block-record_activity">
+            <td class="label"></td>
+           <td>{$form.record_activity.html}&nbsp;{$form.record_activity.label}</td>
         </tr>
         <tr class="crm-scheduleReminder-form-block-template">
             <td class="label">{$form.template.label}</td>


### PR DESCRIPTION
Old field ordering:
- When:
- Record activity for automated email?
- Repeat:
- Email:
  - Send email?
  - Use Template
  - Subject

New field ordering:
- When:
- Repeat:
- Email
  - Send email?
  - Record activity for automated email?
  - Use Template
  - Subjec

This is less-stupid because:
- It doesn't breakup the When/Repeat sections
- It puts the email options together
