### PR TITLE
CRM-15431 - CRM_Core_I18n - Use CRM_Core_DAO::escapeString for typical, runtime escaping

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1495,6 +1495,20 @@ SELECT contact_id
     static $_dao = NULL;
 
     if (!$_dao) {
+      // If this is an atypical case (e.g. preparing .sql files
+      // before Civi has been installed), then we fallback to
+      // DB-less escaping helper (mysql_real_escape_string).
+      // Note: In typical usage, escapeString() will only
+      // check one conditional ("if !$_dao") rather than
+      // two conditionals ("if !defined(DSN)")
+      if (!defined('CIVICRM_DSN')) {
+        if (function_exists('mysql_real_escape_string')) {
+          return mysql_real_escape_string($string);
+        } else {
+          throw new CRM_Core_Exception("Cannot generate SQL. \"mysql_real_escape_string\" is missing. Have you installed PHP \"mysql\" extension?");
+        }
+      }
+
       $_dao = new CRM_Core_DAO();
     }
 

--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -225,7 +225,7 @@ class CRM_Core_I18n {
     // in such cases we return early, only doing SQL/JS escaping
     if (isset($params['skip']) and $params['skip']) {
       if (isset($escape) and ($escape == 'sql')) {
-        $text = mysql_real_escape_string($text);
+        $text = CRM_Core_DAO::escapeString($text);
       }
       if (isset($escape) and ($escape == 'js')) {
         $text = addcslashes($text, "'");
@@ -322,7 +322,7 @@ class CRM_Core_I18n {
 
     // escape SQL if we were asked for it
     if (isset($escape) and ($escape == 'sql')) {
-      $text = mysql_real_escape_string($text);
+      $text = CRM_Core_DAO::escapeString($text);
     }
 
     // escape for JavaScript (if requested)


### PR DESCRIPTION
The call from CRM_Core_I18n breaks on systems that use "mysqli" without
"mysql." Such systems cannot be fully supported for development using
current dataflows (i.e.  "GenCode" won't work), but this patch may make them
usable for regular installations.
