### PR TITLE
CRM-17953 Hotfix for broken URLs in CiviMail

### DIFF
--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -438,7 +438,7 @@ class CRM_Utils_System {
       ));
     }
 
-    self::setHttpHeader('Location', $url);
+    header('Location: ' . $url);
     self::civiExit();
   }
 


### PR DESCRIPTION
- [CRM-17953: URLs in CiviMail messages do not work](https://issues.civicrm.org/jira/browse/CRM-17953)
