### PR TITLE
CRM-15925 - Define extra import permission

### DIFF
--- a/CRM/Contact/Import/Form/DataSource.php
+++ b/CRM/Contact/Import/Form/DataSource.php
@@ -112,12 +112,16 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Core_Form {
       $this->assign('showOnlyDataSourceFormPane', TRUE);
     }
 
-    if (strpos($this->_dataSource, 'CRM_Import_DataSource_') === 0) {
+    $dataSources = $this->_getDataSources();
+    if ($this->_dataSource && isset($dataSources[$this->_dataSource])) {
       $this->_dataSourceIsValid = TRUE;
       $this->assign('showDataSourceFormPane', TRUE);
       $dataSourcePath = explode('_', $this->_dataSource);
       $templateFile = "CRM/Contact/Import/Form/" . $dataSourcePath[3] . ".tpl";
       $this->assign('dataSourceFormTemplateFile', $templateFile);
+    }
+    elseif ($this->_dataSource) {
+      throw new \CRM_Core_Exception("Invalid data source");
     }
   }
 
@@ -259,6 +263,11 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Core_Form {
    * @throws Exception
    */
   private function _getDataSources() {
+    // Hmm... file-system scanners don't really belong in forms...
+    if (isset(Civi::$statics[__CLASS__]['datasources'])) {
+      return Civi::$statics[__CLASS__]['datasources'];
+    }
+
     // Open the data source dir and scan it for class files
     global $civicrm_root;
     $dataSourceDir = $civicrm_root . DIRECTORY_SEPARATOR . 'CRM' . DIRECTORY_SEPARATOR . 'Import' . DIRECTORY_SEPARATOR . 'DataSource' . DIRECTORY_SEPARATOR;
@@ -280,10 +289,14 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Core_Form {
         require_once $dataSourceDir . DIRECTORY_SEPARATOR . $dataSourceFile;
         $object = new $dataSourceClass();
         $info = $object->getInfo();
-        $dataSources[$dataSourceClass] = $info['title'];
+        if ($object->checkPermission()) {
+          $dataSources[$dataSourceClass] = $info['title'];
+        }
       }
     }
     closedir($dataSourceHandle);
+
+    Civi::$statics[__CLASS__]['datasources'] = $dataSources;
     return $dataSources;
   }
 

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -690,6 +690,10 @@ class CRM_Core_Permission {
         $prefix . ts('import contacts'),
         ts('Import contacts and activities'),
       ),
+      'import SQL datasource' => array(
+        $prefix . ts('import SQL datasource'),
+        ts('When importing, consume data directly from a SQL datasource'),
+      ),
       'edit groups' => array(
         $prefix . ts('edit groups'),
         ts('Create new groups, edit group settings (e.g. group name, visibility...), delete groups'),

--- a/CRM/Import/DataSource.php
+++ b/CRM/Import/DataSource.php
@@ -43,7 +43,10 @@ abstract class CRM_Import_DataSource {
    * Provides information about the data source.
    *
    * @return array
-   *   collection of info about this data source
+   *   Description of this data source, including:
+   *   - title: string, translated, required
+   *   - permissions: array, optional
+   *
    */
   abstract public function getInfo();
 
@@ -71,5 +74,15 @@ abstract class CRM_Import_DataSource {
    * @param CRM_Core_Form $form
    */
   abstract public function postProcess(&$params, &$db, &$form);
+
+  /**
+   * Determine if the current user has access to this data source.
+   *
+   * @return bool
+   */
+  public function checkPermission() {
+    $info = $this->getInfo();
+    return empty($info['permissions']) || CRM_Core_Permission::check($info['permissions']);
+  }
 
 }

--- a/CRM/Import/DataSource/SQL.php
+++ b/CRM/Import/DataSource/SQL.php
@@ -41,7 +41,10 @@ class CRM_Import_DataSource_SQL extends CRM_Import_DataSource {
    *   collection of info about this data source
    */
   public function getInfo() {
-    return array('title' => ts('SQL Query'));
+    return array(
+      'title' => ts('SQL Query'),
+      'permissions' => array('import SQL datasource'),
+    );
   }
 
   /**


### PR DESCRIPTION
This defines and enforces a new permission, `import SQL datasource`; to
import contacts directly from a SQL table, you must have this permission. 
In some organizations, admins may want to grant the ability to import from
CSV without granting the ability to import from SQL (since SQL bypasses any
PHP-level ACLs).

---
- [CRM-15925](https://issues.civicrm.org/jira/browse/CRM-15925)
