### PR TITLE
CRM-16768: Invoice template function uses domain id instead of contac…

### DIFF
--- a/CRM/Contribute/Form/Task/Invoice.php
+++ b/CRM/Contribute/Form/Task/Invoice.php
@@ -398,7 +398,7 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
 
       // get organization address
       $domain = CRM_Core_BAO_Domain::getDomain();
-      $locParams = array('contact_id' => $domain->id);
+      $locParams = array('contact_id' => $domain->contact_id);
       $locationDefaults = CRM_Core_BAO_Location::getValues($locParams);
       if (isset($locationDefaults['address'][1]['state_province_id'])) {
         $stateProvinceAbbreviationDomain = CRM_Core_PseudoConstant::stateProvinceAbbreviation($locationDefaults['address'][1]['state_province_id']);


### PR DESCRIPTION
…t id to get address parts

---
- CRM-16768: Invoice template function uses domain id instead of contact id to get address parts
  https://issues.civicrm.org/jira/browse/CRM-16768
