### PR TITLE
CRM-17508:jquery datepicker doesn't inherit CMS language

### DIFF
--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -752,7 +752,7 @@ class CRM_Core_Resources {
     if (CRM_Core_Permission::check('administer CiviCRM') && $this->ajaxPopupsEnabled) {
       $items[] = "js/crm.optionEdit.js";
     }
-    
+
     global $tsLocale;
     // Add localized jQuery UI files
     if ($tsLocale && $tsLocale != 'en_US') {

--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -603,8 +603,9 @@ class CRM_Core_Resources {
         }
       }
 
+      global $tsLocale;
       // Dynamic localization script
-      $this->addScriptUrl(CRM_Utils_System::url('civicrm/ajax/l10n-js/' . $config->lcMessages, array('r' => $this->getCacheCode())), $jsWeight++, $region);
+      $this->addScriptUrl(CRM_Utils_System::url('civicrm/ajax/l10n-js/' . $tsLocale, array('r' => $this->getCacheCode())), $jsWeight++, $region);
 
       // Add global settings
       $settings = array(
@@ -751,13 +752,14 @@ class CRM_Core_Resources {
     if (CRM_Core_Permission::check('administer CiviCRM') && $this->ajaxPopupsEnabled) {
       $items[] = "js/crm.optionEdit.js";
     }
-
+    
+    global $tsLocale;
     // Add localized jQuery UI files
-    if ($config->lcMessages && $config->lcMessages != 'en_US') {
+    if ($tsLocale && $tsLocale != 'en_US') {
       // Search for i18n file in order of specificity (try fr-CA, then fr)
-      list($lang) = explode('_', $config->lcMessages);
+      list($lang) = explode('_', $tsLocale);
       $path = "bower_components/jquery-ui/ui/i18n";
-      foreach (array(str_replace('_', '-', $config->lcMessages), $lang) as $language) {
+      foreach (array(str_replace('_', '-', $tsLocale), $lang) as $language) {
         $localizationFile = "$path/datepicker-{$language}.js";
         if ($this->getPath('civicrm', $localizationFile)) {
           $items[] = $localizationFile;


### PR DESCRIPTION
Localized datepicker according to rationale in issue.

---
- [CRM-17508: jquery datepicker doesn't inherit CMS language](https://issues.civicrm.org/jira/browse/CRM-17508)
