### PR TITLE
CRM-18155 Remove membership_type_id from legacyConvertFormValues

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -1558,8 +1558,6 @@ class CRM_Contact_BAO_Query {
    */
   public static function legacyConvertFormValues($id, &$values) {
     $legacyElements = array(
-      'membership_type_id',
-      'membership_status_id',
       'activity_type_id',
       'location_type',
     );


### PR DESCRIPTION
- [CRM-18155: Membership type smart group stops working in 4.6.13\/4.6.14](https://issues.civicrm.org/jira/browse/CRM-18155)
