### PR TITLE
(WIP) CRM-16395 - Installation with localized default settings

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -1415,6 +1415,8 @@ class Installer extends InstallRequirements {
           $settingsParams['domain_id'] = 'current_domain';
           $settingsParams['lcMessages'] = $config['seedLanguage'];
 
+          civicrm_api3('Setting', 'create', $settingsParams);
+
         }
 
         $output .= '</ul>';

--- a/install/index.php
+++ b/install/index.php
@@ -1394,7 +1394,7 @@ class Installer extends InstallRequirements {
           $fileName = $crmPath . DIRECTORY_SEPARATOR . 'l10n' . DIRECTORY_SEPARATOR . $config['seedLanguage'] . DIRECTORY_SEPARATOR . 'settings.json';
           if (file_exists($fileName)) {
             $json = file_get_contents($fileName);
-            $settings = json_decode($json, true);
+            $settings = json_decode($json, TRUE);
 
             if (!empty($settings)) {
 

--- a/install/index.php
+++ b/install/index.php
@@ -1383,17 +1383,38 @@ class Installer extends InstallRequirements {
         $GLOBALS['user'] = $original_user;
         drupal_save_session(TRUE);
 
-        //change the default language to one chosen
+        //change the default settings based on the language chosen
         if (isset($config['seedLanguage']) && $config['seedLanguage'] != 'en_US') {
           // This ensures that defaults get set, otherwise the user will login
           // and most configurations will be empty, not set to en_US defaults.
           civicrm_api3('Setting', 'revert');
 
-          civicrm_api3('Setting', 'create', array(
-              'domain_id' => 'current_domain',
-              'lcMessages' => $config['seedLanguage'],
-            )
-          );
+          // get settings if the corresponding file exist
+          $settingsParams = array();
+          $fileName = $crmPath . DIRECTORY_SEPARATOR . 'l10n' . DIRECTORY_SEPARATOR . $config['seedLanguage'] . DIRECTORY_SEPARATOR . 'settings.json';
+          if (file_exists($fileName)) {
+            $json = file_get_contents($fileName);
+            $settings = json_decode($json, true);
+
+            if (!empty($settings)) {
+
+              // get all valid settings
+              $results = civicrm_api3('Setting', 'getfields', array());
+              $validSettings = array_keys($results['values']);
+
+              // add valid settings to params to send to api
+              foreach ($settings as $setting => $value) {
+                if (in_array($setting, $validSettings)) {
+                  $settingsParams[$setting] = $value;
+                }
+
+                // TODO: add support for currencies_enabled which is an OptionGroup
+              }
+            }
+          }
+          $settingsParams['domain_id'] = 'current_domain';
+          $settingsParams['lcMessages'] = $config['seedLanguage'];
+
         }
 
         $output .= '</ul>';


### PR DESCRIPTION
Will read a file settings.json in l10n/xx_XX/ and update the settings depending on the locale selected during installation.

currencies_enabled will not work because it's not a setting, it's an option group.

---
- [CRM-16395: Installation with localized default settings](https://issues.civicrm.org/jira/browse/CRM-16395)
