### PR TITLE
CRM-18114: DB error when exporting contact using 'merge household' op…

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -1388,7 +1388,7 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
             }
           }
           else {
-            $sqlColumns[$fieldName] = "$fieldName varchar(255)";
+            $sqlColumns[$fieldName] = "$fieldName text";
           }
         }
       }


### PR DESCRIPTION
Changed to text for columns that do not have types. The problem was caused by a temporary table having a row data size exceeding 64kb. This was caused by having a large number of wide columns. This update solves the problem for the report in question, but may have an adverse effect on performance, and the largest effect should be on this export, as a large number of columns got the type text after the change. The error message itself suggested changing the columns to text, so it should be a fairly standard approach.

Other options for solving this that I thought of include:
Reducing number of columns in the generated temporary table
Using a different datastructure where the data is divided in several tables or as rows
