### PR TITLE
Followup crm-16088 add classname variable, this is assigned to template

### DIFF
--- a/CRM/Contact/Form/Location.php
+++ b/CRM/Contact/Form/Location.php
@@ -53,6 +53,7 @@ class CRM_Contact_Form_Location {
       $form->set($form->_addBlockName . '_Block_Count', $additionalblockCount);
     }
 
+    $className = CRM_Utils_System::getClassName($form);
     if (is_a($form, 'CRM_Event_Form_ManageEvent_Location')
     || is_a($form, 'CRM_Contact_Form_Domain')) {
       $form->_blocks = array(


### PR DESCRIPTION
add classname variable, this is assigned to template
We removed this variable, but it is assigned to the template, which causes warnings. 
