### PR TITLE
Fixes one of the failing tests & towards CRM-16417, CRM-16402, CRM-16545

### DIFF
--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -794,7 +794,8 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
             $value['membership_type_id'],
             FALSE,
             $this,
-            NULL,
+            // This may or may not apply to this form - was in a shared form uber-spaghetti bowl.
+            $this->get('renewalDate'),
             NULL,
             $value['custom'],
             1,

--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -561,7 +561,6 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
           $value['contact_type_b'] == $otherContactType
         ) &&
         (in_array($value['contact_sub_type_a'], $contactSubType) ||
-          in_array($value['contact_sub_type_b'], $contactSubType) ||
           (!$value['contact_sub_type_a'] && !$onlySubTypeRelationTypes)
         )
       ) {
@@ -576,7 +575,6 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
           $value['contact_type_a'] == $otherContactType
         ) &&
         (in_array($value['contact_sub_type_b'], $contactSubType) ||
-          in_array($value['contact_sub_type_a'], $contactSubType) ||
           (!$value['contact_sub_type_b'] && !$onlySubTypeRelationTypes)
         )
       ) {

--- a/CRM/Contribute/BAO/Contribution/Utils.php
+++ b/CRM/Contribute/BAO/Contribution/Utils.php
@@ -295,6 +295,8 @@ class CRM_Contribute_BAO_Contribution_Utils {
       return $result;
     }
 
+    // @todo - is shit still reachable? We are trying to eliminate it into the second
+    // (complete transaction) phase.
     // get the price set values for receipt.
     if ($form->_priceSetId && $form->_lineItem) {
       $form->_values['lineItem'] = $form->_lineItem;

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1778,6 +1778,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     ) {
       $this->_params['campaign_id'] = $this->_params['onbehalf']['member_campaign_id'];
     }
+
     $fields = array('email-Primary' => 1);
 
     // get the add to groups
@@ -2070,6 +2071,12 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         $fieldTypes = array('Contact', 'Organization', 'Contribution');
       }
       $financialTypeID = $this->wrangleFinancialTypeID($contributionTypeId);
+
+      // @todo - is this meaningful / required. Taken from shared function.
+      if ($this->_priceSetId && $this->_lineItem) {
+        $this->_values['lineItem'] = $this->_lineItem;
+        $this->_values['priceSetID'] = $this->_priceSetId;
+      }
 
       $result = CRM_Contribute_BAO_Contribution_Utils::processConfirm($this, $paymentParams,
         $premiumParams, $contactID,

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1333,13 +1333,16 @@ AND civicrm_membership.is_test = %2";
    * @param bool $isPayLater
    * @param bool $isPending
    *
+   * @param $isPending
+   *
    * @throws \CRM_Core_Exception
    */
   public static function postProcessMembership(
     $membershipParams, $contactID, &$form, $premiumParams,
     $customFieldsFormatted = NULL, $includeFieldTypes = NULL, $membershipDetails, $membershipTypeIDs, $isPaidMembership, $membershipID,
-    $isProcessSeparateMembershipTransaction, $defaultContributionTypeID, $membershipLineItems, $isPayLater, $isPending) {
-    $result = $membershipContribution = NULL;
+    $isProcessSeparateMembershipTransaction, $defaultContributionTypeID, $membershipLineItems, $isPayLater,
+    $isPending) {
+    $membershipContribution = NULL;
     $isTest = CRM_Utils_Array::value('is_test', $membershipParams, FALSE);
     $errors = $createdMemberships = $paymentResult = array();
 
@@ -1369,6 +1372,7 @@ AND civicrm_membership.is_test = %2";
         $isTest,
         $isPayLater
       );
+
       if (is_a($result[1], 'CRM_Core_Error')) {
         $errors[1] = CRM_Core_Error::getMessages($paymentResult[1]);
       }
@@ -1420,7 +1424,7 @@ AND civicrm_membership.is_test = %2";
         else {
           $pending = $isPending;
         }
-        $membership = self::renewMembershipFormWrapper($contactID, $memType,
+        $createdMemberships = self::renewMembershipFormWrapper($contactID, $memType,
           $isTest, $form, date('YmdHis'),
           CRM_Utils_Array::value('cms_contactID', $membershipParams),
           $customFieldsFormatted, $numTerms,
@@ -1430,8 +1434,8 @@ AND civicrm_membership.is_test = %2";
 
         if (!empty($membershipContribution)) {
           // update recurring id for membership record
-          self::updateRecurMembership($membership, $membershipContribution);
-          self::linkMembershipPayment($membership, $membershipContribution);
+          self::updateRecurMembership($createdMemberships[$memType], $membershipContribution);
+          self::linkMembershipPayment($createdMemberships[$memType], $membershipContribution);
         }
       }
       if ($form->_priceSetId && !empty($form->_useForMember) && !empty($form->_lineItem)) {

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1373,14 +1373,17 @@ AND civicrm_membership.is_test = %2";
         $isPayLater
       );
 
-      if (is_a($result[1], 'CRM_Core_Error')) {
-        $errors[1] = CRM_Core_Error::getMessages($paymentResult[1]);
+      // @todo - is this meaningful / required. Taken from shared function.
+      if ($form->_priceSetId && $form->_lineItem) {
+        $form->_values['lineItem'] = $form->_lineItem;
+        $form->_values['priceSetID'] = $form->_priceSetId;
       }
 
       if (is_a($paymentResult, 'CRM_Core_Error')) {
         $errors[1] = CRM_Core_Error::getMessages($paymentResult);
       }
-      elseif (!empty($paymentResult['contribution'])) {
+
+      if (!empty($paymentResult['contribution'])) {
         //note that this will be over-written if we are using a separate membership transaction. Otherwise there is only one
         $membershipContribution = $paymentResult['contribution'];
         // Save the contribution ID so that I can be used in email receipts
@@ -1408,12 +1411,7 @@ AND civicrm_membership.is_test = %2";
       $membershipContributionID = $membershipContribution->id;
     }
 
-    //@todo - why is this nested so deep? it seems like it could be just set on the calling function on the form layer
-    if (isset($membershipParams['onbehalf']) && !empty($membershipParams['onbehalf']['member_campaign_id'])) {
-      $form->_params['campaign_id'] = $membershipParams['onbehalf']['member_campaign_id'];
-    }
-    //@todo it should no longer be possible for it to get to this point & membership to not be an array
-    if (is_array($membershipTypeIDs) && !empty($membershipContributionID)) {
+    if (!empty($membershipContributionID)) {
       $typesTerms = CRM_Utils_Array::value('types_terms', $membershipParams, array());
       foreach ($membershipTypeIDs as $memType) {
         $numTerms = CRM_Utils_Array::value($memType, $typesTerms, 1);

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -434,7 +434,7 @@ function civicrm_api3_contribution_completetransaction(&$params) {
     $params = _ipn_process_transaction($params, $contribution, $input, $ids);
   }
   catch(Exception $e) {
-    throw new API_Exception('failed to load related objects' . $e->getMessage() . "\n" . $e->getTraceAsString());
+    throw new API_Exception('failed to process transaction' . $e->getMessage() . "\n" . $e->getTraceAsString());
   }
 }
 


### PR DESCRIPTION
I need to see test output to see if there is some fallout from this. The tests are broken after a merge from 4.6 - the breakage relates to work done in 4.6 on separate payments with recurring memberships & in 4.7 the membership duration was incorrect (2 years rather than one) - this fixes that & includes work towards the other test fix - but quite a bit of refactoring to get to the point where that can be pinned down
