### PR TITLE
CRM-18156 don't false positive on security update available

### DIFF
--- a/CRM/Utils/VersionCheck.php
+++ b/CRM/Utils/VersionCheck.php
@@ -179,12 +179,17 @@ class CRM_Utils_VersionCheck {
   public function isSecurityUpdateAvailable() {
     $thisVersion = $this->getReleaseInfo($this->localVersion);
     $localVersionDate = CRM_Utils_Array::value('date', $thisVersion, 0);
-    foreach ($this->versionInfo as $majorVersion) {
+    // If not defined we will get an e-notice. That seems OK....
+    $isLTS = $this->versionInfo[$this->localMajorVersion]['status'] === 'lts' ? TRUE : FALSE;
+
+    foreach ($this->versionInfo as $majorVersionNumber => $majorVersion) {
       foreach ($majorVersion['releases'] as $release) {
         if (!empty($release['security']) && $release['date'] > $localVersionDate
           && version_compare($this->localVersion, $release['version']) < 0
         ) {
-          if (!$this->ignoreDate || $this->ignoreDate < $release['date']) {
+          if ((!$this->ignoreDate || $this->ignoreDate < $release['date'])
+            && (!$isLTS || $majorVersionNumber === $this->localMajorVersion)
+          ) {
             return TRUE;
           }
         }


### PR DESCRIPTION
- [CRM-18156: CiviCRM version 4.6.14 incorrectly shows security update required](https://issues.civicrm.org/jira/browse/CRM-18156)
