### PR TITLE
CRM-4287 - Trialing the concept of eliminating is_primary filter on e…

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2537,11 +2537,11 @@ class CRM_Contact_BAO_Query {
           continue;
 
         case 'civicrm_phone':
-          $from .= " $side JOIN civicrm_phone ON (contact_a.id = civicrm_phone.contact_id AND civicrm_phone.is_primary = 1) ";
+          $from .= " $side JOIN civicrm_phone ON (contact_a.id = civicrm_phone.contact_id) ";
           continue;
 
         case 'civicrm_email':
-          $from .= " $side JOIN civicrm_email ON (contact_a.id = civicrm_email.contact_id AND civicrm_email.is_primary = 1) ";
+          $from .= " $side JOIN civicrm_email ON (contact_a.id = civicrm_email.contact_id) ";
           continue;
 
         case 'civicrm_im':

--- a/api/v3/Contact.php
+++ b/api/v3/Contact.php
@@ -849,7 +849,7 @@ function civicrm_api3_contact_getquick($params) {
     $exactWhereClause = " WHERE ( sort_name LIKE '$name' $exactIncludeNickName ) {$where} ";
     if ($config->includeEmailInName) {
       if (!in_array('email', $list)) {
-        $includeEmailFrom = "LEFT JOIN civicrm_email eml ON ( cc.id = eml.contact_id AND eml.is_primary = 1 )";
+        $includeEmailFrom = "LEFT JOIN civicrm_email eml ON ( cc.id = eml.contact_id )";
       }
       $emailWhere = " WHERE email LIKE '$strSearch'";
     }

--- a/api/v3/Contact.php
+++ b/api/v3/Contact.php
@@ -716,7 +716,7 @@ function civicrm_api3_contact_getquick($params) {
         if ($value == 'phone') {
           $actualSelectElements[] = $select[] = 'phone_ext';
         }
-        $from[$value] = "LEFT JOIN civicrm_{$value} {$suffix} ON ( cc.id = {$suffix}.contact_id ) ";
+        $from[$value] = "LEFT JOIN civicrm_{$value} {$suffix} ON ( cc.id = {$suffix}.contact_id AND {$suffix}.is_primary = 1 ) ";
         break;
 
       case 'country':
@@ -849,7 +849,7 @@ function civicrm_api3_contact_getquick($params) {
     $exactWhereClause = " WHERE ( sort_name LIKE '$name' $exactIncludeNickName ) {$where} ";
     if ($config->includeEmailInName) {
       if (!in_array('email', $list)) {
-        $includeEmailFrom = "LEFT JOIN civicrm_email eml ON ( cc.id = eml.contact_id )";
+        $includeEmailFrom = "LEFT JOIN civicrm_email eml ON ( cc.id = eml.contact_id AND eml.is_primary = 1 )";
       }
       $emailWhere = " WHERE email LIKE '$strSearch'";
     }

--- a/api/v3/Contact.php
+++ b/api/v3/Contact.php
@@ -716,7 +716,7 @@ function civicrm_api3_contact_getquick($params) {
         if ($value == 'phone') {
           $actualSelectElements[] = $select[] = 'phone_ext';
         }
-        $from[$value] = "LEFT JOIN civicrm_{$value} {$suffix} ON ( cc.id = {$suffix}.contact_id AND {$suffix}.is_primary = 1 ) ";
+        $from[$value] = "LEFT JOIN civicrm_{$value} {$suffix} ON ( cc.id = {$suffix}.contact_id ) ";
         break;
 
       case 'country':


### PR DESCRIPTION
…mail for Basic and Advanced Search.

---
- CRM-4287: Contact search for email address fails to show non-primary email matches as results
  https://issues.civicrm.org/jira/browse/CRM-4287
