### PR TITLE
CRM-18656 Advanced search fails to show tagset criteria

### DIFF
--- a/CRM/Contact/Form/Search/Advanced.php
+++ b/CRM/Contact/Form/Search/Advanced.php
@@ -400,7 +400,8 @@ class CRM_Contact_Form_Search_Advanced extends CRM_Contact_Form_Search {
         $tag->retrieve($params, $result);
         $parentId = $result['parent_id'];
         $element = "contact_taglist[$parentId]";
-        if ($this->elementExists($element)) {    // It's a tagset
+        if ($this->elementExists($element)) {
+          // This tag is a tagset
           unset($defaults['contact_tags'][$key]);
           if (!isset($defaults[$element])) {
             $defaults[$element] = array();

--- a/CRM/Contact/Form/Search/Advanced.php
+++ b/CRM/Contact/Form/Search/Advanced.php
@@ -385,6 +385,34 @@ class CRM_Contact_Form_Search_Advanced extends CRM_Contact_Form_Search {
     if ($this->_ssID && empty($_POST)) {
       $defaults = array_merge($defaults, CRM_Contact_BAO_SavedSearch::getFormValues($this->_ssID));
     }
+
+    /*
+     * CRM-18656 - reverse the normalisation of 'contact_taglist' done in
+     * self::normalizeFormValues(). Remove tagset tags from the default
+     * 'contact_tags' and put them in 'contact_taglist[N]' where N is the
+     * id of the tagset.
+     */
+    if (isset($defaults['contact_tags'])) {
+      $tag = new CRM_Core_BAO_Tag();
+      foreach ($defaults['contact_tags'] as $key => $tagId) {
+        $params = array('id' => $tagId);
+        $result = array();
+        $tag->retrieve($params, $result);
+        $parentId = $result['parent_id'];
+        $element = "contact_taglist[$parentId]";
+        if ($this->elementExists($element)) {    // It's a tagset
+          unset($defaults['contact_tags'][$key]);
+          if (!isset($defaults[$element])) {
+            $defaults[$element] = array();
+          }
+          $defaults[$element][] = $tagId;
+        }
+      }
+      if (empty($defaults['contact_tags'])) {
+        unset($defaults['contact_tags']);
+      }
+    }
+
     return $defaults;
   }
 


### PR DESCRIPTION
When editing a saved search, tagset criteria don't show.

This occurs because on the form the tagsets are displayed separately to other tags, while in the saved search they are all stored together. When retrieved from the saved search, the tagset tags need to be separated again.

The function that 'normalises' the tags so they are all stored together in the saved search is CRM_Contact_Form_Search_Advanced::normalizeFormValues(). On the form, normal tags are stored in an element named 'contact_tags' while tagset tags are stored in elements named 'contact_taglist[23]' where '23' is the Id of the tagset. normalizeFormValues() converts them all to parameters with name 'contact_tags' (the queries can use the IN operator on all the tag values: they don't care about tagsets).

What's needed is some code that reverses this. This patch ...
1. Does no harm if the $defaults don't need this processing
2. Looks at each 'contact_tags' default to see if it is a tagset tag
3. If it is, move the 'contact_tags' element to an array like 'contact_taglist[23]'
4. Cleans up the 'contact_tags' array

---
- [CRM-18656: Advanced search fails to show tagset criteria when editing saved search](https://issues.civicrm.org/jira/browse/CRM-18656)
