### PR TITLE
CRM-19222 Export: temp table field length at least 255 for strings

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -1312,7 +1312,7 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
 
         case CRM_Utils_Type::T_STRING:
           // May be option labels, which could be up to 255 characters
-          $length = max(255, CRM_Utils_Array::value('maxlength', $query->_fields[$field]));
+          $length = max(512, CRM_Utils_Array::value('maxlength', $query->_fields[$field]));
           $sqlColumns[$fieldName] = "$fieldName varchar($length)";
           break;
 
@@ -1373,7 +1373,7 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
             switch ($query->_fields[$field]['data_type']) {
               case 'String':
                 // May be option labels, which could be up to 255 characters
-                $length = max(255, CRM_Utils_Array::value('text_length', $query->_fields[$field]));
+                $length = max(512, CRM_Utils_Array::value('text_length', $query->_fields[$field]));
                 $sqlColumns[$fieldName] = "$fieldName varchar($length)";
                 break;
 

--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -1311,12 +1311,9 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
           break;
 
         case CRM_Utils_Type::T_STRING:
-          if (isset($query->_fields[$field]['maxlength'])) {
-            $sqlColumns[$fieldName] = "$fieldName varchar({$query->_fields[$field]['maxlength']})";
-          }
-          else {
-            $sqlColumns[$fieldName] = "$fieldName varchar(255)";
-          }
+          // May be option labels, which could be up to 255 characters
+          $length = max(255, CRM_Utils_Array::value('maxlength', $query->_fields[$field]));
+          $sqlColumns[$fieldName] = "$fieldName varchar($length)";
           break;
 
         case CRM_Utils_Type::T_TEXT:
@@ -1375,7 +1372,8 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
 
             switch ($query->_fields[$field]['data_type']) {
               case 'String':
-                $length = empty($query->_fields[$field]['text_length']) ? 255 : $query->_fields[$field]['text_length'];
+                // May be option labels, which could be up to 255 characters
+                $length = max(255, CRM_Utils_Array::value('text_length', $query->_fields[$field]));
                 $sqlColumns[$fieldName] = "$fieldName varchar($length)";
                 break;
 


### PR DESCRIPTION
The 4.7 equivalent of #8876

---
- [CRM-19222: Data too long on export including custom field](https://issues.civicrm.org/jira/browse/CRM-19222)
