### PR TITLE
fixed #CRM-17382

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -2205,9 +2205,6 @@ AND cl.modified_id  = c.id
             'type' => CRM_Utils_Type::T_BOOLEAN,
           ),
         );
-
-        // add custom data for cases
-        $fields = array_merge($fields, CRM_Core_BAO_CustomField::getFieldsForImport('Case'));
       }
 
       // add custom data for case activities

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -1741,6 +1741,9 @@ SELECT case_status.label AS case_status, status_id, civicrm_case_type.title AS c
         'name' => 'case_status',
       );
 
+      // add custom data for cases
+      $fields = array_merge($fields, CRM_Core_BAO_CustomField::getFieldsForImport('Case'));
+
       self::$_exportableFields = $fields;
     }
     return self::$_exportableFields;


### PR DESCRIPTION
Moved the custom fields for export from the Activity BAO to the Case BAO. This way the custom fields linked to cases will show up on the export screen under case (where you would expect them) rather than under Case Activity
