### PR TITLE
CRM-17147 - ensure is_deceased FALSE values are 0, not NULL

### DIFF
--- a/CRM/Upgrade/Incremental/sql/4.7.beta2.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.7.beta2.mysql.tpl
@@ -11,3 +11,7 @@ ALTER TABLE civicrm_contact ALTER COLUMN do_not_phone SET DEFAULT 0;
 ALTER TABLE civicrm_contact ALTER COLUMN do_not_mail SET DEFAULT 0;
 ALTER TABLE civicrm_contact ALTER COLUMN do_not_sms SET DEFAULT 0;
 ALTER TABLE civicrm_contact ALTER COLUMN do_not_trade SET DEFAULT 0;
+
+-- CRM-17147 People with empty deceased-flag ('is null') get removed from recipient list of a mailing
+UPDATE civicrm_contact SET is_deceased = 0 WHERE is_deceased IS NULL;
+ALTER TABLE civicrm_contact ALTER COLUMN is_deceased SET DEFAULT 0;


### PR DESCRIPTION
---
- CRM-17147: People with empty deceased-flag ('is null') get removed from recipient list of a mailing
  https://issues.civicrm.org/jira/browse/CRM-17147
