### PR TITLE
CRM-18528 Manage Groups search ignores filters

### DIFF
--- a/CRM/Group/Page/AJAX.php
+++ b/CRM/Group/Page/AJAX.php
@@ -50,7 +50,18 @@ class CRM_Group_Page_AJAX {
       CRM_Utils_JSON::output($groups);
     }
     else {
+      $requiredParams = array();
+      $optionalParams = array(
+        'title' => 'String',
+        'created_by' => 'String',
+        'group_type' => 'String',
+        'visibility' => 'String',
+        'status' => 'Integer',
+        'parentsOnly' => 'Integer',
+        // Ignore 'parent_id' as that case is handled above
+      );
       $params = CRM_Core_Page_AJAX::defaultSortAndPagerParams();
+      $params += CRM_Core_Page_AJAX::validateParams($requiredParams, $optionalParams);
 
       // get group list
       $groups = CRM_Contact_BAO_Group::getGroupListSelector($params);

--- a/CRM/Group/Page/AJAX.php
+++ b/CRM/Group/Page/AJAX.php
@@ -58,16 +58,11 @@ class CRM_Group_Page_AJAX {
         'visibility' => 'String',
         'status' => 'Integer',
         'parentsOnly' => 'Integer',
+        'showOrgInfo' => 'Boolean',
         // Ignore 'parent_id' as that case is handled above
       );
       $params = CRM_Core_Page_AJAX::defaultSortAndPagerParams();
       $params += CRM_Core_Page_AJAX::validateParams($requiredParams, $optionalParams);
-
-      $optionalParameters = array(
-        'parentsOnly' => 'Integer',
-        'showOrgInfo' => 'Boolean',
-      );
-      $params += CRM_Core_Page_AJAX::validateParams(array(), $optionalParameters);
 
       // get group list
       $groups = CRM_Contact_BAO_Group::getGroupListSelector($params);


### PR DESCRIPTION
- [CRM-18528: Manage Groups search ignores filters](https://issues.civicrm.org/jira/browse/CRM-18528)
