### PR TITLE
CRM-19296 - Improvements in action schedule reminder activity and postemailsend with more params

### DIFF
--- a/CRM/Mailing/BAO/Spool.php
+++ b/CRM/Mailing/BAO/Spool.php
@@ -129,7 +129,7 @@ class CRM_Mailing_BAO_Spool extends CRM_Mailing_DAO_Spool {
     $spoolMail->copyValues($params);
     $spoolMail->save();
 
-    return TRUE;
+    return $spoolMail;//This way useful like in the CRM_Core_BAO_ActionLog
   }
 
 }

--- a/CRM/Utils/Mail.php
+++ b/CRM/Utils/Mail.php
@@ -280,6 +280,10 @@ class CRM_Utils_Mail {
         CRM_Core_Session::setStatus($message, ts('Mailing Error'), 'error');
         return FALSE;
       }
+      //make following details avilable in postemailsend hook
+      $params['to'] = $to;
+      $params['headers'] = $headers;
+      $params['message'] = $message;
       // CRM-10699
       CRM_Utils_Hook::postEmailSend($params);
       return TRUE;


### PR DESCRIPTION
issues
1. Reminder sent activity does not display actual email content which was sent by scheduled reminder job
2. postEmailSend hook does not have enough information if want to do more logging for reminder
3. Spool BAO does not return spoolmail object

The above issues are handled in this PR

---
- [CRM-19296: Reminder Sent acitivity and postEmailSend hook in mailing improvement](https://issues.civicrm.org/jira/browse/CRM-19296)
