### PR TITLE
CRM-19036: Incorrect recipient count as ACL permission is ignored

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -920,8 +920,7 @@ ORDER BY   i.contact_id, i.{$tempColumn}
    * @return void
    */
   public function getTestRecipients($testParams) {
-    $session = CRM_Core_Session::singleton();
-    $senderId = $session->get('userID');
+    $senderId = CRM_Core_Session::singleton()->getLoggedInContactID();
     list($aclJoin, $aclWhere) = CRM_ACL_BAO_ACL::buildAcl($senderId);
 
     if (array_key_exists($testParams['test_group'], CRM_Core_PseudoConstant::group())) {

--- a/CRM/Mailing/BAO/Recipients.php
+++ b/CRM/Mailing/BAO/Recipients.php
@@ -137,4 +137,26 @@ SET mr.mailing_id = $newMailingID
     }
   }
 
+  /**
+   * @inheritDoc
+   */
+  public function addSelectWhereClause() {
+    $clauses = array(
+      // Append ACL clauses while fetching recipient count or list when check_permissions is TRUE
+      'contact_id' => array(),
+    );
+
+    // TODO: For now we are using logged ib contact ID as it is not possible to
+    // fetch creator id of the mail  for building ACL clauses
+    $contactID = CRM_Core_Session::getLoggedInContactID();
+    list($aclJoin, $aclWhere) = CRM_ACL_BAO_ACL::buildAcl($contactID);
+
+    if (!CRM_Utils_System::isNull($aclWhere)) {
+      $clauses['contact_id'][] = " IN (SELECT contact_a.id FROM civicrm_contact contact_a $aclJoin WHERE ( 1 ) $aclWhere ) ";
+    }
+
+    CRM_Utils_Hook::selectWhereClause($this, $clauses);
+    return $clauses;
+  }
+
 }

--- a/ang/crmMailing/services.js
+++ b/ang/crmMailing/services.js
@@ -314,7 +314,8 @@
           options: {force_rollback: 1},
           'api.mailing_job.create': 1, // note: exact match to API default
           'api.MailingRecipients.getcount': {
-            mailing_id: '$value.id'
+            mailing_id: '$value.id',
+            check_permissions: 1
           }
         });
         delete params.recipients; // the content was merged in
@@ -442,7 +443,7 @@
             .then(function (deliveryInfos) {
               var count = Object.keys(deliveryInfos).length;
               if (count === 0) {
-                CRM.alert(ts('Could not identify any recipients. Perhaps the group is empty?'));
+                CRM.alert(ts('Could not identify any recipients. Perhaps the group is empty or due to insufficient permission?'));
               }
             })
           ;
@@ -509,7 +510,7 @@
             return crmLegacy.url('civicrm/contact/search/advanced',
               'force=1&mailing_id=' + mailing.id + statType.searchFilter);
           case 'report':
-            var reportIds = CRM.crmMailing.reportIds; 
+            var reportIds = CRM.crmMailing.reportIds;
             return crmLegacy.url('civicrm/report/instance/' + reportIds[statType.reportType],
                 'reset=1&mailing_id_value=' + mailing.id + statType.reportFilter);
           default:


### PR DESCRIPTION
- [CRM-19036: Incorrect recipient count as ACL permission is ignored](https://issues.civicrm.org/jira/browse/CRM-19036)
