### PR TITLE
Use mailing template subject in 4.6

### DIFF
--- a/CRM/Contribute/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contribute/Form/Task/PDFLetterCommon.php
@@ -337,7 +337,6 @@ class CRM_Contribute_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDF
       $defaults = array(
         'toName' => $contact['display_name'],
         'toEmail' => $contact['email'],
-        'subject' => ts('Thank you for your contribution/s'),
         'text' => '',
         'html' => $html,
       );
@@ -345,6 +344,12 @@ class CRM_Contribute_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDF
         $emails = CRM_Core_BAO_Email::getFromEmail();
         $emails = array_keys($emails);
         $defaults['from'] = array_pop($emails);
+      }
+      if (!empty($params['subject'])) {
+        $defaults['subject'] = $params['subject'];
+      }
+      else {
+        $defaults['subject'] = ts('Thank you for your contribution/s');
       }
       if ($is_pdf) {
         $defaults['html'] = ts('Please see attached');


### PR DESCRIPTION
A fix for https://issues.civicrm.org/jira/browse/CRM-17548 for 4.6.

Already included in 4.7.6: https://github.com/civicrm/civicrm-core/commit/ab0f580c8b5407474c482ea20ca668563385e816
