### PR TITLE
CRM-17789 - CRM_Core_Smarty - Remove constructor override

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -77,15 +77,6 @@ class CRM_Core_Smarty extends Smarty {
    */
   private $backupFrames = array();
 
-  /**
-   * Class constructor.
-   *
-   * @return CRM_Core_Smarty
-   */
-  private function __construct() {
-    parent::__construct();
-  }
-
   private function initialize() {
     $config = CRM_Core_Config::singleton();
 


### PR DESCRIPTION
This is unnecessary and is part of a cyclical dependence among PHP 7 PRs.
With this resolved, we should be able to resolve some of the other PR's
in a reasonable order.

This is an adaptation of one part of #8455.  It _should_ enable merging or
testing https://github.com/civicrm/civicrm-packages/pull/150 without #8455.

---
- [CRM-17789: Support PHP 7](https://issues.civicrm.org/jira/browse/CRM-17789)
