### PR TITLE
CRM-19776: Allow to set component for case types hook

### DIFF
--- a/CRM/Case/ManagedEntities.php
+++ b/CRM/Case/ManagedEntities.php
@@ -71,17 +71,17 @@ class CRM_Case_ManagedEntities {
     foreach ($actTypes as $actType) {
       $managed = array(
         'module' => 'civicrm',
-        'name' => "civicase:act:$actType",
+        'name' => "civicase:act:" . $actType['name'],
         'entity' => 'OptionValue',
         'update' => 'never',
         'cleanup' => 'unused',
         'params' => array(
           'version' => 3,
           'option_group_id' => 'activity_type',
-          'label' => $actType,
-          'name' => $actType,
-          'description' => $actType,
-          'component_id' => 'CiviCase',
+          'label' => $actType['name'],
+          'name' => $actType['name'],
+          'description' => $actType['name'],
+          'component_id' => $actType['component_name'],
         ),
       );
 

--- a/CRM/Case/XMLProcessor/Process.php
+++ b/CRM/Case/XMLProcessor/Process.php
@@ -318,9 +318,15 @@ class CRM_Case_XMLProcessor_Process extends CRM_Case_XMLProcessor {
   public function getDeclaredActivityTypes($caseTypeXML) {
     $result = array();
 
+    $componentName = 'CiviCase';
+    if (!empty($caseTypeXML->componentName)) {
+      $componentName = (string) $caseTypeXML->componentName;
+    }
+
     if (!empty($caseTypeXML->ActivityTypes) && $caseTypeXML->ActivityTypes->ActivityType) {
       foreach ($caseTypeXML->ActivityTypes->ActivityType as $activityTypeXML) {
-        $result[] = (string) $activityTypeXML->name;
+        $result[] = array('name' => (string) $activityTypeXML->name,
+          'component_name' =>  $componentName);
       }
     }
 
@@ -328,13 +334,14 @@ class CRM_Case_XMLProcessor_Process extends CRM_Case_XMLProcessor {
       foreach ($caseTypeXML->ActivitySets->ActivitySet as $activitySetXML) {
         if ($activitySetXML->ActivityTypes && $activitySetXML->ActivityTypes->ActivityType) {
           foreach ($activitySetXML->ActivityTypes->ActivityType as $activityTypeXML) {
-            $result[] = (string) $activityTypeXML->name;
+            $result[] = array('name' => (string) $activityTypeXML->name,
+              'component_name' =>  $componentName);
           }
         }
       }
     }
 
-    $result = array_unique($result);
+    $result = array_map("unserialize", array_unique(array_map("serialize", $result)));
     sort($result);
     return $result;
   }

--- a/CRM/Case/XMLProcessor/Process.php
+++ b/CRM/Case/XMLProcessor/Process.php
@@ -330,7 +330,8 @@ class CRM_Case_XMLProcessor_Process extends CRM_Case_XMLProcessor {
       foreach ($caseTypeXML->ActivityTypes->ActivityType as $activityTypeXML) {
         $result[] = array(
           'name' => (string) $activityTypeXML->name,
-          'component_name' => $componentName);
+          'component_name' => $componentName
+        );
       }
     }
 
@@ -340,7 +341,8 @@ class CRM_Case_XMLProcessor_Process extends CRM_Case_XMLProcessor {
           foreach ($activitySetXML->ActivityTypes->ActivityType as $activityTypeXML) {
             $result[] = array(
               'name' => (string) $activityTypeXML->name,
-              'component_name' => $componentName);
+              'component_name' => $componentName
+            );
           }
         }
       }

--- a/CRM/Case/XMLProcessor/Process.php
+++ b/CRM/Case/XMLProcessor/Process.php
@@ -325,8 +325,9 @@ class CRM_Case_XMLProcessor_Process extends CRM_Case_XMLProcessor {
 
     if (!empty($caseTypeXML->ActivityTypes) && $caseTypeXML->ActivityTypes->ActivityType) {
       foreach ($caseTypeXML->ActivityTypes->ActivityType as $activityTypeXML) {
-        $result[] = array('name' => (string) $activityTypeXML->name,
-          'component_name' =>  $componentName);
+        $result[] = array(
+          'name' => (string) $activityTypeXML->name,
+          'component_name' => $componentName);
       }
     }
 
@@ -334,8 +335,9 @@ class CRM_Case_XMLProcessor_Process extends CRM_Case_XMLProcessor {
       foreach ($caseTypeXML->ActivitySets->ActivitySet as $activitySetXML) {
         if ($activitySetXML->ActivityTypes && $activitySetXML->ActivityTypes->ActivityType) {
           foreach ($activitySetXML->ActivityTypes->ActivityType as $activityTypeXML) {
-            $result[] = array('name' => (string) $activityTypeXML->name,
-              'component_name' =>  $componentName);
+            $result[] = array(
+              'name' => (string) $activityTypeXML->name,
+              'component_name' => $componentName);
           }
         }
       }

--- a/CRM/Case/XMLProcessor/Process.php
+++ b/CRM/Case/XMLProcessor/Process.php
@@ -313,7 +313,10 @@ class CRM_Case_XMLProcessor_Process extends CRM_Case_XMLProcessor {
 
   /**
    * @param SimpleXMLElement $caseTypeXML
-   * @return array<string> symbolic activity-type names
+   * @return array[]
+   *   List of activity types along with their component name. Each activity type is an array with keys:
+   *    'name': string; activity type name
+   *    'component_name': string; activity type component name ( e.g : CiviCase )
    */
   public function getDeclaredActivityTypes($caseTypeXML) {
     $result = array();

--- a/CRM/Case/XMLRepository.php
+++ b/CRM/Case/XMLRepository.php
@@ -231,7 +231,7 @@ class CRM_Case_XMLRepository {
 
   /**
    * @return array[]
-   *   @see CRM_Case_XMLProcessor_Process::getDeclaredActivityTypes()
+   * @see CRM_Case_XMLProcessor_Process::getDeclaredActivityTypes()
    */
   public function getAllDeclaredActivityTypes() {
     $result = array();

--- a/CRM/Case/XMLRepository.php
+++ b/CRM/Case/XMLRepository.php
@@ -241,7 +241,7 @@ class CRM_Case_XMLRepository {
       $result = array_merge($result, $p->getDeclaredActivityTypes($caseTypeXML));
     }
 
-    $result = array_unique($result);
+    $result = array_map("unserialize", array_unique(array_map("serialize", $result)));
     sort($result);
     return $result;
   }
@@ -276,7 +276,10 @@ class CRM_Case_XMLRepository {
     $count = 0;
     foreach ($this->getAllCaseTypes() as $caseTypeName) {
       $caseTypeXML = $this->retrieve($caseTypeName);
-      if (in_array($activityType, $p->getDeclaredActivityTypes($caseTypeXML))) {
+      $declaredActivityTypes = array_map(function($row) {
+        return $row['name'];
+      }, $p->getDeclaredActivityTypes($caseTypeXML));
+      if (in_array($activityType, $declaredActivityTypes)) {
         $count++;
       }
     }

--- a/CRM/Case/XMLRepository.php
+++ b/CRM/Case/XMLRepository.php
@@ -230,7 +230,8 @@ class CRM_Case_XMLRepository {
   }
 
   /**
-   * @return array<string> symbolic-names of activity-types
+   * @return array[]
+   *   @see CRM_Case_XMLProcessor_Process::getDeclaredActivityTypes()
    */
   public function getAllDeclaredActivityTypes() {
     $result = array();

--- a/tests/phpunit/CRM/Case/XMLRepositoryTest.php
+++ b/tests/phpunit/CRM/Case/XMLRepositoryTest.php
@@ -109,9 +109,9 @@ class CRM_Case_XMLRepositoryTest extends CiviUnitTestCase {
 
     // omitted: 'Single Activity Type'
     $expected = array(
-      array('CiviCase' => 'First Activity Type'),
-      array('CiviCase' => 'Second Activity Type'),
-      array('CiviCase' => 'Third Activity Type'));
+      array('component_name' => 'CiviCase', 'name' => 'First Activity Type'),
+      array('component_name' => 'CiviCase', 'name' => 'Second Activity Type'),
+      array('component_name' => 'CiviCase', 'name' => 'Third Activity Type'));
     $actual = $repo->getAllDeclaredActivityTypes();
     $this->assertEquals($expected, $actual);
   }

--- a/tests/phpunit/CRM/Case/XMLRepositoryTest.php
+++ b/tests/phpunit/CRM/Case/XMLRepositoryTest.php
@@ -108,7 +108,10 @@ class CRM_Case_XMLRepositoryTest extends CiviUnitTestCase {
     );
 
     // omitted: 'Single Activity Type'
-    $expected = array('First Activity Type', 'Second Activity Type', 'Third Activity Type');
+    $expected = array(
+      array('CiviCase' => 'First Activity Type'),
+      array('CiviCase' => 'Second Activity Type'),
+      array('CiviCase' => 'Third Activity Type'));
     $actual = $repo->getAllDeclaredActivityTypes();
     $this->assertEquals($expected, $actual);
   }


### PR DESCRIPTION
The current problem with created case types via hook_civicrm_caseTypes or hook_civicrm_managed is that it doesn't allow you to specify the component ID for the attached activity types and CiviCase component will be used by default.

This change allow developers to specify the component for managed case types in the XML file , and if it defined , it will be used to specify the component for the managed activities for that case type .. otherwise ; the default CiviCase component will be used .

Example usage :

if an extension define  a new component let's call it "TestComponent" , and the developer want to create a new case type when installing this extension let's call it "TestCase" and there will be some activities attached to this case type but they have to be part of "TestComponent" not "CiviCase" component ..

then a file called at xml/case/TestCase.xml can be created which contain something like this :

``` xml

<?xml version="1.0" encoding="iso-8859-1" ?>

<CaseType>
  <name>TestCase</name>
  <weight>100</weight>
  <componentName>TestComponent</componentName>
  <ActivityTypes>
    <ActivityType>
      <name>Background Check</name>
    </ActivityType>
    <ActivityType>
      <name>References Check</name>
    </ActivityType>
  </ActivityTypes>
</CaseType>
```

in this case the two activities "Background Check" and "References Check" when get created via managed entities handler will have component_id = [TestComponent ID].

but in case "<componentName>TestComponent</componentName>"  is not defined in the xml file , the default "CiviCase" will be used .

---

 * [CRM-19776: CaseTypes hook doesn't allow you to specify the component for child activity types](https://issues.civicrm.org/jira/browse/CRM-19776)