### PR TITLE
CRM-19085 - Fix "Add to Group" in Reports

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -4602,6 +4602,7 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
    *   is that we might print a bar chart as a pdf.
    */
   protected function setOutputMode() {
+    $buttonName = $this->controller->getButtonName();
     $this->_outputMode = str_replace('report_instance.', '', CRM_Utils_Request::retrieve(
       'output',
       'String',
@@ -4611,6 +4612,9 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
     ));
     if (isset($this->_params['task'])) {
       unset($this->_params['task']);
+    }
+    if ($this->_groupButtonName == $buttonName) {
+      $this->_outputMode = 'group';
     }
   }
 

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -2517,7 +2517,6 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
   public function processReportMode() {
     $this->setOutputMode();
 
-    $buttonName = $this->controller->getButtonName();
     $this->_sendmail
       = CRM_Utils_Request::retrieve(
         'sendmail',
@@ -4602,7 +4601,6 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
    *   is that we might print a bar chart as a pdf.
    */
   protected function setOutputMode() {
-    $buttonName = $this->controller->getButtonName();
     $this->_outputMode = str_replace('report_instance.', '', CRM_Utils_Request::retrieve(
       'output',
       'String',
@@ -4610,11 +4608,12 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
       FALSE,
       CRM_Utils_Array::value('task', $this->_params)
     ));
+    // if contacts are added to group
+    if (!empty($this->_params['groups']) && empty($this->_outputMode)) {
+      $this->_outputMode = 'group';
+    }
     if (isset($this->_params['task'])) {
       unset($this->_params['task']);
-    }
-    if ($this->_groupButtonName == $buttonName) {
-      $this->_outputMode = 'group';
     }
   }
 

--- a/tests/phpunit/CRM/Report/Form/TestCaseTest.php
+++ b/tests/phpunit/CRM/Report/Form/TestCaseTest.php
@@ -180,4 +180,29 @@ class CRM_Report_Form_TestCaseTest extends CiviReportTestCase {
     $this->assertCsvArraysEqual($expectedOutputCsvArray, $reportCsvArray);
   }
 
+  /**
+   * Test processReportMode() Function in Reports
+   */
+  public function testOutputMode() {
+    $clazz = new ReflectionClass('CRM_Report_Form');
+    $reportForm = new CRM_Report_Form();
+
+    $params = $clazz->getProperty('_params');
+    $params->setAccessible(TRUE);
+    $outputMode = $clazz->getProperty('_outputMode');
+    $outputMode->setAccessible(TRUE);
+
+    $params->setValue($reportForm, array('groups' => 4));
+    $reportForm->processReportMode();
+    $this->assertEquals('group', $outputMode->getValue($reportForm));
+
+    $params->setValue($reportForm, array('task' => 'copy'));
+    $reportForm->processReportMode();
+    $this->assertEquals('copy', $outputMode->getValue($reportForm));
+
+    $params->setValue($reportForm, array('task' => 'print'));
+    $reportForm->processReportMode();
+    $this->assertEquals('print', $outputMode->getValue($reportForm));
+  }
+
 }


### PR DESCRIPTION
- [CRM-19085: CiviReport "Add to Group" not working in 4.7.10 - introduced in 4.7.9](https://issues.civicrm.org/jira/browse/CRM-19085)
