### PR TITLE
CRM-18193 make unique ID for request available to php & mysql

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -112,6 +112,7 @@ class CRM_Core_DAO extends DB_DataObject {
       CRM_Core_DAO::executeQuery('SET SESSION sql_mode = STRICT_TRANS_TABLES');
     }
     CRM_Core_DAO::executeQuery('SET NAMES utf8');
+    CRM_Core_DAO::executeQuery('SET @uniqueID = %1', array(1 => array(CRM_Utils_Request::id(), 'String')));
   }
 
   /**

--- a/CRM/Utils/Request.php
+++ b/CRM/Utils/Request.php
@@ -37,6 +37,34 @@
 class CRM_Utils_Request {
 
   /**
+   * Get a unique ID for the request.
+   *
+   * This unique ID is assigned to mysql when the connection is opened and is
+   * available in PHP.
+   *
+   * The intent is that it is available for logging purposes and for triggers.
+   *
+   * The resulting string is 17 characters long. This consists of 13 characters of uniqid
+   * and 4 more random characters.
+   *
+   * Uniqid is unique to the microsecond - to make it more unique we add 4 more characters
+   * but stop short of the full 23 character string that a prefix would generate.
+   *
+   * It is intended that this string will be saved to log tables so striking a balance between
+   * uniqueness and length is important. Note that I did check & lining up with byte values
+   * (e.g 16 characters) does not confer any benefits. Using a CHAR field rather than VARCHAR
+   * may improve speed, if indexed.
+   *
+   * @return string
+   */
+  public static function id() {
+    if (!isset(\Civi::$statics[__CLASS__]['id'])) {
+      \Civi::$statics[__CLASS__]['id'] = uniqid() . CRM_Utils_String::createRandom(CRM_Utils_String::ALPHANUMERIC, 4);
+    }
+    return \Civi::$statics[__CLASS__]['id'];
+  }
+
+  /**
    * Retrieve a value from the request (GET/POST/REQUEST)
    *
    * @param string $name


### PR DESCRIPTION
- [CRM-18193: Use unique log_conn_id in logging](https://issues.civicrm.org/jira/browse/CRM-18193)
