### PR TITLE
CRM-17846 	Fixing lock name to be less than 64 characters for MySQL 5.7 compatib

### DIFF
--- a/CRM/Core/Lock.php
+++ b/CRM/Core/Lock.php
@@ -145,7 +145,7 @@ class CRM_Core_Lock implements \Civi\Core\Lock\LockInterface {
    */
   public function acquire($timeout = NULL) {
     if (!$this->_hasLock) {
-      if (self::$jobLog && CRM_Core_DAO::singleValueQuery("SELECT IS_USED_LOCK( '" . $this->_id . "')")) {
+      if (self::$jobLog && CRM_Core_DAO::singleValueQuery("SELECT IS_USED_LOCK( '" . self::$jobLog . "')")) {
         return $this->hackyHandleBrokenCode(self::$jobLog);
       }
 
@@ -161,7 +161,7 @@ class CRM_Core_Lock implements \Civi\Core\Lock\LockInterface {
         }
         $this->_hasLock = TRUE;
         if (stristr($this->_name, 'data.mailing.job.')) {
-          self::$jobLog = $this->_name;
+          self::$jobLog = $this->_id;
         }
       }
       else {
@@ -183,7 +183,7 @@ class CRM_Core_Lock implements \Civi\Core\Lock\LockInterface {
       }
       $this->_hasLock = FALSE;
 
-      if (self::$jobLog == $this->_name) {
+      if (self::$jobLog == $this->_id) {
         self::$jobLog = FALSE;
       }
 


### PR DESCRIPTION
This is Andrew Perry's patch but I adjusted a little as it was failing tests. I think test coverage is pretty good

---
- [CRM-17846: Improving locks for CiviMail](https://issues.civicrm.org/jira/browse/CRM-17846)
