### PR TITLE
CRM-17213 add tests for group search

### DIFF
--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -346,7 +346,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
    * @return CRM_Contact_BAO_Group|NULL
    *   The new group BAO (if created)
    */
-  public static function &create(&$params) {
+  public static function create(&$params) {
 
     if (!empty($params['id'])) {
       CRM_Utils_Hook::pre('edit', 'Group', $params['id'], $params);

--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -460,7 +460,6 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
     }
 
     if (!empty($params['organization_id'])) {
-      $groupOrg = array();
       $groupOrg = $params;
       $groupOrg['group_id'] = $group->id;
       CRM_Contact_BAO_GroupOrganization::add($groupOrg);

--- a/CRM/Contact/BAO/GroupContact.php
+++ b/CRM/Contact/BAO/GroupContact.php
@@ -331,7 +331,7 @@ class CRM_Contact_BAO_GroupContact extends CRM_Contact_DAO_GroupContact {
    * @return array|int $values
    *   the relevant data object values for the contact or the total count when $count is TRUE
    */
-  public static function &getContactGroup(
+  public static function getContactGroup(
     $contactId,
     $status = NULL,
     $numGroupContact = NULL,
@@ -356,7 +356,7 @@ class CRM_Contact_BAO_GroupContact extends CRM_Contact_DAO_GroupContact {
                     civicrm_subscription_history.method as method';
     }
 
-    $where = " WHERE contact_a.id = %1 AND civicrm_group.is_active = 1";
+    $where = " WHERE contact_a.id = %1 AND civicrm_group.is_active = 1 AND saved_search_id IS NULL";
 
     if ($excludeHidden) {
       $where .= " AND civicrm_group.is_hidden = 0 ";
@@ -385,10 +385,6 @@ class CRM_Contact_BAO_GroupContact extends CRM_Contact_DAO_GroupContact {
     }
 
     $from = CRM_Contact_BAO_Query::fromClause($tables);
-
-    //CRM-16945: seems hackish but as per CRM-16483 of using group criteria for Search Builder it is mandatory
-    //to include group_contact_cache clause when group table is present, so following code remove duplicacy
-    $from = str_replace("OR civicrm_group.id = civicrm_group_contact_cache.group_id", 'AND civicrm_group.saved_search_id IS NULL', $from);
 
     $where .= " AND $permission ";
 

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2878,11 +2878,11 @@ class CRM_Contact_BAO_Query {
   }
 
   /**
-   * Where / qill clause for groups
+   * Where / qill clause for groups.
    *
    * @param $values
    */
-  public function group(&$values) {
+  public function group($values) {
     list($name, $op, $value, $grouping, $wildcard) = $values;
 
     // If the $value is in OK (operator as key) array format we need to extract the key as operator and value first
@@ -2910,7 +2910,7 @@ class CRM_Contact_BAO_Query {
     }
 
     $groupIds = NULL;
-    $names = array();
+
     $isSmart = FALSE;
     $isNotOp = ($op == 'NOT IN' || $op == '!=');
 

--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -1189,7 +1189,7 @@ SELECT DISTINCT 'civicrm_contact', contact_a.id, contact_a.id, '$cacheKey', cont
   /**
    * @return CRM_Contact_BAO_Query
    */
-  public function &getQuery() {
+  public function getQuery() {
     return $this->_query;
   }
 

--- a/tests/phpunit/CRM/Contact/BAO/GroupContactTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/GroupContactTest.php
@@ -110,7 +110,7 @@ class CRM_Contact_BAO_GroupContactTest extends CiviUnitTestCase {
       'title' => 'Child Group',
       'description' => 'Child Group',
       'visibility' => 'User and User Admin Only',
-      'parents' => $parentGroup->id,
+      'parents' => $parentGroup['id'],
       'is_active' => 1,
     );
     $childGroup = $this->callAPISuccess('Group', 'create', $groupParams2);
@@ -119,7 +119,7 @@ class CRM_Contact_BAO_GroupContactTest extends CiviUnitTestCase {
     $parentContactParams = array(
       'first_name' => 'Parent1 Fname',
       'last_name' => 'Parent1 Lname',
-      'group' => array($parentGroup->id => 1),
+      'group' => array($parentGroup['id'] => 1),
     );
     $parentContact = Contact::createIndividual($parentContactParams);
 
@@ -127,13 +127,13 @@ class CRM_Contact_BAO_GroupContactTest extends CiviUnitTestCase {
     $childContactParams = array(
       'first_name' => 'Child1 Fname',
       'last_name' => 'Child2 Lname',
-      'group' => array($childGroup->id => 1),
+      'group' => array($childGroup['id'] => 1),
     );
     $childContact = Contact::createIndividual($childContactParams);
 
     // Check if searching by parent group  returns both parent and child group contacts
     $searchParams = array(
-      'group' => $parentGroup->id,
+      'group' => $parentGroup['id'],
     );
     $result = $this->callAPISuccess('contact', 'get', $searchParams);
     $validContactIds = array($parentContact, $childContact);
@@ -146,7 +146,7 @@ class CRM_Contact_BAO_GroupContactTest extends CiviUnitTestCase {
 
     // Check if searching by child group returns just child group contacts
     $searchParams = array(
-      'group' => $childGroup->id,
+      'group' => $childGroup['id'],
     );
     $result = $this->callAPISuccess('contact', 'get', $searchParams);
     $validChildContactIds = array($childContact);

--- a/tests/phpunit/CRM/Contact/BAO/GroupContactTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/GroupContactTest.php
@@ -96,7 +96,6 @@ class CRM_Contact_BAO_GroupContactTest extends CiviUnitTestCase {
    */
   public function testContactSearchByParentGroup() {
     // create a parent group
-    // TODO: This is not an API test!!
     $groupParams1 = array(
       'title' => 'Parent Group',
       'description' => 'Parent Group',
@@ -104,7 +103,7 @@ class CRM_Contact_BAO_GroupContactTest extends CiviUnitTestCase {
       'parents' => '',
       'is_active' => 1,
     );
-    $parentGroup = CRM_Contact_BAO_Group::create($groupParams1);
+    $parentGroup = $this->callAPISuccess('Group', 'create', $groupParams1);
 
     // create a child group
     $groupParams2 = array(
@@ -114,7 +113,7 @@ class CRM_Contact_BAO_GroupContactTest extends CiviUnitTestCase {
       'parents' => $parentGroup->id,
       'is_active' => 1,
     );
-    $childGroup = CRM_Contact_BAO_Group::create($groupParams2);
+    $childGroup = $this->callAPISuccess('Group', 'create', $groupParams2);
 
     // Create a contact within parent group
     $parentContactParams = array(
@@ -135,9 +134,8 @@ class CRM_Contact_BAO_GroupContactTest extends CiviUnitTestCase {
     // Check if searching by parent group  returns both parent and child group contacts
     $searchParams = array(
       'group' => $parentGroup->id,
-      'version' => 3,
     );
-    $result = civicrm_api('contact', 'get', $searchParams);
+    $result = $this->callAPISuccess('contact', 'get', $searchParams);
     $validContactIds = array($parentContact, $childContact);
     $resultContactIds = array();
     foreach ($result['values'] as $k => $v) {
@@ -149,9 +147,8 @@ class CRM_Contact_BAO_GroupContactTest extends CiviUnitTestCase {
     // Check if searching by child group returns just child group contacts
     $searchParams = array(
       'group' => $childGroup->id,
-      'version' => 3,
     );
-    $result = civicrm_api('contact', 'get', $searchParams);
+    $result = $this->callAPISuccess('contact', 'get', $searchParams);
     $validChildContactIds = array($childContact);
     $resultChildContactIds = array();
     foreach ($result['values'] as $k => $v) {

--- a/tests/phpunit/CRM/Contact/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTest.php
@@ -292,16 +292,27 @@ class CRM_Contact_BAO_QueryTest extends CiviUnitTestCase {
 
     // Refresh the cache for test purposes. It would be better to alter to alter the GroupContact add function to add contacts to the cache.
     CRM_Contact_BAO_GroupContactCache::remove($groupID, FALSE);
-    $query = new CRM_Contact_BAO_Query(
+
+    $sql = CRM_Contact_BAO_Query::getQuery(
       array(array('group', 'IN', array($groupID), 0, 0)),
       array('contact_id')
     );
 
-    $sql = $query->query();
-    $queryString = implode(' ', $sql);
-    $dao = CRM_Core_DAO::executeQuery($queryString);
+    $dao = CRM_Core_DAO::executeQuery($sql);
     $this->assertEquals(3, $dao->N);
-    $this->assertFalse(strstr(implode(' ', $sql), ' OR '));
+    $this->assertFalse(strstr($sql, ' OR '));
+
+    $sql = CRM_Contact_BAO_Query::getQuery(
+      array(array('group', 'IN', array($groupID), 0, 0)),
+      array('contact_id' => 1, 'group' => 1)
+    );
+
+    $dao = CRM_Core_DAO::executeQuery($sql);
+    $this->assertEquals(3, $dao->N);
+    $this->assertFalse(strstr($sql, ' OR '), 'Query does not include or');
+    while ($dao->fetch()) {
+      $this->assertTrue(($dao->groups == $groupID || $dao->groups == ',' . $groupID), $dao->groups . ' includes ' . $groupID);
+    }
   }
 
 }

--- a/tests/phpunit/CRM/Contact/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTest.php
@@ -290,6 +290,8 @@ class CRM_Contact_BAO_QueryTest extends CiviUnitTestCase {
     $this->callAPISuccess('GroupContact', 'create', array('group_id' => $groupID, 'contact_id' => $individualID, 'status' => 'Added'));
     $this->callAPISuccess('GroupContact', 'create', array('group_id' => $groupID, 'contact_id' => $householdID, 'status' => 'Added'));
 
+    // Refresh the cache for test purposes. It would be better to alter to alter the GroupContact add function to add contacts to the cache.
+    CRM_Contact_BAO_GroupContactCache::remove($groupID, FALSE);
     $query = new CRM_Contact_BAO_Query(
       array(array('group', 'IN', array($groupID), 0, 0)),
       array('contact_id')
@@ -299,6 +301,7 @@ class CRM_Contact_BAO_QueryTest extends CiviUnitTestCase {
     $queryString = implode(' ', $sql);
     $dao = CRM_Core_DAO::executeQuery($queryString);
     $this->assertEquals(3, $dao->N);
+    $this->assertFalse(strstr(implode(' ', $sql), ' OR '));
   }
 
 }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -1788,6 +1788,25 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
     return $result['id'];
   }
 
+  /**
+   * Create a smart group.
+   *
+   * By default it will be a group of households.
+   *
+   * @param array $smartGroupParams
+   * @param array $groupParams
+   * @return int
+   */
+  public function smartGroupCreate($smartGroupParams = array(), $groupParams = array()) {
+    $smartGroupParams = array_merge(array(
+      'formValues' => array('contact_type' => array('IN' => array('Household'))),
+    ),
+    $smartGroupParams);
+    $savedSearch = CRM_Contact_BAO_SavedSearch::create($smartGroupParams);
+
+    $groupParams['saved_search_id'] = $savedSearch->id;
+    return $this->groupCreate($groupParams);
+  }
 
   /**
    * Function to add a Group.


### PR DESCRIPTION
This test ensures we don't break the group search while fixing CRM-17213

---
- [CRM-17213: Manage Groups time outs due to CRM-16483](https://issues.civicrm.org/jira/browse/CRM-17213)

---
- [CRM-16483: Fix search builder to accept all operators with contact groups](https://issues.civicrm.org/jira/browse/CRM-16483)
