### PR TITLE
CRM-15705 - crmMailingAB - Remove extra styling

### DIFF
--- a/partials/crmMailingAB/joint-mailing.html
+++ b/partials/crmMailingAB/joint-mailing.html
@@ -30,7 +30,7 @@ processed by Angular; if false, the field will be hidden and completely ignored 
         <a crm-icon="disk" ng-click="saveTemplate(abtest.mailings.a)" class="crm-hover-button" title="{{ts('Save As')}}"></a>
       </div>
     </div>
-    <div crm-ui-field="subform.msg_template_idA" crm-title="ts('Template (A)')" style="background: #bbf; width:100%; padding: 0.1em;" ng-if="fields.msg_template_idA">
+    <div crm-ui-field="subform.msg_template_idA" crm-title="ts('Template (A)')" ng-if="fields.msg_template_idA">
       <div ng-controller="MsgTemplateCtrl">
         <select
           crm-ui-id="subform.msg_template_idA"
@@ -45,7 +45,7 @@ processed by Angular; if false, the field will be hidden and completely ignored 
         <a crm-icon="disk" ng-click="saveTemplate(abtest.mailings.a)" class="crm-hover-button" title="{{ts('Save As')}}"></a>
       </div>
     </div>
-    <div crm-ui-field="subform.msg_template_idB" crm-title="ts('Template (B)')" style="background: #bbf; width:100%; padding: 0.1em;" ng-if="fields.msg_template_idB">
+    <div crm-ui-field="subform.msg_template_idB" crm-title="ts('Template (B)')" ng-if="fields.msg_template_idB">
       <div ng-controller="MsgTemplateCtrl">
         <select
           crm-ui-id="subform.msg_template_idB"


### PR DESCRIPTION
The "Message Template" used to have blue background and spacing in all the
UIs.  We removed that in the main crmMailing and crmMailingAB (for
subject/from testing).  This patch removes from crmMailingAB for full-email
testing.
