### PR TITLE
Change 12-hour `Ymdhis` to 24-hour `YmdHis`

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1678,7 +1678,7 @@ SELECT $columnName
 
       $fileDAO->uri = $filename;
       $fileDAO->mime_type = $mimeType;
-      $fileDAO->upload_date = date('Ymdhis');
+      $fileDAO->upload_date = date('YmdHis');
       $fileDAO->save();
       $fileId = $fileDAO->id;
       $value = $filename;

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1517,7 +1517,7 @@ ORDER BY civicrm_custom_group.weight,
 
             //store the file in d/b
             $entityId = explode('=', $groupTree['info']['where'][0]);
-            $fileParams = array('upload_date' => date('Ymdhis'));
+            $fileParams = array('upload_date' => date('YmdHis'));
 
             if ($groupTree[$groupID]['fields'][$fieldId]['customValue']['fid']) {
               $fileParams['id'] = $groupTree[$groupID]['fields'][$fieldId]['customValue']['fid'];

--- a/CRM/Core/BAO/File.php
+++ b/CRM/Core/BAO/File.php
@@ -145,7 +145,7 @@ class CRM_Core_BAO_File extends CRM_Core_DAO_File {
     $fileDAO->uri = $filename;
     $fileDAO->mime_type = $mimeType;
     $fileDAO->file_type_id = $fileTypeID;
-    $fileDAO->upload_date = date('Ymdhis');
+    $fileDAO->upload_date = date('YmdHis');
     $fileDAO->save();
 
     // need to add/update civicrm_entity_file
@@ -532,7 +532,7 @@ AND       CEF.entity_id    = %2";
 
     $numAttachments = Civi::settings()->get('max_attachments');
 
-    $now = date('Ymdhis');
+    $now = date('YmdHis');
 
     // setup all attachments
     for ($i = 1; $i <= $numAttachments; $i++) {

--- a/CRM/Utils/Mail/Incoming.php
+++ b/CRM/Utils/Mail/Incoming.php
@@ -338,7 +338,7 @@ class CRM_Utils_Mail_Incoming {
 
     // format and move attachments to the civicrm area
     if (!empty($attachments)) {
-      $date = date('Ymdhis');
+      $date = date('YmdHis');
       $config = CRM_Core_Config::singleton();
       for ($i = 0; $i < count($attachments); $i++) {
         $attachNum = $i + 1;

--- a/Civi/Core/SettingsBag.php
+++ b/Civi/Core/SettingsBag.php
@@ -378,7 +378,7 @@ class SettingsBag {
       $dao->group_name = 'placeholder';
     }
 
-    $dao->created_date = \CRM_Utils_Time::getTime('Ymdhis');
+    $dao->created_date = \CRM_Utils_Time::getTime('YmdHis');
 
     $session = \CRM_Core_Session::singleton();
     if (\CRM_Contact_BAO_Contact_Utils::isContactId($session->get('userID'))) {

--- a/sql/GenerateData.php
+++ b/sql/GenerateData.php
@@ -374,7 +374,7 @@ class CRM_GCD {
 
     // number of seconds per year
     $numSecond = 31536000;
-    $dateFormat = "Ymdhis";
+    $dateFormat = "YmdHis";
     $today = time();
 
     // both are defined

--- a/sql/GenerateReportData.php
+++ b/sql/GenerateReportData.php
@@ -352,7 +352,7 @@ class CRM_GCD {
     // number of seconds for 2 year
     $numSecond = 63072000;
 
-    $dateFormat = "Ymdhis";
+    $dateFormat = "YmdHis";
     $today = time();
 
     // both are defined


### PR DESCRIPTION
There are several places which store dates generated using `date('Ymdhis')`
(notice the "h" uses 12-hour clock).  This is non-sensical because there is
no "AM/PM" information, and DB datetime/timestamp values should be on
24-hour clock (`date('YmdHis')`).

The 12-hour clock should be an aesthetic used in the view-layer for certain
locales.
