### PR TITLE
CRM-19120: Fix display of chain-select fields in event cart.

### DIFF
--- a/CRM/Event/Cart/Page/CheckoutAJAX.php
+++ b/CRM/Event/Cart/Page/CheckoutAJAX.php
@@ -35,9 +35,8 @@ class CRM_Event_Cart_Page_CheckoutAJAX {
     $requiredTemplate = file_get_contents($templateDir . '/CRM/Form/label.tpl');
     $renderer->setRequiredTemplate($requiredTemplate);
 
-    $form->accept($renderer);
     $template = CRM_Core_Smarty::singleton();
-    $template->assign('form', $renderer->toArray());
+    $template->assign('form', $form->toSmarty());
     $template->assign('participant', $participant);
     $output = $template->fetch("CRM/Event/Cart/Form/Checkout/Participant.tpl");
     $transaction->commit();


### PR DESCRIPTION
This is a small patch, but there are no tests yet for the whole file. Tests would require knowing an existing cart_id and event_id, but that seems like a lot to know.  What kind of tests should I be adding with this PR?

---
- [CRM-19120: country\/state chain-select behavior is broken in Event Cart Checkout "add another participant"](https://issues.civicrm.org/jira/browse/CRM-19120)
