### PR TITLE
CRM-17350 preliminary test clean up for entity-tag acl permission fix

### DIFF
--- a/CRM/Core/BAO/EntityTag.php
+++ b/CRM/Core/BAO/EntityTag.php
@@ -44,7 +44,7 @@ class CRM_Core_BAO_EntityTag extends CRM_Core_DAO_EntityTag {
    * @return array
    *   reference $tag array of category id's the contact belongs to.
    */
-  public static function &getTag($entityID, $entityTable = 'civicrm_contact') {
+  public static function getTag($entityID, $entityTable = 'civicrm_contact') {
     $tags = array();
 
     $entityTag = new CRM_Core_BAO_EntityTag();

--- a/tests/phpunit/api/v3/ACLPermissionTest.php
+++ b/tests/phpunit/api/v3/ACLPermissionTest.php
@@ -359,7 +359,6 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
     $this->assertEquals(0, $result['count']);
   }
 
-
   /**
    * @dataProvider entities
    * Function tests that an empty where hook returns no results
@@ -401,24 +400,28 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
 
   /**
    * No results returned.
+   *
    * @implements CRM_Utils_Hook::aclWhereClause
-   * @param $type
-   * @param $tables
-   * @param $whereTables
-   * @param $contactID
-   * @param $where
+   *
+   * @param string $type
+   * @param array $tables
+   * @param array $whereTables
+   * @param int $contactID
+   * @param string $where
    */
   public function aclWhereHookNoResults($type, &$tables, &$whereTables, &$contactID, &$where) {
   }
 
   /**
    * All results returned.
+   *
    * @implements CRM_Utils_Hook::aclWhereClause
-   * @param $type
-   * @param $tables
-   * @param $whereTables
-   * @param $contactID
-   * @param $where
+   *
+   * @param string $type
+   * @param array $tables
+   * @param array $whereTables
+   * @param int $contactID
+   * @param string $where
    */
   public function aclWhereHookAllResults($type, &$tables, &$whereTables, &$contactID, &$where) {
     $where = " (1) ";


### PR DESCRIPTION
- [CRM-17350: Non-administrators unable to tag contacts using Tags tab](https://issues.civicrm.org/jira/browse/CRM-17350)
