### PR TITLE
CRM-18474 - Escape unicode characters to avoid json syntax errors

### DIFF
--- a/ang/crmUtil.js
+++ b/ang/crmUtil.js
@@ -16,6 +16,11 @@
       var deferred = $q.defer();
       var p;
       var backend = crmApi.backend || CRM.api3;
+      if (params.body_html) {
+        // CRM-18474 - remove Unicode Character 'LINE SEPARATOR' (U+2028)
+        // and 'PARAGRAPH SEPARATOR' (U+2029) from the html if present.
+        params.body_html = params.body_html.replace(/([\u2028]|[\u2029])/g, '\n');
+      }
       if (_.isObject(entity)) {
         // eval content is locally generated.
         /*jshint -W061 */


### PR DESCRIPTION
@eileenmcnaughton I see a similar issue you've [reported it here ](https://issues.civicrm.org/jira/browse/CRM-16969). Can you please take a look and share your views on this patch?

---
- [CRM-18474: Mass mailing saving does not proceed](https://issues.civicrm.org/jira/browse/CRM-18474)
