### PR TITLE
CRM-16501 fix warnings on empty tags

### DIFF
--- a/CRM/Core/BAO/Tag.php
+++ b/CRM/Core/BAO/Tag.php
@@ -100,6 +100,7 @@ class CRM_Core_BAO_Tag extends CRM_Core_DAO_Tag {
     $dao = CRM_Core_DAO::executeQuery($sql, CRM_Core_DAO::$_nullArray, TRUE, NULL, FALSE, FALSE);
 
     $refs = array();
+    $this->tree = array();
     while ($dao->fetch()) {
       $thisref = &$refs[$dao->id];
 
@@ -115,7 +116,6 @@ class CRM_Core_BAO_Tag extends CRM_Core_DAO_Tag {
         $refs[$dao->parent_id]['children'][$dao->id] = &$thisref;
       }
     }
-
   }
 
   /**

--- a/templates/CRM/Contact/Form/Edit/TagsAndGroups.tpl
+++ b/templates/CRM/Contact/Form/Edit/TagsAndGroups.tpl
@@ -97,7 +97,7 @@
             {$form.group.html}
           </td>
         {/if}
-        {if !$type || $type eq 'tag'}
+        {if (!$type || $type eq 'tag') && $tree}
           <td width="70%">{if $title}<span class="label">{$form.tag.label}</span>{/if}
             <div id="tagtree">
               {include file="CRM/Contact/Form/Edit/Tagtree.tpl" level=1}


### PR DESCRIPTION
This fixes the warnings on the empty tags, and only shows the tag label in the form when there are effectively tags available. 
