### PR TITLE
CRM-16389 - Absolute URLs in HTML Profile Snippets

### DIFF
--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -505,6 +505,9 @@ class CRM_Core_Config extends CRM_Core_Config_Variables {
         CRM_Utils_System::mapConfigToSSL();
       }
       $rrb = parse_url($this->userFrameworkResourceURL);
+      if(array_key_exists('port', $rrb)) {
+        $rrb['host'] .= ':' . $rrb['port'];
+      }
       // don't use absolute path if resources are stored on a different server
       // CRM-4642
       $this->resourceBase = $this->userFrameworkResourceURL;

--- a/CRM/UF/Page/Group.php
+++ b/CRM/UF/Page/Group.php
@@ -255,9 +255,27 @@ class CRM_UF_Page_Group extends CRM_Core_Page {
       $profile = str_replace('/wp-admin/admin.php', '/' . $wpbase . '/', $profile);
     }
 
-    // add header files
-    CRM_Core_Resources::singleton()->addCoreResources('html-header');
-    $profile = CRM_Core_Region::instance('html-header')->render('', FALSE) . $profile;
+    // Create a custom CRM_Extension_System object that contains a 
+    // CRM_Extension_Mapper configured to produce URLs with absolute 
+    // links so the js and css files have absolute paths.
+    $sys = CRM_Extension_System::singleton();
+    $ext_mapper = new CRM_Extension_Mapper(
+      $sys->getFullContainer(),
+      $sys->getCache(),
+      'mapper',
+      NULL,
+      $config->userFrameworkBaseURL
+    );
+    $cache = new CRM_Utils_Cache_SqlGroup(array(
+      'group' => 'js-strings',
+      'prefetch' => FALSE,
+    ));
+    $res = new CRM_Core_Resources($ext_mapper, $cache, 'resCacheCode');
+
+    // Create our own custom region call html-header-profile so we don't
+    // conflict with the html-header in use by the site.
+    $res->addCoreResources('html-header-profile');
+    $profile = CRM_Core_Region::instance('html-header-profile')->render('', FALSE) . $profile;
 
     $this->assign('profile', htmlentities($profile, ENT_NOQUOTES, 'UTF-8'));
     //get the title of uf group


### PR DESCRIPTION
Ensure profile html snippets have absolute URL

---
- [CRM-16389: html snippet references to scripts and css files does not reference CIVICRM_UF_BASEURL](https://issues.civicrm.org/jira/browse/CRM-16389)
