### PR TITLE
enforce enotice compliance on remaining tests

### DIFF
--- a/CRM/Extension/Container/Collection.php
+++ b/CRM/Extension/Container/Collection.php
@@ -155,7 +155,7 @@ class CRM_Extension_Container_Collection implements CRM_Extension_Container_Inte
     if ($this->cache) {
       $k2c = $this->cache->get($this->cacheKey);
     }
-    if (!is_array($k2c)) {
+    if (!isset($k2c) || !is_array($k2c)) {
       $k2c = array();
       $containerNames = array_reverse(array_keys($this->containers));
       foreach ($containerNames as $name) {

--- a/CRM/Extension/Manager/Payment.php
+++ b/CRM/Extension/Manager/Payment.php
@@ -213,13 +213,12 @@ class CRM_Extension_Manager_Payment extends CRM_Extension_Manager_Base {
       return;
     }
 
-    // See if we have any instances of this PP defined ..
-    if ($processor_id = CRM_Core_DAO::singleValueQuery("
-                SELECT pp.id
+    $processorDAO = CRM_Core_DAO::executeQuery(
+      "                SELECT pp.id, ppt.class_name
                   FROM civicrm_extension ext
             INNER JOIN civicrm_payment_processor_type ppt
                     ON ext.name = ppt.name
-            INNER JOIN civicrm_payment_processor pp
+            LEFT JOIN civicrm_payment_processor pp
                     ON ppt.id = pp.payment_processor_type_id
                  WHERE ext.type = 'payment'
                    AND ext.full_name = %1
@@ -227,52 +226,20 @@ class CRM_Extension_Manager_Payment extends CRM_Extension_Manager_Base {
       array(
         1 => array($info->key, 'String'),
       )
-    )
-    ) {
-      // If so, load params in the usual way ..
-      $paymentProcessor = CRM_Financial_BAO_PaymentProcessor::getPayment($processor_id, NULL);
+    );
+
+    while ($processorDAO->fetch()) {
+      $class_name = $processorDAO->class_name;
+      $processor_id = $processorDAO->id;
     }
-    else {
-      // Otherwise, do the best we can to construct some ..
-      $dao = CRM_Core_DAO::executeQuery("
-                    SELECT ppt.*
-                      FROM civicrm_extension ext
-                INNER JOIN civicrm_payment_processor_type ppt
-                        ON ppt.name = ext.name
-                     WHERE ext.name = %1
-                       AND ext.type = 'payment'
-            ",
-        array(
-          1 => array($info->name, 'String'),
-        )
-      );
-      if ($dao->fetch()) {
-        $paymentProcessor = array(
-          'id' => -1,
-          'name' => $dao->title,
-          'payment_processor_type_id' => $dao->id,
-          'user_name' => 'nothing',
-          'password' => 'nothing',
-          'signature' => '',
-          'url_site' => $dao->url_site_default,
-          'url_api' => $dao->url_api_default,
-          'url_recur' => $dao->url_recur_default,
-          'url_button' => $dao->url_button_default,
-          'subject' => '',
-          'class_name' => $dao->class_name,
-          'is_recur' => $dao->is_recur,
-          'billing_mode' => $dao->billing_mode,
-          'payment_type' => $dao->payment_type,
-        );
-      }
-      else {
-        CRM_Core_Error::fatal("Unable to find payment processor in " . __CLASS__ . '::' . __METHOD__);
-      }
+
+    if (empty($class_name)) {
+      CRM_Core_Error::fatal("Unable to find payment processor in " . __CLASS__ . '::' . __METHOD__);
     }
 
     // In the case of uninstall, check for instances of PP first.
     // Don't run hook if any are found.
-    if ($method == 'uninstall' && $paymentProcessor['id'] > 0) {
+    if ($method == 'uninstall' && $processor_id > 0) {
       return;
     }
 
@@ -281,9 +248,8 @@ class CRM_Extension_Manager_Payment extends CRM_Extension_Manager_Base {
       case 'uninstall':
       case 'enable':
       case 'disable':
-
-        // Instantiate PP
-        $processorInstance = $paymentProcessor['object'];
+        // Instantiate PP - the getClass function allows us to do this when no payment processor instances exist.
+        $processorInstance = Civi\Payment\System::singleton()->getByClass($class_name);
 
         // Does PP implement this method, and can we call it?
         if (method_exists($processorInstance, $method) && is_callable(array(

--- a/Civi/Payment/System.php
+++ b/Civi/Payment/System.php
@@ -78,7 +78,7 @@ class System {
    * @throws \CiviCRM_API3_Exception
    */
   public function getById($id) {
-    $processor = civicrm_api3('payment_processor', 'getsingle', array('id' => $id));
+    $processor = civicrm_api3('payment_processor', 'getsingle', array('id' => $id, 'is_test' => NULL));
     return self::getByProcessor($processor);
   }
 

--- a/Civi/Payment/System.php
+++ b/Civi/Payment/System.php
@@ -60,14 +60,15 @@ class System {
       }
 
       $processorObject = new $paymentClass(!empty($processor['is_test']) ? 'test' : 'live', $processor);
-      if (!$force && !$processorObject->checkConfig()) {
+      if (!$force && $processorObject->checkConfig()) {
         $processorObject = NULL;
       }
       else {
         $processorObject->setPaymentProcessor($processor);
       }
+      $this->cache[$id] = $processorObject;
     }
-    $this->cache[$id] = $processorObject;
+
     return $this->cache[$id];
   }
 

--- a/Civi/Payment/System.php
+++ b/Civi/Payment/System.php
@@ -34,41 +34,40 @@ class System {
    * If there is no valid configuration it will not be retrieved.
    *
    * @param array $processor
+   * @param bool $force
+   *   Override the config check. This is required in uninstall as no valid instances exist
+   *   but will deliberately not work with any valid processors.
    *
    * @return CRM_Core_Payment|NULL
    *
    * @throws \CRM_Core_Exception
    */
-  public function getByProcessor($processor) {
-    $id = $processor['id'];
+  public function getByProcessor($processor, $force = FALSE) {
+    $id = $force ? 0 : $processor['id'];
 
-    if (!isset($this->cache[$id])) {
-      if (!isset($this->cache[$id])) {
-        //does this config need to be called?
-        $config = \CRM_Core_Config::singleton();
-        $ext = \CRM_Extension_System::singleton()->getMapper();
-        if ($ext->isExtensionKey($processor['class_name'])) {
-          $paymentClass = $ext->keyToClass($processor['class_name'], 'payment');
-          require_once $ext->classToPath($paymentClass);
-        }
-        else {
-          $paymentClass = 'CRM_Core_' . $processor['class_name'];
-          if (empty($paymentClass)) {
-            throw new \CRM_Core_Exception('no class provided');
-          }
-          require_once str_replace('_', DIRECTORY_SEPARATOR, $paymentClass) . '.php';
-        }
-
-        $processorObject = new $paymentClass(!empty($processor['is_test']) ? 'test' : 'live', $processor);
-        if ($processorObject->checkConfig()) {
-          $processorObject = NULL;
-        }
-        else {
-          $processorObject->setPaymentProcessor($processor);
-        }
+    if (!isset($this->cache[$id]) || $force) {
+      $ext = \CRM_Extension_System::singleton()->getMapper();
+      if ($ext->isExtensionKey($processor['class_name'])) {
+        $paymentClass = $ext->keyToClass($processor['class_name'], 'payment');
+        require_once $ext->classToPath($paymentClass);
       }
-      $this->cache[$id] = $processorObject;
+      else {
+        $paymentClass = 'CRM_Core_' . $processor['class_name'];
+        if (empty($paymentClass)) {
+          throw new \CRM_Core_Exception('no class provided');
+        }
+        require_once str_replace('_', DIRECTORY_SEPARATOR, $paymentClass) . '.php';
+      }
+
+      $processorObject = new $paymentClass(!empty($processor['is_test']) ? 'test' : 'live', $processor);
+      if (!$force && !$processorObject->checkConfig()) {
+        $processorObject = NULL;
+      }
+      else {
+        $processorObject->setPaymentProcessor($processor);
+      }
     }
+    $this->cache[$id] = $processorObject;
     return $this->cache[$id];
   }
 
@@ -105,6 +104,26 @@ class System {
     $this->cache = array();
     \CRM_Financial_BAO_PaymentProcessor::getAllPaymentProcessors(NULL, TRUE);
     \CRM_Financial_BAO_PaymentProcessor::getAllPaymentProcessors('test', TRUE);
+  }
+
+  /**
+   * Sometimes we want to instantiate a processor object when no valid instance exists (eg. when uninstalling a
+   * processor).
+   *
+   * This function does not load instance specific details for the processor.
+   *
+   * @param string $className
+   *
+   * @return \Civi\Payment\CRM_Core_Payment|NULL
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function getByClass($className) {
+    return $this->getByProcessor(array(
+      'class_name' => $className,
+      'id' => 0,
+      'is_test' => 0,
+    ),
+    TRUE);
   }
 
 }

--- a/tests/extensions/test.extension.manager.paymenttest/info.xml
+++ b/tests/extensions/test.extension.manager.paymenttest/info.xml
@@ -1,6 +1,7 @@
 <extension key='test.extension.manager.paymenttest' type='payment'>
   <file>main</file>
   <name>test_extension_manager_paymenttest</name>
+  <description>Sample Payment extension</description>
   <typeInfo>
     <userNameLabel>username</userNameLabel>
     <passwordLabel>password</passwordLabel>

--- a/tests/extensions/test.extension.manager.paymenttest/main.php
+++ b/tests/extensions/test.extension.manager.paymenttest/main.php
@@ -8,18 +8,22 @@ class test_extension_manager_paymenttest extends CRM_Core_Payment {
   static $counts = array();
 
   public function install() {
+    self::$counts['install'] = isset(self::$counts['install']) ? self::$counts['install'] : 0;
     self::$counts['install'] = 1 + (int) self::$counts['install'];
   }
 
   public function uninstall() {
+    self::$counts['uninstall'] = isset(self::$counts['uninstall']) ? self::$counts['uninstall'] : 0;
     self::$counts['uninstall'] = 1 + (int) self::$counts['uninstall'];
   }
 
   public function disable() {
+    self::$counts['disable'] = isset(self::$counts['disable']) ? self::$counts['disable'] : 0;
     self::$counts['disable'] = 1 + (int) self::$counts['disable'];
   }
 
   public function enable() {
+    self::$counts['enable'] = isset(self::$counts['enable']) ? self::$counts['enable'] : 0;
     self::$counts['enable'] = 1 + (int) self::$counts['enable'];
   }
 

--- a/tests/extensions/test.extension.manager.paymenttest/main.php
+++ b/tests/extensions/test.extension.manager.paymenttest/main.php
@@ -30,4 +30,15 @@ class test_extension_manager_paymenttest extends CRM_Core_Payment {
   public function checkConfig() {
   }
 
+  /**
+   * Get the desired value from $counts.
+   *
+   * @param string $type
+   *
+   * @return int
+   */
+  public static function getCount($type) {
+    return isset(self::$counts[$type]) ? self::$counts[$type] : 0;
+  }
+
 }

--- a/tests/phpunit/CRM/Extension/Container/CollectionTest.php
+++ b/tests/phpunit/CRM/Extension/Container/CollectionTest.php
@@ -30,10 +30,6 @@ require_once 'CiviTest/CiviUnitTestCase.php';
  * Class CRM_Extension_Container_CollectionTest
  */
 class CRM_Extension_Container_CollectionTest extends CiviUnitTestCase {
-  //@todo make BAO enotice compliant  & remove the line below
-  // WARNING - NEVER COPY & PASTE $_eNoticeCompliant = FALSE
-  // new test classes should be compliant.
-  public $_eNoticeCompliant = FALSE;
 
   public function setUp() {
     parent::setUp();

--- a/tests/phpunit/CRM/Extension/Manager/ModuleTest.php
+++ b/tests/phpunit/CRM/Extension/Manager/ModuleTest.php
@@ -6,10 +6,6 @@ require_once 'CiviTest/CiviUnitTestCase.php';
  * Class CRM_Extension_Manager_ModuleTest
  */
 class CRM_Extension_Manager_ModuleTest extends CiviUnitTestCase {
-  //@todo make BAO enotice compliant  & remove the line below
-  // WARNING - NEVER COPY & PASTE $_eNoticeCompliant = FALSE
-  // new test classes should be compliant.
-  public $_eNoticeCompliant = FALSE;
 
   public function setUp() {
     parent::setUp();
@@ -283,6 +279,9 @@ class CRM_Extension_Manager_ModuleTest extends CiviUnitTestCase {
    */
   public static function incHookCount($module, $name) {
     global $_test_extension_manager_moduletest_counts;
+    if (!isset($_test_extension_manager_moduletest_counts[$module][$name])) {
+      $_test_extension_manager_moduletest_counts[$module][$name] = 0;
+    }
     $_test_extension_manager_moduletest_counts[$module][$name] = 1 + (int) $_test_extension_manager_moduletest_counts[$module][$name];
   }
 

--- a/tests/phpunit/CRM/Extension/Manager/PaymentTest.php
+++ b/tests/phpunit/CRM/Extension/Manager/PaymentTest.php
@@ -122,14 +122,14 @@ class CRM_Extension_Manager_PaymentTest extends CiviUnitTestCase {
     }
     catch (CRM_Extension_Exception_DependencyException $e) {
     }
-    $this->assertEquals(0, test_extension_manager_paymenttest::$counts['uninstall']);
+    $this->assertEquals(0, test_extension_manager_paymenttest::getCount('uninstall'));
     $this->assertDBQuery(1, 'SELECT count(*) FROM civicrm_payment_processor_type WHERE class_name = "test.extension.manager.paymenttest"');
 
     $ppDAO->delete();
 
     // second attempt to uninstall -- ok
     $manager->uninstall(array('test.extension.manager.paymenttest'));
-    $this->assertEquals(1, test_extension_manager_paymenttest::$counts['uninstall']);
+    $this->assertEquals(1, test_extension_manager_paymenttest::getCount('uninstall'));
     $this->assertDBQuery(0, 'SELECT count(*) FROM civicrm_payment_processor_type WHERE class_name = "test.extension.manager.paymenttest"');
   }
 

--- a/tests/phpunit/CRM/Extension/Manager/PaymentTest.php
+++ b/tests/phpunit/CRM/Extension/Manager/PaymentTest.php
@@ -30,10 +30,6 @@ require_once 'CiviTest/CiviUnitTestCase.php';
  * Class CRM_Extension_Manager_PaymentTest
  */
 class CRM_Extension_Manager_PaymentTest extends CiviUnitTestCase {
-  //@todo make BAO enotice compliant  & remove the line below
-  // WARNING - NEVER COPY & PASTE $_eNoticeCompliant = FALSE
-  // new test classes should be compliant.
-  public $_eNoticeCompliant = FALSE;
 
   public function setUp() {
     parent::setUp();

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -119,11 +119,6 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
   public static $populateOnce = FALSE;
 
   /**
-   * Allow classes to state E-notice compliance
-   */
-  public $_eNoticeCompliant = TRUE;
-
-  /**
    * @var boolean DBResetRequired allows skipping DB reset
    *               in specific test case. If you still need
    *               to reset single test (method) of such case, call
@@ -433,12 +428,8 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
     //flush component settings
     CRM_Core_Component::getEnabledComponents(TRUE);
 
-    if ($this->_eNoticeCompliant) {
-      error_reporting(E_ALL);
-    }
-    else {
-      error_reporting(E_ALL & ~E_NOTICE);
-    }
+    error_reporting(E_ALL);
+
     $this->_sethtmlGlobals();
   }
 

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -1455,7 +1455,7 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
       'billing_mode' => 1,
     ), $params);
 
-    $result = $this->callAPISuccess('payment_processor', 'create', $params);
+    $result = $this->callAPISuccess('PaymentProcessor', 'create', $params);
     return $result['id'];
   }
 


### PR DESCRIPTION
Note that adding description to the payment_processor info is a bit of a hack (but this is heavily deprecated anyway). 

Also, @totten I'm going to have to re-read your stuff from yesterday about isset & is_array combos as I had convinced myself after that that I wouldn't need the isset in the first part of this patch
