### PR TITLE
CRM-15490 - Recurring entity QA fixes

### DIFF
--- a/CRM/Core/BAO/RecurringEntity.php
+++ b/CRM/Core/BAO/RecurringEntity.php
@@ -1011,6 +1011,7 @@ class CRM_Core_BAO_RecurringEntity extends CRM_Core_DAO_RecurringEntity {
       if (CRM_Utils_Array::value('absolute_date', $scheduleReminderDetails)) {
         $absoluteDate = CRM_Utils_Date::setDateDefaults($scheduleReminderDetails['absolute_date']);
         $endDate = new DateTime($absoluteDate[0].' '.$absoluteDate[1]);
+        $endDate->modify('+1 day');
         $r->until($endDate);
       }
 

--- a/CRM/Core/BAO/RecurringEntity.php
+++ b/CRM/Core/BAO/RecurringEntity.php
@@ -52,6 +52,7 @@ class CRM_Core_BAO_RecurringEntity extends CRM_Core_DAO_RecurringEntity {
   public $isRecurringEntityRecord = TRUE;
 
   protected $recursion = NULL;
+  protected $recursion_start_date = NULL;
 
   public static $_entitiesToBeDeleted = array();
 
@@ -329,6 +330,11 @@ class CRM_Core_BAO_RecurringEntity extends CRM_Core_DAO_RecurringEntity {
 
       $count = 1;
       while ($result = $this->recursion->next()) {
+        $skip = FALSE;
+        if ($result == $this->recursion_start_date) {
+          // skip the recursion-start-date from the list we going to generate
+          $skip = TRUE;
+        }
         $baseDate = CRM_Utils_Date::processDate($result->format('Y-m-d H:i:s'));
 
         foreach ($this->dateColumns as $col) {
@@ -344,7 +350,6 @@ class CRM_Core_BAO_RecurringEntity extends CRM_Core_DAO_RecurringEntity {
           $exRangeEndDate   = CRM_Utils_Date::processDate($recursionDates[$count][$exRangeEnd], NULL, FALSE, 'Ymd');
         }
 
-        $skip = FALSE;
         foreach ($this->excludeDates as $exDate) {
           $exDate = CRM_Utils_Date::processDate($exDate, NULL, FALSE, 'Ymd');
           if (!$exRangeStart) {
@@ -830,7 +835,6 @@ class CRM_Core_BAO_RecurringEntity extends CRM_Core_DAO_RecurringEntity {
         $repetitionStartDate = $repetitionStartDate . " " . $formParams['repetition_start_date_time'];
       }
       $repetition_start_date = new DateTime($repetitionStartDate);
-      $repetition_start_date->modify('+1 day');
       $dbParams['start_action_date'] = CRM_Utils_Date::processDate($repetition_start_date->format('Y-m-d H:i:s'));
     }
 
@@ -942,6 +946,7 @@ class CRM_Core_BAO_RecurringEntity extends CRM_Core_DAO_RecurringEntity {
         $currDate = date("Y-m-d H:i:s");
       }
       $start = new DateTime($currDate);
+      $this->recursion_start_date = $start;
       if ($scheduleReminderDetails['repetition_frequency_unit']) {
         $repetition_frequency_unit = $scheduleReminderDetails['repetition_frequency_unit'];
         if ($repetition_frequency_unit == "day") {

--- a/CRM/Core/BAO/RecurringEntity.php
+++ b/CRM/Core/BAO/RecurringEntity.php
@@ -820,7 +820,12 @@ class CRM_Core_BAO_RecurringEntity extends CRM_Core_DAO_RecurringEntity {
     }
 
     if (CRM_Utils_Array::value('repetition_start_date', $formParams)) {
-      $repetitionStartDate = $formParams['repetition_start_date'];
+      if (CRM_Utils_Array::value('repetition_start_date_display', $formParams)) {
+        $repetitionStartDate = $formParams['repetition_start_date_display'];
+      }
+      else {
+        $repetitionStartDate = $formParams['repetition_start_date'];
+      }
       if (CRM_Utils_Array::value('repetition_start_date_time', $formParams)) {
         $repetitionStartDate = $repetitionStartDate . " " . $formParams['repetition_start_date_time'];
       }

--- a/CRM/Core/Form/RecurringEntity.php
+++ b/CRM/Core/Form/RecurringEntity.php
@@ -146,6 +146,12 @@ class CRM_Core_Form_RecurringEntity {
   }
 
   static function buildQuickForm(&$form) {
+    if (self::$_entityTable) {
+      $entityType = explode("_", self::$_entityTable);
+      if ($entityType[1]) {
+        $form->assign('entityType', ucwords($entityType[1]));
+      }
+    }
     $form->assign('currentEntityId', self::$_entityId);
     $form->assign('entityTable', self::$_entityTable);
     $form->assign('scheduleReminderId', self::$_scheduleReminderID);

--- a/CRM/Core/Form/RecurringEntity.php
+++ b/CRM/Core/Form/RecurringEntity.php
@@ -442,8 +442,13 @@ class CRM_Core_Form_RecurringEntity {
               }
             }
           }
-          // lets delete current entity from recurring-entity table, which is going to be a new parent
-          CRM_Core_BAO_RecurringEntity::delEntity($params['entity_id'], $params['entity_table'], TRUE);
+
+          // find all entities from the recurring set. At this point we 'll get entities which were not deleted 
+          // for e.g due to participants being present. We need to delete them from recurring tables anyway.
+          $pRepeatingEntities = CRM_Core_BAO_RecurringEntity::getEntitiesFor($params['entity_id'], $params['entity_table']);
+          foreach($pRepeatingEntities as $val) {
+            CRM_Core_BAO_RecurringEntity::delEntity($val['id'], $val['table'], TRUE);
+          }
         }
 
         $recursion = new CRM_Core_BAO_RecurringEntity();

--- a/CRM/Core/Form/RecurringEntity.php
+++ b/CRM/Core/Form/RecurringEntity.php
@@ -88,7 +88,9 @@ class CRM_Core_Form_RecurringEntity {
         self::$_parentEntityId = self::$_entityId;
         self::$_scheduleReminderDetails = CRM_Core_BAO_RecurringEntity::getReminderDetailsByEntityId(self::$_entityId, $entityTable);
       }
-      self::$_scheduleReminderID = self::$_scheduleReminderDetails->id;
+      if (property_exists(self::$_scheduleReminderDetails, 'id')) {
+        self::$_scheduleReminderID = self::$_scheduleReminderDetails->id;
+      }
     }
     if ($entityTable) {
       CRM_Core_OptionValue::getValues(array('name' => $entityTable.'_repeat_exclude_dates_'.self::$_parentEntityId), $optionValue);

--- a/templates/CRM/Activity/Form/Activity.tpl
+++ b/templates/CRM/Activity/Form/Activity.tpl
@@ -218,10 +218,15 @@
                 $('#repetition_start_date, #repetition_start_date_display').val($('#activity_date_time').val());
                 $('#repetition_start_date_time').val($('#activity_date_time_time').val());
               }
-              $('#activity_date_time_display').blur(function() {
-                $('#repetition_start_date, #repetition_start_date_display').val($('#activity_date_time').val());
+
+              $('#activity_date_time_display').change(function() {
+                $('#repetition_start_date_display').val($('#activity_date_time').val());
+              });
+
+              $('#activity_date_time_time').change(function() {
                 $('#repetition_start_date_time').val($('#activity_date_time_time').val());
               });
+
               if ($('#start_action_offset').val() == "" && $('#repeat_absolute_date_display').val() == "") {
                 $('#recurring-entity-block').addClass('collapsed');
               }

--- a/templates/CRM/Core/Form/RecurringEntity.hlp
+++ b/templates/CRM/Core/Form/RecurringEntity.hlp
@@ -83,7 +83,7 @@
 {htxt id="id-ends-after"}
   {ts}
     Use this field to limit/end the repetition of the event.<br/>
-    Example: You want to repeat an event which is now a six month course(i.e it repeats 6 times), then you give 6 as a value to this field.
+    Example: You want to repeat an event which is now a six month course (i.e it repeats 6 times), then set 6 as a value for this field.
   {/ts}
 {/htxt}
 
@@ -102,7 +102,8 @@
 {/htxt}
 {htxt id="id-exclude-date"}
     {ts}
-        Add dates here, if you don't want to repeat your event on those dates.<br/>
-        This field enables you to alter certain session, skip a holiday in the middle of a term or a public holiday on which you are close.
+        Add dates here, if you don't want to repeat your event on those dates.
+        This list enables you to skip days.<br/>
+        Example: Public holidays
     {/ts}
 {/htxt}

--- a/templates/CRM/Core/Form/RecurringEntity.hlp
+++ b/templates/CRM/Core/Form/RecurringEntity.hlp
@@ -36,7 +36,7 @@
         <li>Monthly:&nbsp;&nbsp;your event repeats on one or more days every month</li>
         <li>Yearly:&nbsp;&nbsp;your event repeats yearly or after every few years</li>
     </ul>
-    For eg - You would select option "monthly", if your event occurs every month.
+    Example: You would select option "monthly", if your event occurs every month.
   {/ts}
 {/htxt}
 
@@ -45,7 +45,7 @@
 {/htxt}
 {htxt id="id-repeats-every"}
   {ts}Option you select here decides the repetition interval.<br/>
-      For eg - If your event repeats every 5 months, then you would select option 5.{/ts}
+      Example: If your event repeats every 5 months, then you would select option 5.{/ts}
 {/htxt}
 
 {htxt id="id-repeats-on-title"}
@@ -54,7 +54,7 @@
 {htxt id="id-repeats-on"}
   {ts}
     You can choose to select your event to repeat on weekdays, weekends or any combination of day of the week.<br/>
-    For eg - You can select Monday, Wednesday and Friday for your event to occur on alternate weekdays.
+    Example: You can select Monday, Wednesday and Friday for your event to occur on alternate weekdays.
   {/ts}
 {/htxt}
 
@@ -64,7 +64,7 @@
 {htxt id="id-repeats-by-month"}
   {ts}
     Options given here are days of a month from 1 - 31<br/>
-    For eg - If your event repeats 8th of every month then you would select 8.
+    Example: If your event repeats 8th of every month then you would select 8.
   {/ts}
 {/htxt}
 
@@ -83,7 +83,7 @@
 {htxt id="id-ends-after"}
   {ts}
     Use this field to limit/end the repetition of the event.<br/>
-    For eg - You want to repeat an event which is now a six month course(i.e it repeats 6 times), then you give 6 as a value to this field.
+    Example: You want to repeat an event which is now a six month course(i.e it repeats 6 times), then you give 6 as a value to this field.
   {/ts}
 {/htxt}
 
@@ -93,7 +93,7 @@
 {htxt id="id-ends-on"}
     {ts}
         Choose a specific date here to limit/end the repetition<br/>
-        For eg - Your event ends on 26th of September 2014
+        Example: Your event ends on 26th of September 2014
     {/ts}
 {/htxt}
 

--- a/templates/CRM/Core/Form/RecurringEntity.hlp
+++ b/templates/CRM/Core/Form/RecurringEntity.hlp
@@ -28,15 +28,15 @@
 {ts}Repeats{/ts}
 {/htxt}
 {htxt id="id-repeats"}
-  {ts}Access the drop-down menu here to select how frequently your event occurs. You have several options:
+  {ts}Access the drop-down menu here to select how frequently your {$params.entityType|lower} occurs. You have several options:
     <ul>
-        <li>Hourly:&nbsp;&nbsp;your event repeats hourly or after every few hours</li>
-        <li>Daily:&nbsp;&nbsp;your event repeats daily or after every few days</li>
-        <li>Weekly:&nbsp;&nbsp;your event repeats on one or more days every week</li>
-        <li>Monthly:&nbsp;&nbsp;your event repeats on one or more days every month</li>
-        <li>Yearly:&nbsp;&nbsp;your event repeats yearly or after every few years</li>
+        <li>Hourly:&nbsp;&nbsp;your {$params.entityType|lower} repeats hourly or after every few hours</li>
+        <li>Daily:&nbsp;&nbsp;your {$params.entityType|lower} repeats daily or after every few days</li>
+        <li>Weekly:&nbsp;&nbsp;your {$params.entityType|lower} repeats on one or more days every week</li>
+        <li>Monthly:&nbsp;&nbsp;your {$params.entityType|lower} repeats on one or more days every month</li>
+        <li>Yearly:&nbsp;&nbsp;your {$params.entityType|lower} repeats yearly or after every few years</li>
     </ul>
-    Example: You would select option "monthly", if your event occurs every month.
+    Example: You would select option "monthly", if your {$params.entityType|lower} occurs every month.
   {/ts}
 {/htxt}
 
@@ -45,7 +45,7 @@
 {/htxt}
 {htxt id="id-repeats-every"}
   {ts}Option you select here decides the repetition interval.<br/>
-      Example: If your event repeats every 5 months, then you would select option 5.{/ts}
+      Example: If your {$params.entityType|lower} repeats every 5 months, then you would select option 5.{/ts}
 {/htxt}
 
 {htxt id="id-repeats-on-title"}
@@ -53,8 +53,8 @@
 {/htxt}
 {htxt id="id-repeats-on"}
   {ts}
-    You can choose to select your event to repeat on weekdays, weekends or any combination of day of the week.<br/>
-    Example: You can select Monday, Wednesday and Friday for your event to occur on alternate weekdays.
+    You can choose to select your {$params.entityType|lower} to repeat on weekdays, weekends or any combination of day of the week.<br/>
+    Example: You can select Monday, Wednesday and Friday for your {$params.entityType|lower} to occur on alternate weekdays.
   {/ts}
 {/htxt}
 
@@ -64,7 +64,7 @@
 {htxt id="id-repeats-by-month"}
   {ts}
     Options given here are days of a month from 1 - 31<br/>
-    Example: If your event repeats 8th of every month then you would select 8.
+    Example: If your {$params.entityType|lower} repeats 8th of every month then you would select 8.
   {/ts}
 {/htxt}
 
@@ -73,7 +73,7 @@
 {/htxt}
 {htxt id="id-repeats-by-week"}
     {ts}
-        You can choose to select event occurring every third Friday, last Monday, fourth Wednesday of the month and various other combinations given in the dropdown.
+        You can choose to select {$params.entityType|lower} occurring every third Friday, last Monday, fourth Wednesday of the month and various other combinations given in the dropdown.
     {/ts}
 {/htxt}
 
@@ -82,8 +82,8 @@
 {/htxt}
 {htxt id="id-ends-after"}
   {ts}
-    Use this field to limit/end the repetition of the event.<br/>
-    Example: You want to repeat an event which is now a six month course (i.e it repeats 6 times), then set 6 as a value for this field.
+    Use this field to limit/end the repetition of the {$params.entityType|lower}.<br/>
+    Example: If you want to repeat an {$params.entityType|lower} for six months (i.e it repeats 6 times), then set 6 as a value for this field.
   {/ts}
 {/htxt}
 
@@ -93,7 +93,7 @@
 {htxt id="id-ends-on"}
     {ts}
         Choose a specific date here to limit/end the repetition<br/>
-        Example: Your event ends on 26th of September 2014
+        Example: Your {$params.entityType|lower} ends on 26th of September 2014
     {/ts}
 {/htxt}
 
@@ -102,7 +102,7 @@
 {/htxt}
 {htxt id="id-exclude-date"}
     {ts}
-        Add dates here, if you don't want to repeat your event on those dates.
+        Add dates here, if you don't want to repeat your {$params.entityType|lower} on those dates.
         This list enables you to skip days.<br/>
         Example: Public holidays
     {/ts}

--- a/templates/CRM/Core/Form/RecurringEntity.hlp
+++ b/templates/CRM/Core/Form/RecurringEntity.hlp
@@ -103,7 +103,6 @@
 {htxt id="id-exclude-date"}
     {ts}
         Add dates here, if you don't want to repeat your {$params.entityType|lower} on those dates.
-        This list enables you to skip days.<br/>
-        Example: Public holidays
+        This field enables you to alter certain sessions, skip holidays, or create gaps in the sequence for other reasons.<br/>
     {/ts}
 {/htxt}

--- a/templates/CRM/Core/Form/RecurringEntity.tpl
+++ b/templates/CRM/Core/Form/RecurringEntity.tpl
@@ -273,7 +273,7 @@
             if (Object.keys(result).length > 0) {
               var errors = [];
               var participantData = [];
-              var html = 'Based on your repeat configuration here is the list of dates, Do you wish to create recurring set of these dates?<br/><table id="options" class="display"><thead><tr><th>Sr No</th><th>Start date</th><th id="th-end-date">End date</th></tr><thead>';
+              var html = 'Based on your repeat configuration here is the list of dates, Do you wish to create recurring set of these dates?<br/><table id="options" class="display"><thead><tr><th></th><th>Start date</th><th id="th-end-date">End date</th></tr><thead>';
               var count = 1;
               for(var i in result) {
                 if (i != 'errors') {

--- a/templates/CRM/Core/Form/RecurringEntity.tpl
+++ b/templates/CRM/Core/Form/RecurringEntity.tpl
@@ -39,11 +39,11 @@
           </tr>
           <tr class="crm-core-form-recurringentity-block-repetition_frequency_unit">
             <td class="label">{$form.repetition_frequency_unit.label}&nbsp;<span class="crm-marker" title="This field is required.">*</span></td>
-            <td>{$form.repetition_frequency_unit.html} {help id="id-repeats" file="CRM/Core/Form/RecurringEntity.hlp"}</td>
+            <td>{$form.repetition_frequency_unit.html} {help id="id-repeats" entityType=$entityType file="CRM/Core/Form/RecurringEntity.hlp"}</td>
           </tr>
           <tr class="crm-core-form-recurringentity-block-repetition_frequency_interval">
             <td class="label">{$form.repetition_frequency_interval.label}&nbsp;<span class="crm-marker" title="This field is required.">*</span></td>
-            <td>{$form.repetition_frequency_interval.html} &nbsp;<span id="repeats-every-text">hour(s)</span> {help id="id-repeats-every" file="CRM/Core/Form/RecurringEntity.hlp"}</td>
+            <td>{$form.repetition_frequency_interval.html} &nbsp;<span id="repeats-every-text">hour(s)</span> {help id="id-repeats-every" entityType=$entityType file="CRM/Core/Form/RecurringEntity.hlp"}</td>
             </td>
           </tr>
           <tr class="crm-core-form-recurringentity-block-start_action_condition">
@@ -51,33 +51,33 @@
                 <label for="repeats_on">{$form.start_action_condition.label}: </label>
             </td>
             <td>
-                {$form.start_action_condition.html} {help id="id-repeats-on" file="CRM/Core/Form/RecurringEntity.hlp"}</td>
+                {$form.start_action_condition.html} {help id="id-repeats-on" entityType=$entityType file="CRM/Core/Form/RecurringEntity.hlp"}</td>
             </td>
           </tr>
           <tr class="crm-core-form-recurringentity-block-repeats_by">
             <td class="label">{$form.repeats_by.label}</td>
-            <td>{$form.repeats_by.1.html}&nbsp;&nbsp;{$form.limit_to.html} {help id="id-repeats-by-month" file="CRM/Core/Form/RecurringEntity.hlp"}
+            <td>{$form.repeats_by.1.html}&nbsp;&nbsp;{$form.limit_to.html} {help id="id-repeats-by-month" entityType=$entityType file="CRM/Core/Form/RecurringEntity.hlp"}
             </td>
           </tr>
           <tr class="crm-core-form-recurringentity-block-repeats_by">
             <td class="label"></td>
-            <td>{$form.repeats_by.2.html}&nbsp;&nbsp;{$form.entity_status_1.html}&nbsp;&nbsp;{$form.entity_status_2.html} {help id="id-repeats-by-week" file="CRM/Core/Form/RecurringEntity.hlp"}
+            <td>{$form.repeats_by.2.html}&nbsp;&nbsp;{$form.entity_status_1.html}&nbsp;&nbsp;{$form.entity_status_2.html} {help id="id-repeats-by-week" entityType=$entityType file="CRM/Core/Form/RecurringEntity.hlp"}
             </td>
           </tr>
           <tr class="crm-core-form-recurringentity-block-ends">
             <td class="label">{$form.ends.label}&nbsp;<span class="crm-marker" title="This field is required.">*</span></td>
-            <td>{$form.ends.1.html}&nbsp;{$form.start_action_offset.html}&nbsp;occurrences&nbsp;{help id="id-ends-after" file="CRM/Core/Form/RecurringEntity.hlp"}</td>
+            <td>{$form.ends.1.html}&nbsp;{$form.start_action_offset.html}&nbsp;occurrences&nbsp;{help id="id-ends-after" entityType=$entityType file="CRM/Core/Form/RecurringEntity.hlp"}</td>
           </tr>
           <tr class="crm-core-form-recurringentity-block-absolute_date">
               <td class="label"></td>
-              <td>{$form.ends.2.html}&nbsp;{include file="CRM/common/jcalendar.tpl" elementName=repeat_absolute_date} {help id="id-ends-on" file="CRM/Core/Form/RecurringEntity.hlp"}
+              <td>{$form.ends.2.html}&nbsp;{include file="CRM/common/jcalendar.tpl" elementName=repeat_absolute_date} {help id="id-ends-on" entityType=$entityType file="CRM/Core/Form/RecurringEntity.hlp"}
               </td>
           </tr>
           <tr class="crm-core-form-recurringentity-block-exclude_date">
               <td class="label">{$form.exclude_date.label}</td>
               <td>&nbsp;{include file="CRM/common/jcalendar.tpl" elementName=exclude_date}
                   &nbsp;{$form.add_to_exclude_list.html}&nbsp;{$form.remove_from_exclude_list.html}
-                  {$form.exclude_date_list.html} {help id="id-exclude-date" file="CRM/Core/Form/RecurringEntity.hlp"}
+                  {$form.exclude_date_list.html} {help id="id-exclude-date" entityType=$entityType file="CRM/Core/Form/RecurringEntity.hlp"}
               </td>
           </tr>
           <tr>

--- a/templates/CRM/Core/Form/RecurringEntity.tpl
+++ b/templates/CRM/Core/Form/RecurringEntity.tpl
@@ -25,7 +25,9 @@
 *}
 
 <div class="crm-block crm-form-block crm-core-form-recurringentity-block crm-accordion-wrapper" id="recurring-entity-block">
-    <div class="crm-accordion-header">Repeat Configuration</div>
+    <div class="crm-accordion-header">
+      Repeat {if $entityType}{$entityType}{/if}
+    </div>
     <div class="crm-accordion-body">
         <div class="crm-submit-buttons">
             {include file="CRM/common/formButtons.tpl" location="top"}

--- a/tests/phpunit/WebTest/Activity/AddRecurringActivityTest.php
+++ b/tests/phpunit/WebTest/Activity/AddRecurringActivityTest.php
@@ -25,82 +25,17 @@
 */
 
 /**
- * Description of RecurringEntityTest
+ * Description of AddRecurringActivityTest
  *
  * @author Priyanka
  */
 
 require_once 'CiviTest/CiviSeleniumTestCase.php';
 
-class WebTest_Core_BAO_RecurringEntityTest extends CiviSeleniumTestCase {
+class WebTest_Activity_AddRecurringActivityTest extends CiviSeleniumTestCase {
 
   protected function setUp() {
     parent::setUp();
-  }
-
-  function testRecurringEvent() {
-    $this->webtestLogin();
-
-    //Add repeat configuration for an event
-    $this->openCiviPage("event/manage/repeat", "reset=1&action=update&id=1", '_qf_Repeat_cancel-bottom');
-
-    $this->click('repetition_frequency_unit');
-    $this->select('repetition_frequency_unit', 'label=weekly');
-    $this->click('repetition_frequency_interval');
-    $this->select('repetition_frequency_interval', 'label=1');
-    $this->click('start_action_condition_monday');
-    $this->click('start_action_condition_tuesday');
-    $this->click('CIVICRM_QFID_1_ends');
-
-    $occurrences = rand(3, 5);
-    if (!$occurrences) {
-      $occurrences = 3;
-    }
-    $this->type('start_action_offset', $occurrences);
-    $this->webtestFillDate("exclude_date", "11/05/2015");
-    $this->click('add_to_exclude_list');
-    $this->webtestFillDate("exclude_date", "12/05/2015");
-    $this->click('add_to_exclude_list');
-    $this->click('_qf_Repeat_submit-bottom');
-    $this->waitForTextPresent('Based on your repeat configuration here is the list of dates, Do you wish to create recurring set of these dates?');
-    $this->click("xpath=//div[@class='ui-dialog-buttonset']/button/span[text()='Ok']");
-    $this->waitForAjaxContent();
-    $this->checkCRMAlert('Repeat Configuration has been saved');
-
-    //Check if assertions are correct
-    $count = $this->getXpathCount("xpath=//div[@id='event_status_id']/div[@class='crm-accordion-body']/div/table/tbody/tr");
-    $count = $count - 1;
-    $this->assertEquals($occurrences, $count);
-
-    //Lets go to find participant page and see our repetitive events there
-    $this->openCiviPage("event/manage", "reset=1");
-    $eventTitle = "Fall Fundraiser Dinner";
-    $this->type("title", $eventTitle);
-    $this->click("_qf_SearchEvent_refresh");
-    $this->assertTrue($this->isTextPresent("Recurring Event - (Child)"));
-    $this->assertTrue($this->isTextPresent("Recurring Event - (Parent)"));
-
-    //Update Mode Cascade Changes
-    $this->click('event-configure-1');
-    $this->waitForElementPresent("xpath=//span[@id='event-configure-1']/ul[@class='panel']/li/a[text()='Info and Settings']");
-    $this->click("xpath=//span[@id='event-configure-1']/ul[@class='panel']/li/a[text()='Info and Settings']");
-    $this->waitForElementPresent('_qf_EventInfo_cancel-bottom');
-    $this->type('title', 'CiviCon');
-    $this->click('_qf_EventInfo_upload_done-top');
-    $this->waitForElementPresent("xpath=//div[@class='ui-dialog-buttonset']/button/span[text()='Cancel']");
-    $this->click("xpath=//div[@id='recurring-dialog']/div[@class='show-block']/div[@class='recurring-dialog-inner-wrapper']/div[@class='recurring-dialog-inner-left']/button[text()='All the entities']");
-    $this->waitForAjaxContent();
-    $this->openCiviPage("event/manage", "reset=1");
-    $newEventTitle = "CiviCon";
-    $this->type("title", $newEventTitle);
-    $this->click("_qf_SearchEvent_refresh");
-    $this->waitForPageToLoad();
-    $countOfEvents = $this->getXpathCount("xpath=//div[@id='option11_wrapper']/table[@id='option11']/tbody/tr");
-    if ($countOfEvents) {
-      for ($i = 0; $i <= $countOfEvents; $i++) {
-        $this->verifyText("xpath=//div[@id='option11_wrapper']/table[@id='option11']/tbody/tr/td/a", 'CiviCon');
-      }
-    }
   }
 
   function testRecurringActivity() {

--- a/tests/phpunit/WebTest/Core/BAO/RecurringEntityTest.php
+++ b/tests/phpunit/WebTest/Core/BAO/RecurringEntityTest.php
@@ -42,7 +42,7 @@ class WebTest_Core_BAO_RecurringEntityTest extends CiviSeleniumTestCase {
     $this->webtestLogin();
 
     //Add repeat configuration for an event
-    $this->openCiviPage("event/manage/repeat", "reset=1&action=update&id=148", '_qf_Repeat_cancel-bottom');
+    $this->openCiviPage("event/manage/repeat", "reset=1&action=update&id=1", '_qf_Repeat_cancel-bottom');
 
     $this->click('repetition_frequency_unit');
     $this->select('repetition_frequency_unit', 'label=weekly');
@@ -57,9 +57,9 @@ class WebTest_Core_BAO_RecurringEntityTest extends CiviSeleniumTestCase {
       $occurrences = 3;
     }
     $this->type('start_action_offset', $occurrences);
-    $this->webtestFillDate("exclude_date", "05/12/2015");
+    $this->webtestFillDate("exclude_date", "11/05/2015");
     $this->click('add_to_exclude_list');
-    $this->webtestFillDate("exclude_date", "06/12/2015");
+    $this->webtestFillDate("exclude_date", "12/05/2015");
     $this->click('add_to_exclude_list');
     $this->click('_qf_Repeat_submit-bottom');
     $this->waitForTextPresent('Based on your repeat configuration here is the list of dates, Do you wish to create recurring set of these dates?');
@@ -75,6 +75,14 @@ class WebTest_Core_BAO_RecurringEntityTest extends CiviSeleniumTestCase {
     $count = $this->getXpathCount("xpath=//div[@id='event_status_id']/div[@class='crm-accordion-body']/div/table/tbody/tr");
     $count = $count - 1;
     $this->assertEquals($occurrences, $count);
+
+    //Lets go to find participant page and see our repetitive events there
+    $this->openCiviPage("event/manage", "reset=1");
+    $eventTitle = "Fall Fundraiser Dinner";
+    $this->type("title", $eventTitle);
+    $this->click("_qf_SearchEvent_refresh");
+    $this->assertTrue($this->isTextPresent("Recurring Event - (Child)"));
+    $this->assertTrue($this->isTextPresent("Recurring Event - (Parent)"));
   }
 
   function testRecurringActivity() {

--- a/tests/phpunit/WebTest/Core/BAO/RecurringEntityTest.php
+++ b/tests/phpunit/WebTest/Core/BAO/RecurringEntityTest.php
@@ -1,0 +1,166 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.5                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2014                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License along with this program; if not, contact CiviCRM LLC       |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*/
+
+/**
+ * Description of RecurringEntityTest
+ *
+ * @author Priyanka
+ */
+
+require_once 'CiviTest/CiviSeleniumTestCase.php';
+
+class WebTest_Core_BAO_RecurringEntityTest extends CiviSeleniumTestCase {
+
+  protected function setUp() {
+    parent::setUp();
+  }
+
+  function testRecurringEvent() {
+    $this->webtestLogin();
+
+    //Add repeat configuration for an event
+    $this->openCiviPage("event/manage/repeat", "reset=1&action=update&id=148", '_qf_Repeat_cancel-bottom');
+
+    $this->click('repetition_frequency_unit');
+    $this->select('repetition_frequency_unit', 'label=weekly');
+    $this->click('repetition_frequency_interval');
+    $this->select('repetition_frequency_interval', 'label=1');
+    $this->click('start_action_condition_monday');
+    $this->click('start_action_condition_tuesday');
+    $this->click('CIVICRM_QFID_1_ends');
+
+    $occurrences = rand(3, 5);
+    if (!$occurrences) {
+      $occurrences = 3;
+    }
+    $this->type('start_action_offset', $occurrences);
+    $this->webtestFillDate("exclude_date", "05/12/2015");
+    $this->click('add_to_exclude_list');
+    $this->webtestFillDate("exclude_date", "06/12/2015");
+    $this->click('add_to_exclude_list');
+    $this->click('_qf_Repeat_submit-bottom');
+    $this->waitForTextPresent('Based on your repeat configuration here is the list of dates, Do you wish to create recurring set of these dates?');
+    $this->click("xpath=//div[@class='ui-dialog-buttonset']/button/span[text()='Ok']");
+    $this->waitForAjaxContent();
+    $this->checkCRMAlert('Repeat Configuration has been saved');
+
+    //Check if assertions are correct
+    $this->assertEquals('week', $this->getSelectedValue('id=repetition_frequency_unit'));
+    $this->assertEquals('1', $this->getSelectedValue('id=repetition_frequency_interval'));
+    $this->assertChecked('start_action_condition_monday');
+    $this->assertChecked('start_action_condition_tuesday');
+    $count = $this->getXpathCount("xpath=//div[@id='event_status_id']/div[@class='crm-accordion-body']/div/table/tbody/tr");
+    $count = $count - 1;
+    $this->assertEquals($occurrences, $count);
+  }
+
+  function testRecurringActivity() {
+    $this->webtestLogin();
+
+    //Adding new contact
+    $contact1 = substr(sha1(rand()), 0, 7);
+    $this->webtestAddContact("$contact1", "Karan", $contact1 . "@exampleone.com");
+    $contact2 = substr(sha1(rand()), 0, 7);
+    $this->webtestAddContact("$contact2", "Jane", $contact2 . "@exampletwo.com");
+
+    //Lets create an activity and add repeat configuration
+    $this->openCiviPage("activity", "?reset=1&action=add&context=standalone", '_qf_Activity_cancel-bottom');
+    $this->select("activity_type_id", "value=1");
+
+    //Add a new contact
+    $this->click("xpath=//div[@id='s2id_target_contact_id']/ul/li/input");
+    $this->keyDown("xpath=//div[@id='s2id_target_contact_id']/ul/li/input", " ");
+    $this->type("xpath=//div[@id='s2id_target_contact_id']/ul/li/input", $contact1);
+    $this->typeKeys("xpath=//div[@id='s2id_target_contact_id']/ul/li/input", $contact1);
+
+    // ...waiting for drop down with results to show up...
+    $this->waitForElementPresent("xpath=//div[@class='select2-result-label']");
+
+    // ...need to use mouseDownAt on first result (which is a li element), click does not work
+    $this->clickAt("xpath=//div[@class='select2-result-label']");
+    $this->waitForText("xpath=//div[@id='s2id_target_contact_id']","$contact1");
+    $this->assertElementContainsText("xpath=//div[@id='s2id_target_contact_id']", "Karan, $contact1", 'Contact not found in line ' . __LINE__);
+
+
+    //Assigned To field
+    $this->click("xpath=//div[@id='s2id_assignee_contact_id']/ul/li/input");
+    $this->keyDown("xpath=//div[@id='s2id_assignee_contact_id']/ul/li/input", " ");
+    $this->type("xpath=//div[@id='s2id_assignee_contact_id']/ul/li/input", $contact2);
+    $this->typeKeys("xpath=//div[@id='s2id_assignee_contact_id']/ul/li/input", $contact2);
+
+    // ...waiting for drop down with results to show up...
+    $this->waitForElementPresent("xpath=//div[@class='select2-result-label']");
+
+    //..need to use mouseDownAt on first result (which is a li element), click does not work
+    $this->clickAt("xpath=//div[@class='select2-result-label']");
+
+    // ...again, waiting for the box with contact name to show up...
+    $this->waitForText("xpath=//div[@id='s2id_assignee_contact_id']","$contact2");
+
+    // ...and verifying if the page contains properly formatted display name for chosen contact.
+    $this->assertElementContainsText("xpath=//div[@id='s2id_assignee_contact_id']", "Jane, $contact2", 'Contact not found in line ' . __LINE__);
+
+    $subject = "Test activity recursion";
+    $this->type("subject", $subject);
+    $this->type("duration", "30");
+
+    //Lets configure recursion for activity
+    $this->click("css=.crm-activity-form-block-recurring_activity div.crm-accordion-header");
+    $this->click('repetition_frequency_unit');
+    $this->select('repetition_frequency_unit', 'label=monthly');
+    $this->click('repetition_frequency_interval');
+    $this->select('repetition_frequency_interval', 'label=1');
+    $this->click('CIVICRM_QFID_1_repeats_by');
+    $this->click('limit_to');
+    $this->select('limit_to', 'label=26');
+    $this->click('CIVICRM_QFID_1_ends');
+
+    $occurrences = rand(3, 5);
+    if (!$occurrences) {
+      $occurrences = 3;
+    }
+    $this->type('start_action_offset', $occurrences);
+    $this->click('_qf_Activity_upload-bottom');
+    $this->waitForTextPresent('Based on your repeat configuration here is the list of dates, Do you wish to create recurring set of these dates?');
+    $this->click("xpath=//div[@class='ui-dialog-buttonset']/button/span[text()='Ok']");
+    $this->waitForPageToLoad();
+
+    //Lets go to search screen and see if the records new activities are created()
+    $this->openCiviPage("activity/search", "?reset=1", '_qf_Search_refresh');
+    $search_subject = 'Test activity recursion';
+    $this->type('activity_subject', $search_subject);
+    $this->click('_qf_Search_refresh');
+    $this->waitForPageToLoad();
+
+    //Minus tr having th and parent activity
+    $countOfActivities = $this->getXpathCount("//div[@class='crm-search-results']/table/tbody/tr");
+    $countOfActivities = $countOfActivities - 2;
+    $this->assertEquals($occurrences, $countOfActivities);
+    $this->assertTrue($this->isTextPresent("Recurring Activity - (Child)"));
+    $this->assertTrue($this->isTextPresent("Recurring Activity - (Parent)"));
+  }
+
+}

--- a/tests/phpunit/WebTest/Core/BAO/RecurringEntityTest.php
+++ b/tests/phpunit/WebTest/Core/BAO/RecurringEntityTest.php
@@ -68,10 +68,6 @@ class WebTest_Core_BAO_RecurringEntityTest extends CiviSeleniumTestCase {
     $this->checkCRMAlert('Repeat Configuration has been saved');
 
     //Check if assertions are correct
-    $this->assertEquals('week', $this->getSelectedValue('id=repetition_frequency_unit'));
-    $this->assertEquals('1', $this->getSelectedValue('id=repetition_frequency_interval'));
-    $this->assertChecked('start_action_condition_monday');
-    $this->assertChecked('start_action_condition_tuesday');
     $count = $this->getXpathCount("xpath=//div[@id='event_status_id']/div[@class='crm-accordion-body']/div/table/tbody/tr");
     $count = $count - 1;
     $this->assertEquals($occurrences, $count);
@@ -83,6 +79,28 @@ class WebTest_Core_BAO_RecurringEntityTest extends CiviSeleniumTestCase {
     $this->click("_qf_SearchEvent_refresh");
     $this->assertTrue($this->isTextPresent("Recurring Event - (Child)"));
     $this->assertTrue($this->isTextPresent("Recurring Event - (Parent)"));
+
+    //Update Mode Cascade Changes
+    $this->click('event-configure-1');
+    $this->waitForElementPresent("xpath=//span[@id='event-configure-1']/ul[@class='panel']/li/a[text()='Info and Settings']");
+    $this->click("xpath=//span[@id='event-configure-1']/ul[@class='panel']/li/a[text()='Info and Settings']");
+    $this->waitForElementPresent('_qf_EventInfo_cancel-bottom');
+    $this->type('title', 'CiviCon');
+    $this->click('_qf_EventInfo_upload_done-top');
+    $this->waitForElementPresent("xpath=//div[@class='ui-dialog-buttonset']/button/span[text()='Cancel']");
+    $this->click("xpath=//div[@id='recurring-dialog']/div[@class='show-block']/div[@class='recurring-dialog-inner-wrapper']/div[@class='recurring-dialog-inner-left']/button[text()='All the entities']");
+    $this->waitForAjaxContent();
+    $this->openCiviPage("event/manage", "reset=1");
+    $newEventTitle = "CiviCon";
+    $this->type("title", $newEventTitle);
+    $this->click("_qf_SearchEvent_refresh");
+    $this->waitForPageToLoad();
+    $countOfEvents = $this->getXpathCount("xpath=//div[@id='option11_wrapper']/table[@id='option11']/tbody/tr");
+    if ($countOfEvents) {
+      for ($i = 0; $i <= $countOfEvents; $i++) {
+        $this->verifyText("xpath=//div[@id='option11_wrapper']/table[@id='option11']/tbody/tr/td/a", 'CiviCon');
+      }
+    }
   }
 
   function testRecurringActivity() {
@@ -169,6 +187,24 @@ class WebTest_Core_BAO_RecurringEntityTest extends CiviSeleniumTestCase {
     $this->assertEquals($occurrences, $countOfActivities);
     $this->assertTrue($this->isTextPresent("Recurring Activity - (Child)"));
     $this->assertTrue($this->isTextPresent("Recurring Activity - (Parent)"));
+
+    //Cascade changes
+    $this->click("xpath=//div[@class='crm-search-results']/table/tbody/tr[2]/td/span/a[text()='Edit']");
+    $this->waitForElementPresent("xpath=//div[@class='ui-dialog-buttonset']/button/span[text()='Cancel']");
+    $this->type('subject', 'Test activity recursion modified');
+    $this->click("xpath=//div[@class='ui-dialog-buttonset']/button/span[text()='Save']");
+    $this->waitForElementPresent("xpath=//div[@class='ui-dialog-buttonset']/button/span[text()='Cancel']");
+    $this->click("xpath=//div[@id='recurring-dialog']/div[@class='show-block']/div[@class='recurring-dialog-inner-wrapper']/div[@class='recurring-dialog-inner-left']/button[text()='This and Following entities']");
+    $this->waitForAjaxContent();
+    $this->type('activity_subject', 'Test activity recursion modified');
+    $this->click('_qf_Search_refresh');
+    $this->waitForPageToLoad();
+    $countOfActivities = $this->getXpathCount("xpath=//div[@class='crm-search-results']/table/tbody/tr");
+    if ($countOfActivities) {
+      for ($i = 0; $i <= $countOfActivities; $i++) {
+        $this->verifyText("xpath=//div[@class='crm-search-results']/table/tbody/tr/td[3]", 'Test activity recursion modified');
+      }
+    }
   }
 
 }

--- a/tests/phpunit/WebTest/Event/AddRecurringEventTest.php
+++ b/tests/phpunit/WebTest/Event/AddRecurringEventTest.php
@@ -1,0 +1,106 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.5                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2014                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License along with this program; if not, contact CiviCRM LLC       |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*/
+
+/**
+ * Description of AddRecurringEventTest
+ *
+ * @author Priyanka
+ */
+
+require_once 'CiviTest/CiviSeleniumTestCase.php';
+
+class WebTest_Event_AddRecurringEventTest extends CiviSeleniumTestCase {
+
+  protected function setUp() {
+    parent::setUp();
+  }
+
+  function testRecurringEvent() {
+    $this->webtestLogin();
+
+    //Add repeat configuration for an event
+    $this->openCiviPage("event/manage/repeat", "reset=1&action=update&id=1", '_qf_Repeat_cancel-bottom');
+
+    $this->click('repetition_frequency_unit');
+    $this->select('repetition_frequency_unit', 'label=weekly');
+    $this->click('repetition_frequency_interval');
+    $this->select('repetition_frequency_interval', 'label=1');
+    $this->click('start_action_condition_monday');
+    $this->click('start_action_condition_tuesday');
+    $this->click('CIVICRM_QFID_1_ends');
+
+    $occurrences = rand(3, 5);
+    if (!$occurrences) {
+      $occurrences = 3;
+    }
+    $this->type('start_action_offset', $occurrences);
+    $this->webtestFillDate("exclude_date", "11/05/2015");
+    $this->click('add_to_exclude_list');
+    $this->webtestFillDate("exclude_date", "12/05/2015");
+    $this->click('add_to_exclude_list');
+    $this->click('_qf_Repeat_submit-bottom');
+    $this->waitForTextPresent('Based on your repeat configuration here is the list of dates, Do you wish to create recurring set of these dates?');
+    $this->click("xpath=//div[@class='ui-dialog-buttonset']/button/span[text()='Ok']");
+    $this->waitForAjaxContent();
+    $this->checkCRMAlert('Repeat Configuration has been saved');
+
+    //Check if assertions are correct
+    $count = $this->getXpathCount("xpath=//div[@id='event_status_id']/div[@class='crm-accordion-body']/div/table/tbody/tr");
+    $count = $count - 1;
+    $this->assertEquals($occurrences, $count);
+
+    //Lets go to find participant page and see our repetitive events there
+    $this->openCiviPage("event/manage", "reset=1");
+    $eventTitle = "Fall Fundraiser Dinner";
+    $this->type("title", $eventTitle);
+    $this->click("_qf_SearchEvent_refresh");
+    $this->assertTrue($this->isTextPresent("Recurring Event - (Child)"));
+    $this->assertTrue($this->isTextPresent("Recurring Event - (Parent)"));
+
+    //Update Mode Cascade Changes
+    $this->click('event-configure-1');
+    $this->waitForElementPresent("xpath=//span[@id='event-configure-1']/ul[@class='panel']/li/a[text()='Info and Settings']");
+    $this->click("xpath=//span[@id='event-configure-1']/ul[@class='panel']/li/a[text()='Info and Settings']");
+    $this->waitForElementPresent('_qf_EventInfo_cancel-bottom');
+    $this->type('title', 'CiviCon');
+    $this->click('_qf_EventInfo_upload_done-top');
+    $this->waitForElementPresent("xpath=//div[@class='ui-dialog-buttonset']/button/span[text()='Cancel']");
+    $this->click("xpath=//div[@id='recurring-dialog']/div[@class='show-block']/div[@class='recurring-dialog-inner-wrapper']/div[@class='recurring-dialog-inner-left']/button[text()='All the entities']");
+    $this->waitForAjaxContent();
+    $this->openCiviPage("event/manage", "reset=1");
+    $newEventTitle = "CiviCon";
+    $this->type("title", $newEventTitle);
+    $this->click("_qf_SearchEvent_refresh");
+    $this->waitForPageToLoad();
+    $countOfEvents = $this->getXpathCount("xpath=//div[@id='option11_wrapper']/table[@id='option11']/tbody/tr");
+    if ($countOfEvents) {
+      for ($i = 0; $i <= $countOfEvents; $i++) {
+        $this->verifyText("xpath=//div[@id='option11_wrapper']/table[@id='option11']/tbody/tr/td/a", 'CiviCon');
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
https://issues.civicrm.org/jira/browse/CRM-15256 :  
Points 1 & 2 is fixed. Point 3 is something not supported by recurring entity. Datetime column if used with propagation algorithm, would just copy over the same dates.
However there is a workaround, we can modify recurring configuration, which should re-generate the set considering the new datetime.
Agree that propagation confirmation box just for date/time updates could be misleading. We could probably notify this to user some way?

https://issues.civicrm.org/jira/browse/CRM-15490 :  
1, 3, improvements are done. Also added some webtests (4). 
