### PR TITLE
Fix for CRM-16866: modules permissions cleared on every rebuild

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -600,16 +600,19 @@ class CRM_Core_Permission {
       $perm = $comp->getPermissions(FALSE, $descriptions);
       if ($perm) {
         $info = $comp->getInfo();
-        if ($descriptions) {
-          foreach ($perm as $p => $attr) {
-            $title = $info['translatedName'] . ': ' . array_shift($attr);
-            array_unshift($attr, $title);
+        foreach ($perm as $p => $attr) {
+
+          if (!is_array($attr)) {
+            $attr = array($attr);
+          }
+
+          $attr[0] = $info['translatedName'] . ': ' . $attr[0];
+
+          if ($descriptions) {
             $permissions[$p] = $attr;
           }
-        }
-        else {
-          foreach ($perm as $p) {
-            $permissions[$p] = $info['translatedName'] . ': ' . $p;
+          else {
+            $permissions[$p] = $attr[0];
           }
         }
       }


### PR DESCRIPTION
See issue: https://issues.civicrm.org/jira/browse/CRM-16866
