### PR TITLE
CRM-18429 fix formatting of workflow permissions in hook

### DIFF
--- a/CRM/Mailing/Info.php
+++ b/CRM/Mailing/Info.php
@@ -249,20 +249,14 @@ class CRM_Mailing_Info extends CRM_Core_Component_Info {
     );
 
     if (self::workflowEnabled() || $getAllUnconditionally) {
-      $permissions[] = array(
-        'create mailings' => array(
-          ts('create mailings'),
-        ),
+      $permissions['create mailings'] = array(
+        ts('create mailings'),
       );
-      $permissions[] = array(
-        'schedule mailings' => array(
-          ts('schedule mailings'),
-        ),
+      $permissions['schedule mailings'] = array(
+        ts('schedule mailings'),
       );
-      $permissions[] = array(
-        'approve mailings' => array(
-          ts('approve mailings'),
-        ),
+      $permissions['approve mailings'] = array(
+        ts('approve mailings'),
       );
     }
 


### PR DESCRIPTION
- [CRM-18429: CiviMail workflow permissions mis-formatted](https://issues.civicrm.org/jira/browse/CRM-18429)
