### PR TITLE
CRM-16307 - Fix civicrm_navigation permission for A/B Test items.

### DIFF
--- a/CRM/Upgrade/Incremental/sql/4.6.3.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.6.3.mysql.tpl
@@ -1,1 +1,5 @@
 {* file to handle db changes in 4.6.3 during upgrade *}
+-- CRM-16307 fix CRM-15578 typo - Require access CiviMail permission for A/B Testing feature
+UPDATE civicrm_navigation
+SET permission = 'access CiviMail', permission_operator = ''
+WHERE name = 'New A/B Test' OR name = 'Manage A/B Tests';


### PR DESCRIPTION
---
- CRM-16307: A/B test menu items don't appear on upgrade to 4.6
  https://issues.civicrm.org/jira/browse/CRM-16307
