### PR TITLE
Changing something to the domain should leave the domain_version untouched

### DIFF
--- a/api/v3/Domain.php
+++ b/api/v3/Domain.php
@@ -163,6 +163,7 @@ function _civicrm_api3_domain_create_spec(&$params) {
   $params['domain_version'] = array(
     'title' => "CiviCRM Version",
     'description' => "The civicrm version this instance is running",
+    'type' => CRM_Utils_Type::T_STRING,
   );
   $params['domain_version']['api.required'] = 1;
   unset($params['version']);

--- a/api/v3/Domain.php
+++ b/api/v3/Domain.php
@@ -141,10 +141,13 @@ function civicrm_api3_domain_create($params) {
   }
   $result = _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
 
-  // Rename version to domain_version, see CRM-17430.
   $result_value = CRM_Utils_Array::first($result['values']);
-  $result_value['domain_version'] = $result_value['version'];
-  unset($result_value['version']);
+  if (isset($result_value['version'])) {
+    // Rename version to domain_version, see CRM-17430.
+    $result_value['domain_version'] = $result_value['version'];
+    unset($result_value['version']);
+    $result['values'][$result['id']] = $result_value;
+  }
   return $result;
 }
 

--- a/api/v3/Domain.php
+++ b/api/v3/Domain.php
@@ -157,7 +157,6 @@ function civicrm_api3_domain_create($params) {
  *   Array of parameters determined by getfields.
  */
 function _civicrm_api3_domain_create_spec(&$params) {
-  $params['domain_version']['api.required'] = 1;
   unset($params['version']);
   $params['name']['api.required'] = 1;
 }

--- a/api/v3/Domain.php
+++ b/api/v3/Domain.php
@@ -157,6 +157,7 @@ function civicrm_api3_domain_create($params) {
  *   Array of parameters determined by getfields.
  */
 function _civicrm_api3_domain_create_spec(&$params) {
+  $params['domain_version']['api.required'] = 1;
   unset($params['version']);
   $params['name']['api.required'] = 1;
 }

--- a/api/v3/Domain.php
+++ b/api/v3/Domain.php
@@ -130,6 +130,14 @@ function _civicrm_api3_domain_get_spec(&$params) {
  */
 function civicrm_api3_domain_create($params) {
   $params['version'] = $params['domain_version'];
+  if ($params['version'] == 3) {
+    // This is an ugly hack to fix CRM-17430. Since CiviCRM version 3 is way
+    // older than this hack, we can safely assume that the user does not want
+    // to set his CiviCRM version to 3.
+    // domain_version is set to 3 by the function below. But if you leave that
+    // assignment out, a lot of unit tests break. So let's hack around this.
+    unset($params['version']);
+  }
   return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
 }
 

--- a/api/v3/Domain.php
+++ b/api/v3/Domain.php
@@ -129,13 +129,10 @@ function _civicrm_api3_domain_get_spec(&$params) {
  * @return array
  */
 function civicrm_api3_domain_create($params) {
-  $params['version'] = $params['domain_version'];
-  if ($params['version'] == 3) {
-    // This is an ugly hack to fix CRM-17430. Since CiviCRM version 3 is way
-    // older than this hack, we can safely assume that the user does not want
-    // to set his CiviCRM version to 3.
-    // domain_version is set to 3 by the function below. But if you leave that
-    // assignment out, a lot of unit tests break. So let's hack around this.
+  if (isset($params['domain_version'])) {
+    $params['version'] = $params['domain_version'];
+  }
+  else {
     unset($params['version']);
   }
   return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -150,7 +147,6 @@ function civicrm_api3_domain_create($params) {
  *   Array of parameters determined by getfields.
  */
 function _civicrm_api3_domain_create_spec(&$params) {
-  $params['domain_version'] = $params['version'];
   $params['domain_version']['api.required'] = 1;
   unset($params['version']);
   $params['name']['api.required'] = 1;

--- a/api/v3/Domain.php
+++ b/api/v3/Domain.php
@@ -157,6 +157,10 @@ function civicrm_api3_domain_create($params) {
  *   Array of parameters determined by getfields.
  */
 function _civicrm_api3_domain_create_spec(&$params) {
+  $params['domain_version'] = array(
+    'title' => "CiviCRM Version",
+    'description' => "The civicrm version this instance is running",
+  );
   $params['domain_version']['api.required'] = 1;
   unset($params['version']);
   $params['name']['api.required'] = 1;

--- a/api/v3/Domain.php
+++ b/api/v3/Domain.php
@@ -99,6 +99,10 @@ function civicrm_api3_domain_get($params) {
       list($domain['from_name'],
         $domain['from_email']
       ) = CRM_Core_BAO_Domain::getNameAndEmail(TRUE);
+
+      // Rename version to domain_version, see CRM-17430.
+      $domain['domain_version'] = $domain['version'];
+      unset($domain['version']);
       $domains[$domain['id']] = array_merge($domains[$domain['id']], $domain);
     }
   }
@@ -135,7 +139,13 @@ function civicrm_api3_domain_create($params) {
   else {
     unset($params['version']);
   }
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  $result = _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+
+  // Rename version to domain_version, see CRM-17430.
+  $result_value = CRM_Utils_Array::first($result['values']);
+  $result_value['domain_version'] = $result_value['version'];
+  unset($result_value['version']);
+  return $result;
 }
 
 /**

--- a/tests/phpunit/api/v3/DomainTest.php
+++ b/tests/phpunit/api/v3/DomainTest.php
@@ -172,7 +172,7 @@ class api_v3_DomainTest extends CiviUnitTestCase {
     $this->assertEquals($result['count'], 1);
     $this->assertNotNull($result['id']);
     $this->assertEquals($result['values'][$result['id']]['name'], $this->params['name']);
-    $this->assertEquals($result['values'][$result['id']]['version'], $this->params['domain_version']);
+    $this->assertEquals($result['values'][$result['id']]['domain_version'], $this->params['domain_version']);
   }
 
   /**
@@ -198,6 +198,20 @@ class api_v3_DomainTest extends CiviUnitTestCase {
     $this->assertEquals($domain_before['version'], $domain_after['version']);
   }
 
+  /**
+   * Test whether Domain.create returns a correct value for domain_version.
+   *
+   * See CRM-17430.
+   */
+  public function testCreateDomainResult() {
+    // First create a domain.
+    $domain_result = $this->callAPISuccess('Domain', 'create', $this->params);
+    $result_value = CRM_Utils_Array::first($domain_result['values']);
+
+    // Check for domain_version in create result.
+    $this->assertEquals($this->params['domain_version'], $result_value['domain_version']);
+  }
+  
   /**
    * Test civicrm_domain_create with empty params.
    *

--- a/tests/phpunit/api/v3/DomainTest.php
+++ b/tests/phpunit/api/v3/DomainTest.php
@@ -211,7 +211,7 @@ class api_v3_DomainTest extends CiviUnitTestCase {
     // Check for domain_version in create result.
     $this->assertEquals($this->params['domain_version'], $result_value['domain_version']);
   }
-  
+
   /**
    * Test civicrm_domain_create with empty params.
    *

--- a/tests/phpunit/api/v3/DomainTest.php
+++ b/tests/phpunit/api/v3/DomainTest.php
@@ -176,6 +176,29 @@ class api_v3_DomainTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test if Domain.create does not touch the version of the domain.
+   *
+   * See CRM-17430.
+   */
+  public function testUpdateDomainName() {
+    // First create a domain.
+    $domain_result = $this->callAPISuccess('domain', 'create', $this->params);
+    $domain_before = $this->callAPISuccess('Domain', 'getsingle', array('id' => $domain_result['id']));
+
+    // Change domain name.
+    $this->callAPISuccess('Domain', 'create', array(
+      'id' => $domain_result['id'],
+      'name' => 'B-Team domain',
+    ));
+
+    // Get domain again.
+    $domain_after = $this->callAPISuccess('Domain', 'getsingle', array('id' => $domain_result['id']));
+
+    // Version should still be the same.
+    $this->assertEquals($domain_before['version'], $domain_after['version']);
+  }
+
+  /**
    * Test civicrm_domain_create with empty params.
    *
    * Error expected.

--- a/tests/phpunit/api/v3/SettingTest.php
+++ b/tests/phpunit/api/v3/SettingTest.php
@@ -52,6 +52,7 @@ class api_v3_SettingTest extends CiviUnitTestCase {
     parent::setUp();
     $params = array(
       'name' => 'Default Domain Name',
+      'domain_version' => '4.7',
     );
     $result = $this->callAPISuccess('domain', 'get', $params);
     if (empty($result['id'])) {
@@ -515,6 +516,7 @@ class api_v3_SettingTest extends CiviUnitTestCase {
   public function testDefaults() {
     $domparams = array(
       'name' => 'B Team Domain',
+      'domain_version' => '4.7',
     );
     $dom = $this->callAPISuccess('domain', 'create', $domparams);
     $params = array(


### PR DESCRIPTION
This is a unit  test and a fix for CRM-17430.

---
- [CRM-17430: Altering the domain using the API changes the CiviCRM version to 3](https://issues.civicrm.org/jira/browse/CRM-17430)
