### PR TITLE
CRM-11801 defer to Authorize.net config on whether a.net receipts sho…

### DIFF
--- a/CRM/Core/Payment/AuthorizeNet.php
+++ b/CRM/Core/Payment/AuthorizeNet.php
@@ -57,7 +57,6 @@ class CRM_Core_Payment_AuthorizeNet extends CRM_Core_Payment {
     $this->_setParam('paymentType', 'AIM');
     $this->_setParam('md5Hash', CRM_Utils_Array::value('signature', $paymentProcessor));
 
-    $this->_setParam('emailCustomer', 'TRUE');
     $this->_setParam('timestamp', time());
     srand(time());
     $this->_setParam('sequence', rand(1, 1000));


### PR DESCRIPTION
…uld be sent.

This means CiviCRM receipts will go out as configured from CiviCRM & Authorize.net as configured from
the Authorize.net UI
