### PR TITLE
CRM-17619 add space before numeric suffix

### DIFF
--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -1289,6 +1289,10 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
           ))) {
             $streetAddress .= ' ';
           }
+          // CRM-17619 - if the street number suffix begins with a number, add a space
+          if ($fld === 'street_number_suffix' && ctype_digit(substr(CRM_Utils_Array::value($fld, $address), 0, 1))) {
+            $streetAddress .= ' ';
+          }            
           $streetAddress .= CRM_Utils_Array::value($fld, $address);
         }
         $address['street_address'] = trim($streetAddress);

--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -1290,8 +1290,11 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
             $streetAddress .= ' ';
           }
           // CRM-17619 - if the street number suffix begins with a number, add a space
-          if ($fld === 'street_number_suffix' && ctype_digit(substr(CRM_Utils_Array::value($fld, $address), 0, 1))) {
-            $streetAddress .= ' ';
+          $thesuffix = CRM_Utils_Array::value('street_number_suffix', $address);
+          if ($fld === 'street_number_suffix' && $thesuffix) {
+            if (ctype_digit(substr($thesuffix, 0, 1))) {
+              $streetAddress .= ' ';
+            }
           }
           $streetAddress .= CRM_Utils_Array::value($fld, $address);
         }

--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -1292,7 +1292,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
           // CRM-17619 - if the street number suffix begins with a number, add a space
           if ($fld === 'street_number_suffix' && ctype_digit(substr(CRM_Utils_Array::value($fld, $address), 0, 1))) {
             $streetAddress .= ' ';
-          }            
+          }
           $streetAddress .= CRM_Utils_Array::value($fld, $address);
         }
         $address['street_address'] = trim($streetAddress);


### PR DESCRIPTION
A third place with the same problem.

---
- [CRM-17619: Fractional Addresses are not handled properly when Street Address Parsing is enabled](https://issues.civicrm.org/jira/browse/CRM-17619)
