### PR TITLE
CRM-13901 - Fix unintentional suppression of Membership Dashboard Summar...

### DIFF
--- a/CRM/Mailing/Form/Test.php
+++ b/CRM/Mailing/Form/Test.php
@@ -213,7 +213,7 @@ class CRM_Mailing_Form_Test extends CRM_Core_Form {
         foreach ($emailAdd as $key => $value) {
           $email = trim($value);
           $testParams['emails'][] = $email;
-          $emails .= $emails ? ",'$email'" : "'$email'";
+          $emails .= ($emails ? ',' : '') . "'" . CRM_Core_DAO::escapeString($email)  . "'";
           if (!CRM_Utils_Rule::email($email)) {
             CRM_Core_Session::setStatus(ts('Please enter a valid email addresses.'), ts('Test not sent.'), 'error');
             $error = TRUE;

--- a/CRM/Member/Page/DashBoard.php
+++ b/CRM/Member/Page/DashBoard.php
@@ -51,7 +51,7 @@ class CRM_Member_Page_DashBoard extends CRM_Core_Page {
     //CRM-13901 don't show dashboard to contacts with limited view writes & it does not relect
     //what they have access to
     //@todo implement acls on dashboard querys (preferably via api to enhance that at the same time)
-    if(!CRM_Core_Permission::check(array('view all contacts', 'edit all contacts'))) {
+    if (!CRM_Core_Permission::check('view all contacts') && !CRM_Core_Permission::check('edit all contacts')) {
       $this->showMembershipSummary = FALSE;
       $this->assign('membershipSummary', FALSE);
       return;


### PR DESCRIPTION
...y table for users with view all contacts permission.

---
- CRM-13901: Suppress Membership Dashboard for contacts who may not see all users as it contains info about members they are blocked from
  https://issues.civicrm.org/jira/browse/CRM-13901

Conflicts:
    CRM/Member/Page/DashBoard.php
