### PR TITLE
CRM-16809 paypal express button not always loading

### DIFF
--- a/templates/CRM/Financial/Form/PaypalExpress.tpl
+++ b/templates/CRM/Financial/Form/PaypalExpress.tpl
@@ -25,7 +25,6 @@
 *}
 
   <div id="paypalExpress">
-    {assign var=expressButtonName value='_qf_Main_upload_express'}
     <fieldset class="crm-group paypal_checkout-group">
       <legend>{ts}Checkout with PayPal{/ts}</legend>
       <div class="section">


### PR DESCRIPTION
The issue was that the button name was being overridden
