### PR TITLE
CRM-15905 - unit test to illustrate the problem.

### DIFF
--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -1103,6 +1103,22 @@ class api_v3_ContactTest extends CiviUnitTestCase {
   }
 
   /**
+   *  Test civicrm_contact_get() sort by id.
+   */
+  public function testContactGetOrderById() {
+    $contact = $this->callAPISuccess('contact', 'create', $this->_params);
+    $params = array(
+      'contact_id' => $contact['id'],
+      'return_first_name' => TRUE,
+      'sort' => 'id',
+    );
+    $result = $this->callAPISuccess('contact', 'get', $params);
+    $this->assertEquals(1, $result['count']);
+    $this->assertEquals($contact['id'], $result['id']);
+    $this->assertEquals('abc1', $result['values'][$contact['id']]['first_name']);
+  }
+
+  /**
    * Test civicrm_contact_get() return only first name & last name.
    *
    * Use comma separated string return with a space.

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -1106,16 +1106,17 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    *  Test civicrm_contact_get() sort by id.
    */
   public function testContactGetOrderById() {
-    $contact = $this->callAPISuccess('contact', 'create', $this->_params);
     $params = array(
-      'contact_id' => $contact['id'],
-      'return_first_name' => TRUE,
-      'sort' => 'id',
-    );
+      'sequential' => 1,
+      'options' => array(
+        'sort' => 'id DESC',
+        'limit' => 2,
+      ));
     $result = $this->callAPISuccess('contact', 'get', $params);
-    $this->assertEquals(1, $result['count']);
-    $this->assertEquals($contact['id'], $result['id']);
-    $this->assertEquals('abc1', $result['values'][$contact['id']]['first_name']);
+    $this->assertEquals(2, $result['count']);
+    // Please note that assertGreaterThan($expected, $actual)
+    // asserts that $actual is greater than $expected.
+    $this->assertGreaterThan($result['values'][1]['id'], $result['values'][0]['id']);
   }
 
   /**


### PR DESCRIPTION
If you request contacts using the API, and you try to sort them
on ID, you run into a database error.

So this unit test will fail.

---
- CRM-15905:
  https://issues.civicrm.org/jira/browse/CRM-15905
