### PR TITLE
CRM-17120 Unit test to ensure replacing deprecated function (to get labels) does not cause regressions.

### DIFF
--- a/CRM/Financial/Page/AJAX.php
+++ b/CRM/Financial/Page/AJAX.php
@@ -518,13 +518,20 @@ class CRM_Financial_Page_AJAX {
   public static function getBatchSummary() {
     $batchID = CRM_Utils_Type::escape($_REQUEST['batchID'], 'String');
     $params = array('id' => $batchID);
-    $batchInfo = CRM_Batch_BAO_Batch::retrieve($params, $value);
+    
+    $batchSummary = makeBatchSummary($batchID, $params);
+
+    CRM_Utils_JSON::output($batchSummary);
+  }
+
+  public static function makeBatchSummary($batchID, $params) {
+  	$batchInfo = CRM_Batch_BAO_Batch::retrieve($params, $value);
     $batchTotals = CRM_Batch_BAO_Batch::batchTotals(array($batchID));
-    $batchSummary = array(
+  	$batchSummary = array(
       'created_by' => CRM_Contact_BAO_Contact::displayName($batchInfo->created_id),
-      'status' => CRM_Core_OptionGroup::getLabel('batch_status', $batchInfo->status_id),
+      'status' => CRM_Core_PseudoConstant::getLabel('CRM_Batch_BAO_Batch', 'batch_status_id', $batchInfo->status_id),
       'description' => $batchInfo->description,
-      'payment_instrument' => CRM_Core_OptionGroup::getLabel('payment_instrument', $batchInfo->payment_instrument_id),
+      'payment_instrument' => CRM_Core_PseudoConstant::getLabel('CRM_Batch_BAO_Batch', 'payment_instrument_id', $batchInfo->payment_instrument_id),
       'item_count' => $batchInfo->item_count,
       'assigned_item_count' => $batchTotals[$batchID]['item_count'],
       'total' => CRM_Utils_Money::format($batchInfo->total),
@@ -532,7 +539,6 @@ class CRM_Financial_Page_AJAX {
       'opened_date' => CRM_Utils_Date::customFormat($batchInfo->created_date),
     );
 
-    CRM_Utils_JSON::output($batchSummary);
+    return $batchSummary;
   }
-
 }

--- a/CRM/Financial/Page/AJAX.php
+++ b/CRM/Financial/Page/AJAX.php
@@ -524,12 +524,20 @@ class CRM_Financial_Page_AJAX {
     CRM_Utils_JSON::output($batchSummary);
   }
 
+  /**
+   * Makes an array of the batch's summary and returns array to parent getBatchSummary() function.
+   *
+   * @param $batchID
+   * @param $params
+   *
+   * @return array
+   */
   public static function makeBatchSummary($batchID, $params) {
   	$batchInfo = CRM_Batch_BAO_Batch::retrieve($params, $value);
     $batchTotals = CRM_Batch_BAO_Batch::batchTotals(array($batchID));
   	$batchSummary = array(
       'created_by' => CRM_Contact_BAO_Contact::displayName($batchInfo->created_id),
-      'status' => CRM_Core_PseudoConstant::getLabel('CRM_Batch_BAO_Batch', 'batch_status_id', $batchInfo->status_id),
+      'status' => CRM_Core_PseudoConstant::getLabel('CRM_Batch_BAO_Batch', 'status_id', $batchInfo->status_id),
       'description' => $batchInfo->description,
       'payment_instrument' => CRM_Core_PseudoConstant::getLabel('CRM_Batch_BAO_Batch', 'payment_instrument_id', $batchInfo->payment_instrument_id),
       'item_count' => $batchInfo->item_count,

--- a/CRM/Financial/Page/AJAX.php
+++ b/CRM/Financial/Page/AJAX.php
@@ -518,7 +518,7 @@ class CRM_Financial_Page_AJAX {
   public static function getBatchSummary() {
     $batchID = CRM_Utils_Type::escape($_REQUEST['batchID'], 'String');
     $params = array('id' => $batchID);
-    
+
     $batchSummary = makeBatchSummary($batchID, $params);
 
     CRM_Utils_JSON::output($batchSummary);
@@ -533,9 +533,9 @@ class CRM_Financial_Page_AJAX {
    * @return array
    */
   public static function makeBatchSummary($batchID, $params) {
-  	$batchInfo = CRM_Batch_BAO_Batch::retrieve($params, $value);
+    $batchInfo = CRM_Batch_BAO_Batch::retrieve($params, $value);
     $batchTotals = CRM_Batch_BAO_Batch::batchTotals(array($batchID));
-  	$batchSummary = array(
+    $batchSummary = array(
       'created_by' => CRM_Contact_BAO_Contact::displayName($batchInfo->created_id),
       'status' => CRM_Core_PseudoConstant::getLabel('CRM_Batch_BAO_Batch', 'status_id', $batchInfo->status_id),
       'description' => $batchInfo->description,
@@ -549,4 +549,5 @@ class CRM_Financial_Page_AJAX {
 
     return $batchSummary;
   }
+
 }

--- a/tests/phpunit/CRM/Financial/Page/AjaxBatchSummaryTest.php
+++ b/tests/phpunit/CRM/Financial/Page/AjaxBatchSummaryTest.php
@@ -30,20 +30,21 @@ require_once 'CiviTest/CiviUnitTestCase.php';
  * Test for CRM_Financial_Page_Ajax class.
  */
 class CRM_Financial_Page_AjaxBatchSummaryTest extends CiviUnitTestCase {
-	/**
-	 * Test the makeBatchSummary function.
-	 *
-	 * We want to ensure changing the meethod of obtaining status and payment_instrument
-	 * does not cause any regression.
-	 */
-    public function testMakeBatchSummary() {
-    	$batch = $this->callAPISuccess('Batch', 'create', array('title' => 'test', 'status_id' => 'Open', 'payment_instrument_id' => 'Cash'));
+  /**
+   * Test the makeBatchSummary function.
+   *
+   * We want to ensure changing the method of obtaining status and payment_instrument
+   * does not cause any regression.
+   */
+  public function testMakeBatchSummary() {
+    $batch = $this->callAPISuccess('Batch', 'create', array('title' => 'test', 'status_id' => 'Open', 'payment_instrument_id' => 'Cash'));
 
-    	$batchID = $batch['id'];
-    	$params = array('id' => $batchID);
-    	$makeBatchSummary = CRM_Financial_Page_AJAX::makeBatchSummary($batchID,$params);
+    $batchID = $batch['id'];
+    $params = array('id' => $batchID);
+    $makeBatchSummary = CRM_Financial_Page_AJAX::makeBatchSummary($batchID, $params);
 
-    	$this->assertEquals('Open', $makeBatchSummary['status']);
-    	$this->assertEquals('Cash', $makeBatchSummary['payment_instrument']);
-    }
+    $this->assertEquals('Open', $makeBatchSummary['status']);
+    $this->assertEquals('Cash', $makeBatchSummary['payment_instrument']);
+  }
+
 }

--- a/tests/phpunit/CRM/Financial/Page/AjaxBatchSummaryTest.php
+++ b/tests/phpunit/CRM/Financial/Page/AjaxBatchSummaryTest.php
@@ -1,0 +1,46 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2015                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+require_once 'CiviTest/CiviUnitTestCase.php';
+
+class CRM_Financial_Page_AjaxBatchSummaryTest extends CiviUnitTestCase {
+
+    public function testMakeBatchSummary() {
+    	$batch = $this->callAPISuccess('Batch', 'create', array('title' => 'test', 'status_id' => 'Open'));
+    	$batchID = $batch['id'];
+    	$params = array('id' => $batchID);
+
+    	$test = array(
+    			'status' => 'some status', // how do i extract the batch's status?
+    			'payment_instrument' => 'some instrument', // how do i extract the batch's payment instrument?
+    		);
+
+    	$makeBatchSummary = CRM_Financial_Page_AJAX::makeBatchSummary($batchID,$params);
+
+    	$this->assertEquals($test['status'], $makeBatchSummary['status']);
+    	$this->assertEquals($test['payment_instrument'], $makeBatchSummary['payment_instrument']);
+    }
+}

--- a/tests/phpunit/CRM/Financial/Page/AjaxBatchSummaryTest.php
+++ b/tests/phpunit/CRM/Financial/Page/AjaxBatchSummaryTest.php
@@ -26,21 +26,24 @@
  */
 require_once 'CiviTest/CiviUnitTestCase.php';
 
+/**
+ * Test for CRM_Financial_Page_Ajax class.
+ */
 class CRM_Financial_Page_AjaxBatchSummaryTest extends CiviUnitTestCase {
-
+	/**
+	 * Test the makeBatchSummary function.
+	 *
+	 * We want to ensure changing the meethod of obtaining status and payment_instrument
+	 * does not cause any regression.
+	 */
     public function testMakeBatchSummary() {
-    	$batch = $this->callAPISuccess('Batch', 'create', array('title' => 'test', 'status_id' => 'Open'));
+    	$batch = $this->callAPISuccess('Batch', 'create', array('title' => 'test', 'status_id' => 'Open', 'payment_instrument_id' => 'Cash'));
+
     	$batchID = $batch['id'];
     	$params = array('id' => $batchID);
-
-    	$test = array(
-    			'status' => 'some status', // how do i extract the batch's status?
-    			'payment_instrument' => 'some instrument', // how do i extract the batch's payment instrument?
-    		);
-
     	$makeBatchSummary = CRM_Financial_Page_AJAX::makeBatchSummary($batchID,$params);
 
-    	$this->assertEquals($test['status'], $makeBatchSummary['status']);
-    	$this->assertEquals($test['payment_instrument'], $makeBatchSummary['payment_instrument']);
+    	$this->assertEquals('Open', $makeBatchSummary['status']);
+    	$this->assertEquals('Cash', $makeBatchSummary['payment_instrument']);
     }
 }


### PR DESCRIPTION
- [CRM-17120: Function CRM_Core_OptionGroup::getLabel does not use caching](https://issues.civicrm.org/jira/browse/CRM-17120)
