### PR TITLE
CRM-18093 point query debugging to separate log file

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -611,7 +611,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
         CRM_Core_Error::backtrace($string, TRUE);
       }
       elseif (CIVICRM_DEBUG_LOG_QUERY) {
-        CRM_Core_Error::debug_var('Query', $string, TRUE, TRUE);
+        CRM_Core_Error::debug_var('Query', $string, TRUE, TRUE, 'sql_log');
       }
     }
   }


### PR DESCRIPTION
- [CRM-18093: Provide speed information on queries when CIVICRM_DEBUG_LOG_QUERY is on](https://issues.civicrm.org/jira/browse/CRM-18093)
