### PR TITLE
CRM-15578 - Mailing API - Fix bug with resaving mailings

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1608,6 +1608,10 @@ ORDER BY   civicrm_email.is_bulkmail DESC
    * @throws \Exception
    */
   public static function create(&$params, $ids = array()) {
+    // WTH $ids
+    if (empty($ids) && isset($params['id'])) {
+      $ids['id'] = $params['id'];
+    }
 
     // CRM-12430
     // Do the below only for an insert


### PR DESCRIPTION
The bug manifested as failure to validate the required tokens. When
submitting (resaving with scheduled_date, etal), the BAO's create() function
incorrectly applied defaults and overwrote the value of footer_id (among
others) -- which subsequently caused checkSendable() to fail.
