### PR TITLE
CRM-17253 omit expensive unused information from token query

### DIFF
--- a/CRM/Core/BAO/MessageTemplate.php
+++ b/CRM/Core/BAO/MessageTemplate.php
@@ -426,6 +426,11 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate {
           $returnProperties[$name] = 1;
         }
       }
+
+      // @todo CRM-17253 don't resolve contact details if there are no tokens
+      // effectively comment out this next (performance-expensive) line
+      // but unfortunately testing is a bit think on the ground to that needs to
+      // be added.
       list($contact) = CRM_Utils_Token::getTokenDetails($contactParams,
         $returnProperties,
         FALSE, FALSE, NULL,

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1181,7 +1181,7 @@ class CRM_Utils_Token {
       // putting a fatal here so we can track if/when this happens
       CRM_Core_Error::fatal();
     }
-
+    // @todo this functions needs unit tests.
     $params = array();
     foreach ($contactIDs as $key => $contactID) {
       $params[] = array(
@@ -1213,7 +1213,14 @@ class CRM_Utils_Token {
         array('display_name', 'checksum', 'contact_id')
       );
       foreach ($fields as $key => $val) {
-        $returnProperties[$val] = 1;
+        // The unavailable fields are not available as tokens, do not have a one-2-one relationship
+        // with contacts and are expensive to resolve.
+        // @todo see CRM-17253 - there are some other fields (e.g note) that should be excluded
+        // and upstream calls to this should populate return properties.
+        $unavailableFields = array('group', 'tag');
+        if (!in_array($val, $unavailableFields)) {
+          $returnProperties[$val] = 1;
+        }
       }
     }
 


### PR DESCRIPTION
- [CRM-17253: CiviCRM resolves all tokens including groups & tags if none are present in the mail text](https://issues.civicrm.org/jira/browse/CRM-17253)
