### PR TITLE
CRM-17293 align payment processor interface between 4.6 & 4.7

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -102,6 +102,18 @@ abstract class CRM_Core_Payment {
   }
 
   /**
+   * Opportunity for the payment processor to override the entire form build.
+   *
+   * @param CRM_Core_Form $form
+   *
+   * @return bool
+   *   Should form building stop at this point?
+   */
+  public function buildForm(&$form) {
+    return FALSE;
+  }
+
+  /**
    * Log payment notification message to forensic system log.
    *
    * @todo move to factory class \Civi\Payment\System (or similar)

--- a/CRM/Core/Payment/Form.php
+++ b/CRM/Core/Payment/Form.php
@@ -297,8 +297,7 @@ class CRM_Core_Payment_Form {
 
     // $processor->buildForm appears to be an undocumented (possibly unused) option for payment processors
     // which was previously available only in some form flows
-    if (!empty($form->_paymentProcessor) && !empty($form->_paymentProcessor['object']) && $form->_paymentProcessor['object']->isSupported('buildForm')) {
-      $form->_paymentProcessor['object']->buildForm($form);
+    if (!empty($form->_paymentProcessor) && !empty($form->_paymentProcessor['object']) && $form->_paymentProcessor['object']->buildForm($form)) {
       return NULL;
     }
 


### PR DESCRIPTION
- [CRM-17293: Align 4.6 behaviour with 4.7 for Payment processor buildForm method](https://issues.civicrm.org/jira/browse/CRM-17293)
