### PR TITLE
Deal with ACL'ed users not getting is_deleted = 0 added on

### DIFF
--- a/CRM/Contact/BAO/Contact/Permission.php
+++ b/CRM/Contact/BAO/Contact/Permission.php
@@ -230,7 +230,7 @@ AND    $operationClause LIMIT 1";
     }
     else {
       $fromClause = " INNER JOIN civicrm_acl_contact_cache aclContactCache ON {$contactAlias}.id = aclContactCache.contact_id ";
-      $whereClase = " aclContactCache.user_id = $contactID ";
+      $whereClase = " aclContactCache.user_id = $contactID AND $contactAlias.is_deleted = 0";
     }
 
     return array($fromClause, $whereClase);

--- a/CRM/Contact/Form/Search/Custom/Basic.php
+++ b/CRM/Contact/Form/Search/Custom/Basic.php
@@ -194,7 +194,7 @@ class CRM_Contact_Form_Search_Custom_Basic extends CRM_Contact_Form_Search_Custo
   public function where($includeContactIDs = FALSE) {
     if ($whereClause = $this->_query->whereClause()) {
       if ($this->_aclWhere) {
-        $whereClause .= " AND {$this->_aclWhere} AND contact_a.is_deleted = 0";
+        $whereClause .= " AND {$this->_aclWhere}";
       }
       return $whereClause;
     }

--- a/CRM/Contact/Form/Search/Custom/DateAdded.php
+++ b/CRM/Contact/Form/Search/Custom/DateAdded.php
@@ -400,7 +400,6 @@ class CRM_Contact_Form_Search_Custom_DateAdded extends CRM_Contact_Form_Search_C
     $where = '(1)';
     if ($this->_aclWhere) {
       $where .= " AND {$this->_aclWhere} ";
-      $where .= " AND contact_a.is_deleted = 0";
     }
     return $where;
   }

--- a/CRM/Contact/Form/Search/Custom/MultipleValues.php
+++ b/CRM/Contact/Form/Search/Custom/MultipleValues.php
@@ -274,7 +274,7 @@ contact_a.sort_name    as sort_name,
       $clause[] = "cgc.group_id = {$this->_group}";
     }
     if ($this->_aclWhere) {
-      $clause[] = " {$this->_aclWhere} AND contact_a.is_deleted = 0";
+      $clause[] = " {$this->_aclWhere}";
     }
 
     $where = '( 1 )';

--- a/CRM/Contact/Form/Search/Custom/ZipCodeRange.php
+++ b/CRM/Contact/Form/Search/Custom/ZipCodeRange.php
@@ -173,7 +173,7 @@ LEFT JOIN civicrm_email   email   ON ( email.contact_id = contact_a.id AND
     );
 
     if ($this->_aclWhere) {
-      $where .= " AND {$this->_aclWhere} AND contact_a.is_deleted = 0";
+      $where .= " AND {$this->_aclWhere} ";
     }
     return $this->whereClause($where, $params);
   }


### PR DESCRIPTION
During My testing of https://github.com/civicrm/civicrm-core/pull/5839/files. I found that when I was masquerading as an ACLed user in the SQL the contact_alias.is_deleted = 0 was not being added which potentially may have meant that ACLed users would get deleted contacts in their search results. I did some fixes on some of the searches i fixed up but i figure that this is the much more better way of dealing with it. For non ACLed users (view all contacts, edit all contacts) they do get the contact_alias.is_deleted = 0 line added on. 
