### PR TITLE
Ignore Components in disabled Extensions - Implementing changes from pull request #8351

### DIFF
--- a/CRM/Core/Component.php
+++ b/CRM/Core/Component.php
@@ -95,7 +95,11 @@ class CRM_Core_Component {
       $cr->find(FALSE);
       while ($cr->fetch()) {
         $infoClass = $cr->namespace . '_' . self::COMPONENT_INFO_CLASS;
-        require_once str_replace('_', DIRECTORY_SEPARATOR, $infoClass) . '.php';
+        $infoClassFile = str_replace('_', DIRECTORY_SEPARATOR, $infoClass) . '.php';
+        if (!CRM_Utils_File::isIncludable($infoClassFile)) {
+          continue;
+        }
+        require_once $infoClassFile;
         $infoObject = new $infoClass($cr->name, $cr->namespace, $cr->id);
         if ($infoObject->info['name'] !== $cr->name) {
           CRM_Core_Error::fatal("There is a discrepancy between name in component registry and in info file ({$cr->name}).");

--- a/CRM/Core/OptionValue.php
+++ b/CRM/Core/OptionValue.php
@@ -62,12 +62,15 @@ class CRM_Core_OptionValue {
    *   Has links like edit, delete, disable ..etc.
    * @param string $orderBy
    *   For orderBy clause.
+   * @param  bool  $skipEmptyComponents
+   *   Whether to skip OptionValue rows with empty Component name
+   *   (i.e. when Extension providing the Component is disabled)
    *
    * @return array
    *   Array of option-values
    *
    */
-  public static function getRows($groupParams, $links, $orderBy = 'weight') {
+  public static function getRows($groupParams, $links, $orderBy = 'weight', $skipEmptyComponents = TRUE) {
     $optionValue = array();
 
     $optionGroupID = NULL;
@@ -115,6 +118,13 @@ class CRM_Core_OptionValue {
     while ($dao->fetch()) {
       $optionValue[$dao->id] = array();
       CRM_Core_DAO::storeValues($dao, $optionValue[$dao->id]);
+      if (!empty($optionValue[$dao->id]['component_id']) &&
+        empty($componentNames[$optionValue[$dao->id]['component_id']]) &&
+        $skipEmptyComponents
+      ) {
+        unset($optionValue[$dao->id]);
+        continue;
+      }
       // form all action links
       $action = array_sum(array_keys($links));
 


### PR DESCRIPTION
@totten @eileenmcnaughton 
I've implemented the changes provided by https://github.com/civicrm/civicrm-core/pull/8351 .

Approach to solve the issue occuring after disabling an extension which contains it's own Component.

**CRM_Core_Component::getComponents()**
Basing on Tim's suggestion (https://gist.github.com/totten/4f038f9c5f661af087bdb96318f3f5d5) - in CRM_Core_Component::getComponents() method there is 'isIncludable()' check added for each Component so we don't include anything that is out of include path (for example any Components which exist inside a disabled Extensions). 
After this change the methods such as getComponents() or getNames() won't return any unreachable Component which I think is our goal (there is no disabled components on Administer -> System Settings -> Enable CiviHR Components too).

**CRM_Core_OptionValue::getRows()**
Second change is done for CRM_Core_OptionValue::getRows() method which now skips all the Option Value rows which point to disabled / non-existent Components. This prevents from listing Activity Types with empty Components.
CRM_Core_OptionValue::getRows() is used in three files:
- CRM/Admin/Page/Options.php
- CRM/Report/Page/Options.php
- CRM/Campaign/Page/SurveyType.php

and all three cases listed above don't cause any unwanted issues by this change (in my opinion). Anyway I've added an optional argument ($skipEmptyComponents) to the method which is currently set to TRUE but we can switch it to FALSE and use TRUE only for Admin page (listing Activity Types) if we want to skip non-existent Components only on Admin Page for some reason.
