### PR TITLE
CRM-18046: Search link in AB Testing report erroneously requires view…

### DIFF
--- a/CRM/Mailing/Info.php
+++ b/CRM/Mailing/Info.php
@@ -187,6 +187,7 @@ class CRM_Mailing_Info extends CRM_Core_Component_Info {
       ))
       ->addPermissions(array(
         'view all contacts',
+        'edit all contacts',
         'access CiviMail',
         'create mailings',
         'schedule mailings',

--- a/ang/crmMailingAB/EditCtrl/report.html
+++ b/ang/crmMailingAB/EditCtrl/report.html
@@ -70,7 +70,7 @@
         <a
           class="crm-hover-button action-item"
           ng-href="{{statUrl(am.mailing, statType, 'search')}}"
-          ng-if="checkPerm('view all contacts')"
+          ng-if="checkPerm('view all contacts') || checkPerm('edit all contacts')"
           title="{{ts('Search for contacts using \'%1\'', {1: statType.title})}}"
           crm-icon="fa-search"
           ></a>


### PR DESCRIPTION
… all contacts permission

---
- CRM-18046: Search link in AB Testing report erroneously requires view all contacts permission
  https://issues.civicrm.org/jira/browse/CRM-18046
