### PR TITLE
CRM-17075 convert membership_type_id field to entity_reference field in search

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -1465,15 +1465,23 @@ class CRM_Contact_BAO_Query {
    *
    * @param string $apiEntity
    *
+   * @param array $entityReferenceFields
+   *   Field names of any entity reference fields (which will need reformatting to IN syntax).
+   *
    * @return array
    */
-  public static function convertFormValues(&$formValues, $wildcard = 0, $useEquals = FALSE, $apiEntity = NULL) {
+  public static function convertFormValues(&$formValues, $wildcard = 0, $useEquals = FALSE, $apiEntity = NULL,
+    $entityReferenceFields = array()) {
     $params = array();
     if (empty($formValues)) {
       return $params;
     }
 
     foreach ($formValues as $id => $values) {
+      if (self::isAlreadyProcessedForQueryFormat($values)) {
+        $params[] = $values;
+        continue;
+      }
       if ($id == 'privacy') {
         if (is_array($formValues['privacy'])) {
           $op = !empty($formValues['privacy']['do_not_toggle']) ? '=' : '!=';
@@ -1525,6 +1533,10 @@ class CRM_Contact_BAO_Query {
           CRM_Contact_BAO_Query::fixDateValues($formValues[$id], $formValues[$fromRange], $formValues[$toRange]);
           continue;
         }
+      }
+      elseif (in_array($id, $entityReferenceFields) && !empty($values) && is_string($values) && (strpos($values, ',') !=
+        FALSE)) {
+        $params[] = array($id, 'IN', explode(',', $values), 0, 0);
       }
       else {
         $values = CRM_Contact_BAO_Query::fixWhereValues($id, $values, $wildcard, $useEquals, $apiEntity);
@@ -4390,6 +4402,30 @@ civicrm_relationship.is_permission_a_b = 0
       0,
       0,
     );
+  }
+
+  /**
+   * Has this field already been reformatting to Query object syntax.
+   *
+   * The form layer passed formValues to this function in preProcess & postProcess. Reason unknown. This seems
+   * to come with associated double queries & is possibly damaging performance.
+   *
+   * However, here we add a tested function to ensure convertFormValues identifies pre-processed fields & returns
+   * them as they are.
+   *
+   * @param mixed $values
+   *   Value in formValues for the field.
+   *
+   * @return bool;
+   */
+  protected static function isAlreadyProcessedForQueryFormat($values) {
+    if (!is_array($values)) {
+      return FALSE;
+    }
+    if (($operator = CRM_Utils_Array::value(1, $values)) == FALSE) {
+      return FALSE;
+    }
+    return in_array($operator, CRM_Core_DAO::acceptedSQLOperators());
   }
 
   /**

--- a/CRM/Core/Form/Search.php
+++ b/CRM/Core/Form/Search.php
@@ -80,6 +80,16 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
   protected $_taskList = array();
 
   /**
+   * Declare entity reference fields as they will need to be converted.
+   *
+   * The entity reference format looks like '2,3' whereas the Query object expects array(2, 3)
+   * or array('IN' => array(2, 3). The latter is the one we are moving towards standardising on.
+   *
+   * @var array
+   */
+  protected $entityReferenceFields = array();
+
+  /**
    * Builds the list of tasks or actions that a searcher can perform on a result set.
    *
    * To modify the task list, child classes should alter $this->_taskList,

--- a/CRM/Core/Form/Search.php
+++ b/CRM/Core/Form/Search.php
@@ -92,7 +92,7 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
   }
 
   /**
-   * Common buildform tasks required by all searches
+   * Common buildForm tasks required by all searches.
    */
   public function buildQuickform() {
     CRM_Core_Resources::singleton()
@@ -116,7 +116,7 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
   }
 
   /**
-   * Add checkboxes for each row plus a master checkbox
+   * Add checkboxes for each row plus a master checkbox.
    */
   public function addRowSelectors($rows) {
     $this->addElement('checkbox', 'toggleSelect', NULL, NULL, array('class' => 'select-rows'));

--- a/CRM/Member/BAO/Query.php
+++ b/CRM/Member/BAO/Query.php
@@ -409,6 +409,12 @@ class CRM_Member_BAO_Query {
       'class' => 'crm-select2',
     ));
 
+    $form->addEntityRef('membership_type_id', ts('Membership Type(s)'), array(
+      'entity' => 'MembershipType',
+      'multiple' => TRUE,
+      'placeholder' => ts('- any -'),
+    ));
+
     $form->addElement('text', 'member_source', ts('Source'));
 
     CRM_Core_Form_Date::buildDateRange($form, 'member_join_date', 1, '_low', '_high', ts('From'), FALSE);

--- a/CRM/Member/BAO/Query.php
+++ b/CRM/Member/BAO/Query.php
@@ -33,6 +33,8 @@
 class CRM_Member_BAO_Query {
 
   /**
+   * Get available fields.
+   *
    * @return array
    */
   public static function &getFields() {
@@ -41,9 +43,9 @@ class CRM_Member_BAO_Query {
   }
 
   /**
-   * If membership are involved, add the specific membership fields
+   * If membership are involved, add the specific membership fields.
    *
-   * @param $query
+   * @param CRM_Contact_BAO_Query $query
    */
   public static function select(&$query) {
     // if membership mode add membership id
@@ -127,10 +129,11 @@ class CRM_Member_BAO_Query {
   }
 
   /**
-   * @param $query
+   * Generate where clause.
+   *
+   * @param CRM_Contact_BAO_Query $query
    */
   public static function where(&$query) {
-    $grouping = NULL;
     foreach (array_keys($query->_params) as $id) {
       if (empty($query->_params[$id][0])) {
         continue;
@@ -139,18 +142,19 @@ class CRM_Member_BAO_Query {
         if ($query->_mode == CRM_Contact_BAO_QUERY::MODE_CONTACTS) {
           $query->_useDistinct = TRUE;
         }
-        $grouping = $query->_params[$id][3];
         self::whereClauseSingle($query->_params[$id], $query);
       }
     }
   }
 
   /**
-   * @param $values
-   * @param $query
+   * Generate where for a single parameter.
+   *
+   * @param array $values
+   * @param CRM_Contact_BAO_Query $query
    */
   public static function whereClauseSingle(&$values, &$query) {
-    list($name, $op, $value, $grouping, $wildcard) = $values;
+    list($name, $op, $value, $grouping) = $values;
     switch ($name) {
       case 'member_join_date_low':
       case 'member_join_date_high':
@@ -181,7 +185,6 @@ class CRM_Member_BAO_Query {
         $date = CRM_Utils_Date::format($value);
         if ($date) {
           $query->_where[$grouping][] = "civicrm_membership.join_date {$op} {$date}";
-          $date = CRM_Utils_Date::customFormat($value);
           $format = CRM_Utils_Date::customFormat(CRM_Utils_Date::format(array_reverse($value), '-'));
           $query->_qill[$grouping][] = ts('Member Since %2 %1', array(1 => $format, 2 => $op));
         }
@@ -233,7 +236,11 @@ class CRM_Member_BAO_Query {
           "Integer"
         );
         list($op, $value) = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Member_DAO_Membership', $name, $value, $op);
-        $query->_qill[$grouping][] = ts('%1 %2 %3', array(1 => $qillName, 2 => $op, 3 => $value));
+        $query->_qill[$grouping][] = ts('%1 %2 %3', array(
+          1 => $qillName,
+          2 => $op,
+          3 => $value,
+        ));
         $query->_tables['civicrm_membership'] = $query->_whereTables['civicrm_membership'] = 1;
         return;
 
@@ -300,11 +307,13 @@ class CRM_Member_BAO_Query {
   }
 
   /**
-   * @param string $name
-   * @param $mode
-   * @param $side
+   * Generate from clause.
    *
-   * @return null|string
+   * @param string $name
+   * @param int $mode
+   * @param string $side
+   *
+   * @return string
    */
   public static function from($name, $mode, $side) {
     $from = NULL;
@@ -340,7 +349,9 @@ class CRM_Member_BAO_Query {
   }
 
   /**
-   * @param $mode
+   * Get default return properties.
+   *
+   * @param string $mode
    * @param bool $includeCustomFields
    *
    * @return array|null
@@ -386,17 +397,17 @@ class CRM_Member_BAO_Query {
   }
 
   /**
+   * Build the search form.
+   *
    * @param CRM_Core_Form $form
    */
   public static function buildSearchForm(&$form) {
     $membershipStatus = CRM_Member_PseudoConstant::membershipStatus();
-    $form->add('select', 'membership_status_id', ts('Membership Status(s)'), $membershipStatus, FALSE,
-      array('id' => 'membership_status_id', 'multiple' => 'multiple', 'class' => 'crm-select2')
-    );
-
-    $form->addSelect('membership_type_id',
-      array('entity' => 'membership', 'multiple' => 'multiple', 'label' => ts('Membership Type(s)'), 'option_url' => NULL, 'placeholder' => ts('- any -'))
-    );
+    $form->add('select', 'membership_status_id', ts('Membership Status(s)'), $membershipStatus, FALSE, array(
+      'id' => 'membership_status_id',
+      'multiple' => 'multiple',
+      'class' => 'crm-select2',
+    ));
 
     $form->addElement('text', 'member_source', ts('Source'));
 
@@ -436,17 +447,20 @@ class CRM_Member_BAO_Query {
   }
 
   /**
-   * @param $row
+   * Possibly un-required function.
+   *
+   * @param array $row
    * @param int $id
    */
   public static function searchAction(&$row, $id) {
   }
 
   /**
-   * @param $tables
+   * Add membership table.
+   *
+   * @param array $tables
    */
   public static function tableNames(&$tables) {
-    //add membership table
     if (!empty($tables['civicrm_membership_log']) || !empty($tables['civicrm_membership_status']) || CRM_Utils_Array::value('civicrm_membership_type', $tables)) {
       $tables = array_merge(array('civicrm_membership' => 1), $tables);
     }

--- a/CRM/Member/BAO/Query.php
+++ b/CRM/Member/BAO/Query.php
@@ -413,6 +413,7 @@ class CRM_Member_BAO_Query {
       'entity' => 'MembershipType',
       'multiple' => TRUE,
       'placeholder' => ts('- any -'),
+      'select' => array('minimumInputLength' => 0),
     ));
 
     $form->addElement('text', 'member_source', ts('Source'));

--- a/CRM/Member/Form/Search.php
+++ b/CRM/Member/Form/Search.php
@@ -69,6 +69,13 @@ class CRM_Member_Form_Search extends CRM_Core_Form_Search {
   protected $_prefix = "member_";
 
   /**
+   * Declare entity reference fields as they will need to be converted to using 'IN'.
+   *
+   * @var array
+   */
+  protected $entityReferenceFields = array('membership_type_id');
+
+  /**
    * Processing needed for buildForm and later.
    */
   public function preProcess() {
@@ -114,7 +121,7 @@ class CRM_Member_Form_Search extends CRM_Core_Form_Search {
       );
     }
 
-    $this->_queryParams = CRM_Contact_BAO_Query::convertFormValues($this->_formValues);
+    $this->_queryParams = CRM_Contact_BAO_Query::convertFormValues($this->_formValues, 0, FALSE, NULL, $this->entityReferenceFields);
     $selector = new CRM_Member_Selector_Search($this->_queryParams,
       $this->_action,
       NULL,
@@ -197,7 +204,7 @@ class CRM_Member_Form_Search extends CRM_Core_Form_Search {
 
     CRM_Core_BAO_CustomValue::fixCustomFieldValue($this->_formValues);
 
-    $this->_queryParams = CRM_Contact_BAO_Query::convertFormValues($this->_formValues);
+    $this->_queryParams = CRM_Contact_BAO_Query::convertFormValues($this->_formValues, 0, FALSE, NULL, $this->entityReferenceFields);
 
     $this->set('formValues', $this->_formValues);
     $this->set('queryParams', $this->_queryParams);

--- a/CRM/Member/Form/Search.php
+++ b/CRM/Member/Form/Search.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 
 /**
@@ -38,7 +36,9 @@
  */
 
 /**
- * This file is for civimember search
+ * Membership search.
+ *
+ * Class is a pane in advanced search and the membership search page.
  */
 class CRM_Member_Form_Search extends CRM_Core_Form_Search {
 
@@ -70,15 +70,10 @@ class CRM_Member_Form_Search extends CRM_Core_Form_Search {
 
   /**
    * Processing needed for buildForm and later.
-   *
-   * @return void
    */
   public function preProcess() {
     $this->set('searchFormName', 'Search');
 
-    /**
-     * set the button names
-     */
     $this->_searchButtonName = $this->getButtonName('refresh');
     $this->_actionButtonName = $this->getButtonName('next', 'action');
 
@@ -152,9 +147,6 @@ class CRM_Member_Form_Search extends CRM_Core_Form_Search {
 
   /**
    * Build the form object.
-   *
-   *
-   * @return void
    */
   public function buildQuickForm() {
     parent::buildQuickForm();
@@ -186,10 +178,6 @@ class CRM_Member_Form_Search extends CRM_Core_Form_Search {
    *        done.
    * The processing consists of using a Selector / Controller framework for getting the
    * search results.
-   *
-   * @param
-   *
-   * @return void
    */
   public function postProcess() {
     if ($this->_done) {
@@ -262,15 +250,23 @@ class CRM_Member_Form_Search extends CRM_Core_Form_Search {
     $controller->run();
   }
 
+  /**
+   * Set default values.
+   *
+   * @todo - can this function override be removed?
+   *
+   * @return array
+   */
   public function setDefaultValues() {
     return $this->_defaults;
   }
 
+  /**
+   * If this search has been forced then see if there are any get values, and if so over-ride the post values.
+   *
+   * Note that this means that GET over-rides POST :) & that force with no parameters can be very destructive.
+   */
   public function fixFormValues() {
-    // if this search has been forced
-    // then see if there are any get values, and if so over-ride the post values
-    // note that this means that GET over-rides POST :)
-
     if (!$this->_force) {
       return;
     }
@@ -352,7 +348,7 @@ class CRM_Member_Form_Search extends CRM_Core_Form_Search {
   }
 
   /**
-   * Return a descriptive name for the page, used in wizard header
+   * Return a descriptive name for the page, used in wizard header.
    *
    * @return string
    */

--- a/tests/phpunit/CRM/Member/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Member/BAO/QueryTest.php
@@ -1,0 +1,82 @@
+<?php
+require_once 'CiviTest/CiviUnitTestCase.php';
+/**
+ *  Include dataProvider for tests
+ */
+class CRM_Member_BAO_QueryTest extends CiviUnitTestCase {
+
+  /**
+   * Set up function.
+   *
+   * Ensure CiviCase is enabled.
+   */
+  public function setUp() {
+    parent::setUp();
+    CRM_Core_BAO_ConfigSetting::enableComponent('CiviCase');
+  }
+
+  /**
+   * Check that membership type is handled.
+   *
+   * We want to see the following syntaxes for membership_type_id field handled:
+   *   1) membership_type_id => 1
+   */
+  public function testConvertEntityFieldSingleValue() {
+    $formValues = array('membership_type_id' => 2);
+    $params = CRM_Contact_BAO_Query::convertFormValues($formValues, 0, FALSE, NULL, array('membership_type_id'));
+    $this->assertEquals(array('membership_type_id', '=', 2, 0, 0), $params[0]);
+    $obj = new CRM_Contact_BAO_Query($params);
+    $this->assertEquals(array('civicrm_membership.membership_type_id = 2'), $obj->_where[0]);
+  }
+
+  /**
+   * Check that membership type is handled.
+   *
+   * We want to see the following syntaxes for membership_type_id field handled:
+   *   2) membership_type_id => 5,6
+   *
+   * The last of these is the format used prior to converting membership_type_id to an entity reference field.
+   */
+  public function testConvertEntityFieldMultipleValueEntityRef() {
+    $formValues = array('membership_type_id' => '1,2');
+    $params = CRM_Contact_BAO_Query::convertFormValues($formValues, 0, FALSE, NULL, array('membership_type_id'));
+    $this->assertEquals(array('membership_type_id', 'IN', array(1, 2), 0, 0), $params[0]);
+    $obj = new CRM_Contact_BAO_Query($params);
+    $this->assertEquals(array('civicrm_membership.membership_type_id IN ("1", "2")'), $obj->_where[0]);
+  }
+
+  /**
+   * Check that membership type is handled.
+   *
+   * We want to see the following syntaxes for membership_type_id field handled:
+   *   3) membership_type_id => array(5,6)
+   *
+   * The last of these is the format used prior to converting membership_type_id to an entity reference field. It will
+   * be used by pre-existing smart groups.
+   */
+  public function testConvertEntityFieldMultipleValueLegacy() {
+    $formValues = array('membership_type_id' => array(1, 2));
+    $params = CRM_Contact_BAO_Query::convertFormValues($formValues, 0, FALSE, NULL, array('membership_type_id'));
+    $this->assertEquals(array('membership_type_id', 'IN', array(1, 2), 0, 0), $params[0]);
+    $obj = new CRM_Contact_BAO_Query($params);
+    $this->assertEquals(array('civicrm_membership.membership_type_id IN ("1", "2")'), $obj->_where[0]);
+  }
+
+  /**
+   * Check that running convertFormValues more than one doesn't mangle the array.
+   *
+   * Unfortunately the convertFormValues & indeed much of the query code is run in pre-process AND post-process.
+   *
+   * The convertFormValues function should cope with this until such time as we can rationalise that.
+   */
+  public function testConvertEntityFieldMultipleValueEntityRefDoubleRun() {
+    $formValues = array('membership_type_id' => '1,2');
+    $params = CRM_Contact_BAO_Query::convertFormValues($formValues, 0, FALSE, NULL, array('membership_type_id'));
+    $this->assertEquals(array('membership_type_id', 'IN', array(1, 2), 0, 0), $params[0]);
+    $params = CRM_Contact_BAO_Query::convertFormValues($params, 0, FALSE, NULL, array('membership_type_id'));
+    $this->assertEquals(array('membership_type_id', 'IN', array(1, 2), 0, 0), $params[0]);
+    $obj = new CRM_Contact_BAO_Query($params);
+    $this->assertEquals(array('civicrm_membership.membership_type_id IN ("1", "2")'), $obj->_where[0]);
+  }
+
+}

--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -1388,4 +1388,20 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
 
   }
 
+  /**
+   * Test that all membership types are returned when getoptions is called.
+   *
+   * This test locks in current behaviour where types for all domains are returned. It should possibly be domain
+   * specific but that should only be done in conjunction with adding a hook to allow that to be altered as the
+   * multisite use case expects the master domain to be able to see all sites.
+   *
+   * See CRM-17075.
+   */
+  public function testGetOptionsMembershipTypeID() {
+    $options = $this->callAPISuccess('Membership', 'getoptions', array('field' => 'membership_type_id'));
+    $this->assertEquals('General', array_pop($options['values']));
+    $this->assertEquals('General', array_pop($options['values']));
+    $this->assertEquals(NULL, array_pop($options['values']));
+  }
+
 }

--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -32,7 +32,6 @@
  * @subpackage API_Member
  */
 
-
 require_once 'CiviTest/CiviUnitTestCase.php';
 
 /**
@@ -50,9 +49,10 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
   protected $_entity;
   protected $_params;
 
-
+  /**
+   * Set up for tests.
+   */
   public function setUp() {
-    // Connect to the database.
     parent::setUp();
     $this->_apiversion = 3;
     $this->_contactID = $this->individualCreate();
@@ -83,6 +83,11 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     );
   }
 
+  /**
+   * Clean up after tests.
+   *
+   * @throws \Exception
+   */
   public function tearDown() {
     $this->quickCleanup(array(
         'civicrm_membership',
@@ -211,6 +216,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
 
   /**
    * Test civicrm_membership_get with params not array.
+   *
    * Gets treated as contact_id, memberships expected.
    */
   public function testGetWithParamsMemberShipTypeId() {
@@ -223,14 +229,14 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
       'id' => $membership['id'],
     ));
     $result = $membership['values'][$membership['id']];
-    $this->assertEquals($result['contact_id'], $this->_contactID, "In line " . __LINE__);
-    $this->assertEquals($result['membership_type_id'], $this->_membershipTypeID, "In line " . __LINE__);
-    $this->assertEquals($result['status_id'], $this->_membershipStatusID, "In line " . __LINE__);
-    $this->assertEquals($result['join_date'], '2009-01-21', "In line " . __LINE__);
-    $this->assertEquals($result['start_date'], '2009-01-21', "In line " . __LINE__);
-    $this->assertEquals($result['end_date'], '2009-12-21', "In line " . __LINE__);
-    $this->assertEquals($result['source'], 'Payment', "In line " . __LINE__);
-    $this->assertEquals($result['is_override'], 1, "In line " . __LINE__);
+    $this->assertEquals($result['contact_id'], $this->_contactID);
+    $this->assertEquals($result['membership_type_id'], $this->_membershipTypeID);
+    $this->assertEquals($result['status_id'], $this->_membershipStatusID);
+    $this->assertEquals($result['join_date'], '2009-01-21');
+    $this->assertEquals($result['start_date'], '2009-01-21');
+    $this->assertEquals($result['end_date'], '2009-12-21');
+    $this->assertEquals($result['source'], 'Payment');
+    $this->assertEquals($result['is_override'], 1);
     $this->assertEquals($result['id'], $membership['id']);
   }
 
@@ -262,7 +268,8 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
   }
 
   /**
-   * Check with complete array + custom field
+   * Check with complete array + custom field.
+   *
    * Note that the test is written on purpose without any
    * variables specific to participant so it can be replicated into other entities
    * and / or moved to the automated test suite
@@ -299,15 +306,15 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     $this->callAPISuccess('Membership', 'Delete', array(
       'id' => $membership['id'],
     ));
-    $this->assertEquals($result['join_date'], '2009-01-21', "In line " . __LINE__);
-    $this->assertEquals($result['contact_id'], $this->_contactID, "In line " . __LINE__);
-    $this->assertEquals($result['membership_type_id'], $this->_membershipTypeID, "In line " . __LINE__);
-    $this->assertEquals($result['status_id'], $this->_membershipStatusID, "In line " . __LINE__);
+    $this->assertEquals($result['join_date'], '2009-01-21');
+    $this->assertEquals($result['contact_id'], $this->_contactID);
+    $this->assertEquals($result['membership_type_id'], $this->_membershipTypeID);
+    $this->assertEquals($result['status_id'], $this->_membershipStatusID);
 
-    $this->assertEquals($result['start_date'], '2009-01-21', "In line " . __LINE__);
-    $this->assertEquals($result['end_date'], '2009-12-21', "In line " . __LINE__);
-    $this->assertEquals($result['source'], 'Payment', "In line " . __LINE__);
-    $this->assertEquals($result['is_override'], 1, "In line " . __LINE__);
+    $this->assertEquals($result['start_date'], '2009-01-21');
+    $this->assertEquals($result['end_date'], '2009-12-21');
+    $this->assertEquals($result['source'], 'Payment');
+    $this->assertEquals($result['is_override'], 1);
   }
 
 
@@ -372,7 +379,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     );
 
     $membership = $this->callAPISuccess('membership', 'get', $params);
-    $this->assertEquals($membership['count'], 0, "In line " . __LINE__);
+    $this->assertEquals($membership['count'], 0);
   }
 
   /**

--- a/tests/phpunit/api/v3/MembershipTypeTest.php
+++ b/tests/phpunit/api/v3/MembershipTypeTest.php
@@ -36,6 +36,9 @@ class api_v3_MembershipTypeTest extends CiviUnitTestCase {
   protected $_apiversion;
   protected $_entity = 'MembershipType';
 
+  /**
+   * Set up for tests.
+   */
   public function setUp() {
     parent::setUp();
     $this->useTransaction(TRUE);
@@ -43,6 +46,11 @@ class api_v3_MembershipTypeTest extends CiviUnitTestCase {
     $this->_contactID = $this->organizationCreate();
   }
 
+  /**
+   * Get the membership without providing an ID.
+   *
+   * This should return an empty array but not an error.
+   */
   public function testGetWithoutId() {
     $params = array(
       'name' => '60+ Membership',
@@ -54,23 +62,26 @@ class api_v3_MembershipTypeTest extends CiviUnitTestCase {
       'visibility' => 'public',
     );
 
-    $membershiptype = $this->callAPISuccess('membership_type', 'get', $params);
-    $this->assertEquals($membershiptype['count'], 0);
+    $membershipType = $this->callAPISuccess('membership_type', 'get', $params);
+    $this->assertEquals($membershipType['count'], 0);
   }
 
+  /**
+   * Test get works.
+   */
   public function testGet() {
     $id = $this->membershipTypeCreate(array('member_of_contact_id' => $this->_contactID));
 
     $params = array(
       'id' => $id,
     );
-    $membershiptype = $this->callAPIAndDocument('membership_type', 'get', $params, __FUNCTION__, __FILE__);
-    $this->assertEquals($membershiptype['values'][$id]['name'], 'General');
-    $this->assertEquals($membershiptype['values'][$id]['member_of_contact_id'], $this->_contactID);
-    $this->assertEquals($membershiptype['values'][$id]['financial_type_id'], 1);
-    $this->assertEquals($membershiptype['values'][$id]['duration_unit'], 'year');
-    $this->assertEquals($membershiptype['values'][$id]['duration_interval'], '1');
-    $this->assertEquals($membershiptype['values'][$id]['period_type'], 'rolling');
+    $membershipType = $this->callAPIAndDocument('membership_type', 'get', $params, __FUNCTION__, __FILE__);
+    $this->assertEquals($membershipType['values'][$id]['name'], 'General');
+    $this->assertEquals($membershipType['values'][$id]['member_of_contact_id'], $this->_contactID);
+    $this->assertEquals($membershipType['values'][$id]['financial_type_id'], 1);
+    $this->assertEquals($membershipType['values'][$id]['duration_unit'], 'year');
+    $this->assertEquals($membershipType['values'][$id]['duration_interval'], '1');
+    $this->assertEquals($membershipType['values'][$id]['period_type'], 'rolling');
     $this->membershipTypeDelete($params);
   }
 
@@ -87,9 +98,7 @@ class api_v3_MembershipTypeTest extends CiviUnitTestCase {
       'visibility' => 'public',
     );
 
-    $membershiptype = $this->callAPIFailure('membership_type', 'create', $params,
-                      'Mandatory key(s) missing from params array: member_of_contact_id'
-                                           );
+    $this->callAPIFailure('membership_type', 'create', $params, 'Mandatory key(s) missing from params array: member_of_contact_id');
   }
 
   public function testCreateWithoutNameandDomainIDandDurationUnit() {


### PR DESCRIPTION
This patch includes tests for ensuring that the field continues to support the old format - with that code being generic to changing select fields to entity reference.

---
- [CRM-17075: MembershipType search changed in 4.6](https://issues.civicrm.org/jira/browse/CRM-17075)
