### PR TITLE
CRM-16882 renew my membership automatically should not show for non-auto-renew memberships

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -838,7 +838,7 @@ INNER JOIN  civicrm_membership_type type ON ( type.id = membership.membership_ty
           }
           elseif ($memType['is_active']) {
             $javascriptMethod = NULL;
-            $allowAutoRenewOpt = 1;
+            $allowAutoRenewOpt = (int) $memType['auto_renew'];
             if (is_array($form->_paymentProcessors)) {
               foreach ($form->_paymentProcessors as $id => $val) {
                 if (!$val['is_recur']) {


### PR DESCRIPTION
I am not convinced this is the full story on CRM-16882 - however, it makes
the symptom disappear, at least in one instance & the logic of the change
is strong - ie. when iterating through the memberships to determine
auto-renewability we should
check whether they are auto-renew
