### PR TITLE
CRM-17512 Improve event sellout messages

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -1409,11 +1409,11 @@ WHERE  v.option_group_id = g.id
           }
           elseif (($optMax - $opDbCount) == 1) {
             $errors[$soldOutPnum[$optId]]["price_{$fieldId}"]
-              = ts('Sorry, currently only a single seat is available for this option.', array(1 => ($optMax - $opDbCount)));
+              = ts('Sorry, currently only a single space is available for this option.', array(1 => ($optMax - $opDbCount)));
           }
           else {
             $errors[$soldOutPnum[$optId]]["price_{$fieldId}"]
-              = ts('Sorry, currently only %1 seats are available for this option.', array(1 => ($optMax - $opDbCount)));
+              = ts('Sorry, currently only %1 spaces are available for this option.', array(1 => ($optMax - $opDbCount)));
           }
         }
       }

--- a/CRM/Event/Form/Registration/AdditionalParticipant.php
+++ b/CRM/Event/Form/Registration/AdditionalParticipant.php
@@ -476,7 +476,7 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
           if (!$self->_allowConfirmation && empty($self->_values['event']['has_waitlist']) &&
             $totalParticipants > $self->_availableRegistrations
           ) {
-            $errors['_qf_default'] = ts('It looks like event has only %2 seats available and you are trying to register %1 participants, so could you please select price options accordingly.', array(
+            $errors['_qf_default'] = ts('Sorry, it looks like this event only has %2 spaces available, and you are trying to register %1 participants. Please change your selections accordingly.', array(
                 1 => $totalParticipants,
                 2 => $self->_availableRegistrations,
               ));

--- a/tests/phpunit/WebTest/Event/PricesetMaxCountTest.php
+++ b/tests/phpunit/WebTest/Event/PricesetMaxCountTest.php
@@ -205,7 +205,7 @@ class WebTest_Event_PricesetMaxCountTest extends CiviSeleniumTestCase {
     // fill billing related info and register
     $this->_fillRegisterWithBillingInfo();
 
-    $this->assertStringsPresent(array('Sorry, currently only a single seat is available for this option.'));
+    $this->assertStringsPresent(array('Sorry, currently only a single space is available for this option.'));
 
     // fill correct value for test field
     $this->type("xpath=//input[@id='price_{$textFieldId}']", '1');

--- a/tests/phpunit/WebTest/Event/PricesetMaxCountTest.php
+++ b/tests/phpunit/WebTest/Event/PricesetMaxCountTest.php
@@ -177,7 +177,7 @@ class WebTest_Event_PricesetMaxCountTest extends CiviSeleniumTestCase {
     // fill billing related info
     $this->_fillRegisterWithBillingInfo();
 
-    $this->assertStringsPresent(array('Sorry, currently only 2 seats are available for this option.'));
+    $this->assertStringsPresent(array('Sorry, currently only 2 spaces are available for this option.'));
 
     // fill correct value for text field
     $this->type("xpath=//input[@id='price_{$textFieldId}']", '1');
@@ -370,7 +370,7 @@ class WebTest_Event_PricesetMaxCountTest extends CiviSeleniumTestCase {
     // fill billing related info
     $this->_fillRegisterWithBillingInfo();
 
-    $this->assertStringsPresent(array('Sorry, currently only 4 seats are available for this option.'));
+    $this->assertStringsPresent(array('Sorry, currently only 4 spaces are available for this option.'));
 
     $this->select("price_{$selectFieldId}", "value={$selectFieldOp1}");
 
@@ -400,7 +400,7 @@ class WebTest_Event_PricesetMaxCountTest extends CiviSeleniumTestCase {
     // fill billing related info and register
     $this->_fillRegisterWithBillingInfo();
 
-    $this->assertStringsPresent(array('Sorry, currently only 2 seats are available for this option.'));
+    $this->assertStringsPresent(array('Sorry, currently only 2 spaces are available for this option.'));
 
     // fill correct value and register
     $this->type("xpath=//input[@id='price_{$textFieldId}']", '1');
@@ -563,7 +563,7 @@ class WebTest_Event_PricesetMaxCountTest extends CiviSeleniumTestCase {
     // fill billing related info
     $this->_fillRegisterWithBillingInfo();
 
-    $this->assertStringsPresent(array('Sorry, currently only 6 seats are available for this option.'));
+    $this->assertStringsPresent(array('Sorry, currently only 6 spaces are available for this option.'));
 
     // fill correct value for text field
     $this->type("xpath=//input[@id='price_{$textFieldId}']", '1');
@@ -584,7 +584,7 @@ class WebTest_Event_PricesetMaxCountTest extends CiviSeleniumTestCase {
     $this->click('_qf_Participant_1_next-Array');
     $this->waitForPageToLoad($this->getTimeoutMsec());
 
-    $this->assertStringsPresent(array('Sorry, currently only 6 seats are available for this option.'));
+    $this->assertStringsPresent(array('Sorry, currently only 6 spaces are available for this option.'));
 
     // fill correct value for text field
     $this->type("xpath=//input[@id='price_{$textFieldId}']", '3');
@@ -605,7 +605,7 @@ class WebTest_Event_PricesetMaxCountTest extends CiviSeleniumTestCase {
     $this->click('_qf_Participant_2_next-Array');
     $this->waitForPageToLoad($this->getTimeoutMsec());
 
-    $this->assertStringsPresent(array('Sorry, currently only 6 seats are available for this option.'));
+    $this->assertStringsPresent(array('Sorry, currently only 6 spaces are available for this option.'));
 
     // fill correct value for text field
     $this->type("xpath=//input[@id='price_{$textFieldId}']", '1');
@@ -644,7 +644,7 @@ class WebTest_Event_PricesetMaxCountTest extends CiviSeleniumTestCase {
     // fill billing related info
     $this->_fillRegisterWithBillingInfo();
 
-    $this->assertStringsPresent(array('Sorry, currently only 2 seats are available for this option.'));
+    $this->assertStringsPresent(array('Sorry, currently only 2 spaces are available for this option.'));
 
     // fill correct value for text field
     $this->type("xpath=//input[@id='price_{$textFieldId}']", '1');
@@ -670,7 +670,7 @@ class WebTest_Event_PricesetMaxCountTest extends CiviSeleniumTestCase {
     $this->click('_qf_Participant_1_next-Array');
     $this->waitForPageToLoad($this->getTimeoutMsec());
 
-    $this->assertStringsPresent(array('Sorry, currently only 2 seats are available for this option.'));
+    $this->assertStringsPresent(array('Sorry, currently only 2 spaces are available for this option.'));
 
     // fill correct value for text field
     $this->type("xpath=//input[@id='price_{$textFieldId}']", '1');
@@ -840,7 +840,7 @@ class WebTest_Event_PricesetMaxCountTest extends CiviSeleniumTestCase {
     // fill billing related info
     $this->_fillRegisterWithBillingInfo();
 
-    $this->assertStringsPresent(array('Sorry, currently only 12 seats are available for this option.'));
+    $this->assertStringsPresent(array('Sorry, currently only 12 spaces are available for this option.'));
 
     // fill correct value for text field
     $this->type("xpath=//input[@id='price_{$textFieldId}']", '1');
@@ -861,7 +861,7 @@ class WebTest_Event_PricesetMaxCountTest extends CiviSeleniumTestCase {
     $this->click('_qf_Participant_1_next-Array');
     $this->waitForPageToLoad($this->getTimeoutMsec());
 
-    $this->assertStringsPresent(array('Sorry, currently only 12 seats are available for this option.'));
+    $this->assertStringsPresent(array('Sorry, currently only 12 spaces are available for this option.'));
 
     // fill correct value for text field
     $this->type("xpath=//input[@id='price_{$textFieldId}']", '3');
@@ -882,7 +882,7 @@ class WebTest_Event_PricesetMaxCountTest extends CiviSeleniumTestCase {
     $this->click('_qf_Participant_2_next-Array');
     $this->waitForPageToLoad($this->getTimeoutMsec());
 
-    $this->assertStringsPresent(array('Sorry, currently only 12 seats are available for this option.'));
+    $this->assertStringsPresent(array('Sorry, currently only 12 spaces are available for this option.'));
 
     // fill correct value for text field
     $this->type("xpath=//input[@id='price_{$textFieldId}']", '1');
@@ -921,7 +921,7 @@ class WebTest_Event_PricesetMaxCountTest extends CiviSeleniumTestCase {
     // fill billing related info
     $this->_fillRegisterWithBillingInfo();
 
-    $this->assertStringsPresent(array('Sorry, currently only 4 seats are available for this option.'));
+    $this->assertStringsPresent(array('Sorry, currently only 4 spaces are available for this option.'));
 
     // fill correct value for text field
     $this->type("xpath=//input[@id='price_{$textFieldId}']", '1');
@@ -947,7 +947,7 @@ class WebTest_Event_PricesetMaxCountTest extends CiviSeleniumTestCase {
     $this->click('_qf_Participant_1_next-Array');
     $this->waitForPageToLoad($this->getTimeoutMsec());
 
-    $this->assertStringsPresent(array('Sorry, currently only 4 seats are available for this option.'));
+    $this->assertStringsPresent(array('Sorry, currently only 4 spaces are available for this option.'));
 
     // fill correct value for text field
     $this->type("xpath=//input[@id='price_{$textFieldId}']", '1');


### PR DESCRIPTION
- [CRM-17512: Event selections message: 'spaces' not 'seats'](https://issues.civicrm.org/jira/browse/CRM-17512)
