### PR TITLE
CRM-19197 merge links fix and CRM-19198 Add form merge hook call

### DIFF
--- a/CRM/Contact/Form/Merge.php
+++ b/CRM/Contact/Form/Merge.php
@@ -44,6 +44,13 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
 
   var $_contactType = NULL;
 
+  /**
+   * Query limit to be retained in the urls.
+   *
+   * @var int
+   */
+  var $limit;
+
   // FIXME: QuickForm can't create advcheckboxes with value set to 0 or '0' :(
   // see HTML_QuickForm_advcheckbox::setValues() - but patching that doesn't
   // help, as QF doesn't put the 0-value elements in exportValues() anyway...
@@ -55,7 +62,6 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
       CRM_Core_Error::fatal(ts('You do not have access to this page'));
     }
 
-    $rows = array();
     $cid = CRM_Utils_Request::retrieve('cid', 'Positive', $this, TRUE);
     $oid = CRM_Utils_Request::retrieve('oid', 'Positive', $this, TRUE);
     $flip = CRM_Utils_Request::retrieve('flip', 'Positive', $this, FALSE);
@@ -63,6 +69,8 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
     $this->_rgid = CRM_Utils_Request::retrieve('rgid', 'Positive', $this, FALSE);
     $this->_gid = $gid = CRM_Utils_Request::retrieve('gid', 'Positive', $this, FALSE);
     $this->_mergeId = CRM_Utils_Request::retrieve('mergeId', 'Positive', $this, FALSE);
+    $this->limit = CRM_Utils_Request::retrieve('limit', 'Positive', $this, FALSE);
+    $urlParams = "reset=1&rgid={$this->_rgid}&gid={$this->_gid}&limit=" . $this->limit;
 
     // Sanity check
     if ($cid == $oid) {
@@ -133,16 +141,8 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
              ) as $position) {
       if (!empty($pos[$position])) {
         if ($pos[$position]['id1'] && $pos[$position]['id2']) {
-          $urlParam = "reset=1&cid={$pos[$position]['id1']}&oid={$pos[$position]['id2']}&mergeId={$pos[$position]['mergeId']}&action=update";
-
-          if ($this->_rgid) {
-            $urlParam .= "&rgid={$this->_rgid}";
-          }
-          if ($gid) {
-            $urlParam .= "&gid={$gid}";
-          }
-
-          $this->$position = CRM_Utils_System::url('civicrm/contact/merge', $urlParam);
+          $urlParams .= "&cid={$pos[$position]['id1']}&oid={$pos[$position]['id2']}&mergeId={$pos[$position]['mergeId']}&action=update";
+          $this->$position = CRM_Utils_System::url('civicrm/contact/merge', $urlParams);
           $this->assign($position, $this->$position);
         }
       }
@@ -172,11 +172,7 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
 
     // context fixed.
     if ($isFromDedupeScreen) {
-      $urlParam = "reset=1&action=browse&rgid={$this->_rgid}";
-      if ($gid) {
-        $urlParam .= "&gid={$gid}";
-      }
-      $browseUrl = CRM_Utils_System::url('civicrm/contact/dedupefind', $urlParam);
+      $browseUrl = CRM_Utils_System::url('civicrm/contact/dedupefind', $urlParams . '&action=browse');
       $session->pushUserContext($browseUrl);
     }
     $this->assign('browseUrl', empty($browseUrl) ? '' : $browseUrl);
@@ -329,13 +325,12 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
     CRM_Core_Session::setStatus($message, ts('Contacts Merged'), 'success');
 
     $url = CRM_Utils_System::url('civicrm/contact/view', "reset=1&cid={$this->_cid}");
+    $urlParams = "reset=1&gid={$this->_gid}&rgid={$this->_rgid}&limit={$this->limit}";
+
     if (!empty($formValues['_qf_Merge_submit'])) {
-      $listParamsURL = "reset=1&action=update&rgid={$this->_rgid}";
-      if ($this->_gid) {
-        $listParamsURL .= "&gid={$this->_gid}";
-      }
+      $urlParams .= "&action=update";
       $lisitingURL = CRM_Utils_System::url('civicrm/contact/dedupefind',
-        $listParamsURL
+        $urlParams
       );
       CRM_Utils_System::redirect($lisitingURL);
     }
@@ -356,15 +351,8 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
         $pos['next']['id2']
       ) {
 
-        $urlParam = "reset=1&cid={$pos['next']['id1']}&oid={$pos['next']['id2']}&mergeId={$pos['next']['mergeId']}&action=update";
-        if ($this->_rgid) {
-          $urlParam .= "&rgid={$this->_rgid}";
-        }
-        if ($this->_gid) {
-          $urlParam .= "&gid={$this->_gid}";
-        }
-
-        $url = CRM_Utils_System::url('civicrm/contact/merge', $urlParam);
+        $urlParams .= "&cid={$pos['next']['id1']}&oid={$pos['next']['id2']}&mergeId={$pos['next']['mergeId']}&action=update";
+        $url = CRM_Utils_System::url('civicrm/contact/merge', $urlParams);
       }
     }
 

--- a/CRM/Contact/Form/Merge.php
+++ b/CRM/Contact/Form/Merge.php
@@ -317,8 +317,9 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
 
     $formValues['main_details'] = $this->_mainDetails;
     $formValues['other_details'] = $this->_otherDetails;
-
-    CRM_Dedupe_Merger::moveAllBelongings($this->_cid, $this->_oid, $formValues);
+    $migrationData = array('migration_info' => $formValues);
+    CRM_Utils_Hook::merge('form', $migrationData, $this->_cid, $this->_oid);
+    CRM_Dedupe_Merger::moveAllBelongings($this->_cid, $this->_oid, $migrationData['migration_info']);
 
     $name = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $this->_cid, 'display_name');
     $message = '<ul><li>' . ts('%1 has been updated.', array(1 => $name)) . '</li><li>' . ts('Contact ID %1 has been deleted.', array(1 => $this->_oid)) . '</li></ul>';

--- a/CRM/Contact/Page/AJAX.php
+++ b/CRM/Contact/Page/AJAX.php
@@ -640,8 +640,8 @@ LIMIT {$offset}, {$rowCount}
     $offset    = isset($_REQUEST['start']) ? CRM_Utils_Type::escape($_REQUEST['start'], 'Integer') : 0;
     $rowCount  = isset($_REQUEST['length']) ? CRM_Utils_Type::escape($_REQUEST['length'], 'Integer') : 25;
 
-    $gid         = isset($_REQUEST['gid']) ? CRM_Utils_Type::escape($_REQUEST['gid'], 'Integer') : 0;
-    $rgid        = isset($_REQUEST['rgid']) ? CRM_Utils_Type::escape($_REQUEST['rgid'], 'Integer') : 0;
+    $gid = CRM_Utils_Request::retrieve('gid', 'Positive');
+    $rgid = CRM_Utils_Request::retrieve('rgid', 'Positive');
     $selected    = isset($_REQUEST['selected']) ? CRM_Utils_Type::escape($_REQUEST['selected'], 'Integer') : 0;
     if ($rowCount < 0) {
       $rowCount = 0;
@@ -802,7 +802,7 @@ LIMIT {$offset}, {$rowCount}
       $searchRows[$count]['weight'] = CRM_Utils_Array::value('weight', $pair);
 
       if (!empty($pairInfo['data']['canMerge'])) {
-        $mergeParams = "reset=1&cid={$pairInfo['entity_id1']}&oid={$pairInfo['entity_id2']}&action=update&rgid={$rgid}";
+        $mergeParams = "reset=1&cid={$pairInfo['entity_id1']}&oid={$pairInfo['entity_id2']}&action=update&rgid={$rgid}&limit=" . CRM_Utils_Request::retrieve('limit', 'Integer');
         if ($gid) {
           $mergeParams .= "&gid={$gid}";
         }

--- a/CRM/Contact/Page/DedupeFind.php
+++ b/CRM/Contact/Page/DedupeFind.php
@@ -60,6 +60,9 @@ class CRM_Contact_Page_DedupeFind extends CRM_Core_Page_Basic {
     $action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 0);
     $context = CRM_Utils_Request::retrieve('context', 'String', $this);
     $limit = CRM_Utils_Request::retrieve('limit', 'Integer', $this);
+    $rgid = CRM_Utils_Request::retrieve('rgid', 'Positive');
+    $urlQry = "reset=1&rgid={$rgid}&gid={$gid}&limit={$limit}";
+    $this->assign('urlQuery', $urlQry);
 
     $session = CRM_Core_Session::singleton();
     $contactIds = $session->get('selectedSearchContactIds');
@@ -70,20 +73,14 @@ class CRM_Contact_Page_DedupeFind extends CRM_Core_Page_Basic {
 
     if ($action & CRM_Core_Action::RENEW) {
       // empty cache
-      $rgid = CRM_Utils_Request::retrieve('rgid', 'Positive', $this, FALSE, 0);
 
       if ($rgid) {
         CRM_Core_BAO_PrevNextCache::deleteItem(NULL, CRM_Dedupe_Merger::getMergeCacheKeyString($rgid, $gid));
       }
-      $urlQry = "reset=1&action=update&rgid={$rgid}";
-      if ($gid) {
-        $urlQry .= "&gid={$gid}";
-      }
-      CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/contact/dedupefind', $urlQry));
+      CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/contact/dedupefind', $urlQry . "&action=update"));
     }
     elseif ($action & CRM_Core_Action::MAP) {
       // do a batch merge if requested
-      $rgid = CRM_Utils_Request::retrieve('rgid', 'Positive', $this, FALSE, 0);
       $result = CRM_Dedupe_Merger::batchMerge($rgid, $gid, 'safe', TRUE, 75);
 
       $skippedCount = CRM_Utils_Request::retrieve('skipped', 'Positive', $this, FALSE, 0);
@@ -104,19 +101,10 @@ class CRM_Contact_Page_DedupeFind extends CRM_Core_Page_Basic {
         }
         $message .= ts(" during the batch merge process with safe mode.");
         CRM_Core_Session::setStatus($message, ts('Merge Complete'), 'success');
-
-        $urlQry = "reset=1&action=update&rgid={$rgid}";
-        if ($gid) {
-          $urlQry .= "&gid={$gid}";
-        }
-        CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/contact/dedupefind', $urlQry));
+        CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/contact/dedupefind', $urlQry . "&action=update"));
       }
       else {
-        $urlQry = "reset=1&action=map&rgid={$rgid}";
-        if ($gid) {
-          $urlQry .= "&gid={$gid}";
-        }
-        $urlQry .= "&skipped={$skippedCount}&merged={$mergedCount}";
+        $urlQry .= "&action=map&skipped={$skippedCount}&merged={$mergedCount}";
         CRM_Utils_System::jsRedirect(
           CRM_Utils_System::url('civicrm/contact/dedupefind', $urlQry),
           ts('Batch Merge Task in progress'),
@@ -129,21 +117,14 @@ class CRM_Contact_Page_DedupeFind extends CRM_Core_Page_Basic {
       $action & CRM_Core_Action::BROWSE
     ) {
       $cid = CRM_Utils_Request::retrieve('cid', 'Positive', $this, FALSE, 0);
-      $rgid = CRM_Utils_Request::retrieve('rgid', 'Positive', $this, FALSE, 0);
       $this->action = CRM_Core_Action::UPDATE;
 
-      $sourceParams = 'snippet=4';
-      if ($gid) {
-        $sourceParams .= "&gid={$gid}";
-      }
-      if ($rgid) {
-        $sourceParams .= "&rgid={$rgid}";
-      }
+      $urlQry .= '&snippet=4';
       if ($context == 'conflicts') {
-        $sourceParams .= "&selected=1";
+        $urlQry .= "&selected=1";
       }
 
-      $this->assign('sourceUrl', CRM_Utils_System::url('civicrm/ajax/dedupefind', $sourceParams, FALSE, NULL, FALSE));
+      $this->assign('sourceUrl', CRM_Utils_System::url('civicrm/ajax/dedupefind', $urlQry, FALSE, NULL, FALSE));
 
       //reload from cache table
       $cacheKeyString = CRM_Dedupe_Merger::getMergeCacheKeyString($rgid, $gid);
@@ -163,14 +144,7 @@ class CRM_Contact_Page_DedupeFind extends CRM_Core_Page_Basic {
       if (empty($this->_mainContacts)) {
         if ($context == 'conflicts') {
           // if the current screen was intended to list only selected contacts, move back to full dupe list
-          $sourceParams = 'reset=1&action=update';
-          if ($gid) {
-            $sourceParams .= "&gid={$gid}";
-          }
-          if ($rgid) {
-            $sourceParams .= "&rgid={$rgid}";
-          }
-          CRM_Utils_System::redirect(CRM_Utils_System::url(CRM_Utils_System::currentPath(), $sourceParams));
+          CRM_Utils_System::redirect(CRM_Utils_System::url(CRM_Utils_System::currentPath(), $urlQry . '&action=update'));
         }
         if ($gid) {
           $foundDupes = $this->get("dedupe_dupes_$gid");
@@ -221,12 +195,12 @@ class CRM_Contact_Page_DedupeFind extends CRM_Core_Page_Basic {
           $session = CRM_Core_Session::singleton();
           if ($this->_cid) {
             $session->pushUserContext(CRM_Utils_System::url('civicrm/contact/deduperules',
-              "action=update&rgid={$this->_rgid}&gid={$this->_gid}&cid={$this->_cid}"
+              $urlQry . "&action=update&cid={$this->_cid}"
             ));
           }
           else {
             $session->pushUserContext(CRM_Utils_System::url('civicrm/contact/dedupefind',
-              "reset=1&action=update&rgid={$this->_rgid}"
+              $urlQry . "&action=update"
             ));
           }
         }

--- a/CRM/Contact/Page/DedupeFind.php
+++ b/CRM/Contact/Page/DedupeFind.php
@@ -35,6 +35,7 @@ class CRM_Contact_Page_DedupeFind extends CRM_Core_Page_Basic {
   protected $_rgid;
   protected $_mainContacts;
   protected $_gid;
+  protected $action;
 
   /**
    * Get BAO Name.
@@ -158,7 +159,7 @@ class CRM_Contact_Page_DedupeFind extends CRM_Core_Page_Basic {
           if (!$foundDupes) {
             $foundDupes = CRM_Dedupe_Finder::dupes($rgid, $contactIds);
           }
-          $this->get("search_dedupe_dupes_$gid", $foundDupes);
+          $this->set("search_dedupe_dupes_$gid", $foundDupes);
         }
         else {
           $foundDupes = $this->get('dedupe_dupes');

--- a/CRM/Contact/Page/DedupeMerge.php
+++ b/CRM/Contact/Page/DedupeMerge.php
@@ -55,15 +55,15 @@ class CRM_Contact_Page_DedupeMerge extends CRM_Core_Page {
    * Build a queue of tasks by dividing dupe pairs in batches.
    */
   public static function getRunner() {
-    $rgid = CRM_Utils_Request::retrieve('rgid', 'Positive', $this, FALSE, 0);
-    $gid  = CRM_Utils_Request::retrieve('gid', 'Positive', $this, FALSE, 0);
+    $rgid = CRM_Utils_Request::retrieve('rgid', 'Positive');
+    $gid  = CRM_Utils_Request::retrieve('gid', 'Positive');
+    $limit  = CRM_Utils_Request::retrieve('limit', 'Positive');
     $action = CRM_Utils_Request::retrieve('action', 'String', CRM_Core_DAO::$_nullObject);
     $mode   = CRM_Utils_Request::retrieve('mode', 'String', CRM_Core_DAO::$_nullObject, FALSE, 'safe');
 
     $cacheKeyString = CRM_Dedupe_Merger::getMergeCacheKeyString($rgid, $gid);
 
-    $urlQry = "reset=1&action=update&rgid={$rgid}";
-    $urlQry = $gid ? ($urlQry . "&gid={$gid}") : $urlQry;
+    $urlQry = "reset=1&action=update&rgid={$rgid}&gid={$gid}&limit={$limit}";
 
     if ($mode == 'aggressive' && !CRM_Core_Permission::check('force merge duplicate contacts')) {
       CRM_Core_Session::setStatus(ts('You do not have permission to force merge duplicate contact records'), ts('Permission Denied'), 'error');

--- a/templates/CRM/Contact/Page/DedupeFind.tpl
+++ b/templates/CRM/Contact/Page/DedupeFind.tpl
@@ -160,11 +160,7 @@
    {/if}
    <a href="{$backURL}" title="{ts}List All Duplicates{/ts}" class="button"><span><i class="crm-i fa-refresh"></i> {ts}List All Duplicates{/ts}</span></a>
 {else}
-   {if $gid}
-      {capture assign=backURL}{crmURL p="civicrm/contact/dedupefind" q="reset=1&rgid=`$rgid`&gid=`$gid`&action=renew" a=1}{/capture}
-   {else}
-      {capture assign=backURL}{crmURL p="civicrm/contact/dedupefind" q="reset=1&rgid=`$rgid`&action=renew" a=1}{/capture}
-   {/if}
+   {capture assign=backURL}{crmURL p="civicrm/contact/dedupefind" q="`$urlQuery`&action=renew" a=1}{/capture}
    <a href="{$backURL}" title="{ts}Refresh List of Duplicates{/ts}" onclick="return confirm('{ts escape="js"}This will refresh the duplicates list. Click OK to proceed.{/ts}');" class="button">
      <span><i class="crm-i fa-refresh"></i> {ts}Refresh Duplicates{/ts}</span>
    </a>

--- a/templates/CRM/Contact/Page/DedupeFind.tpl
+++ b/templates/CRM/Contact/Page/DedupeFind.tpl
@@ -137,27 +137,15 @@
 {if $context eq 'search'}
    {crmButton href=$backURL icon="times"}{ts}Done{/ts}{/crmButton}
 {elseif $context eq 'conflicts'}
-   {if call_user_func(array('CRM_Core_Permission','check'), 'force merge duplicate contacts')}
-     {if $gid}
-       {capture assign=backURL}{crmURL p="civicrm/contact/dedupemerge" q="reset=1&rgid=`$rgid`&gid=`$gid`&action=map&mode=aggressive" a=1}{/capture}
-     {else}
-       {capture assign=backURL}{crmURL p="civicrm/contact/dedupemerge" q="reset=1&rgid=`$rgid`&action=map&mode=aggressive" a=1}{/capture}
-     {/if}
+  {if call_user_func(array('CRM_Core_Permission','check'), 'force merge duplicate contacts')}
+     {capture assign=backURL}{crmURL p="civicrm/contact/dedupemerge" q="`$urlQuery`&action=map&mode=aggressive" a=1}{/capture}
      <a href="{$backURL}" title="{ts}Force Merge Selected Duplicates{/ts}" onclick="return confirm('{ts escape="js"}This will run the batch merge process on the selected duplicates. The operation will run in force merge mode - all selected duplicates will be merged into main contacts even in case of any conflicts. Click OK to proceed if you are sure you wish to run this operation.{/ts}');" class="button"><span><i class="crm-i fa-bolt"></i> {ts}Force Merge Selected Duplicates{/ts}</span></a>
 
-     {if $gid}
-       {capture assign=backURL}{crmURL p="civicrm/contact/dedupemerge" q="reset=1&rgid=`$rgid`&gid=`$gid`&action=map" a=1}{/capture}
-     {else}
-       {capture assign=backURL}{crmURL p="civicrm/contact/dedupemerge" q="reset=1&rgid=`$rgid`&action=map" a=1}{/capture}
-     {/if}
+     {capture assign=backURL}{crmURL p="civicrm/contact/dedupemerge" q="`$urlQuery`&action=map" a=1}{/capture}
      <a href="{$backURL}" title="{ts}Safe Merge Selected Duplicates{/ts}" onclick="return confirm('{ts escape="js"}This will run the batch merge process on the selected duplicates. The operation will run in safe mode - only records with no direct data conflicts will be merged. Click OK to proceed if you are sure you wish to run this operation.{/ts}');" class="button"><span><i class="crm-i fa-compress"></i> {ts}Safe Merge Selected Duplicates{/ts}</span></a>
-   {/if}
+  {/if}
 
-   {if $gid}
-      {capture assign=backURL}{crmURL p="civicrm/contact/dedupefind" q="reset=1&action=update&rgid=`$rgid`&gid=`$gid`" a=1}{/capture}
-   {else}
-      {capture assign=backURL}{crmURL p="civicrm/contact/dedupefind" q="reset=1&action=update&rgid=`$rgid`" a=1}{/capture}
-   {/if}
+  {capture assign=backURL}{crmURL p="civicrm/contact/dedupefind" q="`$urlQuery`&action=update" a=1}{/capture}
    <a href="{$backURL}" title="{ts}List All Duplicates{/ts}" class="button"><span><i class="crm-i fa-refresh"></i> {ts}List All Duplicates{/ts}</span></a>
 {else}
    {capture assign=backURL}{crmURL p="civicrm/contact/dedupefind" q="`$urlQuery`&action=renew" a=1}{/capture}
@@ -165,18 +153,10 @@
      <span><i class="crm-i fa-refresh"></i> {ts}Refresh Duplicates{/ts}</span>
    </a>
 
-   {if $gid}
-      {capture assign=backURL}{crmURL p="civicrm/contact/dedupemerge" q="reset=1&rgid=`$rgid`&gid=`$gid`&action=map" a=1}{/capture}
-   {else}
-      {capture assign=backURL}{crmURL p="civicrm/contact/dedupemerge" q="reset=1&rgid=`$rgid`&action=map" a=1}{/capture}
-   {/if}
+  {capture assign=backURL}{crmURL p="civicrm/contact/dedupemerge" q="`$urlQuery`&action=map" a=1}{/capture}
    <a href="{$backURL}" title="{ts}Batch Merge Duplicate Contacts{/ts}" onclick="return confirm('{ts escape="js"}This will run the batch merge process on the selected duplicates. The operation will run in safe mode - only records with no direct data conflicts will be merged. Click OK to proceed if you are sure you wish to run this operation.{/ts}');" class="button"><span><i class="crm-i fa-compress"></i> {ts}Batch Merge Selected Duplicates{/ts}</span></a>
 
-   {if $gid}
-      {capture assign=backURL}{crmURL p="civicrm/contact/dedupemerge" q="reset=1&rgid=`$rgid`&gid=`$gid`" a=1}{/capture}
-   {else}
-      {capture assign=backURL}{crmURL p="civicrm/contact/dedupemerge" q="reset=1&rgid=`$rgid`" a=1}{/capture}
-   {/if}
+   {capture assign=backURL}{crmURL p="civicrm/contact/dedupemerge" q=$urlQuery a=1}{/capture}
    <a href="{$backURL}" title="{ts}Batch Merge Duplicate Contacts{/ts}" onclick="return confirm('{ts escape="js"}This will run the batch merge process on the listed duplicates. The operation will run in safe mode - only records with no direct data conflicts will be merged. Click OK to proceed if you are sure you wish to run this operation.{/ts}');" class="button"><span><i class="crm-i fa-compress"></i> {ts}Batch Merge All Duplicates{/ts}</span></a>
 
    <a href='#' title="{ts}Flip Selected Duplicates{/ts}" class="crm-dedupe-flip-selections button"><span><i class="crm-i fa-exchange"></i> {ts}Flip Selected Duplicates{/ts}</span></a>


### PR DESCRIPTION
- [CRM-19197: Stop Merge links from dropping the limit parameter](https://issues.civicrm.org/jira/browse/CRM-19197)
  - [CRM-19198: Add form merge hook call to dedupe form](https://issues.civicrm.org/jira/browse/CRM-19198)
