### PR TITLE
CRM-18743 - Undefined variable $order

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -5952,6 +5952,7 @@ AND   displayRelType.is_active = 1
    *   list(string $orderByClause, string $additionalFromClause).
    */
   protected function prepareOrderBy($sort, $sortByChar, $sortOrder, $additionalFromClause) {
+    $order = NULL;
     $config = CRM_Core_Config::singleton();
     if ($config->includeOrderByClause ||
       isset($this->_distinctComponentClause)


### PR DESCRIPTION
Fixes 3 notice/errors stating "Undefined variable: order in CRM_Contact_BAO_Query->prepareOrderBy()" on Drupal user page when the user record is linked to a Civi contact record. eg at path: user/1

---
- [CRM-18743: Undefined variable: order in CRM_Contact_BAO_Query->prepareOrderBy()](https://issues.civicrm.org/jira/browse/CRM-18743)
