### PR TITLE
 Add regions for report headers (4.7)

### DIFF
--- a/CRM/Report/Form/Instance.php
+++ b/CRM/Report/Form/Instance.php
@@ -227,11 +227,18 @@ class CRM_Report_Form_Instance {
     }
 
     $config = CRM_Core_Config::singleton();
+
+    // Add a special region for the default HTML header of printed reports.  It
+    // won't affect reports with customized headers, just ones with the default.
+    $printHeaderRegion = CRM_Core_Region::instance('default-report-header', FALSE);
+    $htmlHeader = ($printHeaderRegion) ? $printHeaderRegion->render('', FALSE) : '';
+
     $defaults['report_header'] = $report_header = "<html>
   <head>
     <title>CiviCRM Report</title>
     <meta http-equiv='Content-Type' content='text/html; charset=utf-8' />
     <style type=\"text/css\">@import url({$config->userFrameworkResourceURL}css/print.css);</style>
+    {$htmlHeader}
   </head>
   <body><div id=\"crm-container\">";
 

--- a/CRM/Utils/PDF/Utils.php
+++ b/CRM/Utils/PDF/Utils.php
@@ -84,12 +84,18 @@ class CRM_Utils_PDF_Utils {
     $margins = array($metric, $t, $r, $b, $l);
 
     $config = CRM_Core_Config::singleton();
+
+    // Add a special region for the HTML header of PDF files:
+    $pdfHeaderRegion = CRM_Core_Region::instance('pdf-header', FALSE);
+    $htmlHeader = ($pdfHeaderRegion) ? $pdfHeaderRegion->render('', FALSE) : '';
+
     $html = "
 <html>
   <head>
     <meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\"/>
     <style>@page { margin: {$t}{$metric} {$r}{$metric} {$b}{$metric} {$l}{$metric}; }</style>
     <style type=\"text/css\">@import url({$config->userFrameworkResourceURL}css/print.css);</style>
+    {$htmlHeader}
   </head>
   <body>
     <div id=\"crm-container\">\n";

--- a/CRM/Utils/PDF/Utils.php
+++ b/CRM/Utils/PDF/Utils.php
@@ -86,7 +86,7 @@ class CRM_Utils_PDF_Utils {
     $config = CRM_Core_Config::singleton();
 
     // Add a special region for the HTML header of PDF files:
-    $pdfHeaderRegion = CRM_Core_Region::instance('pdf-header', FALSE);
+    $pdfHeaderRegion = CRM_Core_Region::instance('export-document-header', FALSE);
     $htmlHeader = ($pdfHeaderRegion) ? $pdfHeaderRegion->render('', FALSE) : '';
 
     $html = "


### PR DESCRIPTION
Replaces #7375: now based on 4.7 and with more generic name for PDF header region.
