### PR TITLE
CRM-16734 participant tokens in participant pdf

### DIFF
--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -531,6 +531,8 @@ class CRM_Core_SelectValues {
       '{event.end_date}' => ts('Event End Date'),
       '{event.event_type}' => ts('Event Type'),
       '{event.summary}' => ts('Event Summary'),
+      // These are location_email and location_contact
+      // Should be cleaned up after ActionSchedule token replacement cleanup.
       '{event.contact_email}' => ts('Event Contact Email'),
       '{event.contact_phone}' => ts('Event Contact Phone'),
       '{event.description}' => ts('Event Description'),

--- a/CRM/Event/Form/Task.php
+++ b/CRM/Event/Form/Task.php
@@ -65,7 +65,7 @@ class CRM_Event_Form_Task extends CRM_Core_Form {
    *
    * @var array
    */
-  protected $_participantIds;
+  public $_participantIds;
 
   /**
    * Build all the data structures needed to build the form.

--- a/CRM/Event/Form/Task/PDF.php
+++ b/CRM/Event/Form/Task/PDF.php
@@ -102,6 +102,11 @@ class CRM_Event_Form_Task_PDF extends CRM_Event_Form_Task {
     // Should be cleaned up after ActionSchedule token replacement cleanup.
     unset($tokens['{event.contact_email}']);
     unset($tokens['{event.contact_phone}']);
+    $customEventTokens = CRM_CORE_BAO_CustomField::getFields('Event');
+
+    foreach ($customEventTokens as $customEventTokenKey => $customEventTokenValue) {
+      $tokens["{event.custom_customEventTokenKey}"] = $customEventTokenValue['label'] . '::' . $customEventTokenValue['groupTitle'];
+    }
     return $tokens;
   }
 

--- a/CRM/Event/Form/Task/PDF.php
+++ b/CRM/Event/Form/Task/PDF.php
@@ -60,19 +60,16 @@ class CRM_Event_Form_Task_PDF extends CRM_Event_Form_Task {
    * Build all the data structures needed to build the form.
    */
   public function preProcess() {
-    CRM_Contact_Form_Task_PDFLetterCommon::preProcess($this);
     parent::preProcess();
-
-    // we have all the participant ids, so now we get the contact ids
-    parent::setContactIDs();
-
-    $this->assign('single', $this->_single);
+    CRM_Contact_Form_Task_PDFLetterCommon::preProcess($this);
   }
 
   /**
    * Build the form object.
    */
   public function buildQuickForm() {
+    // We have all the participant ids, so now we get the contact ids.
+    $this->setContactIDs();
     CRM_Contact_Form_Task_PDFLetterCommon::buildQuickForm($this);
   }
 
@@ -80,7 +77,7 @@ class CRM_Event_Form_Task_PDF extends CRM_Event_Form_Task {
    * Process the form after the input has been submitted and validated.
    */
   public function postProcess() {
-    CRM_Contact_Form_Task_PDFLetterCommon::postProcess($this);
+    CRM_Event_Form_Task_PDFLetterCommon::postProcess($this);
   }
 
   /**
@@ -99,6 +96,12 @@ class CRM_Event_Form_Task_PDF extends CRM_Event_Form_Task {
    */
   public function listTokens() {
     $tokens = CRM_Core_SelectValues::contactTokens();
+    $tokens = array_merge(CRM_Core_SelectValues::eventTokens(), $tokens);
+    // unset contact_email and contact_phone tokens.
+    // These are location_email and location_contact
+    // Should be cleaned up after ActionSchedule token replacement cleanup.
+    unset($tokens['{event.contact_email}']);
+    unset($tokens['{event.contact_phone}']);
     return $tokens;
   }
 

--- a/CRM/Event/Form/Task/PDF.php
+++ b/CRM/Event/Form/Task/PDF.php
@@ -107,6 +107,10 @@ class CRM_Event_Form_Task_PDF extends CRM_Event_Form_Task {
     foreach ($customEventTokens as $customEventTokenKey => $customEventTokenValue) {
       $tokens["{event.custom_$customEventTokenKey}"] = $customEventTokenValue['label'] . '::' . $customEventTokenValue['groupTitle'];
     }
+    $tokens = array_merge(CRM_Core_SelectValues::participantTokens(), $tokens);
+    unset($tokens['{participant.template_title}']);
+    unset($tokens['{participant.fee_label}']);
+    unset($tokens['{participant.default_role_id}']);
     return $tokens;
   }
 

--- a/CRM/Event/Form/Task/PDF.php
+++ b/CRM/Event/Form/Task/PDF.php
@@ -105,7 +105,7 @@ class CRM_Event_Form_Task_PDF extends CRM_Event_Form_Task {
     $customEventTokens = CRM_CORE_BAO_CustomField::getFields('Event');
 
     foreach ($customEventTokens as $customEventTokenKey => $customEventTokenValue) {
-      $tokens["{event.custom_customEventTokenKey}"] = $customEventTokenValue['label'] . '::' . $customEventTokenValue['groupTitle'];
+      $tokens["{event.custom_$customEventTokenKey}"] = $customEventTokenValue['label'] . '::' . $customEventTokenValue['groupTitle'];
     }
     return $tokens;
   }

--- a/CRM/Event/Form/Task/PDFLetterCommon.php
+++ b/CRM/Event/Form/Task/PDFLetterCommon.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+  +--------------------------------------------------------------------+
+  | CiviCRM version 4.6                                                |
+  +--------------------------------------------------------------------+
+  | Copyright CiviCRM LLC (c) 2004-2015                                |
+  +--------------------------------------------------------------------+
+  | This file is a part of CiviCRM.                                    |
+  |                                                                    |
+  | CiviCRM is free software; you can copy, modify, and distribute it  |
+  | under the terms of the GNU Affero General Public License           |
+  | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+  |                                                                    |
+  | CiviCRM is distributed in the hope that it will be useful, but     |
+  | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+  | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+  | See the GNU Affero General Public License for more details.        |
+  |                                                                    |
+  | You should have received a copy of the GNU Affero General Public   |
+  | License and the CiviCRM Licensing Exception along                  |
+  | with this program; if not, contact CiviCRM LLC                     |
+  | at info[AT]civicrm[DOT]org. If you have questions about the        |
+  | GNU Affero General Public License or the licensing of CiviCRM,     |
+  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+  +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2015
+ * $Id$
+ *
+ */
+
+/**
+ * This class provides the common functionality for creating PDF letter for
+ * one or a group of participant ids.
+ */
+class CRM_Event_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDFLetterCommon {
+  /**
+   * process the form after the input has been submitted and validated
+   * @todo this is horrible copy & paste code because there is so much risk of breakage
+   * in fixing the existing pdfLetter classes to be suitably generic
+   * @access public
+   *
+   * @return None
+   */
+  static function postProcess(&$form) {
+
+    list($formValues, $categories, $html_message, $messageToken, $returnProperties) = self::processMessageTemplate($form);
+
+    $skipOnHold = isset($form->skipOnHold) ? $form->skipOnHold : FALSE;
+    $skipDeceased = isset($form->skipDeceased) ? $form->skipDeceased : TRUE;
+
+    foreach ($form->_participantIds as $participantID) {
+
+      $participant = civicrm_api3('participant', 'get', array('participant_id' => $participantID))['values'][$participantID];
+      $event = civicrm_api3('event', 'get', array('id' => $eventid))['values'][$participant['event_id']];
+
+      // get contact information
+
+      $params = array('contact_id' => $participant['contact_id']);
+      list($contact) = CRM_Utils_Token::getTokenDetails($params, $returnProperties, $skipOnHold, $skipDeceased, NULL, $messageToken, 'CRM_Contact_Form_Task_PDFLetterCommon'
+      );
+
+      if (civicrm_error($contact)) {
+        $notSent[] = $contactId;
+        continue;
+      }
+
+      $tokenHtml = CRM_Utils_Token::replaceContactTokens($html_message, $contact[$contactId], TRUE, $messageToken);
+      $tokenHtml = CRM_Utils_Token::replaceEntityTokens('event', $event, $tokenHtml, $messageToken);
+      $tokenHtml = CRM_Utils_Token::replaceHookTokens($tokenHtml, $contact[$contactId], $categories, TRUE);
+
+      if (defined('CIVICRM_MAIL_SMARTY') && CIVICRM_MAIL_SMARTY) {
+        $smarty = CRM_Core_Smarty::singleton();
+        // also add the contact tokens to the template
+        $smarty->assign_by_ref('contact', $contact);
+        $smarty->assign_by_ref('event', $event);
+        $tokenHtml = $smarty->fetch("string:$tokenHtml");
+      }
+
+      $html[] = $tokenHtml;
+    }
+
+    self::createActivities($form, $html_message, $form->_contactIds);
+
+    CRM_Utils_PDF_Utils::html2pdf($html, "CiviLetter.pdf", FALSE, $formValues);
+
+    $form->postProcessHook();
+
+    CRM_Utils_System::civiExit(1);
+  }
+
+ 
+}

--- a/CRM/Event/Form/Task/PDFLetterCommon.php
+++ b/CRM/Event/Form/Task/PDFLetterCommon.php
@@ -52,7 +52,8 @@ class CRM_Event_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDFLette
 
     foreach ($form->_participantIds as $participantID) {
 
-      $participant = civicrm_api3('participant', 'get', array('participant_id' => $participantID))['values'][$participantID];
+      $participant = civicrm_api3('participant', 'get', array('participant_id' => $participantID));
+      $participant = $participant['values'][$participantID];
       $event = civicrm_api3('event', 'get', array('id' => $eventid))['values'][$participant['event_id']];
 
       // get contact information

--- a/CRM/Event/Form/Task/PDFLetterCommon.php
+++ b/CRM/Event/Form/Task/PDFLetterCommon.php
@@ -54,7 +54,8 @@ class CRM_Event_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDFLette
 
       $participant = civicrm_api3('participant', 'get', array('participant_id' => $participantID));
       $participant = $participant['values'][$participantID];
-      $event = civicrm_api3('event', 'get', array('id' => $eventid))['values'][$participant['event_id']];
+      $event = civicrm_api3('event', 'get', array('id' => $eventid));
+      $event = $event['values'][$participant['event_id']];
 
       // get contact information
 

--- a/CRM/Event/Form/Task/PDFLetterCommon.php
+++ b/CRM/Event/Form/Task/PDFLetterCommon.php
@@ -40,14 +40,10 @@
  */
 class CRM_Event_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDFLetterCommon {
   /**
-   * process the form after the input has been submitted and validated
-   * @todo this is horrible copy & paste code because there is so much risk of breakage
-   * in fixing the existing pdfLetter classes to be suitably generic
+   * Process the form after the input has been submitted and validated.
    * @access public
-   *
-   * @return None
    */
-  static function postProcess(&$form) {
+  public static function postProcess(&$form) {
 
     list($formValues, $categories, $html_message, $messageToken, $returnProperties) = self::processMessageTemplate($form);
 
@@ -94,5 +90,4 @@ class CRM_Event_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDFLette
     CRM_Utils_System::civiExit(1);
   }
 
- 
 }

--- a/CRM/Event/Form/Task/PDFLetterCommon.php
+++ b/CRM/Event/Form/Task/PDFLetterCommon.php
@@ -64,23 +64,17 @@ class CRM_Event_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDFLette
       // https://issues.civicrm.org/jira/browse/CRM-16599?focusedCommentId=77663&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-77663
       $contactId = $participant['contact_id'];
       $params = array('contact_id' => $contactId);
-      list($contact) = CRM_Utils_Token::getTokenDetails($params, $returnProperties, $skipOnHold, $skipDeceased, NULL, $messageToken, 'CRM_Contact_Form_Task_PDFLetterCommon'
-      );
-
-      if (civicrm_error($contact)) {
-        $notSent[] = $contactId;
-        continue;
-      }
-
-      $tokenHtml = CRM_Utils_Token::replaceContactTokens($html_message, $contact[$contactId], TRUE, $messageToken);
+      $tokenHtml = CRM_Utils_Token::replaceContactTokens($html_message, $contact, TRUE, $messageToken);
       $tokenHtml = CRM_Utils_Token::replaceEntityTokens('event', $event, $tokenHtml, $messageToken);
-      $tokenHtml = CRM_Utils_Token::replaceHookTokens($tokenHtml, $contact[$contactId], $categories, TRUE);
+      $tokenHtml = CRM_Utils_Token::replaceEntityTokens('participant', $participant, $tokenHtml, $messageToken);
+      $tokenHtml = CRM_Utils_Token::replaceHookTokens($tokenHtml, $contact, $categories, TRUE);
 
       if (defined('CIVICRM_MAIL_SMARTY') && CIVICRM_MAIL_SMARTY) {
         $smarty = CRM_Core_Smarty::singleton();
         // also add the contact tokens to the template
         $smarty->assign_by_ref('contact', $contact);
         $smarty->assign_by_ref('event', $event);
+        $smarty->assign_by_ref('participant', $participant);
         $tokenHtml = $smarty->fetch("string:$tokenHtml");
       }
 

--- a/CRM/Event/Form/Task/PDFLetterCommon.php
+++ b/CRM/Event/Form/Task/PDFLetterCommon.php
@@ -54,7 +54,7 @@ class CRM_Event_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDFLette
 
       $participant = civicrm_api3('participant', 'get', array('participant_id' => $participantID));
       $participant = $participant['values'][$participantID];
-      $event = civicrm_api3('event', 'get', array('id' => $eventid));
+      $event = civicrm_api3('event', 'get', array('id' => $participant['event_id']));
       $event = $event['values'][$participant['event_id']];
 
       // get contact information

--- a/CRM/Event/Form/Task/PDFLetterCommon.php
+++ b/CRM/Event/Form/Task/PDFLetterCommon.php
@@ -64,7 +64,7 @@ class CRM_Event_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDFLette
       );
 
       if (civicrm_error($contact)) {
-        $notSent[] = $contactId;
+        $notSent[] = $participant['contact_id'];
         continue;
       }
 

--- a/CRM/Event/Form/Task/PDFLetterCommon.php
+++ b/CRM/Event/Form/Task/PDFLetterCommon.php
@@ -59,12 +59,16 @@ class CRM_Event_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDFLette
 
       // get contact information
 
-      $params = array('contact_id' => $participant['contact_id']);
+      // Create variable $contactId which is used below as well.
+      // $contactID not existing caused the error mentioned in
+      // https://issues.civicrm.org/jira/browse/CRM-16599?focusedCommentId=77663&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-77663
+      $contactId = $participant['contact_id'];
+      $params = array('contact_id' => $contactId);
       list($contact) = CRM_Utils_Token::getTokenDetails($params, $returnProperties, $skipOnHold, $skipDeceased, NULL, $messageToken, 'CRM_Contact_Form_Task_PDFLetterCommon'
       );
 
       if (civicrm_error($contact)) {
-        $notSent[] = $participant['contact_id'];
+        $notSent[] = $contactId;
         continue;
       }
 

--- a/CRM/Event/Form/Task/PDFLetterCommon.php
+++ b/CRM/Event/Form/Task/PDFLetterCommon.php
@@ -70,11 +70,6 @@ class CRM_Event_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDFLette
         'CRM_Contact_Form_Task_PDFLetterCommon'
       );
 
-      // Create variable $contactId which is used below as well.
-      // $contactID not existing caused the error mentioned in
-      // https://issues.civicrm.org/jira/browse/CRM-16599?focusedCommentId=77663&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-77663
-      $contactId = $participant['contact_id'];
-      $params = array('contact_id' => $contactId);
       $tokenHtml = CRM_Utils_Token::replaceContactTokens($html_message, $contact[$contactId], TRUE, $messageToken);
       $tokenHtml = CRM_Utils_Token::replaceEntityTokens('event', $event, $tokenHtml, $messageToken);
       $tokenHtml = CRM_Utils_Token::replaceEntityTokens('participant', $participant, $tokenHtml, $messageToken);

--- a/CRM/Event/Form/Task/PDFLetterCommon.php
+++ b/CRM/Event/Form/Task/PDFLetterCommon.php
@@ -58,16 +58,27 @@ class CRM_Event_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDFLette
       $event = $event['values'][$participant['event_id']];
 
       // get contact information
+      // Use 'getTokenDetails' so that hook_civicrm_tokenValues is called.
+      $contactId = $participant['contact_id'];
+      $params = array('id' => $contactId);
+      list($contact) = CRM_Utils_Token::getTokenDetails($params,
+        $returnProperties,
+        $skipOnHold,
+        $skipDeceased,
+        NULL,
+        $messageToken,
+        'CRM_Contact_Form_Task_PDFLetterCommon'
+      );
 
       // Create variable $contactId which is used below as well.
       // $contactID not existing caused the error mentioned in
       // https://issues.civicrm.org/jira/browse/CRM-16599?focusedCommentId=77663&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-77663
       $contactId = $participant['contact_id'];
       $params = array('contact_id' => $contactId);
-      $tokenHtml = CRM_Utils_Token::replaceContactTokens($html_message, $contact, TRUE, $messageToken);
+      $tokenHtml = CRM_Utils_Token::replaceContactTokens($html_message, $contact[$contactId], TRUE, $messageToken);
       $tokenHtml = CRM_Utils_Token::replaceEntityTokens('event', $event, $tokenHtml, $messageToken);
       $tokenHtml = CRM_Utils_Token::replaceEntityTokens('participant', $participant, $tokenHtml, $messageToken);
-      $tokenHtml = CRM_Utils_Token::replaceHookTokens($tokenHtml, $contact, $categories, TRUE);
+      $tokenHtml = CRM_Utils_Token::replaceHookTokens($tokenHtml, $contact[$contactId], $categories, TRUE);
 
       if (defined('CIVICRM_MAIL_SMARTY') && CIVICRM_MAIL_SMARTY) {
         $smarty = CRM_Core_Smarty::singleton();

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -858,7 +858,6 @@ class CRM_Utils_Token {
     if ($escapeSmarty) {
       $value = self::tokenEscapeSmarty($value);
     }
-
     return $value;
   }
 
@@ -1606,6 +1605,25 @@ class CRM_Utils_Token {
   }
 
   /**
+   * store event tokens on the static _tokens array
+   */
+  protected static function _buildEventTokens() {
+    $key = 'event';
+    if (!isset(self::$_tokens[$key]) || self::$_tokens[$key] == NULL) {
+      $eventTokens = array();
+      $tokens = CRM_Core_SelectValues::eventTokens();
+      foreach ($tokens as $token => $dontCare) {
+        $eventTokens[] = substr($token, (strpos($token, '.') + 1), -1);
+      }
+      $customtokens = CRM_CORE_BAO_CustomField::getFields('Event');
+      foreach ($customtokens as $tokenkey => $tokenvalue) {
+        $eventTokens[] = 'custom_' . $tokenkey;
+      }
+      self::$_tokens[$key] = $eventTokens;
+    }
+  }
+
+  /**
    * Replace tokens for an entity.
    * @param string $entity
    * @param array $entityArray
@@ -1756,6 +1774,93 @@ class CRM_Utils_Token {
       unset($knownTokens['contribution']['receive_date']);
     }
     return self::replaceContributionTokens($str, $contribution, $html, $knownTokens, $escapeSmarty);
+  }
+
+  /**
+   * Get replacement strings for any event tokens
+   * @param string $token
+   * @param array $event an api result array for a single event
+   * @param bool $escapeSmarty
+   * @return string token replacement
+   */
+  public static function getEventTokenReplacement($token, $event, $escapeSmarty = FALSE) {
+    $entity = 'event';
+    self::_buildEventTokens();
+
+    $params = array('entity_id' => $event['id'], 'entity_table' => 'civicrm_event');
+
+    switch ($token) {
+      case 'balance':
+        $info = CRM_Contribute_BAO_Contribution::getPaymentInfo($params['entity_id'], 'event');
+        $balancePay = CRM_Utils_Array::value('balance', $info);
+        $balancePay = CRM_Utils_Money::format($balancePay);
+        $value = $balancePay;
+        break;
+
+      case 'title':
+        $value = $event['event_title'];
+        break;
+
+      case 'end_date':
+      case 'start_date':
+        $value = CRM_Utils_Date::customFormat($event[$token], "%d/%m/%Y");
+        break;
+
+      case 'type':
+        $params = array(
+          'option_group_id' => 14,
+          'value' => $event['event_type_id'],
+          'return' => 'label',
+        );
+        $value = civicrm_api3('OptionValue', 'getvalue', $params);
+        break;
+
+      case 'location':
+        $location = CRM_Core_BAO_Location::getValues($params, TRUE);
+        foreach ($location['address'] as $address) {
+          $value = $address['display_text'];
+        }
+        break;
+
+      case 'info_url':
+        $value = CIVICRM_UF_BASEURL . 'civicrm/event/info?reset=1&id=' . $event['id'];
+        break;
+
+      case 'registration_url':
+        $value = CIVICRM_UF_BASEURL . 'civicrm/event/register?reset=1&id=' . $event['id'];
+        break;
+
+      case 'fee_amount':
+        $priceSetId = CRM_Price_BAO_PriceSet::getFor('civicrm_event', $event['id']);
+        $result = civicrm_api3('PriceFieldValue', 'get', array('price_field_id' => $priceSetId));
+        $value = '';
+        foreach ($result['values'] as $pricefield) {
+          $value .= $pricefield['label'] . ": " . CRM_Utils_Money::format($pricefield['amount']) . "<br>";
+        }
+        break;
+
+      case 'event_id':
+        $value = $event['id'];
+        break;
+
+      case 'event_type':
+        $value = CRM_Utils_Array::value($event['event_type_id'], CRM_Event_PseudoConstant::eventType());
+        break;
+
+      default:
+        if (in_array($token, self::$_tokens[$entity])) {
+          $value = $event[$token];
+        }
+        else {
+          $value = "{$entity}.{$token}";
+        }
+        break;
+    }
+
+    if ($escapeSmarty) {
+      $value = self::tokenEscapeSmarty($value);
+    }
+    return $value;
   }
 
   /**

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1836,15 +1836,6 @@ class CRM_Utils_Token {
         $value = CIVICRM_UF_BASEURL . 'civicrm/event/register?reset=1&id=' . $event['id'];
         break;
 
-      case 'fee_amount':
-        $priceSetId = CRM_Price_BAO_PriceSet::getFor('civicrm_event', $event['id']);
-        $result = civicrm_api3('PriceFieldValue', 'get', array('price_field_id' => $priceSetId));
-        $value = '';
-        foreach ($result['values'] as $pricefield) {
-          $value .= $pricefield['label'] . ": " . CRM_Utils_Money::format($pricefield['amount']) . "<br>";
-        }
-        break;
-
       case 'event_id':
         $value = $event['id'];
         break;

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1791,7 +1791,7 @@ class CRM_Utils_Token {
 
     switch ($token) {
       case 'balance':
-        $info = CRM_Contribute_BAO_Contribution::getPaymentInfo($params['entity_id'], 'event');
+        $info = CRM_Contribute_BAO_Contribution::getPaymentInfo($params['participant_id'], 'event');
         $balancePay = CRM_Utils_Array::value('balance', $info);
         $balancePay = CRM_Utils_Money::format($balancePay);
         $value = $balancePay;

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1778,13 +1778,19 @@ class CRM_Utils_Token {
 
   /**
    * Get replacement strings for any event tokens
+   * @param string $entity - name of entity type, should be Event.
    * @param string $token
    * @param array $event an api result array for a single event
    * @param bool $escapeSmarty
    * @return string token replacement
    */
-  public static function getEventTokenReplacement($token, $event, $escapeSmarty = FALSE) {
-    $entity = 'event';
+  public static function getEventTokenReplacement($entity, $token, $event, $escapeSmarty = FALSE) {
+    $entity = strtolower($entity);
+    if ($entity != 'event') {
+      // Not sure which exception is appropriate.
+      throw new Exception('$entity is expected to be "event".');
+    }
+
     self::_buildEventTokens();
 
     $params = array('entity_id' => $event['id'], 'entity_table' => 'civicrm_event');

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1881,13 +1881,19 @@ class CRM_Utils_Token {
 
   /**
    * Get replacement strings for any participant tokens
+   * @param string $entity - name of entity type, should be Participant.
    * @param string $token
    * @param array $participant an api result array for a single participant
    * @param bool $escapeSmarty
    * @return string token replacement
    */
-  public static function getParticipantTokenReplacement($token, $participant, $escapeSmarty = FALSE) {
-    $entity = 'participant';
+  public static function getParticipantTokenReplacement($entity, $token, $participant, $escapeSmarty = FALSE) {
+    $entity = strtolower($entity);
+    if ($entity != 'participant') {
+      // Not sure which exception is appropriate.
+      throw new Exception('$entity is expected to be "participant".');
+    }
+
     self::_buildParticipantTokens();
 
     $params = array('entity_id' => $participant['id'], 'entity_table' => 'civicrm_participant');
@@ -1915,7 +1921,7 @@ class CRM_Utils_Token {
         break;
 
       default:
-        
+
         if (in_array($token, self::$_tokens[$entity])) {
           $value = $participant[$token];
         }


### PR DESCRIPTION
Continued up @mallezie's work for CRM-15734 (participant tokens in PDF letters for participants). This pull request is a continuation of #8258, which provides event tokens for PDF letters to participants (CRM-16599). Now you can create PDF letters like this:

> Hi {contact.first_name}, 
> 
> This is your letter. You subscribed for {event.title}; the event fee amount was {participant.participant_fee_amount}.

---
- [CRM-15734: Dedupe contacts in group searches outside of group](https://issues.civicrm.org/jira/browse/CRM-15734)
- [CRM-16599: Add event tokens to participant pdf creation](https://issues.civicrm.org/jira/browse/CRM-16599)

---
- [CRM-16734: Add participant tokens to participant pdf action](https://issues.civicrm.org/jira/browse/CRM-16734)
