### PR TITLE
CRM-19069 Remove server-hurty OR join

### DIFF
--- a/CRM/Dedupe/BAO/Rule.php
+++ b/CRM/Dedupe/BAO/Rule.php
@@ -171,20 +171,22 @@ class CRM_Dedupe_BAO_Rule extends CRM_Dedupe_DAO_Rule {
       $where[] = "t1.{$this->rule_field} IS NOT NULL";
       $where[] = "t1.{$this->rule_field} <> ''";
     }
+    $query = "SELECT $select FROM $from WHERE " . implode(' AND ', $where);
     if ($this->contactIds) {
       $cids = array();
       foreach ($this->contactIds as $cid) {
         $cids[] = CRM_Utils_Type::escape($cid, 'Integer');
       }
       if (count($cids) == 1) {
-        $where[] = "(t1.$id = {$cids[0]} OR t2.$id = {$cids[0]})";
+        $query .= " AND (t1.$id = {$cids[0]}) UNION $query AND t2.$id = {$cids[0]}";
       }
       else {
-        $where[] = "(t1.$id IN (" . implode(',', $cids) . ") OR t2.$id IN (" . implode(',', $cids) . "))";
+        $query .= " AND t1.$id IN (" . implode(',', $cids) . ")
+        UNION $query AND  t2.$id IN (" . implode(',', $cids) . ")";
       }
     }
 
-    return "SELECT $select FROM $from WHERE " . implode(' AND ', $where);
+    return $query;
   }
 
   /**

--- a/tests/phpunit/CRM/Dedupe/MergerTest.php
+++ b/tests/phpunit/CRM/Dedupe/MergerTest.php
@@ -392,6 +392,43 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
         'canMerge' => TRUE,
       ),
     ), $pairs);
+
+    $this->callAPISuccess('GroupContact', 'create', array('group_id' => $groupID, 'contact_id' => $this->contacts[5]['id']));
+    CRM_Core_DAO::executeQuery("DELETE FROM civicrm_prevnext_cache");
+    $pairs = CRM_Dedupe_Merger::getDuplicatePairs(
+      $ruleGroups['id'],
+      $groupID,
+      TRUE,
+      25,
+      FALSE
+    );
+
+    $this->assertEquals(array(
+      0 => array(
+        'srcID' => $this->contacts[5]['id'],
+        'srcName' => 'Walt Disney Ltd',
+        'dstID' => $this->contacts[4]['id'],
+        'dstName' => 'Walt Disney Ltd',
+        'weight' => 20,
+        'canMerge' => TRUE,
+      ),
+      1 => array(
+        'srcID' => $this->contacts[6]['id'],
+        'srcName' => 'Walt Disney',
+        'dstID' => $this->contacts[4]['id'],
+        'dstName' => 'Walt Disney Ltd',
+        'weight' => 10,
+        'canMerge' => TRUE,
+      ),
+      2 => array(
+        'srcID' => $this->contacts[6]['id'],
+        'srcName' => 'Walt Disney',
+        'dstID' => $this->contacts[5]['id'],
+        'dstName' => 'Walt Disney Ltd',
+        'weight' => 10,
+        'canMerge' => TRUE,
+      ),
+    ), $pairs);
   }
 
   /**


### PR DESCRIPTION
This has already been done in Individual Supervised but this covers a non-special rule

---
- [CRM-19069: (unncessary) Slow query for dedupes - #2](https://issues.civicrm.org/jira/browse/CRM-19069)
