### PR TITLE
CRM-19171 - Avoid clearing radio/checkbox values while form reset

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/OnBehalfOf.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/OnBehalfOf.tpl
@@ -95,7 +95,13 @@
      $('.crm-chain-select-control', "#select_org div").select2('val', '');
      $('input[type=text], select, textarea', "#select_org div").not('.crm-chain-select-control, #onbehalfof_id').val('').change();
      $('input[type=radio], input[type=checkbox]', "#select_org div").prop('checked', false).change();
-     $('#on-behalf-block input').val('');
+
+     $('#on-behalf-block input').not('input[type=checkbox], input[type=radio], #onbehalfof_id').val('');
+     // clear checkboxes and radio
+     $('#on-behalf-block')
+      .find('input[type=checkbox], input[type=radio]')
+      .not('input[name=org_option]')
+      .attr('checked', false);
     }
 
    function selectCreateOrg( orgOption, reset ) {


### PR DESCRIPTION
- [CRM-19171: Custom checkboxes not saved on Membership renewal.](https://issues.civicrm.org/jira/browse/CRM-19171)
