### PR TITLE
CRM-18563 Fix test failure on MariaDB due to default sorting.

### DIFF
--- a/tests/phpunit/CRM/Contact/Form/Search/Custom/SampleTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Search/Custom/SampleTest.php
@@ -122,7 +122,7 @@ class CRM_Contact_Form_Search_Custom_SampleTest extends CiviUnitTestCase {
       )
     );
     $obj = new CRM_Contact_Form_Search_Custom_Sample($fv);
-    $sql = $obj->all();
+    $sql = $obj->all(0, 0, 'contact_id');
     $this->assertTrue(is_string($sql));
     $dao = CRM_Core_DAO::executeQuery($sql);
     $all = array();


### PR DESCRIPTION
- [CRM-18563: Issues with the API and testing the API](https://issues.civicrm.org/jira/browse/CRM-18563)
