### PR TITLE
CRM-18197: Activity report: fix view-contact links when multiple assign/targets.

### DIFF
--- a/CRM/Report/Form/Activity.php
+++ b/CRM/Report/Form/Activity.php
@@ -433,7 +433,7 @@ class CRM_Report_Form_Activity extends CRM_Report_Form {
           strstr($clause, 'civicrm_email_contact_target_email') ||
           strstr($clause, 'civicrm_phone_contact_target_phone')
         ) {
-          $this->_selectClauses[$key] = "GROUP_CONCAT($clause SEPARATOR '; ') as $clause";
+          $this->_selectClauses[$key] = "GROUP_CONCAT($clause SEPARATOR ';') as $clause";
         }
       }
     }


### PR DESCRIPTION
- [CRM-18197: Activity report: activities with multiple targets have broken links to contact record](https://issues.civicrm.org/jira/browse/CRM-18197)
