### PR TITLE
Split up some of CRM_Export_BAO_Export::ExportComponents into smaller…

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -52,6 +52,8 @@ class CRM_Export_BAO_Export {
    * return string Querymode
    */
   public static function getQueryMode($exportMode) {
+    $queryMode = CRM_Contact_BAO_Query::MODE_CONTACTS;
+
     switch ($exportMode) {
       case CRM_Export_Form_Select::CONTRIBUTE_EXPORT:
         $queryMode = CRM_Contact_BAO_Query::MODE_CONTRIBUTE;
@@ -212,7 +214,6 @@ class CRM_Export_BAO_Export {
       'name',
       FALSE
     );
-    $queryMode = CRM_Contact_BAO_Query::MODE_CONTACTS;
 
     $queryMode = self::getQueryMode($exportMode);
 
@@ -329,7 +330,7 @@ class CRM_Export_BAO_Export {
         }
       }
       $returnProperties[self::defaultReturnProperty($exportMode)] = 1;
-      if ($exportmode == CRM_Export_Form_Select::EVENT_EXPORT && !empty($returnProperties['participant_role'])) {
+      if ($exportMode == CRM_Export_Form_Select::EVENT_EXPORT && !empty($returnProperties['participant_role'])) {
         unset($returnProperties['participant_role']);
         $returnProperties['participant_role_id'] = 1;
       }

--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -606,11 +606,13 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
         $excludeTrashed = FALSE;
       }
     }
-    if (empty($where) && $excludeTrashed) {
-      $where = "WHERE contact_a.is_deleted != 1";
+    $trashClause = $excludeTrashed ? "contact_a.is_deleted != 1" : "( 1 )";
+
+    if (empty($where) {
+      $where = "WHERE $trashClause";
     }
-    elseif ($excludeTrashed) {
-      $where .= " AND contact_a.is_deleted != 1";
+    else {
+      $where .= " AND $trashClause";
     }
 
     $queryString = "$select $from $where $having";

--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -92,7 +92,7 @@ class CRM_Export_BAO_Export {
    *
    * return string $property
    */
-  public static function defultReturnProperty($exportMode) {
+  public static function defaultReturnProperty($exportMode) {
     // hack to add default returnproperty based on export mode
     if ($exportMode == CRM_Export_Form_Select::CONTRIBUTE_EXPORT) {
       $property = 'contribution_id';
@@ -328,7 +328,7 @@ class CRM_Export_BAO_Export {
           }
         }
       }
-      $returnProperties[self::defultReturnProperty($exportMode)] = 1;
+      $returnProperties[self::defaultReturnProperty($exportMode)] = 1;
       if ($exportmode == CRM_Export_Form_Select::EVENT_EXPORT && !empty($returnProperties['participant_role'])) {
         unset($returnProperties['participant_role']);
         $returnProperties['participant_role_id'] = 1;

--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -44,6 +44,117 @@ class CRM_Export_BAO_Export {
   const EXPORT_ROW_COUNT = 10000;
 
   /**
+   * Get Querymode based on ExportMode
+   *
+   * @param int $exportMode
+   *   Export mode.
+   *
+   * return string Querymode
+   */
+  public function getQueryMode($exportMode) {
+    switch ($exportMode) {
+      case CRM_Export_Form_Select::CONTRIBUTE_EXPORT:
+        $queryMode = CRM_Contact_BAO_Query::MODE_CONTRIBUTE;
+        break;
+
+      case CRM_Export_Form_Select::EVENT_EXPORT:
+        $queryMode = CRM_Contact_BAO_Query::MODE_EVENT;
+        break;
+
+      case CRM_Export_Form_Select::MEMBER_EXPORT:
+        $queryMode = CRM_Contact_BAO_Query::MODE_MEMBER;
+        break;
+
+      case CRM_Export_Form_Select::PLEDGE_EXPORT:
+        $queryMode = CRM_Contact_BAO_Query::MODE_PLEDGE;
+        break;
+
+      case CRM_Export_Form_Select::CASE_EXPORT:
+        $queryMode = CRM_Contact_BAO_Query::MODE_CASE;
+        break;
+
+      case CRM_Export_Form_Select::GRANT_EXPORT:
+        $queryMode = CRM_Contact_BAO_Query::MODE_GRANT;
+        break;
+
+      case CRM_Export_Form_Select::ACTIVITY_EXPORT:
+        $queryMode = CRM_Contact_BAO_Query::MODE_ACTIVITY;
+        break;
+    }
+    return $queryMode;
+  }
+
+  /**
+   * Get default return property for export based on mode
+   *
+   * @param int $exportMode
+   *   Export mode.
+   * return returnProperties
+   */
+  function defultReturnProperty($exportMode) {
+    // hack to add default returnproperty based on export mode
+    if ($exportMode == CRM_Export_Form_Select::CONTRIBUTE_EXPORT) {
+      $returnProperties['contribution_id'] = 1;
+    }
+    elseif ($exportMode == CRM_Export_Form_Select::EVENT_EXPORT) {
+      $returnProperties['participant_id'] = 1;
+      if (!empty($returnProperties['participant_role'])) {
+        unset($returnProperties['participant_role']);
+        $returnProperties['participant_role_id'] = 1;
+      }
+    }
+    elseif ($exportMode == CRM_Export_Form_Select::MEMBER_EXPORT) {
+      $returnProperties['membership_id'] = 1;
+    }
+    elseif ($exportMode == CRM_Export_Form_Select::PLEDGE_EXPORT) {
+      $returnProperties['pledge_id'] = 1;
+    }
+    elseif ($exportMode == CRM_Export_Form_Select::CASE_EXPORT) {
+      $returnProperties['case_id'] = 1;
+    }
+    elseif ($exportMode == CRM_Export_Form_Select::GRANT_EXPORT) {
+      $returnProperties['grant_id'] = 1;
+    }
+    elseif ($exportMode == CRM_Export_Form_Select::ACTIVITY_EXPORT) {
+      $returnProperties['activity_id'] = 1;
+    }
+    return $returnProperties;
+  }
+
+  /**
+   * Get Export component
+   *
+   * @param int $exportMode
+   *   Export mode.
+   *
+   * return string component
+   */
+   public function exportComponent($exportMode) {
+    switch ($exportMode) {
+      case CRM_Export_Form_Select::CONTRIBUTE_EXPORT:
+        $component = 'civicrm_contribution';
+        break;
+
+      case CRM_Export_Form_Select::EVENT_EXPORT:
+        $component = 'civicrm_participant';
+        break;
+
+      case CRM_Export_Form_Select::MEMBER_EXPORT:
+        $component = 'civicrm_membership';
+        break;
+
+      case CRM_Export_Form_Select::PLEDGE_EXPORT:
+        $component = 'civicrm_pledge';
+        break;
+
+      case CRM_Export_Form_Select::GRANT_EXPORT:
+        $component = 'civicrm_grant';
+        break;
+    }
+    return $component;
+  }
+
+  /**
    * Get the list the export fields.
    *
    * @param int $selectAll
@@ -106,35 +217,8 @@ class CRM_Export_BAO_Export {
     );
     $queryMode = CRM_Contact_BAO_Query::MODE_CONTACTS;
 
-    switch ($exportMode) {
-      case CRM_Export_Form_Select::CONTRIBUTE_EXPORT:
-        $queryMode = CRM_Contact_BAO_Query::MODE_CONTRIBUTE;
-        break;
-
-      case CRM_Export_Form_Select::EVENT_EXPORT:
-        $queryMode = CRM_Contact_BAO_Query::MODE_EVENT;
-        break;
-
-      case CRM_Export_Form_Select::MEMBER_EXPORT:
-        $queryMode = CRM_Contact_BAO_Query::MODE_MEMBER;
-        break;
-
-      case CRM_Export_Form_Select::PLEDGE_EXPORT:
-        $queryMode = CRM_Contact_BAO_Query::MODE_PLEDGE;
-        break;
-
-      case CRM_Export_Form_Select::CASE_EXPORT:
-        $queryMode = CRM_Contact_BAO_Query::MODE_CASE;
-        break;
-
-      case CRM_Export_Form_Select::GRANT_EXPORT:
-        $queryMode = CRM_Contact_BAO_Query::MODE_GRANT;
-        break;
-
-      case CRM_Export_Form_Select::ACTIVITY_EXPORT:
-        $queryMode = CRM_Contact_BAO_Query::MODE_ACTIVITY;
-        break;
-    }
+    $queryMode = self::getQueryMode($exportMode);
+  
     if ($fields) {
       //construct return properties
       $locationTypes = CRM_Core_PseudoConstant::get('CRM_Core_DAO_Address', 'location_type_id');
@@ -247,34 +331,7 @@ class CRM_Export_BAO_Export {
           }
         }
       }
-
-      // hack to add default returnproperty based on export mode
-      if ($exportMode == CRM_Export_Form_Select::CONTRIBUTE_EXPORT) {
-        $returnProperties['contribution_id'] = 1;
-      }
-      elseif ($exportMode == CRM_Export_Form_Select::EVENT_EXPORT) {
-        $returnProperties['participant_id'] = 1;
-        if (!empty($returnProperties['participant_role'])) {
-          unset($returnProperties['participant_role']);
-          $returnProperties['participant_role_id'] = 1;
-        }
-      }
-      elseif ($exportMode == CRM_Export_Form_Select::MEMBER_EXPORT) {
-        $returnProperties['membership_id'] = 1;
-      }
-      elseif ($exportMode == CRM_Export_Form_Select::PLEDGE_EXPORT) {
-        $returnProperties['pledge_id'] = 1;
-      }
-      elseif ($exportMode == CRM_Export_Form_Select::CASE_EXPORT) {
-        $returnProperties['case_id'] = 1;
-      }
-      elseif ($exportMode == CRM_Export_Form_Select::GRANT_EXPORT) {
-        $returnProperties['grant_id'] = 1;
-      }
-      elseif ($exportMode == CRM_Export_Form_Select::ACTIVITY_EXPORT) {
-        $returnProperties['activity_id'] = 1;
-      }
-    }
+      self::defultReturnProperty($exportMode);
     else {
       $primary = TRUE;
       $fields = CRM_Contact_BAO_Contact::exportableFields('All', TRUE, TRUE);
@@ -473,27 +530,7 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
           }
         }
         else {
-          switch ($exportMode) {
-            case CRM_Export_Form_Select::CONTRIBUTE_EXPORT:
-              $component = 'civicrm_contribution';
-              break;
-
-            case CRM_Export_Form_Select::EVENT_EXPORT:
-              $component = 'civicrm_participant';
-              break;
-
-            case CRM_Export_Form_Select::MEMBER_EXPORT:
-              $component = 'civicrm_membership';
-              break;
-
-            case CRM_Export_Form_Select::PLEDGE_EXPORT:
-              $component = 'civicrm_pledge';
-              break;
-
-            case CRM_Export_Form_Select::GRANT_EXPORT:
-              $component = 'civicrm_grant';
-              break;
-          }
+          self::exportComponent($exportMode);
 
           if ($exportMode == CRM_Export_Form_Select::CASE_EXPORT) {
             $relIDs = CRM_Case_BAO_Case::retrieveContactIdsByCaseId($ids);

--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -126,7 +126,7 @@ class CRM_Export_BAO_Export {
    *
    * return string component
    */
-   public static function exportComponent($exportMode) {
+  public static function exportComponent($exportMode) {
     switch ($exportMode) {
       case CRM_Export_Form_Select::CONTRIBUTE_EXPORT:
         $component = 'civicrm_contribution';

--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -51,7 +51,7 @@ class CRM_Export_BAO_Export {
    *
    * return string Querymode
    */
-  public function getQueryMode($exportMode) {
+  public static function getQueryMode($exportMode) {
     switch ($exportMode) {
       case CRM_Export_Form_Select::CONTRIBUTE_EXPORT:
         $queryMode = CRM_Contact_BAO_Query::MODE_CONTRIBUTE;
@@ -89,36 +89,33 @@ class CRM_Export_BAO_Export {
    *
    * @param int $exportMode
    *   Export mode.
-   * return returnProperties
+   *
+   * return string $property
    */
-  function defultReturnProperty($exportMode) {
+  public static function defultReturnProperty($exportMode) {
     // hack to add default returnproperty based on export mode
     if ($exportMode == CRM_Export_Form_Select::CONTRIBUTE_EXPORT) {
-      $returnProperties['contribution_id'] = 1;
+      $property = 'contribution_id';
     }
     elseif ($exportMode == CRM_Export_Form_Select::EVENT_EXPORT) {
-      $returnProperties['participant_id'] = 1;
-      if (!empty($returnProperties['participant_role'])) {
-        unset($returnProperties['participant_role']);
-        $returnProperties['participant_role_id'] = 1;
-      }
+      $property = 'participant_id';
     }
     elseif ($exportMode == CRM_Export_Form_Select::MEMBER_EXPORT) {
-      $returnProperties['membership_id'] = 1;
+      $property = 'membership_id';
     }
     elseif ($exportMode == CRM_Export_Form_Select::PLEDGE_EXPORT) {
-      $returnProperties['pledge_id'] = 1;
+      $property = 'pledge_id';
     }
     elseif ($exportMode == CRM_Export_Form_Select::CASE_EXPORT) {
-      $returnProperties['case_id'] = 1;
+      $property = 'case_id';
     }
     elseif ($exportMode == CRM_Export_Form_Select::GRANT_EXPORT) {
-      $returnProperties['grant_id'] = 1;
+      $property = 'grant_id';
     }
     elseif ($exportMode == CRM_Export_Form_Select::ACTIVITY_EXPORT) {
-      $returnProperties['activity_id'] = 1;
+      $property = 'activity_id';
     }
-    return $returnProperties;
+    return $property;
   }
 
   /**
@@ -129,7 +126,7 @@ class CRM_Export_BAO_Export {
    *
    * return string component
    */
-   public function exportComponent($exportMode) {
+   public static function exportComponent($exportMode) {
     switch ($exportMode) {
       case CRM_Export_Form_Select::CONTRIBUTE_EXPORT:
         $component = 'civicrm_contribution';
@@ -218,7 +215,7 @@ class CRM_Export_BAO_Export {
     $queryMode = CRM_Contact_BAO_Query::MODE_CONTACTS;
 
     $queryMode = self::getQueryMode($exportMode);
-  
+
     if ($fields) {
       //construct return properties
       $locationTypes = CRM_Core_PseudoConstant::get('CRM_Core_DAO_Address', 'location_type_id');
@@ -331,7 +328,12 @@ class CRM_Export_BAO_Export {
           }
         }
       }
-      self::defultReturnProperty($exportMode);
+      $returnProperties[self::defultReturnProperty($exportMode)] = 1;
+      if ($exportmode == CRM_Export_Form_Select::EVENT_EXPORT && !empty($returnProperties['participant_role'])) {
+        unset($returnProperties['participant_role']);
+        $returnProperties['participant_role_id'] = 1;
+      }
+    }
     else {
       $primary = TRUE;
       $fields = CRM_Contact_BAO_Contact::exportableFields('All', TRUE, TRUE);
@@ -530,7 +532,7 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
           }
         }
         else {
-          self::exportComponent($exportMode);
+          $component = self::exportComponent($exportMode);
 
           if ($exportMode == CRM_Export_Form_Select::CASE_EXPORT) {
             $relIDs = CRM_Case_BAO_Case::retrieveContactIdsByCaseId($ids);

--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -608,7 +608,7 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
     }
     $trashClause = $excludeTrashed ? "contact_a.is_deleted != 1" : "( 1 )";
 
-    if (empty($where) {
+    if (empty($where)) {
       $where = "WHERE $trashClause";
     }
     else {


### PR DESCRIPTION
… tighter functions

There isn't a issue case for this but just having a look through this function i saw these 3 sections that seemed to be easy to spin out. Would appreciate someone having a look over. I tested these split outs against my 4.6 install and I think its safe but would appreciate some feedback on this
