### PR TITLE
CRM-17044 sched reminders on membership join_date

### DIFF
--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -1315,6 +1315,7 @@ HAVING reminder.id = MAX(reminder.id) AND reminder.reference_date <> {$dateField
         }
         $insertAdditionalSql = "
 INSERT INTO civicrm_action_log (contact_id, entity_id, entity_table, action_schedule_id)
+SELECT * FROM (
 {$addSelect}
 FROM ({$contactTable})
 LEFT JOIN {$additionReminderClause}
@@ -1328,7 +1329,9 @@ AND c.id NOT IN (
      WHERE rem.action_schedule_id = {$actionSchedule->id}
       AND rem.entity_table = '{$mapping->entity}'
     )
+
 GROUP BY c.id
+) as reminders
 ";
         CRM_Core_DAO::executeQuery($insertAdditionalSql);
       }


### PR DESCRIPTION
This PR isn't expected to pass as the test illustrates current behaviour whereas the change to the BAO changes that behaviour a little (& is possibly the fix I recommend for 4.6 as it seems like the 'minimum sane behaviour') - I've been hearing about minimum viable product lately :-)

---
- [CRM-17044: 4.6 upgrade triggered out mass-email to 'also include' recipient](https://issues.civicrm.org/jira/browse/CRM-17044)
