### PR TITLE
CRM-16230 - Permissions: handle extensions with and without descriptions

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -616,7 +616,7 @@ class CRM_Core_Permission {
     }
 
     // Add any permissions defined in hook_civicrm_permission implementations.
-    $module_permissions = $config->userPermissionClass->getAllModulePermissions();
+    $module_permissions = $config->userPermissionClass->getAllModulePermissions($descriptions);
     $permissions = array_merge($permissions, $module_permissions);
     return $permissions;
   }

--- a/CRM/Core/Permission/Base.php
+++ b/CRM/Core/Permission/Base.php
@@ -256,9 +256,20 @@ class CRM_Core_Permission_Base {
    * @return array
    *   Array of permissions, in the same format as CRM_Core_Permission::getCorePermissions().
    */
-  public function getAllModulePermissions() {
+  public function getAllModulePermissions($descriptions = FALSE) {
     $permissions = array();
     CRM_Utils_Hook::permission($permissions);
+
+    if ($descriptions) {
+      foreach ($permissions as $permission => $label) {
+        $permissions[$permission] = (is_array($label)) ? $label : array($label);
+      }
+    }
+    else {
+      foreach ($permissions as $permission => $label) {
+        $permissions[$permission] = (is_array($label)) ? array_shift($label) : $label;
+      }
+    }
     return $permissions;
   }
 


### PR DESCRIPTION
---
- CRM-16230: Extensions providing permissions will choke
  https://issues.civicrm.org/jira/browse/CRM-16230

Replaces #5560 
