### PR TITLE
Fix bug CRM-16824 Unrecognized date format in custom fields during im…

### DIFF
--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -260,6 +260,7 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Contribute_Import_Pa
     }
 
     $params = &$this->getActiveFieldParams();
+    $params['contact_type'] = 'Contribution';
     $formatted = array('version' => 3);
 
     // don't add to recent items, CRM-4399


### PR DESCRIPTION
…port of contributions

During import of contributions, the contact type was not explicely set, leading to
misrecognized contribution custom fields. This was fixed by comparing with the
pre-import (summary) function, and tested on a real import of contributions with custom
fields.
