### PR TITLE
CRM-18449 prevent fatal error on Update recurring contribution

### DIFF
--- a/CRM/Contribute/Form/UpdateSubscription.php
+++ b/CRM/Contribute/Form/UpdateSubscription.php
@@ -77,6 +77,8 @@ class CRM_Contribute_Form_UpdateSubscription extends CRM_Core_Form {
    */
   public function preProcess() {
 
+    $this->setAction(CRM_Core_Action::UPDATE);
+
     $this->contributionRecurID = CRM_Utils_Request::retrieve('crid', 'Integer', $this, FALSE);
     if ($this->contributionRecurID) {
       $this->_paymentProcessor = CRM_Contribute_BAO_ContributionRecur::getPaymentProcessor($this->contributionRecurID);


### PR DESCRIPTION
Set the form action to UPDATE

---
- [CRM-18449: Update recurring contribution - fatal error - no Action set](https://issues.civicrm.org/jira/browse/CRM-18449)
