### PR TITLE
INFRA-124 - tools/scripts/phpunit - Add error check

### DIFF
--- a/tools/scripts/phpunit
+++ b/tools/scripts/phpunit
@@ -47,6 +47,11 @@ ini_set('include_path',
         "$civi_pkgs_dir"        . PATH_SEPARATOR
         . ini_get( 'include_path') );
 
+if (!is_dir("$civi_pkgs_dir/PHPUnit")) {
+  fwrite(STDERR, "PHPUnit is not embedded with this copy of CiviCRM. Perhaps you should use the standalone phpunit command?\n\nExample: \"phpunit tests/phpunit/CRM/Core/RegionTest.php\"\n");
+  exit(1);
+}
+
 #  Relying on system timezone setting produces a warning,
 #  doing the following prevents the warning message
 if ( file_exists( '/etc/timezone' ) ) {


### PR DESCRIPTION
The goal is to eventually switch from the embedded phpunit
("civicrm/packages/PHPUnit") to a more standard/standalone copy.  Howeer,
this requires a different CLI (e.g.  "./scripts/phpunit CRM_Foo_BarTest" vs
"phpunit tests/phpunit/CRM/Foo/BarTest.php").

When we make the switch, we'll need some kind of transition for developers
who use the old CLI. This commit provides them with a better error message.

Note: It's tempting to automatically call the standalone phpunit rather than
printing an error; however, there are edge-cases (like unit-tests for
extensions) to consider, and (for now) it's easier to just throw an error
rather than try to think through each of them.
