### PR TITLE
CRM-17987 Allow grouping pledge summary report by financial type.

### DIFF
--- a/CRM/Report/Form/Pledge/Summary.php
+++ b/CRM/Report/Form/Pledge/Summary.php
@@ -163,6 +163,9 @@ class CRM_Report_Form_Pledge_Summary extends CRM_Report_Form {
           'status_id' => array(
             'title' => ts('Pledge Status'),
           ),
+          'financial_type_id' => array(
+            'title' => ts('Financial Type'),
+          ),
         ),
       ),
       'civicrm_pledge_payment' => array(


### PR DESCRIPTION
- [CRM-17987: Allow grouping by financial type on Pledge Summary Report](https://issues.civicrm.org/jira/browse/CRM-17987)
