### PR TITLE
CRM-19261 Set uniqueID as well

### DIFF
--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -311,6 +311,8 @@ class CRM_Utils_File {
       $db->query('SET SESSION sql_mode = STRICT_TRANS_TABLES');
     }
     $db->query('SET NAMES utf8');
+    $transactionId = CRM_Utils_Type::escape(CRM_Utils_Request::id(), 'String');
+    $db->query('SET @uniqueID = ' . $transactionId);
 
     if (!$isQueryString) {
       $string = $prefix . file_get_contents($fileName);

--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -312,7 +312,7 @@ class CRM_Utils_File {
     }
     $db->query('SET NAMES utf8');
     $transactionId = CRM_Utils_Type::escape(CRM_Utils_Request::id(), 'String');
-    $db->query('SET @uniqueID = ' . $transactionId);
+    $db->query('SET @uniqueID = ' . "'$transactionId'");
 
     if (!$isQueryString) {
       $string = $prefix . file_get_contents($fileName);


### PR DESCRIPTION
@totten I think this is it, I have a funny feeling query in this format doesn't do the escaping executeQuery does

---
- [CRM-19261: Missing connection charset in CRM_Utils_File::sourceSQLFile](https://issues.civicrm.org/jira/browse/CRM-19261)
