### PR TITLE
CRM-17335 toward eliminating use of leaky static

### DIFF
--- a/CRM/Core/Payment/BaseIPN.php
+++ b/CRM/Core/Payment/BaseIPN.php
@@ -1163,7 +1163,7 @@ LIMIT 1;";
           $from = ' FROM ' . $tableName;
           $where = " WHERE {$tableName}.entity_id = {$sourceContributionId}";
           $query = $insert . $select . $from . $where;
-          $dao = CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+          CRM_Core_DAO::executeQuery($query);
         }
       }
     }


### PR DESCRIPTION
I'm not sure if this one causes a problem but I have found at least one 'hard-to-diagnose' problem was because the null array was passed to executeQuery - but it wasn't actually null as the static had been used as the null to another function earlier

---
- [CRM-17335: Stop passing CRM_Core_DAO::$_nullArray  pointlessly](https://issues.civicrm.org/jira/browse/CRM-17335)
