### PR TITLE
CRM-19172: on behalf form + user account creation attempts to create user for org

### DIFF
--- a/CRM/Contribute/BAO/Contribution/Utils.php
+++ b/CRM/Contribute/BAO/Contribution/Utils.php
@@ -327,7 +327,7 @@ INNER JOIN   civicrm_contact contact ON ( contact.id = contrib.contact_id )
     $created = TRUE;
 
     if (!empty($params['cms_create_account'])) {
-      $params['contactID'] = $contactID;
+      $params['contactID'] = !empty($params['onbehalf_contact_id']) ? $params['onbehalf_contact_id'] : $contactID;
       if (!CRM_Core_BAO_CMSUser::create($params, $mail)) {
         CRM_Core_Error::statusBounce(ts('Your profile is not saved and Account is not created.'));
       }

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1211,6 +1211,9 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       // required for mailing/template display ..etc
       $values['related_contact'] = $contactID;
 
+      //CRM-19172: Create CMS user for individual on whose behalf organization is doing contribution
+      $params['onbehalf_contact_id'] = $contactID;
+
       //make this employee of relationship as current
       //employer / employee relationship,  CRM-3532
       if ($isNotCurrentEmployer &&


### PR DESCRIPTION
Now we ensure that the (existing/created) CMS user is always linked with individual who do contribution on behalf of organization.

---
- [CRM-19172: on behalf form + user account creation attempts to create user for org](https://issues.civicrm.org/jira/browse/CRM-19172)
