### PR TITLE
CRM-16963 - Access CiviCRM sufficient to retrieve country information

### DIFF
--- a/CRM/Core/DAO/permissions.php
+++ b/CRM/Core/DAO/permissions.php
@@ -95,6 +95,16 @@ function _civicrm_api3_permissions($entity, $action, &$params) {
     ),
   );
 
+  // CRM-16963 - Permissions for country.
+  $permissions['country'] = array(
+    'get' => array(
+      'access CiviCRM',
+    ),
+    'default' => array(
+      'administer CiviCRM',
+    ),
+  );
+
   // Contact-related data permissions.
   // CRM-14094 - Users can edit and delete contact-related objects using inline edit with 'edit all contacts' permission
   $permissions['address'] = array(


### PR DESCRIPTION
## If you have 'access CiviCRM' permissions, you should be able to retreive country information using the HTTP-API.
- CRM-16963: 'Administer CiviCRM' permissions needed to retrieve countries using the API
  https://issues.civicrm.org/jira/browse/CRM-16963
