### PR TITLE
CRM-17111 - Typo error on system error message.

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -373,7 +373,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
         $out['backtrace'] = self::parseBacktrace(debug_backtrace());
         $message .= '<p><em>See console for backtrace</em></p>';
       }
-      CRM_Core_Session::setStatus($message, ts('Sorry an Error Occured'), 'error');
+      CRM_Core_Session::setStatus($message, ts('Sorry an error occurred'), 'error');
       CRM_Core_Transaction::forceRollbackIfEnabled();
       CRM_Core_Page_AJAX::returnJsonResponse($out);
     }


### PR DESCRIPTION
- [CRM-17111: Typo error on system error message.](https://issues.civicrm.org/jira/browse/CRM-17111)
