### PR TITLE
Crm 14920 sort order labels custom search 2nd try

### DIFF
--- a/CRM/Contact/Form/Search/Custom/PostalMailing.php
+++ b/CRM/Contact/Form/Search/Custom/PostalMailing.php
@@ -112,10 +112,10 @@ class CRM_Contact_Form_Search_Custom_PostalMailing extends CRM_Contact_Form_Sear
       // also need to select contact_a.id. This is because of the patch we
       // use for CRM-16587.
       $selectClause = "
-DISTINCT contact_a.id as contact_id,
+DISTINCT contact_a.id  as contact_id  ,
 contact_a.id,
-contact_a.contact_type,
-contact_a.sort_name,
+contact_a.contact_type  as contact_type,
+contact_a.sort_name     as sort_name,
 address.street_address,
 state_province.name
 ";

--- a/CRM/Contact/Form/Search/Custom/PostalMailing.php
+++ b/CRM/Contact/Form/Search/Custom/PostalMailing.php
@@ -103,7 +103,7 @@ class CRM_Contact_Form_Search_Custom_PostalMailing extends CRM_Contact_Form_Sear
   ) {
     if ($justIDs) {
       $selectClause = "contact_a.id as contact_id";
-      //$sort = 'contact_a.id';
+      // Don't change sort order when $justIDs is TRUE, see CRM-14920.
     }
     else {
       // YOU NEED to select contact_a.id as contact_id, if you want to be able

--- a/CRM/Contact/Form/Search/Custom/PostalMailing.php
+++ b/CRM/Contact/Form/Search/Custom/PostalMailing.php
@@ -106,7 +106,7 @@ class CRM_Contact_Form_Search_Custom_PostalMailing extends CRM_Contact_Form_Sear
   ) {
     if ($justIDs) {
       $selectClause = "contact_a.id as contact_id";
-      $sort = 'contact_a.id';
+      //$sort = 'contact_a.id';
     }
     else {
       $selectClause = "

--- a/CRM/Contact/Form/Search/Custom/PostalMailing.php
+++ b/CRM/Contact/Form/Search/Custom/PostalMailing.php
@@ -42,11 +42,26 @@ class CRM_Contact_Form_Search_Custom_PostalMailing extends CRM_Contact_Form_Sear
     parent::__construct($formValues);
 
     $this->_columns = array(
+      // The only alias you can (and should!) use in the
+      // columns, is contact_id. Because contact_id is used
+      // in a lot of places, and it seems to be important that
+      // it is called contact_id_a.
+      //
+      // For the other fields, if possible, you should prefix
+      // their names with the table alias you are selecting them
+      // from. This way, you can work around CRM-16587.
+      //
+      // This approach wil not work if you want to select fields
+      // with the same name from different tables, this will generate
+      // an invalid query somewhere. In that case, you can
+      // use column aliases in your SELECT clause and in the array
+      // below, but you will still hit CRM-16587 when sorting on these
+      // fields.
       ts('Contact ID') => 'contact_id',
-      ts('Address') => 'address',
-      ts('Contact Type') => 'contact_type',
-      ts('Name') => 'sort_name',
-      ts('State') => 'state_province',
+      ts('Address') => 'address.street_address',
+      ts('Contact Type') => 'contact_a.contact_type',
+      ts('Name') => 'contact_a.sort_name',
+      ts('State') => 'state_province.name',
     );
   }
 
@@ -95,11 +110,11 @@ class CRM_Contact_Form_Search_Custom_PostalMailing extends CRM_Contact_Form_Sear
     }
     else {
       $selectClause = "
-DISTINCT contact_a.id  as contact_id  ,
-contact_a.contact_type  as contact_type,
-contact_a.sort_name     as sort_name,
-address.street_address  as address,
-state_province.name     as state_province
+DISTINCT contact_a.id  as contact_id,
+contact_a.contact_type,
+contact_a.sort_name,
+address.street_address,
+state_province.name
 ";
     }
 

--- a/CRM/Contact/Form/Search/Custom/PostalMailing.php
+++ b/CRM/Contact/Form/Search/Custom/PostalMailing.php
@@ -42,14 +42,12 @@ class CRM_Contact_Form_Search_Custom_PostalMailing extends CRM_Contact_Form_Sear
     parent::__construct($formValues);
 
     $this->_columns = array(
-      // The only alias you can (and should!) use in the
-      // columns, is contact_id. Because contact_id is used
-      // in a lot of places, and it seems to be important that
-      // it is called contact_id_a.
-      //
-      // For the other fields, if possible, you should prefix
-      // their names with the table alias you are selecting them
-      // from. This way, you can work around CRM-16587.
+      // If possible, you should prefix all column names with the
+      // table alias you are selecting them from. This includes
+      // contact_id: if you can select it from another table than
+      // contact_a, you should.
+      // All this is needed if you want to work around CRM-16587 with
+      // the patch that can be found over there.
       //
       // This approach wil not work if you want to select fields
       // with the same name from different tables, this will generate
@@ -57,7 +55,7 @@ class CRM_Contact_Form_Search_Custom_PostalMailing extends CRM_Contact_Form_Sear
       // use column aliases in your SELECT clause and in the array
       // below, but you will still hit CRM-16587 when sorting on these
       // fields.
-      ts('Contact ID') => 'contact_id',
+      ts('Contact ID') => 'address.contact_id',
       ts('Address') => 'address.street_address',
       ts('Contact Type') => 'contact_a.contact_type',
       ts('Name') => 'contact_a.sort_name',

--- a/CRM/Contact/Form/Search/Custom/ZipCodeRange.php
+++ b/CRM/Contact/Form/Search/Custom/ZipCodeRange.php
@@ -42,10 +42,14 @@ class CRM_Contact_Form_Search_Custom_ZipCodeRange extends CRM_Contact_Form_Searc
     parent::__construct($formValues);
 
     $this->_columns = array(
-      // If contact_id exists in another table than contact_a, you
-      // should select from there, if you want to use the
-      // workaround form CRM-16587.
-      ts('Contact ID') => 'email.contact_id',
+      // If possible, don't use aliases for the columns you select.
+      // You can prefix columns with table aliases, if needed.
+      //
+      // If you don't do this, selecting individual records from the
+      // custom search result won't work if your results are sorted on the
+      // aliased colums.
+      // (This is why we map Contact ID on contact_a.id, and not on contact_id).
+      ts('Contact ID') => 'contact_a.id',
       ts('Name') => 'sort_name',
       ts('Email') => 'email',
       ts('Zip') => 'postal_code',
@@ -118,8 +122,13 @@ class CRM_Contact_Form_Search_Custom_ZipCodeRange extends CRM_Contact_Form_Searc
       $sort = "contact_a.id";
     }
     else {
+      // We select contact_a.id twice. Once as contact_a.id,
+      // because it is used to fill the prevnext_cache. And once
+      // as contact_a.id, for the patch of CRM-16587 to work when
+      // the results are sorted on contact ID.
       $selectClause = "
 contact_a.id           as contact_id ,
+contact_a.id           as id ,
 contact_a.sort_name    as sort_name  ,
 email.email            as email   ,
 address.postal_code    as postal_code

--- a/CRM/Contact/Form/Search/Custom/ZipCodeRange.php
+++ b/CRM/Contact/Form/Search/Custom/ZipCodeRange.php
@@ -119,7 +119,7 @@ class CRM_Contact_Form_Search_Custom_ZipCodeRange extends CRM_Contact_Form_Searc
   ) {
     if ($justIDs) {
       $selectClause = "contact_a.id as contact_id";
-      $sort = "contact_a.id";
+      // Don't change sort order when $justIDs is TRUE, see CRM-14920.
     }
     else {
       // We select contact_a.id twice. Once as contact_a.id,

--- a/CRM/Contact/Form/Search/Custom/ZipCodeRange.php
+++ b/CRM/Contact/Form/Search/Custom/ZipCodeRange.php
@@ -42,7 +42,10 @@ class CRM_Contact_Form_Search_Custom_ZipCodeRange extends CRM_Contact_Form_Searc
     parent::__construct($formValues);
 
     $this->_columns = array(
-      ts('Contact ID') => 'contact_id',
+      // If contact_id exists in another table than contact_a, you
+      // should select from there, if you want to use the
+      // workaround form CRM-16587.
+      ts('Contact ID') => 'email.contact_id',
       ts('Name') => 'sort_name',
       ts('Email') => 'email',
       ts('Zip') => 'postal_code',

--- a/CRM/Contact/Form/Task.php
+++ b/CRM/Contact/Form/Task.php
@@ -190,9 +190,7 @@ class CRM_Contact_Form_Task extends CRM_Core_Form {
         // and it decides when to use distinct based on input criteria, which needs
         // to be fixed and optimized.
 
-        foreach ($allCids[$cacheKey] as $cid => $ignore) {
-          $form->_contactIds[] = $cid;
-        }
+        $form->_contactIds = array_unique($allCids[$cacheKey]);
       }
     }
     elseif (CRM_Utils_Array::value('radio_ts', self::$_searchFormValues) == 'ts_sel') {
@@ -313,7 +311,7 @@ class CRM_Contact_Form_Task extends CRM_Core_Form {
 
     $contactIds = array();
     while ($dao->fetch()) {
-      $contactIds[$dao->contact_id] = $dao->contact_id;
+      $contactIds[] = $dao->contact_id;
     }
 
     return $contactIds;

--- a/CRM/Contact/Form/Task.php
+++ b/CRM/Contact/Form/Task.php
@@ -190,7 +190,9 @@ class CRM_Contact_Form_Task extends CRM_Core_Form {
         // and it decides when to use distinct based on input criteria, which needs
         // to be fixed and optimized.
 
-        $form->_contactIds = array_unique($allCids[$cacheKey]);
+        foreach ($allCids[$cacheKey] as $cid => $ignore) {
+          $form->_contactIds[] = $cid;
+        }
       }
     }
     elseif (CRM_Utils_Array::value('radio_ts', self::$_searchFormValues) == 'ts_sel') {
@@ -311,7 +313,7 @@ class CRM_Contact_Form_Task extends CRM_Core_Form {
 
     $contactIds = array();
     while ($dao->fetch()) {
-      $contactIds[] = $dao->contact_id;
+      $contactIds[$dao->contact_id] = $dao->contact_id;
     }
 
     return $contactIds;

--- a/CRM/Contact/Selector/Custom.php
+++ b/CRM/Contact/Selector/Custom.php
@@ -425,10 +425,24 @@ class CRM_Contact_Selector_Custom extends CRM_Contact_Selector {
    * @return Object
    */
   public function contactIDQuery($params, $action, $sortID, $displayRelationshipType = NULL, $queryOperator = 'AND') {
-    $params = array();
-    $sql = $this->_search->contactIDs($params);
+    // $action, $displayRelationshipType and $queryOperator are unused. I have
+    // no idea why they are there.
 
-    return CRM_Core_DAO::executeQuery($sql, $params);
+    // I wonder whether there is some helper function for this:
+    $matches = array();
+    if (preg_match('/([0-9]*)(_(u|d))?/', $sortID, $matches)) {
+      $columns = array_values($this->_search->columns());
+      $sort = $columns[$matches[1] - 1];
+      if (array_key_exists(3, $matches) && $matches[3] == 'd') {
+        $sort .= " DESC";
+      }
+    }
+    else {
+      $sort = NULL;
+    }
+
+    $sql = $this->_search->contactIDs(0, 0, $sort);
+    return CRM_Core_DAO::executeQuery($sql);
   }
 
   /**

--- a/CRM/Contact/Selector/Custom.php
+++ b/CRM/Contact/Selector/Custom.php
@@ -333,8 +333,10 @@ class CRM_Contact_Selector_Custom extends CRM_Contact_Selector {
 
       // the columns we are interested in
       foreach ($columnNames as $property) {
-        $row[$property] = $dao->$property;
-        if (!empty($dao->$property)) {
+        // Get part of name after last . (if any)
+        $unqualified_property = CRM_Utils_Array::First(array_slice(explode('.', $property), -1));
+        $row[$property] = $dao->$unqualified_property;
+        if (!empty($dao->$unqualified_property)) {
           $empty = FALSE;
         }
       }

--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -1330,7 +1330,8 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
       $row = array();
 
       foreach ($fields as $field) {
-        $row[$field] = $dao->$field;
+        $unqualified_field = CRM_Utils_Array::First(array_slice(explode('.', $field), -1));
+        $row[$field] = $dao->$unqualified_field;
       }
       if ($alterRow) {
         $search->alterRow($row);


### PR DESCRIPTION
This PR replaces #7446. It seems to fix CRM-14920, but it uses a dodgy workaround for CRM-16587.

---
- [CRM-14920: Custom Searches do not honor user sort order](https://issues.civicrm.org/jira/browse/CRM-14920)
- [CRM-16587: Action menu is not available on selected records on a Custom search](https://issues.civicrm.org/jira/browse/CRM-16587)
