### PR TITLE
CRM-15939 - Custom Rich Text Editor fields aren't save from in-line edit...

### DIFF
--- a/templates/CRM/Contact/Page/View/Summary.js
+++ b/templates/CRM/Contact/Page/View/Summary.js
@@ -6,6 +6,20 @@
     beforeSubmit: function(arr, $form, options) {
       addCiviOverlay($form);
     },
+    // CRM-15939: Custom Rich Text Editor fields aren't save from in-line editing.
+    beforeSerialize: function(form, options) {
+      // Copied from 4.5 patch
+      if (window.CKEDITOR && window.CKEDITOR.instances) {
+        $.each(CKEDITOR.instances, function() {
+          this.updateElement && this.updateElement();
+        });
+      }
+      if (window.tinyMCE && tinyMCE.editors) {
+        $.each(tinyMCE.editors, function() {
+          this.save();
+        });
+      }
+    },
     success: requestHandler,
     error: errorHandler
   };


### PR DESCRIPTION
...ing.

This back-port has been tested, it resolves the issue in 4.4 even tough the code base is really different from 4.5 on all ajax stuff.
