### PR TITLE
CRM-17322 output upgrade as text

### DIFF
--- a/CRM/Upgrade/Headless.php
+++ b/CRM/Upgrade/Headless.php
@@ -76,9 +76,11 @@ class CRM_Upgrade_Headless {
 
     CRM_Upgrade_Form::doFinish();
 
+    $message = file_get_contents($postUpgradeMessageFile);
     return array(
       'latestVer' => $latestVer,
-      'message' => file_get_contents($postUpgradeMessageFile),
+      'message' => $message,
+      'text' => CRM_Utils_String::htmlToText($message),
     );
   }
 


### PR DESCRIPTION
This adds the 'text' array to the output params. There is a patch in drush to
print this rather than the html. wp-cli could do with such a patch too but out-of-scope here

---
- [CRM-17322: Convert drush upgrade output to html](https://issues.civicrm.org/jira/browse/CRM-17322)
