### PR TITLE
 CRM-17005 Removed word "Occupied" from Country PS

### DIFF
--- a/xml/templates/civicrm_country.tpl
+++ b/xml/templates/civicrm_country.tpl
@@ -205,7 +205,7 @@ INSERT INTO civicrm_country (id, name,iso_code,region_id,is_province_abbreviated
 INSERT INTO civicrm_country (id, name,iso_code,region_id,is_province_abbreviated) VALUES("1162", "OMAN", "OM", "3", "0");
 INSERT INTO civicrm_country (id, name,iso_code,region_id,is_province_abbreviated) VALUES("1163", "PAKISTAN", "PK", "4", "0");
 INSERT INTO civicrm_country (id, name,iso_code,region_id,is_province_abbreviated) VALUES("1164", "PALAU", "PW", "4", "0");
-INSERT INTO civicrm_country (id, name,iso_code,region_id,is_province_abbreviated) VALUES("1165", "PALESTINIAN TERRITORY, OCCUPIED", "PS", "3", "0");
+INSERT INTO civicrm_country (id, name,iso_code,region_id,is_province_abbreviated) VALUES("1165", "PALESTINIAN TERRITORY", "PS", "3", "0");
 INSERT INTO civicrm_country (id, name,iso_code,region_id,is_province_abbreviated) VALUES("1166", "PANAMA", "PA", "2", "0");
 INSERT INTO civicrm_country (id, name,iso_code,region_id,is_province_abbreviated) VALUES("1167", "PAPUA NEW GUINEA", "PG", "4", "0");
 INSERT INTO civicrm_country (id, name,iso_code,region_id,is_province_abbreviated) VALUES("1168", "PARAGUAY", "PY", "2", "0");


### PR DESCRIPTION
Note - this is my first PR so hope it works :)

---
- [CRM-17005: Remove Word "Occupied" from Palestinian Territory in country list](https://issues.civicrm.org/jira/browse/CRM-17005)
