### PR TITLE
Comment fixes for CRM/Mailing/ and CRM/Report/Page directories.

### DIFF
--- a/CRM/Mailing/BAO/BouncePattern.php
+++ b/CRM/Mailing/BAO/BouncePattern.php
@@ -29,13 +29,11 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 class CRM_Mailing_BAO_BouncePattern extends CRM_Mailing_DAO_BouncePattern {
 
   /**
-   * Pseudo-constant pattern array
+   * Pseudo-constant pattern array.
    */
   static $_patterns = NULL;
 
@@ -48,8 +46,6 @@ class CRM_Mailing_BAO_BouncePattern extends CRM_Mailing_DAO_BouncePattern {
 
   /**
    * Build the static pattern array.
-   *
-   * @return void
    */
   public static function buildPatterns() {
     self::$_patterns = array();

--- a/CRM/Mailing/BAO/Component.php
+++ b/CRM/Mailing/BAO/Component.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 class CRM_Mailing_BAO_Component extends CRM_Mailing_DAO_Component {
 
@@ -49,7 +47,7 @@ class CRM_Mailing_BAO_Component extends CRM_Mailing_DAO_Component {
    * @param array $defaults
    *   (reference ) an assoc array to hold the flattened values.
    *
-   * @return CRM_Core_BAO_LocaationType
+   * @return CRM_Core_BAO_LocationType.
    */
   public static function retrieve(&$params, &$defaults) {
     $component = new CRM_Mailing_DAO_Component();
@@ -85,7 +83,6 @@ class CRM_Mailing_BAO_Component extends CRM_Mailing_DAO_Component {
    *   (deprecated) the array that holds all the db ids.
    *
    * @return CRM_Mailing_BAO_Component
-   *
    */
   public static function add(&$params, $ids = array()) {
     $id = CRM_Utils_Array::value('id', $params, CRM_Utils_Array::value('id', $ids));

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 require_once 'Mail/mime.php';
 
@@ -42,54 +40,54 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing {
   /**
    * An array that holds the complete templates
    * including any headers or footers that need to be prepended
-   * or appended to the body
+   * or appended to the body.
    */
   private $preparedTemplates = NULL;
 
   /**
    * An array that holds the complete templates
    * including any headers or footers that need to be prepended
-   * or appended to the body
+   * or appended to the body.
    */
   private $templates = NULL;
 
   /**
-   * An array that holds the tokens that are specifically found in our text and html bodies
+   * An array that holds the tokens that are specifically found in our text and html bodies.
    */
   private $tokens = NULL;
 
   /**
-   * An array that holds the tokens that are specifically found in our text and html bodies
+   * An array that holds the tokens that are specifically found in our text and html bodies.
    */
   private $flattenedTokens = NULL;
 
   /**
-   * The header associated with this mailing
+   * The header associated with this mailing.
    */
   private $header = NULL;
 
   /**
-   * The footer associated with this mailing
+   * The footer associated with this mailing.
    */
   private $footer = NULL;
 
   /**
-   * The HTML content of the message
+   * The HTML content of the message.
    */
   private $html = NULL;
 
   /**
-   * The text content of the message
+   * The text content of the message.
    */
   private $text = NULL;
 
   /**
-   * Cached BAO for the domain
+   * Cached BAO for the domain.
    */
   private $_domain = NULL;
 
   /**
-   * Class constructor
+   * Class constructor.
    */
   public function __construct() {
     parent::__construct();
@@ -105,14 +103,14 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing {
    */
   public static function getRecipientsCount($job_id, $mailing_id = NULL) {
     // need this for backward compatibility, so we can get count for old mailings
-    // please do not use this function if possible
+    // please do not use this function if possible.
     $eq = self::getRecipients($job_id, $mailing_id);
     return $eq->N;
   }
 
   /**
    * note that $job_id is used only as a variable in the temp table construction
-   * and does not play a role in the queries generated
+   * and does not play a role in the queries generated.
    * @param int $job_id
    *   (misnomer) a nonce value used to name temporary tables.
    * @param int $mailing_id
@@ -192,15 +190,15 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing {
         $order_by = "ORDER BY $email.is_bulkmail";
     }
 
-    /* Create a temp table for contact exclusion */
+    // Create a temp table for contact exclusion.
     $mailingGroup->query(
       "CREATE TEMPORARY TABLE X_$job_id
             (contact_id int primary key)
             ENGINE=HEAP"
     );
 
-    /* Add all the members of groups excluded from this mailing to the temp
-     * table */
+    // Add all the members of groups excluded from this mailing to the temp
+    // table.
 
     $excludeSubGroup = "INSERT INTO        X_$job_id (contact_id)
                     SELECT  DISTINCT    $g2contact.contact_id
@@ -213,8 +211,8 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing {
                         AND             $mg.group_type = 'Exclude'";
     $mailingGroup->query($excludeSubGroup);
 
-    /* Add all unsubscribe members of base group from this mailing to the temp
-     * table */
+    // Add all unsubscribe members of base group from this mailing to the temp
+    // table.
 
     $unSubscribeBaseGroup = "INSERT INTO        X_$job_id (contact_id)
                     SELECT  DISTINCT    $g2contact.contact_id
@@ -227,8 +225,8 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing {
                         AND             $mg.group_type = 'Base'";
     $mailingGroup->query($unSubscribeBaseGroup);
 
-    /* Add all the (intended) recipients of an excluded prior mailing to
-     * the temp table */
+    // Add all the (intended) recipients of an excluded prior mailing to
+    // the temp table.
 
     $excludeSubMailing = "INSERT IGNORE INTO X_$job_id (contact_id)
                     SELECT  DISTINCT    $eq.contact_id
@@ -276,7 +274,7 @@ WHERE  c.group_id = {$groupDAO->id}
       $tempColumn = 'phone_id';
     }
 
-    /* Get all the group contacts we want to include */
+    // Get all the group contacts we want to include.
 
     $mailingGroup->query(
       "CREATE TEMPORARY TABLE I_$job_id
@@ -284,8 +282,8 @@ WHERE  c.group_id = {$groupDAO->id}
             ENGINE=HEAP"
     );
 
-    /* Get the group contacts, but only those which are not in the
-     * exclusion temp table */
+    // Get the group contacts, but only those which are not in the
+    // exclusion temp table.
 
     $query = "REPLACE INTO       I_$job_id (email_id, contact_id)
 
@@ -347,7 +345,7 @@ WHERE  c.group_id = {$groupDAO->id}
     }
     $mailingGroup->query($query);
 
-    /* Query prior mailings */
+    // Query prior mailings.
 
     $query = "REPLACE INTO       I_$job_id (email_id, contact_id)
                     SELECT DISTINCT     $email.id as email_id,
@@ -453,9 +451,7 @@ WHERE      gc.group_id = {$groupDAO->id}
       $mailingGroup->query($smartGroupInclude);
     }
 
-    /**
-     * Construct the filtered search queries
-     */
+    // Construct the filtered search queries.
     $query = "
 SELECT search_id, search_args, entity_id
 FROM   $mg
@@ -473,7 +469,7 @@ AND    $mg.mailing_id = {$mailing_id}
       $mailingGroup->query($query);
     }
 
-    /* Get the emails with only location override */
+    // Get the emails with only location override.
 
     $query = "REPLACE INTO       I_$job_id (email_id, contact_id)
                     SELECT DISTINCT     $email.id as local_email_id,
@@ -567,7 +563,7 @@ ORDER BY   i.contact_id, i.{$tempColumn}
       }
     }
 
-    /* Delete the temp table */
+    // Delete the temp table.
 
     $mailingGroup->reset();
     $mailingGroup->query("DROP TEMPORARY TABLE X_$job_id");

--- a/CRM/Mailing/BAO/MailingAB.php
+++ b/CRM/Mailing/BAO/MailingAB.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 
 /**
@@ -117,8 +115,6 @@ class CRM_Mailing_BAO_MailingAB extends CRM_Mailing_DAO_MailingAB {
    *
    * @param int $id
    *   Id of the mail to delete.
-   *
-   * @return void
    */
   public static function del($id) {
     if (empty($id)) {

--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -628,8 +628,8 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
     $params = $targetParams = $deliveredParams = array();
     $count = 0;
 
-     // CRM-15702: Sending bulk sms to contacts without e-mail address fails.
-     // Solution is to skip checking for on hold
+    // CRM-15702: Sending bulk sms to contacts without e-mail address fails.
+    // Solution is to skip checking for on hold
     $skipOnHold = TRUE;    //do include a statement to check wether e-mail address is on hold
     if ($mailing->sms_provider_id) {
       $skipOnHold = FALSE; //do not include a statement to check wether e-mail address is on hold

--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 
 require_once 'Mail.php';
@@ -84,8 +82,6 @@ class CRM_Mailing_BAO_MailingJob extends CRM_Mailing_DAO_MailingJob {
    *
    * @param array $testParams
    * @param null $mode
-   *
-   * @return void
    */
   public static function runJobs($testParams = NULL, $mode = NULL) {
     $job = new CRM_Mailing_BAO_MailingJob();
@@ -198,7 +194,7 @@ class CRM_Mailing_BAO_MailingJob extends CRM_Mailing_DAO_MailingJob {
 
       // Mark the child complete
       if ($isComplete) {
-        /* Finish the job */
+        // Finish the job.
 
         $transaction = new CRM_Core_Transaction();
 
@@ -223,8 +219,8 @@ class CRM_Mailing_BAO_MailingJob extends CRM_Mailing_DAO_MailingJob {
   }
 
   /**
-   * post process to determine if the parent job.
-   * as well as the mailing is complete after the run
+   * Post process to determine if the parent job
+   * as well as the mailing is complete after the run.
    * @param null $mode
    */
   public static function runJobs_post($mode = NULL) {
@@ -478,8 +474,6 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
    *   A Mail object to send the messages.
    *
    * @param array $testParams
-   *
-   * @return void
    */
   public function deliver(&$mailer, $testParams = NULL) {
     $mailing = new CRM_Mailing_BAO_Mailing();
@@ -566,7 +560,7 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
 
     // CRM-12376
     // This handles the edge case scenario where all the mails
-    // have been delivered in prior jobs
+    // have been delivered in prior jobs.
     $isDelivered = TRUE;
 
     // make sure that there's no more than $mailerBatchLimit mails processed in a run
@@ -634,11 +628,9 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
     $params = $targetParams = $deliveredParams = array();
     $count = 0;
 
-    /**
-     * CRM-15702: Sending bulk sms to contacts without e-mail address fails.
-     * Solution is to skip checking for on hold
-     */
-    $skipOnHold = TRUE; //do include a statement to check wether e-mail address is on hold
+     // CRM-15702: Sending bulk sms to contacts without e-mail address fails.
+     // Solution is to skip checking for on hold
+    $skipOnHold = TRUE;    //do include a statement to check wether e-mail address is on hold
     if ($mailing->sms_provider_id) {
       $skipOnHold = FALSE; //do not include a statement to check wether e-mail address is on hold
     }
@@ -663,7 +655,7 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
         $details[0][$contactID] = array();
       }
 
-      /* Compose the mailing */
+      // Compose the mailing.
       $recipient = $replyToEmail = NULL;
       $replyValue = strcmp($mailing->replyto_email, $mailing->from_email);
       if ($replyValue) {
@@ -683,7 +675,7 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
         continue;
       }
 
-      /* Send the mailing */
+      // Send the mailing.
 
       $body = &$message->get();
       $headers = &$message->headers();
@@ -740,7 +732,7 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
           CRM_Utils_System::civiExit();
         }
 
-        /* Register the bounce event */
+        // Register the bounce event.
 
         $params = array(
           'event_queue_id' => $field['id'],
@@ -760,7 +752,7 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
         CRM_Core_Error::debug_log_message($result->getMessage());
       }
       else {
-        /* Register the delivery event */
+        // Register the delivery event.
         $deliveredParams[] = $field['id'];
         $targetParams[] = $field['contact_id'];
 

--- a/CRM/Mailing/BAO/Query.php
+++ b/CRM/Mailing/BAO/Query.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 class CRM_Mailing_BAO_Query {
 
@@ -55,8 +53,6 @@ class CRM_Mailing_BAO_Query {
    * If mailings are involved, add the specific Mailing fields
    *
    * @param $query
-   *
-   * @return void
    */
   public static function select(&$query) {
     // if Mailing mode add mailing id
@@ -399,7 +395,6 @@ class CRM_Mailing_BAO_Query {
    *
    *
    * @param CRM_Core_Form $form
-   * @return void
    */
   public static function buildSearchForm(&$form) {
     // mailing selectors
@@ -468,8 +463,6 @@ class CRM_Mailing_BAO_Query {
    * @param $fieldTitle
    *
    * @param $valueTitles
-   *
-   * @return void
    */
   public static function mailingEventQueryBuilder(&$query, &$values, $tableName, $fieldName, $fieldTitle, &$valueTitles) {
     list($name, $op, $value, $grouping, $wildcard) = $values;

--- a/CRM/Mailing/BAO/Recipients.php
+++ b/CRM/Mailing/BAO/Recipients.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 class CRM_Mailing_BAO_Recipients extends CRM_Mailing_DAO_Recipients {
 

--- a/CRM/Mailing/BAO/Spool.php
+++ b/CRM/Mailing/BAO/Spool.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 class CRM_Mailing_BAO_Spool extends CRM_Mailing_DAO_Spool {
 
@@ -90,7 +88,7 @@ class CRM_Mailing_BAO_Spool extends CRM_Mailing_DAO_Spool {
       }
 
       $job = new CRM_Mailing_BAO_MailingJob();
-      $job->is_test = 0; // if set to 1 it doesn't show in the UI
+      $job->is_test = 0;  // if set to 1 it doesn't show in the UI
       $job->status = 'Complete';
       $job->scheduled_date = CRM_Utils_Date::processDate(date('Y-m-d'), date('H:i:s'));
       $job->start_date = $job->scheduled_date;

--- a/CRM/Mailing/BAO/TrackableURL.php
+++ b/CRM/Mailing/BAO/TrackableURL.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 class CRM_Mailing_BAO_TrackableURL extends CRM_Mailing_DAO_TrackableURL {
 

--- a/CRM/Mailing/Config.php
+++ b/CRM/Mailing/Config.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 class CRM_Mailing_Config {
 

--- a/CRM/Mailing/Controller/Send.php
+++ b/CRM/Mailing/Controller/Send.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 class CRM_Mailing_Controller_Send extends CRM_Core_Controller {
 

--- a/CRM/Mailing/Event/BAO/Bounce.php
+++ b/CRM/Mailing/Event/BAO/Bounce.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 class CRM_Mailing_Event_BAO_Bounce extends CRM_Mailing_Event_DAO_Bounce {
 

--- a/CRM/Mailing/Event/BAO/Confirm.php
+++ b/CRM/Mailing/Event/BAO/Confirm.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 
 require_once 'Mail/mime.php';

--- a/CRM/Mailing/Event/BAO/Delivered.php
+++ b/CRM/Mailing/Event/BAO/Delivered.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 class CRM_Mailing_Event_BAO_Delivered extends CRM_Mailing_Event_DAO_Delivered {
 
@@ -46,8 +44,6 @@ class CRM_Mailing_Event_BAO_Delivered extends CRM_Mailing_Event_DAO_Delivered {
    *
    * @param array $params
    *   Associative array of delivery event values.
-   *
-   * @return void
    */
   public static function &create(&$params) {
     $q = &CRM_Mailing_Event_BAO_Queue::verify($params['job_id'],
@@ -264,7 +260,7 @@ class CRM_Mailing_Event_BAO_Delivered extends CRM_Mailing_Event_DAO_Delivered {
   }
 
   /**
-   * Since we never no when a mailing really bounces (hard bounce == NOW, soft bounce == NOW to NOW + 3 days?)
+   * Since we never know when a mailing really bounces (hard bounce == NOW, soft bounce == NOW to NOW + 3 days?)
    * we cannot decide when an email address last got an email.
    *
    * We want to avoid putting on hold an email address which had a few bounces (mbox full) and then got quite a few
@@ -278,8 +274,6 @@ class CRM_Mailing_Event_BAO_Delivered extends CRM_Mailing_Event_DAO_Delivered {
    *   Consider mailings that were completed at least $minDays ago.
    * @param int $maxDays
    *   Consider mailings that were completed not more than $maxDays ago.
-   *
-   * @return void
    */
   public static function updateEmailResetDate($minDays = 3, $maxDays = 7) {
     $dao = new CRM_Core_Dao();

--- a/CRM/Mailing/Event/BAO/Forward.php
+++ b/CRM/Mailing/Event/BAO/Forward.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 class CRM_Mailing_Event_BAO_Forward extends CRM_Mailing_Event_DAO_Forward {
 
@@ -62,7 +60,7 @@ class CRM_Mailing_Event_BAO_Forward extends CRM_Mailing_Event_DAO_Forward {
       return $successfulForward;
     }
 
-    /* Find the email address/contact, if it exists */
+    // Find the email address/contact, if it exists.
 
     $contact = CRM_Contact_BAO_Contact::getTableName();
     $location = CRM_Core_BAO_Location::getTableName();
@@ -100,8 +98,8 @@ class CRM_Mailing_Event_BAO_Forward extends CRM_Mailing_Event_DAO_Forward {
     if (isset($dao->queue_id) ||
       (isset($dao->do_not_email) && $dao->do_not_email == 1)
     ) {
-      /* We already sent this mailing to $forward_email, or we should
-       * never email this contact.  Give up. */
+      // We already sent this mailing to $forward_email, or we should
+      // never email this contact.  Give up.
 
       return $successfulForward;
     }
@@ -115,7 +113,7 @@ class CRM_Mailing_Event_BAO_Forward extends CRM_Mailing_Event_DAO_Forward {
     $count = $contactValues['count'];
 
     if ($count == 0) {
-      /* If the contact does not exist, create one. */
+      // If the contact does not exist, create one.
 
       $formatted = array(
         'contact_type' => 'Individual',
@@ -144,7 +142,7 @@ class CRM_Mailing_Event_BAO_Forward extends CRM_Mailing_Event_DAO_Forward {
       $contact_id = $email->contact_id;
     }
 
-    /* Create a new queue event */
+    // Create a new queue event.
 
     $queue_params = array(
       'email_id' => $email_id,
@@ -203,7 +201,7 @@ class CRM_Mailing_Event_BAO_Forward extends CRM_Mailing_Event_DAO_Forward {
       'hash' => $queue->hash,
     );
     if (is_a($result, 'PEAR_Error')) {
-      /* Register the bounce event */
+      // Register the bounce event.
 
       $params = array_merge($params,
         CRM_Mailing_BAO_BouncePattern::match($result->getMessage())
@@ -212,7 +210,7 @@ class CRM_Mailing_Event_BAO_Forward extends CRM_Mailing_Event_DAO_Forward {
     }
     else {
       $successfulForward = TRUE;
-      /* Register the delivery event */
+      // Register the delivery event.
 
       CRM_Mailing_Event_BAO_Delivered::create($params);
     }

--- a/CRM/Mailing/Event/BAO/Opened.php
+++ b/CRM/Mailing/Event/BAO/Opened.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 class CRM_Mailing_Event_BAO_Opened extends CRM_Mailing_Event_DAO_Opened {
 
@@ -46,11 +44,9 @@ class CRM_Mailing_Event_BAO_Opened extends CRM_Mailing_Event_DAO_Opened {
    *
    * @param int $queue_id
    *   The Queue Event ID of the recipient.
-   *
-   * @return void
    */
   public static function open($queue_id) {
-    /* First make sure there's a matching queue event */
+    // First make sure there's a matching queue event.
 
     $success = FALSE;
 

--- a/CRM/Mailing/Event/BAO/Queue.php
+++ b/CRM/Mailing/Event/BAO/Queue.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 class CRM_Mailing_Event_BAO_Queue extends CRM_Mailing_Event_DAO_Queue {
 

--- a/CRM/Mailing/Event/BAO/Reply.php
+++ b/CRM/Mailing/Event/BAO/Reply.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 
 require_once 'Mail/mime.php';
@@ -66,7 +64,7 @@ class CRM_Mailing_Event_BAO_Reply extends CRM_Mailing_Event_DAO_Reply {
    *   The mailing object, or null on failure
    */
   public static function &reply($job_id, $queue_id, $hash, $replyto = NULL) {
-    /* First make sure there's a matching queue event */
+    // First make sure there's a matching queue event.
 
     $q = CRM_Mailing_Event_BAO_Queue::verify($job_id, $queue_id, $hash);
 
@@ -117,8 +115,6 @@ class CRM_Mailing_Event_BAO_Reply extends CRM_Mailing_Event_DAO_Reply {
    *   HTML part of the body (ignored if $fullEmail provided).
    * @param string $fullEmail
    *   Whole email to forward in one string.
-   *
-   * @return void
    */
   public static function send($queue_id, &$mailing, &$bodyTxt, $replyto, &$bodyHTML = NULL, &$fullEmail = NULL) {
     $domain = CRM_Core_BAO_Domain::getDomain();
@@ -219,8 +215,6 @@ class CRM_Mailing_Event_BAO_Reply extends CRM_Mailing_Event_DAO_Reply {
    *   The queue ID.
    * @param string $replyto
    *   Optional reply-to from the reply.
-   *
-   * @return void
    */
   private static function autoRespond(&$mailing, $queue_id, $replyto) {
     $config = CRM_Core_Config::singleton();
@@ -263,7 +257,7 @@ class CRM_Mailing_Event_BAO_Reply extends CRM_Mailing_Event_DAO_Reply {
       'Return-Path' => "do-not-reply@$emailDomain",
     );
 
-    /* TODO: do we need reply tokens? */
+    // TODO: do we need reply tokens?
 
     $html = $component->body_html;
     if ($component->body_text) {

--- a/CRM/Mailing/Event/BAO/Resubscribe.php
+++ b/CRM/Mailing/Event/BAO/Resubscribe.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 
 require_once 'Mail/mime.php';
@@ -54,7 +52,7 @@ class CRM_Mailing_Event_BAO_Resubscribe {
    *   $groups    Array of all groups to which the contact was added, or null if the queue event could not be found.
    */
   public static function &resub_to_mailing($job_id, $queue_id, $hash) {
-    /* First make sure there's a matching queue event */
+    // First make sure there's a matching queue event.
 
     $q = CRM_Mailing_Event_BAO_Queue::verify($job_id, $queue_id, $hash);
     $success = NULL;
@@ -81,7 +79,7 @@ class CRM_Mailing_Event_BAO_Resubscribe {
     $group = CRM_Contact_BAO_Group::getTableName();
     $gc = CRM_Contact_BAO_GroupContact::getTableName();
 
-    //We Need the mailing Id for the hook...
+    // We Need the mailing Id for the hook...
     $do->query("SELECT $job.mailing_id as mailing_id
                      FROM   $job
                      WHERE $job.id = " . CRM_Utils_Type::escape($job_id, 'Integer'));
@@ -101,9 +99,8 @@ class CRM_Mailing_Event_BAO_Resubscribe {
                 AND     $group.is_hidden = 0"
     );
 
-    /* Make a list of groups and a list of prior mailings that received
-     * this mailing */
-
+    // Make a list of groups and a list of prior mailings that received
+    // this mailing.
     $groups = array();
     $mailings = array();
 
@@ -116,9 +113,8 @@ class CRM_Mailing_Event_BAO_Resubscribe {
       }
     }
 
-    /* As long as we have prior mailings, find their groups and add to the
-     * list */
-
+    // As long as we have prior mailings, find their groups and add to the
+    // list.
     while (!empty($mailings)) {
       $do->query("
                 SELECT      $mg.entity_table as entity_table,
@@ -143,9 +139,8 @@ class CRM_Mailing_Event_BAO_Resubscribe {
     $base_groups = NULL;
     CRM_Utils_Hook::unsubscribeGroups('resubscribe', $mailing_id, $contact_id, $group_ids, $base_groups);
 
-    /* Now we have a complete list of recipient groups.  Filter out all
-     * those except smart groups and those that the contact belongs to */
-
+    // Now we have a complete list of recipient groups.  Filter out all
+    // those except smart groups and those that the contact belongs to.
     $do->query("
             SELECT      $group.id as group_id,
                         $group.title as title
@@ -197,8 +192,6 @@ class CRM_Mailing_Event_BAO_Resubscribe {
    *   Is this domain-level?.
    * @param int $job
    *   The job ID.
-   *
-   * @return void
    */
   public static function send_resub_response($queue_id, $groups, $is_domain = FALSE, $job) {
     // param is_domain is not supported as of now.

--- a/CRM/Mailing/Event/BAO/Subscribe.php
+++ b/CRM/Mailing/Event/BAO/Subscribe.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 
 
@@ -85,7 +83,7 @@ class CRM_Mailing_Event_BAO_Subscribe extends CRM_Mailing_Event_DAO_Subscribe {
       $contact_id = $contactId;
     }
     else {
-      /* First, find out if the contact already exists */
+      // First, find out if the contact already exists.
 
       $query = "
    SELECT DISTINCT contact_a.id as contact_id
@@ -108,7 +106,7 @@ LEFT JOIN civicrm_email      ON contact_a.id = civicrm_email.contact_id
     if (!$contact_id) {
       require_once 'CRM/Utils/DeprecatedUtils.php';
 
-      /* If the contact does not exist, create one. */
+      // If the contact does not exist, create one.
 
       $formatted = array(
         'contact_type' => 'Individual',
@@ -137,7 +135,7 @@ LEFT JOIN civicrm_email      ON contact_a.id = civicrm_email.contact_id
       return $success;
     }
 
-    /* Get the primary email id from the contact to use as a hash input */
+    // Get the primary email id from the contact to use as a hash input.
 
     $dao = new CRM_Core_DAO();
 
@@ -205,8 +203,6 @@ SELECT     civicrm_email.id as email_id
    *
    * @param string $email
    *   The email address.
-   *
-   * @return void
    */
   public function send_confirm_request($email) {
     $config = CRM_Core_Config::singleton();
@@ -376,8 +372,6 @@ SELECT     civicrm_email.id as email_id
    *   Specifically to avoid linking group to wrong duplicate contact
    *   during event registration.
    * @param string $context
-   *
-   * @return void
    */
   public static function commonSubscribe(&$groups, &$params, $contactId = NULL, $context = NULL) {
     $contactGroups = CRM_Mailing_Event_BAO_Subscribe::getContactGroups($params['email'], $contactId);

--- a/CRM/Mailing/Event/BAO/TrackableURLOpen.php
+++ b/CRM/Mailing/Event/BAO/TrackableURLOpen.php
@@ -56,8 +56,7 @@ class CRM_Mailing_Event_BAO_TrackableURLOpen extends CRM_Mailing_Event_DAO_Track
     $search = new CRM_Mailing_BAO_TrackableURL();
 
     // To find the url, we also join on the queue and job tables.  This
-    // prevents foreign key violations. 
-
+    // prevents foreign key violations.
     $job = CRM_Mailing_BAO_MailingJob::getTableName();
     $eq = CRM_Mailing_Event_BAO_Queue::getTableName();
     $turl = CRM_Mailing_BAO_TrackableURL::getTableName();

--- a/CRM/Mailing/Event/BAO/TrackableURLOpen.php
+++ b/CRM/Mailing/Event/BAO/TrackableURLOpen.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 class CRM_Mailing_Event_BAO_TrackableURLOpen extends CRM_Mailing_Event_DAO_TrackableURLOpen {
 
@@ -57,8 +55,8 @@ class CRM_Mailing_Event_BAO_TrackableURLOpen extends CRM_Mailing_Event_DAO_Track
 
     $search = new CRM_Mailing_BAO_TrackableURL();
 
-    /* To find the url, we also join on the queue and job tables.  This
-     * prevents foreign key violations. */
+    // To find the url, we also join on the queue and job tables.  This
+    // prevents foreign key violations. 
 
     $job = CRM_Mailing_BAO_MailingJob::getTableName();
     $eq = CRM_Mailing_Event_BAO_Queue::getTableName();
@@ -81,7 +79,7 @@ class CRM_Mailing_Event_BAO_TrackableURLOpen extends CRM_Mailing_Event_DAO_Track
     );
 
     if (!$search->fetch()) {
-      /* Whoops, error, don't track it.  Return the base url. */
+      // Whoops, error, don't track it.  Return the base url.
 
       return CRM_Utils_System::baseURL();
     }

--- a/CRM/Mailing/Event/BAO/Unsubscribe.php
+++ b/CRM/Mailing/Event/BAO/Unsubscribe.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 
 require_once 'Mail/mime.php';
@@ -129,7 +127,7 @@ WHERE  email = %2
    *   $groups    Array of all groups from which the contact was removed, or null if the queue event could not be found.
    */
   public static function &unsub_from_mailing($job_id, $queue_id, $hash, $return = FALSE) {
-    /* First make sure there's a matching queue event */
+    // First make sure there's a matching queue event.
 
     $q = CRM_Mailing_Event_BAO_Queue::verify($job_id, $queue_id, $hash);
     $success = NULL;
@@ -173,8 +171,8 @@ WHERE  email = %2
                 AND     $group.is_hidden = 0"
     );
 
-    /* Make a list of groups and a list of prior mailings that received
-     * this mailing */
+    // Make a list of groups and a list of prior mailings that received
+    // this mailing.
 
     $groups = array();
     $base_groups = array();
@@ -194,8 +192,8 @@ WHERE  email = %2
       }
     }
 
-    /* As long as we have prior mailings, find their groups and add to the
-     * list */
+    // As long as we have prior mailings, find their groups and add to the
+    // list.
 
     while (!empty($mailings)) {
       $do->query("
@@ -222,9 +220,9 @@ WHERE  email = %2
     $base_group_ids = array_keys($base_groups);
     CRM_Utils_Hook::unsubscribeGroups('unsubscribe', $mailing_id, $contact_id, $group_ids, $base_group_ids);
 
-    /* Now we have a complete list of recipient groups.  Filter out all
-     * those except smart groups, those that the contact belongs to and
-     * base groups from search based mailings */
+    // Now we have a complete list of recipient groups.  Filter out all
+    // those except smart groups, those that the contact belongs to and
+    // base groups from search based mailings.
 
     $baseGroupClause = '';
     if (!empty($base_group_ids)) {
@@ -303,8 +301,6 @@ WHERE  email = %2
    *   Is this domain-level?.
    * @param int $job
    *   The job ID.
-   *
-   * @return void
    */
   public static function send_unsub_response($queue_id, $groups, $is_domain = FALSE, $job) {
     $config = CRM_Core_Config::singleton();

--- a/CRM/Mailing/Form/Approve.php
+++ b/CRM/Mailing/Form/Approve.php
@@ -29,12 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
- */
-
-/**
- *
  */
 class CRM_Mailing_Form_Approve extends CRM_Core_Form {
 
@@ -45,8 +39,6 @@ class CRM_Mailing_Form_Approve extends CRM_Core_Form {
 
   /**
    * Set variables up before form is built.
-   *
-   * @return void
    */
   public function preProcess() {
     if (CRM_Mailing_Info::workflowEnabled()) {
@@ -81,9 +73,6 @@ class CRM_Mailing_Form_Approve extends CRM_Core_Form {
 
   /**
    * Set default values for the form.
-   *
-   *
-   * @return void
    */
   public function setDefaultValues() {
     $defaults = array();
@@ -96,11 +85,7 @@ class CRM_Mailing_Form_Approve extends CRM_Core_Form {
   }
 
   /**
-   * Build the form object for the approval/rejection mailing
-   *
-   * @param
-   *
-   * @return void
+   * Build the form object for the approval/rejection mailing.
    */
   public function buildQuickform() {
     $title = ts('Approve/Reject Mailing') . " - {$this->_mailing->name}";
@@ -158,10 +143,6 @@ class CRM_Mailing_Form_Approve extends CRM_Core_Form {
 
   /**
    * Process the posted form values.  Approve /reject a mailing.
-   *
-   * @param
-   *
-   * @return void
    */
   public function postProcess() {
     // get the submitted form values.

--- a/CRM/Mailing/Form/Browse.php
+++ b/CRM/Mailing/Form/Browse.php
@@ -29,24 +29,16 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 
 /**
  * Build the form object for disable mail feature
- *
- * @param
- *
- * @return void
  */
 class CRM_Mailing_Form_Browse extends CRM_Core_Form {
 
   /**
    * Heart of the viewing process. The runner gets all the meta data for
    * the contact and calls the appropriate type of page to view.
-   *
-   * @return void
    */
   public function preProcess() {
     $this->_mailingId = CRM_Utils_Request::retrieve('mid', 'Positive', $this);
@@ -68,8 +60,6 @@ class CRM_Mailing_Form_Browse extends CRM_Core_Form {
 
   /**
    * Build the form object.
-   *
-   * @return void
    */
   public function buildQuickForm() {
     $this->addButtons(array(
@@ -86,10 +76,6 @@ class CRM_Mailing_Form_Browse extends CRM_Core_Form {
     );
   }
 
-  /**
-   *
-   * @return void
-   */
   public function postProcess() {
     if ($this->_action & CRM_Core_Action::DELETE) {
       CRM_Mailing_BAO_Mailing::del($this->_mailingId);

--- a/CRM/Mailing/Form/Component.php
+++ b/CRM/Mailing/Form/Component.php
@@ -29,13 +29,10 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 
 /**
- * This class generates form components for Location Type
- *
+ * This class generates form components for Location Type.
  */
 class CRM_Mailing_Form_Component extends CRM_Core_Form {
 
@@ -60,8 +57,6 @@ class CRM_Mailing_Form_Component extends CRM_Core_Form {
 
   /**
    * Build the form object.
-   *
-   * @return void
    */
   public function buildQuickForm() {
     $this->applyFilter('__ALL__', 'trim');
@@ -109,9 +104,6 @@ class CRM_Mailing_Form_Component extends CRM_Core_Form {
 
   /**
    * Set default values for the form.
-   *
-   *
-   * @return void
    */
   public function setDefaultValues() {
     $defaults = array();
@@ -131,9 +123,6 @@ class CRM_Mailing_Form_Component extends CRM_Core_Form {
 
   /**
    * Process the form submission.
-   *
-   *
-   * @return void
    */
   public function postProcess() {
     // store the submitted values in an array

--- a/CRM/Mailing/Form/ForwardMailing.php
+++ b/CRM/Mailing/Form/ForwardMailing.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 class CRM_Mailing_Form_ForwardMailing extends CRM_Core_Form {
   public function preProcess() {
@@ -48,7 +46,7 @@ class CRM_Mailing_Form_ForwardMailing extends CRM_Core_Form {
 
     if ($q == NULL) {
 
-      /** ERROR **/
+      // ERROR.
       CRM_Core_Error::fatal(ts('Invalid form parameters.'));
       CRM_Core_Error::statusBounce(ts('Invalid form parameters.'));
     }
@@ -60,8 +58,8 @@ class CRM_Mailing_Form_ForwardMailing extends CRM_Core_Form {
       $this->assign('fromEmail', $fromEmail);
     }
 
-    /* Show the subject instead of the name here, since it's being
-     * displayed to external contacts/users */
+    // Show the subject instead of the name here, since it's being
+    // displayed to external contacts/users.
 
     CRM_Utils_System::setTitle(ts('Forward Mailing: %1', array(1 => $mailing->subject)));
 
@@ -72,8 +70,6 @@ class CRM_Mailing_Form_ForwardMailing extends CRM_Core_Form {
 
   /**
    * Build the form object.
-   *
-   * @return void
    */
   public function buildQuickForm() {
     for ($i = 0; $i < 5; $i++) {
@@ -103,9 +99,6 @@ class CRM_Mailing_Form_ForwardMailing extends CRM_Core_Form {
 
   /**
    * Form submission of new/edit contact is processed.
-   *
-   *
-   * @return void
    */
   public function postProcess() {
     $queue_id = $this->get('queue_id');

--- a/CRM/Mailing/Form/Optout.php
+++ b/CRM/Mailing/Form/Optout.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 class CRM_Mailing_Form_Optout extends CRM_Core_Form {
 

--- a/CRM/Mailing/Form/Search.php
+++ b/CRM/Mailing/Form/Search.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 class CRM_Mailing_Form_Search extends CRM_Core_Form {
 

--- a/CRM/Mailing/Form/Subscribe.php
+++ b/CRM/Mailing/Form/Subscribe.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 class CRM_Mailing_Form_Subscribe extends CRM_Core_Form {
   protected $_groupID = NULL;
@@ -77,8 +75,6 @@ SELECT   title, description
 
   /**
    * Build the form object.
-   *
-   * @return void
    */
   public function buildQuickForm() {
     // add the email address
@@ -140,9 +136,9 @@ ORDER BY title";
       $addCaptcha = FALSE;
     }
     else {
-      // if this is POST request and came from a block,
-      // lets add recaptcha only if already present
-      // gross hack for now
+      // If this is POST request and came from a block,
+      // lets add recaptcha only if already present.
+      // Gross hack for now.
       if (!empty($_POST) &&
         !array_key_exists('recaptcha_challenge_field', $_POST)
       ) {
@@ -185,10 +181,6 @@ ORDER BY title";
     return array('_qf_default' => 'Please select one or more mailing lists.');
   }
 
-  /**
-   *
-   * @return void
-   */
   public function postProcess() {
     $params = $this->controller->exportValues($this->_name);
 

--- a/CRM/Mailing/Form/Task.php
+++ b/CRM/Mailing/Form/Task.php
@@ -29,13 +29,10 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 
 /**
  * This class generates form components for relationship
- *
  */
 class CRM_Mailing_Form_Task extends CRM_Core_Form {
 
@@ -62,10 +59,6 @@ class CRM_Mailing_Form_Task extends CRM_Core_Form {
 
   /**
    * Build all the data structures needed to build the form.
-   *
-   * @param
-   *
-   * @return void
    */
   public function preProcess() {
     self::preProcessCommon($this);
@@ -113,7 +106,7 @@ class CRM_Mailing_Form_Task extends CRM_Core_Form {
       $form->_componentClause = ' civicrm_mailing_recipients.id IN ( ' . implode(',', $ids) . ' ) ';
     }
 
-    //set the context for redirection for any task actions
+    // set the context for redirection for any task actions
     $session = CRM_Core_Session::singleton();
 
     $fragment = 'search';
@@ -141,9 +134,6 @@ class CRM_Mailing_Form_Task extends CRM_Core_Form {
    * @param string $nextType
    * @param string $backType
    * @param bool $submitOnce
-   *
-   *
-   * @return void
    */
   public function addDefaultButtons($title, $nextType = 'next', $backType = 'back', $submitOnce = FALSE) {
     $this->addButtons(array(

--- a/CRM/Mailing/Form/Task/AdhocMailing.php
+++ b/CRM/Mailing/Form/Task/AdhocMailing.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 
 /**

--- a/CRM/Mailing/Form/Task/Print.php
+++ b/CRM/Mailing/Form/Task/Print.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 
 /**
@@ -40,8 +38,6 @@ class CRM_Mailing_Form_Task_Print extends CRM_Mailing_Form_Task {
 
   /**
    * Build all the data structures needed to build the form.
-   *
-   * @return void
    */
   public function preProcess() {
     parent::preprocess();
@@ -68,10 +64,7 @@ class CRM_Mailing_Form_Task_Print extends CRM_Mailing_Form_Task {
   /**
    * Build the form object - it consists of
    *    - displaying the QILL (query in local language)
-   *    - displaying elements for saving the search
-   *
-   *
-   * @return void
+   *    - displaying elements for saving the search.
    */
   public function buildQuickForm() {
     //
@@ -94,9 +87,6 @@ class CRM_Mailing_Form_Task_Print extends CRM_Mailing_Form_Task {
 
   /**
    * Process the form after the input has been submitted and validated.
-   *
-   *
-   * @return void
    */
   public function postProcess() {
     // redirect to the main search page after printing is over

--- a/CRM/Mailing/Form/Unsubscribe.php
+++ b/CRM/Mailing/Form/Unsubscribe.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 class CRM_Mailing_Form_Unsubscribe extends CRM_Core_Form {
 

--- a/CRM/Mailing/Info.php
+++ b/CRM/Mailing/Info.php
@@ -32,8 +32,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 class CRM_Mailing_Info extends CRM_Core_Component_Info {
 
@@ -58,7 +56,7 @@ class CRM_Mailing_Info extends CRM_Core_Component_Info {
   }
 
   /**
-   * Get AngularJS modules and their dependencies
+   * Get AngularJS modules and their dependencies.
    *
    * @return array
    *   list of modules; same format as CRM_Utils_Hook::angularModules(&$angularModules)
@@ -97,8 +95,8 @@ class CRM_Mailing_Info extends CRM_Core_Component_Info {
     $session = CRM_Core_Session::singleton();
     $contactID = $session->get('userID');
 
-    // Get past mailings
-    // CRM-16155 - Limit to a reasonable number
+    // Get past mailings.
+    // CRM-16155 - Limit to a reasonable number.
     $civiMails = civicrm_api3('Mailing', 'get', array(
       'is_completed' => 1,
       'mailing_type' => array('IN' => array('standalone', 'winner')),
@@ -110,7 +108,7 @@ class CRM_Mailing_Info extends CRM_Core_Component_Info {
         'sort' => 'is_archived asc, scheduled_date desc',
       ),
     ));
-    // Generic params
+    // Generic params.
     $params = array(
       'options' => array('limit' => 0),
       'sequential' => 1,

--- a/CRM/Mailing/MailStore.php
+++ b/CRM/Mailing/MailStore.php
@@ -29,15 +29,13 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 class CRM_Mailing_MailStore {
   // flag to decide whether to print debug messages
   var $_debug = FALSE;
 
   /**
-   * Return the proper mail store implementation, based on config settings
+   * Return the proper mail store implementation, based on config settings.
    *
    * @param string $name
    *   Name of the settings set from civimail_mail_settings to use (null for default).
@@ -94,7 +92,7 @@ class CRM_Mailing_MailStore {
   }
 
   /**
-   * Expunge the messages marked for deletion; stub function to be redefined by IMAP store
+   * Expunge the messages marked for deletion; stub function to be redefined by IMAP store.
    */
   public function expunge() {
   }

--- a/CRM/Mailing/MailStore/Imap.php
+++ b/CRM/Mailing/MailStore/Imap.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 
 require_once 'ezc/Base/src/ezc_bootstrap.php';
@@ -103,8 +101,6 @@ class CRM_Mailing_MailStore_Imap extends CRM_Mailing_MailStore {
    *
    * @param int $nr
    *   Number of the message to move.
-   *
-   * @return void
    */
   public function markIgnored($nr) {
     if ($this->_debug) {
@@ -120,8 +116,6 @@ class CRM_Mailing_MailStore_Imap extends CRM_Mailing_MailStore {
    *
    * @param int $nr
    *   Number of the message to move.
-   *
-   * @return void
    */
   public function markProcessed($nr) {
     if ($this->_debug) {

--- a/CRM/Mailing/MailStore/Localdir.php
+++ b/CRM/Mailing/MailStore/Localdir.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 
 require_once 'ezc/Base/src/ezc_bootstrap.php';
@@ -102,7 +100,7 @@ class CRM_Mailing_MailStore_Localdir extends CRM_Mailing_MailStore {
 
       $set = new ezcMailFileSet(array($file));
       $parser = new ezcMailParser();
-      //set property text attachment as file CRM-5408
+      // set property text attachment as file CRM-5408
       $parser->options->parseTextAttachmentsAsFiles = TRUE;
 
       $mail = $parser->parseMail($set);
@@ -131,7 +129,6 @@ class CRM_Mailing_MailStore_Localdir extends CRM_Mailing_MailStore {
    *   File location of the message to fetch.
    *
    * @throws Exception
-   * @return void
    */
   public function markIgnored($file) {
     if ($this->_debug) {
@@ -150,7 +147,6 @@ class CRM_Mailing_MailStore_Localdir extends CRM_Mailing_MailStore {
    *   File location of the message to fetch.
    *
    * @throws Exception
-   * @return void
    */
   public function markProcessed($file) {
     if ($this->_debug) {

--- a/CRM/Mailing/MailStore/Maildir.php
+++ b/CRM/Mailing/MailStore/Maildir.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 
 require_once 'ezc/Base/src/ezc_bootstrap.php';
@@ -79,7 +77,7 @@ class CRM_Mailing_MailStore_Maildir extends CRM_Mailing_MailStore {
   public function fetchNext($count = 0) {
     $mails = array();
     $parser = new ezcMailParser();
-    //set property text attachment as file CRM-5408
+    // set property text attachment as file CRM-5408
     $parser->options->parseTextAttachmentsAsFiles = TRUE;
 
     foreach (array(
@@ -114,7 +112,6 @@ class CRM_Mailing_MailStore_Maildir extends CRM_Mailing_MailStore {
    *   File location of the message to fetch.
    *
    * @throws Exception
-   * @return void
    */
   public function markIgnored($file) {
     if ($this->_debug) {
@@ -133,7 +130,6 @@ class CRM_Mailing_MailStore_Maildir extends CRM_Mailing_MailStore {
    *   File location of the message to fetch.
    *
    * @throws Exception
-   * @return void
    */
   public function markProcessed($file) {
     if ($this->_debug) {

--- a/CRM/Mailing/MailStore/Mbox.php
+++ b/CRM/Mailing/MailStore/Mbox.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 
 require_once 'ezc/Base/src/ezc_bootstrap.php';
@@ -70,9 +68,7 @@ class CRM_Mailing_MailStore_Mbox extends CRM_Mailing_MailStore {
   }
 
   /**
-   * Empty the mail source (if it was processed fully) and unlock the file
-   *
-   * @return void
+   * Empty the mail source (if it was processed fully) and unlock the file.
    */
   public function __destruct() {
     if ($this->_leftToProcess === 0) {
@@ -90,8 +86,6 @@ class CRM_Mailing_MailStore_Mbox extends CRM_Mailing_MailStore {
    *
    * @param int $nr
    *   Number of the message to fetch.
-   *
-   * @return void
    */
   public function markIgnored($nr) {
     if ($this->_debug) {
@@ -108,8 +102,6 @@ class CRM_Mailing_MailStore_Mbox extends CRM_Mailing_MailStore {
    *
    * @param int $nr
    *   Number of the message to fetch.
-   *
-   * @return void
    */
   public function markProcessed($nr) {
     if ($this->_debug) {

--- a/CRM/Mailing/MailStore/Pop3.php
+++ b/CRM/Mailing/MailStore/Pop3.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 
 require_once 'ezc/Base/src/ezc_bootstrap.php';
@@ -83,8 +81,6 @@ class CRM_Mailing_MailStore_Pop3 extends CRM_Mailing_MailStore {
    *
    * @param int $nr
    *   Number of the message to fetch.
-   *
-   * @return void
    */
   public function markIgnored($nr) {
     if ($this->_debug) {
@@ -101,8 +97,6 @@ class CRM_Mailing_MailStore_Pop3 extends CRM_Mailing_MailStore {
    *
    * @param int $nr
    *   Number of the message to fetch.
-   *
-   * @return void
    */
   public function markProcessed($nr) {
     if ($this->_debug) {

--- a/CRM/Mailing/Page/AJAX.php
+++ b/CRM/Mailing/Page/AJAX.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 
 /**

--- a/CRM/Mailing/Page/Browse.php
+++ b/CRM/Mailing/Page/Browse.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 
 /**
@@ -50,14 +48,14 @@ class CRM_Mailing_Page_Browse extends CRM_Core_Page {
   /**
    * The mailing id of the mailing we're operating on
    *
-   * @int
+   * @var int
    */
   protected $_mailingId;
 
   /**
    * The action that we are performing (in CRM_Core_Action terms)
    *
-   * @int
+   * @var int
    */
   protected $_action;
 
@@ -69,7 +67,7 @@ class CRM_Mailing_Page_Browse extends CRM_Core_Page {
   /**
    * Scheduled mailing.
    *
-   * @boolean
+   * @var boolean
    */
   public $_scheduled;
 
@@ -78,8 +76,6 @@ class CRM_Mailing_Page_Browse extends CRM_Core_Page {
   /**
    * Heart of the viewing process. The runner gets all the meta data for
    * the contact and calls the appropriate type of page to view.
-   *
-   * @return void
    */
   public function preProcess() {
     $this->_unscheduled = $this->_archived = $archiveLinks = FALSE;
@@ -114,8 +110,6 @@ class CRM_Mailing_Page_Browse extends CRM_Core_Page {
 
   /**
    * Run this page (figure out the action needed and perform it).
-   *
-   * @return void
    */
   public function run() {
     $this->preProcess();
@@ -201,9 +195,9 @@ class CRM_Mailing_Page_Browse extends CRM_Core_Page {
       }
     }
     elseif ($this->_action & CRM_Core_Action::RENEW) {
-      //archive this mailing, CRM-3752.
+      // archive this mailing, CRM-3752.
       if (CRM_Utils_Request::retrieve('confirmed', 'Boolean', $this)) {
-        //set is_archived to 1
+        // set is_archived to 1
         CRM_Core_DAO::setFieldValue('CRM_Mailing_DAO_Mailing', $this->_mailingId, 'is_archived', TRUE);
         CRM_Utils_System::redirect($context);
       }
@@ -232,7 +226,7 @@ class CRM_Mailing_Page_Browse extends CRM_Core_Page {
     $controller->setEmbedded(TRUE);
     $controller->run();
 
-    //hack to display results as per search
+    // hack to display results as per search
     $rows = $controller->getRows($controller);
 
     $this->assign('rows', $rows);
@@ -276,8 +270,8 @@ class CRM_Mailing_Page_Browse extends CRM_Core_Page {
     $url = CRM_Utils_System::url($urlString, $urlParams);
     $session->pushUserContext($url);
 
-    //CRM-6862 -run form cotroller after
-    //selector, since it erase $_POST
+    // CRM-6862 -run form cotroller after
+    // selector, since it erase $_POST
     $this->search();
 
     return parent::run();
@@ -312,7 +306,7 @@ class CRM_Mailing_Page_Browse extends CRM_Core_Page {
 
     $clauses = array();
     $title = $this->get('mailing_name');
-    //echo " name=$title  ";
+    // echo " name=$title  ";
     if ($title) {
       $clauses[] = 'name LIKE %1';
       if (strpos($title, '%') !== FALSE) {

--- a/CRM/Mailing/Page/Common.php
+++ b/CRM/Mailing/Page/Common.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 class CRM_Mailing_Page_Common extends CRM_Core_Page {
   protected $_type = NULL;
@@ -121,7 +119,7 @@ class CRM_Mailing_Page_Common extends CRM_Core_Page {
         "reset=1&jid={$job_id}&qid={$queue_id}&h={$hash}&confirm=1"
       );
       $this->assign('confirmURL', $confirmURL);
-      //push context for further process CRM-4431
+      // push context for further process CRM-4431
       $session = CRM_Core_Session::singleton();
       $session->pushUserContext($confirmURL);
     }

--- a/CRM/Mailing/Page/Component.php
+++ b/CRM/Mailing/Page/Component.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 
 /**

--- a/CRM/Mailing/Page/Confirm.php
+++ b/CRM/Mailing/Page/Confirm.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 class CRM_Mailing_Page_Confirm extends CRM_Core_Page {
   /**

--- a/CRM/Mailing/Page/Event.php
+++ b/CRM/Mailing/Page/Event.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 
 /**
@@ -49,8 +47,6 @@ class CRM_Mailing_Page_Event extends CRM_Core_Page {
 
   /**
    * Run this page (figure out the action needed and perform it).
-   *
-   * @return void
    */
   public function run() {
     $selector = &new CRM_Mailing_Selector_Event(
@@ -63,7 +59,7 @@ class CRM_Mailing_Page_Event extends CRM_Core_Page {
 
     $mailing_id = CRM_Utils_Request::retrieve('mid', 'Positive', $this);
 
-    //assign backurl
+    // assign backurl
     $context = CRM_Utils_Request::retrieve('context', 'String', $this);
 
     if ($context == 'activitySelector') {

--- a/CRM/Mailing/Page/Optout.php
+++ b/CRM/Mailing/Page/Optout.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 class CRM_Mailing_Page_Optout extends CRM_Mailing_Page_Common {
   /**

--- a/CRM/Mailing/Page/Preview.php
+++ b/CRM/Mailing/Page/Preview.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 
 /**
@@ -40,8 +38,6 @@ class CRM_Mailing_Page_Preview extends CRM_Core_Page {
 
   /**
    * Run this page (figure out the action needed and perform it).
-   *
-   * @return void
    */
   public function run() {
 
@@ -53,7 +49,7 @@ class CRM_Mailing_Page_Preview extends CRM_Core_Page {
     $options = array();
     $session->getVars($options, "CRM_Mailing_Controller_Send_$qfKey");
 
-    //get the options if control come from search context, CRM-3711
+    // get the options if control come from search context, CRM-3711
     if (empty($options)) {
       $session->getVars($options, "CRM_Contact_Controller_Search_$qfKey");
     }
@@ -76,7 +72,7 @@ class CRM_Mailing_Page_Preview extends CRM_Core_Page {
       $mailing->id
     );
 
-    //get details of contact with token value including Custom Field Token Values.CRM-3734
+    // get details of contact with token value including Custom Field Token Values.CRM-3734
     $returnProperties = $mailing->getReturnProperties();
     $params = array('contact_id' => $session->get('userID'));
 

--- a/CRM/Mailing/Page/Report.php
+++ b/CRM/Mailing/Page/Report.php
@@ -29,13 +29,10 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 
 /**
- * Page to display / edit the header / footer of a mailing
- *
+ * Page to display / edit the header / footer of a mailing.
  */
 class CRM_Mailing_Page_Report extends CRM_Core_Page_Basic {
   public $_mailing_id;
@@ -107,10 +104,10 @@ class CRM_Mailing_Page_Report extends CRM_Core_Page_Basic {
 
     $report = CRM_Mailing_BAO_Mailing::report($this->_mailing_id);
 
-    //get contents of mailing
+    // get contents of mailing
     CRM_Mailing_BAO_Mailing::getMailingContent($report, $this);
 
-    //assign backurl
+    // assign backurl
     $context = CRM_Utils_Request::retrieve('context', 'String', $this);
     $cid = CRM_Utils_Request::retrieve('cid', 'Positive', $this);
 

--- a/CRM/Mailing/Page/Resubscribe.php
+++ b/CRM/Mailing/Page/Resubscribe.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 class CRM_Mailing_Page_Resubscribe extends CRM_Mailing_Page_Common {
   /**

--- a/CRM/Mailing/Page/Tab.php
+++ b/CRM/Mailing/Page/Tab.php
@@ -29,7 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
  */
 
 /**

--- a/CRM/Mailing/Page/Unsubscribe.php
+++ b/CRM/Mailing/Page/Unsubscribe.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 class CRM_Mailing_Page_Unsubscribe extends CRM_Mailing_Page_Common {
 

--- a/CRM/Mailing/Page/View.php
+++ b/CRM/Mailing/Page/View.php
@@ -29,12 +29,10 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 
 /**
- * a page for mailing preview
+ * A page for mailing preview.
  */
 class CRM_Mailing_Page_View extends CRM_Core_Page {
   protected $_mailingID;
@@ -43,9 +41,9 @@ class CRM_Mailing_Page_View extends CRM_Core_Page {
 
   /**
    * Lets do permission checking here.
-   * First check for valid mailing, if false return fatal
-   * Second check for visibility
-   * Call a hook to see if hook wants to override visibility setting
+   * First check for valid mailing, if false return fatal.
+   * Second check for visibility.
+   * Call a hook to see if hook wants to override visibility setting.
    */
   public function checkPermission() {
     if (!$this->_mailing) {
@@ -78,8 +76,6 @@ class CRM_Mailing_Page_View extends CRM_Core_Page {
    * @param int $contactID
    * @param bool $print
    * @param bool $allowID
-   *
-   * @return void
    */
   public function run($id = NULL, $contactID = NULL, $print = TRUE, $allowID = FALSE) {
     if (is_numeric($id)) {
@@ -144,7 +140,7 @@ class CRM_Mailing_Page_View extends CRM_Core_Page {
     // get contact detail and compose if contact id exists
     $returnProperties = $this->_mailing->getReturnProperties();
     if (isset($this->_contactID)) {
-      //get details of contact with token value including Custom Field Token Values.CRM-3734
+      // get details of contact with token value including Custom Field Token Values.CRM-3734
       $params = array('contact_id' => $this->_contactID);
       $details = CRM_Utils_Token::getTokenDetails($params,
         $returnProperties,
@@ -156,7 +152,7 @@ class CRM_Mailing_Page_View extends CRM_Core_Page {
       $contactId = $this->_contactID;
     }
     else {
-      //get tokens that are not contact specific resolved
+      // get tokens that are not contact specific resolved
       $params = array('contact_id' => 0);
       $details = CRM_Utils_Token::getAnonymousTokenDetails($params,
         $returnProperties,

--- a/CRM/Mailing/PseudoConstant.php
+++ b/CRM/Mailing/PseudoConstant.php
@@ -29,13 +29,11 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 
 /**
  * This class holds all the Pseudo constants that are specific to Mass mailing. This avoids
- * polluting the core class and isolates the mass mailer class
+ * polluting the core class and isolates the mass mailer class.
  */
 class CRM_Mailing_PseudoConstant extends CRM_Core_PseudoConstant {
 

--- a/CRM/Mailing/Selector/Browse.php
+++ b/CRM/Mailing/Selector/Browse.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 
 /**
@@ -179,7 +177,7 @@ class CRM_Mailing_Selector_Browse extends CRM_Core_Selector_Base implements CRM_
   /**
    * Returns total number of rows for the query.
    *
-   * @param
+   * @param string $action
    *
    * @return int
    *   Total number of rows
@@ -189,7 +187,7 @@ class CRM_Mailing_Selector_Browse extends CRM_Core_Selector_Base implements CRM_
     $mailing = CRM_Mailing_BAO_Mailing::getTableName();
     $mailingACL = CRM_Mailing_BAO_Mailing::mailingACL();
 
-    //get the where clause.
+    // get the where clause.
     $params = array();
     $whereClause = "$mailingACL AND " . $this->whereClause($params);
 
@@ -283,7 +281,7 @@ LEFT JOIN  civicrm_contact scheduledContact ON ( $mailing.scheduled_id = schedul
     if (CRM_Mailing_Info::workflowEnabled()) {
       $allAccess = FALSE;
       $workFlow = TRUE;
-      //supercedes all permission
+      // supercedes all permission
       if (CRM_Core_Permission::check('access CiviMail')) {
         $allAccess = TRUE;
       }
@@ -314,15 +312,15 @@ LEFT JOIN  civicrm_contact scheduledContact ON ( $mailing.scheduled_id = schedul
     }
     $rows = &$mailing->getRows($offset, $rowCount, $sort, $whereClause, $params);
 
-    //get the search base mailing Ids, CRM-3711.
+    // get the search base mailing Ids, CRM-3711.
     $searchMailings = $mailing->searchMailingIDs();
 
-    //check for delete CRM-4418
+    // check for delete CRM-4418
     $allowToDelete = CRM_Core_Permission::check('delete in CiviMail');
 
     if ($output != CRM_Core_Selector_Controller::EXPORT) {
 
-      //create the appropriate $op to use for hook_civicrm_links
+      // create the appropriate $op to use for hook_civicrm_links
       $pageTypes = array('view', 'mailing', 'browse');
       if ($this->_parent->_unscheduled) {
         $pageTypes[] = 'unscheduled';
@@ -385,7 +383,7 @@ LEFT JOIN  civicrm_contact scheduledContact ON ( $mailing.scheduled_id = schedul
           }
         }
 
-        //check for delete permission.
+        // check for delete permission.
         if ($allowToDelete) {
           $actionMask |= CRM_Core_Action::DELETE;
         }
@@ -393,7 +391,7 @@ LEFT JOIN  civicrm_contact scheduledContact ON ( $mailing.scheduled_id = schedul
         if ($actionMask == NULL) {
           $actionMask = CRM_Core_Action::ADD;
         }
-        //get status strings as per locale settings CRM-4411.
+        // get status strings as per locale settings CRM-4411.
         $rows[$key]['status'] = CRM_Mailing_BAO_MailingJob::status($row['status']);
 
         $rows[$key]['action'] = CRM_Core_Action::formLink($actionLinks,
@@ -406,7 +404,7 @@ LEFT JOIN  civicrm_contact scheduledContact ON ( $mailing.scheduled_id = schedul
           $row['id']
         );
 
-        //unset($rows[$key]['id']);
+        // unset($rows[$key]['id']);
         // if the scheduled date is 0, replace it with an empty string
         if ($rows[$key]['scheduled_iso'] == '0000-00-00 00:00:00') {
           $rows[$key]['scheduled'] = '';

--- a/CRM/Mailing/Selector/Event.php
+++ b/CRM/Mailing/Selector/Event.php
@@ -29,15 +29,12 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 
 /**
  * This class is used to retrieve and display a range of
  * contacts that match the given criteria (specifically for
  * results of advanced search options.
- *
  */
 class CRM_Mailing_Selector_Event extends CRM_Core_Selector_Base implements CRM_Core_Selector_API {
 
@@ -257,7 +254,7 @@ class CRM_Mailing_Selector_Event extends CRM_Core_Selector_Base implements CRM_C
   /**
    * Returns total number of rows for the query.
    *
-   * @param
+   * @param string $action
    *
    * @return int
    *   Total number of rows

--- a/CRM/Mailing/Selector/Search.php
+++ b/CRM/Mailing/Selector/Search.php
@@ -29,15 +29,12 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 
 /**
  * This class is used to retrieve and display a range of
  * contacts that match the given criteria (specifically for
  * results of advanced search options.
- *
  */
 class CRM_Mailing_Selector_Search extends CRM_Core_Selector_Base implements CRM_Core_Selector_API {
 
@@ -241,7 +238,7 @@ class CRM_Mailing_Selector_Search extends CRM_Core_Selector_Base implements CRM_
   /**
    * Returns total number of rows for the query.
    *
-   * @param
+   * @param string $action
    *
    * @return int
    *   Total number of rows

--- a/CRM/Mailing/Task.php
+++ b/CRM/Mailing/Task.php
@@ -29,25 +29,23 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 
 /**
  * class to represent the actions that can be performed on a group of contacts
- * used by the search forms
+ * used by the search forms.
  *
  */
 class CRM_Mailing_Task {
   /**
-   * The task array
+   * The task array.
    *
    * @var array
    */
   static $_tasks = NULL;
 
   /**
-   * The optional task array
+   * The optional task array.
    *
    * @var array
    */
@@ -55,10 +53,10 @@ class CRM_Mailing_Task {
 
   /**
    * These tasks are the core set of tasks that the user can perform
-   * on a contact / group of contacts
+   * on a contact / group of contacts.
    *
    * @return array
-   *   the set of tasks for a group of contacts
+   *   the set of tasks for a group of contacts.
    */
   public static function &tasks() {
     if (!(self::$_tasks)) {
@@ -79,10 +77,10 @@ class CRM_Mailing_Task {
 
   /**
    * These tasks are the core set of task titles
-   * on mailing recipients
+   * on mailing recipients.
    *
    * @return array
-   *   the set of task titles
+   *   the set of task titles.
    */
   public static function &taskTitles() {
     return array();
@@ -90,7 +88,7 @@ class CRM_Mailing_Task {
 
   /**
    * Show tasks selectively based on the permission level
-   * of the user
+   * of the user.
    *
    * @param int $permission
    *
@@ -104,7 +102,7 @@ class CRM_Mailing_Task {
 
   /**
    * These tasks are the core set of tasks that the user can perform.
-   * on mailing recipients
+   * on mailing recipients.
    *
    * @param int $value
    *

--- a/CRM/Report/Page/Instance.php
+++ b/CRM/Report/Page/Instance.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 
 /**
@@ -39,8 +37,6 @@
 class CRM_Report_Page_Instance extends CRM_Core_Page {
   /**
    * Run this page (figure out the action needed and perform it).
-   *
-   * @return void
    */
   public function run() {
     $instanceId = CRM_Report_Utils_Report::getInstanceID();

--- a/CRM/Report/Page/Options.php
+++ b/CRM/Report/Page/Options.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 
 /**
@@ -70,8 +68,6 @@ class CRM_Report_Page_Options extends CRM_Core_Page_Basic {
 
   /**
    * Obtains the group name from url and sets the title.
-   *
-   * @return void
    */
   public function preProcess() {
     $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE);
@@ -110,7 +106,7 @@ class CRM_Report_Page_Options extends CRM_Core_Page_Basic {
    * Get action Links.
    *
    * @return array
-   *   (reference) of action links
+   *   (reference) of action links.
    */
   public function &links() {
     if (!(self::$_links)) {
@@ -145,8 +141,6 @@ class CRM_Report_Page_Options extends CRM_Core_Page_Basic {
 
   /**
    * Run the basic page (run essentially starts execution for that page).
-   *
-   * @return void
    */
   public function run() {
     $this->preProcess();
@@ -155,9 +149,6 @@ class CRM_Report_Page_Options extends CRM_Core_Page_Basic {
 
   /**
    * Browse all options.
-   *
-   *
-   * @return void
    */
   public function browse() {
     $groupParams = array('name' => self::$_gName);

--- a/CRM/Report/Page/Report.php
+++ b/CRM/Report/Page/Report.php
@@ -29,19 +29,15 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 
 /**
- * Page for invoking report templates
+ * Page for invoking report templates.
  */
 class CRM_Report_Page_Report extends CRM_Core_Page {
 
   /**
    * Run this page (figure out the action needed and perform it).
-   *
-   * @return void
    */
   public function run() {
     if (!CRM_Core_Permission::check('administer Reports')) {

--- a/CRM/Report/Page/TemplateList.php
+++ b/CRM/Report/Page/TemplateList.php
@@ -29,12 +29,10 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
  */
 
 /**
- * Page for displaying list of Reprot templates available
+ * Page for displaying list of Report templates available.
  */
 class CRM_Report_Page_TemplateList extends CRM_Core_Page {
 
@@ -108,8 +106,6 @@ LEFT  JOIN civicrm_component comp
 
   /**
    * Run this page (figure out the action needed and perform it).
-   *
-   * @return void
    */
   public function run() {
     $compID = CRM_Utils_Request::retrieve('compid', 'Positive', $this);


### PR DESCRIPTION
The patch contains comment fixes for all files in CRM/Mailing/ and Report/Page directories:
1. Removed unnecessary @return void statements.
2. Removed unnecessary empty @param statements (function had no parameters).
3. Removed empty comments.
4. Changed C style comments (/\* */) to standard C++ comments (//) in functions as recommended by Drupal coding standards.
5. @var tags were missing, added them. (for example @int changes to @var int).
6. Minor spell checks.
