### PR TITLE
CRM-17888: Updated frequency_unit to type T_STRING

### DIFF
--- a/CRM/Report/Form/Contribute/Recur.php
+++ b/CRM/Report/Form/Contribute/Recur.php
@@ -174,7 +174,7 @@ class CRM_Report_Form_Contribute_Recur extends CRM_Report_Form {
             'title' => ts('Frequency Unit'),
             'operatorType' => CRM_Report_Form::OP_MULTISELECT,
             'options' => CRM_Core_OptionGroup::values('recur_frequency_units'),
-            'type' => CRM_Utils_Type::T_INT,
+            'type' => CRM_Utils_Type::T_STRING,
           ),
           'frequency_interval' => array(
             'title' => ts('Frequency Interval'),


### PR DESCRIPTION
- [CRM-17888: Filtering on frequency_unit Breaks Recur report](https://issues.civicrm.org/jira/browse/CRM-17888)
