### PR TITLE
Don't join on deleted contacts at the other end of a relationship

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2539,16 +2539,16 @@ class CRM_Contact_BAO_Query {
             }
             else {
               $from .= " $side JOIN civicrm_relationship ON (civicrm_relationship.contact_id_b = contact_a.id OR civicrm_relationship.contact_id_a = contact_a.id)";
-              $from .= " $side JOIN civicrm_contact contact_b ON ((civicrm_relationship.contact_id_a = contact_b.id OR civicrm_relationship.contact_id_b = contact_b.id) AND contact_b.is_deleted != 1)";
+              $from .= " $side JOIN civicrm_contact contact_b ON ((civicrm_relationship.contact_id_a = contact_b.id OR civicrm_relationship.contact_id_b = contact_b.id) AND contact_b.is_deleted = 0)";
             }
           }
           elseif (self::$_relType == 'b') {
             $from .= " $side JOIN civicrm_relationship ON (civicrm_relationship.contact_id_b = contact_a.id )";
-            $from .= " $side JOIN civicrm_contact contact_b ON (civicrm_relationship.contact_id_a = contact_b.id AND contact_b.is_deleted != 1)";
+            $from .= " $side JOIN civicrm_contact contact_b ON (civicrm_relationship.contact_id_a = contact_b.id AND contact_b.is_deleted = 0)";
           }
           else {
             $from .= " $side JOIN civicrm_relationship ON (civicrm_relationship.contact_id_a = contact_a.id )";
-            $from .= " $side JOIN civicrm_contact contact_b ON (civicrm_relationship.contact_id_b = contact_b.id AND contact_b.is_deleted != 1)";
+            $from .= " $side JOIN civicrm_contact contact_b ON (civicrm_relationship.contact_id_b = contact_b.id AND contact_b.is_deleted = 0)";
           }
           continue;
 

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2539,16 +2539,16 @@ class CRM_Contact_BAO_Query {
             }
             else {
               $from .= " $side JOIN civicrm_relationship ON (civicrm_relationship.contact_id_b = contact_a.id OR civicrm_relationship.contact_id_a = contact_a.id)";
-              $from .= " $side JOIN civicrm_contact contact_b ON (civicrm_relationship.contact_id_a = contact_b.id OR civicrm_relationship.contact_id_b = contact_b.id)";
+              $from .= " $side JOIN civicrm_contact contact_b ON ((civicrm_relationship.contact_id_a = contact_b.id OR civicrm_relationship.contact_id_b = contact_b.id) AND contact_b.is_deleted != 1)";
             }
           }
           elseif (self::$_relType == 'b') {
             $from .= " $side JOIN civicrm_relationship ON (civicrm_relationship.contact_id_b = contact_a.id )";
-            $from .= " $side JOIN civicrm_contact contact_b ON (civicrm_relationship.contact_id_a = contact_b.id )";
+            $from .= " $side JOIN civicrm_contact contact_b ON (civicrm_relationship.contact_id_a = contact_b.id AND contact_b.is_deleted != 1)";
           }
           else {
             $from .= " $side JOIN civicrm_relationship ON (civicrm_relationship.contact_id_a = contact_a.id )";
-            $from .= " $side JOIN civicrm_contact contact_b ON (civicrm_relationship.contact_id_b = contact_b.id )";
+            $from .= " $side JOIN civicrm_contact contact_b ON (civicrm_relationship.contact_id_b = contact_b.id AND contact_b.is_deleted != 1)";
           }
           continue;
 


### PR DESCRIPTION
Advanced Search does not filter relationships with deleted contacts.

The change to line 2551 fixes this. The changes to lines 2542 and 2547 have been added for symmetry but haven't been tested. As this bit of code is probably used in a number of places, it would be good to have some further testing.

Note that http://dev.mysql.com/doc/refman/5.5/en/join.html says "The conditional_expr used with ON is any conditional expression of the form that can be used in a WHERE clause. Generally, you should use the ON clause for conditions that specify how to join tables, and the WHERE clause to restrict which rows you want in the result set". 

So this SQL will work but perhaps the best change would be to adjust the WHERE clause. It just seemed too hard to track that.
