### PR TITLE
CRM-16600 Allow Smart groups in the list of unsubscribe groups

### DIFF
--- a/CRM/Mailing/Form/Group.php
+++ b/CRM/Mailing/Form/Group.php
@@ -239,12 +239,13 @@ class CRM_Mailing_Form_Group extends CRM_Contact_Form_Task {
     //when the context is search add base group's.
     if ($this->_searchBasedMailing) {
       //get the static groups
-      $staticGroups = CRM_Core_PseudoConstant::staticGroup(FALSE, 'Mailing');
+      //CRM-16600 Include Smart Groups in Unsubscribe list as that matches
+      //all other practices in CiviMail
       $this->add('select', 'baseGroup',
         ts('Unsubscription Group'),
         array(
           '' => ts('- select -'),
-        ) + CRM_Contact_BAO_Group::getGroupsHierarchy($staticGroups, NULL, '&nbsp;&nbsp;', TRUE),
+        ) + $groups,
         TRUE,
         array('class' => 'crm-select2 huge')
       );

--- a/ang/crmMailing/BlockMailing.html
+++ b/ang/crmMailing/BlockMailing.html
@@ -60,7 +60,7 @@ It could perhaps be thinned by 30-60% by making more directives.
           ng-model="mailing.recipients.groups.base[0]"
           ng-required="true"
           >
-          <option ng-repeat="grp in crmMailingConst.groupNames | filter:{visibility:'Public pages'}" value="{{grp.id}}">{{grp.title}}</option>
+          <option ng-repeat="grp in crmMailingConst.groupNames | orderBy:'title'" value="{{grp.id}}">{{grp.title}}</option>
         </select>
       </div>
     </span>


### PR DESCRIPTION
@colemanw I believe this will do the job. I also removed the filter on visibility as that did not seem to make sense to me given we allow non public pages groups to be mailed. There may be a reason for this that I am not aware of. If your happy with this solution, I'm happy to back port for 4.6, 4.5 and 4.4.
