### PR TITLE
Running the fetch_activities cli task stops with a fatal error when t…

### DIFF
--- a/CRM/Utils/Mail/EmailProcessor.php
+++ b/CRM/Utils/Mail/EmailProcessor.php
@@ -238,8 +238,14 @@ class CRM_Utils_Mail_EmailProcessor {
 
         // preseve backward compatibility
         if ($usedfor == 0 || !$civiMail) {
-          // if its the activities that needs to be processed ..
-          $mailParams = CRM_Utils_Mail_Incoming::parseMailingObject($mail);
+           // if its the activities that needs to be processed ..
+          try {
+			$mailParams = CRM_Utils_Mail_Incoming::parseMailingObject($mail);
+		  } catch (Exception $e) {
+			echo $e->getMessage();
+			$store->markIgnored($key);
+			continue;
+		  }
 
           require_once 'CRM/Utils/DeprecatedUtils.php';
           $params = _civicrm_api3_deprecated_activity_buildmailparams($mailParams, $emailActivityTypeId);

--- a/CRM/Utils/Mail/EmailProcessor.php
+++ b/CRM/Utils/Mail/EmailProcessor.php
@@ -238,14 +238,15 @@ class CRM_Utils_Mail_EmailProcessor {
 
         // preseve backward compatibility
         if ($usedfor == 0 || !$civiMail) {
-           // if its the activities that needs to be processed ..
+          // if its the activities that needs to be processed ..
           try {
-			$mailParams = CRM_Utils_Mail_Incoming::parseMailingObject($mail);
-		  } catch (Exception $e) {
-			echo $e->getMessage();
-			$store->markIgnored($key);
-			continue;
-		  }
+            $mailParams = CRM_Utils_Mail_Incoming::parseMailingObject($mail);
+          } 
+          catch (Exception $e) {
+            echo $e->getMessage();
+            $store->markIgnored($key);
+            continue;
+          }
 
           require_once 'CRM/Utils/DeprecatedUtils.php';
           $params = _civicrm_api3_deprecated_activity_buildmailparams($mailParams, $emailActivityTypeId);

--- a/CRM/Utils/Mail/EmailProcessor.php
+++ b/CRM/Utils/Mail/EmailProcessor.php
@@ -241,7 +241,7 @@ class CRM_Utils_Mail_EmailProcessor {
           // if its the activities that needs to be processed ..
           try {
             $mailParams = CRM_Utils_Mail_Incoming::parseMailingObject($mail);
-          } 
+          }
           catch (Exception $e) {
             echo $e->getMessage();
             $store->markIgnored($key);


### PR DESCRIPTION
…he incomming mail parser is unable to determine the ezcMailDeliveryStatus. The fetch_activities task will continue to download and attempt to parse the offending email, dying every time. This prevents other mails from being downloaded and parsed.

Error Message: "No clue about the ezcMailDeliveryStatus"

This patch catches that error, prints it, marks the offending email ignored, and allows activities processing to continue.

Should fix issues:
https://issues.civicrm.org/jira/browse/CRM-9484 (last comment in June 2015, 
Second bullet point here: https://forum.civicrm.org/index.php?topic=35916.0
