### PR TITLE
CRM-18554 Using IS EMPTY operator for some date fields crashes 4.7.7

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -5164,14 +5164,19 @@ SELECT COUNT( conts.total_amount ) as cancel_count,
         $date = "'$date'";
       }
 
+      $this->_tables[$tableName] = $this->_whereTables[$tableName] = 1;
+
+      // handle IS NULL / IS NOT NULL / IS EMPTY / IS NOT EMPTY
+      if ($this->nameNullOrEmptyOp($fieldName, $op, $grouping)) {
+        return;
+      }
+
       if ($date) {
         $this->_where[$grouping][] = "{$tableName}.{$dbFieldName} $op $date";
       }
       else {
         $this->_where[$grouping][] = "{$tableName}.{$dbFieldName} $op";
       }
-
-      $this->_tables[$tableName] = $this->_whereTables[$tableName] = 1;
 
       $op = CRM_Utils_Array::value($op, CRM_Core_SelectValues::getSearchBuilderOperators(), $op);
       $this->_qill[$grouping][] = "$fieldTitle $op $format";

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -5142,6 +5142,13 @@ SELECT COUNT( conts.total_amount ) as cancel_count,
         $value = $value[$op];
       }
 
+      $this->_tables[$tableName] = $this->_whereTables[$tableName] = 1;
+
+      // handle IS NULL / IS NOT NULL / IS EMPTY / IS NOT EMPTY
+      if ($this->nameNullOrEmptyOp($fieldName, $op, $grouping)) {
+        return;
+      }
+
       $date = $format = NULL;
       if (strstr($op, 'IN')) {
         $format = array();
@@ -5162,13 +5169,6 @@ SELECT COUNT( conts.total_amount ) as cancel_count,
         }
         $format = CRM_Utils_Date::customFormat($date);
         $date = "'$date'";
-      }
-
-      $this->_tables[$tableName] = $this->_whereTables[$tableName] = 1;
-
-      // handle IS NULL / IS NOT NULL / IS EMPTY / IS NOT EMPTY
-      if ($this->nameNullOrEmptyOp($fieldName, $op, $grouping)) {
-        return;
       }
 
       if ($date) {


### PR DESCRIPTION
This defect is reproducible on the 4.7 Drupal7 demo site.

```
1. With Search Builder, search for 'Individual > Deceased Date > Is Empty
2. CiviCRM crashes with a database error
```

MySQL complains about the clause 'contact_a.deceased_date IS EMPTY'.

Reviewing the code for CRM_Contact_BAO_Query I see that IS EMPTY needs to be translated into 'IS NULL' or "equals the empty string".

The code for CRM_Contact_BAO_Query::dateQueryBuilder() doesn't do this.

This change calls nameNullOrEmptyOp() to handle the IS EMPTY etc cases. I copied this calling logic from another function in this file.

The line setting $this->_table etc is moved earlier in the function so it is set before calling nameNullOrEmptyOp().

An outstanding issue is that the statement setting $op on 5176 is not invoked in the case where nameNullOrEmptyOp() succeeds. this doesn't seem a big deal, but if it is required then I suggest fixing this in the nameNullOrEmptyOp() function, as the other place this is called will have this issue.

---
- [CRM-18554: Using IS EMPTY operator for some date fields crashes 4.7.7](https://issues.civicrm.org/jira/browse/CRM-18554)
