### PR TITLE
fixed number format problem with PayPal fee calculation

### DIFF
--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -316,7 +316,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
     $params['fee_amount'] = $result['feeamt'];
     $params['net_amount'] = CRM_Utils_Array::value('settleamt', $result);
     if ($params['net_amount'] == 0 && $params['fee_amount'] != 0) {
-      $params['net_amount'] = $params['gross_amount'] - $params['fee_amount'];
+      $params['net_amount'] = number_format(($params['gross_amount'] - $params['fee_amount']), 2);
     }
     $params['payment_status'] = $result['paymentstatus'];
     $params['pending_reason'] = $result['pendingreason'];
@@ -382,7 +382,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
     $params['fee_amount'] = $result['feeamt'];
     $params['net_amount'] = $result['settleamt'];
     if ($params['net_amount'] == 0 && $params['fee_amount'] != 0) {
-      $params['net_amount'] = $params['gross_amount'] - $params['fee_amount'];
+      $params['net_amount'] = number_format(($params['gross_amount'] - $params['fee_amount']), 2);
     }
     $params['payment_status'] = $result['paymentstatus'];
     $params['pending_reason'] = $result['pendingreason'];


### PR DESCRIPTION
properly format calculated `net_amount`
