### PR TITLE
Add all subtype fields to customFields variable

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -1902,7 +1902,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
             unset($params[$key]);
           }
           else {
-            $params[$key] = CRM_Utils_String::strtoboolstr($val);
+            $params[$key] = empty($val) ? "" : CRM_Utils_String::strtoboolstr($val);
           }
         }
       }

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -1874,7 +1874,21 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
       $csType = $relCsType;
     }
 
-    $customFields = CRM_Core_BAO_CustomField::getFields($formatted['contact_type'], FALSE, FALSE, $csType);
+    // Get array of subtypes if parent is one of the core contact Types
+    if (in_array($formatted['contact_type'], array('Individual', 'Organization', 'Household'))) {
+      $csType = self::getSubtypes($csType);
+    }
+
+    // Get custom fields for every subtype
+    if (is_array($csType)) {
+      $customFields = array();
+      foreach ($csType as $cType) {
+        $customFields += CRM_Core_BAO_CustomField::getFields($formatted['contact_type'], FALSE, FALSE, $cType);
+      }
+    }
+    else {
+      $customFields = CRM_Core_BAO_CustomField::getFields($formatted['contact_type'], FALSE, FALSE, $csType);
+    }
 
     $addressCustomFields = CRM_Core_BAO_CustomField::getFields('Address');
     $customFields = $customFields + $addressCustomFields;


### PR DESCRIPTION
CRM-18959

**Issue:**
While importing multi value custom field, the date field throws error with the message of `Notice: Undefined offset`.

**Steps to reproduce:**
1. Create a multi-value custom group with a date field (Start date with dd/mm/yyyy format for example).
2. Assign this custom group to a subtype (Student, for instance).
3. Import a csv via `civicrm/import/custom`.
4. Notices will appear after hitting *_Import Now *_ button on preview step.

**Reason:**
This is because of the same reason as CRM-18708, which is, the custom fields for subTypes are not included in `$customFields` array.

**Solution:**
Adding custom fields for subtypes in `$customFields` array sorted the issue. and fields are imported as expected.

---
- [CRM-18708: Unable to import multi-value custom field ](https://issues.civicrm.org/jira/browse/CRM-18708)

---
- [CRM-18959: Import fails when custom multi-value date field is imported](https://issues.civicrm.org/jira/browse/CRM-18959)
