### PR TITLE
CRM-17917 - Fix D8 Civi/Install/Requirements

### DIFF
--- a/Civi/Install/Requirements.php
+++ b/Civi/Install/Requirements.php
@@ -437,7 +437,8 @@ class Requirements {
       'details' => 'MySQL thread_stack is OK',
     );
 
-    $conn = @mysql_connect($db_config['server'], $db_config['username'], $db_config['password']);
+    $host = isset($db_config['server']) ? $db_config['server'] : $db_config['host'];
+    $conn = @mysql_connect($host, $db_config['username'], $db_config['password']);
     if (!$conn) {
       $results['severity'] = $this::REQUIREMENT_ERROR;
       $results['details'] = 'Could not connect to database';
@@ -478,7 +479,8 @@ class Requirements {
       'details' => 'Can successfully lock and unlock tables',
     );
 
-    $conn = @mysql_connect($db_config['server'], $db_config['username'], $db_config['password']);
+    $host = isset($db_config['server']) ? $db_config['server'] : $db_config['host'];
+    $conn = @mysql_connect($host, $db_config['username'], $db_config['password']);
     if (!$conn) {
       $results['severity'] = $this::REQUIREMENT_ERROR;
       $results['details'] = 'Could not connect to database';


### PR DESCRIPTION
This is a bit confusing because there are two nearly identical classes for
checking system requirements -- `install/index.php#InstallRequirements`
(used by the graphical D6/D7/WP) and `Civi/Install/Requirements.php` (used
by the headless D8 installer).  This looks like a code cleanup gone awry.

In any event, the DB config objects in these contexts have different
properties.  This fixes the D8 one to consistently use the D8 properties.

WISHLIST: Use the same classes and array structures in each context!

---
- [CRM-17917: Add support for Drupal 8](https://issues.civicrm.org/jira/browse/CRM-17917)
