### PR TITLE
Revert "CRM-16512 - Fix permission checks on self"

### DIFF
--- a/CRM/ACL/API.php
+++ b/CRM/ACL/API.php
@@ -118,18 +118,9 @@ class CRM_ACL_API {
       return $deleteClause;
     }
 
-    $user = CRM_Core_Session::getLoggedInContactID();
     if ($contactID == NULL) {
+      $user = CRM_Core_Session::getLoggedInContactID();
       $contactID = $user ? $user : 0;
-    }
-
-    // Check if contact has permissions on self
-    if ($user && $contactID == $user) {
-      if (CRM_Core_Permission::check('edit my contact') ||
-        ($type == self::VIEW && CRM_Core_Permission::check('view my contact'))
-      ) {
-        return ' ( 1 ) ';
-      }
     }
 
     return implode(' AND ',


### PR DESCRIPTION
This reverts commit 071a4d0ecfadb1c0d7b023259c817fecb38aebd1.

Conflicts:
    CRM/ACL/API.php

---
- [CRM-16512: Contact Dashboard: 403 and dataTables warning if user doesn't have 'view all contacts'](https://issues.civicrm.org/jira/browse/CRM-16512)
