### PR TITLE
CRM-18083 Trigger crmLoad for each child group when they are shown

### DIFF
--- a/templates/CRM/Group/Form/Search.tpl
+++ b/templates/CRM/Group/Form/Search.tpl
@@ -228,7 +228,7 @@
                 appendHTML += "</tr>";
               });
               $( rowID ).after( appendHTML );
-              $( rowID ).next().trigger('crmLoad');
+              $( '.parent_is_'+parent_id ).trigger('crmLoad');
             }
         });
       }


### PR DESCRIPTION
The `next()` function only _get the immediately following sibling_, and so let the other rows not editable.

---
- [CRM-18083: Only the first group children is made editable](https://issues.civicrm.org/jira/browse/CRM-18083)
