### PR TITLE
CRM-18555: API utils: avoid unset() on empty array.

### DIFF
--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -134,12 +134,14 @@ function civicrm_api3_create_error($msg, $data = array()) {
 
   // we will show sql to privileged user only (not sure of a specific
   // security hole here but seems sensible - perhaps should apply to the trace as well?)
-  if (isset($data['sql']) && (CRM_Core_Permission::check('Administer CiviCRM') || CIVICRM_UF == 'UnitTests')) {
-    // Isn't this redundant?
-    $data['debug_information'] = $data['sql'];
-  }
-  else {
-    unset($data['sql']);
+  if (isset($data['sql'])) {
+    if (CRM_Core_Permission::check('Administer CiviCRM') || CIVICRM_UF == 'UnitTests') {
+      // Isn't this redundant?
+      $data['debug_information'] = $data['sql'];
+    }
+    else {
+      unset($data['sql']);
+    }
   }
   return $data;
 }


### PR DESCRIPTION
- [CRM-18555: Importing incorrect data can result in PHP fatal error](https://issues.civicrm.org/jira/browse/CRM-18555)
