### PR TITLE
CRM-18317 - Links to Drupal system broken if hook altered by a module

### DIFF
--- a/CRM/Admin/Page/Access.php
+++ b/CRM/Admin/Page/Access.php
@@ -45,11 +45,11 @@ class CRM_Admin_Page_Access extends CRM_Core_Page {
 
     switch ($config->userFramework) {
       case 'Drupal':
-        $this->assign('ufAccessURL', CRM_Utils_System::url('admin/people/permissions'));
+        $this->assign('ufAccessURL', url('admin/people/permissions'));
         break;
 
       case 'Drupal6':
-        $this->assign('ufAccessURL', CRM_Utils_System::url('admin/user/permissions'));
+        $this->assign('ufAccessURL', url('admin/user/permissions'));
         break;
 
       case 'Joomla':

--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -149,7 +149,7 @@ class CRM_Utils_System_Drupal extends CRM_Utils_System_DrupalBase {
           array(':mail' => $params['mail'])
         )->fetchField();
         if ((bool) $uid) {
-          $resetUrl = $config->userFrameworkBaseURL . 'user/password';
+          $resetUrl = url('user/password');
           $errors[$emailName] = ts('The email address %1 is already registered. <a href="%2">Have you forgotten your password?</a>',
             array(1 => $params['mail'], 2 => $resetUrl)
           );

--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -249,7 +249,7 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
           'cms:view user account',
         ))
     ) {
-      return CRM_Utils_System::url('user/' . $uid);
+      return url('user/' . $uid);
     };
   }
 


### PR DESCRIPTION
This is what I suggest for fixing broken links to custom Drupal system paths on:
civicrm/contact/view?reset=1&cid=1
civicrm/admin/access?reset=1

Test with a Drupal module like [Rename Admin Paths](https://www.drupal.org/project/rename_admin_paths) configured to alter the system paths admin/... and user/...

I have tested these on D7 & 4.6.14 & 4.7.4.

I note url() is depreciated from D8, but there is a Civi D8 url() class function that presumably takes over.

Is this ok?

---
- [CRM-18317: Links to Drupal system broken if hook altered by a module](https://issues.civicrm.org/jira/browse/CRM-18317)
