### PR TITLE
CRM-16259 exclude payment from syntax conformance tests

### DIFF
--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -92,6 +92,7 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
       'ReportTemplate',
       'System',
       'Setting',
+      'Payment',
     );
     $this->toBeImplemented['create'] = array(
       'Cxn',
@@ -106,6 +107,7 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
       'ReportTemplate',
       'System',
       'User',
+      'Payment',
     );
     $this->toBeImplemented['delete'] = array(
       'Cxn',
@@ -118,6 +120,7 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
       'UFMatch',
       'Extension',
       'System',
+      'Payment',
     );
     $this->onlyIDNonZeroCount['get'] = array(
       'ActivityType',


### PR DESCRIPTION
- [CRM-16259: Create Payment API](https://issues.civicrm.org/jira/browse/CRM-16259)
