### PR TITLE
Test fix

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1795,39 +1795,39 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     if (!empty($params['non_deductible_amount'])) {
       return $params['non_deductible_amount'];
     }
-    if (empty($params['non_deductible_amount'])) {
-      $contributionType = new CRM_Financial_DAO_FinancialType();
-      $contributionType->id = $params['financial_type_id'];
 
-      if ($contributionType->is_deductible) {
+    $financialType = new CRM_Financial_DAO_FinancialType();
+    $financialType->id = $params['financial_type_id'];
 
-        if (isset($formValues['product_name'][0])) {
-          $selectProduct = $formValues['product_name'][0];
+    if ($financialType->is_deductible) {
+
+      if (isset($formValues['product_name'][0])) {
+        $selectProduct = $formValues['product_name'][0];
+      }
+      // if there is a product - compare the value to the contribution amount
+      if (isset($selectProduct)) {
+        $productDAO = new CRM_Contribute_DAO_Product();
+        $productDAO->id = $selectProduct;
+        $productDAO->find(TRUE);
+        // product value exceeds contribution amount
+        if ($params['total_amount'] < $productDAO->price) {
+          return $params['total_amount'];
         }
-        // if there is a product - compare the value to the contribution amount
-        if (isset($selectProduct)) {
-          $productDAO = new CRM_Contribute_DAO_Product();
-          $productDAO->id = $selectProduct;
-          $productDAO->find(TRUE);
-          // product value exceeds contribution amount
-          if ($params['total_amount'] < $productDAO->price) {
-            return $params['total_amount'];
-          }
-          // product value does NOT exceed contribution amount
-          else {
-            return $productDAO->price;
-          }
-        }
-        // contribution is deductible - but there is no product
+        // product value does NOT exceed contribution amount
         else {
-          return '0.00';
+          return $productDAO->price;
         }
       }
-      // contribution is NOT deductible
+      // contribution is deductible - but there is no product
       else {
-        return $params['total_amount'];
+        return '0.00';
       }
     }
+    // contribution is NOT deductible
+    else {
+      return $params['total_amount'];
+    }
+
     return 0;
   }
 

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -426,10 +426,13 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
       'id' => $contribution['id'],
     ),
       CRM_Core_Action::UPDATE);
-    $this->callAPISuccessGetCount('Contribution', array('contact_id' => $this->_individualId), 1);
+    $contribution = $this->callAPISuccessGetSingle('Contribution', array('contact_id' => $this->_individualId));
+    $this->assertEquals(45, (int) $contribution['total_amount']);
+
     $financialTransactions = $this->callAPISuccess('FinancialTrxn', 'get', array('sequential' => TRUE));
     $this->assertEquals(2, $financialTransactions['count']);
     $this->assertEquals(50, $financialTransactions['values'][0]['total_amount']);
+    $this->assertEquals(45, $financialTransactions['values'][1]['net_amount']);
     $this->assertEquals(45, $financialTransactions['values'][1]['total_amount']);
     $lineItem = $this->callAPISuccessGetSingle('LineItem', array());
     $this->assertEquals(45, $lineItem['line_total']);

--- a/tests/phpunit/CRM/Member/Form/MembershipRenewalTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipRenewalTest.php
@@ -1,0 +1,302 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.6                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2015                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *  File for the MembershipTest class
+ *
+ *  (PHP 5)
+ *
+ * @author Walt Haas <walt@dharmatech.org> (801) 534-1262
+ */
+
+/**
+ *  Include class definitions
+ */
+require_once 'CiviTest/CiviUnitTestCase.php';
+
+require_once 'HTML/QuickForm/Page.php';
+
+/**
+ *  Test CRM_Member_Form_Membership functions.
+ *
+ * @package   CiviCRM
+ */
+class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
+
+  /**
+   * Assume empty database with just civicrm_data.
+   */
+  protected $_individualId;
+  protected $_contribution;
+  protected $_financialTypeId = 1;
+  protected $_apiversion;
+  protected $_entity = 'Membership';
+  protected $_params;
+  protected $_ids = array();
+  protected $_paymentProcessorID;
+
+  /**
+   * Membership type ID for annual fixed membership.
+   *
+   * @var int
+   */
+  protected $membershipTypeAnnualFixedID;
+
+  /**
+   * Parameters to create payment processor.
+   *
+   * @var array
+   */
+  protected $_processorParams = array();
+
+  /**
+   * ID of created membership.
+   *
+   * @var int
+   */
+  protected $_membershipID;
+
+  /**
+   * Payment instrument mapping.
+   *
+   * @var array
+   */
+  protected $paymentInstruments = array();
+
+  /**
+   * Test setup for every test.
+   *
+   * Connect to the database, truncate the tables that will be used
+   * and redirect stdin to a temporary file.
+   */
+  public function setUp() {
+    $this->_apiversion = 3;
+    parent::setUp();
+
+    $this->_individualId = $this->individualCreate();
+    $processor = $this->processorCreate();
+    $this->_paymentProcessorID = $processor->id;
+    // Insert test data.
+    $op = new PHPUnit_Extensions_Database_Operation_Insert();
+    $op->execute($this->_dbconn,
+      $this->createFlatXMLDataSet(
+        dirname(__FILE__) . '/dataset/data.xml'
+      )
+    );
+    $membershipTypeAnnualFixed = $this->callAPISuccess('membership_type', 'create', array(
+      'domain_id' => 1,
+      'name' => "AnnualFixed",
+      'member_of_contact_id' => 23,
+      'duration_unit' => "year",
+      'duration_interval' => 1,
+      'period_type' => "fixed",
+      'fixed_period_start_day' => "101",
+      'fixed_period_rollover_day' => "1231",
+      'relationship_type_id' => 20,
+      'financial_type_id' => 2,
+    ));
+    $this->membershipTypeAnnualFixedID = $membershipTypeAnnualFixed['id'];
+    $membership = $this->callAPISuccess('Membership', 'create', array(
+      'contact_id' => $this->_individualId,
+      'membership_type_id' => $this->membershipTypeAnnualFixedID,
+    ));
+    $this->_membershipID = $membership['id'];
+
+    $instruments = $this->callAPISuccess('contribution', 'getoptions', array('field' => 'payment_instrument_id'));
+    $this->paymentInstruments = $instruments['values'];
+  }
+
+  /**
+   * Clean up after each test.
+   */
+  public function tearDown() {
+    $this->quickCleanUpFinancialEntities();
+    $this->quickCleanup(
+      array(
+        'civicrm_relationship',
+        'civicrm_membership_type',
+        'civicrm_membership',
+        'civicrm_uf_match',
+      )
+    );
+    $this->callAPISuccess('contact', 'delete', array('id' => 17, 'skip_undelete' => TRUE));
+    $this->callAPISuccess('contact', 'delete', array('id' => 23, 'skip_undelete' => TRUE));
+    $this->callAPISuccess('relationship_type', 'delete', array('id' => 20));
+  }
+
+  /**
+   *  Test CRM_Member_Form_Membership::buildQuickForm()
+   */
+  //function testCRMMemberFormMembershipBuildQuickForm()
+  //{
+  //    throw new PHPUnit_Framework_IncompleteTestError( "not implemented" );
+  //}
+
+  /**
+   * Test the submit function of the membership form.
+   */
+  public function testSubmit() {
+    $form = $this->getForm();
+    $this->createLoggedInUser();
+    $params = array(
+      'cid' => $this->_individualId,
+      'join_date' => date('m/d/Y', time()),
+      'start_date' => '',
+      'end_date' => '',
+      // This format reflects the 23 being the organisation & the 25 being the type.
+      'membership_type_id' => array(23, $this->membershipTypeAnnualFixedID),
+      'auto_renew' => '0',
+      'max_related' => '',
+      'num_terms' => '1',
+      'source' => '',
+      'total_amount' => '50.00',
+      'financial_type_id' => '2', //Member dues, see data.xml
+      'soft_credit_type_id' => '',
+      'soft_credit_contact_id' => '',
+      'from_email_address' => '"Demonstrators Anonymous" <info@example.org>',
+      'receipt_text_signup' => 'Thank you text',
+      'payment_processor_id' => $this->_paymentProcessorID,
+      'credit_card_number' => '4111111111111111',
+      'cvv2' => '123',
+      'credit_card_exp_date' => array(
+        'M' => '9',
+        'Y' => '2024', // TODO: Future proof
+      ),
+      'credit_card_type' => 'Visa',
+      'billing_first_name' => 'Test',
+      'billing_middlename' => 'Last',
+      'billing_street_address-5' => '10 Test St',
+      'billing_city-5' => 'Test',
+      'billing_state_province_id-5' => '1003',
+      'billing_postal_code-5' => '90210',
+      'billing_country_id-5' => '1228',
+    );
+    $form->_contactID = $this->_individualId;
+
+    $form->testSubmit($params);
+    $membership = $this->callAPISuccessGetSingle('Membership', array('contact_id' => $this->_individualId));
+    $this->callAPISuccessGetCount('ContributionRecur', array('contact_id' => $this->_individualId), 0);
+    $contribution = $this->callAPISuccess('Contribution', 'get', array(
+      'contact_id' => $this->_individualId,
+      'is_test' => TRUE,
+    ));
+
+    $this->callAPISuccessGetCount('LineItem', array(
+      'entity_id' => $membership['id'],
+      'entity_table' => 'civicrm_membership',
+      'contribution_id' => $contribution['id'],
+    ), 1);
+  }
+
+  /**
+   * Test the submit function of the membership form.
+   */
+  public function testSubmitRecur() {
+    $form = $this->getForm();
+
+    $this->callAPISuccess('MembershipType', 'create', array(
+      'id' => $this->membershipTypeAnnualFixedID,
+      'duration_unit' => 'month',
+      'duration_interval' => 1,
+      'auto_renew' => TRUE,
+    ));
+    $form->preProcess();
+    $this->createLoggedInUser();
+    $params = array(
+      'cid' => $this->_individualId,
+      'price_set_id' => 0,
+      'join_date' => date('m/d/Y', time()),
+      'start_date' => '',
+      'end_date' => '',
+      'campaign_id' => '',
+      // This format reflects the 23 being the organisation & the 25 being the type.
+      'membership_type_id' => array(23, $this->membershipTypeAnnualFixedID),
+      'auto_renew' => '1',
+      'is_recur' => 1,
+      'max_related' => 0,
+      'num_terms' => '1',
+      'source' => '',
+      'total_amount' => '77.00',
+      'financial_type_id' => '2', //Member dues, see data.xml
+      'soft_credit_type_id' => 11,
+      'soft_credit_contact_id' => '',
+      'from_email_address' => '"Demonstrators Anonymous" <info@example.org>',
+      'receipt_text' => 'Thank you text',
+      'payment_processor_id' => $this->_paymentProcessorID,
+      'credit_card_number' => '4111111111111111',
+      'cvv2' => '123',
+      'credit_card_exp_date' => array(
+        'M' => '9',
+        'Y' => '2019', // TODO: Future proof
+      ),
+      'credit_card_type' => 'Visa',
+      'billing_first_name' => 'Test',
+      'billing_middlename' => 'Last',
+      'billing_street_address-5' => '10 Test St',
+      'billing_city-5' => 'Test',
+      'billing_state_province_id-5' => '1003',
+      'billing_postal_code-5' => '90210',
+      'billing_country_id-5' => '1228',
+    );
+    $form->_mode = 'test';
+    $form->_contactID = $this->_individualId;
+
+    $form->testSubmit($params);
+    $membership = $this->callAPISuccessGetSingle('Membership', array('contact_id' => $this->_individualId));
+    //$this->callAPISuccessGetCount('ContributionRecur', array('contact_id' => $this->_individualId), 1);
+    $contribution = $this->callAPISuccess('Contribution', 'get', array(
+      'contact_id' => $this->_individualId,
+      'is_test' => TRUE,
+    ));
+
+    $this->callAPISuccessGetCount('LineItem', array(
+      'entity_id' => $membership['id'],
+      'entity_table' => 'civicrm_membership',
+      'contribution_id' => $contribution['id'],
+    ), 1);
+
+  }
+
+  /**
+   * Get a membership form object.
+   *
+   * We need to instantiate the form to run preprocess, which means we have to trick it about the request method.
+   *
+   * @return \CRM_Member_Form_MembershipRenewal
+   */
+  protected function getForm() {
+    $form = new CRM_Member_Form_MembershipRenewal();
+    $_SERVER['REQUEST_METHOD'] = 'GET';
+    $form->controller = new CRM_Core_Controller();
+    $form->_bltID = 5;
+    $form->_mode = 'test';
+    $form->_id = $this->_membershipID;
+    $form->preProcess();
+    return $form;
+  }
+
+}


### PR DESCRIPTION
This doesn't actually fully complete the test but I need @JoeMurray input to fix it.

The test is
CRM_Contribute_Form_ContributionTest::testSubmitUpdate
& the error is

1) CRM_Contribute_Form_ContributionTest::testSubmitUpdate
Failed asserting that '-5.00' matches expected 45.

/home/vagrant/civicrm-buildkit/build/drupal-demo/sites/all/modules/civicrm/tests/phpunit/CRM/Contribute/Form/ContributionTest.php:433
/home/vagrant/civicrm-buildkit/build/drupal-demo/sites/all/modules/civicrm/tests/phpunit/CiviTest/CiviUnitTestCase.php:209
/home/vagrant/civicrm-buildkit/build/drupal-demo/sites/all/modules/civicrm/tools/scripts/phpunit:80

However, I'm unsure if the test of the behaviour is wrong. The test was probably written by me to 'lock in' whatever existing behaviour was rather than because I knew what it should be. The scenario is

1) contribution created. One row is created in civicrm_financial_trxn. Both have a total_amount of $50
2) contribution updated. Contribution.total_amount is now $45. The row in civicrm_financial_trxn for $50 remains & a new row has been added to the civicrm_financial_trxn table - this is where the test expectation differs from reality.

New row in civicrm_financial_entity:

REALITY
            [total_amount] => -5
            [fee_amount] =>
            [net_amount] => 45

TEST EXPECTATION 
            [total_amount] => 45
            [fee_amount] =>
            [net_amount] => 45

Is the test correct - or is the correct output in fact 
PERHAPS THIS SHOULD BE REALITY
            [total_amount] => -5
            [fee_amount] =>
            [net_amount] => -5
