### PR TITLE
[unresolved-regression] CRM-17616 - Moving to an arbitrary search page result could lead to incomplete results

### DIFF
--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -904,8 +904,8 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
       $cacheKey .= "_alphabet";
       $this->fillupPrevNextCache($sort, $cacheKey);
     }
-    elseif ($firstRecord >= $countRow) {
-      $this->fillupPrevNextCache($sort, $cacheKey, $countRow, 500 + $firstRecord - $countRow);
+    elseif ($firstRecord + $pageSize >= $countRow) {
+      $this->fillupPrevNextCache($sort, $cacheKey, $countRow, max(500, $pageSize) + $firstRecord - $countRow);
     }
     return $cacheKey;
   }


### PR DESCRIPTION
Partial resolution of this problem.
When launching a new search without reset=1, $pageSize is not initialized correctly and is initialized to 50 by default. 
There is no regression though because i have used max(500, $pageSize) to enforce at least 500 each time the cache is refreshed.

Next step is to see if we can have $pageSize properly initialized every time.

---
- [CRM-17616: Moving to an arbitrary search page result could lead to incomplete results](https://issues.civicrm.org/jira/browse/CRM-17616)
