### PR TITLE
CRM-17881 add test to CRM_Core_BAO_SchemaHandler::createIndexes fn

### DIFF
--- a/tests/phpunit/CRM/Core/BAO/SchemaHandlerTest.php
+++ b/tests/phpunit/CRM/Core/BAO/SchemaHandlerTest.php
@@ -1,0 +1,57 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2015                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+require_once 'CiviTest/CiviUnitTestCase.php';
+
+/**
+ * Class CRM_Core_BAO_SchemaHandlerTest.
+ */
+class CRM_Core_BAO_SchemaHandlerTest extends CiviUnitTestCase {
+
+  /**
+   * Test creating an index.
+   *
+   * We want to be sure it creates an index and exits gracefully if the index
+   * already exists.
+   */
+  public function testCreateIndex() {
+    $tables = array('civicrm_uf_join' => array('weight'));
+    CRM_Core_BAO_SchemaHandler::createIndexes($tables);
+    CRM_Core_BAO_SchemaHandler::createIndexes($tables);
+    $dao = CRM_Core_DAO::executeQuery("SHOW INDEX FROM civicrm_uf_join");
+    $count = 0;
+
+    while ($dao->fetch()) {
+      if ($dao->Column_name == 'weight') {
+        $count++;
+        CRM_Core_DAO::executeQuery("ALTER TABLE civicrm_uf_join DROP INDEX " . $dao->Key_name);
+      }
+    }
+    $this->assertEquals(1, $count);
+  }
+
+}


### PR DESCRIPTION
- [CRM-17881: Use CRM_Core_BAO_SchemaHandler::createIndexes as a safe way to add indexes on upgrade](https://issues.civicrm.org/jira/browse/CRM-17881)
