### PR TITLE
CRM-17485 fix

### DIFF
--- a/CRM/Report/Form/Event/ParticipantListCount.php
+++ b/CRM/Report/Form/Event/ParticipantListCount.php
@@ -241,6 +241,7 @@ class CRM_Report_Form_Event_ParticipantListCount extends CRM_Report_Form_Event {
             'name' => 'role_id',
             'title' => ts('Participant Role'),
             'operatorType' => CRM_Report_Form::OP_MULTISELECT_SEPARATOR,
+            'type' => CRM_Utils_Type::T_INT,
             'options' => CRM_Event_PseudoConstant::participantRole(),
           ),
           'participant_register_date' => array(


### PR DESCRIPTION
- [CRM-17485: Event participant role filter not working in Participant list Count Report](https://issues.civicrm.org/jira/browse/CRM-17485)
