### PR TITLE
CRM-18980 Make payment processor selection on event pages multi-site aware again

### DIFF
--- a/CRM/Event/Form/ManageEvent/Fee.php
+++ b/CRM/Event/Form/ManageEvent/Fee.php
@@ -259,6 +259,9 @@ class CRM_Event_Form_ManageEvent_Fee extends CRM_Event_Form_ManageEvent {
     $this->addEntityRef('payment_processor', ts('Payment Processor'), array(
       'entity' => 'PaymentProcessor',
       'multiple' => TRUE,
+      'api' => array(
+        'params' => array('domain_id' => CRM_Core_Config::domainID()),
+      ),
       'select' => array('minimumInputLength' => 0),
     ));
 


### PR DESCRIPTION
- [CRM-18980: Event payment processor selection is no longer multi-site aware](https://issues.civicrm.org/jira/browse/CRM-18980)
