### PR TITLE
CRM-17846 - Fixing lock name to be less than 64 characters for MySQL 5.7 compatibility

### DIFF
--- a/CRM/Core/Lock.php
+++ b/CRM/Core/Lock.php
@@ -122,7 +122,7 @@ class CRM_Core_Lock implements \Civi\Core\Lock\LockInterface {
       $this->_name = $database . '.' . $domainID . '.' . $name;
     }
     if (strlen($this->_name) > 64) {
-      $this->_name = sha1( $this->_name );
+      $this->_name = sha1($this->_name);
     }
     if (defined('CIVICRM_LOCK_DEBUG')) {
       CRM_Core_Error::debug_log_message('trying to construct lock for ' . $this->_name);

--- a/CRM/Core/Lock.php
+++ b/CRM/Core/Lock.php
@@ -121,6 +121,9 @@ class CRM_Core_Lock implements \Civi\Core\Lock\LockInterface {
     else {
       $this->_name = $database . '.' . $domainID . '.' . $name;
     }
+    if (strlen($this->_name) > 64) {
+      $this->_name = sha1( $this->_name );
+    }
     if (defined('CIVICRM_LOCK_DEBUG')) {
       CRM_Core_Error::debug_log_message('trying to construct lock for ' . $this->_name);
     }

--- a/CRM/Core/Lock.php
+++ b/CRM/Core/Lock.php
@@ -145,7 +145,7 @@ class CRM_Core_Lock implements \Civi\Core\Lock\LockInterface {
    */
   public function acquire($timeout = NULL) {
     if (!$this->_hasLock) {
-      if (self::$jobLog && CRM_Core_DAO::singleValueQuery("SELECT IS_USED_LOCK( '" . self::$jobLog . "')")) {
+      if (self::$jobLog && CRM_Core_DAO::singleValueQuery("SELECT IS_USED_LOCK( '" . $this->_id . "')")) {
         return $this->hackyHandleBrokenCode(self::$jobLog);
       }
 

--- a/CRM/Core/Lock.php
+++ b/CRM/Core/Lock.php
@@ -104,8 +104,6 @@ class CRM_Core_Lock implements \Civi\Core\Lock\LockInterface {
    *
    *   Categories: worker|data|cache|...
    *   Component: core|mailing|member|contribute|...
-   * @param string $id
-   *   Sha1 hash of the name as lock names > 64 chars no longer valid
    * @param int $timeout
    *   The number of seconds to wait to get the lock. 1 if not set.
    * @param bool $serverWideLock
@@ -128,7 +126,7 @@ class CRM_Core_Lock implements \Civi\Core\Lock\LockInterface {
     // MySQL 5.7 doesn't like long lock names so creating a lock id
     $this->_id = sha1($this->_name);
     if (defined('CIVICRM_LOCK_DEBUG')) {
-      CRM_Core_Error::debug_log_message('trying to construct lock for ' . $this->_name . '('. $this->_id .')');
+      CRM_Core_Error::debug_log_message('trying to construct lock for ' . $this->_name . '(' . $this->_id . ')');
     }
     $this->_timeout = $timeout !== NULL ? $timeout : self::TIMEOUT;
   }
@@ -159,7 +157,7 @@ class CRM_Core_Lock implements \Civi\Core\Lock\LockInterface {
       $res = CRM_Core_DAO::singleValueQuery($query, $params);
       if ($res) {
         if (defined('CIVICRM_LOCK_DEBUG')) {
-          CRM_Core_Error::debug_log_message('acquire lock for ' . $this->_name . '('. $this->_id .')');
+          CRM_Core_Error::debug_log_message('acquire lock for ' . $this->_name . '(' . $this->_id . ')');
         }
         $this->_hasLock = TRUE;
         if (stristr($this->_name, 'data.mailing.job.')) {
@@ -168,7 +166,7 @@ class CRM_Core_Lock implements \Civi\Core\Lock\LockInterface {
       }
       else {
         if (defined('CIVICRM_LOCK_DEBUG')) {
-          CRM_Core_Error::debug_log_message('failed to acquire lock for ' . $this->_name . '('. $this->_id .')');
+          CRM_Core_Error::debug_log_message('failed to acquire lock for ' . $this->_name . '(' . $this->_id . ')');
         }
       }
     }
@@ -181,7 +179,7 @@ class CRM_Core_Lock implements \Civi\Core\Lock\LockInterface {
   public function release() {
     if ($this->_hasLock) {
       if (defined('CIVICRM_LOCK_DEBUG')) {
-        CRM_Core_Error::debug_log_message('release lock for ' . $this->_name . '('. $this->_id .')');
+        CRM_Core_Error::debug_log_message('release lock for ' . $this->_name . '(' . $this->_id . ')');
       }
       $this->_hasLock = FALSE;
 
@@ -226,11 +224,11 @@ class CRM_Core_Lock implements \Civi\Core\Lock\LockInterface {
    */
   public function hackyHandleBrokenCode($jobLog) {
     if (stristr($this->_name, 'job')) {
-      CRM_Core_Error::debug_log_message('lock acquisition for ' . $this->_name . '('. $this->_id .')' . ' attempted when ' . $jobLog . ' is not released');
-      throw new CRM_Core_Exception('lock acquisition for ' . $this->_name . '('. $this->_id .')' . ' attempted when ' . $jobLog . ' is not released');
+      CRM_Core_Error::debug_log_message('lock acquisition for ' . $this->_name . '(' . $this->_id . ')' . ' attempted when ' . $jobLog . ' is not released');
+      throw new CRM_Core_Exception('lock acquisition for ' . $this->_name . '(' . $this->_id . ')' . ' attempted when ' . $jobLog . ' is not released');
     }
     if (defined('CIVICRM_LOCK_DEBUG')) {
-      CRM_Core_Error::debug_log_message('(CRM-12856) faking lock for ' . $this->_name . '('. $this->_id .')');
+      CRM_Core_Error::debug_log_message('(CRM-12856) faking lock for ' . $this->_name . '(' . $this->_id . ')');
     }
     $this->_hasLock = TRUE;
     return TRUE;

--- a/CRM/Core/Lock.php
+++ b/CRM/Core/Lock.php
@@ -230,8 +230,8 @@ class CRM_Core_Lock implements \Civi\Core\Lock\LockInterface {
     if (defined('CIVICRM_LOCK_DEBUG')) {
       CRM_Core_Error::debug_log_message('(CRM-12856) faking lock for ' . $this->_name . '(' . $this->_id . ')');
     }
-    $this->_hasLock = FALSE;
-    return FALSE;
+    $this->_hasLock = TRUE;
+    return TRUE;
   }
 
 }

--- a/CRM/Core/Lock.php
+++ b/CRM/Core/Lock.php
@@ -43,6 +43,8 @@ class CRM_Core_Lock implements \Civi\Core\Lock\LockInterface {
 
   protected $_name;
 
+  protected $_id;
+
   /**
    * Use MySQL's GET_LOCK(). Locks are shared across all Civi instances
    * on the same MySQL server.
@@ -102,6 +104,8 @@ class CRM_Core_Lock implements \Civi\Core\Lock\LockInterface {
    *
    *   Categories: worker|data|cache|...
    *   Component: core|mailing|member|contribute|...
+   * @param string $id
+   *   Sha1 hash of the name as lock names > 64 chars no longer valid
    * @param int $timeout
    *   The number of seconds to wait to get the lock. 1 if not set.
    * @param bool $serverWideLock
@@ -121,11 +125,10 @@ class CRM_Core_Lock implements \Civi\Core\Lock\LockInterface {
     else {
       $this->_name = $database . '.' . $domainID . '.' . $name;
     }
-    if (strlen($this->_name) > 64) {
-      $this->_name = sha1($this->_name);
-    }
+    // MySQL 5.7 doesn't like long lock names so creating a lock id
+    $this->_id = sha1($this->_name);
     if (defined('CIVICRM_LOCK_DEBUG')) {
-      CRM_Core_Error::debug_log_message('trying to construct lock for ' . $this->_name);
+      CRM_Core_Error::debug_log_message('trying to construct lock for ' . $this->_name . '('. $this->_id .')');
     }
     $this->_timeout = $timeout !== NULL ? $timeout : self::TIMEOUT;
   }
@@ -150,13 +153,13 @@ class CRM_Core_Lock implements \Civi\Core\Lock\LockInterface {
 
       $query = "SELECT GET_LOCK( %1, %2 )";
       $params = array(
-        1 => array($this->_name, 'String'),
+        1 => array($this->_id, 'String'),
         2 => array($timeout ? $timeout : $this->_timeout, 'Integer'),
       );
       $res = CRM_Core_DAO::singleValueQuery($query, $params);
       if ($res) {
         if (defined('CIVICRM_LOCK_DEBUG')) {
-          CRM_Core_Error::debug_log_message('acquire lock for ' . $this->_name);
+          CRM_Core_Error::debug_log_message('acquire lock for ' . $this->_name . '('. $this->_id .')');
         }
         $this->_hasLock = TRUE;
         if (stristr($this->_name, 'data.mailing.job.')) {
@@ -165,7 +168,7 @@ class CRM_Core_Lock implements \Civi\Core\Lock\LockInterface {
       }
       else {
         if (defined('CIVICRM_LOCK_DEBUG')) {
-          CRM_Core_Error::debug_log_message('failed to acquire lock for ' . $this->_name);
+          CRM_Core_Error::debug_log_message('failed to acquire lock for ' . $this->_name . '('. $this->_id .')');
         }
       }
     }
@@ -178,7 +181,7 @@ class CRM_Core_Lock implements \Civi\Core\Lock\LockInterface {
   public function release() {
     if ($this->_hasLock) {
       if (defined('CIVICRM_LOCK_DEBUG')) {
-        CRM_Core_Error::debug_log_message('release lock for ' . $this->_name);
+        CRM_Core_Error::debug_log_message('release lock for ' . $this->_name . '('. $this->_id .')');
       }
       $this->_hasLock = FALSE;
 
@@ -187,7 +190,7 @@ class CRM_Core_Lock implements \Civi\Core\Lock\LockInterface {
       }
 
       $query = "SELECT RELEASE_LOCK( %1 )";
-      $params = array(1 => array($this->_name, 'String'));
+      $params = array(1 => array($this->_id, 'String'));
       return CRM_Core_DAO::singleValueQuery($query, $params);
     }
   }
@@ -197,7 +200,7 @@ class CRM_Core_Lock implements \Civi\Core\Lock\LockInterface {
    */
   public function isFree() {
     $query = "SELECT IS_FREE_LOCK( %1 )";
-    $params = array(1 => array($this->_name, 'String'));
+    $params = array(1 => array($this->_id, 'String'));
     return CRM_Core_DAO::singleValueQuery($query, $params);
   }
 
@@ -223,11 +226,11 @@ class CRM_Core_Lock implements \Civi\Core\Lock\LockInterface {
    */
   public function hackyHandleBrokenCode($jobLog) {
     if (stristr($this->_name, 'job')) {
-      CRM_Core_Error::debug_log_message('lock acquisition for ' . $this->_name . ' attempted when ' . $jobLog . ' is not released');
-      throw new CRM_Core_Exception('lock acquisition for ' . $this->_name . ' attempted when ' . $jobLog . ' is not released');
+      CRM_Core_Error::debug_log_message('lock acquisition for ' . $this->_name . '('. $this->_id .')' . ' attempted when ' . $jobLog . ' is not released');
+      throw new CRM_Core_Exception('lock acquisition for ' . $this->_name . '('. $this->_id .')' . ' attempted when ' . $jobLog . ' is not released');
     }
     if (defined('CIVICRM_LOCK_DEBUG')) {
-      CRM_Core_Error::debug_log_message('(CRM-12856) faking lock for ' . $this->_name);
+      CRM_Core_Error::debug_log_message('(CRM-12856) faking lock for ' . $this->_name . '('. $this->_id .')');
     }
     $this->_hasLock = TRUE;
     return TRUE;

--- a/CRM/Core/Lock.php
+++ b/CRM/Core/Lock.php
@@ -230,8 +230,8 @@ class CRM_Core_Lock implements \Civi\Core\Lock\LockInterface {
     if (defined('CIVICRM_LOCK_DEBUG')) {
       CRM_Core_Error::debug_log_message('(CRM-12856) faking lock for ' . $this->_name . '(' . $this->_id . ')');
     }
-    $this->_hasLock = TRUE;
-    return TRUE;
+    $this->_hasLock = FALSE;
+    return FALSE;
   }
 
 }


### PR DESCRIPTION
Self explanatory, with thanks to https://gerrit.wikimedia.org/r/#/c/259450/2/includes/db/DatabaseMysqlBase.php

---
- [CRM-17846: Improving locks for CiviMail](https://issues.civicrm.org/jira/browse/CRM-17846)
