### PR TITLE
CRM-16210 fix where Uploading a file to an activity with multiple custom file fields removes the existing attached files

### DIFF
--- a/CRM/Case/Form/Activity.php
+++ b/CRM/Case/Form/Activity.php
@@ -413,6 +413,10 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
     // format activity custom data
     if (!empty($params['hidden_custom'])) {
       if ($this->_activityId) {
+        // retrieve and include the custom data of old Activity
+        $oldActivity = civicrm_api3('Activity', 'getsingle', array('id' => $this->_activityId));
+        $params = array_merge($params, $oldActivity);
+
         // unset custom fields-id from params since we want custom
         // fields to be saved for new activity.
         foreach ($params as $key => $value) {
@@ -504,8 +508,8 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
       else {
         $newActParams['original_id'] = $activity->id;
       }
-      //is_current_revision will be set to 1 by default.
 
+      //is_current_revision will be set to 1 by default.
       // add attachments if any
       CRM_Core_BAO_File::formatAttachment($newActParams,
         $newActParams,

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1619,14 +1619,27 @@ SELECT id
       $fName = $value['name'];
       $mimeType = $value['type'];
 
+      // If we are already passing the file id as a value then retrieve and set the file data
+      if (CRM_Utils_Rule::integer($value)) {
+        $fileDAO = new CRM_Core_DAO_File();
+        $fileDAO->id = $value;
+        $fileDAO->find(TRUE);
+        if ($fileDAO->N){
+          $fileID = $value;
+          $fName = $fileDAO->uri;
+          $mimeType = $fileDAO->mime_type;
+        }
+      }
+
       $filename = pathinfo($fName, PATHINFO_BASENAME);
 
-      // rename this file to go into the secure directory
-      if (!rename($fName, $config->customFileUploadDir . $filename)) {
+      // rename this file to go into the secure directory only if
+      // user has uploaded new file not existing verfied on the basis of $fileID
+      if (!$fileID && !rename($fName, $config->customFileUploadDir . $filename)) {
         CRM_Core_Error::statusBounce(ts('Could not move custom file to custom upload directory'));
       }
 
-      if ($customValueId) {
+      if ($customValueId && !$fileID) {
         $query = "
 SELECT $columnName
   FROM $tableName

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1624,7 +1624,7 @@ SELECT id
         $fileDAO = new CRM_Core_DAO_File();
         $fileDAO->id = $value;
         $fileDAO->find(TRUE);
-        if ($fileDAO->N){
+        if ($fileDAO->N) {
           $fileID = $value;
           $fName = $fileDAO->uri;
           $mimeType = $fileDAO->mime_type;


### PR DESCRIPTION
- [CRM-16210: Uploading a file to an activity with multiple custom file fields removes the existing attached files](https://issues.civicrm.org/jira/browse/CRM-16210)
