### PR TITLE
CRM-19088 : Always build contact subtype field

### DIFF
--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -312,13 +312,6 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
     $this->assign('contactType', $this->_contactType);
     $this->assign('contactSubType', $this->_contactSubType);
 
-    //build contact subtype form element, CRM-6864
-    $buildContactSubType = TRUE;
-    if ($this->_contactSubType && ($this->_action & CRM_Core_Action::ADD)) {
-      $buildContactSubType = FALSE;
-    }
-    $this->assign('buildContactSubType', $buildContactSubType);
-
     // get the location blocks.
     $this->_blocks = $this->get('blocks');
     if (CRM_Utils_System::isNull($this->_blocks)) {

--- a/templates/CRM/Contact/Form/Edit/Individual.tpl
+++ b/templates/CRM/Contact/Form/Edit/Individual.tpl
@@ -124,10 +124,8 @@ CRM.$(function($) {
       {$form.nick_name.html}
     </td>
     <td>
-      {if $buildContactSubType}
       {$form.contact_sub_type.label}<br />
       {$form.contact_sub_type.html}
-      {/if}
     </td>
   </tr>
 </table>


### PR DESCRIPTION
If a contact subtype can be of more contact subtypes then make sense to always show contact subtype on the form contact.

See a related [discussion](http://civicrm.stackexchange.com/questions/12780/how-can-i-create-a-contact-quickly-with-multiple-contact-subtypes)

---
- [CRM-19088: Show contact subtype field when create contact subtype](https://issues.civicrm.org/jira/browse/CRM-19088)
