### PR TITLE
CRM-16555 add code-comments

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -432,6 +432,11 @@ LEFT JOIN  civicrm_contribution on (civicrm_contribution.contact_id = civicrm_co
       }
       $this->_processors = array();
       foreach ($this->_paymentProcessors as $id => $processor) {
+        // @todo review this. The inclusion of this IF was to address test processors being incorrectly loaded.
+        // However the function $this->getValidProcessors() is expected to only return the processors relevant
+        // to the mode (using the actual id - ie. the id of the test processor for the test processor).
+        // for some reason there was a need to filter here per commit history - but this indicates a problem 
+        // somewhere else.
         if ($processor['is_test'] == ($this->_mode == 'test')) {
           $this->_processors[$id] = ts($processor['name']);
           if (!empty($processor['description'])) {


### PR DESCRIPTION
The patch added for CRM-16555 should not have been needed as the intention was that the function to getValidProcessors handling for mode would have worked. Adding some comments to indicate this for next time someone looks at it.

---
- [CRM-16555: Make Payment form credit \/ debit card changing available to backoffice](https://issues.civicrm.org/jira/browse/CRM-16555)
