### PR TITLE
CRM-17799 -- Error type: Could not find a valid session key." when ad…

### DIFF
--- a/templates/CRM/common/customData.tpl
+++ b/templates/CRM/common/customData.tpl
@@ -48,9 +48,6 @@
       }
 
       {/literal}
-      {if $urlPathVar}
-        dataUrl += '&' + '{$urlPathVar}';
-      {/if}
       {if $groupID}
         dataUrl += '&groupID=' + '{$groupID}';
       {/if}


### PR DESCRIPTION
…ding activity via search task https://issues.civicrm.org/jira/browse/CRM-17799

As the `qfKey` param was removed in [replace the distributed custom data with the actual form](https://github.com/civicrm/civicrm-core/commit/5b15263aad651d054bfa986cde5303a34c3d3eab#diff-8dd71cd2b4ff3bc91e82e75dcdf32badR29) has one param(`urlPathVar`) left which contain the **search** form `qfKey` leading to a `session key` error.
