### PR TITLE
Fix api.File.delete to actually delete the file

### DIFF
--- a/api/v3/File.php
+++ b/api/v3/File.php
@@ -133,19 +133,5 @@ function civicrm_api3_file_delete($params) {
 
   civicrm_api3_verify_mandatory($params, NULL, array('id'));
 
-  $check = FALSE;
-
-  $entityFileDAO = new CRM_Core_DAO_EntityFile();
-  $entityFileDAO->file_id = $params['id'];
-  if ($entityFileDAO->find()) {
-    $check = $entityFileDAO->delete();
-  }
-
-  $fileDAO = new CRM_Core_DAO_File();
-  $fileDAO->id = $params['id'];
-  if ($fileDAO->find(TRUE)) {
-    $check = $fileDAO->delete();
-  }
-
-  return $check ? NULL : civicrm_api3_create_error('Error while deleting a file.');
+  CRM_Core_BAO_File::deleteEntityFile('*', $params['id']);
 }


### PR DESCRIPTION
The previous implementation used entityFile and File DAOs to remove the
DB entries, but didn't remove the actual file.

Use CRM_Core_BAO_File::deleteEntityFile() instead -- which is not only
much simpler, but also appears to actually Do The Right Thing (TM)...
