### PR TITLE
CRM-16108 - Backport to 4.6.

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -631,7 +631,7 @@ ORDER BY   i.contact_id, i.{$tempColumn}
 
     $protos = '(https?|ftp)';
     $letters = '\w';
-    $gunk = '\{\}/#~:.?+=&;%@!\,\-';
+    $gunk = '\{\}/#~:.?+=&;%@!\,\-\|\(\)\*';
     $punc = '.:?\-';
     $any = "{$letters}{$gunk}{$punc}";
     if ($onlyHrefs) {


### PR DESCRIPTION
---
- CRM-16108: Some URL's cannot be parsed
  https://issues.civicrm.org/jira/browse/CRM-16108
