### PR TITLE
CRM-18362 get current local for navigation menu

### DIFF
--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -542,6 +542,16 @@ class CRM_Core_I18n {
     return $locales[$tsLocale];
   }
 
+  /**
+   * Get the current locale
+   *
+   * @return string
+   */
+  public static function getLocale() {
+    global $tsLocale;
+    return $tsLocale;
+  }
+
 }
 
 /**

--- a/CRM/Core/Smarty/plugins/function.crmNavigationMenu.php
+++ b/CRM/Core/Smarty/plugins/function.crmNavigationMenu.php
@@ -61,7 +61,7 @@ function smarty_function_crmNavigationMenu($params, &$smarty) {
       // These params force the browser to refresh the js file when switching user, domain, or language
       // We don't put them as a query string because some browsers will refuse to cache a page with a ? in the url
       // @see CRM_Admin_Page_AJAX::getNavigationMenu
-      $lang = $config->lcMessages;
+      $lang = CRM_Core_I18n::getLocale();
       $domain = CRM_Core_Config::domainID();
       $key = CRM_Core_BAO_Navigation::getCacheKey($contactID);
       $src = CRM_Utils_System::url("civicrm/ajax/menujs/$contactID/$lang/$domain/$key");


### PR DESCRIPTION
- [CRM-18362: navigation menu is always displayed in English](https://issues.civicrm.org/jira/browse/CRM-18362)
