### PR TITLE
CRM-18959: Import fails when custom multi-value date field is imported.

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -1130,22 +1130,8 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
       $params['contact_type'] = 'Individual';
     }
 
-    // get array of subtypes - CRM-18708
-    if (in_array($csType, array('Individual', 'Organization', 'Household'))) {
-      $csType = self::getSubtypes($params['contact_type']);
-    }
-
-    if (is_array($csType)) {
-      // fetch custom fields for every subtype and add it to $customFields array
-      // CRM-18708
-      $customFields = array();
-      foreach ($csType as $cType) {
-        $customFields += CRM_Core_BAO_CustomField::getFields($params['contact_type'], FALSE, FALSE, $cType);
-      }
-    }
-    else {
-      $customFields = CRM_Core_BAO_CustomField::getFields($params['contact_type'], FALSE, FALSE, $csType);
-    }
+    $customFields = CRM_Core_BAO_CustomField::getFields($params['contact_type'], FALSE, FALSE, $csType);
+    
 
     $addressCustomFields = CRM_Core_BAO_CustomField::getFields('Address');
     $customFields = $customFields + $addressCustomFields;

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -1131,7 +1131,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
     }
 
     $customFields = CRM_Core_BAO_CustomField::getFields($params['contact_type'], FALSE, FALSE, $csType);
-    
 
     $addressCustomFields = CRM_Core_BAO_CustomField::getFields('Address');
     $customFields = $customFields + $addressCustomFields;

--- a/CRM/Custom/Import/Form/DataSource.php
+++ b/CRM/Custom/Import/Form/DataSource.php
@@ -53,9 +53,9 @@ class CRM_Custom_Import_Form_DataSource extends CRM_Import_Form_DataSource {
       'multipleCustomData' => $this->_id,
     );
 
-    if ($loadeMapping = $this->get('loadedMapping')) {
-      $this->assign('loadedMapping', $loadeMapping);
-      $defaults['savedMapping'] = $loadeMapping;
+    if ($loadedMapping = $this->get('loadedMapping')) {
+      $this->assign('loadedMapping', $loadedMapping);
+      $defaults['savedMapping'] = $loadedMapping;
     }
 
     return $defaults;
@@ -72,7 +72,30 @@ class CRM_Custom_Import_Form_DataSource extends CRM_Import_Form_DataSource {
     $multipleCustomData = CRM_Core_BAO_CustomGroup::getMultipleFieldGroup();
     $this->add('select', 'multipleCustomData', ts('Multi-value Custom Data'), array('' => ts('- select -')) + $multipleCustomData, TRUE);
 
-    $this->addContactTypeSelector();
+    $js = array('onClick' => "buildSubTypes()");
+    // contact types option
+    $contactOptions = array();
+    if (CRM_Contact_BAO_ContactType::isActive('Individual')) {
+      $contactOptions[] = $this->createElement('radio',
+        NULL, NULL, ts('Individual'), CRM_Import_Parser::CONTACT_INDIVIDUAL, $js
+      );
+    }
+    if (CRM_Contact_BAO_ContactType::isActive('Household')) {
+      $contactOptions[] = $this->createElement('radio',
+        NULL, NULL, ts('Household'), CRM_Import_Parser::CONTACT_HOUSEHOLD, $js
+      );
+    }
+    if (CRM_Contact_BAO_ContactType::isActive('Organization')) {
+      $contactOptions[] = $this->createElement('radio',
+        NULL, NULL, ts('Organization'), CRM_Import_Parser::CONTACT_ORGANIZATION, $js
+      );
+    }
+
+    $this->addGroup($contactOptions, 'contactType',
+      ts('Contact Type')
+    );
+
+    $this->addElement('select', 'contactSubType', ts('Subtype'));
   }
 
   /**
@@ -83,6 +106,7 @@ class CRM_Custom_Import_Form_DataSource extends CRM_Import_Form_DataSource {
   public function postProcess() {
     $this->storeFormValues(array(
       'contactType',
+      'contactSubType',
       'dateFormats',
       'savedMapping',
       'multipleCustomData',

--- a/CRM/Custom/Import/Form/MapField.php
+++ b/CRM/Custom/Import/Form/MapField.php
@@ -219,7 +219,7 @@ class CRM_Custom_Import_Form_MapField extends CRM_Contact_Import_Form_MapField {
     $parser = new $this->_parser($mapperKeysMain);
     $parser->setEntity($this->_multipleCustomData);
     $parser->run($fileName, $separator, $mapper, $skipColumnHeader,
-      CRM_Import_Parser::MODE_PREVIEW, $this->get('contactType')
+      CRM_Import_Parser::MODE_PREVIEW, $this->get('contactType'), $this->get('contactSubType')
     );
     // add all the necessary variables to the form
     $parser->set($this);

--- a/CRM/Custom/Import/Form/Preview.php
+++ b/CRM/Custom/Import/Form/Preview.php
@@ -115,6 +115,7 @@ class CRM_Custom_Import_Form_Preview extends CRM_Import_Form_Preview {
       $skipColumnHeader,
       CRM_Import_Parser::MODE_IMPORT,
       $this->get('contactType'),
+      $this->get('contactSubType'),
       $onDuplicate
     );
 

--- a/CRM/Custom/Import/Parser.php
+++ b/CRM/Custom/Import/Parser.php
@@ -32,7 +32,7 @@
  * $Id$
  *
  */
-abstract class CRM_Custom_Import_Parser extends CRM_Contact_Import_Parser {
+abstract class CRM_Custom_Import_Parser extends CRM_Import_Parser {
 
   protected $_fileName;
 
@@ -81,6 +81,7 @@ abstract class CRM_Custom_Import_Parser extends CRM_Contact_Import_Parser {
     $skipColumnHeader = FALSE,
     $mode = self::MODE_PREVIEW,
     $contactType = self::CONTACT_INDIVIDUAL,
+    $contactSubType = NULL,
     $onDuplicate = self::DUPLICATE_SKIP
   ) {
     if (!is_array($fileName)) {
@@ -100,6 +101,8 @@ abstract class CRM_Custom_Import_Parser extends CRM_Contact_Import_Parser {
       case CRM_Import_Parser::CONTACT_ORGANIZATION:
         $this->_contactType = 'Organization';
     }
+
+    $this->_contactSubType = $contactSubType;
     $this->init();
 
     $this->_haveColumnHeader = $skipColumnHeader;
@@ -324,6 +327,25 @@ abstract class CRM_Custom_Import_Parser extends CRM_Contact_Import_Parser {
       }
     }
     return $params;
+  }
+
+  /**
+   * @param string $name
+   * @param $title
+   * @param int $type
+   * @param string $headerPattern
+   * @param string $dataPattern
+   * @param bool $hasLocationType
+   */
+  public function addField(
+    $name, $title, $type = CRM_Utils_Type::T_INT,
+    $headerPattern = '//', $dataPattern = '//',
+    $hasLocationType = FALSE
+  ) {
+    $this->_fields[$name] = new CRM_Contact_Import_Field($name, $title, $type, $headerPattern, $dataPattern, $hasLocationType);
+    if (empty($name)) {
+      $this->_fields['doNotImport'] = new CRM_Contact_Import_Field($name, $title, $type, $headerPattern, $dataPattern, $hasLocationType);
+    }
   }
 
   /**

--- a/CRM/Custom/Import/Parser/Api.php
+++ b/CRM/Custom/Import/Parser/Api.php
@@ -35,6 +35,7 @@ class CRM_Custom_Import_Parser_Api extends CRM_Custom_Import_Parser {
     $this->_fields = array_merge(array(
         'do_not_import' => array('title' => ts('- do not import -')),
         'contact_id' => array('title' => ts('Contact ID')),
+        'contact_sub_type' => array('title' => ts('Contact Sub Type')),
       ), $importableFields);
   }
 

--- a/CRM/Import/Form/DataSource.php
+++ b/CRM/Import/Form/DataSource.php
@@ -179,7 +179,8 @@ abstract class CRM_Import_Form_DataSource extends CRM_Core_Form {
       $mapper,
       $skipColumnHeader,
       CRM_Import_Parser::MODE_MAPFIELD,
-      $this->get('contactType')
+      $this->get('contactType'),
+      $this->get('contactSubType')
     );
 
     // add all the necessary variables to the form

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -490,5 +490,4 @@ abstract class CRM_Import_Parser {
     fclose($fd);
   }
 
-
 }

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -444,4 +444,51 @@ abstract class CRM_Import_Parser {
     return $fileName;
   }
 
+  /**
+   * Export data to a CSV file.
+   *
+   * @param string $fileName
+   * @param array $header
+   * @param array $data
+   */
+  public static function exportCSV($fileName, $header, $data) {
+
+    if (file_exists($fileName) && !is_writable($fileName)) {
+      CRM_Core_Error::movedSiteError($fileName);
+    }
+    //hack to remove '_status', '_statusMsg' and '_id' from error file
+    $errorValues = array();
+    $dbRecordStatus = array('IMPORTED', 'ERROR', 'DUPLICATE', 'INVALID', 'NEW');
+    foreach ($data as $rowCount => $rowValues) {
+      $count = 0;
+      foreach ($rowValues as $key => $val) {
+        if (in_array($val, $dbRecordStatus) && $count == (count($rowValues) - 3)) {
+          break;
+        }
+        $errorValues[$rowCount][$key] = $val;
+        $count++;
+      }
+    }
+    $data = $errorValues;
+
+    $output = array();
+    $fd = fopen($fileName, 'w');
+
+    foreach ($header as $key => $value) {
+      $header[$key] = "\"$value\"";
+    }
+    $config = CRM_Core_Config::singleton();
+    $output[] = implode($config->fieldSeparator, $header);
+
+    foreach ($data as $datum) {
+      foreach ($datum as $key => $value) {
+        $datum[$key] = "\"$value\"";
+      }
+      $output[] = implode($config->fieldSeparator, $datum);
+    }
+    fwrite($fd, implode("\n", $output));
+    fclose($fd);
+  }
+
+
 }

--- a/templates/CRM/Custom/Import/Form/DataSource.tpl
+++ b/templates/CRM/Custom/Import/Form/DataSource.tpl
@@ -67,8 +67,9 @@
               <td><span>{$form.multipleCustomData.html}</span> </td>
   </tr>
   <tr class="crm-custom-import-uploadfile-from-block-contactType">
-              <td class="label">{$form.contactType.label}</td>
-             <td>{$form.contactType.html}<br />
+       <td class="label">{$form.contactType.label}</td>
+             <td>{$form.contactType.html} {help id='contact-type' file='CRM/Contact/Import/Form/DataSource'}&nbsp;&nbsp;&nbsp;
+               <span id="contact-subtype">{$form.contactSubType.label}&nbsp;&nbsp;&nbsp;{$form.contactSubType.html} {help id='contact-sub-type' file='CRM/Contact/Import/Form/DataSource'}</span></td>
                 <span class="description">
                 {ts}Select 'Individual' if you are importing custom data for individual persons.{/ts}
                 {ts}Select 'Organization' or 'Household' if you are importing custom data . (NOTE: Some built-in contact types may not be enabled for your site.){/ts}
@@ -95,5 +96,42 @@
         </tr>
     </table>
     <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
+  {literal}
+    <script type="text/javascript">
+      CRM.$(function($) {
+         buildSubTypes();
+      });
+
+      function buildSubTypes( )
+      {
+        element = cj('input[name="contactType"]:checked').val( );
+        var postUrl = {/literal}"{crmURL p='civicrm/ajax/subtype' h=0 }"{literal};
+        var param = 'parentId='+ element;
+        cj.ajax({ type: "POST", url: postUrl, data: param, async: false, dataType: 'json',
+
+                        success: function(subtype){
+                                                   if ( subtype.length == 0 ) {
+                                                      cj("#contactSubType").empty();
+                                                      cj("#contact-subtype").hide();
+                                                   } else {
+                                                       cj("#contact-subtype").show();
+                                                       cj("#contactSubType").empty();
+
+                                                       cj("#contactSubType").append("<option value=''>- {/literal}{ts escape='js'}select{/ts}{literal} -</option>");
+                                                       for ( var key in  subtype ) {
+                                                           // stick these new options in the subtype select
+                                                           cj("#contactSubType").append("<option value="+key+">"+subtype[key]+" </option>");
+                                                       }
+                                                   }
+
+
+                                                 }
+  });
+
+      }
+
+
+    </script>
+  {/literal}
   </div>
  </div>


### PR DESCRIPTION
Different path for solving: [CRM-18959](https://issues.civicrm.org/jira/browse/CRM-18959)
Other solution is [PR-8566](https://github.com/civicrm/civicrm-core/pull/8566)
Also reverts [CRM-18708](https://issues.civicrm.org/jira/browse/CRM-18708) 

The guts of the custom import have always supported importing to contact sub types ([CRM-5125](https://issues.civicrm.org/jira/browse/CRM-5125)).  However, at some point mapping the "Contact Sub Type" was dropped from the form.  This PR restores that option.
