### PR TITLE
CRM-19027 clean up use of slow query to get tables.

### DIFF
--- a/CRM/Admin/Form/Setting/UF.php
+++ b/CRM/Admin/Form/Setting/UF.php
@@ -79,14 +79,14 @@ class CRM_Admin_Form_Setting_UF extends CRM_Admin_Form_Setting {
       )
     ) {
       $dsnArray = DB::parseDSN($config->dsn);
-      $tableNames = CRM_Core_DAO::GetStorageValues(NULL, 0, 'Name');
+      $tableNames = CRM_Core_DAO::getTableNames();
       $tablePrefixes = '$databases[\'default\'][\'default\'][\'prefix\']= array(';
       $tablePrefixes .= "\n  'default' => '$drupal_prefix',"; // add default prefix: the drupal database prefix
       $prefix = "";
       if ($config->dsn != $config->userFrameworkDSN) {
         $prefix = "`{$dsnArray['database']}`.";
       }
-      foreach ($tableNames as $tableName => $value) {
+      foreach ($tableNames as $tableName) {
         $tablePrefixes .= "\n  '" . str_pad($tableName . "'", 41) . " => '{$prefix}',";
       }
       $tablePrefixes .= "\n);";

--- a/tests/phpunit/CRM/Core/DAOTest.php
+++ b/tests/phpunit/CRM/Core/DAOTest.php
@@ -249,4 +249,14 @@ class CRM_Core_DAOTest extends CiviUnitTestCase {
     }
   }
 
+  /**
+   * Test the function designed to find myIsam tables.
+   */
+  public function testMyISAMCheck() {
+    $this->assertEquals(0, CRM_Core_DAO::isDBMyISAM());
+    CRM_Core_DAO::executeQuery('CREATE TABLE civicrm_my_isam (`id` int(10) unsigned NOT NULL) ENGINE = MyISAM');
+    $this->assertEquals(1, CRM_Core_DAO::isDBMyISAM());
+    CRM_Core_DAO::executeQuery('DROP TABLE civicrm_my_isam');
+  }
+
 }


### PR DESCRIPTION
This is mainly targetting the MyISam DB check - but I also cleaned up the function that gets the code to render the list of tables on the screen civicrm/admin/setting/uf?reset=1 (on drupal when views is enabled

---
- [CRM-19027: Slow query in MyIsam db check](https://issues.civicrm.org/jira/browse/CRM-19027)
