### PR TITLE
Fix array_key_exists() PHP warning in Report Forms

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -2090,6 +2090,7 @@ class CRM_Report_Form extends CRM_Core_Form {
       return;
     }
 
+    $customFields = array();
     $customFieldIds = array();
     foreach ($this->_params['fields'] as $fieldAlias => $value) {
       if ($fieldId = CRM_Core_BAO_CustomField::getKeyID($fieldAlias)) {


### PR DESCRIPTION
If the query just below returns an empty set, PHP throws a warning about $customFields being undefined (null), so initialize it properly as an empty array.
