### PR TITLE
CRM-18554: Using IS EMPTY operator for some date fields crashes 4.7.7

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -5085,10 +5085,10 @@ SELECT COUNT( conts.total_amount ) as cancel_count,
       }
 
       if ($date) {
-        $this->_where[$grouping][] = "{$tableName}.{$dbFieldName} $op $date";
+        $this->_where[$grouping][] = self::buildClause("{$tableName}.{$dbFieldName}", $op, $date);
       }
       else {
-        $this->_where[$grouping][] = "{$tableName}.{$dbFieldName} $op";
+        $this->_where[$grouping][] = self::buildClause("{$tableName}.{$dbFieldName}", $op);
       }
 
       $this->_tables[$tableName] = $this->_whereTables[$tableName] = 1;

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -5085,7 +5085,7 @@ SELECT COUNT( conts.total_amount ) as cancel_count,
       }
 
       if ($date) {
-        $this->_where[$grouping][] = self::buildClause("{$tableName}.{$dbFieldName}", $op, $date);
+        $this->_where[$grouping][] = "{$tableName}.{$dbFieldName} $op $date";
       }
       else {
         $this->_where[$grouping][] = self::buildClause("{$tableName}.{$dbFieldName}", $op);


### PR DESCRIPTION
---
- CRM-18554: Using IS EMPTY operator for some date fields crashes 4.7.7
  https://issues.civicrm.org/jira/browse/CRM-18554
