### PR TITLE
CRM-15578 - crmMailing - Fix for sending tests

### DIFF
--- a/js/angular-crmMailingAB.js
+++ b/js/angular-crmMailingAB.js
@@ -38,10 +38,10 @@
     $scope.testing_criteria = crmMailingABCriteria.getAll();
   });
 
-  angular.module('crmMailingAB').controller('CrmMailingABEditCtrl', function ($scope, abtest, crmMailingABCriteria, crmMailingMgr) {
+  angular.module('crmMailingAB').controller('CrmMailingABEditCtrl', function ($scope, abtest, crmMailingABCriteria, crmMailingMgr, crmMailingPreviewMgr, crmStatus) {
     window.ab = abtest;
     $scope.abtest = abtest;
-    $scope.ts = CRM.ts('CiviMail');
+    var ts = $scope.ts = CRM.ts('CiviMail');
     $scope.crmMailingABCriteria = crmMailingABCriteria;
     $scope.crmMailingConst = CRM.crmMailing;
     $scope.partialUrl = partialUrl;
@@ -79,7 +79,19 @@
     };
     $scope.save = function save() {
       $scope.sync();
-      return abtest.save();
+      return crmStatus({start: ts('Saving...'), success: ts('Saved')}, abtest.save());
+    };
+    // @return Promise
+    $scope.previewMailing = function previewMailing(mailingName, mode) {
+      return crmMailingPreviewMgr.preview(abtest.mailings[mailingName], mode);
+    };
+
+    // @return Promise
+    $scope.sendTest = function sendTest(mailingName, recipient) {
+      return crmStatus({start: ts('Saving...'), success: ''}, abtest.save())
+        .then(function () {
+          crmMailingPreviewMgr.sendTest(abtest.mailings[mailingName], recipient);
+        });
     };
     $scope.delete = function () {
       throw "Not implemented: EditCtrl.delete"

--- a/partials/crmMailing/edit-unified.html
+++ b/partials/crmMailing/edit-unified.html
@@ -37,7 +37,7 @@
     </div>
 
     <div crm-ui-accordion crm-title="ts('Preview')">
-      <div crm-mailing-block-preview crm-mailing="mailing"/>
+      <div crm-mailing-block-preview crm-mailing="mailing" on-preview="previewMailing(mailing, preview.mode)" on-send="sendTest(mailing, attachments, preview.recipient)" />
     </div>
 
     <button ng-click="submit().then(leave)">{{ts('Submit Mailing')}}</button>

--- a/partials/crmMailing/edit-unified2.html
+++ b/partials/crmMailing/edit-unified2.html
@@ -30,7 +30,7 @@
       <div crm-mailing-block-tracking crm-mailing="mailing"/>
     </div>
     <div crm-ui-accordion crm-title="ts('Preview')">
-      <div crm-mailing-block-preview crm-mailing="mailing"/>
+      <div crm-mailing-block-preview crm-mailing="mailing" on-preview="previewMailing(mailing, preview.mode)" on-send="sendTest(mailing, attachments, preview.recipient)" />
     </div>
     <div crm-ui-accordion id="tab-schedule" crm-title="ts('Schedule')">
       <div crm-mailing-block-schedule crm-mailing="mailing"/>

--- a/partials/crmMailing/edit-wizard.html
+++ b/partials/crmMailing/edit-wizard.html
@@ -26,7 +26,7 @@
           <div crm-attachments="attachments"/>
         </div>
         <div crm-ui-accordion crm-title="ts('Preview')">
-          <div crm-mailing-block-preview crm-mailing="mailing"/>
+          <div crm-mailing-block-preview crm-mailing="mailing" on-preview="previewMailing(mailing, preview.mode)" on-send="sendTest(mailing, attachments, preview.recipient)" />
         </div>
       </div>
 

--- a/partials/crmMailing/edit.html
+++ b/partials/crmMailing/edit.html
@@ -36,7 +36,7 @@
           </div>
         </div>
         <div crm-ui-accordion crm-title="ts('Preview')">
-          <div crm-mailing-block-preview crm-mailing="mailing"/>
+          <div crm-mailing-block-preview crm-mailing="mailing" on-preview="previewMailing(mailing, preview.mode)" on-send="sendTest(mailing, attachments, preview.recipient)" />
         </div>
       </div>
       <div crm-ui-wizard-step crm-title="ts('Review and Schedule')">

--- a/partials/crmMailing/preview.html
+++ b/partials/crmMailing/preview.html
@@ -1,4 +1,7 @@
-<div ng-controller="PreviewMailingCtrl" class="crmMailing-preview">
+<!--
+Vars: mailing:obj, testContact:obj, testGroup:obj, crmMailing:FormController
+-->
+<div class="crmMailing-preview">
   <!-- Note:
   In Firefox (at least), clicking the preview buttons causes the browser to display validation warnings
   for unrelated fields *and* display preview. To avoid this weird UX, we disable preview buttons when the form is incomplete/invalid.
@@ -8,14 +11,14 @@
       <em>({{ts('No content to preview')}})</em>
     </div>
     <div ng-hide="!mailing.body_html">
-      <button ng-disabled="crmMailing.$invalid" ng-click="previewHtml()">{{ts('Preview as HTML')}}</button>
+      <button ng-disabled="crmMailing.$invalid" ng-click="doPreview('html')">{{ts('Preview as HTML')}}</button>
     </div>
     <div ng-hide="!mailing.body_text">
-      <button ng-disabled="crmMailing.$invalid" ng-click="previewText()">{{ts('Preview as Plain Text')}}</button>
+      <button ng-disabled="crmMailing.$invalid" ng-click="doPreview('text')">{{ts('Preview as Plain Text')}}</button>
     </div>
     <!--
     <div ng-hide="!mailing.body_html && !mailing.body_text">
-      <button ng-disabled="crmMailing.$invalid" ng-click="previewFull()">{{ts('Preview')}}</button>
+      <button ng-disabled="crmMailing.$invalid" ng-click="doPreview('full')">{{ts('Preview')}}</button>
     </div>
     -->
   </div>
@@ -32,7 +35,7 @@
         placeholder="example@example.org"
         />
     </div>
-    <button ng-disabled="crmMailing.$invalid || !testContact.email" ng-click="sendTestToContact()">{{ts('Send test')}}</button>
+    <button ng-disabled="crmMailing.$invalid || !testContact.email" ng-click="doSend({email: testContact.email})">{{ts('Send test')}}</button>
   </div>
   <div class="preview-group" ng-form>
     <div>
@@ -49,7 +52,7 @@
         <option value=""></option>
       </select>
     </div>
-    <button ng-disabled="crmMailing.$invalid || !testGroup.gid" ng-click="sendTestToGroup()">{{ts('Send test')}}</button>
+    <button ng-disabled="crmMailing.$invalid || !testGroup.gid" ng-click="doSend({gid: testGroup.gid})">{{ts('Send test')}}</button>
   </div>
   <div class="clear"></div>
 </div>

--- a/partials/crmMailing/review.html
+++ b/partials/crmMailing/review.html
@@ -20,11 +20,9 @@ Required vars: mailing
         </div>
       </div>
       <div crm-ui-field crm-title="ts('Content')">
-        <div ng-controller="PreviewMailingCtrl">
-          <span ng-show="mailing.body_html"><a class="crm-hover-button action-item" ng-click="previewHtml()">{{ts('HTML')}} <span class="icon ui-icon-newwin"></span></a></span>
-          <span ng-show="mailing.body_text"><a class="crm-hover-button action-item" ng-click="previewText()">{{ts('Plain Text')}} <span class="icon ui-icon-newwin"></span></a></span>
-          <!-- TODO: attachments -->
-        </div>
+        <span ng-show="mailing.body_html"><a class="crm-hover-button action-item" ng-click="previewMailing(mailing, 'html')">{{ts('HTML')}} <span class="icon ui-icon-newwin"></span></a></span>
+        <span ng-show="mailing.body_text"><a class="crm-hover-button action-item" ng-click="previewMailing(mailing, 'text')">{{ts('Plain Text')}} <span class="icon ui-icon-newwin"></span></a></span>
+        <!-- TODO: attachments -->
       </div>
       <div crm-ui-field crm-title="ts('Attachments')" ng-show="attachments.files.length > 0 || attachments.uploader.queue.length > 0">
         <div ng-repeat="file in attachments.files">

--- a/partials/crmMailingAB/edit.html
+++ b/partials/crmMailingAB/edit.html
@@ -80,10 +80,10 @@
           </div>
         </div>
         <div crm-ui-accordion crm-title="ts('Preview (A)')">
-          <div crm-mailing-block-preview crm-mailing="abtest.mailings.a"/>
+          <div crm-mailing-block-preview crm-mailing="abtest.mailings.a" on-preview="previewMailing('a', preview.mode)" on-send="sendTest('a', preview.recipient)" />
         </div>
         <div crm-ui-accordion crm-title="ts('Preview (B)')">
-          <div crm-mailing-block-preview crm-mailing="abtest.mailings.b"/>
+          <div crm-mailing-block-preview crm-mailing="abtest.mailings.b" on-preview="previewMailing('b', preview.mode)" on-send="sendTest('b', preview.recipient)" />
         </div>
       </div>
       <div crm-ui-wizard-step="21" crm-title="ts('Compose (A)')" ng-if="criteriaName == 'Two different emails'">
@@ -118,7 +118,7 @@
           </div>
         </div>
         <div crm-ui-accordion crm-title="ts('Preview')">
-          <div crm-mailing-block-preview crm-mailing="abtest.mailings.a"/>
+          <div crm-mailing-block-preview crm-mailing="abtest.mailings.a" on-preview="previewMailing('a', preview.mode)" on-send="sendTest('a', preview.recipient)" />
         </div>
       </div>
       <div crm-ui-wizard-step="22" crm-title="ts('Compose (B)')" ng-if="criteriaName == 'Two different emails'">
@@ -153,7 +153,7 @@
           </div>
         </div>
         <div crm-ui-accordion crm-title="ts('Preview')">
-          <div crm-mailing-block-preview crm-mailing="abtest.mailings.b"/>
+          <div crm-mailing-block-preview crm-mailing="abtest.mailings.b" on-preview="previewMailing('b', preview.mode)" on-send="sendTest('b', preview.recipient)" />
         </div>
       </div>
       <div crm-ui-wizard-step="30" crm-title="ts('Schedule')">


### PR DESCRIPTION
The basic problem is that one must save before sending a test -- and the
"save" mechanics are necessarily different for crmMailing and crmMailingAB.

This commit resolves the problem by refactoring to eliminate PreviewMailingCtrl.
Now:
- Ultimate authority for deciding how to perform a preview or test mailing lies with
  the main page (EditMailingCtrl, crmMailing/edit.html, CrmMailingABEditCtrl, crmMailingAB/edit.html)
- We don't want it to be difficult for the main page to do that, so we define two reusable
  components -- directive crmMailingBlockPreview and service crmMailingPreviewMgr.
