### PR TITLE
CRM-15674 - A fix for the content type of json API results.

### DIFF
--- a/CRM/Utils/REST.php
+++ b/CRM/Utils/REST.php
@@ -146,7 +146,7 @@ class CRM_Utils_REST {
     }
 
     if (CRM_Utils_Array::value('json', $requestParams)) {
-      header('Content-Type: text/javascript');
+      header('Content-Type: application/json');
       $json = json_encode(array_merge($result));
       if (CRM_Utils_Array::value('prettyprint', $requestParams)) {
         return self::jsonFormated($json);


### PR DESCRIPTION
---
- CRM-15674: Content type for json results should be application/json
  https://issues.civicrm.org/jira/browse/CRM-15674
