### PR TITLE
CRM-18001 - Group titles undefined in groups list

### DIFF
--- a/templates/CRM/Group/Form/Search.tpl
+++ b/templates/CRM/Group/Form/Search.tpl
@@ -211,7 +211,7 @@
               $.each( response.data, function( i, val ) {
                 appendHTML += '<tr id="row_'+val.group_id+'_'+parent_id+'" data-entity="group" data-id="'+val.group_id+'" class="crm-entity parent_is_'+parent_id+' crm-row-child">';
                 if ( val.is_parent ) {
-                  appendHTML += '<td class="crm-group-name crmf-title crm-editable ' + levelClass + '">' + '{/literal}<span class="collapsed show-children" title="{ts}show child groups{/ts}"/></span>{literal}' + val.group_name + '</td>';
+                  appendHTML += '<td class="crm-group-name crmf-title crm-editable ' + levelClass + '">' + '{/literal}<span class="collapsed show-children" title="{ts}show child groups{/ts}"/></span>{literal}' + val.title + '</td>';
                 }
                 else {
                   appendHTML += '<td class="crm-group-name  crmf-title crm-editable ' + levelClass + '"><span class="crm-no-children"></span>' + val.title + '</td>';


### PR DESCRIPTION
When displaying civi groups via "Manage groups" and therefore via templates/CRM/Group/Form/Search.tpl the group titltes are shown as 'undefined' if a group has a parent and is self a parent. See attachment.
## ![bildschirmfoto von 2016-02-09 13-05-28](https://cloud.githubusercontent.com/assets/1521157/12916566/b8243194-cf33-11e5-9a8d-265db614550c.png)
- CRM-18001: Group titles undefined in groups list
  https://issues.civicrm.org/jira/browse/CRM-18001
