### PR TITLE
Backport to 4.4- CRM-18112 / PR #7888 / Additional permission for editing "api_key"

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -551,6 +551,8 @@ class CRM_Core_Permission {
       'export own manual batches' => $prefix . ts('export own manual batches'),
       'export all manual batches' => $prefix . ts('export all manual batches'),
       'administer payment processors' => $prefix . ts('administer payment processors'),
+      'edit api keys' => $prefix . ts('Edit API keys'),
+      'edit own api keys' => $prefix . ts('Edit user\'s own API keys'),
     );
 
     return $permissions;

--- a/api/v3/Contact.php
+++ b/api/v3/Contact.php
@@ -62,6 +62,18 @@ function civicrm_api3_contact_create($params) {
     return $values;
   }
 
+  if (array_key_exists('api_key', $params) && !empty($params['check_permissions'])) {
+    if (CRM_Core_Permission::check('edit api keys') || CRM_Core_Permission::check('administer CiviCRM')) {
+      // OK
+    }
+    elseif ($contactID && CRM_Core_Permission::check('edit own api keys') && CRM_Core_Session::singleton()->get('userID') == $contactID) {
+      // OK
+    }
+    else {
+      throw new API_Exception('Permission denied to modify api key');
+    }
+  }
+
   if (!$contactID) {
     // If we get here, we're ready to create a new contact
     if (($email = CRM_Utils_Array::value('email', $params)) && !is_array($params['email'])) {


### PR DESCRIPTION
I've backported the fix for CIVI-SA-2016-05 to 4.4 if anyone's interested?

---
- [CRM-18112](https://issues.civicrm.org/jira/browse/CRM-18112)
