### PR TITLE
CRM-16527 - Hide credit card section in membership contribution form

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -444,6 +444,7 @@
     toggleConfirmButton();
     enableHonorType();
     showRecurHelp();
+    skipPaymentMethod();
   });
 
   function showHidePayPalExpressOption() {
@@ -455,6 +456,43 @@
       cj("#paypalExpress").show();
       cj("#crm-submit-buttons").hide();
     }
+  }
+
+  function showHidePayment(flag) {
+    var payment_options = cj(".payment_options-group");
+    var payment_processor = cj("div.payment_processor-section");
+    var payment_information = cj("div#payment_information");
+    if (flag) {
+      payment_options.hide();
+      payment_processor.hide();
+      payment_information.hide();
+      // also unset selected payment methods
+      cj('input[name="payment_processor"]').removeProp('checked');
+    }
+    else {
+      payment_options.show();
+      payment_processor.show();
+      payment_information.show();
+    }
+  }
+  
+  function skipPaymentMethod() {
+    var flag = false;
+    cj('.price-set-option-content input').each( function(){
+      currentTotal = cj(this).attr('data-amount').replace(/[^\/\d]/g,'');
+      if( cj(this).is(':checked') && currentTotal == 0 ) {
+          flag = true;
+      }
+    });
+    cj('.price-set-option-content input').change( function () {
+      if (cj(this).attr('data-amount').replace(/[^\/\d]/g,'') == 0 ) {
+        flag = true;
+      } else {
+        flag = false;
+      }
+      showHidePayment(flag);
+    });
+    showHidePayment(flag);
   }
 
   CRM.$(function($) {


### PR DESCRIPTION
1. Membership contribution form has set-up with membership-types rather than membership-price sets in the membership setting tab
2. When 100% discount applied on membership, form should hide credit card section, at the moment, it is not happening.

Please refer the issue raised here.

dlobo/org.civicrm.module.cividiscount#86
