### PR TITLE
Fixes CRM-19308: Disallow false-y values for paths purged during cach…

### DIFF
--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -140,7 +140,7 @@ class CRM_Utils_File {
    */
   public static function cleanDir($target, $rmdir = TRUE, $verbose = TRUE) {
     static $exceptions = array('.', '..');
-    if ($target == '' || $target == '/') {
+    if ($target == '' || $target == '/' || !$target) {
       throw new Exception("Overly broad deletion");
     }
 


### PR DESCRIPTION
…e clears.

Fixes: https://issues.civicrm.org/jira/browse/CRM-19308
