### PR TITLE
CRM-18683 smart group caching fixes (CRM-18683 CRM-18692 CRM-18695)

### DIFF
--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -211,17 +211,6 @@ AND    g.refresh_date IS NULL
   }
 
   /**
-   * Fill the group contact cache if it is empty.
-   *
-   * Do this by the expensive operation of loading all groups. Call sparingly.
-   */
-  public static function fillIfEmpty() {
-    if (!CRM_Core_DAO::singleValueQuery("SELECT COUNT(id) FROM civicrm_group_contact_cache")) {
-      self::loadAll();
-    }
-  }
-
-  /**
    * Build the smart group cache for a given group.
    *
    * @param int $groupID

--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -354,7 +354,7 @@ WHERE  id IN ( $groupIDs )
     if (!isset($groupID)) {
       if ($smartGroupCacheTimeout == 0) {
         $query = "
-TRUNCATE civicrm_group_contact_cache
+DELETE FROM civicrm_group_contact_cache
 ";
         $update = "
 UPDATE civicrm_group g

--- a/CRM/Group/Page/Group.php
+++ b/CRM/Group/Page/Group.php
@@ -143,8 +143,8 @@ class CRM_Group_Page_Group extends CRM_Core_Page_Basic {
     if (!empty($_GET['update_smart_groups'])) {
       CRM_Contact_BAO_GroupContactCache::loadAll();
     }
-    else {
-      CRM_Contact_BAO_GroupContactCache::fillIfEmpty();
+    elseif (!CRM_Core_DAO::singleValueQuery("SELECT id FROM civicrm_group_contact_cache LIMIT 1")) {
+      CRM_Core_Session::setStatus(ts('Count data for smart groups is not currently calculated. You may click Update Smart Groups to generate it. Be aware this can cause significant server load'));
     }
 
     $this->search();


### PR DESCRIPTION
- [CRM-18683: Smart group refresh  locks issue on 4.7.8rc](https://issues.civicrm.org/jira/browse/CRM-18683)
  - [CRM-18692: Don't fill the entire smart group cache if someone goes to 'Manage Groups' and the cache is empty](https://issues.civicrm.org/jira/browse/CRM-18692)
  - [CRM-18695: Don't break roll back when clearing caches if smartgroup timeout is 0](https://issues.civicrm.org/jira/browse/CRM-18695)
