### PR TITLE
Proposed fix for searching/reporting on similar multi select values CRM-16575

### DIFF
--- a/CRM/Core/BAO/CustomQuery.php
+++ b/CRM/Core/BAO/CustomQuery.php
@@ -400,9 +400,20 @@ SELECT label, value
             else {
               $val = CRM_Utils_Type::escape($strtolower(trim($value)), 'String');
 
-              if ($wildcard) {
-                $val = $strtolower(CRM_Core_DAO::escapeString($val));
-                $val = "%$val%";
+              $specialHTMLType = array(
+                'CheckBox',
+                'Multi-Select',
+                'AdvMulti-Select',
+                'Multi-Select State/Province',
+                'Multi-Select Country',
+              );
+               
+              if (in_array($field['html_type'], $specialHTMLType)) {
+                $val = "[[:cntrl:]]".$val."[[:cntrl:]]";
+                $op  = 'RLIKE';
+
+              } elseif ($wildcard) {
+				$val = "[[:cntrl:]]%$val%[[:cntrl:]]";
                 $op = 'LIKE';
               }
 

--- a/CRM/Core/BAO/CustomQuery.php
+++ b/CRM/Core/BAO/CustomQuery.php
@@ -413,7 +413,7 @@ SELECT label, value
                 $op  = 'RLIKE';
 
               }
-			  elseif ($wildcard) {
+              elseif ($wildcard) {
                 $val = "[[:cntrl:]]%$val%[[:cntrl:]]";
                 $op = 'LIKE';
               }

--- a/CRM/Core/BAO/CustomQuery.php
+++ b/CRM/Core/BAO/CustomQuery.php
@@ -413,7 +413,7 @@ SELECT label, value
                 $op  = 'RLIKE';
 
               } elseif ($wildcard) {
-				$val = "[[:cntrl:]]%$val%[[:cntrl:]]";
+                $val = "[[:cntrl:]]%$val%[[:cntrl:]]";
                 $op = 'LIKE';
               }
 

--- a/CRM/Core/BAO/CustomQuery.php
+++ b/CRM/Core/BAO/CustomQuery.php
@@ -407,12 +407,13 @@ SELECT label, value
                 'Multi-Select State/Province',
                 'Multi-Select Country',
               );
-               
+
               if (in_array($field['html_type'], $specialHTMLType)) {
-                $val = "[[:cntrl:]]".$val."[[:cntrl:]]";
+                $val = "[[:cntrl:]]" . $val . "[[:cntrl:]]";
                 $op  = 'RLIKE';
 
-              } elseif ($wildcard) {
+              }
+			  elseif ($wildcard) {
                 $val = "[[:cntrl:]]%$val%[[:cntrl:]]";
                 $op = 'LIKE';
               }

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -1739,8 +1739,8 @@ class CRM_Report_Form extends CRM_Core_Form {
         if ($value !== NULL && count($value) > 0) {
           $sqlOP = $this->getSQLOperator($op);
           $clause
-            = "{$field['dbAlias']} REGEXP '[[:<:]]" . implode('|', $value) .
-            "[[:>:]]'";
+            = "{$field['dbAlias']} REGEXP '[[:cntrl:]]" . implode('|', $value) .
+            "[[:cntrl:]]'";
         }
         break;
 
@@ -1749,8 +1749,8 @@ class CRM_Report_Form extends CRM_Core_Form {
         if ($value !== NULL && count($value) > 0) {
           $sqlOP = $this->getSQLOperator($op);
           $clause
-            = "( {$field['dbAlias']} NOT REGEXP '[[:<:]]" . implode('|', $value) .
-            "[[:>:]]' OR {$field['dbAlias']} IS NULL )";
+            = "( {$field['dbAlias']} NOT REGEXP '[[:cntrl:]]" . implode('|', $value) .
+            "[[:cntrl:]]' OR {$field['dbAlias']} IS NULL )";
         }
         break;
 


### PR DESCRIPTION
CRM-16575

Info about the the [[:cntrl:]] characters.. http://en.wikipedia.org/wiki/Control_character

Alternative is to use [[.SOH.]] but anywhere the code changes query values to lower-case would need to be changed as [[.soh.]] doesn't work.
