### PR TITLE
CRM-16417 stop removing failed payments

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -858,6 +858,21 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = civicrm_contribution.conta
   }
 
   /**
+   * React to a financial transaction (payment) failure.
+   *
+   * Prior to CRM-16417 these were simply removed from the database but it has been agreed that seeing attempted
+   * payments is important for forensic and outreach reasons.
+   *
+   * This function updates the financial transaction records to failed.
+   *
+   * @todo in principle we also think it makes sense to add an activity - this part would be a second step as
+   * the first change is likely to go into the LTS.
+   */
+  public static function failPayment($contributionID, $message) {
+
+  }
+
+  /**
    * Check if there is a contribution with the same trxn_id or invoice_id.
    *
    * @param array $input

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 
 /**

--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -26,6 +26,7 @@
  */
 
 use Civi\Payment\System;
+use Civi\Payment\Exception\PaymentProcessorException;
 
 /**
  * Class CRM_Core_Payment.
@@ -481,25 +482,45 @@ abstract class CRM_Core_Payment {
    * The function ensures an exception is thrown & moves some of this logic out of the form layer and makes the forms
    * more agnostic.
    *
+   * Payment processors should set contribution_status_id. This function adds some historical defaults ie. the
+   * assumption that if a 'doDirectPayment' processors comes back it completed the transaction & in fact
+   * doTransferCheckout would not traditionally come back.
+   *
+   * doDirectPayment does not do an immediate payment for Authorize.net or Paypal so the default is assumed
+   * to be Pending.
+   *
    * @param array $params
    *
-   * @param $component
+   * @param string $component
    *
    * @return array
-   *   (modified)
-   * @throws CRM_Core_Exception
+   *   Result array
+   *
+   * @throws \Civi\Payment\Exception\PaymentProcessorException
    */
   public function doPayment(&$params, $component = 'contribute') {
+    $statuses = CRM_Contribute_BAO_Contribution::buildOptions('contribution_status_id');
     if ($this->_paymentProcessor['billing_mode'] == 4) {
       $result = $this->doTransferCheckout($params, $component);
+      if (is_array($result) && !isset($result['contribution_status_id'])) {
+        $result['contribution_status_id'] = array_search('Pending', $statuses);
+      }
     }
     else {
       $result = $this->doDirectPayment($params, $component);
+      if (is_array($result) && !isset($result['contribution_status_id'])) {
+        if ($params['is_recur']) {
+          // See comment block.
+          $paymentParams['contribution_status_id'] = array_search('Pending', $statuses);
+        }
+        else {
+          $result['contribution_status_id'] = array_search('Completed', $statuses);
+        }
+      }
     }
     if (is_a($result, 'CRM_Core_Error')) {
-      throw new CRM_Core_Exception(CRM_Core_Error::getMessages($result));
+      throw new PaymentProcessorException(CRM_Core_Error::getMessages($result));
     }
-    //CRM-15767 - Submit Credit Card Contribution not being saved
     return $result;
   }
 

--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -509,7 +509,7 @@ abstract class CRM_Core_Payment {
     else {
       $result = $this->doDirectPayment($params, $component);
       if (is_array($result) && !isset($result['contribution_status_id'])) {
-        if ($params['is_recur']) {
+        if (!empty($params['is_recur'])) {
           // See comment block.
           $paymentParams['contribution_status_id'] = array_search('Pending', $statuses);
         }

--- a/CRM/Core/Payment/Dummy.php
+++ b/CRM/Core/Payment/Dummy.php
@@ -87,6 +87,13 @@ class CRM_Core_Payment_Dummy extends CRM_Core_Payment {
       $params,
       $cookedParams
     );
+    // This means we can test failing transactions by setting a past year in expiry. A full expiry check would
+    // be more complete.
+    if (!empty($params['credit_card_exp_date']) && date('Y') >
+      CRM_Core_Payment_Form::getCreditCardExpirationYear($params)) {
+      $error = new CRM_Core_Error(ts('transaction failed'));
+      return $error;
+    }
     //end of hook invocation
     if (!empty($this->_doDirectPaymentResult)) {
       $result = $this->_doDirectPaymentResult;

--- a/Civi/Payment/Exception/PaymentProcessorException.php
+++ b/Civi/Payment/Exception/PaymentProcessorException.php
@@ -1,0 +1,10 @@
+<?php
+namespace Civi\Payment\Exception;
+
+/**
+ * Class PaymentProcessorException
+ */
+class PaymentProcessorException extends \CRM_Core_Exception {
+
+}
+

--- a/Civi/Payment/Exception/PaymentProcessorException.php
+++ b/Civi/Payment/Exception/PaymentProcessorException.php
@@ -7,4 +7,3 @@ namespace Civi\Payment\Exception;
 class PaymentProcessorException extends \CRM_Core_Exception {
 
 }
-

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -205,8 +205,10 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
         'live');
     }
     catch (\Civi\Payment\Exception\PaymentProcessorException $e) {
-      $this->callAPISuccessGetCount('Contribution', array('contact_id' => $this->_individualId,
-        'contribution_status_id' => 'Pending'), 1);
+      $this->callAPISuccessGetCount('Contribution', array(
+        'contact_id' => $this->_individualId,
+        'contribution_status_id' => 'Pending',
+      ), 1);
       $lineItem = $this->callAPISuccessGetSingle('line_item', array());
       $this->assertEquals('50.00', $lineItem['unit_price']);
       $this->assertEquals('50.00', $lineItem['line_total']);

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -80,9 +80,9 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
   /**
    * Dummy payment processor.
    *
-   * @var array
+   * @var CRM_Core_Payment_Dummy
    */
-  protected $paymentProcessor = array();
+  protected $paymentProcessor;
 
   /**
    * Setup function.
@@ -93,7 +93,6 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
     $this->createLoggedInUser();
 
     $this->_individualId = $this->individualCreate();
-    $paymentProcessor = $this->processorCreate();
     $this->_params = array(
       'contact_id' => $this->_individualId,
       'receive_date' => '20120511',
@@ -116,17 +115,7 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
       'url_recur' => 'http://dummy.com',
       'billing_mode' => 1,
     );
-    $this->_pageParams = array(
-      'title' => 'Test Contribution Page',
-      'financial_type_id' => 1,
-      'currency' => 'USD',
-      'financial_account_id' => 1,
-      'payment_processor' => $paymentProcessor->id,
-      'is_active' => 1,
-      'is_allow_other_amount' => 1,
-      'min_amount' => 10,
-      'max_amount' => 1000,
-    );
+
     $instruments = $this->callAPISuccess('contribution', 'getoptions', array('field' => 'payment_instrument_id'));
     $this->paymentInstruments = $instruments['values'];
     $product1 = $this->callAPISuccess('product', 'create', array(
@@ -179,32 +168,59 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
       'payment_instrument_id' => array_search('Credit Card', $this->paymentInstruments),
       'contribution_status_id' => 1,
     ), CRM_Core_Action::ADD);
-    $this->callAPISuccessGetCount('Contribution', array('contact_id' => $this->_individualId), 1);
+    $this->callAPISuccessGetCount('Contribution', array(
+      'contact_id' => $this->_individualId,
+      'contribution_status_id' => 'Completed',
+      ),
+    1);
   }
 
   /**
-   * Test the submit function on the contribution page.
+   * Test the submit function with an invalid payment.
+   *
+   * We expect the contribution to be created but left pending. The payment has failed.
+   *
+   * Test covers CRM-16417 change to keep failed transactions.
+   *
+   * We are left with
+   *  - 1 Contribution with status = Pending
+   *  - 1 Line item
+   *  - 1 civicrm_financial_item. This is linked to the line item and has a status of 3
    */
-  public function testSubmitCreditCardInvalidExpiry() {
+  public function testSubmitCreditCardInvalid() {
     $form = new CRM_Contribute_Form_Contribution();
-    $form->testSubmit(array(
-      'total_amount' => 50,
-      'financial_type_id' => 1,
-      'receive_date' => '04/21/2015',
-      'receive_date_time' => '11:27PM',
-      'contact_id' => $this->_individualId,
-      'payment_instrument_id' => array_search('Credit Card', $this->paymentInstruments),
-      'payment_processor_id' => $this->paymentProcessor->id,
-      'credit_card_exp_date' => array('M' => 5, 'Y' => 2012),
-      'credit_card_number' => '411111111111111',
-    ), CRM_Core_Action::ADD,
-    'live');
-    $this->callAPISuccessGetCount('Contribution', array('contact_id' => $this->_individualId), 1);
-    $lineItem = $this->callAPISuccessGetSingle('line_item', array());
-    $this->assertEquals('50.00', $lineItem['unit_price']);
-    $this->assertEquals('50.00', $lineItem['line_total']);
-    $this->assertEquals(1, $lineItem['qty']);
-    $this->assertEquals(1, $lineItem['financial_type_id']);
+    $this->paymentProcessor->setDoDirectPaymentResult(array('is_error' => 1));
+    try {
+      $form->testSubmit(array(
+        'total_amount' => 50,
+        'financial_type_id' => 1,
+        'receive_date' => '04/21/2015',
+        'receive_date_time' => '11:27PM',
+        'contact_id' => $this->_individualId,
+        'payment_instrument_id' => array_search('Credit Card', $this->paymentInstruments),
+        'payment_processor_id' => $this->paymentProcessor->id,
+        'credit_card_exp_date' => array('M' => 5, 'Y' => 2012),
+        'credit_card_number' => '411111111111111',
+      ), CRM_Core_Action::ADD,
+        'live');
+    }
+    catch (\Civi\Payment\Exception\PaymentProcessorException $e) {
+      $this->callAPISuccessGetCount('Contribution', array('contact_id' => $this->_individualId,
+        'contribution_status_id' => 'Pending'), 1);
+      $lineItem = $this->callAPISuccessGetSingle('line_item', array());
+      $this->assertEquals('50.00', $lineItem['unit_price']);
+      $this->assertEquals('50.00', $lineItem['line_total']);
+      $this->assertEquals(1, $lineItem['qty']);
+      $this->assertEquals(1, $lineItem['financial_type_id']);
+      $financialItem = $this->callAPISuccessGetSingle('financial_item', array(
+        'civicrm_line_item' => $lineItem['id'],
+        'entity_id' => $lineItem['id'],
+      ));
+      $this->assertEquals('50.00', $financialItem['amount']);
+      $this->assertEquals(3, $financialItem['status_id']);
+      return;
+    }
+    $this->fail('An expected exception has not been raised.');
   }
 
   /**
@@ -320,7 +336,7 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
       'is_email_receipt' => TRUE,
       'from_email_address' => 'test@test.com',
       'payment_processor_id' => $this->paymentProcessor->id,
-      'credit_card_exp_date' => array('M' => 5, 'Y' => 2012),
+      'credit_card_exp_date' => array('M' => 5, 'Y' => 2026),
       'credit_card_number' => '411111111111111',
     ), CRM_Core_Action::ADD,
     'live');


### PR DESCRIPTION
This patch prevents failed payments from being removes and tests that they aren't. It also provides the backend work for supporting direct debit & offsite in the post process function.

It is currently blocked by https://github.com/civicrm/civicrm-core/pull/5764 which is blocked by https://github.com/civicrm/civicrm-core/pull/5764 & tests won't pass until those 2 are merged
