### PR TITLE
CRM-15891 - Unit test to illustrate the problem.

### DIFF
--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -1423,8 +1423,6 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
     $result = $this->callAPISuccess('Contact', 'create', $params);
 
-    file_put_contents('/tmp/out.txt', print_r($result, true));
-
     // delete the contact and custom groups
     $this->callAPISuccess('contact', 'delete', array('id' => $result['id']));
     $this->customGroupDelete($ids['custom_group_id']);

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -1396,6 +1396,45 @@ class api_v3_ContactTest extends CiviUnitTestCase {
   }
 
   /**
+   *  Verify attempt to create individual with chained arrays and sequential
+   */
+  public function testGetIndividualWithChainedArraysAndSequential() {
+    $ids = $this->entityCustomGroupWithSingleFieldCreate(__FUNCTION__, __FILE__);
+    $params['custom_' . $ids['custom_field_id']] = "custom string";
+
+    $moreids = $this->CustomGroupMultipleCreateWithFields();
+    $description = "/*this demonstrates the usage of chained api functions. In this case no notes or custom fields have been created ";
+    $subfile = "APIChainedArray";
+    $params = array(
+      'sequential' => 1,
+      'first_name' => 'abc3',
+      'last_name' => 'xyz3',
+      'contact_type' => 'Individual',
+      'email' => 'man3@yahoo.com',
+      'api.website.create' => array(
+        array(
+          'url' => "http://civicrm.org",
+        ),
+        array(
+          'url' => "https://civicrm.org",
+        ),
+      ),
+    );
+
+    $result = $this->callAPISuccess('Contact', 'create', $params);
+
+    file_put_contents('/tmp/out.txt', print_r($result, true));
+
+    // delete the contact and custom groups
+    $this->callAPISuccess('contact', 'delete', array('id' => $result['id']));
+    $this->customGroupDelete($ids['custom_group_id']);
+    $this->customGroupDelete($moreids['custom_group_id']);
+
+    $this->assertEquals($result['id'], $result['values'][0]['id']);
+    $this->assertArrayKeyExists('api.website.create', $result['values'][0]);
+  }
+
+  /**
    *  Verify attempt to create individual with chained arrays
    */
   public function testGetIndividualWithChainedArrays() {


### PR DESCRIPTION
This patch contains a (failing) unit test, to illustrate CRM-15819.

If I use the api to create a contact and two websites, I expect the
result values to contain the array key 'api.website.create'.

---
- CRM-15891: Inconsistency in returned json for chained get and chained create
  https://issues.civicrm.org/jira/browse/CRM-15891
