### PR TITLE
CRM-15578 - crmMailing recipients - Filter on group_type="Mailing List" instead of visibility

### DIFF
--- a/js/angular-crmMailing.js
+++ b/js/angular-crmMailing.js
@@ -231,6 +231,12 @@
   //  - [output] recipients: array of recipient records
   angular.module('crmMailing').controller('EditRecipCtrl', function EditRecipCtrl($scope, dialogService, crmApi, crmMailingMgr, $q, crmMetadata) {
     var ts = $scope.ts = CRM.ts(null);
+
+    $scope.isMailingList = function isMailingList(group) {
+      var GROUP_TYPE_MAILING_LIST = '2';
+      return _.contains(group.group_type, GROUP_TYPE_MAILING_LIST);
+    };
+
     $scope.recipients = null;
     $scope.getRecipientsEstimate = function () {
       var ts = $scope.ts;

--- a/partials/crmMailing/recipients.html
+++ b/partials/crmMailing/recipients.html
@@ -8,7 +8,7 @@
     crm-mailing-recipients
     ng-model="mailing.recipients"
     crm-mandatory-groups="crmMailingConst.groupNames | filter:{is_hidden:1}"
-    crm-avail-groups="crmMailingConst.groupNames | filter:{visibility:'Public pages'}"
+    crm-avail-groups="crmMailingConst.groupNames | filter:isMailingList"
     crm-avail-mailings="crmMailingConst.civiMails | filter:{is_completed:1}"
     crm-ui-id="{{crmMailingBlockRecipients.id}}"
     name="{{crmMailingBlockRecipients.name}}"


### PR DESCRIPTION
Testing note: The "Case Resources" group is a bit confusing -- the
group_type is initialized to "2" (ie "Mailing List") but the norm is ";2;"
(where ";" is the unprintable delimiter).  The CiviMail UI recognizes this
as "Mailing List" with or without delimiters, but the "Manage Groups" screen
does not.
