### PR TITLE
CRM-14599 - Exclude deleted contacts from test mailing

### DIFF
--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -591,6 +591,7 @@ function civicrm_api3_mailing_send_test($params) {
         ->where('c.is_opt_out = 0')
         ->where('c.do_not_email = 0')
         ->where('c.is_deceased = 0')
+        ->where('c.is_deleted = 0')
         ->groupBy('e.id')
         ->orderBy(array('e.is_bulkmail DESC', 'e.is_primary DESC'))
         ->toSQL();


### PR DESCRIPTION
This is a backport of @colemanw work to 4.6. I have this running locally and its pretty decent backport

---
- [CRM-14599: CiviMail's test email functionality does not check to see if a contact is deleted before using it for token substitution](https://issues.civicrm.org/jira/browse/CRM-14599)
