### PR TITLE
CRM-19169 - ang/crmCxn - If `welcome` link defined, open it

### DIFF
--- a/ang/crmCxn.js
+++ b/ang/crmCxn.js
@@ -14,7 +14,7 @@
           apiCalls: function(crmApi){
             var reqs = {};
             reqs.cxns = ['Cxn', 'get', {sequential: 1}];
-            reqs.appMetas = ['CxnApp', 'get', {sequential: 1, return: ['id', 'title', 'desc', 'appId', 'appUrl', 'perm']}];
+            reqs.appMetas = ['CxnApp', 'get', {sequential: 1, return: ['id', 'title', 'desc', 'appId', 'appUrl', 'links', 'perm']}];
             reqs.cfg = ['Cxn', 'getcfg', {}];
             reqs.sysCheck = ['System', 'check', {}]; // FIXME: filter on checkCxnOverrides
             return crmApi(reqs);

--- a/ang/crmCxn/ManageCtrl.js
+++ b/ang/crmCxn/ManageCtrl.js
@@ -75,12 +75,20 @@
     };
 
     $scope.register = function(appMeta) {
-      var reg = crmApi('Cxn', 'register', {app_guid: appMeta.appId}).then($scope.refreshCxns);
+      var reg = crmApi('Cxn', 'register', {app_guid: appMeta.appId}).then($scope.refreshCxns).then(function() {
+        if (appMeta.links.welcome) {
+          return $scope.openLink(appMeta, 'welcome', {title: ts('%1: Welcome (External)', {1: appMeta.title})});
+        }
+      });
       return block(crmStatus({start: ts('Connecting...'), success: ts('Connected')}, reg));
     };
 
     $scope.reregister = function(appMeta) {
-      var reg = crmApi('Cxn', 'register', {app_guid: appMeta.appId}).then($scope.refreshCxns);
+      var reg = crmApi('Cxn', 'register', {app_guid: appMeta.appId}).then($scope.refreshCxns).then(function() {
+        if (appMeta.links.welcome) {
+          return $scope.openLink(appMeta, 'welcome', {title: ts('%1: Welcome (External)', {1: appMeta.title})});
+        }
+      });
       return block(crmStatus({start: ts('Reconnecting...'), success: ts('Reconnected')}, reg));
     };
 


### PR DESCRIPTION
When establishing a new connection, check if the application defines a `welcome` link and automatically open it.

This is closely related to https://github.com/civicrm/cxnapp/pull/13
## 
- [CRM-19169: CiviConnect - Allow services to define a welcome dialog](https://issues.civicrm.org/jira/browse/CRM-19169)
