### PR TITLE
CRM-17718 update repeattransaction to accept contribution_recur_id in…

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3767,6 +3767,20 @@ WHERE con.id = {$contributionId}
   }
 
   /**
+   * Is there only one line item attached to the contribution.
+   *
+   * @param int $id
+   *   Contribution ID.
+   *
+   * @return bool
+   * @throws \CiviCRM_API3_Exception
+   */
+  public static function isSingleLineItem($id) {
+    $lineItemCount = civicrm_api3('LineItem', 'getcount', array('contribution_id' => $id));
+    return ($lineItemCount == 1);
+  }
+
+  /**
    * Generate credit note id with next avaible number
    *
    * @return string

--- a/CRM/Core/Payment/BaseIPN.php
+++ b/CRM/Core/Payment/BaseIPN.php
@@ -649,6 +649,9 @@ LIMIT 1;";
       elseif (!empty($recurContrib->campaign_id)) {
         $contribution->campaign_id = $recurContrib->campaign_id;
       }
+      if (CRM_Contribute_BAO_Contribution::isSingleLineItem($primaryContributionID) && !empty($input['financial_type_id'])) {
+        $contribution->financial_type_id = $input['financial_type_id'];
+      }
     }
 
     $contributionStatuses = CRM_Core_PseudoConstant::get('CRM_Contribute_DAO_Contribution', 'contribution_status_id', array(
@@ -1092,6 +1095,10 @@ LIMIT 1;";
     $lineItems = CRM_Price_BAO_LineItem::getLineItemsByContributionID($originalContributionID);
     if (count($lineItems) == 1) {
       foreach ($lineItems as $index => $lineItem) {
+        if (isset($contribution->financial_type_id)) {
+          // CRM-17718 allow for possibility of changed financial type ID having been set prior to calling this.
+          $lineItems[$index]['financial_type_id'] = $contribution->financial_type_id;
+        }
         if ($lineItem['line_total'] != $contribution->total_amount) {
           // We are dealing with a changed amount! Per CRM-16397 we can work out what to do with these
           // if there is only one line item, and the UI should prevent this situation for those with more than one.

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -507,7 +507,7 @@ function civicrm_api3_contribution_repeattransaction(&$params) {
     $contribution->contribution_status_id = $params['contribution_status_id'];
     $contribution->receive_date = $params['receive_date'];
 
-    $passThroughParams = array('trxn_id', 'total_amount', 'campaign_id', 'fee_amount');
+    $passThroughParams = array('trxn_id', 'total_amount', 'campaign_id', 'fee_amount', 'financial_type_id');
     $input = array_intersect_key($params, array_fill_keys($passThroughParams, NULL));
 
     $params = _ipn_process_transaction($params, $contribution, $input, $ids, $original_contribution);
@@ -616,6 +616,16 @@ function _civicrm_api3_contribution_repeattransaction_spec(&$params) {
       'table' => 'civicrm_campaign',
       'keyColumn' => 'id',
       'labelColumn' => 'title',
+    ),
+  );
+  $params['financial_type_id'] = array(
+    'title' => 'Financial ID (ignored if more than one line item)',
+    'name' => 'financial_type_id',
+    'type' => CRM_Utils_Type::T_INT,
+    'pseudoconstant' => array(
+      'table' => 'civicrm_financial_type',
+      'keyColumn' => 'id',
+      'labelColumn' => 'name',
     ),
   );
   $params['payment_processor_id'] = array(

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -483,6 +483,14 @@ function _civicrm_api3_contribution_completetransaction_spec(&$params) {
  */
 function civicrm_api3_contribution_repeattransaction(&$params) {
   $input = $ids = array();
+  civicrm_api3_verify_one_mandatory($params, NULL, array('contribution_recur_id', 'original_contribution_id'));
+  if (empty($params['original_contribution_id'])) {
+    $params['original_contribution_id'] = civicrm_api3('contribution', 'getvalue', array(
+      'return' => 'id',
+      'contribution_recur_id' => $params['contribution_recur_id'],
+      'options' => array('limit' => 1, 'sort' => 'id DESC'),
+    ));
+  }
   $contribution = new CRM_Contribute_BAO_Contribution();
   $contribution->id = $params['original_contribution_id'];
   if (!$contribution->find(TRUE)) {
@@ -565,8 +573,12 @@ function _ipn_process_transaction(&$params, $contribution, $input, $ids, $firstC
 function _civicrm_api3_contribution_repeattransaction_spec(&$params) {
   $params['original_contribution_id'] = array(
     'title' => 'Original Contribution ID',
+    'description' => 'Contribution ID to copy (will be calculated from recurring contribution if not provided)',
     'type' => CRM_Utils_Type::T_INT,
-    'api.required' => TRUE,
+  );
+  $params['contribution_recur_id'] = array(
+    'title' => 'Recurring contribution ID',
+    'type' => CRM_Utils_Type::T_INT,
   );
   $params['trxn_id'] = array(
     'title' => 'Transaction ID',

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -49,6 +49,12 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
   protected $_params;
   protected $_ids = array();
   protected $_pageParams = array();
+  /**
+   * Payment processor ID (dummy processor).
+   *
+   * @var int
+   */
+  protected $paymentProcessorID;
 
   /**
    * Parameters to create payment processor.
@@ -72,7 +78,6 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
 
     $this->_apiversion = 3;
     $this->_individualId = $this->individualCreate();
-    $paymentProcessor = $this->processorCreate();
     $this->_params = array(
       'contact_id' => $this->_individualId,
       'receive_date' => '20120511',
@@ -95,12 +100,14 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'url_recur' => 'http://dummy.com',
       'billing_mode' => 1,
     );
+    $this->processor = $this->processorCreate();
+    $this->paymentProcessorID = $this->processor->id;
     $this->_pageParams = array(
       'title' => 'Test Contribution Page',
       'financial_type_id' => 1,
       'currency' => 'USD',
       'financial_account_id' => 1,
-      'payment_processor' => $paymentProcessor->id,
+      'payment_processor' => $this->paymentProcessorID,
       'is_active' => 1,
       'is_allow_other_amount' => 1,
       'min_amount' => 10,
@@ -1414,6 +1421,35 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test repeat contribution accepts recur_id instead of original_contribution_id.
+   */
+  public function testRepeatTransactionAcceptRecurID() {
+    $contributionRecur = $this->callAPISuccess('contribution_recur', 'create', array(
+      'contact_id' => $this->_individualId,
+      'installments' => '12',
+      'frequency_interval' => '1',
+      'amount' => '100',
+      'contribution_status_id' => 1,
+      'start_date' => '2012-01-01 00:00:00',
+      'currency' => 'USD',
+      'frequency_unit' => 'month',
+      'payment_processor_id' => $this->paymentProcessorID,
+    ));
+    $this->callAPISuccess('contribution', 'create', array_merge(
+        $this->_params,
+        array('contribution_recur_id' => $contributionRecur['id']))
+    );
+
+    $this->callAPISuccess('contribution', 'repeattransaction', array(
+      'contribution_recur_id' => $contributionRecur['id'],
+      'contribution_status_id' => 'Completed',
+      'trxn_id' => uniqid(),
+    ));
+
+    $this->quickCleanUpFinancialEntities();
+  }
+
+  /**
    * CRM-16397 test appropriate action if total amount has changed for single line items.
    */
   public function testRepeatTransactionAlteredAmount() {
@@ -1482,7 +1518,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
   }
 
   /**
-   * CRM-16397 test appropriate action if total amount has changed for single line items.
+   * CRM-16397 test appropriate action if campaign has been passed in.
    */
   public function testRepeatTransactionPassedInCampaign() {
     $paymentProcessorID = $this->paymentProcessorCreate();


### PR DESCRIPTION
…stead of original_contribution_id

wq
I feel like passing in the contribution_recur_id actually makes more sense - the internals of which contribution is repeated should be 'core business' & consistent across processors.

Importantly it has been set here to repeat the latest rather than the earliest which is not as good as saving such things as line items against the recurring transaction but
better than using the earliest - ie. pick up changes over time

Conflicts:
    tests/phpunit/api/v3/ContributionTest.php
