### PR TITLE
CRM-17255 group.api ACLS : do not exclude hidden groups for ACL users

### DIFF
--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -302,12 +302,17 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
    *
    * @param int $id
    *   The id of the object.
+   * @param bool $excludeHidden
+   *   Should hidden groups be excluded.
+   *   Logically this is the wrong place to filter hidden groups out as that is
+   *   not a permission issue. However, as other functions may rely on that defaulting to
+   *   FALSE for now & only the api call is calling with true.
    *
-   * @return string
-   *   the permission that the user has (or NULL)
+   * @return array
+   *   The permission that the user has (or NULL)
    */
-  public static function checkPermission($id) {
-    $allGroups = CRM_Core_PseudoConstant::allGroup();
+  public static function checkPermission($id, $excludeHidden = FALSE) {
+    $allGroups = CRM_Core_PseudoConstant::allGroup(NULL, $excludeHidden);
 
     $permissions = NULL;
     if (CRM_Core_Permission::check('edit all contacts') ||

--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -933,14 +933,14 @@ WHERE  id = %1";
    * @return array
    *   array reference of all groups.
    */
-  public static function &allGroup($groupType = NULL, $excludeHidden = TRUE) {
+  public static function allGroup($groupType = NULL, $excludeHidden = TRUE) {
     $condition = CRM_Contact_BAO_Group::groupTypeCondition($groupType, $excludeHidden);
 
     if (!self::$group) {
       self::$group = array();
     }
 
-    $groupKey = $groupType ? $groupType : 'null';
+    $groupKey = ($groupType ? $groupType : 'null') . !empty($excludeHidden);
 
     if (!isset(self::$group[$groupKey])) {
       self::$group[$groupKey] = NULL;


### PR DESCRIPTION
This commit prevents hidden groups from being filtered out of api results by the check
permission function. The api permission check is fairly new so this only hones the check

---
- [CRM-17255: ACLd users do not see saved search group when sending a civimail from a saved search](https://issues.civicrm.org/jira/browse/CRM-17255)
