### PR TITLE
CRM-18091 disambiguate TRUE as not meaning 'backtrace'

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -607,7 +607,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    */
   public static function debug_query($string) {
     if (defined('CIVICRM_DEBUG_LOG_QUERY')) {
-      if (CIVICRM_DEBUG_LOG_QUERY == 'backtrace') {
+      if (CIVICRM_DEBUG_LOG_QUERY === 'backtrace') {
         CRM_Core_Error::backtrace($string, TRUE);
       }
       elseif (CIVICRM_DEBUG_LOG_QUERY) {


### PR DESCRIPTION
- [CRM-18091: Constant CIVICRM_DEBUG_LOG_QUERY equates TRUE to 'backtrace'](https://issues.civicrm.org/jira/browse/CRM-18091)
