### PR TITLE
CRM-18567 - stristr was called with arguments in wrong order, causing…

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -363,7 +363,7 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup {
         $subTypes = array();
       }
       else {
-        if (stristr(',', $subTypes)) {
+        if (stristr($subTypes, ',')) {
           $subTypes = explode(',', $subTypes);
         }
         else {


### PR DESCRIPTION
… $subTypes not to be exploded correctly when comma-separated. Bug was introduced in https://github.com/civicrm/civicrm-core/commit/35e83f391d6380159fac9ae1891117622093be4a
