### PR TITLE
CRM-9484: Handle message formats more robustly

### DIFF
--- a/CRM/Utils/Mail/Incoming.php
+++ b/CRM/Utils/Mail/Incoming.php
@@ -83,6 +83,10 @@ class CRM_Utils_Mail_Incoming {
       return self::formatMailMultipart($part, $attachments);
     }
 
+    if ($part instanceof ezcMailDeliveryStatus) {
+      return self::formatMailDeliveryStatus($part);
+    }
+
     // CRM-19111 - Handle blank emails with a subject.
     if (!$part) {
       return NULL;
@@ -116,6 +120,10 @@ class CRM_Utils_Mail_Incoming {
 
     if ($part instanceof ezcMailMultipartReport) {
       return self::formatMailMultipartReport($part, $attachments);
+    }
+
+    if ($part instanceof ezcMailDeliveryStatus) {
+      return self::formatMailDeliveryStatus($part);
     }
 
     CRM_Core_Error::fatal(ts("No clue about the %1", array(1 => get_class($part))));
@@ -224,6 +232,19 @@ class CRM_Utils_Mail_Incoming {
       $t .= self::formatMailPart($reportPart, $attachments);
     }
     $t .= "-REPORT END---\n";
+    return $t;
+  }
+
+  /**
+   * @param $part
+   *
+   * @return string
+   */
+  public function formatMailDeliveryStatus($part) {
+    $t = '';
+    $t .= "-DELIVERY STATUS BEGIN-\n";
+    $t .= $part->generateBody();
+    $t .= "-DELIVERY STATUS END-\n";
     return $t;
   }
 

--- a/CRM/Utils/Mail/Incoming.php
+++ b/CRM/Utils/Mail/Incoming.php
@@ -92,7 +92,7 @@ class CRM_Utils_Mail_Incoming {
       return NULL;
     }
 
-    CRM_Core_Error::fatal(ts("No clue about the %1", array(1 => get_class($part))));
+    return self::formatMailUnrecognisedPart($part);
   }
 
   /**
@@ -126,7 +126,7 @@ class CRM_Utils_Mail_Incoming {
       return self::formatMailDeliveryStatus($part);
     }
 
-    CRM_Core_Error::fatal(ts("No clue about the %1", array(1 => get_class($part))));
+    return self::formatMailUnrecognisedPart($part);
   }
 
   /**
@@ -246,6 +246,15 @@ class CRM_Utils_Mail_Incoming {
     $t .= $part->generateBody();
     $t .= "-DELIVERY STATUS END-\n";
     return $t;
+  }
+
+  /**
+   * @param $part
+   *
+   * @return string
+   */
+  public function formatUnrecognisedPart($part) {
+    return ts('Unrecognised message part of type "%1".', array('%1' => get_class($part)));
   }
 
   /**

--- a/CRM/Utils/Mail/Incoming.php
+++ b/CRM/Utils/Mail/Incoming.php
@@ -254,6 +254,7 @@ class CRM_Utils_Mail_Incoming {
    * @return string
    */
   public function formatUnrecognisedPart($part) {
+    CRM_Core_Error::debug_log_message(ts('CRM_Utils_Mail_Incoming: Unable to handle message part of type "%1".', array('%1' => get_class($part))));
     return ts('Unrecognised message part of type "%1".', array('%1' => get_class($part)));
   }
 


### PR DESCRIPTION
- Handle messages containing an ezcMailDeliveryStatus
- Handle any other unknowns with an informative message rather than giving up entirely

---
- [CRM-9484: running EmailProcessor.php causes Fatal Error and creates and empty contact record](https://issues.civicrm.org/jira/browse/CRM-9484)
