### PR TITLE
CRM-18277 : add test & fix for the contact.source field.

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -699,6 +699,12 @@ LEFT JOIN  civicrm_contribution on (civicrm_contribution.contact_id = civicrm_co
 
     if ($hasBillingField) {
       $addressParams = array_merge($this->_params, $addressParams);
+      // CRM-18277 don't let this get passed in because we don't want contribution source to override contact source.
+      // Ideally we wouldn't just randomly merge everything into addressParams but just pass in a relevant array.
+      // Note this source field is covered by a unit test.
+      if (isset($addressParams['source'])) {
+        unset($addressParams['source']);
+      }
       //here we are setting up the billing contact - if different from the member they are already created
       // but they will get billing details assigned
       CRM_Contact_BAO_Contact::createProfileContact($addressParams, $fields,

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -234,7 +234,7 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
       'contribution_status_id' => 'Pending',
     ), 1);
     $contact = $this->callAPISuccessGetSingle('Contact', array('id' => $this->_individualId));
-    $this->assertEmpty($contact['source']);
+    $this->assertTrue(empty($contact['source']));
   }
 
   /**

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -222,7 +222,7 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
         'receipt_date_time' => '',
         'payment_processor_id' => $paymentProcessorID,
         'currency' => 'USD',
-        'source' => '',
+        'source' => 'bob sled race',
       ), CRM_Core_Action::ADD);
     }
     catch (Civi\Payment\Exception\PaymentProcessorException $e) {
@@ -233,6 +233,8 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
       'contact_id' => $this->_individualId,
       'contribution_status_id' => 'Pending',
     ), 1);
+    $contact = $this->callAPISuccessGetSingle('Contact', array('id' => $this->_individualId));
+    $this->assertEmpty($contact['source']);
   }
 
   /**


### PR DESCRIPTION
@mlutfy I figured out what was wrong with your test in https://github.com/civicrm/civicrm-core/pull/8047 & I'm happy with your hacky proposed fix given that it's locked in with a test - so I added that.

If this works for you please confirm you have tested it & we'll close your PR in favour of it.

---
- [CRM-18277: Backend Credit Card Transactions rewrite Source as 'recurring contribution'](https://issues.civicrm.org/jira/browse/CRM-18277)
