### PR TITLE
CRM-16120 - crmUiDebug - Only display debug fields if ?angularDebug=1

### DIFF
--- a/js/angular-crm-ui.js
+++ b/js/angular-crm-ui.js
@@ -85,6 +85,31 @@
       };
     })
 
+    // Display debug information (if available)
+    // For richer DX, checkout Batarang/ng-inspector (Chrome/Safari), or AngScope/ng-inspect (Firefox).
+    // example: <div crm-ui-debug="myobject" />
+    .directive('crmUiDebug', function ($location) {
+      return {
+        restrict: 'AE',
+        scope: {
+          crmUiDebug: '@'
+        },
+        template: function() {
+          var args = $location.search();
+          return (args && args.angularDebug) ? '<div crm-ui-accordion crm-title=\'ts("Debug (%1)", {1: crmUiDebug})\' crm-collapsed="true"><pre>{{data|json}}</pre></div>' : '';
+        },
+        link: function(scope, element, attrs) {
+          var args = $location.search();
+          if (args && args.angularDebug) {
+            scope.ts = CRM.ts(null);
+            scope.$parent.$watch(attrs.crmUiDebug, function(data) {
+              scope.data = data;
+            });
+          }
+        }
+      };
+    })
+
     // Display a field/row in a field list
     // example: <div crm-ui-field crm-title="My Field"> {{mydata}} </div>
     // example: <div crm-ui-field="subform.myfield" crm-title="'My Field'"> <input crm-ui-id="subform.myfield" name="myfield" /> </div>

--- a/partials/crmMailing/edit-unified.html
+++ b/partials/crmMailing/edit-unified.html
@@ -1,6 +1,4 @@
-<div crm-ui-accordion crm-title="ts('Debug')" crm-collapsed="true">
-  <pre>{{mailing|json}}</pre>
-</div>
+<div crm-ui-debug="mailing"></div>
 
 <div ng-show="isSubmitted()">
   {{ts('This mailing has been submitted.')}}

--- a/partials/crmMailing/edit-unified2.html
+++ b/partials/crmMailing/edit-unified2.html
@@ -1,6 +1,4 @@
-<div crm-ui-accordion crm-title="ts('Debug')" crm-collapsed="true">
-  <pre>{{mailing|json}}</pre>
-</div>
+<div crm-ui-debug="mailing"></div>
 
 <div ng-show="isSubmitted()">
   {{ts('This mailing has been submitted.')}}

--- a/partials/crmMailing/edit-wizard.html
+++ b/partials/crmMailing/edit-wizard.html
@@ -1,6 +1,4 @@
-<div crm-ui-accordion crm-title="ts('Debug')" crm-collapsed="true">
-  <pre>{{mailing|json}}</pre>
-</div>
+<div crm-ui-debug="mailing"></div>
 
 <div ng-show="isSubmitted()">
   {{ts('This mailing has been submitted.')}}

--- a/partials/crmMailing/edit-workflow.html
+++ b/partials/crmMailing/edit-workflow.html
@@ -1,6 +1,4 @@
-<div crm-ui-accordion crm-title="ts('Debug')" crm-collapsed="true">
-  <pre>{{mailing|json}}</pre>
-</div>
+<div crm-ui-debug="mailing"></div>
 
 <div ng-show="isSubmitted()">
   {{ts('This mailing has been submitted.')}}

--- a/partials/crmMailing/edit.html
+++ b/partials/crmMailing/edit.html
@@ -1,6 +1,4 @@
-<div crm-ui-accordion crm-title="ts('Debug')" crm-collapsed="true">
-  <pre>{{mailing|json}}</pre>
-</div>
+<div crm-ui-debug="mailing"></div>
 
 <div ng-show="isSubmitted()">
   {{ts('This mailing has been submitted.')}}

--- a/partials/crmMailingAB/main.html
+++ b/partials/crmMailingAB/main.html
@@ -1,10 +1,8 @@
 <!--
   Implicit Controller: CrmMailingABEditCtrl
 -->
-<div crm-ui-accordion crm-title="ts('Debug')" crm-collapsed="true">
-  <pre>{{abtest.ab|json}}</pre>
-  <pre>{{abtest.mailings|json}}</pre>
-</div>
+<div crm-ui-debug="abtest.ab"></div>
+<div crm-ui-debug="abtest.mailings"></div>
 
 <form name="crmMailingAB" novalidate>
   <div ng-include="'~/crmMailingAB/edit.html'" ng-if="!isSubmitted()"></div>


### PR DESCRIPTION
We've been outputting a collapsible debug panel by default. This completely
hides (or shows) the debug panel depending on whether parameter
"angularDebug" is set.

Note that there are also browser plugins which are richer, more flexible,
more thorough, and it's probably better to install one of those.  However,
it's tough to standardize on one plugin (b/c they're different for each
browser and because we can't bundle them into buildkit).  In a crunch (e.g.
when debugging on a non-developer's workstation), the parameter could still
be helpful.
