### PR TITLE
Toward CRM-17917, support for Drupal 8

### DIFF
--- a/CRM/Core/Permission/Drupal8.php
+++ b/CRM/Core/Permission/Drupal8.php
@@ -61,4 +61,49 @@ class CRM_Core_Permission_Drupal8 extends CRM_Core_Permission_DrupalBase {
     return \Drupal::currentUser()->hasPermission($str);
   }
 
+  /**
+   * Get all the contact emails for users that have a specific permission.
+   *
+   * @param string $permissionName
+   *   Name of the permission we are interested in.
+   *
+   * @return string
+   *   a comma separated list of email addresses
+   */
+  public function permissionEmails($permissionName) {
+    static $_cache = array();
+
+    if (isset($_cache[$permissionName])) {
+      return $_cache[$permissionName];
+    }
+
+    $role_ids = array_map(
+      function (\Drupal\user\RoleInterface $role) {
+        return $role->id();
+      }, user_roles(TRUE, $permissionName)
+    );
+    $users = \Drupal::entityTypeManager()->getStorage('user')->loadByProperties(array('roles' => $role_ids));
+    $uids = array_keys($users);
+
+    $_cache[$permissionName] = self::getContactEmails($uids);
+    return $_cache[$permissionName];
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function upgradePermissions($permissions) {
+    $civicrm_perms = array_keys(CRM_Core_Permission::getCorePermissions());
+    if (empty($civicrm_perms)) {
+      throw new CRM_Core_Exception("Cannot upgrade permissions: permission list missing");
+    }
+
+    $roles = user_roles(TRUE);
+    foreach ($roles as $role) {
+      foreach ($civicrm_perms as $permission) {
+        $role->revokePermission($permission);
+      }
+    }
+  }
+
 }

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -226,6 +226,7 @@ class Container {
   public function createEventDispatcher($container) {
     $dispatcher = new ContainerAwareEventDispatcher($container);
     $dispatcher->addListener(SystemInstallEvent::EVENT_NAME, array('\Civi\Core\InstallationCanary', 'check'));
+    $dispatcher->addListener(SystemInstallEvent::EVENT_NAME, array('\Civi\Core\DatabaseInitializer', 'initialize'));
     $dispatcher->addListener('hook_civicrm_post::Activity', array('\Civi\CCase\Events', 'fireCaseChange'));
     $dispatcher->addListener('hook_civicrm_post::Case', array('\Civi\CCase\Events', 'fireCaseChange'));
     $dispatcher->addListener('hook_civicrm_caseChange', array('\Civi\CCase\Events', 'delegateToXmlListeners'));

--- a/Civi/Core/DatabaseInitializer.php
+++ b/Civi/Core/DatabaseInitializer.php
@@ -1,0 +1,53 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2015                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Core;
+
+use Civi\Core\Event\SystemInstallEvent;
+
+/**
+ * Class DatabaseInitializer
+ * @package Civi\Core
+ */
+class DatabaseInitializer {
+
+  /**
+   * Flush system to build the menu and MySQL triggers
+   *
+   * @param \Civi\Core\Event\SystemInstallEvent $event
+   * @throws \CRM_Core_Exception
+   */
+  public static function initialize(SystemInstallEvent $event) {
+    $api_params = array(
+      'version' => 3,
+      'triggers' => 1,
+      'session' => 1,
+    );
+    civicrm_api('System', 'flush', $api_params);
+  }
+
+}

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -228,9 +228,6 @@ fi
 
 if [ -n "$DO_FLUSH" ]; then
   pushd "$CALLEDPATH/.."
-    # run the cli script to build the menu and the triggers
-    "$PHP5PATH"php bin/cli.php -e System -a flush --triggers 1 --session 1
-
     # reset config_backend and userFrameworkResourceURL which gets set
     # when config object is initialized
     $MYSQLCMD -e "UPDATE civicrm_domain SET config_backend = NULL; UPDATE civicrm_setting SET value = NULL WHERE name = 'userFrameworkResourceURL';"


### PR DESCRIPTION
Moved system flush from setup.sh to first-run; added permissionEmails() and upgradePermissions() in CRM_Core_Permission_Drupal8.

---
- [CRM-17917: Add support for Drupal 8](https://issues.civicrm.org/jira/browse/CRM-17917)
