### PR TITLE
Issues with printing reports

### DIFF
--- a/CRM/Report/Form/Instance.php
+++ b/CRM/Report/Form/Instance.php
@@ -237,8 +237,12 @@ class CRM_Report_Form_Instance {
     if ($instanceID) {
       // this is already retrieved via Form.php
       $defaults['description'] = CRM_Utils_Array::value('description', $defaults);
-      $defaults['report_header'] = CRM_Utils_Array::value('header', $defaults);
-      $defaults['report_footer'] = CRM_Utils_Array::value('footer', $defaults);
+      if (!empty($defaults['header'])) {
+        $defaults['report_header'] = $defaults['header'];
+      }
+      if (!empty($defaults['footer'])) {
+        $defaults['report_footer'] = $defaults['footer'];
+      }
 
       if (!empty($defaults['navigation_id'])) {
         // Get the default navigation parent id.

--- a/css/print.css
+++ b/css/print.css
@@ -74,7 +74,7 @@ table.form-layout td, table.form-layout th {
    border-top       : 2px groove #DCDCDC;
 }
 
-#crm-container table.report-layout tr.crm-report-sectionHeader.page-break {
+#crm-container table.report-layout.page-break {
   page-break-before: always;
 }
 

--- a/css/print.css
+++ b/css/print.css
@@ -74,8 +74,9 @@ table.form-layout td, table.form-layout th {
    border-top       : 2px groove #DCDCDC;
 }
 
-#crm-container table.report-layout.page-break {
+#crm-container div.page-break {
   page-break-before: always;
+  height: 0;
 }
 
 #crm-container .report-label {

--- a/templates/CRM/Report/Form/Layout/Table.tpl
+++ b/templates/CRM/Report/Form/Layout/Table.tpl
@@ -85,7 +85,8 @@
                       {if $section.pageBreak}
                         {$l}if $pageBroke >= {$h} or $pageBroke == 0{$r}
                           </table>
-                          <table class="report-layout display page-break">
+                          <div class="page-break"></div>
+                          <table class="report-layout display">
                         {$l}/if{$r}
                         {$l}assign var=pageBroke value={$h}{$r}
                       {/if}

--- a/templates/CRM/Report/Form/Layout/Table.tpl
+++ b/templates/CRM/Report/Form/Layout/Table.tpl
@@ -68,6 +68,7 @@
             {assign var=columnCount value=$columnHeaders|@count}
             {assign var=l value=$smarty.ldelim}
             {assign var=r value=$smarty.rdelim}
+            {assign var=pageBroke value=0}
             {foreach from=$sections item=section key=column name=sections}
                 {counter assign="h"}
                 {$l}isValueChange value=$row.{$column} key="{$column}" assign=isValueChanged{$r}
@@ -80,8 +81,17 @@
                     {$l}else{$r}
                         {$l}assign var=printValue value=$row.{$column}{$r}
                     {$l}/if{$r}
+                    {$l}if $rowid neq 0{$r}
+                      {if $section.pageBreak}
+                        {$l}if $pageBroke >= {$h} or $pageBroke == 0{$r}
+                          </table>
+                          <table class="report-layout display page-break">
+                        {$l}/if{$r}
+                        {$l}assign var=pageBroke value={$h}{$r}
+                      {/if}
+                    {$l}/if{$r}
+                    <tr class="crm-report-sectionHeader crm-report-sectionHeader-{$h}"><th colspan="{$columnCount}">
 
-                    <tr class="crm-report-sectionHeader crm-report-sectionHeader-{$h}{if $section.pageBreak} page-break{/if}"><th colspan="{$columnCount}">
                         <h{$h}>{$section.title}: {$l}$printValue|default:"<em>none</em>"{$r}
                             ({$l}sectionTotal key=$row.{$column} depth={$smarty.foreach.sections.index}{$r})
                         </h{$h}>


### PR DESCRIPTION
Two things relating to page break on reports:
1. Reports without headers saved would have the header field on the Title and Format tab empty, rather than the default.  No header, no CSS.  No CSS, no page breaks.
2. Page breaks were not working on Chrome because Webkit doesn't want to break up the table.  The PDF generator was also funky.  Firefox was working fine.  Now, the table is closed, a page-break div is inserted, and a new table is opened if there's a section with a page break.
