### PR TITLE
CRM-15799 - CRM_Utils_File - Improve error handling

### DIFF
--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -146,8 +146,8 @@ class CRM_Utils_File {
       throw new Exception("Overly broad deletion");
     }
 
-    if ($sourcedir = @opendir($target)) {
-      while (FALSE !== ($sibling = readdir($sourcedir))) {
+    if ($dh = @opendir($target)) {
+      while (FALSE !== ($sibling = readdir($dh))) {
         if (!in_array($sibling, $exceptions)) {
           $object = $target . DIRECTORY_SEPARATOR . $sibling;
 
@@ -161,7 +161,7 @@ class CRM_Utils_File {
         }
       }
       }
-      closedir($sourcedir);
+      closedir($dh);
 
       if ($rmdir) {
         if (rmdir($target)) {
@@ -182,19 +182,20 @@ class CRM_Utils_File {
    * @param $destination
    */
   static function copyDir($source, $destination) {
-    $dir = opendir($source);
-    @mkdir($destination);
-    while (FALSE !== ($file = readdir($dir))) {
-      if (($file != '.') && ($file != '..')) {
-        if (is_dir($source . DIRECTORY_SEPARATOR . $file)) {
-          CRM_Utils_File::copyDir($source . DIRECTORY_SEPARATOR . $file, $destination . DIRECTORY_SEPARATOR . $file);
-        }
-        else {
-          copy($source . DIRECTORY_SEPARATOR . $file, $destination . DIRECTORY_SEPARATOR . $file);
+    if ($dh = opendir($source)) {
+      @mkdir($destination);
+      while (FALSE !== ($file = readdir($dh))) {
+        if (($file != '.') && ($file != '..')) {
+          if (is_dir($source . DIRECTORY_SEPARATOR . $file)) {
+            CRM_Utils_File::copyDir($source . DIRECTORY_SEPARATOR . $file, $destination . DIRECTORY_SEPARATOR . $file);
+          }
+          else {
+            copy($source . DIRECTORY_SEPARATOR . $file, $destination . DIRECTORY_SEPARATOR . $file);
+          }
         }
       }
+      closedir($dh);
     }
-    closedir($dir);
   }
 
   /**
@@ -400,14 +401,15 @@ class CRM_Utils_File {
    */
   static function getFilesByExtension($path, $ext) {
     $path  = self::addTrailingSlash($path);
-    $dh    = opendir($path);
     $files = array();
-    while (FALSE !== ($elem = readdir($dh))) {
-      if (substr($elem, -(strlen($ext) + 1)) == '.' . $ext) {
-        $files[] .= $path . $elem;
+    if ($dh = opendir($path)) {
+      while (FALSE !== ($elem = readdir($dh))) {
+        if (substr($elem, -(strlen($ext) + 1)) == '.' . $ext) {
+          $files[] .= $path . $elem;
+        }
       }
+      closedir($dh);
     }
-    closedir($dh);
     return $files;
   }
 
@@ -618,8 +620,7 @@ HTACCESS;
           }
         }
       }
-      $dh = opendir($subdir);
-      if ($dh) {
+      if ($dh = opendir($subdir)) {
         while (FALSE !== ($entry = readdir($dh))) {
           $path = $subdir . DIRECTORY_SEPARATOR . $entry;
           if ($entry{0} == '.') {


### PR DESCRIPTION
The title doesn't really reflect the subject of this modification, but what fixed here _is_ the reason why mysql was ran out of space.

Basically, the original code produced infinite loop:

``` php
 static function getFilesByExtension($path, $ext) {
    $path  = self::addTrailingSlash($path);
    $dh = opendir($path);
    $files = array();
    while (FALSE !== ($elem = readdir($dh))) {
```

i.e. it didn't check the result of `opendir($path)`, but if it doesn't return correct resource (which is the case if directory doesn't exist for example), then we get all the bad things:
1) `FALSE !== ($elem = readdir($dh))` is always TRUE => loop is infinite
2) Drupal's error_handler write record to watchdog log on every such error ($dh is boolean, not a resource)

This simple patch fixes the issue in `getFilesByExtension()` and `copyDir()`
Minor fixes: renamed directory resources vars to $dh; minor aesthetic optimization (621-622 lines).

---
- CRM-15799: System crash on attempt to upgrade from 4.5.4 to 4.5.5
  https://issues.civicrm.org/jira/browse/CRM-15799
