### PR TITLE
Allow falsy values as custom field db defaults

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1865,7 +1865,7 @@ SELECT $columnName
       $params['fk_field_name'] = 'id';
       $params['fk_attributes'] = 'ON DELETE SET NULL';
     }
-    if ($field->default_value) {
+    if (isset($field->default_value)) {
       $params['default'] = "'{$field->default_value}'";
     }
 


### PR DESCRIPTION
Use if isset($field->default_value) instead of just
if ($field->default_value) so we can set a custom field database
column's default to zero.
