### PR TITLE
CRM-18684 add test to demonstrate OrderBy failure

### DIFF
--- a/tests/phpunit/CRM/Utils/TypeTest.php
+++ b/tests/phpunit/CRM/Utils/TypeTest.php
@@ -55,6 +55,7 @@ class CRM_Utils_TypeTest extends CiviUnitTestCase {
       array('asc', 'MysqlOrderByDirection', 'asc'),
       array('DESC', 'MysqlOrderByDirection', 'desc'),
       array('DESCc', 'MysqlOrderByDirection', NULL),
+      array('`contact_a.sort_name` asc, contact_a.id', 'MysqlOrderBy', '`contact_a.sort_name` asc, contact_a.id'),
       array('table.civicrm_column_name desc', 'MysqlOrderBy', 'table.civicrm_column_name desc'),
       array('table.civicrm_column_name desc,other_column, another_column desc', 'MysqlOrderBy', 'table.civicrm_column_name desc,other_column, another_column desc'),
       array('table.`Home-street_address` asc, `table-alias`.`Home-street_address` desc,`table-alias`.column', 'MysqlOrderBy', 'table.`Home-street_address` asc, `table-alias`.`Home-street_address` desc,`table-alias`.column'),

--- a/tests/phpunit/CRM/Utils/TypeTest.php
+++ b/tests/phpunit/CRM/Utils/TypeTest.php
@@ -56,6 +56,7 @@ class CRM_Utils_TypeTest extends CiviUnitTestCase {
       array('DESC', 'MysqlOrderByDirection', 'desc'),
       array('DESCc', 'MysqlOrderByDirection', NULL),
       array('`contact_a.sort_name` asc, contact_a.id', 'MysqlOrderBy', '`contact_a.sort_name` asc, contact_a.id'),
+      array('contact_a.sort_name asc, contact_a.id', 'MysqlOrderBy', 'contact_a.sort_name asc, contact_a.id'),
       array('table.civicrm_column_name desc', 'MysqlOrderBy', 'table.civicrm_column_name desc'),
       array('table.civicrm_column_name desc,other_column, another_column desc', 'MysqlOrderBy', 'table.civicrm_column_name desc,other_column, another_column desc'),
       array('table.`Home-street_address` asc, `table-alias`.`Home-street_address` desc,`table-alias`.column', 'MysqlOrderBy', 'table.`Home-street_address` asc, `table-alias`.`Home-street_address` desc,`table-alias`.column'),


### PR DESCRIPTION
- [CRM-18684: Group Load fails with contact_a.id is not of the type MysqlOrderBy](https://issues.civicrm.org/jira/browse/CRM-18684)
