### PR TITLE
CRM-19230: Fix groupBy for mailing summary report

### DIFF
--- a/CRM/Report/Form/Mailing/Summary.php
+++ b/CRM/Report/Form/Mailing/Summary.php
@@ -458,7 +458,6 @@ class CRM_Report_Form_Mailing_Summary extends CRM_Report_Form {
   public function groupBy() {
     $groupBy = array(
       "{$this->_aliases['civicrm_mailing']}.id",
-      "{$this->_aliases['civicrm_mailing_job']}.end_date",
     );
     $this->_groupBy = CRM_Contact_BAO_Query::getGroupByFromSelectColumns($this->_selectClauses, $groupBy);
   }


### PR DESCRIPTION
- [CRM-19230: CiviMail Reporting splitting results by mailing job size rather than mailing](https://issues.civicrm.org/jira/browse/CRM-19230)
