### PR TITLE
Test to check CRM-17146 - include trxn_date in completetransaction API

### DIFF
--- a/CRM/Contribute/Form/Task/Status.php
+++ b/CRM/Contribute/Form/Task/Status.php
@@ -140,7 +140,7 @@ AND    co.id IN ( $contribIDs )";
       $this->addRule("fee_amount_{$row['contribution_id']}", ts('Please enter a valid amount.'), 'money');
       $defaults["fee_amount_{$row['contribution_id']}"] = 0.0;
 
-      $row['trxn_date'] = &$this->addDate("trxn_date_{$row['contribution_id']}", FALSE,
+      $row['trxn_date'] = $this->addDate("trxn_date_{$row['contribution_id']}", FALSE,
         ts('Receipt Date'), array('formatType' => 'activityDate')
       );
       $defaults["trxn_date_{$row['contribution_id']}"] = $now;

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -473,6 +473,11 @@ function _civicrm_api3_contribution_completetransaction_spec(&$params) {
     'description' => 'If a fee has been charged then the amount',
     'type' => CRM_Utils_Type::T_FLOAT,
   );
+  $params['trxn_date'] = array(
+    'title' => 'Transaction Date',
+    'description' => 'Date this transaction occurred',
+    'type' => CRM_Utils_Type::T_DATE,
+  );
 }
 
 /**
@@ -547,6 +552,9 @@ function _ipn_process_transaction(&$params, $contribution, $input, $ids, $firstC
 
   if (isset($params['is_email_receipt'])) {
     $input['is_email_receipt'] = $params['is_email_receipt'];
+  }
+  if (!empty($params['trxn_date'])) {
+    $input['trxn_date'] = $params['trxn_date'];
   }
   if (empty($contribution->contribution_page_id)) {
     static $domainFromName;

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -1542,9 +1542,10 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $this->createLoggedInUser();
     $params = array_merge($this->_params, array('contribution_status_id' => 2, 'receipt_date' => 'now'));
     $contribution = $this->callAPISuccess('contribution', 'create', $params);
-    $this->callAPISuccess('contribution', 'completetransaction', array('id' => $contribution['id']));
+    $this->callAPISuccess('contribution', 'completetransaction', array('id' => $contribution['id'], 'trxn_date' => date('Y-m-d')));
     $contribution = $this->callAPISuccess('contribution', 'get', array('id' => $contribution['id'], 'sequential' => 1));
     $this->assertEquals('Completed', $contribution['values'][0]['contribution_status']);
+    $this->assertEquals(date('Y-m-d'), date('Y-m-d', strtotime($contribution['values'][0]['receive_date'])));
     $mut->checkMailLog(array(
       'Receipt - Contribution',
       'Please print this confirmation for your records.',


### PR DESCRIPTION
- [CRM-17146: updating the contribution state in finding contriutions does not update the receive date](https://issues.civicrm.org/jira/browse/CRM-17146)

Extend tests to check https://github.com/civicrm/civicrm-core/pull/6684
