### PR TITLE
CRM-19209 fix regression found when parents param is empty CRM-18591

### DIFF
--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -368,8 +368,11 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
     if (isset($params['group_type'])) {
       if (is_array($params['group_type'])) {
         $params['group_type'] = CRM_Core_DAO::VALUE_SEPARATOR . implode(CRM_Core_DAO::VALUE_SEPARATOR,
-            array_keys($params['group_type'])
+            $params['group_type']
           ) . CRM_Core_DAO::VALUE_SEPARATOR;
+      }
+      else {
+        $params['group_type'] = CRM_Core_DAO::VALUE_SEPARATOR . $params['group_type'] . CRM_Core_DAO::VALUE_SEPARATOR;
       }
     }
     else {
@@ -389,7 +392,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
 
     // CRM-19068.
     // Validate parents parameter when creating group.
-    if (isset($params['parents'])) {
+    if (!empty($params['parents'])) {
       if (is_array($params['parents'])) {
         foreach ($params['parents'] as $parent => $dc) {
           CRM_Utils_Type::validate($parent, 'Integer');

--- a/CRM/Group/Form/Edit.php
+++ b/CRM/Group/Form/Edit.php
@@ -395,6 +395,17 @@ WHERE  title = %1
 
       $params['is_reserved'] = CRM_Utils_Array::value('is_reserved', $params, FALSE);
 
+      $groupTypeIds = array();
+      $groupType = CRM_Utils_Array::value('group_type', $params);
+      if (is_array($groupType)) {
+        foreach ($groupType as $type => $selected) {
+          if ($selected) {
+            $groupTypeIds[] = $type;
+          }
+        }
+      }
+      $params['group_type'] = $groupTypeIds;
+
       $customFields = CRM_Core_BAO_CustomField::getFields('Group');
       $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params,
         $customFields,

--- a/tests/phpunit/api/v3/GroupTest.php
+++ b/tests/phpunit/api/v3/GroupTest.php
@@ -128,6 +128,40 @@ class api_v3_GroupTest extends CiviUnitTestCase {
     }
   }
 
+  /**
+   * Test Group create with Group Type and Parent
+   */
+  public function testGroupCreateWithTypeAndParent() {
+    $params = array(
+      'name' => 'Test Group type',
+      'title' => 'Test Group Type',
+      'description' => 'Test Group with Group Type',
+      'is_active' => 1,
+      //check for empty parent
+      'parents' => "",
+      'visibility' => 'Public Pages',
+      'group_type' => array(1, 2),
+    );
+    $result = $this->callAPISuccess('Group', 'create', $params);
+    $group = $result['values'][$result['id']];
+    $this->assertEquals($group['name'], "Test Group type");
+    $this->assertEquals($group['is_active'], 1);
+    $this->assertEquals($group['parents'], "");
+    $this->assertEquals($group['group_type'], $params['group_type']);
+    //assert single value for group_type and parent
+    $params = array_merge($params, array(
+        'name' => 'Test Group 2',
+        'title' => 'Test Group 2',
+        'group_type' => 2,
+        'parents' => $result['id'],
+      )
+    );
+    $result = $this->callAPISuccess('Group', 'create', $params);
+    $group = $result["values"][$result['id']];
+    $this->assertEquals($group['group_type'], array($params['group_type']));
+    $this->assertEquals($group['parents'], $params['parents']);
+  }
+
   public function testGetNonExistingGroup() {
     $params = array();
     $params['title'] = 'No such group Exist';

--- a/xml/schema/Contact/Group.xml
+++ b/xml/schema/Contact/Group.xml
@@ -119,6 +119,9 @@
     <title>Group Type</title>
     <length>128</length>
     <comment>FK to group type</comment>
+    <pseudoconstant>
+      <optionGroupName>group_type</optionGroupName>
+    </pseudoconstant>
     <add>1.9</add>
   </field>
   <field>


### PR DESCRIPTION
fix issue where group_type param in api was strange fixed in master

---
- [CRM-19209: Create Group without selecting parent throws fatal error on dmaster](https://issues.civicrm.org/jira/browse/CRM-19209)
- [CRM-18591: group_type parameter ignored when using API to create group](https://issues.civicrm.org/jira/browse/CRM-18591)
