### PR TITLE
CRM-18955: CiviMail sending multiple copies to test address and when submitted

### DIFF
--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -501,7 +501,8 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
 
     list($aclJoin, $aclWhere) = CRM_ACL_BAO_ACL::buildAcl($mailing->created_id);
 
-    $query = "  SELECT      $eqTable.id,
+    $query = "  
+                SELECT DISTINCT $eqTable.id,
                                 $emailTable.email as email,
                                 $eqTable.contact_id,
                                 $eqTable.hash,
@@ -524,7 +525,7 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
 
     if ($mailing->sms_provider_id) {
       $query = "
-                    SELECT      $eqTable.id,
+                SELECT DISTINCT $eqTable.id,
                                 $phoneTable.phone as phone,
                                 $eqTable.contact_id,
                                 $eqTable.hash,


### PR DESCRIPTION
fix for duplicate rows from introduction of CRM-18159

---
- [CRM-18955: CiviMail sending multiple copies to test address and when submitted](https://issues.civicrm.org/jira/browse/CRM-18955)
- [CRM-18159: Mailings does not have an ACL restriction in place](https://issues.civicrm.org/jira/browse/CRM-18159)
