### PR TITLE
CRM-14945 Event confirmation email - message not saved to Activities

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1835,6 +1835,7 @@ SELECT  display_name
       ),
       'subject' => $subject,
       'activity_date_time' => $date,
+      'details' => $activity->details,
       'is_test' => $activity->is_test,
       'status_id' => CRM_Core_OptionGroup::getValue('activity_status',
         'Completed',


### PR DESCRIPTION
I feel like this fix was ported but this line got lost
