### PR TITLE
CRM-16354 - Civi/Angular - Don't load ckeditor from "packages"

### DIFF
--- a/Civi/Angular/Page/Main.php
+++ b/Civi/Angular/Page/Main.php
@@ -79,9 +79,6 @@ class Main extends \CRM_Core_Page {
 
     $this->res->addScriptFile('civicrm', 'bower_components/angular/angular.min.js', 100, 'html-header', FALSE);
 
-    // FIXME: crmUi depends on loading ckeditor, but ckeditor doesn't work with this aggregation.
-    $this->res->addScriptFile('civicrm', 'packages/ckeditor/ckeditor.js', 100, 'page-header', FALSE);
-
     $headOffset = 0;
     $config = \CRM_Core_Config::singleton();
     if ($config->debug) {


### PR DESCRIPTION
It's now loaded on all pages via Resources::coreResourceList().
The old references produces a warning in dev console.
