### PR TITLE
Fix for CRM-18759.

### DIFF
--- a/CRM/Utils/Type.php
+++ b/CRM/Utils/Type.php
@@ -356,7 +356,10 @@ class CRM_Utils_Type {
       case 'String':
       case 'Link':
       case 'Memo':
-        return $data;
+        if (CRM_Utils_Rule::string($data)) {
+          return $data;
+        }
+        break;
 
       case 'Date':
         // a null date is valid

--- a/tests/phpunit/CRM/Utils/TypeTest.php
+++ b/tests/phpunit/CRM/Utils/TypeTest.php
@@ -58,6 +58,9 @@ class CRM_Utils_TypeTest extends CiviUnitTestCase {
       array('table.civicrm_column_name desc', 'MysqlOrderBy', 'table.civicrm_column_name desc'),
       array('table.civicrm_column_name desc,other_column, another_column desc', 'MysqlOrderBy', 'table.civicrm_column_name desc,other_column, another_column desc'),
       array('table.`Home-street_address` asc, `table-alias`.`Home-street_address` desc,`table-alias`.column', 'MysqlOrderBy', 'table.`Home-street_address` asc, `table-alias`.`Home-street_address` desc,`table-alias`.column'),
+      array('a string', 'String', 'a string'),
+      array(array(1), 'String', NULL),
+      array(new stdClass(), 'String', NULL),
     );
   }
 


### PR DESCRIPTION
Patch, with test. Feedback is most welcome.

---
- [CRM-18759: CRM_Utils_Type::validate($data, 'String') should fail for non-string-like values of $data](https://issues.civicrm.org/jira/browse/CRM-18759)
