### PR TITLE
CRM-18035: Deleting file / attachment causes Undefined index: tag_id …

### DIFF
--- a/CRM/Core/BAO/EntityTag.php
+++ b/CRM/Core/BAO/EntityTag.php
@@ -116,8 +116,10 @@ class CRM_Core_BAO_EntityTag extends CRM_Core_DAO_EntityTag {
     $entityTag->delete();
 
     //invoke post hook on entityTag
-    $object = array(0 => array(0 => $params['entity_id']), 1 => $params['entity_table']);
-    CRM_Utils_Hook::post('delete', 'EntityTag', $params['tag_id'], $object);
+    if (!empty($params['tag_id'])) {
+      $object = array(0 => array(0 => $params['entity_id']), 1 => $params['entity_table']);
+      CRM_Utils_Hook::post('delete', 'EntityTag', $params['tag_id'], $object);
+    }
   }
 
   /**


### PR DESCRIPTION
…in CRM_Core_BAO_EntityTag::del()

`'tag_id'` gets passed only when the tag associated with [some entity](https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/BAO/EntityTag.php#L281-L289)(eg. Contact) gets deleted. Hence just a !empty() check would avoid the notice in other scenarios.

https://issues.civicrm.org/jira/browse/CRM-18035
