### PR TITLE
Possible multiplication of $fResult in $result

### DIFF
--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -178,12 +178,13 @@ abstract class CRM_Utils_Hook {
     // must be reentrant. PHP is finicky about running
     // multiple loops over the same variable. The circumstances
     // to reproduce the issue are pretty intricate.
-    $result = $fResult = array();
+    $result = array();
 
     if ($civiModules !== NULL) {
       foreach ($civiModules as $module) {
         $fnName = "{$module}_{$fnSuffix}";
         if (function_exists($fnName)) {
+          $fResult = array();
           switch ($numParams) {
             case 0:
               $fResult = $fnName();
@@ -217,11 +218,11 @@ abstract class CRM_Utils_Hook {
               CRM_Core_Error::fatal(ts('Invalid hook invocation'));
               break;
           }
-        }
 
-        if (!empty($fResult) &&
-          is_array($fResult)) {
-          $result = array_merge($result, $fResult);
+          if (!empty($fResult) &&
+            is_array($fResult)) {
+            $result = array_merge($result, $fResult);
+          }
         }
       }
     }


### PR DESCRIPTION
The old structure allowed for possible multiplication of $fResult in $result when a specific $fnSuffix hook was implemented in one module, but not in another.
We only want to add $fResult to $result if $fnName exists, so moved the array_merge() into that if-statement. Furthermore, if $numParams is not case-specified in the switch, at the array_merge(), $fResult could hold the result from a previous module (because in the default case $fResult is not being set), so we have to initialize $fResult to an empty array in the foreach().
