### PR TITLE
crm-19150 Preserve contribution when associated membership is deleted (step 1 of 2 | API and BAO)

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -603,10 +603,10 @@ INNER JOIN  civicrm_membership_type type ON ( type.id = membership.membership_ty
    * @return int
    *   Id of deleted Membership on success, false otherwise.
    */
-  public static function del($membershipId) {
+  public static function del($membershipId, $preserveContrib = 0) {
     //delete related first and then delete parent.
     self::deleteRelatedMemberships($membershipId);
-    return self::deleteMembership($membershipId);
+    return self::deleteMembership($membershipId, $preserveContrib);
   }
 
   /**
@@ -618,7 +618,7 @@ INNER JOIN  civicrm_membership_type type ON ( type.id = membership.membership_ty
    * @return int
    *   Id of deleted Membership on success, false otherwise.
    */
-  public static function deleteMembership($membershipId) {
+  public static function deleteMembership($membershipId, $preserveContrib = 0) {
     // CRM-12147, retrieve membership data before we delete it for hooks
     $params = array('id' => $membershipId);
     $memValues = array();
@@ -654,7 +654,7 @@ INNER JOIN  civicrm_membership_type type ON ( type.id = membership.membership_ty
       $params['source_record_id'] = $membershipId;
       CRM_Activity_BAO_Activity::deleteActivity($params);
     }
-    self::deleteMembershipPayment($membershipId);
+    self::deleteMembershipPayment($membershipId, $preserveContrib);
 
     $results = $membership->delete();
     $transaction->commit();
@@ -1500,14 +1500,16 @@ WHERE  civicrm_membership.contact_id = civicrm_contact.id
    * @return object
    *   $membershipPayment deleted membership payment object
    */
-  public static function deleteMembershipPayment($membershipId) {
+  public static function deleteMembershipPayment($membershipId, $preserveContrib = 0) {
 
     $membershipPayment = new CRM_Member_DAO_MembershipPayment();
     $membershipPayment->membership_id = $membershipId;
     $membershipPayment->find();
 
     while ($membershipPayment->fetch()) {
-      CRM_Contribute_BAO_Contribution::deleteContribution($membershipPayment->contribution_id);
+      if (!$preserveContrib) {
+        CRM_Contribute_BAO_Contribution::deleteContribution($membershipPayment->contribution_id);
+      }
       CRM_Utils_Hook::pre('delete', 'MembershipPayment', $membershipPayment->id, $membershipPayment);
       $membershipPayment->delete();
       CRM_Utils_Hook::post('delete', 'MembershipPayment', $membershipPayment->id, $membershipPayment);

--- a/api/v3/Membership.php
+++ b/api/v3/Membership.php
@@ -33,6 +33,18 @@
  */
 
 /**
+ * Adjust Metadata for Delete action.
+ *
+ * The metadata is used for setting defaults, documentation & validation.
+ *
+ * @param array $params
+ *   Array of parameters determined by getfields.
+ */
+function _civicrm_api3_membership_delete_spec(&$params) {
+  $params['preserve_contribution']['api.required'] = 0;
+}
+
+/**
  * Deletes an existing contact Membership.
  *
  * @param array $params
@@ -42,7 +54,15 @@
  *   API result array.
  */
 function civicrm_api3_membership_delete($params) {
-  return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  if (isset($params['preserve_contribution'])){
+    if (CRM_Member_BAO_Membership::del($params['id'], $params['preserve_contribution'])) {
+      return civicrm_api3_create_success(TRUE, $params);
+    }else {
+      return civicrm_api3_create_error('Could not delete membership');
+    }
+  }else {
+    return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  }
 }
 
 /**

--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -133,6 +133,37 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test membership deletion and with the preserve contribution param.
+   */
+  public function testMembershipDeletePreserveContribution() {
+    $membershipID = $this->contactMembershipCreate($this->_params); //DELETE
+    $this->assertDBRowExist('CRM_Member_DAO_Membership', $membershipID); //DELETE
+    $ContributionCreate = $this->callAPISuccess('Contribution', 'create', array(
+      'sequential' => 1,
+      'financial_type_id' => "Member Dues",
+      'total_amount' => 100,
+      'contact_id' => $this->_params['contact_id'],
+    ));
+    $membershipPaymentCreate = $this->callAPISuccess('MembershipPayment', 'create', array(
+      'sequential' => 1,
+      'contribution_id' => $ContributionCreate['values'][0]['id'],
+      'membership_id' => $membershipID,
+    ));
+    $memParams = array(
+      'id' => $membershipID,
+      'preserve_contribution' => 1,
+    );
+    $contribParams = array(
+      'id' => $ContributionCreate['values'][0]['id']
+    );
+    $this->callAPIAndDocument('membership', 'delete', $memParams, __FUNCTION__, __FILE__);
+    $this->assertDBRowNotExist('CRM_Member_DAO_Membership', $membershipID);
+    $this->assertDBRowExist('CRM_Contribute_DAO_Contribution', $ContributionCreate['values'][0]['id']);
+    $this->callAPISuccess('Contribution', 'delete', $contribParams);
+    $this->assertDBRowNotExist('CRM_Contribute_DAO_Contribution', $ContributionCreate['values'][0]['id']);
+  }
+
+  /**
    * Test membership get.
    */
   public function testContactMembershipsGet() {


### PR DESCRIPTION
Currently when a membership is deleted, if there is an associated contribution then the contribution also gets deleted. This gives the option to keep the preserve the contrition. I suggest this be completed in two steps: 1) The ability the preserver the contribution through code (API and BAO) and 2) UI change to allow front-end users to check a box to preserve the associated contribution. This is step 1.

https://issues.civicrm.org/jira/browse/CRM-19150
