### PR TITLE
fix hidden form elements in addFieldMethod

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -1263,7 +1263,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
         break;
 
       case 'hidden':
-        $this->add('hidden', $name, $label, $props, $required);
+        $this->add('hidden', $name, NULL, $props, $required);
         break;
 
       case 'TextArea':


### PR DESCRIPTION
Followup for https://issues.civicrm.org/jira/browse/CRM-16130

 In latest master checkout, saving the Organization Address and Contact Info form throws a fatal error (civicrm/admin/domain?action=update&reset=1) because the master_id element in $params['address'] is being populated by a string which is that elements 'title' (Master Address Belongs To). I'm wondering if this related to the changes your working on - possibly due to the fact that this field/element is not defined by this particular form ??? 

[address] => Array 
        ( 
            [1] => Array 
                ( 
                    [master_id] => Master Address Belongs To 
                    [street_address] => 330 Upper Terrace 
                    [supplemental_address_1] => 
                    [supplemental_address_2] => 
                    [city] => San Francisco 
                    [postal_code] => 94117 
                    [postal_code_suffix] => 
                    [country_id] => 1228 
                    [state_province_id] => 1004 
                    [geo_code_1] => 
                    [geo_code_2] => 
                    [location_type_id] => 1 
                ) 

```
    ) 
```
