### PR TITLE
CRM-18483 - Fix variable typo for Paypal Pro

### DIFF
--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -337,10 +337,10 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
     $params['pending_reason'] = $result['pendingreason'];
     if (!empty($params['is_recur'])) {
       // See comment block.
-      $result['payment_status_id'] = array_search('Pending', $statuses);
+      $params['payment_status_id'] = array_search('Pending', $statuses);
     }
     else {
-      $result['payment_status_id'] = array_search('Completed', $statuses);
+      $params['payment_status_id'] = array_search('Completed', $statuses);
     }
     return $params;
   }


### PR DESCRIPTION
This doesn't update `Pending` status to `Completed` when a contribution is made from `expressCheckout Button` for PayPal Pro.

---
- [CRM-18483: Paypal payments - Pending (Incomplete Transaction)](https://issues.civicrm.org/jira/browse/CRM-18483)
