### PR TITLE
CRM-18447 Can't create Survey if Events have 'is required' custom data

### DIFF
--- a/CRM/Campaign/Form/Survey.php
+++ b/CRM/Campaign/Form/Survey.php
@@ -80,7 +80,7 @@ class CRM_Campaign_Form_Survey extends CRM_Core_Form {
 
     // when custom data is included in this page
     if (!empty($_POST['hidden_custom'])) {
-      $this->set('type', 'Event');
+      $this->set('type', 'Survey');
       $this->set('entityId', $this->_surveyId);
       CRM_Custom_Form_CustomData::preProcess($this, NULL, NULL, 1, 'Survey', $this->_surveyId);
       CRM_Custom_Form_CustomData::buildQuickForm($this);


### PR DESCRIPTION
- [CRM-18447: Cannot create Survey if Events have 'is required' custom data](https://issues.civicrm.org/jira/browse/CRM-18447)
