### PR TITLE
handle !isset($short['ref']) as '', not null

### DIFF
--- a/CRM/Core/Block.php
+++ b/CRM/Core/Block.php
@@ -459,7 +459,7 @@ class CRM_Core_Block {
       $value['url'] = CRM_Utils_System::url($short['path'], $short['query'], FALSE);
     }
     $value['title'] = $short['title'];
-    $value['ref'] = $short['ref'];
+    $value['ref'] = isset($short['ref']) ? $short['ref'] : '';
     if (!empty($short['shortCuts'])) {
       foreach ($short['shortCuts'] as $shortCut) {
         $value['shortCuts'][] = self::setShortcutValues($shortCut);


### PR DESCRIPTION
This was in an override of a site I am taking over and seems like it should have been submitted to core.
