### PR TITLE
CRM-18691 Select2 Height being squashed when defult is blank

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -3537,7 +3537,6 @@ span.crm-status-icon {
 }
 .crm-container.crm-public .select2-container .select2-choice {
   padding: 5px 5px 5px 8px;
-  height: auto;
 }
 .crm-container.crm-public .select2-container-multi .select2-choices {
   padding: 4px;


### PR DESCRIPTION
https://issues.civicrm.org/jira/browse/CRM-18691

If Select2 dropdown is blank by defualt. Height Auto renders it squashed. 
