### PR TITLE
CRM-17519 add test to (fail to) demonstrate leakage

### DIFF
--- a/CRM/Core/Payment/AuthorizeNetIPN.php
+++ b/CRM/Core/Payment/AuthorizeNetIPN.php
@@ -55,11 +55,11 @@ class CRM_Core_Payment_AuthorizeNetIPN extends CRM_Core_Payment_BaseIPN {
     //we only get invoice num as a key player from payment gateway response.
     //for ARB we get x_subscription_id and x_subscription_paynum
     $x_subscription_id = $this->retrieve('x_subscription_id', 'String');
+    $ids = $objects = $input = array();
 
     if ($x_subscription_id) {
       //Approved
 
-      $ids = $objects = array();
       $input['component'] = $component;
 
       // load post vars in $input

--- a/tests/phpunit/CiviTest/CiviMailUtils.php
+++ b/tests/phpunit/CiviTest/CiviMailUtils.php
@@ -260,13 +260,24 @@ class CiviMailUtils extends PHPUnit_Framework_TestCase {
    */
   public function checkMailLog($strings, $absentStrings = array(), $prefix = '') {
     $mail = $this->getMostRecentEmail('raw');
-    foreach ($strings as $string) {
-      $this->_ut->assertContains($string, $mail, "$string .  not found in  $mail  $prefix");
-    }
-    foreach ($absentStrings as $string) {
-      $this->_ut->assertEmpty(strstr($mail, $string), "$string  incorrectly found in $mail $prefix");;
-    }
-    return $mail;
+    return $this->checkMailForStrings($strings, $absentStrings, $prefix, $mail);
+  }
+
+  /**
+   * Check contents of mail log.
+   *
+   * @param array $strings
+   *   Strings that should be included.
+   * @param array $absentStrings
+   *   Strings that should not be included.
+   * @param string $prefix
+   *
+   * @return \ezcMail|string
+   */
+  public function checkAllMailLog($strings, $absentStrings = array(), $prefix = '') {
+    $mails = $this->getAllMessages('raw');
+    $mail = implode(',', $mails);
+    return $this->checkMailForStrings($strings, $absentStrings, $prefix, $mail);
   }
 
   /**
@@ -348,6 +359,23 @@ class CiviMailUtils extends PHPUnit_Framework_TestCase {
     $mail = $parser->parseMail($set);
     $this->_ut->assertNotEmpty($mail, 'Cannot parse mail');
     return $mail[0];
+  }
+
+  /**
+   * @param $strings
+   * @param $absentStrings
+   * @param $prefix
+   * @param $mail
+   * @return mixed
+   */
+  public function checkMailForStrings($strings, $absentStrings, $prefix, $mail) {
+    foreach ($strings as $string) {
+      $this->_ut->assertContains($string, $mail, "$string .  not found in  $mail  $prefix");
+    }
+    foreach ($absentStrings as $string) {
+      $this->_ut->assertEmpty(strstr($mail, $string), "$string  incorrectly found in $mail $prefix");;
+    }
+    return $mail;
   }
 
 }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3187,7 +3187,9 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
       'frequency_interval' => 1,
       'invoice_id' => $this->_invoiceID,
       'contribution_status_id' => 2,
-      'processor_id' => $this->_paymentProcessorID,
+      'payment_processor_id' => $this->_paymentProcessorID,
+      // processor provided ID - use contact ID as proxy.
+      'processor_id' => $this->_contactID,
       'api.contribution.create' => array(
         'total_amount' => '200',
         'invoice_id' => $this->_invoiceID,
@@ -3382,6 +3384,22 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
     CRM_Price_BAO_PriceField::create($paramsField);
 
     return $priceSetId;
+  }
+
+  /**
+   * Add a profile to a contribution page.
+   *
+   * @param string $name
+   * @param int $contributionPageID
+   */
+  protected function addProfile($name, $contributionPageID) {
+    $this->callAPISuccess('UFJoin', 'create', array(
+      'uf_group_id' => $name,
+      'module' => 'CiviContribute',
+      'entity_table' => 'civicrm_contribution_page',
+      'entity_id' => $contributionPageID,
+      'weight' => 1,
+    ));
   }
 
 }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3177,8 +3177,8 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
   /**
    * Set up initial recurring payment allowing subsequent IPN payments.
    */
-  public function setupRecurringPaymentProcessorTransaction() {
-    $contributionRecur = $this->callAPISuccess('contribution_recur', 'create', array(
+  public function setupRecurringPaymentProcessorTransaction($params = array()) {
+    $contributionRecur = $this->callAPISuccess('contribution_recur', 'create', array_merge(array(
       'contact_id' => $this->_contactID,
       'amount' => 1000,
       'sequential' => 1,
@@ -3198,7 +3198,7 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
         'payment_processor_id' => $this->_paymentProcessorID,
         'is_test' => 0,
       ),
-    ));
+    ), $params));
     $this->_contributionRecurID = $contributionRecur['id'];
     $this->_contributionID = $contributionRecur['values']['0']['api.contribution.create']['id'];
   }
@@ -3209,13 +3209,15 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
   public function setupMembershipRecurringPaymentProcessorTransaction() {
     $this->ids['membership_type'] = $this->membershipTypeCreate();
     //create a contribution so our membership & contribution don't both have id = 1
-    $this->contributionCreate(array(
-      'contact_id' => $this->_contactID,
-      'is_test' => 1,
-      'financial_type_id' => 1,
-      'invoice_id' => 'abcd',
-      'trxn_id' => 345,
-    ));
+    if ($this->callAPISuccess('Contribution', 'getcount', array()) == 0) {
+      $this->contributionCreate(array(
+        'contact_id' => $this->_contactID,
+        'is_test' => 1,
+        'financial_type_id' => 1,
+        'invoice_id' => 'abcd',
+        'trxn_id' => 345,
+      ));
+    }
     $this->setupRecurringPaymentProcessorTransaction();
 
     $this->ids['membership'] = $this->callAPISuccess('membership', 'create', array(
@@ -3239,10 +3241,12 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
       'price_field_id' => $this->callAPISuccess('price_field', 'getvalue', array(
         'return' => 'id',
         'label' => 'Membership Amount',
+        'options' => array('limit' => 1, 'sort' => 'id DESC'),
       )),
       'price_field_value_id' => $this->callAPISuccess('price_field_value', 'getvalue', array(
         'return' => 'id',
         'label' => 'General',
+        'options' => array('limit' => 1, 'sort' => 'id DESC'),
       )),
     ));
     $this->callAPISuccess('membership_payment', 'create', array(


### PR DESCRIPTION
This was an attempt to replicate CRM-17519 & the part of CRM-17539 that I'm blocked on (leakage) in a test. I failed to replicate but tests seem worth adding.

NB - have also stuck in a 4.6 PR & will decide which to merge depending on how that runs so am adding 'wip' to both until I have seen

---
- [CRM-17519: CRM_Core_Payment_BaseIPN::completeTransaction() should clear the Smarty template](https://issues.civicrm.org/jira/browse/CRM-17519)
- [CRM-17539: Free $0 contribution\/membership show payment status: 'Incomplete transaction' instead of 'Completed'](https://issues.civicrm.org/jira/browse/CRM-17539)
