### PR TITLE
CRM-18193 logging schema: fix mismatch between comment & code convention

### DIFF
--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -874,7 +874,7 @@ COLS;
         // We tried setting the @uniqueID in the trigger but it was unreliable.
         // An external interaction could split over 2 connections & it seems worth blocking the revert on
         // these reports & adding extra permissioning to the api for this.
-        $connectionSQLString = "COALESCE(@uniqueID, LEFT(CONCAT('con_', unix_timestamp()/3600, CONNECTION_ID()), 17))";
+        $connectionSQLString = "COALESCE(@uniqueID, LEFT(CONCAT('c_', unix_timestamp()/3600, CONNECTION_ID()), 17))";
       }
       else {
         // The log tables have not yet been converted to have varchar(17) fields for log_conn_id.


### PR DESCRIPTION
Comment suggests 'c_' to identify a non-CRM connection + timestamp to the hour + connection_id but code used 'con_'

I think the shorter version in comment is better as there is more real information space.

This is an error picked up during RC testing
