### PR TITLE
CRM-17539 preliminary tests on receipts for memberships

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2391,9 +2391,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
         foreach ($this->_relatedObjects['membership'] as $membership) {
           if ($membership->id) {
             $values['isMembership'] = TRUE;
-
-            // need to set the membership values here
-            $template->assign('membership_assign', 1);
+            $values['membership_assign'] = TRUE;
             $template->assign('membership_name',
               CRM_Member_PseudoConstant::membershipType($membership->membership_type_id)
             );

--- a/CRM/Contribute/BAO/Contribution/Utils.php
+++ b/CRM/Contribute/BAO/Contribution/Utils.php
@@ -116,8 +116,10 @@ class CRM_Contribute_BAO_Contribution_Utils {
         $form->_bltID,
         $isRecur
       );
-
-      $paymentParams['contributionTypeID'] = $contributionTypeId;
+      $paymentParams['contributionID'] = $contribution->id;
+      //CRM-15297 deprecate contributionTypeID
+      $paymentParams['financialTypeID'] = $paymentParams['contributionTypeID'] = $contribution->financial_type_id;
+      $paymentParams['contributionPageID'] = $contribution->contribution_page_id;
       $paymentParams['item_name'] = $form->_params['description'];
 
       if ($contribution && $form->_values['is_recur'] && $contribution->contribution_recur_id

--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -350,11 +350,30 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
         'title' => $title,
         'isShare' => CRM_Utils_Array::value('is_share', $values),
         'thankyou_title' => CRM_Utils_Array::value('thankyou_title', $values),
+        // The meaning of this parameter seems to have a weak correlation with the variable name.
+        'useForMember' => TRUE,
       );
 
+      // This next section sets tplParams for these parameters if they exist.
+      // There is some leakage around these parameters so ideally they would always be passed in
+      // to ensure that multiple iterations of this code (e.g via the api) don't cause parameter
+      // leakage.
+      // It might make sense to mae these e-noticy to encourage consistency .....
+      $parametersThatWeThinkShouldAlwaysBePassedIn = array(
+        'amount',
+        'membership_assign',
+        'useForMember',
+        'membership_amount',
+      );
+      foreach ($parametersThatWeThinkShouldAlwaysBePassedIn as $parameter) {
+        if (isset($values[$parameter])) {
+          $tplParams[$parameter] = $values[$parameter];
+        }
+      }
+
       if ($contributionTypeId = CRM_Utils_Array::value('financial_type_id', $values)) {
-        $tplParams['contributionTypeId'] = $contributionTypeId;
-        $tplParams['contributionTypeName'] = CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_FinancialType',
+        $tplParams['financialTypeId'] = $tplParams['contributionTypeId'] = $contributionTypeId;
+        $tplParams['financialTypeName'] = $tplParams['contributionTypeName'] = CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_FinancialType',
           $contributionTypeId);
       }
 

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1419,7 +1419,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $membershipContribution = NULL;
     $isTest = CRM_Utils_Array::value('is_test', $membershipParams, FALSE);
     $errors = $createdMemberships = $paymentResults = array();
-    
+
     $isRecurForFirstTransaction = CRM_Utils_Array::value('is_recur', $form->_values, CRM_Utils_Array::value('is_recur', $membershipParams));
     $membershipAmount = $amount = $membershipParams['amount'];
 

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1376,7 +1376,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $this->postProcessMembership($membershipParams, $contactID,
       $this, $premiumParams, $customFieldsFormatted, $fieldTypes, $membershipType, $membershipTypeIDs, $isPaidMembership, $this->_membershipId, $isProcessSeparateMembershipTransaction, $financialTypeID,
       $membershipLineItems, $isPayLater, $isPending);
-
+    $this->assign('is_separate_membership_payment', $isProcessSeparateMembershipTransaction);
     $this->assign('membership_assign', TRUE);
     $this->set('membershipTypeID', $membershipParams['selectMembership']);
   }
@@ -1419,8 +1419,9 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $membershipContribution = NULL;
     $isTest = CRM_Utils_Array::value('is_test', $membershipParams, FALSE);
     $errors = $createdMemberships = $paymentResults = array();
-
+    
     $isRecurForFirstTransaction = CRM_Utils_Array::value('is_recur', $form->_values, CRM_Utils_Array::value('is_recur', $membershipParams));
+    $membershipAmount = $amount = $membershipParams['amount'];
 
     if ($isPaidMembership) {
       if ($isProcessSeparateMembershipTransaction) {
@@ -1455,8 +1456,11 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         if (empty($form->_params['auto_renew']) && !empty($membershipParams['is_recur'])) {
           unset($membershipParams['is_recur']);
         }
+        $membershipAmount = CRM_Utils_Array::value('minimum_fee', $membershipDetails, 0);
+        $form->set('membership_amount', $membershipAmount);
+        $form->assign('membership_amount', $membershipAmount);
         list($membershipContribution, $secondPaymentResult) = $this->processSecondaryFinancialTransaction($contactID, $form, $membershipParams,
-          $isTest, $membershipLineItems, CRM_Utils_Array::value('minimum_fee', $membershipDetails, 0), CRM_Utils_Array::value('financial_type_id', $membershipDetails));
+          $isTest, $membershipLineItems, $membershipAmount, CRM_Utils_Array::value('financial_type_id', $membershipDetails));
         $paymentResults[] = array('contribution_id' => $membershipContribution->id, 'result' => $secondPaymentResult);
       }
       catch (CRM_Core_Exception $e) {
@@ -1595,14 +1599,18 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       $paymentParams = array_merge($form->_params, array('contributionID' => $form->_values['contribution_other_id']));
       $paymentActionResult = $payment->doPayment($paymentParams, 'contribute');
       $paymentResults[] = array('contribution_id' => $paymentResult['contribution']->id, 'result' => $paymentActionResult);
-      // Do not send an email if Recurring transaction is done via Direct Mode
-      // Email will we sent when the IPN is received.
       foreach ($paymentResults as $result) {
         $this->completeTransaction($result['result'], $result['contribution_id']);
       }
       return;
     }
 
+    $form->_values['membership_amount'] = $membershipAmount;
+    $form->_values['amount'] = $amount;
+    if ($amount == 0) {
+      // This feels like a bizarre hack as the variable name doesn't seem to be directly connected to it's use in the template.
+      $form->_values['useForMember'] = 0;
+    }
     //finally send an email receipt
     CRM_Contribute_BAO_ContributionPage::sendMail($contactID,
       $form->_values,
@@ -1642,12 +1650,12 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    * @throws Exception
    * @return CRM_Contribute_BAO_Contribution
    */
-  protected function processSecondaryFinancialTransaction($contactID, &$form, $tempParams, $isTest, $lineItems, $minimumFee,
+  protected function processSecondaryFinancialTransaction($contactID, &$form, $tempParams, $isTest, $lineItems, $membershipAmount,
                                                    $financialTypeID) {
     $financialType = new CRM_Financial_DAO_FinancialType();
     $financialType->id = $financialTypeID;
     $financialType->find(TRUE);
-    $tempParams['amount'] = $minimumFee;
+    $tempParams['amount'] = $membershipAmount;
     $tempParams['invoiceID'] = md5(uniqid(rand(), TRUE));
     $isRecur = CRM_Utils_Array::value('is_recur', $tempParams);
 
@@ -1660,9 +1668,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       $form->set('params', $form->_params);
       $form->assign('receive_date', $receiveDate);
     }
-
-    $form->set('membership_amount', $minimumFee);
-    $form->assign('membership_amount', $minimumFee);
 
     // we don't need to create the user twice, so lets disable cms_create_account
     // irrespective of the value, CRM-2888
@@ -1699,7 +1704,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     );
 
     $result = array();
-    if ($form->_values['is_monetary'] && !$form->_params['is_pay_later'] && $minimumFee > 0.0) {
+    if ($form->_values['is_monetary'] && !$form->_params['is_pay_later'] && $membershipAmount > 0.0) {
       // At the moment our tests are calling this form in a way that leaves 'object' empty. For
       // now we compensate here.
       if (empty($form->_paymentProcessor['object'])) {

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1514,6 +1514,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
           $numTerms, $membershipID, $pending,
           $contributionRecurID, $membershipSource, $isPayLater, $campaignId
         );
+        $createdMemberships[] = $membership;
         $form->set('renewal_mode', $renewalMode);
         if (!empty($dates)) {
           $form->assign('mem_start_date',
@@ -1844,6 +1845,8 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $params['invoiceID'] = md5(uniqid(rand(), TRUE));
     $paramsProcessedForForm = $form->_params = self::getFormParams($params['id'], $params);
     $form->_amount = $params['amount'];
+    $form->_bltID = CRM_Core_BAO_LocationType::getBilling();
+
     // hack these in for test support.
     $form->_fields['billing_first_name'] = 1;
     $form->_fields['billing_last_name'] = 1;

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -905,4 +905,20 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
     $this->_paymentProcessor = $this->callAPISuccess('payment_processor', 'getsingle', array('id' => $this->params['payment_processor_id']));
   }
 
+  /**
+   * Add a profile to a contribution page.
+   *
+   * @param string $name
+   * @param int $contributionPageID
+   */
+  protected function addProfile($name, $contributionPageID) {
+    $this->callAPISuccess('UFJoin', 'create', array(
+      'uf_group_id' => $name,
+      'module' => 'civicrm_contribution_page',
+      'entity_table' => 'civicrm_contribution_page',
+      'entity_id' => $contributionPageID,
+      'weight' => 1,
+    ));
+  }
+
 }

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -329,7 +329,7 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
     $contribution = $this->callAPISuccess('contribution', 'getsingle', array('contribution_page_id' => $this->_ids['contribution_page']));
     $this->callAPISuccess('membership_payment', 'getsingle', array('contribution_id' => $contribution['id']));
     $mut->checkMailLog(array(
-      'Membership Type: General',
+      'Membership',
     ));
     $mut->stop();
     $mut->clearMessages();
@@ -400,12 +400,14 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
   public function testSubmitMembershipBlockIsSeparatePaymentWithEmail() {
     $mut = new CiviMailUtils($this, TRUE);
     $this->setUpMembershipContributionPage(TRUE);
+    $this->addOtherAmountFieldToMembershipPriceSet();
     $this->addProfile('supporter_profile', $this->_ids['contribution_page']);
 
     $submitParams = array(
       'price_' . $this->_ids['price_field'][0] => reset($this->_ids['price_field_value']),
+      'price_' . $this->_ids['price_field']['other_amount'] => 8,
       'id' => (int) $this->_ids['contribution_page'],
-      'amount' => 10,
+      'amount' => 8,
       'billing_first_name' => 'Billy',
       'billing_middle_name' => 'Goat',
       'billing_last_name' => 'Gruff',
@@ -421,8 +423,7 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
     $membership = $this->callAPISuccessGetSingle('membership', array('id' => $membershipPayment['membership_id']));
     $this->assertEquals($membership['contact_id'], $contributions['values'][$membershipPayment['contribution_id']]['contact_id']);
     $mut->checkMailLog(array(
-      'General Membership: $ 2.00',
-      'Membership Fee',
+      '$ 8.00',
     ));
     $mut->stop();
     $mut->clearMessages();
@@ -809,7 +810,7 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
         'membership_type_id' => $membershipTypeID,
         'price_field_id' => $priceField['id'],
       ));
-      $this->_ids['price_field_value'][] = $priceFieldValue['id'];
+      $this->_ids['price_field_value'][] = $priceFieldValue;
     }
   }
 


### PR DESCRIPTION
(I have some doubts as to whether the receipt text is quite right as tested -but that can be edited later so setting to merge on pass)

---
- [CRM-17539: Free $0 contribution\/membership show payment status: 'Incomplete transaction' instead of 'Completed'](https://issues.civicrm.org/jira/browse/CRM-17539)
