### PR TITLE
CRM-16867 add function to determin combination of membership types in  a priceset

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -100,7 +100,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
    *
    * @var array
    */
-  public $_params;
+  public $_params = array();
 
   /**
    * The fields involved in this contribution page

--- a/CRM/Contribute/Form/ContributionPage/Custom.php
+++ b/CRM/Contribute/Form/ContributionPage/Custom.php
@@ -26,13 +26,12 @@
  */
 
 /**
- *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
  */
 
 /**
- * form to process actions on the group aspect of Custom Data
+ * Form to process actions on the group aspect of Custom Data.
  */
 class CRM_Contribute_Form_ContributionPage_Custom extends CRM_Contribute_Form_ContributionPage {
 

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -1422,6 +1422,54 @@ WHERE       ps.id = %1
   }
 
   /**
+   * Get an array of the membership types in a price set.
+   *
+   * @param int $id
+   *
+   * @return array(
+   *   Membership types in the price set
+   */
+  public static function getMembershipTypesFromPriceSet($id) {
+    $query
+      = "SELECT      pfv.id, pfv.price_field_id, pfv.name, pfv.membership_type_id, pf.html_type, mt.auto_renew
+FROM        civicrm_price_field_value pfv
+LEFT JOIN   civicrm_price_field pf ON pf.id = pfv.price_field_id
+LEFT JOIN   civicrm_price_set ps ON ps.id = pf.price_set_id
+LEFT JOIN   civicrm_membership_type mt ON mt.id = pfv.membership_type_id
+WHERE       ps.id = %1
+";
+
+    $params = array(1 => array($id, 'Integer'));
+    $dao = CRM_Core_DAO::executeQuery($query, $params);
+
+    $membershipTypes = array(
+      'all' => array(),
+      'autorenew' => array(),
+      'autorenew_required' => array(),
+      'autorenew_optional' => array(),
+    );
+    while ($dao->fetch()) {
+      if (empty($dao->membership_type_id)) {
+        continue;
+      }
+      $membershipTypes['all'][] = $dao->membership_type_id;
+      if (!empty($dao->auto_renew)) {
+        $membershipTypes['autorenew'][] = $dao->membership_type_id;
+        if ($dao->auto_renew == 2) {
+          $membershipTypes['autorenew_required'][] = $dao->membership_type_id;
+        }
+        else {
+          $membershipTypes['autorenew_optional'][] = $dao->membership_type_id;
+        }
+      }
+      else {
+        $membershipTypes['non_renew'][] = $dao->membership_type_id;
+      }
+    }
+    return $membershipTypes;
+  }
+
+  /**
    * Copy priceSet when event/contibution page is copied
    *
    * @param string $baoName


### PR DESCRIPTION
This function is part of the fix towards CRM-16850 & CRM-16867 & a further commit causes the function it was copied off
to re-use rather than duplicate it, however, various aspects of QA still being undergone - this function addition only PR
allows the work on both those issues to continue without being interrelated
