### PR TITLE
CRM-16255 pass contact_id to payment processor from backoffice participa...

### DIFF
--- a/CRM/Core/Payment/Form.php
+++ b/CRM/Core/Payment/Form.php
@@ -392,6 +392,7 @@ class CRM_Core_Payment_Form {
         'state_province' => "billing_state_province-$id",
         'postal_code' => "billing_postal_code-$id",
         'country' => "billing_country-$id",
+        'contactID' => 'contact_id',
       );
     }
 

--- a/CRM/Core/Payment/Form.php
+++ b/CRM/Core/Payment/Form.php
@@ -351,6 +351,9 @@ class CRM_Core_Payment_Form {
   /**
    * Make sure that credit card number and cvv are valid.
    * Called within the scope of a QF formRule function
+   *
+   * @param array $values
+   * @param array $errors
    */
   public static function validateCreditCard($values, &$errors) {
     if (!empty($values['credit_card_type']) || !empty($values['credit_card_number'])) {
@@ -371,13 +374,11 @@ class CRM_Core_Payment_Form {
    * Map address fields.
    *
    * @param int $id
-   * @param $src
-   * @param $dst
+   * @param array $src
+   * @param array $dst
    * @param bool $reverse
-   *
-   * @return void
    */
-  public static function mapParams($id, &$src, &$dst, $reverse = FALSE) {
+  public static function mapParams($id, $src, &$dst, $reverse = FALSE) {
     static $map = NULL;
     if (!$map) {
       $map = array(

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1189,7 +1189,14 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       if (!empty($this->_params['send_receipt'])) {
         $paymentParams['email'] = $this->_contributorEmail;
       }
-      CRM_Core_Payment_Form::mapParams($this->_bltID, $this->_params, $paymentParams, TRUE);
+
+      // The only reason for merging in the 'contact_id' rather than ensuring it is set
+      // is that this patch is being done around the time of the stable release
+      // so more conservative approach is called for.
+      // In fact the use of $params and $this->_params & $this->_contactId vs $contactID
+      // needs rationalising.
+      $mapParams = array_merge(array('contact_id' => $contactID), $this->_params);
+      CRM_Core_Payment_Form::mapParams($this->_bltID, $mapParams, $paymentParams, TRUE);
 
       $payment = CRM_Core_Payment::singleton($this->_mode, $this->_paymentProcessor, $this);
 

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1228,7 +1228,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
         = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event', $params['event_id'], 'financial_type_id');
       $this->_params['mode'] = $this->_mode;
 
-      //add contribution reocord
+      //add contribution record
       $contributions[] = $contribution = CRM_Event_Form_Registration_Confirm::processContribution($this, $this->_params, $result, $contactID, FALSE);
 
       // add participant record


### PR DESCRIPTION
...nt form

I also took away the pass-by-ref on src (source) in this function

public static function mapParams($id, $src, &$dst, $reverse = FALSE) {

since it is not altered it seems clearer to me to not pass by ref.
