### PR TITLE
CRM-14126: Updating HttpClient to use HttpGuzzle instead of CURL

### DIFF
--- a/CRM/Extension/Downloader.php
+++ b/CRM/Extension/Downloader.php
@@ -83,11 +83,6 @@ class CRM_Extension_Downloader {
       );
     }
 
-    if (empty($errors) && !CRM_Utils_HttpClient::singleton()->isRedirectSupported()) {
-      CRM_Core_Session::setStatus(ts('WARNING: The downloader may be unable to download files which require HTTP redirection. This may be a configuration issue with PHP\'s open_basedir or safe_mode.'));
-      CRM_Core_Error::debug_log_message('WARNING: The downloader may be unable to download files which require HTTP redirection. This may be a configuration issue with PHP\'s open_basedir or safe_mode.');
-    }
-
     return $errors;
   }
 

--- a/CRM/Utils/HttpClient.php
+++ b/CRM/Utils/HttpClient.php
@@ -35,6 +35,8 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
+ * $Id$
+ *
  */
 class CRM_Utils_HttpClient {
 
@@ -47,17 +49,14 @@ class CRM_Utils_HttpClient {
    */
   protected static $singleton;
 
+
+  protected $sslCertificatePath;
+
   /**
-   * @var int|NULL
-   *   seconds; or NULL to use system default
+   * @var int|NULL seconds; or NULL to use system default
    */
   protected $connectionTimeout;
 
-  /**
-   * @var string
-   */
-  protected static $sslCertificatePath;
-  
   /**
    * @return CRM_Utils_HttpClient
    */
@@ -73,7 +72,7 @@ class CRM_Utils_HttpClient {
    */
   public function __construct($connectionTimeout = NULL) {
     $this->connectionTimeout = $connectionTimeout;
-	$this->sslCertificatePath = dirname(dirname(__DIR__)).'/vendor/totten/ca-config/src/CA/Config/cacert.pem';
+    $this->sslCertificatePath = dirname(dirname(__DIR__)) . '/vendor/totten/ca-config/src/CA/Config/cacert.pem';
   }
 
   /**
@@ -87,33 +86,34 @@ class CRM_Utils_HttpClient {
    */
   public function fetch($remoteFile, $localFile) {
     // Download extension zip file ...
-	$caConfig = $this->getCaConfig();
-	
-	if (preg_match('/^https:/', $remoteFile) && !$caConfig->isEnableSSL()) {
+    $caConfig = $this->getCaConfig();
+
+    if (preg_match('/^https:/', $remoteFile) && !$caConfig->isEnableSSL()) {
       CRM_Core_Error::fatal('Cannot install this extension - does not support SSL');
     }
-	
+
     $fp = @fopen($localFile, "w");
     if (!$fp) {
       CRM_Core_Session::setStatus(ts('Unable to write to %1.<br />Is the location writable?', array(1 => $localFile)), ts('Write Error'), 'error');
       return self::STATUS_WRITE_ERROR;
     }
-	$guzzleClient = new GuzzleHttp\Client();
-	try {
-		$guzzleClient->get($remoteFile, array(
-			'headers' => array('Accept-Encoding' => 'gzip'),
-			'debug' => false,
-			'save_to' => $localFile,
-			'verify' => $this->sslCertificatePath
-    ));
-	} catch (GuzzleHttp\Exception\ClientException $e) {
-		$response = $e->getResponse();
-		$errorMessage = $response->getStatusCode()." - ".$response->getReasonPhrase();
-		CRM_Core_Session::setStatus(ts('Unable to download extension from %1. Error Message: %2',
-			array(1 => $remoteFile, 2 => $errorMessage)), ts('Extension Download Error'), 'error');
-		return self::STATUS_DL_ERROR;
-	}
-	
+    $guzzleClient = new GuzzleHttp\Client();
+    try {
+      $guzzleClient->get($remoteFile, array(
+        'headers' => array('Accept-Encoding' => 'gzip'),
+        'debug' => FALSE,
+        'save_to' => $localFile,
+        'verify' => $this->sslCertificatePath,
+      ));
+    }
+    catch (GuzzleHttp\Exception\ClientException $e) {
+      $response = $e->getResponse();
+      $errorMessage = $response->getStatusCode() . " - " . $response->getReasonPhrase();
+      CRM_Core_Session::setStatus(ts('Unable to download extension from %1. Error Message: %2',
+      array(1 => $remoteFile, 2 => $errorMessage)), ts('Extension Download Error'), 'error');
+      return self::STATUS_DL_ERROR;
+    }
+
     fclose($fp);
 
     return self::STATUS_OK;
@@ -131,25 +131,26 @@ class CRM_Utils_HttpClient {
     // Download extension zip file ...
 
     $caConfig = $this->getCaConfig();
-	
+
     if (preg_match('/^https:/', $remoteFile) && !$caConfig->isEnableSSL()) {
       //CRM_Core_Error::fatal('Cannot install this extension - does not support SSL');
       return array(self::STATUS_DL_ERROR, NULL);
     }
 
-	$guzzleClient = new GuzzleHttp\Client();
-	try {
-		$data = $guzzleClient->get($remoteFile, array(
-			'headers' => array('Accept-Encoding' => 'gzip'),
-			'debug' => false,
-			'verify' => $this->sslCertificatePath
-		))->getBody();
-		return array(self::STATUS_OK, $data);
-	} catch (GuzzleHttp\Exception\ClientException $e) {
-		$response = $e->getResponse();
-		$data = $response->getStatusCode()." - ".$response->getReasonPhrase();
-		return array(self::STATUS_DL_ERROR, $data);
-	}
+    $guzzleClient = new GuzzleHttp\Client();
+    try {
+      $data = $guzzleClient->get($remoteFile, array(
+        'headers' => array('Accept-Encoding' => 'gzip'),
+        'debug' => FALSE,
+        'verify' => $this->sslCertificatePath,
+        ))->getBody();
+      return array(self::STATUS_OK, $data);
+    }
+    catch (GuzzleHttp\Exception\ClientException $e) {
+      $response = $e->getResponse();
+      $data = $response->getStatusCode() . " - " . $response->getReasonPhrase();
+      return array(self::STATUS_DL_ERROR, $data);
+    }
 
   }
 
@@ -167,38 +168,39 @@ class CRM_Utils_HttpClient {
     // Download extension zip file ...
 
     $caConfig = $this->getCaConfig();
-	
+
     if (preg_match('/^https:/', $remoteFile) && !$caConfig->isEnableSSL()) {
       //CRM_Core_Error::fatal('Cannot install this extension - does not support SSL');
       return array(self::STATUS_DL_ERROR, NULL);
     }
-	
-	$guzzleClient = new GuzzleHttp\Client();
-	try {
-		$data = $guzzleClient->post($remoteFile, array(
-			'headers' => array('Accept-Encoding' => 'gzip'),
-			'debug' => false,
-			'verify' => $this->sslCertificatePath,
-			'body' => $params
-		))->getBody();
-		return array(self::STATUS_OK, $data);
-	} catch (GuzzleHttp\Exception\ClientException $e) {
-		$response = $e->getResponse();
-		$data = $response->getStatusCode()." - ".$response->getReasonPhrase();
-		return array(self::STATUS_DL_ERROR, $data);
-	}
+
+    $guzzleClient = new GuzzleHttp\Client();
+    try {
+      $data = $guzzleClient->post($remoteFile, array(
+        'headers' => array('Accept-Encoding' => 'gzip'),
+        'debug' => FALSE,
+        'verify' => $this->sslCertificatePath,
+        'body' => $params,
+      ))->getBody();
+      return array(self::STATUS_OK, $data);
+    }
+    catch (GuzzleHttp\Exception\ClientException $e) {
+      $response = $e->getResponse();
+      $data = $response->getStatusCode() . " - " . $response->getReasonPhrase();
+      return array(self::STATUS_DL_ERROR, $data);
+    }
 
   }
 
-  
   /**
-   * @return CA_Config_Curl
+   * @return array
+   *   (0 => resource, 1 => CA_Config_Curl)
    */
   protected function getCaConfig() {
     $caConfig = CA_Config_Curl::probe(array(
-      'verify_peer' => (bool) CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME, 'verifySSL'),
+      'verify_peer' => (bool) Civi::settings()->get('verifySSL'),
     ));
-	return $caConfig;
+    return $caConfig;
   }
 
 }

--- a/CRM/Utils/HttpClient.php
+++ b/CRM/Utils/HttpClient.php
@@ -38,7 +38,7 @@
  * $Id$
  *
  */
-require_once dirname(__DIR__) . '/vendor/autoload.php';
+require_once dirname(dirname(__DIR__)) . '/vendor/autoload.php';
 
 class CRM_Utils_HttpClient {
 

--- a/CRM/Utils/HttpClient.php
+++ b/CRM/Utils/HttpClient.php
@@ -38,6 +38,8 @@
  * $Id$
  *
  */
+require_once dirname(__DIR__) . '/vendor/autoload.php';
+
 class CRM_Utils_HttpClient {
 
   const STATUS_OK = 'ok';

--- a/CRM/Utils/HttpClient.php
+++ b/CRM/Utils/HttpClient.php
@@ -54,6 +54,11 @@ class CRM_Utils_HttpClient {
   protected $connectionTimeout;
 
   /**
+   * @var string
+   */
+  protected static $sslCertificatePath;
+  
+  /**
    * @return CRM_Utils_HttpClient
    */
   public static function singleton() {
@@ -68,6 +73,7 @@ class CRM_Utils_HttpClient {
    */
   public function __construct($connectionTimeout = NULL) {
     $this->connectionTimeout = $connectionTimeout;
+	$this->sslCertificatePath = dirname(dirname(__DIR__)).'/vendor/totten/ca-config/src/CA/Config/cacert.pem';
   }
 
   /**
@@ -81,34 +87,33 @@ class CRM_Utils_HttpClient {
    */
   public function fetch($remoteFile, $localFile) {
     // Download extension zip file ...
-    if (!function_exists('curl_init')) {
-      CRM_Core_Error::fatal('Cannot install this extension - curl is not installed!');
-    }
-
-    list($ch, $caConfig) = $this->createCurl($remoteFile);
-    if (preg_match('/^https:/', $remoteFile) && !$caConfig->isEnableSSL()) {
+	$caConfig = $this->getCaConfig();
+	
+	if (preg_match('/^https:/', $remoteFile) && !$caConfig->isEnableSSL()) {
       CRM_Core_Error::fatal('Cannot install this extension - does not support SSL');
     }
-
+	
     $fp = @fopen($localFile, "w");
     if (!$fp) {
-      // Fixme: throw error instead of setting message
       CRM_Core_Session::setStatus(ts('Unable to write to %1.<br />Is the location writable?', array(1 => $localFile)), ts('Write Error'), 'error');
       return self::STATUS_WRITE_ERROR;
     }
-    curl_setopt($ch, CURLOPT_FILE, $fp);
-
-    curl_exec($ch);
-    if (curl_errno($ch)) {
-      // Fixme: throw error instead of setting message
-      CRM_Core_Session::setStatus(ts('Unable to download extension from %1. Error Message: %2',
-        array(1 => $remoteFile, 2 => curl_error($ch))), ts('Extension download error'), 'error');
-      return self::STATUS_DL_ERROR;
-    }
-    else {
-      curl_close($ch);
-    }
-
+	$guzzleClient = new GuzzleHttp\Client();
+	try {
+		$guzzleClient->get($remoteFile, array(
+			'headers' => array('Accept-Encoding' => 'gzip'),
+			'debug' => false,
+			'save_to' => $localFile,
+			'verify' => $this->sslCertificatePath
+    ));
+	} catch (GuzzleHttp\Exception\ClientException $e) {
+		$response = $e->getResponse();
+		$errorMessage = $response->getStatusCode()." - ".$response->getReasonPhrase();
+		CRM_Core_Session::setStatus(ts('Unable to download extension from %1. Error Message: %2',
+			array(1 => $remoteFile, 2 => $errorMessage)), ts('Extension Download Error'), 'error');
+		return self::STATUS_DL_ERROR;
+	}
+	
     fclose($fp);
 
     return self::STATUS_OK;
@@ -124,32 +129,28 @@ class CRM_Utils_HttpClient {
    */
   public function get($remoteFile) {
     // Download extension zip file ...
-    if (!function_exists('curl_init')) {
-      // CRM-13805
-      CRM_Core_Session::setStatus(
-        ts('As a result, actions like retrieving the CiviCRM news feed will fail. Talk to your server administrator or hosting company to rectify this.'),
-        ts('Curl is not installed')
-      );
-      return array(self::STATUS_DL_ERROR, NULL);
-    }
 
-    list($ch, $caConfig) = $this->createCurl($remoteFile);
-
+    $caConfig = $this->getCaConfig();
+	
     if (preg_match('/^https:/', $remoteFile) && !$caConfig->isEnableSSL()) {
-      // CRM_Core_Error::fatal('Cannot install this extension - does not support SSL');
+      //CRM_Core_Error::fatal('Cannot install this extension - does not support SSL');
       return array(self::STATUS_DL_ERROR, NULL);
     }
 
-    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-    $data = curl_exec($ch);
-    if (curl_errno($ch)) {
-      return array(self::STATUS_DL_ERROR, $data);
-    }
-    else {
-      curl_close($ch);
-    }
+	$guzzleClient = new GuzzleHttp\Client();
+	try {
+		$data = $guzzleClient->get($remoteFile, array(
+			'headers' => array('Accept-Encoding' => 'gzip'),
+			'debug' => false,
+			'verify' => $this->sslCertificatePath
+		))->getBody();
+		return array(self::STATUS_OK, $data);
+	} catch (GuzzleHttp\Exception\ClientException $e) {
+		$response = $e->getResponse();
+		$data = $response->getStatusCode()." - ".$response->getReasonPhrase();
+		return array(self::STATUS_DL_ERROR, $data);
+	}
 
-    return array(self::STATUS_OK, $data);
   }
 
   /**
@@ -164,66 +165,40 @@ class CRM_Utils_HttpClient {
    */
   public function post($remoteFile, $params) {
     // Download extension zip file ...
-    if (!function_exists('curl_init')) {
-      //CRM_Core_Error::fatal('Cannot install this extension - curl is not installed!');
-      return array(self::STATUS_DL_ERROR, NULL);
-    }
 
-    list($ch, $caConfig) = $this->createCurl($remoteFile);
-
+    $caConfig = $this->getCaConfig();
+	
     if (preg_match('/^https:/', $remoteFile) && !$caConfig->isEnableSSL()) {
-      // CRM_Core_Error::fatal('Cannot install this extension - does not support SSL');
+      //CRM_Core_Error::fatal('Cannot install this extension - does not support SSL');
       return array(self::STATUS_DL_ERROR, NULL);
     }
+	
+	$guzzleClient = new GuzzleHttp\Client();
+	try {
+		$data = $guzzleClient->post($remoteFile, array(
+			'headers' => array('Accept-Encoding' => 'gzip'),
+			'debug' => false,
+			'verify' => $this->sslCertificatePath,
+			'body' => $params
+		))->getBody();
+		return array(self::STATUS_OK, $data);
+	} catch (GuzzleHttp\Exception\ClientException $e) {
+		$response = $e->getResponse();
+		$data = $response->getStatusCode()." - ".$response->getReasonPhrase();
+		return array(self::STATUS_DL_ERROR, $data);
+	}
 
-    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-    curl_setopt($ch, CURLOPT_POST, TRUE);
-    curl_setopt($ch, CURLOPT_POST, count($params));
-    curl_setopt($ch, CURLOPT_POSTFIELDS, $params);
-    $data = curl_exec($ch);
-    if (curl_errno($ch)) {
-      return array(self::STATUS_DL_ERROR, $data);
-    }
-    else {
-      curl_close($ch);
-    }
-
-    return array(self::STATUS_OK, $data);
   }
 
+  
   /**
-   * @param string $remoteFile
-   * @return array
-   *   (0 => resource, 1 => CA_Config_Curl)
+   * @return CA_Config_Curl
    */
-  protected function createCurl($remoteFile) {
+  protected function getCaConfig() {
     $caConfig = CA_Config_Curl::probe(array(
       'verify_peer' => (bool) CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME, 'verifySSL'),
     ));
-
-    $ch = curl_init();
-    curl_setopt($ch, CURLOPT_URL, $remoteFile);
-    curl_setopt($ch, CURLOPT_HEADER, FALSE);
-    curl_setopt($ch, CURLOPT_ENCODING, 'gzip');
-    curl_setopt($ch, CURLOPT_VERBOSE, 0);
-    if ($this->isRedirectSupported()) {
-      curl_setopt($ch, CURLOPT_FOLLOWLOCATION, TRUE);
-    }
-    if ($this->connectionTimeout !== NULL) {
-      curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $this->connectionTimeout);
-    }
-    if (preg_match('/^https:/', $remoteFile) && $caConfig->isEnableSSL()) {
-      curl_setopt_array($ch, $caConfig->toCurlOptions());
-    }
-
-    return array($ch, $caConfig);
-  }
-
-  /**
-   * @return bool
-   */
-  public function isRedirectSupported() {
-    return (ini_get('open_basedir') == '') && (ini_get('safe_mode') == 'Off' || ini_get('safe_mode') == '' || ini_get('safe_mode') === FALSE);
+	return $caConfig;
   }
 
 }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     "symfony/finder": "~2.5.0",
     "totten/ca-config": "~13.02",
     "civicrm/civicrm-cxn-rpc": "~0.15.07.27",
-    "iats-payments/civicrm": "~1.4.2"
+    "iats-payments/civicrm": "~1.4.2",
+    "guzzlehttp/guzzle": "~5.0"
   },
   "scripts": {
     "post-install-cmd": [


### PR DESCRIPTION
I have updated httpclient to use httpGuzzle library instead of curl , so now the users can download any extension even if  open_basedir is set .

---
- [CRM-14126: HttpClient.php library used by CiviCRM issues a PHP warning when open_basedir is set](https://issues.civicrm.org/jira/browse/CRM-14126)
