### PR TITLE
CRM-15542 - Unit test.

### DIFF
--- a/tests/phpunit/api/v3/CustomFieldTest.php
+++ b/tests/phpunit/api/v3/CustomFieldTest.php
@@ -261,6 +261,35 @@ class api_v3_CustomFieldTest extends CiviUnitTestCase {
     $this->assertEquals(0, $optionValueCount);
   }
 
+  /**
+   * Test custom field with existing option group
+   */
+  function testCustomFieldExistingOptionGroup() {
+    $customGroup = $this->customGroupCreate(array('extends' => 'Organization', 'title' => 'test_group'));
+    $params = array(
+      'custom_group_id' => $customGroup['id'],
+      // Just to say something:
+      'label' => 'Organization Gender',
+      'html_type' => 'Select',
+      'data_type' => 'Int',
+      'weight' => 4,
+      'is_required' => 1,
+      'is_searchable' => 0,
+      'is_active' => 1,
+      // Option group id 3: gender
+      'option_group_id' => 3,
+    );
+
+    $customField = $this->callAPISuccess('custom_field', 'create', $params);
+    $this->assertNotNull($customField['id']);
+    $optionGroupID = $this->callAPISuccess('custom_field', 'getvalue', array(
+      'id' => $customField['id'],
+      'return' => 'option_group_id',
+    ));
+
+    $this->assertEquals($optionGroupID,3);
+  }
+
 
   /**
    * Test custom field get works & return param works


### PR DESCRIPTION
A unit test for CRM-15542. Technically this was a bug in the BAO layer, not in the API.
## But I felt more comfortable writing this test for the API. You can merge this if it is useable.
- CRM-15542: The api ignores option_group_id when creating a new custom_field.
  https://issues.civicrm.org/jira/browse/CRM-15542
