### PR TITLE
use addField in communication preferences form

### DIFF
--- a/CRM/Contact/Form/Edit/CommunicationPreferences.php
+++ b/CRM/Contact/Form/Edit/CommunicationPreferences.php
@@ -67,16 +67,15 @@ class CRM_Contact_Form_Edit_CommunicationPreferences {
     foreach ($privacyOptions as $name => $label) {
       $privacy[] = $form->createElement('advcheckbox', $name, NULL, $label);
     }
-    $form->addGroup($privacy, 'privacy', ts('Privacy'), '&nbsp;');
+    $form->addGroup($privacy, 'privacy', ts('Privacy'), '&nbsp;<br/>');
 
     // preferred communication method
     $comm = CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'preferred_communication_method', array('loclize' => TRUE));
     foreach ($comm as $value => $title) {
       $commPreff[] = $form->createElement('advcheckbox', $value, NULL, $title);
     }
-    $form->addGroup($commPreff, 'preferred_communication_method', ts('Preferred Method(s)'));
-
-    $form->addSelect('preferred_language');
+    $form->addField('preferred_communication_method', array('entity' => 'contact', 'type' => 'CheckBoxGroup'));
+    $form->addField('preferred_language', array('entity' => 'contact'));
 
     if (!empty($privacyOptions)) {
       $commPreference['privacy'] = $privacyOptions;
@@ -88,21 +87,11 @@ class CRM_Contact_Form_Edit_CommunicationPreferences {
     //using for display purpose.
     $form->assign('commPreference', $commPreference);
 
-    $form->add('select', 'preferred_mail_format', ts('Email Format'), CRM_Core_SelectValues::pmf());
-    $form->add('checkbox', 'is_opt_out', ts('NO BULK EMAILS (User Opt Out)'));
+    $form->addField('preferred_mail_format', array('entity' => 'contact', 'label' => ts('Email Format')));
 
-    $communicationStyleOptions = array();
-    $communicationStyle = CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'communication_style_id', array('localize' => TRUE));
-    foreach ($communicationStyle as $key => $var) {
-      $communicationStyleOptions[$key] = $form->createElement('radio', NULL,
-        ts('Communication Style'), $var, $key,
-        array('id' => "civicrm_communication_style_{$var}_{$key}")
-      );
-    }
-    if (!empty($communicationStyleOptions)) {
-      $form->addGroup($communicationStyleOptions, 'communication_style_id', ts('Communication Style'));
-    }
+    $form->addField('is_opt_out', array('entity' => 'contact', 'label' => ts('NO BULK EMAILS (User Opt Out)')));
 
+    $form->addField('communication_style_id', array('entity' => 'contact', 'type' => 'RadioGroup'));
     //check contact type and build filter clause accordingly for greeting types, CRM-4575
     $greetings = self::getGreetingFields($form->_contactType);
 

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -901,20 +901,6 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
   }
 
   /**
-   * @param string $name
-   * @param $title
-   * @param $values
-   * @param array $attributes
-   * @param null $separator
-   * @param bool $required
-   *
-   * @return HTML_QuickForm_group
-   */
-  public function &addRadioGroup($name, $title, $values, $attributes = array(), $separator = NULL, $required = FALSE) {
-    return $this->addRadio($name, $title, $values, $attributes, $separator, $required);
-  }
-
-  /**
    * @param int $id
    * @param $title
    * @param bool $allowClear
@@ -988,28 +974,6 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
         'required'
       );
     }
-  }
-
-
-  /**
-   * @param int $id
-   * @param $title
-   * @param $values
-   * @param null $other
-   * @param null $attributes
-   * @param null $required
-   * @param null $javascriptMethod
-   * @param string $separator
-   * @param bool $flipValues
-   */
-  public function addCheckBoxGroup(
-  $id, $title, $values, $other = NULL, $attributes = NULL, $required = NULL,
-  $javascriptMethod = NULL, $separator = '<br />', $flipValues = FALSE
-  ) {
-    $this->addCheckBox(
-        $id, $title, $values, $other,
-        $attributes, $required, $javascriptMethod, $separator, $flipValues
-    );
   }
 
   public function resetValues() {
@@ -1334,11 +1298,11 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
         break;
 
       case 'CheckBoxGroup':
-        $this->addCheckBoxGroup($name, $label, array_flip($options), $required, $props);
+        $this->addCheckBox($name, $label, array_flip($options), $required, $props);
         break;
 
       case 'RadioGroup':
-        $this->addRadioGroup($name, $label, $options, $props, NULL, $required);
+        $this->addRadio($name, $label, $options, $props, NULL, $required);
         break;
 
       //case 'AdvMulti-Select':

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -901,6 +901,20 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
   }
 
   /**
+   * @param string $name
+   * @param $title
+   * @param $values
+   * @param array $attributes
+   * @param null $separator
+   * @param bool $required
+   *
+   * @return HTML_QuickForm_group
+   */
+  public function &addRadioGroup($name, $title, $values, $attributes = array(), $separator = NULL, $required = FALSE) {
+    return $this->addRadio($name, $title, $values, $attributes, $separator, $required);
+  }
+
+  /**
    * @param int $id
    * @param $title
    * @param bool $allowClear
@@ -974,6 +988,28 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
         'required'
       );
     }
+  }
+
+
+  /**
+   * @param int $id
+   * @param $title
+   * @param $values
+   * @param null $other
+   * @param null $attributes
+   * @param null $required
+   * @param null $javascriptMethod
+   * @param string $separator
+   * @param bool $flipValues
+   */
+  public function addCheckBoxGroup(
+  $id, $title, $values, $other = NULL, $attributes = NULL, $required = NULL,
+  $javascriptMethod = NULL, $separator = '<br />', $flipValues = FALSE
+  ) {
+    $this->addCheckBox(
+        $id, $title, $values, $other,
+        $attributes, $required, $javascriptMethod, $separator, $flipValues
+    );
   }
 
   public function resetValues() {
@@ -1197,7 +1233,8 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
           'Select Country',
           'Multi-Select Country',
           'AdvMulti-Select',
-          'CheckBox',
+          'CheckBoxGroup',
+          'RadioGroup',
           'Radio',
     )));
 
@@ -1294,6 +1331,14 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
         }
         $this->add('select', $name, $label, $options, $required, $props);
         // TODO: Add and/or option for fields that store multiple values
+        break;
+
+      case 'CheckBoxGroup':
+        $this->addCheckBoxGroup($name, $label, array_flip($options), $required, $props);
+        break;
+
+      case 'RadioGroup':
+        $this->addRadioGroup($name, $label, $options, $props, NULL, $required);
         break;
 
       //case 'AdvMulti-Select':

--- a/templates/CRM/Contact/Form/Edit/CommunicationPreferences.tpl
+++ b/templates/CRM/Contact/Form/Edit/CommunicationPreferences.tpl
@@ -107,18 +107,16 @@
             {/if}
         </tr>
         <tr>
-            {foreach key=key item=item from=$commPreference}
-                <td>
-                    <br /><span class="label">{$form.$key.label}</span> {help id="id-$key" file="CRM/Contact/Form/Contact.hlp"}
-                    {foreach key=k item=i from=$item}
-                     <br />{$form.$key.$k.html}
-                    {/foreach}
-                </td>
-            {/foreach}
-                 <td>
-                     <br /><span class="label">{$form.preferred_language.label}</span>
-                     <br />{$form.preferred_language.html}
-                </td>
+          {foreach key=key item=item from=$commPreference}
+            <td>
+              <br/><span class="label">{$form.$key.label}</span> {help id="id-$key" file="CRM/Contact/Form/Contact.hlp"}
+              <br/>{$form.$key.html}
+            </td>
+          {/foreach}
+          <td>
+            <br/><span class="label">{$form.preferred_language.label}</span>
+            <br/>{$form.preferred_language.html}
+          </td>
         </tr>
         <tr>
             <td>{$form.is_opt_out.html} {$form.is_opt_out.label} {help id="id-optOut" file="CRM/Contact/Form/Contact.hlp"}</td>

--- a/xml/schema/Contact/Contact.xml
+++ b/xml/schema/Contact/Contact.xml
@@ -493,6 +493,9 @@
     <export>true</export>
     <comment>Communication style (e.g. formal vs. familiar) to use with this contact. FK to communication styles in civicrm_option_value.</comment>
     <add>4.4</add>
+    <html>
+      <type>Select</type>
+    </html>
   </field>
   <index>
     <name>index_communication_style_id</name>


### PR DESCRIPTION
This uses addField method in communication preferences form. 

This adds two new 'html types' to the addfield method. CheckBoxGroup en RadioGroup, those are defined by a wrapper function on addCheckBox and addRadio. 
Those two methods should IMHO be renamed to addCheckBoxGroup and addRadioGroup since they're actually not adding a resp CheckBox nor Radio but a group of those. 
This is perhaps debatable, so comments are very welcome. 
