### PR TITLE
CRM-19265 - Fix fieldOptions for AutoComplete Select

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -821,6 +821,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
       'AdvMulti-Select',
       'CheckBox',
       'Radio',
+      'Autocomplete-Select',
     )));
 
     if ($isSelect) {


### PR DESCRIPTION
---
- [CRM-19265: fieldOptions() hook doesn't load options for Autocomplete-Select widget](https://issues.civicrm.org/jira/browse/CRM-19265)
