### PR TITLE
CRM-18343: Ajax CRM test failure fixes

### DIFF
--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -750,7 +750,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
         $value['class'] = array_diff($value['class'], array('crm-row-parent'));
       }
       $group['DT_RowId'] = 'row_' . $value['id'];
-      if (!$params['parentsOnly']) {
+      if (!empty($params['parentsOnly'])) {
         foreach ($value['class'] as $id => $class) {
           if ($class == 'crm-group-parent') {
             unset($value['class'][$id]);
@@ -778,7 +778,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
 
       $group['is_parent'] = $value['is_parent'];
 
-      array_push($groupList, $group);
+      $groupList[$id] = $group;
     }
 
     $groupsDT = array();
@@ -801,7 +801,6 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
     $config = CRM_Core_Config::singleton();
 
     $whereClause = self::whereClause($params, FALSE);
-
     //$this->pagerAToZ( $whereClause, $params );
 
     if (!empty($params['rowCount']) &&

--- a/CRM/Group/Page/AJAX.php
+++ b/CRM/Group/Page/AJAX.php
@@ -43,7 +43,6 @@ class CRM_Group_Page_AJAX {
    */
   public static function getGroupList() {
     $params = $_GET;
-
     if (isset($params['parent_id'])) {
       // requesting child groups for a given parent
       $params['page'] = 1;
@@ -55,7 +54,8 @@ class CRM_Group_Page_AJAX {
     else {
 
       $sortMapper = array();
-      foreach ($_GET['columns'] as $key => $value) {
+      $columns = CRM_Utils_Array::value('columns', $params, array());
+      foreach ($columns as $key => $value) {
         $sortMapper[$key] = $value['data'];
       };
 
@@ -90,7 +90,7 @@ class CRM_Group_Page_AJAX {
       //@todo - ideally the portion of this that retrieves the groups should be extracted into a function separate
       // from the one which deals with web inputs & outputs so we have a properly testable & re-usable function
       if (!empty($params['is_unit_test'])) {
-        return array($groups, $iFilteredTotal);
+        return array($groups['data'], $params['total']);
       }
       CRM_Utils_JSON::output($groups);
     }

--- a/tests/phpunit/CRM/Group/Page/AjaxTest.php
+++ b/tests/phpunit/CRM/Group/Page/AjaxTest.php
@@ -65,8 +65,8 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
   public function setPermissionAndRequest($permission) {
     CRM_Core_Config::singleton()->userPermissionClass->permissions = (array) $permission;
     CRM_Contact_BAO_Group::getPermissionClause(TRUE);
-    global $_REQUEST;
-    $_REQUEST = $this->_params;
+    global $_GET;
+    $_GET = $this->_params;
   }
 
   /**
@@ -77,8 +77,8 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
     CRM_Core_Config::singleton()->userPermissionClass->permissions = (array) $permission;
     $this->hookClass->setHook('civicrm_aclGroup', array($this, $hook));
     CRM_Contact_BAO_Group::getPermissionClause(TRUE);
-    global $_REQUEST;
-    $_REQUEST = $this->_params;
+    global $_GET;
+    $_GET = $this->_params;
   }
 
   /**
@@ -88,8 +88,8 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
     $this->setPermissionAndRequest(array('view all contacts', 'edit groups'));
     list($groups, $total) = CRM_Group_Page_AJAX::getGroupList();
     $this->assertEquals(2, $total);
-    $this->assertEquals('<span class="crm-editable crmf-title">pick-me-active</span>', $groups[2]['group_name']);
-    $this->assertEquals('<span class="crm-editable crmf-title">not-me-active</span>', $groups[4]['group_name']);
+    $this->assertEquals('pick-me-active', $groups[2]['title']);
+    $this->assertEquals('not-me-active', $groups[4]['title']);
   }
 
   /**
@@ -99,15 +99,15 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
     $this->setPermissionAndRequest('view all contacts');
     list($groups, $total) = CRM_Group_Page_AJAX::getGroupList();
     $this->assertEquals(2, $total);
-    $this->assertEquals('pick-me-active', $groups[2]['group_name']);
-    $this->assertEquals('not-me-active', $groups[4]['group_name']);
+    $this->assertEquals('pick-me-active', $groups[2]['title']);
+    $this->assertEquals('not-me-active', $groups[4]['title']);
 
     // as per changes made in PR-6822
     $this->setPermissionAndRequest(array('view all contacts', 'edit groups'));
     list($groups, $total) = CRM_Group_Page_AJAX::getGroupList();
     $this->assertEquals(2, $total);
-    $this->assertEquals('<span class="crm-editable crmf-title">pick-me-active</span>', $groups[2]['group_name']);
-    $this->assertEquals('<span class="crm-editable crmf-title">not-me-active</span>', $groups[4]['group_name']);
+    $this->assertEquals('pick-me-active', $groups[2]['title']);
+    $this->assertEquals('not-me-active', $groups[4]['title']);
   }
 
   /**
@@ -120,8 +120,8 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
     $this->setPermissionAndRequest(array('view all contacts', 'edit groups'));
     list($groups, $total) = CRM_Group_Page_AJAX::getGroupList();
     $this->assertEquals(2, $total);
-    $this->assertEquals('<span class="crm-editable crmf-title">pick-me-active</span>', $groups[2]['group_name']);
-    $this->assertEquals('<span class="crm-editable crmf-title">pick-me-disabled</span>', $groups[1]['group_name']);
+    $this->assertEquals('pick-me-active', $groups[2]['title']);
+    $this->assertEquals('pick-me-disabled', $groups[1]['title']);
   }
 
   /**
@@ -141,8 +141,8 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
     $this->setPermissionAndRequest(array('edit all contacts', 'edit groups'));
     list($groups, $total) = CRM_Group_Page_AJAX::getGroupList();
     $this->assertEquals(2, $total);
-    $this->assertEquals('<span class="crm-editable crmf-title">pick-me-active</span>', $groups[2]['group_name']);
-    $this->assertEquals('<span class="crm-editable crmf-title">not-me-active</span>', $groups[4]['group_name']);
+    $this->assertEquals('pick-me-active', $groups[2]['title']);
+    $this->assertEquals('not-me-active', $groups[4]['title']);
   }
 
   /**
@@ -153,8 +153,8 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
     $this->setPermissionAndRequest(array('view all contacts', 'edit groups'));
     list($groups, $total) = CRM_Group_Page_AJAX::getGroupList();
     $this->assertEquals(2, $total);
-    $this->assertEquals('<span class="crm-editable crmf-title">pick-me-active</span>', $groups[2]['group_name']);
-    $this->assertEquals('<span class="crm-editable crmf-title">not-me-active</span>', $groups[4]['group_name']);
+    $this->assertEquals('pick-me-active', $groups[2]['title']);
+    $this->assertEquals('not-me-active', $groups[4]['title']);
   }
 
   /**
@@ -165,8 +165,8 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
     $this->setPermissionAndRequest(array('view all contacts', 'edit groups'));
     list($groups, $total) = CRM_Group_Page_AJAX::getGroupList();
     $this->assertEquals(2, $total);
-    $this->assertEquals('<span class="crm-editable crmf-title">pick-me-disabled</span>', $groups[1]['group_name']);
-    $this->assertEquals('<span class="crm-editable crmf-title">not-me-disabled</span>', $groups[3]['group_name']);
+    $this->assertEquals('pick-me-disabled', $groups[1]['title']);
+    $this->assertEquals('not-me-disabled', $groups[3]['title']);
   }
 
   /**
@@ -178,7 +178,7 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
     $this->setPermissionAndRequest(array('view all contacts', 'edit groups'));
     list($groups, $total) = CRM_Group_Page_AJAX::getGroupList();
     $this->assertEquals(1, $total);
-    $this->assertEquals('<span class="crm-editable crmf-title">not-me-disabled</span>', $groups[3]['group_name']);
+    $this->assertEquals('not-me-disabled', $groups[3]['title']);
   }
 
   /**
@@ -190,7 +190,7 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
     $this->setPermissionAndRequest(array('view all contacts', 'edit groups'));
     list($groups, $total) = CRM_Group_Page_AJAX::getGroupList();
     $this->assertEquals(1, $total);
-    $this->assertEquals('<span class="crm-editable crmf-title">pick-me-disabled</span>', $groups[1]['group_name']);
+    $this->assertEquals('pick-me-disabled', $groups[1]['title']);
   }
 
   /**
@@ -201,10 +201,10 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
     $this->setPermissionAndRequest(array('view all contacts', 'edit groups'));
     list($groups, $total) = CRM_Group_Page_AJAX::getGroupList();
     $this->assertEquals(4, $total);
-    $this->assertEquals('<span class="crm-editable crmf-title">pick-me-disabled</span>', $groups[1]['group_name']);
-    $this->assertEquals('<span class="crm-editable crmf-title">not-me-disabled</span>', $groups[3]['group_name']);
-    $this->assertEquals('<span class="crm-editable crmf-title">pick-me-active</span>', $groups[2]['group_name']);
-    $this->assertEquals('<span class="crm-editable crmf-title">not-me-active</span>', $groups[4]['group_name']);
+    $this->assertEquals('pick-me-disabled', $groups[1]['title']);
+    $this->assertEquals('not-me-disabled', $groups[3]['title']);
+    $this->assertEquals('pick-me-active', $groups[2]['title']);
+    $this->assertEquals('not-me-active', $groups[4]['title']);
   }
 
 
@@ -281,7 +281,7 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
     list($groups, $total) = CRM_Group_Page_AJAX::getGroupList();
     $this->assertEquals(1, count($groups), 'Returned groups should exclude disabled by default');
     $this->assertEquals(1, $total, 'Total needs to be set correctly');
-    $this->assertEquals('<span class="crm-editable crmf-title">pick-me-active</span>', $groups[2]['group_name']);
+    $this->assertEquals('pick-me-active', $groups[2]['title']);
   }
 
   public function testTraditionalACLNotFoundTitle() {
@@ -299,8 +299,8 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
     list($groups, $total) = CRM_Group_Page_AJAX::getGroupList();
     $this->assertEquals(2, count($groups), 'Returned groups should exclude disabled by default');
     $this->assertEquals(2, $total, 'Total needs to be set correctly');
-    $this->assertEquals('<span class="crm-editable crmf-title">pick-me-active</span>', $groups[2]['group_name']);
-    $this->assertEquals('<span class="crm-editable crmf-title">pick-me-disabled</span>', $groups[1]['group_name']);
+    $this->assertEquals('pick-me-active', $groups[2]['title']);
+    $this->assertEquals('pick-me-disabled', $groups[1]['title']);
   }
 
   public function testTraditionalACLDisabled() {
@@ -310,7 +310,7 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
     list($groups, $total) = CRM_Group_Page_AJAX::getGroupList();
     $this->assertEquals(1, count($groups), 'Returned groups should exclude disabled by default');
     $this->assertEquals(1, $total, 'Total needs to be set correctly');
-    $this->assertEquals('<span class="crm-editable crmf-title">pick-me-disabled</span>', $groups[1]['group_name']);
+    $this->assertEquals('pick-me-disabled', $groups[1]['title']);
   }
 
   public function testTraditionalACLDisabledFoundTitle() {
@@ -321,7 +321,7 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
     list($groups, $total) = CRM_Group_Page_AJAX::getGroupList();
     $this->assertEquals(1, count($groups), 'Returned groups should exclude disabled by default');
     $this->assertEquals(1, $total, 'Total needs to be set correctly');
-    $this->assertEquals('<span class="crm-editable crmf-title">pick-me-disabled</span>', $groups[1]['group_name']);
+    $this->assertEquals('pick-me-disabled', $groups[1]['title']);
   }
 
   public function testTraditionalACLDisabledNotFoundTitle() {
@@ -340,7 +340,7 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
     list($groups, $total) = CRM_Group_Page_AJAX::getGroupList();
     $this->assertEquals(1, count($groups), 'Returned groups should exclude disabled by default');
     $this->assertEquals(1, $total, 'Total needs to be set correctly');
-    $this->assertEquals('<span class="crm-editable crmf-title">pick-me-active</span>', $groups[2]['group_name']);
+    $this->assertEquals('pick-me-active', $groups[2]['title']);
   }
 
   public function testTraditionalACLAll() {
@@ -350,8 +350,8 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
     list($groups, $total) = CRM_Group_Page_AJAX::getGroupList();
     $this->assertEquals(2, count($groups), 'Returned groups should exclude disabled by default');
     $this->assertEquals(2, $total, 'Total needs to be set correctly');
-    $this->assertEquals('<span class="crm-editable crmf-title">pick-me-active</span>', $groups[2]['group_name']);
-    $this->assertEquals('<span class="crm-editable crmf-title">pick-me-disabled</span>', $groups[1]['group_name']);
+    $this->assertEquals('pick-me-active', $groups[2]['title']);
+    $this->assertEquals('pick-me-disabled', $groups[1]['title']);
   }
 
   /**
@@ -363,7 +363,7 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
     list($groups, $total) = CRM_Group_Page_AJAX::getGroupList();
     $this->assertEquals(1, count($groups), 'Returned groups should exclude disabled by default');
     $this->assertEquals(1, $total, 'Total needs to be set correctly');
-    $this->assertEquals('<span class="crm-editable crmf-title">pick-me-disabled</span>', $groups[1]['group_name']);
+    $this->assertEquals('pick-me-disabled', $groups[1]['title']);
   }
 
   /**
@@ -376,7 +376,7 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
     list($groups, $total) = CRM_Group_Page_AJAX::getGroupList();
     $this->assertEquals(1, count($groups), 'Returned groups should exclude disabled by default');
     $this->assertEquals(1, $total, 'Total needs to be set correctly');
-    $this->assertEquals('<span class="crm-editable crmf-title">pick-me-disabled</span>', $groups[1]['group_name']);
+    $this->assertEquals('pick-me-disabled', $groups[1]['title']);
   }
 
   /**
@@ -400,7 +400,7 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
     list($groups, $total) = CRM_Group_Page_AJAX::getGroupList();
     $this->assertEquals(1, count($groups), 'Returned groups should exclude disabled by default');
     $this->assertEquals(1, $total, 'Total needs to be set correctly');
-    $this->assertEquals('<span class="crm-editable crmf-title">pick-me-active</span>', $groups[2]['group_name']);
+    $this->assertEquals('pick-me-active', $groups[2]['title']);
   }
 
   /**
@@ -423,8 +423,8 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
     list($groups, $total) = CRM_Group_Page_AJAX::getGroupList();
     $this->assertEquals(2, count($groups), 'Returned groups should exclude disabled by default');
     $this->assertEquals(2, $total, 'Total needs to be set correctly');
-    $this->assertEquals('<span class="crm-editable crmf-title">pick-me-active</span>', $groups[2]['group_name']);
-    $this->assertEquals('<span class="crm-editable crmf-title">pick-me-disabled</span>', $groups[1]['group_name']);
+    $this->assertEquals('pick-me-active', $groups[2]['title']);
+    $this->assertEquals('pick-me-disabled', $groups[1]['title']);
   }
 
   /**
@@ -436,8 +436,8 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
     list($groups, $total) = CRM_Group_Page_AJAX::getGroupList();
     $this->assertEquals(2, count($groups), 'Returned groups should exclude disabled by default');
     $this->assertEquals(2, $total, 'Total needs to be set correctly');
-    $this->assertEquals('<span class="crm-editable crmf-title">pick-me-active</span>', $groups[2]['group_name']);
-    $this->assertEquals('<span class="crm-editable crmf-title">pick-me-disabled</span>', $groups[1]['group_name']);
+    $this->assertEquals('pick-me-active', $groups[2]['title']);
+    $this->assertEquals('pick-me-disabled', $groups[1]['title']);
   }
 
   /**
@@ -449,7 +449,7 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
     list($groups, $total) = CRM_Group_Page_AJAX::getGroupList();
     $this->assertEquals(1, count($groups), 'Returned groups should exclude disabled by default');
     $this->assertEquals(1, $total, 'Total needs to be set correctly');
-    $this->assertEquals('<span class="crm-editable crmf-title">pick-me-active</span>', $groups[2]['group_name']);
+    $this->assertEquals('pick-me-active', $groups[2]['title']);
   }
 
   /**


### PR DESCRIPTION
Fixes 32 CRM test failures CRM_Group_Page_AjaxTest.\* as result of recent Datatable refactoring done in https://github.com/civicrm/civicrm-core/pull/7451

---
- [CRM-18343: CRM and API test failures](https://issues.civicrm.org/jira/browse/CRM-18343)
