### PR TITLE
CRM-16427 - Advanced logging: ignore changes to civicrm_group refresh_date field

### DIFF
--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -49,7 +49,7 @@ class CRM_Logging_Schema {
   //CRM-13028 / NYSS-6933 - table => array (cols) - to be excluded from the update statement
   private $exceptions = array(
     'civicrm_job' => array('last_run'),
-    'civicrm_group' => array('cache_date'),
+    'civicrm_group' => array('cache_date', 'refresh_date'),
   );
 
   /**


### PR DESCRIPTION
CRM-16427 - Advanced logging: ignore changes to civicrm_group refresh_date field
https://issues.civicrm.org/jira/browse/CRM-16427
