### PR TITLE
Removed testTinyMCE testcase and fix for other webtest failure

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1242,6 +1242,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       }
     }
     // Send receipt mail.
+    array_unshift($this->statusMessage, ts('The contribution record has been saved.'));
     if ($contribution->id && !empty($this->_params['is_email_receipt'])) {
       $this->_params['trxn_id'] = CRM_Utils_Array::value('trxn_id', $result);
       $this->_params['contact_id'] = $contactID;

--- a/tests/phpunit/CiviTest/CiviSeleniumTestCase.php
+++ b/tests/phpunit/CiviTest/CiviSeleniumTestCase.php
@@ -852,7 +852,9 @@ class CiviSeleniumTestCase extends PHPUnit_Extensions_SeleniumTestCase {
     elseif ($processorType == 'AuthNet') {
       // FIXME: we 'll need to make a new separate account for testing
       $processorSettings = array(
+        'user_name' => '5ULu56ex',
         'test_user_name' => '5ULu56ex',
+        'password' => '7ARxW575w736eF5p',
         'test_password' => '7ARxW575w736eF5p',
       );
     }

--- a/tests/phpunit/WebTest/Contact/SignatureTest.php
+++ b/tests/phpunit/WebTest/Contact/SignatureTest.php
@@ -36,61 +36,6 @@ class WebTest_Contact_SignatureTest extends CiviSeleniumTestCase {
   }
 
   /**
-   * Test Signature in TinyMC.
-   */
-  public function testTinyMCE() {
-    $this->webtestLogin();
-
-    $this->openCiviPage('dashboard', 'reset=1', 'crm-recently-viewed');
-    $this->click("//div[@id='crm-recently-viewed']/ul/li/a");
-    $this->waitForPageToLoad($this->getTimeoutMsec());
-    $name = $this->getText("xpath=//div[@class='crm-summary-display_name']");
-
-    // Get contact id from url.
-    $contactId = $this->urlArg('cid');
-
-    // Select Your Editor
-    $this->_selectEditor('TinyMCE');
-
-    $this->openCiviPage("contact/add", "reset=1&action=update&cid=$contactId");
-
-    $this->click("//tr[@id='Email_Block_1']/td[1]/div[3]/div[1]");
-    // HTML format message
-    $signature = 'Contact Signature in html';
-
-    $this->fireEvent('email_1_signature_html', 'focus');
-    $this->fillRichTextField('email_1_signature_html', $signature, 'TinyMCE');
-
-    // TEXT Format Message
-    $this->type('email_1_signature_text', 'Contact Signature in text');
-    $this->click('_qf_Contact_upload_view-top');
-    $this->waitForPageToLoad($this->getTimeoutMsec());
-
-    // Is status message correct?
-    $this->waitForText('crm-notification-container', "Contact Saved");
-
-    // Go for Ckeck Your Editor, Click on Send Mail
-    $this->click("//a[@id='crm-contact-actions-link']/span");
-    // the other test checks this in a popup, we'll try it full-page here
-    $this->clickLinkSuppressPopup('link=Send an Email', "xpath=//body[@id='tinymce']/p[2]");
-
-    $this->click('subject');
-    $subject = 'Subject_' . substr(sha1(rand()), 0, 8);
-    $this->type('subject', $subject);
-
-    // Is signature correct? in Editor
-    $this->_checkSignature('html_message', $signature, 'TinyMCE');
-
-    $this->click('_qf_Email_upload-top');
-
-    // Go for Activity Search
-    $this->_checkActivity($subject, $signature);
-
-    // Set Editor back to default so we don't break other tests
-    $this->_selectEditor('CKEditor');
-  }
-
-  /**
    *  Test Signature in CKEditor.
    */
   public function testCKEditor() {

--- a/tests/phpunit/WebTest/Contribute/OfflineRecurContributionTest.php
+++ b/tests/phpunit/WebTest/Contribute/OfflineRecurContributionTest.php
@@ -82,7 +82,7 @@ class WebTest_Contribute_OfflineRecurContributionTest extends CiviSeleniumTestCa
     $this->webtestAddBillingDetails($firstName, $middleName, $lastName);
     $this->click('_qf_Contribution_upload-bottom');
     $this->waitForElementPresent('link=Edit');
-    $this->waitForText('crm-notification-container', "The contribution record has been processed.");
+    $this->waitForText('crm-notification-container', "The contribution record has been saved.");
     // Use Find Contributions to make sure test recurring contribution exists
     $this->openCiviPage("contribute/search", "reset=1", 'contribution_currency_type');
 

--- a/tests/phpunit/WebTest/Event/AddPricesetTest.php
+++ b/tests/phpunit/WebTest/Event/AddPricesetTest.php
@@ -280,8 +280,7 @@ class WebTest_Event_AddPricesetTest extends CiviSeleniumTestCase {
     $this->check('is_online_registration');
     $this->assertChecked('is_online_registration');
 
-    $this->click('intro_text-plain');
-    $this->fillRichTextField('intro_text', $registerIntro);
+    $this->fillRichTextField('intro_text', $registerIntro, 'CKEditor', TRUE);
 
     // enable confirmation email
     $this->click('CIVICRM_QFID_1_is_email_confirm');
@@ -440,8 +439,7 @@ class WebTest_Event_AddPricesetTest extends CiviSeleniumTestCase {
     $this->check('is_online_registration');
     $this->assertChecked('is_online_registration');
 
-    $this->click('intro_text-plain');
-    $this->fillRichTextField('intro_text', $registerIntro);
+    $this->fillRichTextField('intro_text', $registerIntro, 'CKEditor', TRUE);
 
     // enable confirmation email
     $this->click('CIVICRM_QFID_1_is_email_confirm');

--- a/tests/phpunit/WebTest/Event/PricesetMaxCountTest.php
+++ b/tests/phpunit/WebTest/Event/PricesetMaxCountTest.php
@@ -1141,8 +1141,7 @@ class WebTest_Event_PricesetMaxCountTest extends CiviSeleniumTestCase {
       $this->click('is_multiple_registrations');
     }
 
-    $this->click('intro_text-plain');
-    $this->fillRichTextField('intro_text', 'Fill in all the fields below and click Continue.');
+    $this->fillRichTextField('intro_text', 'Fill in all the fields below and click Continue.', 'CKEditor', TRUE);
 
     // enable confirmation email
     $this->click('CIVICRM_QFID_1_is_email_confirm');

--- a/tests/phpunit/WebTest/Generic/CheckDashboardTest.php
+++ b/tests/phpunit/WebTest/Generic/CheckDashboardTest.php
@@ -149,7 +149,7 @@ class WebTest_Generic_CheckDashboardTest extends CiviSeleniumTestCase {
     }
     else {
       // click 'Delete Activity' link
-      $this->click("//table[@class='contact-activity-selector-dashlet dataTable no-footer']/tbody/tr[1]/td[8]/span//a[text()='Delete']");
+      $this->click("//table[@class='contact-activity-selector-dashlet crm-ajax-table dataTable no-footer']/tbody/tr[1]/td[8]/span//a[text()='Delete']");
     }
     $this->waitForPageToLoad($this->getTimeoutMsec());
     $this->waitForElementPresent("_qf_Activity_next-bottom");


### PR DESCRIPTION
Fix for,
WebTest_Event_AddPricesetTest::testParticipantWithDateSpecificPriceSet
WebTest_Event_AddPricesetTest::testRegisterWithPriceSet
testOfflineRecurContribution WebTest_Contribute_OfflineRecurContributionTest
WebTest_Contact_SignatureTest::testTinyMCE (as per the https://github.com/civicrm/civicrm-core/pull/6212 changes)
WebTest_Generic_CheckDashboardTest::testCheckDashboardElements
WebTest_Event_PricesetMaxCountTest::testWithoutFieldCount 
WebTest_Event_PricesetMaxCountTest::testWithFieldCount
WebTest_Event_PricesetMaxCountTest::testAdditionalParticipantWithFieldCount
WebTest_Event_PricesetMaxCountTest::testAdditionalParticipantWithoutFieldCount
