### PR TITLE
CRM-17038 -- custom tokens not replaced for schedule reminder

### DIFF
--- a/Civi/Token/TokenCompatSubscriber.php
+++ b/Civi/Token/TokenCompatSubscriber.php
@@ -83,6 +83,10 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
         $row->context['controller']
       );
 
+      // merge the custom tokens in the $contact array
+      if (!empty($contactArray[$contactId])) {
+        $contact = array_merge($contact, $contactArray[$contactId]);
+      }
       $row->context('contact', $contact);
     }
   }


### PR DESCRIPTION
- [CRM-17038: Custom Tokens in greetings not replaced](https://issues.civicrm.org/jira/browse/CRM-17038)
