### PR TITLE
CRM-16373 - $config - Separate runtime and boot services

### DIFF
--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -431,7 +431,7 @@ WHERE  id = %1
     }
 
     // grab a lock so other processes dont compete and do the same query
-    $lock = Civi::service('lockManager')->acquire("data.core.group.{$groupID}");
+    $lock = Civi::lockManager()->acquire("data.core.group.{$groupID}");
     if (!$lock->isAcquired()) {
       // this can cause inconsistent results since we dont know if the other process
       // will fill up the cache before our calling routine needs it.

--- a/CRM/Core/BAO/Cache.php
+++ b/CRM/Core/BAO/Cache.php
@@ -153,7 +153,7 @@ class CRM_Core_BAO_Cache extends CRM_Core_DAO_Cache {
     // get a lock so that multiple ajax requests on the same page
     // dont trample on each other
     // CRM-11234
-    $lock = Civi::service('lockManager')->acquire("cache.{$group}_{$path}._{$componentID}");
+    $lock = Civi::lockManager()->acquire("cache.{$group}_{$path}._{$componentID}");
     if (!$lock->isAcquired()) {
       CRM_Core_Error::fatal();
     }

--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -90,6 +90,11 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
       self::$_singleton->getRuntime()->initialize($loadFromDB);
       if ($loadFromDB && self::$_singleton->getRuntime()->dsn) {
         CRM_Core_DAO::init(self::$_singleton->getRuntime()->dsn);
+      }
+      \Civi\Core\Container::getBootServices();
+      if ($loadFromDB && self::$_singleton->getRuntime()->dsn) {
+        CRM_Extension_System::singleton();
+        \Civi\Core\Container::singleton();
 
         $domain = \CRM_Core_BAO_Domain::getDomain();
         \CRM_Core_BAO_ConfigSetting::applyLocale(\Civi::settings($domain->id), $domain->locales);

--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -389,17 +389,6 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
     return FALSE;
   }
 
-
-  /**
-   * Wrapper function to allow unit tests to switch user framework on the fly.
-   *
-   * @param string $userFramework
-   *   One of 'Drupal', 'Joomla', etc.
-   * @deprecated
-   */
-  public function setUserFramework($userFramework) {
-    $this->getRuntime()->setUserFramework($userFramework);
-  }
   /**
    * Is back office credit card processing enabled for this site - ie are there any installed processors that support
    * it?

--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -87,15 +87,8 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
       }
 
       self::$_singleton = new CRM_Core_Config();
-      self::$_singleton->getRuntime()->initialize($loadFromDB);
-      if ($loadFromDB && self::$_singleton->getRuntime()->dsn) {
-        CRM_Core_DAO::init(self::$_singleton->getRuntime()->dsn);
-      }
-      \Civi\Core\Container::getBootServices();
-      if ($loadFromDB && self::$_singleton->getRuntime()->dsn) {
-        CRM_Extension_System::singleton();
-        \Civi\Core\Container::singleton();
-
+      \Civi\Core\Container::boot($loadFromDB);
+      if ($loadFromDB && self::$_singleton->dsn) {
         $domain = \CRM_Core_BAO_Domain::getDomain();
         \CRM_Core_BAO_ConfigSetting::applyLocale(\Civi::settings($domain->id), $domain->locales);
 

--- a/CRM/Core/Config/MagicMerge.php
+++ b/CRM/Core/Config/MagicMerge.php
@@ -30,8 +30,8 @@
  *
  * Originally, the $config object was based on a single, serialized
  * data object stored in the database. As the needs for settings
- * grew (with robust metadata, system overrides, and extension support),
- * the $config started to store a mix of:
+ * grew (with robust metadata, system overrides, extension support,
+ * and multi-tenancy), the $config started to store a mix of:
  *   (a) canonical config options,
  *   (b) dynamically generated runtime data,
  *   (c) cached data derived from other sources (esp civicrm_setting)
@@ -82,8 +82,36 @@ class CRM_Core_Config_MagicMerge {
     // If $foreignName is omitted/null, then it's assumed to match the $propertyName.
     // Other parameters may be specified, depending on the type.
     return array(
+      // "local" properties are unique to each instance of CRM_Core_Config (each request).
+      'doNotResetCache' => array('local'),
+      'inCiviCRM' => array('local'),
+      'userFrameworkFrontend' => array('local'),
+
+      // "runtime" properties are computed from define()s, $_ENV, etc.
+      // See also: CRM_Core_Config_Runtime.
+      'dsn' => array('runtime'),
+      'initialized' => array('runtime'),
+      'userFramework' => array('runtime'),
+      'userFrameworkBaseURL' => array('runtime'),
+      'userFrameworkClass' => array('runtime'),
+      'userFrameworkDSN' => array('runtime'),
+      'useFrameworkRelativeBase' => array('runtime', 'useFrameworkRelativeBase'),
+      'userFrameworkURLVar' => array('runtime'),
+      'userFrameworkVersion' => array('runtime'),
+      'userPermissionClass' => array('runtime'),
+      'userPermissionTemp' => array('runtime'),
+      'userSystem' => array('runtime'),
+      'userHookClass' => array('runtime'),
+      'cleanURL' => array('runtime'),
+      'configAndLogDir' => array('runtime'),
+      'templateCompileDir' => array('runtime'),
+      'templateDir' => array('runtime'),
+
+      // "setting" properties are loaded through the setting layer, esp
+      // table "civicrm_setting" and global $civicrm_setting.
+      // See also: Civi::settings().
       'backtrace' => array('setting'),
-      'contact_default_language' => array('contact_default_language'),
+      'contact_default_language' => array('setting'),
       'countryLimit' => array('setting'),
       'dashboardCacheTimeout' => array('setting'),
       'dateInputFormat' => array('setting'),
@@ -144,28 +172,8 @@ class CRM_Core_Config_MagicMerge {
       'wpBasePage' => array('setting'),
       'wpLoadPhp' => array('setting'),
 
-      'doNotResetCache' => array('local'),
-      'inCiviCRM' => array('local'),
-      'userFrameworkFrontend' => array('local'),
-
-      'dsn' => array('runtime'),
-      'initialized' => array('runtime'),
-      'userFramework' => array('runtime'),
-      'userFrameworkBaseURL' => array('runtime'),
-      'userFrameworkClass' => array('runtime'),
-      'userFrameworkDSN' => array('runtime'),
-      'useFrameworkRelativeBase' => array('runtime', 'useFrameworkRelativeBase'),
-      'userFrameworkURLVar' => array('runtime'),
-      'userFrameworkVersion' => array('runtime'),
-      'userPermissionClass' => array('runtime'),
-      'userPermissionTemp' => array('runtime'),
-      'userSystem' => array('runtime'),
-      'userHookClass' => array('runtime'),
-      'cleanURL' => array('runtime'),
-      'configAndLogDir' => array('runtime'),
-      'templateCompileDir' => array('runtime'),
-      'templateDir' => array('runtime'),
-
+      // "setting-path" properties are settings with special filtering
+      // to return normalized file paths.
       'customFileUploadDir' => array('setting-path', NULL, array('mkdir', 'restrict')),
       'customPHPPathDir' => array('setting-path'),
       'customTemplateDir' => array('setting-path'),
@@ -173,12 +181,15 @@ class CRM_Core_Config_MagicMerge {
       'imageUploadDir' => array('setting-path', NULL, array('mkdir')),
       'uploadDir' => array('setting-path', NULL, array('mkdir', 'restrict')),
 
+      // "setting-url-*" properties are settings with special filtering
+      // to return normalized URLs (in either absolute or relative format).
       'customCSSURL' => array('setting-url-abs'),
       'extensionsURL' => array('setting-url-abs'),
       'imageUploadURL' => array('setting-url-abs'),
       'resourceBase' => array('setting-url-rel', 'userFrameworkResourceURL'),
       'userFrameworkResourceURL' => array('setting-url-abs'),
 
+      // "callback" properties are generated on-demand by calling a function.
       'geocodeMethod' => array('callback', 'CRM_Utils_Geocode', 'getProviderClass'),
       'defaultCurrencySymbol' => array('callback', 'CRM_Core_BAO_Country', 'getDefaultCurrencySymbol'),
     );

--- a/CRM/Core/Config/MagicMerge.php
+++ b/CRM/Core/Config/MagicMerge.php
@@ -54,7 +54,7 @@ class CRM_Core_Config_MagicMerge {
    */
   private $map;
 
-  private $runtime, $locals, $settings;
+  private $locals, $settings;
 
   private $cache = array();
 
@@ -103,7 +103,7 @@ class CRM_Core_Config_MagicMerge {
       'templateDir' => array('runtime'),
 
       // "boot-svc" properties are critical services needed during init.
-      // See also: Civi\Core\Container::getBootServices().
+      // See also: Civi\Core\Container::getBootService().
       'userSystem' => array('boot-svc'),
       'userPermissionClass' => array('boot-svc'),
 
@@ -241,7 +241,7 @@ class CRM_Core_Config_MagicMerge {
         return $this->cache[$k];
 
       case 'runtime':
-        return $this->getRuntime()->{$name};
+        return \Civi\Core\Container::getBootService('runtime')->{$name};
 
       case 'boot-svc':
         $this->cache[$k] = \Civi\Core\Container::getBootService($name);
@@ -337,16 +337,6 @@ class CRM_Core_Config_MagicMerge {
       default:
         throw new \CRM_Core_Exception("Cannot unset property CRM_Core_Config::\${$k} ($type)");
     }
-  }
-
-  /**
-   * @return CRM_Core_Config_Runtime
-   */
-  protected function getRuntime() {
-    if ($this->runtime === NULL) {
-      $this->runtime = new CRM_Core_Config_Runtime();
-    }
-    return $this->runtime;
   }
 
   /**

--- a/CRM/Core/Config/MagicMerge.php
+++ b/CRM/Core/Config/MagicMerge.php
@@ -287,6 +287,7 @@ class CRM_Core_Config_MagicMerge {
       case 'user-system':
       case 'runtime':
       case 'callback':
+      case 'boot-svc':
         // In the past, changes to $config were not persisted automatically.
         $this->cache[$name] = $v;
         return;

--- a/CRM/Core/Config/Runtime.php
+++ b/CRM/Core/Config/Runtime.php
@@ -135,6 +135,7 @@ class CRM_Core_Config_Runtime {
 
     $this->templateDir = array(dirname(dirname(dirname(__DIR__))) . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR);
 
+    // FIXME
     if (isset($this->customPHPPathDir) && $this->customPHPPathDir) {
       set_include_path($this->customPHPPathDir . PATH_SEPARATOR . get_include_path());
     }

--- a/CRM/Core/Config/Runtime.php
+++ b/CRM/Core/Config/Runtime.php
@@ -195,4 +195,28 @@ class CRM_Core_Config_Runtime {
     exit();
   }
 
+  /**
+   * Create a unique identification code for this runtime.
+   *
+   * If two requests involve a different hostname, different
+   * port, different DSN, etc., then they should also have a
+   * different runtime ID.
+   *
+   * @return mixed
+   */
+  public static function getId() {
+    if (!isset(Civi::$statics[__CLASS__]['id'])) {
+      Civi::$statics[__CLASS__]['id'] = md5(implode(\CRM_Core_DAO::VALUE_SEPARATOR, array(
+        defined('CIVICRM_DOMAIN_ID') ? CIVICRM_DOMAIN_ID : 1, // e.g. one database, multi URL
+        parse_url(CIVICRM_DSN, PHP_URL_PATH), // e.g. one codebase, multi database
+        \CRM_Utils_Array::value('SCRIPT_FILENAME', $_SERVER, ''), // e.g. CMS vs extern vs installer
+        \CRM_Utils_Array::value('HTTP_HOST', $_SERVER, ''), // e.g. name-based vhosts
+        \CRM_Utils_Array::value('SERVER_PORT', $_SERVER, ''), // e.g. port-based vhosts
+        // Depending on deployment arch, these signals *could* be redundant, but who cares?
+      )));
+    }
+    return Civi::$statics[__CLASS__]['id'];
+  }
+
+
 }

--- a/CRM/Core/Config/Runtime.php
+++ b/CRM/Core/Config/Runtime.php
@@ -67,25 +67,6 @@ class CRM_Core_Config_Runtime {
 
   public $userHookClass;
 
-  public $userPermissionClass;
-
-  /**
-   * Manager for temporary permissions.
-   * @todo move to container
-   *
-   * @var CRM_Core_Permission_Temp
-   */
-  public $userPermissionTemp;
-
-  /**
-   * The connector module for the CMS/UF
-   * @todo Introduce an interface.
-   * @todo move to container
-   *
-   * @var CRM_Utils_System_Base
-   */
-  public $userSystem;
-
   /**
    * Are we generating clean url's and using mod_rewrite
    * @var string
@@ -131,55 +112,18 @@ class CRM_Core_Config_Runtime {
     if (!defined('CIVICRM_UF')) {
       $this->fatal('You need to define CIVICRM_UF in civicrm.settings.php');
     }
-    $this->setUserFramework(CIVICRM_UF);
 
-    $this->templateDir = array(dirname(dirname(dirname(__DIR__))) . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR);
+    $this->userFramework = CIVICRM_UF;
+    $this->userFrameworkClass = 'CRM_Utils_System_' . CIVICRM_UF;
+    $this->userHookClass = 'CRM_Utils_Hook_' . CIVICRM_UF;
 
-    if (CRM_Utils_System::isSSL()) {
-      $this->userSystem->mapConfigToSSL();
-    }
-
-    if (isset($this->customPHPPathDir) && $this->customPHPPathDir) {
-      set_include_path($this->customPHPPathDir . PATH_SEPARATOR . get_include_path());
-    }
-
-    $this->initialized = 1;
-  }
-
-  public function setUserFramework($userFramework) {
-    $this->userFramework = $userFramework;
-    $this->userFrameworkClass = 'CRM_Utils_System_' . $userFramework;
-    $this->userHookClass = 'CRM_Utils_Hook_' . $userFramework;
-    $userPermissionClass = 'CRM_Core_Permission_' . $userFramework;
-    $this->userPermissionClass = new $userPermissionClass();
-
-    $class = $this->userFrameworkClass;
-    $this->userSystem = new $class();
-
-    if ($userFramework == 'Joomla') {
+    if (CIVICRM_UF == 'Joomla') {
       $this->userFrameworkURLVar = 'task';
-    }
-
-    if (defined('CIVICRM_UF_BASEURL')) {
-      $this->userFrameworkBaseURL = CRM_Utils_File::addTrailingSlash(CIVICRM_UF_BASEURL, '/');
-
-      //format url for language negotiation, CRM-7803
-      $this->userFrameworkBaseURL = CRM_Utils_System::languageNegotiationURL($this->userFrameworkBaseURL);
-
-      if (CRM_Utils_System::isSSL()) {
-        $this->userFrameworkBaseURL = str_replace('http://', 'https://', $this->userFrameworkBaseURL);
-      }
-
-      $base = parse_url($this->userFrameworkBaseURL);
-      $this->useFrameworkRelativeBase = $base['path'];
-      //$this->useFrameworkRelativeBase = empty($base['path']) ? '/' : $base['path'];
     }
 
     if (defined('CIVICRM_UF_DSN')) {
       $this->userFrameworkDSN = CIVICRM_UF_DSN;
     }
-
-    $this->userFrameworkVersion = $this->userSystem->getVersion();
 
     // this is dynamically figured out in the civicrm.settings.php file
     if (defined('CIVICRM_CLEANURL')) {
@@ -188,6 +132,14 @@ class CRM_Core_Config_Runtime {
     else {
       $this->cleanURL = 0;
     }
+
+    $this->templateDir = array(dirname(dirname(dirname(__DIR__))) . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR);
+
+    if (isset($this->customPHPPathDir) && $this->customPHPPathDir) {
+      set_include_path($this->customPHPPathDir . PATH_SEPARATOR . get_include_path());
+    }
+
+    $this->initialized = 1;
   }
 
   private function fatal($message) {
@@ -217,6 +169,5 @@ class CRM_Core_Config_Runtime {
     }
     return Civi::$statics[__CLASS__]['id'];
   }
-
 
 }

--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -170,6 +170,9 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    * @param object $pearError PEAR_Error
    */
   public static function handle($pearError) {
+    if (defined('CIVICRM_TEST')) {
+      return self::simpleHandler($pearError);
+    }
 
     // setup smarty with config, session and template location.
     $template = CRM_Core_Smarty::singleton();

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -2854,7 +2854,7 @@ WHERE  civicrm_mailing_job.id = %1
 
       // check if we are using global locks
       foreach ($lockArray as $lockID) {
-        $cronLock = Civi::service('lockManager')->acquire("worker.mailing.send.{$lockID}");
+        $cronLock = Civi::lockManager()->acquire("worker.mailing.send.{$lockID}");
         if ($cronLock->isAcquired()) {
           $gotCronLock = TRUE;
           break;

--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -136,7 +136,7 @@ class CRM_Mailing_BAO_MailingJob extends CRM_Mailing_DAO_MailingJob {
 
     while ($job->fetch()) {
       // still use job level lock for each child job
-      $lock = Civi::service('lockManager')->acquire("data.mailing.job.{$job->id}");
+      $lock = Civi::lockManager()->acquire("data.mailing.job.{$job->id}");
       if (!$lock->isAcquired()) {
         continue;
       }
@@ -341,7 +341,7 @@ class CRM_Mailing_BAO_MailingJob extends CRM_Mailing_DAO_MailingJob {
     // X Number of child jobs
     while ($job->fetch()) {
       // still use job level lock for each child job
-      $lock = Civi::service('lockManager')->acquire("data.mailing.job.{$job->id}");
+      $lock = Civi::lockManager()->acquire("data.mailing.job.{$job->id}");
       if (!$lock->isAcquired()) {
         continue;
       }

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -50,6 +50,12 @@ abstract class CRM_Utils_System_Base {
    */
   var $supports_form_extensions = FALSE;
 
+  public function initialize() {
+    if (\CRM_Utils_System::isSSL()) {
+      $this->mapConfigToSSL();
+    }
+  }
+
   /**
    * Append an additional breadcrumb tag to the existing breadcrumb.
    *
@@ -282,6 +288,33 @@ abstract class CRM_Utils_System_Base {
    */
   public function getDefaultBlockLocation() {
     return 'left';
+  }
+
+  public function getAbsoluteBaseURL() {
+    if (!defined('CIVICRM_UF_BASEURL')) {
+      return FALSE;
+    }
+
+    $url = CRM_Utils_File::addTrailingSlash(CIVICRM_UF_BASEURL, '/');
+
+    //format url for language negotiation, CRM-7803
+    $url = $this->languageNegotiationURL($url);
+
+    if (CRM_Utils_System::isSSL()) {
+      $url = str_replace('http://', 'https://', $url);
+    }
+
+    return $url;
+  }
+
+  public function getRelativeBaseURL() {
+    $absoluteBaseURL = $this->getAbsoluteBaseURL();
+    if ($absoluteBaseURL === FALSE) {
+      return FALSE;
+    }
+    $parts = parse_url($absoluteBaseURL);
+    return $parts['path'];
+    //$this->useFrameworkRelativeBase = empty($base['path']) ? '/' : $base['path'];
   }
 
   /**

--- a/Civi.php
+++ b/Civi.php
@@ -74,11 +74,7 @@ class Civi {
    * @return \Civi\Core\Paths
    */
   public static function paths() {
-    // Paths must be available before container can boot.
-    if (!isset(Civi::$statics[__CLASS__]['paths'])) {
-      Civi::$statics[__CLASS__]['paths'] = new \Civi\Core\Paths();
-    }
-    return Civi::$statics[__CLASS__]['paths'];
+    return \Civi\Core\Container::getBootService('paths');
   }
 
   /**

--- a/Civi.php
+++ b/Civi.php
@@ -94,8 +94,7 @@ class Civi {
    */
   public static function reset() {
     self::$statics = array();
-    Civi\Core\Container::getBootServices();
-    Civi\Core\Container::singleton(TRUE);
+    Civi\Core\Container::singleton();
   }
 
   /**

--- a/Civi.php
+++ b/Civi.php
@@ -55,6 +55,13 @@ class Civi {
   }
 
   /**
+   * @return \Civi\Core\Lock\LockManager
+   */
+  public static function lockManager() {
+    return \Civi\Core\Container::getBootService('lockManager');
+  }
+
+  /**
    * @return \Psr\Log\LoggerInterface
    */
   public static function log() {
@@ -90,8 +97,9 @@ class Civi {
    * singletons, containers.
    */
   public static function reset() {
-    Civi\Core\Container::singleton(TRUE);
     self::$statics = array();
+    Civi\Core\Container::getBootServices();
+    Civi\Core\Container::singleton(TRUE);
   }
 
   /**
@@ -109,7 +117,7 @@ class Civi {
    * @return \Civi\Core\SettingsBag
    */
   public static function settings($domainID = NULL) {
-    return Civi\Core\Container::singleton()->get('settings_manager')->getBagByDomain($domainID);
+    return \Civi\Core\Container::getBootService('settings_manager')->getBagByDomain($domainID);
   }
 
 }

--- a/api/v3/Job.php
+++ b/api/v3/Job.php
@@ -178,7 +178,7 @@ function civicrm_api3_job_send_reminder($params) {
   // in that case (ie. makes it non-configurable via the UI). Another approach would be to set a default of 0
   // in the _spec function - but since that is a deprecated value it seems more contentious than this approach
   $params['rowCount'] = 0;
-  $lock = Civi::service('lockManager')->acquire('worker.core.ActionSchedule');
+  $lock = Civi::lockManager()->acquire('worker.core.ActionSchedule');
   if (!$lock->isAcquired()) {
     return civicrm_api3_create_error('Could not acquire lock, another ActionSchedule process is running');
   }
@@ -354,7 +354,7 @@ function civicrm_api3_job_process_sms($params) {
  * @return array
  */
 function civicrm_api3_job_fetch_bounces($params) {
-  $lock = Civi::service('lockManager')->acquire('worker.mailing.EmailProcessor');
+  $lock = Civi::lockManager()->acquire('worker.mailing.EmailProcessor');
   if (!$lock->isAcquired()) {
     return civicrm_api3_create_error('Could not acquire lock, another EmailProcessor process is running');
   }
@@ -377,7 +377,7 @@ function civicrm_api3_job_fetch_bounces($params) {
  * @return array
  */
 function civicrm_api3_job_fetch_activities($params) {
-  $lock = Civi::service('lockManager')->acquire('worker.mailing.EmailProcessor');
+  $lock = Civi::lockManager()->acquire('worker.mailing.EmailProcessor');
   if (!$lock->isAcquired()) {
     return civicrm_api3_create_error('Could not acquire lock, another EmailProcessor process is running');
   }
@@ -430,7 +430,7 @@ function civicrm_api3_job_process_participant($params) {
  *   true if success, else false
  */
 function civicrm_api3_job_process_membership($params) {
-  $lock = Civi::service('lockManager')->acquire('worker.member.UpdateMembership');
+  $lock = Civi::lockManager()->acquire('worker.member.UpdateMembership');
   if (!$lock->isAcquired()) {
     return civicrm_api3_create_error('Could not acquire lock, another Membership Processing process is running');
   }
@@ -627,7 +627,7 @@ function civicrm_api3_job_disable_expired_relationships($params) {
  * @throws \API_Exception
  */
 function civicrm_api3_job_group_rebuild($params) {
-  $lock = Civi::service('lockManager')->acquire('worker.core.GroupRebuild');
+  $lock = Civi::lockManager()->acquire('worker.core.GroupRebuild');
   if (!$lock->isAcquired()) {
     throw new API_Exception('Could not acquire lock, another EmailProcessor process is running');
   }

--- a/bin/ContributionProcessor.php
+++ b/bin/ContributionProcessor.php
@@ -697,7 +697,7 @@ CRM_Utils_System::authenticateScript(TRUE);
 //log the execution of script
 CRM_Core_Error::debug_log_message('ContributionProcessor.php');
 
-$lock = Civi::service('lockManager')->acquire('worker.contribute.CiviContributeProcessor');
+$lock = Civi::lockManager()->acquire('worker.contribute.CiviContributeProcessor');
 
 if ($lock->isAcquired()) {
   // try to unset any time limits

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -410,7 +410,6 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
     $config = CRM_Core_Config::singleton(TRUE, TRUE); // ugh, performance
 
     // when running unit tests, use mockup user framework
-    $config->setUserFramework('UnitTests');
     $this->hookClass = CRM_Utils_Hook::singleton(TRUE);
 
     // Make sure the DB connection is setup properly


### PR DESCRIPTION
Prior to this revision, `$runtime` included a mix of config data and
object-construction.  This moves most pre-container object-construction to
Container::boot().

---
- [CRM-16373: Setting improvements](https://issues.civicrm.org/jira/browse/CRM-16373)
