### PR TITLE
CRM-18591: group_type parameter ignored when using API to create group

### DIFF
--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -368,6 +368,9 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
             $params['group_type']
           ) . CRM_Core_DAO::VALUE_SEPARATOR;
       }
+      else {
+        $params['group_type'] = CRM_Core_DAO::VALUE_SEPARATOR . $params['group_type'] . CRM_Core_DAO::VALUE_SEPARATOR;
+      }
     }
     else {
       $params['group_type'] = NULL;

--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -365,7 +365,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
     if (isset($params['group_type'])) {
       if (is_array($params['group_type'])) {
         $params['group_type'] = CRM_Core_DAO::VALUE_SEPARATOR . implode(CRM_Core_DAO::VALUE_SEPARATOR,
-            array_keys($params['group_type'])
+            $params['group_type']
           ) . CRM_Core_DAO::VALUE_SEPARATOR;
       }
     }

--- a/CRM/Group/Form/Edit.php
+++ b/CRM/Group/Form/Edit.php
@@ -384,7 +384,17 @@ WHERE  title = %1
       }
 
       $params['is_reserved'] = CRM_Utils_Array::value('is_reserved', $params, FALSE);
-      $params['group_type'] = CRM_Utils_Array::value('group_type', $params, array());
+
+      $groupTypeIds = array();
+      $groupType = CRM_Utils_Array::value('group_type', $params);
+      if (is_array($groupType)) {
+        foreach ($groupType as $type => $selected) {
+          if ($selected) {
+            $groupTypeIds[] = $type;
+          }
+        }
+      }
+      $params['group_type'] = $groupTypeIds;
 
       $customFields = CRM_Core_BAO_CustomField::getFields('Group');
       $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params,

--- a/tests/phpunit/api/v3/GroupTest.php
+++ b/tests/phpunit/api/v3/GroupTest.php
@@ -127,6 +127,33 @@ class api_v3_GroupTest extends CiviUnitTestCase {
     }
   }
 
+  /**
+   * Test Group create with Group Type
+   */
+  public function testgroupCreateWithGroupType() {
+    $params = array(
+      'name' => 'Test Group type',
+      'title' => 'Test Group Type',
+      'description' => 'Test Group with Group Type',
+      'is_active' => 1,
+      'visibility' => 'Public Pages',
+      'group_type' => array(1, 2),
+    );
+
+    $result = $this->callAPISuccess('Group', 'create', $params);
+    $group = $result['values'][$result['id']];
+    $this->assertEquals($group['name'], "Test Group type");
+    $this->assertEquals($group['is_active'], 1);
+    $this->assertEquals($group['group_type'], $params['group_type']);
+    $this->groupDelete($result['id']);
+
+    //assert single value for group_type
+    $params['group_type'] = 2;
+    $result = $this->callAPISuccess('Group', 'create', $params);
+    $group = $result["values"][$result['id']];
+    $this->assertEquals($group['group_type'], array($params['group_type']));
+  }
+
   public function testGetNonExistingGroup() {
     $params = array();
     $params['title'] = 'No such group Exist';

--- a/xml/schema/Contact/Group.xml
+++ b/xml/schema/Contact/Group.xml
@@ -119,6 +119,9 @@
     <title>Group Type</title>
     <length>128</length>
     <comment>FK to group type</comment>
+    <pseudoconstant>
+      <optionGroupName>group_type</optionGroupName>
+    </pseudoconstant>
     <add>1.9</add>
   </field>
   <field>


### PR DESCRIPTION
---
- CRM-18591: group_type parameter ignored when using API to create group
  https://issues.civicrm.org/jira/browse/CRM-18591
