### PR TITLE
Feature: CRM/Dedupe/Merger.php updates other referencing tables

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -196,6 +196,7 @@ class CRM_Dedupe_Merger {
     if (!$cidRefs) {
       $sql = "
 SELECT
+	table_schema,
     table_name,
     column_name
 FROM information_schema.key_column_usage
@@ -206,7 +207,7 @@ WHERE
       ";
       $dao = CRM_Core_DAO::executeQuery($sql);
       while ($dao->fetch()) {
-        $cidRefs[$dao->table_name][] = $dao->column_name;
+        $cidRefs[$dao->table_schema . "." . $dao->table_name][] = $dao->column_name;
       }
 
       // FixME for time being adding below line statically as no Foreign key constraint defined for table 'civicrm_entity_tag'


### PR DESCRIPTION
We are using CiviCRM as our main CRM system, and over time we built custom projects that uses CiviCRM's database as contact storage database. These projects has foreign keys to some CiviCRM tables (e.g. column "id" in civicrm_contact).

Normally, when merging contacts in CiviCRM, CRM/Dedupe/Merger.php recursively updates contact ID in other referencing tables. However in my case, some referencing tables are in different databases, and the UPDATE query in Merger.php will produce "table does not exist" error because it did not specify database name.

As a quick fix, appending the corresponding database name will resolve this issue. This will only work if CiviCRM database shares the same credentials with other referencing databases.
