### PR TITLE
CRM-18983. MySQL fatal error on 4.7.8 upgrade due to excess key length.

### DIFF
--- a/CRM/Upgrade/Incremental/sql/4.7.8.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.7.8.mysql.tpl
@@ -1,8 +1,9 @@
 {* file to handle db changes in 4.7.8 during upgrade *}
 
--- CRM-17967 - Allow contact image file name length during upload up to 255 characters long.
+-- CRM-18983 - Do not choke on excess column length when changing image_url column.
 DROP INDEX `index_image_url` ON `civicrm_contact`;
 CREATE INDEX `index_image_url` ON `civicrm_contact` ( image_URL(128) ) ;
+-- CRM-17967 - Allow contact image file name length during upload up to 512 characters long.
 ALTER TABLE `civicrm_contact` CHANGE `image_URL` `image_URL` VARCHAR(512) CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL DEFAULT NULL COMMENT 'optional URL for preferred image (photo, logo, etc.) to display for this contact.';
 
 -- CRM-18516 Convert the date fields relating to group caching and acl caching timestamp

--- a/CRM/Upgrade/Incremental/sql/4.7.8.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.7.8.mysql.tpl
@@ -1,6 +1,8 @@
 {* file to handle db changes in 4.7.8 during upgrade *}
 
-#CRM-17967 - Allow conact image file name length during upload up to 255 characters long
+-- CRM-17967 - Allow contact image file name length during upload up to 255 characters long.
+DROP INDEX `index_image_url` ON `civicrm_contact`;
+CREATE INDEX `index_image_url` ON `civicrm_contact` ( image_URL(128) ) ;
 ALTER TABLE `civicrm_contact` CHANGE `image_URL` `image_URL` VARCHAR(512) CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL DEFAULT NULL COMMENT 'optional URL for preferred image (photo, logo, etc.) to display for this contact.';
 
 -- CRM-18516 Convert the date fields relating to group caching and acl caching timestamp
@@ -12,4 +14,3 @@ DELETE FROM civicrm_state_province WHERE name = 'Fernando de Noronha';
 
 -- CRM-17118 extend civicrm_address postal_code to accept full data strings from paypal etc.
 ALTER TABLE civicrm_address CHANGE `postal_code` `postal_code` varchar(64) ;
-


### PR DESCRIPTION
- [CRM-18983: CiviCRM DB error on 4.7.8 upgrade](https://issues.civicrm.org/jira/browse/CRM-18983)
