### PR TITLE
CRM-18436: Non-mandatory custom rich text fields are mandatory in advanced search

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1007,7 +1007,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
         if ($field->text_length) {
           $attributes['maxlength'] = $field->text_length;
         }
-        $element = $qf->add('wysiwyg', $elementName, $label, $attributes, $search);
+        $element = $qf->add('wysiwyg', $elementName, $label, $attributes, $useRequired && !$search);
         break;
 
       case 'Autocomplete-Select':


### PR DESCRIPTION
This fixes the rich-text editor type textarea custom field which are searchable and non-required. Earlier when such custom field are used in Advance Search then it throws required validation error which is not expected.

---
- [CRM-18436: Non-mandatory custom rich text fields are mandatory in advanced search](https://issues.civicrm.org/jira/browse/CRM-18436)
