### PR TITLE
CRM-18402 ensure admin statuses are not used

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -2277,7 +2277,7 @@ WHERE      civicrm_membership.is_test = 0";
           array(
             'membership_id' => $dao->membership_id,
             'version' => 3,
-            'ignore_admin_only' => FALSE,
+            'ignore_admin_only' => TRUE,
           ), TRUE
         );
         $statusId = CRM_Utils_Array::value('id', $newStatus);


### PR DESCRIPTION
- [CRM-18402: membership status update may use admin statuses](https://issues.civicrm.org/jira/browse/CRM-18402)
