### PR TITLE
CRM-18421: Fix getContactMailings() notice

### DIFF
--- a/CRM/Mailing/Page/AJAX.php
+++ b/CRM/Mailing/Page/AJAX.php
@@ -82,7 +82,6 @@ class CRM_Mailing_Page_AJAX {
     $params['rp'] = $rowCount;
 
     $params['contact_id'] = $contactID;
-    $params['context'] = $context;
 
     // get the contact mailings
     $mailings = CRM_Mailing_BAO_Mailing::getContactMailingSelector($params);


### PR DESCRIPTION
- [CRM-18421: Undefined variable notice for CRM_Mailing_Page_AJAX::getContactMailings()](https://issues.civicrm.org/jira/browse/CRM-18421)
