### PR TITLE
CRM_AllTests - Fix hidden GroupTest/TransactionTest interaction

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -116,6 +116,15 @@ class CRM_Core_DAO extends DB_DataObject {
   }
 
   /**
+   * @return DB_common
+   */
+  public static function getConnection() {
+    global $_DB_DATAOBJECT;
+    $dao = new CRM_Core_DAO();
+    return $_DB_DATAOBJECT['CONNECTIONS'][$dao->_database_dsn_md5];
+  }
+
+  /**
    * @param string $fieldName
    * @param $fieldDef
    * @param array $params

--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -287,16 +287,23 @@ class CRM_Utils_File {
   }
 
   /**
-   * @param $dsn
+   * @param string|NULL $dsn
+   *   Use NULL to load the default/active connection from CRM_Core_DAO.
+   *   Otherwise, give a full DSN string.
    * @param string $fileName
    * @param null $prefix
    * @param bool $isQueryString
    * @param bool $dieOnErrors
    */
   public static function sourceSQLFile($dsn, $fileName, $prefix = NULL, $isQueryString = FALSE, $dieOnErrors = TRUE) {
-    require_once 'DB.php';
+    if ($dsn === NULL) {
+      $db = CRM_Core_DAO::getConnection();
+    }
+    else {
+      require_once 'DB.php';
+      $db = DB::connect($dsn);
+    }
 
-    $db = DB::connect($dsn);
     if (PEAR::isError($db)) {
       die("Cannot open $dsn: " . $db->getMessage());
     }

--- a/tests/phpunit/CRM/Contact/BAO/GroupTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/GroupTest.php
@@ -111,9 +111,8 @@ class CRM_Contact_BAO_GroupTest extends CiviUnitTestCase {
    * Load saved search sql files into the DB.
    */
   public function loadSavedSearches() {
-    $dsn = CRM_Core_Config::singleton()->dsn;
     foreach (glob(dirname(__FILE__) . "/SavedSearchDataSets/*.sql") as $file) {
-      CRM_Utils_File::sourceSQLFile($dsn, $file);
+      CRM_Utils_File::sourceSQLFile(NULL, $file);
     }
   }
 


### PR DESCRIPTION
There's a hidden test interaction where CRM_Contact_BAO_GroupTest causes
CRM_Core_TransactionTest to fail, and this seems to involve munging the
active DB connection.

With this revision, CRM_Contact_BAO_GroupTest uses the same DB connection as
everything else.

The failure was reproducible using this command:

```
env CIVICRM_UF=UnitTests PHPUNIT_TESTS="CRM_Contact_BAO_GroupTest::testGroupData CRM_Core_TransactionTest::testBasicCommit" phpunit4  tests/phpunit/EnvTests.php
```
