### PR TITLE
CRM-17071 add required marker to payment form

### DIFF
--- a/CRM/Core/Payment/ProcessorForm.php
+++ b/CRM/Core/Payment/ProcessorForm.php
@@ -102,7 +102,9 @@ class CRM_Core_Payment_ProcessorForm {
   }
 
   /**
-   * @param $form
+   * Build the payment processor form.
+   *
+   * @param CRM_Core_Form $form
    */
   public static function buildQuickform(&$form) {
     //@todo document why this addHidden is here

--- a/templates/CRM/Core/BillingBlock.tpl
+++ b/templates/CRM/Core/BillingBlock.tpl
@@ -35,8 +35,11 @@
       {/if}
       <div class="crm-section billing_mode-section {$paymentTypeName}_info-section">
         {foreach from=$paymentFields item=paymentField}
+          {assign var='name' value=$form.$paymentField.name}
           <div class="crm-section {$form.$paymentField.name}-section">
-            <div class="label">{$form.$paymentField.label}</div>
+            <div class="label">{$form.$paymentField.label}
+              {if $requiredPaymentFields.$name}<span class="crm-marker" title="{ts}This field is required.{/ts}">*</span>{/if}
+            </div>
             <div class="content">{$form.$paymentField.html}
               {if $paymentField == 'cvv2'}{* @todo move to form assignment*}
                 <span class="cvv2-icon" title="{ts}Usually the last 3-4 digits in the signature area on the back of the card.{/ts}"> </span>
@@ -59,8 +62,11 @@
       <legend>{ts}Billing Name and Address{/ts}</legend>
       <div class="crm-section billing_name_address-section">
         {foreach from=$billingDetailsFields item=billingField}
+          {assign var='name' value=$form.$billingField.name}
           <div class="crm-section {$form.$billingField.name}-section">
-            <div class="label">{$form.$billingField.label}</div>
+            <div class="label">{$form.$billingField.label}
+              {if $requiredPaymentFields.$name}<span class="crm-marker" title="{ts}This field is required.{/ts}">*</span>{/if}
+            </div>
             {if $form.$billingField.type == 'text'}
               <div class="content">{$form.$billingField.html}</div>
             {else}


### PR DESCRIPTION
This commit adds the red asterisk to required payment fields, although they
are not set on the form layer as required as we don't want to alter existing validation

---
- [CRM-17071: Required billing fields not marked as required](https://issues.civicrm.org/jira/browse/CRM-17071)
