### PR TITLE
CRM_Utils_Check - Allow extensions to define their own alerts.

### DIFF
--- a/CRM/Utils/Check.php
+++ b/CRM/Utils/Check.php
@@ -137,6 +137,9 @@ class CRM_Utils_Check {
     foreach ($checks as $check) {
       $messages = array_merge($messages, $check->checkAll());
     }
+
+    CRM_Utils_Hook::check($messages);
+
     return $messages;
   }
 

--- a/CRM/Utils/Check/Message.php
+++ b/CRM/Utils/Check/Message.php
@@ -49,14 +49,28 @@ class CRM_Utils_Check_Message {
   private $title;
 
   /**
-   * @param string $name
-   * @param $message
-   * @param $title
+   * @var string
+   * @see Psr\Log\LogLevel
    */
-  public function __construct($name, $message, $title) {
+  private $level;
+
+  /**
+   * @param string $name
+   *   Symbolic name for the check.
+   * @param string $message
+   *   Printable message (short or long).
+   * @param string $title
+   *   Printable message (short).
+   * @param string $level
+   *   The severity of the message. Use PSR-3 log levels.
+   *
+   * @see Psr\Log\LogLevel
+   */
+  public function __construct($name, $message, $title, $level = \Psr\Log\LogLevel::WARNING) {
     $this->name = $name;
     $this->message = $message;
     $this->title = $title;
+    $this->level = $level;
   }
 
   /**
@@ -81,6 +95,14 @@ class CRM_Utils_Check_Message {
   }
 
   /**
+   * @return string
+   * @see Psr\Log\LogLevel
+   */
+  public function getLevel() {
+    return $this->level;
+  }
+
+  /**
    * @return array
    */
   public function toArray() {
@@ -88,6 +110,7 @@ class CRM_Utils_Check_Message {
       'name' => $this->name,
       'message' => $this->message,
       'title' => $this->title,
+      'level' => $this->level,
     );
   }
 

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -1920,4 +1920,16 @@ abstract class CRM_Utils_Hook {
     );
   }
 
+  /**
+   * Check system status.
+   *
+   * @param array $messages
+   *   Array<CRM_Utils_Check_Message>. A list of messages regarding system status.
+   * @return mixed
+   */
+  public static function check(&$messages) {
+    return self::singleton()
+      ->invoke(1, $messages, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_check');
+  }
+
 }


### PR DESCRIPTION
Example usage:

``` php
function mymodule_civicrm_check(&$messages) {
  if ($snafu) {
    $messages[] = new CRM_Utils_Check_Message(
      'mymodule_snafu',
     ts('Situation normal, all funnied up'),
     ts('SNAFU')
    );
  }
}
```

I've marked the PR as WIP so that we can allow a comment-period -- looking for opinions on whether this contract is good/bad
