### PR TITLE
CRM-18275 sort contact's Activity list by descending date order

### DIFF
--- a/templates/CRM/Activity/Selector/Selector.tpl
+++ b/templates/CRM/Activity/Selector/Selector.tpl
@@ -39,7 +39,7 @@
       </div>
     </div><!-- /.crm-accordion-body -->
   </div><!-- /.crm-accordion-wrapper -->
-  <table class="contact-activity-selector-{$context} crm-ajax-table" data-order='[[5,"desc"]]'>
+  <table class="contact-activity-selector-{$context} crm-ajax-table">
     <thead>
     <tr>
       <th data-data="activity_type" class="crm-contact-activity-activity_type">{ts}Type{/ts}</th>

--- a/templates/CRM/Activity/Selector/Selector.tpl
+++ b/templates/CRM/Activity/Selector/Selector.tpl
@@ -39,7 +39,7 @@
       </div>
     </div><!-- /.crm-accordion-body -->
   </div><!-- /.crm-accordion-wrapper -->
-  <table class="contact-activity-selector-{$context} crm-ajax-table" data-order='[[5,"asc"]]'>
+  <table class="contact-activity-selector-{$context} crm-ajax-table" data-order='[[5,"desc"]]'>
     <thead>
     <tr>
       <th data-data="activity_type" class="crm-contact-activity-activity_type">{ts}Type{/ts}</th>


### PR DESCRIPTION
- [CRM-18275: Regression: Activities in contacts' Activity tabs default to ascending order](https://issues.civicrm.org/jira/browse/CRM-18275)
