### PR TITLE
CRM-12920 - search exposes bulk actions user has no permission to access...

### DIFF
--- a/CRM/Contribute/Task.php
+++ b/CRM/Contribute/Task.php
@@ -120,6 +120,10 @@ class CRM_Contribute_Task {
       if (!CRM_Core_Permission::check('delete in CiviContribute')) {
         unset(self::$_tasks[1]);
       }
+      //CRM-12920 - check for edit permission
+      if( !CRM_Core_Permission::check('edit contributions') ){
+        unset(self::$_tasks[4],self::$_tasks[6]);
+      }
 
       CRM_Utils_Hook::searchTasks('contribution', self::$_tasks);
       asort(self::$_tasks);

--- a/CRM/Event/Task.php
+++ b/CRM/Event/Task.php
@@ -133,6 +133,10 @@ class CRM_Event_Task {
       if (!CRM_Core_Permission::check('delete in CiviEvent')) {
         unset(self::$_tasks[1]);
       }
+      //CRM-12920 - check for edit permission
+      if( !CRM_Core_Permission::check('edit event participants') ){
+        unset(self::$_tasks[4],self::$_tasks[5],self::$_tasks[15]);
+      }
     }
 
     CRM_Utils_Hook::searchTasks('event', self::$_tasks);

--- a/CRM/Member/Task.php
+++ b/CRM/Member/Task.php
@@ -118,6 +118,10 @@ class CRM_Member_Task {
       if (!CRM_Core_Permission::check('delete in CiviMember')) {
         unset(self::$_tasks[1]);
       }
+      //CRM-12920 - check for edit permission
+      if( !CRM_Core_Permission::check('edit memberships') ){
+        unset(self::$_tasks[5]);
+      }
     }
     CRM_Utils_Hook::searchTasks('membership', self::$_tasks);
     asort(self::$_tasks);


### PR DESCRIPTION
## See comments attached to JIRA issue for details.
- CRM-12920: Edit all contacts permission overrides CiviEvent/CiviContrib permissions in search
  https://issues.civicrm.org/jira/browse/CRM-12920
