### PR TITLE
CRM_Utils_Hook::alterMailer -- Fix typo

### DIFF
--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -1795,9 +1795,28 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    * @see Mail::factory
    */
-  public static function alterMail(&$mailer, $driver, $params) {
+  public static function alterMailer(&$mailer, $driver, $params) {
     return self::singleton()
       ->invoke(3, $mailer, $driver, $params, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_alterMailer');
+  }
+
+  /**
+   * Deprecated: Misnamed version of alterMailer(). Remove post-4.7.x.
+   * Modify or replace the Mailer object used for outgoing mail.
+   *
+   * @param object $mailer
+   *   The default mailer produced by normal configuration; a PEAR "Mail" class (like those returned by Mail::factory)
+   * @param string $driver
+   *   The type of the default mailer (eg "smtp", "sendmail", "mock", "CRM_Mailing_BAO_Spool")
+   * @param array $params
+   *   The default mailer config options
+   *
+   * @return mixed
+   * @see Mail::factory
+   * @deprecated
+   */
+  public static function alterMail(&$mailer, $driver, $params) {
+    return CRM_Utils_Hook::alterMailer($mailer, $driver, $params);
   }
 
   /**

--- a/CRM/Utils/Mail.php
+++ b/CRM/Utils/Mail.php
@@ -126,7 +126,7 @@ class CRM_Utils_Mail {
     else {
       $mailer = Mail::factory($driver, $params);
     }
-    CRM_Utils_Hook::alterMail($mailer, $driver, $params);
+    CRM_Utils_Hook::alterMailer($mailer, $driver, $params);
     return $mailer;
   }
 


### PR DESCRIPTION
There was a discrepancy in the naming of this hook:
- The stub function was named `alterMail`. Internal code therefore referred to `Hook::alterMail()`.
- The hook invocation fires as `alterMailer`. Downstream code therefore referred to `hook_civicrm_alterMailer`.

This patch standardizes on `alterMailer` to preserve the downstream
interface.  It leaves `::alterMail()` as a deprecated alias in case there's
some unexpected external use-case.
