### PR TITLE
CRM-19111 - Email-to-Activity - 4.6 fix for blank body mail

### DIFF
--- a/CRM/Utils/Mail/Incoming.php
+++ b/CRM/Utils/Mail/Incoming.php
@@ -69,7 +69,7 @@ class CRM_Utils_Mail_Incoming {
       return self::formatMail($part, $attachments);
     }
 
-    if ($part instanceof ezcMailText || !$part) {
+    if ($part instanceof ezcMailText) {
       return self::formatMailText($part, $attachments);
     }
 
@@ -83,6 +83,11 @@ class CRM_Utils_Mail_Incoming {
 
     if ($part instanceof ezcMailMultiPart) {
       return self::formatMailMultipart($part, $attachments);
+    }
+
+    // CRM-19111 - Handle blank emails with a subject.
+    if (!$part) {
+      return NULL;
     }
 
     CRM_Core_Error::fatal(ts("No clue about the %1", array(1 => get_class($part))));

--- a/CRM/Utils/Mail/Incoming.php
+++ b/CRM/Utils/Mail/Incoming.php
@@ -69,7 +69,7 @@ class CRM_Utils_Mail_Incoming {
       return self::formatMail($part, $attachments);
     }
 
-    if ($part instanceof ezcMailText) {
+    if ($part instanceof ezcMailText || !$part) {
       return self::formatMailText($part, $attachments);
     }
 


### PR DESCRIPTION
- [CRM-19111: Inbound email-to-activity chokes on empty email](https://issues.civicrm.org/jira/browse/CRM-19111)
