### PR TITLE
CRM-18701 remove inappropriate actions from processAmount

### DIFF
--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -1040,6 +1040,38 @@ WHERE  civicrm_participant.id = {$participantId}
   }
 
   /**
+   * Get the amount for the undiscounted version of the field.
+   *
+   * Note this function is part of the refactoring process rather than the best approach.
+   *
+   * @param int $eventID
+   * @param int $discountedPriceFieldOptionID
+   * @param string $feeLevel (deprecated)
+   *
+   * @return null|string
+   */
+  public static function getUnDiscountedAmountForEventPriceSetFieldValue($eventID, $discountedPriceFieldOptionID, $feeLevel) {
+    $priceSetId = CRM_Price_BAO_PriceSet::getFor('civicrm_event', $eventID, NULL);
+    $params = array(
+      1 => array($priceSetId, 'Integer'),
+    );
+    if ($discountedPriceFieldOptionID) {
+      $query = "SELECT cpfv.amount FROM `civicrm_price_field_value` cpfv
+LEFT JOIN civicrm_price_field cpf ON cpfv.price_field_id = cpf.id
+WHERE cpf.price_set_id = %1 AND cpfv.label = (SELECT label from civicrm_price_field_value WHERE id = %2)";
+      $params[2] = array($discountedPriceFieldOptionID, 'Integer');
+    }
+    else {
+      $feeLevel = current($feeLevel);
+      $query = "SELECT cpfv.amount FROM `civicrm_price_field_value` cpfv
+LEFT JOIN civicrm_price_field cpf ON cpfv.price_field_id = cpf.id
+WHERE cpf.price_set_id = %1 AND cpfv.label LIKE %2";
+      $params[2] = array($feeLevel, 'String');
+    }
+    return CRM_Core_DAO::singleValueQuery($query, $params);
+  }
+
+  /**
    * Get the event fee info for given participant ids
    * either from line item table / participant table.
    *
@@ -1789,36 +1821,29 @@ WHERE    civicrm_participant.contact_id = {$contactID} AND
    * @param array $contributionParams
    *   Contribution params.
    *
-   * @param $feeLevel
-   *
+   * @param string $feeLevel (deprecated)
+   * @param int $discountedPriceFieldOptionID
+   *   ID of the civicrm_price_field_value field for the discount id.
    */
-  public static function createDiscountTrxn($eventID, $contributionParams, $feeLevel) {
-    // CRM-11124
+  public static function createDiscountTrxn($eventID, $contributionParams, $feeLevel, $discountedPriceFieldOptionID) {
+    $financialTypeID = $contributionParams['contribution']->financial_type_id;
+    $total_amount = $contributionParams['total_amount'];
+
     $checkDiscount = CRM_Core_BAO_Discount::findSet($eventID, 'civicrm_event');
     if (!empty($checkDiscount)) {
-      $feeLevel = current($feeLevel);
-      $priceSetId = CRM_Price_BAO_PriceSet::getFor('civicrm_event', $eventID, NULL);
-      $query = "SELECT cpfv.amount FROM `civicrm_price_field_value` cpfv
-LEFT JOIN civicrm_price_field cpf ON cpfv.price_field_id = cpf.id
-WHERE cpf.price_set_id = %1 AND cpfv.label LIKE %2";
-      $params = array(
-        1 => array($priceSetId, 'Integer'),
-        2 => array($feeLevel, 'String'),
-      );
-      $mainAmount = CRM_Core_DAO::singleValueQuery($query, $params);
+      $mainAmount = self::getUnDiscountedAmountForEventPriceSetFieldValue($eventID, $discountedPriceFieldOptionID, $feeLevel);
       $relationTypeId = key(CRM_Core_PseudoConstant::accountOptionValues('account_relationship', NULL, " AND v.name LIKE 'Discounts Account is' "));
-      $contributionParams['trxnParams']['from_financial_account_id'] = CRM_Contribute_PseudoConstant::financialAccountType(
-        $contributionParams['contribution']->financial_type_id, $relationTypeId);
-      if (!empty($contributionParams['trxnParams']['from_financial_account_id'])) {
-        $contributionParams['trxnParams']['total_amount'] = $mainAmount - $contributionParams['total_amount'];
-        $contributionParams['trxnParams']['payment_processor_id'] = NULL;
-        $contributionParams['trxnParams']['payment_instrument_id'] = NULL;
-        $contributionParams['trxnParams']['check_number'] = NULL;
-        $contributionParams['trxnParams']['trxn_id'] = NULL;
-        $contributionParams['trxnParams']['net_amount'] = NULL;
-        $contributionParams['trxnParams']['fee_amount'] = NULL;
-
-        CRM_Core_BAO_FinancialTrxn::create($contributionParams['trxnParams']);
+      $transactionParams['from_financial_account_id'] = CRM_Contribute_PseudoConstant::financialAccountType(
+        $financialTypeID, $relationTypeId);
+      if (!empty($transactionParams['trxnParams']['from_financial_account_id'])) {
+        $transactionParams['trxnParams']['total_amount'] = $mainAmount - $total_amount;
+        $transactionParams['trxnParams']['payment_processor_id'] = NULL;
+        $transactionParams['trxnParams']['payment_instrument_id'] = NULL;
+        $transactionParams['trxnParams']['check_number'] = NULL;
+        $transactionParams['trxnParams']['trxn_id'] = NULL;
+        $transactionParams['trxnParams']['net_amount'] = NULL;
+        $transactionParams['trxnParams']['fee_amount'] = NULL;
+        CRM_Core_BAO_FinancialTrxn::create($transactionParams);
       }
     }
   }

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1412,14 +1412,13 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
         $transaction = new CRM_Core_Transaction();
 
         // CRM-11124
-        if ($this->_quickConfig) {
-          if (!empty($this->_params['amount_priceset_level_radio'])) {
-            $feeLevel = $this->_params['amount_priceset_level_radio'];
-          }
-          else {
-            $feeLevel[] = $this->_params['fee_level'];
-          }
-          CRM_Event_BAO_Participant::createDiscountTrxn($this->_eventId, $contributionParams, $feeLevel);
+        if ($this->_params['discount_id']) {
+          CRM_Event_BAO_Participant::createDiscountTrxn(
+            $this->_eventId,
+            $contributionParams,
+            NULL,
+            CRM_Price_BAO_PriceSet::parseFirstPriceSetValueIDFromParams($this->_params)
+          );
         }
         $transaction->commit();
       }

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1045,11 +1045,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
     }
 
     // Retrieve the name and email of the current user - this will be the FROM for the receipt email
-    $session = CRM_Core_Session::singleton();
-    $userID = $session->get('userID');
-    list($userName,
-      $userEmail
-      ) = CRM_Contact_BAO_Contact_Location::getEmailDetails($userID);
+    $userName = CRM_Core_Session::singleton()->getLoggedInContactDisplayName();
 
     if ($this->_contactId) {
       list($this->_contributorDisplayName, $this->_contributorEmail, $this->_toDoNotEmail) = CRM_Contact_BAO_Contact::getContactDetails($this->_contactId);

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -99,9 +99,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
           $params['discountAmount'] = $this->_params[0]['discountAmount'];
           $params['discountMessage'] = $this->_params[0]['discountMessage'];
         }
-        if (!empty($this->_params[0]['amount_priceset_level_radio'])) {
-          $params['amount_priceset_level_radio'] = $this->_params[0]['amount_priceset_level_radio'];
-        }
+
         $params['amount_level'] = $this->_params[0]['amount_level'];
         $params['currencyID'] = $this->_params[0]['currencyID'];
 
@@ -1025,7 +1023,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
     // create contribution record
     $contribution = CRM_Contribute_BAO_Contribution::add($contribParams, $ids);
     // CRM-11124
-    CRM_Event_BAO_Participant::createDiscountTrxn($form->_eventId, $contribParams, CRM_Utils_Array::value('amount_priceset_level_radio', $params, NULL));
+    CRM_Event_BAO_Participant::createDiscountTrxn($form->_eventId, $contribParams, NULL, CRM_Price_BAO_PriceSet::parseFirstPriceSetValueIDFromParams($params));
 
     // process soft credit / pcp pages
     if (!empty($params['pcp_made_through_id'])) {

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -792,9 +792,6 @@ WHERE  id = %1";
           }
           $params["price_{$id}"] = array($params["price_{$id}"] => 1);
           $optionValueId = CRM_Utils_Array::key(1, $params["price_{$id}"]);
-          $optionLabel = CRM_Utils_Array::value('label', $field['options'][$optionValueId]);
-          $params['amount_priceset_level_radio'] = array();
-          $params['amount_priceset_level_radio'][$optionValueId] = $optionLabel;
 
           CRM_Price_BAO_LineItem::format($id, $params, $field, $lineItem);
           if (CRM_Utils_Array::value('tax_rate', $field['options'][$optionValueId])) {
@@ -819,9 +816,6 @@ WHERE  id = %1";
         case 'Select':
           $params["price_{$id}"] = array($params["price_{$id}"] => 1);
           $optionValueId = CRM_Utils_Array::key(1, $params["price_{$id}"]);
-          $optionLabel = $field['options'][$optionValueId]['label'];
-          $params['amount_priceset_level_select'] = array();
-          $params['amount_priceset_level_select'][CRM_Utils_Array::key(1, $params["price_{$id}"])] = $optionLabel;
 
           CRM_Price_BAO_LineItem::format($id, $params, $field, $lineItem);
           if (CRM_Utils_Array::value('tax_rate', $field['options'][$optionValueId])) {
@@ -1651,6 +1645,59 @@ WHERE       ps.id = %1
     $lineItem[$optionValueId]['tax_rate'] = $taxRate;
 
     return $lineItem;
+  }
+
+  /**
+   * Get the first price set value IDs from a parameters array.
+   *
+   * In practice this is really used when we only expect one to exist.
+   *
+   * @param array $params
+   *
+   * @return array
+   *   Array of the ids of the price set values.
+   */
+  public static function parseFirstPriceSetValueIDFromParams($params) {
+    $priceSetValueIDs = self::parsePriceSetValueIDsFromParams($params);
+    return reset($priceSetValueIDs);
+  }
+
+  /**
+   * Get the price set value IDs from a set of parameters
+   *
+   * @param array $params
+   *
+   * @return array
+   *   Array of the ids of the price set values.
+   */
+  public static function parsePriceSetValueIDsFromParams($params) {
+    $priceSetParams = self::parsePriceSetArrayFromParams($params);
+    $priceSetValueIDs = array();
+    foreach ($priceSetParams as $priceSetParam) {
+      foreach (array_keys($priceSetParam) as $priceValueID) {
+        $priceSetValueIDs[] = $priceValueID;
+      }
+    }
+    return $priceSetValueIDs;
+  }
+
+  /**
+   * Get the price set value IDs from a set of parameters
+   *
+   * @param array $params
+   *
+   * @return array
+   *   Array of price fields filtered from the params.
+   */
+  public static function parsePriceSetArrayFromParams($params) {
+    $priceSetParams = array();
+    foreach ($params as $field => $value) {
+      $parts = explode('_', $field);
+      if (count($parts) == 2 && $parts[0] == 'price' && is_numeric($parts[1])) {
+        $priceSetParams[$field] = $value;
+      }
+    }
+    return $priceSetParams;
   }
 
 }


### PR DESCRIPTION
I need to fix a bug in that function & I'm struggling with the readability so I have refactored the 'amount_priceset_level_radio' setting back to the form. In the process I came to the conclusion that the CRM_Event_BAO_Participant::createDiscountTrxn is not actually working and the problem is in this line 

$contributionParams['trxnParams']['from_financial_account_id'] = CRM_Contribute_PseudoConstant::financialAccountType(
        $contributionParams['contribution']->financial_type_id, $relationTypeId);

which is not retrieving the value it should.

This is the case before & after the patch - so I'm going to log a separate ticket for that. https://issues.civicrm.org/jira/browse/CRM-18775  @JoeMurray

---
- [CRM-18701: civicrm_financial_item has wrong amount when overriding line item price](https://issues.civicrm.org/jira/browse/CRM-18701)
