### PR TITLE
tests/phpunit - Flag 3 ornery test classes

### DIFF
--- a/tests/phpunit/CRM/Dedupe/MergerTest.php
+++ b/tests/phpunit/CRM/Dedupe/MergerTest.php
@@ -120,6 +120,9 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
     civicrm_api('group', 'delete', $params);
   }
 
+  /**
+   * @group ornery
+   */
   public function testBatchMergeSelectedDuplicates() {
     $this->createDupeContacts();
 
@@ -179,6 +182,9 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
     $this->deleteDupeContacts();
   }
 
+  /**
+   * @group ornery
+   */
   public function testBatchMergeAllDuplicates() {
     $this->createDupeContacts();
 

--- a/tests/phpunit/CRM/Financial/BAO/FinancialTypeTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/FinancialTypeTest.php
@@ -131,6 +131,7 @@ class CRM_Financial_BAO_FinancialTypeTest extends CiviUnitTestCase {
 
   /**
    * Check method testGetAvailableFinancialTypes()
+   * @group ornery
    */
   public function testGetAvailableFinancialTypes() {
     $this->setACL();
@@ -156,6 +157,7 @@ class CRM_Financial_BAO_FinancialTypeTest extends CiviUnitTestCase {
 
   /**
    * Check method testgetAvailableMembershipTypes()
+   * @group ornery
    */
   public function testgetAvailableMembershipTypes() {
     // Create Membership types
@@ -201,6 +203,7 @@ class CRM_Financial_BAO_FinancialTypeTest extends CiviUnitTestCase {
 
   /**
    * Check method testPermissionedFinancialTypes()
+   * @group ornery
    */
   public function testPermissionedFinancialTypes() {
     // First get all core permissions

--- a/tests/phpunit/CRM/Group/Page/AjaxTest.php
+++ b/tests/phpunit/CRM/Group/Page/AjaxTest.php
@@ -3,6 +3,7 @@
 /**
  * Class CRM_Group_Page_AjaxTest
  * @group headless
+ * @group ornery
  */
 class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
   /**


### PR DESCRIPTION
At the moment, a handful of tests in `CRM_AllTests` are failing (for
different reasons).  This creates a bind:
- If we run `CRM_AllTests` as part of PR testing, then it will
  cause lots of annoyance and train people to disregard test outputs.
- If we don't run `CRM_AllTests` as part of PR testing, then we're
  liable to get more regressions spotted too late.
- Some of the failures don't appear to be trivial to resolve.

The idea here is to flag these particular tests as `ornery`.  For PRs, we'll
enable tests with `CRM_AllTests` but also `--exclude-group ornery`.
