### PR TITLE
CRM-18448 Update recurring contribution - fix Financial Type required error

### DIFF
--- a/CRM/Contribute/Form/UpdateSubscription.php
+++ b/CRM/Contribute/Form/UpdateSubscription.php
@@ -193,7 +193,7 @@ class CRM_Contribute_Form_UpdateSubscription extends CRM_Core_Form {
     }
 
     if (CRM_Contribute_BAO_ContributionRecur::supportsFinancialTypeChange($this->contributionRecurID)) {
-      $this->addEntityRef('financial_type_id', ts('Financial Type'), array('entity' => 'FinancialType'), TRUE);
+      $this->addEntityRef('financial_type_id', ts('Financial Type'), array('entity' => 'FinancialType'), !$this->_selfService);
     }
 
     $type = 'next';


### PR DESCRIPTION
Donors can do self-service updates of their recurring contributions.

The PHP makes the Financial Type field 'is required', but then the TPL excludes the field when it is being used in the self-service mode. So the form fails validation in this case.

The change is to make the field non-mandatory in self-service mode. This is safe because Financial Type is mandatory for contributions, so it will have a non-NULL value before the form is displayed.

---
- [CRM-18448:  Update recurring contribution - prevent 'Financial Type is required field' validation error](https://issues.civicrm.org/jira/browse/CRM-18448)
