### PR TITLE
Crm 15622

### DIFF
--- a/CRM/Case/Form/Activity.php
+++ b/CRM/Case/Form/Activity.php
@@ -318,7 +318,7 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
     $this->add('select', 'medium_id', ts('Medium'), $encounterMediums, TRUE);
     $i = 0;
     foreach ($this->_caseId as $key => $val) {
-      $this->_relatedContacts[] = CRM_Case_BAO_Case::getRelatedAndGlobalContacts($val);
+      $this->_relatedContacts[] = $rgc = CRM_Case_BAO_Case::getRelatedAndGlobalContacts($val);
       $contName = CRM_Case_BAO_Case::getContactNames($val);
       foreach ($contName as $nkey => $nval) {
         array_push($this->_relatedContacts[$i][0] , $this->_relatedContacts[$i][0]['managerOf']= $nval['display_name']);
@@ -328,7 +328,7 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
 
     //add case client in send a copy selector.CRM-4438.
     foreach ($this->_caseId as $key => $val) {
-      $relatedContacts[] = CRM_Case_BAO_Case::getContactNames($val);
+      $relatedContacts[] = $relCon= CRM_Case_BAO_Case::getContactNames($val);
     }
 
     if (!empty($relatedContacts)) {
@@ -349,6 +349,7 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
       );
       $this->assign('searchRows', $this->_relatedContacts);
     }
+    $this->_relatedContacts = $rgc + $relCon;
 
     $this->addFormRule(array('CRM_Case_Form_Activity', 'formRule'), $this);
   }

--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -210,15 +210,31 @@ class CRM_Core_Resources {
   }
 
   /**
-   * Add JavaScript variables to the global CRM object.
+   * Add JavaScript variables to CRM.vars
    *
    * Example:
    * From the server:
-   * CRM_Core_Resources::singleton()->addSetting(array('myNamespace' => array('foo' => 'bar')));
-   * From javascript:
-   * CRM.myNamespace.foo // "bar"
+   * CRM_Core_Resources::singleton()->addVars('myNamespace', array('foo' => 'bar'));
+   * Access var from javascript:
+   * CRM.vars.myNamespace.foo // "bar"
    *
    * @see http://wiki.civicrm.org/confluence/display/CRMDOC/Javascript+Reference
+   *
+   * @param string $nameSpace - usually the name of your extension
+   * @param array $vars
+   * @return CRM_Core_Resources
+   */
+  public function addVars($nameSpace, $vars) {
+    $existing = CRM_Utils_Array::value($nameSpace, CRM_Utils_Array::value('vars', $this->settings), array());
+    $vars = $this->mergeSettings($existing, $vars);
+    $this->addSetting(array('vars' => array($nameSpace => $vars)));
+    return $this;
+  }
+
+  /**
+   * Add JavaScript variables to the root of the CRM object.
+   * This function is usually reserved for low-level system use.
+   * Extensions and components should generally use addVars instead.
    *
    * @param $settings array
    * @return CRM_Core_Resources

--- a/CRM/Event/Form/ManageEvent/Registration.php
+++ b/CRM/Event/Form/ManageEvent/Registration.php
@@ -376,8 +376,7 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
       'profileEntities' => array(),
     );
 
-    $configs['allowCoreTypes'][] = 'Contact';
-    $configs['allowCoreTypes'][] = 'Individual';
+    $configs['allowCoreTypes'] = array_merge(array('Contact', 'Individual'), CRM_Contact_BAO_ContactType::subTypes('Individual'));
     $configs['allowCoreTypes'][] = 'Participant';
     //CRM-15427
     $id = CRM_Utils_Request::retrieve( 'id' , 'Integer' );

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1248,6 +1248,8 @@ class CRM_Event_Form_Participant extends CRM_Contact_Form_Task {
 
       $payment = CRM_Core_Payment::singleton($this->_mode, $this->_paymentProcessor, $this);
 
+      // CRM-15622: fix for incorrect contribution.fee_amount
+      $paymentParams['fee_amount'] = NULL;
       $result = $payment->doDirectPayment($paymentParams);
 
       if (is_a($result, 'CRM_Core_Error')) {

--- a/CRM/UF/Page/ProfileEditor.php
+++ b/CRM/UF/Page/ProfileEditor.php
@@ -31,6 +31,7 @@ class CRM_UF_Page_ProfileEditor extends CRM_Core_Page {
             'is_active' => 1,
             'rowCount' => 1000, // FIXME
           )),
+          'contactSubTypes' => CRM_Contact_BAO_ContactType::subTypes(),
           'profilePreviewKey' => CRM_Core_Key::get('CRM_UF_Form_Inline_Preview', TRUE),
         );
       })
@@ -195,7 +196,9 @@ class CRM_UF_Page_ProfileEditor extends CRM_Core_Page {
         case 'Individual':
         case 'Organization':
         case 'Household':
-          if ($field['field_type'] != $extends && $field['field_type'] != 'Contact') {
+          if ($field['field_type'] != $extends && $field['field_type'] != 'Contact'
+            //CRM-15595 check if subtype
+            && !in_array($field['field_type'], CRM_Contact_BAO_ContactType::subTypes($extends))) {
             continue 2;
           }
           break;

--- a/js/jquery/jquery.crmProfileSelector.js
+++ b/js/jquery/jquery.crmProfileSelector.js
@@ -61,12 +61,7 @@
         else {
           civiComponent = 'Contribution';
         }
-        CRM.alert(
-          ts('The selected profile is using a custom field which is not assigned to the "%1" being configured.', {
-            1: civiComponent
-          }),
-          ts('Warning')
-        );
+        CRM.alert(ts('The selected profile is using a custom field which is not assigned to the "%1" being configured.', {1: civiComponent}), ts('Warning'));
       }
       var view = new CRM.ProfileSelector.View({
         ufGroupId: $select.val(),

--- a/js/jquery/jquery.crmProfileSelector.js
+++ b/js/jquery/jquery.crmProfileSelector.js
@@ -61,7 +61,12 @@
         else {
           civiComponent = 'Contribution';
         }
-        CRM.alert(ts('The selected profile is using a custom field which is not assigned to the '+civiComponent+' being configured.'),ts('Warning'));
+        CRM.alert(
+          ts('The selected profile is using a custom field which is not assigned to the "%1" being configured.', {
+            1: civiComponent
+          }),
+          ts('Warning')
+        );
       }
       var view = new CRM.ProfileSelector.View({
         ufGroupId: $select.val(),

--- a/js/model/crm.uf.js
+++ b/js/model/crm.uf.js
@@ -104,8 +104,7 @@
       case 'Case':
         return 'case_1';
       default:
-        if (!$.isEmptyObject(CRM.contactSubTypes) &&
-        ($.inArray(field_type,CRM.contactSubTypes) > -1)) {
+        if (!$.isEmptyObject(CRM.contactSubTypes) && ($.inArray(field_type,CRM.contactSubTypes) > -1)) {
           return 'contact_1';
         }
         else {

--- a/js/model/crm.uf.js
+++ b/js/model/crm.uf.js
@@ -104,7 +104,13 @@
       case 'Case':
         return 'case_1';
       default:
-        throw "Cannot guess entity name for field_type=" + field_type;
+        if (!$.isEmptyObject(CRM.contactSubTypes) &&
+        ($.inArray(field_type,CRM.contactSubTypes) > -1)) {
+          return 'contact_1';
+        }
+        else {
+          throw "Cannot guess entity name for field_type=" + field_type;
+        }
     }
   }
 

--- a/tests/phpunit/CRM/Core/ResourcesTest.php
+++ b/tests/phpunit/CRM/Core/ResourcesTest.php
@@ -127,6 +127,17 @@ class CRM_Core_ResourcesTest extends CiviUnitTestCase {
     $this->assertEquals($expected, $actual);
   }
 
+  function testAddVars() {
+    $this->res
+      ->addVars('food', array('fruit' => array('mine' => 'apple', 'ours' => 'banana')))
+      ->addVars('food', array('fruit' => array('mine' => 'new apple', 'yours' => 'orange')))
+    ;
+    $this->assertTreeEquals(
+      array('vars' => array('food' => array('fruit' => array('yours' => 'orange', 'mine' => 'new apple', 'ours' => 'banana')))),
+      $this->res->getSettings()
+    );
+  }
+
   function testAddSetting() {
     $this->res
       ->addSetting(array('fruit' => array('mine' => 'apple')))


### PR DESCRIPTION
CRM-15622: Fix for incorrect Fee Amount.

```
There's a bunch of fee_amount fields in this section of the code leading
to a lot of confusion (see CRM-15372). Many of the payment processors set
the fee_amount field in the result array they return which sets up the
contribution.fee_amount field, but the Authorize.Net AIM API doesn't
return fee information, so Authorize.Net doesn't set this field. Instead
of setting this field to 0 there, I thought it would be better to not
require that the payment processor set this field. Since some of the
payment processors return the same array that was passed into them and the
payment processors don't need the fee_amount field as an argument, I think
that setting that to NULL before passing it in gets us the correct output.

Note that we still need the fix from CRM-15372 to get the
participant.fee_amount field set correctly because the code that sets up
the pariticpant shares the field array that the contribution creation
uses even though they don't have the same 'fee_amount' field.
```
