### PR TITLE
enable Single Value Alter test for email

### DIFF
--- a/CRM/Core/BAO/Email.php
+++ b/CRM/Core/BAO/Email.php
@@ -72,10 +72,11 @@ class CRM_Core_BAO_Email extends CRM_Core_DAO_Email {
 
     $email = new CRM_Core_DAO_Email();
     $email->copyValues($params);
-
-    // lower case email field to optimize queries
-    $strtolower = function_exists('mb_strtolower') ? 'mb_strtolower' : 'strtolower';
-    $email->email = $strtolower($email->email);
+    if (!empty($email->email)) {
+      // lower case email field to optimize queries
+      $strtolower = function_exists('mb_strtolower') ? 'mb_strtolower' : 'strtolower';
+      $email->email = $strtolower($email->email);
+    }
 
     /*
      * since we're setting bulkmail for 1 of this contact's emails, first reset all their other emails to is_bulkmail false
@@ -83,7 +84,7 @@ class CRM_Core_BAO_Email extends CRM_Core_DAO_Email {
      *  are about to reset it to avoid contaminating the changelog if logging is enabled
      * (only 1 email address can have is_bulkmail = true)
      */
-    if ($email->is_bulkmail != 'null' && $params['contact_id'] && !self::isMultipleBulkMail()) {
+    if ($email->is_bulkmail != 'null' && !empty($params['contact_id']) && !self::isMultipleBulkMail()) {
       $sql = "
 UPDATE civicrm_email
 SET    is_bulkmail = 0

--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -449,7 +449,6 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
       'MailingEventResubscribe',
       'UFGroup',
       'Activity',
-      'Email',
       'Event',
       'GroupContact',
       'MembershipPayment',
@@ -565,6 +564,12 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
         'cant_update' => array(
           // can't be changed through api
           'pcp_id',
+        ),
+      ),
+      'Email' => array(
+        'cant_update' => array(
+          // This is being legitimately manipulated to always have a valid primary - skip.
+          'is_primary',
         ),
       ),
       'Pledge' => array(
@@ -1182,6 +1187,9 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
           }
           else {
             $entity[$fieldName] = substr('New String', 0, CRM_Utils_Array::Value('maxlength', $specs, 100));
+            if ($fieldName == 'email') {
+              $entity[$fieldName] = strtolower($entity[$fieldName]);
+            }
             // typecast with array to satisfy changes made in CRM-13160
             if ($entityName == 'MembershipType' && in_array($fieldName, array(
                 'relationship_type_id',


### PR DESCRIPTION
@colemanw  so I looked at one of the single value alter tests & it turned out that the reason it had to be skipped earlier was we were deleting emails on update unless email was provided in the update. But if you want to see something really scary - look at the reason UFJoin is failing...
