### PR TITLE
CRM-18467 Set amount to appear on pay-later receipt

### DIFF
--- a/CRM/Contribute/BAO/Contribution/Utils.php
+++ b/CRM/Contribute/BAO/Contribution/Utils.php
@@ -205,6 +205,10 @@ class CRM_Contribute_BAO_Contribution_Utils {
         'payment_processor_id' => 0,
       );
     }
+    elseif (empty($form->_values['amount'])) {
+      // If the amount is not in _values[], set it
+      $form->_values['amount'] = $form->_params['amount'];
+    }
     CRM_Contribute_BAO_ContributionPage::sendMail($contactID,
       $form->_values,
       $contribution->is_test


### PR DESCRIPTION
The amount is passed to this function as $form->_params['amount']

If $form->_values['amount'] is not set, then the Amount won't print on the receipt.

The previous if-statement handles the case when the amount is zero. So this elseif checks whether $form->_values['amount'] is empty, and if it is, copies the amount into it.

---
- [CRM-18467: Amount doesn't appear on Pay Later receipt](https://issues.civicrm.org/jira/browse/CRM-18467)
