### PR TITLE
CRM-17898 look at phone_numeric rather than phone when deduping

### DIFF
--- a/CRM/Dedupe/BAO/RuleGroup.php
+++ b/CRM/Dedupe/BAO/RuleGroup.php
@@ -77,6 +77,7 @@ class CRM_Dedupe_BAO_RuleGroup extends CRM_Dedupe_DAO_RuleGroup {
         'addressee.label' => 'civicrm_contact.addressee_id',
         'email_greeting.label' => 'civicrm_contact.email_greeting_id',
         'postal_greeting.label' => 'civicrm_contact.postal_greeting_id',
+        'civicrm_phone.phone' => 'civicrm_phone.phone_numeric',
       );
       // the table names we support in dedupe rules - a filter for importableFields()
       $supportedTables = array(


### PR DESCRIPTION
- [CRM-17898: Deduping of phone number should use phone_numeric field](https://issues.civicrm.org/jira/browse/CRM-17898)
