### PR TITLE
CRM-17254 retrieving groups: don't append extra params

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -1347,10 +1347,17 @@ class CRM_Contact_BAO_Query {
 
           if (!isset($group->saved_search_id)) {
             $tbName = "`civicrm_group_contact-{$groupId}`";
-            $this->_select['group_contact_id'] = "$tbName.id as group_contact_id";
-            $this->_element['group_contact_id'] = 1;
-            $this->_select['status'] = "$tbName.status as status";
-            $this->_element['status'] = 1;
+            // CRM-17254 don't retrieve extra fields if contact_id is specifically requested
+            // as this will add load to an intentionally light query.
+            // ideally this code would be removed as it appears to be to support CRM-1203
+            // and passing in the required returnProperties from the url would
+            // make more sense that globally applying the requirements of one form.
+            if (($this->_returnProperties != array('contact_id'))) {
+              $this->_select['group_contact_id'] = "$tbName.id as group_contact_id";
+              $this->_element['group_contact_id'] = 1;
+              $this->_select['status'] = "$tbName.status as status";
+              $this->_element['status'] = 1;
+            }
           }
         }
         $this->_useGroupBy = TRUE;

--- a/tests/phpunit/CRM/Contact/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTest.php
@@ -191,4 +191,25 @@ class CRM_Contact_BAO_QueryTest extends CiviUnitTestCase {
     }
   }
 
+  /**
+   * Test set up to test calling the query object per GroupContactCache BAO usage.
+   *
+   * CRM-17254 ensure that if only the contact_id is required other fields should
+   * not be appended.
+   */
+  public function testGroupContactCacheAddSearch() {
+    $returnProperties = array('contact_id');
+    $params = array(array('group', 'IN', array(1 => 1), 0, 0));
+
+    $query = new CRM_Contact_BAO_Query(
+      $params, $returnProperties,
+      NULL, TRUE, FALSE, 1,
+      TRUE,
+      TRUE, FALSE
+    );
+
+    list($select) = $query->query(FALSE);
+    $this->assertEquals('SELECT contact_a.id as contact_id', $select);
+  }
+
 }


### PR DESCRIPTION
when only contact_id is requested in returnProperties this should be respected

---
- [CRM-17254: Reduce load when rebuilding smartgroups by not getting unrequired fields](https://issues.civicrm.org/jira/browse/CRM-17254)
