### PR TITLE
CRM-17812 - enable anonymous access to angular extension pages

### DIFF
--- a/CRM/Core/xml/Menu/Misc.xml
+++ b/CRM/Core/xml/Menu/Misc.xml
@@ -183,7 +183,7 @@
   <item>
     <path>civicrm/ajax/angular-modules</path>
     <page_callback>\Civi\Angular\Page\Modules</page_callback>
-    <access_arguments>access CiviCRM</access_arguments>
+    <access_arguments>*always allow*</access_arguments>
   </item>
   <item>
      <path>civicrm/ajax/recurringentity/update-mode</path>


### PR DESCRIPTION
- [CRM-17812: Access to angular modules differs depending on whether debug is enabled or not](https://issues.civicrm.org/jira/browse/CRM-17812)
