### PR TITLE
CRM-18420 : Details field of a scheduled reminder contains raw HTML

### DIFF
--- a/Civi/Token/TokenRow.php
+++ b/Civi/Token/TokenRow.php
@@ -194,7 +194,15 @@ class TokenRow {
         foreach ($textTokens as $entity => $values) {
           foreach ($values as $field => $value) {
             if (!isset($htmlTokens[$entity][$field])) {
-              $htmlTokens[$entity][$field] = htmlentities($value);
+              // CRM-18420 - Activity Details Field are enclosed within <p>,
+              // hence if $body_text is empty, htmlentities will lead to
+              // conversion of these tags resulting in raw HTML.
+              if ($entity == 'activity' && $field == 'details') {
+                $htmlTokens[$entity][$field] = $value;
+              }
+              else {
+                $htmlTokens[$entity][$field] = htmlentities($value);
+              }
             }
           }
         }


### PR DESCRIPTION
`activity_detail` field is saved within `<p>` tag, hence `htmlentities()` converts it into `&lt;` and `&gt;`.

So, if `$body_text` is not present, [`$body_html` gets converted to `$body_text`](https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/BAO/ActionSchedule.php#L611) leading to raw HTML for the detail field in the sent mail.

---
- [CRM-18420: Details field of a scheduled reminder contains raw HTML](https://issues.civicrm.org/jira/browse/CRM-18420)
