### PR TITLE
Fix returning to a smart group search after adding an activity.

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -418,7 +418,8 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
       if ($this->_compContext == 'advanced' ) {
         $urlString = 'civicrm/contact/search/advanced';
       }
-      elseif ($path == 'civicrm/contact/search'
+      elseif ($path == 'civicrm/group/search'
+	|| $path == 'civicrm/contact/search'
         || $path == 'civicrm/contact/search/advanced'
         || $path == 'civicrm/contact/search/custom') {
         $urlString = $path;


### PR DESCRIPTION
The previous fix was here: https://github.com/civicrm/civicrm-core/pull/1770

However, this was missing the civicrm/group/search url in the list of possible urls to return to; thus smart groups were still broken for this workflow.
