### PR TITLE
CRM-17537 use name label only when search excludes email

### DIFF
--- a/CRM/Activity/Form/Search.php
+++ b/CRM/Activity/Form/Search.php
@@ -166,7 +166,7 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
    */
   public function buildQuickForm() {
     parent::buildQuickForm();
-    $this->addElement('text', 'sort_name', ts('Name or Email'), CRM_Core_DAO::getAttribute('CRM_Contact_DAO_Contact', 'sort_name'));
+    $this->addSortNameField();
 
     CRM_Activity_BAO_Query::buildSearchForm($this);
 

--- a/CRM/Case/Form/Search.php
+++ b/CRM/Case/Form/Search.php
@@ -171,11 +171,7 @@ class CRM_Case_Form_Search extends CRM_Core_Form_Search {
    */
   public function buildQuickForm() {
     parent::buildQuickForm();
-    $this->addElement('text',
-      'sort_name',
-      ts('Client Name or Email'),
-      CRM_Core_DAO::getAttribute('CRM_Contact_DAO_Contact', 'sort_name')
-    );
+    $this->addSortNameField();
 
     CRM_Case_BAO_Query::buildSearchForm($this);
 
@@ -199,6 +195,28 @@ class CRM_Case_Form_Search extends CRM_Core_Form_Search {
       $this->addTaskMenu($tasks);
     }
 
+  }
+
+  /**
+   * Get the label for the sortName field if email searching is on.
+   *
+   * (email searching is a setting under search preferences).
+   *
+   * @return string
+   */
+  protected function getSortNameLabelWithEmail() {
+    return ts('Client Name or email');
+  }
+
+  /**
+   * Get the label for the sortName field if email searching is off.
+   *
+   * (email searching is a setting under search preferences).
+   *
+   * @return string
+   */
+  protected function getSortNameLabelWithOutEmail() {
+    return ts('Client Name');
   }
 
   /**

--- a/CRM/Contact/Form/Search/Basic.php
+++ b/CRM/Contact/Form/Search/Basic.php
@@ -57,10 +57,7 @@ class CRM_Contact_Form_Search_Basic extends CRM_Contact_Form_Search {
    * @return void
    */
   public function buildQuickForm() {
-    // text for sort_name or email criteria
-    $config = CRM_Core_Config::singleton();
-    $label = empty($config->includeEmailInName) ? ts('Name') : ts('Name or Email');
-    $this->add('text', 'sort_name', $label);
+    $this->addSortNameField();
 
     $searchOptions = CRM_Core_BAO_Setting::valueOptions(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
       'advanced_search_options'

--- a/CRM/Contribute/Form/Search.php
+++ b/CRM/Contribute/Form/Search.php
@@ -168,14 +168,7 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
    */
   public function buildQuickForm() {
     parent::buildQuickForm();
-    // text for sort_name
-    $this->addElement('text',
-      'sort_name',
-      ts('Contributor Name or Email'),
-      CRM_Core_DAO::getAttribute('CRM_Contact_DAO_Contact',
-        'sort_name'
-      )
-    );
+    $this->addSortNameField();
 
     $this->_group = CRM_Core_PseudoConstant::nestedGroup();
 
@@ -214,6 +207,28 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
       $this->addTaskMenu($tasks);
     }
 
+  }
+
+  /**
+   * Get the label for the sortName field if email searching is on.
+   *
+   * (email searching is a setting under search preferences).
+   *
+   * @return string
+   */
+  protected function getSortNameLabelWithEmail() {
+    return ts('Contributor Name or email');
+  }
+
+  /**
+   * Get the label for the sortName field if email searching is off.
+   *
+   * (email searching is a setting under search preferences).
+   *
+   * @return string
+   */
+  protected function getSortNameLabelWithOutEmail() {
+    return ts('Contributor Name');
   }
 
   /**

--- a/CRM/Core/Form/Search.php
+++ b/CRM/Core/Form/Search.php
@@ -150,4 +150,44 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
     }
   }
 
+  /**
+   * Add the sort-name field to the form.
+   *
+   * There is a setting to determine whether email is included in the search & we look this up to determine
+   * which text to choose.
+   *
+   * Note that for translation purposes the full string works better than using 'prefix' hence we use override-able functions
+   * to define the string.
+   */
+  protected function addSortNameField() {
+    $this->addElement(
+      'text',
+      'sort_name',
+      civicrm_api3('setting', 'getvalue', array('name' => 'includeEmailInName', 'group' => 'Search Preferences')) ? $this->getSortNameLabelWithEmail() : $this->getSortNameLabelWithOutEmail(),
+      CRM_Core_DAO::getAttribute('CRM_Contact_DAO_Contact', 'sort_name')
+    );
+  }
+
+  /**
+   * Get the label for the sortName field if email searching is on.
+   *
+   * (email searching is a setting under search preferences).
+   *
+   * @return string
+   */
+  protected function getSortNameLabelWithEmail() {
+    return ts('Name or email');
+  }
+
+  /**
+   * Get the label for the sortName field if email searching is off.
+   *
+   * (email searching is a setting under search preferences).
+   *
+   * @return string
+   */
+  protected function getSortNameLabelWithOutEmail() {
+    return ts('Name');
+  }
+
 }

--- a/CRM/Event/Form/Search.php
+++ b/CRM/Event/Form/Search.php
@@ -170,7 +170,7 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
    */
   public function buildQuickForm() {
     parent::buildQuickForm();
-    $this->addElement('text', 'sort_name', ts('Participant Name or Email'), CRM_Core_DAO::getAttribute('CRM_Contact_DAO_Contact', 'sort_name'));
+    $this->addSortNameField();
 
     CRM_Event_BAO_Query::buildSearchForm($this);
 
@@ -239,6 +239,28 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
       $this->addTaskMenu($tasks);
     }
 
+  }
+
+  /**
+   * Get the label for the sortName field if email searching is on.
+   *
+   * (email searching is a setting under search preferences).
+   *
+   * @return string
+   */
+  protected function getSortNameLabelWithEmail() {
+    return ts('Participant Name or email');
+  }
+
+  /**
+   * Get the label for the sortName field if email searching is off.
+   *
+   * (email searching is a setting under search preferences).
+   *
+   * @return string
+   */
+  protected function getSortNameLabelWithOutEmail() {
+    return ts('Participant Name');
   }
 
   /**

--- a/CRM/Grant/Form/Search.php
+++ b/CRM/Grant/Form/Search.php
@@ -162,7 +162,7 @@ class CRM_Grant_Form_Search extends CRM_Core_Form_Search {
    */
   public function buildQuickForm() {
     parent::buildQuickForm();
-    $this->addElement('text', 'sort_name', ts('Name or Email'), array('class' => 'twenty') + CRM_Core_DAO::getAttribute('CRM_Contact_DAO_Contact', 'sort_name'));
+    $this->addSortNameField();
 
     CRM_Grant_BAO_Query::buildSearchForm($this);
 

--- a/CRM/Member/Form/Search.php
+++ b/CRM/Member/Form/Search.php
@@ -160,7 +160,7 @@ class CRM_Member_Form_Search extends CRM_Core_Form_Search {
    */
   public function buildQuickForm() {
     parent::buildQuickForm();
-    $this->addElement('text', 'sort_name', ts('Member Name or Email'), CRM_Core_DAO::getAttribute('CRM_Contact_DAO_Contact', 'sort_name'));
+    $this->addSortNameField();
 
     CRM_Member_BAO_Query::buildSearchForm($this);
 
@@ -175,6 +175,28 @@ class CRM_Member_Form_Search extends CRM_Core_Form_Search {
       $this->addTaskMenu(CRM_Member_Task::permissionedTaskTitles($permission));
     }
 
+  }
+
+  /**
+   * Get the label for the sortName field if email searching is on.
+   *
+   * (email searching is a setting under search preferences).
+   *
+   * @return string
+   */
+  protected function getSortNameLabelWithEmail() {
+    return ts('Member Name or email');
+  }
+
+  /**
+   * Get the label for the sortName field if email searching is off.
+   *
+   * (email searching is a setting under search preferences).
+   *
+   * @return string
+   */
+  protected function getSortNameLabelWithOutEmail() {
+    return ts('Member Name');
   }
 
   /**

--- a/CRM/Pledge/Form/Search.php
+++ b/CRM/Pledge/Form/Search.php
@@ -158,7 +158,7 @@ class CRM_Pledge_Form_Search extends CRM_Core_Form_Search {
    */
   public function buildQuickForm() {
     parent::buildQuickForm();
-    $this->addElement('text', 'sort_name', ts('Pledger Name or Email'), CRM_Core_DAO::getAttribute('CRM_Contact_DAO_Contact', 'sort_name'));
+    $this->addSortNameField();
 
     CRM_Pledge_BAO_Query::buildSearchForm($this);
 
@@ -173,6 +173,28 @@ class CRM_Pledge_Form_Search extends CRM_Core_Form_Search {
       $this->addTaskMenu(CRM_Pledge_Task::permissionedTaskTitles($permission));
     }
 
+  }
+
+  /**
+   * Get the label for the sortName field if email searching is on.
+   *
+   * (email searching is a setting under search preferences).
+   *
+   * @return string
+   */
+  protected function getSortNameLabelWithEmail() {
+    return ts('Pledger Name or email');
+  }
+
+  /**
+   * Get the label for the sortName field if email searching is off.
+   *
+   * (email searching is a setting under search preferences).
+   *
+   * @return string
+   */
+  protected function getSortNameLabelWithOutEmail() {
+    return ts('Pledger Name');
   }
 
   /**


### PR DESCRIPTION
- [CRM-17537: Search screens use 'Name or Email' label when search setting is name only](https://issues.civicrm.org/jira/browse/CRM-17537)
