### PR TITLE
Revert "CRM-17908: text version of header/footer not used when auto-generatin…"

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -758,27 +758,17 @@ ORDER BY   i.contact_id, i.{$tempColumn}
     if (!$this->templates) {
       $this->getHeaderFooter();
       $this->templates = array();
-      if ($this->body_text || $this->header->body_text || $this->footer->body_text) {
+
+      if ($this->body_text) {
         $template = array();
-        if ($this->header->body_text) {
+        if ($this->header) {
           $template[] = $this->header->body_text;
         }
-        else {
-          $template[] = CRM_Utils_String::htmlToText($this->header->body_html);
-        }
 
-        if ($this->body_text) {
-          $template[] = $this->body_text;
-        }
-        else {
-          $template[] = CRM_Utils_String::htmlToText($this->body_html);
-        }
+        $template[] = $this->body_text;
 
-        if ($this->footer->body_text) {
+        if ($this->footer) {
           $template[] = $this->footer->body_text;
-        }
-        else {
-          $template[] = CRM_Utils_String::htmlToText($this->footer->body_html);
         }
 
         $this->templates['text'] = implode("\n", $template);
@@ -802,7 +792,7 @@ ORDER BY   i.contact_id, i.{$tempColumn}
         // this is where we create a text template from the html template if the text template did not exist
         // this way we ensure that every recipient will receive an email even if the pref is set to text and the
         // user uploads an html email only
-        if (empty($this->templates['text'])) {
+        if (!$this->body_text) {
           $this->templates['text'] = CRM_Utils_String::htmlToText($this->templates['html']);
         }
       }


### PR DESCRIPTION
Reverts civicrm/civicrm-core#7717

If you look at https://test.civicrm.org/job/CiviCRM-Core-PR/7816/testReport/ , it aborted after ~30 tests.

I've traced the following failure to this commit using git bisect: https://test.civicrm.org/job/CiviCRM-Core-PR/7837/testReport/junit/%28root%29/api_v3_MailingTest/testMailerPreview/
