### PR TITLE
CRM-17902 fix null string

### DIFF
--- a/CRM/Custom/Form/CustomData.php
+++ b/CRM/Custom/Form/CustomData.php
@@ -151,6 +151,10 @@ class CRM_Custom_Form_CustomData {
    * @return array
    */
   public static function setGroupTree(&$form, $subType, $gid, $onlySubType = NULL, $getCachedTree = FALSE) {
+    // CRM-17902
+    if ($form->_subName == 'null') {
+      $form->_subName = NULL;
+    }
 
     $groupTree = CRM_Core_BAO_CustomGroup::getTree($form->_type,
       $form,


### PR DESCRIPTION
- [CRM-17902: Participant custom fields not shown on registration form](https://issues.civicrm.org/jira/browse/CRM-17902)
