### PR TITLE
CRM-19053 - Fix Source Message for Pending Contribution

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4807,7 +4807,10 @@ LIMIT 1;";
     elseif ($event) {
       return ts('Online Event Registration') . ': ' . $event->title;
     }
-    return 'recurring contribution';
+    elseif (!empty($contribution->contribution_recur_id)) {
+      return 'recurring contribution';
+    }
+    return '';
   }
 
   /**

--- a/CRM/Contribute/Form/Task/Status.php
+++ b/CRM/Contribute/Form/Task/Status.php
@@ -83,6 +83,13 @@ AND    {$this->_componentClause}";
   }
 
   /**
+   * Sets contribution Ids for unit test.
+   */
+  public function setContributionIds($contributionIds) {
+    $this->_contributionIds = $contributionIds;
+  }
+
+  /**
    * Build the form object.
    */
   public function buildQuickForm() {
@@ -209,19 +216,30 @@ AND    co.id IN ( $contribIDs )";
    */
   public function postProcess() {
     $params = $this->controller->exportValues($this->_name);
-    $statusID = CRM_Utils_Array::value('contribution_status_id', $params);
 
+    // submit the form with values.
+    self::processForm($this, $params);
+
+    CRM_Core_Session::setStatus(ts('Contribution status has been updated for selected record(s).'), ts('Status Updated'), 'success');
+  }
+
+  /**
+   * Process the form with submitted params.
+   * Also supports unit test.
+   */
+  public static function processForm($form, $params) {
+    $statusID = CRM_Utils_Array::value('contribution_status_id', $params);
     $baseIPN = new CRM_Core_Payment_BaseIPN();
 
     $transaction = new CRM_Core_Transaction();
 
     // get the missing pieces for each contribution
-    $contribIDs = implode(',', $this->_contributionIds);
+    $contribIDs = implode(',', $form->_contributionIds);
     $details = self::getDetails($contribIDs);
     $template = CRM_Core_Smarty::singleton();
 
     // for each contribution id, we just call the baseIPN stuff
-    foreach ($this->_rows as $row) {
+    foreach ($form->_rows as $row) {
       $input = $ids = $objects = array();
       $input['component'] = $details[$row['contribution_id']]['component'];
 
@@ -285,8 +303,6 @@ AND    co.id IN ( $contribIDs )";
       // reset template values before processing next transactions
       $template->clearTemplateVars();
     }
-
-    CRM_Core_Session::setStatus(ts('Contribution status has been updated for selected record(s).'), ts('Status Updated'), 'success');
   }
 
   /**

--- a/CRM/Contribute/Form/Task/Status.php
+++ b/CRM/Contribute/Form/Task/Status.php
@@ -277,7 +277,7 @@ AND    co.id IN ( $contribIDs )";
       else {
         $input['trxn_id'] = $contribution->invoice_id;
       }
-      $input['trxn_date'] = CRM_Utils_Date::processDate($params["trxn_date_{$row['contribution_id']}"]);
+      $input['trxn_date'] = CRM_Utils_Date::processDate($params["trxn_date_{$row['contribution_id']}"], date('H:i:s'));
 
       // @todo calling baseIPN like this is a pattern in it's last gasps. Call contribute.completetransaction api.
       $baseIPN->completeTransaction($input, $ids, $objects, $transaction, FALSE);

--- a/tests/phpunit/CRM/Contribute/Form/Task/StatusTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Task/StatusTest.php
@@ -1,0 +1,85 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2016                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Class CRM_Contribute_Form_Task_StatusTest
+ */
+class CRM_Contribute_Form_Task_StatusTest extends CiviUnitTestCase {
+  /**
+   * Assume empty database with just civicrm_data.
+   */
+  protected $_individualId;
+
+  /**
+   * Clean up after each test.
+   */
+  public function tearDown() {
+    $this->quickCleanUpFinancialEntities();
+    CRM_Utils_Hook::singleton()->reset();
+  }
+
+  /**
+   * Test update pending contribution
+   */
+  public function testUpdatePendingContribution() {
+    $this->_individualId = $this->individualCreate();
+    $form = new CRM_Contribute_Form_Task_Status();
+
+    // create a pending contribution
+    $contributionParams = array(
+      'contact_id' => $this->_individualId,
+      'total_amount' => 100,
+      'financial_type_id' => 'Donation',
+      'contribution_status_id' => 2,
+    );
+    $contribution = $this->callAPISuccess('Contribution', 'create', $contributionParams);
+    $contributionId = $contribution['id'];
+    $form->setContributionIds(array($contributionId));
+
+    $form->buildQuickForm();
+
+    $params = array(
+      "contribution_status_id" => 1,
+      "trxn_id_{$contributionId}" => NULL,
+      "check_number_{$contributionId}" => NULL,
+      "fee_amount_{$contributionId}" => 0,
+      "trxn_date_{$contributionId}" => date('m/d/Y'),
+      "payment_instrument_id_{$contributionId}" => 4,
+    );
+
+    CRM_Contribute_Form_Task_Status::processForm($form, $params);
+
+    $contribution = $this->callAPISuccess('Contribution', 'get', array('id' => $contributionId));
+    $updatedContribution = $contribution['values'][1];
+
+    $this->assertEquals('', $updatedContribution['contribution_source']);
+    $this->assertEquals(date("Y-m-d"), date("Y-m-d", strtotime($updatedContribution['receive_date'])));
+    $this->assertNotEquals("00:00:00", date("H:i:s", strtotime($updatedContribution['receive_date'])));
+    $this->assertEquals('Completed', $updatedContribution['contribution_status']);
+  }
+
+}

--- a/tests/phpunit/CRM/Custom/Page/AjaxTest.php
+++ b/tests/phpunit/CRM/Custom/Page/AjaxTest.php
@@ -1,4 +1,29 @@
 <?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2016                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
 
 /**
  * Class CRM_Custom_Page_AJAXTest


### PR DESCRIPTION
- [CRM-19053: Update Pending Contribution Status Action Injects "recurring contribution" in Source Field if Blank and Time Stamp set to 00:00](https://issues.civicrm.org/jira/browse/CRM-19053)

will be adding unit test to check the same.
