### PR TITLE
CRM-11338 backport exception class

### DIFF
--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -25,12 +25,16 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Payment\Exception\PaymentProcessorException;
+
 /**
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2015
- * $Id$
- *
+ */
+
+/**
+ * Class CRM_Core_Payment_PayPalImpl for paypal pro, paypal standard & paypal express.
  */
 class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
   const CHARSET = 'iso-8859-1';
@@ -51,7 +55,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
    * @param string $mode
    *   The mode of operation: live or test.
    *
-   * @param $paymentProcessor
+   * @param CRM_Core_Payment $paymentProcessor
    *
    * @return \CRM_Core_Payment_PayPalImpl
    */
@@ -416,7 +420,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
    */
   public function doQuery($params) {
     if (empty($params['trxn_id'])) {
-      throw new \Civi\Payment\Exception\PaymentProcessorException('transaction id not set');
+      return array();
     }
     $args = array(
       'TRANSACTIONID' => $params['trxn_id'],

--- a/Civi/Payment/Exception/PaymentProcessorException.php
+++ b/Civi/Payment/Exception/PaymentProcessorException.php
@@ -1,0 +1,9 @@
+<?php
+namespace Civi\Payment\Exception;
+
+/**
+ * Class PaymentProcessorException
+ */
+class PaymentProcessorException extends \CRM_Core_Exception {
+
+}


### PR DESCRIPTION
- [CRM-11338: CiviCRM does not record processing fees for certain PayPalPro transactions](https://issues.civicrm.org/jira/browse/CRM-11338)
