### PR TITLE
CRM-18339: Fix merge screen link to contact's mailings

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -122,7 +122,7 @@ class CRM_Dedupe_Merger {
         'rel_table_mailings' => array(
           'title' => ts('Mailings'),
           'tables' => array('civicrm_mailing', 'civicrm_mailing_event_queue', 'civicrm_mailing_event_subscribe'),
-          'url' => CRM_Utils_System::url('civicrm/mailing', 'reset=1&force=1&cid=$cid'),
+          'url' => CRM_Utils_System::url('civicrm/contact/view', 'reset=1&force=1&cid=$cid&selectedChild=mailing'),
         ),
         'rel_table_cases' => array(
           'title' => ts('Cases'),


### PR DESCRIPTION
- [CRM-18339: Merge screen link to a contact's mailings does not work](https://issues.civicrm.org/jira/browse/CRM-18339)
