### PR TITLE
CRM-17000 bypass separatevalues for getfields for performance

### DIFF
--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -231,7 +231,9 @@ function civicrm_api3_create_success($values = 1, $params = array(), $entity = N
     $result['count'] = (int) count($values);
 
     // Convert value-separated strings to array
-    _civicrm_api3_separate_values($values);
+    if ($action != 'getfields') {
+      _civicrm_api3_separate_values($values);
+    }
 
     if ($result['count'] == 1) {
       list($result['id']) = array_keys($values);


### PR DESCRIPTION
- [CRM-17000: API performance: _civicrm_api3_separate_values](https://issues.civicrm.org/jira/browse/CRM-17000)
