### PR TITLE
CRM-16867 fix membership-renew check to get membership types from pri…

### DIFF
--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -26,11 +26,8 @@
  */
 
 /**
- *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 
 /**

--- a/CRM/Contribute/Form/ContributionPage/Amount.php
+++ b/CRM/Contribute/Form/ContributionPage/Amount.php
@@ -299,12 +299,20 @@ SELECT id
     $membershipBlock->entity_id = $self->_id;
     $membershipBlock->is_active = 1;
     $hasMembershipBlk = FALSE;
+
     if ($membershipBlock->find(TRUE)) {
+      $setID = CRM_Price_BAO_PriceSet::getFor('civicrm_contribution_page', $self->_id, NULL, NULL);
       if (!empty($fields['amount_block_is_active']) &&
-        ($setID = CRM_Price_BAO_PriceSet::getFor('civicrm_contribution_page', $self->_id, NULL, 1))
+        // I don't think setID could ever not be set.
+        ($setID)
       ) {
-        $extends = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $setID, 'extends');
-        if ($extends && $extends == CRM_Core_Component::getComponentID('CiviMember')) {
+        // If we are using quick config for the contribution part we need quick config for the membership part.
+        // Note that having 2 price sets against a page may allow our code to be more sensible when managing separate payments.
+        // The quick config is intended to make it possible not to force people to use price sets until the price set UI
+        // is easier to use, but should have no effect on form processing but the separate membership payment complicates this
+        // as there is no linking of the contribution price set to the page.
+        $priceSet = civicrm_api3('PriceSet', 'getsingle', array('id' => $setID));
+        if (empty($priceSet['is_quick_config']) && CRM_Utils_Array::value('extends', $priceSet) == CRM_Core_Component::getComponentID('CiviMember')) {
           $errors['amount_block_is_active'] = ts('You cannot use a Membership Price Set when the Contribution Amounts section is enabled. Click the Memberships tab above, and select your Membership Price Set on that form. Membership Price Sets may include additional fields for non-membership options that require an additional fee (e.g. magazine subscription) or an additional voluntary contribution.');
           return $errors;
         }
@@ -314,13 +322,13 @@ SELECT id
         $errors['amount_block_is_active'] = ts('To disable Contribution Amounts section you need to first disable Separate Membership Payment option from Membership Settings.');
       }
 
-      //CRM-16165, Don't allow reccuring contribution if membership block contain any renewable membership option
-      $membershipTypes = unserialize($membershipBlock->membership_types);
-      if (!empty($fields['is_recur']) && !empty($membershipTypes)) {
+      //CRM-16165, Don't allow recurring contribution if membership block contain any renewable membership option
+      $membershipTypes = CRM_Price_BAO_PriceSet::getMembershipTypesFromPriceSet($setID);
+      if (!empty($fields['is_recur']) && !empty($membershipTypes['autorenew'])) {
         if (!$membershipBlock->is_separate_payment) {
           $errors['is_recur'] = ts('You need to enable Separate Membership Payment when online contribution page is configured for both Membership and Recurring Contribution.');
         }
-        elseif (count(array_filter($membershipTypes)) != 0) {
+        else {
           $errors['is_recur'] = ts('You cannot enable both Recurring Contributions and Auto-renew memberships on the same online contribution page.');
         }
       }

--- a/CRM/Contribute/Form/ContributionPage/Custom.php
+++ b/CRM/Contribute/Form/ContributionPage/Custom.php
@@ -26,15 +26,12 @@
  */
 
 /**
- *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 
 /**
- * form to process actions on the group aspect of Custom Data
+ * Form to process actions on the group aspect of Custom Data.
  */
 class CRM_Contribute_Form_ContributionPage_Custom extends CRM_Contribute_Form_ContributionPage {
 

--- a/CRM/Member/Form/MembershipBlock.php
+++ b/CRM/Member/Form/MembershipBlock.php
@@ -231,7 +231,7 @@ class CRM_Member_Form_MembershipBlock extends CRM_Contribute_Form_ContributionPa
 
     if (!empty($params['member_price_set_id'])) {
       //check if this price set has membership type both auto-renew and non-auto-renew memberships.
-      $bothTypes = CRM_Price_BAO_PriceSet::checkMembershipPriceSet($params['member_price_set_id']);
+      $bothTypes = CRM_Price_BAO_PriceSet::isMembershipPriceSetContainsMixOfRenewNonRenew($params['member_price_set_id']);
 
       //check for supporting payment processors
       //if both auto-renew and non-auto-renew memberships

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -1383,6 +1383,54 @@ WHERE       ps.id = %1
   }
 
   /**
+   * Get an array of the membership types in a price set.
+   *
+   * @param int $id
+   *
+   * @return array(
+   *  Membership types in the price set
+   */
+  static function getMembershipTypesFromPriceSet($id) {
+    $query
+      = "SELECT      pfv.id, pfv.price_field_id, pfv.name, pfv.membership_type_id, pf.html_type, mt.auto_renew
+FROM        civicrm_price_field_value pfv
+LEFT JOIN   civicrm_price_field pf ON pf.id = pfv.price_field_id
+LEFT JOIN   civicrm_price_set ps ON ps.id = pf.price_set_id
+LEFT JOIN   civicrm_membership_type mt ON mt.id = pfv.membership_type_id
+WHERE       ps.id = %1
+";
+
+    $params = array(1 => array($id, 'Integer'));
+    $dao = CRM_Core_DAO::executeQuery($query, $params);
+
+    $membershipTypes = array(
+      'all' => array(),
+      'autorenew' => array(),
+      'autorenew_required' => array(),
+      'autorenew_optional' => array(),
+    );
+    while ($dao->fetch()) {
+      if (empty($dao->membership_type_id)) {
+        continue;
+      }
+      $membershipTypes['all'][] = $dao->membership_type_id;
+      if (!empty($dao->auto_renew)) {
+        $membershipTypes['autorenew'][] = $dao->membership_type_id;
+        if ($dao->auto_renew == 2) {
+          $membershipTypes['autorenew_required'][] = $dao->membership_type_id;
+        }
+        else {
+          $membershipTypes['autorenew_optional'][] = $dao->membership_type_id;
+        }
+      }
+      else {
+        $membershipTypes['non_renew'][] = $dao->membership_type_id;
+      }
+    }
+    return $membershipTypes;
+  }
+
+  /**
    * Copy priceSet when event/contibution page is copied
    *
    * @param string $baoName

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -1343,41 +1343,16 @@ GROUP BY     mt.member_of_contact_id";
   }
 
   /**
-   * Check if price set id provides option for
-   * user to select both auto-renew and non-auto-renew memberships
+   * Check if price set id provides option for user to select both auto-renew and non-auto-renew memberships
    *
    * @param int $id
    *
    * @return bool
    */
-  public static function checkMembershipPriceSet($id) {
-    $query
-      = "SELECT      pfv.id, pfv.price_field_id, pfv.name, pfv.membership_type_id, pf.html_type, mt.auto_renew
-FROM        civicrm_price_field_value pfv
-LEFT JOIN   civicrm_price_field pf ON pf.id = pfv.price_field_id
-LEFT JOIN   civicrm_price_set ps ON ps.id = pf.price_set_id
-LEFT JOIN   civicrm_membership_type mt ON mt.id = pfv.membership_type_id
-WHERE       ps.id = %1
-";
-
-    $params = array(1 => array($id, 'Integer'));
-    $dao = CRM_Core_DAO::executeQuery($query, $params);
-
-    $autoRenew = array();
-    //FIXME: do a comprehensive check of whether
-    //2 membership types can be selected
-    //instead of comparing all of them
-    while ($dao->fetch()) {
-      //temp fix for #CRM-10370
-      //if its NULL consider it '0' i.e. 'No auto-renew option'
-      $daoAutoRenew = $dao->auto_renew;
-      if ($daoAutoRenew === NULL) {
-        $daoAutoRenew = 0;
-      }
-      if (!empty($autoRenew) && !in_array($daoAutoRenew, $autoRenew)) {
-        return TRUE;
-      }
-      $autoRenew[] = $daoAutoRenew;
+  public static function isMembershipPriceSetContainsMixOfRenewNonRenew($id) {
+    $membershipTypes = self::getMembershipTypesFromPriceSet($id);
+    if (!empty($membershipTypes['autorenew']) && !empty($membershipTypes['non_renew'])) {
+      return TRUE;
     }
     return FALSE;
   }


### PR DESCRIPTION
This PR includes the fix in https://github.com/civicrm/civicrm-core/pull/6252 but also prevents code duplication by re-using code. NOTE - this retains existing functionality from what I can tell the existing functionality is not correct.

ie. a price set that allows purchase of a non-renew membership AND a renew membership type
or that allows purchase of a non-renew membership **OR** a renew membership type will not be permitted with this message

"The membership price set associated with this online contribution allows a user to select BOTH an auto-renew AND a non-auto-renew membership. This requires submitting multiple processor transactions, and is not supported for one or more of the payment processors enabled under the Amounts tab."
