### PR TITLE
Avoid insertion of warnings in gencode while creating distmaker

### DIFF
--- a/xml/GenCode.php
+++ b/xml/GenCode.php
@@ -1,5 +1,4 @@
 <?php
-ini_set('display_errors', 1);
 ini_set('include_path', '.' . PATH_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'packages' . PATH_SEPARATOR . '..');
 // make sure the memory_limit is at least 512 MB
 $memLimitString = trim(ini_get('memory_limit'));


### PR DESCRIPTION
mysql_real_escape_string() warnings get inserted in queries resulting in DB syntax error during installaiton
