### PR TITLE
Duplicate notes on import

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -584,7 +584,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
                   $this->_retCode = CRM_Import_Parser::NO_MATCH;
                 }
                 else {
-                  $newContact     = $this->createContact($formatted, $contactFields, $onDuplicate, $contactId, FALSE, $this->_dedupeRuleGroupID);
                   $updateflag     = FALSE;
                   $this->_retCode = CRM_Import_Parser::VALID;
                 }


### PR DESCRIPTION
Fix duplicate notes. Inspired by the 4.6 "CRM-16008 Fix-Import contacts: notes are imported twice"

---
- [CRM-16008: Import contacts: notes are imported twice ](https://issues.civicrm.org/jira/browse/CRM-16008)
