### PR TITLE
CRM-18327 Fix filter value  on the contact deleted by merge activity

### DIFF
--- a/CRM/Upgrade/Incremental/php/FourSeven.php
+++ b/CRM/Upgrade/Incremental/php/FourSeven.php
@@ -552,6 +552,7 @@ FROM `civicrm_dashboard_contact` JOIN `civicrm_contact` WHERE civicrm_dashboard_
       'label' => ts('Contact Deleted by Merge'),
       'description' => ts('Contact was merged into another contact'),
       'is_active' => TRUE,
+      'filter' => 1,
     ));
     return TRUE;
   }

--- a/CRM/Upgrade/Incremental/sql/4.7.5.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.7.5.mysql.tpl
@@ -16,3 +16,9 @@ SET
   nav2.weight = nav1.weight,
   nav2.has_separator = 1,
   nav2.label = 'Extensions';
+
+--CRM-18327 filter value missed on the contact deleted by merge activity --
+UPDATE civicrm_option_value ov
+LEFT JOIN civicrm_option_group og ON og.id = ov.option_group_id
+SET filter = 1
+WHERE ov.name = 'Contact Deleted by Merge' AND og.name = 'activity_type'


### PR DESCRIPTION
Note new installs should be OK on this...

---
- [CRM-18327: New Contact Deleted by merge Activity Type is displayed where it shouldn't be](https://issues.civicrm.org/jira/browse/CRM-18327)
