### PR TITLE
CRM-17650 ensure that replyto_email is updated when re-using a previo…

### DIFF
--- a/ang/crmMailing/FromAddress.js
+++ b/ang/crmMailing/FromAddress.js
@@ -18,6 +18,7 @@
           var addr = crmFromAddresses.getByLabel(newValue);
           mailing.from_name = addr.author;
           mailing.from_email = addr.email;
+          mailing.replyto_email = addr.email;
         });
         // FIXME: Shouldn't we also be watching mailing.from_name and mailing.from_email?
       }


### PR DESCRIPTION
…us mailing and changing the from address

This is a backport of the exact same fix that is in master @eileenmcnaughton i think i have already pushed this into fuzion's repo i think
