### PR TITLE
CRM-16619 Add financial type code

### DIFF
--- a/CRM/Financial/BAO/ExportFormat/CSV.php
+++ b/CRM/Financial/BAO/ExportFormat/CSV.php
@@ -104,7 +104,9 @@ class CRM_Financial_BAO_ExportFormat_CSV extends CRM_Financial_BAO_ExportFormat 
       fac.account_type_code AS from_credit_account_type_code,
       fac.accounting_code AS from_credit_account,
       fac.name AS from_credit_account_name,
-      fi.description AS item_description
+      fi.description AS item_description,
+      ftype.name AS financial_type_name,
+      ftype.financial_type_code
       FROM civicrm_entity_batch eb
       LEFT JOIN civicrm_financial_trxn ft ON (eb.entity_id = ft.id AND eb.entity_table = 'civicrm_financial_trxn')
       LEFT JOIN civicrm_financial_account fa_to ON fa_to.id = ft.to_financial_account_id
@@ -119,6 +121,9 @@ class CRM_Financial_BAO_ExportFormat_CSV extends CRM_Financial_BAO_ExportFormat 
       LEFT JOIN civicrm_financial_item fi ON fi.id = efti.entity_id
       LEFT JOIN civicrm_financial_account fac ON fac.id = fi.financial_account_id
       LEFT JOIN civicrm_financial_account fa ON fa.id = fi.financial_account_id
+      LEFT JOIN civicrm_entity_financial_trxn eft ON (eft.financial_trxn_id = ft.id AND eft.entity_table = 'civicrm_contribution')
+      LEFT JOIN civicrm_contribution contribution ON contribution.id = eft.entity_id
+      LEFT JOIN civicrm_financial_type ftype ON ftype.id = contribution.financial_type_id
       WHERE eb.batch_id = ( %1 )";
 
     CRM_Utils_Hook::batchQuery($sql);
@@ -220,6 +225,8 @@ class CRM_Financial_BAO_ExportFormat_CSV extends CRM_Financial_BAO_ExportFormat 
           'Credit Account Name' => $creditAccountName,
           'Credit Account Type' => $creditAccountType,
           'Item Description' => $dao->item_description,
+          'Financial Type Name' => $dao->financial_type_name,
+          'Financial Type Code' => $dao->financial_type_code,
         );
 
         end($financialItems);

--- a/CRM/Financial/Form/FinancialType.php
+++ b/CRM/Financial/Form/FinancialType.php
@@ -67,7 +67,7 @@ class CRM_Financial_Form_FinancialType extends CRM_Contribute_Form {
     $this->add('text', 'name', ts('Name'), CRM_Core_DAO::getAttribute('CRM_Financial_DAO_FinancialType', 'name'), TRUE);
 
     $this->add('text', 'description', ts('Description'), CRM_Core_DAO::getAttribute('CRM_Financial_DAO_FinancialType', 'description'));
-
+    $this->add('text', 'financial_type_code', ts('Financial Type Code'), CRM_Core_DAO::getAttribute('CRM_Financial_DAO_FinancialType', 'financial_type_code'));
     $this->add('checkbox', 'is_deductible', ts('Tax-Deductible?'), CRM_Core_DAO::getAttribute('CRM_Financial_DAO_FinancialType', 'is_deductible'));
     $this->add('checkbox', 'is_active', ts('Enabled?'), CRM_Core_DAO::getAttribute('CRM_Financial_DAO_FinancialType', 'is_active'));
     $this->add('checkbox', 'is_reserved', ts('Reserved?'), CRM_Core_DAO::getAttribute('CRM_Financial_DAO_FinancialType', 'is_reserved'));

--- a/templates/CRM/Financial/ExportFormat/IIF.tpl
+++ b/templates/CRM/Financial/ExportFormat/IIF.tpl
@@ -59,7 +59,7 @@ CUST{$tabchar}{$contact.name}{$tabchar}{$tabchar}{$tabchar}{$tabchar}{$tabchar}{
 {foreach from=$journalEntries key=id item=je}
 TRNS{$tabchar}{$je.to_account.trxn_id}{$tabchar}GENERAL JOURNAL{$tabchar}{$je.to_account.trxn_date}{$tabchar}{$je.to_account.account_name}{$tabchar}{$je.to_account.contact_name}{$tabchar}{$tabchar}{$je.to_account.amount}{$tabchar}{$je.to_account.check_number}{$tabchar}{$tabchar}{$je.to_account.payment_instrument}
 {foreach from=$je.splits key=spl_id item=spl}
-SPL{$tabchar}{$spl.spl_id}{$tabchar}GENERAL JOURNAL{$tabchar}{$spl.trxn_date}{$tabchar}{$spl.account_name}{$tabchar}{$spl.contact_name}{$tabchar}{$tabchar}{$spl.amount}{$tabchar}{$spl.check_number}{$tabchar}{$spl.description}{$tabchar}{$spl.payment_instrument}
+SPL{$tabchar}{$spl.spl_id}{$tabchar}GENERAL JOURNAL{$tabchar}{$spl.trxn_date}{$tabchar}{$spl.account_name}{$tabchar}{$spl.contact_name}{$tabchar}{$spl.financial_type_code}{$tabchar}{$spl.amount}{$tabchar}{$spl.check_number}{$tabchar}{$spl.description}{$tabchar}{$spl.payment_instrument}
 {/foreach}
 ENDTRNS
 {/foreach}

--- a/templates/CRM/Financial/Form/FinancialType.tpl
+++ b/templates/CRM/Financial/Form/FinancialType.tpl
@@ -41,6 +41,10 @@
         <td class="label">{$form.description.label}</td>
     <td class="html-adjust">{$form.description.html}</td>
        </tr>
+       <tr class="crm-contribution-form-block-financial_type_code">
+        <td class="label">{$form.financial_type_code.label}</td>
+    <td class="html-adjust">{$form.financial_type_code.html}</td>
+       </tr>
 
        <tr class="crm-contribution-form-block-is_deductible">
         <td class="label">{$form.is_deductible.label}</td>

--- a/xml/schema/Financial/FinancialType.xml
+++ b/xml/schema/Financial/FinancialType.xml
@@ -51,6 +51,13 @@
     <add>1.3</add>
   </field>
   <field>
+    <name>financial_type_code</name>
+    <type>varchar</type>
+    <length>255</length>
+    <comment>Optional value for mapping financial types to accounting system categories (QuickBooks Classes for example).</comment>
+    <add>4.8</add>
+  </field>
+  <field>
     <name>is_deductible</name>
     <title>Is Tax Deductible?</title>
     <type>boolean</type>


### PR DESCRIPTION
Add a financial type code attribute to financial types. 
When working with accounting batches use this attribute 
to specify the quickbooks class for IIF generation.
Also add the attribute to the csv generation.

---
- [CRM-16619: Add CLASS support for IIF Export of accounting batches](https://issues.civicrm.org/jira/browse/CRM-16619)
