### PR TITLE
CRM-18320: Fix URLs with ampersands in CiviMail

### DIFF
--- a/extern/url.php
+++ b/extern/url.php
@@ -54,6 +54,9 @@ if (strlen($query_string) > 0) {
   }
 }
 
+// CRM-18320 - Fix encoded ampersands (see CRM_Utils_System::redirect)
+$url = str_replace('&amp;', '&', $url);
+
 // CRM-17953 - The CMS is not bootstrapped so cannot use CRM_Utils_System::redirect
 header('Location: ' . $url);
 CRM_Utils_System::civiExit();


### PR DESCRIPTION
- [CRM-18320: CiviMail: Ampersands in tracked URLs are no longer decoded (regression)](https://issues.civicrm.org/jira/browse/CRM-18320)
