### PR TITLE
CRM-19056 - Add record button edits existing custom field record instead

### DIFF
--- a/CRM/Core/BAO/CustomOption.php
+++ b/CRM/Core/BAO/CustomOption.php
@@ -81,7 +81,7 @@ class CRM_Core_BAO_CustomOption {
 
     $optionValues = CRM_Core_PseudoConstant::get('CRM_Core_BAO_CustomField', 'custom_' . $fieldID, array(), $inactiveNeeded ? 'get' : 'create');
 
-    foreach ($optionValues as $value => $label) {
+    foreach ((array) $optionValues as $value => $label) {
       $options[] = array(
         'label' => $label,
         'value' => $value,

--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -501,8 +501,8 @@ AND    $cond
         }
       }
     }
-    if (!empty($DTparams)) {
-      return array($result, $sortedResult);
+    if (!empty($sortedResult)) {
+      $result['sortedResult'] = $sortedResult;
     }
     return $result;
   }

--- a/CRM/Custom/Page/AJAX.php
+++ b/CRM/Custom/Page/AJAX.php
@@ -125,7 +125,7 @@ class CRM_Custom_Page_AJAX {
     $obj->_contactType = $contactType;
     $obj->_DTparams['offset'] = ($params['page'] - 1) * $params['rp'];
     $obj->_DTparams['rowCount'] = $params['rp'];
-    if ($params['sortBy']) {
+    if (!empty($params['sortBy'])) {
       $obj->_DTparams['sort'] = $params['sortBy'];
     }
 
@@ -153,6 +153,10 @@ class CRM_Custom_Page_AJAX {
     $multiRecordFields['data'] = $fieldList;
     $multiRecordFields['recordsTotal'] = $totalRecords;
     $multiRecordFields['recordsFiltered'] = $totalRecords;
+
+    if (!empty($_GET['is_unit_test'])) {
+      return $multiRecordFields;
+    }
 
     CRM_Utils_JSON::output($multiRecordFields);
   }

--- a/CRM/Profile/Page/MultipleRecordFieldsListing.php
+++ b/CRM/Profile/Page/MultipleRecordFieldsListing.php
@@ -262,9 +262,11 @@ class CRM_Profile_Page_MultipleRecordFieldsListing extends CRM_Core_Page_Basic {
 
       $DTparams = !empty($this->_DTparams) ? $this->_DTparams : NULL;
       // commonly used for both views i.e profile listing view (profileDataView) and custom data listing view (customDataView)
-      list($result, $sortedResult) = CRM_Core_BAO_CustomValueTable::getEntityValues($this->_contactId, NULL, $fieldIDs, TRUE, $DTparams);
+      $result = CRM_Core_BAO_CustomValueTable::getEntityValues($this->_contactId, NULL, $fieldIDs, TRUE, $DTparams);
       $resultCount = !empty($result['count']) ? $result['count'] : count($result);
+      $sortedResult = !empty($result['sortedResult']) ? $result['sortedResult'] : array();
       unset($result['count']);
+      unset($result['sortedResult']);
 
       if ($this->_pageViewType == 'profileDataView') {
         if (!empty($fieldIDs)) {

--- a/tests/phpunit/CRM/Custom/Page/AjaxTest.php
+++ b/tests/phpunit/CRM/Custom/Page/AjaxTest.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * Class CRM_Custom_Page_AJAXTest
+ * @group headless
+ */
+class CRM_Custom_Page_AJAXTest extends CiviUnitTestCase {
+
+  /**
+   * Set up function.
+   */
+  public function setUp() {
+    parent::setUp();
+  }
+
+  /**
+   * Test multi-record custom fields
+   */
+  public function testMultiRecordFieldList() {
+    //create multi record custom group
+    $ids = $this->CustomGroupMultipleCreateWithFields(array('style' => 'Tab with table'));
+    $params = array(
+      'contact_type' => 'Individual',
+      'first_name' => 'Test',
+      'last_name' => 'Contact',
+    );
+    $customFields = $ids['custom_field_id'];
+    $result = $this->callAPISuccess('contact', 'create', $params);
+    $contactId = $result['id'];
+
+    //enter values for custom fields
+    $customParams = array(
+      "custom_{$customFields[0]}_-1" => "test value {$customFields[0]} one",
+      "custom_{$customFields[0]}_-2" => "test value {$customFields[0]} two",
+      "custom_{$customFields[1]}_-1" => "test value {$customFields[1]} one",
+      "custom_{$customFields[1]}_-2" => "test value {$customFields[1]} two",
+      "custom_{$customFields[2]}_-1" => "test value {$customFields[2]} one",
+      "custom_{$customFields[2]}_-2" => "test value {$customFields[2]} two",
+    );
+    CRM_Core_BAO_CustomValueTable::postProcess($customParams, "civicrm_contact", $contactId, NULL);
+
+    $_GET = array(
+      'cid' => $contactId,
+      'cgid' => $ids['custom_group_id'],
+      'is_unit_test' => TRUE,
+    );
+    $multiRecordFields = CRM_Custom_Page_AJAX::getMultiRecordFieldList();
+
+    //check sorting
+    foreach ($customFields as $fieldId) {
+      $columnName = "field_{$fieldId}{$ids['custom_group_id']}_{$fieldId}";
+      $_GET['columns'][] = array(
+        'data' => $columnName,
+      );
+    }
+    // get the results in descending order
+    $_GET['order'] = array(
+      '0' => array(
+        'column' => 0,
+        'dir' => 'desc',
+      ),
+    );
+    $sortedRecords = CRM_Custom_Page_AJAX::getMultiRecordFieldList();
+
+    $this->assertEquals(2, $sortedRecords['recordsTotal']);
+    $this->assertEquals(2, $multiRecordFields['recordsTotal']);
+    foreach ($customFields as $fieldId) {
+      $columnName = "field_{$fieldId}{$ids['custom_group_id']}_{$fieldId}";
+      $this->assertEquals("test value {$fieldId} one", $multiRecordFields['data'][0][$columnName]['data']);
+      $this->assertEquals("test value {$fieldId} two", $multiRecordFields['data'][1][$columnName]['data']);
+
+      // this should be sorted in descending order.
+      $this->assertEquals("test value {$fieldId} two", $sortedRecords['data'][0][$columnName]['data']);
+      $this->assertEquals("test value {$fieldId} one", $sortedRecords['data'][1][$columnName]['data']);
+    }
+
+    //check the links
+    $sorted = FALSE;
+    foreach (array($multiRecordFields, $sortedRecords) as $records) {
+      $count = 1;
+      //check links for result sorted in descending order
+      if ($sorted) {
+        $count = 2;
+      }
+      foreach ($records['data'] as $key => $val) {
+        preg_match_all('!https?://\S+!', $val['action'], $matches);
+        foreach ($matches[0] as $match) {
+          $parts = parse_url($match);
+          $parts['query'] = str_replace('&amp;', '&', $parts['query']);
+          parse_str($parts['query'], $query);
+
+          switch (trim($query['mode'], '"')) {
+            case 'view':
+              $this->assertEquals($count, $query['recId']);
+              break;
+
+            case 'edit':
+              $this->assertEquals($count, $query['cgcount']);
+              break;
+
+            case 'copy':
+              $this->assertEquals(3, $query['cgcount']);
+              break;
+          }
+        }
+
+        //decrement the count as we're sorting in descending order.
+        if ($sorted) {
+          $count--;
+        }
+        else {
+          $count++;
+        }
+      }
+      $sorted = TRUE;
+    }
+  }
+
+}

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -2074,6 +2074,7 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
     $customField = $this->customFieldCreate(array(
       'custom_group_id' => $ids['custom_group_id'],
       'label' => 'field_1' . $ids['custom_group_id'],
+      'in_selector' => 1,
     ));
 
     $ids['custom_field_id'][] = $customField['id'];
@@ -2082,6 +2083,7 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
       'custom_group_id' => $ids['custom_group_id'],
       'default_value' => '',
       'label' => 'field_2' . $ids['custom_group_id'],
+      'in_selector' => 1,
     ));
     $ids['custom_field_id'][] = $customField['id'];
 
@@ -2089,6 +2091,7 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
       'custom_group_id' => $ids['custom_group_id'],
       'default_value' => '',
       'label' => 'field_3' . $ids['custom_group_id'],
+      'in_selector' => 1,
     ));
     $ids['custom_field_id'][] = $customField['id'];
 


### PR DESCRIPTION
- [CRM-19056: Add record button edits existing custom field record instead](https://issues.civicrm.org/jira/browse/CRM-19056)
