### PR TITLE
CRM-19187 Add link to public mailing

### DIFF
--- a/CRM/Core/Action.php
+++ b/CRM/Core/Action.php
@@ -210,7 +210,6 @@ class CRM_Core_Action {
     $objectName = NULL,
     $objectId = NULL
   ) {
-    $config = CRM_Core_Config::singleton();
     if (empty($links)) {
       return NULL;
     }

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -3183,4 +3183,18 @@ AND        m.id = %1
     return array_combine($tables, $tables);
   }
 
+  /**
+   * Get the public view url.
+   *
+   * @param int $id
+   * @param bool $absolute
+   *
+   * @return string
+   */
+  public static function getPublicViewUrl($id, $absolute = TRUE) {
+    if ((civicrm_api3('Mailing', 'getvalue', array('id' => $id, 'return' => 'visibility'))) === 'Public Pages') {
+      return CRM_Utils_System::url('civicrm/mailing/view', array('id' => $id), $absolute, NULL, TRUE, TRUE);
+    }
+  }
+
 }

--- a/CRM/Mailing/Page/Report.php
+++ b/CRM/Mailing/Page/Report.php
@@ -48,6 +48,8 @@ class CRM_Mailing_Page_Report extends CRM_Core_Page_Basic {
   }
 
   /**
+   * An array of action links.
+   *
    * @return null
    */
   public function &links() {
@@ -139,6 +141,7 @@ class CRM_Mailing_Page_Report extends CRM_Core_Page_Basic {
     CRM_Utils_System::setTitle(ts('CiviMail Report: %1',
       array(1 => $report['mailing']['name'])
     ));
+    $this->assign('public_url', CRM_Mailing_BAO_Mailing::getPublicViewUrl($this->_mailing_id));
 
     return CRM_Core_Page::run();
   }

--- a/CRM/Mailing/Page/View.php
+++ b/CRM/Mailing/Page/View.php
@@ -78,6 +78,7 @@ class CRM_Mailing_Page_View extends CRM_Core_Page {
    * @param bool $allowID
    *
    * @return null|string
+   *   Not really sure if anything should be returned - parent doesn't
    */
   public function run($id = NULL, $contactID = NULL, $print = TRUE, $allowID = FALSE) {
     if (is_numeric($id)) {
@@ -115,7 +116,7 @@ class CRM_Mailing_Page_View extends CRM_Core_Page {
           !$allowID
         ) {
           CRM_Utils_System::permissionDenied();
-          return;
+          return NULL;
         }
       }
     }
@@ -128,7 +129,7 @@ class CRM_Mailing_Page_View extends CRM_Core_Page {
       !$this->checkPermission()
     ) {
       CRM_Utils_System::permissionDenied();
-      return;
+      return NULL;
     }
 
     CRM_Mailing_BAO_Mailing::tokenReplace($this->_mailing);

--- a/CRM/Mailing/Page/View.php
+++ b/CRM/Mailing/Page/View.php
@@ -76,6 +76,8 @@ class CRM_Mailing_Page_View extends CRM_Core_Page {
    * @param int $contactID
    * @param bool $print
    * @param bool $allowID
+   *
+   * @return null|string
    */
   public function run($id = NULL, $contactID = NULL, $print = TRUE, $allowID = FALSE) {
     if (is_numeric($id)) {
@@ -94,8 +96,7 @@ class CRM_Mailing_Page_View extends CRM_Core_Page {
       $this->_contactID = $contactID;
     }
     else {
-      $session = CRM_Core_Session::singleton();
-      $this->_contactID = $session->get('userID');
+      $this->_contactID = CRM_Core_Session::singleton()->getLoggedInContactID();
     }
 
     // mailing key check

--- a/CRM/Mailing/Selector/Browse.php
+++ b/CRM/Mailing/Selector/Browse.php
@@ -393,8 +393,19 @@ LEFT JOIN  civicrm_contact scheduledContact ON ( $mailing.scheduled_id = schedul
         }
         // get status strings as per locale settings CRM-4411.
         $rows[$key]['status'] = CRM_Mailing_BAO_MailingJob::status($row['status']);
+        $validLinks = $actionLinks;
+        if (($mailingUrl = CRM_Mailing_BAO_Mailing::getPublicViewUrl($row['id'])) != FALSE) {
+          $validLinks[] = array(
+            'name' => ts('Public View'),
+            'url' => 'civicrm/mailing/view',
+            'qs' => 'id=%%mid%%&reset=1',
+            'title' => ts('Public View'),
+            'fe' => TRUE,
+          );
+        }
 
-        $rows[$key]['action'] = CRM_Core_Action::formLink($actionLinks,
+        $rows[$key]['action'] = CRM_Core_Action::formLink(
+          $validLinks,
           $actionMask,
           array('mid' => $row['id']),
           "more",

--- a/templates/CRM/Mailing/Page/Report.tpl
+++ b/templates/CRM/Mailing/Page/Report.tpl
@@ -222,7 +222,7 @@
 
 <tr><td class="label">{ts}Open tracking{/ts}</td><td>{if $report.mailing.open_tracking}{ts}On{/ts}{else}{ts}Off{/ts}{/if}</td></tr>
 <tr><td class="label">{ts}URL Click-through tracking{/ts}</td><td>{if $report.mailing.url_tracking}{ts}On{/ts}{else}{ts}Off{/ts}{/if}</td></tr>
-
+{if $public_url}<td class="label">{ts}Public url{/ts}</td><td><a href="{$public_url}"> {$public_url}</a></td></tr>{/if}
 {if $report.mailing.campaign}
 <tr><td class="label">{ts}Campaign{/ts}</td><td>{$report.mailing.campaign}</td></tr>
 {/if}


### PR DESCRIPTION
Links are now on the Report page & the browse link drop-down.

They only show if the visibility is Public

---
- [CRM-19187: Add links to the public version of the civimails](https://issues.civicrm.org/jira/browse/CRM-19187)
