### PR TITLE
CRM-18213 remove hard-coding of DAO names

### DIFF
--- a/CRM/Logging/Differ.php
+++ b/CRM/Logging/Differ.php
@@ -257,25 +257,8 @@ WHERE lt.log_conn_id = %1 AND
     static $titles = array();
     static $values = array();
 
-    // FIXME: split off the table → DAO mapping to a GenCode-generated class
-    static $daos = array(
-      'civicrm_address' => 'CRM_Core_DAO_Address',
-      'civicrm_contact' => 'CRM_Contact_DAO_Contact',
-      'civicrm_email' => 'CRM_Core_DAO_Email',
-      'civicrm_im' => 'CRM_Core_DAO_IM',
-      'civicrm_openid' => 'CRM_Core_DAO_OpenID',
-      'civicrm_phone' => 'CRM_Core_DAO_Phone',
-      'civicrm_website' => 'CRM_Core_DAO_Website',
-      'civicrm_contribution' => 'CRM_Contribute_DAO_Contribution',
-      'civicrm_note' => 'CRM_Core_DAO_Note',
-      'civicrm_relationship' => 'CRM_Contact_DAO_Relationship',
-      'civicrm_activity' => 'CRM_Activity_DAO_Activity',
-      'civicrm_case' => 'CRM_Case_DAO_Case',
-    );
-
     if (!isset($titles[$table]) or !isset($values[$table])) {
-
-      if (in_array($table, array_keys($daos))) {
+      if (($tableDAO = CRM_Core_DAO_AllCoreTables::getClassForTable($table)) != FALSE) {
         // FIXME: these should be populated with pseudo constants as they
         // were at the time of logging rather than their current values
         // FIXME: Use *_BAO:buildOptions() method rather than pseudoconstants & fetch programmatically
@@ -311,7 +294,7 @@ WHERE lt.log_conn_id = %1 AND
             break;
         }
 
-        $dao = new $daos[$table]();
+        $dao = new $tableDAO();
         foreach ($dao->fields() as $field) {
           $titles[$table][$field['name']] = CRM_Utils_Array::value('title', $field);
 

--- a/CRM/Logging/Reverter.php
+++ b/CRM/Logging/Reverter.php
@@ -49,22 +49,11 @@ class CRM_Logging_Reverter {
   }
 
   /**
+   * Revert changes in the array of diffs in $this->diffs.
+   *
    * @param $tables
    */
   public function revert($tables) {
-    // FIXME: split off the table → DAO mapping to a GenCode-generated class
-    $daos = array(
-      'civicrm_address' => 'CRM_Core_DAO_Address',
-      'civicrm_contact' => 'CRM_Contact_DAO_Contact',
-      'civicrm_email' => 'CRM_Core_DAO_Email',
-      'civicrm_im' => 'CRM_Core_DAO_IM',
-      'civicrm_openid' => 'CRM_Core_DAO_OpenID',
-      'civicrm_phone' => 'CRM_Core_DAO_Phone',
-      'civicrm_website' => 'CRM_Core_DAO_Website',
-      'civicrm_contribution' => 'CRM_Contribute_DAO_Contribution',
-      'civicrm_note' => 'CRM_Core_DAO_Note',
-      'civicrm_relationship' => 'CRM_Contact_DAO_Relationship',
-    );
 
     // get custom data tables, columns and types
     $ctypes = array();
@@ -109,14 +98,13 @@ class CRM_Logging_Reverter {
     foreach ($deletes as $table => $ids) {
       CRM_Core_DAO::executeQuery("DELETE FROM `$table` WHERE id IN (" . implode(', ', array_unique($ids)) . ')');
     }
-
     // revert updates by updating to previous values
     foreach ($reverts as $table => $row) {
       switch (TRUE) {
         // DAO-based tables
 
-        case in_array($table, array_keys($daos)):
-          $dao = new $daos[$table]();
+        case (($tableDAO = CRM_Core_DAO_AllCoreTables::getClassForTable($table)) != FALSE):
+          $dao = new $tableDAO ();
           foreach ($row as $id => $changes) {
             $dao->id = $id;
             foreach ($changes as $field => $value) {


### PR DESCRIPTION
- [CRM-18213: Per fix me : \/\/ FIXME: split off the table → DAO mapping to a GenCode-generated class](https://issues.civicrm.org/jira/browse/CRM-18213)
