### PR TITLE
CRM-15375 - make the setup create metadata for I18n - used in the popup

### DIFF
--- a/CRM/Core/CodeGen/I18n.php
+++ b/CRM/Core/CodeGen/I18n.php
@@ -25,9 +25,11 @@ class CRM_Core_CodeGen_I18n extends CRM_Core_CodeGen_BaseTask {
     echo "Generating CRM_Core_I18n_SchemaStructure...\n";
     $columns = array();
     $indices = array();
+    $widgets = array();
     foreach ($this->tables as $table) {
       if ($table['localizable']) {
         $columns[$table['name']] = array();
+        $widgets[$table['name']] = array();
       }
       else {
         continue;
@@ -35,6 +37,7 @@ class CRM_Core_CodeGen_I18n extends CRM_Core_CodeGen_BaseTask {
       foreach ($table['fields'] as $field) {
         if ($field['localizable']) {
           $columns[$table['name']][$field['name']] = $field['sqlType'];
+          $widgets[$table['name']][$field['name']] = $field['widget'];
         }
       }
       if (isset($table['index'])) {
@@ -50,6 +53,7 @@ class CRM_Core_CodeGen_I18n extends CRM_Core_CodeGen_BaseTask {
 
     $template->assign('columns', $columns);
     $template->assign('indices', $indices);
+    $template->assign('widgets', $widgets);
 
     $template->run('schema_structure.tpl', $this->config->phpCodePath . "/CRM/Core/I18n/SchemaStructure.php");
   }

--- a/CRM/Core/CodeGen/Specification.php
+++ b/CRM/Core/CodeGen/Specification.php
@@ -410,7 +410,7 @@ class CRM_Core_CodeGen_Specification {
         'labelColumn',
         // Non-translated machine name for programmatic lookup. Defaults to 'name' if that column exists
         'nameColumn',
-		// Where clause snippet (will be joined to the rest of the query with AND operator)
+	// Where clause snippet (will be joined to the rest of the query with AND operator)
         'condition',
         // callback funtion incase of static arrays
         'callback',

--- a/CRM/Core/CodeGen/Specification.php
+++ b/CRM/Core/CodeGen/Specification.php
@@ -410,7 +410,7 @@ class CRM_Core_CodeGen_Specification {
         'labelColumn',
         // Non-translated machine name for programmatic lookup. Defaults to 'name' if that column exists
         'nameColumn',
-	// Where clause snippet (will be joined to the rest of the query with AND operator)
+        // Where clause snippet (will be joined to the rest of the query with AND operator)
         'condition',
         // callback funtion incase of static arrays
         'callback',

--- a/CRM/Core/CodeGen/Specification.php
+++ b/CRM/Core/CodeGen/Specification.php
@@ -381,6 +381,21 @@ class CRM_Core_CodeGen_Specification {
         }
       }
     }
+
+    // in multilingual context popup, we need extra information to create appropriate widget
+    if ($fieldXML->localizable) {
+      if (isset($fieldXML->html)) {
+        $field['widget'] = (array) $fieldXML->html;
+      }
+      else {
+        // default
+        $field['widget'] = array('type' => 'Text');
+      }
+      if (isset($fieldXML->required)) {
+        $field['widget']['required'] = $this->value('required', $fieldXML);
+      }
+    }
+
     $field['pseudoconstant'] = $this->value('pseudoconstant', $fieldXML);
     if (!empty($field['pseudoconstant'])) {
       //ok this is a bit long-winded but it gets there & is consistent with above approach
@@ -395,7 +410,7 @@ class CRM_Core_CodeGen_Specification {
         'labelColumn',
         // Non-translated machine name for programmatic lookup. Defaults to 'name' if that column exists
         'nameColumn',
-        // Where clause snippet (will be joined to the rest of the query with AND operator)
+		// Where clause snippet (will be joined to the rest of the query with AND operator)
         'condition',
         // callback funtion incase of static arrays
         'callback',

--- a/CRM/Core/I18n/Form.php
+++ b/CRM/Core/I18n/Form.php
@@ -66,16 +66,15 @@ class CRM_Core_I18n_Form extends CRM_Core_Form {
     $widget = $widgets[$table][$field];
 
     // attributes
-    $attributes = array('css' => '');
+    $attributes = array('class' => '');
     if (isset($widget['rows'])) {
       $attributes['rows'] = $widget['rows'];
     }
     if (isset($widget['cols'])) {
       $attributes['cols'] = $widget['cols'];
     }
-    // FIXME: should have this
     $required = !empty($widget['required']);
-    
+
     $languages = CRM_Core_I18n::languages(TRUE);
     foreach ($this->_locales as $locale) {
       $name = "{$field}_{$locale}";
@@ -83,8 +82,8 @@ class CRM_Core_I18n_Form extends CRM_Core_Form {
         $attributes['class'] .= ' default-lang';
       }
       if ($widget['type'] == 'RichTextEditor') {
-        $attributes['click_wysiwyg'] = TRUE;
-        $this->addWysiwyg($name, $languages[$locale], $attributes, $required);
+        $attributes['class'] = ' collapsed';
+        $this->add('wysiwyg', $name, $languages[$locale], $attributes, $required);
       }
       else {
         $this->add($widget['type'], $name, $languages[$locale], $attributes, $required);

--- a/CRM/Core/I18n/Form.php
+++ b/CRM/Core/I18n/Form.php
@@ -82,7 +82,7 @@ class CRM_Core_I18n_Form extends CRM_Core_Form {
         $attributes['class'] .= ' default-lang';
       }
       if ($widget['type'] == 'RichTextEditor') {
-        $attributes['class'] = ' collapsed';
+        $attributes['class'] .= ' collapsed';
         $this->add('wysiwyg', $name, $languages[$locale], $attributes, $required);
       }
       else {

--- a/CRM/Core/I18n/Form.php
+++ b/CRM/Core/I18n/Form.php
@@ -83,11 +83,9 @@ class CRM_Core_I18n_Form extends CRM_Core_Form {
       }
       if ($widget['type'] == 'RichTextEditor') {
         $attributes['class'] .= ' collapsed';
-        $this->add('wysiwyg', $name, $languages[$locale], $attributes, $required);
+        $widget['type'] = 'wysiwyg';
       }
-      else {
-        $this->add($widget['type'], $name, $languages[$locale], $attributes, $required);
-      }
+      $this->add($widget['type'], $name, $languages[$locale], $attributes, $required);
 
       $this->_defaults[$name] = $dao->$locale;
     }

--- a/CRM/Core/I18n/Form.php
+++ b/CRM/Core/I18n/Form.php
@@ -61,13 +61,36 @@ class CRM_Core_I18n_Form extends CRM_Core_Form {
     $dao->query($query, FALSE);
     $dao->fetch();
 
-    // we want TEXTAREAs for long fields and INPUTs for short ones
-    $this->_structure[$table][$field] == 'text' ? $type = 'textarea' : $type = 'text';
+    // get html type and attributes for this field
+    $widgets = CRM_Core_I18n_SchemaStructure::widgets();
+    $widget = $widgets[$table][$field];
 
+    // attributes
+    $attributes = array('css' => '');
+    if (isset($widget['rows'])) {
+      $attributes['rows'] = $widget['rows'];
+    }
+    if (isset($widget['cols'])) {
+      $attributes['cols'] = $widget['cols'];
+    }
+    // FIXME: should have this
+    $required = !empty($widget['required']);
+    
     $languages = CRM_Core_I18n::languages(TRUE);
     foreach ($this->_locales as $locale) {
-      $this->addElement($type, "{$field}_{$locale}", $languages[$locale], array('class' => 'huge huge12' . ($locale == $tsLocale ? ' default-lang' : '')));
-      $this->_defaults["{$field}_{$locale}"] = $dao->$locale;
+      $name = "{$field}_{$locale}";
+      if ($locale == $tsLocale) {
+        $attributes['class'] .= ' default-lang';
+      }
+      if ($widget['type'] == 'RichTextEditor') {
+        $attributes['click_wysiwyg'] = TRUE;
+        $this->addWysiwyg($name, $languages[$locale], $attributes, $required);
+      }
+      else {
+        $this->add($widget['type'], $name, $languages[$locale], $attributes, $required);
+      }
+
+      $this->_defaults[$name] = $dao->$locale;
     }
 
     $this->addDefaultButtons(ts('Save'), 'next', NULL);

--- a/xml/schema/Contribute/ContributionPage.xml
+++ b/xml/schema/Contribute/ContributionPage.xml
@@ -33,7 +33,7 @@
     <title>Contribution Page Introduction Text</title>
     <type>text</type>
     <html>
-      <type>TextArea</type>
+      <type>RichTextEditor</type>
       <rows>6</rows>
       <cols>50</cols>
     </html>
@@ -249,7 +249,7 @@
     <title>Thank-you Text</title>
     <type>text</type>
     <html>
-      <type>TextArea</type>
+      <type>RichTextEditor</type>
       <rows>8</rows>
       <cols>60</cols>
     </html>
@@ -262,7 +262,7 @@
     <title>Thank-you Footer</title>
     <type>text</type>
     <html>
-      <type>TextArea</type>
+      <type>RichTextEditor</type>
       <rows>8</rows>
       <cols>60</cols>
     </html>
@@ -357,7 +357,7 @@
     <title>Footer Text</title>
     <type>text</type>
     <html>
-      <type>TextArea</type>
+      <type>RichTextEditor</type>
       <rows>6</rows>
       <cols>50</cols>
     </html>

--- a/xml/templates/schema_structure.tpl
+++ b/xml/templates/schema_structure.tpl
@@ -84,4 +84,24 @@ class CRM_Core_I18n_SchemaStructure
         {rdelim}
         return $result;
     {rdelim}
+    static function &widgets()
+    {ldelim}
+        static $result = null;
+        if (!$result) {ldelim}
+          $result = array(
+            {foreach from=$widgets key=table item=columns}
+              '{$table}' => array(
+                {foreach from=$columns key=column item=widget}
+                  '{$column}' => array(
+                    {foreach from=$widget key=name item=value}
+                      '{$name}' => "{$value}",
+                    {/foreach}
+                  ),
+                {/foreach}
+              ),
+            {/foreach}
+          );
+        {rdelim}
+        return $result;
+    {rdelim}
 {rdelim}


### PR DESCRIPTION
The setup.sh generate new widget info in CRM/Core/I18n/SchemaStructure.php
It can then be used to generate appropriate html in the I18n translation popup.

There are still a lot of field with the type TextArea that needs to be converted to RichTextEditor in the xml schema definition
