### PR TITLE
CRM-19126: civicrm_line_item.tax_amount incorrectly set when using on…

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4109,7 +4109,7 @@ WHERE eft.financial_trxn_id IN ({$trxnId}, {$baseTrxnId['financialTrxnId']})
 
     // Update contribution.
     if (!empty($params['id'])) {
-      // CRM-19126, civicrm_line_item.tax_amount incorrectly set when using online payment processor.
+      // CRM-19126 and CRM-19152, civicrm_line_item.tax_amount incorrectly set when using online payment processor.
       // It looks like this method is meant to be called in multiple contexts: new & update
       // When creating, would expect total_amount to be set?  Prior to 4.7, when creating online membership
       // via contribution page, call scenario was different.
@@ -4118,9 +4118,9 @@ WHERE eft.financial_trxn_id IN ({$trxnId}, {$baseTrxnId['financialTrxnId']})
       // Conceptually, if we're "updating", and total_amount is unknown.  We're dealing with an incomplete
       // view, why are we nulling out all line item taxes, or messing with any other tax amounts?
       if (!isset($params['total_amount'])) {
-          return $params;
+        return $params;
       }
-      
+
       $id = $params['id'];
       $values = $ids = array();
       $contrbutionParams = array('id' => $id);

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4109,6 +4109,18 @@ WHERE eft.financial_trxn_id IN ({$trxnId}, {$baseTrxnId['financialTrxnId']})
 
     // Update contribution.
     if (!empty($params['id'])) {
+      // CRM-19126, civicrm_line_item.tax_amount incorrectly set when using online payment processor.
+      // It looks like this method is meant to be called in multiple contexts: new & update
+      // When creating, would expect total_amount to be set?  Prior to 4.7, when creating online membership
+      // via contribution page, call scenario was different.
+      // This would not never get called, end result, taxes were correct.
+      // Since 4.7 it does.  Not sure this fix is ideal, but it does do the trick.
+      // Conceptually, if we're "updating", and total_amount is unknown.  We're dealing with an incomplete
+      // view, why are we nulling out all line item taxes, or messing with any other tax amounts?
+      if (!isset($params['total_amount'])) {
+          return $params;
+      }
+      
       $id = $params['id'];
       $values = $ids = array();
       $contrbutionParams = array('id' => $id);


### PR DESCRIPTION
Not sure what I did with my previous commits for this patch.  Because they were fairly simple, I just re-cloned & restarted.

This pull request is for CRM-19126.  I'm not 100% happy with this patch. It seems really, we shouldn't even be calling CRM_Contribute_BAO_Contribution.checkTaxAmount a second time. I would even be tempted to throw an Exception in checkTaxAmount , if total_amount isn't set.  But changing that behaviour would most likely open up a can of something.

So the changes, are based more on what's going on within that method call.  "checkTaxAmount".  If some of the required fields are missing (e.g., "total_amount" and we're in an update scenario (id not empty)) then don't do anything.
