### PR TITLE
Update complete transaction test to reflect date change

### DIFF
--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -2105,6 +2105,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
    * that person.
    */
   public function testCompleteTransactionUpdatePledgePayment() {
+    $this->swapMessageTemplateForTestTemplate();
     $mut = new CiviMailUtils($this, TRUE);
     $mut->clearMessages();
     $this->createLoggedInUser();
@@ -2124,10 +2125,12 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     ));
     $this->assertEquals(1, $status);
     $mut->checkMailLog(array(
-      '$ 500.00',
-      'May 11th, 2012 12:00 AM',
+      'amount:::500.00',
+      'receive_date:::20130201000000',
+      'receipt_date:::201',
     ));
     $mut->stop();
+    $this->revertTemplateToReservedTemplate();
   }
 
   /**


### PR DESCRIPTION
This is a new test & the expected receive date is changed by the setting of trxn_date but the check was not updated
