### PR TITLE
Fix for CRM-15622 is causing issue: CRM-16190

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1340,7 +1340,7 @@ loadCampaign( {$this->_eID}, {$eventCampaigns} );
       $payment = CRM_Core_Payment::singleton($this->_mode, $this->_paymentProcessor, $this);
 
       // CRM-15622: fix for incorrect contribution.fee_amount
-      $paymentParams['fee_amount'] = NULL;
+      // $paymentParams['fee_amount'] = NULL;
       $result = $payment->doDirectPayment($paymentParams);
 
       if (is_a($result, 'CRM_Core_Error')) {


### PR DESCRIPTION
I must note that this line works fine in 4.5 and 4.6 - just not in 4.4 - so this line per se may not be the issue - I just know that rolling this particular one back fixes the Amounts not showing up on the Events -> Dashboard under Recent Registrations. See details:
https://issues.civicrm.org/jira/browse/CRM-16190

---
- [CRM-15622: Contribution "Fee Amount" field not set correctly with back end Authorize.Net event registration](https://issues.civicrm.org/jira/browse/CRM-15622)
