### PR TITLE
CRM-15764 - Make opendir() usage more consistent.

### DIFF
--- a/CRM/Core/Component.php
+++ b/CRM/Core/Component.php
@@ -443,8 +443,7 @@ class CRM_Core_Component {
   static function getComponentsFromFile($crmFolderDir) {
     $components = array();
     //traverse CRM folder and check for Info file
-    if (is_dir($crmFolderDir)) {
-      $dir = opendir($crmFolderDir);
+    if (is_dir($crmFolderDir) && $dir = opendir($crmFolderDir)) {
       while ($subDir = readdir($dir)) {
         // skip the extensions diretory since it has an Info.php file also
         if ($subDir == 'Extension') {
@@ -465,4 +464,3 @@ class CRM_Core_Component {
     return $components;
   }
 }
-

--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -131,8 +131,7 @@ class CRM_Core_I18n {
       // check which ones are available; add them to $all if not there already
       $config = CRM_Core_Config::singleton();
       $codes = array();
-      if (is_dir($config->gettextResourceDir)) {
-        $dir = opendir($config->gettextResourceDir);
+      if (is_dir($config->gettextResourceDir) && $dir = opendir($config->gettextResourceDir)) {
         while ($filename = readdir($dir)) {
           if (preg_match('/^[a-z][a-z]_[A-Z][A-Z]$/', $filename)) {
             $codes[] = $filename;
@@ -520,4 +519,3 @@ function ts($text, $params = array()) {
     return $i18n->crm_translate($text, $params);
   }
 }
-

--- a/CRM/Upgrade/Incremental/php/ThreeThree.php
+++ b/CRM/Upgrade/Incremental/php/ThreeThree.php
@@ -292,8 +292,7 @@ WHERE id = %2
     //CRM-7123 -lets activate needful languages.
     $config = CRM_Core_Config::singleton();
     $locales = array();
-    if (is_dir($config->gettextResourceDir)) {
-      $dir = opendir($config->gettextResourceDir);
+    if (is_dir($config->gettextResourceDir) && $dir = opendir($config->gettextResourceDir)) {
       while ($filename = readdir($dir)) {
         if (preg_match('/^[a-z][a-z]_[A-Z][A-Z]$/', $filename)) {
           $locales[$filename] = $filename;
@@ -406,4 +405,3 @@ INNER JOIN  civicrm_option_group grp ON ( grp.id = val.option_group_id )
     $upgrade->processSQL($rev);
   }
 }
-

--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -144,7 +144,7 @@ class CRM_Utils_File {
       throw new Exception("Overly broad deletion");
     }
 
-    if ($sourcedir = @opendir($target)) {
+    if ($sourcedir = opendir($target)) {
       while (FALSE !== ($sibling = readdir($sourcedir))) {
         if (!in_array($sibling, $exceptions)) {
           $object = $target . DIRECTORY_SEPARATOR . $sibling;
@@ -180,19 +180,20 @@ class CRM_Utils_File {
    * @param $destination
    */
   static function copyDir($source, $destination) {
-    $dir = opendir($source);
-    @mkdir($destination);
-    while (FALSE !== ($file = readdir($dir))) {
-      if (($file != '.') && ($file != '..')) {
-        if (is_dir($source . DIRECTORY_SEPARATOR . $file)) {
-          CRM_Utils_File::copyDir($source . DIRECTORY_SEPARATOR . $file, $destination . DIRECTORY_SEPARATOR . $file);
-        }
-        else {
-          copy($source . DIRECTORY_SEPARATOR . $file, $destination . DIRECTORY_SEPARATOR . $file);
+    if ($dir = opendir($source)) {
+      @mkdir($destination);
+      while (FALSE !== ($file = readdir($dir))) {
+        if (($file != '.') && ($file != '..')) {
+          if (is_dir($source . DIRECTORY_SEPARATOR . $file)) {
+            CRM_Utils_File::copyDir($source . DIRECTORY_SEPARATOR . $file, $destination . DIRECTORY_SEPARATOR . $file);
+          }
+          else {
+            copy($source . DIRECTORY_SEPARATOR . $file, $destination . DIRECTORY_SEPARATOR . $file);
+          }
         }
       }
+      closedir($dir);
     }
-    closedir($dir);
   }
 
   /**
@@ -398,15 +399,16 @@ class CRM_Utils_File {
    */
   static function getFilesByExtension($path, $ext) {
     $path  = self::addTrailingSlash($path);
-    $dh    = opendir($path);
-    $files = array();
-    while (FALSE !== ($elem = readdir($dh))) {
-      if (substr($elem, -(strlen($ext) + 1)) == '.' . $ext) {
-        $files[] .= $path . $elem;
+    if ($dh = opendir($path)) {
+      $files = array();
+      while (FALSE !== ($elem = readdir($dh))) {
+        if (substr($elem, -(strlen($ext) + 1)) == '.' . $ext) {
+          $files[] .= $path . $elem;
+        }
       }
+      closedir($dh);
+      return $files;
     }
-    closedir($dh);
-    return $files;
   }
 
   /**
@@ -616,8 +618,7 @@ HTACCESS;
           }
         }
       }
-      $dh = opendir($subdir);
-      if ($dh) {
+      if ($dh = opendir($subdir)) {
         while (FALSE !== ($entry = readdir($dh))) {
           $path = $subdir . DIRECTORY_SEPARATOR . $entry;
           if ($entry{0} == '.') {
@@ -688,4 +689,3 @@ HTACCESS;
     return TRUE;
   }
 }
-

--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -791,15 +791,15 @@ AND    u.status = 1
     //lets remove sript name to reduce one iteration.
     array_pop($pathVars);
 
-    //CRM-7429 --do check for upper most 'includes' dir,
-    //which would effectually work for multisite installation.
+    // CRM-7429 -- do check for uppermost 'includes' dir, which would
+    // work for multisite installation.
     do {
       $cmsRoot = $firstVar . '/' . implode('/', $pathVars);
       $cmsIncludePath = "$cmsRoot/includes";
-      //stop as we found bootstrap.
-      if (@opendir($cmsIncludePath) &&
-        file_exists("$cmsIncludePath/bootstrap.inc")
-      ) {
+      // Stop if we find bootstrap.
+      //
+      // @TODO What is opendir() here for?
+      if (opendir($cmsIncludePath) && file_exists("$cmsIncludePath/bootstrap.inc")) {
         $valid = TRUE;
         break;
       }

--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -797,9 +797,7 @@ AND    u.status = 1
       $cmsRoot = $firstVar . '/' . implode('/', $pathVars);
       $cmsIncludePath = "$cmsRoot/includes";
       // Stop if we find bootstrap.
-      //
-      // @TODO What is opendir() here for?
-      if (opendir($cmsIncludePath) && file_exists("$cmsIncludePath/bootstrap.inc")) {
+      if (file_exists("$cmsIncludePath/bootstrap.inc")) {
         $valid = TRUE;
         break;
       }

--- a/CRM/Utils/System/Drupal6.php
+++ b/CRM/Utils/System/Drupal6.php
@@ -741,10 +741,10 @@ class CRM_Utils_System_Drupal6 extends CRM_Utils_System_DrupalBase {
     do {
       $cmsRoot = $firstVar . '/' . implode('/', $pathVars);
       $cmsIncludePath = "$cmsRoot/includes";
-      //stop as we found bootstrap.
-      if (@opendir($cmsIncludePath) &&
-        file_exists("$cmsIncludePath/bootstrap.inc")
-      ) {
+      // Stop if we found bootstrap.
+      //
+      // @TODO What is opendir() here for?
+      if (opendir($cmsIncludePath) && file_exists("$cmsIncludePath/bootstrap.inc")) {
         $valid = TRUE;
         break;
       }

--- a/CRM/Utils/System/Drupal6.php
+++ b/CRM/Utils/System/Drupal6.php
@@ -742,9 +742,7 @@ class CRM_Utils_System_Drupal6 extends CRM_Utils_System_DrupalBase {
       $cmsRoot = $firstVar . '/' . implode('/', $pathVars);
       $cmsIncludePath = "$cmsRoot/includes";
       // Stop if we found bootstrap.
-      //
-      // @TODO What is opendir() here for?
-      if (opendir($cmsIncludePath) && file_exists("$cmsIncludePath/bootstrap.inc")) {
+      if (file_exists("$cmsIncludePath/bootstrap.inc")) {
         $valid = TRUE;
         break;
       }

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -522,7 +522,7 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
    */
   function validInstallDir($dir) {
     $includePath = "$dir/wp-includes";
-    if (opendir($includePath) && file_exists("$includePath/version.php")) {
+    if (file_exists("$includePath/version.php")) {
       return TRUE;
     }
     return FALSE;

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -522,10 +522,7 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
    */
   function validInstallDir($dir) {
     $includePath = "$dir/wp-includes";
-    if (
-      @opendir($includePath) &&
-      file_exists("$includePath/version.php")
-    ) {
+    if (opendir($includePath) && file_exists("$includePath/version.php")) {
       return TRUE;
     }
     return FALSE;
@@ -784,4 +781,3 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
     }
   }
 }
-


### PR DESCRIPTION
When the result of opendir() is unchecked, it's unwise to start a loop based on readdir() from the directory handle.

This commit should ensure that opendir() result is always checked. Removes `@` error control operator in a couple of locations.
