### PR TITLE
Added call to hook_civicrm_fieldOptions()...

### DIFF
--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -252,7 +252,10 @@ class CRM_Core_PseudoConstant {
 
       // if callback is specified..
       if (!empty($pseudoconstant['callback'])) {
-        return call_user_func(Civi\Core\Resolver::singleton()->get($pseudoconstant['callback']));
+        $fieldOptions = call_user_func(Civi\Core\Resolver::singleton()->get($pseudoconstant['callback']));
+        //CRM-18223: Allow additions to field options via hook.
+        CRM_Utils_Hook::fieldOptions($entity, $fieldName, $fieldOptions, $params);
+        return $fieldOptions;
       }
 
       // Merge params with schema defaults


### PR DESCRIPTION
 from within CRM_Core_PseudoConstant::get() for fields that validate against a callback.
