### PR TITLE
CRM-17806 Class-api: Check if constant is defined before defining it

### DIFF
--- a/api/class.api.php
+++ b/api/class.api.php
@@ -112,7 +112,9 @@ class civicrm_api3 {
       return;
     }
     if (isset($config) && isset($config['conf_path'])) {
-      define('CIVICRM_SETTINGS_PATH', $config['conf_path'] . '/civicrm.settings.php');
+      if (!defined('CIVICRM_SETTINGS_PATH')) {
+        define('CIVICRM_SETTINGS_PATH', $config['conf_path'] . '/civicrm.settings.php');
+      }
       require_once CIVICRM_SETTINGS_PATH;
       require_once 'CRM/Core/ClassLoader.php';
       require_once 'api/api.php';


### PR DESCRIPTION
- [CRM-17806: CIviCRM class API should check if constant is defined before defining it](https://issues.civicrm.org/jira/browse/CRM-17806)
