### PR TITLE
CRM-18743 - Undefined variable $order

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -5796,6 +5796,7 @@ AND   displayRelType.is_active = 1
    *   list(string $orderByClause, string $additionalFromClause).
    */
   protected function prepareOrderBy($sort, $sortByChar, $sortOrder, $additionalFromClause) {
+    $order = NULL;
     $config = CRM_Core_Config::singleton();
     if ($config->includeOrderByClause ||
       isset($this->_distinctComponentClause)


### PR DESCRIPTION
Fix notice/error "Undefined variable: order in CRM_Contact_BAO_Query->prepareOrderBy()" on user/# screen if the viewed user page is linked to a contact record in Civi.

Also submitted to master.

---
- [CRM-18743: Undefined variable: order in CRM_Contact_BAO_Query->prepareOrderBy()](https://issues.civicrm.org/jira/browse/CRM-18743)
