### PR TITLE
check element contain display word, fix for CRM-18349

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/OnBehalfOf.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/OnBehalfOf.tpl
@@ -258,7 +258,12 @@ function setLocationDetails(contactID , reset) {
         else {
           // do not set defaults to file type fields
           if (cj('#' + ele).attr('type') != 'file') {
-            cj('#' + ele ).val(data[ele].value).change();
+            if (ele.split("_").pop() == 'display') {
+              cj("[id^='"+ele+"']").val(data[ele].value).change();
+            }
+            else {
+              cj('#' + ele ).val(data[ele].value).change();
+            }
           }
         }
       }


### PR DESCRIPTION
- [CRM-18349: Custom date field default value not set on "On Behalf of" Profiles](https://issues.civicrm.org/jira/browse/CRM-18349)
