### PR TITLE
CRM-17548 - Thank-you e-mail fails to include message template subject

### DIFF
--- a/CRM/Contribute/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contribute/Form/Task/PDFLetterCommon.php
@@ -343,10 +343,10 @@ class CRM_Contribute_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDF
         $defaults['from'] = array_pop($emails);
       }
       if (!empty($params['subject'])) {
-        $defaults['subject'] => $params['subject'];
+        $defaults['subject'] = $params['subject'];
       }
       else {
-        $defaults['subject'] => ts('Thank you for your contribution/s');
+        $defaults['subject'] = ts('Thank you for your contribution/s');
       }
       if ($is_pdf) {
         $defaults['html'] = ts('Please see attached');

--- a/CRM/Contribute/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contribute/Form/Task/PDFLetterCommon.php
@@ -334,7 +334,6 @@ class CRM_Contribute_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDF
       $defaults = array(
         'toName' => $contact['display_name'],
         'toEmail' => $contact['email'],
-        'subject' => ts('Thank you for your contribution/s'),
         'text' => '',
         'html' => $html,
       );
@@ -342,6 +341,12 @@ class CRM_Contribute_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDF
         $emails = CRM_Core_BAO_Email::getFromEmail();
         $emails = array_keys($emails);
         $defaults['from'] = array_pop($emails);
+      }
+      if (!empty($params['subject'])) {
+        $defaults['subject'] => $params['subject'];
+      }
+      else {
+        $defaults['subject'] => ts('Thank you for your contribution/s');
       }
       if ($is_pdf) {
         $defaults['html'] = ts('Please see attached');


### PR DESCRIPTION
CRM-17548 - Thank-you e-mail fails to include message template subject, sends only default
https://issues.civicrm.org/jira/browse/CRM-17548
