### PR TITLE
CRM-4287 - add optional search on all emails instead of just primary

### DIFF
--- a/CRM/Admin/Form/Setting/Search.php
+++ b/CRM/Admin/Form/Setting/Search.php
@@ -94,6 +94,9 @@ class CRM_Admin_Form_Setting_Search extends CRM_Admin_Form_Setting {
     $element = $this->getElement('autocompleteContactReference');
     $element->_elements[0]->_flagFrozen = TRUE;
 
+    // primary only or search all
+    $this->addYesNo('searchPrimaryEmailOnly', ts('Search primary email only'));
+
     parent::buildQuickForm();
   }
 

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2531,7 +2531,12 @@ class CRM_Contact_BAO_Query {
           continue;
 
         case 'civicrm_email':
-          $from .= " $side JOIN civicrm_email ON (contact_a.id = civicrm_email.contact_id AND civicrm_email.is_primary = 1) ";
+          if ($config->searchPrimaryEmailOnly) {
+            $from .= " $side JOIN civicrm_email ON (contact_a.id = civicrm_email.contact_id AND civicrm_email.is_primary = 1) ";
+          }
+          else {
+            $from .= " $side JOIN civicrm_email ON (contact_a.id = civicrm_email.contact_id ) ";
+          }
           continue;
 
         case 'civicrm_im':

--- a/CRM/Core/Config/Variables.php
+++ b/CRM/Core/Config/Variables.php
@@ -418,6 +418,8 @@ class CRM_Core_Config_Variables extends CRM_Core_Config_Defaults {
 
   public $defaultSearchProfileID = NULL;
 
+  public $searchPrimaryEmailOnly = 1; 
+
   /**
    * Dashboard timeout
    */

--- a/CRM/Core/Config/Variables.php
+++ b/CRM/Core/Config/Variables.php
@@ -418,7 +418,7 @@ class CRM_Core_Config_Variables extends CRM_Core_Config_Defaults {
 
   public $defaultSearchProfileID = NULL;
 
-  public $searchPrimaryEmailOnly = 1; 
+  public $searchPrimaryEmailOnly = 1;
 
   /**
    * Dashboard timeout

--- a/templates/CRM/Admin/Form/Setting/Search.tpl
+++ b/templates/CRM/Admin/Form/Setting/Search.tpl
@@ -83,7 +83,12 @@
                 <p class="description">{$enable_innodb_fts_description}</p>
             </td>
         </tr>
-
+        <tr class="crm-search-setting-form-block-searchPrimaryEmailOnly">
+            <td class="label">{$form.searchPrimaryEmailOnly.label}</td>
+            <td>{$form.searchPrimaryEmailOnly.html}<br />
+                <p class="description">{ts}By default, search by Email look only for primary Email. You can extend the search to all contact Emails. It may have impact on the performance.{/ts}</p>
+            </td>
+        </tr>
 
        </table>
             <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>


### PR DESCRIPTION
Minimal but fonctionnal patch

---
- [CRM-4287: Contact search for email address fails to show non-primary email matches as results](https://issues.civicrm.org/jira/browse/CRM-4287)
