### PR TITLE
CRM-19245: Wrap title and description fields ..

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -3274,6 +3274,12 @@ div.m ul#civicrm-menu,
   padding-left: 2px;
   border: 2px dashed transparent;
 }
+
+.crm-container .crmf-title .crm-editable-enabled,
+.crm-container .crmf-description .crm-editable-enabled {
+  white-space: normal;
+}
+
 .crm-container .crm-editable-textarea-enabled {
   white-space: normal;
 }


### PR DESCRIPTION
.. on Manage Groups page

---
- [CRM-19245: Text no longer wraps in name and description fields on Manage Groups page](https://issues.civicrm.org/jira/browse/CRM-19245)
