### PR TITLE
CRM-16729 - Fix inline help to account for payment from a different c…

### DIFF
--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -277,12 +277,12 @@
         {if $emailExists and $outBound_option != 2 }
           <tr id="send-receipt" class="crm-membership-form-block-send_receipt">
             <td class="label">{$form.send_receipt.label}</td><td>{$form.send_receipt.html}<br />
-            <span class="description">{ts 1=$emailExists}Automatically email a membership confirmation and receipt to %1?{/ts}</span></td>
+            <span class="description">{ts 1=$emailExists}Automatically email a membership confirmation and receipt to %1 ?{/ts} {ts}OR if the payment is from a different contact, this email will only go to them.{/ts}</span></td>
           </tr>
           {elseif $context eq 'standalone' and $outBound_option != 2 }
           <tr id="email-receipt" style="display:none;">
             <td class="label">{$form.send_receipt.label}</td><td>{$form.send_receipt.html}<br />
-            <span class="description">{ts}Automatically email a membership confirmation and receipt to {/ts}<span id="email-address"></span>?</span></td>
+            <span class="description">{ts}Automatically email a membership confirmation and receipt to {/ts}<span id="email-address"></span>? {ts}OR if the payment is from a different contact, this email will only go to them.{/ts}</span></td>
           </tr>
         {/if}
         <tr id="fromEmail" style="display:none;">


### PR DESCRIPTION
…ontact scenario.

---
- CRM-16729: IHM : Wrong email on receipt help text when new membership is paid by a different contact
  https://issues.civicrm.org/jira/browse/CRM-16729
