### PR TITLE
CRM-18345: Don't delete mailing data on email/phone deletion

### DIFF
--- a/CRM/Report/Form/Mailing/Bounce.php
+++ b/CRM/Report/Form/Mailing/Bounce.php
@@ -189,7 +189,6 @@ class CRM_Report_Form_Mailing_Bounce extends CRM_Report_Form {
         'email' => array(
           'title' => ts('Email'),
           'no_repeat' => TRUE,
-          'required' => TRUE,
         ),
         'on_hold' => array(
           'title' => ts('On hold'),
@@ -294,7 +293,7 @@ class CRM_Report_Form_Mailing_Bounce extends CRM_Report_Form {
     $this->_from .= "
         INNER JOIN civicrm_mailing_event_queue
           ON civicrm_mailing_event_queue.contact_id = {$this->_aliases['civicrm_contact']}.id
-        INNER JOIN civicrm_email {$this->_aliases['civicrm_email']}
+        LEFT JOIN civicrm_email {$this->_aliases['civicrm_email']}
           ON civicrm_mailing_event_queue.email_id = {$this->_aliases['civicrm_email']}.id
         INNER JOIN civicrm_mailing_event_bounce {$this->_aliases['civicrm_mailing_event_bounce']}
           ON {$this->_aliases['civicrm_mailing_event_bounce']}.event_queue_id = civicrm_mailing_event_queue.id
@@ -439,6 +438,15 @@ class CRM_Report_Form_Mailing_Bounce extends CRM_Report_Form {
 
     $entryFound = FALSE;
     foreach ($rows as $rowNum => $row) {
+
+      // If the email address has been deleted
+      if (array_key_exists('civicrm_email_email', $row)) {
+        if (empty($rows[$rowNum]['civicrm_email_email'])) {
+          $rows[$rowNum]['civicrm_email_email'] = '<del>Email address deleted</del>';
+        }
+        $entryFound = TRUE;
+      }
+
       // make count columns point to detail report
       // convert display name to links
       if (array_key_exists('civicrm_contact_sort_name', $row) &&

--- a/CRM/Report/Form/Mailing/Clicks.php
+++ b/CRM/Report/Form/Mailing/Clicks.php
@@ -134,7 +134,6 @@ class CRM_Report_Form_Mailing_Clicks extends CRM_Report_Form {
         'email' => array(
           'title' => ts('Email'),
           'no_repeat' => TRUE,
-          'required' => TRUE,
         ),
       ),
       'grouping' => 'contact-fields',
@@ -231,7 +230,7 @@ class CRM_Report_Form_Mailing_Clicks extends CRM_Report_Form {
     $this->_from .= "
         INNER JOIN civicrm_mailing_event_queue
           ON civicrm_mailing_event_queue.contact_id = {$this->_aliases['civicrm_contact']}.id
-        INNER JOIN civicrm_email {$this->_aliases['civicrm_email']}
+        LEFT JOIN civicrm_email {$this->_aliases['civicrm_email']}
           ON civicrm_mailing_event_queue.email_id = {$this->_aliases['civicrm_email']}.id
         INNER JOIN civicrm_mailing_event_trackable_url_open
           ON civicrm_mailing_event_trackable_url_open.event_queue_id = civicrm_mailing_event_queue.id
@@ -320,6 +319,15 @@ class CRM_Report_Form_Mailing_Clicks extends CRM_Report_Form {
   public function alterDisplay(&$rows) {
     $entryFound = FALSE;
     foreach ($rows as $rowNum => $row) {
+
+      // If the email address has been deleted
+      if (array_key_exists('civicrm_email_email', $row)) {
+        if (empty($rows[$rowNum]['civicrm_email_email'])) {
+          $rows[$rowNum]['civicrm_email_email'] = '<del>Email address deleted</del>';
+        }
+        $entryFound = TRUE;
+      }
+
       // make count columns point to detail report
       // convert display name to links
       if (array_key_exists('civicrm_contact_sort_name', $row) &&

--- a/CRM/Report/Form/Mailing/Detail.php
+++ b/CRM/Report/Form/Mailing/Detail.php
@@ -236,7 +236,6 @@ class CRM_Report_Form_Mailing_Detail extends CRM_Report_Form {
       'fields' => array(
         'email' => array(
           'title' => ts('Email'),
-          'required' => TRUE,
         ),
       ),
       'grouping' => 'contact-fields',
@@ -311,7 +310,7 @@ class CRM_Report_Form_Mailing_Detail extends CRM_Report_Form {
     $this->_from .= "
         INNER JOIN civicrm_mailing_event_queue
           ON civicrm_mailing_event_queue.contact_id = {$this->_aliases['civicrm_contact']}.id
-        INNER JOIN civicrm_email {$this->_aliases['civicrm_email']}
+        LEFT JOIN civicrm_email {$this->_aliases['civicrm_email']}
           ON civicrm_mailing_event_queue.email_id = {$this->_aliases['civicrm_email']}.id";
 
     if (array_key_exists('delivery_id', $this->_params['fields'])) {
@@ -459,6 +458,15 @@ class CRM_Report_Form_Mailing_Detail extends CRM_Report_Form {
   public function alterDisplay(&$rows) {
     $entryFound = FALSE;
     foreach ($rows as $rowNum => $row) {
+
+      // If the email address has been deleted
+      if (array_key_exists('civicrm_email_email', $row)) {
+        if (empty($rows[$rowNum]['civicrm_email_email'])) {
+          $rows[$rowNum]['civicrm_email_email'] = '<del>Email address deleted</del>';
+        }
+        $entryFound = TRUE;
+      }
+
       // make count columns point to detail report
       // convert display name to links
       if (array_key_exists('civicrm_contact_sort_name', $row) &&

--- a/CRM/Report/Form/Mailing/Opened.php
+++ b/CRM/Report/Form/Mailing/Opened.php
@@ -134,7 +134,6 @@ class CRM_Report_Form_Mailing_Opened extends CRM_Report_Form {
         'email' => array(
           'title' => ts('Email'),
           'no_repeat' => TRUE,
-          'required' => TRUE,
         ),
       ),
       'order_bys' => array(
@@ -211,7 +210,7 @@ class CRM_Report_Form_Mailing_Opened extends CRM_Report_Form {
     $this->_from .= "
         INNER JOIN civicrm_mailing_event_queue
           ON civicrm_mailing_event_queue.contact_id = {$this->_aliases['civicrm_contact']}.id
-        INNER JOIN civicrm_email {$this->_aliases['civicrm_email']}
+        LEFT JOIN civicrm_email {$this->_aliases['civicrm_email']}
           ON civicrm_mailing_event_queue.email_id = {$this->_aliases['civicrm_email']}.id
         INNER JOIN civicrm_mailing_event_opened
           ON civicrm_mailing_event_opened.event_queue_id = civicrm_mailing_event_queue.id
@@ -297,6 +296,15 @@ class CRM_Report_Form_Mailing_Opened extends CRM_Report_Form {
   public function alterDisplay(&$rows) {
     $entryFound = FALSE;
     foreach ($rows as $rowNum => $row) {
+
+      // If the email address has been deleted
+      if (array_key_exists('civicrm_email_email', $row)) {
+        if (empty($rows[$rowNum]['civicrm_email_email'])) {
+          $rows[$rowNum]['civicrm_email_email'] = '<del>Email address deleted</del>';
+        }
+        $entryFound = TRUE;
+      }
+      
       // make count columns point to detail report
       // convert display name to links
       if (array_key_exists('civicrm_contact_sort_name', $row) &&

--- a/CRM/Report/Form/Mailing/Opened.php
+++ b/CRM/Report/Form/Mailing/Opened.php
@@ -304,7 +304,7 @@ class CRM_Report_Form_Mailing_Opened extends CRM_Report_Form {
         }
         $entryFound = TRUE;
       }
-      
+
       // make count columns point to detail report
       // convert display name to links
       if (array_key_exists('civicrm_contact_sort_name', $row) &&

--- a/CRM/Upgrade/Incremental/sql/4.7.5.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.7.5.mysql.tpl
@@ -25,3 +25,44 @@ WHERE ov.name = 'Contact Deleted by Merge' AND og.name = 'activity_type';
 
 -- CRM-18241 Change field length of civicrm_option_value.label from 255 to 512 --
 ALTER TABLE civicrm_option_value CHANGE label label varchar( 512 ) DEFAULT NULL ;
+
+-- CRM-18345: Don't delete mailing records when email address / phone is deleted
+ALTER TABLE `civicrm_mailing_event_queue`
+  DROP FOREIGN KEY `FK_civicrm_mailing_event_queue_email_id`;
+  
+ALTER TABLE `civicrm_mailing_event_queue`
+  ADD CONSTRAINT `FK_civicrm_mailing_event_queue_email_id`
+  FOREIGN KEY (`email_id`)
+  REFERENCES `civicrm_email`(`id`)
+  ON DELETE SET NULL
+  ON UPDATE RESTRICT;
+  
+ALTER TABLE `civicrm_mailing_event_queue`
+  DROP FOREIGN KEY `FK_civicrm_mailing_event_queue_phone_id`;
+  
+ALTER TABLE `civicrm_mailing_event_queue`
+  ADD CONSTRAINT `FK_civicrm_mailing_event_queue_phone_id`
+  FOREIGN KEY (`phone_id`)
+  REFERENCES `civicrm_phone`(`id`)
+  ON DELETE SET NULL
+  ON UPDATE RESTRICT;
+
+ALTER TABLE `civicrm_mailing_recipients`
+  DROP FOREIGN KEY `FK_civicrm_mailing_recipients_email_id`;
+  
+ALTER TABLE `civicrm_mailing_recipients`
+  ADD CONSTRAINT `FK_civicrm_mailing_recipients_email_id`
+  FOREIGN KEY (`email_id`)
+  REFERENCES `civicrm_email`(`id`)
+  ON DELETE SET NULL
+  ON UPDATE RESTRICT;
+  
+ALTER TABLE `civicrm_mailing_recipients`
+  DROP FOREIGN KEY `FK_civicrm_mailing_recipients_phone_id`;
+  
+ALTER TABLE `civicrm_mailing_recipients`
+  ADD CONSTRAINT `FK_civicrm_mailing_recipients_phone_id`
+  FOREIGN KEY (`phone_id`)
+  REFERENCES `civicrm_phone`(`id`)
+  ON DELETE SET NULL
+  ON UPDATE RESTRICT;

--- a/xml/schema/Mailing/Event/Queue.xml
+++ b/xml/schema/Mailing/Event/Queue.xml
@@ -40,7 +40,7 @@
     <name>email_id</name>
     <table>civicrm_email</table>
     <key>id</key>
-    <onDelete>CASCADE</onDelete>
+    <onDelete>SET NULL</onDelete>
   </foreignKey>
   <field>
     <name>contact_id</name>
@@ -74,6 +74,6 @@
     <name>phone_id</name>
     <table>civicrm_phone</table>
     <key>id</key>
-    <onDelete>CASCADE</onDelete>
+    <onDelete>SET NULL</onDelete>
   </foreignKey>
 </table>

--- a/xml/schema/Mailing/Recipients.xml
+++ b/xml/schema/Mailing/Recipients.xml
@@ -53,7 +53,7 @@
     <name>email_id</name>
     <table>civicrm_email</table>
     <key>id</key>
-    <onDelete>CASCADE</onDelete>
+    <onDelete>SET NULL</onDelete>
   </foreignKey>
   <field>
     <name>phone_id</name>
@@ -66,6 +66,6 @@
     <name>phone_id</name>
     <table>civicrm_phone</table>
     <key>id</key>
-    <onDelete>CASCADE</onDelete>
+    <onDelete>SET NULL</onDelete>
   </foreignKey>
 </table>


### PR DESCRIPTION
- [CRM-18345: Deleting an email address deletes any mailing events related to it, and the contact](https://issues.civicrm.org/jira/browse/CRM-18345)
