### PR TITLE
CRM-18469, CRM-17984 - getTree - Restore return by reference

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -343,7 +343,7 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup {
    *   The reason for the info array in unclear and it could be determined from parsing the group tree after creation
    *   With caching the performance impact would be small & the function would be cleaner
    */
-  public static function getTree(
+  public static function &getTree(
     $entityType,
     $deprecated = NULL,
     $entityID = NULL,


### PR DESCRIPTION
The reference in `getTree()`'s signature was recently removed ( 27dd62528f5f16e856760db948bbe90bd6240f8c) which has prompted a few piecemeal updates to callers (eg 64c71b4, 1d8a5bb).

This PR restores the `&` in hopes of preventing similar patches in ten other places.

There is an _alternative_ PR (#8243) which changes more callers in bulk. Choose one or the other.

---
- [CRM-18469: Strict warning for calling getTree by reference](https://issues.civicrm.org/jira/browse/CRM-18469)
- [CRM-17984](https://issues.civicrm.org/jira/browse/CRM-17984)
