### PR TITLE
CRM-17413: Set ufID and userID in the session when bootstrapping for a REST call

### DIFF
--- a/CRM/Utils/REST.php
+++ b/CRM/Utils/REST.php
@@ -706,8 +706,11 @@ class CRM_Utils_REST {
       }
     }
 
-    if ($uid) {
+    if ($uid && $contact_id) {
       CRM_Utils_System::loadBootStrap(array('uid' => $uid), TRUE, FALSE);
+      $session = CRM_Core_Session::singleton();
+      $session->set('ufID', $uid);
+      $session->set('userID', $contact_id);
       return NULL;
     }
     else {


### PR DESCRIPTION
@totten Here's the PR for the REST issue from earlier in the week.

---
- [CRM-17413: Can't determine logged-in cid during a REST call](https://issues.civicrm.org/jira/browse/CRM-17413)
