### PR TITLE
CRM-19243- Fixed duplicate log activity issue. The complete order fun…

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4617,8 +4617,8 @@ LIMIT 1;";
       if (!empty($ids['related_contact'])) {
         $targetContactID = $contribution->contact_id;
         $contribution->contact_id = $ids['related_contact'];
+        CRM_Activity_BAO_Activity::addActivity($contribution, NULL, $targetContactID);
       }
-      CRM_Activity_BAO_Activity::addActivity($contribution, NULL, $targetContactID);
       // event
     }
     else {


### PR DESCRIPTION
CRM-19243- Fixed duplicate log activity issue. The complete order function calls the Contribution create function in line 4581 which has already logged an activity.

The only reason another activity needs to be logged is when
id['related_contact'] is not empty else another activity is created with same details as one already created when create contribution was called.
This issue seems to be observed not only for free membership alone but even for paid.

Email activity is actually not duplicated according to what was reported in the ticket , the Status only moves from Pending to New in quick succession due to the fact that its a free membership and also due to the fact that a free membership calls the Contribute completetransaction function to simulate a payment completion for free membership
