### PR TITLE
CRM-18007:PCP: alpha pagination messed up

### DIFF
--- a/CRM/PCP/Page/PCP.php
+++ b/CRM/PCP/Page/PCP.php
@@ -168,6 +168,8 @@ class CRM_PCP_Page_PCP extends CRM_Core_Page_Basic {
    * @return void
    */
   public function browse($action = NULL) {
+    CRM_Core_Resources::singleton()->addStyleFile('civicrm', 'css/searchForm.css', 1, 'html-header');
+
     $this->_sortByCharacter = CRM_Utils_Request::retrieve('sortByCharacter',
       'String',
       $this


### PR DESCRIPTION
May not be correct way to include css, i based solution on as it was done in finance. Could also be some root cause that should be solved instead of adding this css. Please get back to me if this is wrong or something needs correction.

---
- [CRM-18007: PCP: alpha pagination messed up](https://issues.civicrm.org/jira/browse/CRM-18007)
