### PR TITLE
CRM-18805 - Allow fetching values for cc_receipt and bcc_receipt when …

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2575,6 +2575,11 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       if (!empty($softContributions)) {
         $values['softContributions'] = $softContributions['soft_credit'];
       }
+      
+      //CRM-18805: Allow fetching values for cc_receipt and bcc_receipt when we get here via civicrm_api3_contribution_sendconfirmation
+      if (!isset($this->contribution_page_id) && isset($input['contribution_page_id'])) 
+         $this->contribution_page_id = $input['contribution_page_id']; 
+      
       if (isset($this->contribution_page_id)) {
         $values = $this->addContributionPageValuesToValuesHeavyHandedly($values);
         if ($this->contribution_page_id) {
@@ -4591,6 +4596,9 @@ LIMIT 1;";
       civicrm_api3('Contribution', 'sendconfirmation', array(
         'id' => $contribution->id,
         'payment_processor_id' => $paymentProcessorId,
+ 
+        //CRM-18805: Allow fetching values for cc_receipt and bcc_receipt when we get here via civicrm_api3_contribution_sendconfirmation
+        'contribution_page_id' => $input['component'] == 'contribute' && isset($contribution->contribution_page_id) ? $contribution->contribution_page_id : 0, 
       ));
       CRM_Core_Error::debug_log_message("Receipt sent");
     }

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -395,6 +395,7 @@ function civicrm_api3_contribution_sendconfirmation($params) {
     'bcc_receipt',
     'receipt_text',
     'payment_processor_id',
+    'contribution_page_id',  //CRM-18805: Allow fetching values for cc_receipt and bcc_receipt
   );
   foreach ($passThroughParams as $key) {
     if (isset($params[$key])) {


### PR DESCRIPTION
…sending recurring contribution confirmations

Provides contribution_page_id value to civicrm_api3_contribution_sendconfirmation so that subsequent function _gatherMessageValues can use it to pull cc_receipt and bcc_receipt values.
Also fixes the failure to generate profile notification email when a recurring contribution payment is made. 

Tried to be overly cautious about setting and using the contribution_page_id value as I wasn't sure about all uses of the functions modified.
