### PR TITLE
CRM-18176 payjunction error on events

### DIFF
--- a/CRM/Core/Payment/PayJunction.php
+++ b/CRM/Core/Payment/PayJunction.php
@@ -15,6 +15,8 @@
  * $Id$
  *
  */
+require_once 'PayJunction/pjClasses.php';
+
 class CRM_Core_Payment_PayJunction extends CRM_Core_Payment {
   # (not used, implicit in the API, might need to convert?)
   const CHARSET = 'UFT-8';
@@ -38,9 +40,6 @@ class CRM_Core_Payment_PayJunction extends CRM_Core_Payment {
    * @return \CRM_Core_Payment_PayJunction
    */
   public function __construct($mode, &$paymentProcessor) {
-    //require PayJunction API library
-    require_once 'PayJunction/pjClasses.php';
-
     $this->_mode = $mode;
     $this->_paymentProcessor = $paymentProcessor;
     $this->_processorName = ts('PayJunction');


### PR DESCRIPTION
- [CRM-18176: CiviEvent Registration Fails (Server Error 500) with PayJunction](https://issues.civicrm.org/jira/browse/CRM-18176)
