### PR TITLE
Webtests fixes

### DIFF
--- a/tests/phpunit/WebTest/Contact/CustomDataAddTest.php
+++ b/tests/phpunit/WebTest/Contact/CustomDataAddTest.php
@@ -205,7 +205,7 @@ class WebTest_Contact_CustomDataAddTest extends CiviSeleniumTestCase {
 
     //Get the customFieldsetID
     $this->openCiviPage('admin/custom/group', 'reset=1');
-    $customFieldsetId = explode('&gid=', $this->getAttribute("xpath=//div[@id='custom_group']//table/tbody//tr/td/span[text()='$customGroupTitle']/../../td[7]/span/a@href"));
+    $customFieldsetId = explode('&gid=', $this->getAttribute("xpath=//div[@id='custom_group']/table/tbody//tr/td/div[text()='$customGroupTitle']/../../td[7]/span/a@href"));
     $customFieldsetId = $customFieldsetId[1];
 
     //create Individual contact

--- a/tests/phpunit/WebTest/Contact/MergeContactsTest.php
+++ b/tests/phpunit/WebTest/Contact/MergeContactsTest.php
@@ -240,8 +240,8 @@ class WebTest_Contact_MergeContactsTest extends CiviSeleniumTestCase {
     $this->waitForElementPresent('_qf_DedupeFind_submit-bottom');
     $this->click("_qf_DedupeFind_next-bottom");
 
-    $this->waitForElementPresent("xpath=div[@id='DedupeFind']/div[2]/div/table/tbody/tr[1]/td[4]/a[text()='merge']");
-    $this->waitForElementPresent("xpath=//*[@id='DedupeFind']/a[3]/span[contains(text(),'Done')]");
+    $this->waitForElementPresent("xpath=//form[@id='DedupeFind']/div[2]/div/table/tbody/tr[1]/td[4]/a[text()='merge']");
+    $this->waitForElementPresent("xpath=//form[@id='DedupeFind']/a[3]/span[contains(text(),'Done')]");
     $this->isElementPresent("xpath=//table[@id='option51']/tbody/tr/td[1]/a[text()='{$firstName} {$lastName}']/../td[2]/a[text()='{$fName} {$lName}']");
     $this->click("xpath=//table[@id='option51']/tbody/tr[1]/td[4]/a[text()='merge']");
     $this->waitForElementPresent('_qf_Merge_cancel-bottom');

--- a/tests/phpunit/WebTest/Contact/TagAddTest.php
+++ b/tests/phpunit/WebTest/Contact/TagAddTest.php
@@ -67,10 +67,10 @@ class WebTest_Contact_TagAddTest extends CiviSeleniumTestCase {
     $this->waitForElementPresent("css=table.display tbody tr td");
 
     // verify text
-    $this->waitForElementPresent("xpath=//table//tbody/tr/td[1][text()= '$tagName']");
-    $this->waitForElementPresent("xpath=//table//tbody/tr/td[1][text()= '$tagName']/following-sibling::td[2][text()='Adding new tag. ']");
-    $this->waitForElementPresent("xpath=//table//tbody/tr/td[1][text()= '$tagName']/following-sibling::td[4][text()= 'Contacts']");
-    $this->waitForElementPresent("xpath=//table//tbody/tr/td[1][text()= '$tagName']/following-sibling::td[7]/span/a[text()= 'Edit']");
+    $this->assertTrue($this->isTextPresent($tagName), 'Missing text: ' . $tagName);
+    $this->assertTrue($this->isTextPresent('Adding new tag.'), 'Missing text: ' . 'Adding new tag.');
+    $this->assertTrue($this->isTextPresent('Contacts'), 'Missing text: ' . 'Contacts');
+    $this->assertTrue($this->isTextPresent('Edit'), 'Missing text: ' . 'Edit');
   }
 
   public function testAddTagSet() {
@@ -105,9 +105,9 @@ class WebTest_Contact_TagAddTest extends CiviSeleniumTestCase {
     $this->waitForElementPresent("css=table.display tbody tr td");
 
     // verify text
-    $this->waitForElementPresent("xpath=//table//tbody/tr/td[1][text()= '$tagSetName']");
-    $this->waitForElementPresent("xpath=//table//tbody/tr/td[1][text()= '$tagSetName']/following-sibling::td[2][text()='Adding new tag set. ']");
-    $this->waitForElementPresent("xpath=//table//tbody/tr/td[1][text()= '$tagSetName']/following-sibling::td[4][text()= 'Contacts']");
-    $this->waitForElementPresent("xpath=//table//tbody/tr/td[1][text()= '$tagSetName']/following-sibling::td[7]/span/a[text()= 'Edit']");
+    $this->assertTrue($this->isTextPresent($tagSetName), 'Missing text: ' . $tagSetName);
+    $this->assertTrue($this->isTextPresent('Adding new tag set.'), 'Missing text: ' . 'Adding new tag set.');
+    $this->assertTrue($this->isTextPresent('Contacts'), 'Missing text: ' . 'Contacts');
+    $this->assertTrue($this->isTextPresent('Edit'), 'Missing text: ' . 'Edit');
   }
 }

--- a/tests/phpunit/WebTest/Contact/TagSetSearchTest.php
+++ b/tests/phpunit/WebTest/Contact/TagSetSearchTest.php
@@ -148,9 +148,9 @@ class WebTest_Contact_TagSetSearchTest extends CiviSeleniumTestCase {
     $this->waitForElementPresent("css=table.display tbody tr td");
 
     // verify text
-    $this->waitForElementPresent("xpath=//table//tbody/tr/td[1][text()= '$tagSetName']");
+    $this->assertTrue($this->isTextPresent($tagSetName), 'Missing text: ' . $tagSetName);
 
-    $tagid = explode('&id=', $this->getAttribute("xpath=//table//tbody/tr/td[1][text()= '$tagSetName']/following-sibling::td[7]/span/a[text()= 'Edit']@href"));
+    $tagid = explode('&id=', $this->getAttribute("xpath=//table[@class='display dataTable no-footer']/tbody//tr/td[1]/div[text()= '$tagSetName']/../../td[8]/span/a[text()= 'Edit']@href"));
     $tagid = explode('&', $tagid[1]);
     $tagid = $tagid[0];
 

--- a/tests/phpunit/WebTest/Contribute/ContributionPageAddTest.php
+++ b/tests/phpunit/WebTest/Contribute/ContributionPageAddTest.php
@@ -356,7 +356,9 @@ class WebTest_Contribute_ContributionPageAddTest extends CiviSeleniumTestCase {
 
     // fill in Receipt details
     $this->type('thankyou_title', "Thank-you Page Title $hash");
+    $this->click("xpath=//form[@id='ThankYou']/div[2]/table[1]/tbody/tr[2]/td[2]/div/a/span");
     $this->fillRichTextField('thankyou_text', 'This is thankyou message for ' . $pageTitle, 'CKEditor');
+    $this->click("xpath=//form[@id='ThankYou']/div[2]/table[1]/tbody/tr[3]/td[2]/div/a/span");
     $this->fillRichTextField('thankyou_footer', 'This is thankyou footer message for ' . $pageTitle, 'CKEditor');
     $this->click('is_email_receipt');
     $this->waitForElementPresent('bcc_receipt');

--- a/tests/phpunit/WebTest/Contribute/OfflineContributionTest.php
+++ b/tests/phpunit/WebTest/Contribute/OfflineContributionTest.php
@@ -46,7 +46,7 @@ class WebTest_Contribute_OfflineContributionTest extends CiviSeleniumTestCase {
 
     //financial account for check
     $this->openCiviPage("admin/options/payment_instrument", "reset=1");
-    $financialAccount = $this->getText("xpath=//div[@id='payment_instrument']/table/tbody//tr/td[1][text()='Check']/../td[3]");
+    $financialAccount = $this->getText("xpath=//div[@id='payment_instrument']/table/tbody//tr/td[1]/div[text()='Check']/../../td[3]");
 
     // Add new Financial Account
     $orgName = 'Alberta ' . substr(sha1(rand()), 0, 7);

--- a/tests/phpunit/WebTest/Event/AddPricesetTest.php
+++ b/tests/phpunit/WebTest/Event/AddPricesetTest.php
@@ -736,7 +736,8 @@ class WebTest_Event_AddPricesetTest extends CiviSeleniumTestCase {
 
     //check the delete for priceset
     $this->openCiviPage("admin/price", "reset=1");
-    $this->click("xpath=//table[@id='option11']/tbody/tr/td[4]/span[2]/ul/li[3]/a");
+    $this->waitForElementPresent("xpath=//div[@class='dataTables_wrapper no-footer']/table/tbody/tr/td[4]/span[2]");
+    $this->click("xpath=//div[@class='dataTables_wrapper no-footer']/table/tbody/tr/td[4]/span[2]/ul/li[3]/a");
     // Check confirmation alert.
     $this->assertTrue((bool) preg_match("/^Are you sure you want to delete this price set?/",
       $this->getConfirmation()

--- a/tests/phpunit/WebTest/Member/OfflineMembershipAddPricesetTest.php
+++ b/tests/phpunit/WebTest/Member/OfflineMembershipAddPricesetTest.php
@@ -91,7 +91,7 @@ class WebTest_Member_OfflineMembershipAddPricesetTest extends CiviSeleniumTestCa
     $setHelp          = 'Select your membership options.';
     $memTypeParams1 = $this->webtestAddMembershipType();
     $memTypeTitle1  = $memTypeParams1['membership_type'];
-    $memTypeId1     = explode('&id=', $this->getAttribute("xpath=//div[@id='membership_type']/table/tbody//tr/td[text()='{$memTypeTitle1}']/../td[12]/span/a[3]@href"));
+    $memTypeId1     = explode('&id=', $this->getAttribute("xpath=//div[@id='membership_type']/table/tbody//tr/td[1]/div[text()='{$memTypeTitle1}']/../../td[12]/span/a[3]@href"));
     $memTypeId1     = $memTypeId1[1];
     $this->_testAddSet($setTitle, $usedFor, $contributionType, $setHelp);
 
@@ -211,12 +211,12 @@ class WebTest_Member_OfflineMembershipAddPricesetTest extends CiviSeleniumTestCa
     $memTypeParams1 = $this->webtestAddMembershipType();
     $memTypeTitle1  = $memTypeParams1['membership_type'];
 
-    $memTypeId1     = explode('&id=', $this->getAttribute("xpath=//div[@id='membership_type']/table/tbody//tr/td[text()='{$memTypeTitle1}']/../td[12]/span/a[3]@href"));
+    $memTypeId1     = explode('&id=', $this->getAttribute("xpath=//div[@id='membership_type']/table/tbody//tr/td[1]/div[text()='{$memTypeTitle1}']/../../td[12]/span/a[3]@href"));
     $memTypeId1     = $memTypeId1[1];
 
     $memTypeParams2 = $this->webtestAddMembershipType();
     $memTypeTitle2  = $memTypeParams2['membership_type'];
-    $memTypeId2     = explode('&id=', $this->getAttribute("xpath=//div[@id='membership_type']/table/tbody//tr/td[text()='{$memTypeTitle2}']/../td[12]/span/a[3]@href"));
+    $memTypeId2     = explode('&id=', $this->getAttribute("xpath=//div[@id='membership_type']/table/tbody//tr/td[1]/div[text()='{$memTypeTitle2}']/../../td[12]/span/a[3]@href"));
     $memTypeId2     = $memTypeId2[1];
 
     $this->openCiviPage("admin/price/field", "reset=1&action=add&sid={$sid}");

--- a/tests/phpunit/WebTest/Member/OfflineMembershipRenewTest.php
+++ b/tests/phpunit/WebTest/Member/OfflineMembershipRenewTest.php
@@ -198,7 +198,7 @@ class WebTest_Member_OfflineMembershipRenewTest extends CiviSeleniumTestCase {
     // page was loaded
     $this->waitForTextPresent($sourceText);
 
-    $this->waitForElementPresent("xpath=//div[@id='memberships']/div/table/tbody/tr/td[9]/span/a[1][text()='View']");
+    $this->waitForElementPresent("xpath=//div[@id='memberships']/div/table/tbody/tr/td[9]/span[1]/a[1][text()='View']");
 
     // click through to the membership view screen
     $this->click("xpath=//div[@id='memberships']/div/table/tbody/tr/td[9]/span/a[1][text()='View']");

--- a/tests/phpunit/WebTest/Member/OnlineMembershipAddPricesetTest.php
+++ b/tests/phpunit/WebTest/Member/OnlineMembershipAddPricesetTest.php
@@ -226,12 +226,12 @@ class WebTest_Member_OnlineMembershipAddPricesetTest extends CiviSeleniumTestCas
   public function _testAddPriceFields(&$fields, &$validateString, $dateSpecificFields = FALSE, $title, $sid, $contributionType) {
     $memTypeParams1 = $this->webtestAddMembershipType();
     $memTypeTitle1 = $memTypeParams1['membership_type'];
-    $memTypeId1 = explode('&id=', $this->getAttribute("xpath=//div[@id='membership_type']/table/tbody//tr/td[1][text()='{$memTypeTitle1}']/../td[12]/span/a[3]@href"));
+    $memTypeId1 = explode('&id=', $this->getAttribute("xpath=//div[@id='membership_type']/table/tbody//tr/td[1]/div[text()='{$memTypeTitle1}']/../../td[12]/span/a[3]@href"));
     $memTypeId1 = $memTypeId1[1];
 
     $memTypeParams2 = $this->webtestAddMembershipType();
     $memTypeTitle2 = $memTypeParams2['membership_type'];
-    $memTypeId2 = explode('&id=', $this->getAttribute("xpath=//div[@id='membership_type']/table/tbody//tr/td[1][text()='{$memTypeTitle2}']/../td[12]/span/a[3]@href"));
+    $memTypeId2 = explode('&id=', $this->getAttribute("xpath=//div[@id='membership_type']/table/tbody//tr/td[1]/div[text()='{$memTypeTitle2}']/../../td[12]/span/a[3]@href"));
     $memTypeId2 = $memTypeId2[1];
 
     $this->openCiviPage('admin/price/field', "reset=1&action=add&sid={$sid}");

--- a/tests/phpunit/WebTest/Member/OnlineMembershipCreateTest.php
+++ b/tests/phpunit/WebTest/Member/OnlineMembershipCreateTest.php
@@ -94,12 +94,12 @@ class WebTest_Member_OnlineMembershipCreateTest extends CiviSeleniumTestCase {
     // create two new membership types
     $memTypeParams1 = $this->webtestAddMembershipType();
     $memTypeTitle1 = $memTypeParams1['membership_type'];
-    $memTypeId1 = explode('&id=', $this->getAttribute("xpath=//div[@id='membership_type']/table/tbody//tr/td[1][text()='{$memTypeTitle1}']/../td[12]/span/a[3]@href"));
+    $memTypeId1 = explode('&id=', $this->getAttribute("xpath=//div[@id='membership_type']/table/tbody//tr/td[1]/div[text()='{$memTypeTitle1}']/../../td[12]/span/a[3]@href"));
     $memTypeId1 = $memTypeId1[1];
 
     $memTypeParams2 = $this->webtestAddMembershipType();
     $memTypeTitle2 = $memTypeParams2['membership_type'];
-    $memTypeId2 = explode('&id=', $this->getAttribute("xpath=//div[@id='membership_type']/table/tbody//tr/td[1][text()='{$memTypeTitle2}']/../td[12]/span/a[3]@href"));
+    $memTypeId2 = explode('&id=', $this->getAttribute("xpath=//div[@id='membership_type']/table/tbody//tr/td[1]/div[text()='{$memTypeTitle2}']/../../td[12]/span/a[3]@href"));
     $memTypeId2 = $memTypeId2[1];
 
     // edit contribution page memberships tab to add two new membership types

--- a/tests/phpunit/WebTest/Member/OnlineMembershipRenewTest.php
+++ b/tests/phpunit/WebTest/Member/OnlineMembershipRenewTest.php
@@ -406,8 +406,8 @@ class WebTest_Member_OnlineMembershipRenewTest extends CiviSeleniumTestCase {
     $this->waitForElementPresent('link=Add Membership Type');
     $this->waitForText('crm-notification-container', "The membership type 'Membership Type $title' has been saved.");
 
-    $this->waitForElementPresent("xpath=//div[@id='membership_type']/table/tbody//tr/td[1][text()='{$membershipTypeTitle}']/../td[12]/span/a[3][text()='Delete']/@href");
-    $url = $this->getAttribute("xpath=//div[@id='membership_type']/table/tbody//tr/td[1][text()='{$membershipTypeTitle}']/../td[12]/span/a[3][text()='Delete']/@href");
+    $this->waitForElementPresent("xpath=//div[@id='membership_type']/table/tbody//tr/td[1]/div[text()='{$membershipTypeTitle}']/../../td[12]/span/a[3][text()='Delete']/@href");
+    $url = $this->getAttribute("xpath=//div[@id='membership_type']/table/tbody//tr/td[1]/div[text()='{$membershipTypeTitle}']/../../td[12]/span/a[3][text()='Delete']/@href");
     $matches = array();
     preg_match('/id=([0-9]+)/', $url, $matches);
     $membershipTypeId = $matches[1];

--- a/tests/phpunit/WebTest/Member/SeperateMembershipPaymentTest.php
+++ b/tests/phpunit/WebTest/Member/SeperateMembershipPaymentTest.php
@@ -92,12 +92,12 @@ class WebTest_Member_SeperateMembershipPaymentTest extends CiviSeleniumTestCase 
     // create new membership types
     $memTypeParams1 = $this->webtestAddMembershipType();
     $memTypeTitle1  = $memTypeParams1['membership_type'];
-    $memTypeId1     = explode('&id=', $this->getAttribute("xpath=//div[@id='membership_type']/table/tbody//tr/td[text()='{$memTypeTitle1}']/../td[12]/span/a[3]@href"));
+    $memTypeId1     = explode('&id=', $this->getAttribute("xpath=//div[@id='membership_type']/table/tbody//tr/td/div[text()='{$memTypeTitle1}']/../../td[12]/span/a[3]@href"));
     $memTypeId1     = $memTypeId1[1];
 
     $memTypeParams2 = $this->webtestAddMembershipType();
     $memTypeTitle2  = $memTypeParams2['membership_type'];
-    $memTypeId2     = explode('&id=', $this->getAttribute("xpath=//div[@id='membership_type']/table/tbody//tr/td[text()='{$memTypeTitle2}']/../td[12]/span/a[3]@href"));
+    $memTypeId2     = explode('&id=', $this->getAttribute("xpath=//div[@id='membership_type']/table/tbody//tr/td/div[text()='{$memTypeTitle2}']/../../td[12]/span/a[3]@href"));
     $memTypeId2     = $memTypeId2[1];
 
     // edit contribution page memberships tab to add two new membership types

--- a/tests/phpunit/WebTest/Profile/ProfileAddTest.php
+++ b/tests/phpunit/WebTest/Profile/ProfileAddTest.php
@@ -236,8 +236,8 @@ class WebTest_Profile_ProfileAddTest extends CiviSeleniumTestCase {
    */
   public function _testdeleteProfile($profileTitle) {
     //$this->waitForPageToLoad($this->getTimeoutMsec());
-    $this->waitForElementPresent("xpath=//div[@id='user-profiles']/div/div/table/tbody//tr/td/span[text() = '$profileTitle']/../../td[7]/span[2][text()='more']/ul//li/a[text()='Delete']");
-    $this->click("xpath=//div[@id='user-profiles']/div/div/table/tbody//tr/td/span[text() = '$profileTitle']/../../td[7]/span[2][text()='more']/ul//li/a[text()='Delete']");
+    $this->waitForElementPresent("xpath=//div[@id='user-profiles']/div/div/table/tbody//tr/td/div[text() = '$profileTitle']/../../td[7]/span[2][text()='more']/ul//li/a[text()='Delete']");
+    $this->click("xpath=//div[@id='user-profiles']/div/div/table/tbody//tr/td/div[text() = '$profileTitle']/../../td[7]/span[2][text()='more']/ul//li/a[text()='Delete']");
 
     $this->waitForElementPresent('_qf_Group_next-bottom');
     $this->click('_qf_Group_next-bottom');

--- a/tests/phpunit/WebTest/Profile/ProfileGroupSubscriptionTest.php
+++ b/tests/phpunit/WebTest/Profile/ProfileGroupSubscriptionTest.php
@@ -135,8 +135,8 @@ class WebTest_Profile_ProfileGroupSubscriptionTest extends CiviSeleniumTestCase 
    * @param $profileTitle
    */
   public function _testdeleteProfile($profileTitle) {
-    $this->waitForElementPresent("xpath=//div[@id='user-profiles']/div/div[1]/table/tbody//tr/td[1]/span[text() = '$profileTitle']/../../td[7]/span[2][text()='more']/ul/li[5]/a[text()='Delete']");
-    $this->click("xpath=//div[@id='user-profiles']/div/div[1]/table/tbody//tr/td[1]/span[text() = '$profileTitle']/../../td[7]/span[2][text()='more']/ul/li[5]/a[text()='Delete']");
+    $this->waitForElementPresent("xpath=//div[@id='user-profiles']/div/div[1]/table/tbody//tr/td[1]/div[text() = '$profileTitle']/../../td[7]/span[2][text()='more']/ul//li/a[text()='Delete']");
+    $this->click("xpath=//div[@id='user-profiles']/div/div[1]/table/tbody//tr/td[1]/div[text() = '$profileTitle']/../../td[7]/span[2][text()='more']/ul//li/a[text()='Delete']");
     $this->waitForElementPresent('_qf_Group_next-bottom');
     $this->click('_qf_Group_next-bottom');
     $this->waitForElementPresent('newCiviCRMProfile-bottom');


### PR DESCRIPTION
Fix for Following webtests: 

WebTest_Member_OfflineMembershipAddPricesetTest.testAddPriceSet
WebTest_Member_OfflineMembershipAddPricesetTest.testAddPriceSetWithMultipleTerms WebTest_Member_OfflineMembershipRenewTest.testOfflineMemberRenewOverride
WebTest_Member_OnlineMembershipRenewTest::testUpdateInheritedMembershipOnBehalfOfRenewal WebTest_Member_OnlineMembershipCreateTest.testOnlineMembershipCreate
WebTest_Member_SeperateMembershipPaymentTest.testSeperateMembershipCreate
WebTest_Member_OnlineMembershipAddPricesetTest.testAddPriceSet

WebTest_Contact_CustomDataAddTest.testCustomDataMoneyAdd
WebTest_Contact_MergeContactsTest.testMergeContactSubType
WebTest_Contact_TagSetSearchTest.testTagSetSearch
WebTest_Contribute_OfflineContributionTest.testStandaloneContributeAdd
WebTest_Contribute_ContributionPageAddTest.testContributionPageAddPremiumRequiredField

WebTest_Contact_TagAddTest.testAddTagSet
WebTest_Contact_TagAddTest.testAddTag
WebTest_Event_AddPricesetTest::testDeletePriceSetforEventTemplate
WebTest_Profile_ProfileGroupSubscriptionTest.testProfileGroupSubscription
WebTest_Profile_ProfileAddTest.testAddNewProfile
WebTest_Profile_ProfileAddTest.testCheckDescAndCreatedIdFields 
