### PR TITLE
[NFC] CRM-19033 improve standardisation of tests

### DIFF
--- a/tests/phpunit/CRM/Core/BAO/CustomValueTableSetGetTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomValueTableSetGetTest.php
@@ -18,22 +18,23 @@ class CRM_Core_BAO_CustomValueTableSetGetTest extends CiviUnitTestCase {
     $contactID = $this->individualCreate();
 
     //create Custom Group
-    $customGroup = Custom::createGroup($params, 'Individual', TRUE);
+    $customGroup = $this->customGroupCreate(array('is_multiple' => 1));
 
     //create Custom Field of data type Date
     $fields = array(
-      'groupId' => $customGroup->id,
-      'dataType' => 'Date',
-      'htmlType' => 'Select Date',
+      'custom_group_id' => $customGroup['id'],
+      'data_type' => 'Date',
+      'html_type' => 'Select Date',
+      'default_value' => '',
     );
-    $customField = Custom::createField($params, $fields);
+    $customField = $this->customFieldCreate($fields);
 
     // Retrieve the field ID for sample custom field 'test_Date'
     $params = array('label' => 'test_Date');
     $field = array();
 
     CRM_Core_BAO_CustomField::retrieve($params, $field);
-    $fieldID = $field['id'];
+    $fieldID = $customField['id'];
 
     // Set test_Date to a valid date value
     $date = '20080608000000';
@@ -65,10 +66,10 @@ class CRM_Core_BAO_CustomValueTableSetGetTest extends CiviUnitTestCase {
       'custom_' . $fieldID => $badDate,
     );
 
-    $errorScope = CRM_Core_TemporaryErrorScope::useException();
+    CRM_Core_TemporaryErrorScope::useException();
     $message = NULL;
     try {
-      $result = CRM_Core_BAO_CustomValueTable::setValues($params);
+      CRM_Core_BAO_CustomValueTable::setValues($params);
     }
     catch (Exception $e) {
       $message = $e->getMessage();
@@ -104,8 +105,8 @@ class CRM_Core_BAO_CustomValueTableSetGetTest extends CiviUnitTestCase {
     $this->assertEquals($values['is_error'], 0, 'Verify that is_error = 0 (success).');
 
     // Cleanup
-    Custom::deleteField($customField);
-    Custom::deleteGroup($customGroup);
+    $this->customFieldDelete($customField);
+    $this->customGroupDelete($customGroup['id']);
     $this->contactDelete($contactID);
   }
 
@@ -113,19 +114,18 @@ class CRM_Core_BAO_CustomValueTableSetGetTest extends CiviUnitTestCase {
    * Test setValues() and getValues() methods with custom field YesNo(Boolean) Radio
    */
   public function testSetGetValuesYesNoRadio() {
-    $params = array();
     $contactID = $this->individualCreate();
 
-    //create Custom Group
-    $customGroup = Custom::createGroup($params, 'Individual', TRUE);
+    $customGroup = $this->customGroupCreate(array('is_multiple' => 1));
 
     //create Custom Field of type YesNo(Boolean) Radio
     $fields = array(
-      'groupId' => $customGroup->id,
-      'dataType' => 'Boolean',
-      'htmlType' => 'Radio',
+      'custom_group_id' => $customGroup['id'],
+      'data_type' => 'Boolean',
+      'html_type' => 'Radio',
+      'default_value' => '',
     );
-    $customField = Custom::createField($params, $fields);
+    $customField = $this->customFieldCreate($fields);
 
     // Retrieve the field ID for sample custom field 'test_Boolean'
     $params = array('label' => 'test_Boolean');
@@ -134,7 +134,7 @@ class CRM_Core_BAO_CustomValueTableSetGetTest extends CiviUnitTestCase {
     //get field Id
     CRM_Core_BAO_CustomField::retrieve($params, $field);
 
-    $fieldID = $field['id'];
+    $fieldID = $customField['id'];
 
     // valid boolean value '1' for Boolean Radio
     $yesNo = '1';
@@ -147,7 +147,6 @@ class CRM_Core_BAO_CustomValueTableSetGetTest extends CiviUnitTestCase {
     $this->assertEquals($result['is_error'], 0, 'Verify that is_error = 0 (success).');
 
     // Check that the YesNo radio value is stored
-    $values = array();
     $params = array(
       'entityID' => $contactID,
       'custom_' . $fieldID => 1,
@@ -166,10 +165,10 @@ class CRM_Core_BAO_CustomValueTableSetGetTest extends CiviUnitTestCase {
       'custom_' . $fieldID => $badYesNo,
     );
 
-    $errorScope = CRM_Core_TemporaryErrorScope::useException();
+    CRM_Core_TemporaryErrorScope::useException();
     $message = NULL;
     try {
-      $result = CRM_Core_BAO_CustomValueTable::setValues($params);
+      CRM_Core_BAO_CustomValueTable::setValues($params);
     }
     catch (Exception $e) {
       $message = $e->getMessage();
@@ -190,8 +189,8 @@ class CRM_Core_BAO_CustomValueTableSetGetTest extends CiviUnitTestCase {
     );
 
     // Cleanup
-    Custom::deleteField($customField);
-    Custom::deleteGroup($customGroup);
+    $this->customFieldDelete($customField['id']);
+    $this->customGroupDelete($customGroup['id']);
     $this->contactDelete($contactID);
   }
 

--- a/tests/phpunit/CRM/Core/BAO/CustomValueTableTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomValueTableTest.php
@@ -10,74 +10,73 @@ class CRM_Core_BAO_CustomValueTableTest extends CiviUnitTestCase {
     parent::setUp();
   }
 
-
   /**
    * Test store function for country.
    */
   public function testStoreCountry() {
     $params = array();
     $contactID = $this->individualCreate();
-    $customGroup = Custom::createGroup($params, 'Individual');
+    $customGroup = $this->customGroupCreate();
     $fields = array(
-      'groupId' => $customGroup->id,
-      'dataType' => 'Country',
-      'htmlType' => 'Select Country',
+      'custom_group_id' => $customGroup['id'],
+      'data_type' => 'Country',
+      'html_type' => 'Select Country',
+      'default_value' => '',
     );
 
-    $customField = Custom::createField($params, $fields);
+    $customField = $this->customFieldCreate($fields);
 
     $params[] = array(
-      $customField->id => array(
+      $customField['id'] => array(
         'value' => 1228,
         'type' => 'Country',
-        'custom_field_id' => $customField->id,
-        'custom_group_id' => $customGroup->id,
-        'table_name' => 'civicrm_value_test_group_' . $customGroup->id,
-        'column_name' => 'test_Country_' . $customField->id,
+        'custom_field_id' => $customField['id'],
+        'custom_group_id' => $customGroup['id'],
+        'table_name' => $customGroup['values'][$customGroup['id']]['table_name'],
+        'column_name' => $customField['values'][$customField['id']]['column_name'],
         'file_id' => '',
       ),
     );
 
     CRM_Core_BAO_CustomValueTable::store($params, 'civicrm_contact', $contactID);
-    //        $this->assertDBCompareValue('CRM_Custom_DAO_CustomValue', )
 
-    Custom::deleteField($customField);
-    Custom::deleteGroup($customGroup);
+    $this->customFieldDelete($customField['id']);
+    $this->customGroupDelete($customGroup['id']);
     $this->contactDelete($contactID);
   }
 
   /**
    * Test store function for file.
    */
-  public function atestStoreFile() {
-    $params = array();
+  public function testStoreFile() {
     $contactID = $this->individualCreate();
-    $customGroup = Custom::createGroup($params, 'Individual');
+    $file = $this->callAPISuccess('File', 'create', array('uri' => 'dummy_data'));
+    $customGroup = $this->customGroupCreate();
     $fields = array(
-      'groupId' => $customGroup->id,
-      'dataType' => 'File',
-      'htmlType' => 'File',
+      'custom_group_id' => $customGroup['id'],
+      'data_type' => 'File',
+      'html_type' => 'File',
+      'default_value' => '',
     );
 
-    $customField = Custom::createField($params, $fields);
+    $customField = $this->customFieldCreate($fields);
 
     $params[] = array(
-      $customField->id => array(
+      $customField['id'] => array(
         'value' => 'i/contact_house.png',
         'type' => 'File',
-        'custom_field_id' => $customField->id,
-        'custom_group_id' => $customGroup->id,
-        'table_name' => 'civicrm_value_test_group_' . $customGroup->id,
-        'column_name' => 'test_File_' . $customField->id,
-        'file_id' => 1,
+        'custom_field_id' => $customField['id'],
+        'custom_group_id' => $customGroup['id'],
+        'table_name' => $customGroup['values'][$customGroup['id']]['table_name'],
+        'column_name' => $customField['values'][$customField['id']]['column_name'],
+        'file_id' => $file['id'],
       ),
     );
 
     CRM_Core_BAO_CustomValueTable::store($params, 'civicrm_contact', $contactID);
-    //        $this->assertDBCompareValue('CRM_Custom_DAO_CustomValue', )
 
-    Custom::deleteField($customField);
-    Custom::deleteGroup($customGroup);
+    $this->customFieldDelete($customField['id']);
+    $this->customGroupDelete($customGroup['id']);
     $this->contactDelete($contactID);
   }
 
@@ -85,33 +84,33 @@ class CRM_Core_BAO_CustomValueTableTest extends CiviUnitTestCase {
    * Test store function for state province.
    */
   public function testStoreStateProvince() {
-    $params = array();
     $contactID = $this->individualCreate();
-    $customGroup = Custom::createGroup($params, 'Individual');
+    $customGroup = $this->customGroupCreate();
     $fields = array(
-      'groupId' => $customGroup->id,
-      'dataType' => 'StateProvince',
-      'htmlType' => 'Select State/Province',
+      'custom_group_id' => $customGroup['id'],
+      'data_type' => 'StateProvince',
+      'html_type' => 'Select State/Province',
+      'default_value' => '',
     );
 
-    $customField = Custom::createField($params, $fields);
+    $customField = $this->customFieldCreate($fields);
 
     $params[] = array(
-      $customField->id => array(
+      $customField['id'] => array(
         'value' => 1029,
         'type' => 'StateProvince',
-        'custom_field_id' => $customField->id,
-        'custom_group_id' => $customGroup->id,
-        'table_name' => 'civicrm_value_test_group_' . $customGroup->id,
-        'column_name' => 'test_StateProvince_' . $customField->id,
+        'custom_field_id' => $customField['id'],
+        'custom_group_id' => $customGroup['id'],
+        'table_name' => $customGroup['values'][$customGroup['id']]['table_name'],
+        'column_name' => $customField['values'][$customField['id']]['column_name'],
         'file_id' => 1,
       ),
     );
 
     CRM_Core_BAO_CustomValueTable::store($params, 'civicrm_contact', $contactID);
 
-    Custom::deleteField($customField);
-    Custom::deleteGroup($customGroup);
+    $this->customFieldDelete($customField['id']);
+    $this->customGroupDelete($customGroup['id']);
     $this->contactDelete($contactID);
   }
 
@@ -121,32 +120,32 @@ class CRM_Core_BAO_CustomValueTableTest extends CiviUnitTestCase {
   public function testStoreDate() {
     $params = array();
     $contactID = $this->individualCreate();
-    $customGroup = Custom::createGroup($params, 'Individual');
+    $customGroup = $this->customGroupCreate();
     $fields = array(
-      'groupId' => $customGroup->id,
-      'dataType' => 'Date',
-      'htmlType' => 'Select Date',
+      'custom_group_id' => $customGroup['id'],
+      'data_type' => 'Date',
+      'html_type' => 'Select Date',
+      'default_value' => '',
     );
 
-    $customField = Custom::createField($params, $fields);
+    $customField = $this->customFieldCreate($fields);
 
     $params[] = array(
-      $customField->id => array(
+      $customField['id'] => array(
         'value' => '20080608000000',
         'type' => 'Date',
-        'custom_field_id' => $customField->id,
-        'custom_group_id' => $customGroup->id,
-        'table_name' => 'civicrm_value_test_group_' . $customGroup->id,
-        'column_name' => 'test_Date_' . $customField->id,
+        'custom_field_id' => $customField['id'],
+        'custom_group_id' => $customGroup['id'],
+        'table_name' => $customGroup['values'][$customGroup['id']]['table_name'],
+        'column_name' => $customField['values'][$customField['id']]['column_name'],
         'file_id' => '',
       ),
     );
 
     CRM_Core_BAO_CustomValueTable::store($params, 'civicrm_contact', $contactID);
-    //        $this->assertDBCompareValue('CRM_Custom_DAO_CustomValue', )
 
-    Custom::deleteField($customField);
-    Custom::deleteGroup($customGroup);
+    $this->customFieldDelete($customField['id']);
+    $this->customGroupDelete($customGroup['id']);
     $this->contactDelete($contactID);
   }
 
@@ -156,106 +155,104 @@ class CRM_Core_BAO_CustomValueTableTest extends CiviUnitTestCase {
   public function testStoreRichTextEditor() {
     $params = array();
     $contactID = $this->individualCreate();
-    $customGroup = Custom::createGroup($params, 'Individual');
+    $customGroup = $this->customGroupCreate();
     $fields = array(
-      'groupId' => $customGroup->id,
-      'htmlType' => 'RichTextEditor',
-      'dataType' => 'Memo',
+      'custom_group_id' => $customGroup['id'],
+      'html_type' => 'RichTextEditor',
+      'data_type' => 'Memo',
     );
 
-    $customField = Custom::createField($params, $fields);
+    $customField = $this->customFieldCreate($fields);
 
     $params[] = array(
-      $customField->id => array(
+      $customField['id'] => array(
         'value' => '<p><strong>This is a <u>test</u></p>',
         'type' => 'Memo',
-        'custom_field_id' => $customField->id,
-        'custom_group_id' => $customGroup->id,
-        'table_name' => 'civicrm_value_test_group_' . $customGroup->id,
-        'column_name' => 'test_Memo_' . $customField->id,
+        'custom_field_id' => $customField['id'],
+        'custom_group_id' => $customGroup['id'],
+        'table_name' => $customGroup['values'][$customGroup['id']]['table_name'],
+        'column_name' => $customField['values'][$customField['id']]['column_name'],
         'file_id' => '',
       ),
     );
 
     CRM_Core_BAO_CustomValueTable::store($params, 'civicrm_contact', $contactID);
-    //        $this->assertDBCompareValue('CRM_Custom_DAO_CustomValue', )
 
-    Custom::deleteField($customField);
-    Custom::deleteGroup($customGroup);
+    $this->customFieldDelete($customField['id']);
+    $this->customGroupDelete($customGroup['id']);
     $this->contactDelete($contactID);
   }
 
   /**
    * Test getEntityValues function for stored value.
    */
-  public function testgetEntityValues() {
+  public function testGetEntityValues() {
 
     $params = array();
     $contactID = $this->individualCreate();
-    $customGroup = Custom::createGroup($params, 'Individual');
+    $customGroup = $this->customGroupCreate(array('extends' => 'Individual'));
     $fields = array(
-      'groupId' => $customGroup->id,
-      'htmlType' => 'RichTextEditor',
-      'dataType' => 'Memo',
+      'custom_group_id' => $customGroup['id'],
+      'html_type' => 'RichTextEditor',
+      'data_type' => 'Memo',
     );
 
-    $customField = Custom::createField($params, $fields);
+    $customField = $this->customFieldCreate($fields);
 
     $params[] = array(
-      $customField->id => array(
+      $customField['id'] => array(
         'value' => '<p><strong>This is a <u>test</u></p>',
         'type' => 'Memo',
-        'custom_field_id' => $customField->id,
-        'custom_group_id' => $customGroup->id,
-        'table_name' => 'civicrm_value_test_group_' . $customGroup->id,
-        'column_name' => 'test_Memo_' . $customField->id,
+        'custom_field_id' => $customField['id'],
+        'custom_group_id' => $customGroup['id'],
+        'table_name' => $customGroup['values'][$customGroup['id']]['table_name'],
+        'column_name' => $customField['values'][$customField['id']]['column_name'],
         'file_id' => '',
       ),
     );
 
     CRM_Core_BAO_CustomValueTable::store($params, 'civicrm_contact', $contactID);
-    //        $this->assertDBCompareValue('CRM_Custom_DAO_CustomValue', )
 
     $entityValues = CRM_Core_BAO_CustomValueTable::getEntityValues($contactID, 'Individual');
 
-    $this->assertEquals($entityValues[$customField->id], '<p><strong>This is a <u>test</u></p>',
+    $this->assertEquals($entityValues[$customField['id']], '<p><strong>This is a <u>test</u></p>',
       'Checking same for returned value.'
     );
-    Custom::deleteField($customField);
-    Custom::deleteGroup($customGroup);
+    $this->customFieldDelete($customField['id']);
+    $this->customGroupDelete($customGroup['id']);
     $this->contactDelete($contactID);
   }
 
   public function testCustomGroupMultiple() {
     $params = array();
     $contactID = $this->individualCreate();
-    $customGroup = Custom::createGroup($params, 'Individual');
+    $customGroup = $this->customGroupCreate();
 
     $fields = array(
-      'groupId' => $customGroup->id,
-      'dataType' => 'String',
-      'htmlType' => 'Text',
+      'custom_group_id' => $customGroup['id'],
+      'data_type' => 'String',
+      'html_type' => 'Text',
     );
 
-    $customField = Custom::createField($params, $fields);
+    $customField = $this->customFieldCreate($fields);
 
     $params = array(
       'entityID' => $contactID,
-      'custom_' . $customField->id . '_-1' => 'First String',
+      'custom_' . $customField['id'] . '_-1' => 'First String',
     );
     $error = CRM_Core_BAO_CustomValueTable::setValues($params);
 
     $newParams = array(
       'entityID' => $contactID,
-      'custom_' . $customField->id => 1,
+      'custom_' . $customField['id'] => 1,
     );
     $result = CRM_Core_BAO_CustomValueTable::getValues($newParams);
 
-    $this->assertEquals($params['custom_' . $customField->id . '_-1'], $result['custom_' . $customField->id]);
+    $this->assertEquals($params['custom_' . $customField['id'] . '_-1'], $result['custom_' . $customField['id']]);
     $this->assertEquals($params['entityID'], $result['entityID']);
 
-    Custom::deleteField($customField);
-    Custom::deleteGroup($customGroup);
+    $this->customFieldDelete($customField['id']);
+    $this->customGroupDelete($customGroup['id']);
     $this->contactDelete($contactID);
   }
 


### PR DESCRIPTION
Per the others in this series adding merge on pass because 
1) it is only tidy up
2) code change only affects tests
3) I've been having trouble getting jenkins to ping back on the full set out of keeping with the risk involved so breaking into several commits & self-merging

---
- [CRM-19033: Improve standardisation of test classes by removing the duplicate functions](https://issues.civicrm.org/jira/browse/CRM-19033)
