### PR TITLE
CRM-18120 remove deadlocky-ness from acl cache refreshes

### DIFF
--- a/CRM/ACL/BAO/Cache.php
+++ b/CRM/ACL/BAO/Cache.php
@@ -135,7 +135,7 @@ WHERE contact_id = %1
     self::build($id);
 
     // rebuilds civicrm_acl_contact_cache
-    CRM_Contact_BAO_Contact_Permission::cache($id, CRM_Core_Permission::VIEW, TRUE);
+    CRM_Contact_BAO_Contact_Permission::cache($id, TRUE);
   }
 
   /**

--- a/CRM/Contact/BAO/Contact/Permission.php
+++ b/CRM/Contact/BAO/Contact/Permission.php
@@ -46,13 +46,13 @@ class CRM_Contact_BAO_Contact_Permission {
     $tables = array();
     $whereTables = array();
 
-    # FIXME: push this somewhere below, to not give this permission so many rights
+    // FIXME: push this somewhere below, to not give this permission so many rights
     $isDeleted = (bool) CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $id, 'is_deleted');
     if (CRM_Core_Permission::check('access deleted contacts') && $isDeleted) {
       return TRUE;
     }
 
-    // short circuit for admin rights here so we avoid unneeeded queries
+    // short circuit for admin rights here so we avoid unneeded queries
     // some duplication of code, but we skip 3-5 queries
     if (CRM_Core_Permission::check('edit all contacts') ||
       ($type == CRM_ACL_API::VIEW && CRM_Core_Permission::check('view all contacts'))
@@ -82,21 +82,13 @@ WHERE contact_a.id = %1 AND $permission";
    * Fill the acl contact cache for this contact id if empty.
    *
    * @param int $userID
-   * @param int|string $type the type of operation (view|edit)
    * @param bool $force
    *   Should we force a recompute.
    */
-  public static function cache($userID, $type = CRM_Core_Permission::VIEW, $force = FALSE) {
+  public static function cache($userID, $force = FALSE) {
     static $_processed = array();
-
-    if ($type = CRM_Core_Permission::VIEW) {
-      $operationClause = " operation IN ( 'Edit', 'View' ) ";
-      $operation = 'View';
-    }
-    else {
-      $operationClause = " operation = 'Edit' ";
-      $operation = 'Edit';
-    }
+    $operationClause = " operation IN ( 'Edit', 'View' ) ";
+    $operation = 'View';
 
     if (!$force) {
       if (!empty($_processed[$userID])) {
@@ -121,7 +113,7 @@ AND    $operationClause
     $tables = array();
     $whereTables = array();
 
-    $permission = CRM_ACL_API::whereClause($type, $tables, $whereTables, $userID);
+    $permission = CRM_ACL_API::whereClause(CRM_Core_Permission::VIEW, $tables, $whereTables, $userID);
 
     $from = CRM_Contact_BAO_Query::fromClause($whereTables);
 

--- a/CRM/Contact/BAO/Contact/Permission.php
+++ b/CRM/Contact/BAO/Contact/Permission.php
@@ -88,7 +88,6 @@ WHERE contact_a.id = %1 AND $permission";
   public static function cache($userID, $force = FALSE) {
     static $_processed = array();
     $operationClause = " operation IN ( 'Edit', 'View' ) ";
-    $operation = 'View';
 
     if (!$force) {
       if (!empty($_processed[$userID])) {
@@ -116,18 +115,14 @@ AND    $operationClause
     $permission = CRM_ACL_API::whereClause(CRM_Core_Permission::VIEW, $tables, $whereTables, $userID);
 
     $from = CRM_Contact_BAO_Query::fromClause($whereTables);
-
     CRM_Core_DAO::executeQuery("
 INSERT INTO civicrm_acl_contact_cache ( user_id, contact_id, operation )
-SELECT      $userID as user_id, contact_a.id as contact_id, '$operation' as operation
+SELECT DISTINCT $userID as user_id, contact_a.id as contact_id, 'View' as operation
          $from
+         LEFT JOIN civicrm_acl_contact_cache ac ON ac.user_id = $userID AND contact_a.id = ac.contact_id AND ac.operation = 'View'
 WHERE    $permission
-GROUP BY contact_a.id
-ON DUPLICATE KEY UPDATE
-         user_id=VALUES(user_id),
-         contact_id=VALUES(contact_id),
-         operation=VALUES(operation)"
-    );
+AND ac.id IS NULL
+");
 
     $_processed[$userID] = 1;
   }

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -2458,7 +2458,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     $this->assertEquals(0, $result['count']);
 
     $this->hookClass->setHook('civicrm_aclWhereClause', array($this, 'aclWhereNoBobH'));
-    CRM_Contact_BAO_Contact_Permission::cache($userID, CRM_Core_Permission::VIEW, TRUE);
+    CRM_Contact_BAO_Contact_Permission::cache($userID, TRUE);
     $result = $this->callAPISuccess('contact', 'getquick', array(
       'name' => 'Bob',
       'field_name' => 'first_name',


### PR DESCRIPTION
Remove type option from cache query. The type is always set to view by
what looks like an error in the IF clause. In order not to give the
impression this is in someway working for edit, remove the variable

---
- [CRM-18120: Deadlocks on ACL contact Cache](https://issues.civicrm.org/jira/browse/CRM-18120)
