### PR TITLE
 Edit <title> to avoid clash with other field

### DIFF
--- a/xml/schema/Contribute/ContributionRecur.xml
+++ b/xml/schema/Contribute/ContributionRecur.xml
@@ -118,7 +118,7 @@
   </field>
   <field>
     <name>processor_id</name>
-    <title>Payment Processor</title>
+    <title>Processor ID</title>
     <type>varchar</type>
     <length>255</length>
     <comment>Possibly needed to store a unique identifier for this recurring payment order - if this is available from the processor??</comment>


### PR DESCRIPTION
Both processor_id and payment_processor_id have <title>Payment Processor</title>. This causes issues with imports into the recurring series table (using Eileen's CSV importer) - as the field mapping is stored by title and will always select the first match - even if you previously selected 'the second Payment Processor' <title>. Renaming the <title> for processor_id to Processor ID. Leaving the payment_processor_id <title> as is: Payment Processor
