### PR TITLE
CRM-14152 only join to civicrm_participant line items

### DIFF
--- a/CRM/Report/Form/Event/ParticipantListing.php
+++ b/CRM/Report/Form/Event/ParticipantListing.php
@@ -495,7 +495,8 @@ GROUP BY  cv.label
     if ($this->_lineitemField){
       $this->_from .= "
             LEFT JOIN civicrm_line_item line_item_civireport
-                  ON line_item_civireport.entity_id = {$this->_aliases['civicrm_participant']}.id
+                  ON line_item_civireport.entity_table = 'civicrm_participant' AND
+                    line_item_civireport.entity_id = {$this->_aliases['civicrm_participant']}.id
       ";
     }
   }


### PR DESCRIPTION
Backporting a change from https://github.com/civicrm/civicrm-core/commit/99f13d8d83f1786a6bd8e2238d0424663488a988 that fixes a problem in the event participant report.
