### PR TITLE
CRM-17350 - Allowing editing of tags by ACL

### DIFF
--- a/CRM/Activity/Form/Task/AddToTag.php
+++ b/CRM/Activity/Form/Task/AddToTag.php
@@ -135,7 +135,8 @@ class CRM_Activity_Form_Task_AddToTag extends CRM_Activity_Form_Task {
     foreach ($allTags as $key => $dnc) {
       $this->_name[] = $this->_tags[$key];
 
-      list($total, $added, $notAdded) = CRM_Core_BAO_EntityTag::addEntitiesToTag($this->_activityHolderIds, $key, 'civicrm_activity');
+      list($total, $added, $notAdded) = CRM_Core_BAO_EntityTag::addEntitiesToTag($this->_activityHolderIds, $key,
+        'civicrm_activity', FALSE);
 
       $status = array(ts('Activity tagged', array('count' => $added, 'plural' => '%count activities tagged')));
       if ($notAdded) {

--- a/CRM/Activity/Form/Task/RemoveFromTag.php
+++ b/CRM/Activity/Form/Task/RemoveFromTag.php
@@ -124,7 +124,8 @@ class CRM_Activity_Form_Task_RemoveFromTag extends CRM_Activity_Form_Task {
     foreach ($allTags as $key => $dnc) {
       $this->_name[] = $this->_tags[$key];
 
-      list($total, $removed, $notRemoved) = CRM_Core_BAO_EntityTag::removeEntitiesFromTag($this->_activityHolderIds, $key, 'civicrm_activity');
+      list($total, $removed, $notRemoved) = CRM_Core_BAO_EntityTag::removeEntitiesFromTag($this->_activityHolderIds,
+        $key, 'civicrm_activity', FALSE);
 
       $status = array(
         ts('%count activity un-tagged', array(

--- a/CRM/Contact/Form/Task/AddToTag.php
+++ b/CRM/Contact/Form/Task/AddToTag.php
@@ -136,7 +136,8 @@ class CRM_Contact_Form_Task_AddToTag extends CRM_Contact_Form_Task {
     foreach ($allTags as $key => $dnc) {
       $this->_name[] = $this->_tags[$key];
 
-      list($total, $added, $notAdded) = CRM_Core_BAO_EntityTag::addEntitiesToTag($this->_contactIds, $key);
+      list($total, $added, $notAdded) = CRM_Core_BAO_EntityTag::addEntitiesToTag($this->_contactIds, $key,
+        'civicrm_contact', FALSE);
 
       $status = array(ts('%count contact tagged', array('count' => $added, 'plural' => '%count contacts tagged')));
       if ($notAdded) {

--- a/CRM/Contact/Form/Task/RemoveFromTag.php
+++ b/CRM/Contact/Form/Task/RemoveFromTag.php
@@ -124,7 +124,8 @@ class CRM_Contact_Form_Task_RemoveFromTag extends CRM_Contact_Form_Task {
     foreach ($allTags as $key => $dnc) {
       $this->_name[] = $this->_tags[$key];
 
-      list($total, $removed, $notRemoved) = CRM_Core_BAO_EntityTag::removeEntitiesFromTag($this->_contactIds, $key);
+      list($total, $removed, $notRemoved) = CRM_Core_BAO_EntityTag::removeEntitiesFromTag($this->_contactIds, $key,
+        'civicrm_contact', FALSE);
 
       $status = array(
         ts('%count contact un-tagged', array(

--- a/CRM/Contact/Import/ImportJob.php
+++ b/CRM/Contact/Import/ImportJob.php
@@ -424,7 +424,7 @@ class CRM_Contact_Import_ImportJob {
     if (is_array($this->_tag)) {
       $tagAdditions = array();
       foreach ($this->_tag as $tagId => $val) {
-        $addTagCount = CRM_Core_BAO_EntityTag::addEntitiesToTag($contactIds, $tagId);
+        $addTagCount = CRM_Core_BAO_EntityTag::addEntitiesToTag($contactIds, $tagId, 'civicrm_contact', FALSE);
         $totalTagCount = $addTagCount[1];
         if (isset($addedTag) && $tagId == $addedTag->id) {
           $tagName = $newTagName;

--- a/CRM/Core/BAO/EntityTag.php
+++ b/CRM/Core/BAO/EntityTag.php
@@ -121,7 +121,7 @@ class CRM_Core_BAO_EntityTag extends CRM_Core_DAO_EntityTag {
   }
 
   /**
-   * Given an array of entity ids and entity table, add all the entity to the tags
+   * Given an array of entity ids and entity table, add all the entity to the tags.
    *
    * @param array $entityIds
    *   (reference ) the array of entity ids to be added.
@@ -139,6 +139,12 @@ class CRM_Core_BAO_EntityTag extends CRM_Core_DAO_EntityTag {
     $entityIdsAdded = array();
 
     foreach ($entityIds as $entityId) {
+      // CRM-17350 - check if we have permission to edit the contact
+      // that this tag belongs to.
+      if (!CRM_Contact_BAO_Contact_Permission::allow($entityId, CRM_Core_Permission::EDIT)) {
+        $numEntitiesNotAdded++;
+        continue;
+      }
       $tag = new CRM_Core_DAO_EntityTag();
 
       $tag->entity_id = $entityId;
@@ -184,6 +190,12 @@ class CRM_Core_BAO_EntityTag extends CRM_Core_DAO_EntityTag {
     $entityIdsRemoved = array();
 
     foreach ($entityIds as $entityId) {
+      // CRM-17350 - check if we have permission to edit the contact
+      // that this tag belongs to.
+      if (!CRM_Contact_BAO_Contact_Permission::allow($entityId, CRM_Core_Permission::EDIT)) {
+        $numEntitiesNotAdded++;
+        continue;
+      }
       $tag = new CRM_Core_DAO_EntityTag();
 
       $tag->entity_id = $entityId;

--- a/CRM/Core/BAO/EntityTag.php
+++ b/CRM/Core/BAO/EntityTag.php
@@ -129,11 +129,13 @@ class CRM_Core_BAO_EntityTag extends CRM_Core_DAO_EntityTag {
    *   The id of the tag.
    * @param string $entityTable
    *   Name of entity table default:civicrm_contact.
+   * @param bool $applyPermissions
+   *   Should permissions be applied in this function.
    *
    * @return array
-   *   (total, added, notAdded) count of enities added to tag
+   *   (total, added, notAdded) count of entities added to tag
    */
-  public static function addEntitiesToTag(&$entityIds, $tagId, $entityTable = 'civicrm_contact') {
+  public static function addEntitiesToTag(&$entityIds, $tagId, $entityTable, $applyPermissions) {
     $numEntitiesAdded = 0;
     $numEntitiesNotAdded = 0;
     $entityIdsAdded = array();
@@ -141,7 +143,7 @@ class CRM_Core_BAO_EntityTag extends CRM_Core_DAO_EntityTag {
     foreach ($entityIds as $entityId) {
       // CRM-17350 - check if we have permission to edit the contact
       // that this tag belongs to.
-      if (!CRM_Contact_BAO_Contact_Permission::allow($entityId, CRM_Core_Permission::EDIT)) {
+      if ($applyPermissions && !self::checkPermissionOnEntityTag($entityId, $entityTable)) {
         $numEntitiesNotAdded++;
         continue;
       }
@@ -172,7 +174,30 @@ class CRM_Core_BAO_EntityTag extends CRM_Core_DAO_EntityTag {
   }
 
   /**
-   * Given an array of entity ids and entity table, remove entity(s) tags
+   * Basic check for ACL permission on editing/creating/removing a tag.
+   *
+   * In the absence of something better contacts get a proper check and other entities
+   * default to 'edit all contacts'. This is currently only accessed from the api which previously
+   * applied edit all contacts to all - so while still too restrictive it represents a loosening.
+   *
+   * Current possible entities are attachments, activities, cases & contacts.
+   *
+   * @param int $entityID
+   * @param string $entityTable
+   *
+   * @return bool
+   */
+  public static function checkPermissionOnEntityTag($entityID, $entityTable) {
+    if ($entityTable == 'civicrm_contact') {
+      return CRM_Contact_BAO_Contact_Permission::allow($entityID, CRM_Core_Permission::EDIT);
+    }
+    else {
+      return CRM_Core_Permission::check('edit all contacts');
+    }
+  }
+
+  /**
+   * Given an array of entity ids and entity table, remove entity(s)tags.
    *
    * @param array $entityIds
    *   (reference ) the array of entity ids to be removed.
@@ -180,11 +205,13 @@ class CRM_Core_BAO_EntityTag extends CRM_Core_DAO_EntityTag {
    *   The id of the tag.
    * @param string $entityTable
    *   Name of entity table default:civicrm_contact.
+   * @param bool $applyPermissions
+   *   Should permissions be applied in this function.
    *
    * @return array
    *   (total, removed, notRemoved) count of entities removed from tags
    */
-  public static function removeEntitiesFromTag(&$entityIds, $tagId, $entityTable = 'civicrm_contact') {
+  public static function removeEntitiesFromTag(&$entityIds, $tagId, $entityTable, $applyPermissions) {
     $numEntitiesRemoved = 0;
     $numEntitiesNotRemoved = 0;
     $entityIdsRemoved = array();
@@ -192,8 +219,8 @@ class CRM_Core_BAO_EntityTag extends CRM_Core_DAO_EntityTag {
     foreach ($entityIds as $entityId) {
       // CRM-17350 - check if we have permission to edit the contact
       // that this tag belongs to.
-      if (!CRM_Contact_BAO_Contact_Permission::allow($entityId, CRM_Core_Permission::EDIT)) {
-        $numEntitiesNotAdded++;
+      if ($applyPermissions && !self::checkPermissionOnEntityTag($entityId, $entityTable)) {
+        $numEntitiesNotRemoved++;
         continue;
       }
       $tag = new CRM_Core_DAO_EntityTag();

--- a/CRM/Core/DAO/permissions.php
+++ b/CRM/Core/DAO/permissions.php
@@ -124,6 +124,17 @@ function _civicrm_api3_permissions($entity, $action, &$params) {
   // @todo - ditto
   $permissions['note'] = $permissions['entity_tag'];
 
+  // CRM-17350 - entity_tag ACL permissions are checked at the BAO level
+  $permissions['entity_tag'] = array(
+    'get' => array(
+      'access CiviCRM',
+      'view all contacts',
+    ),
+    'default' => array(
+      'access CiviCRM',
+    ),
+  );
+
   // Allow non-admins to get and create tags to support tagset widget
   // Delete is still reserved for admins
   $permissions['tag'] = array(

--- a/api/v3/EntityTag.php
+++ b/api/v3/EntityTag.php
@@ -49,6 +49,7 @@ function civicrm_api3_entity_tag_get($params) {
   else {
     //do legacy non-standard behaviour
     $values = CRM_Core_BAO_EntityTag::getTag($params['entity_id'], $params['entity_table']);
+
     $result = array();
     foreach ($values as $v) {
       $result[$v] = array('tag_id' => $v);
@@ -128,6 +129,7 @@ function _civicrm_api3_entity_tag_common($params, $op = 'add') {
       }
     }
   }
+
   if (empty($entityIDs)) {
     return civicrm_api3_create_error('contact_id is a required field');
   }
@@ -145,7 +147,8 @@ function _civicrm_api3_entity_tag_common($params, $op = 'add') {
   if ($op == 'add') {
     $values['total_count'] = $values['added'] = $values['not_added'] = 0;
     foreach ($tagIDs as $tagID) {
-      list($te, $a, $na) = CRM_Core_BAO_EntityTag::addEntitiesToTag($entityIDs, $tagID, $entityTable);
+      list($te, $a, $na) = CRM_Core_BAO_EntityTag::addEntitiesToTag($entityIDs, $tagID, $entityTable,
+        CRM_Utils_Array::value('check_permissions', $params));
       $values['total_count'] += $te;
       $values['added'] += $a;
       $values['not_added'] += $na;
@@ -154,7 +157,7 @@ function _civicrm_api3_entity_tag_common($params, $op = 'add') {
   else {
     $values['total_count'] = $values['removed'] = $values['not_removed'] = 0;
     foreach ($tagIDs as $tagID) {
-      list($te, $r, $nr) = CRM_Core_BAO_EntityTag::removeEntitiesFromTag($entityIDs, $tagID, $entityTable);
+      list($te, $r, $nr) = CRM_Core_BAO_EntityTag::removeEntitiesFromTag($entityIDs, $tagID, $entityTable, CRM_Utils_Array::value('check_permissions', $params));
       $values['total_count'] += $te;
       $values['removed'] += $r;
       $values['not_removed'] += $nr;

--- a/tests/phpunit/api/v3/EntityTagACLTest.php
+++ b/tests/phpunit/api/v3/EntityTagACLTest.php
@@ -1,0 +1,234 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2015                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *  Test APIv3 civicrm_entity_tag_* functions
+ *
+ * @package CiviCRM_APIv3
+ * @subpackage API_Core
+ */
+
+require_once 'CiviTest/CiviUnitTestCase.php';
+
+/**
+ * Class api_v3_EntityTagTest.
+ *
+ * This test class was introduced to ensure that the fix for CRM-17350 (reducing the required permission
+ * from edit all contacts to has right to edit this contact) would not result in inappropriate permission opening on
+ * other entities. Other entities are still too restricted but that is a larger job.
+ */
+class api_v3_EntityTagACLTest extends CiviUnitTestCase {
+
+  /**
+   * API Version in use.
+   *
+   * @var int
+   */
+  protected $_apiversion = 3;
+
+  /**
+   * Entity being tested.
+   *
+   * @var string
+   */
+  protected $_entity = 'entity_tag';
+
+  /**
+   * Set up permissions for test.
+   */
+  public function setUp() {
+    $this->useTransaction(TRUE);
+    parent::setUp();
+    $individualID = $this->individualCreate();
+    $daoObj = new CRM_Core_DAO();
+    $this->callAPISuccess('Attachment', 'create', array(
+      'entity_table' => 'civicrm_contact',
+      'entity_id' => $individualID,
+      'mime_type' => 'k',
+      'name' => 'p',
+      'content' => 'l',
+    ));
+    $daoObj->createTestObject('CRM_Activity_BAO_Activity', array(), 1, 0);
+    $daoObj->createTestObject('CRM_Case_BAO_Case', array(), 1, 0);
+    $entities = $this->getTagOptions();
+    foreach ($entities as $key => $entity) {
+      $this->callAPISuccess('Tag', 'create', array(
+        'used_for' => $key,
+        'name' => $entity,
+        'description' => $entity,
+        )
+      );
+    }
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = array('access CiviCRM');
+  }
+
+  /**
+   * Get the options for the used_for fields.
+   *
+   * @return array
+   */
+  public function getTagOptions() {
+    $options = $this->callAPISuccess('Tag', 'getoptions', array('field' => 'used_for'));
+    return $options['values'];
+  }
+
+  /**
+   * Get the entity table for a tag label.
+   *
+   * @param string $entity
+   *
+   * @return string
+   */
+  protected function getTableForTag($entity) {
+    $options = $this->getTagOptions();
+    return array_search($entity, $options);
+  }
+  /**
+   * Get entities which can be tagged in data provider format.
+   */
+  public function taggableEntities() {
+    $return = array();
+    foreach ($this->getTagOptions() as $entity) {
+      $return[] = array($entity);
+    }
+    return $return;
+  }
+
+  /**
+   * This test checks that users with edit all contacts can edit all tags.
+   *
+   * @dataProvider taggableEntities
+   *
+   * We are looking to see that a contact with edit all contacts can still add all tags (for all
+   * tag entities since that was how it was historically and we are not fixing non-contact entities).
+   *
+   * @param string $entity
+   *   Entity to test
+   */
+  public function testThatForEntitiesEditAllContactsCanAddTags($entity) {
+
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = array('edit all contacts');
+    $this->callAPISuccess('EntityTag', 'create', array(
+      'entity_id' => 1,
+      'tag_id' => $entity,
+      'check_permissions' => TRUE,
+      'entity_table' => $this->getTableForTag($entity),
+    ));
+    $this->callAPISuccessGetCount('EntityTag', array(
+      'entity_id' => 1,
+      'entity_table' => $this->getTableForTag($entity),
+    ), 1);
+  }
+
+  /**
+   * This test checks that an ACL or edit all contacts is required to be able to create a contact.
+   *
+   * @dataProvider taggableEntities
+   */
+  public function testThatForEntityWithoutACLOrEditAllThereIsNoAccess($entity) {
+
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = array('access CiviCRM', 'view all contacts');
+    $this->callAPISuccess('EntityTag', 'create', array(
+      'entity_id' => 1,
+      'tag_id' => $entity,
+      'check_permissions' => TRUE,
+      'entity_table' => $this->getTableForTag($entity),
+    ));
+    $this->callAPISuccessGetCount('EntityTag', array(
+      'entity_id' => 1,
+      'entity_table' => $this->getTableForTag($entity),
+    ), 0);
+  }
+
+  /**
+   * This test checks that permissions are not applied when check_permissions is off.
+   *
+   * @dataProvider taggableEntities
+   *
+   * @param string $entity
+   *   Entity to test
+   */
+  public function testCheckPermissionsOffWorks($entity) {
+
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = array('access CiviCRM', 'view all contacts');
+    $result = $this->callAPISuccess('EntityTag', 'create', array(
+      'entity_id' => 1,
+      'tag_id' => $entity,
+      'check_permissions' => 0,
+      'entity_table' => $this->getTableForTag($entity),
+    ));
+    $this->assertEquals(1, $result['added']);
+    $this->callAPISuccessGetCount('EntityTag', array(
+      'entity_id' => 1,
+      'entity_table' => $this->getTableForTag($entity),
+      'check_permissions' => 0,
+    ), 1);
+  }
+
+  /**
+   * This test checks ACLs can be used to control who can edit a contact.
+   *
+   * Note that for other entities this hook will not allow them to edit the entity_tag and they still need
+   * edit all contacts (pending a more extensive fix).
+   *
+   * @dataProvider taggableEntities
+   *
+   * @param string $entity
+   *   Entity to test
+   */
+  public function testThatForEntitiesACLApplies($entity) {
+
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = array('access CiviCRM', 'view all contacts');
+    $this->hookClass->setHook('civicrm_aclWhereClause', array($this, 'aclWhereHookAllResults'));
+    $this->callAPISuccess('EntityTag', 'create', array(
+      'entity_id' => 1,
+      'tag_id' => $entity,
+      'entity_table' => $this->getTableForTag($entity),
+      'check_permissions' => TRUE,
+    ));
+    $this->callAPISuccessGetCount('EntityTag', array(
+      'entity_id' => 1,
+      'entity_table' => $this->getTableForTag($entity),
+    ), ($entity == 'Contacts' ? 1 : 0));
+  }
+
+  /**
+   * All results returned.
+   *
+   * @implements CRM_Utils_Hook::aclWhereClause
+   *
+   * @param string $type
+   * @param array $tables
+   * @param array $whereTables
+   * @param int $contactID
+   * @param string $where
+   */
+  public function aclWhereHookAllResults($type, &$tables, &$whereTables, &$contactID, &$where) {
+    $where = " (1) ";
+  }
+
+}


### PR DESCRIPTION
- [CRM-17350: Non-administrators unable to tag contacts using Tags tab](https://issues.civicrm.org/jira/browse/CRM-17350)
