### PR TITLE
CRM-15983. Unit test and fix: sort and limit for chained get contact-relationship

### DIFF
--- a/Civi/API/Subscriber/ChainSubscriber.php
+++ b/Civi/API/Subscriber/ChainSubscriber.php
@@ -133,7 +133,21 @@ class ChainSubscriber implements EventSubscriberInterface {
             //set to the parent's id
             $subParams["entity_id"] = $parentAPIValues['id'];
             $subParams['entity_table'] = 'civicrm_' . $lowercase_entity;
-            $subParams[$lowercase_entity . "_id"] = $parentAPIValues['id'];
+
+            // If 'main' entity is contact and subentity is relationship,
+            // contact_id does not make a lot of
+            // sense, since there is a contact_id_a, and contact_id_b.
+            // But if contact_id is set, the relationship api behaves
+            // different, and just returns all relations, ignoring any
+            // filters.
+            //
+            // So we only set the main entity id for the chained call of
+            // main entity is not contact or sub entity is not relationship.
+            //
+            // See CRM-15983: https://issues.civicrm.org/jira/browse/CRM-15983
+            if ($subEntity != 'relationship' || $lowercase_entity != 'contact') {
+              $subParams[$lowercase_entity . "_id"] = $parentAPIValues['id'];
+            }
           }
           if ($entity != 'Contact' && \CRM_Utils_Array::value(strtolower($subEntity . "_id"), $parentAPIValues)) {
             //e.g. if event_id is in the values returned & subentity is event

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -657,7 +657,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
           'contact_id_a' => '$value.id',
           'contact_id_b' => 1,
           'relationship_type_id' => 5,
-          'start_date' => '2005-07-01',
+          'start_date' => '2006-07-01',
           'end_date' => '2010-07-01',
           'description' => 'new',
         ),

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -637,7 +637,14 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    * https://issues.civicrm.org/jira/browse/CRM-15983
    */
   public function testSortLimitChainedRelationshipGetCRM15983() {
-    // Create a contact with two relationships.
+    // Some contact
+    $create_result_1 = $this->callAPISuccess('contact', 'create', array(
+      'first_name' => 'Jules',
+      'last_name' => 'Smos',
+      'contact_type' => 'Individual',
+    ));
+
+    // Create another contact with two relationships.
     $create_params = array(
       'first_name' => 'Jos',
       'last_name' => 'Smos',
@@ -646,17 +653,17 @@ class api_v3_ContactTest extends CiviUnitTestCase {
         array(
           'contact_id_a' => '$value.id',
           // default organization:
-          'contact_id_b' => 1,
-          // employee of:
-          'relationship_type_id' => 5,
+          'contact_id_b' => $create_result_1['id'],
+          // spouse of:
+          'relationship_type_id' => 2,
           'start_date' => '2005-01-12',
           'end_date' => '2006-01-11',
           'description' => 'old',
         ),
         array(
           'contact_id_a' => '$value.id',
-          'contact_id_b' => 1,
-          'relationship_type_id' => 5,
+          'contact_id_b' => $create_result_1['id'],
+          'relationship_type_id' => 2,
           'start_date' => '2006-07-01',
           'end_date' => '2010-07-01',
           'description' => 'new',
@@ -682,7 +689,9 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     $this->assertEquals('new', $get_result['api.relationship.get']['values'][0]['description']);
 
     // Clean up.
-    $this->callAPISuccess('contact', 'delete', $create_result['id']);
+    $this->callAPISuccess('contact', 'delete', array(
+      'id' => $create_result['id'],
+      ));
   }
 
   /**

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -670,6 +670,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
       'sequential' => 1,
       'id' => $create_result['id'],
       'api.relationship.get' => array(
+        'contact_id_a' => '$value.id',
         'options' => array(
           'limit' => '1',
           'sort' => 'start_date DESC',

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -673,7 +673,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
         'options' => array(
           'limit' => '1',
           'sort' => 'start_date DESC',
-      )),
+        )),
     );
     $get_result = $this->callAPISuccess('contact', 'getsingle', $get_params);
 


### PR DESCRIPTION
A unit test for CRM-15983.

Get a contact with his relationships. Sort and limit options for the relationships don't work.
So this test will fail.

---
- CRM-15983: limit and sort options don't work inside chained call to relationship API
  https://issues.civicrm.org/jira/browse/CRM-15983
