### PR TITLE
xml/GenCode - Expand memory limit (4.4 backport)

### DIFF
--- a/xml/GenCode.php
+++ b/xml/GenCode.php
@@ -11,7 +11,8 @@ switch ($memLimitUnit) {
 }
 
 if ($memLimit >= 0 and $memLimit < 536870912) {
-    ini_set('memory_limit', '512M');
+    // Note: When processing all locales, CRM_Core_I18n::singleton() eats a lot of RAM.
+    ini_set('memory_limit', -1);
 }
 date_default_timezone_set('UTC'); // avoid php warnings if timezone is not set - CRM-10844
 


### PR DESCRIPTION
GenCode processes translations in all locales.  Loading all locales is
memory-intensive (est ~20mb per locale based on `memory_get_usage()`).

The locales are tracked in `CRM_Core_I18n::singleton()`.  The behavior is
actually good for typical usage (1-2 locales per page-view), but it breaks
down when one request needs to work with all locales.  If it mattered more,
we'd probably implement some cache-management to deallocate older/unused
locales.  But for GenCode, it's OK to bump up memory requirements as high as
1gb.
