### PR TITLE
CRM-16084 - A unit test and a fix.(relationship direction in chained call)

### DIFF
--- a/Civi/API/Subscriber/ChainSubscriber.php
+++ b/Civi/API/Subscriber/ChainSubscriber.php
@@ -133,7 +133,24 @@ class ChainSubscriber implements EventSubscriberInterface {
             //set to the parent's id
             $subParams["entity_id"] = $parentAPIValues['id'];
             $subParams['entity_table'] = 'civicrm_' . $lowercase_entity;
-            $subParams[$lowercase_entity . "_id"] = $parentAPIValues['id'];
+
+            $crm16084 = FALSE;
+            if ($subEntity == 'relationship' && $lowercase_entity == 'contact') {
+              // if a relationship call is chained to a contact call, we need
+              // to check whether contact_id_a or contact_id_b for the
+              // relationship is given. If so, don't add an extra subParam
+              // "contact_id" => parent_id.
+              // See CRM-16084.
+              foreach (array_keys($newparams) as $key) {
+                if (substr($key, 0, 11) == 'contact_id_') {
+                  $crm16084 = TRUE;
+                  break;
+                }
+              }
+            }
+            if (!$crm16084) {
+              $subParams[$lowercase_entity . "_id"] = $parentAPIValues['id'];
+            }
           }
           if ($entity != 'Contact' && \CRM_Utils_Array::value(strtolower($subEntity . "_id"), $parentAPIValues)) {
             //e.g. if event_id is in the values returned & subentity is event

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -632,6 +632,70 @@ class api_v3_ContactTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test sort and limit for chained relationship get.
+   *
+   * https://issues.civicrm.org/jira/browse/CRM-15983
+   */
+  public function testSortLimitChainedRelationshipGetCRM15983() {
+    // Some contact
+    $create_result_1 = $this->callAPISuccess('contact', 'create', array(
+      'first_name' => 'Jules',
+      'last_name' => 'Smos',
+      'contact_type' => 'Individual',
+    ));
+
+    // Create another contact with two relationships.
+    $create_params = array(
+      'first_name' => 'Jos',
+      'last_name' => 'Smos',
+      'contact_type' => 'Individual',
+      'api.relationship.create' => array(
+        array(
+          'contact_id_a' => '$value.id',
+          'contact_id_b' => $create_result_1['id'],
+          // spouse of:
+          'relationship_type_id' => 2,
+          'start_date' => '2005-01-12',
+          'end_date' => '2006-01-11',
+          'description' => 'old',
+        ),
+        array(
+          'contact_id_a' => '$value.id',
+          'contact_id_b' => $create_result_1['id'],
+          // spouse of (was married twice :))
+          'relationship_type_id' => 2,
+          'start_date' => '2006-07-01',
+          'end_date' => '2010-07-01',
+          'description' => 'new',
+        ),
+      ),
+    );
+    $create_result = $this->callAPISuccess('contact', 'create', $create_params);
+
+    // Try to retrieve the contact and the most recent relationship.
+    $get_params = array(
+      'sequential' => 1,
+      'id' => $create_result['id'],
+      'api.relationship.get' => array(
+        'contact_id_a' => '$value.id',
+        'options' => array(
+          'limit' => '1',
+          'sort' => 'start_date DESC',
+        )),
+    );
+    $get_result = $this->callAPISuccess('contact', 'getsingle', $get_params);
+
+    // Clean up.
+    $this->callAPISuccess('contact', 'delete', array(
+      'id' => $create_result['id'],
+    ));
+
+    // Assert.
+    $this->assertEquals(1, $get_result['api.relationship.get']['count']);
+    $this->assertEquals('new', $get_result['api.relationship.get']['values'][0]['description']);
+  }
+
+  /**
    * Test apostrophe works in get & create.
    */
   public function testGetApostropheCRM10857() {


### PR DESCRIPTION
When you chain a relationship call to a contact call,
and contact_id_a or contact_id_b is provided for the
chained call, don't add the contact_id parameter.

---
- CRM-16084: API: when getting contact chaining relationships, the relationship direction is ignored
  https://issues.civicrm.org/jira/browse/CRM-16084
