### PR TITLE
Better tag overview

### DIFF
--- a/CRM/Admin/Form/Tag.php
+++ b/CRM/Admin/Form/Tag.php
@@ -91,8 +91,7 @@ class CRM_Admin_Form_Tag extends CRM_Admin_Form {
         CRM_Core_DAO::getAttribute('CRM_Core_DAO_Tag', 'description')
       );
 
-      //@lobo haven't a clue why the checkbox isn't displayed (it should be checked by default
-      $this->add('checkbox', 'is_selectable');
+      $this->add('checkbox', 'is_selectable', ts('Selectable?'));
 
       $isReserved = $this->add('checkbox', 'is_reserved', ts('Reserved?'));
 
@@ -148,6 +147,10 @@ class CRM_Admin_Form_Tag extends CRM_Admin_Form {
 
     if (!isset($params['is_reserved'])) {
       $params['is_reserved'] = 0;
+    }
+
+    if (!isset($params['is_selectable'])) {
+      $params['is_selectable'] = 0;
     }
 
     if ($this->_action == CRM_Core_Action::DELETE) {

--- a/CRM/Contact/Form/Edit/TagsAndGroups.php
+++ b/CRM/Contact/Form/Edit/TagsAndGroups.php
@@ -142,21 +142,30 @@ class CRM_Contact_Form_Edit_TagsAndGroups {
     }
 
     if ($type & self::TAG) {
+      // CODE FROM CRM/Tag/Form/Tag.php //
+      CRM_Core_Resources::singleton()
+        ->addScriptFile('civicrm', 'packages/jquery/plugins/jstree/jquery.jstree.js', 0, 'html-header', FALSE)
+        ->addStyleFile('civicrm', 'packages/jquery/plugins/jstree/themes/default/style.css', 0, 'html-header');
+
       $fName = 'tag';
       if ($fieldName) {
         $fName = $fieldName;
       }
       $form->_tagGroup[$fName] = 1;
-      $elements = array();
-      $tag = CRM_Core_BAO_Tag::getTags();
 
-      foreach ($tag as $id => $name) {
-        $elements[] = $form->createElement('checkbox', $id, NULL, $name);
-      }
-      if (!empty($elements)) {
-        $form->addGroup($elements, $fName, $tagName, '<br />');
-        $form->assign('tagCount', count($elements));
-      }
+      // get the list of all the categories
+      $tags = new CRM_Core_BAO_Tag();
+      $tree = $tags->getTree('civicrm_contact', TRUE);
+
+      $elements = array();
+      self::climbtree($form, $tree, $elements);
+
+      $form->addGroup($elements, $fName, $tagName, '<br />');
+      $form->assign('tagCount', count($elements));
+      $form->assign('tree', $tree);
+      $form->assign('tag', $tree);
+      $form->assign('entityID', $contactId);
+      $form->assign('entityTable', 'civicrm_contact');
 
       if ($isRequired) {
         $form->addRule($fName, ts('%1 is a required field.', array(1 => $tagName)), 'required');
@@ -164,10 +173,25 @@ class CRM_Contact_Form_Edit_TagsAndGroups {
 
       // build tag widget
       $parentNames = CRM_Core_BAO_Tag::getTagSet('civicrm_contact');
-
       CRM_Core_Form_Tag::buildQuickForm($form, $parentNames, 'civicrm_contact', $contactId, FALSE, TRUE);
     }
     $form->assign('tagGroup', $form->_tagGroup);
+  }
+  
+  static function climbtree($form, $tree, &$elements) {
+    foreach ($tree as $tagID => $varValue) {
+      $tagAttribute = array(
+      'onclick' => "return changeRowColor(\"rowidtag_$tagID\")",
+      'id' => "tag_{$tagID}",
+      );
+
+      $elements[$tagID] = $form->createElement('checkbox', $tagID, '', '', $tagAttribute);
+
+      if (array_key_exists('children', $varValue)) {
+        self::climbtree($form, $varValue['children'], $elements);
+      }
+    }
+   return $elements;
   }
 
   /**

--- a/CRM/Core/BAO/Tag.php
+++ b/CRM/Core/BAO/Tag.php
@@ -84,7 +84,7 @@ class CRM_Core_BAO_Tag extends CRM_Core_DAO_Tag {
    * @param bool $excludeHidden
    */
   function buildTree($usedFor = NULL, $excludeHidden = FALSE) {
-    $sql = "SELECT id, parent_id, name, description FROM civicrm_tag";
+    $sql = "SELECT id, parent_id, name, description, is_selectable FROM civicrm_tag";
 
     $whereClause = array();
     if ($usedFor) {
@@ -109,6 +109,7 @@ class CRM_Core_BAO_Tag extends CRM_Core_DAO_Tag {
       $thisref['parent_id'] = $dao->parent_id;
       $thisref['name'] = $dao->name;
       $thisref['description'] = $dao->description;
+      $thisref['is_selectable'] = $dao->is_selectable;
 
       if (!$dao->parent_id) {
         $this->tree[$dao->id] = &$thisref;

--- a/templates/CRM/Admin/Form/Tag.tpl
+++ b/templates/CRM/Admin/Form/Tag.tpl
@@ -57,6 +57,11 @@
            <td>{$form.is_reserved.html} <br /><span class="description">{ts}Reserved tags can not be deleted. Users with 'administer reserved tags' permission can set or unset the reserved flag. You must uncheck 'Reserved' (and delete any child tags) before you can delete a tag.{/ts}
            </td>
         </tr>
+        <tr class="crm-tag-form-block-is_slectable">
+           <td class="label">{$form.is_selectable.label}</td>
+           <td>{$form.is_selectable.html}<br /><span class="description">{ts}Defines if you can select this tag.{/ts}
+           </td>
+        </tr>
     </table>
         {if $parent_tags|@count > 0}
         <table class="form-layout-compressed">

--- a/templates/CRM/Contact/Form/Edit/TagsAndGroups.tpl
+++ b/templates/CRM/Contact/Form/Edit/TagsAndGroups.tpl
@@ -23,6 +23,63 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
+{literal}
+<style>
+  #tagtree .highlighted > span {
+    background-color: #fefca6;
+  }
+  #tagtree .helpicon ins {
+    display: none;
+  }
+  #tagtree ins.jstree-icon {
+    cursor: pointer;
+  }
+</style>
+<script type="text/javascript">
+  (function($, _){{/literal}
+    var entityID={$entityID},
+      entityTable='{$entityTable}',
+      $form = $('form.{$form.formClass}');
+    {literal}
+
+    $(function() {
+      function highlightSelected() {
+        $("ul input:not(:checked)", '#tagtree').each(function () {
+          $(this).closest("li").removeClass('highlighted');
+        });
+        $("ul input:checked", '#tagtree').each(function () {
+          $(this).parents("li[id^=tag]").addClass('highlighted');
+        });
+      }
+      highlightSelected();
+
+      $("#tagtree input").change(function(){
+        highlightSelected();
+      });
+
+      //load js tree.
+      $("#tagtree").jstree({
+        plugins : ["themes", "html_data"],
+        themes: {
+          "theme": 'classic',
+          "dots": false,
+          "icons": false,
+          "url": CRM.config.resourceBase + 'packages/jquery/plugins/jstree/themes/classic/style.css'
+        }
+      });
+	  
+	  {/literal}
+      {if $permission neq 'edit'}
+        {literal}
+          $("#tagtree input").prop('disabled', true);
+        {/literal}
+      {/if}
+      {literal}
+    });
+  })(CRM.$, CRM._);
+  {/literal}
+</script>
+
 {if $title}
 <div class="crm-accordion-wrapper crm-tagGroup-accordion collapsed">
   <div class="crm-accordion-header">{$title}</div>
@@ -35,31 +92,12 @@
             {$form.group.html}
           </td>
       {/if}
-      {foreach key=key item=item from=$tagGroup}
-        {* $type assigned from dynamic.tpl *}
-        {if !$type || $type eq $key }
-          <td width={cycle name=tdWidth values="70%","30%"}><span class="label">{if $title}{$form.$key.label}{/if}</span>
-            <div id="crm-tagListWrap">
-              <table id="crm-tagGroupTable">
-                {foreach key=k item=it from=$form.$key}
-                  {if $k|is_numeric}
-                    <tr class={cycle values="'odd-row','even-row'" name=$key} id="crm-tagRow{$k}">
-                      <td>
-                        <strong>{$it.html}</strong><br />
-                        {if $item.$k.description}
-                          <div class="description">
-                            {$item.$k.description}
-                          </div>
-                        {/if}
-                      </td>
-                    </tr>
-                  {/if}
-                {/foreach}
-              </table>
-            </div>
-          </td>
-        {/if}
-      {/foreach}
+      
+	  <td width="70%"><span class="label">{if $title}{$form.$key.label}{/if}</span>
+		<div id="tagtree">
+			{include file="CRM/Contact/Form/Edit/Tagtree.tpl" level=1}
+		</div>
+	  </td>
     </tr>
     {if !$type || $type eq 'tag'}
       <tr><td>{include file="CRM/common/Tagset.tpl"}</td></tr>

--- a/templates/CRM/Contact/Form/Edit/Tagtree.tpl
+++ b/templates/CRM/Contact/Form/Edit/Tagtree.tpl
@@ -26,15 +26,15 @@
 {* This tpl runs recursively to build each level of the tag tree *}
 <ul class="tree-level-{$level}">
   {foreach from=$tree item="node" key="id"}
-    <li id="tag_{$id}">
-      <input name="tagList[{$id}]" id="check_{$id}" type="checkbox" {if $node.is_selectable EQ 0}disabled=""{/if} {if $tagged[$id]}checked="checked"{/if}/>
+    <li id="tagli_{$id}">
+      <input name="tag[{$id}]" id="tag_{$id}" class="form-checkbox" type="checkbox" value="1" {if $node.is_selectable EQ 0}disabled=""{/if} {if $form.tag.value.$id EQ 1}checked="checked"{/if}/>
       <span>
-        <label for="check_{$id}" id="tagLabel_{$id}">{$node.name}</label>
+        <label for="tag_{$id}" id="tagLabel_{$id}">{$node.name}</label>
         {if $node.description}{help id=$id title=$node.name file="CRM/Tag/Form/Tagtree"}{/if}
       </span>
       {if $node.children}
         {* Recurse... *}
-        {include file="CRM/Tag/Form/Tagtree.tpl" tree=$node.children level=$level+1}
+        {include file="CRM/Contact/Form/Edit/Tagtree.tpl" tree=$node.children level=$level+1}
       {/if}
     </li>
   {/foreach}


### PR DESCRIPTION
I think the tag overview of the page for the existing contact (jstree) looks way better than the boring list on the 'new Contact' page... So I ported it. :)

I also implemented the existing option to disable checkboxes for tags with 'is_selectable'=0.

This is the third try.
Hope this one stays clean :)

Forum topic:
http://forum.civicrm.org/index.php/topic,33934.0.html
Issue:
https://issues.civicrm.org/jira/browse/CRM-15180
