### PR TITLE
CRM-15713 - CRM_Case_BAO_Case::accessCase - Split off from getCases().

### DIFF
--- a/CRM/Case/Page/AJAX.php
+++ b/CRM/Case/Page/AJAX.php
@@ -130,7 +130,7 @@ class CRM_Case_Page_AJAX {
   function caseDetails() {
     $caseId = CRM_Utils_Type::escape($_GET['caseId'], 'Positive');
 
-    if (!CRM_Case_BAO_Case::accessCase($caseId)) {
+    if (!CRM_Case_BAO_Case::accessCase($caseId, FALSE)) {
       CRM_Utils_System::permissionDenied();
     }
 


### PR DESCRIPTION
This allows us to explicit control over more parameters (eg case_status_id)
and to improve performance (by focusing on the specific $caseId).

(This is an untested backport of https://github.com/civicrm/civicrm-core/pull/4729 .)
