### PR TITLE
CRM-12326 quicksearch speed improvements

### DIFF
--- a/api/v3/Contact.php
+++ b/api/v3/Contact.php
@@ -853,7 +853,7 @@ function civicrm_api3_contact_getquick($params) {
       if (!in_array('email', $list)) {
         $includeEmailFrom = "LEFT JOIN civicrm_email eml ON ( cc.id = eml.contact_id AND eml.is_primary = 1 )";
       }
-      $emailWhere =  " WHERE email LIKE '$strSearch'";
+      $emailWhere = " WHERE email LIKE '$strSearch'";
     }
   }
 
@@ -912,7 +912,7 @@ function civicrm_api3_contact_getquick($params) {
       )
     ";
   }
-  $query .=") t
+  $query .= ") t
     {$orderByOuter}
     LIMIT    0, {$limit}
   ";

--- a/api/v3/Contact.php
+++ b/api/v3/Contact.php
@@ -906,7 +906,7 @@ function civicrm_api3_contact_getquick($params) {
           FROM   civicrm_contact cc {$from}
         {$aclFrom}
         {$additionalFrom} {$includeEmailFrom}
-        {$emailWhere}
+        {$emailWhere} AND cc.is_deleted = 0
         {$orderByInner}
       LIMIT 0, {$limit}
       )

--- a/api/v3/Contact.php
+++ b/api/v3/Contact.php
@@ -876,7 +876,7 @@ function civicrm_api3_contact_getquick($params) {
 
   $orderByInner = $orderByOuter = "ORDER BY exactFirst";
   if ($config->includeOrderByClause) {
-    $orderByInner = "ORDER BY sort_name";
+    $orderByInner = "ORDER BY exactFirst, sort_name";
     $orderByOuter .= ", sort_name";
   }
 

--- a/api/v3/Contact.php
+++ b/api/v3/Contact.php
@@ -877,8 +877,7 @@ function civicrm_api3_contact_getquick($params) {
       ";
   }
 
-  $orderByInner = "";
-  $orderByOuter = "ORDER BY exactFirst";
+  $orderByInner = $orderByOuter = "ORDER BY exactFirst";
   if ($config->includeOrderByClause) {
     $orderByInner = "ORDER BY sort_name";
     $orderByOuter .= ", sort_name";
@@ -895,7 +894,8 @@ function civicrm_api3_contact_getquick($params) {
             FROM   civicrm_contact cc {$from}
     {$aclFrom}
     {$additionalFrom} {$includeEmailFrom}
-    {$exactWhereClause}
+    {$whereClause}
+    {$orderByInner}
     LIMIT 0, {$limit} )
     ";
   if ($whereClause != $exactWhereClause) {

--- a/api/v3/Contact.php
+++ b/api/v3/Contact.php
@@ -906,7 +906,7 @@ function civicrm_api3_contact_getquick($params) {
           FROM   civicrm_contact cc {$from}
         {$aclFrom}
         {$additionalFrom} {$includeEmailFrom}
-        {$emailWhere} AND cc.is_deleted = 0
+        {$emailWhere} AND cc.is_deleted = 0 " . ($aclWhere ? " AND $aclWhere " : '') . "
         {$orderByInner}
       LIMIT 0, {$limit}
       )

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -2150,13 +2150,78 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   /**
    * Test that getquick returns contacts with an exact first name match first.
+   *
+   * The search string 'b' & 'bob' both return ordered by sort_name if includeOrderByClause
+   * is true (default) but if it is false then matches are returned in ID order.
    */
   public function testGetQuickExactFirst() {
     $this->getQuickSearchSampleData();
     $result = $this->callAPISuccess('contact', 'getquick', array('name' => 'b'));
     $this->assertEquals('A Bobby, Bobby', $result['values'][0]['sort_name']);
+    $this->assertEquals('B Bobby, Bobby', $result['values'][1]['sort_name']);
     $result = $this->callAPISuccess('contact', 'getquick', array('name' => 'bob'));
     $this->assertEquals('A Bobby, Bobby', $result['values'][0]['sort_name']);
+    $this->assertEquals('B Bobby, Bobby', $result['values'][1]['sort_name']);
+    $this->callAPISuccess('Setting', 'create', array('includeOrderByClause' => FALSE));
+    $result = $this->callAPISuccess('contact', 'getquick', array('name' => 'bob'));
+    $this->assertEquals('Bob, Bob', $result['values'][0]['sort_name']);
+    $this->assertEquals('A Bobby, Bobby', $result['values'][1]['sort_name']);
+  }
+
+  /**
+   * Test that getquick returns contacts with an exact first name match first.
+   */
+  public function testGetQuickExternalID() {
+    $this->getQuickSearchSampleData();
+    $result = $this->callAPISuccess('contact', 'getquick', array(
+      'name' => 'b',
+      'field_name' => 'external_identifier',
+      'table_name' => 'cc',
+    ));
+    $this->assertEquals(0, $result['count']);
+    $result = $this->callAPISuccess('contact', 'getquick', array(
+      'name' => 'abc',
+      'field_name' => 'external_identifier',
+      'table_name' => 'cc',
+    ));
+    $this->assertEquals(1, $result['count']);
+    $this->assertEquals('Bob, Bob', $result['values'][0]['sort_name']);
+  }
+
+  /**
+   * Test that getquick returns contacts with an exact first name match first.
+   */
+  public function testGetQuickID() {
+    $this->getQuickSearchSampleData();
+    $result = $this->callAPISuccess('contact', 'getquick', array(
+      'name' => 2,
+      'field_name' => 'id',
+      'table_name' => 'cc',
+    ));
+    $this->assertEquals(1, $result['count']);
+    $this->assertEquals('A Bobby, Bobby', $result['values'][0]['sort_name']);
+    $result = $this->callAPISuccess('contact', 'getquick', array(
+      'name' => 2,
+      'field_name' => 'contact_id',
+      'table_name' => 'cc',
+    ));
+    $this->assertEquals(1, $result['count']);
+    $this->assertEquals('A Bobby, Bobby', $result['values'][0]['sort_name']);
+  }
+
+  /**
+   * Test that getquick returns contacts with an exact first name match first.
+   */
+  public function testGetQuickFirstName() {
+    $this->getQuickSearchSampleData();
+    $result = $this->callAPISuccess('contact', 'getquick', array(
+      'name' => 'Bob',
+      'field_name' => 'first_name',
+      'table_name' => 'cc',
+    ));
+    $this->assertEquals('Bob, Bob', $result['values'][0]['sort_name']);
+    $this->assertEquals('K Bobby, Bob', $result['values'][1]['sort_name']);
+    $this->assertEquals('A Bobby, Bobby', $result['values'][2]['sort_name']);
     $this->callAPISuccess('Setting', 'create', array('includeOrderByClause' => FALSE));
     $result = $this->callAPISuccess('contact', 'getquick', array('name' => 'bob'));
     $this->assertEquals('Bob, Bob', $result['values'][0]['sort_name']);
@@ -2167,8 +2232,18 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    */
   public function getQuickSearchSampleData() {
     $contacts = array(
-      array('first_name' => 'Bob', 'last_name' => 'Bob'),
-      array('first_name' => 'Bobby', 'last_name' => 'A Bobby'),
+      array('first_name' => 'Bob', 'last_name' => 'Bob', 'external_identifier' => 'abc'),
+      array('first_name' => 'Bobby', 'last_name' => 'A Bobby', 'external_identifier' => 'abcd'),
+      array('first_name' => 'Bobby', 'last_name' => 'B Bobby', 'external_identifier' => 'bcd'),
+      array('first_name' => 'Bobby', 'last_name' => 'C Bobby', 'external_identifier' => 'bcde'),
+      array('first_name' => 'Bobby', 'last_name' => 'D Bobby', 'external_identifier' => 'efg'),
+      array('first_name' => 'Bobby', 'last_name' => 'E Bobby', 'external_identifier' => 'hij'),
+      array('first_name' => 'Bobby', 'last_name' => 'F Bobby', 'external_identifier' => 'klm'),
+      array('first_name' => 'Bobby', 'last_name' => 'G Bobby', 'external_identifier' => 'nop'),
+      array('first_name' => 'Bobby', 'last_name' => 'H Bobby', 'external_identifier' => 'qrs'),
+      array('first_name' => 'Bobby', 'last_name' => 'I Bobby'),
+      array('first_name' => 'Bobby', 'last_name' => 'J Bobby'),
+      array('first_name' => 'Bob', 'last_name' => 'K Bobby', 'external_identifier' => 'bcdef'),
     );
     foreach ($contacts as $type => $contact) {
       $contact['contact_type'] = 'Individual';

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -2267,7 +2267,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     $expected = array(
       'Bob, Bob',
       'A Bobby, Bobby',
-      'B Bobby, Bobby'
+      'B Bobby, Bobby',
     );
 
     foreach ($expected as $index => $value) {
@@ -2305,16 +2305,26 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     $contacts = array(
       array('first_name' => 'Bob', 'last_name' => 'Bob', 'external_identifier' => 'abc', 'email' => 'bob@bob.com'),
       array('first_name' => 'Bobby', 'last_name' => 'A Bobby', 'external_identifier' => 'abcd'),
-      array('first_name' => 'Bobby', 'last_name' => 'B Bobby', 'external_identifier' => 'bcd', 'api.address.create' => array(
-        'street_address' => 'Sesame Street',
-        'city' => 'Toronto',
-        'location_type_id' => 1,
-      ),),
-      array('first_name' => 'Bobby', 'last_name' => 'C Bobby', 'external_identifier' => 'bcde',  'api.address.create' => array(
-        'street_address' => 'Te huarahi',
-        'city' => 'Whanganui',
-        'location_type_id' => 1,
-      ),),
+      array(
+        'first_name' => 'Bobby',
+        'last_name' => 'B Bobby',
+        'external_identifier' => 'bcd',
+        'api.address.create' => array(
+          'street_address' => 'Sesame Street',
+          'city' => 'Toronto',
+          'location_type_id' => 1,
+        ),
+      ),
+      array(
+        'first_name' => 'Bobby',
+        'last_name' => 'C Bobby',
+        'external_identifier' => 'bcde',
+        'api.address.create' => array(
+          'street_address' => 'Te huarahi',
+          'city' => 'Whanganui',
+          'location_type_id' => 1,
+        ),
+      ),
       array('first_name' => 'Bobby', 'last_name' => 'D Bobby', 'external_identifier' => 'efg'),
       array('first_name' => 'Bobby', 'last_name' => 'E Bobby', 'external_identifier' => 'hij', 'email' => 'bob@bobby.com'),
       array('first_name' => 'Bobby', 'last_name' => 'F Bobby', 'external_identifier' => 'klm'),

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -441,7 +441,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     $this->assertNotNull($customFldDate);
     $this->assertEquals($dateTime, $customFldDate);
     $this->assertEquals(000000, $customFldTime);
-    $result = $this->callAPIAndDocument('Contact', 'create', $params, __FUNCTION__, __FILE__);
+    $this->callAPIAndDocument('Contact', 'create', $params, __FUNCTION__, __FILE__);
   }
 
 
@@ -1641,9 +1641,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     $ids = $this->entityCustomGroupWithSingleFieldCreate(__FUNCTION__, __FILE__);
     $params['custom_' . $ids['custom_field_id']] = "custom string";
 
-    $moreids = $this->CustomGroupMultipleCreateWithFields();
-    $description = "/*this demonstrates the usage of chained api functions. In this case no notes or custom fields have been created ";
-    $subfile = "APIChainedArray";
+    $moreIDs = $this->CustomGroupMultipleCreateWithFields();
     $params = array(
       'sequential' => 1,
       'first_name' => 'abc3',
@@ -1665,7 +1663,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     // delete the contact and custom groups
     $this->callAPISuccess('contact', 'delete', array('id' => $result['id']));
     $this->customGroupDelete($ids['custom_group_id']);
-    $this->customGroupDelete($moreids['custom_group_id']);
+    $this->customGroupDelete($moreIDs['custom_group_id']);
 
     $this->assertEquals($result['id'], $result['values'][0]['id']);
     $this->assertArrayKeyExists('api.website.create', $result['values'][0]);
@@ -1996,10 +1994,9 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     $this->createContactFromXML();
     $description = "This demonstrates use of the 'getCount' action.
       This param causes the count of the only function to be returned as an integer.";
-    $subfile = "GetCountContact";
     $params = array('id' => 17);
     $result = $this->callAPIAndDocument('Contact', 'GetCount', $params, __FUNCTION__, __FILE__, $description,
-      $subfile, 'getcount');
+      'GetCountContact');
     $this->assertEquals('1', $result);
     $this->callAPISuccess('Contact', 'Delete', $params);
   }

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -2186,6 +2186,21 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     foreach ($expectedData as $index => $value) {
       $this->assertEquals($value, $result['values'][$index]['data']);
     }
+    $result = $this->callAPISuccess('contact', 'getquick', array(
+      'name' => 'h.',
+    ));
+    $expectedData = array(
+      'H Bobby, Bobby :: bob@h.com',
+    );
+    foreach ($expectedData as $index => $value) {
+      $this->assertEquals($value, $result['values'][$index]['data']);
+    }
+    $this->callAPISuccess('Setting', 'create', array('includeWildCardInName' => FALSE));
+    $result = $this->callAPISuccess('contact', 'getquick', array(
+      'name' => 'h.',
+    ));
+    $this->callAPISuccess('Setting', 'create', array('includeWildCardInName' => TRUE));
+    $this->assertEquals(0, $result['count']);
   }
 
   /**

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -2270,6 +2270,51 @@ class api_v3_ContactTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test that getquick applies ACLs.
+   */
+  public function testGetQuickFirstNameACLs() {
+    $this->getQuickSearchSampleData();
+    $userID = $this->createLoggedInUser();
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = array();
+    $result = $this->callAPISuccess('contact', 'getquick', array(
+      'name' => 'Bob',
+      'field_name' => 'first_name',
+      'table_name' => 'cc',
+    ));
+    $this->assertEquals(0, $result['count']);
+
+    $this->hookClass->setHook('civicrm_aclWhereClause', array($this, 'aclWhereNoBobH'));
+    CRM_Contact_BAO_Contact_Permission::cache($userID, CRM_Core_Permission::VIEW, TRUE);
+    $result = $this->callAPISuccess('contact', 'getquick', array(
+      'name' => 'Bob',
+      'field_name' => 'first_name',
+      'table_name' => 'cc',
+    ));
+    $this->assertEquals('K Bobby, Bob', $result['values'][1]['sort_name']);
+    // Without the ACL 9 would be bob@h.com.
+    $this->assertEquals('I Bobby, Bobby', $result['values'][9]['sort_name']);
+    $this->callAPISuccess('Setting', 'create', array('includeOrderByClause' => FALSE));
+    $result = $this->callAPISuccess('contact', 'getquick', array('name' => 'bob'));
+    $this->assertEquals('Bob, Bob', $result['values'][0]['sort_name']);
+    $this->assertEquals('A Bobby, Bobby', $result['values'][1]['sort_name']);
+  }
+
+  /**
+   * Full results returned.
+   * @implements CRM_Utils_Hook::aclWhereClause
+   *
+   * @param string $type
+   * @param array $tables
+   * @param array $whereTables
+   * @param int $contactID
+   * @param string $where
+   */
+  public function aclWhereNoBobH($type, &$tables, &$whereTables, &$contactID, &$where) {
+    $where = " email <> 'bob@h.com' OR email IS NULL";
+    $whereTables['civicrm_email'] = "LEFT JOIN civicrm_email e ON contact_a.id = e.contact_id";
+  }
+
+  /**
    * Test that getquick returns contacts with an exact last name match first.
    */
   public function testGetQuickLastName() {

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -2243,9 +2243,12 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   /**
    * Test that getquick returns contacts with an exact first name match first.
+   *
+   * Depending on the setting the sort name sort might click in next or not - test!
    */
   public function testGetQuickFirstName() {
     $this->getQuickSearchSampleData();
+    $this->callAPISuccess('Setting', 'create', array('includeOrderByClause' => TRUE));
     $result = $this->callAPISuccess('contact', 'getquick', array(
       'name' => 'Bob',
       'field_name' => 'first_name',
@@ -2263,6 +2266,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     $this->callAPISuccess('Setting', 'create', array('includeOrderByClause' => FALSE));
     $result = $this->callAPISuccess('contact', 'getquick', array('name' => 'bob'));
     $this->assertEquals('Bob, Bob', $result['values'][0]['sort_name']);
+    $this->assertEquals('A Bobby, Bobby', $result['values'][1]['sort_name']);
   }
 
   /**


### PR DESCRIPTION
Plus tests to cover CRM-17023, CRM-10687 (partially - this ticket added no tests & this PR backfills it somewhat )

---
- [CRM-12326: Name&email search is not using indexes correctly](https://issues.civicrm.org/jira/browse/CRM-12326)
- [CRM-17023: ExactFirst doesn't work in quicksearch](https://issues.civicrm.org/jira/browse/CRM-17023)
- [CRM-10687: Allow quicksearch by multiple fields](https://issues.civicrm.org/jira/browse/CRM-10687)
