### PR TITLE
CRM-18267 upgrade php-font-lib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     "totten/ca-config": "~13.02",
     "civicrm/civicrm-cxn-rpc": "~0.15.12.04",
     "zetacomponents/base": "1.7.*",
-    "zetacomponents/mail": "dev-1.7-civi"
+    "zetacomponents/mail": "dev-1.7-civi",
+    "phenx/php-font-lib": "0.4.*"
   },
   "repositories": [
     {


### PR DESCRIPTION
- [CRM-18267: upgrade php-font-lib](https://issues.civicrm.org/jira/browse/CRM-18267)
