### PR TITLE
CRM-18652 Show no results label in quick search

### DIFF
--- a/templates/CRM/common/navigation.js.tpl
+++ b/templates/CRM/common/navigation.js.tpl
@@ -103,10 +103,12 @@ $('#civicrm-menu').ready(function() {
           };
         CRM.api3('contact', 'getquick', params).done(function(result) {
           var ret = [];
-          if (result.values) {
+          if (result.values.length > 0) {
             $.each(result.values, function(k, v) {
               ret.push({value: v.id, label: v.data});
-            })
+            });
+          } else {
+            ret.push({value: '0', label: 'No matches'});
           }
           response(ret);
         })
@@ -115,7 +117,9 @@ $('#civicrm-menu').ready(function() {
         return false;
       },
       select: function (event, ui) {
-        document.location = CRM.url('civicrm/contact/view', {reset: 1, cid: ui.item.value});
+        if (ui.item.value > 0) {
+          document.location = CRM.url('civicrm/contact/view', {reset: 1, cid: ui.item.value});
+        }
         return false;
       },
       create: function() {

--- a/templates/CRM/common/navigation.js.tpl
+++ b/templates/CRM/common/navigation.js.tpl
@@ -108,7 +108,7 @@ $('#civicrm-menu').ready(function() {
               ret.push({value: v.id, label: v.data});
             });
           } else {
-            ret.push({value: '0', label: 'No matches'});
+            ret.push({value: '0', label: {/literal}'{ts escape='js'}None found.{/ts}'{literal}});
           }
           response(ret);
         })

--- a/templates/CRM/common/navigation.js.tpl
+++ b/templates/CRM/common/navigation.js.tpl
@@ -119,6 +119,8 @@ $('#civicrm-menu').ready(function() {
       select: function (event, ui) {
         if (ui.item.value > 0) {
           document.location = CRM.url('civicrm/contact/view', {reset: 1, cid: ui.item.value});
+        } else {
+          document.location = CRM.url('civicrm/contact/search/advanced', {reset: 1});
         }
         return false;
       },
@@ -171,8 +173,10 @@ $('#civicrm-menu').ready(function() {
     var $menu = $('#sort_name_navigation').autocomplete('widget');
     if ($('li.ui-menu-item', $menu).length === 1) {
       var cid = $('li.ui-menu-item', $menu).data('ui-autocomplete-item').value;
-      document.location = CRM.url('civicrm/contact/view', {reset: 1, cid: cid});
-      return false;
+      if (cid > 0) {
+        document.location = CRM.url('civicrm/contact/view', {reset: 1, cid: cid});
+        return false;
+      }
     }
   });
   // Close menu after selecting an item


### PR DESCRIPTION
This is a re-roll of https://github.com/civicrm/civicrm-core/pull/8425 with bug fix found in testing at sprint

---
- [CRM-18652: Quick search should provide feedback to user if no matches are found](https://issues.civicrm.org/jira/browse/CRM-18652)
