### PR TITLE
CRM-18544 - Fix for issue with custom fields for localized installations

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -652,7 +652,7 @@ ORDER BY civicrm_custom_group.weight,
       return $subType;
     }
     $contactTypes = civicrm_api3('Contact', 'getoptions', array('field' => 'contact_type'));
-    if ($entityType != 'Contact' && !in_array($entityType, $contactTypes['values'])) {
+    if ($entityType != 'Contact' && !isset($contactTypes['values'][$entityType])) {
       // Not quite sure if we want to fail this hard. But quiet ignore would be pretty bad too.
       // Am inclined to go with this for RC release & considering softening.
       throw new CRM_Core_Exception('Invalid Entity Filter');


### PR DESCRIPTION
In localized installations, custom fields on contact subtypes break the
create/edit forms for contacts.

The check for the entity type should be on the keys of $contactTypes['values'], and
not on the values, which can be changed/translated.

---
- CRM-18544: Problem with custom fields for contact subtypes with localized installation
  https://issues.civicrm.org/jira/browse/CRM-18544
