### PR TITLE
CRM-15380 : Fixes for Change Selections postProcess

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3181,6 +3181,8 @@ WHERE eft.entity_table = 'civicrm_contribution'
         $contributionDAO->contribution_status_id = $statusId;
         $contributionDAO->cancel_date = 'null';
         $contributionDAO->cancel_reason = NULL;
+        $netAmount = !empty($trxnsData['net_amount']) ? $trxnsData['net_amount'] : $trxnsData['total_amount'];
+        $contributionDAO->net_amount = $contributionDAO->net_amount + $netAmount;
         $contributionDAO->save();
 
         //Change status of financial record too

--- a/templates/CRM/Event/Form/ParticipantFeeSelection.tpl
+++ b/templates/CRM/Event/Form/ParticipantFeeSelection.tpl
@@ -27,7 +27,7 @@
 {literal}
 <script type='text/javascript'>
 function display(totalfee) {
-  totalfee += {/literal}{$optionFullTotalAmount}{literal};
+  totalfee += {/literal}"{$optionFullTotalAmount}"{literal};
   // totalfee is monetary, round it to 2 decimal points so it can
   // go as a float - CRM-13491
   totalfee = Math.round(totalfee*100)/100;


### PR DESCRIPTION
CRM-15380 : Change Selections postProcess: erroneously updates contribution status to Completed and inserts line_items with NULL contribution_id
