### PR TITLE
CRM-16527 - Hide credit card section in membership contribution form

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -465,6 +465,7 @@
 
   cj(function() {
     toggleConfirmButton();
+    skipPaymentMethod();
   });
 
   function showHidePayPalExpressOption() {
@@ -478,7 +479,44 @@
     }
   }
 
-  cj(function(){
+  function showHidePayment(flag) {
+    var payment_options = cj(".payment_options-group");
+    var payment_processor = cj("div.payment_processor-section");
+    var payment_information = cj("div#payment_information");
+    if (flag) {
+      payment_options.hide();
+      payment_processor.hide();
+      payment_information.hide();
+      // also unset selected payment methods
+      cj('input[name="payment_processor"]').removeProp('checked');
+    }
+    else {
+      payment_options.show();
+      payment_processor.show();
+      payment_information.show();
+    }
+  }
+
+  function skipPaymentMethod() {
+    var flag = false;
+    cj('.price-set-option-content input').each( function(){
+      currentTotal = cj(this).attr('data-amount').replace(/[^\/\d]/g,'');
+      if( cj(this).is(':checked') && currentTotal == 0 ) {
+          flag = true;
+      }
+    });
+    cj('.price-set-option-content input').change( function () {
+      if (cj(this).attr('data-amount').replace(/[^\/\d]/g,'') == 0 ) {
+        flag = true;
+      } else {
+        flag = false;
+      }
+      showHidePayment(flag);
+    });
+    showHidePayment(flag);
+  }
+
+    cj(function(){
     // highlight price sets
     function updatePriceSetHighlight() {
       cj('#priceset .price-set-row span').removeClass('highlight');


### PR DESCRIPTION
Conflicts:
    templates/CRM/Contribute/Form/Contribution/Main.tpl

---
- [CRM-16527: Hide credit card fields in membership contribution form.](https://issues.civicrm.org/jira/browse/CRM-16527)
