### PR TITLE
Fix for CRM-18770.

### DIFF
--- a/tests/phpunit/CRM/Utils/TypeTest.php
+++ b/tests/phpunit/CRM/Utils/TypeTest.php
@@ -58,6 +58,7 @@ class CRM_Utils_TypeTest extends CiviUnitTestCase {
       array('table.civicrm_column_name desc', 'MysqlOrderBy', 'table.civicrm_column_name desc'),
       array('table.civicrm_column_name desc,other_column, another_column desc', 'MysqlOrderBy', 'table.civicrm_column_name desc,other_column, another_column desc'),
       array('table.`Home-street_address` asc, `table-alias`.`Home-street_address` desc,`table-alias`.column', 'MysqlOrderBy', 'table.`Home-street_address` asc, `table-alias`.`Home-street_address` desc,`table-alias`.column'),
+      array('a string', 'String', 'a string'),
     );
   }
 


### PR DESCRIPTION
- [CRM-18770: Add test for 'String' validation for CRM_Utils_Type::validate()](https://issues.civicrm.org/jira/browse/CRM-18770)
