### PR TITLE
CRM-17911 - Fix cxn "Settings" link on WordPress

### DIFF
--- a/ang/crmCxn/ManageCtrl.js
+++ b/ang/crmCxn/ManageCtrl.js
@@ -98,7 +98,7 @@
     };
 
     $scope.openLink = function openLink(appMeta, page, options) {
-      var promise = crmApi('Cxn', 'getlink', {app_guid: appMeta.appId, page: page}).then(function(result) {
+      var promise = crmApi('Cxn', 'getlink', {app_guid: appMeta.appId, page_name: page}).then(function(result) {
         var mode = result.values.mode ? result.values.mode : 'popup';
         switch (result.values.mode) {
           case 'iframe':

--- a/api/v3/Cxn.php
+++ b/api/v3/Cxn.php
@@ -212,13 +212,14 @@ function _civicrm_api3_cxn_getlink_spec(&$spec) {
   $daoFields = CRM_Cxn_DAO_Cxn::fields();
   $spec['app_guid'] = $daoFields['app_guid'];
   $spec['cxn_guid'] = $daoFields['cxn_guid'];
-  $spec['page'] = array(
-    'name' => 'page',
+  $spec['page_name'] = array(
+    'name' => 'page_name',
     'type' => CRM_Utils_Type::T_STRING,
     'title' => ts('Page Type'),
     'description' => 'The type of page (eg "settings")',
     'maxlength' => 63,
     'size' => CRM_Utils_Type::HUGE,
+    'api.aliases' => array('page'),
   );
 }
 
@@ -235,14 +236,14 @@ function civicrm_api3_cxn_getlink($params) {
   $cxnId = _civicrm_api3_cxn_parseCxnId($params);
   $appMeta = CRM_Cxn_BAO_Cxn::getAppMeta($cxnId);
 
-  if (empty($params['page']) || !is_string($params['page'])) {
+  if (empty($params['page_name']) || !is_string($params['page_name'])) {
     throw new API_Exception("Invalid page");
   }
 
   /** @var \Civi\Cxn\Rpc\RegistrationClient $client */
   $client = \Civi\Core\Container::singleton()->get('cxn_reg_client');
   return $client->call($appMeta, 'Cxn', 'getlink', array(
-    'page' => $params['page'],
+    'page' => $params['page_name'],
   ));
 }
 
@@ -260,19 +261,6 @@ function civicrm_api3_cxn_getcfg($params) {
     'siteCallbackUrl' => CRM_Cxn_BAO_Cxn::getSiteCallbackUrl(),
   );
   return civicrm_api3_create_success($result);
-
-  $cxnId = _civicrm_api3_cxn_parseCxnId($params);
-  $appMeta = CRM_Cxn_BAO_Cxn::getAppMeta($cxnId);
-
-  if (empty($params['page']) || !is_string($params['page'])) {
-    throw new API_Exception("Invalid page");
-  }
-
-  /** @var \Civi\Cxn\Rpc\RegistrationClient $client */
-  $client = \Civi\Core\Container::singleton()->get('cxn_reg_client');
-  return $client->call($appMeta, 'Cxn', 'getlink', array(
-    'page' => $params['page'],
-  ));
 }
 
 /**


### PR DESCRIPTION
- [CRM-17911: Cxn.getlink API fails on WordPress due to "page" conflict](https://issues.civicrm.org/jira/browse/CRM-17911)
