### PR TITLE
CRM-17924 - crm.ckeditor.js - Allow email-style tags+attributes

### DIFF
--- a/js/wysiwyg/crm.ckeditor.js
+++ b/js/wysiwyg/crm.ckeditor.js
@@ -75,6 +75,7 @@
         filebrowserUploadUrl: uploadUrl + '&type=files',
         filebrowserImageUploadUrl: uploadUrl + '&type=images',
         filebrowserFlashUploadUrl: uploadUrl + '&type=flash',
+        allowedContent: true, // For CiviMail!
         customConfig: CRM.config.CKEditorCustomConfig,
         on: {
           instanceReady: onReady


### PR DESCRIPTION
- [CRM-17924: After 4.7 upgrade the mailing templates lost html formatting in edit mode](https://issues.civicrm.org/jira/browse/CRM-17924)
