### PR TITLE
Relax composer dependency "psr/log":

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "dompdf/dompdf" : "0.6.*",
     "symfony/dependency-injection": "2.3.*",
     "symfony/event-dispatcher": "2.3.*",
-    "psr/log": "1.0.0",
+    "psr/log": "~1.0.0",
     "symfony/finder": "2.3.*",
     "totten/ca-config": "~13.02"
   },


### PR DESCRIPTION
 Dependency on the exact version is too strict -- under some circumstances
 it produces unjustifiable requirement.

Signed-off-by: Dmitry Smirnov onlyjob@member.fsf.org
