### PR TITLE
Remove unused parameters from function signature

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -2660,7 +2660,7 @@ INNER JOIN  civicrm_option_group grp ON ( grp.id = val.option_group_id AND grp.n
           }
         }
       }
-      CRM_Core_BAO_CustomValueTable::postProcess($customParams, CRM_Core_DAO::$_nullArray, 'civicrm_activity',
+      CRM_Core_BAO_CustomValueTable::postProcess($customParams, 'civicrm_activity',
         $params['mainActivityId'], 'Activity'
       );
     }

--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -908,7 +908,6 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
         )
       );
       $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params,
-        $customFields,
         $this->_activityId,
         'Activity'
       );

--- a/CRM/Activity/Form/Task/Batch.php
+++ b/CRM/Activity/Form/Task/Batch.php
@@ -221,7 +221,6 @@ class CRM_Activity_Form_Task_Batch extends CRM_Activity_Form_Task {
       foreach ($params['field'] as $key => $value) {
 
         $value['custom'] = CRM_Core_BAO_CustomField::postProcess($value,
-          CRM_Core_DAO::$_nullObject,
           $key, 'Activity'
         );
         $value['id'] = $key;

--- a/CRM/Activity/Import/Parser/Activity.php
+++ b/CRM/Activity/Import/Parser/Activity.php
@@ -298,7 +298,6 @@ class CRM_Activity_Import_Parser_Activity extends CRM_Activity_Import_Parser {
     }
 
     $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params,
-      CRM_Core_DAO::$_nullObject,
       NULL,
       'Activity'
     );

--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -463,7 +463,6 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
         }
 
         $value['custom'] = CRM_Core_BAO_CustomField::postProcess($value,
-          CRM_Core_DAO::$_nullObject,
           NULL,
           'Contribution'
         );
@@ -674,7 +673,6 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
 
         //check for custom data
         $value['custom'] = CRM_Core_BAO_CustomField::postProcess($params['field'][$key],
-          $customFields,
           $key,
           'Membership',
           $membershipTypeId

--- a/CRM/Campaign/Form/Campaign.php
+++ b/CRM/Campaign/Form/Campaign.php
@@ -365,7 +365,6 @@ class CRM_Campaign_Form_Campaign extends CRM_Core_Form {
       CRM_Utils_Array::value('campaign_type_id', $params)
     );
     $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params,
-      $customFields,
       $this->_campaignId,
       'Campaign'
     );

--- a/CRM/Campaign/Form/Petition/Signature.php
+++ b/CRM/Campaign/Form/Petition/Signature.php
@@ -515,7 +515,6 @@ class CRM_Campaign_Form_Petition_Signature extends CRM_Core_Form {
     );
 
     $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params,
-      $customActivityFields,
       NULL,
       'Activity'
     );

--- a/CRM/Campaign/Form/Survey/Main.php
+++ b/CRM/Campaign/Form/Survey/Main.php
@@ -216,7 +216,6 @@ class CRM_Campaign_Form_Survey_Main extends CRM_Campaign_Form_Survey {
     $params['is_default'] = CRM_Utils_Array::value('is_default', $params, 0);
 
     $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params,
-      $customFields,
       $this->_surveyId,
       'Survey'
     );

--- a/CRM/Campaign/Form/Task/Interview.php
+++ b/CRM/Campaign/Form/Task/Interview.php
@@ -498,7 +498,6 @@ WHERE {$clause}
 
     //format custom fields.
     $customParams = CRM_Core_BAO_CustomField::postProcess($params,
-      $surveyFields,
       $activityId,
       'Activity'
     );

--- a/CRM/Case/Form/Activity.php
+++ b/CRM/Case/Form/Activity.php
@@ -473,7 +473,6 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
         )
       );
       $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params,
-        $customFields,
         $this->_activityId,
         'Activity'
       );

--- a/CRM/Case/Form/Case.php
+++ b/CRM/Case/Form/Case.php
@@ -376,7 +376,6 @@ class CRM_Case_Form_Case extends CRM_Core_Form {
       $customFields = array();
       $params['custom'] = CRM_Core_BAO_CustomField::postProcess(
         $params,
-        $customFields,
         NULL,
         'Case'
       );
@@ -423,7 +422,6 @@ class CRM_Case_Form_Case extends CRM_Core_Form {
         )
       );
       $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params,
-        $customFields,
         $this->_activityId,
         'Activity'
       );

--- a/CRM/Case/Form/CustomData.php
+++ b/CRM/Case/Form/CustomData.php
@@ -136,12 +136,10 @@ class CRM_Case_Form_CustomData extends CRM_Core_Form {
    */
   public function postProcess() {
     $params = $this->controller->exportValues($this->_name);
-    $fields = array();
 
     $transaction = new CRM_Core_Transaction();
 
     CRM_Core_BAO_CustomValueTable::postProcess($params,
-      $fields,
       'civicrm_case',
       $this->_entityID,
       'Case'

--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -946,7 +946,6 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
     $customFieldExtends = (CRM_Utils_Array::value('contact_sub_type', $params)) ? $params['contact_sub_type'] : $params['contact_type'];
 
     $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params,
-      $customFields,
       $this->_contactId,
       $customFieldExtends,
       TRUE

--- a/CRM/Contact/Form/CustomData.php
+++ b/CRM/Contact/Form/CustomData.php
@@ -297,7 +297,6 @@ class CRM_Contact_Form_CustomData extends CRM_Core_Form {
     $params = $this->controller->exportValues($this->_name);
 
     CRM_Core_BAO_CustomValueTable::postProcess($params,
-      $this->_groupTree[$this->_groupID]['fields'],
       'civicrm_contact',
       $this->_tableID,
       $this->_entityType

--- a/CRM/Contact/Form/Inline/CustomData.php
+++ b/CRM/Contact/Form/Inline/CustomData.php
@@ -96,7 +96,6 @@ class CRM_Contact_Form_Inline_CustomData extends CRM_Contact_Form_Inline {
     // Get the form values and groupTree
     $params = $this->controller->exportValues($this->_name);
     CRM_Core_BAO_CustomValueTable::postProcess($params,
-      $this->_groupTree[$this->_groupID]['fields'],
       'civicrm_contact',
       $this->_contactId,
       $this->_entityType

--- a/CRM/Contribute/BAO/Contribution/Utils.php
+++ b/CRM/Contribute/BAO/Contribution/Utils.php
@@ -798,7 +798,6 @@ INNER JOIN   civicrm_contact contact ON ( contact.id = contrib.contact_id )
       )
     );
     $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params,
-      $customFields,
       CRM_Utils_Array::value('id', $params, NULL),
       'Contribution'
     );

--- a/CRM/Contribute/Form/AdditionalInfo.php
+++ b/CRM/Contribute/Form/AdditionalInfo.php
@@ -324,7 +324,6 @@ class CRM_Contribute_Form_AdditionalInfo {
       )
     );
     $formatted['custom'] = CRM_Core_BAO_CustomField::postProcess($params,
-      $customFields,
       CRM_Utils_Array::value('id', $params, NULL),
       'Contribution'
     );

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1484,7 +1484,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
     if ($online && $contribution) {
       CRM_Core_BAO_CustomValueTable::postProcess($form->_params,
-        CRM_Core_DAO::$_nullArray,
         'civicrm_contribution',
         $contribution->id,
         'Contribution'

--- a/CRM/Contribute/Form/Task/Batch.php
+++ b/CRM/Contribute/Form/Task/Batch.php
@@ -221,7 +221,6 @@ class CRM_Contribute_Form_Task_Batch extends CRM_Contribute_Form_Task {
       foreach ($params['field'] as $key => $value) {
 
         $value['custom'] = CRM_Core_BAO_CustomField::postProcess($value,
-          CRM_Core_DAO::$_nullObject,
           $key,
           'Contribution'
         );

--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -355,7 +355,6 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Contribute_Import_Pa
 
     if ($onDuplicate != CRM_Import_Parser::DUPLICATE_UPDATE) {
       $formatted['custom'] = CRM_Core_BAO_CustomField::postProcess($formatted,
-        CRM_Core_DAO::$_nullObject,
         NULL,
         'Contribution'
       );
@@ -375,7 +374,6 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Contribute_Import_Pa
         if ($ids['contribution']) {
           $formatted['id'] = $ids['contribution'];
           $formatted['custom'] = CRM_Core_BAO_CustomField::postProcess($formatted,
-            CRM_Core_DAO::$_nullObject,
             $formatted['id'],
             'Contribution'
           );

--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -170,7 +170,6 @@ class CRM_Core_BAO_Address extends CRM_Core_DAO_Address {
       }
       if (!empty($customFields)) {
         $addressCustom = CRM_Core_BAO_CustomField::postProcess($params,
-          $customFields,
           $address->id,
           'Address',
           TRUE

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -2234,8 +2234,6 @@ ORDER BY html_type";
 
   /**
    * @param array $params
-   * @param array $customFields
-   *   Unused parameter
    * @param int $entityID
    * @param $customFieldExtends
    * @param bool $inline
@@ -2244,7 +2242,6 @@ ORDER BY html_type";
    */
   public static function postProcess(
     &$params,
-    $customFields,
     $entityID,
     $customFieldExtends,
     $inline = FALSE

--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -354,14 +354,13 @@ class CRM_Core_BAO_CustomValueTable {
    * Post process function.
    *
    * @param array $params
-   * @param $customFields
    * @param $entityTable
    * @param int $entityID
    * @param $customFieldExtends
    */
-  public static function postProcess(&$params, &$customFields, $entityTable, $entityID, $customFieldExtends) {
+  public static function postProcess(&$params, $entityTable, $entityID, $customFieldExtends) {
     $customData = CRM_Core_BAO_CustomField::postProcess($params,
-      $customFields,
+      array(),
       $entityID,
       $customFieldExtends
     );

--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -360,7 +360,6 @@ class CRM_Core_BAO_CustomValueTable {
    */
   public static function postProcess(&$params, $entityTable, $entityID, $customFieldExtends) {
     $customData = CRM_Core_BAO_CustomField::postProcess($params,
-      array(),
       $entityID,
       $customFieldExtends
     );

--- a/CRM/Custom/Form/CustomData.php
+++ b/CRM/Custom/Form/CustomData.php
@@ -46,8 +46,6 @@ class CRM_Custom_Form_CustomData {
    * @param string $type
    * @param null|int $entityID
    * @param null $onlySubType
-   *
-   * @return void
    */
   public static function preProcess(
     &$form, $subName = NULL, $subType = NULL,
@@ -160,7 +158,6 @@ class CRM_Custom_Form_CustomData {
 
   /**
    * @param CRM_Core_Form $form
-   * @return void
    */
   public static function buildQuickForm(&$form) {
     $form->addElement('hidden', 'hidden_custom', 1);

--- a/CRM/Event/Form/ManageEvent/EventInfo.php
+++ b/CRM/Event/Form/ManageEvent/EventInfo.php
@@ -294,7 +294,6 @@ class CRM_Event_Form_ManageEvent_EventInfo extends CRM_Event_Form_ManageEvent {
       CRM_Utils_Array::value('event_type_id', $params)
     );
     $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params,
-      $customFields,
       $this->_id,
       'Event'
     );

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1164,7 +1164,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       $customFields = CRM_Utils_Array::crmArrayMerge($customFieldsEvent, $customFields);
       $customFields = CRM_Utils_Array::crmArrayMerge($customFieldsEventType, $customFields);
       $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params,
-        $customFields,
         $this->_id,
         'Participant'
       );

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1260,7 +1260,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
 
       //add custom data for participant
       CRM_Core_BAO_CustomValueTable::postProcess($this->_params,
-        CRM_Core_DAO::$_nullArray,
         'civicrm_participant',
         $participants[0]->id,
         'Participant'

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -755,7 +755,6 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
     }
 
     CRM_Core_BAO_CustomValueTable::postProcess($this->_params,
-      CRM_Core_DAO::$_nullArray,
       'civicrm_participant',
       $participant->id,
       'Participant'

--- a/CRM/Event/Form/Task/Batch.php
+++ b/CRM/Event/Form/Task/Batch.php
@@ -278,7 +278,6 @@ class CRM_Event_Form_Task_Batch extends CRM_Event_Form_Task {
 
         //check for custom data
         $value['custom'] = CRM_Core_BAO_CustomField::postProcess($value,
-          CRM_Core_DAO::$_nullObject,
           $key,
           'Participant'
         );

--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -352,7 +352,6 @@ class CRM_Event_Import_Parser_Participant extends CRM_Event_Import_Parser {
 
     if ($onDuplicate != CRM_Import_Parser::DUPLICATE_UPDATE) {
       $formatted['custom'] = CRM_Core_BAO_CustomField::postProcess($formatted,
-        CRM_Core_DAO::$_nullObject,
         NULL,
         'Participant'
       );
@@ -363,7 +362,6 @@ class CRM_Event_Import_Parser_Participant extends CRM_Event_Import_Parser {
         $dao->id = $formatValues['participant_id'];
 
         $formatted['custom'] = CRM_Core_BAO_CustomField::postProcess($formatted,
-          CRM_Core_DAO::$_nullObject,
           $formatValues['participant_id'],
           'Participant'
         );

--- a/CRM/Grant/Form/Grant.php
+++ b/CRM/Grant/Form/Grant.php
@@ -302,7 +302,6 @@ class CRM_Grant_Form_Grant extends CRM_Core_Form {
       CRM_Core_BAO_CustomField::getFields('Grant', FALSE, FALSE, NULL, NULL, TRUE)
     );
     $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params,
-      $customFields,
       $this->_id,
       'Grant'
     );

--- a/CRM/Group/Form/Edit.php
+++ b/CRM/Group/Form/Edit.php
@@ -396,7 +396,6 @@ WHERE  title = %1
 
       $customFields = CRM_Core_BAO_CustomField::getFields('Group');
       $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params,
-        $customFields,
         $this->_id,
         'Group'
       );

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1407,7 +1407,6 @@ AND civicrm_membership.is_test = %2";
     foreach ($createdMemberships as $createdMembership) {
       CRM_Core_BAO_CustomValueTable::postProcess(
         $form->_params,
-        CRM_Core_DAO::$_nullArray,
         'civicrm_membership',
         $createdMembership->id,
         'Membership'

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1177,7 +1177,6 @@ WHERE   id IN ( ' . implode(' , ', array_keys($membershipType)) . ' )';
       );
 
       $membershipTypeValues[$memType]['custom'] = CRM_Core_BAO_CustomField::postProcess($formValues,
-        $customFields,
         $this->_id,
         'Membership'
       );

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -107,7 +107,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
     $this->assign('cdType', FALSE);
     if ($this->_cdType) {
       $this->assign('cdType', TRUE);
-      return CRM_Custom_Form_CustomData::preProcess($this);
+      CRM_Custom_Form_CustomData::preProcess($this);
     }
 
     parent::preProcess();
@@ -156,8 +156,8 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
    * Set default values for the form.
    * the default values are retrieved from the database
    *
-   *
-   * @return void
+   * @return array
+   *   Default values.
    */
   public function setDefaultValues() {
     if ($this->_cdType) {
@@ -240,12 +240,10 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
 
   /**
    * Build the form object.
-   *
-   * @return void
    */
   public function buildQuickForm() {
     if ($this->_cdType) {
-      return CRM_Custom_Form_CustomData::buildQuickForm($this);
+      CRM_Custom_Form_CustomData::buildQuickForm($this);
     }
 
     parent::buildQuickForm();
@@ -492,7 +490,6 @@ WHERE   id IN ( ' . implode(' , ', array_keys($membershipType)) . ' )';
    */
   public function postProcess() {
 
-    $ids = array();
     $config = CRM_Core_Config::singleton();
 
     // get the submitted form values.

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -639,7 +639,6 @@ WHERE   id IN ( ' . implode(' , ', array_keys($membershipType)) . ' )';
     );
 
     $customFieldsFormatted = CRM_Core_BAO_CustomField::postProcess($formValues,
-      $customFields,
       $this->_id,
       'Membership'
     );

--- a/CRM/Member/Form/Task/Batch.php
+++ b/CRM/Member/Form/Task/Batch.php
@@ -254,7 +254,6 @@ class CRM_Member_Form_Task_Batch extends CRM_Member_Form_Task {
         }
         //check for custom data
         $value['custom'] = CRM_Core_BAO_CustomField::postProcess($params['field'][$key],
-          $customFields,
           $key,
           'Membership',
           $membershipTypeId

--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -356,7 +356,6 @@ class CRM_Member_Import_Parser_Membership extends CRM_Member_Import_Parser {
 
       if ($onDuplicate != CRM_Import_Parser::DUPLICATE_UPDATE) {
         $formatted['custom'] = CRM_Core_BAO_CustomField::postProcess($formatted,
-          CRM_Core_DAO::$_nullObject,
           NULL,
           'Membership'
         );
@@ -380,7 +379,6 @@ class CRM_Member_Import_Parser_Membership extends CRM_Member_Import_Parser {
           }
 
           $formatted['custom'] = CRM_Core_BAO_CustomField::postProcess($formatted,
-            CRM_Core_DAO::$_nullObject,
             $formatValues['membership_id'],
             'Membership'
           );

--- a/CRM/Pledge/Form/Pledge.php
+++ b/CRM/Pledge/Form/Pledge.php
@@ -569,7 +569,6 @@ class CRM_Pledge_Form_Pledge extends CRM_Core_Form {
 
       $customFields = CRM_Core_BAO_CustomField::getFields('Pledge');
       $params['custom'] = CRM_Core_BAO_CustomField::postProcess($formValues,
-        $customFields,
         $this->_id,
         'Pledge'
       );


### PR DESCRIPTION
Am I missing anything? These functions keep get called & the calling functions go to some effort to generate the $customFields - but it is completely ignored. NB once this is merged need to also do drupal folder fix on this
