### PR TITLE
CRM-16355 - reminders in multilingual sites fix

### DIFF
--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -425,8 +425,12 @@ FROM civicrm_action_schedule cas
    * @param $preferred_language
    */
   public static function setCommunicationLanguage($communication_language, $preferred_language) {
-    $config = CRM_Core_Config::singleton();
-    $language = $config->lcMessages;
+    $i18n = CRM_Core_I18n::singleton();
+
+    // FIXME: convert to getLocale when https://issues.civicrm.org/jira/browse/CRM-18362 is fixed
+    global $tsLocale;
+    $currentLocale = $tsLocale;
+    $language = $currentLocale;
 
     // prepare the language for the email
     if ($communication_language == CRM_Core_I18n::AUTO) {
@@ -440,13 +444,12 @@ FROM civicrm_action_schedule cas
 
     // language not in the existing language, use default
     $languages = CRM_Core_I18n::languages(TRUE);
-    if (!in_array($language, $languages)) {
-      $language = $config->lcMessages;
+    if (!array_key_exists($language, $languages)) {
+      $language = $currentLocale;
     }
 
     // change the language
-    $i18n = CRM_Core_I18n::singleton();
-    $i18n->setLanguage($language);
+    $i18n->setLocale($language);
   }
 
   /**

--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -427,9 +427,7 @@ FROM civicrm_action_schedule cas
   public static function setCommunicationLanguage($communication_language, $preferred_language) {
     $i18n = CRM_Core_I18n::singleton();
 
-    // FIXME: convert to getLocale when https://issues.civicrm.org/jira/browse/CRM-18362 is fixed
-    global $tsLocale;
-    $currentLocale = $tsLocale;
+    $currentLocale = CRM_Core_I18n::getLocale();
     $language = $currentLocale;
 
     // prepare the language for the email

--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -425,8 +425,6 @@ FROM civicrm_action_schedule cas
    * @param $preferred_language
    */
   public static function setCommunicationLanguage($communication_language, $preferred_language) {
-    $i18n = CRM_Core_I18n::singleton();
-
     $currentLocale = CRM_Core_I18n::getLocale();
     $language = $currentLocale;
 

--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -445,6 +445,7 @@ FROM civicrm_action_schedule cas
     }
 
     // change the language
+    $i18n = CRM_Core_I18n::singleton();
     $i18n->setLocale($language);
   }
 

--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -78,41 +78,12 @@ class CRM_Core_I18n {
         // Note: the file hierarchy for .po must be, for example: l10n/fr_FR/LC_MESSAGES/civicrm.mo
 
         $this->_nativegettext = TRUE;
-
-        $locale .= '.utf8';
-        putenv("LANG=$locale");
-
-        // CRM-11833 Avoid LC_ALL because of LC_NUMERIC and potential DB error.
-        setlocale(LC_TIME, $locale);
-        setlocale(LC_MESSAGES, $locale);
-        setlocale(LC_CTYPE, $locale);
-
-        bindtextdomain('civicrm', CRM_Core_I18n::getResourceDir());
-        bind_textdomain_codeset('civicrm', 'UTF-8');
-        textdomain('civicrm');
-
-        $this->_phpgettext = new CRM_Core_I18n_NativeGettext();
-        $this->_extensioncache['civicrm'] = 'civicrm';
+        $this->setNativeGettextLocale($locale);
         return;
       }
 
       // Otherwise, use PHP-gettext
-      // we support both the old file hierarchy format and the new:
-      // pre-4.5:  civicrm/l10n/xx_XX/civicrm.mo
-      // post-4.5: civicrm/l10n/xx_XX/LC_MESSAGES/civicrm.mo
-      require_once 'PHPgettext/streams.php';
-      require_once 'PHPgettext/gettext.php';
-
-      $mo_file = CRM_Core_I18n::getResourceDir() . $locale . DIRECTORY_SEPARATOR . 'LC_MESSAGES' . DIRECTORY_SEPARATOR . 'civicrm.mo';
-
-      if (!file_exists($mo_file)) {
-        // fallback to pre-4.5 mode
-        $mo_file = CRM_Core_I18n::getResourceDir() . $locale . DIRECTORY_SEPARATOR . 'civicrm.mo';
-      }
-
-      $streamer = new FileReader($mo_file);
-      $this->_phpgettext = new gettext_reader($streamer);
-      $this->_extensioncache['civicrm'] = $this->_phpgettext;
+      $this->setPhpGettextLocale($locale);
     }
   }
 
@@ -125,6 +96,48 @@ class CRM_Core_I18n {
   public function isNative() {
     return $this->_nativegettext;
   }
+
+
+  protected function setNativeGettextLocale($locale) {
+
+    $locale .= '.utf8';
+    putenv("LANG=$locale");
+
+    // CRM-11833 Avoid LC_ALL because of LC_NUMERIC and potential DB error.
+    setlocale(LC_TIME, $locale);
+    setlocale(LC_MESSAGES, $locale);
+    setlocale(LC_CTYPE, $locale);
+
+    bindtextdomain('civicrm', CRM_Core_I18n::getResourceDir());
+    bind_textdomain_codeset('civicrm', 'UTF-8');
+    textdomain('civicrm');
+
+    $this->_phpgettext = new CRM_Core_I18n_NativeGettext();
+    $this->_extensioncache['civicrm'] = 'civicrm';
+
+  }
+
+  protected function setPhpGettextLocale($locale) {
+
+    // we support both the old file hierarchy format and the new:
+    // pre-4.5:  civicrm/l10n/xx_XX/civicrm.mo
+    // post-4.5: civicrm/l10n/xx_XX/LC_MESSAGES/civicrm.mo
+    require_once 'PHPgettext/streams.php';
+    require_once 'PHPgettext/gettext.php';
+
+    $mo_file = CRM_Core_I18n::getResourceDir() . $locale . DIRECTORY_SEPARATOR . 'LC_MESSAGES' . DIRECTORY_SEPARATOR . 'civicrm.mo';
+
+    if (!file_exists($mo_file)) {
+      // fallback to pre-4.5 mode
+      $mo_file = CRM_Core_I18n::getResourceDir() . $locale . DIRECTORY_SEPARATOR . 'civicrm.mo';
+    }
+
+    $streamer = new FileReader($mo_file);
+    $this->_phpgettext = new gettext_reader($streamer);
+    $this->_extensioncache['civicrm'] = $this->_phpgettext;
+
+  }
+
 
   /**
    * Return languages available in this instance of CiviCRM.
@@ -563,53 +576,27 @@ class CRM_Core_I18n {
   /**
    * Change the processing language without changing the current user language
    *
-   * @param $language
-   *   Language (for example 'en_US', or 'fr_CA').
+   * @param $locale
+   *   Locale (for example 'en_US', or 'fr_CA').
    *   True if the domain was changed for an extension.
    */
-  public function setLocale($language) {
-
-    $config = CRM_Core_Config::singleton();
+  public function setLocale($locale) {
 
     // Change the language of the CMS as well, for URLs.
-    CRM_Utils_System::setUFLocale($language);
+    CRM_Utils_System::setUFLocale($locale);
 
     // change the gettext ressources
     if ($this->_nativegettext) {
-      $locale = $language . '.utf8';
-      putenv("LANG=$locale");
-
-      setlocale(LC_TIME, $locale);
-      setlocale(LC_MESSAGES, $locale);
-      setlocale(LC_CTYPE, $locale);
-
-      bindtextdomain('civicrm', CRM_Core_I18n::getResourceDir());
-      bind_textdomain_codeset('civicrm', 'UTF-8');
-      textdomain('civicrm');
-
-      $this->_phpgettext = new CRM_Core_I18n_NativeGettext();
-      $this->_extensioncache['civicrm'] = 'civicrm';
+      $this->setNativeGettextLocale($locale);
     }
     else {
       // phpgettext
-      require_once 'PHPgettext/streams.php';
-      require_once 'PHPgettext/gettext.php';
-
-      $mo_file = CRM_Core_I18n::getResourceDir() . $locale . DIRECTORY_SEPARATOR . 'LC_MESSAGES' . DIRECTORY_SEPARATOR . 'civicrm.mo';
-      if (!file_exists($mo_file)) {
-        // fallback to pre-4.5 mode
-        $mo_file = CRM_Core_I18n::getResourceDir() . $locale . DIRECTORY_SEPARATOR . 'civicrm.mo';
-      }
-
-      $streamer = new FileReader($mo_file);
-      $this->_phpgettext = new gettext_reader($streamer);
-      $this->_extensioncache['civicrm'] = $this->_phpgettext;
-
+      $this->setPhpGettextLocale($locale);
     }
 
     // for sql queries
     global $dbLocale;
-    $dbLocale = "_{$language}";
+    $dbLocale = "_{$locale}";
 
   }
 

--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -583,7 +583,7 @@ class CRM_Core_I18n {
       setlocale(LC_MESSAGES, $locale);
       setlocale(LC_CTYPE, $locale);
 
-      bindtextdomain('civicrm', $config->gettextResourceDir);
+      bindtextdomain('civicrm', CRM_Core_I18n::getResourceDir());
       bind_textdomain_codeset('civicrm', 'UTF-8');
       textdomain('civicrm');
 
@@ -595,7 +595,11 @@ class CRM_Core_I18n {
       require_once 'PHPgettext/streams.php';
       require_once 'PHPgettext/gettext.php';
 
-      $mo_file = $config->gettextResourceDir . $language . DIRECTORY_SEPARATOR . 'LC_MESSAGES' . DIRECTORY_SEPARATOR . 'civicrm.mo';
+      $mo_file = CRM_Core_I18n::getResourceDir() . $locale . DIRECTORY_SEPARATOR . 'LC_MESSAGES' . DIRECTORY_SEPARATOR . 'civicrm.mo';
+      if (!file_exists($mo_file)) {
+        // fallback to pre-4.5 mode
+        $mo_file = CRM_Core_I18n::getResourceDir() . $locale . DIRECTORY_SEPARATOR . 'civicrm.mo';
+      }
 
       $streamer = new FileReader($mo_file);
       $this->_phpgettext = new gettext_reader($streamer);


### PR DESCRIPTION
- [CRM-16355: Reminders in multilingual sites: allow to define the language of the sending](https://issues.civicrm.org/jira/browse/CRM-16355)
