### PR TITLE
CRM-15763 - Payment Express has deprecated SSLv3

### DIFF
--- a/CRM/Core/Payment/PaymentExpressUtils.php
+++ b/CRM/Core/Payment/PaymentExpressUtils.php
@@ -98,7 +98,7 @@ class CRM_Core_Payment_PaymentExpressUtils {
       curl_setopt($curl, CURLOPT_FOLLOWLOCATION, FALSE);
     }
     curl_setopt($curl, CURLOPT_HEADER, 0);
-    curl_setopt($curl, CURLOPT_SSLVERSION, 3);
+    curl_setopt($curl, CURLOPT_SSLVERSION, 0);
 
     if (strtoupper(substr(@php_uname('s'), 0, 3)) === 'WIN') {
       curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME, 'verifySSL'));


### PR DESCRIPTION
Payment Express (DPS) no longer supports SSLv3 (3), so suggest this is adjusted to default (0) which will allow curl to auto-negotiate to use a compatible version of TLS
