### PR TITLE
CRM-17588 - fix for single value for multi-select-fields passed by the api-explorer

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1647,6 +1647,11 @@ SELECT id
               array_values($value)
             ) . CRM_Core_DAO::VALUE_SEPARATOR;
         }
+        // Passing a single value via api-explorer you won't get an array
+        // but a string without separators - CRM-17588
+        elseif (strpos($value, CRM_Core_DAO::VALUE_SEPARATOR) !== 0) {
+          $value = CRM_Core_DAO::VALUE_SEPARATOR . $value . CRM_Core_DAO::VALUE_SEPARATOR;
+        }
       }
       else {
         $value = '';


### PR DESCRIPTION
The api-explorer passes a single value for a multi-select-field as string. But CRM_Core_BAO_CustomField::formatCustomField expects values for multi-select-fields to be an array (or when merging contacts an already prepared string).
At least the value will be written to the database without any separators and that will lead to some problems when editing the entity.
