### PR TITLE
CRM-18432: In CiviMail’s updateEmailResetDate(), exec the main query.

### DIFF
--- a/CRM/Mailing/Event/BAO/Delivered.php
+++ b/CRM/Mailing/Event/BAO/Delivered.php
@@ -304,6 +304,7 @@ CREATE TEMPORARY TABLE civicrm_email_temp_values (
               AND       (civicrm_email.reset_date IS NULL OR civicrm_email.reset_date < civicrm_mailing_job.start_date)
             GROUP BY    civicrm_email.id
          ";
+    CRM_Core_DAO::executeQuery($query);
 
     $query = "
 UPDATE     civicrm_email e


### PR DESCRIPTION
In CRM_Mailing_Event_BAO_Delivered::updateEmailResetDate(), call for
CRM_Core_DAO::executeQuery($query), so the temporary table can be filled.
