### PR TITLE
CRM-19214 - Loop on parent row instead of first td element

### DIFF
--- a/templates/CRM/Group/Form/Search.tpl
+++ b/templates/CRM/Group/Form/Search.tpl
@@ -142,8 +142,10 @@
         //Reload table after draw
         $(settings.nTable).trigger('crmLoad');
         if (parentsOnly) {
-          $('tbody tr.crm-group-parent td:first', settings.nTable).each( function() {
-            $(this).prepend('{/literal}<span class="collapsed show-children" title="{ts}show child groups{/ts}"/></span>{literal}').find('div').css({'display': 'inline'});
+          $('tbody tr.crm-group-parent', settings.nTable).each( function() {
+            $(this).find('td:first')
+              .prepend('{/literal}<span class="collapsed show-children" title="{ts}show child groups{/ts}"/></span>{literal}')
+              .find('div').css({'display': 'inline'});
           });
         }
       }


### PR DESCRIPTION
- [CRM-19214: Manage Groups tree not working](https://issues.civicrm.org/jira/browse/CRM-19214)
