### PR TITLE
CRM-19173: Strip Bcc header.

### DIFF
--- a/CRM/Utils/Mail.php
+++ b/CRM/Utils/Mail.php
@@ -267,6 +267,7 @@ class CRM_Utils_Mail {
       }
       if (!empty($headers['Bcc'])) {
         $to[] = CRM_Utils_Array::value('Bcc', $headers);
+        unset($headers['Bcc']);
       }
     }
     if (is_object($mailer)) {


### PR DESCRIPTION
- [CRM-19173: BCC shown in emails sent via SMTP](https://issues.civicrm.org/jira/browse/CRM-19173)
