### PR TITLE
CRM-19123 - Merging contacts: blank date fields write as 1970

### DIFF
--- a/CRM/Contact/BAO/Individual.php
+++ b/CRM/Contact/BAO/Individual.php
@@ -59,7 +59,7 @@ class CRM_Contact_BAO_Individual extends CRM_Contact_DAO_Contact {
 
     // "null" value for example is passed by dedupe merge in order to empty.
     // Display name computation shouldn't consider such values.
-    foreach (array('first_name', 'middle_name', 'last_name', 'nick_name', 'formal_title') as $displayField) {
+    foreach (array('first_name', 'middle_name', 'last_name', 'nick_name', 'formal_title', 'birth_date', 'deceased_date') as $displayField) {
       if (CRM_Utils_Array::value($displayField, $params) == "null") {
         $params[$displayField] = '';
       }

--- a/tests/phpunit/CRM/Contact/BAO/IndividualTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/IndividualTest.php
@@ -13,9 +13,9 @@ class CRM_Contact_BAO_IndividualTest extends CiviUnitTestCase {
    */
   public function testFormatNullDates() {
     $params = array(
-	    'contact_type' => 'Individual',
-	    'birth_date' => 'null',
-	    'deceased_date' => 'null',
+      'contact_type' => 'Individual',
+      'birth_date' => 'null',
+      'deceased_date' => 'null',
     );
     $contact = new CRM_Contact_DAO_Contact();
 
@@ -24,4 +24,5 @@ class CRM_Contact_BAO_IndividualTest extends CiviUnitTestCase {
     $this->assertEmpty($contact->birth_date);
     $this->assertEmpty($contact->deceased_date);
   }
+
 }

--- a/tests/phpunit/CRM/Contact/BAO/IndividualTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/IndividualTest.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Class CRM_Contact_BAO_IndividualTest
+ * @group headless
+ */
+class CRM_Contact_BAO_IndividualTest extends CiviUnitTestCase {
+
+  /**
+   * Test case for format() with "null" value dates.
+   *
+   * See CRM-19123: Merging contacts: blank date fields write as 1970
+   */
+  public function testFormatNullDates() {
+    $params = array(
+	    'contact_type' => 'Individual',
+	    'birth_date' => 'null',
+	    'deceased_date' => 'null',
+    );
+    $contact = new CRM_Contact_DAO_Contact();
+
+    CRM_Contact_BAO_Individual::format($params, $contact);
+
+    $this->assertEmpty($contact->birth_date);
+    $this->assertEmpty($contact->deceased_date);
+  }
+}


### PR DESCRIPTION
- CRM-19123: Merging contacts: blank date fields write as 1970
  https://issues.civicrm.org/jira/browse/CRM-19123

(See comments on JIRA issue above.)
