### PR TITLE
CRM-16675 remove unused function composeMessage on ContributionPage c…

### DIFF
--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -431,36 +431,7 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
   }
 
   /**
-   * Construct the message to be sent by the send function.
-   *
-   * @param array $tplParams
-   * @param int $contactID
-   * @param $isTest
-   *
-   * @return array
-   */
-  public function composeMessage($tplParams, $contactID, $isTest) {
-    $sendTemplateParams = array(
-      'groupName' => $tplParams['membershipID'] ? 'msg_tpl_workflow_membership' : 'msg_tpl_workflow_contribution',
-      'valueName' => $tplParams['membershipID'] ? 'membership_online_receipt' : 'contribution_online_receipt',
-      'contactId' => $contactID,
-      'tplParams' => $tplParams,
-      'isTest' => $isTest,
-      'PDFFilename' => 'receipt.pdf',
-    );
-    if ($returnMessageText) {
-      list($sent, $subject, $message, $html) = CRM_Core_BAO_MessageTemplate::sendTemplate($sendTemplateParams);
-      return array(
-        'subject' => $subject,
-        'body' => $message,
-        'to' => $displayName,
-        'html' => $html,
-      );
-    }
-  }
-
-  /**
-   * Send the emails for Recurring Contribution Notication.
+   * Send the emails for Recurring Contribution Notification.
    *
    * @param string $type
    *   TxnType.
@@ -471,8 +442,6 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
    * @param object $recur
    *   Object of recurring contribution table.
    * @param bool|object $autoRenewMembership is it a auto renew membership.
-   *
-   * @return void
    */
   public static function recurringNotify($type, $contactID, $pageID, $recur, $autoRenewMembership = FALSE) {
     $value = array();
@@ -548,7 +517,7 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
         $template->assign('updateSubscriptionUrl', $url);
       }
 
-      list($sent, $subject, $message, $html) = CRM_Core_BAO_MessageTemplate::sendTemplate($templatesParams);
+      list($sent) = CRM_Core_BAO_MessageTemplate::sendTemplate($templatesParams);
 
       if ($sent) {
         CRM_Core_Error::debug_log_message('Success: mail sent for recurring notification.');


### PR DESCRIPTION
…lass

On grepping I find only composeMessageArray rather than any calls to this function. I'm pretty sure it has been an orphan for many many releases - but would like another pair of eyes on if possible.

There are some other unused functions that I will add to the ticket & do as separate PRs if I get to them.
