### PR TITLE
CRM-17335 reduce use of nullArray

### DIFF
--- a/CRM/ACL/Page/ACL.php
+++ b/CRM/ACL/Page/ACL.php
@@ -152,9 +152,7 @@ class CRM_ACL_Page_ACL extends CRM_Core_Page_Basic {
    WHERE ( object_table IN ( 'civicrm_saved_search', 'civicrm_uf_group', 'civicrm_custom_group', 'civicrm_event' ) )
 ORDER BY entity_id
 ";
-    $dao = CRM_Core_DAO::executeQuery($query,
-      CRM_Core_DAO::$_nullArray
-    );
+    $dao = CRM_Core_DAO::executeQuery($query);
 
     $roles = CRM_Core_OptionGroup::values('acl_role');
 

--- a/CRM/ACL/Page/ACLBasic.php
+++ b/CRM/ACL/Page/ACLBasic.php
@@ -129,9 +129,7 @@ class CRM_ACL_Page_ACLBasic extends CRM_Core_Page_Basic {
    WHERE ( object_table NOT IN ( 'civicrm_saved_search', 'civicrm_uf_group', 'civicrm_custom_group' ) )
 ORDER BY entity_id
 ";
-    $dao = CRM_Core_DAO::executeQuery($query,
-      CRM_Core_DAO::$_nullArray
-    );
+    $dao = CRM_Core_DAO::executeQuery($query);
 
     $roles = CRM_Core_OptionGroup::values('acl_role');
 

--- a/CRM/Activity/Form/Task/SearchTaskHookSample.php
+++ b/CRM/Activity/Form/Task/SearchTaskHookSample.php
@@ -60,9 +60,7 @@ INNER JOIN civicrm_contact ct ON ( ac.contact_id = ct.id )
  LEFT JOIN civicrm_option_value ov ON (at.activity_type_id = ov.value AND og.id = ov.option_group_id )
      WHERE at.id IN ( $activityIDs )";
 
-    $dao = CRM_Core_DAO::executeQuery($query,
-      CRM_Core_DAO::$_nullArray
-    );
+    $dao = CRM_Core_DAO::executeQuery($query);
 
     while ($dao->fetch()) {
       $rows[] = array(

--- a/CRM/Admin/Form/LocationType.php
+++ b/CRM/Admin/Form/LocationType.php
@@ -110,7 +110,7 @@ class CRM_Admin_Form_LocationType extends CRM_Admin_Form {
 
     if ($params['is_default']) {
       $query = "UPDATE civicrm_location_type SET is_default = 0";
-      CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+      CRM_Core_DAO::executeQuery($query);
     }
 
     if ($this->_action & CRM_Core_Action::UPDATE) {

--- a/CRM/Admin/Form/PaymentProcessor.php
+++ b/CRM/Admin/Form/PaymentProcessor.php
@@ -362,7 +362,7 @@ class CRM_Admin_Form_PaymentProcessor extends CRM_Admin_Form {
 
     if (!empty($values['is_default'])) {
       $query = "UPDATE civicrm_payment_processor SET is_default = 0 WHERE domain_id = $domainID";
-      CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+      CRM_Core_DAO::executeQuery($query);
     }
 
     $this->updatePaymentProcessor($values, $domainID, FALSE);

--- a/CRM/Admin/Form/PaymentProcessorType.php
+++ b/CRM/Admin/Form/PaymentProcessorType.php
@@ -215,7 +215,7 @@ class CRM_Admin_Form_PaymentProcessorType extends CRM_Admin_Form {
     if (!empty($values['is_default'])) {
       $query = "
 UPDATE civicrm_payment_processor SET is_default = 0";
-      CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+      CRM_Core_DAO::executeQuery($query);
     }
 
     $dao = new CRM_Financial_DAO_PaymentProcessorType();

--- a/CRM/Badge/BAO/Layout.php
+++ b/CRM/Badge/BAO/Layout.php
@@ -112,7 +112,7 @@ class CRM_Badge_BAO_Layout extends CRM_Core_DAO_PrintLabel {
 
     if ($params['is_default']) {
       $query = "UPDATE civicrm_print_label SET is_default = 0";
-      CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+      CRM_Core_DAO::executeQuery($query);
     }
 
     $printLabel->save();

--- a/CRM/Campaign/BAO/Survey.php
+++ b/CRM/Campaign/BAO/Survey.php
@@ -78,7 +78,7 @@ class CRM_Campaign_BAO_Survey extends CRM_Campaign_DAO_Survey {
 
     if (!empty($params['is_default'])) {
       $query = "UPDATE civicrm_survey SET is_default = 0";
-      CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+      CRM_Core_DAO::executeQuery($query);
     }
 
     if (!(CRM_Utils_Array::value('id', $params))) {

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -775,7 +775,7 @@ SELECT case_status.label AS case_status, status_id, civicrm_case_type.title AS c
  WHERE is_deleted = 0 AND cc.contact_id IN (SELECT id FROM civicrm_contact WHERE is_deleted <> 1)
 {$myCaseWhereClause} {$myGroupByClause}";
 
-    $res = CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+    $res = CRM_Core_DAO::executeQuery($query);
     while ($res->fetch()) {
       if (!empty($rows[$res->case_type]) && !empty($rows[$res->case_type][$res->case_status])) {
         $rows[$res->case_type][$res->case_status]['count'] = $rows[$res->case_type][$res->case_status]['count'] + 1;
@@ -1562,7 +1562,7 @@ SELECT case_status.label AS case_status, status_id, civicrm_case_type.title AS c
 
     $query = self::getCaseActivityQuery($type, $userID, $condition, $cases['case_deleted']);
 
-    $res = CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+    $res = CRM_Core_DAO::executeQuery($query);
 
     $activityInfo = array();
     while ($res->fetch()) {
@@ -2140,7 +2140,7 @@ SELECT civicrm_contact.id as casemanager_id,
             $from = ' FROM ' . $tableName;
             $where = " WHERE {$tableName}.entity_id = {$otherCaseId}";
             $query = $insert . $select . $from . $where;
-            $dao = CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+            $dao = CRM_Core_DAO::executeQuery($query);
           }
         }
 

--- a/CRM/Case/Form/Task/SearchTaskHookSample.php
+++ b/CRM/Case/Form/Task/SearchTaskHookSample.php
@@ -57,7 +57,7 @@ INNER JOIN civicrm_contact ct ON ( cc.contact_id = ct.id)
 LEFT  JOIN civicrm_option_value ov ON (cs.status_id = ov.value AND ov.option_group_id = {$statusId} )
 WHERE cs.id IN ( {$caseIDs} )";
 
-    $dao = CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+    $dao = CRM_Core_DAO::executeQuery($query);
     while ($dao->fetch()) {
       $rows[] = array(
         'display_name' => $dao->display_name,

--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -956,7 +956,7 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
 UPDATE civicrm_contact
 SET image_URL=NULL
 WHERE id={$id}; ";
-    CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+    CRM_Core_DAO::executeQuery($query);
     return TRUE;
   }
 

--- a/CRM/Contact/BAO/Contact/Utils.php
+++ b/CRM/Contact/BAO/Contact/Utils.php
@@ -266,7 +266,7 @@ UNION
 UNION
 ( SELECT location_type_id FROM civicrm_address WHERE contact_id = {$contactId} )
 ";
-    $dao = CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+    $dao = CRM_Core_DAO::executeQuery($query);
     return $dao->N;
   }
 
@@ -555,7 +555,7 @@ UPDATE civicrm_contact
    SET organization_name=NULL, employer_id = NULL
  WHERE employer_id={$employerId}; ";
 
-    $dao = CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+    $dao = CRM_Core_DAO::executeQuery($query);
   }
 
   /**

--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -1797,7 +1797,7 @@ FROM civicrm_contact
 WHERE id IN ( {$contacts} )
 ";
 
-    $dao = CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+    $dao = CRM_Core_DAO::executeQuery($query);
     $currentEmployer = array();
     while ($dao->fetch()) {
       $currentEmployer[$dao->id]['org_id'] = $dao->employer_id;

--- a/CRM/Contact/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contact/Form/Task/PDFLetterCommon.php
@@ -281,7 +281,7 @@ class CRM_Contact_Form_Task_PDFLetterCommon {
       else {
         $query = "UPDATE civicrm_msg_template SET pdf_format_id = NULL WHERE id = {$formValues['template']}";
       }
-      CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+      CRM_Core_DAO::executeQuery($query);
     }
     if (!empty($formValues['update_format'])) {
       $bao = new CRM_Core_BAO_PdfFormat();

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -1332,7 +1332,7 @@ WHERE  civicrm_contribution.contact_id = civicrm_contact.id
       $additionalWhere
       GROUP BY currency
       ";
-    $dao = CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+    $dao = CRM_Core_DAO::executeQuery($query);
     $count = 0;
     $amount = $average = array();
     while ($dao->fetch()) {

--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -200,7 +200,7 @@ SELECT r.payment_processor_id
          WHERE contribution_recur_id IN ( {$recurID}) AND is_test = 0
          GROUP BY contribution_recur_id";
 
-    $res = CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+    $res = CRM_Core_DAO::executeQuery($query);
 
     while ($res->fetch()) {
       $totalCount[$res->contribution_recur_id] = $res->commpleted;
@@ -598,7 +598,7 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
           $from = ' FROM ' . $tableName;
           $where = " WHERE {$tableName}.entity_id = {$sourceContributionId}";
           $query = $insert . $select . $from . $where;
-          CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+          CRM_Core_DAO::executeQuery($query);
         }
       }
     }

--- a/CRM/Core/BAO/LabelFormat.php
+++ b/CRM/Core/BAO/LabelFormat.php
@@ -471,7 +471,7 @@ class CRM_Core_BAO_LabelFormat extends CRM_Core_DAO_OptionValue {
     // clear other default if this is the new default label format
     if ($values['is_default']) {
       $query = "UPDATE civicrm_option_value SET is_default = 0 WHERE option_group_id = $group_id";
-      CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+      CRM_Core_DAO::executeQuery($query);
     }
     if ($id) {
       // fetch existing record

--- a/CRM/Core/BAO/LocationType.php
+++ b/CRM/Core/BAO/LocationType.php
@@ -133,7 +133,7 @@ class CRM_Core_BAO_LocationType extends CRM_Core_DAO_LocationType {
     $locationType->copyValues($params);
     if (!empty($params['is_default'])) {
       $query = "UPDATE civicrm_location_type SET is_default = 0";
-      CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+      CRM_Core_DAO::executeQuery($query);
     }
 
     $locationType->save();

--- a/CRM/Core/BAO/PaperSize.php
+++ b/CRM/Core/BAO/PaperSize.php
@@ -274,7 +274,7 @@ class CRM_Core_BAO_PaperSize extends CRM_Core_DAO_OptionValue {
     // clear other default if this is the new default Paper Size
     if ($values['is_default']) {
       $query = "UPDATE civicrm_option_value SET is_default = 0 WHERE option_group_id = $group_id";
-      CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+      CRM_Core_DAO::executeQuery($query);
     }
     if ($id) {
       // fetch existing record

--- a/CRM/Core/BAO/PdfFormat.php
+++ b/CRM/Core/BAO/PdfFormat.php
@@ -331,7 +331,7 @@ class CRM_Core_BAO_PdfFormat extends CRM_Core_DAO_OptionValue {
     // clear other default if this is the new default PDF Page Format
     if ($values['is_default']) {
       $query = "UPDATE civicrm_option_value SET is_default = 0 WHERE option_group_id = $group_id";
-      CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+      CRM_Core_DAO::executeQuery($query);
     }
     if ($id) {
       // fetch existing record

--- a/CRM/Core/BAO/Tag.php
+++ b/CRM/Core/BAO/Tag.php
@@ -456,7 +456,7 @@ class CRM_Core_BAO_Tag extends CRM_Core_DAO_Tag {
     $tags = $tagSets = array();
     // first get all the tag sets
     $query = "SELECT id FROM civicrm_tag WHERE is_tagset=1 AND parent_id IS NULL";
-    $dao = CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+    $dao = CRM_Core_DAO::executeQuery($query);
     while ($dao->fetch()) {
       $tagSets[] = $dao->id;
     }

--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -964,7 +964,7 @@ SELECT id
   FROM civicrm_state_province
  WHERE LOWER(name) = '$fieldStateProvince'
     OR abbreviation = '$fieldStateProvince'";
-          $dao = CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+          $dao = CRM_Core_DAO::executeQuery($query);
           if ($dao->fetch()) {
             $params['default_value'] = $dao->id;
           }
@@ -977,7 +977,7 @@ SELECT id
   FROM civicrm_country
  WHERE LOWER(name) = '$fieldCountry'
     OR iso_code = '$fieldCountry'";
-          $dao = CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+          $dao = CRM_Core_DAO::executeQuery($query);
           if ($dao->fetch()) {
             $params['default_value'] = $dao->id;
           }

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -194,7 +194,7 @@ class CRM_Event_BAO_Event extends CRM_Event_DAO_Event {
         2 => array($id, 'integer'),
       );
 
-      CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+      CRM_Core_DAO::executeQuery($query);
     }
 
     // price set cleanup, CRM-5527
@@ -1008,7 +1008,7 @@ WHERE civicrm_event.is_active = 1
           $from = ' FROM ' . $tableName;
           $where = " WHERE {$tableName}.entity_id = {$id}";
           $query = $insert . $select . $from . $where;
-          $dao = CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+          $dao = CRM_Core_DAO::executeQuery($query);
         }
       }
     }

--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -801,7 +801,7 @@ FROM   civicrm_participant
    LEFT JOIN civicrm_contact ON (civicrm_participant.contact_id = civicrm_contact.id)
 WHERE  civicrm_participant.id = {$participantId}
 ";
-    $dao = CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+    $dao = CRM_Core_DAO::executeQuery($query);
 
     $details = array();
     while ($dao->fetch()) {

--- a/CRM/Event/Form/SelfSvcTransfer.php
+++ b/CRM/Event/Form/SelfSvcTransfer.php
@@ -181,7 +181,7 @@ class CRM_Event_Form_SelfSvcTransfer extends CRM_Core_Form {
       LEFT JOIN civicrm_option_value cov ON cov.value = cp.role_id and cov.option_group_id = {$optionGroupId}
       LEFT JOIN civicrm_event ON civicrm_event.id = cp.event_id
       WHERE cp.id = {$this->_from_participant_id}";
-    $dao = CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+    $dao = CRM_Core_DAO::executeQuery($query);
     while ($dao->fetch()) {
       $details['status']  = $dao->status;
       $details['role'] = $dao->role;
@@ -291,7 +291,7 @@ class CRM_Event_Form_SelfSvcTransfer extends CRM_Core_Form {
     $contact_details = CRM_Contact_BAO_Contact::getContactDetails($contact_id);
     $display_name = $contact_details[0];
     $query = "select event_id from civicrm_participant where contact_id = " . $contact_id;
-    $dao = CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+    $dao = CRM_Core_DAO::executeQuery($query);
     while ($dao->fetch()) {
       $to_event_id[]  = $dao->event_id;
     }
@@ -313,13 +313,13 @@ class CRM_Event_Form_SelfSvcTransfer extends CRM_Core_Form {
     $params = $this->controller->exportValues($this->_name);
     //cancel 'from' participant row
     $query = "select contact_id from civicrm_email where email = '" . $params['email'] . "'";
-    $dao = CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+    $dao = CRM_Core_DAO::executeQuery($query);
     while ($dao->fetch()) {
       $contact_id  = $dao->contact_id;
     }
     $from_participant = $params = array();
     $query = "select role_id, source, fee_level, is_test, is_pay_later, fee_amount, discount_id, fee_currency,campaign_id, discount_amount from civicrm_participant where id = " . $this->_from_participant_id;
-    $dao = CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+    $dao = CRM_Core_DAO::executeQuery($query);
     $value_to = array();
     while ($dao->fetch()) {
       $value_to['role_id'] = $dao->role_id;

--- a/CRM/Event/Form/SelfSvcUpdate.php
+++ b/CRM/Event/Form/SelfSvcUpdate.php
@@ -155,7 +155,7 @@ class CRM_Event_Form_SelfSvcUpdate extends CRM_Core_Form {
       LEFT JOIN civicrm_option_value cov ON cov.value = cp.role_id and cov.option_group_id = {$optionGroupId}
       LEFT JOIN civicrm_event ON civicrm_event.id = cp.event_id
       WHERE cp.id = {$this->_participant_id}";
-    $dao = CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+    $dao = CRM_Core_DAO::executeQuery($query);
     while ($dao->fetch()) {
       $details['status']  = $dao->status;
       $details['role'] = $dao->role;
@@ -171,7 +171,7 @@ class CRM_Event_Form_SelfSvcUpdate extends CRM_Core_Form {
       CRM_Utils_System::redirect($url);
     }
     $query = "select start_date as start, selfcancelxfer_time as time from civicrm_event where id = " . $this->_event_id;
-    $dao = CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+    $dao = CRM_Core_DAO::executeQuery($query);
     while ($dao->fetch()) {
       $time_limit  = $dao->time;
       $start_date = $dao->start;

--- a/CRM/Event/Form/Task/SearchTaskHookSample.php
+++ b/CRM/Event/Form/Task/SearchTaskHookSample.php
@@ -59,7 +59,7 @@ class CRM_Event_Form_Task_SearchTaskHookSample extends CRM_Event_Form_Task {
  INNER JOIN civicrm_contact ct ON ( p.contact_id = ct.id )
       WHERE p.id IN ( $participantIDs )";
 
-    $dao = CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+    $dao = CRM_Core_DAO::executeQuery($query);
     while ($dao->fetch()) {
       $rows[] = array(
         'display_name' => $dao->display_name,

--- a/CRM/Grant/BAO/Grant.php
+++ b/CRM/Grant/BAO/Grant.php
@@ -61,7 +61,7 @@ class CRM_Grant_BAO_Grant extends CRM_Grant_DAO_Grant {
             SELECT status_id, count(id) as status_total
             FROM civicrm_grant  GROUP BY status_id";
 
-    $dao = CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+    $dao = CRM_Core_DAO::executeQuery($query);
 
     $status = array();
     $summary = array();

--- a/CRM/Grant/Form/Task/SearchTaskHookSample.php
+++ b/CRM/Grant/Form/Task/SearchTaskHookSample.php
@@ -59,7 +59,7 @@ class CRM_Grant_Form_Task_SearchTaskHookSample extends CRM_Grant_Form_Task {
 INNER JOIN civicrm_contact ct ON ( grt.contact_id = ct.id )
      WHERE grt.id IN ( $grantIDs )";
 
-    $dao = CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+    $dao = CRM_Core_DAO::executeQuery($query);
 
     while ($dao->fetch()) {
       $rows[] = array(

--- a/CRM/Mailing/Event/BAO/Queue.php
+++ b/CRM/Mailing/Event/BAO/Queue.php
@@ -293,7 +293,7 @@ SELECT DISTINCT(civicrm_mailing_event_queue.contact_id) as contact_id,
    AND civicrm_mailing_event_queue.email_id = civicrm_email.id
    AND civicrm_mailing_event_queue.id = " . CRM_Utils_Type::escape($queueID, 'Integer');
 
-    $dao = CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+    $dao = CRM_Core_DAO::executeQuery($query);
 
     $displayName = 'Unknown';
     $email = 'Unknown';

--- a/CRM/Mailing/Event/BAO/Unsubscribe.php
+++ b/CRM/Mailing/Event/BAO/Unsubscribe.php
@@ -606,7 +606,7 @@ SELECT DISTINCT(civicrm_mailing_event_queue.contact_id) as contact_id,
    AND civicrm_mailing_event_queue.email_id = civicrm_email.id
    AND civicrm_mailing_event_queue.id = " . CRM_Utils_Type::escape($queueID, 'Integer');
 
-    $dao = CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+    $dao = CRM_Core_DAO::executeQuery($query);
 
     $displayName = 'Unknown';
     $email = 'Unknown';

--- a/CRM/Mailing/Form/Subscribe.php
+++ b/CRM/Mailing/Form/Subscribe.php
@@ -56,7 +56,7 @@ SELECT   title, description
    AND   visibility != 'User and User Admin Only'
    AND   $groupTypeCondition";
 
-      $dao = CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+      $dao = CRM_Core_DAO::executeQuery($query);
       if ($dao->fetch()) {
         $this->assign('groupName', $dao->title);
         CRM_Utils_System::setTitle(ts('Subscribe to Mailing List - %1', array(1 => $dao->title)));
@@ -100,7 +100,7 @@ SELECT   id, title, description
    AND   visibility != 'User and User Admin Only'
    AND   $groupTypeCondition
 ORDER BY title";
-      $dao = CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+      $dao = CRM_Core_DAO::executeQuery($query);
       $rows = array();
       while ($dao->fetch()) {
         $row = array();

--- a/CRM/Member/BAO/MembershipStatus.php
+++ b/CRM/Member/BAO/MembershipStatus.php
@@ -283,7 +283,7 @@ class CRM_Member_BAO_MembershipStatus extends CRM_Member_DAO_MembershipStatus {
  WHERE    {$where}
  ORDER BY weight ASC";
 
-    $membershipStatus = CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+    $membershipStatus = CRM_Core_DAO::executeQuery($query);
     $hour = $minute = $second = 0;
 
     while ($membershipStatus->fetch()) {

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -3634,7 +3634,7 @@ ORDER BY cg.weight, cf.weight";
     //CRM-18276 GROUP_CONCAT could be used with singleValueQuery and then exploded,
     //but by default that truncates to 1024 characters, which causes errors with installs with lots of custom field sets
     $customTables = array();
-    $customTablesDAO = CRM_Core_DAO::executeQuery("SELECT table_name FROM civicrm_custom_group", CRM_Core_DAO::$_nullArray);
+    $customTablesDAO = CRM_Core_DAO::executeQuery("SELECT table_name FROM civicrm_custom_group");
     while ($customTablesDAO->fetch()) {
       $customTables[] = $customTablesDAO->table_name;
     }

--- a/bin/ContributionProcessor.php
+++ b/bin/ContributionProcessor.php
@@ -470,9 +470,7 @@ class CiviContributeProcessor {
       }
     }
 
-    $contribution = &CRM_Contribute_BAO_Contribution::create($params,
-      CRM_Core_DAO::$_nullArray
-    );
+    $contribution = CRM_Contribute_BAO_Contribution::create($params);
     if (!$contribution->id) {
       return FALSE;
     }

--- a/sql/GenerateGroups.php
+++ b/sql/GenerateGroups.php
@@ -45,7 +45,7 @@ $config = CRM_Core_Config::singleton();
 
 $prefix = 'Automated Generated Group: ';
 $query = "DELETE FROM civicrm_group where name like '%{$prefix}%'";
-CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+CRM_Core_DAO::executeQuery($query);
 
 $numGroups = 100;
 

--- a/sql/GenerateMailing.php
+++ b/sql/GenerateMailing.php
@@ -54,7 +54,7 @@ $tables = array(
 );
 foreach ($tables as $t) {
   $query = "DELETE FROM $t";
-  CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+  CRM_Core_DAO::executeQuery($query);
 }
 
 $prefix = 'Automated Mailing Gen: ';

--- a/sql/GenerateReportData.php
+++ b/sql/GenerateReportData.php
@@ -1563,7 +1563,7 @@ INSERT INTO `civicrm_pcp`
 VALUES
     ({$this->individual[3]}, 2, 'My Personal Civi Fundraiser', 'I''m on a mission to get all my friends and family to help support my favorite open-source civic sector CRM.', '<p>Friends and family - please help build much needed infrastructure for the civic sector by supporting my personal campaign!</p>\r\n<p><a href=\"https://civicrm.org\">You can learn more about CiviCRM here</a>.</p>\r\n<p>Then click the <strong>Contribute Now</strong> button to go to our easy-to-use online contribution form.</p>', 'Contribute Now', 1, 1, 1, 5000.00, NULL, 1);
 ";
-    CRM_Core_DAO::executeQuery($query, CRM_Core_DAO::$_nullArray);
+    CRM_Core_DAO::executeQuery($query);
   }
 
   public function addContribution() {


### PR DESCRIPTION
The null array static is a work-around for pass-by-reference signatures but the executeQuery no longer requires it.

It's not actually 'just' tidy-up as the array can become contaminated, leading to hard to diagnose bugs.

Note there is one instance of a similar tidy up on contribution::create in this - the  parameter is no longer mandatory & we call this function so often I feel confident about removing the stray & too

---
- [CRM-17335: Stop passing CRM_Core_DAO::$_nullArray  pointlessly](https://issues.civicrm.org/jira/browse/CRM-17335)
