### PR TITLE
CRM-15078: make sure logging schema is updated on extension installation

### DIFF
--- a/CRM/Extension/Manager.php
+++ b/CRM/Extension/Manager.php
@@ -244,6 +244,8 @@ class CRM_Extension_Manager {
     $this->statuses = NULL;
     $this->mapper->refresh();
     CRM_Core_Invoke::rebuildMenuAndCaches(TRUE);
+    $schema = new CRM_Logging_Schema();
+    $schema->fixSchemaDifferences();
 
     foreach ($keys as $key) {
       list ($info, $typeManager) = $this->_getInfoTypeHandler($key); // throws Exception


### PR DESCRIPTION
This patch is a 4.7 backport that we have had running in production for some time without error

---
- [CRM-15078: log tables not created for extensions with tables](https://issues.civicrm.org/jira/browse/CRM-15078)
