### PR TITLE
CRM-18708: subtype custom field import issue

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -1139,7 +1139,22 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
     if (empty($params['contact_type'])) {
       $params['contact_type'] = 'Individual';
     }
-    $customFields = CRM_Core_BAO_CustomField::getFields($params['contact_type'], FALSE, FALSE, $csType);
+
+    // get array of subtypes - CRM-18708
+    if(in_array($csType, array('Individual', 'Organization', 'Household'))) {
+      $csType = self::getSubtypes($params['contact_type']);
+    }
+
+    if(is_array($csType)) {
+      // fetch custom fields for every subtype and add it to $customFields array
+      // CRM-18708
+      $customFields = array();
+      foreach($csType as $cType) {
+        $customFields += CRM_Core_BAO_CustomField::getFields($params['contact_type'], FALSE, FALSE, $cType);
+      }
+    }else {
+      $customFields = CRM_Core_BAO_CustomField::getFields($params['contact_type'], FALSE, FALSE, $csType);
+    }
 
     $addressCustomFields = CRM_Core_BAO_CustomField::getFields('Address');
     $customFields = $customFields + $addressCustomFields;
@@ -2140,6 +2155,24 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
     }
 
     return $allowToCreate;
+  }
+
+  /**
+   * get subtypes given the contact type
+   *
+   * @param string $contactType
+   * @return array $subTypes
+   */
+  public static function getSubtypes($contactType) {
+    $subTypes = array();
+    $types = CRM_Contact_BAO_ContactType::subTypeInfo($contactType);
+
+    if (count($types) > 0) {
+      foreach ($types as $type) {
+        $subTypes[] = $type['name'];
+      }
+    }
+    return $subTypes;
   }
 
 }


### PR DESCRIPTION
**Issue:**
When you have custom field set that is used for a specific contact type, you can't use /civicrm/import/custom (You should be able to reproduce this problem in demo site d46.demo.civicrm.org/ also.) 

**Reason:**
`$customFields` array only had fields related to main contact types (Individual, Household, organization).

**Solution:**
1. Fetch subtypes
2. Fetch subtype specific custom fields for each subtype
3. Add those custom fields to `$customFields` array.

---
- [CRM-18708: Unable to import multi-value custom field ](https://issues.civicrm.org/jira/browse/CRM-18708)
