### PR TITLE
CRM-17725 - Fix for Twitter link broken contributio email receipt

### DIFF
--- a/templates/CRM/common/SocialNetwork.tpl
+++ b/templates/CRM/common/SocialNetwork.tpl
@@ -35,7 +35,7 @@
     <div class="crm-fb-tweet-buttons">
         {if $emailMode eq true}
             {*use images for email*}
-            <a href="http://twitter.com/share?url={$url}&amp;text={$title}" id="crm_tweet">
+            <a href="http://twitter.com/share?url={$url|escape:'url'}&amp;text={$title}" id="crm_tweet">
                 <img title="Twitter Tweet Button" src="{$config->userFrameworkResourceURL|replace:'https://':'http://'}/i/tweet.png" width="55px" height="20px"  alt="Tweet Button">
             </a>
             <a href="http://www.facebook.com/plugins/like.php?href={$url}" target="_blank">


### PR DESCRIPTION
Issue: Twitter link is broken when we click on Twitter image in contribution email receipt where we can't see contribution id in the URL

https://issues.civicrm.org/jira/browse/CRM-17725

![twitter_link](https://cloud.githubusercontent.com/assets/7429798/11872958/09a2fd22-a4d0-11e5-883c-0bc3411416ce.png)
