### PR TITLE
CRM_Utils_Check - Suggest using `[cms.root]`, etal

### DIFF
--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -260,6 +260,83 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
   }
 
   /**
+   * Recommend that sites use path-variables for their directories and URLs.
+   * @return array
+   */
+  public function checkUrlVariables() {
+    $messages = array();
+    $hasOldStyle = FALSE;
+    $settingNames = array(
+      'userFrameworkResourceURL',
+      'imageUploadURL',
+      'customCSSURL',
+      'extensionsURL',
+    );
+
+    foreach ($settingNames as $settingName) {
+      $settingValue = Civi::settings()->get($settingName);
+      if (!empty($settingValue) && $settingValue{0} != '[') {
+        $hasOldStyle = TRUE;
+        break;
+      }
+    }
+
+    if ($hasOldStyle) {
+      $message = new CRM_Utils_Check_Message(
+        __FUNCTION__,
+        ts('<a href="%1">Resource URLs</a> may use absolute paths, relative paths, or variables. Absolute paths are more difficult to maintain. To maximize portability, consider using a variable in each URL (eg "<tt>[cms.root]</tt>" or "<tt>[civicrm.files]</tt>").',
+          array(1 => CRM_Utils_System::url('civicrm/admin/setting/url', "reset=1"))),
+        ts('Resource URLs: Make them portable'),
+        \Psr\Log\LogLevel::NOTICE,
+        'fa-server'
+      );
+      $messages[] = $message;
+    }
+
+    return $messages;
+  }
+
+  /**
+   * Recommend that sites use path-variables for their directories and URLs.
+   * @return array
+   */
+  public function checkDirVariables() {
+    $messages = array();
+    $hasOldStyle = FALSE;
+    $settingNames = array(
+      'uploadDir',
+      'imageUploadDir',
+      'customFileUploadDir',
+      'customTemplateDir',
+      'customPHPPathDir',
+      'extensionsDir',
+    );
+
+    foreach ($settingNames as $settingName) {
+      $settingValue = Civi::settings()->get($settingName);
+      if (!empty($settingValue) && $settingValue{0} != '[') {
+        $hasOldStyle = TRUE;
+        break;
+      }
+    }
+
+    if ($hasOldStyle) {
+      $message = new CRM_Utils_Check_Message(
+        __FUNCTION__,
+        ts('<a href="%1">Directories</a> may use absolute paths, relative paths, or variables. Absolute paths are more difficult to maintain. To maximize portability, consider using a variable in each directory (eg "<tt>[cms.root]</tt>" or "<tt>[civicrm.files]</tt>").',
+          array(1 => CRM_Utils_System::url('civicrm/admin/setting/path', "reset=1"))),
+        ts('Directory Paths: Make them portable'),
+        \Psr\Log\LogLevel::NOTICE,
+        'fa-server'
+      );
+      $messages[] = $message;
+    }
+
+    return $messages;
+  }
+
+
+  /**
    * Checks if new versions are available
    * @return array
    */


### PR DESCRIPTION
In "Admin => Resource URLs" and "Admin => Directories", sites may have a
confusing mix of absolute and relative paths, especially if they originated
in <=v4.6.  This complicates migrations (e.g.  moving to a new server or
syncing with a dev/staging system).  In 4.7+, we can use more portable path
variables.

This is a soft suggestion (NOTICE) and not a validation error or warning.
There are obscure scenarios where one would want to use absolute addresses;
but for most sites, it's an extraneous maintenance cost.
