### PR TITLE
civicrm/admin/reltype - Fix warning

### DIFF
--- a/CRM/Core/Page/Basic.php
+++ b/CRM/Core/Page/Basic.php
@@ -243,8 +243,12 @@ abstract class CRM_Core_Page_Basic extends CRM_Core_Page {
           CRM_Core_DAO::storeValues($object, $values[$object->id]);
 
           if (is_a($object, 'CRM_Contact_DAO_RelationshipType')) {
-            $values[$object->id]['contact_type_a_display'] = $contactTypes[$values[$object->id]['contact_type_a']];
-            $values[$object->id]['contact_type_b_display'] = $contactTypes[$values[$object->id]['contact_type_b']];
+            if (isset($values[$object->id]['contact_type_a'])) {
+              $values[$object->id]['contact_type_a_display'] = $contactTypes[$values[$object->id]['contact_type_a']];
+            }
+            if (isset($values[$object->id]['contact_type_b'])) {
+              $values[$object->id]['contact_type_b_display'] = $contactTypes[$values[$object->id]['contact_type_b']];
+            }
           }
 
           // populate action links


### PR DESCRIPTION
Scenario:
1. Create a new relationship-type. It should target "All Contacts" (not "Individual" or "Organization"). (Note: In the schema, "All Contacts" translates to `contact_type_a=NULL`.)
2. Reload the list of relationship-types
3. Observe: Warnings

Notes:
1. The relationship type appears to work correctly if you try to create
   relationship-instances, so this feels like a cosmetic issue on the listing
   screen.
2. What a silly place for that code live. Keep calm and carry on.
