### PR TITLE
CRM-15768, make Drupal module version consistent with other Drupal modules

### DIFF
--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -116,15 +116,15 @@ function dm_install_drupal() {
   local to="$2"
   dm_install_dir "$repo" "$to"
 
-  # set full version in .info files
+  # Set full version in .info files. See CRM-15768.
   local MODULE_DIRS=`find "$to" -type f -name "*.info"`
   for INFO in $MODULE_DIRS; do
     if [ $(uname) = "Darwin" ]; then
       ## BSD sed
-      sed -i '' "s/version = [1-9.]*/version = $DM_VERSION/g" $INFO
+      sed -i '' "s/version = \([0-9]*\.x-\)[1-9.]*/version = \1$DM_VERSION/g" $INFO
     else
       ## GNU sed
-      sed -i'' "s/version = [1-9.]*/version = $DM_VERSION/g" $INFO
+      sed -i'' "s/version = \([0-9]*\.x-\)[1-9.]*/version = \1$DM_VERSION/g" $INFO
     fi
   done
 


### PR DESCRIPTION
Drupal module version strings include the core version as 6.x, 7.x, 8.x.

The sed regex has been stripping this information, which leads to CiviCRM being reported somewhat inconsistently in Drupal's update checks. This change better preserves the core version prefix when building CiviCRM releases.

A fix for this was previously committed to civicrm-drupal, but did not "stick" due to the sed in the release build scripts overwriting that.

---
- [CRM-15768: Correct "project" and "version" values in Drupal module info files](https://issues.civicrm.org/jira/browse/CRM-15768)
