### PR TITLE
Unified bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,7 +113,6 @@ CRM/Standalone/OpenID/DAO
 bin/setup.conf
 civicrm-version.php
 civicrm-version.txt
-civicrm.config.php
 install/langs.php
 node_modules
 packages/.channels

--- a/CRM/Core/CodeGen/Config.php
+++ b/CRM/Core/CodeGen/Config.php
@@ -5,69 +5,12 @@
  */
 class CRM_Core_CodeGen_Config extends CRM_Core_CodeGen_BaseTask {
   public function run() {
-    $this->generateTemplateVersion();
-
-    $this->setupCms();
-  }
-
-  public function generateTemplateVersion() {
-    file_put_contents($this->config->tplCodePath . "/CRM/common/version.tpl", $this->config->db_version);
-  }
-
-  public function setupCms() {
-    if (!in_array($this->config->cms, array(
-      'drupal',
-      'joomla',
-      'wordpress',
-    ))) {
-      echo "Config file for '{$this->config->cms}' not known.";
-      exit();
-    }
-    elseif ($this->config->cms !== 'joomla') {
-      $configTemplate = $this->findConfigTemplate($this->config->cms);
-      if ($configTemplate) {
-        echo "Generating civicrm.config.php\n";
-        copy($configTemplate, '../civicrm.config.php');
-      }
-      else {
-        throw new Exception("Failed to locate template for civicrm.config.php");
-      }
-    }
-
     echo "Generating civicrm-version file\n";
     $template = new CRM_Core_CodeGen_Util_Template('php');
     $template->assign('db_version', $this->config->db_version);
     $template->assign('cms', ucwords($this->config->cms));
+    $template->assign('svnrevision', $this->config->db_version); // FIXME
     $template->run('civicrm_version.tpl', $this->config->phpCodePath . "civicrm-version.php");
-  }
-
-  /**
-   * @param string $cms
-   *   "drupal"|"wordpress".
-   * @return null|string
-   *   path to config template
-   */
-  public function findConfigTemplate($cms) {
-    $candidates = array();
-    switch ($cms) {
-      case 'drupal':
-        $candidates[] = "../drupal/civicrm.config.php.drupal";
-        $candidates[] = "../../drupal/civicrm.config.php.drupal";
-        break;
-
-      case 'wordpress':
-        $candidates[] = "../../civicrm.config.php.wordpress";
-        $candidates[] = "../WordPress/civicrm.config.php.wordpress";
-        $candidates[] = "../drupal/civicrm.config.php.drupal";
-        break;
-    }
-    foreach ($candidates as $candidate) {
-      if (file_exists($candidate)) {
-        return $candidate;
-        break;
-      }
-    }
-    return NULL;
   }
 
 }

--- a/Civi/Bootstrap.php
+++ b/Civi/Bootstrap.php
@@ -149,6 +149,9 @@ class Bootstrap {
       if ($error == FALSE) {
         throw new \Exception("Could not load the CiviCRM settings file: {$settings}");
       }
+
+      list ($cmsType, $cmsBasePath) = $this->findCmsRoot($this->getSearchDir());
+      $_SERVER['SCRIPT_FILENAME'] = $cmsBasePath . '/index.php';
     }
 
     // Backward compatibility - New civicrm.settings.php files include

--- a/Civi/Bootstrap.php
+++ b/Civi/Bootstrap.php
@@ -1,0 +1,327 @@
+<?php
+namespace Civi;
+
+/**
+ * Bootstrap the CiviCRM runtime.
+ *
+ * @code
+ * // Use default bootstrap
+ * require_once '/path/to/Civi/Bootstrap.php';
+ * Civi\Bootstrap::singleton()->boot();
+ *
+ * // Use custom bootstrap
+ * require_once '/path/to/Civi/Bootstrap.php';
+ * Civi\Bootstrap::singleton()->boot(array(
+ *   'settingsFile' => '/path/to/civicrm.settings.php',
+ * ));
+ * @endcode
+ *
+ * This class is intended to be run *before* the classloader is available. Therefore, it
+ * must be self-sufficient.
+ *
+ * A key issue is locating the civicrm.settings.php file -- this is complicated because
+ * each CMS has a different structure, because some CMS's have multisite features, and
+ * because we don't know who's calling us.
+ *
+ * By default, bootstrap will search as follows:
+ *   - Check ../settings_location.php for define(CIVICRM_CONFDIR)
+ *   - Check ENV['CIVICRM_SETTINGS']
+ *   - Check $options['settingsFile']
+ *   - Scan PWD and every ancestor directory to see if it
+ *     contains civicrm.settings.php in one of the
+ *     standard subdirectories.
+ *
+ * Recommendations:
+ *   - Administrators with an unusual directory structure should either:
+ *     - Set env var CIVICRM_SETTINGS in their httpd vhost and bashrc, or
+ *     - Create settings_location.php
+ *   - Primary CMS-integration modules should preemptively configure the
+ *     defaults so that other code may bootstrap without specifying options.
+ *       require_once $cividir/Civi/Bootstrap.php
+ *       Civi\Bootstrap::singleton()->setOptions(
+ *         'settingsFile' => ...,
+ *         'search' => FALSE,
+ *       ));
+ *   - External scripts should call:
+ *       require_once $cividir/Civi/Bootstrap.php;
+ *       Civi\Bootstrap::singleton()->boot();
+ *   - Administrators who are concerned about bootstrap time for external
+ *     scripts should use CIVICRM_SETTINGS or settings_location.php.
+ *   - Pre-installation programs (code-generators, installers, etc) should not
+ *     use Civi\Bootstrap. Instead, they should use CRM_Core_ClassLoader.
+ *
+ * The bootstrapper accepts a few options (either via setOptions() or boot()). They are:
+ *   - dynamicSettingsFile: string|NULL. The location of a PHP file which dynamically
+ *     determines the location of civicrm.settings.php. This is provided for backward
+ *     compatibility.
+ *     (Default: $civiRoot/settings_location.php)
+ *   - cmsType: string|NULL. Give a hint to the search algorithm about which
+ *     type of CMS is being used.
+ *     (Default: NULL)
+ *   - env: string|NULL. The environment variable which may contain the path to
+ *     civicrm.settings.php. Set NULL to disable.
+ *     (Default: CIVICRM_SETTINGS)
+ *   - prefetch: bool. Whether to load various caches.
+ *     (Default: TRUE)
+ *   - settingsFile: string|NULL. The full path to the civicrm.settings.php
+ *     (Default: NULL)
+ *   - search: bool|string. Attempt to determine root+settings by searching
+ *     the file system and checking against common Civi directory structures.
+ *     Boolean TRUE means it should use a default (PWD).
+ *     (Default: TRUE aka PWD)
+ *
+ * TODO: Consider adding flags for CMS bootstrap.
+ *
+ * @package Civi
+ */
+class Bootstrap {
+
+  protected static $singleton = NULL;
+
+  protected $options = array();
+
+  /**
+   * @return Bootstrap
+   */
+  public static function singleton() {
+    if (self::$singleton === NULL) {
+      self::$singleton = new Bootstrap(array(
+        'dynamicSettingsFile' => dirname(__DIR__) . '/settings_location.php',
+        'env' => 'CIVICRM_SETTINGS',
+        'prefetch' => TRUE,
+        'settingsFile' => NULL,
+        'search' => TRUE,
+        'cmsType' => NULL,
+        'httpHost' => array_key_exists('HTTP_HOST', $_SERVER) ? $_SERVER['HTTP_HOST'] : '',
+      ));
+    }
+    return self::$singleton;
+  }
+
+  /**
+   * @param array $options
+   *   See options in class doc.
+   */
+  public function __construct($options = array()) {
+    $this->options = $options;
+  }
+
+  /**
+   * Bootstrap the CiviCRM runtime.
+   *
+   * @param array $options
+   *   See options in class doc.
+   * @throws \Exception
+   */
+  public function boot($options = array()) {
+    if (!defined('CIVICRM_SETTINGS_PATH')) {
+      $this->options = $options = array_merge($this->options, $options);
+
+      if (!empty($options['dynamicSettingsFile']) && file_exists($options['dynamicSettingsFile'])) {
+        include $options['dynamicSettingsFile'];
+      }
+
+      /**
+       * @var string
+       *   Path to the settings file.
+       */
+      $settings = NULL;
+
+      if (defined('CIVICRM_CONFDIR') && file_exists(CIVICRM_CONFDIR . '/civicrm.settings.php')) {
+        $settings = CIVICRM_CONFDIR . '/civicrm.settings.php';
+      }
+      elseif (!empty($options['env']) && getenv($options['env']) && file_exists(getenv($options['env']))) {
+        $settings = getenv($options['env']);
+      }
+      elseif (!empty($options['settingsFile']) && file_exists($options['settingsFile'])) {
+        $settings = $options['settingsFile'];
+      }
+      elseif (!empty($options['search'])) {
+        list (, , $settings) = $this->findCivicrmSettingsPhp($this->getSearchDir());
+      }
+
+      if (empty($settings) || !file_exists($settings)) {
+        throw new \Exception("Failed to locate civicrm.settings.php. Please boot with settingsFile, search, or CIVICRM_SETTINGS; or normalize your directory structure.");
+      }
+
+      define('CIVICRM_SETTINGS_PATH', $settings);
+      $error = @include_once $settings;
+      if ($error == FALSE) {
+        throw new \Exception("Could not load the CiviCRM settings file: {$settings}");
+      }
+    }
+
+    // Backward compatibility - New civicrm.settings.php files include
+    // the classloader, but old ones don't.
+    global $civicrm_root;
+    require_once $civicrm_root . '/CRM/Core/ClassLoader.php';
+    \CRM_Core_ClassLoader::singleton()->register();
+
+    if (!empty($options['prefetch'])) {
+      // I'm not sure why this is called explicitly during bootstrap
+      // rather than lazily. However, it seems to be done by all
+      // the existing bootstrap code. Perhaps initializing Config
+      // has a side-effect of initializing other things?
+      \CRM_Core_Config::singleton();
+    }
+  }
+
+  /**
+   * @return array
+   *   See options in class doc.
+   */
+  public function getOptions() {
+    return $this->options;
+  }
+
+  /**
+   * @param array $options
+   *   See options in class doc.
+   */
+  public function setOptions($options) {
+    $this->options = $options;
+  }
+
+  /**
+   * Locate a civicrm.settings.php using normal directory structures.
+   *
+   * @param string $searchDir
+   *   The directory from which to begin the upward search.
+   * @return array
+   *   Array(string $cmsType, string $cmsRoot, string $settingsFile).
+   */
+  protected function findCivicrmSettingsPhp($searchDir) {
+    list ($cmsType, $cmsRoot) = $this->findCmsRoot($searchDir);
+
+    $settings = NULL;
+    switch ($cmsType) {
+      case 'drupal':
+        $settings = $this->findFirstFile($this->findDrupalDirs($cmsRoot), 'civicrm.settings.php');
+        break;
+
+      case 'joomla':
+        // Note: Joomla technically has two copies of civicrm.settings.php with
+        // slightly different values of CIVICRM_UF_BASEURL. It appears that Joomla
+        // always used the admin copy for CLI/bin/extern scripts, so we do the
+        // same. However, the arrangement seems gratuitous considering that WP
+        // has the same frontend/backend split and does not need two copies of
+        // civicrm.settings.php.
+
+        $settings = $cmsRoot . 'administrator/components/com_civicrm/civicrm.settings.php';
+        // $result =  $cmsRoot . 'components/com_civicrm/civicrm.settings.php';
+        break;
+
+      case 'wp':
+        $settings = 'wp-content/plugins/civicrm/civicrm.settings.php';
+        break;
+    }
+    return array($cmsType, $cmsRoot, $settings);
+  }
+
+  /**
+   * Get an ordered list of multisite dirs that might apply to this request.
+   *
+   * @param string $cmsRoot
+   *   The root of the Drupal installation.
+   * @return string
+   */
+  protected function findDrupalDirs($cmsRoot) {
+    $dirs = array();
+    $server = explode('.', implode('.', array_reverse(explode(':', rtrim($this->options['httpHost'], '.')))));
+    for ($j = count($server); $j > 0; $j--) {
+      $dirs[] = "$cmsRoot/sites/" . implode('.', array_slice($server, -$j));
+    }
+    $dirs[] = "$cmsRoot/sites/default";
+    return $dirs;
+  }
+
+  /**
+   * @param string $searchDir
+   *   The directory from which to begin the upward search.
+   * @return array
+   *   Array(string $cmsType, string $cmsRoot, string $civiRoot)
+   */
+  protected function findCmsRoot($searchDir) {
+    // A list of file patterns; if one of the patterns matches a give
+    // directory, then we can assume that this directory is the
+    // CMS root.
+    $cmsPatterns = array(
+      'wp' => array(
+        'wp-content/plugins/civicrm/civicrm/civicrm-version.php',
+        // Future? 'vendor/civicrm/wordpress/civicrm.php' => 'wp',
+      ),
+      'joomla' => array(
+        'administrator/components/com_civicrm/civicrm/civicrm-version.php',
+        // Future? 'vendor/civicrm/joomla/civicrm.php' => 'joomla',
+      ),
+      'drupal' => array(
+        'sites/*/civicrm.settings.php',
+        // Future? 'sites/libraries/civicrm/civicrm-version.php' => 'drupal',
+        // Future? 'vendor/civicrm/drupal/civicrm.module' => 'drupal',
+      ),
+    );
+
+    $parts = explode('/', str_replace('\\', '/', $searchDir));
+    while (!empty($parts)) {
+      $basePath = implode('/', $parts);
+
+      foreach ($cmsPatterns as $cmsType => $relPaths) {
+        if (!empty($this->options['cmsType']) && $this->options['cmsType'] != $cmsType) {
+          continue;
+        }
+        foreach ($relPaths as $relPath) {
+          $matches = glob("$basePath/$relPath");
+          if (!empty($matches)) {
+            return array($cmsType, $basePath);
+          }
+        }
+      }
+
+      array_pop($parts);
+    }
+
+    return array(NULL, NULL);
+  }
+
+  /**
+   * @param string|array $dirs
+   *   List of directories to check.
+   * @param string|array $items
+   *   List of globs to check in each directory.
+   * @return null|string
+   */
+  protected function findFirstFile($dirs, $items) {
+    $dirs = (array) $dirs;
+    $items = (array) $items;
+    foreach ($dirs as $dir) {
+      foreach ($items as $item) {
+        $matches = (array) glob("$dir/$item");
+        if (isset($matches[0])) {
+          return $matches[0];
+        }
+      }
+    }
+    return NULL;
+  }
+
+  /**
+   * @return string
+   */
+  protected function getSearchDir() {
+    if ($this->options['search'] === TRUE) {
+      // exec(pwd) works better with symlinked source trees, but it's
+      // probably not portable to Windows.
+      if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+        return getcwd();
+      }
+      else {
+        exec('pwd', $output);
+        return trim(implode("\n", $output));
+      }
+    }
+    else {
+      return $this->options['search'];
+    }
+  }
+
+}

--- a/bin/cli.class.php
+++ b/bin/cli.class.php
@@ -215,13 +215,9 @@ class civicrm_cli {
 
     $civicrm_root = dirname(__DIR__);
     chdir($civicrm_root);
-    require_once 'civicrm.config.php';
-    // autoload
-    if (!class_exists('CRM_Core_ClassLoader')) {
-      require_once $civicrm_root . '/CRM/Core/ClassLoader.php';
-    }
-    CRM_Core_ClassLoader::singleton()->register();
 
+    require_once __DIR__ . '/../Civi/Bootstrap.php';
+    Civi\Bootstrap::singleton()->boot();
     $this->_config = CRM_Core_Config::singleton();
 
     // HTTP_HOST will be 'localhost' unless overwritten with the -s argument.

--- a/bin/cron.php
+++ b/bin/cron.php
@@ -25,12 +25,8 @@
  +--------------------------------------------------------------------+
  */
 
-
-require_once '../civicrm.config.php';
-require_once 'CRM/Core/Config.php';
-require_once 'CRM/Utils/Request.php';
-$config = CRM_Core_Config::singleton();
-
+require_once '../Civi/Bootstrap.php';
+Civi\Bootstrap::singleton()->boot();
 CRM_Utils_System::authenticateScript(TRUE);
 
 $job = CRM_Utils_Request::retrieve('job', 'String', CRM_Core_DAO::$_nullArray, FALSE, NULL, 'REQUEST');

--- a/civicrm.config.php
+++ b/civicrm.config.php
@@ -1,0 +1,7 @@
+<?php
+// This is an adapter which allows old scripts to continue booting.
+require_once __DIR__ . '/Civi/Bootstrap.php';
+Civi\Bootstrap::singleton()->boot(array(
+  'search' => TRUE,
+  'prefetch' => FALSE,
+));

--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -69,7 +69,7 @@ function dm_install_core() {
     [ -d "$repo/$dir" ] && dm_install_dir "$repo/$dir" "$to/$dir"
   done
 
-  dm_install_files "$repo" "$to" {agpl-3.0,agpl-3.0.exception,gpl,README,CONTRIBUTORS}.txt
+  dm_install_files "$repo" "$to" {agpl-3.0,agpl-3.0.exception,gpl,README,CONTRIBUTORS}.txt civicrm.config.php
   dm_install_files "$repo" "$to" composer.json composer.lock bower.json package.json
 
   mkdir -p "$to/sql"
@@ -176,7 +176,6 @@ function dm_install_wordpress() {
   ${DM_RSYNC:-rsync} -avC \
     --exclude=.git \
     --exclude=.svn \
-    --exclude=civicrm.config.php.wordpress \
     --exclude=.gitignore \
     --exclude=civicrm \
     "$repo/./"  "$to/./"

--- a/distmaker/dists/drupal6_php5.sh
+++ b/distmaker/dists/drupal6_php5.sh
@@ -16,7 +16,6 @@ TRG=$DM_TMPDIR/civicrm
 
 # copy all the stuff
 dm_reset_dirs "$TRG"
-cp $SRC/drupal/civicrm.config.php.drupal $TRG/civicrm.config.php
 dm_generate_version "$TRG/civicrm-version.php" Drupal6
 dm_install_core "$SRC" "$TRG"
 dm_install_packages "$SRC/packages" "$TRG/packages"

--- a/distmaker/dists/drupal_php5.sh
+++ b/distmaker/dists/drupal_php5.sh
@@ -16,7 +16,6 @@ TRG=$DM_TMPDIR/civicrm
 
 # copy all the stuff
 dm_reset_dirs "$TRG"
-cp $SRC/drupal/civicrm.config.php.drupal $TRG/civicrm.config.php
 dm_generate_version "$TRG/civicrm-version.php" Drupal
 dm_install_core "$SRC" "$TRG"
 dm_install_packages "$SRC/packages" "$TRG/packages"

--- a/distmaker/dists/drupal_sk_php5.sh
+++ b/distmaker/dists/drupal_sk_php5.sh
@@ -16,7 +16,6 @@ TRG=$DM_TMPDIR/civicrm
 
 # copy all the stuff
 dm_reset_dirs "$TRG"
-cp $SRC/drupal/civicrm.config.php.drupal $TRG/civicrm.config.php
 dm_generate_version "$TRG/civicrm-version.php" Drupal
 dm_install_core "$SRC" "$TRG"
 dm_install_packages "$SRC/packages" "$TRG/packages"

--- a/distmaker/dists/joomla_php5.sh
+++ b/distmaker/dists/joomla_php5.sh
@@ -16,7 +16,6 @@ TRG=$DM_TMPDIR/civicrm
 
 # copy all the rest of the stuff
 dm_reset_dirs "$TRG" "$DM_TMPDIR/com_civicrm"
-cp $SRC/civicrm.config.php $TRG
 dm_generate_version "$TRG/civicrm-version.php" Joomla
 dm_install_core "$SRC" "$TRG"
 dm_install_packages "$SRC/packages" "$TRG/packages"

--- a/distmaker/dists/wordpress_php5.sh
+++ b/distmaker/dists/wordpress_php5.sh
@@ -16,7 +16,6 @@ TRG=$DM_TMPDIR/civicrm
 
 # copy all the stuff
 dm_reset_dirs "$TRG" "$TRG/civicrm/civicrm"
-cp $SRC/WordPress/civicrm.config.php.wordpress $TRG/civicrm/civicrm/civicrm.config.php
 dm_generate_version "$TRG/civicrm/civicrm/civicrm-version.php" Wordpress
 dm_install_core "$SRC" "$TRG/civicrm/civicrm"
 dm_install_packages "$SRC/packages" "$TRG/civicrm/civicrm/packages"

--- a/distmaker/utils/joomlaxml.php
+++ b/distmaker/utils/joomlaxml.php
@@ -33,7 +33,10 @@ else {
 ini_set('include_path',
   "{$sourceCheckoutDir}:{$sourceCheckoutDir}/packages:" . ini_get('include_path')
 );
-require_once "$sourceCheckoutDir/civicrm.config.php";
+
+
+require_once "$sourceCheckoutDir/CRM/Core/ClassLoader.php";
+CRM_Core_ClassLoader::singleton()->register();
 require_once 'Smarty/Smarty.class.php';
 
 generateJoomlaConfig($version);
@@ -74,9 +77,6 @@ function generateJoomlaConfig($version) {
   $fd = fopen($output, "w");
   fwrite($fd, $xml);
   fclose($fd);
-
-  require_once 'CRM/Core/Config.php';
-  $config = CRM_Core_Config::singleton(FALSE);
 
   require_once 'CRM/Core/Permission.php';
   require_once 'CRM/Utils/String.php';

--- a/extern/authorizeIPN.php
+++ b/extern/authorizeIPN.php
@@ -33,8 +33,8 @@
 
 session_start();
 
-require_once '../civicrm.config.php';
-$config = CRM_Core_Config::singleton();
+require_once '../Civi/Bootstrap.php';
+Civi\Bootstrap::singleton()->boot();
 $log = new CRM_Utils_SystemLogger();
 $log->alert('payment_notification processor_name=AuthNet', $_REQUEST);
 

--- a/extern/googleNotify.php
+++ b/extern/googleNotify.php
@@ -33,9 +33,9 @@
 
 session_start();
 
-require_once '../civicrm.config.php';
+require_once '../Civi/Bootstrap.php';
+Civi\Bootstrap::singleton()->boot();
 
-$config = CRM_Core_Config::singleton();
 $log = new CRM_Utils_SystemLogger();
 $log->alert('payment_notification processor_name=Google_Checkout', $_REQUEST);
 

--- a/extern/ipn.php
+++ b/extern/ipn.php
@@ -33,11 +33,11 @@
 
 session_start();
 
-require_once '../civicrm.config.php';
+require_once '../Civi/Bootstrap.php';
+Civi\Bootstrap::singleton()->boot();
 
 /* Cache the real UF, override it with the SOAP environment */
 
-$config = CRM_Core_Config::singleton();
 $log = new CRM_Utils_SystemLogger();
 if (empty($_GET)) {
   $log->alert('payment_notification processor_name=PayPal', $_REQUEST);

--- a/extern/open.php
+++ b/extern/open.php
@@ -1,17 +1,13 @@
 <?php
-require_once '../civicrm.config.php';
-require_once 'CRM/Core/Config.php';
-require_once 'CRM/Core/Error.php';
-require_once 'CRM/Utils/Array.php';
+require_once '../Civi/Bootstrap.php';
+Civi\Bootstrap::singleton()->boot();
 
-$config = CRM_Core_Config::singleton();
 $queue_id = CRM_Utils_Array::value('q', $_GET);
 if (!$queue_id) {
   echo "Missing input parameters\n";
   exit();
 }
 
-require_once 'CRM/Mailing/Event/BAO/Opened.php';
 CRM_Mailing_Event_BAO_Opened::open($queue_id);
 
 $filename = "../i/tracker.gif";

--- a/extern/pxIPN.php
+++ b/extern/pxIPN.php
@@ -13,10 +13,9 @@
 
 session_start();
 
-require_once '../civicrm.config.php';
-require_once 'CRM/Core/Config.php';
+require_once '../Civi/Bootstrap.php';
+Civi\Bootstrap::singleton()->boot();
 
-$config = CRM_Core_Config::singleton();
 $log = new CRM_Utils_SystemLogger();
 $log->alert('payment_notification processor_name=Payment_Express', $_REQUEST);
 /*

--- a/extern/rest.php
+++ b/extern/rest.php
@@ -25,8 +25,8 @@
  +--------------------------------------------------------------------+
  */
 
-require_once '../civicrm.config.php';
-$config = CRM_Core_Config::singleton();
+require_once '../Civi/Bootstrap.php';
+Civi\Bootstrap::singleton()->boot();
 
 session_start();
 $rest = new CRM_Utils_REST();

--- a/extern/soap.php
+++ b/extern/soap.php
@@ -35,7 +35,10 @@ if (phpversion() == "5.2.2" &&
 
 session_start();
 
-require_once '../civicrm.config.php';
+require_once '../Civi/Bootstrap.php';
+Civi\Bootstrap::singleton()->boot(array(
+  'prefetch' => FALSE,
+));
 require_once 'CRM/Core/Config.php';
 
 $server = new SoapServer(NULL,

--- a/extern/url.php
+++ b/extern/url.php
@@ -1,10 +1,6 @@
 <?php
-require_once '../civicrm.config.php';
-require_once 'CRM/Core/Config.php';
-require_once 'CRM/Core/Error.php';
-require_once 'CRM/Utils/Array.php';
-
-$config = CRM_Core_Config::singleton();
+require_once '../Civi/Bootstrap.php';
+Civi\Bootstrap::singleton()->boot();
 
 // To keep backward compatibility for URLs generated
 // by CiviCRM < 1.7, we check for the q variable as well.

--- a/extern/widget.php
+++ b/extern/widget.php
@@ -31,10 +31,9 @@
  * @copyright CiviCRM LLC (c) 2004-2014
  * $Id$
  */
-require_once '../civicrm.config.php';
-require_once 'CRM/Core/Config.php';
+require_once '../Civi/Bootstrap.php';
+Civi\Bootstrap::singleton()->boot();
 
-$config = CRM_Core_Config::singleton();
 $template = CRM_Core_Smarty::singleton();
 
 require_once 'CRM/Utils/Request.php';

--- a/xml/templates/civicrm_version.tpl
+++ b/xml/templates/civicrm_version.tpl
@@ -1,11 +1,7 @@
 <?php
 
-function civicrmVersion( ) {ldelim}
-{include file="../../templates/CRM/common/version.tpl" assign=svnrevision}
+function civicrmVersion() {ldelim}
   return array( 'version'  => '{$db_version}',
                 'cms'      => '{$cms}',
                 'revision' => '{$svnrevision}' );
 {rdelim}
-
-
-


### PR DESCRIPTION
(This is some preliminary work toward http://forum.civicrm.org/index.php/topic,35050.0.html )

TODO:
- Remove civicrm.config.php templates from Drupal and WordPress repos
- Remove civicrm.config.php generator Joomla installer
- Assimilate some error-checking/reporting ideas from civicrm.module's civicrm_initialize()
- Update CMS's to call Civi\Bootstrap and pass in settings_file.
- _civicrm_registerClassLoader in civicrm.module  - not sure why this is needed when
  civicrm.settings.php will use ClassLoader from $civicrm_root. Perhaps this is a workaround
  for running the installer (ie before $civicrm_root is set).
- Test:
  - Run each bin/ and extern/ script
  - Try each CMS
  - Setup various directory structures with Drupal singlesite and multisite
  - Try installation & upgrade (with/without classloader in civicrm.settings.php)
