### PR TITLE
CRM-16795 - Remove redundant css

### DIFF
--- a/templates/CRM/Core/Form/ShortCode.tpl
+++ b/templates/CRM/Core/Form/ShortCode.tpl
@@ -45,7 +45,6 @@
 {* Hack to prevent WP toolbars from popping up above the dialog *}
 {literal}<style type="text/css">
   #wpadminbar,
-  #adminmenuwrap,
   .wp-editor-expand #wp-content-editor-tools,
   .wp-editor-expand div.mce-toolbar-grp {
     z-index: 100 !important;


### PR DESCRIPTION
The adminmenuwrap was already dealt with in 469d8da

---
- CRM-16795: Popups obscured by wordpress admin bar
  https://issues.civicrm.org/jira/browse/CRM-16795
