### PR TITLE
CRM-17177. die() instead of trigger_error() when accessed via web.

### DIFF
--- a/bin/cli.class.php
+++ b/bin/cli.class.php
@@ -88,7 +88,7 @@ class civicrm_cli {
       return TRUE;
     }
     else {
-      trigger_error("cli.php can only be run from command line.", E_USER_ERROR);
+      die("cli.php can only be run from command line.");
     }
   }
 


### PR DESCRIPTION
- [CRM-17177](https://issues.civicrm.org/jira/browse/CRM-17177)
