### PR TITLE
CRM-18502 - Fix payment reminder activity creation

### DIFF
--- a/CRM/Pledge/BAO/Pledge.php
+++ b/CRM/Pledge/BAO/Pledge.php
@@ -1079,15 +1079,16 @@ SELECT  pledge.contact_id              as contact_id,
                   $activityType,
                   'name'
                 ),
-                'activity_date_time' => CRM_Utils_Date::isoToMysql(date('YmdHis')),
                 'due_date_time' => CRM_Utils_Date::isoToMysql($details['scheduled_date']),
                 'is_test' => $details['is_test'],
                 'status_id' => 2,
                 'campaign_id' => $details['campaign_id'],
               );
-              $result = civicrm_api3('activity', 'create', $activityParams);
-              if (civicrm_error($result)) {
-                $returnMessages[] = "Failed creating Activity for acknowledgment";
+              try {
+                civicrm_api3('activity', 'create', $activityParams);
+              }
+              catch (CiviCRM_API3_Exception $e) {
+                $returnMessages[] = "Failed creating Activity for Pledge Reminder: " . $e->getMessage();
                 return array('is_error' => 1, 'message' => $returnMessages);
               }
               $returnMessages[] = "Payment reminder sent to: {$pledgerName} - {$toEmail}";

--- a/CRM/Pledge/BAO/Pledge.php
+++ b/CRM/Pledge/BAO/Pledge.php
@@ -1079,13 +1079,14 @@ SELECT  pledge.contact_id              as contact_id,
                   $activityType,
                   'name'
                 ),
-                'activity_date_time' => CRM_Utils_Date::isoToMysql($now),
+                'activity_date_time' => CRM_Utils_Date::isoToMysql(date('YmdHis')),
                 'due_date_time' => CRM_Utils_Date::isoToMysql($details['scheduled_date']),
                 'is_test' => $details['is_test'],
                 'status_id' => 2,
                 'campaign_id' => $details['campaign_id'],
               );
-              if (is_a(civicrm_api('activity', 'create', $activityParams), 'CRM_Core_Error')) {
+              $result = civicrm_api3('activity', 'create', $activityParams);
+              if (civicrm_error($result)) {
                 $returnMessages[] = "Failed creating Activity for acknowledgment";
                 return array('is_error' => 1, 'message' => $returnMessages);
               }


### PR DESCRIPTION
Call to civicrm_api() fails due to missing "version" parameter, but is undetected due to test for is_a 'CRM_Core_Error'.  Changed to use civicrm_api3() and properly test result for civicrm_error.

---
- [CRM-18502: Pledge payment reminder activity fails to record](https://issues.civicrm.org/jira/browse/CRM-18502)
