### PR TITLE
CRM-18219,CRM-9067 fixes on onbehalf

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -455,7 +455,12 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $this->buildCustom($this->_values['custom_pre_id'], 'customPre', TRUE);
     $this->buildCustom($this->_values['custom_post_id'], 'customPost', TRUE);
 
-    if (!empty($this->_values['onbehalf_profile_id']) && !empty($params['onbehalf'])) {
+    if (!empty($this->_values['onbehalf_profile_id']) &&
+      !empty($params['onbehalf']) &&
+      ($this->_values['is_for_organization'] == 2 ||
+        !empty($params['is_for_organization'])
+      )
+    ) {
       $fieldTypes = array('Contact', 'Organization');
       $contactSubType = CRM_Contact_BAO_ContactType::subTypes('Organization');
       $fieldTypes = array_merge($fieldTypes, $contactSubType);
@@ -2083,7 +2088,12 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
     // If onbehalf-of-organization contribution / signup, add organization
     // and it's location.
-    if (isset($this->_values['onbehalf_profile_id']) && isset($behalfOrganization['organization_name']) && !empty($this->_params['is_for_organization'])) {
+    if (isset($this->_values['onbehalf_profile_id']) &&
+      isset($behalfOrganization['organization_name']) &&
+      ($this->_values['is_for_organization'] == 2 ||
+        !empty($this->_params['is_for_organization'])
+      )
+    ) {
       $ufFields = array();
       foreach ($this->_fields['onbehalf'] as $name => $value) {
         $ufFields[$name] = 1;


### PR DESCRIPTION
- [CRM-18219: Organization data shows up as required fields on contribution confirm page](https://issues.civicrm.org/jira/browse/CRM-18219)
  - [CRM-9067: Organization contact is not created via contribution page with "on behalf" required and the default "on behalf" profile is used](https://issues.civicrm.org/jira/browse/CRM-9067)
