### PR TITLE
(WIP) CRM-18323- PCP Search implementation like group search

### DIFF
--- a/CRM/Admin/Page/AJAX.php
+++ b/CRM/Admin/Page/AJAX.php
@@ -235,6 +235,10 @@ class CRM_Admin_Page_AJAX {
             $ret['content'] .= '<br /><br /><strong>' . ts('This recurring contribution is linked to an auto-renew membership. If you cancel it, the associated membership will no longer renew automatically. However, the current membership status will not be affected.') . '</strong>';
           }
           break;
+					
+				case 'CRM_PCP_BAO_PCP':
+					$ret['content'] = ts('Are you sure you want to disable this Personal Campaign Page?');
+					break;
 
         default:
           $ret['content'] = ts('Are you sure you want to disable this record?');

--- a/CRM/Core/xml/Menu/PCP.xml
+++ b/CRM/Core/xml/Menu/PCP.xml
@@ -2,9 +2,11 @@
 <menu>
   <item>
      <path>civicrm/pcp</path>
-     <page_callback>CRM_PCP_Form_PCP</page_callback>
-     <access_callback>1</access_callback>
-     <is_public>true</is_public>
+     <title>Manage Personal Campaign Pages</title>
+     <page_type>1</page_type>
+     <page_callback>CRM_PCP_Page_PCP</page_callback>
+     <access_arguments>access CiviCRM</access_arguments>
+     <weight>30</weight>
   </item>
   <item>
      <path>civicrm/pcp/campaign</path>
@@ -25,5 +27,10 @@
      <title>Personal Campaign Pages</title>
      <page_callback>CRM_PCP_Page_PCP</page_callback>
      <desc>View and manage existing personal campaign pages.</desc>
+  </item>
+  <item>
+     <path>civicrm/ajax/pcplist</path>
+     <page_callback>CRM_PCP_Page_AJAX::getPcpList</page_callback>
+     <access_arguments>access CiviCRM</access_arguments>
   </item>
 </menu>

--- a/CRM/PCP/BAO/PCP.php
+++ b/CRM/PCP/BAO/PCP.php
@@ -931,5 +931,286 @@ INNER JOIN civicrm_uf_group ufgroup
       return $ownerNotificationId;
     }
   }
+	
+	/**
+   * wrapper for ajax pcp selector.
+   *
+   * @param array $params
+   *   Associated array for params record id.
+   *
+   * @return array
+   *   associated array of pcp list
+   *   -rp = rowcount
+   *   -page= offset
+   * @todo there seems little reason for the small number of functions that call this to pass in
+   * params that then need to be translated in this function since they are coding them when calling
+   */
+  static public function getPcpListSelector(&$params) {
+    // format the params
+    $params['offset'] = ($params['page'] - 1) * $params['rp'];
+    $params['rowCount'] = $params['rp'];
+    $params['sort'] = CRM_Utils_Array::value('sortBy', $params);
+
+    // get pcps
+    $pcps = CRM_PCP_BAO_PCP::getPcpList($params);
+    $params['total'] = CRM_PCP_BAO_PCP::getPcpCount($params);
+
+    // format params and add links
+    $pcpList = array();
+    if (!empty($pcps)) {
+      foreach ($pcps as $id => $value) {
+        $value['class'][] = 'crm-entity';
+        $pcpList[$id]['class'] = $value['id'] . ',' . implode(' ', $value['class']);
+        $pcpList[$id]['pcp_id'] = $value['id'];
+        $pcpList[$id]['pcp_name'] = $value['pcp_title'];
+        $value['class'][] = 'crm-entity';
+        $pcpList[$id]['class'] = $value['id'] . ',' . implode(' ', $value['class']);
+        $pcpList[$id]['pcp_supporter'] = CRM_Utils_Array::value('pcp_supporter', $value);
+        $pcpList[$id]['pcp_page'] = CRM_Utils_Array::value('pcp_page', $value);
+        $pcpList[$id]['pcp_start_date'] = CRM_Utils_Array::value('pcp_start_date', $value);
+        $pcpList[$id]['pcp_end_date'] = CRM_Utils_Array::value('pcp_end_date', $value) ? $value['pcp_end_date'] : '(ongoing)';
+        $pcpList[$id]['pcp_status'] = CRM_Utils_Array::value('pcp_status', $value);
+        $pcpList[$id]['action'] = CRM_Utils_Array::value('action', $value);
+      }
+      return $pcpList;
+    }
+  }
+  
+    /**
+   * This function to get list of pcps.
+   *
+   * @param array $params
+   *   Associated array for params.
+   *
+   * @return array
+   */
+  public static function getPcpList(&$params) {
+    $config = CRM_Core_Config::singleton();
+
+    $whereClause = self::whereClause($params, FALSE);
+
+    //$this->pagerAToZ( $whereClause, $params );
+
+    if (!empty($params['rowCount']) &&
+      $params['rowCount'] > 0
+    ) {
+      $limit = " LIMIT {$params['offset']}, {$params['rowCount']} ";
+    }
+
+    $orderBy = ' ORDER BY pcps.title asc';
+    if (!empty($params['sort'])) {
+      $orderBy = ' ORDER BY ' . CRM_Utils_Type::escape($params['sort'], 'String');
+    }
+
+    $query = "
+        SELECT pcps.*, pcp_supporter.display_name,
+        CASE WHEN pcp_block.entity_table = 'civicrm_event' THEN event.title 
+        WHEN pcp_block.entity_table = 'civicrm_contribution_page' THEN contribution_page.title 
+        END as page,
+        CASE WHEN pcp_block.entity_table = 'civicrm_event' THEN event.registration_start_date 
+        WHEN pcp_block.entity_table = 'civicrm_contribution_page' THEN contribution_page.start_date 
+        END as start_date,
+        CASE WHEN pcp_block.entity_table = 'civicrm_event' THEN event.registration_end_date 
+        WHEN pcp_block.entity_table = 'civicrm_contribution_page' THEN contribution_page.end_date 
+        END as end_date
+        FROM  civicrm_pcp pcps
+        LEFT JOIN civicrm_contact pcp_supporter ON pcp_supporter.id = pcps.contact_id
+        LEFT JOIN civicrm_pcp_block pcp_block ON (pcp_block.id = pcps.pcp_block_id)
+        LEFT JOIN civicrm_event event ON (event.id = pcp_block.entity_id AND pcp_block.entity_table = 'civicrm_event')   
+        LEFT JOIN civicrm_contribution_page contribution_page ON (contribution_page.id = pcp_block.entity_id AND pcp_block.entity_table = 'civicrm_contribution_page')
+        LEFT JOIN civicrm_email supporter_email ON (pcp_supporter.id = supporter_email.contact_id AND supporter_email.is_primary = 1)
+        WHERE $whereClause
+        GROUP BY pcps.id
+        {$orderBy}
+        {$limit}";
+        
+    $object = CRM_Core_DAO::executeQuery($query, $params, TRUE, 'CRM_PCP_DAO_PCP');
+
+    while ($object->fetch()) {
+      $links = self::actionLinks();
+      
+      $approvedId = CRM_Core_OptionGroup::getValue('pcp_status', 'Approved', 'name');
+      $allowToDelete = CRM_Core_Permission::check('delete in CiviContribute');
+
+      CRM_Core_DAO::storeValues($object, $values[$object->id]);
+      
+      if ($object->page_type == 'contribute') {
+        $pageUrl = CRM_Utils_System::url('civicrm/' . $object->page_type . '/transact', 'reset=1&id=' . $object->page_id);
+      }
+      else {
+        $pageUrl = CRM_Utils_System::url('civicrm/' . $object->page_type . '/register', 'reset=1&id=' . $object->page_id);
+      }
+      $supporterUrl = CRM_Utils_System::url('civicrm/contact/view', "reset=1&cid={$object->contact_id}");
+      $pcpUrl = CRM_Utils_System::url('civicrm/pcp/info', "reset=1&id={$object->id}");
+      $status = CRM_PCP_BAO_PCP::buildOptions('status_id', 'create');
+      $values[$object->id]['pcp_title'] = "<a href='{$pcpUrl}'>{$object->title}</a>";
+      $values[$object->id]['pcp_supporter'] = "<a href='{$supporterUrl}'>{$object->display_name}</a>";
+      $values[$object->id]['pcp_page'] = "<a href='{$pageUrl}'>{$object->page}</a>";
+      $values[$object->id]['pcp_start_date'] = CRM_Utils_Date::customFormat($object->start_date);
+      $values[$object->id]['pcp_end_date'] = CRM_Utils_Date::customFormat($object->end_date);
+      $values[$object->id]['pcp_status'] = $status[$object->status_id];
+      
+      $action = array_sum(array_keys($links));
+
+      $class = '';
+
+      if ($object->status_id != $approvedId || $object->is_active != 1) {
+        $class = 'disabled';
+      }
+
+      switch ($object->status_id) {
+        case 2:
+          $action -= CRM_Core_Action::RENEW;
+          break;
+
+        case 3:
+          $action -= CRM_Core_Action::REVERT;
+          break;
+      }
+
+      switch ($object->is_active) {
+        case 1:
+          $action -= CRM_Core_Action::ENABLE;
+          break;
+
+        case 0:
+          $values[$object->id]['class'][] = 'disabled';
+          $action -= CRM_Core_Action::DISABLE;
+          break;
+      }
+
+      if (!$allowToDelete) {
+        $action -= CRM_Core_Action::DELETE;
+      }
+      
+      $values[$object->id]['action'] = CRM_Core_Action::formLink($links,
+          $action,
+          array('id' => $object->id), ts('more'), FALSE, 'pcp.selector.row', 'PCP', $object->id
+        );
+
+    }
+    return $values;
+  }
+  
+   /**
+   * @param array $params
+   *
+   * @return NULL|string
+   */
+  public static function getPcpCount(&$params) {
+    $whereClause = self::whereClause($params, FALSE);
+    $query = "SELECT 
+      COUNT(pcps.id) FROM civicrm_pcp pcps 
+      INNER JOIN civicrm_contact pcp_supporter ON pcps.contact_id = pcp_supporter.id
+      LEFT JOIN civicrm_pcp_block pcp_block ON (pcp_block.id = pcps.pcp_block_id)
+      LEFT JOIN civicrm_event event ON (event.id = pcp_block.entity_id AND pcp_block.entity_table = 'civicrm_event')   
+      LEFT JOIN civicrm_contribution_page contribution_page ON (contribution_page.id = pcp_block.entity_id AND pcp_block.entity_table = 'civicrm_contribution_page')
+      LEFT JOIN civicrm_email supporter_email ON (pcp_supporter.id = supporter_email.contact_id AND supporter_email.is_primary = 1)";
+    $query .= "
+    WHERE {$whereClause}";
+    return CRM_Core_DAO::singleValueQuery($query, $params);
+  }
+  
+  /**
+   * Generate permissioned where clause for group search.
+   * @param array $params
+   * @param bool $sortBy
+   * @param bool $excludeHidden
+   *
+   * @return string
+   */
+  public static function whereClause(&$params, $sortBy = TRUE, $excludeHidden = TRUE) {
+    $values = array();
+    $title = CRM_Utils_Array::value('title', $params);
+    if ($title) {
+      $clauses[] = "pcps.title LIKE %1";
+      if (strpos($title, '%') !== FALSE) {
+        $params[1] = array($title, 'String', FALSE);
+      }
+      else {
+        $params[1] = array($title, 'String', TRUE);
+      }
+    }
+    $pageType = CRM_Utils_Array::value('page_type', $params);
+    if ($pageType) {
+      $clauses[] = 'pcps.page_type LIKE %2';
+      $params[2] = array($pageType, 'String');
+    }
+    $status = CRM_Utils_Array::value('status_id', $params);
+    if ($status) {
+      $clauses[] = 'pcps.status_id = %3';
+      $params[3] = array($status, 'Integer');
+    }
+    $page_id = CRM_Utils_Array::value('page_id', $params);
+    if ($page_id) {
+      $clauses[] = 'pcps.page_id = %4 AND pcps.page_type = "contribute"';
+      $params[4] = array($page_id, 'Integer');
+    }
+    $event_id = CRM_Utils_Array::value('event_id', $params);
+    if ($event_id) {
+      $clauses[] = 'pcps.page_id = %5 AND pcps.page_type = "event"';
+      $params[5] = array($event_id, 'Integer');
+    }
+    $supporter = CRM_Utils_Array::value('supporter', $params);
+    if ($supporter) {
+      $clauses[] = "(pcp_supporter.sort_name LIKE %6 OR supporter_email.email LIKE %6)";
+      if (strpos($supporter, '%') !== FALSE) {
+        $params[6] = array($supporter, 'String', FALSE);
+      }
+      else {
+        $params[6] = array($supporter, 'String', TRUE);
+      }
+    }
+    $start_date = CRM_Utils_Array::value('start_date', $params);
+    if ($start_date) {
+      $clauses[] = '(event.registration_start_date >= %7 OR contribution_page.start_date >= %7)';
+      $params[7] = array(CRM_Utils_Date::processDate($start_date), 'String'); 
+    }
+    $end_date = CRM_Utils_Array::value('end_date', $params);
+    if ($end_date) {
+      $clauses[] = '(event.registration_end_date <= %8 OR contribution_page.end_date <= %8)';
+      $params[8] = array(CRM_Utils_Date::processDate($end_date), 'String'); 
+    }
+    if (empty($clauses)) {
+      $clauses[] = '1';
+    }
+    return implode(' AND ', $clauses);
+  }
+  
+  public static function actionLinks() {
+    $links = array(
+      CRM_Core_Action::UPDATE => array(
+          'name' => ts('Edit'),
+          'url' => 'civicrm/pcp/info',
+          'qs' => 'action=update&reset=1&id=%%id%%&context=dashboard',
+          'title' => ts('Edit Personal Campaign Page'),
+        ),
+        CRM_Core_Action::RENEW => array(
+          'name' => ts('Approve'),
+          'title' => ts('Approve Personal Campaign Page'),
+        ),
+        CRM_Core_Action::REVERT => array(
+          'name' => ts('Reject'),
+          'title' => ts('Reject Personal Campaign Page'),
+        ),
+        CRM_Core_Action::DELETE => array(
+          'name' => ts('Delete'),
+          'url' => 'civicrm/pcp',
+          'qs' => 'action=delete&id=%%id%%',           
+          'title' => ts('Delete Personal Campaign Page'),
+        ),
+        CRM_Core_Action::ENABLE => array(
+          'name' => ts('Enable'),
+          'ref' => 'crm-enable-disable',
+          'title' => ts('Enable'),
+        ),
+        CRM_Core_Action::DISABLE => array(
+          'name' => ts('Disable'),
+          'ref' => 'crm-enable-disable',
+          'title' => ts('Disable'),
+        ),
+    );
+    return $links;
+  }
 
 }

--- a/CRM/PCP/Form/Search.php
+++ b/CRM/PCP/Form/Search.php
@@ -1,0 +1,107 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                               |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2016                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2016
+ * $Id$
+ *
+ */
+class CRM_PCP_Form_Search extends CRM_Core_Form {
+  public $_context;
+
+  public function preProcess() {
+  }
+
+  /**
+   * @return array
+   */
+  public function setDefaultValues() {
+    $defaults = array();
+    $pageType = CRM_Utils_Request::retrieve('page_type', 'String', $this);
+    $defaults['page_type'] = !empty($pageType) ? $pageType : '';
+
+    return $defaults;
+  }
+
+  public function buildQuickForm() {
+    $this->add('text', 'title', ts('Find'),
+      CRM_Core_DAO::getAttribute('CRM_PCP_DAO_PCP', 'title')
+    );
+    
+    $this->add('text', 'supporter', ts('Supporter Name or Email'),
+      CRM_Core_DAO::getAttribute('CRM_Contact_DAO_Contact', 'sort_name')
+    );
+    
+    $status = array('' => ts('- select -')) + CRM_Core_OptionGroup::values("pcp_status");
+    $types = array(
+      '' => ts('- select -'),
+      'contribute' => ts('Contribution'),
+      'event' => ts('Event'),
+    );
+    $contribPages = CRM_Contribute_PseudoConstant::contributionPage();
+    $eventPages   = CRM_Event_PseudoConstant::event(NULL, FALSE, "( is_template IS NULL OR is_template != 1 )");
+
+    $this->addElement('select', 'status_id', ts('Status'), $status);
+    $this->addElement('select', 'page_type', ts('Source Type'), $types);
+    $this->add('select', 'page_id', ts('Contribution Page'), $contribPages, FALSE, array('class' => 'crm-select2', 'placeholder' => ts('- any -')));
+    $this->add('select', 'event_id', ts('Event Page'), $eventPages, FALSE, array('class' => 'crm-select2', 'placeholder' => ts('- any -')));
+    $this->addDate('start_date', ts('Starts on or After'), FALSE);
+    $this->addDate('end_date', ts('Ends on or Before'), FALSE);
+    
+    $this->addButtons(array(
+      array(
+        'type' => 'refresh',
+        'name' => ts('Search'),
+        'isDefault' => TRUE,
+      ),
+    ));
+
+    parent::buildQuickForm();
+    $this->assign('suppressForm', TRUE);
+  }
+
+  public function postProcess() {
+    $params = $this->controller->exportValues($this->_name);
+    $parent = $this->controller->getParent();
+    if (!empty($params)) {
+      $fields = array('title', 'page_type', 'page_id', 'event_id', 'status_id','active_status', 'inactive_status');
+      foreach ($fields as $field) {
+        if (isset($params[$field]) &&
+          !CRM_Utils_System::isNull($params[$field])
+        ) {
+          $parent->set($field, $params[$field]);
+        }
+        else {
+          $parent->set($field, NULL);
+        }
+      }
+    }
+  }
+
+}

--- a/CRM/PCP/Page/AJAX.php
+++ b/CRM/PCP/Page/AJAX.php
@@ -1,0 +1,110 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                               |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2016                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2016
+ *
+ */
+
+/**
+ * This class contains the functions that are called using AJAX (jQuery)
+ */
+class CRM_PCP_Page_AJAX {
+  /**
+   * Get list of groups.
+   *
+   * @return array
+   */
+  public static function getPcpList() {
+    $params = $_REQUEST;
+    $sortMapper = array(
+      0 => 'pcps.title',
+      1 => 'pcp_supporter.display_name',
+      2 => 'page',
+      3 => 'start_date',
+      4 => 'end_date',
+      5 => 'pcps.status_id',
+    );
+
+    $sEcho = CRM_Utils_Type::escape($_REQUEST['sEcho'], 'Integer');
+    $offset = isset($_REQUEST['iDisplayStart']) ? CRM_Utils_Type::escape($_REQUEST['iDisplayStart'], 'Integer') : 0;
+    $rowCount = isset($_REQUEST['iDisplayLength']) ? CRM_Utils_Type::escape($_REQUEST['iDisplayLength'], 'Integer') : 25;
+    $sort = isset($_REQUEST['iSortCol_0']) ? CRM_Utils_Array::value(CRM_Utils_Type::escape($_REQUEST['iSortCol_0'], 'Integer'), $sortMapper) : NULL;
+    $sortOrder = isset($_REQUEST['sSortDir_0']) ? CRM_Utils_Type::escape($_REQUEST['sSortDir_0'], 'String') : 'asc';
+
+    if ($sort && $sortOrder) {
+      $params['sortBy'] = $sort . ' ' . $sortOrder;
+    }
+
+    $params['page'] = ($offset / $rowCount) + 1;
+    $params['rp'] = $rowCount;
+
+    // get pcp list
+    $groups = CRM_PCP_BAO_PCP::getPcpListSelector($params);
+
+    $iFilteredTotal = $iTotal = $params['total'];
+    $selectorElements = array(
+      'pcp_name',
+      'pcp_supporter',
+      'pcp_page',
+      'pcp_start_date',
+      'pcp_end_date',
+      'pcp_status',
+      'action',
+      'class',
+    );
+
+    header('Content-Type: application/json');
+    echo CRM_Utils_JSON::encodeDataTableSelector($groups, $sEcho, $iTotal, $iFilteredTotal, $selectorElements);
+    CRM_Utils_System::civiExit();
+  }
+  
+  public static function approve() {
+    $id = CRM_Utils_Request::retrieve('id', 'Positive');
+    $action = CRM_Utils_Request::retrieve('action', 'String');
+    if ($action & CRM_Core_Action::RENEW) {
+      CRM_PCP_BAO_PCP::setIsActive($id, 1);
+      $response = array('status' => 'Approved',);
+      echo json_encode($response);
+      CRM_Utils_System::civiExit();
+    }
+  }
+  
+  public static function reject() {
+    $id = CRM_Utils_Request::retrieve('id', 'Positive');
+    $action = CRM_Utils_Request::retrieve('action', 'String');
+    if ($action & CRM_Core_Action::REVERT) {
+      CRM_PCP_BAO_PCP::setIsActive($id, 0);
+      $response = array('status' => 'Reverted',);
+      echo json_encode($response);
+      CRM_Utils_System::civiExit();
+    }
+  }
+
+}

--- a/CRM/PCP/Page/PCP.php
+++ b/CRM/PCP/Page/PCP.php
@@ -37,6 +37,7 @@
  * Page for displaying list of financial types
  */
 class CRM_PCP_Page_PCP extends CRM_Core_Page_Basic {
+   protected $_sortByCharacter;
 
   /**
    * The action links that we need to display for the browse screen.
@@ -62,101 +63,6 @@ class CRM_PCP_Page_PCP extends CRM_Core_Page_Basic {
    *   (reference) of action links
    */
   public function &links() {
-    if (!(self::$_links)) {
-      // helper variable for nicer formatting
-      $deleteExtra = ts('Are you sure you want to delete this Campaign Page ?');
-
-      self::$_links = array(
-        CRM_Core_Action::UPDATE => array(
-          'name' => ts('Edit'),
-          'url' => 'civicrm/pcp/info',
-          'qs' => 'action=update&reset=1&id=%%id%%&context=dashboard',
-          'title' => ts('Edit Personal Campaign Page'),
-        ),
-        CRM_Core_Action::RENEW => array(
-          'name' => ts('Approve'),
-          'url' => 'civicrm/admin/pcp',
-          'qs' => 'action=renew&id=%%id%%',
-          'title' => ts('Approve Personal Campaign Page'),
-        ),
-        CRM_Core_Action::REVERT => array(
-          'name' => ts('Reject'),
-          'url' => 'civicrm/admin/pcp',
-          'qs' => 'action=revert&id=%%id%%',
-          'title' => ts('Reject Personal Campaign Page'),
-        ),
-        CRM_Core_Action::DELETE => array(
-          'name' => ts('Delete'),
-          'url' => 'civicrm/admin/pcp',
-          'qs' => 'action=delete&id=%%id%%',
-          'extra' => 'onclick = "return confirm(\'' . $deleteExtra . '\');"',
-          'title' => ts('Delete Personal Campaign Page'),
-        ),
-        CRM_Core_Action::ENABLE => array(
-          'name' => ts('Enable'),
-          'url' => 'civicrm/admin/pcp',
-          'qs' => 'action=enable&id=%%id%%',
-          'title' => ts('Enable'),
-        ),
-        CRM_Core_Action::DISABLE => array(
-          'name' => ts('Disable'),
-          'url' => 'civicrm/admin/pcp',
-          'qs' => 'action=disable&id=%%id%%',
-          'title' => ts('Disable'),
-        ),
-      );
-    }
-    return self::$_links;
-  }
-
-  /**
-   * Run the page.
-   *
-   * This method is called after the page is created. It checks for the
-   * type of action and executes that action.
-   * Finally it calls the parent's run method.
-   *
-   * @param
-   *
-   * @return void
-   */
-  public function run() {
-    // get the requested action
-    $action = CRM_Utils_Request::retrieve('action', 'String',
-      $this, FALSE,
-      'browse'
-    );
-    if ($action & CRM_Core_Action::REVERT) {
-      $id = CRM_Utils_Request::retrieve('id', 'Positive', $this, FALSE);
-      CRM_PCP_BAO_PCP::setIsActive($id, 0);
-      $session = CRM_Core_Session::singleton();
-      $session->pushUserContext(CRM_Utils_System::url(CRM_Utils_System::currentPath(), 'reset=1'));
-    }
-    elseif ($action & CRM_Core_Action::RENEW) {
-      $id = CRM_Utils_Request::retrieve('id', 'Positive', $this, FALSE);
-      CRM_PCP_BAO_PCP::setIsActive($id, 1);
-      $session = CRM_Core_Session::singleton();
-      $session->pushUserContext(CRM_Utils_System::url(CRM_Utils_System::currentPath(), 'reset=1'));
-    }
-    elseif ($action & CRM_Core_Action::DELETE) {
-      $id = CRM_Utils_Request::retrieve('id', 'Positive', $this, FALSE);
-      $session = CRM_Core_Session::singleton();
-      $session->pushUserContext(CRM_Utils_System::url(CRM_Utils_System::currentPath(), 'reset=1&action=browse'));
-      $controller = new CRM_Core_Controller_Simple('CRM_PCP_Form_PCP',
-        'Personal Campaign Page',
-        CRM_Core_Action::DELETE
-      );
-      //$this->setContext( $id, $action );
-      $controller->set('id', $id);
-      $controller->process();
-      return $controller->run();
-    }
-
-    // finally browse
-    $this->browse();
-
-    // parent run
-    parent::run();
   }
 
   /**
@@ -168,189 +74,15 @@ class CRM_PCP_Page_PCP extends CRM_Core_Page_Basic {
    * @return void
    */
   public function browse($action = NULL) {
-    CRM_Core_Resources::singleton()->addStyleFile('civicrm', 'css/searchForm.css', 1, 'html-header');
-
-    $this->_sortByCharacter = CRM_Utils_Request::retrieve('sortByCharacter',
-      'String',
-      $this
-    );
-    if ($this->_sortByCharacter == 1 ||
-      !empty($_POST)
-    ) {
-      $this->_sortByCharacter = '';
-    }
-
-    $status = CRM_PCP_BAO_PCP::buildOptions('status_id', 'create');
-
-    $pcpSummary = $params = array();
-    $whereClause = NULL;
-
-    if (!empty($_POST) || !empty($_GET['page_type'])) {
-      if (!empty($_POST['status_id'])) {
-        $whereClause = ' AND cp.status_id = %1';
-        $params['1'] = array($_POST['status_id'], 'Integer');
-      }
-
-      if (!empty($_POST['page_type'])) {
-        $whereClause .= ' AND cp.page_type = %2';
-        $params['2'] = array($_POST['page_type'], 'String');
-      }
-      elseif (!empty($_GET['page_type'])) {
-        $whereClause .= ' AND cp.page_type = %2';
-        $params['2'] = array($_GET['page_type'], 'String');
-      }
-
-      if (!empty($_POST['page_id'])) {
-        $whereClause .= ' AND cp.page_id = %4 AND cp.page_type = "contribute"';
-        $params['4'] = array($_POST['page_id'], 'Integer');
-      }
-
-      if (!empty($_POST['event_id'])) {
-        $whereClause .= ' AND cp.page_id = %5 AND cp.page_type = "event"';
-        $params['5'] = array($_POST['event_id'], 'Integer');
-      }
-
-      if ($whereClause) {
-        $this->set('whereClause', $whereClause);
-        $this->set('params', $params);
-      }
-      else {
-        $this->set('whereClause', NULL);
-        $this->set('params', NULL);
-      }
-    }
-
-    $approvedId = CRM_Core_OptionGroup::getValue('pcp_status', 'Approved', 'name');
-
-    //check for delete CRM-4418
-    $allowToDelete = CRM_Core_Permission::check('delete in CiviContribute');
-
-    // get all contribution pages
-    $query = "SELECT id, title, start_date, end_date FROM civicrm_contribution_page WHERE (1)";
-    $cpages = CRM_Core_DAO::executeQuery($query);
-    while ($cpages->fetch()) {
-      $pages['contribute'][$cpages->id]['id'] = $cpages->id;
-      $pages['contribute'][$cpages->id]['title'] = $cpages->title;
-      $pages['contribute'][$cpages->id]['start_date'] = $cpages->start_date;
-      $pages['contribute'][$cpages->id]['end_date'] = $cpages->end_date;
-    }
-
-    // get all event pages. pcp campaign start and end dates for event related pcp's use the online registration start and end dates,
-    // although if target is contribution page this might not be correct. fixme? dgg
-    $query = "SELECT id, title, start_date, end_date, registration_start_date, registration_end_date
-                  FROM civicrm_event
-                  WHERE is_template IS NULL OR is_template != 1";
-    $epages = CRM_Core_DAO::executeQuery($query);
-    while ($epages->fetch()) {
-      $pages['event'][$epages->id]['id'] = $epages->id;
-      $pages['event'][$epages->id]['title'] = $epages->title;
-      $pages['event'][$epages->id]['start_date'] = $epages->registration_start_date;
-      $pages['event'][$epages->id]['end_date'] = $epages->registration_end_date;
-    }
-
-    $params = $this->get('params') ? $this->get('params') : array();
-
-    $title = '1';
-    if ($this->_sortByCharacter !== NULL) {
-      $clauses[] = "cp.title LIKE '" . strtolower(CRM_Core_DAO::escapeWildCardString($this->_sortByCharacter)) . "%'";
-    }
-
-    $query = "
-        SELECT cp.id, cp.contact_id , cp.status_id, cp.title, cp.is_active, cp.page_type, cp.page_id
-        FROM civicrm_pcp cp
-        WHERE $title" . $this->get('whereClause') . " ORDER BY cp.status_id";
-
-    $pcp = CRM_Core_DAO::executeQuery($query, $params);
-    while ($pcp->fetch()) {
-      $action = array_sum(array_keys($this->links()));
-      $contact = CRM_Contact_BAO_Contact::getDisplayAndImage($pcp->contact_id);
-
-      $class = '';
-
-      if ($pcp->status_id != $approvedId || $pcp->is_active != 1) {
-        $class = 'disabled';
-      }
-
-      switch ($pcp->status_id) {
-        case 2:
-          $action -= CRM_Core_Action::RENEW;
-          break;
-
-        case 3:
-          $action -= CRM_Core_Action::REVERT;
-          break;
-      }
-
-      switch ($pcp->is_active) {
-        case 1:
-          $action -= CRM_Core_Action::ENABLE;
-          break;
-
-        case 0:
-          $action -= CRM_Core_Action::DISABLE;
-          break;
-      }
-
-      if (!$allowToDelete) {
-        $action -= CRM_Core_Action::DELETE;
-      }
-
-      $page_type = $pcp->page_type;
-      $page_id = (int) $pcp->page_id;
-      if ($pages[$page_type][$page_id]['title'] == '' || $pages[$page_type][$page_id]['title'] == NULL) {
-        $title = '(no title found for ' . $page_type . ' id ' . $page_id . ')';
-      }
-      else {
-        $title = $pages[$page_type][$page_id]['title'];
-      }
-
-      if ($pcp->page_type == 'contribute') {
-        $pageUrl = CRM_Utils_System::url('civicrm/' . $page_type . '/transact', 'reset=1&id=' . $pcp->page_id);
-      }
-      else {
-        $pageUrl = CRM_Utils_System::url('civicrm/' . $page_type . '/register', 'reset=1&id=' . $pcp->page_id);
-      }
-
-      $pcpSummary[$pcp->id] = array(
-        'id' => $pcp->id,
-        'start_date' => $pages[$page_type][$page_id]['start_date'],
-        'end_date' => $pages[$page_type][$page_id]['end_date'],
-        'supporter' => $contact['0'],
-        'supporter_id' => $pcp->contact_id,
-        'status_id' => $status[$pcp->status_id],
-        'page_id' => $page_id,
-        'page_title' => $title,
-        'page_url' => $pageUrl,
-        'page_type' => $page_type,
-        'action' => CRM_Core_Action::formLink(self::links(), $action,
-          array('id' => $pcp->id), ts('more'), FALSE, 'contributionpage.pcp.list', 'PCP', $pcp->id
-        ),
-        'title' => $pcp->title,
-        'class' => $class,
-      );
-    }
-
     $this->search();
-    $this->pagerAToZ($this->get('whereClause'), $params);
-
-    $this->assign('rows', $pcpSummary);
-
-    // Let template know if user has run a search or not
-    if ($this->get('whereClause')) {
-      $this->assign('isSearch', 1);
-    }
-    else {
-      $this->assign('isSearch', 0);
-    }
   }
 
   public function search() {
-
     if ($this->_action & CRM_Core_Action::DELETE) {
       return;
     }
 
-    $form = new CRM_Core_Controller_Simple('CRM_PCP_Form_PCP', ts('Search Campaign Pages'), CRM_Core_Action::ADD);
+    $form = new CRM_Core_Controller_Simple('CRM_PCP_Form_Search', ts('Search Campaign Pages'), CRM_Core_Action::ADD);
     $form->setEmbedded(TRUE);
     $form->setParent($this);
     $form->process();
@@ -376,6 +108,15 @@ class CRM_PCP_Page_PCP extends CRM_Core_Page_Basic {
   public function editName() {
     return ts('Personal Campaign Page');
   }
+  
+  /**
+   * Return name of delete form.
+   *
+   * @return string
+   */
+  public function deleteName() {
+    return 'Delete Personal Campaign Page';
+  }
 
   /**
    * Get user context.
@@ -386,7 +127,18 @@ class CRM_PCP_Page_PCP extends CRM_Core_Page_Basic {
    *   user context.
    */
   public function userContext($mode = NULL) {
-    return 'civicrm/admin/pcp';
+    return 'civicrm/pcp';
+  }
+  
+   /**
+   * Return user context uri params.
+   *
+   * @param null $mode
+   *
+   * @return string
+   */
+  public function userContextParams($mode = NULL) {
+    return 'reset=1&action=browse';
   }
 
   /**

--- a/templates/CRM/PCP/Form/Search.tpl
+++ b/templates/CRM/PCP/Form/Search.tpl
@@ -1,0 +1,223 @@
+{*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2016                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*}
+<div class="crm-block crm-form-block crm-pcp-search-form-block">
+
+<h3>{ts}Find Campaign Pages{/ts}</h3>
+<table class="form-layout">
+  <tr>
+    <td>
+      {$form.title.label}<br />
+      {$form.title.html}<br />
+      <span class="description font-italic">
+          {ts}Complete OR partial pcp Name.{/ts}
+      </span>
+    </td>
+    <td>
+      {$form.supporter.label}<br />
+      {$form.supporter.html}<br />
+      <span class="description font-italic">
+          {ts}Complete OR partial pcp supporter Name/Email.{/ts}
+      </span>
+    </td>
+    <td>
+      {$form.status_id.label}<br />
+      {$form.status_id.html}<br />
+      <span class="description font-italic">
+          {ts}Filter search by Status.{/ts}
+      </span>
+    </td>
+  </tr>
+  <tr>
+    <td id="pcp_type-block">
+      {$form.page_type.label}<br />
+      {$form.page_type.html}<br />
+      <span class="description font-italic">
+          {ts}Filter search by pcp Type.{/ts}
+      </span>
+    </td>
+    <td>
+      {$form.page_id.label}<br />
+      {$form.page_id.html|crmAddClass:twenty}<br />
+      <span class="description font-italic">
+          {ts}Filter search by Contribution Page.{/ts}
+      </span>
+    </td>
+    <td>
+      {$form.event_id.label}<br />
+      {$form.event_id.html|crmAddClass:twenty}<br />
+      <span class="description font-italic">
+          {ts}Filter search by Event.{/ts}
+      </span>
+    </td>
+  </tr>
+  <tr>
+    <td>{$form.start_date.label}<br />
+      {include file="CRM/common/jcalendar.tpl" elementName=start_date}<br />
+      <span class="description font-italic">
+	{ts}Filter search by Contribution/Event Start Date{/ts}
+      </span>
+    </td>
+    <td>{$form.end_date.label}<br />
+      {include file="CRM/common/jcalendar.tpl" elementName=end_date}<br />
+      <span class="description font-italic">
+	{ts}Filter search by Contribution/Event End Date{/ts}
+      </span>
+    </td>
+  </tr>
+  <tr>
+     <td>{$form.buttons.html}</td><td colspan="2">
+  </tr>
+</table>
+</div>
+<table class="crm-pcp-selector">
+  <thead>
+    <tr>
+      <th class='crm-pcp-search-form-block-name'>{ts}Page Title{/ts}</th>
+      <th class='crm-pcp-supporter'>{ts}Supporter{/ts}</th>
+      <th class='crm-pcp-page-type'>{ts}Contribution Page/Event{/ts}</th>
+      <th class='crm-pcp-start'>{ts}Starts{/ts}</th>
+      <th class='crm-pcp-end'>{ts}Ends{/ts}</th>
+      <th class='crm-pcp-status'>{ts}Status{/ts}</th>
+      <th class='crm-pcp-pcp_links nosort'>&nbsp;</th>
+      <th class='hiddenElement'>&nbsp;</th>
+    </tr>
+  </thead>
+</table>
+
+{* handle enable/disable actions*}
+{include file="CRM/common/enableDisableApi.tpl"}
+
+{literal}
+<script type="text/javascript">
+CRM.$(function($) {
+  buildPcpSelector(true, 1);
+  $('#_qf_Search_refresh').click( function() {
+    buildPcpSelector( true );
+  });
+  // Add livePage functionality
+  $('#crm-container')
+    .on('click', 'a.button, a.action-item[href*="action=delete"]', CRM.popup)
+    .on('crmPopupFormSuccess', 'a.button, a.action-item[href*="action=delete"]', function() {
+        // Refresh datatable when form completes
+        var $context = $('#crm-main-content-wrapper');
+        $('table.crm-pcp-selector', $context).dataTable().fnDraw();
+    });
+
+  function buildPcpSelector( filterSearch) {
+    if ( filterSearch ) {
+      if (typeof crmPcpSelector !== 'undefined') {
+        crmPcpSelector.fnDestroy();
+      }
+      var ZeroRecordText = '<div class="status messages">{/literal}{ts escape="js"}No matching PCPs found for your search criteria. Suggestions:{/ts}{literal}<div class="spacer"></div><ul><li>{/literal}{ts escape="js"}Check your spelling.{/ts}{literal}</li><li>{/literal}{ts escape="js"}Try a different spelling or use fewer letters.{/ts}{literal}</li><li>{/literal}{ts escape="js"}Make sure you have enough privileges in the access control system.{/ts}{literal}</li></ul></div>';
+    } else {
+        var ZeroRecordText = {/literal}'{ts escape="js"}<div class="status messages">No PCPs have been created for this site.{/ts}</div>'{literal};
+    }
+
+    var columns = '';
+    var sourceUrl = {/literal}'{crmURL p="civicrm/ajax/pcplist" h=0 q="snippet=4"}'{literal};
+    var $context = $('#crm-main-content-wrapper');
+
+    crmPcpSelector = $('table.crm-pcp-selector', $context).dataTable({
+        "bFilter"    : false,
+        "bAutoWidth" : false,
+        "aaSorting"  : [],
+        "aoColumns"  : [
+                        {sClass:'crm-pcp-name'},
+                        {sClass:'crm-pcp-supporter'},
+                        {sClass:'crm-pcp-page-type'},
+                        {sClass:'crm-pcp-start'},
+                        {sClass:'crm-pcp-end'},
+                        {sClass:'crm-pcp-status'},
+                        {sClass:'crm-pcp-pcp_links', bSortable:false},
+			{sClass:'hiddenElement', bSortable:false}
+                       ],
+        "bProcessing": true,
+        "asStripClasses" : [ "odd-row", "even-row" ],
+        "sPaginationType": "full_numbers",
+        "sDom"       : '<"crm-datatable-pager-top"lfp>rt<"crm-datatable-pager-bottom"ip>',
+        "bServerSide": true,
+        "bJQueryUI": true,
+        "sAjaxSource": sourceUrl,
+        "iDisplayLength": 25,
+        "oLanguage": { "sZeroRecords":  ZeroRecordText,
+                       "sProcessing":    {/literal}"{ts escape='js'}Processing...{/ts}"{literal},
+                       "sLengthMenu":    {/literal}"{ts escape='js'}Show _MENU_ entries{/ts}"{literal},
+                       "sInfo":          {/literal}"{ts escape='js'}Showing _START_ to _END_ of _TOTAL_ entries{/ts}"{literal},
+                       "sInfoEmpty":     {/literal}"{ts escape='js'}Showing 0 to 0 of 0 entries{/ts}"{literal},
+                       "sInfoFiltered":  {/literal}"{ts escape='js'}(filtered from _MAX_ total entries){/ts}"{literal},
+                       "sSearch":        {/literal}"{ts escape='js'}Search:{/ts}"{literal},
+                       "oPaginate": {
+                            "sFirst":    {/literal}"{ts escape='js'}First{/ts}"{literal},
+                            "sPrevious": {/literal}"{ts escape='js'}Previous{/ts}"{literal},
+                            "sNext":     {/literal}"{ts escape='js'}Next{/ts}"{literal},
+                            "sLast":     {/literal}"{ts escape='js'}Last{/ts}"{literal}
+                        }
+                    },
+        "fnRowCallback": function(nRow, aData, iDisplayIndex, iDisplayIndexFull) {
+	  var status = $('.crm-pcp-status', nRow).text();
+	  var action = '';
+	  if(status=='Approved'){
+	    action = 'revert';
+	  } else {
+	    action = 'renew';
+	  }
+	  var id = $('td:last', nRow).text().split(',')[0];
+          var cl = $('td:last', nRow).text().split(',')[1];
+          $(nRow).addClass(cl).attr({id: 'row_' + id, 'data-id': id, 'data-entity': 'PCP', 'action': action});
+          return nRow;
+        },
+        "fnDrawCallback": function() {
+          // FIXME: trigger crmLoad and crmEditable would happen automatically
+          $('.crm-editable').crmEditable();
+        },
+        "fnServerData": function ( sSource, aoData, fnCallback ) {
+            if ( filterSearch ) {
+                aoData.push(
+                    {name:'title', value: $('.crm-pcp-search-form-block #title').val()},
+                    {name:'page_type', value: $('.crm-pcp-search-form-block #page_type').val()},
+                    {name:'page_id', value: $('.crm-pcp-search-form-block #page_id').val()},
+                    {name:'event_id', value: $('.crm-pcp-search-form-block #event_id').val()},
+                    {name:'status_id', value: $('.crm-pcp-search-form-block #status_id').val()},
+                    {name:'supporter', value: $('.crm-pcp-search-form-block #supporter').val()},
+                    {name:'start_date', value: $('.crm-pcp-search-form-block #start_date').val()},
+                    {name:'end_date', value: $('.crm-pcp-search-form-block #end_date').val()}
+                );
+            }
+            $.ajax( {
+                "dataType": 'json',
+                "type": "POST",
+                "url": sSource,
+                "data": aoData,
+                "success": fnCallback
+            } );
+        }
+    });
+  }
+
+});
+
+</script>
+{/literal}

--- a/templates/CRM/PCP/Page/PCP.tpl
+++ b/templates/CRM/PCP/Page/PCP.tpl
@@ -23,57 +23,62 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-<div class="help">
-{ts}This screen shows all the Personal Campaign Pages created in the system and allows administrator to review them and change their status.{/ts} {help id="id-pcp-intro"}
-</div>
-{if $action ne 8}
-{include file="CRM/PCP/Form/PCP/PCP.tpl"}
-{else}
+{if $action ne 2 AND $action ne 8}
+{include file="CRM/PCP/Form/Search.tpl"}
+{/if}
+{if $action eq 8}
 {include file="CRM/PCP/Form/PCP/Delete.tpl"}
 {/if}
+{*approve/reject Personal Campaign Page*}
+{literal}
+<script type="text/javascript">
+CRM.$(function($) {
+  $('#crm-container')
+    .on('click', 'a.button, a.action-item[title*="Reject Personal Campaign Page"]', function(e) {
+       e.preventDefault();
+    var $el = $(this).closest('tr');
+    CRM.confirm({
+      title: ts('{/literal}{ts escape="js"}Reject Campaign Page{/ts}{literal}'),
+      message: ts('{/literal}{ts escape="js"}Are you sure you want to revert the Campaign Page?{/ts}{literal}'),
+      options: {{/literal}yes: '{ts escape="js"}Yes{/ts}', no: '{ts escape="js"}No{/ts}'{literal}},
+      width: 300,
+      height: 'auto'
+    }).on('crmConfirm:yes', function() {
+      CRM.status({/literal}"{ts escape='js'}Saving...{/ts}"{literal}, request);
+      var postUrl = {/literal}"{crmURL p='civicrm/ajax/rest' h=0 q='snippet=4&className=CRM_PCP_Page_AJAX&fnName=reject'}"{literal};
+      var request = $.post(postUrl, {id : $el.attr('data-id'), action : $el.attr('action'), dataType: 'json',});
+      request.done(function(data) {
+	if (data.status = "Reverted") {
+	  CRM.status({/literal}"{ts escape='js'}Record Reverted{/ts}"{literal}, request);
+	  CRM.refreshParent($el);
+	} 
+      });
+    });
+  });
+  
+  $('#crm-container')
+    .on('click', 'a.button, a.action-item[title*="Approve Personal Campaign Page"]', function(e) {
+       e.preventDefault();
+    var $el = $(this).closest('tr');
+    CRM.confirm({
+      title: ts('{/literal}{ts escape="js"}Approve Campaign Page{/ts}{literal}'),
+      message: ts('{/literal}{ts escape="js"}Are you sure you want to approve the Campaign Page?{/ts}{literal}'),
+      options: {{/literal}yes: '{ts escape="js"}Yes{/ts}', no: '{ts escape="js"}No{/ts}'{literal}},
+      width: 300,
+      height: 'auto'
+    }).on('crmConfirm:yes', function() {
+      CRM.status({/literal}"{ts escape='js'}Saving...{/ts}"{literal}, request);
+      var postUrl = {/literal}"{crmURL p='civicrm/ajax/rest' h=0 q='snippet=4&className=CRM_PCP_Page_AJAX&fnName=approve'}"{literal};
+      var request = $.post(postUrl, {id : $el.attr('data-id'), action : $el.attr('action'), dataType: 'json',});
+      request.done(function(data) {
+	if (data.status = "Approved") {
+	  CRM.status({/literal}"{ts escape='js'}Record Approved{/ts}"{literal}, request);
+	  CRM.refreshParent($el);
+	} 
+      });
+    });
+  });
 
-{if $rows}
-<div id="ltype">
-<p></p>
-{include file="CRM/common/pager.tpl" location="top"}
-{include file="CRM/common/pagerAToZ.tpl"}
-{include file="CRM/common/jsortable.tpl"}
-{strip}
-<table id="options" class="display">
-  <thead>
-    <tr>
-    <th>{ts}Page Title{/ts}</th>
-    <th>{ts}Supporter{/ts}</th>
-    <th>{ts}Contribution Page / Event{/ts}</th>
-    <th>{ts}Starts{/ts}</th>
-    <th>{ts}Ends{/ts}</th>
-    <th>{ts}Status{/ts}</th>
-    <th></th>
-    </tr>
-  </thead>
-  <tbody>
-  {foreach from=$rows item=row}
-  <tr id="row_{$row.id}" class="{$row.class}">
-    <td><a href="{crmURL p='civicrm/pcp/info' q="reset=1&id=`$row.id`" fe='true'}" title="{ts}View Personal Campaign Page{/ts}" target="_blank">{$row.title}</a></td>
-    <td><a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.supporter_id`"}" title="{ts}View contact record{/ts}">{$row.supporter}</a></td>
-    <td><a href="{$row.page_url}" title="{ts}View page{/ts}" target="_blank">{$row.page_title}</td>
-    <td>{$row.start_date|crmDate}</td>
-    <td>{if $row.end_date}{$row.end_date|crmDate}{else}({ts}ongoing{/ts}){/if}</td>
-    <td>{$row.status_id}</td>
-    <td id={$row.id}>{$row.action|replace:'xx':$row.id}</td>
-  </tr>
-  {/foreach}
-  </tbody>
-</table>
-{/strip}
-</div>
-{else}
-<div class="messages status no-popup">
-<div class="icon inform-icon"></div>
-    {if $isSearch}
-        {ts}There are no Personal Campaign Pages which match your search criteria.{/ts}
-    {else}
-        {ts}There are currently no Personal Campaign Pages.{/ts}
-    {/if}
-</div>
-{/if}
+});
+</script>
+{/literal}


### PR DESCRIPTION
PCP Search screen improved similar to Group Search screen

issue:- If we have too many Personal Campaign Pages, server crashes because search page brings all PCPs every time we navigate to PCP search

Further, PCP search screen has lack of filters like PCP supporter Name, PCP title, Event/Contribution starts, Event/Contribution Ends on and etc. 

https://issues.civicrm.org/jira/browse/CRM-18323
