### PR TITLE
PR for CRM-16701: Saved Search API

### DIFF
--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -309,4 +309,15 @@ LEFT JOIN civicrm_email ON (contact_a.id = civicrm_email.contact_id AND civicrm_
     return $savedSearch;
   }
 
+  protected function assignTestValue($fieldName, &$fieldDef, $counter) {
+    if ($fieldName == 'form_values') {
+      // A dummy value for form_values.
+      $this->{$fieldName} = serialize(
+          array('sort_name' => "SortName{$counter}"));
+    }
+    else {
+      parent::assignTestValues($fieldName, $fieldDef, $counter);
+    }
+  }
+
 }

--- a/api/v3/SavedSearch.php
+++ b/api/v3/SavedSearch.php
@@ -99,7 +99,11 @@ function civicrm_api3_saved_search_get($params) {
  * @param array $result API result to be cleaned up.
  */
 function _civicrm_api3_saved_search_result_cleanup(&$result) {
-  foreach ($result['values'] as $key => $value) {
-    $result['values'][$key]['form_values'] = unserialize($value['form_values']);
+  // Only clean up the values if there are values. (A getCount operation
+  // for example does not return values.)
+  if (isset($result['values'])) {
+    foreach ($result['values'] as $key => $value) {
+      $result['values'][$key]['form_values'] = unserialize($value['form_values']);
+    }
   }
 }

--- a/api/v3/SavedSearch.php
+++ b/api/v3/SavedSearch.php
@@ -43,6 +43,11 @@
  * @access public
  */
 function civicrm_api3_saved_search_create($params) {
+  // The create function of the dao expects a 'formValues' that is
+  // not serialized. The get function returns form_values, that is
+  // serialized. For now, I will hack around this problem like this:
+  $params["formValues"] = unserialize($params["form_values"]);
+
   return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
 }
 

--- a/api/v3/SavedSearch.php
+++ b/api/v3/SavedSearch.php
@@ -99,7 +99,7 @@ function civicrm_api3_saved_search_get($params) {
  * @param array $result API result to be cleaned up.
  */
 function _civicrm_api3_saved_search_result_cleanup(&$result) {
-  if (isset($result['values'])) {
+  if (isset($result['values']) && is_array($result['values'])) {
     // Only clean up the values if there are values. (A getCount operation
     // for example does not return values.)
     foreach ($result['values'] as $key => $value) {

--- a/api/v3/SavedSearch.php
+++ b/api/v3/SavedSearch.php
@@ -1,28 +1,29 @@
 <?php
+
 /*
- +--------------------------------------------------------------------+
- | CiviCRM version 4.6                                                |
- +--------------------------------------------------------------------+
- | Copyright Chirojeugd-Vlaanderen vzw 2015                           |
- +--------------------------------------------------------------------+
- | This file is a part of CiviCRM.                                    |
- |                                                                    |
- | CiviCRM is free software; you can copy, modify, and distribute it  |
- | under the terms of the GNU Affero General Public License           |
- | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
- |                                                                    |
- | CiviCRM is distributed in the hope that it will be useful, but     |
- | WITHOUT ANY WARRANTY; without even the implied warranty of         |
- | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
- | See the GNU Affero General Public License for more details.        |
- |                                                                    |
- | You should have received a copy of the GNU Affero General Public   |
- | License and the CiviCRM Licensing Exception along                  |
- | with this program; if not, contact CiviCRM LLC                     |
- | at info[AT]civicrm[DOT]org. If you have questions about the        |
- | GNU Affero General Public License or the licensing of CiviCRM,     |
- | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
- +--------------------------------------------------------------------+
+  +--------------------------------------------------------------------+
+  | CiviCRM version 4.6                                                |
+  +--------------------------------------------------------------------+
+  | Copyright Chirojeugd-Vlaanderen vzw 2015                           |
+  +--------------------------------------------------------------------+
+  | This file is a part of CiviCRM.                                    |
+  |                                                                    |
+  | CiviCRM is free software; you can copy, modify, and distribute it  |
+  | under the terms of the GNU Affero General Public License           |
+  | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+  |                                                                    |
+  | CiviCRM is distributed in the hope that it will be useful, but     |
+  | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+  | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+  | See the GNU Affero General Public License for more details.        |
+  |                                                                    |
+  | You should have received a copy of the GNU Affero General Public   |
+  | License and the CiviCRM Licensing Exception along                  |
+  | with this program; if not, contact CiviCRM LLC                     |
+  | at info[AT]civicrm[DOT]org. If you have questions about the        |
+  | GNU Affero General Public License or the licensing of CiviCRM,     |
+  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+  +--------------------------------------------------------------------+
  */
 
 /**
@@ -32,35 +33,29 @@
  */
 
 /**
- * Create a saved search.
+ * Create or update a saved search.
  *
  * @param array $params
- *
- * @return array
+ *   Associative array of property name-value pairs to insert in new saved search.
+ * @example SavedSearch/Create.php Std create example.
+ * @return array api result array
+ *   {@getfields saved_search_create}
+ * @access public
  */
 function civicrm_api3_saved_search_create($params) {
   return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
 }
 
 /**
- * Adjust Metadata for Create action.
- *
- * The metadata is used for setting defaults, documentation & validation.
+ * Delete an existing saved search.
  *
  * @param array $params
- *   Array of parameters determined by getfields.
- */
-function _civicrm_api3_saved_search_create_spec(&$params) {
-  // TODO: find out wherther something needs to be done here.
-}
-
-/**
- * Deletes an existing saved search.
- *
- * @param array $params
- *
- * @return array
- *   API result Array
+ *   Associative array of property name-value pairs. $params['id'] should be
+ *   the ID of the saved search to be deleted.
+ * @example SavedSearch/Delete.php Std delete example.
+ * @return array api result array
+ *   {@getfields saved_search_delete}
+ * @access public
  */
 function civicrm_api3_saved_search_delete($params) {
   return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -70,10 +65,11 @@ function civicrm_api3_saved_search_delete($params) {
  * Retrieve one or more saved search(es).
  *
  * @param array $params
- *   An associative array of name/value pairs.
- *
- * @return array
- *   details of found saved searches
+ *   An associative array of name-value pairs.
+ * @example SavedSearch/Get.php Std get example.
+ * @return array api result array
+ *   {@getfields saved_search_get}
+ * @access public
  */
 function civicrm_api3_saved_search_get($params) {
   return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);

--- a/api/v3/SavedSearch.php
+++ b/api/v3/SavedSearch.php
@@ -1,0 +1,80 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.6                                                |
+ +--------------------------------------------------------------------+
+ | Copyright Chirojeugd-Vlaanderen vzw 2015                           |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * This api exposes CiviCRM saved searches.
+ *
+ * @package CiviCRM_APIv3
+ */
+
+/**
+ * Create a saved search.
+ *
+ * @param array $params
+ *
+ * @return array
+ */
+function civicrm_api3_saved_search_create($params) {
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+}
+
+/**
+ * Adjust Metadata for Create action.
+ *
+ * The metadata is used for setting defaults, documentation & validation.
+ *
+ * @param array $params
+ *   Array of parameters determined by getfields.
+ */
+function _civicrm_api3_saved_search_create_spec(&$params) {
+  // TODO: find out wherther something needs to be done here.
+}
+
+/**
+ * Deletes an existing saved search.
+ *
+ * @param array $params
+ *
+ * @return array
+ *   API result Array
+ */
+function civicrm_api3_saved_search_delete($params) {
+  return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+}
+
+/**
+ * Retrieve one or more saved search(es).
+ *
+ * @param array $params
+ *   An associative array of name/value pairs.
+ *
+ * @return array
+ *   details of found saved searches
+ */
+function civicrm_api3_saved_search_get($params) {
+  return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+}

--- a/api/v3/SavedSearch.php
+++ b/api/v3/SavedSearch.php
@@ -49,12 +49,14 @@ function civicrm_api3_saved_search_create($params) {
   // So for the create API, I guess it should work for serialized and
   // unserialized form_values.
 
-  if (is_array($params["form_values"])) {
-    $params["formValues"] = $params["form_values"];
-  }
-  else {
-    // Assume that form_values is serialized.
-    $params["formValues"] = unserialize($params["form_values"]);
+  if (isset($params["form_values"])) {
+    if (is_array($params["form_values"])) {
+      $params["formValues"] = $params["form_values"];
+    }
+    else {
+      // Assume that form_values is serialized.
+      $params["formValues"] = unserialize($params["form_values"]);
+    }
   }
 
   $result = _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);

--- a/api/v3/SavedSearch.php
+++ b/api/v3/SavedSearch.php
@@ -99,9 +99,9 @@ function civicrm_api3_saved_search_get($params) {
  * @param array $result API result to be cleaned up.
  */
 function _civicrm_api3_saved_search_result_cleanup(&$result) {
-  // Only clean up the values if there are values. (A getCount operation
-  // for example does not return values.)
   if (isset($result['values'])) {
+    // Only clean up the values if there are values. (A getCount operation
+    // for example does not return values.)
     foreach ($result['values'] as $key => $value) {
       $result['values'][$key]['form_values'] = unserialize($value['form_values']);
     }

--- a/tests/phpunit/api/v3/SavedSearchTest.php
+++ b/tests/phpunit/api/v3/SavedSearchTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+  +--------------------------------------------------------------------+
+  | CiviCRM version 4.6                                                |
+  +--------------------------------------------------------------------+
+  | Copyright Chirojeugd-Vlaanderen vzw 2015                           |
+  +--------------------------------------------------------------------+
+  | This file is a part of CiviCRM.                                    |
+  |                                                                    |
+  | CiviCRM is free software; you can copy, modify, and distribute it  |
+  | under the terms of the GNU Affero General Public License           |
+  | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+  |                                                                    |
+  | CiviCRM is distributed in the hope that it will be useful, but     |
+  | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+  | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+  | See the GNU Affero General Public License for more details.        |
+  |                                                                    |
+  | You should have received a copy of the GNU Affero General Public   |
+  | License and the CiviCRM Licensing Exception along                  |
+  | with this program; if not, contact CiviCRM LLC                     |
+  | at info[AT]civicrm[DOT]org. If you have questions about the        |
+  | GNU Affero General Public License or the licensing of CiviCRM,     |
+  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+  +--------------------------------------------------------------------+
+ */
+
+require_once 'CiviTest/CiviUnitTestCase.php';
+
+/**
+ *  Class api_v3_SavedSearchTest
+ *
+ * @package CiviCRM_APIv3
+ */
+class api_v3_SavedSearchTest extends CiviUnitTestCase {
+
+  protected $_apiversion = 3;
+  protected $params;
+  protected $id;
+  protected $_entity;
+  public $DBResetRequired = FALSE;
+
+  public function setUp() {
+    parent::setUp();
+
+    // The line below makes it unneccessary to do cleanup after a test,
+    // because the transaction of the test will be rolled back.
+    // see http://forum.civicrm.org/index.php/topic,35627.0.html
+    $this->useTransaction(TRUE);
+
+    $this->_entity = 'SavedSearch';
+
+    // I created a smart group using the CiviCRM gui. The smart group contains
+    // all contacts tagged with 'company'.
+    // I got the params below from the database.
+
+    $this->params = array(
+      'form_values' => 'a:36:{s:5:"qfKey";s:37:"4b50e233dcbe77cced4bd8fd8df90567_9974";s:8:"entryURL";s:64:"' . CIVICRM_UF_BASEURL . '/civicrm/contact/search/advanced?reset=1";s:12:"hidden_basic";s:1:"1";s:12:"contact_type";a:0:{}s:5:"group";a:0:{}s:10:"group_type";a:0:{}s:21:"group_search_selected";s:5:"group";s:9:"sort_name";s:0:"";s:5:"email";s:0:"";s:14:"contact_source";s:0:"";s:9:"job_title";s:0:"";s:10:"contact_id";s:0:"";s:19:"external_identifier";s:0:"";s:7:"uf_user";s:0:"";s:10:"tag_search";s:0:"";s:11:"uf_group_id";s:0:"";s:14:"component_mode";s:1:"1";s:8:"operator";s:3:"AND";s:25:"display_relationship_type";s:0:"";s:15:"privacy_options";a:0:{}s:16:"privacy_operator";s:2:"OR";s:14:"privacy_toggle";s:1:"1";s:13:"email_on_hold";a:1:{s:7:"on_hold";s:0:"";}s:30:"preferred_communication_method";a:5:{i:1;s:0:"";i:2;s:0:"";i:3;s:0:"";i:4;s:0:"";i:5;s:0:"";}s:18:"preferred_language";s:0:"";s:13:"phone_numeric";s:0:"";s:22:"phone_location_type_id";s:0:"";s:19:"phone_phone_type_id";s:0:"";s:4:"task";s:2:"13";s:8:"radio_ts";s:6:"ts_sel";s:12:"toggleSelect";s:1:"1";s:10:"mark_x_165";s:1:"1";s:10:"mark_x_155";s:1:"1";s:10:"mark_x_124";s:1:"1";s:9:"mark_x_35";s:1:"1";s:12:"contact_tags";a:1:{i:2;i:1;}}',
+      'where_clause' => '( `civicrm_entity_tag-2`.tag_id IN (2) )  ',
+      'select_tables' => "a:8:{s:15:\"civicrm_contact\";i:1;s:15:\"civicrm_address\";i:1;s:15:\"civicrm_country\";i:1;s:13:\"civicrm_email\";i:1;s:13:\"civicrm_phone\";i:1;s:10:\"civicrm_im\";i:1;s:19:\"civicrm_worldregion\";i:1;s:22:\"`civicrm_entity_tag-2`\";s:168:\" LEFT JOIN civicrm_entity_tag `civicrm_entity_tag-2` ON ( `civicrm_entity_tag-2`.entity_id = contact_a.id  AND `civicrm_entity_tag-2`.entity_table = \'civicrm_contact\') \";} ",
+      'where_tables' => "a:2:{s:15:\"civicrm_contact\";i:1;s:22:\"`civicrm_entity_tag-2`\";s:168:\" LEFT JOIN civicrm_entity_tag `civicrm_entity_tag-2` ON ( `civicrm_entity_tag-2`.entity_id = contact_a.id  AND `civicrm_entity_tag-2`.entity_table = \'civicrm_contact\') \";}",
+    );
+  }
+
+  public function testCreateSavedSearch() {
+    // Act:
+    $result = $this->callAPIAndDocument(
+        $this->_entity, 'create', $this->params, __FUNCTION__, __FILE__);
+    $this->assertEquals(1, $result['count']);
+
+    // Assert:
+    // Get the entity with the id returned in $result['id'], and check whether
+    // the parameters are set correctly:
+    $this->getAndCheck($this->params, $result['id'], $this->_entity);
+
+    // Check whether the new ID is correctly returned by the API.
+    $this->assertNotNull($result['values'][$result['id']]['id']);
+  }
+
+  public function testGetSavedSearch() {
+    // Arrange:
+    // (create a saved search)
+    $create_result = $this->callAPISuccess(
+        $this->_entity, 'create', $this->params);
+
+    // Act:
+    $get_result = $this->callAPIAndDocument(
+        $this->_entity, 'get', array('id' => $create_result['id']), __FUNCTION__, __FILE__);
+
+    // Assert:
+    $this->assertEquals(1, $get_result['count']);
+    $this->assertNotNull($get_result['values'][$get_result['id']]['id']);
+  }
+
+  public function testDeleteSavedSearch() {
+    // Create saved search, delete it again, and try to get it
+    $create_result = $this->callAPISuccess($this->_entity, 'create', $this->params);
+    $delete_params = array('id' => $create_result['id']);
+    $this->callAPIAndDocument(
+        $this->_entity, 'delete', $delete_params, __FUNCTION__, __FILE__);
+    $get_result = $this->callAPISuccess($this->_entity, 'get', array());
+
+    $this->assertEquals(0, $get_result['count']);
+  }
+
+}

--- a/tests/phpunit/api/v3/SavedSearchTest.php
+++ b/tests/phpunit/api/v3/SavedSearchTest.php
@@ -55,14 +55,18 @@ class api_v3_SavedSearchTest extends CiviUnitTestCase {
     // all contacts tagged with 'company'.
     // I got the params below from the database.
 
+    $url = CIVICRM_UF_BASEURL . "/civicrm/contact/search/advanced?reset=1";
+    $serialized_url = serialize($url);
+
     $this->params = array(
-      'form_values' => 'a:36:{s:5:"qfKey";s:37:"4b50e233dcbe77cced4bd8fd8df90567_9974";s:8:"entryURL";s:64:"' . CIVICRM_UF_BASEURL . '/civicrm/contact/search/advanced?reset=1";s:12:"hidden_basic";s:1:"1";s:12:"contact_type";a:0:{}s:5:"group";a:0:{}s:10:"group_type";a:0:{}s:21:"group_search_selected";s:5:"group";s:9:"sort_name";s:0:"";s:5:"email";s:0:"";s:14:"contact_source";s:0:"";s:9:"job_title";s:0:"";s:10:"contact_id";s:0:"";s:19:"external_identifier";s:0:"";s:7:"uf_user";s:0:"";s:10:"tag_search";s:0:"";s:11:"uf_group_id";s:0:"";s:14:"component_mode";s:1:"1";s:8:"operator";s:3:"AND";s:25:"display_relationship_type";s:0:"";s:15:"privacy_options";a:0:{}s:16:"privacy_operator";s:2:"OR";s:14:"privacy_toggle";s:1:"1";s:13:"email_on_hold";a:1:{s:7:"on_hold";s:0:"";}s:30:"preferred_communication_method";a:5:{i:1;s:0:"";i:2;s:0:"";i:3;s:0:"";i:4;s:0:"";i:5;s:0:"";}s:18:"preferred_language";s:0:"";s:13:"phone_numeric";s:0:"";s:22:"phone_location_type_id";s:0:"";s:19:"phone_phone_type_id";s:0:"";s:4:"task";s:2:"13";s:8:"radio_ts";s:6:"ts_sel";s:12:"toggleSelect";s:1:"1";s:10:"mark_x_165";s:1:"1";s:10:"mark_x_155";s:1:"1";s:10:"mark_x_124";s:1:"1";s:9:"mark_x_35";s:1:"1";s:12:"contact_tags";a:1:{i:2;i:1;}}',
-      'where_clause' => '( `civicrm_entity_tag-2`.tag_id IN (2) )  ',
-      'select_tables' => "a:8:{s:15:\"civicrm_contact\";i:1;s:15:\"civicrm_address\";i:1;s:15:\"civicrm_country\";i:1;s:13:\"civicrm_email\";i:1;s:13:\"civicrm_phone\";i:1;s:10:\"civicrm_im\";i:1;s:19:\"civicrm_worldregion\";i:1;s:22:\"`civicrm_entity_tag-2`\";s:168:\" LEFT JOIN civicrm_entity_tag `civicrm_entity_tag-2` ON ( `civicrm_entity_tag-2`.entity_id = contact_a.id  AND `civicrm_entity_tag-2`.entity_table = \'civicrm_contact\') \";} ",
-      'where_tables' => "a:2:{s:15:\"civicrm_contact\";i:1;s:22:\"`civicrm_entity_tag-2`\";s:168:\" LEFT JOIN civicrm_entity_tag `civicrm_entity_tag-2` ON ( `civicrm_entity_tag-2`.entity_id = contact_a.id  AND `civicrm_entity_tag-2`.entity_table = \'civicrm_contact\') \";}",
+      'form_values' => 'a:36:{s:5:"qfKey";s:37:"4b50e233dcbe77cced4bd8fd8df90567_9974";s:8:"entryURL";'
+      . $serialized_url . 's:12:"hidden_basic";s:1:"1";s:12:"contact_type";a:0:{}s:5:"group";a:0:{}s:10:"group_type";a:0:{}s:21:"group_search_selected";s:5:"group";s:9:"sort_name";s:0:"";s:5:"email";s:0:"";s:14:"contact_source";s:0:"";s:9:"job_title";s:0:"";s:10:"contact_id";s:0:"";s:19:"external_identifier";s:0:"";s:7:"uf_user";s:0:"";s:10:"tag_search";s:0:"";s:11:"uf_group_id";s:0:"";s:14:"component_mode";s:1:"1";s:8:"operator";s:3:"AND";s:25:"display_relationship_type";s:0:"";s:15:"privacy_options";a:0:{}s:16:"privacy_operator";s:2:"OR";s:14:"privacy_toggle";s:1:"1";s:13:"email_on_hold";a:1:{s:7:"on_hold";s:0:"";}s:30:"preferred_communication_method";a:5:{i:1;s:0:"";i:2;s:0:"";i:3;s:0:"";i:4;s:0:"";i:5;s:0:"";}s:18:"preferred_language";s:0:"";s:13:"phone_numeric";s:0:"";s:22:"phone_location_type_id";s:0:"";s:19:"phone_phone_type_id";s:0:"";s:4:"task";s:2:"13";s:8:"radio_ts";s:6:"ts_sel";s:12:"toggleSelect";s:1:"1";s:10:"mark_x_165";s:1:"1";s:10:"mark_x_155";s:1:"1";s:10:"mark_x_124";s:1:"1";s:9:"mark_x_35";s:1:"1";s:12:"contact_tags";a:1:{i:2;i:1;}}',
     );
   }
 
+  /**
+   * Create a saved search, and see whether the returned values make sense.
+   */
   public function testCreateSavedSearch() {
     // Act:
     $result = $this->callAPIAndDocument(
@@ -91,6 +95,8 @@ class api_v3_SavedSearchTest extends CiviUnitTestCase {
     // Assert:
     $this->assertEquals(1, $get_result['count']);
     $this->assertNotNull($get_result['values'][$get_result['id']]['id']);
+    $this->assertEquals(
+        $this->params['form_values'], $get_result['values'][$get_result['id']]['form_values']);
   }
 
   public function testDeleteSavedSearch() {

--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -1144,7 +1144,7 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
         case CRM_Utils_Type::T_TEXT:
         case CRM_Utils_Type::T_LONGTEXT:
         case CRM_Utils_Type::T_EMAIL:
-          if ($fieldName == 'form_values') {
+          if ($fieldName == 'form_values' && $entity_name == 'SavedSearch') {
             // This is a hack for the SavedSearch API. It expects form_values
             // to be a serialized array.
             // If you want to fix this, you should definitely read this forum

--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -599,6 +599,15 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
           'weight', //won't update as there is no 1 in the same price set
         ),
       ),
+      'SavedSearch' => array(
+        // I think the fields below are generated based on form_values.
+        'cant_update' => array(
+          'search_custom_id',
+          'where_clause',
+          'select_tables',
+          'where_tables',
+        )
+      )
     );
     if (empty($knownFailures[$entity]) || empty($knownFailures[$entity][$key])) {
       return array();

--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -1135,7 +1135,19 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
         case CRM_Utils_Type::T_TEXT:
         case CRM_Utils_Type::T_LONGTEXT:
         case CRM_Utils_Type::T_EMAIL:
-          $entity[$fieldName] = substr('New String', 0, CRM_Utils_Array::Value('maxlength', $specs, 100));
+          if ($fieldName == 'form_values') {
+            // This is a hack for the SavedSearch API. It expects form_values
+            // to be a serialized array.
+            // If you want to fix this, you should definitely read this forum
+            // post.
+            // http://forum.civicrm.org/index.php/topic,33990.0.html
+            // See also my question on the CiviCRM Stack Exchange:
+            // https://civicrm.stackexchange.com/questions/3437
+            $entity[$fieldName] = serialize(array('sort_name' => "SortName2{$counter}"));
+          }
+          else {
+            $entity[$fieldName] = substr('New String', 0, CRM_Utils_Array::Value('maxlength', $specs, 100));
+          }
           break;
 
         case CRM_Utils_Type::T_INT:

--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -1144,9 +1144,9 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
         case CRM_Utils_Type::T_TEXT:
         case CRM_Utils_Type::T_LONGTEXT:
         case CRM_Utils_Type::T_EMAIL:
-          if ($fieldName == 'form_values' && $entity_name == 'SavedSearch') {
-            // This is a hack for the SavedSearch API. It expects form_values
-            // to be a serialized array.
+          if ($fieldName == 'form_values' && $entityName == 'SavedSearch') {
+            // This is a hack for the SavedSearch API.
+            // It expects form_values to be an array.
             // If you want to fix this, you should definitely read this forum
             // post.
             // http://forum.civicrm.org/index.php/topic,33990.0.html

--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -606,8 +606,8 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
           'where_clause',
           'select_tables',
           'where_tables',
-        )
-      )
+        ),
+      ),
     );
     if (empty($knownFailures[$entity]) || empty($knownFailures[$entity][$key])) {
       return array();

--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -1143,7 +1143,7 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
             // http://forum.civicrm.org/index.php/topic,33990.0.html
             // See also my question on the CiviCRM Stack Exchange:
             // https://civicrm.stackexchange.com/questions/3437
-            $entity[$fieldName] = serialize(array('sort_name' => "SortName2{$counter}"));
+            $entity[$fieldName] = array('sort_name' => "SortName2");
           }
           else {
             $entity[$fieldName] = substr('New String', 0, CRM_Utils_Array::Value('maxlength', $specs, 100));

--- a/xml/schema/Contact/SavedSearch.xml
+++ b/xml/schema/Contact/SavedSearch.xml
@@ -9,8 +9,9 @@
   <field>
     <name>id</name>
     <type>int unsigned</type>
+    <title>Saved Search ID</title>
     <required>true</required>
-    <comment>Saved search ID</comment>
+    <comment>Saved Search ID</comment>
     <add>1.1</add>
   </field>
   <primaryKey>
@@ -37,6 +38,7 @@
   <field>
     <name>is_active</name>
     <type>boolean</type>
+    <title>Saved Search Enabled</title>
     <comment>Is this entry active?</comment>
     <add>1.1</add>
     <drop>1.5</drop>
@@ -44,6 +46,7 @@
   <field>
     <name>mapping_id</name>
     <type>int unsigned</type>
+    <title>Mapping ID</title>
     <comment>Foreign key to civicrm_mapping used for saved search-builder searches.</comment>
     <add>1.5</add>
   </field>
@@ -56,24 +59,28 @@
   <field>
     <name>search_custom_id</name>
     <type>int unsigned</type>
+    <title>Option Value ID</name>
     <comment>Foreign key to civicrm_option value table used for saved custom searches.</comment>
     <add>2.0</add>
   </field>
   <field>
     <name>where_clause</name>
     <type>text</type>
+    <title>Where Clause</title>
     <comment>the sql where clause if a saved search acl</comment>
     <add>1.6</add>
   </field>
   <field>
     <name>select_tables</name>
     <type>text</type>
+    <title>Select Tables</title>
     <comment>the tables to be included in a select data</comment>
     <add>1.6</add>
   </field>
   <field>
     <name>where_tables</name>
     <type>text</type>
+    <title>Where Tables</title>
     <comment>the tables to be included in the count statement</comment>
     <add>1.6</add>
   </field>

--- a/xml/schema/Contact/SavedSearch.xml
+++ b/xml/schema/Contact/SavedSearch.xml
@@ -59,7 +59,7 @@
   <field>
     <name>search_custom_id</name>
     <type>int unsigned</type>
-    <title>Option Value ID</name>
+    <title>Option Value ID</title>
     <comment>Foreign key to civicrm_option value table used for saved custom searches.</comment>
     <add>2.0</add>
   </field>


### PR DESCRIPTION
This might be not 100% complete, but it works for the use case 'creating smart groups using the api'. If you apply this patch, you can create e.g. a smart group for all volunteers in the default organization like this:

```
$params = array(
  'form_values' => array(
    // Is volunteer for
    'relation_type_id' => '6_a_b',
    'relation_target_name' => 'Default Organization',
  ),
  'api.Group.create' => array(
    'name' => 'my_smartgroup',
    'title' => 'my smartgroup',
    'description' => 'Volunteers for the default organization',
    'saved_search_id' => '$value.id',
    'is_active' => 1,
    'visibility' => 'User and User Admin Only',
    'is_hidden' => 0,
    'is_reserved' => 0,
  ),
);
civicrm_api3('SavedSearch', 'create', $params);
```
