### PR TITLE
CRM-17619 add space before numeric suffix

### DIFF
--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -1289,6 +1289,10 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
           ))) {
             $streetAddress .= ' ';
           }
+          // CRM-17619 - if the street number suffix begins with a number, add a space
+          if ($fld === 'street_number_suffix' && ctype_digit(substr(CRM_Utils_Array::value($fld, $address), 0, 1))) {
+            $streetAddress .= ' ';
+          }            
           $streetAddress .= CRM_Utils_Array::value($fld, $address);
         }
         $address['street_address'] = trim($streetAddress);

--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -1290,8 +1290,11 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
             $streetAddress .= ' ';
           }
           // CRM-17619 - if the street number suffix begins with a number, add a space
-          if ($fld === 'street_number_suffix' && ctype_digit(substr(CRM_Utils_Array::value($fld, $address), 0, 1))) {
-            $streetAddress .= ' ';
+          $thesuffix = CRM_Utils_Array::value('street_number_suffix', $address);
+          if ($fld === 'street_number_suffix' && $thesuffix) {
+            if (ctype_digit(substr($thesuffix, 0, 1))) {
+              $streetAddress .= ' ';
+            }
           }
           $streetAddress .= CRM_Utils_Array::value($fld, $address);
         }

--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -1292,7 +1292,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
           // CRM-17619 - if the street number suffix begins with a number, add a space
           if ($fld === 'street_number_suffix' && ctype_digit(substr(CRM_Utils_Array::value($fld, $address), 0, 1))) {
             $streetAddress .= ' ';
-          }            
+          }
           $streetAddress .= CRM_Utils_Array::value($fld, $address);
         }
         $address['street_address'] = trim($streetAddress);

--- a/CRM/Contact/Form/Edit/Address.php
+++ b/CRM/Contact/Form/Edit/Address.php
@@ -361,9 +361,15 @@ class CRM_Contact_Form_Edit_Address {
             $address['street_address'] = $streetAddress;
           }
           if (isset($address['street_number'])) {
-            $address['street_number'] .= CRM_Utils_Array::value('street_number_suffix', $address);
+            // CRM-17619 - if the street number suffix begins with a number, add a space
+            $thesuffix = CRM_Utils_Array::value('street_number_suffix', $address);
+            if ($thesuffix) {
+              if (ctype_digit(substr($thesuffix, 0, 1))) {
+                $address['street_number'] .= " ";
+              }
+            }
+            $address['street_number'] .= $thesuffix;
           }
-
           // build array for set default.
           foreach ($parseFields as $field) {
             $addressValues["{$field}_{$cnt}"] = CRM_Utils_Array::value($field, $address);

--- a/CRM/Contact/Form/Edit/Address.php
+++ b/CRM/Contact/Form/Edit/Address.php
@@ -355,8 +355,9 @@ class CRM_Contact_Form_Edit_Address {
               $streetAddress .= ' ';
             }
             // CRM-17619 - if the street number suffix begins with a number, add a space
-            if ($fld === 'street_number_suffix' && !empty(CRM_Utils_Array::value($fld, $address))) {
-              if (ctype_digit(substr(CRM_Utils_Array::value($fld, $address), 0, 1))) {
+            $numsuffix = CRM_Utils_Array::value($fld, $address);
+            if ($fld === 'street_number_suffix' && !empty($numsuffix)) {
+              if (ctype_digit(substr($numsuffix, 0, 1))) {
                 $streetAddress .= ' ';
               }
             }

--- a/CRM/Contact/Form/Edit/Address.php
+++ b/CRM/Contact/Form/Edit/Address.php
@@ -354,6 +354,12 @@ class CRM_Contact_Form_Edit_Address {
             ))) {
               $streetAddress .= ' ';
             }
+            // CRM-17619 - if the street number suffix begins with a number, add a space
+            if ($fld === 'street_number_suffix' && !empty(CRM_Utils_Array::value($fld, $address))) {
+              if (ctype_digit(substr(CRM_Utils_Array::value($fld, $address), 0, 1))) {
+                $streetAddress .= ' ';
+              }
+            }
             $streetAddress .= CRM_Utils_Array::value($fld, $address);
           }
           $streetAddress = trim($streetAddress);


### PR DESCRIPTION
When creating street address, the extension to a number is usually alphabetic, and there is not a space (eg.  221B Baker Street).  For numbers that have a fraction (221 1/2 Baker Street) a space is required.

---
- [CRM-17619: Fractional Addresses are not handled properly when Street Address Parsing is enabled](https://issues.civicrm.org/jira/browse/CRM-17619)
