### PR TITLE
CRM-15798 adjust membership date calculation for multiyear membership

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -105,7 +105,7 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
     if (empty($membership->contact_id) || empty($membership->status_id)) {
       // this means we are in renewal mode and are just updating the membership
       // record or this is an API update call and all fields are not present in the update record
-      // however the hooks dont care and want all data CRM-7784
+      // however the hooks don't care and want all data CRM-7784
       $tempMembership = new CRM_Member_DAO_Membership();
       $tempMembership->id = $membership->id;
       $tempMembership->find(TRUE);

--- a/CRM/Member/BAO/MembershipType.php
+++ b/CRM/Member/BAO/MembershipType.php
@@ -163,6 +163,7 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
       $baoString = 'CRM_Member_BAO_' . $name;
       $dao = new $baoString();
       $dao->$field = $membershipTypeId;
+      /** @noinspection PhpUndefinedMethodInspection */
       if ($dao->find(TRUE)) {
         $check = TRUE;
         $status[] = $name;
@@ -359,7 +360,7 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
           $fixedStartDate = date('Y-m-d', mktime(0, 0, 0, $startMonth, $startDay, $year - 1));
         }
         $actualStartDate = $fixedStartDate;
-        $fixed_period_rollover = self::isDuringFixedAnnualRolloverPeriod($joinDate, $numRenewTerms, $membershipTypeDetails, $year, $fixedStartDate);
+        $fixed_period_rollover = self::isDuringFixedAnnualRolloverPeriod($joinDate, $membershipTypeDetails, $year, $fixedStartDate);
 
         if (!$startDate) {
           $startDate = $actualStartDate;
@@ -440,13 +441,12 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
    * May and June will return TRUE and between June and May will return FALSE
    *
    * @param string $startDate start date of current membership period
-   * @param int $numRenewTerms
    * @param array $membershipTypeDetails
    * @param int $year
-   * @param $actualStartDate
+   * @param $fixedStartDate
    * @return bool is this in the window where the membership gets an extra part-period added
    */
-  protected static function isDuringFixedAnnualRolloverPeriod($startDate, $numRenewTerms, $membershipTypeDetails, $year, $actualStartDate) {
+  protected static function isDuringFixedAnnualRolloverPeriod($startDate, $membershipTypeDetails, $year, $fixedStartDate) {
 
     $rolloverMonth = substr($membershipTypeDetails['fixed_period_rollover_day'], 0,
       strlen($membershipTypeDetails['fixed_period_rollover_day']) - 2
@@ -627,17 +627,17 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
    *   array of the details of membership types with Member of Contact id
    */
   public static function getMemberOfContactByMemTypes($membershipTypes) {
-    $memTypeOrgs = array();
+    $memTypeOrganizations = array();
     if (empty($membershipTypes)) {
-      return $memTypeOrgs;
+      return $memTypeOrganizations;
     }
 
     $result = CRM_Core_DAO::executeQuery("SELECT id, member_of_contact_id FROM civicrm_membership_type WHERE id IN (" . implode(',', $membershipTypes) . ")");
     while ($result->fetch()) {
-      $memTypeOrgs[$result->id] = $result->member_of_contact_id;
+      $memTypeOrganizations[$result->id] = $result->member_of_contact_id;
     }
 
-    return $memTypeOrgs;
+    return $memTypeOrganizations;
   }
 
   /**
@@ -648,7 +648,7 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
    * @return array
    */
   public static function getMembershipTypeOrganization($membershipTypeId = NULL) {
-    $allmembershipTypes = array();
+    $allMembershipTypes = array();
 
     $membershipType = new CRM_Member_DAO_MembershipType();
 
@@ -658,9 +658,9 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
     $membershipType->find();
 
     while ($membershipType->fetch()) {
-      $allmembershipTypes[$membershipType->id] = $membershipType->member_of_contact_id;
+      $allMembershipTypes[$membershipType->id] = $membershipType->member_of_contact_id;
     }
-    return $allmembershipTypes;
+    return $allMembershipTypes;
   }
 
   /**
@@ -779,6 +779,7 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
    * @param array $params
    */
   public static function updateAllPriceFieldValue($membershipTypeId, $params) {
+    $updateFields = array();
     if (!empty($params['minimum_fee'])) {
       $amount = $params['minimum_fee'];
     }

--- a/CRM/Member/BAO/MembershipType.php
+++ b/CRM/Member/BAO/MembershipType.php
@@ -464,7 +464,7 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
     $endDateOfFirstYearMembershipPeriod = date('Y-m-d', mktime(0, 0, 0,
       $dateParts[1],
       $dateParts[2] - 1,
-      $dateParts[0] + ($numRenewTerms * $membershipTypeDetails['duration_interval'])
+      $dateParts[0] + 1
     ));
 
     //we know the month and day of the rollover date but not the year (we're just

--- a/CRM/Member/BAO/MembershipType.php
+++ b/CRM/Member/BAO/MembershipType.php
@@ -360,7 +360,7 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
         else {
           $actualStartDate = date('Y-m-d', mktime(0, 0, 0, $startMonth, $startDay, $year - 1));
         }
-;
+
         $fixed_period_rollover = self::isDuringFixedAnnualRolloverPeriod($joinDate, $membershipTypeDetails, $year, $actualStartDate);
 
         if (!$startDate) {

--- a/CRM/Member/BAO/MembershipType.php
+++ b/CRM/Member/BAO/MembershipType.php
@@ -35,21 +35,21 @@
 class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
 
   /**
-   * Static holder for the default LT
+   * Static holder for the default Membership Type.
    */
   static $_defaultMembershipType = NULL;
 
   static $_membershipTypeInfo = array();
 
   /**
-   * Class constructor
+   * Class constructor.
    */
   public function __construct() {
     parent::__construct();
   }
 
   /**
-   * Fetch object based on array of properties
+   * Fetch object based on array of properties.
    *
    * @param array $params
    *   (reference ) an assoc array of name/value pairs.
@@ -69,7 +69,7 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
   }
 
   /**
-   * Update the is_active flag in the db
+   * Update the is_active flag in the db.
    *
    * @param int $id
    *   Id of the database record.
@@ -84,7 +84,7 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
   }
 
   /**
-   * Add the membership types
+   * Add the membership types.
    *
    * @param array $params
    *   Reference array contains the values submitted by the form.
@@ -133,7 +133,8 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
   }
 
   /**
-   * Flush anywhere that membership types might be cached
+   * Flush anywhere that membership types might be cached.
+   *
    * @throws \CiviCRM_API3_Exception
    */
   public static function flush() {
@@ -143,7 +144,7 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
   }
 
   /**
-   * Delete membership Types
+   * Delete membership Types.
    *
    * @param int $membershipTypeId
    *
@@ -151,7 +152,7 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
    * @return bool|mixed
    */
   public static function del($membershipTypeId) {
-    //check dependencies
+    // Check dependencies.
     $check = FALSE;
     $status = array();
     $dependency = array(
@@ -207,7 +208,7 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
   }
 
   /**
-   * Convert membership Type's 'start day' & 'rollover day' to human readable formats.
+   * Convert membership type's 'start day' & 'rollover day' to human readable formats.
    *
    * @param array $membershipType
    *   An array of membershipType-details.
@@ -248,7 +249,7 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
   }
 
   /**
-   * Get membership Types
+   * Get membership Types.
    *
    * @param bool $public
    *
@@ -271,7 +272,7 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
   }
 
   /**
-   * Get membership Type Details
+   * Get membership Type Details.
    *
    * @param int $membershipTypeId
    *
@@ -294,7 +295,7 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
   }
 
   /**
-   * Calculate start date and end date for new membership
+   * Calculate start date and end date for new membership.
    *
    * @param int $membershipTypeId
    *   Membership type id.
@@ -312,7 +313,7 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
   public static function getDatesForMembershipType($membershipTypeId, $joinDate = NULL, $startDate = NULL, $endDate = NULL, $numRenewTerms = 1) {
     $membershipTypeDetails = self::getMembershipTypeDetails($membershipTypeId);
 
-    // convert all dates to 'Y-m-d' format.
+    // Convert all dates to 'Y-m-d' format.
     foreach (array(
                'joinDate',
                'startDate',
@@ -354,13 +355,13 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
         $startDay = substr($membershipTypeDetails['fixed_period_start_day'], -2);
 
         if (date('Y-m-d', mktime(0, 0, 0, $startMonth, $startDay, $year)) <= date('Y-m-d', mktime(0, 0, 0, $month, $day, $year))) {
-          $fixedStartDate = date('Y-m-d', mktime(0, 0, 0, $startMonth, $startDay, $year));
+          $actualStartDate = date('Y-m-d', mktime(0, 0, 0, $startMonth, $startDay, $year));
         }
         else {
-          $fixedStartDate = date('Y-m-d', mktime(0, 0, 0, $startMonth, $startDay, $year - 1));
+          $actualStartDate = date('Y-m-d', mktime(0, 0, 0, $startMonth, $startDay, $year - 1));
         }
-        $actualStartDate = $fixedStartDate;
-        $fixed_period_rollover = self::isDuringFixedAnnualRolloverPeriod($joinDate, $membershipTypeDetails, $year, $fixedStartDate);
+;
+        $fixed_period_rollover = self::isDuringFixedAnnualRolloverPeriod($joinDate, $membershipTypeDetails, $year, $actualStartDate);
 
         if (!$startDate) {
           $startDate = $actualStartDate;
@@ -381,7 +382,7 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
       }
     }
 
-    //calculate end date if it is not passed by user
+    // Calculate end date if it is not passed by user.
     if (!$endDate) {
       //end date calculation
       $date = explode('-', $actualStartDate);

--- a/CRM/Member/BAO/MembershipType.php
+++ b/CRM/Member/BAO/MembershipType.php
@@ -444,10 +444,10 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
    * @param string $startDate start date of current membership period
    * @param array $membershipTypeDetails
    * @param int $year
-   * @param $fixedStartDate
+   * @param string $actualStartDate
    * @return bool is this in the window where the membership gets an extra part-period added
    */
-  protected static function isDuringFixedAnnualRolloverPeriod($startDate, $membershipTypeDetails, $year, $fixedStartDate) {
+  protected static function isDuringFixedAnnualRolloverPeriod($startDate, $membershipTypeDetails, $year, $actualStartDate) {
 
     $rolloverMonth = substr($membershipTypeDetails['fixed_period_rollover_day'], 0,
       strlen($membershipTypeDetails['fixed_period_rollover_day']) - 2

--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -1016,13 +1016,44 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test that if membership start date is not set it defaults to correct end date for fixed multi year memberships.
+   * Test correct end and start dates are calculated for fixed multi year memberships.
+   *
+   * The empty start date is calculated to be the start_date (1 Jan prior to the join_date - so 1 Jan 15)
    *
    * In this set our start date is after the start day and before the rollover day so we don't get an extra year
    * and we end one day before the rollover day. Start day is 1 Jan so we end on 31 Dec
    * and we add on 4 years rather than 5 because we are not after the rollover day - so we calculate 31 Dec 2019
    */
-  public function testEmptyStartEndDateFixedMultiYearDateSetTwo() {
+  public function testFixedMultiYearDateSetTwoEmptyStartEndDate() {
+    unset($this->_params['start_date'], $this->_params['is_override'], $this->_params['end_date']);
+
+    $this->callAPISuccess('membership_type', 'create', array(
+      'id' => $this->_membershipTypeID2,
+      'duration_interval' => 5,
+      // Ie 1 Jan.
+      'fixed_period_start_day' => '101',
+      // Ie. 1 Nov.
+      'fixed_period_rollover_day' => '1101',
+    ));
+    $this->_params['membership_type_id'] = $this->_membershipTypeID2;
+    $dates = array(
+      'join_date' => '28-Jan 2015',
+    );
+    $result = $this->callAPISuccess($this->_entity, 'create', array_merge($this->_params, $dates));
+    $result = $this->callAPISuccess($this->_entity, 'getsingle', array('id' => $result['id']));
+    $this->assertEquals('2015-01-28', $result['join_date']);
+    $this->assertEquals('2015-01-01', $result['start_date']);
+    $this->assertEquals('2019-12-31', $result['end_date']);
+  }
+
+  /**
+   * Test that correct end date is calculated for fixed multi year memberships and start date is not changed.
+   *
+   * In this set our start date is after the start day and before the rollover day so we don't get an extra year
+   * and we end one day before the rollover day. Start day is 1 Jan so we end on 31 Dec
+   * and we add on 4 years rather than 5 because we are not after the rollover day - so we calculate 31 Dec 2019
+   */
+  public function testFixedMultiYearDateSetTwoEmptyEndDate() {
     unset($this->_params['start_date'], $this->_params['is_override'], $this->_params['end_date']);
 
     $this->callAPISuccess('membership_type', 'create', array(
@@ -1046,13 +1077,44 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test that if membership start date is not set it defaults to correct end date for fixed single year memberships.
+   * Test correct end and start dates are calculated for fixed multi year memberships.
+   *
+   * The empty start date is calculated to be the start_date (1 Jan prior to the join_date - so 1 Jan 15)
    *
    * In this set our start date is after the start day and before the rollover day so we don't get an extra year
    * and we end one day before the rollover day. Start day is 1 Jan so we end on 31 Dec
    * and we add on <1 years rather than > 1 because we are not after the rollover day - so we calculate 31 Dec 2015
    */
-  public function testEmptyStartEndDateFixedSingleYearDateSetTwo() {
+  public function testFixedSingleYearDateSetTwoEmptyStartEndDate() {
+    unset($this->_params['start_date'], $this->_params['is_override'], $this->_params['end_date']);
+
+    $this->callAPISuccess('membership_type', 'create', array(
+      'id' => $this->_membershipTypeID2,
+      'duration_interval' => 1,
+      // Ie 1 Jan.
+      'fixed_period_start_day' => '101',
+      // Ie. 1 Nov.
+      'fixed_period_rollover_day' => '1101',
+    ));
+    $this->_params['membership_type_id'] = $this->_membershipTypeID2;
+    $dates = array(
+      'join_date' => '28-Jan 2015',
+    );
+    $result = $this->callAPISuccess($this->_entity, 'create', array_merge($this->_params, $dates));
+    $result = $this->callAPISuccess($this->_entity, 'getsingle', array('id' => $result['id']));
+    $this->assertEquals('2015-01-28', $result['join_date']);
+    $this->assertEquals('2015-01-01', $result['start_date']);
+    $this->assertEquals('2015-12-31', $result['end_date']);
+  }
+
+  /**
+   * Test correct end date for fixed single year memberships is calculated and start_date is not changed.
+   *
+   * In this set our start date is after the start day and before the rollover day so we don't get an extra year
+   * and we end one day before the rollover day. Start day is 1 Jan so we end on 31 Dec
+   * and we add on <1 years rather than > 1 because we are not after the rollover day - so we calculate 31 Dec 2015
+   */
+  public function testFixedSingleYearDateSetTwoEmptyEndDate() {
     unset($this->_params['start_date'], $this->_params['is_override'], $this->_params['end_date']);
 
     $this->callAPISuccess('membership_type', 'create', array(
@@ -1076,13 +1138,13 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test that if membership start date is not set it defaults to correct end date for fixed multi year memberships.
+   * Test that correct end date is calculated for fixed multi year memberships and start date is not changed.
    *
    * In this set our start date is after the start day and after the rollover day so we do get an extra year
    * and we end one day before the rollover day. Start day is 1 Nov so we end on 31 Oct
-   * and we add on 5 years we are after the rollover day - so we calculate 31 Oct 2020
+   * and we add on 1 year we are after the rollover day - so we calculate 31 Oct 2016
    */
-  public function testEmptyStartEndDateFixedSingleYearDateSetThree() {
+  public function testFixedSingleYearDateSetThreeEmptyEndDate() {
     unset($this->_params['start_date'], $this->_params['is_override'], $this->_params['end_date']);
 
     $this->callAPISuccess('membership_type', 'create', array(
@@ -1105,15 +1167,45 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     $this->assertEquals('2016-10-31', $result['end_date']);
   }
 
+  /**
+   * Test correct end and start dates are calculated for fixed multi year memberships.
+   *
+   *  The empty start date is calculated to be the start_date (1 Nov prior to the join_date - so 1 Nov 14)
+   *
+   * In this set our start date is after the start day and after the rollover day so we do get an extra year
+   * and we end one day before the rollover day. Start day is 1 Nov so we end on 31 Oct
+   * and we add on 1 year we are after the rollover day - so we calculate 31 Oct 2016
+   */
+  public function testFixedSingleYearDateSetThreeEmptyStartEndDate() {
+    unset($this->_params['start_date'], $this->_params['is_override'], $this->_params['end_date']);
+
+    $this->callAPISuccess('membership_type', 'create', array(
+      'id' => $this->_membershipTypeID2,
+      'duration_interval' => 1,
+      // Ie. 1 Nov.
+      'fixed_period_start_day' => '1101',
+      // Ie 1 Jan.
+      'fixed_period_rollover_day' => '101',
+    ));
+    $this->_params['membership_type_id'] = $this->_membershipTypeID2;
+    $dates = array(
+      'join_date' => '28-Jan 2015',
+    );
+    $result = $this->callAPISuccess($this->_entity, 'create', array_merge($this->_params, $dates));
+    $result = $this->callAPISuccess($this->_entity, 'getsingle', array('id' => $result['id']));
+    $this->assertEquals('2015-01-28', $result['join_date']);
+    $this->assertEquals('2014-11-01', $result['start_date']);
+    $this->assertEquals('2016-10-31', $result['end_date']);
+  }
 
   /**
-   * Test that if membership start date is not set it defaults to correct end date for fixed multi year memberships.
+   * Test that correct end date is calculated for fixed multi year memberships and start date is not changed.
    *
    * In this set our start date is after the start day and after the rollover day so we do get an extra year
    * and we end one day before the rollover day. Start day is 1 Nov so we end on 31 Oct
    * and we add on 5 years we are after the rollover day - so we calculate 31 Oct 2020
    */
-  public function testEmptyStartEndDateFixedMultiYearDateSetThree() {
+  public function testFixedMultiYearDateSetThreeEmptyEndDate() {
     unset($this->_params['start_date'], $this->_params['is_override'], $this->_params['end_date']);
 
     $this->callAPISuccess('membership_type', 'create', array(
@@ -1133,6 +1225,38 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     $result = $this->callAPISuccess($this->_entity, 'getsingle', array('id' => $result['id']));
     $this->assertEquals('2015-01-28', $result['join_date']);
     $this->assertEquals('2015-01-28', $result['start_date']);
+    $this->assertEquals('2020-10-31', $result['end_date']);
+  }
+
+  /**
+   * Test correct end and start dates are calculated for fixed multi year memberships.
+   *
+   *  The empty start date is calculated to be the start_date (1 Nov prior to the join_date - so 1 Nov 14)
+   *
+   * The empty start date is calculated to be the start_date (1 Nov prior to the join_date - so 1 Nov 14)
+   * In this set our join date is after the start day and after the rollover day so we do get an extra year
+   * and we end one day before the rollover day. Start day is 1 Nov so we end on 31 Oct
+   * and we add on 5 years we are after the rollover day - so we calculate 31 Oct 2020
+   */
+  public function testFixedMultiYearDateSetThreeEmptyStartEndDate() {
+    unset($this->_params['start_date'], $this->_params['is_override'], $this->_params['end_date']);
+
+    $this->callAPISuccess('membership_type', 'create', array(
+      'id' => $this->_membershipTypeID2,
+      'duration_interval' => 5,
+      // Ie. 1 Nov.
+      'fixed_period_start_day' => '1101',
+      // Ie 1 Jan.
+      'fixed_period_rollover_day' => '101',
+    ));
+    $this->_params['membership_type_id'] = $this->_membershipTypeID2;
+    $dates = array(
+      'join_date' => '28-Jan 2015',
+    );
+    $result = $this->callAPISuccess($this->_entity, 'create', array_merge($this->_params, $dates));
+    $result = $this->callAPISuccess($this->_entity, 'getsingle', array('id' => $result['id']));
+    $this->assertEquals('2015-01-28', $result['join_date']);
+    $this->assertEquals('2014-11-01', $result['start_date']);
     $this->assertEquals('2020-10-31', $result['end_date']);
   }
 

--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -1002,7 +1002,22 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test that if membership start date is not set it defaults to correct end date for rolling memberships.
+   * Test that if membership start date is not set it defaults to correct end date for fixed multi year memberships.
+   */
+  public function testEmptyStartEndDateFixedMultiYear() {
+    unset($this->_params['start_date'], $this->_params['is_override'], $this->_params['end_date']);
+    $this->callAPISuccess('membership_type', 'create', array('id' => $this->_membershipTypeID2, 'duration_interval' => 5));
+    $this->_params['membership_type_id'] = $this->_membershipTypeID2;
+    $result = $this->callAPISuccess($this->_entity, 'create', $this->_params);
+    $result = $this->callAPISuccess($this->_entity, 'getsingle', array('id' => $result['id']));
+    $this->assertEquals('2009-01-21', $result['join_date']);
+    $this->assertEquals('2008-03-01', $result['start_date']);
+    $this->assertEquals('2014-02-28', $result['end_date']);
+  }
+
+
+  /**
+   * Test that if membership start date is not set it defaults to correct end date for fixed single year memberships.
    */
   public function testEmptyStartDateRolling() {
     unset($this->_params['start_date'], $this->_params['is_override']);

--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -1015,6 +1015,126 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     $this->assertEquals('2014-02-28', $result['end_date']);
   }
 
+  /**
+   * Test that if membership start date is not set it defaults to correct end date for fixed multi year memberships.
+   *
+   * In this set our start date is after the start day and before the rollover day so we don't get an extra year
+   * and we end one day before the rollover day. Start day is 1 Jan so we end on 31 Dec
+   * and we add on 4 years rather than 5 because we are not after the rollover day - so we calculate 31 Dec 2019
+   */
+  public function testEmptyStartEndDateFixedMultiYearDateSetTwo() {
+    unset($this->_params['start_date'], $this->_params['is_override'], $this->_params['end_date']);
+
+    $this->callAPISuccess('membership_type', 'create', array(
+      'id' => $this->_membershipTypeID2,
+      'duration_interval' => 5,
+      // Ie 1 Jan.
+      'fixed_period_start_day' => '101',
+      // Ie. 1 Nov.
+      'fixed_period_rollover_day' => '1101',
+    ));
+    $this->_params['membership_type_id'] = $this->_membershipTypeID2;
+    $dates = array(
+      'start_date' => '28-Jan 2015',
+      'join_date' => '28-Jan 2015',
+    );
+    $result = $this->callAPISuccess($this->_entity, 'create', array_merge($this->_params, $dates));
+    $result = $this->callAPISuccess($this->_entity, 'getsingle', array('id' => $result['id']));
+    $this->assertEquals('2015-01-28', $result['join_date']);
+    $this->assertEquals('2015-01-28', $result['start_date']);
+    $this->assertEquals('2019-12-31', $result['end_date']);
+  }
+
+  /**
+   * Test that if membership start date is not set it defaults to correct end date for fixed single year memberships.
+   *
+   * In this set our start date is after the start day and before the rollover day so we don't get an extra year
+   * and we end one day before the rollover day. Start day is 1 Jan so we end on 31 Dec
+   * and we add on <1 years rather than > 1 because we are not after the rollover day - so we calculate 31 Dec 2015
+   */
+  public function testEmptyStartEndDateFixedSingleYearDateSetTwo() {
+    unset($this->_params['start_date'], $this->_params['is_override'], $this->_params['end_date']);
+
+    $this->callAPISuccess('membership_type', 'create', array(
+      'id' => $this->_membershipTypeID2,
+      'duration_interval' => 1,
+      // Ie 1 Jan.
+      'fixed_period_start_day' => '101',
+      // Ie. 1 Nov.
+      'fixed_period_rollover_day' => '1101',
+    ));
+    $this->_params['membership_type_id'] = $this->_membershipTypeID2;
+    $dates = array(
+      'start_date' => '28-Jan 2015',
+      'join_date' => '28-Jan 2015',
+    );
+    $result = $this->callAPISuccess($this->_entity, 'create', array_merge($this->_params, $dates));
+    $result = $this->callAPISuccess($this->_entity, 'getsingle', array('id' => $result['id']));
+    $this->assertEquals('2015-01-28', $result['join_date']);
+    $this->assertEquals('2015-01-28', $result['start_date']);
+    $this->assertEquals('2015-12-31', $result['end_date']);
+  }
+
+  /**
+   * Test that if membership start date is not set it defaults to correct end date for fixed multi year memberships.
+   *
+   * In this set our start date is after the start day and after the rollover day so we do get an extra year
+   * and we end one day before the rollover day. Start day is 1 Nov so we end on 31 Oct
+   * and we add on 5 years we are after the rollover day - so we calculate 31 Oct 2020
+   */
+  public function testEmptyStartEndDateFixedSingleYearDateSetThree() {
+    unset($this->_params['start_date'], $this->_params['is_override'], $this->_params['end_date']);
+
+    $this->callAPISuccess('membership_type', 'create', array(
+      'id' => $this->_membershipTypeID2,
+      'duration_interval' => 1,
+      // Ie. 1 Nov.
+      'fixed_period_start_day' => '1101',
+      // Ie 1 Jan.
+      'fixed_period_rollover_day' => '101',
+    ));
+    $this->_params['membership_type_id'] = $this->_membershipTypeID2;
+    $dates = array(
+      'start_date' => '28-Jan 2015',
+      'join_date' => '28-Jan 2015',
+    );
+    $result = $this->callAPISuccess($this->_entity, 'create', array_merge($this->_params, $dates));
+    $result = $this->callAPISuccess($this->_entity, 'getsingle', array('id' => $result['id']));
+    $this->assertEquals('2015-01-28', $result['join_date']);
+    $this->assertEquals('2015-01-28', $result['start_date']);
+    $this->assertEquals('2016-10-31', $result['end_date']);
+  }
+
+
+  /**
+   * Test that if membership start date is not set it defaults to correct end date for fixed multi year memberships.
+   *
+   * In this set our start date is after the start day and after the rollover day so we do get an extra year
+   * and we end one day before the rollover day. Start day is 1 Nov so we end on 31 Oct
+   * and we add on 5 years we are after the rollover day - so we calculate 31 Oct 2020
+   */
+  public function testEmptyStartEndDateFixedMultiYearDateSetThree() {
+    unset($this->_params['start_date'], $this->_params['is_override'], $this->_params['end_date']);
+
+    $this->callAPISuccess('membership_type', 'create', array(
+      'id' => $this->_membershipTypeID2,
+      'duration_interval' => 5,
+      // Ie. 1 Nov.
+      'fixed_period_start_day' => '1101',
+      // Ie 1 Jan.
+      'fixed_period_rollover_day' => '101',
+    ));
+    $this->_params['membership_type_id'] = $this->_membershipTypeID2;
+    $dates = array(
+      'start_date' => '28-Jan 2015',
+      'join_date' => '28-Jan 2015',
+    );
+    $result = $this->callAPISuccess($this->_entity, 'create', array_merge($this->_params, $dates));
+    $result = $this->callAPISuccess($this->_entity, 'getsingle', array('id' => $result['id']));
+    $this->assertEquals('2015-01-28', $result['join_date']);
+    $this->assertEquals('2015-01-28', $result['start_date']);
+    $this->assertEquals('2020-10-31', $result['end_date']);
+  }
 
   /**
    * Test that if membership start date is not set it defaults to correct end date for fixed single year memberships.


### PR DESCRIPTION
After refactoring the code to understand it & adding a test this is the upshot...
we are dealing with annual memberships (even if they are in 5 year blocks rollover is
still about month & day) so if the definition of whether they are in the rollover period is
actually the same in multi-year as for a single year - if they are between the rollover &
the cut off they get an extra part-year. Hence, when determining whether to give an extra
part year we don't need to compare the rollover to the final end date (5 years on) but
to the next year's end date - just like for an annual

Note that one could argue, but I don't think anyone has, that if the 5 year period has started
then the get the remainder of this 5 years + the next 5 years - which is what the
existing code seems to be almost trying to do
