### PR TITLE
CRM-15383 - fix template loading for PDF letter

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -2576,7 +2576,7 @@ LEFT JOIN civicrm_mailing_group g ON g.mailing_id   = m.id
       $form->add('select', 'template', ts('Select Template'),
         array(
           '' => ts('- select -')) + $form->_templates, FALSE,
-        array('onChange' => "selectValue( this.value );")
+        array('onChange' => "selectValue( this.value,'' );")
       );
       $form->add('checkbox', 'updateTemplate', ts('Update Template'), NULL);
     }


### PR DESCRIPTION
## This was introduced as part of: CRM-13912 (SMS Support for scheduled reminders) which added an additional parameter to JS function selectValue() causing non-SMS templates to crash out.
- CRM-15383: Can't load template when creating PDF letter
  https://issues.civicrm.org/jira/browse/CRM-15383
