### PR TITLE
(WIP) 'Contains' operation for searching multi-select custom fields with the API.

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2329,6 +2329,20 @@ SELECT contact_id
             }
             return $escapedCriteria;
 
+          // contains
+          case 'CONTAINS':
+            $filters = array();
+            foreach (CRM_Utils_Array::explodePadded($criteria) as $criterium) {
+              $filters[] = (sprintf(
+                      '(%s LIKE "%%%s%%")', $fieldName, CRM_Core_DAO::VALUE_SEPARATOR . CRM_Core_DAO::escapeString($criterium) . CRM_Core_DAO::VALUE_SEPARATOR));
+            }
+            if (!$returnSanitisedArray) {
+              return (implode(' AND ', $filters));
+            }
+            else {
+              return NULL; // I am just guessing here ;-)
+            }
+
           // binary operators
 
           default:
@@ -2365,6 +2379,7 @@ SELECT contact_id
       'NOT BETWEEN',
       'IS NOT NULL',
       'IS NULL',
+      'CONTAINS',
     );
   }
 

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2342,9 +2342,9 @@ SELECT contact_id
             else {
               return NULL; // I am just guessing here ;-)
             }
+            break;
 
           // binary operators
-
           default:
             if (!$returnSanitisedArray) {
               return (sprintf('%s %s "%s"', $fieldName, $operator, CRM_Core_DAO::escapeString($criteria)));

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -641,7 +641,7 @@ function _civicrm_api3_get_using_utils_sql($dao_name, $params, $isFillUniqueFiel
         );
       }
       else {
-        $query->where(CRM_Core_DAO::createSQLFilter('a.' . $column_name, $value, $type));
+        $query->where(CRM_Core_DAO::createSQLFilter("{$table_name}.{$column_name}", $value, $type));
       }
     }
   }

--- a/tests/phpunit/api/v3/EventTest.php
+++ b/tests/phpunit/api/v3/EventTest.php
@@ -451,7 +451,7 @@ class api_v3_EventTest extends CiviUnitTestCase {
 
   /**
    * Test searching on custom fields with less than or equal.
-   * 
+   *
    * See CRM-17101.
    */
   public function testEventGetCustomFieldLte() {

--- a/tests/phpunit/api/v3/RelationshipTest.php
+++ b/tests/phpunit/api/v3/RelationshipTest.php
@@ -410,6 +410,96 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
     $this->customFieldDelete($ids['custom_field_id']);
     $this->customGroupDelete($ids['custom_group_id']);
   }
+  
+  /**
+   * Try to retrieve a relationship searching on multi-select custom field.
+   */
+  public function testGetWithCustomContains() {
+    $custom_group_result = $this->CallApiSuccess('CustomGroup', 'Create', array(
+      'name' => 'custom_group_on_relationship',
+      'title' => 'Custom group on relationship (test)',
+      'extends' => 'Relationship',
+      'is_active' => 1,
+      'sequential' => 1,
+    ));
+
+    $custom_field_result = $this->CallApiSuccess('CustomField', 'Create', array(
+      'custom_group_id' => $custom_group_result['id'],
+      'weight' => 1,
+      'name' => 'my_custom_field',
+      'label' => 'My custom field',
+      'data_type' => 'String',
+      'html_type' => 'Multi-Select',
+      'option_values' => array(
+        'A' => array(
+          'weight' => 1,
+          'value' => 'A',
+          'label' => 'label A',
+          'is_active' => 1,
+        ),
+        'B' => array(
+          'weight' => 2,
+          'value' => 'B',
+          'label' => 'label B',
+          'is_active' => 1,
+        ),
+        'C' => array(
+          'weight' => 3,
+          'value' => 'C',
+          'label' => 'label C',
+          'is_active' => 1,
+        ),
+      ),
+      'is_active' => 1,
+      'sequential' => 1,
+    ));
+
+    $organization_create_result = $this->CallApiSuccess('Contact', 'Create', array(
+      'contact_type' => 'Organization',
+      'organization_name' => 'Schmoe inc.',
+      'sequential' => 1,
+    ));
+
+    $contact_create_result = $this->CallApiSuccess('Contact', 'Create', array(
+      'contact_type' => 'Individual',
+      'first_name' => 'Joe',
+      'last_name' => 'Schmoe',
+      'api.relationship.create' => array(
+        'contact_id_a' => '$value.id',
+        'contact_id_b' => $organization_create_result['id'],
+        'relationship_type_id' => 5, // works for
+        'custom_' . $custom_field_result['id'] => array('A','B'),
+      ),
+      'sequential' => 1,
+    ));
+
+    $relationship_id = $contact_create_result['values'][0]['api.relationship.create']['id'];
+
+    $relationship_get_result = $this->CallApiSuccess('Relationship', 'GetSingle', array(
+      'custom_' . $custom_field_result['id'] => array('CONTAINS' => 'B'),
+      'sequential' => 1,
+    ));
+
+    // Clean up first, then assert.
+
+    $this->CallApiSuccess('Contact', 'Delete', array(
+      'id' => $contact_create_result['id'],
+    ));
+
+    $this->CallApiSuccess('Contact', 'Delete', array(
+      'id' => $organization_create_result['id'],
+    ));
+
+    $this->CallApiSuccess('CustomField', 'Delete', array(
+      'id' => $custom_field_result['id'],
+    ));
+
+    $this->CallApiSuccess('CustomGroup', 'Delete', array(
+      'id' => $custom_group_result['id'],
+    ));
+
+    $this->AssertEquals($relationship_id, $relationship_get_result['id']);    
+}
 
   /**
    * @return mixed

--- a/tests/phpunit/api/v3/RelationshipTest.php
+++ b/tests/phpunit/api/v3/RelationshipTest.php
@@ -410,7 +410,7 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
     $this->customFieldDelete($ids['custom_field_id']);
     $this->customGroupDelete($ids['custom_group_id']);
   }
-  
+
   /**
    * Try to retrieve a relationship searching on multi-select custom field.
    */
@@ -468,7 +468,7 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
         'contact_id_a' => '$value.id',
         'contact_id_b' => $organization_create_result['id'],
         'relationship_type_id' => 5, // works for
-        'custom_' . $custom_field_result['id'] => array('A','B'),
+        'custom_' . $custom_field_result['id'] => array('A', 'B'),
       ),
       'sequential' => 1,
     ));
@@ -498,8 +498,8 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
       'id' => $custom_group_result['id'],
     ));
 
-    $this->AssertEquals($relationship_id, $relationship_get_result['id']);    
-}
+    $this->AssertEquals($relationship_id, $relationship_get_result['id']);
+  }
 
   /**
    * @return mixed


### PR DESCRIPTION
I had to rebase this on my PR for CRM-17101 (#6611).

I implemented a 'contains' operator for searching values in multi-select custom fields.
I'm not sure whether this is a useful enhancement for the API, I'll leave that to you. It covers my use case, so I might as well upload it :-)

(Update: This PR is related to CRM-17096, which might be unclear because I mentioned another issue as well.)

---
- [CRM-17096: A 'contains' operation for the api to search multiselect custom values.](https://issues.civicrm.org/jira/browse/CRM-17096)

---
- [CRM-17101: civicrm_api3_basic_get does not work for SQL operators on custom fields.](https://issues.civicrm.org/jira/browse/CRM-17101)
