### PR TITLE
CRM-17860 - CRM_Utils_System_WordPress - Path lookup

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -76,29 +76,48 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
    * Moved from CRM_Utils_System_Base
    */
   public function getDefaultFileStorage() {
-    global $civicrm_root;
-    $config  = CRM_Core_Config::singleton();
-    $baseURL = CRM_Utils_System::languageNegotiationURL($config->userFrameworkBaseURL, FALSE, TRUE);
-
-    $filesURL        = NULL;
-    $filesPath       = NULL;
-    $upload_dir      = wp_upload_dir();
-    $settingsDir     = $upload_dir['basedir'] . DIRECTORY_SEPARATOR . 'civicrm' . DIRECTORY_SEPARATOR;
-    $settingsURL     = $upload_dir['baseurl'] . DIRECTORY_SEPARATOR . 'civicrm' . DIRECTORY_SEPARATOR;
-    if (is_dir(WP_PLUGIN_DIR . '/files/civicrm/')) {
-      //for legacy path
-      $filesURL = WP_PLUGIN_URL . "/files/civicrm/";
-    }
-    elseif (is_dir($settingsDir)) {
-      $filesURL = $settingsURL;
-    }
-    else {
-      throw new CRM_Core_Exception("Failed to locate default file storage ($config->userFramework)");
-    }
-
+    $config = CRM_Core_Config::singleton();
+    $cmsUrl = CRM_Utils_System::languageNegotiationURL($config->userFrameworkBaseURL, FALSE, TRUE);
+    $cmsPath = $this->cmsRootPath();
+    $filesPath = CRM_Utils_File::baseFilePath();
+    $filesRelPath = CRM_Utils_File::relativize($filesPath, $cmsPath);
+    $filesURL = rtrim($cmsUrl, '/') . '/' . ltrim($filesRelPath, ' /');
     return array(
-      'url'  => $filesURL,
-      'path' => CRM_Utils_File::baseFilePath(),
+      'url' => CRM_Utils_File::addTrailingSlash($filesURL, '/'),
+      'path' => CRM_Utils_File::addTrailingSlash($filesPath),
+    );
+  }
+
+  /**
+   * Determine the location of the CiviCRM source tree.
+   *
+   * @return array
+   *   - url: string. ex: "http://example.com/sites/all/modules/civicrm"
+   *   - path: string. ex: "/var/www/sites/all/modules/civicrm"
+   */
+  public function getCiviSourceStorage() {
+    global $civicrm_root;
+
+    // Don't use $config->userFrameworkBaseURL; it has garbage on it.
+    // More generally, we shouldn't be using $config here.
+    if (!defined('CIVICRM_UF_BASEURL')) {
+      throw new RuntimeException('Undefined constant: CIVICRM_UF_BASEURL');
+    }
+
+    $cmsPath = $this->cmsRootPath();
+
+    // $config  = CRM_Core_Config::singleton();
+    // overkill? // $cmsUrl = CRM_Utils_System::languageNegotiationURL($config->userFrameworkBaseURL, FALSE, TRUE);
+    $cmsUrl = CIVICRM_UF_BASEURL;
+    if (CRM_Utils_System::isSSL()) {
+      $cmsUrl = str_replace('http://', 'https://', $cmsUrl);
+    }
+
+    $civiRelPath = CRM_Utils_File::relativize($civicrm_root, $cmsPath);
+    $civiUrl = rtrim($cmsUrl, '/') . '/' . ltrim($civiRelPath, ' /');
+    return array(
+      'url' => CRM_Utils_File::addTrailingSlash($civiUrl, '/'),
+      'path' => CRM_Utils_File::addTrailingSlash($civicrm_root),
     );
   }
 


### PR DESCRIPTION
The implementations of `getDefaultFileStorage()` and
`getCiviSourceStorage()` depended on having the CMS bootstrapped, causing
failures in scripts that boot Civi first.

This patch computes those values by doing some arithmetic, e.g.
- Civi source URL == CMS Base URL + relative path to source tree
- Civi file URL == CMS Base URL + relative path to files dir

---
- CRM-17860: More consistent, flexible handling of tests for extensions
  https://issues.civicrm.org/jira/browse/CRM-17860
