### PR TITLE
CRM-15714 CiviContribute convert validateCreditCard to validatePaymentIn...

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -1083,7 +1083,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     if (!empty($self->_paymentFields)) {
       CRM_Core_Form::validateMandatoryFields($self->_paymentFields, $fields, $errors);
     }
-    CRM_Core_Payment_Form::validateCreditCard($fields, $errors);
+    CRM_Core_Payment_Form::validatePaymentInstrument($fields['payment_processor'], $fields, $errors, $self);
 
     foreach (CRM_Contact_BAO_Contact::$_greetingTypes as $greeting) {
       if ($greetingType = CRM_Utils_Array::value($greeting, $fields)) {

--- a/CRM/Contribute/Form/UpdateBilling.php
+++ b/CRM/Contribute/Form/UpdateBilling.php
@@ -234,8 +234,8 @@ class CRM_Contribute_Form_UpdateBilling extends CRM_Core_Form {
     $errors = array();
     CRM_Core_Form::validateMandatoryFields($self->_fields, $fields, $errors);
 
-    // make sure that credit card number and cvv are valid
-    CRM_Core_Payment_Form::validateCreditCard($fields, $errors);
+    // validate the payment instrument values (e.g. credit card number)
+    CRM_Core_Payment_Form::validatePaymentInstrument($self->_paymentProcessor['id'], $fields, $errors, $self);
 
     return empty($errors) ? TRUE : $errors;
   }

--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -172,6 +172,17 @@ abstract class CRM_Core_Payment {
   }
 
   /**
+   * Default payment instrument validation
+   * Implement the usual Luhn algorithm via a static function in the CRM_Core_Payment_Form if it's a credit card
+   * Not a static function, because I need to check for payment_type
+   */
+  public function validatePaymentInstrument($values, &$errors) {
+    if ($this->_paymentProcessor['payment_type'] == 1) {
+      CRM_Core_Payment_Form::validateCreditCard($values, $errors);
+    }
+  }
+
+  /**
    * Setter for the payment form that wants to use the processor
    * @deprecated
    * @param CRM_Core_Form $paymentForm

--- a/CRM/Core/Payment/Form.php
+++ b/CRM/Core/Payment/Form.php
@@ -324,7 +324,7 @@ class CRM_Core_Payment_Form {
   public static function validatePaymentInstrument($payment_processor_id, $values, &$errors, $form) {
     // ignore if we don't have a payment instrument to validate (e.g. backend payments)
     if ($payment_processor_id > 0) {
-      $paymentProcessor = CRM_Financial_BAO_PaymentProcessor::getPayment($payment_processor_id,'live');
+      $paymentProcessor = CRM_Financial_BAO_PaymentProcessor::getPayment($payment_processor_id, 'live');
       $payment = CRM_Core_Payment::singleton('live', $paymentProcessor, $form);
       $payment->validatePaymentInstrument($values, $errors);
     }

--- a/CRM/Core/Payment/Form.php
+++ b/CRM/Core/Payment/Form.php
@@ -317,6 +317,20 @@ class CRM_Core_Payment_Form {
   }
 
   /**
+   * Validate the payment instrument values before passing it to the payment processor
+   * We want this to be overrideable by the payment processor, and default to using
+   * this object's validCreditCard for credit cards (implemented as the default in the Payment class).
+   */
+  public static function validatePaymentInstrument($payment_processor_id, $values, &$errors, $form) {
+    // ignore if we don't have a payment instrument to validate (e.g. backend payments)
+    if ($payment_processor_id > 0) {
+      $paymentProcessor = CRM_Financial_BAO_PaymentProcessor::getPayment($payment_processor_id,'live');
+      $payment = CRM_Core_Payment::singleton('live', $paymentProcessor, $form);
+      $payment->validatePaymentInstrument($values, $errors);
+    }
+  }
+
+  /**
    * The credit card pseudo constant results only the CC label, not the key ID
    * So we normalize the name to use it as a CSS class.
    */

--- a/CRM/Event/Cart/Form/Checkout/Payment.php
+++ b/CRM/Event/Cart/Form/Checkout/Payment.php
@@ -398,8 +398,8 @@ class CRM_Event_Cart_Form_Checkout_Payment extends CRM_Event_Cart_Form_Cart {
       }
       CRM_Core_Form::validateMandatoryFields($self->_fields, $fields, $errors);
 
-      // make sure that credit card number and cvv are valid
-      CRM_Core_Payment_Form::validateCreditCard($fields, $errors);
+      // validate payment instrument values (e.g. credit card number)
+      CRM_Core_Payment_Form::validatePaymentInstrument($self->_paymentProcessor['id'], $fields, $errors, $self);
     }
 
     return empty($errors) ? TRUE : $errors;

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -814,8 +814,8 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
     $errorMsg = array();
 
     if (!empty($values['payment_processor_id'])) {
-      // make sure that credit card number and cvv are valid
-      CRM_Core_Payment_Form::validateCreditCard($values, $errorMsg);
+      // make sure that payment instrument values (e.g. credit card number and cvv) are valid
+      CRM_Core_Payment_Form::validatePaymentInstrument($values['payment_processor_id'], $values, $errorMsg, $self);
     }
 
     if (!empty($values['record_contribution'])) {

--- a/CRM/Event/Form/Registration/AdditionalParticipant.php
+++ b/CRM/Event/Form/Registration/AdditionalParticipant.php
@@ -565,8 +565,9 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
 
     CRM_Core_Form::validateMandatoryFields($self->_fields, $fields, $errors);
 
-    // make sure that credit card number and cvv are valid
-    CRM_Core_Payment_Form::validateCreditCard($self->_params[0], $errors);
+    // validate supplied payment instrument values (e.g. credit card number and cvv)
+    $payment_processor_id = $self->params[0]['payment_processor_id'];
+    CRM_Core_Payment_Form::validatePaymentInstrument($payment_processor_id, $self->_params[0], $errors, $self);
 
     if ($errors) {
       return FALSE;

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -930,7 +930,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       if (!empty($self->_paymentFields)) {
         CRM_Core_Form::validateMandatoryFields($self->_paymentFields, $fields, $errors);
       }
-      CRM_Core_Payment_Form::validateCreditCard($fields, $errors);
+      CRM_Core_Payment_Form::validatePaymentInstrument($self->_paymentProcessorID, $fields, $errors, $self);
     }
 
     foreach (CRM_Contact_BAO_Contact::$_greetingTypes as $greeting) {

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -859,8 +859,8 @@ WHERE   id IN ( ' . implode(' , ', array_keys($membershipType)) . ' )';
     }
 
     if (!empty($params['payment_processor_id'])) {
-      // make sure that credit card number and cvv are valid
-      CRM_Core_Payment_Form::validateCreditCard($params, $errors);
+      // validate payment instrument (e.g. credit card number)
+      CRM_Core_Payment_Form::validatePaymentInstrument($params['payment_processor_id'], $params, $errors, $self);
     }
 
     $joinDate = NULL;


### PR DESCRIPTION
...strument

The validateCreditCard function is too restrictive for both SWIPE and DirectDebit payment processors. Convert those calls to a new validatePaymentInstrument that only invokes validateCreditCard for credit card payment processors, and also allows SWIPE processors to override it.
