### PR TITLE
CRM-18236 - demonstrate bug with test for reminder (incorrectly) repeating on same day 

### DIFF
--- a/tests/phpunit/CRM/Core/BAO/ActionScheduleTest.php
+++ b/tests/phpunit/CRM/Core/BAO/ActionScheduleTest.php
@@ -1289,6 +1289,13 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
         'recipients' => array(array('member@example.com')),
       ),
     ));
+    $this->assertCronRuns(array(
+      array(
+        // It should not re-send on the same day
+        'time' => '2012-04-12 01:00:00',
+        'recipients' => array(array()),
+      ),
+    ));
   }
 
   public function testMembershipOnMultipleReminder() {


### PR DESCRIPTION
- [CRM-18236: Scheduled reminder sends multiple reminders when reference date has changed](https://issues.civicrm.org/jira/browse/CRM-18236)
