### PR TITLE
CRM-18193, CRM-18104, CRM-18180 logging definition enhancements

### DIFF
--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -662,9 +662,7 @@ COLS;
    * Predicate whether logging is enabled.
    */
   public function isEnabled() {
-    $config = CRM_Core_Config::singleton();
-
-    if ($config->logging) {
+    if (CRM_Core_Config::singleton()->logging) {
       return $this->tablesExist() and $this->triggersExist();
     }
     return FALSE;
@@ -675,6 +673,19 @@ COLS;
    */
   private function tablesExist() {
     return !empty($this->logs);
+  }
+
+  /**
+   * Drop all log tables.
+   *
+   * This does not currently have a usage outside the tests.
+   */
+  public function dropAllLogTables() {
+    if ($this->tablesExist()) {
+      foreach ($this->logs as $log_table) {
+        CRM_Core_DAO::executeQuery("DROP TABLE $log_table");
+      }
+    }
   }
 
   /**

--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -57,6 +57,18 @@ class CRM_Logging_Schema {
   );
 
   /**
+   * Specifications of all log table including
+   *  - engine (default is archive, if not set.)
+   *  - indexes (default is none and they cannot be added unless engine is innodb. If they are added and
+   *    engine is not set to innodb an exception will be thrown since quiet acquiescence is easier to miss).
+   *  - exceptions (by default those stored in $this->exceptions are included). These are
+   *    excluded from the triggers.
+   *
+   * @var array
+   */
+  private $logTableSpec = array();
+
+  /**
    * Setting Callback - Validate.
    *
    * @param mixed $value
@@ -136,6 +148,12 @@ AND    TABLE_NAME LIKE 'civicrm_%'
 
     // do not log civicrm_mailing_recipients table, CRM-16193
     $this->tables = array_diff($this->tables, array('civicrm_mailing_recipients'));
+    $this->logTableSpec = array_fill_keys($this->tables, array());
+    foreach ($this->exceptions as $tableName => $fields) {
+      $this->logTableSpec[$tableName]['exceptions'] = $fields;
+    }
+    CRM_Utils_Hook::alterLogTables($this->logTableSpec);
+    $this->tables = array_keys($this->logTableSpec);
 
     if (defined('CIVICRM_LOGGING_DSN')) {
       $dsn = DB::parseDSN(CIVICRM_LOGGING_DSN);
@@ -583,6 +601,15 @@ WHERE  table_schema IN ('{$this->db}', '{$civiDB}')";
             log_action  ENUM('Initialization', 'Insert', 'Update', 'Delete')
 COLS;
 
+    if (!empty($this->logTableSpec[$table]['indexes'])) {
+      foreach ($this->logTableSpec[$table]['indexes'] as $indexName => $indexSpec) {
+        if (is_array($indexSpec)) {
+          $indexSpec = implode(" , ", $indexSpec);
+        }
+        $cols .= ", INDEX {$indexName}($indexSpec)";
+      }
+    }
+
     // - prepend the name with log_
     // - drop AUTO_INCREMENT columns
     // - drop non-column rows of the query (keys, constraints, etc.)
@@ -591,7 +618,8 @@ COLS;
     $query = preg_replace("/^CREATE TABLE `$table`/i", "CREATE TABLE `{$this->db}`.log_$table", $query);
     $query = preg_replace("/ AUTO_INCREMENT/i", '', $query);
     $query = preg_replace("/^  [^`].*$/m", '', $query);
-    $query = preg_replace("/^\) ENGINE=[^ ]+ /im", ') ENGINE=ARCHIVE ', $query);
+    $engine = strtoupper(CRM_Utils_Array::value('engine', $this->logTableSpec[$table], 'ARCHIVE'));
+    $query = preg_replace("/^\) ENGINE=[^ ]+ /im", ') ENGINE=' . $engine . ' ', $query);
 
     // log_civicrm_contact.modified_date for example would always be copied from civicrm_contact.modified_date,
     // so there's no need for a default timestamp and therefore we remove such default timestamps
@@ -687,8 +715,9 @@ COLS;
       // only do the change if any data has changed
       $cond = array();
       foreach ($columns as $column) {
+        $tableExceptions = array_key_exists('exceptions', $this->logTableSpec[$table]) ? $this->logTableSpec[$table]['exceptions'] : array();
         // ignore modified_date changes
-        if ($column != 'modified_date' && !in_array($column, CRM_Utils_Array::value($table, $this->exceptions, array()))) {
+        if ($column != 'modified_date' && !in_array($column, $tableExceptions)) {
           $cond[] = "IFNULL(OLD.$column,'') <> IFNULL(NEW.$column,'')";
         }
       }

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -1474,6 +1474,20 @@ abstract class CRM_Utils_Hook {
       'civicrm_triggerInfo'
     );
   }
+  /**
+   * This hook allows changes to the spec of which tables to log.
+   *
+   * @param array $logTableSpec
+   *
+   * @return mixed
+   */
+  public static function alterLogTables(&$logTableSpec) {
+    return self::singleton()->invoke(1, $logTableSpec, $_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      self::$_nullObject,
+      'civicrm_alterLogTables'
+    );
+  }
 
   /**
    * This hook is called when a module-extension is installed.

--- a/tests/phpunit/api/v3/LoggingTest.php
+++ b/tests/phpunit/api/v3/LoggingTest.php
@@ -1,0 +1,149 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+| CiviCRM version 4.7                                                |
++--------------------------------------------------------------------+
+| Copyright CiviCRM LLC (c) 2004-2015                                |
++--------------------------------------------------------------------+
+| This file is a part of CiviCRM.                                    |
+|                                                                    |
+| CiviCRM is free software; you can copy, modify, and distribute it  |
+| under the terms of the GNU Affero General Public License           |
+| Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+|                                                                    |
+| CiviCRM is distributed in the hope that it will be useful, but     |
+| WITHOUT ANY WARRANTY; without even the implied warranty of         |
+| MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+| See the GNU Affero General Public License for more details.        |
+|                                                                    |
+| You should have received a copy of the GNU Affero General Public   |
+| License and the CiviCRM Licensing Exception along                  |
+| with this program; if not, contact CiviCRM LLC                     |
+| at info[AT]civicrm[DOT]org. If you have questions about the        |
+| GNU Affero General Public License or the licensing of CiviCRM,     |
+| see the CiviCRM license FAQ at http://civicrm.org/licensing        |
++--------------------------------------------------------------------+
+ */
+
+/**
+ * Test class for Logging API.
+ *
+ * @package CiviCRM
+ * @group headless
+ */
+class api_v3_LoggingTest extends CiviUnitTestCase {
+
+  /**
+   * Sets up the fixture, for example, opens a network connection.
+   *
+   * This method is called before a test is executed.
+   */
+  protected function setUp() {
+    parent::setUp();
+  }
+
+  /**
+   * Clean up log tables.
+   */
+  protected function tearDown() {
+    parent::tearDown();
+    $this->callAPISuccess('Setting', 'create', array('logging' => FALSE));
+    $schema = new CRM_Logging_Schema();
+    $schema->dropAllLogTables();
+    CRM_Core_DAO::executeQuery("DELETE FROM civicrm_setting WHERE name LIKE 'logg%'");
+  }
+
+  /**
+   * Test that logging is successfully enabled and disabled.
+   */
+  public function testEnableDisableLogging() {
+    $this->assertEquals(0, $this->callAPISuccessGetValue('Setting', array('name' => 'logging', 'group' => 'core')));
+    $this->assertLoggingEnabled(FALSE);
+
+    $this->callAPISuccess('Setting', 'create', array('logging' => TRUE));
+    $this->assertLoggingEnabled(TRUE);
+    $this->checkLogTableCreated();
+    $this->checkTriggersCreated();
+    // Create a contact to make sure they aren't borked.
+    $this->individualCreate();
+    $this->assertTrue($this->callAPISuccessGetValue('Setting', array('name' => 'logging', 'group' => 'core')));
+
+    $this->callAPISuccess('Setting', 'create', array('logging' => FALSE));
+    $this->assertEquals(0, $this->callAPISuccessGetValue('Setting', array('name' => 'logging', 'group' => 'core')));
+    $this->assertLoggingEnabled(FALSE);
+  }
+
+  /**
+   * Test that logging is successfully enabled and disabled.
+   */
+  public function testEnableDisableLoggingWithTriggerHook() {
+    $this->hookClass->setHook('civicrm_alterLogTables', array($this, 'innodbLogTableSpec'));
+    $this->callAPISuccess('Setting', 'create', array('logging' => TRUE));
+    $this->checkINNODBLogTableCreated();
+    $this->checkTriggersCreated();
+    // Create a contact to make sure they aren't borked.
+    $this->individualCreate();
+    $this->callAPISuccess('Setting', 'create', array('logging' => FALSE));
+  }
+
+  /**
+   * Use a hook to declare an INNODB engine for the contact log table.
+   *
+   * @param array $logTableSpec
+   */
+  public function innodbLogTableSpec(&$logTableSpec) {
+    $logTableSpec['civicrm_contact'] = array(
+      'engine' => 'INNODB',
+      'indexes' => array(
+        'index_id' => 'id',
+        'index_log_conn_id' => 'log_conn_id',
+        'index_log_date' => 'log_date',
+      ),
+    );
+  }
+
+  /**
+   * Check the log tables were created and look OK.
+   */
+  protected function checkLogTableCreated() {
+    $dao = CRM_Core_DAO::executeQuery("SHOW CREATE TABLE log_civicrm_contact");
+    $dao->fetch();
+    $this->assertEquals('log_civicrm_contact', $dao->Table);
+    $tableField = 'Create_Table';
+    $this->assertContains('`log_date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,', $dao->$tableField);
+    return $dao->$tableField;
+  }
+
+  /**
+   * Check the log tables were created and reflect the INNODB hook.
+   */
+  protected function checkINNODBLogTableCreated() {
+    $createTableString = $this->checkLogTableCreated();
+    $this->assertContains('ENGINE=InnoDB', $createTableString);
+    $this->assertContains('KEY `index_id` (`id`),', $createTableString);
+  }
+
+  /**
+   * Check the triggers were created and look OK.
+   */
+  protected function checkTriggersCreated() {
+    $dao = CRM_Core_DAO::executeQuery("SHOW TRIGGERS LIKE 'civicrm_contact'");
+    while ($dao->fetch()) {
+      if ($dao->Timing == 'After') {
+        $this->assertContains('@uniqueID', $dao->Statement);
+      }
+    }
+  }
+
+  /**
+   * Assert logging is enabled or disabled as per input parameter.
+   *
+   * @param bool $expected
+   *   Do we expect it to be enabled.
+   */
+  protected function assertLoggingEnabled($expected) {
+    $schema = new CRM_Logging_Schema();
+    $this->assertTrue($schema->isEnabled() === $expected);
+  }
+
+}


### PR DESCRIPTION
Covers allowing hook definition of log tables (CRM-18104), converting log_conn_id (CRM-18193) to a unique field and minor fix (CRM-18180)

---
- [CRM-18193: Use unique log_conn_id in logging](https://issues.civicrm.org/jira/browse/CRM-18193)
- [CRM-18104: Add hook for defining logging tables](https://issues.civicrm.org/jira/browse/CRM-18104)
- [CRM-18180: Log table lookup should include all declared tables, even if they don't start with civicrm_](https://issues.civicrm.org/jira/browse/CRM-18180)
