### PR TITLE
CRM-18379: `Date range` issue for 'Select Date' custom field, when include in profile.

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -898,11 +898,16 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
 
       case 'Select Date':
         $attr = array('data-crm-custom' => $dataCrmCustomVal);
+        //CRM-18379: Fix for date range of 'Select Date' custom field when include in profile.
+        $minYear = isset($field->start_date_years) ? (date('Y') - $field->start_date_years) : NULL;
+        $maxYear = isset($field->end_date_years) ? (date('Y') + $field->end_date_years) : NULL;
+
         $params = array(
           'date' => $field->date_format,
-          'minDate' => isset($field->start_date_years) ? (date('Y') - $field->start_date_years) . '-01-01' : NULL,
-          'maxDate' => isset($field->end_date_years) ? (date('Y') + $field->end_date_years) . '-01-01' : NULL,
+          'minDate' => isset($minYear) ? $minYear . '-01-01' : NULL,
+          'maxDate' => isset($maxYear) ? $maxYear . '-01-01' : NULL,
           'time' => $field->time_format ? $field->time_format * 12 : FALSE,
+          'yearRange' => "{$minYear}:{$maxYear}",
         );
         if ($field->is_search_range && $search) {
           $qf->add('datepicker', $elementName . '_from', $label, $attr + array('placeholder' => ts('From')), FALSE, $params);


### PR DESCRIPTION
When include a 'Select Date' custom field in profile, the date range is still forced to 10 years prior to the current year.

Previously, `Date Range` issue was existed for both `prior to current date` and 'after the current date'.
So, Created a PR to fix date range issue.

https://issues.civicrm.org/jira/browse/CRM-18379
