### PR TITLE
CRM-18694 alternative solution to easier post code searching.

### DIFF
--- a/CRM/Contact/Page/AJAX.php
+++ b/CRM/Contact/Page/AJAX.php
@@ -688,7 +688,9 @@ LIMIT {$offset}, {$rowCount}
 
     foreach ($mappings as $key => $dbName) {
       if (!empty($searchParams[$key])) {
-        $queryParams[$nextParamKey] = array('%' . $searchParams[$key] . '%', 'String');
+        // CRM-18694.
+        $wildcard = strstr($key, 'postcode') ? '' : '%';
+        $queryParams[$nextParamKey] = array($wildcard . $searchParams[$key] . '%', 'String');
         $where[] = $dbName . " LIKE %{$nextParamKey} ";
         $nextParamKey++;
       }


### PR DESCRIPTION
The proposal is to change it to regex but the comments suggest the primary reason for this is that it makes more sense to search from the start of the string. This being the case it seems that we could opt to use an indexed query rather than regex

---
- [CRM-18694: DedupeFind: AJAX getdupes method should reflect DataTable's sort-by-regex functionality](https://issues.civicrm.org/jira/browse/CRM-18694)
