### PR TITLE
CRM-13584: localization of the CiviCRM installer

### DIFF
--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -877,4 +877,16 @@ AND
     return CRM_Financial_BAO_PaymentProcessor::hasPaymentProcessorSupporting(array('BackOffice'));
   }
 
+  /**
+   * Resets the singleton, so that the next call to CRM_Core_Config::singleton()
+   * reloads completely.
+   *
+   * While normally we could call the singleton function with $force = TRUE,
+   * this function addresses a very specific use-case in the CiviCRM installer,
+   * where we cannot yet force a reload, but we want to make sure that the next
+   * call to this object gets a fresh start (ex: to initialize the DAO).
+   */
+  public function free() {
+    self::$_singleton = NULL;
+  }
 }

--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -889,4 +889,5 @@ AND
   public function free() {
     self::$_singleton = NULL;
   }
+
 }

--- a/install/civicrm.php
+++ b/install/civicrm.php
@@ -36,12 +36,6 @@ function civicrm_setup($filesDirectory) {
   global $crmPath, $sqlPath, $pkgPath, $tplPath;
   global $compileDir;
 
-  $pkgPath = $crmPath . DIRECTORY_SEPARATOR . 'packages';
-  set_include_path($crmPath . PATH_SEPARATOR .
-    $pkgPath . PATH_SEPARATOR .
-    get_include_path()
-  );
-
   $sqlPath = $crmPath . DIRECTORY_SEPARATOR . 'sql';
   $tplPath = $crmPath . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'CRM' . DIRECTORY_SEPARATOR . 'common' . DIRECTORY_SEPARATOR;
 

--- a/install/index.php
+++ b/install/index.php
@@ -167,6 +167,8 @@ if (isset($_REQUEST['seedLanguage']) and isset($langs[$_REQUEST['seedLanguage']]
 }
 
 $config = CRM_Core_Config::singleton(FALSE);
+$GLOBALS['civicrm_default_error_scope'] = NULL;
+
 // The translation files are in the parent directory (l10n)
 $config->gettextResourceDir = '..' . DIRECTORY_SEPARATOR . $config->gettextResourceDir;
 $i18n = CRM_Core_I18n::singleton();

--- a/install/index.php
+++ b/install/index.php
@@ -323,9 +323,9 @@ class InstallRequirements {
     ) {
       $this->requireMySQLServer($databaseConfig['server'],
         array(
-          "MySQL $dbName Configuration",
-          "Does the server exist",
-          "Can't find the a MySQL server on '$databaseConfig[server]'",
+          ts("MySQL %1 Configuration", array(1 => $dbName)),
+          ts("Does the server exist?"),
+          ts("Can't find the a MySQL server on '%1'.", array(1 => $databaseConfig['server'])),
           $databaseConfig['server'],
         )
       );
@@ -333,27 +333,27 @@ class InstallRequirements {
         $databaseConfig['username'],
         $databaseConfig['password'],
         array(
-          "MySQL $dbName Configuration",
-          "Are the access credentials correct",
-          "That username/password doesn't work",
+          ts("MySQL %1 Configuration", array(1 => $dbName)),
+          ts("Are the access credentials correct?"),
+          ts("That username/password doesn't work"),
         )
       )
       ) {
         @$this->requireMySQLVersion("5.1",
           array(
-            "MySQL $dbName Configuration",
-            "MySQL version at least 5.1",
-            "MySQL version 5.1 or higher is required, you only have ",
-            "MySQL " . mysql_get_server_info(),
+            ts("MySQL %1 Configuration", array(1 => $dbName)),
+            ts("MySQL version at least %1", array(1 => '5.1')),
+            ts("MySQL version %1 or higher is required, you are running MySQL %2.", array(1 => '5.1', 2 => mysql_get_server_info())),
+            ts("MySQL %1", array(1 => mysql_get_server_info())),
           )
         );
         $this->requireMySQLAutoIncrementIncrementOne($databaseConfig['server'],
           $databaseConfig['username'],
           $databaseConfig['password'],
           array(
-            "MySQL $dbName Configuration",
-            "Is auto_increment_increment set to 1",
-            "An auto_increment_increment value greater than 1 is not currently supported. Please see issue CRM-7923 for further details and potential workaround.",
+            ts("MySQL %1 Configuration", array(1 => $dbName)),
+            ts("Is auto_increment_increment set to 1"),
+            ts("An auto_increment_increment value greater than 1 is not currently supported. Please see issue CRM-7923 for further details and potential workaround."),
           )
         );
         $this->requireMySQLThreadStack($databaseConfig['server'],
@@ -362,8 +362,8 @@ class InstallRequirements {
           $databaseConfig['database'],
           self::MINIMUM_THREAD_STACK,
           array(
-            "MySQL $dbName Configuration",
-            "Does MySQL thread_stack meet minimum (" . self::MINIMUM_THREAD_STACK . "k)",
+            ts("MySQL %1 Configuration", array(1 => $dbName)),
+            ts("Does MySQL thread_stack meet minimum (%1k)", array(1 => self::MINIMUM_THREAD_STACK)),
             "",
             // "The MySQL thread_stack does not meet minimum " . CRM_Upgrade_Form::MINIMUM_THREAD_STACK . "k. Please update thread_stack in my.cnf.",
           )
@@ -376,9 +376,9 @@ class InstallRequirements {
         $databaseConfig['password'],
         $databaseConfig['database'],
         array(
-          "MySQL $dbName Configuration",
-          "Can I access/create the database",
-          "I can't create new databases and the database '$databaseConfig[database]' doesn't exist",
+          ts("MySQL %1 Configuration", array(1 => $dbName)),
+          ts("Can I access/create the database?"),
+          ts("I can't create new databases and the database '%1' doesn't exist.", array(1 => $databaseConfig[database])),
         ),
         $onlyRequire
       );
@@ -388,9 +388,9 @@ class InstallRequirements {
           $databaseConfig['password'],
           $databaseConfig['database'],
           array(
-            "MySQL $dbName Configuration",
-            "Can I access/create InnoDB tables in the database",
-            "Unable to create InnoDB tables. MySQL InnoDB support is required for CiviCRM but is either not available or not enabled in this MySQL database server.",
+            ts("MySQL %1 Configuration", array(1 => $dbName)),
+            ts("Can I access/create InnoDB tables in the database?"),
+            ts("Unable to create InnoDB tables. MySQL InnoDB support is required for CiviCRM but is either not available or not enabled in this MySQL database server."),
           )
         );
         $this->requireMySQLTempTables($databaseConfig['server'],
@@ -398,9 +398,9 @@ class InstallRequirements {
           $databaseConfig['password'],
           $databaseConfig['database'],
           array(
-            "MySQL $dbName Configuration",
-            'Can I create temporary tables in the database',
-            'Unable to create temporary tables. This MySQL user is missing the CREATE TEMPORARY TABLES privilege.',
+            ts("MySQL %1 Configuration", array(1 => $dbName)),
+            ts('Can I create temporary tables in the database?'),
+            ts('Unable to create temporary tables. This MySQL user is missing the CREATE TEMPORARY TABLES privilege.'),
           )
         );
         $this->requireMySQLLockTables($databaseConfig['server'],
@@ -408,9 +408,9 @@ class InstallRequirements {
           $databaseConfig['password'],
           $databaseConfig['database'],
           array(
-            "MySQL $dbName Configuration",
-            'Can I create lock tables in the database',
-            'Unable to lock tables. This MySQL user is missing the LOCK TABLES privilege.',
+            ts("MySQL %1 Configuration", array(1 => $dbName)),
+            ts('Can I create lock tables in the database?'),
+            ts('Unable to lock tables. This MySQL user is missing the LOCK TABLES privilege.'),
           )
         );
         $this->requireMySQLTrigger($databaseConfig['server'],
@@ -418,9 +418,9 @@ class InstallRequirements {
           $databaseConfig['password'],
           $databaseConfig['database'],
           array(
-            "MySQL $dbName Configuration",
-            'Can I create triggers in the database',
-            'Unable to create triggers. This MySQL user is missing the CREATE TRIGGERS  privilege.',
+            ts("MySQL %1 Configuration", array(1 => $dbName)),
+            ts('Can I create triggers in the database?'),
+            ts('Unable to create triggers. This MySQL user is missing the CREATE TRIGGERS  privilege.'),
           )
         );
       }
@@ -436,18 +436,18 @@ class InstallRequirements {
     $this->errors = NULL;
 
     $this->requirePHPVersion('5.3.3', array(
-      "PHP Configuration",
-      "PHP5 installed",
+      ts("PHP Configuration"),
+      ts("PHP5 installed"),
       NULL,
-      "PHP version " . phpversion(),
+      ts("PHP version %1", array(1 => phpversion())),
     ));
 
     // Check that we can identify the root folder successfully
     $this->requireFile($crmPath . CIVICRM_DIRECTORY_SEPARATOR . 'README.txt',
       array(
-        "File permissions",
-        "Does the webserver know where files are stored?",
-        "The webserver isn't letting me identify where files are stored.",
+        ts("File permissions"),
+        ts("Does the webserver know where files are stored?"),
+        ts("The webserver isn't letting me identify where files are stored."),
         $this->getBaseDir(),
       ),
       TRUE
@@ -456,9 +456,9 @@ class InstallRequirements {
     // CRM-6485: make sure the path does not contain PATH_SEPARATOR, as we don’t know how to escape it
     $this->requireNoPathSeparator(
       array(
-        'File permissions',
-        'does the CiviCRM path contain PATH_SEPARATOR?',
-        'the ' . $this->getBaseDir() . ' path contains PATH_SEPARATOR (the ' . PATH_SEPARATOR . ' character)',
+        ts("File permissions"),
+        ts('Does the CiviCRM path contain PATH_SEPARATOR?'),
+        ts('The path %1 contains PATH_SEPARATOR (the %2 character).', array(1 => $this->getBaseDir(), 2 => PATH_SEPARATOR)),
         $this->getBaseDir(),
       )
     );
@@ -467,9 +467,9 @@ class InstallRequirements {
     foreach ($requiredDirectories as $dir) {
       $this->requireFile($crmPath . CIVICRM_DIRECTORY_SEPARATOR . $dir,
         array(
-          "File permissions",
-          "$dir folder exists",
-          "There is no $dir folder",
+          ts("File permissions"),
+          ts("Folder '%1' exists?", array(1 => $dir)),
+          ts("There is no '%1' folder.", array(1 => $dir)),
         ), TRUE
       );
     }
@@ -497,10 +497,12 @@ class InstallRequirements {
 
     foreach ($writableDirectories as $dir) {
       $dirName = CIVICRM_WINDOWS ? $dir : CIVICRM_DIRECTORY_SEPARATOR . $dir;
-      $this->requireWriteable($dirName,
-        array("File permissions", "Is the $dir folder writeable?", NULL),
-        TRUE
+      $testDetails = array(
+        ts("File permissions"),
+        ts("Is the %1 folder writeable?", array(1 => $dir)),
+        NULL,
       );
+      $this->requireWriteable($dirName, $testDetails, TRUE);
     }
 
     //check for Config.IDS.ini, file may exist in re-install
@@ -522,40 +524,44 @@ class InstallRequirements {
     }
 
     if ($webserver == '') {
-      $webserver = "I can't tell what webserver you are running";
+      $webserver = ts("I can't tell what webserver you are running");
     }
 
     // Check for $_SERVER configuration
     $this->requireServerVariables(array('SCRIPT_NAME', 'HTTP_HOST', 'SCRIPT_FILENAME'), array(
-      "Webserver config",
-      "Recognised webserver",
-      "You seem to be using an unsupported webserver.  The server variables SCRIPT_NAME, HTTP_HOST, SCRIPT_FILENAME need to be set.",
+      ts("Webserver config"),
+      ts("Recognised webserver"),
+      ts("You seem to be using an unsupported webserver. The server variables SCRIPT_NAME, HTTP_HOST, SCRIPT_FILENAME need to be set."),
     ));
 
     // Check for MySQL support
-    $this->requireFunction('mysql_connect',
-      array("PHP Configuration", "MySQL support", "MySQL support not included in PHP.")
-    );
+    $this->requireFunction('mysql_connect', array(
+      ts("PHP Configuration"),
+      ts("MySQL support"),
+      ts("MySQL support not included in PHP."),
+    ));
 
     // Check for JSON support
-    $this->requireFunction('json_encode',
-      array("PHP Configuration", "JSON support", "JSON support not included in PHP.")
-    );
+    $this->requireFunction('json_encode', array(
+      ts("PHP Configuration"),
+      ts("JSON support"),
+      ts("JSON support not included in PHP."),
+    ));
 
     // Check for xcache_isset and emit warning if exists
     $this->checkXCache(array(
-      "PHP Configuration",
-      "XCache compatibility",
-      "XCache is installed and there are known compatibility issues between XCache and CiviCRM. Consider using an alternative PHP caching mechanism or disable PHP caching altogether.",
+      ts("PHP Configuration"),
+      ts("XCache compatibility"),
+      ts("XCache is installed and there are known compatibility issues between XCache and CiviCRM. Consider using an alternative PHP caching mechanism or disable PHP caching altogether."),
     ));
 
     // Check memory allocation
     $this->requireMemory(32 * 1024 * 1024,
       64 * 1024 * 1024,
       array(
-        "PHP Configuration",
-        "Memory allocated (PHP config option 'memory_limit')",
-        "CiviCRM needs a minimum of 32M allocated to PHP, but recommends 64M.",
+        ts("PHP Configuration"),
+        ts("Memory allocated (PHP config option 'memory_limit')"),
+        ts("CiviCRM needs a minimum of %1 MB allocated to PHP, but recommends %2 MB.", array(1 => 32, 2 => 64)),
         ini_get("memory_limit"),
       )
     );
@@ -573,15 +579,15 @@ class InstallRequirements {
     $mem = $this->getPHPMemory();
 
     if ($mem < $min && $mem > 0) {
-      $testDetails[2] .= " You only have " . ini_get("memory_limit") . " allocated";
+      $testDetails[2] .= " " . ts("You only have %1 allocated", array(1 => ini_get("memory_limit")));
       $this->error($testDetails);
     }
     elseif ($mem < $recommended && $mem > 0) {
-      $testDetails[2] .= " You only have " . ini_get("memory_limit") . " allocated";
+      $testDetails[2] .= " " . ts("You only have %1 allocated", array(1 => ini_get("memory_limit")));
       $this->warning($testDetails);
     }
     elseif ($mem == 0) {
-      $testDetails[2] .= " We can't determine how much memory you have allocated. Install only if you're sure you've allocated at least 20 MB.";
+      $testDetails[2] .= " " . ts("We can't determine how much memory you have allocated. Install only if you're sure you've allocated at least %1 MB.", array(1 => 32));
       $this->warning($testDetails);
     }
   }
@@ -609,7 +615,7 @@ class InstallRequirements {
 
   public function listErrors() {
     if ($this->errors) {
-      echo "<p>The following problems are preventing me from installing CiviCRM:</p>";
+      echo "<p>" . ts("The following problems are preventing me from installing CiviCRM:") . "</p>";
       foreach ($this->errors as $error) {
         echo "<li>" . htmlentities($error) . "</li>";
       }
@@ -693,10 +699,10 @@ class InstallRequirements {
 
     if (!$testDetails[2]) {
       if (!$aboveMinVersion) {
-        $testDetails[2] = "You need PHP version $minVersion or later, only {$phpVersion} is installed.  Please upgrade your server, or ask your web-host to do so.";
+        $testDetails[2] = ts("You need PHP version %1 or later, only %2 is installed. Please upgrade your server, or ask your web-host to do so.", array(1 => $minVersion, 2 => $phpVersion));
       }
       else {
-        $testDetails[2] = "PHP version {$phpVersion} is not supported. PHP version earlier than $maxVersion is required. You might want to downgrade your server, or ask your web-host to do so.";
+        $testDetails[2] = ts("PHP version %1 is not supported. PHP version earlier than %2 is required. You might want to downgrade your server, or ask your web-host to do so.", array(1 => $maxVersion, 2 => $phpVersion));
       }
     }
 
@@ -714,7 +720,7 @@ class InstallRequirements {
       $filename = $this->getBaseDir() . $filename;
     }
     if (!file_exists($filename)) {
-      $testDetails[2] .= " (file '$filename' not found)";
+      $testDetails[2] .= " (" . ts("file '%1' not found", array(1 => $filename)) . ')';
       $this->error($testDetails);
     }
   }
@@ -737,7 +743,7 @@ class InstallRequirements {
     $this->testing($testDetails);
     $filename = $this->getBaseDir() . $filename;
     if (file_exists($filename)) {
-      $testDetails[2] .= " (file '$filename' found)";
+      $testDetails[2] .= " (" . ts("file '%1' found", array(1 => $filename)) . ")";
       $this->error($testDetails);
     }
   }
@@ -778,7 +784,7 @@ class InstallRequirements {
       if (!isset($testDetails[2])) {
         $testDetails[2] = NULL;
       }
-      $testDetails[2] .= "The user account used by your web-server $name needs to be granted write access to the following directory in order to configure the CiviCRM settings file:\n$filename";
+      $testDetails[2] .= ts("The user account used by your web-server %1 needs to be granted write access to the following directory in order to configure the CiviCRM settings file:", array(1 => $name)) . "\n$filename";
       $this->error($testDetails);
     }
   }
@@ -838,7 +844,7 @@ class InstallRequirements {
     $this->testing($testDetails);
 
     if (!mysql_get_server_info()) {
-      $testDetails[2] = 'Cannot determine the version of MySQL installed. Please ensure at least version 4.1 is installed.';
+      $testDetails[2] = ts('Cannot determine the version of MySQL installed. Please ensure at least version %1 is installed.', array(1 => $version));
       $this->warning($testDetails);
     }
     else {
@@ -866,7 +872,7 @@ class InstallRequirements {
     $this->testing($testDetails);
     $conn = @mysql_connect($server, $username, $password);
     if (!$conn) {
-      $testDetails[2] .= ' Could not determine if mysql has innodb support. Assuming no';
+      $testDetails[2] .= ' ' . ts("Could not determine if MySQL has InnoDB support. Assuming no.");
       $this->error($testDetails);
       return;
     }
@@ -883,10 +889,10 @@ class InstallRequirements {
       }
     }
     if ($innodb_support) {
-      $testDetails[3] = 'MySQL server does have innodb support';
+      $testDetails[3] = ts('MySQL server does have InnoDB support');
     }
     else {
-      $testDetails[2] .= ' Could not determine if mysql has innodb support. Assuming no';
+      $testDetails[2] .= ' ' . ts('Could not determine if MySQL has InnoDB support. Assuming no');
     }
   }
 
@@ -901,20 +907,20 @@ class InstallRequirements {
     $this->testing($testDetails);
     $conn = @mysql_connect($server, $username, $password);
     if (!$conn) {
-      $testDetails[2] = 'Could not login to the database.';
+      $testDetails[2] = ts('Could not login to the database.');
       $this->error($testDetails);
       return;
     }
 
     if (!@mysql_select_db($database, $conn)) {
-      $testDetails[2] = 'Could not select the database.';
+      $testDetails[2] = ts('Could not select the database.');
       $this->error($testDetails);
       return;
     }
 
     $result = mysql_query('CREATE TEMPORARY TABLE civicrm_install_temp_table_test (test text)', $conn);
     if (!$result) {
-      $testDetails[2] = 'Could not create a temp table.';
+      $testDetails[2] = ts('Could not create a temp table.');
       $this->error($testDetails);
     }
     $result = mysql_query('DROP TEMPORARY TABLE civicrm_install_temp_table_test');
@@ -931,27 +937,27 @@ class InstallRequirements {
     $this->testing($testDetails);
     $conn = @mysql_connect($server, $username, $password);
     if (!$conn) {
-      $testDetails[2] = 'Could not login to the database.';
+      $testDetails[2] = ts('Could not login to the database.');
       $this->error($testDetails);
       return;
     }
 
     if (!@mysql_select_db($database, $conn)) {
-      $testDetails[2] = 'Could not select the database.';
+      $testDetails[2] = ts('Could not select the database.');
       $this->error($testDetails);
       return;
     }
 
     $result = mysql_query('CREATE TABLE civicrm_install_temp_table_test (test text)', $conn);
     if (!$result) {
-      $testDetails[2] = 'Could not create a table.';
+      $testDetails[2] = ts('Could not create a table in the database.');
       $this->error($testDetails);
     }
 
     $result = mysql_query('CREATE TRIGGER civicrm_install_temp_table_test_trigger BEFORE INSERT ON civicrm_install_temp_table_test FOR EACH ROW BEGIN END');
     if (!$result) {
       mysql_query('DROP TABLE civicrm_install_temp_table_test');
-      $testDetails[2] = 'Could not create a trigger.';
+      $testDetails[2] = ts('Could not create a database trigger.');
       $this->error($testDetails);
     }
 
@@ -971,27 +977,27 @@ class InstallRequirements {
     $this->testing($testDetails);
     $conn = @mysql_connect($server, $username, $password);
     if (!$conn) {
-      $testDetails[2] = 'Could not login to the database.';
+      $testDetails[2] = ts('Could not connect to the database server.');
       $this->error($testDetails);
       return;
     }
 
     if (!@mysql_select_db($database, $conn)) {
-      $testDetails[2] = 'Could not select the database.';
+      $testDetails[2] = ts('Could not select the database.');
       $this->error($testDetails);
       return;
     }
 
     $result = mysql_query('CREATE TEMPORARY TABLE civicrm_install_temp_table_test (test text)', $conn);
     if (!$result) {
-      $testDetails[2] = 'Could not create a table.';
+      $testDetails[2] = ts('Could not create a table in the database.');
       $this->error($testDetails);
       return;
     }
 
     $result = mysql_query('LOCK TABLES civicrm_install_temp_table_test WRITE', $conn);
     if (!$result) {
-      $testDetails[2] = 'Could not obtain a write lock for the table.';
+      $testDetails[2] = ts('Could not obtain a write lock for the database table.');
       $this->error($testDetails);
       $result = mysql_query('DROP TEMPORARY TABLE civicrm_install_temp_table_test');
       return;
@@ -999,7 +1005,7 @@ class InstallRequirements {
 
     $result = mysql_query('UNLOCK TABLES', $conn);
     if (!$result) {
-      $testDetails[2] = 'Could not release the lock for the table.';
+      $testDetails[2] = ts('Could not release the lock for the database table.');
       $this->error($testDetails);
       $result = mysql_query('DROP TEMPORARY TABLE civicrm_install_temp_table_test');
       return;
@@ -1018,21 +1024,21 @@ class InstallRequirements {
     $this->testing($testDetails);
     $conn = @mysql_connect($server, $username, $password);
     if (!$conn) {
-      $testDetails[2] = 'Could not connect to the database server.';
+      $testDetails[2] = ts('Could not connect to the database server.');
       $this->error($testDetails);
       return;
     }
 
     $result = mysql_query("SHOW variables like 'auto_increment_increment'", $conn);
     if (!$result) {
-      $testDetails[2] = 'Could not query database server variables.';
+      $testDetails[2] = ts('Could not query database server variables.');
       $this->error($testDetails);
       return;
     }
     else {
       $values = mysql_fetch_row($result);
       if ($values[1] == 1) {
-        $testDetails[3] = 'MySQL server auto_increment_increment is 1';
+        $testDetails[3] = ts('MySQL server auto_increment_increment is 1');
       }
       else {
         $this->error($testDetails);
@@ -1052,26 +1058,26 @@ class InstallRequirements {
     $this->testing($testDetails);
     $conn = @mysql_connect($server, $username, $password);
     if (!$conn) {
-      $testDetails[2] = 'Could not login to the database.';
+      $testDetails[2] = ts('Could not connect to the database server.');
       $this->error($testDetails);
       return;
     }
 
     if (!@mysql_select_db($database, $conn)) {
-      $testDetails[2] = 'Could not select the database.';
+      $testDetails[2] = ts('Could not select the database.');
       $this->error($testDetails);
       return;
     }
 
     $result = mysql_query("SHOW VARIABLES LIKE 'thread_stack'", $conn); // bytes => kb
     if (!$result) {
-      $testDetails[2] = 'Could not query thread_stack.';
+      $testDetails[2] = ts('Could not get information about the thread_stack of the database.');
       $this->error($testDetails);
     }
     else {
       $values = mysql_fetch_row($result);
       if ($values[1] < (1024 * $minValueKB)) {
-        $testDetails[2] = 'MySQL "thread_stack" is ' . ($values[1] / 1024) . 'k';
+        $testDetails[2] = ts('MySQL "thread_stack" is %1 kb', array(1 => ($values[1] / 1024)));
         $this->error($testDetails);
       }
     }
@@ -1101,16 +1107,16 @@ class InstallRequirements {
       $okay = "Database '$database' exists";
     }
     elseif ($onlyRequire) {
-      $testDetails[2] = "The database: '$database' does not exist";
+      $testDetails[2] = ts("The database: '%1' does not exist.", array(1 => $database));
       $this->error($testDetails);
       return;
     }
     else {
       if (@mysql_query("CREATE DATABASE $database")) {
-        $okay = "Able to create a new database";
+        $okay = ts("Able to create a new database.");
       }
       else {
-        $testDetails[2] .= " (user '$username' doesn't have CREATE DATABASE permissions.)";
+        $testDetails[2] .= " (" . ts("user '%1' doesn't have CREATE DATABASE permissions.", array(1 => $username)) . ")";
         $this->error($testDetails);
         return;
       }
@@ -1137,7 +1143,7 @@ class InstallRequirements {
       return TRUE;
     }
     else {
-      $testDetails[2] = " (the following PHP variables are missing: " . implode(", ", $missing) . ")";
+      $testDetails[2] = " (" . ts('the following PHP variables are missing: %1', array(1 => implode(", ", $missing))) . ")";
       $this->error($testDetails);
     }
   }
@@ -1175,7 +1181,7 @@ class InstallRequirements {
     $section = $testDetails[0];
     $test = $testDetails[1];
 
-    $message = "OK";
+    $message = ts("OK");
     if (isset($testDetails[3])) {
       $message .= " ($testDetails[3])";
     }
@@ -1291,11 +1297,11 @@ class Installer extends InstallRequirements {
         $output .= '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">';
         $output .= '<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">';
         $output .= '<head>';
-        $output .= '<title>CiviCRM Installed</title>';
+        $output .= '<title>' . ts('CiviCRM Installed') . '</title>';
         $output .= '<link rel="stylesheet" type="text/css" href="template.css" />';
         $output .= '</head>';
         $output .= '<body>';
-        $output .= '<div style="padding: 1em;"><p class="good">CiviCRM has been successfully installed</p>';
+        $output .= '<div style="padding: 1em;"><p class="good">' . ts('CiviCRM has been successfully installed') . '</p>';
         $output .= '<ul>';
         $docLinkConfig = CRM_Utils_System::docURL2('Configuring a New Site', FALSE, 'here', NULL, NULL, "wiki");
         if (!function_exists('ts')) {
@@ -1401,6 +1407,11 @@ class Installer extends InstallRequirements {
 
         // relative / abosolute paths are not working for drupal, hence using chdir()
         chdir($cmsPath);
+
+        // Force the re-initialisation of the config singleton on the next call
+        // since so far, we had used the Config object without loading the DB.
+        $c = CRM_Core_Config::singleton(FALSE);
+        $c->free();
 
         include_once "./includes/bootstrap.inc";
         drupal_bootstrap(DRUPAL_BOOTSTRAP_FULL);

--- a/install/index.php
+++ b/install/index.php
@@ -153,7 +153,7 @@ $installTypeToUF = array(
   'drupal' => 'Drupal',
 );
 
-$uf = (! isset($installTypeToUF[$installType]) ? $installTypeToUF[$installType] : 'Drupal');
+$uf = (isset($installTypeToUF[$installType]) ? $installTypeToUF[$installType] : 'Drupal');
 define('CIVICRM_UF', $uf);
 
 global $tsLocale;

--- a/install/index.php
+++ b/install/index.php
@@ -1350,6 +1350,15 @@ class Installer extends InstallRequirements {
         $GLOBALS['user'] = $original_user;
         drupal_save_session(TRUE);
 
+        //change the default language to one chosen
+        if (isset($config['seedLanguage']) && $config['seedLanguage'] != 'en_US') {
+          civicrm_api3('Setting', 'create', array(
+              'domain_id' => 'current_domain',
+              'lcMessages' => $config['seedLanguage'],
+            )
+          );
+        }
+
         $output .= '</ul>';
         $output .= '</div>';
         $output .= '</body>';
@@ -1417,6 +1426,9 @@ class Installer extends InstallRequirements {
           $docLinkConfig = "<a href=\"{$docLinkConfig}\">here</a>";
         }
 
+        $c = CRM_Core_Config::singleton(FALSE);
+        $c->free();
+
         $cmsURL = civicrm_cms_base();
         $cmsURL .= "wp-admin/admin.php?page=CiviCRM&q=civicrm/admin/configtask&reset=1";
         $wpPermissionsURL = "wp-admin/admin.php?page=CiviCRM&q=civicrm/admin/access/wp-permissions&reset=1";
@@ -1429,21 +1441,6 @@ class Installer extends InstallRequirements {
 
         echo '</ul>';
         echo '</div>';
-      }
-
-      //change the default language to one chosen
-      if (isset($config['seedLanguage']) && $config['seedLanguage'] != 'en_US') {
-        $domainID = CRM_Core_Config::domainID();
-        $configBackend = civicrm_api3('Domain', 'getvalue', array('id' => $domainID, 'return'=> 'config_backend'));
-        $configBackend = unserialize($config_backend);
-
-        //TODO: Scope to set default attributes like for now e.g. Default Launguage
-        $configBackend['lcMessages'] = $config['seedLanguage'];
-        $result = civicrm_api3('Domain', 'setvalue', array(
-                    'id' => $domainID,
-                    'field' => 'config_backend',
-                    'value' => serialize($configBackend),
-                  ));
       }
     }
 

--- a/install/index.php
+++ b/install/index.php
@@ -1433,13 +1433,17 @@ class Installer extends InstallRequirements {
 
       //change the default language to one chosen
       if (isset($config['seedLanguage']) && $config['seedLanguage'] != 'en_US') {
-        $domain = new CRM_Core_DAO_Domain();
-        $domain->id = CRM_Core_Config::domainID();
-        $domain->find(TRUE);
-        $configSettings = unserialize($domain->config_backend);
-        $configSettings['lcMessages'] = $config['seedLanguage'];
-        $domain->config_backend = serialize($configSettings);
-        $domain->save();
+        $domainID = CRM_Core_Config::domainID();
+        $configBackend = civicrm_api3('Domain', 'getvalue', array('id' => $domainID, 'return'=> 'config_backend'));
+        $configBackend = unserialize($config_backend);
+
+        //TODO: Scope to set default attributes like for now e.g. Default Launguage
+        $configBackend['lcMessages'] = $config['seedLanguage'];
+        $result = civicrm_api3('Domain', 'setvalue', array(
+                    'id' => $domainID,
+                    'field' => 'config_backend',
+                    'value' => serialize($configBackend),
+                  ));
       }
     }
 

--- a/install/template.css
+++ b/install/template.css
@@ -27,7 +27,7 @@ li {
 
 label span {
   float: left;
-  width: 12em;
+  width: 14em;
 }
 
 .good td {
@@ -69,7 +69,8 @@ p.good {
 }
 
 p.error a {
-  color: #ccf;
+  color: #FFF;
+  font-weight: bold;
 }
 
 .testResults {

--- a/install/template.html
+++ b/install/template.html
@@ -9,7 +9,7 @@
 <body>
 
 <div id="All">
-  <div style="float: right"><strong>Version <?php echo "{$civicrm_version['version']} {$civicrm_version['cms']}" ?></strong><br/>
+  <div style="float: right"><strong><?php echo ts('Version %1', array(1 => "{$civicrm_version['version']} {$civicrm_version['cms']}")); ?></strong><br/>
     <span><img src=<?php echo $installURLPath . "block_small.png"?> /></span>
   </div>
 
@@ -78,9 +78,9 @@
 </span>
 </p>
 
-<h4><?php echo ts('CiviCRM Database Settings'); ?></h4>
 <input type="hidden" name="database" value="MySQLDatabase" />
 
+<h2><?php echo ts('Database Version and Connection Settings'); ?></h2>
 <p>
 <?php echo ts('CiviCRM stores its content in a MySQL database. Please provide the username and password to connect to the server here.  If this account has permission to create databases, then we will create the database for you; otherwise, you must give the name of a database that already exists.'); ?>
 </p>
@@ -91,7 +91,8 @@
   <p class="good"><?php echo ts("Database version and connection settings have been verified and look correct!"); ?></p>
 <?php } ?>
 
-<p style="margin-left: 2em" id="mysql_credentials" >
+<h4><?php echo ts('CiviCRM Database Settings'); ?></h4>
+<p style="margin-left: 2em" id="mysql_credentials">
   <label for="mysql_server"> <span><?php echo ts('MySQL server:'); ?></span> <input id="mysql_server" type="text" name="mysql[server]" value="<?php echo $databaseConfig['server'] ?>" /></label> <br />
   <label for="mysql_username"> <span><?php echo ts('MySQL username:'); ?></span> <input id="mysql_username" type="text" name="mysql[username]" value="<?php echo $databaseConfig['username'] ?>"  /></label> <br />
   <label for="mysql_password"> <span><?php echo ts('MySQL password:'); ?></span> <input id="mysql_password" type="password" name="mysql[password]" value="<?php echo $databaseConfig['password'] ?>" /></label> <br />
@@ -116,19 +117,22 @@
     <span class="testResults">Check this box to pre-populate CiviCRM with sample English contact records, online contribution pages, profile forms, etc. These examples can help you learn about CiviCRM features.</span><br />
 </p>
 
-<p style="margin-left: 2em"><input type="submit" value="Re-check requirements" /></p>
+<p style="margin-left: 2em"><input type="submit" value="<?php echo ts('Re-check requirements', array('escape' => 'js')); ?>" /></p>
 
 <a name="dbDetails">
-<h4>CiviCRM Database Details</h4>
-<?php $dbReq->showTable("MySQL CiviCRM Configuration"); ?>
+
+<?php
+  echo '<h4>' . ts('CiviCRM Database Details') . '</h4>';
+  $dbReq->showTable(ts("MySQL %1 Configuration", array(1 => 'CiviCRM')));
+?>
 
 <?php if ($installType == 'drupal') {
-echo "<h4>Drupal Database Details</h4>";
-$dbReq->showTable("MySQL Drupal Configuration");
+echo "<h4>" . ts('Drupal Database Details') . "</h4>";
+$dbReq->showTable(ts("MySQL %1 Configuration", array(1 => 'Drupal')));
 }?>
 <br /><hr />
 
-<h2 id="requirements">Requirements</h2>
+<h2 id="requirements"><?php echo ts('Requirements'); ?></h2>
 <?php
 $req->showTable();
 ?>

--- a/install/template.html
+++ b/install/template.html
@@ -2,81 +2,63 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
-<title>CiviCRM Installer</title>
+<title><?php echo ts('CiviCRM Installer'); ?></title>
 <link rel="stylesheet" type="text/css" href=<?php echo $installURLPath . "template.css"?> />
 </head>
 
 <body>
+
 <div id="All">
-    <div style="float: right"><b>Version <?php echo "{$civicrm_version['version']} {$civicrm_version['cms']}" ?></b></br>
+  <div style="float: right"><strong>Version <?php echo "{$civicrm_version['version']} {$civicrm_version['cms']}" ?></strong><br/>
     <span><img src=<?php echo $installURLPath . "block_small.png"?> /></span>
-    </div>
-<h1>CiviCRM Installer</h1>
-<div>Thanks for choosing to use CiviCRM!  Please follow the instructions below to get CiviCRM installed.</div>
-</br><br>
+  </div>
+
+<h1><?php echo ts("CiviCRM Installer"); ?></h1>
+<p><?php echo ts("Thanks for choosing CiviCRM! Please follow the instructions below to install CiviCRM."); ?></p>
+
 <form name="civicrm_form" method="post" action="<?php echo str_replace( '%7E', '~', $_SERVER['REQUEST_URI']); ?>">
-<?php if(isset($hasErrorOtherThanDatabase)) { ?>
-<p class="error">We are not able to install the software.  Please <a style="color: #CCF" href="#requirements">see below</a> for details.</p>
+
+<?php if (isset($hasErrorOtherThanDatabase)) { ?>
+  <p class="error"><?php echo ts('We are not able to install the software. Please <a href="#requirements">see below</a> for details.'); ?></p>
 <?php } else { ?>
-<?php if($req->hasWarnings()) { ?>
-<p class="warning">There are some issues that we recommend you look at before installing, however, you are still able to install the software.  Please see below for details.</p>
+  <?php if ($req->hasWarnings()) { ?>
+    <p class="warning"><?php echo ts('There are some issues that we recommend you look at before installing, however, you are still able to install the software.  Please see below for details.'); ?></p>
+  <?php } elseif (!$dbReq->hasErrors()) { ?>
+    <p class="good"><?php echo ts("You're ready to install!"); ?></p>
+  <?php } ?>
 
-<?php } else if(!$dbReq->hasErrors()) { ?>
-<p class="good">You're ready to install! &nbsp;&nbsp;
-</p>
-
-<?php } ?>
-
-<p>
-  <input id="install_button" type="submit" name="go" value="Check Requirements and Install CiviCRM" onclick="document.getElementById('saving_top').style.display = ''; this.value = 'Installing CiviCRM...'" />
+  <p>
+  <input id="install_button" type="submit" name="go" value="<?php echo ts('Check Requirements and Install CiviCRM', array('escape' => 'js')); ?>" onclick="document.getElementById('saving_top').style.display = ''; this.value = '<?php echo ts('Installing CiviCRM...', array('escape' => 'js')); ?>'" />
 
   <span id="saving_top" style="display: none">
   &nbsp;
     <img src=<?php echo $installURLPath . "network-save.gif"?> />
-  (this will take a few minutes)
+  <?php echo ts('(this will take a few minutes)'); ?>
   </span>
-</p>
+  </p>
 <?php } ?>
 
+<h4><?php echo ts('Language and Region Settings'); ?></h4>
 
-<input type="hidden" name="database" value="MySQLDatabase" />
+<p><?php echo ts('CiviCRM has been translated to many languages, thanks to its community of translators. By selecting another language, the installer may be available in that language. The initial configuration of the basic data will also be set to that language (ex: individual prefixes, suffixes, activity types, etc.). <a href="%1">Learn more about using CiviCRM in other languages.</a>', array(1 => 'http://wiki.civicrm.org/confluence/pages/viewpage.action?pageId=88408149')); ?></p>
 
-<h2>Database Version and Connection Settings</h2>
-<p>
-CiviCRM stores its content in a MySQL database.  Please provide the username
-and password to connect to the server here.  If this account has permission to create databases, then we will
-create the database for you; otherwise, you must give the name of a database that already exists.
-</p>
+<script>
+  function civicrmInstallerSetLanguage(language) {
+     var location = window.location.toString();
 
-<?php if($dbReq->hasErrors()) { ?>
-<p class="error">Your database settings don't appear to be correct. Please check the <strong><a href="#dbDetails" style="color: white;">Database Details</a></strong> below for specific errors.</p>
-<?php } else { ?>
-<p class="good">Database version and connection settings have been verified and look correct!</p>
-<?php } ?>
+     if (location.match(/seedLanguage=.._../)) {
+       location = location.replace(/seedLanguage=.._../, 'seedLanguage=' + language);
+       window.location = location;
+     }
+     else {
+       window.location += '?seedLanguage=' + language;
+     }
+  }
+</script>
 
-<h4>CiviCRM Database Settings</h4>
-<p style="margin-left: 2em" id="mysql_credentials" > <!--style="display: none"-->
-  <label for="mysql_server"> <span>MySQL server:</span> <input id="mysql_server" type="text" name="mysql[server]" value="<?php echo $databaseConfig['server'] ?>" /></label> <br />
-  <label for="mysql_username"> <span>MySQL username:</span> <input id="mysql_username" type="text" name="mysql[username]" value="<?php echo $databaseConfig['username'] ?>"  /></label> <br />
-  <label for="mysql_password"> <span>MySQL password:</span> <input id="mysql_password" type="password" name="mysql[password]" value="<?php echo $databaseConfig['password'] ?>" /></label> <br />
-  <label for="mysql_database"><span>MySQL database:</span> <input id="mysql_database" type="text" name="mysql[database]" value="<?php echo $databaseConfig['database'] ?>" /></label> <br />
-</p>
-
-<?php if ($installType == 'drupal') { ?>
-<h4>Drupal Database Settings</h4>
-<p style="margin-left: 2em" id="drupal_credentials" > <!--style="display: none"-->
-  <label for="drupal_server"> <span>MySQL server:</span> <input id="drupal_server" type="text" name="drupal[server]" value="<?php echo $drupalConfig['server'] ?>" /></label> <br />
-  <label for="drupal_username"> <span>MySQL username:</span> <input id="drupal_username" type="text" name="drupal[username]" value="<?php echo $drupalConfig['username'] ?>"  /></label> <br />
-  <label for="drupal_password"> <span>MySQL password:</span> <input id="drupal_password" type="password" name="drupal[password]" value="<?php echo $drupalConfig['password'] ?>" /></label> <br />
-  <label for="drupal_database"><span>MySQL database:</span> <input id="drupal_database" type="text" name="drupal[database]" value="<?php echo $drupalConfig['database'] ?>" /></label> <br />
-</p>
-<?php } ?>
-
-
-<h4>Other Settings</h4>
-<p style="margin-left: 2em" id="misc_credentials" >
-<!--style="display: none"-->
-<label for="seedLanguage"><span>Language of basic data:</span></label><select id="seedLanguage" name="seedLanguage">
+<p style="margin-left: 2em" id="locale">
+<label for="seedLanguage"><span><?php echo ts('Language of basic data:'); ?></span></label>
+<select id="seedLanguage" name="seedLanguage" onchange="civicrmInstallerSetLanguage(this.value);">
   <?php
     foreach ($langs as $locale => $language) {
       $selected = ($locale == $seedLanguage) ? 'selected="selected"' : '';
@@ -84,13 +66,52 @@ create the database for you; otherwise, you must give the name of a database tha
     }
   ?>
 </select>
+<noscript>
+  <input type="submit" name="setlanguage" value="<?php echo ts('Change language', array('escape' => 'js')); ?>" />
+</noscript>
 <span class="testResults">
   <?php
     if (count($langs) < 2) {
       echo "(download the civicrm-{$civicrm_version['version']}-l10n.tar.gz file and unzip into CiviCRM’s directory to add languages here)";
     }
   ?>
-</span><br />
+</span>
+</p>
+
+<h4><?php echo ts('CiviCRM Database Settings'); ?></h4>
+<input type="hidden" name="database" value="MySQLDatabase" />
+
+<p>
+<?php echo ts('CiviCRM stores its content in a MySQL database. Please provide the username and password to connect to the server here.  If this account has permission to create databases, then we will create the database for you; otherwise, you must give the name of a database that already exists.'); ?>
+</p>
+
+<?php if ($dbReq->hasErrors()) { ?>
+  <p class="error"><?php echo ts("Your database settings don't appear to be correct. Please check the <a href='%1'>Database Details</a> below for specific errors.", array(1 => '#dbDetails')); ?></p>
+<?php } else { ?>
+  <p class="good"><?php echo ts("Database version and connection settings have been verified and look correct!"); ?></p>
+<?php } ?>
+
+<p style="margin-left: 2em" id="mysql_credentials" >
+  <label for="mysql_server"> <span><?php echo ts('MySQL server:'); ?></span> <input id="mysql_server" type="text" name="mysql[server]" value="<?php echo $databaseConfig['server'] ?>" /></label> <br />
+  <label for="mysql_username"> <span><?php echo ts('MySQL username:'); ?></span> <input id="mysql_username" type="text" name="mysql[username]" value="<?php echo $databaseConfig['username'] ?>"  /></label> <br />
+  <label for="mysql_password"> <span><?php echo ts('MySQL password:'); ?></span> <input id="mysql_password" type="password" name="mysql[password]" value="<?php echo $databaseConfig['password'] ?>" /></label> <br />
+  <label for="mysql_database"><span><?php echo ts('MySQL database:'); ?></span> <input id="mysql_database" type="text" name="mysql[database]" value="<?php echo $databaseConfig['database'] ?>" /></label> <br />
+</p>
+
+<?php if ($installType == 'drupal') { ?>
+<h4><?php echo ts('Drupal Database Settings'); ?></h4>
+<p style="margin-left: 2em" id="drupal_credentials" > <!--style="display: none"-->
+  <label for="drupal_server"> <span><?php echo ts('MySQL server:'); ?></span> <input id="drupal_server" type="text" name="drupal[server]" value="<?php echo $drupalConfig['server'] ?>" /></label> <br />
+  <label for="drupal_username"> <span><?php echo ts('MySQL username:'); ?></span> <input id="drupal_username" type="text" name="drupal[username]" value="<?php echo $drupalConfig['username'] ?>"  /></label> <br />
+  <label for="drupal_password"> <span><?php echo ts('MySQL password:'); ?></span> <input id="drupal_password" type="password" name="drupal[password]" value="<?php echo $drupalConfig['password'] ?>" /></label> <br />
+  <label for="drupal_database"><span><?php echo ts('MySQL database:'); ?></span> <input id="drupal_database" type="text" name="drupal[database]" value="<?php echo $drupalConfig['database'] ?>" /></label> <br />
+</p>
+<?php } ?>
+
+
+<h4><?php echo ts('Other Settings'); ?></h4>
+
+<p>
     <label for="loadGenerated"><span>Load sample data:</span><input id="loadGenerated" type="checkbox" name="loadGenerated" value=1 <?php if ( $loadGenerated == 1 ) { echo "checked='checked'"; } ?> /></label> <br />
     <span class="testResults">Check this box to pre-populate CiviCRM with sample English contact records, online contribution pages, profile forms, etc. These examples can help you learn about CiviCRM features.</span><br />
 </p>

--- a/install/template.html
+++ b/install/template.html
@@ -51,7 +51,7 @@
        window.location = location;
      }
      else {
-       window.location += '?seedLanguage=' + language;
+       window.location += (location.indexOf('?') < 0 ? '?' : '&') + 'seedLanguage=' + language;
      }
   }
 </script>


### PR DESCRIPTION
- displays the CiviCRM installer in the language of the user (using seedLanguage)
- sets the default language of CiviCRM to the seedLanguage, once the installation is finished (Drupal and Drupal6, but not Wordpress, since Wordpress is not bootstrapped post-install, so we can't use the API).

Work done with @monishdeb.
