### PR TITLE
CRM-14399 add alterCalculatedMembershipStatus hook

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -1546,7 +1546,9 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
               $dates['end_date'],
               $dates['join_date'],
               'today',
-              TRUE
+              TRUE,
+              $membership->membership_type_id,
+              (array) $membership
             );
 
             $formattedParams = array(

--- a/CRM/Core/Payment/BaseIPN.php
+++ b/CRM/Core/Payment/BaseIPN.php
@@ -398,7 +398,9 @@ LIMIT 1;";
               $dates['end_date'],
               $dates['join_date'],
               'today',
-              TRUE
+              TRUE,
+              $membership->membership_type_id,
+              (array) $membership
             );
 
             $formatedParams = array('status_id' => CRM_Utils_Array::value('id', $calcStatus, 2),

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -251,7 +251,7 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
       }
 
       $calcStatus = CRM_Member_BAO_MembershipStatus::getMembershipStatusByDate($start_date, $end_date, $join_date,
-        'today', $excludeIsAdmin
+        'today', $excludeIsAdmin, CRM_Utils_Array::value('membership_type_id', $params), $params
       );
       if (empty($calcStatus)) {
         // Redirect the form in case of error
@@ -1728,7 +1728,10 @@ AND civicrm_membership.is_test = %2";
           CRM_Utils_Date::customFormat($dates['join_date'],
             $statusFormat
           ),
-          'today', TRUE
+          'today',
+          TRUE,
+          $membershipTypeID,
+          $memParams
         );
         $updateStatusId = CRM_Utils_Array::value('id', $status);
       }
@@ -1825,7 +1828,9 @@ AND civicrm_membership.is_test = %2";
       CRM_Utils_Array::value('end_date', $currentMembership),
       CRM_Utils_Array::value('join_date', $currentMembership),
       $today,
-      TRUE
+      TRUE,
+      $currentMembership['membership_type_id'],
+      $currentMembership
     );
 
     if (empty($status) ||

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1007,7 +1007,9 @@ WHERE   id IN ( ' . implode(' , ', array_keys($membershipType)) . ' )';
             $endDate,
             $joinDate,
             'today',
-            TRUE
+            TRUE,
+            $memType,
+            $params
           );
           if (empty($calcStatus)) {
             $url = CRM_Utils_System::url('civicrm/admin/member/membershipStatus', 'reset=1&action=browse');

--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -445,7 +445,9 @@ class CRM_Member_Import_Parser_Membership extends CRM_Member_Import_Parser {
               $endDate,
               $joinDate,
               'today',
-              $excludeIsAdmin
+              $excludeIsAdmin,
+              $formatted['membership_type_id'],
+              $formatted
             );
 
             if (!CRM_Utils_Array::value('status_id', $formatted)) {
@@ -533,7 +535,9 @@ class CRM_Member_Import_Parser_Membership extends CRM_Member_Import_Parser {
           $endDate,
           $joinDate,
           'today',
-          $excludeIsAdmin
+          $excludeIsAdmin,
+          $formatted['membership_type_id'],
+          $formatted
         );
         if (!CRM_Utils_Array::value('status_id', $formatted)) {
           $formatted['status_id'] = CRM_Utils_Array::value('id', $calcStatus);

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -736,6 +736,26 @@ abstract class CRM_Utils_Hook {
   }
 
   /**
+   * This hook is called when membership status is being calculated
+   *
+   * @param array $membershipStatus membership status details as determined - alter if required
+   * @param array $arguments arguments passed in to calculate date
+   * - 'start_date'
+   * - 'end_date'
+   * - 'status_date'
+   * - 'join_date'
+   * - 'exclude_is_admin'
+   * - 'membership_type_id'
+   * @param array $membership membership details from the calling function
+   */
+  static function alterCalculatedMembershipStatus(&$membershipStatus, $arguments, $membership) {
+    return self::singleton()->invoke(3, $membershipStatus, $arguments,
+      $membership, self::$_nullObject, self::$_nullObject,
+      'civicrm_alterCalculatedMembershipStatus'
+    );
+  }
+
+  /**
    * This hook is called when rendering the Manage Case screen
    *
    * @param int $caseID - the case ID

--- a/api/v3/MembershipStatus.php
+++ b/api/v3/MembershipStatus.php
@@ -149,35 +149,33 @@ function civicrm_api3_membership_status_delete($params) {
  * @public
  */
 function civicrm_api3_membership_status_calc($membershipParams) {
-
   if (!($membershipID = CRM_Utils_Array::value('membership_id', $membershipParams))) {
-    return civicrm_api3_create_error('membershipParams do not contain membership_id');
+    throw new API_Exception('membershipParams do not contain membership_id');
   }
 
+  if(empty($membershipParams['id'])) {
+    //for consistency lets make sure id is set as this will get passed to hooks downstream
+    $membershipParams['id'] = $membershipID;
+  }
   $query = "
-SELECT start_date, end_date, join_date
+SELECT start_date, end_date, join_date, membership_type_id
   FROM civicrm_membership
  WHERE id = %1
 ";
 
   $params = array(1 => array($membershipID, 'Integer'));
-  $dao = &CRM_Core_DAO::executeQuery($query, $params);
+  $dao = CRM_Core_DAO::executeQuery($query, $params);
   if ($dao->fetch()) {
-    // Take the is_admin column in MembershipStatus into consideration when requested
-    if (! CRM_Utils_Array::value('ignore_admin_only', $membershipParams) ) {
-      $result = &CRM_Member_BAO_MembershipStatus::getMembershipStatusByDate($dao->start_date, $dao->end_date, $dao->join_date, 'today', TRUE);
-    }
-    else {
-    $result = &CRM_Member_BAO_MembershipStatus::getMembershipStatusByDate($dao->start_date, $dao->end_date, $dao->join_date);
-    }
-
+    $membershipTypeID = empty($membershipParams['membership_type_id']) ? $dao->membership_type_id : $membershipParams['membership_type_id'];
+    $result = CRM_Member_BAO_MembershipStatus::getMembershipStatusByDate($dao->start_date, $dao->end_date, $dao->join_date, 'today', CRM_Utils_Array::value('ignore_admin_only', $membershipParams), $membershipTypeID, $membershipParams);
     //make is error zero only when valid status found.
     if (CRM_Utils_Array::value('id', $result)) {
       $result['is_error'] = 0;
     }
   }
   else {
-    $result = civicrm_api3_create_error('did not find a membership record');
+    $dao->free();
+    throw new API_Exception('did not find a membership record');
   }
   $dao->free();
   return $result;


### PR DESCRIPTION
merge for 4.4.10 once 4.4.9 is out as 4.4.9 in pre-release mode

Note this has been running & the hook has been used on fuzion sites for several months now & I'm of the opinion that getting it into core 4.4. in addition to providing developer consistency is also less risky than porting further patches without syncing this up
