### PR TITLE
CRM-16445 - crmUiRichtext - Fix "Source" mode. Listen to 'key' event.

### DIFF
--- a/ang/crmUi.js
+++ b/ang/crmUi.js
@@ -422,10 +422,15 @@
           // afterCommandExec, afterInsertHtml, afterPaste, afterSetData, change, insertElement,
           // insertHtml, insertText, pasteState. It seems that 'pasteState' is the general equivalent of
           // what 'change' should be, except (in the case of image insertion) it fires too soon.
-          ck.on('pasteState', function(evt) {
-            $timeout(function() {
-              ngModel.$setViewValue(ck.getData());
-            }, 50);
+          // The 'key' event is needed to detect changes in "Source" mode.
+          var debounce = null;
+          angular.forEach(['key', 'pasteState'], function(evName){
+            ck.on(evName, function(evt) {
+              $timeout.cancel(debounce);
+              debounce = $timeout(function() {
+                ngModel.$setViewValue(ck.getData());
+              }, 50);
+            });
           });
 
           ngModel.$render = function (value) {


### PR DESCRIPTION
See also:
- http://civicrm.stackexchange.com/questions/2492/civimail-mailings-not-saving-or-corrupting
- http://stackoverflow.com/questions/17358203/how-to-detect-ckeditor-source-mode-on-change-event

This is not strictly part of CRM-16445, but it's very similar (dealing with
the events emitted by ckeditor).
