### PR TITLE
CRM-15958 - Fix problem where financial_trxn.trxn_id is not being saved ...

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2843,6 +2843,7 @@ WHERE  contribution_id = %1 ";
 
         //Update contribution status
         $params['trxnParams']['status_id'] = $params['contribution']->contribution_status_id;
+        $params['trxnParams']['trxn_id'] = $params['contribution']->trxn_id;
         if (!empty($params['contribution_status_id']) &&
           $params['prevContribution']->contribution_status_id != $params['contribution']->contribution_status_id
         ) {


### PR DESCRIPTION
...on contribution update.

---
- CRM-15958: Updating a contribution to completed with a new trxn_id writes unjoinable finanical_trxn record
  https://issues.civicrm.org/jira/browse/CRM-15958
