### PR TITLE
CRM-18223 Add civicrm_hook_entityTables to allow extension of entityTables whitelist

### DIFF
--- a/CRM/Core/BAO/Note.php
+++ b/CRM/Core/BAO/Note.php
@@ -585,6 +585,7 @@ WHERE participant.contact_id = %1 AND  note.entity_table = 'civicrm_participant'
       'civicrm_participant',
       'civicrm_contribution',
     );
+    CRM_Utils_Hook::entityTables($this, $tables);
     // Identical keys & values
     return array_combine($tables, $tables);
   }

--- a/CRM/Core/BAO/Note.php
+++ b/CRM/Core/BAO/Note.php
@@ -585,7 +585,8 @@ WHERE participant.contact_id = %1 AND  note.entity_table = 'civicrm_participant'
       'civicrm_participant',
       'civicrm_contribution',
     );
-    CRM_Utils_Hook::entityTables($this, $tables);
+    $entity = CRM_Core_DAO_AllCoreTables::getBriefName(str_replace("BAO", "DAO", get_called_class()));
+    CRM_Utils_Hook::entityTables($entity, $tables);
     // Identical keys & values
     return array_combine($tables, $tables);
   }

--- a/CRM/Core/BAO/UFJoin.php
+++ b/CRM/Core/BAO/UFJoin.php
@@ -190,6 +190,7 @@ class CRM_Core_BAO_UFJoin extends CRM_Core_DAO_UFJoin {
       'civicrm_event',
       'civicrm_contribution_page',
     );
+    CRM_Utils_Hook::entityTables($this, $tables);
     // Identical keys & values
     return array_combine($tables, $tables);
   }

--- a/CRM/Core/BAO/UFJoin.php
+++ b/CRM/Core/BAO/UFJoin.php
@@ -190,7 +190,8 @@ class CRM_Core_BAO_UFJoin extends CRM_Core_DAO_UFJoin {
       'civicrm_event',
       'civicrm_contribution_page',
     );
-    CRM_Utils_Hook::entityTables($this, $tables);
+    $entity = CRM_Core_DAO_AllCoreTables::getBriefName(str_replace("BAO", "DAO", get_called_class()));
+    CRM_Utils_Hook::entityTables($entity, $tables);
     // Identical keys & values
     return array_combine($tables, $tables);
   }

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -1732,14 +1732,14 @@ abstract class CRM_Utils_Hook {
   /**
    * This hook is called to alter the list of allowable entityTables.
    *
-   * @param sting|CRM_Core_DAO $entity
+   * @param string|CRM_Core_DAO $entity
    * @param array $tables array of allowable entityTables
    * @return mixed
    */
   public static function entityTables($entity, &$tables) {
     $entityName = is_object($entity) ? _civicrm_api_get_entity_name_from_dao($entity) : $entity;
-    return self::singleton()->invoke(2, $entityName, $clauses,
-      self::$_nullobject, self::$_nullobject, self::$_nullobject, self::$_nullobject,
+    return self::singleton()->invoke(2, $entityName, $tables,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_entityTables'
     );
   }

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -1732,6 +1732,7 @@ abstract class CRM_Utils_Hook {
   /**
    * This hook is called to alter the list of allowable entityTables.
    *
+   * @param sting|CRM_Core_DAO $entity
    * @param array $tables array of allowable entityTables
    * @return mixed
    */

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -1730,6 +1730,20 @@ abstract class CRM_Utils_Hook {
   }
 
   /**
+   * This hook is called to alter the list of allowable entityTables.
+   *
+   * @param array $tables array of allowable entityTables
+   * @return mixed
+   */
+  public static function entityTables($entity, &$tables) {
+    $entityName = is_object($entity) ? _civicrm_api_get_entity_name_from_dao($entity) : $entity;
+    return self::singleton()->invoke(2, $entityName, $clauses,
+      self::$_nullobject, self::$_nullobject, self::$_nullobject, self::$_nullobject,
+      'civicrm_entityTables'
+    );
+  }
+
+  /**
    * This hook is called while validating a profile form submission.
    *
    * @param string $name


### PR DESCRIPTION
I forked this off @seamuslee001 's branch, cleaned up the invocation, and added entity name look-ups because $this is out of scope in static functions.

---
- [CRM-18223: entity_table whitelist breaks extension use of Profiles.](https://issues.civicrm.org/jira/browse/CRM-18223)
