### PR TITLE
Profile select search field is disabled

### DIFF
--- a/js/view/crm.profile-selector.js
+++ b/js/view/crm.profile-selector.js
@@ -101,7 +101,7 @@
       }
     },
     disableForm: function() {
-      this.$(':input', '.crm-profile-selector-preview-pane').prop('readOnly', true);
+      this.$(':input', '.crm-profile-selector-preview-pane').not('.select2-input').prop('readOnly', true);
     },
     doEdit: function(e) {
       e.preventDefault();


### PR DESCRIPTION
Fixes an issue in events online registration profile selector, on already saved profiles the search field is disabled by readonly attribute.
