### PR TITLE
CRM-17593 - fix built in role 'administer users' to check for capabil…

### DIFF
--- a/CRM/Core/Permission/WordPress.php
+++ b/CRM/Core/Permission/WordPress.php
@@ -49,7 +49,7 @@ class CRM_Core_Permission_WordPress extends CRM_Core_Permission_Base {
   public function check($str) {
     // Generic cms 'administer users' role tranlates to 'administrator' WordPress role
     $str = $this->translatePermission($str, 'WordPress', array(
-      'administer users' => 'administrator',
+      'administer users' => 'edit_users',
     ));
     if ($str == CRM_Core_Permission::ALWAYS_DENY_PERMISSION) {
       return FALSE;

--- a/CRM/Core/Permission/WordPress.php
+++ b/CRM/Core/Permission/WordPress.php
@@ -47,7 +47,7 @@ class CRM_Core_Permission_WordPress extends CRM_Core_Permission_Base {
    *   true if yes, else false
    */
   public function check($str) {
-    // Generic cms 'administer users' role tranlates to 'administrator' WordPress role
+    // Generic cms 'administer users' role tranlates to users with the 'edit_users' capability' in WordPress
     $str = $this->translatePermission($str, 'WordPress', array(
       'administer users' => 'edit_users',
     ));


### PR DESCRIPTION
…ity of 'edit_users' rather than set at the administrator level- Backport to 4.6

---
- CRM-17593: Certain Permissions are hard coded to 'Administrator' in CRM_Core_Permission_WordPress
  https://issues.civicrm.org/jira/browse/CRM-17593
