### PR TITLE
Adding required extensions paths to include_path while loading Components + removing include_path duplicates after 'hook_civicrm_config' execution.

### DIFF
--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -901,10 +901,12 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   static function config(&$config) {
-    return self::singleton()->invoke(1, $config,
+    $invoked = self::singleton()->invoke(1, $config,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_config'
     );
+    set_include_path(implode(PATH_SEPARATOR, array_unique(explode(PATH_SEPARATOR, get_include_path()))));
+    return $invoked;
   }
 
   /**


### PR DESCRIPTION
Yet another approach to allowing Components being loaded from Extensions structure.
- CRM/Core/Component.php - adding check for Components inside each available Extension and if it's found then include_path is updated with the extension path.
- CRM/Utils/Hook.php - adding remove include_path duplicated entries to avoid duplicated paths after extension.civix.php hook_civicrm_config execution.
