### PR TITLE
CRM-14720 - smart groups based on postal code numeric ranges cause fatal

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -3515,7 +3515,7 @@ WHERE  $smartGroupClause
 
     // Handle numeric postal code range searches properly by casting the column as numeric
     if (is_numeric($value)) {
-      $field = 'ROUND(civicrm_address.postal_code)';
+      $field = "IF (civicrm_address.postal_code REGEXP '^[0-9]+$', CAST(civicrm_address.postal_code AS UNSIGNED), 0)";
       $val = CRM_Utils_Type::escape($value, 'Integer');
     }
     else {

--- a/tests/phpunit/CRM/Contact/BAO/GroupContactTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/GroupContactTest.php
@@ -46,13 +46,14 @@ class CRM_Contact_BAO_GroupContactTest extends CiviUnitTestCase {
 
   /**
    * Tears down the fixture, for example, closes a network connection.
+   *
    * This method is called after a test is executed.
    */
   protected function tearDown() {
   }
 
   /**
-   * Test case for add( )
+   * Test case for add( ).
    */
   public function testAdd() {
 

--- a/tests/phpunit/CRM/Contact/BAO/GroupTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/GroupTest.php
@@ -37,6 +37,7 @@ class CRM_Contact_BAO_GroupTest extends CiviUnitTestCase {
 
   /**
    * Sets up the fixture, for example, opens a network connection.
+   *
    * This method is called before a test is executed.
    */
   protected function setUp() {
@@ -45,6 +46,7 @@ class CRM_Contact_BAO_GroupTest extends CiviUnitTestCase {
 
   /**
    * Tears down the fixture, for example, closes a network connection.
+   *
    * This method is called after a test is executed.
    */
   protected function tearDown() {
@@ -52,7 +54,7 @@ class CRM_Contact_BAO_GroupTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test case for add( )
+   * Test case for add( ).
    */
   public function testAddSimple() {
 
@@ -72,6 +74,9 @@ class CRM_Contact_BAO_GroupTest extends CiviUnitTestCase {
     );
   }
 
+  /**
+   * Test adding a smart group.
+   */
   public function testAddSmart() {
 
     $checkParams = $params = array(
@@ -93,7 +98,8 @@ class CRM_Contact_BAO_GroupTest extends CiviUnitTestCase {
   }
 
   /**
-   * Load all sql data sets & return an array of saved searches
+   * Load all sql data sets & return an array of saved searches.
+   *
    * @return array
    */
   public function dataProviderSavedSearch() {
@@ -114,7 +120,9 @@ class CRM_Contact_BAO_GroupTest extends CiviUnitTestCase {
   }
 
   /**
-   * Check we can load smart groups based on config from 'real DBs' without fatal errors - note that we are only testing lack of errors at this stage
+   * Check we can load smart groups based on config from 'real DBs' without fatal errors.
+   *
+   * Note that we are only testing lack of errors at this stage
    * @todo - for some reason the data was getting truncated from the group table using dataprovider - would be preferable to get that working
    * //@notdataProvider dataProviderSavedSearch
    * //@notparam integer $groupID


### PR DESCRIPTION
The fatal error requires the following

1) The postal_code field contains at least 1 long non-numeric string
2) mysql is set to re-act to warnings.

I couldn't replicate 2 in a test to demonstrate failure without this patch :-( but the tests still add some coverage.

This difference between ROUND & the IF + CAST replacement is that rows that are not entirely numeric as skipped

---
- [CRM-14720: smart groups based on postal code numeric ranges cause fatal ](https://issues.civicrm.org/jira/browse/CRM-14720)
