### PR TITLE
Add job ID to mailParams for external email delivery service to utilise

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1267,6 +1267,9 @@ ORDER BY   civicrm_email.is_bulkmail DESC
     );
     $mailParams['toEmail'] = $email;
 
+    // Add job ID to mailParams for external email delivery service to utilise
+    $mailParams['job_id'] = $job_id;
+
     CRM_Utils_Hook::alterMailParams($mailParams, 'civimail');
 
     // CRM-10699 support custom email headers


### PR DESCRIPTION
With this parameter added, mass mailing related extensions such as Mailjet integration will not need to override Mailing.php in BAO any more which solved version compatibility issues.
