### PR TITLE
CRM-18660 - Fix custom field year range selection

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -908,7 +908,6 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
           //CRM-18487 - max date should be the last date of the year.
           'maxDate' => isset($maxYear) ? $maxYear . '-12-31' : NULL,
           'time' => $field->time_format ? $field->time_format * 12 : FALSE,
-          'yearRange' => "{$minYear}:{$maxYear}",
         );
         if ($field->is_search_range && $search) {
           $qf->add('datepicker', $elementName . '_from', $label, $attr + array('placeholder' => ts('From')), FALSE, $params);

--- a/js/Common.js
+++ b/js/Common.js
@@ -655,12 +655,15 @@ if (!CRM.vars) CRM.vars = {};
         $dateField = $('<input type="' + type + '">').insertAfter($dataField);
         copyAttributes($dataField, $dateField, ['placeholder', 'style', 'class', 'disabled']);
         $dateField.addClass('crm-form-' + type);
-        settings.minDate = settings.minDate ? CRM.utils.makeDate(settings.minDate) : null;
-        settings.maxDate = settings.maxDate ? CRM.utils.makeDate(settings.maxDate) : null;
         if (hasDatepicker) {
+          settings.minDate = settings.minDate ? CRM.utils.makeDate(settings.minDate) : null;
+          settings.maxDate = settings.maxDate ? CRM.utils.makeDate(settings.maxDate) : null;
           settings.dateFormat = typeof settings.date === 'string' ? settings.date : CRM.config.dateInputFormat;
           settings.changeMonth = _.includes(settings.dateFormat, 'm');
           settings.changeYear = _.includes(settings.dateFormat, 'y');
+          if (!settings.yearRange && settings.minDate !== null && settings.maxDate !== null) {
+            settings.yearRange = '' + CRM.utils.formatDate(settings.minDate, 'yy') + ':' + CRM.utils.formatDate(settings.maxDate, 'yy');
+          }
           $dateField.addClass('crm-form-date').datepicker(settings);
         } else {
           $dateField.attr('min', settings.minDate ? CRM.utils.formatDate(settings.minDate, 'yy') : '1000');


### PR DESCRIPTION
https://issues.civicrm.org/jira/browse/CRM-18660

This fixes the yearRange setting to be the responsibility of the crmDatepicker
widget instead of setting it from php. The php implementation was also buggy.
