### PR TITLE
CRM-18106 create activity against contact deleted by merge

### DIFF
--- a/CRM/Upgrade/Incremental/php/FourSeven.php
+++ b/CRM/Upgrade/Incremental/php/FourSeven.php
@@ -175,6 +175,15 @@ class CRM_Upgrade_Incremental_php_FourSeven extends CRM_Upgrade_Incremental_Base
   }
 
   /**
+   * Upgrade function.
+   *
+   * @param string $rev
+   */
+  public function upgrade_4_7_4($rev) {
+    $this->addTask('Add Contact Deleted by Merge Activity Type', 'addDeletedByMergeActivityType');
+  }
+
+  /**
    * CRM-16354
    *
    * @return int
@@ -522,6 +531,27 @@ FROM `civicrm_dashboard_contact` WHERE 1 GROUP BY contact_id";
   public function addIndexContributionAmount(CRM_Queue_TaskContext $ctx) {
     CRM_Core_BAO_SchemaHandler::createIndexes(array(
       'civicrm_contribution' => array(array('total_amount', 'receive_date')),
+    ));
+    return TRUE;
+  }
+
+  /**
+   * CRM-18124 Add index to civicrm_contribution.total_amount.
+   *
+   * Note that I made this a combined index with receive_date because the issue included
+   * both criteria and they seemed likely to be used in conjunction to me in other cases.
+   *
+   * @param \CRM_Queue_TaskContext $ctx
+   *
+   * @return bool
+   */
+  public function addDeletedByMergeActivityType(CRM_Queue_TaskContext $ctx) {
+    CRM_Core_BAO_OptionValue::ensureOptionValueExists(array(
+      'option_group_id' => 'activity_type',
+      'name' => 'Contact Deleted by Merge',
+      'label' => ts('Contact Deleted by Merge'),
+      'description' => ts('Contact was merged into another contact'),
+      'is_active' => TRUE,
     ));
     return TRUE;
   }

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -2872,6 +2872,16 @@ class api_v3_ContactTest extends CiviUnitTestCase {
       'activity_type_id' => 'Contact Merged',
     ));
     $this->assertEquals(date('Y-m-d'), date('Y-m-d', strtotime($activity['activity_date_time'])));
+    $activity2 = $this->callAPISuccess('Activity', 'getsingle', array(
+      'target_contact_id' => $otherContact['id'],
+      'activity_type_id' => 'Contact Deleted by Merge',
+    ));
+    $this->assertEquals($activity['id'], $activity2['parent_id']);
+    $this->assertEquals('Normal', civicrm_api3('option_value', 'getvalue', array(
+      'value' => $activity['priority_id'],
+      'return' => 'label',
+      'option_group_id' => 'priority',
+    )));
 
   }
 

--- a/xml/templates/civicrm_data.tpl
+++ b/xml/templates/civicrm_data.tpl
@@ -381,9 +381,10 @@ VALUES
 
   -- for manual contact merge
    (@option_group_id_act, '{ts escape="sql"}Contact Merged{/ts}', 51, 'Contact Merged', NULL, 1, NULL, 51, '{ts escape="sql"}Contact Merged{/ts}',0, 1, 1, NULL, NULL),
+   (@option_group_id_act, '{ts escape="sql"}Contact Deleted by Merge{/ts}', 52, 'Contact Deleted by Merge', NULL, 1, NULL, 52, '{ts escape="sql"}Contact was merged into another contact{/ts}',0, 1, 1, NULL, NULL),
 
   -- Activity Type for failed payment
-   (@option_group_id_act, 'Failed Payment', 52, 'Failed Payment', NULL, 1, 0, 43, 'Failed Payment', 0, 1, 1, @contributeCompId, NULL),
+   (@option_group_id_act, 'Failed Payment', 53, 'Failed Payment', NULL, 1, 0, 53, 'Failed Payment', 0, 1, 1, @contributeCompId, NULL),
 
    (@option_group_id_gender, '{ts escape="sql"}Female{/ts}',      1, 'Female',      NULL, 0, NULL, 1, NULL, 0, 0, 1, NULL, NULL),
    (@option_group_id_gender, '{ts escape="sql"}Male{/ts}',        2, 'Male',        NULL, 0, NULL, 2, NULL, 0, 0, 1, NULL, NULL),


### PR DESCRIPTION
Note that in discussion on the ticket & IRC we talked about storing more data in the activity details - I'm treating that as a potential stage 2 at the moment (and investigating logging reversals)

---
- [CRM-18106: Add activity to deleted contacts showing they were deleted by merge](https://issues.civicrm.org/jira/browse/CRM-18106)
