### PR TITLE
CRM-18688: Whitelist Pending Status

### DIFF
--- a/CRM/Core/Payment/BaseIPN.php
+++ b/CRM/Core/Payment/BaseIPN.php
@@ -346,8 +346,11 @@ class CRM_Core_Payment_BaseIPN {
             'labelColumn' => 'name',
             'flip' => 1,
           ));
+        // Cancel only Pending memberships
+        // CRM-18688
+        $pendingStatusId = $membershipStatuses['Pending'];
         foreach ($memberships as $membership) {
-          if ($membership) {
+          if ($membership && ($membership->status_id == $pendingStatusId)) {
             $membership->status_id = $membershipStatuses['Cancelled'];
             $membership->save();
 


### PR DESCRIPTION
Issue:
If user cancels the payment on off-site payment processor (Sagepay, etc.), It cancels entire membership.

Reason:
In public function cancelled, the status of membership was set to "cancelled" without checking the current status of the membership.

Solution:
Cancel the status only if membership status is "Pending".

---
- [CRM-18688: Cancel an IPN payment when renewing membership cancels entire membership](https://issues.civicrm.org/jira/browse/CRM-18688)
