### PR TITLE
Add custom_pre hook for custom fields

### DIFF
--- a/CRM/Core/BAO/CustomValue.php
+++ b/CRM/Core/BAO/CustomValue.php
@@ -205,6 +205,12 @@ class CRM_Core_BAO_CustomValue extends CRM_Core_DAO {
     // first we need to find custom value table, from custom group ID
     $tableName = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $customGroupID, 'table_name');
 
+    CRM_Utils_Hook::custom_pre('delete',
+      $customGroupID,
+      NULL,
+      $customValueID
+    );
+
     // delete custom value from corresponding custom value table
     $sql = "DELETE FROM {$tableName} WHERE id = {$customValueID}";
     CRM_Core_DAO::executeQuery($sql);

--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -238,6 +238,13 @@ class CRM_Core_BAO_CustomValueTable {
           else {
             $query = "$sqlOP SET $setClause $where";
           }
+
+          CRM_Utils_Hook::custom_pre($hookOP,
+            $hookID,
+            $entityID,
+            $fields
+          );
+
           $dao = CRM_Core_DAO::executeQuery($query, $params);
 
           CRM_Utils_Hook::custom($hookOP,

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -423,6 +423,26 @@ abstract class CRM_Utils_Hook {
       ->invoke(5, $formName, $fields, $files, $form, $errors, self::$_nullObject, 'civicrm_validateForm');
   }
 
+   /**
+   * This hook is called before a db write on a custom table.
+   *
+   * @param string $op
+   *   The type of operation being performed.
+   * @param string $groupID
+   *   The custom group ID.
+   * @param object $entityID
+   *   The entityID of the row in the custom table.
+   * @param array $params
+   *   The parameters that were sent into the calling function.
+   *
+   * @return null
+   *   the return value is ignored
+   */
+  public static function custom_pre($op, $groupID, $entityID, &$params) {
+    return self::singleton()
+      ->invoke(4, $op, $groupID, $entityID, $params, self::$_nullObject, self::$_nullObject, 'civicrm_custom_pre');
+  }
+
   /**
    * This hook is called after a db write on a custom table.
    *

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -437,7 +437,7 @@ abstract class CRM_Utils_Hook {
    *
    * @return null
    *   the return value is ignored
-  */
+   */
   public static function custom_pre($op, $groupID, $entityID, &$params) {
     return self::singleton()
       ->invoke(4, $op, $groupID, $entityID, $params, self::$_nullObject, self::$_nullObject, 'civicrm_custom_pre');

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -423,7 +423,7 @@ abstract class CRM_Utils_Hook {
       ->invoke(5, $formName, $fields, $files, $form, $errors, self::$_nullObject, 'civicrm_validateForm');
   }
 
-   /**
+  /**
    * This hook is called before a db write on a custom table.
    *
    * @param string $op
@@ -437,7 +437,7 @@ abstract class CRM_Utils_Hook {
    *
    * @return null
    *   the return value is ignored
-   */
+  */
   public static function custom_pre($op, $groupID, $entityID, &$params) {
     return self::singleton()
       ->invoke(4, $op, $groupID, $entityID, $params, self::$_nullObject, self::$_nullObject, 'civicrm_custom_pre');


### PR DESCRIPTION
https://issues.civicrm.org/jira/browse/CRM-16583

to fire before a custom field database write to match the custom(_post) hook that already exists.
