### PR TITLE
CRM-19126: civicrm_line_item.tax_amount incorrectly set when using online payment processor

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4109,6 +4109,18 @@ WHERE eft.financial_trxn_id IN ({$trxnId}, {$baseTrxnId['financialTrxnId']})
 
     // Update contribution.
     if (!empty($params['id'])) {
+      // CRM-19126, civicrm_line_item.tax_amount incorrectly set when using online payment processor.
+      // It looks like this method is meant to be called in multiple contexts: new & update
+      // When creating, would expect total_amount to be set?  Prior to 4.7, when creating online membership
+      // via contribution page, call scenario was different.
+      // This would not never get called, end result, taxes were correct.
+      // Since 4.7 it does.  Not sure this fix is ideal, but it does do the trick.
+      // Conceptually, if we're "updating", and total_amount is unknown.  We're dealing with an incomplete
+      // view, why are we nulling out all line item taxes, or messing with any other tax amounts?
+      if (!isset($params['total_amount'])) {
+          return $params;
+      }
+      
       $id = $params['id'];
       $values = $ids = array();
       $contrbutionParams = array('id' => $id);


### PR DESCRIPTION
Client I'm working with is looking to setup with CiviCRM.  In some of their testing in 4.6, extended report module would show taxes correctly.  After upgrade to 4.7 wouldn't.

This is my fix for this.

An another alternative might have been to prevent the "new" call to checkTaxAmount / trace the problem higher up (and maybe throw an exception when id is set, but not total amount).  This would have required more work, which I simply couldn't afford the time.

My fix here, does sound logical though, so hoping we can get this incorporated into a publicly available build, so that I'm not "special brewing" them.

---
- [CRM-19126: civicrm_line_item.tax_amount incorrectly set when using online payment processor](https://issues.civicrm.org/jira/browse/CRM-19126)
