### PR TITLE
CRM-16408 - Installer Changes for WordPress.  Default to use add Civi…

### DIFF
--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -579,10 +579,6 @@ abstract class CRM_Utils_System_Base {
       $tempURL = str_replace("/administrator/", "/", $baseURL);
       $filesURL = $tempURL . "media/civicrm/";
     }
-    elseif ($config->userFramework == 'WordPress') {
-      //for standalone no need of sites/defaults directory
-      $filesURL = $baseURL . "wp-content/plugins/files/civicrm/";
-    }
     elseif ($this->is_drupal) {
       $siteName = $config->userSystem->parseDrupalSiteName($civicrm_root);
       if ($siteName) {

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -73,6 +73,34 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
   }
 
   /**
+   * Moved from CRM_Utils_System_Base
+   */
+  public function getDefaultFileStorage() {
+    global $civicrm_root;
+    $config  = CRM_Core_Config::singleton();
+    $baseURL = CRM_Utils_System::languageNegotiationURL($config->userFrameworkBaseURL, FALSE, TRUE);
+    $filesURL        = NULL;
+    $filesPath       = NULL;
+    $upload_dir      = wp_upload_dir();
+    $settingsDir     = $upload_dir['basedir'] . DIRECTORY_SEPARATOR . 'civicrm' . DIRECTORY_SEPARATOR;
+    $settingsURL     = $upload_dir['baseurl'] . DIRECTORY_SEPARATOR . 'civicrm' . DIRECTORY_SEPARATOR;
+    if (is_dir(ABSPATH . 'wp-content/plugins/files/civicrm/')) {
+      //for legacy path
+      $filesURL = $baseURL . "wp-content/plugins/files/civicrm/";
+    }
+    elseif (is_dir($settingsDir)) {
+      $filesURL = $settingsURL;
+    }
+    else {
+      throw new CRM_Core_Exception("Failed to locate default file storage ($config->userFramework)");
+    }
+    return array(
+      'url'  => $filesURL,
+      'path' => CRM_Utils_File::baseFilePath(),
+    );
+  }
+
+  /**
    * @inheritDoc
    */
   public function appendBreadCrumb($breadCrumbs) {

--- a/install/civicrm.php
+++ b/install/civicrm.php
@@ -89,7 +89,9 @@ function civicrm_main(&$config) {
     );
   }
   elseif ($installType == 'wordpress') {
-    civicrm_setup(WP_PLUGIN_DIR . DIRECTORY_SEPARATOR . 'files');
+    $upload_dir = wp_upload_dir();
+    $files_dirname = $upload_dir['basedir'];
+    civicrm_setup($files_dirname);
   }
 
   $dsn = "mysql://{$config['mysql']['username']}:{$config['mysql']['password']}@{$config['mysql']['server']}/{$config['mysql']['database']}?new_link=true";
@@ -119,7 +121,7 @@ function civicrm_main(&$config) {
     $configFile = $cmsPath . DIRECTORY_SEPARATOR . 'sites' . DIRECTORY_SEPARATOR . $siteDir . DIRECTORY_SEPARATOR . 'civicrm.settings.php';
   }
   elseif ($installType == 'wordpress') {
-    $configFile = $cmsPath . DIRECTORY_SEPARATOR . 'civicrm.settings.php';
+    $configFile = $files_dirname . DIRECTORY_SEPARATOR . 'civicrm' . DIRECTORY_SEPARATOR . 'civicrm.settings.php';
   }
 
   $string = civicrm_config($config);

--- a/install/index.php
+++ b/install/index.php
@@ -107,12 +107,15 @@ if (isset($_REQUEST['mysql'])) {
   $databaseConfig = $_REQUEST['mysql'];
 }
 else {
-  $databaseConfig = array(
-    "server" => "localhost",
-    "username" => "civicrm",
-    "password" => "",
-    "database" => "civicrm",
-  );
+  if ($installType == 'wordpress') {
+    //WP Database Data
+    $databaseConfig = array(
+      "server" => DB_HOST,
+      "username" => DB_USER,
+      "password" => DB_PASSWORD,
+      "database" => DB_NAME,
+    );
+  }
 }
 
 if ($installType == 'drupal') {
@@ -187,6 +190,8 @@ if ($installType == 'drupal') {
 }
 elseif ($installType == 'wordpress') {
   $cmsPath = WP_PLUGIN_DIR . DIRECTORY_SEPARATOR . 'civicrm';
+  $upload_dir = wp_upload_dir();
+  $files_dirname = $upload_dir['basedir'] . DIRECTORY_SEPARATOR . 'civicrm';
   $alreadyInstalled = file_exists($cmsPath . CIVICRM_DIRECTORY_SEPARATOR .
     'civicrm.settings.php'
   );
@@ -501,8 +506,13 @@ class InstallRequirements {
       );
     }
     elseif ($installType == 'wordpress') {
-      // make sure that we can write to plugins/civicrm  and plugins/files/
-      $writableDirectories = array(WP_PLUGIN_DIR . DIRECTORY_SEPARATOR . 'files', $cmsPath);
+      // make sure that we can write to uploads/civicrm/
+      $upload_dir = wp_upload_dir();
+      $files_dirname = $upload_dir['basedir'] . DIRECTORY_SEPARATOR . 'civicrm';
+      if (!file_exists($files_dirname)) {
+        wp_mkdir_p($files_dirname);
+      }
+      $writableDirectories = array($files_dirname);
     }
 
     foreach ($writableDirectories as $dir) {
@@ -1457,6 +1467,10 @@ class Installer extends InstallRequirements {
 
         $c = CRM_Core_Config::singleton(FALSE);
         $c->free();
+        $wpInstallRedirect = admin_url("?page=CiviCRM&q=civicrm&reset=1");
+        echo "<script>
+         window.location = '$wpInstallRedirect';
+        </script>";
       }
     }
 


### PR DESCRIPTION
…CRM to existing WP Database, but allow override.  Change location of user files from plugins/files to uploads/civicrm.  Redirect to CiviCRM admin after successful install.  Change location of civicm.settings.php to uploads/civicrm. Move getDefaultFileStorage to CRM_Utils_System_WordPress.

---
- CRM-16408: Installer rewrite
  https://issues.civicrm.org/jira/browse/CRM-16408
