### PR TITLE
CRM-14968

### DIFF
--- a/CRM/Contribute/BAO/Contribution/Utils.php
+++ b/CRM/Contribute/BAO/Contribution/Utils.php
@@ -141,7 +141,7 @@ class CRM_Contribute_BAO_Contribution_Utils {
       $form->set('params', $form->_params);
       $form->postProcessPremium($premiumParams, $contribution);
 
-      if ($form->_values['is_monetary'] && $form->_amount > 0.0) {
+      if ($form->_values['is_monetary'] && $form->_amount >= 0.0) {
         // add qfKey so we can send to paypal
         $form->_params['qfKey'] = $form->controller->_key;
         if ($component == 'membership') {

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -1188,7 +1188,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     if (($this->_values['is_pay_later'] &&
         empty($this->_paymentProcessor) &&
         !array_key_exists('hidden_processor', $params)) ||
-      CRM_Utils_Array::value('payment_processor', $params) == 0) {
+      (!empty($params['payment_processor']) && $params['payment_processor'] == 0)) {
       $params['is_pay_later'] = 1;
     }
     else {


### PR DESCRIPTION
Fix For https://issues.civicrm.org/jira/browse/CRM-14968?focusedCommentId=66281&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-66281

CRM_Utils_Array returns NULL(if 'payment_processor' is not present in $params) which makes the condition TRUE on matching with 0, hence used !empty to check in a proper manner.
