### PR TITLE
CRM-18390 - Adding contact summary tab dynamically

### DIFF
--- a/CRM/Contact/Page/View/Summary.php
+++ b/CRM/Contact/Page/View/Summary.php
@@ -395,13 +395,20 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
         'weight' => $weight,
         'count' => CRM_Contact_BAO_Contact::getCountComponent($id, $this->_contactId, $group['table_name']),
         'hideCount' => !$group['is_multiple'],
-        'class' => 'livePage'
+        'class' => 'livePage',
       );
       $weight += 10;
     }
 
     // see if any other modules want to add any tabs
     CRM_Utils_Hook::tabs($allTabs, $this->_contactId);
+
+    $allTabs[] = array(
+      'id' => 'summary',
+      'url' => '#contact-summary',
+      'title' => ts('Summary'),
+      'weight' => 0,
+    );
 
     // now sort the tabs based on weight
     usort($allTabs, array('CRM_Utils_Sort', 'cmpFunc'));

--- a/templates/CRM/Contact/Page/View/Summary.tpl
+++ b/templates/CRM/Contact/Page/View/Summary.tpl
@@ -130,12 +130,6 @@
   <div class="crm-block crm-content-block crm-contact-page crm-inline-edit-container">
     <div id="mainTabContainer">
       <ul class="crm-contact-tabs-list">
-        <li id="tab_summary" class="crm-tab-button ui-corner-all">
-          <a href="#contact-summary" title="{ts}Summary{/ts}">
-            <span> </span> {ts}Summary{/ts}
-            <em></em>
-          </a>
-        </li>
         {foreach from=$allTabs key=tabName item=tabValue}
           <li id="tab_{$tabValue.id}" class="crm-tab-button ui-corner-all crm-count-{$tabValue.count}{if isset($tabValue.class)} {$tabValue.class}{/if}">
             <a href="{$tabValue.url}" title="{$tabValue.title}">


### PR DESCRIPTION
While working on CiviHR project we created a new tab and we need it to be the first tab instead of "summary" tab . But unfortunately summary tab is hardcoded to be the first tab and we had no luck to achieve that without altering the core files .

Also i am submitting this against 4.5 branch because CiviHR is currently based on it but i am thinking to create another PR and do the same to the master branch in case this one approved.

---
- [CRM-18390: Adding contact summary tab dynamically](https://issues.civicrm.org/jira/browse/CRM-18390)
