### PR TITLE
CRM-17571 - Search Builder - Activity type/status fix

### DIFF
--- a/CRM/Activity/BAO/Query.php
+++ b/CRM/Activity/BAO/Query.php
@@ -215,7 +215,10 @@ class CRM_Activity_BAO_Query {
 
       case 'activity_type':
       case 'activity_status':
-        $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause("$name.label", $op, $value, 'String');
+        list($field, $type) = array("{$name}.value", 'Integer');
+        if (in_array($op, array('LIKE', 'NOT LIKE', 'RLIKE')))
+          list($field, $type) = array("{$name}.label", 'String');
+        $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause($field, $op, $value, $type);
         list($op, $value) = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Activity_DAO_Activity', $name, $value, $op);
         $query->_qill[$grouping][] = ts('%1 %2 %3', array(1 => $fields[$name]['title'], 2 => $op, 3 => $value));
         $query->_tables[$name] = $query->_whereTables[$name] = 1;


### PR DESCRIPTION
By default, the search builder used a field label to compare with the user input. This worked fine with operators like "Like", "Not like" or "Regex".
However, for certain operators (like "=" or "In", "Not in") the field value is what needs to be compared (not label). This commits tries to solve the issue.

---
- CRM-17571: Cannot search for Activity type and status in Search Builder (it translates values incorrectly)
  https://issues.civicrm.org/jira/browse/CRM-17571
