### PR TITLE
CRM-17536 fix quicksearch label for when email search is disabled

### DIFF
--- a/CRM/Admin/Page/AJAX.php
+++ b/CRM/Admin/Page/AJAX.php
@@ -46,7 +46,9 @@ class CRM_Admin_Page_AJAX {
     $contactID = CRM_Core_Session::singleton()->get('userID');
     if ($contactID) {
       CRM_Core_Page_AJAX::setJsHeaders();
-      print CRM_Core_Smarty::singleton()->fetchWith('CRM/common/navigation.js.tpl', array(
+      $smarty = CRM_Core_Smarty::singleton();
+      $smarty->assign('includeEmail', civicrm_api3('setting', 'getvalue', array('name' => 'includeEmailInName', 'group' => 'Search Preferences')));
+      print $smarty->fetchWith('CRM/common/navigation.js.tpl', array(
         'navigation' => CRM_Core_BAO_Navigation::createNavigation($contactID),
       ));
     }

--- a/templates/CRM/common/navigation.js.tpl
+++ b/templates/CRM/common/navigation.js.tpl
@@ -37,8 +37,8 @@
           </div>
         </form>
         <ul>
-          <li><label class="crm-quickSearchField"><input type="radio" data-tablename="cc" checked="checked" value="" name="quickSearchField">{ts}Name/Email{/ts}</label></li>
-          <li><label class="crm-quickSearchField"><input type="radio" data-tablename="cc" value="contact_id" name="quickSearchField">{ts}CiviCRM ID{/ts}</label></li>
+          <li><label class="crm-quickSearchField"><input type="radio" data-tablename="cc" checked="checked" value="" name="quickSearchField">{if $includeEmail}{ts}Name/Email{/ts}{else}{ts}Name{/ts}{/if}</label></li>
+          <li><label class="crm-quickSearchField"><input type="radio" data-tablename="cc" value="contact_id" name="quickSearchField">{ts}Contact ID{/ts}</label></li>
           <li><label class="crm-quickSearchField"><input type="radio" data-tablename="cc" value="external_identifier" name="quickSearchField">{ts}External ID{/ts}</label></li>
           <li><label class="crm-quickSearchField"><input type="radio" data-tablename="cc" value="first_name" name="quickSearchField">{ts}First Name{/ts}</label></li>
           <li><label class="crm-quickSearchField"><input type="radio" data-tablename="cc" value="last_name" name="quickSearchField">{ts}Last Name{/ts}</label></li>


### PR DESCRIPTION
Bug: T118036

(note the change of label from CIviCRM ID to contact ID is already in master - it seemed to make sense to sync that while doing this)

---
- [CRM-17536: Label for name search is called 'Name\/Email' even when email searching is turned off](https://issues.civicrm.org/jira/browse/CRM-17536)
