### PR TITLE
(NFC) bin/regen.sh - Drop-create table `zipcodes`

### DIFF
--- a/bin/regen.sh
+++ b/bin/regen.sh
@@ -39,6 +39,7 @@ echo "SELECT table_name FROM information_schema.TABLES  WHERE TABLE_SCHEMA='${DB
 $MYSQLCMD < civicrm.mysql
 $MYSQLCMD < civicrm_data.mysql
 $MYSQLCMD < civicrm_sample.mysql
+echo "DROP TABLE IF EXISTS zipcodes" | $MYSQLCMD
 $MYSQLCMD < zipcodes.mysql
 php GenerateData.php
 


### PR DESCRIPTION
The original `regen.sh` script drops the table `zipcodes` after creating it.
That works fine in normal execution (when `regen.sh` finishes without
erorr).  But if there is an error, then the table gets left in the DB -- and
creates a conflict when you try re-run `regen.sh`.

This patch does a 'drop-create' so that subsequent runs will work despite a
previous error.
