### PR TITLE
CRM-18484 : Error thrown in Reports if one of the params for in betwe…

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -1775,10 +1775,9 @@ class CRM_Report_Form extends CRM_Core_Form {
         if (($min !== NULL && strlen($min) > 0) ||
           ($max !== NULL && strlen($max) > 0)
         ) {
-          $min = CRM_Utils_Type::escape($min, $type);
-          $max = CRM_Utils_Type::escape($max, $type);
           $clauses = array();
           if ($min) {
+            $min = CRM_Utils_Type::escape($min, $type);
             if ($op == 'bw') {
               $clauses[] = "( {$field['dbAlias']} >= $min )";
             }
@@ -1787,6 +1786,7 @@ class CRM_Report_Form extends CRM_Core_Form {
             }
           }
           if ($max) {
+            $max = CRM_Utils_Type::escape($max, $type);
             if ($op == 'bw') {
               $clauses[] = "( {$field['dbAlias']} <= $max )";
             }


### PR DESCRIPTION
…en filter is NULL

---
- CRM-18484: Error thrown in Reports if one of the params for in between filter is NULL
  https://issues.civicrm.org/jira/browse/CRM-18484
