### PR TITLE
CRM-18424 better amount label for repeat transactions

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -300,32 +300,6 @@
   {/if}
 
   {literal}
-  if ({/literal}"{$form.is_recur}"{literal}) {
-    if (document.getElementsByName("is_recur")[0].checked == true) {
-      window.onload = function() {
-        enablePeriod();
-      }
-    }
-  }
-
-  function enablePeriod ( ) {
-    var frqInt  = {/literal}"{$form.frequency_interval}"{literal};
-    if ( document.getElementsByName("is_recur")[0].checked == true ) {
-      //get back to auto renew settings.
-      var allowAutoRenew = {/literal}'{$allowAutoRenewMembership}'{literal};
-      if ( allowAutoRenew && cj("#auto_renew") ) {
-        showHideAutoRenew( null );
-      }
-    }
-    else {
-      //disabled auto renew settings.
-    var allowAutoRenew = {/literal}'{$allowAutoRenewMembership}'{literal};
-      if ( allowAutoRenew && cj("#auto_renew") ) {
-        cj("#auto_renew").prop('checked', false );
-        cj('#allow_auto_renew').hide( );
-      }
-    }
-  }
 
   cj('input[name="soft_credit_type_id"]').on('change', function() {
     enableHonorType();
@@ -342,16 +316,28 @@
   }
 
   cj('input[id="is_recur"]').on('change', function() {
-    showRecurHelp();
+    toggleRecur();
   });
 
-  function showRecurHelp( ) {
-    var showHelp = cj('input[id="is_recur"]:checked');
-    if ( showHelp.val() > 0) {
+  function toggleRecur( ) {
+    var isRecur = cj('input[id="is_recur"]:checked');
+    var allowAutoRenew = {/literal}'{$allowAutoRenewMembership}'{literal};
+    if (isRecur.val() > 0) {
       cj('#recurHelp').show();
+      cj('#amount_sum_label').text(ts('Regular amount'));
+      //get back to auto renew settings.
+      if ( allowAutoRenew && cj("#auto_renew") ) {
+        showHideAutoRenew( null );
+      }
     }
     else {
       cj('#recurHelp').hide();
+      cj('#amount_sum_label').text(ts('Total amount'));
+      //disabled auto renew settings.
+      if ( allowAutoRenew && cj("#auto_renew") ) {
+        cj("#auto_renew").prop('checked', false );
+        cj('#allow_auto_renew').hide( );
+      }
     }
   }
 
@@ -381,7 +367,7 @@
 
   CRM.$(function($) {
     enableHonorType();
-    showRecurHelp();
+    toggleRecur();
     skipPaymentMethod();
   });
 

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -322,22 +322,16 @@
   function toggleRecur( ) {
     var isRecur = cj('input[id="is_recur"]:checked');
     var allowAutoRenew = {/literal}'{$allowAutoRenewMembership}'{literal};
+    if ( allowAutoRenew && cj("#auto_renew") ) {
+      showHideAutoRenew( null );
+    }
     if (isRecur.val() > 0) {
       cj('#recurHelp').show();
       cj('#amount_sum_label').text(ts('Regular amount'));
-      //get back to auto renew settings.
-      if ( allowAutoRenew && cj("#auto_renew") ) {
-        showHideAutoRenew( null );
-      }
     }
     else {
       cj('#recurHelp').hide();
       cj('#amount_sum_label').text(ts('Total amount'));
-      //disabled auto renew settings.
-      if ( allowAutoRenew && cj("#auto_renew") ) {
-        cj("#auto_renew").prop('checked', false );
-        cj('#allow_auto_renew').hide( );
-      }
     }
   }
 

--- a/templates/CRM/Price/Form/Calculate.tpl
+++ b/templates/CRM/Price/Form/Calculate.tpl
@@ -26,16 +26,15 @@
 
 {assign var='hideTotal' value=$quickConfig+$noCalcValueDisplay}
 <div id="pricesetTotal" class="crm-section section-pricesetTotal">
-  {if !$hideTotal}
-  <div class="label" id="pricelabel">
+  <div class="label
+  {if $hideTotal},  hiddenElement{/if}" id="pricelabel">
     <label>
       {if ( $extends eq 'Contribution' ) || ( $extends eq 'Membership' )}
-        {ts}Total Amount{/ts}{else}{ts}Total Fee(s){/ts}
-         {if $isAdditionalParticipants} {ts}for this participant{/ts}{/if}
+      <span id='amount_sum_label'>{ts}Total Amount{/ts}{else}{ts}Total Fee(s){/ts}</span>
+       {if $isAdditionalParticipants} {ts}for this participant{/ts}{/if}
       {/if}
     </label>
   </div>
-  {/if}
   <div class="content calc-value" {if $hideTotal}style="display:none;"{/if} id="pricevalue" ></div>
 </div>
 


### PR DESCRIPTION
Note that this patch also does some minor consolidation, bringing actions that relate to the is_recur checkbox into the same function.

I made the total_amount label always present, but sometimes hidden. this saves us having to check for it and also gives is a place to store data
consistently. We have been moving towards greater DOM consistency on payment pages

---
- [CRM-18424: Terminogy issue 'Total amount' is misleading for recurring](https://issues.civicrm.org/jira/browse/CRM-18424)
