### PR TITLE
CRM-16502 - fix type assignments in Geocode Job.

### DIFF
--- a/api/v3/Job.php
+++ b/api/v3/Job.php
@@ -140,12 +140,12 @@ function civicrm_api3_job_geocode($params) {
  */
 function _civicrm_api3_job_geocode_spec(&$params) {
   $params['start'] = array(
-    'title' => 'Start Date',
-    'type' => CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME,
+    'title' => 'Starting Contact ID',
+    'type' => CRM_Utils_Type::T_INT,
   );
   $params['end'] = array(
-    'title' => 'End Date',
-    'type' => CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME,
+    'title' => 'Ending Contact ID',
+    'type' => CRM_Utils_Type::T_INT,
   );
   $params['geocoding'] = array(
     'title' => 'Geocode address?',


### PR DESCRIPTION
---
- CRM-16502: Geocoder scheduled job incorrect API parameters
  https://issues.civicrm.org/jira/browse/CRM-16502
