### PR TITLE
[Ready for Core Team review] CRM-17463 re-work Group Gontact Cache clause

### DIFF
--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -313,6 +313,7 @@ WHERE  id IN ( $groupIDs )
     }
 
     $refresh = NULL;
+    $update = NULL;
     $params = array();
     $smartGroupCacheTimeout = self::smartGroupCacheTimeout();
 
@@ -324,6 +325,7 @@ WHERE  id IN ( $groupIDs )
         $query = "
 TRUNCATE civicrm_group_contact_cache
 ";
+        CRM_Core_DAO::executeQuery($query);
         $update = "
 UPDATE civicrm_group g
 SET    cache_date = null,
@@ -331,27 +333,37 @@ SET    cache_date = null,
 ";
       }
       else {
-
-        $query = "
-DELETE     gc
-FROM       civicrm_group_contact_cache gc
-INNER JOIN civicrm_group g ON g.id = gc.group_id
-WHERE      g.cache_date <= %1
-";
-        $update = "
-UPDATE civicrm_group g
-SET    cache_date = null,
-       refresh_date = null
-WHERE  g.cache_date <= %1
-";
-        $refresh = "
-UPDATE civicrm_group g
-SET    refresh_date = $refreshTime
-WHERE  g.cache_date > %1
-AND    refresh_date IS NULL
-";
+        $groupsQuery = "SELECT id
+          FROM civicrm_group
+          WHERE cache_date <= %1 
+        ";
         $cacheTime = date('Y-m-d H-i-s', strtotime("- $smartGroupCacheTimeout minutes"));
         $params = array(1 => array($cacheTime, 'String'));
+        $dao = CRM_Core_DAO::executeQuery($groupsQuery, $params);
+        $groupsIDs = array();
+        while ($dao->fetch()) {
+          $groupsIDs[] = $dao->id;
+          $params[2] = array($dao->id, 'Integer');
+          $query = "
+            DELETE g
+            FROM  civicrm_group_contact_cache g
+            WHERE g.group_id = %2
+            ";
+          CRM_Core_DAO::executeQuery($query, $params);
+        }
+        if ($groupsIDs) {
+          $groups = implode(',', $groupsIDs);
+          $update = "
+            UPDATE civicrm_group
+            SET cache_date = $now,
+            refresh_date = null
+            WHERE id IN ( $groups )";
+          $refresh = "
+            UPDATE civicrm_group
+            SET    refresh_date = $refreshTime
+            WHERE  id IN ( $groups )
+            AND    refresh_date IS NULL";
+        }
       }
     }
     elseif (is_array($groupID)) {
@@ -361,19 +373,23 @@ DELETE     g
 FROM       civicrm_group_contact_cache g
 WHERE      g.group_id IN ( $groupIDs )
 ";
+      CRM_Core_DAO::executeQuery($query);
+
       $update = "
 UPDATE civicrm_group g
-SET    cache_date = null,
+SET    cache_date = $now,
        refresh_date = null
 WHERE  id IN ( $groupIDs )
 ";
     }
     else {
+
       $query = "
 DELETE     g
 FROM       civicrm_group_contact_cache g
 WHERE      g.group_id = %1
 ";
+
       $update = "
 UPDATE civicrm_group g
 SET    cache_date = null,
@@ -381,16 +397,18 @@ SET    cache_date = null,
 WHERE  id = %1
 ";
       $params = array(1 => array($groupID, 'Integer'));
+      CRM_Core_DAO::executeQuery($query, $params);
+
     }
 
-    CRM_Core_DAO::executeQuery($query, $params);
+    if ($update) {
+      // also update the cache_date for these groups
+      CRM_Core_DAO::executeQuery($update, $params);
+    }
 
     if ($refresh) {
       CRM_Core_DAO::executeQuery($refresh, $params);
     }
-
-    // also update the cache_date for these groups
-    CRM_Core_DAO::executeQuery($update, $params);
   }
 
   /**

--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -333,10 +333,7 @@ SET    cache_date = null,
 ";
       }
       else {
-        $groupsQuery = "SELECT id
-          FROM civicrm_group
-          WHERE cache_date <= %1 
-        ";
+        $groupsQuery = self::groupRefreshedClause();
         $cacheTime = date('Y-m-d H-i-s', strtotime("- $smartGroupCacheTimeout minutes"));
         $params = array(1 => array($cacheTime, 'String'));
         $dao = CRM_Core_DAO::executeQuery($groupsQuery, $params);
@@ -355,7 +352,7 @@ SET    cache_date = null,
           $groups = implode(',', $groupsIDs);
           $update = "
             UPDATE civicrm_group
-            SET cache_date = $now,
+            SET cache_date = null,
             refresh_date = null
             WHERE id IN ( $groups )";
           $refresh = "
@@ -377,7 +374,7 @@ WHERE      g.group_id IN ( $groupIDs )
 
       $update = "
 UPDATE civicrm_group g
-SET    cache_date = $now,
+SET    cache_date = null,
        refresh_date = null
 WHERE  id IN ( $groupIDs )
 ";
@@ -392,7 +389,7 @@ WHERE      g.group_id = %1
 
       $update = "
 UPDATE civicrm_group g
-SET    cache_date = $now,
+SET    cache_date = null,
        refresh_date = null
 WHERE  id = %1
 ";

--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -392,7 +392,7 @@ WHERE      g.group_id = %1
 
       $update = "
 UPDATE civicrm_group g
-SET    cache_date = null,
+SET    cache_date = $now,
        refresh_date = null
 WHERE  id = %1
 ";


### PR DESCRIPTION
This should mean that we clear the cache table on a group by group basis when no groups are specified in the groupsID param and also we actually set a cache_date

---
- [CRM-17463: Deadlocks on group_cache clearing](https://issues.civicrm.org/jira/browse/CRM-17463)
