### PR TITLE
CRM-17452: CiviCase overrides case status if Sequence is used

### DIFF
--- a/Civi/CCase/SequenceListener.php
+++ b/Civi/CCase/SequenceListener.php
@@ -64,7 +64,15 @@ class SequenceListener implements CaseChangeListener {
       }
     }
 
-    // OK, the activity has completed every step in the sequence!
+    //CRM-17452 - Close the case only if all the activities are complete
+    $activities = $analyzer->getActivities();
+    foreach ($activities as $activity) {
+      if ($activity['status_id'] != $actStatuses['Completed']) {
+        return;
+      }
+    }
+
+    // OK, the all activities have completed
     civicrm_api3('Case', 'create', array(
       'id' => $analyzer->getCaseId(),
       'status_id' => 'Closed',


### PR DESCRIPTION
This fixes CRM-17452 by changing SequenceListener to check if
all the case activities are closed, instead of checking only the ones
belonging to the Sequence.

---
- [CRM-17452: CiviCase overrides case status if Sequence is used](https://issues.civicrm.org/jira/browse/CRM-17452)
