### PR TITLE
CRM-17520 webtest fix

### DIFF
--- a/tests/phpunit/WebTest/Contribute/OfflineContributionTest.php
+++ b/tests/phpunit/WebTest/Contribute/OfflineContributionTest.php
@@ -283,7 +283,7 @@ class WebTest_Contribute_OfflineContributionTest extends CiviSeleniumTestCase {
       'From' => "{$firstName} {$lastName}",
       'Financial Type' => 'Donation',
       'Total Amount' => 123,
-      'Non-deductible Amount' => 123,
+      'Non-deductible Amount' => '0.00',
       'sort_name' => "$lastName, $firstName",
     );
     $this->_verifyAmounts($checkScenario4);


### PR DESCRIPTION
---
- CRM-17520: Wrong Non-deductable amount after doing back-office contribution with is_deductible = TRUE and no premium
  https://issues.civicrm.org/jira/browse/CRM-17520
