### PR TITLE
Remove specific handling of name field in getModuleUFGroup

### DIFF
--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -1669,10 +1669,6 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
         if($field == 'id') {
           continue;
         }
-        elseif ($field == 'name') {
-          $ufGroups[$dao->id][$field] = $dao->title;
-          continue;
-        }
         $ufGroups[$dao->id][$field] = $dao->$field;
       }
     }


### PR DESCRIPTION
The field name is only used in Drupal. 
For some historical reason that doesn't seems relevant any more, the value was replaced by the title. 
That was causing problems when switching language because the url was changing depending on the language.

This request is linked to https://github.com/civicrm/civicrm-drupal/pull/166 and refers to https://issues.civicrm.org/jira/browse/CRM-15330 
