### PR TITLE
CRM-17802 Make start time midnight not midday woops

### DIFF
--- a/CRM/Contact/Form/Search/Custom/ContributionAggregate.php
+++ b/CRM/Contact/Form/Search/Custom/ContributionAggregate.php
@@ -202,7 +202,7 @@ civicrm_contact AS contact_a {$this->_aclFrom}
     $clauses[] = "contrib.contact_id = contact_a.id";
     $clauses[] = "contrib.is_test = 0";
 
-    $startTime = !empty($this->_formValues['start_date_time']) ? $this->_formValues['start_date_time'] : '12:00:00';
+    $startTime = !empty($this->_formValues['start_date_time']) ? $this->_formValues['start_date_time'] : '00:00:00';
     $endTime = !empty($this->_formValues['end_date_time']) ? $this->_formValues['end_date_time'] : '23:59:59';
 
     $startDate = CRM_Utils_Date::processDate($this->_formValues['start_date'], $startTime);


### PR DESCRIPTION
@eileenmcnaughton i accidentally made the start time midday not midnight this fixes it

---
- [CRM-17802: Contribution Aggregate custom search end date field default time issues](https://issues.civicrm.org/jira/browse/CRM-17802)
