### PR TITLE
CRM-18335: Add transaction ID back into confirmation emails

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2547,6 +2547,12 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    * @return array
    */
   public function _gatherMessageValues($input, &$values, $ids = array()) {
+
+    // CRM-18335: Assign transaction ID too
+    if (!empty($this->trxn_id)) {
+      $values['trxn_id'] = $this->trxn_id;
+    }
+
     // set display address of contributor
     if ($this->address_id) {
       $addressParams = array('id' => $this->address_id);

--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -167,6 +167,7 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
       'membership_assign',
       'amount',
       'receipt_date',
+      'trxn_id',
     );
 
     foreach ($valuesRequiredForTemplate as $valueRequiredForTemplate) {
@@ -382,6 +383,7 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
         'membership_assign' => $values['membership_assign'],
         'amount' => $values['amount'],
         'receipt_date' => !$values['receipt_date'] ?: date('YmdHis', strtotime($values['receipt_date'])),
+        'trxn_id' => $values['trxn_id'],
       );
 
       if ($contributionTypeId = CRM_Utils_Array::value('financial_type_id', $values)) {


### PR DESCRIPTION
- [CRM-18335: Transaction ID no longer included in contribution receipt email (regression)](https://issues.civicrm.org/jira/browse/CRM-18335)
