### PR TITLE
CRM-17984. Ensure input for subType param is valid.

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -441,10 +441,14 @@ LEFT JOIN civicrm_custom_field ON (civicrm_custom_field.custom_group_id = civicr
         $subTypeParts = explode(',', $subType);
         $subTypeClauses = array();
         foreach ($subTypeParts as $subTypePart) {
-          $subTypePart = CRM_Core_DAO::VALUE_SEPARATOR .
-            trim($subTypePart, CRM_Core_DAO::VALUE_SEPARATOR) .
-            CRM_Core_DAO::VALUE_SEPARATOR;
-          $subTypeClauses[] = "civicrm_custom_group.extends_entity_column_value LIKE '%$subTypePart%'";
+          // CRM-17984: Only filter by this input if valid.
+          $subTypePart = CRM_Utils_Type::escape(trim($subTypePart, CRM_Core_DAO::VALUE_SEPARATOR), 'Integer', FALSE);
+          if ($subTypePart) {
+            $subTypePart = CRM_Core_DAO::VALUE_SEPARATOR .
+              $subTypePart .
+              CRM_Core_DAO::VALUE_SEPARATOR;
+            $subTypeClauses[] = "civicrm_custom_group.extends_entity_column_value LIKE '%$subTypePart%'";
+          }
         }
 
         if ($onlySubType) {
@@ -456,17 +460,25 @@ LEFT JOIN civicrm_custom_field ON (civicrm_custom_field.custom_group_id = civicr
         }
       }
       else {
-        $subType = CRM_Core_DAO::VALUE_SEPARATOR .
-          trim($subType, CRM_Core_DAO::VALUE_SEPARATOR) .
-          CRM_Core_DAO::VALUE_SEPARATOR;
+        // CRM-17984: Only filter by this input if valid.
+        $subType = CRM_Utils_Type::escape(trim($subType, CRM_Core_DAO::VALUE_SEPARATOR), 'Integer', FALSE);
+        if ($subType) {
+          $subType = CRM_Core_DAO::VALUE_SEPARATOR .
+            $subType .
+            CRM_Core_DAO::VALUE_SEPARATOR;
 
-        if ($onlySubType) {
-          $subTypeClause = "( civicrm_custom_group.extends_entity_column_value LIKE '%$subType%' )";
+          if ($onlySubType) {
+            $subTypeClause = "( civicrm_custom_group.extends_entity_column_value LIKE '%$subType%' )";
+          }
+          else {
+            $subTypeClause = "( civicrm_custom_group.extends_entity_column_value LIKE '%$subType%'
+      OR    civicrm_custom_group.extends_entity_column_value IS NULL )";
+          }
         }
-        else {
-          $subTypeClause = "( civicrm_custom_group.extends_entity_column_value LIKE '%$subType%'
-    OR    civicrm_custom_group.extends_entity_column_value IS NULL )";
-        }
+      }
+
+      if (empty($subTypeClause)) {
+        $subTypeClause = '1=1';
       }
 
       $strWhere = "


### PR DESCRIPTION
Ensure input for subtype is valid; if not then do not use it to filter custom fields.

---
- [CRM-17984](https://issues.civicrm.org/jira/browse/CRM-17984)
