### PR TITLE
CRM-17148 set crm-initial-value for billingcheckbox

### DIFF
--- a/templates/CRM/Core/BillingBlock.tpl
+++ b/templates/CRM/Core/BillingBlock.tpl
@@ -131,7 +131,7 @@
         }
       }
       if (checked) {
-        $('#billingcheckbox').prop('checked', true);
+        $('#billingcheckbox').prop('checked', true).data('crm-initial-value', true);
         if (!CRM.billing || CRM.billing.billingProfileIsHideable) {
           $('.billing_name_address-group').hide();
         }


### PR DESCRIPTION
- [CRM-17148: contrib pages trigger "unsaved changes" warning automatically](https://issues.civicrm.org/jira/browse/CRM-17148)
