### PR TITLE
CiviTest/bootstrap.php - Change env handling in `cv()`

### DIFF
--- a/tests/phpunit/CiviTest/bootstrap.php
+++ b/tests/phpunit/CiviTest/bootstrap.php
@@ -39,8 +39,10 @@ if (CIVICRM_UF === 'UnitTests') {
 function cv($cmd, $decode = 'json') {
   $cmd = 'cv ' . $cmd;
   $descriptorSpec = array(0 => array("pipe", "r"), 1 => array("pipe", "w"), 2 => STDERR);
-  $env = $_ENV + array('CV_OUTPUT' => 'json');
-  $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__, $env);
+  $oldOutput = getenv('CV_OUTPUT');
+  putenv("CV_OUTPUT=json");
+  $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
+  putenv("CV_OUTPUT=$oldOutput");
   fclose($pipes[0]);
   $result = stream_get_contents($pipes[1]);
   fclose($pipes[1]);


### PR DESCRIPTION
In Ubuntu's php-cli, the php.ini overrides `variables_order` with `GPCS` --
which destroys `$_ENV`.

This seems pretty stupid...  perhaps they conflated `variables_order` with
`request_order`.

At any rate, we'll have to do statey-swappy `putenv()` things instead.
