### PR TITLE
Test clean up. Standardise delete contact calls.

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -1207,7 +1207,12 @@ GROUP BY p.id
   }
 
   /**
-   * Get list of contribution In Honor of contact Ids.
+   * Get list of contributions which credit the passed in contact ID.
+   *
+   * The returned array provides details about the original contribution & donor.
+   *
+   * @todo - this is a confusing function called from one place. It has a test. It would be
+   * nice to deprecate it.
    *
    * @param int $honorId
    *   In Honor of Contact ID.

--- a/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
@@ -52,7 +52,7 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
     );
     $this->assertEquals($activityTypeId, 3, 'Verify activity type id is 3.');
 
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
   /**
@@ -87,8 +87,8 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
 
     $this->assertEquals($activities[$activityId]['subject'], 'Scheduling Meeting', 'Verify activity subject is correct.');
 
-    Contact::delete($contactId);
-    Contact::delete($targetContactId);
+    $this->contactDelete($contactId);
+    $this->contactDelete($targetContactId);
   }
 
   /**
@@ -136,8 +136,8 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
 
     $this->assertEquals($defaults['target_contact'][0], $targetContactId, 'Verify target contact id is correct.');
 
-    Contact::delete($contactId);
-    Contact::delete($targetContactId);
+    $this->contactDelete($contactId);
+    $this->contactDelete($targetContactId);
   }
 
   /**
@@ -179,13 +179,13 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
       'activity_type_id' => 2,
     );
 
-    $result = CRM_Activity_BAO_Activity::deleteActivity($params);
+    CRM_Activity_BAO_Activity::deleteActivity($params);
 
-    $activityId = $this->assertDBNull('CRM_Activity_DAO_Activity', 'Scheduling Meeting', 'id',
+    $this->assertDBNull('CRM_Activity_DAO_Activity', 'Scheduling Meeting', 'id',
       'subject', 'Database check for deleted activity.'
     );
-    Contact::delete($contactId);
-    Contact::delete($targetContactId);
+    $this->contactDelete($contactId);
+    $this->contactDelete($targetContactId);
   }
 
   /**
@@ -226,8 +226,8 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
       'contact_id', 'Database check for deleted activity target.'
     );
 
-    Contact::delete($contactId);
-    Contact::delete($targetContactId);
+    $this->contactDelete($contactId);
+    $this->contactDelete($targetContactId);
   }
 
   /**
@@ -268,8 +268,8 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
       'contact_id', 'Database check for deleted activity assignment.'
     );
 
-    Contact::delete($contactId);
-    Contact::delete($assigneeContactId);
+    $this->contactDelete($contactId);
+    $this->contactDelete($assigneeContactId);
   }
 
   /**

--- a/tests/phpunit/CRM/Contact/BAO/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ContactTest.php
@@ -67,7 +67,7 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
     $this->assertEquals($firstName, $contact->first_name, 'Check for updated first name.');
 
     $contactId = $contact->id;
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
   /**
@@ -210,7 +210,7 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
     }
     $this->assertAttributesEquals($checkPrefComm, $prefComm);
 
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
   /**
@@ -242,7 +242,7 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
     $contact = CRM_Contact_BAO_Contact::add($params);
     $this->assertEquals($firstName, $contact->first_name, 'Check for updated first name.');
     $contactId = $contact->id;
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
 
     $householdName = 'Adams house';
     $params = array(
@@ -262,7 +262,7 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
     );
     $contact = CRM_Contact_BAO_Contact::add($params);
     $this->assertEquals($householdName, $contact->sort_name, 'Check for updated household.');
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
 
     $organizationName = 'My Organization';
     $params = array(
@@ -282,7 +282,7 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
     );
     $contact = CRM_Contact_BAO_Contact::add($params);
     $this->assertEquals($organizationName, $contact->sort_name, 'Check for updated organization.');
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
   /**
@@ -493,7 +493,7 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
     CRM_Core_BAO_Note::cleanContactNotes($contactId);
 
     // Cleanup DB by deleting the contact.
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
     $this->quickCleanup(array('civicrm_contact', 'civicrm_note'));
   }
 
@@ -624,14 +624,14 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
       //Now check values of Relationship type.
       $this->assertEquals('Employee of', $val['relation'], 'Check for relationship type');
       //delete the organization.
-      Contact::delete(CRM_Utils_Array::value('contact_id_b', $val));
+      $this->contactDelete(CRM_Utils_Array::value('contact_id_b', $val));
     }
 
     //delete all notes related to contact
     CRM_Core_BAO_Note::cleanContactNotes($contactId);
 
     //cleanup DB by deleting the contact
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
     $this->quickCleanup(array('civicrm_contact'));
   }
 
@@ -893,7 +893,7 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
       //Now check values of Relationship type.
       $this->assertEquals('Employee of', $val['relation'], 'Check for relationship type');
       //delete the organization.
-      Contact::delete(CRM_Utils_Array::value('cid', $val));
+      $this->contactDelete(CRM_Utils_Array::value('cid', $val));
     }
 
     //Now check values of tag ids.
@@ -1096,7 +1096,7 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
       //Now check values of Relationship type.
       $this->assertEquals('Employee of', $val['relation'], 'Check for relationship type');
       //delete the organization.
-      Contact::delete(CRM_Utils_Array::value('cid', $val));
+      $this->contactDelete(CRM_Utils_Array::value('cid', $val));
     }
 
     //Now check values of tag ids.
@@ -1107,7 +1107,7 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
     $this->assertAttributesEquals($updatePfParams['tag'], $tagIds);
 
     //cleanup DB by deleting the contact
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
   /**
@@ -1132,7 +1132,7 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
     $this->assertAttributesEquals($compareParams, $contactDetails);
 
     //cleanup DB by deleting the contact
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
     $this->quickCleanup(array('civicrm_contact'));
   }
 
@@ -1180,7 +1180,7 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
     $this->assertEquals($email, CRM_Utils_Array::value('email', $params['email'][2]), 'Check Primary Email');
 
     //cleanup DB by deleting the contact
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
     $this->quickCleanup(array('civicrm_contact'));
   }
 
@@ -1205,7 +1205,7 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
     $this->assertEquals($openID, strtolower($params['openid'][2]['openid']), 'Check Primary OpenID');
 
     //cleanup DB by deleting the contact
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
   /**
@@ -1225,7 +1225,7 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
     $this->assertEquals($contactId, $match->contact_id, 'Check For Matching Contact');
 
     //cleanup DB by deleting the contact
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
     $this->quickCleanup(array('civicrm_contact'));
   }
 
@@ -1244,7 +1244,7 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
     $this->assertEquals($contactType, $params['contact_type'], 'Check For Contact Type');
 
     //cleanup DB by deleting the contact
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
     $this->quickCleanup(array('civicrm_contact'));
   }
 
@@ -1271,7 +1271,7 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
     $this->assertEquals($dbDisplayName, $paramsDisplayName, 'Check For Display Name');
 
     //cleanup DB by deleting the contact
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
     $this->quickCleanup(array('civicrm_contact'));
   }
 
@@ -1301,7 +1301,7 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
     $this->assertEquals($image, $checkImage, 'Check For Image');
 
     //cleanup DB by deleting the contact
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
   /**
@@ -1560,7 +1560,7 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
       $prevTimestamps = $newTimestamps;
     }
 
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
 }

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -25,9 +25,6 @@
  +--------------------------------------------------------------------+
  */
 
-require_once 'CiviTest/Contact.php';
-require_once 'CiviTest/Custom.php';
-
 /**
  * Class CRM_Contribute_BAO_ContributionTest
  * @group headless
@@ -35,11 +32,19 @@ require_once 'CiviTest/Custom.php';
 class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
 
   /**
-   * Create() method (create and update modes).
+   * Clean up after tests.
+   */
+  public function tearDown() {
+    $this->quickCleanUpFinancialEntities();
+    $this->quickCleanUpFinancialEntities(array('civicrm_event'));
+    parent::tearDown();
+  }
+
+  /**
+   * Test create method (create and update modes).
    */
   public function testCreate() {
-    $contactId = Contact::createIndividual();
-    $ids = array('contribution' => NULL);
+    $contactId = $this->individualCreate();
 
     $params = array(
       'contact_id' => $contactId,
@@ -59,9 +64,9 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
       'thankyou_date' => '20080522',
     );
 
-    $contribution = CRM_Contribute_BAO_Contribution::create($params, $ids);
+    $contribution = CRM_Contribute_BAO_Contribution::create($params);
 
-    $this->assertEquals($params['trxn_id'], $contribution->trxn_id, 'Check for transcation id creation.');
+    $this->assertEquals($params['trxn_id'], $contribution->trxn_id, 'Check for transaction id creation.');
     $this->assertEquals($contactId, $contribution->contact_id, 'Check for contact id  creation.');
 
     //update contribution amount
@@ -73,29 +78,25 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
 
     $this->assertEquals($params['trxn_id'], $contribution->trxn_id, 'Check for transcation id .');
     $this->assertEquals($params['net_amount'], $contribution->net_amount, 'Check for Amount updation.');
-
-    //Delete Contribution
-    $this->contributionDelete($contribution->id);
-
-    //Delete Contact
-    $this->contactDelete($contactId);
   }
 
   /**
    * Create() method with custom data.
    */
   public function testCreateWithCustomData() {
-    $contactId = Contact::createIndividual();
-    $ids = array('contribution' => NULL);
+    $contactId = $this->individualCreate();
 
     //create custom data
-    $customGroup = Custom::createGroup(array(), 'Contribution');
+    $customGroup = $this->customGroupCreate(array('extends' => 'Contribution'));
+    $customGroupID = $customGroup['id'];
+    $customGroup = $customGroup['values'][$customGroupID];
+
     $fields = array(
       'label' => 'testFld',
       'data_type' => 'String',
       'html_type' => 'Text',
       'is_active' => 1,
-      'custom_group_id' => $customGroup->id,
+      'custom_group_id' => $customGroupID,
     );
     $customField = CRM_Core_BAO_CustomField::create($fields);
 
@@ -124,15 +125,15 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
           'value' => 'Test custom value',
           'type' => 'String',
           'custom_field_id' => $customField->id,
-          'custom_group_id' => $customGroup->id,
-          'table_name' => $customGroup->table_name,
+          'custom_group_id' => $customGroupID,
+          'table_name' => $customGroup['table_name'],
           'column_name' => $customField->column_name,
           'file_id' => NULL,
         ),
       ),
     );
 
-    $contribution = CRM_Contribute_BAO_Contribution::create($params, $ids);
+    $contribution = CRM_Contribute_BAO_Contribution::create($params);
 
     // Check that the custom field value is saved
     $customValueParams = array(
@@ -144,19 +145,13 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
 
     $this->assertEquals($params['trxn_id'], $contribution->trxn_id, 'Check for transcation id creation.');
     $this->assertEquals($contactId, $contribution->contact_id, 'Check for contact id for Conribution.');
-
-    $this->contributionDelete($contribution->id);
-    Custom::deleteField($customField);
-    Custom::deleteGroup($customGroup);
-    $this->contactDelete($contactId);
   }
 
   /**
    * DeleteContribution() method
    */
   public function testDeleteContribution() {
-    $contactId = Contact::createIndividual();
-    $ids = array('contribution' => NULL);
+    $contactId = $this->individualCreate();
 
     $params = array(
       'contact_id' => $contactId,
@@ -177,23 +172,22 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
       'thankyou_date' => '20080522',
     );
 
-    $contribution = CRM_Contribute_BAO_Contribution::create($params, $ids);
+    $contribution = CRM_Contribute_BAO_Contribution::create($params);
 
     $this->assertEquals($params['trxn_id'], $contribution->trxn_id, 'Check for transcation id creation.');
     $this->assertEquals($contactId, $contribution->contact_id, 'Check for contact id  creation.');
 
-    $contributiondelete = CRM_Contribute_BAO_Contribution::deleteContribution($contribution->id);
+    CRM_Contribute_BAO_Contribution::deleteContribution($contribution->id);
 
     $this->assertDBNull('CRM_Contribute_DAO_Contribution', $contribution->trxn_id,
       'id', 'trxn_id', 'Database check for deleted Contribution.'
     );
-    $this->contactDelete($contactId);
   }
 
   /**
-   * Create honor-contact method
+   * Create honor-contact method.
    */
-  public function testcreateAndGetHonorContact() {
+  public function testCreateAndGetHonorContact() {
     $firstName = 'John_' . substr(sha1(rand()), 0, 7);
     $lastName = 'Smith_' . substr(sha1(rand()), 0, 7);
     $email = "{$firstName}.{$lastName}@example.com";
@@ -223,10 +217,8 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
     );
     //create contribution on behalf of honary.
 
-    $contactId = Contact::createIndividual();
-    $softParam['contact_id'] = $honoreeContactId;
+    $contactId = $this->individualCreate(array('first_name' => 'John', 'last_name' => 'Doe'));
 
-    $ids = array('contribution' => NULL);
     $param = array(
       'contact_id' => $contactId,
       'currency' => 'USD',
@@ -236,8 +228,9 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
       'total_amount' => 66,
     );
 
-    $contribution = CRM_Contribute_BAO_Contribution::create($param, $ids);
+    $contribution = CRM_Contribute_BAO_Contribution::create($param);
     $id = $contribution->id;
+    $softParam['contact_id'] = $honoreeContactId;
     $softParam['contribution_id'] = $id;
     $softParam['currency'] = $contribution->currency;
     $softParam['amount'] = $contribution->total_amount;
@@ -253,8 +246,8 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
     $this->assertEquals(array(
       $id => array(
         'honor_type' => 'In Honor of',
-        'honorId' => $id,
-        'display_name' => 'John Doe',
+        'honorId' => $contactId,
+        'display_name' => 'Mr. John Doe II',
         'type' => 'Event Fee',
         'type_id' => '4',
         'amount' => '$ 66.00',
@@ -276,15 +269,6 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
     $this->assertDBCompareValue('CRM_Contribute_DAO_Contribution', $id, 'total_amount',
       'id', ltrim($annual[2], $currencySymbol), 'Check DB for total amount of the contribution'
     );
-
-    //Delete honor contact
-    $this->contactDelete($honoreeContactId);
-
-    //Delete Contribution record
-    $this->contributionDelete($contribution->id);
-
-    //Delete contributor contact
-    $this->contactDelete($contactId);
   }
 
   /**
@@ -336,11 +320,6 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
     $sortName = CRM_Contribute_BAO_Contribution::sortName($contribution->id);
 
     $this->assertEquals('Whatson, Shane', $sortName, 'Check for sort name.');
-
-    //Delete Contribution
-    $this->contributionDelete($contribution->id);
-    //Delete Contact
-    $this->contactDelete($contactId);
   }
 
   /**
@@ -349,7 +328,7 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
    * AddPremium();
    */
   public function testAddPremium() {
-    $contactId = Contact::createIndividual();
+    $contactId = $this->individualCreate();
 
     $ids = array(
       'premium' => NULL,
@@ -410,11 +389,6 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
     $this->assertDBNull('CRM_Contribute_DAO_Product', $premium->name,
       'id', 'name', 'Database check for deleted Product.'
     );
-
-    //Delete Contribution
-    $this->contributionDelete($contribution->id);
-    //Delete Contact
-    $this->contactDelete($contactId);
   }
 
   /**
@@ -423,9 +397,7 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
    * checkDuplicateIds();
    */
   public function testcheckDuplicateIds() {
-    $contactId = Contact::createIndividual();
-
-    $ids = array('contribution' => NULL);
+    $contactId = $this->individualCreate();
 
     $param = array(
       'contact_id' => $contactId,
@@ -446,7 +418,7 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
       'thankyou_date' => '20080522',
     );
 
-    $contribution = CRM_Contribute_BAO_Contribution::create($param, $ids);
+    $contribution = CRM_Contribute_BAO_Contribution::create($param);
 
     $this->assertEquals($param['trxn_id'], $contribution->trxn_id, 'Check for transcation id creation.');
     $this->assertEquals($contactId, $contribution->contact_id, 'Check for contact id  creation.');
@@ -457,11 +429,6 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
     );
     $contributionID = CRM_Contribute_BAO_Contribution::checkDuplicateIds($data);
     $this->assertEquals($contributionID, $contribution->id, 'Check for duplicate transcation id .');
-
-    // Delete Contribution
-    $this->contributionDelete($contribution->id);
-    // Delete Contact
-    $this->contactDelete($contactId);
   }
 
   /**
@@ -470,9 +437,7 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
    * createCreditNoteId();
    */
   public function testCreateCreditNoteId() {
-    $contactId = Contact::createIndividual();
-
-    $ids = array('contribution' => NULL);
+    $contactId = $this->individualCreate();
 
     $param = array(
       'contact_id' => $contactId,
@@ -494,22 +459,16 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
     );
 
     $creditNoteId = CRM_Contribute_BAO_Contribution::createCreditNoteId();
-    $contribution = CRM_Contribute_BAO_Contribution::create($param, $ids);
+    $contribution = CRM_Contribute_BAO_Contribution::create($param);
     $this->assertEquals($contactId, $contribution->contact_id, 'Check for contact id  creation.');
     $this->assertEquals($creditNoteId, $contribution->creditnote_id, 'Check if credit note id is created correctly.');
-
-    // Delete Contribution
-    $this->contributionDelete($contribution->id);
-    // Delete Contact
-    $this->contactDelete($contactId);
   }
 
   /**
    * Create() method (create and update modes).
    */
   public function testIsPaymentFlag() {
-    $contactId = Contact::createIndividual();
-    $ids = array('contribution' => NULL);
+    $contactId = $this->individualCreate();
 
     $params = array(
       'contact_id' => $contactId,
@@ -529,7 +488,7 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
       'thankyou_date' => '20080522',
     );
 
-    $contribution = CRM_Contribute_BAO_Contribution::create($params, $ids);
+    $contribution = CRM_Contribute_BAO_Contribution::create($params);
 
     $this->assertEquals($params['trxn_id'], $contribution->trxn_id, 'Check for transcation id creation.');
     $this->assertEquals($contactId, $contribution->contact_id, 'Check for contact id  creation.');
@@ -559,20 +518,13 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
     $trxnArray['is_payment'] = 0;
     $financialTrxn = CRM_Core_BAO_FinancialTrxn::retrieve($trxnArray, $defaults);
     $this->assertEquals(NULL, $financialTrxn, 'Mismatch count for is payment flag.');
-
-    //Delete Contribution
-    $this->contributionDelete($contribution->id);
-
-    //Delete Contact
-    $this->contactDelete($contactId);
   }
 
   /**
    * Create() method (create and update modes).
    */
   public function testIsPaymentFlagForPending() {
-    $contactId = Contact::createIndividual();
-    $ids = array('contribution' => NULL);
+    $contactId = $this->individualCreate();
 
     $params = array(
       'contact_id' => $contactId,
@@ -593,7 +545,7 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
       'thankyou_date' => '20080522',
     );
 
-    $contribution = CRM_Contribute_BAO_Contribution::create($params, $ids);
+    $contribution = CRM_Contribute_BAO_Contribution::create($params);
 
     $this->assertEquals($params['trxn_id'], $contribution->trxn_id, 'Check for transcation id creation.');
     $this->assertEquals($contactId, $contribution->contact_id, 'Check for contact id  creation.');
@@ -626,12 +578,6 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
     $trxnArray['is_payment'] = 0;
     $financialTrxn = CRM_Core_BAO_FinancialTrxn::retrieve($trxnArray, $defaults);
     $this->assertEquals(2, $financialTrxn->N, 'Mismatch count for is payment flag.');
-
-    //Delete Contribution
-    $this->contributionDelete($contribution->id);
-
-    //Delete Contact
-    $this->contactDelete($contactId);
   }
 
   /**
@@ -651,7 +597,7 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
   public function checkItemValues($contribution) {
     $relationTypeId = key(CRM_Core_PseudoConstant::accountOptionValues('account_relationship', NULL, " AND v.name LIKE 'Accounts Receivable Account is' "));
     $toFinancialAccount = CRM_Contribute_PseudoConstant::financialAccountType(4, $relationTypeId);
-    $query = "SELECT eft1.entity_id, ft.total_amount, eft1.amount FROM civicrm_financial_trxn ft INNER JOIN civicrm_entity_financial_trxn eft ON (eft.financial_trxn_id = ft.id AND eft.entity_table = 'civicrm_contribution') 
+    $query = "SELECT eft1.entity_id, ft.total_amount, eft1.amount FROM civicrm_financial_trxn ft INNER JOIN civicrm_entity_financial_trxn eft ON (eft.financial_trxn_id = ft.id AND eft.entity_table = 'civicrm_contribution')
 INNER JOIN civicrm_entity_financial_trxn eft1 ON (eft1.financial_trxn_id = eft.financial_trxn_id AND eft1.entity_table = 'civicrm_financial_item')
 WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
 
@@ -664,9 +610,6 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
       $this->assertEquals(150.00, $dao->total_amount, 'Mismatch of total amount paid.');
       $this->assertEquals($dao->amount, array_pop($amounts), 'Mismatch of amount proportionally assigned to financial item');
     }
-
-    $this->contactDelete($this->_contactId);
-    Event::delete($this->_eventId);
   }
 
   /**
@@ -693,9 +636,9 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
    */
   public function addParticipantWithContribution() {
     // creating price set, price field
-    require_once 'CiviTest/Event.php';
-    $this->_contactId = Contact::createIndividual();
-    $this->_eventId = Event::create($this->_contactId);
+    $this->_contactId = $this->individualCreate();
+    $event = $this->eventCreate();
+    $this->_eventId = $event['id'];
     $paramsSet['title'] = 'Price Set' . substr(sha1(rand()), 0, 4);
     $paramsSet['name'] = CRM_Utils_String::titleToVar($paramsSet['title']);
     $paramsSet['is_active'] = TRUE;
@@ -819,7 +762,7 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
       ),
     );
     try {
-      $error = CRM_Contribute_BAO_Contribution::checkLineItems($params);
+      CRM_Contribute_BAO_Contribution::checkLineItems($params);
       $this->fail("Missed expected exception");
     }
     catch (Exception $e) {

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -78,7 +78,7 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
     $this->contributionDelete($contribution->id);
 
     //Delete Contact
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
   /**
@@ -148,7 +148,7 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
     $this->contributionDelete($contribution->id);
     Custom::deleteField($customField);
     Custom::deleteGroup($customGroup);
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
   /**
@@ -187,7 +187,7 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
     $this->assertDBNull('CRM_Contribute_DAO_Contribution', $contribution->trxn_id,
       'id', 'trxn_id', 'Database check for deleted Contribution.'
     );
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
   /**
@@ -278,13 +278,13 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
     );
 
     //Delete honor contact
-    Contact::delete($honoreeContactId);
+    $this->contactDelete($honoreeContactId);
 
     //Delete Contribution record
     $this->contributionDelete($contribution->id);
 
     //Delete contributor contact
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
   /**
@@ -340,7 +340,7 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
     //Delete Contribution
     $this->contributionDelete($contribution->id);
     //Delete Contact
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
   /**
@@ -414,7 +414,7 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
     //Delete Contribution
     $this->contributionDelete($contribution->id);
     //Delete Contact
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
   /**
@@ -461,7 +461,7 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
     // Delete Contribution
     $this->contributionDelete($contribution->id);
     // Delete Contact
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
   /**
@@ -501,7 +501,7 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
     // Delete Contribution
     $this->contributionDelete($contribution->id);
     // Delete Contact
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
   /**
@@ -564,7 +564,7 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
     $this->contributionDelete($contribution->id);
 
     //Delete Contact
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
   /**
@@ -631,7 +631,7 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
     $this->contributionDelete($contribution->id);
 
     //Delete Contact
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
   /**
@@ -665,7 +665,7 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
       $this->assertEquals($dao->amount, array_pop($amounts), 'Mismatch of amount proportionally assigned to financial item');
     }
 
-    Contact::delete($this->_contactId);
+    $this->contactDelete($this->_contactId);
     Event::delete($this->_eventId);
   }
 

--- a/tests/phpunit/CRM/Core/BAO/AddressTest.php
+++ b/tests/phpunit/CRM/Core/BAO/AddressTest.php
@@ -89,13 +89,13 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
 
     $block = CRM_Core_BAO_Address::create($params, $fixAddress, $entity = NULL);
 
-    $cid = $this->assertDBNotNull('CRM_Core_DAO_Address', $contactId, 'id', 'contact_id',
+    $this->assertDBNotNull('CRM_Core_DAO_Address', $contactId, 'id', 'contact_id',
       'Database check for updated address by contactId.'
     );
-    $addressId = $this->assertDBNotNull('CRM_Core_DAO_Address', '120 Terminal Road', 'id', 'street_address',
+    $this->assertDBNotNull('CRM_Core_DAO_Address', '120 Terminal Road', 'id', 'street_address',
       'Database check for updated address by street_name.'
     );
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
   /**
@@ -134,7 +134,7 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
     $this->assertEquals($addAddress->geo_code_1, '31.694842', 'In line' . __LINE__);
     $this->assertEquals($addAddress->geo_code_2, '-106.29998', 'In line' . __LINE__);
     $this->assertEquals($addAddress->country_id, '1228', 'In line' . __LINE__);
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
   /**
@@ -192,7 +192,7 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
 
     $this->assertEquals(count($allAddress), 2, 'Checking number of returned addresses.');
 
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
   /**
@@ -230,7 +230,7 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
 
     $this->assertEquals($allAddress, NULL, 'Checking null for returned addresses.');
 
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
   /**
@@ -270,7 +270,7 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
     $this->assertEquals($address[1]['id'], $addressId);
     $this->assertEquals($address[1]['contact_id'], $contactId);
     $this->assertEquals($address[1]['street_address'], 'Oberoi Garden');
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
   /**

--- a/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
@@ -449,7 +449,7 @@ class CRM_Core_BAO_CustomGroupTest extends CiviUnitTestCase {
     }
 
     Custom::deleteGroup($customGroup);
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
   /**

--- a/tests/phpunit/CRM/Core/BAO/CustomValueTableMultipleTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomValueTableMultipleTest.php
@@ -38,7 +38,7 @@ class CRM_Core_BAO_CustomValueTableMultipleTest extends CiviUnitTestCase {
 
     Custom::deleteField($customField);
     Custom::deleteGroup($customGroup);
-    Contact::delete($contactID);
+    $this->contactDelete($contactID);
   }
 
   public function testCustomGroupMultipleDouble() {
@@ -71,7 +71,7 @@ class CRM_Core_BAO_CustomValueTableMultipleTest extends CiviUnitTestCase {
 
     Custom::deleteField($customField);
     Custom::deleteGroup($customGroup);
-    Contact::delete($contactID);
+    $this->contactDelete($contactID);
   }
 
   public function testCustomGroupMultipleUpdate() {
@@ -113,7 +113,7 @@ class CRM_Core_BAO_CustomValueTableMultipleTest extends CiviUnitTestCase {
 
     Custom::deleteField($customField);
     Custom::deleteGroup($customGroup);
-    Contact::delete($contactID);
+    $this->contactDelete($contactID);
   }
 
   public function testCustomGroupMultipleOldFormate() {
@@ -144,7 +144,7 @@ class CRM_Core_BAO_CustomValueTableMultipleTest extends CiviUnitTestCase {
 
     Custom::deleteField($customField);
     Custom::deleteGroup($customGroup);
-    Contact::delete($contactID);
+    $this->contactDelete($contactID);
   }
 
 }

--- a/tests/phpunit/CRM/Core/BAO/CustomValueTableSetGetTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomValueTableSetGetTest.php
@@ -106,7 +106,7 @@ class CRM_Core_BAO_CustomValueTableSetGetTest extends CiviUnitTestCase {
     // Cleanup
     Custom::deleteField($customField);
     Custom::deleteGroup($customGroup);
-    Contact::delete($contactID);
+    $this->contactDelete($contactID);
   }
 
   /**
@@ -192,7 +192,7 @@ class CRM_Core_BAO_CustomValueTableSetGetTest extends CiviUnitTestCase {
     // Cleanup
     Custom::deleteField($customField);
     Custom::deleteGroup($customGroup);
-    Contact::delete($contactID);
+    $this->contactDelete($contactID);
   }
 
 }

--- a/tests/phpunit/CRM/Core/BAO/CustomValueTableTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomValueTableTest.php
@@ -43,7 +43,7 @@ class CRM_Core_BAO_CustomValueTableTest extends CiviUnitTestCase {
 
     Custom::deleteField($customField);
     Custom::deleteGroup($customGroup);
-    Contact::delete($contactID);
+    $this->contactDelete($contactID);
   }
 
   /**
@@ -78,7 +78,7 @@ class CRM_Core_BAO_CustomValueTableTest extends CiviUnitTestCase {
 
     Custom::deleteField($customField);
     Custom::deleteGroup($customGroup);
-    Contact::delete($contactID);
+    $this->contactDelete($contactID);
   }
 
   /**
@@ -112,7 +112,7 @@ class CRM_Core_BAO_CustomValueTableTest extends CiviUnitTestCase {
 
     Custom::deleteField($customField);
     Custom::deleteGroup($customGroup);
-    Contact::delete($contactID);
+    $this->contactDelete($contactID);
   }
 
   /**
@@ -147,7 +147,7 @@ class CRM_Core_BAO_CustomValueTableTest extends CiviUnitTestCase {
 
     Custom::deleteField($customField);
     Custom::deleteGroup($customGroup);
-    Contact::delete($contactID);
+    $this->contactDelete($contactID);
   }
 
   /**
@@ -182,7 +182,7 @@ class CRM_Core_BAO_CustomValueTableTest extends CiviUnitTestCase {
 
     Custom::deleteField($customField);
     Custom::deleteGroup($customGroup);
-    Contact::delete($contactID);
+    $this->contactDelete($contactID);
   }
 
   /**
@@ -223,7 +223,7 @@ class CRM_Core_BAO_CustomValueTableTest extends CiviUnitTestCase {
     );
     Custom::deleteField($customField);
     Custom::deleteGroup($customGroup);
-    Contact::delete($contactID);
+    $this->contactDelete($contactID);
   }
 
   public function testCustomGroupMultiple() {
@@ -256,7 +256,7 @@ class CRM_Core_BAO_CustomValueTableTest extends CiviUnitTestCase {
 
     Custom::deleteField($customField);
     Custom::deleteGroup($customGroup);
-    Contact::delete($contactID);
+    $this->contactDelete($contactID);
   }
 
 }

--- a/tests/phpunit/CRM/Core/BAO/EmailTest.php
+++ b/tests/phpunit/CRM/Core/BAO/EmailTest.php
@@ -50,7 +50,7 @@ class CRM_Core_BAO_EmailTest extends CiviUnitTestCase {
     );
     $this->assertEquals($isBulkMail, 1, 'Verify bulkmail value is 1.');
 
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
   /**
@@ -59,7 +59,6 @@ class CRM_Core_BAO_EmailTest extends CiviUnitTestCase {
   public function testHoldEmail() {
     $contactId = Contact::createIndividual();
 
-    $params = array();
     $params = array(
       'email' => 'jane.doe@example.com',
       'is_primary' => 1,
@@ -123,7 +122,7 @@ class CRM_Core_BAO_EmailTest extends CiviUnitTestCase {
       'Compare reset_date (' . $resetDate . ') in DB to current year.'
     );
 
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
   /**
@@ -149,7 +148,7 @@ class CRM_Core_BAO_EmailTest extends CiviUnitTestCase {
     $this->assertEquals('alan.smith1@example.com', $firstEmailValue[0]['email'], 'Confirm primary email address value.');
     $this->assertEquals(1, $firstEmailValue[0]['is_primary'], 'Confirm first email address is primary.');
 
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
 }

--- a/tests/phpunit/CRM/Core/BAO/IMTest.php
+++ b/tests/phpunit/CRM/Core/BAO/IMTest.php
@@ -47,7 +47,7 @@ class CRM_Core_BAO_IMTest extends CiviUnitTestCase {
     $isEditIM = $this->assertDBNotNull('CRM_Core_DAO_IM', $imId, 'name', 'id', 'Database check on updated IM name record.');
     $this->assertEquals($isEditIM, 'doe.jane', 'Verify IM provider_id value is doe.jane.');
 
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
   /**
@@ -70,7 +70,7 @@ class CRM_Core_BAO_IMTest extends CiviUnitTestCase {
     $this->assertEquals('alan1.smith1', $firstIMValue[0]['name'], 'Confirm primary IM value.');
     $this->assertEquals(1, $firstIMValue[0]['is_primary'], 'Confirm first IM is primary.');
 
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
 }

--- a/tests/phpunit/CRM/Core/BAO/LocationTest.php
+++ b/tests/phpunit/CRM/Core/BAO/LocationTest.php
@@ -78,8 +78,7 @@ class CRM_Core_BAO_LocationTest extends CiviUnitTestCase {
       'Database check, Address created successfully.'
     );
 
-    //cleanup DB by deleting the contact
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
   /**
@@ -201,9 +200,7 @@ class CRM_Core_BAO_LocationTest extends CiviUnitTestCase {
 
     //delete the location block
     CRM_Core_BAO_Location::deleteLocBlock($locBlockId);
-
-    //cleanup DB by deleting the contact
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
   /**
@@ -354,7 +351,7 @@ class CRM_Core_BAO_LocationTest extends CiviUnitTestCase {
 
     //cleanup DB by deleting the record.
     Event::delete($eventId);
-    Contact::delete($this->_contactId);
+    $this->contactDelete($this->_contactId);
   }
 
   /**
@@ -442,7 +439,7 @@ class CRM_Core_BAO_LocationTest extends CiviUnitTestCase {
 
     //cleanup DB by deleting the record.
     Event::delete($eventId);
-    Contact::delete($this->_contactId);
+    $this->contactDelete($this->_contactId);
 
     //Now check DB for Event
     $this->assertDBNull('CRM_Event_DAO_Event', $eventId, 'id', 'id',
@@ -549,9 +546,7 @@ class CRM_Core_BAO_LocationTest extends CiviUnitTestCase {
     $this->assertAttributesEquals(CRM_Utils_Array::value('1', $params['im']),
       CRM_Utils_Array::value('1', $values['im'])
     );
-
-    //cleanup DB by deleting the contact
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
 }

--- a/tests/phpunit/CRM/Core/BAO/OpenIDTest.php
+++ b/tests/phpunit/CRM/Core/BAO/OpenIDTest.php
@@ -167,7 +167,6 @@ class CRM_Core_BAO_OpenIDTest extends CiviUnitTestCase {
     $this->assertEquals(0, $openIds[$openIdTwo]['is_primary'], 'Confirm is_primary field value for second openid.');
     $this->assertEquals(0, $openIds[$openIdTwo]['allowed_to_login'], 'Confirm allowed_to_login field value for second openid.');
 
-    //Contact::delete($contactId);
     $this->contactDelete($contactId);
     $this->assertDBRowNotExist('CRM_Contact_DAO_Contact', $contactId);
   }

--- a/tests/phpunit/CRM/Core/BAO/PhoneTest.php
+++ b/tests/phpunit/CRM/Core/BAO/PhoneTest.php
@@ -75,7 +75,7 @@ class CRM_Core_BAO_PhoneTest extends CiviUnitTestCase {
       "Check if phone field has expected value in updated record ( civicrm_phone.id={$phoneId} )."
     );
 
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
   /**
@@ -102,7 +102,7 @@ class CRM_Core_BAO_PhoneTest extends CiviUnitTestCase {
     $this->assertEquals('(415) 222-1011 x 221', $firstPhoneValue[0]['phone'], "Confirm primary Phone value ( {$firstPhoneValue[0]['phone']} ).");
     $this->assertEquals(1, $firstPhoneValue[0]['is_primary'], 'Confirm first Phone is primary.');
 
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
   /**

--- a/tests/phpunit/CRM/Dedupe/DedupeFinderTest.php
+++ b/tests/phpunit/CRM/Dedupe/DedupeFinderTest.php
@@ -113,9 +113,8 @@ class CRM_Dedupe_DedupeFinderTest extends CiviUnitTestCase {
     // so 1 pair for - first + last + mail
     $this->assertEquals(count($foundDupes), 1, 'Check Individual-Fuzzy dupe rule for dupesInGroup().');
 
-    // delete all created contacts
     foreach ($contactIds as $contactId) {
-      Contact::delete($contactId);
+      $this->contactDelete($contactId);
     }
     // delete dupe group
     $params = array('id' => $groupId, 'version' => 3);
@@ -220,7 +219,7 @@ class CRM_Dedupe_DedupeFinderTest extends CiviUnitTestCase {
 
     // delete all created contacts
     foreach ($contactIds as $contactId) {
-      Contact::delete($contactId);
+      $this->contactDelete($contactId);
     }
   }
 

--- a/tests/phpunit/CRM/Dedupe/MergerTest.php
+++ b/tests/phpunit/CRM/Dedupe/MergerTest.php
@@ -109,10 +109,12 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
     }
   }
 
+  /**
+   * Delete all created contacts.
+   */
   public function deleteDupeContacts() {
-    // delete all created contacts
     foreach ($this->_contactIds as $contactId) {
-      Contact::delete($contactId);
+      $this->contactDelete($contactId);
     }
 
     // delete dupe group

--- a/tests/phpunit/CRM/Event/BAO/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/BAO/ParticipantTest.php
@@ -80,7 +80,7 @@ class CRM_Event_BAO_ParticipantTest extends CiviUnitTestCase {
       'id', 3, 'Check DB for updated status id  of the participant'
     );
 
-    Contact::delete($this->_contactId);
+    $this->contactDelete($this->_contactId);
     Event::delete($this->_eventId);
   }
 
@@ -125,7 +125,7 @@ class CRM_Event_BAO_ParticipantTest extends CiviUnitTestCase {
     }
 
     Participant::delete($participantId);
-    Contact::delete($this->_contactId);
+    $this->contactDelete($this->_contactId);
     Event::delete($this->_eventId);
   }
 
@@ -134,11 +134,11 @@ class CRM_Event_BAO_ParticipantTest extends CiviUnitTestCase {
    */
   public function testgetValuesWithoutValidParams() {
     $params = $values = $ids = array();
-    $participantId = Participant::create($this->_contactId, $this->_eventId);
+    Participant::create($this->_contactId, $this->_eventId);
     $fetchParticipant = CRM_Event_BAO_Participant::getValues($params, $values, $ids);
     $this->assertNull($fetchParticipant);
 
-    Contact::delete($this->_contactId);
+    $this->contactDelete($this->_contactId);
     Event::delete($this->_eventId);
   }
 
@@ -158,7 +158,7 @@ class CRM_Event_BAO_ParticipantTest extends CiviUnitTestCase {
     $this->assertEquals($eventFull, 'This event is full.', 'Checking if Event is full.');
 
     Participant::delete($participantId);
-    Contact::delete($this->_contactId);
+    $this->contactDelete($this->_contactId);
     Event::delete($this->_eventId);
   }
 
@@ -169,7 +169,7 @@ class CRM_Event_BAO_ParticipantTest extends CiviUnitTestCase {
     $importableFields = CRM_Event_BAO_Participant::importableFields();
     $this->assertNotEquals(count($importableFields), 0, 'Checking array not to be empty.');
 
-    Contact::delete($this->_contactId);
+    $this->contactDelete($this->_contactId);
     Event::delete($this->_eventId);
   }
 
@@ -187,7 +187,7 @@ class CRM_Event_BAO_ParticipantTest extends CiviUnitTestCase {
     $this->assertEquals($participantDetails['title'], $params['title'], 'Checking Event Title in which participant is enroled.');
 
     Participant::delete($participantId);
-    Contact::delete($this->_contactId);
+    $this->contactDelete($this->_contactId);
     Event::delete($this->_eventId);
   }
 
@@ -218,10 +218,10 @@ class CRM_Event_BAO_ParticipantTest extends CiviUnitTestCase {
       'id', $this->_contactId, 'Check DB for contact of the participant'
     );
 
-    $deleteParticipant = CRM_Event_BAO_Participant::deleteParticipant($participant->id);
+    CRM_Event_BAO_Participant::deleteParticipant($participant->id);
     $this->assertDBNull('CRM_Event_BAO_Participant', $participant->id, 'contact_id', 'id', 'Check DB for deleted Participant.');
 
-    Contact::delete($this->_contactId);
+    $this->contactDelete($this->_contactId);
     Event::delete($this->_eventId);
   }
 
@@ -251,7 +251,7 @@ class CRM_Event_BAO_ParticipantTest extends CiviUnitTestCase {
       $partidel[] = Participant::delete($partiId[$i]);
     }
 
-    Contact::delete($this->_contactId);
+    $this->contactDelete($this->_contactId);
     Event::delete($this->_eventId);
   }
 
@@ -320,7 +320,7 @@ class CRM_Event_BAO_ParticipantTest extends CiviUnitTestCase {
       'contact_id', 'Check DB for deleted participant. Should be NULL.'
     );
 
-    Contact::delete($this->_contactId);
+    $this->contactDelete($this->_contactId);
     Event::delete($this->_eventId);
   }
 
@@ -331,7 +331,7 @@ class CRM_Event_BAO_ParticipantTest extends CiviUnitTestCase {
     $exportableFields = CRM_Event_BAO_Participant::exportableFields();
     $this->assertNotEquals(count($exportableFields), 0, 'Checking array not to be empty.');
 
-    Contact::delete($this->_contactId);
+    $this->contactDelete($this->_contactId);
     Event::delete($this->_eventId);
   }
 
@@ -411,18 +411,18 @@ class CRM_Event_BAO_ParticipantTest extends CiviUnitTestCase {
       CRM_Event_BAO_Participant::fixEventLevel($values[$participant->id]['fee_level']);
     }
 
-    $deletePricefield = CRM_Price_BAO_PriceField::deleteField($pricefield->id);
+    CRM_Price_BAO_PriceField::deleteField($pricefield->id);
     $this->assertDBNull('CRM_Price_BAO_PriceField', $pricefield->id, 'name',
       'id', 'Check DB for non-existence of Price Field.'
     );
 
-    $deletePriceset = CRM_Price_BAO_PriceSet::deleteSet($priceset->id);
+    CRM_Price_BAO_PriceSet::deleteSet($priceset->id);
     $this->assertDBNull('CRM_Price_BAO_PriceSet', $priceset->id, 'title',
       'id', 'Check DB for non-existence of Price Set.'
     );
 
     Participant::delete($participant->id);
-    Contact::delete($this->_contactId);
+    $this->contactDelete($this->_contactId);
     Event::delete($eventId);
   }
 

--- a/tests/phpunit/CRM/Member/BAO/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipTest.php
@@ -63,7 +63,7 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
   public function tearDown() {
     $this->membershipTypeDelete(array('id' => $this->_membershipTypeID));
     $this->membershipStatusDelete($this->_membershipStatusID);
-    Contact::delete($this->_contactID);
+    $this->contactDelete($this->_contactID);
 
     $this->_contactID = $this->_membershipStatusID = $this->_membershipTypeID = NULL;
   }
@@ -114,7 +114,7 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
     $this->assertEquals($membershipTypeId, $this->_membershipTypeID, 'Verify membership type id is fetched.');
 
     $this->membershipDelete($membershipId);
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
   public function testGetValues() {
@@ -172,7 +172,7 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
 
     $this->membershipDelete($membershipId1);
     $this->membershipDelete($membershipId2);
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
   public function testRetrieve() {
@@ -260,7 +260,7 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
 
     $this->membershipDelete($membershipId1);
     $this->membershipDelete($membershipId2);
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
   public function testDeleteMembership() {
@@ -284,10 +284,10 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
     );
     CRM_Member_BAO_Membership::del($membershipId);
 
-    $membershipId = $this->assertDBNull('CRM_Member_BAO_Membership', $contactId, 'id',
+    $this->assertDBNull('CRM_Member_BAO_Membership', $contactId, 'id',
       'contact_id', 'Database check for deleted membership.'
     );
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
   public function testGetContactMembership() {
@@ -315,7 +315,7 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
     $this->assertEquals($membership['id'], $membershipId, 'Verify membership record is retrieved.');
 
     $this->membershipDelete($membershipId);
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
 
@@ -345,7 +345,7 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
     $membership[$membershipId]['renewPageId'] = CRM_Member_BAO_Membership::getContributionPageId($membershipId);
 
     $this->membershipDelete($membershipId);
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
   /**
@@ -377,7 +377,7 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
     CRM_Member_BAO_Membership::getMembershipStarts($this->_membershipTypeID, $yearStart, $currentDate);
 
     $this->membershipDelete($membershipId);
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
   /**
@@ -408,7 +408,7 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
     CRM_Member_BAO_Membership::getMembershipCount($this->_membershipTypeID, $currentDate, $test);
 
     $this->membershipDelete($membershipId);
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
 
@@ -444,7 +444,7 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
     );
 
     $this->membershipDelete($membershipId);
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
   /**
@@ -474,7 +474,7 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
     CRM_Member_BAO_Membership::deleteRelatedMemberships($membershipId);
 
     $this->membershipDelete($membershipId);
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
   /**
@@ -540,7 +540,7 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
     $this->assertEquals($endDate, $MembershipRenew->end_date, 'Verify correct end date is calculated after membership renewal');
 
     $this->membershipDelete($membershipId);
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
   /**
@@ -624,7 +624,7 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
     );
 
     $this->membershipDelete($membershipId);
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
 }

--- a/tests/phpunit/CiviTest/Contact.php
+++ b/tests/phpunit/CiviTest/Contact.php
@@ -86,17 +86,4 @@ class Contact extends CiviUnitTestCase {
     return $organization->id;
   }
 
-  /**
-   * Helper function to delete a contact.
-   *
-   * @param int $contactID
-   *   Id of the contact to delete.
-   * @return bool
-   *   true if contact deleted, false otherwise
-   */
-  public static function delete($contactID) {
-    require_once 'CRM/Contact/BAO/Contact.php';
-    return CRM_Contact_BAO_Contact::deleteContact($contactID);
-  }
-
 }


### PR DESCRIPTION
There are 2 different methods in play for deleting contacts in tests. The one I'm removing uses a non-standard path & sometimes
causes loading issues when run in isolation, as well as being the less used.

Other functions could do with the same treatment.

Some unused vars removed too
