### PR TITLE
CRM-16563 include end-date by using time 23:59 than incrementing by day1

### DIFF
--- a/CRM/Core/BAO/RecurringEntity.php
+++ b/CRM/Core/BAO/RecurringEntity.php
@@ -1082,8 +1082,9 @@ class CRM_Core_BAO_RecurringEntity extends CRM_Core_DAO_RecurringEntity {
 
       if (!empty($scheduleReminderDetails['absolute_date'])) {
         $absoluteDate = CRM_Utils_Date::setDateDefaults($scheduleReminderDetails['absolute_date']);
-        $endDate = new DateTime($absoluteDate[0] . ' ' . $absoluteDate[1]);
-        $endDate->modify('+1 day');
+        // absolute_date column of scheduled-reminder table is of type date (and not datetime)
+        // and we always want the date to be included, and therefore appending 23:59
+        $endDate = new DateTime($absoluteDate[0] . ' ' . '23:59');
         $r->until($endDate);
       }
 


### PR DESCRIPTION
Reason is: ends-on date is stored against absolute-date column of scheduled reminder table which is of type date than datetime. To make the day count as inclusion, code was adding day 1 to it. 
This being interpreted by recursion library as next-day with time of 12:00AM. Which made events with no or 12:00AM time propagate to next day satisfying the condition.

The fix removes the increment of day 1, and adds a time of 23:59, to the ends-on date.

---
- CRM-16563: Recurring event system sometimes suggests incorrect dates
  https://issues.civicrm.org/jira/browse/CRM-16563
