### PR TITLE
CRM-18322 notice in participant search

### DIFF
--- a/CRM/Event/Form/Search.php
+++ b/CRM/Event/Form/Search.php
@@ -199,7 +199,7 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
           $seatClause[] = "( participant.is_test = {$this->_formValues['participant_test']} )";
         }
         if (!empty($this->_formValues['participant_status_id'])) {
-          $seatClause[] = CRM_Contact_BAO_Query::buildClause("participant.status_id", '=', $this->_formValues['participant_status_id'], 'Int');
+          $seatClause[] = CRM_Contact_BAO_Query::buildClause("participant.status_id", 'IN', $this->_formValues['participant_status_id'], 'Int');
           if ($status = CRM_Utils_Array::value('IN', $this->_formValues['participant_status_id'])) {
             $this->_formValues['participant_status_id'] = $status;
           }


### PR DESCRIPTION
This patch fixes the notice. I have 2 observations. 
1. The returned clause is something like "participant.status_id IN ("1", "2")" so I was concerned that the integer-value Id is being compared to strings. Happily the MySQL manual says an IN statement "_returns 1 if expr is equal to any of the values in the IN list, else returns 0. If all values are constants, they are evaluated according to the type of expr_" so this is OK.
2. The 'Int' argument has no effect as it is eventually passed to CRM_Core_DAO::createSqlFilter() which ignores that argument.

---
- [CRM-18322: iAmAnIntentionalENoticeThatWarnsOfAProblemYouShouldReport in Participant Search](https://issues.civicrm.org/jira/browse/CRM-18322)
