### PR TITLE
CRM-18656 - Advanced search fails to show tagset criteria when editing saved search

### DIFF
--- a/CRM/Contact/Form/Search/Advanced.php
+++ b/CRM/Contact/Form/Search/Advanced.php
@@ -400,7 +400,8 @@ class CRM_Contact_Form_Search_Advanced extends CRM_Contact_Form_Search {
         $tag->retrieve($params, $result);
         $parentId = $result['parent_id'];
         $element = "contact_taglist[$parentId]";
-        if ($this->elementExists($element)) {    // It's a tagset
+        if ($this->elementExists($element)) {
+          // This tag is a tagset
           unset($defaults['contact_tags'][$key]);
           if (!isset($defaults[$element])) {
             $defaults[$element] = array();

--- a/CRM/Contact/Form/Search/Advanced.php
+++ b/CRM/Contact/Form/Search/Advanced.php
@@ -393,12 +393,8 @@ class CRM_Contact_Form_Search_Advanced extends CRM_Contact_Form_Search {
      * id of the tagset.
      */
     if (isset($defaults['contact_tags'])) {
-      $tag = new CRM_Core_BAO_Tag();
       foreach ($defaults['contact_tags'] as $key => $tagId) {
-        $params = array('id' => $tagId);
-        $result = array();
-        $tag->retrieve($params, $result);
-        $parentId = $result['parent_id'];
+        $parentId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Tag', $tagId, 'parent_id');
         $element = "contact_taglist[$parentId]";
         if ($this->elementExists($element)) {
           // This tag is a tagset

--- a/CRM/Contact/Form/Search/Advanced.php
+++ b/CRM/Contact/Form/Search/Advanced.php
@@ -385,6 +385,34 @@ class CRM_Contact_Form_Search_Advanced extends CRM_Contact_Form_Search {
     if ($this->_ssID && empty($_POST)) {
       $defaults = array_merge($defaults, CRM_Contact_BAO_SavedSearch::getFormValues($this->_ssID));
     }
+
+    /*
+     * CRM-18656 - reverse the normalisation of 'contact_taglist' done in
+     * self::normalizeFormValues(). Remove tagset tags from the default
+     * 'contact_tags' and put them in 'contact_taglist[N]' where N is the
+     * id of the tagset.
+     */
+    if (isset($defaults['contact_tags'])) {
+      $tag = new CRM_Core_BAO_Tag();
+      foreach ($defaults['contact_tags'] as $key => $tagId) {
+        $params = array('id' => $tagId);
+        $result = array();
+        $tag->retrieve($params, $result);
+        $parentId = $result['parent_id'];
+        $element = "contact_taglist[$parentId]";
+        if ($this->elementExists($element)) {    // It's a tagset
+          unset($defaults['contact_tags'][$key]);
+          if (!isset($defaults[$element])) {
+            $defaults[$element] = array();
+          }
+          $defaults[$element][] = $tagId;
+        }
+      }
+      if (empty($defaults['contact_tags'])) {
+        unset($defaults['contact_tags']);
+      }
+    }
+
     return $defaults;
   }
 


### PR DESCRIPTION
- [CRM-18656: Advanced search fails to show tagset criteria when editing saved search](https://issues.civicrm.org/jira/browse/CRM-18656)
