### PR TITLE
CRM-18259 call pledge & pledgePayment specific functions for geting status

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2124,6 +2124,7 @@ SELECT contact_id
 
   /**
    * Get options for the called BAO object's field.
+   *
    * This function can be overridden by each BAO to add more logic related to context.
    * The overriding function will generally call the lower-level CRM_Core_PseudoConstant::get
    *

--- a/CRM/Pledge/BAO/Pledge.php
+++ b/CRM/Pledge/BAO/Pledge.php
@@ -159,8 +159,7 @@ class CRM_Pledge_BAO_Pledge extends CRM_Pledge_DAO_Pledge {
       $params['amount'] = $params['installment_amount'] * $params['installments'];
     }
 
-    // update the pledge status only if it does NOT come from form
-    if (!isset($params['pledge_status_id'])) {
+    if (!isset($params['pledge_status_id']) && !isset($params['status_id'])) {
       if (isset($params['contribution_id'])) {
         if ($params['installments'] > 1) {
           $params['status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Pledge_BAO_Pledge', 'status_id', 'In Progress');

--- a/CRM/Pledge/BAO/Pledge.php
+++ b/CRM/Pledge/BAO/Pledge.php
@@ -1147,9 +1147,9 @@ SELECT  pledge.contact_id              as contact_id,
     }
 
     return civicrm_api3('pledge_payment', 'getcount', array(
-        'pledge_id' => $pledgeID,
-        'status_id' => array('IN' => self::getTransactionalStatus()),
-      ));
+      'pledge_id' => $pledgeID,
+      'contribution_id' => array('NOT NULL' => TRUE),
+    ));
   }
 
   /**
@@ -1177,15 +1177,6 @@ SELECT  pledge.contact_id              as contact_id,
     return array_flip(array_intersect($paymentStatus, array('Overdue', 'Pending')));
   }
 
-  /**
-   * Get array of non transactional statuses.
-   * @return array
-   *   non transactional status ids
-   */
-  protected static function getTransactionalStatus() {
-    $paymentStatus = CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name');
-    return array_diff(array_flip($paymentStatus), self::getNonTransactionalStatus());
-  }
 
   /**
    * Create array for recur record for pledge.

--- a/CRM/Pledge/BAO/PledgePayment.php
+++ b/CRM/Pledge/BAO/PledgePayment.php
@@ -870,4 +870,23 @@ WHERE civicrm_pledge_payment.contribution_id = {$paymentContributionId}
     }
   }
 
+  /**
+   * Override buildOptions to hack out some statuses.
+   *
+   * @todo instead of using & hacking the shared optionGroup contribution_status use a separate one.
+   *
+   * @param string $fieldName
+   * @param string $context
+   * @param array $props
+   *
+   * @return array|bool
+   */
+  public static function buildOptions($fieldName, $context = NULL, $props = array()) {
+    $result = parent::buildOptions($fieldName, $context, $props);
+    if ($fieldName == 'status_id') {
+      $result = array_diff($result, array('Failed', 'In Progress'));
+    }
+    return $result;
+  }
+
 }

--- a/CRM/Pledge/BAO/Query.php
+++ b/CRM/Pledge/BAO/Query.php
@@ -534,13 +534,8 @@ class CRM_Pledge_BAO_Query {
     $form->add('text', 'pledge_amount_high', ts('To'), array('size' => 8, 'maxlength' => 8));
     $form->addRule('pledge_amount_high', ts('Please enter a valid money value (e.g. %1).', array(1 => CRM_Utils_Money::format('99.99', ' '))), 'money');
 
-    $statusValues = CRM_Contribute_PseudoConstant::contributionStatus();
-    // Remove status values that are only used for recurring contributions for now (Failed and In Progress).
-    unset($statusValues['4']);
-    // unset in progress for payment
-    unset($statusValues['5']);
     $form->add('select', 'pledge_status_id',
-      ts('Pledge Status'), $statusValues,
+      ts('Pledge Status'), CRM_Pledge_BAO_Pledge::buildOptions('status_id'),
       FALSE, array('class' => 'crm-select2', 'multiple' => 'multiple')
     );
 
@@ -553,7 +548,7 @@ class CRM_Pledge_BAO_Query {
     $form->addRule('pledge_installments_high', ts('Please enter number.'), 'integer');
 
     $form->add('select', 'pledge_payment_status_id',
-      ts('Pledge Payment Status'), $statusValues,
+      ts('Pledge Payment Status'), CRM_Pledge_BAO_PledgePayment::buildOptions('status_id'),
       FALSE, array('class' => 'crm-select2', 'multiple' => 'multiple')
     );
 

--- a/CRM/Pledge/Form/Payment.php
+++ b/CRM/Pledge/Form/Payment.php
@@ -70,7 +70,7 @@ class CRM_Pledge_Form_Payment extends CRM_Core_Form {
       if (isset($defaults['contribution_id'])) {
         $this->assign('pledgePayment', TRUE);
       }
-      $status = CRM_Contribute_PseudoConstant::contributionStatus($defaults['status_id']);
+      $status = CRM_Core_PseudoConstant::getName('CRM_Pledge_BAO_Pledge', 'status_id', $defaults['status_id']);
       $this->assign('status', $status);
     }
     $defaults['option_type'] = 1;
@@ -129,13 +129,12 @@ class CRM_Pledge_Form_Payment extends CRM_Core_Form {
     $params['scheduled_date'] = CRM_Utils_Date::format($formValues['scheduled_date']);
     $params['currency'] = CRM_Utils_Array::value('currency', $formValues);
     $now = date('Ymd');
-    $contributionStatus = CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name');
 
     if (CRM_Utils_Date::overdue(CRM_Utils_Date::customFormat($params['scheduled_date'], '%Y%m%d'), $now)) {
-      $params['status_id'] = array_search('Overdue', $contributionStatus);
+      $params['status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Pledge_BAO_Pledge', 'status_id', 'Overdue');
     }
     else {
-      $params['status_id'] = array_search('Pending', $contributionStatus);
+      $params['status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Pledge_BAO_Pledge', 'status_id', 'Pending');
     }
 
     $params['id'] = $this->_id;

--- a/CRM/Pledge/Form/Pledge.php
+++ b/CRM/Pledge/Form/Pledge.php
@@ -502,14 +502,6 @@ class CRM_Pledge_Form_Pledge extends CRM_Core_Form {
       $params[$f] = CRM_Utils_Array::value($f, $formValues);
     }
 
-    // defaults status is "Pending".
-    // if update get status.
-    if ($this->_id) {
-      $params['pledge_status_id'] = $params['status_id'] = $this->_values['status_id'];
-    }
-    else {
-      $params['pledge_status_id'] = $params['status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Pledge_BAO_Pledge', 'status_id', 'Pending');
-    }
     // format amount
     $params['amount'] = CRM_Utils_Rule::cleanMoney(CRM_Utils_Array::value('amount', $formValues));
     $params['currency'] = CRM_Utils_Array::value('currency', $formValues);

--- a/CRM/Pledge/Form/Pledge.php
+++ b/CRM/Pledge/Form/Pledge.php
@@ -178,7 +178,7 @@ class CRM_Pledge_Form_Pledge extends CRM_Core_Form {
       $defaults['financial_type_id'] = array_search('Donation', CRM_Contribute_PseudoConstant::financialType());
     }
 
-    $pledgeStatus = CRM_Contribute_PseudoConstant::contributionStatus();
+    $pledgeStatus = CRM_Pledge_BAO_Pledge::buildOptions('status_id');
     $pledgeStatusNames = CRM_Core_OptionGroup::values('contribution_status',
       FALSE, FALSE, FALSE, NULL, 'name', TRUE
     );
@@ -362,7 +362,7 @@ class CRM_Pledge_Form_Pledge extends CRM_Core_Form {
     }
 
     if (CRM_Utils_Array::value('status_id', $this->_values) !=
-      array_search('Cancelled', CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name'))
+      CRM_Core_PseudoConstant::getKey('CRM_Pledge_BAO_Pledge', 'status_id', 'Cancelled')
     ) {
 
       $this->addElement('checkbox', 'is_acknowledge', ts('Send Acknowledgment?'), NULL,
@@ -486,9 +486,6 @@ class CRM_Pledge_Form_Pledge extends CRM_Core_Form {
 
     $session = CRM_Core_Session::singleton();
 
-    // get All Payments status types.
-    $paymentStatusTypes = CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name');
-
     $fields = array(
       'frequency_unit',
       'frequency_interval',
@@ -511,7 +508,7 @@ class CRM_Pledge_Form_Pledge extends CRM_Core_Form {
       $params['pledge_status_id'] = $params['status_id'] = $this->_values['status_id'];
     }
     else {
-      $params['pledge_status_id'] = $params['status_id'] = array_search('Pending', $paymentStatusTypes);
+      $params['pledge_status_id'] = $params['status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Pledge_BAO_Pledge', 'status_id', 'Pending');
     }
     // format amount
     $params['amount'] = CRM_Utils_Rule::cleanMoney(CRM_Utils_Array::value('amount', $formValues));

--- a/CRM/Pledge/Form/PledgeView.php
+++ b/CRM/Pledge/Form/PledgeView.php
@@ -73,7 +73,7 @@ class CRM_Pledge_Form_PledgeView extends CRM_Core_Form {
     $values['financial_type'] = CRM_Utils_Array::value($values['financial_type_id'], CRM_Contribute_PseudoConstant::financialType());
 
     if ($values['status_id']) {
-      $values['pledge_status'] = CRM_Utils_Array::value($values['status_id'], CRM_Contribute_PseudoConstant::contributionStatus());
+      $values['pledge_status'] = CRM_Core_PseudoConstant::getKey('CRM_Pledge_BAO_Pledge', 'status_id', $values['status_id']);
     }
 
     $url = CRM_Utils_System::url('civicrm/contact/view/pledge',

--- a/CRM/Pledge/Form/Search.php
+++ b/CRM/Pledge/Form/Search.php
@@ -353,11 +353,9 @@ class CRM_Pledge_Form_Search extends CRM_Core_Form_Search {
 
     // set pledge related fields
     $pledgeStatus = CRM_Utils_Request::retrieve('pstatus', 'String');
-    if ($pledgeStatus) {
-      $statusValues = CRM_Contribute_PseudoConstant::contributionStatus();
 
-      // Remove status values that are only used for recurring contributions for now (Failed).
-      unset($statusValues['4']);
+    if ($pledgeStatus) {
+      $statusValues = CRM_Pledge_BAO_Pledge::buildOptions('status_id');
 
       // we need set all statuses except Cancelled
       unset($statusValues[$pledgeStatus]);

--- a/CRM/Pledge/Form/Search.php
+++ b/CRM/Pledge/Form/Search.php
@@ -331,26 +331,20 @@ class CRM_Pledge_Form_Search extends CRM_Core_Form_Search {
     }
 
     // set pledge payment related fields
-    $status = CRM_Utils_Request::retrieve('status', 'String',
-      CRM_Core_DAO::$_nullObject
-    );
+    $status = CRM_Utils_Request::retrieve('status', 'String');
     if ($status) {
       $this->_formValues['pledge_payment_status_id'] = array($status => 1);
       $this->_defaults['pledge_payment_status_id'] = array($status => 1);
     }
 
-    $fromDate = CRM_Utils_Request::retrieve('start', 'Date',
-      CRM_Core_DAO::$_nullObject
-    );
+    $fromDate = CRM_Utils_Request::retrieve('start', 'Date');
     if ($fromDate) {
       list($date) = CRM_Utils_Date::setDateDefaults($fromDate);
       $this->_formValues['pledge_payment_date_low'] = $date;
       $this->_defaults['pledge_payment_date_low'] = $date;
     }
 
-    $toDate = CRM_Utils_Request::retrieve('end', 'Date',
-      CRM_Core_DAO::$_nullObject
-    );
+    $toDate = CRM_Utils_Request::retrieve('end', 'Date');
     if ($toDate) {
       list($date) = CRM_Utils_Date::setDateDefaults($toDate);
       $this->_formValues['pledge_payment_date_high'] = $date;
@@ -358,9 +352,7 @@ class CRM_Pledge_Form_Search extends CRM_Core_Form_Search {
     }
 
     // set pledge related fields
-    $pledgeStatus = CRM_Utils_Request::retrieve('pstatus', 'String',
-      CRM_Core_DAO::$_nullObject
-    );
+    $pledgeStatus = CRM_Utils_Request::retrieve('pstatus', 'String');
     if ($pledgeStatus) {
       $statusValues = CRM_Contribute_PseudoConstant::contributionStatus();
 

--- a/CRM/Pledge/Form/Task.php
+++ b/CRM/Pledge/Form/Task.php
@@ -72,6 +72,8 @@ class CRM_Pledge_Form_Task extends CRM_Core_Form {
   }
 
   /**
+   * Common pre-processing.
+   *
    * @param CRM_Core_Form $form
    * @param bool $useTable
    */

--- a/CRM/Pledge/Page/DashBoard.php
+++ b/CRM/Pledge/Page/DashBoard.php
@@ -37,8 +37,9 @@
 class CRM_Pledge_Page_DashBoard extends CRM_Core_Page {
 
   /**
-   * Heart of the viewing process: The runner gets all the meta data for
-   * the contact and calls the appropriate type of page to view.
+   * Heart of the viewing process.
+   *
+   * The runner gets all the meta data for the contact and calls the appropriate type of page to view.
    */
   public function preProcess() {
     CRM_Utils_System::setTitle(ts('CiviPledge'));
@@ -56,8 +57,7 @@ class CRM_Pledge_Page_DashBoard extends CRM_Core_Page {
     $startDateEnd = NULL;
 
     // current year - prefix = 'year'
-    $config = CRM_Core_Config::singleton();
-    $yearDate = $config->fiscalYearStart;
+    $yearDate = \Civi::settings()->get('fiscalYearStart');
     $year = array('Y' => date('Y'));
     $this->assign('curYear', $year['Y']);
     $yearDate = array_merge($year, $yearDate);
@@ -89,7 +89,8 @@ class CRM_Pledge_Page_DashBoard extends CRM_Core_Page {
   }
 
   /**
-   * the main function that is called when the page loads,
+   * The main function that is called when the page loads.
+   *
    * it decides which action has to be taken for the page.
    *
    * @return null

--- a/CRM/Pledge/Selector/Search.php
+++ b/CRM/Pledge/Selector/Search.php
@@ -290,9 +290,7 @@ class CRM_Pledge_Selector_Search extends CRM_Core_Selector_Base {
     $rows = array();
 
     // get all pledge status
-    $pledgeStatuses = CRM_Core_OptionGroup::values('contribution_status',
-      FALSE, FALSE, FALSE, NULL, 'name', FALSE
-    );
+    $pledgeStatuses = CRM_Pledge_BAO_Pledge::buildOptions('status_id');
 
     // get all campaigns.
     $allCampaigns = CRM_Campaign_BAO_Campaign::getCampaigns(NULL, NULL, FALSE, FALSE, FALSE, TRUE);


### PR DESCRIPTION
The current config is to have a long list of contributions statuses which are shared as an option group
with pledge & pledge_payment. The irrelevant ones are then hacked out.

I believe that the correct way to do this is to split out the option groups into 3 separate ones.

However, there is quite a lot of work in re-pointing the various places that get the statuses from contributions.

So, I decided to limit this step to fixing the code to call the correct buildOptions function to get
the list & moving the hacks into there.

This does fix the original issue as the  status was being hacked out for pledge payment
when it should have been kept for pledge

---
- [CRM-18259: In progress Pledge status not available as a an option on the pledge search screen](https://issues.civicrm.org/jira/browse/CRM-18259)
