### PR TITLE
CRM-17767:Expose Campaign ID as a column in Campaign Dashboard page

### DIFF
--- a/templates/CRM/Campaign/Form/Search/Campaign.tpl
+++ b/templates/CRM/Campaign/Form/Search/Campaign.tpl
@@ -49,7 +49,7 @@
   <table class="campaigns">
     <thead>
     <tr class="columnheader">
-      <th class="hiddenElement">{ts}Campaign ID{/ts}</th>
+      <th>{ts}ID{/ts}</th>
       <th class="hiddenElement">{ts}Campaign Name{/ts}</th>
       <th>{ts}Title{/ts}</th>
       <th>{ts}Description{/ts}</th>
@@ -191,7 +191,7 @@
       "bLengthChange": false,
       "aaSorting": [],
       "aoColumns": [
-        {sClass: 'crm-campaign-id                   hiddenElement' },
+        {sClass: 'crm-campaign-id'                         },
         {sClass: 'crm-campaign-name                 hiddenElement' },
         {sClass: 'crmf-title'                              },
         {sClass: 'crmf-description'                        },


### PR DESCRIPTION
Made existing field visible, changed title to make field take less space.

---
- [CRM-17767: Expose Campaign ID as a column in Campaign Dashboard page.](https://issues.civicrm.org/jira/browse/CRM-17767)
