### PR TITLE
CRM-18454 : webtest fixes

### DIFF
--- a/tests/phpunit/CiviTest/CiviSeleniumTestCase.php
+++ b/tests/phpunit/CiviTest/CiviSeleniumTestCase.php
@@ -403,6 +403,16 @@ class CiviSeleniumTestCase extends PHPUnit_Extensions_SeleniumTestCase {
   }
 
   /**
+   * override this since the built in function doesn't work with the new phpunit.
+   * @param string $element
+   * @param string $text
+   */
+  public function waitForText($element, $text) {
+    $this->waitForTextPresent($text);
+    $this->assertElementContainsText($element, $text);
+  }
+
+  /**
    * Ensures the required CiviCRM components are enabled.
    * @param $components
    */
@@ -1558,7 +1568,7 @@ class CiviSeleniumTestCase extends PHPUnit_Extensions_SeleniumTestCase {
     $this->clickLink('_qf_Edit_upload-bottom');
 
     // Is status message correct?
-    $this->waitForText('crm-notification-container', "$groupName");
+    $this->waitForText('crm-notification-container', "The Group '$groupName' has been saved.");
     return $groupName;
   }
 

--- a/tests/phpunit/WebTest/Profile/ProfileAddTest.php
+++ b/tests/phpunit/WebTest/Profile/ProfileAddTest.php
@@ -194,9 +194,9 @@ class WebTest_Profile_ProfileAddTest extends CiviSeleniumTestCase {
     //check the existence of the two contacts in the group
     $this->openCiviPage('group', 'reset=1');
     $this->type('title', $groupName);
-    $this->click('_qf_Search_refresh');
-    $this->waitForElementPresent("xpath=//table[@class='crm-group-selector no-footer dataTable']/tbody/tr/td/span[text() = '$groupName']/parent::td/following-sibling::td[@class=' crm-group-group_links']/span/a");
-    $this->clickLink("xpath=//table[@class='crm-group-selector no-footer dataTable']/tbody/tr/td[1]/span[text() = '$groupName']/parent::td/following-sibling::td[@class=' crm-group-group_links']/span/a");
+    $this->click('title');
+    $this->waitForElementPresent("xpath=//div[text() = '$groupName']/parent::td/following-sibling::td[@class='crm-group-group_links']/span/a");
+    $this->clickLink("xpath=//div[text() = '$groupName']/parent::td/following-sibling::td[@class='crm-group-group_links']/span/a");
     $contactEmails = array(
       1 => "$lastName1, $firstName1",
       2 => "$lastName2, $firstName2",


### PR DESCRIPTION
Most of the [webtest listed on jenkins](https://test.civicrm.org/job/CiviCRM-WebTest-Matrix/CIVIVER=master,label=test-ubu1204-1/716/testReport/) (total 232) fails as waitForText() function is unable to assert the text inside the element. This is after the phpunit update done as this function was  working previously (4.6). Hence, overriding this function to pass them.

---
- [CRM-18454: Webtest Failures](https://issues.civicrm.org/jira/browse/CRM-18454)
