### PR TITLE
CRM-18511: Fix regression introduced in 79363422.

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -652,7 +652,7 @@ ORDER BY civicrm_custom_group.weight,
       return $subType;
     }
     $contactTypes = civicrm_api3('Contact', 'getoptions', array('field' => 'contact_type'));
-    if ($entityType != 'Contact' && !in_array($entityType, $contactTypes['values'])) {
+    if ($entityType != 'Contact' && !in_array($entityType, array_keys($contactTypes['values']))) {
       // Not quite sure if we want to fail this hard. But quiet ignore would be pretty bad too.
       // Am inclined to go with this for RC release & considering softening.
       throw new CRM_Core_Exception('Invalid Entity Filter');


### PR DESCRIPTION
As `Contact::getoptions()` returns an associative array, so we need to use `array_keys` before using `in_array`.

---
- [CRM-18511: Fix CRM_Core_BAO_CustomGroup::validateSubTypeByEntity()](https://issues.civicrm.org/jira/browse/CRM-18511)
