### PR TITLE
CRM-6131: Allow to override the dedupe rule used when submitting a form (useful for buildForm hooks).

### DIFF
--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -111,6 +111,12 @@ class CRM_Profile_Form extends CRM_Core_Form {
    */
   public $_isUpdateDupe = 0;
 
+  /**
+   * Dedupe using a specific rule (CRM-6131).
+   * Not currently exposed in profile settings, but can be set in a buildForm hook.
+   */
+  public $_ruleGroupID = NULL;
+
   public $_isAddCaptcha = FALSE;
 
   protected $_isPermissionedChecksum = FALSE;
@@ -946,7 +952,8 @@ class CRM_Profile_Form extends CRM_Core_Form {
       $ids = CRM_Dedupe_Finder::dupesByParams($dedupeParams,
         $ctype,
         $ruleType,
-        $exceptions
+        $exceptions,
+        $form->_ruleGroupID
       );
       if ($ids) {
         if ($form->_isUpdateDupe == 2) {


### PR DESCRIPTION
I found this quickfix to make it possible to override the dedupe rule on a specific profile.

My use-case is this:
- usually we dedupe on firstname+email (contribution forms, events, etc)
- however, the newsletter signup block only asks for an email (we later try to get their name and other infos)
- so if the user already had a contact record, we risk creating a duplicate record.

I guess it would be fairly easy to add this to the profile settings UI, but I thought I would start by this and see how it goes.

To use this option, I used hook_civicrm_buildForm():

```
/**
 * Implements hook_civicrm_buildForm().
 */
function example_civicrm_buildForm($formName, &$form) {
  if ($formName == 'CRM_Profile_Form_Edit') {
    // Dedupe by email only
    $gid = $form->get('gid');

    if ($gid == 60 || $gid == 61) {
      $form->_ruleGroupID = 13;
    }
  }
}
```
