### PR TITLE
CRM-18973

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -596,7 +596,7 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
         }
 
         foreach ($table as $tableName => $tableColumns) {
-          $insert = 'INSERT INTO ' . $tableName . ' (' . implode(', ', $tableColumns) . ') ';
+          $insert = 'INSERT IGNORE INTO ' . $tableName . ' (' . implode(', ', $tableColumns) . ') ';
           $tableColumns[0] = $targetContributionId;
           $select = 'SELECT ' . implode(', ', $tableColumns);
           $from = ' FROM ' . $tableName;


### PR DESCRIPTION
Convert an INSERT into an INSERT IGNORE to deal with the possibility that custom fields already exist for a contribution.

---
- [CRM-18973: IPN copyCustomValues DB Error: already exists](https://issues.civicrm.org/jira/browse/CRM-18973)
