### PR TITLE
CRM-17763 trigger postEmailSend hook in civimail

### DIFF
--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -285,6 +285,10 @@ class CRM_Mailing_BAO_MailingJob extends CRM_Mailing_DAO_MailingJob {
         $mailing->is_completed = TRUE;
         $mailing->save();
         $transaction->commit();
+
+        // CRM-17763
+        $details = CRM_Mailing_BAO_Mailing::report($job->mailing_id);
+        CRM_Utils_Hook::postEmailSend($details, 'civimail');
       }
     }
   }

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -1557,13 +1557,15 @@ abstract class CRM_Utils_Hook {
    *   The mailing parameters. Array fields include: groupName, from, toName,
    *   toEmail, subject, cc, bcc, text, html, returnPath, replyTo, headers,
    *   attachments (array)
+   * @param string $context
+   *   Context of the mailing, either 'activity' or 'civimail'
    *
    * @return mixed
    */
-  public static function postEmailSend(&$params) {
-    return self::singleton()->invoke(1, $params,
+  public static function postEmailSend(&$params, $context = '') {
+    return self::singleton()->invoke(2, $params, $context,
       self::$_nullObject, self::$_nullObject,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject,
       'civicrm_postEmailSend'
     );
   }

--- a/CRM/Utils/Mail.php
+++ b/CRM/Utils/Mail.php
@@ -281,7 +281,7 @@ class CRM_Utils_Mail {
         return FALSE;
       }
       // CRM-10699
-      CRM_Utils_Hook::postEmailSend($params);
+      CRM_Utils_Hook::postEmailSend($params, 'activity');
       return TRUE;
     }
     return FALSE;


### PR DESCRIPTION
- [CRM-17763: extend postEmailSend hook to be triggered by civimail](https://issues.civicrm.org/jira/browse/CRM-17763)
