### PR TITLE
CRM-18085 remove redundant code line

### DIFF
--- a/CRM/Report/Form/Contribute/Lybunt.php
+++ b/CRM/Report/Form/Contribute/Lybunt.php
@@ -599,8 +599,6 @@ class CRM_Report_Form_Contribute_Lybunt extends CRM_Report_Form {
    * This function is called by both the api (tests) and the UI.
    */
   public function beginPostProcessCommon() {
-    // Call this first so we can construct the WHERE temp table before we get into the FROM stuff.
-    $this->storeWhereHavingClauseArray();
     $this->buildQuery();
     // @todo this acl has no test coverage and is very hard to test manually so could be fragile.
     $this->getPermissionedFTQuery($this);


### PR DESCRIPTION
Change-Id: Ib312f987253661dfbea6f8a82e7c592f68367178

---
- [CRM-18085: Remove redundant call to $this->storeWhereHavingClauseArray(); from Lybunt](https://issues.civicrm.org/jira/browse/CRM-18085)
