### PR TITLE
CRM-14978 related cleanup

### DIFF
--- a/templates/CRM/Event/Form/ManageEvent/EventInfo.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/EventInfo.tpl
@@ -88,14 +88,12 @@
         <td>{include file="CRM/common/jcalendar.tpl" elementName=end_date}</td>
       </tr>
     {/if}
-    {capture assign=participantStatusURL}{crmURL p='civicrm/admin/participant_status' q="reset=1"}{/capture} 
     <tr class="crm-event-manage-eventinfo-form-block-max_participants">
-      <td class="label">{$form.max_participants.label}</td>
+      <td class="label">{$form.max_participants.label} {help id="id-max_participants" waitlist=$waitlist}</td>
       <td>
-        {$form.max_participants.html|crmAddClass:four}  {help id="id-max_participants" waitlist=$waitlist}
+        {$form.max_participants.html|crmAddClass:four}
         {if call_user_func(array('CRM_Core_Permission','check'), 'administer CiviCRM') }
-          {capture assign=participantStatusURL}{/capture} 
-          <a class="crm-option-edit-link crm-hover-button" title="{ts}Edit Participant Status Options{/ts}" href="{crmURL p='civicrm/admin/participant_status' q='reset=1'}"><span class="icon edit-icon"> </span></a>
+          <a class="crm-popup crm-hover-button" target="_blank" title="{ts}Edit Participant Status Options{/ts}" href="{crmURL p='civicrm/admin/participant_status' q='reset=1'}"><span class="icon edit-icon"> </span></a>
         {/if}
       </td>
     </tr>


### PR DESCRIPTION
The "crm-option-edit-link" has special properties that might crash js if not used on a "real" option-edit link that is actually associated with a _select_ element.
Also cleaned up an unused variable.
