### PR TITLE
CRM-18102 - Bug fix for contribution soft save in edit contribution

### DIFF
--- a/CRM/Contribute/Form/SoftCredit.php
+++ b/CRM/Contribute/Form/SoftCredit.php
@@ -55,7 +55,7 @@ class CRM_Contribute_Form_SoftCredit {
 
       //check if any honree profile is enabled if yes then assign its profile type to $_honoreeProfileType
       // which will be used to constraint soft-credit contact type in formRule, CRM-13981
-      if ($profileId[0]) {
+      if ($profileId[0] && $profileId[2] == 1) {
         $form->_honoreeProfileType = CRM_Core_BAO_UFGroup::getContactType($profileId[0]);
       }
     }


### PR DESCRIPTION
https://issues.civicrm.org/jira/browse/CRM-18102

Issue:- Validation error occurred when we tried to soft credit to a contact in edit contribution

solution:

Contribution is made by a individual contact for a contribution page.

This contribution page has initially set-up for 'Honoree' section enabled with a profile and later this 'Honoree' section disabled.

The above action will create an entry in 'civicrm_uf_join' table with module as 'soft_credit' and entity_table as 'civicrm_contribution_page' with is_active column 1 as first and later 0(while honoree section disabled)

And let's say this profile has been created for contact type of 'Indiviual'.

Now when we try to soft credit to a contact with the type of 'Organization' throws validation error. It is because the current code checks profile type against type of contact to be soft credited to, even the contribution page is not enabled 'Honoree' section.

fix:- Type validation should be happening if 'Honoree' section is enabled for contribution page.
