### PR TITLE
CRM-17225 allow report to be viewed without expensive queries

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -2269,6 +2269,31 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
   }
 
   /**
+   * Add actions menu to results form.
+   *
+   * @param $tasks
+   */
+  public function addTaskMenu($tasks) {
+    if (is_array($tasks) && !empty($tasks)) {
+      $tasks = array('' => ts('Actions')) + $tasks;
+      $this->add('select', 'task', NULL, $tasks, FALSE, array('class' => 'crm-select2 crm-action-menu huge crm-search-result-actions'));
+      if (empty($this->_actionButtonName)) {
+        $this->_actionButtonName = $this->getButtonName('next', 'action');
+      }
+      $this->assign('actionButtonName', $this->_actionButtonName);
+      $this->add('submit', $this->_actionButtonName, ts('Go'), array('class' => 'hiddenElement crm-search-go-button'));
+
+      // Radio to choose "All items" or "Selected items only"
+      $selectedRowsRadio = $this->addElement('radio', 'radio_ts', NULL, '', 'ts_sel', array('checked' => 'checked'));
+      $allRowsRadio = $this->addElement('radio', 'radio_ts', NULL, '', 'ts_all');
+      $this->assign('ts_sel_id', $selectedRowsRadio->_attributes['id']);
+      $this->assign('ts_all_id', $allRowsRadio->_attributes['id']);
+
+      CRM_Core_Resources::singleton()->addScriptFile('civicrm', 'js/crm.searchForm.js', 1, 'html-header');
+    }
+  }
+
+  /**
    * Set options and attributes for chain select fields based on the controlling field's value
    */
   private function preProcessChainSelectFields() {

--- a/CRM/Report/BAO/ReportInstance.php
+++ b/CRM/Report/BAO/ReportInstance.php
@@ -160,6 +160,9 @@ class CRM_Report_BAO_ReportInstance extends CRM_Report_DAO_ReportInstance {
       unset($params['parent_id']);
       unset($params['is_navigation']);
     }
+    $viewMode = $params['view_mode'];
+    // Do not save to the DB - it's saved in the url.
+    unset($params['view_mode']);
 
     $viewMode = !empty($params['view_mode']) ? $params['view_mode'] : FALSE;
     if ($viewMode) {

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -597,9 +597,6 @@ class CRM_Report_Form extends CRM_Core_Form {
 
     $this->_instanceButtonName = $this->getButtonName('submit', 'save');
     $this->_createNewButtonName = $this->getButtonName('submit', 'next');
-    $this->_printButtonName = $this->getButtonName('submit', 'print');
-    $this->_pdfButtonName = $this->getButtonName('submit', 'pdf');
-    $this->_csvButtonName = $this->getButtonName('submit', 'csv');
     $this->_groupButtonName = $this->getButtonName('submit', 'group');
     $this->_chartButtonName = $this->getButtonName('submit', 'chart');
   }
@@ -1425,30 +1422,17 @@ class CRM_Report_Form extends CRM_Core_Form {
    */
   public function buildInstanceAndButtons() {
     CRM_Report_Form_Instance::buildForm($this);
-
-    $label = $this->_id ? ts('Update Report') : ts('Create Report');
-
-    $this->addElement('submit', $this->_instanceButtonName, $label);
-    $this->addElement('submit', $this->_printButtonName, ts('Print Report'));
-    $this->addElement('submit', $this->_pdfButtonName, ts('PDF'));
+    $this->_actionButtonName = $this->getButtonName('submit');
+    $this->addTaskMenu($this->getActions($this->_id));
 
     if ($this->_id) {
       $this->addElement('submit', $this->_createNewButtonName,
         ts('Save a Copy') . '...');
     }
+    $this->addElement('submit', $this->_instanceButtonName,
+      ts('Save') . '...');
+
     $this->assign('instanceForm', $this->_instanceForm);
-
-    $label = $this->_id ? ts('Print Report') : ts('Print Preview');
-    $this->addElement('submit', $this->_printButtonName, $label);
-
-    $label = $this->_id ? ts('PDF') : ts('Preview PDF');
-    $this->addElement('submit', $this->_pdfButtonName, $label);
-
-    $label = $this->_id ? ts('Export to CSV') : ts('Preview CSV');
-
-    if ($this->_csvSupported) {
-      $this->addElement('submit', $this->_csvButtonName, $label);
-    }
 
     // CRM-16274 Determine if user has 'edit all contacts' or equivalent
     $permission = CRM_Core_Permission::getPermission();
@@ -1466,14 +1450,72 @@ class CRM_Report_Form extends CRM_Core_Form {
     $this->addElement('submit', $this->_groupButtonName, '', array('style' => 'display: none;'));
 
     $this->addChartOptions();
+    $showResultsLabel = $this->getResultsLabel();
     $this->addButtons(array(
         array(
           'type' => 'submit',
-          'name' => ts('Preview Report'),
+          'name' => $showResultsLabel,
           'isDefault' => TRUE,
         ),
       )
     );
+  }
+
+  /**
+   * Has this form been submitted already?
+   *
+   * @return bool
+   */
+  public function resultsDisplayed() {
+    $buttonName = $this->controller->getButtonName();
+    return ($buttonName || $this->_outputMode);
+  }
+
+  /**
+   * Get the actions for this report instance.
+   *
+   * @param int $instanceId
+   *
+   * @return array
+   */
+  protected function getActions($instanceId) {
+    $actions = array(
+      'html' => $this->getResultsLabel(),
+      'save' => 'Update',
+      'copy' => 'Save a Copy',
+      'print' => 'Print Report',
+      'pdf' => 'Print to PDF',
+    );
+    if (empty($instanceId)) {
+      $actions['save'] = ts('Create Report');
+    }
+
+    if ($this->_outputMode || $this->_id) {
+      $actions['html'] = 'Refresh Results';
+    }
+
+    if ($this->_csvSupported) {
+      $actions['csv'] = 'Export as CSV';
+    }
+
+    if (!empty($this->_charts)) {
+      $this->assign('charts', $this->_charts);
+      if ($this->_format != '') {
+        $actions['tabular'] = 'View as tabular data';
+      }
+      if ($this->_format != 'pieChart') {
+        $actions['pieChart'] = 'View as pie chart';
+      }
+      if ($this->_format != 'barChart') {
+        $actions['barChart'] = 'View as bar graph';
+      }
+    }
+
+    if (CRM_Core_Permission::check('administer Reports')) {
+      $actions['delete'] = 'Delete report';
+    }
+
+    return $actions;
   }
 
   /**
@@ -2619,6 +2661,7 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
   public function processReportMode() {
     $this->setOutputMode();
 
+    $buttonName = $this->controller->getButtonName();
     $this->_sendmail
       = CRM_Utils_Request::retrieve(
         'sendmail',
@@ -2652,15 +2695,19 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
       $this->_absoluteUrl = TRUE;
       $this->addPaging = FALSE;
     }
-    elseif ($this->_outputMode == 'group') {
+    elseif ($this->_groupButtonName == $buttonName || $this->_outputMode == 'group') {
       $this->assign('outputMode', 'group');
     }
     elseif ($this->_outputMode == 'create_report' && $this->_criteriaForm) {
       $this->assign('outputMode', 'create_report');
     }
+    elseif (!empty($this->_outputMode) && !empty($this->_charts[$this->_outputMode])) {
+      $this->_params['charts'] = $this->_outputMode;
+    }
     elseif ($this->_outputMode == 'copy' && $this->_criteriaForm) {
       $this->_createNew = TRUE;
     }
+    $this->assign('outputMode', $this->_outputMode);
 
     $this->assign('outputMode', $this->_outputMode);
     $this->assign('printOnly', $printOnly);
@@ -4581,8 +4628,7 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
     if (empty($financialTypes)) {
       $contFTs = "0";
       $liFTs = implode(',', array_keys(CRM_Contribute_Pseudoconstant::financialType()));
-    }
-    else {
+    } else {
       $contFTs = $liFTs = implode(',', array_keys($financialTypes));
     }
     if ($alias) {
@@ -4647,25 +4693,8 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
       CRM_Utils_Array::value('task', $this->_params)
     );
 
-    if ($buttonName) {
-      if ($buttonName == $this->_instanceButtonName) {
-        $this->_outputMode = 'save';
-      }
-      if ($buttonName == $this->_printButtonName) {
-        $this->_outputMode = 'print';
-      }
-      if ($buttonName == $this->_pdfButtonName) {
-        $this->_outputMode = 'pdf';
-      }
-      if ($this->_csvButtonName == $buttonName) {
-        $this->_outputMode = 'csv';
-      }
-      if ($this->_groupButtonName == $buttonName) {
-        $this->_outputMode = 'group';
-      }
-      if ($buttonName == $this->_createNewButtonName) {
-        $this->_outputMode = 'copy';
-      }
+    if ($buttonName && $buttonName == $this->_instanceButtonName) {
+      $this->_outputMode = 'save';
     }
   }
 

--- a/CRM/Report/Form/Contribute/Detail.php
+++ b/CRM/Report/Form/Contribute/Detail.php
@@ -707,7 +707,6 @@ UNION ALL
 
     // assign variables to templates
     $this->doTemplateAssignment($rows);
-
     // do print / pdf / instance stuff if needed
     $this->endPostProcess($rows);
   }

--- a/templates/CRM/Report/Form.tpl
+++ b/templates/CRM/Report/Form.tpl
@@ -23,8 +23,6 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-{if $outputMode neq 'print'}
-{/if}
 {* this div is being used to apply special css *}
 {if $section eq 1}
   <div class="crm-block crm-content-block crm-report-layoutGraph-form-block">

--- a/templates/CRM/Report/Form/Actions.tpl
+++ b/templates/CRM/Report/Form/Actions.tpl
@@ -27,9 +27,6 @@
 
   {* build the print pdf buttons *}
     <div class="crm-tasks">
-      {assign var=print value="_qf_"|cat:$form.formName|cat:"_submit_print"}
-      {assign var=pdf   value="_qf_"|cat:$form.formName|cat:"_submit_pdf"}
-      {assign var=csv   value="_qf_"|cat:$form.formName|cat:"_submit_csv"}
       {assign var=group value="_qf_"|cat:$form.formName|cat:"_submit_group"}
       {assign var=chart value="_qf_"|cat:$form.formName|cat:"_submit_chart"}
       <table style="border:0;">
@@ -37,9 +34,7 @@
           <td>
             <table class="form-layout-compressed">
               <tr>
-                <td>{$form.$print.html}&nbsp;&nbsp;</td>
-                <td>{$form.$pdf.html}&nbsp;&nbsp;</td>
-                <td>{$form.$csv.html}&nbsp;&nbsp;</td>
+                {include file="CRM/common/tasks.tpl" location="botton"}
                 {if $instanceUrl}
                   <td>&nbsp;&nbsp;&raquo;&nbsp;<a href="{$instanceUrl}">{ts}Existing report(s) from this template{/ts}</a></td>
                 {/if}

--- a/templates/CRM/common/tasks.tpl
+++ b/templates/CRM/common/tasks.tpl
@@ -1,0 +1,4 @@
+<span id='task-section'>
+  {$form.task.html}
+  {$form.$actionButtonName.html} &nbsp; &nbsp;
+</span>


### PR DESCRIPTION
Also includes changes to buttons

@colemanw  this is still WIP but I think it's at a state where it is helpful to look at. Pulling https://github.com/civicrm/civicrm-core/pull/6837 before doing any reports work & resetting the menu helps....

I've put the charts buttons back as they were - still kind of in 2 minds about it all.

---
- [CRM-17225: Reports treat 'reset' like force'](https://issues.civicrm.org/jira/browse/CRM-17225)
