### PR TITLE
CRM-18699 Fixed Wake Island spelling

### DIFF
--- a/CRM/Upgrade/Incremental/sql/4.7.8.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.7.8.mysql.tpl
@@ -13,5 +13,3 @@ DELETE FROM civicrm_state_province WHERE name = 'Fernando de Noronha';
 -- CRM-17118 extend civicrm_address postal_code to accept full data strings from paypal etc.
 ALTER TABLE civicrm_address CHANGE `postal_code` `postal_code` varchar(64) ;
 
--- CRM-18699 Fix Wake Island misspelling, was Wake Ialand
-UPDATE civicrm_state_province SET name="Wake Island" WHERE id=4981;

--- a/CRM/Upgrade/Incremental/sql/4.7.8.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.7.8.mysql.tpl
@@ -13,3 +13,5 @@ DELETE FROM civicrm_state_province WHERE name = 'Fernando de Noronha';
 -- CRM-17118 extend civicrm_address postal_code to accept full data strings from paypal etc.
 ALTER TABLE civicrm_address CHANGE `postal_code` `postal_code` varchar(64) ;
 
+-- CRM-18699 Fix Wake Island misspelling, was Wake Ialand
+UPDATE civicrm_state_province SET name="Wake Island" WHERE id=4981;

--- a/CRM/Upgrade/Incremental/sql/4.7.9.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.7.9.mysql.tpl
@@ -6,3 +6,6 @@ UPDATE civicrm_option_value SET
   {localize field="label"}label = '{ts escape="sql"}Print/Merge Document{/ts}'{/localize},
   {localize field="description"}description = '{ts escape="sql"}Export letters and other printable documents.{/ts}'{/localize}
 WHERE name = 'Print PDF Letter' AND option_group_id = @option_group_id_act;
+
+-- CRM-18699 Fix Wake Island misspelling, was Wake Ialand
+UPDATE civicrm_state_province SET name="Wake Island" WHERE name="Wake Ialand";

--- a/xml/templates/civicrm_state_province.tpl
+++ b/xml/templates/civicrm_state_province.tpl
@@ -3430,7 +3430,7 @@ INSERT INTO civicrm_state_province (id, country_id, abbreviation, name) VALUES
 (4978, 1227, "71", "Midway Islands"),
 (4979, 1227, "76", "Navassa Island"),
 (4980, 1227, "95", "Palmyra Atoll"),
-(4981, 1227, "79", "Wake Ialand"),
+(4981, 1227, "79", "Wake Island"),
 (4982, 1229, "AR", "Artigsa"),
 (4983, 1229, "CA", "Canelones"),
 (4984, 1229, "CL", "Cerro Largo"),


### PR DESCRIPTION
Found a misspelling, made changes based on other DB changes.

---
- [CRM-18699: Wake Island is misspelled](https://issues.civicrm.org/jira/browse/CRM-18699)
