### PR TITLE
CRM-17570 - CRM_Core_Menu - Fire `alterMenu` hook

### DIFF
--- a/CRM/Core/Menu.php
+++ b/CRM/Core/Menu.php
@@ -94,6 +94,8 @@ class CRM_Core_Menu {
       foreach ($files as $file) {
         self::read($file, self::$_items);
       }
+
+      CRM_Utils_Hook::alterMenu(self::$_items);
     }
 
     return self::$_items;

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -519,6 +519,21 @@ abstract class CRM_Utils_Hook {
   }
 
   /**
+   * (Experimental) This hook is called when build the menu table.
+   *
+   * @param array $items
+   *   List of records to include in menu table.
+   * @return null
+   *   the return value is ignored
+   */
+  public static function alterMenu(&$items) {
+    return self::singleton()->invoke(1, $items,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      'civicrm_alterMenu'
+    );
+  }
+
+  /**
    * This hook is called for declaring managed entities via API.
    *
    * @param array $entities


### PR DESCRIPTION
The `xmlMenu` hook requires a literal XML file.  The `alterMenu` exposes the
live data structure, so that you can more easily mix in data from other
sources.

---
- [CRM-17570: Add hook to permit use of custom callback paths](https://issues.civicrm.org/jira/browse/CRM-17570)
