### PR TITLE
CRM-15578 - Add Civi\Core\Callback. Fix loading of Angular content after updating components.

### DIFF
--- a/CRM/Admin/Form/Setting.php
+++ b/CRM/Admin/Form/Setting.php
@@ -211,12 +211,10 @@ class CRM_Admin_Form_Setting extends CRM_Core_Form {
 
     // save components to be enabled
     if (array_key_exists('enableComponents', $params)) {
-      CRM_Core_BAO_Setting::setItem($params['enableComponents'],
-        CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME, 'enable_components');
-
-      // unset params by emptying the values, so while retrieving we can detect and load from settings table
-      // instead of config-backend for backward compatibility. We could use unset() in later releases.
-      $params['enableComponents'] = $params['enableComponentIDs'] = array();
+      civicrm_api3('setting', 'create', array(
+        'enable_components' => $params['enableComponents'],
+      ));
+      unset($params['enableComponents']);
     }
 
     // save checksum timeout

--- a/CRM/Admin/Form/Setting/Component.php
+++ b/CRM/Admin/Form/Setting/Component.php
@@ -112,7 +112,6 @@ class CRM_Admin_Form_Setting_Component extends CRM_Admin_Form_Setting {
   public function postProcess() {
     $params = $this->controller->exportValues($this->_name);
 
-    CRM_Case_Info::onToggleComponents($this->_defaults['enableComponents'], $params['enableComponents'], NULL);
     parent::commonProcess($params);
 
     // reset navigation when components are enabled / disabled

--- a/CRM/Core/BAO/Setting.php
+++ b/CRM/Core/BAO/Setting.php
@@ -398,7 +398,12 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
 
     if (isset($metadata['on_change'])) {
       foreach ($metadata['on_change'] as $callback) {
-        call_user_func($callback, unserialize($dao->value), $value, $metadata);
+        call_user_func(
+          Civi\Core\Callback::create($callback),
+          unserialize($dao->value),
+          $value,
+          $metadata
+        );
       }
     }
 
@@ -588,8 +593,8 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
       return TRUE;
     }
     else {
-      list($class, $fn) = explode('::', $fieldSpec['validate_callback']);
-      if (!$class::$fn($value, $fieldSpec)) {
+      $cb = Civi\Core\Callback::create($fieldSpec['validate_callback']);
+      if (!call_user_func_array($cb, array(&$value, $fieldSpec))) {
         throw new api_Exception("validation failed for {$fieldSpec['name']} = $value  based on callback {$fieldSpec['validate_callback']}");
       }
     }

--- a/CRM/Core/Invoke.php
+++ b/CRM/Core/Invoke.php
@@ -267,12 +267,8 @@ class CRM_Core_Invoke {
       }
 
       $result = NULL;
-      if (is_array($item['page_callback'])) {
-        if ($item['page_callback']{0} !== '\\') {
-          // Legacy class-loading for PHP 5.2 namespaces; not sure it's needed, but counter-productive for PHP 5.3 namespaces
-          require_once str_replace('_', DIRECTORY_SEPARATOR, $item['page_callback'][0]) . '.php';
-        }
-        $result = call_user_func($item['page_callback']);
+      if (is_array($item['page_callback']) || strpos($item['page_callback'], ':')) {
+        $result = call_user_func(Civi\Core\Callback::create($item['page_callback']));
       }
       elseif (strstr($item['page_callback'], '_Form')) {
         $wrapper = new CRM_Utils_Wrapper();
@@ -284,10 +280,6 @@ class CRM_Core_Invoke {
       }
       else {
         $newArgs = explode('/', $_GET[$config->userFrameworkURLVar]);
-        if ($item['page_callback']{0} !== '\\') {
-          // Legacy class-loading for PHP 5.2 namespaces; not sure it's needed, but counter-productive for PHP 5.3 namespaces
-          require_once str_replace('_', DIRECTORY_SEPARATOR, $item['page_callback']) . '.php';
-        }
         $mode = 'null';
         if (isset($pageArgs['mode'])) {
           $mode = $pageArgs['mode'];

--- a/CRM/Core/Menu.php
+++ b/CRM/Core/Menu.php
@@ -126,9 +126,12 @@ class CRM_Core_Menu {
         if (strpos($key, '_callback') &&
           strpos($value, '::')
         ) {
+          // FIXME Remove the rewrite at this level. Instead, change downstream call_user_func*($value)
+          // to call_user_func*(Civi\Core\Callback::create($value)).
           $value = explode('::', $value);
         }
         elseif ($key == 'access_arguments') {
+          // FIXME Move the permission parser to its own class (or *maybe* CRM_Core_Permission).
           if (strpos($value, ',') ||
             strpos($value, ';')
           ) {

--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -274,10 +274,7 @@ class CRM_Core_PseudoConstant {
 
       // if callback is specified..
       if (!empty($pseudoconstant['callback'])) {
-        list($className, $fnName) = explode('::', $pseudoconstant['callback']);
-        if (method_exists($className, $fnName)) {
-          return call_user_func(array($className, $fnName));
-        }
+        return call_user_func(Civi\Core\Callback::create($pseudoconstant['callback']));
       }
 
       // Merge params with schema defaults

--- a/Civi/Core/Callback.php
+++ b/Civi/Core/Callback.php
@@ -1,0 +1,179 @@
+<?php
+namespace Civi\Core;
+
+/**
+ * The callback helper class provides a richer callback binding notation.
+ *
+ * @package Civi\Core
+ */
+class Callback {
+
+  /**
+   * Convert a callback expression to a valid PHP callback.
+   *
+   * @param string|array $callback
+   *   A callback expression; any of the following:
+   *   - 'function_name' - Call a global function.
+   *   - 'ClassName::methodName" - Call a static method in class.
+   *   - 'obj://objectName/method' - Call a method on an object from Civi\Core\Container.
+   *     (Performance note: Requires an extra lookup to find objectName.)
+   *   - 'api3://EntityName/action' - Call an API method.
+   *     (Performance note: Requires full setup/teardown of API subsystem.)
+   *   - 'api3://EntityName/action?first=@1&second=@2' - Call an API method, mapping the
+   *     first & second args to named parameters.
+   *     (Performance note: Requires parsing/interpolating arguments).
+   *   - '0' or '1' - A dummy which returns the constant '0' or '1'.
+   *
+   * @return array
+   *   A PHP callback. Do not serialize (b/c it may include an object).
+   */
+  public static function create($callback) {
+    if (!is_string($callback)) {
+      // If caller has already produced an array or object, then it's probably
+      // a valid callback.
+      return $callback;
+    }
+
+    if (strpos($callback, '::') !== FALSE) {
+      return explode('::', $callback);
+    }
+    elseif (strpos($callback, '://') !== FALSE) {
+      $url = parse_url($callback);
+      switch ($url['scheme']) {
+        case 'obj':
+          $obj = Container::singleton()->get($url['host']);
+          return array($obj, ltrim($url['path'], '/'));
+
+        case 'api3':
+          return new CallbackApi($url);
+
+        default:
+          throw new \RuntimeException("Unsupported callback scheme: " . $url['scheme']);
+      }
+    }
+    elseif (in_array($callback, array('0', '1'))) {
+      return new CallbackConstant($callback);
+    }
+    else {
+      return $callback;
+    }
+  }
+
+}
+
+/**
+ * Private helper which produces a dummy callback.
+ *
+ * @package Civi\Core
+ */
+class CallbackConstant {
+  /**
+   * @var mixed
+   */
+  private $value;
+
+  /**
+   * @param mixed $value
+   *   The value to be returned by the dummy callback.
+   */
+  public function __construct($value) {
+    $this->value = $value;
+  }
+
+  /**
+   * @return mixed
+   */
+  public function __invoke() {
+    return $this->value;
+  }
+
+}
+
+/**
+ * Private helper which treats an API as a callable function.
+ *
+ * @package Civi\Core
+ */
+class CallbackApi {
+  /**
+   * @var array
+   *  - string scheme
+   *  - string host
+   *  - string path
+   *  - string query (optional)
+   */
+  private $url;
+
+  /**
+   * @param array $url
+   *   Parsed URL (e.g. "api3://EntityName/action?foo=bar").
+   * @see parse_url
+   */
+  public function __construct($url) {
+    $this->url = $url;
+  }
+
+  /**
+   * Fire an API call.
+   */
+  public function __invoke() {
+    $apiParams = array();
+    if (isset($this->url['query'])) {
+      parse_str($this->url['query'], $apiParams);
+    }
+
+    if (count($apiParams)) {
+      $args = func_get_args();
+      if (count($args)) {
+        $this->interpolate($apiParams, $this->createPlaceholders($args));
+      }
+    }
+
+    $result = civicrm_api3($this->url['host'], ltrim($this->url['path'], '/'), $apiParams);
+    return isset($result['values']) ? $result['values'] : NULL;
+  }
+
+  /**
+   * @param array $args
+   *   Positional arguments.
+   * @return array
+   *   Named placeholders based on the positional arguments
+   *   (e.g. "@1" => "firstValue").
+   */
+  protected function createPlaceholders($args) {
+    $result = array();
+    foreach ($args as $offset => $arg) {
+      $result['@' . (1 + $offset)] = $arg;
+    }
+    return $result;
+  }
+
+  /**
+   * Recursively interpolate values.
+   *
+   * @code
+   * $params = array('foo' => '@1');
+   * $this->interpolate($params, array('@1'=> $object))
+   * assert $data['foo'] == $object;
+   * @endcode
+   *
+   * @param array $array
+   *   Array which may or many not contain a mix of tokens.
+   * @param array $replacements
+   *   A list of tokens to substitute.
+   */
+  protected function interpolate(&$array, $replacements) {
+    foreach (array_keys($array) as $key) {
+      if (is_array($array[$key])) {
+        $this->interpolate($array[$key], $replacements);
+        continue;
+      }
+      foreach ($replacements as $oldVal => $newVal) {
+        if ($array[$key] === $oldVal) {
+          $array[$key] = $newVal;
+        }
+      }
+    }
+  }
+
+}

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\Tools\Setup;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 
@@ -88,6 +89,20 @@ class Container {
       array(new Reference('dispatcher'), new Reference('magic_function_provider'))
     ))
       ->setFactoryService(self::SELF)->setFactoryMethod('createApiKernel');
+
+    // Expose legacy singletons as services in the container.
+    $singletons = array(
+      'resources' => 'CRM_Core_Resources',
+      'httpClient' => 'CRM_Utils_HttpClient',
+      // Maybe? 'config' => 'CRM_Core_Config',
+      // Maybe? 'smarty' => 'CRM_Core_Smarty',
+    );
+    foreach ($singletons as $name => $class) {
+      $container->setDefinition($name, new Definition(
+        $class
+      ))
+        ->setFactoryClass($class)->setFactoryMethod('singleton');
+    }
 
     return $container;
   }

--- a/settings/Core.setting.php
+++ b/settings/Core.setting.php
@@ -699,8 +699,9 @@ return array(
     'description' => NULL,
     'help_text' => NULL,
     'on_change' => array(
-      array('CRM_Case_Info', 'onToggleComponents'),
-      array('CRM_Core_Component', 'flushEnabledComponents'),
+      'CRM_Case_Info::onToggleComponents',
+      'CRM_Core_Component::flushEnabledComponents',
+      'obj://resources/resetCacheCode',
     ),
   ),
   'disable_core_css' => array(

--- a/tests/phpunit/Civi/Core/CallbackTest.php
+++ b/tests/phpunit/Civi/Core/CallbackTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Civi\Core {
+  require_once 'CiviTest/CiviUnitTestCase.php';
+
+  /**
+   * Class CallbackTest
+   * @package Civi\Core
+   */
+  class CallbackTest extends \CiviUnitTestCase {
+    /**
+     * Test callback for a global function.
+     */
+    public function testGlobalFunc() {
+      // Note: civi_core_callback_dummy is implemented at the bottom of this file.
+      $cb = Callback::create('civi_core_callback_dummy');
+      $this->assertEquals('civi_core_callback_dummy', $cb);
+
+      $expected = 'global dummy received foo';
+      $actual = call_user_func($cb, 'foo');
+      $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test callback for a static function.
+     */
+    public function testStatic() {
+      $cb = Callback::create('Civi\Core\CallbackTest::dummy');
+      $this->assertEquals(array('Civi\Core\CallbackTest', 'dummy'), $cb);
+
+      $expected = 'static dummy received foo';
+      $actual = call_user_func($cb, 'foo');
+      $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test callback for an API.
+     */
+    public function testApi() {
+      // Note: Callbacktest.Ping API is implemented at the bottom of this file.
+      $cb = Callback::create('api3://Callbacktest/ping?first=@1');
+      $expected = 'api dummy received foo';
+      $actual = call_user_func($cb, 'foo');
+      $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test callback for an object in the container.
+     */
+    public function testContainer() {
+      // Note: CallbackTestExampleService is implemented at the bottom of this file.
+      Container::singleton()->set('callbackTestService', new CallbackTestExampleService());
+      $cb = Callback::create('obj://callbackTestService/ping');
+      $expected = 'service dummy received foo';
+      $actual = call_user_func($cb, 'foo');
+      $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test callback for an invalid object in the container.
+     *
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\ExceptionInterface
+     */
+    public function testContainerWithInvalidService() {
+      $cb = Callback::create('obj://totallyNonexistentService/ping');
+      call_user_func($cb, 'foo');
+    }
+
+    /**
+     * @param string $arg1
+     *   Dummy value to pass through.
+     * @return array
+     */
+    public static function dummy($arg1) {
+      return "static dummy received $arg1";
+    }
+
+  }
+
+  /**
+   * Class CallbackTestExampleService
+   *
+   * @package Civi\Core
+   */
+  class CallbackTestExampleService {
+
+    /**
+     * @param string $arg1
+     *   Dummy value to pass through.
+     * @return string
+     */
+    public function ping($arg1) {
+      return "service dummy received $arg1";
+    }
+
+  }
+}
+
+namespace {
+  /**
+   * @param string $arg1
+   *   Dummy value to pass through.
+   * @return string
+   */
+  function civi_core_callback_dummy($arg1) {
+    return "global dummy received $arg1";
+  }
+
+  /**
+   * @param array $params
+   *   API parameters.
+   * @return array
+   */
+  function civicrm_api3_callbacktest_ping($params) {
+    return civicrm_api3_create_success("api dummy received " . $params['first']);
+  }
+}


### PR DESCRIPTION
After enabling or disabling components, the Angular content may have
changed, so we must call CRM_Core_Resources::singleton()->resetCacheCode.
This commit does so in a few pieces:
- It updates the admin UI so that it uses the API for saving changes to
  "enable_components". (This resolves a split where UI+API were different.)
- It updates the "enable_components" setting so that changes trigger
  a cache-code reset.
- It updates the settings framework so that callbacks can reference
  non-static functions. (The objects must be registered in "Container".)
- It exposes some of our singletons (eg CRM_Core_Resources) as objects
  in "Container".
- It adds a helper function (Civi\Core\Callback::create()) which
  should be used whenever we process callbacks from data files
  (*.setting.php, *.xml, *.json, etc).
- It updates various places that use callbacks to run through the helper.

See also: http://forum.civicrm.org/index.php/topic,35579.0.html
