### PR TITLE
CRM-19034 Remove line that makes all countries upper case

### DIFF
--- a/CRM/Upgrade/Incremental/sql/4.7.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.7.alpha1.mysql.tpl
@@ -50,9 +50,6 @@ ALTER TABLE civicrm_payment_processor_type
 ADD COLUMN
 `payment_instrument_id` int unsigned   DEFAULT 1 COMMENT 'Payment Instrument ID';
 
--- CRM-16876 Set country names to UPPERCASE
-UPDATE civicrm_country SET `name` = UPPER( `name` );
-
 -- CRM-16447
 UPDATE civicrm_state_province SET name = 'Northern Ostrobothnia' WHERE name = 'Nothern Ostrobothnia';
 


### PR DESCRIPTION
This turned out to be a bad thing :-) separate issue will deal with repairing casing.

---
- [CRM-19034: Remove line that makes all countries upper case](https://issues.civicrm.org/jira/browse/CRM-19034)
