### PR TITLE
CRM-18543 Deleting email address or phone of CiviMail recipient hangs job

### DIFF
--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -450,6 +450,12 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
       $params = array();
       $count = 0;
       while ($recipients->fetch()) {
+        // CRM-18543: there are cases where both the email and phone are null.
+        // Skip the recipient in this case.
+        if (empty($recipients->email_id) && empty($recipients->phone_id)) {
+          continue;
+        }
+
         if ($recipients->phone_id) {
           $recipients->email_id = "null";
         }

--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -450,7 +450,7 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
       $params = array();
       $count = 0;
       while ($recipients->fetch()) {
-        // CRM-18543: there are cases where both the email and phone are null.
+        // CRM-18543: there are situations when both the email and phone are null.
         // Skip the recipient in this case.
         if (empty($recipients->email_id) && empty($recipients->phone_id)) {
           continue;


### PR DESCRIPTION
There are situations when both the email and phone are null. See CRM-18345.
Skip the recipient in this case.

---
- [CRM-18543: Deleting email address or phone of CiviMail recipient causes job to hang](https://issues.civicrm.org/jira/browse/CRM-18543)
- [CRM-18345: Deleting an email address deletes any mailing events related to it, and the contact](https://issues.civicrm.org/jira/browse/CRM-18345)
