### PR TITLE
CRM-15991 - Can now delete relationships w edit all contacts permission

### DIFF
--- a/CRM/Core/DAO/permissions.php
+++ b/CRM/Core/DAO/permissions.php
@@ -131,7 +131,7 @@ function _civicrm_api3_permissions($entity, $action, &$params) {
     ),
     'delete' => array(
       'access CiviCRM',
-      'delete contacts',
+      'edit all contacts',
     ),
     'default' => array(
       'access CiviCRM',


### PR DESCRIPTION
Delete contacts permission is not required any more for deleting
relationships.

---
- CRM-15991: http-api: User needs 'delete contacts' permission to delete relationships
  https://issues.civicrm.org/jira/browse/CRM-15991
