### PR TITLE
Added call to getRecipients before executing a mail job

### DIFF
--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -295,7 +295,27 @@ class CRM_Mailing_BAO_MailingJob extends CRM_Mailing_DAO_MailingJob {
       }
     }
   }
-
+  /**
+   * Update the recipients table with a given job Id
+   * @param int $jobId
+   */
+  private static function getRecipientsPreJob($jobId) {
+    $job = new CRM_Mailing_BAO_MailingJob();
+    $job->id = $jobId;
+    if($job->id && $job->find(TRUE)) {
+        $mailing = new CRM_Mailing_BAO_Mailing();
+        $mailing->id = $job->mailing_id;
+        if ($mailing->id && $mailing->find(TRUE)) {
+          $mailing->getRecipients($job->id, $mailing->id, NULL, NULL, TRUE, $mailing->dedupe_email);
+        }
+        else {
+          throw new CRM_Core_Exception("Failed to getRecipientsPreJob: Unknown mailing ID");
+        }
+    }
+    else {
+      throw new CRM_Core_Exception("Failed to getRecipientsPreJob: Unknown job ID");
+    }
+}
 
   /**
    * before we run jobs, we need to split the jobs
@@ -343,6 +363,8 @@ class CRM_Mailing_BAO_MailingJob extends CRM_Mailing_DAO_MailingJob {
     // For each of the "Parent Jobs" we find, we split them into
     // X Number of child jobs
     while ($job->fetch()) {
+	  // fill/update the recipients for this job
+	  self::getRecipientsPreJob($job->id);
       // still use job level lock for each child job
       $lockName = "civimail.job.{$job->id}";
 


### PR DESCRIPTION
We recently posted a question on [stack exchange](http://civicrm.stackexchange.com/questions/3496/change-group-after-a-mailing-is-scheduled-results-in-mailing-still-being-send-to) about the recipients table beining filled when a mail is scheduled and not being updated when the mailing actually starts. 

We quite often will schedule a mailing and then either we or someone else will change the group members. In older civi versions this wasn't a problem, but the current civi version takes a snapshot of the members when scheduling the mailing and then this isn't refreshed anymore when the mailing actually starts.

My colleague came up with this little fix. Basically it will execute the code to update/fill the recipients table again when the mail actually starts. We found that when a group changed, the existing code to fill the recipients table actually does a great job of adding or deleting contacts based on group changes.

What we tested:
- Scheduled a mailing then added a person to the group. _Result_: recipients table had 1 extra row.
- Scheduled a maling then removed a person from the group. _Result_: recipients table had 1 less row.

**Remark**: we didn't test security frankly because we aren't that skilled in php or the inner workings of civi/drupal. But we think the call to the "recipients table fill" when scheduling a mail uses the current user, Then when it is time to send the e-mail the cronjob executes and probably uses an admin user to execute the "fill of the recipients table", making it so that potentially some ACL rules could be ignored.
We did investigate a little further and to us it should be possible to look up the id of the user that scheduled the job/mailing and pass this along to the security methods (some parameters are already there but are null) but again this was a bit over our head.

We just wanted to share and hope somebody can put this to good use, maybe even make it an option during the mail schedule process...
