### PR TITLE
CRM-15550 test + test error fix

### DIFF
--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -1233,8 +1233,8 @@ LEFT JOIN {$reminderJoinClause}
 {$whereClause} {$limitWhereClause} AND {$dateClause} {$notINClause}
 ";
       CRM_Core_DAO::executeQuery($query, array(1 => array($actionSchedule->id, 'Integer')));
-
-      if (!is_null($limitTo) && $limitTo == 0 && (!empty($addGroup) || !empty($addWhere))) {
+      $isSendToAdditionalContacts = (!is_null($limitTo) && $limitTo == 0 && (!empty($addGroup) || !empty($addWhere))) ? TRUE : FALSE;
+      if ($isSendToAdditionalContacts) {
         $additionWhere = ' WHERE ';
         if ($actionSchedule->start_action_date) {
           $additionWhere = $whereClause . ' AND ';
@@ -1322,7 +1322,7 @@ INNER JOIN {$reminderJoinClause}
           CRM_Core_DAO::executeQuery($query, array(1 => array($actionSchedule->id, 'Integer')));
         }
 
-        if (!is_null($limitTo) && $limitTo == 0) {
+        if ($isSendToAdditionalContacts) {
           $addSelect .= ', MAX(reminder.action_date_time) as latest_log_time';
           $sqlEndEventCheck = "
 SELECT * FROM {$table}

--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -1235,10 +1235,6 @@ LEFT JOIN {$reminderJoinClause}
       CRM_Core_DAO::executeQuery($query, array(1 => array($actionSchedule->id, 'Integer')));
       $isSendToAdditionalContacts = (!is_null($limitTo) && $limitTo == 0 && (!empty($addGroup) || !empty($addWhere))) ? TRUE : FALSE;
       if ($isSendToAdditionalContacts) {
-        $additionWhere = ' WHERE ';
-        if ($actionSchedule->start_action_date) {
-          $additionWhere = $whereClause . ' AND ';
-        }
         $contactTable = "civicrm_contact c";
         $addSelect  = "SELECT c.id as contact_id, c.id as entity_id, 'civicrm_contact' as entity_table, {$actionSchedule->id} as action_schedule_id";
         $additionReminderClause = "civicrm_action_log reminder ON reminder.contact_id = c.id AND

--- a/tests/phpunit/CRM/Core/BAO/ActionScheduleTest.php
+++ b/tests/phpunit/CRM/Core/BAO/ActionScheduleTest.php
@@ -393,8 +393,36 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
       'start_action_unit' => 'month',
       'subject' => 'subject sched_membership_end_2month',
     );
-
-
+    $this->fixtures['sched_membership_end_limit_to_none'] = array( // create()
+      'name' => 'limit to none',
+      'title' => 'limit to none',
+      'absolute_date' => '',
+      'body_html' => '<p>body sched_membership_end_2month</p>',
+      'body_text' => 'body sched_membership_end_2month',
+      'end_action' => '',
+      'end_date' => '',
+      'end_frequency_interval' => '4',
+      'end_frequency_unit' => 'month',
+      'entity_status' => '',
+      'entity_value' => '',
+      'limit_to' => 0,
+      'group_id' => '',
+      'is_active' => 1,
+      'is_repeat' => '1',
+      'mapping_id' => 4,
+      'msg_template_id' => '',
+      'recipient' => '',
+      'recipient_listing' => '',
+      'recipient_manual' => '',
+      'record_activity' => 1,
+      'repetition_frequency_interval' => '4',
+      'repetition_frequency_unit' => 'week',
+      'start_action_condition' => 'after',
+      'start_action_date' => 'membership_end_date',
+      'start_action_offset' => '2',
+      'start_action_unit' => 'month',
+      'subject' => 'limit to none',
+    );
     $this->_setUp();
   }
 
@@ -754,6 +782,39 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
     ));
     $this->callAPISuccess('custom_group', 'delete', array('id' => $createGroup['id'],));
   }
+  /**
+   * Check that limit_to + an empty recipients doesn't sent to multiple contacts
+   */
+  function testMembershipLimitToNone() {
+    // creates membership with end_date = 20120615
+    $membership = $this->createTestObject('CRM_Member_DAO_Membership', array_merge($this->fixtures['rolling_membership'], array('status_id' => 2)));
+
+    $this->assertTrue(is_numeric($membership->id));
+    $result = $this->callAPISuccess('Email', 'create', array(
+      'contact_id' => $membership->contact_id,
+      'email' => 'member@example.com',
+    ));
+    $this->callAPISuccess('contact', 'create', array_merge($this->fixtures['contact'], array('contact_id' => $membership->contact_id)));
+    $this->callAPISuccess('contact', 'create', array('email' => 'b@c.com', 'contact_type' => 'Individual'));
+
+    $this->assertAPISuccess($result);
+
+    $actionSchedule = $this->fixtures['sched_membership_end_limit_to_none'];
+    $actionSchedule['entity_value'] = $membership->membership_type_id;
+    $actionScheduleDao = CRM_Core_BAO_ActionSchedule::add($actionSchedule);
+    $this->assertTrue(is_numeric($actionScheduleDao->id));
+
+    // end_date=2012-06-15 ; schedule is 2 weeks before end_date
+    $this->assertCronRuns(array(
+      array( // Before the 2-week mark, no email
+        'time' => '2012-05-31 01:00:00',
+        // 'time' => '2012-06-01 01:00:00', // FIXME: Is this the right boundary?
+        'recipients' => array(),
+      ),
+    ));
+  }
+
+
 
   function testContactCustomDate_Anniv() {
     $group = array(

--- a/tests/phpunit/CRM/Core/BAO/ActionScheduleTest.php
+++ b/tests/phpunit/CRM/Core/BAO/ActionScheduleTest.php
@@ -88,13 +88,11 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
       'is_deleted' => 0,
     );
     $this->fixtures['contact'] = array( // API
-      'version' => 3,
       'is_deceased' => 0,
       'contact_type' => 'Individual',
       'email' => 'test-member@example.com',
     );
     $this->fixtures['contact_birthdate'] = array( // API
-      'version' => 3,
       'is_deceased' => 0,
       'contact_type' => 'Individual',
       'email' => 'test-bday@example.com',
@@ -422,7 +420,7 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
 
     $activity = $this->createTestObject('CRM_Activity_DAO_Activity', $this->fixtures['phonecall']);
     $this->assertTrue(is_numeric($activity->id));
-    $contact = civicrm_api('contact', 'create', $this->fixtures['contact']);
+    $contact =  $this->callAPISuccess('contact', 'create', $this->fixtures['contact']);
     $activity->save();
 
     $source['contact_id'] = $contact['id'];
@@ -453,7 +451,7 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
 
     $activity = $this->createTestObject('CRM_Activity_DAO_Activity', $this->fixtures['phonecall']);
     $this->assertTrue(is_numeric($activity->id));
-    $contact = civicrm_api('contact', 'create', $this->fixtures['contact']);
+    $contact =  $this->callAPISuccess('contact', 'create', $this->fixtures['contact']);
     $activity->save();
 
     $source['contact_id'] = $contact['id'];
@@ -495,15 +493,14 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
   function testMembershipJoinDate_Match() {
     $membership = $this->createTestObject('CRM_Member_DAO_Membership', array_merge($this->fixtures['rolling_membership'], array('status_id' => 1)));
     $this->assertTrue(is_numeric($membership->id));
-    $result = civicrm_api('Email', 'create', array(
+    $result = $this->callAPISuccess('Email', 'create', array(
       'contact_id' => $membership->contact_id,
       'email' => 'test-member@example.com',
       'location_type_id' => 1,
-      'version' => 3,
-    ));
+     ));
     $this->assertAPISuccess($result);
 
-    $contact = civicrm_api('contact', 'create', array_merge($this->fixtures['contact'], array('contact_id' => $membership->contact_id)));
+    $this->callAPISuccess('contact', 'create', array_merge($this->fixtures['contact'], array('contact_id' => $membership->contact_id)));
     $actionSchedule = $this->fixtures['sched_membership_join_2week'];
     $actionSchedule['entity_value'] = $membership->membership_type_id;
     $actionScheduleDao = CRM_Core_BAO_ActionSchedule::add($actionSchedule);
@@ -529,13 +526,11 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
   function testMembershipJoinDate_NonMatch() {
     $membership = $this->createTestObject('CRM_Member_DAO_Membership', $this->fixtures['rolling_membership']);
     $this->assertTrue(is_numeric($membership->id));
-    $result = civicrm_api('Email', 'create', array(
+    $result = $this->callAPISuccess('Email', 'create', array(
       'contact_id' => $membership->contact_id,
       'location_type_id' => 1,
       'email' => 'test-member@example.com',
-      'version' => 3,
     ));
-    $this->assertAPISuccess($result);
 
     // Add an alternative membership type, and only send messages for that type
     $extraMembershipType = $this->createTestObject('CRM_Member_DAO_MembershipType', array());
@@ -627,13 +622,11 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
     // creates membership with end_date = 20120615
     $membership = $this->createTestObject('CRM_Member_DAO_Membership', array_merge($this->fixtures['rolling_membership'], array('status_id' => 2)));
     $this->assertTrue(is_numeric($membership->id));
-    $result = civicrm_api('Email', 'create', array(
+    $this->callAPISuccess('Email', 'create', array(
       'contact_id' => $membership->contact_id,
       'email' => 'test-member@example.com',
-      'version' => 3,
-    ));
-    $contact = civicrm_api('contact', 'create', array_merge($this->fixtures['contact'], array('contact_id' => $membership->contact_id)));
-    $this->assertAPISuccess($result);
+     ));
+    $this->callAPISuccess('contact', 'create', array_merge($this->fixtures['contact'], array('contact_id' => $membership->contact_id)));
 
     $actionSchedule = $this->fixtures['sched_membership_end_2week'];
     $actionSchedule['entity_value'] = $membership->membership_type_id;
@@ -663,13 +656,11 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
     // creates membership with end_date = 20120615
     $membership = $this->createTestObject('CRM_Member_DAO_Membership', array_merge($this->fixtures['rolling_membership_past'], array('status_id' => 3)));
     $this->assertTrue(is_numeric($membership->id));
-    $result = civicrm_api('Email', 'create', array(
+    $result =  $this->callAPISuccess('Email', 'create', array(
       'contact_id' => $membership->contact_id,
       'email' => 'test-member@example.com',
-      'version' => 3,
     ));
-    $contact = civicrm_api('contact', 'create', array_merge($this->fixtures['contact'], array('contact_id' => $membership->contact_id)));
-    $this->assertAPISuccess($result);
+    $this->callAPISuccess('contact', 'create', array_merge($this->fixtures['contact'], array('contact_id' => $membership->contact_id)));
 
     $actionSchedule = $this->fixtures['sched_membership_end_2month'];
     $actionSchedule['entity_value'] = $membership->membership_type_id;
@@ -691,8 +682,7 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
   }
 
   function testContactBirthDate_noAnniv() {
-    $contact = civicrm_api('Contact', 'create', $this->fixtures['contact_birthdate']);
-    $this->assertAPISuccess($contact);
+    $contact = $this->callAPISuccess('Contact', 'create', $this->fixtures['contact_birthdate']);
     $this->_testObjects['CRM_Contact_DAO_Contact'][] = $contact['id'];
     $actionSchedule = $this->fixtures['sched_contact_bday_yesterday'];
     $actionScheduleDao = CRM_Core_BAO_ActionSchedule::add($actionSchedule);
@@ -710,8 +700,7 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
   }
 
   function testContactBirthDate_Anniv() {
-    $contact = civicrm_api('Contact', 'create', $this->fixtures['contact_birthdate']);
-    $this->assertAPISuccess($contact);
+    $contact =  $this->callAPISuccess('Contact', 'create', $this->fixtures['contact_birthdate']);
     $this->_testObjects['CRM_Contact_DAO_Contact'][] = $contact['id'];
     $actionSchedule = $this->fixtures['sched_contact_bday_anniv'];
     $actionScheduleDao = CRM_Core_BAO_ActionSchedule::add($actionSchedule);
@@ -736,23 +725,18 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
       'style' => 'Inline',
       'is_multiple' => false,
       'is_active' => 1,
-      'version' => 3,
     );
-    $createGroup = civicrm_api('custom_group', 'create', $group);
-    $this->assertAPISuccess($createGroup);
+    $createGroup = $this->callAPISuccess('custom_group', 'create', $group);
     $field = array(
-      'version' => 3,
       'label' => 'Graduation',
       'data_type' => 'Date',
       'html_type' => 'Select Date',
       'custom_group_id' => $createGroup['id'],
     );
-    $createField = civicrm_api('custom_field', 'create', $field);
-    $this->assertAPISuccess($createField);
+    $createField = $this->callAPISuccess('custom_field', 'create', $field);
     $contactParams = $this->fixtures['contact'];
     $contactParams["custom_{$createField['id']}"] = '2013-12-16';
-    $contact = civicrm_api('Contact', 'create', $contactParams);
-    $this->assertAPISuccess($contact);
+    $contact = $this->callAPISuccess('Contact', 'create', $contactParams);
     $this->_testObjects['CRM_Contact_DAO_Contact'][] = $contact['id'];
     $actionSchedule = $this->fixtures['sched_contact_grad_tomorrow'];
     $actionSchedule['entity_value'] = "custom_{$createField['id']}";
@@ -768,11 +752,7 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
         'recipients' => array(array('test-member@example.com')),
       ),
     ));
-    $deleteParams = array(
-      'version' => 3,
-      'id' => $createGroup['id'],
-    );
-    $deleteGroup = civicrm_api('custom_group', 'delete', $deleteParams);
+    $this->callAPISuccess('custom_group', 'delete', array('id' => $createGroup['id'],));
   }
 
   function testContactCustomDate_Anniv() {
@@ -783,23 +763,19 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
       'style' => 'Inline',
       'is_multiple' => false,
       'is_active' => 1,
-      'version' => 3,
     );
-    $createGroup = civicrm_api('custom_group', 'create', $group);
-    $this->assertAPISuccess($createGroup);
+    $createGroup = $this->callAPISuccess('custom_group', 'create', $group);
     $field = array(
-      'version' => 3,
       'label' => 'Graduation',
       'data_type' => 'Date',
       'html_type' => 'Select Date',
       'custom_group_id' => $createGroup['id'],
     );
-    $createField = civicrm_api('custom_field', 'create', $field);
-    $this->assertAPISuccess($createField);
+    $createField = $this->callAPISuccess('custom_field', 'create', $field);
+
     $contactParams = $this->fixtures['contact'];
     $contactParams["custom_{$createField['id']}"] = '2013-12-16';
-    $contact = civicrm_api('Contact', 'create', $contactParams);
-    $this->assertAPISuccess($contact);
+    $contact = $this->callAPISuccess('Contact', 'create', $contactParams);
     $this->_testObjects['CRM_Contact_DAO_Contact'][] = $contact['id'];
     $actionSchedule = $this->fixtures['sched_contact_grad_anniv'];
     $actionSchedule['entity_value'] = "custom_{$createField['id']}";
@@ -815,11 +791,7 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
         'recipients' => array(array('test-member@example.com')),
       ),
     ));
-    $deleteParams = array(
-      'version' => 3,
-      'id' => $createGroup['id'],
-    );
-    $deleteGroup = civicrm_api('custom_group', 'delete', $deleteParams);
+    $this->callAPISuccess('custom_group', 'delete', array('id' => $createGroup['id'],));
   }
 
   // TODO // function testMembershipEndDate_NonMatch() { }
@@ -840,10 +812,7 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
   function assertCronRuns($cronRuns) {
     foreach ($cronRuns as $cronRun) {
       CRM_Utils_Time::setTime($cronRun['time']);
-      $result = civicrm_api('job', 'send_reminder', array(
-        'version' => 3,
-      ));
-      $this->assertAPISuccess($result);
+      $this->callAPISuccess('job', 'send_reminder', array());
       $this->mut->assertRecipients($cronRun['recipients']);
       $this->mut->clearMessages();
     }


### PR DESCRIPTION
When I looked into CRM-15550 & the patch for 4.4 I found that I was getting a fatal (sql) error when trying to send out emails where limit_to=0 and no additional contacts are set.  It seemed to me the qualification of the IF in line 1219 ALSO needs to happen in 1303 (line numbers based on ActionSchedule.php patch below)
