### PR TITLE
CRM-17412 strict notice fix

### DIFF
--- a/CRM/Mailing/Page/Event.php
+++ b/CRM/Mailing/Page/Event.php
@@ -32,8 +32,9 @@
  */
 
 /**
- * This implements the profile page for all contacts. It uses a selector
- * object to do the actual dispay. The fields displayd are controlled by
+ * This implements the profile page for all contacts.
+ *
+ * It uses a selector object to do the actual display. The fields displayed are controlled by
  * the admin
  */
 class CRM_Mailing_Page_Event extends CRM_Core_Page {
@@ -49,7 +50,7 @@ class CRM_Mailing_Page_Event extends CRM_Core_Page {
    * Run this page (figure out the action needed and perform it).
    */
   public function run() {
-    $selector = &new CRM_Mailing_Selector_Event(
+    $selector = new CRM_Mailing_Selector_Event(
       CRM_Utils_Request::retrieve('event', 'String', $this),
       CRM_Utils_Request::retrieve('distinct', 'Boolean', $this),
       CRM_Utils_Request::retrieve('mid', 'Positive', $this),
@@ -59,7 +60,6 @@ class CRM_Mailing_Page_Event extends CRM_Core_Page {
 
     $mailing_id = CRM_Utils_Request::retrieve('mid', 'Positive', $this);
 
-    // assign backurl
     $context = CRM_Utils_Request::retrieve('context', 'String', $this);
 
     if ($context == 'activitySelector') {


### PR DESCRIPTION
- [CRM-17412: strict warning PHP Deprecated:  Assigning the return value of new by reference is deprecated in \/srv\/www\/buildkit\/build\/dmaster\/sites\/all\/modules\/civicrm\/CRM\/Mailing\/Page\/Event.php on line 52](https://issues.civicrm.org/jira/browse/CRM-17412)
