### PR TITLE
CRM-15636: API Unit test: price set for events and contributions.

### DIFF
--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -67,7 +67,7 @@ class CRM_Price_BAO_PriceSet extends CRM_Price_DAO_PriceSet {
     if(empty($params['id']) && empty($params['name'])) {
       $params['name'] = CRM_Utils_String::munge($params['title'], '_', 242);
     }
-    if (!empty($params['extends'])) {
+    if (!empty($params['extends']) && is_array($params['extends'])) {
       $params['extends'] = CRM_Utils_Array::implodePadded($params['extends']);
     }
     $priceSetBAO = new CRM_Price_BAO_PriceSet();

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -67,6 +67,9 @@ class CRM_Price_BAO_PriceSet extends CRM_Price_DAO_PriceSet {
     if(empty($params['id']) && empty($params['name'])) {
       $params['name'] = CRM_Utils_String::munge($params['title'], '_', 242);
     }
+    if (!empty($params['extends'])) {
+      $params['extends'] = CRM_Utils_Array::implodePadded($params['extends']);
+    }
     $priceSetBAO = new CRM_Price_BAO_PriceSet();
     $priceSetBAO->copyValues($params);
     if (self::eventPriceSetDomainID()) {

--- a/tests/phpunit/api/v3/PriceSetTest.php
+++ b/tests/phpunit/api/v3/PriceSetTest.php
@@ -69,6 +69,29 @@ class api_v3_PriceSetTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test for creating price sets used for both events and contributions.
+   */
+  public function testCreatePriceSetForEventAndContribution() {
+    // Create the price set
+    $createParams = array(
+      'name' => 'some_price_set',
+      'title' => 'Some Price Set',
+      'is_active' => 1,
+      'financial_type_id' => 1,
+      'extends' => array(1,2),
+    );
+    $createResult = $this->callAPIAndDocument($this->_entity, 'create', $createParams, __FUNCTION__, __FILE__);
+
+    // Get priceset we just created.
+    $result = $this->callAPISuccess($this->_entity, 'getSingle', array(
+      'id' => $createResult['id'],
+    ));
+
+    // Count the number of items in 'extends'.
+    $this->assertEquals(2, count($result['extends']));
+  }
+
+  /**
    * Check that no name doesn't cause failure
    */
   public function testCreatePriceSetNoName() {


### PR DESCRIPTION
## This pull request now contains a unit test and a patch.
- CRM-15636: Using the API to create a price set for both events and contributions.
  https://issues.civicrm.org/jira/browse/CRM-15636
