### PR TITLE
composer.json - Use symfony/filesystem circa 2.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     "symfony/config": "~2.5.0",
     "symfony/dependency-injection": "~2.5.0",
     "symfony/event-dispatcher": "~2.5.0",
+    "symfony/filesystem": "~2.5.0",
     "symfony/process": "~2.5.0",
     "psr/log": "1.0.0",
     "symfony/finder": "~2.5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "17a96ee2a893c966c2affd0eec056402",
-    "content-hash": "4ada5fd23e9e7d0dc464c7cc7857d65f",
+    "hash": "1ca80bcd5b78e24dbc9578ae774ac763",
+    "content-hash": "ae05dc8ff99d56f083c2d09c7e54c4a2",
     "packages": [
         {
             "name": "civicrm/civicrm-cxn-rpc",
@@ -422,32 +422,30 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v2.7.2",
+            "version": "v2.5.12",
+            "target-dir": "Symfony/Component/Filesystem",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Filesystem.git",
-                "reference": "2d7b2ddaf3f548f4292df49a99d19c853d43f0b8"
+                "reference": "d3c24d7d6e9c342008d8421b2fade460311647ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/2d7b2ddaf3f548f4292df49a99d19c853d43f0b8",
-                "reference": "2d7b2ddaf3f548f4292df49a99d19c853d43f0b8",
+                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/d3c24d7d6e9c342008d8421b2fade460311647ea",
+                "reference": "d3c24d7d6e9c342008d8421b2fade460311647ea",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.9"
-            },
-            "require-dev": {
-                "symfony/phpunit-bridge": "~2.7"
+                "php": ">=5.3.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.5-dev"
                 }
             },
             "autoload": {
-                "psr-4": {
+                "psr-0": {
                     "Symfony\\Component\\Filesystem\\": ""
                 }
             },
@@ -457,17 +455,17 @@
             ],
             "authors": [
                 {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
                 },
                 {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
                 }
             ],
             "description": "Symfony Filesystem Component",
-            "homepage": "https://symfony.com",
-            "time": "2015-07-09 16:07:40"
+            "homepage": "http://symfony.com",
+            "time": "2015-01-03 21:04:44"
         },
         {
             "name": "symfony/finder",


### PR DESCRIPTION
The rest of the Symfony components are targetting ~2.5, but some reason
we're autoselecting `symfony/filesystem` ~2.7.  That produces errors on
`test-debian6-1`.
