### PR TITLE
CRM-17237: Add Dedupe Rule allows user to save invalid (empty) RESERV…

### DIFF
--- a/CRM/Contact/Form/DedupeRules.php
+++ b/CRM/Contact/Form/DedupeRules.php
@@ -153,10 +153,6 @@ class CRM_Contact_Form_DedupeRules extends CRM_Admin_Form {
    */
   public static function formRule($fields, $files, $self) {
     $errors = array();
-    if (!empty($fields['is_reserved'])) {
-      return TRUE;
-    }
-
     $fieldSelected = FALSE;
     for ($count = 0; $count < self::RULES_COUNT; $count++) {
       if (!empty($fields["where_$count"])) {

--- a/CRM/Contact/Form/DedupeRules.php
+++ b/CRM/Contact/Form/DedupeRules.php
@@ -155,7 +155,7 @@ class CRM_Contact_Form_DedupeRules extends CRM_Admin_Form {
     $errors = array();
     $fieldSelected = FALSE;
     for ($count = 0; $count < self::RULES_COUNT; $count++) {
-        if (!empty($fields["where_$count"]) || ($self->_defaults['is_reserved'] && !empty($self->_defaults["where_$count"]))) {
+      if (!empty($fields["where_$count"]) || ($self->_defaults['is_reserved'] && !empty($self->_defaults["where_$count"]))) {
         $fieldSelected = TRUE;
         break;
       }
@@ -228,7 +228,7 @@ UPDATE civicrm_dedupe_rule_group
     }
 
     // lets skip updating of fields for reserved dedupe group
-    if ($this->_defaults['is_reserved']) {
+    if (isset($this->_defaults['is_reserved'])) {
       CRM_Core_Session::setStatus(ts("The rule '%1' has been saved.", array(1 => $rgDao->title)), ts('Saved'), 'success');
       return;
     }

--- a/CRM/Contact/Form/DedupeRules.php
+++ b/CRM/Contact/Form/DedupeRules.php
@@ -155,7 +155,7 @@ class CRM_Contact_Form_DedupeRules extends CRM_Admin_Form {
     $errors = array();
     $fieldSelected = FALSE;
     for ($count = 0; $count < self::RULES_COUNT; $count++) {
-      if (!empty($fields["where_$count"]) || ($self->_defaults['is_reserved'] && !empty($self->_defaults["where_$count"]))) {
+      if (!empty($fields["where_$count"]) || (isset($self->_defaults['is_reserved']) && !empty($self->_defaults["where_$count"]))) {
         $fieldSelected = TRUE;
         break;
       }

--- a/CRM/Contact/Form/DedupeRules.php
+++ b/CRM/Contact/Form/DedupeRules.php
@@ -155,7 +155,7 @@ class CRM_Contact_Form_DedupeRules extends CRM_Admin_Form {
     $errors = array();
     $fieldSelected = FALSE;
     for ($count = 0; $count < self::RULES_COUNT; $count++) {
-      if (!empty($fields["where_$count"])) {
+        if (!empty($fields["where_$count"]) || ($self->_defaults['is_reserved'] && !empty($self->_defaults["where_$count"]))) {
         $fieldSelected = TRUE;
         break;
       }
@@ -228,7 +228,7 @@ UPDATE civicrm_dedupe_rule_group
     }
 
     // lets skip updating of fields for reserved dedupe group
-    if ($rgDao->is_reserved) {
+    if ($this->_defaults['is_reserved']) {
       CRM_Core_Session::setStatus(ts("The rule '%1' has been saved.", array(1 => $rgDao->title)), ts('Saved'), 'success');
       return;
     }


### PR DESCRIPTION
…ED rule

---
- CRM-17237: Add Dedupe Rule allows user to save invalid (empty) RESERVED rule
  https://issues.civicrm.org/jira/browse/CRM-17237
