### PR TITLE
(WIP) CRM-13639: Improve available logging methods

### DIFF
--- a/CRM/Admin/Form/Setting/Debugging.php
+++ b/CRM/Admin/Form/Setting/Debugging.php
@@ -37,6 +37,7 @@
 class CRM_Admin_Form_Setting_Debugging extends CRM_Admin_Form_Setting {
 
   protected $_settings = array(
+    'logging_method' => CRM_Core_BAO_Setting::DEVELOPER_PREFERENCES_NAME,
     'debug_enabled' => CRM_Core_BAO_Setting::DEVELOPER_PREFERENCES_NAME,
     'backtrace' => CRM_Core_BAO_Setting::DEVELOPER_PREFERENCES_NAME,
     'fatalErrorHandler' => CRM_Core_BAO_Setting::DEVELOPER_PREFERENCES_NAME,
@@ -46,10 +47,32 @@ class CRM_Admin_Form_Setting_Debugging extends CRM_Admin_Form_Setting {
    * Build the form object.
    */
   public function buildQuickForm() {
-    CRM_Utils_System::setTitle(ts(' Settings - Debugging and Error Handling '));
+    CRM_Utils_System::setTitle(ts('Settings - Debugging and Error Handling'));
+
+    // Get expected location: CiviCRM error log.
+    if (!isset(\Civi::$statics['CRM_Core_Error']['logger_file'])) {
+      // Log file location is set only when first message is logged via CRM_Core_Error.
+      CRM_Core_Error::debug_log_message('Finding CRM_Core_Error logfile.');
+    }
+    $this->assign('civicrm_logfile_location', \Civi::$statics['CRM_Core_Error']['logger_file']);
+
+    // Get expected location/destination: PHP error log.
+    $php_error_log = ini_get('error_log');
+    if (empty($php_error_log)) {
+      $php_error_log = 'error_log unset, will use SAPI error log';
+    }
+    $this->assign('php_error_log_location', $php_error_log);
+
     if (CRM_Core_Config::singleton()->userSystem->supports_UF_Logging == '1') {
       $this->_settings['userFrameworkLogging'] = CRM_Core_BAO_Setting::DEVELOPER_PREFERENCES_NAME;
     }
+
+    Civi::log()->info('Hello, log!');
+    Civi::log()->warning('Oh no, {kittens}!', array('kittens' => 'wildcats'));
+    $var = 'the coffee';
+    Civi::log()->error("There is something bad with {var}.", array(
+        'var' => $var,
+    ));
 
     parent::buildQuickForm();
   }

--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -528,29 +528,23 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    * in the formatting of the output.
    *
    * @param string $variable_name
-   * @param mixed $variable
-   * @param bool $print
-   *   Should we use print_r ? (else we use var_dump).
-   * @param bool $log
-   *   Should we log or return the output.
-   * @param string $comp
    *   Variable name.
+   * @param mixed $variable
+   *   Variable value.
+   * @param bool $print
+   *   Use print_r (if true) or var_dump (if false).
+   * @param bool $log
+   *   Log or return the output?
+   * @param string $prefix
+   *   Prefix for output logfile.
    *
    * @return string
-   *   the generated output
-   *
-   *
+   *   The generated output
    *
    * @see CRM_Core_Error::debug()
    * @see CRM_Core_Error::debug_log_message()
    */
-  public static function debug_var(
-    $variable_name,
-    $variable,
-    $print = TRUE,
-    $log = TRUE,
-    $comp = ''
-  ) {
+  public static function debug_var($variable_name, $variable, $print = TRUE, $log = TRUE, $prefix = '') {
     // check if variable is set
     if (!isset($variable)) {
       $out = "\$$variable_name is not set";
@@ -573,7 +567,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
         reset($variable);
       }
     }
-    return self::debug_log_message($out, FALSE, $comp);
+    return self::debug_log_message($out, FALSE, $prefix);
   }
 
   /**
@@ -586,17 +580,17 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    * @param bool $out
    *   Should we log or return the output.
    *
-   * @param string $comp
-   *   Message to be output.
+   * @param string $prefix
+   *   Message prefix.
    * @param string $priority
    *
    * @return string
    *   Format of the backtrace
    */
-  public static function debug_log_message($message, $out = FALSE, $comp = '', $priority = NULL) {
+  public static function debug_log_message($message, $out = FALSE, $prefix = '', $priority = NULL) {
     $config = CRM_Core_Config::singleton();
 
-    $file_log = self::createDebugLogger($comp);
+    $file_log = self::createDebugLogger($prefix);
     $file_log->log("$message\n", $priority);
 
     $str = '<p/><code>' . htmlspecialchars($message) . '</code>';

--- a/CRM/Core/Error/Log.php
+++ b/CRM/Core/Error/Log.php
@@ -68,8 +68,129 @@ class CRM_Core_Error_Log extends \Psr\Log\AbstractLogger {
       if (CRM_Utils_System::isDevelopment() && CRM_Utils_Array::value('civi.tag', $context) === 'deprecated') {
         trigger_error($message, E_USER_DEPRECATED);
       }
+      // Interpolate context into message.
+      if (FALSE !== strpos($message, '{')) {
+        $replacements = [];
+        foreach ($context as $key => $val) {
+          if (is_null($val) || is_scalar($val) || (is_object($val) && method_exists($val, "__toString"))) {
+            $replacements['{' . $key . '}'] = $val;
+          }
+          elseif (is_object($val)) {
+            $replacements['{' . $key . '}'] = '[object ' . get_class($val) . ']';
+          }
+          else {
+            $replacements['{' . $key . '}'] = '[' . gettype($val) . ']';
+          }
+        }
+        $message = strtr($message, $replacements);
+        $message .= "\n" . print_r($context, 1);
+      }
     }
     CRM_Core_Error::debug_log_message($message, FALSE, '', $this->map[$level]);
+  }
+
+  /**
+   * Adds a log record at the INFO level.
+   *
+   * This method allows for compatibility with common interfaces.
+   *
+   * @param string $message
+   * @param array $context
+   * @return null|void
+   */
+  public function debug($message, array $context = array()) {
+    return $this->log(\Psr\Log\LogLevel::DEBUG, $message, $context);
+  }
+
+  /**
+   * Adds a log record at the DEBUG level.
+   *
+   * This method allows for compatibility with common interfaces.
+   *
+   * @param string $message
+   * @param array $context
+   * @return null|void
+   */
+  public function info($message, array $context = array()) {
+    return $this->log(\Psr\Log\LogLevel::INFO, $message, $context);
+  }
+
+  /**
+   * Adds a log record at the NOTICE level.
+   *
+   * This method allows for compatibility with common interfaces.
+   *
+   * @param string $message
+   * @param array $context
+   * @return null|void
+   */
+  public function notice($message, array $context = array()) {
+    return $this->log(\Psr\Log\LogLevel::NOTICE, $message, $context);
+  }
+
+  /**
+   * Adds a log record at the WARNING level.
+   *
+   * This method allows for compatibility with common interfaces.
+   *
+   * @param string $message
+   * @param array $context
+   * @return null|void
+   */
+  public function warning($message, array $context = array()) {
+    return $this->log(\Psr\Log\LogLevel::WARNING, $message, $context);
+  }
+
+  /**
+   * Adds a log record at the ERROR level.
+   *
+   * This method allows for compatibility with common interfaces.
+   *
+   * @param string $message
+   * @param array $context
+   * @return null|void
+   */
+  public function error($message, array $context = array()) {
+    return $this->log(\Psr\Log\LogLevel::ERROR, $message, $context);
+  }
+
+  /**
+   * Adds a log record at the CRITICAL level.
+   *
+   * This method allows for compatibility with common interfaces.
+   *
+   * @param string $message
+   * @param array $context
+   * @return null|void
+   */
+  public function critical($message, array $context = array()) {
+    return $this->log(\Psr\Log\LogLevel::CRITICAL, $message, $context);
+  }
+
+  /**
+   * Adds a log record at the ALERT level.
+   *
+   * This method allows for compatibility with common interfaces.
+   *
+   * @param string $message
+   * @param array $context
+   * @return null|void
+   */
+  public function alert($message, array $context = array()) {
+    return $this->log(\Psr\Log\LogLevel::ALERT, $message, $context);
+  }
+
+  /**
+   * Adds a log record at the EMERGENCY level.
+   *
+   * This method allows for compatibility with common interfaces.
+   *
+   * @param string $message
+   * @param array $context
+   * @return null|void
+   */
+  public function emergency($message, array $context = array()) {
+    return $this->log(\Psr\Log\LogLevel::EMERGENCY, $message, $context);
   }
 
 }

--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -1107,5 +1107,22 @@ class CRM_Core_SelectValues {
       6 => ts('Both'),
     );
   }
+  /**
+   * Logging providers.
+   */
+  public static function loggingProviders() {
+    // Initialise with log types we know are available.
+    $results = array(
+      'crm_core_error' => 'CiviCRM file-based log',
+      'ErrorLog' => 'PHP error log',
+      'Syslog' => 'Syslog - UNIX system log',
+      'BrowserConsole' => 'Browser console',
+    );
+
+    // @TODO If Drupal, consider offering PSR3 watchdog method?
+
+    // @TODO Scan for available implementations, eg any provided by extensions.
+    return $results;
+  }
 
 }

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     "phpoffice/phpword": "^0.13.0",
     "pear/Validate_Finance_CreditCard": "dev-master",
     "civicrm/civicrm-cxn-rpc": "~0.16.12.05"
+    "monolog/monolog": "^1.19"
   },
   "repositories": [
     {

--- a/settings/Developer.setting.php
+++ b/settings/Developer.setting.php
@@ -37,6 +37,24 @@
  */
 
 return array(
+  'logging_method' => array(
+    'title' => 'Debug log method',
+    'group_name' => 'Developer Preferences',
+    'group' => 'developer',
+    'name' => 'debug_log_method',
+    'type' => 'String',
+    'quick_form_type' => 'Select',
+    'pseudoconstant' => array(
+      'callback' => 'CRM_Core_SelectValues::loggingProviders',
+    ),
+    'default' => 'legacy',
+    'add' => '4.7',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    //
+    'description' => '',
+    'help_text' => 'CRM_Core_Error" is the long-standing CiviCRM file log. "Syslog" logs to the UNIX system log.',
+  ),
   'userFrameworkLogging' => array(
     'group_name' => 'Developer Preferences',
     'group' => 'developer',
@@ -48,8 +66,8 @@ return array(
     'title' => 'Enable Drupal Watchdog Logging',
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => "Set this value to Yes if you want CiviCRM error/debugging messages to appear in the Drupal error logs",
-    'help_text' => "Set this value to Yes if you want CiviCRM error/debugging messages the appear in your CMS' error log. In the case of Drupal, this will cause all CiviCRM error messages to appear in the watchdog (assuming you have Drupal's watchdog enabled)",
+    'description' => "Set this value to Yes if you want CiviCRM error/debugging messages to appear in the CMS error logs",
+    'help_text' => "Set this value to Yes if you want CiviCRM error/debugging messages the appear in the CMS error log. In the case of Drupal, this will cause all CiviCRM error messages to appear in the watchdog (assuming you have Drupal's watchdog enabled)",
   ),
   'debug_enabled' => array(
     'group_name' => 'Developer Preferences',

--- a/settings/Search.setting.php
+++ b/settings/Search.setting.php
@@ -85,7 +85,7 @@ return array(
     'html_type' => 'Text',
     'default' => 'simple',
     'add' => '4.5',
-    'title' => 'How to handle full-tet queries',
+    'title' => 'How to handle full-text queries',
     'is_domain' => 1,
     'is_contact' => 0,
     'description' => NULL,

--- a/templates/CRM/Admin/Form/Setting/Debugging.tpl
+++ b/templates/CRM/Admin/Form/Setting/Debugging.tpl
@@ -29,6 +29,21 @@
 </div>
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
          <table class="form-layout">
+             <tr class="crm-debugging-form-block-debug">
+                 <td class="label">{$form.logging_method.label}</td>
+                 <td>{$form.logging_method.html}<br />
+                 <span class="description">
+                    <p>{ts}Select the logging method to use.{/ts} {help id='logging_method'}</p>
+                    <p>
+                       <ul>
+                        <li>CiviCRM file log - legacy method, logs to file: <tt>{$civicrm_logfile_location}</tt>.</li>
+                        <li>PHP error_log - logs to PHP error: <tt>{$php_error_log_location}</tt>.</li>
+                        <li>Syslog - logs to UNIX syslog.</li>
+                        <li>Browser console - logs to browser console, testing environments only.</li>
+                       </ul>
+                    </p>
+                 </span></td>
+             </tr>
             {if $form.userFrameworkLogging}
             <tr class="crm-debugging-form-block-userFrameworkLogging">
                 <td class="label">{$form.userFrameworkLogging.label}</td>


### PR DESCRIPTION
Stage 1 - with this it is possible to log to Syslog, PHP error log, or traditional CiviCRM log

---
- [CRM-13639](https://issues.civicrm.org/jira/browse/CRM-13639)
