### PR TITLE
CRM-19207: Fix succeeding of checkTriggerViewPermission while have no CREATE VIEW permission

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1884,8 +1884,8 @@ SELECT contact_id
     $errorScope = CRM_Core_TemporaryErrorScope::ignoreException();
     $dao = new CRM_Core_DAO();
     if ($view) {
-      $dao->query('CREATE OR REPLACE VIEW civicrm_domain_view AS SELECT * FROM civicrm_domain');
-      if (PEAR::getStaticProperty('DB_DataObject', 'lastError')) {
+      $result = $dao->query('CREATE OR REPLACE VIEW civicrm_domain_view AS SELECT * FROM civicrm_domain');
+      if (PEAR::getStaticProperty('DB_DataObject', 'lastError') || is_a($result, 'DB_Error')) {
         return FALSE;
       }
     }


### PR DESCRIPTION
Fix succeeding of checkTriggerViewPermission while have no CREATE VIEW permission

---
- [CRM-19207: checkTriggerViewPermission succeeds despite lacking CREATE VIEW permission](https://issues.civicrm.org/jira/browse/CRM-19207)
