### PR TITLE
CRM-17619 add space before numeric suffix

### DIFF
--- a/CRM/Contact/Form/Edit/Address.php
+++ b/CRM/Contact/Form/Edit/Address.php
@@ -370,7 +370,7 @@ class CRM_Contact_Form_Edit_Address {
             if ($thesuffix) {
               if (ctype_digit(substr($thesuffix, 0, 1))) {
                 $address['street_number'] .= " ";
-             }
+              }
             }
             $address['street_number'] .= $thesuffix;
           }

--- a/CRM/Contact/Form/Edit/Address.php
+++ b/CRM/Contact/Form/Edit/Address.php
@@ -355,7 +355,7 @@ class CRM_Contact_Form_Edit_Address {
               $streetAddress .= ' ';
             }
             // CRM-17619 - if the street number suffix begins with a number, add a space
-            if (ctype_digit(substr(CRM_Utils_Array::value($fld, $address), 0, 1 ))) {
+            if (ctype_digit(substr(CRM_Utils_Array::value($fld, $address), 0, 1))) {
               $streetAddress .= ' ';
             }
             $streetAddress .= CRM_Utils_Array::value($fld, $address);

--- a/CRM/Contact/Form/Edit/Address.php
+++ b/CRM/Contact/Form/Edit/Address.php
@@ -354,6 +354,10 @@ class CRM_Contact_Form_Edit_Address {
             ))) {
               $streetAddress .= ' ';
             }
+            // CRM-17619 - if the street number suffix begins with a number, add a space
+            if (ctype_digit ( substr ( CRM_Utils_Array::value($fld, $address), 0, 1 ) )) {
+              $streetAddress .= ' ';
+            }
             $streetAddress .= CRM_Utils_Array::value($fld, $address);
           }
           $streetAddress = trim($streetAddress);

--- a/CRM/Contact/Form/Edit/Address.php
+++ b/CRM/Contact/Form/Edit/Address.php
@@ -357,7 +357,7 @@ class CRM_Contact_Form_Edit_Address {
             // CRM-17619 - if the street number suffix begins with a number, add a space
             if ($fld === 'street_number_suffix' && ctype_digit(substr(CRM_Utils_Array::value($fld, $address), 0, 1))) {
               $streetAddress .= ' ';
-            }            
+            }
             $streetAddress .= CRM_Utils_Array::value($fld, $address);
           }
           $streetAddress = trim($streetAddress);
@@ -366,10 +366,13 @@ class CRM_Contact_Form_Edit_Address {
           }
           if (isset($address['street_number'])) {
             // CRM-17619 - if the street number suffix begins with a number, add a space
-            if (ctype_digit(substr(CRM_Utils_Array::value('street_number_suffix', $address),0,1))) {
-              $address['street_number'] .= " ";
+            $thesuffix = CRM_Utils_Array::value('street_number_suffix', $address);
+            if ($thesuffix) {
+              if (ctype_digit(substr($thesuffix, 0, 1))) {
+                $address['street_number'] .= " ";
+             }
             }
-            $address['street_number'] .= CRM_Utils_Array::value('street_number_suffix', $address);
+            $address['street_number'] .= $thesuffix;
           }
 
           // build array for set default.

--- a/CRM/Contact/Form/Edit/Address.php
+++ b/CRM/Contact/Form/Edit/Address.php
@@ -355,9 +355,9 @@ class CRM_Contact_Form_Edit_Address {
               $streetAddress .= ' ';
             }
             // CRM-17619 - if the street number suffix begins with a number, add a space
-            if (ctype_digit(substr(CRM_Utils_Array::value($fld, $address), 0, 1))) {
+            if ($fld === 'street_number_suffix' && ctype_digit(substr(CRM_Utils_Array::value($fld, $address), 0, 1))) {
               $streetAddress .= ' ';
-            }
+            }            
             $streetAddress .= CRM_Utils_Array::value($fld, $address);
           }
           $streetAddress = trim($streetAddress);
@@ -365,6 +365,10 @@ class CRM_Contact_Form_Edit_Address {
             $address['street_address'] = $streetAddress;
           }
           if (isset($address['street_number'])) {
+            // CRM-17619 - if the street number suffix begins with a number, add a space
+            if (ctype_digit(substr(CRM_Utils_Array::value('street_number_suffix', $address),0,1))) {
+              $address['street_number'] .= " ";
+            }
             $address['street_number'] .= CRM_Utils_Array::value('street_number_suffix', $address);
           }
 

--- a/CRM/Contact/Form/Edit/Address.php
+++ b/CRM/Contact/Form/Edit/Address.php
@@ -355,7 +355,7 @@ class CRM_Contact_Form_Edit_Address {
               $streetAddress .= ' ';
             }
             // CRM-17619 - if the street number suffix begins with a number, add a space
-            if (ctype_digit ( substr ( CRM_Utils_Array::value($fld, $address), 0, 1 ) )) {
+            if (ctype_digit(substr(CRM_Utils_Array::value($fld, $address), 0, 1 ))) {
               $streetAddress .= ' ';
             }
             $streetAddress .= CRM_Utils_Array::value($fld, $address);


### PR DESCRIPTION
CRM-17619 - if the street number suffix begins with a number, add a space

---
- [CRM-17619: Fractional Addresses are not handled properly when Street Address Parsing is enabled](https://issues.civicrm.org/jira/browse/CRM-17619)
