### PR TITLE
Declaring required as false on timestamp fields causes allow null in …

### DIFF
--- a/xml/schema/ACL/Cache.xml
+++ b/xml/schema/ACL/Cache.xml
@@ -56,6 +56,7 @@
     <name>modified_date</name>
     <title>Cache Modified Date</title>
     <type>timestamp</type>
+    <required>false</required>
     <comment>When was this cache entry last modified</comment>
     <add>1.6</add>
   </field>


### PR DESCRIPTION
…new installs

Really this is kind of a GenCode bug - but this works...
