### PR TITLE
CRM-15784 Made message template form layout mirror email composition layout

### DIFF
--- a/CRM/Admin/Form/MessageTemplates.php
+++ b/CRM/Admin/Form/MessageTemplates.php
@@ -158,10 +158,6 @@ class CRM_Admin_Form_MessageTemplates extends CRM_Admin_Form {
 
     $this->assign('tokens', CRM_Utils_Token::formatTokensForDisplay($tokens));
 
-    $this->add('textarea', 'msg_text', ts('Text Message'),
-      "cols=50 rows=6"
-    );
-
     // if not a system message use a wysiwyg editor, CRM-5971
     if ($this->_id &&
       CRM_Core_DAO::getFieldValue('CRM_Core_DAO_MessageTemplate',
@@ -181,6 +177,10 @@ class CRM_Admin_Form_MessageTemplates extends CRM_Admin_Form {
         )
       );
     }
+
+    $this->add('textarea', 'msg_text', ts('Text Message'),
+      "cols=50 rows=6"
+    );
 
     $this->add('select', 'pdf_format_id', ts('PDF Page Format'),
       array(

--- a/templates/CRM/Admin/Form/MessageTemplates.tpl
+++ b/templates/CRM/Admin/Form/MessageTemplates.tpl
@@ -61,6 +61,24 @@
         <tr>
   </table>
 
+      <div class="crm-accordion-wrapper crm-html_email-accordion ">
+        <div class="crm-accordion-header">
+            {ts}HTML Format{/ts}
+            {help id="id-message-text" file="CRM/Contact/Form/Task/Email.hlp"}
+        </div><!-- /.crm-accordion-header -->
+         <div class="crm-accordion-body">
+           <div class="helpIcon" id="helphtml">
+             <input class="crm-token-selector big" data-field="html_message" />
+             {help id="id-token-html" tplFile=$tplFile isAdmin=$isAdmin editor=$editor file="CRM/Contact/Form/Task/Email.hlp"}
+           </div>
+                <div class="clear"></div>
+                <div class='html resizable-textarea'>
+                    {$form.msg_html.html}
+                    <div class="description">{ts}An HTML formatted version of this message will be sent to contacts whose Email Format preference is 'HTML' or 'Both'.{/ts} {ts 1=$tokenDocsRepeated}Tokens may be included (%1).{/ts}</div>
+                </div>
+        </div><!-- /.crm-accordion-body -->
+      </div><!-- /.crm-accordion-wrapper -->
+
       <div class="crm-accordion-wrapper crm-plaint_text_email-accordion ">
         <div class="crm-accordion-header">
                 {ts}Plain-Text Format{/ts}
@@ -76,24 +94,6 @@
                     <div class="description">{ts}Text formatted message.{/ts} {ts 1=$tokenDocsRepeated}Tokens may be included (%1).{/ts}</div>
                 </div>
             </div><!-- /.crm-accordion-body -->
-      </div><!-- /.crm-accordion-wrapper -->
-
-      <div class="crm-accordion-wrapper crm-html_email-accordion ">
-        <div class="crm-accordion-header">
-            {ts}HTML Format{/ts}
-            {help id="id-message-text" file="CRM/Contact/Form/Task/Email.hlp"}
-        </div><!-- /.crm-accordion-header -->
-         <div class="crm-accordion-body">
-           <div class="helpIcon" id="helphtml">
-             <input class="crm-token-selector big" data-field="html_message" />
-             {help id="id-token-html" tplFile=$tplFile isAdmin=$isAdmin editor=$editor file="CRM/Contact/Form/Task/Email.hlp"}
-           </div>
-                <div class="clear"></div>
-                <div class='html resizable-textarea'>
-                    {$form.msg_html.html}
-                    <div class="description">{ts}You may optionally create an HTML formatted version of this message. It will be sent to contacts whose Email Format preference is 'HTML' or 'Both'.{/ts} {ts 1=$tokenDocsRepeated}Tokens may be included (%1).{/ts}</div>
-                </div>
-        </div><!-- /.crm-accordion-body -->
       </div><!-- /.crm-accordion-wrapper -->
 
       <div class="crm-accordion-wrapper crm-html_email-accordion ">


### PR DESCRIPTION
When composing templates, the plain-text version is presented first, followed by HTML and PDF formatting. When composing an email, the layout is reversed, with the HTML version followed by the plain-text version.

This commit changes the template layout to mirror the email composition layout
