### PR TITLE
CRM-18485 Delete activity Tab filter settings before upgrade

### DIFF
--- a/CRM/Upgrade/Incremental/php/FourSeven.php
+++ b/CRM/Upgrade/Incremental/php/FourSeven.php
@@ -269,11 +269,13 @@ class CRM_Upgrade_Incremental_php_FourSeven extends CRM_Upgrade_Incremental_Base
     CRM_Core_DAO::executeQuery('ALTER TABLE civicrm_setting DROP INDEX index_group_name');
     CRM_Core_DAO::executeQuery('ALTER TABLE civicrm_setting DROP COLUMN group_name');
     CRM_Core_DAO::executeQuery('ALTER TABLE civicrm_setting ADD UNIQUE INDEX index_domain_contact_name (domain_id, contact_id, name)');
-    CRM_Core_DAO::executeQuery('INSERT INTO civicrm_setting (name, contact_id, domain_id, value)
-     SELECT DISTNCT name, contact_id, domain_id, value
+    CRM_Core_DAO::executeQuery('INSERT INTO civicrm_setting (name, contact_id, domain_id, value, is_domain, created_id, created_date)
+     SELECT name, contact_id, domain_id, value, 0, contact_id, %1
      FROM civicrm_activity_setting
      WHERE name = "activity_tab_filter"
-     AND value is not NULL');
+     AND value is not NULL', array(
+      1 => CRM_Utils_Time::getTime('Y-m-d H:i:s'),
+    );
     CRM_Core_DAO::executeQuery('DROP TABLE civicrm_activity_setting');
 
     $domainDao = CRM_Core_DAO::executeQuery('SELECT id, config_backend FROM civicrm_domain');

--- a/CRM/Upgrade/Incremental/php/FourSeven.php
+++ b/CRM/Upgrade/Incremental/php/FourSeven.php
@@ -255,19 +255,20 @@ class CRM_Upgrade_Incremental_php_FourSeven extends CRM_Upgrade_Incremental_Base
     // Nav records are expendable. https://forum.civicrm.org/index.php?topic=36933.0
     CRM_Core_DAO::executeQuery('DELETE FROM civicrm_setting WHERE contact_id IS NOT NULL AND name = "navigation"');
 
+    CRM_Core_DAO::executeQuery('ALTER TABLE civicrm_setting DROP INDEX index_group_name');
+    CRM_Core_DAO::executeQuery('ALTER TABLE civicrm_setting DROP COLUMN group_name');
+
     // Handle Strange activity_tab_filter settings.
     CRM_Core_DAO::executeQuery('CREATE TABLE civicrm_activity_setting LIKE civicrm_setting');
-    CRM_Core_DAO::executeQuery('ALTER TABLE civicrm_activity_setting DROP INDEX index_group_name');
-    CRM_Core_DAO::executeQuery('ALTER TABLE civicrm_activity_setting DROP COLUMN group_name');
+    CRM_Core_DAO::executeQuery('ALTER TABLE civicrm_activity_setting ADD UNIQUE INDEX index_domain_contact_name (domain_id, contact_id, name)');
     CRM_Core_DAO::executeQuery('INSERT INTO civicrm_activity_setting (name, contact_id, domain_id, value)
-     SELECT DISTNCT name, contact_id, domain_id, value
+     SELECT DISTINCT name, contact_id, domain_id, value
      FROM civicrm_setting
      WHERE name = "activity_tab_filter"
      AND value is not NULL');
     CRM_Core_DAO::executeQuery('DELETE FROM civicrm_setting WHERE name = "activity_tab_filter"');
 
-    CRM_Core_DAO::executeQuery('ALTER TABLE civicrm_setting DROP INDEX index_group_name');
-    CRM_Core_DAO::executeQuery('ALTER TABLE civicrm_setting DROP COLUMN group_name');
+
     CRM_Core_DAO::executeQuery('ALTER TABLE civicrm_setting ADD UNIQUE INDEX index_domain_contact_name (domain_id, contact_id, name)');
     CRM_Core_DAO::executeQuery('INSERT INTO civicrm_setting (name, contact_id, domain_id, value, is_domain, created_id, created_date)
      SELECT name, contact_id, domain_id, value, 0, contact_id, %1

--- a/CRM/Upgrade/Incremental/php/FourSeven.php
+++ b/CRM/Upgrade/Incremental/php/FourSeven.php
@@ -268,14 +268,13 @@ class CRM_Upgrade_Incremental_php_FourSeven extends CRM_Upgrade_Incremental_Base
      AND value is not NULL');
     CRM_Core_DAO::executeQuery('DELETE FROM civicrm_setting WHERE name = "activity_tab_filter"');
 
-
+    $date = CRM_Utils_Time::getTime('Y-m-d H:i:s');
     CRM_Core_DAO::executeQuery('ALTER TABLE civicrm_setting ADD UNIQUE INDEX index_domain_contact_name (domain_id, contact_id, name)');
-    CRM_Core_DAO::executeQuery('INSERT INTO civicrm_setting (name, contact_id, domain_id, value, is_domain, created_id, created_date)
-     SELECT name, contact_id, domain_id, value, 0, contact_id, %1
+    CRM_Core_DAO::executeQuery("INSERT INTO civicrm_setting (name, contact_id, domain_id, value, is_domain, created_id, created_date)
+     SELECT name, contact_id, domain_id, value, 0, contact_id,'$date'
      FROM civicrm_activity_setting
-     WHERE name = "activity_tab_filter"
-     AND value is not NULL', array(
-      1 => CRM_Utils_Time::getTime('Y-m-d H:i:s'),
+     WHERE name = 'activity_tab_filter'
+     AND value is not NULL"
     );
     CRM_Core_DAO::executeQuery('DROP TABLE civicrm_activity_setting');
 

--- a/CRM/Upgrade/Incremental/php/FourSeven.php
+++ b/CRM/Upgrade/Incremental/php/FourSeven.php
@@ -254,6 +254,7 @@ class CRM_Upgrade_Incremental_php_FourSeven extends CRM_Upgrade_Incremental_Base
 
     // Nav records are expendable. https://forum.civicrm.org/index.php?topic=36933.0
     CRM_Core_DAO::executeQuery('DELETE FROM civicrm_setting WHERE contact_id IS NOT NULL AND name = "navigation"');
+    CRM_Core_DAO::executeQuery('DELETE FROM civicrm_setting WHERE name = "activity_tab_filter"');
 
     CRM_Core_DAO::executeQuery('ALTER TABLE civicrm_setting DROP INDEX index_group_name');
     CRM_Core_DAO::executeQuery('ALTER TABLE civicrm_setting DROP COLUMN group_name');


### PR DESCRIPTION
- [CRM-18485: Activity Tab Filter settings break 4.7 upgrade](https://issues.civicrm.org/jira/browse/CRM-18485)
