### PR TITLE
CRM-19068 clean up Group Nesting class.

### DIFF
--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -107,11 +107,6 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
     $query = "DELETE FROM civicrm_acl_entity_role where entity_table = 'civicrm_group' AND entity_id = %1";
     CRM_Core_DAO::executeQuery($query, $params);
 
-    if (Civi::settings()->get('is_enabled')) {
-      // clear any descendant groups cache if exists
-      CRM_Core_BAO_Cache::deleteGroup('descendant groups for an org');
-    }
-
     // delete from group table
     $group = new CRM_Contact_DAO_Group();
     $group->id = $id;
@@ -447,9 +442,6 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
           }
         }
       }
-
-      // clear any descendant groups cache if exists
-      $finalGroups = CRM_Core_BAO_Cache::deleteGroup('descendant groups for an org');
 
       // this is always required, since we don't know when a
       // parent group is removed

--- a/CRM/Contact/BAO/GroupNesting.php
+++ b/CRM/Contact/BAO/GroupNesting.php
@@ -285,44 +285,6 @@ class CRM_Contact_BAO_GroupNesting extends CRM_Contact_DAO_GroupNesting {
   }
 
   /**
-   * Returns array of group ids of ancestor groups of the specified group.
-   *
-   * @param array $groupIds
-   *   An array of valid group ids (passed by reference).
-   *
-   * @param bool $includeSelf
-   *
-   * @return array
-   *   List of groupIds that represent the requested group and its ancestors
-   */
-  protected static function getAncestorGroupIds($groupIds, $includeSelf = TRUE) {
-    if (!is_array($groupIds)) {
-      $groupIds = array($groupIds);
-    }
-    $dao = new CRM_Contact_DAO_GroupNesting();
-    $query = "SELECT parent_group_id, child_group_id
-                  FROM   civicrm_group_nesting
-                  WHERE  child_group_id IN (" . implode(',', $groupIds) . ")";
-    $dao->query($query);
-    $tmpGroupIds = array();
-    $parentGroupIds = array();
-    if ($includeSelf) {
-      $parentGroupIds = $groupIds;
-    }
-    while ($dao->fetch()) {
-      // make sure we're not following any cyclical references
-      if (!array_key_exists($dao->child_group_id, $parentGroupIds) && $dao->parent_group_id != $groupIds[0]) {
-        $tmpGroupIds[] = $dao->parent_group_id;
-      }
-    }
-    if (!empty($tmpGroupIds)) {
-      $newParentGroupIds = self::getAncestorGroupIds($tmpGroupIds);
-      $parentGroupIds = array_merge($parentGroupIds, $newParentGroupIds);
-    }
-    return $parentGroupIds;
-  }
-
-  /**
    * Returns array of group ids of child groups of the specified group.
    *
    * @param array $groupIds

--- a/CRM/Contact/BAO/GroupNesting.php
+++ b/CRM/Contact/BAO/GroupNesting.php
@@ -31,7 +31,7 @@
  * @package CRM
  * @copyright U.S. PIRG 2007
  */
-class CRM_Contact_BAO_GroupNesting extends CRM_Contact_DAO_GroupNesting implements Iterator {
+class CRM_Contact_BAO_GroupNesting extends CRM_Contact_DAO_GroupNesting {
 
   static $_sortOrder = 'ASC';
 
@@ -41,295 +41,66 @@ class CRM_Contact_BAO_GroupNesting extends CRM_Contact_DAO_GroupNesting implemen
 
   private $_lastParentlessGroup;
 
-  private $_styleLabels;
-
   private $_styleIndent;
 
   private $_alreadyStyled = FALSE;
 
   /**
-   * Class constructor.
+   * Get the number of levels of nesting.
    *
-   * @param bool $styleLabels
-   * @param string $styleIndent
-   */
-  public function __construct($styleLabels = FALSE, $styleIndent = "&nbsp;--&nbsp;") {
-    parent::__construct();
-    $this->_styleLabels = $styleLabels;
-    $this->_styleIndent = $styleIndent;
-  }
-
-  /**
-   * @param $sortOrder
-   */
-  public function setSortOrder($sortOrder) {
-    switch ($sortOrder) {
-      case 'ASC':
-      case 'DESC':
-        if ($sortOrder != self::$_sortOrder) {
-          self::$_sortOrder = $sortOrder;
-          $this->rewind();
-        }
-        break;
-
-      default:
-        // spit out some error, someday
-    }
-  }
-
-  /**
-   * @return string
-   */
-  public function getSortOrder() {
-    return self::$_sortOrder;
-  }
-
-  /**
    * @return int
    */
-  public function getCurrentNestingLevel() {
+  protected function getCurrentNestingLevel() {
     return count($this->_parentStack);
   }
 
   /**
-   * Go back to the first element in the group nesting graph,
-   * which is the first group (according to _sortOrder) that
-   * has no parent groups
-   */
-  public function rewind() {
-    $this->_parentStack = array();
-    // calling _getNextParentlessGroup w/ no arguments
-    // makes it return the first parentless group
-    $firstGroup = $this->_getNextParentlessGroup();
-    $this->_current = $firstGroup;
-    $this->_lastParentlessGroup = $firstGroup;
-    $this->_alreadyStyled = FALSE;
-  }
-
-  /**
-   * @return mixed
-   */
-  public function current() {
-    if ($this->_styleLabels &&
-      $this->valid() &&
-      !$this->_alreadyStyled
-    ) {
-      $styledGroup = clone($this->_current);
-      $nestingLevel = $this->getCurrentNestingLevel();
-      $indent = '';
-      while ($nestingLevel--) {
-        $indent .= $this->_styleIndent;
-      }
-      $styledGroup->title = $indent . $styledGroup->title;
-
-      $this->_current = &$styledGroup;
-      $this->_alreadyStyled = TRUE;
-    }
-    return $this->_current;
-  }
-
-  /**
-   * @return string
-   */
-  public function key() {
-    $group = &$this->_current;
-    $ids = array();
-    foreach ($this->_parentStack as $parentGroup) {
-      $ids[] = $parentGroup->id;
-    }
-    $key = implode('-', $ids);
-    if (strlen($key) > 0) {
-      $key .= '-';
-    }
-    $key .= $group->id;
-    return $key;
-  }
-
-  /**
-   * @return CRM_Contact_BAO_Group|null
-   */
-  public function next() {
-    $currentGroup = &$this->_current;
-    $childGroup = $this->_getNextChildGroup($currentGroup);
-    if ($childGroup) {
-      $nextGroup = &$childGroup;
-      $this->_parentStack[] = &$this->_current;
-    }
-    else {
-      $nextGroup = $this->_getNextSiblingGroup($currentGroup);
-      if (!$nextGroup) {
-        // no sibling, find an ancestor w/ a sibling
-        for (;;) {
-          // since we pop this array every time, we should be
-          // reasonably safe from infinite loops, I think :)
-          $ancestor = array_pop($this->_parentStack);
-          $this->_current = &$ancestor;
-          if ($ancestor == NULL) {
-            break;
-          }
-          $nextGroup = $this->_getNextSiblingGroup($ancestor);
-          if ($nextGroup) {
-            break;
-          }
-        }
-      }
-    }
-    $this->_current = &$nextGroup;
-    $this->_alreadyStyled = FALSE;
-    return $nextGroup;
-  }
-
-  /**
-   * @return bool
-   */
-  public function valid() {
-    if ($this->_current) {
-      return TRUE;
-    }
-    else {
-      return FALSE;
-    }
-  }
-
-  /**
-   * @param null $group
-   *
-   * @return CRM_Contact_BAO_Group|null
-   */
-  public function _getNextParentlessGroup(&$group = NULL) {
-    $lastParentlessGroup = $this->_lastParentlessGroup;
-    $nextGroup = new CRM_Contact_BAO_Group();
-    $nextGroup->order_by = 'title ' . self::$_sortOrder;
-    $nextGroup->find();
-    if ($group == NULL) {
-      $sawLast = TRUE;
-    }
-    else {
-      $sawLast = FALSE;
-    }
-    while ($nextGroup->fetch()) {
-      if (!self::hasParentGroups($nextGroup->id) && $sawLast) {
-        return $nextGroup;
-      }
-      elseif ($lastParentlessGroup->id == $nextGroup->id) {
-        $sawLast = TRUE;
-      }
-    }
-    return NULL;
-  }
-
-  /**
-   * @param $parentGroup
-   * @param null $group
-   *
-   * @return CRM_Contact_BAO_Group|null
-   */
-  public function _getNextChildGroup(&$parentGroup, &$group = NULL) {
-    $children = self::getChildGroupIds($parentGroup->id);
-    if (count($children) > 0) {
-      // we have child groups, so get the first one based on _sortOrder
-      $childGroup = new CRM_Contact_BAO_Group();
-      $cgQuery = "SELECT * FROM civicrm_group WHERE id IN (" . implode(',', $children) . ") ORDER BY title " . self::$_sortOrder;
-      $childGroup->query($cgQuery);
-      $currentGroup = &$this->_current;
-      if ($group == NULL) {
-        $sawLast = TRUE;
-      }
-      else {
-        $sawLast = FALSE;
-      }
-      while ($childGroup->fetch()) {
-        if ($sawLast) {
-          return $childGroup;
-        }
-        elseif ($currentGroup->id === $childGroup->id) {
-          $sawLast = TRUE;
-        }
-      }
-    }
-    return NULL;
-  }
-
-  /**
-   * @param $group
-   *
-   * @return CRM_Contact_BAO_Group|null
-   */
-  public function _getNextSiblingGroup(&$group) {
-    $parentGroup = end($this->_parentStack);
-    if ($parentGroup) {
-      $nextGroup = $this->_getNextChildGroup($parentGroup, $group);
-      return $nextGroup;
-    }
-    else {
-      /* if we get here, it could be because we're out of siblings
-       * (in which case we return null) or because we're at the
-       * top level groups which do not have parents but may still
-       * have siblings, so check for that first.
-       */
-
-      $nextGroup = $this->_getNextParentlessGroup($group);
-      if ($nextGroup) {
-        $this->_lastParentlessGroup = $nextGroup;
-        return $nextGroup;
-      }
-      return NULL;
-    }
-  }
-
-  /**
-   * Adds a new child group identified by $childGroupId to the group
-   * identified by $groupId
+   * Adds a new group nesting record.
    *
    * @param int $parentID
    *   Id of the group to add the child to.
    * @param int $childID
    *   Id of the new child group.
+   *
+   * @return \CRM_Contact_DAO_GroupNesting
    */
   public static function add($parentID, $childID) {
-    // TODO: Add checks here to make sure invalid nests can't be created
     $dao = new CRM_Contact_DAO_GroupNesting();
-    $query = "REPLACE INTO civicrm_group_nesting (child_group_id, parent_group_id) VALUES ($childID,$parentID);";
-    $dao->query($query);
+    $dao->child_group_id = $childID;
+    $dao->parent_group_id = $parentID;
+    if (!$dao->find(TRUE)) {
+      $dao->save();
+    }
+    return $dao;
   }
 
   /**
-   * Removes a child group identified by $childGroupId from the group
-   * identified by $groupId; does not delete child group, just the
-   * association between the two
+   * Removes a child group from it's parent.
    *
-   * @param $parentID
+   * Does not delete child group, just the association between the two
+   *
+   * @param int $parentID
    *   The id of the group to remove the child from.
-   * @param $childID
+   * @param int $childID
    *   The id of the child group being removed.
    */
   public static function remove($parentID, $childID) {
     $dao = new CRM_Contact_DAO_GroupNesting();
-    $query = "DELETE FROM civicrm_group_nesting WHERE child_group_id = $childID AND parent_group_id = $parentID";
-    $dao->query($query);
-  }
-
-  /**
-   * Removes associations where a child group is identified by $childGroupId from the group
-   * identified by $groupId; does not delete child group, just the
-   * association between the two
-   *
-   * @param int $childID
-   *   The id of the child group being removed.
-   */
-  public static function removeAllParentForChild($childID) {
-    $dao = new CRM_Contact_DAO_GroupNesting();
-    $query = "DELETE FROM civicrm_group_nesting WHERE child_group_id = $childID";
-    $dao->query($query);
+    $dao->child_group_id = $childID;
+    $dao->parent_group_id = $parentID;
+    if (!$dao->find(TRUE)) {
+      $dao->delete();
+    }
   }
 
   /**
    * Returns true if the association between parent and child is present,
    * false otherwise.
    *
-   * @param $parentID
+   * @param int $parentID
    *   The parent id of the association.
-   * @param $childID
+   *
+   * @param int $childID
    *   The child id of the association.
    *
    * @return bool
@@ -337,31 +108,10 @@ class CRM_Contact_BAO_GroupNesting extends CRM_Contact_DAO_GroupNesting implemen
    */
   public static function isParentChild($parentID, $childID) {
     $dao = new CRM_Contact_DAO_GroupNesting();
-    $query = "SELECT id FROM civicrm_group_nesting WHERE child_group_id = $childID AND parent_group_id = $parentID";
-    $dao->query($query);
-    if ($dao->fetch()) {
-      return TRUE;
-    }
-    return FALSE;
-  }
-
-  /**
-   * Returns true if if the given groupId has 1 or more child groups,
-   * false otherwise.
-   *
-   * @param $groupId
-   *   The id of the group to check for child groups.
-   *
-   * @return bool
-   *   True if 1 or more child groups are found, false otherwise.
-   */
-  public static function hasChildGroups($groupId) {
-    $dao = new CRM_Contact_DAO_GroupNesting();
-    $query = "SELECT child_group_id FROM civicrm_group_nesting WHERE parent_group_id = $groupId LIMIT 1";
-    //print $query . "\n<br><br>";
-    $dao->query($query);
-    if ($dao->fetch()) {
-      return TRUE;
+    $dao->child_group_id = $childID;
+    $dao->parent_group_id = $parentID;
+    if (!$dao->find(TRUE)) {
+      return $dao;
     }
     return FALSE;
   }
@@ -545,7 +295,7 @@ class CRM_Contact_BAO_GroupNesting extends CRM_Contact_DAO_GroupNesting implemen
    * @return array
    *   List of groupIds that represent the requested group and its ancestors
    */
-  public static function getAncestorGroupIds($groupIds, $includeSelf = TRUE) {
+  protected static function getAncestorGroupIds($groupIds, $includeSelf = TRUE) {
     if (!is_array($groupIds)) {
       $groupIds = array($groupIds);
     }
@@ -570,22 +320,6 @@ class CRM_Contact_BAO_GroupNesting extends CRM_Contact_DAO_GroupNesting implemen
       $parentGroupIds = array_merge($parentGroupIds, $newParentGroupIds);
     }
     return $parentGroupIds;
-  }
-
-  /**
-   * Returns array of ancestor groups of the specified group.
-   *
-   * @param array $groupIds
-   *   An array of valid group ids (passed by reference).
-   *
-   * @param bool $includeSelf
-   * @return array
-   *   List of ancestor groups
-   */
-  public static function getAncestorGroups($groupIds, $includeSelf = TRUE) {
-    $groupIds = self::getAncestorGroupIds($groupIds, $includeSelf);
-    $params['id'] = $groupIds;
-    return CRM_Contact_BAO_Group::getGroups($params);
   }
 
   /**
@@ -708,27 +442,6 @@ class CRM_Contact_BAO_GroupNesting extends CRM_Contact_DAO_GroupNesting implemen
       }
     }
     return $potentialChildGroupIds;
-  }
-
-  /**
-   * @param int $contactId
-   * @param int $parentGroupId
-   *
-   * @return array
-   */
-  public static function getContainingGroups($contactId, $parentGroupId) {
-    $groups = CRM_Contact_BAO_Group::getGroups();
-    $containingGroups = array();
-    foreach ($groups as $group) {
-      if (self::isDescendentGroup($parentGroupId, $group->id)) {
-        $members = CRM_Contact_BAO_Group::getMember($group->id);
-        if ($members[$contactId]) {
-          $containingGroups[] = $group->title;
-        }
-      }
-    }
-
-    return $containingGroups;
   }
 
 }

--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -87,7 +87,6 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
    */
   public $_group;
   public $_groupElement;
-  public $_groupIterator;
 
   /**
    * The tag elements.
@@ -500,7 +499,6 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
 
     $this->_group = CRM_Core_PseudoConstant::group();
 
-    $this->_groupIterator = CRM_Core_PseudoConstant::groupIterator();
     $this->_tag = CRM_Core_BAO_Tag::getTags();
     $this->_done = FALSE;
 

--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -100,12 +100,6 @@ class CRM_Core_PseudoConstant {
   private static $group;
 
   /**
-   * GroupIterator
-   * @var mixed
-   */
-  private static $groupIterator;
-
-  /**
    * RelationshipType
    * @var array
    */
@@ -922,28 +916,6 @@ WHERE  id = %1";
       self::populate(self::$group[$groupKey], 'CRM_Contact_DAO_Group', FALSE, 'title', 'is_active', $condition);
     }
     return self::$group[$groupKey];
-  }
-
-  /**
-   * Create or get groups iterator (iterates over nested groups in a
-   * logical fashion)
-   *
-   * The GroupNesting instance is returned; it's created if this is being
-   * called for the first time
-   *
-   *
-   *
-   * @param bool $styledLabels
-   *
-   * @return CRM_Contact_BAO_GroupNesting
-   */
-  public static function &groupIterator($styledLabels = FALSE) {
-    if (!self::$groupIterator) {
-      // When used as an object, GroupNesting implements Iterator
-      // and iterates nested groups in a logical manner for us
-      self::$groupIterator = new CRM_Contact_BAO_GroupNesting($styledLabels);
-    }
-    return self::$groupIterator;
   }
 
   /**

--- a/api/v3/Constant.php
+++ b/api/v3/Constant.php
@@ -156,7 +156,6 @@ function _civicrm_api3_constant_get_spec(&$params) {
     'fromEmailAddress',
     'gender',
     'group',
-    'groupIterator',
     'honor',
     'IMProvider',
     'individualPrefix',

--- a/api/v3/GroupNesting.php
+++ b/api/v3/GroupNesting.php
@@ -61,7 +61,6 @@ function civicrm_api3_group_nesting_get($params) {
 function civicrm_api3_group_nesting_create($params) {
   CRM_Contact_BAO_GroupNesting::add($params['parent_group_id'], $params['child_group_id']);
 
-  // FIXME: CRM_Contact_BAO_GroupNesting requires some work
   $result = array('is_error' => 0);
   return civicrm_api3_create_success($result, $params, 'GroupNesting');
 }


### PR DESCRIPTION
As identified in the ticket the add function is using non-standard
handling,
as, it turns out is the remove.

However, on further delving I found a lot of functions in this class that
do not appear to be in use. In addition the whole groupIterator complexity
seems to be unused.

@seamuslee001 this is kind of an alternative to the BAO part of your change - but really it's a big clean out of unused stuff. It feels pretty big in terms of readability though. Maybe I should break into smaller commits?

---
- [CRM-19068](https://issues.civicrm.org/jira/browse/CRM-19068)
