### PR TITLE
CRM-17031 Improvement to offline Event Confirmation template

### DIFF
--- a/xml/templates/message_templates/event_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_html.tpl
@@ -21,6 +21,7 @@
 
   <tr>
    <td>
+    <p>Dear {contact.display_name}</p>
 
     {if $event.confirm_email_text AND (not $isOnWaitlist AND not $isRequireApproval)}
      <p>{$event.confirm_email_text|htmlize}</p>


### PR DESCRIPTION
the Online Event Confirmation template starts with the text:
Dear {contact.display_name}
while the Offline one does not. This issue is to add the line in the same place in the Offline template.

---
- [CRM-17031: Improvement to offline Event Confirmation template](https://issues.civicrm.org/jira/browse/CRM-17031)
