### PR TITLE
CRM-16943: CRM_Core_Form_Search assumes a checkbox. CiviGrant dashboa…

### DIFF
--- a/CRM/Core/Form/Search.php
+++ b/CRM/Core/Form/Search.php
@@ -120,8 +120,10 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
    */
   public function addRowSelectors($rows) {
     $this->addElement('checkbox', 'toggleSelect', NULL, NULL, array('class' => 'select-rows'));
-    foreach ($rows as $row) {
-      $this->addElement('checkbox', $row['checkbox'], NULL, NULL, array('class' => 'select-row'));
+    if (!empty($rows)) {
+      foreach ($rows as $row) {
+        $this->addElement('checkbox', $row['checkbox'], NULL, NULL, array('class' => 'select-row'));
+      }
     }
   }
 


### PR DESCRIPTION
…rd has none

---
- CRM-16943: CRM_Core_Form_Search assumes a checkbox. CiviGrant dashboard has none
  https://issues.civicrm.org/jira/browse/CRM-16943
