### PR TITLE
CRM-17066 Limit the Save template icon display to only those who have…

### DIFF
--- a/CRM/Mailing/Info.php
+++ b/CRM/Mailing/Info.php
@@ -175,6 +175,7 @@ class CRM_Mailing_Info extends CRM_Core_Component_Info {
         'schedule mailings',
         'approve mailings',
         'delete in CiviMail',
+        'edit message templates',
       ));
 
     return $result;

--- a/ang/crmMailing/BlockMailing.html
+++ b/ang/crmMailing/BlockMailing.html
@@ -18,7 +18,7 @@ It could perhaps be thinned by 30-60% by making more directives.
           <option value=""></option>
           <option ng-repeat="frm in crmMsgTemplates.getAll() | orderBy:'msg_title'" ng-value="frm.id">{{frm.msg_title}}</option>
         </select>
-        <a crm-icon="disk" ng-click="saveTemplate(mailing)" class="crm-hover-button" title="{{ts('Save As')}}"></a>
+        <a crm-icon="disk" ng-if="checkPerm('edit message templates')" ng-click="saveTemplate(mailing)" class="crm-hover-button" title="{{ts('Save As')}}"></a>
       </div>
     </div>
     <div crm-ui-field="{name: 'subform.fromAddress', title: ts('From'), help: hs('from_email')}">

--- a/ang/crmMailing/MsgTemplateCtrl.js
+++ b/ang/crmMailing/MsgTemplateCtrl.js
@@ -4,7 +4,7 @@
   angular.module('crmMailing').controller('MsgTemplateCtrl', function MsgTemplateCtrl($scope, crmMsgTemplates, dialogService) {
     var ts = $scope.ts = CRM.ts(null);
     $scope.crmMsgTemplates = crmMsgTemplates;
-
+    $scope.checkPerm = CRM.checkPerm;
     // @return Promise MessageTemplate (per APIv3)
     $scope.saveTemplate = function saveTemplate(mailing) {
       var model = {


### PR DESCRIPTION
… permission to edit mailing templates

@colemanw I see this as supplementing your PR on this issue, All this does is follow's Tim's pattern and filters who can see the "Save Templates" icon to those who actually have permission to save the template
