### PR TITLE
(Backport) CRM-17952 - Escape HTML in body_text field on "Headers, Footers, and Automated Messages"

### DIFF
--- a/templates/CRM/Mailing/Page/Component.tpl
+++ b/templates/CRM/Mailing/Page/Component.tpl
@@ -49,7 +49,7 @@
            <td class="crm-editable" data-field="name">{$row.name}</td>
            <td>{$row.component_type}</td>
            <td>{$row.subject}</td>
-           <td>{$row.body_text}</td>
+           <td>{$row.body_text|escape}</td>
            <td>{$row.body_html|escape}</td>
            <td>{if $row.is_default eq 1}<img src="{$config->resourceBase}i/check.gif" alt="{ts}Default{/ts}" />{/if}&nbsp;</td>
      <td id="row_{$row.id}_status">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>


### PR DESCRIPTION
- [CRM-17952: $currency is not available in CRM_Financial_Form_Payment - must be added to the AJAX call](https://issues.civicrm.org/jira/browse/CRM-17952)
