### PR TITLE
Removing unsupported status change options when the contribution is completed

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -705,7 +705,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       $name = CRM_Utils_Array::value($contributionStatus, $statusName);
       switch ($name) {
         case 'Completed':
-		  // [CRM-17498] Removing unsupported status change options.
+          // [CRM-17498] Removing unsupported status change options.
           unset($status[CRM_Utils_Array::key('Pending', $statusName)]);
           unset($status[CRM_Utils_Array::key('Failed', $statusName)]);
           unset($status[CRM_Utils_Array::key('Partially paid', $statusName)]);

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -705,6 +705,11 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       $name = CRM_Utils_Array::value($contributionStatus, $statusName);
       switch ($name) {
         case 'Completed':
+		  // [CRM-17498] Removing unsupported status change options.
+          unset($status[CRM_Utils_Array::key('Pending', $statusName)]);
+          unset($status[CRM_Utils_Array::key('Failed', $statusName)]);
+          unset($status[CRM_Utils_Array::key('Partially paid', $statusName)]);
+          unset($status[CRM_Utils_Array::key('Pending refund', $statusName)]);
         case 'Cancelled':
         case 'Chargeback':
         case 'Refunded':


### PR DESCRIPTION
As per Joe Murray's suggestion on CRM-17498 I removed the unsupported status change options from the dropdown list. I kept the validation in the case someone tries to manually manipulate the form.

---
- [CRM-17498: Issues with Pending refund contribution status.](https://issues.civicrm.org/jira/browse/CRM-17498)
