### PR TITLE
CRM-19168: Fix membership batch update with profiles that have custom date fields.

### DIFF
--- a/templates/CRM/Member/Form/Task/Batch.tpl
+++ b/templates/CRM/Member/Form/Task/Batch.tpl
@@ -51,7 +51,7 @@
 
               {foreach from=$fields item=field key=fieldName}
                 {assign var=n value=$field.name}
-                {if ( $fields.$n.data_type eq 'Date') or ($n eq 'join_date') or ($n eq 'membership_start_date') or ($n eq 'membership_end_date')}
+                {if ($n eq 'join_date') or ($n eq 'membership_start_date') or ($n eq 'membership_end_date')}
                    <td class="compressed">{include file="CRM/common/jcalendar.tpl" elementName=$n elementIndex=$mid batchUpdate=1}</td>
                 {else}
                   <td class="compressed">{$form.field.$mid.$n.html}</td>


### PR DESCRIPTION
copied from #8302

---
- [CRM-19168: Membership batch update: Custom date field causes Javascript date_format error](https://issues.civicrm.org/jira/browse/CRM-19168)
