### PR TITLE
CRM-18353 skip url from IDS check

### DIFF
--- a/CRM/Core/IDS.php
+++ b/CRM/Core/IDS.php
@@ -58,7 +58,8 @@ class CRM_Core_IDS {
    */
   public function check(&$args) {
     // lets bypass a few civicrm urls from this check
-    static $skip = array('civicrm/admin/setting/updateConfigBackend', 'civicrm/admin/messageTemplates');
+    $skip = array('civicrm/admin/setting/updateConfigBackend', 'civicrm/admin/messageTemplates');
+    CRM_Utils_Hook::idsException($skip);
     $path = implode('/', $args);
     if (in_array($path, $skip)) {
       return NULL;

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -1966,4 +1966,15 @@ abstract class CRM_Utils_Hook {
     );
   }
 
+  /**
+   * This hook is called for bypass a few civicrm urls from IDS check
+   * @param array $skip list of civicrm url;
+   */
+  public static function idsException(&$skip) {
+    return self::singleton()->invoke(1, $skip, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      'civicrm_idsException'
+    );
+  }
+
 }


### PR DESCRIPTION
- [CRM-18353: allow to skip extension url from IDS check](https://issues.civicrm.org/jira/browse/CRM-18353)
