### PR TITLE
Don't clobber contributionRecur currency on edit

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -861,7 +861,7 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
     else {
       // Only update next sched date if it's empty or 'just now' because payment processors may be managing
       // the scheduled date themselves as core did not previously provide any help.
-      if (empty($params['next_sched_contribution_date']) || strtotime($params['next_sched_contribution_date']) ==
+      if (empty($existing['next_sched_contribution_date']) || strtotime($existing['next_sched_contribution_date']) ==
         strtotime(date('Y-m-d'))) {
         $params['next_sched_contribution_date'] = date('Y-m-d', strtotime('+' . $existing['frequency_interval'] . ' ' . $existing['frequency_unit']));
       }

--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -85,7 +85,7 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
     $recurring->id = CRM_Utils_Array::value('id', $params);
 
     // set currency for CRM-1496
-    if (!isset($recurring->currency)) {
+    if (empty($params['id']) && !isset($recurring->currency)) {
       $config = CRM_Core_Config::singleton();
       $recurring->currency = $config->defaultCurrency;
     }

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
@@ -112,4 +112,22 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
     $this->assertTrue(CRM_Contribute_BAO_ContributionRecur::supportsFinancialTypeChange($contributionRecur['id']));
   }
 
+  /**
+   * Test we don't change unintended fields on API edit
+   */
+  public function testUpdateRecur() {
+    $createParams = $this->_params;
+    $createParams['currency'] = 'XAU';
+    $contributionRecur = $this->callAPISuccess('contribution_recur', 'create', $createParams);
+    $editParams = array(
+      'id' => $contributionRecur['id'],
+      'end_date' => '+ 4 weeks',
+    );
+    $contributionRecur = $this->callAPISuccess('contribution_recur', 'create', $editParams);
+    $dao = new CRM_Contribute_BAO_ContributionRecur();
+    $dao->id = $contributionRecur['id'];
+    $dao->find(TRUE);
+    $this->assertEquals('XAU', $dao->currency, 'Edit clobbered recur currency');
+  }
+
 }


### PR DESCRIPTION
When editing an existing contribution_recur without specifying a
currency, do not change the record to the default currency.
