### PR TITLE
CRM-17199: Partial fix for ContributionPage honore title/text multi-lingual.

### DIFF
--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -838,7 +838,9 @@ LEFT JOIN  civicrm_premiums            ON ( civicrm_premiums.entity_id = civicrm
    * @return array|string
    */
   public static function formatMultilingualHonorParams($params, $setDefault = FALSE) {
+    global $tsLocale;
     $config = CRM_Core_Config::singleton();
+
     $sctJson = $sctJsonDecode = NULL;
     $domain = new CRM_Core_DAO_Domain();
     $domain->find(TRUE);
@@ -852,12 +854,12 @@ LEFT JOIN  civicrm_premiums            ON ( civicrm_premiums.entity_id = civicrm
         //monolingual state
         $sctJsonDecode += (array) $sctJsonDecode['default'];
       }
-      elseif (!empty($sctJsonDecode[$config->lcMessages])) {
+      elseif (!empty($sctJsonDecode[$tsLocale])) {
         //multilingual state
-        foreach ($sctJsonDecode[$config->lcMessages] as $column => $value) {
+        foreach ($sctJsonDecode[$tsLocale] as $column => $value) {
           $sctJsonDecode[$column] = $value;
         }
-        unset($sctJsonDecode[$config->lcMessages]);
+        unset($sctJsonDecode[$tsLocale]);
       }
       return $sctJsonDecode;
     }


### PR DESCRIPTION
This fixes how the uf_join data is retrieved to display the honoree title/text on contribution forms.

I think that $config->lcMessages is the default language, where as $tsLanguage is the current UI language.

This is only a partial fix because the UI still does not show the fields as multi-lingual, so it the ContributionPage form is pretty confusing. Switching the UI language to edit the field seems to work.

---
- [CRM-17199: Contribution form honoree\/memory section does not support multi-lingual](https://issues.civicrm.org/jira/browse/CRM-17199)
