### PR TITLE
CRM-17846 - Fixing lock name to be less than 64 characters for MySQL 5.7 compatibility

### DIFF
--- a/CRM/Core/Lock.php
+++ b/CRM/Core/Lock.php
@@ -67,7 +67,7 @@ class CRM_Core_Lock {
       $this->_name = $database . '.' . $domainID . '.' . $name;
     }
     if (strlen($this->_name) > 64) {
-      $this->_name = sha1( $this->_name );
+      $this->_name = sha1($this->_name);
     }
     if (defined('CIVICRM_LOCK_DEBUG')) {
       CRM_Core_Error::debug_log_message('trying to construct lock for ' . $this->_name);

--- a/CRM/Core/Lock.php
+++ b/CRM/Core/Lock.php
@@ -66,6 +66,9 @@ class CRM_Core_Lock {
     else {
       $this->_name = $database . '.' . $domainID . '.' . $name;
     }
+    if (strlen($this->_name) > 64) {
+      $this->_name = sha1( $this->_name );
+    }
     if (defined('CIVICRM_LOCK_DEBUG')) {
       CRM_Core_Error::debug_log_message('trying to construct lock for ' . $this->_name);
     }


### PR DESCRIPTION
for 4.4LTS

---
- [CRM-17846: Improving locks for CiviMail](https://issues.civicrm.org/jira/browse/CRM-17846)
