### PR TITLE
CRM-17152 fix non-static method called statically

### DIFF
--- a/CRM/Financial/Form/BatchTransaction.php
+++ b/CRM/Financial/Form/BatchTransaction.php
@@ -176,7 +176,9 @@ class CRM_Financial_Form_BatchTransaction extends CRM_Contribute_Form {
   }
 
   /**
-   * @return array|null
+   * Get action links.
+   *
+   * @return array
    */
   public function &links() {
     if (!(self::$_links)) {

--- a/CRM/Financial/Page/AJAX.php
+++ b/CRM/Financial/Page/AJAX.php
@@ -427,7 +427,8 @@ class CRM_Financial_Page_AJAX {
       }
       else {
         $row[$financialItem->id]['check'] = NULL;
-        $links = CRM_Financial_Page_BatchTransaction::links();
+        $tempBAO = new CRM_Financial_Page_BatchTransaction();
+        $links = $tempBAO->links();
         unset($links['remove']);
         $row[$financialItem->id]['action'] = CRM_Core_Action::formLink(
           $links,


### PR DESCRIPTION
- [CRM-17152: Non-static method CRM_Financial_Page_BatchTransaction::links() should not be called statically](https://issues.civicrm.org/jira/browse/CRM-17152)
