### PR TITLE
Fix js error on contribution page

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -499,13 +499,13 @@
 
   function skipPaymentMethod() {
     var flag = false;
-    cj('.price-set-option-content input').each( function(){
+    cj('.price-set-option-content input[data-amount]').each( function(){
       currentTotal = cj(this).attr('data-amount').replace(/[^\/\d]/g,'');
       if( cj(this).is(':checked') && currentTotal == 0 ) {
           flag = true;
       }
     });
-    cj('.price-set-option-content input').change( function () {
+    cj('.price-set-option-content input[data-amount]').change( function () {
       if (cj(this).attr('data-amount').replace(/[^\/\d]/g,'') == 0 ) {
         flag = true;
       } else {


### PR DESCRIPTION
https://issues.civicrm.org/jira/browse/CRM-16527?focusedCommentId=81537&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-81537

It looks like CRM-16527's backport in 4.4.20, but it causes this JS error:

TypeError: undefined is not an object (evaluating 'cj(this).attr('data-amount').replace')

When there is a "No thank you" option for additional contribution.

I fixed this by cherry-picking commit 06165b2f95c293f4d075958a55f1f1b61cf58abf onto the 4.4 branch.
