### PR TITLE
CRM-17789 - replace mysql extension with mysqli

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1402,6 +1402,8 @@ FROM   civicrm_domain
     foreach ($ids as $id) {
       if (isset($_DB_DATAOBJECT['RESULTS'][$id])) {
         if (is_resource($_DB_DATAOBJECT['RESULTS'][$id]->result)) {
+          // @fixme mysql_free_result() does not exist in PHP7.
+          // No fatal error, however, because mysqli result is not a resource.
           mysql_free_result($_DB_DATAOBJECT['RESULTS'][$id]->result);
         }
         unset($_DB_DATAOBJECT['RESULTS'][$id]);
@@ -1647,17 +1649,13 @@ SELECT contact_id
     if (!$_dao) {
       // If this is an atypical case (e.g. preparing .sql files
       // before Civi has been installed), then we fallback to
-      // DB-less escaping helper (mysql_real_escape_string).
+      // DB-less escaping helper (addslashes). This is unsafe
+      // so should only be used on trusted strings.
       // Note: In typical usage, escapeString() will only
       // check one conditional ("if !$_dao") rather than
       // two conditionals ("if !defined(DSN)")
       if (!defined('CIVICRM_DSN')) {
-        if (function_exists('mysql_real_escape_string')) {
-          return mysql_real_escape_string($string);
-        }
-        else {
-          throw new CRM_Core_Exception("Cannot generate SQL. \"mysql_real_escape_string\" is missing. Have you installed PHP \"mysql\" extension?");
-        }
+        return addslashes($string);
       }
 
       $_dao = new CRM_Core_DAO();

--- a/CRM/Report/Form/Mailing/Detail.php
+++ b/CRM/Report/Form/Mailing/Detail.php
@@ -440,7 +440,7 @@ class CRM_Report_Form_Mailing_Detail extends CRM_Report_Form {
     $mailing->query($query);
 
     while ($mailing->fetch()) {
-      $data[mysql_real_escape_string($mailing->name)] = $mailing->name;
+      $data[$mailing->escape($mailing->name)] = $mailing->name;
     }
 
     return $data;

--- a/CRM/Report/Form/Mailing/Summary.php
+++ b/CRM/Report/Form/Mailing/Summary.php
@@ -301,7 +301,7 @@ class CRM_Report_Form_Mailing_Summary extends CRM_Report_Form {
     $mailing->query($query);
 
     while ($mailing->fetch()) {
-      $data[mysql_real_escape_string($mailing->name)] = $mailing->name;
+      $data[$mailing->escape($mailing->name)] = $mailing->name;
     }
 
     return $data;

--- a/install/civicrm.php
+++ b/install/civicrm.php
@@ -94,7 +94,7 @@ function civicrm_main(&$config) {
     civicrm_setup($files_dirname);
   }
 
-  $dsn = "mysql://{$config['mysql']['username']}:{$config['mysql']['password']}@{$config['mysql']['server']}/{$config['mysql']['database']}?new_link=true";
+  $dsn = "mysqli://{$config['mysql']['username']}:{$config['mysql']['password']}@{$config['mysql']['server']}/{$config['mysql']['database']}?new_link=true";
 
   civicrm_source($dsn, $sqlPath . DIRECTORY_SEPARATOR . 'civicrm.mysql');
 

--- a/install/index.php
+++ b/install/index.php
@@ -340,7 +340,7 @@ else {
  *  $description[2] - The test error to show, if it goes wrong
  */
 class InstallRequirements {
-  var $errors, $warnings, $tests;
+  var $errors, $warnings, $tests, $conn;
 
   // @see CRM_Upgrade_Form::MINIMUM_THREAD_STACK
   const MINIMUM_THREAD_STACK = 192;
@@ -351,7 +351,7 @@ class InstallRequirements {
    * @param $dbName
    */
   public function checkdatabase($databaseConfig, $dbName) {
-    if ($this->requireFunction('mysql_connect',
+    if ($this->requireFunction('mysqli_connect',
       array(
         ts("PHP Configuration"),
         ts("MySQL support"),
@@ -381,8 +381,8 @@ class InstallRequirements {
           array(
             ts("MySQL %1 Configuration", array(1 => $dbName)),
             ts("MySQL version at least %1", array(1 => '5.1')),
-            ts("MySQL version %1 or higher is required, you are running MySQL %2.", array(1 => '5.1', 2 => mysql_get_server_info())),
-            ts("MySQL %1", array(1 => mysql_get_server_info())),
+            ts("MySQL version %1 or higher is required, you are running MySQL %2.", array(1 => '5.1', 2 => mysqli_get_server_info($this->conn))),
+            ts("MySQL %1", array(1 => mysqli_get_server_info($this->conn))),
           )
         );
         $this->requireMySQLAutoIncrementIncrementOne($databaseConfig['server'],
@@ -590,7 +590,7 @@ class InstallRequirements {
     ));
 
     // Check for MySQL support
-    $this->requireFunction('mysql_connect', array(
+    $this->requireFunction('mysqli_connect', array(
       ts("PHP Configuration"),
       ts("MySQL support"),
       ts("MySQL support not included in PHP."),
@@ -867,13 +867,13 @@ class InstallRequirements {
    */
   public function requireMysqlConnection($server, $username, $password, $testDetails) {
     $this->testing($testDetails);
-    $conn = @mysql_connect($server, $username, $password);
+    $this->conn = @mysqli_connect($server, $username, $password);
 
-    if ($conn) {
+    if ($this->conn) {
       return TRUE;
     }
     else {
-      $testDetails[2] .= ": " . mysql_error();
+      $testDetails[2] .= ": " . mysqli_connect_error();
       $this->error($testDetails);
     }
   }
@@ -884,13 +884,13 @@ class InstallRequirements {
    */
   public function requireMySQLServer($server, $testDetails) {
     $this->testing($testDetails);
-    $conn = @mysql_connect($server, NULL, NULL);
+    $conn = @mysqli_connect($server, NULL, NULL);
 
-    if ($conn || mysql_errno() < 2000) {
+    if ($conn || mysqli_connect_errno() < 2000) {
       return TRUE;
     }
     else {
-      $testDetails[2] .= ": " . mysql_error();
+      $testDetails[2] .= ": " . mysqli_connect_error();
       $this->error($testDetails);
     }
   }
@@ -902,13 +902,13 @@ class InstallRequirements {
   public function requireMySQLVersion($version, $testDetails) {
     $this->testing($testDetails);
 
-    if (!mysql_get_server_info()) {
+    if (!mysqli_get_server_info($this->conn)) {
       $testDetails[2] = ts('Cannot determine the version of MySQL installed. Please ensure at least version %1 is installed.', array(1 => $version));
       $this->warning($testDetails);
     }
     else {
       list($majorRequested, $minorRequested) = explode('.', $version);
-      list($majorHas, $minorHas) = explode('.', mysql_get_server_info());
+      list($majorHas, $minorHas) = explode('.', mysqli_get_server_info($this->conn));
 
       if (($majorHas > $majorRequested) || ($majorHas == $majorRequested && $minorHas >= $minorRequested)) {
         return TRUE;
@@ -929,7 +929,7 @@ class InstallRequirements {
    */
   public function requireMySQLInnoDB($server, $username, $password, $database, $testDetails) {
     $this->testing($testDetails);
-    $conn = @mysql_connect($server, $username, $password);
+    $conn = @mysqli_connect($server, $username, $password);
     if (!$conn) {
       $testDetails[2] .= ' ' . ts("Could not determine if MySQL has InnoDB support. Assuming no.");
       $this->error($testDetails);
@@ -937,8 +937,8 @@ class InstallRequirements {
     }
 
     $innodb_support = FALSE;
-    $result = mysql_query("SHOW ENGINES", $conn);
-    while ($values = mysql_fetch_array($result)) {
+    $result = mysqli_query($conn, "SHOW ENGINES");
+    while ($values = mysqli_fetch_array($result)) {
       if ($values['Engine'] == 'InnoDB') {
         if (strtolower($values['Support']) == 'yes' ||
           strtolower($values['Support']) == 'default'
@@ -964,25 +964,25 @@ class InstallRequirements {
    */
   public function requireMySQLTempTables($server, $username, $password, $database, $testDetails) {
     $this->testing($testDetails);
-    $conn = @mysql_connect($server, $username, $password);
+    $conn = @mysqli_connect($server, $username, $password);
     if (!$conn) {
       $testDetails[2] = ts('Could not login to the database.');
       $this->error($testDetails);
       return;
     }
 
-    if (!@mysql_select_db($database, $conn)) {
+    if (!@mysqli_select_db($conn, $database)) {
       $testDetails[2] = ts('Could not select the database.');
       $this->error($testDetails);
       return;
     }
 
-    $result = mysql_query('CREATE TEMPORARY TABLE civicrm_install_temp_table_test (test text)', $conn);
+    $result = mysqli_query($conn, 'CREATE TEMPORARY TABLE civicrm_install_temp_table_test (test text)');
     if (!$result) {
       $testDetails[2] = ts('Could not create a temp table.');
       $this->error($testDetails);
     }
-    $result = mysql_query('DROP TEMPORARY TABLE civicrm_install_temp_table_test');
+    $result = mysqli_query($conn, 'DROP TEMPORARY TABLE civicrm_install_temp_table_test');
   }
 
   /**
@@ -994,34 +994,34 @@ class InstallRequirements {
    */
   public function requireMySQLTrigger($server, $username, $password, $database, $testDetails) {
     $this->testing($testDetails);
-    $conn = @mysql_connect($server, $username, $password);
+    $conn = @mysqli_connect($server, $username, $password);
     if (!$conn) {
       $testDetails[2] = ts('Could not login to the database.');
       $this->error($testDetails);
       return;
     }
 
-    if (!@mysql_select_db($database, $conn)) {
+    if (!@mysqli_select_db($conn, $database)) {
       $testDetails[2] = ts('Could not select the database.');
       $this->error($testDetails);
       return;
     }
 
-    $result = mysql_query('CREATE TABLE civicrm_install_temp_table_test (test text)', $conn);
+    $result = mysqli_query($conn, 'CREATE TABLE civicrm_install_temp_table_test (test text)');
     if (!$result) {
       $testDetails[2] = ts('Could not create a table in the database.');
       $this->error($testDetails);
     }
 
-    $result = mysql_query('CREATE TRIGGER civicrm_install_temp_table_test_trigger BEFORE INSERT ON civicrm_install_temp_table_test FOR EACH ROW BEGIN END');
+    $result = mysqli_query($conn, 'CREATE TRIGGER civicrm_install_temp_table_test_trigger BEFORE INSERT ON civicrm_install_temp_table_test FOR EACH ROW BEGIN END');
     if (!$result) {
-      mysql_query('DROP TABLE civicrm_install_temp_table_test');
+      mysqli_query($conn, 'DROP TABLE civicrm_install_temp_table_test');
       $testDetails[2] = ts('Could not create a database trigger.');
       $this->error($testDetails);
     }
 
-    mysql_query('DROP TRIGGER civicrm_install_temp_table_test_trigger');
-    mysql_query('DROP TABLE civicrm_install_temp_table_test');
+    mysqli_query($conn, 'DROP TRIGGER civicrm_install_temp_table_test_trigger');
+    mysqli_query($conn, 'DROP TABLE civicrm_install_temp_table_test');
   }
 
 
@@ -1034,43 +1034,43 @@ class InstallRequirements {
    */
   public function requireMySQLLockTables($server, $username, $password, $database, $testDetails) {
     $this->testing($testDetails);
-    $conn = @mysql_connect($server, $username, $password);
+    $conn = @mysqli_connect($server, $username, $password);
     if (!$conn) {
       $testDetails[2] = ts('Could not connect to the database server.');
       $this->error($testDetails);
       return;
     }
 
-    if (!@mysql_select_db($database, $conn)) {
+    if (!@mysqli_select_db($conn, $database)) {
       $testDetails[2] = ts('Could not select the database.');
       $this->error($testDetails);
       return;
     }
 
-    $result = mysql_query('CREATE TEMPORARY TABLE civicrm_install_temp_table_test (test text)', $conn);
+    $result = mysqli_query($conn, 'CREATE TEMPORARY TABLE civicrm_install_temp_table_test (test text)');
     if (!$result) {
       $testDetails[2] = ts('Could not create a table in the database.');
       $this->error($testDetails);
       return;
     }
 
-    $result = mysql_query('LOCK TABLES civicrm_install_temp_table_test WRITE', $conn);
+    $result = mysqli_query($conn, 'LOCK TABLES civicrm_install_temp_table_test WRITE');
     if (!$result) {
       $testDetails[2] = ts('Could not obtain a write lock for the database table.');
       $this->error($testDetails);
-      $result = mysql_query('DROP TEMPORARY TABLE civicrm_install_temp_table_test');
+      $result = mysqli_query($conn, 'DROP TEMPORARY TABLE civicrm_install_temp_table_test');
       return;
     }
 
-    $result = mysql_query('UNLOCK TABLES', $conn);
+    $result = mysqli_query($conn, 'UNLOCK TABLES');
     if (!$result) {
       $testDetails[2] = ts('Could not release the lock for the database table.');
       $this->error($testDetails);
-      $result = mysql_query('DROP TEMPORARY TABLE civicrm_install_temp_table_test');
+      $result = mysqli_query($conn, 'DROP TEMPORARY TABLE civicrm_install_temp_table_test');
       return;
     }
 
-    $result = mysql_query('DROP TEMPORARY TABLE civicrm_install_temp_table_test');
+    $result = mysqli_query($conn, 'DROP TEMPORARY TABLE civicrm_install_temp_table_test');
   }
 
   /**
@@ -1081,21 +1081,21 @@ class InstallRequirements {
    */
   public function requireMySQLAutoIncrementIncrementOne($server, $username, $password, $testDetails) {
     $this->testing($testDetails);
-    $conn = @mysql_connect($server, $username, $password);
+    $conn = @mysqli_connect($server, $username, $password);
     if (!$conn) {
       $testDetails[2] = ts('Could not connect to the database server.');
       $this->error($testDetails);
       return;
     }
 
-    $result = mysql_query("SHOW variables like 'auto_increment_increment'", $conn);
+    $result = mysqli_query($conn, "SHOW variables like 'auto_increment_increment'");
     if (!$result) {
       $testDetails[2] = ts('Could not query database server variables.');
       $this->error($testDetails);
       return;
     }
     else {
-      $values = mysql_fetch_row($result);
+      $values = mysqli_fetch_row($result);
       if ($values[1] == 1) {
         $testDetails[3] = ts('MySQL server auto_increment_increment is 1');
       }
@@ -1115,26 +1115,26 @@ class InstallRequirements {
    */
   public function requireMySQLThreadStack($server, $username, $password, $database, $minValueKB, $testDetails) {
     $this->testing($testDetails);
-    $conn = @mysql_connect($server, $username, $password);
+    $conn = @mysqli_connect($server, $username, $password);
     if (!$conn) {
       $testDetails[2] = ts('Could not connect to the database server.');
       $this->error($testDetails);
       return;
     }
 
-    if (!@mysql_select_db($database, $conn)) {
+    if (!@mysqli_select_db($conn, $database)) {
       $testDetails[2] = ts('Could not select the database.');
       $this->error($testDetails);
       return;
     }
 
-    $result = mysql_query("SHOW VARIABLES LIKE 'thread_stack'", $conn); // bytes => kb
+    $result = mysqli_query($conn, "SHOW VARIABLES LIKE 'thread_stack'"); // bytes => kb
     if (!$result) {
       $testDetails[2] = ts('Could not get information about the thread_stack of the database.');
       $this->error($testDetails);
     }
     else {
-      $values = mysql_fetch_row($result);
+      $values = mysqli_fetch_row($result);
       if ($values[1] < (1024 * $minValueKB)) {
         $testDetails[2] = ts('MySQL "thread_stack" is %1 kb', array(1 => ($values[1] / 1024)));
         $this->error($testDetails);
@@ -1159,10 +1159,10 @@ class InstallRequirements {
     $onlyRequire = FALSE
   ) {
     $this->testing($testDetails);
-    $conn = @mysql_connect($server, $username, $password);
+    $conn = @mysqli_connect($server, $username, $password);
 
     $okay = NULL;
-    if (@mysql_select_db($database)) {
+    if (@mysqli_select_db($conn, $database)) {
       $okay = "Database '$database' exists";
     }
     elseif ($onlyRequire) {
@@ -1171,8 +1171,8 @@ class InstallRequirements {
       return;
     }
     else {
-      $query = sprintf("CREATE DATABASE %s", mysql_real_escape_string($database));
-      if (@mysql_query($query)) {
+      $query = sprintf("CREATE DATABASE %s", mysqli_real_escape_string($conn, $database));
+      if (@mysqli_query($conn, $query)) {
         $okay = ts("Able to create a new database.");
       }
       else {
@@ -1298,14 +1298,14 @@ class Installer extends InstallRequirements {
    * @param $database
    */
   public function createDatabaseIfNotExists($server, $username, $password, $database) {
-    $conn = @mysql_connect($server, $username, $password);
+    $conn = @mysqli_connect($server, $username, $password);
 
-    if (@mysql_select_db($database)) {
+    if (@mysqli_select_db($conn, $database)) {
       // skip if database already present
       return;
     }
-    $query = sprintf("CREATE DATABASE %s", mysql_real_escape_string($database));
-    if (@mysql_query($query)) {
+    $query = sprintf("CREATE DATABASE %s", mysqli_real_escape_string($conn, $database));
+    if (@mysqli_query($conn, $query)) {
     }
     else {
       $errorTitle = ts("Oops! Could not create database %1", array(1 => $database));

--- a/sql/GenerateData.php
+++ b/sql/GenerateData.php
@@ -430,7 +430,7 @@ class CRM_GCD {
   private function _insert(&$dao) {
     if (self::ADD_TO_DB) {
       if (!$dao->insert()) {
-        echo "ERROR INSERT: " . mysql_error() . "\n";
+        echo "ERROR INSERT: " . mysqli_error($dao->getConnection()->connection) . "\n";
         print_r($dao);
         exit(1);
       }
@@ -444,7 +444,7 @@ class CRM_GCD {
   private function _update(&$dao) {
     if (self::ADD_TO_DB) {
       if (!$dao->update()) {
-        echo "ERROR UPDATE: " . mysql_error() . "\n";
+        echo "ERROR UPDATE: " . mysqli_error($dao->getConnection()->connection) . "\n";
         print_r($dao);
         exit(1);
       }

--- a/sql/GenerateReportData.php
+++ b/sql/GenerateReportData.php
@@ -383,7 +383,7 @@ class CRM_GCD {
   private function _insert(&$dao) {
     if (self::ADD_TO_DB) {
       if (!$dao->insert()) {
-        echo "ERROR INSERT: " . mysql_error() . "\n";
+        echo "ERROR INSERT: " . mysqli_error($dao->getConnection()->connection) . "\n";
         print_r($dao);
         exit(1);
       }
@@ -397,7 +397,7 @@ class CRM_GCD {
   private function _update($dao) {
     if (self::ADD_TO_DB) {
       if (!$dao->update()) {
-        echo "ERROR UPDATE: " . mysql_error() . "\n";
+        echo "ERROR UPDATE: " . mysqli_error($dao->getConnection()->connection) . "\n";
         print_r($dao);
         exit(1);
       }

--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -67,10 +67,10 @@ if (!defined('CIVICRM_UF')) {
  *
  * Update this setting with your CMS (Drupal, Backdrop CMS, or Joomla) database username, server and DB name.
  * Datasource (DSN) format:
- *      define( 'CIVICRM_UF_DSN', 'mysql://cms_db_username:cms_db_password@db_server/cms_database?new_link=true');
+ *      define( 'CIVICRM_UF_DSN', 'mysqli://cms_db_username:cms_db_password@db_server/cms_database?new_link=true');
  */
 if (!defined('CIVICRM_UF_DSN') && CIVICRM_UF !== 'UnitTests') {
-  define( 'CIVICRM_UF_DSN'           , 'mysql://%%CMSdbUser%%:%%CMSdbPass%%@%%CMSdbHost%%/%%CMSdbName%%?new_link=true');
+  define( 'CIVICRM_UF_DSN'           , 'mysqli://%%CMSdbUser%%:%%CMSdbPass%%@%%CMSdbHost%%/%%CMSdbName%%?new_link=true');
 }
 
 /**
@@ -78,19 +78,19 @@ if (!defined('CIVICRM_UF_DSN') && CIVICRM_UF !== 'UnitTests') {
  *
  * Database URL (CIVICRM_DSN) for CiviCRM Data:
  * Database URL format:
- *      define( 'CIVICRM_DSN', 'mysql://crm_db_username:crm_db_password@db_server/crm_database?new_link=true');
+ *      define( 'CIVICRM_DSN', 'mysqli://crm_db_username:crm_db_password@db_server/crm_database?new_link=true');
  *
  * Drupal and CiviCRM can share the same database, or can be installed into separate databases.
  * Backdrop CMS and CiviCRM can also share the same database, or can be installed into separate databases.
  *
  * EXAMPLE: Drupal/Backdrop and CiviCRM running in the same database...
  *      DB Name = cms, DB User = cms
- *      define( 'CIVICRM_DSN'         , 'mysql://cms:YOUR_PASSWORD@localhost/cms?new_link=true');
+ *      define( 'CIVICRM_DSN'         , 'mysqli://cms:YOUR_PASSWORD@localhost/cms?new_link=true');
  *
  * EXAMPLE: Drupal/Backdrop and CiviCRM running in separate databases...
  *      CMS DB Name = cms, DB User = cms
  *      CiviCRM DB Name = civicrm, CiviCRM DB User = civicrm
- *      define( 'CIVICRM_DSN'         , 'mysql://civicrm:YOUR_PASSWORD@localhost/civicrm?new_link=true');
+ *      define( 'CIVICRM_DSN'         , 'mysqli://civicrm:YOUR_PASSWORD@localhost/civicrm?new_link=true');
  *
  */
 if (!defined('CIVICRM_DSN')) {
@@ -98,7 +98,7 @@ if (!defined('CIVICRM_DSN')) {
     define('CIVICRM_DSN', $GLOBALS['_CV']['TEST_DB_DSN']);
   }
   else {
-    define('CIVICRM_DSN', 'mysql://%%dbUser%%:%%dbPass%%@%%dbHost%%/%%dbName%%?new_link=true');
+    define('CIVICRM_DSN', 'mysqli://%%dbUser%%:%%dbPass%%@%%dbHost%%/%%dbName%%?new_link=true');
   }
 }
 

--- a/tests/phpunit/CRM/Core/TransactionTest.php
+++ b/tests/phpunit/CRM/Core/TransactionTest.php
@@ -362,6 +362,7 @@ class CRM_Core_TransactionTest extends CiviUnitTestCase {
 
     if ($insert == 'sql-insert') {
       $r = CRM_Core_DAO::executeQuery("INSERT INTO civicrm_contact(first_name,last_name) VALUES ('ff', 'll')");
+      // @fixme mysql_insert_id() does not exist in PHP7.
       $cid = mysql_insert_id();
     }
     elseif ($insert == 'bao-create') {


### PR DESCRIPTION
Theoretically, everyone using CiviCRM by now should have the `mysqli` extension so perhaps we could drop reference to `mysql` - which was deprecated in PHP 5.5 and no longer exists in PHP 7.

---
- [CRM-17789: Support PHP 7](https://issues.civicrm.org/jira/browse/CRM-17789)
