### PR TITLE
handle more better date formats in 4.6

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2536,7 +2536,7 @@ WHERE  contribution_id = %1 ";
 
     $template->assign('trxn_id', $this->trxn_id);
     $template->assign('receive_date',
-      CRM_Utils_Date::mysqlToIso($this->receive_date)
+      CRM_Utils_Date::processDate($this->receive_date)
     );
     $template->assign('contributeMode', 'notify');
     $template->assign('action', $this->is_test ? 1024 : 1);


### PR DESCRIPTION
this is the same issue as https://issues.civicrm.org/jira/browse/CRM-13063 but in a different location, Contribution.php's _assignMesssageVariablesToTemplate

already submitted and accepted for 4.7: https://github.com/civicrm/civicrm-core/commit/5bab7daf82c8005c92527fd8f3a76f0bb4f315a6
