### PR TITLE
Mange Groups: Fix child groups so that they can be expanded

### DIFF
--- a/templates/CRM/Group/Form/Search.tpl
+++ b/templates/CRM/Group/Form/Search.tpl
@@ -211,7 +211,7 @@
               $.each( response.data, function( i, val ) {
                 appendHTML += '<tr id="row_'+val.group_id+'_'+parent_id+'" data-entity="group" data-id="'+val.group_id+'" class="crm-entity parent_is_'+parent_id+' crm-row-child">';
                 if ( val.is_parent ) {
-                  appendHTML += '<td class="crm-group-name crmf-title crm-editable ' + levelClass + '">' + '{/literal}<span class="collapsed show-children" title="{ts}show child groups{/ts}"/></span>{literal}' + val.title + '</td>';
+                  appendHTML += '<td class="crm-group-name crmf-title ' + levelClass + '">' + '{/literal}<span class="collapsed show-children" title="{ts}show child groups{/ts}"/></span><div class="crm-editable">{literal}' + val.title + '</div></td>';
                 }
                 else {
                   appendHTML += '<td class="' + levelClass + '">' + '{/literal}<span class="collapsed show-children" title="{ts}show child groups{/ts}"/></span><span class="crm-group-name crmf-title crm-editable">{literal}' + val.title + '</span></td>';


### PR DESCRIPTION
When managing groups you cannot expand (uncollapse) 2nd level child groups. Clicking on the arrow to view children initiates inline editing. The inline editing field is encompassing the expand icon that allows children to be viewed. This effectively breaks management of child groups from the manage groups page. Changing this line fixes the issue.
