### PR TITLE
CRM-18176 Fix for error 500 with Event Registrations

### DIFF
--- a/CRM/Core/Payment/PayJunction.php
+++ b/CRM/Core/Payment/PayJunction.php
@@ -57,6 +57,7 @@ class CRM_Core_Payment_PayJunction extends CRM_Core_Payment {
    *   the result in an nice formatted array (or an error object)
    */
   public function doDirectPayment(&$params) {
+    require_once 'PayJunction/pjClasses.php'; // necessary for event registrations 
     $logon = $this->_paymentProcessor['user_name'];
     $password = $this->_paymentProcessor['password'];
     $url_site = $this->_paymentProcessor['url_site'];


### PR DESCRIPTION
When using the PayJunction payment provider, event registration will fail at the last step of submission.
The server will return error 500. 

Error.log shows:
`PHP Fatal error:  Class 'pjpgCustInfo' not found in /civicrm/CRM/Core/Payment/PayJunction.php on line 65, referer: https://XXXXX/civicrm/event/register?_qf_Confirm_display=true`

Currently pjClasses include is within the __construct function, but that doesn't seem to be working with the event registrations.

By adding the include to the doDirectPayment function everything works as expected.

Related Issue:
https://issues.civicrm.org/jira/browse/CRM-18176
