### PR TITLE
CRM-19126 Tax amount fix

### DIFF
--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -1331,11 +1331,11 @@ WHERE {$whereClause}";
    * @param int $counter
    */
   protected function assignTestValue($fieldName, &$fieldDef, $counter) {
-    if ($fieldName == 'children' || $fieldName = 'parents') {
+    if ($fieldName == 'children' || $fieldName == 'parents') {
       $this->{$fieldName} = "NULL";
     }
     else {
-      parent::assignTestValues($fieldaName, $fieldDef, $counter);
+      parent::assignTestValues($fieldName, $fieldDef, $counter);
     }
   }
 

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4125,26 +4125,22 @@ WHERE eft.financial_trxn_id IN ({$trxnId}, {$baseTrxnId['financialTrxnId']})
       if (empty($params['prevContribution'])) {
         $params['prevContribution'] = self::getOriginalContribution($params['id']);
       }
-      $isRequireTaxCalculation = FALSE;
-      foreach (array('total_amount', 'financial_type_id', 'fee_amount', 'tax_amount') as $field) {
+
+      foreach (array('total_amount', 'financial_type_id', 'fee_amount') as $field) {
         if (!isset($params[$field])) {
           if ($field == 'total_amount' && $params['prevContribution']->tax_amount) {
             // Tax amount gets added back on later....
             $params['total_amount'] = $params['prevContribution']->total_amount -
               $params['prevContribution']->tax_amount;
-            $isRequireTaxCalculation = TRUE;
           }
           else {
             $params[$field] = $params['prevContribution']->$field;
             if ($params[$field] != $params['prevContribution']->$field) {
-              $isRequireTaxCalculation = TRUE;
             }
           }
         }
       }
-      if (!$isRequireTaxCalculation) {
-        return $params;
-      }
+
       self::calculateMissingAmountParams($params, $params['id']);
       if (!array_key_exists($params['financial_type_id'], $taxRates)) {
         // Assign tax Amount on update of contribution

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -5200,4 +5200,29 @@ LEFT JOIN  civicrm_contribution on (civicrm_contribution.contact_id = civicrm_co
     return $statusMsg;
   }
 
+  /**
+   * Assign Test Value.
+   *
+   * @param string $fieldName
+   * @param array $fieldDef
+   * @param int $counter
+   */
+  protected function assignTestValue($fieldName, &$fieldDef, $counter) {
+    if ($fieldName == 'tax_amount') {
+      $this->{$fieldName} = "0.00";
+    }
+    elseif ($fieldName == 'net_amount') {
+      $this->{$fieldName} = "2.00";
+    }
+    elseif ($fieldName == 'total_amount') {
+      $this->{$fieldName} = "3.00";
+    }
+    elseif ($fieldName == 'fee_amount') {
+      $this->{$fieldName} = "1.00";
+    }
+    else {
+      parent::assignTestValues($fieldName, $fieldDef, $counter);
+    }
+  }
+
 }

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -191,7 +191,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
 
     if (!isset($params['tax_amount']) && $setPrevContribution && (isset($params['total_amount']) || isset
       ($params['financial_type_id']))) {
-      CRM_Contribute_BAO_Contribution::checkTaxAmount($params);
+      $params = CRM_Contribute_BAO_Contribution::checkTaxAmount($params);
     }
 
     if ($contributionID) {

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -183,11 +183,16 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
       }
     }
     if ($contributionID && $setPrevContribution) {
-      $params['prevContribution'] = self::getValues(array('id' => $contributionID), CRM_Core_DAO::$_nullArray, CRM_Core_DAO::$_nullArray);
+      $params['prevContribution'] = self::getOriginalContribution($contributionID);
     }
 
     // CRM-16189
     CRM_Financial_BAO_FinancialAccount::checkFinancialTypeHasDeferred($params, $contributionID);
+
+    if (!isset($params['tax_amount']) && $setPrevContribution && (isset($params['total_amount']) || isset
+      ($params['financial_type_id']))) {
+      CRM_Contribute_BAO_Contribution::checkTaxAmount($params);
+    }
 
     if ($contributionID) {
       CRM_Utils_Hook::pre('edit', 'Contribution', $contributionID, $params);
@@ -4079,12 +4084,12 @@ WHERE eft.financial_trxn_id IN ({$trxnId}, {$baseTrxnId['financialTrxnId']})
   }
 
   /**
-   * Get financial account id has 'Sales Tax Account is'
-   * account relationship with financial type
+   * Get financial account id has 'Sales Tax Account is' account relationship with financial type.
    *
    * @param int $financialTypeId
    *
-   * @return FinancialAccountId
+   * @return int
+   *   Financial Account Id
    */
   public static function getFinancialAccountId($financialTypeId) {
     $accountRel = key(CRM_Core_PseudoConstant::accountOptionValues('account_relationship', NULL, " AND v.name LIKE 'Sales Tax Account is' "));
@@ -4100,61 +4105,50 @@ WHERE eft.financial_trxn_id IN ({$trxnId}, {$baseTrxnId['financialTrxnId']})
   }
 
   /**
-   * Check tax amount.
+   * Get the tax amount (misnamed function).
    *
    * @param array $params
    * @param bool $isLineItem
    *
-   * @return mixed
+   * @return array
    */
   public static function checkTaxAmount($params, $isLineItem = FALSE) {
     $taxRates = CRM_Core_PseudoConstant::getTaxRates();
 
     // Update contribution.
     if (!empty($params['id'])) {
-
-      $id = $params['id'];
-      $values = $ids = array();
-      $contrbutionParams = array('id' => $id);
-      $prevContributionValue = CRM_Contribute_BAO_Contribution::getValues($contrbutionParams, $values, $ids);
-
-      // CRM-19126 and CRM-19152, civicrm_line_item.tax_amount incorrectly set when using online payment processor.
-      // It looks like this method is meant to be called in multiple contexts: new & update
-      // When creating, would expect total_amount to be set?  Prior to 4.7, when creating online membership
-      // via contribution page, call scenario was different.
-      // This would not never get called, end result, taxes were correct.
-      // Since 4.7 it does.  Not sure this fix is ideal, but it does do the trick.
-      // Conceptually, if we're "updating", and total_amount is unknown.  We're dealing with an incomplete
-      // view, why are we nulling out all line item taxes, or messing with any other tax amounts?
-      if (!isset($params['total_amount'])) {
-        if (!empty($prevContributionValue->tax_amount)) {
-          $params['total_amount'] = $prevContributionValue->total_amount - $prevContributionValue->tax_amount;
-          if (isset($params['fee_amount'])) {
-            $params['net_amount'] = $params['total_amount'] - $params['fee_amount'];
+      // CRM-19126 and CRM-19152 If neither total or financial_type_id are set on an update
+      // there are no tax implications - early return.
+      if (!isset($params['total_amount']) && !isset($params['financial_type_id'])) {
+        return $params;
+      }
+      if (empty($params['prevContribution'])) {
+        $params['prevContribution'] = self::getOriginalContribution($params['id']);
+      }
+      $isRequireTaxCalculation = FALSE;
+      foreach (array('total_amount', 'financial_type_id', 'fee_amount', 'tax_amount') as $field) {
+        if (!isset($params[$field])) {
+          if ($field == 'total_amount' && $params['prevContribution']->tax_amount) {
+            // Tax amount gets added back on later....
+            $params['total_amount'] = $params['prevContribution']->total_amount -
+              $params['prevContribution']->tax_amount;
+            $isRequireTaxCalculation = TRUE;
           }
           else {
-            $params['net_amount'] = $params['total_amount'] - $prevContributionValue->fee_amount;
-            $params['fee_amount'] = $prevContributionValue->fee_amount;
-          }
-        }
-        else {
-          if (isset($params['fee_amount'])) {
-            $params['net_amount'] = $prevContributionValue->total_amount - $params['fee_amount'];
-            $params['total_amount'] = $prevContributionValue->total_amount;
-          }
-          else {
-            $params['total_amount'] = $prevContributionValue->total_amount;
-            $params['fee_amount'] = $prevContributionValue->fee_amount;
+            $params[$field] = $params['prevContribution']->$field;
+            if ($params[$field] != $params['prevContribution']->$field) {
+              $isRequireTaxCalculation = TRUE;
+            }
           }
         }
       }
-      // To assign pervious finantial type on update of contribution
-      if (!isset($params['financial_type_id'])) {
-        $params['financial_type_id'] = $prevContributionValue->financial_type_id;
+      if (!$isRequireTaxCalculation) {
+        return $params;
       }
-      elseif (isset($params['financial_type_id']) && !array_key_exists($params['financial_type_id'], $taxRates)) {
-        // Assisn tax Amount on update of contrbution
-        if (!empty($prevContributionValue->tax_amount)) {
+      self::calculateMissingAmountParams($params, $params['id']);
+      if (!array_key_exists($params['financial_type_id'], $taxRates)) {
+        // Assign tax Amount on update of contribution
+        if (!empty($params['prevContribution']->tax_amount)) {
           $params['tax_amount'] = 'null';
           CRM_Price_BAO_LineItem::getLineItemArray($params, array($params['id']));
           foreach ($params['line_item'] as $setID => $priceField) {
@@ -4166,7 +4160,7 @@ WHERE eft.financial_trxn_id IN ({$trxnId}, {$baseTrxnId['financialTrxnId']})
       }
     }
 
-    // New Contrbution and update of contribution with tax rate financial type
+    // New Contribution and update of contribution with tax rate financial type
     if (isset($params['financial_type_id']) && array_key_exists($params['financial_type_id'], $taxRates) &&
       empty($params['skipLineItem']) && !$isLineItem
     ) {
@@ -5217,6 +5211,17 @@ LEFT JOIN  civicrm_contribution on (civicrm_contribution.contact_id = civicrm_co
     }
 
     return $statusMsg;
+  }
+
+  /**
+   * Get the contribution as it is in the database before being updated.
+   *
+   * @param int $contributionID
+   *
+   * @return array
+   */
+  private static function getOriginalContribution($contributionID) {
+    return self::getValues(array('id' => $contributionID), CRM_Core_DAO::$_nullArray, CRM_Core_DAO::$_nullArray);
   }
 
   /**

--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -1828,6 +1828,8 @@ WHERE  id = %1
   public static function getTaxRates() {
     if (!isset(Civi::$statics[__CLASS__]['taxRates'])) {
       Civi::$statics[__CLASS__]['taxRates'] = array();
+      // Never do a copy & paste of this as the join on the option value is not indexed.
+      // @todo fix to resolve option values first.
       $sql = "
         SELECT fa.tax_rate, efa.entity_id
         FROM civicrm_entity_financial_account efa

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -80,10 +80,6 @@ function civicrm_api3_contribution_create(&$params) {
   }
   _civicrm_api3_contribution_create_legacy_support_45($params);
 
-  // Make sure tax calculation is handled via api.
-  // @todo this belongs in the BAO NOT the api.
-  $params = CRM_Contribute_BAO_Contribution::checkTaxAmount($params);
-
   return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'Contribution');
 }
 

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -1794,9 +1794,12 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $this->callAPISuccess('contribution', 'completetransaction', array(
        'id' => $contribution['id'],
        'trxn_id' => '777788888',
+       'fee_amount' => '6.00',
     ));
-    $contribution2 = $this->callAPISuccess('contribution', 'get', array('id' => $contribution['id'], 'return' => 'tax_amount', 'sequential' => 1));
+    $contribution2 = $this->callAPISuccess('contribution', 'get', array('id' => $contribution['id'], 'return' => array('tax_amount', 'fee_amount', 'net_amount'), 'sequential' => 1));
     $this->assertEquals($contribution1['values'][0]['tax_amount'], $contribution2['values'][0]['tax_amount']);
+    $this->assertEquals('6.00', $contribution2['values'][0]['fee_amount']);
+    $this->assertEquals('94.00', $contribution2['values'][0]['net_amount']);
   }
 
   /**

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -1786,7 +1786,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'account_relationship' => 10,
       'financial_account_id' => $financialAccountId,
     );
-    $financialRelation = CRM_Financial_BAO_FinancialTypeAccount::add($financialAccountParams);
+    CRM_Financial_BAO_FinancialTypeAccount::add($financialAccountParams);
     $taxRates = CRM_Core_PseudoConstant::getTaxRates();
     $params = array_merge($this->_params, array('contribution_status_id' => 2, 'financial_type_id' => $financialTypeId));
     $contribution = $this->callAPISuccess('contribution', 'create', $params);

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -1799,7 +1799,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $contribution2 = $this->callAPISuccess('contribution', 'get', array('id' => $contribution['id'], 'return' => array('tax_amount', 'fee_amount', 'net_amount'), 'sequential' => 1));
     $this->assertEquals($contribution1['values'][0]['tax_amount'], $contribution2['values'][0]['tax_amount']);
     $this->assertEquals('6.00', $contribution2['values'][0]['fee_amount']);
-    $this->assertEquals('94.00', $contribution2['values'][0]['net_amount']);
+    $this->assertEquals('99.00', $contribution2['values'][0]['net_amount']);
   }
 
   /**

--- a/tests/phpunit/api/v3/TaxContributionPageTest.php
+++ b/tests/phpunit/api/v3/TaxContributionPageTest.php
@@ -361,7 +361,8 @@ class api_v3_TaxContributionPageTest extends CiviUnitTestCase {
   }
 
   /**
-   * Updation of contrbution.
+   * Update a contribution.
+   *
    * Function tests that line items, financial records are updated when contribution amount is changed
    */
   public function testCreateUpdateContributionChangeTotal() {
@@ -389,7 +390,7 @@ class api_v3_TaxContributionPageTest extends CiviUnitTestCase {
       'financial_type_id' => 1, // without tax rate i.e Donation
       'total_amount' => '300',
     );
-    $contribution = $this->callAPISuccess('contribution', 'update', $newParams);
+    $contribution = $this->callAPISuccess('contribution', 'create', $newParams);
 
     $lineItems = $this->callAPISuccess('line_item', 'getvalue', array(
       'entity_id' => $contribution['id'],


### PR DESCRIPTION
@seamuslee001 this is my take on what the fix should look like

1) move check tax amount to the BAO
2) use the existing pre-load of the prevContribution
3) exit early if at all possible

One thing you did that I wasn't clear about was $params['total_amount'] = $prevContributionValue->total_amount - $prevContributionValue->tax_amount;

I thought the saved total would be right?

---
- [CRM-19126: civicrm_line_item.tax_amount incorrectly set when using online payment processor](https://issues.civicrm.org/jira/browse/CRM-19126)
