### PR TITLE
CRM-17215 fix auto-renew not showing on radio options

### DIFF
--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -1288,6 +1288,11 @@ GROUP BY     mt.member_of_contact_id";
   /**
    * Check if auto renew option should be shown.
    *
+   * The auto-renew option should be visible if membership types associated with all the fields has
+   * been set for auto-renew option.
+   *
+   * Auto renew checkbox should be frozen if for all the membership type auto renew is required
+   *
    * @param int $priceSetId
    *   Price set id.
    *
@@ -1295,43 +1300,46 @@ GROUP BY     mt.member_of_contact_id";
    *   $autoRenewOption ( 0:hide, 1:optional 2:required )
    */
   public static function checkAutoRenewForPriceSet($priceSetId) {
-    // auto-renew option should be visible if membership types associated with all the fields has
-    // been set for auto-renew option
-    // Auto renew checkbox should be frozen if for all the membership type auto renew is required
-
-    // get the membership type auto renew option and check if required or optional
-    $query = 'SELECT mt.auto_renew, mt.duration_interval, mt.duration_unit
+    $query = 'SELECT DISTINCT mt.auto_renew, mt.duration_interval, mt.duration_unit,
+             pf.html_type, pf.id as price_field_id
             FROM civicrm_price_field_value pfv
             INNER JOIN civicrm_membership_type mt ON pfv.membership_type_id = mt.id
             INNER JOIN civicrm_price_field pf ON pfv.price_field_id = pf.id
             WHERE pf.price_set_id = %1
             AND   pf.is_active = 1
-            AND   pfv.is_active = 1';
+            AND   pfv.is_active = 1
+            ORDER BY price_field_id';
 
     $params = array(1 => array($priceSetId, 'Integer'));
 
     $dao = CRM_Core_DAO::executeQuery($query, $params);
+
     $autoRenewOption = 2;
-    $interval = $unit = array();
+    $priceFields = array();
     while ($dao->fetch()) {
       if (!$dao->auto_renew) {
-        $autoRenewOption = 0;
-        break;
+        // If any one can't be renewed none can.
+        return 0;
       }
       if ($dao->auto_renew == 1) {
         $autoRenewOption = 1;
       }
 
-      $interval[$dao->duration_interval] = $dao->duration_interval;
-      $unit[$dao->duration_unit] = $dao->duration_unit;
+      if ($dao->html_type == 'Checkbox' && !in_array($dao->duration_interval . $dao->duration_unit, $priceFields[$dao->price_field_id])) {
+        // Checkbox fields cannot support auto-renew if they have more than one duration configuration
+        // as more than one can be selected. Radio and select are either-or so they can have more than one duration.
+        return 0;
+      }
+      $priceFields[$dao->price_field_id][] = $dao->duration_interval . $dao->duration_unit;
+      foreach ($priceFields as $priceFieldID => $durations) {
+        if ($priceFieldID != $dao->price_field_id && !in_array($dao->duration_interval . $dao->duration_unit, $durations)) {
+          // Another price field has a duration configuration that differs so we can't offer auto-renew.
+          return 0;
+        }
+      }
     }
 
-    if (count($interval) == 1 && count($unit) == 1 && $autoRenewOption > 0) {
-      return $autoRenewOption;
-    }
-    else {
-      return 0;
-    }
+    return $autoRenewOption;
   }
 
   /**


### PR DESCRIPTION
Fix the scenario where auto-renew is blocked because multiple duration configurations are available
in a price set but need not be blocked as they are mutually exclusive

---
- [CRM-17215: Renew options hidden on a form when 2 mutually exclusive radio options have different duration](https://issues.civicrm.org/jira/browse/CRM-17215)
