### PR TITLE
Adding jasmine testing across domains

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,7 +1,18 @@
 module.exports = function(config) {
   config.set({
     autoWatch: true,
-    browsers: ['PhantomJS'],
+    browsers: ['PhantomJS', 'PhantomJS_custom'],
+    customLaunchers: {
+      'PhantomJS_custom': {
+        base: 'PhantomJS',
+        options: {
+            windowName: 'my-window',
+            settings: {
+                webSecurityEnabled: false
+            }
+        }
+      }
+    },
     exclude: [
     ],
     files: [

--- a/tests/karma/unit/externalDomainSpec.js
+++ b/tests/karma/unit/externalDomainSpec.js
@@ -1,0 +1,29 @@
+'use strict';
+
+describe('Web page', function(){
+
+    var request = new XMLHttpRequest();
+    var url = 'http://localhost:8000'; // Change to your port!
+
+    beforeAll(function(){
+        /**
+         * Warning! Default installation of jasmine (karma+phantomjs)
+         * doesn't support JS request to other domains than own.
+         * The solutions is at page https://github.com/karma-runner/karma-phantomjs-launcher
+         * + add additional configuration to karma.conf.js
+         *   with parameter for PhantomJS webSecurityEnabled: false
+         * + change run parameter in npm/test.sh
+         */
+        request.open("GET", url, false);
+        request.send();
+    });
+
+    it('has response code 200', function(){
+        expect(request.status).toBe(200);
+    });
+
+    it('contain tag body', function(){
+        expect(request.responseText).toContain('<body');
+    });
+
+});

--- a/tools/scripts/npm/test.sh
+++ b/tools/scripts/npm/test.sh
@@ -2,13 +2,13 @@
 if which node_modules/karma/bin/karma >> /dev/null; then
   if which nodejs >> /dev/null; then
     ## Debian
-    nodejs node_modules/karma/bin/karma start
+    nodejs node_modules/karma/bin/karma start --browsers PhantomJS_custom
   else
     ## Official
-    node node_modules/karma/bin/karma start
+    node node_modules/karma/bin/karma start --browsers PhantomJS_custom
   fi
 elif which karma >> /dev/null ; then
-  karma start
+  karma start --browsers PhantomJS_custom
 else
   echo "ERROR: Failed to find karma"
   exit 1


### PR DESCRIPTION
Default installation of jasmine (karma+phantomjs) doesn't support JS request to other domains than own.

Example of use /tests/karma/unit/externaExample.js:

```
'use strict';

describe('Web page', function(){

    var request = new XMLHttpRequest();
    var url = 'http://localhost:8000/'; // change to your port

    beforeAll(function(){
        request.open("GET", url, false);
        request.send();
    });

    it('has response code 200', function(){
        expect(request.status).toBe(200);
    });

    it('contain tag body', function(){
        expect(request.responseText).toContain('<body');
    });

});
```
