### PR TITLE
Revert portion of CRM17748

### DIFF
--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -1222,7 +1222,7 @@ SELECT DISTINCT 'civicrm_contact', contact_a.id, contact_a.id, '$cacheKey', cont
     if (!$displayRelationshipType) {
       $query = new CRM_Contact_BAO_Query($params,
         CRM_Contact_BAO_Query::NO_RETURN_PROPERTIES,
-        array('contact_id'), FALSE, FALSE, 1,
+        NULL, FALSE, FALSE, 1,
         FALSE, TRUE, TRUE, NULL,
         $queryOperator
       );
@@ -1230,7 +1230,7 @@ SELECT DISTINCT 'civicrm_contact', contact_a.id, contact_a.id, '$cacheKey', cont
     else {
       $query = new CRM_Contact_BAO_Query($params,
         CRM_Contact_BAO_Query::NO_RETURN_PROPERTIES,
-        array('contact_id'), FALSE, FALSE, 1,
+        NULL, FALSE, FALSE, 1,
         FALSE, TRUE, TRUE, $displayRelationshipType,
         $queryOperator
       );


### PR DESCRIPTION
The $fields parameter to CRM_Contact_BAO_Query::__construct() should be `NULL` except in extraordinary circumstances.
