### PR TITLE
CRM-15967 - Fix profile state/province sort.

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -4598,6 +4598,9 @@ civicrm_relationship.is_permission_a_b = 0
     // CRM-15231
     $this->_sort = $sort;
 
+    //CRM-15967
+    $this->includePseudoFieldsJoin($sort);
+
     list($select, $from, $where, $having) = $this->query($count, $sortByChar, $groupContacts, $onlyDeleted);
 
     if ($additionalWhereClause) {


### PR DESCRIPTION
---
- CRM-15967: profile: cannot sort state/province
  https://issues.civicrm.org/jira/browse/CRM-15967
