### PR TITLE
CRM-16525 - Remove $finType var assign since it throws an eNotice if …

### DIFF
--- a/CRM/Member/Form/MembershipView.php
+++ b/CRM/Member/Form/MembershipView.php
@@ -169,7 +169,6 @@ class CRM_Member_Form_MembershipView extends CRM_Core_Form {
       else {
         $this->assign('noACL', TRUE);
       }
-      $this->assign('financialTypeId', $finType);
       $membershipType = CRM_Member_BAO_MembershipType::getMembershipTypeDetails($values['membership_type_id']);
 
       // Do the action on related Membership if needed


### PR DESCRIPTION
…Financial Type ACLs are not enabled AND it does not appear to be used in any tpl file.

---
- CRM-16525: Add the possibility to enable/disable membership status for certain membership types
  https://issues.civicrm.org/jira/browse/CRM-16525
