### PR TITLE
CRM-18033 don't remove disabled campaigns

### DIFF
--- a/CRM/Contribute/Form/UpdateSubscription.php
+++ b/CRM/Contribute/Form/UpdateSubscription.php
@@ -189,7 +189,7 @@ class CRM_Contribute_Form_UpdateSubscription extends CRM_Core_Form {
     }
 
     if (CRM_Core_Permission::check('edit contributions')) {
-      CRM_Campaign_BAO_Campaign::addCampaign($this);
+      CRM_Campaign_BAO_Campaign::addCampaign($this, $this->_subscriptionDetails->campaign_id);
     }
 
     if (CRM_Contribute_BAO_ContributionRecur::supportsFinancialTypeChange($this->contributionRecurID)) {


### PR DESCRIPTION
- [CRM-18033: Campaign field on contribution recur edit screen drops the existing campaign if disabled](https://issues.civicrm.org/jira/browse/CRM-18033)
