### PR TITLE
 Notification "PCP information has been saved" doesn't appear on the Manage Event tab for PCP after the save button is clicked. 

### DIFF
--- a/CRM/Event/Form/ManageEvent/TabHeader.php
+++ b/CRM/Event/Form/ManageEvent/TabHeader.php
@@ -151,7 +151,6 @@ WHERE      e.id = %1
     $fullName  = $form->getVar('_name');
     $className = CRM_Utils_String::getClassName($fullName);
     $new       = '';
-    $action = 'update';
 
     // hack for special cases.
     switch ($className) {
@@ -189,6 +188,7 @@ WHERE      e.id = %1
           $tabs[$key]['qfKey'] = NULL;
         }
 
+        $action = 'update';
         if ($key == 'reminder') {
           $action = 'browse';
         }


### PR DESCRIPTION
Failing Webtest : WebTest_Event_PCPAddTest.testPCPAdd
