### PR TITLE
require utils.php

### DIFF
--- a/api/v3/Group.php
+++ b/api/v3/Group.php
@@ -24,6 +24,7 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
  */
+require_once 'api/v3/utils.php';
 
 /**
  * This api exposes CiviCRM Groups.


### PR DESCRIPTION
I'm using commerce_civicrm on drupal but I keep getting this error message: 
Fatal error: Call to undefined function _civicrm_api3_get_options_from_params() in /var/www/vonne.ccuptest.co.uk/httpdocs/sites/all/modules/civicrm/api/v3/Group.php on line 73

I fixed this by adding "require_one 'utils.php'  " in Group.php
