### PR TITLE
Notice Fix on offline membership

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1702,7 +1702,7 @@ WHERE   id IN ( ' . implode(' , ', array_keys($membershipType)) . ' )';
         }
       }
       $statusMsg = implode('<br/>', $statusMsg);
-      if ($receiptSend && $mailSend) {
+      if ($receiptSend && !empty($mailSend)) {
         $statusMsg .= ' ' . ts('A membership confirmation and receipt has been sent to %1.', array(1 => $this->_contributorEmail));
       }
     }


### PR DESCRIPTION
Steps to replicate:

1) create offline membership.
2) save it. 

Following notice is displayed:
Notice: Undefined variable: mailSend in CRM_Member_Form_Membership->postProcess() 
(line 1705 of /home/web/gitcivi_4.6/civicrm/CRM/Member/Form/Membership.php).
