### PR TITLE
Correctly display the API Entity and Action in the Job Log.

### DIFF
--- a/CRM/Core/JobManager.php
+++ b/CRM/Core/JobManager.php
@@ -243,7 +243,7 @@ class CRM_Core_JobManager {
     if ($this->currentJob) {
       $dao->job_id  = $this->currentJob->id;
       $dao->name    = $this->currentJob->name;
-      $dao->command = ts("Entity:") . " " + $this->currentJob->api_entity + " " . ts("Action:") . " " + $this->currentJob->api_action;
+      $dao->command = ts("Entity:") . " " . $this->currentJob->api_entity . " " . ts("Action:") . " " . $this->currentJob->api_action;
       $data         = "";
       if (!empty($this->currentJob->parameters)) {
         $data .= "\n\nParameters raw (from db settings): \n" . $this->currentJob->parameters;


### PR DESCRIPTION
The scheduled jobs log was setting the command for every job entry to 0
because of a string concatenation bug. This commit corrects that bug so API
Entity and Action is now correctly shown.
