### PR TITLE
Api explorer improvement and getfields description cleanup

### DIFF
--- a/api/v3/Address.php
+++ b/api/v3/Address.php
@@ -91,7 +91,10 @@ function civicrm_api3_address_create(&$params) {
 function _civicrm_api3_address_create_spec(&$params) {
   $params['location_type_id']['api.required'] = 1;
   $params['contact_id']['api.required'] = 1;
-  $params['street_parsing'] = array('title' => 'optional param to indicate you want the street_address field parsed into individual params');
+  $params['street_parsing'] = array(
+    'title' => 'Street Address Parsing',
+    'description' => 'Optional param to indicate you want the street_address field parsed into individual params',
+  );
   $params['world_region'] = array(
     'title' => ts('World Region'),
     'name' => 'world_region',

--- a/api/v3/CustomField.php
+++ b/api/v3/CustomField.php
@@ -81,7 +81,8 @@ function _civicrm_api3_custom_field_create_spec(&$params) {
   $params['custom_group_id']['api.required'] = 1;
   $params['is_active']['api.default'] = 1;
   $params['option_type'] = array(
-    'title' => 'This (boolean) field tells the BAO to create an option group for the field if the field type is appropriate',
+    'title' => 'Option Type',
+    'description' => 'This (boolean) field tells the BAO to create an option group for the field if the field type is appropriate',
     'api.default' => 1,
     'type' => CRM_Utils_Type::T_BOOLEAN,
   );

--- a/api/v3/Domain.php
+++ b/api/v3/Domain.php
@@ -117,7 +117,10 @@ function civicrm_api3_domain_get($params) {
  *   Array of parameters determined by getfields.
  */
 function _civicrm_api3_domain_get_spec(&$params) {
-  $params['current_domain'] = array('title' => "get loaded domain");
+  $params['current_domain'] = array(
+    'title' => "Current Domain",
+    'description' => "get loaded domain",
+  );
 }
 
 /**

--- a/api/v3/Generic.php
+++ b/api/v3/Generic.php
@@ -286,9 +286,10 @@ function civicrm_api3_generic_getvalue($apiRequest) {
  *
  * @param array $params
  */
-function _civicrm_api3_generic_getrefcount_spec(&$params) {
+function _civicrm_api3_generic_getrefcount_spec(&$params, $apiRequest) {
   $params['id']['api.required'] = 1;
-  $params['id']['title'] = 'Entity ID';
+  $params['id']['title'] = $apiRequest['entity'] . ' ID';
+  $params['id']['type'] = CRM_Utils_Type::T_INT;
 }
 
 /**

--- a/api/v3/Generic.php
+++ b/api/v3/Generic.php
@@ -80,7 +80,7 @@ function civicrm_api3_generic_getfields($apiRequest) {
   if (!$action || $action == 'getvalue' || $action == 'getcount') {
     $action = 'get';
   }
-  // determines whether to use unique field names - seem comment block above
+  // determines whether to use unique field names - see comment block above
   $unique = TRUE;
   if (empty($apiOptions) && isset($results[$entity . $subentity]) && isset($action, $results[$entity . $subentity])
     && isset($action, $results[$entity . $subentity][$sequential])) {
@@ -123,23 +123,30 @@ function civicrm_api3_generic_getfields($apiRequest) {
       $metadata = array(
         'id' => array(
           'title' => $entity . ' ID',
-          'name' => 'id',
           'api.required' => 1,
           'api.aliases' => array($lowercase_entity . '_id'),
           'type' => CRM_Utils_Type::T_INT,
         ));
       break;
 
-    case 'getoptions':
+    // Note: adding setvalue case here instead of in a generic spec function because
+    // some APIs override the generic setvalue fn which causes the generic spec to be overlooked.
+    case 'setvalue':
       $metadata = array(
         'field' => array(
-          'name' => 'field',
           'title' => 'Field name',
           'api.required' => 1,
+          'type' => CRM_Utils_Type::T_STRING,
         ),
-        'context' => array(
-          'name' => 'context',
-          'title' => 'Context',
+        'id' => array(
+          'title' => $entity . ' ID',
+          'api.required' => 1,
+          'type' => CRM_Utils_Type::T_INT,
+        ),
+        'value' => array(
+          'title' => 'Value',
+          'description' => "Field value to set",
+          'api.required' => 1,
         ),
       );
       break;
@@ -343,6 +350,28 @@ function civicrm_api3_generic_getoptions($apiRequest) {
     $options = CRM_Utils_Array::makeNonAssociative($options);
   }
   return civicrm_api3_create_success($options, $apiRequest['params'], $apiRequest['entity'], 'getoptions');
+}
+
+/**
+ * Provide metadata for this generic action
+ *
+ * @param $params
+ * @param $apiRequest
+ */
+function _civicrm_api3_generic_getoptions_spec(&$params, $apiRequest) {
+  $contexts = array_combine(array_keys(CRM_Core_DAO::buildOptionsContext()), array_keys(CRM_Core_DAO::buildOptionsContext()));
+  $params += array(
+    'field' => array(
+      'title' => 'Field name',
+      'api.required' => 1,
+      'type' => CRM_Utils_Type::T_STRING,
+    ),
+    'context' => array(
+      'title' => 'Context',
+      'options' => !empty($apiRequest['sequential']) ? CRM_Utils_Array::makeNonAssociative($contexts) : $contexts,
+      'type' => CRM_Utils_Type::T_STRING,
+    ),
+  );
 }
 
 /**

--- a/api/v3/Generic/Getlist.php
+++ b/api/v3/Generic/Getlist.php
@@ -184,3 +184,57 @@ function _civicrm_api3_generic_getlist_output($result, $request) {
   }
   return $output;
 }
+
+/**
+ * Provide metadata for this api
+ *
+ * @param array $params
+ * @param array $apiRequest
+ */
+function _civicrm_api3_generic_getlist_spec(&$params, $apiRequest) {
+  $params += array(
+    'page_num' => array(
+      'title' => 'Page Number',
+      'description' => "Current page of a multi-page lookup",
+      'type' => CRM_Utils_Type::T_INT,
+    ),
+    'input' => array(
+      'title' => 'Search Input',
+      'description' => "String to search on",
+      'type' => CRM_Utils_Type::T_TEXT,
+    ),
+    'params' => array(
+      'title' => 'API Params',
+      'description' => "Additional filters to send to the {$apiRequest['entity']} API.",
+    ),
+    'extra' => array(
+      'title' => 'Extra',
+      'description' => 'Array of additional fields to return.',
+    ),
+    'image_field' => array(
+      'title' => 'Image Field',
+      'description' => "Field that this entity uses to store icons (usually automatic)",
+      'type' => CRM_Utils_Type::T_TEXT,
+    ),
+    'id_field' => array(
+      'title' => 'ID Field',
+      'description' => "Field that uniquely identifies this entity (usually automatic)",
+      'type' => CRM_Utils_Type::T_TEXT,
+    ),
+    'description_field' => array(
+      'title' => 'Description Field',
+      'description' => "Field that this entity uses to store summary text (usually automatic)",
+      'type' => CRM_Utils_Type::T_TEXT,
+    ),
+    'label_field' => array(
+      'title' => 'Search Field',
+      'description' => "Field to display as title of results (usually automatic)",
+      'type' => CRM_Utils_Type::T_TEXT,
+    ),
+    'search_field' => array(
+      'title' => 'Search Field',
+      'description' => "Field to search on (assumed to be the same as label field unless otherwise specified)",
+      'type' => CRM_Utils_Type::T_TEXT,
+    ),
+  );
+}

--- a/api/v3/Generic/Setvalue.php
+++ b/api/v3/Generic/Setvalue.php
@@ -43,8 +43,6 @@
 function civicrm_api3_generic_setValue($apiRequest) {
   $entity = $apiRequest['entity'];
   $params = $apiRequest['params'];
-  // we can't use _spec, doesn't work with generic
-  civicrm_api3_verify_mandatory($params, NULL, array('id', 'field', 'value'));
   $id = $params['id'];
   if (!is_numeric($id)) {
     return civicrm_api3_create_error(ts('Please enter a number'), array(

--- a/api/v3/Job.php
+++ b/api/v3/Job.php
@@ -143,7 +143,10 @@ function _civicrm_api3_job_geocode_spec(&$params) {
   $params['end'] = array('title' => 'End Date');
   $params['geocoding'] = array('title' => 'Geocode address?');
   $params['parse'] = array('title' => 'Parse street address?');
-  $params['throttle'] = array('title' => 'Throttle? if enabled, geo-codes at a slow rate');
+  $params['throttle'] = array(
+    'title' => 'Throttle?',
+    'description' => 'if enabled, geo-codes at a slow rate',
+  );
 }
 
 /**

--- a/api/v3/Membership.php
+++ b/api/v3/Membership.php
@@ -150,10 +150,12 @@ function _civicrm_api3_membership_create_spec(&$params) {
   $params['membership_type_id']['api.aliases'] = array('membership_type');
   $params['status_id']['api.aliases'] = array('membership_status');
   $params['skipStatusCal'] = array(
-    'title' => 'Skip status calculation. By default this is 0 if id is not set and 1 if it is set.',
+    'title' => 'Skip status calculation',
+    'description' => 'By default this is 0 if id is not set and 1 if it is set.',
   );
   $params['num_terms'] = array(
-    'title' => 'Number of terms to add/renew. If this parameter is passed, dates will be calculated automatically. If no id is passed (new membership) and no dates are given, num_terms will be assumed to be 1.',
+    'title' => 'Number of terms',
+    'description' => 'Terms to add/renew. If this parameter is passed, dates will be calculated automatically. If no id is passed (new membership) and no dates are given, num_terms will be assumed to be 1.',
     'type' => CRM_Utils_Type::T_INT,
   );
 }
@@ -169,7 +171,8 @@ function _civicrm_api3_membership_create_spec(&$params) {
 function _civicrm_api3_membership_get_spec(&$params) {
   $params['membership_type_id']['api.aliases'] = array('membership_type');
   $params['active_only'] = array(
-    'title' => 'Only retrieve active memberships',
+    'title' => 'Active Only',
+    'description' => 'Only retrieve active memberships',
     'type' => CRM_Utils_Type::T_BOOLEAN,
   );
 }

--- a/api/v3/PledgePayment.php
+++ b/api/v3/PledgePayment.php
@@ -126,5 +126,9 @@ function civicrm_api3_pledge_payment_get($params) {
  *   Modifiable list of fields allowed for the PledgePayment.get action.
  */
 function civicrm_api3_pledge_payment_get_spec(&$params) {
-  $params['option.create_new'] = array('title' => "Create new field rather than update an unpaid payment");
+  $params['option.create_new'] = array(
+    'title' => "Create New",
+    'description' => "Create new field rather than update an unpaid payment",
+    'type' => CRM_Utils_Type::T_BOOLEAN,
+  );
 }

--- a/api/v3/Setting.php
+++ b/api/v3/Setting.php
@@ -80,9 +80,18 @@ function civicrm_api3_setting_getfields($params) {
  * @param array $params
  */
 function _civicrm_api3_setting_getfields_spec(&$params) {
-  $params['filters'] = array('title' => 'Fields you wish to filter by e.g. array("group_name" => "CiviCRM Preferences")');
-  $params['component_id'] = array('title' => 'id of relevant component');
-  $params['profile'] = array('title' => 'profile is passed through to hooks & added to cachestring');
+  $params['filters'] = array(
+    'title' => 'Filters',
+    'description' => 'Fields you wish to filter by e.g. array("group_name" => "CiviCRM Preferences")',
+  );
+  $params['component_id'] = array(
+    'title' => 'Component ID',
+    'description' => 'ID of relevant component',
+  );
+  $params['profile'] = array(
+    'title' => 'Profile',
+    'description' => 'Profile is passed through to hooks & added to cachestring',
+  );
 }
 
 /**
@@ -168,8 +177,14 @@ function civicrm_api3_setting_revert(&$params) {
  * @param array $params
  */
 function _civicrm_api3_setting_revert_spec(&$params) {
-  $params['name'] = array('title' => 'Setting Name belongs to');
-  $params['component_id'] = array('title' => 'id of relevant component');
+  $params['name'] = array(
+    'title' => 'Name',
+    'description' => 'Setting Name belongs to',
+  );
+  $params['component_id'] = array(
+    'title' => 'Component ID',
+    'description' => 'ID of relevant component',
+  );
   $params['domain_id'] = array(
     'api.default' => 'current_domain',
     'description' => 'Defaults may differ by domain - if you do not pass in a domain id this will default to the current domain'
@@ -211,8 +226,14 @@ function civicrm_api3_setting_fill(&$params) {
  * @param array $params
  */
 function _civicrm_api3_setting_fill_spec(&$params) {
-  $params['name'] = array('title' => 'Setting Name belongs to');
-  $params['component_id'] = array('title' => 'id of relevant component');
+  $params['name'] = array(
+    'title' => 'Name',
+    'description' => 'Setting Name belongs to',
+  );
+  $params['component_id'] = array(
+    'title' => 'Component ID',
+    'description' => 'ID of relevant component',
+  );
   $params['domain_id'] = array(
     'api.default' => 'current_domain',
     'title' => 'Setting Domain',

--- a/api/v3/System.php
+++ b/api/v3/System.php
@@ -60,8 +60,16 @@ function civicrm_api3_system_flush($params) {
  *   Array of parameters determined by getfields.
  */
 function _civicrm_api3_system_flush_spec(&$params) {
-  $params['triggers'] = array('title' => 'rebuild triggers (boolean)');
-  $params['session'] = array('title' => 'refresh sessions (boolean)');
+  $params['triggers'] = array(
+    'title' => 'Triggers',
+    'description' => 'rebuild triggers (boolean)',
+    'type' => CRM_Utils_Type::T_BOOLEAN,
+  );
+  $params['session'] = array(
+    'title' => 'Sessions',
+    'description' => 'refresh sessions (boolean)',
+    'type' => CRM_Utils_Type::T_BOOLEAN,
+  );
 }
 
 /**

--- a/api/v3/UFField.php
+++ b/api/v3/UFField.php
@@ -107,7 +107,8 @@ function civicrm_api3_uf_field_create($params) {
  */
 function _civicrm_api3_uf_field_create_spec(&$params) {
   $params['option.autoweight'] = array(
-    'title' => "Automatically adjust weights in UFGroup to align with UFField",
+    'title' => "Auto Weight",
+    'description' => "Automatically adjust weights in UFGroup to align with UFField",
     'type' => CRM_Utils_Type::T_BOOLEAN,
     'api.default' => TRUE,
   );

--- a/templates/CRM/Admin/Page/APIExplorer.js
+++ b/templates/CRM/Admin/Page/APIExplorer.js
@@ -23,6 +23,9 @@
     // Actions that don't support fancy operators
     NO_OPERATORS = ['create', 'update', 'delete', 'setvalue', 'getoptions', 'getactions', 'getfields'],
 
+    // Actions that don't support multiple values
+    NO_MULTI = ['delete', 'getoptions', 'getactions', 'getfields'],
+
     // Operators with special properties
     BOOL = ['IS NULL', 'IS NOT NULL'],
     TEXT = ['LIKE', 'NOT LIKE'],
@@ -266,7 +269,7 @@
    * @returns boolean
    */
   function isMultiSelect(fieldName, operator) {
-    if (isYesNo(fieldName)) {
+    if (isYesNo(fieldName) || _.includes(NO_MULTI, action)) {
       return false;
     }
     if (_.includes(MULTI, operator)) {

--- a/templates/CRM/Admin/Page/APIExplorer.js
+++ b/templates/CRM/Admin/Page/APIExplorer.js
@@ -243,6 +243,10 @@
     }
   }
 
+  function isYesNo(fieldName) {
+    return getFieldData[fieldName] && getFieldData[fieldName].type === 16;
+  }
+
   /**
    * Should we render a select or textfield?
    *
@@ -251,7 +255,7 @@
    * @returns boolean
    */
   function isSelect(fieldName, operator) {
-    return (options[fieldName] || (getFieldData[fieldName] && getFieldData[fieldName].FKApiName)) && !_.includes(TEXT, operator);
+    return (isYesNo(fieldName) || options[fieldName] || (getFieldData[fieldName] && getFieldData[fieldName].FKApiName)) && !_.includes(TEXT, operator);
   }
 
   /**
@@ -262,6 +266,9 @@
    * @returns boolean
    */
   function isMultiSelect(fieldName, operator) {
+    if (isYesNo(fieldName)) {
+      return false;
+    }
     if (_.includes(MULTI, operator)) {
       return true;
     }
@@ -309,8 +316,14 @@
       else if (!multiSelect && _.includes(currentVal, ',')) {
         $valField.val(currentVal.split(',')[0]);
       }
+      // Yes-No options
+      if (isYesNo(name)) {
+        $valField.select2({
+          data: [{id: 1, text: ts('Yes')}, {id: 0, text: ts('No')}]
+        });
+      }
       // Select options
-      if (options[name]) {
+      else if (options[name]) {
         $valField.select2({
           multiple: multiSelect,
           data: _.map(options[name], function (value, key) {

--- a/templates/CRM/Admin/Page/APIExplorer.js
+++ b/templates/CRM/Admin/Page/APIExplorer.js
@@ -24,7 +24,7 @@
     NO_OPERATORS = ['create', 'update', 'delete', 'setvalue', 'getoptions', 'getactions', 'getfields'],
 
     // Actions that don't support multiple values
-    NO_MULTI = ['delete', 'getoptions', 'getactions', 'getfields'],
+    NO_MULTI = ['delete', 'getoptions', 'getactions', 'getfields', 'setvalue'],
 
     // Operators with special properties
     BOOL = ['IS NULL', 'IS NOT NULL'],

--- a/templates/CRM/Admin/Page/APIExplorer.js
+++ b/templates/CRM/Admin/Page/APIExplorer.js
@@ -158,18 +158,34 @@
         CRM.alert(data.deprecated, entity + ' Deprecated');
       }
       showFields(required);
-      if (action === 'get' || action === 'getsingle' || action === 'getstat') {
-        showReturn(action === 'getstat' ? ts('Group by') : ts('Fields to return'));
+      if (action === 'get' || action === 'getsingle' || action == 'getvalue' || action === 'getstat') {
+        showReturn();
       }
     });
   }
 
   /**
    * For "get" actions show the "return" options
+   *
+   * TODO: Too many hard-coded actions here. Need a way to fetch this from metadata
    */
-  function showReturn(title) {
+  function showReturn() {
+    var title = ts('Fields to return'),
+      params = {
+        data: fields,
+        multiple: true,
+        placeholder: ts('Leave blank for default')
+      };
+    if (action == 'getstat') {
+      title = ts('Group by');
+    }
+    if (action == 'getvalue') {
+      title = ts('Return Value');
+      params.placeholder = ts('Select field');
+      params.multiple = false;
+    }
     $('#api-params').prepend($(returnTpl({title: title})));
-    $('#api-return-value').crmSelect2({data: fields, multiple: true});
+    $('#api-return-value').crmSelect2(params);
   }
 
   /**

--- a/templates/CRM/Admin/Page/APIExplorer.tpl
+++ b/templates/CRM/Admin/Page/APIExplorer.tpl
@@ -283,7 +283,7 @@
     <td colspan="3">
       <label for="api-return-value"><%- title %>:</label> &nbsp;
       <input type="hidden" class="api-param-name" value="return" />
-      <input style="width: 50%;" id="api-return-value" class="crm-form-text api-param-value api-input" placeholder="{ts}Leave blank for default{/ts}"/>
+      <input style="width: 50%;" id="api-return-value" class="crm-form-text api-param-value api-input"/>
     </td>
   </tr>
 </script>


### PR DESCRIPTION
This makes the api explorer a lot better at auto-discovering fields for the `getoptions`, `getvalue` and `setvalue` actions, among other improvements.
