### PR TITLE
Allow contact image file name length during upload up to 255 characters long

### DIFF
--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -807,7 +807,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
     CRM_Contact_Form_Location::buildQuickForm($this);
 
     // add attachment
-    $this->addField('image_URL', array('maxlength' => '60', 'label' => ts('Browse/Upload Image')));
+    $this->addField('image_URL', array('maxlength' => '255', 'label' => ts('Browse/Upload Image')));
 
     // add the dedupe button
     $this->addElement('submit',

--- a/CRM/Upgrade/Incremental/sql/4.7.8.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.7.8.mysql.tpl
@@ -1,4 +1,4 @@
 {* file to handle db changes in 4.7.8 during upgrade *}
 
 #CRM-17967 - Allow conact image file name length during upload up to 255 characters long
-ALTER TABLE `civicrm_contact` CHANGE `image_URL` `image_URL` VARCHAR(450) CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL DEFAULT NULL COMMENT 'optional URL for preferred image (photo, logo, etc.) to display for this contact.';
+ALTER TABLE `civicrm_contact` CHANGE `image_URL` `image_URL` VARCHAR(512) CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL DEFAULT NULL COMMENT 'optional URL for preferred image (photo, logo, etc.) to display for this contact.';

--- a/CRM/Upgrade/Incremental/sql/4.7.8.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.7.8.mysql.tpl
@@ -1,1 +1,4 @@
 {* file to handle db changes in 4.7.8 during upgrade *}
+
+#CRM-17967 - Allow conact image file name length during upload up to 255 characters long
+ALTER TABLE `civicrm_contact` CHANGE `image_URL` `image_URL` VARCHAR(450) CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL DEFAULT NULL COMMENT 'optional URL for preferred image (photo, logo, etc.) to display for this contact.';

--- a/xml/schema/Contact/Contact.xml
+++ b/xml/schema/Contact/Contact.xml
@@ -265,7 +265,7 @@
   <field>
     <name>image_URL</name>
     <type>varchar</type>
-    <length>450</length>
+    <length>512</length>
     <import>true</import>
     <comment>optional URL for preferred image (photo, logo, etc.) to display for this contact.</comment>
     <add>1.1</add>

--- a/xml/schema/Contact/Contact.xml
+++ b/xml/schema/Contact/Contact.xml
@@ -265,7 +265,7 @@
   <field>
     <name>image_URL</name>
     <type>varchar</type>
-    <length>255</length>
+    <length>450</length>
     <import>true</import>
     <comment>optional URL for preferred image (photo, logo, etc.) to display for this contact.</comment>
     <add>1.1</add>


### PR DESCRIPTION
https://issues.civicrm.org/jira/browse/CRM-17967

Currently Add/Edit New Contact page restricts the length of the image file to 60 characters.
