### PR TITLE
CRM-17306 fix location update action

### DIFF
--- a/CRM/Core/BAO/LocationType.php
+++ b/CRM/Core/BAO/LocationType.php
@@ -123,15 +123,15 @@ class CRM_Core_BAO_LocationType extends CRM_Core_DAO_LocationType {
    * @return object
    */
   public static function create(&$params) {
-    $params['is_active'] = CRM_Utils_Array::value('is_active', $params, FALSE);
-    $params['is_default'] = CRM_Utils_Array::value('is_default', $params, FALSE);
-    $params['is_reserved'] = CRM_Utils_Array::value('is_reserved', $params, FALSE);
+    if (empty($params['id'])) {
+      $params['is_active'] = CRM_Utils_Array::value('is_active', $params, FALSE);
+      $params['is_default'] = CRM_Utils_Array::value('is_default', $params, FALSE);
+      $params['is_reserved'] = CRM_Utils_Array::value('is_reserved', $params, FALSE);
+    }
 
-    // action is taken depending upon the mode
     $locationType = new CRM_Core_DAO_LocationType();
     $locationType->copyValues($params);
-
-    if ($params['is_default']) {
+    if (!empty($params['is_default'])) {
       $query = "UPDATE civicrm_location_type SET is_default = 0";
       CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
     }

--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -101,7 +101,6 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
       'OptionGroup',
       'MailingRecipients',
       'UFMatch',
-      'LocationType',
       'CustomSearch',
       'Extension',
       'ReportTemplate',
@@ -118,7 +117,6 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
       'UFJoin',
       'UFMatch',
       'Extension',
-      'LocationType',
       'System',
     );
     $this->onlyIDNonZeroCount['get'] = array(
@@ -563,6 +561,15 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
         'cant_update' => array(
           // can't be changed through api
           'pcp_id',
+        ),
+      ),
+      'LocationType' => array(
+        'cant_update' => array(
+          // I'm on the fence about whether the test should skip or the behaviour is wrong.
+          // display_name is set to match name if display_name is not provided. It would be more 'normal'
+          // to only calculate a default IF id is not set - but perhaps the current behaviour is kind
+          // of what someone updating the name expects..
+          'name',
         ),
       ),
       'Pledge' => array(


### PR DESCRIPTION
Conflicts:
    tests/phpunit/api/v3/SyntaxConformanceTest.php

 Please enter the commit message for your changes. Lines starting

---
- [CRM-17306: Updating Location Type sets is_default to 0](https://issues.civicrm.org/jira/browse/CRM-17306)
