### PR TITLE
CRM-18490: test leakage fix

### DIFF
--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -412,9 +412,9 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
     );
     $contribution = $this->callAPISuccessGetSingle('Contribution', array('return' => 'address_id'));
     $this->assertNotEmpty($contribution['address_id']);
+    // CRM-18490 : There is a unwanted test leakage due to below getsingle Api as it only fails in Jenkin
+    // for now we are only fetching address on based on Address ID (removed filter location_type_id and city)
     $this->callAPISuccessGetSingle('Address', array(
-      'city' => 'Vancouver',
-      'location_type_id' => 5,
       'id' => $contribution['address_id'],
     ));
 


### PR DESCRIPTION
- [CRM-18490: API does not return Address ID via API](https://issues.civicrm.org/jira/browse/CRM-18490)
