### PR TITLE
CRM-19228: $contributionPageId is not populated in Contribution Receipt email

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -5029,6 +5029,7 @@ LIMIT 1;";
     );
     $valuesToCopy = array(
       // These are the values that I believe to be useful.
+      'id',
       'title',
       'is_email_receipt',
       'pay_later_receipt',


### PR DESCRIPTION
---
- CRM-19228: $contributionPageId is not populated in Contribution Receipt email
  https://issues.civicrm.org/jira/browse/CRM-19228
