### PR TITLE
CRM-17717 - send correct MIME type for .jpg files

### DIFF
--- a/CRM/Contact/Page/ImageFile.php
+++ b/CRM/Contact/Page/ImageFile.php
@@ -60,7 +60,7 @@ class CRM_Contact_Page_ImageFile extends CRM_Core_Page {
     }
     if ($cid) {
       $config = CRM_Core_Config::singleton();
-      $fileExtension = pathinfo($_GET['photo'], PATHINFO_EXTENSION);
+      $fileExtension = strtolower(pathinfo($_GET['photo'], PATHINFO_EXTENSION));
       $this->download(
         $config->customFileUploadDir . $_GET['photo'],
         'image/' . ($fileExtension == 'jpg' ? 'jpeg' : $fileExtension),

--- a/CRM/Contact/Page/ImageFile.php
+++ b/CRM/Contact/Page/ImageFile.php
@@ -60,9 +60,10 @@ class CRM_Contact_Page_ImageFile extends CRM_Core_Page {
     }
     if ($cid) {
       $config = CRM_Core_Config::singleton();
+      $fileExtension = pathinfo($_GET['photo'], PATHINFO_EXTENSION);
       $this->download(
         $config->customFileUploadDir . $_GET['photo'],
-        'image/' . pathinfo($_GET['photo'], PATHINFO_EXTENSION),
+        'image/' . ($fileExtension == 'jpg' ? 'jpeg' : $fileExtension),
         $this->ttl
       );
       CRM_Utils_System::civiExit();


### PR DESCRIPTION
Content-Type should be image/jpeg, not image/jpg .

---
- [CRM-17717: Contact images with .jpg extension fail to display in Internet Explorer](https://issues.civicrm.org/jira/browse/CRM-17717)
