### PR TITLE
CRM-16504 fix recurring option to show on membership renewal

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -177,7 +177,8 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
       $this->assign('cdType', TRUE);
       return CRM_Custom_Form_CustomData::preProcess($this);
     }
-
+    // This string makes up part of the class names, differentiating them (not sure why) from the membership fields.
+    $this->assign('formClass', 'membership');
     parent::preProcess();
     // get price set id.
     $this->_priceSetId = CRM_Utils_Array::value('priceSetId', $_GET);
@@ -751,9 +752,8 @@ WHERE   id IN ( ' . implode(' , ', array_keys($membershipType)) . ' )';
       array('' => ts('- select -')) + CRM_Contribute_PseudoConstant::financialType()
     );
 
-    //CRM-10223 - allow contribution to be recorded against different contact
-    // causes a conflict in standalone mode so skip in standalone for now
     $this->addElement('checkbox', 'is_different_contribution_contact', ts('Record Payment from a Different Contact?'));
+
     $this->addSelect('soft_credit_type_id', array('entity' => 'contribution_soft'));
     $this->addEntityRef('soft_credit_contact_id', ts('Payment From'), array('create' => TRUE));
 
@@ -765,7 +765,7 @@ WHERE   id IN ( ' . implode(' , ', array_keys($membershipType)) . ' )';
 
     $this->add('select', 'from_email_address', ts('Receipt From'), $this->_fromEmails);
 
-    $this->add('textarea', 'receipt_text_signup', ts('Receipt Message'));
+    $this->add('textarea', 'receipt_text', ts('Receipt Message'));
 
     // Retrieve the name and email of the contact - this will be the TO for receipt email
     if ($this->_contactID) {
@@ -1688,7 +1688,10 @@ WHERE   id IN ( ' . implode(' , ', array_keys($membershipType)) . ' )';
     if (!empty($formValues['send_receipt']) && $receiptSend) {
       $formValues['contact_id'] = $this->_contactID;
       $formValues['contribution_id'] = $contributionId;
-
+      // We really don't need a distinct receipt_text_signup vs receipt_text_renewal as they are
+      // handled in the receipt. But by setting one we avoid breaking templates for now
+      // although at some point we should switch in the templates.
+      $formValues['receipt_text_signup'] = $formValues['receipt_text'];
       // send email receipt
       $mailSend = self::emailReceipt($this, $formValues, $membership);
     }

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -801,7 +801,7 @@ WHERE   id IN ( ' . implode(' , ', array_keys($membershipType)) . ' )';
         $this->assign('isAmountzero', 0);
         $this->assign('is_pay_later', 0);
         $this->assign('isPrimary', 1);
-        $this->assign(['receipt_text_renewal'], $this->_params['receipt_text']);
+        $this->assign('receipt_text_renewal', $this->_params['receipt_text']);
         if ($this->_mode == 'test') {
           $this->assign('action', '1024');
         }

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -110,6 +110,8 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
       CRM_Custom_Form_CustomData::preProcess($this);
     }
 
+    // This string makes up part of the class names, differentiating them (not sure why) from the membership fields.
+    $this->assign('formClass', 'membershiprenew');
     parent::preProcess();
     // check for edit permission
     if (!CRM_Core_Permission::check('edit memberships')) {
@@ -425,6 +427,9 @@ WHERE   id IN ( ' . implode(' , ', array_keys($membershipType)) . ' )';
       $this->_contributorEmail
       ) = CRM_Contact_BAO_Contact_Location::getEmailDetails($this->_contactID);
     $this->assign('email', $this->_contributorEmail);
+    // The member form uses emailExists. Assigning both while we transition / synchronise.
+    $this->assign('emailExists', $this->_contributorEmail);
+
 
     $mailingInfo = CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::MAILING_PREFERENCES_NAME,
       'mailing_backend'
@@ -439,13 +444,10 @@ WHERE   id IN ( ' . implode(' , ', array_keys($membershipType)) . ' )';
       }
     }
     $this->addFormRule(array('CRM_Member_Form_MembershipRenewal', 'formRule'));
-    if ($this->_context != 'standalone') {
-      //CRM-10223 - allow contribution to be recorded against different contact
-      // causes a conflict in standalone mode so skip in standalone for now
-      $this->addElement('checkbox', 'contribution_contact', ts('Record Payment from a Different Contact?'));
-      $this->addSelect('soft_credit_type_id', array('entity' => 'contribution_soft'));
-      $this->addEntityRef('soft_credit_contact_id', ts('Payment From'), array('create' => TRUE));
-    }
+    $this->addElement('checkbox', 'is_different_contribution_contact', ts('Record Payment from a Different
+      Contact?'));
+    $this->addSelect('soft_credit_type_id', array('entity' => 'contribution_soft'));
+    $this->addEntityRef('soft_credit_contact_id', ts('Payment From'), array('create' => TRUE));
   }
 
   /**
@@ -800,12 +802,13 @@ WHERE   id IN ( ' . implode(' , ', array_keys($membershipType)) . ' )';
         $this->assign('isAmountzero', 0);
         $this->assign('is_pay_later', 0);
         $this->assign('isPrimary', 1);
+        $this->assign(['receipt_text_renewal'], $this->_params['receipt_text']);
         if ($this->_mode == 'test') {
           $this->assign('action', '1024');
         }
       }
 
-      list($mailSend, $subject, $message, $html) = CRM_Core_BAO_MessageTemplate::sendTemplate(
+      list($mailSend) = CRM_Core_BAO_MessageTemplate::sendTemplate(
         array(
           'groupName' => 'msg_tpl_workflow_membership',
           'valueName' => 'membership_offline_receipt',

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -430,7 +430,6 @@ WHERE   id IN ( ' . implode(' , ', array_keys($membershipType)) . ' )';
     // The member form uses emailExists. Assigning both while we transition / synchronise.
     $this->assign('emailExists', $this->_contributorEmail);
 
-
     $mailingInfo = CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::MAILING_PREFERENCES_NAME,
       'mailing_backend'
     );

--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -86,7 +86,10 @@
           <td>{$form.contact_id.html}</td>
         {/if}
         {if $membershipMode}
-          <tr><td class="label">{$form.payment_processor_id.label}</td><td>{$form.payment_processor_id.html}</td></tr>
+          <tr>
+            <td class="label">{$form.payment_processor_id.label}</td>
+            <td>{$form.payment_processor_id.html}</td>
+          </tr>
         {/if}
         <tr class="crm-membership-form-block-membership_type_id">
           <td class="label">{$form.membership_type_id.label}</td>
@@ -148,17 +151,8 @@
             <span class="description">{ts}Latest membership period expiration date. End Date will be automatically set based on Membership Type if you don't select a date.{/ts}</span>
           </td>
         </tr>
-        {if !empty($form.auto_renew)}
-          <tr id="autoRenew" class="crm-membership-form-block-auto_renew">
-            <td class="label"> {$form.auto_renew.label} {help id="id-auto_renew" file="CRM/Member/Form/Membership.hlp" action=$action} </td>
-            <td> {$form.auto_renew.html} </td>
-          </tr>
-        {/if}
         {if !$membershipMode}
           <tr><td class="label">{$form.is_override.label} {help id="id-status-override"}</td><td>{$form.is_override.html}</td></tr>
-        {/if}
-
-        {if ! $membershipMode}
           {* Show read-only Status block - when action is UPDATE and is_override is FALSE *}
           <tr id="memberStatus_show">
             {if $action eq 2}
@@ -169,45 +163,9 @@
           {* Show editable status field when is_override is TRUE *}
           <tr id="memberStatus"><td class="label">{$form.status_id.label}</td><td>{$form.status_id.html}<br />
             <span class="description">{ts}If <strong>Status Override</strong> is checked, the selected status will remain in force (it will NOT be modified by the automated status update script).{/ts}</span></td></tr>
-
-          {elseif $membershipMode}
-          <tr class="crm-membership-form-block-financial_type_id-mode">
-            <td class="label">{$form.financial_type_id.label}</td>
-            <td>{$form.financial_type_id.html}<br />
-              <span class="description">{ts}Select the appropriate financial type for this payment.{/ts}</span></td>
-          </tr>
-          <tr class="crm-membership-form-block-total_amount">
-            <td class="label">{$form.total_amount.label}</td>
-            <td>{$form.total_amount.html}<br />
-              <span class="description">{ts}Membership payment amount.{/ts}</span><div class="totaltaxAmount"></div></td>
-          </tr>
-          <tr class="crm-membership-form-block-contribution-contact">
-            <td class="label">{$form.is_different_contribution_contact.label}</td>
-            <td>{$form.is_different_contribution_contact.html}&nbsp;&nbsp;{help id="id-contribution_contact"}</td>
-          </tr>
-          <tr id="record-different-contact">
-            <td>&nbsp;</td>
-            <td>
-              <table class="compressed">
-                <tr class="crm-membership-form-block-soft-credit-type">
-                {*CRM-15366*}
-                  <td class="label">{$form.soft_credit_type_id.label}</td>
-                  <td>{$form.soft_credit_type_id.html}</td>
-                </tr>
-                <tr class="crm-membership-form-block-soft-credit-contact-id">
-                  <td class="label">{$form.soft_credit_contact_id.label}</td>
-                  <td>{$form.soft_credit_contact_id.html}</td>
-                </tr>
-              </table>
-            </td>
-          </tr>
-          <tr class="crm-membership-form-block-billing">
-            <td colspan="2">
-            {include file='CRM/Core/BillingBlock.tpl'}
-            </td>
-          </tr>
         {/if}
-        {if $accessContribution and ! $membershipMode AND ($action neq 2 or (!$rows.0.contribution_id AND !$softCredit) or $onlinePendingContributionId)}
+
+        {if $accessContribution and !$membershipMode AND ($action neq 2 or (!$rows.0.contribution_id AND !$softCredit) or $onlinePendingContributionId)}
           <tr id="contri">
             <td class="label">{if $onlinePendingContributionId}{ts}Update Payment Status{/ts}{else}{$form.record_contribution.label}{/if}</td>
             <td>{$form.record_contribution.html}<br />
@@ -215,71 +173,15 @@
           </tr>
           <tr class="crm-membership-form-block-record_contribution"><td colspan="2">
             <fieldset id="recordContribution"><legend>{ts}Membership Payment and Receipt{/ts}</legend>
-              <table>
-                <tr class="crm-membership-form-block-contribution-contact">
-                  <td class="label">{$form.is_different_contribution_contact.label}</td>
-                  <td>{$form.is_different_contribution_contact.html}&nbsp;&nbsp;{help id="id-contribution_contact"}</td>
-                </tr>
-                <tr id="record-different-contact">
-                  <td>&nbsp;</td>
-                  <td>
-                    <table class="compressed">
-                      <tr class="crm-membership-form-block-soft-credit-type">
-                        <td class="label">{$form.soft_credit_type_id.label}</td>
-                        <td>{$form.soft_credit_type_id.html}</td>
-                      </tr>
-                      <tr class="crm-membership-form-block-soft-credit-contact-id">
-                        <td class="label">{$form.soft_credit_contact_id.label}</td>
-                        <td>{$form.soft_credit_contact_id.html}</td>
-                      </tr>
-                    </table>
-                  </td>
-                </tr>
-                  <tr class="crm-membership-form-block-financial_type_id">
-                      <td class="label">{$form.financial_type_id.label}</td>
-                      <td>{$form.financial_type_id.html}<br />
-                      <span class="description">{ts}Select the appropriate financial type for this payment.{/ts}</span></td>
-                </tr>
-                <tr class="crm-membership-form-block-total_amount">
-                  <td class="label">{$form.total_amount.label}</td>
-                  <td>{$form.total_amount.html}<br />
-                    <span class="description">{ts}Membership payment amount. A contribution record will be created for this amount.{/ts}</span><div class="totaltaxAmount"></div></td>
-                </tr>
-                <tr class="crm-membership-form-block-receive_date">
-                  <td class="label">{$form.receive_date.label}</td>
-                  <td>{include file="CRM/common/jcalendar.tpl" elementName=receive_date}</td>
-                </tr>
-                <tr class="crm-membership-form-block-payment_instrument_id">
-                  <td class="label">{$form.payment_instrument_id.label}<span class="marker"> *</span></td>
-                  <td>{$form.payment_instrument_id.html} {help id="payment_instrument_id" file="CRM/Contribute/Page/Tab.hlp"}</td>
-                </tr>
-                <tr id="checkNumber" class="crm-membership-form-block-check_number">
-                  <td class="label">{$form.check_number.label}</td>
-                  <td>{$form.check_number.html|crmAddClass:six}</td>
-                </tr>
-                {if $action neq 2 }
-                  <tr class="crm-membership-form-block-trxn_id">
-                    <td class="label">{$form.trxn_id.label}</td>
-                    <td>{$form.trxn_id.html}</td>
-                  </tr>
-                {/if}
-                <tr class="crm-membership-form-block-contribution_status_id">
-                  <td class="label">{$form.contribution_status_id.label}</td>
-                  <td>{$form.contribution_status_id.html}</td>
-                </tr>
-              </table>
-            </fieldset>
-          </td></tr>
-          {else}
-          <div class="spacer"></div>
-        {/if}
+         {/if}
+        {include file="CRM/Member/Form/MembershipCommon.tpl"}
 
-        {if $emailExists and $outBound_option != 2 }
+        {if $emailExists and $outBound_option != 2}
           <tr id="send-receipt" class="crm-membership-form-block-send_receipt">
             <td class="label">{$form.send_receipt.label}</td><td>{$form.send_receipt.html}<br />
             <span class="description">{ts 1=$emailExists}Automatically email a membership confirmation and receipt to %1?{/ts}</span></td>
           </tr>
-          {elseif $context eq 'standalone' and $outBound_option != 2 }
+          {elseif $context eq 'standalone' and $outBound_option != 2}
           <tr id="email-receipt" style="display:none;">
             <td class="label">{$form.send_receipt.label}</td><td>{$form.send_receipt.html}<br />
             <span class="description">{ts}Automatically email a membership confirmation and receipt to {/ts}<span id="email-address"></span>?</span></td>
@@ -290,9 +192,9 @@
           <td>{$form.from_email_address.html}</td>
         </tr>
         <tr id='notice' style="display:none;">
-          <td class="label">{$form.receipt_text_signup.label}</td>
+          <td class="label">{$form.receipt_text.label}</td>
           <td class="html-adjust"><span class="description">{ts}If you need to include a special message for this member, enter it here. Otherwise, the confirmation email will include the standard receipt message configured under System Message Templates.{/ts}</span>
-            {$form.receipt_text_signup.html|crmAddClass:huge}</td>
+            {$form.receipt_text.html|crmAddClass:huge}</td>
         </tr>
       </table>
       <div id="customData"></div>
@@ -442,7 +344,7 @@
       cj('#is_different_contribution_contact').change( function() {
         setDifferentContactBlock();
       });
-      
+
       // give option to override end-date for auto-renew memberships
       {/literal}
       {if $isRecur && $endDate}
@@ -471,7 +373,7 @@
         cj('#record-different-contact').hide();
       }
     }
-    
+
     </script>
     {/literal}
 

--- a/templates/CRM/Member/Form/MembershipCommon.tpl
+++ b/templates/CRM/Member/Form/MembershipCommon.tpl
@@ -1,0 +1,106 @@
+{if !$membershipMode}
+  {if $accessContribution}
+    <table>
+      <tr class="crm-{$formClass}-form-block-contribution-contact">
+        <td class="label">{$form.is_different_contribution_contact.label}</td>
+        <td>{$form.is_different_contribution_contact.html}&nbsp;&nbsp;{help id="id-contribution_contact"}</td>
+      </tr>
+      <tr id="record-different-contact">
+        <td>&nbsp;</td>
+        <td>
+          <table class="compressed">
+            <tr class="crm-{$formClass}-form-block-soft-credit-type">
+              <td class="label">{$form.soft_credit_type_id.label}</td>
+              <td>{$form.soft_credit_type_id.html}</td>
+            </tr>
+            <tr class="crm-{$formClass}-form-block-soft-credit-contact-id">
+              <td class="label">{$form.soft_credit_contact_id.label}</td>
+              <td>{$form.soft_credit_contact_id.html}</td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+
+        <tr class="crm-{$formClass}-form-block-total_amount">
+          <td class="label">{$form.total_amount.label}</td>
+          <td>{$form.total_amount.html}<br />
+            <span class="description">{ts}Membership payment amount. A contribution record will be created for this amount.{/ts}</span><div class="totaltaxAmount"></div></td>
+        </tr>
+        <tr class="crm-{$formClass}-form-block-receive_date">
+          <td class="label">{$form.receive_date.label}</td>
+          <td>{include file="CRM/common/jcalendar.tpl" elementName=receive_date}</td>
+        </tr>
+        <tr class="crm-{$formClass}-form-block-financial_type_id">
+          <td class="label">{$form.financial_type_id.label}</td>
+          <td>{$form.financial_type_id.html}<br/>
+            <span class="description">{ts}Select the appropriate financial type for this payment.{/ts}</span>
+          </td>
+        </tr>
+        <tr class="crm-{$formClass}-form-block-payment_instrument_id">
+          <td class="label">{$form.payment_instrument_id.label}<span class='marker'>*</span></td>
+          <td>{$form.payment_instrument_id.html} {help id="payment_instrument_id" file="CRM/Contribute/Page/Tab.hlp"}</td>
+        </tr>
+        <tr id="checkNumber" class="crm-{$formClass}-form-block-check_number">
+          <td class="label">{$form.check_number.label}</td>
+          <td>{$form.check_number.html|crmAddClass:six}</td>
+        </tr>
+
+        {if $action neq 2 }
+          <tr class="crm-{$formClass}-form-block-trxn_id">
+            <td class="label">{$form.trxn_id.label}</td>
+            <td>{$form.trxn_id.html}</td>
+          </tr>
+        {/if}
+        <tr class="crm-{$formClass}-form-block-contribution_status_id">
+          <td class="label">{$form.contribution_status_id.label}</td>
+          <td>{$form.contribution_status_id.html}</td>
+        </tr>
+      </table>
+    </fieldset></td></tr>
+  {/if}
+
+{else}
+  {if !empty($form.auto_renew)}
+    <tr id="autoRenew" class="crm-{$formClass}-form-block-auto_renew">
+      <td class="label"> {$form.auto_renew.label} {help id="id-auto_renew" file="CRM/Member/Form/Membership.hlp" action=$action} </td>
+      <td> {$form.auto_renew.html} </td>
+    </tr>
+  {/if}
+  <tr class="crm-member-{$formClass}-form-block-financial_type_id">
+    <td class="label">{$form.financial_type_id.label}</td>
+    <td>{$form.financial_type_id.html}<br/>
+      <span class="description">{ts}Select the appropriate financial type for this payment.{/ts}</span></td>
+  </tr>
+  <tr class="crm-{$formClass}-form-block-total_amount">
+    <td class="label">{$form.total_amount.label}</td>
+    <td>{$form.total_amount.html}<br />
+      <span class="description">{ts}Membership payment amount.{/ts}</span><div class="totaltaxAmount"></div>
+    </td>
+  </tr>
+  <tr class="crm-membership-form-block-contribution-contact">
+    <td class="label">{$form.is_different_contribution_contact.label}</td>
+    <td>{$form.is_different_contribution_contact.html}&nbsp;&nbsp;{help id="id-contribution_contact"}</td>
+  </tr>
+  <tr id="record-different-contact">
+    <td>&nbsp;</td>
+    <td>
+      <table class="compressed">
+        <tr class="crm-membership-form-block-soft-credit-type">
+          {*CRM-15366*}
+          <td class="label">{$form.soft_credit_type_id.label}</td>
+          <td>{$form.soft_credit_type_id.html}</td>
+        </tr>
+        <tr class="crm-membership-form-block-soft-credit-contact-id">
+          <td class="label">{$form.soft_credit_contact_id.label}</td>
+          <td>{$form.soft_credit_contact_id.html}</td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+  <tr class="crm-membership-form-block-billing">
+    <td colspan="2">
+      {include file='CRM/Core/BillingBlock.tpl'}
+    </td>
+  </tr>
+  <div class="spacer"></div>
+{/if}

--- a/templates/CRM/Member/Form/MembershipRenewal.tpl
+++ b/templates/CRM/Member/Form/MembershipRenewal.tpl
@@ -93,13 +93,6 @@
         <td class="label">{$form.renewal_date.label}</td>
         <td>{include file="CRM/common/jcalendar.tpl" elementName=renewal_date}</td>
       </tr>
-      {if $membershipMode}
-        <tr class="crm-member-membershiprenew-form-block-financial_type_id">
-          <td class="label">{$form.financial_type_id.label}</td>
-          <td>{$form.financial_type_id.html}<br/>
-            <span class="description">{ts}Select the appropriate financial type for this payment.{/ts}</span></td>
-        </tr>
-      {/if}
       {if $accessContribution and ! $membershipMode}
         <tr class="crm-member-membershiprenew-form-block-record_contribution">
           <td class="label">{$form.record_contribution.label}</td>
@@ -127,108 +120,14 @@
                       class="description">{ts}Extend the membership end date by this many membership periods. Make sure the appropriate corresponding fee is entered below.{/ts}</span>
                   </td>
                 </tr>
-                {if $context neq 'standalone'}
-                  <tr class="crm-membership-form-block-contribution-contact">
-                    <td class="label">{$form.contribution_contact.label}</td>
-                    <td>{$form.contribution_contact.html}&nbsp;&nbsp;{help id="id-contribution_contact"}</td>
-                  </tr>
-                  <tr id="record-different-contact">
-                    <td>&nbsp;</td>
-                    <td>
-                      <table class="compressed">
-                        <tr class="crm-membership-form-block-soft-credit-type">
-                          <td class="label">{$form.soft_credit_type_id.label}</td>
-                          <td>{$form.soft_credit_type_id.html}</td>
-                        </tr>
-                        <tr class="crm-membership-form-block-soft-credit-contact-id">
-                          <td class="label">{$form.soft_credit_contact_id.label}</td>
-                          <td>{$form.soft_credit_contact_id.html}</td>
-                        </tr>
-                      </table>
-                    </td>
-                  </tr>
-                {/if}
-                <tr class="crm-member-membershiprenew-form-block-financial_type_id">
-                  <td class="label">{$form.financial_type_id.label}</td>
-                  <td>{$form.financial_type_id.html}<br/>
-                    <span class="description">{ts}Select the appropriate financial type for this payment.{/ts}</span>
-                  </td>
-                </tr>
-                <tr class="crm-member-membershiprenew-form-block-total_amount">
-                  <td class="label">{$form.total_amount.label}</td>
-                  <td>{$form.total_amount.html}<br/>
-                    <span
-                      class="description">{ts}Membership payment amount. A contribution record will be created for this amount.{/ts}</span>
-                  </td>
-                </tr>
-                <tr class="crm-membershiprenew-form-block-receive_date">
-                  <td class="label">{$form.receive_date.label}</td>
-                  <td>{include file="CRM/common/jcalendar.tpl" elementName=receive_date}</td>
-                </tr>
-                <tr class="crm-member-membershiprenew-form-block-payment_instrument_id">
-                  <td class="label">{$form.payment_instrument_id.label}<span class='marker'>*</span></td>
-                  <td>{$form.payment_instrument_id.html} {help id="payment_instrument_id" file="CRM/Contribute/Page/Tab.hlp"}</td>
-                </tr>
-                <tr id="checkNumber" class="crm-member-membershiprenew-form-block-check_number">
-                  <td class="label">{$form.check_number.label}</td>
-                  <td>{$form.check_number.html|crmAddClass:six}</td>
-                </tr>
-                <tr class="crm-member-membershiprenew-form-block-trxn_id">
-                  <td class="label">{$form.trxn_id.label}</td>
-                  <td>{$form.trxn_id.html}</td>
-                </tr>
-                <tr class="crm-member-membershiprenew-form-block-contribution_status_id">
-                  <td class="label">{$form.contribution_status_id.label}</td>
-                  <td>{$form.contribution_status_id.html}</td>
-                </tr>
-              </table>
-            </fieldset>
-          </td>
-        </tr>
-      {else}
-        <tr class="crm-member-membershiprenew-form-block-total_amount">
-          <td class="label">{$form.total_amount.label}</td>
-          <td>{$form.total_amount.html}<br/>
-            <span
-              class="description">{ts}Membership payment amount. A contribution record will be created for this amount.{/ts}</span>
-          </td>
-        </tr>
       {/if}
-    </table>
-    {if $membershipMode}
-      {if $context neq 'standalone'}
-        <table class="form-layout-compressed">
-          <tr class="crm-membership-form-block-contribution-contact">
-            <td class="label">{$form.contribution_contact.label}</td>
-            <td>{$form.contribution_contact.html}&nbsp;&nbsp;{help id="id-contribution_contact"}</td>
-          </tr>
-          <tr id="record-different-contact">
-            <td>&nbsp;</td>
-            <td>
-              <table class="form-layout-compressed">
-                <tr class="crm-membership-form-block-soft-credit-type">
-                  <td class="label">{$form.soft_credit_type_id.label}</td>
-                  <td>{$form.soft_credit_type_id.html}</td>
-                </tr>
-                <tr class="crm-membership-form-soft-credit-contact-id">
-                  <td class="label">{$form.soft_credit_contact_id.label}</td>
-                  <td>{$form.soft_credit_contact_id.html}</td>
-                </tr>
-              </table>
-            </td>
-          </tr>
-        </table>
-      {/if}
-      <div class="spacer"></div>
-      {include file='CRM/Core/BillingBlock.tpl'}
-    {/if}
-    {if $email and $outBound_option != 2}
+      {include file="CRM/Member/Form/MembershipCommon.tpl"}
+      {if $emailExists and $outBound_option != 2}
       <table class="form-layout">
-        <tr class="crm-member-membershiprenew-form-block-send_receipt">
+        <tr class="crm-{$formClass}-form-block-send_receipt">
           <td class="label">{$form.send_receipt.label}</td>
           <td>{$form.send_receipt.html}<br/>
-            <span
-              class="description">{ts 1=$email}Automatically email a membership confirmation and receipt to %1?{/ts}</span>
+            <span class="description">{ts 1=$emailExists}Automatically email a membership confirmation and receipt to %1?{/ts}</span>
           </td>
         </tr>
         <tr id="fromEmail">
@@ -393,13 +292,13 @@
 
     // show/hide different contact section
     setDifferentContactBlock();
-    cj('#contribution_contact').change(function () {
+    cj('#is_different_contribution_contact').change(function () {
       setDifferentContactBlock();
     });
 
     function setDifferentContactBlock() {
       //get the
-      if (cj('#contribution_contact').prop('checked')) {
+      if (cj('#is_different_contribution_contact').prop('checked')) {
         cj('#record-different-contact').show();
       }
       else {

--- a/templates/CRM/Member/Form/Task/j.html
+++ b/templates/CRM/Member/Form/Task/j.html
@@ -1,0 +1,1143 @@
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML+RDFa 1.0//EN"
+        "http://www.w3.org/MarkUp/DTD/xhtml-rdfa-1.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" version="XHTML+RDFa 1.0" dir="ltr"
+      xmlns:content="http://purl.org/rss/1.0/modules/content/"
+      xmlns:dc="http://purl.org/dc/terms/"
+      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      xmlns:og="http://ogp.me/ns#"
+      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+      xmlns:sioc="http://rdfs.org/sioc/ns#"
+      xmlns:sioct="http://rdfs.org/sioc/types#"
+      xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+      xmlns:fb="http://ogp.me/ns/fb#"
+      xmlns:article="http://ogp.me/ns/article#"
+      xmlns:book="http://ogp.me/ns/book#"
+      xmlns:profile="http://ogp.me/ns/profile#"
+      xmlns:video="http://ogp.me/ns/video#">
+
+<head profile="http://www.w3.org/1999/xhtml/vocab">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <link rel="shortcut icon" href="http://civi45/misc/favicon.ico" type="image/vnd.microsoft.icon" />
+
+    <script type="text/javascript">
+        var CRM = {"config":{"isFrontend":false}};
+    </script>
+    <meta name="generator" content="Drupal 7 (http://drupal.org)" />
+    <link rel="canonical" href="http://civi45/civicrm/contact/view/membership?reset=1&amp;action=add&amp;cid=40&amp;context=membership" />
+    <link rel="shortlink" href="http://civi45/civicrm/contact/view/membership?reset=1&amp;action=add&amp;cid=40&amp;context=membership" />
+    <meta property="og:site_name" content="drupal-demo" />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="http://civi45/civicrm/contact/view/membership?reset=1&amp;action=add&amp;cid=40&amp;context=membership" />
+    <meta property="og:title" content="New Membership" />
+    <title>New Membership | drupal-demo</title>
+    <style type="text/css" media="all">
+        @import url("http://civi45/modules/system/system.base.css?no9erv");
+        @import url("http://civi45/modules/system/system.menus.css?no9erv");
+        @import url("http://civi45/modules/system/system.messages.css?no9erv");
+        @import url("http://civi45/modules/system/system.theme.css?no9erv");
+    </style>
+    <style type="text/css" media="all">
+        @import url("http://civi45/modules/comment/comment.css?no9erv");
+        @import url("http://civi45/sites/all/modules/contrib/commerce_add_to_cart_confirmation/css/commerce_add_to_cart_confirmation.css?no9erv");
+        @import url("http://civi45/sites/all/modules/contrib/date/date_api/date.css?no9erv");
+        @import url("http://civi45/sites/all/modules/contrib/date/date_popup/themes/datepicker.1.7.css?no9erv");
+        @import url("http://civi45/modules/field/theme/field.css?no9erv");
+        @import url("http://civi45/modules/node/node.css?no9erv");
+        @import url("http://civi45/modules/search/search.css?no9erv");
+        @import url("http://civi45/modules/user/user.css?no9erv");
+        @import url("http://civi45/sites/all/modules/contrib/views/css/views.css?no9erv");
+    </style>
+    <style type="text/css" media="all">
+        @import url("http://civi45/sites/all/modules/contrib/ctools/css/ctools.css?no9erv");
+        @import url("http://civi45/sites/all/modules/civicrm/bower_components/datatables/media/css/jquery.dataTables.css?no9erv");
+        @import url("http://civi45/sites/all/modules/civicrm/bower_components/jquery-ui/themes/smoothness/jquery-ui.css?no9erv");
+        @import url("http://civi45/sites/all/modules/civicrm/bower_components/select2/select2.css?no9erv");
+        @import url("http://civi45/sites/all/modules/civicrm/css/navigation.css?no9erv");
+        @import url("http://civi45/sites/all/modules/civicrm/css/civicrm.css?no9erv");
+        @import url("http://civi45/modules/shortcut/shortcut.css?no9erv");
+        @import url("http://civi45/modules/toolbar/toolbar.css?no9erv");
+    </style>
+    <style type="text/css" media="all">
+        @import url("http://civi45/sites/default/files/color/garland-4281d447/style.css?no9erv");
+    </style>
+    <style type="text/css" media="print">
+        @import url("http://civi45/themes/garland/print.css?no9erv");
+    </style>
+
+    <!--[if lt IE 7]>
+    <link type="text/css" rel="stylesheet" href="http://civi45/themes/garland/fix-ie.css?no9erv" media="all" />
+    <![endif]-->
+    <script type="text/javascript" src="http://civi45/misc/jquery.js?v=1.4.4"></script>
+    <script type="text/javascript" src="http://civi45/misc/jquery.once.js?v=1.2"></script>
+    <script type="text/javascript" src="http://civi45/misc/drupal.js?no9erv"></script>
+    <script type="text/javascript" src="http://civi45/misc/jquery.cookie.js?v=1.0"></script>
+    <script type="text/javascript" src="http://civi45/sites/all/modules/civicrm/bower_components/jquery/dist/jquery.js?no9erv"></script>
+    <script type="text/javascript" src="http://civi45/sites/all/modules/civicrm/bower_components/jquery-ui/jquery-ui.js?no9erv"></script>
+    <script type="text/javascript" src="http://civi45/sites/all/modules/civicrm/bower_components/lodash-compat/lodash.js?no9erv"></script>
+    <script type="text/javascript" src="http://civi45/sites/all/modules/civicrm/packages/jquery/plugins/jquery.mousewheel.js?no9erv"></script>
+    <script type="text/javascript" src="http://civi45/sites/all/modules/civicrm/bower_components/select2/select2.js?no9erv"></script>
+    <script type="text/javascript" src="http://civi45/sites/all/modules/civicrm/packages/jquery/plugins/jquery.tableHeader.js?no9erv"></script>
+    <script type="text/javascript" src="http://civi45/sites/all/modules/civicrm/packages/jquery/plugins/jquery.form.js?no9erv"></script>
+    <script type="text/javascript" src="http://civi45/sites/all/modules/civicrm/packages/jquery/plugins/jquery.timeentry.js?no9erv"></script>
+    <script type="text/javascript" src="http://civi45/sites/all/modules/civicrm/packages/jquery/plugins/jquery.blockUI.js?no9erv"></script>
+    <script type="text/javascript" src="http://civi45/sites/all/modules/civicrm/bower_components/datatables/media/js/jquery.dataTables.js?no9erv"></script>
+    <script type="text/javascript" src="http://civi45/sites/all/modules/civicrm/bower_components/jquery-validation/dist/jquery.validate.js?no9erv"></script>
+    <script type="text/javascript" src="http://civi45/sites/all/modules/civicrm/packages/jquery/plugins/jquery.ui.datepicker.validation.pack.js?no9erv"></script>
+    <script type="text/javascript" src="http://civi45/sites/all/modules/civicrm/js/Common.js?no9erv"></script>
+    <script type="text/javascript" src="http://civi45/sites/all/modules/civicrm/js/crm.ajax.js?no9erv"></script>
+    <script type="text/javascript" src="http://civi45/sites/all/modules/civicrm/js/wysiwyg/crm.wysiwyg.js?no9erv"></script>
+    <script type="text/javascript" src="http://civi45/sites/all/modules/civicrm/packages/jquery/plugins/jquery.menu.js?no9erv"></script>
+    <script type="text/javascript" src="http://civi45/sites/all/modules/civicrm/packages/jquery/plugins/jquery.jeditable.js?no9erv"></script>
+    <script type="text/javascript" src="http://civi45/sites/all/modules/civicrm/packages/jquery/plugins/jquery.notify.js?no9erv"></script>
+    <script type="text/javascript" src="http://civi45/sites/all/modules/civicrm/js/jquery/jquery.crmeditable.js?no9erv"></script>
+    <script type="text/javascript" src="http://civi45/sites/all/modules/civicrm/js/crm.optionEdit.js?no9erv"></script>
+    <script type="text/javascript" src="http://civi45/sites/all/modules/civicrm/js/crm.drupal.js?no9erv"></script>
+    <script type="text/javascript" src="/civicrm/ajax/l10n-js/en_US?r=emQ4Z"></script>
+    <script type="text/javascript" src="http://civi45/sites/all/modules/civicrm/js/noconflict.js?no9erv"></script>
+    <script type="text/javascript" src="http://civi45/sites/all/modules/contrib/commerce_add_to_cart_confirmation/js/commerce_add_to_cart_confirmation.js?no9erv"></script>
+    <script type="text/javascript" src="http://civi45/modules/toolbar/toolbar.js?no9erv"></script>
+    <script type="text/javascript">
+        <!--//--><![CDATA[//><!--
+        jQuery.extend(Drupal.settings, {"basePath":"\/","pathPrefix":"","ajaxPageState":{"theme":"garland","theme_token":"ajQQAyPu9RH9K2uS_lrg5X89XsbUcbZXACyeRFu6zRI","js":{"misc\/jquery.js":1,"misc\/jquery.once.js":1,"misc\/drupal.js":1,"misc\/jquery.cookie.js":1,"sites\/all\/modules\/civicrm\/bower_components\/jquery\/dist\/jquery.js":1,"sites\/all\/modules\/civicrm\/bower_components\/jquery-ui\/jquery-ui.js":1,"sites\/all\/modules\/civicrm\/bower_components\/lodash-compat\/lodash.js":1,"sites\/all\/modules\/civicrm\/packages\/jquery\/plugins\/jquery.mousewheel.js":1,"sites\/all\/modules\/civicrm\/bower_components\/select2\/select2.js":1,"sites\/all\/modules\/civicrm\/packages\/jquery\/plugins\/jquery.tableHeader.js":1,"sites\/all\/modules\/civicrm\/packages\/jquery\/plugins\/jquery.form.js":1,"sites\/all\/modules\/civicrm\/packages\/jquery\/plugins\/jquery.timeentry.js":1,"sites\/all\/modules\/civicrm\/packages\/jquery\/plugins\/jquery.blockUI.js":1,"sites\/all\/modules\/civicrm\/bower_components\/datatables\/media\/js\/jquery.dataTables.js":1,"sites\/all\/modules\/civicrm\/bower_components\/jquery-validation\/dist\/jquery.validate.js":1,"sites\/all\/modules\/civicrm\/packages\/jquery\/plugins\/jquery.ui.datepicker.validation.pack.js":1,"sites\/all\/modules\/civicrm\/js\/Common.js":1,"sites\/all\/modules\/civicrm\/js\/crm.ajax.js":1,"sites\/all\/modules\/civicrm\/js\/wysiwyg\/crm.wysiwyg.js":1,"sites\/all\/modules\/civicrm\/packages\/jquery\/plugins\/jquery.menu.js":1,"sites\/all\/modules\/civicrm\/packages\/jquery\/plugins\/jquery.jeditable.js":1,"sites\/all\/modules\/civicrm\/packages\/jquery\/plugins\/jquery.notify.js":1,"sites\/all\/modules\/civicrm\/js\/jquery\/jquery.crmeditable.js":1,"sites\/all\/modules\/civicrm\/js\/crm.optionEdit.js":1,"sites\/all\/modules\/civicrm\/js\/crm.drupal.js":1,"\/civicrm\/ajax\/l10n-js\/en_US?r=emQ4Z":1,"sites\/all\/modules\/civicrm\/js\/noconflict.js":1,"sites\/all\/modules\/contrib\/commerce_add_to_cart_confirmation\/js\/commerce_add_to_cart_confirmation.js":1,"modules\/toolbar\/toolbar.js":1},"css":{"modules\/system\/system.base.css":1,"modules\/system\/system.menus.css":1,"modules\/system\/system.messages.css":1,"modules\/system\/system.theme.css":1,"modules\/comment\/comment.css":1,"sites\/all\/modules\/contrib\/commerce_add_to_cart_confirmation\/css\/commerce_add_to_cart_confirmation.css":1,"sites\/all\/modules\/contrib\/date\/date_api\/date.css":1,"sites\/all\/modules\/contrib\/date\/date_popup\/themes\/datepicker.1.7.css":1,"modules\/field\/theme\/field.css":1,"modules\/node\/node.css":1,"modules\/search\/search.css":1,"modules\/user\/user.css":1,"sites\/all\/modules\/contrib\/views\/css\/views.css":1,"sites\/all\/modules\/contrib\/ctools\/css\/ctools.css":1,"sites\/all\/modules\/civicrm\/bower_components\/datatables\/media\/css\/jquery.dataTables.css":1,"sites\/all\/modules\/civicrm\/bower_components\/jquery-ui\/themes\/smoothness\/jquery-ui.css":1,"sites\/all\/modules\/civicrm\/bower_components\/select2\/select2.css":1,"sites\/all\/modules\/civicrm\/css\/navigation.css":1,"sites\/all\/modules\/civicrm\/css\/civicrm.css":1,"modules\/shortcut\/shortcut.css":1,"modules\/toolbar\/toolbar.css":1,"themes\/garland\/style.css":1,"themes\/garland\/print.css":1,"themes\/garland\/fix-ie.css":1}},"tableHeaderOffset":"Drupal.toolbar.height"});
+        //--><!]]>
+    </script>
+</head>
+<body class="html not-front logged-in no-sidebars page-civicrm page-civicrm-contact page-civicrm-contact-view page-civicrm-contact-view-membership toolbar toolbar-drawer fluid-width" >
+<div id="skip-link">
+    <a href="#main-content" class="element-invisible element-focusable">Skip to main content</a>
+</div>
+<div class="region region-page-top">
+    <div id="toolbar" class="toolbar overlay-displace-top clearfix">
+        <div class="toolbar-menu clearfix">
+            <ul id="toolbar-home"><li class="home first last"><a href="/" title="Home"><span class="home-link">Home</span></a></li>
+            </ul>    <ul id="toolbar-user"><li class="account first"><a href="/user" title="User account">Hello <strong>test</strong></a></li>
+            <li class="logout last"><a href="/user/logout?current=civicrm/contact/view/membership">Log out</a></li>
+        </ul>              <a href="/toolbar/toggle?destination=civicrm/contact/view/membership%3Freset%3D1%26action%3Dadd%26cid%3D40%26context%3Dmembership" title="Hide shortcuts" class="toggle toggle-active">Hide shortcuts</a>      </div>
+
+        <div class="toolbar-drawer clearfix">
+            <div class="toolbar-shortcuts"></div>  </div>
+    </div>
+</div>
+
+<div id="wrapper">
+    <div id="container" class="clearfix">
+
+        <div id="header">
+            <div id="logo-floater">
+                <div id="branding"><strong><a href="/">
+                    <img src="http://civi45/sites/default/files/logo.png" alt="drupal-demo " title="drupal-demo " id="logo" />
+                    <span>drupal-demo</span>            </a></strong></div>
+            </div>
+
+            <h2 class="element-invisible">Main menu</h2><ul class="links inline main-menu"><li class="menu-218 first last"><a href="/">Home</a></li>
+        </ul>        <h2 class="element-invisible">Secondary menu</h2><ul class="links inline secondary-menu"><li class="menu-601 first last"><a href="/welcome">Contact</a></li>
+        </ul>      </div> <!-- /#header -->
+
+
+        <div id="center"><div id="squeeze"><div class="right-corner"><div class="left-corner">
+            <h2 class="element-invisible">You are here</h2><div class="breadcrumb"><a href="/">Home</a> › <a href="/civicrm?reset=1">CiviCRM</a> › <a href="/civicrm/contact/view?reset=1&amp;cid=40">Contact Summary</a></div>                    <a id="main-content"></a>
+            <div id="tabs-wrapper" class="clearfix">                                <h1 class="with-tabs">New Membership</h1>
+            </div>                                                  <div class="clearfix">
+            <div class="region region-content">
+                <div id="block-system-main" class="block block-system clearfix">
+
+
+                    <div class="content">
+
+
+
+
+
+
+                        <div id="crm-container" class="crm-container" lang="en" xml:lang="en">
+
+
+                            <script id="civicrm-navigation-menu" type="text/javascript" src="/civicrm/ajax/menujs/207/en_US/1/1cJ2UX9u" data-qfkey="baeec0c69227ddd150ba62469eacd3c9_2494"></script>
+
+                            <div id="printer-friendly">
+                                <a href="/civicrm/contact/view/membership?action=add&amp;cid=40&amp;context=membership&amp;snippet=2" target='_blank' title="Printer-friendly view of this page.">
+                                    <div class="ui-icon ui-icon-print"></div>
+                                </a>
+                            </div>
+
+                            <div class="clear"></div>
+
+                            <div id="crm-main-content-wrapper">
+                                <!-- .tpl file invoked: CRM/Member/Page/Tab.tpl. Call via form.tpl if we have a form in the page. -->
+                                <form  action="/civicrm/contact/view/membership" method="post" name="Membership" id="Membership" class="CRM_Member_Form_Membership" enctype="multipart/form-data" data-warn-changes="true" >
+
+
+                                    <div><input name="qfKey" type="hidden" value="3518b4a969162cb5ce288965a9d07f8b_9622" />
+                                        <input name="entryURL" type="hidden" value="http://civi45/civicrm/contact/view/membership?reset=1&amp;amp;action=add&amp;amp;cid=40&amp;amp;context=membership" />
+                                        <input name="included_past_campaigns" type="hidden" value="" />
+                                        <input name="_qf_default" type="hidden" value="Membership:upload" />
+                                        <input name="MAX_FILE_SIZE" type="hidden" value="2097152" />
+                                    </div>
+
+
+
+
+                                    <div class="view-content">
+                                        <div class="spacer"></div>
+                                        <div class="crm-block crm-form-block crm-membership-form-block">
+                                            <div class="crm-submit-buttons">
+
+        <span class="crm-button crm-button-type-upload crm-button_qf_Membership_upload crm-icon-button">
+          <span class="crm-button-icon ui-icon-check"> </span>          <input class="crm-form-submit default validate" accesskey="S" crm-icon="check" name="_qf_Membership_upload" value="Save" type="submit" id="_qf_Membership_upload-top" />
+        </span>
+
+
+        <span class="crm-button crm-button-type-upload crm-button_qf_Membership_upload_new crm-icon-button">
+          <span class="crm-button-icon ui-icon-plus"> </span>          <input class="crm-form-submit validate" crm-icon="plus" name="_qf_Membership_upload_new" value="Save and New" type="submit" id="_qf_Membership_upload_new-top" />
+        </span>
+
+
+        <span class="crm-button crm-button-type-cancel crm-button_qf_Membership_cancel crm-icon-button">
+          <span class="crm-button-icon ui-icon-close"> </span>          <input class="crm-form-submit cancel" crm-icon="close" name="_qf_Membership_cancel" value="Cancel" type="submit" id="_qf_Membership_cancel-top" />
+        </span>
+                                            </div>
+                                            <table class="form-layout-compressed">
+                                                <tr>
+                                                    <td class="font-size12pt label"><strong>Member</strong></td><td class="font-size12pt"><strong>Mr. Jackson Adams</strong></td>
+                                                </tr>
+                                                <tr class="crm-membership-form-block-membership_type_id">
+                                                    <td class="label"><label>Membership Organization and Type</label></td>
+                                                    <td><span id='mem_type_id'><script type="text/javascript">
+                                                        //<![CDATA[
+                                                        hs_membership_type_id_1 = {
+                                                            "0":"- select -",
+                                                            "1":"General",
+                                                            "3":"Lifetime",
+                                                            "2":"Student"
+                                                        }
+                                                        function swapOptions(frm, grpName, eleIndex, nbElements, arName)
+                                                        {
+                                                            var n = "";
+                                                            var ctl;
+
+                                                            for (var i = 0; i < nbElements; i++) {
+                                                                ctl = frm[grpName+'['+i+']'];
+                                                                if (!ctl) {
+                                                                    ctl = frm[grpName+'['+i+'][]'];
+                                                                }
+                                                                if (i <= eleIndex) {
+                                                                    n += "_"+ctl.value;
+                                                                } else {
+                                                                    ctl.length = 0;
+                                                                }
+                                                            }
+
+                                                            var t = eval("typeof("+arName + n +")");
+                                                            if (t != 'undefined') {
+                                                                var the_array = eval(arName+n);
+                                                                var j = 0;
+                                                                n = eleIndex + 1;
+                                                                ctl = frm[grpName+'['+ n +']'];
+                                                                if (!ctl) {
+                                                                    ctl = frm[grpName+'['+ n +'][]'];
+                                                                }
+                                                                ctl.style.display = 'inline';
+                                                                for (var i in the_array) {
+                                                                    opt = new Option(the_array[i], i, false, false);
+                                                                    ctl.options[j++] = opt;
+                                                                }
+                                                            } else {
+                                                                n = eleIndex + 1;
+                                                                ctl = frm[grpName+'['+n+']'];
+                                                                if (!ctl) {
+                                                                    ctl = frm[grpName+'['+ n +'][]'];
+                                                                }
+                                                                if (ctl) {
+                                                                    ctl.style.display = 'none';
+                                                                }
+                                                            }
+                                                            if (eleIndex+1 < nbElements) {
+                                                                swapOptions(frm, grpName, eleIndex+1, nbElements, arName);
+                                                            }
+                                                        }
+                                                        //]]>
+                                                    </script><select onchange="swapOptions(this.form, 'membership_type_id', 0, 2, 'hs_membership_type_id');" name="membership_type_id[0]" id="membership_type_id_0" class="crm-form-select">
+                                                        <option value="1">Default Organization</option>
+                                                    </select>&nbsp;<select onchange="buildMaxRelated(this.value,true); CRM.buildCustomData( 'Membership', this.value );" name="membership_type_id[1]" id="membership_type_id_1" class="crm-form-select">
+                                                        <option value="0">- select -</option>
+                                                        <option value="1">General</option>
+                                                        <option value="3">Lifetime</option>
+                                                        <option value="2">Student</option>
+                                                    </select></span>
+                                                        <span id='totalAmountORPriceSet'> OR</span>
+              <span id='selectPriceSet'><select onchange="buildAmount( this.value );" name="price_set_id" id="price_set_id" class="crm-form-select">
+                  <option value="">Choose price set</option>
+                  <option value="4">Member Signup and Renewal</option>
+              </select></span>
+                                                        <div id="priceset" class="hiddenElement"></div>
+                                                        <br />
+                                                        <span class="description">Select Membership Organization and then Membership Type. Alternatively, you can use a price set.</span>
+                                                    </td>
+                                                </tr>
+                                                <tr id="maxRelated" class="crm-membership-form-block-max_related">
+                                                    <td class="label"><label for="max_related">Max related</label></td>
+                                                    <td><input size="6" maxlength="14" name="max_related" type="text" id="max_related" class="six crm-form-text" /><br />
+                                                        <span class="description">Maximum number of related memberships (leave blank for unlimited).</span>
+                                                    </td>
+                                                </tr>
+                                                <tr id="num_terms_row" class="crm-membership-form-block-num_terms">
+                                                    <td class="label"><label for="num_terms">Number of Terms</label></td>
+                                                    <td>&nbsp;<input size="6" name="num_terms" type="text" value="1" id="num_terms" class="six crm-form-text" /><br />
+                                                        <span class="description">Set the membership end date this many membership periods from now. Make sure the appropriate corresponding fee is entered below.</span>
+                                                    </td>
+                                                </tr>
+                                                <tr class="crm-membership-form-block-source">
+                                                    <td class="label"><label for="source">Source</label></td>
+                                                    <td>&nbsp;<input name="source" type="text" id="source" class="crm-form-text" /><br />
+                                                        <span class="description">Source of this membership. This value is searchable.</span></td>
+                                                </tr>
+
+
+
+                                                <tr class="crm-membership-form-block-join_date"><td class="label"><label for="join_date">Member Since</label></td><td>                      <input formattype="activityDate" startoffset="20" endoffset="10" format="mm/dd/yy" name="join_date" type="text" value="05/14/2015" id="join_date" class="crm-form-text" />
+
+
+                                                    <input type="text" name="join_date_display_55548897854dd" id="join_date_display_55548897854dd" class="dateplugin" autocomplete="off"/>
+
+
+
+                                                    <a href="#" class="crm-hover-button crm-clear-link" title="Clear"><span class="icon ui-icon-close"></span></a>
+
+                                                    <script type="text/javascript">
+
+                                                        CRM.$(function($) {
+
+                                                            // Workaround for possible duplicate ids in the dom - select by name instead of id and exclude already initialized widgets
+                                                            var $dateElement = $('input[name=join_date_display_55548897854dd].dateplugin:not(.hasDatepicker)');
+
+                                                            if (!$dateElement.length) {
+                                                                return;
+                                                            }
+
+                                                            var $timeElement = $dateElement.siblings("#join_date_time");
+                                                            var time_format = $timeElement.attr('timeFormat');
+
+                                                            $timeElement.timeEntry({ show24Hours : time_format, spinnerImage: '' });
+
+                                                            var currentYear = new Date().getFullYear(),
+                                                                    $originalElement = $dateElement.siblings('#join_date').hide(),
+                                                                    date_format = $originalElement.attr('format'),
+                                                                    altDateFormat = 'mm/dd/yy';
+
+
+                                                            if ( !( ( date_format == 'M yy' ) || ( date_format == 'yy' ) || ( date_format == 'yy-mm' ) ) ) {
+                                                                $dateElement.addClass( 'dpDate' );
+                                                            }
+
+                                                            var yearRange = (currentYear - parseInt($originalElement.attr('startOffset'))) +
+                                                                            ':' + currentYear + parseInt($originalElement.attr('endOffset')),
+                                                                    startRangeYr = currentYear - parseInt($originalElement.attr('startOffset')),
+                                                                    endRangeYr = currentYear + parseInt($originalElement.attr('endOffset'));
+
+                                                            $dateElement.datepicker({
+                                                                closeAtTop: true,
+                                                                dateFormat: date_format,
+                                                                changeMonth: (date_format.indexOf('m') > -1),
+                                                                changeYear: (date_format.indexOf('y') > -1),
+                                                                altField: $originalElement,
+                                                                altFormat: altDateFormat,
+                                                                yearRange: yearRange,
+                                                                minDate: new Date(startRangeYr, 1 - 1, 1),
+                                                                maxDate: new Date(endRangeYr, 12 - 1, 31)
+                                                            });
+
+                                                            // format display date
+                                                            var displayDateValue = $.datepicker.formatDate(date_format, $.datepicker.parseDate(altDateFormat, $originalElement.val()));
+                                                            //support unsaved-changes warning: CRM-14353
+                                                            $dateElement.val(displayDateValue).data('crm-initial-value', displayDateValue);
+
+                                                            // Add clear button
+                                                            $($timeElement).add($originalElement).add($dateElement).on('blur change', function() {
+                                                                var vis = $dateElement.val() || $timeElement.val() ? '' : 'hidden';
+                                                                $dateElement.siblings('.crm-clear-link').css('visibility', vis);
+                                                            });
+                                                            $originalElement.change();
+                                                        });
+
+
+                                                    </script>
+
+                                                    <br />
+                                                    <span class="description">When did this contact first become a member?</span></td></tr>
+                                                <tr class="crm-membership-form-block-start_date"><td class="label"><label for="start_date">Start Date</label></td><td>                      <input formattype="activityDate" startoffset="20" endoffset="10" format="mm/dd/yy" name="start_date" type="text" id="start_date" class="crm-form-text" />
+
+
+                                                    <input type="text" name="start_date_display_5554889785dd7" id="start_date_display_5554889785dd7" class="dateplugin" autocomplete="off"/>
+
+
+
+                                                    <a href="#" class="crm-hover-button crm-clear-link" title="Clear"><span class="icon ui-icon-close"></span></a>
+
+                                                    <script type="text/javascript">
+
+                                                        CRM.$(function($) {
+
+                                                            // Workaround for possible duplicate ids in the dom - select by name instead of id and exclude already initialized widgets
+                                                            var $dateElement = $('input[name=start_date_display_5554889785dd7].dateplugin:not(.hasDatepicker)');
+
+                                                            if (!$dateElement.length) {
+                                                                return;
+                                                            }
+
+                                                            var $timeElement = $dateElement.siblings("#start_date_time");
+                                                            var time_format = $timeElement.attr('timeFormat');
+
+                                                            $timeElement.timeEntry({ show24Hours : time_format, spinnerImage: '' });
+
+                                                            var currentYear = new Date().getFullYear(),
+                                                                    $originalElement = $dateElement.siblings('#start_date').hide(),
+                                                                    date_format = $originalElement.attr('format'),
+                                                                    altDateFormat = 'mm/dd/yy';
+
+
+                                                            if ( !( ( date_format == 'M yy' ) || ( date_format == 'yy' ) || ( date_format == 'yy-mm' ) ) ) {
+                                                                $dateElement.addClass( 'dpDate' );
+                                                            }
+
+                                                            var yearRange = (currentYear - parseInt($originalElement.attr('startOffset'))) +
+                                                                            ':' + currentYear + parseInt($originalElement.attr('endOffset')),
+                                                                    startRangeYr = currentYear - parseInt($originalElement.attr('startOffset')),
+                                                                    endRangeYr = currentYear + parseInt($originalElement.attr('endOffset'));
+
+                                                            $dateElement.datepicker({
+                                                                closeAtTop: true,
+                                                                dateFormat: date_format,
+                                                                changeMonth: (date_format.indexOf('m') > -1),
+                                                                changeYear: (date_format.indexOf('y') > -1),
+                                                                altField: $originalElement,
+                                                                altFormat: altDateFormat,
+                                                                yearRange: yearRange,
+                                                                minDate: new Date(startRangeYr, 1 - 1, 1),
+                                                                maxDate: new Date(endRangeYr, 12 - 1, 31)
+                                                            });
+
+                                                            // format display date
+                                                            var displayDateValue = $.datepicker.formatDate(date_format, $.datepicker.parseDate(altDateFormat, $originalElement.val()));
+                                                            //support unsaved-changes warning: CRM-14353
+                                                            $dateElement.val(displayDateValue).data('crm-initial-value', displayDateValue);
+
+                                                            // Add clear button
+                                                            $($timeElement).add($originalElement).add($dateElement).on('blur change', function() {
+                                                                var vis = $dateElement.val() || $timeElement.val() ? '' : 'hidden';
+                                                                $dateElement.siblings('.crm-clear-link').css('visibility', vis);
+                                                            });
+                                                            $originalElement.change();
+                                                        });
+
+
+                                                    </script>
+
+                                                    <br />
+                                                    <span class="description">First day of current continuous membership period. Start Date will be automatically set based on Membership Type if you don't select a date.</span></td></tr>
+                                                <tr class="crm-membership-form-block-end_date"><td class="label"><label for="end_date">End Date</label></td>
+                                                    <td id="end-date-readonly">
+
+                                                        <a href="#" class="crm-hover-button action-item override-date" id="show-end-date">
+                                                            Over-ride end date              </a>
+                                                        <a class="helpicon" title="Override End Date for Auto-renew Memberships Help" href="#" onclick='CRM.help(&quot;Override End Date for Auto-renew Memberships&quot;, {"id":"override_end_date","file":"CRM\/Member\/Page\/Tab"}); return false;'>&nbsp;</a>
+                                                    </td>
+                                                    <td id="end-date-editable">
+                                                        <input formattype="activityDate" startoffset="20" endoffset="10" format="mm/dd/yy" name="end_date" type="text" id="end_date" class="crm-form-text" />
+
+
+                                                        <input type="text" name="end_date_display_5554889786d0d" id="end_date_display_5554889786d0d" class="dateplugin" autocomplete="off"/>
+
+
+
+                                                        <a href="#" class="crm-hover-button crm-clear-link" title="Clear"><span class="icon ui-icon-close"></span></a>
+
+                                                        <script type="text/javascript">
+
+                                                            CRM.$(function($) {
+
+                                                                // Workaround for possible duplicate ids in the dom - select by name instead of id and exclude already initialized widgets
+                                                                var $dateElement = $('input[name=end_date_display_5554889786d0d].dateplugin:not(.hasDatepicker)');
+
+                                                                if (!$dateElement.length) {
+                                                                    return;
+                                                                }
+
+                                                                var $timeElement = $dateElement.siblings("#end_date_time");
+                                                                var time_format = $timeElement.attr('timeFormat');
+
+                                                                $timeElement.timeEntry({ show24Hours : time_format, spinnerImage: '' });
+
+                                                                var currentYear = new Date().getFullYear(),
+                                                                        $originalElement = $dateElement.siblings('#end_date').hide(),
+                                                                        date_format = $originalElement.attr('format'),
+                                                                        altDateFormat = 'mm/dd/yy';
+
+
+                                                                if ( !( ( date_format == 'M yy' ) || ( date_format == 'yy' ) || ( date_format == 'yy-mm' ) ) ) {
+                                                                    $dateElement.addClass( 'dpDate' );
+                                                                }
+
+                                                                var yearRange = (currentYear - parseInt($originalElement.attr('startOffset'))) +
+                                                                                ':' + currentYear + parseInt($originalElement.attr('endOffset')),
+                                                                        startRangeYr = currentYear - parseInt($originalElement.attr('startOffset')),
+                                                                        endRangeYr = currentYear + parseInt($originalElement.attr('endOffset'));
+
+                                                                $dateElement.datepicker({
+                                                                    closeAtTop: true,
+                                                                    dateFormat: date_format,
+                                                                    changeMonth: (date_format.indexOf('m') > -1),
+                                                                    changeYear: (date_format.indexOf('y') > -1),
+                                                                    altField: $originalElement,
+                                                                    altFormat: altDateFormat,
+                                                                    yearRange: yearRange,
+                                                                    minDate: new Date(startRangeYr, 1 - 1, 1),
+                                                                    maxDate: new Date(endRangeYr, 12 - 1, 31)
+                                                                });
+
+                                                                // format display date
+                                                                var displayDateValue = $.datepicker.formatDate(date_format, $.datepicker.parseDate(altDateFormat, $originalElement.val()));
+                                                                //support unsaved-changes warning: CRM-14353
+                                                                $dateElement.val(displayDateValue).data('crm-initial-value', displayDateValue);
+
+                                                                // Add clear button
+                                                                $($timeElement).add($originalElement).add($dateElement).on('blur change', function() {
+                                                                    var vis = $dateElement.val() || $timeElement.val() ? '' : 'hidden';
+                                                                    $dateElement.siblings('.crm-clear-link').css('visibility', vis);
+                                                                });
+                                                                $originalElement.change();
+                                                            });
+
+
+                                                        </script>
+
+                                                        <br />
+                                                        <span class="description">Latest membership period expiration date. End Date will be automatically set based on Membership Type if you don't select a date.</span>
+                                                    </td>
+                                                </tr>
+                                                <tr><td class="label"><label for="is_override">Status Override?</label> <a class="helpicon" title="Override Status Help" href="#" onclick='CRM.help(&quot;Override Status&quot;, {"id":"id-status-override","file":"CRM\/Member\/Page\/Tab"}); return false;'>&nbsp;</a></td><td><input onclick="showHideMemberStatus()" id="is_override" name="is_override" type="checkbox" value="1" class="crm-form-checkbox" /></td></tr>
+                                                <tr id="memberStatus_show">
+                                                </tr>
+
+                                                <tr id="memberStatus"><td class="label"><label for="status_id">Membership Status</label></td><td><select name="status_id" id="status_id" class="crm-form-select">
+                                                    <option value="">- select -</option>
+                                                    <option value="1">New</option>
+                                                    <option value="2">Current</option>
+                                                    <option value="3">Grace</option>
+                                                    <option value="4">Expired</option>
+                                                    <option value="5">Pending</option>
+                                                    <option value="6">Cancelled</option>
+                                                    <option value="7">Deceased</option>
+                                                </select><br />
+                                                    <span class="description">If <strong>Status Override</strong> is checked, the selected status will remain in force (it will NOT be modified by the automated status update script).</span></td></tr>
+
+                                                <table>
+
+
+                                                    <tr id="send-receipt" class="crm-membership-form-block-send_receipt">
+                                                        <td class="label"><label for="send_receipt">Send Confirmation and Receipt?</label></td><td><input onclick="showHideByValue( 'send_receipt', '', 'notice', 'table-row', 'radio', false); showHideByValue( 'send_receipt', '', 'fromEmail', 'table-row', 'radio', false);" id="send_receipt" name="send_receipt" type="checkbox" value="1" class="crm-form-checkbox" /><br />
+                                                        <span class="description">Automatically email a membership confirmation and receipt to eileen@mcnaughty.com?</span></td>
+                                                    </tr>
+                                                    <tr id="fromEmail" style="display:none;">
+                                                        <td class="label"><label for="from_email_address">Receipt From</label></td>
+                                                        <td><select name="from_email_address" id="from_email_address" class="crm-form-select">
+                                                            <option value="&quot;FIXME&quot; &lt;info@EXAMPLE.ORG&gt;">&quot;FIXME&quot; &lt;info@EXAMPLE.ORG&gt;</option>
+                                                            <option value="test test &lt;test@mcnaughty.com&gt;">test test &lt;test@mcnaughty.com&gt; Home (preferred)</option>
+                                                        </select></td>
+                                                    </tr>
+                                                    <tr id='notice' style="display:none;">
+                                                        <td class="label"></td>
+                                                        <td class="html-adjust"><span class="description">If you need to include a special message for this member, enter it here. Otherwise, the confirmation email will include the standard receipt message configured under System Message Templates.</span>
+                                                        </td>
+                                                    </tr>
+                                                </table>
+                                                <div id="customData"></div>
+
+                                                <script type="text/javascript">
+                                                    CRM.buildCustomData = function( type, subType, subName, cgCount, groupID, isMultiple ) {
+                                                        var dataUrl = "/civicrm/custom?snippet=4&type=" + type;
+
+                                                        if ( subType ) {
+                                                            dataUrl = dataUrl + '&subType=' + subType;
+                                                        }
+
+                                                        if ( subName ) {
+                                                            dataUrl = dataUrl + '&subName=' + subName;
+                                                            cj('#customData' + subName ).show();
+                                                        }
+                                                        else {
+                                                            cj('#customData').show();
+                                                        }
+                                                        if ( groupID ) {
+                                                            dataUrl = dataUrl + '&groupID=' + groupID;
+                                                        }
+
+
+
+
+                                                        if ( !cgCount ) {
+                                                            cgCount = 1;
+                                                            var prevCount = 1;
+                                                        }
+                                                        else if ( cgCount >= 1 ) {
+                                                            var prevCount = cgCount;
+                                                            cgCount++;
+                                                        }
+
+                                                        dataUrl = dataUrl + '&cgcount=' + cgCount;
+
+
+                                                        if ( isMultiple ) {
+                                                            var fname = '#custom_group_' + groupID + '_' + prevCount;
+                                                            if (cj(".add-more-link-" + groupID + "-" + prevCount ).length) {
+                                                                cj(".add-more-link-" + groupID + "-" + prevCount).hide();
+                                                            }
+                                                            else {
+                                                                cj("#add-more-link-"+prevCount).hide();
+                                                            }
+                                                        }
+                                                        else {
+                                                            if ( subName && subName != 'null' ) {
+                                                                var fname = '#customData' + subName ;
+                                                            }
+                                                            else {
+                                                                var fname = '#customData';
+                                                            }
+                                                        }
+
+                                                        cj.ajax({
+                                                            url: dataUrl,
+                                                            dataType: 'html',
+                                                            async: false,
+                                                            success: function(response) {
+                                                                var target = cj(fname);
+                                                                var storage = {};
+                                                                target.children().each(function() {
+                                                                    var id = cj(this).attr('id');
+                                                                    if (id) {
+                                                                        // Help values survive storage
+                                                                        cj('textarea', this).each(function() {
+                                                                            cj(this).text(cj(this).val());
+                                                                        });
+                                                                        cj('option:selected', this).attr('selected', 'selected');
+                                                                        cj('option:not(:selected)', this).removeAttr('selected');
+                                                                        storage[id] = cj(this).detach();
+                                                                    }
+                                                                });
+                                                                target.html(response).trigger('crmLoad');
+                                                                target.children().each(function() {
+                                                                    var id = cj(this).attr('id');
+                                                                    if (id && storage[id]) {
+                                                                        cj(this).replaceWith(storage[id]);
+                                                                    }
+                                                                });
+                                                                storage = null;
+                                                            }
+                                                        });
+                                                    };
+
+                                                </script>
+
+
+                                                <script type="text/javascript">
+                                                    CRM.$(function($) {
+
+                                                        CRM.buildCustomData( 'Membership' );
+
+                                                    });
+                                                </script>
+
+
+                                                <div class="spacer"></div>
+                                                <div class="crm-submit-buttons">
+
+        <span class="crm-button crm-button-type-upload crm-button_qf_Membership_upload crm-icon-button">
+          <span class="crm-button-icon ui-icon-check"> </span>          <input class="crm-form-submit default validate" accesskey="S" crm-icon="check" name="_qf_Membership_upload" value="Save" type="submit" id="_qf_Membership_upload-bottom" />
+        </span>
+
+
+        <span class="crm-button crm-button-type-upload crm-button_qf_Membership_upload_new crm-icon-button">
+          <span class="crm-button-icon ui-icon-plus"> </span>          <input class="crm-form-submit validate" crm-icon="plus" name="_qf_Membership_upload_new" value="Save and New" type="submit" id="_qf_Membership_upload_new-bottom" />
+        </span>
+
+
+        <span class="crm-button crm-button-type-cancel crm-button_qf_Membership_cancel crm-icon-button">
+          <span class="crm-button-icon ui-icon-close"> </span>          <input class="crm-form-submit cancel" crm-icon="close" name="_qf_Membership_cancel" value="Cancel" type="submit" id="_qf_Membership_cancel-bottom" />
+        </span>
+                                                </div>
+                                        </div> <!-- end form-block -->
+
+
+
+                                        <script type="text/javascript">
+                                            function setPaymentBlock(mode, checkboxEvent) {
+                                                var memType = parseInt(cj('#membership_type_id_1').val( ));
+                                                var isPriceSet = 0;
+
+                                                if ( cj('#price_set_id').length > 0 && cj('#price_set_id').val() ) {
+                                                    isPriceSet = 1;
+                                                }
+
+                                                if ( !memType || isPriceSet ) {
+                                                    return;
+                                                }
+
+                                                var allMemberships = {"1":{"financial_type_id":"2","total_amount":"100.00","total_amount_numeric":"100.00","auto_renew":"1","has_related":true,"max_related":null},"2":{"financial_type_id":"2","total_amount":"50.00","total_amount_numeric":"50.00","auto_renew":"0","has_related":false,"max_related":null},"3":{"financial_type_id":"2","total_amount":"1,200.00","total_amount_numeric":"1200.00","auto_renew":"0","has_related":true,"max_related":null}};
+                                                if ( !mode ) {
+                                                    //check the record_contribution checkbox if membership is a paid one
+
+                                                    if (!checkboxEvent) {
+                                                        if (allMemberships[memType]['total_amount_numeric'] > 0) {
+                                                            cj('#record_contribution').prop('checked','checked');
+                                                            cj('#recordContribution').show();
+                                                        }
+                                                        else {
+                                                            cj('#record_contribution').prop('checked', false);
+                                                            cj('#recordContribution').hide();
+                                                        }
+                                                    }
+
+                                                }
+
+                                                // skip this for test and live modes because financial type is set automatically
+                                                cj("#financial_type_id").val(allMemberships[memType]['financial_type_id']);
+                                                var term = cj('#num_terms').val();
+                                                var taxRates = '[]';
+                                                var taxTerm = '';
+                                                var taxRates = JSON.parse(taxRates);
+                                                var taxRate = taxRates[allMemberships[memType]['financial_type_id']];
+                                                var currency = '$';
+                                                var taxAmount = (taxRate/100)*allMemberships[memType]['total_amount_numeric'];
+                                                taxAmount = isNaN (taxAmount) ? 0:taxAmount;
+                                                if ( term ) {
+                                                    if (!taxRate) {
+                                                        var feeTotal = allMemberships[memType]['total_amount_numeric'] * term;
+                                                    }
+                                                    else {
+                                                        var feeTotal = Number((taxRate/100) * (allMemberships[memType]['total_amount_numeric'] * term))+Number(allMemberships[memType]['total_amount_numeric'] * term );
+                                                    }
+                                                    cj("#total_amount").val(CRM.formatMoney(feeTotal, true));
+                                                }
+                                                else {
+                                                    if (taxRate) {
+                                                        var feeTotal = parseFloat(Number((taxRate/100) * allMemberships[memType]['total_amount'])+Number(allMemberships[memType]['total_amount_numeric'])).toFixed(2);
+                                                        cj("#total_amount").val(CRM.formatMoney(feeTotal, true));
+                                                    }
+                                                    else {
+                                                        var feeTotal = allMemberships[memType]['total_amount'];
+                                                        cj("#total_amount").val( allMemberships[memType]['total_amount'] );
+                                                    }
+                                                }
+                                                var taxMessage = taxRate!=undefined ? 'Includes '+taxTerm+' amount of '+currency+' '+taxAmount:'';
+                                                cj('.totaltaxAmount').html(taxMessage);
+                                            }
+
+
+                                            CRM.$(function($) {
+                                                var mode   = '';
+                                                if ( !mode ) {
+                                                    // Offline form (mode = false) has the record_contribution checkbox
+                                                    cj('#record_contribution').click( function( ) {
+                                                        if ( cj(this).prop('checked') ) {
+                                                            cj('#recordContribution').show( );
+                                                            setPaymentBlock( false, true);
+                                                        }
+                                                        else {
+                                                            cj('#recordContribution').hide( );
+                                                        }
+                                                    });
+                                                }
+
+                                                cj('#membership_type_id_1').change( function( ) {
+                                                    setPaymentBlock(mode);
+                                                });
+                                                cj('#num_terms').change( function( ) {
+                                                    setPaymentBlock(mode);
+                                                });
+                                                setPaymentBlock(mode);
+
+                                                // show/hide different contact section
+                                                setDifferentContactBlock();
+                                                cj('#is_different_contribution_contact').change( function() {
+                                                    setDifferentContactBlock();
+                                                });
+
+                                                // give option to override end-date for auto-renew memberships
+
+                                                cj('#end-date-readonly').hide();
+                                                cj('#end-date-editable').show();
+
+
+                                                cj('#show-end-date').click( function( e ) {
+                                                    e.preventDefault();
+                                                    cj('#end-date-readonly').hide();
+                                                    cj('#end-date-editable').show();
+                                                });
+
+                                            });
+
+                                            function setDifferentContactBlock( ) {
+                                                // show/hide different contact section
+                                                if ( cj('#is_different_contribution_contact').prop('checked') ) {
+                                                    cj('#record-different-contact').show();
+                                                }
+                                                else {
+                                                    cj('#record-different-contact').hide();
+                                                }
+                                            }
+
+                                        </script>
+
+
+                                        <script type="text/javascript">
+                                            var trigger_field_id = 'send_receipt';
+                                            var trigger_value = '';
+                                            var target_element_id = 'notice';
+                                            var target_element_type = 'table-row';
+                                            var field_type  = 'radio';
+                                            var invert = 0;
+
+                                            showHideByValue(trigger_field_id, trigger_value, target_element_id, target_element_type, field_type, invert);
+
+                                        </script>
+                                        <script type="text/javascript">
+                                            var trigger_field_id = 'send_receipt';
+                                            var trigger_value = '';
+                                            var target_element_id = 'fromEmail';
+                                            var target_element_type = 'table-row';
+                                            var field_type  = 'radio';
+                                            var invert = 0;
+
+                                            showHideByValue(trigger_field_id, trigger_value, target_element_id, target_element_type, field_type, invert);
+
+                                        </script>
+
+
+                                        <script type="text/javascript">
+
+
+                                            showHideMemberStatus();
+                                            function showHideMemberStatus() {
+                                                if ( cj( "#is_override" ).prop('checked' ) ) {
+                                                    cj('#memberStatus').show( );
+                                                    cj('#memberStatus_show').hide( );
+                                                }
+                                                else {
+                                                    cj('#memberStatus').hide( );
+                                                    cj('#memberStatus_show').show( );
+                                                }
+                                            }
+
+
+
+                                            //keep read only always checked.
+                                            CRM.$(function($) {
+                                                var $form = $("form.CRM_Member_Form_Membership");
+                                                var allowAutoRenew   = '';
+                                                var alreadyAutoRenew = '';
+                                                if ( allowAutoRenew || alreadyAutoRenew ) {
+                                                    $( "#auto_renew" ).click(function( ) {
+                                                        if ( $(this).attr( 'readonly' ) ) {
+                                                            $(this).prop('checked', true );
+                                                        }
+                                                    });
+                                                }
+
+
+
+                                                var alert, memberorgs = {"1":{"id":"98","membership_id":"98","contact_id":"40","membership_contact_id":"40","membership_type_id":"1","join_date":"2015-05-13","start_date":"2015-05-13","membership_start_date":"2015-05-13","end_date":"2016-05-12","membership_end_date":"May 12th, 2016","source":"General Membership Signup: Credit card or direct debit (by k k)","membership_source":"General Membership Signup: Credit card or direct debit (by k k)","status_id":"1","is_test":"0","member_is_test":"0","is_pay_later":"0","member_is_pay_later":"0","contribution_recur_id":"19","member_of_contact_id":"1","membership_type":"General","membership_status":"New","renewUrl":"\/civicrm\/contact\/view\/membership?reset=1&amp;action=renew&amp;cid=40&amp;id=98&amp;context=membership&amp;selectedChild=member","membershipTab":"\/civicrm\/contact\/view?reset=1&amp;force=1&amp;cid=40&amp;selectedChild=member"}};
+
+
+                                                $("select[name='membership_type_id[0]']").change(checkExistingMemOrg);
+
+
+
+                                                function checkExistingMemOrg () {
+                                                    alert && alert.close && alert.close();
+                                                    var selectedorg = $("select[name='membership_type_id[0]']").val();
+                                                    if (selectedorg in memberorgs) {
+                                                        var andEndDate = '',
+                                                                endDate = memberorgs[selectedorg].membership_end_date,
+                                                                org = $('option:selected', "select[name='membership_type_id[0]']").text();
+                                                        if (endDate) {
+                                                            andEndDate = 'and end date of %1';
+                                                            andEndDate = ' ' + ts(andEndDate, {1:endDate});
+                                                        }
+
+                                                        alert = CRM.alert(
+                                                                // Mixing client-side variables with a translated string in smarty is awkward!
+                                                                ts('This contact has an existing %1 membership at %2 with %3 status%4.', {1:memberorgs[selectedorg].membership_type, 2: org, 3: memberorgs[selectedorg].membership_status, 4: andEndDate})
+                                                                + '<ul><li><a href="' + memberorgs[selectedorg].renewUrl + '">'
+                                                                + 'Renew the existing membership instead'
+                                                                + '</a></li><li><a href="' + memberorgs[selectedorg].membershipTab + '">'
+                                                                + 'View all existing and / or expired memberships for this contact'
+                                                                + '</a></li></ul>',
+                                                                'Duplicate Membership?', 'alert');
+                                                    }
+                                                }
+                                                checkExistingMemOrg();
+
+
+
+
+                                            });
+
+
+
+
+                                            function buildReceiptANDNotice( ) {
+                                                if ( cj("#auto_renew").prop('checked' ) ) {
+                                                    cj("#notice").hide( );
+                                                    cj("#send-receipt").hide( );
+                                                }
+                                                else {
+                                                    cj("#send-receipt").show( );
+                                                    if ( cj("#send_receipt").prop('checked' ) ) {
+                                                        cj("#notice").show( );
+                                                    }
+                                                }
+                                            }
+
+                                            var customDataType = 'Membership';
+
+                                            // load form during form rule.
+
+
+                                            function buildAmount( priceSetId ) {
+                                                if ( !priceSetId ) {
+                                                    priceSetId = cj("#price_set_id").val( );
+                                                }
+                                                var fname = '#priceset';
+                                                if ( !priceSetId ) {
+                                                    cj('#membership_type_id_1').val(0);
+                                                    CRM.buildCustomData(customDataType, 'null' );
+
+                                                    // hide price set fields.
+                                                    cj( fname ).hide( );
+
+                                                    // show/hide price set amount and total amount.
+                                                    cj( "#mem_type_id").show( );
+                                                    var choose = "Choose price set";
+                                                    cj("#price_set_id option[value='']").html( choose );
+                                                    cj( "#totalAmountORPriceSet" ).show( );
+                                                    cj('#total_amount').removeAttr("readonly");
+                                                    cj( "#num_terms_row").show( );
+                                                    cj(".crm-membership-form-block-financial_type_id-mode").show();
+
+
+                                                    return;
+                                                }
+
+                                                cj( "#total_amount" ).val( '' );
+                                                cj('#total_amount').attr("readonly", true);
+
+                                                var dataUrl = "/civicrm/contact/view/membership?snippet=4" + '&priceSetId=' + priceSetId;
+
+                                                var response = cj.ajax({
+                                                    url: dataUrl,
+                                                    async: false
+                                                }).responseText;
+
+                                                cj( fname ).show( ).html( response );
+                                                // freeze total amount text field.
+
+                                                cj( "#totalAmountORPriceSet" ).hide( );
+                                                cj( "#mem_type_id" ).hide( );
+                                                var manual = "Manual membership and price";
+                                                cj("#price_set_id option[value='']").html( manual );
+                                                cj( "#num_terms_row" ).hide( );
+                                                cj(".crm-membership-form-block-financial_type_id-mode").hide();
+                                            }
+
+                                            buildMaxRelated(cj('#membership_type_id_1', false).val());
+
+                                            function buildMaxRelated( memType, setDefault ) {
+                                                var allMemberships = {"1":{"financial_type_id":"2","total_amount":"100.00","total_amount_numeric":"100.00","auto_renew":"1","has_related":true,"max_related":null},"2":{"financial_type_id":"2","total_amount":"50.00","total_amount_numeric":"50.00","auto_renew":"0","has_related":false,"max_related":null},"3":{"financial_type_id":"2","total_amount":"1,200.00","total_amount_numeric":"1200.00","auto_renew":"0","has_related":true,"max_related":null}};
+
+                                                if ((memType > 0) && (allMemberships[memType]['has_related'])) {
+                                                    if (setDefault) cj('#max_related').val(allMemberships[memType]['max_related']);
+                                                    cj('#maxRelated').show();
+                                                    var cid = 40;
+                                                    if (cid) {
+                                                        CRM.api('relationship', 'getcount', {contact_id: cid, membership_type_id: memType}, {
+                                                            success: function(result) {
+                                                                var relatable;
+                                                                if (result.result === 0) {
+                                                                    relatable = 'No contacts are currently eligible to inherit this relationship.';
+                                                                }
+                                                                else if (result.result === 1) {
+                                                                    relatable = 'One contact is currently eligible to inherit this relationship.';
+                                                                }
+                                                                else {
+                                                                    relatable = '%1 contacts are currently eligible to inherit this relationship.';
+                                                                    relatable = ts(relatable, {1: result});
+                                                                }
+                                                                cj('#max_related').siblings('.description').append(' ' + relatable);
+                                                            }
+                                                        });
+                                                    }
+                                                } else {
+                                                    cj('#max_related').val('');
+                                                    cj('#maxRelated').hide();
+                                                }
+                                            }
+
+                                            var lastMembershipTypes = [];
+                                            var optionsMembershipTypes = [];
+
+                                            // function to load custom data for selected membership types through priceset
+                                            function processMembershipPriceset( membershipValues, autoRenewOption, reload ) {
+                                                var currentMembershipType = [];
+                                                var count = 0;
+                                                var loadCustomData = 0;
+                                                if ( membershipValues ) {
+                                                    optionsMembershipTypes = membershipValues;
+                                                }
+
+                                                if ( reload ) {
+                                                    lastMembershipTypes = [];
+
+                                                }
+
+                                                cj("input,#priceset select,#priceset").each(function () {
+                                                    if ( cj(this).attr('price') ) {
+                                                        switch( cj(this).attr('type') ) {
+                                                            case 'checkbox':
+                                                                if ( cj(this).prop('checked') ) {
+                                                                    eval( 'var option = ' + cj(this).attr('price') ) ;
+                                                                    var ele = option[0];
+                                                                    var memTypeId = optionsMembershipTypes[ele];
+                                                                    if ( memTypeId && cj.inArray(optionsMembershipTypes[ele], currentMembershipType) == -1 ) {
+                                                                        currentMembershipType[count] = memTypeId;
+                                                                        count++;
+                                                                    }
+                                                                }
+                                                                if ( reload ) {
+                                                                    cj(this).click( function( ) {
+                                                                        processMembershipPriceset();
+                                                                    });
+                                                                }
+                                                                break;
+
+                                                            case 'radio':
+                                                                if ( cj(this).prop('checked') && cj(this).val() ) {
+                                                                    var memTypeId = optionsMembershipTypes[cj(this).val()];
+                                                                    if ( memTypeId && cj.inArray(memTypeId, currentMembershipType) == -1 ) {
+                                                                        currentMembershipType[count] = memTypeId;
+                                                                        count++;
+                                                                    }
+                                                                }
+                                                                if ( reload ) {
+                                                                    cj(this).click( function( ) {
+                                                                        processMembershipPriceset();
+                                                                    });
+                                                                }
+                                                                break;
+
+                                                            case 'select-one':
+                                                                if ( cj(this).val( ) ) {
+                                                                    var memTypeId = optionsMembershipTypes[cj(this).val()];
+                                                                    if ( memTypeId && cj.inArray(memTypeId, currentMembershipType) == -1 ) {
+                                                                        currentMembershipType[count] = memTypeId;
+                                                                        count++;
+                                                                    }
+                                                                }
+                                                                if ( reload ) {
+                                                                    cj(this).change( function( ) {
+                                                                        processMembershipPriceset();
+                                                                    });
+                                                                }
+                                                                break;
+                                                        }
+                                                    }
+                                                });
+
+                                                for( i in currentMembershipType ) {
+                                                    if ( cj.inArray(currentMembershipType[i], lastMembershipTypes) == -1 ) {
+                                                        loadCustomData = 1;
+                                                        break;
+                                                    }
+                                                }
+
+                                                if ( !loadCustomData ) {
+                                                    for( i in lastMembershipTypes) {
+                                                        if ( cj.inArray(lastMembershipTypes[i], currentMembershipType) == -1 ) {
+                                                            loadCustomData = 1;
+                                                            break;
+                                                        }
+                                                    }
+                                                }
+
+                                                lastMembershipTypes = currentMembershipType;
+
+                                                // load custom data only if change in membership type selection
+                                                if ( !loadCustomData ) {
+                                                    return;
+                                                }
+
+                                                subTypeNames = currentMembershipType.join(',');
+                                                if ( subTypeNames.length < 1 ) {
+                                                    subTypeNames = 'null';
+                                                }
+
+                                                CRM.buildCustomData( customDataType, subTypeNames );
+                                            }
+
+                                            function enableAmountSection( setContributionType ) {
+                                                if ( !cj('#record_contribution').prop('checked') ) {
+                                                    cj('#record_contribution').click( );
+                                                    cj('#recordContribution').show( );
+                                                }
+                                                if ( setContributionType ) {
+                                                    cj('#financial_type_id').val(setContributionType);
+                                                }
+                                            }
+                                        </script>
+
+                                    </div>
+
+                                </form>
+                            </div>
+
+                            <div class="footer" id="access">
+                                Access Keys:<a class="helpicon" title="Access Keys Help" href="#" onclick='CRM.help(&quot;Access Keys&quot;, {"id":"accesskeys","file":"CRM\/common\/accesskeys"}); return false;'>&nbsp;</a>
+                            </div>
+                            <div class="crm-footer" id="crm-record-log"><span class="col1">&nbsp; &nbsp;CiviCRM ID:&nbsp;40</span></div>
+
+                            <div class="crm-footer" id="civicrm-footer">
+
+                                Powered by CiviCRM 4.7.alpha1.    CiviCRM is openly available under the <a href='http://www.gnu.org/licenses/agpl-3.0.html'>GNU AGPL License</a>.<br/>
+                                <a href="https://civicrm.org/download">Download CiviCRM.</a> &nbsp; &nbsp;
+                                <a href="http://issues.civicrm.org/jira/browse/CRM?report=com.atlassian.jira.plugin.system.project:roadmap-panel">View issues and report bugs.</a> &nbsp; &nbsp;
+                                <a href="http://book.civicrm.org/"  target="_blank" class="crm-doc-link no-popup" title="Opens documentation in a new window.">Online documentation.</a>
+                            </div>
+                            <div id="crm-notification-container" style="display:none">
+                                <div id="crm-notification-alert" class="#{type}">
+                                    <div class="icon ui-notify-close" title="close"> </div>
+                                    <a class="ui-notify-cross ui-notify-close" href="#" title="close">x</a>
+                                    <h1>#{title}</h1>
+                                    <div class="notify-content">#{text}</div>
+                                </div>
+                            </div>
+
+
+                        </div>   </div>
+                </div>
+            </div>
+        </div>
+            <div class="region region-footer">
+                <div id="block-system-powered-by" class="block block-system clearfix">
+
+
+                    <div class="content">
+                        <span>Powered by <a href="https://www.drupal.org">Drupal</a></span>  </div>
+                </div>
+            </div>
+        </div></div></div></div> <!-- /.left-corner, /.right-corner, /#squeeze, /#center -->
+
+
+    </div> <!-- /#container -->
+</div> <!-- /#wrapper -->
+</body>
+</html>


### PR DESCRIPTION
This patch also moves a lot of template code that is shared between the backoffice
membership renewal and the backoffice membership receipt. From what I can tell the rest of the
file could pretty much be shared code and I think there is some invoice functionality
missing from renewals as I spotted a case where there was an invoice related class
on the member form but not the renewal (that is now in the shared code)
I also found (& fixed) a situation where the amount shows for people with membership but not contribution
permissions. It is now suppressed like other contribution fields

The next step towards bringing these closer is to use the same email field name on both.

In fact the templates look for either {receipt_test_signup} or {receipt_text_renew} so
it makes sense to just set {receipt_text} - although that involves a change to the msg
template so I don't know how off-putting that is
