### PR TITLE
CRM-16627 add invoice id to contribution search

### DIFF
--- a/CRM/Contribute/BAO/Query.php
+++ b/CRM/Contribute/BAO/Query.php
@@ -329,6 +329,7 @@ class CRM_Contribute_BAO_Query {
       case 'contribution_status':
         $name .= '_id';
       case 'financial_type_id':
+      case 'invoice_id':
       case 'payment_instrument_id':
       case 'contribution_payment_instrument_id':
       case 'contribution_page_id':
@@ -916,7 +917,7 @@ class CRM_Contribute_BAO_Query {
 
     // Add field for transaction ID search
     $form->addElement('text', 'contribution_trxn_id', ts("Transaction ID"));
-
+    $form->addElement('text', 'invoice_id', ts("Invoice ID"));
     $form->addElement('text', 'contribution_check_number', ts('Check Number'));
 
     // Add field for pcp display in roll search

--- a/CRM/Contribute/Form/Search.php
+++ b/CRM/Contribute/Form/Search.php
@@ -275,6 +275,7 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
         'contribution_status_id',
         'contribution_source',
         'contribution_trxn_id',
+        'invoice_id',
       );
       foreach ($specialParams as $element) {
         $value = CRM_Utils_Array::value($element, $this->_formValues);

--- a/templates/CRM/Contribute/Form/Search/Common.tpl
+++ b/templates/CRM/Contribute/Form/Search/Common.tpl
@@ -57,12 +57,14 @@
   <td>
     {$form.contribution_or_softcredits.label} <br />
     {$form.contribution_or_softcredits.html}
-  </td>
-  <td>
     <div class="float-left" id="contribution_soft_credit_type_wrapper">
       {$form.contribution_soft_credit_type_id.label} <br />
       {$form.contribution_soft_credit_type_id.html|crmAddClass:twenty}
     </div>
+  </td>
+  <td>
+    {$form.invoice_id.label} <br />
+    {$form.invoice_id.html}
   </td>
 </tr>
 <tr>

--- a/templates/CRM/Contribute/Form/Search/Common.tpl
+++ b/templates/CRM/Contribute/Form/Search/Common.tpl
@@ -56,7 +56,7 @@
 <tr>
   <td>
     {$form.contribution_or_softcredits.label} <br />
-    {$form.contribution_or_softcredits.html}
+    {$form.contribution_or_softcredits.html}<br />
     <div class="float-left" id="contribution_soft_credit_type_wrapper">
       {$form.contribution_soft_credit_type_id.label} <br />
       {$form.contribution_soft_credit_type_id.html|crmAddClass:twenty}

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -505,6 +505,25 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
   }
 
   /**
+   * CRM-16227 introduces invoice_id as a parameter.
+   */
+  public function testGetContributionByInvoice() {
+    $this->callAPISuccess('Contribution', 'create', array_merge($this->_params, array('invoice_id' => 'curly')));
+    $this->callAPISuccess('Contribution', 'create', array_merge($this->_params), array('invoice_id' => 'churlish'));
+    $this->callAPISuccessGetCount('Contribution', array(), 2);
+    $this->callAPISuccessGetSingle('Contribution', array('invoice_id' => 'curly'));
+    // The following don't work. They are the format we are trying to introduce but although the form uses this format
+    // CRM_Contact_BAO_Query::convertFormValues puts them into the other format & the where only supports that.
+    // ideally the where clause would support this format (as it does on contact_BAO_Query) and those lines would
+    // come out of convertFormValues
+    // $this->callAPISuccessGetSingle('Contribution', array('invoice_id' => array('LIKE' => '%ish%')));
+    // $this->callAPISuccessGetSingle('Contribution', array('invoice_id' => array('NOT IN' => array('curly'))));
+    // $this->callAPISuccessGetCount('Contribution', array('invoice_id' => array('LIKE' => '%ly%')), 2);
+    // $this->callAPISuccessGetCount('Contribution', array('invoice_id' => array('IN' => array('curly', 'churlish'))),
+    // 2);
+  }
+
+  /**
    * Create test with unique field name on source.
    */
   public function testCreateContributionSource() {


### PR DESCRIPTION
@davecivicrm my main concern with this is the layout of the soft credit was doing something I didn't quite get. So - I'm not sure if this could affect the layout in some circumstances

@colemanw I went with invoice_id rather than contribution_invoice_id since there is no unique name declared in the schema. I added an api test although it looks like more triage would be required to make the more sophisticated api params work here - I did get  a clue to how to do it. @monishdeb added some lines to the form to format into the more flexible, standardised, api-supported  handling style ('invoice_id' => array('LIKE' => 'hhh')) . Unfortunately a little later they get reformatted & the query doesn't handle that - but I think it would be not too hard to start to whitelist out fields that 'work' & get rid of code in the process.
