### PR TITLE
setup.sh, npm test - Fix for debian.org's build of nodejs

### DIFF
--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -151,6 +151,10 @@ if [ -n "$DO_DOWNLOAD" ]; then
     fi
 
     BOWER=$(pickcmd node_modules/bower/bin/bower bower)
+    if [ -f "$BOWER" ]; then
+      NODE=$(pickcmd node nodejs)
+      BOWER="$NODE $BOWER"
+    fi
     # Without the force flag bower won't check for new versions or verify that installed software matches version specified in bower.json
     $BOWER install -f
   popd

--- a/tools/scripts/npm/test.sh
+++ b/tools/scripts/npm/test.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 if which node_modules/karma/bin/karma >> /dev/null; then
-  node node_modules/karma/bin/karma start
+  if which nodejs >> /dev/null; then
+    ## Debian
+    nodejs node_modules/karma/bin/karma start
+  else
+    ## Official
+    node node_modules/karma/bin/karma start
+  fi
 elif which karma >> /dev/null ; then
   karma start
 else


### PR DESCRIPTION
Debian renamed "node" to "nodejs" to avoid conflicts with another package.
One can resolve that by installing an extra package ("nodejs-legacy") or by
using the nodesource.com packages, but users may not know that.

https://lists.debian.org/debian-devel-announce/2012/07/msg00002.html

This commit uses whichever command is available.
