### PR TITLE
CRM-17394 - Initialize DB slightly later. Fix query-log and redundant SET NAMES.

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -590,7 +590,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
     }
     $file_log->close();
 
-    if ($config->userFrameworkLogging) {
+    if (!empty($config->userFrameworkLogging)) {
       // should call $config->userSystem->logger($message) here - but I got a situation where userSystem was not an object - not sure why
       if ($config->userSystem->is_drupal and function_exists('watchdog')) {
         watchdog('civicrm', '%message', array('%message' => $message), WATCHDOG_DEBUG);

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -335,10 +335,6 @@ class Container {
     );
     $runtime->initialize($loadFromDB);
 
-    if ($loadFromDB && $runtime->dsn) {
-      \CRM_Core_DAO::init($runtime->dsn);
-    }
-
     $bootServices['paths'] = array(
       'class' => 'Civi\Core\Paths',
       'obj' => new \Civi\Core\Paths(),
@@ -377,6 +373,7 @@ class Container {
     );
 
     if ($loadFromDB && $runtime->dsn) {
+      \CRM_Core_DAO::init($runtime->dsn);
       \CRM_Utils_Hook::singleton(TRUE);
       \CRM_Extension_System::singleton(TRUE);
 


### PR DESCRIPTION
Strictly speaking, this patch does two different things:
- Initialize DB slightly later. This fixes a race among settings-manager, DB init, and query logging.
- Call `SET NAMES utf8` once during connection init. Before, it was called once for every DAO object.

Based on quick spot-check, it still seems to store UTF-8 data. To be safe,
I've added an extra error-check to ensure that the `SET NAMES utf8` is still
called before we actually use the DAO.
