### PR TITLE
add unique index for new sites on uf_group.name CRM-15961

### DIFF
--- a/xml/schema/Core/UFGroup.xml
+++ b/xml/schema/Core/UFGroup.xml
@@ -217,6 +217,12 @@
     <comment>Name of the UF group for directly addressing it in the codebase</comment>
     <add>3.0</add>
   </field>
+  <index>
+    <name>UI_name</name>
+    <fieldName>name</fieldName>
+    <unique>true</unique>
+    <add>4.7</add>
+  </index>
   <field>
     <name>created_id</name>
     <title>Profile Created By</title>


### PR DESCRIPTION
Given dgg indicated no appetitie for mass fixing non-unique names on existing sites, and we have been hurt by the existence of them more than once - I think we should at least add a unique index on new sites....

---
- [CRM-15961: uf_group.name may not be a unique value for CiviCRM installs that started prior to 4.2](https://issues.civicrm.org/jira/browse/CRM-15961)
