### PR TITLE
CRM-16408 WordPress Installer changes WIP

### DIFF
--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -380,7 +380,11 @@ class CRM_Core_Config extends CRM_Core_Config_Variables {
       echo 'You need to define CIVICRM_TEMPLATE_COMPILEDIR in civicrm.settings.php';
       exit();
     }
-
+	  $upload_dir    = wp_upload_dir();
+	  $settingsDir = $upload_dir[basedir] . DIRECTORY_SEPARATOR . 'civicrm';
+	  if (defined('CIVICRM_SETTINGS_PATH')) {
+		  CRM_Utils_File::restrictAccessSettings( $settingsDir );
+	  }
     $this->_initDAO();
 
     if (defined('CIVICRM_UF')) {

--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -381,7 +381,7 @@ class CRM_Core_Config extends CRM_Core_Config_Variables {
       exit();
     }
 	  $upload_dir    = wp_upload_dir();
-	  $settingsDir = $upload_dir[basedir] . DIRECTORY_SEPARATOR . 'civicrm';
+	  $settingsDir = $upload_dir[basedir] . DIRECTORY_SEPARATOR . 'civicrm' . DIRECTORY_SEPARATOR;
 	  if (defined('CIVICRM_SETTINGS_PATH')) {
 		  CRM_Utils_File::restrictAccessSettings( $settingsDir );
 	  }

--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -463,6 +463,33 @@ HTACCESS;
       }
     }
   }
+	/**
+	 * Restrict access to civicrm.settings.php (by planting there a restrictive .htaccess file)
+	 *
+	 * @param string $dir
+	 *   The directory to be secured.
+	 * @param bool $overwrite
+	 */
+	public static function restrictAccessSettings($dir, $overwrite = FALSE) {
+		// note: empty value for $dir can play havoc, since that might result in putting '.htaccess' to root dir
+		// of site, causing site to stop functioning.
+		// FIXME: we should do more checks here -
+		if (!empty($dir) && is_dir($dir)) {
+			$htaccess = <<<HTACCESS
+<Files "civicrm.settings.php">
+  Order allow,deny
+  Deny from all
+</Files>
+
+HTACCESS;
+			$file = $dir . '.htaccess';
+			if ($overwrite || !file_exists($file)) {
+				if (file_put_contents($file, $htaccess) === FALSE) {
+					CRM_Core_Error::movedSiteError($file);
+				}
+			}
+		}
+	}
 
   /**
    * Restrict remote users from browsing the given directory.

--- a/install/civicrm.php
+++ b/install/civicrm.php
@@ -89,7 +89,9 @@ function civicrm_main(&$config) {
     );
   }
   elseif ($installType == 'wordpress') {
-    civicrm_setup(WP_PLUGIN_DIR . DIRECTORY_SEPARATOR . 'files');
+	  $upload_dir    = wp_upload_dir();
+	  $files_dirname = $upload_dir[basedir];
+    civicrm_setup($files_dirname);
   }
 
   $dsn = "mysql://{$config['mysql']['username']}:{$config['mysql']['password']}@{$config['mysql']['server']}/{$config['mysql']['database']}?new_link=true";
@@ -119,7 +121,7 @@ function civicrm_main(&$config) {
     $configFile = $cmsPath . DIRECTORY_SEPARATOR . 'sites' . DIRECTORY_SEPARATOR . $siteDir . DIRECTORY_SEPARATOR . 'civicrm.settings.php';
   }
   elseif ($installType == 'wordpress') {
-    $configFile = $cmsPath . DIRECTORY_SEPARATOR . 'civicrm.settings.php';
+    $configFile = $files_dirname . DIRECTORY_SEPARATOR . 'civicrm'. DIRECTORY_SEPARATOR . 'civicrm.settings.php';
   }
 
   $string = civicrm_config($config);

--- a/install/index.php
+++ b/install/index.php
@@ -167,8 +167,11 @@ elseif ($installType == 'wordpress') {
   $cmsPath = WP_PLUGIN_DIR . DIRECTORY_SEPARATOR . 'civicrm';
 	//$content_dir = WP_CONTENT_DIR;
 	//$settings_dir = $content_dir . DIRECTORY_SEPARATOR . 'civicrm' . 'settings';
-	//$upload_dir      = wp_upload_dir();
-	//$files_dirname = $upload_dir['basedir'] . DIRECTORY_SEPARATOR . 'civicrm';
+	$upload_dir      = wp_upload_dir();
+	$files_dirname = $upload_dir['basedir'] . DIRECTORY_SEPARATOR . 'civicrm';
+  /*$alreadyInstalled = file_exists($files_dirname . CIVICRM_DIRECTORY_SEPARATOR .
+    'civicrm.settings.php'
+    );*/
   $alreadyInstalled = file_exists($cmsPath . CIVICRM_DIRECTORY_SEPARATOR .
     'civicrm.settings.php'
   );
@@ -485,16 +488,16 @@ class InstallRequirements {
     }
     elseif ($installType == 'wordpress') {
 	    // make sure that we can write to plugins/civicrm  and uploads/civicrm/
-	    $content_dir   = WP_CONTENT_DIR;
-	    $settings_dir  = $content_dir . DIRECTORY_SEPARATOR . 'civicrm' . DIRECTORY_SEPARATOR . 'settings';
+	    //$content_dir   = WP_CONTENT_DIR;
+	    //$settings_dir  = $content_dir . DIRECTORY_SEPARATOR . 'civicrm' . DIRECTORY_SEPARATOR . 'settings';
 	    $upload_dir    = wp_upload_dir();
-	    $files_dirname = $content_dir . DIRECTORY_SEPARATOR . 'civicrm';
+	    $files_dirname = $upload_dir[basedir] . DIRECTORY_SEPARATOR . 'civicrm';
 	    if ( ! file_exists( $files_dirname ) ) {
 		    wp_mkdir_p( $files_dirname );
 	    }
-	    if ( ! file_exists( $settings_dir ) ) {
+	    /*if ( ! file_exists( $settings_dir ) ) {
 		    wp_mkdir_p( $settings_dir );
-	    }
+	    }*/
 	    $writableDirectories = array( $files_dirname, $cmsPath );
 	    //$writableDirectories = array(WP_PLUGIN_DIR . DIRECTORY_SEPARATOR . 'files', $cmsPath);
 	    //TODO: Sample Code to download packages currently testing with download of full zip

--- a/install/index.php
+++ b/install/index.php
@@ -78,13 +78,17 @@ CRM_Core_ClassLoader::singleton()->register();
 // Load civicrm database config
 if (isset($_REQUEST['mysql'])) {
   $databaseConfig = $_REQUEST['mysql'];
-}
-else {
+} else if ( $installType == 'wordpress' ) {
+	//WP Database Data
+	$database     = DB_NAME;
+	$username     = DB_USER;
+	$password     = DB_PASSWORD;
+	$server       = DB_HOST;
   $databaseConfig = array(
-    "server" => "localhost",
-    "username" => "civicrm",
-    "password" => "",
-    "database" => "civicrm",
+	  "server"   => $server,
+	  "username" => $username,
+	  "password" => $password,
+	  "database" => $database,
   );
 }
 
@@ -161,6 +165,10 @@ if ($installType == 'drupal') {
 }
 elseif ($installType == 'wordpress') {
   $cmsPath = WP_PLUGIN_DIR . DIRECTORY_SEPARATOR . 'civicrm';
+	//$content_dir = WP_CONTENT_DIR;
+	//$settings_dir = $content_dir . DIRECTORY_SEPARATOR . 'civicrm' . 'settings';
+	//$upload_dir      = wp_upload_dir();
+	//$files_dirname = $upload_dir['basedir'] . DIRECTORY_SEPARATOR . 'civicrm';
   $alreadyInstalled = file_exists($cmsPath . CIVICRM_DIRECTORY_SEPARATOR .
     'civicrm.settings.php'
   );
@@ -234,6 +242,7 @@ if ($installType == 'drupal') {
 }
 elseif ($installType == 'wordpress') {
   //HACK for now
+	//TODO: what does this actually do?
   $civicrm_version['cms'] = 'WordPress';
 
   // Ensure that they have downloaded the correct version of CiviCRM
@@ -475,8 +484,30 @@ class InstallRequirements {
       );
     }
     elseif ($installType == 'wordpress') {
-      // make sure that we can write to plugins/civicrm  and plugins/files/
-      $writableDirectories = array(WP_PLUGIN_DIR . DIRECTORY_SEPARATOR . 'files', $cmsPath);
+	    // make sure that we can write to plugins/civicrm  and uploads/civicrm/
+	    $content_dir   = WP_CONTENT_DIR;
+	    $settings_dir  = $content_dir . DIRECTORY_SEPARATOR . 'civicrm' . DIRECTORY_SEPARATOR . 'settings';
+	    $upload_dir    = wp_upload_dir();
+	    $files_dirname = $content_dir . DIRECTORY_SEPARATOR . 'civicrm';
+	    if ( ! file_exists( $files_dirname ) ) {
+		    wp_mkdir_p( $files_dirname );
+	    }
+	    if ( ! file_exists( $settings_dir ) ) {
+		    wp_mkdir_p( $settings_dir );
+	    }
+	    $writableDirectories = array( $files_dirname, $cmsPath );
+	    //$writableDirectories = array(WP_PLUGIN_DIR . DIRECTORY_SEPARATOR . 'files', $cmsPath);
+	    //TODO: Sample Code to download packages currently testing with download of full zip
+	    /*
+	    $dlcontent_dir = WP_CONTENT_DIR;
+	    $dlfiles_dirname = $dlcontent_dir . DIRECTORY_SEPARATOR . 'civicrm';
+	    $wpcv_url = "http://sourceforge.net/projects/civicrm/files/civicrm-stable/4.6.2/civicrm-4.6.2-wordpress.zip";
+	    $permfile = $dlfiles_dirname . DIRECTORY_SEPARATOR . 'civicrm.zip';
+	    $tmpfile = download_url( $wpcv_url, $timeout = 300 );
+	    copy( $tmpfile, $permfile );
+	    unlink( $tmpfile ); // must unlink afterwards
+	    */
+
     }
 
     foreach ($writableDirectories as $dir) {


### PR DESCRIPTION
Changes to civicrm-core to support new file locations for WordPress, add .htaccess to protect civicrm.settings.php in new location, on install page populate credentials from existing WP database.  Commented out download section used as POC currently hard coded to the full zip file for testing, will need to be updated for proper package later.

Still need to do wp-cli version, make certain wp-cli will be compatible with new and old locations.  This will be part of larger refactoring of the install process.

---
- [CRM-16408: Installer rewrite](https://issues.civicrm.org/jira/browse/CRM-16408)
