### PR TITLE
CRM-15774 - Core - Call BAO not DAO on contact create via profile

### DIFF
--- a/CRM/Core/BAO/CMSUser.php
+++ b/CRM/Core/BAO/CMSUser.php
@@ -238,15 +238,10 @@ class CRM_Core_BAO_CMSUser {
       isset($params['contactID'])
     ) {
       // create the UF Match record
-      $ufmatch             = new CRM_Core_DAO_UFMatch();
-      $ufmatch->domain_id  = CRM_Core_Config::domainID();
-      $ufmatch->uf_id      = $ufID;
-      $ufmatch->contact_id = $params['contactID'];
-      $ufmatch->uf_name    = $params[$mail];
-
-      if (!$ufmatch->find(TRUE)) {
-        $ufmatch->save();
-      }
+      $ufmatch['uf_id']      = $ufID;
+      $ufmatch['contact_id'] = $params['contactID'];
+      $ufmatch['uf_name']    = $params[$mail];
+      CRM_Core_BAO_UFMatch::create($ufmatch);
     }
 
     return $ufID;


### PR DESCRIPTION
Notes:
- I didn't add $ufmatch['domain_id'] because the BAO calls the same function.
- There shouldn't be any possible way in this code path that $ufmatch->find(TRUE) returns TRUE (see line 236).
