### PR TITLE
Per CRM-17860 these require_once for files in CiviTest can go

### DIFF
--- a/tests/phpunit/api/v3/JobProcessMailingTest.php
+++ b/tests/phpunit/api/v3/JobProcessMailingTest.php
@@ -36,9 +36,6 @@
  *
  */
 
-//@todo - why doesn't class loader find these (I tried renaming)
-require_once 'CiviTest/CiviMailUtils.php';
-
 /**
  * Class api_v3_JobTest
  * @group headless


### PR DESCRIPTION
With this require once I could not run the test in isolation but it was fine once I removed it

---
- [CRM-17860: More consistent, flexible handling of tests for extensions](https://issues.civicrm.org/jira/browse/CRM-17860)
