### PR TITLE
Remove debugging comment when not in debug mode

### DIFF
--- a/templates/CRM/common/backdrop.tpl
+++ b/templates/CRM/common/backdrop.tpl
@@ -58,7 +58,6 @@
 <div id="crm-main-content-wrapper">
   {include file="CRM/common/status.tpl"}
   {crmRegion name='page-body'}
-    <!-- .tpl file invoked: {$tplFile}. Call via form.tpl if we have a form in the page. -->
     {if isset($isForm) and $isForm and isset($formTpl)}
       {include file="CRM/Form/$formTpl.tpl"}
     {else}

--- a/templates/CRM/common/debug.tpl
+++ b/templates/CRM/common/debug.tpl
@@ -23,6 +23,7 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
+<!-- .tpl file invoked: {$tplFile}. Call via form.tpl if we have a form in the page. -->
 {if $smarty.get.smartyDebug}
 {debug}
 {/if}

--- a/templates/CRM/common/drupal.tpl
+++ b/templates/CRM/common/drupal.tpl
@@ -58,7 +58,6 @@
 <div id="crm-main-content-wrapper">
   {include file="CRM/common/status.tpl"}
   {crmRegion name='page-body'}
-    <!-- .tpl file invoked: {$tplFile}. Call via form.tpl if we have a form in the page. -->
     {if isset($isForm) and $isForm and isset($formTpl)}
       {include file="CRM/Form/$formTpl.tpl"}
     {else}

--- a/templates/CRM/common/drupal6.tpl
+++ b/templates/CRM/common/drupal6.tpl
@@ -60,7 +60,6 @@
 <div id="crm-main-content-wrapper">
   {include file="CRM/common/status.tpl"}
   {crmRegion name='page-body'}
-    <!-- .tpl file invoked: {$tplFile}. Call via form.tpl if we have a form in the page. -->
     {if isset($isForm) and $isForm and isset($formTpl)}
       {include file="CRM/Form/$formTpl.tpl"}
     {else}

--- a/templates/CRM/common/drupal8.tpl
+++ b/templates/CRM/common/drupal8.tpl
@@ -58,7 +58,6 @@
 <div id="crm-main-content-wrapper">
   {include file="CRM/common/status.tpl"}
   {crmRegion name='page-body'}
-    <!-- .tpl file invoked: {$tplFile}. Call via form.tpl if we have a form in the page. -->
     {if isset($isForm) and $isForm and isset($formTpl)}
       {include file="CRM/Form/$formTpl.tpl"}
     {else}

--- a/templates/CRM/common/joomla.tpl
+++ b/templates/CRM/common/joomla.tpl
@@ -81,7 +81,6 @@
     <div id="crm-main-content-wrapper">
       {include file="CRM/common/status.tpl"}
       {crmRegion name='page-body'}
-        <!-- .tpl file invoked: {$tplFile}. Call via form.tpl if we have a form in the page. -->
         {if isset($isForm) and $isForm and isset($formTpl)}
           {include file="CRM/Form/$formTpl.tpl"}
         {else}

--- a/templates/CRM/common/print.tpl
+++ b/templates/CRM/common/print.tpl
@@ -44,7 +44,6 @@
 {include file="CRM/common/status.tpl"}
 
 {crmRegion name='page-body' allowCmsOverride=0}
-<!-- .tpl file invoked: {$tplFile}. Call via form.tpl if we have a form in the page. -->
   {if $isForm and isset($formTpl)}
     {include file="CRM/Form/$formTpl.tpl"}
   {else}

--- a/templates/CRM/common/printBody.tpl
+++ b/templates/CRM/common/printBody.tpl
@@ -25,7 +25,6 @@
 *}
 {* printBody.tpl: wrapper for Print views without HTML surrounds. *}
 
-<!-- .tpl file invoked: {$tplFile}. Call via form.tpl if we have a form in the page. -->
 {if $isForm and isset($formTpl)}
     {include file="CRM/Form/$formTpl.tpl"}
 {else}

--- a/templates/CRM/common/snippet.tpl
+++ b/templates/CRM/common/snippet.tpl
@@ -50,7 +50,6 @@
           {include file="CRM/common/status.tpl"}
         {/if}
 
-        <!-- .tpl file invoked: {$tplFile}. Call via form.tpl if we have a form in the page. -->
         {if !empty($isForm)}
           {include file="CRM/Form/default.tpl"}
         {else}

--- a/templates/CRM/common/unittests.tpl
+++ b/templates/CRM/common/unittests.tpl
@@ -58,7 +58,6 @@
 <div id="crm-main-content-wrapper">
   {include file="CRM/common/status.tpl"}
   {crmRegion name='page-body'}
-    <!-- .tpl file invoked: {$tplFile}. Call via form.tpl if we have a form in the page. -->
     {if isset($isForm) and $isForm and isset($formTpl)}
       {include file="CRM/Form/$formTpl.tpl"}
     {else}

--- a/templates/CRM/common/wordpress.tpl
+++ b/templates/CRM/common/wordpress.tpl
@@ -77,7 +77,6 @@
 <div id="crm-main-content-wrapper">
   {include file="CRM/common/status.tpl"}
   {crmRegion name='page-body'}
-    <!-- .tpl file invoked: {$tplFile}. Call via form.tpl if we have a form in the page. -->
     {if isset($isForm) and $isForm and isset($formTpl)}
       {include file="CRM/Form/$formTpl.tpl"}
     {else}


### PR DESCRIPTION
Sometimes things just lie around so long you stop noticing them anymore.
This debugging comment has been part of civi for as long as I can remember. But seriously, it should respect the global debug settings.
