### PR TITLE
Fix for CRM-17520 - webtest

### DIFF
--- a/tests/phpunit/WebTest/Contribute/OfflineContributionTest.php
+++ b/tests/phpunit/WebTest/Contribute/OfflineContributionTest.php
@@ -283,7 +283,7 @@ class WebTest_Contribute_OfflineContributionTest extends CiviSeleniumTestCase {
       'From' => "{$firstName} {$lastName}",
       'Financial Type' => 'Donation',
       'Total Amount' => 123,
-      'Non-deductible Amount' => 123,
+      'Non-deductible Amount' => '0.00',
       'sort_name' => "$lastName, $firstName",
     );
     $this->_verifyAmounts($checkScenario4);


### PR DESCRIPTION
This is an outcome of https://github.com/civicrm/civicrm-core/pull/5378. Not sure why the assertion was changed there as it doesn't have any comment to indicate as for which the line was modified. IMO, if an assertion is changed, a reason for it should be mentioned as an additional information.

https://issues.civicrm.org/jira/browse/CRM-17520
