### PR TITLE
CRM-19222 Export: temp table field length at least 255 for strings

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -1356,12 +1356,9 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
           break;
 
         case CRM_Utils_Type::T_STRING:
-          if (isset($query->_fields[$field]['maxlength'])) {
-            $sqlColumns[$fieldName] = "$fieldName varchar({$query->_fields[$field]['maxlength']})";
-          }
-          else {
-            $sqlColumns[$fieldName] = "$fieldName varchar(255)";
-          }
+          // May be option labels, which could be up to 255 characters
+          $length = max(255, CRM_Utils_Array::value('maxlength', $query->_fields[$field]));
+          $sqlColumns[$fieldName] = "$fieldName varchar($length)";
           break;
 
         case CRM_Utils_Type::T_TEXT:
@@ -1420,7 +1417,8 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
 
             switch ($query->_fields[$field]['data_type']) {
               case 'String':
-                $length = empty($query->_fields[$field]['text_length']) ? 255 : $query->_fields[$field]['text_length'];
+                // May be option labels, which could be up to 255 characters
+                $length = max(255, CRM_Utils_Array::value('text_length', $query->_fields[$field]));
                 $sqlColumns[$fieldName] = "$fieldName varchar($length)";
                 break;
 


### PR DESCRIPTION
String fields in exports might be the option labels, which can be up to 255 characters long.  This makes sure that the field length in the temp table is at least that long.

---
- [CRM-19222: Data too long on export including custom field](https://issues.civicrm.org/jira/browse/CRM-19222)
