### PR TITLE
CRM-17914: Support right-to-left languages in the CiviCRM installer.

### DIFF
--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -542,6 +542,21 @@ class CRM_Core_I18n {
     return (bool) $domain->locales;
   }
 
+  /**
+   * Is the language written "right-to-left"?
+   *
+   * @param $language
+   *   Language (for example 'en_US', or 'fr_CA').
+   *
+   * @return Bool
+   *   True if it is an RTL language.
+   */
+  public static function isLanguageRTL($language) {
+    $rtl = CRM_Core_I18n_PseudoConstant::getRTLlanguages();
+    $short = CRM_Core_I18n_PseudoConstant::shortForLong($language);
+
+    return (in_array($short, $rtl));
+  }
 
   /**
    * Change the processing language without changing the current user language

--- a/CRM/Core/I18n/PseudoConstant.php
+++ b/CRM/Core/I18n/PseudoConstant.php
@@ -78,4 +78,20 @@ class CRM_Core_I18n_PseudoConstant {
     return substr($long, 0, 2);
   }
 
+  /**
+   * Returns a list of ISO 639-1 "right-to-left" language codes.
+   *
+   * @return array
+   */
+  public static function getRTLlanguages() {
+    $rtl = array(
+      'ar',
+      'fa',
+      'he',
+      'ur',
+    );
+
+    return $rtl;
+  }
+
 }

--- a/install/index.php
+++ b/install/index.php
@@ -185,6 +185,11 @@ $GLOBALS['civicrm_default_error_scope'] = NULL;
 // The translation files are in the parent directory (l10n)
 $i18n = CRM_Core_I18n::singleton();
 
+// Support for Arabic, Hebrew, Farsi, etc.
+// Used in the template.html
+$short_lang_code = CRM_Core_I18n_PseudoConstant::shortForLong($tsLocale);
+$text_direction = (CRM_Core_I18n::isLanguageRTL($tsLocale) ? 'rtl' : 'ltr');
+
 global $cmsPath;
 if ($installType == 'drupal') {
   //CRM-6840 -don't force to install in sites/all/modules/

--- a/install/template.css
+++ b/install/template.css
@@ -13,6 +13,10 @@ body {
   max-width: 1200px;
 }
 
+.civicrm-logo {
+  float: right;
+}
+
 form {
   margin: 0;
 }

--- a/install/template.html
+++ b/install/template.html
@@ -1,15 +1,19 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $short_lang_code; ?>" lang="<?php echo $short_lang_code; ?>" dir="<?php echo $text_direction; ?>">
 <head>
-<meta http-equiv="Content-type" content="text/html; charset=utf-8" />
-<title><?php echo ts('CiviCRM Installer'); ?></title>
-<link rel="stylesheet" type="text/css" href=<?php echo $installURLPath . "template.css"?> />
+  <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
+  <title><?php echo ts('CiviCRM Installer'); ?></title>
+  <link rel="stylesheet" type="text/css" href=<?php echo $installURLPath . "template.css"?> />
+<?php
+if ($text_direction == 'rtl') {
+  echo "  <link rel='stylesheet' type='text/css' href='{$installURLPath}template-rtl.css' />\n";
+}
+?>
 </head>
-
 <body>
 
 <div id="All">
-  <div style="float: right"><strong><?php echo ts('Version %1', array(1 => "{$civicrm_version['version']} {$civicrm_version['cms']}")); ?></strong><br/>
+  <div class="civicrm-logo"><strong><?php echo ts('Version %1', array(1 => "{$civicrm_version['version']} {$civicrm_version['cms']}")); ?></strong><br/>
     <span><img src=<?php echo $installURLPath . "block_small.png"?> /></span>
   </div>
 


### PR DESCRIPTION
- [CRM-17914: CiviCRM installer: better support for right-to-left (arabic\/hebrew)](https://issues.civicrm.org/jira/browse/CRM-17914)
