### PR TITLE
CRM-18528 - unit test to check group filter

### DIFF
--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -755,7 +755,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
         $value['class'] = array_diff($value['class'], array('crm-row-parent'));
       }
       $group['DT_RowId'] = 'row_' . $value['id'];
-      if (!$params['parentsOnly']) {
+      if (empty($params['parentsOnly'])) {
         foreach ($value['class'] as $id => $class) {
           if ($class == 'crm-group-parent') {
             unset($value['class'][$id]);

--- a/CRM/Group/Page/AJAX.php
+++ b/CRM/Group/Page/AJAX.php
@@ -46,8 +46,6 @@ class CRM_Group_Page_AJAX {
       $params['page'] = 1;
       $params['rp'] = 0;
       $groups = CRM_Contact_BAO_Group::getGroupListSelector($params);
-
-      CRM_Utils_JSON::output($groups);
     }
     else {
       $requiredParams = array();
@@ -78,9 +76,13 @@ class CRM_Group_Page_AJAX {
           $groups = CRM_Contact_BAO_Group::getGroupListSelector($params);
         }
       }
-
-      CRM_Utils_JSON::output($groups);
     }
+
+    if (!empty($_GET['is_unit_test'])) {
+      return $groups;
+    }
+
+    CRM_Utils_JSON::output($groups);
   }
 
 }

--- a/tests/phpunit/CRM/Group/Page/AjaxTest.php
+++ b/tests/phpunit/CRM/Group/Page/AjaxTest.php
@@ -85,22 +85,32 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
    */
   public function testGroupListWithFilter() {
     global $_GET;
-    $_GET = $this->_params;
+    $_GET = array(
+      'page' => 1,
+      'rp' => 50,
+      'offset' => 0,
+      'rowCount' => 50,
+      'sort' => NULL,
+      'parentsOnly' => FALSE,
+      'is_unit_test' => TRUE,
+    );
+    $this->groupCreate(array('title' => 'Active Group', 'is_active' => 1, 'name' => 'active-group'));
+    $this->groupCreate(array('title' => 'Disabled Group', 'is_active' => 0, 'name' => 'disabled-group'));
     $obj = new CRM_Group_Page_AJAX();
 
     //filter with title
-    $_GET['title'] = "not-me-active";
+    $_GET['title'] = "Active Group";
     $groups = $obj->getGroupList();
     $this->assertEquals(1, $groups['recordsTotal']);
-    $this->assertEquals('not-me-active', $groups['data'][0]['title']);
+    $this->assertEquals('Active Group', $groups['data'][0]['title']);
     unset($_GET['title']);
 
     // check on status
     $_GET['status'] = 2;
     $groups = $obj->getGroupList();
-    $this->assertEquals(2, $groups['recordsTotal']);
-    $this->assertEquals('not-me-disabled', $groups['data'][0]['title']);
-    $this->assertEquals('pick-me-disabled', $groups['data'][1]['title']);
+    foreach ($groups['data'] as $key => $val) {
+      $this->assertEquals('crm-entity disabled', $val['DT_RowClass']);
+    }
   }
 
   /**

--- a/tests/phpunit/CRM/Group/Page/AjaxTest.php
+++ b/tests/phpunit/CRM/Group/Page/AjaxTest.php
@@ -81,6 +81,29 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
   }
 
   /**
+   * CRM-18528 - Retrieve groups with filter
+   */
+  public function testGroupListWithFilter() {
+    global $_GET;
+    $_GET = $this->_params;
+    $obj = new CRM_Group_Page_AJAX();
+
+    //filter with title
+    $_GET['title'] = "not-me-active";
+    $groups = $obj->getGroupList();
+    $this->assertEquals(1, $groups['recordsTotal']);
+    $this->assertEquals('not-me-active', $groups['data'][0]['title']);
+    unset($_GET['title']);
+
+    // check on status
+    $_GET['status'] = 2;
+    $groups = $obj->getGroupList();
+    $this->assertEquals(2, $groups['recordsTotal']);
+    $this->assertEquals('not-me-disabled', $groups['data'][0]['title']);
+    $this->assertEquals('pick-me-disabled', $groups['data'][1]['title']);
+  }
+
+  /**
    * Retrieve groups as 'view all contacts'
    */
   public function testGroupListViewAllContacts() {


### PR DESCRIPTION
- [CRM-18528: Manage Groups search ignores filters](https://issues.civicrm.org/jira/browse/CRM-18528)

unit test to check https://github.com/civicrm/civicrm-core/pull/8366
