### PR TITLE
CRM-19007 Optionally disable USPS address validation during contact import.

### DIFF
--- a/CRM/Contact/Import/Form/DataSource.php
+++ b/CRM/Contact/Import/Form/DataSource.php
@@ -217,6 +217,11 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Core_Form {
 
     $this->addElement('text', 'fieldSeparator', ts('Import Field Separator'), array('size' => 2));
 
+    if (CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::ADDRESS_STANDARDIZATION_PREFERENCES_NAME,
+      'address_standardization_provider') == 'USPS') {
+      $this->addElement('checkbox', 'disableUSPS', ts('Disable USPS address validation during import?'));
+    }
+
     $this->addButtons(array(
         array(
           'type' => 'upload',
@@ -320,6 +325,7 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Core_Form {
         $$storeName = $this->exportValue($storeValueName);
         $this->set($storeName, $$storeName);
       }
+      $this->set('disableUSPS', !empty($this->_params['disableUSPS']));
 
       $this->set('dataSource', $this->_params['dataSource']);
       $this->set('skipColumnHeader', CRM_Utils_Array::value('skipColumnHeader', $this->_params));

--- a/CRM/Contact/Import/Form/Preview.php
+++ b/CRM/Contact/Import/Form/Preview.php
@@ -40,6 +40,13 @@
 class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
 
   /**
+   * Whether USPS validation should be disabled during import.
+   *
+   * @var bool
+   */
+  protected $_disableUSPS;
+
+  /**
    * Set variables up before form is built.
    *
    * @return void
@@ -52,6 +59,7 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
     $conflictRowCount = $this->get('conflictRowCount');
     $mismatchCount = $this->get('unMatchCount');
     $columnNames = $this->get('columnNames');
+    $this->_disableUSPS = $this->get('disableUSPS');
 
     //assign column names
     $this->assign('columnNames', $columnNames);
@@ -291,6 +299,8 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
       $userID = $session->get('userID');
       CRM_ACL_BAO_Cache::updateEntry($userID);
     }
+
+    CRM_Utils_Address_USPS::disable($this->_disableUSPS);
 
     // run the import
     $importJob->runImport($this);

--- a/CRM/Utils/Address/USPS.php
+++ b/CRM/Utils/Address/USPS.php
@@ -61,7 +61,7 @@ class CRM_Utils_Address_USPS {
    */
   public static function checkAddress(&$values) {
     if (self::$_disabled) {
-      return;
+      return FALSE;
     }
     if (!isset($values['street_address']) ||
       (!isset($values['city']) &&

--- a/CRM/Utils/Address/USPS.php
+++ b/CRM/Utils/Address/USPS.php
@@ -39,11 +39,30 @@
 class CRM_Utils_Address_USPS {
 
   /**
+   * Whether USPS validation should be disabled during import.
+   *
+   * @var bool
+   */
+  protected static $_disabled = FALSE;
+
+  /**
+   * @param $disabled
+   *
+   * @return void
+   */
+  public static function disable($disable = TRUE) {
+    self::$_disabled = $disable;
+  }
+
+  /**
    * @param $values
    *
    * @return bool
    */
   public static function checkAddress(&$values) {
+    if (self::$_disabled) {
+      return;
+    }
     if (!isset($values['street_address']) ||
       (!isset($values['city']) &&
         !isset($values['state_province']) &&

--- a/templates/CRM/Contact/Import/Form/DataSource.tpl
+++ b/templates/CRM/Contact/Import/Form/DataSource.tpl
@@ -98,6 +98,14 @@
       &nbsp;&nbsp;&nbsp;<span class="description">{ts}Select Saved Mapping or Leave blank to create a new One.{/ts}</span></td>
          </tr>
         { /if}
+
+        {if $form.disableUSPS}
+         <tr  class="crm-import-datasource-form-block-disableUSPS">
+              <td class="label"></td>
+              <td>{$form.disableUSPS.html} <label for="disableUSPS">{$form.disableUSPS.label}</label></td>
+         </tr>
+
+        {/if}
  </table>
   </div>
 


### PR DESCRIPTION
- [CRM-19007: Optionally disable USPS address validation during contact import](https://issues.civicrm.org/jira/browse/CRM-19007)
