### PR TITLE
CRM-17635 show option to email for autorenew memberships

### DIFF
--- a/CRM/Member/Form.php
+++ b/CRM/Member/Form.php
@@ -160,7 +160,7 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
       $this->add('select', 'payment_processor_id',
         ts('Payment Processor'),
         $this->_processors, TRUE,
-        array('onChange' => "buildAutoRenew( null, this.value );")
+        array('onChange' => "buildAutoRenew( null, this.value, '{$this->_mode}');")
       );
       CRM_Core_Payment_Form::buildPaymentForm($this, $this->_paymentProcessor, FALSE, TRUE);
     }
@@ -181,9 +181,7 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
       $this->assign('recurProcessor', json_encode($this->_recurPaymentProcessors));
       $this->addElement('checkbox',
         'auto_renew',
-        ts('Membership renewed automatically'),
-        NULL,
-        array('onclick' => "buildReceiptANDNotice( );")
+        ts('Membership renewed automatically')
       );
 
       $this->assignPaymentRelatedVariables();

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -563,7 +563,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
     );
 
     if (!empty($this->_recurPaymentProcessors)) {
-      $memTypeJs['onChange'] = "" . $memTypeJs['onChange'] . 'buildAutoRenew(this.value, null);';
+      $memTypeJs['onChange'] = "" . $memTypeJs['onChange'] . "buildAutoRenew(this.value, null, '{$this->_mode}');";
     }
 
     $this->add('text', 'max_related', ts('Max related'),
@@ -681,7 +681,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
     $this->addElement('checkbox',
       'send_receipt',
       ts('Send Confirmation and Receipt?'), NULL,
-      array('onclick' => "showHideByValue( 'send_receipt', '', 'notice', 'table-row', 'radio', false); showHideByValue( 'send_receipt', '', 'fromEmail', 'table-row', 'radio', false);")
+      array('onclick' => "showEmailOptions()")
     );
 
     $this->add('select', 'from_email_address', ts('Receipt From'), $this->_fromEmails);
@@ -718,8 +718,8 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
     $this->assign('isRecur', $isRecur);
 
     $this->addFormRule(array('CRM_Member_Form_Membership', 'formRule'), $this);
-
-    $this->assign('outBound_option', Civi::settings()->get('mailing_backend'));
+    $mailingInfo = Civi::settings()->get('mailing_backend');
+    $this->assign('isEmailEnabledForSite', ($mailingInfo['outBound_option'] != 2));
 
     parent::buildQuickForm();
   }

--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -174,12 +174,12 @@
         {/if}
         {include file="CRM/Member/Form/MembershipCommon.tpl"}
 
-        {if $emailExists and $outBound_option != 2}
+        {if $emailExists and $isEmailEnabledForSite}
           <tr id="send-receipt" class="crm-membership-form-block-send_receipt">
             <td class="label">{$form.send_receipt.label}</td><td>{$form.send_receipt.html}<br />
             <span class="description">{ts 1=$emailExists}Automatically email a membership confirmation and receipt to %1 ?{/ts} {ts}OR if the payment is from a different contact, this email will only go to them.{/ts}</span></td>
           </tr>
-          {elseif $context eq 'standalone' and $outBound_option != 2}
+          {elseif $context eq 'standalone' and $isEmailEnabledForSite}
           <tr id="email-receipt" style="display:none;">
             <td class="label">{$form.send_receipt.label}</td><td>{$form.send_receipt.html}<br />
             <span class="description">{ts}Automatically email a membership confirmation and receipt to {/ts}<span id="email-address"></span>? {ts}OR if the payment is from a different contact, this email will only go to them.{/ts}</span></td>
@@ -377,35 +377,36 @@
       }
     }
 
+    function showEmailOptions() {
+      {/literal}
+      // @todo emailExists refers to the primary contact for the page.
+      // elsewhere some script determines if there is a paying contact the
+      // email should go to instead (e.g gift membership). This should be checked for here
+      // and that merged into that code as currently behaviour is inconsistent.
+      var emailExists = '{$emailExists}';
+      var isStandalone = ('{$context}' == 'standalone');
+      var isEmailEnabledForSite = {$isEmailEnabledForSite};
+
+      {literal}
+      var isEmailable = (isEmailEnabledForSite && (emailExists || isStandalone));
+
+      if (isEmailable && cj('#send_receipt').prop('checked') && !cj('#auto_renew').prop('checked')) {
+        // Hide extra message and from email for recurring as they cannot be stored until use.
+        cj('#notice').show();
+        cj('#fromEmail').show();
+      }
+      else {
+        cj('#notice').hide();
+        cj('#fromEmail').hide();
+      }
+    }
     </script>
-    {/literal}
-
-    {if ($emailExists and $outBound_option != 2) OR $context eq 'standalone' }
-    {include file="CRM/common/showHideByFieldValue.tpl"
-    trigger_field_id    ="send_receipt"
-    trigger_value       =""
-    target_element_id   ="notice"
-    target_element_type ="table-row"
-    field_type          ="radio"
-    invert              = 0
-    }
-    {include file="CRM/common/showHideByFieldValue.tpl"
-    trigger_field_id    ="send_receipt"
-    trigger_value       =""
-    target_element_id   ="fromEmail"
-    target_element_type ="table-row"
-    field_type          ="radio"
-    invert              = 0
-    }
-    {/if}
-    {literal}
-
     <script type="text/javascript">
 
     {/literal}{if !$membershipMode}{literal}
     showHideMemberStatus();
     function showHideMemberStatus() {
-      if ( cj( "#is_override" ).prop('checked' ) ) {
+      if ( cj( "#is_override" ).prop('checked') ) {
         cj('#memberStatus').show( );
         cj('#memberStatus_show').hide( );
       }
@@ -416,7 +417,7 @@
     }
     {/literal}{/if}
 
-    {if $context eq 'standalone' and $outBound_option != 2 }
+    {if $context eq 'standalone' and $isEmailEnabledForSite }
     {literal}
     CRM.$(function($) {
       var $form = $("form.{/literal}{$form.formClass}{literal}");
@@ -452,6 +453,7 @@
           if ( $(this).attr( 'readonly' ) ) {
             $(this).prop('checked', true );
           }
+          showEmailOptions();
         });
       }
 
@@ -498,12 +500,10 @@
     {/literal}
 
     {if $membershipMode or $action eq 2}
+
+    buildAutoRenew( null, null, '{$membershipMode}');
     {literal}
-
-    buildAutoRenew( null, null );
-
-    function buildAutoRenew( membershipType, processorId ) {
-      var mode   = {/literal}'{$membershipMode}'{literal};
+    function buildAutoRenew( membershipType, processorId, mode ) {
       var action = {/literal}'{$action}'{literal};
 
       //for update lets hide it when not already recurring.
@@ -528,6 +528,7 @@
       if ( !processorId || !membershipType ) {
         cj("#auto_renew").prop('checked', false );
         cj("#autoRenew").hide( );
+        showEmailOptions();
         return;
       }
 
@@ -537,7 +538,7 @@
 
       if ( !currentOption || !recurProcessors[processorId] ) {
         cj("#auto_renew").prop('checked', false );
-        cj("#autoRenew").hide( );
+        cj("#autoRenew").hide();
         return;
       }
 
@@ -557,36 +558,12 @@
         cj("#auto_renew").prop('checked', false );
         cj("#autoRenew").hide( );
       }
-
-      //play w/ receipt option.
-      if ( cj("#auto_renew").prop('checked' ) ) {
-        cj("#notice").hide( );
-        cj("#send_receipt").prop('checked', false );
-        cj("#send-receipt").hide( );
-      }
-      else {
-        cj("#send-receipt").show( );
-        if ( cj("#send_receipt").prop('checked' ) ) {
-          cj("#notice").show( );
-        }
-      }
+      showEmailOptions();
     }
     {/literal}
     {/if}
 
     {literal}
-    function buildReceiptANDNotice( ) {
-      if ( cj("#auto_renew").prop('checked' ) ) {
-        cj("#notice").hide( );
-        cj("#send-receipt").hide( );
-      }
-      else {
-        cj("#send-receipt").show( );
-        if ( cj("#send_receipt").prop('checked' ) ) {
-          cj("#notice").show( );
-        }
-      }
-    }
 
     var customDataType = '{/literal}{$customDataType}{literal}';
 

--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -178,11 +178,13 @@
           <tr id="send-receipt" class="crm-membership-form-block-send_receipt">
             <td class="label">{$form.send_receipt.label}</td><td>{$form.send_receipt.html}<br />
             <span class="description">{ts 1=$emailExists}Automatically email a membership confirmation and receipt to %1 ?{/ts} {ts}OR if the payment is from a different contact, this email will only go to them.{/ts}</span></td>
+            <span class="auto-renew-text">{ts}For auto-renewing memberships the emails are sent when each payment is received{/ts}</span>
           </tr>
           {elseif $context eq 'standalone' and $isEmailEnabledForSite}
           <tr id="email-receipt" style="display:none;">
             <td class="label">{$form.send_receipt.label}</td><td>{$form.send_receipt.html}<br />
             <span class="description">{ts}Automatically email a membership confirmation and receipt to {/ts}<span id="email-address"></span>? {ts}OR if the payment is from a different contact, this email will only go to them.{/ts}</span></td>
+            <span class="auto-renew-text">{ts}For auto-renewing memberships the emails are sent when each payment is received{/ts}</span>
           </tr>
         {/if}
         <tr id="fromEmail" style="display:none;">


### PR DESCRIPTION
- [CRM-17635: Back-office email receipt box disappears for auto-renew](https://issues.civicrm.org/jira/browse/CRM-17635)
