### PR TITLE
CRM-16736 - changed 'null' into NULL.

### DIFF
--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -296,7 +296,7 @@ LEFT JOIN civicrm_email ON (contact_a.id = civicrm_email.contact_id AND civicrm_
       $savedSearch->form_values = serialize($params['formValues']);
     }
     else {
-      $savedSearch->form_values = 'null';
+      $savedSearch->form_values = NULL;
     }
 
     $savedSearch->is_active = CRM_Utils_Array::value('is_active', $params, 1);


### PR DESCRIPTION
I think this might fix the issues I have with this PR:
https://github.com/civicrm/civicrm-core/pull/6059

---
- CRM-16736: Possible NULL/'null' error in SavedSearch BAO
  https://issues.civicrm.org/jira/browse/CRM-16736
