### PR TITLE
CRM-14987 find correct WP install path

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -412,21 +412,11 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
       }
     }
     else {
-      $pathVars = explode('/', str_replace('\\', '/', $_SERVER['SCRIPT_FILENAME']));
-
-      //might be windows installation.
-      $firstVar = array_shift($pathVars);
-      if ($firstVar) {
-        $cmsRoot = $firstVar;
-      }
-
-      //start w/ csm dir search.
-      foreach ($pathVars as $var) {
-        $cmsRoot .= "/$var";
+      if (function_exists('get_home_path()')) {
+        $cmsRoot = get_home_path();
         if ($this->validInstallDir($cmsRoot)) {
-          //stop as we found bootstrap.
+          define('CIVICRM_CMSDIR' , $cmsRoot);  //should we go ahead and set the constant here for future bootstrap performance?
           $valid = TRUE;
-          break;
         }
       }
     }


### PR DESCRIPTION
No errors in my testing, and should fix CRM-14987 as well as recently-reported open_basedir() security warnings. I took the liberty of defining the constant if it's not found in civicrm.settings.php; please advise if that's too presumptuous.

---
- [CRM-14987: WordPress cmsRootPath can incorrectly return unrelated CMS install](https://issues.civicrm.org/jira/browse/CRM-14987)
