### PR TITLE
CRM-18683 fix handling on UTC time in smart groups

### DIFF
--- a/CRM/ACL/BAO/Cache.php
+++ b/CRM/ACL/BAO/Cache.php
@@ -147,17 +147,14 @@ WHERE contact_id = %1
     // reset any static caching
     self::$_cache = NULL;
 
-    // reset any db caching
-    $config = CRM_Core_Config::singleton();
-    $smartGroupCacheTimeout = CRM_Contact_BAO_GroupContactCache::smartGroupCacheTimeout();
-
     $query = "
 DELETE
 FROM   civicrm_acl_cache
 WHERE  modified_date IS NULL
-   OR  (TIMESTAMPDIFF(MINUTE, modified_date, NOW()) >= $smartGroupCacheTimeout)
+   OR  (modified_date <= %1)
 ";
-    CRM_Core_DAO::singleValueQuery($query);
+    $params = array(1 => array(CRM_Contact_BAO_GroupContactCache::getCacheInvalidDateTime(), 'String'));
+    CRM_Core_DAO::singleValueQuery($query, $params);
 
     // CRM_Core_DAO::singleValueQuery("TRUNCATE TABLE civicrm_acl_contact_cache"); // No, force-commits transaction
     // CRM_Core_DAO::singleValueQuery("DELETE FROM civicrm_acl_contact_cache"); // Transaction-safe

--- a/CRM/ACL/BAO/Cache.php
+++ b/CRM/ACL/BAO/Cache.php
@@ -151,14 +151,11 @@ WHERE contact_id = %1
     $config = CRM_Core_Config::singleton();
     $smartGroupCacheTimeout = CRM_Contact_BAO_GroupContactCache::smartGroupCacheTimeout();
 
-    //make sure to give original timezone settings again.
-    $now = CRM_Utils_Date::getUTCTime();
-
     $query = "
 DELETE
 FROM   civicrm_acl_cache
 WHERE  modified_date IS NULL
-   OR  (TIMESTAMPDIFF(MINUTE, modified_date, $now) >= $smartGroupCacheTimeout)
+   OR  (TIMESTAMPDIFF(MINUTE, modified_date, NOW()) >= $smartGroupCacheTimeout)
 ";
     CRM_Core_DAO::singleValueQuery($query);
 

--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -69,7 +69,6 @@ class CRM_Contact_BAO_GroupContactCache extends CRM_Contact_DAO_GroupContactCach
    */
   public static function groupRefreshedClause($groupIDClause = NULL, $includeHiddenGroups = FALSE) {
     $smartGroupCacheTimeout = self::smartGroupCacheTimeout();
-    $now = CRM_Utils_Date::getUTCTime();
 
     $query = "
 SELECT  g.id
@@ -77,8 +76,8 @@ FROM    civicrm_group g
 WHERE   ( g.saved_search_id IS NOT NULL OR g.children IS NOT NULL )
 AND     g.is_active = 1
 AND     ( g.cache_date IS NULL OR
-          ( TIMESTAMPDIFF(MINUTE, g.cache_date, $now) >= $smartGroupCacheTimeout ) OR
-          ( $now >= g.refresh_date )
+          ( TIMESTAMPDIFF(MINUTE, g.cache_date, NOW()) >= $smartGroupCacheTimeout ) OR
+          ( NOW() >= g.refresh_date )
         )
 ";
 
@@ -178,7 +177,7 @@ AND     ( g.cache_date IS NULL OR
 
     if (!empty($refreshGroupIDs)) {
       $refreshGroupIDString = CRM_Core_DAO::escapeString(implode(', ', $refreshGroupIDs));
-      $time = CRM_Utils_Date::getUTCTime(self::smartGroupCacheTimeout() * 60);
+      $time = self::getRefreshDateTime();
       $query = "
 UPDATE civicrm_group g
 SET    g.refresh_date = $time
@@ -267,7 +266,7 @@ AND    g.refresh_date IS NULL
     if ($processed) {
       // also update the group with cache date information
       //make sure to give original timezone settings again.
-      $now = CRM_Utils_Date::getUTCTime();
+      $now = date('YmdHis');
       $refresh = 'null';
     }
     else {
@@ -332,8 +331,7 @@ WHERE  id IN ( $groupIDs )
     $params = array();
     $smartGroupCacheTimeout = self::smartGroupCacheTimeout();
 
-    $now = CRM_Utils_Date::getUTCTime();
-    $refreshTime = CRM_Utils_Date::getUTCTime($smartGroupCacheTimeout * 60);
+    $refreshTime = self::getRefreshDateTime();
 
     if (!isset($groupID)) {
       if ($smartGroupCacheTimeout == 0) {
@@ -703,6 +701,17 @@ ORDER BY   gc.contact_id, g.children
     else {
       return $contactGroup;
     }
+  }
+
+  /**
+   * Get the date when the cache should be refreshed from.
+   *
+   * Ie. now + the offset & we will delete anything prior to then.
+   *
+   * @return string
+   */
+  protected static function getRefreshDateTime() {
+    return date('Ymdhis', strtotime("+ " . self::smartGroupCacheTimeout() . " Minutes"));
   }
 
 }

--- a/CRM/Upgrade/Incremental/sql/4.6.18.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.6.18.mysql.tpl
@@ -1,1 +1,4 @@
 {* file to handle db changes in 4.6.18 during upgrade *}
+-- CRM-18516 Convert the date fields relating to group caching and acl caching timestamp
+ALTER TABLE civicrm_group CHANGE cache_date cache_date timestamp NULL DEFAULT NULL , CHANGE refresh_date refresh_date timestamp NULL DEFAULT NULL;
+ALTER TABLE civicrm_acl_cache CHANGE modified_date modified_date timestamp NULL DEFAULT NULL;

--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -1786,25 +1786,6 @@ class CRM_Utils_Date {
   }
 
   /**
-   * Get the time in UTC for the current time. You can optionally send an offset from the current time if needed
-   *
-   * @param int $offset
-   *   the offset from the current time in seconds.
-   *
-   * @return string
-   *   the time in UTC
-   */
-  public static function getUTCTime($offset = 0) {
-    $originalTimezone = date_default_timezone_get();
-    date_default_timezone_set('UTC');
-    $time = time() + $offset;
-    $now = date('YmdHis', $time);
-    date_default_timezone_set($originalTimezone);
-    return $now;
-  }
-
-
-  /**
    * @param $date
    * @param $dateType
    *

--- a/xml/schema/ACL/Cache.xml
+++ b/xml/schema/ACL/Cache.xml
@@ -51,7 +51,9 @@
   </index>
   <field>
     <name>modified_date</name>
-    <type>date</type>
+    <title>Cache Modified Date</title>
+    <type>timestamp</type>
+    <required>false</required>
     <comment>When was this cache entry last modified</comment>
     <add>1.6</add>
   </field>

--- a/xml/schema/Contact/Group.xml
+++ b/xml/schema/Contact/Group.xml
@@ -123,14 +123,14 @@
   </field>
   <field>
     <name>cache_date</name>
-    <type>datetime</type>
+    <type>timestamp</type>
     <title>Group Cache Date</title>
     <comment>Date when we created the cache for a smart group</comment>
     <add>2.1</add>
   </field>
   <field>
     <name>refresh_date</name>
-    <type>datetime</type>
+    <type>timestamp</type>
     <title>Next Group Refresh Time</title>
     <comment>Date and time when we need to refresh the cache next.</comment>
     <add>4.3</add>

--- a/xml/schema/Contact/Group.xml
+++ b/xml/schema/Contact/Group.xml
@@ -125,6 +125,7 @@
     <name>cache_date</name>
     <type>timestamp</type>
     <title>Group Cache Date</title>
+    <required>false</required>
     <comment>Date when we created the cache for a smart group</comment>
     <add>2.1</add>
   </field>
@@ -132,6 +133,7 @@
     <name>refresh_date</name>
     <type>timestamp</type>
     <title>Next Group Refresh Time</title>
+    <required>false</required>
     <comment>Date and time when we need to refresh the cache next.</comment>
     <add>4.3</add>
   </field>


### PR DESCRIPTION
This ports back 4.7 code to 4.6 after identifying an earlier 4.6 fix munges UTC with site date

https://issues.civicrm.org/jira/browse/CRM-18683

Note that the upgrade script patch is a place holder - I will update it to 4.6.18 once 4.6.17 has been cut
