### PR TITLE
CRM-18524: Fix db error when exporting contributions (phone_type_id is not a real ID field).

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -1346,7 +1346,7 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
         // to accommodate different systems - CRM-13739
         static $notRealIDFields = NULL;
         if ($notRealIDFields == NULL) {
-          $notRealIDFields = array('trxn_id', 'componentpaymentfield_transaction_id');
+          $notRealIDFields = array('trxn_id', 'componentpaymentfield_transaction_id', 'phone_type_id');
         }
 
         if (in_array($fieldName, $notRealIDFields)) {


### PR DESCRIPTION
Just a guess from poking at the code. Not sure if it's a good fix.

---
- [CRM-18524: DB error when exporting contributions from Advanced search](https://issues.civicrm.org/jira/browse/CRM-18524)
