### PR TITLE
CRM-18275: set default ordering of activities as desc in Activity Ta…

### DIFF
--- a/templates/CRM/Activity/Selector/Selector.tpl
+++ b/templates/CRM/Activity/Selector/Selector.tpl
@@ -39,7 +39,7 @@
       </div>
     </div><!-- /.crm-accordion-body -->
   </div><!-- /.crm-accordion-wrapper -->
-  <table class="contact-activity-selector-{$context} crm-ajax-table" data-order='[[5,"asc"]]'>
+  <table class="contact-activity-selector-{$context} crm-ajax-table"'>
     <thead>
     <tr>
       <th data-data="activity_type" class="crm-contact-activity-activity_type">{ts}Type{/ts}</th>


### PR DESCRIPTION
…b and asc in dashlet.

The ordering is already [handled in the BAO file](https://github.com/civicrm/civicrm-core/blob/master/CRM/Activity/BAO/Activity.php#L736-L739), hence removing `data-order` from the DT settings.

https://issues.civicrm.org/jira/browse/CRM-18275
