### PR TITLE
CRM-16417 always create contributions, even if failed

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -870,13 +870,18 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = civicrm_contribution.conta
    * Prior to CRM-16417 these were simply removed from the database but it has been agreed that seeing attempted
    * payments is important for forensic and outreach reasons.
    *
-   * This function updates the financial transaction records to failed.
-   *
-   * @todo in principle we also think it makes sense to add an activity - this part would be a second step as
-   * the first change is likely to go into the LTS.
+   * @param int $contributionID
+   * @param string $message
    */
-  public static function failPayment($contributionID, $message) {
-
+  public static function failPayment($contributionID, $contactID, $message) {
+    civicrm_api3('activity', 'create', array(
+      'activity_type_id' => 'Failed Payment',
+      'details' => $message,
+      'subject' => ts('Payment failed at payment processor'),
+      'source_record_id' => $contributionID,
+      'source_contact_id' => CRM_Core_Session::getLoggedInContactID() ? CRM_Core_Session::getLoggedInContactID() :
+        $contactID,
+    ));
   }
 
   /**

--- a/CRM/Contribute/BAO/Contribution/Utils.php
+++ b/CRM/Contribute/BAO/Contribution/Utils.php
@@ -144,8 +144,7 @@ class CRM_Contribute_BAO_Contribution_Utils {
         // add qfKey so we can send to paypal
         $form->_params['qfKey'] = $form->controller->_key;
         if ($component == 'membership') {
-          $membershipResult = array(1 => $contribution);
-          return $membershipResult;
+          return array('contribution' => $contribution);
         }
         else {
           if (!$isPayLater) {
@@ -265,18 +264,8 @@ class CRM_Contribute_BAO_Contribution_Utils {
           CRM_Contribute_BAO_ContributionRecur::deleteRecurContribution($paymentParams['contributionRecurID']);
         }
 
-        if ($component !== 'membership') {
-          // This is only called from contribution form.
-          // Not sure if there is any reason not to just throw an exception up to it.
-          $result['is_payment_failure'] = TRUE;
-          return $result;
-        }
-        $membershipResult[1] = $result;
+        $result['is_payment_failure'] = TRUE;
       }
-    }
-
-    if ($component == 'membership') {
-      $membershipResult = array();
     }
 
     if ($result || ($form->_amount == 0.0 && !$form->_params['is_pay_later'])) {
@@ -297,13 +286,8 @@ class CRM_Contribute_BAO_Contribution_Utils {
       if (is_array($result) && !empty($result['trxn_id'])) {
         $contribution->trxn_id = $result['trxn_id'];
       }
-      $membershipResult[1] = $contribution;
+      $result['contribution'] = $contribution;
     }
-
-    if ($component == 'membership') {
-      return $membershipResult;
-    }
-
     //Do not send an email if Recurring contribution is done via Direct Mode
     //We will send email once the IPN is received.
     if ($form->_contributeMode == 'direct') {

--- a/CRM/Contribute/BAO/Contribution/Utils.php
+++ b/CRM/Contribute/BAO/Contribution/Utils.php
@@ -93,13 +93,12 @@ class CRM_Contribute_BAO_Contribution_Utils {
     $payment = NULL;
     $paymentObjError = ts('The system did not record payment details for this payment and so could not process the transaction. Please report this error to the site administrator.');
 
-    if ($isPaymentTransaction) {
-      $payment = CRM_Core_Payment::singleton($form->_mode, $form->_paymentProcessor, $form);
+    if ($isPaymentTransaction && !empty($form->_paymentProcessor)) {
+      // @todo - remove this line once we are sure we can just use $form->_paymentProcessor['object'] consistently.
+      $payment = Civi\Payment\System::singleton()->getByProcessor($form->_paymentProcessor);
     }
 
-    //fix for CRM-2062
     //fix for CRM-16317
-
     $form->_params['receive_date'] = date('YmdHis');
     $form->assign('receive_date',
       CRM_Utils_Date::mysqlToIso($form->_params['receive_date'])

--- a/CRM/Contribute/BAO/Contribution/Utils.php
+++ b/CRM/Contribute/BAO/Contribution/Utils.php
@@ -265,6 +265,7 @@ class CRM_Contribute_BAO_Contribution_Utils {
         }
 
         $result['is_payment_failure'] = TRUE;
+        $result['error'] = $e;
       }
     }
 

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1264,7 +1264,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
         }
       }
       catch (PaymentProcessorException $e) {
-        CRM_Contribute_BAO_Contribution::failPayment($contribution->id, $e->getMessage());
+        CRM_Contribute_BAO_Contribution::failPayment($contribution->id, $paymentParams['contactID'], $e->getMessage());
         throw new PaymentProcessorException($e->getMessage());
       }
     }

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -2107,7 +2107,11 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       );
 
       if (CRM_Utils_Array::value('contribution_status_id', $result) == 1) {
-        civicrm_api3('contribution', 'completetransaction', array('id' => $result['contribution']->id));
+        civicrm_api3('contribution', 'completetransaction', array(
+          'id' => $result['contribution']->id,
+          'trxn_id' => CRM_Utils_Array::value('trxn_id', $result),
+          )
+        );
       }
       return $result;
     }

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -728,7 +728,9 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $contactID = $this->getContactID();
     $result = $this->processFormSubmission($contactID);
     if (is_array($result) && !empty($result['is_payment_failure'])) {
-      CRM_Core_Error::displaySessionError($result);
+      // We will probably have the function that gets this error throw an exception on the next round of refactoring.
+      CRM_Core_Session::singleton()->setStatus(ts("Payment Processor Error message :") .
+          $result['error']->getMessage());
       CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/contribute/transact',
         "_qf_Main_display=true&qfKey={$this->_params['qfKey']}"
       ));

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -2097,7 +2097,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       }
       $financialTypeID = $this->wrangleFinancialTypeID($contributionTypeId);
 
-      return CRM_Contribute_BAO_Contribution_Utils::processConfirm($this, $paymentParams,
+      $result = CRM_Contribute_BAO_Contribution_Utils::processConfirm($this, $paymentParams,
         $premiumParams, $contactID,
         $financialTypeID,
         'contribution',
@@ -2105,6 +2105,11 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         ($this->_mode == 'test') ? 1 : 0,
         $isPayLater
       );
+
+      if (CRM_Utils_Array::value('contribution_status_id', $result) == 1) {
+        civicrm_api3('contribution', 'completetransaction', array('id' => $result['contribution']->id));
+      }
+      return $result;
     }
   }
 

--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -856,6 +856,29 @@ abstract class CRM_Core_Payment {
   }
 
   /**
+   * Checks to see if invoice_id already exists in db.
+   *
+   * It's arguable if this belongs in the payment subsystem at all but since several processors implement it
+   * it is better to standardise to being here.
+   *
+   * @param int $invoiceId The ID to check.
+   *
+   * @param null $contributionID
+   *   If a contribution exists pass in the contribution ID.
+   *
+   * @return bool
+   *   True if invoice ID otherwise exists, else false
+   */
+  protected function checkDupe($invoiceId, $contributionID = NULL) {
+    $contribution = new CRM_Contribute_DAO_Contribution();
+    $contribution->invoice_id = $invoiceId;
+    if ($contributionID) {
+      $contribution->whereAdd("id <> $contributionID");
+    }
+    return $contribution->find();
+  }
+
+  /**
    * Get url for users to manage this recurring contribution for this processor.
    *
    * @param int $entityID

--- a/CRM/Core/Payment/AuthorizeNet.php
+++ b/CRM/Core/Payment/AuthorizeNet.php
@@ -128,7 +128,7 @@ class CRM_Core_Payment_AuthorizeNet extends CRM_Core_Payment {
     }
 
     // Authorize.Net will not refuse duplicates, so we should check if the user already submitted this transaction
-    if ($this->_checkDupe($authorizeNetFields['x_invoice_num'])) {
+    if ($this->checkDupe($authorizeNetFields['x_invoice_num'], CRM_Utils_Array::value('contributionID', $params))) {
       return self::error(9004, 'It appears that this transaction is a duplicate.  Have you already submitted the form once?  If so there may have been a connection problem.  Check your email for a receipt from Authorize.net.  If you do not receive a receipt within 2 hours you can try your transaction again.  If you continue to have problems please contact the site administrator.');
     }
 
@@ -371,21 +371,6 @@ class CRM_Core_Payment_AuthorizeNet extends CRM_Core_Payment {
     }
 
     return $fields;
-  }
-
-  /**
-   * Checks to see if invoice_id already exists in db.
-   *
-   * @param int $invoiceId
-   *   The ID to check.
-   *
-   * @return bool
-   *   True if ID exists, else false
-   */
-  public function _checkDupe($invoiceId) {
-    $contribution = new CRM_Contribute_DAO_Contribution();
-    $contribution->invoice_id = $invoiceId;
-    return $contribution->find();
   }
 
   /**

--- a/CRM/Core/Payment/Dummy.php
+++ b/CRM/Core/Payment/Dummy.php
@@ -106,7 +106,7 @@ class CRM_Core_Payment_Dummy extends CRM_Core_Payment {
       $trxn_id = strval(CRM_Core_Dao::singleValueQuery($query, $p));
       $trxn_id = str_replace('test_', '', $trxn_id);
       $trxn_id = intval($trxn_id) + 1;
-      $params['trxn_id'] = sprintf('test_%08d', $trxn_id);
+      $params['trxn_id'] = 'test_' . $trxn_id . '_' . uniqid();
     }
     else {
       $query = "SELECT MAX(trxn_id) FROM civicrm_contribution WHERE trxn_id LIKE 'live_%'";
@@ -114,7 +114,7 @@ class CRM_Core_Payment_Dummy extends CRM_Core_Payment {
       $trxn_id = strval(CRM_Core_Dao::singleValueQuery($query, $p));
       $trxn_id = str_replace('live_', '', $trxn_id);
       $trxn_id = intval($trxn_id) + 1;
-      $params['trxn_id'] = sprintf('live_%08d', $trxn_id);
+      $params['trxn_id'] = 'live_' . $trxn_id . '_' . uniqid();
     }
     $params['gross_amount'] = $params['amount'];
     // Add a fee_amount so we can make sure fees are handled properly in underlying classes.

--- a/CRM/Core/Payment/Elavon.php
+++ b/CRM/Core/Payment/Elavon.php
@@ -145,7 +145,7 @@ class CRM_Core_Payment_Elavon extends CRM_Core_Payment {
     CRM_Utils_Hook::alterPaymentProcessorParams($this, $params, $requestFields);
 
     // Check to see if we have a duplicate before we send
-    if ($this->_checkDupe($params['invoiceID'])) {
+    if ($this->checkDupe($params['invoiceID'], CRM_Utils_Array::value('contributionID', $params))) {
       return self::errorExit(9003, 'It appears that this transaction is a duplicate.  Have you already submitted the form once?  If so there may have been a connection problem.  Check your email for a receipt.  If you do not receive a receipt within 2 hours you can try your transaction again.  If you continue to have problems please contact the site administrator.');
     }
 
@@ -257,21 +257,6 @@ class CRM_Core_Payment_Elavon extends CRM_Core_Payment {
 
       return $params;
     }
-  }
-
-  /**
-   * Checks to see if invoice_id already exists in db.
-   *
-   * @param int $invoiceId
-   *   The ID to check.
-   *
-   * @return bool
-   *   True if ID exists, else false
-   */
-  public function _checkDupe($invoiceId) {
-    $contribution = new CRM_Contribute_DAO_Contribution();
-    $contribution->invoice_id = $invoiceId;
-    return $contribution->find();
   }
 
   /**

--- a/CRM/Core/Payment/FirstData.php
+++ b/CRM/Core/Payment/FirstData.php
@@ -178,7 +178,7 @@ class CRM_Core_Payment_FirstData extends CRM_Core_Payment {
     //----------------------------------------------------------------------------------------------------
     // Check to see if we have a duplicate before we send
     //----------------------------------------------------------------------------------------------------
-    if ($this->_checkDupe($params['invoiceID'])) {
+    if ($this->checkDupe($params['invoiceID'], CRM_Utils_Array::value('contributionID', $params))) {
       return self::errorExit(9003, 'It appears that this transaction is a duplicate.  Have you already submitted the form once?  If so there may have been a connection problem.  Check your email for a receipt from eWAY.  If you do not receive a receipt within 2 hours you can try your transaction again.  If you continue to have problems please contact the site administrator.');
     }
     //----------------------------------------------------------------------------------------------------
@@ -299,21 +299,6 @@ class CRM_Core_Payment_FirstData extends CRM_Core_Payment {
     }
   }
   // end function doDirectPayment
-
-  /**
-   * Checks to see if invoice_id already exists in db.
-   *
-   * @param int $invoiceId
-   *   The ID to check.
-   *
-   * @return bool
-   *   True if ID exists, else false
-   */
-  public function _checkDupe($invoiceId) {
-    $contribution = new CRM_Contribute_DAO_Contribution();
-    $contribution->invoice_id = $invoiceId;
-    return $contribution->find();
-  }
 
   /**
    * Produces error message and returns from class.

--- a/CRM/Core/Payment/PayflowPro.php
+++ b/CRM/Core/Payment/PayflowPro.php
@@ -260,7 +260,7 @@ class CRM_Core_Payment_PayflowPro extends CRM_Core_Payment {
     /*
      * Check to see if we have a duplicate before we send
      */
-    if ($this->_checkDupe($params['invoiceID'])) {
+    if ($this->checkDupe($params['invoiceID'], CRM_Utils_Array::value('contributionID', $params))) {
       return self::errorExit(9003, 'It appears that this transaction is a duplicate.  Have you already submitted the form once?  If so there may have been a connection problem.  Check your email for a receipt.  If you do not receive a receipt within 2 hours you can try your transaction again.  If you continue to have problems please contact the site administrator.');
     }
 
@@ -343,22 +343,6 @@ class CRM_Core_Payment_PayflowPro extends CRM_Core_Payment {
     }
 
     return self::errorExit(9014, "Check the code - all transactions should have been headed off before they got here. Something slipped through the net");
-  }
-
-  /**
-   * Checks to see if invoice_id already exists in db.
-   *
-   * @param int $invoiceId
-   *   The ID to check.
-   *
-   * @return bool
-   *   True if ID exists, else false
-   */
-  public function _checkDupe($invoiceId) {
-    //copied from Eway but not working and not really sure it should!
-    $contribution = new CRM_Contribute_DAO_Contribution();
-    $contribution->invoice_id = $invoiceId;
-    return $contribution->find();
   }
 
   /*

--- a/CRM/Core/Payment/Realex.php
+++ b/CRM/Core/Payment/Realex.php
@@ -136,7 +136,7 @@ class CRM_Core_Payment_Realex extends CRM_Core_Payment {
     /**********************************************************
      * Check to see if we have a duplicate before we send
      **********************************************************/
-    if ($this->_checkDupe($this->_getParam('order_id'))) {
+    if ($this->checkDupe($params['invoiceID'], CRM_Utils_Array::value('contributionID', $params))) {
       return self::error(9004, ts('It appears that this transaction is a duplicate.  Have you already submitted the form once?  If so there may have been a connection problem.  Check your email for a receipt from Authorize.net.  If you do not receive a receipt within 2 hours you can try your transaction again.  If you continue to have problems please contact the site administrator.'));
     }
 
@@ -425,21 +425,6 @@ class CRM_Core_Payment_Realex extends CRM_Core_Payment {
     $this->_setParam('timestamp', $timestamp);
 
     return TRUE;
-  }
-
-  /**
-   * Checks to see if invoice_id already exists in db.
-   *
-   * @param int $invoiceId
-   *   The ID to check.
-   *
-   * @return bool
-   *   True if ID exists, else false
-   */
-  public function _checkDupe($invoiceId) {
-    $contribution = new CRM_Contribute_DAO_Contribution();
-    $contribution->invoice_id = $invoiceId;
-    return $contribution->find();
   }
 
   /**

--- a/CRM/Core/Payment/eWAY.php
+++ b/CRM/Core/Payment/eWAY.php
@@ -256,7 +256,7 @@ class CRM_Core_Payment_eWAY extends CRM_Core_Payment {
     //----------------------------------------------------------------------------------------------------
     // Check to see if we have a duplicate before we send
     //----------------------------------------------------------------------------------------------------
-    if ($this->_checkDupe($params['invoiceID'])) {
+    if ($this->checkDupe($params['invoiceID'], CRM_Utils_Array::value('contributionID', $params))) {
       return self::errorExit(9003, 'It appears that this transaction is a duplicate.  Have you already submitted the form once?  If so there may have been a connection problem.  Check your email for a receipt from eWAY.  If you do not receive a receipt within 2 hours you can try your transaction again.  If you continue to have problems please contact the site administrator.');
     }
 
@@ -407,21 +407,6 @@ class CRM_Core_Payment_eWAY extends CRM_Core_Payment {
     return $params;
   }
   // end function doDirectPayment
-
-  /**
-   * Checks to see if invoice_id already exists in db.
-   *
-   * @param int $invoiceId
-   *   The ID to check.
-   *
-   * @return bool
-   *   True if ID exists, else false
-   */
-  public function _checkDupe($invoiceId) {
-    $contribution = new CRM_Contribute_DAO_Contribution();
-    $contribution->invoice_id = $invoiceId;
-    return $contribution->find();
-  }
 
   /**
    * **********************************************************************************************

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1314,7 +1314,7 @@ AND civicrm_membership.is_test = %2";
     $isProcessSeparateMembershipTransaction, $defaultContributionTypeID, $membershipLineItems, $isPayLater) {
     $result = $membershipContribution = NULL;
     $isTest = CRM_Utils_Array::value('is_test', $membershipParams, FALSE);
-    $errors = $createdMemberships = array();
+    $errors = $createdMemberships = $paymentResult = array();
 
     //@todo move this into the calling function & pass in the correct financialTypeID
     if (isset($paymentParams['financial_type'])) {
@@ -1343,7 +1343,7 @@ AND civicrm_membership.is_test = %2";
         $isPayLater
       );
       if (is_a($result[1], 'CRM_Core_Error')) {
-        $errors[1] = CRM_Core_Error::getMessages($result[1]);
+        $errors[1] = CRM_Core_Error::getMessages($paymentResult[1]);
       }
 
       if (is_a($paymentResult, 'CRM_Core_Error')) {
@@ -1360,7 +1360,7 @@ AND civicrm_membership.is_test = %2";
 
     if ($isProcessSeparateMembershipTransaction) {
       try {
-        $lineItems = $form->_lineItem = $membershipLineItems;
+        $form->_lineItem = $membershipLineItems;
         if (empty($form->_params['auto_renew']) && !empty($membershipParams['is_recur'])) {
           unset($membershipParams['is_recur']);
         }

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1329,7 +1329,12 @@ AND civicrm_membership.is_test = %2";
     }
 
     if ($isPaidMembership) {
-      $result = CRM_Contribute_BAO_Contribution_Utils::processConfirm($form, $membershipParams,
+      if ($isProcessSeparateMembershipTransaction) {
+        // If we have 2 transactions only one can use the invoice id.
+        $membershipParams['invoiceID'] .= '-2';
+      }
+
+      $paymentResult = CRM_Contribute_BAO_Contribution_Utils::processConfirm($form, $membershipParams,
         $premiumParams, $contactID,
         $financialTypeID,
         'membership',
@@ -1340,12 +1345,16 @@ AND civicrm_membership.is_test = %2";
       if (is_a($result[1], 'CRM_Core_Error')) {
         $errors[1] = CRM_Core_Error::getMessages($result[1]);
       }
-      elseif (!empty($result[1])) {
+
+      if (is_a($paymentResult, 'CRM_Core_Error')) {
+        $errors[1] = CRM_Core_Error::getMessages($paymentResult);
+      }
+      elseif (!empty($paymentResult['contribution'])) {
+        //note that this will be over-written if we are using a separate membership transaction. Otherwise there is only one
+        $membershipContribution = $paymentResult['contribution'];
         // Save the contribution ID so that I can be used in email receipts
         // For example, if you need to generate a tax receipt for the donation only.
-        $form->_values['contribution_other_id'] = $result[1]->id;
-        //note that this will be over-written if we are using a separate membership transaction. Otherwise there is only one
-        $membershipContribution = $result[1];
+        $form->_values['contribution_other_id'] = $membershipContribution->id;
       }
     }
 
@@ -1438,14 +1447,13 @@ AND civicrm_membership.is_test = %2";
       $form->_values['contribution_id'] = $membershipContributionID;
     }
 
-    // Do not send an email if Recurring transaction is done via Direct Mode
-    // Email will we sent when the IPN is received.
-    if (!empty($form->_params['is_recur']) && $form->_contributeMode == 'direct') {
-      if (!empty($membershipContribution->trxn_id)) {
+    if ($form->_contributeMode == 'direct') {
+      if (CRM_Utils_Array::value('contribution_status_id', $paymentResult) == 1) {
         try {
           civicrm_api3('contribution', 'completetransaction', array(
-            'id' => $membershipContribution->id,
-            'trxn_id' => $membershipContribution->trxn_id,
+            'id' => $paymentResult['contribution']->id,
+            'trxn_id' => $paymentResult['contribution']->trxn_id,
+            'is_transactional' => FALSE,
           ));
         }
         catch (CiviCRM_API3_Exception $e) {

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1136,7 +1136,7 @@ INNER JOIN  civicrm_membership_type type ON ( type.id = membership.membership_ty
   /**
    * Get all exportable fields.
    *
-   * @retun array return array of all exportable fields
+   * @return array return array of all exportable fields
    */
   public static function &exportableFields() {
     $expFieldMembership = CRM_Member_DAO_Membership::export();
@@ -1761,8 +1761,12 @@ WHERE  civicrm_membership.contact_id = civicrm_contact.id
    * @param CRM_Core_DAO $dao
    *   Membership object.
    *
-   * @return null|array
-   *   array of memberships if created
+   * @param bool $reset
+   *
+   * @return array|null
+   *   Membership details, if created.
+   *
+   * @throws \CRM_Core_Exception
    */
   public static function createRelatedMemberships(&$params, &$dao, $reset = FALSE) {
     static $relatedContactIds = array();

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -225,8 +225,10 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
 
   /**
    * Test submit with a membership block in place.
+   *
+   * We are expecting a separate payment for the membership vs the contribution.
    */
-  public function testSubmitMembershipBlockIsSeparatePaymentPaymentProcessor() {
+  public function testSubmitMembershipBlockIsSeparatePaymentPaymentProcessorNow() {
     $this->setUpMembershipContributionPage(TRUE);
     $submitParams = array(
       'price_' . $this->_ids['price_field'][0] => reset($this->_ids['price_field_value']),
@@ -288,7 +290,6 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
       'activity_type_id' => 'Failed Payment',
     ));
 
-
   }
 
   /**
@@ -298,7 +299,7 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
    * - the first creates a new membership, completed contribution, in progress recurring. Check these
    * - create another - end date should be extended
    */
-  public function testSubmitMembershipPriceSetPaymentPaymentProcessorRecur() {
+  public function testSubmitMembershipPriceSetPaymentPaymentProcessorRecurNow() {
     $this->params['is_recur'] = 1;
     $var = array();
     $this->params['recur_frequency_unit'] = 'month';


### PR DESCRIPTION
We agreed a while back that it is better to see attempted payments in the database, rather than not create them when failed. The process is that a pending payment should always be created, & updated to complete if that happens. We agreed a change to how that would look recently (https://issues.civicrm.org/jira/browse/CRM-16737) but this PR is not yet using that format. 

Note the seemingly big code change is simply removing the guts of the postProcess function into a function that is called by the test - & which does not contain the form handling of a redirect on error but contains pretty much everything else. The indentation changed slightly - leading it to show as a huge change here - but in fact it's just moving a big chunk of code within the same file
