### PR TITLE
CRM-16468 - Mailing.send_test - Don't populate recipients list

### DIFF
--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -68,8 +68,10 @@ class CRM_Mailing_BAO_MailingJob extends CRM_Mailing_DAO_MailingJob {
     $job->scheduled_date = $params['scheduled_date'];
     $job->is_test = $params['is_test'];
     $job->save();
-    $mailing = new CRM_Mailing_BAO_Mailing();
-    $mailing->getRecipients($job->id, $params['mailing_id'], NULL, NULL, TRUE, FALSE);
+    if (!isset($params['options']['auto_recipients']) || $params['options']['auto_recipients']) {
+      $mailing = new CRM_Mailing_BAO_Mailing();
+      $mailing->getRecipients($job->id, $params['mailing_id'], NULL, NULL, TRUE, FALSE);
+    }
     return $job;
   }
 

--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -579,7 +579,9 @@ function civicrm_api3_mailing_send_test($params) {
 
   $testEmailParams = _civicrm_api3_generic_replace_base_params($params);
   $testEmailParams['is_test'] = 1;
-  $job = civicrm_api3('MailingJob', 'create', $testEmailParams);
+  $job = civicrm_api3('MailingJob', 'create', $testEmailParams + array(
+    'options' => array('auto_recipients' => 0),
+  ));
   $testEmailParams['job_id'] = $job['id'];
   $testEmailParams['emails'] = explode(',', $testEmailParams['test_email']);
   if (!empty($params['test_email'])) {


### PR DESCRIPTION
This isn't expected to be a fix... it's just a tidy-up.

---
- [CRM-16468: Reusing mailings prior to upgrade causes mails to be sent on conducting test](https://issues.civicrm.org/jira/browse/CRM-16468)
