### PR TITLE
CRM-18536 Remove require_onces no longer required

### DIFF
--- a/tests/phpunit/AllTests.php
+++ b/tests/phpunit/AllTests.php
@@ -31,11 +31,6 @@
  */
 
 /**
- *  Include parent class definition
- */
-require_once 'CiviTest/CiviTestSuite.php';
-
-/**
  *  Class containing all test suites
  *
  * @package   CiviCRM

--- a/tests/phpunit/CRM/Activity/AllTests.php
+++ b/tests/phpunit/CRM/Activity/AllTests.php
@@ -31,11 +31,6 @@
  */
 
 /**
- *  Include parent class definition
- */
-require_once 'CiviTest/CiviTestSuite.php';
-
-/**
  *  Class containing all test suites
  *
  * @package   CiviCRM

--- a/tests/phpunit/CRM/AllTests.php
+++ b/tests/phpunit/CRM/AllTests.php
@@ -31,11 +31,6 @@
  */
 
 /**
- *  Include parent class definition
- */
-require_once 'CiviTest/CiviTestSuite.php';
-
-/**
  *  Class containing all CRM test suites
  *
  * @package   CiviCRM

--- a/tests/phpunit/CRM/Case/AllTests.php
+++ b/tests/phpunit/CRM/Case/AllTests.php
@@ -1,11 +1,6 @@
 <?php
 
 /**
- *  Include parent class definition
- */
-require_once 'CiviTest/CiviTestSuite.php';
-
-/**
  *  Class containing all test suites
  *
  * @package   CiviCRM

--- a/tests/phpunit/CRM/Case/BAO/CaseTypeForkTest.php
+++ b/tests/phpunit/CRM/Case/BAO/CaseTypeForkTest.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once 'CiviTest/CiviCaseTestCase.php';
-
 /**
  * Case Types support an optional forking mechanism wherein the local admin
  * creates a custom DB-based definition that deviates from the file-based definition.

--- a/tests/phpunit/CRM/Contact/AllTests.php
+++ b/tests/phpunit/CRM/Contact/AllTests.php
@@ -31,11 +31,6 @@
  */
 
 /**
- *  Include parent class definition
- */
-require_once 'CiviTest/CiviTestSuite.php';
-
-/**
  *  Class containing all test suites
  *
  * @package   CiviCRM

--- a/tests/phpunit/CRM/Contribute/AllTests.php
+++ b/tests/phpunit/CRM/Contribute/AllTests.php
@@ -31,11 +31,6 @@
  */
 
 /**
- *  Include parent class definition
- */
-require_once 'CiviTest/CiviTestSuite.php';
-
-/**
  *  Class containing all test suites
  *
  * @package   CiviCRM

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -452,7 +452,6 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
    */
   public function testSubmitEmailReceipt() {
     $form = new CRM_Contribute_Form_Contribution();
-    require_once 'CiviTest/CiviMailUtils.php';
     $mut = new CiviMailUtils($this, TRUE);
     $form->testSubmit(array(
       'total_amount' => 50,

--- a/tests/phpunit/CRM/Core/AllTests.php
+++ b/tests/phpunit/CRM/Core/AllTests.php
@@ -31,11 +31,6 @@
  */
 
 /**
- *  Include parent class definition
- */
-require_once 'CiviTest/CiviTestSuite.php';
-
-/**
  *  Class containing all test suites
  *
  * @package   CiviCRM

--- a/tests/phpunit/CRM/Core/BAO/ActionScheduleTest.php
+++ b/tests/phpunit/CRM/Core/BAO/ActionScheduleTest.php
@@ -39,7 +39,6 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
   public function setUp() {
     parent::setUp();
 
-    require_once 'CiviTest/CiviMailUtils.php';
     $this->mut = new CiviMailUtils($this, TRUE);
 
     $this->fixtures['rolling_membership'] = array(

--- a/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
@@ -269,7 +269,6 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
   public function testsendMailParticipantObjectsCheckLog() {
     $this->_setUpParticipantObjects();
     $values = array();
-    require_once 'CiviTest/CiviMailUtils.php';
     $mut = new CiviMailUtils($this, TRUE);
     $this->IPN->loadObjects($this->input, $this->ids, $this->objects, FALSE, $this->_processorId);
     $this->IPN->sendMail($this->input, $this->ids, $this->objects, $values, FALSE, FALSE);
@@ -296,7 +295,6 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
       'civicrm_mailing_spool',
     );
     $this->quickCleanup($tablesToTruncate, FALSE);
-    require_once 'CiviTest/CiviMailUtils.php';
     $mut = new CiviMailUtils($this, TRUE);
     $this->IPN->loadObjects($this->input, $this->ids, $this->objects, FALSE, $this->_processorId);
     $this->IPN->sendMail($this->input, $this->ids, $this->objects, $values, FALSE, FALSE);

--- a/tests/phpunit/CRM/Event/AllTests.php
+++ b/tests/phpunit/CRM/Event/AllTests.php
@@ -31,11 +31,6 @@
  */
 
 /**
- *  Include parent class definition
- */
-require_once 'CiviTest/CiviTestSuite.php';
-
-/**
  *  Class containing all test suites
  *
  * @package   CiviCRM

--- a/tests/phpunit/CRM/Extension/AllTests.php
+++ b/tests/phpunit/CRM/Extension/AllTests.php
@@ -31,11 +31,6 @@
  */
 
 /**
- *  Include parent class definition
- */
-require_once 'CiviTest/CiviTestSuite.php';
-
-/**
  *  Class containing all test suites
  *
  * @package   CiviCRM

--- a/tests/phpunit/CRM/Extension/Container/AllTests.php
+++ b/tests/phpunit/CRM/Extension/Container/AllTests.php
@@ -31,11 +31,6 @@
  */
 
 /**
- *  Include parent class definition
- */
-require_once 'CiviTest/CiviTestSuite.php';
-
-/**
  *  Class containing all test suites
  *
  * @package   CiviCRM

--- a/tests/phpunit/CRM/Extension/Manager/AllTests.php
+++ b/tests/phpunit/CRM/Extension/Manager/AllTests.php
@@ -31,11 +31,6 @@
  */
 
 /**
- *  Include parent class definition
- */
-require_once 'CiviTest/CiviTestSuite.php';
-
-/**
  *  Class containing all test suites
  *
  * @package   CiviCRM

--- a/tests/phpunit/CRM/Member/AllTests.php
+++ b/tests/phpunit/CRM/Member/AllTests.php
@@ -31,11 +31,6 @@
  */
 
 /**
- *  Include parent class definition
- */
-require_once 'CiviTest/CiviTestSuite.php';
-
-/**
  *  Class containing all test suites
  *
  * @package   CiviCRM

--- a/tests/phpunit/CRM/Member/Form/AllTests.php
+++ b/tests/phpunit/CRM/Member/Form/AllTests.php
@@ -31,11 +31,6 @@
  */
 
 /**
- *  Include parent class definition
- */
-require_once 'CiviTest/CiviTestSuite.php';
-
-/**
  *  Class containing all test suites
  *
  * @package   CiviCRM

--- a/tests/phpunit/CRM/Pledge/AllTests.php
+++ b/tests/phpunit/CRM/Pledge/AllTests.php
@@ -31,11 +31,6 @@
  */
 
 /**
- *  Include parent class definition
- */
-require_once 'CiviTest/CiviTestSuite.php';
-
-/**
  *  Class containing all test suites
  *
  * @package   CiviCRM

--- a/tests/phpunit/CRM/Queue/AllTests.php
+++ b/tests/phpunit/CRM/Queue/AllTests.php
@@ -31,11 +31,6 @@
  */
 
 /**
- *  Include parent class definition
- */
-require_once 'CiviTest/CiviTestSuite.php';
-
-/**
  *  Class containing all test suites
  *
  * @package   CiviCRM

--- a/tests/phpunit/CRM/Queue/Queue/AllTests.php
+++ b/tests/phpunit/CRM/Queue/Queue/AllTests.php
@@ -31,11 +31,6 @@
  */
 
 /**
- *  Include parent class definition
- */
-require_once 'CiviTest/CiviTestSuite.php';
-
-/**
  *  Class containing all test suites
  *
  * @package   CiviCRM

--- a/tests/phpunit/CRM/Queue/QueueTest.php
+++ b/tests/phpunit/CRM/Queue/QueueTest.php
@@ -190,7 +190,6 @@ class CRM_Queue_QueueTest extends CiviUnitTestCase {
     $this->queue = $this->queueService->create($queueSpec);
     $this->assertTrue($this->queue instanceof CRM_Queue_Queue);
 
-    require_once 'CRM/Utils/Time.php';
     CRM_Utils_Time::setTime('2012-04-01 1:00:00');
     $this->queue->createItem(array(
       'test-key' => 'a',

--- a/tests/phpunit/CRM/Queue/RunnerTest.php
+++ b/tests/phpunit/CRM/Queue/RunnerTest.php
@@ -33,7 +33,6 @@ class CRM_Queue_RunnerTest extends CiviUnitTestCase {
 
   public function setUp() {
     parent::setUp();
-    require_once 'CRM/Queue/Service.php';
     $this->queueService = CRM_Queue_Service::singleton(TRUE);
     $this->queue = $this->queueService->create(array(
       'type' => 'Sql',

--- a/tests/phpunit/CRM/Report/Form/Contribute/DetailTest.php
+++ b/tests/phpunit/CRM/Report/Form/Contribute/DetailTest.php
@@ -25,8 +25,6 @@
  +--------------------------------------------------------------------+
  */
 
-require_once 'CiviTest/CiviReportTestCase.php';
-
 /**
  *  Test report outcome
  *

--- a/tests/phpunit/CRM/Utils/Cache/AllTests.php
+++ b/tests/phpunit/CRM/Utils/Cache/AllTests.php
@@ -31,11 +31,6 @@
  */
 
 /**
- *  Include parent class definition.
- */
-require_once 'CiviTest/CiviTestSuite.php';
-
-/**
  *  Class containing all test suites.
  *
  * @package   CiviCRM

--- a/tests/phpunit/CRM/Utils/SignerTest.php
+++ b/tests/phpunit/CRM/Utils/SignerTest.php
@@ -142,7 +142,6 @@ class CRM_Utils_SignerTest extends CiviUnitTestCase {
     );
 
     foreach ($cases as $caseId => $case) {
-      require_once 'CRM/Utils/Signer.php';
       $signer = new CRM_Utils_Signer('secret', array('a', 'b', 'c'));
       $signature = $signer->sign($case['signParams']);
       $this->assertTrue(!empty($signature) && is_string($signature)); // arbitrary

--- a/tests/phpunit/Civi/ActionSchedule/AbstractMappingTest.php
+++ b/tests/phpunit/Civi/ActionSchedule/AbstractMappingTest.php
@@ -141,7 +141,6 @@ abstract class AbstractMappingTest extends \CiviUnitTestCase {
     parent::setUp();
     $this->useTransaction();
 
-    require_once 'CiviTest/CiviMailUtils.php';
     $this->mut = new \CiviMailUtils($this, TRUE);
 
     $this->cronSchedule = array(

--- a/tests/phpunit/Civi/AllTests.php
+++ b/tests/phpunit/Civi/AllTests.php
@@ -31,11 +31,6 @@
  */
 
 /**
- *  Include parent class definition
- */
-require_once 'CiviTest/CiviTestSuite.php';
-
-/**
  *  Class containing all CRM test suites
  *
  * @package   CiviCRM

--- a/tests/phpunit/Civi/CCase/SequenceListenerTest.php
+++ b/tests/phpunit/Civi/CCase/SequenceListenerTest.php
@@ -1,8 +1,6 @@
 <?php
 namespace Civi\CCase;
 
-require_once 'CiviTest/CiviCaseTestCase.php';
-
 /**
  * Class SequenceListenerTest
  *

--- a/tests/phpunit/api/v3/AllTests.php
+++ b/tests/phpunit/api/v3/AllTests.php
@@ -31,11 +31,6 @@
  */
 
 /**
- *  Include parent class definition
- */
-require_once 'CiviTest/CiviTestSuite.php';
-
-/**
  *  Class containing all API v3 test suites
  *
  * @package   CiviCRM

--- a/tests/phpunit/api/v3/CaseTest.php
+++ b/tests/phpunit/api/v3/CaseTest.php
@@ -32,7 +32,6 @@
 /**
  * Include class definitions
  */
-require_once 'CiviTest/CiviCaseTestCase.php';
 
 /**
  *  Test APIv3 civicrm_case_* functions

--- a/tests/phpunit/api/v3/CaseTypeTest.php
+++ b/tests/phpunit/api/v3/CaseTypeTest.php
@@ -25,8 +25,6 @@
  +--------------------------------------------------------------------+
  */
 
-require_once 'CiviTest/CiviCaseTestCase.php';
-
 /**
  * Class api_v3_CaseTypeTest
  * @group headless

--- a/tests/phpunit/api/v3/FinancialTypeACLTest.php
+++ b/tests/phpunit/api/v3/FinancialTypeACLTest.php
@@ -25,10 +25,6 @@
  +--------------------------------------------------------------------+
  */
 
-require_once 'CiviTest/CiviUnitTestCase.php';
-require_once 'CiviTest/CiviMailUtils.php';
-
-
 /**
  *  Test APIv3 civicrm_contribute_* functions
  *


### PR DESCRIPTION
Tim hacked class loader for this.

@totten I'd like to sneak in getting this merged for the rc cycle because it makes it heaps easier for me to run tests through phpstorm - hence easier to QA for the RC

---
- [CRM-18536: require_once 'CiviTest\/CiviUnitTestCase.php'; no longer required (& causes some problems)](https://issues.civicrm.org/jira/browse/CRM-18536)
