### PR TITLE
CRM-10230 Custom fields text type with limited length not validated

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -834,6 +834,12 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
           $qf->add('text', $elementName . '_to', ts('To'), $field->attributes);
         }
         else {
+          if ($field->text_length) {
+            $field->attributes .= ' maxlength=' . $field->text_length;
+            if ($field->text_length < 20) {
+              $field->attributes .= ' size=' . $field->text_length;
+            }
+          }
           $element = &$qf->add('text', $elementName, $label,
             $field->attributes,
             $useRequired && !$search


### PR DESCRIPTION
- [CRM-10230: Custom fields with limited length not validated](https://issues.civicrm.org/jira/browse/CRM-10230)
