### PR TITLE
Fix conference slot does not seem to save parent item. CRM-16100

### DIFF
--- a/CRM/Event/Form/ManageEvent/Conference.php
+++ b/CRM/Event/Form/ManageEvent/Conference.php
@@ -45,32 +45,6 @@ class CRM_Event_Form_ManageEvent_Conference extends CRM_Event_Form_ManageEvent {
   public $_action;
 
   /**
-   * This function sets the default values for the form. For edit/view mode
-   * the default values are retrieved from the database
-   *
-   * @access public
-   *
-   * @return void
-   */
-  function setDefaultValues() {
-    $parentDefaults = parent::setDefaultValues();
-
-    $eventId  = $this->_id;
-    $params   = array();
-    $defaults = array();
-    if (isset($eventId)) {
-      $params = array('id' => $eventId);
-    }
-
-    CRM_Event_BAO_Event::retrieve($params, $defaults);
-
-    $defaults = array_merge($defaults, $parentDefaults);
-    $defaults['id'] = $eventId;
-
-    return $defaults;
-  }
-
-  /**
    * Function to build the form
    *
    * @return void
@@ -101,11 +75,6 @@ class CRM_Event_Form_ManageEvent_Conference extends CRM_Event_Form_ManageEvent {
     $params = array();
     $params = $this->exportValues();
 
-    if (trim($params['parent_event_name']) === '') {
-      # believe me...
-      $params['parent_event_id'] = '';
-    }
-    //update events table
     $params['id'] = $this->_id;
     CRM_Event_BAO_Event::add($params);
 


### PR DESCRIPTION
The conference slot parent event field was not saving the parent event data.
The new version of Civi automatically looks up the event information from the
event id saved in that field, so I removed a bunch of old logic that did all
that for us. The only thing that needs to be saved in that field now is the
parent event id, which is what is happening.
