### PR TITLE
CRM-18414: On changing payment processor selection on Contribution page, disable submit button

### DIFF
--- a/CRM/Financial/Form/Payment.php
+++ b/CRM/Financial/Form/Payment.php
@@ -37,7 +37,7 @@ class CRM_Financial_Form_Payment extends CRM_Core_Form {
    */
   protected $_paymentProcessorID;
   protected $currency;
-  protected $_values = array();
+  public $_values = array();
 
   /**
    * @var array


### PR DESCRIPTION
@eileenmcnaughton due to e-notice fix, the internal links civicrm/payment/form?currency=USD&id=1&processor_id=1&cid=202&snippet=json throws error
Fatal error: Cannot access protected property CRM_Financial_Form_Payment::$_values in <site>/CRM/Core/Payment/ProcessorForm.php on line 69

---
- [CRM-18414: On changing payment processor selection on Contribution page, disable submit button ](https://issues.civicrm.org/jira/browse/CRM-18414)
