### PR TITLE
Fix multipal participant registration with confirmation email and tax enabled

### DIFF
--- a/CRM/Contribute/Form/Task/Status.php
+++ b/CRM/Contribute/Form/Task/Status.php
@@ -317,10 +317,11 @@ AND    co.id IN ( $contribIDs )";
         LEFT JOIN civicrm_membership_payment  mp ON mp.contribution_id = c.id
         LEFT JOIN civicrm_participant_payment pp ON pp.contribution_id = c.id
         LEFT JOIN civicrm_participant         p  ON pp.participant_id  = p.id";
-    if($contributionIDs){
+    if ($contributionIDs) {
       $query .= "
         WHERE     c.id IN ( $contributionIDs )";
-    }else{
+    }
+    else {
       $query .= "
         WHERE     c.id IN (NULL)";
     }

--- a/CRM/Contribute/Form/Task/Status.php
+++ b/CRM/Contribute/Form/Task/Status.php
@@ -307,17 +307,23 @@ AND    co.id IN ( $contribIDs )";
    * @return array
    */
   static function &getDetails($contributionIDs) {
-    $query = "
-SELECT    c.id              as contribution_id,
-          c.contact_id      as contact_id     ,
-          mp.membership_id  as membership_id  ,
-          pp.participant_id as participant_id ,
-          p.event_id        as event_id
-FROM      civicrm_contribution c
-LEFT JOIN civicrm_membership_payment  mp ON mp.contribution_id = c.id
-LEFT JOIN civicrm_participant_payment pp ON pp.contribution_id = c.id
-LEFT JOIN civicrm_participant         p  ON pp.participant_id  = p.id
-WHERE     c.id IN ( $contributionIDs )";
+    $query = 
+        "SELECT    c.id              as contribution_id,
+                  c.contact_id      as contact_id     ,
+                  mp.membership_id  as membership_id  ,
+                  pp.participant_id as participant_id ,
+                  p.event_id        as event_id
+        FROM      civicrm_contribution c
+        LEFT JOIN civicrm_membership_payment  mp ON mp.contribution_id = c.id
+        LEFT JOIN civicrm_participant_payment pp ON pp.contribution_id = c.id
+        LEFT JOIN civicrm_participant         p  ON pp.participant_id  = p.id";
+    if($contributionIDs){
+      $query .= "
+        WHERE     c.id IN ( $contributionIDs )";
+    }else{
+      $query .= "
+        WHERE     c.id IN (NULL)";
+    }
 
     $rows = array();
     $dao = CRM_Core_DAO::executeQuery($query,

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -623,7 +623,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
         $value['eventID']   = $this->_eventId;
         $value['item_name'] = $value['description'];
       }
-      if($value['contributionID']){
+      if ($value['contributionID']) {
         $this->_values['contributionId'] = $value['contributionID'] ;
       }
 

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -623,7 +623,9 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
         $value['eventID']   = $this->_eventId;
         $value['item_name'] = $value['description'];
       }
-      $this->_values['contributionId'] = $value['contributionID'] ;
+      if($value['contributionID']){
+        $this->_values['contributionId'] = $value['contributionID'] ;
+      }
 
       //CRM-4453.
       if (!empty($value['is_primary'])) {


### PR DESCRIPTION
When register multipal participants for a event, if the confirmation email of the event, tax and invoice are enabled, this will cause a syntax error after processing the registration.

This issue is fixed here.
