### PR TITLE
CRM-16355 : new options in schedule reminder for mutlilingual installation

### DIFF
--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -247,6 +247,33 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
       CRM_Core_PseudoConstant::nestedGroup('Mailing'), FALSE, array('class' => 'crm-select2 huge')
     );
 
+    // multilingual only options
+    $domain = new CRM_Core_DAO_Domain();
+    $domain->find(TRUE);
+    $multilingual = (bool) $domain->locales;
+    if ($multilingual) {
+      $smarty = CRM_Core_Smarty::singleton();
+      $smarty->assign('multilingual', $multilingual);
+
+      $languageFilter = array();
+      $locales = explode(CRM_Core_DAO::VALUE_SEPARATOR, $domain->locales);
+      $languages = CRM_Core_I18n::languages();
+      foreach ($locales as $locale) {
+        $languageFilter[$locale] = $languages[$locale];
+      }
+      $languageFilter['none'] = ts('Contacts with no preferred language');
+      $element = $this->add('select', 'filter_contact_language', ts('Recipients language'), $languageFilter, FALSE,
+        array('multiple' => TRUE, 'class' => 'crm-select2', 'placeholder' => TRUE));
+
+      $communicationLanguage = array();
+      $communicationLanguage[''] = ts('System default language');
+      $communicationLanguage['auto'] = ts('Follow recipient preferred language');
+      foreach ($locales as $locale) {
+        $communicationLanguage[$locale] = $languages[$locale];
+      }
+      $this->add('select', 'communication_language', ts('Communication language'), $communicationLanguage);
+    }
+
     CRM_Mailing_BAO_Mailing::commonCompose($this);
 
     $this->add('text', 'subject', ts('Subject'),
@@ -366,6 +393,9 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
       elseif (!empty($defaults['recipient_manual'])) {
         $defaults['recipient'] = 'manual';
         $defaults['recipient_manual_id'] = $defaults['recipient_manual'];
+      }
+      if ($contactLanguage = CRM_Utils_Array::value('filter_contact_language', $defaults)) {
+        $defaults['filter_contact_language'] =  explode(CRM_Core_DAO::VALUE_SEPARATOR, $contactLanguage);
       }
     }
 
@@ -491,6 +521,11 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
       $params['end_action'] = 'null';
       $params['end_date'] = 'null';
     }
+
+    // multilingual options
+    $params['filter_contact_language'] = CRM_Utils_Array::value('filter_contact_language', $values, null);
+    $params['filter_contact_language'] = implode(CRM_Core_DAO::VALUE_SEPARATOR, $params['filter_contact_language']);
+    $params['communication_language'] = CRM_Utils_Array::value('communication_language', $values, null);
 
     if ($this->_action & CRM_Core_Action::UPDATE) {
       $params['id'] = $this->_id;

--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -387,7 +387,7 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
         $defaults['recipient_manual_id'] = $defaults['recipient_manual'];
       }
       if ($contactLanguage = CRM_Utils_Array::value('filter_contact_language', $defaults)) {
-        $defaults['filter_contact_language'] =  explode(CRM_Core_DAO::VALUE_SEPARATOR, $contactLanguage);
+        $defaults['filter_contact_language'] = explode(CRM_Core_DAO::VALUE_SEPARATOR, $contactLanguage);
       }
     }
 
@@ -515,9 +515,9 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
     }
 
     // multilingual options
-    $params['filter_contact_language'] = CRM_Utils_Array::value('filter_contact_language', $values, null);
+    $params['filter_contact_language'] = CRM_Utils_Array::value('filter_contact_language', $values, NULL);
     $params['filter_contact_language'] = implode(CRM_Core_DAO::VALUE_SEPARATOR, $params['filter_contact_language']);
-    $params['communication_language'] = CRM_Utils_Array::value('communication_language', $values, null);
+    $params['communication_language'] = CRM_Utils_Array::value('communication_language', $values, NULL);
 
     if ($this->_action & CRM_Core_Action::UPDATE) {
       $params['id'] = $this->_id;

--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -261,13 +261,13 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
       foreach ($locales as $locale) {
         $languageFilter[$locale] = $languages[$locale];
       }
-      $languageFilter['none'] = ts('Contacts with no preferred language');
+      $languageFilter[CRM_Core_I18n::NONE] = ts('Contacts with no preferred language');
       $element = $this->add('select', 'filter_contact_language', ts('Recipients language'), $languageFilter, FALSE,
         array('multiple' => TRUE, 'class' => 'crm-select2', 'placeholder' => TRUE));
 
       $communicationLanguage = array();
       $communicationLanguage[''] = ts('System default language');
-      $communicationLanguage['auto'] = ts('Follow recipient preferred language');
+      $communicationLanguage[CRM_Core_I18n::AUTO] = ts('Follow recipient preferred language');
       foreach ($locales as $locale) {
         $communicationLanguage[$locale] = $languages[$locale];
       }

--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -258,10 +258,11 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
       $element = $this->add('select', 'filter_contact_language', ts('Recipients language'), $languageFilter, FALSE,
         array('multiple' => TRUE, 'class' => 'crm-select2', 'placeholder' => TRUE));
 
-      $communicationLanguage = $languages + array(
+      $communicationLanguage = array(
         '' => ts('System default language'),
         CRM_Core_I18n::AUTO => ts('Follow recipient preferred language')
       );
+      $communicationLanguage = $communicationLanguage + $languages;
       $this->add('select', 'communication_language', ts('Communication language'), $communicationLanguage);
     }
 

--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -260,7 +260,7 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
 
       $communicationLanguage = array(
         '' => ts('System default language'),
-        CRM_Core_I18n::AUTO => ts('Follow recipient preferred language')
+        CRM_Core_I18n::AUTO => ts('Follow recipient preferred language'),
       );
       $communicationLanguage = $communicationLanguage + $languages;
       $this->add('select', 'communication_language', ts('Communication language'), $communicationLanguage);

--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -248,29 +248,20 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
     );
 
     // multilingual only options
-    $domain = new CRM_Core_DAO_Domain();
-    $domain->find(TRUE);
-    $multilingual = (bool) $domain->locales;
+    $multilingual = CRM_Core_I18n::isMultilingual();
     if ($multilingual) {
       $smarty = CRM_Core_Smarty::singleton();
       $smarty->assign('multilingual', $multilingual);
 
-      $languageFilter = array();
-      $locales = explode(CRM_Core_DAO::VALUE_SEPARATOR, $domain->locales);
-      $languages = CRM_Core_I18n::languages();
-      foreach ($locales as $locale) {
-        $languageFilter[$locale] = $languages[$locale];
-      }
-      $languageFilter[CRM_Core_I18n::NONE] = ts('Contacts with no preferred language');
+      $languages = CRM_Core_I18n::languages(TRUE);
+      $languageFilter = $languages + array(CRM_Core_I18n::NONE => ts('Contacts with no preferred language'));
       $element = $this->add('select', 'filter_contact_language', ts('Recipients language'), $languageFilter, FALSE,
         array('multiple' => TRUE, 'class' => 'crm-select2', 'placeholder' => TRUE));
 
-      $communicationLanguage = array();
-      $communicationLanguage[''] = ts('System default language');
-      $communicationLanguage[CRM_Core_I18n::AUTO] = ts('Follow recipient preferred language');
-      foreach ($locales as $locale) {
-        $communicationLanguage[$locale] = $languages[$locale];
-      }
+      $communicationLanguage = $languages + array(
+        '' => ts('System default language'),
+        CRM_Core_I18n::AUTO => ts('Follow recipient preferred language')
+      );
       $this->add('select', 'communication_language', ts('Communication language'), $communicationLanguage);
     }
 

--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -1577,8 +1577,8 @@ WHERE     m.owner_membership_id IS NOT NULL AND
     }
 
     // language not in the existing language, use default
-    $locales = CRM_Core_I18n::getLocales();
-    if (!in_array($language, $locales)) {
+    $languages = CRM_Core_I18n::languages(TRUE);
+    if (!in_array($language, $languages)) {
       $language = $config->lcMessages;
     }
 

--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -815,7 +815,6 @@ LEFT JOIN civicrm_phone phone ON phone.id = lb.phone_id
       }
       $entityJoinClause .= $extraOn;
 
-
       $query = "
 SELECT reminder.id as reminderID, reminder.contact_id as contactID, reminder.entity_table as entityTable, reminder.*, e.id as entityID, e.* {$extraSelect}
 FROM  civicrm_action_log reminder
@@ -1242,7 +1241,7 @@ reminder.action_schedule_id = %1";
 
       if ($table != 'civicrm_contact e') {
         $join[] = "INNER JOIN civicrm_contact c ON c.id = {$contactField} AND c.is_deleted = 0 AND c.is_deceased = 0 ";
-      } 
+      }
 
       $multilingual = CRM_Core_I18n::isMultilingual();
       if ($multilingual && !empty($actionSchedule->filter_contact_language)) {
@@ -1251,7 +1250,7 @@ reminder.action_schedule_id = %1";
         // get language filter for the schedule
         $filter_contact_language = explode(CRM_Core_DAO::VALUE_SEPARATOR, $actionSchedule->filter_contact_language);
         $w = '';
-        if (($key = array_search(CRM_Core_I18n::NONE, $filter_contact_language)) !== false) {
+        if (($key = array_search(CRM_Core_I18n::NONE, $filter_contact_language)) !== FALSE) {
           $w .= "{$tableAlias}.preferred_language IS NULL OR {$tableAlias}.preferred_language = '' OR ";
           unset($filter_contact_language[$key]);
         }
@@ -1565,7 +1564,7 @@ WHERE     m.owner_membership_id IS NOT NULL AND
   public static function setCommunicationLanguage($communication_language, $preferred_language) {
     $config = CRM_Core_Config::singleton();
     $language = $config->lcMessages;
- 
+
     // prepare the language for the email
     if ($communication_language == CRM_Core_I18n::AUTO) {
       if (!empty($preferred_language)) {

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -320,6 +320,7 @@ class CRM_Core_DAO extends DB_DataObject {
     global $dbLocale;
     if ($i18nRewrite and $dbLocale) {
       $query = CRM_Core_I18n_Schema::rewriteQuery($query);
+//watchdog('debug', $query);
     }
 
     return parent::query($query);

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -320,7 +320,6 @@ class CRM_Core_DAO extends DB_DataObject {
     global $dbLocale;
     if ($i18nRewrite and $dbLocale) {
       $query = CRM_Core_I18n_Schema::rewriteQuery($query);
-//watchdog('debug', $query);
     }
 
     return parent::query($query);

--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -541,7 +541,7 @@ class CRM_Core_I18n {
    *   True if the domain was changed for an extension.
    */
   public function setLanguage($language) {
- 
+
     $config = CRM_Core_Config::singleton();
     if ($this->_nativegettext) {
       $locale = $language . '.utf8';

--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -541,7 +541,6 @@ class CRM_Core_I18n {
    *   True if the domain was changed for an extension.
    */
   public function setLanguage($language) {
-
  
     $config = CRM_Core_Config::singleton();
     if ($this->_nativegettext) {

--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -540,9 +540,14 @@ class CRM_Core_I18n {
    *   Language (for example 'en_US', or 'fr_CA').
    *   True if the domain was changed for an extension.
    */
-  public function setLanguage($language) {
+  public function setLocale($language) {
 
     $config = CRM_Core_Config::singleton();
+
+    // Change the language of the CMS as well, for URLs.
+    CRM_Utils_System::setUFLocale($language);
+
+    // change the gettext ressources
     if ($this->_nativegettext) {
       $locale = $language . '.utf8';
       putenv("LANG=$locale");

--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -532,16 +532,6 @@ class CRM_Core_I18n {
     return (bool) $domain->locales;
   }
 
-  /**
-   * Get the enabled locales list
-   *
-   * @return array
-   */
-  public static function getLocales() {
-    $domain = new CRM_Core_DAO_Domain();
-    $domain->find(TRUE);
-    return $domain->locales;
-  }
 
   /**
    * Change the processing language without changing the current user language

--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -543,6 +543,15 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
       $config = CRM_Core_Config::singleton();
     }
 
+    if ($mailing->language && $mailing->language != 'en_US') {
+      // Since we are called from cron, CiviCRM runs in the default language,
+      // which causes issues for multi-lingual environments.
+      // NB: we do not switch back once the mailing is finished,
+      // assuming that CiviCRM stops running after the mail run.
+      $i18n = CRM_Core_I18n::singleton();
+      $i18n->setLocale($mailing->language);
+    }
+
     $job_date = CRM_Utils_Date::isoToMysql($this->scheduled_date);
     $fields = array();
 

--- a/CRM/Upgrade/Incremental/sql/4.7.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.7.alpha1.mysql.tpl
@@ -1,0 +1,6 @@
+
+-- Add new columns for multilingual purpose
+ALTER TABLE `civicrm_action_schedule` ADD COLUMN `filter_contact_language` varchar(128) DEFAULT NULL COMMENT 'Used for multilingual installation';
+ALTER TABLE `civicrm_action_schedule` ADD COLUMN `communication_language` varchar(8) DEFAULT NULL COMMENT 'Used for multilingual installation';
+
+

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1342,7 +1342,7 @@ class CRM_Utils_System {
   }
 
   /**
-   * Get the locale set in the hosting CMS.
+   * Get the locale of the hosting CMS.
    *
    * @return string
    *   The used locale or null for none.
@@ -1350,6 +1350,23 @@ class CRM_Utils_System {
   public static function getUFLocale() {
     $config = CRM_Core_Config::singleton();
     return $config->userSystem->getUFLocale();
+  }
+
+  /**
+   * Set the locale of the hosting CMS.
+   *
+   * For example, a mailing will want to change the CMS language so that
+   * URLs are in the correct language (such as the Drupal language prefix).
+   *
+   * @param String $civicrm_language
+   *   An array of parameters (see CRM_Utils_System::docURL2 method for names)
+   *
+   * @return bool
+   *   Returns whether the locale was successfully changed.
+   */
+  public static function setUFLocale($civicrm_language) {
+    $config = CRM_Core_Config::singleton();
+    return $config->userSystem->setUFLocale($civicrm_language);
   }
 
   /**

--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -430,6 +430,29 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
   }
 
   /**
+   * @inheritDoc
+   */
+  public function setUFLocale($civicrm_language) {
+    global $language;
+
+    $langcode = substr($civicrm_language, 0, 2);
+    $languages = language_list();
+
+    if (isset($languages[$langcode])) {
+      $language = $languages[$langcode];
+
+      // Config must be re-initialized to reset the base URL
+      // otherwise links will have the wrong language prefix/domain.
+      $config = CRM_Core_Config::singleton();
+      $config->free();
+
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  /**
    * Perform any post login activities required by the UF -
    * e.g. for drupal: records a watchdog message about the new session, saves the login timestamp,
    * calls hook_user op 'login' and generates a new session.

--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -474,6 +474,14 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
   /**
    * @inheritDoc
    */
+  public function setUFLocale($civicrm_language) {
+    // TODO
+    return TRUE;
+  }
+
+  /**
+   * @inheritDoc
+   */
   public function getVersion() {
     if (class_exists('JVersion')) {
       $version = new JVersion();

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -326,6 +326,14 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
   }
 
   /**
+   * @inheritDoc
+   */
+  public function setUFLocale($civicrm_language) {
+    // TODO (probably not possible with WPML?)
+    return TRUE;
+  }
+
+  /**
    * Load wordpress bootstrap.
    *
    * @param string $name

--- a/templates/CRM/Admin/Form/ScheduleReminders.tpl
+++ b/templates/CRM/Admin/Form/ScheduleReminders.tpl
@@ -98,6 +98,16 @@
       <td class="label">{$form.mode.label}</td>
       <td>{$form.mode.html}</td>
     </tr>
+    {if $multilingual}
+    <tr class="crm-scheduleReminder-form-block-filter-contact-language">
+      <td class="label">{$form.filter_contact_language.label}</td>
+      <td>{$form.filter_contact_language.html} {help id="filter_contact_language"}</td>
+    </tr>
+    <tr class="crm-scheduleReminder-form-block-communication-language">
+      <td class="label">{$form.communication_language.label}</td>
+      <td>{$form.communication_language.html} {help id="communication_language"}</td>
+    </tr>
+    {/if}
     <tr class="crm-scheduleReminder-form-block-active">
       <td class="label"></td>
       <td>{$form.is_active.html}&nbsp;{$form.is_active.label}</td>

--- a/templates/CRM/Admin/Page/ScheduleReminders.hlp
+++ b/templates/CRM/Admin/Page/ScheduleReminders.hlp
@@ -41,3 +41,12 @@
 {htxt id="id-from_name_email"}
   {ts}You can set the FROM name and email address for this reminder in these fields. If you leave these fields blank, the default FROM name and email address for your site will be used (Administer > Communications > FROM Email Addresses).{/ts}
 {/htxt}
+
+{htxt id="filter_contact_language"}
+  {ts}You can limt the recipient of the reminder to contact with the specified preferred language. You can also choose to add contacts that have no preferred language defined.{/ts}
+{/htxt}
+
+{htxt id="communication_language"}
+  {ts}This is the language of the communication. If there are template translation or tokens, it will follow this preferrence. By default, it follows the system default language.{/ts}
+{/htxt}
+

--- a/templates/CRM/Admin/Page/ScheduleReminders.hlp
+++ b/templates/CRM/Admin/Page/ScheduleReminders.hlp
@@ -43,10 +43,10 @@
 {/htxt}
 
 {htxt id="filter_contact_language"}
-  {ts}You can limt the recipient of the reminder to contact with the specified preferred language. You can also choose to add contacts that have no preferred language defined.{/ts}
+  {ts}You can limit the recipient of the reminder to contacts with the specified preferred language. You can also choose to add contacts that have no preferred language defined.{/ts}
 {/htxt}
 
 {htxt id="communication_language"}
-  {ts}This is the language of the communication. If there are template translation or tokens, it will follow this preferrence. By default, it follows the system default language.{/ts}
+  {ts}This is the communication language. If there are template translation or tokens, they will be localized accordingly. By default, the system default language will be used.{/ts}
 {/htxt}
 

--- a/xml/schema/Core/ActionSchedule.xml
+++ b/xml/schema/Core/ActionSchedule.xml
@@ -332,4 +332,18 @@
     <comment>Used for repeating entity</comment>
     <add>4.6</add>
   </field>
+  <field>
+    <name>filter_contact_language</name>
+    <type>varchar</type>
+    <length>128</length>
+    <comment>Used for multilingual installation</comment>
+    <add>4.7</add>
+  </field>
+  <field>
+    <name>communication_language</name>
+    <type>varchar</type>
+    <length>8</length>
+    <comment>Used for multilingual installation</comment>
+    <add>4.7</add>
+  </field>
 </table>


### PR DESCRIPTION
Add 2 options in multilingual installation for schedule reminders:
- filter the recipients of the message based on the language
- set the language of the message - either static or dynamic based on the preferred language

---
- [CRM-16355: Reminders in multilingual sites: allow to define the language of the sending](https://issues.civicrm.org/jira/browse/CRM-16355)
