### PR TITLE
CRM-18058: Define cmsRootPath() for Joomla

### DIFF
--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -678,6 +678,21 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
   }
 
   /**
+   * Determine the location of the CMS root.
+   *
+   * @return string|NULL
+   *   local file system path to CMS root, or NULL if it cannot be determined
+   */
+  public function cmsRootPath() {
+    list($url, $siteName, $siteRoot) = $this->getDefaultSiteSettings();
+    $includePath = "$siteRoot/libraries/cms/version";
+    if (file_exists("$includePath/version.php")) {
+      return $siteRoot;
+    }
+    return NULL;
+  }
+
+  /**
    * @inheritDoc
    */
   public function getDefaultSiteSettings($dir) {


### PR DESCRIPTION
- [CRM-18058: CMS root path error in Directories page (Joomla version)](https://issues.civicrm.org/jira/browse/CRM-18058)
