### PR TITLE
CRM-18713: ensure SMS activities are sent to all contacts

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1431,7 +1431,7 @@ LEFT JOIN civicrm_activity_contact src ON (src.activity_id = ac.activity_id AND 
 
     // get token details for contacts, call only if tokens are used
     $details = array();
-    if (!empty($returnProperties) || !empty($tokens)) {
+    if (!empty($returnProperties) && !empty($tokens)) {
       list($details) = CRM_Utils_Token::getTokenDetails($contactIds,
         $returnProperties,
         NULL, NULL, FALSE,


### PR DESCRIPTION
Only try to fill in details if we have tokens to replace. Otherwise
our array gets populated with all data for the contact and the mobile
number carefully chosen is lost.

https://issues.civicrm.org/jira/browse/CRM-18713
