### PR TITLE
CRM-16737 support either payment_status_id OR contribution_status_id

### DIFF
--- a/CRM/Contribute/BAO/Contribution/Utils.php
+++ b/CRM/Contribute/BAO/Contribution/Utils.php
@@ -335,7 +335,7 @@ class CRM_Contribute_BAO_Contribution_Utils {
           $contribution->trxn_id = $result['trxn_id'];
         }
         if (!empty($result['payment_status_id'])) {
-          $contribution->contribution_status_id = $result['payment_status_id'];
+          $contribution->payment_status_id = $result['payment_status_id'];
         }
       }
       $membershipResult[1] = $contribution;

--- a/CRM/Contribute/BAO/Contribution/Utils.php
+++ b/CRM/Contribute/BAO/Contribution/Utils.php
@@ -330,8 +330,13 @@ class CRM_Contribute_BAO_Contribution_Utils {
         );
       }
       $form->postProcessPremium($premiumParams, $contribution);
-      if (is_array($result) && !empty($result['trxn_id'])) {
-        $contribution->trxn_id = $result['trxn_id'];
+      if (is_array($result)) {
+        if (!empty($result['trxn_id'])) {
+          $contribution->trxn_id = $result['trxn_id'];
+        }
+        if (!empty($result['payment_status_id'])) {
+          $contribution->contribution_status_id = $result['payment_status_id'];
+        }
       }
       $membershipResult[1] = $contribution;
     }

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -2317,7 +2317,12 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = membership.contact_id AND 
    */
   public static function createOrRenewMembership($membershipParams, $contactID, $customFieldsFormatted, $membershipID, $memType, $isTest, $numTerms, $membershipContribution, &$form) {
     if (!empty($membershipContribution)) {
+      // CRM-16737 contribution_status_id is the deprecated return parameter from the payment processor. Use
+      // payment_status_id.
       $pending = ($membershipContribution->contribution_status_id == 2) ? TRUE : FALSE;
+      if (isset($membershipContribution->payment_status_id)) {
+        $pending = ($membershipContribution->payment_status_id == 2) ? TRUE : $pending;
+      }
     }
     $membership = self::renewMembershipFormWrapper($contactID, $memType,
       $isTest, $form, NULL,

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1449,8 +1449,13 @@ AND civicrm_membership.is_test = %2";
       $form->_values['contribution_id'] = $membershipContributionID;
     }
 
-    // Do not send an email if Recurring transaction is done via Direct Mode
-    // Email will we sent when the IPN is received.
+    // Refer to CRM-16737. Payment processors 'should' return payment_status_id
+    // to denote the outcome of the transaction.
+    //
+    // In 4.7 trxn_id will no longer denote the outcome & all processor transactions must return an array
+    // containing payment_status_id.
+    // In 4.6 support (such as there was) for other ways of denoting payment outcome is retained but the use
+    // of payment_status_id is strongly encouraged.
     if (!empty($form->_params['is_recur']) && $form->_contributeMode == 'direct') {
       if (!empty($membershipContribution->trxn_id) && !isset($membershipContribution->payment_status_id)
         || (!empty($membershipContribution->payment_status_id) && $membershipContribution->payment_status_id == 1)) {
@@ -1466,6 +1471,8 @@ AND civicrm_membership.is_test = %2";
           CRM_Core_Error::debug_log_message('contribution ' . $membershipContribution->id . ' not completed with trxn_id ' . $membershipContribution->trxn_id . ' and message ' . $e->getMessage());
         }
       }
+      // Do not send an email if Recurring transaction is done via Direct Mode
+      // Email will we sent when the IPN is received.
       return;
     }
 

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1452,7 +1452,8 @@ AND civicrm_membership.is_test = %2";
     // Do not send an email if Recurring transaction is done via Direct Mode
     // Email will we sent when the IPN is received.
     if (!empty($form->_params['is_recur']) && $form->_contributeMode == 'direct') {
-      if (!empty($membershipContribution->trxn_id)) {
+      if (!empty($membershipContribution->trxn_id) && !isset($membershipContribution->payment_status_id)
+        || (!empty($membershipContribution->payment_status_id) && $membershipContribution->payment_status_id == 1)) {
         try {
           civicrm_api3('contribution', 'completetransaction', array(
             'id' => $membershipContribution->id,

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1425,6 +1425,12 @@ WHERE   id IN ( ' . implode(' , ', array_keys($membershipType)) . ' )';
       if (isset($result['contribution_status_id'])) {
         $params['contribution_status_id'] = $result['contribution_status_id'];
       }
+      elseif (isset($result['payment_status_id'])) {
+        // CRM-16737 $result['contribution_status_id'] is deprecated in favour
+        // of payment_status_id as the payment processor only knows whether the payment is complete
+        // not whether payment completes the contribution
+        $params['contribution_status_id'] = $params['payment_status_id'];
+      }
       // do what used to happen previously
       else {
         $params['contribution_status_id'] = !empty($paymentParams['is_recur']) ? 2 : 1;

--- a/api/v3/examples/ContributionPage/Submit.php
+++ b/api/v3/examples/ContributionPage/Submit.php
@@ -70,7 +70,7 @@ function contribution_page_submit_expectedresult() {
 
 /*
 * This example has been generated from the API test suite.
-* The test that created it is called "testSubmitMembershipPriceSetPaymentPaymentProcessorRecurDelayed"
+* The test that created it is called "testLegacySubmitMembershipPriceSetPaymentPaymentProcessorRecurDelayed"
 * and can be found at:
 * https://github.com/civicrm/civicrm-core/blob/master/tests/phpunit/api/v3/ContributionPageTest.php
 *

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -268,6 +268,72 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
     $this->params['recur_frequency_unit'] = 'month';
     $this->setUpMembershipContributionPage();
     $dummyPP = CRM_Core_Payment::singleton('live', $this->_paymentProcessor);
+    $dummyPP->setDoDirectPaymentResult(array('payment_status_id' => 1, 'trxn_id' => 'create_first_success'));
+
+    $submitParams = array(
+      'price_' . $this->_ids['price_field'][0] => reset($this->_ids['price_field_value']),
+      'id' => (int) $this->_ids['contribution_page'],
+      'amount' => 10,
+      'billing_first_name' => 'Billy',
+      'billing_middle_name' => 'Goat',
+      'billing_last_name' => 'Gruff',
+      'email' => 'billy@goat.gruff',
+      'selectMembership' => $this->_ids['membership_type'],
+      'payment_processor' => 1,
+      'credit_card_number' => '4111111111111111',
+      'credit_card_type' => 'Visa',
+      'credit_card_exp_date' => array('M' => 9, 'Y' => 2040),
+      'cvv2' => 123,
+      'is_recur' => 1,
+      'frequency_interval' => 1,
+      'frequency_unit' => 'month',
+    );
+
+    $this->callAPIAndDocument('contribution_page', 'submit', $submitParams, __FUNCTION__, __FILE__, 'submit contribution page', NULL);
+    $contribution = $this->callAPISuccess('contribution', 'getsingle', array(
+      'contribution_page_id' => $this->_ids['contribution_page'],
+      'contribution_status_id' => 1,
+    ));
+    $membershipPayment = $this->callAPISuccess('membership_payment', 'getsingle', array());
+    $this->assertEquals($membershipPayment['contribution_id'], $contribution['id']);
+    $membership = $this->callAPISuccessGetSingle('membership', array('id' => $membershipPayment['membership_id']));
+    $this->assertEquals($membership['contact_id'], $contribution['contact_id']);
+    $this->assertEquals(1, $membership['status_id']);
+    $this->callAPISuccess('contribution_recur', 'getsingle', array('id' => $contribution['contribution_recur_id']));
+    //@todo - check with Joe about these not existing
+    //$this->callAPISuccess('line_item', 'getsingle', array('contribution_id' => $contribution['id'], 'entity_id' => $membership['id']));
+    //renew it with processor setting completed - should extend membership
+    $submitParams['contact_id'] = $contribution['contact_id'];
+    $dummyPP->setDoDirectPaymentResult(array('payment_status_id' => 1, 'trxn_id' => 'create_second_success'));
+    $this->callAPISuccess('contribution_page', 'submit', $submitParams);
+    $this->callAPISuccess('contribution', 'getsingle', array(
+      'id' => array('NOT IN' => array($contribution['id'])),
+      'contribution_page_id' => $this->_ids['contribution_page'],
+      'contribution_status_id' => 1,
+    ));
+    $renewedMembership = $this->callAPISuccessGetSingle('membership', array('id' => $membershipPayment['membership_id']));
+    $this->assertEquals(date('Y-m-d', strtotime('+ 1 year', strtotime($membership['end_date']))), $renewedMembership['end_date']);
+    $recurringContribution = $this->callAPISuccess('contribution_recur', 'getsingle', array('id' => $contribution['contribution_recur_id']));
+    $this->assertEquals(2, $recurringContribution['contribution_status_id']);
+  }
+
+  /**
+   * Test submit recurring membership with immediate confirmation (IATS style).
+   *
+   * Per CRM-16737 we are deprecating the use of contribution_status_id to indicate success in favour of
+   * payment_status_id.
+   *
+   * - we process 2 membership transactions against with a recurring contribution against a contribution page with an immediate
+   * processor (IATS style - denoted by returning trxn_id)
+   * - the first creates a new membership, completed contribution, in progress recurring. Check these
+   * - create another - end date should be extended
+   */
+  public function testLegacySubmitMembershipPriceSetPaymentPaymentProcessorRecur() {
+    $this->params['is_recur'] = 1;
+    $var = array();
+    $this->params['recur_frequency_unit'] = 'month';
+    $this->setUpMembershipContributionPage();
+    $dummyPP = CRM_Core_Payment::singleton('live', $this->_paymentProcessor);
     $dummyPP->setDoDirectPaymentResult(array('contribution_status_id' => 1, 'trxn_id' => 'create_first_success'));
 
     $submitParams = array(
@@ -326,6 +392,87 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
    * - create another - end date should NOT be extended
    */
   public function testSubmitMembershipPriceSetPaymentPaymentProcessorRecurDelayed() {
+    $this->params['is_recur'] = 1;
+    $this->params['recur_frequency_unit'] = 'month';
+    $this->setUpMembershipContributionPage();
+    $dummyPP = CRM_Core_Payment::singleton('live', $this->_paymentProcessor);
+    $dummyPP->setDoDirectPaymentResult(array('payment_status_id' => 2));
+
+    $submitParams = array(
+      'price_' . $this->_ids['price_field'][0] => reset($this->_ids['price_field_value']),
+      'id' => (int) $this->_ids['contribution_page'],
+      'amount' => 10,
+      'billing_first_name' => 'Billy',
+      'billing_middle_name' => 'Goat',
+      'billing_last_name' => 'Gruff',
+      'email' => 'billy@goat.gruff',
+      'selectMembership' => $this->_ids['membership_type'],
+      'payment_processor' => 1,
+      'credit_card_number' => '4111111111111111',
+      'credit_card_type' => 'Visa',
+      'credit_card_exp_date' => array('M' => 9, 'Y' => 2040),
+      'cvv2' => 123,
+      'is_recur' => 1,
+      'frequency_interval' => 1,
+      'frequency_unit' => 'month',
+    );
+
+    $this->callAPIAndDocument('contribution_page', 'submit', $submitParams, __FUNCTION__, __FILE__, 'submit contribution page', NULL);
+    $contribution = $this->callAPISuccess('contribution', 'getsingle', array(
+      'contribution_page_id' => $this->_ids['contribution_page'],
+      'contribution_status_id' => 2,
+    ));
+    $membershipPayment = $this->callAPISuccess('membership_payment', 'getsingle', array());
+    $this->assertEquals($membershipPayment['contribution_id'], $contribution['id']);
+    $membership = $this->callAPISuccessGetSingle('membership', array('id' => $membershipPayment['membership_id']));
+    $this->assertEquals($membership['contact_id'], $contribution['contact_id']);
+    $this->assertEquals(5, $membership['status_id']);
+    //@todo - check with Joe about these not existing
+    //$this->callAPISuccess('line_item', 'getsingle', array('contribution_id' => $contribution['id'], 'entity_id' => $membership['id']));
+    $this->callAPISuccess('contribution', 'completetransaction', array(
+      'id' => $contribution['id'],
+      'trxn_id' => 'ipn_called',
+    ));
+    $membership = $this->callAPISuccessGetSingle('membership', array('id' => $membershipPayment['membership_id']));
+    //renew it with processor setting completed - should extend membership
+    $submitParams = array_merge($submitParams, array(
+        'contact_id' => $contribution['contact_id'],
+        'is_recur' => 1,
+        'frequency_interval' => 1,
+        'frequency_unit' => 'month',
+      )
+    );
+    $dummyPP->setDoDirectPaymentResult(array('payment_status_id' => 2));
+    $this->callAPISuccess('contribution_page', 'submit', $submitParams);
+    $newContribution = $this->callAPISuccess('contribution', 'getsingle', array(
+        'id' => array(
+          'NOT IN' => array($contribution['id']),
+        ),
+        'contribution_page_id' => $this->_ids['contribution_page'],
+        'contribution_status_id' => 2,
+      )
+    );
+
+    $renewedMembership = $this->callAPISuccessGetSingle('membership', array('id' => $membershipPayment['membership_id']));
+    //no renewal as the date hasn't changed
+    $this->assertEquals($membership['end_date'], $renewedMembership['end_date']);
+    $recurringContribution = $this->callAPISuccess('contribution_recur', 'getsingle', array('id' => $newContribution['contribution_recur_id']));
+    $this->assertEquals(2, $recurringContribution['contribution_status_id']);
+  }
+
+  /**
+   * Test submit recurring membership with delayed confirmation (Authorize.net style)
+   * - we process 2 membership transactions against with a recurring contribution against a contribution page with a delayed
+   * processor (Authorize.net style - denoted by NOT returning trxn_id)
+   *
+   * Per CRM-16737 we are deprecating the use of contribution_status_id to indicate success in favour of
+   * payment_status_id.
+   *
+   * - the first creates a pending membership, pending contribution, pending recurring. Check these
+   * - complete the transaction
+   * - create another - end date should NOT be extended
+   */
+  public function testLegacySubmitMembershipPriceSetPaymentPaymentProcessorRecurDelayed() {
     $this->params['is_recur'] = 1;
     $this->params['recur_frequency_unit'] = 'month';
     $this->setUpMembershipContributionPage();

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -262,7 +262,7 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
    * - the first creates a new membership, completed contribution, in progress recurring. Check these
    * - create another - end date should be extended
    */
-  public function testSubmitMembershipPriceSetPaymentPaymentProcessorRecur() {
+  public function testSubmitMembershipPriceSetPaymentPaymentProcessorRecurInstantPayment() {
     $this->params['is_recur'] = 1;
     $var = array();
     $this->params['recur_frequency_unit'] = 'month';


### PR DESCRIPTION
Per CRM-16737 from 4.6 onwards payment processors should declare the outcome of a payment transaction by setting payment_status_id in the result array.

Other methods (setting trxn_id or contribution_status_id are deprecated in 4.6 & will be removed in 4.7).

Note that setting payment_status_id will as of 4.6 work 'better' than either of the other 2 as contribution_status_id worked in one place & trxn_id in another (inappropriately according to CRM-15296). 
