### PR TITLE
CRM-18476: Invalid argument supplied for foreach() in CRM_Extension_Browser->_discoverRemote()

### DIFF
--- a/CRM/Extension/Browser.php
+++ b/CRM/Extension/Browser.php
@@ -197,7 +197,7 @@ class CRM_Extension_Browser {
     }
 
     $this->_remotesDiscovered = array();
-    foreach ($remotes as $id => $xml) {
+    foreach ((array) $remotes as $id => $xml) {
       $ext = CRM_Extension_Info::loadFromString($xml);
       $this->_remotesDiscovered[] = $ext;
     }


### PR DESCRIPTION
- [CRM-18476:  Invalid argument supplied for foreach() in CRM_Extension_Browser->_discoverRemote()](https://issues.civicrm.org/jira/browse/CRM-18476)
