### PR TITLE
CRM-17242 notice fix

### DIFF
--- a/CRM/Report/Form/Member/Summary.php
+++ b/CRM/Report/Form/Member/Summary.php
@@ -185,7 +185,6 @@ class CRM_Report_Form_Member_Summary extends CRM_Report_Form {
         'operatorType' => CRM_Report_Form::OP_MULTISELECT,
         'options' => $this->activeCampaigns,
       );
-      $this->_columns['civicrm_membership']['grouping']['campaign_id'] = 'contri-fields';
       $this->_columns['civicrm_membership']['group_bys']['campaign_id'] = array('title' => ts('Campaign'));
     }
 


### PR DESCRIPTION
group is already a string so can't be treated as an array

---
- [CRM-17242: Warning: Illegal string offset 'campaign_id' in CRM_Report_Form_Member_Summary->__construct() (line 189 CRM\/Report\/Form\/Member\/Summary.php).](https://issues.civicrm.org/jira/browse/CRM-17242)
