### PR TITLE
(WIP) Organization Contact's Activities

### DIFF
--- a/tools/extensions/com.compucorp.orgtaskskr/CRM/Orgtaskskr/Form/OrgTaskListAdmin.php
+++ b/tools/extensions/com.compucorp.orgtaskskr/CRM/Orgtaskskr/Form/OrgTaskListAdmin.php
@@ -1,0 +1,123 @@
+<?php
+
+require_once 'CRM/Core/Form.php';
+
+/**
+ * Form controller class
+ *
+ * @see http://wiki.civicrm.org/confluence/display/CRMDOC43/QuickForm+Reference
+ */
+class CRM_Orgtaskskr_Form_OrgTaskListAdmin extends CRM_Core_Form {
+  /**
+   * Builds Form!
+   */
+  public function buildQuickForm() {
+
+    // Relationship Types Multi-select
+    $this->add(
+      'select', // field type
+      'included_relationships', // field name
+      'Included Relationship Types', // field label
+      $this->getRelationshipTypes(), // list of options
+      TRUE, // is required
+      array('class' => 'crm-select2', 'multiple' => true)
+    );
+    
+    // Activity Types Multi-select
+    $this->add(
+      'select', // field type
+      'included_activities', // field name
+      'Included Activity Types', // field label
+      $this->getActivityTypes(), // list of options
+      TRUE, // is required
+      array('class' => 'crm-select2', 'multiple' => true)
+    );
+    
+    // Submit Buttons
+    $this->addButtons(array(
+      array(
+        'type' => 'submit',
+        'name' => ts('Submit'),
+        'isDefault' => TRUE,
+      ),
+    ));
+
+    // export form elements
+    $this->assign('elementNames', $this->getRenderableElementNames());
+    parent::buildQuickForm();
+  }
+  
+  /**
+   * Calls API to get all possible relationship types between two contacts.
+   * @return array
+   */
+  function getRelationshipTypes() {
+    $values = array();
+    
+    $result = civicrm_api3('RelationshipType', 'get', array(
+      'sequential' => 1,
+    ));
+    
+    foreach ($result['values'] as $type) {
+      $values[$type['id']] = $type['label_b_a'] . ' / ' . $type['label_a_b'];
+    }
+    
+    return $values;
+  }
+  
+  /**
+   * Method that retrieves values of all activity types.
+   * @return array
+   */
+  private function getActivityTypes() {
+    $values = array();
+    
+    $result = civicrm_api3('OptionGroup', 'get', array(
+      'sequential' => 1,
+      'return' => array("name"),
+      'name' => 'activity_type',
+      'api.OptionValue.get' => array('option_group_id' => "\$value.id"),
+    ));
+    
+    foreach ($result['values'] as $currGroup) {
+      foreach ($currGroup['api.OptionValue.get']['values'] as $currOptValue) {
+        $values[$currOptValue['value']] = $currOptValue['label'];
+      }
+    }
+    
+    return $values;
+  }
+  
+  /**
+   * Inserts values into settings table
+   */
+  public function postProcess() {
+    $values = $this->exportValues();
+    
+    Civi::settings()->set('orgtasks_included_relationships', $values['included_relationships']);
+    Civi::settings()->set('orgtasks_included_activities', $values['included_activities']);
+    
+    parent::postProcess();
+  }
+
+  /**
+   * Get the fields/elements defined in this form.
+   *
+   * @return array (string)
+   */
+  public function getRenderableElementNames() {
+    // The _elements list includes some items which should not be
+    // auto-rendered in the loop -- such as "qfKey" and "buttons".  These
+    // items don't have labels.  We'll identify renderable by filtering on
+    // the 'label'.
+    $elementNames = array();
+    foreach ($this->_elements as $element) {
+      /** @var HTML_QuickForm_Element $element */
+      $label = $element->getLabel();
+      if (!empty($label)) {
+        $elementNames[] = $element->getName();
+      }
+    }
+    return $elementNames;
+  }
+}

--- a/tools/extensions/com.compucorp.orgtaskskr/CRM/Orgtaskskr/Page/TaskList.php
+++ b/tools/extensions/com.compucorp.orgtaskskr/CRM/Orgtaskskr/Page/TaskList.php
@@ -1,0 +1,236 @@
+<?php
+
+require_once 'CRM/Core/Page.php';
+
+class CRM_Orgtaskskr_Page_TaskList extends CRM_Core_Page {
+  
+  /**
+   * Holds cache of contacts per activity. 
+   * @var array
+   */
+  private $activityContacts;
+  
+  public function __construct($title = NULL, $mode = NULL) {
+    $this->activityContacts = array();
+    
+    parent::__construct($title, $mode);
+  }
+  
+  public function run() {
+    // Example: Set the page-title dynamically; alternatively, declare a static title in xml/Menu/*.xml
+    CRM_Utils_System::setTitle(ts('Organisation Activities'));
+    
+    $contactid = CRM_Utils_Request::retrieve('contact', 'Positive');
+    
+    // Example: Assign a variable for use in a template
+    $this->assign('currentTime', date('Y-m-d H:i:s'));
+    $this->assign('activities', $this->getTasks($contactid));
+    
+    parent::run();
+  }
+  
+  /**
+   * Method that retrieves values for given option group.
+   * 
+   * @param string $optgroup_name optgroup name
+   * @return array values belonging to given optgroup.
+   */
+  private function getParameterValues($optgroup_name) {
+    $values = array();
+    
+    $result = civicrm_api3('OptionGroup', 'get', array(
+      'sequential' => 1,
+      'return' => array("name"),
+      'name' => $optgroup_name,
+      'api.OptionValue.get' => array('option_group_id' => "\$value.id"),
+    ));
+    
+    foreach ($result['values'] as $currGroup) {
+      foreach ($currGroup['api.OptionValue.get']['values'] as $currOptValue) {
+        $values[$currOptValue['value']] = $currOptValue;
+      }
+    }
+    
+    return $values;
+  }
+  
+  /**
+   * Returns array of activity statuses configured in DB.
+   * 
+   * @return array of possible statuses for an activity.
+   */
+  private function getActivityStatus() {
+    return $this->getParameterValues('activity_status');
+  }
+  
+  /**
+   * Returns array of activity types.
+   * 
+   * @return array list of activity types
+   */
+  private function getActivityTypes() {
+    return $this->getParameterValues('activity_type');
+  }
+  
+  /**
+   * Method the searches for given organistion contact's activities.
+   * 
+   * @param int $contactid ID of organisation.
+   * 
+   * @return array List of activities belonging to contacts of organisation
+   */
+  private function getTasks($contactid) {
+    $activitytypes = $this->getActivityTypes();
+    $activityStatus = $this->getActivityStatus();
+    $allowed_activities = Civi::settings()->get('orgtasks_included_activities');
+    
+    $params = $this->buildRelationshipParamsArray($contactid);
+    
+    // Get list of contacts associated to organisation + activity list per contact
+    $activitiesPerContact = civicrm_api3('Relationship', 'get', $params);
+    
+    // Go through contacts, building task list
+    $activites = array();
+    foreach ($activitiesPerContact['values'] as $currentContact) {
+      if (count($currentContact['api.ActivityContact.get']['values']) > 0) {
+        foreach ($currentContact['api.ActivityContact.get']['values'] as $currentActivity) {
+          if (in_array($currentActivity['activity_id.activity_type_id'], $allowed_activities)) {
+            $currentActivity['activity_type'] = $activitytypes[$currentActivity['activity_id.activity_type_id']];
+            $currentActivity['subject'] = $currentActivity['activity_id.subject'];
+            $currentActivity['date'] = $currentActivity['activity_id.activity_date_time'];
+            $currentActivity['creator'] = $this->getActivityCreator($currentActivity['activity_id']);
+            $currentActivity['targets'] = $this->getActivityTargets($currentActivity['activity_id']);
+            $currentActivity['assigned'] = $this->getActivityAssigned($currentActivity['activity_id']);
+            $currentActivity['status'] = $activityStatus[$currentActivity['activity_id.status_id']];
+            $activities[$currentActivity['activity_id']] = $currentActivity;
+          }
+        }
+      }
+    }
+    
+    //var_dump('<pre>', $activities);
+    return $activities;
+  }
+  
+  /**
+   * Method builds params array for API call to get contacts and chained activities.
+   * 
+   * @param int $contactid ID of organiation
+   * @return array parameters array to make call to API
+   */
+  private function buildRelationshipParamsArray($contactid) {
+    $params = array(
+      'sequential' => 1,
+      'return' => array(
+          "contact_id_a.display_name", 
+          "contact_id_b.display_name", 
+          "relationship_type_id", 
+          "contact_id_a.id", 
+          "contact_id_b.id"
+       ),
+      'contact_id_b' => $contactid,
+      'contact_id_a.contact_type' => "Individual",
+      'api.ActivityContact.get' => array(
+        'sequential' => 1, 
+        'contact_id' => "\$value.contact_id_a.id", 
+        'return' => "activity_id, record_type_id, contact_id, activity_id.subject, activity_id.status_id, activity_id.activity_date_time, activity_id.activity_type_id, activity_id.activity_type, status_id",
+      ),
+    );
+    
+    $allowed_relationships = Civi::settings()->get('orgtasks_included_relationships');
+    if (count($allowed_relationships) > 0) {
+      $params['relationship_type_id'] = $allowed_relationships;
+    }
+    
+    $allowed_activities = Civi::settings()->get('orgtasks_included_activities');
+    if (count($allowed_activities) > 0) {
+      $params['api.ActivityContact.get']['activity_id.activity_type_id'] = $allowed_activities;
+    }
+    
+    return $params;
+  }
+  
+  /**
+   * Method retuns contacts to which the activity is assigned.
+   * 
+   * @param int $activityid ID of activity.
+   * @return array list of contacts to which the activity was assigned.
+   */
+  private function getActivityAssigned($activityid) {
+    return $this->getActivityContactsByType($activityid, 1);
+  }
+  
+  /**
+   * Returns target contacts of activity.
+   * 
+   * @param int $activityid ID of activity.
+   * @return array list of target contacts.
+   */
+  private function getActivityTargets($activityid) {
+    return $this->getActivityContactsByType($activityid, 3);
+  }
+  
+  /**
+   * Gets activity creator contact for given activity id,
+   * 
+   * @param int $activityid ID of activity
+   * @return array holding values of contact
+   */
+  private function getActivityCreator($activityid) {
+    $creator = $this->getActivityContactsByType($activityid, 2);
+    return $creator[0];
+  }
+  
+  /**
+   * Returns contacts associated to activity, filtering by contact type.
+   * 
+   * @param int $activityid ID of activity
+   * @param int $contacttype ID of contact type (1: Assigned, 2: Creator, 3: Target.
+   * @return array of contacts of given type associated to activity identified by given id.
+   */
+  private function getActivityContactsByType($activityid, $contacttype) {
+    if (!isset($this->activityContacts[$activityid])) {
+      $this->loadActivityContacts($activityid);
+    }
+    
+    return $this->activityContacts[$activityid][$contacttype];
+  }
+  
+  /**
+   * Loads all contacts of activity to a class attribute to hold as caché.
+   * 
+   * @param type $activityid
+   */
+  private function loadActivityContacts($activityid) {
+    $contacts = civicrm_api3('ActivityContact', 'get', array(
+      'sequential' => 1,
+      'return' => array(
+        'contact_id', 
+        'contact_id.display_name', 
+        'contact_id.phone', 
+        'record_type_id'
+      ),
+      'activity_id' => $activityid,
+      'api.Contact.get' => array(
+        'contact_id' => "\$value.contact_id",
+        'return' => 'contact_type, phone, street_address, city, state_province, country, postal_code, email, gender_id, birth_date'
+      )
+    ));
+    //var_dump('<pre>', $contacts, '</pre><br><br>');
+    foreach ($contacts['values'] as $currContact) {
+      foreach ($currContact as $field => $value) {
+        $currContact[strtr($field, array('contact_id.' => ''))] = $value;
+      }
+      
+      foreach ($currContact['api.Contact.get']['values'] as $innerData) {
+        foreach ($innerData as $field => $value) {
+          $currContact['inner_' . $field] = $value;
+        }
+      }
+      
+      $this->activityContacts[$activityid][$currContact['record_type_id']][] = $currContact;
+    }
+    
+    //var_dump('<pre>', $this->activityContacts[$activityid]);
+  }
+}

--- a/tools/extensions/com.compucorp.orgtaskskr/LICENSE.txt
+++ b/tools/extensions/com.compucorp.orgtaskskr/LICENSE.txt
@@ -1,0 +1,667 @@
+Package: com.compucorp.orgtaskskr
+Copyright (C) 2016, FIXME <FIXME>
+Licensed under the GNU Affero Public License 3.0 (below).
+
+-------------------------------------------------------------------------------
+
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<http://www.gnu.org/licenses/>.

--- a/tools/extensions/com.compucorp.orgtaskskr/info.xml
+++ b/tools/extensions/com.compucorp.orgtaskskr/info.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<extension key="com.compucorp.orgtaskskr" type="module">
+  <file>orgtaskskr</file>
+  <name>Organisation Tasks</name>
+  <description>Extension that adds new tab to contact summary, and shows all activities undertaken by members of the organisation.</description>
+  <license>AGPL-3.0</license>
+  <maintainer>
+    <author>Camilo Rodriguez</author>
+    <email>camilo.rodriguez@gfecolombia.com.co</email>
+  </maintainer>
+  <urls>
+    <url desc="Support">http://www.gfecolombia.com.co</url>
+    <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
+  </urls>
+  <releaseDate>2016-08-31</releaseDate>
+  <version>1.0</version>
+  <develStage>alpha</develStage>
+  <compatibility>
+    <ver>4.2</ver>
+  </compatibility>
+  <comments>This is a new, undeveloped module</comments>
+  <civix>
+    <namespace>CRM/Orgtaskskr</namespace>
+  </civix>
+</extension>

--- a/tools/extensions/com.compucorp.orgtaskskr/orgtaskskr.civix.php
+++ b/tools/extensions/com.compucorp.orgtaskskr/orgtaskskr.civix.php
@@ -1,0 +1,348 @@
+<?php
+
+// AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
+
+/**
+ * (Delegated) Implements hook_civicrm_config().
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_config
+ */
+function _orgtaskskr_civix_civicrm_config(&$config = NULL) {
+  static $configured = FALSE;
+  if ($configured) {
+    return;
+  }
+  $configured = TRUE;
+
+  $template =& CRM_Core_Smarty::singleton();
+
+  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+  $extDir = $extRoot . 'templates';
+
+  if ( is_array( $template->template_dir ) ) {
+      array_unshift( $template->template_dir, $extDir );
+  }
+  else {
+      $template->template_dir = array( $extDir, $template->template_dir );
+  }
+
+  $include_path = $extRoot . PATH_SEPARATOR . get_include_path( );
+  set_include_path($include_path);
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_xmlMenu().
+ *
+ * @param $files array(string)
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_xmlMenu
+ */
+function _orgtaskskr_civix_civicrm_xmlMenu(&$files) {
+  foreach (_orgtaskskr_civix_glob(__DIR__ . '/xml/Menu/*.xml') as $file) {
+    $files[] = $file;
+  }
+}
+
+/**
+ * Implements hook_civicrm_install().
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_install
+ */
+function _orgtaskskr_civix_civicrm_install() {
+  _orgtaskskr_civix_civicrm_config();
+  if ($upgrader = _orgtaskskr_civix_upgrader()) {
+    $upgrader->onInstall();
+  }
+}
+
+/**
+ * Implements hook_civicrm_uninstall().
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_uninstall
+ */
+function _orgtaskskr_civix_civicrm_uninstall() {
+  _orgtaskskr_civix_civicrm_config();
+  if ($upgrader = _orgtaskskr_civix_upgrader()) {
+    $upgrader->onUninstall();
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_enable().
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_enable
+ */
+function _orgtaskskr_civix_civicrm_enable() {
+  _orgtaskskr_civix_civicrm_config();
+  if ($upgrader = _orgtaskskr_civix_upgrader()) {
+    if (is_callable(array($upgrader, 'onEnable'))) {
+      $upgrader->onEnable();
+    }
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_disable().
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_disable
+ * @return mixed
+ */
+function _orgtaskskr_civix_civicrm_disable() {
+  _orgtaskskr_civix_civicrm_config();
+  if ($upgrader = _orgtaskskr_civix_upgrader()) {
+    if (is_callable(array($upgrader, 'onDisable'))) {
+      $upgrader->onDisable();
+    }
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_upgrade().
+ *
+ * @param $op string, the type of operation being performed; 'check' or 'enqueue'
+ * @param $queue CRM_Queue_Queue, (for 'enqueue') the modifiable list of pending up upgrade tasks
+ *
+ * @return mixed  based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
+ *                for 'enqueue', returns void
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_upgrade
+ */
+function _orgtaskskr_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
+  if ($upgrader = _orgtaskskr_civix_upgrader()) {
+    return $upgrader->onUpgrade($op, $queue);
+  }
+}
+
+/**
+ * @return CRM_Orgtaskskr_Upgrader
+ */
+function _orgtaskskr_civix_upgrader() {
+  if (!file_exists(__DIR__.'/CRM/Orgtaskskr/Upgrader.php')) {
+    return NULL;
+  }
+  else {
+    return CRM_Orgtaskskr_Upgrader_Base::instance();
+  }
+}
+
+/**
+ * Search directory tree for files which match a glob pattern
+ *
+ * Note: Dot-directories (like "..", ".git", or ".svn") will be ignored.
+ * Note: In Civi 4.3+, delegate to CRM_Utils_File::findFiles()
+ *
+ * @param $dir string, base dir
+ * @param $pattern string, glob pattern, eg "*.txt"
+ * @return array(string)
+ */
+function _orgtaskskr_civix_find_files($dir, $pattern) {
+  if (is_callable(array('CRM_Utils_File', 'findFiles'))) {
+    return CRM_Utils_File::findFiles($dir, $pattern);
+  }
+
+  $todos = array($dir);
+  $result = array();
+  while (!empty($todos)) {
+    $subdir = array_shift($todos);
+    foreach (_orgtaskskr_civix_glob("$subdir/$pattern") as $match) {
+      if (!is_dir($match)) {
+        $result[] = $match;
+      }
+    }
+    if ($dh = opendir($subdir)) {
+      while (FALSE !== ($entry = readdir($dh))) {
+        $path = $subdir . DIRECTORY_SEPARATOR . $entry;
+        if ($entry{0} == '.') {
+        } elseif (is_dir($path)) {
+          $todos[] = $path;
+        }
+      }
+      closedir($dh);
+    }
+  }
+  return $result;
+}
+/**
+ * (Delegated) Implements hook_civicrm_managed().
+ *
+ * Find any *.mgd.php files, merge their content, and return.
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_managed
+ */
+function _orgtaskskr_civix_civicrm_managed(&$entities) {
+  $mgdFiles = _orgtaskskr_civix_find_files(__DIR__, '*.mgd.php');
+  foreach ($mgdFiles as $file) {
+    $es = include $file;
+    foreach ($es as $e) {
+      if (empty($e['module'])) {
+        $e['module'] = 'com.compucorp.orgtaskskr';
+      }
+      $entities[] = $e;
+    }
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_caseTypes().
+ *
+ * Find any and return any files matching "xml/case/*.xml"
+ *
+ * Note: This hook only runs in CiviCRM 4.4+.
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_caseTypes
+ */
+function _orgtaskskr_civix_civicrm_caseTypes(&$caseTypes) {
+  if (!is_dir(__DIR__ . '/xml/case')) {
+    return;
+  }
+
+  foreach (_orgtaskskr_civix_glob(__DIR__ . '/xml/case/*.xml') as $file) {
+    $name = preg_replace('/\.xml$/', '', basename($file));
+    if ($name != CRM_Case_XMLProcessor::mungeCaseType($name)) {
+      $errorMessage = sprintf("Case-type file name is malformed (%s vs %s)", $name, CRM_Case_XMLProcessor::mungeCaseType($name));
+      CRM_Core_Error::fatal($errorMessage);
+      // throw new CRM_Core_Exception($errorMessage);
+    }
+    $caseTypes[$name] = array(
+      'module' => 'com.compucorp.orgtaskskr',
+      'name' => $name,
+      'file' => $file,
+    );
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_angularModules().
+ *
+ * Find any and return any files matching "ang/*.ang.php"
+ *
+ * Note: This hook only runs in CiviCRM 4.5+.
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
+ */
+function _orgtaskskr_civix_civicrm_angularModules(&$angularModules) {
+  if (!is_dir(__DIR__ . '/ang')) {
+    return;
+  }
+
+  $files = _orgtaskskr_civix_glob(__DIR__ . '/ang/*.ang.php');
+  foreach ($files as $file) {
+    $name = preg_replace(':\.ang\.php$:', '', basename($file));
+    $module = include $file;
+    if (empty($module['ext'])) {
+      $module['ext'] = 'com.compucorp.orgtaskskr';
+    }
+    $angularModules[$name] = $module;
+  }
+}
+
+/**
+ * Glob wrapper which is guaranteed to return an array.
+ *
+ * The documentation for glob() says, "On some systems it is impossible to
+ * distinguish between empty match and an error." Anecdotally, the return
+ * result for an empty match is sometimes array() and sometimes FALSE.
+ * This wrapper provides consistency.
+ *
+ * @link http://php.net/glob
+ * @param string $pattern
+ * @return array, possibly empty
+ */
+function _orgtaskskr_civix_glob($pattern) {
+  $result = glob($pattern);
+  return is_array($result) ? $result : array();
+}
+
+/**
+ * Inserts a navigation menu item at a given place in the hierarchy.
+ *
+ * @param array $menu - menu hierarchy
+ * @param string $path - path where insertion should happen (ie. Administer/System Settings)
+ * @param array $item - menu you need to insert (parent/child attributes will be filled for you)
+ */
+function _orgtaskskr_civix_insert_navigation_menu(&$menu, $path, $item) {
+  // If we are done going down the path, insert menu
+  if (empty($path)) {
+    $menu[] = array(
+      'attributes' => array_merge(array(
+        'label'      => CRM_Utils_Array::value('name', $item),
+        'active'     => 1,
+      ), $item),
+    );
+    return TRUE;
+  }
+  else {
+    // Find an recurse into the next level down
+    $found = false;
+    $path = explode('/', $path);
+    $first = array_shift($path);
+    foreach ($menu as $key => &$entry) {
+      if ($entry['attributes']['name'] == $first) {
+        if (!$entry['child']) $entry['child'] = array();
+        $found = _orgtaskskr_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item, $key);
+      }
+    }
+    return $found;
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_navigationMenu().
+ */
+function _orgtaskskr_civix_navigationMenu(&$nodes) {
+  if (!is_callable(array('CRM_Core_BAO_Navigation', 'fixNavigationMenu'))) {
+    _orgtaskskr_civix_fixNavigationMenu($nodes);
+  }
+}
+
+/**
+ * Given a navigation menu, generate navIDs for any items which are
+ * missing them.
+ */
+function _orgtaskskr_civix_fixNavigationMenu(&$nodes) {
+  $maxNavID = 1;
+  array_walk_recursive($nodes, function($item, $key) use (&$maxNavID) {
+    if ($key === 'navID') {
+      $maxNavID = max($maxNavID, $item);
+    }
+    });
+  _orgtaskskr_civix_fixNavigationMenuItems($nodes, $maxNavID, NULL);
+}
+
+function _orgtaskskr_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID) {
+  $origKeys = array_keys($nodes);
+  foreach ($origKeys as $origKey) {
+    if (!isset($nodes[$origKey]['attributes']['parentID']) && $parentID !== NULL) {
+      $nodes[$origKey]['attributes']['parentID'] = $parentID;
+    }
+    // If no navID, then assign navID and fix key.
+    if (!isset($nodes[$origKey]['attributes']['navID'])) {
+      $newKey = ++$maxNavID;
+      $nodes[$origKey]['attributes']['navID'] = $newKey;
+      $nodes[$newKey] = $nodes[$origKey];
+      unset($nodes[$origKey]);
+      $origKey = $newKey;
+    }
+    if (isset($nodes[$origKey]['child']) && is_array($nodes[$origKey]['child'])) {
+      _orgtaskskr_civix_fixNavigationMenuItems($nodes[$origKey]['child'], $maxNavID, $nodes[$origKey]['attributes']['navID']);
+    }
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_alterSettingsFolders().
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterSettingsFolders
+ */
+function _orgtaskskr_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
+  static $configured = FALSE;
+  if ($configured) {
+    return;
+  }
+  $configured = TRUE;
+
+  $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
+  if(is_dir($settingsDir) && !in_array($settingsDir, $metaDataFolders)) {
+    $metaDataFolders[] = $settingsDir;
+  }
+}

--- a/tools/extensions/com.compucorp.orgtaskskr/orgtaskskr.php
+++ b/tools/extensions/com.compucorp.orgtaskskr/orgtaskskr.php
@@ -1,0 +1,181 @@
+<?php
+
+require_once 'orgtaskskr.civix.php';
+
+/**
+ * Implements hook_civicrm_config().
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_config
+ */
+function orgtaskskr_civicrm_config(&$config) {
+  _orgtaskskr_civix_civicrm_config($config);
+}
+
+/**
+ * Implements hook_civicrm_xmlMenu().
+ *
+ * @param array $files
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_xmlMenu
+ */
+function orgtaskskr_civicrm_xmlMenu(&$files) {
+  _orgtaskskr_civix_civicrm_xmlMenu($files);
+}
+
+/**
+ * Implements hook_civicrm_install().
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_install
+ */
+function orgtaskskr_civicrm_install() {
+  _orgtaskskr_civix_civicrm_install();
+}
+
+/**
+ * Implements hook_civicrm_uninstall().
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_uninstall
+ */
+function orgtaskskr_civicrm_uninstall() {
+  _orgtaskskr_civix_civicrm_uninstall();
+}
+
+/**
+ * Implements hook_civicrm_enable().
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_enable
+ */
+function orgtaskskr_civicrm_enable() {
+  _orgtaskskr_civix_civicrm_enable();
+}
+
+/**
+ * Implements hook_civicrm_disable().
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_disable
+ */
+function orgtaskskr_civicrm_disable() {
+  _orgtaskskr_civix_civicrm_disable();
+}
+
+/**
+ * Implements hook_civicrm_upgrade().
+ *
+ * @param $op string, the type of operation being performed; 'check' or 'enqueue'
+ * @param $queue CRM_Queue_Queue, (for 'enqueue') the modifiable list of pending up upgrade tasks
+ *
+ * @return mixed
+ *   Based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
+ *                for 'enqueue', returns void
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_upgrade
+ */
+function orgtaskskr_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
+  return _orgtaskskr_civix_civicrm_upgrade($op, $queue);
+}
+
+/**
+ * Implements hook_civicrm_managed().
+ *
+ * Generate a list of entities to create/deactivate/delete when this module
+ * is installed, disabled, uninstalled.
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_managed
+ */
+function orgtaskskr_civicrm_managed(&$entities) {
+  _orgtaskskr_civix_civicrm_managed($entities);
+}
+
+/**
+ * Implements hook_civicrm_caseTypes().
+ *
+ * Generate a list of case-types.
+ *
+ * @param array $caseTypes
+ *
+ * Note: This hook only runs in CiviCRM 4.4+.
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_caseTypes
+ */
+function orgtaskskr_civicrm_caseTypes(&$caseTypes) {
+  _orgtaskskr_civix_civicrm_caseTypes($caseTypes);
+}
+
+/**
+ * Implements hook_civicrm_angularModules().
+ *
+ * Generate a list of Angular modules.
+ *
+ * Note: This hook only runs in CiviCRM 4.5+. It may
+ * use features only available in v4.6+.
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_caseTypes
+ */
+function orgtaskskr_civicrm_angularModules(&$angularModules) {
+  $angularModule['crmProfileUtils'] = array(
+    'ext' => 'org.compucorp.orgtaskskr',
+    'js' => array('js/*.js'),
+    'partials' => array('partials'),
+  );
+}
+
+/**
+ * Implements hook_civicrm_alterSettingsFolders().
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterSettingsFolders
+ */
+function orgtaskskr_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
+  _orgtaskskr_civix_civicrm_alterSettingsFolders($metaDataFolders);
+}
+
+function orgtaskskr_civicrm_tabset($tabsetName, &$tabs, $context) {
+  if ($tabsetName == 'civicrm/contact/view') {
+    //var_dump($tabsetName, $tabs, $context);
+	  //$context['contact_id']
+    
+    $contact = civicrm_api3('Contact', 'get', array(
+      'sequential' => 1,
+      'return' => array("contact_type"),
+      'id' => $context['contact_id'],
+    ));
+    
+    if ($contact['values'][0]['contact_type'] == 'Organization') {
+      $tabs[] = array( 
+        'id' => 'orgTasksTab',
+        'url' => CRM_Utils_System::url('civicrm/tasklist', "contact=" . $context['contact_id']),
+        'title' => ts('Org. Activities'),
+        'weight' => 300,
+      );
+    }
+  }
+}
+
+/**
+ * Functions below this ship commented out. Uncomment as required.
+ *
+
+/**
+ * Implements hook_civicrm_preProcess().
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_preProcess
+ *
+function orgtaskskr_civicrm_preProcess($formName, &$form) {
+
+} // */
+
+/**
+ * Implements hook_civicrm_navigationMenu().
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_navigationMenu
+ */
+function orgtaskskr_civicrm_navigationMenu(&$menu) {
+  _orgtaskskr_civix_insert_navigation_menu($menu, 'Administer/System Settings', array(
+    'label' => ts('Organization Activity Lists', array('domain' => 'com.compucorp.orgtaskskr')),
+    'name' => 'tasklist_admin',
+    'url' => 'civicrm/tasklist/admin',
+    'permission' => 'access CiviReport,access CiviContribute',
+    'operator' => 'OR',
+    'separator' => 0,
+  ));
+  _orgtaskskr_civix_navigationMenu($menu);
+} // */

--- a/tools/extensions/com.compucorp.orgtaskskr/templates/CRM/Orgtaskskr/Form/OrgTaskListAdmin.tpl
+++ b/tools/extensions/com.compucorp.orgtaskskr/templates/CRM/Orgtaskskr/Form/OrgTaskListAdmin.tpl
@@ -1,0 +1,27 @@
+{* HEADER *}
+
+<div class="crm-submit-buttons">
+{include file="CRM/common/formButtons.tpl" location="top"}
+</div>
+
+{* FIELD EXAMPLE: OPTION 1 (AUTOMATIC LAYOUT) *}
+
+{foreach from=$elementNames item=elementName}
+  <div class="crm-section">
+    <div class="label">{$form.$elementName.label}</div>
+    <div class="content">{$form.$elementName.html}</div>
+    <div class="clear"></div>
+  </div>
+{/foreach}
+
+{* FIELD EXAMPLE: OPTION 2 (MANUAL LAYOUT)
+
+  <div>
+    <span>{$form.favorite_color.label}</span>
+    <span>{$form.favorite_color.html}</span>
+  </div>
+
+{* FOOTER *}
+<div class="crm-submit-buttons">
+{include file="CRM/common/formButtons.tpl" location="bottom"}
+</div>

--- a/tools/extensions/com.compucorp.orgtaskskr/templates/CRM/Orgtaskskr/Page/ContactSummary.tpl
+++ b/tools/extensions/com.compucorp.orgtaskskr/templates/CRM/Orgtaskskr/Page/ContactSummary.tpl
@@ -1,0 +1,124 @@
+<a href="{crmURL p='civicrm/profile/view' q="reset=1&gid=7&id=`$contact.contact_id`&snippet=4"}" class="crm-summary-link">
+  <div class="icon crm-icon {$contact.inner_contact_type}-icon"></div>
+  <div class="crm-tooltip-wrapper">
+    <div class="crm-tooltip">            
+      <div class="crm-summary-group">
+        <table class="crm-table-group-summary">
+          <tbody><tr><td>{$contact.display_name}</td></tr>
+            <tr><td>
+                <div class="crm-summary-col-0">
+                  <div class="crm-section phone_1_1-section">
+                    <div class="label">
+                      Home Phone
+                    </div>
+                    <div class="content">
+                      {$contact.inner_phone}
+                    </div>
+                    <div class="clear"></div>
+                  </div>
+                  <div class="crm-section phone_1_2-section">
+                    <div class="label">
+                      Home Mobile
+                    </div>
+                    <div class="content">
+                      {$contact.inner_phone}
+                    </div>
+                    <div class="clear"></div>
+                  </div>
+                  <div class="crm-section street_address_Primary-section">
+                    <div class="label">
+                      Primary Address
+                    </div>
+                    <div class="content">
+                      {$contact.inner_street_address}
+                    </div>
+                    <div class="clear"></div>
+                  </div>
+                  <div class="crm-section city_Primary-section">
+                    <div class="label">
+                      City
+                    </div>
+                    <div class="content">
+                      {$contact.inner_city}
+                    </div>
+                    <div class="clear"></div>
+                  </div>
+                  <div class="crm-section state_province_Primary-section">
+                    <div class="label">
+                      State
+                    </div>
+                    <div class="content">
+                      {$contact.inner_state_province}, {$contact.inner_country}
+                    </div>
+                    <div class="clear"></div>
+                  </div>
+                  <div class="crm-section postal_code_Primary-section">
+                    <div class="label">
+                      Postal Code
+                    </div>
+                    <div class="content">
+                      {$contact.inner_postal_code}
+                    </div>
+                    <div class="clear"></div>
+                  </div>
+                </div>
+              </td><td>
+                <div class="crm-summary-col-1">
+                  <div class="crm-section email_Primary-section">
+                    <div class="label">
+                      Primary Email
+                    </div>
+                    <div class="content">
+                      {$contact.inner_email}
+                    </div>
+                    <div class="clear"></div>
+                  </div>
+                  {*
+                  <div class="crm-section group-section">
+                    <div class="label">
+                      Groups
+                    </div>
+                    <div class="content">
+
+                    </div>
+                    <div class="clear"></div>
+                  </div>
+                  
+                  <div class="crm-section tag-section">
+                    <div class="label">
+                      Tags
+                    </div>
+                    <div class="content">
+
+                    </div>
+                    <div class="clear"></div>
+                  </div>
+                  *}
+                  <div class="crm-section gender_id-section">
+                    <div class="label">
+                      Gender
+                    </div>
+                    <div class="content">
+                      {$contact.inner_gender}
+                    </div>
+                    <div class="clear"></div>
+                  </div>
+                  <div class="crm-section birth_date-section">
+                    <div class="label">
+                      Date of Birth
+                    </div>
+                    <div class="content">
+                      {$contact.inner_birth_date}
+                    </div>
+                    <div class="clear"></div>
+                  </div>
+                </div>
+              </td></tr>
+          </tbody></table>
+      </div>
+    </div>
+  </div>
+</a>
+<a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$contact.contact_id`"}">
+  {$contact.display_name}
+</a>

--- a/tools/extensions/com.compucorp.orgtaskskr/templates/CRM/Orgtaskskr/Page/TaskList.tpl
+++ b/tools/extensions/com.compucorp.orgtaskskr/templates/CRM/Orgtaskskr/Page/TaskList.tpl
@@ -1,0 +1,56 @@
+{*
+<div class="crm-activity-selector-{$context}">
+  <div class="crm-accordion-wrapper crm-search_filters-accordion">
+    <div class="crm-accordion-header">
+    {ts}Filter by Activity Type{/ts}</a>
+    </div><!-- /.crm-accordion-header -->
+    <div class="crm-accordion-body">
+      <div class="no-border form-layout-compressed activity-search-options">
+          <div class="crm-contact-form-block-activity_type_filter_id crm-inline-edit-field">
+            {$form.activity_type_filter_id.label} {$form.activity_type_filter_id.html|crmAddClass:big}
+          </div>
+          <div class="crm-contact-form-block-activity_type_exclude_filter_id crm-inline-edit-field">
+            {$form.activity_type_exclude_filter_id.label} {$form.activity_type_exclude_filter_id.html|crmAddClass:big}
+          </div>
+      </div>
+    </div><!-- /.crm-accordion-body -->
+  </div><!-- /.crm-accordion-wrapper -->
+ *}
+  <table class="contact-activity-selector-orgtasks{* crm-ajax-table*}">
+    <thead>
+    <tr>
+      <th data-data="activity_type" class="crm-contact-activity-activity_type" data-orderable="false">{ts}Type{/ts}</th>
+      <th data-data="subject" cell-class="crmf-subject crm-editable" data-orderable="false" class="crm-contact-activity_subject">{ts}Subject{/ts}</th>
+      <th data-data="source_contact_name" data-orderable="false" class="crm-contact-activity-source_contact">{ts}Added By{/ts}</th>
+      <th data-data="target_contact_name" data-orderable="false" class="crm-contact-activity-target_contact">{ts}With{/ts}</th>
+      <th data-data="assignee_contact_name" data-orderable="false" class="crm-contact-activity-assignee_contact">{ts}Assigned{/ts}</th>
+      <th data-data="activity_date_time" class="crm-contact-activity-activity_date" data-orderable="false">{ts}Date{/ts}</th>
+      <th data-data="status_id" cell-class="crmf-status_id crm-editable" cell-data-type="select" cell-data-refresh="true" class="crm-contact-activity-activity_status" data-orderable="false">{ts}Status{/ts}</th>
+      <th data-data="links" data-orderable="false" class="crm-contact-activity-links">&nbsp;</th>
+    </tr>
+    </thead>
+    {foreach from=$activities item="currActivity"}
+      <tr class="{cycle values="odd-row,even-row"}">
+        <td>{$currActivity.activity_type.label}</td>
+        <td>{$currActivity.subject}</td>
+        <td>
+          {include file="CRM/Orgtaskskr/Page/ContactSummary.tpl" contact=$currActivity.creator}
+        </td>
+        <td>
+          {foreach from=$currActivity.targets item="currTarget"}
+            {include file="CRM/Orgtaskskr/Page/ContactSummary.tpl" contact=$currTarget}
+          {/foreach}
+        </td>
+        <td>
+          {foreach from=$currActivity.assigned item="currTarget"}
+            {include file="CRM/Orgtaskskr/Page/ContactSummary.tpl" contact=$currTarget}
+          {/foreach}
+        </td>
+        <td>{$currActivity.date}</td>
+        <td>{$currActivity.status.label}</td>
+        <td></td>
+      </tr>
+    {/foreach}
+  </table>
+
+</div>

--- a/tools/extensions/com.compucorp.orgtaskskr/xml/Menu/orgtaskskr.xml
+++ b/tools/extensions/com.compucorp.orgtaskskr/xml/Menu/orgtaskskr.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<menu>
+  <item>
+    <path>civicrm/tasklist</path>
+    <page_callback>CRM_Orgtaskskr_Page_TaskList</page_callback>
+    <title>TaskList</title>
+    <access_arguments>access CiviCRM</access_arguments>
+  </item>
+  <item>
+    <path>civicrm/tasklist/admin</path>
+    <page_callback>CRM_Orgtaskskr_Form_OrgTaskListAdmin</page_callback>
+    <title>Organization Activity Lists Administration</title>
+    <access_arguments>access CiviCRM</access_arguments>
+  </item>
+</menu>


### PR DESCRIPTION
Alpha release of Extension that adds new tab to contact summary, and shows all activities undertaken by members of the organisation.

The aim of this extension is to show all of the activities (i.e. phone calls, meetings, letters) for all of the persons who work at a particular organisation on the organisation contact record. This means that a user can quickly look at the “parent” organisation record and see all the communications with everyone who works there.

For additional flexibility, a settings page (that is only accessible by the administrator) was added at "Administer > System Settings > Organization Activity Lists" to:
- specify which relationship types should be included by the new tab 
- which activity types should be included by the new tab
