### PR TITLE
CRM-17669 and CRM-17686, flexible scheduled jobs

### DIFF
--- a/CRM/Core/ScheduledJob.php
+++ b/CRM/Core/ScheduledJob.php
@@ -89,8 +89,8 @@ class CRM_Core_ScheduledJob {
   /**
    * @return void
    */
-  public function clearNextScheduledRun() {
-    CRM_Core_DAO::executeQuery('UPDATE civicrm_job SET next_scheduled_run = NULL WHERE id = %1',
+  public function clearScheduledRunDate() {
+    CRM_Core_DAO::executeQuery('UPDATE civicrm_job SET scheduled_run_date = NULL WHERE id = %1',
       array(
         '1' => array($this->id, 'Integer'),
       ));
@@ -103,9 +103,9 @@ class CRM_Core_ScheduledJob {
 
     // CRM-17686
     // check if the job has a specific scheduled date/time
-    if (!empty($this->next_scheduled_run)) {
-      if (strtotime($this->next_scheduled_run) <= time()) {
-        $this->clearNextScheduledRun();
+    if (!empty($this->scheduled_run_date)) {
+      if (strtotime($this->scheduled_run_date) <= time()) {
+        $this->clearScheduledRunDate();
         return TRUE;
       }
       else {

--- a/CRM/Core/ScheduledJob.php
+++ b/CRM/Core/ScheduledJob.php
@@ -87,9 +87,32 @@ class CRM_Core_ScheduledJob {
   }
 
   /**
+   * @return void
+   */
+  public function clearNextScheduledRun() {
+    CRM_Core_DAO::executeQuery('UPDATE civicrm_job SET next_scheduled_run = NULL WHERE id = %1',
+      array(
+        '1' => array($this->id, 'Integer'),
+      ));
+  }
+
+  /**
    * @return bool
    */
   public function needsRunning() {
+
+    // CRM-17686
+    // check if the job has a specific scheduled date/time
+    if (!empty($this->next_scheduled_run)) {
+      if (strtotime($this->next_scheduled_run) <= time()) {
+        $this->clearNextScheduledRun();
+        return TRUE;
+      }
+      else {
+        return FALSE;
+      }
+    }
+
     // run if it was never run
     if (empty($this->last_run)) {
       return TRUE;
@@ -100,43 +123,37 @@ class CRM_Core_ScheduledJob {
       case 'Always':
         return TRUE;
 
-      case 'Hourly':
-        $format = 'YmdH';
+      // CRM-17669
+      case 'Yearly':
+        $offset = '+1 year';
+        break;
+
+      case 'Quarter':
+        $offset = '+3 months';
+        break;
+
+      case 'Monthly':
+        $offset = '+1 month';
+        break;
+
+      case 'Weekly':
+        $offset = '+1 week';
         break;
 
       case 'Daily':
-        $format = 'Ymd';
+        $offset = '+1 day';
         break;
 
-      case 'Mondays':
-        $now = CRM_Utils_Date::currentDBDate();
-        $dayAgo = strtotime('-1 day', strtotime($now));
-        $lastRun = strtotime($this->last_run);
-        $nowDayOfWeek = date('l', strtotime($now));
-        return ($lastRun < $dayAgo && $nowDayOfWeek == 'Monday');
-
-      case '1stOfMth':
-        $now = CRM_Utils_Date::currentDBDate();
-        $dayAgo = strtotime('-1 day', strtotime($now));
-        $lastRun = strtotime($this->last_run);
-        $nowDayOfMonth = date('j', strtotime($now));
-        return ($lastRun < $dayAgo && $nowDayOfMonth == '1');
-
-      case '1stOfQtr':
-        $now = CRM_Utils_Date::currentDBDate();
-        $dayAgo = strtotime('-1 day', strtotime($now));
-        $lastRun = strtotime($this->last_run);
-        $nowDayOfMonth = date('j', strtotime($now));
-        $nowMonth = date('n', strtotime($now));
-        $qtrMonths = array('1', '4', '7', '10');
-        return ($lastRun < $dayAgo && $nowDayOfMonth == '13' && in_array($nowMonth, $qtrMonths));
+      case 'Hourly':
+        $offset = '+1 hour';
+        break;
     }
 
-    $now = CRM_Utils_Date::currentDBDate();
-    $lastTime = date($format, strtotime($this->last_run));
-    $thisTime = date($format, strtotime($now));
+    $now = strtotime(CRM_Utils_Date::currentDBDate());
+    $lastTime = strtotime($this->last_run);
+    $nextTime = strtotime($offset, $lastTime);
 
-    return ($lastTime <> $thisTime);
+    return ($now >= $nextTime);
   }
 
   public function __destruct() {

--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -893,9 +893,12 @@ class CRM_Core_SelectValues {
    */
   public static function getJobFrequency() {
     return array(
-      '1stOfQtr' => ts('1st day of every quarter'),
-      '1stOfMth' => ts('1st day of every month'),
-      'Mondays' => ts('Monday of every week'),
+      // CRM-17669
+      'Yearly' => ts('Yearly'),
+      'Quarter' => ts('Quarterly'),
+      'Monthly' => ts('Monthly'),
+      'Weekly' => ts('Weekly'),
+
       'Daily' => ts('Daily'),
       'Hourly' => ts('Hourly'),
       'Always' => ts('Every time cron job is run'),

--- a/CRM/Upgrade/Incremental/php/FourSeven.php
+++ b/CRM/Upgrade/Incremental/php/FourSeven.php
@@ -139,7 +139,7 @@ class CRM_Upgrade_Incremental_php_FourSeven extends CRM_Upgrade_Incremental_Base
    *
    * @param string $rev
    */
-  public function upgrade_4_7_beta5($rev) {
+  public function upgrade_4_7_beta6($rev) {
     $this->addTask(ts('Upgrade DB to %1: SQL', array(1 => $rev)), 'runSql', $rev);
     $this->addTask('Disable flexible jobs extension', 'disableFlexibleJobsExtension');
   }

--- a/CRM/Upgrade/Incremental/php/FourSeven.php
+++ b/CRM/Upgrade/Incremental/php/FourSeven.php
@@ -135,6 +135,15 @@ class CRM_Upgrade_Incremental_php_FourSeven extends CRM_Upgrade_Incremental_Base
   }
 
   /**
+   * Upgrade function.
+   *
+   * @param string $rev
+   */
+  public function upgrade_4_7_beta5($rev) {
+    $this->addTask('Disable flexible jobs extension', 'disableFlexibleJobsExtension');
+  }
+
+  /**
    * CRM-16354
    *
    * @return int
@@ -360,6 +369,19 @@ FROM `civicrm_dashboard_contact` WHERE 1 GROUP BY contact_id";
     if (file_exists($cacheFile)) {
       unlink($cacheFile);
     }
+    return TRUE;
+  }
+
+  /**
+   * CRM-17669 and CRM-17686, make scheduled jobs more flexible, disable the 4.6 extension if installed
+   *
+   * @param \CRM_Queue_TaskContext $ctx
+   *
+   * @return bool
+   */
+  public function disableFlexibleJobsExtension(CRM_Queue_TaskContext $ctx) {
+    CRM_Core_DAO::setFieldValue('CRM_Core_DAO_Job', 'Flexible Jobs', 'is_active', 0, 'name');
+
     return TRUE;
   }
 

--- a/CRM/Upgrade/Incremental/php/FourSeven.php
+++ b/CRM/Upgrade/Incremental/php/FourSeven.php
@@ -140,6 +140,7 @@ class CRM_Upgrade_Incremental_php_FourSeven extends CRM_Upgrade_Incremental_Base
    * @param string $rev
    */
   public function upgrade_4_7_beta5($rev) {
+    $this->addTask(ts('Upgrade DB to %1: SQL', array(1 => $rev)), 'runSql', $rev);
     $this->addTask('Disable flexible jobs extension', 'disableFlexibleJobsExtension');
   }
 
@@ -380,7 +381,7 @@ FROM `civicrm_dashboard_contact` WHERE 1 GROUP BY contact_id";
    * @return bool
    */
   public function disableFlexibleJobsExtension(CRM_Queue_TaskContext $ctx) {
-    CRM_Core_DAO::setFieldValue('CRM_Core_DAO_Job', 'Flexible Jobs', 'is_active', 0, 'name');
+    civicrm_api3('Extension', 'disable', array('key' => 'com.klangsoft.flexiblejobs'));
 
     return TRUE;
   }

--- a/CRM/Upgrade/Incremental/php/FourSeven.php
+++ b/CRM/Upgrade/Incremental/php/FourSeven.php
@@ -381,7 +381,12 @@ FROM `civicrm_dashboard_contact` WHERE 1 GROUP BY contact_id";
    * @return bool
    */
   public function disableFlexibleJobsExtension(CRM_Queue_TaskContext $ctx) {
-    civicrm_api3('Extension', 'disable', array('key' => 'com.klangsoft.flexiblejobs'));
+    try {
+      civicrm_api3('Extension', 'disable', array('key' => 'com.klangsoft.flexiblejobs'));
+    }
+    catch (CiviCRM_API3_Exception $e) {
+      // just ignore if the extension isn't installed
+    }
 
     return TRUE;
   }

--- a/CRM/Upgrade/Incremental/sql/4.7.beta5.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.7.beta5.mysql.tpl
@@ -2,4 +2,4 @@
 
 -- CRM-17686
 ALTER TABLE `civicrm_job`
-ADD COLUMN `next_scheduled_run` timestamp NULL DEFAULT NULL COMMENT 'When is this cron entry scheduled to run next' AFTER `last_run`;
+ADD COLUMN `scheduled_run_date` timestamp NULL DEFAULT NULL COMMENT 'When is this cron entry scheduled to run' AFTER `last_run`;

--- a/CRM/Upgrade/Incremental/sql/4.7.beta5.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.7.beta5.mysql.tpl
@@ -1,5 +1,1 @@
 {* file to handle db changes in 4.7.beta5 during upgrade *}
-
--- CRM-17686
-ALTER TABLE `civicrm_job`
-ADD COLUMN `scheduled_run_date` timestamp NULL DEFAULT NULL COMMENT 'When is this cron entry scheduled to run' AFTER `last_run`;

--- a/CRM/Upgrade/Incremental/sql/4.7.beta5.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.7.beta5.mysql.tpl
@@ -1,1 +1,5 @@
 {* file to handle db changes in 4.7.beta5 during upgrade *}
+
+-- CRM-17686
+ALTER TABLE `civicrm_job`
+ADD COLUMN `next_scheduled_run` timestamp NULL DEFAULT NULL COMMENT 'When is this cron entry scheduled to run next' AFTER `last_run`;

--- a/CRM/Upgrade/Incremental/sql/4.7.beta6.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.7.beta6.mysql.tpl
@@ -1,1 +1,5 @@
 {* file to handle db changes in 4.7.beta6 during upgrade *}
+
+-- CRM-17686
+ALTER TABLE `civicrm_job`
+ADD COLUMN `scheduled_run_date` timestamp NULL DEFAULT NULL COMMENT 'When is this cron entry scheduled to run' AFTER `last_run`;

--- a/templates/CRM/Admin/Form/Job.tpl
+++ b/templates/CRM/Admin/Form/Job.tpl
@@ -105,6 +105,15 @@ CRM.$(function($) {
       <td class="label">{$form.parameters.label}<br />{docURL page="Managing Scheduled Jobs" resource="wiki"}</td>
       <td>{$form.parameters.html}</td>
     </tr>
+    <tr class="crm-job-form-block-next_scheduled_run">
+        <td class="label">{$form.next_scheduled_run.label}</td>
+        <td>
+            {if $hideCalender neq true}{include file="CRM/common/jcalendar.tpl" elementName=next_scheduled_run}{else}{$next_scheduled_run|crmDate}{/if}<br />
+            <div dlass="description">{ts}Do not run this job before this date / time.
+              Leave blank to run {if $action eq 1}as soon as possible{else}at next scheduled interval{/if}.{/ts}
+            </div>
+        </td>
+    </tr>
     <tr class="crm-job-form-block-is_active">
       <td></td><td>{$form.is_active.html}&nbsp;{$form.is_active.label}</td>
     </tr>

--- a/templates/CRM/Admin/Form/Job.tpl
+++ b/templates/CRM/Admin/Form/Job.tpl
@@ -105,12 +105,12 @@ CRM.$(function($) {
       <td class="label">{$form.parameters.label}<br />{docURL page="Managing Scheduled Jobs" resource="wiki"}</td>
       <td>{$form.parameters.html}</td>
     </tr>
-    <tr class="crm-job-form-block-next_scheduled_run">
-        <td class="label">{$form.next_scheduled_run.label}</td>
+    <tr class="crm-job-form-block-scheduled-run-date">
+        <td class="label">{$form.scheduled_run_date.label}</td>
         <td>
-            {if $hideCalender neq true}{include file="CRM/common/jcalendar.tpl" elementName=next_scheduled_run}{else}{$next_scheduled_run|crmDate}{/if}<br />
+            {if $hideCalender neq true}{include file="CRM/common/jcalendar.tpl" elementName=scheduled_run_date}{else}{$scheduled_run_date|crmDate}{/if}<br />
             <div dlass="description">{ts}Do not run this job before this date / time.
-              Leave blank to run {if $action eq 1}as soon as possible{else}at next scheduled interval{/if}.{/ts}
+              Leave blank to run {if $action eq 1}as soon as possible{else}at next run frequency{/if}.{/ts}
             </div>
         </td>
     </tr>

--- a/templates/CRM/Admin/Form/Job.tpl
+++ b/templates/CRM/Admin/Form/Job.tpl
@@ -109,7 +109,7 @@ CRM.$(function($) {
         <td class="label">{$form.scheduled_run_date.label}</td>
         <td>{$form.scheduled_run_date.html}<br />
             <div dlass="description">{ts}Do not run this job before this date / time. The run frequency selected above will apply thereafter.{/ts}<br />
-              {ts}Leave blank to run{/ts} {if $action eq 1}{ts}as soon as possible{/ts}{else}{ts}at next run frequency{/ts}{/if}.
+              {if $action eq 1}{ts}Leave blank to run as soon as possible.{/ts}{else}{ts}Leave blank to run at next run frequency.{/ts}{/if}
             </div>
         </td>
     </tr>

--- a/templates/CRM/Admin/Form/Job.tpl
+++ b/templates/CRM/Admin/Form/Job.tpl
@@ -107,10 +107,9 @@ CRM.$(function($) {
     </tr>
     <tr class="crm-job-form-block-scheduled-run-date">
         <td class="label">{$form.scheduled_run_date.label}</td>
-        <td>
-            {if $hideCalender neq true}{include file="CRM/common/jcalendar.tpl" elementName=scheduled_run_date}{else}{$scheduled_run_date|crmDate}{/if}<br />
-            <div dlass="description">{ts}Do not run this job before this date / time.
-              Leave blank to run {if $action eq 1}as soon as possible{else}at next run frequency{/if}.{/ts}
+        <td>{$form.scheduled_run_date.html}<br />
+            <div dlass="description">{ts}Do not run this job before this date / time. The run frequency selected above will apply thereafter.{/ts}<br />
+              {ts}Leave blank to run{/ts} {if $action eq 1}{ts}as soon as possible{/ts}{else}{ts}at next run frequency{/ts}{/if}.
             </div>
         </td>
     </tr>

--- a/xml/schema/Core/Job.xml
+++ b/xml/schema/Core/Job.xml
@@ -61,6 +61,13 @@
     <add>4.1</add>
   </field>
   <field>
+    <name>next_scheduled_run</name>
+    <type>timestamp</type>
+    <default>NULL</default>
+    <comment>When is this cron entry scheduled to run next</comment>
+    <add>4.7</add>
+  </field>
+  <field>
     <name>name</name>
     <title>Job Name</title>
     <type>varchar</type>

--- a/xml/schema/Core/Job.xml
+++ b/xml/schema/Core/Job.xml
@@ -61,10 +61,10 @@
     <add>4.1</add>
   </field>
   <field>
-    <name>next_scheduled_run</name>
+    <name>scheduled_run_date</name>
     <type>timestamp</type>
     <default>NULL</default>
-    <comment>When is this cron entry scheduled to run next</comment>
+    <comment>When is this cron entry scheduled to run</comment>
     <add>4.7</add>
   </field>
   <field>

--- a/xml/schema/Core/Job.xml
+++ b/xml/schema/Core/Job.xml
@@ -64,6 +64,7 @@
     <name>scheduled_run_date</name>
     <type>timestamp</type>
     <default>NULL</default>
+    <required>false</required>
     <comment>When is this cron entry scheduled to run</comment>
     <add>4.7</add>
   </field>


### PR DESCRIPTION
- [CRM-17669: Add additional run frequencies for scheduled jobs](https://issues.civicrm.org/jira/browse/CRM-17669)
  - [CRM-17686: Add field to scheduled job form to specify first\/next run](https://issues.civicrm.org/jira/browse/CRM-17686)
