### PR TITLE
CRM-19061 Updated Reports from sprint

### DIFF
--- a/CRM/Report/Form/Contribute/Bookkeeping.php
+++ b/CRM/Report/Form/Contribute/Bookkeeping.php
@@ -214,20 +214,20 @@ class CRM_Report_Form_Contribute_Bookkeeping extends CRM_Report_Form {
         'dao' => 'CRM_Price_DAO_LineItem',
         'fields' => array(
           'financial_type_id' => array(
-            'title' => ts('Financial Type'),
+            'title' => ts('Line Item Financial Type'),
             'default' => TRUE,
           ),
         ),
         'filters' => array(
           'financial_type_id' => array(
-            'title' => ts('Financial Type'),
+            'title' => ts('Line Item Financial Type'),
             'type' => CRM_Utils_Type::T_INT,
             'operatorType' => CRM_Report_Form::OP_MULTISELECT,
             'options' => CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes(),
           ),
         ),
         'order_bys' => array(
-          'financial_type_id' => array('title' => ts('Financial Type')),
+          'financial_type_id' => array('title' => ts('Line Item Financial Type')),
         ),
       ),
       'civicrm_batch' => array(

--- a/CRM/Report/Form/Contribute/Detail.php
+++ b/CRM/Report/Form/Contribute/Detail.php
@@ -32,26 +32,26 @@
  * $Id$
  *
  */
-class CRM_Report_Form_Contribute_Detail extends CRM_Report_Form {
+class CRM_Report_Form_Member_Detail extends CRM_Report_Form {
+
   protected $_addressField = FALSE;
 
   protected $_emailField = FALSE;
 
+  protected $_phoneField = FALSE;
+
+  protected $_contribField = FALSE;
+
   protected $_summary = NULL;
-  protected $_allBatches = NULL;
 
-  protected $_softFrom = NULL;
-
-  protected $_customGroupExtends = array(
-    'Contact',
-    'Individual',
-    'Contribution',
-  );
+  protected $_customGroupExtends = array('Membership', 'Contribution');
+  protected $_customGroupGroupBy = FALSE;
 
   /**
+   * Class constructor.
    */
   public function __construct() {
-    $this->_autoIncludeIndexedFieldsAsOrderBys = 1;
+
     // Check if CiviCampaign is a) enabled and b) has active campaigns
     $config = CRM_Core_Config::singleton();
     $campaignEnabled = in_array("CiviCampaign", $config->enableComponents);
@@ -60,37 +60,18 @@ class CRM_Report_Form_Contribute_Detail extends CRM_Report_Form {
       $this->activeCampaigns = $getCampaigns['campaigns'];
       asort($this->activeCampaigns);
     }
+
     $this->_columns = array(
         'civicrm_contact' => array(
           'dao' => 'CRM_Contact_DAO_Contact',
           'fields' => $this->getBasicContactFields(),
           'filters' => array(
             'sort_name' => array(
-              'title' => ts('Donor Name'),
+              'title' => ts('Contact Name'),
               'operator' => 'like',
             ),
-            'id' => array(
-              'title' => ts('Contact ID'),
-              'no_display' => TRUE,
-              'type' => CRM_Utils_Type::T_INT,
-            ),
-            'gender_id' => array(
-              'title' => ts('Gender'),
-              'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-              'options' => CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'gender_id'),
-            ),
-            'birth_date' => array(
-              'title' => ts('Birth Date'),
-              'operatorType' => CRM_Report_Form::OP_DATE,
-            ),
-            'contact_type' => array(
-              'title' => ts('Contact Type'),
-            ),
-            'contact_sub_type' => array(
-              'title' => ts('Contact Subtype'),
-            ),
+            'id' => array('no_display' => TRUE),
           ),
-          'grouping' => 'contact-fields',
           'order_bys' => array(
             'sort_name' => array(
               'title' => ts('Last Name, First Name'),
@@ -98,49 +79,91 @@ class CRM_Report_Form_Contribute_Detail extends CRM_Report_Form {
               'default_weight' => '0',
               'default_order' => 'ASC',
             ),
-            'first_name' => array(
-              'name' => 'first_name',
-              'title' => ts('First Name'),
-            ),
-            'gender_id' => array(
-              'name' => 'gender_id',
-              'title' => ts('Gender'),
-            ),
-            'birth_date' => array(
-              'name' => 'birth_date',
-              'title' => ts('Birth Date'),
-            ),
-            'contact_type' => array(
-              'title' => ts('Contact Type'),
-            ),
-            'contact_sub_type' => array(
-              'title' => ts('Contact Subtype'),
-            ),
-          ),
-
-        ),
-        'civicrm_email' => array(
-          'dao' => 'CRM_Core_DAO_Email',
-          'fields' => array(
-            'email' => array(
-              'title' => ts('Donor Email'),
-              'default' => TRUE,
-            ),
           ),
           'grouping' => 'contact-fields',
         ),
-        'civicrm_line_item' => array(
-          'dao' => 'CRM_Price_DAO_LineItem',
+        'civicrm_membership' => array(
+          'dao' => 'CRM_Member_DAO_Membership',
+          'fields' => array(
+            'membership_type_id' => array(
+              'title' => 'Membership Type',
+              'required' => TRUE,
+              'no_repeat' => TRUE,
+            ),
+            'membership_start_date' => array(
+              'title' => ts('Start Date'),
+              'default' => TRUE,
+            ),
+            'membership_end_date' => array(
+              'title' => ts('End Date'),
+              'default' => TRUE,
+            ),
+            'join_date' => array(
+              'title' => ts('Join Date'),
+              'default' => TRUE,
+            ),
+            'source' => array('title' => 'Source'),
+          ),
+          'filters' => array(
+            'join_date' => array('operatorType' => CRM_Report_Form::OP_DATE),
+            'membership_start_date' => array('operatorType' => CRM_Report_Form::OP_DATE),
+            'membership_end_date' => array('operatorType' => CRM_Report_Form::OP_DATE),
+            'owner_membership_id' => array(
+              'title' => ts('Membership Owner ID'),
+              'operatorType' => CRM_Report_Form::OP_INT,
+            ),
+            'tid' => array(
+              'name' => 'membership_type_id',
+              'title' => ts('Membership Types'),
+              'type' => CRM_Utils_Type::T_INT,
+              'operatorType' => CRM_Report_Form::OP_MULTISELECT,
+              'options' => CRM_Member_PseudoConstant::membershipType(),
+            ),
+          ),
+          'order_bys' => array(
+            'membership_type_id' => array(
+              'title' => ts('Membership Type'),
+              'default' => '0',
+              'default_weight' => '1',
+              'default_order' => 'ASC',
+            ),
+          ),
+          'grouping' => 'member-fields',
+          'group_bys' => array(
+            'id' => array(
+              'title' => ts('Membership'),
+              'default' => TRUE,
+            ),
+          ),
+        ),
+        'civicrm_membership_status' => array(
+          'dao' => 'CRM_Member_DAO_MembershipStatus',
+          'alias' => 'mem_status',
+          'fields' => array(
+            'name' => array(
+              'title' => ts('Status'),
+              'default' => TRUE,
+            ),
+          ),
+          'filters' => array(
+            'sid' => array(
+              'name' => 'id',
+              'title' => ts('Status'),
+              'type' => CRM_Utils_Type::T_INT,
+              'operatorType' => CRM_Report_Form::OP_MULTISELECT,
+              'options' => CRM_Member_PseudoConstant::membershipStatus(NULL, NULL, 'label'),
+            ),
+          ),
+          'grouping' => 'member-fields',
+        ),
+        'civicrm_email' => array(
+          'dao' => 'CRM_Core_DAO_Email',
+          'fields' => array('email' => NULL),
+          'grouping' => 'contact-fields',
         ),
         'civicrm_phone' => array(
           'dao' => 'CRM_Core_DAO_Phone',
-          'fields' => array(
-            'phone' => array(
-              'title' => ts('Donor Phone'),
-              'default' => TRUE,
-              'no_repeat' => TRUE,
-            ),
-          ),
+          'fields' => array('phone' => NULL),
           'grouping' => 'contact-fields',
         ),
         'civicrm_contribution' => array(
@@ -151,85 +174,29 @@ class CRM_Report_Form_Contribute_Detail extends CRM_Report_Form {
               'no_display' => TRUE,
               'required' => TRUE,
             ),
-            'list_contri_id' => array(
-              'name' => 'id',
-              'title' => ts('Contribution ID'),
-            ),
-            'financial_type_id' => array(
-              'title' => ts('Contribution Financial Type'),
-              'default' => TRUE,
-            ),
-            'contribution_status_id' => array(
-              'title' => ts('Contribution Status'),
-            ),
-            'contribution_page_id' => array(
-              'title' => ts('Contribution Page'),
-            ),
-            'source' => array(
-              'title' => ts('Source'),
-            ),
-            'payment_instrument_id' => array(
-              'title' => ts('Payment Type'),
-            ),
-            'check_number' => array(
-              'title' => ts('Check Number'),
-            ),
+            'financial_type_id' => array('title' => ts('Financial Type')),
+            'contribution_status_id' => array('title' => ts('Contribution Status')),
+            'payment_instrument_id' => array('title' => ts('Payment Type')),
             'currency' => array(
               'required' => TRUE,
               'no_display' => TRUE,
             ),
             'trxn_id' => NULL,
-            'receive_date' => array('default' => TRUE),
+            'receive_date' => NULL,
             'receipt_date' => NULL,
-            'total_amount' => array(
-              'title' => ts('Amount'),
-              'statistics' => array('sum' => ts('Amount')),
-            ),
             'fee_amount' => NULL,
             'net_amount' => NULL,
-            'contribution_or_soft' => array(
-              'title' => ts('Contribution OR Soft Credit?'),
-              'dbAlias' => "'Contribution'",
-            ),
-            'soft_credits' => array(
-              'title' => ts('Soft Credits'),
-              'dbAlias' => "NULL",
-            ),
-            'soft_credit_for' => array(
-              'title' => ts('Soft Credit For'),
-              'dbAlias' => "NULL",
+            'total_amount' => array(
+              'title' => ts('Payment Amount (most recent)'),
+              'statistics' => array('sum' => ts('Amount')),
             ),
           ),
           'filters' => array(
-            'contribution_or_soft' => array(
-              'title' => ts('Contribution OR Soft Credit?'),
-              'clause' => "(1)",
-              'operatorType' => CRM_Report_Form::OP_SELECT,
-              'type' => CRM_Utils_Type::T_STRING,
-              'options' => array(
-                'both' => ts('Both'),
-                'contributions_only' => ts('Contributions Only'),
-                'soft_credits_only' => ts('Soft Credits Only'),
-              ),
-            ),
             'receive_date' => array('operatorType' => CRM_Report_Form::OP_DATE),
-            'currency' => array(
-              'title' => 'Currency',
-              'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-              'options' => CRM_Core_OptionGroup::values('currencies_enabled'),
-              'default' => NULL,
-              'type' => CRM_Utils_Type::T_STRING,
-            ),
             'financial_type_id' => array(
-              'title' => ts('Contribution Financial Type'),
+              'title' => ts('Financial Type'),
               'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-              'options' => CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes(),
-              'type' => CRM_Utils_Type::T_INT,
-            ),
-            'contribution_page_id' => array(
-              'title' => ts('Contribution Page'),
-              'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-              'options' => CRM_Contribute_PseudoConstant::contributionPage(),
+              'options' => CRM_Contribute_PseudoConstant::financialType(),
               'type' => CRM_Utils_Type::T_INT,
             ),
             'payment_instrument_id' => array(
@@ -238,147 +205,52 @@ class CRM_Report_Form_Contribute_Detail extends CRM_Report_Form {
               'options' => CRM_Contribute_PseudoConstant::paymentInstrument(),
               'type' => CRM_Utils_Type::T_INT,
             ),
+            'currency' => array(
+              'title' => 'Currency',
+              'operatorType' => CRM_Report_Form::OP_MULTISELECT,
+              'options' => CRM_Core_OptionGroup::values('currencies_enabled'),
+              'default' => NULL,
+              'type' => CRM_Utils_Type::T_STRING,
+            ),
             'contribution_status_id' => array(
               'title' => ts('Contribution Status'),
               'operatorType' => CRM_Report_Form::OP_MULTISELECT,
               'options' => CRM_Contribute_PseudoConstant::contributionStatus(),
-              'default' => array(1),
               'type' => CRM_Utils_Type::T_INT,
             ),
             'total_amount' => array('title' => ts('Contribution Amount')),
           ),
           'order_bys' => array(
-            'financial_type_id' => array('title' => ts('Contribution Financial Type')),
-            'contribution_status_id' => array('title' => ts('Contribution Status')),
-            'payment_instrument_id' => array('title' => ts('Payment Method')),
-            'receive_date' => array('title' => ts('Date Received')),
+            'receive_date' => array(
+              'title' => ts('Date Received'),
+              'default_weight' => '2',
+              'default_order' => 'DESC',
+            ),
           ),
           'grouping' => 'contri-fields',
         ),
-        'civicrm_contribution_soft' => array(
-          'dao' => 'CRM_Contribute_DAO_ContributionSoft',
-          'fields' => array(
-            'soft_credit_type_id' => array('title' => ts('Soft Credit Type')),
-          ),
-          'filters' => array(
-            'soft_credit_type_id' => array(
-              'title' => 'Soft Credit Type',
-              'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-              'options' => CRM_Core_OptionGroup::values('soft_credit_type'),
-              'default' => NULL,
-              'type' => CRM_Utils_Type::T_STRING,
-            ),
-          ),
-        ),
-        'civicrm_line_item' => array(
-          'dao' => 'CRM_Price_DAO_LineItem',
-          'fields' => array(
-            'line_item_financial_type_id' => array(
-              'name' => 'financial_type_id',
-              'title' => ts('Line Item Financial Type'),
-              'default' => FALSE,
-            ),
-            'line_total' => array(
-              'title' => ts('Line Amount'),
-              'type' => CRM_Utils_Type::T_MONEY,
-              'default' => FALSE,
-            ),
-          ),
-          'filters' => array(
-            'line_item_financial_type_id' => array(
-              'name' => 'financial_type_id',
-              'title' => ts('Line Item Financial Type'),
-              'type' => CRM_Utils_Type::T_INT,
-              'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-              'options' => CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes(),
-            ),
-            'line_total' => array(
-              'title' => ts('Line Amount'),
-              'type' => CRM_Utils_Type::T_MONEY,
-              'default' => FALSE,
-            ),
-          ),
-          'group_bys' => array(
-            'line_item_financial_type_id' => array(
-              'name' => 'financial_type_id',
-              'title' => ts('Line Item Financial Type'),
-            ),
-          )
-        ),
-        'civicrm_contribution_ordinality' => array(
-          'dao' => 'CRM_Contribute_DAO_Contribution',
-          'alias' => 'cordinality',
-          'filters' => array(
-            'ordinality' => array(
-              'title' => ts('Contribution Ordinality'),
-              'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-              'options' => array(
-                0 => 'First by Contributor',
-                1 => 'Second or Later by Contributor',
-              ),
-              'type' => CRM_Utils_Type::T_INT,
-            ),
-          ),
-        ),
-        'civicrm_note' => array(
-          'dao' => 'CRM_Core_DAO_Note',
-          'fields' => array(
-            'contribution_note' => array(
-              'name' => 'note',
-              'title' => ts('Contribution Note'),
-            ),
-          ),
-          'filters' => array(
-            'note' => array(
-              'name' => 'note',
-              'title' => ts('Contribution Note'),
-              'operator' => 'like',
-              'type' => CRM_Utils_Type::T_STRING,
-            ),
-          ),
-        ),
-      ) + $this->addAddressFields(FALSE);
-    // The tests test for this variation of the sort_name field. Don't argue with the tests :-).
-    $this->_columns['civicrm_contact']['fields']['sort_name']['title'] = ts('Donor Name');
+      ) + $this->getAddressColumns(array(
+        // These options are only excluded because they were not previously present.
+        'order_by' => FALSE,
+        'group_by' => FALSE,
+      ));
     $this->_groupFilter = TRUE;
     $this->_tagFilter = TRUE;
 
-    // Don't show Batch display column and filter unless batches are being used
-    $this->_allBatches = CRM_Batch_BAO_Batch::getBatches();
-    if (!empty($this->_allBatches)) {
-      $this->_columns['civicrm_batch']['dao'] = 'CRM_Batch_DAO_Batch';
-      $this->_columns['civicrm_batch']['fields']['batch_id'] = array(
-        'name' => 'id',
-        'title' => ts('Batch Name'),
-      );
-      $this->_columns['civicrm_batch']['filters']['bid'] = array(
-        'name' => 'id',
-        'title' => ts('Batch Name'),
-        'type' => CRM_Utils_Type::T_INT,
-        'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-        'options' => $this->_allBatches,
-      );
-      $this->_columns['civicrm_entity_batch']['dao'] = 'CRM_Batch_DAO_EntityBatch';
-      $this->_columns['civicrm_entity_batch']['fields']['entity_batch_id'] = array(
-        'name' => 'batch_id',
-        'default' => TRUE,
-        'no_display' => TRUE,
-      );
-    }
-
     // If we have active campaigns add those elements to both the fields and filters
     if ($campaignEnabled && !empty($this->activeCampaigns)) {
-      $this->_columns['civicrm_contribution']['fields']['campaign_id'] = array(
+      $this->_columns['civicrm_membership']['fields']['campaign_id'] = array(
         'title' => ts('Campaign'),
         'default' => 'false',
       );
-      $this->_columns['civicrm_contribution']['filters']['campaign_id'] = array(
+      $this->_columns['civicrm_membership']['filters']['campaign_id'] = array(
         'title' => ts('Campaign'),
         'operatorType' => CRM_Report_Form::OP_MULTISELECT,
         'options' => $this->activeCampaigns,
         'type' => CRM_Utils_Type::T_INT,
       );
-      $this->_columns['civicrm_contribution']['order_bys']['campaign_id'] = array('title' => ts('Campaign'));
+      $this->_columns['civicrm_membership']['order_bys']['campaign_id'] = array('title' => ts('Campaign'));
+
     }
 
     $this->_currencyColumn = 'civicrm_contribution_currency';
@@ -386,375 +258,96 @@ class CRM_Report_Form_Contribute_Detail extends CRM_Report_Form {
   }
 
   public function preProcess() {
+    $this->assign('reportTitle', ts('Membership Detail Report'));
     parent::preProcess();
   }
 
   public function select() {
-    $this->_columnHeaders = array();
+    $select = $this->_columnHeaders = array();
 
-    parent::select();
-    //total_amount was affected by sum as it is considered as one of the stat field
-    //so it is been replaced with correct alias, CRM-13833
-    $this->_select = str_replace("sum({$this->_aliases['civicrm_contribution']}.total_amount)", "{$this->_aliases['civicrm_contribution']}.total_amount", $this->_select);
-  }
-
-  public function orderBy() {
-    parent::orderBy();
-
-    // please note this will just add the order-by columns to select query, and not display in column-headers.
-    // This is a solution to not throw fatal errors when there is a column in order-by, not present in select/display columns.
-    foreach ($this->_orderByFields as $orderBy) {
-      if (!array_key_exists($orderBy['name'], $this->_params['fields']) &&
-        empty($orderBy['section']) && (strpos($this->_select, $orderBy['dbAlias']) === FALSE)
-      ) {
-        $this->_select .= ", {$orderBy['dbAlias']} as {$orderBy['tplField']}";
+    foreach ($this->_columns as $tableName => $table) {
+      if (array_key_exists('fields', $table)) {
+        foreach ($table['fields'] as $fieldName => $field) {
+          if (!empty($field['required']) || !empty($this->_params['fields'][$fieldName])) {
+            if ($tableName == 'civicrm_email') {
+              $this->_emailField = TRUE;
+            }
+            elseif ($tableName == 'civicrm_phone') {
+              $this->_phoneField = TRUE;
+            }
+            elseif ($tableName == 'civicrm_contribution') {
+              $this->_contribField = TRUE;
+            }
+            $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
+            if (array_key_exists('title', $field)) {
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'];
+            }
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
+          }
+        }
       }
     }
+
+    $this->_select = "SELECT " . implode(', ', $select) . " ";
   }
 
-  /**
-   * @param bool $softcredit
-   */
-  public function from($softcredit = FALSE) {
+  public function from() {
     $this->_from = "
-        FROM  civicrm_contact      {$this->_aliases['civicrm_contact']} {$this->_aclFrom}
-              INNER JOIN civicrm_contribution {$this->_aliases['civicrm_contribution']}
-                      ON {$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_contribution']}.contact_id AND {$this->_aliases['civicrm_contribution']}.is_test = 0";
-    $this->getPermissionedFTQuery($this);
+         FROM  civicrm_contact {$this->_aliases['civicrm_contact']} {$this->_aclFrom}
+               INNER JOIN civicrm_membership {$this->_aliases['civicrm_membership']}
+                          ON {$this->_aliases['civicrm_contact']}.id =
+                             {$this->_aliases['civicrm_membership']}.contact_id AND {$this->_aliases['civicrm_membership']}.is_test = 0
+               LEFT  JOIN civicrm_membership_status {$this->_aliases['civicrm_membership_status']}
+                          ON {$this->_aliases['civicrm_membership_status']}.id =
+                             {$this->_aliases['civicrm_membership']}.status_id ";
 
-    if (CRM_Utils_Array::value('contribution_or_soft_value', $this->_params) ==
-      'both'
-    ) {
-      $this->_from .= "\n LEFT JOIN civicrm_contribution_soft contribution_soft_civireport
-                         ON contribution_soft_civireport.contribution_id = {$this->_aliases['civicrm_contribution']}.id";
-    }
-    elseif (CRM_Utils_Array::value('contribution_or_soft_value', $this->_params) ==
-      'soft_credits_only'
-    ) {
-      $this->_from .= "\n INNER JOIN civicrm_contribution_soft contribution_soft_civireport
-                         ON contribution_soft_civireport.contribution_id = {$this->_aliases['civicrm_contribution']}.id";
-    }
-
-    if ($softcredit) {
-      $this->_from = "
-        FROM  civireport_contribution_detail_temp1 temp1_civireport
-               INNER JOIN civicrm_contribution {$this->_aliases['civicrm_contribution']}
-                       ON temp1_civireport.civicrm_contribution_contribution_id = {$this->_aliases['civicrm_contribution']}.id
-               INNER JOIN civicrm_contribution_soft contribution_soft_civireport
-                       ON contribution_soft_civireport.contribution_id = {$this->_aliases['civicrm_contribution']}.id
-               INNER JOIN civicrm_contact      {$this->_aliases['civicrm_contact']}
-                       ON {$this->_aliases['civicrm_contact']}.id = contribution_soft_civireport.contact_id
-               {$this->_aclFrom}";
-    }
-
-    if (!empty($this->_params['ordinality_value'])) {
-      if (!empty($this->_params['line_item_financial_type_id_value']) || ($this->_params['line_total_value'] !== "")) {
-        $this->_from .= "
-          INNER JOIN (SELECT c.id, IF(COUNT(ol.id) = 0, 0, 1) AS ordinality
-           FROM civicrm_contribution c
-           LEFT JOIN civicrm_line_item l ON c.id = l.contribution_id
-           LEFT JOIN civicrm_contribution oc ON c.contact_id = oc.contact_id AND oc.receive_date < c.receive_date
-           LEFT JOIN civicrm_line_item ol ON oc.id = ol.contribution_id AND ol.financial_type_id IN (" . implode(",", $this->_params['line_item_financial_type_id_value']) . ")
-           GROUP BY l.id)
-	       cordinality_civireport ON cordinality_civireport.id = contribution_civireport.id ";
-      }
-      else {
-
-        $this->_from .= "
-              INNER JOIN (SELECT c.id, IF(COUNT(oc.id) = 0, 0, 1) AS ordinality FROM civicrm_contribution c LEFT JOIN civicrm_contribution oc ON c.contact_id = oc.contact_id AND oc.receive_date < c.receive_date GROUP BY c.id) {$this->_aliases['civicrm_contribution_ordinality']}
-                      ON {$this->_aliases['civicrm_contribution_ordinality']}.id = {$this->_aliases['civicrm_contribution']}.id";
-      }
-    }
-
-    $this->addPhoneFromClause();
-
-    if ($this->_addressField OR
-      (!empty($this->_params['state_province_id_value']) OR
-        !empty($this->_params['country_id_value']))
-    ) {
+    if ($this->isTableSelected('civicrm_address')) {
       $this->_from .= "
-            LEFT JOIN civicrm_address {$this->_aliases['civicrm_address']}
-                   ON {$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_address']}.contact_id AND
-                      {$this->_aliases['civicrm_address']}.is_primary = 1\n";
+             LEFT JOIN civicrm_address {$this->_aliases['civicrm_address']}
+                       ON {$this->_aliases['civicrm_contact']}.id =
+                          {$this->_aliases['civicrm_address']}.contact_id AND
+                          {$this->_aliases['civicrm_address']}.is_primary = 1\n";
     }
 
+    //used when email field is selected
     if ($this->_emailField) {
       $this->_from .= "
-            LEFT JOIN civicrm_email {$this->_aliases['civicrm_email']}
-                   ON {$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_email']}.contact_id AND
-                      {$this->_aliases['civicrm_email']}.is_primary = 1\n";
+              LEFT JOIN civicrm_email {$this->_aliases['civicrm_email']}
+                        ON {$this->_aliases['civicrm_contact']}.id =
+                           {$this->_aliases['civicrm_email']}.contact_id AND
+                           {$this->_aliases['civicrm_email']}.is_primary = 1\n";
     }
-    // include contribution note
-    if (!empty($this->_params['fields']['contribution_note']) ||
-      !empty($this->_params['note_value'])
-    ) {
+    //used when phone field is selected
+    if ($this->_phoneField) {
       $this->_from .= "
-            LEFT JOIN civicrm_note {$this->_aliases['civicrm_note']}
-                      ON ( {$this->_aliases['civicrm_note']}.entity_table = 'civicrm_contribution' AND
-                           {$this->_aliases['civicrm_contribution']}.id = {$this->_aliases['civicrm_note']}.entity_id )";
+              LEFT JOIN civicrm_phone {$this->_aliases['civicrm_phone']}
+                        ON {$this->_aliases['civicrm_contact']}.id =
+                           {$this->_aliases['civicrm_phone']}.contact_id AND
+                           {$this->_aliases['civicrm_phone']}.is_primary = 1\n";
     }
-    //for contribution batches
-    if ($this->_allBatches &&
-      (!empty($this->_params['fields']['batch_id']) ||
-        !empty($this->_params['bid_value']))
-    ) {
+    //used when contribution field is selected
+    if ($this->_contribField) {
       $this->_from .= "
-        LEFT JOIN (
-          SELECT entity_id, financial_trxn_id
-          FROM civicrm_entity_financial_trxn
-          WHERE entity_table = 'civicrm_contribution'
-          GROUP BY entity_id
-        ) tx ON tx.entity_id = {$this->_aliases['civicrm_contribution']}.id
-        LEFT JOIN  civicrm_entity_batch {$this->_aliases['civicrm_entity_batch']}
-          ON ({$this->_aliases['civicrm_entity_batch']}.entity_id = tx.financial_trxn_id
-          AND {$this->_aliases['civicrm_entity_batch']}.entity_table = 'civicrm_financial_trxn')
-        LEFT JOIN civicrm_batch {$this->_aliases['civicrm_batch']}
-          ON {$this->_aliases['civicrm_batch']}.id = {$this->_aliases['civicrm_entity_batch']}.batch_id";
+             LEFT JOIN civicrm_membership_payment cmp
+                 ON {$this->_aliases['civicrm_membership']}.id = cmp.membership_id
+             LEFT JOIN civicrm_contribution {$this->_aliases['civicrm_contribution']}
+                 ON cmp.contribution_id={$this->_aliases['civicrm_contribution']}.id\n";
     }
-
-    // for line item financial types
-    if (!empty($this->_params['line_item_financial_type_id_value']) || ($this->_params['line_total_value'] !== "")) {
-      $this->_from .= "
-              LEFT  JOIN civicrm_line_item  {$this->_aliases['civicrm_line_item']}
-                      ON {$this->_aliases['civicrm_contribution']}.id = {$this->_aliases['civicrm_line_item']}.contribution_id";
-    }
-  }
-
-  public function groupBy() {
-    $this->_groupBy = " GROUP BY {$this->_aliases['civicrm_contact']}.id, {$this->_aliases['civicrm_contribution']}.id ";
-  }
-
-  /**
-   * @param $rows
-   *
-   * @return array
-   */
-  public function statistics(&$rows) {
-    $statistics = parent::statistics($rows);
-
-    $totalAmount = $average = $fees = $net = array();
-    $count = 0;
-    $select = "
-        SELECT COUNT({$this->_aliases['civicrm_contribution']}.total_amount ) as count,
-               SUM( {$this->_aliases['civicrm_contribution']}.total_amount ) as amount,
-               ROUND(AVG({$this->_aliases['civicrm_contribution']}.total_amount), 2) as avg,
-               {$this->_aliases['civicrm_contribution']}.currency as currency,
-               SUM( {$this->_aliases['civicrm_contribution']}.fee_amount ) as fees,
-               SUM( {$this->_aliases['civicrm_contribution']}.net_amount ) as net
-        ";
-    // for line item financial types
-    if (!empty($this->_params['line_item_financial_type_id_value']) || ($this->_params['line_total_value'] !== "")) {
-      $select .= ",
-               COUNT({$this->_aliases['civicrm_line_item']}.line_total ) as line_count,
-               SUM( {$this->_aliases['civicrm_line_item']}.line_total ) as line_totals";
-    }
-
-    $group = "\nGROUP BY {$this->_aliases['civicrm_contribution']}.currency";
-    $sql = "{$select} {$this->_from} {$this->_where} {$group}";
-    $dao = CRM_Core_DAO::executeQuery($sql);
-
-    while ($dao->fetch()) {
-      // for line item financial types
-      if (!empty($this->_params['line_item_financial_type_id_value']) || ($this->_params['line_total_value'] !== "")) {
-        $lineAmounts[] = CRM_Utils_Money::format($dao->line_totals, $dao->currency) . " (" . $statistics['counts']['rowsFound']['value'] . ")";
-      }
-      $totalAmount[] = CRM_Utils_Money::format($dao->amount, $dao->currency) . " (" . $dao->count . ")";
-      $fees[] = CRM_Utils_Money::format($dao->fees, $dao->currency);
-      $net[] = CRM_Utils_Money::format($dao->net, $dao->currency);
-      $average[] = CRM_Utils_Money::format($dao->avg, $dao->currency);
-      $count += $dao->count;
-    }
-    // for line item financial types
-    if (!empty($this->_params['line_item_financial_type_id_value']) || ($this->_params['line_total_value'] !== "")) {
-      $statistics['counts']['line_totals'] = array(
-        'title' => ts('Total Amounts (Line Items)'),
-        'value' => implode(',  ', $lineAmounts),
-        'type' => CRM_Utils_Type::T_STRING,
-      );
-    }
-    $statistics['counts']['amount'] = array(
-      'title' => ts('Total Amount (Contributions)'),
-      'value' => implode(',  ', $totalAmount),
-      'type' => CRM_Utils_Type::T_STRING,
-    );
-    $statistics['counts']['count'] = array(
-      'title' => ts('Total Contributions'),
-      'value' => $count,
-    );
-    $statistics['counts']['fees'] = array(
-      'title' => ts('Fees'),
-      'value' => implode(',  ', $fees),
-      'type' => CRM_Utils_Type::T_STRING,
-    );
-    $statistics['counts']['net'] = array(
-      'title' => ts('Net'),
-      'value' => implode(',  ', $net),
-      'type' => CRM_Utils_Type::T_STRING,
-    );
-    $statistics['counts']['avg'] = array(
-      'title' => ts('Average'),
-      'value' => implode(',  ', $average),
-      'type' => CRM_Utils_Type::T_STRING,
-    );
-
-    // Stats for soft credits
-    if ($this->_softFrom &&
-      CRM_Utils_Array::value('contribution_or_soft_value', $this->_params) !=
-      'contributions_only'
-    ) {
-      $totalAmount = $average = array();
-      $count = 0;
-      $select = "
-SELECT COUNT(contribution_soft_civireport.amount ) as count,
-       SUM(contribution_soft_civireport.amount ) as amount,
-       ROUND(AVG(contribution_soft_civireport.amount), 2) as avg,
-       {$this->_aliases['civicrm_contribution']}.currency as currency";
-      $sql = "
-{$select}
-{$this->_softFrom}
-GROUP BY {$this->_aliases['civicrm_contribution']}.currency";
-      $dao = CRM_Core_DAO::executeQuery($sql);
-      while ($dao->fetch()) {
-        $totalAmount[] = CRM_Utils_Money::format($dao->amount, $dao->currency) . " (" .
-          $dao->count . ")";
-        $average[] = CRM_Utils_Money::format($dao->avg, $dao->currency);
-        $count += $dao->count;
-      }
-      $statistics['counts']['softamount'] = array(
-        'title' => ts('Total Amount (Soft Credits)'),
-        'value' => implode(',  ', $totalAmount),
-        'type' => CRM_Utils_Type::T_STRING,
-      );
-      $statistics['counts']['softcount'] = array(
-        'title' => ts('Total Soft Credits'),
-        'value' => $count,
-      );
-      $statistics['counts']['softavg'] = array(
-        'title' => ts('Average (Soft Credits)'),
-        'value' => implode(',  ', $average),
-        'type' => CRM_Utils_Type::T_STRING,
-      );
-    }
-
-    return $statistics;
   }
 
   public function postProcess() {
-    // get the acl clauses built before we assemble the query
-    $this->buildACLClause($this->_aliases['civicrm_contact']);
 
     $this->beginPostProcess();
-    // CRM-18312 - display soft_credits and soft_credits_for column
-    // when 'Contribution or Soft Credit?' column is not selected
-    if (empty($this->_params['fields']['contribution_or_soft'])) {
-      $this->_params['fields']['contribution_or_soft'] = 1;
-      $this->noDisplayContributionOrSoftColumn = TRUE;
-    }
 
-    if (CRM_Utils_Array::value('contribution_or_soft_value', $this->_params) ==
-      'contributions_only' &&
-      !empty($this->_params['fields']['soft_credit_type_id'])
-    ) {
-      unset($this->_params['fields']['soft_credit_type_id']);
-      if (!empty($this->_params['soft_credit_type_id_value'])) {
-        $this->_params['soft_credit_type_id_value'] = array();
-      }
-    }
+    // get the acl clauses built before we assemble the query
+    $this->buildACLClause($this->_aliases['civicrm_contact']);
+    $sql = $this->buildQuery(TRUE);
 
-    // 1. use main contribution query to build temp table 1
-    $sql = $this->buildQuery();
-    $tempQuery = 'CREATE TEMPORARY TABLE civireport_contribution_detail_temp1 AS ' . $sql;
-    CRM_Core_DAO::executeQuery($tempQuery);
-    $this->setPager();
-
-    // 2. customize main contribution query for soft credit, and build temp table 2 with soft credit contributions only
-    $this->from(TRUE);
-    // also include custom group from if included
-    // since this might be included in select
-    $this->customDataFrom();
-
-    $select = str_ireplace('contribution_civireport.total_amount', 'contribution_soft_civireport.amount', $this->_select);
-    $select = str_ireplace("'Contribution' as", "'Soft Credit' as", $select);
-    // we inner join with temp1 to restrict soft contributions to those in temp1 table
-    $sql = "{$select} {$this->_from} {$this->_where} {$this->_groupBy}";
-    $tempQuery = 'CREATE TEMPORARY TABLE civireport_contribution_detail_temp2 AS ' . $sql;
-    CRM_Core_DAO::executeQuery($tempQuery);
-    if (CRM_Utils_Array::value('contribution_or_soft_value', $this->_params) ==
-      'soft_credits_only'
-    ) {
-      // revise pager : prev, next based on soft-credits only
-      $this->setPager();
-    }
-
-    // copy _from for later use of stats calculation for soft credits, and reset $this->_from to main query
-    $this->_softFrom = $this->_from;
-
-    // simple reset of ->_from
-    $this->from();
-
-    // also include custom group from if included
-    // since this might be included in select
-    $this->customDataFrom();
-
-    // 3. Decide where to populate temp3 table from
-    if (CRM_Utils_Array::value('contribution_or_soft_value', $this->_params) ==
-      'contributions_only'
-    ) {
-      $tempQuery = "(SELECT * FROM civireport_contribution_detail_temp1)";
-    }
-    elseif (CRM_Utils_Array::value('contribution_or_soft_value', $this->_params) ==
-      'soft_credits_only'
-    ) {
-      $tempQuery = "(SELECT * FROM civireport_contribution_detail_temp2)";
-    }
-    else {
-      $tempQuery = "
-(SELECT * FROM civireport_contribution_detail_temp1)
-UNION ALL
-(SELECT * FROM civireport_contribution_detail_temp2)";
-    }
-
-    // 4. build temp table 3
-    $sql = "CREATE TEMPORARY TABLE civireport_contribution_detail_temp3 AS {$tempQuery}";
-    CRM_Core_DAO::executeQuery($sql);
-
-    // 5. Re-construct order-by to make sense for final query on temp3 table
-    $orderBy = '';
-    if (!empty($this->_orderByArray)) {
-      $aliases = array_flip($this->_aliases);
-      $orderClause = array();
-      foreach ($this->_orderByArray as $clause) {
-        list($alias, $rest) = explode('.', $clause);
-        // CRM-17280 -- In case, we are ordering by custom fields
-        // modify $rest to match the alias used for them in temp3 table
-        $grp = new CRM_Core_DAO_CustomGroup();
-        $grp->table_name = $aliases[$alias];
-        if ($grp->find()) {
-          list($fld, $order) = explode(' ', $rest);
-          foreach ($this->_columns[$aliases[$alias]]['fields'] as $fldName => $value) {
-            if ($value['name'] == $fld) {
-              $fld = $fldName;
-            }
-          }
-          $rest = "{$fld} {$order}";
-        }
-        $orderClause[] = $aliases[$alias] . "_" . $rest;
-      }
-      $orderBy = (!empty($orderClause)) ? "ORDER BY " . implode(', ', $orderClause) : '';
-    }
-
-    // 6. show result set from temp table 3
     $rows = array();
-    $sql = "SELECT * FROM civireport_contribution_detail_temp3 {$orderBy}";
     $this->buildRows($sql, $rows);
 
-    // format result set.
-    $this->formatDisplay($rows, FALSE);
-
-    // assign variables to templates
+    $this->formatDisplay($rows);
     $this->doTemplateAssignment($rows);
-
-    // do print / pdf / instance stuff if needed
     $this->endPostProcess($rows);
   }
 
@@ -768,58 +361,69 @@ UNION ALL
    *   Rows generated by SQL, with an array for each row.
    */
   public function alterDisplay(&$rows) {
-    $checkList = array();
     $entryFound = FALSE;
-    $display_flag = $prev_cid = $cid = 0;
+    $checkList = array();
+
     $contributionTypes = CRM_Contribute_PseudoConstant::financialType();
     $contributionStatus = CRM_Contribute_PseudoConstant::contributionStatus();
     $paymentInstruments = CRM_Contribute_PseudoConstant::paymentInstrument();
-    $contributionPages = CRM_Contribute_PseudoConstant::contributionPage();
 
+    $repeatFound = FALSE;
     foreach ($rows as $rowNum => $row) {
+      if ($repeatFound == FALSE ||
+        $repeatFound < $rowNum - 1
+      ) {
+        unset($checkList);
+        $checkList = array();
+      }
       if (!empty($this->_noRepeats) && $this->_outputMode != 'csv') {
-        // don't repeat contact details if its same as the previous row
-        if (array_key_exists('civicrm_contact_id', $row)) {
-          if ($cid = $row['civicrm_contact_id']) {
-            if ($rowNum == 0) {
-              $prev_cid = $cid;
-            }
-            else {
-              if ($prev_cid == $cid) {
-                $display_flag = 1;
-                $prev_cid = $cid;
+        // not repeat contact display names if it matches with the one
+        // in previous row
+        foreach ($row as $colName => $colVal) {
+          if (in_array($colName, $this->_noRepeats) &&
+            $rowNum > 0
+          ) {
+            if ($rows[$rowNum][$colName] == $rows[$rowNum - 1][$colName] ||
+              (!empty($checkList[$colName]) &&
+                in_array($colVal, $checkList[$colName]))
+            ) {
+              $rows[$rowNum][$colName] = "";
+              // CRM-15917: Don't blank the name if it's a different contact
+              if ($colName == 'civicrm_contact_exposed_id') {
+                $rows[$rowNum]['civicrm_contact_sort_name'] = "";
               }
-              else {
-                $display_flag = 0;
-                $prev_cid = $cid;
-              }
+              $repeatFound = $rowNum;
             }
-
-            if ($display_flag) {
-              foreach ($row as $colName => $colVal) {
-                // Hide repeats in no-repeat columns, but not if the field's a section header
-                if (in_array($colName, $this->_noRepeats) &&
-                  !array_key_exists($colName, $this->_sections)
-                ) {
-                  unset($rows[$rowNum][$colName]);
-                }
-              }
-            }
-            $entryFound = TRUE;
+          }
+          if (in_array($colName, $this->_noRepeats)) {
+            $checkList[$colName][] = $colVal;
           }
         }
       }
 
-      if (CRM_Utils_Array::value('civicrm_contribution_contribution_or_soft', $rows[$rowNum]) ==
-        'Contribution'
-      ) {
-        unset($rows[$rowNum]['civicrm_contribution_soft_soft_credit_type_id']);
+      if (array_key_exists('civicrm_membership_membership_type_id', $row)) {
+        if ($value = $row['civicrm_membership_membership_type_id']) {
+          $rows[$rowNum]['civicrm_membership_membership_type_id'] = CRM_Member_PseudoConstant::membershipType($value, FALSE);
+        }
+        $entryFound = TRUE;
       }
 
-      $entryFound = $this->alterDisplayContactFields($row, $rows, $rowNum, 'contribution/detail', ts('View Contribution Details')) ? TRUE : $entryFound;
-      // convert donor sort name to link
+      if (array_key_exists('civicrm_address_state_province_id', $row)) {
+        if ($value = $row['civicrm_address_state_province_id']) {
+          $rows[$rowNum]['civicrm_address_state_province_id'] = CRM_Core_PseudoConstant::stateProvince($value, FALSE);
+        }
+        $entryFound = TRUE;
+      }
+
+      if (array_key_exists('civicrm_address_country_id', $row)) {
+        if ($value = $row['civicrm_address_country_id']) {
+          $rows[$rowNum]['civicrm_address_country_id'] = CRM_Core_PseudoConstant::country($value, FALSE);
+        }
+        $entryFound = TRUE;
+      }
+
       if (array_key_exists('civicrm_contact_sort_name', $row) &&
-        !empty($rows[$rowNum]['civicrm_contact_sort_name']) &&
+        $rows[$rowNum]['civicrm_contact_sort_name'] &&
         array_key_exists('civicrm_contact_id', $row)
       ) {
         $url = CRM_Utils_System::url("civicrm/contact/view",
@@ -828,6 +432,7 @@ UNION ALL
         );
         $rows[$rowNum]['civicrm_contact_sort_name_link'] = $url;
         $rows[$rowNum]['civicrm_contact_sort_name_hover'] = ts("View Contact Summary for this Contact.");
+        $entryFound = TRUE;
       }
 
       if ($value = CRM_Utils_Array::value('civicrm_contribution_financial_type_id', $row)) {
@@ -838,216 +443,23 @@ UNION ALL
         $rows[$rowNum]['civicrm_contribution_contribution_status_id'] = $contributionStatus[$value];
         $entryFound = TRUE;
       }
-      if ($value = CRM_Utils_Array::value('civicrm_contribution_contribution_page_id', $row)) {
-        $rows[$rowNum]['civicrm_contribution_contribution_page_id'] = $contributionPages[$value];
-        $entryFound = TRUE;
-      }
       if ($value = CRM_Utils_Array::value('civicrm_contribution_payment_instrument_id', $row)) {
         $rows[$rowNum]['civicrm_contribution_payment_instrument_id'] = $paymentInstruments[$value];
         $entryFound = TRUE;
       }
-      if (array_key_exists('civicrm_batch_batch_id', $row)) {
-        if ($value = $row['civicrm_batch_batch_id']) {
-          $rows[$rowNum]['civicrm_batch_batch_id'] = CRM_Core_DAO::getFieldValue('CRM_Batch_DAO_Batch', $value, 'title');
-        }
-        $entryFound = TRUE;
-      }
 
-      // change line item financial type ID to financial type name
-      if ($value = CRM_Utils_Array::value('civicrm_line_item_line_item_financial_type_id', $row)) {
-        $rows[$rowNum]['civicrm_line_item_line_item_financial_type_id'] = $contributionTypes[$value];
-        $entryFound = TRUE;
-      }
-
-      // Contribution amount links to viewing contribution
-      if (($value = CRM_Utils_Array::value('civicrm_contribution_total_amount_sum', $row)) &&
-        CRM_Core_Permission::check('access CiviContribute')
-      ) {
-        $url = CRM_Utils_System::url("civicrm/contact/view/contribution",
-          "reset=1&id=" . $row['civicrm_contribution_contribution_id'] .
-          "&cid=" . $row['civicrm_contact_id'] .
-          "&action=view&context=contribution&selectedChild=contribute",
-          $this->_absoluteUrl
-        );
-        $rows[$rowNum]['civicrm_contribution_total_amount_sum_link'] = $url;
-        $rows[$rowNum]['civicrm_contribution_total_amount_sum_hover'] = ts("View Details of this Contribution.");
-        $entryFound = TRUE;
-      }
-
-      // convert campaign_id to campaign title
-      if (array_key_exists('civicrm_contribution_campaign_id', $row)) {
-        if ($value = $row['civicrm_contribution_campaign_id']) {
-          $rows[$rowNum]['civicrm_contribution_campaign_id'] = $this->activeCampaigns[$value];
+      // Convert campaign_id to campaign title
+      if (array_key_exists('civicrm_membership_campaign_id', $row)) {
+        if ($value = $row['civicrm_membership_campaign_id']) {
+          $rows[$rowNum]['civicrm_membership_campaign_id'] = $this->activeCampaigns[$value];
           $entryFound = TRUE;
         }
       }
+      $entryFound = $this->alterDisplayAddressFields($row, $rows, $rowNum, 'member/detail', 'List all memberships(s) for this ') ? TRUE : $entryFound;
+      $entryFound = $this->alterDisplayContactFields($row, $rows, $rowNum, 'member/detail', 'List all memberships(s) for this ') ? TRUE : $entryFound;
 
-      // soft credits
-      if (array_key_exists('civicrm_contribution_soft_credits', $row) &&
-        'Contribution' ==
-        CRM_Utils_Array::value('civicrm_contribution_contribution_or_soft', $rows[$rowNum]) &&
-        array_key_exists('civicrm_contribution_contribution_id', $row)
-      ) {
-        $query = "
-SELECT civicrm_contact_id, civicrm_contact_sort_name, civicrm_contribution_total_amount_sum, civicrm_contribution_currency
-FROM   civireport_contribution_detail_temp2
-WHERE  civicrm_contribution_contribution_id={$row['civicrm_contribution_contribution_id']}";
-        $dao = CRM_Core_DAO::executeQuery($query);
-        $string = '';
-        $separator = ($this->_outputMode !== 'csv') ? "<br/>" : ' ';
-        while ($dao->fetch()) {
-          $url = CRM_Utils_System::url("civicrm/contact/view", 'reset=1&cid=' .
-            $dao->civicrm_contact_id);
-          $string = $string . ($string ? $separator : '') .
-            "<a href='{$url}'>{$dao->civicrm_contact_sort_name}</a> " .
-            CRM_Utils_Money::format($dao->civicrm_contribution_total_amount_sum, $dao->civicrm_contribution_currency);
-        }
-        $rows[$rowNum]['civicrm_contribution_soft_credits'] = $string;
-      }
-
-      if (array_key_exists('civicrm_contribution_soft_credit_for', $row) &&
-        'Soft Credit' ==
-        CRM_Utils_Array::value('civicrm_contribution_contribution_or_soft', $rows[$rowNum]) &&
-        array_key_exists('civicrm_contribution_contribution_id', $row)
-      ) {
-        $query = "
-SELECT civicrm_contact_id, civicrm_contact_sort_name
-FROM   civireport_contribution_detail_temp1
-WHERE  civicrm_contribution_contribution_id={$row['civicrm_contribution_contribution_id']}";
-        $dao = CRM_Core_DAO::executeQuery($query);
-        $string = '';
-        while ($dao->fetch()) {
-          $url = CRM_Utils_System::url("civicrm/contact/view", 'reset=1&cid=' .
-            $dao->civicrm_contact_id);
-          $string = $string .
-            "\n<a href='{$url}'>{$dao->civicrm_contact_sort_name}</a>";
-        }
-        $rows[$rowNum]['civicrm_contribution_soft_credit_for'] = $string;
-      }
-
-      // CRM-18312 - hide 'contribution_or_soft' column if unchecked.
-      if (!empty($this->noDisplayContributionOrSoftColumn)) {
-        unset($rows[$rowNum]['civicrm_contribution_contribution_or_soft']);
-        unset($this->_columnHeaders['civicrm_contribution_contribution_or_soft']);
-      }
-
-      //convert soft_credit_type_id into label
-      if (array_key_exists('civicrm_contribution_soft_soft_credit_type_id', $rows[$rowNum])) {
-        $rows[$rowNum]['civicrm_contribution_soft_soft_credit_type_id'] = CRM_Core_PseudoConstant::getLabel(
-          'CRM_Contribute_BAO_ContributionSoft',
-          'soft_credit_type_id',
-          $row['civicrm_contribution_soft_soft_credit_type_id']
-        );
-      }
-
-      $entryFound = $this->alterDisplayAddressFields($row, $rows, $rowNum, 'contribute/detail', 'List all contribution(s) for this ') ? TRUE : $entryFound;
-
-      // skip looking further in rows, if first row itself doesn't
-      // have the column we need
       if (!$entryFound) {
         break;
-      }
-      $lastKey = $rowNum;
-    }
-  }
-
-  public function sectionTotals() {
-
-    // Reports using order_bys with sections must populate $this->_selectAliases in select() method.
-    if (empty($this->_selectAliases)) {
-      return;
-    }
-
-    if (!empty($this->_sections)) {
-      // build the query with no LIMIT clause
-      $select = str_ireplace('SELECT SQL_CALC_FOUND_ROWS ', 'SELECT ', $this->_select);
-      $sql = "{$select} {$this->_from} {$this->_where} {$this->_groupBy} {$this->_having} {$this->_orderBy}";
-
-      // pull section aliases out of $this->_sections
-      $sectionAliases = array_keys($this->_sections);
-
-      $ifnulls = array();
-      foreach (array_merge($sectionAliases, $this->_selectAliases) as $alias) {
-        $ifnulls[] = "ifnull($alias, '') as $alias";
-      }
-
-      /* Group (un-limited) report by all aliases and get counts. This might
-       * be done more efficiently when the contents of $sql are known, ie. by
-       * overriding this method in the report class.
-       */
-
-      $addtotals = '';
-
-      if (array_search("civicrm_contribution_total_amount_sum", $this->_selectAliases) !==
-        FALSE
-      ) {
-        $addtotals = ", sum(civicrm_contribution_total_amount_sum) as sumcontribs";
-        $showsumcontribs = TRUE;
-      }
-
-      $query = "select "
-        . implode(", ", $ifnulls)
-        .
-        "$addtotals, count(*) as ct from civireport_contribution_detail_temp3 group by " .
-        implode(", ", $sectionAliases);
-      // initialize array of total counts
-      $sumcontribs = $totals = array();
-      $dao = CRM_Core_DAO::executeQuery($query);
-      while ($dao->fetch()) {
-
-        // let $this->_alterDisplay translate any integer ids to human-readable values.
-        $rows[0] = $dao->toArray();
-        $this->alterDisplay($rows);
-        $row = $rows[0];
-
-        // add totals for all permutations of section values
-        $values = array();
-        $i = 1;
-        $aliasCount = count($sectionAliases);
-        foreach ($sectionAliases as $alias) {
-          $values[] = $row[$alias];
-          $key = implode(CRM_Core_DAO::VALUE_SEPARATOR, $values);
-          if ($i == $aliasCount) {
-            // the last alias is the lowest-level section header; use count as-is
-            $totals[$key] = $dao->ct;
-            if ($showsumcontribs) {
-              $sumcontribs[$key] = $dao->sumcontribs;
-            }
-          }
-          else {
-            // other aliases are higher level; roll count into their total
-            $totals[$key] = (array_key_exists($key, $totals)) ? $totals[$key] + $dao->ct : $dao->ct;
-            if ($showsumcontribs) {
-              $sumcontribs[$key] = array_key_exists($key, $sumcontribs) ? $sumcontribs[$key] + $dao->sumcontribs : $dao->sumcontribs;
-            }
-          }
-        }
-      }
-      if ($showsumcontribs) {
-        $totalandsum = array();
-        // ts exception to avoid having ts("%1 %2: %3")
-        $title = '%1 contributions / soft-credits: %2';
-
-        if (CRM_Utils_Array::value('contribution_or_soft_value', $this->_params) ==
-          'contributions_only'
-        ) {
-          $title = '%1 contributions: %2';
-        }
-        elseif (CRM_Utils_Array::value('contribution_or_soft_value', $this->_params) ==
-          'soft_credits_only'
-        ) {
-          $title = '%1 soft-credits: %2';
-        }
-        foreach ($totals as $key => $total) {
-          $totalandsum[$key] = ts($title, array(
-            1 => $total,
-            2 => CRM_Utils_Money::format($sumcontribs[$key]),
-          ));
-        }
-        $this->assign('sectionTotals', $totalandsum);
-      }
-      else {
-        $this->assign('sectionTotals', $totals);
       }
     }
   }

--- a/CRM/Report/Form/Contribute/Detail.php
+++ b/CRM/Report/Form/Contribute/Detail.php
@@ -61,249 +61,283 @@ class CRM_Report_Form_Contribute_Detail extends CRM_Report_Form {
       asort($this->activeCampaigns);
     }
     $this->_columns = array(
-      'civicrm_contact' => array(
-        'dao' => 'CRM_Contact_DAO_Contact',
-        'fields' => $this->getBasicContactFields(),
-        'filters' => array(
-          'sort_name' => array(
-            'title' => ts('Donor Name'),
-            'operator' => 'like',
+        'civicrm_contact' => array(
+          'dao' => 'CRM_Contact_DAO_Contact',
+          'fields' => $this->getBasicContactFields(),
+          'filters' => array(
+            'sort_name' => array(
+              'title' => ts('Donor Name'),
+              'operator' => 'like',
+            ),
+            'id' => array(
+              'title' => ts('Contact ID'),
+              'no_display' => TRUE,
+              'type' => CRM_Utils_Type::T_INT,
+            ),
+            'gender_id' => array(
+              'title' => ts('Gender'),
+              'operatorType' => CRM_Report_Form::OP_MULTISELECT,
+              'options' => CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'gender_id'),
+            ),
+            'birth_date' => array(
+              'title' => ts('Birth Date'),
+              'operatorType' => CRM_Report_Form::OP_DATE,
+            ),
+            'contact_type' => array(
+              'title' => ts('Contact Type'),
+            ),
+            'contact_sub_type' => array(
+              'title' => ts('Contact Subtype'),
+            ),
           ),
-          'id' => array(
-            'title' => ts('Contact ID'),
-            'no_display' => TRUE,
-            'type' => CRM_Utils_Type::T_INT,
+          'grouping' => 'contact-fields',
+          'order_bys' => array(
+            'sort_name' => array(
+              'title' => ts('Last Name, First Name'),
+              'default' => '1',
+              'default_weight' => '0',
+              'default_order' => 'ASC',
+            ),
+            'first_name' => array(
+              'name' => 'first_name',
+              'title' => ts('First Name'),
+            ),
+            'gender_id' => array(
+              'name' => 'gender_id',
+              'title' => ts('Gender'),
+            ),
+            'birth_date' => array(
+              'name' => 'birth_date',
+              'title' => ts('Birth Date'),
+            ),
+            'contact_type' => array(
+              'title' => ts('Contact Type'),
+            ),
+            'contact_sub_type' => array(
+              'title' => ts('Contact Subtype'),
+            ),
           ),
-          'gender_id' => array(
-            'title' => ts('Gender'),
-            'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-            'options' => CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'gender_id'),
-          ),
-          'birth_date' => array(
-            'title' => ts('Birth Date'),
-            'operatorType' => CRM_Report_Form::OP_DATE,
-          ),
-          'contact_type' => array(
-            'title' => ts('Contact Type'),
-          ),
-          'contact_sub_type' => array(
-            'title' => ts('Contact Subtype'),
-          ),
-        ),
-        'grouping' => 'contact-fields',
-        'order_bys' => array(
-          'sort_name' => array(
-            'title' => ts('Last Name, First Name'),
-            'default' => '1',
-            'default_weight' => '0',
-            'default_order' => 'ASC',
-          ),
-          'first_name' => array(
-            'name' => 'first_name',
-            'title' => ts('First Name'),
-          ),
-          'gender_id' => array(
-            'name' => 'gender_id',
-            'title' => ts('Gender'),
-          ),
-          'birth_date' => array(
-            'name' => 'birth_date',
-            'title' => ts('Birth Date'),
-          ),
-          'contact_type' => array(
-            'title' => ts('Contact Type'),
-          ),
-          'contact_sub_type' => array(
-            'title' => ts('Contact Subtype'),
-          ),
-        ),
 
-      ),
-      'civicrm_email' => array(
-        'dao' => 'CRM_Core_DAO_Email',
-        'fields' => array(
-          'email' => array(
-            'title' => ts('Donor Email'),
-            'default' => TRUE,
-          ),
         ),
-        'grouping' => 'contact-fields',
-      ),
-      'civicrm_line_item' => array(
-        'dao' => 'CRM_Price_DAO_LineItem',
-      ),
-      'civicrm_phone' => array(
-        'dao' => 'CRM_Core_DAO_Phone',
-        'fields' => array(
-          'phone' => array(
-            'title' => ts('Donor Phone'),
-            'default' => TRUE,
-            'no_repeat' => TRUE,
-          ),
-        ),
-        'grouping' => 'contact-fields',
-      ),
-      'civicrm_contribution' => array(
-        'dao' => 'CRM_Contribute_DAO_Contribution',
-        'fields' => array(
-          'contribution_id' => array(
-            'name' => 'id',
-            'no_display' => TRUE,
-            'required' => TRUE,
-          ),
-          'list_contri_id' => array(
-            'name' => 'id',
-            'title' => ts('Contribution ID'),
-          ),
-          'financial_type_id' => array(
-            'title' => ts('Financial Type'),
-            'default' => TRUE,
-          ),
-          'contribution_status_id' => array(
-            'title' => ts('Contribution Status'),
-          ),
-          'contribution_page_id' => array(
-            'title' => ts('Contribution Page'),
-          ),
-          'source' => array(
-            'title' => ts('Source'),
-          ),
-          'payment_instrument_id' => array(
-            'title' => ts('Payment Type'),
-          ),
-          'check_number' => array(
-            'title' => ts('Check Number'),
-          ),
-          'currency' => array(
-            'required' => TRUE,
-            'no_display' => TRUE,
-          ),
-          'trxn_id' => NULL,
-          'receive_date' => array('default' => TRUE),
-          'receipt_date' => NULL,
-          'total_amount' => array(
-            'title' => ts('Amount'),
-            'required' => TRUE,
-            'statistics' => array('sum' => ts('Amount')),
-          ),
-          'fee_amount' => NULL,
-          'net_amount' => NULL,
-          'contribution_or_soft' => array(
-            'title' => ts('Contribution OR Soft Credit?'),
-            'dbAlias' => "'Contribution'",
-          ),
-          'soft_credits' => array(
-            'title' => ts('Soft Credits'),
-            'dbAlias' => "NULL",
-          ),
-          'soft_credit_for' => array(
-            'title' => ts('Soft Credit For'),
-            'dbAlias' => "NULL",
-          ),
-        ),
-        'filters' => array(
-          'contribution_or_soft' => array(
-            'title' => ts('Contribution OR Soft Credit?'),
-            'clause' => "(1)",
-            'operatorType' => CRM_Report_Form::OP_SELECT,
-            'type' => CRM_Utils_Type::T_STRING,
-            'options' => array(
-              'both' => ts('Both'),
-              'contributions_only' => ts('Contributions Only'),
-              'soft_credits_only' => ts('Soft Credits Only'),
+        'civicrm_email' => array(
+          'dao' => 'CRM_Core_DAO_Email',
+          'fields' => array(
+            'email' => array(
+              'title' => ts('Donor Email'),
+              'default' => TRUE,
             ),
           ),
-          'receive_date' => array('operatorType' => CRM_Report_Form::OP_DATE),
-          'currency' => array(
-            'title' => 'Currency',
-            'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-            'options' => CRM_Core_OptionGroup::values('currencies_enabled'),
-            'default' => NULL,
-            'type' => CRM_Utils_Type::T_STRING,
-          ),
-          'financial_type_id' => array(
-            'title' => ts('Financial Type'),
-            'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-            'options' => CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes(),
-            'type' => CRM_Utils_Type::T_INT,
-          ),
-          'contribution_page_id' => array(
-            'title' => ts('Contribution Page'),
-            'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-            'options' => CRM_Contribute_PseudoConstant::contributionPage(),
-            'type' => CRM_Utils_Type::T_INT,
-          ),
-          'payment_instrument_id' => array(
-            'title' => ts('Payment Type'),
-            'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-            'options' => CRM_Contribute_PseudoConstant::paymentInstrument(),
-            'type' => CRM_Utils_Type::T_INT,
-          ),
-          'contribution_status_id' => array(
-            'title' => ts('Contribution Status'),
-            'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-            'options' => CRM_Contribute_PseudoConstant::contributionStatus(),
-            'default' => array(1),
-            'type' => CRM_Utils_Type::T_INT,
-          ),
-          'total_amount' => array('title' => ts('Contribution Amount')),
+          'grouping' => 'contact-fields',
         ),
-        'order_bys' => array(
-          'financial_type_id' => array('title' => ts('Financial Type')),
-          'contribution_status_id' => array('title' => ts('Contribution Status')),
-          'payment_instrument_id' => array('title' => ts('Payment Method')),
-          'receive_date' => array('title' => ts('Date Received')),
+        'civicrm_line_item' => array(
+          'dao' => 'CRM_Price_DAO_LineItem',
         ),
-        'grouping' => 'contri-fields',
-      ),
-      'civicrm_contribution_soft' => array(
-        'dao' => 'CRM_Contribute_DAO_ContributionSoft',
-        'fields' => array(
-          'soft_credit_type_id' => array('title' => ts('Soft Credit Type')),
-        ),
-        'filters' => array(
-          'soft_credit_type_id' => array(
-            'title' => 'Soft Credit Type',
-            'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-            'options' => CRM_Core_OptionGroup::values('soft_credit_type'),
-            'default' => NULL,
-            'type' => CRM_Utils_Type::T_STRING,
-          ),
-        ),
-      ),
-      'civicrm_contribution_ordinality' => array(
-        'dao' => 'CRM_Contribute_DAO_Contribution',
-        'alias' => 'cordinality',
-        'filters' => array(
-          'ordinality' => array(
-            'title' => ts('Contribution Ordinality'),
-            'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-            'options' => array(
-              0 => 'First by Contributor',
-              1 => 'Second or Later by Contributor',
+        'civicrm_phone' => array(
+          'dao' => 'CRM_Core_DAO_Phone',
+          'fields' => array(
+            'phone' => array(
+              'title' => ts('Donor Phone'),
+              'default' => TRUE,
+              'no_repeat' => TRUE,
             ),
-            'type' => CRM_Utils_Type::T_INT,
+          ),
+          'grouping' => 'contact-fields',
+        ),
+        'civicrm_contribution' => array(
+          'dao' => 'CRM_Contribute_DAO_Contribution',
+          'fields' => array(
+            'contribution_id' => array(
+              'name' => 'id',
+              'no_display' => TRUE,
+              'required' => TRUE,
+            ),
+            'list_contri_id' => array(
+              'name' => 'id',
+              'title' => ts('Contribution ID'),
+            ),
+            'financial_type_id' => array(
+              'title' => ts('Contribution Financial Type'),
+              'default' => TRUE,
+            ),
+            'contribution_status_id' => array(
+              'title' => ts('Contribution Status'),
+            ),
+            'contribution_page_id' => array(
+              'title' => ts('Contribution Page'),
+            ),
+            'source' => array(
+              'title' => ts('Source'),
+            ),
+            'payment_instrument_id' => array(
+              'title' => ts('Payment Type'),
+            ),
+            'check_number' => array(
+              'title' => ts('Check Number'),
+            ),
+            'currency' => array(
+              'required' => TRUE,
+              'no_display' => TRUE,
+            ),
+            'trxn_id' => NULL,
+            'receive_date' => array('default' => TRUE),
+            'receipt_date' => NULL,
+            'total_amount' => array(
+              'title' => ts('Amount'),
+              'statistics' => array('sum' => ts('Amount')),
+            ),
+            'fee_amount' => NULL,
+            'net_amount' => NULL,
+            'contribution_or_soft' => array(
+              'title' => ts('Contribution OR Soft Credit?'),
+              'dbAlias' => "'Contribution'",
+            ),
+            'soft_credits' => array(
+              'title' => ts('Soft Credits'),
+              'dbAlias' => "NULL",
+            ),
+            'soft_credit_for' => array(
+              'title' => ts('Soft Credit For'),
+              'dbAlias' => "NULL",
+            ),
+          ),
+          'filters' => array(
+            'contribution_or_soft' => array(
+              'title' => ts('Contribution OR Soft Credit?'),
+              'clause' => "(1)",
+              'operatorType' => CRM_Report_Form::OP_SELECT,
+              'type' => CRM_Utils_Type::T_STRING,
+              'options' => array(
+                'both' => ts('Both'),
+                'contributions_only' => ts('Contributions Only'),
+                'soft_credits_only' => ts('Soft Credits Only'),
+              ),
+            ),
+            'receive_date' => array('operatorType' => CRM_Report_Form::OP_DATE),
+            'currency' => array(
+              'title' => 'Currency',
+              'operatorType' => CRM_Report_Form::OP_MULTISELECT,
+              'options' => CRM_Core_OptionGroup::values('currencies_enabled'),
+              'default' => NULL,
+              'type' => CRM_Utils_Type::T_STRING,
+            ),
+            'financial_type_id' => array(
+              'title' => ts('Contribution Financial Type'),
+              'operatorType' => CRM_Report_Form::OP_MULTISELECT,
+              'options' => CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes(),
+              'type' => CRM_Utils_Type::T_INT,
+            ),
+            'contribution_page_id' => array(
+              'title' => ts('Contribution Page'),
+              'operatorType' => CRM_Report_Form::OP_MULTISELECT,
+              'options' => CRM_Contribute_PseudoConstant::contributionPage(),
+              'type' => CRM_Utils_Type::T_INT,
+            ),
+            'payment_instrument_id' => array(
+              'title' => ts('Payment Type'),
+              'operatorType' => CRM_Report_Form::OP_MULTISELECT,
+              'options' => CRM_Contribute_PseudoConstant::paymentInstrument(),
+              'type' => CRM_Utils_Type::T_INT,
+            ),
+            'contribution_status_id' => array(
+              'title' => ts('Contribution Status'),
+              'operatorType' => CRM_Report_Form::OP_MULTISELECT,
+              'options' => CRM_Contribute_PseudoConstant::contributionStatus(),
+              'default' => array(1),
+              'type' => CRM_Utils_Type::T_INT,
+            ),
+            'total_amount' => array('title' => ts('Contribution Amount')),
+          ),
+          'order_bys' => array(
+            'financial_type_id' => array('title' => ts('Contribution Financial Type')),
+            'contribution_status_id' => array('title' => ts('Contribution Status')),
+            'payment_instrument_id' => array('title' => ts('Payment Method')),
+            'receive_date' => array('title' => ts('Date Received')),
+          ),
+          'grouping' => 'contri-fields',
+        ),
+        'civicrm_contribution_soft' => array(
+          'dao' => 'CRM_Contribute_DAO_ContributionSoft',
+          'fields' => array(
+            'soft_credit_type_id' => array('title' => ts('Soft Credit Type')),
+          ),
+          'filters' => array(
+            'soft_credit_type_id' => array(
+              'title' => 'Soft Credit Type',
+              'operatorType' => CRM_Report_Form::OP_MULTISELECT,
+              'options' => CRM_Core_OptionGroup::values('soft_credit_type'),
+              'default' => NULL,
+              'type' => CRM_Utils_Type::T_STRING,
+            ),
           ),
         ),
-      ),
-      'civicrm_note' => array(
-        'dao' => 'CRM_Core_DAO_Note',
-        'fields' => array(
-          'contribution_note' => array(
-            'name' => 'note',
-            'title' => ts('Contribution Note'),
+        'civicrm_line_item' => array(
+          'dao' => 'CRM_Price_DAO_LineItem',
+          'fields' => array(
+            'line_item_financial_type_id' => array(
+              'name' => 'financial_type_id',
+              'title' => ts('Line Item Financial Type'),
+              'default' => FALSE,
+            ),
+            'line_total' => array(
+              'title' => ts('Line Amount'),
+              'type' => CRM_Utils_Type::T_MONEY,
+              'default' => FALSE,
+            ),
+          ),
+          'filters' => array(
+            'line_item_financial_type_id' => array(
+              'name' => 'financial_type_id',
+              'title' => ts('Line Item Financial Type'),
+              'type' => CRM_Utils_Type::T_INT,
+              'operatorType' => CRM_Report_Form::OP_MULTISELECT,
+              'options' => CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes(),
+            ),
+            'line_total' => array(
+              'title' => ts('Line Amount'),
+              'type' => CRM_Utils_Type::T_MONEY,
+              'default' => FALSE,
+            ),
+          ),
+          'group_bys' => array(
+            'line_item_financial_type_id' => array(
+              'name' => 'financial_type_id',
+              'title' => ts('Line Item Financial Type'),
+            ),
+          )
+        ),
+        'civicrm_contribution_ordinality' => array(
+          'dao' => 'CRM_Contribute_DAO_Contribution',
+          'alias' => 'cordinality',
+          'filters' => array(
+            'ordinality' => array(
+              'title' => ts('Contribution Ordinality'),
+              'operatorType' => CRM_Report_Form::OP_MULTISELECT,
+              'options' => array(
+                0 => 'First by Contributor',
+                1 => 'Second or Later by Contributor',
+              ),
+              'type' => CRM_Utils_Type::T_INT,
+            ),
           ),
         ),
-        'filters' => array(
-          'note' => array(
-            'name' => 'note',
-            'title' => ts('Contribution Note'),
-            'operator' => 'like',
-            'type' => CRM_Utils_Type::T_STRING,
+        'civicrm_note' => array(
+          'dao' => 'CRM_Core_DAO_Note',
+          'fields' => array(
+            'contribution_note' => array(
+              'name' => 'note',
+              'title' => ts('Contribution Note'),
+            ),
+          ),
+          'filters' => array(
+            'note' => array(
+              'name' => 'note',
+              'title' => ts('Contribution Note'),
+              'operator' => 'like',
+              'type' => CRM_Utils_Type::T_STRING,
+            ),
           ),
         ),
-      ),
-    ) + $this->addAddressFields(FALSE);
+      ) + $this->addAddressFields(FALSE);
     // The tests test for this variation of the sort_name field. Don't argue with the tests :-).
     $this->_columns['civicrm_contact']['fields']['sort_name']['title'] = ts('Donor Name');
     $this->_groupFilter = TRUE;
@@ -414,9 +448,21 @@ class CRM_Report_Form_Contribute_Detail extends CRM_Report_Form {
     }
 
     if (!empty($this->_params['ordinality_value'])) {
-      $this->_from .= "
+      if (!empty($this->_params['line_item_financial_type_id_value'])) {
+        $this->_from .= "
+          INNER JOIN (SELECT c.id, IF(COUNT(ol.id) = 0, 0, 1) AS ordinality
+           FROM civicrm_contribution c
+           LEFT JOIN civicrm_line_item l ON c.id = l.contribution_id
+           LEFT JOIN civicrm_contribution oc ON c.contact_id = oc.contact_id AND oc.receive_date < c.receive_date
+           LEFT JOIN civicrm_line_item ol ON oc.id = ol.contribution_id AND ol.financial_type_id IN (".implode(",",$this->_params['line_item_financial_type_id_value']).")
+           GROUP BY l.id)
+	       cordinality_civireport ON cordinality_civireport.id = contribution_civireport.id ";
+      } else {
+
+        $this->_from .= "
               INNER JOIN (SELECT c.id, IF(COUNT(oc.id) = 0, 0, 1) AS ordinality FROM civicrm_contribution c LEFT JOIN civicrm_contribution oc ON c.contact_id = oc.contact_id AND oc.receive_date < c.receive_date GROUP BY c.id) {$this->_aliases['civicrm_contribution_ordinality']}
                       ON {$this->_aliases['civicrm_contribution_ordinality']}.id = {$this->_aliases['civicrm_contribution']}.id";
+      }
     }
 
     $this->addPhoneFromClause();
@@ -463,6 +509,13 @@ class CRM_Report_Form_Contribute_Detail extends CRM_Report_Form {
           AND {$this->_aliases['civicrm_entity_batch']}.entity_table = 'civicrm_financial_trxn')
         LEFT JOIN civicrm_batch {$this->_aliases['civicrm_batch']}
           ON {$this->_aliases['civicrm_batch']}.id = {$this->_aliases['civicrm_entity_batch']}.batch_id";
+    }
+
+    // for line item financial types
+    if (!empty($this->_params['line_item_financial_type_id_value'])) {
+      $this->_from .= "
+              LEFT  JOIN civicrm_line_item  {$this->_aliases['civicrm_line_item']}
+                      ON {$this->_aliases['civicrm_contribution']}.id = {$this->_aliases['civicrm_line_item']}.contribution_id";
     }
   }
 
@@ -778,6 +831,12 @@ UNION ALL
         if ($value = $row['civicrm_batch_batch_id']) {
           $rows[$rowNum]['civicrm_batch_batch_id'] = CRM_Core_DAO::getFieldValue('CRM_Batch_DAO_Batch', $value, 'title');
         }
+        $entryFound = TRUE;
+      }
+
+      // change line item financial type ID to financial type name
+      if ($value = CRM_Utils_Array::value('civicrm_line_item_line_item_financial_type_id', $row)) {
+        $rows[$rowNum]['civicrm_line_item_line_item_financial_type_id'] = $contributionTypes[$value];
         $entryFound = TRUE;
       }
 

--- a/CRM/Report/Form/Contribute/Sybunt.php
+++ b/CRM/Report/Form/Contribute/Sybunt.php
@@ -214,7 +214,7 @@ class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
             'name' => 'financial_type_id',
             'title' => ts('Line Item Financial Type'),
           ),
-        )
+        ),
       ),
       'civicrm_contribution' => array(
         'dao' => 'CRM_Contribute_DAO_Contribution',
@@ -268,7 +268,7 @@ class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
             'name' => 'financial_type_id',
             'title' => ts('Contribution Financial Type'),
           ),
-        )
+        ),
       ),
     );
 
@@ -304,12 +304,10 @@ class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
     $statistics = parent::statistics($rows);
 
     if (!empty($rows)) {
-      if (sizeof($this->_params['fields']['line_total']) > 0) {
+      if (count($this->_params['fields']['line_total']) > 0) {
         $select = "
                    SELECT
                         SUM({$this->_aliases['civicrm_line_item']}.line_total ) as lineamount ";
-
-
         $sql = "{$select} {$this->_from} {$this->_where}";
         $dao = CRM_Core_DAO::executeQuery($sql);
         if ($dao->fetch()) {
@@ -320,12 +318,10 @@ class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
           );
         }
       }
-      if (sizeof($this->_params['fields']['total_amount']) > 0 || sizeof($this->_params['fields']['line_total']) == 0) {
+      if (count($this->_params['fields']['total_amount']) > 0 || count($this->_params['fields']['line_total']) == 0) {
         $select = "
                    SELECT
                         SUM({$this->_aliases['civicrm_contribution']}.total_amount ) as amount ";
-
-
         $sql = "{$select} {$this->_from} {$this->_where}";
         $dao = CRM_Core_DAO::executeQuery($sql);
         if ($dao->fetch()) {

--- a/CRM/Report/Form/Contribute/Sybunt.php
+++ b/CRM/Report/Form/Contribute/Sybunt.php
@@ -1,4 +1,4 @@
-<?php
+x<?php
 /*
  +--------------------------------------------------------------------+
  | CiviCRM version 4.7                                                |
@@ -165,9 +165,32 @@ class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
           ),
         ),
       ),
-      'civicrm_line_item' => array(
-        'dao' => 'CRM_Price_DAO_LineItem',
-      ),
+        'civicrm_line_item' => array(
+            'dao' => 'CRM_Price_DAO_LineItem',
+            'fields' => array(
+                'financial_type_id' => array(
+                    'title' => ts('Line Item Financial Type'),
+                    'default' => FALSE,
+                ),
+                'line_total' => array(
+                    'title' => ts('Yearly Line Item Totals'),
+                    'default' => FALSE,
+                ),
+            ),
+            'filters' => array(
+                'financial_type_id' => array(
+                    'title' => ts('Line Item Financial Type'),
+                    'type' => CRM_Utils_Type::T_INT,
+                    'operatorType' => CRM_Report_Form::OP_MULTISELECT,
+                    'options' => CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes(),
+                ),
+            ),
+            'group_bys' => array(
+                'financial_type_id' => array(
+                    'title' => ts('Line Item Financial Type'),
+                ),
+      )
+        ),
       'civicrm_email' => array(
         'dao' => 'CRM_Core_DAO_Email',
         'grouping' => 'contact-field',
@@ -201,10 +224,8 @@ class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
             'no_repeat' => TRUE,
           ),
           'total_amount' => array(
-            'title' => ts('Total Amount'),
-            'no_display' => TRUE,
-            'required' => TRUE,
-            'no_repeat' => TRUE,
+            'title' => ts('Yearly Contribution Totals'),
+            'default' => TRUE,
           ),
           'receive_date' => array(
             'title' => ts('Year'),
@@ -222,12 +243,12 @@ class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
             'default' => date('Y'),
             'type' => CRM_Utils_Type::T_INT,
           ),
-          'financial_type_id' => array(
-            'title' => ts('Financial Type'),
-            'type' => CRM_Utils_Type::T_INT,
-            'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-            'options' => CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes(),
-          ),
+//          'financial_type_id' => array(
+//            'title' => ts('Financial Type'),
+//            'type' => CRM_Utils_Type::T_INT,
+//            'operatorType' => CRM_Report_Form::OP_MULTISELECT,
+//            'options' => CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes(),
+//          ),
           'contribution_status_id' => array(
             'title' => ts('Contribution Status'),
             'operatorType' => CRM_Report_Form::OP_MULTISELECT,
@@ -237,6 +258,39 @@ class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
         ),
       ),
     );
+//    $this->_columns += array(
+//        'civicrm_line_item' => array(
+//            'dao' => 'CRM_Price_DAO_LineItem',
+//            'fields' => array(
+//                'contribution_id' => array(
+//                    'title' => ts('contributionID'),
+//                    'no_display' => TRUE,
+//                    'required' => TRUE,
+//                    'no_repeat' => TRUE,
+//                ),
+//                'line_total' => array(
+//                    'title' => ts('Line Total'),
+//                    'no_display' => FALSE,
+//                    'required' => FALSE,
+//                    'no_repeat' => FALSE,
+//                ),
+//                'financial_type_id' => array(
+//                    'title' => ts('Financial Type ID'),
+//                    'no_display' => FALSE,
+//                    'required' => FALSE,
+//                    'no_repeat' => FALSE,
+//                ),
+//            ),
+//            'filters' => array(
+//                'financial_type_id' => array(
+//                    'title' => ts('Financial Type'),
+//                    'type' => CRM_Utils_Type::T_INT,
+//                    'operatorType' => CRM_Report_Form::OP_MULTISELECT,
+//                    'options' => CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes(),
+//                ),
+//            ),
+//        ),
+//    );
 
     // If we have a campaign, build out the relevant elements
     if ($campaignEnabled && !empty($this->activeCampaigns)) {
@@ -277,23 +331,35 @@ class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
           if (!empty($field['required']) ||
             !empty($this->_params['fields'][$fieldName])
           ) {
-            if ($fieldName == 'total_amount') {
-              $select[] = "SUM({$field['dbAlias']}) as {$tableName}_{$fieldName}";
+            if ($fieldName == 'total_amount' || $fieldName == 'line_total') {
+                if ($fieldName == 'line_total') {
+                    if (sizeof($this->_params['financial_type_id_value']) > 0) {
+                        $select[] = "SUM(line_item_civireport.line_total) as {$tableName}_{$fieldName}";
+                    }
+                    $labelprefix = "Line Items";
+                    $columnprefix = "line_items";
+                } else {// if total_amount or default to total_amount
+                    if (sizeof($this->_params['financial_type_id_value']) > 0) {
+                        $select[] = "SUM({$field['dbAlias']}) as {$tableName}_{$fieldName}";
+                    }
+                    $labelprefix = "Contributions";
+                    $columnprefix = "contributions";
+                }
 
-              $this->_columnHeaders["civicrm_upto_{$upTo_year}"]['type'] = $field['type'];
-              $this->_columnHeaders["civicrm_upto_{$upTo_year}"]['title'] = "Up To $upTo_year";
+              $this->_columnHeaders["{$columnprefix}_civicrm_upto_{$upTo_year}"]['type'] = $field['type'];
+              $this->_columnHeaders["{$columnprefix}_civicrm_upto_{$upTo_year}"]['title'] = "$labelprefix Up To $upTo_year";
 
-              $this->_columnHeaders["year_{$previous_ppyear}"]['type'] = $field['type'];
-              $this->_columnHeaders["year_{$previous_ppyear}"]['title'] = $previous_ppyear;
+              $this->_columnHeaders["{$columnprefix}_year_{$previous_ppyear}"]['type'] = $field['type'];
+              $this->_columnHeaders["{$columnprefix}_year_{$previous_ppyear}"]['title'] = "$labelprefix for $previous_ppyear";
 
-              $this->_columnHeaders["year_{$previous_pyear}"]['type'] = $field['type'];
-              $this->_columnHeaders["year_{$previous_pyear}"]['title'] = $previous_pyear;
+              $this->_columnHeaders["{$columnprefix}_year_{$previous_pyear}"]['type'] = $field['type'];
+              $this->_columnHeaders["{$columnprefix}_year_{$previous_pyear}"]['title'] = "$labelprefix for $previous_pyear";
 
-              $this->_columnHeaders["year_{$previous_year}"]['type'] = $field['type'];
-              $this->_columnHeaders["year_{$previous_year}"]['title'] = $previous_year;
+              $this->_columnHeaders["{$columnprefix}_year_{$previous_year}"]['type'] = $field['type'];
+              $this->_columnHeaders["{$columnprefix}_year_{$previous_year}"]['title'] = "$labelprefix for $previous_year";
 
-              $this->_columnHeaders["civicrm_life_time_total"]['type'] = $field['type'];
-              $this->_columnHeaders["civicrm_life_time_total"]['title'] = 'LifeTime';;
+              $this->_columnHeaders["{$columnprefix}_civicrm_life_time_total"]['type'] = $field['type'];
+              $this->_columnHeaders["{$columnprefix}_civicrm_life_time_total"]['title'] = "$labelprefix for LifeTime";
             }
             elseif ($fieldName == 'receive_date') {
               $select[] = self::fiscalYearOffset($field['dbAlias']) .
@@ -322,7 +388,11 @@ class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
               INNER JOIN civicrm_contact {$this->_aliases['civicrm_contact']}
                       ON {$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_contribution']}.contact_id
              {$this->_aclFrom}";
-
+      if ($this->isTableSelected('civicrm_line_item')) {
+          $this->_from .= "
+              LEFT  JOIN civicrm_line_item  {$this->_aliases['civicrm_line_item']}
+                      ON {$this->_aliases['civicrm_contribution']}.id = {$this->_aliases['civicrm_line_item']}.contribution_id";
+      }
     if ($this->isTableSelected('civicrm_email')) {
       $this->_from .= "
               LEFT  JOIN civicrm_email  {$this->_aliases['civicrm_email']}
@@ -395,9 +465,13 @@ class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
 
   public function groupBy() {
     $this->assign('chartSupported', TRUE);
-    $this->_groupBy = "Group BY {$this->_aliases['civicrm_contribution']}.contact_id, " .
-      self::fiscalYearOffset($this->_aliases['civicrm_contribution'] .
+    $this->_groupBy = "Group BY {$this->_aliases['civicrm_contribution']}.contact_id, ";
+      if ($this->isTableSelected('civicrm_line_item')) {
+          $this->_groupBy .= " {$this->_aliases['civicrm_line_item']}.financial_type_id, ";
+      }
+      $this->_groupBy .= self::fiscalYearOffset($this->_aliases['civicrm_contribution'] .
         '.receive_date') . " "  . " " . $this->_rollup;
+
   }
 
   /**
@@ -409,19 +483,39 @@ class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
     $statistics = parent::statistics($rows);
 
     if (!empty($rows)) {
-      $select = "
+        if (sizeof($this->_params['fields']['line_total'])>0) {
+            $select = "
+                   SELECT
+                        SUM({$this->_aliases['civicrm_line_item']}.line_total ) as lineamount ";
+
+
+            $sql = "{$select} {$this->_from} {$this->_where}";
+            $dao = CRM_Core_DAO::executeQuery($sql);
+            if ($dao->fetch()) {
+                $statistics['counts']['lineamount'] = array(
+                    'value' => $dao->lineamount,
+                    'title' => 'Total Line Items LifeTime',
+                    'type' => CRM_Utils_Type::T_MONEY,
+                );
+            }
+        }
+        if (sizeof($this->_params['fields']['total_amount'])>0 || sizeof($this->_params['fields']['line_total'])==0) {
+            $select = "
                    SELECT
                         SUM({$this->_aliases['civicrm_contribution']}.total_amount ) as amount ";
 
-      $sql = "{$select} {$this->_from} {$this->_where}";
-      $dao = CRM_Core_DAO::executeQuery($sql);
-      if ($dao->fetch()) {
-        $statistics['counts']['amount'] = array(
-          'value' => $dao->amount,
-          'title' => 'Total LifeTime',
-          'type' => CRM_Utils_Type::T_MONEY,
-        );
-      }
+
+            $sql = "{$select} {$this->_from} {$this->_where}";
+            $dao = CRM_Core_DAO::executeQuery($sql);
+            if ($dao->fetch()) {
+                $statistics['counts']['amount'] = array(
+                    'value' => $dao->amount,
+                    'title' => 'Total Contributions LifeTime',
+                    'type' => CRM_Utils_Type::T_MONEY,
+                );
+            }
+        }
+
     }
     return $statistics;
   }
@@ -470,6 +564,7 @@ class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
       $rows = $row = array();
       $dao = CRM_Core_DAO::executeQuery($sql);
       $contributionSum = 0;
+        $linetotalSum = 0;
       $yearcal = array();
       while ($dao->fetch()) {
         if (!$dao->civicrm_contribution_contact_id) {
@@ -478,24 +573,41 @@ class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
         $row = array();
         foreach ($this->_columnHeaders as $key => $value) {
           if (property_exists($dao, $key)) {
-            $rows[$dao->civicrm_contribution_contact_id][$key] = $dao->$key;
+            $rows[$dao->civicrm_contribution_contact_id."-".$dao->civicrm_line_item_financial_type_id][$key] = $dao->$key;
           }
         }
-        if ($dao->civicrm_contribution_receive_date) {
-          if ($dao->civicrm_contribution_receive_date > $upTo_year) {
-            $contributionSum += $dao->civicrm_contribution_total_amount;
-            $rows[$dao->civicrm_contribution_contact_id]['year_' . $dao->civicrm_contribution_receive_date] = $dao->civicrm_contribution_total_amount;
+          if (sizeof($this->_params['fields']['line_total'])>0) {
+              if ($dao->civicrm_contribution_receive_date) {
+                  if ($dao->civicrm_contribution_receive_date > $upTo_year) {
+                      $linetotalSum += $dao->civicrm_line_item_line_total;
+                      $rows[$dao->civicrm_contribution_contact_id . "-" . $dao->civicrm_line_item_financial_type_id]['line_item_year_' . $dao->civicrm_contribution_receive_date] = $dao->civicrm_line_item_line_total;
+                  }
+              } else {
+                  $rows[$dao->civicrm_contribution_contact_id . "-" . $dao->civicrm_line_item_financial_type_id]['civicrm_line_life_time_total'] = $dao->civicrm_line_item_line_total;
+                  if (($dao->civicrm_line_item_line_total - $linetotalSum) > 0
+                  ) {
+                      $rows[$dao->civicrm_contribution_contact_id . "-" . $dao->civicrm_line_item_financial_type_id]["line_item_civicrm_line_upto_{$upTo_year}"]
+                          = $dao->civicrm_line_item_line_total - $linetotalSum;
+                  }
+                  $linetotalSum = 0;
+              }
           }
-        }
-        else {
-          $rows[$dao->civicrm_contribution_contact_id]['civicrm_life_time_total'] = $dao->civicrm_contribution_total_amount;
-          if (($dao->civicrm_contribution_total_amount - $contributionSum) > 0
-          ) {
-            $rows[$dao->civicrm_contribution_contact_id]["civicrm_upto_{$upTo_year}"]
-              = $dao->civicrm_contribution_total_amount - $contributionSum;
+          if (sizeof($this->_params['fields']['total_amount'])>0 || sizeof($this->_params['fields']['line_total'])==0) {
+              if ($dao->civicrm_contribution_receive_date) {
+                  if ($dao->civicrm_contribution_receive_date > $upTo_year) {
+                      $contributionSum += $dao->civicrm_contribution_total_amount;
+                      $rows[$dao->civicrm_contribution_contact_id . "-" . $dao->civicrm_line_item_financial_type_id]['contribution_year_' . $dao->civicrm_contribution_receive_date] = $dao->civicrm_contribution_total_amount;
+                  }
+              } else {
+                  $rows[$dao->civicrm_contribution_contact_id . "-" . $dao->civicrm_line_item_financial_type_id]['contribution_civicrm_life_time_total'] = $dao->civicrm_contribution_total_amount;
+                  if (($dao->civicrm_contribution_total_amount - $contributionSum) > 0
+                  ) {
+                      $rows[$dao->civicrm_contribution_contact_id . "-" . $dao->civicrm_line_item_financial_type_id]["contribution_civicrm_upto_{$upTo_year}"]
+                          = $dao->civicrm_contribution_total_amount - $contributionSum;
+                  }
+                  $contributionSum = 0;
+              }
           }
-          $contributionSum = 0;
-        }
       }
       $dao->free();
     }
@@ -566,6 +678,7 @@ class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
    */
   public function alterDisplay(&$rows) {
     $entryFound = FALSE;
+      $contributionTypes = CRM_Contribute_PseudoConstant::financialType();
 
     foreach ($rows as $rowNum => $row) {
       //Convert Display name into link
@@ -609,6 +722,13 @@ class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
         }
         $entryFound = TRUE;
       }
+        // change financial type ID to financial type name
+        if ((array_key_exists('civicrm_line_item_financial_type_id', $row))) {
+            if ($value = $row['civicrm_line_item_financial_type_id']) {
+                $rows[$rowNum]['civicrm_line_item_financial_type_id'] = $contributionTypes[$value];
+            }
+            $entryFound = TRUE;
+        }
 
       // skip looking further in rows, if first row itself doesn't
       // have the column we need

--- a/CRM/Report/Form/Contribute/Sybunt.php
+++ b/CRM/Report/Form/Contribute/Sybunt.php
@@ -1,4 +1,4 @@
-x<?php
+<?php
 /*
  +--------------------------------------------------------------------+
  | CiviCRM version 4.7                                                |
@@ -32,19 +32,17 @@ x<?php
  */
 class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
 
+  public $_drilldownReport = array('contribute/detail' => 'Link to Detail Report');
   protected $_charts = array(
     '' => 'Tabular',
     'barChart' => 'Bar Chart',
     'pieChart' => 'Pie Chart',
   );
-
   protected $_customGroupExtends = array(
     'Contact',
     'Individual',
     'Contribution',
   );
-
-  public $_drilldownReport = array('contribute/detail' => 'Link to Detail Report');
 
   /**
    */
@@ -165,32 +163,6 @@ class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
           ),
         ),
       ),
-        'civicrm_line_item' => array(
-            'dao' => 'CRM_Price_DAO_LineItem',
-            'fields' => array(
-                'financial_type_id' => array(
-                    'title' => ts('Line Item Financial Type'),
-                    'default' => FALSE,
-                ),
-                'line_total' => array(
-                    'title' => ts('Yearly Line Item Totals'),
-                    'default' => FALSE,
-                ),
-            ),
-            'filters' => array(
-                'financial_type_id' => array(
-                    'title' => ts('Line Item Financial Type'),
-                    'type' => CRM_Utils_Type::T_INT,
-                    'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-                    'options' => CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes(),
-                ),
-            ),
-            'group_bys' => array(
-                'financial_type_id' => array(
-                    'title' => ts('Line Item Financial Type'),
-                ),
-      )
-        ),
       'civicrm_email' => array(
         'dao' => 'CRM_Core_DAO_Email',
         'grouping' => 'contact-field',
@@ -214,6 +186,36 @@ class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
     );
     $this->_columns += $this->addAddressFields();
     $this->_columns += array(
+      'civicrm_line_item' => array(
+        'dao' => 'CRM_Price_DAO_LineItem',
+        'fields' => array(
+          'line_item_financial_type_id' => array(
+            'name' => 'financial_type_id',
+            'title' => ts('Line Item Financial Type'),
+            'default' => FALSE,
+          ),
+          'line_total' => array(
+            'title' => ts('Yearly Line Item Totals (Use only with Line Item Financial Type filters in order to avoid double counting)'),
+            'type' => CRM_Utils_Type::T_MONEY,
+            'default' => FALSE,
+          ),
+        ),
+        'filters' => array(
+          'line_item_financial_type_id' => array(
+            'name' => 'financial_type_id',
+            'title' => ts('Line Item Financial Type'),
+            'type' => CRM_Utils_Type::T_INT,
+            'operatorType' => CRM_Report_Form::OP_MULTISELECT,
+            'options' => CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes(),
+          ),
+        ),
+        'group_bys' => array(
+          'line_item_financial_type_id' => array(
+            'name' => 'financial_type_id',
+            'title' => ts('Line Item Financial Type'),
+          ),
+        )
+      ),
       'civicrm_contribution' => array(
         'dao' => 'CRM_Contribute_DAO_Contribution',
         'fields' => array(
@@ -233,6 +235,11 @@ class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
             'required' => TRUE,
             'no_repeat' => TRUE,
           ),
+          'financial_type_id' => array(
+            'name' => 'financial_type_id',
+            'title' => ts('Contribution Financial Type'),
+            'default' => FALSE,
+          ),
         ),
         'filters' => array(
           'yid' => array(
@@ -243,12 +250,12 @@ class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
             'default' => date('Y'),
             'type' => CRM_Utils_Type::T_INT,
           ),
-//          'financial_type_id' => array(
-//            'title' => ts('Financial Type'),
-//            'type' => CRM_Utils_Type::T_INT,
-//            'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-//            'options' => CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes(),
-//          ),
+          'financial_type_id' => array(
+            'title' => ts('Financial Type'),
+            'type' => CRM_Utils_Type::T_INT,
+            'operatorType' => CRM_Report_Form::OP_MULTISELECT,
+            'options' => CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes(),
+          ),
           'contribution_status_id' => array(
             'title' => ts('Contribution Status'),
             'operatorType' => CRM_Report_Form::OP_MULTISELECT,
@@ -256,41 +263,14 @@ class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
             'default' => array('1'),
           ),
         ),
+        'group_bys' => array(
+          'financial_type_id' => array(
+            'name' => 'financial_type_id',
+            'title' => ts('Contribution Financial Type'),
+          ),
+        )
       ),
     );
-//    $this->_columns += array(
-//        'civicrm_line_item' => array(
-//            'dao' => 'CRM_Price_DAO_LineItem',
-//            'fields' => array(
-//                'contribution_id' => array(
-//                    'title' => ts('contributionID'),
-//                    'no_display' => TRUE,
-//                    'required' => TRUE,
-//                    'no_repeat' => TRUE,
-//                ),
-//                'line_total' => array(
-//                    'title' => ts('Line Total'),
-//                    'no_display' => FALSE,
-//                    'required' => FALSE,
-//                    'no_repeat' => FALSE,
-//                ),
-//                'financial_type_id' => array(
-//                    'title' => ts('Financial Type ID'),
-//                    'no_display' => FALSE,
-//                    'required' => FALSE,
-//                    'no_repeat' => FALSE,
-//                ),
-//            ),
-//            'filters' => array(
-//                'financial_type_id' => array(
-//                    'title' => ts('Financial Type'),
-//                    'type' => CRM_Utils_Type::T_INT,
-//                    'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-//                    'options' => CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes(),
-//                ),
-//            ),
-//        ),
-//    );
 
     // If we have a campaign, build out the relevant elements
     if ($campaignEnabled && !empty($this->activeCampaigns)) {
@@ -315,6 +295,182 @@ class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
     parent::preProcess();
   }
 
+  /**
+   * @param $rows
+   *
+   * @return array
+   */
+  public function statistics(&$rows) {
+    $statistics = parent::statistics($rows);
+
+    if (!empty($rows)) {
+      if (sizeof($this->_params['fields']['line_total']) > 0) {
+        $select = "
+                   SELECT
+                        SUM({$this->_aliases['civicrm_line_item']}.line_total ) as lineamount ";
+
+
+        $sql = "{$select} {$this->_from} {$this->_where}";
+        $dao = CRM_Core_DAO::executeQuery($sql);
+        if ($dao->fetch()) {
+          $statistics['counts']['lineamount'] = array(
+            'value' => $dao->lineamount,
+            'title' => 'Total Line Items LifeTime',
+            'type' => CRM_Utils_Type::T_MONEY,
+          );
+        }
+      }
+      if (sizeof($this->_params['fields']['total_amount']) > 0 || sizeof($this->_params['fields']['line_total']) == 0) {
+        $select = "
+                   SELECT
+                        SUM({$this->_aliases['civicrm_contribution']}.total_amount ) as amount ";
+
+
+        $sql = "{$select} {$this->_from} {$this->_where}";
+        $dao = CRM_Core_DAO::executeQuery($sql);
+        if ($dao->fetch()) {
+          $statistics['counts']['amount'] = array(
+            'value' => $dao->amount,
+            'title' => 'Total Contributions LifeTime',
+            'type' => CRM_Utils_Type::T_MONEY,
+          );
+        }
+      }
+
+    }
+    return $statistics;
+  }
+
+  public function postProcess() {
+    // get ready with post process params
+    $this->beginPostProcess();
+    $this->buildACLClause($this->_aliases['civicrm_contact']);
+    $this->select();
+    $this->from();
+    $this->where();
+    $this->groupBy();
+    $this->getPermissionedFTQuery($this);
+
+    $rows = $contactIds = array();
+    if (empty($this->_params['charts'])) {
+      $this->limit();
+      $getContacts = "SELECT SQL_CALC_FOUND_ROWS {$this->_aliases['civicrm_contact']}.id as cid {$this->_from} {$this->_where} GROUP BY {$this->_aliases['civicrm_contact']}.id {$this->_limit}";
+
+      $dao = CRM_Core_DAO::executeQuery($getContacts);
+
+      while ($dao->fetch()) {
+        $contactIds[] = $dao->cid;
+      }
+      $dao->free();
+      $this->setPager();
+    }
+
+    if (!empty($contactIds) || !empty($this->_params['charts'])) {
+      if (!empty($this->_params['charts'])) {
+        $sql = "{$this->_select} {$this->_from} {$this->_where} {$this->_groupBy}";
+      }
+      else {
+        $sql = "" .
+          "{$this->_select} {$this->_from} WHERE {$this->_aliases['civicrm_contact']}.id IN (" .
+          implode(',', $contactIds) .
+          ") AND {$this->_aliases['civicrm_contribution']}.is_test = 0 {$this->_statusClause} {$this->_groupBy} ";
+      }
+
+      $current_year = $this->_params['yid_value'];
+      $previous_year = $current_year - 1;
+      $previous_pyear = $current_year - 2;
+      $previous_ppyear = $current_year - 3;
+      $upTo_year = $current_year - 4;
+
+      $rows = $row = array();
+      $dao = CRM_Core_DAO::executeQuery($sql);
+      $this->addToDeveloperTab($sql);
+      $contributionSum = 0;
+      $linetotalSum = 0;
+      $yearcal = array();
+      $count = 0;
+      while ($dao->fetch()) {
+        $count++;
+        if (!$dao->civicrm_contribution_contact_id) {
+          continue;
+        }
+
+        // these conditions set row index values to keep groupings collated, and eliminate subtotals from the rollup results, yet preserving the last row which is the grand total
+        if ($this->_params['group_bys']['line_item_financial_type_id'] && $this->_params['group_bys']['financial_type_id']) {
+          if (is_null($dao->civicrm_contribution_financial_type_id) && $count != $dao->N - 1) {
+            continue;
+          }
+          $rowindex = "-l" . $dao->civicrm_line_item_line_item_financial_type_id . "-c" . $dao->civicrm_contribution_financial_type_id;
+        }
+        elseif ($this->_params['group_bys']['line_item_financial_type_id']) {
+          if (is_null($dao->civicrm_line_item_line_item_financial_type_id) && $count != $dao->N - 1) {
+            continue;
+          }
+          $rowindex = "-l" . $dao->civicrm_line_item_line_item_financial_type_id;
+        }
+        elseif ($this->_params['group_bys']['financial_type_id'] || $this->_params['group_bys']['line_item_financial_type_id']) {
+          if (is_null($dao->civicrm_contribution_financial_type_id) && $count != $dao->N - 1) {
+            continue;
+          }
+          $rowindex = "-c" . $dao->civicrm_contribution_financial_type_id;
+        }
+        else {
+          $rowindex = "";
+        }
+        $row = array();
+        foreach ($this->_columnHeaders as $key => $value) {
+          if (property_exists($dao, $key)) {
+            $rows[$dao->civicrm_contribution_contact_id . $rowindex][$key] = $dao->$key;
+          }
+        }
+
+        //if ($this->_params['group_bys']['line_item_financial_type_id']) {
+        if ($dao->civicrm_contribution_receive_date) {
+          if ($dao->civicrm_contribution_receive_date > $upTo_year) {
+            $linetotalSum += $dao->civicrm_line_item_line_total;
+            $rows[$dao->civicrm_contribution_contact_id . $rowindex]['line_items_year_' . $dao->civicrm_contribution_receive_date] = $dao->civicrm_line_item_line_total;
+          }
+        }
+        else {
+          $rows[$dao->civicrm_contribution_contact_id . $rowindex]['line_items_life_time_total'] = $dao->civicrm_line_item_line_total;
+          if (($dao->civicrm_line_item_line_total - $linetotalSum) > 0
+          ) {
+            $rows[$dao->civicrm_contribution_contact_id . $rowindex]["line_items_civicrm_upto_{$upTo_year}"]
+              = $dao->civicrm_line_item_line_total - $linetotalSum;
+          }
+          $linetotalSum = 0;
+        }
+        //}
+        //if ($this->_params['group_bys']['financial_type_id'] || $this->_params['group_bys']['line_item_financial_type_id']) {
+        if ($dao->civicrm_contribution_receive_date) {
+          if ($dao->civicrm_contribution_receive_date > $upTo_year) {
+            $contributionSum += $dao->civicrm_contribution_total_amount;
+            $rows[$dao->civicrm_contribution_contact_id . $rowindex]['contributions_year_' . $dao->civicrm_contribution_receive_date] = $dao->civicrm_contribution_total_amount;
+          }
+        }
+        else {
+          $rows[$dao->civicrm_contribution_contact_id . $rowindex]['contributions_life_time_total'] = $dao->civicrm_contribution_total_amount;
+          if (($dao->civicrm_contribution_total_amount - $contributionSum) > 0
+          ) {
+            $rows[$dao->civicrm_contribution_contact_id . $rowindex]["contributions_civicrm_upto_{$upTo_year}"]
+              = $dao->civicrm_contribution_total_amount - $contributionSum;
+          }
+          $contributionSum = 0;
+        }
+        //}
+      }
+      $dao->free();
+    }
+    // format result set.
+    $this->formatDisplay($rows, FALSE);
+
+    // assign variables to templates
+    $this->doTemplateAssignment($rows);
+
+    // do print / pdf / instance stuff if needed
+    $this->endPostProcess($rows);
+  }
+
   public function select() {
     $select = array();
     $this->_columnHeaders = array();
@@ -327,24 +483,19 @@ class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
     foreach ($this->_columns as $tableName => $table) {
       if (array_key_exists('fields', $table)) {
         foreach ($table['fields'] as $fieldName => $field) {
-
-          if (!empty($field['required']) ||
-            !empty($this->_params['fields'][$fieldName])
-          ) {
+          // if field is required, or if specified, or, default to include total amount if line total isn't specified (so that it behaves like it did before line total was an option and total amount was required
+          if (!empty($field['required']) || !empty($this->_params['fields'][$fieldName]) || (empty($this->_params['fields']['line_total']) && $fieldName == 'total_amount')) {
             if ($fieldName == 'total_amount' || $fieldName == 'line_total') {
-                if ($fieldName == 'line_total') {
-                    if (sizeof($this->_params['financial_type_id_value']) > 0) {
-                        $select[] = "SUM(line_item_civireport.line_total) as {$tableName}_{$fieldName}";
-                    }
-                    $labelprefix = "Line Items";
-                    $columnprefix = "line_items";
-                } else {// if total_amount or default to total_amount
-                    if (sizeof($this->_params['financial_type_id_value']) > 0) {
-                        $select[] = "SUM({$field['dbAlias']}) as {$tableName}_{$fieldName}";
-                    }
-                    $labelprefix = "Contributions";
-                    $columnprefix = "contributions";
-                }
+              if ($fieldName == 'line_total') {
+                $select[] = "SUM(line_item_civireport.line_total) as {$tableName}_{$fieldName}";
+                $labelprefix = "Line Items";
+                $columnprefix = "line_items";
+              }
+              else {// if total_amount or default to total_amount
+                $select[] = "SUM({$field['dbAlias']}) as {$tableName}_{$fieldName}";
+                $labelprefix = "Contributions";
+                $columnprefix = "contributions";
+              }
 
               $this->_columnHeaders["{$columnprefix}_civicrm_upto_{$upTo_year}"]['type'] = $field['type'];
               $this->_columnHeaders["{$columnprefix}_civicrm_upto_{$upTo_year}"]['title'] = "$labelprefix Up To $upTo_year";
@@ -358,8 +509,8 @@ class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
               $this->_columnHeaders["{$columnprefix}_year_{$previous_year}"]['type'] = $field['type'];
               $this->_columnHeaders["{$columnprefix}_year_{$previous_year}"]['title'] = "$labelprefix for $previous_year";
 
-              $this->_columnHeaders["{$columnprefix}_civicrm_life_time_total"]['type'] = $field['type'];
-              $this->_columnHeaders["{$columnprefix}_civicrm_life_time_total"]['title'] = "$labelprefix for LifeTime";
+              $this->_columnHeaders["{$columnprefix}_life_time_total"]['type'] = $field['type'];
+              $this->_columnHeaders["{$columnprefix}_life_time_total"]['title'] = "$labelprefix for LifeTime";
             }
             elseif ($fieldName == 'receive_date') {
               $select[] = self::fiscalYearOffset($field['dbAlias']) .
@@ -388,11 +539,11 @@ class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
               INNER JOIN civicrm_contact {$this->_aliases['civicrm_contact']}
                       ON {$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_contribution']}.contact_id
              {$this->_aclFrom}";
-      if ($this->isTableSelected('civicrm_line_item')) {
-          $this->_from .= "
+    if ($this->isTableSelected('civicrm_line_item')) {
+      $this->_from .= "
               LEFT  JOIN civicrm_line_item  {$this->_aliases['civicrm_line_item']}
                       ON {$this->_aliases['civicrm_contribution']}.id = {$this->_aliases['civicrm_line_item']}.contribution_id";
-      }
+    }
     if ($this->isTableSelected('civicrm_email')) {
       $this->_from .= "
               LEFT  JOIN civicrm_email  {$this->_aliases['civicrm_email']}
@@ -442,6 +593,7 @@ class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
                 CRM_Utils_Array::value("{$fieldName}_max", $this->_params)
               );
               if (($fieldName == 'contribution_status_id' ||
+                  $fieldName == 'line_item_financial_type_id' ||
                   $fieldName == 'financial_type_id') && !empty($clause)
               ) {
                 $this->_statusClause .= " AND " . $clause;
@@ -466,159 +618,15 @@ class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
   public function groupBy() {
     $this->assign('chartSupported', TRUE);
     $this->_groupBy = "Group BY {$this->_aliases['civicrm_contribution']}.contact_id, ";
-      if ($this->isTableSelected('civicrm_line_item')) {
-          $this->_groupBy .= " {$this->_aliases['civicrm_line_item']}.financial_type_id, ";
-      }
-      $this->_groupBy .= self::fiscalYearOffset($this->_aliases['civicrm_contribution'] .
-        '.receive_date') . " "  . " " . $this->_rollup;
-
-  }
-
-  /**
-   * @param $rows
-   *
-   * @return array
-   */
-  public function statistics(&$rows) {
-    $statistics = parent::statistics($rows);
-
-    if (!empty($rows)) {
-        if (sizeof($this->_params['fields']['line_total'])>0) {
-            $select = "
-                   SELECT
-                        SUM({$this->_aliases['civicrm_line_item']}.line_total ) as lineamount ";
-
-
-            $sql = "{$select} {$this->_from} {$this->_where}";
-            $dao = CRM_Core_DAO::executeQuery($sql);
-            if ($dao->fetch()) {
-                $statistics['counts']['lineamount'] = array(
-                    'value' => $dao->lineamount,
-                    'title' => 'Total Line Items LifeTime',
-                    'type' => CRM_Utils_Type::T_MONEY,
-                );
-            }
-        }
-        if (sizeof($this->_params['fields']['total_amount'])>0 || sizeof($this->_params['fields']['line_total'])==0) {
-            $select = "
-                   SELECT
-                        SUM({$this->_aliases['civicrm_contribution']}.total_amount ) as amount ";
-
-
-            $sql = "{$select} {$this->_from} {$this->_where}";
-            $dao = CRM_Core_DAO::executeQuery($sql);
-            if ($dao->fetch()) {
-                $statistics['counts']['amount'] = array(
-                    'value' => $dao->amount,
-                    'title' => 'Total Contributions LifeTime',
-                    'type' => CRM_Utils_Type::T_MONEY,
-                );
-            }
-        }
-
+    if ($this->_params['group_bys']['line_item_financial_type_id']) {
+      $this->_groupBy .= " {$this->_aliases['civicrm_line_item']}.financial_type_id, ";
     }
-    return $statistics;
-  }
-
-  public function postProcess() {
-    // get ready with post process params
-    $this->beginPostProcess();
-    $this->buildACLClause($this->_aliases['civicrm_contact']);
-    $this->select();
-    $this->from();
-    $this->where();
-    $this->groupBy();
-    $this->getPermissionedFTQuery($this);
-
-    $rows = $contactIds = array();
-    if (empty($this->_params['charts'])) {
-      $this->limit();
-      $getContacts = "SELECT SQL_CALC_FOUND_ROWS {$this->_aliases['civicrm_contact']}.id as cid {$this->_from} {$this->_where} GROUP BY {$this->_aliases['civicrm_contact']}.id {$this->_limit}";
-
-      $dao = CRM_Core_DAO::executeQuery($getContacts);
-
-      while ($dao->fetch()) {
-        $contactIds[] = $dao->cid;
-      }
-      $dao->free();
-      $this->setPager();
+    if ($this->_params['group_bys']['financial_type_id']) {
+      $this->_groupBy .= " {$this->_aliases['civicrm_contribution']}.financial_type_id, ";
     }
+    $this->_groupBy .= self::fiscalYearOffset($this->_aliases['civicrm_contribution'] .
+        '.receive_date') . " " . " " . $this->_rollup;
 
-    if (!empty($contactIds) || !empty($this->_params['charts'])) {
-      if (!empty($this->_params['charts'])) {
-        $sql = "{$this->_select} {$this->_from} {$this->_where} {$this->_groupBy}";
-      }
-      else {
-        $sql = "" .
-          "{$this->_select} {$this->_from} WHERE {$this->_aliases['civicrm_contact']}.id IN (" .
-          implode(',', $contactIds) .
-          ") AND {$this->_aliases['civicrm_contribution']}.is_test = 0 {$this->_statusClause} {$this->_groupBy} ";
-      }
-
-      $current_year = $this->_params['yid_value'];
-      $previous_year = $current_year - 1;
-      $previous_pyear = $current_year - 2;
-      $previous_ppyear = $current_year - 3;
-      $upTo_year = $current_year - 4;
-
-      $rows = $row = array();
-      $dao = CRM_Core_DAO::executeQuery($sql);
-      $contributionSum = 0;
-        $linetotalSum = 0;
-      $yearcal = array();
-      while ($dao->fetch()) {
-        if (!$dao->civicrm_contribution_contact_id) {
-          continue;
-        }
-        $row = array();
-        foreach ($this->_columnHeaders as $key => $value) {
-          if (property_exists($dao, $key)) {
-            $rows[$dao->civicrm_contribution_contact_id."-".$dao->civicrm_line_item_financial_type_id][$key] = $dao->$key;
-          }
-        }
-          if (sizeof($this->_params['fields']['line_total'])>0) {
-              if ($dao->civicrm_contribution_receive_date) {
-                  if ($dao->civicrm_contribution_receive_date > $upTo_year) {
-                      $linetotalSum += $dao->civicrm_line_item_line_total;
-                      $rows[$dao->civicrm_contribution_contact_id . "-" . $dao->civicrm_line_item_financial_type_id]['line_item_year_' . $dao->civicrm_contribution_receive_date] = $dao->civicrm_line_item_line_total;
-                  }
-              } else {
-                  $rows[$dao->civicrm_contribution_contact_id . "-" . $dao->civicrm_line_item_financial_type_id]['civicrm_line_life_time_total'] = $dao->civicrm_line_item_line_total;
-                  if (($dao->civicrm_line_item_line_total - $linetotalSum) > 0
-                  ) {
-                      $rows[$dao->civicrm_contribution_contact_id . "-" . $dao->civicrm_line_item_financial_type_id]["line_item_civicrm_line_upto_{$upTo_year}"]
-                          = $dao->civicrm_line_item_line_total - $linetotalSum;
-                  }
-                  $linetotalSum = 0;
-              }
-          }
-          if (sizeof($this->_params['fields']['total_amount'])>0 || sizeof($this->_params['fields']['line_total'])==0) {
-              if ($dao->civicrm_contribution_receive_date) {
-                  if ($dao->civicrm_contribution_receive_date > $upTo_year) {
-                      $contributionSum += $dao->civicrm_contribution_total_amount;
-                      $rows[$dao->civicrm_contribution_contact_id . "-" . $dao->civicrm_line_item_financial_type_id]['contribution_year_' . $dao->civicrm_contribution_receive_date] = $dao->civicrm_contribution_total_amount;
-                  }
-              } else {
-                  $rows[$dao->civicrm_contribution_contact_id . "-" . $dao->civicrm_line_item_financial_type_id]['contribution_civicrm_life_time_total'] = $dao->civicrm_contribution_total_amount;
-                  if (($dao->civicrm_contribution_total_amount - $contributionSum) > 0
-                  ) {
-                      $rows[$dao->civicrm_contribution_contact_id . "-" . $dao->civicrm_line_item_financial_type_id]["contribution_civicrm_upto_{$upTo_year}"]
-                          = $dao->civicrm_contribution_total_amount - $contributionSum;
-                  }
-                  $contributionSum = 0;
-              }
-          }
-      }
-      $dao->free();
-    }
-    // format result set.
-    $this->formatDisplay($rows, FALSE);
-
-    // assign variables to templates
-    $this->doTemplateAssignment($rows);
-
-    // do print / pdf / instance stuff if needed
-    $this->endPostProcess($rows);
   }
 
   /**
@@ -678,7 +686,7 @@ class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
    */
   public function alterDisplay(&$rows) {
     $entryFound = FALSE;
-      $contributionTypes = CRM_Contribute_PseudoConstant::financialType();
+    $contributionTypes = CRM_Contribute_PseudoConstant::financialType();
 
     foreach ($rows as $rowNum => $row) {
       //Convert Display name into link
@@ -722,13 +730,21 @@ class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
         }
         $entryFound = TRUE;
       }
-        // change financial type ID to financial type name
-        if ((array_key_exists('civicrm_line_item_financial_type_id', $row))) {
-            if ($value = $row['civicrm_line_item_financial_type_id']) {
-                $rows[$rowNum]['civicrm_line_item_financial_type_id'] = $contributionTypes[$value];
-            }
-            $entryFound = TRUE;
+      // change line item financial type ID to financial type name
+      if ((array_key_exists('civicrm_line_item_line_item_financial_type_id', $row))) {
+        if ($value = $row['civicrm_line_item_line_item_financial_type_id']) {
+          $rows[$rowNum]['civicrm_line_item_line_item_financial_type_id'] = $contributionTypes[$value];
         }
+        $entryFound = TRUE;
+      }
+
+      // change contribution financial type ID to financial type name
+      if ((array_key_exists('civicrm_contribution_financial_type_id', $row))) {
+        if ($value = $row['civicrm_contribution_financial_type_id']) {
+          $rows[$rowNum]['civicrm_contribution_financial_type_id'] = $contributionTypes[$value];
+        }
+        $entryFound = TRUE;
+      }
 
       // skip looking further in rows, if first row itself doesn't
       // have the column we need


### PR DESCRIPTION
SYBUNT updated to handle line items.  I tried to take care to keep previous default behavior as expected, so when someone who doesn't care about line items continues to use this report they will get the same results as always.  So while there is an option to not display Contribution yearly totals, it will if neither Contribution or Line Item yearly totals are selected.  There are issues with getting results using the MySQL ROLLUP modifier when filtering on both line item financial types and contribution financial types; it results in subtotals in rollup results with no reliable way to filter them out.  So I opted to include hints not to do that in the Columns tab.  Overall it works well.

Bookkeeping report update only needed the Financial Types options to explicitly say "line Item" Financial Types.  Everywhere else in CiviCRM, if not specified it means Contribution Financial Types.

---
- [CRM-19061: Update CiviReports (starting with Lybunt) to optionally show line items](https://issues.civicrm.org/jira/browse/CRM-19061)
