### PR TITLE
CRM-18472 - CRM_Contact_BAO_GroupContact - Remove erroneous references

### DIFF
--- a/CRM/Contact/BAO/GroupContact.php
+++ b/CRM/Contact/BAO/GroupContact.php
@@ -528,7 +528,7 @@ SELECT    *
     }
 
     if ($contactId) {
-      $contactGroupList = &CRM_Contact_BAO_GroupContact::getContactGroup($contactId, 'Added',
+      $contactGroupList = CRM_Contact_BAO_GroupContact::getContactGroup($contactId, 'Added',
         NULL, FALSE, $ignorePermission
       );
       if (is_array($contactGroupList)) {

--- a/CRM/Contact/Page/View/UserDashBoard/GroupContact.php
+++ b/CRM/Contact/Page/View/UserDashBoard/GroupContact.php
@@ -43,21 +43,21 @@ class CRM_Contact_Page_View_UserDashBoard_GroupContact extends CRM_Contact_Page_
       $this->_onlyPublicGroups
     );
 
-    $in =& CRM_Contact_BAO_GroupContact::getContactGroup(
+    $in = CRM_Contact_BAO_GroupContact::getContactGroup(
       $this->_contactId,
       'Added',
       NULL, FALSE, TRUE,
       $this->_onlyPublicGroups
     );
 
-    $pending =& CRM_Contact_BAO_GroupContact::getContactGroup(
+    $pending = CRM_Contact_BAO_GroupContact::getContactGroup(
       $this->_contactId,
       'Pending',
       NULL, FALSE, TRUE,
       $this->_onlyPublicGroups
     );
 
-    $out =& CRM_Contact_BAO_GroupContact::getContactGroup(
+    $out = CRM_Contact_BAO_GroupContact::getContactGroup(
       $this->_contactId,
       'Removed',
       NULL, FALSE, TRUE,


### PR DESCRIPTION
These lines are attempting to accept a return-value by reference, but the
function does not return by reference. In PHP 5.3+, this is effectively
not a reference; and in PHP 5.4+, it generates a warning. That leads
to test failures in CRM_Contact_BAO_ContactTest::testCreateProfileContact.

---
- [CRM-18472: Notice fixes](https://issues.civicrm.org/jira/browse/CRM-18472)
