### PR TITLE
CRM-15931, CRM-15733 - civicrm_mailing_group.group_type - Restore uppercase values

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1607,6 +1607,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
 
     /* Create the mailing group record */
     $mg = new CRM_Mailing_DAO_MailingGroup();
+    $groupTypes = array('include' => 'Include', 'exclude' => 'Exclude', 'base' => 'Base');
     foreach (array('groups', 'mailings') as $entity) {
       foreach (array('include', 'exclude', 'base') as $type) {
         if (isset($params[$entity]) && !empty($params[$entity][$type]) &&
@@ -1616,7 +1617,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
             $mg->mailing_id   = $mailing->id;
             $mg->entity_table = ($entity == 'groups') ? $groupTableName : $mailingTableName;
             $mg->entity_id    = $entityId;
-            $mg->group_type   = $type;
+            $mg->group_type   = $groupTypes[$type];
             $mg->save();
           }
         }

--- a/CRM/Mailing/Form/Group.php
+++ b/CRM/Mailing/Form/Group.php
@@ -143,12 +143,12 @@ class CRM_Mailing_Form_Group extends CRM_Contact_Form_Task {
         $mailingGroups[$entityTable][$dao->group_type][] = $dao->entity_id;
       }
 
-      $defaults['includeGroups'] = CRM_Utils_Array::value('include', $mailingGroups['civicrm_group']);
-      $defaults['excludeGroups'] = CRM_Utils_Array::value('exclude', $mailingGroups['civicrm_group']);
+      $defaults['includeGroups'] = CRM_Utils_Array::value('Include', $mailingGroups['civicrm_group']);
+      $defaults['excludeGroups'] = CRM_Utils_Array::value('Exclude', $mailingGroups['civicrm_group']);
 
       if (!empty($mailingGroups['civicrm_mailing'])) {
-        $defaults['includeMailings'] = CRM_Utils_Array::value('include', $mailingGroups['civicrm_mailing']);
-        $defaults['excludeMailings'] = CRM_Utils_Array::value('exclude', $mailingGroups['civicrm_mailing']);
+        $defaults['includeMailings'] = CRM_Utils_Array::value('Include', $mailingGroups['civicrm_mailing']);
+        $defaults['excludeMailings'] = CRM_Utils_Array::value('Exclude', $mailingGroups['civicrm_mailing']);
       }
     }
 

--- a/CRM/Upgrade/Incremental/sql/4.5.7.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.5.7.mysql.tpl
@@ -1,0 +1,6 @@
+{* file to handle db changes in 4.5.7 during upgrade *}
+
+-- CRM-15931
+UPDATE civicrm_mailing_group SET group_type = 'Include' WHERE group_type = 'include';
+UPDATE civicrm_mailing_group SET group_type = 'Exclude' WHERE group_type = 'exclude';
+UPDATE civicrm_mailing_group SET group_type = 'Base' WHERE group_type = 'base';

--- a/xml/version.xml
+++ b/xml/version.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="iso-8859-1" ?>
 <version>
-  <version_no>4.5.6</version_no>
+  <version_no>4.5.7</version_no>
 </version>


### PR DESCRIPTION
In 4.5.x, the schema for group_type changed from
enum('Include','Exclude','Base') to varchar, which made it more sensitive to
variations in case.  New mailings would be created with lowercase 'include',
but old mailings still had 'Include'.  UI's would display correctly for old
mailings but not for new mailings.

CRM-15733 and CRM-15931 both report peculiar symptoms of the change.

This patch aims to consistently use the 4.4.x data-model (for both old and
new mailings).
