### PR TITLE
Additional tests on 4.6 (CRM-17519 CRM17539)

### DIFF
--- a/CRM/Core/Payment/AuthorizeNetIPN.php
+++ b/CRM/Core/Payment/AuthorizeNetIPN.php
@@ -57,11 +57,11 @@ class CRM_Core_Payment_AuthorizeNetIPN extends CRM_Core_Payment_BaseIPN {
     //we only get invoice num as a key player from payment gateway response.
     //for ARB we get x_subscription_id and x_subscription_paynum
     $x_subscription_id = $this->retrieve('x_subscription_id', 'String');
+    $ids = $objects = $input = array();
 
     if ($x_subscription_id) {
       //Approved
 
-      $ids = $objects = array();
       $input['component'] = $component;
 
       // load post vars in $input

--- a/tests/phpunit/CRM/Core/BAO/FinancialTrxnTest.php
+++ b/tests/phpunit/CRM/Core/BAO/FinancialTrxnTest.php
@@ -41,7 +41,7 @@ class CRM_Core_BAO_FinancialTrxnTest extends CiviUnitTestCase {
   public function testCreate() {
     $contactId = $this->individualCreate();
     $financialTypeId = 1;
-    $contributionId = $this->contributionCreate($contactId, $financialTypeId);
+    $this->contributionCreate(array('contact_id' => $contactId), $financialTypeId);
     $params = array(
       'contribution_id' => $financialTypeId,
       'to_financial_account_id' => 1,

--- a/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
@@ -16,9 +16,7 @@ class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
 
   public function setUp() {
     parent::setUp();
-    $this->_paymentProcessorID = $this->paymentProcessorCreate(array(
-      'payment_processor_type_id' => 'AuthNet',
-    ));
+    $this->_paymentProcessorID = $this->paymentProcessorAuthorizeNetCreate(array('is_test' => 0));
     $this->_contactID = $this->individualCreate();
     $contributionPage = $this->callAPISuccess('contribution_page', 'create', array(
       'title' => "Test Contribution Page",
@@ -38,8 +36,8 @@ class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
    */
   public function testIPNPaymentRecurSuccess() {
     $this->setupRecurringPaymentProcessorTransaction();
-    $paypalIPN = new CRM_Core_Payment_AuthorizeNetIPN($this->getRecurTransaction());
-    $paypalIPN->main();
+    $IPN = new CRM_Core_Payment_AuthorizeNetIPN($this->getRecurTransaction());
+    $IPN->main();
     $contribution = $this->callAPISuccess('contribution', 'getsingle', array('id' => $this->_contributionID));
     $this->assertEquals(1, $contribution['contribution_status_id']);
     $this->assertEquals('6511143069', $contribution['trxn_id']);
@@ -47,8 +45,8 @@ class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
     $this->assertTrue(substr($contribution['contribution_source'], 0, 20) == "Online Contribution:");
     $contributionRecur = $this->callAPISuccess('contribution_recur', 'getsingle', array('id' => $this->_contributionRecurID));
     $this->assertEquals(5, $contributionRecur['contribution_status_id']);
-    $paypalIPN = new CRM_Core_Payment_AuthorizeNetIPN($this->getRecurSubsequentTransaction());
-    $paypalIPN->main();
+    $IPN = new CRM_Core_Payment_AuthorizeNetIPN($this->getRecurSubsequentTransaction());
+    $IPN->main();
     $contribution = $this->callAPISuccess('contribution', 'get', array(
         'contribution_recur_id' => $this->_contributionRecurID,
         'sequential' => 1,
@@ -62,8 +60,8 @@ class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
    */
   public function testIPNPaymentMembershipRecurSuccess() {
     $this->setupMembershipRecurringPaymentProcessorTransaction();
-    $paypalIPN = new CRM_Core_Payment_AuthorizeNetIPN($this->getRecurTransaction());
-    $paypalIPN->main();
+    $IPN = new CRM_Core_Payment_AuthorizeNetIPN($this->getRecurTransaction());
+    $IPN->main();
     $contribution = $this->callAPISuccess('contribution', 'getsingle', array('id' => $this->_contributionID));
     $this->assertEquals(1, $contribution['contribution_status_id']);
     $this->assertEquals('6511143069', $contribution['trxn_id']);
@@ -71,8 +69,8 @@ class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
     $this->assertTrue(substr($contribution['contribution_source'], 0, 20) == "Online Contribution:");
     $contributionRecur = $this->callAPISuccess('contribution_recur', 'getsingle', array('id' => $this->_contributionRecurID));
     $this->assertEquals(5, $contributionRecur['contribution_status_id']);
-    $paypalIPN = new CRM_Core_Payment_AuthorizeNetIPN($this->getRecurSubsequentTransaction());
-    $paypalIPN->main();
+    $IPN = new CRM_Core_Payment_AuthorizeNetIPN($this->getRecurSubsequentTransaction());
+    $IPN->main();
     $contribution = $this->callAPISuccess('contribution', 'get', array(
         'contribution_recur_id' => $this->_contributionRecurID,
         'sequential' => 1,

--- a/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
@@ -49,6 +49,16 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
   protected $input;
   protected $ids;
   protected $objects;
+
+  /**
+   * @var int
+   */
+  protected $_membershipTypeID;
+
+  /**
+   * @var int
+   */
+  protected $_membershipStatusID;
   public $DBResetRequired = FALSE;
 
   public function setUp() {
@@ -80,13 +90,12 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $processorEntity = $this->paymentProcessor->create($paymentProcessorParams);
 
     $this->_processorId = $processorEntity->id;
-    $this->_contributionTypeId = 1;
+    $this->_financialTypeId = 1;
 
     $this->_contributionParams = array(
       'contact_id' => $this->_contactId,
-      'version' => 3,
-      'financial_type_id' => $this->_contributionTypeId,
-      'recieve_date' => date('Ymd'),
+      'financial_type_id' => $this->_financialTypeId,
+      'receive_date' => date('Ymd'),
       'total_amount' => 150.00,
       'invoice_id' => 'c8acb91e080ad7bd8a2adc119c192885',
       'currency' => 'USD',
@@ -128,6 +137,24 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
   /**
    * Test the LoadObjects function with recurring membership data.
    */
+  public function testLoadMembershipObjectsNoLeakage() {
+    $this->_setUpMembershipObjects();
+    $this->_setUpRecurringContribution();
+    $this->IPN->loadObjects($this->input, $this->ids, $this->objects, FALSE, $this->_processorId);
+    $this->assertEquals('Anthony', $this->objects['contact']->first_name);
+
+    $this->ids['contact'] = $this->_contactId = $this->individualCreate(array('first_name' => 'Donald', 'last_name' => 'Duck', 'email' => 'the-don@duckville.com'));
+    $contribution = $this->callAPISuccess('contribution', 'create', array_merge($this->_contributionParams, array('invoice_id' => 'abc')));
+    $this->_contributionId = $contribution['id'];
+    $this->_setUpMembershipObjects();
+    $this->input['invoiceID'] = 'abc';
+    $this->IPN->loadObjects($this->input, $this->ids, $this->objects, FALSE, $this->_processorId);
+    $this->assertEquals('Donald', $this->objects['contact']->first_name);
+  }
+
+  /**
+   * Test the LoadObjects function with recurring membership data.
+   */
   public function testLoadMembershipObjectsLoadAll() {
     $this->_setUpMembershipObjects();
     $this->_setUpRecurringContribution();
@@ -156,6 +183,33 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $this->assertEquals('Mr. Anthony Anderson II', $msg['to']);
     $this->assertContains('<p>Please print this confirmation for your records.</p>', $msg['html']);
     $this->assertContains('Membership Type: General', $msg['body']);
+  }
+
+  /**
+   * Test the LoadObjects function data does not leak.
+   *
+   * If more than one iteration takes place the variables should not leak.
+   */
+  public function testSendMailMembershipObjectsNoLeakage() {
+    $this->_setUpMembershipObjects();
+    $values = array();
+    $this->IPN->loadObjects($this->input, $this->ids, $this->objects, FALSE, $this->_processorId);
+    $msg = $this->IPN->sendMail($this->input, $this->ids, $this->objects, $values, FALSE, TRUE);
+    $this->assertEquals('Mr. Anthony Anderson II', $msg['to']);
+    $this->assertContains('Membership Type: General', $msg['body']);
+
+    $this->ids['contact'] = $this->_contactId = $this->individualCreate(array('prefix_id' => 'Dr.', 'first_name' => 'Donald', 'last_name' => 'Duck', 'email' => 'the-don@duckville.com'));
+    $contribution = $this->callAPISuccess('contribution', 'create', array_merge($this->_contributionParams, array('invoice_id' => 'abc')));
+    $this->_contributionId = $contribution['id'];
+
+    $this->_membershipTypeID = $this->membershipTypeCreate(array('name' => 'Fowl'));
+    $this->_setUpMembershipObjects();
+    $this->input['invoiceID'] = 'abc';
+    $this->IPN->loadObjects($this->input, $this->ids, $this->objects, FALSE, $this->_processorId);
+    $this->assertEquals('Donald', $this->objects['contact']->first_name);
+    $msg = $this->IPN->sendMail($this->input, $this->ids, $this->objects, $values, FALSE, TRUE);
+    $this->assertEquals('Dr. Donald Duck II', $msg['to']);
+    $this->assertContains('Membership Type: Fowl', $msg['body']);
   }
 
   /**
@@ -471,8 +525,12 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
    */
   public function _setUpMembershipObjects() {
     try {
-      $this->_membershipTypeID = $this->membershipTypeCreate();
-      $this->_membershipStatusID = $this->membershipStatusCreate('test status');
+      if (!$this->_membershipTypeID) {
+        $this->_membershipTypeID = $this->membershipTypeCreate();
+      }
+      if (!$this->_membershipStatusID) {
+        $this->_membershipStatusID = $this->membershipStatusCreate('test status');
+      }
     }
     catch (Exception$e) {
       echo $e->getMessage();
@@ -492,7 +550,12 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     );
 
     $membership = $this->callAPISuccess('membership', 'create', $this->_membershipParams);
-
+    if ($this->objects['contribution']->id != $this->_contributionId) {
+      $contribution = new CRM_Contribute_BAO_Contribution();
+      $contribution->id = $this->_contributionId;
+      $contribution->find(TRUE);
+      $this->objects = array('contribution' => $contribution);
+    }
     $this->_membershipId = $membership['id'];
     //we'll create membership payment here because to make setup more re-usable
     civicrm_api('membership_payment', 'create', array(
@@ -510,7 +573,7 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
       'total_amount' => 150.00,
       'invoiceID' => "c8acb91e080ad7bd8a2adc119c192885",
       'contactID' => $this->_contactId,
-      'contributionID' => $this->objects['contribution']->id,
+      'contributionID' => $this->_contributionId,
       'membershipID' => $this->_membershipId,
     );
 

--- a/tests/phpunit/CRM/Financial/Page/AjaxTest.php
+++ b/tests/phpunit/CRM/Financial/Page/AjaxTest.php
@@ -38,7 +38,7 @@ class CRM_Financial_Page_AjaxTest extends CiviUnitTestCase {
    */
   public function testGetFinancialTransactionsList() {
     $individualID = $this->individualCreate();
-    $this->contributionCreate($individualID);
+    $this->contributionCreate(array('contact_id' => $individualID));
     $batch = $this->callAPISuccess('Batch', 'create', array('title' => 'test', 'status_id' => 'Open'));
     CRM_Core_DAO::executeQuery("
      INSERT INTO civicrm_entity_batch (entity_table, entity_id, batch_id)

--- a/tests/phpunit/CiviTest/CiviMailUtils.php
+++ b/tests/phpunit/CiviTest/CiviMailUtils.php
@@ -260,13 +260,24 @@ class CiviMailUtils extends PHPUnit_Framework_TestCase {
    */
   public function checkMailLog($strings, $absentStrings = array(), $prefix = '') {
     $mail = $this->getMostRecentEmail('raw');
-    foreach ($strings as $string) {
-      $this->_ut->assertContains($string, $mail, "$string .  not found in  $mail  $prefix");
-    }
-    foreach ($absentStrings as $string) {
-      $this->_ut->assertEmpty(strstr($mail, $string), "$string  incorrectly found in $mail $prefix");;
-    }
-    return $mail;
+    return $this->checkMailForStrings($strings, $absentStrings, $prefix, $mail);
+  }
+
+  /**
+   * Check contents of mail log.
+   *
+   * @param array $strings
+   *   Strings that should be included.
+   * @param array $absentStrings
+   *   Strings that should not be included.
+   * @param string $prefix
+   *
+   * @return \ezcMail|string
+   */
+  public function checkAllMailLog($strings, $absentStrings = array(), $prefix = '') {
+    $mails = $this->getAllMessages('raw');
+    $mail = implode(',', $mails);
+    return $this->checkMailForStrings($strings, $absentStrings, $prefix, $mail);
   }
 
   /**
@@ -327,6 +338,23 @@ class CiviMailUtils extends PHPUnit_Framework_TestCase {
     $mail = $parser->parseMail($set);
     $this->_ut->assertNotEmpty($mail, 'Cannot parse mail');
     return $mail[0];
+  }
+
+  /**
+   * @param $strings
+   * @param $absentStrings
+   * @param $prefix
+   * @param $mail
+   * @return mixed
+   */
+  public function checkMailForStrings($strings, $absentStrings, $prefix, $mail) {
+    foreach ($strings as $string) {
+      $this->_ut->assertContains($string, $mail, "$string .  not found in  $mail  $prefix");
+    }
+    foreach ($absentStrings as $string) {
+      $this->_ut->assertEmpty(strstr($mail, $string), "$string  incorrectly found in $mail $prefix");;
+    }
+    return $mail;
   }
 
 }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -1440,6 +1440,35 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
   }
 
   /**
+   * Create test Authorize.net instance.
+   *
+   * @param array $params
+   *
+   * @return mixed
+   */
+  public function paymentProcessorAuthorizeNetCreate($params = array()) {
+    $params = array_merge(array(
+      'name' => 'Authorize',
+      'domain_id' => CRM_Core_Config::domainID(),
+      'payment_processor_type_id' => 'AuthNet',
+      'title' => 'AuthNet',
+      'is_active' => 1,
+      'is_default' => 0,
+      'is_test' => 1,
+      'is_recur' => 1,
+      'user_name' => '4y5BfuW7jm',
+      'password' => '4cAmW927n8uLf5J8',
+      'url_site' => 'https://test.authorize.net/gateway/transact.dll',
+      'url_recur' => 'https://apitest.authorize.net/xml/v1/request.api',
+      'class_name' => 'Payment_AuthorizeNet',
+      'billing_mode' => 1,
+    ), $params);
+
+    $result = $this->callAPISuccess('PaymentProcessor', 'create', $params);
+    return $result['id'];
+  }
+
+  /**
    * Create Participant.
    *
    * @param array $params
@@ -1474,7 +1503,7 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
    * Create Payment Processor.
    *
    * @return CRM_Financial_DAO_PaymentProcessor
-   *   instance of Payment Processsor
+   *   instance of Payment Processor
    */
   public function processorCreate() {
     $processorParams = array(
@@ -1490,6 +1519,20 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
     );
     $paymentProcessor = CRM_Financial_BAO_PaymentProcessor::create($processorParams);
     return $paymentProcessor;
+  }
+
+
+  /**
+   * Create Payment Processor.
+   *
+   * @param array $processorParams
+   *
+   * @return \CRM_Core_Payment_Dummy
+   *    Instance of Dummy Payment Processor
+   */
+  public function dummyProcessorCreate($processorParams = array()) {
+    $paymentProcessorID = $this->processorCreate($processorParams);
+    return Civi\Payment\System::singleton()->getById($paymentProcessorID);
   }
 
   /**
@@ -1513,6 +1556,17 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
     );
     $contributionPage = $this->callAPISuccess('contribution_page', 'create', $this->_pageParams);
     return $contributionPage;
+  }
+
+  /**
+   * Create a sample batch.
+   */
+  public function batchCreate() {
+    $params = $this->_params;
+    $params['name'] = $params['title'] = 'Batch_433397';
+    $params['status_id'] = 1;
+    $result = $this->callAPISuccess('batch', 'create', $params);
+    return $result['id'];
   }
 
   /**
@@ -1606,38 +1660,34 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
   /**
    * Create contribution.
    *
-   * @param int $cID
-   *   Contact_id.
+   * @param array $params
+   *   Array of parameters.
    * @param int $cTypeID
    *   Id of financial type.
    * @param int $invoiceID
    * @param int $trxnID
    * @param int $paymentInstrumentID
-   * @param bool $isFee
    *
    * @return int
    *   id of created contribution
    */
-  public function contributionCreate($cID, $cTypeID = 1, $invoiceID = 67890, $trxnID = 12345, $paymentInstrumentID = 1, $isFee = TRUE) {
-    $params = array(
+  public function contributionCreate($params, $cTypeID = 1, $invoiceID = 67890, $trxnID = 12345,
+    $paymentInstrumentID = 1) {
+
+    $params = array_merge(array(
       'domain_id' => 1,
-      'contact_id' => $cID,
       'receive_date' => date('Ymd'),
       'total_amount' => 100.00,
-      'financial_type_id' => empty($cTypeID) ? 1 : $cTypeID,
+      'fee_amount' => 5.00,
+      'net_ammount' => 95.00,
+      'financial_type_id' => $cTypeID,
       'payment_instrument_id' => empty($paymentInstrumentID) ? 1 : $paymentInstrumentID,
       'non_deductible_amount' => 10.00,
       'trxn_id' => $trxnID,
       'invoice_id' => $invoiceID,
       'source' => 'SSF',
       'contribution_status_id' => 1,
-      // 'note'                   => 'Donating for Nobel Cause', *Fixme
-    );
-
-    if ($isFee) {
-      $params['fee_amount'] = 5.00;
-      $params['net_amount'] = 95.00;
-    }
+    ), $params);
 
     $result = $this->callAPISuccess('contribution', 'create', $params);
     return $result['id'];
@@ -1719,7 +1769,7 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
       'registration_end_date' => 20081015,
       'max_participants' => 100,
       'event_full_text' => 'Sorry! We are already full',
-      'is_monetory' => 0,
+      'is_monetary' => 0,
       'is_active' => 1,
       'is_show_location' => 0,
     ), $params);
@@ -2322,7 +2372,7 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
    * @param string $description
    *   Descriptive text for the example file.
    * @param string $exampleName
-   *   Name for this example file (CamelCase) - if ommitted the action name will be substituted.
+   *   Name for this example file (CamelCase) - if omitted the action name will be substituted.
    */
   private function documentMe($entity, $action, $params, $result, $testFunction, $testFile, $description = "", $exampleName = NULL) {
     if (defined('DONT_DOCUMENT_TEST_CONFIG') && DONT_DOCUMENT_TEST_CONFIG) {
@@ -2571,8 +2621,11 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
    */
   public function quickCleanUpFinancialEntities() {
     $tablesToTruncate = array(
+      'civicrm_activity',
+      'civicrm_activity_contact',
       'civicrm_contribution',
       'civicrm_contribution_soft',
+      'civicrm_contribution_product',
       'civicrm_financial_trxn',
       'civicrm_financial_item',
       'civicrm_contribution_recur',
@@ -2602,6 +2655,7 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
   }
 
   public function restoreDefaultPriceSetConfig() {
+    CRM_Core_DAO::executeQuery('DELETE FROM civicrm_price_set WHERE id > 2');
     CRM_Core_DAO::executeQuery("INSERT INTO `civicrm_price_field` (`id`, `price_set_id`, `name`, `label`, `html_type`, `is_enter_qty`, `help_pre`, `help_post`, `weight`, `is_display_amounts`, `options_per_line`, `is_active`, `is_required`, `active_on`, `expire_on`, `javascript`, `visibility_id`) VALUES (1, 1, 'contribution_amount', 'Contribution Amount', 'Text', 0, NULL, NULL, 1, 1, 1, 1, 1, NULL, NULL, NULL, 1)");
     CRM_Core_DAO::executeQuery("INSERT INTO `civicrm_price_field_value` (`id`, `price_field_id`, `name`, `label`, `description`, `amount`, `count`, `max_value`, `weight`, `membership_type_id`, `membership_num_terms`, `is_default`, `is_active`, `financial_type_id`, `deductible_amount`) VALUES (1, 1, 'contribution_amount', 'Contribution Amount', NULL, '1', NULL, NULL, 1, NULL, NULL, 0, 1, 1, 0.00)");
   }
@@ -2609,7 +2663,7 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
    * Function does a 'Get' on the entity & compares the fields in the Params with those returned
    * Default behaviour is to also delete the entity
    * @param array $params
-   *   Params array to check agains.
+   *   Params array to check against.
    * @param int $id
    *   Id of the entity concerned.
    * @param string $entity
@@ -3024,6 +3078,8 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
    *  $this->createLoggedInUser();
    *   $this->_permissionedDisabledGroup = $this->groupCreate(array('title' => 'pick-me-disabled', 'is_active' => 0, 'name' => 'pick-me-disabled'));
    *   $this->_permissionedGroup = $this->groupCreate(array('title' => 'pick-me-active', 'is_active' => 1, 'name' => 'pick-me-active'));
+   *
+   * @param bool $isProfile
    */
   public function setupACL($isProfile = FALSE) {
     global $_REQUEST;
@@ -3133,7 +3189,7 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
    * @todo this isn't a great place to put it - but really it belongs on a class that extends
    * this parent class & we don't have a structure for that yet
    * There is another function to this effect on the PaypalPro test but it appears to be silently failing
-   * & the best protection agains that is the functions this class affords
+   * & the best protection against that is the functions this class affords
    * @param array $params
    * @return int $result['id'] payment processor id
    */
@@ -3190,6 +3246,7 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
         'contact_id' => $this->_contactID,
         'contribution_page_id' => $this->_contributionPageID,
         'payment_processor_id' => $this->_paymentProcessorID,
+        'is_test' => 0,
       ),
     ));
     $this->_contributionRecurID = $contributionRecur['id'];
@@ -3202,7 +3259,10 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
   public function setupMembershipRecurringPaymentProcessorTransaction() {
     $this->ids['membership_type'] = $this->membershipTypeCreate();
     //create a contribution so our membership & contribution don't both have id = 1
-    $this->contributionCreate($this->_contactID, 1, 'abcd', '345j');
+    $this->contributionCreate(array(
+      'contact_id' => $this->_contactID,
+      'is_test' => 1),
+      1, 'abcd', '345j');
     $this->setupRecurringPaymentProcessorTransaction();
 
     $this->ids['membership'] = $this->callAPISuccess('membership', 'create', array(
@@ -3305,7 +3365,9 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
   }
 
   /**
-   * @param $exists
+   * Assert the attachment exists.
+   *
+   * @param bool $exists
    * @param array $apiResult
    */
   protected function assertAttachmentExistence($exists, $apiResult) {

--- a/tests/phpunit/api/v3/ContributionSoftTest.php
+++ b/tests/phpunit/api/v3/ContributionSoftTest.php
@@ -56,7 +56,7 @@ class api_v3_ContributionSoftTest extends CiviUnitTestCase {
     $this->_individualId = $this->individualCreate();
     $this->_softIndividual1Id = $this->individualCreate();
     $this->_softIndividual2Id = $this->individualCreate();
-    $this->_contributionId = $this->contributionCreate($this->_individualId);
+    $this->_contributionId = $this->contributionCreate(array('contact_id' => $this->_individualId));
 
     $paymentProcessor = $this->processorCreate();
     $this->_params = array(
@@ -103,11 +103,11 @@ class api_v3_ContributionSoftTest extends CiviUnitTestCase {
     );
     $softcontribution = $this->callAPIAndDocument('contribution_soft', 'get', $params, __FUNCTION__, __FILE__);
     $this->assertEquals(1, $softcontribution['count']);
-    $this->assertEquals($softcontribution['values'][$this->_softcontribution['id']]['contribution_id'], $this->_contributionId, 'In line ' . __LINE__);
-    $this->assertEquals($softcontribution['values'][$this->_softcontribution['id']]['contact_id'], $this->_softIndividual1Id, 'In line ' . __LINE__);
-    $this->assertEquals($softcontribution['values'][$this->_softcontribution['id']]['amount'], '10.00', 'In line ' . __LINE__);
-    $this->assertEquals($softcontribution['values'][$this->_softcontribution['id']]['currency'], 'USD', 'In line ' . __LINE__);
-    $this->assertEquals($softcontribution['values'][$this->_softcontribution['id']]['soft_credit_type_id'], 4, 'In line ' . __LINE__);
+    $this->assertEquals($softcontribution['values'][$this->_softcontribution['id']]['contribution_id'], $this->_contributionId);
+    $this->assertEquals($softcontribution['values'][$this->_softcontribution['id']]['contact_id'], $this->_softIndividual1Id);
+    $this->assertEquals($softcontribution['values'][$this->_softcontribution['id']]['amount'], '10.00');
+    $this->assertEquals($softcontribution['values'][$this->_softcontribution['id']]['currency'], 'USD');
+    $this->assertEquals($softcontribution['values'][$this->_softcontribution['id']]['soft_credit_type_id'], 4);
 
     //create a second soft contribution on the same hard contribution - we are testing that 'id' gets the right soft contribution id (not the contribution id)
     $p['contact_id'] = $this->_softIndividual2Id;
@@ -121,7 +121,7 @@ class api_v3_ContributionSoftTest extends CiviUnitTestCase {
     $result = $this->callAPISuccess('contribution_soft', 'get', array(
       'id' => $this->_softcontribution['id'],
     ));
-    $this->assertEquals(1, $result['count'], 'In line ' . __LINE__);
+    $this->assertEquals(1, $result['count']);
     $this->assertEquals($this->_softcontribution['id'], $result['id']);
     $this->assertEquals($this->_softcontribution['id'], $result['id'], print_r($softcontribution, TRUE));
 
@@ -137,7 +137,7 @@ class api_v3_ContributionSoftTest extends CiviUnitTestCase {
         'contact_id' => $this->_softIndividual2Id,
       )
     );
-    $this->assertEquals(1, $result['count'], 'In line ' . __LINE__);
+    $this->assertEquals(1, $result['count']);
 
     $this->callAPISuccess('contribution_soft', 'Delete', array(
       'id' => $this->_softcontribution['id'],
@@ -209,11 +209,11 @@ class api_v3_ContributionSoftTest extends CiviUnitTestCase {
     );
 
     $softcontribution = $this->callAPIAndDocument('contribution_soft', 'create', $params, __FUNCTION__, __FILE__);
-    $this->assertEquals($softcontribution['values'][$softcontribution['id']]['contribution_id'], $this->_contributionId, 'In line ' . __LINE__);
-    $this->assertEquals($softcontribution['values'][$softcontribution['id']]['contact_id'], $this->_softIndividual1Id, 'In line ' . __LINE__);
-    $this->assertEquals($softcontribution['values'][$softcontribution['id']]['amount'], '10.00', 'In line ' . __LINE__);
-    $this->assertEquals($softcontribution['values'][$softcontribution['id']]['currency'], 'USD', 'In line ' . __LINE__);
-    $this->assertEquals($softcontribution['values'][$softcontribution['id']]['soft_credit_type_id'], 5, 'In line ' . __LINE__);
+    $this->assertEquals($softcontribution['values'][$softcontribution['id']]['contribution_id'], $this->_contributionId);
+    $this->assertEquals($softcontribution['values'][$softcontribution['id']]['contact_id'], $this->_softIndividual1Id);
+    $this->assertEquals($softcontribution['values'][$softcontribution['id']]['amount'], '10.00');
+    $this->assertEquals($softcontribution['values'][$softcontribution['id']]['currency'], 'USD');
+    $this->assertEquals($softcontribution['values'][$softcontribution['id']]['soft_credit_type_id'], 5);
   }
 
   /**
@@ -238,7 +238,7 @@ class api_v3_ContributionSoftTest extends CiviUnitTestCase {
     );
     $original = $this->callAPISuccess('contribution_soft', 'get', $old_params);
     //Make sure it came back
-    $this->assertEquals($original['id'], $softcontributionID, 'In line ' . __LINE__);
+    $this->assertEquals($original['id'], $softcontributionID);
     //set up list of old params, verify
     $old_contribution_id = $original['values'][$softcontributionID]['contribution_id'];
     $old_contact_id = $original['values'][$softcontributionID]['contact_id'];
@@ -247,11 +247,11 @@ class api_v3_ContributionSoftTest extends CiviUnitTestCase {
     $old_soft_credit_type_id = $original['values'][$softcontributionID]['soft_credit_type_id'];
 
     //check against original values
-    $this->assertEquals($old_contribution_id, $this->_contributionId, 'In line ' . __LINE__);
-    $this->assertEquals($old_contact_id, $this->_softIndividual1Id, 'In line ' . __LINE__);
-    $this->assertEquals($old_amount, 10.00, 'In line ' . __LINE__);
-    $this->assertEquals($old_currency, 'USD', 'In line ' . __LINE__);
-    $this->assertEquals($old_soft_credit_type_id, 6, 'In line ' . __LINE__);
+    $this->assertEquals($old_contribution_id, $this->_contributionId);
+    $this->assertEquals($old_contact_id, $this->_softIndividual1Id);
+    $this->assertEquals($old_amount, 10.00);
+    $this->assertEquals($old_currency, 'USD');
+    $this->assertEquals($old_soft_credit_type_id, 6);
     $params = array(
       'id' => $softcontributionID,
       'contribution_id' => $this->_contributionId,
@@ -268,11 +268,11 @@ class api_v3_ContributionSoftTest extends CiviUnitTestCase {
     );
     $softcontribution = $this->callAPISuccess('contribution_soft', 'get', $new_params);
     //check against original values
-    $this->assertEquals($softcontribution['values'][$softcontributionID]['contribution_id'], $this->_contributionId, 'In line ' . __LINE__);
-    $this->assertEquals($softcontribution['values'][$softcontributionID]['contact_id'], $this->_softIndividual1Id, 'In line ' . __LINE__);
-    $this->assertEquals($softcontribution['values'][$softcontributionID]['amount'], 7.00, 'In line ' . __LINE__);
-    $this->assertEquals($softcontribution['values'][$softcontributionID]['currency'], 'CAD', 'In line ' . __LINE__);
-    $this->assertEquals($softcontribution['values'][$softcontributionID]['soft_credit_type_id'], 7, 'In line ' . __LINE__);
+    $this->assertEquals($softcontribution['values'][$softcontributionID]['contribution_id'], $this->_contributionId);
+    $this->assertEquals($softcontribution['values'][$softcontributionID]['contact_id'], $this->_softIndividual1Id);
+    $this->assertEquals($softcontribution['values'][$softcontributionID]['amount'], 7.00);
+    $this->assertEquals($softcontribution['values'][$softcontributionID]['currency'], 'CAD');
+    $this->assertEquals($softcontribution['values'][$softcontributionID]['soft_credit_type_id'], 7);
 
     $params = array(
       'id' => $softcontributionID,
@@ -332,10 +332,10 @@ class api_v3_ContributionSoftTest extends CiviUnitTestCase {
     // We're taking the first element.
     $res = $result['values'][$softcontribution['id']];
 
-    $this->assertEquals($p['contribution_id'], $res['contribution_id'], 'In line ' . __LINE__);
-    $this->assertEquals($p['contact_id'], $res['contact_id'], 'In line ' . __LINE__);
-    $this->assertEquals($p['amount'], $res['amount'], 'In line ' . __LINE__);
-    $this->assertEquals($p['currency'], $res['currency'], 'In line ' . __LINE__);
+    $this->assertEquals($p['contribution_id'], $res['contribution_id']);
+    $this->assertEquals($p['contact_id'], $res['contact_id']);
+    $this->assertEquals($p['amount'], $res['amount']);
+    $this->assertEquals($p['currency'], $res['currency']);
   }
 
   /**
@@ -364,10 +364,10 @@ class api_v3_ContributionSoftTest extends CiviUnitTestCase {
     $result = $this->callAPISuccess('contribution_soft', 'get', $params);
     $res = $result['values'][$softcontribution2['id']];
 
-    $this->assertEquals($p2['contribution_id'], $res['contribution_id'], 'In line ' . __LINE__);
-    $this->assertEquals($p2['contact_id'], $res['contact_id'], 'In line ' . __LINE__);
-    $this->assertEquals($p2['amount'], $res['amount'], 'In line ' . __LINE__);
-    $this->assertEquals($p2['currency'], $res['currency'], 'In line ' . __LINE__);
+    $this->assertEquals($p2['contribution_id'], $res['contribution_id']);
+    $this->assertEquals($p2['contact_id'], $res['contact_id']);
+    $this->assertEquals($p2['amount'], $res['amount']);
+    $this->assertEquals($p2['currency'], $res['currency']);
   }
 
 }

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -214,7 +214,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'source' => 'SSF',
       'contribution_status_id' => 1,
     );
-    $this->_contribution = $this->callAPISuccess('contribution', 'create', $p);
+    $this->_contribution = $this->callAPISuccess('Contribution', 'create', $p);
 
     $params = array(
       'contribution_id' => $this->_contribution['id'],
@@ -1142,7 +1142,8 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
    */
   public function testCreateUpdateContribution() {
 
-    $contributionID = $this->contributionCreate($this->_individualId, $this->_financialTypeId, 'idofsh', 212355);
+    $contributionID = $this->contributionCreate(array('contact_id' => $this->_individualId), $this->_financialTypeId,
+    'idofsh', 212355);
     $old_params = array(
       'contribution_id' => $contributionID,
 
@@ -1233,7 +1234,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
 
   public function testDeleteContribution() {
 
-    $contributionID = $this->contributionCreate($this->_individualId, $this->_financialTypeId, 'dfsdf', 12389);
+    $contributionID = $this->contributionCreate(array('contact_id' => $this->_individualId), $this->_financialTypeId, 'dfsdf', 12389);
     $params = array(
       'id' => $contributionID,
     );
@@ -1511,7 +1512,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $this->createLoggedInUser();
     $params = array_merge($this->_params, array('contribution_status_id' => 2, 'receipt_date' => 'now'));
     $contribution = $this->callAPISuccess('contribution', 'create', $params);
-    $this->callAPISuccess('contribution', 'completetransaction', array('id' => $contribution['id']));
+    $this->callAPISuccess('contribution', 'completetransaction', array('id' => $contribution['id'], 'trxn_date' => date('Y-m-d')));
     $contribution = $this->callAPISuccess('contribution', 'get', array('id' => $contribution['id'], 'sequential' => 1));
     $this->assertEquals('Completed', $contribution['values'][0]['contribution_status']);
     $mut->checkMailLog(array(
@@ -1576,7 +1577,6 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
   public function cleanUpAfterPriceSets() {
     $this->quickCleanUpFinancialEntities();
     $this->contactDelete($this->_ids['contact']);
-    $this->callAPISuccess('price_set', 'delete', array('id' => $this->_ids['price_set']));
   }
 
 

--- a/tests/phpunit/api/v3/PledgePaymentTest.php
+++ b/tests/phpunit/api/v3/PledgePaymentTest.php
@@ -49,7 +49,7 @@ class api_v3_PledgePaymentTest extends CiviUnitTestCase {
     parent::setUp();
     $this->_individualId = $this->individualCreate();
     $this->_pledgeID = $this->pledgeCreate($this->_individualId);
-    $this->_contributionID = $this->contributionCreate($this->_individualId);
+    $this->_contributionID = $this->contributionCreate(array('contact_id' => $this->_individualId));
   }
 
   public function tearDown() {
@@ -214,7 +214,8 @@ class api_v3_PledgePaymentTest extends CiviUnitTestCase {
       'sequential' => 1,
     );
 
-    $contributionID = $this->contributionCreate($this->_individualId, $this->_financialTypeId, 45, 45);
+    $contributionID = $this->contributionCreate(array('contact_id' => $this->_individualId), $this->_financialTypeId,
+      45, 45);
     $pledge = $this->callAPISuccess('Pledge', 'Create', $pledgeParams);
 
     //test the pledge_payment_create function

--- a/tests/phpunit/api/v3/TaxContributionPageTest.php
+++ b/tests/phpunit/api/v3/TaxContributionPageTest.php
@@ -255,14 +255,14 @@ class api_v3_TaxContributionPageTest extends CiviUnitTestCase {
 
     $contribution = $this->callAPIAndDocument('contribution', 'create', $params, __FUNCTION__, __FILE__);
     $this->_ids['contributionId'] = $contribution['id'];
-    $this->assertEquals($contribution['values'][$contribution['id']]['contact_id'], $this->_individualId, 'In line ' . __LINE__);
-    $this->assertEquals($contribution['values'][$contribution['id']]['total_amount'], 120.00, 'In line ' . __LINE__);
-    $this->assertEquals($contribution['values'][$contribution['id']]['financial_type_id'], $this->financialtypeID, 'In line ' . __LINE__);
-    $this->assertEquals($contribution['values'][$contribution['id']]['trxn_id'], 12345, 'In line ' . __LINE__);
-    $this->assertEquals($contribution['values'][$contribution['id']]['invoice_id'], 67890, 'In line ' . __LINE__);
-    $this->assertEquals($contribution['values'][$contribution['id']]['source'], 'SSF', 'In line ' . __LINE__);
-    $this->assertEquals($contribution['values'][$contribution['id']]['tax_amount'], 20, 'In line ' . __LINE__);
-    $this->assertEquals($contribution['values'][$contribution['id']]['contribution_status_id'], 1, 'In line ' . __LINE__);
+    $this->assertEquals($contribution['values'][$contribution['id']]['contact_id'], $this->_individualId);
+    $this->assertEquals($contribution['values'][$contribution['id']]['total_amount'], 120.00);
+    $this->assertEquals($contribution['values'][$contribution['id']]['financial_type_id'], $this->financialtypeID);
+    $this->assertEquals($contribution['values'][$contribution['id']]['trxn_id'], 12345);
+    $this->assertEquals($contribution['values'][$contribution['id']]['invoice_id'], 67890);
+    $this->assertEquals($contribution['values'][$contribution['id']]['source'], 'SSF');
+    $this->assertEquals($contribution['values'][$contribution['id']]['tax_amount'], 20);
+    $this->assertEquals($contribution['values'][$contribution['id']]['contribution_status_id'], 1);
     $this->_checkFinancialRecords($contribution, 'online');
   }
 
@@ -324,14 +324,14 @@ class api_v3_TaxContributionPageTest extends CiviUnitTestCase {
       'contribution_status_id' => 2,
     );
     $contribution = $this->callAPIAndDocument('contribution', 'create', $params, __FUNCTION__, __FILE__);
-    $this->assertEquals($contribution['values'][$contribution['id']]['contact_id'], $this->_individualId, 'In line ' . __LINE__);
-    $this->assertEquals($contribution['values'][$contribution['id']]['total_amount'], 120.00, 'In line ' . __LINE__);
-    $this->assertEquals($contribution['values'][$contribution['id']]['financial_type_id'], $this->financialtypeID, 'In line ' . __LINE__);
-    $this->assertEquals($contribution['values'][$contribution['id']]['trxn_id'], 12345, 'In line ' . __LINE__);
-    $this->assertEquals($contribution['values'][$contribution['id']]['invoice_id'], 67890, 'In line ' . __LINE__);
-    $this->assertEquals($contribution['values'][$contribution['id']]['source'], 'SSF', 'In line ' . __LINE__);
-    $this->assertEquals($contribution['values'][$contribution['id']]['tax_amount'], 20, 'In line ' . __LINE__);
-    $this->assertEquals($contribution['values'][$contribution['id']]['contribution_status_id'], 2, 'In line ' . __LINE__);
+    $this->assertEquals($contribution['values'][$contribution['id']]['contact_id'], $this->_individualId);
+    $this->assertEquals($contribution['values'][$contribution['id']]['total_amount'], 120.00);
+    $this->assertEquals($contribution['values'][$contribution['id']]['financial_type_id'], $this->financialtypeID);
+    $this->assertEquals($contribution['values'][$contribution['id']]['trxn_id'], 12345);
+    $this->assertEquals($contribution['values'][$contribution['id']]['invoice_id'], 67890);
+    $this->assertEquals($contribution['values'][$contribution['id']]['source'], 'SSF');
+    $this->assertEquals($contribution['values'][$contribution['id']]['tax_amount'], 20);
+    $this->assertEquals($contribution['values'][$contribution['id']]['contribution_status_id'], 2);
     $this->_checkFinancialRecords($contribution, 'payLater');
   }
 
@@ -350,14 +350,14 @@ class api_v3_TaxContributionPageTest extends CiviUnitTestCase {
     );
 
     $contribution = $this->callAPIAndDocument('contribution', 'create', $params, __FUNCTION__, __FILE__);
-    $this->assertEquals($contribution['values'][$contribution['id']]['contact_id'], $this->_individualId, 'In line ' . __LINE__);
-    $this->assertEquals($contribution['values'][$contribution['id']]['total_amount'], 120.00, 'In line ' . __LINE__);
-    $this->assertEquals($contribution['values'][$contribution['id']]['financial_type_id'], $this->financialtypeID, 'In line ' . __LINE__);
-    $this->assertEquals($contribution['values'][$contribution['id']]['trxn_id'], 12345, 'In line ' . __LINE__);
-    $this->assertEquals($contribution['values'][$contribution['id']]['invoice_id'], 67890, 'In line ' . __LINE__);
-    $this->assertEquals($contribution['values'][$contribution['id']]['source'], 'SSF', 'In line ' . __LINE__);
-    $this->assertEquals($contribution['values'][$contribution['id']]['tax_amount'], 20, 'In line ' . __LINE__);
-    $this->assertEquals($contribution['values'][$contribution['id']]['contribution_status_id'], 2, 'In line ' . __LINE__);
+    $this->assertEquals($contribution['values'][$contribution['id']]['contact_id'], $this->_individualId);
+    $this->assertEquals($contribution['values'][$contribution['id']]['total_amount'], 120.00);
+    $this->assertEquals($contribution['values'][$contribution['id']]['financial_type_id'], $this->financialtypeID);
+    $this->assertEquals($contribution['values'][$contribution['id']]['trxn_id'], 12345);
+    $this->assertEquals($contribution['values'][$contribution['id']]['invoice_id'], 67890);
+    $this->assertEquals($contribution['values'][$contribution['id']]['source'], 'SSF');
+    $this->assertEquals($contribution['values'][$contribution['id']]['tax_amount'], 20);
+    $this->assertEquals($contribution['values'][$contribution['id']]['contribution_status_id'], 2);
     $this->_checkFinancialRecords($contribution, 'pending');
   }
 
@@ -523,7 +523,7 @@ class api_v3_TaxContributionPageTest extends CiviUnitTestCase {
    *
    */
   public function testDeleteContribution() {
-    $contributionID = $this->contributionCreate($this->_individualId, $this->financialtypeID, 'dfsdf', 12389);
+    $contributionID = $this->contributionCreate(array('contact_id' => $this->_individualId), $this->financialtypeID, 'dfsdf', 12389);
     $params = array(
       'id' => $contributionID,
     );


### PR DESCRIPTION
This is Ok to merge if it passes as it is all extra tests & test suite fixes that I want on 4.6 & 4.7

---
- [CRM-17519: CRM_Core_Payment_BaseIPN::completeTransaction() should clear the Smarty template](https://issues.civicrm.org/jira/browse/CRM-17519)
