### PR TITLE
CRM-18953 - Add events tab to news dashlet

### DIFF
--- a/CRM/Dashlet/Page/Blog.php
+++ b/CRM/Dashlet/Page/Blog.php
@@ -41,11 +41,12 @@ class CRM_Dashlet_Page_Blog extends CRM_Core_Page {
   const CHECK_TIMEOUT = 5;
   const CACHE_DAYS = 1;
   const BLOG_URL = 'https://civicrm.org/blog/feed';
+  const EVENT_URL = 'https://civicrm.org/civicrm/event/ical?reset=1&list=1&rss=1';
 
   /**
-   * Get the final, usable URL string (after interpolating any variables)
+   * Gets url for blog feed.
    *
-   * @return FALSE|string
+   * @return string
    */
   public function getBlogUrl() {
     // Note: We use "*default*" as the default (rather than self::BLOG_URL) so that future
@@ -58,24 +59,38 @@ class CRM_Dashlet_Page_Blog extends CRM_Core_Page {
   }
 
   /**
-   * List blog articles as dashlet.
+   * Gets url for the events feed.
+   *
+   * @return string
+   */
+  public function getEventUrl() {
+    $url = self::EVENT_URL
+      . '&start=' . date("Ymd")
+      . '&end=' . date("Ymd", strtotime('now +6 month'));
+    return $url;
+  }
+
+  /**
+   * Output data to template.
    */
   public function run() {
-    $context = CRM_Utils_Request::retrieve('context', 'String', $this, FALSE, 'dashlet');
-    $this->assign('context', $context);
-
-    $this->assign('blog', $this->_getBlog());
+    $this->assign('tabs', array(
+      'blog' => ts('Blog'),
+      'events' => ts('Events'),
+    ));
+    $this->assign('feeds', $this->getData());
 
     return parent::run();
   }
 
   /**
-   * Load blog articles from cache.
-   * Refresh cache if expired
+   * Load feeds from cache.
+   *
+   * Refresh cache if expired.
    *
    * @return array
    */
-  private function _getBlog() {
+  protected function getData() {
     // Fetch data from cache
     $cache = CRM_Core_DAO::executeQuery("SELECT data, created_date FROM civicrm_cache
       WHERE group_name = 'dashboard' AND path = 'blog'");
@@ -83,38 +98,65 @@ class CRM_Dashlet_Page_Blog extends CRM_Core_Page {
       $expire = time() - (60 * 60 * 24 * self::CACHE_DAYS);
       // Refresh data after CACHE_DAYS
       if (strtotime($cache->created_date) < $expire) {
-        $new_data = $this->_getFeed($this->getBlogUrl());
+        $new_data = $this->getFeeds();
         // If fetching the new rss feed was successful, return it
         // Otherwise use the old cached data - it's better than nothing
-        if ($new_data) {
+        if ($new_data['blog']) {
           return $new_data;
         }
       }
       return unserialize($cache->data);
     }
-    return $this->_getFeed($this->getBlogUrl());
+    return $this->getFeeds();
   }
 
   /**
-   * Parse rss feed and cache results.
+   * Fetch all feeds & cache results.
+   *
+   * @return array
+   */
+  protected function getFeeds() {
+    $blogFeed = $this->getFeed($this->getBlogUrl());
+    // If unable to fetch the first feed, give up and return empty results.
+    if (!$blogFeed) {
+      return array_fill_keys(array_keys($this->get_template_vars('tabs')), array());
+    }
+    $eventFeed = $this->getFeed($this->getEventUrl());
+    $feeds = array(
+      'blog' => $this->formatItems($blogFeed),
+      'events' => $this->formatItems($eventFeed),
+    );
+    CRM_Core_BAO_Cache::setItem($feeds, 'dashboard', 'blog');
+    return $feeds;
+  }
+
+  /**
+   * Parse a single rss feed.
    *
    * @param $url
    *
    * @return array|NULL
    *   array of blog items; or NULL if not available
    */
-  public function _getFeed($url) {
+  protected function getFeed($url) {
     $httpClient = new CRM_Utils_HttpClient(self::CHECK_TIMEOUT);
     list ($status, $rawFeed) = $httpClient->get($url);
     if ($status !== CRM_Utils_HttpClient::STATUS_OK) {
       return NULL;
     }
-    $feed = @simplexml_load_string($rawFeed);
+    return @simplexml_load_string($rawFeed);
+  }
 
-    $blog = array();
+  /**
+   * @param string $feed
+   * @return array
+   */
+  protected function formatItems($feed) {
+    $items = array();
     if ($feed && !empty($feed->channel->item)) {
       foreach ($feed->channel->item as $item) {
         $item = (array) $item;
+        $item['title'] = strip_tags($item['title']);
         // Clean up description - remove tags that would break dashboard layout
         $description = preg_replace('#<h[1-3][^>]*>(.+?)</h[1-3][^>]*>#s', '<h4>$1</h4>', $item['description']);
         $description = strip_tags($description, "<a><p><h4><h5><h6><b><i><em><strong><ol><ul><li><dd><dt><code><pre><br/>");
@@ -123,13 +165,10 @@ class CRM_Dashlet_Page_Blog extends CRM_Core_Page {
           $description = '<p>' . $description . '</p>';
         }
         $item['description'] = $description;
-        $blog[] = $item;
-      }
-      if ($blog) {
-        CRM_Core_BAO_Cache::setItem($blog, 'dashboard', 'blog');
+        $items[] = $item;
       }
     }
-    return $blog;
+    return $items;
   }
 
 }

--- a/CRM/Utils/ICalendar.php
+++ b/CRM/Utils/ICalendar.php
@@ -42,20 +42,36 @@ class CRM_Utils_ICalendar {
   /**
    * Escape text elements for safe ICalendar use.
    *
-   * @param $text
+   * @param string $text
    *   Text to escape.
    *
    * @return string
-   *   Escaped text
    */
   public static function formatText($text) {
     $text = strip_tags($text);
     $text = str_replace("\"", "DQUOTE", $text);
     $text = str_replace("\\", "\\\\", $text);
-    $text = str_replace(",", "\,", $text);
-    $text = str_replace(";", "\;", $text);
+    $text = str_replace(',', '\,', $text);
+    $text = str_replace(';', '\;', $text);
     $text = str_replace(array("\r\n", "\n", "\r"), "\\n ", $text);
     $text = implode("\n ", str_split($text, 50));
+    return $text;
+  }
+
+  /**
+   * Restore iCal formatted text to normal.
+   *
+   * @param string $text
+   *   Text to unescape.
+   *
+   * @return string
+   */
+  public static function unformatText($text) {
+    $text = str_replace('\n ', "\n", $text);
+    $text = str_replace('\;', ';', $text);
+    $text = str_replace('\,', ',', $text);
+    $text = str_replace("\\\\", "\\", $text);
+    $text = str_replace("DQUOTE", "\"", $text);
     return $text;
   }
 

--- a/templates/CRM/Dashlet/Page/Blog.tpl
+++ b/templates/CRM/Dashlet/Page/Blog.tpl
@@ -25,33 +25,101 @@
 *}
 {strip}{literal}
 <style type="text/css">
-  #civicrm-blog-feed .collapsed .crm-accordion-header {
+  #civicrm-news-feed {
+    border: 0 none;
+  }
+  #civicrm-news-feed .collapsed .crm-accordion-header {
     text-overflow: ellipsis;
     text-wrap: none;
     white-space: nowrap;
     overflow: hidden;
   }
-  #civicrm-blog-feed .crm-blog-preview {
+  #civicrm-news-feed .crm-news-feed-item-preview {
     color: #8d8d8d;
     display: none;
   }
-  #civicrm-blog-feed .collapsed .crm-blog-preview {
+  #civicrm-news-feed .collapsed .crm-news-feed-item-preview {
     display: inline;
+  }
+  #civicrm-news-feed .crm-news-feed-item-link {
+    margin-bottom: 0;
   }
 </style>
 {/literal}
-<div id="civicrm-blog-feed">
-{foreach from=$blog item=article}
-  <div class="crm-accordion-wrapper collapsed">
-    <div class="crm-accordion-header">
-      <span class="crm-blog-title">{$article.title}</span>
-      <span class="crm-blog-preview"> - {$article.description|strip_tags|substr:0:100}…</span>
+<div id="civicrm-news-feed">
+  <ul>
+    {foreach from=$tabs key="key" item="title"}
+      <li class="ui-corner-all crm-tab-button">
+        <a href="#civicrm-news-feed-{$key}">{$title}</a>
+      </li>
+    {/foreach}
+  </ul>
+
+  {foreach from=$feeds key="key" item="feed"}
+    <div id="civicrm-news-feed-{$key}">
+    {foreach from=$feed item=article}
+      <div class="crm-accordion-wrapper collapsed">
+        <div class="crm-accordion-header">
+          <span class="crm-news-feed-item-title">{$article.title}</span>
+          <span class="crm-news-feed-item-preview"> - {$article.description|strip_tags|substr:0:100}…</span>
+        </div>
+        <div class="crm-accordion-body">
+          <div>{$article.description}</div>
+          <p class="crm-news-feed-item-link"><a target="_blank" href="{$article.link}" title="{$article.title}"><i class="crm-i fa-external-link"></i> {ts}read more{/ts}…</a></p>
+        </div>
+      </div>
+    {/foreach}
+    {if !$feed}
+      <div class="messages status no-popup">
+        <div class="icon inform-icon"></div>
+        {ts}Sorry but we are not able to provide this at the moment.{/ts}
+      </div>
+    {/if}
     </div>
-    <div class="crm-accordion-body">
-      <div>{$article.description}</div>
-      <div><a target="_blank" href="{$article.link}" title="{$article.title}"><i class="crm-i fa-external-link"></i> {ts}read more{/ts}…</a></div>
-    </div>
-  </div>
-{/foreach}
+  {/foreach}
+  
 </div>
+{literal}<script type="text/javascript">
+  (function($, _) {
+    $(function() {
+      $('#civicrm-news-feed').tabs();
+      if (window.localStorage) {
+        var opened = localStorage.newsFeed ? JSON.parse(localStorage.newsFeed) : {};
+        $('#civicrm-news-feed ul.ui-tabs-nav a').each(function() {
+          var
+            $tab = $(this),
+            href = $tab.attr('href'),
+            $content = $(href),
+            $items = $('.crm-accordion-wrapper', $content),
+            key = href.substring(19),
+            count = 0;
+          if (!opened[key]) opened[key] = [];
+          if ($items.length) {
+            $items.each(function () {
+              var itemKey = $('.crm-news-feed-item-link a', this).attr('href');
+              if ($.inArray(itemKey, opened[key]) < 0) {
+                $('.crm-news-feed-item-title', this).css('font-weight', 'bold');
+                ++count;
+                $(this).one('crmAccordion:open', function () {
+                  $('.crm-news-feed-item-title', this).css('font-weight', '');
+                  $('em', $tab).text(--count);
+                  opened[key].push(itemKey);
+                  localStorage.newsFeed = JSON.stringify(opened);
+                });
+              }
+            });
+            $tab.html($tab.text() + ' <em>' + count + '</em>');
+            // Remove items from localstorage that are no longer in the current feed
+            $.each(opened[key], function(i, itemKey) {
+              if (!$('a[href="' + itemKey + '"]', $content).length) {
+                opened[key][i] = null;
+              }
+            });
+            _.remove(opened[key], function(n) {return !n});
+          }
+        });
+      }
+    });
+  })(CRM.$, CRM._);
+</script>{/literal}
 {/strip}

--- a/tests/phpunit/CRM/Utils/ICalendarTest.php
+++ b/tests/phpunit/CRM/Utils/ICalendarTest.php
@@ -1,0 +1,55 @@
+<?php
+/*
++--------------------------------------------------------------------+
+| CiviCRM version 4.7                                                |
++--------------------------------------------------------------------+
+| Copyright CiviCRM LLC (c) 2004-2016                                |
++--------------------------------------------------------------------+
+| This file is a part of CiviCRM.                                    |
+|                                                                    |
+| CiviCRM is free software; you can copy, modify, and distribute it  |
+| under the terms of the GNU Affero General Public License           |
+| Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+|                                                                    |
+| CiviCRM is distributed in the hope that it will be useful, but     |
+| WITHOUT ANY WARRANTY; without even the implied warranty of         |
+| MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+| See the GNU Affero General Public License for more details.        |
+|                                                                    |
+| You should have received a copy of the GNU Affero General Public   |
+| License and the CiviCRM Licensing Exception along                  |
+| with this program; if not, contact CiviCRM LLC                     |
+| at info[AT]civicrm[DOT]org. If you have questions about the        |
+| GNU Affero General Public License or the licensing of CiviCRM,     |
+| see the CiviCRM license FAQ at http://civicrm.org/licensing        |
++--------------------------------------------------------------------+
+ */
+
+/**
+ * Tests for linking to resource files
+ * @group headless
+ */
+class CRM_Utils_ICalendarTest extends CiviUnitTestCase {
+
+  /**
+   * @return array
+   */
+  public function escapeExamples() {
+    $cases = array();
+    $cases[] = array("Hello
+    this is, a test!");
+    $cases[] = array("Hello!!
+
+    this is, a \"test\"!");
+    return $cases;
+  }
+
+  /**
+   * @param string $testString
+   * @dataProvider escapeExamples
+   */
+  public function testParseStrings($testString) {
+    $this->assertEquals($testString, CRM_Utils_ICalendar::unformatText(CRM_Utils_ICalendar::formatText($testString)));
+  }
+
+}


### PR DESCRIPTION
Structures the news widget into tabs, with a count of unread items in each tab.
We can add more tabs later.

![screenshot blog dashlet tab](https://cloud.githubusercontent.com/assets/2874912/18020239/6bd52a06-6bae-11e6-9fed-95feea5f3392.png)

---
- [CRM-18953: Revise Latest News dashboard widget to segment relevant information](https://issues.civicrm.org/jira/browse/CRM-18953)
