### PR TITLE
CRM-15238 Add option to use semicolon as separator for the

### DIFF
--- a/bin/cli.class.php
+++ b/bin/cli.class.php
@@ -46,6 +46,7 @@ class civicrm_cli {
   var $_action = NULL;
   var $_output = FALSE;
   var $_joblog = FALSE;
+  var $_semicolon = FALSE;
   var $_config;
 
   // optional arguments
@@ -184,6 +185,9 @@ class civicrm_cli {
       }
       elseif ($arg == '-j' || $arg == '--joblog') {
         $this->_joblog = TRUE;
+      }
+      elseif ($arg == '-sem' || $arg == '--semicolon') {
+        $this->_semicolon = TRUE;
       }
       else {
         foreach ($this->_additional_arguments as $short => $long) {
@@ -342,7 +346,14 @@ class civicrm_cli_csv_exporter extends civicrm_cli {
     parent::initialize();
   }
 
+  /**
+   * Run the script.
+   */
   public function run() {
+    if ($this->_semicolon) {
+      $this->separator = ';';
+    }
+
     $out = fopen("php://output", 'w');
     fputcsv($out, $this->columns, $this->separator, '"');
 


### PR DESCRIPTION
bin/csv/export.php

Replaces https://github.com/civicrm/civicrm-core/pull/4096/commits

---
- [CRM-15238: Add option to use semicolon as separator for the bin\/csv\/export.php](https://issues.civicrm.org/jira/browse/CRM-15238)
