### PR TITLE
CRM-17393, changed the incorrect logic

### DIFF
--- a/CRM/Mailing/Info.php
+++ b/CRM/Mailing/Info.php
@@ -67,9 +67,9 @@ class CRM_Mailing_Info extends CRM_Core_Component_Info {
   public function getAngularModules() {
     // load angular files only if valid permissions are granted to the user
     if (!CRM_Core_Permission::check('access CiviMail')
-      || !CRM_Core_Permission::check('create mailings')
-      || !CRM_Core_Permission::check('schedule mailings')
-      || !CRM_Core_Permission::check('approve mailings')
+      && !CRM_Core_Permission::check('create mailings')
+      && !CRM_Core_Permission::check('schedule mailings')
+      && !CRM_Core_Permission::check('approve mailings')
     ) {
       return array();
     }


### PR DESCRIPTION
- [CRM-17393: Load CiviMail angular module files based on permission](https://issues.civicrm.org/jira/browse/CRM-17393)
