### PR TITLE
CRM-17830 - Setting Form - Remove redundant default check

### DIFF
--- a/CRM/Admin/Form/Setting.php
+++ b/CRM/Admin/Form/Setting.php
@@ -56,12 +56,10 @@ class CRM_Admin_Form_Setting extends CRM_Core_Form {
 
       // we can handle all the ones defined in the metadata here. Others to be converted
       foreach ($this->_settings as $setting => $group) {
-        $settingMetaData = civicrm_api('setting', 'getfields', array('version' => 3, 'name' => $setting));
         $this->_defaults[$setting] = civicrm_api('setting', 'getvalue', array(
             'version' => 3,
             'name' => $setting,
             'group' => $group,
-            'default_value' => CRM_Utils_Array::value('default', $settingMetaData['values'][$setting]),
           )
         );
       }


### PR DESCRIPTION
Default values should already be merged within SettingsBag (which sits
under-the-hood, beneath Setting::getItem and Setting API). Don't see why
we need to explicitly check default in this form.

---
- [CRM-17830: Move localization defaults to Localization.setting.php](https://issues.civicrm.org/jira/browse/CRM-17830)
