### PR TITLE
CRM-19223 - Tighter permissions for migration scripts

### DIFF
--- a/bin/encryptDB.php
+++ b/bin/encryptDB.php
@@ -25,6 +25,13 @@
  +--------------------------------------------------------------------+
  */
 
+die("This script is disabled because it is dangerous. If you need it, please duplicate it elsewhere and provide your own secure workflow. This example file will be removed in the future.");
+
+// TIP: If/when we do delete this file, take care to affirmatively check for
+// deletion as part of the status-check infrastructure. Some upgrade workflows
+// don't clear out old files properly, and there's no telling the history
+// of upgrades that have been performed.
+
 /**
  *
  * @package CRM

--- a/bin/encryptDB.php
+++ b/bin/encryptDB.php
@@ -93,6 +93,9 @@ function run() {
 
   // this does not return on failure
   CRM_Utils_System::authenticateScript(TRUE);
+  if (!CRM_Core_Permission::check('administer CiviCRM')) {
+    CRM_Utils_System::authenticateAbort("User does not have required permission (administer CiviCRM).\n", TRUE);
+  }
 
   encryptDB();
 }

--- a/bin/migrate/export.php
+++ b/bin/migrate/export.php
@@ -39,6 +39,9 @@ function run() {
 
   // this does not return on failure
   CRM_Utils_System::authenticateScript(TRUE);
+  if (!CRM_Core_Permission::check('administer CiviCRM')) {
+    CRM_Utils_System::authenticateAbort("User does not have required permission (administer CiviCRM).\n", TRUE);
+  }
 
   require_once 'CRM/Utils/Migrate/Export.php';
   $export = new CRM_Utils_Migrate_Export();

--- a/bin/migrate/exportJSON.php
+++ b/bin/migrate/exportJSON.php
@@ -38,7 +38,7 @@ function run() {
   $config = CRM_Core_Config::singleton();
 
   // this does not return on failure
-  CRM_Utils_System::authenticateScript( true );
+  CRM_Utils_System::authenticateScript(TRUE);
   if (!CRM_Core_Permission::check('administer CiviCRM')) {
     CRM_Utils_System::authenticateAbort("User does not have required permission (administer CiviCRM).\n", TRUE);
   }

--- a/bin/migrate/exportJSON.php
+++ b/bin/migrate/exportJSON.php
@@ -38,7 +38,11 @@ function run() {
   $config = CRM_Core_Config::singleton();
 
   // this does not return on failure
-  // CRM_Utils_System::authenticateScript( true );
+  CRM_Utils_System::authenticateScript( true );
+  if (!CRM_Core_Permission::check('administer CiviCRM')) {
+    CRM_Utils_System::authenticateAbort("User does not have required permission (administer CiviCRM).\n", TRUE);
+  }
+
   $params = array();
 
   require_once 'CRM/Utils/Migrate/ExportJSON.php';

--- a/bin/migrate/import.php
+++ b/bin/migrate/import.php
@@ -46,6 +46,9 @@ function run() {
 
   // this does not return on failure
   CRM_Utils_System::authenticateScript(TRUE);
+  if (!CRM_Core_Permission::check('administer CiviCRM')) {
+    CRM_Utils_System::authenticateAbort("User does not have required permission (administer CiviCRM).\n", TRUE);
+  }
 
   require_once 'CRM/Utils/Migrate/Import.php';
   $import = new CRM_Utils_Migrate_Import();

--- a/bin/migrate/importJSON.php
+++ b/bin/migrate/importJSON.php
@@ -38,7 +38,7 @@ function run() {
   $config = CRM_Core_Config::singleton();
 
   // this does not return on failure
-  CRM_Utils_System::authenticateScript( true );
+  CRM_Utils_System::authenticateScript(TRUE);
   if (!CRM_Core_Permission::check('administer CiviCRM')) {
     CRM_Utils_System::authenticateAbort("User does not have required permission (administer CiviCRM).\n", TRUE);
   }

--- a/bin/migrate/importJSON.php
+++ b/bin/migrate/importJSON.php
@@ -38,7 +38,10 @@ function run() {
   $config = CRM_Core_Config::singleton();
 
   // this does not return on failure
-  // CRM_Utils_System::authenticateScript( true );
+  CRM_Utils_System::authenticateScript( true );
+  if (!CRM_Core_Permission::check('administer CiviCRM')) {
+    CRM_Utils_System::authenticateAbort("User does not have required permission (administer CiviCRM).\n", TRUE);
+  }
 
   require_once 'CRM/Utils/Migrate/ImportJSON.php';
   $import = new CRM_Utils_Migrate_ImportJSON();

--- a/bin/migrate/move.php
+++ b/bin/migrate/move.php
@@ -40,6 +40,9 @@ function run() {
 
   // this does not return on failure
   CRM_Utils_System::authenticateScript(TRUE);
+  if (!CRM_Core_Permission::check('administer CiviCRM')) {
+    CRM_Utils_System::authenticateAbort("User does not have required permission (administer CiviCRM).\n", TRUE);
+  }
 
   require_once 'CRM/Core/BAO/ConfigSetting.php';
   $moveStatus = CRM_Core_BAO_ConfigSetting::doSiteMove();


### PR DESCRIPTION
To test this, I created Drupal users with different permissions (e.g. `administer CiviCRM` versus no particular permissions) and checked the outputs before/after the patch. I specifically tested the change with:
- `migrate/export.php`
- `migrate/import.php`
- `migrate/exportJSON.php`
- `migrate/importJSON.php`

but did not specifically test:
- `migrate/move.php`
- `encryptDB.php`

---
- [CRM-19223](https://issues.civicrm.org/jira/browse/CRM-19223)
