### PR TITLE
CRM-19080 - fix enotice in advance search

### DIFF
--- a/CRM/Contact/Form/Search/Advanced.php
+++ b/CRM/Contact/Form/Search/Advanced.php
@@ -394,15 +394,17 @@ class CRM_Contact_Form_Search_Advanced extends CRM_Contact_Form_Search {
      */
     if (isset($defaults['contact_tags'])) {
       foreach ($defaults['contact_tags'] as $key => $tagId) {
-        $parentId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Tag', $tagId, 'parent_id');
-        $element = "contact_taglist[$parentId]";
-        if ($this->elementExists($element)) {
-          // This tag is a tagset
-          unset($defaults['contact_tags'][$key]);
-          if (!isset($defaults[$element])) {
-            $defaults[$element] = array();
+        if (!is_array($tagId)) {
+          $parentId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Tag', $tagId, 'parent_id');
+          $element = "contact_taglist[$parentId]";
+          if ($this->elementExists($element)) {
+            // This tag is a tagset
+            unset($defaults['contact_tags'][$key]);
+            if (!isset($defaults[$element])) {
+              $defaults[$element] = array();
+            }
+            $defaults[$element][] = $tagId;
           }
-          $defaults[$element][] = $tagId;
         }
       }
       if (empty($defaults['contact_tags'])) {


### PR DESCRIPTION
- [CRM-19080: New enotice (in 4.7.10 - possibly introduced in 4.7.9 CRM-18656](https://issues.civicrm.org/jira/browse/CRM-19080)

---
- [CRM-18656: Advanced search fails to show tagset criteria when editing saved search](https://issues.civicrm.org/jira/browse/CRM-18656)
