### PR TITLE
CRM-16528 Fixed-hook_civicrm_contact_get_displayname does not work. M…

### DIFF
--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -1839,7 +1839,7 @@ abstract class CRM_Utils_Hook {
    *
    * @return mixed
    */
-  public static function alterDisplayName($displayName, $contactId, $dao) {
+  public static function alterDisplayName(&$displayName, $contactId, $dao) {
     return self::singleton()->invoke(3,
       $displayName, $contactId, $dao, self::$_nullObject, self::$_nullObject,
       self::$_nullObject, 'civicrm_contact_get_displayname'


### PR DESCRIPTION
…issing an "&" in alterDisplayName inhooks.php

---
- CRM-16528: hook_civicrm_contact_get_displayname does not work.  Missing an "&" in alterDisplayName inhooks.php
  https://issues.civicrm.org/jira/browse/CRM-16528
