### PR TITLE
Say which extension being operated on

### DIFF
--- a/CRM/Admin/Form/Extensions.php
+++ b/CRM/Admin/Form/Extensions.php
@@ -105,30 +105,34 @@ class CRM_Admin_Form_Extensions extends CRM_Admin_Form {
    */
   public function buildQuickForm() {
 
+    $info = CRM_Extension_System::singleton()->getMapper()->keyToInfo($this->_key);
+    $extInfo = CRM_Admin_Page_Extensions::createExtendedInfo($info);
+    $extName = $extInfo['name'];
+
     switch ($this->_action) {
       case CRM_Core_Action::ADD:
         $buttonName = ts('Install');
-        $title = ts('Install Extension');
+        $title = ts('Install ' . $extName  . '?');
         break;
 
       case CRM_Core_Action::UPDATE:
         $buttonName = ts('Download and Install');
-        $title = ts('Download and Install Extension');
+        $title = ts('Download and Install ' . $extName  . '?');
         break;
 
       case CRM_Core_Action::DELETE:
         $buttonName = ts('Uninstall');
-        $title = ts('Uninstall Extension');
+        $title = ts('Uninstall ' . $extName . '?');
         break;
 
       case CRM_Core_Action::ENABLE:
         $buttonName = ts('Enable');
-        $title = ts('Enable Extension');
+        $title = ts('Enable ' . $extName . '?');
         break;
 
       case CRM_Core_Action::DISABLE:
         $buttonName = ts('Disable');
-        $title = ts('Disable Extension');
+        $title = ts('Disable ' . $extName . '?');
         break;
     }
 


### PR DESCRIPTION
This changes the title of the extension form to include the name of the extension being disabled. This makes it clear if users are batch disabling extensions.
