### PR TITLE
CRM-17324 Log upgrade steps

### DIFF
--- a/CRM/Queue/Runner.php
+++ b/CRM/Queue/Runner.php
@@ -210,6 +210,7 @@ class CRM_Queue_Runner {
 
       $exception = NULL;
       try {
+        CRM_Core_Error::debug_log_message("Running task: " . $this->lastTaskTitle);
         $isOK = $item->data->run($this->getTaskContext());
         if (!$isOK) {
           $exception = new Exception('Task returned false');


### PR DESCRIPTION
This puts the meter back into thermometer watching.  Prints a granular
log line for each upgrade migration patch.

TODO:
- The Drush harness should install a logging callback that captures Civi
  output and displays it on the console.

Bug: T99842
Change-Id: I8977b6b06b4eac9cd7e5ac5768c783d8560abfe3

---
- [CRM-17324: Log upgrade progress to CiviCRM log](https://issues.civicrm.org/jira/browse/CRM-17324)
