### PR TITLE
CRM-15601, CRM-19027 - Fix regression in MyISAM DB check

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -777,7 +777,7 @@ LIKE %1
        WHERE TABLE_SCHEMA = '" . CRM_Core_DAO::getDatabaseName() . "'
          AND TABLE_NAME LIKE 'civicrm_%'
          AND TABLE_NAME NOT LIKE 'civicrm_import_job_%'
-         AND TABLE_NAME NOT LIKE '%temp'
+         AND TABLE_NAME NOT LIKE '%_temp%'
       ");
 
     while ($dao->fetch()) {
@@ -800,7 +800,7 @@ LIKE %1
          AND TABLE_SCHEMA = '" . CRM_Core_DAO::getDatabaseName() . "'
          AND TABLE_NAME LIKE 'civicrm_%'
          AND TABLE_NAME NOT LIKE 'civicrm_import_job_%'
-         AND TABLE_NAME NOT LIKE '%temp'
+         AND TABLE_NAME NOT LIKE '%_temp%'
       ");
   }
 

--- a/tests/phpunit/CRM/Core/DAOTest.php
+++ b/tests/phpunit/CRM/Core/DAOTest.php
@@ -253,10 +253,28 @@ class CRM_Core_DAOTest extends CiviUnitTestCase {
    * Test the function designed to find myIsam tables.
    */
   public function testMyISAMCheck() {
+    // Cleanup previous, failed tests.
+    CRM_Core_DAO::executeQuery('DROP TABLE IF EXISTS civicrm_my_isam');
+
+    // A manually created MyISAM table should raise a redflag.
     $this->assertEquals(0, CRM_Core_DAO::isDBMyISAM());
     CRM_Core_DAO::executeQuery('CREATE TABLE civicrm_my_isam (`id` int(10) unsigned NOT NULL) ENGINE = MyISAM');
     $this->assertEquals(1, CRM_Core_DAO::isDBMyISAM());
     CRM_Core_DAO::executeQuery('DROP TABLE civicrm_my_isam');
+
+    // A temp table should not raise flag (static naming).
+    $tempName = CRM_Core_DAO::createTempTableName('civicrm', FALSE);
+    $this->assertEquals(0, CRM_Core_DAO::isDBMyISAM());
+    CRM_Core_DAO::executeQuery("CREATE TABLE $tempName (`id` int(10) unsigned NOT NULL) ENGINE = MyISAM");
+    $this->assertEquals(0, CRM_Core_DAO::isDBMyISAM()); // Ignore temp tables
+    CRM_Core_DAO::executeQuery("DROP TABLE $tempName");
+
+    // A temp table should not raise flag (randomized naming).
+    $tempName = CRM_Core_DAO::createTempTableName('civicrm', TRUE);
+    $this->assertEquals(0, CRM_Core_DAO::isDBMyISAM());
+    CRM_Core_DAO::executeQuery("CREATE TABLE $tempName (`id` int(10) unsigned NOT NULL) ENGINE = MyISAM");
+    $this->assertEquals(0, CRM_Core_DAO::isDBMyISAM()); // Ignore temp tables
+    CRM_Core_DAO::executeQuery("DROP TABLE $tempName");
   }
 
 }


### PR DESCRIPTION
3fa9688a5 (4.7.10) introduced a subtle break in how it skips temp tables:
- (Old) `strpos($dao->Name, '_temp') !== FALSE`
- (New) `TABLE_NAME NOT LIKE '%temp'`

This is relevant when a random suffix is appended to the table name.

I don't know the performance issue being addressed by CRM-19027.  If there's an
issue with this hurting indexes, then maybe the check should be done in PHP
again? Alternatively, maybe we should patch all the code which makes temp
tables to enforce `ENGINE=InnoDB`?

---
- [CRM-15601: civicrm_export_temp_ tables are getting created as MyISAM](https://issues.civicrm.org/jira/browse/CRM-15601)
- [CRM-19027: Slow query in MyIsam db check](https://issues.civicrm.org/jira/browse/CRM-19027)
