### PR TITLE
[WIP] CRM-18186: Participant API: registered by id fixes

### DIFF
--- a/CRM/Event/BAO/Query.php
+++ b/CRM/Event/BAO/Query.php
@@ -368,6 +368,7 @@ class CRM_Event_BAO_Query {
       case 'participant_fee_amount':
       case 'participant_fee_level':
       case 'participant_campaign_id':
+      case 'participant_registered_by_id':
 
         $qillName = $name;
         if (in_array($name, array(
@@ -379,6 +380,7 @@ class CRM_Event_BAO_Query {
           'participant_fee_level',
           'participant_is_pay_later',
           'participant_campaign_id',
+          'participant_registered_by_id',
         ))
         ) {
           $name = str_replace('participant_', '', $name);

--- a/tests/phpunit/api/v3/ParticipantTest.php
+++ b/tests/phpunit/api/v3/ParticipantTest.php
@@ -69,6 +69,7 @@ class api_v3_ParticipantTest extends CiviUnitTestCase {
     $this->_participantID2 = $this->participantCreate(array(
         'contact_id' => $this->_contactID2,
         'event_id' => $this->_eventID,
+        'registered_by_id' => $this->_participantID,
       ));
     $this->_participantID3 = $this->participantCreate(array(
         'contact_id' => $this->_contactID2,
@@ -341,6 +342,19 @@ class api_v3_ParticipantTest extends CiviUnitTestCase {
     $participant = $this->callAPISuccess('participant', 'get', $params);
 
     $this->assertEquals($participant['count'], 2);
+  }
+
+  /**
+   * Test search by lead booker (registered by ID)
+   */
+  public function testSearchByRegisteredById() {
+    $params = array(
+      'registered_by_id' => $this->_participantID,
+    );
+    $participant = $this->callAPISuccess('participant', 'get', $params);
+
+    $this->assertEquals($participant['count'], 1);
+    $this->assertEquals($participant['id'], $this->_participantID2);
   }
 
   ///////////////// civicrm_participant_create methods


### PR DESCRIPTION
- [CRM-18186: Participant API: get: 'Registered by ID' does not work](https://issues.civicrm.org/jira/browse/CRM-18186)
