### PR TITLE
CRM-17519 add test to (fail to) demonstrate leakage

### DIFF
--- a/api/v3/MembershipLog.php
+++ b/api/v3/MembershipLog.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * @file
+ * Created by PhpStorm.
+ * User: eileen
+ * Date: 26/11/2015
+ * Time: 10:11 AM
+ */


### PR DESCRIPTION
This was an attempt to replicate CRM-17519 & the part of CRM-17539 that I'm blocked on (leakage) in a test. I failed to replicate but tests seem worth adding.

NB - I tested this against master not 4.6 but if it passes against 4.6 it makes more sense to merge the extra tests to 4.6

---
- [CRM-17519: CRM_Core_Payment_BaseIPN::completeTransaction() should clear the Smarty template](https://issues.civicrm.org/jira/browse/CRM-17519)
- [CRM-17539: Free $0 contribution\/membership show payment status: 'Incomplete transaction' instead of 'Completed'](https://issues.civicrm.org/jira/browse/CRM-17539)
