### PR TITLE
CRM-16876 - Upgrade query to set civicrm_country.name values to upper…

### DIFF
--- a/CRM/Upgrade/Incremental/sql/4.7.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.7.alpha1.mysql.tpl
@@ -25,3 +25,6 @@ UPDATE civicrm_option_value SET {localize field="label"}label = 'Activity Summar
 {include file='../CRM/Upgrade/4.7.alpha1.msg_template/civicrm_msg_template.tpl'}
 
 UPDATE civicrm_state_province SET name = 'Bataan' WHERE name = 'Batasn';
+
+-- CRM-16876 Set country names to UPPERCASE
+UPDATE civicrm_country SET `name` = UPPER( `name` );


### PR DESCRIPTION
…case.

---
- CRM-16876: Display Country in uppercase so that mailing labels comply with postal regulations
  https://issues.civicrm.org/jira/browse/CRM-16876
