### PR TITLE
CRM-14756 fixed some legacy code and the issue where supplying id was not enough.

### DIFF
--- a/CRM/Core/BAO/UFField.php
+++ b/CRM/Core/BAO/UFField.php
@@ -192,15 +192,13 @@ WHERE cf.id IN (" . $customFieldIds . ") AND is_multiple = 1 LIMIT 0,1";
    *
    * @param array $params
    *   (reference) array containing the values submitted by the form.
-   * @param array $ids
-   *   Array containing the id.
    *
    * @return CRM_Core_BAO_UFField
-   *
    */
-  public static function add(&$params, $ids = array()) {
+  public static function add(&$params) {
     // set values for uf field properties and save
     $ufField = new CRM_Core_DAO_UFField();
+    $ufField->copyValues($params);
     $ufField->field_type = $params['field_name'][0];
     $ufField->field_name = $params['field_name'][1];
 
@@ -221,24 +219,6 @@ WHERE cf.id IN (" . $customFieldIds . ") AND is_multiple = 1 LIMIT 0,1";
     }
 
     $ufField->phone_type_id = CRM_Utils_Array::value(3, $params['field_name'], 'NULL');
-    $ufField->listings_title = CRM_Utils_Array::value('listings_title', $params);
-    $ufField->visibility = CRM_Utils_Array::value('visibility', $params);
-    $ufField->help_pre = CRM_Utils_Array::value('help_pre', $params);
-    $ufField->help_post = CRM_Utils_Array::value('help_post', $params);
-    $ufField->label = CRM_Utils_Array::value('label', $params);
-    $ufField->is_required = CRM_Utils_Array::value('is_required', $params, FALSE);
-    $ufField->is_active = CRM_Utils_Array::value('is_active', $params, FALSE);
-    $ufField->in_selector = CRM_Utils_Array::value('in_selector', $params, FALSE);
-    $ufField->is_view = CRM_Utils_Array::value('is_view', $params, FALSE);
-    $ufField->is_registration = CRM_Utils_Array::value('is_registration', $params, FALSE);
-    $ufField->is_match = CRM_Utils_Array::value('is_match', $params, FALSE);
-    $ufField->is_searchable = CRM_Utils_Array::value('is_searchable', $params, FALSE);
-    $ufField->is_multi_summary = CRM_Utils_Array::value('is_multi_summary', $params, FALSE);
-    $ufField->weight = CRM_Utils_Array::value('weight', $params, 0);
-
-    // need the FKEY - uf group id
-    $ufField->uf_group_id = CRM_Utils_Array::value('uf_group', $ids, FALSE);
-    $ufField->id = CRM_Utils_Array::value('uf_field', $ids, FALSE);
 
     return $ufField->save();
   }

--- a/api/v3/UFField.php
+++ b/api/v3/UFField.php
@@ -44,7 +44,7 @@
  */
 function civicrm_api3_uf_field_create($params) {
   // CRM-14756: kind of a hack-ish fix. If the user gives the id, uf_group_id is retrieved and then set.
-  if(isset($params['id'])) {
+  if (isset($params['id'])) {
     $groupId = civicrm_api3('UFField', 'getvalue', array(
       'return' => 'uf_group_id',
       'id' => $params['id'],
@@ -95,7 +95,7 @@ function civicrm_api3_uf_field_create($params) {
   if (CRM_Utils_Array::value('option.autoweight', $params, TRUE)) {
     $params['weight'] = CRM_Core_BAO_UFField::autoWeight($params);
   }
-  $ufField = CRM_Core_BAO_UFField::add($params, $ids);
+  $ufField = CRM_Core_BAO_UFField::add($params);
 
   $fieldsType = CRM_Core_BAO_UFGroup::calculateGroupType($groupId, TRUE);
   CRM_Core_BAO_UFGroup::updateGroupTypes($groupId, $fieldsType);

--- a/api/v3/UFField.php
+++ b/api/v3/UFField.php
@@ -43,10 +43,15 @@
  *   Newly created $ufFieldArray
  */
 function civicrm_api3_uf_field_create($params) {
-  civicrm_api3_verify_one_mandatory($params, NULL, array('field_name', 'uf_group_id'));
-  $groupId = CRM_Utils_Array::value('uf_group_id', $params);
-  if ((int) $groupId < 1) {
-    throw new API_Exception('Params must be a field_name-carrying array and a positive integer.');
+  // CRM-14756: kind of a hack-ish fix. If the user gives the id, uf_group_id is retrieved and then set.
+  if(isset($params['id'])) {
+    $groupId = civicrm_api3('UFField', 'getvalue', array(
+      'return' => 'uf_group_id',
+      'id' => $params['id'],
+    ));
+  }
+  else {
+    $groupId = CRM_Utils_Array::value('uf_group_id', $params);
   }
 
   $field_type       = CRM_Utils_Array::value('field_type', $params);
@@ -106,6 +111,9 @@ function civicrm_api3_uf_field_create($params) {
  * @param array $params
  */
 function _civicrm_api3_uf_field_create_spec(&$params) {
+  $params['field_name']['api.required'] = TRUE;
+  $params['uf_group_id']['api.required'] = TRUE;
+
   $params['option.autoweight'] = array(
     'title' => "Auto Weight",
     'description' => "Automatically adjust weights in UFGroup to align with UFField",


### PR DESCRIPTION
- [CRM-14756: uf_field api wants "field_name" as required parameter for exiting fields.](https://issues.civicrm.org/jira/browse/CRM-14756)
