### PR TITLE
CRM-16544, CRM-17127 - Select::where() - Less aggressive dedupe

### DIFF
--- a/CRM/Utils/SQL/Select.php
+++ b/CRM/Utils/SQL/Select.php
@@ -236,7 +236,8 @@ class CRM_Utils_SQL_Select implements ArrayAccess {
   public function where($exprs, $args = NULL) {
     $exprs = (array) $exprs;
     foreach ($exprs as $expr) {
-      $this->wheres[$expr] = $this->interpolate($expr, $args);
+      $evaluatedExpr = $this->interpolate($expr, $args);
+      $this->wheres[$evaluatedExpr] = $evaluatedExpr;
     }
     return $this;
   }


### PR DESCRIPTION
The where() function attempts to dedupe WHERE clauses, but this could
misbehave when similar clauses are used with different data, and it's been
implicated in a symptom where CiviMail shows irrelevant attachments.

http://civicrm.stackexchange.com/a/5059/93

---
- [CRM-16544: CiviMail automatically attaches CiviGrant files to Mailing](https://issues.civicrm.org/jira/browse/CRM-16544)
- [CRM-17127: CiviMail uses custom field files as attachment](https://issues.civicrm.org/jira/browse/CRM-17127)
