### PR TITLE
CRM-16876 Set country names to UPPERCASE - rebasing.

### DIFF
--- a/CRM/Upgrade/Incremental/sql/4.7.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.7.alpha1.mysql.tpl
@@ -35,3 +35,6 @@ ALTER TABLE civicrm_payment_processor_type
 ADD COLUMN
 `payment_instrument_id` int unsigned   DEFAULT 1 COMMENT 'Payment Instrument ID';
 
+-- CRM-16876 Set country names to UPPERCASE
+UPDATE civicrm_country SET `name` = UPPER( `name` );
+


### PR DESCRIPTION
---
- CRM-16876: Display Country in uppercase so that mailing labels comply with postal regulations
  https://issues.civicrm.org/jira/browse/CRM-16876
