### PR TITLE
repeatTransaction lineItems - includes tests - CRM-19309

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4578,7 +4578,7 @@ LIMIT 1;";
 
     $contributionParams['id'] = $contribution->id;
 
-    // KG - if you update the contribution here with financial_type_id it can/will mess with $lineItem
+    // CRM-19309 - if you update the contribution here with financial_type_id it can/will mess with $lineItem
     // unsetting it here does NOT cause any other contribution test to fail!
     unset($contributionParams['financial_type_id']);
     $contributionResult = civicrm_api3('Contribution', 'create', $contributionParams);

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4578,6 +4578,9 @@ LIMIT 1;";
 
     $contributionParams['id'] = $contribution->id;
 
+    // KG - if you update the contribution here with financial_type_id it can/will mess with $lineItem
+    // unsetting it here does NOT cause any other contribution test to fail!
+    unset($contributionParams['financial_type_id']);
     $contributionResult = civicrm_api3('Contribution', 'create', $contributionParams);
 
     // Add new soft credit against current $contribution.

--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -902,7 +902,7 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
   public static function calculateRecurLineItems($recurId, $total_amount, $financial_type_id) {
     $originalContributionID = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $recurId, 'id', 'contribution_recur_id');
     $lineItems = CRM_Price_BAO_LineItem::getLineItemsByContributionID($originalContributionID);
-    $lineSets=[];
+    $lineSets = array();
     if (count($lineItems) == 1) {
       foreach ($lineItems as $index => $lineItem) {
         if ($financial_type_id) {
@@ -921,7 +921,7 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
         $lineSets[$priceField->price_set_id][] = $lineItem;
       }
     }
-    // KG if more than one then just pass them through:
+    // CRM-19309 if more than one then just pass them through:
     elseif (count($lineItems) > 1) {
       foreach ($lineItems as $index => $lineItem) {
         $lineSets[$index][] = $lineItem;

--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -902,6 +902,7 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
   public static function calculateRecurLineItems($recurId, $total_amount, $financial_type_id) {
     $originalContributionID = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $recurId, 'id', 'contribution_recur_id');
     $lineItems = CRM_Price_BAO_LineItem::getLineItemsByContributionID($originalContributionID);
+    $lineSets=[];
     if (count($lineItems) == 1) {
       foreach ($lineItems as $index => $lineItem) {
         if ($financial_type_id) {
@@ -920,6 +921,13 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
         $lineSets[$priceField->price_set_id][] = $lineItem;
       }
     }
+    // KG if more than one then just pass them through:
+    elseif (count($lineItems) > 1) {
+      foreach ($lineItems as $index => $lineItem) {
+        $lineSets[$index][] = $lineItem;
+      }
+    }
+
     return $lineSets;
   }
 

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -1844,7 +1844,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
    * Test repeat contribution successfully creates line items (plural).
    */
   public function testRepeatTransactionLineItems() {
-    // KG
+    // CRM-19309
     $originalContribution = $this->setUpRepeatTransaction($recurParams = array(), 'multiple');
     $this->callAPISuccess('contribution', 'repeattransaction', array(
       'original_contribution_id' => $originalContribution['id'],
@@ -1883,9 +1883,8 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     unset($lineItem2['values'][1]['id'], $lineItem2['values'][1]['entity_id']);
     $this->assertEquals($lineItem1['values'][1], $lineItem2['values'][1]);
 
-    // KG ok so we want to:
-    // check that financial_line_items have been created for entity_id 3 and 4; - visually they look good
-    // the first set of line items id 1 and 2 will not create financial_items b/c of how I created them
+    // CRM-19309 so in future we also want to:
+    // check that financial_line_items have been created for entity_id 3 and 4;
 
     $this->callAPISuccessGetCount('FinancialItem', array('description' => 'Sales Tax', 'amount' => 0), 0);
     $this->quickCleanUpFinancialEntities();
@@ -2956,9 +2955,9 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'payment_processor_id' => $paymentProcessorID,
     ), $recurParams));
 
-    $originalContribution=[];
+    $originalContribution = '';
     if ($flag == 'multiple') {
-      // KG create a contribution + also add in line_items (plural):
+      // CRM-19309 create a contribution + also add in line_items (plural):
       $originalContribution = $this->callAPISuccess('contribution', 'create', array_merge(
           $this->_params,
           array(

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -1803,11 +1803,10 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test repeat contribution successfully creates line items.
+   * Test repeat contribution successfully creates line item.
    */
   public function testRepeatTransaction() {
-    $originalContribution = $this->setUpRepeatTransaction();
-
+    $originalContribution = $this->setUpRepeatTransaction($recurParams = array(), 'single');
     $this->callAPISuccess('contribution', 'repeattransaction', array(
       'original_contribution_id' => $originalContribution['id'],
       'contribution_status_id' => 'Completed',
@@ -1842,11 +1841,62 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test repeat contribution successfully creates line items.
+   * Test repeat contribution successfully creates line items (plural).
+   */
+  public function testRepeatTransactionLineItems() {
+    // KG
+    $originalContribution = $this->setUpRepeatTransaction($recurParams = array(), 'multiple');
+    $this->callAPISuccess('contribution', 'repeattransaction', array(
+      'original_contribution_id' => $originalContribution['id'],
+      'contribution_status_id' => 'Completed',
+      'trxn_id' => uniqid(),
+    ));
+
+    $lineItemParams = array(
+      'entity_id' => $originalContribution['id'],
+      'sequential' => 1,
+      'return' => array(
+        'entity_table',
+        'qty',
+        'unit_price',
+        'line_total',
+        'label',
+        'financial_type_id',
+        'deductible_amount',
+        'price_field_value_id',
+        'price_field_id',
+      ),
+    );
+    $lineItem1 = $this->callAPISuccess('line_item', 'get', array_merge($lineItemParams, array(
+      'entity_id' => $originalContribution['id'],
+    )));
+    $lineItem2 = $this->callAPISuccess('line_item', 'get', array_merge($lineItemParams, array(
+      'entity_id' => $originalContribution['id'] + 1,
+    )));
+
+    // unset id and entity_id for all of them to be able to compare the lineItems:
+    unset($lineItem1['values'][0]['id'], $lineItem1['values'][0]['entity_id']);
+    unset($lineItem2['values'][0]['id'], $lineItem2['values'][0]['entity_id']);
+    $this->assertEquals($lineItem1['values'][0], $lineItem2['values'][0]);
+
+    unset($lineItem1['values'][1]['id'], $lineItem1['values'][1]['entity_id']);
+    unset($lineItem2['values'][1]['id'], $lineItem2['values'][1]['entity_id']);
+    $this->assertEquals($lineItem1['values'][1], $lineItem2['values'][1]);
+
+    // KG ok so we want to:
+    // check that financial_line_items have been created for entity_id 3 and 4; - visually they look good
+    // the first set of line items id 1 and 2 will not create financial_items b/c of how I created them
+
+    $this->callAPISuccessGetCount('FinancialItem', array('description' => 'Sales Tax', 'amount' => 0), 0);
+    $this->quickCleanUpFinancialEntities();
+  }
+
+  /**
+   * Test repeat contribution successfully creates is_test transaction.
    */
   public function testRepeatTransactionIsTest() {
     $this->_params['is_test'] = 1;
-    $originalContribution = $this->setUpRepeatTransaction(array('is_test' => 1));
+    $originalContribution = $this->setUpRepeatTransaction(array('is_test' => 1), 'single');
 
     $this->callAPISuccess('contribution', 'repeattransaction', array(
       'original_contribution_id' => $originalContribution['id'],
@@ -1860,7 +1910,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
    * Test repeat contribution passed in status.
    */
   public function testRepeatTransactionPassedInStatus() {
-    $originalContribution = $this->setUpRepeatTransaction();
+    $originalContribution = $this->setUpRepeatTransaction($recurParams = array(), 'single');
 
     $this->callAPISuccess('contribution', 'repeattransaction', array(
       'original_contribution_id' => $originalContribution['id'],
@@ -1929,6 +1979,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'total_amount' => '400',
       'fee_amount' => 50,
     ));
+
     $lineItemParams = array(
       'entity_id' => $originalContribution['id'],
       'sequential' => 1,
@@ -1962,6 +2013,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $lineItem2 = $this->callAPISuccess('line_item', 'get', array_merge($lineItemParams, array(
       'entity_id' => $originalContribution['id'] + 1,
     )));
+
     unset($expectedLineItem['id'], $expectedLineItem['entity_id']);
     unset($lineItem2['values'][0]['id'], $lineItem2['values'][0]['entity_id']);
     $this->assertEquals($expectedLineItem, $lineItem2['values'][0]);
@@ -2890,7 +2942,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
    *
    * @return array
    */
-  protected function setUpRepeatTransaction($recurParams = array()) {
+  protected function setUpRepeatTransaction($recurParams = array(), $flag) {
     $paymentProcessorID = $this->paymentProcessorCreate();
     $contributionRecur = $this->callAPISuccess('contribution_recur', 'create', array_merge(array(
       'contact_id' => $this->_individualId,
@@ -2903,10 +2955,42 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'frequency_unit' => 'month',
       'payment_processor_id' => $paymentProcessorID,
     ), $recurParams));
-    $originalContribution = $this->callAPISuccess('contribution', 'create', array_merge(
-      $this->_params,
-      array('contribution_recur_id' => $contributionRecur['id']))
-    );
+
+    $originalContribution=[];
+    if ($flag == 'multiple') {
+      // KG create a contribution + also add in line_items (plural):
+      $originalContribution = $this->callAPISuccess('contribution', 'create', array_merge(
+          $this->_params,
+          array(
+            'contribution_recur_id' => $contributionRecur['id'],
+            'skipLineItem' => 1,
+            'api.line_item.create' => array(
+              array(
+                'price_field_id' => 1,
+                'qty' => 2,
+                'line_total' => '20',
+                'unit_price' => '10',
+                'financial_type_id' => 1,
+              ),
+              array(
+                'price_field_id' => 1,
+                'qty' => 1,
+                'line_total' => '80',
+                'unit_price' => '80',
+                'financial_type_id' => 2,
+              ),
+            ),
+          )
+        )
+      );
+    }
+    elseif ($flag == 'single') {
+      $originalContribution = $this->callAPISuccess('contribution', 'create', array_merge(
+          $this->_params,
+          array('contribution_recur_id' => $contributionRecur['id']))
+      );
+    }
+
     return $originalContribution;
   }
 


### PR DESCRIPTION
Ok first pass at getting repeatTransaction API to handle more than one contribution lineItem [and thus also more than one financial lineItem]. Tests included! Will open this and then summarize/write up my edits/thoughts - both here as well as in the JIRA ticket.

---
- [CRM-19309: RepeatTransaction API currently only handles one Contribution LineItem not LineItems](https://issues.civicrm.org/jira/browse/CRM-19309)
