### PR TITLE
CRM-17887 - Fix date format in Export Batch to IIF

### DIFF
--- a/CRM/Financial/BAO/ExportFormat/IIF.php
+++ b/CRM/Financial/BAO/ExportFormat/IIF.php
@@ -351,7 +351,7 @@ class CRM_Financial_BAO_ExportFormat_IIF extends CRM_Financial_BAO_ExportFormat 
     $s1 = str_replace(self::$SEPARATOR, '\t', $s);
     switch ($type) {
       case 'date':
-        $sout = date('Y/m/d', strtotime($s1));
+        $sout = CRM_Utils_Date::customFormat(date('Ymd', strtotime($s1)));
         break;
 
       case 'money':


### PR DESCRIPTION
https://issues.civicrm.org/jira/browse/CRM-17887

Export Batch to IIF now uses the default 'Complete date format' set from Administer > Localization > Date Formats.
