### PR TITLE
CRM-17908:text version of header/footer not used when auto-generating

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -758,7 +758,7 @@ ORDER BY   i.contact_id, i.{$tempColumn}
     if (!$this->templates) {
       $this->getHeaderFooter();
       $this->templates = array();
-      if ($this->body_text || property_exists($this->header, 'body_text') || property_exists($this->footer, 'body_text')) {
+      if ($this->body_text || !empty($this->header)) {
         $template = array();
         if ($this->header->body_text) {
           $template[] = $this->header->body_text;

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -760,7 +760,7 @@ ORDER BY   i.contact_id, i.{$tempColumn}
       $this->templates = array();
       if ($this->body_text || !empty($this->header)) {
         $template = array();
-        if ($this->header->body_text) {
+        if (!empty($this->header->body_text)) {
           $template[] = $this->header->body_text;
         }
         else {
@@ -774,7 +774,7 @@ ORDER BY   i.contact_id, i.{$tempColumn}
           $template[] = CRM_Utils_String::htmlToText($this->body_html);
         }
 
-        if ($this->footer->body_text) {
+        if (!empty($this->footer->body_text)) {
           $template[] = $this->footer->body_text;
         }
         else {

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -758,17 +758,27 @@ ORDER BY   i.contact_id, i.{$tempColumn}
     if (!$this->templates) {
       $this->getHeaderFooter();
       $this->templates = array();
-
-      if ($this->body_text) {
+      if ($this->body_text || property_exists($this->header, 'body_text') || property_exists($this->footer, 'body_text')) {
         $template = array();
-        if ($this->header) {
+        if ($this->header->body_text) {
           $template[] = $this->header->body_text;
         }
+        else {
+          $template[] = CRM_Utils_String::htmlToText($this->header->body_html);
+        }
 
-        $template[] = $this->body_text;
+        if ($this->body_text) {
+          $template[] = $this->body_text;
+        }
+        else {
+          $template[] = CRM_Utils_String::htmlToText($this->body_html);
+        }
 
-        if ($this->footer) {
+        if ($this->footer->body_text) {
           $template[] = $this->footer->body_text;
+        }
+        else {
+          $template[] = CRM_Utils_String::htmlToText($this->footer->body_html);
         }
 
         $this->templates['text'] = implode("\n", $template);
@@ -792,7 +802,7 @@ ORDER BY   i.contact_id, i.{$tempColumn}
         // this is where we create a text template from the html template if the text template did not exist
         // this way we ensure that every recipient will receive an email even if the pref is set to text and the
         // user uploads an html email only
-        if (!$this->body_text) {
+        if (empty($this->templates['text'])) {
           $this->templates['text'] = CRM_Utils_String::htmlToText($this->templates['html']);
         }
       }

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -763,7 +763,7 @@ ORDER BY   i.contact_id, i.{$tempColumn}
         if (!empty($this->header->body_text)) {
           $template[] = $this->header->body_text;
         }
-        else {
+        elseif (!empty($this->header->body_html)) {
           $template[] = CRM_Utils_String::htmlToText($this->header->body_html);
         }
 
@@ -777,7 +777,7 @@ ORDER BY   i.contact_id, i.{$tempColumn}
         if (!empty($this->footer->body_text)) {
           $template[] = $this->footer->body_text;
         }
-        else {
+        elseif (!empty($this->footer->body_html)) {
           $template[] = CRM_Utils_String::htmlToText($this->footer->body_html);
         }
 


### PR DESCRIPTION
---
- CRM-17908: text version of header/footer not used when auto-generating text version of email
  https://issues.civicrm.org/jira/browse/CRM-17908
