### PR TITLE
CRM-16812 - prevent popup for custom search RUN link.

### DIFF
--- a/CRM/Admin/Page/Options.php
+++ b/CRM/Admin/Page/Options.php
@@ -210,6 +210,7 @@ class CRM_Admin_Page_Options extends CRM_Core_Page_Basic {
             'url' => 'civicrm/contact/search/custom',
             'qs' => 'reset=1&csid=%%value%%',
             'title' => ts('Run %1', array(1 => self::$_gName)),
+            'class' => 'no-popup',
           ),
         );
         self::$_links = $runLink + self::$_links;


### PR DESCRIPTION
---
- CRM-16812: CiviCRM » Administer CiviCRM » Option Groups  » <custom search> run yields no results
  https://issues.civicrm.org/jira/browse/CRM-16812
