### PR TITLE
CRM-15492

### DIFF
--- a/CRM/Mailing/Form/Group.php
+++ b/CRM/Mailing/Form/Group.php
@@ -143,7 +143,7 @@ class CRM_Mailing_Form_Group extends CRM_Contact_Form_Task {
         $mailingGroups[$entityTable][$dao->group_type][] = $dao->entity_id;
       }
 
-      $defaults['includeGroups'] = $mailingGroups['civicrm_group']['include'];
+      $defaults['includeGroups'] = CRM_Utils_Array::value('include', $mailingGroups['civicrm_group']);
       $defaults['excludeGroups'] = CRM_Utils_Array::value('exclude', $mailingGroups['civicrm_group']);
 
       if (!empty($mailingGroups['civicrm_mailing'])) {


### PR DESCRIPTION
Notice: Undefined index: include in CRM_Mailing_Form_Group->setDefaultValues()

line 146 of /CRM/Mailing/Form/Group.php assumes the 'include groups' field is set because it is mandatory, but it isn't set when the defaults are being set up.
