### PR TITLE
bin/regen.sh - Execute GenerateData.php after initializing other database structures

### DIFF
--- a/bin/regen.sh
+++ b/bin/regen.sh
@@ -41,7 +41,7 @@ $MYSQLCMD < civicrm_data.mysql
 $MYSQLCMD < civicrm_sample.mysql
 echo "DROP TABLE IF EXISTS zipcodes" | $MYSQLCMD
 $MYSQLCMD < zipcodes.mysql
-php GenerateData.php
+env CIVICRM_UF=UnitTests php GenerateData.php
 
 # run the cli script to build the menu and the triggers
 cd $CIVISOURCEDIR

--- a/bin/regen.sh
+++ b/bin/regen.sh
@@ -41,12 +41,13 @@ $MYSQLCMD < civicrm_data.mysql
 $MYSQLCMD < civicrm_sample.mysql
 echo "DROP TABLE IF EXISTS zipcodes" | $MYSQLCMD
 $MYSQLCMD < zipcodes.mysql
-env CIVICRM_UF=UnitTests php GenerateData.php
 
-# run the cli script to build the menu and the triggers
-cd $CIVISOURCEDIR
-"$PHP5PATH"php bin/cli.php -e System -a flush --triggers 1 --session 1
+## For first boot on fresh DB, boot CMS before CRM.
+cms_eval 'civicrm_initialize();'
 
+php GenerateData.php
+
+## Prune local data
 $MYSQLCMD -e "DROP TABLE zipcodes; DROP TABLE IF EXISTS civicrm_install_canary; UPDATE civicrm_domain SET config_backend = NULL; DELETE FROM civicrm_extension; DELETE FROM civicrm_cache; DELETE FROM civicrm_setting;"
 TABLENAMES=$( echo "show tables like 'civicrm_%'" | $MYSQLCMD | grep ^civicrm_ | xargs )
 

--- a/bin/setup.lib.sh
+++ b/bin/setup.lib.sh
@@ -55,3 +55,20 @@ function has_commands() {
   done
   return 0
 }
+
+## Execute some PHP within CMS context
+## usage: cms_eval '<php-code>'
+function cms_eval() {
+  case "$GENCODE_CMS" in
+    Drupal*)
+      drush ev "$1"
+      ;;
+    WordPress*)
+      wp eval "$1"
+      ;;
+    *)
+      echo "Cannot boot (GENCODE_CMS=$GENCODE_CMS)" > /dev/stderr
+      exit 1
+      ;;
+  esac
+}

--- a/sql/GenerateData.php
+++ b/sql/GenerateData.php
@@ -1978,22 +1978,6 @@ AND    a.details = 'Participant Payment'
 
 }
 
-/**
- * @param null $str
- *
- * @return bool
- */
-function user_access($str = NULL) {
-  return TRUE;
-}
-
-/**
- * @return array
- */
-function module_list() {
-  return array();
-}
-
 echo ("Starting data generation on " . date("F dS h:i:s A") . "\n");
 $gcd = new CRM_GCD();
 $gcd->initID();


### PR DESCRIPTION
1. This addresses the error [PHP Fatal error:  Call to undefined function db_query() in /opt/buildkit/build/mytestbuild/sites/all/modules/civicrm/CRM/Utils/System/DrupalBase.php](http://civicrm.stackexchange.com/questions/11972/regen-sh-call-to-undefined-function-db-query/11986#11986).
2.  Generally, the goal here is to produce `civicrm_generated.mysql`, which
   is used on any/all CMS's to initialize the Civi database.  If the generation
   were really dependent on Drupal 7, then we wouldn't be able to use that
   output on other CMS's, right?  Thus I'm hopeful that we can generate
   `civicrm_generated.mysql` with any `CIVICRM_UF`.  And the `UnitTests` UF has
   fewer dependencies/interactions.
3. Since `GenerateData.php` is running in a dummy CMS, we can remove
   these weird mock-drupal-functions.
4. To test, I ran `regen.sh` and compared the output with the old one.
   All the changes looked like random-data (`civicrm_contact`, etal) and
   not structural data (`civicrm_option_value`, etal).
