### PR TITLE
CRM-16251 - CRM_Contact_BAO_GroupContactCache - Respect transactions

### DIFF
--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -543,7 +543,7 @@ WHERE  civicrm_group_contact.status = 'Added'
         "INSERT IGNORE INTO civicrm_group_contact_cache (contact_id, group_id)
         SELECT DISTINCT $idName, group_id FROM $tempTable
       ");
-      CRM_Core_DAO::executeQuery(" DROP TABLE $tempTable");
+      CRM_Core_DAO::executeQuery(" DROP TEMPORARY TABLE $tempTable");
     }
 
     self::updateCacheTime($groupIDs, $processed);


### PR DESCRIPTION
The use of "DROP TABLE" will force-commit any pending transactions, even if
the table is temporary.  To avoid a force-commit, one must explicitly say
"DROP TEMPORARY TABLE".
