### PR TITLE
CRM-17557 membership not processed to current

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2220,47 +2220,46 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       }
     }
 
-    if ($this->_component == 'contribute') {
-      // retrieve the other optional objects first so
-      // stuff down the line can use this info and do things
-      // CRM-6056
-      //in any case get the memberships associated with the contribution
-      //because we now support multiple memberships w/ price set
-      // see if there are any other memberships to be considered for same contribution.
-      $query = "
-            SELECT membership_id
-            FROM   civicrm_membership_payment
-WHERE  contribution_id = %1 ";
-      $params = array(1 => array($this->id, 'Integer'));
+    // retrieve the other optional objects first so
+    // stuff down the line can use this info and do things
+    // CRM-6056
+    //in any case get the memberships associated with the contribution
+    //because we now support multiple memberships w/ price set
+    // see if there are any other memberships to be considered for same contribution.
+    $query = "
+          SELECT entity_id as membership_id
+          FROM   civicrm_line_item
+WHERE  contribution_id = %1 AND entity_table = 'civicrm_membership'";
+    $params = array(1 => array($this->id, 'Integer'));
 
-      $dao = CRM_Core_DAO::executeQuery($query, $params);
-      while ($dao->fetch()) {
-        if ($dao->membership_id) {
-          if (!is_array($ids['membership'])) {
-            $ids['membership'] = array();
-          }
-          $ids['membership'][] = $dao->membership_id;
+    $dao = CRM_Core_DAO::executeQuery($query, $params);
+    while ($dao->fetch()) {
+      if ($dao->membership_id) {
+        if (!is_array($ids['membership'])) {
+          $ids['membership'] = array();
         }
+        $ids['membership'][] = $dao->membership_id;
       }
+    }
 
-      if (array_key_exists('membership', $ids) && is_array($ids['membership'])) {
-        foreach ($ids['membership'] as $id) {
-          if (!empty($id)) {
-            $membership = new CRM_Member_BAO_Membership();
-            $membership->id = $id;
-            if (!$membership->find(TRUE)) {
-              throw new Exception("Could not find membership record: $id");
-            }
-            $membership->join_date = CRM_Utils_Date::isoToMysql($membership->join_date);
-            $membership->start_date = CRM_Utils_Date::isoToMysql($membership->start_date);
-            $membership->end_date = CRM_Utils_Date::isoToMysql($membership->end_date);
-            $this->_relatedObjects['membership'][$membership->membership_type_id] = $membership;
-            $membership->free();
+    if (array_key_exists('membership', $ids) && is_array($ids['membership'])) {
+      foreach ($ids['membership'] as $id) {
+        if (!empty($id)) {
+          $membership = new CRM_Member_BAO_Membership();
+          $membership->id = $id;
+          if (!$membership->find(TRUE)) {
+            throw new Exception("Could not find membership record: $id");
           }
+          $membership->join_date = CRM_Utils_Date::isoToMysql($membership->join_date);
+          $membership->start_date = CRM_Utils_Date::isoToMysql($membership->start_date);
+          $membership->end_date = CRM_Utils_Date::isoToMysql($membership->end_date);
+          $this->_relatedObjects['membership'][$membership->membership_type_id] = $membership;
+          $membership->free();
         }
       }
     }
-    else {
+
+    if ($this->_component != 'contribute') {
       // we are in event mode
       // make sure event exists and is valid
       $event = new CRM_Event_BAO_Event();

--- a/CRM/Contribute/BAO/Contribution/Utils.php
+++ b/CRM/Contribute/BAO/Contribution/Utils.php
@@ -158,7 +158,7 @@ class CRM_Contribute_BAO_Contribution_Utils {
         $paymentParams['contributionRecurID'] = $contribution->contribution_recur_id;
       }
 
-      if (!empty($form->_paymentProcessor) && $form->_amount > 0.0) {
+      if (!empty($form->_paymentProcessor)) {
         try {
           $payment = Civi\Payment\System::singleton()->getByProcessor($form->_paymentProcessor);
           if ($form->_contributeMode == 'notify') {
@@ -211,7 +211,16 @@ class CRM_Contribute_BAO_Contribution_Utils {
 
     $form->_values['contribution_id'] = $contribution->id;
     $form->_values['contribution_page_id'] = $contribution->contribution_page_id;
-
+    if ($form->_params['amount'] == 0) {
+      // This is kind of a back-up for pay-later $0 transactions.
+      // In other flows they pick up the manual processor & get dealt with above (I
+      // think that might be better...).
+      return array(
+        'payment_status_id' => 1,
+        'contribution' => $contribution,
+        'payment_processor_id' => 0,
+      );
+    }
     CRM_Contribute_BAO_ContributionPage::sendMail($contactID,
       $form->_values,
       $contribution->is_test

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -108,7 +108,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       $contributionParams['contribution_recur_id'] = $recurringContributionID;
     }
 
-    $contributionParams['contribution_status_id'] = ($pending && $contributionParams['total_amount'] != 0) ? 2 : 1;
+    $contributionParams['contribution_status_id'] = $pending ? 2 : 1;
     if (isset($contributionParams['invoice_id'])) {
       $contributionParams['id'] = CRM_Core_DAO::getFieldValue(
         'CRM_Contribute_DAO_Contribution',

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1686,6 +1686,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       $form->_bltID
     );
 
+    $result = array();
     if ($form->_values['is_monetary'] && !$form->_params['is_pay_later'] && $minimumFee > 0.0) {
       // At the moment our tests are calling this form in a way that leaves 'object' empty. For
       // now we compensate here.

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1579,7 +1579,11 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       }
 
       $payment = Civi\Payment\System::singleton()->getByProcessor($form->_paymentProcessor);
-      $paymentActionResult = $payment->doPayment($form->_params, 'contribute');
+      // The contribution_other_id is effectively the ID for the only contribution or the non-membership contribution.
+      // Since we have called the membership contribution (in a 2 contribution scenario) this is out
+      // primary-contribution compared to that - but let's face it - it's all just too hard & confusing at the moment!
+      $paymentParams = array_merge($form->_params, array('contributionID' => $form->_values['contribution_other_id']));
+      $paymentActionResult = $payment->doPayment($paymentParams, 'contribute');
       $paymentResults[] = array('contribution_id' => $paymentResult['contribution']->id, 'result' => $paymentActionResult);
       // Do not send an email if Recurring transaction is done via Direct Mode
       // Email will we sent when the IPN is received.

--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -916,6 +916,15 @@ abstract class CRM_Core_Payment {
   public function doPayment(&$params, $component = 'contribute') {
     $this->_component = $component;
     $statuses = CRM_Contribute_BAO_Contribution::buildOptions('contribution_status_id');
+
+    // If we have a $0 amount, skip call to processor and set payment_status to Completed.
+    // Conceivably a processor might override this - perhaps for setting up a token - but we don't
+    // have an example of that at the mome.
+    if ($params['amount'] == 0) {
+      $result['payment_status_id'] = array_search('Completed', $statuses);
+      return $result;
+    }
+
     if ($this->_paymentProcessor['billing_mode'] == 4) {
       $result = $this->doTransferCheckout($params, $component);
       if (is_array($result) && !isset($result['payment_status_id'])) {

--- a/CRM/Member/BAO/MembershipType.php
+++ b/CRM/Member/BAO/MembershipType.php
@@ -486,7 +486,10 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
   }
 
   /**
-   * Calculate start date and end date for renewal membership.
+   * Calculate start date and end date for membership updates.
+   *
+   * Note that this function is called by the api for any membership update although it was
+   * originally written for renewal (which feels a bit fragile but hey....).
    *
    * @param int $membershipId
    * @param $changeToday
@@ -503,17 +506,19 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
   public static function getRenewalDatesForMembershipType($membershipId, $changeToday = NULL, $membershipTypeID = NULL, $numRenewTerms = 1) {
     $params = array('id' => $membershipId);
     $membershipDetails = CRM_Member_BAO_Membership::getValues($params, $values);
-    $statusID = $membershipDetails[$membershipId]->status_id;
-    $membershipDates = array(
-      'join_date' => CRM_Utils_Date::customFormat($membershipDetails[$membershipId]->join_date, '%Y%m%d'),
-    );
+    $membershipDetails = $membershipDetails[$membershipId];
+    $statusID = $membershipDetails->status_id;
+    $membershipDates = array();
+    if (!empty($membershipDetails->join_date)) {
+      $membershipDates['join_date'] = CRM_Utils_Date::customFormat($membershipDetails->join_date, '%Y%m%d');
+    }
 
     $oldPeriodType = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipType',
       CRM_Core_DAO::getFieldValue('CRM_Member_DAO_Membership', $membershipId, 'membership_type_id'), 'period_type');
 
     // CRM-7297 Membership Upsell
     if (is_null($membershipTypeID)) {
-      $membershipTypeDetails = self::getMembershipTypeDetails($membershipDetails[$membershipId]->membership_type_id);
+      $membershipTypeDetails = self::getMembershipTypeDetails($membershipDetails->membership_type_id);
     }
     else {
       $membershipTypeDetails = self::getMembershipTypeDetails($membershipTypeID);
@@ -521,14 +526,14 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
     $statusDetails = CRM_Member_BAO_MembershipStatus::getMembershipStatus($statusID);
 
     if ($statusDetails['is_current_member'] == 1) {
-      $startDate = $membershipDetails[$membershipId]->start_date;
+      $startDate = $membershipDetails->start_date;
       // CRM=7297 Membership Upsell: we need to handle null end_date in case we are switching
       // from a lifetime to a different membership type
-      if (is_null($membershipDetails[$membershipId]->end_date)) {
+      if (is_null($membershipDetails->end_date)) {
         $date = date('Y-m-d');
       }
       else {
-        $date = $membershipDetails[$membershipId]->end_date;
+        $date = $membershipDetails->end_date;
       }
       $date = explode('-', $date);
       $logStartDate = date('Y-m-d', mktime(0, 0, 0,
@@ -592,6 +597,9 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
       $membershipDates['start_date'] = $renewalDates['start_date'];
       $membershipDates['end_date'] = $renewalDates['end_date'];
       $membershipDates['log_start_date'] = $renewalDates['start_date'];
+    }
+    if (!isset($membershipDates['join_date'])) {
+      $membershipDates['join_date'] = $membershipDates['start_date'];
     }
 
     return $membershipDates;


### PR DESCRIPTION
CRM-17557 lists 2 issues

1) the separate payment is not processed past pending
2) member since is blank.

The cause for the first is that the transaction was being completed before the membership_payment record was added.

The second issue is not fixed by this PR - but I'm inclined to put the fix in the BAO ie.

I feel like the rule could be 'if membership_start_date is set & join date is null set join date to start date' -

---
- [CRM-17557: Membership Since Date missing and Status changed to 'Current' after renewal from Online Contribution page](https://issues.civicrm.org/jira/browse/CRM-17557)
