### PR TITLE
CRM-17471 Add test to prove the bug

### DIFF
--- a/tests/phpunit/CRM/Member/BAO/MembershipStatusTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipStatusTest.php
@@ -68,7 +68,7 @@ class CRM_Member_BAO_MembershipStatusTest extends CiviUnitTestCase {
     $this->assertEquals($result->name, 'testStatus', 'Verify membership status name.');
     CRM_Member_BAO_MembershipStatus::del($membershipStatus->id);
   }
-  
+
   public function testPseudoConstantflush() {
     $params = array(
       'name' => 'testStatus',
@@ -78,12 +78,12 @@ class CRM_Member_BAO_MembershipStatusTest extends CiviUnitTestCase {
     $defaults = array();
     $result = CRM_Member_BAO_MembershipStatus::retrieve($params, $defaults);
     $this->assertEquals($result->name, 'testStatus', 'Verify membership status name.');
-    $params = array(
-      'id' = $membershipStatus->id,
+    $updateParams = array(
+      'id' => $membershipStatus->id,
       'name' => 'test Status',
       'is_active' => 1,
     );
-    $membershipStatus2 = CRM_Member_BAO_MembershipStatus::add($params);
+    $membershipStatus2 = CRM_Member_BAO_MembershipStatus::add($updateParams);
     $result = CRM_Member_PseudoConstant::membershipStatus($membershipStatus->id, NULL, 'name', FALSE, FALSE);
     $this->assertEquals($result, 'test Status', 'Verify Updated Membership status name From PseduoConstant.');
     CRM_Member_BAO_MembershipStatus::del($membershipStatus->id);

--- a/tests/phpunit/CRM/Member/BAO/MembershipStatusTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipStatusTest.php
@@ -80,12 +80,13 @@ class CRM_Member_BAO_MembershipStatusTest extends CiviUnitTestCase {
     $this->assertEquals($result->name, 'testStatus', 'Verify membership status name.');
     $updateParams = array(
       'id' => $membershipStatus->id,
-      'name' => 'test Status',
+      'name' => 'testStatus',
+      'label' => 'Changed Status',
       'is_active' => 1,
     );
     $membershipStatus2 = CRM_Member_BAO_MembershipStatus::add($updateParams);
-    $result = CRM_Member_PseudoConstant::membershipStatus($membershipStatus->id, NULL, 'name', FALSE, FALSE);
-    $this->assertEquals($result, 'test Status', 'Verify Updated Membership status name From PseduoConstant.');
+    $result = CRM_Member_PseudoConstant::membershipStatus($membershipStatus->id, NULL, 'label', FALSE, FALSE);
+    $this->assertEquals($result, 'Changed Status', 'Verify Updated Membership status name From PseduoConstant.');
     CRM_Member_BAO_MembershipStatus::del($membershipStatus->id);
   }
 

--- a/tests/phpunit/CRM/Member/BAO/MembershipStatusTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipStatusTest.php
@@ -68,6 +68,26 @@ class CRM_Member_BAO_MembershipStatusTest extends CiviUnitTestCase {
     $this->assertEquals($result->name, 'testStatus', 'Verify membership status name.');
     CRM_Member_BAO_MembershipStatus::del($membershipStatus->id);
   }
+  
+  public function testPseudoConstantflush() {
+    $params = array(
+      'name' => 'testStatus',
+      'is_active' => 1,
+    );
+    $membershipStatus = CRM_Member_BAO_MembershipStatus::add($params);
+    $defaults = array();
+    $result = CRM_Member_BAO_MembershipStatus::retrieve($params, $defaults);
+    $this->assertEquals($result->name, 'testStatus', 'Verify membership status name.');
+    $params = array(
+      'id' = $membershipStatus->id,
+      'name' => 'test Status',
+      'is_active' => 1,
+    );
+    $membershipStatus2 = CRM_Member_BAO_MembershipStatus::add($params);
+    $result = CRM_Member_PseudoConstant::membershipStatus($membershipStatus->id);
+    $this->assertEquals($result, 'test Status', 'Verify Updated Membership status name From PseduoConstant.');
+    CRM_Member_BAO_MembershipStatus::del($membershipStatus->id);
+  }
 
   public function testSetIsActive() {
 

--- a/tests/phpunit/CRM/Member/BAO/MembershipStatusTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipStatusTest.php
@@ -86,7 +86,7 @@ class CRM_Member_BAO_MembershipStatusTest extends CiviUnitTestCase {
     );
     $membershipStatus2 = CRM_Member_BAO_MembershipStatus::add($updateParams);
     $result = CRM_Member_PseudoConstant::membershipStatus($membershipStatus->id, NULL, 'label', FALSE, FALSE);
-    $this->assertEquals($result, 'Changed Status', 'Verify Updated Membership status name From PseduoConstant.');
+    $this->assertEquals($result, 'Changed Status', 'Verify updated membership status label From PseudoConstant.');
     CRM_Member_BAO_MembershipStatus::del($membershipStatus->id);
   }
 

--- a/tests/phpunit/CRM/Member/BAO/MembershipStatusTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipStatusTest.php
@@ -84,7 +84,7 @@ class CRM_Member_BAO_MembershipStatusTest extends CiviUnitTestCase {
       'is_active' => 1,
     );
     $membershipStatus2 = CRM_Member_BAO_MembershipStatus::add($params);
-    $result = CRM_Member_PseudoConstant::membershipStatus($membershipStatus->id);
+    $result = CRM_Member_PseudoConstant::membershipStatus($membershipStatus->id, NULL, 'name', FALSE, FALSE);
     $this->assertEquals($result, 'test Status', 'Verify Updated Membership status name From PseduoConstant.');
     CRM_Member_BAO_MembershipStatus::del($membershipStatus->id);
   }


### PR DESCRIPTION
- [CRM-17471: Changed Membership Status(s) not displaying on Advanced Search form](https://issues.civicrm.org/jira/browse/CRM-17471)
