### PR TITLE
CRM-17550 - Missing payment description in PayPalImpl.

### DIFF
--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -837,7 +837,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
     $paypalParams = array(
       'business' => $this->_paymentProcessor['user_name'],
       'notify_url' => $notifyURL,
-      'item_name' => $this->getPaymentDescription(),
+      'item_name' => $this->getPaymentDescription($params),
       'quantity' => 1,
       'undefined_quantity' => 0,
       'cancel_return' => $cancelURL,


### PR DESCRIPTION
---
- CRM-17550: PayPal Website Standard : payment description is not being passed to PayPal
  https://issues.civicrm.org/jira/browse/CRM-17550
