### PR TITLE
CRM-18546 Duplicate email addresses created when merging in 4.7

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -829,11 +829,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
    */
   public static function skipMerge($mainId, $otherId, &$migrationInfo, $mode = 'safe', &$conflicts = array()) {
 
-    $migrationData = array(
-      'old_migration_info' => $migrationInfo,
-      'mode' => $mode,
-    );
-
+    $originalMigrationInfo = $migrationInfo;
     foreach ($migrationInfo as $key => $val) {
       if ($val === "null") {
         // Rule: Never overwrite with an empty value (in any mode)
@@ -890,12 +886,17 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
     // there's a conflict (to handle "gotchas"). fields_in_conflict could be modified here
     // merge happens with new values filled in here. For a particular field / row not to be merged
     // field should be unset from fields_in_conflict.
-    $migrationData['fields_in_conflict'] = $conflicts;
-    $migrationData['merge_mode']         = $mode;
+    $migrationData = array(
+      'old_migration_info' => $originalMigrationInfo,
+      'mode' => $mode,
+      'fields_in_conflict' => $conflicts,
+      'merge_mode' => $mode,
+      'migration_info' => $migrationInfo,
+    );
     CRM_Utils_Hook::merge('batch', $migrationData, $mainId, $otherId);
     $conflicts = $migrationData['fields_in_conflict'];
     // allow hook to override / manipulate migrationInfo as well
-    $migrationInfo = $migrationData['old_migration_info'];
+    $migrationInfo = $migrationData['migration_info'];
 
     if (!empty($conflicts)) {
       foreach ($conflicts as $key => $val) {

--- a/tests/phpunit/CRM/Core/Payment/AuthorizeNetTest.php
+++ b/tests/phpunit/CRM/Core/Payment/AuthorizeNetTest.php
@@ -335,8 +335,8 @@ class CRM_Core_Payment_AuthorizeNetTest extends CiviUnitTestCase {
       $this->processor->doPayment($params);
     }
     catch (Exception $e) {
-      $this->assertTrue(substr($e->getMessage(), 0, 32) == 'E00001: Internal Error Occurred.',
-        'AuthorizeNet failed for unknown reason.');
+      $this->assertTrue(strstr($e->getMessage(), 'E00001: Internal Error Occurred.'),
+        'AuthorizeNet failed for unknown reason.' . $e->getMessage());
       $this->markTestSkipped('AuthorizeNet test server is not in a good mood so we can\'t test this right now');
     }
   }

--- a/tests/phpunit/CRM/Dedupe/DedupeFinderTest.php
+++ b/tests/phpunit/CRM/Dedupe/DedupeFinderTest.php
@@ -26,10 +26,9 @@ class CRM_Dedupe_DedupeFinderTest extends CiviUnitTestCase {
       'domain_id' => 1,
       'is_active' => 1,
       'visibility' => 'Public Pages',
-      'version' => 3,
     );
-    // TODO: This is not an API test!!
-    $result = civicrm_api('group', 'create', $params);
+
+    $result = $this->callAPISuccess('group', 'create', $params);
     $groupId = $result['id'];
 
     // contact data set
@@ -80,18 +79,15 @@ class CRM_Dedupe_DedupeFinderTest extends CiviUnitTestCase {
     );
 
     $count = 1;
-    // TODO: This is not an API test!!
     foreach ($params as $param) {
-      $param['version'] = 3;
-      $contact = civicrm_api('contact', 'create', $param);
+      $contact = $this->callAPISuccess('contact', 'create', $param);
       $contactIds[$count++] = $contact['id'];
 
       $grpParams = array(
         'contact_id' => $contact['id'],
         'group_id' => $groupId,
-        'version' => 3,
       );
-      $res = civicrm_api('group_contact', 'create', $grpParams);
+      $this->callAPISuccess('group_contact', 'create', $grpParams);
     }
 
     // verify that all contacts have been created separately
@@ -181,17 +177,15 @@ class CRM_Dedupe_DedupeFinderTest extends CiviUnitTestCase {
     );
 
     $count = 1;
-    // TODO: This is not an API test!!
+
     foreach ($params as $param) {
-      $param['version'] = 3;
-      $contact = civicrm_api('contact', 'create', $param);
+      $contact = $this->callAPISuccess('contact', 'create', $param);
       $params = array(
         'contact_id' => $contact['id'],
         'street_address' => 'Ambachtstraat 23',
         'location_type_id' => 1,
-        'version' => 3,
       );
-      $result = civicrm_api('address', 'create', $params);
+      $this->callAPISuccess('address', 'create', $params);
       $contactIds[$count++] = $contact['id'];
     }
 
@@ -210,7 +204,7 @@ class CRM_Dedupe_DedupeFinderTest extends CiviUnitTestCase {
       'email' => 'hood@example.com',
       'street_address' => 'Ambachtstraat 23',
     );
-    $errorScope = CRM_Core_TemporaryErrorScope::useException();
+    CRM_Core_TemporaryErrorScope::useException();
     $dedupeParams = CRM_Dedupe_Finder::formatParams($fields, 'Individual');
     $ids = CRM_Dedupe_Finder::dupesByParams($dedupeParams, 'Individual', 'General');
 

--- a/tests/phpunit/CRM/Dedupe/MergerTest.php
+++ b/tests/phpunit/CRM/Dedupe/MergerTest.php
@@ -22,10 +22,9 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
       'domain_id'  => 1,
       'is_active'  => 1,
       'visibility' => 'Public Pages',
-      'version'    => 3,
     );
-    // TODO: This is not an API test!!
-    $result = civicrm_api('group', 'create', $params);
+
+    $result = $this->callAPISuccess('group', 'create', $params);
     $this->_groupId = $result['id'];
 
     // contact data set
@@ -110,7 +109,7 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
         'group_id'   => $this->_groupId,
         'version'    => 3,
       );
-      $res = civicrm_api('group_contact', 'create', $grpParams);
+      $this->callAPISuccess('group_contact', 'create', $grpParams);
     }
   }
 
@@ -121,10 +120,7 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
     foreach ($this->_contactIds as $contactId) {
       $this->contactDelete($contactId);
     }
-
-    // delete dupe group
-    $params = array('id' => $this->_groupId, 'version' => 3);
-    civicrm_api('group', 'delete', $params);
+    $this->groupDelete($this->_groupId);
   }
 
   /**


### PR DESCRIPTION
- [CRM-18546: Duplicate email addresses created when merging in 4.7](https://issues.civicrm.org/jira/browse/CRM-18546)
