### PR TITLE
CRM-19118 Fix syntax conformace test hidden by cache files

### DIFF
--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -712,6 +712,7 @@ AND  civicrm_group_contact.group_id = $groupID ";
 
       $childrenIDs = explode(',', $group->children);
       foreach ($childrenIDs as $childID) {
+        $childID = str_replace('children_', '', $childID);
         $contactIDs = CRM_Contact_BAO_Group::getMember($childID, FALSE);
         //Unset each contact that is removed from the parent group
         foreach ($removed_contacts as $removed_contact) {


### PR DESCRIPTION
- [CRM-19118: Cache files hiding issue with Syntax Conformance test, Group adding children_ before id of children groups](https://issues.civicrm.org/jira/browse/CRM-19118)
