### PR TITLE
CRM-16290 fix fatal on relationship edit

### DIFF
--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -1601,9 +1601,21 @@ SELECT count(*)
 
   /**
    * Helper function to check whether to delete the membership or not.
+   *
+   * Function takes a list of related membership types and if it is not also passed a
+   * relationship ID of that types evaluates whether the membership should be deleted.
+   *
+   * @param array $membershipTypeRelationshipTypeIDs
+   *   Relation type IDs related to the given membership type.
+   * @param int $contactId
+   * @param int $mainRelatedContactId
+   * @param int $relTypeId
+   * @param array $relIds
+   *
+   * @return bool
    */
-  public static function isDeleteRelatedMembership($relTypeIds, $contactId, $mainRelatedContactId, $relTypeId, $relIds) {
-    if (in_array($relTypeId, $relTypeIds)) {
+  public static function isDeleteRelatedMembership($membershipTypeRelationshipTypeIDs, $contactId, $mainRelatedContactId, $relTypeId, $relIds) {
+    if (empty($membershipTypeRelationshipTypeIDs) || in_array($relTypeId, $membershipTypeRelationshipTypeIDs)) {
       return FALSE;
     }
 
@@ -1617,14 +1629,15 @@ SELECT count(*)
     );
 
     if ($contactId == $mainRelatedContactId) {
-      $recordsFound = (int) CRM_Core_DAO::singleValueQuery("SELECT COUNT(*) FROM civicrm_relationship WHERE relationship_type_id IN ( " . implode(',', $relTypeIds) . " )  AND contact_id_a IN ( %1 ) OR contact_id_b IN ( %1 ) AND id IN (" . implode(',', $relIds) . ")", $relParamas);
+      $recordsFound = (int) CRM_Core_DAO::singleValueQuery("SELECT COUNT(*) FROM civicrm_relationship WHERE relationship_type_id IN ( " . implode(',', $membershipTypeRelationshipTypeIDs) . " )  AND
+contact_id_a IN ( %1 ) OR contact_id_b IN ( %1 ) AND id IN (" . implode(',', $relIds) . ")", $relParamas);
       if ($recordsFound) {
         return FALSE;
       }
       return TRUE;
     }
 
-    $recordsFound = (int) CRM_Core_DAO::singleValueQuery("SELECT COUNT(*) FROM civicrm_relationship WHERE relationship_type_id IN ( " . implode(',', $relTypeIds) . " ) AND contact_id_a IN ( %1, %2 ) AND contact_id_b IN ( %1, %2 ) AND id NOT IN (" . implode(',', $relIds) . ")", $relParamas);
+    $recordsFound = (int) CRM_Core_DAO::singleValueQuery("SELECT COUNT(*) FROM civicrm_relationship WHERE relationship_type_id IN ( " . implode(',', $membershipTypeRelationshipTypeIDs) . " ) AND contact_id_a IN ( %1, %2 ) AND contact_id_b IN ( %1, %2 ) AND id NOT IN (" . implode(',', $relIds) . ")", $relParamas);
 
     if ($recordsFound) {
       return FALSE;

--- a/CRM/Contact/Form/Relationship.php
+++ b/CRM/Contact/Form/Relationship.php
@@ -409,12 +409,21 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
       $ids['relationship'] = $this->_relationshipId;
       $relation = CRM_Contact_BAO_Relationship::getRelationshipByID($this->_relationshipId);
       if ($relation->contact_id_a == $this->_contactId) {
+        // I couldn't replicate this path in testing. See below.
         $params['contact_id_a'] = $this->_contactId;
         $params['contact_id_b'] = array($params['related_contact_id']);
+        $outcome = CRM_Contact_BAO_Relationship::createMultiple($params, $relationshipTypeParts[1]);
+        $relationshipIds = $outcome['relationship_ids'];
       }
       else {
+        // The only reason we have changed this to use the api & not the above is that this was broken.
+        // Recommend extracting all of update into a function that uses the api
+        // and ensuring api / bao take care of 'other stuff' in this form
+        // the contact_id_a & b can't be changed on this form so don't really need setting.
         $params['contact_id_b'] = $this->_contactId;
-        $params['contact_id_a'] = array($params['related_contact_id']);
+        $params['contact_id_a'] = $params['related_contact_id'];
+        $result = civicrm_api3('relationship', 'create', $params);
+        $relationshipIds = array($result['id']);
       }
       $ids['contactTarget'] = ($relation->contact_id_a == $this->_contactId) ? $relation->contact_id_b : $relation->contact_id_a;
 
@@ -429,19 +438,19 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
           $this->ajaxResponse['reloadBlocks'] = array('#crm-contactinfo-content');
         }
       }
+      $this->setMessage(ts('The relationship has been updated'));
     }
     // Create mode (could be 1 or more relationships)
     else {
       $params['contact_id_' .  $relationshipTypeParts[2]] = explode(',', $params['related_contact_id']);
+      $outcome = CRM_Contact_BAO_Relationship::createMultiple($params, $relationshipTypeParts[1]);
+      $relationshipIds = $outcome['relationship_ids'];
+      if (empty($outcome['saved']) && !empty($update)) {
+        $outcome['saved'] = $update;
+      }
+      $this->setMessage($outcome);
     }
 
-    // Save the relationships.
-    $outcome = CRM_Contact_BAO_Relationship::createMultiple($params, $relationshipTypeParts[1]);
-    $relationshipIds = $outcome['relationship_ids'];
-    if (empty($outcome['saved']) && !empty($update)) {
-      $outcome['saved'] = $update;
-    }
-    $this->setMessage($outcome);
 
     // if this is called from case view,
     //create an activity for case role removal.CRM-4480

--- a/CRM/Contact/Form/Relationship.php
+++ b/CRM/Contact/Form/Relationship.php
@@ -451,7 +451,6 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
       $this->setMessage($outcome);
     }
 
-
     // if this is called from case view,
     //create an activity for case role removal.CRM-4480
     // @todo this belongs in the BAO.


### PR DESCRIPTION
This seems to be a new break deriving from a webtest fix - I did replicate on live.

I'd really like to put in some unittests on the relationship update when related enties are involved - I think in this case the error only occurs when a membership is involved - & probably only when it's of a type with no relationship_type_id attached. Maybe at the sprint
