### PR TITLE
CRM-18445 don't 'Assign Case Role' to client

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -1800,8 +1800,8 @@ SELECT case_status.label AS case_status, status_id, civicrm_case_type.title AS c
     $dao = CRM_Core_DAO::executeQuery($query, $queryParam);
 
     while ($dao->fetch()) {
-      //to get valid assignee contact(s).
-      if (isset($dao->caseId) || $dao->rel_contact_id != $contactId) {
+      // The assignee is not the client.
+      if ($dao->rel_contact_id != $contactId) {
         $caseRelationship = $dao->relation_a_b;
         $assigneContactName = $dao->clientName;
         $assigneContactIds[$dao->rel_contact_id] = $dao->rel_contact_id;


### PR DESCRIPTION
This PR removes an unnecessary test that Case Id is set. Observing how the function is called, the Case Id will always be set, so the condition is always true and the else part is never executed.

Even if Case Id was not set, this test is not the appropriate response.

---
- [CRM-18445: In 4.7 the activity 'Assign Case Role' is assigned to the client](https://issues.civicrm.org/jira/browse/CRM-18445)
