### PR TITLE
CRM-16642 - Compute timestamps using 24-hour clock

### DIFF
--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -710,7 +710,7 @@ ORDER BY   gc.contact_id, g.children
    * @return string
    */
   public static function getCacheInvalidDateTime() {
-    return date('Ymdhis', strtotime("-" . self::smartGroupCacheTimeout() . " Minutes"));
+    return date('YmdHis', strtotime("-" . self::smartGroupCacheTimeout() . " Minutes"));
   }
 
   /**
@@ -721,7 +721,7 @@ ORDER BY   gc.contact_id, g.children
    * @return string
    */
   public static function getRefreshDateTime() {
-    return date('Ymdhis', strtotime("+ " . self::smartGroupCacheTimeout() . " Minutes"));
+    return date('YmdHis', strtotime("+ " . self::smartGroupCacheTimeout() . " Minutes"));
   }
 
 }


### PR DESCRIPTION
`Ymdhis` is silly here.  Use `YmdHis`.  This was causing test results to
vary based on they were run.

---
- [CRM-16642: Smart groups never refreshed by scheduled jobs](https://issues.civicrm.org/jira/browse/CRM-16642)
