### PR TITLE
CRM-16722 - Fixed token fails in event registration email

### DIFF
--- a/CRM/Core/BAO/MessageTemplate.php
+++ b/CRM/Core/BAO/MessageTemplate.php
@@ -405,6 +405,7 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate {
     $domain = CRM_Core_BAO_Domain::getDomain();
     $hookTokens = array();
     $mailing = new CRM_Mailing_BAO_Mailing();
+    $mailing->subject = $subject;
     $mailing->body_text = $text;
     $mailing->body_html = $html;
     $tokens = $mailing->getTokens();
@@ -416,6 +417,12 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate {
     if ($contactID) {
       $contactParams = array('contact_id' => $contactID);
       $returnProperties = array();
+
+      if (isset($tokens['subject']['contact'])) {
+        foreach ($tokens['subject']['contact'] as $name) {
+          $returnProperties[$name] = 1;
+        }
+      }
 
       if (isset($tokens['text']['contact'])) {
         foreach ($tokens['text']['contact'] as $name) {


### PR DESCRIPTION
Found that the registration receipt flow does not check for token in Subject field, causing token that define in Subject field does not work (Unless HTML or Text fields need to load the same token). Fixed by checking Subject field for token. Tested working locally.

---
- [CRM-16722: {contact.display_name} token fails in Offline Event Registration mail (message Subject only)](https://issues.civicrm.org/jira/browse/CRM-16722)
