### PR TITLE
CRM-16471 remove constants for size in Schema

### DIFF
--- a/CRM/Core/CodeGen/Specification.php
+++ b/CRM/Core/CodeGen/Specification.php
@@ -660,35 +660,14 @@ class CRM_Core_CodeGen_Specification {
 
   /**
    * Sets the size property of a textfield.
-   * See constants defined in CRM_Utils_Type for possible values
    */
   protected function getSize($fieldXML) {
     // Extract from <size> tag if supplied
     if (!empty($fieldXML->html) && $this->value('size', $fieldXML->html)) {
-      $const = 'CRM_Utils_Type::' . strtoupper($fieldXML->html->size);
-      if (defined($const)) {
-        return $const;
-      }
+      return $this->value('size', $fieldXML->html);
     }
     // Infer from <length> tag if <size> was not explicitly set or was invalid
-
-    // This map is slightly different from CRM_Core_Form_Renderer::$_sizeMapper
-    // Because we usually want fields to render as smaller than their maxlength
-    $sizes = array(
-      2 => 'TWO',
-      4 => 'FOUR',
-      6 => 'SIX',
-      8 => 'EIGHT',
-      16 => 'TWELVE',
-      32 => 'MEDIUM',
-      64 => 'BIG',
-    );
-    foreach ($sizes as $length => $name) {
-      if ($fieldXML->length <= $length) {
-        return "CRM_Utils_Type::$name";
-      }
-    }
-    return 'CRM_Utils_Type::HUGE';
+    return $fieldXML->length;
   }
 
 }

--- a/xml/schema/Contact/Contact.xml
+++ b/xml/schema/Contact/Contact.xml
@@ -166,7 +166,7 @@
     <length>64</length>
     <html>
       <type>Text</type>
-      <size>EIGHT</size>
+      <size>8</size>
     </html>
 
     <import>true</import>
@@ -188,7 +188,7 @@
     <length>128</length>
     <html>
       <type>Text</type>
-      <size>BIG</size>
+      <size>30</size>
     </html>
 
     <export>true</export>
@@ -207,7 +207,7 @@
     <length>128</length>
     <html>
       <type>Text</type>
-      <size>BIG</size>
+      <size>30</size>
     </html>
 
     <export>true</export>
@@ -221,7 +221,7 @@
     <length>128</length>
     <html>
       <type>Text</type>
-      <size>BIG</size>
+      <size>30</size>
     </html>
 
     <import>true</import>
@@ -237,7 +237,7 @@
     <length>128</length>
     <html>
       <type>Text</type>
-      <size>BIG</size>
+      <size>30</size>
     </html>
 
     <import>true</import>
@@ -254,7 +254,7 @@
     <length>128</length>
     <html>
       <type>Text</type>
-      <size>BIG</size>
+      <size>30</size>
     </html>
 
     <import>true</import>
@@ -273,7 +273,7 @@
     <add>1.1</add>
     <html>
       <type>File</type>
-      <size>BIG</size>
+      <size>30</size>
     </html>
   </field>
   <field>
@@ -366,7 +366,7 @@
     <length>255</length>
     <html>
       <type>Text</type>
-      <size>BIG</size>
+      <size>30</size>
     </html>
 
     <import>true</import>
@@ -380,7 +380,7 @@
     <length>64</length>
     <html>
       <type>Text</type>
-      <size>BIG</size>
+      <size>30</size>
     </html>
     <import>true</import>
     <headerPattern>/^first|(f(irst\s)?name)$/i</headerPattern>
@@ -400,7 +400,7 @@
     <length>64</length>
     <html>
       <type>Text</type>
-      <size>MEDIUM</size>
+      <size>30</size>
     </html>
     <import>true</import>
     <headerPattern>/^middle|(m(iddle\s)?name)$/i</headerPattern>
@@ -415,7 +415,7 @@
     <length>64</length>
     <html>
       <type>Text</type>
-      <size>BIG</size>
+      <size>30</size>
     </html>
     <import>true</import>
     <headerPattern>/^last|(l(ast\s)?name)$/i</headerPattern>
@@ -624,7 +624,7 @@
     <length>255</length>
     <html>
       <type>Text</type>
-      <size>MEDIUM</size>
+      <size>30</size>
     </html>
     <import>true</import>
     <headerPattern>/^job|(j(ob\s)?title)$/i</headerPattern>
@@ -715,7 +715,7 @@
     <length>128</length>
     <html>
       <type>Text</type>
-      <size>BIG</size>
+      <size>30</size>
     </html>
     <import>true</import>
     <headerPattern>/^household|(h(ousehold\s)?name)$/i</headerPattern>
@@ -752,7 +752,7 @@
     <length>128</length>
     <html>
       <type>Text</type>
-      <size>BIG</size>
+      <size>30</size>
     </html>
     <import>true</import>
     <headerPattern>/^organization|(o(rganization\s)?name)$/i</headerPattern>

--- a/xml/schema/Contribute/Contribution.xml
+++ b/xml/schema/Contribute/Contribution.xml
@@ -423,7 +423,7 @@
     <length>255</length>
     <html>
       <type>Text</type>
-      <size>SIX</size>
+      <size>6</size>
     </html>
     <import>true</import>
     <add>2.2</add>

--- a/xml/schema/Core/Email.xml
+++ b/xml/schema/Core/Email.xml
@@ -60,7 +60,7 @@
     <length>254</length>
     <html>
       <type>Text</type>
-      <size>MEDIUM</size>
+      <size>30</size>
     </html>
     <import>true</import>
     <headerPattern>/e.?mail/i</headerPattern>

--- a/xml/schema/Core/Phone.xml
+++ b/xml/schema/Core/Phone.xml
@@ -108,7 +108,7 @@
     <length>16</length>
     <html>
       <type>Text</type>
-      <size>FOUR</size>
+      <size>4</size>
     </html>
     <import>true</import>
     <export>true</export>

--- a/xml/schema/Core/Website.xml
+++ b/xml/schema/Core/Website.xml
@@ -39,7 +39,7 @@
     <length>128</length>
     <html>
       <type>Text</type>
-      <size>BIG</size>
+      <size>30</size>
     </html>
     <import>true</import>
     <headerPattern>/Website/i</headerPattern>

--- a/xml/schema/Financial/FinancialTrxn.xml
+++ b/xml/schema/Financial/FinancialTrxn.xml
@@ -212,7 +212,7 @@
     <length>255</length>
     <html>
       <type>Text</type>
-      <size>SIX</size>
+      <size>6</size>
     </html>
     <add>4.3</add>
   </field>

--- a/xml/schema/Price/PriceFieldValue.xml
+++ b/xml/schema/Price/PriceFieldValue.xml
@@ -74,7 +74,7 @@
     <length>512</length>
     <html>
       <type>Text</type>
-      <size>EIGHT</size>
+      <size>8</size>
     </html>
     <required>true</required>
     <comment>Price field option amount</comment>


### PR DESCRIPTION
This allows free values for the size's in the schema, removes the use of the constants in the mapper, and replaces all used values in the schema. 
