### PR TITLE
CRM-16875 Performance of finding contributions not in financial batch

### DIFF
--- a/CRM/Batch/BAO/Batch.php
+++ b/CRM/Batch/BAO/Batch.php
@@ -666,6 +666,7 @@ class CRM_Batch_BAO_Batch extends CRM_Batch_DAO_Batch {
     $from = "civicrm_financial_trxn
 LEFT JOIN civicrm_entity_financial_trxn ON civicrm_entity_financial_trxn.financial_trxn_id = civicrm_financial_trxn.id
 LEFT JOIN civicrm_entity_batch ON civicrm_entity_batch.entity_id = civicrm_financial_trxn.id
+AND civicrm_entity_batch.entity_table = 'civicrm_financial_trxn'
 LEFT JOIN civicrm_contribution ON civicrm_contribution.id = civicrm_entity_financial_trxn.entity_id
 LEFT JOIN civicrm_financial_type ON civicrm_financial_type.id = civicrm_contribution.financial_type_id
 LEFT JOIN civicrm_contact contact_a ON contact_a.id = civicrm_contribution.contact_id


### PR DESCRIPTION
add entity table field on join, to use index_entity index on civicrm_entity_batch table and make left join significantly faster

---
- [CRM-16875: Performance of finding contributions not in financial batch](https://issues.civicrm.org/jira/browse/CRM-16875)
