### PR TITLE
SOAP Authentication Fails on WP (4.7)

### DIFF
--- a/CRM/Utils/SoapServer.php
+++ b/CRM/Utils/SoapServer.php
@@ -117,7 +117,8 @@ class CRM_Utils_SoapServer {
   public function authenticate($name, $pass, $loadCMSBootstrap = FALSE) {
     require_once str_replace('_', DIRECTORY_SEPARATOR, $this->ufClass) . '.php';
 
-    if ($this->ufClass == 'CRM_Utils_System_Joomla') {
+    if ($this->ufClass == 'CRM_Utils_System_Joomla'
+      || $this->ufClass == 'CRM_Utils_System_WordPress') {
       $loadCMSBootstrap = TRUE;
     }
 


### PR DESCRIPTION
---
- CRM-19154: SOAP Authentication Fails on WP
  https://issues.civicrm.org/jira/browse/CRM-19154
- CRM-13007: SOAP authentication fails on WP with CCRM 4.3+
  https://issues.civicrm.org/jira/browse/CRM-13007
