### PR TITLE
Updated getPatterns regex to add extra URL chars

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -631,7 +631,7 @@ ORDER BY   i.contact_id, i.{$tempColumn}
 
     $protos = '(https?|ftp)';
     $letters = '\w';
-    $gunk = '\{\}/#~:.?+=&;%@!\,\-';
+    $gunk = '\{\}/#~:.?+=&;%@!\,\-\|\(\)\*';
     $punc = '.:?\-';
     $any = "{$letters}{$gunk}{$punc}";
     if ($onlyHrefs) {


### PR DESCRIPTION
We noticed that some URL's didn't get parsed, so we added these extra characters to the regex, to get those recognized properly too.
