### PR TITLE
CRM_Core_Config, Upgrade Tests - Display warning when mkdir fails

### DIFF
--- a/CRM/Core/Config/MagicMerge.php
+++ b/CRM/Core/Config/MagicMerge.php
@@ -225,7 +225,12 @@ class CRM_Core_Config_MagicMerge {
         if ($value) {
           $value = CRM_Utils_File::addTrailingSlash($value);
           if (isset($this->map[$k][2]) && in_array('mkdir', $this->map[$k][2])) {
-            CRM_Utils_File::createDir($value);
+            if (!CRM_Utils_File::createDir($value, FALSE)) {
+              CRM_Core_Session::setStatus(ts('Failed to make directory (%1) at "%2". Please update the settings or file permissions.', array(
+                1 => $k,
+                2 => $value,
+              )));
+            }
           }
           if (isset($this->map[$k][2]) && in_array('restrict', $this->map[$k][2])) {
             CRM_Utils_File::restrictAccess($value);


### PR DESCRIPTION
Some automated upgrade tests fail because because they include absolute paths which are invalid and unmakeable. This revision displays a warning instead of a fatal.
