### PR TITLE
Changes to CRM/Report/Form/Activity.php regarding Civicase permissions

### DIFF
--- a/CRM/Report/Form/Activity.php
+++ b/CRM/Report/Form/Activity.php
@@ -59,7 +59,8 @@ class CRM_Report_Form_Activity extends CRM_Report_Form {
 
     $components = CRM_Core_Component::getEnabledComponents();
     foreach ($components as $componentName => $componentInfo) {
-      if (CRM_Core_Permission::check("access $componentName")) {
+      $permission = sprintf("access %s", $componentName == 'CiviCase' ? "all cases and activities" : $componentName);
+      if (CRM_Core_Permission::check($permission)) {
         $accessAllowed[] = $componentInfo->componentID;
       }
     }


### PR DESCRIPTION
We've been investigating a problem with certain Activity types not appearing in the filtering for the Activity report for users which should be able to see them, which seems to be down to permissions checking - in the case of CiviCase, it is checking for the permission 'access CiviCase', whereas 'access all cases and activities' seems to be the permission it should be checking for this.

This PR should solve that issue, if so.
