### PR TITLE
CRM-18303 - Reload contribution object after update

### DIFF
--- a/tests/phpunit/CRM/Core/Payment/PayPalProIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/PayPalProIPNTest.php
@@ -51,6 +51,9 @@ class CRM_Core_Payment_PayPalProIPNTest extends CiviUnitTestCase {
     parent::setUp();
     $this->_paymentProcessorID = $this->paymentProcessorCreate(array('is_test' => 0));
     $this->_contactID = $this->individualCreate();
+    $session = CRM_Core_Session::singleton();
+    $session->set('userID', $this->_contactID);
+
     $contributionPage = $this->callAPISuccess('contribution_page', 'create', array(
         'title' => "Test Contribution Page",
         'financial_type_id' => $this->_financialTypeID,


### PR DESCRIPTION
- [CRM-18303: Online pledge payments paid through payment processor never complete](https://issues.civicrm.org/jira/browse/CRM-18303)
