### PR TITLE
Issue with loading Components in disabled Extension

### DIFF
--- a/CRM/Core/Component.php
+++ b/CRM/Core/Component.php
@@ -95,7 +95,11 @@ class CRM_Core_Component {
       $cr->find(FALSE);
       while ($cr->fetch()) {
         $infoClass = $cr->namespace . '_' . self::COMPONENT_INFO_CLASS;
-        require_once str_replace('_', DIRECTORY_SEPARATOR, $infoClass) . '.php';
+        $infoClassFile = str_replace('_', DIRECTORY_SEPARATOR, $infoClass) . '.php';
+        if (!CRM_Utils_File::isIncludable($infoClassFile)) {
+          continue;
+        }
+        require_once $infoClassFile;
         $infoObject = new $infoClass($cr->name, $cr->namespace, $cr->id);
         if ($infoObject->info['name'] !== $cr->name) {
           CRM_Core_Error::fatal("There is a discrepancy between name in component registry and in info file ({$cr->name}).");

--- a/CRM/Core/OptionValue.php
+++ b/CRM/Core/OptionValue.php
@@ -62,12 +62,15 @@ class CRM_Core_OptionValue {
    *   Has links like edit, delete, disable ..etc.
    * @param string $orderBy
    *   For orderBy clause.
+   * @param  bool  $skipEmptyComponents
+   *   Whether to skip OptionValue rows with empty Component name
+   *   (i.e. when Extension providing the Component is disabled)
    *
    * @return array
    *   Array of option-values
    *
    */
-  public static function getRows($groupParams, $links, $orderBy = 'weight') {
+  public static function getRows($groupParams, $links, $orderBy = 'weight', $skipEmptyComponents = TRUE) {
     $optionValue = array();
 
     $optionGroupID = NULL;
@@ -115,6 +118,13 @@ class CRM_Core_OptionValue {
     while ($dao->fetch()) {
       $optionValue[$dao->id] = array();
       CRM_Core_DAO::storeValues($dao, $optionValue[$dao->id]);
+      if (!empty($optionValue[$dao->id]['component_id']) &&
+        empty($componentNames[$optionValue[$dao->id]['component_id']]) &&
+        $skipEmptyComponents
+      ) {
+        unset($optionValue[$dao->id]);
+        continue;
+      }
       // form all action links
       $action = array_sum(array_keys($links));
 


### PR DESCRIPTION
@totten @eileenmcnaughton 

Source PR: https://github.com/civicrm/civicrm-core/pull/8353 (against 4.7)

As @eileenmcnaughton asked on https://github.com/civicrm/civicrm-core/pull/8353 I've created a new PR against the master branch. Also, here is my list of steps taken to show the issue and civicrm pages which are affected by it.

**---- Initial steps ----**

0a. Installing fresh Drupal + CiviCRM (civicrm-core master branch) setup using buildkit.

0b. Log in as 'admin'.

**---- No patch applied ----**
1. Checking Extensions list:
   ![original_extensions_list](https://cloud.githubusercontent.com/assets/8986209/15901347/3baa43dc-2da3-11e6-85a2-f8aeac56ebdb.png)
2. Checking Components list:
   (notice that CiviEvent and CiviContribute are there as disabled components)
   ![original_components_list](https://cloud.githubusercontent.com/assets/8986209/15901358/43dd47a2-2da3-11e6-8099-605598bb2c1f.png)
3. Checking Activity Types list:
   ![original_activity_types_list](https://cloud.githubusercontent.com/assets/8986209/15901364/49021c30-2da3-11e6-9eeb-c26fd55080ec.png)
4. Installing Tasksassignments extension (the one which has two custom Components inside - CiviTask and CiviDocument).
5. Checking Extensions list:
   ![after_ta_installation-extensions_list](https://cloud.githubusercontent.com/assets/8986209/15901375/53848b16-2da3-11e6-8f85-66429091a9e5.png)
6. Checking Components list:
   (notice that now there are CiviTask and CiviDocument enabled components)
   ![after_ta_installation-components_list](https://cloud.githubusercontent.com/assets/8986209/15901380/5a1fab4a-2da3-11e6-9d9b-272a01e456b2.png)
7. Checking Activity Types list:
   (there are Activity Types with both CiviTask and CiviDocument components visible)
   ![after_ta_installation-activity_types_list](https://cloud.githubusercontent.com/assets/8986209/15901403/6bd021bc-2da3-11e6-9c43-0999172bfe50.png)
   (also there are Activity Types with both CiviContribute and CiviEvent components visible)
   ![after_ta_installation-activity_types_list-civicontribute_and_civievent_entries](https://cloud.githubusercontent.com/assets/8986209/15901413/74e73cae-2da3-11e6-97ef-8d7ab0036e08.png)
8. Disabling CiviTask and CiviDocument components:
   ![after_ta_installation_and_disabled_civitask_and_cividocument_components-components_list](https://cloud.githubusercontent.com/assets/8986209/15901435/9444fa96-2da3-11e6-95d0-2947bfe64e86.png)
9. Checking Activity Types list:
   (entries with CiviTask and CiviDocument are still visible on the list but we can't choose any of disabled Components when creating a new Activity Type)
   ![after_ta_installation_and_disabled_civitask_and_cividocument_components-creating_a_new_activity_type-components_list](https://cloud.githubusercontent.com/assets/8986209/15901482/baad368a-2da3-11e6-8b92-bd881f1d7e88.png)
10. Disabling Tasksassignments extension:
    ![after_ta_disabling-extensions_list](https://cloud.githubusercontent.com/assets/8986209/15901489/c68580d4-2da3-11e6-99cf-a2ad41a53dc8.png)
11. Checking Extensions list - PHP Warning at the top of the page:
    ![after_ta_disabling-extensions_list-warning](https://cloud.githubusercontent.com/assets/8986209/15901498/ce919fa6-2da3-11e6-9a56-6c3c8a4b49b0.png)
    Warning info:
    `Warning: require_once(CRM/CiviTask/Info.php): failed to open stream: No such file or directory in CRM_Core_Component::getComponents() (line 98 of /home/kacper/www/hr194/sites/all/modules/civicrm/CRM/Core/Component.php).`
12. Checking Components list - Error 500:
    ![after_ta_disabling-components_list](https://cloud.githubusercontent.com/assets/8986209/15901551/fb0922b6-2da3-11e6-9f2b-0978672edc9a.png)
    Error info:
    `Components list page: Error 500:
    PHP Fatal error:  require_once(): Failed opening required 'CRM/CiviTask/Info.php' (include_path='/home/kacper/www/hr194/sites/all/modules/civicrm/tools/extensions/civihr/org.civicrm.reqangular/:/home/kacper/www/hr194/sites/all/modules/civicrm/tools/extensions/civihr/hrrecruitment/:/home/kacper/www/hr194/sites/all/modules/civicrm/tools/extensions/civihr/hrcaseutils/:/home/kacper/www/hr194/sites/all/modules/civicrm/tools/extensions/civihr/hrprofile/:/home/kacper/www/hr194/sites/all/modules/civicrm/tools/extensions/civihr/hrim/:/home/kacper/www/hr194/sites/all/modules/civicrm/tools/extensions/civihr/hrstaffdir/:/home/kacper/www/hr194/sites/all/modules/civicrm/tools/extensions/civihr/hrcase/:/home/kacper/www/hr194/sites/all/modules/civicrm/tools/extensions/civihr/hrui/:/home/kacper/www/hr194/sites/all/modules/civicrm/tools/extensions/civihr/hrreport/:/home/kacper/www/hr194/sites/all/modules/civicrm/tools/extensions/civihr/hrcareer/:/home/kacper/www/hr194/sites/all/modules/civicrm/tools/extensions/c in /home/kacper/www/hr194/sites/all/modules/civicrm/CRM/Core/Component.php on line 98`
    which refers to https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/Component.php#L98
13. Checking Activity Types list - Error 500 (the same as above).

**---- After applying the patch ----**
1. PHP Warning is no more on Extensions list page.
   ![after_ta_disabling_and_applying_the_patch-extensions_list-no_warning](https://cloud.githubusercontent.com/assets/8986209/15901611/4035d942-2da4-11e6-8bac-1b880dd4442c.png)
2. Checking Components list
   (shows no CiviTask and no CiviDocuments (custom Components within disabled Extension))
   ![after_ta_disabling_and_applying_the_patch-components_list](https://cloud.githubusercontent.com/assets/8986209/15901574/164dbe60-2da4-11e6-8d08-fcda0255712c.png)
3. Checking Activity Types list
   (no entries with disabled CiviTask and CiviDocument components)
   ![after_ta_disabling_and_applying_the_patch-activity_types_list-no_entries_with_disabled_civitask_and_cividocument_components](https://cloud.githubusercontent.com/assets/8986209/15901598/2ea0ecd0-2da4-11e6-8c5c-4c4cae913549.png)
   (but there are still visible Activity Types with CiviContribute and CiviEvent disabled components)
   ![after_ta_disabling_and_applying_the_patch-activity_types_list-entries_with_civicontribute_and_civievent_still_exist](https://cloud.githubusercontent.com/assets/8986209/15901606/38483284-2da4-11e6-8b46-be9ba5aadc15.png)
4. After uninstalling and installing Tasksandassignments extension again the system behaves as originally without the patch.

**---- The main conclusion ----**

As you could see on point 2 and 3 ("After applying the patch") - there is no components / component based entries (Activity Types) visibled if the Extension (which has the components inside) is disabled. Anyway, the core components (such as CiviContribute or CiviEvent) are still visible on the Components list / Activity Types list because they are core components (not extension components) and they are always accessible (use civicrm base include path). Long story short: the patch doesn't affect core components and they behave in the same way with or without the patch.
