### PR TITLE
CRM-15910. Increase field length of external_identifier to 64 bytes.

### DIFF
--- a/CRM/Upgrade/Incremental/sql/4.6.alpha5.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.6.alpha5.mysql.tpl
@@ -1,1 +1,5 @@
 {* file to handle db changes in 4.6.alpha5 during upgrade *}
+
+-- CRM-15910
+ALTER TABLE `civicrm_contact`
+  CHANGE COLUMN `external_identifier` `external_identifier` VARCHAR(64) DEFAULT NULL;

--- a/xml/schema/Contact/Contact.xml
+++ b/xml/schema/Contact/Contact.xml
@@ -163,7 +163,7 @@
   <field>
     <name>external_identifier</name>
     <type>varchar</type>
-    <length>32</length>
+    <length>64</length>
     <html>
       <type>Text</type>
       <size>EIGHT</size>


### PR DESCRIPTION
Permits storage of UUID external identifiers.
