### PR TITLE
Fix event Default Role label

### DIFF
--- a/xml/schema/Event/Event.xml
+++ b/xml/schema/Event/Event.xml
@@ -328,7 +328,7 @@
   <field>
     <name>default_role_id</name>
     <uniqueName>default_role_id</uniqueName>
-    <title>Default Role ID</title>
+    <title>Default Role</title>
     <import>true</import>
     <type>int unsigned</type>
     <default>1</default>


### PR DESCRIPTION
This fixes a cosmetic issue where the "Create Event" form was showing the default role field as "Default Role ID" instead of "Default Role"
