### PR TITLE
CRM-18302 - Pass payment processor ID in notify URL

### DIFF
--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -321,11 +321,17 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
       $ids['onbehalf_dupe_alert'] = self::retrieve('onBehalfDupeAlert', 'Integer', 'GET', FALSE);
     }
 
-    $paymentProcessorID = CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_PaymentProcessorType',
-      'PayPal_Standard', 'id', 'name'
+    $processorParams = array(
+      'user_name' => self::retrieve('receiver_email', 'String', 'POST', FALSE),
+      'payment_processor_type_id' => CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_PaymentProcessorType', 'PayPal_Standard', 'id', 'name'),
+      'is_test' => empty($input['is_test']) ? 0 : 1,
     );
+    $processorInfo = array();
+    if (!CRM_Financial_BAO_PaymentProcessor::retrieve($processorParams, $processorInfo)) {
+      return FALSE;
+    }
 
-    if (!$this->validateData($input, $ids, $objects, TRUE, $paymentProcessorID)) {
+    if (!$this->validateData($input, $ids, $objects, TRUE, $processorInfo['id'])) {
       return FALSE;
     }
 

--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -324,7 +324,7 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
     // CRM-18302: get payment processor ID passed from CRM_Core_Payment_PayPalImpl::doTransferCheckout()
     $paymentProcessorID = self::retrieve('paymentProcessorID', 'Integer', 'GET', TRUE);
 
-    if (!$this->validateData($input, $ids, $objects, TRUE, $processorInfo['id'])) {
+    if (!$this->validateData($input, $ids, $objects, TRUE, $paymentProcessorID)) {
       return FALSE;
     }
 

--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -321,9 +321,8 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
       $ids['onbehalf_dupe_alert'] = self::retrieve('onBehalfDupeAlert', 'Integer', 'GET', FALSE);
     }
 
-    $paymentProcessorID = CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_PaymentProcessorType',
-      'PayPal_Standard', 'id', 'name'
-    );
+    // CRM-18302: get payment processor ID passed from CRM_Core_Payment_PayPalImpl::doTransferCheckout()
+    $paymentProcessorID = self::retrieve('paymentProcessorID', 'Integer', 'GET', TRUE);
 
     if (!$this->validateData($input, $ids, $objects, TRUE, $paymentProcessorID)) {
       return FALSE;

--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -321,15 +321,8 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
       $ids['onbehalf_dupe_alert'] = self::retrieve('onBehalfDupeAlert', 'Integer', 'GET', FALSE);
     }
 
-    $processorParams = array(
-      'user_name' => self::retrieve('receiver_email', 'String', 'POST', FALSE),
-      'payment_processor_type_id' => CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_PaymentProcessorType', 'PayPal_Standard', 'id', 'name'),
-      'is_test' => empty($input['is_test']) ? 0 : 1,
-    );
-    $processorInfo = array();
-    if (!CRM_Financial_BAO_PaymentProcessor::retrieve($processorParams, $processorInfo)) {
-      return FALSE;
-    }
+    // CRM-18302: get payment processor ID passed from CRM_Core_Payment_PayPalImpl::doTransferCheckout()
+    $paymentProcessorID = self::retrieve('paymentProcessorID', 'Integer', 'GET', TRUE);
 
     if (!$this->validateData($input, $ids, $objects, TRUE, $processorInfo['id'])) {
       return FALSE;

--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -794,6 +794,8 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
     }
 
     $notifyURL = $config->userFrameworkResourceURL . "extern/ipn.php?reset=1&contactID={$params['contactID']}" . "&contributionID={$params['contributionID']}" . "&module={$component}";
+    // CRM-18302: pass payment processor ID to IPN handler
+    $notifyURL .= "&paymentProcessorID={$this->_paymentProcessor['id']}";
 
     if ($component == 'event') {
       $notifyURL .= "&eventID={$params['eventID']}&participantID={$params['participantID']}";

--- a/templates/CRM/Price/Form/PriceSet.tpl
+++ b/templates/CRM/Price/Form/PriceSet.tpl
@@ -102,7 +102,7 @@
                 </div>
 
             {/if}
-              {if !empty($extends) && $extends eq "Membership" && $element.html_type != 'Text'}
+              {if !empty($extends) && $extends eq "Membership" && $element.name == 'membership_amount'}
                 <div id="allow_auto_renew">
                   <div class='crm-section auto-renew'>
                     <div class='label'></div>


### PR DESCRIPTION
PayPal IPN handler set $paymentProcessorID to the payment processor type ID instead of the payment processor ID. This change passes the actual payment processor ID in the IPN notify URL so $paymentProcessorID can be set properly.

---
- [CRM-18302: PayPal Standard test payments never complete](https://issues.civicrm.org/jira/browse/CRM-18302)
