### PR TITLE
CRM-17542 fix fatal on pay-later with separate membership

### DIFF
--- a/CRM/Core/Payment/Manual.php
+++ b/CRM/Core/Payment/Manual.php
@@ -155,4 +155,13 @@ class CRM_Core_Payment_Manual extends CRM_Core_Payment {
     return '';
   }
 
+  /**
+   * Declare that more than one payment can be processed at once.
+   *
+   * @return bool
+   */
+  protected function supportsMultipleConcurrentPayments() {
+    return TRUE;
+  }
+
 }

--- a/CRM/Financial/BAO/PaymentProcessor.php
+++ b/CRM/Financial/BAO/PaymentProcessor.php
@@ -314,6 +314,8 @@ class CRM_Financial_BAO_PaymentProcessor extends CRM_Financial_DAO_PaymentProces
       'name' => 'pay_later',
       'billing_mode' => '',
       'is_default' => 0,
+      // This should ideally be retrieved from the DB but existing default is check so we'll code that for now.
+      'payment_instrument_id' => CRM_Core_OptionGroup::getValue('payment_instrument', 'Check', 'name'),
       // Making this optionally recur would give lots of options -but it should
       // be a row in the payment processor table before we do that.
       'is_recur' => FALSE,


### PR DESCRIPTION
- [CRM-17542: Contribution page configured with 'Separate Membership Payment = TRUE' throws fatal error on chosing pay-later](https://issues.civicrm.org/jira/browse/CRM-17542)
