### PR TITLE
Fix for CRM-18061

### DIFF
--- a/CRM/Admin/Form/PaymentProcessor.php
+++ b/CRM/Admin/Form/PaymentProcessor.php
@@ -378,6 +378,10 @@ class CRM_Admin_Form_PaymentProcessor extends CRM_Admin_Form {
    * @param bool $test
    */
   public function updatePaymentProcessor(&$values, $domainID, $test) {
+    if ($test == TRUE) {
+      $values['user_name'] = $values['test_user_name'];
+      $values['password'] = $values['test_password'];
+    }	
     $params  = array_merge(array(
       'id' => $test ? $this->_testID : $this->_id,
       'domain_id' => $domainID,


### PR DESCRIPTION
Fixes issue where the live username and password clobber the test username and password when adding a payment processor or resaving it.

---
- [CRM-18061: Test secret\/publishable keys get overwritten with live keys on payment processor configuration save](https://issues.civicrm.org/jira/browse/CRM-18061)
