### PR TITLE
tools/scripts/phpunit - Delegate to `phpunit` from `PATH`

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,8 +11,17 @@
          bootstrap="tests/phpunit/CiviTest/bootstrap.php"
 >
   <testsuites>
-    <testsuite name="CiviCRM Test Suite">
-      <directory>./tests/phpunit/</directory>
+    <testsuite name="api_v3_AllTests">
+      <directory>./tests/phpunit/api</directory>
+    </testsuite>
+    <testsuite name="CRM_AllTests">
+      <directory>./tests/phpunit/CRM</directory>
+    </testsuite>
+    <testsuite name="Civi_AllTests">
+      <directory>./tests/phpunit/Civi</directory>
+    </testsuite>
+    <testsuite name="WebTest_AllTests">
+      <directory>./tests/phpunit/WebTest</directory>
     </testsuite>
   </testsuites>
 

--- a/tools/scripts/phpunit
+++ b/tools/scripts/phpunit
@@ -1,80 +1,74 @@
 #!/usr/bin/env php
 <?php
-/* PHPUnit
+
+/**
+ * In the past, Civi bundled a hacked copy of PHPUnit used like:
  *
- * Copyright (c) 2002-2008, Sebastian Bergmann <sb@sebastian-bergmann.de>.
- * All rights reserved.
+ *   cd tools
+ *   ./scripts/phpunit Some_Class_NameTest
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *
- *   * Redistributions of source code must retain the above copyright
- *     notice, this list of conditions and the following disclaimer.
- *
- *   * Redistributions in binary form must reproduce the above copyright
- *     notice, this list of conditions and the following disclaimer in
- *     the documentation and/or other materials provided with the
- *     distribution.
- *
- *   * Neither the name of Sebastian Bergmann nor the names of his
- *     contributors may be used to endorse or promote products derived
- *     from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRIC
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
- * $Id: phpunit 522 2012-04-23 13:53:45Z deepak $
+ * This script is an adapter for backwards compatibility.
  */
 
-$GLOBALS['base_dir'] = dirname( dirname( dirname( __FILE__ ) ) );
-$tests_dir = $GLOBALS['base_dir']  . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'phpunit';
-$civi_pkgs_dir = $GLOBALS['base_dir'] .   DIRECTORY_SEPARATOR . 'packages';
-ini_set('safe_mode', 0);
-ini_set('include_path',
-        "{$GLOBALS['base_dir']}" . PATH_SEPARATOR .
-        "$tests_dir"            . PATH_SEPARATOR .
-        "$civi_pkgs_dir"        . PATH_SEPARATOR
-        . ini_get( 'include_path') );
-
-if (!is_dir("$civi_pkgs_dir/PHPUnit")) {
-  fwrite(STDERR, "PHPUnit is not embedded with this copy of CiviCRM (in $civi_pkgs_dir). Perhaps you should use the standalone phpunit command?\n\nExample: \"phpunit tests/phpunit/CRM/Core/RegionTest.php\"\n");
-  exit(1);
+if (PHP_SAPI !== 'cli') {
+  die("phpunit can only be run from command line.");
 }
 
-#  Relying on system timezone setting produces a warning,
-#  doing the following prevents the warning message
-if ( file_exists( '/etc/timezone' ) ) {
-    $timezone = trim( file_get_contents( '/etc/timezone' ) );
-    if ( ini_set('date.timezone', $timezone ) === false ) {
-        echo "ini_set( 'date.timezone', '$timezone' ) failed\n";
+$phpunit = findCommand('phpunit');
+if (!$phpunit) {
+  echo "Plesae ensure that:\n";
+  echo " * PHPUnit is installed.\n";
+  echo " * The extensions for dbunit and selenium are installed.\n" ;
+  echo " * The command \"phpunit\" is in the PATH.\n";
+  echo "See also: https://github.com/civicrm/civicrm-buildkit/\n";
+  exit(127);
+}
+
+chdir(dirname(dirname(__DIR__))); // civicrm-core root dir
+
+array_shift($argv);
+
+// Convert class names to file names
+foreach ($argv as $k => $v) {
+  if (preg_match('/^(CRM_|api_v3|_Civi_|WebTest_)/', $v)) {
+    $argv[$k] = 'tests/phpunit/' . strtr($v, '_', '/') . '.php';
+  }
+}
+
+// Transition: Make sure we use phpunit code from PATH, not
+// civicrm-packages.  This will be unnecessary once civicrm-packages is
+// updated.
+if (is_dir('packages/PHPUnit/')) {
+  if (!rename('packages/PHPUnit', 'packages/PHPUnit.bak')) {
+    echo "Failed to move aside stale copy of PHPUnit.\n";
+    exit(1);
+  }
+}
+
+$cmd =
+  findPhp() // In case this system has multiple copies of PHP, use the active/preferred one.
+  . ' '
+  . escapeshellarg($phpunit)
+  . ' '
+  . implode(' ', array_map('escapeshellarg', $argv));
+passthru($cmd);
+
+function findPhp() {
+  if (defined('PHP_BINARY')) {
+    return PHP_BINARY; // php 5.4+
+  } elseif (defined('PHP_BINDIR') && file_exists(PHP_BINDIR . '/php')) {
+    return PHP_BINDIR . '/php'; // php 5.3
+  } else {
+    die("Failed to determine active PHP version.");
+  }
+}
+
+function findCommand($name) {
+  $paths = explode(PATH_SEPARATOR, getenv('PATH'));
+  foreach ($paths as $path) {
+    if (file_exists("$path/$name")) {
+      return "$path/$name";
     }
+  }
+  return NULL;
 }
-
-# Crank up the memory
-ini_set('memory_limit', '2G');
-
-error_reporting( E_ALL );
-
-require 'PHPUnit/TextUI/Command.php';
-
-define('PHPUnit_MAIN_METHOD', 'PHPUnit_TextUI_Command::main');
-
-require dirname(__FILE__) . DIRECTORY_SEPARATOR .
-	'..' . DIRECTORY_SEPARATOR .
-	'..' . DIRECTORY_SEPARATOR .
-	'packages' . DIRECTORY_SEPARATOR .
-	'PHPUnit' . DIRECTORY_SEPARATOR .
-	'Autoload.php';
-
-PHPUnit_TextUI_Command::main( );


### PR DESCRIPTION
Embedding a copy of PHPUnit within CiviCRM makes it really confusing when
testing extensions. For example, if an extension author tries to use
`phpunit` directly, he'll conflicts between his copy and the embedded copy.

The work-around has been to _always_ use the embedded copy, but this is
still confusing because bootstrapping becomes complicated.

The goal here is to remove Civi's embedded copy of PHPUnit to avoid
conflicts.

To preserve compatibility with existing test-documentation and test-scripts
(Jenkins), we leave behind a stub script in `tools/scripts/phpunit`.
