### PR TITLE
CRM-18276 Fixing truncated custom data tables array with GROUP_CONCAT

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -3660,6 +3660,7 @@ ORDER BY cg.weight, cf.weight";
     $mapper = CRM_Core_BAO_CustomQuery::$extendsMap;
     //CRM-18276 GROUP_CONCAT could be used with singleValueQuery and then exploded,
     //but by default that truncates to 1024 characters, which causes errors with installs with lots of custom field sets
+    $customTables = array();
     $customTablesDAO = CRM_Core_DAO::executeQuery("SELECT table_name FROM civicrm_custom_group", CRM_Core_DAO::$_nullArray);
     while ($customTablesDAO->fetch()) {
       $customTables[] = $customTablesDAO->table_name;

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -3658,7 +3658,12 @@ ORDER BY cg.weight, cf.weight";
       return;
     }
     $mapper = CRM_Core_BAO_CustomQuery::$extendsMap;
-    $customTables = explode(',', CRM_Core_DAO::singleValueQuery("SELECT GROUP_CONCAT(table_name) FROM civicrm_custom_group"));
+    //CRM-18276 GROUP_CONCAT could be used with singleValueQuery and then exploded,
+    //but by default that truncates to 1024 characters, which causes errors with installs with lots of custom field sets
+    $customTablesDAO = CRM_Core_DAO::executeQuery("SELECT table_name FROM civicrm_custom_group", CRM_Core_DAO::$_nullArray);
+    while ($customTablesDAO->fetch()) {
+      $customTables[] = $customTablesDAO->table_name;
+    }
 
     foreach ($this->_columns as $table => $prop) {
       if (in_array($table, $customTables)) {


### PR DESCRIPTION
---
- CRM-18276: Report custom data table retrieval fails when tables are more than 1024 characters
  https://issues.civicrm.org/jira/browse/CRM-18276
