### PR TITLE
CRM-18039 -- Do not set default for blocks if in update mode

### DIFF
--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -510,11 +510,13 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
 
       for ($instance = 1; $instance <= $this->get($blockName . '_Block_Count'); $instance++) {
         // make we require one primary block, CRM-5505
-        if ($updateMode && !$hasPrimary) {
-          $hasPrimary = CRM_Utils_Array::value(
-            'is_primary',
-            CRM_Utils_Array::value($instance, $defaults[$name])
-          );
+        if ($updateMode) {
+          if(!$hasPrimary) {
+            $hasPrimary = CRM_Utils_Array::value(
+              'is_primary',
+              CRM_Utils_Array::value($instance, $defaults[$name])
+            );
+          }
           continue;
         }
 

--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -511,7 +511,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
       for ($instance = 1; $instance <= $this->get($blockName . '_Block_Count'); $instance++) {
         // make we require one primary block, CRM-5505
         if ($updateMode) {
-          if(!$hasPrimary) {
+          if (!$hasPrimary) {
             $hasPrimary = CRM_Utils_Array::value(
               'is_primary',
               CRM_Utils_Array::value($instance, $defaults[$name])


### PR DESCRIPTION
- [CRM-18039: Error while saving contact with 2 addresses: "The Location Type should be set if there is Address information."](https://issues.civicrm.org/jira/browse/CRM-18039)
