### PR TITLE
Webtests Fix

### DIFF
--- a/tests/phpunit/WebTest/Campaign/OnlineEventRegistrationTest.php
+++ b/tests/phpunit/WebTest/Campaign/OnlineEventRegistrationTest.php
@@ -140,7 +140,7 @@ class WebTest_Campaign_OnlineEventRegistrationTest extends CiviSeleniumTestCase 
     $eventInfoStrings = array($eventTitle, $eventDescription, $streetAddress);
     $this->_testVerifyEventInfo($eventTitle, $eventInfoStrings);
 
-    $registerStrings = array("$ 250.00 Member", "$ 325.00 Non-member", $registerIntro);
+    $registerStrings = array("Member - $ 250.00", "Non-member - $ 325.00", $registerIntro);
     $registerUrl = $this->_testVerifyRegisterPage($registerStrings);
 
     $numberRegistrations = 3;
@@ -357,9 +357,9 @@ class WebTest_Campaign_OnlineEventRegistrationTest extends CiviSeleniumTestCase 
 
     $this->type('sort_name', $email);
     $this->click("_qf_Search_refresh");
-    $this->waitForElementPresent("//*[@id='participantSearch']");
-    $this->click("xpath=//div[@id='participantSearch']/table/tbody/tr/td[11]/span/a[text()='Edit']");
+    $this->waitForElementPresent("xpath=//div[@id='participantSearch']");
+    $this->click("xpath=//div[@id='participantSearch']/table/tbody/tr/td[11]/span[1]/a[2][text()='Edit']");
     $this->waitForElementPresent("_qf_Participant_cancel-bottom");
-    $this->assertElementContainsText('crm-container', "$campaignTitle");
+    $this->assertElementContainsText("xpath=//form[@id='Participant']/div[2]/div/table[@class='form-layout-compressed']/tbody/tr[4]/td[2]/select", "$campaignTitle");
   }
 }

--- a/tests/phpunit/WebTest/Event/AddEventTest.php
+++ b/tests/phpunit/WebTest/Event/AddEventTest.php
@@ -807,12 +807,12 @@ class WebTest_Event_AddEventTest extends CiviSeleniumTestCase {
 
     $this->openCiviPage("event/search?reset=1", "reset=1");
     $this->select2("event_id", $eventTitle, FALSE);
-    $this->click("xpath=//td[@class='crm-event-form-block-participant_status']/div[@class='listing-box']//div/label[text()='Pending from pay later']");
+    $this->click("xpath=//div[@id='searchForm']/table/tbody/tr[5]/td[1]/div//div/label[text()='Pending from pay later']");
     $this->clickLink('_qf_Search_refresh');
-    $this->waitForElementPresent("xpath=//div[@id='participantSearch']/table/tbody//tr/td[11]/span/a[text()='Edit']");
+    $this->waitForElementPresent("xpath=//div[@id='participantSearch']/table/tbody//tr/td[11]/span/a[2][text()='Edit']");
 
-    $uRL = $this->getAttribute("xpath=//div[@id='participantSearch']/table/tbody//tr/td[11]/span/a[text()='Edit']@href");
-    $this->click("xpath=//div[@id='participantSearch']/table/tbody//tr/td[11]/span/a[text()='Edit']");
+    $uRL = $this->getAttribute("xpath=//div[@id='participantSearch']/table/tbody//tr/td[11]/span/a[2][text()='Edit']@href");
+    $this->click("xpath=//div[@id='participantSearch']/table/tbody//tr/td[11]/span/a[2][text()='Edit']");
     $this->waitForElementPresent("status_id");
     $this->select('status_id', 'label=Registered');
     $this->waitForElementPresent("record_contribution");

--- a/tests/phpunit/WebTest/Event/ParticipantCountTest.php
+++ b/tests/phpunit/WebTest/Event/ParticipantCountTest.php
@@ -106,7 +106,7 @@ class WebTest_Event_ParticipantCountTest extends CiviSeleniumTestCase {
     $this->waitForPageToLoad($this->getTimeoutMsec());
 
     // verify number of registered participants
-    $this->assertTrue($this->isTextPresent('2 Results'));
+    $this->assertElementContainsText("xpath=//div[@id='search-status']/table/tbody/tr[1]/td", '2 Results');
   }
 
   function testParticipantCountWithPriceset() {

--- a/tests/phpunit/WebTest/Event/ParticipantSearchTest.php
+++ b/tests/phpunit/WebTest/Event/ParticipantSearchTest.php
@@ -160,7 +160,7 @@ class WebTest_Event_ParticipantSearchTest extends CiviSeleniumTestCase {
 
 
     $this->click("_qf_Search_refresh");
-    $this->waitForElementPresent("search-status");
+    $this->waitForElementPresent("xpath=//form[@id='Search']/div[3]/div/div[1]/div");
 
     $stringsToCheck = array(
       "Start Date - greater than or equal to",

--- a/tests/phpunit/WebTest/Member/OnlineAutoRenewMembershipGCTest.php
+++ b/tests/phpunit/WebTest/Member/OnlineAutoRenewMembershipGCTest.php
@@ -42,7 +42,7 @@ class WebTest_Member_OnlineAutoRenewMembershipGCTest extends CiviSeleniumTestCas
     //now do the test membership signup.
     $this->openCiviPage('contribute/transact', "reset=1&action=preview&id={$pageId}", "_qf_Main_upload-bottom");
 
-    $this->click("xpath=//div[@class='crm-section membership_amount-section']/div[2]//span/label/span[2][contains(text(),'Student')]");
+    $this->click("xpath=//div[@class='crm-section membership_amount-section']/div[2]/div[2]/span/label/span[1][contains(text(),'Student')]");
     $this->click("auto_renew");
 
     $firstName = 'John';
@@ -74,7 +74,7 @@ class WebTest_Member_OnlineAutoRenewMembershipGCTest extends CiviSeleniumTestCas
 
     //now do the test membership signup.
     $this->openCiviPage('contribute/transact', "reset=1&action=preview&id={$pageId}", "_qf_Main_upload-bottom");
-    $this->click("xpath=//div[@class='crm-section membership_amount-section']/div[2]//span/label/span[2][contains(text(),'Student')]");
+    $this->click("xpath=//div[@class='crm-section membership_amount-section']/div[2]/div[2]/span/label/span[1][contains(text(),'Student')]");
 
     $this->click("auto_renew");
 

--- a/tests/phpunit/WebTest/Member/OnlineAutoRenewMembershipTest.php
+++ b/tests/phpunit/WebTest/Member/OnlineAutoRenewMembershipTest.php
@@ -42,7 +42,7 @@ class WebTest_Member_OnlineAutoRenewMembershipTest extends CiviSeleniumTestCase 
     //now do the test membership signup.
     $this->openCiviPage('contribute/transact', "reset=1&action=preview&id={$pageId}", "_qf_Main_upload-bottom");
 
-    $this->click("xpath=//div[@class='crm-section membership_amount-section']/div[2]//span/label/span[2][contains(text(),'Student')]");
+    $this->click("xpath=//div[@class='crm-section membership_amount-section']/div[2]/div[2]/span/label/span[1][contains(text(),'Student')]");
 
     $this->click("auto_renew");
 
@@ -55,13 +55,13 @@ class WebTest_Member_OnlineAutoRenewMembershipTest extends CiviSeleniumTestCase 
     $this->clickLink("_qf_Main_upload-bottom", "_qf_Confirm_next-bottom");
 
     $text = 'I want this membership to be renewed automatically every 1 year(s).';
-    $this->assertElementContainsText("xpath=//div[@class='crm-group amount_display-group']/div[2]", $text, 'Missing text: ' . $text);
+    $this->assertElementContainsText("xpath=//div[@class='crm-group amount_display-group']/div[2]/strong[2]", $text, 'Missing text: ' . $text);
 
     $this->click("_qf_Confirm_next-bottom");
     $this->waitForPageToLoad($this->getTimeoutMsec());
 
     $text = 'This membership will be renewed automatically every 1 year(s).';
-    $this->assertElementContainsText("xpath=//div[@class='crm-group amount_display-group']/div[2]", $text, 'Missing text: ' . $text);
+    $this->assertElementContainsText("xpath=//div[@class='crm-group amount_display-group']/div[2]/strong[3]", $text, 'Missing text: ' . $text);
   }
 
   function testOnlineAutoRenewMembershipAuthenticated() {
@@ -74,7 +74,7 @@ class WebTest_Member_OnlineAutoRenewMembershipTest extends CiviSeleniumTestCase 
     //now do the test membership signup.
     $this->openCiviPage('contribute/transact', "reset=1&action=preview&id={$pageId}", "_qf_Main_upload-bottom");
 
-    $this->click("xpath=//div[@class='crm-section membership_amount-section']/div[2]//span/label/span[2][contains(text(),'Student')]");
+    $this->click("xpath=//div[@class='crm-section membership_amount-section']/div[2]/div[2]/span/label/span[1][contains(text(),'Student')]");
 
     $this->click("auto_renew");
 
@@ -88,13 +88,13 @@ class WebTest_Member_OnlineAutoRenewMembershipTest extends CiviSeleniumTestCase 
     $this->waitForElementPresent("_qf_Confirm_next-bottom");
 
     $text = 'I want this membership to be renewed automatically every 1 year(s).';
-    $this->assertElementContainsText("xpath=//div[@class='crm-group amount_display-group']/div[2]", $text, 'Missing text: ' . $text);
+    $this->assertElementContainsText("xpath=//div[@class='crm-group amount_display-group']/div[2]/strong[2]", $text, 'Missing text: ' . $text);
 
     $this->click("_qf_Confirm_next-bottom");
     $this->waitForPageToLoad($this->getTimeoutMsec());
 
     $text = 'This membership will be renewed automatically every 1 year(s).';
-    $this->assertElementContainsText("xpath=//div[@class='crm-group amount_display-group']/div[2]", $text, 'Missing text: ' . $text);
+    $this->assertElementContainsText("xpath=//div[@class='crm-group amount_display-group']/div[2]/strong[3]", $text, 'Missing text: ' . $text);
   }
 
   function testOnlinePendingAutoRenewMembershipAnonymous() {
@@ -104,7 +104,7 @@ class WebTest_Member_OnlineAutoRenewMembershipTest extends CiviSeleniumTestCase 
     //now do the test membership signup.
     $this->openCiviPage('contribute/transact', "reset=1&action=preview&id={$pageId}", "_qf_Main_upload-bottom");
 
-    $this->click("xpath=//div[@class='crm-section membership_amount-section']/div[2]//span/label/span[2][contains(text(),'Student')]");
+    $this->click("xpath=//div[@class='crm-section membership_amount-section']/div[2]/div[2]/span/label/span[1][contains(text(),'Student')]");
 
     $this->click("auto_renew");
 
@@ -116,13 +116,13 @@ class WebTest_Member_OnlineAutoRenewMembershipTest extends CiviSeleniumTestCase 
     $this->waitForElementPresent("_qf_Confirm_next-bottom");
 
     $text = 'I want this membership to be renewed automatically every 1 year(s).';
-    $this->assertElementContainsText("xpath=//div[@class='crm-group amount_display-group']/div[2]", $text, 'Missing text: ' . $text);
+    $this->assertElementContainsText("xpath=//div[@class='crm-group amount_display-group']/div[2]/strong[2]", $text, 'Missing text: ' . $text);
 
     $this->click("_qf_Confirm_next-bottom");
     $this->waitForPageToLoad($this->getTimeoutMsec());
 
     $text = 'This membership will be renewed automatically every 1 year(s).';
-    $this->assertElementContainsText("xpath=//div[@class='crm-group amount_display-group']/div[2]", $text, 'Missing text: ' . $text);
+    $this->assertElementContainsText("xpath=//div[@class='crm-group amount_display-group']/div[2]/strong[3]", $text, 'Missing text: ' . $text);
   }
 
   /**

--- a/tests/phpunit/WebTest/Member/SeperateMembershipPaymentTest.php
+++ b/tests/phpunit/WebTest/Member/SeperateMembershipPaymentTest.php
@@ -157,7 +157,7 @@ class WebTest_Member_SeperateMembershipPaymentTest extends CiviSeleniumTestCase 
     $this->openCiviPage("contribute/transact", $args, '_qf_Main_upload-bottom');
 
     // Select membership type 1
-    $this->click("xpath=//div[@class='crm-section membership_amount-section']/div[2]//span/label/span[2][contains(text(),'$memTypeId')]");
+    $this->click("xpath=//div[@class='crm-section membership_amount-section']/div[2]//div/span/label/span[1][contains(text(),'$memTypeId')]");
     $this->type("xpath=//div[@class='crm-section other_amount-section']//div[2]/input", 60);
     $this->clickLink("_qf_Main_upload-bottom", "_qf_Confirm_next-bottom");
     $this->clickLink("_qf_Confirm_next-bottom", NULL);


### PR DESCRIPTION
Fix for Following webtests:

WebTest_Event_ParticipantCountTest::testParticipantCountWithFeelevel
WebTest_Event_ParticipantSearchTest::testParticipantSearchEventDateAndType
WebTest_Event_AddEventTest.testEventAddMultipleParticipant
WebTest_Member_OnlineAutoRenewMembershipGCTest::testOnlineAutoRenewMembershipAuthenticated
WebTest_Member_OnlineAutoRenewMembershipGCTest::testOnlineAutoRenewMembershipAnonymous
WebTest_Member_SeperateMembershipPaymentTest.testSeperateMembershipCreate
WebTest_Member_OnlineAutoRenewMembershipTest::testOnlinePendingAutoRenewMembershipAnonymous
WebTest_Member_OnlineAutoRenewMembershipTest::testOnlineAutoRenewMembershipAnonymous
WebTest_Member_OnlineAutoRenewMembershipTest::testOnlineAutoRenewMembershipAuthenticated
WebTest_Campaign_OnlineEventRegistrationTest.testCreateCampaign
