### PR TITLE
CRM-17862: Source field - in backend - one-time credit card contribution defaults to 'recurring contribution'.

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4763,7 +4763,10 @@ LIMIT 1;";
    * @throws \CiviCRM_API3_Exception
    */
   protected static function getRecurringContributionDescription($contribution, $event) {
-    if (!empty($contribution->contribution_page_id)) {
+    if (! empty($contribution->source)) {
+      return $contribution->source;
+    }
+    elseif (!empty($contribution->contribution_page_id)) {
       $contributionPageTitle = civicrm_api3('ContributionPage', 'getvalue', array(
         'id' => $contribution->contribution_page_id,
         'return' => 'title',

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4763,7 +4763,7 @@ LIMIT 1;";
    * @throws \CiviCRM_API3_Exception
    */
   protected static function getRecurringContributionDescription($contribution, $event) {
-    if (! empty($contribution->source)) {
+    if (!empty($contribution->source)) {
       return $contribution->source;
     }
     elseif (!empty($contribution->contribution_page_id)) {


### PR DESCRIPTION
- [CRM-17862: Source field - backed - one-time credit card contribution defaults to 'recurring contribution'](https://issues.civicrm.org/jira/browse/CRM-17862)
