### PR TITLE
CRM-19248

### DIFF
--- a/js/Common.js
+++ b/js/Common.js
@@ -752,6 +752,7 @@ if (!CRM.vars) CRM.vars = {};
         "aaSorting": [],
         "dom": '<"crm-datatable-pager-top"lfp>rt<"crm-datatable-pager-bottom"ip>',
         "pageLength": 25,
+        "pagingType": "full_numbers",
         "drawCallback": function(settings) {
           //Add data attributes to cells
           $('thead th', settings.nTable).each( function( index ) {


### PR DESCRIPTION
Restoring pagingType from 4.5.4

---
- [CRM-19248: Missing css styles for paging_simple_numbers](https://issues.civicrm.org/jira/browse/CRM-19248)
