### PR TITLE
CRM-17748 Expose options['result_buffering'] to CRM_Core_DAO

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -42,6 +42,7 @@ class CRM_Contact_BAO_Query {
    * @var int
    */
   const
+    NO_RETURN_PROPERTIES = 'CRM_Contact_BAO_Query::NO_RETURN_PROPERTIES',
     MODE_CONTACTS = 1,
     MODE_CONTRIBUTE = 2,
     MODE_MEMBER = 8,
@@ -419,7 +420,10 @@ class CRM_Contact_BAO_Query {
       $this->_params = array();
     }
 
-    if (empty($returnProperties)) {
+    if ($returnProperties === self::NO_RETURN_PROPERTIES) {
+      $this->_returnProperties = array();
+    }
+    elseif (empty($returnProperties)) {
       $this->_returnProperties = self::defaultReturnProperties($mode);
     }
     else {

--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -1221,15 +1221,16 @@ SELECT DISTINCT 'civicrm_contact', contact_a.id, contact_a.id, '$cacheKey', cont
 
     if (!$displayRelationshipType) {
       $query = new CRM_Contact_BAO_Query($params,
-        $this->_returnProperties,
-        NULL, FALSE, FALSE, 1,
+        CRM_Contact_BAO_Query::NO_RETURN_PROPERTIES,
+        array('contact_id'), FALSE, FALSE, 1,
         FALSE, TRUE, TRUE, NULL,
         $queryOperator
       );
     }
     else {
-      $query = new CRM_Contact_BAO_Query($params, $this->_returnProperties,
-        NULL, FALSE, FALSE, 1,
+      $query = new CRM_Contact_BAO_Query($params,
+        CRM_Contact_BAO_Query::NO_RETURN_PROPERTIES,
+        array('contact_id'), FALSE, FALSE, 1,
         FALSE, TRUE, TRUE, $displayRelationshipType,
         $queryOperator
       );

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -72,6 +72,12 @@ class CRM_Core_DAO extends DB_DataObject {
   static $_checkedSqlFunctionsExist = FALSE;
 
   /**
+   * https://issues.civicrm.org/jira/browse/CRM-17748
+   * internal variable for DAO to hold per-query settings
+   */
+  protected $_options = array();
+
+  /**
    * Class constructor.
    *
    * @return \CRM_Core_DAO
@@ -315,12 +321,20 @@ class CRM_Core_DAO extends DB_DataObject {
    */
   public function query($query, $i18nRewrite = TRUE) {
     // rewrite queries that should use $dbLocale-based views for multi-language installs
-    global $dbLocale;
+    global $dbLocale, $_DB_DATAOBJECT;
+
+    $conn = &$_DB_DATAOBJECT['CONNECTIONS'][$this->_database_dsn_md5];
+    $orig_options = $conn->options;
+    $this->_setDBOptions($this->_options);
+
     if ($i18nRewrite and $dbLocale) {
       $query = CRM_Core_I18n_Schema::rewriteQuery($query);
     }
 
-    return parent::query($query);
+    $ret = parent::query($query);
+
+    $this->_setDBOptions($orig_options);
+    return $ret;
   }
 
   /**
@@ -2401,6 +2415,37 @@ SELECT contact_id
   }
 
   /**
+   * https://issues.civicrm.org/jira/browse/CRM-17748
+   * Sets the internal options to be used on a query
+   *
+   * @param array $options
+   *
+   */
+  function setOptions($options) {
+    if (is_array($options)) {
+      $this->_options = $options;
+    }
+  }
+
+  /**
+   * https://issues.civicrm.org/jira/browse/CRM-17748
+   * wrapper to pass internal DAO options down to DB_mysql/DB_Common level
+   *
+   * @param array $options
+   *
+   */
+  protected function _setDBOptions($options) {
+    global $_DB_DATAOBJECT;
+
+    if (is_array($options) && count($options)) {
+      $conn = &$_DB_DATAOBJECT['CONNECTIONS'][$this->_database_dsn_md5];
+      foreach ($options as $option_name => $option_value) {
+        $conn->setOption($option_name, $option_value);
+      }
+    }
+  }
+
+   /**
    * @param array $params
    */
   public function setApiFilter(&$params) {

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2421,7 +2421,7 @@ SELECT contact_id
    * @param array $options
    *
    */
-  function setOptions($options) {
+  public function setOptions($options) {
     if (is_array($options)) {
       $this->_options = $options;
     }
@@ -2445,7 +2445,7 @@ SELECT contact_id
     }
   }
 
-   /**
+  /**
    * @param array $params
    */
   public function setApiFilter(&$params) {


### PR DESCRIPTION
Allows for using unbuffered queries (mysql_unbuffered_query()) in CRM_Core_DAO.  Also allows for the minimization of fields while executing the initialization query for contact advanced search.

---
- [CRM-17748: Expose options['result_buffering'] to CRM_Core_DAO](https://issues.civicrm.org/jira/browse/CRM-17748)
