### PR TITLE
CRM-17789 - PHP 7 - Cherrypick syntax fixes

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -5749,7 +5749,7 @@ AND   displayRelType.is_active = 1
       }
 
       if (is_object($dao) && property_exists($dao, $value['idCol'])) {
-        $val = $dao->$value['idCol'];
+        $val = $dao->{$value['idCol']};
         if ($key == 'groups') {
           $dao->groups = $this->convertGroupIDStringToLabelString($dao, $val);
           return;
@@ -5764,10 +5764,10 @@ AND   displayRelType.is_active = 1
           $dao->$idColumn = $val;
 
           if ($key == 'state_province_name') {
-            $dao->$value['pseudoField'] = $dao->$key = CRM_Core_PseudoConstant::stateProvinceAbbreviation($val);
+            $dao->{$value['pseudoField']} = $dao->$key = CRM_Core_PseudoConstant::stateProvinceAbbreviation($val);
           }
           else {
-            $dao->$value['pseudoField'] = $dao->$key = CRM_Core_PseudoConstant::getLabel($baoName, $value['pseudoField'], $val);
+            $dao->{$value['pseudoField']} = $dao->$key = CRM_Core_PseudoConstant::getLabel($baoName, $value['pseudoField'], $val);
           }
         }
         elseif ($value['pseudoField'] == 'state_province_abbreviation') {

--- a/CRM/Core/BAO/RecurringEntity.php
+++ b/CRM/Core/BAO/RecurringEntity.php
@@ -842,8 +842,8 @@ class CRM_Core_BAO_RecurringEntity extends CRM_Core_DAO_RecurringEntity {
           }
 
           $linkedDao = new $daoName();
-          $linkedDao->$linfo['entity_id_col'] = $entityId;
-          $linkedDao->$linfo['entity_table_col'] = $entityTable;
+          $linkedDao->{$linfo['entity_id_col']} = $entityId;
+          $linkedDao->{$linfo['entity_table_col']} = $entityTable;
           $linkedDao->find();
           while ($linkedDao->fetch()) {
             CRM_Core_BAO_RecurringEntity::delEntity($linkedDao->id, $linkedTable, FALSE);

--- a/CRM/Core/CodeGen/Main.php
+++ b/CRM/Core/CodeGen/Main.php
@@ -81,7 +81,7 @@ class CRM_Core_CodeGen_Main {
       exit();
     }
 
-    if (substr(phpversion(), 0, 1) != 5) {
+    if (substr(phpversion(), 0, 1) < 5) {
       echo phpversion() . ', ' . substr(phpversion(), 0, 1) . "\n";
       echo "
 CiviCRM requires a PHP Version >= 5

--- a/CRM/Core/Controller.php
+++ b/CRM/Core/Controller.php
@@ -220,7 +220,7 @@ class CRM_Core_Controller extends HTML_QuickForm_Controller {
       ));
     }
 
-    $this->HTML_QuickForm_Controller($name, $modal);
+    parent::__construct($name, $modal);
 
     $snippet = CRM_Utils_Array::value('snippet', $_REQUEST);
     if ($snippet) {

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -242,7 +242,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       $this->_name = CRM_Utils_String::getClassName(CRM_Utils_System::getClassName($this));
     }
 
-    $this->HTML_QuickForm_Page($this->_name, $method);
+    parent::__construct($this->_name, $method);
 
     $this->_state =& $state;
     if ($this->_state) {

--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -82,7 +82,7 @@ class CRM_Core_Smarty extends Smarty {
    *
    * @return CRM_Core_Smarty
    */
-  private function __construct() {
+  public function __construct() {
     parent::__construct();
   }
 

--- a/CRM/Financial/BAO/FinancialAccount.php
+++ b/CRM/Financial/BAO/FinancialAccount.php
@@ -149,7 +149,7 @@ class CRM_Financial_BAO_FinancialAccount extends CRM_Financial_DAO_FinancialAcco
       require_once str_replace('_', DIRECTORY_SEPARATOR, "CRM_" . $name[0] . "_BAO_" . $name[1]) . ".php";
       $className = "CRM_{$name[0]}_BAO_{$name[1]}";
       $bao = new $className();
-      $bao->$name[2] = $financialAccountId;
+      $bao->{$name[2]} = $financialAccountId;
       if ($bao->find(TRUE)) {
         $check = TRUE;
       }

--- a/CRM/Logging/Differ.php
+++ b/CRM/Logging/Differ.php
@@ -244,7 +244,7 @@ WHERE lt.log_conn_id = %1
         // we need to make sure separators are trimmed
         if ($diff == 'case_type_id') {
           foreach (array('original', 'changed') as $var) {
-            if (!empty($$var[$diff])) {
+            if (!empty(${$var[$diff]})) {
               $holder =& $$var;
               $val = explode(CRM_Case_BAO_Case::VALUE_SEPARATOR, $holder[$diff]);
               $holder[$diff] = CRM_Utils_Array::value(1, $val);

--- a/CRM/Report/Form/Extended.php
+++ b/CRM/Report/Form/Extended.php
@@ -171,7 +171,7 @@ class CRM_Report_Form_Extended extends CRM_Report_Form {
     foreach ($rows as $index => & $row) {
       foreach ($row as $selectedfield => $value) {
         if (array_key_exists($selectedfield, $alterfunctions)) {
-          $rows[$index][$selectedfield] = $this->$alterfunctions[$selectedfield]($value, $row, $selectedfield, $altermap[$selectedfield]);
+          $rows[$index][$selectedfield] = $this->{$alterfunctions[$selectedfield]}($value, $row, $selectedfield, $altermap[$selectedfield]);
         }
       }
     }

--- a/CRM/Utils/Pager.php
+++ b/CRM/Utils/Pager.php
@@ -75,7 +75,7 @@ class CRM_Utils_Pager extends Pager_Sliding {
 
     $this->initialize($params);
 
-    $this->Pager_Sliding($params);
+    parent::__construct($params);
 
     list($offset, $limit) = $this->getOffsetAndRowCount();
     $start = $offset + 1;


### PR DESCRIPTION
This is based on https://github.com/civicrm/civicrm-core/pull/8455 but only
provides the syntax fixes.  I'd like to get these parts checked/merged
separate from the mysqli stuff.

---
- [CRM-17789: Support PHP 7](https://issues.civicrm.org/jira/browse/CRM-17789)
