### PR TITLE
CRM-17718 installments should NOT be mandatory on recur edit page

### DIFF
--- a/CRM/Contribute/Form/UpdateSubscription.php
+++ b/CRM/Contribute/Form/UpdateSubscription.php
@@ -158,7 +158,7 @@ class CRM_Contribute_Form_UpdateSubscription extends CRM_Core_Form {
       TRUE, 'currency', $this->_subscriptionDetails->currency, TRUE
     );
 
-    $this->add('text', 'installments', ts('Number of Installments'), array('size' => 20), TRUE);
+    $this->add('text', 'installments', ts('Number of Installments'), array('size' => 20), FALSE);
 
     if ($this->_donorEmail) {
       $this->add('checkbox', 'is_notify', ts('Notify Contributor?'));


### PR DESCRIPTION
- this change is in 4.7 already and reflects the fact no value is required if there is no limit set

---
- [CRM-17718: Allow editing of campaign for recurring contributions AND financial type for simple contributions](https://issues.civicrm.org/jira/browse/CRM-17718)
