### PR TITLE
Replace wizard-bar radical with heavy checkmark

### DIFF
--- a/CRM/Core/Controller.php
+++ b/CRM/Core/Controller.php
@@ -584,7 +584,7 @@ class CRM_Core_Controller extends HTML_QuickForm_Controller {
     $wizard['style'] = array(
       'barClass' => '',
       'stepPrefixCurrent' => '&raquo;',
-      'stepPrefixPast' => '&radic;',
+      'stepPrefixPast' => '&#x2714;',
       'stepPrefixFuture' => ' ',
       'subStepPrefixCurrent' => '&nbsp;&nbsp;',
       'subStepPrefixPast' => '&nbsp;&nbsp;',


### PR DESCRIPTION
Replaced &radic; with ✔
**Before**
![before](https://cloud.githubusercontent.com/assets/665387/5594088/6de8647a-91ee-11e4-8fd5-21d42e282b4f.png)

**After**
![after](https://cloud.githubusercontent.com/assets/665387/5594087/6cb4ab9a-91ee-11e4-8ed5-8725b9f359d1.png)
