### PR TITLE
scripts/phpunit-{ls,indiv} - Fixes for standalone PHPUnit

### DIFF
--- a/tools/scripts/phpunit-indiv
+++ b/tools/scripts/phpunit-indiv
@@ -54,6 +54,8 @@ fi
 
 #phpunit-ls "$TESTSUITE"
 $BINDIR/phpunit-ls "$TESTSUITE" | while read FILE CLASS METHOD ; do
+  if [ -z "$FILE" -o ! -f "$FILE" ]; then continue; fi
+  echo "[[Processing $FILE $CLASS::$METHOD]]"
   ## Optionally reset DBs
   if [ -n "$CIVIBUILD_RESTORE" ]; then
     civibuild restore "$CIVIBUILD_RESTORE"

--- a/tools/scripts/phpunit-ls
+++ b/tools/scripts/phpunit-ls
@@ -1,5 +1,17 @@
 #!/usr/bin/env php
 <?php
+
 require_once dirname(dirname(__DIR__)) . '/tests/phpunit/CiviTest/bootstrap.php';
 error_reporting(E_ALL);
+
+if (!class_exists('PHPUnit_Framework_TestCase')) {
+  // Oooph.  PHPUnit isn't available, and we don't really need its services,
+  // but the scanner will try to read metadata about our test-classes, and
+  // that requires having the parent-classes defined.
+
+  class PHPUnit_Framework_TestCase {}
+  class PHPUnit_Extensions_Database_TestCase {}
+  class PHPUnit_Extensions_SeleniumTestCase {}
+}
+
 \Civi\CiUtil\Command\LsCommand::main($argv);


### PR DESCRIPTION
The `phpunit-ls` scanner crashes with errors like `PHP Fatal error: Class
'PHPUnit_Extensions_SeleniumTestCase' not found` because the PHPUnit is no
longer bundled into core. This makes it unnecessary.
