### PR TITLE
CRM-17539 & progress on CRM-16929

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -108,7 +108,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       $contributionParams['contribution_recur_id'] = $recurringContributionID;
     }
 
-    $contributionParams['contribution_status_id'] = $pending ? 2 : 1;
+    $contributionParams['contribution_status_id'] = ($pending && $contributionParams['total_amount'] != 0) ? 2 : 1;
     if (isset($contributionParams['invoice_id'])) {
       $contributionParams['id'] = CRM_Core_DAO::getFieldValue(
         'CRM_Contribute_DAO_Contribution',

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -905,8 +905,8 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       return $errors;
     }
 
-    if (CRM_Utils_Array::value('payment_method', $fields) == NULL) {
-      $errors['payment_method'] = ts('Payment Method is a required field.');
+    if (CRM_Utils_Array::value('payment_processor_id', $fields) == NULL) {
+      $errors['payment_processor_id'] = ts('Payment Method is a required field.');
     }
     else {
       CRM_Core_Payment_Form::validatePaymentInstrument(

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -330,7 +330,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
 
     if (count($pps) > 1) {
       $this->addRadio('payment_processor_id', ts('Payment Method'), $pps,
-        NULL, "&nbsp;", TRUE
+        NULL, "&nbsp;"
       );
     }
     elseif (!empty($pps)) {
@@ -683,7 +683,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
         $errorText = 'Your %1 membership was previously cancelled and can not be renewed online. Please contact the site administrator for assistance.';
         foreach ($self->_values['fee'] as $fieldKey => $fieldValue) {
           if ($fieldValue['html_type'] != 'Text' && CRM_Utils_Array::value('price_' . $fieldKey, $fields)) {
-            if (!is_array($fields['price_' . $fieldKey])) {
+            if (!is_array($fields['price_' . $fieldKey]) && isset($fieldValue['options'][$fields['price_' . $fieldKey]])) {
               if (array_key_exists('membership_type_id', $fieldValue['options'][$fields['price_' . $fieldKey]])
                 && in_array($fieldValue['options'][$fields['price_' . $fieldKey]]['membership_type_id'], $currentMemberships)
               ) {
@@ -691,11 +691,13 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
               }
             }
             else {
-              foreach ($fields['price_' . $fieldKey] as $key => $ignore) {
-                if (array_key_exists('membership_type_id', $fieldValue['options'][$key])
-                  && in_array($fieldValue['options'][$key]['membership_type_id'], $currentMemberships)
-                ) {
-                  $errors['price_' . $fieldKey] = ts($errorText, array(1 => CRM_Member_PseudoConstant::membershipType($fieldValue['options'][$key]['membership_type_id'])));
+              if (is_array($fields['price_' . $fieldKey])) {
+                foreach (array_keys($fields['price_' . $fieldKey]) as $key) {
+                  if (array_key_exists('membership_type_id', $fieldValue['options'][$key])
+                    && in_array($fieldValue['options'][$key]['membership_type_id'], $currentMemberships)
+                  ) {
+                    $errors['price_' . $fieldKey] = ts($errorText, array(1 => CRM_Member_PseudoConstant::membershipType($fieldValue['options'][$key]['membership_type_id'])));
+                  }
                 }
               }
             }
@@ -903,12 +905,17 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       return $errors;
     }
 
-    CRM_Core_Payment_Form::validatePaymentInstrument(
-      $fields['payment_processor_id'],
-      $fields,
-      $errors,
-      (!$self->_isBillingAddressRequiredForPayLater ? NULL : 'billing')
-    );
+    if (CRM_Utils_Array::value('payment_method', $fields) == NULL) {
+      $errors['payment_method'] = ts('Payment Method is a required field.');
+    }
+    else {
+      CRM_Core_Payment_Form::validatePaymentInstrument(
+        $fields['payment_processor_id'],
+        $fields,
+        $errors,
+        (!$self->_isBillingAddressRequiredForPayLater ? NULL : 'billing')
+      );
+    }
 
     foreach (CRM_Contact_BAO_Contact::$_greetingTypes as $greeting) {
       if ($greetingType = CRM_Utils_Array::value($greeting, $fields)) {
@@ -1008,7 +1015,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
         $priceOptions = array();
         while ($priceField->fetch()) {
           CRM_Price_BAO_PriceFieldValue::getValues($priceField->id, $priceOptions);
-          if ($selectedPriceOptionID = CRM_Utils_Array::value("price_{$priceField->id}", $params)) {
+          if (($selectedPriceOptionID = CRM_Utils_Array::value("price_{$priceField->id}", $params)) != FALSE && $selectedPriceOptionID > 0) {
             switch ($priceField->name) {
               case 'membership_amount':
                 $this->_params['selectMembership'] = $params['selectMembership'] = CRM_Utils_Array::value('membership_type_id', $priceOptions[$selectedPriceOptionID]);

--- a/CRM/Core/Payment/ProcessorForm.php
+++ b/CRM/Core/Payment/ProcessorForm.php
@@ -57,6 +57,10 @@ class CRM_Core_Payment_ProcessorForm {
       $form->_paymentProcessor = CRM_Financial_BAO_PaymentProcessor::getPayment($form->_type, $form->_mode);
     }
 
+    if (empty($form->_paymentProcessor)) {
+      // This would happen when hitting the back-button on a multi-page form with a $0 selection in play.
+      return;
+    }
     $form->set('paymentProcessor', $form->_paymentProcessor);
     $form->_paymentObject = Civi\Payment\System::singleton()->getByProcessor($form->_paymentProcessor);
 

--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -430,6 +430,8 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
         if (!empty($qf->_membershipBlock) && $field->name == 'contribution_amount') {
           $choice[] = $qf->createElement('radio', NULL, '', ts('No thank you'), '-1',
             array(
+              'price' => json_encode(array($elementName, '0|0')),
+              'data-currency' => $currencyName,
               'onclick' => 'clearAmountOther();',
             )
           );

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -253,10 +253,7 @@
   {/if}
 
   <div id="billing-payment-block">
-    {* If we have a payment processor, load it - otherwise it happens via ajax *}
-    {if $paymentProcessorID or $isBillingAddressRequiredForPayLater}
-      {include file="CRM/Financial/Form/Payment.tpl" snippet=4}
-    {/if}
+    {include file="CRM/Financial/Form/Payment.tpl" snippet=4}
   </div>
   {include file="CRM/common/paymentBlock.tpl"}
 

--- a/templates/CRM/Event/Form/ParticipantFeeSelection.tpl
+++ b/templates/CRM/Event/Form/ParticipantFeeSelection.tpl
@@ -130,7 +130,7 @@ CRM.$(function($) {
       <table class='form-layout'>
         <tr class="crm-event-eventfees-form-block-price_set_amount">
           <td class="label" style="padding-top: 10px;">{$form.amount.label}</td>
-          <td class="view-value"><table class="form-layout">{include file="CRM/Price/Form/PriceSet.tpl" extends="Event" dontInclCal="true" context="participant"}</table></td>
+          <td class="view-value"><table class="form-layout">{include file="CRM/Price/Form/PriceSet.tpl" extends="Event" noCalcValueDisplay=0 context="participant"}</table></td>
         </tr>
      {if $paymentInfo}
        <tr><td></td><td>
@@ -143,7 +143,7 @@ CRM.$(function($) {
          </div>
          <div class='label'><strong>{ts}Balance Owed{/ts}</strong></div><div class='content'><strong id='balance-fee'></strong></div>
           </div>
-       {include file='CRM/Price/Form/Calculate.tpl' currencySymbol=$currencySymbol noCalcValueDisplay='false' displayOveride='true'}
+       {include file='CRM/Price/Form/Calculate.tpl' currencySymbol=$currencySymbol noCalcValueDisplay=1 displayOveride='true'}
        {/if}
       </table>
     </fieldset>

--- a/templates/CRM/Price/Form/Calculate.tpl
+++ b/templates/CRM/Price/Form/Calculate.tpl
@@ -120,52 +120,48 @@ cj("input,#priceset select,#priceset").each(function () {
 
   case 'select-one':
 
-    //default calcution of element.
-    var ele = cj(this).attr('id');
-    if ( ! price[ele] ) {
-      price[ele] = 0;
+    //default calculation of element.
+    var elementID = cj(this).attr('id');
+    if ( ! price[elementID] ) {
+      price[elementID] = 0;
     }
-    eval( 'var selectedText = ' + cj(this).attr('price') );
-    var addprice = 0;
-    if ( cj(this).val( ) ) {
-      optionPart = selectedText[cj(this).val( )].split(optionSep);
-      addprice   = parseFloat( optionPart[0] );
-    }
-
-    if ( addprice ) {
-      totalfee   = parseFloat(totalfee) + addprice - parseFloat(price[ele]);
-      price[ele] = addprice;
-    }
+    var addPrice = calculateSelectLineItemValue(this);
+    // In other words we subtract any existing value before adding the new value it seems.
+    totalfee   = parseFloat(totalfee) + addPrice - parseFloat(price[elementID]);
+    price[elementID] = addPrice;
 
     //event driven calculation of element.
     cj(this).change( function() {
-      var ele = cj(this).attr('id');
-      if ( ! price[ele] ) {
-        price[ele] = 0;
-      }
-      eval( 'var selectedText = ' + cj(this).attr('price') );
-
-      var addprice = 0;
-      if ( cj(this).val( ) ) {
-        optionPart = selectedText[cj(this).val( )].split(optionSep);
-        addprice   = parseFloat( optionPart[0] );
+      var elementID = cj(this).attr('id');
+      if ( ! price[elementID] ) {
+        price[elementID] = 0;
       }
 
-      if ( addprice ) {
-        totalfee   = parseFloat(totalfee) + addprice - parseFloat(price[ele]);
-        price[ele] = addprice;
-      }
-      else {
-        totalfee   = parseFloat(totalfee) - parseFloat(price[ele]);
-        price[ele] = parseFloat('0');
-      }
+      var addPrice = calculateSelectLineItemValue(this);
+      totalfee   = parseFloat(totalfee) + addPrice - parseFloat(price[elementID]);
+      price[elementID] = addPrice;
       display( totalfee );
     });
+
     display( totalfee );
     break;
     }
   }
 });
+
+/**
+ * Calculate the value of the line item for a select value.
+ */
+function calculateSelectLineItemValue(priceElement) {
+  eval( 'var selectedText = ' + cj(priceElement).attr('price') );
+  var addprice = parseFloat('0');
+  if ( cj(priceElement).val( ) ) {
+    optionPart = selectedText[cj(priceElement).val( )].split(optionSep);
+    addprice   = parseFloat( optionPart[0] );
+  }
+  return addprice;
+
+}
 
 //calculation for text box.
 function calculateText( object ) {

--- a/templates/CRM/Price/Form/Calculate.tpl
+++ b/templates/CRM/Price/Form/Calculate.tpl
@@ -45,65 +45,66 @@ var priceSet = price = Array( );
 cj("input,#priceset select,#priceset").each(function () {
 
   if ( cj(this).attr('price') ) {
-  var eleType =  cj(this).attr('type');
-  if ( this.tagName == 'SELECT' ) {
-    eleType = 'select-one';
-  }
-  switch( eleType ) {
-
-  case 'checkbox':
-
-    //default calcution of element.
-    eval( 'var option = ' + cj(this).attr('price') ) ;
-    ele        = option[0];
-    optionPart = option[1].split(optionSep);
-    addprice   = parseFloat( optionPart[0] );
-
-    if( cj(this).prop('checked') ) {
-      totalfee   += addprice;
-      price[ele] += addprice;
+    var eleType =  cj(this).attr('type');
+    if ( this.tagName == 'SELECT' ) {
+      eleType = 'select-one';
     }
+    switch( eleType ) {
 
-    //event driven calculation of element.
-    cj(this).click( function(){
+      case 'checkbox':
 
-      if ( cj(this).prop('checked') )  {
-  totalfee   += addprice;
-  price[ele] += addprice;
-      } else {
-  totalfee   -= addprice;
-  price[ele] -= addprice;
+        //default calcution of element.
+        eval( 'var option = ' + cj(this).attr('price') ) ;
+        ele = option[0];
+        optionPart = option[1].split(optionSep);
+        addprice   = parseFloat( optionPart[0] );
+
+        if( cj(this).prop('checked') ) {
+          totalfee   += addprice;
+          price[ele] += addprice;
+        }
+
+        //event driven calculation of element.
+        cj(this).click( function(){
+
+          if ( cj(this).prop('checked') )  {
+            totalfee   += addprice;
+            price[ele] += addprice;
+          }
+          else {
+            totalfee   -= addprice;
+            price[ele] -= addprice;
+          }
+          display( totalfee );
+        });
+        display( totalfee );
+      break;
+
+    case 'radio':
+
+      //default calcution of element.
+      eval( 'var option = ' + cj(this).attr('price') );
+      ele        = option[0];
+      optionPart = option[1].split(optionSep);
+      addprice   = parseFloat( optionPart[0] );
+      if ( ! price[ele] ) {
+        price[ele] = 0;
       }
+
+      if( cj(this).prop('checked') ) {
+        totalfee   = parseFloat(totalfee) + addprice - parseFloat(price[ele]);
+        price[ele] = addprice;
+      }
+
+      //event driven calculation of element.
+      cj(this).click( function(){
+        totalfee   = parseFloat(totalfee) + addprice - parseFloat(price[ele]);
+        price[ele] = addprice;
+
+        display( totalfee );
+      });
       display( totalfee );
-    });
-    display( totalfee );
-    break;
-
-  case 'radio':
-
-    //default calcution of element.
-    eval( 'var option = ' + cj(this).attr('price') );
-    ele        = option[0];
-    optionPart = option[1].split(optionSep);
-    addprice   = parseFloat( optionPart[0] );
-    if ( ! price[ele] ) {
-      price[ele] = 0;
-    }
-
-    if( cj(this).prop('checked') ) {
-      totalfee   = parseFloat(totalfee) + addprice - parseFloat(price[ele]);
-      price[ele] = addprice;
-    }
-
-    //event driven calculation of element.
-    cj(this).click( function(){
-      totalfee   = parseFloat(totalfee) + addprice - parseFloat(price[ele]);
-      price[ele] = addprice;
-
-      display( totalfee );
-    });
-    display( totalfee );
-    break;
+      break;
 
   case 'text':
 
@@ -115,32 +116,32 @@ cj("input,#priceset select,#priceset").each(function () {
     }).bind( 'blur' , function() { calculateText( this );
     });
 
-   break;
+    break;
 
   case 'select-one':
 
     //default calcution of element.
     var ele = cj(this).attr('id');
-      if ( ! price[ele] ) {
-  price[ele] = 0;
-      }
-      eval( 'var selectedText = ' + cj(this).attr('price') );
-      var addprice = 0;
-      if ( cj(this).val( ) ) {
-        optionPart = selectedText[cj(this).val( )].split(optionSep);
-        addprice   = parseFloat( optionPart[0] );
-      }
+    if ( ! price[ele] ) {
+      price[ele] = 0;
+    }
+    eval( 'var selectedText = ' + cj(this).attr('price') );
+    var addprice = 0;
+    if ( cj(this).val( ) ) {
+      optionPart = selectedText[cj(this).val( )].split(optionSep);
+      addprice   = parseFloat( optionPart[0] );
+    }
 
     if ( addprice ) {
-  totalfee   = parseFloat(totalfee) + addprice - parseFloat(price[ele]);
-  price[ele] = addprice;
+      totalfee   = parseFloat(totalfee) + addprice - parseFloat(price[ele]);
+      price[ele] = addprice;
     }
 
     //event driven calculation of element.
     cj(this).change( function() {
       var ele = cj(this).attr('id');
       if ( ! price[ele] ) {
-  price[ele] = 0;
+        price[ele] = 0;
       }
       eval( 'var selectedText = ' + cj(this).attr('price') );
 
@@ -151,11 +152,12 @@ cj("input,#priceset select,#priceset").each(function () {
       }
 
       if ( addprice ) {
-  totalfee   = parseFloat(totalfee) + addprice - parseFloat(price[ele]);
-  price[ele] = addprice;
-      } else {
-  totalfee   = parseFloat(totalfee) - parseFloat(price[ele]);
-  price[ele] = parseFloat('0');
+        totalfee   = parseFloat(totalfee) + addprice - parseFloat(price[ele]);
+        price[ele] = addprice;
+      }
+      else {
+        totalfee   = parseFloat(totalfee) - parseFloat(price[ele]);
+        price[ele] = parseFloat('0');
       }
       display( totalfee );
     });

--- a/templates/CRM/Price/Form/Calculate.tpl
+++ b/templates/CRM/Price/Form/Calculate.tpl
@@ -23,16 +23,22 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-{if $noCalcValueDisplay neq 'false'}
+
+{assign var='hideTotal' value=$quickConfig+$noCalcValueDisplay}
 <div id="pricesetTotal" class="crm-section section-pricesetTotal">
-  <div class="label" id="pricelabel"><label>
-    {if ( $extends eq 'Contribution' ) || ( $extends eq 'Membership' )}
-      {ts}Total Amount{/ts}{else}{ts}Total Fee(s){/ts}
-       {if $isAdditionalParticipants} {ts}for this participant{/ts}{/if}
-    {/if}</label></div>
-  <div class="content calc-value" id="pricevalue" ></div>
+  {if !$hideTotal}
+  <div class="label" id="pricelabel">
+    <label>
+      {if ( $extends eq 'Contribution' ) || ( $extends eq 'Membership' )}
+        {ts}Total Amount{/ts}{else}{ts}Total Fee(s){/ts}
+         {if $isAdditionalParticipants} {ts}for this participant{/ts}{/if}
+      {/if}
+    </label>
+  </div>
+  {/if}
+  <div class="content calc-value" {if $hideTotal}style="display:none;"{/if} id="pricevalue" ></div>
 </div>
-{/if}
+
 <script type="text/javascript">
 {literal}
 

--- a/templates/CRM/Price/Form/PriceSet.tpl
+++ b/templates/CRM/Price/Form/PriceSet.tpl
@@ -123,9 +123,6 @@
       <div class="messages help">{$priceSet.help_post}</div>
     {/if}
 
-{* Include the total calculation widget if this is NOT a quickconfig event/contribution page. *}
-{if !$quickConfig and !$dontInclCal}
     {include file="CRM/Price/Form/Calculate.tpl"}
-{/if}
 </div>
 {/crmRegion}


### PR DESCRIPTION
This PR refactors calculate.tpl to always calculate raw_total. There are further places where show-hide payment block is calculated that should be updated to use this new consistency but I'd like to process those in a second commit -as long as no obvious regressions come from this.

Also fixe for CRM-17539

---
- [CRM-17539: Free $0 contribution\/membership show payment status: 'Incomplete transaction' instead of 'Completed'](https://issues.civicrm.org/jira/browse/CRM-17539)
- [CRM-16929: Selecting a zero event price should remove billing block](https://issues.civicrm.org/jira/browse/CRM-16929)
