### PR TITLE
CRM-18194 - Bug fix for group type set to empty while updating Group

### DIFF
--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -368,7 +368,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
       }
     }
     else {
-      $params['group_type'] = '';
+      $params['group_type'] = NULL;
     }
 
     $session = CRM_Core_Session::singleton();

--- a/CRM/Group/Form/Edit.php
+++ b/CRM/Group/Form/Edit.php
@@ -384,6 +384,7 @@ WHERE  title = %1
       }
 
       $params['is_reserved'] = CRM_Utils_Array::value('is_reserved', $params, FALSE);
+      $params['group_type'] = CRM_Utils_Array::value('group_type', $params, array());
 
       $customFields = CRM_Core_BAO_CustomField::getFields('Group');
       $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params,


### PR DESCRIPTION
---
- CRM-18194: Group Type is set to empty while updating Group
  https://issues.civicrm.org/jira/browse/CRM-18194
