### PR TITLE
CRM-16799 Contribution.get api - support 'is_test'

### DIFF
--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -256,6 +256,7 @@ function _civicrm_api3_contribution_get_spec(&$params) {
     'api.default' => 0,
     'type' => CRM_Utils_Type::T_BOOLEAN,
     'title' => 'Get Test Contributions?',
+    'api.aliases' => array('is_test'),
   );
   $params['financial_type_id']['api.aliases'] = array('contribution_type_id');
   $params['payment_instrument_id']['api.aliases'] = array('contribution_payment_instrument', 'payment_instrument');

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -198,6 +198,14 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test that test contributions can be retrieved.
+   */
+  public function testGetTestContribution() {
+    $this->callAPISuccess('Contribution', 'create', array_merge($this->_params, array('is_test' => 1)));
+    $this->callAPISuccessGetSingle('Contribution', array('is_test' => 1));
+  }
+
+  /**
    * We need to ensure previous tested behaviour still works as part of the api contract.
    */
   public function testGetContributionLegacyBehaviour() {
@@ -214,7 +222,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'source' => 'SSF',
       'contribution_status_id' => 1,
     );
-    $this->_contribution = $this->callAPISuccess('contribution', 'create', $p);
+    $this->_contribution = $this->callAPISuccess('Contribution', 'create', $p);
 
     $params = array(
       'contribution_id' => $this->_contribution['id'],


### PR DESCRIPTION
It would probably be more correct to accept is_test & make contribution_test an alias of that for backwards compatibility, but this
is the quick version which at least supports the 'right' param
