### PR TITLE
Allow end dates of auto-renew memberships to be edited.

### DIFF
--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -135,9 +135,9 @@
           <br />
           <span class="description">{ts}First day of current continuous membership period. Start Date will be automatically set based on Membership Type if you don't select a date.{/ts}</span></td></tr>
         <tr class="crm-membership-form-block-end_date"><td class="label">{$form.end_date.label}</td>
-          <td>{if $isRecur && $endDate}{$endDate|crmDate}{else}{include file="CRM/common/jcalendar.tpl" elementName=end_date}{/if}
+          <td>{include file="CRM/common/jcalendar.tpl" elementName=end_date}
             <br />
-            <span class="description">{ts}Latest membership period expiration date. End Date will be automatically set based on Membership Type if you don't select a date.{/ts}</span></td></tr>
+            <span class="description">{ts}Latest membership period expiration date. End Date will be automatically set based on Membership Type if you don't select a date.  If the membership is auto-renew, the expiration date will be overridden upon the next billing cycle.{/ts}</span></td></tr>
         {if !empty($form.auto_renew)}
           <tr id="autoRenew" class="crm-membership-form-block-auto_renew">
             <td class="label"> {$form.auto_renew.label} {help id="id-auto_renew" file="CRM/Member/Form/Membership.hlp" action=$action} </td>


### PR DESCRIPTION
It is convenient to be able to adjust the expiration date for auto-renew memberships, even though the auto-renew system will override that date upon the next billing cycle.  A example use-case for this is when there's a temporary failure within the system that results in a successful PayPal recurring payment, but Civi doesn't process it.  With this patch, back office staff can record the contribution manually (as they already can), adjust the membership's expiration date, and let things continue as normal during the next automatic billing cycle.
