### PR TITLE
CRM-17064 transactions going to paypal express instead of pro

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1027,7 +1027,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
    *   Contact ID
    *
    * @return bool|\CRM_Contribute_DAO_Contribution
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    * @throws \Civi\Payment\Exception\PaymentProcessorException
    */
   protected function processCreditCard($submittedValues, $lineItem, $contactID) {
@@ -1112,7 +1112,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       $this->_params["country-{$this->_bltID}"] = $this->_params["billing_country-{$this->_bltID}"] = CRM_Core_PseudoConstant::countryIsoCode($this->_params["billing_country_id-{$this->_bltID}"]);
     }
 
-    if (in_array('credit_card_exp_date', array_keys($this->_paymentFields))) {
+    if (in_array('credit_card_exp_date', array_keys($this->_params))) {
       $this->_params['year'] = CRM_Core_Payment_Form::getCreditCardExpirationYear($this->_params);
       $this->_params['month'] = CRM_Core_Payment_Form::getCreditCardExpirationMonth($this->_params);
     }

--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -705,12 +705,7 @@ abstract class CRM_Core_Payment {
       }
     }
     else {
-      if ($this->_paymentProcessor['billing_mode'] == 1) {
-        $result = $this->doDirectPayment($params, $component);
-      }
-      else {
-        $result = $this->doExpressCheckout($params);
-      }
+      $result = $this->doDirectPayment($params, $component);
       if (is_array($result) && !isset($result['payment_status_id'])) {
         if (!empty($params['is_recur'])) {
           // See comment block.

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -176,6 +176,60 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test the submit function on the contribution page.
+   */
+  public function testSubmitCreditCardPayPal() {
+    $form = new CRM_Contribute_Form_Contribution();
+    $paymentProcessorID = $this->paymentProcessorCreate(array('is_test' => 0));
+    $form->_mode = 'Live';
+    try {
+      $form->testSubmit(array(
+        'total_amount' => 50,
+        'financial_type_id' => 1,
+        'receive_date' => '04/21/2015',
+        'receive_date_time' => '11:27PM',
+        'contact_id' => $this->_individualId,
+        'payment_instrument_id' => array_search('Credit Card', $this->paymentInstruments),
+        'contribution_status_id' => 1,
+        'credit_card_number' => 4444333322221111,
+        'cvv2' => 123,
+        'credit_card_exp_date' => array(
+          'M' => 9,
+          'Y' => 2025,
+        ),
+        'credit_card_type' => 'Visa',
+        'billing_first_name' => 'Junko',
+        'billing_middle_name' => '',
+        'billing_last_name' => 'Adams',
+        'billing_street_address-5' => '790L Lincoln St S',
+        'billing_city-5' => 'Maryknoll',
+        'billing_state_province_id-5' => 1031,
+        'billing_postal_code-5' => 10545,
+        'billing_country_id-5' => 1228,
+        'frequency_interval' => 1,
+        'frequency_unit' => 'month',
+        'installments' => '',
+        'hidden_AdditionalDetail' => 1,
+        'hidden_Premium' => 1,
+        'from_email_address' => '"civi45" <civi45@civicrm.com>',
+        'receipt_date' => '',
+        'receipt_date_time' => '',
+        'payment_processor_id' => $paymentProcessorID,
+        'currency' => 'USD',
+        'source' => '',
+      ), CRM_Core_Action::ADD);
+    }
+    catch (Civi\Payment\Exception\PaymentProcessorException $e) {
+      $this->assertEquals('10544: Transaction cannot be processed. Please use a different payment card.',
+        $e->getMessage());
+    }
+    $this->callAPISuccessGetCount('Contribution', array(
+      'contact_id' => $this->_individualId,
+      'contribution_status_id' => 'Pending',
+    ), 1);
+  }
+
+  /**
    * Test the submit function with an invalid payment.
    *
    * We expect the contribution to be created but left pending. The payment has failed.


### PR DESCRIPTION
4.7 regression...

---
- [CRM-17064: Paypal transactions being passed to Paypal Express not Paypal pro](https://issues.civicrm.org/jira/browse/CRM-17064)
