### PR TITLE
CRM-15228 - replace bogus DTEND with DURATION property in activity ic…

### DIFF
--- a/templates/CRM/Activity/Calendar/ICal.tpl
+++ b/templates/CRM/Activity/Calendar/ICal.tpl
@@ -34,7 +34,7 @@ SUMMARY:{$activity->subject|crmICalText}
 CALSCALE:GREGORIAN
 DTSTAMP;VALUE=DATE-TIME:{$smarty.now|date_format:'%Y-%m-%d %H:%M:%S'|crmICalDate}
 DTSTART;VALUE=DATE-TIME:{$activity->activity_date_time|crmICalDate}
-DTEND;VALUE=DATE-TIME:{$activity->activity_date_time|crmICalDate}
+DURATION:PT{$activity->duration}M
 {if $activity->location}
 LOCATION:{$activity->location|crmICalText}
 {/if}


### PR DESCRIPTION
…al output.

---
- CRM-15228: Activity End Time same as start Time in iCal invitation
  https://issues.civicrm.org/jira/browse/CRM-15228
