### PR TITLE
CRM-16433 fix - "User and User Admin Only" groups should NOT be included...

### DIFF
--- a/CRM/ACL/API.php
+++ b/CRM/ACL/API.php
@@ -204,6 +204,7 @@ class CRM_ACL_API {
   ) {
 
     static $cache = array();
+    $groups = array();
     //@todo this is pretty hacky!!!
     //adding a way for unit tests to flush the cache
     if ($flush) {


### PR DESCRIPTION
... in Contribution Receipt Profile Field Group(s) output

https://issues.civicrm.org/jira/browse/CRM-16433
