### PR TITLE
CRM-15490 repetition_start_date_display not being set due to change in dat...

### DIFF
--- a/CRM/Core/Form/RecurringEntity.php
+++ b/CRM/Core/Form/RecurringEntity.php
@@ -298,7 +298,7 @@ class CRM_Core_Form_RecurringEntity {
         }
         if ($values['repeats_by'] == 2) {
           if (CRM_Utils_Array::value('entity_status_1', $values)) {
-            $dayOfTheWeekNo = array(first, second, third, fourth, last);
+            $dayOfTheWeekNo = array('first', 'second', 'third', 'fourth', 'last');
             if (!in_array($values['entity_status_1'], $dayOfTheWeekNo)) {
               $errors['entity_status_1'] = ts('Invalid option');
             }

--- a/templates/CRM/Activity/Form/Activity.tpl
+++ b/templates/CRM/Activity/Form/Activity.tpl
@@ -216,19 +216,19 @@
           <script type="text/javascript">
             CRM.$(function($) {
               if ($('#activity_date_time').val() !== "" && $('#activity_date_time_time').val() !== "") {
-                $('#repetition_start_date, #repetition_start_date_display').val($('#activity_date_time').val());
+                $('#repetition_start_date, input[id^="repetition_start_date_display_"]').val($('#activity_date_time').val());
                 $('#repetition_start_date_time').val($('#activity_date_time_time').val());
               }
 
-              $('#activity_date_time_display').change(function() {
-                $('#repetition_start_date, #repetition_start_date_display').val($('#activity_date_time').val());
+              $('input[id^="activity_date_time_display_"]').change(function() {
+                $('#repetition_start_date, input[id^="repetition_start_date_display_"]').val($('#activity_date_time').val());
               });
 
               $('#activity_date_time_time').change(function() {
                 $('#repetition_start_date_time').val($('#activity_date_time_time').val());
               });
 
-              if ($('#start_action_offset').val() == "" && $('#repeat_absolute_date_display').val() == "") {
+              if ($('#start_action_offset').val() == "" && $('input[id^="repeat_absolute_date_display_"]').val() == "") {
                 $('#recurring-entity-block').addClass('collapsed');
               }
             });


### PR DESCRIPTION
...e widget input id pattern > parent and child activity with same dates

Resolves parent and child activity with same date.
Regression was due to date-widget-input-ids now having a random number as suffix. 
