### PR TITLE
CRM-16356

### DIFF
--- a/CRM/Core/BAO/Setting.php
+++ b/CRM/Core/BAO/Setting.php
@@ -305,7 +305,7 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
     $reloadConfig = FALSE;
 
     $fields = $result = array();
-    $fieldsToGet = self::validateSettingsInput(array_flip($settingsToReturn), $fields, FALSE);
+    $fieldsToGet = self::validateSettingsInput(array_flip($settingsToReturn), $fields, FALSE, $params['filters']);
     foreach ($domains as $domainID) {
       if ($domainID != CRM_Core_Config::domainID()) {
         $reloadConfig = TRUE;
@@ -549,19 +549,20 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
    *
    * This function filters on the fields like 'version' & 'debug' that are not settings
    *
-   * @param array $params
-   *   Parameters as passed into API.
+   * @param array $names
+   *   Setting Names to validate
    * @param array $fields
    *   Empty array to be populated with fields metadata.
    * @param bool $createMode
+   *  default TRUE
+   * @param array $filters
+   *   passed to setting getFields
    *
    * @throws api_Exception
    * @return array
    *   name => value array of the fields to be set (with extraneous removed)
    */
-  public static function validateSettingsInput($params, &$fields, $createMode = TRUE) {
-    $group = CRM_Utils_Array::value('group', $params);
-
+  public static function validateSettingsInput($names, &$fields, $createMode = TRUE, $filters = NULL) {
     $ignoredParams = array(
       'version',
       'id',
@@ -581,8 +582,8 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
       'options',
       'prettyprint',
     );
-    $settingParams = array_diff_key($params, array_fill_keys($ignoredParams, TRUE));
-    $getFieldsParams = array('version' => 3);
+    $settingParams = array_diff_key($names, array_fill_keys($ignoredParams, TRUE));
+    $getFieldsParams = array('version' => 3, 'filters' => $filters);
     if (count($settingParams) == 1) {
       // ie we are only setting one field - we'll pass it into getfields for efficiency
       list($name) = array_keys($settingParams);

--- a/CRM/Core/BAO/Setting.php
+++ b/CRM/Core/BAO/Setting.php
@@ -746,6 +746,10 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
     $settingsFiles = CRM_Utils_File::findFiles($metaDataFolder, '*.setting.php');
     foreach ($settingsFiles as $file) {
       $settings = include $file;
+      $dupes = array_intersect($settingMetaData, $settings);
+      if (count($dupes)) {
+        throw new CRM_Core_Exception("Duplicate Setting Name Detected in $file. ", 0, $dupes);
+      }
       $settingMetaData = array_merge($settingMetaData, $settings);
     }
     CRM_Core_BAO_Cache::setItem($settingMetaData, 'CiviCRM setting Spec', 'All');

--- a/CRM/Upgrade/Incremental/php/FourSix.php
+++ b/CRM/Upgrade/Incremental/php/FourSix.php
@@ -56,6 +56,9 @@ class CRM_Upgrade_Incremental_php_FourSix {
    * @param null $currentVer
    */
   public function setPreUpgradeMessage(&$preUpgradeMessage, $rev, $currentVer = NULL) {
+    if (!$this->validateUniqueSettingNames()) {
+      CRM_Core_Error::fatal("Database unique constraint will fail. Rename duplicate settings table name fields before upgrading.");
+    }
   }
 
   /**
@@ -218,6 +221,21 @@ class CRM_Upgrade_Incremental_php_FourSix {
       CRM_Core_DAO::executeQuery($query);
     }
     return TRUE;
+  }
+
+  public function upgrade_4_6_3($rev) {
+    $upgrade = new CRM_Upgrade_Form();
+    $upgrade->processSQL($rev);
+  }
+
+  /**
+   * confirm that it is okay to add a unique constraint to civicrm_setting
+   * @return boolean
+   */
+  public function validateUniqueSettingNames() {
+    $query = 'select name, count(*) from civicrm_setting GROUP BY name HAVING count(*) > 1;';
+    $dao = CRM_Core_DAO::executeQuery($query);
+    return ($dao->N == 0);
   }
 
 }

--- a/CRM/Upgrade/Incremental/sql/4.5.3.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.5.3.mysql.tpl
@@ -10,6 +10,3 @@ ON DUPLICATE KEY UPDATE is_reserved = 1;
 
 -- CRM-15558
 ALTER TABLE `civicrm_mailing_bounce_type` CHANGE `name` `name` VARCHAR( 24 ) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL COMMENT 'Type of bounce';
-
--- CRM-16356
-ALTER TABLE `civicrm_setting` ADD UNIQUE (name);

--- a/CRM/Upgrade/Incremental/sql/4.5.3.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.5.3.mysql.tpl
@@ -10,3 +10,6 @@ ON DUPLICATE KEY UPDATE is_reserved = 1;
 
 -- CRM-15558
 ALTER TABLE `civicrm_mailing_bounce_type` CHANGE `name` `name` VARCHAR( 24 ) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL COMMENT 'Type of bounce';
+
+-- CRM-16356
+ALTER TABLE `civicrm_setting` ADD UNIQUE (name);

--- a/CRM/Upgrade/Incremental/sql/4.6.3.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.6.3.mysql.tpl
@@ -1,1 +1,4 @@
 {* file to handle db changes in 4.6.3 during upgrade *}
+
+-- CRM-16356
+ALTER TABLE `civicrm_setting` ADD UNIQUE (name);

--- a/xml/schema/Core/Setting.xml
+++ b/xml/schema/Core/Setting.xml
@@ -31,6 +31,7 @@
     <title>Setting Name</title>
     <type>varchar</type>
     <length>255</length>
+    <unique>true</unique>
     <comment>Unique name for setting</comment>
     <add>4.1</add>
   </field>


### PR DESCRIPTION
Add UNIQUE to name field of civicrm_setting;
Changes to update/install for same.
Enable use of api filters param to setting.get;

---
- [CRM-16356: Settings group_name cannot be specified in api.setting.create.](https://issues.civicrm.org/jira/browse/CRM-16356)
