### PR TITLE
CRM-17881 change index upgrade addition civicrm_financian_trxn.trxn_i…

### DIFF
--- a/CRM/Upgrade/Incremental/php/FourSeven.php
+++ b/CRM/Upgrade/Incremental/php/FourSeven.php
@@ -142,6 +142,7 @@ class CRM_Upgrade_Incremental_php_FourSeven extends CRM_Upgrade_Incremental_Base
   public function upgrade_4_7_beta6($rev) {
     $this->addTask(ts('Upgrade DB to %1: SQL', array(1 => $rev)), 'runSql', $rev);
     $this->addTask('Disable flexible jobs extension', 'disableFlexibleJobsExtension');
+    $this->addTask('Add Index to financial_trxn trxn_id field', 'addIndexFinancialTrxnTrxnID');
   }
 
   /**
@@ -388,6 +389,19 @@ FROM `civicrm_dashboard_contact` WHERE 1 GROUP BY contact_id";
       // just ignore if the extension isn't installed
     }
 
+    return TRUE;
+  }
+
+  /**
+   * CRM-17752 add index to civicrm_financial_trxn.trxn_id (deliberately non-unique).
+   *
+   * @param \CRM_Queue_TaskContext $ctx
+   *
+   * @return bool
+   */
+  public function addIndexFinancialTrxnTrxnID(CRM_Queue_TaskContext $ctx) {
+    $tables = array('civicrm_financial_trxn' => array('trxn_id'));
+    CRM_Core_BAO_SchemaHandler::createIndexes($tables);
     return TRUE;
   }
 

--- a/CRM/Upgrade/Incremental/sql/4.7.beta6.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.7.beta6.mysql.tpl
@@ -14,9 +14,5 @@ UPDATE civicrm_event
 SET max_additional_participants = 9
 WHERE is_multiple_registrations = 1;
 
--- CRM-17752
-ALTER TABLE `civicrm_financial_trxn`
-ADD INDEX `UI_ftrxn_trxn_id` (`trxn_id`);
-
 SELECT @domainID := min(id) FROM civicrm_domain;
 INSERT INTO civicrm_setting(name, value, domain_id, is_domain) values ('installed', 'i:1;', @domainID, 1);


### PR DESCRIPTION
…d to be upgrade friendly

Also ref CRM-17752

(We really should try to get this into the release as the existing upgrade sql gives it the wrong name @colemanw @monishdeb  - see how it was called UI_ftrxn_trxn_id - I think that is the name for a unique index )
