### PR TITLE
CRM-17909. Correct parameter to ts() for risky file warning.

### DIFF
--- a/CRM/Utils/Check/Component/Security.php
+++ b/CRM/Utils/Check/Component/Security.php
@@ -246,7 +246,7 @@ class CRM_Utils_Check_Component_Security extends CRM_Utils_Check_Component {
       if (file_exists($file[0])) {
         $messages[] = new CRM_Utils_Check_Message(
           __FUNCTION__,
-          ts('File \'%1\' presents a security risk and should be deleted.', array(1 => $file)),
+          ts('File \'%1\' presents a security risk and should be deleted.', array(1 => $file[0])),
           ts('Unsafe Files'),
           $file[1],
           'fa-lock'


### PR DESCRIPTION
Untested fix. See question [Removing an “Unsafe File”](http://civicrm.stackexchange.com/questions/9242/removing-an-unsafe-file) on Stack Exchange.
