### PR TITLE
CRM-16246 - Load ngRoute through Civi\Angular\Manager

### DIFF
--- a/Civi/Angular/Manager.php
+++ b/Civi/Angular/Manager.php
@@ -97,6 +97,10 @@ class Manager {
         'ext' => 'civicrm',
         'js' => array('bower_components/angular-jquery-dialog-service/dialog-service.js'),
       );
+      $angularModules['ngRoute'] = array(
+        'ext' => 'civicrm',
+        'js' => array('bower_components/angular-route/angular-route.min.js'),
+      );
       $angularModules['ui.utils'] = array(
         'ext' => 'civicrm',
         'js' => array('bower_components/angular-ui-utils/ui-utils.min.js'),

--- a/Civi/Angular/Page/Main.php
+++ b/Civi/Angular/Page/Main.php
@@ -81,7 +81,6 @@ class Main extends \CRM_Core_Page {
     });
 
     $this->res->addScriptFile('civicrm', 'bower_components/angular/angular.min.js', 100, 'html-header', FALSE);
-    $this->res->addScriptFile('civicrm', 'bower_components/angular-route/angular-route.min.js', 110, 'html-header', FALSE);
 
     // FIXME: crmUi depends on loading ckeditor, but ckeditor doesn't work with this aggregation.
     $this->res->addScriptFile('civicrm', 'packages/ckeditor/ckeditor.js', 100, 'page-header', FALSE);


### PR DESCRIPTION
This should resolve one of Chrome's warnings about min.map.
