### PR TITLE
Wysiwyg editor by default on long text fields for I18n translation popup

### DIFF
--- a/CRM/Core/I18n/Form.php
+++ b/CRM/Core/I18n/Form.php
@@ -66,7 +66,11 @@ class CRM_Core_I18n_Form extends CRM_Core_Form {
 
     $languages = CRM_Core_I18n::languages(TRUE);
     foreach ($this->_locales as $locale) {
-      $this->addElement($type, "{$field}_{$locale}", $languages[$locale], array('class' => 'huge huge12' . ($locale == $tsLocale ? ' default-lang' : '')));
+      if ($type == 'textarea') {
+        $this->addWysiwyg("{$field}_{$locale}", $languages[$locale], array('class' => 'huge huge12' . ($locale == $tsLocale ? ' default-lang' : '')));
+      } else {
+        $this->addElement($type, "{$field}_{$locale}", $languages[$locale], array('class' => 'huge huge12' . ($locale == $tsLocale ? ' default-lang' : '')));
+      }
       $this->_defaults["{$field}_{$locale}"] = $dao->$locale;
     }
 


### PR DESCRIPTION
cf. https://issues.civicrm.org/jira/browse/CRM-15375
