### PR TITLE
added contribution table in query from clause for contribution note

### DIFF
--- a/CRM/Contribute/BAO/Query.php
+++ b/CRM/Contribute/BAO/Query.php
@@ -95,6 +95,7 @@ class CRM_Contribute_BAO_Query {
       $query->_select['contribution_note'] = "civicrm_note.note as contribution_note";
       $query->_element['contribution_note'] = 1;
       $query->_tables['contribution_note'] = 1;
+      $query->_tables['civicrm_contribution'] = 1;
     }
 
     if (CRM_Utils_Array::value('contribution_batch', $query->_returnProperties)) {


### PR DESCRIPTION
This fixes the issue:
-  when you had a contribution note in a profile with no other contribution fields
- then there is a database error when the user is moved from confirm screen to thank you screen
- this is because there is a missing join table in the SELECT query
