### PR TITLE
add hidden support to addField, convert Edit_Lock and Inline_Lock

### DIFF
--- a/CRM/Contact/Form/Edit/Lock.php
+++ b/CRM/Contact/Form/Edit/Lock.php
@@ -48,7 +48,7 @@ class CRM_Contact_Form_Edit_Lock {
    * @return void
    */
   public static function buildQuickForm(&$form) {
-    $form->addElement('hidden', 'modified_date', '', array('id' => 'modified_date'));
+    $form->addField('modified_date', array('type' => 'hidden', 'id' => 'modified_date', 'label' => ''));
   }
 
   /**

--- a/CRM/Contact/Form/Inline.php
+++ b/CRM/Contact/Form/Inline.php
@@ -54,6 +54,20 @@ abstract class CRM_Contact_Form_Inline extends CRM_Core_Form {
   public $_contactSubType;
 
   /**
+   * Explicitly declare the form context.
+   */
+  public function getDefaultContext() {
+    return 'create';
+  }
+
+  /**
+   * Explicitly declare the entity api name.
+   */
+  public function getDefaultEntity() {
+    return 'Contact';
+  }
+
+  /**
    * Common preprocess: fetch contact ID and contact type
    */
   public function preProcess() {

--- a/CRM/Contact/Form/Inline/Lock.php
+++ b/CRM/Contact/Form/Inline/Lock.php
@@ -58,7 +58,7 @@ class CRM_Contact_Form_Inline_Lock {
     // - V1:open E1:open E1:submit V1.email:open V1.email:submit
     // - V1:open V1.email:open E1:open E1:submit V1.email:submit V1:lock
     $timestamps = CRM_Contact_BAO_Contact::getTimestamps($contactID);
-    $form->addElement('hidden', 'oplock_ts', $timestamps['modified_date'], array('id' => 'oplock_ts'));
+    $form->addField('oplock_ts', array('type' => 'hidden', 'id' => 'oplock_ts', 'label' => $timestamps['modified_date']));
     $form->addFormRule(array('CRM_Contact_Form_Inline_Lock', 'formRule'), $contactID);
   }
 

--- a/CRM/Contact/Form/Inline/Lock.php
+++ b/CRM/Contact/Form/Inline/Lock.php
@@ -58,7 +58,7 @@ class CRM_Contact_Form_Inline_Lock {
     // - V1:open E1:open E1:submit V1.email:open V1.email:submit
     // - V1:open V1.email:open E1:open E1:submit V1.email:submit V1:lock
     $timestamps = CRM_Contact_BAO_Contact::getTimestamps($contactID);
-    $form->addField('oplock_ts', array('type' => 'hidden', 'id' => 'oplock_ts', 'label' => $timestamps['modified_date']));
+    $form->addElement('hidden', 'oplock_ts', $timestamps['modified_date'], array('id' => 'oplock_ts'));
     $form->addFormRule(array('CRM_Contact_Form_Inline_Lock', 'formRule'), $contactID);
   }
 

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -1222,6 +1222,10 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
         $this->addElement('text', $name, $label, $props, $required);
         break;
 
+      case 'hidden':
+        $this->addElement('hidden', $name, $label, $props);
+        break;
+
       //case 'TextArea':
       //case 'Select Date':
       //TODO: Add date formats


### PR DESCRIPTION
This adds hidden support to addField, and converts the first inline form to use it. 
First part of https://issues.civicrm.org/jira/browse/CRM-16178
