### PR TITLE
CRM-17015: “Sold out” error message when registering event with PayPal …

### DIFF
--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -145,7 +145,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
             $params[$name] = $value;
           }
           if (substr($name, 0, 6) == 'price_') {
-            $params[$name] =$this->_params[0][$name];
+            $params[$name] = $this->_params[0][$name];
           }
         }
         $this->set('getExpressCheckoutDetails', $params);

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -144,6 +144,9 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
           if (!in_array($name, $skipFields)) {
             $params[$name] = $value;
           }
+          if (substr($name, 0, 6) == 'price_') {
+            $params[$name] =$this->_params[0][$name];
+          }
         }
         $this->set('getExpressCheckoutDetails', $params);
       }


### PR DESCRIPTION
…Express payment (event is not full though)

---
- CRM-17015: “Sold out” error message when registering event with PayPal Express payment (event is not full though)
  https://issues.civicrm.org/jira/browse/CRM-17015
