### PR TITLE
CRM-16524 float equal to string fails in form validation

### DIFF
--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -271,7 +271,7 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
       }
     }
 
-    if ($batchTotal != $self->_batchInfo['total']) {
+    if ((string) $batchTotal !== $self->_batchInfo['total']) {
       $self->assign('batchAmountMismatch', TRUE);
       $errors['_qf_defaults'] = ts('Total for amounts entered below does not match the expected batch total.');
     }

--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -271,7 +271,7 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
       }
     }
 
-    if ((string) $batchTotal !== $self->_batchInfo['total']) {
+    if ((string) $batchTotal != $self->_batchInfo['total']) {
       $self->assign('batchAmountMismatch', TRUE);
       $errors['_qf_defaults'] = ts('Total for amounts entered below does not match the expected batch total.');
     }


### PR DESCRIPTION
Batch Entry Form validation fails when total amount equal to total expected amount.,
condition in batch entry form validation trying to compare float value and string value. 
