### PR TITLE
CRM-17020 remove unindexed join from activity report

### DIFF
--- a/CRM/Report/Form/Activity.php
+++ b/CRM/Report/Form/Activity.php
@@ -236,71 +236,18 @@ class CRM_Report_Form_Activity extends CRM_Report_Form {
           'activity_type_id' => array(
             'title' => ts('Activity Type'),
             'default_weight' => '2',
-            'dbAlias' => "option_value_civireport",
+            'dbAlias' => 'field(civicrm_activity_activity_type_id, ' . implode(', ', array_keys($this->activityTypes)) . ')',
           ),
         ),
         'grouping' => 'activity-fields',
         'alias' => 'activity',
       ),
+      // Hack to get $this->_alias populated for the table.
       'civicrm_activity_contact' => array(
         'dao' => 'CRM_Activity_DAO_ActivityContact',
-        'fields' => array(// so we have $this->_alias populated
+        'fields' => array(
         ),
-      ),
-      'civicrm_option_value' => array(
-        'dao' => 'CRM_Core_DAO_OptionValue',
-        'fields' => array(// so we have $this->_alias populated
-        ),
-        'status_id' =>
-        array(
-          'title' => ts('Activity Status'),
-          'default' => TRUE,
-          'type' => CRM_Utils_Type::T_STRING,
-        ),
-        'duration' =>
-        array(
-          'title' => ts('Duration'),
-          'type' => CRM_Utils_Type::T_INT,
-        ),
-        'location' =>
-        array(
-          'title' => ts('Location'),
-          'type' => CRM_Utils_Type::T_STRING,
-        ),
-        'details' => array(
-          'title' => ts('Activity Details'),
-        ),
-      ),
-      'filters' => array(
-        'activity_date_time' => array(
-          'default' => 'this.month',
-          'operatorType' => CRM_Report_Form::OP_DATE,
-        ),
-        'activity_subject' =>
-        array('title' => ts('Activity Subject')),
-        'location' =>
-        array(
-          'title' => ts('Location'),
-          'type' => CRM_Utils_Type::T_TEXT,
-        ),
-        'activity_type_id' =>
-        array(
-          'title' => ts('Activity Type'),
-          'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-          'options' => $this->activityTypes,
-        ),
-        'status_id' =>
-        array(
-          'title' => ts('Activity Status'),
-          'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-          'options' => CRM_Core_PseudoConstant::activityStatus(),
-        ),
-        'details' => array(
-          'title' => ts('Activity Details'),
-          'type' => CRM_Utils_Type::T_TEXT,
-        ),
-      ),
-    ) + $this->addressFields(TRUE);
+    )) + $this->addressFields(TRUE);
 
     if ($campaignEnabled) {
       // Add display column and filter for Survey Results, Campaign and Engagement Index if CiviCampaign is enabled
@@ -443,8 +390,6 @@ class CRM_Report_Form_Activity extends CRM_Report_Form {
           $this->_selectAliases[] = $orderByFld['dbAlias'];
           $this->_selectClauses[] = "{$fldInfo['dbAlias']} as {$orderByFld['dbAlias']}";
         }
-        $this->_selectAliases[] = $this->_aliases['civicrm_option_value'];
-        $this->_selectClauses[] = "{$this->_aliases['civicrm_option_value']}.label as {$this->_aliases['civicrm_option_value']}";
         $this->_selectAliases = array_unique($this->_selectAliases);
         $this->_selectClauses = array_unique($this->_selectClauses);
       }
@@ -518,9 +463,7 @@ class CRM_Report_Form_Activity extends CRM_Report_Form {
       }
       $this->_aliases['civicrm_contact'] = 'civicrm_contact_source';
     }
-    $this->_from .= " INNER JOIN civicrm_option_value {$this->_aliases['civicrm_option_value']}
-            ON {$this->_aliases['civicrm_option_value']}.option_group_id = {$activityTypeId}
-            AND {$this->_aliases['civicrm_option_value']}.value = {$this->_aliases['civicrm_activity']}.activity_type_id";
+
     $this->addAddressFromClause();
   }
 

--- a/CRM/Report/Form/Activity.php
+++ b/CRM/Report/Form/Activity.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 class CRM_Report_Form_Activity extends CRM_Report_Form {
   protected $_selectAliasesTotal = array();
@@ -245,9 +243,9 @@ class CRM_Report_Form_Activity extends CRM_Report_Form {
       // Hack to get $this->_alias populated for the table.
       'civicrm_activity_contact' => array(
         'dao' => 'CRM_Activity_DAO_ActivityContact',
-        'fields' => array(
-        ),
-    )) + $this->addressFields(TRUE);
+        'fields' => array(),
+      ),
+    ) + $this->addressFields(TRUE);
 
     if ($campaignEnabled) {
       // Add display column and filter for Survey Results, Campaign and Engagement Index if CiviCampaign is enabled
@@ -309,6 +307,8 @@ class CRM_Report_Form_Activity extends CRM_Report_Form {
   }
 
   /**
+   * Build select clause.
+   *
    * @param null $recordType
    */
   public function select($recordType = NULL) {
@@ -398,7 +398,9 @@ class CRM_Report_Form_Activity extends CRM_Report_Form {
   }
 
   /**
-   * @param $recordType
+   * Build from clause.
+   *
+   * @param string $recordType
    */
   public function from($recordType) {
     $activityContacts = CRM_Core_OptionGroup::values('activity_contacts', FALSE, FALSE, FALSE, NULL, 'name');
@@ -468,7 +470,9 @@ class CRM_Report_Form_Activity extends CRM_Report_Form {
   }
 
   /**
-   * @param null $recordType
+   * Build where clause.
+   *
+   * @param string $recordType
    */
   public function where($recordType = NULL) {
     $this->_where = " WHERE {$this->_aliases['civicrm_activity']}.is_test = 0 AND
@@ -552,11 +556,16 @@ class CRM_Report_Form_Activity extends CRM_Report_Form {
     }
   }
 
+  /**
+   * Override group by function.
+   */
   public function groupBy() {
     $this->_groupBy = "GROUP BY {$this->_aliases['civicrm_activity']}.id";
   }
 
   /**
+   * Build ACL clause.
+   *
    * @param string $tableAlias
    */
   public function buildACLClause($tableAlias = 'contact_a') {


### PR DESCRIPTION
These queries have basically been running until we kill them. Fixing it should be a candidate for 4.6.8 (but too late for 4.6.7 IMHO)

---
- [CRM-17020: Activity report brings server to it's knees](https://issues.civicrm.org/jira/browse/CRM-17020)
