### PR TITLE
CRM-16737 adjustment, (do not merge to master) referred to wrong param

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1429,7 +1429,7 @@ WHERE   id IN ( ' . implode(' , ', array_keys($membershipType)) . ' )';
         // CRM-16737 $result['contribution_status_id'] is deprecated in favour
         // of payment_status_id as the payment processor only knows whether the payment is complete
         // not whether payment completes the contribution
-        $params['contribution_status_id'] = $params['payment_status_id'];
+        $params['contribution_status_id'] = $result['payment_status_id'];
       }
       // do what used to happen previously
       else {


### PR DESCRIPTION
- [CRM-16737: Payment Gateways that have processed a payment to use payment_status_id = 1](https://issues.civicrm.org/jira/browse/CRM-16737)
