### PR TITLE
Upgrade: Fix `value` for added `option_value` entries in various places

### DIFF
--- a/CRM/Upgrade/Incremental/sql/2.2.alpha3.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/2.2.alpha3.mysql.tpl
@@ -35,7 +35,7 @@ ALTER TABLE `civicrm_pcp_block`
 -- PCP userDashboard Option
 
  SELECT @option_group_id_udOpt  := max(id) from civicrm_option_group where name = 'user_dashboard_options';
- SELECT @maxValue  := max(value) from civicrm_option_value where option_group_id=@option_group_id_udOpt ;
+ SELECT @maxValue  := max(ROUND(value)) from civicrm_option_value where option_group_id=@option_group_id_udOpt ;
 
 {if $multilingual}
   INSERT INTO civicrm_option_value

--- a/CRM/Upgrade/Incremental/sql/3.4.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/3.4.alpha1.mysql.tpl
@@ -75,7 +75,7 @@ ON cml.membership_id=cm.id SET cml.membership_type_id=cm.membership_type_id;
 -- CRM-7445 add client to case
 SELECT @option_group_id_act            := max(id) from civicrm_option_group where name = 'activity_type';
 SELECT @weight                 := MAX(weight) FROM civicrm_option_value WHERE option_group_id = @option_group_id_act;
-SELECT @value                 := MAX(value) FROM civicrm_option_value WHERE option_group_id = @option_group_id_act;
+SELECT @value                 := MAX(ROUND(value)) FROM civicrm_option_value WHERE option_group_id = @option_group_id_act;
 SELECT @caseCompId       := max(id) FROM civicrm_component where name = 'CiviCase';
 INSERT INTO civicrm_option_value
   (option_group_id,         {localize field='label'}label{/localize},                   value,                        name,                                        weight,                 {localize field='description'}description{/localize}, is_active, component_id) VALUES

--- a/CRM/Upgrade/Incremental/sql/4.3.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.3.alpha1.mysql.tpl
@@ -601,7 +601,7 @@ SELECT 'civicrm_payment_processor', id, @option_value_rel_id_as, @financial_acco
 -- CRM-9923 and CRM-11037
 SELECT @option_group_id_batch_status   := max(id) from civicrm_option_group where name = 'batch_status';
 
-SELECT @weight                 := MAX(value) FROM civicrm_option_value WHERE option_group_id = @option_group_id_batch_status;
+SELECT @weight                 := MAX(ROUND(value)) FROM civicrm_option_value WHERE option_group_id = @option_group_id_batch_status;
 
 INSERT INTO
    `civicrm_option_value` (`option_group_id`, {localize field='label'}label{/localize}, `value`, `name`, `grouping`, `filter`, `is_default`, `weight`)

--- a/CRM/Upgrade/Incremental/sql/4.4.5.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.4.5.mysql.tpl
@@ -1,7 +1,7 @@
 {* file to handle db changes in 4.4.5 during upgrade *}
 -- CRM-14191
 SELECT @option_group_id_batch_status   := max(id) from civicrm_option_group where name = 'batch_status';
-SELECT @weight := MAX(value) FROM civicrm_option_value WHERE option_group_id = @option_group_id_batch_status;
+SELECT @weight := MAX(ROUND(value)) FROM civicrm_option_value WHERE option_group_id = @option_group_id_batch_status;
 
 UPDATE civicrm_option_value 
 SET value = (Select @weight := @weight +1),
@@ -9,7 +9,7 @@ weight = @weight
 WHERE option_group_id = @option_group_id_batch_status AND name IN ('Data Entry', 'Reopened', 'Exported') AND value = 0 ORDER BY id;
 
 SELECT @option_group_id_batch_modes := max(id) from civicrm_option_group where name = 'batch_mode';
-SELECT @weights := MAX(value) FROM civicrm_option_value WHERE option_group_id = @option_group_id_batch_modes;
+SELECT @weights := MAX(ROUND(value)) FROM civicrm_option_value WHERE option_group_id = @option_group_id_batch_modes;
 
 UPDATE civicrm_option_value 
 SET value = (Select @weights := @weights +1),


### PR DESCRIPTION
In several places, the highest existing option value for a group was
being determined using max(value), which breaks as soon as there are
values above 9, because `value` is defined as a varchar rather than
integer for lulz. In most instances, this is taken care of by using
max(round(value)) instead -- but not everwhere. Fix the wrong ones.

(BTW, convert(value, decimal) would be more obvious than round()
IMHO...)

Note that while this patch is against master, it should be backported to
all maintained branches.

PS. Database normalisation is only for wimps who can't handle the
anomalies, right?...
