### PR TITLE
CRM-17264 Profile: Duplicate User Notice Text Is Confusing 

### DIFF
--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -150,7 +150,7 @@ class CRM_Utils_System_Drupal extends CRM_Utils_System_DrupalBase {
         )->fetchField();
         if ((bool) $uid) {
           $resetUrl = $config->userFrameworkBaseURL . 'user/password';
-          $errors[$emailName] = ts('The email address %1 is already registered. <a href="%2">Have you forgotten your password?</a>',
+          $errors[$emailName] = ts('The email address %1 already has an account associated with it. <a href="%2">Have you forgotten your password?</a>',
             array(1 => $params['mail'], 2 => $resetUrl)
           );
         }

--- a/CRM/Utils/System/Drupal6.php
+++ b/CRM/Utils/System/Drupal6.php
@@ -194,7 +194,7 @@ class CRM_Utils_System_Drupal6 extends CRM_Utils_System_DrupalBase {
           );
         }
         else {
-          $errors[$emailName] = ts('This email %1 is already registered. Please select another email.',
+          $errors[$emailName] = ts('This email %1 already has an account associated with it. Please select another email.',
             array(1 => $email)
           );
         }

--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -155,7 +155,7 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
       }
       if (strtolower($dbEmail) == strtolower($email)) {
         $resetUrl = str_replace('administrator/', '', $config->userFrameworkBaseURL) . 'index.php?option=com_users&view=reset';
-        $errors[$emailName] = ts('The email address %1 is already registered. <a href="%2">Have you forgotten your password?</a>',
+        $errors[$emailName] = ts('The email address %1 ialready has an account associated with it. <a href="%2">Have you forgotten your password?</a>',
           array(1 => $email, 2 => $resetUrl)
         );
       }

--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -155,7 +155,7 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
       }
       if (strtolower($dbEmail) == strtolower($email)) {
         $resetUrl = str_replace('administrator/', '', $config->userFrameworkBaseURL) . 'index.php?option=com_users&view=reset';
-        $errors[$emailName] = ts('The email address %1 ialready has an account associated with it. <a href="%2">Have you forgotten your password?</a>',
+        $errors[$emailName] = ts('The email address %1 already has an account associated with it. <a href="%2">Have you forgotten your password?</a>',
           array(1 => $email, 2 => $resetUrl)
         );
       }

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -508,7 +508,7 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
       }
       elseif (email_exists($params['mail'])) {
         $resetUrl = $config->userFrameworkBaseURL . 'wp-login.php?action=lostpassword';
-        $errors[$emailName] = ts('The email address %1 is already registered. <a href="%2">Have you forgotten your password?</a>',
+        $errors[$emailName] = ts('The email address %1 already has an account associated with it. <a href="%2">Have you forgotten your password?</a>',
           array(1 => $params['mail'], 2 => $resetUrl)
         );
       }


### PR DESCRIPTION
Fixing text to make it more clear that the user has an account but is not registered for an event

---
- [CRM-17264: Profile: Duplicate User Notice Text Is Confusing](https://issues.civicrm.org/jira/browse/CRM-17264)
