### PR TITLE
CRM-18071: free membership doesn't depend on is_monetary

### DIFF
--- a/CRM/Contribute/BAO/Contribution/Utils.php
+++ b/CRM/Contribute/BAO/Contribution/Utils.php
@@ -89,8 +89,8 @@ class CRM_Contribute_BAO_Contribution_Utils {
     $form->assign('receive_date',
       CRM_Utils_Date::mysqlToIso($form->_params['receive_date'])
     );
-    if ($isPaymentTransaction) {
 
+    if ($isPaymentTransaction) {
       $contributionParams = array(
         'contact_id' => $contactID,
         'line_item' => $lineItems,
@@ -231,11 +231,7 @@ class CRM_Contribute_BAO_Contribution_Utils {
    * @return bool
    */
   static protected function isPaymentTransaction($form) {
-    if (!empty($form->_values['is_monetary']) && $form->_amount >= 0.0) {
-      return TRUE;
-    }
-    return FALSE;
-
+    return ($form->_amount >= 0.0) ? TRUE : FALSE;
   }
 
   /**

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -486,8 +486,8 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     // The concept of contributeMode is deprecated.
     // the is_monetary concept probably should be too as it can be calculated from
     // the existence of 'amount' & seems fragile.
-    if ($this->_contributeMode == 'notify' || !$this->_values['is_monetary'] ||
-      $this->_amount <= 0.0 || $this->_params['is_pay_later'] ||
+    if ($this->_contributeMode == 'notify' ||
+      $this->_amount < 0.0 || $this->_params['is_pay_later'] ||
       ($this->_separateMembershipPayment && $this->_amount <= 0.0)
     ) {
       $contribButton = ts('Continue');
@@ -1501,6 +1501,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
           $numTerms, $membershipID, $pending,
           $contributionRecurID, $membershipSource, $isPayLater, $campaignId
         );
+
         $form->set('renewal_mode', $renewalMode);
         if (!empty($dates)) {
           $form->assign('mem_start_date', CRM_Utils_Date::customFormat($dates['start_date'], '%Y%m%d'));
@@ -1591,7 +1592,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       //CRM-18071, where on selecting $0 free membership payment section got hidden and
       // also it reset any payment processor selection result into pending free membership
       // so its a kind of hack to complete free membership at this point since there is no $form->_paymentProcessor info
-      if (empty($form->_params['is_pay_later']) && !empty($membershipContribution) && !is_a($membershipContribution, 'CRM_Core_Error')) {
+      if (!empty($membershipContribution) && !is_a($membershipContribution, 'CRM_Core_Error')) {
         $paymentProcessorIDs = explode(CRM_Core_DAO::VALUE_SEPARATOR, CRM_Utils_Array::value('payment_processor', $this->_values));
         if (empty($form->_paymentProcessor) && !empty($paymentProcessorIDs)) {
           $this->_paymentProcessor['id'] = $paymentProcessorIDs[0];


### PR DESCRIPTION
- [CRM-18071: Contribution form no longer entering data into CiviMember for free memberships](https://issues.civicrm.org/jira/browse/CRM-18071)
