### PR TITLE
CRM-14987 add commented out option for CIVICRM_CMSDIR

### DIFF
--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -218,6 +218,10 @@ if (!defined('CIVICRM_UF_BASEURL')) {
  // Disable automatic download / installation of extensions
  // $civicrm_setting['Extension Preferences']['ext_repo_url'] = false;
 
+ // Override the CMS root path defined by cmsRootPath.
+ // define('CIVICRM_CMSDIR', '/path/to/install/root/');
+
+
 /**
  * If you are using any CiviCRM script in the bin directory that
  * requires authentication, then you also need to set this key.


### PR DESCRIPTION
---
- CRM-14987: WordPress cmsRootPath can incorrectly return unrelated CMS install
  https://issues.civicrm.org/jira/browse/CRM-14987
