### PR TITLE
CRM-17123 - Include Transaction ID in membership bulk entry profile

### DIFF
--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -280,6 +280,11 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
 
     //CRM-16480 if contact is selected, validate financial type and amount field.
     foreach ($params['field'] as $key => $value) {
+      if (isset($value['trxn_id'])) {
+        if (0 < CRM_Core_DAO::singleValueQuery('SELECT id FROM civicrm_contribution WHERE trxn_id = %1', array(1 => array($value['trxn_id'], 'String')))) {
+          $errors["field[$key][trxn_id]"] = ts('Transaction ID must be unique within the database');
+        }
+      }
       foreach ($fields as $field => $label) {
         if (!empty($params['primary_contact_id'][$key]) && empty($value[$field])) {
           $errors["field[$key][$field]"] = ts('%1 is a required field.', array(1 => $label));

--- a/CRM/Core/BAO/UFField.php
+++ b/CRM/Core/BAO/UFField.php
@@ -1125,6 +1125,10 @@ SELECT  id
           'name' => 'contribution_status_id',
           'title' => ts('Contribution Status'),
         ),
+        'trxn_id' => array(
+          'name' => 'contribution_trxn_id',
+          'title' => ts('Contribution Transaction ID'),
+        ),
       );
     }
     return self::$_memberBatchEntryFields;

--- a/templates/CRM/Batch/Form/Entry.tpl
+++ b/templates/CRM/Batch/Form/Entry.tpl
@@ -66,7 +66,7 @@
       {/if}
       {foreach from=$fields item=field key=fieldName}
         <div class="crm-grid-cell">
-          {if $field.name|substr:0:11 ne 'soft_credit'}
+          {if $field.name|substr:0:11 ne 'soft_credit' and $field.name ne 'trxn_id'}
           <img src="{$config->resourceBase}i/copy.png"
                alt="{ts 1=$field.title}Click to copy %1 from row one to all rows.{/ts}"
                fname="{$field.name}" class="action-icon"

--- a/tests/phpunit/CRM/Batch/Form/EntryTest.php
+++ b/tests/phpunit/CRM/Batch/Form/EntryTest.php
@@ -174,14 +174,15 @@ class CRM_Batch_Form_EntryTest extends CiviUnitTestCase {
     $this->assertEquals(date('Y-m-d', strtotime('07/22/2013')), $result['values'][1]['join_date']);
     $this->assertEquals(date('Y-m-d', strtotime('07/03/2013')), $result['values'][2]['join_date']);
     $this->assertEquals(date('Y-m-d', strtotime('now')), $result['values'][3]['join_date']);
-    $result = $this->callAPISuccess('contribution', 'get', array('return' => 'total_amount'));
+    $result = $this->callAPISuccess('contribution', 'get', array('return' => array('total_amount', 'trxn_id')));
     $this->assertEquals(3, $result['count']);
-    foreach ($result['values'] as $contribution) {
+    foreach ($result['values'] as $key => $contribution) {
       $this->assertEquals($this->callAPISuccess('line_item', 'getvalue', array(
         'contribution_id' => $contribution['id'],
         'return' => 'line_total',
 
       )), $contribution['total_amount']);
+      $this->assertEquals($params['field'][$key]['trxn_id'], $contribution['trxn_id']);
     }
   }
 
@@ -274,6 +275,7 @@ class CRM_Batch_Form_EntryTest extends CiviUnitTestCase {
           'receive_date' => '07/24/2013',
           'receive_date_time' => NULL,
           'payment_instrument' => 1,
+          'trxn_id' => 'TX101',
           'check_number' => NULL,
           'contribution_status_id' => 1,
         ),
@@ -288,6 +290,7 @@ class CRM_Batch_Form_EntryTest extends CiviUnitTestCase {
           'receive_date' => '07/17/2013',
           'receive_date_time' => NULL,
           'payment_instrument' => NULL,
+          'trxn_id' => 'TX102',
           'check_number' => NULL,
           'contribution_status_id' => 1,
         ),
@@ -303,6 +306,7 @@ class CRM_Batch_Form_EntryTest extends CiviUnitTestCase {
           'receive_date' => '07/17/2013',
           'receive_date_time' => NULL,
           'payment_instrument' => NULL,
+          'trxn_id' => 'TX103',
           'check_number' => NULL,
           'contribution_status_id' => 1,
         ),


### PR DESCRIPTION
Proposed replacement for https://github.com/civicrm/civicrm-core/pull/6938/files

The previous PR adds it by default (& hence went stale). I think it's arguable whether it should be there by default but agree it should be addable - which this enables. 

It removes the copy-down as per the other PR, but also validates the uniquenes of the trxn_id.

@joannechester do you want to test this. I will go ahead & close the other one as it is stale anyway.

---
- [CRM-17123: Include Transaction ID in membership bulk entry profile](https://issues.civicrm.org/jira/browse/CRM-17123)
