### PR TITLE
CRM-19183 - Remove .pdf extension for dompdf

### DIFF
--- a/CRM/Utils/PDF/Utils.php
+++ b/CRM/Utils/PDF/Utils.php
@@ -210,6 +210,8 @@ class CRM_Utils_PDF_Utils {
       return $dompdf->output();
     }
     else {
+      // CRM-19183 remove .pdf extension from filename
+      $fileName = basename($fileName, ".pdf");
       $dompdf->stream($fileName);
     }
   }


### PR DESCRIPTION
- [CRM-19183: Filename error on PDF download (DOMPDF).](https://issues.civicrm.org/jira/browse/CRM-19183)
