### PR TITLE
CRM-18625 - payment processors - correctly set test URLs from edit form

### DIFF
--- a/CRM/Admin/Form/PaymentProcessor.php
+++ b/CRM/Admin/Form/PaymentProcessor.php
@@ -379,7 +379,7 @@ class CRM_Admin_Form_PaymentProcessor extends CRM_Admin_Form {
    */
   public function updatePaymentProcessor(&$values, $domainID, $test) {
     if ($test) {
-      foreach (array('user_name', 'password', 'signature') as $field) {
+      foreach (array('user_name', 'password', 'signature', 'url_site', 'url_recur') as $field) {
         $values[$field] = empty($values["test_{$field}"]) ? CRM_Utils_Array::value($field, $values) : $values["test_{$field}"];
       }
     }

--- a/CRM/Admin/Form/PaymentProcessor.php
+++ b/CRM/Admin/Form/PaymentProcessor.php
@@ -379,7 +379,7 @@ class CRM_Admin_Form_PaymentProcessor extends CRM_Admin_Form {
    */
   public function updatePaymentProcessor(&$values, $domainID, $test) {
     if ($test) {
-      foreach (array('user_name', 'password', 'signature', 'url_site', 'url_recur') as $field) {
+      foreach (array('user_name', 'password', 'signature', 'url_site', 'url_recur', 'url_api', 'url_button', 'subject') as $field) {
         $values[$field] = empty($values["test_{$field}"]) ? CRM_Utils_Array::value($field, $values) : $values["test_{$field}"];
       }
     }


### PR DESCRIPTION
Update the hardcoded list of fields to use the test fields for site, recur, button, subject, and api when updating the test processor record.

---
- CRM-18625: Authorize.net not saving testing URL
  https://issues.civicrm.org/jira/browse/CRM-18625
