### PR TITLE
Improve subquery performance.

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -489,7 +489,7 @@ LEFT JOIN civicrm_option_group aog ON aog.name='activity_type'
 (
   SELECT ca4.case_id, act4.id AS id, act4.activity_date_time AS desired_date, act4.activity_type_id, act4.status_id, aov.name AS act_type_name, aov.label AS act_type
   FROM civicrm_activity act4
-  LEFT JOIN civicrm_case_activity ca4
+  INNER JOIN civicrm_case_activity ca4
     ON ca4.activity_id = act4.id
     AND act4.is_current_revision = 1
   LEFT JOIN civicrm_option_group aog


### PR DESCRIPTION
Have been investigating a problem with slow queries for one of our clients and have narrowed it down to this subquery in CRM/Case/BAO/Case.php, which queries all activities on the system then attempts to join the results of the main query onto them, resulting in some very slow queries.

Looking at the condition for the join which follows that, it seems it's only looking for results that are linked to a Case, so can we restrict the subquery by means of an INNER join?

Seems to me this won't have any effect on the end result of the query, but do double-check my logic in case I'm missing something.
