### PR TITLE
Install CiviCRM in Backdrop is mostly working

### DIFF
--- a/install/civicrm.php
+++ b/install/civicrm.php
@@ -88,6 +88,9 @@ function civicrm_main(&$config) {
       $siteDir . DIRECTORY_SEPARATOR . 'files'
     );
   }
+  elseif ($installType == 'backdrop') {
+    civicrm_setup($cmsPath . DIRECTORY_SEPARATOR . 'files');
+  }
   elseif ($installType == 'wordpress') {
     $upload_dir = wp_upload_dir();
     $files_dirname = $upload_dir['basedir'];
@@ -119,6 +122,9 @@ function civicrm_main(&$config) {
   // generate backend settings file
   if ($installType == 'drupal') {
     $configFile = $cmsPath . DIRECTORY_SEPARATOR . 'sites' . DIRECTORY_SEPARATOR . $siteDir . DIRECTORY_SEPARATOR . 'civicrm.settings.php';
+  }
+  elseif ($installType == 'backdrop') {
+    $configFile = $cmsPath . DIRECTORY_SEPARATOR . 'civicrm.settings.php';
   }
   elseif ($installType == 'wordpress') {
     $configFile = $files_dirname . DIRECTORY_SEPARATOR . 'civicrm' . DIRECTORY_SEPARATOR . 'civicrm.settings.php';
@@ -233,6 +239,13 @@ function civicrm_config(&$config) {
     $params['CMSdbHost'] = $config['cmsdb']['server'];
     $params['CMSdbName'] = addslashes($config['cmsdb']['database']);
   }
+  elseif ($installType == 'backdrop') {
+    $params['cms'] = 'Backdrop';
+    $params['CMSdbUser'] = addslashes($config['backdrop']['username']);
+    $params['CMSdbPass'] = addslashes($config['backdrop']['password']);
+    $params['CMSdbHost'] = $config['backdrop']['server'];
+    $params['CMSdbName'] = addslashes($config['backdrop']['database']);
+  }
   else {
     $params['cms'] = 'WordPress';
     $params['CMSdbUser'] = addslashes(DB_USER);
@@ -275,7 +288,7 @@ function civicrm_cms_base() {
 
   $baseURL = $_SERVER['SCRIPT_NAME'];
 
-  if ($installType == 'drupal') {
+  if ($installType == 'drupal' || $installType == 'backdrop') {
     //don't assume 6 dir levels, as civicrm
     //may or may not be in sites/all/modules/
     //lets allow to install in custom dir. CRM-6840

--- a/install/template.html
+++ b/install/template.html
@@ -113,6 +113,15 @@ if ($text_direction == 'rtl') {
 </p>
 <?php } ?>
 
+<?php if ($installType == 'backdrop') { ?>
+<h4><?php echo ts('Backdrop Database Settings'); ?></h4>
+<p style="margin-left: 2em" id="backdrop_credentials" > <!--style="display: none"-->
+  <label for="backdrop_server"> <span><?php echo ts('MySQL server:'); ?></span> <input id="backdrop_server" type="text" name="backdrop[server]" value="<?php echo $backdropConfig['server'] ?>" /></label> <br />
+  <label for="backdrop_username"> <span><?php echo ts('MySQL username:'); ?></span> <input id="backdrop_username" type="text" name="backdrop[username]" value="<?php echo $backdropConfig['username'] ?>"  /></label> <br />
+  <label for="backdrop_password"> <span><?php echo ts('MySQL password:'); ?></span> <input id="backdrop_password" type="password" name="backdrop[password]" value="<?php echo $backdropConfig['password'] ?>" /></label> <br />
+  <label for="backdrop_database"><span><?php echo ts('MySQL database:'); ?></span> <input id="backdrop_database" type="text" name="backdrop[database]" value="<?php echo $backdropConfig['database'] ?>" /></label> <br />
+</p>
+<?php } ?>
 
 <h4><?php echo ts('Other Settings'); ?></h4>
 
@@ -133,6 +142,11 @@ if ($text_direction == 'rtl') {
 <?php if ($installType == 'drupal') {
 echo "<h4>" . ts('Drupal Database Details') . "</h4>";
 $dbReq->showTable(ts("MySQL %1 Configuration", array(1 => 'Drupal')));
+}?>
+
+<?php if ($installType == 'backdrop') {
+echo "<h4>" . ts('Backdrop Database Details') . "</h4>";
+$dbReq->showTable(ts("MySQL %1 Configuration", array(1 => 'Backdrop')));
 }?>
 <br /><hr />
 


### PR DESCRIPTION
Just wanted to post an initial PR and get feedback if anyone is available. This could be part of CRM-17711.

I've gotten CiviCRM installing in Backdrop so that part seems to be fine. But I'm still getting a fatal error after clicking the install button:

`Fatal error: Call to undefined function config_get() in /path/code/core/includes/bootstrap.inc on line 1808`

So it seems like it's not bootstrapping Backdrop once it's trying to go to the Install success page. It has something to do with calling t().

I'll keep investigating and update the PR if I find the issue, otherwise it would help if someone had a moment to try out the install. Thanks!

---
- [CRM-17711: Add Support for Backdrop](https://issues.civicrm.org/jira/browse/CRM-17711)
