### PR TITLE
CRM-17982 - CRM_Core_Config_MagicMerge - Fix warning on demos sites

### DIFF
--- a/CRM/Core/Config/MagicMerge.php
+++ b/CRM/Core/Config/MagicMerge.php
@@ -225,7 +225,7 @@ class CRM_Core_Config_MagicMerge {
         if ($value) {
           $value = CRM_Utils_File::addTrailingSlash($value);
           if (isset($this->map[$k][2]) && in_array('mkdir', $this->map[$k][2])) {
-            if (!CRM_Utils_File::createDir($value, FALSE)) {
+            if (!is_dir($value) && !CRM_Utils_File::createDir($value, FALSE)) {
               CRM_Core_Session::setStatus(ts('Failed to make directory (%1) at "%2". Please update the settings or file permissions.', array(
                 1 => $k,
                 2 => $value,

--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -102,10 +102,14 @@ class CRM_Utils_File {
    *   The path name.
    * @param bool $abort
    *   Should we abort or just return an invalid code.
+   * @return bool|NULL
+   *   NULL: Folder already exists or was not specified.
+   *   TRUE: Creation succeeded.
+   *   FALSE: Creation failed.
    */
   public static function createDir($path, $abort = TRUE) {
     if (is_dir($path) || empty($path)) {
-      return;
+      return NULL;
     }
 
     CRM_Utils_File::createDir(dirname($path), $abort);


### PR DESCRIPTION
Apparently, createDir() will return FALSE if the folder already exists _or_
if the creation-act fails.  We only want to display a warning if the
creation-act fails.

---

https://issues.civicrm.org/jira/browse/CRM-17982
