### PR TITLE
CRM-15884 fix typo in variable name related to earlier code cleanup.

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1935,7 +1935,7 @@ WHERE  civicrm_membership.contact_id = civicrm_contact.id
     while ($membershipPayment->fetch()) {
       CRM_Contribute_BAO_Contribution::deleteContribution($membershipPayment->contribution_id);
       CRM_Utils_Hook::pre('delete', 'MembershipPayment', $membershipPayment->id, $membershipPayment);
-      $membesrshipPayment->delete();
+      $membershipPayment->delete();
       CRM_Utils_Hook::post('delete', 'MembershipPayment', $membershipPayment->id, $membershipPayment);
     }
     return $membershipPayment;


### PR DESCRIPTION
---
- CRM-15884: Delete Membership fails due to typo in variable name
  https://issues.civicrm.org/jira/browse/CRM-15884
