### PR TITLE
CRM-17984 getTree regression

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -658,7 +658,7 @@ ORDER BY civicrm_custom_group.weight,
       throw new CRM_Core_Exception('Invalid Entity Filter');
     }
     $subTypes = civicrm_api3('Contact', 'getoptions', array('field' => 'contact_sub_type'));
-    if (!in_array($subType, $subTypes['values'])) {
+    if (!isset($subTypes['values'][$subType])) {
       // Same comments about fail hard as above.
       throw new CRM_Core_Exception('Invalid Filter');
     }

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -363,7 +363,12 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup {
         $subTypes = array();
       }
       else {
-        $subTypes = explode(',', $subTypes);
+        if (stristr(',', $subTypes)) {
+          $subTypes = explode(',', $subTypes);
+        }
+        else {
+          $subTypes = explode(CRM_Core_DAO::VALUE_SEPARATOR, trim($subTypes, CRM_Core_DAO::VALUE_SEPARATOR));
+        }
       }
     }
 

--- a/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
@@ -74,6 +74,25 @@ class CRM_Core_BAO_CustomGroupTest extends CiviUnitTestCase {
 
   /**
    * Test calling getTree with contact subtype data.
+   *
+   * Note that the function seems to support a range of formats so 3 are tested. Yay for
+   * inconsistency.
+   */
+  public function testGetTreeCampaignSubType() {
+    $this->campaignCreate();
+    $this->campaignCreate();
+    $customGroup = $this->CustomGroupCreate(array(
+      'extends' => 'Campaign',
+      'extends_entity_column_value' => '12'
+    ));
+    $customField = $this->customFieldCreate(array('custom_group_id' => $customGroup['id']));
+    $result1 = CRM_Core_BAO_CustomGroup::getTree('Campaign', NULL, NULL, NULL, '12');
+    $this->assertEquals('Custom Field', $result1[$customGroup['id']]['fields'][$customField['id']]['label']);
+    $this->customGroupDelete($customGroup['id']);
+  }
+
+  /**
+   * Test calling getTree with contact subtype data.
    */
   public function testGetTreeActivitySubType() {
     $customGroup = $this->CustomGroupCreate(array('extends' => 'Activity', 'extends_entity_column_value' => 1));
@@ -84,7 +103,7 @@ class CRM_Core_BAO_CustomGroupTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test retrieve() with Empty Params
+   * Test retrieve() with Empty Params.
    */
   public function testRetrieveEmptyParams() {
     $params = array();

--- a/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
@@ -79,11 +79,12 @@ class CRM_Core_BAO_CustomGroupTest extends CiviUnitTestCase {
    * inconsistency.
    */
   public function testGetTreeCampaignSubType() {
+    $sep = CRM_Core_DAO::VALUE_SEPARATOR;
     $this->campaignCreate();
     $this->campaignCreate();
     $customGroup = $this->CustomGroupCreate(array(
       'extends' => 'Campaign',
-      'extends_entity_column_value' => '12'
+      'extends_entity_column_value' => "{$sep}1{$sep}2{$sep}",
     ));
     $customField = $this->customFieldCreate(array('custom_group_id' => $customGroup['id']));
     $result1 = CRM_Core_BAO_CustomGroup::getTree('Campaign', NULL, NULL, NULL, '12');

--- a/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
@@ -53,14 +53,14 @@ class CRM_Core_BAO_CustomGroupTest extends CiviUnitTestCase {
    * inconsistency.
    */
   public function testGetTreeContactSubType() {
-    $this->callAPISuccess('ContactType', 'create', array('name' => 'Big Bank', 'parent_id' => 'Organization'));
-    $customGroup = $this->CustomGroupCreate(array('extends' => 'Organization', 'extends_entity_column_value' => array('Big Bank')));
+    $this->callAPISuccess('ContactType', 'create', array('name' => 'Big Bank', 'label' => 'biggee', 'parent_id' => 'Organization'));
+    $customGroup = $this->CustomGroupCreate(array('extends' => 'Organization', 'extends_entity_column_value' => array('Big_Bank')));
     $customField = $this->customFieldCreate(array('custom_group_id' => $customGroup['id']));
-    $result1 = CRM_Core_BAO_CustomGroup::getTree('Organization', NULL, NULL, NULL, array('Big Bank'));
+    $result1 = CRM_Core_BAO_CustomGroup::getTree('Organization', NULL, NULL, NULL, array('Big_Bank'));
     $this->assertEquals('Custom Field', $result1[$customGroup['id']]['fields'][$customField['id']]['label']);
-    $result = CRM_Core_BAO_CustomGroup::getTree('Organization', NULL, NULL, NULL, CRM_Core_DAO::VALUE_SEPARATOR . 'Big Bank' . CRM_Core_DAO::VALUE_SEPARATOR);
+    $result = CRM_Core_BAO_CustomGroup::getTree('Organization', NULL, NULL, NULL, CRM_Core_DAO::VALUE_SEPARATOR . 'Big_Bank' . CRM_Core_DAO::VALUE_SEPARATOR);
     $this->assertEquals($result1, $result);
-    $result = CRM_Core_BAO_CustomGroup::getTree('Organization', NULL, NULL, NULL, 'Big Bank');
+    $result = CRM_Core_BAO_CustomGroup::getTree('Organization', NULL, NULL, NULL, 'Big_Bank');
     $this->assertEquals($result1, $result);
     try {
       CRM_Core_BAO_CustomGroup::getTree('Organization', NULL, NULL, NULL, array('Small Kind Bank'));


### PR DESCRIPTION
Value separating was not being unpackaged correctly & labels were being looked at rather than names for contact_type

---
- [CRM-17984](https://issues.civicrm.org/jira/browse/CRM-17984)
