### PR TITLE
Work around infinite memory consumption bug. CRM-17853

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -440,7 +440,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
     // Case C: Default error handler
 
     // log to file
-    CRM_Core_Error::debug_var('Fatal Error Details', $vars);
+    CRM_Core_Error::debug_var('Fatal Error Details', $vars, FALSE);
     CRM_Core_Error::backtrace('backTrace', TRUE);
 
     // print to screen


### PR DESCRIPTION
When handling an Unhandled exception, the default error handler path uses debug_var to handle outputting debug information. When calling debug_var, no print argument is passed. Without a print argument, debug_var uses print_r to dump a passed in variable's contents. This consumes all memory, and leads to a crash (500). passing a different option to debug_var works around the issue.

---
- [CRM-17853: Infinite memory and clash in error handler.](https://issues.civicrm.org/jira/browse/CRM-17853)
