### PR TITLE
CRM-16277 - crmMailing - Fix slow recipient count

### DIFF
--- a/CRM/Mailing/Info.php
+++ b/CRM/Mailing/Info.php
@@ -137,7 +137,6 @@ class CRM_Mailing_Info extends CRM_Core_Component_Info {
       'return' => array("msg_html", "id", "msg_title", "msg_subject", "msg_text"),
       'workflow_id' => array('IS NULL' => ""),
     ));
-    $mailGrp = civicrm_api3('MailingGroup', 'get', $params);
     $mailTokens = civicrm_api3('Mailing', 'gettokens', array(
       'entity' => array('contact', 'mailing'),
       'sequential' => 1,
@@ -154,7 +153,6 @@ class CRM_Mailing_Info extends CRM_Core_Component_Info {
           'headerfooterList' => $headerfooterList['values'],
           'mesTemplate' => $mesTemplate['values'],
           'emailAdd' => $emailAdd['values'],
-          'mailGrp' => $mailGrp['values'],
           'mailTokens' => $mailTokens['values'],
           'contactid' => $contactID,
           'requiredTokens' => CRM_Utils_Token::getRequiredTokens(),

--- a/ang/crmMailing/EditRecipCtrl.js
+++ b/ang/crmMailing/EditRecipCtrl.js
@@ -29,7 +29,7 @@
       if ($scope.recipients === 1) {
         return ts('~1 recipient');
       }
-      return ts('~%1 recipients', {1: CRM.sigfig($scope.recipients, 2)});
+      return ts('~%1 recipients', {1: $scope.recipients});
     };
 
     // We monitor four fields -- use debounce so that changes across the

--- a/ang/crmMailing/EditRecipCtrl.js
+++ b/ang/crmMailing/EditRecipCtrl.js
@@ -5,10 +5,10 @@
   // Scope members:
   //  - [input] mailing: object
   //  - [output] recipients: array of recipient records
-  angular.module('crmMailing').controller('EditRecipCtrl', function EditRecipCtrl($scope, dialogService, crmApi, crmMailingMgr, $q, crmMetadata) {
+  angular.module('crmMailing').controller('EditRecipCtrl', function EditRecipCtrl($scope, dialogService, crmApi, crmMailingMgr, $q, crmMetadata, crmStatus) {
     // Time to wait before triggering AJAX update to recipients list
     var RECIPIENTS_DEBOUNCE_MS = 100;
-    var RECIPIENTS_PREVIEW_LIMIT = 10000;
+    var RECIPIENTS_PREVIEW_LIMIT = 50;
 
     var ts = $scope.ts = CRM.ts(null);
 
@@ -23,16 +23,13 @@
       if ($scope.recipients === null) {
         return ts('(Estimating)');
       }
-      if ($scope.recipients.length === 0) {
+      if ($scope.recipients === 0) {
         return ts('No recipients');
       }
-      if ($scope.recipients.length === 1) {
+      if ($scope.recipients === 1) {
         return ts('~1 recipient');
       }
-      if (RECIPIENTS_PREVIEW_LIMIT > 0 && $scope.recipients.length >= RECIPIENTS_PREVIEW_LIMIT) {
-        return ts('>%1 recipients', {1: RECIPIENTS_PREVIEW_LIMIT});
-      }
-      return ts('~%1 recipients', {1: $scope.recipients.length});
+      return ts('~%1 recipients', {1: CRM.sigfig($scope.recipients, 2)});
     };
 
     // We monitor four fields -- use debounce so that changes across the
@@ -43,7 +40,7 @@
         if (!$scope.mailing) {
           return;
         }
-        crmMailingMgr.previewRecipients($scope.mailing, RECIPIENTS_PREVIEW_LIMIT).then(function(recipients) {
+        crmMailingMgr.previewRecipientCount($scope.mailing).then(function(recipients) {
           $scope.recipients = recipients;
         });
       });
@@ -54,17 +51,21 @@
     $scope.$watchCollection("mailing.recipients.mailings.exclude", refreshRecipients);
 
     $scope.previewRecipients = function previewRecipients() {
-      var model = {
-        recipients: $scope.recipients
-      };
-      var options = CRM.utils.adjustDialogDefaults({
-        width: '40%',
-        autoOpen: false,
-        title: ts('Preview (%1)', {
-          1: $scope.getRecipientsEstimate()
-        })
-      });
-      dialogService.open('recipDialog', '~/crmMailing/PreviewRecipCtrl.html', model, options);
+      return crmStatus({start: ts('Previewing...'), success: ''}, crmMailingMgr.previewRecipients($scope.mailing, RECIPIENTS_PREVIEW_LIMIT).then(function(recipients) {
+        var model = {
+          count: $scope.recipients,
+          sample: recipients,
+          sampleLimit: RECIPIENTS_PREVIEW_LIMIT
+        };
+        var options = CRM.utils.adjustDialogDefaults({
+          width: '40%',
+          autoOpen: false,
+          title: ts('Preview (%1)', {
+            1: $scope.getRecipientsEstimate()
+          })
+        });
+        dialogService.open('recipDialog', '~/crmMailing/PreviewRecipCtrl.html', model, options);
+      }));
     };
 
     // Open a dialog for editing the advanced recipient options.

--- a/ang/crmMailing/PreviewRecipCtrl.html
+++ b/ang/crmMailing/PreviewRecipCtrl.html
@@ -1,13 +1,21 @@
 <div ng-controller="PreviewRecipCtrl">
   <!--
   Controller: PreviewRecipCtrl
-  Required vars: model.recipients
+  Required vars: model.sample
   -->
-  <p><em>{{ts('Based on current data, the following contacts will receive a copy of the mailing. If contacts are added or removed from the target groups, then the final list may change.')}}</em></p>
-  <div ng-show="model.recipients == 0">
+
+  <div class="help">
+    <p>{{ts('Based on current data, approximately %1 contacts will receive a copy of the mailing.', {1: model.count})}}</p>
+
+    <p ng-show="model.sample.length == model.sampleLimit">{{ts('Below is a sample of the first %1 recipients.', {1: model.sampleLimit})}}</p>
+
+    <p>{{ts('If individual contacts are separately modified, added, or removed, then the final list may change.')}}</p>
+  </div>
+
+  <div ng-show="model.sample == 0">
     {{ts('No recipients')}}
   </div>
-  <table ng-show="model.recipients.length > 0">
+  <table ng-show="model.sample.length > 0">
     <thead>
       <tr>
         <th>{{ts('Name')}}</th>
@@ -15,7 +23,7 @@
       </tr>
     </thead>
     <tbody>
-      <tr ng-repeat="recipient in model.recipients">
+      <tr ng-repeat="recipient in model.sample">
         <td>{{recipient['api.contact.getvalue']}}</td>
         <td>{{recipient['api.email.getvalue']}}</td>
       </tr>

--- a/ang/crmMailing/ViewRecipCtrl.js
+++ b/ang/crmMailing/ViewRecipCtrl.js
@@ -1,6 +1,6 @@
 (function(angular, $, _) {
 
-  angular.module('crmMailing').controller('ViewRecipCtrl', function EditRecipCtrl($scope) {
+  angular.module('crmMailing').controller('ViewRecipCtrl', function ViewRecipCtrl($scope) {
     $scope.getIncludesAsString = function(mailing) {
       var first = true;
       var names = '';

--- a/ang/crmMailing/services.js
+++ b/ang/crmMailing/services.js
@@ -435,7 +435,7 @@
             });
             result = dialogService.open('previewDialog', templates[mode], content, options);
           });
-        crmStatus({start: ts('Previewing'), success: ''}, p);
+        crmStatus({start: ts('Previewing...'), success: ''}, p);
         return result;
       },
 

--- a/ang/crmMailing/services.js
+++ b/ang/crmMailing/services.js
@@ -309,6 +309,25 @@
         });
       },
 
+      previewRecipientCount: function previewRecipientCount(mailing) {
+        // To get list of recipients, we tentatively save the mailing and
+        // get the resulting recipients -- then rollback any changes.
+        var params = angular.extend({}, mailing, mailing.recipients, {
+          name: 'placeholder', // for previewing recipients on new, incomplete mailing
+          subject: 'placeholder', // for previewing recipients on new, incomplete mailing
+          options: {force_rollback: 1},
+          'api.mailing_job.create': 1, // note: exact match to API default
+          'api.MailingRecipients.getcount': {
+            mailing_id: '$value.id'
+          }
+        });
+        delete params.recipients; // the content was merged in
+        return qApi('Mailing', 'create', params).then(function (recipResult) {
+          // changes rolled back, so we don't care about updating mailing
+          return recipResult.values[recipResult.id]['api.MailingRecipients.getcount'];
+        });
+      },
+
       // Save a (draft) mailing
       // @param mailing Object (per APIv3)
       // @return Promise

--- a/ang/crmMailing/services.js
+++ b/ang/crmMailing/services.js
@@ -97,7 +97,8 @@
   });
 
   // The crmMailingMgr service provides business logic for loading, saving, previewing, etc
-  angular.module('crmMailing').factory('crmMailingMgr', function ($q, crmApi, crmFromAddresses) {
+  angular.module('crmMailing').factory('crmMailingMgr', function ($q, crmApi, crmFromAddresses, crmQueue) {
+    var qApi = crmQueue(crmApi);
     var pickDefaultMailComponent = function pickDefaultMailComponent(type) {
       var mcs = _.where(CRM.crmMailing.headerfooterList, {
         component_type: type,
@@ -116,7 +117,7 @@
       get: function get(id) {
         var crmMailingMgr = this;
         var mailing;
-        return crmApi('Mailing', 'getsingle', {id: id})
+        return qApi('Mailing', 'getsingle', {id: id})
           .then(function (getResult) {
             mailing = getResult;
             return $q.all([
@@ -172,7 +173,7 @@
       // @return Promise
       'delete': function (mailing) {
         if (mailing.id) {
-          return crmApi('Mailing', 'delete', {id: mailing.id});
+          return qApi('Mailing', 'delete', {id: mailing.id});
         }
         else {
           var d = $q.defer();
@@ -263,7 +264,7 @@
       // @return Promise an object with "subject", "body_text", "body_html"
       preview: function preview(mailing) {
         if (CRM.crmMailing.workflowEnabled && !CRM.checkPerm('create mailings') && !CRM.checkPerm('access CiviMail')) {
-          return crmApi('Mailing', 'preview', {id: mailing.id}).then(function(result) {
+          return qApi('Mailing', 'preview', {id: mailing.id}).then(function(result) {
             return result.values;
           });
         }
@@ -276,7 +277,7 @@
             }
           });
           delete params.recipients; // the content was merged in
-          return crmApi('Mailing', 'create', params).then(function(result) {
+          return qApi('Mailing', 'create', params).then(function(result) {
             // changes rolled back, so we don't care about updating mailing
             return result.values[result.id]['api.Mailing.preview'].values;
           });
@@ -302,7 +303,7 @@
           }
         });
         delete params.recipients; // the content was merged in
-        return crmApi('Mailing', 'create', params).then(function (recipResult) {
+        return qApi('Mailing', 'create', params).then(function (recipResult) {
           // changes rolled back, so we don't care about updating mailing
           return recipResult.values[recipResult.id]['api.MailingRecipients.get'].values;
         });
@@ -330,7 +331,7 @@
 
         delete params.recipients; // the content was merged in
 
-        return crmApi('Mailing', 'create', params).then(function(result) {
+        return qApi('Mailing', 'create', params).then(function(result) {
           if (result.id && !mailing.id) {
             mailing.id = result.id;
           }  // no rollback, so update mailing.id
@@ -349,7 +350,7 @@
           approval_date: 'now',
           scheduled_date: mailing.scheduled_date ? mailing.scheduled_date : 'now'
         };
-        return crmApi('Mailing', 'submit', params)
+        return qApi('Mailing', 'submit', params)
           .then(function (result) {
             angular.extend(mailing, result.values[result.id]); // Perhaps we should reload mailing based on result?
             return crmMailingMgr._loadJobs(mailing);
@@ -382,7 +383,7 @@
 
         delete params.recipients; // the content was merged in
 
-        return crmApi('Mailing', 'create', params).then(function (result) {
+        return qApi('Mailing', 'create', params).then(function (result) {
           if (result.id && !mailing.id) {
             mailing.id = result.id;
           }  // no rollback, so update mailing.id

--- a/ang/crmUtil.js
+++ b/ang/crmUtil.js
@@ -193,6 +193,40 @@
     };
   }]);
 
+  // Wrap an async function in a queue, ensuring that independent async calls are issued in strict sequence.
+  // usage: qApi = crmQueue(crmApi); qApi(entity,action,...).then(...); qApi(entity2,action2,...).then(...);
+  // This is similar to promise-chaining, but allows chaining independent procs (without explicitly sharing promises).
+  angular.module('crmUtil').factory('crmQueue', function($q) {
+    // @param worker A function which generates promises
+    return function crmQueue(worker) {
+      var queue = [];
+      function next() {
+        var task = queue[0];
+        worker.apply(null, task.a).then(
+          function onOk(data) {
+            queue.shift();
+            task.dfr.resolve(data);
+            if (queue.length > 0) next();
+          },
+          function onErr(err) {
+            queue.shift();
+            task.dfr.reject(err);
+            if (queue.length > 0) next();
+          }
+        );
+      }
+      function enqueue() {
+        var dfr = $q.defer();
+        queue.push({a: arguments, dfr: dfr});
+        if (queue.length === 1) {
+          next();
+        }
+        return dfr.promise;
+      }
+      return enqueue;
+    };
+  });
+
   // Adapter for CRM.status which supports Angular promises (instead of jQuery promises)
   // example: crmStatus('Saving', crmApi(...)).then(function(result){...})
   angular.module('crmUtil').factory('crmStatus', function($q){

--- a/js/Common.js
+++ b/js/Common.js
@@ -1378,4 +1378,11 @@ CRM.strings = CRM.strings || {};
   CRM.checkPerm = function(perm) {
     return CRM.permissions[perm];
   };
+
+  // Round while preserving sigfigs
+  CRM.sigfig = function(n, digits) {
+    var len = ("" + n).length;
+    var scale = Math.pow(10.0, len-digits);
+    return Math.round(n / scale) * scale;
+  };
 })(jQuery, _);

--- a/tests/karma/unit/crmUtilSpec.js
+++ b/tests/karma/unit/crmUtilSpec.js
@@ -103,4 +103,46 @@ describe('crmUtil', function() {
     });
 
   });
+
+  describe('crmQueue', function() {
+    var crmQueue, $q, $rootScope, $timeout;
+
+    beforeEach(inject(function(_crmQueue_, _$rootScope_, _$q_, _$timeout_) {
+      crmQueue = _crmQueue_;
+      $rootScope = _$rootScope_;
+      $q = _$q_;
+      $timeout = _$timeout_;
+    }));
+
+    function addAfterTimeout(a, b, ms) {
+      var dfr = $q.defer();
+      $timeout(function(){
+        dfr.resolve(a+b);
+      }, ms);
+      return dfr.promise;
+    }
+
+    it('returns in order', function(done) {
+      var last = null;
+      var queuedFunc = crmQueue(addAfterTimeout);
+      // note: the queueing order is more important the timeout-durations (15ms vs 5ms)
+      queuedFunc(1, 2, 25).then(function(sum) {
+        expect(last).toBe(null);
+        expect(sum).toBe(3);
+        last = sum;
+      });
+      queuedFunc(3, 4, 5).then(function(sum){
+        expect(last).toBe(3);
+        expect(sum).toBe(7);
+        last = sum;
+        done();
+      });
+
+      for (var i = 0; i < 5; i++) {
+        $rootScope.$apply();
+        $timeout.flush(20);
+      }
+    });
+  });
+
 });

--- a/tests/karma/unit/sigfigSpec.js
+++ b/tests/karma/unit/sigfigSpec.js
@@ -1,0 +1,14 @@
+'use strict';
+
+describe('CRM.sigfig', function() {
+  it('should round while preserving significant digits', function(){
+    expect(CRM.sigfig(9, 1)).toBe(9);
+    expect(CRM.sigfig(172, 1)).toBe(200);
+    expect(CRM.sigfig(172, 2)).toBe(170);
+    expect(CRM.sigfig(176, 2)).toBe(180);
+    expect(CRM.sigfig(1492, 1)).toBe(1000);
+    expect(CRM.sigfig(1492, 2)).toBe(1500);
+    expect(CRM.sigfig(1492, 3)).toBe(1490);
+    expect(CRM.sigfig(10943, 3)).toBe(10900);
+  });
+});


### PR DESCRIPTION
The main performance problem comes from getting the name + email of
recipients via API chaning.  With these changes, we can quick(ish)ly provide the overall
count of recipients in the yellow box (without name/email).  When displaying
particular names, names+emails, we only fetch 50 (which avoids performance
and pagination issues).

This PR also strictly serializes write/preview operations to mitigate the risk of DB contention.
