### PR TITLE
CRM-18178 exclude _bak & _backup tables from trigger creation

### DIFF
--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -127,6 +127,9 @@ AND    TABLE_NAME LIKE 'civicrm_%'
     //CRM-14672
     $this->tables = preg_grep('/^civicrm_menu/', $this->tables, PREG_GREP_INVERT);
     $this->tables = preg_grep('/_temp_/', $this->tables, PREG_GREP_INVERT);
+    // CRM-18178
+    $this->tables = preg_grep('/_bak$/', $this->tables, PREG_GREP_INVERT);
+    $this->tables = preg_grep('/_backup$/', $this->tables, PREG_GREP_INVERT);
 
     // do not log civicrm_mailing_event* tables, CRM-12300
     $this->tables = preg_grep('/^civicrm_mailing_event_/', $this->tables, PREG_GREP_INVERT);


### PR DESCRIPTION
- [CRM-18178: Skip _bak & _backup tables when generating log tables & triggers](https://issues.civicrm.org/jira/browse/CRM-18178)
