### PR TITLE
CRM-18469, CRM-17984 - getTree - No more pass by reference

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -379,7 +379,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
 
     if ($this->_action & CRM_Core_Action::VIEW) {
       // Get the tree of custom fields.
-      $this->_groupTree = &CRM_Core_BAO_CustomGroup::getTree('Activity', $this,
+      $this->_groupTree = CRM_Core_BAO_CustomGroup::getTree('Activity', $this,
         $this->_activityId, 0, $this->_activityTypeId
       );
     }

--- a/CRM/Case/Form/CaseView.php
+++ b/CRM/Case/Form/CaseView.php
@@ -161,7 +161,7 @@ class CRM_Case_Form_CaseView extends CRM_Core_Form {
 
     $entitySubType = !empty($values['case_type_id']) ? $values['case_type_id'] : NULL;
     $this->assign('caseTypeID', $entitySubType);
-    $groupTree = &CRM_Core_BAO_CustomGroup::getTree('Case',
+    $groupTree = CRM_Core_BAO_CustomGroup::getTree('Case',
       $this,
       $this->_caseID,
       NULL,

--- a/CRM/Case/Form/CustomData.php
+++ b/CRM/Case/Form/CustomData.php
@@ -65,7 +65,7 @@ class CRM_Case_Form_CustomData extends CRM_Core_Form {
     $this->_subTypeID = CRM_Utils_Request::retrieve('subType', 'Positive', $this, TRUE);
     $this->_contactID = CRM_Utils_Request::retrieve('cid', 'Positive', $this, TRUE);
 
-    $groupTree = &CRM_Core_BAO_CustomGroup::getTree('Case',
+    $groupTree = CRM_Core_BAO_CustomGroup::getTree('Case',
       $this,
       $this->_entityID,
       $this->_groupID,

--- a/CRM/Contact/Form/CustomData.php
+++ b/CRM/Contact/Form/CustomData.php
@@ -230,7 +230,7 @@ class CRM_Contact_Form_CustomData extends CRM_Core_Form {
     if ($this->_cdType || $this->_multiRecordDisplay == 'single') {
       if ($this->_copyValueId) {
         // cached tree is fetched
-        $groupTree = &CRM_Core_BAO_CustomGroup::getTree($this->_type,
+        $groupTree = CRM_Core_BAO_CustomGroup::getTree($this->_type,
           $this,
           $this->_entityId,
           $this->_groupID
@@ -253,7 +253,7 @@ class CRM_Contact_Form_CustomData extends CRM_Core_Form {
       return $customDefaultValue;
     }
 
-    $groupTree = &CRM_Core_BAO_CustomGroup::getTree($this->_contactType,
+    $groupTree = CRM_Core_BAO_CustomGroup::getTree($this->_contactType,
       $this,
       $this->_tableID,
       $this->_groupID,
@@ -262,7 +262,7 @@ class CRM_Contact_Form_CustomData extends CRM_Core_Form {
 
     if (empty($_POST['hidden_custom_group_count'])) {
       // custom data building in edit mode (required to handle multi-value)
-      $groupTree = &CRM_Core_BAO_CustomGroup::getTree($this->_contactType, $this, $this->_tableID,
+      $groupTree = CRM_Core_BAO_CustomGroup::getTree($this->_contactType, $this, $this->_tableID,
         $this->_groupID, $this->_contactSubType
       );
       $customValueCount = CRM_Core_BAO_CustomGroup::buildCustomDataView($this, $groupTree, TRUE, $this->_groupID, NULL, NULL, $this->_tableID);

--- a/CRM/Contact/Form/Search/Custom/ActivitySearch.php
+++ b/CRM/Contact/Form/Search/Custom/ActivitySearch.php
@@ -70,7 +70,7 @@ class CRM_Contact_Form_Search_Custom_ActivitySearch extends CRM_Contact_Form_Sea
     );
 
     //Add custom fields to columns array for inclusion in export
-    $groupTree = &CRM_Core_BAO_CustomGroup::getTree('Activity', $form, NULL,
+    $groupTree = CRM_Core_BAO_CustomGroup::getTree('Activity', $form, NULL,
       NULL, '', NULL
     );
 

--- a/CRM/Contact/Page/Inline/CustomData.php
+++ b/CRM/Contact/Page/Inline/CustomData.php
@@ -51,7 +51,7 @@ class CRM_Contact_Page_Inline_CustomData extends CRM_Core_Page {
     //custom groups Inline
     $entityType = CRM_Contact_BAO_Contact::getContactType($contactId);
     $entitySubType = CRM_Contact_BAO_Contact::getContactSubType($contactId);
-    $groupTree = &CRM_Core_BAO_CustomGroup::getTree($entityType, $this, $contactId,
+    $groupTree = CRM_Core_BAO_CustomGroup::getTree($entityType, $this, $contactId,
       $cgId, $entitySubType
     );
     $details = CRM_Core_BAO_CustomGroup::buildCustomDataView($this, $groupTree, FALSE, NULL, NULL, NULL, $contactId);

--- a/CRM/Event/Form/ParticipantView.php
+++ b/CRM/Event/Form/ParticipantView.php
@@ -140,7 +140,7 @@ class CRM_Event_Form_ParticipantView extends CRM_Core_Form {
 
     foreach ($allRoleIDs as $k => $v) {
       $roleGroupTree = CRM_Core_BAO_CustomGroup::getTree('Participant', $this, $participantID, NULL, $v, $roleCustomDataTypeID);
-      $eventGroupTree = &CRM_Core_BAO_CustomGroup::getTree('Participant', $this, $participantID, NULL,
+      $eventGroupTree = CRM_Core_BAO_CustomGroup::getTree('Participant', $this, $participantID, NULL,
         $values[$participantID]['event_id'], $eventNameCustomDataTypeID
       );
       $eventTypeID = CRM_Core_DAO::getFieldValue("CRM_Event_DAO_Event", $values[$participantID]['event_id'], 'event_type_id', 'id');

--- a/CRM/Grant/Form/GrantView.php
+++ b/CRM/Grant/Form/GrantView.php
@@ -117,7 +117,7 @@ class CRM_Grant_Form_GrantView extends CRM_Core_Form {
     $this->assign('attachment', $attachment);
 
     $grantType = CRM_Core_DAO::getFieldValue("CRM_Grant_DAO_Grant", $this->_id, "grant_type_id");
-    $groupTree = &CRM_Core_BAO_CustomGroup::getTree("Grant", $this, $this->_id, 0, $grantType);
+    $groupTree = CRM_Core_BAO_CustomGroup::getTree("Grant", $this, $this->_id, 0, $grantType);
     CRM_Core_BAO_CustomGroup::buildCustomDataView($this, $groupTree, FALSE, NULL, NULL, NULL, $this->_id);
 
     $this->assign('id', $this->_id);


### PR DESCRIPTION
The reference in `getTree()`'s signature was recently removed ( 27dd62528f5f16e856760db948bbe90bd6240f8c) which has prompted a few piecemeal updates to callers (eg 64c71b4, 1d8a5bb).

This PR does a search/replace for  based on grepping for all callers.

There is an _alternative_ PR (#8242) which restores the old signature. Choose one or the other.

---
- [CRM-18469: Strict warning for calling getTree by reference](https://issues.civicrm.org/jira/browse/CRM-18469)
- [CRM-17984](https://issues.civicrm.org/jira/browse/CRM-17984)
