### PR TITLE
CRM-18665 Fixing bug where event subtype doesn't reload when validati…

### DIFF
--- a/CRM/Event/Form/ManageEvent/EventInfo.php
+++ b/CRM/Event/Form/ManageEvent/EventInfo.php
@@ -62,6 +62,7 @@ class CRM_Event_Form_ManageEvent_EventInfo extends CRM_Event_Form_ManageEvent {
     if (!empty($_POST['hidden_custom'])) {
       $this->set('type', 'Event');
       $this->set('subType', CRM_Utils_Array::value('event_type_id', $_POST));
+      $this->assign('customDataSubType', CRM_Utils_Array::value('event_type_id', $_POST));
       $this->set('entityId', $this->_id);
 
       CRM_Custom_Form_CustomData::preProcess($this, NULL, $this->_eventType, 1, 'Event', $this->_id);


### PR DESCRIPTION
…on fails, and therefore the custom data sets don't render.

---
- CRM-18665: Custom data sets configured for an event type only aren't redisplayed after failing validation
  https://issues.civicrm.org/jira/browse/CRM-18665
