### PR TITLE
(WIP) CRM-14126: CURL library issues a PHP warning when open_basedir is set

### DIFF
--- a/CRM/Extension/Downloader.php
+++ b/CRM/Extension/Downloader.php
@@ -83,11 +83,6 @@ class CRM_Extension_Downloader {
       );
     }
 
-    if (empty($errors) && !CRM_Utils_HttpClient::singleton()->isRedirectSupported()) {
-      CRM_Core_Session::setStatus(ts('WARNING: The downloader may be unable to download files which require HTTP redirection. This may be a configuration issue with PHP\'s open_basedir or safe_mode.'));
-      CRM_Core_Error::debug_log_message('WARNING: The downloader may be unable to download files which require HTTP redirection. This may be a configuration issue with PHP\'s open_basedir or safe_mode.');
-    }
-
     return $errors;
   }
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     "totten/ca-config": "~13.02",
     "civicrm/civicrm-cxn-rpc": "~0.15.12.04",
     "zetacomponents/base": "1.7.*",
-    "zetacomponents/mail": "dev-1.7-civi"
+    "zetacomponents/mail": "dev-1.7-civi",
+    "guzzlehttp/guzzle": "~5.0"
   },
   "repositories": [
     {


### PR DESCRIPTION
This replace the current HttpClient implementation to use HttpGuzzle library instead of using CURL which should solve the problems when open_basedir is set or safe_mode is enabled.

---
- [CRM-14126: HttpClient.php library used by CiviCRM issues a PHP warning when open_basedir is set](https://issues.civicrm.org/jira/browse/CRM-14126)
