### PR TITLE
CRM-16138 - CRM_Extensions_System - Include domain_id in cache paths

### DIFF
--- a/CRM/Extension/System.php
+++ b/CRM/Extension/System.php
@@ -53,6 +53,13 @@ class CRM_Extension_System {
   private $_repoUrl = NULL;
 
   /**
+   * @var array
+   *   Construction parameters. These are primarily retained so
+   *   that they can influence the cache name.
+   */
+  protected $parameters;
+
+  /**
    * @param bool $fresh
    *   TRUE to force creation of a new system.
    *
@@ -101,6 +108,9 @@ class CRM_Extension_System {
     }
     if (!array_key_exists('cmsRootPath', $parameters)) {
       $parameters['cmsRootPath'] = $config->userSystem->cmsRootPath();
+    }
+    if (!array_key_exists('domain_id', $parameters)) {
+      $parameters['domain_id'] = CRM_Core_Config::domainID();
     }
     ksort($parameters); // guaranteed ordering - useful for md5(serialize($parameters))
 


### PR DESCRIPTION
The extension cache (returned by CRM_Extension_System::getCache) is already
keyed off extensionDir, extensionUrl, civicrm_root, and several others.
This patch adds domain_id to the list.

The patch is derived from agileware's patch from 4.4. Notably, the original
patch only influenced mapper (not the other caches).

I don't really think this patch should be necessary. Firstly, there are
already many variables factored into the cache-key for 4.6+ (CRM-15788) --
one (or more) should get tripped in "single-database, multiple-codebase"
architecture.  Secondly, the extension list is not innately domain-based.

However, there are a dizzying range of variations on
multi-site/multi-domain, and I may not have a full appreciation for the one
that led to agileware's patch.  And (theoertically) there's no big downside
to including domain_id as part of the cache.
