### PR TITLE
CRM-15915 standardise output on custom fields with arrays 

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -1718,6 +1718,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
       $modeFill = TRUE;
     }
 
+    // @todo - can we remove these lines $groupTree & $defaults are not used!
     $groupTree = CRM_Core_BAO_CustomGroup::getTree($params['contact_type'], CRM_Core_DAO::$_nullObject, $cid, 0, NULL);
     CRM_Core_BAO_CustomGroup::setDefaults($groupTree, $defaults, FALSE, FALSE);
 

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -1429,9 +1429,21 @@ function _civicrm_api3_custom_data_get(&$returnArray, $entity, $entity_id, $grou
   }
   if (!empty($customValues)) {
     foreach ($customValues as $key => $val) {
+      // CRM-15915 the setDefaults functions keys the fields by their values.
+      // This results in an array like array('A' => 'A') which results in different json
+      // than entities using the BAO query object.
+      // A case could be made to change it in CRM_Core_BAO_CustomGroup::setDefaults
+      // but it would affect some forms & require testing called from 9 other places - one of which appears
+      // to be just for fun.
+      // Note that the setDefaults also sets arrays like $val => 0 for checkboxes.
+      // This would probably still return odd json output but have restricted this to a narrow (tested)
+      // scope.
+      if (is_array($val) && array_keys($val) == array_values($val)) {
+        $val = array_values($val);
+      }
       // per standard - return custom_fieldID
       $id = CRM_Core_BAO_CustomField::getKeyID($key);
-      $returnArray['custom_' . $id] = $val;
+      $returnArray['custom_' . $id] = array_values($val);
 
       //not standard - but some api did this so guess we should keep - cheap as chips
       $returnArray[$key] = $val;

--- a/tests/phpunit/api/v3/CustomValueTest.php
+++ b/tests/phpunit/api/v3/CustomValueTest.php
@@ -123,6 +123,178 @@ class api_v3_CustomValueTest extends CiviUnitTestCase {
     $this->assertEquals('value 4', $result['values'][$thirdCustomField]['2']);
   }
 
+  /**
+   * Unit test for CRM-15915.
+   *
+   * The values for a multi-select custom field on a contact are returned as a
+   * list. This unit test should pass.
+   */
+  public function testMultiSelectCustomValuesContact() {
+    $custom_group_result = $this->CallApiSuccess('CustomGroup', 'Create', array(
+      'name' => 'custom_group_on_contact',
+      'title' => 'Custom group on contact (test)',
+      'extends' => 'Contact',
+      'is_active' => 1,
+      'sequential' => 1,
+    ));
+
+    $custom_field_result = $this->CallApiSuccess('CustomField', 'Create', array(
+      'custom_group_id' => $custom_group_result['id'],
+      'weight' => 1,
+      'name' => 'my_custom_field',
+      'label' => 'My custom field',
+      'data_type' => 'String',
+      'html_type' => 'Multi-Select',
+      'option_values' => array(
+        'A' => array(
+          'weight' => 1,
+          'value' => 'A',
+          'label' => 'label A',
+          'is_active' => 1,
+        ),
+        'B' => array(
+          'weight' => 2,
+          'value' => 'B',
+          'label' => 'label B',
+          'is_active' => 1,
+        ),
+        'C' => array(
+          'weight' => 3,
+          'value' => 'C',
+          'label' => 'label C',
+          'is_active' => 1,
+        ),
+      ),
+      'is_active' => 1,
+      'sequential' => 1,
+    ));
+
+    $contact_create_result = $this->CallApiSuccess('Contact', 'Create', array(
+      'contact_type' => 'Individual',
+      'first_name' => 'Joe',
+      'last_name' => 'Schmoe',
+      'custom_' . $custom_field_result['id'] => array('B'),
+      'sequential' => 1,
+    ));
+
+    $contact_get_result = $this->CallApiSuccess('Contact', 'GetSingle', array(
+      'id' => $contact_create_result['id'],
+      'return' => 'custom_' . $custom_field_result['id'],
+      'sequential' => 1,
+    ));
+
+    // Clean up first, then assert.
+
+    $this->CallApiSuccess('Contact', 'Delete', array(
+      'id' => $contact_get_result['id'],
+    ));
+
+    $this->CallApiSuccess('CustomField', 'Delete', array(
+      'id' => $custom_field_result['id'],
+    ));
+
+    $this->CallApiSuccess('CustomGroup', 'Delete', array(
+      'id' => $custom_group_result['id'],
+    ));
+
+    $this->AssertEquals('B', $contact_get_result['custom_' . $custom_field_result['id']][0]);
+  }
+
+  /**
+   * Unit test for CRM-15915.
+   *
+   * The values for a multi-select custom field should be returned as a list.
+   * This unit test will fail until CRM-15915 is fixed, because the custom field
+   * applies to a relationship.
+   */
+  public function testMultiSelectCustomValuesRelationship() {
+    $custom_group_result = $this->CallApiSuccess('CustomGroup', 'Create', array(
+      'name' => 'custom_group_on_relationship',
+      'title' => 'Custom group on relationship (test)',
+      'extends' => 'Relationship',
+      'is_active' => 1,
+      'sequential' => 1,
+    ));
+
+    $custom_field_result = $this->CallApiSuccess('CustomField', 'Create', array(
+      'custom_group_id' => $custom_group_result['id'],
+      'weight' => 1,
+      'name' => 'my_custom_field',
+      'label' => 'My custom field',
+      'data_type' => 'String',
+      'html_type' => 'Multi-Select',
+      'option_values' => array(
+        'A' => array(
+          'weight' => 1,
+          'value' => 'A',
+          'label' => 'label A',
+          'is_active' => 1,
+        ),
+        'B' => array(
+          'weight' => 2,
+          'value' => 'B',
+          'label' => 'label B',
+          'is_active' => 1,
+        ),
+        'C' => array(
+          'weight' => 3,
+          'value' => 'C',
+          'label' => 'label C',
+          'is_active' => 1,
+        ),
+      ),
+      'is_active' => 1,
+      'sequential' => 1,
+    ));
+
+    $organization_create_result = $this->CallApiSuccess('Contact', 'Create', array(
+      'contact_type' => 'Organization',
+      'organization_name' => 'Schmoe inc.',
+      'sequential' => 1,
+    ));
+
+    $contact_create_result = $this->CallApiSuccess('Contact', 'Create', array(
+      'contact_type' => 'Individual',
+      'first_name' => 'Joe',
+      'last_name' => 'Schmoe',
+      'api.relationship.create' => array(
+        'contact_id_a' => '$value.id',
+        'contact_id_b' => $organization_create_result['id'],
+        'relationship_type_id' => 5, // works for
+        'custom_' . $custom_field_result['id'] => array('B'),
+      ),
+      'sequential' => 1,
+    ));
+
+    $relationship_id = $contact_create_result['values'][0]['api.relationship.create']['id'];
+
+    $relationship_get_result = $this->CallApiSuccess('Relationship', 'GetSingle', array(
+      'id' => $relationship_id,
+      'return' => 'custom_' . $custom_field_result['id'],
+      'sequential' => 1,
+    ));
+
+    // Clean up first, then assert.
+
+    $this->CallApiSuccess('Contact', 'Delete', array(
+      'id' => $contact_create_result['id'],
+    ));
+
+    $this->CallApiSuccess('Contact', 'Delete', array(
+      'id' => $organization_create_result['id'],
+    ));
+
+    $this->CallApiSuccess('CustomField', 'Delete', array(
+      'id' => $custom_field_result['id'],
+    ));
+
+    $this->CallApiSuccess('CustomGroup', 'Delete', array(
+      'id' => $custom_group_result['id'],
+    ));
+
+    $this->AssertEquals('B', $relationship_get_result['custom_' . $custom_field_result['id']][0]);
+  }
+
   public function testMultipleCustomValues() {
     $params = array(
       'first_name' => 'abc3',


### PR DESCRIPTION
This is a replacement for https://github.com/civicrm/civicrm-core/pull/5104/files

I have done  it against 4.6 rather than master as the other fixes went into 4.6 & it's good to get api fixes working in as many versions as possible. 

I have some small misgivings about this as it IS possible that a dev might have coded around the way it currently works & this could cause problems. It's not an obvious coding pattern to follow - ie. because if you are looking for the values of the custom field they are in the values of the relevant field - they just happen to be the array keys as well.

I'm inclined to think this is OK - but we should 
a) add it to the change log
b) potentially keep this PR open until your last bugs are fixed (so if a release goes out in the meantime it isn't in it)
c)  then do a quick blog mentioning there have been a bunch of minor fixes & people should check the list - are you up to do the blog/ update the change log @johanv 

@totten @colemanw - FYW (like FYI but For your wisdom - should you care to impart some :-)

---
- [CRM-15915: API returns values of multi-select custom field in different format depending on the entitiy the custom field set is used for.](https://issues.civicrm.org/jira/browse/CRM-15915)
