### PR TITLE
CRM-15919 Address getoptions alternative: "abbreviate" context

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2173,6 +2173,7 @@ SELECT contact_id
       'create' => "Options are filtered appropriately for the object being created/updated. Labels are translated.",
       'search' => "Searchable options are returned. Labels are translated.",
       'validate' => "All options are returned, even if they are disabled. Machine names are used in place of labels.",
+      'abbreviate' => "Active options are returned, and labels are replaced with abbreviations.",
     );
     // Validation: enforce uniformity of this param
     if ($context !== NULL && !isset($contexts[$context])) {

--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -292,9 +292,11 @@ class CRM_Core_PseudoConstant {
           case 'state_province_id':
             $params['labelColumn'] = 'abbreviation';
             break;
+
           case 'country_id':
             $params['labelColumn'] = 'iso_code';
             break;
+
           default:
         }
       }

--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -287,6 +287,18 @@ class CRM_Core_PseudoConstant {
         'labelColumn' => CRM_Utils_Array::value('labelColumn', $pseudoconstant),
       );
 
+      if ($context == 'abbreviate') {
+        switch ($fieldName) {
+          case 'state_province_id':
+            $params['labelColumn'] = 'abbreviation';
+            break;
+          case 'country_id':
+            $params['labelColumn'] = 'iso_code';
+            break;
+          default:
+        }
+      }
+
       // Fetch option group from option_value table
       if (!empty($pseudoconstant['optionGroupName'])) {
         if ($context == 'validate') {


### PR DESCRIPTION
This is an alternative to https://github.com/civicrm/civicrm-core/pull/5099 - only one is needed
