### PR TITLE
CRM-17789 - CRM_Core_Error - Adjust setDefaultCallback() sig

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -124,8 +124,13 @@ class CRM_Core_Error extends PEAR_ErrorStack {
     $log = CRM_Core_Config::getLog();
     $this->setLogger($log);
 
-    // set up error handling for Pear Error Stack
-    $this->setDefaultCallback(array($this, 'handlePES'));
+    // PEAR<=1.9.0 does not declare "static" properly.
+    if (!is_callable(array('PEAR', '__callStatic'))) {
+      $this->setDefaultCallback(array($this, 'handlePES'));
+    }
+    else {
+      PEAR_ErrorStack::setDefaultCallback(array($this, 'handlePES'));
+    }
   }
 
   /**


### PR DESCRIPTION
The definitions of `PEAR_ErrorStack::setDefaultCallback()` are slightly
different in PEAR 1.9.0 and PEAR 1.10.0.  The older one is _implicitly_
static (which, in some deployments of PHP, produces a warning); while the
newer one is _explicitly_ static.

This code should work with either signature without warnings.

---
- [CRM-17789: Support PHP 7](https://issues.civicrm.org/jira/browse/CRM-17789)
