### PR TITLE
CRM-18095 cache the debugLogger to save some file_exists checks

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -634,31 +634,33 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    * @return Log
    */
   public static function createDebugLogger($comp = '') {
-    $config = CRM_Core_Config::singleton();
+    if (!isset(\Civi::$statics[__CLASS__]['logger_file' . $comp])) {
+      $config = CRM_Core_Config::singleton();
 
-    if ($comp) {
-      $comp = $comp . '.';
-    }
-
-    $fileName = "{$config->configAndLogDir}CiviCRM." . $comp . md5($config->dsn) . '.log';
-
-    // Roll log file monthly or if greater than 256M
-    // note that PHP file functions have a limit of 2G and hence
-    // the alternative was introduce
-    if (file_exists($fileName)) {
-      $fileTime = date("Ym", filemtime($fileName));
-      $fileSize = filesize($fileName);
-      if (($fileTime < date('Ym')) ||
-        ($fileSize > 256 * 1024 * 1024) ||
-        ($fileSize < 0)
-      ) {
-        rename($fileName,
-          $fileName . '.' . date('YmdHi')
-        );
+      if ($comp) {
+        $comp = $comp . '.';
       }
-    }
 
-    return Log::singleton('file', $fileName);
+      $fileName = "{$config->configAndLogDir}CiviCRM." . $comp . md5($config->dsn) . '.log';
+
+      // Roll log file monthly or if greater than 256M
+      // note that PHP file functions have a limit of 2G and hence
+      // the alternative was introduce
+      if (file_exists($fileName)) {
+        $fileTime = date("Ym", filemtime($fileName));
+        $fileSize = filesize($fileName);
+        if (($fileTime < date('Ym')) ||
+          ($fileSize > 256 * 1024 * 1024) ||
+          ($fileSize < 0)
+        ) {
+          rename($fileName,
+            $fileName . '.' . date('YmdHi')
+          );
+        }
+      }
+      \Civi::$statics[__CLASS__]['logger_file' . $comp] = $fileName;
+    }
+    return Log::singleton('file', \Civi::$statics[__CLASS__]['logger_file' . $comp]);
   }
 
   /**


### PR DESCRIPTION
- [CRM-18095: Cache debug logger](https://issues.civicrm.org/jira/browse/CRM-18095)
