### PR TITLE
CRM-17432 Attachment API create: use copy/unlink instead of rename(),…

### DIFF
--- a/api/v3/Attachment.php
+++ b/api/v3/Attachment.php
@@ -160,7 +160,10 @@ function civicrm_api3_attachment_create($params) {
     file_put_contents($path, $content);
   }
   elseif (is_string($moveFile)) {
-    rename($moveFile, $path);
+    // CRM-17432 Do not use rename() since it will break file permissions.
+    // Also avoid move_uplaoded_file() because the API can use options.move-file.
+    copy($moveFile, $path);
+    unlink($moveFile);
   }
 
   // Save custom field to entity


### PR DESCRIPTION
… to avoid file permission problems.
