### PR TITLE
CRM-14232 add setting for default contact language.

### DIFF
--- a/CRM/Admin/Form/Setting/Localization.php
+++ b/CRM/Admin/Form/Setting/Localization.php
@@ -91,7 +91,11 @@ class CRM_Admin_Form_Setting_Localization extends CRM_Admin_Form_Setting {
         );
       }
     }
-
+    $this->addElement('select', 'contact_default_language', ts('Default Language for users'), array(
+      '*default*' => ts('Use default site language'),
+      'undefined' => ts('Leave undefined'),
+      'current_site_language' => ts('Use language in use at the time'),
+    ));
     $this->addElement('checkbox', 'inheritLocale', ts('Inherit CMS Language'));
     $this->addElement('text', 'monetaryThousandSeparator', ts('Thousands Separator'), array('size' => 2));
     $this->addElement('text', 'monetaryDecimalPoint', ts('Decimal Delimiter'), array('size' => 2));

--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -305,12 +305,13 @@ class CRM_Contact_BAO_Contact extends CRM_Contact_DAO_Contact {
     $config = CRM_Core_Config::singleton();
 
     // CRM-6942: set preferred language to the current language if it’s unset (and we’re creating a contact).
-    if (empty($params['contact_id']) && empty($params['preferred_language'])) {
-      $params['preferred_language'] = $config->lcMessages;
-    }
-
-    // CRM-9739: set greeting & addressee if unset and we’re creating a contact.
     if (empty($params['contact_id'])) {
+      // A case could be made for checking isset rather than empty but this is more consistent with previous behaviour.
+      if (empty($params['preferred_language']) && ($language = CRM_Core_I18n::getContactDefaultLanguage()) != FALSE) {
+        $params['preferred_language'] = $language;
+      }
+
+      // CRM-9739: set greeting & addressee if unset and we’re creating a contact.
       foreach (self::$_greetingTypes as $greeting) {
         if (empty($params[$greeting . '_id'])) {
           if ($defaultGreetingTypeId

--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -548,6 +548,34 @@ class CRM_Core_I18n {
     return $locales[$tsLocale];
   }
 
+  /**
+   * Get the default language for contacts where no language is provided.
+   *
+   * Note that NULL is a valid option so be careful with checking for empty etc.
+   *
+   * NULL would mean 'we don't know & we don't want to hazard a guess'.
+   *
+   * @return string
+   */
+  public static  function getContactDefaultLanguage() {
+    $language = CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::LOCALIZATION_PREFERENCES_NAME, 'contact_default_language');
+    if ($language == 'undefined') {
+      return NULL;
+    }
+    if (empty($language) || $language === '*default*') {
+      $language = civicrm_api3('setting', 'getvalue', array(
+        'name' => 'lcMessages',
+        'group' => CRM_Core_BAO_Setting::LOCALIZATION_PREFERENCES_NAME,
+      ));
+    }
+    elseif ($language == 'current_site_language') {
+      global $tsLocale;
+      return $tsLocale;
+    }
+
+    return $language;
+  }
+
 }
 
 /**

--- a/settings/Localization.setting.php
+++ b/settings/Localization.setting.php
@@ -179,7 +179,6 @@ return array(
     'pseudoconstant' => array(
       'callback' => 'CRM_Core_PseudoConstant::stateProvince',
     ),
-    'html_attributes',
     'default' => '',
     'title' => 'Default State/Province',
     'description' => 'This value is selected by default when adding a new contact address.',
@@ -476,5 +475,19 @@ return array(
     'is_contact' => 0,
     'description' => "",
     'help_text' => NULL,
+  ),
+  'contact_default_language' => array(
+    'group_name' => 'Localization Preferences',
+    'group' => 'localization',
+    'name' => 'contact_default_language',
+    'type' => 'String',
+    'default' => '*default*',
+    'add' => '4.7',
+    'title' => 'Default Language for contacts',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => 'Default language (if any) for contact records',
+    'help_text' => 'If a contact is created with no language this setting will determine the language data (if any) to save.'
+    . 'You may or may not wish to make an assumption here about whether it matches the site language',
   ),
 );

--- a/templates/CRM/Admin/Form/Setting/Localization.tpl
+++ b/templates/CRM/Admin/Form/Setting/Localization.tpl
@@ -51,6 +51,11 @@
                 <td class="label">{$form.inheritLocale.label} {help id='inheritLocale' title=$form.inheritLocale.label}</td>
                 <td>{$form.inheritLocale.html}</td>
             </tr>
+          <tr class="crm-localization-form-contact_default_language">
+            <td class="label">{$form.contact_default_language.label}</td>
+            <td>{$form.contact_default_language.html}<br />
+              <span class="description">{ts}Default language (if any) for contact records.{/ts}</span></td>
+          </tr>
             <tr class="crm-localization-form-block-defaultCurrency">
                 <td class="label">{$form.defaultCurrency.label} {help id='defaultCurrency' title=$form.defaultCurrency.label}</td>
                 <td>{$form.defaultCurrency.html}</td>

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -374,6 +374,63 @@ class api_v3_ContactTest extends CiviUnitTestCase {
   }
 
   /**
+   * CRM-14232 test preferred language set to site default if not passed.
+   */
+  public function testCreatePreferredLanguageUnset() {
+    $this->callAPISuccess('Contact', 'create', array(
+      'first_name' => 'Snoop',
+      'last_name' => 'Dog',
+      'contact_type' => 'Individual')
+    );
+    $result = $this->callAPISuccessGetSingle('Contact', array('last_name' => 'Dog'));
+    $this->assertEquals('en_US', $result['preferred_language']);
+  }
+
+  /**
+   * CRM-14232 test preferred language returns setting if not passed.
+   */
+  public function testCreatePreferredLanguageSet() {
+    $this->callAPISuccess('Setting', 'create', array('contact_default_language' => 'fr_FR'));
+    $this->callAPISuccess('Contact', 'create', array(
+      'first_name' => 'Snoop',
+      'last_name' => 'Dog',
+      'contact_type' => 'Individual',
+    ));
+    $result = $this->callAPISuccessGetSingle('Contact', array('last_name' => 'Dog'));
+    $this->assertEquals('fr_FR', $result['preferred_language']);
+  }
+
+  /**
+   * CRM-14232 test preferred language returns setting if not passed where setting is NULL.
+   */
+  public function testCreatePreferredLanguageNull() {
+    $this->callAPISuccess('Setting', 'create', array('contact_default_language' => 'null'));
+    $this->callAPISuccess('Contact', 'create', array(
+        'first_name' => 'Snoop',
+        'last_name' => 'Dog',
+        'contact_type' => 'Individual',
+        )
+    );
+    $result = $this->callAPISuccessGetSingle('Contact', array('last_name' => 'Dog'));
+    $this->assertEquals(NULL, $result['preferred_language']);
+  }
+
+  /**
+   * CRM-14232 test preferred language returns setting if not passed where setting is NULL.
+   */
+  public function testCreatePreferredLanguagePassed() {
+    $this->callAPISuccess('Setting', 'create', array('contact_default_language' => 'null'));
+    $this->callAPISuccess('Contact', 'create', array(
+      'first_name' => 'Snoop',
+      'last_name' => 'Dog',
+      'contact_type' => 'Individual',
+      'preferred_language' => 'en_AU',
+    ));
+    $result = $this->callAPISuccessGetSingle('Contact', array('last_name' => 'Dog'));
+    $this->assertEquals('en_AU', $result['preferred_language']);
+  }
+
+  /**
    * CRM-15792 - create/update datetime field for contact.
    */
   public function testCreateContactCustomFldDateTime() {


### PR DESCRIPTION
If a contact is created & the preferred_language is not set this
setting can be used to manipulate the default.

Tests!

Conflicts:
    settings/Localization.setting.php

---
- [CRM-14232: Contact preferred language should be nullable](https://issues.civicrm.org/jira/browse/CRM-14232)
