### PR TITLE
CRM-17620 expose payment data for contributions in the UI

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3745,6 +3745,12 @@ WHERE eft.financial_trxn_id IN ({$trxnId}, {$baseTrxnId['financialTrxnId']})
         }
       }
     }
+    else {
+      $contributionId = $id;
+      $entity = 'contribution';
+      $entityTable = 'civicrm_contribution';
+    }
+
     $total = CRM_Core_BAO_FinancialTrxn::getBalanceTrxnAmt($contributionId);
     $baseTrxnId = !empty($total['trxn_id']) ? $total['trxn_id'] : NULL;
     $isBalance = NULL;

--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -81,6 +81,7 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
     $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE);
     $this->assign('component', $this->_component);
     $this->assign('id', $this->_id);
+    $this->assign('suppressPaymentFormButtons', $this->isBeingCalledFromSelectorContext());
 
     if ($this->_view == 'transaction' && ($this->_action & CRM_Core_Action::BROWSE)) {
       $paymentInfo = CRM_Contribute_BAO_Contribution::getPaymentInfo($this->_id, $this->_component, TRUE);
@@ -141,6 +142,15 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
     $this->assign('paymentAmt', abs($paymentAmt));
 
     $this->setPageTitle($this->_refund ? ts('Refund') : ts('Payment'));
+  }
+
+  /**
+   * Is this function being called from a datatable selector.
+   *
+   * If so we don't want to show the buttons.
+   */
+  protected function isBeingCalledFromSelectorContext() {
+    return CRM_Utils_Request::retrieve('selector', 'Positive');
   }
 
   /**

--- a/CRM/Contribute/Selector/Search.php
+++ b/CRM/Contribute/Selector/Search.php
@@ -524,6 +524,7 @@ class CRM_Contribute_Selector_Search extends CRM_Core_Selector_Base implements C
           ),
         )
       );
+    $pre = array();
     if (!$this->_single) {
       $pre = array(
         array('desc' => ts('Contact Type')),
@@ -533,8 +534,14 @@ class CRM_Contribute_Selector_Search extends CRM_Core_Selector_Base implements C
           'direction' => CRM_Utils_Sort::DONTCARE,
         ),
       );
-      self::$_columnHeaders = array_merge($pre, self::$_columnHeaders);
     }
+    $pre[] = array(
+      array(
+        'desc' => '',
+        array(),
+      ),
+    );
+    self::$_columnHeaders = array_merge($pre, self::$_columnHeaders);
     if ($this->_includeSoftCredits) {
       self::$_columnHeaders = array_merge(
         self::$_columnHeaders,

--- a/templates/CRM/Contribute/Form/AdditionalPayment.tpl
+++ b/templates/CRM/Contribute/Form/AdditionalPayment.tpl
@@ -51,12 +51,19 @@
      {else}
        {assign var='entity' value=$component}
      {/if}
-    {ts 1=$entity}No additional payments found for this %1 record{/ts}
+    {if $suppressPaymentFormButtons}
+      {ts 1=$entity}No payments found for this %1 record{/ts}
+    {else}
+      {* Am unsure where this appears so unsure if above text could apply *}
+      {ts 1=$entity}No Additional payments found for this %1 record{/ts}
+    {/if}
   {/if}
- <div class="crm-submit-buttons">
-    {include file="CRM/common/formButtons.tpl"}
- </div>
-{elseif $formType}
+  {if !$suppressPaymentFormButtons}
+    <div class="crm-submit-buttons">
+       {include file="CRM/common/formButtons.tpl"}
+    </div>
+  {/if}
+ {elseif $formType}
   {include file="CRM/Contribute/Form/AdditionalInfo/$formType.tpl"}
 {else}
 

--- a/templates/CRM/Contribute/Form/Selector.tpl
+++ b/templates/CRM/Contribute/Form/Selector.tpl
@@ -49,17 +49,24 @@
   </tr>
   </thead>
 
+  <p class="description">
+    {ts}Click arrow to view payment details.{/ts}
+  </p>
   {counter start=0 skip=1 print=false}
   {foreach from=$rows item=row}
-  <tr id="rowid{$row.contribution_id}" class="{cycle values="odd-row,even-row"}{if $row.cancel_date} cancelled{/if} crm-contribution_{$row.contribution_id}">
+  <tr id="rowid{$row.contribution_id}" class="{cycle values="odd-row,even-row"}
+  {if $row.cancel_date} cancelled{/if} crm-contribution_{$row.contribution_id}">
     {if !$single }
         {if $context eq 'Search' }
           {assign var=cbName value=$row.checkbox}
           <td>{$form.$cbName.html}</td>
    {/if}
+
     <td>{$row.contact_type}</td>
       <td><a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.contact_id`"}">{$row.sort_name}</a></td>
     {/if}
+    {assign var="targetRowID" value="paymentDetails"|cat:$row.contribution_id}
+    {include file='CRM/common/expandRow.tpl' rowEntityID=$row.contribution_id rowEntity='contribution' targetRowID=$targetRowID baseUrl='payment'}
     {if $row.contribution_soft_credit_amount}
       <td class="right bold crm-contribution-amount">&nbsp;</td>
     {else}
@@ -89,9 +96,14 @@
     {/if}
     <td>{$row.action|replace:'xx':$row.contribution_id}</td>
   </tr>
+    <tr id="{$targetRowID}_row" class='{$rowClass} hiddenElement'>
+      <td style="border-right: none;"></td>
+      <td colspan= {if $context EQ 'Search'} "10" {else} "8" {/if} class="enclosingNested" id="{$targetRowID}">&nbsp;</td>
+    </tr>
   {/foreach}
 
 </table>
 {/strip}
 
 {include file="CRM/common/pager.tpl" location="bottom"}
+

--- a/templates/CRM/common/expandRow.tpl
+++ b/templates/CRM/common/expandRow.tpl
@@ -1,0 +1,54 @@
+ <td>
+    <span id="icon_{$targetRowID}_show" title="{ts}Show payments{/ts}">
+      <a href="#" data-entity_id='{$rowEntityID}' data-base_url="{$baseUrl}"
+         data-contact_id='{$row.contact_id}' data-entity='{$rowEntity}' data-target_row='{$targetRowID}'
+         onclick="subDetails(this);
+          showSubDetails(this);
+          return false;">
+        <img src="{$config->resourceBase}i/TreePlus.gif" class="action-icon" alt="{ts}open section{/ts}"/>
+      </a>
+    </span>
+    <span id="icon_{$targetRowID}_hide" class="hiddenElement">
+        <a data-entity_id='{$rowEntityID}' href="#"  data-contact_id='{$row.contact_id}' data-entity='{$rowEntity}' data-target_row='{$targetRowID}'
+           href="#" onclick="hideSubDetails(this);
+          return false;"><img src="{$config->resourceBase}i/TreeMinus.gif" class="action-icon" alt="{ts}open section{/ts}"/>
+        </a>
+    </span>
+  </td>
+
+  {literal}
+  <script type="text/javascript">
+      function subDetails(element) {
+        var entityId = cj(element).data('entity_id');
+        var targetRow = cj(element).data('target_row');
+        var rowElement = cj('#' + targetRow);
+        var contactId = cj(element).data('contact_id');
+        var entity = cj(element).data('entity');
+        var baseURL = 'civicrm/' + cj(element).data('base_url');
+        var dataUrl = CRM.url(baseURL, {
+          'view': 'transaction',
+          'component': entity,
+          'action': 'browse',
+          'cid': contactId,
+          'id': entityId,
+          'selector' : 1,
+        });
+        CRM.loadPage(dataUrl, {'target': rowElement});
+      }
+
+      function showSubDetails(element) {
+        var targetRow = cj(element).data('target_row');
+        cj('#' + targetRow + '_row').show();
+        cj('#icon_' + targetRow + '_show').hide();
+        cj('#icon_' + targetRow + '_hide').show();
+      }
+
+      function hideSubDetails(element) {
+        var targetRow = cj(element).data('target_row');
+        cj('#' + targetRow + '_row').hide();
+        cj('#icon_' + targetRow + '_show').show();
+        cj('#icon_' + targetRow + '_hide').hide();
+      }
+
+  </script>
+{/literal}


### PR DESCRIPTION
@colemanw wondering if you can pull this & take a preliminary look

My main driver here was to get visibility onto actual payment data (financial transaction) to check the quality of it. I have noticed enough things of concern as a result that I'm going to side-track to digging into that side of it rather than keep going on this this week - but would be good to have some feedback as to whether it is looking like a 'nearly there'. I notice that it's not working well within snippets.

Datawise I'm concerned that when I refund a contribution the date of the refund is not accurate & some lines don't have financial transactions. I don't know if that is a local issue or not but need to dig on that as a priority now.

---
- [CRM-17620: Expose payment data to be visible in the UI](https://issues.civicrm.org/jira/browse/CRM-17620)
