### PR TITLE
CRM-19079 condition profile edit permission check

### DIFF
--- a/CRM/Profile/Form/Edit.php
+++ b/CRM/Profile/Form/Edit.php
@@ -98,8 +98,9 @@ class CRM_Profile_Form_Edit extends CRM_Profile_Form {
 
         if ($id != $userID) {
           // do not allow edit for anon users in joomla frontend, CRM-4668, unless u have checksum CRM-5228
+          // see also CRM-19079 for modifications to the condition
           $config = CRM_Core_Config::singleton();
-          if ($config->userFrameworkFrontend) {
+          if ($config->userFrameworkFrontend && $config->userSystem->is_joomla) {
             CRM_Contact_BAO_Contact_Permission::validateOnlyChecksum($id, $this);
           }
           else {


### PR DESCRIPTION
- [CRM-19079: profile edit permission checks bypass standard route in WP](https://issues.civicrm.org/jira/browse/CRM-19079)
