### PR TITLE
check.gif not visible due to code formatting issue

### DIFF
--- a/templates/CRM/Admin/Page/LabelFormats.tpl
+++ b/templates/CRM/Admin/Page/LabelFormats.tpl
@@ -53,8 +53,8 @@
               <td class="crm-labelFormat-name">{$row.groupName}</td>
               <td class="crm-labelFormat-order nowrap">{$row.weight}</td>
               <td class="crm-labelFormat-description">{$row.grouping}</td>
-              <td class="crm-labelFormat-is_default">{if $row.is_default eq 1}<img
-                src="{$config->resourceBase}i/check.gif" alt="{ts}Default{/ts}"/>{/if}&nbsp;</td>
+              <td class="crm-labelFormat-is_default">{if $row.is_default eq 1}
+              <img src="{$config->resourceBase}i/check.gif" alt="{ts}Default{/ts}"/>{/if}&nbsp;</td>
               <td class="crm-labelFormat-is_reserved">{if $row.is_reserved eq 1}{ts}Yes{/ts}{else}{ts}No{/ts}{/if}
                 &nbsp;</td>
               <td>{$row.action|replace:'xx':$row.id}</td>


### PR DESCRIPTION
Carriage return should be added at line 56 between closing curly bracket  and start of image tag, it gives check.gif path error thus icon is not visible at civicrm/admin/labelFormats?reset=1
