### PR TITLE
CRM-15494 Fix label display for Joomla 3.x

### DIFF
--- a/css/joomla.css
+++ b/css/joomla.css
@@ -57,6 +57,8 @@ td.active {
 
 td.label {
   background: none;
+  color: #3e3e3e;
+  display: table-cell;
 }
 
 /*


### PR DESCRIPTION
Fix the display of the labels so they are readable in the default administrator template in Joomla 3.
