### PR TITLE
CRM-17741 - Permissions for RelationshipType.get API.

### DIFF
--- a/CRM/Core/DAO/permissions.php
+++ b/CRM/Core/DAO/permissions.php
@@ -149,6 +149,16 @@ function _civicrm_api3_permissions($entity, $action, &$params) {
     ),
   );
 
+  // CRM-17741 - Permissions for RelationshipType.
+  $permissions['relationship_type'] = array(
+    'get' => array(
+      'access CiviCRM',
+    ),
+    'default' => array(
+      'administer CiviCRM',
+    ),
+  );
+
   // Activity permissions
   $permissions['activity'] = array(
     'delete' => array(


### PR DESCRIPTION
## Now you can use the RelationshipType.get API if you have Access CiviCRM permissions.
- CRM-17741: RelationshipType.get API requires Administer CiviCRM permissions
  https://issues.civicrm.org/jira/browse/CRM-17741
