### PR TITLE
CRM-16237 - crmMailing - Restore checking of required tokens

### DIFF
--- a/CRM/Mailing/Info.php
+++ b/CRM/Mailing/Info.php
@@ -120,7 +120,7 @@ class CRM_Mailing_Info extends CRM_Core_Component_Info {
     ));
     $headerfooterList = civicrm_api3('MailingComponent', 'get', $params + array(
       'is_active' => 1,
-      'return' => array('name', 'component_type', 'is_default'),
+      'return' => array('name', 'component_type', 'is_default', 'body_html', 'body_text'),
     ));
 
     $emailAdd = civicrm_api3('Email', 'get', array(


### PR DESCRIPTION
The header/footer day was optimized in beta by removing the
body_html/body_text -- but this optimization made it impossible to check for
required tokens.
