### PR TITLE
CRM-16457 Fixes error caused by contribution fulfillment date

### DIFF
--- a/CRM/Contribute/BAO/Query.php
+++ b/CRM/Contribute/BAO/Query.php
@@ -337,7 +337,7 @@ class CRM_Contribute_BAO_Query {
       case 'contribution_check_number':
       case 'contribution_contact_id':
       case (strpos($name, '_amount') !== FALSE):
-      case (strpos($name, '_date') !== FALSE):
+      case (strpos($name, '_date') !== FALSE && $name != 'contribution_fulfilled_date'):
         $qillName = $name;
         $pseudoExtraParam = NULL;
         if ((strpos($name, '_amount') !== FALSE) || (strpos($name, '_date') !== FALSE) || in_array($name,


### PR DESCRIPTION
This column was being attached the contribution table on the where statement because it ends in "_date". Once it is skipped everything works normally.
