### PR TITLE
CRM-14751, deleted contacts visible in search

### DIFF
--- a/api/v3/Contact.php
+++ b/api/v3/Contact.php
@@ -720,8 +720,8 @@ function civicrm_api3_contact_getquick($params) {
   //CRM-10687
   if (!empty($params['field_name']) && !empty($params['table_name'])) {
     $table_name = CRM_Utils_String::munge($params['table_name']);
-    $whereClause = " WHERE ( $table_name.$field_name LIKE '$strSearch')";
-    $exactWhereClause = " WHERE ( $table_name.$field_name = '$name')";
+    $whereClause = " WHERE ( $table_name.$field_name LIKE '$strSearch') {$where}";
+    $exactWhereClause = " WHERE ( $table_name.$field_name = '$name') {$where}";
     // Search by id should be exact
     if ($field_name == 'id' || $field_name == 'external_identifier') {
       $whereClause = $exactWhereClause;


### PR DESCRIPTION
## Fix for bug introduced in 10687 - the where clause doesn't include required ACL SQL from earlier in the script.
- CRM-14751: Deleted Contacts Visible
  https://issues.civicrm.org/jira/browse/CRM-14751
