### PR TITLE
Revert "CRM-18019: Fix display of checkbox values on event confirmation page"

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1240,15 +1240,8 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
         }
 
         $v = array();
-        if ($html_type == 'CheckBox') {
-          foreach ($checkedData as $key => $val) {
-            $v[] = CRM_Utils_Array::value($key, $option);
-          }
-        }
-        else {
-          foreach ($checkedData as $key => $val) {
-            $v[] = CRM_Utils_Array::value($val, $option);
-          }
+        foreach ($checkedData as $key => $val) {
+          $v[] = CRM_Utils_Array::value($val, $option);
         }
         if (!empty($v)) {
           $display = implode(', ', $v);


### PR DESCRIPTION
Reverts civicrm/civicrm-core#7790

---
- [CRM-18019: Display of custom checkbox field values is broken on event confirmation page](https://issues.civicrm.org/jira/browse/CRM-18019)
