### PR TITLE
CRM-18975 - Activity date filter ignored when viewing activity reports

### DIFF
--- a/CRM/Report/Form/Activity.php
+++ b/CRM/Report/Form/Activity.php
@@ -46,6 +46,8 @@ class CRM_Report_Form_Activity extends CRM_Report_Form {
     // There could be multiple contacts. We not clear on which contact id to display.
     // Lets hide it for now.
     $this->_exposeContactID = FALSE;
+    // if navigated from count link of activity summary reports.
+    $this->_resetDateFilter = CRM_Utils_Request::retrieve('resetDateFilter', 'Boolean', CRM_Core_DAO::$_nullObject);
 
     $config = CRM_Core_Config::singleton();
     $campaignEnabled = in_array("CiviCampaign", $config->enableComponents);
@@ -745,7 +747,7 @@ GROUP BY civicrm_activity_id $having {$this->_orderBy}";
 
   public function postProcess() {
     //reset value of activity_date
-    if (!empty($this->_force)) {
+    if (!empty($this->_resetDateFilter)) {
       $this->_formValues["activity_date_time_relative"] = NULL;
     }
     $this->beginPostProcess();

--- a/CRM/Report/Form/ActivitySummary.php
+++ b/CRM/Report/Form/ActivitySummary.php
@@ -672,6 +672,8 @@ class CRM_Report_Form_ActivitySummary extends CRM_Report_Form {
             break;
           }
         }
+        // reset date filter on activity reports.
+        $url[] = "resetDateFilter=1";
         $url = implode('&', $url);
         $url = CRM_Report_Utils_Report::getNextUrl('activity', "reset=1&force=1&{$url}",
                  $this->_absoluteUrl,


### PR DESCRIPTION
- [CRM-18975: Activity date filter ignored when viewing activity reports](https://issues.civicrm.org/jira/browse/CRM-18975)
