### PR TITLE
CRM-15622: Fix for incorrect Fee Amount.

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1248,6 +1248,8 @@ class CRM_Event_Form_Participant extends CRM_Contact_Form_Task {
 
       $payment = CRM_Core_Payment::singleton($this->_mode, $this->_paymentProcessor, $this);
 
+      // CRM-15622: fix for incorrect contribution.fee_amount
+      $paymentParams['fee_amount'] = NULL;
       $result = $payment->doDirectPayment($paymentParams);
 
       if (is_a($result, 'CRM_Core_Error')) {


### PR DESCRIPTION
There's a bunch of fee_amount fields in this section of the code leading
to a lot of confusion (see CRM-15372). Many of the payment processors set
the fee_amount field in the result array they return which sets up the
contribution.fee_amount field, but the Authorize.Net AIM API doesn't
return fee information, so Authorize.Net doesn't set this field. Instead
of setting this field to 0 there, I thought it would be better to not
require that the payment processor set this field. Since some of the
payment processors return the same array that was passed into them and the
payment processors don't need the fee_amount field as an argument, I think
that setting that to NULL before passing it in gets us the correct output.

Note that we still need the fix from CRM-15372 to get the
participant.fee_amount field set correctly because the code that sets up
the pariticpant shares the field array that the contribution creation
uses even though they don't have the same 'fee_amount' field.
