### PR TITLE
CRM-19012 - Fix log_user_id not being recorded for REST calls

### DIFF
--- a/CRM/Utils/REST.php
+++ b/CRM/Utils/REST.php
@@ -712,6 +712,9 @@ class CRM_Utils_REST {
       $session = CRM_Core_Session::singleton();
       $session->set('ufID', $uid);
       $session->set('userID', $contact_id);
+      CRM_Core_DAO::executeQuery('SET @civicrm_user_id = %1',
+        array(1 => array($contact_id, 'Integer'))
+      );
       return NULL;
     }
     else {


### PR DESCRIPTION
Basically adds the previous fix for CRM-8965 to the previous fix for CRM-17413 - setting the MySQL session variable that holds the active contact ID used by the logging triggers.

---
- [CRM-19012: log_user_id not recorded in log tables for REST calls](https://issues.civicrm.org/jira/browse/CRM-19012)
- [CRM-8965: Checksum identified users are not recorded in the log tables](https://issues.civicrm.org/jira/browse/CRM-8965)
- [CRM-17413: Can't determine logged-in cid during a REST call](https://issues.civicrm.org/jira/browse/CRM-17413)
