### PR TITLE
CRM-16055 fixes from broken relationship form

### DIFF
--- a/CRM/Contact/BAO/Contact/Utils.php
+++ b/CRM/Contact/BAO/Contact/Utils.php
@@ -330,7 +330,7 @@ UNION
         'contact_check' => array($organization => TRUE),
       );
       list($valid, $invalid, $duplicate, $saved, $relationshipIds)
-        = CRM_Contact_BAO_Relationship::createMultiple($relationshipParams, $cid);
+        = CRM_Contact_BAO_Relationship::legacyCreateMultiple($relationshipParams, $cid);
 
       // In case we change employer, clean previous employer related records.
       if (!$previousEmployerID && !$newContact) {

--- a/CRM/Contact/BAO/Contact/Utils.php
+++ b/CRM/Contact/BAO/Contact/Utils.php
@@ -346,7 +346,7 @@ UNION
       self::setCurrentEmployer(array($contactID => $organization));
 
       $relationshipParams['relationship_ids'] = $relationshipIds;
-      // handle related meberships. CRM-3792
+      // Handle related memberships. CRM-3792
       self::currentEmployerRelatedMembership($contactID, $organization, $relationshipParams, $duplicate, $previousEmployerID);
     }
   }

--- a/CRM/Contact/BAO/GroupNesting.php
+++ b/CRM/Contact/BAO/GroupNesting.php
@@ -51,6 +51,9 @@ class CRM_Contact_BAO_GroupNesting extends CRM_Contact_DAO_GroupNesting implemen
 
   /**
    * Class constructor.
+   *
+   * @param bool $styleLabels
+   * @param string $styleIndent
    */
   public function __construct($styleLabels = FALSE, $styleIndent = "&nbsp;--&nbsp;") {
     parent::__construct();

--- a/CRM/Contact/BAO/ProximityQuery.php
+++ b/CRM/Contact/BAO/ProximityQuery.php
@@ -98,6 +98,7 @@ class CRM_Contact_BAO_ProximityQuery {
    * @param float $longitude
    * @param float $latitude
    * @param float $height
+   *
    * @return array
    */
   public static function earthXYZ($longitude, $latitude, $height = 0) {

--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -677,8 +677,9 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
    */
   public static function disableEnableRelationship($id, $action) {
     $relationship = self::clearCurrentEmployer($id, $action);
+
     if (CRM_Core_Permission::access('CiviMember')) {
-      // create $params array which isrequired to delete memberships
+      // create $params array which is required to delete memberships
       // of the related contacts.
       $params = array(
         'relationship_type_id' => "{$relationship->relationship_type_id}_a_b",
@@ -1463,7 +1464,7 @@ LEFT JOIN  civicrm_country ON (civicrm_address.country_id = civicrm_country.id)
         continue;
       }
 
-      $relatedContacts = CRM_Utils_Array::value('relatedContacts', $details, array());
+      $relatedContacts = array_keys(CRM_Utils_Array::value('relatedContacts', $details, array()));
       $mainRelatedContactId = reset($relatedContacts);
 
       foreach ($details['memberships'] as $membershipId => $membershipValues) {

--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -1324,7 +1324,7 @@ LEFT JOIN  civicrm_country ON (civicrm_address.country_id = civicrm_country.id)
    * @return array
    *   array reference of all relationship types with context to current contact type .
    */
-  public function getRelationType($targetContactType) {
+  static public function getRelationType($targetContactType) {
     $relationshipType = array();
     $allRelationshipType = CRM_Core_PseudoConstant::relationshipType();
 
@@ -1457,12 +1457,14 @@ LEFT JOIN  civicrm_country ON (civicrm_address.country_id = civicrm_country.id)
 
     // done with 'values' array.
     // Finally add / edit / delete memberships for the related contacts
+
     foreach ($values as $cid => $details) {
       if (!array_key_exists('memberships', $details)) {
         continue;
       }
 
-      $mainRelatedContactId = key(CRM_Utils_Array::value('relatedContacts', $details, array()));
+      $relatedContacts = CRM_Utils_Array::value('relatedContacts', $details, array());
+      $mainRelatedContactId = reset($relatedContacts);
 
       foreach ($details['memberships'] as $membershipId => $membershipValues) {
         $relTypeIds = array();

--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -805,14 +805,10 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
    */
   public static function checkValidRelationship($params, $ids, $contactId) {
     $errors = '';
-    $contactParams = self::setContactABFromIDs($params, $ids, $contactId);
-    $params = array_merge($params, $contactParams);
-    // get the string of relationship type
-    $relationshipTypes = CRM_Utils_Array::value('relationship_type_id', $params);
-    list($type) = explode('_', $relationshipTypes);
     // function to check if the relationship selected is correct
     // i.e. employer relationship can exit between Individual and Organization (not between Individual and Individual)
-    if (!CRM_Contact_BAO_Relationship::checkRelationshipType($params['contact_id_a'], $params['contact_id_b'], $type)) {
+    if (!CRM_Contact_BAO_Relationship::checkRelationshipType($params['contact_id_a'], $params['contact_id_b'],
+      $params['relationship_type_id'])) {
       $errors = 'Please select valid relationship between these two contacts.';
     }
     return $errors;

--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -26,11 +26,7 @@
  */
 
 /**
- *
- * @package CRM
- * @copyright CiviCRM LLC (c) 2004-2014
- * $Id$
- *
+ * Class CRM_Contact_BAO_Relationship.
  */
 class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
 
@@ -42,12 +38,16 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
   const ALL = 0, PAST = 1, DISABLED = 2, CURRENT = 4, INACTIVE = 8;
 
   /**
-   * Create function. (Use the API instead)
+   * Create function.
+   *
+   * (Use the API instead)
    * Note that the previous create function has been renamed 'legacyCreateMultiple'
    * and this is new in 4.6
    * All existing calls have been changed to legacyCreateMultiple except the api call - however, it is recommended
-   * that you call that as the end to end testing here is based on the api & refactoring may still be done
+   * that you call that as the end to end testing here is based on the api & refactoring may still be done.
+   *
    * @param array $params
+   *
    * @return \CRM_Contact_BAO_Relationship
    * @throws \CRM_Core_Exception
    */
@@ -78,7 +78,7 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
   }
 
   /**
-   * Create multiple relationships
+   * Create multiple relationships.
    *
    * @param $params
    * @param $primaryContactLetter
@@ -96,16 +96,16 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
         $params['contact_id_' . $secondaryContactLetter] = $secondaryContactID;
         $relationship = civicrm_api3('relationship', 'create', $params);
         $relationshipIds[] = $relationship['id'];
-        $valid ++;
+        $valid++;
       }
       catch (CiviCRM_API3_Exception $e) {
         switch ($e->getMessage()) {
-          case 'Duplicate Relationship' :
-            $duplicate ++;
+          case 'Duplicate Relationship':
+            $duplicate++;
             break;
 
-          case 'Invalid Relationship' :
-            $invalid ++;
+          case 'Invalid Relationship':
+            $invalid++;
             break;
 
           default:
@@ -183,7 +183,7 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
           continue;
         }
         $contactFields = self::setContactABFromIDs($params, $ids, $key);
-        $singleInstanceParams = array_merge($params,$contactFields);
+        $singleInstanceParams = array_merge($params, $contactFields);
         $relationship = self::add($singleInstanceParams);
         $relationshipIds[] = $relationship->id;
         $relationships[$relationship->id] = $relationship;
@@ -236,7 +236,7 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
   }
 
   /**
-   * This is the function that check/add if the relationship created is valid
+   * This is the function that check/add if the relationship created is valid.
    *
    * @param array $params
    *   (reference ) an assoc array of name/value pairs.
@@ -317,6 +317,7 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
 
   /**
    * Add relationship to recent links.
+   *
    * @param array $params
    * @param CRM_Contact_DAO_Relationship $relationship
    */
@@ -354,7 +355,7 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
   }
 
   /**
-   * Resolve passed in contact IDs to contact_id_a & contact_id_b
+   * Resolve passed in contact IDs to contact_id_a & contact_id_b.
    *
    * @param array $params
    * @param array $ids
@@ -365,8 +366,9 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
    */
   public static function setContactABFromIDs($params, $ids = array(), $contactID = NULL) {
     $returnFields = array();
-    if (!empty($params['contact_id_a']) && !empty($params['contact_id_b']) && is_numeric
-      ($params['relationship_type_id'])) {
+    if (!empty($params['contact_id_a'])
+      && !empty($params['contact_id_b'])
+      && is_numeric($params['relationship_type_id'])) {
       return $returnFields;
     }
     if (empty($ids['contact'])) {
@@ -463,11 +465,10 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
    *   Name/label that going to retrieve from db.
    * @param bool $biDirectional
    * @param string $contactSubType
-   *   Includes relationshiptypes between this subtype.
+   *   Includes relationship types between this subtype.
    * @param bool $onlySubTypeRelationTypes
-   *   If set only subtype which is passed by $contactSubType.
-   *                                          related relationshiptypes get return
-   *
+   *   If set only subtype which is passed by $contactSubType
+   *   related relationship types get return
    *
    * @return array
    *   array reference of all relationship types with context to current contact.
@@ -1331,10 +1332,11 @@ LEFT JOIN  civicrm_country ON (civicrm_address.country_id = civicrm_country.id)
    *   array of values submitted by POST.
    * @param array $ids
    *   array of ids.
-   * @param \const|\which $action which action called this function
+   * @param \const|int $action which action called this function
    *
    * @param bool $active
    *
+   * @throws \CRM_Core_Exception
    */
   public static function relatedMemberships($contactId, &$params, $ids, $action = CRM_Core_Action::ADD, $active = TRUE) {
     // Check the end date and set the status of the relationship
@@ -1691,6 +1693,7 @@ AND cc.sort_name LIKE '%$name%'";
 
   /**
    * Merge relationships from otherContact to mainContact.
+   *
    * Called during contact merge operation
    *
    * @param int $mainId

--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -593,8 +593,10 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
   }
 
   /**
+   * Delete current employer relationship.
+   *
    * @param int $id
-   * @param $action
+   * @param int $action
    *
    * @return CRM_Contact_DAO_Relationship
    */
@@ -604,7 +606,7 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
     $relationship->find(TRUE);
 
     //to delete relationship between household and individual                                                                                          \
-    //or between individual and orgnization
+    //or between individual and organization
     if (($action & CRM_Core_Action::DISABLE) || ($action & CRM_Core_Action::DELETE)) {
       $relTypes = CRM_Utils_Array::index(array('name_a_b'), CRM_Core_PseudoConstant::relationshipType('name'));
       if ($relationship->relationship_type_id == $relTypes['Employee of']['id'] ||
@@ -629,7 +631,6 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
    *   Relationship id.
    *
    * @return null
-   *
    */
   public static function del($id) {
     // delete from relationship table
@@ -671,13 +672,12 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
   }
 
   /**
-   * Disable/enable the relationship
+   * Disable/enable the relationship.
    *
    * @param int $id
    *   Relationship id.
    *
    * @param $action
-   *
    */
   public static function disableEnableRelationship($id, $action) {
     $relationship = self::clearCurrentEmployer($id, $action);
@@ -717,8 +717,6 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
    *
    * @param int $contactId
    *   Id of the contact to delete.
-   *
-   * @return void
    */
   public static function deleteContact($contactId) {
     $relationship = new CRM_Contact_DAO_Relationship();
@@ -936,8 +934,7 @@ WHERE  relationship_type_id = " . CRM_Utils_Type::escape($type, 'Integer');
   }
 
   /**
-   * Given the list of params in the params array, fetch the object
-   * and store the values in the values array
+   * Fetch a relationship object and store the values in the values array.
    *
    * @param array $params
    *   Input parameters to find object.
@@ -1587,9 +1584,7 @@ SELECT count(*)
   }
 
   /**
-   * Helper function to check whether to delete the membership or
-   * not.
-   *
+   * Helper function to check whether to delete the membership or not.
    */
   public static function isDeleteRelatedMembership($relTypeIds, $contactId, $mainRelatedContactId, $relTypeId, $relIds) {
     if (in_array($relTypeId, $relTypeIds)) {
@@ -1659,7 +1654,6 @@ WHERE id IN ( {$contacts} )
    * @param string $name
    *   employers sort name.
    *
-   *
    * @return array
    *   array of employers.
    */
@@ -1681,7 +1675,6 @@ WHERE id IN ( {$contacts} )
    * @param string $relTypeId
    *   one or more relationship type id's.
    * @param string $name
-   *
    *
    * @return array
    *   Array of contacts
@@ -1734,7 +1727,6 @@ AND cc.sort_name LIKE '%$name%'";
    *   (reference) array of sql statements to append to.
    *
    * @see CRM_Dedupe_Merger::cpTables()
-   *
    */
   public static function mergeRelationships($mainId, $otherId, &$sqls) {
     // Delete circular relationships
@@ -1787,6 +1779,7 @@ AND cc.sort_name LIKE '%$name%'";
 
   /**
    * Function filters the query by possible relationships for the membership type.
+   *
    * It is intended to be called when constructing queries for the api (reciprocal & non-reciprocal)
    * and to add clauses to limit the return to those relationships which COULD inherit a membership type
    * (as opposed to those who inherit a particular membership
@@ -1838,7 +1831,7 @@ AND cc.sort_name LIKE '%$name%'";
 
 
   /**
-   * wrapper for contact relationship selector.
+   * Wrapper for contact relationship selector.
    *
    * @param array $params
    *   Associated array for params record id.

--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -149,15 +149,15 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
     $valid = $invalid = $duplicate = $saved = 0;
     $relationships = $relationshipIds = array();
     $relationshipId = CRM_Utils_Array::value('relationship', $ids, CRM_Utils_Array::value('id', $params));
+    echo 'relationship id is ' . $relationshipId . "\n";
+
     //CRM-9015 - the hooks are called here & in add (since add doesn't call create)
     // but in future should be tidied per ticket
     if (empty($relationshipId)) {
       $hook = 'create';
-      $action = CRM_Core_Action::ADD;
     }
     else {
       $hook = 'edit';
-      $action = CRM_Core_Action::UPDATE;
     }
 
     CRM_Utils_Hook::pre($hook, 'Relationship', $relationshipId, $params);
@@ -269,9 +269,6 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
     //@todo hook are called from create and add - remove one
     CRM_Utils_Hook::pre($hook, 'Relationship', $relationshipId, $params);
 
-    // Requirement to set fields in this function is historical & hopefully can go at some point.
-    $contactFields = self::setContactABFromIDs($params, $ids);
-    $params = array_merge($params, $contactFields);
     $relationshipTypes = CRM_Utils_Array::value('relationship_type_id', $params);
 
     // explode the string with _ to get the relationship type id

--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -60,8 +60,12 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
     }
     $relationship = self::add($params);
     if (!empty($params['contact_id_a'])) {
-      $ids = array('contactTarget' => $relationship->contact_id_b, 'contact' => $params['contact_id_a']);
-      CRM_Contact_BAO_Relationship::relatedMemberships($params['contact_id_a'], $values, $ids, (empty($params['id']) ? CRM_Core_Action::ADD : CRM_Core_Action::UPDATE));
+      $ids = array(
+        'contactTarget' => $relationship->contact_id_b,
+        'contact' => $params['contact_id_a'],
+      );
+      CRM_Contact_BAO_Relationship::relatedMemberships($params['contact_id_a'], $params, $ids, (empty($params['id']) ?
+        CRM_Core_Action::ADD : CRM_Core_Action::UPDATE));
     }
 
     // Alter related membership if the is_active param is changed.
@@ -72,6 +76,7 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
       }
       CRM_Contact_BAO_Relationship::disableEnableRelationship($params['id'], $action);
     }
+
     self::addRecent($params, $relationship);
     return $relationship;
   }
@@ -1362,6 +1367,7 @@ LEFT JOIN  civicrm_country ON (civicrm_address.country_id = civicrm_country.id)
     // Check the end date and set the status of the relationship
     // accordingly.
     $status = self::CURRENT;
+    $targetContact = $targetContact = CRM_Utils_Array::value('contact_check', $params, array());
 
     if (!empty($params['end_date'])) {
       $endDate = CRM_Utils_Date::setDateDefaults(CRM_Utils_Date::format($params['end_date']), NULL, 'Ymd');
@@ -1391,13 +1397,13 @@ LEFT JOIN  civicrm_country ON (civicrm_address.country_id = civicrm_country.id)
       // this call is coming from somewhere where the direction was resolved early on (e.g an api call)
       // so we can assume _a_b
       $relDirection = "_a_b";
+      $targetContact = array($params['contact_id_b'] => 1);
     }
-    $targetContact = array();
+
     if (($action & CRM_Core_Action::ADD) ||
       ($action & CRM_Core_Action::DELETE)
     ) {
       $contact = $contactId;
-      $targetContact = CRM_Utils_Array::value('contact_check', $params);
     }
     elseif ($action & CRM_Core_Action::UPDATE) {
       $contact = $ids['contact'];

--- a/CRM/Contact/Form/Relationship.php
+++ b/CRM/Contact/Form/Relationship.php
@@ -478,13 +478,6 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
 
     $params['relationship_ids'] = $relationshipIds;
 
-    if ($this->_action & CRM_Core_Action::ADD && !empty($params['is_active'])) {
-      CRM_Contact_BAO_Relationship::relatedMemberships($this->_contactId,
-        $params, $ids,
-        $this->_action
-      );
-    }
-
     // Refresh contact tabs which might have been affected
     $this->ajaxResponse['updateTabs'] = array(
       '#tab_member' => CRM_Contact_BAO_Contact::getCountComponent('membership', $this->_contactId),

--- a/CRM/Contact/Form/Relationship.php
+++ b/CRM/Contact/Form/Relationship.php
@@ -404,8 +404,17 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
 
     // Update mode (always single)
     if ($this->_action & CRM_Core_Action::UPDATE) {
+      $params['id'] = $this->_relationshipId;
       $ids['relationship'] = $this->_relationshipId;
       $relation = CRM_Contact_BAO_Relationship::getRelationshipByID($this->_relationshipId);
+      if ($relation->contact_id_a == $this->_contactId) {
+        $params['contact_id_a'] = $this->_contactId;
+        $params['contact_id_b'] = array($params['related_contact_id']);
+      }
+      else {
+        $params['contact_id_b'] = $this->_contactId;
+        $params['contact_id_a'] = array($params['related_contact_id']);
+      }
       $ids['contactTarget'] = ($relation->contact_id_a == $this->_contactId) ? $relation->contact_id_b : $relation->contact_id_a;
 
       // @todo this belongs in the BAO.
@@ -436,7 +445,7 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
 
     // Save relationships
     $outcome = CRM_Contact_BAO_Relationship::createMultiple($params, $relationshipTypeParts[1]);
-    list($valid, $invalid, $duplicate, $saved, $relationshipIds) = $outcome;
+    $relationshipIds = $outcome['relationship_ids'];
     $this->setMessage($outcome);
 
     // if this is called from case view,

--- a/CRM/Contact/Form/Relationship.php
+++ b/CRM/Contact/Form/Relationship.php
@@ -201,8 +201,7 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
   }
 
   /**
-   * Set default values for the form. Relationship that in edit/view mode
-   * the default values are retrieved from the database
+   * Set default values for the form.
    */
   public function setDefaultValues() {
     if ($this->_cdType) {

--- a/CRM/Contact/Form/Relationship.php
+++ b/CRM/Contact/Form/Relationship.php
@@ -434,15 +434,6 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
       $params['contact_id_' .  $relationshipTypeParts[2]] = explode(',', $params['related_contact_id']);
     }
 
-    // @todo create multiple probably does this - test!
-    $customFields = CRM_Core_BAO_CustomField::getFields('Relationship', FALSE, FALSE, $params['relationship_type_id']);
-    $params['custom'] = CRM_Core_BAO_CustomField::postProcess(
-      $params,
-      $customFields,
-      $this->_relationshipId,
-      'Relationship'
-    );
-
     // Save the relationships.
     $outcome = CRM_Contact_BAO_Relationship::createMultiple($params, $relationshipTypeParts[1]);
     $relationshipIds = $outcome['relationship_ids'];

--- a/CRM/Contact/Form/Relationship.php
+++ b/CRM/Contact/Form/Relationship.php
@@ -26,16 +26,7 @@
  */
 
 /**
- *
- * @package CRM
- * @copyright CiviCRM LLC (c) 2004-2014
- * $Id$
- *
- */
-
-/**
- * This class generates form components for relationship
- *
+ * This class generates form components for relationship.
  */
 class CRM_Contact_Form_Relationship extends CRM_Core_Form {
 
@@ -212,9 +203,6 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
   /**
    * Set default values for the form. Relationship that in edit/view mode
    * the default values are retrieved from the database
-   *
-   *
-   * @return void
    */
   public function setDefaultValues() {
     if ($this->_cdType) {
@@ -275,9 +263,7 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
   }
 
   /**
-   * add the rules for form.
-   *
-   * @return void
+   * Add the rules for form.
    */
   public function addRules() {
     if ($this->_cdType) {
@@ -399,13 +385,10 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
   }
 
   /**
-   *  This function is called when the form is submitted.
-   *
-   *
-   * @return void
+   * This function is called when the form is submitted.
    */
   public function postProcess() {
-    // store the submitted values in an array
+    // Store the submitted values in an array.
     $params = $this->controller->exportValues($this->_name);
 
     // action is taken depending upon the mode
@@ -442,7 +425,7 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
     }
     // Create mode (could be 1 or more relationships)
     else {
-      $params['contact_id_' .  $relationshipTypeParts[2]] =  explode(',', $params['related_contact_id']);
+      $params['contact_id_' .  $relationshipTypeParts[2]] = explode(',', $params['related_contact_id']);
     }
 
     // @todo create multiple probably does this - test!
@@ -455,8 +438,7 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
     );
 
     // Save relationships
-    list($valid, $invalid, $duplicate, $saved, $relationshipIds) = CRM_Contact_BAO_Relationship::createMultiple
-    ($params, $relationshipTypeParts[1]);
+    list($valid, $invalid, $duplicate, $saved, $relationshipIds) = CRM_Contact_BAO_Relationship::createMultiple ($params, $relationshipTypeParts[1]);
     $this->setMessage($valid, $invalid, $duplicate, $saved);
 
     // if this is called from case view,
@@ -465,7 +447,6 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
     if ($this->_caseId) {
       CRM_Case_BAO_Case::createCaseRoleActivity($this->_caseId, $relationshipIds, $params['contact_check'], $this->_contactId);
     }
-
 
     // Save notes
     // @todo this belongs in the BAO.

--- a/CRM/Contact/Form/Relationship.php
+++ b/CRM/Contact/Form/Relationship.php
@@ -484,14 +484,7 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
         $this->_action
       );
     }
-    elseif ($this->_action & CRM_Core_Action::UPDATE) {
-      //fixes for CRM-7985
-      //only if the relationship has been toggled to enable /disable
-      if (CRM_Utils_Array::value('is_active', $params) != $this->_enabled) {
-        $active = !empty($params['is_active']) ? CRM_Core_Action::ENABLE : CRM_Core_Action::DISABLE;
-        CRM_Contact_BAO_Relationship::disableEnableRelationship($this->_relationshipId, $active);
-      }
-    }
+
     // Refresh contact tabs which might have been affected
     $this->ajaxResponse['updateTabs'] = array(
       '#tab_member' => CRM_Contact_BAO_Contact::getCountComponent('membership', $this->_contactId),

--- a/CRM/Contact/Form/Relationship.php
+++ b/CRM/Contact/Form/Relationship.php
@@ -277,8 +277,6 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
 
   /**
    * Build the form object.
-   *
-   * @return void
    */
   public function buildQuickForm() {
     if ($this->_cdType) {
@@ -438,8 +436,9 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
     );
 
     // Save relationships
-    list($valid, $invalid, $duplicate, $saved, $relationshipIds) = CRM_Contact_BAO_Relationship::createMultiple ($params, $relationshipTypeParts[1]);
-    $this->setMessage($valid, $invalid, $duplicate, $saved);
+    $outcome = CRM_Contact_BAO_Relationship::createMultiple($params, $relationshipTypeParts[1]);
+    list($valid, $invalid, $duplicate, $saved, $relationshipIds) = $outcome;
+    $this->setMessage($outcome);
 
     // if this is called from case view,
     //create an activity for case role removal.CRM-4480
@@ -537,37 +536,39 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
   /**
    * Set Status message to reflect outcome of the update action.
    *
-   * @param int $valid Number of valid relationships attempted.
-   * @param int $invalid Number of invalid relationships attempted.
-   * @param int $duplicate Number of duplicate relationships attempted.
-   * @param int $saved Number of relationships saved.
+   * @param array $outcome
+   *   Outcome of save action - including
+   *   - 'valid' : Number of valid relationships attempted.
+   *   - 'invalid' : Number of invalid relationships attempted.
+   *   - 'duplicate' : Number of duplicate relationships attempted.
+   *   - 'saved' : boolean of whether save was successful
    */
-  protected function setMessage($valid, $invalid, $duplicate, $saved) {
-    if ($valid) {
+  protected function setMessage($outcome) {
+    if (!empty($outcome['valid'])) {
       CRM_Core_Session::setStatus(ts('Relationship created.', array(
-        'count' => $valid,
+        'count' => $outcome['valid'],
         'plural' => '%count relationships created.',
       )), ts('Saved'), 'success');
     }
-    if ($invalid) {
+    if (!empty($outcome['invalid'])) {
       CRM_Core_Session::setStatus(ts('%count relationship record was not created due to an invalid contact type.', array(
-        'count' => $invalid,
+        'count' => $outcome['invalid'],
         'plural' => '%count relationship records were not created due to invalid contact types.',
       )), ts('%count invalid relationship record', array(
-        'count' => $invalid,
+        'count' => $outcome['invalid'],
         'plural' => '%count invalid relationship records',
       )));
     }
-    if ($duplicate) {
+    if (!empty($outcome['duplicate'])) {
       CRM_Core_Session::setStatus(ts('One relationship was not created because it already exists.', array(
-        'count' => $duplicate,
+        'count' => $outcome['duplicate'],
         'plural' => '%count relationships were not created because they already exist.',
       )), ts('%count duplicate relationship', array(
-        'count' => $duplicate,
+        'count' => $outcome['duplicate'],
         'plural' => '%count duplicate relationships',
       )));
     }
-    if ($saved) {
+    if (!empty($outcome['saved'])) {
       CRM_Core_Session::setStatus(ts('Relationship record has been updated.'), ts('Saved'), 'success');
     }
   }

--- a/CRM/Contact/Form/Relationship.php
+++ b/CRM/Contact/Form/Relationship.php
@@ -443,7 +443,7 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
       'Relationship'
     );
 
-    // Save relationships
+    // Save the relationships.
     $outcome = CRM_Contact_BAO_Relationship::createMultiple($params, $relationshipTypeParts[1]);
     $relationshipIds = $outcome['relationship_ids'];
     $this->setMessage($outcome);
@@ -476,31 +476,28 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
       }
     }
 
-    // Membership for related contacts CRM-1657
-    // @todo this belongs in the BAO.
-    // DOES THIS REALLY MEAN MEMBERSHIPS ARE NOT CREATED IF LOGGED IN USER DOESN'T HAVE PERMISSION!!
-    if (CRM_Core_Permission::access('CiviMember') && (!$duplicate)) {
-      $params['relationship_ids'] = $relationshipIds;
-      if ($this->_action & CRM_Core_Action::ADD && !empty($params['is_active'])) {
-        CRM_Contact_BAO_Relationship::relatedMemberships($this->_contactId,
-          $params, $ids,
-          $this->_action
-        );
-      }
-      elseif ($this->_action & CRM_Core_Action::UPDATE) {
-        //fixes for CRM-7985
-        //only if the relationship has been toggled to enable /disable
-        if (CRM_Utils_Array::value('is_active', $params) != $this->_enabled) {
-          $active = !empty($params['is_active']) ? CRM_Core_Action::ENABLE : CRM_Core_Action::DISABLE;
-          CRM_Contact_BAO_Relationship::disableEnableRelationship($this->_relationshipId, $active);
-        }
-      }
-      // Refresh contact tabs which might have been affected
-      $this->ajaxResponse['updateTabs'] = array(
-        '#tab_member' => CRM_Contact_BAO_Contact::getCountComponent('membership', $this->_contactId),
-        '#tab_contribute' => CRM_Contact_BAO_Contact::getCountComponent('contribution', $this->_contactId),
+    $params['relationship_ids'] = $relationshipIds;
+
+    if ($this->_action & CRM_Core_Action::ADD && !empty($params['is_active'])) {
+      CRM_Contact_BAO_Relationship::relatedMemberships($this->_contactId,
+        $params, $ids,
+        $this->_action
       );
     }
+    elseif ($this->_action & CRM_Core_Action::UPDATE) {
+      //fixes for CRM-7985
+      //only if the relationship has been toggled to enable /disable
+      if (CRM_Utils_Array::value('is_active', $params) != $this->_enabled) {
+        $active = !empty($params['is_active']) ? CRM_Core_Action::ENABLE : CRM_Core_Action::DISABLE;
+        CRM_Contact_BAO_Relationship::disableEnableRelationship($this->_relationshipId, $active);
+      }
+    }
+    // Refresh contact tabs which might have been affected
+    $this->ajaxResponse['updateTabs'] = array(
+      '#tab_member' => CRM_Contact_BAO_Contact::getCountComponent('membership', $this->_contactId),
+      '#tab_contribute' => CRM_Contact_BAO_Contact::getCountComponent('contribution', $this->_contactId),
+    );
+
     // Set current employee/employer relationship, CRM-3532
     if ($params['is_current_employer'] && $this->_allRelationshipNames[$params['relationship_type_id']]["name_a_b"] ==
     'Employee of') {

--- a/CRM/Contact/Form/Task/AddToHousehold.php
+++ b/CRM/Contact/Form/Task/AddToHousehold.php
@@ -26,34 +26,12 @@
  */
 
 /**
- *
- * @package CRM
- * @copyright CiviCRM LLC (c) 2004-2014
- * $Id$
- *
+ * This class provides the functionality to add contact(s) to Household.
  */
-
-/**
- * This class provides the functionality to add contact(s) to Household
- */
-class CRM_Contact_Form_Task_AddToHousehold extends CRM_Contact_Form_Task {
+class CRM_Contact_Form_Task_AddToHousehold extends CRM_Contact_Form_Task_AddToParentClass {
 
   /**
    * Build the form object.
-   *
-   *
-   * @return void
-   */
-  public function preProcess() {
-    // initialize the task and row fields
-    parent::preProcess();
-  }
-
-  /**
-   * Build the form object.
-   *
-   *
-   * @return void
    */
   public function buildQuickForm() {
 
@@ -71,16 +49,16 @@ class CRM_Contact_Form_Task_AddToHousehold extends CRM_Contact_Form_Task {
     $searchCount = $this->get('searchCount');
     if ($searchRows) {
       $checkBoxes = array();
-      $chekFlag = 0;
+      $checkFlag = 0;
       foreach ($searchRows as $id => $row) {
-        if (!$chekFlag) {
-          $chekFlag = $id;
+        if (!$checkFlag) {
+          $checkFlag = $id;
         }
         $checkBoxes[$id] = $this->createElement('radio', NULL, NULL, NULL, $id);
       }
       $this->addGroup($checkBoxes, 'contact_check');
-      if ($chekFlag) {
-        $checkBoxes[$chekFlag]->setChecked(TRUE);
+      if ($checkFlag) {
+        $checkBoxes[$checkFlag]->setChecked(TRUE);
       }
       $this->assign('searchRows', $searchRows);
     }
@@ -107,196 +85,22 @@ class CRM_Contact_Form_Task_AddToHousehold extends CRM_Contact_Form_Task {
 
   /**
    * Process the form after the input has been submitted and validated.
-   *
-   *
-   * @return void
    */
   public function postProcess() {
 
     // store the submitted values in an array
-    $params = $this->controller->exportValues($this->_name);
+    $this->params = $this->controller->exportValues($this->_name);
 
     $this->set('searchDone', 0);
     if (!empty($_POST['_qf_AddToHousehold_refresh'])) {
       $searchParams['contact_type'] = array('Household' => 'Household');
-      $searchParams['rel_contact'] = $params['name'];
-      self::search($this, $searchParams);
+      $searchParams['rel_contact'] = $this->params['name'];
+      $this->search($this, $searchParams);
       $this->set('searchDone', 1);
       return;
     }
 
-    $data = array();
-    //$params['relationship_type_id']='4_a_b';
-    $data['relationship_type_id'] = $params['relationship_type_id'];
-    $data['is_active'] = 1;
-    $invalid = $valid = $duplicate = 0;
-    if (is_array($this->_contactIds)) {
-      foreach ($this->_contactIds as $value) {
-        $ids = array();
-        $ids['contact'] = $value;
-        //contact b --> household
-        // contact a  -> individual
-        $errors = CRM_Contact_BAO_Relationship::checkValidRelationship($params, $ids, $params['contact_check']);
-        if ($errors) {
-          $invalid++;
-          continue;
-        }
-
-        if (CRM_Contact_BAO_Relationship::checkDuplicateRelationship($params,
-          CRM_Utils_Array::value('contact', $ids),
-          // step 2
-          $params['contact_check']
-        )
-        ) {
-          $duplicate++;
-          continue;
-        }
-        CRM_Contact_BAO_Relationship::add($data, $ids, $params['contact_check']);
-        $valid++;
-      }
-
-      $house = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $params['contact_check'], 'display_name');
-      list($rtype, $a_b) = explode('_', $data['relationship_type_id'], 2);
-      $relationship = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_RelationshipType', $rtype, "label_$a_b");
-
-      $status = array(
-        ts('%count %2 %3 relationship created', array(
-            'count' => $valid,
-            'plural' => '%count %2 %3 relationships created',
-            2 => $relationship,
-            3 => $house,
-        )),
-      );
-      if ($duplicate) {
-        $status[] = ts('%count was skipped because the contact is already %2 %3', array(
-            'count' => $duplicate,
-            'plural' => '%count were skipped because the contacts are already %2 %3',
-            2 => $relationship,
-            3 => $house,
-          ));
-      }
-      if ($invalid) {
-        $status[] = ts('%count relationship was not created because the contact is not of the right type for this relationship', array(
-            'count' => $invalid,
-            'plural' => '%count relationships were not created because the contact is not of the right type for this relationship',
-          ));
-      }
-      $status = '<ul><li>' . implode('</li><li>', $status) . '</li></ul>';
-      CRM_Core_Session::setStatus($status, ts('Relationship created.', array(
-            'count' => $valid,
-            'plural' => 'Relationships created.',
-          )), 'success', array('expires' => 0));
-    }
-  }
-
-  /**
-   * get the result of the search for Add to * forms
-   *
-   * @param CRM_Core_Form $form
-   * @param array $params
-   *   This contains elements for search criteria.
-   *
-   *
-   * @return void
-   */
-  public function search(&$form, &$params) {
-    //max records that will be listed
-    $searchValues = array();
-    if (!empty($params['rel_contact'])) {
-      if (isset($params['rel_contact_id']) &&
-        is_numeric($params['rel_contact_id'])
-      ) {
-        $searchValues[] = array('contact_id', '=', $params['rel_contact_id'], 0, 1);
-      }
-      else {
-        $searchValues[] = array('sort_name', 'LIKE', $params['rel_contact'], 0, 1);
-      }
-    }
-    $contactTypeAdded = FALSE;
-
-    $excludedContactIds = array();
-    if (isset($form->_contactId)) {
-      $excludedContactIds[] = $form->_contactId;
-    }
-
-    if (!empty($params['relationship_type_id'])) {
-      $relationshipType = new CRM_Contact_DAO_RelationshipType();
-      list($rid, $direction) = explode('_', $params['relationship_type_id'], 2);
-
-      $relationshipType->id = $rid;
-      if ($relationshipType->find(TRUE)) {
-        if ($direction == 'a_b') {
-          $type = $relationshipType->contact_type_b;
-          $subType = $relationshipType->contact_sub_type_b;
-        }
-        else {
-          $type = $relationshipType->contact_type_a;
-          $subType = $relationshipType->contact_sub_type_a;
-        }
-
-        $form->set('contact_type', $type);
-        $form->set('contact_sub_type', $subType);
-        if ($type == 'Individual' || $type == 'Organization' || $type == 'Household') {
-          $searchValues[] = array('contact_type', '=', $type, 0, 0);
-          $contactTypeAdded = TRUE;
-        }
-
-        if ($subType) {
-          $searchValues[] = array('contact_sub_type', '=', $subType, 0, 0);
-        }
-      }
-    }
-
-    if (!$contactTypeAdded && !empty($params['contact_type'])) {
-      $searchValues[] = array('contact_type', '=', $params['contact_type'], 0, 0);
-    }
-
-    // get the count of contact
-    $contactBAO = new CRM_Contact_BAO_Contact();
-    $query = new CRM_Contact_BAO_Query($searchValues);
-    $searchCount = $query->searchQuery(0, 0, NULL, TRUE);
-    $form->set('searchCount', $searchCount);
-    if ($searchCount <= 50) {
-      // get the result of the search
-      $result = $query->searchQuery(0, 50, NULL);
-
-      $config = CRM_Core_Config::singleton();
-      $searchRows = array();
-
-      //variable is set if only one record is foun and that record already has relationship with the contact
-      $duplicateRelationship = 0;
-
-      while ($result->fetch()) {
-        $query->convertToPseudoNames($result);
-        $contactID = $result->contact_id;
-        if (in_array($contactID, $excludedContactIds)) {
-          $duplicateRelationship++;
-          continue;
-        }
-
-        $duplicateRelationship = 0;
-
-        $searchRows[$contactID]['id'] = $contactID;
-        $searchRows[$contactID]['name'] = $result->sort_name;
-        $searchRows[$contactID]['city'] = $result->city;
-        $searchRows[$contactID]['state'] = $result->state_province;
-        $searchRows[$contactID]['email'] = $result->email;
-        $searchRows[$contactID]['phone'] = $result->phone;
-
-        $contact_type = '<img src="' . $config->resourceBase . 'i/contact_';
-
-        $searchRows[$contactID]['type'] = CRM_Contact_BAO_Contact_Utils::getImage($result->contact_sub_type ? $result->contact_sub_type : $result->contact_type
-        );
-      }
-
-      $form->set('searchRows', $searchRows);
-      $form->set('duplicateRelationship', $duplicateRelationship);
-    }
-    else {
-      // resetting the session variables if many records are found
-      $form->set('searchRows', NULL);
-      $form->set('duplicateRelationship', NULL);
-    }
+    $this->addRelationships();
   }
 
 }

--- a/CRM/Contact/Form/Task/AddToOrganization.php
+++ b/CRM/Contact/Form/Task/AddToOrganization.php
@@ -36,24 +36,10 @@
 /**
  * This class provides the functionality to add contact(s) to Organization
  */
-class CRM_Contact_Form_Task_AddToOrganization extends CRM_Contact_Form_Task {
+class CRM_Contact_Form_Task_AddToOrganization extends CRM_Contact_Form_Task_AddToParentClass {
 
   /**
    * Build the form object.
-   *
-   *
-   * @return void
-   */
-  public function preProcess() {
-    // initialize the task and row fields
-    parent::preProcess();
-  }
-
-  /**
-   * Build the form object.
-   *
-   *
-   * @return void
    */
   public function buildQuickForm() {
     CRM_Utils_System::setTitle(ts('Add Contacts to Organization'));
@@ -110,83 +96,21 @@ class CRM_Contact_Form_Task_AddToOrganization extends CRM_Contact_Form_Task {
 
   /**
    * Process the form after the input has been submitted and validated.
-   *
-   *
-   * @return void
    */
   public function postProcess() {
     // store the submitted values in an array
-    $params = $this->controller->exportValues($this->_name);
+    $this->params = $this->controller->exportValues($this->_name);
 
     $this->set('searchDone', 0);
     if (!empty($_POST['_qf_AddToOrganization_refresh'])) {
       $searchParams['contact_type'] = array('Organization' => 'Organization');
-      $searchParams['rel_contact'] = $params['name'];
-      CRM_Contact_Form_Task_AddToHousehold::search($this, $searchParams);
+      $searchParams['rel_contact'] = $this->params['name'];
+      $this->search($this, $searchParams);
       $this->set('searchDone', 1);
       return;
     }
 
-    $data = array();
-    $data['relationship_type_id'] = $params['relationship_type_id'];
-    $data['is_active'] = 1;
-    $invalid = 0;
-    $valid = 0;
-    $duplicate = 0;
-    if (is_array($this->_contactIds)) {
-      foreach ($this->_contactIds as $value) {
-        $ids = array();
-        $ids['contact'] = $value;
-        $errors = CRM_Contact_BAO_Relationship::checkValidRelationship($params, $ids, $params['contact_check']);
-        if ($errors) {
-          $invalid++;
-          continue;
-        }
-
-        if (CRM_Contact_BAO_Relationship::checkDuplicateRelationship($params,
-          CRM_Utils_Array::value('contact', $ids),
-          // step 2
-          $params['contact_check']
-        )
-        ) {
-          $duplicate++;
-          continue;
-        }
-        CRM_Contact_BAO_Relationship::add($data, $ids, $params['contact_check']);
-        $valid++;
-      }
-      $org = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $params['contact_check'], 'display_name');
-      list($rtype, $a_b) = explode('_', $data['relationship_type_id'], 2);
-      $relationship = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_RelationshipType', $rtype, "label_$a_b");
-
-      $status = array(
-        ts('%count %2 %3 relationship created', array(
-            'count' => $valid,
-            'plural' => '%count %2 %3 relationships created',
-            2 => $relationship,
-            3 => $org,
-          )),
-      );
-      if ($duplicate) {
-        $status[] = ts('%count was skipped because the contact is already %2 %3', array(
-            'count' => $duplicate,
-            'plural' => '%count were skipped because the contacts are already %2 %3',
-            2 => $relationship,
-            3 => $org,
-          ));
-      }
-      if ($invalid) {
-        $status[] = ts('%count relationship was not created because the contact is not of the right type for this relationship', array(
-            'count' => $invalid,
-            'plural' => '%count relationships were not created because the contact is not of the right type for this relationship',
-          ));
-      }
-      $status = '<ul><li>' . implode('</li><li>', $status) . '</li></ul>';
-      CRM_Core_Session::setStatus($status, ts('Relationship created.', array(
-            'count' => $valid,
-            'plural' => 'Relationships created.',
-          )), 'success', array('expires' => 0));
-    }
+    $this->addRelationships();
   }
 
 }

--- a/CRM/Contact/Form/Task/AddToParentClass.php
+++ b/CRM/Contact/Form/Task/AddToParentClass.php
@@ -1,0 +1,216 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.6                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2014                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * This class provides the shared functionality for addToHousehold and addToOrganization.
+ */
+class CRM_Contact_Form_Task_AddToParentClass extends CRM_Contact_Form_Task {
+
+  /**
+   * Exported parameters from the form.
+   *
+   * @var array.
+   */
+  protected $params;
+
+  /**
+   * Build the form object.
+   */
+  public function preProcess() {
+    parent::preProcess();
+  }
+
+  /**
+   * Add relationships from form.
+   */
+  public function addRelationships() {
+
+    if (!is_array($this->_contactIds)) {
+      // Could this really happen?
+      return;
+    }
+    $relationshipTypeParts = explode('_', $this->params['relationship_type_id']);
+    $params = array(
+      'relationship_type_id' => $relationshipTypeParts[0],
+      'is_active' => 1,
+    );
+    $secondaryRelationshipSide = $relationshipTypeParts[1];
+    $primaryRelationshipSide = $relationshipTypeParts[2];
+    $primaryFieldName = 'contact_id_' . $primaryRelationshipSide;
+    $secondaryFieldName = 'contact_id_' . $secondaryRelationshipSide;
+
+
+    $relationshipLabel = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_RelationshipType',
+      $params['relationship_type_id'], "label_{$secondaryRelationshipSide}_{$primaryRelationshipSide}");
+
+
+    $params[$secondaryFieldName] = $this->_contactIds;
+    $params[$primaryFieldName] = $this->params['contact_check'];
+    $outcome = CRM_Contact_BAO_Relationship::createMultiple($params, $primaryRelationshipSide);
+
+    $relatedContactName = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $params[$primaryFieldName],
+      'display_name');
+
+    $status = array(
+      ts('%count %2 %3 relationship created', array(
+        'count' => $outcome['valid'],
+        'plural' => '%count %2 %3 relationships created',
+        2 => $relationshipLabel,
+        3 => $relatedContactName,
+      )),
+    );
+    if ($outcome['duplicate']) {
+      $status[] = ts('%count was skipped because the contact is already %2 %3', array(
+        'count' => $outcome['duplicate'],
+        'plural' => '%count were skipped because the contacts are already %2 %3',
+        2 => $relationshipLabel,
+        3 => $relatedContactName,
+      ));
+    }
+    if ($outcome['invalid']) {
+      $status[] = ts('%count relationship was not created because the contact is not of the right type for this relationship', array(
+        'count' => $outcome['invalid'],
+        'plural' => '%count relationships were not created because the contact is not of the right type for this relationship',
+      ));
+    }
+    $status = '<ul><li>' . implode('</li><li>', $status) . '</li></ul>';
+    CRM_Core_Session::setStatus($status, ts('Relationship created.', array(
+      'count' => $outcome['valid'],
+      'plural' => 'Relationships created.',
+    )), 'success', array('expires' => 0));
+
+
+  }
+
+  /**
+   * Get the result of the search for Add to * forms.
+   *
+   * @param CRM_Core_Form $form
+   * @param array $params
+   *   This contains elements for search criteria.
+   */
+  public function search(&$form, &$params) {
+    //max records that will be listed
+    $searchValues = array();
+    if (!empty($params['rel_contact'])) {
+      if (isset($params['rel_contact_id']) &&
+        is_numeric($params['rel_contact_id'])
+      ) {
+        $searchValues[] = array('contact_id', '=', $params['rel_contact_id'], 0, 1);
+      }
+      else {
+        $searchValues[] = array('sort_name', 'LIKE', $params['rel_contact'], 0, 1);
+      }
+    }
+    $contactTypeAdded = FALSE;
+
+    $excludedContactIds = array();
+    if (isset($form->_contactId)) {
+      $excludedContactIds[] = $form->_contactId;
+    }
+
+    if (!empty($params['relationship_type_id'])) {
+      $relationshipType = new CRM_Contact_DAO_RelationshipType();
+      list($rid, $direction) = explode('_', $params['relationship_type_id'], 2);
+
+      $relationshipType->id = $rid;
+      if ($relationshipType->find(TRUE)) {
+        if ($direction == 'a_b') {
+          $type = $relationshipType->contact_type_b;
+          $subType = $relationshipType->contact_sub_type_b;
+        }
+        else {
+          $type = $relationshipType->contact_type_a;
+          $subType = $relationshipType->contact_sub_type_a;
+        }
+
+        $form->set('contact_type', $type);
+        $form->set('contact_sub_type', $subType);
+        if ($type == 'Individual' || $type == 'Organization' || $type == 'Household') {
+          $searchValues[] = array('contact_type', '=', $type, 0, 0);
+          $contactTypeAdded = TRUE;
+        }
+
+        if ($subType) {
+          $searchValues[] = array('contact_sub_type', '=', $subType, 0, 0);
+        }
+      }
+    }
+
+    if (!$contactTypeAdded && !empty($params['contact_type'])) {
+      $searchValues[] = array('contact_type', '=', $params['contact_type'], 0, 0);
+    }
+
+    // get the count of contact
+    $contactBAO = new CRM_Contact_BAO_Contact();
+    $query = new CRM_Contact_BAO_Query($searchValues);
+    $searchCount = $query->searchQuery(0, 0, NULL, TRUE);
+    $form->set('searchCount', $searchCount);
+    if ($searchCount <= 50) {
+      // get the result of the search
+      $result = $query->searchQuery(0, 50, NULL);
+
+      $config = CRM_Core_Config::singleton();
+      $searchRows = array();
+
+      //variable is set if only one record is foun and that record already has relationship with the contact
+      $duplicateRelationship = 0;
+
+      while ($result->fetch()) {
+        $query->convertToPseudoNames($result);
+        $contactID = $result->contact_id;
+        if (in_array($contactID, $excludedContactIds)) {
+          $duplicateRelationship++;
+          continue;
+        }
+
+        $duplicateRelationship = 0;
+
+        $searchRows[$contactID]['id'] = $contactID;
+        $searchRows[$contactID]['name'] = $result->sort_name;
+        $searchRows[$contactID]['city'] = $result->city;
+        $searchRows[$contactID]['state'] = $result->state_province;
+        $searchRows[$contactID]['email'] = $result->email;
+        $searchRows[$contactID]['phone'] = $result->phone;
+
+        $contact_type = '<img src="' . $config->resourceBase . 'i/contact_';
+
+        $searchRows[$contactID]['type'] = CRM_Contact_BAO_Contact_Utils::getImage($result->contact_sub_type ? $result->contact_sub_type : $result->contact_type
+        );
+      }
+
+      $form->set('searchRows', $searchRows);
+      $form->set('duplicateRelationship', $duplicateRelationship);
+    }
+    else {
+      // resetting the session variables if many records are found
+      $form->set('searchRows', NULL);
+      $form->set('duplicateRelationship', NULL);
+    }
+  }
+
+}

--- a/CRM/Contact/Form/Task/AddToParentClass.php
+++ b/CRM/Contact/Form/Task/AddToParentClass.php
@@ -63,10 +63,8 @@ class CRM_Contact_Form_Task_AddToParentClass extends CRM_Contact_Form_Task {
     $primaryFieldName = 'contact_id_' . $primaryRelationshipSide;
     $secondaryFieldName = 'contact_id_' . $secondaryRelationshipSide;
 
-
     $relationshipLabel = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_RelationshipType',
       $params['relationship_type_id'], "label_{$secondaryRelationshipSide}_{$primaryRelationshipSide}");
-
 
     $params[$secondaryFieldName] = $this->_contactIds;
     $params[$primaryFieldName] = $this->params['contact_check'];
@@ -102,7 +100,6 @@ class CRM_Contact_Form_Task_AddToParentClass extends CRM_Contact_Form_Task {
       'count' => $outcome['valid'],
       'plural' => 'Relationships created.',
     )), 'success', array('expires' => 0));
-
 
   }
 

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -918,7 +918,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
                 'contact' => $primaryContactId,
               );
 
-              list($valid, $invalid, $duplicate, $saved, $relationshipIds) = CRM_Contact_BAO_Relationship::createMultiple($relationParams, $relationIds);
+              list($valid, $invalid, $duplicate, $saved, $relationshipIds) = CRM_Contact_BAO_Relationship::legacyCreateMultiple($relationParams, $relationIds);
 
               if ($valid || $duplicate) {
                 $relationIds['contactTarget'] = $relContactId;

--- a/CRM/Contact/Page/AJAX.php
+++ b/CRM/Contact/Page/AJAX.php
@@ -253,7 +253,7 @@ class CRM_Contact_Page_AJAX {
       }
 
       // create new or update existing relationship
-      $return = CRM_Contact_BAO_Relationship::createMultiple($relationParams, $relationIds);
+      $return = CRM_Contact_BAO_Relationship::legacyCreateMultiple($relationParams, $relationIds);
 
       if (!empty($return[4][0])) {
         $relationshipID = $return[4][0];

--- a/CRM/Contact/Page/AJAX.php
+++ b/CRM/Contact/Page/AJAX.php
@@ -804,7 +804,8 @@ LIMIT {$offset}, {$rowCount}
   public static function getContactRelationships() {
     $contactID = CRM_Utils_Type::escape($_GET['cid'], 'Integer');
     $context = CRM_Utils_Type::escape($_GET['context'], 'String');
-    $relationship_type_id = CRM_Utils_Type::escape($_GET['relationship_type_id'], 'Integer', FALSE);
+    $relationship_type_id = CRM_Utils_Type::escape(CRM_Utils_Array::value('relationship_type_id', $_GET), 'Integer',
+      FALSE);
 
     if (!CRM_Contact_BAO_Contact_Permission::allow($contactID)) {
       return CRM_Utils_System::permissionDenied();

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1685,7 +1685,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     // create relationship
     $relParams['contact_check'][$orgID] = 1;
     $cid = array('contact' => $contactID);
-    CRM_Contact_BAO_Relationship::createMultiple($relParams, $cid);
+    CRM_Contact_BAO_Relationship::legacyCreateMultiple($relParams, $cid);
 
     // if multiple match - send a duplicate alert
     if ($dupeIDs && (count($dupeIDs) > 1)) {

--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -1172,7 +1172,7 @@ SELECT is_primary,
 
     list($valid, $invalid, $duplicate,
       $saved, $relationshipIds
-      ) = CRM_Contact_BAO_Relationship::createMultiple($relationshipParams, $cid);
+      ) = CRM_Contact_BAO_Relationship::legacyCreateMultiple($relationshipParams, $cid);
   }
 
   /**

--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -1163,16 +1163,19 @@ SELECT is_primary,
       CRM_Core_Error::fatal(ts("You seem to have deleted the relationship type '%1'", array(1 => $relationshipType)));
     }
 
-    // create relationship
-    $relationshipParams = array(
-      'is_active' => TRUE,
-      'relationship_type_id' => $relTypeId . '_a_b',
-      'contact_check' => array($sharedContactId => TRUE),
-    );
-
-    list($valid, $invalid, $duplicate,
-      $saved, $relationshipIds
-      ) = CRM_Contact_BAO_Relationship::legacyCreateMultiple($relationshipParams, $cid);
+    try {
+      // create relationship
+      civicrm_api3('relationship', 'create', array(
+        'is_active' => TRUE,
+        'relationship_type_id' => $relTypeId,
+        'contact_id_a' => $cid,
+        'contact_id_b' => $sharedContactId,
+      ));
+    }
+    catch (CiviCRM_API3_Exception $e) {
+      // We catch and ignore here because this has historically been a best-effort relationship create call.
+      // presumably it could refuse due to duplication or similar and we would ignore that.
+    }
   }
 
   /**

--- a/tests/phpunit/CRM/Contact/BAO/ContactType/RelationshipTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ContactType/RelationshipTest.php
@@ -169,7 +169,7 @@ DELETE FROM civicrm_contact_type
     );
     $ids = array('contact' => $this->individual);
 
-    list($valid, $invalid, $duplicate, $saved, $relationshipIds) = CRM_Contact_BAO_Relationship::createMultiple($params, $ids);
+    list($valid, $invalid, $duplicate, $saved, $relationshipIds) = CRM_Contact_BAO_Relationship::legacyCreateMultiple($params, $ids);
 
     $this->assertEquals($invalid, 1, 'In line ' . __LINE__);
     $this->assertEquals(empty($relationshipIds), TRUE, 'In line ' . __LINE__);
@@ -196,7 +196,7 @@ DELETE FROM civicrm_contact_type
     );
     $ids = array('contact' => $this->indivi_parent);
 
-    list($valid, $invalid, $duplicate, $saved, $relationshipIds) = CRM_Contact_BAO_Relationship::createMultiple($params, $ids);
+    list($valid, $invalid, $duplicate, $saved, $relationshipIds) = CRM_Contact_BAO_Relationship::legacyCreateMultiple($params, $ids);
 
     $this->assertEquals($invalid, 1, 'In line ' . __LINE__);
     $this->assertEquals(empty($relationshipIds), TRUE, 'In line ' . __LINE__);
@@ -221,7 +221,7 @@ DELETE FROM civicrm_contact_type
     );
     $ids = array('contact' => $this->indivi_parent);
 
-    list($valid, $invalid, $duplicate, $saved, $relationshipIds) = CRM_Contact_BAO_Relationship::createMultiple($params, $ids);
+    list($valid, $invalid, $duplicate, $saved, $relationshipIds) = CRM_Contact_BAO_Relationship::legacyCreateMultiple($params, $ids);
 
     $this->assertEquals($invalid, 1, 'In line ' . __LINE__);
     $this->assertEquals(empty($relationshipIds), TRUE, 'In line ' . __LINE__);
@@ -249,7 +249,7 @@ DELETE FROM civicrm_contact_type
       'contact_check' => array($this->indivi_parent => $this->indivi_parent),
     );
     $ids = array('contact' => $this->individual);
-    list($valid, $invalid, $duplicate, $saved, $relationshipIds) = CRM_Contact_BAO_Relationship::createMultiple($params, $ids);
+    list($valid, $invalid, $duplicate, $saved, $relationshipIds) = CRM_Contact_BAO_Relationship::legacyCreateMultiple($params, $ids);
 
     $this->assertEquals($valid, 1, 'In line ' . __LINE__);
     $this->assertEquals(empty($relationshipIds), FALSE, 'In line ' . __LINE__);
@@ -277,7 +277,7 @@ DELETE FROM civicrm_contact_type
       'contact_check' => array($this->indivi_student => 1),
     );
     $ids = array('contact' => $this->organization_sponsor);
-    list($valid, $invalid, $duplicate, $saved, $relationshipIds) = CRM_Contact_BAO_Relationship::createMultiple($params, $ids);
+    list($valid, $invalid, $duplicate, $saved, $relationshipIds) = CRM_Contact_BAO_Relationship::legacyCreateMultiple($params, $ids);
 
     $this->assertEquals($valid, 1, 'In line ' . __LINE__);
     $this->assertEquals(empty($relationshipIds), FALSE, 'In line ' . __LINE__);
@@ -302,7 +302,7 @@ DELETE FROM civicrm_contact_type
       'contact_check' => array($this->organization_sponsor => 1),
     );
     $ids = array('contact' => $this->indivi_student);
-    list($valid, $invalid, $duplicate, $saved, $relationshipIds) = CRM_Contact_BAO_Relationship::createMultiple($params, $ids);
+    list($valid, $invalid, $duplicate, $saved, $relationshipIds) = CRM_Contact_BAO_Relationship::legacyCreateMultiple($params, $ids);
 
     $this->assertEquals($valid, 1, 'In line ' . __LINE__);
     $this->assertEquals(empty($relationshipIds), FALSE, 'In line ' . __LINE__);


### PR DESCRIPTION
@colemanw this was absolute whack-a-mole. Perhaps I started down the wrong path early on & wound up having to move much more that necessary.

Unrelated & fixed issue - e-notice on Ajax getContactRelationships()

Fixed issues that I did not verify first
- I don't think the search tasks to add to household & add to org were passing on inherited memberships, I have tested that add to household is now
- I believe that if you selected multiple contacts for a relationship and any of them were duplicates then no relationships would get membership inheritance.

Not really fixed
- memberships only inherited if logged in user has civimember permission (when adding / editing relationships)
- add to household & add to org search tasks have an awful UI.

Tested
- disabling, enabling, adding, deleting from relationship form - to check for addition or deletion of memberships.
- add to organization & add to household tasks
- editing current employer via contact summary edit 

I haven't tested related memberships WRT current employer edit functions at this stage.
