### PR TITLE
CRM-18013: Fix default value issue

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1475,10 +1475,11 @@ WHERE civicrm_event.is_active = 1
           break;
         }
       }
-      $customVal = '';
+
       $imProviders = CRM_Core_PseudoConstant::get('CRM_Core_DAO_IM', 'provider_id');
       //start of code to set the default values
       foreach ($fields as $name => $field) {
+        $customVal = '';
         $skip = FALSE;
         // skip fields that should not be displayed separately
         if ($field['skipDisplay']) {


### PR DESCRIPTION
- [CRM-18013: Custom 'integer' field displays value even if empty on event confirmation pages](https://issues.civicrm.org/jira/browse/CRM-18013)
