### PR TITLE
CRM-19194: printing labels for members with missing address

### DIFF
--- a/CRM/Member/Form/Task/Label.php
+++ b/CRM/Member/Form/Task/Label.php
@@ -133,8 +133,9 @@ class CRM_Member_Form_Task_Label extends CRM_Member_Form_Task {
         'return' => 'contact_id',
       ));
       foreach ($memberships['values'] as $id => $membership) {
-        if (isset($rows[$membership['contact_id']]))
+        if (isset($rows[$membership['contact_id']])) {
           $labelRows[$id] = $rows[$membership['contact_id']];
+        }
       }
     }
     else {

--- a/CRM/Member/Form/Task/Label.php
+++ b/CRM/Member/Form/Task/Label.php
@@ -133,7 +133,8 @@ class CRM_Member_Form_Task_Label extends CRM_Member_Form_Task {
         'return' => 'contact_id',
       ));
       foreach ($memberships['values'] as $id => $membership) {
-        $labelRows[$id] = $rows[$membership['contact_id']];
+        if (isset($rows[$membership['contact_id']]))
+          $labelRows[$id] = $rows[$membership['contact_id']];
       }
     }
     else {


### PR DESCRIPTION
If trying to print address labels for a group of members (via the Search menu), if there's 1 member without address no PDF is generated.
The $rows variable only contains entries for members that actually have an address, so we need to check that.

---
- [CRM-19194: printing labels for members without address (\+ FIX)](https://issues.civicrm.org/jira/browse/CRM-19194)
