### PR TITLE
CRM-17964 Removed duplicate of index IX_entity

### DIFF
--- a/xml/schema/Financial/FinancialItem.xml
+++ b/xml/schema/Financial/FinancialItem.xml
@@ -167,10 +167,4 @@
     <fieldName>entity_id</fieldName>
     <add>4.3</add>
   </index>
-  <index>
-    <name>IX_entity</name>
-    <fieldName>entity_table</fieldName>
-    <fieldName>entity_id</fieldName>
-    <add>4.3</add>
-  </index>
 </table>


### PR DESCRIPTION
- [CRM-17964: financial item IX_entity index misspecified in schema\/xml](https://issues.civicrm.org/jira/browse/CRM-17964)
