### PR TITLE
CiviMail locks - Tests, fixes, and cleanups

### DIFF
--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -434,8 +434,7 @@ WHERE  id = %1
     }
 
     // grab a lock so other processes dont compete and do the same query
-    $lockName = "civicrm.group.{$groupID}";
-    $lock = new CRM_Core_Lock($lockName);
+    $lock = Civi\Core\Container::singleton()->get('lockManager')->acquire("data.core.group.{$groupID}");
     if (!$lock->isAcquired()) {
       // this can cause inconsistent results since we dont know if the other process
       // will fill up the cache before our calling routine needs it.

--- a/CRM/Core/BAO/Cache.php
+++ b/CRM/Core/BAO/Cache.php
@@ -151,8 +151,7 @@ class CRM_Core_BAO_Cache extends CRM_Core_DAO_Cache {
     // get a lock so that multiple ajax requests on the same page
     // dont trample on each other
     // CRM-11234
-    $lockName = "civicrm.cache.{$group}_{$path}._{$componentID}";
-    $lock = new CRM_Core_Lock($lockName);
+    $lock = Civi\Core\Container::singleton()->get('lockManager')->acquire("cache.{$group}_{$path}._{$componentID}");
     if (!$lock->isAcquired()) {
       CRM_Core_Error::fatal();
     }

--- a/CRM/Core/Lock.php
+++ b/CRM/Core/Lock.php
@@ -130,7 +130,7 @@ class CRM_Core_Lock implements \Civi\Core\Lock\LockInterface {
     if (self::$jobLog && CRM_Core_DAO::singleValueQuery("SELECT IS_USED_LOCK( '" . self::$jobLog . "')")) {
       return $this->hackyHandleBrokenCode(self::$jobLog);
     }
-    if (stristr($name, 'civimail.job.')) {
+    if (stristr($name, 'data.mailing.job.')) {
       self::$jobLog = $this->_name;
     }
     $this->_timeout = $timeout !== NULL ? $timeout : self::TIMEOUT;

--- a/CRM/Core/Lock.php
+++ b/CRM/Core/Lock.php
@@ -34,6 +34,8 @@
  */
 class CRM_Core_Lock {
 
+  static $jobLog = FALSE;
+
   // lets have a 3 second timeout for now
   const TIMEOUT = 3;
 
@@ -71,12 +73,11 @@ class CRM_Core_Lock {
     if (defined('CIVICRM_LOCK_DEBUG')) {
       CRM_Core_Error::debug_log_message('trying to construct lock for ' . $this->_name);
     }
-    static $jobLog = FALSE;
-    if ($jobLog && CRM_Core_DAO::singleValueQuery("SELECT IS_USED_LOCK( '{$jobLog}')")) {
-      return $this->hackyHandleBrokenCode($jobLog);
+    if (self::$jobLog && CRM_Core_DAO::singleValueQuery("SELECT IS_USED_LOCK( '" . self::$jobLog . "')")) {
+      return $this->hackyHandleBrokenCode(self::$jobLog);
     }
     if (stristr($name, 'civimail.job.')) {
-      $jobLog = $this->_name;
+      self::$jobLog = $this->_name;
     }
     $this->_timeout = $timeout !== NULL ? $timeout : self::TIMEOUT;
 
@@ -91,9 +92,6 @@ class CRM_Core_Lock {
    * @return bool
    */
   public function acquire() {
-    if (defined('CIVICRM_LOCK_DEBUG')) {
-      CRM_Core_Error::debug_log_message('acquire lock for ' . $this->_name);
-    }
     if (!$this->_hasLock) {
       $query = "SELECT GET_LOCK( %1, %2 )";
       $params = array(
@@ -102,7 +100,15 @@ class CRM_Core_Lock {
       );
       $res = CRM_Core_DAO::singleValueQuery($query, $params);
       if ($res) {
+        if (defined('CIVICRM_LOCK_DEBUG')) {
+          CRM_Core_Error::debug_log_message('acquire lock for ' . $this->_name);
+        }
         $this->_hasLock = TRUE;
+      }
+      else {
+        if (defined('CIVICRM_LOCK_DEBUG')) {
+          CRM_Core_Error::debug_log_message('failed to acquire lock for ' . $this->_name);
+        }
       }
     }
     return $this->_hasLock;
@@ -112,8 +118,15 @@ class CRM_Core_Lock {
    * @return null|string
    */
   public function release() {
+    if (defined('CIVICRM_LOCK_DEBUG')) {
+      CRM_Core_Error::debug_log_message('release lock for ' . $this->_name .  ' (' . ($this->_hasLock ? 'hasLock' : '!hasLock') . ')');
+    }
     if ($this->_hasLock) {
       $this->_hasLock = FALSE;
+
+      if (self::$jobLog == $this->_name) {
+        self::$jobLog = FALSE;
+      }
 
       $query = "SELECT RELEASE_LOCK( %1 )";
       $params = array(1 => array($this->_name, 'String'));
@@ -152,7 +165,8 @@ class CRM_Core_Lock {
    */
   public function hackyHandleBrokenCode($jobLog) {
     if (stristr($this->_name, 'job')) {
-      throw new CRM_Core_Exception('lock aquisition for ' . $this->_name . 'attempted when ' . $jobLog . 'is not released');
+      CRM_Core_Error::debug_log_message('lock acquisition for ' . $this->_name . ' attempted when ' . $jobLog . ' is not released');
+      throw new CRM_Core_Exception('lock acquisition for ' . $this->_name . ' attempted when ' . $jobLog . ' is not released');
     }
     if (defined('CIVICRM_LOCK_DEBUG')) {
       CRM_Core_Error::debug_log_message('(CRM-12856) faking lock for ' . $this->_name);

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -2906,7 +2906,7 @@ WHERE  civicrm_mailing_job.id = %1
     // CRM-8460
     $gotCronLock = FALSE;
 
-    if (property_exists($config, 'mailerJobsMax') && $config->mailerJobsMax && $config->mailerJobsMax > 1) {
+    if (property_exists($config, 'mailerJobsMax') && $config->mailerJobsMax && $config->mailerJobsMax > 0) {
       $lockArray = range(1, $config->mailerJobsMax);
       shuffle($lockArray);
 

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -2928,6 +2928,11 @@ WHERE  civicrm_mailing_job.id = %1
         CRM_Core_Error::debug_log_message('Returning early, since max number of cronjobs running');
         return TRUE;
       }
+
+      if (getenv('CIVICRM_CRON_HOLD')) {
+        // In testing, we may need to simulate some slow activities.
+        sleep(getenv('CIVICRM_CRON_HOLD'));
+      }
     }
 
     // load bootstrap to call hooks

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -2911,12 +2911,8 @@ WHERE  civicrm_mailing_job.id = %1
       shuffle($lockArray);
 
       // check if we are using global locks
-      $serverWideLock = CRM_Core_BAO_Setting::getItem(
-        CRM_Core_BAO_Setting::MAILING_PREFERENCES_NAME,
-        'civimail_server_wide_lock'
-      );
       foreach ($lockArray as $lockID) {
-        $cronLock = new CRM_Core_Lock("civimail.cronjob.{$lockID}", NULL, $serverWideLock);
+        $cronLock = Civi\Core\Container::singleton()->get('lockManager')->acquire("worker.mailing.send.{$lockID}");
         if ($cronLock->isAcquired()) {
           $gotCronLock = TRUE;
           break;

--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -614,7 +614,9 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
   }
 
   /**
-   * @param $fields
+   * @param array $fields
+   *   List of intended recipients.
+   *   Each recipient is an array with keys 'hash', 'contact_id', 'email', etc.
    * @param $mailing
    * @param $mailer
    * @param $job_date

--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -136,9 +136,7 @@ class CRM_Mailing_BAO_MailingJob extends CRM_Mailing_DAO_MailingJob {
 
     while ($job->fetch()) {
       // still use job level lock for each child job
-      $lockName = "civimail.job.{$job->id}";
-
-      $lock = new CRM_Core_Lock($lockName);
+      $lock = Civi\Core\Container::singleton()->get('lockManager')->acquire("data.mailing.job.{$job->id}");
       if (!$lock->isAcquired()) {
         continue;
       }
@@ -344,9 +342,7 @@ class CRM_Mailing_BAO_MailingJob extends CRM_Mailing_DAO_MailingJob {
     // X Number of child jobs
     while ($job->fetch()) {
       // still use job level lock for each child job
-      $lockName = "civimail.job.{$job->id}";
-
-      $lock = new CRM_Core_Lock($lockName);
+      $lock = Civi\Core\Container::singleton()->get('lockManager')->acquire("data.mailing.job.{$job->id}");
       if (!$lock->isAcquired()) {
         continue;
       }

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -662,11 +662,17 @@ class CRM_Utils_System {
      * We typically call authenticate only when we need to bootstrap the CMS
      * directly via Civi and hence bypass the normal CMS auth and bootstrap
      * process typically done in CLI and cron scripts. See: CRM-12648
+     *
+     * Q: Can we move this to the userSystem class so that it can be tuned
+     * per-CMS? For example, when dealing with UnitTests UF, there's no
+     * userFrameworkDSN.
      */
     $session = CRM_Core_Session::singleton();
     $session->set('civicrmInitSession', TRUE);
 
-    $dbDrupal = DB::connect($config->userFrameworkDSN);
+    if ($config->userFrameworkDSN) {
+      $dbDrupal = DB::connect($config->userFrameworkDSN);
+    }
     return $config->userSystem->authenticate($name, $password, $loadCMSBootstrap, $realPath);
   }
 

--- a/CRM/Utils/System/UnitTests.php
+++ b/CRM/Utils/System/UnitTests.php
@@ -53,6 +53,20 @@ class CRM_Utils_System_UnitTests extends CRM_Utils_System_Base {
   }
 
   /**
+   * Bootstrap the phony CMS.
+   *
+   * @param string $name
+   *   Optional username for login.
+   * @param string $pass
+   *   Optional password for login.
+   *
+   * @return bool
+   */
+  public function loadBootStrap($name = NULL, $pass = NULL) {
+    return TRUE;
+  }
+
+  /**
    * @inheritDoc
    */
   public function mapConfigToSSL() {

--- a/Civi/API/ExternalBatch.php
+++ b/Civi/API/ExternalBatch.php
@@ -1,0 +1,233 @@
+<?php
+namespace Civi\API;
+
+use Symfony\Component\Process\PhpExecutableFinder;
+use Symfony\Component\Process\Process;
+
+/**
+ * Class ExternalBatch
+ * @package Civi\API
+ *
+ * Perform a series of external, asynchronous, concurrent API call.
+ */
+class ExternalBatch {
+  /**
+   * The time to wait when polling for process status (microseconds).
+   */
+  const POLL_INTERVAL = 10000;
+
+  /**
+   * @var array
+   *   Array(int $idx => array $apiCall).
+   */
+  protected $apiCalls;
+
+  protected $defaultParams;
+
+  protected $root;
+
+  protected $settingsPath;
+
+  protected $env = array();
+
+  /**
+   * @var array
+   *   Array(int $idx => Process $process).
+   */
+  protected $processes;
+
+  /**
+   * @var array
+   *   Array(int $idx => array $apiResult).
+   */
+  protected $apiResults;
+
+  /**
+   * @param array $defaultParams
+   *   Default values to merge into any API calls.
+   */
+  public function __construct($defaultParams = array()) {
+    global $civicrm_root;
+    $this->root = $civicrm_root;
+    $this->settingsPath = defined('CIVICRM_SETTINGS_PATH') ? CIVICRM_SETTINGS_PATH : NULL;
+    $this->defaultParams = $defaultParams;
+  }
+
+  /**
+   * @param string $entity
+   * @param string $action
+   * @param array $params
+   * @return $this
+   */
+  public function addCall($entity, $action, $params = array()) {
+    $params = array_merge($this->defaultParams, $params);
+
+    $this->apiCalls[] = array(
+      'entity' => $entity,
+      'action' => $action,
+      'params' => $params,
+    );
+    return $this;
+  }
+
+  /**
+   * @param array $env
+   *   List of environment variables to add.
+   * @return static
+   */
+  public function addEnv($env) {
+    $this->env = array_merge($this->env, $env);
+    return $this;
+  }
+
+  /**
+   * Run all the API calls concurrently.
+   *
+   * @return static
+   * @throws \CRM_Core_Exception
+   */
+  public function start() {
+    foreach ($this->apiCalls as $idx => $apiCall) {
+      $process = $this->createProcess($apiCall);
+      $process->start();
+      $this->processes[$idx] = $process;
+    }
+    return $this;
+  }
+
+  /**
+   * @return int
+   *   The number of running processes.
+   */
+  public function getRunningCount() {
+    $count = 0;
+    foreach ($this->processes as $process) {
+      if ($process->isRunning()) {
+        $count++;
+      }
+    }
+    return $count;
+  }
+
+  public function wait() {
+    while (!empty($this->processes)) {
+      usleep(self::POLL_INTERVAL);
+      foreach (array_keys($this->processes) as $idx) {
+        /** @var Process $process */
+        $process = $this->processes[$idx];
+        if (!$process->isRunning()) {
+          $parsed = json_decode($process->getOutput(), TRUE);
+          if ($process->getExitCode() || $parsed === NULL) {
+            $this->apiResults[] = array(
+              'is_error' => 1,
+              'error_message' => 'External API returned malformed response.',
+              'trace' => array(
+                'code' => $process->getExitCode(),
+                'stdout' => $process->getOutput(),
+                'stderr' => $process->getErrorOutput(),
+              ),
+            );
+          }
+          else {
+            $this->apiResults[] = $parsed;
+          }
+          unset($this->processes[$idx]);
+        }
+      }
+    }
+    return $this;
+  }
+
+  /**
+   * @return array
+   */
+  public function getResults() {
+    return $this->apiResults;
+  }
+
+  /**
+   * @param int $idx
+   * @return array
+   */
+  public function getResult($idx = 0) {
+    return $this->apiResults[$idx];
+  }
+
+  /**
+   * Determine if the local environment supports running API calls
+   * externally.
+   *
+   * @return bool
+   */
+  public function isSupported() {
+    // If you try in Windows, feel free to change this...
+    if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' || !function_exists('proc_open')) {
+      return FALSE;
+    }
+    if (!file_exists($this->root . '/bin/cli.php') || !file_exists($this->settingsPath)) {
+      return FALSE;
+    }
+    return TRUE;
+  }
+
+  /**
+   * @param array $apiCall
+   *   Array with keys: entity, action, params.
+   * @return Process
+   * @throws \CRM_Core_Exception
+   */
+  public function createProcess($apiCall) {
+    $parts = array();
+
+    $executableFinder = new PhpExecutableFinder();
+    $php = $executableFinder->find();
+    if (!$php) {
+      throw new \CRM_Core_Exception("Failed to locate PHP interpreter.");
+    }
+    $parts[] = $php;
+
+    $parts[] = escapeshellarg($this->root . '/bin/cli.php');
+    $parts[] = escapeshellarg("-e=" . $apiCall['entity']);
+    $parts[] = escapeshellarg("-a=" . $apiCall['action']);
+    $parts[] = "--json";
+    $parts[] = escapeshellarg("-u=dummyuser");
+    foreach ($apiCall['params'] as $key => $value) {
+      $parts[] = escapeshellarg("--$key=$value");
+    }
+    $command = implode(" ", $parts);
+
+    $env = array_merge($this->env, array(
+      'CIVICRM_SETTINGS' => $this->settingsPath,
+    ));
+    return new Process($command, $this->root, $env);
+  }
+
+  /**
+   * @return string
+   */
+  public function getRoot() {
+    return $this->root;
+  }
+
+  /**
+   * @param string $root
+   */
+  public function setRoot($root) {
+    $this->root = $root;
+  }
+
+  /**
+   * @return string
+   */
+  public function getSettingsPath() {
+    return $this->settingsPath;
+  }
+
+  /**
+   * @param string $settingsPath
+   */
+  public function setSettingsPath($settingsPath) {
+    $this->settingsPath = $settingsPath;
+  }
+
+}

--- a/Civi/Core/Lock/LockInterface.php
+++ b/Civi/Core/Lock/LockInterface.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.6                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2015                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+namespace Civi\Core\Lock;
+
+interface LockInterface {
+
+  /**
+   * @param int|NULL $timeout
+   *   The number of seconds to wait to get the lock.
+   *   For a default value, use NULL.
+   * @return bool
+   */
+  public function acquire($timeout = NULL);
+
+  /**
+   * @return bool|null|string
+   *   Trueish/falsish.
+   */
+  public function release();
+
+  /**
+   * @return bool|null|string
+   *   Trueish/falsish.
+   * @deprecated
+   *   Not supported by some locking strategies. If you need to poll, better
+   *   to use acquire(0).
+   */
+  public function isFree();
+
+  /**
+   * @return bool
+   */
+  public function isAcquired();
+}

--- a/Civi/Core/Lock/LockInterface.php
+++ b/Civi/Core/Lock/LockInterface.php
@@ -55,4 +55,5 @@ interface LockInterface {
    * @return bool
    */
   public function isAcquired();
+
 }

--- a/Civi/Core/Lock/LockManager.php
+++ b/Civi/Core/Lock/LockManager.php
@@ -1,0 +1,121 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.6                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2015                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+namespace Civi\Core\Lock;
+
+use Civi\Core\Resolver;
+
+/**
+ * Class LockManager
+ * @package Civi\Core\Lock
+ *
+ * The lock-manager allows one to define the lock policy -- i.e. given a
+ * specific lock, how does one acquire the lock?
+ */
+class LockManager {
+
+  private $rules = array();
+
+  /**
+   * @param string $name
+   *   Symbolic name for the lock. Names generally look like
+   *   "worker.mailing.EmailProcessor" ("{category}.{component}.{AdhocName}").
+   *
+   *   Categories: worker|data|cache|...
+   *   Component: core|mailing|member|contribute|...
+   * @return LockInterface
+   * @throws \CRM_Core_Exception
+   */
+  public function create($name) {
+    $factory = $this->getFactory($name);
+    if ($factory) {
+      /** @var LockInterface $lock */
+      $lock = call_user_func_array($factory, array($name));
+      return $lock;
+    }
+    else {
+      throw new \CRM_Core_Exception("Lock \"$name\" does not match any rules. Use register() to add more rules.");
+    }
+  }
+
+  /**
+   * Create and attempt to acquire a lock.
+   *
+   * Note: Be sure to check $lock->isAcquired() to determine whether
+   * acquisition was successful.
+   *
+   * @param string $name
+   *   Symbolic name for the lock. Names generally look like
+   *   "worker.mailing.EmailProcessor" ("{category}.{component}.{AdhocName}").
+   *
+   *   Categories: worker|data|cache|...
+   *   Component: core|mailing|member|contribute|...
+   * @param int|NULL $timeout
+   *   The number of seconds to wait to get the lock.
+   *   For a default value, use NULL.
+   * @return LockInterface
+   * @throws \CRM_Core_Exception
+   */
+  public function acquire($name, $timeout = NULL) {
+    $lock = $this->create($name);
+    $lock->acquire($timeout);
+    return $lock;
+  }
+
+  /**
+   * @param string $name
+   *   Symbolic name for the lock.
+   * @return callable|NULL
+   */
+  public function getFactory($name) {
+    foreach ($this->rules as $rule) {
+      if (preg_match($rule['pattern'], $name)) {
+        return Resolver::singleton()->get($rule['factory']);
+      }
+    }
+    return NULL;
+  }
+
+  /**
+   * Register the lock-factory to use for specific lock-names.
+   *
+   * @param string $pattern
+   *   A regex to match against the lock name.
+   * @param string|array $factory
+   *   A callback. The callback should accept a $name parameter.
+   *   Callbacks will be located using the resolver.
+   * @return $this
+   * @see Resolver
+   */
+  public function register($pattern, $factory) {
+    $this->rules[] = array(
+      'pattern' => $pattern,
+      'factory' => $factory,
+    );
+    return $this;
+  }
+
+}

--- a/Civi/Core/Lock/NullLock.php
+++ b/Civi/Core/Lock/NullLock.php
@@ -1,0 +1,86 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.6                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2015                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+namespace Civi\Core\Lock;
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2015
+ * $Id$
+ *
+ */
+class NullLock implements LockInterface {
+
+  private $hasLock = FALSE;
+
+  /**
+   * @param string $name
+   * @return static
+   */
+  public static function create($name) {
+    return new static();
+  }
+
+  /**
+   * @param int|NULL $timeout
+   *   The number of seconds to wait to get the lock.
+   *   For a default value, use NULL.
+   * @return bool
+   */
+  public function acquire($timeout = NULL) {
+    $this->hasLock = TRUE;
+    return TRUE;
+  }
+
+  /**
+   * @return bool|null|string
+   *   Trueish/falsish.
+   */
+  public function release() {
+    $this->hasLock = FALSE;
+    return TRUE;
+  }
+
+  /**
+   * @return bool|null|string
+   *   Trueish/falsish.
+   * @deprecated
+   *   Not supported by some locking strategies. If you need to poll, better
+   *   to use acquire(0).
+   */
+  public function isFree() {
+    return !$this->hasLock;
+  }
+
+  /**
+   * @return bool
+   */
+  public function isAcquired() {
+    return $this->hasLock;
+  }
+
+}

--- a/api/v3/Job.php
+++ b/api/v3/Job.php
@@ -312,12 +312,15 @@ function civicrm_api3_job_process_pledge($params) {
  * @return array
  */
 function civicrm_api3_job_process_mailing($params) {
+  $mailsProcessedOrig = CRM_Mailing_BAO_MailingJob::$mailsProcessed;
 
   if (!CRM_Mailing_BAO_Mailing::processQueue()) {
     return civicrm_api3_create_error('Process Queue failed');
   }
   else {
-    $values = array();
+    $values = array(
+      'processed' => CRM_Mailing_BAO_MailingJob::$mailsProcessed - $mailsProcessedOrig,
+    );
     return civicrm_api3_create_success($values, $params, 'Job', 'process_mailing');
   }
 }
@@ -330,11 +333,15 @@ function civicrm_api3_job_process_mailing($params) {
  * @return array
  */
 function civicrm_api3_job_process_sms($params) {
+  $mailsProcessedOrig = CRM_Mailing_BAO_MailingJob::$mailsProcessed;
+
   if (!CRM_Mailing_BAO_Mailing::processQueue('sms')) {
     return civicrm_api3_create_error('Process Queue failed');
   }
   else {
-    $values = array();
+    $values = array(
+      'processed' => CRM_Mailing_BAO_MailingJob::$mailsProcessed - $mailsProcessedOrig,
+    );
     return civicrm_api3_create_success($values, $params, 'Job', 'process_sms');
   }
 }

--- a/api/v3/Job.php
+++ b/api/v3/Job.php
@@ -178,9 +178,9 @@ function civicrm_api3_job_send_reminder($params) {
   // in that case (ie. makes it non-configurable via the UI). Another approach would be to set a default of 0
   // in the _spec function - but since that is a deprecated value it seems more contentious than this approach
   $params['rowCount'] = 0;
-  $lock = new CRM_Core_Lock('civimail.job.EmailProcessor');
+  $lock = Civi\Core\Container::singleton()->get('lockManager')->acquire('worker.core.ActionSchedule');
   if (!$lock->isAcquired()) {
-    return civicrm_api3_create_error('Could not acquire lock, another EmailProcessor process is running');
+    return civicrm_api3_create_error('Could not acquire lock, another ActionSchedule process is running');
   }
 
   $result = CRM_Core_BAO_ActionSchedule::processQueue(CRM_Utils_Array::value('now', $params), $params);
@@ -354,7 +354,7 @@ function civicrm_api3_job_process_sms($params) {
  * @return array
  */
 function civicrm_api3_job_fetch_bounces($params) {
-  $lock = new CRM_Core_Lock('civimail.job.EmailProcessor');
+  $lock = Civi\Core\Container::singleton()->get('lockManager')->acquire('worker.mailing.EmailProcessor');
   if (!$lock->isAcquired()) {
     return civicrm_api3_create_error('Could not acquire lock, another EmailProcessor process is running');
   }
@@ -377,7 +377,7 @@ function civicrm_api3_job_fetch_bounces($params) {
  * @return array
  */
 function civicrm_api3_job_fetch_activities($params) {
-  $lock = new CRM_Core_Lock('civimail.job.EmailProcessor');
+  $lock = Civi\Core\Container::singleton()->get('lockManager')->acquire('worker.mailing.EmailProcessor');
   if (!$lock->isAcquired()) {
     return civicrm_api3_create_error('Could not acquire lock, another EmailProcessor process is running');
   }
@@ -430,7 +430,7 @@ function civicrm_api3_job_process_participant($params) {
  *   true if success, else false
  */
 function civicrm_api3_job_process_membership($params) {
-  $lock = new CRM_Core_Lock('civimail.job.updateMembership');
+  $lock = Civi\Core\Container::singleton()->get('lockManager')->acquire('worker.member.UpdateMembership');
   if (!$lock->isAcquired()) {
     return civicrm_api3_create_error('Could not acquire lock, another Membership Processing process is running');
   }
@@ -616,7 +616,7 @@ function civicrm_api3_job_disable_expired_relationships($params) {
  * @throws \API_Exception
  */
 function civicrm_api3_job_group_rebuild($params) {
-  $lock = new CRM_Core_Lock('civimail.job.groupRebuild');
+  $lock = Civi\Core\Container::singleton()->get('lockManager')->acquire('worker.core.GroupRebuild');
   if (!$lock->isAcquired()) {
     throw new API_Exception('Could not acquire lock, another EmailProcessor process is running');
   }

--- a/bin/ContributionProcessor.php
+++ b/bin/ContributionProcessor.php
@@ -412,8 +412,7 @@ CRM_Utils_System::authenticateScript(TRUE);
 //log the execution of script
 CRM_Core_Error::debug_log_message('ContributionProcessor.php');
 
-require_once 'CRM/Core/Lock.php';
-$lock = new CRM_Core_Lock('CiviContributeProcessor');
+$lock = Civi\Core\Container::singleton()->get('lockManager')->acquire('worker.contribute.CiviContributeProcessor');
 
 if ($lock->isAcquired()) {
   // try to unset any time limits
@@ -424,7 +423,7 @@ if ($lock->isAcquired()) {
   CiviContributeProcessor::process();
 }
 else {
-  throw new Exception('Could not acquire lock, another CiviMailProcessor process is running');
+  throw new Exception('Could not acquire lock, another CiviContributeProcessor process is running');
 }
 
 $lock->release();

--- a/bin/cli.class.php
+++ b/bin/cli.class.php
@@ -115,6 +115,9 @@ class civicrm_cli {
       $this->_log($result['error_message']);
       return FALSE;
     }
+    elseif ($this->_output === 'json') {
+      echo json_encode($result, defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT : 0);
+    }
     elseif ($this->_output) {
       print_r($result['values']);
     }
@@ -175,6 +178,9 @@ class civicrm_cli {
       }
       elseif ($arg == '-o' || $arg == '--output') {
         $this->_output = TRUE;
+      }
+      elseif ($arg == '--json') {
+        $this->_output = 'json';
       }
       elseif ($arg == '-j' || $arg == '--joblog') {
         $this->_joblog = TRUE;
@@ -300,12 +306,13 @@ class civicrm_cli {
    * @return string
    */
   private function _getUsage() {
-    $out = "Usage: cli.php -e entity -a action [-u user] [-s site] [--output] [PARAMS]\n";
+    $out = "Usage: cli.php -e entity -a action [-u user] [-s site] [--output|--json] [PARAMS]\n";
     $out .= "  entity is the name of the entity, e.g. Contact, Event, etc.\n";
     $out .= "  action is the name of the action e.g. Get, Create, etc.\n";
     $out .= "  user is an optional username to run the script as\n";
     $out .= "  site is the domain name of the web site (for Drupal multi site installs)\n";
-    $out .= "  --output will print the result from the api call\n";
+    $out .= "  --output will pretty print the result from the api call\n";
+    $out .= "  --json will print the result from the api call as JSON\n";
     $out .= "  PARAMS is one or more --param=value combinations to pass to the api\n";
     return ts($out);
   }

--- a/bin/cli.class.php
+++ b/bin/cli.class.php
@@ -179,7 +179,7 @@ class civicrm_cli {
       elseif ($arg == '-o' || $arg == '--output') {
         $this->_output = TRUE;
       }
-      elseif ($arg == '--json') {
+      elseif ($arg == '-J' || $arg == '--json') {
         $this->_output = 'json';
       }
       elseif ($arg == '-j' || $arg == '--joblog') {

--- a/bin/cli.class.php
+++ b/bin/cli.class.php
@@ -216,7 +216,12 @@ class civicrm_cli {
 
     $civicrm_root = dirname(__DIR__);
     chdir($civicrm_root);
-    require_once 'civicrm.config.php';
+    if (getenv('CIVICRM_SETTINGS')) {
+      require_once getenv('CIVICRM_SETTINGS');
+    }
+    else {
+      require_once 'civicrm.config.php';
+    }
     // autoload
     if (!class_exists('CRM_Core_ClassLoader')) {
       require_once $civicrm_root . '/CRM/Core/ClassLoader.php';

--- a/bin/deprecated/CiviReportMail.php
+++ b/bin/deprecated/CiviReportMail.php
@@ -49,8 +49,7 @@ class CiviReportMail {
   }
 
   public function run() {
-    require_once 'CRM/Core/Lock.php';
-    $lock = new CRM_Core_Lock('CiviReportMail');
+    $lock = Civi\Core\Container::singleton()->get('lockManager')->acquire('worker.report.CiviReportMail');
 
     if ($lock->isAcquired()) {
       // try to unset any time limits

--- a/bin/deprecated/EmailProcessor.php
+++ b/bin/deprecated/EmailProcessor.php
@@ -51,8 +51,7 @@ if (php_sapi_name() == "cli") {
   //if it doesn't die, it's authenticated
   //log the execution of script
   CRM_Core_Error::debug_log_message('EmailProcessor.php from the cli');
-  require_once 'CRM/Core/Lock.php';
-  $lock = new CRM_Core_Lock('EmailProcessor');
+  $lock = Civi\Core\Container::singleton()->get('lockManager')->acquire('worker.mailing.EmailProcessor');
 
   if (!$lock->isAcquired()) {
     throw new Exception('Could not acquire lock, another EmailProcessor process is running');
@@ -83,8 +82,7 @@ else {
   //log the execution of script
   CRM_Core_Error::debug_log_message('EmailProcessor.php');
 
-  require_once 'CRM/Core/Lock.php';
-  $lock = new CRM_Core_Lock('EmailProcessor');
+  $lock = Civi\Core\Container::singleton()->get('lockManager')->acquire('worker.mailing.EmailProcessor');
 
   if (!$lock->isAcquired()) {
     throw new Exception('Could not acquire lock, another EmailProcessor process is running');

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
     "dompdf/dompdf" : "0.6.*",
     "symfony/dependency-injection": "2.3.*",
     "symfony/event-dispatcher": "2.3.*",
+    "symfony/process": "2.3.*",
     "psr/log": "1.0.0",
     "symfony/finder": "2.3.*",
     "totten/ca-config": "~13.02"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "bd8520dfd68384402dfe4a986d8bcddc",
+    "hash": "fae511da43e5fb95d62ee09faa1f19b2",
     "packages": [
         {
             "name": "dompdf/dompdf",
@@ -275,6 +275,56 @@
             "description": "Symfony Finder Component",
             "homepage": "http://symfony.com",
             "time": "2014-12-02 19:42:47"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v2.3.28",
+            "target-dir": "Symfony/Component/Process",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Process.git",
+                "reference": "a8fe947ac58e081f8773e0d160807dcffbff7ed8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Process/zipball/a8fe947ac58e081f8773e0d160807dcffbff7ed8",
+                "reference": "a8fe947ac58e081f8773e0d160807dcffbff7ed8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "~2.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Process\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Process Component",
+            "homepage": "https://symfony.com",
+            "time": "2015-05-01 14:06:45"
         },
         {
             "name": "totten/ca-config",

--- a/tests/phpunit/CiviTest/CiviMailUtils.php
+++ b/tests/phpunit/CiviTest/CiviMailUtils.php
@@ -289,8 +289,14 @@ class CiviMailUtils extends PHPUnit_Framework_TestCase {
     foreach ($this->getAllMessages('ezc') as $message) {
       $recipients[] = CRM_Utils_Array::collect('email', $message->to);
     }
-    sort($recipients);
-    sort($expectedRecipients);
+    $cmp = function($a, $b) {
+      if ($a[0] == $b[0]) {
+        return 0;
+      }
+      return ($a[0] < $b[0]) ? 1 : -1;
+    };
+    usort($recipients, $cmp);
+    usort($expectedRecipients, $cmp);
     $this->_ut->assertEquals(
       $expectedRecipients,
       $recipients,

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -909,6 +909,39 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
   }
 
   /**
+   * Create a batch of external API calls which can
+   * be executed concurrently.
+   *
+   * @code
+   * $calls = $this->createExternalAPI()
+   *    ->addCall('Contact', 'get', ...)
+   *    ->addCall('Contact', 'get', ...)
+   *    ...
+   *    ->run()
+   *    ->getResults();
+   * @endcode
+   *
+   * @return \Civi\API\ExternalBatch
+   * @throws PHPUnit_Framework_SkippedTestError
+   */
+  public function createExternalAPI() {
+    global $civicrm_root;
+    $defaultParams = array(
+      'version' => $this->_apiversion,
+      'debug' => 1,
+    );
+
+    $calls = new \Civi\API\ExternalBatch($defaultParams);
+    $calls->setSettingsPath("$civicrm_root/tests/phpunit/CiviTest/civicrm.settings.cli.php");
+
+    if (!$calls->isSupported()) {
+      $this->markTestSkipped('The test relies on Civi\API\ExternalBatch. This is unsupported in the local environment.');
+    }
+
+    return $calls;
+  }
+
+  /**
    * wrap api functions.
    * so we can ensure they succeed & throw exceptions without litterering the test with checks
    *

--- a/tests/phpunit/CiviTest/civicrm.settings.cli.php
+++ b/tests/phpunit/CiviTest/civicrm.settings.cli.php
@@ -1,0 +1,14 @@
+<?php
+// This file is loaded when spawning separate CLI processes that need to
+// talk to the test DB.
+
+require_once dirname(dirname(dirname(__DIR__))) . '/CRM/Core/ClassLoader.php';
+CRM_Core_ClassLoader::singleton()->register();
+
+define('CIVICRM_SETTINGS_PATH', __DIR__ . '/civicrm.settings.dist.php');
+define('CIVICRM_SETTINGS_LOCAL_PATH', __DIR__ . '/civicrm.settings.local.php');
+
+if (file_exists(CIVICRM_SETTINGS_LOCAL_PATH)) {
+  require_once CIVICRM_SETTINGS_LOCAL_PATH;
+}
+require_once CIVICRM_SETTINGS_PATH;

--- a/tests/phpunit/api/v3/JobProcessMailingTest.php
+++ b/tests/phpunit/api/v3/JobProcessMailingTest.php
@@ -116,6 +116,10 @@ class api_v3_JobProcessMailingTest extends CiviUnitTestCase {
       array(
         'recipients' => 20,
         'workers' => 3,
+        // FIXME: lockHold is unrealistic/unrepresentative. In reality, this situation fails because
+        // the data.* locks trample the worker.* locks. However, setting lockHold allows us to
+        // approximate the behavior of what would happen *if* the lock-implementation didn't suffer
+        // trampling effects.
         'lockHold' => 10,
         'mailerBatchLimit' => 4,
         'mailerJobsMax' => 1,
@@ -132,6 +136,10 @@ class api_v3_JobProcessMailingTest extends CiviUnitTestCase {
       array(// Settings.
         'recipients' => 20,
         'workers' => 3,
+        // FIXME: lockHold is unrealistic/unrepresentative. In reality, this situation fails because
+        // the data.* locks trample the worker.* locks. However, setting lockHold allows us to
+        // approximate the behavior of what would happen *if* the lock-implementation didn't suffer
+        // trampling effects.
         'lockHold' => 10,
         'mailerBatchLimit' => 5,
         'mailerJobsMax' => 2,
@@ -148,7 +156,6 @@ class api_v3_JobProcessMailingTest extends CiviUnitTestCase {
       array(// Settings.
         'recipients' => 20,
         'workers' => 3,
-        'lockHold' => 10,
         'mailerBatchLimit' => 6,
         'mailerJobsMax' => 3,
       ),
@@ -163,7 +170,6 @@ class api_v3_JobProcessMailingTest extends CiviUnitTestCase {
       array(// Settings.
         'recipients' => 20,
         'workers' => 4,
-        'lockHold' => 4,
         'mailerBatchLimit' => 6,
         'mailerJobsMax' => 0,
       ),

--- a/tests/phpunit/api/v3/JobProcessMailingTest.php
+++ b/tests/phpunit/api/v3/JobProcessMailingTest.php
@@ -51,14 +51,16 @@ class api_v3_JobProcessMailingTest extends CiviUnitTestCase {
   private $_groupID;
   private $_email;
 
+  protected $defaultSettings;
+
   /**
    * @var CiviMailUtils
    */
   private $_mut;
 
   public function setUp() {
+    $this->cleanupMailingTest();
     parent::setUp();
-    $this->useTransaction();
     CRM_Mailing_BAO_MailingJob::$mailsProcessed = 0; // DGW
     $this->_groupID = $this->groupCreate();
     $this->_email = 'test@test.test';
@@ -70,6 +72,16 @@ class api_v3_JobProcessMailingTest extends CiviUnitTestCase {
       'groups' => array('include' => array($this->_groupID)),
       'scheduled_date' => 'now',
     );
+    $this->defaultSettings = array(
+      'recipients' => 20, // int, #contacts to receive mailing
+      'workers' => 1, // int, #concurrent cron jobs
+      'iterations' => 1, // int, #times to spawn all the workers
+      'lockHold' => 0, // int, #extra seconds each cron job should hold lock
+      'mailerBatchLimit' => 0, // int, max# recipients to send in a given cron run
+      'mailerJobsMax' => 0, // int, max# concurrent jobs
+      'mailerJobSize' => 0, // int, max# recipients in each job
+      'mailThrottleTime' => 0, // int, microseconds separating messages
+    );
     $this->_mut = new CiviMailUtils($this, TRUE);
     $this->callAPISuccess('mail_settings', 'get', array('api.mail_settings.create' => array('domain' => 'chaos.org')));
   }
@@ -77,52 +89,259 @@ class api_v3_JobProcessMailingTest extends CiviUnitTestCase {
   /**
    */
   public function tearDown() {
+    //$this->_mut->clearMessages();
     $this->_mut->stop();
-    //    $this->quickCleanup(array('civicrm_mailing', 'civicrm_mailing_job', 'civicrm_contact'));
     CRM_Utils_Hook::singleton()->reset();
     CRM_Mailing_BAO_MailingJob::$mailsProcessed = 0; // DGW
+    //$this->cleanupMailingTest();
     parent::tearDown();
+  }
 
+  public function testBasic() {
+    $this->createContactsInGroup(10, $this->_groupID);
+    $this->setSettings(array(
+      'mailerBatchLimit' => 2,
+    ));
+    $this->callAPISuccess('mailing', 'create', $this->_params);
+    $this->_mut->assertRecipients(array());
+    $this->callAPISuccess('job', 'process_mailing', array());
+    $this->_mut->assertRecipients($this->getRecipients(1, 2));
+  }
+
+  public function concurrencyExamples() {
+    $es = array();
+
+    // Launch 3 workers, but mailerJobsMax limits us to 1 worker.
+    $es[0] = array(
+      array(
+        'recipients' => 20,
+        'workers' => 3,
+        'lockHold' => 10,
+        'mailerBatchLimit' => 4,
+        'mailerJobsMax' => 1,
+      ),
+      array(
+        0 => 2, // 2 jobs which produce 0 messages
+        4 => 1, // 1 job which produces 4 messages
+      ),
+      4,
+    );
+
+    // Launch 3 workers, but mailerJobsMax limits us to 2 workers.
+    $es[1] = array(
+      array(// Settings.
+        'recipients' => 20,
+        'workers' => 3,
+        'lockHold' => 10,
+        'mailerBatchLimit' => 5,
+        'mailerJobsMax' => 2,
+      ),
+      array(// Tallies.
+        0 => 1, // 1 job which produce 0 messages
+        5 => 2, // 2 jobs which produce 5 messages
+      ),
+      10, // Total sent.
+    );
+
+    // Launch 3 workers and saturate them (mailerJobsMax=3)
+    $es[2] = array(
+      array(// Settings.
+        'recipients' => 20,
+        'workers' => 3,
+        'lockHold' => 10,
+        'mailerBatchLimit' => 6,
+        'mailerJobsMax' => 3,
+      ),
+      array(// Tallies.
+        6 => 3, // 3 jobs which produce 6 messages
+      ),
+      18, // Total sent.
+    );
+
+    // Launch 4 workers and saturate them (mailerJobsMax=0)
+    $es[3] = array(
+      array(// Settings.
+        'recipients' => 20,
+        'workers' => 4,
+        'lockHold' => 4,
+        'mailerBatchLimit' => 6,
+        'mailerJobsMax' => 0,
+      ),
+      array(// Tallies.
+        6 => 3, // 3 jobs which produce 6 messages
+        2 => 1, // 1 job which produces 2 messages
+      ),
+      20, // Total sent.
+    );
+
+    // Launch 1 worker, 3 times in a row. Deliver everything.
+    $es[4] = array(
+      array(// Settings.
+        'recipients' => 10,
+        'workers' => 1,
+        'iterations' => 3,
+        'mailerBatchLimit' => 7,
+      ),
+      array(// Tallies.
+        7 => 1, // 1 job which produces 7 messages
+        3 => 1, // 1 job which produces 3 messages
+        0 => 1, // 1 job which produces 0 messages
+      ),
+      10, // Total sent.
+    );
+
+    // Launch 2 worker, 3 times in a row. Deliver everything.
+    $es[5] = array(
+      array(// Settings.
+        'recipients' => 10,
+        'workers' => 2,
+        'iterations' => 3,
+        'mailerBatchLimit' => 3,
+      ),
+      array(// Tallies.
+        3 => 3, // 3 jobs which produce 3 messages
+        1 => 1, // 1 job which produces 1 messages
+        0 => 2, // 2 jobs which produce 0 messages
+      ),
+      10, // Total sent.
+    );
+
+    return $es;
   }
 
   /**
-   * Check mailing is sent.
+   * Setup various mail configuration options (eg $mailerBatchLimit,
+   * $mailerJobMax) and spawn multiple worker threads ($workers).
+   * Allow the threads to complete. (Optionally, repeat the above
+   * process.) Finally, check to see if the right number of
+   * jobs delivered the right number of messages.
+   *
+   * @param array $settings
+   *   An array of settings (eg mailerBatchLimit, workers). See comments
+   *   for $this->defaultSettings.
+   * @param array $expectedTallies
+   *    A listing of the number cron-runs keyed by their size.
+   *    For example, array(10=>2) means that there 2 cron-runs
+   *    which delivered 10 messages each.
+   * @param int $expectedTotal
+   *    The total number of contacts for whom messages should have
+   *    been sent.
+   * @dataProvider concurrencyExamples
    */
-  public function testProcessMailing() {
-    $this->createContactsInGroup(10, $this->_groupID);
-    CRM_Core_Config::singleton()->mailerBatchLimit = 2;
+  public function testConcurrency($settings, $expectedTallies, $expectedTotal) {
+    $settings = array_merge($this->defaultSettings, $settings);
+
+    $this->createContactsInGroup($settings['recipients'], $this->_groupID);
+    $this->setSettings(CRM_Utils_Array::subset($settings, array(
+      'mailerBatchLimit',
+      'mailerJobsMax',
+      'mailThrottleTime',
+    )));
+
     $this->callAPISuccess('mailing', 'create', $this->_params);
-    $this->callAPISuccess('job', 'process_mailing', array());
-    $this->_mut->assertRecipients($this->getRecipients(1, 2));
+
+    $this->_mut->assertRecipients(array());
+
+    $allApiResults = array();
+    for ($iterationId = 0; $iterationId < $settings['iterations']; $iterationId++) {
+      $apiCalls = $this->createExternalAPI();
+      $apiCalls->addEnv(array('CIVICRM_CRON_HOLD' => $settings['lockHold']));
+      for ($workerId = 0; $workerId < $settings['workers']; $workerId++) {
+        $apiCalls->addCall('job', 'process_mailing', array());
+      }
+      $apiCalls->start();
+      $this->assertEquals($settings['workers'], $apiCalls->getRunningCount());
+
+      $apiCalls->wait();
+      $allApiResults = array_merge($allApiResults, $apiCalls->getResults());
+    }
+
+    $actualTallies = $this->tallyApiResults($allApiResults);
+    $this->assertEquals($expectedTallies, $actualTallies, 'API tallies should match.' . print_r(array(
+        'expectedTallies' => $expectedTallies,
+        'actualTallies' => $actualTallies,
+        'apiResults' => $allApiResults,
+      ), TRUE));
+    $this->_mut->assertRecipients($this->getRecipients(1, $expectedTotal));
+    $this->assertEquals(0, $apiCalls->getRunningCount());
   }
 
   /**
    * @param int $count
    * @param int $groupID
    */
-  public function createContactsInGroup($count, $groupID) {
+  public function createContactsInGroup($count, $groupID, $domain = 'nul.example.com') {
     for ($i = 1; $i <= $count; $i++) {
-      $contactID = $this->individualCreate(array('first_name' => $count, 'email' => 'mail' . $i . '@nul.com'));
+      $contactID = $this->individualCreate(array('first_name' => $count, 'email' => 'mail' . $i . '@' . $domain));
       $this->callAPISuccess('group_contact', 'create', array(
-          'contact_id' => $contactID,
-          'group_id' => $groupID,
-          'status' => 'Added',
-        ));
+        'contact_id' => $contactID,
+        'group_id' => $groupID,
+        'status' => 'Added',
+      ));
     }
   }
 
   /**
+   * Construct the list of email addresses for $count recipients.
+   *
    * @param int $start
    * @param int $count
    *
    * @return array
    */
-  public function getRecipients($start, $count) {
+  public function getRecipients($start, $count, $domain = 'nul.example.com') {
     $recipients = array();
     for ($i = $start; $i < ($start + $count); $i++) {
-      $recipients[][0] = 'mail' . $i . '@nul.com';
+      $recipients[][0] = 'mail' . $i . '@' . $domain;
     }
     return $recipients;
+  }
+
+  /**
+   * @param array $params
+   *   - mailerBatchLimit
+   *   - mailerJobSize
+   *   - mailerJobsMax
+   *   - mailThrottleTime
+   */
+  protected function setSettings($params) {
+    // FIXME: These settings are not available via Setting API.
+    // When they become available, use that instead.
+    CRM_Core_BAO_ConfigSetting::create($params);
+  }
+
+  protected function cleanupMailingTest() {
+    $this->quickCleanup(array(
+      'civicrm_mailing',
+      'civicrm_mailing_job',
+      'civicrm_mailing_spool',
+      'civicrm_mailing_group',
+      'civicrm_mailing_recipients',
+      'civicrm_mailing_event_queue',
+      'civicrm_mailing_event_bounce',
+      'civicrm_mailing_event_delivered',
+      'civicrm_group',
+      'civicrm_group_contact',
+      'civicrm_contact',
+    ));
+  }
+
+  /**
+   * Categorize results based on (a) whether they succeeded
+   * and (b) the number of messages sent.
+   *
+   * @param array $apiResults
+   * @return array
+   *   One key 'error' for all failures.
+   *   A separate key for each distinct quantity.
+   */
+  protected function tallyApiResults($apiResults) {
+    $ret = array();
+    foreach ($apiResults as $apiResult) {
+      $key = !empty($apiResult['is_error']) ? 'error' : $apiResult['values']['processed'];
+      $ret[$key] = !empty($ret[$key]) ? 1 + $ret[$key] : 1;
+    }
+    return $ret;
   }
 
 }


### PR DESCRIPTION
(This replaces #5821. Various changes have been rebased, improved, squashed.)
- Add test cases which exercise various concurrency/delivery options for CiviMail.
  - To make this possible, we needed various patches/helpers -- e.g. bin/cli.php needed to work with the test DB, and we needed a way to spawn multiple copies of bin/cli.php
- Allow downstream implementers to swap lock implementations. To do so:
  - Add a new lock class (`class MyLock implements LockInterface`).
  - Add a new factory function (`public static function create($name) ==> LockInterface`).
  - Define a variable (`CIVICRM_CACHE_LOCK`, `CIVICRM_DATA_LOCK`, `CIVICRM_WORK_LOCK`) with the name of the factory function. (See also: `Resolver`)
  - **Example**: To disable locks for the cronjobs, swap in the NullLock implementation: `define('CIVICRM_WORK_LOCK','Civi\Core\Lock\NullLock::create');`
- **Contract change**: To request a lock, downstream code should use `LockManager` instead of
  directly creating `CRM_Core_Lock`. Callers who do work with `CRM_Core_Lock` must call acquire() explicitly.
- Fix for mailerJobsMax==1
- Fix for lock error ("lock acquisition ... attempted when... not released")
  - This is only a partial fix -- it resolves the scenario I was able to reproduce in the tests. However, there could be other scenarios.
  - The real fix would require swapping the lock provider.
