### PR TITLE
CRM-18411 fix for missing argument

### DIFF
--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -695,7 +695,7 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
   /**
    * @inheritDoc
    */
-  public function getDefaultSiteSettings($dir) {
+  public function getDefaultSiteSettings($dir = NULL) {
     $config = CRM_Core_Config::singleton();
     $url = preg_replace(
       '|/administrator|',


### PR DESCRIPTION
I've tested this patch after upgrading the Joomla site from 4.7.5 to 4.7.6. The error is resolved and the cron runs well after upgrade.

---
- [CRM-18411: Update to 4.7.6 caused CRON error](https://issues.civicrm.org/jira/browse/CRM-18411)
