### PR TITLE
CRM-17824 Membership Report: Detail-receive date unmatched with Contribution date

### DIFF
--- a/CRM/Report/Form/Member/Detail.php
+++ b/CRM/Report/Form/Member/Detail.php
@@ -295,10 +295,11 @@ class CRM_Report_Form_Member_Detail extends CRM_Report_Form {
             // CRM-17824: receive date should be most recent date
             if ($fieldName == 'receive_date') {
               $select[] = "MAX({$field['dbAlias']}) as {$tableName}_{$fieldName}";
-            } else {
+            } 
+            else {
               $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
             }
-            
+
             if (array_key_exists('title', $field)) {
               $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'];
             }

--- a/CRM/Report/Form/Member/Detail.php
+++ b/CRM/Report/Form/Member/Detail.php
@@ -291,7 +291,14 @@ class CRM_Report_Form_Member_Detail extends CRM_Report_Form {
             elseif ($tableName == 'civicrm_contribution') {
               $this->_contribField = TRUE;
             }
-            $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
+
+            // CRM-17824: receive date should be most recent date
+            if ($fieldName == 'receive_date') {
+              $select[] = "MAX({$field['dbAlias']}) as {$tableName}_{$fieldName}";
+            } else {
+              $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
+            }
+            
             if (array_key_exists('title', $field)) {
               $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'];
             }

--- a/CRM/Report/Form/Member/Detail.php
+++ b/CRM/Report/Form/Member/Detail.php
@@ -295,7 +295,7 @@ class CRM_Report_Form_Member_Detail extends CRM_Report_Form {
             // CRM-17824: receive date should be most recent date
             if ($fieldName == 'receive_date') {
               $select[] = "MAX({$field['dbAlias']}) as {$tableName}_{$fieldName}";
-            } 
+            }
             else {
               $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
             }


### PR DESCRIPTION
This should fix [CRM-17824](https://issues.civicrm.org/jira/browse/CRM-17824). The `receive_date` was not properly defined after a `GROUP BY` since it didn't have any aggregators. I agree with `karamveer` that the most recent contribution would make the most sense.

The only thing I'm not sure about is whether there is another way of using this report where this patch wouldn't work - I can't think of anything though.
