### PR TITLE
Upgrade fix for 4.6.0 failure

### DIFF
--- a/CRM/Upgrade/Incremental/sql/4.6.0.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.6.0.mysql.tpl
@@ -29,7 +29,7 @@ WHERE option_group_id = @option_group_id_notePrivacy AND value = 1;
 
 --These labels were never translated so just copy them over as names
 UPDATE civicrm_option_value v, civicrm_option_group g
-SET v.name = v.label
+SET v.name = {localize field='label'}v.label{/localize} 
 WHERE g.id = v.option_group_id AND g.name IN
 ('group_type', 'safe_file_extension', 'wysiwyg_editor');
 


### PR DESCRIPTION
Fix for the following 
https://test.civicrm.org/job/CiviCRM-Core-Matrix/CIVIVER=4.6,label=test-debian6-1/lastCompletedBuild/testReport/(root)/CivicrmUpgradeTest/4_2_9_multilingual_af_bg_en_mysql_bz2/
