### PR TITLE
CRM-17003 previous commit caused wrong formatting in access tab on re…

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -664,8 +664,7 @@ class CRM_Core_Permission {
   }
 
   /**
-   * @param bool $descriptions
-   *   whether to return descriptions
+   * Get core permissions.
    *
    * @return array
    */

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -594,6 +594,11 @@ class CRM_Core_Permission {
       $permissions['administer Multiple Organizations'] = array($prefix . ts('administer Multiple Organizations'));
     }
 
+    if (!$descriptions) {
+      foreach ($permissions as $name => $attr) {
+        $permissions[$name] = array_shift($attr);
+      }
+    }
     if (!$all) {
       $components = CRM_Core_Component::getEnabledComponents();
     }
@@ -664,7 +669,7 @@ class CRM_Core_Permission {
    *
    * @return array
    */
-  public static function getCorePermissions($descriptions = FALSE) {
+  public static function getCorePermissions() {
     $prefix = ts('CiviCRM') . ': ';
     $permissions = array(
       'add contacts' => array(
@@ -835,12 +840,6 @@ class CRM_Core_Permission {
         ts('Allow users to view/ download their own invoices'),
       ),
     );
-
-    if (!$descriptions) {
-      foreach ($permissions as $name => $attr) {
-        $permissions[$name] = array_shift($attr);
-      }
-    }
 
     return $permissions;
   }


### PR DESCRIPTION
…port

The issue appeared to be that the re-formatting of administer multisite is happening after the re-formatting
dependent on the  parameter being passed in. The function doing the reformatting is apparently only called from
that function so we could move the description processing to the calling function.

NB - need to grep wordpress, joomla, drupal dirs for that fn before making the change I guess,
Or we could just do the  stuff twice to be safe
