### PR TITLE
CRM-17275 Importing contact with external ID match null

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -527,6 +527,27 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
       if ($cid = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $params['external_identifier'], 'id', 'external_identifier')) {
         $formatted['id'] = $cid;
       }
+      else {
+        // CRM-17275 - External identifier is treated as a special field/
+        // Having it set will inhibit various efforts to retrieve a duplicate
+        // However, it is valid to update a contact with no external identifier to having
+        // an external identifier if they match according to the dedupe rules so
+        // we check for that possibility here.
+        // There is probably a better approach but this fix is the FIRST (!#!) time
+        /// unit tests have been added to this & we need to build those up a bit before
+        // doing much else in here. Remember when you have build a house of card the
+        // golden rule ... walk away ... carefully.
+        // (did I mention unit tests...)
+        $checkParams = array('check_permissions' => FALSE, 'match' => $params);
+        unset($checkParams['match']['external_identifier']);
+        $checkParams['match']['contact_type'] = $this->_contactType;
+        $possibleMatches = civicrm_api3('Contact', 'duplicatecheck', $checkParams);
+        foreach (array_keys($possibleMatches['values']) as $possibleID) {
+          if (!CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $possibleID, 'external_identifier', 'id')) {
+            $formatted['id'] = $cid = $possibleID;
+          }
+        }
+      }
     }
 
     //format common data, CRM-4062

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -551,7 +551,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
           foreach ($matchedIDs as $contactId) {
             if ($params['id'] == $contactId) {
               $contactType = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $params['id'], 'contact_type');
-
               if ($formatted['contact_type'] == $contactType) {
                 //validation of subtype for update mode
                 //CRM-5125
@@ -1631,7 +1630,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
    */
   public function createContact(&$formatted, &$contactFields, $onDuplicate, $contactId = NULL, $requiredCheck = TRUE, $dedupeRuleGroupID = NULL) {
     $dupeCheck = FALSE;
-
     $newContact = NULL;
 
     if (is_null($contactId) && ($onDuplicate != CRM_Import_Parser::DUPLICATE_NOCHECK)) {
@@ -2001,7 +1999,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
       }
     }
 
-    if (($customFieldID = CRM_Core_BAO_CustomField::getKeyID($key)) && array_key_exists($customFieldID, $customFields) &&
+    if (!empty($key) && ($customFieldID = CRM_Core_BAO_CustomField::getKeyID($key)) && array_key_exists($customFieldID, $customFields) &&
       !array_key_exists($customFieldID, $addressCustomFields)
     ) {
       // @todo calling api functions directly is not supported

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -182,9 +182,15 @@ abstract class CRM_Import_Parser {
    * @var int
    */
   public $_contactType;
+  /**
+   * Contact sub-type
+   *
+   * @var int
+   */
+  public $_contactSubType;
 
   /**
-   * Class constructor
+   * Class constructor.
    */
   public function __construct() {
     $this->_maxLinesToProcess = 0;

--- a/CRM/Utils/DeprecatedUtils.php
+++ b/CRM/Utils/DeprecatedUtils.php
@@ -1428,6 +1428,10 @@ function _civicrm_api3_deprecated_contact_check_params(
   }
 
   if ($dupeCheck) {
+    // @todo switch to using api version by uncommenting these lines & removing following 11.
+    // Any change here is too scary for a stable release.
+    // $dupes = civicrm_api3('Contact', 'duplicatecheck', (array('match' => $params, 'dedupe_rule_id' => $dedupeRuleGroupID)));
+    // $ids = $dupes['count'] ? implode(',', array_keys($dupes['values'])) : NULL;
     // check for record already existing
     require_once 'CRM/Dedupe/Finder.php';
     $dedupeParams = CRM_Dedupe_Finder::formatParams($params, $params['contact_type']);

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -131,4 +131,5 @@ class CRM_Contact_Imports_Parser_ContactTest extends CiviUnitTestCase {
     $parser->init();
     $this->assertEquals($expectedResult, $parser->import($onDuplicateAction, $values));
   }
+
 }

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -1,0 +1,112 @@
+<?php
+/*
++--------------------------------------------------------------------+
+| CiviCRM version 4.6                                                |
++--------------------------------------------------------------------+
+| Copyright CiviCRM LLC (c) 2004-2015                                |
++--------------------------------------------------------------------+
+| This file is a part of CiviCRM.                                    |
+|                                                                    |
+| CiviCRM is free software; you can copy, modify, and distribute it  |
+| under the terms of the GNU Affero General Public License           |
+| Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+|                                                                    |
+| CiviCRM is distributed in the hope that it will be useful, but     |
+| WITHOUT ANY WARRANTY; without even the implied warranty of         |
+| MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+| See the GNU Affero General Public License for more details.        |
+|                                                                    |
+| You should have received a copy of the GNU Affero General Public   |
+| License and the CiviCRM Licensing Exception along                  |
+| with this program; if not, contact CiviCRM LLC                     |
+| at info[AT]civicrm[DOT]org. If you have questions about the        |
+| GNU Affero General Public License or the licensing of CiviCRM,     |
+| see the CiviCRM license FAQ at http://civicrm.org/licensing        |
++--------------------------------------------------------------------+
+ */
+
+/**
+ * @file
+ * File for the CRM_Contact_Imports_Parser_ContactTest class.
+ */
+
+require_once 'CiviTest/CiviUnitTestCase.php';
+
+/**
+ *  Test contact import parser.
+ *
+ * @package CiviCRM
+ */
+class CRM_Contact_Imports_Parser_ContactTest extends CiviUnitTestCase {
+  protected $_tablesToTruncate = array();
+
+  /**
+   * Setup function.
+   */
+  public function setUp() {
+    parent::setUp();
+  }
+
+  /**
+   * Test that the import parser will do an update when external identifier is set.
+   *
+   * @throws \Exception
+   */
+  public function testImportParserWithUpdateWithoutExternalIdentifier() {
+    $originalValues = array(
+      'first_name' => 'Bill',
+      'last_name' => 'Gates',
+      'email' => 'bill.gates@microsoft.com',
+      'nick_name' => 'Billy-boy',
+    );
+    $this->runImport($originalValues, CRM_Import_Parser::DUPLICATE_UPDATE, CRM_Import_Parser::VALID);
+    $result = $this->callAPISuccessGetSingle('Contact', $originalValues);
+    $originalValues['nick_name'] = 'Old Bill';
+    $this->runImport($originalValues, CRM_Import_Parser::DUPLICATE_UPDATE, CRM_Import_Parser::VALID);
+    $originalValues['id'] = $result['id'];
+    $this->assertEquals('Old Bill', $this->callAPISuccessGetValue('Contact', array('id' => $result['id'], 'return' => 'nick_name')));
+    $this->callAPISuccessGetSingle('Contact', $originalValues);
+  }
+
+  /**
+   * Test that the import parser will do an update when external identifier is set.
+   *
+   * @throws \Exception
+   */
+  public function testImportParserWithUpdateWithExternalIdentifier() {
+    $originalValues = array(
+      'first_name' => 'Bill',
+      'last_name' => 'Gates',
+      'email' => 'bill.gates@microsoft.com',
+      'external_identifier' => 'windows',
+      'nick_name' => 'Billy-boy',
+    );
+    $this->runImport($originalValues, CRM_Import_Parser::DUPLICATE_UPDATE, CRM_Import_Parser::VALID);
+    $result = $this->callAPISuccessGetSingle('Contact', $originalValues);
+    $this->assertEquals($result['id'], CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', 'windows', 'id', 'external_identifier', TRUE));
+    $this->assertEquals('windows', $result['external_identifier']);
+    $originalValues['nick_name'] = 'Old Bill';
+    $this->runImport($originalValues, CRM_Import_Parser::DUPLICATE_UPDATE, CRM_Import_Parser::VALID);
+    $originalValues['id'] = $result['id'];
+    $this->assertEquals('Old Bill', $this->callAPISuccessGetValue('Contact', array('id' => $result['id'], 'return' => 'nick_name')));
+    $this->callAPISuccessGetSingle('Contact', $originalValues);
+  }
+
+  /**
+   * Run the import parser.
+   *
+   * @param array $originalValues
+   *
+   * @param int $onDuplicateAction
+   * @param int $expectedResult
+   */
+  protected function runImport($originalValues, $onDuplicateAction, $expectedResult) {
+    $fields = array_keys($originalValues);
+    $values = array_values($originalValues);
+    $parser = new CRM_Contact_Import_Parser_Contact($fields);
+    $parser->_contactType = 'Individual';
+    $parser->_onDuplicate = $onDuplicateAction;
+    $parser->init();
+    $this->assertEquals($expectedResult, $parser->import($onDuplicateAction, $values));
+  }
+}

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -93,6 +93,28 @@ class CRM_Contact_Imports_Parser_ContactTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test that the import parser updates when a new external identifier is set.
+   *
+   * @throws \Exception
+   */
+  public function testImportParserWithUpdateWithNewExternalIdentifier() {
+    $originalValues = array(
+      'first_name' => 'Bill',
+      'last_name' => 'Gates',
+      'email' => 'bill.gates@microsoft.com',
+      'nick_name' => 'Billy-boy',
+    );
+    $this->runImport($originalValues, CRM_Import_Parser::DUPLICATE_UPDATE, CRM_Import_Parser::VALID);
+    $result = $this->callAPISuccessGetSingle('Contact', $originalValues);
+    $originalValues['nick_name'] = 'Old Bill';
+    $originalValues['external_identifier'] = 'windows';
+    $this->runImport($originalValues, CRM_Import_Parser::DUPLICATE_UPDATE, CRM_Import_Parser::VALID);
+    $originalValues['id'] = $result['id'];
+    $this->assertEquals('Old Bill', $this->callAPISuccessGetValue('Contact', array('id' => $result['id'], 'return' => 'nick_name')));
+    $this->callAPISuccessGetSingle('Contact', $originalValues);
+  }
+
+  /**
    * Run the import parser.
    *
    * @param array $originalValues

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -2352,4 +2352,35 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     }
   }
 
+  /**
+   * Test the duplicate check function.
+   */
+  public function testDuplicateCheck() {
+    $this->callAPISuccess('Contact', 'create', array(
+      'first_name' => 'Harry',
+      'last_name' => 'Potter',
+      'email' => 'harry@hogwarts.edu',
+      'contact_type' => 'Individual',
+    ));
+    $result = $this->callAPISuccess('Contact', 'duplicatecheck', array(
+      'match' => array(
+        'first_name' => 'Harry',
+        'last_name' => 'Potter',
+        'email' => 'harry@hogwarts.edu',
+        'contact_type' => 'Individual',
+      ),
+    ));
+
+    $this->assertEquals(1, $result['count']);
+    $result = $this->callAPISuccess('Contact', 'duplicatecheck', array(
+      'match' => array(
+        'first_name' => 'Harry',
+        'last_name' => 'Potter',
+        'email' => 'no5@privet.drive',
+        'contact_type' => 'Individual',
+      ),
+    ));
+    $this->assertEquals(0, $result['count']);
+  }
+
 }


### PR DESCRIPTION
Allow a dedupe to continue when the import has an external ID & matches a contact without one.

---
- [CRM-17275: Import skips silently if the import has an external identifier and the existing contact does not](https://issues.civicrm.org/jira/browse/CRM-17275)
