### PR TITLE
synchronize php and mysql time zones CRM-15656

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -354,7 +354,21 @@ class CRM_Core_DAO extends DB_DataObject {
    */
   public function initialize() {
     $this->_connect();
-    $this->query("SET NAMES utf8");
+    $query_string = "SET NAMES utf8"; // default query string
+    if (defined('CIVICRM_DB_TIMEZONE_SYNC')) {
+      if (CIVICRM_DB_TIMEZONE_SYNC) {
+        /*
+         * Set the database timezone to PHP timezone as per
+         * http://stackoverflow.com/questions/3451847/mysql-timezone-change
+         */
+        $n = new \DateTime();
+        $h = $n->getOffset()/3600;
+        $i = 60*($h-floor($h));
+        $offset = sprintf('%+d:%02d', $h, $i);
+        $query_string = "SET time_zone='$offset', NAMES utf8";
+      }
+    }
+    $this->query($query_string);  // perform the database setup
   }
 
   /**

--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -257,6 +257,16 @@ if (!defined('CIVICRM_DOMAIN_ID')) {
 }
 
 /**
+ * Database time zone synchronization setting
+ * Set this to true if you cannot synchronize your database and PHP time zones.
+ * This may be the case if you share a database with a number of other tenants
+ * of the server, otherwise set to false.
+ */
+if (!defined('CIVICRM_DB_TIMEZONE_SYNC')) {
+  define ('CIVICRM_DB_TIMEZONE_SYNC', true);
+}
+
+/**
  * Settings to enable external caching using a Memcache server.  This is an
  * advanced feature, and you should read and understand the documentation
  * before you turn it on. We cannot store these settings in the DB since the


### PR DESCRIPTION
This is really Stephen's patch from here https://github.com/spalmstr/civicrm-core/blob/master/CRM/Core/DAO.php, but I based it on master.

---
- [CRM-15656: Synchronize PHP and MySQL time zones](https://issues.civicrm.org/jira/browse/CRM-15656)
