### PR TITLE
CRM-18421: QA warning fix

### DIFF
--- a/CRM/Mailing/Page/View.php
+++ b/CRM/Mailing/Page/View.php
@@ -164,7 +164,7 @@ class CRM_Mailing_Page_View extends CRM_Core_Page {
       $details = CRM_Utils_Array::value(0, $details[0]);
       $contactId = 0;
     }
-    $mime = &$this->_mailing->compose(NULL, NULL, NULL, $contactId,
+    $mime = $this->_mailing->compose(NULL, NULL, NULL, $contactId,
       $this->_mailing->from_email,
       $this->_mailing->from_email,
       TRUE, $details, $attachments


### PR DESCRIPTION
https://issues.civicrm.org/jira/browse/CRM-18421

Strict warning: Only variables should be assigned by reference in CRM_Mailing_Page_View->run() (line 171 of /home/web/git_4.6/civicrm/CRM/Mailing/Page/View.php).

Above warning is also getting triggered every time, when viewing the 'mailings' tab on a contact record.
So made simple fix for it.
