### PR TITLE
CRM-18063 fix, exclude contact type and tags from legacy format list

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -1558,9 +1558,6 @@ class CRM_Contact_BAO_Query {
    */
   public static function legacyConvertFormValues($id, &$values) {
     $legacyElements = array(
-      'tag',
-      'contact_tags',
-      'contact_type',
       'membership_type_id',
       'membership_status_id',
       'activity_type_id',


### PR DESCRIPTION
- [CRM-18063: Tag and contact type searches stopped working after upgrade to 4.6.13](https://issues.civicrm.org/jira/browse/CRM-18063)
