### PR TITLE
Fix for CRM-16691

### DIFF
--- a/CRM/Admin/Form/Preferences/Contribute.php
+++ b/CRM/Admin/Form/Preferences/Contribute.php
@@ -211,7 +211,7 @@ class CRM_Admin_Form_Preferences_Contribute extends CRM_Admin_Form_Preferences {
     //CRM-16691: Changes made related to settings of 'CVV'.
     $settings = array_intersect_key($params, $this->_settings);
     $result = civicrm_api3('setting', 'create', $settings);
-    CRM_Core_Session::setStatus(" ", ts('Changes Saved'), "success");
+    CRM_Core_Session::setStatus(ts('Your changes have been saved.'), ts('Changes Saved'), "success");
   }
 
 }

--- a/CRM/Admin/Form/Preferences/Contribute.php
+++ b/CRM/Admin/Form/Preferences/Contribute.php
@@ -38,6 +38,9 @@
  *
  */
 class CRM_Admin_Form_Preferences_Contribute extends CRM_Admin_Form_Preferences {
+  protected $_settings = array(
+    'cvv_backoffice_required' => CRM_Core_BAO_Setting::CONTRIBUTE_PREFERENCES_NAME,
+  );
   /**
    * Process the form submission.
    *
@@ -122,6 +125,27 @@ class CRM_Admin_Form_Preferences_Contribute extends CRM_Admin_Form_Preferences {
    * @return void
    */
   public function buildQuickForm() {
+    //CRM-16691: Changes made related to settings of 'CVV'.
+    foreach ($this->_settings as $setting => $group) {
+      $settingMetaData = civicrm_api3('setting', 'getfields', array('name' => $setting));
+      $props = $settingMetaData['values'][$setting];
+      if (isset($props['quick_form_type'])) {
+        $add = 'add' . $props['quick_form_type'];
+        if ($add == 'addElement') {
+          $this->$add(
+            $props['html_type'],
+            $setting,
+            ts($props['title']),
+            CRM_Utils_Array::value($props['html_type'] == 'select' ? 'option_values' : 'html_attributes', $props, array()),
+            $props['html_type'] == 'select' ? CRM_Utils_Array::value('html_attributes', $props) : NULL
+          );
+        }
+        else {
+          $this->$add($setting, ts($props['title']));
+        }
+      }
+      $this->assign("{$setting}_description", ts($props['description']));
+    }
     $this->add('checkbox', 'invoicing', ts('Enable Tax and Invoicing'));
     parent::buildQuickForm();
   }
@@ -135,6 +159,17 @@ class CRM_Admin_Form_Preferences_Contribute extends CRM_Admin_Form_Preferences {
    */
   public function setDefaultValues() {
     $defaults = CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::CONTRIBUTE_PREFERENCES_NAME, 'contribution_invoice_settings');
+    //CRM-16691: Changes made related to settings of 'CVV'.
+    foreach ($this->_settings as $setting => $group) {
+      $settingMetaData = civicrm_api3('setting', 'getfields', array('name' => $setting));
+      $defaults[$setting] = civicrm_api3('setting', 'getvalue',
+        array(
+          'name' => $setting,
+          'group' => $group,
+          'default_value' => CRM_Utils_Array::value('default', $settingMetaData['values'][$setting]),
+        )
+      );
+    }
     return $defaults;
   }
 
@@ -173,6 +208,10 @@ class CRM_Admin_Form_Preferences_Contribute extends CRM_Admin_Form_Preferences {
         CRM_Core_DAO::VALUE_SEPARATOR;
       CRM_Core_BAO_Setting::setItem($settingName, 'CiviCRM Preferences', 'user_dashboard_options');
     }
+    //CRM-16691: Changes made related to settings of 'CVV'.
+    $settings = array_intersect_key($params, $this->_settings);
+    $result = civicrm_api3('setting', 'create', $settings);
+    CRM_Core_Session::setStatus(" ", ts('Changes Saved'), "success");
   }
 
 }

--- a/CRM/Admin/Form/Setting/Url.php
+++ b/CRM/Admin/Form/Setting/Url.php
@@ -39,7 +39,6 @@
  */
 class CRM_Admin_Form_Setting_Url extends CRM_Admin_Form_Setting {
   protected $_settings = array(
-    'cvv_backoffice_required' => CRM_Core_BAO_Setting::CONTRIBUTE_PREFERENCES_NAME,
     'disable_core_css' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
   );
 

--- a/templates/CRM/Admin/Form/Setting/Url.tpl
+++ b/templates/CRM/Admin/Form/Setting/Url.tpl
@@ -87,13 +87,6 @@
             <p class="description font-red">{ts}{$verifySSL_description}{/ts}</p>
         </td>
     </tr>
-    <tr class="crm-miscellaneous-form-block-cvv-backoffice-required">
-          <td class="label">{$form.cvv_backoffice_required.label}</td>
-          <td>
-            {$form.cvv_backoffice_required.html}<br />
-            <p class="description">{ts}{$cvv_backoffice_required_description}{/ts}</p>
-          </td>
-        </tr>
 </table>
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 </div>

--- a/templates/CRM/Form/basicForm.tpl
+++ b/templates/CRM/Form/basicForm.tpl
@@ -26,12 +26,22 @@
 <div class="crm-block crm-form-block crm-{$formName}-block">
     <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
     {if $formName == "Contribute_Preferences" }
-      <table class="form-layout">
-        <tr class="crm-preferences-form-block-invoicing">
+      <table class = "form-layout">
+        <tr class="crm-miscellaneous-form-block-cvv-backoffice-required">
+          <td class="label">{$form.cvv_backoffice_required.label}</td>
           <td>
-            {$form.invoicing.html} {$form.invoicing.label}
+            {$form.cvv_backoffice_required.html}<br />
+            <p class="description">{ts}{$cvv_backoffice_required_description}{/ts}</p>
           </td>
         </tr>
+        {if $formName == "Contribute_Preferences" }
+          <tr class="crm-preferences-form-block-invoicing">
+            <td class="label">{$form.invoicing.label}</td>
+            <td>
+              {$form.invoicing.html}
+            </td>
+          </tr>
+        {/if}
       </table>
     {/if}
     <table class="form-layout" id="invoicing_blocks">


### PR DESCRIPTION
Moved "CVV required for backoffice" setting from "Administer->System Settings->Resource URL"  form to "Administer->CiviContribute->Civicontribute Component Settings" form.

https://issues.civicrm.org/jira/browse/CRM-16691
