### PR TITLE
CRM-15956 - Reports / Smarty: section headers should be case-insensitive

### DIFF
--- a/CRM/Core/Smarty/plugins/function.isValueChange.php
+++ b/CRM/Core/Smarty/plugins/function.isValueChange.php
@@ -62,7 +62,7 @@ function smarty_function_isValueChange($params, &$smarty) {
 
   $is_changed = FALSE;
 
-  if (!array_key_exists($params['key'], $values) || $params['value'] != $values[$params['key']]) {
+  if (!array_key_exists($params['key'], $values) || strcasecmp($params['value'], $values[$params['key']]) !== 0) {
     // if we have a new value
 
     $is_changed = TRUE;


### PR DESCRIPTION
because MySQL ORDER BY is
