### PR TITLE
CRM-19209 - Fix create group without selecting parent

### DIFF
--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -384,7 +384,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
 
     // CRM-19068.
     // Validate parents parameter when creating group.
-    if (isset($params['parents'])) {
+    if (!empty($params['parents'])) {
       if (is_array($params['parents'])) {
         foreach ($params['parents'] as $parent => $dc) {
           CRM_Utils_Type::validate($parent, 'Integer');

--- a/tests/phpunit/api/v3/GroupTest.php
+++ b/tests/phpunit/api/v3/GroupTest.php
@@ -128,14 +128,16 @@ class api_v3_GroupTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test Group create with Group Type
+   * Test Group create with Group Type and Parent
    */
-  public function testgroupCreateWithGroupType() {
+  public function testGroupCreateWithTypeAndParent() {
     $params = array(
       'name' => 'Test Group type',
       'title' => 'Test Group Type',
       'description' => 'Test Group with Group Type',
       'is_active' => 1,
+      //check for empty parent
+      'parents' => "",
       'visibility' => 'Public Pages',
       'group_type' => array(1, 2),
     );
@@ -144,14 +146,21 @@ class api_v3_GroupTest extends CiviUnitTestCase {
     $group = $result['values'][$result['id']];
     $this->assertEquals($group['name'], "Test Group type");
     $this->assertEquals($group['is_active'], 1);
+    $this->assertEquals($group['parents'], "");
     $this->assertEquals($group['group_type'], $params['group_type']);
-    $this->groupDelete($result['id']);
 
-    //assert single value for group_type
-    $params['group_type'] = 2;
+    //assert single value for group_type and parent
+    $params = array_merge($params, array(
+        'name' => 'Test Group 2',
+        'title' => 'Test Group 2',
+        'group_type' => 2,
+        'parents' => $result['id'],
+      )
+    );
     $result = $this->callAPISuccess('Group', 'create', $params);
     $group = $result["values"][$result['id']];
     $this->assertEquals($group['group_type'], array($params['group_type']));
+    $this->assertEquals($group['parents'], $params['parents']);
   }
 
   public function testGetNonExistingGroup() {


### PR DESCRIPTION
- [CRM-19209: Create Group without selecting parent throws fatal error on dmaster](https://issues.civicrm.org/jira/browse/CRM-19209)
