### PR TITLE
CRM-17212: switch to file-based session storage when Pantheon

### DIFF
--- a/extern/authorizeIPN.php
+++ b/extern/authorizeIPN.php
@@ -31,6 +31,7 @@
  * $Id$
  */
 
+ini_set('session.save_handler', 'files');
 session_start();
 
 require_once '../civicrm.config.php';

--- a/extern/authorizeIPN.php
+++ b/extern/authorizeIPN.php
@@ -31,7 +31,9 @@
  * $Id$
  */
 
-ini_set('session.save_handler', 'files');
+if (defined('PANTHEON_ENVIRONMENT')) {
+  ini_set('session.save_handler', 'files');
+}
 session_start();
 
 require_once '../civicrm.config.php';

--- a/extern/googleNotify.php
+++ b/extern/googleNotify.php
@@ -31,6 +31,9 @@
  * $Id$
  */
 
+if (!empty($_SERVER['PRESSFLOW_SETTINGS'])) {
+  ini_set('session.save_handler', 'files');
+}
 session_start();
 
 require_once '../civicrm.config.php';

--- a/extern/googleNotify.php
+++ b/extern/googleNotify.php
@@ -31,7 +31,7 @@
  * $Id$
  */
 
-if (!empty($_SERVER['PRESSFLOW_SETTINGS'])) {
+if (defined('PANTHEON_ENVIRONMENT')) {
   ini_set('session.save_handler', 'files');
 }
 session_start();

--- a/extern/ipn.php
+++ b/extern/ipn.php
@@ -31,6 +31,9 @@
  * $Id$
  */
 
+if (!empty($_SERVER['PRESSFLOW_SETTINGS'])) {
+  ini_set('session.save_handler', 'files');
+}
 session_start();
 
 require_once '../civicrm.config.php';

--- a/extern/ipn.php
+++ b/extern/ipn.php
@@ -31,7 +31,7 @@
  * $Id$
  */
 
-if (!empty($_SERVER['PRESSFLOW_SETTINGS'])) {
+if (defined('PANTHEON_ENVIRONMENT')) {
   ini_set('session.save_handler', 'files');
 }
 session_start();

--- a/extern/pxIPN.php
+++ b/extern/pxIPN.php
@@ -10,7 +10,9 @@
  * in creating this payment processor module
  */
 
-
+if (!empty($_SERVER['PRESSFLOW_SETTINGS'])) {
+  ini_set('session.save_handler', 'files');
+}
 session_start();
 
 require_once '../civicrm.config.php';

--- a/extern/pxIPN.php
+++ b/extern/pxIPN.php
@@ -10,7 +10,7 @@
  * in creating this payment processor module
  */
 
-if (!empty($_SERVER['PRESSFLOW_SETTINGS'])) {
+if (defined('PANTHEON_ENVIRONMENT')) {
   ini_set('session.save_handler', 'files');
 }
 session_start();

--- a/extern/rest.php
+++ b/extern/rest.php
@@ -28,6 +28,9 @@
 require_once '../civicrm.config.php';
 $config = CRM_Core_Config::singleton();
 
+if (!empty($_SERVER['PRESSFLOW_SETTINGS'])) {
+  ini_set('session.save_handler', 'files');
+}
 session_start();
 $rest = new CRM_Utils_REST();
 

--- a/extern/rest.php
+++ b/extern/rest.php
@@ -28,7 +28,7 @@
 require_once '../civicrm.config.php';
 $config = CRM_Core_Config::singleton();
 
-if (!empty($_SERVER['PRESSFLOW_SETTINGS'])) {
+if (defined('PANTHEON_ENVIRONMENT')) {
   ini_set('session.save_handler', 'files');
 }
 session_start();

--- a/extern/soap.php
+++ b/extern/soap.php
@@ -33,6 +33,9 @@ if (phpversion() == "5.2.2" &&
   $GLOBALS['HTTP_RAW_POST_DATA'] = file_get_contents('php://input');
 }
 
+if (!empty($_SERVER['PRESSFLOW_SETTINGS'])) {
+  ini_set('session.save_handler', 'files');
+}
 session_start();
 
 require_once '../civicrm.config.php';

--- a/extern/soap.php
+++ b/extern/soap.php
@@ -33,7 +33,7 @@ if (phpversion() == "5.2.2" &&
   $GLOBALS['HTTP_RAW_POST_DATA'] = file_get_contents('php://input');
 }
 
-if (!empty($_SERVER['PRESSFLOW_SETTINGS'])) {
+if (defined('PANTHEON_ENVIRONMENT')) {
   ini_set('session.save_handler', 'files');
 }
 session_start();

--- a/install/index.php
+++ b/install/index.php
@@ -30,6 +30,9 @@ else {
 
 // set installation type - drupal
 if (!session_id()) {
+  if (defined('PANTHEON_ENVIRONMENT')) {
+    ini_set('session.save_handler', 'files');
+  }
   session_start();
 }
 

--- a/tools/extensions/org.civicrm.payment.googlecheckout/googleNotify.php
+++ b/tools/extensions/org.civicrm.payment.googlecheckout/googleNotify.php
@@ -33,6 +33,9 @@
  *
  */
 
+if (defined('PANTHEON_ENVIRONMENT')) {
+  ini_set('session.save_handler', 'files');
+}
 session_start();
 
 require_once '../../../civicrm.config.php';


### PR DESCRIPTION
If we're hosting in Pantheon, switch to file-based session storage.

This makes IPN (and others in `extern/*php`) work when hosted on Pantheon.

---
- [CRM-17212: Set session handler to "files" in extern\/*php](https://issues.civicrm.org/jira/browse/CRM-17212)
