### PR TITLE
CRM-17469 - Online pledge payment fix

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -149,19 +149,23 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       $completedContributionIds = array();
       $pledgePayments = CRM_Pledge_BAO_PledgePayment::getPledgePayments($this->_values['pledge_id']);
 
+      $paymentAmount = 0;
       $duePayment = FALSE;
       foreach ($pledgePayments as $payId => $value) {
         if ($value['status'] == 'Overdue') {
           $this->_defaults['pledge_amount'][$payId] = 1;
+          $paymentAmount += $value['scheduled_amount'];
         }
         elseif (!$duePayment && $value['status'] == 'Pending') {
           $this->_defaults['pledge_amount'][$payId] = 1;
+          $paymentAmount += $value['scheduled_amount'];
           $duePayment = TRUE;
         }
         elseif ($value['status'] == 'Completed' && $value['contribution_id']) {
           $completedContributionIds[] = $value['contribution_id'];
         }
       }
+      $this->_defaults['price_' . $this->_priceSetId] = $paymentAmount;
 
       if (count($completedContributionIds)) {
         $softCredit = array();

--- a/CRM/Pledge/BAO/PledgeBlock.php
+++ b/CRM/Pledge/BAO/PledgeBlock.php
@@ -212,7 +212,6 @@ class CRM_Pledge_BAO_PledgeBlock extends CRM_Pledge_DAO_PledgeBlock {
       $nextPayment = array();
       $isNextPayment = FALSE;
       $overduePayments = array();
-      $now = date('Ymd');
       foreach ($allPayments as $payID => $value) {
         if ($allStatus[$value['status_id']] == 'Overdue') {
           $overduePayments[$payID] = array(
@@ -244,20 +243,22 @@ class CRM_Pledge_BAO_PledgeBlock extends CRM_Pledge_DAO_PledgeBlock {
       $payments = array();
       if (!empty($overduePayments)) {
         foreach ($overduePayments as $id => $payment) {
-          $key = ts("%1 - due on %2 (overdue)", array(
+          $label = ts("%1 - due on %2 (overdue)", array(
             1 => CRM_Utils_Money::format(CRM_Utils_Array::value('scheduled_amount', $payment), CRM_Utils_Array::value('scheduled_amount_currency', $payment)),
             2 => CRM_Utils_Array::value('scheduled_date', $payment),
           ));
-          $payments[$key] = CRM_Utils_Array::value('id', $payment);
+          $paymentID = CRM_Utils_Array::value('id', $payment);
+          $payments[] = $form->createElement('checkbox', $paymentID, NULL, $label, array('amount' => CRM_Utils_Array::value('scheduled_amount', $payment)));
         }
       }
 
       if (!empty($nextPayment)) {
-        $key = ts("%1 - due on %2", array(
+        $label = ts("%1 - due on %2", array(
           1 => CRM_Utils_Money::format(CRM_Utils_Array::value('scheduled_amount', $nextPayment), CRM_Utils_Array::value('scheduled_amount_currency', $nextPayment)),
           2 => CRM_Utils_Array::value('scheduled_date', $nextPayment),
         ));
-        $payments[$key] = CRM_Utils_Array::value('id', $nextPayment);
+        $paymentID = CRM_Utils_Array::value('id', $nextPayment);
+        $payments[] = $form->createElement('checkbox', $paymentID, NULL, $label, array('amount' => CRM_Utils_Array::value('scheduled_amount', $nextPayment)));
       }
       // give error if empty or build form for payment.
       if (empty($payments)) {
@@ -265,7 +266,7 @@ class CRM_Pledge_BAO_PledgeBlock extends CRM_Pledge_DAO_PledgeBlock {
       }
       else {
         $form->assign('is_pledge_payment', TRUE);
-        $form->addCheckBox('pledge_amount', ts('Make Pledge Payment(s):'), $payments);
+        $form->addGroup($payments, 'pledge_amount', ts('Make Pledge Payment(s):'), '<br />');
       }
     }
     else {

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -453,9 +453,7 @@
     }
 
     $('#pricevalue').each(toggleBillingBlockIfFree).on('change', toggleBillingBlockIfFree);
-  });
-
-  CRM.$(function($) {
+  
     // Update pledge contribution amount when pledge checkboxes change
     $("input[name^='pledge_amount']").on('change', function() {
       var total = 0;

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -454,6 +454,17 @@
 
     $('#pricevalue').each(toggleBillingBlockIfFree).on('change', toggleBillingBlockIfFree);
   });
+
+  CRM.$(function($) {
+    // Update pledge contribution amount when pledge checkboxes change
+    cj("input[name^='pledge_amount']").on('change', function() {
+      var total = 0;
+      cj("input[name^='pledge_amount']:checked").each(function() {
+        total += Number(cj(this).attr('amount'));
+      });
+      cj("input[name^='price_']").val(total.toFixed(2));
+    });
+  });
   {/literal}
 </script>
 {/if}

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -433,22 +433,22 @@
   CRM.$(function($) {
     // highlight price sets
     function updatePriceSetHighlight() {
-      cj('#priceset .price-set-row span').removeClass('highlight');
-      cj('#priceset .price-set-row input:checked').parent().addClass('highlight');
+      $('#priceset .price-set-row span').removeClass('highlight');
+      $('#priceset .price-set-row input:checked').parent().addClass('highlight');
     }
-    cj('#priceset input[type="radio"]').change(updatePriceSetHighlight);
+    $('#priceset input[type="radio"]').change(updatePriceSetHighlight);
     updatePriceSetHighlight();
 
     function toggleBillingBlockIfFree(){
       var total_amount_tmp =  $(this).data('raw-total');
       // Hide billing questions if this is free
       if (total_amount_tmp == 0){
-        cj("#billing-payment-block").hide();
-        cj(".payment_options-group").hide();
+        $("#billing-payment-block").hide();
+        $(".payment_options-group").hide();
       }
       else {
-        cj("#billing-payment-block").show();
-        cj(".payment_options-group").show();
+        $("#billing-payment-block").show();
+        $(".payment_options-group").show();
       }
     }
 
@@ -457,12 +457,12 @@
 
   CRM.$(function($) {
     // Update pledge contribution amount when pledge checkboxes change
-    cj("input[name^='pledge_amount']").on('change', function() {
+    $("input[name^='pledge_amount']").on('change', function() {
       var total = 0;
-      cj("input[name^='pledge_amount']:checked").each(function() {
-        total += Number(cj(this).attr('amount'));
+      $("input[name^='pledge_amount']:checked").each(function() {
+        total += Number($(this).attr('amount'));
       });
-      cj("input[name^='price_']").val(total.toFixed(2));
+      $("input[name^='price_']").val(total.toFixed(2));
     });
   });
   {/literal}


### PR DESCRIPTION
CRM-17469 does the following:
Initializes the amount field on the online pledge payment form with the total of all payments that are checked. Prior to the patch, the field was blank and the user needed to calculate the total amount themselves.
Recalculates the amount field any time a payment check box changes.
Upon submission, allocates the actual amount paid to each of the selected payments, even if it results in a partial pledge payment or an over payment.

---
- [CRM-17469: Online pledge payment credits scheduled amount, not actual amount](https://issues.civicrm.org/jira/browse/CRM-17469)
