### PR TITLE
CRM-19038 NFC backport safe Remove FK code to 4.6

### DIFF
--- a/CRM/Core/BAO/SchemaHandler.php
+++ b/CRM/Core/BAO/SchemaHandler.php
@@ -604,4 +604,34 @@ MODIFY      {$columnName} varchar( $length )
     return FALSE;
   }
 
+  /**
+   * Remove a foreign key from a table if it exists
+   *
+   * @param $table_name
+   * @param $constraint_name
+   */
+  public static function safeRemoveFK($table_name, $constraint_name) {
+
+    $config = CRM_Core_Config::singleton();
+    $dbUf = DB::parseDSN($config->dsn);
+    $query = "
+      SELECT CONSTRAINT_NAME FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+      WHERE TABLE_SCHEMA = %1
+      AND TABLE_NAME = %2
+      AND CONSTRAINT_NAME = %3
+      AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+    ";
+    $params = array(
+      1 => array($dbUf['database'], 'String'),
+      2 => array($table_name, 'String'),
+      3 => array($constraint_name, 'String'),
+    );
+    $dao = CRM_Core_DAO::executeQuery($query, $params);
+
+    if ($dao->fetch()) {
+      CRM_Core_DAO::executeQuery("ALTER TABLE {$table_name} DROP FOREIGN KEY {$constraint_name}", array());
+    }
+
+  }
+
 }

--- a/CRM/Core/BAO/SchemaHandler.php
+++ b/CRM/Core/BAO/SchemaHandler.php
@@ -630,8 +630,9 @@ MODIFY      {$columnName} varchar( $length )
 
     if ($dao->fetch()) {
       CRM_Core_DAO::executeQuery("ALTER TABLE {$table_name} DROP FOREIGN KEY {$constraint_name}", array());
+      return TRUE;
     }
-
+    return FALSE;
   }
 
 }

--- a/tests/phpunit/CRM/Core/BAO/SchemaHandlerTest.php
+++ b/tests/phpunit/CRM/Core/BAO/SchemaHandlerTest.php
@@ -149,18 +149,26 @@ class CRM_Core_BAO_SchemaHandlerTest extends CiviUnitTestCase {
   }
 
   /**
+   * @return array
+   */
+  public function foreignKeyTests() {
+    $keys = array();
+    $keys[] = array('civicrm_mailing_recipients', 'FK_civicrm_mailing_recipients_email_id');
+    $keys[] = array('civicrm_mailing_recipients', 'FK_civicrm_mailing_recipients_id');
+    return $keys;
+  }
+
+  /**
    * Test to see if we can drop foreign key
    *
+   * @dataProvider foreignKeyTests
    */
-  public function testSafeDropForeignKey() {
-    $tests = array('FK_civicrm_mailing_recipients_email_id', 'FK_civicrm_mailing_recipients_id');
-    foreach ($tests as $test) {
-      if ($test == 'FK_civicrm_mailing_recipients_id') {
-        $this->assertFalse(CRM_Core_BAO_SchemaHandler::safeRemoveFK('civicrm_mailing_recipients', $test));
-      }
-      else {
-        $this->assertTrue(CRM_Core_BAO_SchemaHandler::safeRemoveFK('civicrm_mailing_recipients', $test));
-      }
+  public function testSafeDropForeignKey($tableName, $key) {
+    if ($key == 'FK_civicrm_mailing_recipients_id') {
+      $this->assertFalse(CRM_Core_BAO_SchemaHandler::safeRemoveFK('civicrm_mailing_recipients', $key));
+    }
+    else {
+      $this->assertTrue(CRM_Core_BAO_SchemaHandler::safeRemoveFK('civicrm_mailing_recipients', $key));
     }
   }
 

--- a/tests/phpunit/CRM/Core/BAO/SchemaHandlerTest.php
+++ b/tests/phpunit/CRM/Core/BAO/SchemaHandlerTest.php
@@ -148,4 +148,20 @@ class CRM_Core_BAO_SchemaHandlerTest extends CiviUnitTestCase {
     }
   }
 
+  /**
+   * Test to see if we can drop foreign key
+   *
+   */
+  public function testSafeDropForeignKey() {
+    $tests = array('FK_civicrm_mailing_recipients_email_id', 'FK_civicrm_mailing_recipients_id');
+    foreach ($tests as $test) {
+      if ($test == 'FK_civicrm_mailing_recipients_id') {
+        $this->assertFalse(CRM_Core_BAO_SchemaHandler::safeRemoveFK('civicrm_mailing_recipients', $test));
+      }
+      else {
+        $this->assertTrue(CRM_Core_BAO_SchemaHandler::safeRemoveFK('civicrm_mailing_recipients', $test));
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
- [CRM-19038: Move safeRemoveFK function out of Upgrade code and into schemaHandler class](https://issues.civicrm.org/jira/browse/CRM-19038)
