### PR TITLE
CRM-14232 default not filling for contact preferred language

### DIFF
--- a/CRM/Admin/Form/Setting/Localization.php
+++ b/CRM/Admin/Form/Setting/Localization.php
@@ -54,6 +54,10 @@ class CRM_Admin_Form_Setting_Localization extends CRM_Admin_Form_Setting {
     'provinceLimit' => CRM_Core_BAO_Setting::LOCALIZATION_PREFERENCES_NAME,
   );
 
+  protected $_settings = array(
+    'contact_default_language' => CRM_Core_BAO_Setting::LOCALIZATION_PREFERENCES_NAME,
+  );
+
   /**
    * Build the form object.
    */


### PR DESCRIPTION
Change-Id: I1053c0b7f5f14660af8fc967d03ad6801f8fa51f

---
- [CRM-14232: Contact preferred language should be nullable](https://issues.civicrm.org/jira/browse/CRM-14232)
