### PR TITLE
CRM-18390 - Adding contact summary tab dynamically

### DIFF
--- a/CRM/Contact/Page/View/Summary.php
+++ b/CRM/Contact/Page/View/Summary.php
@@ -392,6 +392,13 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
     CRM_Utils_Hook::tabs($allTabs, $this->_contactId);
     CRM_Utils_Hook::tabset('civicrm/contact/view', $allTabs, $context);
 
+    $allTabs[] = array(
+      'id' => 'summary',
+      'url' => '#contact-summary',
+      'title' => ts('Summary'),
+      'weight' => 0,
+    );
+
     // now sort the tabs based on weight
     usort($allTabs, array('CRM_Utils_Sort', 'cmpFunc'));
 

--- a/templates/CRM/Contact/Page/View/Summary.tpl
+++ b/templates/CRM/Contact/Page/View/Summary.tpl
@@ -123,12 +123,6 @@
   <div class="crm-block crm-content-block crm-contact-page crm-inline-edit-container">
     <div id="mainTabContainer">
       <ul class="crm-contact-tabs-list">
-        <li id="tab_summary" class="crm-tab-button ui-corner-all">
-          <a href="#contact-summary" title="{ts}Summary{/ts}">
-            <span> </span> {ts}Summary{/ts}
-            <em></em>
-          </a>
-        </li>
         {foreach from=$allTabs key=tabName item=tabValue}
           <li id="tab_{$tabValue.id}" class="crm-tab-button ui-corner-all crm-count-{$tabValue.count}{if isset($tabValue.class)} {$tabValue.class}{/if}">
             <a href="{$tabValue.url}" title="{$tabValue.title}">


### PR DESCRIPTION
### similar PR is submitted against 4.5 version since CiviHR is currently based on it. https://github.com/civicrm/civicrm-core/pull/8109

While working on CiviHR project we created a new tab and we need it to be the first tab instead of "summary" tab . But unfortunately summary tab is hardcoded to be the first tab and we had no luck to achieve that without altering the core files .

---
- [CRM-18390: Adding contact summary tab dynamically](https://issues.civicrm.org/jira/browse/CRM-18390)
