### PR TITLE
CRM-18513 - WordReplacements - Load en_US when locale is unspecified

### DIFF
--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -348,15 +348,17 @@ class CRM_Core_I18n {
 
     // do all wildcard translations first
 
-    if (!isset(Civi::$statics[__CLASS__]) || !array_key_exists($this->locale, Civi::$statics[__CLASS__])) {
+    // FIXME: Is there a constant we can reference instead of hardcoding en_US?
+    $replacementsLocale = $this->locale ? $this->locale : 'en_US';
+    if (!isset(Civi::$statics[__CLASS__]) || !array_key_exists($replacementsLocale, Civi::$statics[__CLASS__])) {
       if (defined('CIVICRM_DSN') && !CRM_Core_Config::isUpgradeMode()) {
-        Civi::$statics[__CLASS__][$this->locale] = CRM_Core_BAO_WordReplacement::getLocaleCustomStrings($this->locale);
+        Civi::$statics[__CLASS__][$replacementsLocale] = CRM_Core_BAO_WordReplacement::getLocaleCustomStrings($replacementsLocale);
       }
       else {
-        Civi::$statics[__CLASS__][$this->locale] = array();
+        Civi::$statics[__CLASS__][$replacementsLocale] = array();
       }
     }
-    $stringTable = Civi::$statics[__CLASS__][$this->locale];
+    $stringTable = Civi::$statics[__CLASS__][$replacementsLocale];
 
     $exactMatch = FALSE;
     if (isset($stringTable['enabled']['exactMatch'])) {


### PR DESCRIPTION
On a new installation, the value in `CRM_Core_I18n::$locale` is empty.  The
word-replacement index stored in `civicrm_domain.locale_custom_strings` is
indexed by locale (e.g.  `array('en_US' => ...replacements...)`).  Thus, it
fails to locate the word-replacements (even if there are
word-replacements in the _effective_ locale, `en_US`).

With this patch, the word-replacements explicitly fallback to checking `en_US`.

Note: In my light testing, this patch seems to work, even (somehow,
magically) in multi-lingual (wherein the relationship between
`civicrm_word_replacements` and `civicrm_domain.locale_custom_strings`
boggles my mind).

---
- [CRM-18513: Word Replacement not working in 4.7](https://issues.civicrm.org/jira/browse/CRM-18513)
