### PR TITLE
CRM-master test fix

### DIFF
--- a/tests/phpunit/CRM/Event/BAO/AdditionalPaymentTest.php
+++ b/tests/phpunit/CRM/Event/BAO/AdditionalPaymentTest.php
@@ -98,6 +98,7 @@ class CRM_Event_BAO_AdditionalPaymentTest extends CiviUnitTestCase {
       'is_active' => array('1' => 1),
       'price_set_id' => $priceset->id,
       'is_enter_qty' => 1,
+      'financial_type_id' => CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_FinancialType', 'Event Fee', 'id', 'name'),
     );
 
     $ids = array();


### PR DESCRIPTION
Fix for https://test.civicrm.org/job/CiviCRM-Core-Matrix/CIVIVER=master,label=ubuntu1204/1654/testReport/(root)/CRM_Event_BAO_AdditionalPaymentTest/testAddPartialPayment/

Include `financial_type_id` while creating the PriceFieldValue (to satisfy the changes made in https://github.com/civicrm/civicrm-core/commit/a17e67a12d0290d8be67cb003cb61bab70bcd435)
