### PR TITLE
CRM-18319: Remove unused scan_and_replace method

### DIFF
--- a/CRM/Mailing/BAO/TrackableURL.php
+++ b/CRM/Mailing/BAO/TrackableURL.php
@@ -123,33 +123,4 @@ class CRM_Mailing_BAO_TrackableURL extends CRM_Mailing_DAO_TrackableURL {
     return NULL;
   }
 
-  /**
-   * @param $msg
-   * @param int $mailing_id
-   * @param int $queue_id
-   * @param bool $onlyHrefs
-   */
-  public static function scan_and_replace(&$msg, $mailing_id, $queue_id, $onlyHrefs = FALSE) {
-    if (!$mailing_id) {
-      return;
-    }
-
-    $protos = '(https?|ftp)';
-    $letters = '\w';
-    $gunk = '/#~:.?+=&%@!\-';
-    $punc = '.:?\-';
-    $any = "{$letters}{$gunk}{$punc}";
-    if ($onlyHrefs) {
-      $pattern = "{\\b(href=([\"'])?($protos:[$any]+?(?=[$punc]*[^$any]|$))([\"'])?)}im";
-    }
-    else {
-      $pattern = "{\\b($protos:[$any]+?(?=[$punc]*[^$any]|$))}eim";
-    }
-
-    $trackURL = CRM_Mailing_BAO_TrackableURL::getTrackerURL('\\1', $mailing_id, $queue_id);
-    $replacement = $onlyHrefs ? ("href=\"{$trackURL}\"") : ("\"{$trackURL}\"");
-
-    $msg = preg_replace($pattern, $replacement, $msg);
-  }
-
 }


### PR DESCRIPTION
- [CRM-18319: Unused TrackableURL::scan_and_replace method](https://issues.civicrm.org/jira/browse/CRM-18319)
