### PR TITLE
CRM-18594 Attempt to add test to check aphabetical event type

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -657,10 +657,13 @@ ORDER BY civicrm_custom_group.weight,
     }
 
     $contactTypes = CRM_Contact_BAO_ContactType::basicTypeInfo(TRUE);
+    $contactTypes = array_merge($contactTypes, array('Event' => 1));
+
     if ($entityType != 'Contact' && !array_key_exists($entityType, $contactTypes)) {
       throw new CRM_Core_Exception('Invalid Entity Filter');
     }
     $subTypes = CRM_Contact_BAO_ContactType::subTypeInfo($entityType, TRUE);
+    $subTypes = array_merge($subTypes, CRM_Event_PseudoConstant::eventType());
     if (!array_key_exists($subType, $subTypes)) {
       throw new CRM_Core_Exception('Invalid Filter');
     }

--- a/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
@@ -101,8 +101,11 @@ class CRM_Core_BAO_CustomGroupTest extends CiviUnitTestCase {
     $this->callAPISuccess('ContactType', 'delete', array('id' => $contactType['id']));
   }
 
+  /**
+   * Test calling GetTree for a custom field extending multiple subTypes.
+   */
   public function testGetTreetContactSubTypeForMultipleSubTypes() {
-    $contactType1 = $this->callApiSuccess('ContactType', 'create', array('name' => 'Big Bank', 'label' => 'biggee', 'parent_id' => 'Organization'));
+    $contactType1 = $this->callAPISuccess('ContactType', 'create', array('name' => 'Big Bank', 'label' => 'biggee', 'parent_id' => 'Organization'));
     $contactType2 = $this->callAPISuccess('ContactType', 'create', array('name' => 'Small Bank', 'label' => 'smallee', 'parent_id' => 'Organization'));
     $customGroup = $this->CustomGroupCreate(array('extends' => 'Organization', 'extends_entity_column_value' => array('Big_Bank', 'Small_Bank')));
     $customField = $this->customFieldCreate(array('custom_group_id' => $customGroup['id']));
@@ -111,6 +114,19 @@ class CRM_Core_BAO_CustomGroupTest extends CiviUnitTestCase {
     $this->customGroupDelete($customGroup['id']);
     $this->callAPISuccess('ContactType', 'delete', array('id' => $contactType1['id']));
     $this->callAPISuccess('ContactType', 'delete', array('id' => $contactType2['id']));
+  }
+
+  /**
+   * Test calling GetTree for a custom field that extends a non numerical Event Type.
+   */
+  public function testGetTreeEventSubTypeAlphabetical() {
+    $eventType = $this->callAPISuccess('OptionValue', 'Create', array('option_group_id' => 'event_type', 'value' => 'meeting', 'label' => 'Meeting'));
+    $customGroup = $this->CustomGroupCreate(array('extends' => 'Event', 'extends_entity_column_value' => array('meeting')));
+    $customField = $this->customFieldCreate(array('custom_group_id' => $customGroup['id']));
+    $result1 = CRM_Core_BAO_CustomGroup::getTree('Event', NULL, NULL, NULL, CRM_Core_DAO::VALUE_SEPARATOR . 'meeting' . CRM_Core_DAO::VALUE_SEPARATOR);
+    $this->assertEquals('Custom Field', $result1[$customGroup['id']]['fields'][$customField['id']]['label']);
+    $this->customGroupDelete($customGroup['id']);
+    $this->callAPISuccess('OptionValue', 'delete', array('id' => $eventType['id']));
   }
 
   /**

--- a/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
@@ -121,7 +121,7 @@ class CRM_Core_BAO_CustomGroupTest extends CiviUnitTestCase {
    */
   public function testGetTreeEventSubTypeAlphabetical() {
     $eventType = $this->callAPISuccess('OptionValue', 'Create', array('option_group_id' => 'event_type', 'value' => 'meeting', 'label' => 'Meeting'));
-    $customGroup = $this->CustomGroupCreate(array('extends' => 'Event', 'extends_entity_column_value' => array('meeting')));
+    $customGroup = $this->CustomGroupCreate(array('extends' => 'Event', 'extends_entity_column_value' => array('Meeting')));
     $customField = $this->customFieldCreate(array('custom_group_id' => $customGroup['id']));
     $result1 = CRM_Core_BAO_CustomGroup::getTree('Event', NULL, NULL, NULL, CRM_Core_DAO::VALUE_SEPARATOR . 'meeting' . CRM_Core_DAO::VALUE_SEPARATOR);
     $this->assertEquals('Custom Field', $result1[$customGroup['id']]['fields'][$customField['id']]['label']);


### PR DESCRIPTION
- [CRM-18594: Creating event templates throws an 'Invalid Entity Filter' exception](https://issues.civicrm.org/jira/browse/CRM-18594)
