### PR TITLE
Fix CRM-19240

### DIFF
--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -595,14 +595,44 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
     }
 
     if ($biDirectional) {
-      // lets clean up the data and eliminate all duplicate values
-      // (i.e. the relationship is bi-directional)
-      $relationshipType = array_unique($relationshipType);
+      $relationshipType = self::removeRelationshipTypeDuplicates($relationshipType, $contactSuffix);
     }
 
     // sort the relationshipType in ascending order CRM-7736
     asort($relationshipType);
     return $relationshipType;
+  }
+
+  /**
+   * Given a list of relationship types, return the list with duplicate types
+   * removed, being careful to retain only the duplicate which matches the given
+   * 'a_b' or 'b_a' suffix.
+   *
+   * @param array $relationshipTypeList A list of relationship types, in the format
+   *   returned by self::getContactRelationshipType().
+   * @param string $suffix Either 'a_b' or 'b_a'; defaults to 'a_b'
+   *
+   * @return array The modified value of $relationshipType
+   */
+  static function removeRelationshipTypeDuplicates($relationshipTypeList, $suffix = NULL) {
+    if (empty($suffix)) {
+      $suffix = 'a_b';
+    }
+    
+    // Find those labels which are listed more than once.
+    $duplicateValues = array_diff_assoc($relationshipTypeList, array_unique($relationshipTypeList));
+
+    // For each duplicate label, find its keys, and remove from $relationshipType
+    // the key which does not match $suffix.
+    foreach ($duplicateValues as $value) {
+      $keys = array_Keys($relationshipTypeList, $value);
+      foreach ($keys as $key) {
+        if (substr($key, -3) != $suffix) {
+          unset($relationshipTypeList[$key]);
+        }
+      }
+    }
+    return $relationshipTypeList;
   }
 
   /**

--- a/tests/phpunit/CRM/Contact/BAO/RelationshipTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/RelationshipTest.php
@@ -1,0 +1,115 @@
+<?php
+/*
+  +--------------------------------------------------------------------+
+  | CiviCRM version 4.7                                                |
+  +--------------------------------------------------------------------+
+  | Copyright CiviCRM LLC (c) 2004-2016                                |
+  +--------------------------------------------------------------------+
+  | This file is a part of CiviCRM.                                    |
+  |                                                                    |
+  | CiviCRM is free software; you can copy, modify, and distribute it  |
+  | under the terms of the GNU Affero General Public License           |
+  | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+  |                                                                    |
+  | CiviCRM is distributed in the hope that it will be useful, but     |
+  | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+  | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+  | See the GNU Affero General Public License for more details.        |
+  |                                                                    |
+  | You should have received a copy of the GNU Affero General Public   |
+  | License and the CiviCRM Licensing Exception along                  |
+  | with this program; if not, contact CiviCRM LLC                     |
+  | at info[AT]civicrm[DOT]org. If you have questions about the        |
+  | GNU Affero General Public License or the licensing of CiviCRM,     |
+  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+  +--------------------------------------------------------------------+
+ */
+
+/**
+ * Test class for CRM_Contact_BAO_Relationship
+ *
+ * @package CiviCRM
+ * @group headless
+ */
+class CRM_Contact_BAO_RelationshipTest extends CiviUnitTestCase {
+
+  /**
+   * Sets up the fixture, for example, opens a network connection.
+   *
+   * This method is called before a test is executed.
+   */
+  protected function setUp() {
+    parent::setUp();
+  }
+
+  /**
+   * Tears down the fixture, for example, closes a network connection.
+   *
+   * This method is called after a test is executed.
+   */
+  protected function tearDown() {
+    parent::tearDown();
+  }
+
+  /**
+   * Test removeRelationshipTypeDuplicates method.
+   *
+   * @dataProvider getRelationshipTypeDuplicates
+   */
+  function testRemoveRelationshipTypeDuplicates($relationshipTypeList, $suffix = NULL, $expected, $description) {
+    $result = CRM_Contact_BAO_Relationship::removeRelationshipTypeDuplicates($relationshipTypeList, $suffix);
+    $this->assertEquals($expected, $result, "Failure on set '$description'");
+  }
+
+  function getRelationshipTypeDuplicates() {
+    $relationshipTypeList = array(
+      '1_a_b' => 'duplicate one',
+      '1_b_a' => 'duplicate one',
+      '2_a_b' => 'two a',
+      '2_b_a' => 'two b',
+    );
+    $data = array(
+      array(
+        $relationshipTypeList,
+        'a_b',
+        array(
+          '1_a_b' => 'duplicate one',
+          '2_a_b' => 'two a',
+          '2_b_a' => 'two b',
+        ),
+        'With suffix a_b',
+      ),
+      array(
+        $relationshipTypeList,
+        'b_a',
+        array(
+          '1_b_a' => 'duplicate one',
+          '2_a_b' => 'two a',
+          '2_b_a' => 'two b',
+        ),
+        'With suffix b_a',
+      ),
+      array(
+        $relationshipTypeList,
+        NULL,
+        array(
+          '1_a_b' => 'duplicate one',
+          '2_a_b' => 'two a',
+          '2_b_a' => 'two b',
+        ),
+        'With suffix NULL',
+      ),
+      array(
+        $relationshipTypeList,
+        NULL,
+        array(
+          '1_a_b' => 'duplicate one',
+          '2_a_b' => 'two a',
+          '2_b_a' => 'two b',
+        ),
+        'With suffix "" (empty string)',
+      ),
+    );
+    return $data;
+  }
+}


### PR DESCRIPTION
- [CRM-19240: "Relationship type" empty for half of all relationships with symetrical names](https://issues.civicrm.org/jira/browse/CRM-19240)
