### PR TITLE
CRM-18528 Manage Groups search ignores filters

### DIFF
--- a/CRM/Group/Page/AJAX.php
+++ b/CRM/Group/Page/AJAX.php
@@ -50,13 +50,19 @@ class CRM_Group_Page_AJAX {
       CRM_Utils_JSON::output($groups);
     }
     else {
-      $params = CRM_Core_Page_AJAX::defaultSortAndPagerParams();
-
-      $optionalParameters = array(
+      $requiredParams = array();
+      $optionalParams = array(
+        'title' => 'String',
+        'created_by' => 'String',
+        'group_type' => 'String',
+        'visibility' => 'String',
+        'status' => 'Integer',
         'parentsOnly' => 'Integer',
         'showOrgInfo' => 'Boolean',
+        // Ignore 'parent_id' as that case is handled above
       );
-      $params += CRM_Core_Page_AJAX::validateParams(array(), $optionalParameters);
+      $params = CRM_Core_Page_AJAX::defaultSortAndPagerParams();
+      $params += CRM_Core_Page_AJAX::validateParams($requiredParams, $optionalParams);
 
       // get group list
       $groups = CRM_Contact_BAO_Group::getGroupListSelector($params);


### PR DESCRIPTION
Jitendra,

I tried your instructions but they didn't work for me.

```
git pull --rebase upstream master
git push origin
```

The push failed so I started a new branch and applied the change there.

---
- [CRM-18528: Manage Groups search ignores filters](https://issues.civicrm.org/jira/browse/CRM-18528)
