### PR TITLE
CRM-17627 Set transaction date correctly for refunds

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2896,6 +2896,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
 
     $additionalParticipantId = array();
     $contributionStatuses = CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name');
+    $contributionStatus = empty($params['contribution_status_id']) ? NULL : $contributionStatuses[$params['contribution_status_id']];
 
     if (CRM_Utils_Array::value('contribution_mode', $params) == 'participant') {
       $entityId = $params['participant_id'];
@@ -3014,6 +3015,9 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
         'payment_instrument_id' => $params['contribution']->payment_instrument_id,
         'check_number' => CRM_Utils_Array::value('check_number', $params),
       );
+      if ($contributionStatus == 'Refunded') {
+        $trxnParams['trxn_date'] = !empty($params['contribution']->cancel_date) ? $params['contribution']->cancel_date : date('YmdHis');
+      }
 
       if (!empty($params['payment_processor'])) {
         $trxnParams['payment_processor_id'] = $params['payment_processor'];

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -1049,7 +1049,8 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $contribution = $this->callAPISuccess('contribution', 'create', $contribParams);
     $newParams = array_merge($contribParams, array(
         'id' => $contribution['id'],
-        'contribution_status_id' => 7,
+        'contribution_status_id' => 'Refunded',
+        'cancel_date' => '2015-01-01 09:00',
       )
     );
 
@@ -1988,6 +1989,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
         'to_financial_account_id' => 6,
         'total_amount' => -100,
         'status_id' => 7,
+        'trxn_date' => '2015-01-01 09:00:00',
       );
     }
     elseif ($context == 'cancelPending') {


### PR DESCRIPTION
- [CRM-17627: Incorrect dates on refunded contribution transactions](https://issues.civicrm.org/jira/browse/CRM-17627)
