### PR TITLE
Fix CRON-breaking bug in Drupal6.php 

### DIFF
--- a/CRM/Utils/System/Drupal6.php
+++ b/CRM/Utils/System/Drupal6.php
@@ -286,7 +286,7 @@ class CRM_Utils_System_Drupal6 extends CRM_Utils_System_DrupalBase {
     global $base_url;
     $base_url = str_replace('http://', 'https://', $base_url);
   }
-  
+
   protected function getUsersTableName() {
     $userFrameworkUsersTableName = Civi::settings()->get('userFrameworkUsersTableName');
     if (empty($userFrameworkUsersTableName)) {

--- a/CRM/Utils/System/Drupal6.php
+++ b/CRM/Utils/System/Drupal6.php
@@ -286,6 +286,14 @@ class CRM_Utils_System_Drupal6 extends CRM_Utils_System_DrupalBase {
     global $base_url;
     $base_url = str_replace('http://', 'https://', $base_url);
   }
+  
+    protected function getUsersTableName() {
+    $userFrameworkUsersTableName = Civi::settings()->get('userFrameworkUsersTableName');
+    if (empty($userFrameworkUsersTableName)) {
+      $userFrameworkUsersTableName = 'users';
+    }
+    return $userFrameworkUsersTableName;
+  }
 
   /**
    * @inheritDoc

--- a/CRM/Utils/System/Drupal6.php
+++ b/CRM/Utils/System/Drupal6.php
@@ -287,7 +287,7 @@ class CRM_Utils_System_Drupal6 extends CRM_Utils_System_DrupalBase {
     $base_url = str_replace('http://', 'https://', $base_url);
   }
   
-    protected function getUsersTableName() {
+  protected function getUsersTableName() {
     $userFrameworkUsersTableName = Civi::settings()->get('userFrameworkUsersTableName');
     if (empty($userFrameworkUsersTableName)) {
       $userFrameworkUsersTableName = 'users';


### PR DESCRIPTION
Include previously missing getUsersTableName() function from CRM/Utils/System/Drupal.php.
Fixes broken CRON on CiviCRM 4.7 Drupal 6 installations.

Edit: Just to clarify, the issue was
`$php /www/sites/all/modules/civicrm/bin/cli.php -s site -u user -p pass -e Job -a execute`
`PHP Fatal error:  Call to undefined method CRM_Utils_System_Drupal6::getUsersTableName() in /www/sites/all/modules/civicrm/CRM/Utils/System/Drupal6.php on line 313`

`getUsersTableName()` was included in `CRM/Utils/System/Drupal.php` but missing in `CRM/Utils/System/Drupal6.php`. Fix is just copy paste.
