### PR TITLE
CRM-17109 Simple modification to the Custom.tpl template to use jQuery DatePicker for all *_date fields.

### DIFF
--- a/templates/CRM/Contact/Form/Search/Custom.tpl
+++ b/templates/CRM/Contact/Form/Search/Custom.tpl
@@ -38,10 +38,8 @@
             {foreach from=$elements item=element}
                 <tr class="crm-contact-custom-search-form-row-{$element}">
                     <td class="label">{$form.$element.label}</td>
-                    {if $element eq 'start_date'}
-                        <td>{include file="CRM/common/jcalendar.tpl" elementName=start_date}</td>
-                    {elseif $element eq 'end_date'}
-                        <td>{include file="CRM/common/jcalendar.tpl" elementName=end_date}</td>
+                    {if $element|strstr:'_date'}
+                        <td>{include file="CRM/common/jcalendar.tpl" elementName=$element}</td>
                     {else}
                         <td>{$form.$element.html}</td>
                     {/if}


### PR DESCRIPTION
- [CRM-17109: Use jQuery DatePicker for all "*_date" fields in custom search](https://issues.civicrm.org/jira/browse/CRM-17109)
