### PR TITLE
CRM-15901: Turn off PHP errors display for all ajax calls

### DIFF
--- a/CRM/Core/Invoke.php
+++ b/CRM/Core/Invoke.php
@@ -61,6 +61,10 @@ class CRM_Core_Invoke {
     if ($args[0] !== 'civicrm') {
       return;
     }
+    // CRM-15901: Turn off PHP errors display for all ajax calls
+    if (CRM_Utils_Array::value(1, $args) == 'ajax' || CRM_Utils_Array::value('snippet', $_REQUEST)) {
+      ini_set('display_errors', 0);
+    }
 
     if (!defined('CIVICRM_SYMFONY_PATH')) {
       try {


### PR DESCRIPTION
PR already merged in 4.5
