### PR TITLE
Fix trigger rebuild for all table columns

### DIFF
--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -369,8 +369,10 @@ AND    TABLE_NAME LIKE 'log_civicrm_%'
     }
 
     if ($rebuildTrigger) {
-      // invoke the meta trigger creation call
-      CRM_Core_DAO::triggerRebuild($table);
+      foreach ($diffs as $table => $cols) {
+        // invoke the meta trigger creation call
+        CRM_Core_DAO::triggerRebuild($table);
+      }
     }
   }
 


### PR DESCRIPTION
Not sure why it needs to be done outside of the fixSchemaDifferencesFor loop, but it was only rebuilding triggers for the last in the list.
