### PR TITLE
CRM-17406 update token list for scheduled reminders

### DIFF
--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -667,6 +667,7 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
     $tokens = array_merge(CRM_Core_SelectValues::activityTokens(), $tokens);
     $tokens = array_merge(CRM_Core_SelectValues::eventTokens(), $tokens);
     $tokens = array_merge(CRM_Core_SelectValues::membershipTokens(), $tokens);
+    $tokens = array_merge(CRM_Core_SelectValues::contributionTokens(), $tokens);
     return $tokens;
   }
 


### PR DESCRIPTION
Processing capability for contribution tokens already exists.  This is just adding them to the token dropdown list for easy selection for email.

---
- [CRM-17406: No Contribution tokens available for scheduled reminders](https://issues.civicrm.org/jira/browse/CRM-17406)
