### PR TITLE
CRM-17101 - unit test & fix. searching on custom fields with <=.

### DIFF
--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -641,7 +641,7 @@ function _civicrm_api3_get_using_utils_sql($dao_name, $params, $isFillUniqueFiel
         );
       }
       else {
-        $query->where(CRM_Core_DAO::createSQLFilter('a.' . $column_name, $value, $type));
+        $query->where(CRM_Core_DAO::createSQLFilter("{$table_name}.{$column_name}", $value, $type));
       }
     }
   }

--- a/tests/phpunit/api/v3/EventTest.php
+++ b/tests/phpunit/api/v3/EventTest.php
@@ -451,7 +451,7 @@ class api_v3_EventTest extends CiviUnitTestCase {
 
   /**
    * Test searching on custom fields with less than or equal.
-   * 
+   *
    * See CRM-17101.
    */
   public function testEventGetCustomFieldLte() {


### PR DESCRIPTION
## This is a unit test for CRM-17101. It will fail.
- CRM-17101: civicrm_api3_basic_get does not work for SQL operators on custom fields.
  https://issues.civicrm.org/jira/browse/CRM-17101
