### PR TITLE
CRM-16417 add failed payment activity type

### DIFF
--- a/CRM/Upgrade/Incremental/sql/4.6.5.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.6.5.mysql.tpl
@@ -1,1 +1,12 @@
 {* file to handle db changes in 4.6.5 during upgrade *}
+-- CRM-16417 add failed payment activity type
+SELECT @option_group_id_act := max(id) from civicrm_option_group where name = 'activity_type';
+SELECT @option_group_id_act_wt := MAX(weight) FROM civicrm_option_value WHERE option_group_id = @option_group_id_act;
+SELECT @option_group_id_act_val := MAX(ROUND(value)) FROM civicrm_option_value WHERE option_group_id = @option_group_id_act;
+SELECT @contributeCompId := max(id) FROM civicrm_component where name = 'CiviContribute';
+
+INSERT INTO
+`civicrm_option_value` (`option_group_id`, {localize field='label'}`label`{/localize}, `value`, `name`, `grouping`, `filter`, `is_default`, `weight`, {localize field='description'}`description`{/localize}, `is_optgroup`, `is_reserved`, `is_active`, `component_id`, `visibility_id`)
+VALUES
+(@option_group_id_act, {localize}'{ts escape="sql"}Failed Payment{/ts}'{/localize}, @option_group_id_act_val+1,
+'Failed Payment', NULL, 1, NULL, @option_group_id_act_wt+1, {localize}'{ts escape="sql"}Failed payment.{/ts}'{/localize}, 0, 1, 1, @contributeCompId, NULL);

--- a/xml/templates/civicrm_data.tpl
+++ b/xml/templates/civicrm_data.tpl
@@ -376,8 +376,12 @@ VALUES
  -- for Print or Email Contribution Invoices
    (@option_group_id_act, '{ts escape="sql"}Downloaded Invoice{/ts}', 49, 'Downloaded Invoice',      NULL, 1, NULL, 49, '{ts escape="sql"}Downloaded Invoice.{/ts}',0, 1, 1, NULL, NULL),
    (@option_group_id_act, '{ts escape="sql"}Emailed Invoice{/ts}', 50, 'Emailed Invoice',      NULL, 1, NULL, 50, '{ts escape="sql"}Emailed Invoice.{/ts}',0, 1, 1, NULL, NULL),
- -- for manual contact merge
-   (@option_group_id_act, '{ts escape="sql"}Contact Merged{/ts}', 51, 'Contact Merged', NULL, 1, NULL, 51, '{ts escape="sql"}Contact Merged{/ts}',0, 1, 1, NULL, NULL), 
+
+  -- for manual contact merge
+   (@option_group_id_act, '{ts escape="sql"}Contact Merged{/ts}', 51, 'Contact Merged', NULL, 1, NULL, 51, '{ts escape="sql"}Contact Merged{/ts}',0, 1, 1, NULL, NULL),
+
+  -- Activity Type for failed payment
+   (@option_group_id_act, 'Failed Payment', 52, 'Failed Payment', NULL, 1, 0, 43, 'Failed Payment', 0, 1, 1, @contributeCompId, NULL),
 
    (@option_group_id_gender, '{ts escape="sql"}Female{/ts}',      1, 'Female',      NULL, 0, NULL, 1, NULL, 0, 0, 1, NULL, NULL),
    (@option_group_id_gender, '{ts escape="sql"}Male{/ts}',        2, 'Male',        NULL, 0, NULL, 2, NULL, 0, 0, 1, NULL, NULL),


### PR DESCRIPTION
@davecivicrm  are you able to OK this. It just adds the failed payment activity type. I've done it against 4.6 because I think that it might be used by payment gateways in the 4.6 series & adding it early reduces the risk of a gateway adding a conflicting activity type in the interim.
