### PR TITLE
-- changed size to 255 from 64 for civicrm_action_schedule.entity_value,...

### DIFF
--- a/CRM/Upgrade/Incremental/sql/4.5.6.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.5.6.mysql.tpl
@@ -1,1 +1,4 @@
 {* file to handle db changes in 4.5.6 during upgrade *}
+   
+-- CRM-15760
+ALTER TABLE `civicrm_action_schedule` CHANGE `entity_value` `entity_value` VARCHAR( 255 ) CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL DEFAULT NULL COMMENT 'Entity value';

--- a/xml/schema/Core/ActionSchedule.xml
+++ b/xml/schema/Core/ActionSchedule.xml
@@ -50,7 +50,7 @@
   <field>
     <name>entity_value</name>
     <type>varchar</type>
-    <length>64</length>
+    <length>255</length>
     <comment>Entity value</comment>
     <add>3.4</add>
   </field>


### PR DESCRIPTION
... CRM-15760

---
- CRM-15760: Change size of civicrm_action_schedule.entity_value to 255 from 64
  https://issues.civicrm.org/jira/browse/CRM-15760
