### PR TITLE
Allow crmUiSelect to function without an attached model

### DIFF
--- a/ang/crmUi.js
+++ b/ang/crmUi.js
@@ -616,13 +616,15 @@
           // In cases where UI initiates update, there may be an extra
           // call to refreshUI, but it doesn't create a cycle.
 
-          ngModel.$render = function () {
-            $timeout(function () {
-              // ex: msg_template_id adds new item then selects it; use $timeout to ensure that
-              // new item is added before selection is made
-              element.select2('val', ngModel.$viewValue);
-            });
-          };
+          if (ngModel) {
+            ngModel.$render = function () {
+              $timeout(function () {
+                // ex: msg_template_id adds new item then selects it; use $timeout to ensure that
+                // new item is added before selection is made
+                element.select2('val', ngModel.$viewValue);
+              });
+            };
+          }
           function refreshModel() {
             var oldValue = ngModel.$viewValue, newValue = element.select2('val');
             if (oldValue != newValue) {
@@ -635,8 +637,10 @@
           function init() {
             // TODO watch select2-options
             element.select2(scope.crmUiSelect || {});
-            element.on('change', refreshModel);
-            $timeout(ngModel.$render);
+            if (ngModel) {
+              element.on('change', refreshModel);
+              $timeout(ngModel.$render);
+            }
           }
 
           init();
@@ -673,7 +677,6 @@
           }
 
           function init() {
-            // TODO watch options
             // TODO can we infer "entity" from model?
             element.crmEntityRef(scope.crmEntityref || {});
             element.on('change', refreshModel);


### PR DESCRIPTION
I noticed that the model was an optional parameter but the widget crashes without it.
