### PR TITLE
CRM-17069: Search for Contribution with campaign causes fatal error

### DIFF
--- a/CRM/Campaign/BAO/Query.php
+++ b/CRM/Campaign/BAO/Query.php
@@ -603,13 +603,6 @@ INNER JOIN  civicrm_custom_group grp on fld.custom_group_id = grp.id
         $campaignIds[$campId] = $campId;
         $campaignTitles[$campId] = $allCampaigns[$campId];
       }
-      if (count($campaignIds) > 1) {
-        $op = 'IN';
-        $campaignIds = '(' . implode(',', $campaignIds) . ')';
-      }
-      else {
-        $campaignIds = reset($campaignIds);
-      }
     }
     else {
       $campaignIds = $campaign;


### PR DESCRIPTION
---
- CRM-17069: Search for Contribution with campaign  causes fatal error
  https://issues.civicrm.org/jira/browse/CRM-17069
