### PR TITLE
CRM-18560 - Validate either body text or body html

### DIFF
--- a/CRM/Mailing/Form/Component.php
+++ b/CRM/Mailing/Form/Component.php
@@ -76,8 +76,7 @@ class CRM_Mailing_Form_Component extends CRM_Core_Form {
       TRUE
     );
     $this->add('textarea', 'body_text', ts('Body - TEXT Format'),
-      CRM_Core_DAO::getAttribute('CRM_Mailing_DAO_Component', 'body_text'),
-      TRUE
+      CRM_Core_DAO::getAttribute('CRM_Mailing_DAO_Component', 'body_text')
     );
     $this->add('textarea', 'body_html', ts('Body - HTML Format'),
       CRM_Core_DAO::getAttribute('CRM_Mailing_DAO_Component', 'body_html')
@@ -86,6 +85,7 @@ class CRM_Mailing_Form_Component extends CRM_Core_Form {
     $this->addYesNo('is_default', ts('Default?'));
     $this->addYesNo('is_active', ts('Enabled?'));
 
+    $this->addFormRule(array('CRM_Mailing_Form_Component', 'formRule'));
     $this->addFormRule(array('CRM_Mailing_Form_Component', 'dataRule'));
 
     $this->addButtons(array(
@@ -181,7 +181,26 @@ class CRM_Mailing_Form_Component extends CRM_Core_Form {
           )) . '<ul>' . implode('', $dataErrors) . '</ul><br /><a href="' . CRM_Utils_System::docURL2('Tokens', TRUE, NULL, NULL, NULL, "wiki") . '">' . ts('More information on tokens...') . '</a>';
       }
     }
+    return empty($errors) ? TRUE : $errors;
+  }
 
+  /**
+   * Validates that either body text or body html is required.
+   * @param array $params
+   *   (ref.) an assoc array of name/value pairs.
+   *
+   * @param $files
+   * @param $options
+   *
+   * @return bool|array
+   *   mixed true or array of errors
+   */
+  public static function formRule($params, $files, $options) {
+    $errors = array();
+    if (empty($params['body_text']) && empty($params['body_html'])) {
+      $errors['body_text'] = ts("Please provide either HTML or TEXT format for the Body.");
+      $errors['body_html'] = ts("Please provide either HTML or TEXT format for the Body.");
+    }
     return empty($errors) ? TRUE : $errors;
   }
 

--- a/tests/phpunit/WebTest/Mailing/ValidateBodyMailingComponentTest.php
+++ b/tests/phpunit/WebTest/Mailing/ValidateBodyMailingComponentTest.php
@@ -26,9 +26,8 @@
 
 require_once 'CiviTest/CiviSeleniumTestCase.php';
 /**
- * Class WebTest_Mailing_ValidateBodyMailingComponentTest 
+ * Class WebTest_Mailing_ValidateBodyMailingComponentTest
  */
-
 class WebTest_Mailing_ValidateBodyMailingComponentTest extends CiviSeleniumTestCase {
 
   protected function setUp() {
@@ -41,7 +40,7 @@ class WebTest_Mailing_ValidateBodyMailingComponentTest extends CiviSeleniumTestC
     $this->openCiviPage("admin/component", "action=add&reset=1");
 
     // fill component name.
-    $componentName = 'ComponentName_' . substr(sha1(rand()), 0, 7);
+    $componentName = 'ComponentName_' . substr(base_convert(rand(), 10, 36), 0, 7);
     $this->type("name", $componentName);
 
     // fill component type
@@ -68,4 +67,5 @@ class WebTest_Mailing_ValidateBodyMailingComponentTest extends CiviSeleniumTestC
     // Verify the error text.
     $this->assertTrue($this->isElementPresent("xpath=//table/tbody//tr/td[2]/span[text()='{$status}']"), "The row doesn't consists of proper component details");
   }
+
 }

--- a/tests/phpunit/WebTest/Mailing/ValidateBodyMailingComponentTest.php
+++ b/tests/phpunit/WebTest/Mailing/ValidateBodyMailingComponentTest.php
@@ -1,0 +1,71 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2016                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License along with this program; if not, contact CiviCRM LLC       |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+require_once 'CiviTest/CiviSeleniumTestCase.php';
+/**
+ * Class WebTest_Mailing_ValidateBodyMailingComponentTest 
+ */
+
+class WebTest_Mailing_ValidateBodyMailingComponentTest extends CiviSeleniumTestCase {
+
+  protected function setUp() {
+    parent::setUp();
+  }
+
+  public function testWithoutBodyTextAndHTML() {
+    $this->webtestLogin();
+
+    $this->openCiviPage("admin/component", "action=add&reset=1");
+
+    // fill component name.
+    $componentName = 'ComponentName_' . substr(sha1(rand()), 0, 7);
+    $this->type("name", $componentName);
+
+    // fill component type
+    $this->click("component_type");
+    $this->select("component_type", "value=Header");
+
+    // fill subject
+    $subject = "This is subject for New Mailing Component.";
+    $this->type("subject", $subject);
+
+    // fill no text message
+
+    // fill no html message
+
+    $this->click("is_default");
+    // Clicking save.
+    $this->click("_qf_Component_next");
+    $this->waitForPageToLoad($this->getTimeoutMsec());
+
+    // Is status message correct.
+    $status = "Please provide either HTML or TEXT format for the Body.";
+    $this->waitForText('crm-notification-container', $status);
+
+    // Verify the error text.
+    $this->assertTrue($this->isElementPresent("xpath=//table/tbody//tr/td[2]/span[text()='{$status}']"), "The row doesn't consists of proper component details");
+  }
+}


### PR DESCRIPTION
https://issues.civicrm.org/jira/browse/CRM-18560
Body text made optional. Added a validation rule which checks either one of them is filled.
