### PR TITLE
CRM-17207 - Use mailto link on contact summary when outbound email is…

### DIFF
--- a/CRM/Contact/Page/View/Summary.php
+++ b/CRM/Contact/Page/View/Summary.php
@@ -140,6 +140,9 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
     $params['id'] = $params['contact_id'] = $this->_contactId;
     $params['noRelationships'] = $params['noNotes'] = $params['noGroups'] = TRUE;
     $contact = CRM_Contact_BAO_Contact::retrieve($params, $defaults, TRUE);
+    // Let summary page know if outbound mail is disabled so email links can be built conditionally
+    $mailingBackend = CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::MAILING_PREFERENCES_NAME, 'mailing_backend');
+    $this->assign('mailingOutboundOption', $mailingBackend['outBound_option']);
 
     $communicationType = array(
       'phone' => array(

--- a/templates/CRM/Contact/Page/Inline/Email.tpl
+++ b/templates/CRM/Contact/Page/Inline/Email.tpl
@@ -49,9 +49,15 @@
       </div>
       <div class="crm-content crm-contact_email">
         {if !$item.on_hold and !$privacy.do_not_email}
-          <a href="{crmURL p="civicrm/activity/email/add" q="action=add&reset=1&email_id=`$item.id`"}" class="crm-popup" title="{ts 1=$item.email}Send email to %1{/ts}">
+          {if $mailingOutboundOption == 2} {* Outbound email is disabled, use a mailto link *}
+            <a href="mailto:{$item.email}" title="{ts 1=$item.email}Send email to %1{/ts}">
             {$item.email}
-          </a>
+            </a>
+          {else}
+            <a href="{crmURL p="civicrm/activity/email/add" q="action=add&reset=1&email_id=`$item.id`"}" class="crm-popup" title="{ts 1=$item.email}Send email to %1{/ts}">
+            {$item.email}
+            </a>
+          {/if}
         {else}
           {$item.email}
         {/if}


### PR DESCRIPTION
… disabled.

---
- CRM-17207: Use mailto link on contact summary emails if outbound email is disabled
  https://issues.civicrm.org/jira/browse/CRM-17207
