### PR TITLE
Civi\Angular\ManagerTest - Fix false-negative

### DIFF
--- a/tests/phpunit/Civi/Angular/ManagerTest.php
+++ b/tests/phpunit/Civi/Angular/ManagerTest.php
@@ -101,7 +101,7 @@ class ManagerTest extends \CiviUnitTestCase {
     $this->assertTrue($counts['js'] > 0, 'Expect to find at least one JS file');
     $this->assertTrue($counts['css'] > 0, 'Expect to find at least one CSS file');
     $this->assertTrue($counts['partials'] > 0, 'Expect to find at least one partial HTML file');
-    $this->assertTrue($counts['settings'] > 1, 'Expect to find at least one setting');
+    $this->assertTrue($counts['settings'] > 0, 'Expect to find at least one setting');
   }
 
   /**


### PR DESCRIPTION
The test is a bit overzealous.  To ensure that the 'settings' are being
processed, it checks to ensure that some settings (any settings) are
defined.  However, it looks for 2+ settings, and it's enough look for 1+.
