### PR TITLE
CRM-18303 follow up fix

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2835,6 +2835,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     $template->assign('receive_date',
       CRM_Utils_Date::processDate($this->receive_date)
     );
+    $values['receipt_date'] = (empty($this->receipt_date) ? NULL : $this->receipt_date);
     $template->assign('contributeMode', 'notify');
     $template->assign('action', $this->is_test ? 1024 : 1);
     $template->assign('receipt_text',
@@ -4642,12 +4643,13 @@ LIMIT 1;";
         $values['receipt_from_name'] = CRM_Utils_Array::value('receipt_from_name', $input, $userName);
       }
     }
+
+    $return = $contribution->composeMessageArray($input, $ids, $values, $recur, $returnMessageText);
     // Contribution ID should really always be set. But ?
-    if (!$returnMessageText && (!isset($input['receipt_update']) || $input['receipt_update'])) {
+    if (!$returnMessageText && (!isset($input['receipt_update']) || $input['receipt_update']) && empty($contribution->receipt_date)) {
       civicrm_api3('Contribution', 'create', array('receipt_date' => 'now', 'id' => $contribution->id));
-      $values['receipt_date'] = date('Y-m-d H:i:s');
     }
-    return $contribution->composeMessageArray($input, $ids, $values, $recur, $returnMessageText);
+    return $return;
   }
 
   /**

--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -383,7 +383,7 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
         'membership_assign' => $values['membership_assign'],
         'amount' => $values['amount'],
         'is_pay_later' => $values['is_pay_later'],
-        'receipt_date' => !$values['receipt_date'] ?: date('YmdHis', strtotime($values['receipt_date'])),
+        'receipt_date' => !$values['receipt_date'] ? NULL : date('YmdHis', strtotime($values['receipt_date'])),
       );
 
       if ($contributionTypeId = CRM_Utils_Array::value('financial_type_id', $values)) {

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -1594,7 +1594,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'amount:::100.00',
       'currency:::USD',
       'receive_date:::' . date('Ymd', strtotime($contribution['receive_date'])),
-      'receipt_date:::' . date('Ymd'),
+      "receipt_date:::\n",
       'contributeMode:::notify',
       'title:::Contribution',
       'displayName:::Mr. Anthony Anderson II',
@@ -1627,7 +1627,8 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'location_type_id' => 2,
       'contact_id' => $this->_params['contact_id'],
     ));
-    $params = array_merge($this->_params, array('contribution_status_id' => 2,
+    $params = array_merge($this->_params, array(
+      'contribution_status_id' => 2,
       'address_id' => $address['id'],
       )
     );
@@ -2046,6 +2047,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
    * CRM-14151 - Test completing a transaction via the API.
    */
   public function testCompleteTransactionWithReceiptDateSet() {
+    $this->swapMessageTemplateForTestTemplate();
     $mut = new CiviMailUtils($this, TRUE);
     $this->createLoggedInUser();
     $params = array_merge($this->_params, array('contribution_status_id' => 2, 'receipt_date' => 'now'));
@@ -2056,9 +2058,10 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $this->assertEquals(date('Y-m-d'), date('Y-m-d', strtotime($contribution['values'][0]['receive_date'])));
     $mut->checkMailLog(array(
       'Receipt - Contribution',
-      'Please print this confirmation for your records.',
+      'receipt_date:::' . date('Ymd'),
     ));
     $mut->stop();
+    $this->revertTemplateToReservedTemplate();
   }
 
 
@@ -2182,7 +2185,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $mut->checkMailLog(array(
       'amount:::500.00',
       'receive_date:::20130201000000',
-      'receipt_date:::201',
+      "receipt_date:::\n",
     ));
     $mut->stop();
     $this->revertTemplateToReservedTemplate();


### PR DESCRIPTION
This follows on from the CRM-18303. In that the receipt_date was set to be updated BEFORE the template went out but I realised that it used to be
updated AFTER, allowing people to check if a receipt had previously been sent in the tpl

---
- [CRM-18303: Online pledge payments paid through payment processor never complete](https://issues.civicrm.org/jira/browse/CRM-18303)
