### PR TITLE
CRM-16590 - Admin/Extensions - Fix regression

### DIFF
--- a/CRM/Admin/Form/Extensions.php
+++ b/CRM/Admin/Form/Extensions.php
@@ -100,35 +100,40 @@ class CRM_Admin_Form_Extensions extends CRM_Admin_Form {
    * @return void
    */
   public function buildQuickForm() {
-
-    $info = CRM_Extension_System::singleton()->getMapper()->keyToInfo($this->_key);
-    $extInfo = CRM_Admin_Page_Extensions::createExtendedInfo($info);
-    $extName = $extInfo['name'];
-
     switch ($this->_action) {
       case CRM_Core_Action::ADD:
         $buttonName = ts('Install');
-        $title = ts('Install ' . $extName . '?');
+        $title = ts('Install "%1"?', array(
+          1 => $this->_key,
+        ));
         break;
 
       case CRM_Core_Action::UPDATE:
         $buttonName = ts('Download and Install');
-        $title = ts('Download and Install ' . $extName . '?');
+        $title = ts('Download and Install "%1"?', array(
+          1 => $this->_key,
+        ));
         break;
 
       case CRM_Core_Action::DELETE:
         $buttonName = ts('Uninstall');
-        $title = ts('Uninstall ' . $extName . '?');
+        $title = ts('Uninstall "%1"?', array(
+          1 => $this->_key,
+        ));
         break;
 
       case CRM_Core_Action::ENABLE:
         $buttonName = ts('Enable');
-        $title = ts('Enable ' . $extName . '?');
+        $title = ts('Enable "%1"?', array(
+          1 => $this->_key,
+        ));
         break;
 
       case CRM_Core_Action::DISABLE:
         $buttonName = ts('Disable');
-        $title = ts('Disable ' . $extName . '?');
+        $title = ts('Disable "%1"?', array(
+          1 => $this->_key,
+        ));
         break;
     }
 

--- a/templates/CRM/Admin/Page/ExtensionDetails.tpl
+++ b/templates/CRM/Admin/Page/ExtensionDetails.tpl
@@ -1,5 +1,5 @@
 <table class="crm-info-panel">
-    {if $action EQ 1}
+    {if $extension.name}
     <tr>
         <td class="label">{ts}Name (key){/ts}</td><td>{$extension.name} ({$extension.key})</td>
     </tr>


### PR DESCRIPTION
When installing a new extension, it raises an exception because it cannot
display the pretty name of the extension. Moreover, it handles localization
inappropriately.

This is a follow-up to 17d48d22.
