### PR TITLE
CRM-17012: unit test and maybe a fix.

### DIFF
--- a/CRM/Core/BAO/CustomQuery.php
+++ b/CRM/Core/BAO/CustomQuery.php
@@ -386,6 +386,7 @@ SELECT label, value
         }
         elseif (count($value) && in_array(key($value), CRM_Core_DAO::acceptedSQLOperators(), TRUE)) {
           $op = key($value);
+          $value = $value[$op];
           $qillValue = CRM_Core_BAO_CustomField::getDisplayValue($value[$op], $id, $this->_options);
         }
         else {

--- a/CRM/Core/BAO/CustomQuery.php
+++ b/CRM/Core/BAO/CustomQuery.php
@@ -386,8 +386,8 @@ SELECT label, value
         }
         elseif (count($value) && in_array(key($value), CRM_Core_DAO::acceptedSQLOperators(), TRUE)) {
           $op = key($value);
-          $value = $value[$op];
           $qillValue = CRM_Core_BAO_CustomField::getDisplayValue($value[$op], $id, $this->_options);
+          $value = $value[$op];
         }
         else {
           $qillValue = CRM_Core_BAO_CustomField::getDisplayValue($value, $id, $this->_options);


### PR DESCRIPTION
The API has a problem when searching contacts on a custom datetime
field with the <= operator.

---
- CRM-17012: Contact API ignores <= operator for custom date fields
  https://issues.civicrm.org/jira/browse/CRM-17012
