### PR TITLE
Migrate+upgrade - Another fix for running with a DB that has foreign/unsupported paths

### DIFF
--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -663,6 +663,9 @@ HTACCESS;
    * @return array(string)
    */
   public static function findFiles($dir, $pattern, $relative = FALSE) {
+    if (!is_dir($dir)) {
+      return array();
+    }
     $dir = rtrim($dir, '/');
     $todos = array($dir);
     $result = array();


### PR DESCRIPTION
CRM_Utils_File::findFiles() - Fail gracefully if directory doesn't exist
