### PR TITLE
Make it possible to create new batch ExportFormats in an extension

### DIFF
--- a/CRM/Batch/BAO/Batch.php
+++ b/CRM/Batch/BAO/Batch.php
@@ -593,21 +593,10 @@ class CRM_Batch_BAO_Batch extends CRM_Batch_DAO_Batch {
     else {
       CRM_Core_Error::fatal("Could not locate exporter: $exporterClass");
     }
-    switch (self::$_exportFormat) {
-      case 'CSV':
-        foreach ($batchIds as $batchId) {
-          $export[$batchId] = $exporter->generateExportQuery($batchId);
-        }
-        $exporter->makeCSV($export);
-        break;
-
-      case 'IIF':
-        foreach ($batchIds as $batchId) {
-          $export[$batchId] = $exporter->generateExportQuery($batchId);
-        }
-        $exporter->makeIIF($export);
-        break;
+    foreach ($batchIds as $batchId) {
+      $export[$batchId] = $exporter->generateExportQuery($batchId);
     }
+    $exporter->makeExport($export);
   }
 
   /**

--- a/CRM/Financial/BAO/ExportFormat.php
+++ b/CRM/Financial/BAO/ExportFormat.php
@@ -71,21 +71,13 @@ abstract class CRM_Financial_BAO_ExportFormat {
   }
 
   /**
-   * @param null $fileName
+   * Exports sbatches in $this->_batchIds, and saves to file.
+   * 
+   * @param string $fileName - use this file name (if applicable)
    */
   public function output($fileName = NULL) {
-    switch ($this->getFileExtension()) {
-      case 'csv':
-        self::createActivityExport($this->_batchIds, $fileName);
-        break;
-
-      case 'iif':
-        $tplFile = $this->getHookedTemplateFileName();
-        $out = self::getTemplate()->fetch($tplFile);
-        $fileName = $this->putFile($out);
-        self::createActivityExport($this->_batchIds, $fileName);
-        break;
-    }
+    // Default behaviour, override if needed:
+    self::createActivityExport($this->_batchIds, $fileName);
   }
 
   /**

--- a/CRM/Financial/BAO/ExportFormat.php
+++ b/CRM/Financial/BAO/ExportFormat.php
@@ -95,11 +95,14 @@ abstract class CRM_Financial_BAO_ExportFormat {
   }
 
   /**
+   * Returns some kind of identification for your export format.
+   *
+   * This does not really has to be a file extension, you can name your
+   * file as you wish as you override output.
+   *
    * @return string
    */
-  public function getFileExtension() {
-    return 'txt';
-  }
+  public abstract function getFileExtension();
 
   /**
    * @return object

--- a/CRM/Financial/BAO/ExportFormat.php
+++ b/CRM/Financial/BAO/ExportFormat.php
@@ -72,7 +72,7 @@ abstract class CRM_Financial_BAO_ExportFormat {
 
   /**
    * Exports sbatches in $this->_batchIds, and saves to file.
-   * 
+   *
    * @param string $fileName - use this file name (if applicable)
    */
   public function output($fileName = NULL) {

--- a/CRM/Financial/BAO/ExportFormat.php
+++ b/CRM/Financial/BAO/ExportFormat.php
@@ -36,7 +36,7 @@
  * Create a subclass for a specific format.
  * @see http://wiki.civicrm.org/confluence/display/CRM/CiviAccounts+Specifications+-++Batches#CiviAccountsSpecifications-Batches-%C2%A0Overviewofimplementation
  */
-class CRM_Financial_BAO_ExportFormat {
+abstract class CRM_Financial_BAO_ExportFormat {
 
   /**
    * data which the individual export formats will output in the desired format.
@@ -87,6 +87,13 @@ class CRM_Financial_BAO_ExportFormat {
         break;
     }
   }
+
+  /**
+   * Abstract function that generates exports, and downloads them as zip file.
+   *
+   * @param $exportDaos array with DAO's for queries to be exported.
+   */
+  public abstract function makeExport($exportDaos);
 
   /**
    * @return string

--- a/CRM/Financial/BAO/ExportFormat/CSV.php
+++ b/CRM/Financial/BAO/ExportFormat/CSV.php
@@ -172,7 +172,7 @@ class CRM_Financial_BAO_ExportFormat_CSV extends CRM_Financial_BAO_ExportFormat 
    *
    * @param array $export
    */
-  public function makeCSV($export) {
+  public function makeExport($export) {
     // getting data from admin page
     $prefixValue = Civi::settings()->get('contribution_invoice_settings');
 

--- a/CRM/Financial/BAO/ExportFormat/IIF.php
+++ b/CRM/Financial/BAO/ExportFormat/IIF.php
@@ -150,7 +150,7 @@ class CRM_Financial_BAO_ExportFormat_IIF extends CRM_Financial_BAO_ExportFormat 
   /**
    * @param $export
    */
-  public function makeIIF($export) {
+  public function makeExport($export) {
     // Keep running list of accounts and contacts used in this batch, since we need to
     // include those in the output. Only want to include ones used in the batch, not everything in the db,
     // since would increase the chance of messing up user's existing Quickbooks entries.

--- a/CRM/Financial/BAO/ExportFormat/IIF.php
+++ b/CRM/Financial/BAO/ExportFormat/IIF.php
@@ -79,6 +79,16 @@ class CRM_Financial_BAO_ExportFormat_IIF extends CRM_Financial_BAO_ExportFormat 
   }
 
   /**
+   * @param null $fileName
+   */
+  public function output($fileName = NULL) {
+    $tplFile = $this->getHookedTemplateFileName();
+    $out = self::getTemplate()->fetch($tplFile);
+    $fileName = $this->putFile($out);
+    self::createActivityExport($this->_batchIds, $fileName);
+  }
+
+  /**
    * @param $out
    *
    * @return string


### PR DESCRIPTION
This fixes CRM-18697. I made ExportFormat abstract, and moved implementation-specific code to the deriving classes. If you're interested, I can provide documentation about how this can work.

---
- [CRM-18697: Make it possible to add new ExportFormats via extensions](https://issues.civicrm.org/jira/browse/CRM-18697)
