### PR TITLE
CRM-19176 Add grouping options for contribution thank you letters

### DIFF
--- a/CRM/Contribute/Form/Task/PDFLetter.php
+++ b/CRM/Contribute/Form/Task/PDFLetter.php
@@ -124,7 +124,8 @@ class CRM_Contribute_Form_Task_PDFLetter extends CRM_Contribute_Form_Task {
     );
     $this->addElement('select', 'group_by', ts('Group contributions by'), $options, array(), "<br/>", FALSE);
     // this was going to be free-text but I opted for radio options in case there was a script injection risk
-    $separatorOptions = array('comma' => 'Comma', 'td' => 'Table Cell');
+	 $separatorOptions = array('comma' => 'Comma', 'td' => 'Horizontal Table Cell', 'tr' => 'Vertical Table Cell', 'br' => 'Line Break');
+
     $this->addElement('select', 'group_by_separator', ts('Separator (grouped contributions)'), $separatorOptions);
     $emailOptions = array(
       '' => ts('Generate PDFs for printing (only)'),

--- a/CRM/Contribute/Form/Task/PDFLetter.php
+++ b/CRM/Contribute/Form/Task/PDFLetter.php
@@ -124,7 +124,7 @@ class CRM_Contribute_Form_Task_PDFLetter extends CRM_Contribute_Form_Task {
     );
     $this->addElement('select', 'group_by', ts('Group contributions by'), $options, array(), "<br/>", FALSE);
     // this was going to be free-text but I opted for radio options in case there was a script injection risk
-	 $separatorOptions = array('comma' => 'Comma', 'td' => 'Horizontal Table Cell', 'tr' => 'Vertical Table Cell', 'br' => 'Line Break');
+    $separatorOptions = array('comma' => 'Comma', 'td' => 'Horizontal Table Cell', 'tr' => 'Vertical Table Cell', 'br' => 'Line Break');
 
     $this->addElement('select', 'group_by_separator', ts('Separator (grouped contributions)'), $separatorOptions);
     $emailOptions = array(

--- a/CRM/Contribute/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contribute/Form/Task/PDFLetterCommon.php
@@ -40,7 +40,13 @@ class CRM_Contribute_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDF
       if ($formValues['group_by_separator'] == 'td') {
         $realSeparator = "</td><td>";
       }
-    }
+		elseif ($formValues['group_by_separator'] == 'tr') {
+		  $realSeparator = "</td></tr><tr><td>";
+		}
+		elseif ($formValues['group_by_separator'] == 'br') {
+		  $realSeparator = "<br />";
+		}
+	 }
     $separator = '****~~~~';// a placeholder in case the separator is common in the string - e.g ', '
     $validated = FALSE;
 

--- a/CRM/Contribute/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contribute/Form/Task/PDFLetterCommon.php
@@ -40,13 +40,13 @@ class CRM_Contribute_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDF
       if ($formValues['group_by_separator'] == 'td') {
         $realSeparator = "</td><td>";
       }
-		elseif ($formValues['group_by_separator'] == 'tr') {
-		  $realSeparator = "</td></tr><tr><td>";
-		}
-		elseif ($formValues['group_by_separator'] == 'br') {
-		  $realSeparator = "<br />";
-		}
-	 }
+      elseif ($formValues['group_by_separator'] == 'tr') {
+        $realSeparator = "</td></tr><tr><td>";
+      }
+      elseif ($formValues['group_by_separator'] == 'br') {
+        $realSeparator = "<br />";
+      }
+    }
     $separator = '****~~~~';// a placeholder in case the separator is common in the string - e.g ', '
     $validated = FALSE;
 


### PR DESCRIPTION
Currently when creating Contribution thank you letters, the grouping options only allows for listing of the financial data horizontally. Either with a <td> or a comma. This would cause date to run off the page. 

I've added a couple of options to allow a user to list the contribution data vertically. It allows for unlimited items to be displayed rather than be limited to 8.5in of space and it allows for the contribution amount, date, payment instrument and check number to align side by side.

---
- [CRM-19176: Add grouping options for contribution thank you letters](https://issues.civicrm.org/jira/browse/CRM-19176)
