### PR TITLE
CRM-17120 swap out uncached function for cached function

### DIFF
--- a/CRM/Financial/Form/BatchTransaction.php
+++ b/CRM/Financial/Form/BatchTransaction.php
@@ -176,7 +176,9 @@ class CRM_Financial_Form_BatchTransaction extends CRM_Contribute_Form {
   }
 
   /**
-   * @return array|null
+   * Get action links.
+   *
+   * @return array
    */
   public function &links() {
     if (!(self::$_links)) {

--- a/CRM/Financial/Page/AJAX.php
+++ b/CRM/Financial/Page/AJAX.php
@@ -261,7 +261,15 @@ class CRM_Financial_Page_AJAX {
     CRM_Utils_JSON::output($response);
   }
 
-  public static function getFinancialTransactionsList() {
+  /**
+   * Get output of financial transactions.
+   *
+   * @param bool $return
+   *   Return result. This parameter allows the output to be unit tested.
+   *
+   * @return string
+   */
+  public static function getFinancialTransactionsList($return = FALSE) {
     $sortMapper = array(
       0 => '',
       1 => '',
@@ -463,6 +471,9 @@ class CRM_Financial_Page_AJAX {
       'action',
     );
 
+    if ($return) {
+      return CRM_Utils_JSON::encodeDataTableSelector($financialitems, $sEcho, $iTotal, $iFilteredTotal, $selectorElements);
+    }
     header('Content-Type: application/json');
     echo CRM_Utils_JSON::encodeDataTableSelector($financialitems, $sEcho, $iTotal, $iFilteredTotal, $selectorElements);
     CRM_Utils_System::civiExit();

--- a/CRM/Financial/Page/AJAX.php
+++ b/CRM/Financial/Page/AJAX.php
@@ -379,7 +379,7 @@ class CRM_Financial_Page_AJAX {
           $row[$financialItem->id][$columnKey] = '<a href=' . $url . '>' . $financialItem->$columnKey . '</a>';
         }
         elseif ($columnKey == 'payment_method' && $financialItem->$columnKey) {
-          $row[$financialItem->id][$columnKey] = CRM_Core_OptionGroup::getLabel('payment_instrument', $financialItem->$columnKey);
+          $row[$financialItem->id][$columnKey] = CRM_Core_PseudoConstant::getLabel('CRM_Batch_BAO_Batch', 'payment_instrument_id', $financialItem->$columnKey);
           if ($row[$financialItem->id][$columnKey] == 'Check') {
             $checkNumber = $financialItem->check_number ? ' (' . $financialItem->check_number . ')' : '';
             $row[$financialItem->id][$columnKey] = $row[$financialItem->id][$columnKey] . $checkNumber;
@@ -392,7 +392,7 @@ class CRM_Financial_Page_AJAX {
           $row[$financialItem->id][$columnKey] = CRM_Utils_Date::customFormat($financialItem->$columnKey);
         }
         elseif ($columnKey == 'status' && $financialItem->$columnKey) {
-          $row[$financialItem->id][$columnKey] = CRM_Core_OptionGroup::getLabel('contribution_status', $financialItem->$columnKey);
+          $row[$financialItem->id][$columnKey] = CRM_Core_PseudoConstant::getLabel('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $financialItem->$columnKey);
         }
       }
       if ($statusID == CRM_Core_OptionGroup::getValue('batch_status', 'Open')) {

--- a/CRM/Financial/Page/AJAX.php
+++ b/CRM/Financial/Page/AJAX.php
@@ -427,7 +427,8 @@ class CRM_Financial_Page_AJAX {
       }
       else {
         $row[$financialItem->id]['check'] = NULL;
-        $links = CRM_Financial_Page_BatchTransaction::links();
+        $tempBAO = new CRM_Financial_Page_BatchTransaction();
+        $links = $tempBAO->links();
         unset($links['remove']);
         $row[$financialItem->id]['action'] = CRM_Core_Action::formLink(
           $links,

--- a/tests/phpunit/CRM/Financial/Page/AjaxTest.php
+++ b/tests/phpunit/CRM/Financial/Page/AjaxTest.php
@@ -1,0 +1,56 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.6                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2015                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+require_once 'CiviTest/CiviUnitTestCase.php';
+
+/**
+ * Test for CRM_Financial_Page_Ajax class.
+ */
+class CRM_Financial_Page_AjaxTest extends CiviUnitTestCase {
+
+  /**
+   * Test the ajax function to get financial transactions.
+   *
+   * Test focus is on ensuring changes to how labels are retrieved does not cause regression.
+   */
+  public function testGetFinancialTransactionsList() {
+    $individualID = $this->individualCreate();
+    $this->contributionCreate($individualID);
+    $batch = $this->callAPISuccess('Batch', 'create', array('title' => 'test', 'status_id' => 'Open'));
+    CRM_Core_DAO::executeQuery("
+     INSERT INTO civicrm_entity_batch (entity_table, entity_id, batch_id)
+     values('civicrm_financial_trxn', 1, 1)
+   ");
+    $_REQUEST['sEcho'] = 1;
+    $_REQUEST['entityID'] = $batch['id'];
+    $json = CRM_Financial_Page_AJAX::getFinancialTransactionsList(TRUE);
+    $this->assertEquals($json, '{"sEcho": 1, "iTotalRecords": 1, "iTotalDisplayRecords": 1, "aaData": [ ["","<a href=\"/index.php?q=civicrm/profile/view&amp;reset=1&amp;gid=7&amp;id=3&amp;snippet=4\" class=\"crm-summary-link\"><div'
+    . ' class=\"icon crm-icon Individual-icon\"></div></a>","<a href=/index.php?q=civicrm/contact/view&amp;reset=1&amp;cid=3>Anderson, Anthony</a>","$ 100.00","12345","September 3rd, 2015 12:00 AM",'
+    . '"Credit Card","Completed","Donation","<span><a href=\"http://FIX ME/index.php?q=civicrm/contact/view/contribution&amp;reset=1&amp;id=1&amp;cid=3&amp;action=view&amp;context=contribution&amp;'
+    . 'selectedChild=contribute\" class=\"action-item crm-hover-button\" title=\'View Contribution\' >View</a></span>"]] }');
+  }
+
+}


### PR DESCRIPTION
Most of this PR is adding tests to ensure the 2-line change does not cause regression

---
- [CRM-17120: Function CRM_Core_OptionGroup::getLabel does not use caching](https://issues.civicrm.org/jira/browse/CRM-17120)
