### PR TITLE
Changed development instructions link to go to updated wiki page

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -61,7 +61,7 @@ http://forum.civicrm.org/index.php/board,20.0.html
 
 Installing the latest developmental code requires some special steps. Full
 instructions are on the wiki:
-http://wiki.civicrm.org/confluence/display/CRMDOC/Github+for+CiviCRM
+http://wiki.civicrm.org/confluence/display/CRMDOC/Contributing+to+CiviCRM+using+GitHub
 
 Report all issues to CiviCRM via JIRA:
 https://issues.civicrm.org


### PR DESCRIPTION
The link to the developer's guide on the wiki in the README file was going to an invalid page. This commit directs the user to the new, correct place.
