### PR TITLE
Test fix - adapt tests to not use hard-coded payment_processor_type_id

### DIFF
--- a/tests/phpunit/CRM/Member/Form/MembershipRenewalTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipRenewalTest.php
@@ -98,8 +98,7 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
     parent::setUp();
 
     $this->_individualId = $this->individualCreate();
-    $processor = $this->processorCreate();
-    $this->_paymentProcessorID = $processor->id;
+    $this->_paymentProcessorID = $this->processorCreate();
     // Insert test data.
     $op = new PHPUnit_Extensions_Database_Operation_Insert();
     $op->execute($this->_dbconn,

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -98,8 +98,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
     parent::setUp();
 
     $this->_individualId = $this->individualCreate();
-    $processor = $this->processorCreate();
-    $this->_paymentProcessorID = $processor->id;
+    $this->_paymentProcessorID = $this->processorCreate();
     // Insert test data.
     $op = new PHPUnit_Extensions_Database_Operation_Insert();
     $op->execute($this->_dbconn,

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -1488,14 +1488,14 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
   /**
    * Create Payment Processor.
    *
-   * @return CRM_Financial_DAO_PaymentProcessor
-   *   instance of Payment Processor
+   * @return int
+   *   Id Payment Processor
    */
   public function processorCreate() {
     $processorParams = array(
       'domain_id' => 1,
       'name' => 'Dummy',
-      'payment_processor_type_id' => 10,
+      'payment_processor_type_id' => 'Dummy',
       'financial_account_id' => 12,
       'is_test' => TRUE,
       'is_active' => 1,
@@ -1503,8 +1503,10 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
       'url_site' => 'http://dummy.com',
       'url_recur' => 'http://dummy.com',
       'billing_mode' => 1,
+      'sequential' => 1,
     );
-    return CRM_Financial_BAO_PaymentProcessor::create($processorParams);
+    $processor = $this->callAPISuccess('PaymentProcessor', 'create', $processorParams);
+    return $processor['id'];
   }
 
   /**
@@ -1516,8 +1518,8 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
    *    Instance of Dummy Payment Processor
    */
   public function dummyProcessorCreate($processorParams = array()) {
-    $paymentProcessor = $this->processorCreate($processorParams);
-    return Civi\Payment\System::singleton()->getById($paymentProcessor->id);
+    $paymentProcessorID = $this->processorCreate($processorParams);
+    return Civi\Payment\System::singleton()->getById($paymentProcessorID);
   }
 
   /**

--- a/tests/phpunit/api/v3/ContributionRecurTest.php
+++ b/tests/phpunit/api/v3/ContributionRecurTest.php
@@ -77,9 +77,8 @@ class api_v3_ContributionRecurTest extends CiviUnitTestCase {
   public function testCreateContributionRecurWithToken() {
     // create token
     $this->createLoggedInUser();
-    $paymentProcessor = $this->processorCreate();
     $token = $this->callAPISuccess('PaymentToken', 'create', array(
-      'payment_processor_id' => $paymentProcessor->id,
+      'payment_processor_id' => $this->processorCreate(),
       'token' => 'hhh',
       'contact_id' => $this->individualCreate(),
     ));

--- a/tests/phpunit/api/v3/ContributionSoftTest.php
+++ b/tests/phpunit/api/v3/ContributionSoftTest.php
@@ -72,7 +72,7 @@ class api_v3_ContributionSoftTest extends CiviUnitTestCase {
     $this->_softIndividual2Id = $this->individualCreate();
     $this->_contributionId = $this->contributionCreate(array('contact_id' => $this->_individualId));
 
-    $paymentProcessor = $this->processorCreate();
+    $this->processorCreate();
     $this->_params = array(
       'contact_id' => $this->_individualId,
       'receive_date' => '20120511',

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -72,7 +72,6 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
 
     $this->_apiversion = 3;
     $this->_individualId = $this->individualCreate();
-    $paymentProcessor = $this->processorCreate();
     $this->_params = array(
       'contact_id' => $this->_individualId,
       'receive_date' => '20120511',
@@ -100,7 +99,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'financial_type_id' => 1,
       'currency' => 'USD',
       'financial_account_id' => 1,
-      'payment_processor' => $paymentProcessor->id,
+      'payment_processor' => $this->processorCreate(),
       'is_active' => 1,
       'is_allow_other_amount' => 1,
       'min_amount' => 10,

--- a/tests/phpunit/api/v3/ParticipantPaymentTest.php
+++ b/tests/phpunit/api/v3/ParticipantPaymentTest.php
@@ -202,13 +202,12 @@ class api_v3_ParticipantPaymentTest extends CiviUnitTestCase {
    */
   public function testPaymentOnline() {
 
-    $paymentProcessor = $this->processorCreate();
-    $pageParams['processor_id'] = $paymentProcessor->id;
+    $pageParams['processor_id'] = $this->processorCreate();
     $contributionPage = $this->contributionPageCreate($pageParams);
     $contributionParams = array(
       'contact_id' => $this->_contactID,
       'contribution_page_id' => $contributionPage['id'],
-      'payment_processor' => $paymentProcessor->id,
+      'payment_processor' => $pageParams['processor_id'],
       'financial_type_id' => 1,
     );
     $contributionID = $this->contributionCreate($contributionParams);
@@ -236,9 +235,7 @@ class api_v3_ParticipantPaymentTest extends CiviUnitTestCase {
    * Check financial records for online Participant pay later scenario.
    */
   public function testPaymentPayLaterOnline() {
-
-    $paymentProcessor = $this->processorCreate();
-    $pageParams['processor_id'] = $paymentProcessor->id;
+    $pageParams['processor_id'] = $this->processorCreate();
     $pageParams['is_pay_later'] = 1;
     $contributionPage = $this->contributionPageCreate($pageParams);
     $contributionParams = array(

--- a/tests/phpunit/api/v3/PaymentTokenTest.php
+++ b/tests/phpunit/api/v3/PaymentTokenTest.php
@@ -43,12 +43,11 @@ class api_v3_PaymentTokenTest extends CiviUnitTestCase {
     $this->useTransaction(TRUE);
     parent::setUp();
     $contactID = $this->individualCreate();
-    $paymentProcessor = $this->processorCreate();
     $this->params = array(
       'token' => "fancy-token-xxxx",
       'contact_id' => $contactID,
       'created_id' => $contactID,
-      'payment_processor_id' => $paymentProcessor->id,
+      'payment_processor_id' => $this->processorCreate(),
     );
   }
 


### PR DESCRIPTION
This type id has been changed in core & the tests are now failing - but since the
affected tests were excluded from CI it wasn't picked up at the time
