### PR TITLE
CRM-18688: Cancel IPN cancels entire membership

### DIFF
--- a/CRM/Core/Payment/BaseIPN.php
+++ b/CRM/Core/Payment/BaseIPN.php
@@ -328,15 +328,11 @@ class CRM_Core_Payment_BaseIPN {
             'labelColumn' => 'name',
             'flip' => 1,
           ));
-        // Prevent active memberships from being cancelled
+        // Cancel only Pending memberships
         // CRM-18688
-        $activeStatuses = array(
-          $membershipStatuses['New'],
-          $membershipStatuses['Current'],
-          $membershipStatuses['Grace'],
-        );
+        $pendingStatusId = $membershipStatuses['Pending'];
         foreach ($memberships as $membership) {
-          if ($membership && !in_array($membership->status_id, $activeStatuses)) {
+          if ($membership && ($membership->status_id == $pendingStatusId)) {
             $membership->status_id = $membershipStatuses['Cancelled'];
             $membership->save();
 

--- a/CRM/Core/Payment/BaseIPN.php
+++ b/CRM/Core/Payment/BaseIPN.php
@@ -328,8 +328,15 @@ class CRM_Core_Payment_BaseIPN {
             'labelColumn' => 'name',
             'flip' => 1,
           ));
+        // Prevent active memberships from being cancelled
+        // CRM-18688
+        $activeStatuses = array(
+          $membershipStatuses['New'],
+          $membershipStatuses['Current'],
+          $membershipStatuses['Grace'],
+        );
         foreach ($memberships as $membership) {
-          if ($membership) {
+          if ($membership && !in_array($membership->status_id, $activeStatuses)) {
             $membership->status_id = $membershipStatuses['Cancelled'];
             $membership->save();
 


### PR DESCRIPTION
**Issue:**
If user cancels the payment on off-site payment processor (Sagepay, Paypal etc.), It cancels entire membership.

**Reason:**
In `public function cancelled`, the status of membership was set to "cancelled" without checking the current status of the membership.

**Solution:**
Cancel the status only if membership status is not one of the active statuses (new, current or grace).

---
- [CRM-18688: Cancel an IPN payment when renewing membership cancels entire membership](https://issues.civicrm.org/jira/browse/CRM-18688)
