### PR TITLE
CRM-18434 - First and last names for billing not displayed in confirm…

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -210,11 +210,11 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     if (!empty($this->_paymentProcessor) &&  $this->_paymentProcessor['object']->supports('preApproval')) {
       $preApprovalParams = $this->_paymentProcessor['object']->getPreApprovalDetails($this->get('pre_approval_parameters'));
       $this->_params = array_merge($this->_params, $preApprovalParams);
-    }
 
-    // We may have fetched some billing details from the getPreApprovalDetails function so we
-    // want to ensure we set this after that function has been called.
-    CRM_Core_Payment_Form::mapParams($this->_bltID, $this->_params, $this->_params, FALSE);
+      // We may have fetched some billing details from the getPreApprovalDetails function so we
+      // want to ensure we set this after that function has been called.
+      CRM_Core_Payment_Form::mapParams($this->_bltID, $preApprovalParams, $this->_params, FALSE);
+    }
 
     $this->_params['is_pay_later'] = $this->get('is_pay_later');
     $this->assign('is_pay_later', $this->_params['is_pay_later']);

--- a/tests/phpunit/WebTest/Contribute/OnlineContributionTest.php
+++ b/tests/phpunit/WebTest/Contribute/OnlineContributionTest.php
@@ -132,8 +132,16 @@ class WebTest_Contribute_OnlineContributionTest extends CiviSeleniumTestCase {
     $this->type("billing_postal_code-5", "94129");
     $this->clickLink("_qf_Main_upload-bottom", "_qf_Confirm_next-bottom");
 
+    $this->waitForElementPresent("xpath=//div[@class='crm-section no-label billing_name-section']");
+    $this->assertElementContainsText("xpath=//div[@class='crm-section no-label billing_name-section']", $firstName . "billing");
+    $this->assertElementContainsText("xpath=//div[@class='crm-section no-label billing_name-section']", $lastName . "billing");
+
     $this->click("_qf_Confirm_next-bottom");
     $this->waitForPageToLoad($this->getTimeoutMsec());
+
+    $this->waitForElementPresent("xpath=//div[@class='crm-section no-label billing_name-section']");
+    $this->assertElementContainsText("xpath=//div[@class='crm-section no-label billing_name-section']", $firstName . "billing");
+    $this->assertElementContainsText("xpath=//div[@class='crm-section no-label billing_name-section']", $lastName . "billing");
 
     //login to check contribution
 


### PR DESCRIPTION
…ation screen

[`$this->_params` was passed to the mapParams() function](https://github.com/civicrm/civicrm-core/commit/a97681884a6d5dffe15e69bbcc930441de9a34a2#diff-ecead08fd9d62dd134a679e60a2ba6b4R241) which overrides the `billing_first_name` and `billing_last_name` to be the profile values.

https://issues.civicrm.org/jira/browse/CRM-18434
