### PR TITLE
CRM-19048 - CRM_Utils_QueryFormatter - Multiple fixes for InnoDB FTS

### DIFF
--- a/CRM/Contact/Form/Search/Custom/FullText/AbstractPartialQuery.php
+++ b/CRM/Contact/Form/Search/Custom/FullText/AbstractPartialQuery.php
@@ -260,51 +260,7 @@ GROUP BY {$tableValues['id']}
    *   SQL, eg "MATCH (col1) AGAINST (queryText)" or "col1 LIKE '%queryText%'"
    */
   public function matchText($table, $fullTextFields, $queryText) {
-    if ($queryText === '*' || $queryText === '%' || empty($queryText)) {
-      return '(1)';
-    }
-
-    $strtolower = function_exists('mb_strtolower') ? 'mb_strtolower' : 'strtolower';
-
-    if (strpos($table, ' ') === FALSE) {
-      $tableName = $tableAlias = $table;
-    }
-    else {
-      list ($tableName, $tableAlias) = explode(' ', $table);
-    }
-    if (is_scalar($fullTextFields)) {
-      $fullTextFields = array($fullTextFields);
-    }
-
-    $clauses = array();
-    if (CRM_Core_InnoDBIndexer::singleton()->hasDeclaredIndex($tableName, $fullTextFields)) {
-      $formattedQuery = CRM_Utils_QueryFormatter::singleton()
-        ->format($queryText, CRM_Utils_QueryFormatter::LANG_SQL_FTSBOOL);
-
-      $prefixedFieldNames = array();
-      foreach ($fullTextFields as $fieldName) {
-        $prefixedFieldNames[] = "$tableAlias.$fieldName";
-      }
-
-      $clauses[] = sprintf("MATCH (%s) AGAINST ('%s' IN BOOLEAN MODE)",
-        implode(',', $prefixedFieldNames),
-        $strtolower(CRM_Core_DAO::escapeString($formattedQuery))
-      );
-    }
-    else {
-      //CRM_Core_Session::setStatus(ts('Cannot use FTS for %1 (%2)', array(
-      //  1 => $table,
-      //  2 => implode(', ', $fullTextFields),
-      //)));
-
-      $formattedQuery = CRM_Utils_QueryFormatter::singleton()
-        ->format($queryText, CRM_Utils_QueryFormatter::LANG_SQL_LIKE);
-      $escapedText = $strtolower(CRM_Core_DAO::escapeString($formattedQuery));
-      foreach ($fullTextFields as $fieldName) {
-        $clauses[] = "$tableAlias.$fieldName LIKE '{$escapedText}'";
-      }
-    }
-    return implode(' OR ', $clauses);
+    return CRM_Utils_QueryFormatter::singleton()->formatSql($table, $fullTextFields, $queryText);
   }
 
   /**

--- a/CRM/Contact/Form/Search/Custom/FullText/AbstractPartialQuery.php
+++ b/CRM/Contact/Form/Search/Custom/FullText/AbstractPartialQuery.php
@@ -260,6 +260,10 @@ GROUP BY {$tableValues['id']}
    *   SQL, eg "MATCH (col1) AGAINST (queryText)" or "col1 LIKE '%queryText%'"
    */
   public function matchText($table, $fullTextFields, $queryText) {
+    if ($queryText === '*' || $queryText === '%' || empty($queryText)) {
+      return '(1)';
+    }
+
     $strtolower = function_exists('mb_strtolower') ? 'mb_strtolower' : 'strtolower';
 
     if (strpos($table, ' ') === FALSE) {

--- a/CRM/Utils/QueryFormatter.php
+++ b/CRM/Utils/QueryFormatter.php
@@ -319,7 +319,16 @@ class CRM_Utils_QueryFormatter {
    * @return array
    */
   protected function parseWords($text) {
-    return explode(' ', preg_replace('/[ \r\n\t]+/', ' ', trim($text)));
+    //NYSS 9692 special handling for emails
+    if (preg_match('/^([a-z0-9_\.-]+)@([\da-z\.-]+)\.([a-z\.]{2,6})$/', $text)) {
+      $parts = explode('@', $text);
+      $parts[1] = stristr($parts[1], '.', TRUE);
+      $text = implode(' ', $parts);
+    }
+    //CRM_Core_Error::debug_var('parseWords $text', $text);
+
+    //NYSS also replace other occurrences of @
+    return explode(' ', preg_replace('/[ \r\n\t\@]+/', ' ', trim($text)));
   }
 
   /**

--- a/CRM/Utils/QueryFormatter.php
+++ b/CRM/Utils/QueryFormatter.php
@@ -40,9 +40,24 @@
  * or in vain.
  */
 class CRM_Utils_QueryFormatter {
+  /**
+   * Generate queries using SQL LIKE expressions.
+   */
   const LANG_SQL_LIKE = 'like';
+
+  /**
+   * Generate queries using MySQL FTS expressions.
+   */
   const LANG_SQL_FTS = 'fts';
+
+  /**
+   * Generate queries using MySQL's boolean FTS expressions.
+   */
   const LANG_SQL_FTSBOOL = 'ftsbool';
+
+  /**
+   * Generate queries using Solr expressions.
+   */
   const LANG_SOLR = 'solr';
 
   /**
@@ -325,7 +340,6 @@ class CRM_Utils_QueryFormatter {
       $parts[1] = stristr($parts[1], '.', TRUE);
       $text = implode(' ', $parts);
     }
-    //CRM_Core_Error::debug_var('parseWords $text', $text);
 
     //NYSS also replace other occurrences of @
     return explode(' ', preg_replace('/[ \r\n\t\@]+/', ' ', trim($text)));

--- a/tests/phpunit/CRM/Utils/QueryFormatterTest.php
+++ b/tests/phpunit/CRM/Utils/QueryFormatterTest.php
@@ -16,6 +16,45 @@ class CRM_Utils_QueryFormatterTest extends CiviUnitTestCase {
     $cases = array();
 
     $cases[] = array(
+      'someone@example.com',
+      CRM_Utils_QueryFormatter::LANG_SQL_LIKE,
+      CRM_Utils_QueryFormatter::MODE_NONE,
+      '%someone@example.com%',
+    );
+    $cases[] = array(
+      'someone@example.com',
+      CRM_Utils_QueryFormatter::LANG_SQL_FTS,
+      CRM_Utils_QueryFormatter::MODE_NONE,
+      'someone@example.com',
+    );
+    $cases[] = array(
+      'someone@example.com',
+      CRM_Utils_QueryFormatter::LANG_SQL_FTS,
+      CRM_Utils_QueryFormatter::MODE_PHRASE,
+      '"someone@example.com"',
+    );
+    $cases[] = array(
+      'someone@example.com',
+      CRM_Utils_QueryFormatter::LANG_SQL_FTS,
+      CRM_Utils_QueryFormatter::MODE_WILDPHRASE,
+      '"*someone@example.com*"',
+    );
+    $cases[] = array(
+      'someone@example.com',
+      CRM_Utils_QueryFormatter::LANG_SQL_FTS,
+      CRM_Utils_QueryFormatter::MODE_WILDWORDS,
+      '*someone* *example*',
+      // Hmm, this seems suspicious... drops ".com".
+    );
+    $cases[] = array(
+      'someone@example.com',
+      CRM_Utils_QueryFormatter::LANG_SQL_FTS,
+      CRM_Utils_QueryFormatter::MODE_WILDWORDS_SUFFIX,
+      'someone* example*',
+      // Hmm, this seems suspicious... is `example` a distinct word in mysql lexer?
+    );
+
+    $cases[] = array(
       'first second',
       CRM_Utils_QueryFormatter::LANG_SQL_LIKE,
       CRM_Utils_QueryFormatter::MODE_NONE,

--- a/tests/phpunit/CRM/Utils/QueryFormatterTest.php
+++ b/tests/phpunit/CRM/Utils/QueryFormatterTest.php
@@ -15,224 +15,65 @@ class CRM_Utils_QueryFormatterTest extends CiviUnitTestCase {
     // Array(0=>$inputText, 1=>$language, 2=>$options, 3=>$expectedText).
     $cases = array();
 
-    $cases[] = array(
-      'someone@example.com',
-      CRM_Utils_QueryFormatter::LANG_SQL_LIKE,
-      CRM_Utils_QueryFormatter::MODE_NONE,
-      '%someone@example.com%',
-    );
-    $cases[] = array(
-      'someone@example.com',
-      CRM_Utils_QueryFormatter::LANG_SQL_FTS,
-      CRM_Utils_QueryFormatter::MODE_NONE,
-      'someone@example.com',
-    );
-    $cases[] = array(
-      'someone@example.com',
-      CRM_Utils_QueryFormatter::LANG_SQL_FTS,
-      CRM_Utils_QueryFormatter::MODE_PHRASE,
-      '"someone@example.com"',
-    );
-    $cases[] = array(
-      'someone@example.com',
-      CRM_Utils_QueryFormatter::LANG_SQL_FTS,
-      CRM_Utils_QueryFormatter::MODE_WILDPHRASE,
-      '"*someone@example.com*"',
-    );
-    $cases[] = array(
-      'someone@example.com',
-      CRM_Utils_QueryFormatter::LANG_SQL_FTS,
-      CRM_Utils_QueryFormatter::MODE_WILDWORDS,
-      '*someone* *example*',
-      // Hmm, this seems suspicious... drops ".com".
-    );
-    $cases[] = array(
-      'someone@example.com',
-      CRM_Utils_QueryFormatter::LANG_SQL_FTS,
-      CRM_Utils_QueryFormatter::MODE_WILDWORDS_SUFFIX,
-      'someone* example*',
-      // Hmm, this seems suspicious... is `example` a distinct word in mysql lexer?
-    );
+    $cases[] = array('someone@example.com', 'like', 'simple', '%someone@example.com%');
+    $cases[] = array('someone@example.com', 'like', 'phrase', '%someone@example.com%');
+    $cases[] = array('someone@example.com', 'like', 'wildphrase', '%someone@example.com%');
+    $cases[] = array('someone@example.com', 'like', 'wildwords', '%someone@example.com%');
+    $cases[] = array('someone@example.com', 'like', 'wildwords-suffix', '%someone@example.com%');
 
-    $cases[] = array(
-      'first second',
-      CRM_Utils_QueryFormatter::LANG_SQL_LIKE,
-      CRM_Utils_QueryFormatter::MODE_NONE,
-      '%first second%',
-    );
-    $cases[] = array(
-      'first second',
-      CRM_Utils_QueryFormatter::LANG_SQL_LIKE,
-      CRM_Utils_QueryFormatter::MODE_PHRASE,
-      '%first second%',
-    );
-    $cases[] = array(
-      'first second',
-      CRM_Utils_QueryFormatter::LANG_SQL_LIKE,
-      CRM_Utils_QueryFormatter::MODE_WILDPHRASE,
-      '%first second%',
-    );
-    $cases[] = array(
-      'first second',
-      CRM_Utils_QueryFormatter::LANG_SQL_LIKE,
-      CRM_Utils_QueryFormatter::MODE_WILDWORDS,
-      '%first%second%',
-    );
-    $cases[] = array(
-      'first second',
-      CRM_Utils_QueryFormatter::LANG_SQL_LIKE,
-      CRM_Utils_QueryFormatter::MODE_WILDWORDS_SUFFIX,
-      '%first%second%',
-    );
+    $cases[] = array('someone@example.com', 'fts', 'simple', 'someone@example.com');
+    $cases[] = array('someone@example.com', 'fts', 'phrase', '"someone@example.com"');
+    $cases[] = array('someone@example.com', 'fts', 'wildphrase', '"*someone@example.com*"');
+    $cases[] = array('someone@example.com', 'fts', 'wildwords', '*someone* *example*'); // (1)
+    $cases[] = array('someone@example.com', 'fts', 'wildwords-suffix', 'someone* example*'); // (1)
 
-    $cases[] = array(
-      'first second',
-      CRM_Utils_QueryFormatter::LANG_SQL_FTS,
-      CRM_Utils_QueryFormatter::MODE_NONE,
-      'first second',
-    );
-    $cases[] = array(
-      'first second',
-      CRM_Utils_QueryFormatter::LANG_SQL_FTS,
-      CRM_Utils_QueryFormatter::MODE_PHRASE,
-      '"first second"',
-    );
-    $cases[] = array(
-      'first second',
-      CRM_Utils_QueryFormatter::LANG_SQL_FTS,
-      CRM_Utils_QueryFormatter::MODE_WILDPHRASE,
-      '"*first second*"',
-    );
-    $cases[] = array(
-      'first second',
-      CRM_Utils_QueryFormatter::LANG_SQL_FTS,
-      CRM_Utils_QueryFormatter::MODE_WILDWORDS,
-      '*first* *second*',
-    );
-    $cases[] = array(
-      'first second',
-      CRM_Utils_QueryFormatter::LANG_SQL_FTS,
-      CRM_Utils_QueryFormatter::MODE_WILDWORDS_SUFFIX,
-      'first* second*',
-    );
+    $cases[] = array('someone@example.com', 'ftsbool', 'simple', '+someone +example'); // (1)
+    $cases[] = array('someone@example.com', 'ftsbool', 'phrase', '+"someone@example.com"');
+    $cases[] = array('someone@example.com', 'ftsbool', 'wildphrase', '+"*someone@example.com*"');
+    $cases[] = array('someone@example.com', 'ftsbool', 'wildwords', '+*someone* +*example*'); // (1)
+    $cases[] = array('someone@example.com', 'ftsbool', 'wildwords-suffix', '+someone* +example*'); // (1)
 
-    $cases[] = array(
-      'first second',
-      CRM_Utils_QueryFormatter::LANG_SQL_FTSBOOL,
-      CRM_Utils_QueryFormatter::MODE_NONE,
-      '+first +second',
-    );
-    $cases[] = array(
-      'first second',
-      CRM_Utils_QueryFormatter::LANG_SQL_FTSBOOL,
-      CRM_Utils_QueryFormatter::MODE_PHRASE,
-      '+"first second"',
-    );
-    $cases[] = array(
-      'first second',
-      CRM_Utils_QueryFormatter::LANG_SQL_FTSBOOL,
-      CRM_Utils_QueryFormatter::MODE_WILDPHRASE,
-      '+"*first second*"',
-    );
-    $cases[] = array(
-      'first second',
-      CRM_Utils_QueryFormatter::LANG_SQL_FTSBOOL,
-      CRM_Utils_QueryFormatter::MODE_WILDWORDS,
-      '+*first* +*second*',
-    );
-    $cases[] = array(
-      'first second',
-      CRM_Utils_QueryFormatter::LANG_SQL_FTSBOOL,
-      CRM_Utils_QueryFormatter::MODE_WILDWORDS_SUFFIX,
-      '+first* +second*',
-    );
+    // Note: The examples marked with (1) are suspicious cases where
 
-    $cases[] = array(
-      'first second',
-      CRM_Utils_QueryFormatter::LANG_SOLR,
-      CRM_Utils_QueryFormatter::MODE_NONE,
-      'first second',
-    );
-    $cases[] = array(
-      'first second',
-      CRM_Utils_QueryFormatter::LANG_SOLR,
-      CRM_Utils_QueryFormatter::MODE_PHRASE,
-      '"first second"',
-    );
-    $cases[] = array(
-      'first second',
-      CRM_Utils_QueryFormatter::LANG_SOLR,
-      CRM_Utils_QueryFormatter::MODE_WILDPHRASE,
-      '"*first second*"',
-    );
-    $cases[] = array(
-      'first second',
-      CRM_Utils_QueryFormatter::LANG_SOLR,
-      CRM_Utils_QueryFormatter::MODE_WILDWORDS,
-      '*first* *second*',
-    );
-    $cases[] = array(
-      'first second',
-      CRM_Utils_QueryFormatter::LANG_SOLR,
-      CRM_Utils_QueryFormatter::MODE_WILDWORDS_SUFFIX,
-      'first* second*',
-    );
+    $cases[] = array('first second', 'like', 'simple', '%first second%');
+    $cases[] = array('first second', 'like', 'phrase', '%first second%');
+    $cases[] = array('first second', 'like', 'wildphrase', '%first second%');
+    $cases[] = array('first second', 'like', 'wildwords', '%first%second%');
+    $cases[] = array('first second', 'like', 'wildwords-suffix', '%first%second%');
+
+    $cases[] = array('first second', 'fts', 'simple', 'first second');
+    $cases[] = array('first second', 'fts', 'phrase', '"first second"');
+    $cases[] = array('first second', 'fts', 'wildphrase', '"*first second*"');
+    $cases[] = array('first second', 'fts', 'wildwords', '*first* *second*');
+    $cases[] = array('first second', 'fts', 'wildwords-suffix', 'first* second*');
+
+    $cases[] = array('first second', 'ftsbool', 'simple', '+first +second');
+    $cases[] = array('first second', 'ftsbool', 'phrase', '+"first second"');
+    $cases[] = array('first second', 'ftsbool', 'wildphrase', '+"*first second*"');
+    $cases[] = array('first second', 'ftsbool', 'wildwords', '+*first* +*second*');
+    $cases[] = array('first second', 'ftsbool', 'wildwords-suffix', '+first* +second*');
+
+    $cases[] = array('first second', 'solr', 'simple', 'first second');
+    $cases[] = array('first second', 'solr', 'phrase', '"first second"');
+    $cases[] = array('first second', 'solr', 'wildphrase', '"*first second*"');
+    $cases[] = array('first second', 'solr', 'wildwords', '*first* *second*');
+    $cases[] = array('first second', 'solr', 'wildwords-suffix', 'first* second*');
 
     // If user supplies wildcards, then ignore mode.
     foreach (array(
-               CRM_Utils_QueryFormatter::MODE_NONE,
-               CRM_Utils_QueryFormatter::MODE_WILDPHRASE,
-               CRM_Utils_QueryFormatter::MODE_WILDWORDS,
-               CRM_Utils_QueryFormatter::MODE_WILDWORDS_SUFFIX,
+               'simple',
+               'wildphrase',
+               'wildwords',
+               'wildwords-suffix',
              ) as $mode) {
-      $cases[] = array(
-        'first% second',
-        CRM_Utils_QueryFormatter::LANG_SQL_LIKE,
-        $mode,
-        'first% second',
-      );
-      $cases[] = array(
-        'first% second',
-        CRM_Utils_QueryFormatter::LANG_SQL_FTS,
-        $mode,
-        'first* second',
-      );
-      $cases[] = array(
-        'first% second',
-        CRM_Utils_QueryFormatter::LANG_SQL_FTSBOOL,
-        $mode,
-        '+first* +second',
-      );
-      $cases[] = array(
-        'first% second',
-        CRM_Utils_QueryFormatter::LANG_SOLR,
-        $mode,
-        'first* second',
-      );
-      $cases[] = array(
-        'first second%',
-        CRM_Utils_QueryFormatter::LANG_SQL_LIKE,
-        $mode,
-        'first second%',
-      );
-      $cases[] = array(
-        'first second%',
-        CRM_Utils_QueryFormatter::LANG_SQL_FTS,
-        $mode,
-        'first second*',
-      );
-      $cases[] = array(
-        'first second%',
-        CRM_Utils_QueryFormatter::LANG_SQL_FTSBOOL,
-        $mode,
-        '+first +second*',
-      );
-      $cases[] = array(
-        'first second%',
-        CRM_Utils_QueryFormatter::LANG_SOLR,
-        $mode,
-        'first second*',
-      );
+      $cases[] = array('first% second', 'like', $mode, 'first% second');
+      $cases[] = array('first% second', 'fts', $mode, 'first* second');
+      $cases[] = array('first% second', 'ftsbool', $mode, '+first* +second');
+      $cases[] = array('first% second', 'solr', $mode, 'first* second');
+      $cases[] = array('first second%', 'like', $mode, 'first second%');
+      $cases[] = array('first second%', 'fts', $mode, 'first second*');
+      $cases[] = array('first second%', 'ftsbool', $mode, '+first +second*');
+      $cases[] = array('first second%', 'solr', $mode, 'first second*');
     }
 
     return $cases;

--- a/tests/phpunit/CRM/Utils/QueryFormatterTest.php
+++ b/tests/phpunit/CRM/Utils/QueryFormatterTest.php
@@ -6,58 +6,103 @@
  */
 class CRM_Utils_QueryFormatterTest extends CiviUnitTestCase {
 
+  public function createExampleTable() {
+    CRM_Core_DAO::executeQuery('
+      DROP TABLE IF EXISTS civicrm_fts_example
+    ');
+    CRM_Core_DAO::executeQuery('
+      CREATE TABLE civicrm_fts_example (
+        id int(10) unsigned NOT NULL AUTO_INCREMENT,
+        name varchar(128) COLLATE utf8_unicode_ci DEFAULT NULL,
+        PRIMARY KEY (id)
+      )
+    ');
+    $idx = new CRM_Core_InnoDBIndexer(self::supportsFts(), array(
+      'civicrm_contact' => array(
+        array('first_name', 'last_name'),
+      ),
+    ));
+    $idx->fixSchemaDifferences();
+    $rows = array(
+      array(1, 'someone@example.com'),
+      array(2, 'this is someone@example.com!'),
+      array(3, 'first second'),
+      array(4, 'zeroth first second'),
+      array(5, 'zeroth first second third'),
+      array(6, 'never say never'),
+      array(7, 'first someone@example.com second'),
+      array(8, 'first someone'),
+      array(9, 'firstly someone'),
+    );
+    foreach ($rows as $row) {
+      CRM_Core_DAO::executeQuery("INSERT INTO civicrm_fts_example (id,name) VALUES (%1, %2)",
+        array(
+          1 => array($row[0], 'Int'),
+          2 => array($row[1], 'String'),
+        ));
+    }
+  }
+
+  public static function tearDownAfterClass() {
+    CRM_Core_DAO::executeQuery('DROP TABLE IF EXISTS civicrm_fts_example');
+    parent::tearDownAfterClass();
+  }
+
   /**
    * Generate data for tests to iterate through.
+   *
+   * Note: These examples are not locked in stone -- but do exercise
+   * discretion in revising them!
    *
    * @return array
    */
   public function dataProvider() {
-    // Array(0=>$inputText, 1=>$language, 2=>$options, 3=>$expectedText).
+    // Array(0=>$inputText, 1=>$language, 2=>$options, 3=>$expectedText, 4=>$matchingIds).
     $cases = array();
 
-    $cases[] = array('someone@example.com', 'like', 'simple', '%someone@example.com%');
-    $cases[] = array('someone@example.com', 'like', 'phrase', '%someone@example.com%');
-    $cases[] = array('someone@example.com', 'like', 'wildphrase', '%someone@example.com%');
-    $cases[] = array('someone@example.com', 'like', 'wildwords', '%someone@example.com%');
-    $cases[] = array('someone@example.com', 'like', 'wildwords-suffix', '%someone@example.com%');
+    $allEmailRows = array(1, 2, 7);
 
-    $cases[] = array('someone@example.com', 'fts', 'simple', 'someone@example.com');
-    $cases[] = array('someone@example.com', 'fts', 'phrase', '"someone@example.com"');
-    $cases[] = array('someone@example.com', 'fts', 'wildphrase', '"*someone@example.com*"');
-    $cases[] = array('someone@example.com', 'fts', 'wildwords', '*someone* *example*'); // (1)
-    $cases[] = array('someone@example.com', 'fts', 'wildwords-suffix', 'someone* example*'); // (1)
+    $cases[] = array('someone@example.com', 'like', 'simple', '%someone@example.com%', $allEmailRows);
+    $cases[] = array('someone@example.com', 'like', 'phrase', '%someone@example.com%', $allEmailRows);
+    $cases[] = array('someone@example.com', 'like', 'wildphrase', '%someone@example.com%', $allEmailRows);
+    $cases[] = array('someone@example.com', 'like', 'wildwords', '%someone@example.com%', $allEmailRows);
+    $cases[] = array('someone@example.com', 'like', 'wildwords-suffix', '%someone@example.com%', $allEmailRows);
 
-    $cases[] = array('someone@example.com', 'ftsbool', 'simple', '+someone +example'); // (1)
-    $cases[] = array('someone@example.com', 'ftsbool', 'phrase', '+"someone@example.com"');
-    $cases[] = array('someone@example.com', 'ftsbool', 'wildphrase', '+"*someone@example.com*"');
-    $cases[] = array('someone@example.com', 'ftsbool', 'wildwords', '+*someone* +*example*'); // (1)
-    $cases[] = array('someone@example.com', 'ftsbool', 'wildwords-suffix', '+someone* +example*'); // (1)
+    $cases[] = array('someone@example.com', 'fts', 'simple', 'someone@example.com', $allEmailRows);
+    $cases[] = array('someone@example.com', 'fts', 'phrase', '"someone@example.com"', $allEmailRows);
+    $cases[] = array('someone@example.com', 'fts', 'wildphrase', '"*someone@example.com*"', $allEmailRows);
+    $cases[] = array('someone@example.com', 'fts', 'wildwords', '*someone* *example*', $allEmailRows);
+    $cases[] = array('someone@example.com', 'fts', 'wildwords-suffix', 'someone* example*', $allEmailRows);
 
-    // Note: The examples marked with (1) are suspicious cases where
+    $cases[] = array('someone@example.com', 'ftsbool', 'simple', '+someone +example', $allEmailRows);
+    $cases[] = array('someone@example.com', 'ftsbool', 'phrase', '+"someone@example.com"', $allEmailRows);
+    $cases[] = array('someone@example.com', 'ftsbool', 'wildphrase', '+"*someone@example.com*"', $allEmailRows);
+    $cases[] = array('someone@example.com', 'ftsbool', 'wildwords', '+*someone* +*example*', $allEmailRows);
+    $cases[] = array('someone@example.com', 'ftsbool', 'wildwords-suffix', '+someone* +example*', $allEmailRows);
 
-    $cases[] = array('first second', 'like', 'simple', '%first second%');
-    $cases[] = array('first second', 'like', 'phrase', '%first second%');
-    $cases[] = array('first second', 'like', 'wildphrase', '%first second%');
-    $cases[] = array('first second', 'like', 'wildwords', '%first%second%');
-    $cases[] = array('first second', 'like', 'wildwords-suffix', '%first%second%');
+    $cases[] = array('first second', 'like', 'simple', '%first second%', array(3, 4, 5));
+    $cases[] = array('first second', 'like', 'phrase', '%first second%', array(3, 4, 5));
+    $cases[] = array('first second', 'like', 'wildphrase', '%first second%', array(3, 4, 5));
+    $cases[] = array('first second', 'like', 'wildwords', '%first%second%', array(3, 4, 5, 7));
+    $cases[] = array('first second', 'like', 'wildwords-suffix', '%first%second%', array(3, 4, 5, 7));
 
-    $cases[] = array('first second', 'fts', 'simple', 'first second');
-    $cases[] = array('first second', 'fts', 'phrase', '"first second"');
-    $cases[] = array('first second', 'fts', 'wildphrase', '"*first second*"');
-    $cases[] = array('first second', 'fts', 'wildwords', '*first* *second*');
-    $cases[] = array('first second', 'fts', 'wildwords-suffix', 'first* second*');
+    $cases[] = array('first second', 'fts', 'simple', 'first second', array(3, 4, 5));
+    $cases[] = array('first second', 'fts', 'phrase', '"first second"', array(3, 4, 5));
+    $cases[] = array('first second', 'fts', 'wildphrase', '"*first second*"', array(3, 4, 5));
+    $cases[] = array('first second', 'fts', 'wildwords', '*first* *second*', array(3, 4, 5, 7));
+    $cases[] = array('first second', 'fts', 'wildwords-suffix', 'first* second*', array(3, 4, 5, 7));
 
-    $cases[] = array('first second', 'ftsbool', 'simple', '+first +second');
-    $cases[] = array('first second', 'ftsbool', 'phrase', '+"first second"');
-    $cases[] = array('first second', 'ftsbool', 'wildphrase', '+"*first second*"');
-    $cases[] = array('first second', 'ftsbool', 'wildwords', '+*first* +*second*');
-    $cases[] = array('first second', 'ftsbool', 'wildwords-suffix', '+first* +second*');
+    $cases[] = array('first second', 'ftsbool', 'simple', '+first +second', array(3, 4, 5));
+    $cases[] = array('first second', 'ftsbool', 'phrase', '+"first second"', array(3, 4, 5));
+    $cases[] = array('first second', 'ftsbool', 'wildphrase', '+"*first second*"', array(3, 4, 5));
+    $cases[] = array('first second', 'ftsbool', 'wildwords', '+*first* +*second*', array(3, 4, 5, 7));
+    $cases[] = array('first second', 'ftsbool', 'wildwords-suffix', '+first* +second*', array(3, 4, 5, 7));
 
-    $cases[] = array('first second', 'solr', 'simple', 'first second');
-    $cases[] = array('first second', 'solr', 'phrase', '"first second"');
-    $cases[] = array('first second', 'solr', 'wildphrase', '"*first second*"');
-    $cases[] = array('first second', 'solr', 'wildwords', '*first* *second*');
-    $cases[] = array('first second', 'solr', 'wildwords-suffix', 'first* second*');
+    $cases[] = array('first second', 'solr', 'simple', 'first second', NULL);
+    $cases[] = array('first second', 'solr', 'phrase', '"first second"', NULL);
+    $cases[] = array('first second', 'solr', 'wildphrase', '"*first second*"', NULL);
+    $cases[] = array('first second', 'solr', 'wildwords', '*first* *second*', NULL);
+    $cases[] = array('first second', 'solr', 'wildwords-suffix', 'first* second*', NULL);
 
     // If user supplies wildcards, then ignore mode.
     foreach (array(
@@ -66,14 +111,14 @@ class CRM_Utils_QueryFormatterTest extends CiviUnitTestCase {
                'wildwords',
                'wildwords-suffix',
              ) as $mode) {
-      $cases[] = array('first% second', 'like', $mode, 'first% second');
-      $cases[] = array('first% second', 'fts', $mode, 'first* second');
-      $cases[] = array('first% second', 'ftsbool', $mode, '+first* +second');
-      $cases[] = array('first% second', 'solr', $mode, 'first* second');
-      $cases[] = array('first second%', 'like', $mode, 'first second%');
-      $cases[] = array('first second%', 'fts', $mode, 'first second*');
-      $cases[] = array('first second%', 'ftsbool', $mode, '+first +second*');
-      $cases[] = array('first second%', 'solr', $mode, 'first second*');
+      $cases[] = array('first% second', 'like', $mode, 'first% second', array(3, 7));
+      $cases[] = array('first% second', 'fts', $mode, 'first* second', array(3, 7));
+      $cases[] = array('first% second', 'ftsbool', $mode, '+first* +second', array(3, 7));
+      $cases[] = array('first% second', 'solr', $mode, 'first* second', NULL);
+      $cases[] = array('first second%', 'like', $mode, 'first second%', array(3));
+      $cases[] = array('first second%', 'fts', $mode, 'first second*', array(3));
+      $cases[] = array('first second%', 'ftsbool', $mode, '+first +second*', array(3));
+      $cases[] = array('first second%', 'solr', $mode, 'first second*', NULL);
     }
 
     return $cases;
@@ -89,10 +134,45 @@ class CRM_Utils_QueryFormatterTest extends CiviUnitTestCase {
    *
    * @dataProvider dataProvider
    */
-  public function testFormat($text, $language, $mode, $expectedText) {
+  public function testFormat($text, $language, $mode, $expectedText, $expectedRowIds) {
     $formatter = new CRM_Utils_QueryFormatter($mode);
     $actualText = $formatter->format($text, $language);
     $this->assertEquals($expectedText, $actualText);
+
+    if ($expectedRowIds !== NULL) {
+      if ($language === 'like') {
+        $this->createExampleTable();
+        $this->assertSqlIds($expectedRowIds, "SELECT id FROM civicrm_fts_example WHERE " . $formatter->formatSql('civicrm_fts_example', 'name', $text));
+      }
+      elseif (in_array($language, array('fts', 'ftsbool'))) {
+        if ($this->supportsFts()) {
+          $this->createExampleTable();
+          $this->assertSqlIds($expectedRowIds, "SELECT id FROM civicrm_fts_example WHERE " . $formatter->formatSql('civicrm_fts_example', 'name', $text));
+        }
+      }
+      elseif ($language === 'solr') {
+        // Skip. Don't have solr test harness.
+      }
+      else {
+        $this->fail("Cannot asset expectedRowIds with unrecognized language $language");
+      }
+    }
+  }
+
+  public static function supportsFts() {
+    return version_compare(CRM_Core_DAO::singleValueQuery('SELECT VERSION()'), '5.6.0', '>=');
+  }
+
+  /**
+   * @param array $expectedRowIds
+   * @param string $sql
+   */
+  private function assertSqlIds($expectedRowIds, $sql) {
+    $actualRowIds = CRM_Utils_Array::collect('id',
+      CRM_Core_DAO::executeQuery($sql)->fetchAll());
+    sort($actualRowIds);
+    sort($expectedRowIds);
+    $this->assertEquals($expectedRowIds, $actualRowIds);
   }
 
 }


### PR DESCRIPTION
This PR is derived from https://github.com/nysenate/Bluebird-CRM/commit/aadc17e30130ae1899daad7ed3999148a1fa2610
and addresses two distinct issues with the "Full Text" search UI:
- Searching by email address in FTS mode causes an error. It includes work-arounds to approximate
  the intended search.
- Performing a blank search in FTS mode causes an error. It should instead try to return everything.

This is marked WIP because I'm still writing test-cases.

---
- [CRM-19048: FullText - Search by email, blank](https://issues.civicrm.org/jira/browse/CRM-19048)
