### PR TITLE
CRM-16999 - test: searching for custom datetime with <=

### DIFF
--- a/api/v3/examples/Contact/Create.php
+++ b/api/v3/examples/Contact/Create.php
@@ -2,17 +2,24 @@
 /**
  * Test Generated example demonstrating the Contact.create API.
  *
- * This demonstrates setting a custom field through the API.
- *
  * @return array
  *   API result array
  */
 function contact_create_example() {
   $params = array(
-    'first_name' => 'abc1',
-    'contact_type' => 'Individual',
-    'last_name' => 'xyz1',
-    'custom_1' => 'custom string',
+    'id' => 3,
+    'api.CustomField.create' => array(
+      'id' => 1,
+      'html_type' => 'Select Date',
+      'data_type' => 'Date',
+      'time_format' => '',
+    ),
+    'api.CustomValue.create' => array(
+      'id' => '1',
+      'entity_id' => 3,
+      'custom_1' => '20150810',
+    ),
+    'api.CustomValue.get' => 1,
   );
 
   try{
@@ -45,10 +52,10 @@ function contact_create_expectedresult() {
     'is_error' => 0,
     'version' => 3,
     'count' => 1,
-    'id' => 1,
+    'id' => 3,
     'values' => array(
-      '1' => array(
-        'id' => '1',
+      '3' => array(
+        'id' => '3',
         'contact_type' => 'Individual',
         'contact_sub_type' => '',
         'do_not_email' => 0,
@@ -59,8 +66,8 @@ function contact_create_expectedresult() {
         'is_opt_out' => 0,
         'legal_identifier' => '',
         'external_identifier' => '',
-        'sort_name' => 'xyz1, abc1',
-        'display_name' => 'abc1 xyz1',
+        'sort_name' => 'xyz3, abc3',
+        'display_name' => 'abc3 xyz3',
         'nick_name' => '',
         'legal_name' => '',
         'image_URL' => '',
@@ -69,22 +76,22 @@ function contact_create_expectedresult() {
         'preferred_mail_format' => 'Both',
         'hash' => '67eac7789eaee00',
         'api_key' => '',
-        'first_name' => 'abc1',
+        'first_name' => 'abc3',
         'middle_name' => '',
-        'last_name' => 'xyz1',
+        'last_name' => 'xyz3',
         'prefix_id' => '',
         'suffix_id' => '',
         'formal_title' => '',
         'communication_style_id' => '',
         'email_greeting_id' => '1',
         'email_greeting_custom' => '',
-        'email_greeting_display' => '',
+        'email_greeting_display' => 'Dear abc3',
         'postal_greeting_id' => '1',
         'postal_greeting_custom' => '',
-        'postal_greeting_display' => '',
+        'postal_greeting_display' => 'Dear abc3',
         'addressee_id' => '1',
         'addressee_custom' => '',
-        'addressee_display' => '',
+        'addressee_display' => 'abc3 xyz3',
         'job_title' => '',
         'gender_id' => '',
         'birth_date' => '',
@@ -97,6 +104,67 @@ function contact_create_expectedresult() {
         'user_unique_id' => '',
         'created_date' => '2013-07-28 08:49:19',
         'modified_date' => '2012-11-14 16:02:35',
+        'api.CustomField.create' => array(
+          'is_error' => 0,
+          'version' => 3,
+          'count' => 1,
+          'id' => 1,
+          'values' => array(
+            '0' => array(
+              'id' => '1',
+              'custom_group_id' => '1',
+              'name' => 'test_datetime',
+              'label' => 'Demo Date',
+              'data_type' => 'Date',
+              'html_type' => 'Select Date',
+              'default_value' => '',
+              'is_required' => 0,
+              'is_searchable' => 0,
+              'is_search_range' => 0,
+              'weight' => '4',
+              'help_pre' => '',
+              'help_post' => '',
+              'mask' => '',
+              'attributes' => '',
+              'javascript' => '',
+              'is_active' => '1',
+              'is_view' => 0,
+              'options_per_line' => '',
+              'text_length' => '',
+              'start_date_years' => '',
+              'end_date_years' => '',
+              'date_format' => 'mm/dd/yy',
+              'time_format' => '',
+              'note_columns' => '',
+              'note_rows' => '',
+              'column_name' => 'demo_date_1',
+              'option_group_id' => '',
+              'filter' => '',
+              'in_selector' => 0,
+            ),
+          ),
+        ),
+        'api.CustomValue.create' => array(
+          'is_error' => 0,
+          'version' => 3,
+          'count' => 1,
+          'values' => TRUE,
+        ),
+        'api.CustomValue.get' => array(
+          'is_error' => 0,
+          'version' => 3,
+          'count' => 2,
+          'values' => array(
+            '0' => array(
+              'entity_id' => '3',
+              'latest' => '2015-08-10 00:00:00',
+              'id' => '1',
+            ),
+            '1' => array(
+              'entity_table' => 'Contact',
+            ),
+          ),
+        ),
       ),
     ),
   );
@@ -106,7 +174,7 @@ function contact_create_expectedresult() {
 
 /*
 * This example has been generated from the API test suite.
-* The test that created it is called "testCreateWithCustom"
+* The test that created it is called "testCreateContactCustomFldDateTime"
 * and can be found at:
 * https://github.com/civicrm/civicrm-core/blob/master/tests/phpunit/api/v3/ContactTest.php
 *

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -443,6 +443,48 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     $result = $this->callAPIAndDocument('Contact', 'create', $params, __FUNCTION__, __FILE__);
   }
 
+  /**
+   * Try to retrieve contacts searching on a datetime custom field with <=.
+   *
+   * Unit test for CRM-16999.
+   * 
+   * Searching on custom fields will not work until CRM-16036 is fixed, but
+   * this test just wants to see whether operators like <= are accepted by
+   * the API if a custom field is a DateTime.
+   */
+  public function testGetContactCustomFldDateTimeBefore() {
+    // Create a custom group with a datetime field 'test_datetime'.
+    $custom_group_result = $this->customGroupCreate(
+      array(
+        'extends' => 'Individual',
+        'title' => 'datetime_test_group',
+        'api.CustomField.create' => array(
+          'custom_group_id' => '$value.id',
+          'name' => 'test_datetime',
+          'label' => 'Demo Date',
+          'html_type' => 'Select Date',
+          'data_type' => 'Date',
+          'time_format' => 2,
+          'weight' => 4,
+          'is_required' => 1,
+          'is_searchable' => 0,
+          'is_active' => 1,
+        ),
+      )
+    );
+    $custom_group = CRM_Utils_Array::first($custom_group_result['values']);
+    $custom_field_id = $custom_group['api.CustomField.create']['id'];
+
+    $dateTime = CRM_Utils_Date::currentDBDate();
+
+    // Search for contacts having test_datetime earlier than today.
+    $params = array("custom_$custom_field_id" => array('<=' => $dateTime));
+    $result = $this->callAPIAndDocument(
+        'Contact', 'get', $params, __FUNCTION__, __FILE__);
+
+    // I am happy if there is no error. :-)
+    $this->assertEquals(0, $result['is_error']);
+  }
 
   /**
    * Test creating a current employer through API.

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -446,7 +446,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
   /**
    * Try to retrieve contacts searching on a datetime custom field with <=.
    *
-   * Unit test for CRM-16999.
+   * Unit test for CRM-16999, which was an invalid issue. Never mind :-)
    * 
    * Searching on custom fields will not work until CRM-16036 is fixed, but
    * this test just wants to see whether operators like <= are accepted by
@@ -467,7 +467,8 @@ class api_v3_ContactTest extends CiviUnitTestCase {
           'time_format' => 2,
           'weight' => 4,
           'is_required' => 1,
-          'is_searchable' => 0,
+          'is_searchable' => 1,
+          'is_search_range' => 1,
           'is_active' => 1,
         ),
       )
@@ -475,7 +476,8 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     $custom_group = CRM_Utils_Array::first($custom_group_result['values']);
     $custom_field_id = $custom_group['api.CustomField.create']['id'];
 
-    $dateTime = CRM_Utils_Date::currentDBDate();
+    // Just some date...
+    $dateTime = '2015-08-10';
 
     // Search for contacts having test_datetime earlier than today.
     $params = array("custom_$custom_field_id" => array('<=' => $dateTime));


### PR DESCRIPTION
## This is just a unit test.
- CRM-16999: Using the API for searching on a custom datetime field with '<=' operator throws error
  https://issues.civicrm.org/jira/browse/CRM-16999
