### PR TITLE
SettingsBag - Fix upgrade failure for WP 4.4=>4.7

### DIFF
--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -413,6 +413,15 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
       return TRUE;
     }
 
+    if ($path && preg_match('/^civicrm\/ajax\/l10n-js/', $path)
+      && !empty($_SERVER['HTTP_REFERER'])
+    ) {
+      $ref = parse_url($_SERVER['HTTP_REFERER']);
+      if (preg_match('/civicrm\/upgrade/', $ref['path']) || preg_match('/civicrm\/upgrade/', urldecode($ref['query']))) {
+        return TRUE;
+      }
+    }
+
     return FALSE;
   }
 

--- a/CRM/Utils/SQL/Insert.php
+++ b/CRM/Utils/SQL/Insert.php
@@ -51,6 +51,28 @@ class CRM_Utils_SQL_Insert {
   }
 
   /**
+   * Insert a record based on a DAO.
+   *
+   * @param \CRM_Core_DAO $dao
+   * @return \CRM_Utils_SQL_Insert
+   * @throws \CRM_Core_Exception
+   */
+  public static function dao(CRM_Core_DAO $dao) {
+    $table = CRM_Core_DAO::getLocaleTableName($dao->getTableName());
+    $row = array();
+    foreach ((array) $dao as $key => $value) {
+      if ($value === 'null') {
+        $value = NULL; // Blerg!!!
+      }
+      // Skip '_foobar' and '{\u00}*_options' and 'N'.
+      if (preg_match('/[a-zA-Z]/', $key{0}) && $key !== 'N') {
+        $row[$key] = $value;
+      }
+    }
+    return self::into($table)->row($row);
+  }
+
+  /**
    * Create a new SELECT query.
    *
    * @param string $table

--- a/Civi/Core/SettingsBag.php
+++ b/Civi/Core/SettingsBag.php
@@ -385,7 +385,14 @@ class SettingsBag {
       $dao->created_id = $session->get('userID');
     }
 
-    $dao->save();
+    if ($dao->id) {
+      $dao->save();
+    }
+    else {
+      // Cannot use $dao->save(); in upgrade mode (eg WP + Civi 4.4=>4.7), the DAO will refuse
+      // to save the field `group_name`, which is required in older schema.
+      \CRM_Core_DAO::executeQuery(\CRM_Utils_SQL_Insert::dao($dao)->toSQL());
+    }
     $dao->free();
   }
 


### PR DESCRIPTION
The WP integration attempts to define a new setting (`wpLoadPhp`) during
bootstrap -- before upgrade logic has run.  This was failing because the
`group_name` property wouldn't get passed through by DAO. (The field is required in the old schema, so we try to supply it adaptively, but it's removed in the new schema, so the DAO ignores it.)
