### PR TITLE
CRM-18164 - Fix display of activities when recurring activity is present

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -2604,7 +2604,7 @@ INNER JOIN  civicrm_option_group grp ON ( grp.id = val.option_group_id AND grp.n
         );
 
         if ($values['is_recurring_activity']) {
-          $contactActivities[$activityId]['is_recurring_activity'] = CRM_Core_BAO_RecurringEntity::getPositionAndCount($values['activity_id'], 'civicrm_activity');
+          $activity['is_recurring_activity'] = CRM_Core_BAO_RecurringEntity::getPositionAndCount($values['activity_id'], 'civicrm_activity');
         }
 
         array_push($contactActivities, $activity);


### PR DESCRIPTION
- [CRM-18164: Filtering group contacts by status "removed" doesn't work](https://issues.civicrm.org/jira/browse/CRM-18164)
