### PR TITLE
CRM-19224 - Correct get-call for apccache

### DIFF
--- a/CRM/Utils/Cache/APCcache.php
+++ b/CRM/Utils/Cache/APCcache.php
@@ -87,7 +87,7 @@ class CRM_Utils_Cache_APCcache implements CRM_Utils_Cache_Interface {
    *
    * @return mixed
    */
-  public function &get($key) {
+  public function get($key) {
     return apc_fetch($this->_prefix . $key);
   }
 


### PR DESCRIPTION
Otherwise a php notice pops up (Notice: Only variable references should be returned by reference) and civicrm doesn't even load then ...

---
- [CRM-19224: Correct get-call in apccache](https://issues.civicrm.org/jira/browse/CRM-19224)
