### PR TITLE
Add hook_civicrm_preProcess function.

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -435,6 +435,8 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
 
     $this->preProcess();
 
+    CRM_Utils_Hook::preProcess(get_class($this), $this);
+
     $this->assign('translatePermission', CRM_Core_Permission::check('translate CiviCRM'));
 
     if (

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -303,6 +303,18 @@ abstract class CRM_Utils_Hook {
   }
 
   /**
+   * This hook is invoked during the CiviCRM form preProcess phase.
+   *
+   * @param string $formName the name of the form
+   * @param object $form     reference to the form object
+   *
+   * @return null the return value is ignored
+   */
+  static function preProcess($formName, &$form) {
+    return self::singleton()->invoke(2, $formName, $form, $formName, $formName,
+  }
+
+  /**
    * This hook is invoked when building a CiviCRM form. This hook should also
    * be used to set the default values of a form element
    *

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -311,7 +311,7 @@ abstract class CRM_Utils_Hook {
    * @return null the return value is ignored
    */
   static function preProcess($formName, &$form) {
-    return self::singleton()->invoke(2, $formName, $form, $formName, $formName,
+    return self::singleton()->invoke(2, $formName, $form, $formName, $formName, $formName, self::$_nullObject, 'civicrm_preProcess');
   }
 
   /**

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -311,7 +311,7 @@ abstract class CRM_Utils_Hook {
    * @return null the return value is ignored
    */
   static function preProcess($formName, &$form) {
-    return self::singleton()->invoke(2, $formName, $form, $formName, $formName, $formName, self::$_nullObject, 'civicrm_preProcess');
+    return self::singleton()->invoke(2, $formName, $form, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_preProcess');
   }
 
   /**


### PR DESCRIPTION
This seems to be a generically useful spot to intercept the form object and
change things before the form is processed. Specifically, we need this hook
for integrating the Event Cart with the CiviDiscount extension.
