### PR TITLE
CRM-18267 upgrade php-font-lib

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -62,7 +62,7 @@
                 "shasum": ""
             },
             "require": {
-                "phenx/php-font-lib": "0.2.*"
+                "phenx/php-font-lib": "0.4.*"
             },
             "type": "library",
             "autoload": {
@@ -90,7 +90,7 @@
         },
         {
             "name": "phenx/php-font-lib",
-            "version": "0.2.2",
+            "version": "0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PhenX/php-font-lib.git",

--- a/composer.lock
+++ b/composer.lock
@@ -94,12 +94,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/PhenX/php-font-lib.git",
-                "reference": "c30c7fc00a6b0d863e9bb4c5d5dd015298b2dc82"
+                "reference": "b8af0cacdc3cbf1e41a586fcb78f506f4121a088"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PhenX/php-font-lib/zipball/c30c7fc00a6b0d863e9bb4c5d5dd015298b2dc82",
-                "reference": "c30c7fc00a6b0d863e9bb4c5d5dd015298b2dc82",
+                "url": "https://api.github.com/repos/PhenX/php-font-lib/zipball/b8af0cacdc3cbf1e41a586fcb78f506f4121a088",
+                "reference": "b8af0cacdc3cbf1e41a586fcb78f506f4121a088",
                 "shasum": ""
             },
             "type": "library",


### PR DESCRIPTION
Updated php-font-lib package version to latest 0.4 release.

---
- [CRM-18267: upgrade php-font-lib](https://issues.civicrm.org/jira/browse/CRM-18267)
