### PR TITLE
CRM-16711 - make CRM_Contact_DAO_Relationship::makeURLClause ACL-aware.

### DIFF
--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -1114,6 +1114,19 @@ LEFT JOIN  civicrm_country ON (civicrm_address.country_id = civicrm_country.id)
         $where .= ' AND relationship_type_id = ' . CRM_Utils_Type::escape($params['relationship_type_id'], 'Positive');
       }
     }
+
+    // CRM-9335, CRM-16711: restrict to contacts that the user is permitted to view.
+    $aclTables      = array();
+    $aclWhereTables = array();
+    $permission = CRM_ACL_API::whereClause(CRM_Core_Permission::VIEW, $aclTables, $aclWhereTables);
+    $aclFrom = CRM_Contact_BAO_Query::fromClause($aclWhereTables);
+    $aclQuery = "
+SELECT contact_a.id
+   $aclFrom
+WHERE $permission
+";
+    $where .= " AND civicrm_contact.id IN ($aclQuery)";
+
     if ($direction == 'a_b') {
       $where .= ' ) UNION ';
     }


### PR DESCRIPTION
As described in CRM-9335 and CRM-16711, a contact lacking 'view all contacts' permission can view basic contact details of any contact they're related to, via the relationships tab, even if they're not permitted to view those contacts. This change applies ACL permissioning to the query used to retrieve relationships, so that a contact will only see relationships to contacts they're permitted to view.
