### PR TITLE
CRM-18520 - Wrong message after "unhold email" task on Contact Search.

### DIFF
--- a/CRM/Contact/Form/Task/Unhold.php
+++ b/CRM/Contact/Form/Task/Unhold.php
@@ -23,18 +23,17 @@ class CRM_Contact_Form_Task_Unhold extends CRM_Contact_Form_Task {
       $queryString = "
 UPDATE civicrm_email SET on_hold = 0, hold_date = null
 WHERE on_hold = 1 AND hold_date is not null AND contact_id in (" . implode(",", $this->_contactIds) . ")";
-      CRM_Core_DAO::executeQuery($queryString);
-      $sql = "SELECT ROW_COUNT( )";
-      $result = CRM_Core_DAO::singleValueQuery($sql);
-      if ($result) {
+      $result = CRM_Core_DAO::executeQuery($queryString);
+      $rowCount = $result->affectedRows();
+
+      if ($rowCount) {
         CRM_Core_Session::setStatus(ts('%count email was found on hold and updated.', array(
-              'count' => $result,
+              'count' => $rowCount,
               'plural' => '%count emails were found on hold and updated.',
             )), ts('Emails Restored'), 'success');
       }
       else {
         CRM_Core_Session::setStatus(ts('The selected contact does not have an email on hold.', array(
-              'count' => $result,
               'plural' => 'None of the selected contacts have an email on hold.',
             )), ts('No Emails to Restore'), 'info');
       }


### PR DESCRIPTION
The behaviour of `ROW_COUNT()` has been [changed in MYSQL 5.5](http://dev.mysql.com/doc/refman/5.5/en//information-functions.html#function_row-count). Use `affectedRows()` instead.

---
- [CRM-18520: Wrong message after "unhold email" task on Contact Search.](https://issues.civicrm.org/jira/browse/CRM-18520)
