### PR TITLE
CRM-15904 - Unit test to illustrate the issue.

### DIFF
--- a/tests/phpunit/CRM/Utils/API/ReloadOptionTest.php
+++ b/tests/phpunit/CRM/Utils/API/ReloadOptionTest.php
@@ -88,6 +88,29 @@ class CRM_Utils_API_ReloadOptionTest extends CiviUnitTestCase {
   }
 
   /**
+   * When the reload option is combined with chaining, the reload should munge
+   * the chain results, even if sequential=1.
+   */
+  public function testReloadNoChainInterferenceSequential() {
+    $result = $this->callAPISuccess('contact', 'create', array(
+      'sequential' => 1,
+      'contact_type' => 'Individual',
+      'first_name' => 'First',
+      'last_name' => 'Last',
+      'nick_name' => 'Firstie',
+      'api.Email.create' => array(
+        'email' => 'test@example.com',
+      ),
+      'options' => array(
+        'reload' => 1,
+      ),
+    ));
+    $this->assertEquals('First', $result['values'][0]['first_name']);
+    $this->assertEquals('munged', $result['values'][0]['nick_name']);
+    $this->assertAPISuccess($result['values'][0]['api.Email.create']);
+  }
+
+  /**
    * An implementation of hook_civicrm_post used with all our test cases.
    *
    * @param $op


### PR DESCRIPTION
This unit test illustrates the problem.

I use chaining to create a contact and an e-mail address. If I do
this with sequential=1 and the reload option, I get an error.

Obviously this pull request will cause errors during automatic
testing.

---
- CRM-15904: API: Reload option does not work with chaining and sequential
  https://issues.civicrm.org/jira/browse/CRM-15904
