### PR TITLE
Page title fixes to accompany plugin fixes for CRM-12616

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -52,12 +52,10 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
   }
 
   /**
-   * sets the title of the page
+   * Sets the title of the page
    *
    * @param string $title
    * @param null $pageTitle
-   *
-   * @paqram string $pageTitle
    *
    * @return void
    * @access public

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -64,16 +64,16 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
     if (!$pageTitle) {
       $pageTitle = $title;
     }
-    
+
     // get civi-wordpress instance
     $civi = civi_wp();
-    
+
     // do we have functionality provided by plugin version 4.6+ present?
     if (method_exists($civi, 'civicrm_context_get')) {
-      
+
       global $civicrm_wp_title;
       $civicrm_wp_title = $pageTitle;
-      
+
       // yes, set page title, depending on context
       $context = civi_wp()->civicrm_context_get();
       switch ( $context ) {
@@ -82,15 +82,15 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
           $template = CRM_Core_Smarty::singleton();
           $template->assign('pageTitle', $pageTitle);
       }
-      
+
     } elseif (civicrm_wp_in_civicrm()) {
-      
+
       // legacy pre-4.6 behaviour
       global $civicrm_wp_title;
       $civicrm_wp_title = $pageTitle;
       $template = CRM_Core_Smarty::singleton();
       $template->assign('pageTitle', $pageTitle);
-      
+
     }
   }
 

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -66,11 +66,33 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
     if (!$pageTitle) {
       $pageTitle = $title;
     }
-    if (civicrm_wp_in_civicrm()) {
+    
+    // get civi-wordpress instance
+    $civi = civi_wp();
+    
+    // do we have functionality provided by plugin version 4.6+ present?
+    if (method_exists($civi, 'civicrm_context_get')) {
+      
+      global $civicrm_wp_title;
+      $civicrm_wp_title = $pageTitle;
+      
+      // yes, set page title, depending on context
+      $context = civi_wp()->civicrm_context_get();
+      switch ( $context ) {
+        case 'admin':
+        case 'shortcode':
+          $template = CRM_Core_Smarty::singleton();
+          $template->assign('pageTitle', $pageTitle);
+      }
+      
+    } elseif (civicrm_wp_in_civicrm()) {
+      
+      // legacy pre-4.6 behaviour
       global $civicrm_wp_title;
       $civicrm_wp_title = $pageTitle;
       $template = CRM_Core_Smarty::singleton();
       $template->assign('pageTitle', $pageTitle);
+      
     }
   }
 


### PR DESCRIPTION
This PR is required by:
https://github.com/civicrm/civicrm-wordpress/pull/63

It sets the template title only in circumstances where the page title is needed - i.e. when 
- Civi is being displayed in WordPress admin
- Civi content is displayed via multiple shortcodes (whether within a single page/post or in an archive)

It also sets the global `$civicrm_wp_title` in all cases, so that it can be retrieved elsewhere once the Civi content has been rendered.
