### PR TITLE
 CRM-18684 fix fatal error by backporting 4.7 hack

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -5807,6 +5807,10 @@ AND   displayRelType.is_active = 1
         else {
           $orderBy = trim($sort->orderBy());
         }
+        // Deliberately remove the backticks again, as they mess up the evil
+        // string munging below. This balanced by re-escaping before use.
+        $orderBy = str_replace('`', '', $orderBy);
+
         if (!empty($orderBy)) {
           // this is special case while searching for
           // change log CRM-1718


### PR DESCRIPTION
- [CRM-18684: Group Load fails with contact_a.id is not of the type MysqlOrderBy](https://issues.civicrm.org/jira/browse/CRM-18684)
