### PR TITLE
CRM-18098. Move TCPDF from packages to composer.

### DIFF
--- a/CRM/Utils/PDF/Label.php
+++ b/CRM/Utils/PDF/Label.php
@@ -33,8 +33,6 @@
  * @copyright CiviCRM LLC (c) 2004-2015
  */
 
-require_once 'tcpdf/tcpdf.php';
-
 /**
  * Class CRM_Utils_PDF_Label
  */

--- a/composer.json
+++ b/composer.json
@@ -29,10 +29,12 @@
   ],
   "scripts": {
     "post-install-cmd": [
-      "bash tools/scripts/composer/dompdf-cleanup.sh"
+      "bash tools/scripts/composer/dompdf-cleanup.sh",
+      "bash tools/scripts/composer/tcpdf-cleanup.sh"
     ],
     "post-update-cmd": [
-      "bash tools/scripts/composer/dompdf-cleanup.sh"
+      "bash tools/scripts/composer/dompdf-cleanup.sh",
+      "bash tools/scripts/composer/tcpdf-cleanup.sh"
     ]
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     "symfony/process": "~2.5.0",
     "psr/log": "1.0.0",
     "symfony/finder": "~2.5.0",
+    "tecnickcom/tcpdf" : "6.2.*",
     "totten/ca-config": "~13.02",
     "civicrm/civicrm-cxn-rpc": "~0.15.12.04",
     "zetacomponents/base": "1.7.*",

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
       "Civi\\": [".", "tests/phpunit/"]
     }
   },
+  "include-path": ["vendor/tecnickcom"],
   "require": {
     "dompdf/dompdf" : "0.6.*",
     "symfony/config": "~2.5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "77c841b4a3ad8ae6b4e740251e10526f",
+    "hash": "6d663f79b264d072ee699147bc572115",
+    "content-hash": "9d0da097291dbad481650b039869f719",
     "packages": [
         {
             "name": "civicrm/civicrm-cxn-rpc",
@@ -559,6 +560,69 @@
             "description": "Symfony Process Component",
             "homepage": "http://symfony.com",
             "time": "2015-02-08 07:07:45"
+        },
+        {
+            "name": "tecnickcom/tcpdf",
+            "version": "6.2.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/tecnickcom/TCPDF.git",
+                "reference": "2f732eaa91b5665274689b1d40b285a7bacdc37f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/tecnickcom/TCPDF/zipball/2f732eaa91b5665274689b1d40b285a7bacdc37f",
+                "reference": "2f732eaa91b5665274689b1d40b285a7bacdc37f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "fonts",
+                    "config",
+                    "include",
+                    "tcpdf.php",
+                    "tcpdf_parser.php",
+                    "tcpdf_import.php",
+                    "tcpdf_barcodes_1d.php",
+                    "tcpdf_barcodes_2d.php",
+                    "include/tcpdf_colors.php",
+                    "include/tcpdf_filters.php",
+                    "include/tcpdf_font_data.php",
+                    "include/tcpdf_fonts.php",
+                    "include/tcpdf_images.php",
+                    "include/tcpdf_static.php",
+                    "include/barcodes/datamatrix.php",
+                    "include/barcodes/pdf417.php",
+                    "include/barcodes/qrcode.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPLv3"
+            ],
+            "authors": [
+                {
+                    "name": "Nicola Asuni",
+                    "email": "info@tecnick.com",
+                    "homepage": "http://nicolaasuni.tecnick.com"
+                }
+            ],
+            "description": "TCPDF is a PHP class for generating PDF documents and barcodes.",
+            "homepage": "http://www.tcpdf.org/",
+            "keywords": [
+                "PDFD32000-2008",
+                "TCPDF",
+                "barcodes",
+                "datamatrix",
+                "pdf",
+                "pdf417",
+                "qrcode"
+            ],
+            "time": "2015-09-12 10:08:34"
         },
         {
             "name": "totten/ca-config",

--- a/tools/scripts/composer/tcpdf-cleanup.sh
+++ b/tools/scripts/composer/tcpdf-cleanup.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+## Cleanup the vendor tree. The main issue here is that civi Civi is
+## deployed as a module inside a CMS, so all its source-code gets published.
+## Some libraries distribute admin tools and sample files which should not
+## be published.
+##
+## This script should be idempotent -- if you rerun it several times, it
+## should always produce the same post-condition.
+
+##############################################################################
+## usage: safe_delete <relpath...>
+function safe_delete() {
+  for file in "$@" ; do
+    if [ -z "$file" ]; then
+      echo "Skip: empty file name"
+    elif [ -e "$file" ]; then
+      rm -rf "$file"
+    fi
+  done
+}
+
+##############################################################################
+## Remove example/CLI scripts. They're not needed and increase the attack-surface.
+safe_delete vendor/tecnickcom/tcpdf/examples
+safe_delete vendor/tecnickcom/tcpdf/tools
+
+## Remove all fonts not included before CRM-18098.
+safe_delete vendor/tecnickcom/tcpdf/fonts/a*
+safe_delete vendor/tecnickcom/tcpdf/fonts/ci*
+safe_delete vendor/tecnickcom/tcpdf/fonts/courierb*
+safe_delete vendor/tecnickcom/tcpdf/fonts/courieri*
+safe_delete vendor/tecnickcom/tcpdf/fonts/dejavu-fonts-ttf-2.33
+safe_delete vendor/tecnickcom/tcpdf/fonts/dejavusansb*
+safe_delete vendor/tecnickcom/tcpdf/fonts/dejavusansc*
+safe_delete vendor/tecnickcom/tcpdf/fonts/dejavusanse*
+safe_delete vendor/tecnickcom/tcpdf/fonts/dejavusansi*
+safe_delete vendor/tecnickcom/tcpdf/fonts/dejavusansm*
+safe_delete vendor/tecnickcom/tcpdf/fonts/dejavuserif*
+safe_delete vendor/tecnickcom/tcpdf/fonts/free*
+safe_delete vendor/tecnickcom/tcpdf/fonts/helveticab*
+safe_delete vendor/tecnickcom/tcpdf/fonts/helveticai*
+safe_delete vendor/tecnickcom/tcpdf/fonts/k*
+safe_delete vendor/tecnickcom/tcpdf/fonts/m*
+safe_delete vendor/tecnickcom/tcpdf/fonts/p*
+safe_delete vendor/tecnickcom/tcpdf/fonts/s*
+safe_delete vendor/tecnickcom/tcpdf/fonts/t*
+safe_delete vendor/tecnickcom/tcpdf/fonts/u*
+safe_delete vendor/tecnickcom/tcpdf/fonts/z*

--- a/tools/scripts/composer/tcpdf-cleanup.sh
+++ b/tools/scripts/composer/tcpdf-cleanup.sh
@@ -44,6 +44,5 @@ safe_delete vendor/tecnickcom/tcpdf/fonts/k*
 safe_delete vendor/tecnickcom/tcpdf/fonts/m*
 safe_delete vendor/tecnickcom/tcpdf/fonts/p*
 safe_delete vendor/tecnickcom/tcpdf/fonts/s*
-safe_delete vendor/tecnickcom/tcpdf/fonts/t*
 safe_delete vendor/tecnickcom/tcpdf/fonts/u*
 safe_delete vendor/tecnickcom/tcpdf/fonts/z*


### PR DESCRIPTION
This is a resubmission of @xurizaemon's #7868, with the addition of two changes:
- Re-enable the 'Times New Roman' font. (I compared the contents of "Administer => CiviEvent => Name Badges" and saw the font-list changed before/after the patch.)
- Remove an unnecessary 'require_once' (which generates an error with the changes).

---
- [CRM-18098](https://issues.civicrm.org/jira/browse/CRM-18098)
