### PR TITLE
Webtest Fix

### DIFF
--- a/tests/phpunit/CiviTest/CiviSeleniumTestCase.php
+++ b/tests/phpunit/CiviTest/CiviSeleniumTestCase.php
@@ -1357,7 +1357,7 @@ class CiviSeleniumTestCase extends PHPUnit_Extensions_SeleniumTestCase {
       $this->assertTrue($this->isTextPresent($text), 'Missing text: ' . $text);
       $this->openCiviPage("admin/contribute", "reset=1");
       $this->waitForAjaxContent();
-      $this->click("xpath=//table['dataTables_wrapper no-footer']/tbody//tr/td[1]/strong[text()='$pageTitle']/../../td[4]/div[1]/span/ul/li[8]/a[text()='Premiums']");
+      $this->click("xpath=//table['dataTables_wrapper no-footer']/tbody//tr/td[1]/strong[text()='$pageTitle']/../../td[5]/div[1]/span/ul/li[8]/a[text()='Premiums']");
       $this->waitForElementPresent('_qf_Premium_cancel-bottom');
       $this->click("xpath=//div[@class='messages status no-popup']/a[text()='add one']");
       $this->waitForElementPresent('_qf_AddProduct_cancel-bottom');
@@ -1369,6 +1369,7 @@ class CiviSeleniumTestCase extends PHPUnit_Extensions_SeleniumTestCase {
 
     if ($widget) {
       // fill in step 8 (Widget Settings)
+      $this->waitForPageToLoad($this->getTimeoutMsec());
       $this->click('link=Widgets');
       $this->waitForElementPresent('_qf_Widget_next-bottom');
 
@@ -1388,6 +1389,7 @@ class CiviSeleniumTestCase extends PHPUnit_Extensions_SeleniumTestCase {
 
     if ($pcp) {
       // fill in step 9 (Enable Personal Campaign Pages)
+      $this->waitForPageToLoad($this->getTimeoutMsec());
       $this->click('link=Personal Campaigns');
       $this->waitForElementPresent('_qf_Contribute_next-bottom');
       $this->click('pcp_active');

--- a/tests/phpunit/WebTest/Campaign/OnlineContributionTest.php
+++ b/tests/phpunit/WebTest/Campaign/OnlineContributionTest.php
@@ -256,7 +256,7 @@ class WebTest_Campaign_OnlineContributionTest extends CiviSeleniumTestCase {
     $this->webtestLogout();
 
     //Open Live Contribution Page
-    $this->openCiviPage('contribute/transact', "reset=1&id=$pageId", '_qf_Main_upload-bottom');
+    $this->openCiviPage('contribute/transact', "reset=1&id=$pageId&action=preview", '_qf_Main_upload-bottom');
 
     $firstName = 'Ma' . substr(sha1(rand()), 0, 4);
     $lastName = 'An' . substr(sha1(rand()), 0, 7);
@@ -296,7 +296,7 @@ class WebTest_Campaign_OnlineContributionTest extends CiviSeleniumTestCase {
 
     //Find Contribution
     $this->openCiviPage("contribute/search", "reset=1", "contribution_date_low");
-
+    $this->click("xpath=//tr/td[1]/label[contains(text(), 'Contribution is a Test?')]/../../td[2]/label[contains(text(), 'Yes')]/preceding-sibling::input[1]");
     $this->type("sort_name", "$lastName $firstName");
     $this->clickLink("_qf_Search_refresh", "xpath=//div[@id='contributionSearch']//table//tbody/tr[1]/td[11]/span/a[text()='View']");
     $this->clickLink("xpath=//div[@id='contributionSearch']//table//tbody/tr[1]/td[11]/span/a[text()='View']", "_qf_ContributionView_cancel-bottom", FALSE);

--- a/tests/phpunit/WebTest/Contribute/AddPricesetTest.php
+++ b/tests/phpunit/WebTest/Contribute/AddPricesetTest.php
@@ -374,7 +374,7 @@ class WebTest_Contribute_AddPricesetTest extends CiviSeleniumTestCase {
     $this->webtestLogout();
 
     //Open Live Contribution Page
-    $this->openCiviPage('contribute/transact', "reset=1&id=$pageId", '_qf_Main_upload-bottom');
+    $this->openCiviPage('contribute/transact', "reset=1&id=$pageId&action=preview", '_qf_Main_upload-bottom');
 
     $firstName = 'Ma' . substr(sha1(rand()), 0, 4);
     $lastName = 'An' . substr(sha1(rand()), 0, 7);
@@ -419,6 +419,7 @@ class WebTest_Contribute_AddPricesetTest extends CiviSeleniumTestCase {
     //Find Contribution
     $this->openCiviPage("contribute/search", "reset=1", 'contribution_date_low');
 
+    $this->click("xpath=//tr/td[1]/label[contains(text(), 'Contribution is a Test?')]/../../td[2]/label[contains(text(), 'Yes')]/preceding-sibling::input[1]");
     $this->type('sort_name', "$lastName $firstName");
     $this->clickLink('_qf_Search_refresh', "xpath=//div[@id='contributionSearch']//table//tbody/tr[1]/td[11]/span/a[text()='View']");
     $this->clickLink("xpath=//div[@id='contributionSearch']//table//tbody/tr[1]/td[11]/span/a[text()='View']", "_qf_ContributionView_cancel-bottom", FALSE);
@@ -495,7 +496,7 @@ class WebTest_Contribute_AddPricesetTest extends CiviSeleniumTestCase {
     $this->webtestLogout();
 
     //Open Live Contribution Page
-    $this->openCiviPage('contribute/transact', "reset=1&id=$pageId", '_qf_Main_upload-bottom');
+    $this->openCiviPage('contribute/transact', "reset=1&id=$pageId&action=preview", '_qf_Main_upload-bottom');
 
     $firstName = 'Ma' . substr(sha1(rand()), 0, 4);
     $lastName = 'An' . substr(sha1(rand()), 0, 7);
@@ -536,7 +537,7 @@ class WebTest_Contribute_AddPricesetTest extends CiviSeleniumTestCase {
 
     //Find Contribution
     $this->openCiviPage("contribute/search", "reset=1", 'contribution_date_low');
-
+    $this->click("xpath=//tr/td[1]/label[contains(text(), 'Contribution is a Test?')]/../../td[2]/label[contains(text(), 'Yes')]/preceding-sibling::input[1]");
     $this->type('sort_name', "$lastName $firstName");
     $this->clickLink('_qf_Search_refresh', "xpath=//div[@id='contributionSearch']//table//tbody/tr[1]/td[11]/span/a[text()='View']", FALSE);
     $this->clickLink("xpath=//div[@id='contributionSearch']//table//tbody/tr[1]/td[11]/span/a[text()='View']", '_qf_ContributionView_cancel-bottom', FALSE);

--- a/tests/phpunit/WebTest/Contribute/ConfirmOptionalTest.php
+++ b/tests/phpunit/WebTest/Contribute/ConfirmOptionalTest.php
@@ -98,7 +98,7 @@ class WebTest_Contribute_ConfirmOptionalTest extends CiviSeleniumTestCase {
 
   protected function _fillOutContributionPage() {
     // load contribution page
-    $this->openCiviPage("contribute/transact", "reset=1&id={$this->pageId}", "_qf_Main_upload-bottom");
+    $this->openCiviPage("contribute/transact", "reset=1&id={$this->pageId}&action=preview", "_qf_Main_upload-bottom");
 
     // fill out info
     $this->type("xpath=//div[@class='crm-section other_amount-section']//div[2]/input", "30");

--- a/tests/phpunit/WebTest/Contribute/OnlineContributionTest.php
+++ b/tests/phpunit/WebTest/Contribute/OnlineContributionTest.php
@@ -83,7 +83,7 @@ class WebTest_Contribute_OnlineContributionTest extends CiviSeleniumTestCase {
     $this->webtestLogout();
 
     //Open Live Contribution Page
-    $this->openCiviPage("contribute/transact", "reset=1&id=$pageId", "_qf_Main_upload-bottom");
+    $this->openCiviPage("contribute/transact", "reset=1&id=$pageId&action=preview", "_qf_Main_upload-bottom");
 
     $firstName = 'Ma' . substr(sha1(rand()), 0, 4);
     $lastName = 'An' . substr(sha1(rand()), 0, 7);
@@ -107,9 +107,8 @@ class WebTest_Contribute_OnlineContributionTest extends CiviSeleniumTestCase {
     $this->type("postal_code-1", "94117");
     $this->select("country-1", "value=1228");
     $this->select("state_province-1", "value=1001");
-
     // Honoree Info
-    $this->click("xpath=id('Main')/div[2]/fieldset/div[2]/div/label[text()='In Honor of']");
+    $this->click("xpath=id('Main')/div[3]/fieldset/div[2]/div/label[text()='In Honor of']");
 
     $this->select("honor[prefix_id]", "label=Ms.");
     $this->type("honor[first_name]", $honorFirstName);
@@ -143,8 +142,8 @@ class WebTest_Contribute_OnlineContributionTest extends CiviSeleniumTestCase {
 
     //Find Contribution
     $this->openCiviPage("contribute/search", "reset=1", "contribution_date_low");
-
     $this->type("sort_name", "$lastName $firstName");
+    $this->click("xpath=//tr/td[1]/label[contains(text(), 'Contribution is a Test?')]/../../td[2]/label[contains(text(), 'Yes')]/preceding-sibling::input[1]");
     $this->clickLink("_qf_Search_refresh", "xpath=//div[@id='contributionSearch']//table//tbody/tr[1]/td[11]/span/a[text()='View']");
     $this->clickLink("xpath=//div[@id='contributionSearch']//table//tbody/tr[1]/td[11]/span/a[text()='View']", "_qf_ContributionView_cancel-bottom", FALSE);
 
@@ -156,7 +155,6 @@ class WebTest_Contribute_OnlineContributionTest extends CiviSeleniumTestCase {
       'Contribution Status' => 'Completed',
     );
     $this->webtestVerifyTabularData($expected);
-
     //View Soft Credit record of type 'Honor of'
     $this->waitForTextPresent($honorDisplayName);
     $this->waitForTextPresent('100.00 (In Honor of)');
@@ -266,7 +264,7 @@ class WebTest_Contribute_OnlineContributionTest extends CiviSeleniumTestCase {
     $amountLabel = 'Total Amount';
     $amountValue = '0.00';
     //Open Live Contribution Page
-    $this->openCiviPage("contribute/transact", "reset=1&id=$pageId", "_qf_Main_upload-bottom");
+    $this->openCiviPage("contribute/transact", "reset=1&id=$pageId&action=preview", "_qf_Main_upload-bottom");
 
     $firstName = 'Ma' . substr(sha1(rand()), 0, 4);
     $lastName = 'An' . substr(sha1(rand()), 0, 7);
@@ -325,7 +323,7 @@ class WebTest_Contribute_OnlineContributionTest extends CiviSeleniumTestCase {
     $this->webtestLogout();
 
     //Open Live Contribution Page
-    $this->openCiviPage("contribute/transact", "reset=1&id=$pageId", "_qf_Main_upload-bottom");
+    $this->openCiviPage("contribute/transact", "reset=1&id=$pageId&action=preview", "_qf_Main_upload-bottom");
     $firstName = 'Ma' . substr(sha1(rand()), 0, 4);
     $lastName = 'An' . substr(sha1(rand()), 0, 7);
     $this->type("email-5", $firstName . "@example.com");
@@ -365,6 +363,7 @@ class WebTest_Contribute_OnlineContributionTest extends CiviSeleniumTestCase {
     $this->openCiviPage("contribute/search", "reset=1", "contribution_date_low");
 
     $this->type("sort_name", "$lastName $firstName");
+    $this->click("xpath=//tr/td[1]/label[contains(text(), 'Contribution is a Test?')]/../../td[2]/label[contains(text(), 'Yes')]/preceding-sibling::input[1]");
     $this->clickLink("_qf_Search_refresh", "xpath=//div[@id='contributionSearch']//table//tbody/tr[1]/td[11]/span/a[text()='View']");
     $this->clickLink("xpath=//div[@id='contributionSearch']//table//tbody/tr[1]/td[11]/span/a[text()='View']", "_qf_ContributionView_cancel-bottom", FALSE);
 
@@ -427,7 +426,7 @@ class WebTest_Contribute_OnlineContributionTest extends CiviSeleniumTestCase {
     $this->webtestLogout();
 
     //Open Live Contribution Page
-    $this->openCiviPage("contribute/transact", "reset=1&id=$pageId", "_qf_Main_upload-bottom");
+    $this->openCiviPage("contribute/transact", "reset=1&id=$pageId&action=preview", "_qf_Main_upload-bottom");
 
     $firstName = 'Ma' . substr(sha1(rand()), 0, 4);
     $lastName = 'An' . substr(sha1(rand()), 0, 7);
@@ -477,7 +476,7 @@ class WebTest_Contribute_OnlineContributionTest extends CiviSeleniumTestCase {
 
     //Find Contribution
     $this->openCiviPage("contribute/search", "reset=1", "contribution_date_low");
-
+    $this->click("xpath=//tr/td[1]/label[contains(text(), 'Contribution is a Test?')]/../../td[2]/label[contains(text(), 'Yes')]/preceding-sibling::input[1]");
     $this->type("sort_name", "$lastName $firstName");
     $this->multiselect2('contribution_product_id', array('Coffee Mug'));
     $this->click("_qf_Search_refresh");

--- a/tests/phpunit/WebTest/Contribute/OnlineContributionTest.php
+++ b/tests/phpunit/WebTest/Contribute/OnlineContributionTest.php
@@ -377,8 +377,8 @@ class WebTest_Contribute_OnlineContributionTest extends CiviSeleniumTestCase {
     $this->webtestVerifyTabularData($expected);
   }
 
-  //CRM-16713: Contribution search by premiums on find contribution form.
   public function testOnlineContributionWithPremium() {
+    //CRM-16713: Contribution search by premiums on find contribution form.
     $this->webtestLogin();
 
     // Use default payment processor

--- a/tests/phpunit/WebTest/Contribute/UpdatePendingContributionTest.php
+++ b/tests/phpunit/WebTest/Contribute/UpdatePendingContributionTest.php
@@ -44,7 +44,7 @@ class WebTest_Contribute_UpdatePendingContributionTest extends CiviSeleniumTestC
     //Online Pay Later Contribution
     $this->_testOnlineContribution($contact);
     $this->openCiviPage("contribute/search", "reset=1", "contribution_date_low");
-
+    $this->click("xpath=//tr/td[1]/label[contains(text(), 'Contribution is a Test?')]/../../td[2]/label[contains(text(), 'Yes')]/preceding-sibling::input[1]");
     $this->type("sort_name", $contact['sort_name']);
     $this->click("_qf_Search_refresh");
 
@@ -228,7 +228,7 @@ class WebTest_Contribute_UpdatePendingContributionTest extends CiviSeleniumTestC
 
     //logout
     $this->webtestLogout();
-    $this->openCiviPage("contribute/transact", "reset=1&id=$pageId", "_qf_Main_upload-bottom");
+    $this->openCiviPage("contribute/transact", "reset=1&id=$pageId&action=preview", "_qf_Main_upload-bottom");
 
     $this->type("email-5", $contact['email']);
 
@@ -255,7 +255,7 @@ class WebTest_Contribute_UpdatePendingContributionTest extends CiviSeleniumTestC
 
     //Find Contribution
     $this->openCiviPage("contribute/search", "reset=1", "contribution_date_low");
-
+    $this->click("xpath=//tr/td[1]/label[contains(text(), 'Contribution is a Test?')]/../../td[2]/label[contains(text(), 'Yes')]/preceding-sibling::input[1]");
     $this->type("sort_name", $contact['sort_name']);
     $this->clickLink("_qf_Search_refresh", "xpath=//div[@id='contributionSearch']//table//tbody/tr[2]/td[11]/span/a[text()='View']");
     $this->clickLink("xpath=//div[@id='contributionSearch']//table//tbody/tr[2]/td[11]/span/a[text()='View']", "_qf_ContributionView_cancel-bottom", FALSE);

--- a/tests/phpunit/WebTest/Event/AddEventTest.php
+++ b/tests/phpunit/WebTest/Event/AddEventTest.php
@@ -947,7 +947,7 @@ WHERE ceft.entity_id = %1 AND ceft.entity_table = 'civicrm_contribution'";
     $this->webtestAddContact($firstName, 'Anderson', TRUE);
     $contactName = "Anderson, $firstName";
     $displayName = "$firstName Anderson";
-    $this->openCiviPage("event/register", "reset=1&id=$id", '_qf_Register_upload-bottom');
+    $this->openCiviPage("event/register", "reset=1&id=$id&action=preview", '_qf_Register_upload-bottom');
     $this->type('first_name', $firstName);
 
     //fill in last name

--- a/tests/phpunit/WebTest/Event/MultiprofileEventTest.php
+++ b/tests/phpunit/WebTest/Event/MultiprofileEventTest.php
@@ -91,6 +91,7 @@ class WebTest_Event_MultiprofileEventTest extends CiviSeleniumTestCase {
     // Find Main Participant
     $this->openCiviPage("event/search", "reset=1");
     $this->type("sort_name", $firstName);
+    $this->click("xpath=//tr/td[1]/label[contains(text(), 'Participant is a Test?')]/../label[contains(text(), 'Yes')]/preceding-sibling::input[1]");
     $this->clickLink("_qf_Search_refresh", "xpath=//div[@id='participantSearch']//table//tbody/tr[1]/td[11]/span/a[text()='View']");
     $this->clickLink("xpath=//div[@id='participantSearch']//table//tbody/tr[1]/td[11]/span/a[text()='View']", "_qf_ParticipantView_cancel-top", FALSE);
 
@@ -104,6 +105,7 @@ class WebTest_Event_MultiprofileEventTest extends CiviSeleniumTestCase {
     // Find additional  Participant
     $this->openCiviPage("event/search", "reset=1");
     $this->type("sort_name", $participantfname);
+    $this->click("xpath=//tr/td[1]/label[contains(text(), 'Participant is a Test?')]/../label[contains(text(), 'Yes')]/preceding-sibling::input[1]");
     $this->clickLink("_qf_Search_refresh", "xpath=//div[@id='participantSearch']//table//tbody/tr[1]/td[11]/span/a[text()='View']");
     $this->clickLink("xpath=//div[@id='participantSearch']//table//tbody/tr[1]/td[11]/span/a[text()='View']", "_qf_ParticipantView_cancel-top", FALSE);
 
@@ -194,6 +196,7 @@ class WebTest_Event_MultiprofileEventTest extends CiviSeleniumTestCase {
     // Find Main Participant
     $this->openCiviPage("event/search", "reset=1");
     $this->type("sort_name", $firstName);
+    $this->click("xpath=//tr/td[1]/label[contains(text(), 'Participant is a Test?')]/../label[contains(text(), 'Yes')]/preceding-sibling::input[1]");
     $this->clickLink("_qf_Search_refresh", "xpath=//div[@id='participantSearch']//table//tbody/tr[1]/td[11]/span/a[text()='View']");
     $this->clickLink("xpath=//div[@id='participantSearch']//table//tbody/tr[1]/td[11]/span/a[text()='View']", "_qf_ParticipantView_cancel-top", FALSE);
 
@@ -207,6 +210,7 @@ class WebTest_Event_MultiprofileEventTest extends CiviSeleniumTestCase {
     // Find additional  Participant
     $this->openCiviPage("event/search", "reset=1");
     $this->type("sort_name", $participantfname);
+    $this->click("xpath=//tr/td[1]/label[contains(text(), 'Participant is a Test?')]/../label[contains(text(), 'Yes')]/preceding-sibling::input[1]");
     $this->clickLink("_qf_Search_refresh", "xpath=//div[@id='participantSearch']//table//tbody/tr[1]/td[11]/span/a[text()='View']");
     $this->clickLink("xpath=//div[@id='participantSearch']//table//tbody/tr[1]/td[11]/span/a[text()='View']", "_qf_ParticipantView_cancel-top", FALSE);
 
@@ -232,6 +236,7 @@ class WebTest_Event_MultiprofileEventTest extends CiviSeleniumTestCase {
     // Find Main Participant
     $this->openCiviPage('event/search', "reset=1");
     $this->type("sort_name", $firstName2);
+    $this->click("xpath=//tr/td[1]/label[contains(text(), 'Participant is a Test?')]/../label[contains(text(), 'Yes')]/preceding-sibling::input[1]");
     $this->clickLink("_qf_Search_refresh", "xpath=//div[@id='participantSearch']//table//tbody/tr[1]/td[11]/span/a[text()='View']");
     $this->clickLink("xpath=//div[@id='participantSearch']//table//tbody/tr[1]/td[11]/span/a[text()='View']", "_qf_ParticipantView_cancel-top", FALSE);
 
@@ -245,6 +250,7 @@ class WebTest_Event_MultiprofileEventTest extends CiviSeleniumTestCase {
     // Find additional  Participant
     $this->openCiviPage("event/search", "reset=1");
     $this->type("sort_name", $participantfname2);
+    $this->click("xpath=//tr/td[1]/label[contains(text(), 'Participant is a Test?')]/../label[contains(text(), 'Yes')]/preceding-sibling::input[1]");
     $this->clickLink("_qf_Search_refresh", "xpath=//div[@id='participantSearch']//table//tbody/tr[1]/td[11]/span/a[text()='View']");
     $this->clickLink("xpath=//div[@id='participantSearch']//table//tbody/tr[1]/td[11]/span/a[text()='View']", "_qf_ParticipantView_cancel-top", FALSE);
 
@@ -646,7 +652,8 @@ class WebTest_Event_MultiprofileEventTest extends CiviSeleniumTestCase {
     $eventPageId, $customId, $firstName, $lastName,
     $participantfname, $participantlname, $email1, $email2
   ) {
-    $this->openCiviPage("event/register", "id={$eventPageId}&reset=1", "_qf_Register_upload-bottom");
+    $this->openCiviPage("event/register", "id={$eventPageId}&reset=1&action=preview", "_qf_Register_upload-bottom");
+    $this->waitForElementPresent("_qf_Register_upload-bottom");
     $this->select("additional_participants", "value=1");
 
     $this->type("email-Primary", $email1);
@@ -673,6 +680,7 @@ class WebTest_Event_MultiprofileEventTest extends CiviSeleniumTestCase {
     $this->select("billing_state_province_id-5", "value=1004");
     $this->type("billing_postal_code-5", "94129");
 
+    $this->waitForElementPresent("current_employer");
     $this->type("current_employer", "ABCD");
     $this->type("job_title", "Painter");
     $this->waitForElementPresent('nick_name');
@@ -696,7 +704,6 @@ class WebTest_Event_MultiprofileEventTest extends CiviSeleniumTestCase {
 
     $this->click("_qf_Register_upload-bottom");
     $this->waitForElementPresent("_qf_Participant_1_next-Array");
-
     $this->type("email-Primary", $email2);
     $this->type("first_name", $participantfname);
     $this->type("last_name", $participantlname);
@@ -705,6 +712,7 @@ class WebTest_Event_MultiprofileEventTest extends CiviSeleniumTestCase {
     $this->type("postal_code-1", "2354");
     $this->select("state_province-1", "value=1001");
 
+    $this->waitForElementPresent("current_employer");
     $this->type("current_employer", "ABCD");
     $this->type("job_title", "Potato picker");
 
@@ -737,7 +745,7 @@ class WebTest_Event_MultiprofileEventTest extends CiviSeleniumTestCase {
    * @param $email4
    */
   public function _testEventRegistrationAfterRemoving($eventPageId, $customId, $firstName2, $lastName2, $participantfname2, $participantlname2, $email3, $email4) {
-    $this->openCiviPage("event/register", "id={$eventPageId}&reset=1", "_qf_Register_upload-bottom");
+    $this->openCiviPage("event/register", "id={$eventPageId}&reset=1&action=preview", "_qf_Register_upload-bottom");
     $this->select("additional_participants", "value=1");
 
     $this->type("email-Primary", $email4);

--- a/tests/phpunit/WebTest/Member/DefaultMembershipPricesetTest.php
+++ b/tests/phpunit/WebTest/Member/DefaultMembershipPricesetTest.php
@@ -81,7 +81,7 @@ class WebTest_Member_DefaultMembershipPricesetTest extends CiviSeleniumTestCase 
     $this->assertType('numeric', $cid);
 
     //senario 1
-    $this->openCiviPage("contribute/transact", "reset=1&id={$membershipContributionPageId}&cid={$cid}", "_qf_Main_upload-bottom");
+    $this->openCiviPage("contribute/transact", "reset=1&id={$membershipContributionPageId}&cid={$cid}&action=preview", "_qf_Main_upload-bottom");
 
     $this->_testDefaultSenarios("National_Membership_{$title}-section", 2);
     $this->contactInfoFill($firstName, $lastName, $email, $contactParams, $streetAddress);
@@ -90,7 +90,7 @@ class WebTest_Member_DefaultMembershipPricesetTest extends CiviSeleniumTestCase 
     $this->waitForPageToLoad($this->getTimeoutMsec());
 
     //senario 2
-    $this->openCiviPage("contribute/transact", "reset=1&id={$membershipContributionPageId}&cid={$cid}", "_qf_Main_upload-bottom");
+    $this->openCiviPage("contribute/transact", "reset=1&id={$membershipContributionPageId}&cid={$cid}&action=preview", "_qf_Main_upload-bottom");
     // checking
     $this->checkOptions("National_Membership_{$title}-section", 2);
     // senario 1
@@ -102,7 +102,7 @@ class WebTest_Member_DefaultMembershipPricesetTest extends CiviSeleniumTestCase 
     $this->waitForPageToLoad($this->getTimeoutMsec());
 
     //senario 3
-    $this->openCiviPage("contribute/transact", "reset=1&id={$membershipContributionPageId}&cid={$cid}", "_qf_Main_upload-bottom");
+    $this->openCiviPage("contribute/transact", "reset=1&id={$membershipContributionPageId}&cid={$cid}&action=preview", "_qf_Main_upload-bottom");
     // checking
     $this->checkOptions("Second_Membership_{$title}-section", 2);
     // senario 2
@@ -114,7 +114,7 @@ class WebTest_Member_DefaultMembershipPricesetTest extends CiviSeleniumTestCase 
     $this->waitForPageToLoad($this->getTimeoutMsec());
 
     //senario 4
-    $this->openCiviPage("contribute/transact", "reset=1&id={$membershipContributionPageId}&cid={$cid}", "_qf_Main_upload-bottom");
+    $this->openCiviPage("contribute/transact", "reset=1&id={$membershipContributionPageId}&cid={$cid}&action=preview", "_qf_Main_upload-bottom");
     // checking senario 3
     $this->assertTrue($this->isTextPresent("You have a current Lifetime Membership which does not need to be renewed."));
 

--- a/tests/phpunit/WebTest/Member/OnlineMembershipCreateTest.php
+++ b/tests/phpunit/WebTest/Member/OnlineMembershipCreateTest.php
@@ -192,7 +192,7 @@ class WebTest_Member_OnlineMembershipCreateTest extends CiviSeleniumTestCase {
     $this->openCiviPage("member/search", "reset=1", "member_end_date_high");
 
     $this->type("sort_name", "$lastName $firstName");
-    $this->click("xpath=//tr/td[1]/p/label[contains(text(),'Membership is a Test?')]/../label[contains(text(),'Yes')]/preceding-sibling::input[1]");    
+    $this->click("xpath=//tr/td[1]/p/label[contains(text(),'Membership is a Test?')]/../label[contains(text(),'Yes')]/preceding-sibling::input[1]");
     $this->click("_qf_Search_refresh");
 
     $this->waitForPageToLoad($this->getTimeoutMsec());

--- a/tests/phpunit/WebTest/Member/OnlineMembershipCreateTest.php
+++ b/tests/phpunit/WebTest/Member/OnlineMembershipCreateTest.php
@@ -124,7 +124,7 @@ class WebTest_Member_OnlineMembershipCreateTest extends CiviSeleniumTestCase {
 
     //Find Member
     $this->openCiviPage("member/search", "reset=1", "member_end_date_high");
-
+    $this->click("xpath=//tr/td[1]/p/label[contains(text(),'Membership is a Test?')]/../label[contains(text(),'Yes')]/preceding-sibling::input[1]");
     $this->type("sort_name", "$lastName $firstName");
     $this->clickLink("_qf_Search_refresh", "xpath=//div[@id='memberSearch']/table/tbody/tr");
     $this->click("xpath=//div[@id='memberSearch']/table/tbody/tr/td[11]/span/a[text()='View']");
@@ -192,6 +192,7 @@ class WebTest_Member_OnlineMembershipCreateTest extends CiviSeleniumTestCase {
     $this->openCiviPage("member/search", "reset=1", "member_end_date_high");
 
     $this->type("sort_name", "$lastName $firstName");
+    $this->click("xpath=//tr/td[1]/p/label[contains(text(),'Membership is a Test?')]/../label[contains(text(),'Yes')]/preceding-sibling::input[1]");    
     $this->click("_qf_Search_refresh");
 
     $this->waitForPageToLoad($this->getTimeoutMsec());
@@ -209,7 +210,7 @@ class WebTest_Member_OnlineMembershipCreateTest extends CiviSeleniumTestCase {
    */
   public function _testOnlineMembershipSignup($pageId, $memTypeId, $firstName, $lastName, $payLater, $hash, $otherAmount = FALSE, $amountSection = TRUE) {
     //Open Live Contribution Page
-    $this->openCiviPage("contribute/transact", "reset=1&id=$pageId", "_qf_Main_upload-bottom");
+    $this->openCiviPage("contribute/transact", "reset=1&id=$pageId&action=preview", "_qf_Main_upload-bottom");
     // Select membership type 1
     $this->waitForElementPresent("xpath=//div[@class='crm-section membership_amount-section']/div[2]//span/label");
     if ($memTypeId != 'No thank you') {
@@ -337,6 +338,7 @@ class WebTest_Member_OnlineMembershipCreateTest extends CiviSeleniumTestCase {
     $this->openCiviPage("contribute/search", "reset=1", "contribution_date_low");
 
     $this->type("sort_name", "$lastName $firstName");
+    $this->click("xpath=//tr/td[1]/label[contains(text(), 'Contribution is a Test?')]/../../td[2]/label[contains(text(), 'Yes')]/preceding-sibling::input[1]");
     $this->clickLink("_qf_Search_refresh", "xpath=//div[@id='contributionSearch']//table//tbody/tr[1]/td[11]/span/a[text()='View']");
     $this->clickLink("xpath=//div[@id='contributionSearch']//table//tbody/tr[1]/td[11]/span/a[text()='View']", "_qf_ContributionView_cancel-bottom", FALSE);
 

--- a/tests/phpunit/WebTest/Member/OnlineMembershipRenewTest.php
+++ b/tests/phpunit/WebTest/Member/OnlineMembershipRenewTest.php
@@ -99,7 +99,7 @@ class WebTest_Member_OnlineMembershipRenewTest extends CiviSeleniumTestCase {
     $this->webtestLogout();
 
     //Go to online membership signup page
-    $this->openCiviPage("contribute/transact", "reset=1&id=2", "_qf_Main_upload-bottom");
+    $this->openCiviPage("contribute/transact", "reset=1&id=2&action=preview", "_qf_Main_upload-bottom");
 
     $this->click("xpath=//div[@class='crm-section membership_amount-section']/div[2]/div[2]/span/label/span[1][contains(text(),'Student')]");
 
@@ -136,6 +136,7 @@ class WebTest_Member_OnlineMembershipRenewTest extends CiviSeleniumTestCase {
     $this->openCiviPage("member/search", "reset=1", "member_end_date_high");
 
     $this->type("sort_name", "$lastName $firstName");
+    $this->click("xpath=//tr/td[1]/p/label[contains(text(),'Membership is a Test?')]/../label[contains(text(),'Yes')]/preceding-sibling::input[1]");
     $this->clickLink("_qf_Search_refresh", 'css=#memberSearch table tbody tr td span a.action-item:first-child');
     $this->click('css=#memberSearch table tbody tr td span a.action-item:first-child');
     $this->waitForElementPresent("_qf_MembershipView_cancel-bottom");
@@ -156,7 +157,7 @@ class WebTest_Member_OnlineMembershipRenewTest extends CiviSeleniumTestCase {
     //logout
     $this->webtestLogout();
 
-    $this->openCiviPage("contribute/transact", "reset=1&id=2", "_qf_Main_upload-bottom");
+    $this->openCiviPage("contribute/transact", "reset=1&id=2&action=preview", "_qf_Main_upload-bottom");
 
     $this->click("xpath=//div[@class='crm-section membership_amount-section']/div[2]/div[2]/span/label/span[1][contains(text(),'Student')]");
 
@@ -191,6 +192,7 @@ class WebTest_Member_OnlineMembershipRenewTest extends CiviSeleniumTestCase {
     $this->openCiviPage("member/search", "reset=1", "member_end_date_high");
 
     $this->type("sort_name", "$lastName $firstName");
+    $this->click("xpath=//tr/td[1]/p/label[contains(text(),'Membership is a Test?')]/../label[contains(text(),'Yes')]/preceding-sibling::input[1]");
     $this->clickLink("_qf_Search_refresh", 'css=#memberSearch table tbody tr td span a.action-item:first-child');
     $this->click('css=#memberSearch table tbody tr td span a.action-item:first-child');
     $this->waitForElementPresent("_qf_MembershipView_cancel-bottom");
@@ -269,7 +271,7 @@ class WebTest_Member_OnlineMembershipRenewTest extends CiviSeleniumTestCase {
     $lastName = 'An' . substr(sha1(rand()), 0, 7);
 
     //Go to online membership signup page
-    $this->openCiviPage("contribute/transact", "reset=1&id=2", "_qf_Main_upload-bottom");
+    $this->openCiviPage("contribute/transact", "reset=1&id=2&action=preview", "_qf_Main_upload-bottom");
     $this->click("xpath=//div[@class='crm-section membership_amount-section']/div[2]/div[1]/span/label/span[1][contains(text(),'General')]");
     //Type first name and last name
     $this->type("first_name", $firstName);
@@ -301,6 +303,7 @@ class WebTest_Member_OnlineMembershipRenewTest extends CiviSeleniumTestCase {
     $this->openCiviPage("member/search", "reset=1", "member_end_date_high");
 
     $this->type("sort_name", "$lastName $firstName");
+    $this->click("xpath=//tr/td[1]/p/label[contains(text(),'Membership is a Test?')]/../label[contains(text(),'Yes')]/preceding-sibling::input[1]");
     $this->clickLink("_qf_Search_refresh", 'css=#memberSearch table tbody tr td span a.action-item:first-child');
     $this->click('css=#memberSearch table tbody tr td span a.action-item:first-child');
     $this->waitForElementPresent("_qf_MembershipView_cancel-bottom");
@@ -321,7 +324,7 @@ class WebTest_Member_OnlineMembershipRenewTest extends CiviSeleniumTestCase {
         preg_quote($value)
       );
     }
-    $this->openCiviPage("contribute/transact", "reset=1&id=2", "_qf_Main_upload-bottom");
+    $this->openCiviPage("contribute/transact", "reset=1&id=2&action=preview", "_qf_Main_upload-bottom");
     $this->click("xpath=//div[@class='crm-section membership_amount-section']/div[2]/div[2]/span/label/span[1][contains(text(),'Student')]");
 
     //Credit Card Info
@@ -338,6 +341,7 @@ class WebTest_Member_OnlineMembershipRenewTest extends CiviSeleniumTestCase {
     $this->openCiviPage("member/search", "reset=1", "member_end_date_high");
 
     $this->type("sort_name", "$lastName $firstName");
+    $this->click("xpath=//tr/td[1]/p/label[contains(text(),'Membership is a Test?')]/../label[contains(text(),'Yes')]/preceding-sibling::input[1]");
     $this->clickLink("_qf_Search_refresh", 'css=#memberSearch table tbody tr td span a.action-item:first-child');
     $this->click('css=#memberSearch table tbody tr td span a.action-item:first-child');
     $this->waitForElementPresent("_qf_MembershipView_cancel-bottom");
@@ -478,7 +482,7 @@ class WebTest_Member_OnlineMembershipRenewTest extends CiviSeleniumTestCase {
     $this->webtestLogout();
 
     //get Url for Live Contribution Page
-    $this->openCiviPage("contribute/transact", "reset=1&id=$pageId", '_qf_Main_upload-bottom');
+    $this->openCiviPage("contribute/transact", "reset=1&id=$pageId&action=preview", '_qf_Main_upload-bottom');
     $this->click("xpath=//div[@class='crm-section membership_amount-section']/div[2]/div/span/label/span[1][contains(text(),'$membershipTypeTitle')]");
     $firstName = 'Eia' . substr(sha1(rand()), 0, 4);
     $lastName = 'Ande' . substr(sha1(rand()), 0, 4);
@@ -530,6 +534,7 @@ class WebTest_Member_OnlineMembershipRenewTest extends CiviSeleniumTestCase {
     $this->openCiviPage("member/search", "reset=1", "member_end_date_high");
 
     $this->type("sort_name", "$organisationName");
+    $this->click("xpath=//tr/td[1]/p/label[contains(text(),'Membership is a Test?')]/../label[contains(text(),'Yes')]/preceding-sibling::input[1]");
     $this->clickLink("_qf_Search_refresh", 'css=#memberSearch table tbody tr td span a.action-item:first-child');
     $this->click('css=#memberSearch table tbody tr td span a.action-item:first-child');
     $this->waitForElementPresent("_qf_MembershipView_cancel-bottom");
@@ -551,6 +556,7 @@ class WebTest_Member_OnlineMembershipRenewTest extends CiviSeleniumTestCase {
     $this->openCiviPage("member/search", "reset=1", "member_end_date_high");
 
     $this->type("sort_name", "$lastName, $firstName");
+    $this->click("xpath=//tr/td[1]/p/label[contains(text(),'Membership is a Test?')]/../label[contains(text(),'Yes')]/preceding-sibling::input[1]");
     $this->clickLink("_qf_Search_refresh", 'css=#memberSearch table tbody tr td span a.action-item:first-child');
     $this->click('css=#memberSearch table tbody tr td span a.action-item:first-child');
     $this->waitForElementPresent("_qf_MembershipView_cancel-bottom");
@@ -572,7 +578,7 @@ class WebTest_Member_OnlineMembershipRenewTest extends CiviSeleniumTestCase {
     //logout
     $this->webtestLogout();
 
-    $this->openCiviPage("contribute/transact", "reset=1&id=$pageId", "_qf_Main_upload-bottom");
+    $this->openCiviPage("contribute/transact", "reset=1&id=$pageId&action=preview", "_qf_Main_upload-bottom");
 
     $this->click("xpath=//div[@class='crm-section membership_amount-section']/div[2]/div/span/label/span[1][contains(text(),'$membershipTypeTitle')]");
     $this->type("email-5", $email);
@@ -620,6 +626,7 @@ class WebTest_Member_OnlineMembershipRenewTest extends CiviSeleniumTestCase {
     $this->openCiviPage("member/search", "reset=1", "member_end_date_high");
 
     $this->type("sort_name", "$organisationName");
+    $this->click("xpath=//tr/td[1]/p/label[contains(text(),'Membership is a Test?')]/../label[contains(text(),'Yes')]/preceding-sibling::input[1]");
     $this->clickLink("_qf_Search_refresh", 'css=#memberSearch table tbody tr td span a.action-item:first-child');
     $this->click('css=#memberSearch table tbody tr td span a.action-item:first-child');
     $this->waitForElementPresent("_qf_MembershipView_cancel-bottom");
@@ -640,6 +647,7 @@ class WebTest_Member_OnlineMembershipRenewTest extends CiviSeleniumTestCase {
     $this->openCiviPage("member/search", "reset=1", "member_end_date_high");
 
     $this->type("sort_name", "$lastName, $firstName");
+    $this->click("xpath=//tr/td[1]/p/label[contains(text(),'Membership is a Test?')]/../label[contains(text(),'Yes')]/preceding-sibling::input[1]");
     $this->clickLink("_qf_Search_refresh", 'css=#memberSearch table tbody tr td span a.action-item:first-child');
     $this->click('css=#memberSearch table tbody tr td span a.action-item:first-child');
     $this->waitForElementPresent("_qf_MembershipView_cancel-bottom");
@@ -822,7 +830,7 @@ class WebTest_Member_OnlineMembershipRenewTest extends CiviSeleniumTestCase {
     $lastName = 'Ande' . substr(sha1(rand()), 0, 4);
     $email = $firstName . '@test.com';
 
-    $this->openCiviPage("contribute/transact", "reset=1&id=$pageId", "_qf_Main_upload-bottom");
+    $this->openCiviPage("contribute/transact", "reset=1&id=$pageId&action=preview", "_qf_Main_upload-bottom");
 
     $this->click("xpath=//div[@class='crm-section membership_amount-section']/div[2]/div/span/label/span[1][contains(text(),'$membershipTypeTitle')]");
     $this->waitForElementPresent("auto_renew");
@@ -901,7 +909,7 @@ class WebTest_Member_OnlineMembershipRenewTest extends CiviSeleniumTestCase {
     $this->click('is_recur');//disable recurring contribution
     $this->clickLink('_qf_Amount_next', '_qf_Amount_next-bottom');
 
-    $this->openCiviPage("contribute/transact", "reset=1&id=$pageId", "_qf_Main_upload-bottom");
+    $this->openCiviPage("contribute/transact", "reset=1&id=$pageId&action=preview", "_qf_Main_upload-bottom");
     $this->click("xpath=//div[@class='crm-section membership_amount-section']/div[2]/div/span/label/span[1][contains(text(),'$membershipTypeTitle')]");
     $this->type("xpath=//div[@class='content other_amount-content']/input[@type='text']", '30');
     $this->click("is_recur");


### PR DESCRIPTION
Fix for 
1.WebTest_Member_OnlineMembershipRenewTest::testOnlineMembershipRenewChangeType 
2. WebTest_Campaign_OnlineContributionTest::testCreateCampaign
3. WebTest_Contribute_ConfirmOptionalTest::testWithConfirm
4. WebTest_Contribute_ConfirmOptionalTest::testWithoutConfirm
5.WebTest_Member_OnlineMembershipRenewTest::testOnRecurringContributionAndMembershipRenewal
6.WebTest_Member_OnlineMembershipCreateTest::testOnlineMembershipCreateWithContribution
7.WebTest_Contribute_OnlineContributionTest::testOnlineContributionAdd
8.WebTest_Event_MultiprofileEventTest::testCreateEventRegisterPage
9.WebTest_Member_OnlineMembershipRenewTest::testOnlineMembershipRenew
10.WebTest_Event_AddEventTest::testEventApprovalRegistration
11.WebTest_Member_OnlineMembershipCreateTest::testOnlineMembershipCreateWithContribution
12.WebTest_Member_OnlineMembershipRenewTest::testUpdateInheritedMembershipOnBehalfOfRenewal
