### PR TITLE
CRM-18504: Fix error in validating sub type by entity

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -652,7 +652,7 @@ ORDER BY civicrm_custom_group.weight,
       return $subType;
     }
     $contactTypes = civicrm_api3('Contact', 'getoptions', array('field' => 'contact_type'));
-    if ($entityType != 'Contact' && !in_array($entityType, $contactTypes['values'])) {
+    if ($entityType != 'Contact' && !array_key_exists($entityType, $contactTypes['values'])) {
       // Not quite sure if we want to fail this hard. But quiet ignore would be pretty bad too.
       // Am inclined to go with this for RC release & considering softening.
       throw new CRM_Core_Exception('Invalid Entity Filter');

--- a/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
@@ -53,7 +53,7 @@ class CRM_Core_BAO_CustomGroupTest extends CiviUnitTestCase {
    * inconsistency.
    */
   public function testGetTreeContactSubType() {
-    $this->callAPISuccess('ContactType', 'create', array('name' => 'Big Bank', 'label' => 'biggee', 'parent_id' => 'Organization'));
+    $contactType = $this->callAPISuccess('ContactType', 'create', array('name' => 'Big Bank', 'label' => 'biggee', 'parent_id' => 'Organization'));
     $customGroup = $this->CustomGroupCreate(array('extends' => 'Organization', 'extends_entity_column_value' => array('Big_Bank')));
     $customField = $this->customFieldCreate(array('custom_group_id' => $customGroup['id']));
     $result1 = CRM_Core_BAO_CustomGroup::getTree('Organization', NULL, NULL, NULL, array('Big_Bank'));
@@ -67,9 +67,24 @@ class CRM_Core_BAO_CustomGroupTest extends CiviUnitTestCase {
     }
     catch (CRM_Core_Exception $e) {
       $this->customGroupDelete($customGroup['id']);
+      $this->callAPISuccess('ContactType', 'delete', array('id' => $contactType['id']));
       return;
     }
     $this->fail('There is no such thing as a small kind bank');
+  }
+
+  /**
+   * Test calling getTree for a custom field extending a renamed contact type.
+   */
+  public function testGetTreeContactSubTypeForNameChangedContactType() {
+    $contactType = $this->callAPISuccess('ContactType', 'create', array('name' => 'Big Bank', 'label' => 'biggee', 'parent_id' => 'Organization'));
+    CRM_Core_DAO::executeQuery('UPDATE civicrm_contact_type SET label = "boo" WHERE name = "Organization"');
+    $customGroup = $this->CustomGroupCreate(array('extends' => 'Organization', 'extends_entity_column_value' => array('Big_Bank')));
+    $customField = $this->customFieldCreate(array('custom_group_id' => $customGroup['id']));
+    $result1 = CRM_Core_BAO_CustomGroup::getTree('Organization', NULL, NULL, NULL, array('Big_Bank'));
+    $this->assertEquals('Custom Field', $result1[$customGroup['id']]['fields'][$customField['id']]['label']);
+    $this->customGroupDelete($customGroup['id']);
+    $this->callAPISuccess('ContactType', 'delete', array('id' => $contactType['id']));
   }
 
   /**


### PR DESCRIPTION
- [CRM-18504: validateSubTypeByEntity checks value instead of key (Fatal error after 4.7.7 upgrade)](https://issues.civicrm.org/jira/browse/CRM-18504)
