### PR TITLE
CRM-18307 fix error on merge when undelete is off

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1936,13 +1936,15 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
       'activity_type_id' => 'Contact Merged',
       'status_id' => 'Completed',
     ));
-    civicrm_api3('activity', 'create', array(
-      'subject' => ts('Contact ID %1 has been merged into Contact ID %2 and deleted.', $params),
-      'target_contact_id' => $otherId,
-      'activity_type_id' => 'Contact Deleted by Merge',
-      'parent_id' => $activity['id'],
-      'status_id' => 'Completed',
-    ));
+    if (civicrm_api3('Setting', 'getvalue', array('name' => 'contact_undelete', 'group' => 'CiviCRM Preferences'))) {
+      civicrm_api3('activity', 'create', array(
+        'subject' => ts('Contact ID %1 has been merged into Contact ID %2 and deleted.', $params),
+        'target_contact_id' => $otherId,
+        'activity_type_id' => 'Contact Deleted by Merge',
+        'parent_id' => $activity['id'],
+        'status_id' => 'Completed',
+      ));
+    }
   }
 
 }

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -2885,4 +2885,25 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   }
 
+  /**
+   * Test merging 2 contacts with delete to trash off.
+   *
+   * We are checking that there is no error due to attempting to add an activity for the
+   * deleted contact.
+   *
+   * CRM-18307
+   */
+  public function testMergeNoTrash() {
+    $this->createLoggedInUser();
+    $this->callAPISuccess('Setting', 'create', array('contact_undelete' => FALSE));
+    $otherContact = $this->callAPISuccess('contact', 'create', $this->_params);
+    $retainedContact = $this->callAPISuccess('contact', 'create', $this->_params);
+    $this->callAPISuccess('contact', 'merge', array(
+      'to_keep_id' => $retainedContact['id'],
+      'to_remove_id' => $otherContact['id'],
+      'auto_flip' => FALSE,
+    ));
+    $this->callAPISuccess('Setting', 'create', array('contact_undelete' => TRUE));
+  }
+
 }


### PR DESCRIPTION
- [CRM-18307: Error when merging contacts with delete to trash off](https://issues.civicrm.org/jira/browse/CRM-18307)
