### PR TITLE
(NFC) CRM_Core_CodeGen_Util_Template - Remove PEAR formatting filter (port of Tim's pr to 4.6)

### DIFF
--- a/CRM/Core/CodeGen/Util/Template.php
+++ b/CRM/Core/CodeGen/Util/Template.php
@@ -29,8 +29,6 @@ class CRM_Core_CodeGen_Util_Template {
       $this->beautifier = new PHP_Beautifier();
       $this->beautifier->addFilter('ArrayNested');
       // add one or more filters
-      $this->beautifier->addFilter('Pear');
-      // add one or more filters
       $this->beautifier->addFilter('NewLines', array('after' => 'class, public, require, comment'));
       $this->beautifier->setIndentChar(' ');
       $this->beautifier->setIndentNumber(2);


### PR DESCRIPTION
This filter has several issues:
- Fundamentally, we don't use PEAR style guide - we're closer to Drupal style guide.
- Its only practical effect is to move squiggly braces... to the wrong place.
- It tangentially pulls in PEAR dependencies.
- It adds a ~4 seconds to GenCode (as measured on my laptop).
