### PR TITLE
CRM-16324 Scheduled jobs won't accept zero-valued parameters

### DIFF
--- a/CRM/Core/ScheduledJob.php
+++ b/CRM/Core/ScheduledJob.php
@@ -67,7 +67,7 @@ class CRM_Core_ScheduledJob {
 
       foreach ($lines as $line) {
         $pair = explode("=", $line);
-        if ($pair === false || count($pair) != 2 || trim($pair[0]) == '' || trim($pair[1]) == '') {
+        if ($pair === FALSE || count($pair) != 2 || trim($pair[0]) == '' || trim($pair[1]) == '') {
           $this->remarks[] .= 'Malformed parameters!';
           break;
         }

--- a/CRM/Core/ScheduledJob.php
+++ b/CRM/Core/ScheduledJob.php
@@ -67,7 +67,7 @@ class CRM_Core_ScheduledJob {
 
       foreach ($lines as $line) {
         $pair = explode("=", $line);
-        if (empty($pair[0]) || empty($pair[1])) {
+        if ($pair === false || count($pair) != 2 || trim($pair[0]) == '' || trim($pair[1]) == '') {
           $this->remarks[] .= 'Malformed parameters!';
           break;
         }


### PR DESCRIPTION
Calling explode("=", "param=value") should yield a 2-element array. When explode fails it returns false or the original string in a 1-element array. Finally, it should be the trimmed values that are compared to the empty-string.
