### PR TITLE
CRM-15722 - fixes transposed keys in REST URL output

### DIFF
--- a/templates/CRM/Admin/Page/APIExplorer.js
+++ b/templates/CRM/Admin/Page/APIExplorer.js
@@ -398,7 +398,7 @@
       json: "CRM.api3('" + entity + "', '" + action + "'",
       drush: "drush cvapi " + entity + '.' + action + ' ',
       wpcli: "wp cv api " + entity + '.' + action + ' ',
-      rest: CRM.config.resourceBase + "extern/rest.php?entity=" + entity + "&action=" + action + "&json=" + JSON.stringify(params) + "&api_key=yoursitekey&key=yourkey"
+      rest: CRM.config.resourceBase + "extern/rest.php?entity=" + entity + "&action=" + action + "&json=" + JSON.stringify(params) + "&api_key=yourkey&key=sitekey"
     };
     smartyStub = false;
     $.each(params, function(key, value) {


### PR DESCRIPTION
api_key (the user key defined in the civicrm_contact table) and key (the site_key defined in civicrm.settings.php) were switched in the APIExplorer.js output
