### PR TITLE
CRM-16955 move setting of contact_id to parent form

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -211,7 +211,7 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
   public function preProcess() {
     $this->_contactID = CRM_Utils_Request::retrieve('cid', 'Positive', $this);
     $this->assign('contactID', $this->_contactID);
-
+    CRM_Core_Resources::singleton()->addVars('coreForm', array('contact_id' => (int) $this->_contactID));
     $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'add');
   }
 

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -186,7 +186,6 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
         CRM_Core_Error::fatal(ts("This Membership is linked to a contribution. You must have 'delete in CiviContribute' permission in order to delete this record."));
       }
     }
-    CRM_Core_Resources::singleton()->addVars('coreForm', array('contact_id' => (int) $this->_contactID));
 
     if ($this->_action & CRM_Core_Action::ADD) {
       if (!CRM_Member_BAO_Membership::statusAvailabilty($this->_contactID)) {


### PR DESCRIPTION
- [CRM-16955: Billing form does not preload defaults when changing processor](https://issues.civicrm.org/jira/browse/CRM-16955)
