### PR TITLE
CRM-18517 fix merge code loop

### DIFF
--- a/CRM/Contact/Page/AJAX.php
+++ b/CRM/Contact/Page/AJAX.php
@@ -762,35 +762,35 @@ LIMIT {$offset}, {$rowCount}
     if (!empty($columnDetails)) {
       switch ($columnDetails['data']) {
         case 'src':
-          $whereClause .= " ORDER BY cc1.display_name {$dir}";
+          $orderByClause = " ORDER BY cc1.display_name {$dir}";
           break;
 
         case 'src_email':
-          $whereClause .= " ORDER BY ce1.email {$dir}";
+          $orderByClause = " ORDER BY ce1.email {$dir}";
           break;
 
         case 'src_street':
-          $whereClause .= " ORDER BY ca1.street_address {$dir}";
+          $orderByClause = " ORDER BY ca1.street_address {$dir}";
           break;
 
         case 'src_postcode':
-          $whereClause .= " ORDER BY ca1.postal_code {$dir}";
+          $orderByClause = " ORDER BY ca1.postal_code {$dir}";
           break;
 
         case 'dst':
-          $whereClause .= " ORDER BY cc2.display_name {$dir}";
+          $orderByClause = " ORDER BY cc2.display_name {$dir}";
           break;
 
         case 'dst_email':
-          $whereClause .= " ORDER BY ce2.email {$dir}";
+          $orderByClause = " ORDER BY ce2.email {$dir}";
           break;
 
         case 'dst_street':
-          $whereClause .= " ORDER BY ca2.street_address {$dir}";
+          $orderByClause = " ORDER BY ca2.street_address {$dir}";
           break;
 
         case 'dst_postcode':
-          $whereClause .= " ORDER BY ca2.postal_code {$dir}";
+          $orderByClause = " ORDER BY ca2.postal_code {$dir}";
           break;
 
         default:
@@ -798,7 +798,7 @@ LIMIT {$offset}, {$rowCount}
       }
     }
 
-    $dupePairs = CRM_Core_BAO_PrevNextCache::retrieve($cacheKeyString, $join, $whereClause, $offset, $rowCount, $select);
+    $dupePairs = CRM_Core_BAO_PrevNextCache::retrieve($cacheKeyString, $join, $whereClause, $offset, $rowCount, $select, $orderByClause);
     $iFilteredTotal = CRM_Core_DAO::singleValueQuery("SELECT FOUND_ROWS()");
 
     $count = 0;

--- a/CRM/Contact/Page/AJAX.php
+++ b/CRM/Contact/Page/AJAX.php
@@ -726,7 +726,7 @@ LIMIT {$offset}, {$rowCount}
     if ($selected) {
       $whereClause .= ' AND pn.is_selected = 1';
     }
-    $join .= " LEFT JOIN civicrm_dedupe_exception de ON ( pn.entity_id1 = de.contact_id1 AND pn.entity_id2 = de.contact_id2 )";
+    $join .= CRM_Dedupe_Merger::getJoinOnDedupeTable();
 
     $select = array(
       'cc1.contact_type'     => 'src_contact_type',

--- a/CRM/Core/BAO/PrevNextCache.php
+++ b/CRM/Core/BAO/PrevNextCache.php
@@ -215,8 +215,6 @@ WHERE  cacheKey     = %3 AND
    *   Should we return rows that have already been idenfified as having a conflict.
    *   When this is TRUE you should be careful you do not set up a loop.
    *
-   * @param array $select
-   *
    * @return array
    */
   public static function retrieve($cacheKey, $join = NULL, $whereClause = NULL, $offset = 0, $rowCount = 0, $select = array(), $orderByClause = '', $includeConflicts = TRUE) {

--- a/CRM/Core/BAO/PrevNextCache.php
+++ b/CRM/Core/BAO/PrevNextCache.php
@@ -198,18 +198,30 @@ WHERE  cacheKey     = %3 AND
   /**
    * Retrieve from prev-next cache.
    *
+   * This function is used from a variety of merge related functions, although
+   * it would probably be good to converge on calling CRM_Dedupe_Merger::getDuplicatePairs.
+   *
+   * We seem to currently be storing stats in this table too & they might make more sense in
+   * the main cache table.
+   *
    * @param string $cacheKey
    * @param string $join
-   * @param string $where
+   * @param string $whereClause
    * @param int $offset
    * @param int $rowCount
+   * @param array $select
+   * @param string $orderByClause
+   * @param bool $includeConflicts
+   *   Should we return rows that have already been idenfified as having a conflict.
+   *   When this is TRUE you should be careful you do not set up a loop.
    *
    * @param array $select
    *
    * @return array
    */
-  public static function retrieve($cacheKey, $join = NULL, $where = NULL, $offset = 0, $rowCount = 0, $select = array()) {
+  public static function retrieve($cacheKey, $join = NULL, $whereClause = NULL, $offset = 0, $rowCount = 0, $select = array(), $orderByClause = '', $includeConflicts = TRUE) {
     $selectString = 'pn.*';
+
     if (!empty($select)) {
       $aliasArray = array();
       foreach ($select as $column => $alias) {
@@ -217,20 +229,29 @@ WHERE  cacheKey     = %3 AND
       }
       $selectString .= " , " . implode(' , ', $aliasArray);
     }
+
+    $params = array(
+      1 => array($cacheKey, 'String'),
+    );
+
+    if (!empty($whereClause)) {
+      $whereClause = " AND " . $whereClause;
+    }
+    if ($includeConflicts) {
+      $where = ' WHERE (pn.cacheKey = %1 OR pn.cacheKey = %2)' . $whereClause;
+      $params[2] = array("{$cacheKey}_conflicts", 'String');
+    }
+    else {
+      $where = ' WHERE (pn.cacheKey = %1)' . $whereClause;
+    }
+
     $query = "
 SELECT SQL_CALC_FOUND_ROWS {$selectString}
 FROM   civicrm_prevnext_cache pn
        {$join}
-WHERE  (pn.cacheKey = %1 OR pn.cacheKey = %2)
+       $where
+       $orderByClause
 ";
-    $params = array(
-      1 => array($cacheKey, 'String'),
-      2 => array("{$cacheKey}_conflicts", 'String'),
-    );
-
-    if ($where) {
-      $query .= " AND {$where}";
-    }
 
     if ($rowCount) {
       $offset = CRM_Utils_Type::escape($offset, 'Int');

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -586,7 +586,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
    *                              A 'safe' value skips the merge if there are any un-resolved conflicts.
    *                              Does a force merge otherwise.
    * @param bool $autoFlip to let api decide which contact to retain and which to delete.
-   *   Wether to let api decide which contact to retain and which to delete.
+   *   Whether to let api decide which contact to retain and which to delete.
    * @param int $batchLimit number of merges to carry out in one batch.
    * @param int $isSelected if records with is_selected column needs to be processed.
    *

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -583,8 +583,8 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
    *   Group id.
    * @param string $mode
    *   Helps decide how to behave when there are conflicts.
-   *                              A 'safe' value skips the merge if there are any un-resolved conflicts.
-   *                              Does a force merge otherwise.
+   *   A 'safe' value skips the merge if there are any un-resolved conflicts, wheras 'aggressive'
+   *   mode does a force merge.
    * @param bool $autoFlip to let api decide which contact to retain and which to delete.
    *   Whether to let api decide which contact to retain and which to delete.
    * @param int $batchLimit number of merges to carry out in one batch.

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -595,7 +595,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
   public static function batchMerge($rgid, $gid = NULL, $mode = 'safe', $autoFlip = TRUE, $batchLimit = 1, $isSelected = 2) {
     $redirectForPerformance = ($batchLimit > 1) ? TRUE : FALSE;
     $reloadCacheIfEmpty = (!$redirectForPerformance && $isSelected == 2);
-    $dupePairs = self::getDuplicatePairs($rgid, $gid, $reloadCacheIfEmpty, $batchLimit, $isSelected, '', FALSE);
+    $dupePairs = self::getDuplicatePairs($rgid, $gid, $reloadCacheIfEmpty, $batchLimit, $isSelected, '', ($mode == 'aggressive'));
 
     $cacheParams = array(
       'cache_key_string' => self::getMergeCacheKeyString($rgid, $gid),

--- a/api/v3/Job.php
+++ b/api/v3/Job.php
@@ -474,22 +474,25 @@ function civicrm_api3_job_process_respondent($params) {
  *
  * @return array
  *   API Result Array
+ * @throws \CiviCRM_API3_Exception
  */
 function civicrm_api3_job_process_batch_merge($params) {
-  $rgid = CRM_Utils_Array::value('rgid', $params);
+  $rule_group_id = CRM_Utils_Array::value('rgid', $params);
+  if (!$rule_group_id) {
+    $rule_group_id = civicrm_api3('RuleGroup', 'getvalue', array(
+      'contact_type' => 'Individual',
+      'used' => 'Unsupervised',
+      'return' => 'id',
+    ));
+  }
   $gid = CRM_Utils_Array::value('gid', $params);
 
   $mode = CRM_Utils_Array::value('mode', $params, 'safe');
   $autoFlip = CRM_Utils_Array::value('auto_flip', $params, TRUE);
 
-  $result = CRM_Dedupe_Merger::batchMerge($rgid, $gid, $mode, $autoFlip);
+  $result = CRM_Dedupe_Merger::batchMerge($rule_group_id, $gid, $mode, $autoFlip);
 
-  if ($result['is_error'] == 0) {
-    return civicrm_api3_create_success();
-  }
-  else {
-    return civicrm_api3_create_error($result['messages']);
-  }
+  return civicrm_api3_create_success($result, $params);
 }
 
 /**
@@ -499,7 +502,7 @@ function civicrm_api3_job_process_batch_merge($params) {
  */
 function _civicrm_api3_job_process_batch_merge_spec(&$params) {
   $params['rgid'] = array(
-    'title' => 'rule group id',
+    'title' => 'Dedupe rule group id, defaults to Contact Unsupervised rule',
     'type' => CRM_Utils_Type::T_INT,
   );
   $params['gid'] = array(

--- a/api/v3/RuleGroup.php
+++ b/api/v3/RuleGroup.php
@@ -1,0 +1,83 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2016                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * This api exposes CiviCRM rule_groups.
+ *
+ * RuleGroups are used to group dedupe critieria.
+ *
+ * @package CiviCRM_APIv3
+ */
+
+/**
+ * Create or update a rule_group.
+ *
+ * @param array $params
+ *   Array per getfields metadata.
+ *
+ * @return array
+ *   API result array
+ */
+function civicrm_api3_rule_group_create($params) {
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+}
+
+/**
+ * Specify Meta data for create.
+ *
+ * Note that this data is retrievable via the getfields function
+ * and is used for pre-filling defaults and ensuring mandatory requirements are met.
+ *
+ * @param array $params
+ */
+function _civicrm_api3_rule_group_create_spec(&$params) {
+}
+
+/**
+ * Delete an existing RuleGroup.
+ *
+ * @param array $params
+ *
+ * @return array
+ *   API result array
+ */
+function civicrm_api3_rule_group_delete($params) {
+  return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+}
+
+/**
+ * Get a RuleGroup.
+ *
+ * @param array $params
+ *   Array per getfields metadata.
+ *
+ * @return array
+ *   API result array
+ */
+function civicrm_api3_rule_group_get($params) {
+  return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+}

--- a/tests/phpunit/CRM/Dedupe/MergerTest.php
+++ b/tests/phpunit/CRM/Dedupe/MergerTest.php
@@ -264,6 +264,59 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test function that gets duplicate pairs.
+   *
+   * It turns out there are 2 code paths retrieving this data so my initial focus is on ensuring
+   * they match.
+   */
+  public function testGetMatches() {
+    $this->setupMatchData();
+    $pairs = CRM_Dedupe_Merger::getDuplicatePairs(
+      1,
+      NULL,
+      TRUE,
+      25,
+      FALSE
+    );
+
+    $this->assertEquals(array(
+      0 => array(
+        'srcID' => $this->contacts[0]['id'],
+        'srcName' => 'Mr. Mickey Mouse II',
+        'dstID' => $this->contacts[1]['id'],
+        'dstName' => 'Mr. Mickey Mouse II',
+        'weight' => 20,
+        'canMerge' => TRUE,
+      ),
+    ), $pairs);
+  }
+
+  public function setupMatchData() {
+    $fixtures = array(
+      array(
+        'first_name' => 'Mickey',
+        'last_name' => 'Mouse',
+        'email' => 'mickey@mouse.com',
+      ),
+      array(
+        'first_name' => 'Mickey',
+        'last_name' => 'Mouse',
+        'email' => 'mickey@mouse.com',
+      ),
+      array(
+        'first_name' => 'Minnie',
+        'last_name' => 'Mouse',
+        'email' => 'mickey@mouse.com',
+      ),
+    );
+    foreach ($fixtures as $fixture) {
+      $contactID = $this->individualCreate($fixture);
+      $this->contacts[] = array_merge($fixture, array('id' => $contactID));
+    }
+  }
+
+
+  /**
    * Get the list of tables that refer to the CID.
    *
    * This is a statically maintained (in this test list).

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -32,7 +32,6 @@ use Civi\Payment\System;
  *  Include class definitions
  */
 require_once 'api/api.php';
-require_once 'CRM/Financial/BAO/FinancialType.php';
 define('API_LATEST_VERSION', 3);
 
 /**

--- a/tests/phpunit/api/v3/JobTest.php
+++ b/tests/phpunit/api/v3/JobTest.php
@@ -317,7 +317,7 @@ class api_v3_JobTest extends CiviUnitTestCase {
       $this->callAPISuccess('Contact', 'create', $params);
     }
 
-    $result = $this->callAPISuccess('Job', 'process_batch_merge', array());
+    $result = $this->callAPISuccess('Job', 'process_batch_merge', array('mode' => $dataSet['mode']));
     $this->assertEquals($dataSet['skipped'], count($result['values']['skipped']), 'Failed to skip the right number:' . $dataSet['skipped']);
     $this->assertEquals($dataSet['merged'], count($result['values']['merged']));
     $result = $this->callAPISuccess('Contact', 'get', array('contact_sub_type' => 'Student', 'sequential' => 1));
@@ -330,12 +330,20 @@ class api_v3_JobTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test that in aggressive mode our conflicted contacts are merged.
+   */
+  public function testBatchMergeAggressive() {
+
+  }
+
+  /**
    * Get data for batch merge.
    */
   public function getMergeSets() {
     $data = array(
       array(
         array(
+          'mode' => 'safe',
           'contacts' => array(
             array(
               'first_name' => 'Michael',
@@ -370,6 +378,7 @@ class api_v3_JobTest extends CiviUnitTestCase {
       ),
       array(
         array(
+          'mode' => 'safe',
           'contacts' => array(
             array(
               'first_name' => 'Michael',
@@ -413,6 +422,46 @@ class api_v3_JobTest extends CiviUnitTestCase {
             ),
           ),
         ),
+      ),
+      array(
+        array(
+          'mode' => 'aggressive',
+          'contacts' => array(
+            array(
+              'first_name' => 'Michael',
+              'last_name' => 'Jackson',
+              'email' => 'michael@neverland.com',
+              'contact_type' => 'Individual',
+              'contact_sub_type' => 'Student',
+              'api.Address.create' => array(
+                'street_address' => 'big house',
+                'location_type_id' => 'Home',
+              ),
+            ),
+            array(
+              'first_name' => 'Michael',
+              'last_name' => 'Jackson',
+              'email' => 'michael@neverland.com',
+              'contact_type' => 'Individual',
+              'contact_sub_type' => 'Student',
+              'api.Address.create' => array(
+                'street_address' => 'bigger house',
+                'location_type_id' => 'Home',
+              ),
+            ),
+          ),
+          'skipped' => 0,
+          'merged' => 1,
+          'expected' => array(
+            array(
+              'first_name' => 'Michael',
+              'last_name' => 'Jackson',
+              'email' => 'michael@neverland.com',
+              'contact_type' => 'Individual',
+              'street_address' => 'big house',
+            ),
+          ),
+        )
       ),
     );
     return $data;

--- a/tests/phpunit/api/v3/JobTest.php
+++ b/tests/phpunit/api/v3/JobTest.php
@@ -88,7 +88,7 @@ class api_v3_JobTest extends CiviUnitTestCase {
       'parameters' => 'Semi-formal explanation of runtime job parameters',
       'is_active' => 1,
     );
-    $result = $this->callAPIFailure('job', 'create', $params);
+    $this->callAPIFailure('job', 'create', $params);
   }
 
   /**
@@ -294,6 +294,13 @@ class api_v3_JobTest extends CiviUnitTestCase {
     $this->assertEquals('Go Go you good thing', $result['values'][$relationshipID]['description']);
     $this->contactDelete($individualID);
     $this->contactDelete($orgID);
+  }
+
+  /**
+   * Test the batch merge function.
+   */
+  public function testBatchMerge() {
+    $this->callAPISuccess('Job', 'process_batch_merge', array());
   }
 
   /**

--- a/tests/phpunit/api/v3/JobTest.php
+++ b/tests/phpunit/api/v3/JobTest.php
@@ -461,7 +461,7 @@ class api_v3_JobTest extends CiviUnitTestCase {
               'street_address' => 'big house',
             ),
           ),
-        )
+        ),
       ),
     );
     return $data;


### PR DESCRIPTION
This code fixes the code loop in CRM-18517. It was built on some other refactorings and other attempts to add tests (which failed due to the code loop). Despite all the code the only functional change is the bit that removes the code loop.

All of this is basically preliminary tidy up / getting testing to an OK state in order to address 
- CRM-18546 Duplicate email addresses created when merging in 4.7
- CRM-18539 Permit criteria for batch merging (other than group) and a limit
- CRM-18442 (unncessary) Slow query for dedupes

Which is pretty much a minimum set of fixes for us to do batch mode deduping, and which are all blocked on my ability to write proper unit tests.

Note as to what I have observed in 4.7 but not yet looked at (and see as non-regressive)
1) persistence on the merge screen  - e.g if you choose to show address data & then merge & then go back it has lost that.
2) the ajax function really needs a test of it's own & cleaner parameter retrieval
3) the search functions on the ajax screen don't respect the wildcard setting - which would potentially result in slow queries

Our last requirement to permit batch merging from the UI would be to impose a limit - so that if someone accidentally choses a group with 500,000 people it in the server won't crash. You can't say 'retrieve first 1000' but you could iterate in batches of say 500 contacts & if you get to 1000 matches maybe return & say 'you want more? Do ya punk?'

---
- [CRM-18517: code loop when trying to dedupe through the batch merge job if conflicts exist](https://issues.civicrm.org/jira/browse/CRM-18517)
- [CRM-18546: Duplicate email addresses created when merging in 4.7](https://issues.civicrm.org/jira/browse/CRM-18546)
- [CRM-18539: Permit criteria for batch merging (other than group) and a limit](https://issues.civicrm.org/jira/browse/CRM-18539)
- [CRM-18442: (unncessary) Slow query for dedupes](https://issues.civicrm.org/jira/browse/CRM-18442)
