### PR TITLE
CRM-19058 (Discuss) Add `Civi::request()` facade based on Symfony HttpFoundation

### DIFF
--- a/Civi.php
+++ b/Civi.php
@@ -105,6 +105,13 @@ class Civi {
   }
 
   /**
+   * @return \Symfony\Component\HttpFoundation\Request
+   */
+  public static function request() {
+    return Civi::service('request');
+  }
+
+  /**
    * Obtain the domain settings.
    *
    * @param int|null $domainID

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -18,6 +18,7 @@ use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher;
 use Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass;
+use Symfony\Component\HttpFoundation\Request;
 
 // TODO use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
@@ -129,6 +130,12 @@ class Container {
       array()
     ))
       ->setFactoryService(self::SELF)->setFactoryMethod('createAngularManager');
+
+    $container->setDefinition('request', new Definition(
+      'Symfony\Component\HttpFoundation\Request',
+      array()
+    ))
+      ->setFactoryService(self::SELF)->setFactoryMethod('createRequest');
 
     $container->setDefinition('dispatcher', new Definition(
       'Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher',
@@ -321,6 +328,13 @@ class Container {
     ));
 
     return $kernel;
+  }
+
+  /**
+   * @return \Symfony\Component\HttpFoundation\Request
+   */
+  public function createRequest() {
+    return Request::createFromGlobals();
   }
 
   /**

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
     "symfony/dependency-injection": "~2.5.0",
     "symfony/event-dispatcher": "~2.5.0",
     "symfony/filesystem": "~2.5.0",
+    "symfony/http-foundation": "~2.5.0",
     "symfony/process": "~2.5.0",
     "psr/log": "1.0.0",
     "symfony/finder": "~2.5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "4f2c36b177638f5e22ca05021396c01d",
-    "content-hash": "0d5b97cd31ec69081403638a7e478f1b",
+    "hash": "925051963fe760f313ec9ce767ac4175",
+    "content-hash": "1d52de83935f2bf1f5d09980597fc285",
     "packages": [
         {
             "name": "civicrm/civicrm-cxn-rpc",
@@ -609,6 +609,118 @@
             "description": "Symfony Finder Component",
             "homepage": "http://symfony.com",
             "time": "2015-01-03 08:01:13"
+        },
+        {
+            "name": "symfony/http-foundation",
+            "version": "v2.5.12",
+            "target-dir": "Symfony/Component/HttpFoundation",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-foundation.git",
+                "reference": "08e783861dd9579bac4092814bbfb0cae6666b65"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/08e783861dd9579bac4092814bbfb0cae6666b65",
+                "reference": "08e783861dd9579bac4092814bbfb0cae6666b65",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "symfony/expression-language": "~2.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\HttpFoundation\\": ""
+                },
+                "classmap": [
+                    "Symfony/Component/HttpFoundation/Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Symfony HttpFoundation Component",
+            "homepage": "http://symfony.com",
+            "time": "2015-04-01 15:49:36"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "dff51f72b0706335131b00a7f49606168c582594"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/dff51f72b0706335131b00a7f49606168c582594",
+                "reference": "dff51f72b0706335131b00a7f49606168c582594",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2016-05-18 14:26:46"
         },
         {
             "name": "symfony/process",

--- a/tests/phpunit/Civi/FacadeTest.php
+++ b/tests/phpunit/Civi/FacadeTest.php
@@ -1,0 +1,19 @@
+<?php
+namespace Civi;
+
+/**
+ * Ensure that the facade provides expected services.
+ */
+class FacadeTest extends \CiviUnitTestCase {
+  public function testRequest() {
+    $_GET['fooId'] = 123;
+    $this->assertTrue(\Civi::request() instanceof \Symfony\Component\HttpFoundation\Request);
+    $this->assertEquals(123, \Civi::request()->query->getInt('fooId'));
+  }
+
+  protected function tearDown() {
+    unset($_GET['fooId']);
+    parent::tearDown();
+  }
+
+}


### PR DESCRIPTION
This provides a Symfony-style `$request` object, which includes
`ParameterBag`s for various inputs (GET/POST/COOKIE) along with
various helpers for validation.

Note: I don't expect this to be a large patch, but it's one we may want
to think about carefully. A few issues/questions:
- Symfony Standard Edition provides a request-stack service instead of
  a single request service. This is useful when processing nested
  requests. Should we be doing that?
- Should we be thinking about the `Response` object at the same time?
- In a D8 runtime, there's already a request object floating around.
  How should it relate?
- How often does civicrm-core include overrides for fields in
  `$_GET`, `$_REQUEST`, `$_POST`? (My sense is not very often, with
  the exception of a special field like `q`.)

---
- [CRM-19058: Add `Civi::request\(\)` facade based on Symfony HttpFoundation ](https://issues.civicrm.org/jira/browse/CRM-19058)
