### PR TITLE
CRM-17655 editing recurring through form causes error

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -201,7 +201,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
 
     if (self::isUpdateToRecurringContribution($params)) {
       CRM_Contribute_BAO_ContributionRecur::updateOnNewPayment(
-        $params['contribution_recur_id'],
+        (!empty($params['contribution_recur_id']) ? $params['contribution_recur_id'] : $params['prevContribution']->contribution_recur_id),
         $contributionStatus[$params['contribution_status_id']]
       );
     }


### PR DESCRIPTION
On editing I found previous patches for CRM-17655 had caused a situation where the ID for the recurring contribution
was not always being correctly determined

---
- [CRM-17655: Adding a payment to a recurring contribution sequence should update the contribution_recur table](https://issues.civicrm.org/jira/browse/CRM-17655)
