### PR TITLE
CRM-18586 - add delete link and fix add more button

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -405,6 +405,7 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup {
         'help_pre',
         'help_post',
         'collapse_display',
+        'style',
         'is_multiple',
         'extends',
         'extends_entity_column_id',
@@ -1837,6 +1838,7 @@ SELECT IF( EXISTS(SELECT name FROM civicrm_contact_type WHERE name like %1), 1, 
       $formattedGroupTree[$key]['help_post'] = CRM_Utils_Array::value('help_post', $value);
       $formattedGroupTree[$key]['collapse_display'] = CRM_Utils_Array::value('collapse_display', $value);
       $formattedGroupTree[$key]['collapse_adv_display'] = CRM_Utils_Array::value('collapse_adv_display', $value);
+      $formattedGroupTree[$key]['style'] = CRM_Utils_Array::value('style', $value);
 
       // this params needed of bulding multiple values
       $formattedGroupTree[$key]['is_multiple'] = CRM_Utils_Array::value('is_multiple', $value);
@@ -1917,6 +1919,7 @@ SELECT IF( EXISTS(SELECT name FROM civicrm_contact_type WHERE name like %1), 1, 
             $details[$groupID][$values['id']]['help_post'] = CRM_Utils_Array::value('help_post', $group);
             $details[$groupID][$values['id']]['collapse_display'] = CRM_Utils_Array::value('collapse_display', $group);
             $details[$groupID][$values['id']]['collapse_adv_display'] = CRM_Utils_Array::value('collapse_adv_display', $group);
+            $details[$groupID][$values['id']]['style'] = CRM_Utils_Array::value('style', $group);
             $details[$groupID][$values['id']]['fields'][$k] = array(
               'field_title' => CRM_Utils_Array::value('label', $properties),
               'field_type' => CRM_Utils_Array::value('html_type', $properties),
@@ -1942,6 +1945,7 @@ SELECT IF( EXISTS(SELECT name FROM civicrm_contact_type WHERE name like %1), 1, 
           $details[$groupID][0]['help_post'] = CRM_Utils_Array::value('help_post', $group);
           $details[$groupID][0]['collapse_display'] = CRM_Utils_Array::value('collapse_display', $group);
           $details[$groupID][0]['collapse_adv_display'] = CRM_Utils_Array::value('collapse_adv_display', $group);
+          $details[$groupID][0]['style'] = CRM_Utils_Array::value('style', $group);
           $details[$groupID][0]['fields'][$k] = array('field_title' => CRM_Utils_Array::value('label', $properties));
         }
       }

--- a/CRM/Custom/Form/CustomDataByType.php
+++ b/CRM/Custom/Form/CustomDataByType.php
@@ -50,6 +50,10 @@ class CRM_Custom_Form_CustomDataByType extends CRM_Core_Form {
     $this->assign('cdType', FALSE);
     $this->assign('cgCount', $this->_groupCount);
 
+    $contactTypes = CRM_Contact_BAO_ContactType::contactTypeInfo();
+    if (array_key_exists($this->_type, $contactTypes)) {
+      $this->assign('contactId', $this->_entityId);
+    }
     if (!is_array($this->_subType) && strstr($this->_subType, CRM_Core_DAO::VALUE_SEPARATOR)) {
       $this->_subType = str_replace(CRM_Core_DAO::VALUE_SEPARATOR, ',', trim($this->_subType, CRM_Core_DAO::VALUE_SEPARATOR));
     }

--- a/templates/CRM/Custom/Form/CustomData.tpl
+++ b/templates/CRM/Custom/Form/CustomData.tpl
@@ -63,13 +63,20 @@
         {/if}
       </div>
     {else}
-     <div class="custom-group custom-group-{$cd_edit.name} crm-accordion-wrapper {if $cd_edit.collapse_display and !$skipTitle}collapsed{/if}">
+     <div class="custom-group custom-group-{$cd_edit.name} crm-accordion-wrapper crm-custom-accordion {if $cd_edit.collapse_display and !$skipTitle}collapsed{/if}">
       {if !$skipTitle}
       <div class="crm-accordion-header">
         {$cd_edit.title}
        </div><!-- /.crm-accordion-header -->
       {/if}
       <div class="crm-accordion-body">
+        {if $cd_edit.is_multiple eq 1 and $cd_edit.table_id and $contactId and !$skipTitle and $cd_edit.style eq 'Inline'}
+          {assign var=tableID value=$cd_edit.table_id}
+          <a href="#" class="crm-hover-button crm-custom-value-del" title="{ts 1=$cd_edit.title}Delete %1{/ts}"
+           data-post='{ldelim}"valueID": "{$tableID}", "groupID": "{$group_id}", "contactId": "{$contactId}", "key": "{crmKey name='civicrm/ajax/customvalue'}"{rdelim}'>
+            <span class="icon delete-icon"></span> {ts}Delete{/ts}
+          </a>
+        {/if}
         {if $cd_edit.help_pre}
           <div class="messages help">{$cd_edit.help_pre}</div>
         {/if}
@@ -91,7 +98,7 @@
           <em>{ts 1=$cd_edit.title}Click "Edit Contact" to add more %1 records{/ts}</em>
         </div>
       {else}
-        <div id="add-more-link-{$cgCount}">
+        <div id="add-more-link-{$cgCount}" class="add-more-link-{$group_id} add-more-link-{$group_id}-{$cgCount}">
           <a href="#" class="crm-hover-button" onclick="CRM.buildCustomData('{$cd_edit.extends}',{if $cd_edit.subtype}'{$cd_edit.subtype}'{else}'{$cd_edit.extends_entity_column_id}'{/if}, '', {$cgCount}, {$group_id}, true ); return false;">
             <i class="crm-i fa-plus-circle"></i>
             {ts 1=$cd_edit.title}Another %1 record{/ts}


### PR DESCRIPTION
https://issues.civicrm.org/jira/browse/CRM-18586

Previously delete link used to get built from [CRM/Contact/Form/Edit/CustomData.tpl](https://github.com/civicrm/civicrm-core/blob/master/templates/CRM/Contact/Form/Edit/CustomData.tpl#L47-L50) as each row was generated by calling the buildQuickForm() of `Contact/Form/Edit/CustomData.php`. Now, as we build this with `CRM.buildCustomData()`, we need to specify delete link for Inline display for Contacts.
