### PR TITLE
CRM-18504: Fix error in validating sub type by entity

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -636,7 +636,7 @@ ORDER BY civicrm_custom_group.weight,
       return $subType;
     }
     $contactTypes = civicrm_api3('Contact', 'getoptions', array('field' => 'contact_type'));
-    if ($entityType != 'Contact' && !in_array($entityType, $contactTypes['values'])) {
+    if ($entityType != 'Contact' && !array_key_exists($entityType, $contactTypes['values'])) {
       // Not quite sure if we want to fail this hard. But quiet ignore would be pretty bad too.
       // Am inclined to go with this for RC release & considering softening.
       throw new CRM_Core_Exception('Invalid Entity Filter');

--- a/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
@@ -488,7 +488,7 @@ class CRM_Core_BAO_CustomGroupTest extends CiviUnitTestCase {
     }
 
     Custom::deleteGroup($customGroup);
-    Contact::delete($contactId);
+    $this->contactDelete($contactId);
   }
 
   /**


### PR DESCRIPTION
- [CRM-18504: validateSubTypeByEntity checks value instead of key (Fatal error after 4.7.7 upgrade)](https://issues.civicrm.org/jira/browse/CRM-18504)
