### PR TITLE
CRM-17965 - allow extern/widget.php to boot Drupal

### DIFF
--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -786,6 +786,8 @@ AND    u.status = 1
    * @inheritDoc
    */
   public function setHttpHeader($name, $value) {
+    // CRM-17965: allow extern/widget.php to boot Drupal
+    defined('DRUPAL_ROOT') or self::loadBootStrap(NULL, FALSE);
     drupal_add_http_header($name, $value);
   }
 

--- a/CRM/Utils/System/Drupal6.php
+++ b/CRM/Utils/System/Drupal6.php
@@ -756,6 +756,8 @@ class CRM_Utils_System_Drupal6 extends CRM_Utils_System_DrupalBase {
    * @inheritDoc
    */
   public function setHttpHeader($name, $value) {
+    // CRM-17965: allow extern/widget.php to boot Drupal
+    defined('DRUPAL_ROOT') or self::loadBootStrap(NULL, FALSE);
     drupal_set_header("$name: $value");
   }
 


### PR DESCRIPTION
First check if Drupal already booted before calling loadBootStrap().

---
- [CRM-17965: Contribution page widget broken on Drupal installations](https://issues.civicrm.org/jira/browse/CRM-17965)
