### PR TITLE
CRM-16991 Order Header and Footer lists by name field not by table id

### DIFF
--- a/ang/crmMailing/BlockHeaderFooter.html
+++ b/ang/crmMailing/BlockHeaderFooter.html
@@ -12,7 +12,7 @@ Required vars: mailing, crmMailingConst
         ui-options="{dropdownAutoWidth : true, allowClear: true}"
         ng-change="checkTokens(mailing, '*')"
         ng-model="mailing.header_id"
-        ng-options="mc.id as mc.name for mc in crmMailingConst.headerfooterList | filter:{component_type: 'Header'}">
+        ng-options="mc.id as mc.name for mc in crmMailingConst.headerfooterList | filter:{component_type: 'Header'} | orderBy:'name'">
         <option value=""></option>
       </select>
     </div>
@@ -24,7 +24,7 @@ Required vars: mailing, crmMailingConst
         ui-options="{dropdownAutoWidth : true, allowClear: true}"
         ng-change="checkTokens(mailing, '*')"
         ng-model="mailing.footer_id"
-        ng-options="mc.id as mc.name for mc in crmMailingConst.headerfooterList | filter:{component_type: 'Footer'}">
+        ng-options="mc.id as mc.name for mc in crmMailingConst.headerfooterList | filter:{component_type: 'Footer'} | orderBy:'name'">
         <option value=""></option>
       </select>
     </div>


### PR DESCRIPTION
This is just to improve the usability of the Header and Footer section of the new CiviMail. Having it just by the table id makes it difficult to find the one you want some times, Alpha ordering it makes sense to me. 

@totten I noticed that the from addresses are ordered by weight which i can understand but i'm wondering if it might be better having them also alpha order but want someone else's thoughts on that. 

@eileenmcnaughton this is the filtering with only 1 field of the array doing the job. 
