### PR TITLE
[ready-for-core-team-review] Add settings to configure recently viewed items stack (Recent.php)

### DIFF
--- a/CRM/Admin/Form/Setting/Miscellaneous.php
+++ b/CRM/Admin/Form/Setting/Miscellaneous.php
@@ -50,6 +50,8 @@ class CRM_Admin_Form_Setting_Miscellaneous extends CRM_Admin_Form_Setting {
     'recaptchaPublicKey' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
     'recaptchaPrivateKey' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
     'wkhtmltopdfPath' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
+    'recentItemsMaxCount' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
+    'recentItemsProviders' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
   );
 
   public $_uploadMaxSize;

--- a/CRM/Admin/Form/Setting/Miscellaneous.php
+++ b/CRM/Admin/Form/Setting/Miscellaneous.php
@@ -103,10 +103,10 @@ class CRM_Admin_Form_Setting_Miscellaneous extends CRM_Admin_Form_Setting {
     }
 
     // validate recent items stack size
-    if ($fields['recentItemsMaxCount'] && ($fields['recentItemsMaxCount'] < 1 || $fields['recentItemsMaxCount'] > CRM_Utils_Recent::MAX_ITEMS)) { 
-      $errors['recentItemsMaxCount'] = ts("Illegal stack size. Use values between 1 and %1.", array( 1 => CRM_Utils_Recent::MAX_ITEMS));
+    if ($fields['recentItemsMaxCount'] && ($fields['recentItemsMaxCount'] < 1 || $fields['recentItemsMaxCount'] > CRM_Utils_Recent::MAX_ITEMS)) {
+      $errors['recentItemsMaxCount'] = ts("Illegal stack size. Use values between 1 and %1.", array(1 => CRM_Utils_Recent::MAX_ITEMS));
     }
-    
+
     if (!empty($fields['wkhtmltopdfPath'])) {
       // check and ensure that thi leads to the wkhtmltopdf binary
       // and it is a valid executable binary

--- a/CRM/Admin/Form/Setting/Miscellaneous.php
+++ b/CRM/Admin/Form/Setting/Miscellaneous.php
@@ -102,6 +102,11 @@ class CRM_Admin_Form_Setting_Miscellaneous extends CRM_Admin_Form_Setting {
       $errors['maxFileSize'] = ts("Maximum file size cannot exceed Upload max size ('upload_max_filesize') as defined in PHP.ini.");
     }
 
+    // validate recent items stack size
+    if ($fields['recentItemsMaxCount'] && ($fields['recentItemsMaxCount'] < 1 || $fields['recentItemsMaxCount'] > CRM_Utils_Recent::MAX_ITEMS)) { 
+      $errors['recentItemsMaxCount'] = ts("Illegal stack size. Use values between 1 and %1.", array( 1 => CRM_Utils_Recent::MAX_ITEMS));
+    }
+    
     if (!empty($fields['wkhtmltopdfPath'])) {
       // check and ensure that thi leads to the wkhtmltopdf binary
       // and it is a valid executable binary

--- a/CRM/Utils/Recent.php
+++ b/CRM/Utils/Recent.php
@@ -141,7 +141,7 @@ class CRM_Utils_Recent {
         'delete_url' => CRM_Utils_Array::value('deleteUrl', $others),
       )
     );
-    error_log("FOOOO: " . self::$_maxItems);
+    
     if (count(self::$_recent) > self::$_maxItems) {
       array_pop(self::$_recent);
     }

--- a/CRM/Utils/Recent.php
+++ b/CRM/Utils/Recent.php
@@ -59,7 +59,7 @@ class CRM_Utils_Recent {
    * Initialize this class and set the static variables.
    */
   public static function initialize() {
-    $maxItemsSetting = CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME, 'recentItemsMaxCount');
+    $maxItemsSetting = Civi::settings()->get('recentItemsMaxCount');
     if (isset($maxItemsSetting) && $maxItemsSetting > 0 && $maxItemsSetting < 100) {
       self::$_maxItems = $maxItemsSetting;
     }
@@ -220,7 +220,7 @@ class CRM_Utils_Recent {
     $allowed = TRUE;
 
     // Use core setting recentItemsProviders if configured
-    $providersPermitted = CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME, 'recentItemsProviders');
+    $providersPermitted = Civi::settings()->get('recentItemsProviders');
     if ($providersPermitted) {
       $allowed = in_array($providerName, $providersPermitted);
     }

--- a/CRM/Utils/Recent.php
+++ b/CRM/Utils/Recent.php
@@ -54,15 +54,15 @@ class CRM_Utils_Recent {
    * @var int
    */
   static private $_maxItems = 20;
-  
+
   /**
    * Initialize this class and set the static variables.
    */
   public static function initialize() {
     $maxItemsSetting = CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME, 'recentItemsMaxCount');
-    if (isset($maxItemsSetting) && $maxItemsSetting > 0 && $maxItemsSetting < 100)
-        self::$_maxItems = $maxItemsSetting;
-    
+    if (isset($maxItemsSetting) && $maxItemsSetting > 0 && $maxItemsSetting < 100) {
+      self::$_maxItems = $maxItemsSetting;
+    }
     if (!self::$_recent) {
       $session = CRM_Core_Session::singleton();
       self::$_recent = $session->get(self::STORE_NAME);
@@ -107,10 +107,11 @@ class CRM_Utils_Recent {
     $others = array()
   ) {
     self::initialize();
-    
-    if (!self::isProviderEnabled($type))
-        return;
-    
+
+    if (!self::isProviderEnabled($type)) {
+      return;
+    }
+
     $session = CRM_Core_Session::singleton();
 
     // make sure item is not already present in list
@@ -141,7 +142,7 @@ class CRM_Utils_Recent {
         'delete_url' => CRM_Utils_Array::value('deleteUrl', $others),
       )
     );
-    
+
     if (count(self::$_recent) > self::$_maxItems) {
       array_pop(self::$_recent);
     }
@@ -206,67 +207,48 @@ class CRM_Utils_Recent {
   /**
    * Check if a provider is allowed to add stuff.
    * If correspondig setting is empty, all are allowed
-   * 
+   *
    * @param string $providerName
    */
   public static function isProviderEnabled($providerName) {
-      
-      // Join contact types to providerName 'Contact'
-      $contactTypes = CRM_Contact_BAO_ContactType::contactTypes(TRUE);
-      if (in_array($providerName, $contactTypes))
-         $providerName = 'Contact';
-      
-      $allowed = true;
-      
-      // Use core setting recentItemsProviders if configured
-      $providersPermitted = CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME, 'recentItemsProviders');
-      if ($providersPermitted)
-          $allowed = in_array($providerName, $providersPermitted);
-      
-      // Else allow
-      return $allowed;
+
+    // Join contact types to providerName 'Contact'
+    $contactTypes = CRM_Contact_BAO_ContactType::contactTypes(TRUE);
+    if (in_array($providerName, $contactTypes)) {
+      $providerName = 'Contact';
+    }
+    $allowed = TRUE;
+
+    // Use core setting recentItemsProviders if configured
+    $providersPermitted = CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME, 'recentItemsProviders');
+    if ($providersPermitted) {
+      $allowed = in_array($providerName, $providersPermitted);
+    }
+    // Else allow
+    return $allowed;
   }
 
   /**
    * Gets the list of available providers to civi's recent items stack
    */
   public static function getProviders() {
-      $providers = array(
-          'Contact' => ts('Contacts'),
-          'Relationship' => ts('Relationships'),
-          'Activity' => ts('Activities'),
-          'Note' => ts('Notes'),
-          'Group' => ts('Groups'),
-          'Case' => ts('Cases'),
-          'Contribution' => ts('Contributions'),
-          'Participant' => ts('Participants'),
-          'Grant' => ts('Grants'),
-          'Membership' => ts('Memberships'),
-          'Pledge' => ts('Pledges'),
-          'Event' => ts('Events'),
-          'Campaign' => ts('Campaigns'),
-      );
-      
-      /** We may strip off disabled components **/
-//            $enabledComponents = CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME, 'enable_components', NULL, array());
-//      if (!$enabledComponents) 
-//          return $providers;
-//      
-//      foreach ($enabledComponents as $component) {
-//          switch ($component) {
-//              case 'CiviEvent': => ts('CiviEvent'),
-//              'Participants' => ts('Participants'),
-//              'CiviContribute' => ts('CiviContribute'),
-//              'CiviMember' => ts('CiviMember'),
-//              'CiviMail' => ts('CiviMail'),
-//              'CiviReport' => ts('CiviReport'),
-//              'CiviPledge' => ts('CiviPledge'),
-//              'CiviCase' => ts('CiviCase'),
-//              'CiviCampaign' => ts('CiviCampaign'),
-//              'CiviGrant' => ts('CiviGrant')
-//          }
-//      }
+    $providers = array(
+      'Contact' => ts('Contacts'),
+      'Relationship' => ts('Relationships'),
+      'Activity' => ts('Activities'),
+      'Note' => ts('Notes'),
+      'Group' => ts('Groups'),
+      'Case' => ts('Cases'),
+      'Contribution' => ts('Contributions'),
+      'Participant' => ts('Participants'),
+      'Grant' => ts('Grants'),
+      'Membership' => ts('Memberships'),
+      'Pledge' => ts('Pledges'),
+      'Event' => ts('Events'),
+      'Campaign' => ts('Campaigns'),
+    );
 
-      return $providers;
+    return $providers;
   }
+
 }

--- a/CRM/Utils/Recent.php
+++ b/CRM/Utils/Recent.php
@@ -54,6 +54,7 @@ class CRM_Utils_Recent {
    * @var int
    */
   static private $_maxItems = 20;
+
   /**
    * Initialize this class and set the static variables.
    */
@@ -249,4 +250,5 @@ class CRM_Utils_Recent {
 
     return $providers;
   }
+
 }

--- a/CRM/Utils/Recent.php
+++ b/CRM/Utils/Recent.php
@@ -36,11 +36,11 @@
 class CRM_Utils_Recent {
 
   /**
-   * Max number of items in queue.
+   * Store name
    *
-   * @var int
+   * @var string
    */
-  const MAX_ITEMS = 10, STORE_NAME = 'CRM_Utils_Recent';
+  const STORE_NAME = 'CRM_Utils_Recent';
 
   /**
    * The list of recently viewed items.
@@ -50,9 +50,19 @@ class CRM_Utils_Recent {
   static private $_recent = NULL;
 
   /**
+   * Maximum stack size
+   * @var int
+   */
+  static private $_maxItems = 20;
+  
+  /**
    * Initialize this class and set the static variables.
    */
   public static function initialize() {
+    $maxItemsSetting = CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME, 'recentItemsMaxCount');
+    if (isset($maxItemsSetting) && $maxItemsSetting > 0 && $maxItemsSetting < 100)
+        self::$_maxItems = $maxItemsSetting;
+    
     if (!self::$_recent) {
       $session = CRM_Core_Session::singleton();
       self::$_recent = $session->get(self::STORE_NAME);
@@ -97,6 +107,10 @@ class CRM_Utils_Recent {
     $others = array()
   ) {
     self::initialize();
+    
+    if (!self::isProviderEnabled($type))
+        return;
+    
     $session = CRM_Core_Session::singleton();
 
     // make sure item is not already present in list
@@ -127,7 +141,8 @@ class CRM_Utils_Recent {
         'delete_url' => CRM_Utils_Array::value('deleteUrl', $others),
       )
     );
-    if (count(self::$_recent) > self::MAX_ITEMS) {
+    error_log("FOOOO: " . self::$_maxItems);
+    if (count(self::$_recent) > self::$_maxItems) {
       array_pop(self::$_recent);
     }
 
@@ -188,4 +203,70 @@ class CRM_Utils_Recent {
     $session->set(self::STORE_NAME, self::$_recent);
   }
 
+  /**
+   * Check if a provider is allowed to add stuff.
+   * If correspondig setting is empty, all are allowed
+   * 
+   * @param string $providerName
+   */
+  public static function isProviderEnabled($providerName) {
+      
+      // Join contact types to providerName 'Contact'
+      $contactTypes = CRM_Contact_BAO_ContactType::contactTypes(TRUE);
+      if (in_array($providerName, $contactTypes))
+         $providerName = 'Contact';
+      
+      $allowed = true;
+      
+      // Use core setting recentItemsProviders if configured
+      $providersPermitted = CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME, 'recentItemsProviders');
+      if ($providersPermitted)
+          $allowed = in_array($providerName, $providersPermitted);
+      
+      // Else allow
+      return $allowed;
+  }
+
+  /**
+   * Gets the list of available providers to civi's recent items stack
+   */
+  public static function getProviders() {
+      $providers = array(
+          'Contact' => ts('Contacts'),
+          'Relationship' => ts('Relationships'),
+          'Activity' => ts('Activities'),
+          'Note' => ts('Notes'),
+          'Group' => ts('Groups'),
+          'Case' => ts('Cases'),
+          'Contribution' => ts('Contributions'),
+          'Participant' => ts('Participants'),
+          'Grant' => ts('Grants'),
+          'Membership' => ts('Memberships'),
+          'Pledge' => ts('Pledges'),
+          'Event' => ts('Events'),
+          'Campaign' => ts('Campaigns'),
+      );
+      
+      /** We may strip off disabled components **/
+//            $enabledComponents = CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME, 'enable_components', NULL, array());
+//      if (!$enabledComponents) 
+//          return $providers;
+//      
+//      foreach ($enabledComponents as $component) {
+//          switch ($component) {
+//              case 'CiviEvent': => ts('CiviEvent'),
+//              'Participants' => ts('Participants'),
+//              'CiviContribute' => ts('CiviContribute'),
+//              'CiviMember' => ts('CiviMember'),
+//              'CiviMail' => ts('CiviMail'),
+//              'CiviReport' => ts('CiviReport'),
+//              'CiviPledge' => ts('CiviPledge'),
+//              'CiviCase' => ts('CiviCase'),
+//              'CiviCampaign' => ts('CiviCampaign'),
+//              'CiviGrant' => ts('CiviGrant')
+//          }
+//      }
+
+      return $providers;
+  }
 }

--- a/CRM/Utils/Recent.php
+++ b/CRM/Utils/Recent.php
@@ -54,7 +54,6 @@ class CRM_Utils_Recent {
    * @var int
    */
   static private $_maxItems = 20;
-
   /**
    * Initialize this class and set the static variables.
    */
@@ -250,5 +249,4 @@ class CRM_Utils_Recent {
 
     return $providers;
   }
-
 }

--- a/CRM/Utils/Recent.php
+++ b/CRM/Utils/Recent.php
@@ -40,7 +40,7 @@ class CRM_Utils_Recent {
    *
    * @var string
    */
-  const STORE_NAME = 'CRM_Utils_Recent';
+  const MAX_ITEMS = 30, STORE_NAME = 'CRM_Utils_Recent';
 
   /**
    * The list of recently viewed items.
@@ -53,14 +53,14 @@ class CRM_Utils_Recent {
    * Maximum stack size
    * @var int
    */
-  static private $_maxItems = 20;
+  static private $_maxItems = 10;
 
   /**
    * Initialize this class and set the static variables.
    */
   public static function initialize() {
     $maxItemsSetting = Civi::settings()->get('recentItemsMaxCount');
-    if (isset($maxItemsSetting) && $maxItemsSetting > 0 && $maxItemsSetting < 100) {
+    if (isset($maxItemsSetting) && $maxItemsSetting > 0 && $maxItemsSetting < self::MAX_ITEMS) {
       self::$_maxItems = $maxItemsSetting;
     }
     if (!self::$_recent) {

--- a/settings/Core.setting.php
+++ b/settings/Core.setting.php
@@ -823,4 +823,45 @@ return array(
     'description' => NULL,
     'help_text' => NULL,
   ),
+  'recentItemsMaxCount' => array(
+    'group_name' => 'CiviCRM Preferences',
+    'group' => 'core',
+    'name' => 'recentItemsMaxCount',
+    'type' => 'Integer',
+    'quick_form_type' => 'Element',
+    'html_type' => 'text',
+    'html_attributes' => array(
+      'size' => 2,
+      'maxlength' => 3
+    ),
+    'default' => 20,
+    'add' => '4.7',
+    'title' => 'Size of "Recent Items" stack',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => 'How many items should CiviCRM store in it\'s "Recently viewed" list.',
+    'help_text' => NULL,
+  ),
+  'recentItemsProviders' => array(
+    'group_name' => 'CiviCRM Preferences',
+    'group' => 'core',
+    'name' => 'recentItemsProviders',
+    'type' => 'Array',
+    'html_type' => 'Select',
+    'quick_form_type' => 'Select',
+    'html_attributes' => array(
+      'multiple' => 1,
+      'class' => 'crm-select2',
+    ),
+    'default' => '',
+    'add' => '4.7',
+    'title' => 'Recent Items Providers',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => 'What providers may save views in CiviCRM\'s "Recently viewed" list. If empty, all are in.',
+    'help_text' => NULL,
+    'pseudoconstant' => array(
+      'callback' => 'CRM_Utils_Recent::getProviders'
+    ),
+  ),
 );

--- a/settings/Core.setting.php
+++ b/settings/Core.setting.php
@@ -839,6 +839,7 @@ return array(
     'title' => 'Size of "Recent Items" stack',
     'is_domain' => 1,
     'is_contact' => 0,
+    'description' => 'How many items should CiviCRM store in it\'s "Recently viewed" list.',
     'help_text' => NULL,
   ),
   'recentItemsProviders' => array(

--- a/settings/Core.setting.php
+++ b/settings/Core.setting.php
@@ -839,7 +839,6 @@ return array(
     'title' => 'Size of "Recent Items" stack',
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => 'How many items should CiviCRM store in it\'s "Recently viewed" list.',
     'help_text' => NULL,
   ),
   'recentItemsProviders' => array(

--- a/settings/Core.setting.php
+++ b/settings/Core.setting.php
@@ -832,7 +832,7 @@ return array(
     'html_type' => 'text',
     'html_attributes' => array(
       'size' => 2,
-      'maxlength' => 3
+      'maxlength' => 3,
     ),
     'default' => 20,
     'add' => '4.7',
@@ -861,7 +861,7 @@ return array(
     'description' => 'What providers may save views in CiviCRM\'s "Recently viewed" list. If empty, all are in.',
     'help_text' => NULL,
     'pseudoconstant' => array(
-      'callback' => 'CRM_Utils_Recent::getProviders'
+      'callback' => 'CRM_Utils_Recent::getProviders',
     ),
   ),
 );

--- a/templates/CRM/Admin/Form/Setting/Miscellaneous.tpl
+++ b/templates/CRM/Admin/Form/Setting/Miscellaneous.tpl
@@ -82,8 +82,8 @@
             <td>{$form.max_attachments.html}<br />
                 <span class="description">{ts}Maximum number of files (documents, images, etc.) which can attached to emails or activities.{/ts}</span></td>
         </tr>
-  <tr class="crm-miscellaneous-form-block-maxFileSize">
-      <td class="label">{$form.maxFileSize.label}</td>
+        <tr class="crm-miscellaneous-form-block-maxFileSize">
+            <td class="label">{$form.maxFileSize.label}</td>
             <td>{$form.maxFileSize.html}<br />
                 <span class="description">{$maxFileSize_description}</span></td>
         </tr>
@@ -92,6 +92,16 @@
             <td>{$form.secondDegRelPermissions.html}<br />
                 <p class="description">{ts}If enabled, contacts with the permission to edit a related contact will inherit that contact's permission to edit other related contacts.{/ts}</p>
             </td>
+        </tr>
+        <tr class="crm-miscellaneous-form-block-recentItemsMaxCount">
+            <td class="label">{$form.recentItemsMaxCount.label}</td>
+            <td>{$form.recentItemsMaxCount.html}<br />
+                <span class="description">{$recentItemsMaxCount_description}</span></td>
+        </tr>
+        <tr class="crm-miscellaneous-form-block-recentItemsProviders">
+            <td class="label">{$form.recentItemsProviders.label}</td>
+            <td>{$form.recentItemsProviders.html}<br />
+                <span class="description">{$recentItemsProviders_description}</span></td>
         </tr>
 
     </table>


### PR DESCRIPTION
This changeset introduces two new settings:
1. `recentItemsMaxCount` – Size of "Recent Items" stack:
   The maximum size of the stack may be configured here. It accepts integers between 1 and 100 and defaults to 20. The formerly used constant in `CRM/Utils/Recent.php` has been removed. 
2. `recentItemsProviders` – Recent Items Providers:
   More or less all of Civi's components write to the stack. This may lead to useless views when displaying the list contents. For instance, generating pdf letters for multiple contacts may flood the list with entries which are hard to differentiate.
   This setting accepts strings representing the components and which are allowed to write to the stack, for example 'Contacts', 'Activities' or 'Grants'. If the setting is empty or unset, all components are permitted.

Both settings are located in the `Administer -> System Settings -> Miscellanous`.
