### PR TITLE
Crm 16929 rebase

### DIFF
--- a/CRM/Event/Form/Registration/AdditionalParticipant.php
+++ b/CRM/Event/Form/Registration/AdditionalParticipant.php
@@ -155,7 +155,7 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
    * @return void
    */
   public function buildQuickForm() {
-    $config = CRM_Core_Config::singleton();
+
     $button = substr($this->controller->getButtonName(), -4);
 
     $this->add('hidden', 'scriptFee', NULL);
@@ -226,6 +226,7 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
       }
 
       //we might did reset allow waiting in case of dynamic calculation
+      // @TODO - does this bypass_payment still exist?
       if (!empty($this->_params[0]['bypass_payment']) &&
         is_numeric($spaces) &&
         $processedCnt > $spaces

--- a/CRM/Event/Form/Registration/AdditionalParticipant.php
+++ b/CRM/Event/Form/Registration/AdditionalParticipant.php
@@ -557,10 +557,11 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
 
     CRM_Core_Form::validateMandatoryFields($self->_fields, $fields, $errors);
 
-    // validate supplied payment instrument values (e.g. credit card number and cvv)
-    $payment_processor_id = $self->_params[0]['payment_processor'];
-    CRM_Core_Payment_Form::validatePaymentInstrument($payment_processor_id, $self->_params[0], $errors, (!$self->_isBillingAddressRequiredForPayLater ? NULL : 'billing'));
-
+    if (isset($self->_params[0]['payment_processor'])) {
+      // validate supplied payment instrument values (e.g. credit card number and cvv)
+      $payment_processor_id = $self->_params[0]['payment_processor'];
+      CRM_Core_Payment_Form::validatePaymentInstrument($payment_processor_id, $self->_params[0], $errors, (!$self->_isBillingAddressRequiredForPayLater ? NULL : 'billing'));
+    }
     if (!empty($errors)) {
       return FALSE;
     }

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -275,8 +275,6 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
 
   /**
    * Build the form object.
-   *
-   * @return void
    */
   public function buildQuickForm() {
     // build profiles first so that we can determine address fields etc
@@ -323,7 +321,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
           8 => '9',
           9 => '10',
         );
-        $element = $this->add('select', 'additional_participants',
+        $this->add('select', 'additional_participants',
           ts('How many people are you registering?'),
           $additionalOptions,
           NULL,
@@ -368,9 +366,6 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
     $this->assign('allowGroupOnWaitlist', $allowGroupOnWaitlist);
     $this->assign('isAdditionalParticipants', $isAdditionalParticipants);
 
-    //lets get js on two different qf elements.
-    $showHidePayfieldName = NULL;
-    $showHidePaymentInformation = FALSE;
     if ($this->_values['event']['is_monetary']) {
       self::buildAmount($this);
     }
@@ -415,7 +410,6 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       $this->addElement('hidden', 'bypass_payment', NULL, array('id' => 'bypass_payment'));
     }
     $this->assign('bypassPayment', $bypassPayment);
-    $this->assign('showHidePaymentInformation', $showHidePaymentInformation);
 
     $userID = $this->getContactID();
 
@@ -522,8 +516,6 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
    *   True if you want to add formRule.
    * @param int $discountId
    *   Discount id for the event.
-   *
-   * @return void
    */
   static public function buildAmount(&$form, $required = TRUE, $discountId = NULL) {
     // build amount only when needed, skip incase of event full and waitlisting is enabled

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -1061,13 +1061,16 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       $invoiceID = md5(uniqid(rand(), TRUE));
       $this->set('invoiceID', $invoiceID);
 
-      if (is_array($this->_paymentProcessor)) {
+      if ($this->_paymentProcessor) {
         $payment = $this->_paymentProcessor['object'];
         $payment->setBaseReturnUrl('civicrm/event/register');
       }
-      // default mode is direct
+
+      // ContributeMode is a deprecated concept. It is short-hand for a bunch of
+      // assumptions we are working to remove.
       $this->set('contributeMode', 'direct');
 
+      // This code is duplicated multiple places and should be consolidated.
       if (isset($params["state_province_id-{$this->_bltID}"]) &&
         $params["state_province_id-{$this->_bltID}"]
       ) {

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -126,6 +126,9 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
    */
   public function setDefaultValues() {
     $this->_defaults = array();
+    if (!$this->_allowConfirmation) {
+      $this->_defaults['bypass_payment'] = 1;
+    }
     $contactID = $this->getContactID();
     CRM_Core_Payment_Form::setDefaultValues($this, $contactID);
 
@@ -331,6 +334,10 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       }
     }
 
+    if (!$this->_allowConfirmation) {
+      $bypassPayment = TRUE;
+    }
+
     //hack to allow group to register w/ waiting
     if ((!empty($this->_values['event']['is_multiple_registrations']) ||
         $this->_priceSetId
@@ -405,10 +412,8 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       }
     }
 
-    //lets add some qf element to bypass payment validations, CRM-4320
-    if ($bypassPayment) {
-      $this->addElement('hidden', 'bypass_payment', NULL, array('id' => 'bypass_payment'));
-    }
+    $this->addElement('hidden', 'bypass_payment', NULL, array('id' => 'bypass_payment'));
+
     $this->assign('bypassPayment', $bypassPayment);
 
     $userID = $this->getContactID();
@@ -795,7 +800,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
     }
 
     //don't allow to register w/ waiting if enough spaces available.
-    if (!empty($fields['bypass_payment'])) {
+    if (!empty($fields['bypass_payment']) && $self->_allowConfirmation) {
       if (!is_numeric($self->_availableRegistrations) ||
         (empty($fields['priceSetId']) && CRM_Utils_Array::value('additional_participants', $fields) < $self->_availableRegistrations)
       ) {

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -368,64 +368,11 @@
     }
   }
 
-  {/literal}
-  {if $form.is_pay_later and $paymentProcessor.payment_processor_type EQ 'PayPal_Express'}
-  showHidePayPalExpressOption();
-  {/if}
-  {literal}
-
   CRM.$(function($) {
     enableHonorType();
     showRecurHelp();
     skipPaymentMethod();
   });
-
-  function showHidePayPalExpressOption() {
-    if (cj('input[name="is_pay_later"]').is(':checked')) {
-      cj("#crm-submit-buttons").show();
-      cj("#paypalExpress").hide();
-    }
-    else {
-      cj("#paypalExpress").show();
-      cj("#crm-submit-buttons").hide();
-    }
-  }
-
-  function showHidePayment(flag) {
-    var payment_options = cj(".payment_options-group");
-    var payment_processor = cj("div.payment_processor-section");
-    var payment_information = cj("div#payment_information");
-    if (flag) {
-      payment_options.hide();
-      payment_processor.hide();
-      payment_information.hide();
-    }
-    else {
-      payment_options.show();
-      payment_processor.show();
-      payment_information.show();
-    }
-  }
-
-  function skipPaymentMethod() {
-    var flag = false;
-    cj('.price-set-option-content input[data-amount]').each( function(){
-      currentTotal = cj(this).attr('data-amount').replace(/[^\/\d]/g,'');
-      if( cj(this).is(':checked') && currentTotal == 0 ) {
-          flag = true;
-      }
-    });
-
-    cj('.price-set-option-content input[data-amount]').change( function () {
-      if (cj(this).attr('data-amount').replace(/[^\/\d]/g,'') == 0 ) {
-        flag = true;
-      } else {
-        flag = false;
-      }
-      showHidePayment(flag);
-    });
-    showHidePayment(flag);
-  }
 
   CRM.$(function($) {
     // highlight price sets
@@ -435,21 +382,6 @@
     }
     cj('#priceset input[type="radio"]').change(updatePriceSetHighlight);
     updatePriceSetHighlight();
-
-    function toggleBillingBlockIfFree(){
-      var total_amount_tmp =  $(this).data('raw-total');
-      // Hide billing questions if this is free
-      if (total_amount_tmp == 0){
-        cj("#billing-payment-block").hide();
-        cj(".payment_options-group").hide();
-      }
-      else {
-        cj("#billing-payment-block").show();
-        cj(".payment_options-group").show();
-      }
-    }
-
-    $('#pricevalue').each(toggleBillingBlockIfFree).on('change', toggleBillingBlockIfFree);
   });
   {/literal}
 </script>

--- a/templates/CRM/Event/Form/Registration/Register.tpl
+++ b/templates/CRM/Event/Form/Registration/Register.tpl
@@ -168,10 +168,6 @@
       skipPaymentMethod();
     });
 
-    CRM.$(function($) {
-      skipPaymentMethod();
-    });
-
   {/literal}
   {if $pcp && $is_honor_roll }
     pcpAnonymous();
@@ -228,12 +224,14 @@
       if (isrequireApproval) {
         cj("#id-waitlist-approval-msg").show();
         cj("#id-waitlist-msg").hide();
+        cj("#bypass_payment").val(1);
       }
       else {
         cj("#id-waitlist-approval-msg").hide();
+        cj("#bypass_payment").val(0);
       }
       //reset value since user don't want or not eligible for waitlist
-      cj("#bypass_payment").val(0);
+      skipPaymentMethod();
     }
   }
 

--- a/templates/CRM/Event/Form/Registration/Register.tpl
+++ b/templates/CRM/Event/Form/Registration/Register.tpl
@@ -141,13 +141,7 @@
       </fieldset>
     {/if}
 
-    <div id="billing-payment-block">
-      {* If we have a payment processor, load it - otherwise it happens via ajax *}
-      {if $paymentProcessorID or $isBillingAddressRequiredForPayLater}
-        {include file="CRM/Financial/Form/Payment.tpl" snippet=4}
-      {/if}
-    </div>
-    {include file="CRM/common/paymentBlock.tpl"}
+    {include file='CRM/Core/BillingBlockWrapper.tpl'}
 
     <div class="crm-public-form-item crm-section custom_pre-section">
       {include file="CRM/UF/Form/Block.tpl" fields=$customPost}
@@ -178,48 +172,11 @@
       skipPaymentMethod();
     });
 
-    // Hides billing and payment options block - but only if a price set is used.
-    // Called from display() in Calculate.tpl, depends on display() having been called.
-    function skipPaymentMethod() {
-      // If we're in quick-config price set, we do not have the pricevalue hidden element, so just return.
-      if (cj('#pricevalue').length == 0) {
-        return;
-      }
-      // CRM-15433 Remove currency symbol, decimal separator so we can check for zero numeric total regardless of localization.
-      currentTotal = cj('#pricevalue').text().replace(/[^\/\d]/g,'');
-      var isMultiple = '{/literal}{$event.is_multiple_registrations}{literal}';
-
-      var flag = 1;
-      var payment_options = cj(".payment_options-group");
-      var payment_processor = cj("div.payment_processor-section");
-      var payment_information = cj("div#payment_information");
-
-      // Do not hide billing and payment blocks if user is registering additional participants, since we do not know total owing.
-      if (isMultiple && cj("#additional_participants").val() && currentTotal == 0) {
-        flag = 0;
-      }
-
-      if (currentTotal == 0 && flag) {
-        payment_options.hide();
-        payment_processor.hide();
-        payment_information.hide();
-        // also unset selected payment methods
-        cj('input[name="payment_processor_id"]').removeProp('checked');
-      }
-      else {
-        payment_options.show();
-        payment_processor.show();
-        payment_information.show();
-      }
-    }
-
-    {/literal}
-  </script>
-
-{literal}
-<script type="text/javascript">
-  {/literal}{if $pcp && $is_honor_roll }pcpAnonymous();
-  {/if}{literal}
+  {/literal}
+  {if $pcp && $is_honor_roll }
+    pcpAnonymous();
+  {/if}
+  {literal}
 
   function allowParticipant() {
     {/literal}{if $allowGroupOnWaitlist}{literal}
@@ -231,35 +188,6 @@
 
     allowGroupOnWaitlist(additionalParticipants, pricesetParticipantCount);
     {/literal}{/if}{literal}
-  }
-
-  {/literal}{if ($bypassPayment) and $paymentProcessor.payment_processor_type EQ 'PayPal_Express'}
-  {literal}
-  showHidePayPalExpressOption();
-  {/literal}{/if}{literal}
-
-  function showHidePayPalExpressOption() {
-    if (( cj("#bypass_payment").val() == 1 )) {
-      cj("#crm-submit-buttons").show();
-      cj("#paypalExpress").hide();
-    }
-    else {
-      cj("#paypalExpress").show();
-      cj("#crm-submit-buttons").hide();
-    }
-  }
-
-  {/literal}{if ($bypassPayment and $showHidePaymentInformation)}{literal}
-  showHidePaymentInfo();
-  {/literal} {/if}{literal}
-
-  function showHidePaymentInfo() {
-    if (( cj("#bypass_payment").val() == 1 )) {
-      cj('#billing-payment-block').hide();
-    }
-    else {
-      cj('#billing-payment-block').show();
-    }
   }
 
   {/literal}{if $allowGroupOnWaitlist}{literal}
@@ -307,17 +235,6 @@
       //reset value since user don't want or not eligible for waitlist
       cj("#bypass_payment").val(0);
     }
-
-    //now call showhide payment info.
-    {/literal}
-    {if ($bypassPayment) and $paymentProcessor.payment_processor_type EQ 'PayPal_Express'}{literal}
-    showHidePayPalExpressOption();
-    {/literal}{/if}
-    {literal}
-
-    {/literal}{if ($bypassPayment) and $showHidePaymentInformation}{literal}
-    showHidePaymentInfo();
-    {/literal}{/if}{literal}
   }
 
   {/literal}

--- a/templates/CRM/Price/Form/Calculate.tpl
+++ b/templates/CRM/Price/Form/Calculate.tpl
@@ -46,7 +46,7 @@ var thousandMarker = '{/literal}{$config->monetaryThousandSeparator}{literal}';
 var separator      = '{/literal}{$config->monetaryDecimalPoint}{literal}';
 var symbol         = '{/literal}{$currencySymbol}{literal}';
 var optionSep      = '|';
-var priceSet = price = Array();
+
 cj("#priceset [price]").each(function () {
 
     var elementType =  cj(this).attr('type');
@@ -185,15 +185,12 @@ function display(totalfee) {
     totalfee = Math.round(totalfee*100)/100;
     var totalEventFee  = formatMoney( totalfee, 2, separator, thousandMarker);
     document.getElementById('pricevalue').innerHTML = "<b>"+symbol+"</b> "+totalEventFee;
-    scriptfee   = totalfee;
 
     cj('#total_amount').val( totalfee );
     cj('#pricevalue').data('raw-total', totalfee).trigger('change');
 
     ( totalfee < 0 ) ? cj('table#pricelabel').addClass('disabled') : cj('table#pricelabel').removeClass('disabled');
-    if (typeof skipPaymentMethod == 'function') {
-      skipPaymentMethod();
-    }
+    skipPaymentMethod();
 }
 
 //money formatting/localization
@@ -205,6 +202,60 @@ var n = amount,
     i = parseInt(n = Math.abs(+n || 0).toFixed(c)) + "",
     j = (j = i.length) > 3 ? j % 3 : 0;
   return s + (j ? i.substr(0, j) + t : "") + i.substr(j).replace(/(\d{3})(?=\d)/g, "$1" + t) + (c ? d + Math.abs(n - i).toFixed(c).slice(2) : "");
+}
+
+/**
+ * Show or hide payment options.
+ *
+ * @param bool $isHide
+ *   Should the block be hidden.
+ */
+function showHidePayment(isHide) {
+  var payment_options = cj(".payment_options-group");
+  var payment_processor = cj("div.payment_processor-section");
+  var payment_information = cj("div#payment_information");
+  // I've added a hide for billing block. But, actually the issue
+  // might be that the unselecting of the processor should cause it
+  // to be hidden (or removed) in which case it can go from this function.
+  var billing_block = cj("div#billing-payment-block");
+  if (isHide) {
+    payment_options.hide();
+    payment_processor.hide();
+    payment_information.hide();
+    billing_block.hide();
+    // also unset selected payment methods
+    cj('input[name="payment_processor_id"]').removeProp('checked');
+  }
+  else {
+    payment_options.show();
+    payment_processor.show();
+    payment_information.show();
+    billing_block.show();
+  }
+}
+
+/**
+ * Hides or shows billing and payment options block depending on whether payment is required.
+ *
+ * In general incomplete orders or $0 orders do not require a payment block.
+ */
+function skipPaymentMethod() {
+  var isHide = false;
+  var isMultiple = '{/literal}{$event.is_multiple_registrations}{literal}';
+  var alwaysShowFlag = (isMultiple && cj("#additional_participants").val());
+  var alwaysHideFlag = (cj("#bypass_payment").val() == 1);
+  var total_amount_tmp =  cj('#pricevalue').data('raw-total');
+  // Hide billing questions if this is free
+  if (!alwaysShowFlag && total_amount_tmp == 0){
+    isHide = true;
+  }
+  else {
+    isHide = false;
+  }
+  if (alwaysHideFlag) {
+    isHide = true;
+  }
+  showHidePayment(isHide);
 }
 
 {/literal}

--- a/templates/CRM/Price/Form/Calculate.tpl
+++ b/templates/CRM/Price/Form/Calculate.tpl
@@ -190,7 +190,11 @@ function display(totalfee) {
     cj('#pricevalue').data('raw-total', totalfee).trigger('change');
 
     ( totalfee < 0 ) ? cj('table#pricelabel').addClass('disabled') : cj('table#pricelabel').removeClass('disabled');
-    skipPaymentMethod();
+    if (typeof skipPaymentMethod == 'function') {
+      // Advice to anyone who, like me, feels hatred towards this if construct ... if you remove the if you
+      // get an error on participant 2 of a event that requires approval & permits multiple registrants.
+      skipPaymentMethod();
+    }
 }
 
 //money formatting/localization
@@ -202,60 +206,6 @@ var n = amount,
     i = parseInt(n = Math.abs(+n || 0).toFixed(c)) + "",
     j = (j = i.length) > 3 ? j % 3 : 0;
   return s + (j ? i.substr(0, j) + t : "") + i.substr(j).replace(/(\d{3})(?=\d)/g, "$1" + t) + (c ? d + Math.abs(n - i).toFixed(c).slice(2) : "");
-}
-
-/**
- * Show or hide payment options.
- *
- * @param bool $isHide
- *   Should the block be hidden.
- */
-function showHidePayment(isHide) {
-  var payment_options = cj(".payment_options-group");
-  var payment_processor = cj("div.payment_processor-section");
-  var payment_information = cj("div#payment_information");
-  // I've added a hide for billing block. But, actually the issue
-  // might be that the unselecting of the processor should cause it
-  // to be hidden (or removed) in which case it can go from this function.
-  var billing_block = cj("div#billing-payment-block");
-  if (isHide) {
-    payment_options.hide();
-    payment_processor.hide();
-    payment_information.hide();
-    billing_block.hide();
-    // also unset selected payment methods
-    cj('input[name="payment_processor_id"]').removeProp('checked');
-  }
-  else {
-    payment_options.show();
-    payment_processor.show();
-    payment_information.show();
-    billing_block.show();
-  }
-}
-
-/**
- * Hides or shows billing and payment options block depending on whether payment is required.
- *
- * In general incomplete orders or $0 orders do not require a payment block.
- */
-function skipPaymentMethod() {
-  var isHide = false;
-  var isMultiple = '{/literal}{$event.is_multiple_registrations}{literal}';
-  var alwaysShowFlag = (isMultiple && cj("#additional_participants").val());
-  var alwaysHideFlag = (cj("#bypass_payment").val() == 1);
-  var total_amount_tmp =  cj('#pricevalue').data('raw-total');
-  // Hide billing questions if this is free
-  if (!alwaysShowFlag && total_amount_tmp == 0){
-    isHide = true;
-  }
-  else {
-    isHide = false;
-  }
-  if (alwaysHideFlag) {
-    isHide = true;
-  }
-  showHidePayment(isHide);
 }
 
 {/literal}

--- a/templates/CRM/common/paymentBlock.tpl
+++ b/templates/CRM/common/paymentBlock.tpl
@@ -25,6 +25,60 @@
 *}
 {literal}
 <script type="text/javascript">
+  /**
+   * Show or hide payment options.
+   *
+   * @param bool $isHide
+   *   Should the block be hidden.
+   */
+  function showHidePayment(isHide) {
+    var payment_options = cj(".payment_options-group");
+    var payment_processor = cj("div.payment_processor-section");
+    var payment_information = cj("div#payment_information");
+    // I've added a hide for billing block. But, actually the issue
+    // might be that the unselecting of the processor should cause it
+    // to be hidden (or removed) in which case it can go from this function.
+    var billing_block = cj("div#billing-payment-block");
+    if (isHide) {
+      payment_options.hide();
+      payment_processor.hide();
+      payment_information.hide();
+      billing_block.hide();
+      // also unset selected payment methods
+      cj('input[name="payment_processor_id"]').removeProp('checked');
+    }
+    else {
+      payment_options.show();
+      payment_processor.show();
+      payment_information.show();
+      billing_block.show();
+    }
+  }
+
+  /**
+   * Hides or shows billing and payment options block depending on whether payment is required.
+   *
+   * In general incomplete orders or $0 orders do not require a payment block.
+   */
+  function skipPaymentMethod() {
+    var isHide = false;
+    var isMultiple = '{/literal}{$event.is_multiple_registrations}{literal}';
+    var alwaysShowFlag = (isMultiple && cj("#additional_participants").val());
+    var alwaysHideFlag = (cj("#bypass_payment").val() == 1);
+    var total_amount_tmp =  cj('#pricevalue').data('raw-total');
+    // Hide billing questions if this is free
+    if (!alwaysShowFlag && total_amount_tmp == 0){
+      isHide = true;
+    }
+    else {
+      isHide = false;
+    }
+    if (alwaysHideFlag) {
+      isHide = true;
+    }
+    showHidePayment(isHide);
+  }
+  skipPaymentMethod();
 
   CRM.$(function($) {
     function buildPaymentBlock(type) {


### PR DESCRIPTION
@davecivicrm  I think writing this caused physical injury to my brain. There are some comments on the latest commit but basically I believe the payment block is hiding / showing as it should in all the cases I'm aware of.

However, I noticed that the price set block is displayed for the second participant but not the first in a requires-approval flow (a quick-config one in my test). I suspect it should show on the first AND the second participant - but have not yet been back to 4.6 to compare behaviour.
