### PR TITLE
CRM-18301. Remove Drupal config tpl from Wordpress config generation.

### DIFF
--- a/CRM/Core/CodeGen/Config.php
+++ b/CRM/Core/CodeGen/Config.php
@@ -73,7 +73,6 @@ class CRM_Core_CodeGen_Config extends CRM_Core_CodeGen_BaseTask {
       case 'wordpress':
         $candidates[] = "../../civicrm.config.php.wordpress";
         $candidates[] = "../WordPress/civicrm.config.php.wordpress";
-        $candidates[] = "../drupal/civicrm.config.php.drupal";
         break;
     }
     foreach ($candidates as $candidate) {


### PR DESCRIPTION
- [CRM-18301: Wordpress shouldn't consider civicrm.config.php.drupal as candidate template](https://issues.civicrm.org/jira/browse/CRM-18301)
