### PR TITLE
proposed workaround for CRM-17235

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4670,10 +4670,8 @@ LIMIT 1;";
     do {
       $creditNoteNum++;
       $creditNoteId = CRM_Utils_Array::value('credit_notes_prefix', $prefixValue) . "" . $creditNoteNum;
-      $result = civicrm_api3('Contribution', 'getcount', array(
-        'sequential' => 1,
-        'creditnote_id' => $creditNoteId,
-      ));
+      $params = array(1 => array($creditNoteId, 'String'));
+      $result = CRM_Core_DAO::singleValueQuery("SELECT count(id) FROM civicrm_contribution WHERE creditnote_id = %1", $params);
     } while ($result > 0);
 
     return $creditNoteId;


### PR DESCRIPTION
This workaround should speed up the `createCreditNoteId()` function significantly on larger data sets, especially if you add the index:

```
CREATE INDEX UI_contrib_creditnote_id ON civicrm_contribution (creditnote_id);
```

---
- [CRM-17235: Credit Note sequence problem](https://issues.civicrm.org/jira/browse/CRM-17235)
