### PR TITLE
CRM-17072 fix timezone handling for UTC dates

### DIFF
--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -548,6 +548,10 @@ abstract class CRM_Utils_System_Base {
   public function getTimeZoneOffset() {
     $timezone = $this->getTimeZoneString();
     if ($timezone) {
+      if ($timezone == 'UTC') {
+        // CRM-17072 Let's short-circuit all the zero handling & return it here!
+        return '+00:00';
+      }
       $tzObj = new DateTimeZone($timezone);
       $dateTime = new DateTime("now", $tzObj);
       $tz = $tzObj->getOffset($dateTime);


### PR DESCRIPTION
- [CRM-17072: Drupal timezon code does not handle UTC correctly](https://issues.civicrm.org/jira/browse/CRM-17072)
