### PR TITLE
CRM-16229 - Cannot add participants to event from search

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -35,6 +35,16 @@
 
 /**
  * This class generates form components for processing a contribution
+ * CRM-16229 - During the event registration bulk action via search we
+ * need to inherit CRM_Contact_Form_Task so that we can inherit functions
+ * like getContactIds and make use of controller state. But this is not possible
+ * because CRM_Event_Form_Participant inherits this class.
+ * Ideal situation would be something like
+ * CRM_Event_Form_Participant extends CRM_Contact_Form_Task,
+ * CRM_Contribute_Form_AbstractEditPayment
+ * However this is not possible. Currently PHP does not support multiple
+ * inheritance. So work around solution is to extend this class with
+ * CRM_Contact_Form_Task which further extends CRM_Core_Form.
  *
  */
 class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {

--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -37,7 +37,7 @@
  * This class generates form components for processing a contribution
  *
  */
-class CRM_Contribute_Form_AbstractEditPayment extends CRM_Core_Form {
+class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
   public $_mode;
 
   public $_action;

--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -110,7 +110,9 @@ class CRM_Event_BAO_Participant extends CRM_Event_DAO_Participant {
         $op = key($params['role_id']);
         $params['role_id'] = $params['role_id'][$op];
       }
-      $params['role_id'] = implode(CRM_Core_DAO::VALUE_SEPARATOR, $params['role_id']);
+      else {
+        $params['role_id'] = implode(CRM_Core_DAO::VALUE_SEPARATOR, $params['role_id']);
+      }
     }
 
     $participantBAO = new CRM_Event_BAO_Participant();

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -322,7 +322,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
           $this->_action = CRM_Core_Action::COPY;
           break;
       }
-      parent::preProcess();
+      CRM_Contact_Form_Task::preProcessCommon($this);
 
       $this->_single = FALSE;
       $this->_contactId = NULL;

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -322,7 +322,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
           $this->_action = CRM_Core_Action::COPY;
           break;
       }
-      CRM_Contact_Form_Task::preProcessCommon($this);
+      parent::preProcess();
 
       $this->_single = FALSE;
       $this->_contactId = NULL;


### PR DESCRIPTION
https://issues.civicrm.org/jira/browse/CRM-16229

Also fixed additional warnings :

Warning: implode(): Invalid arguments passed in CRM_Event_BAO_Participant::add() (line 113 of /home/web/gity/civicrm/CRM/Event/BAO/Participant.php).
Warning: implode(): Invalid arguments passed in CRM_Event_BAO_Participant::add() (line 113 of /home/web/gity/civicrm/CRM/Event/BAO/Participant.php).
