### PR TITLE
CRM-18830. Restore Google API key for geocoding.

### DIFF
--- a/CRM/Utils/Geocode/Google.php
+++ b/CRM/Utils/Geocode/Google.php
@@ -115,7 +115,11 @@ class CRM_Utils_Geocode_Google {
       $add .= '+' . urlencode(str_replace('', '+', $values['country']));
     }
 
-    $query = 'http://' . self::$_server . self::$_uri . $add;
+    if (!empty($config->geoAPIKey)) {
+      $add .= '&key=' . urlencode($config->geoAPIKey);
+    }
+
+    $query = 'https://' . self::$_server . self::$_uri . $add;
 
     require_once 'HTTP/Request.php';
     $request = new HTTP_Request($query);


### PR DESCRIPTION
Also, use SSL, do not push all the contact details over plain HTTP.

---
- [CRM-18830: Google Geocoding - use SSL, restore API key](https://issues.civicrm.org/jira/browse/CRM-18830)
