### PR TITLE
CRM-19315 - Block ID and PCP ID are bugging result on getPcpDashboardInfo function

### DIFF
--- a/CRM/PCP/BAO/PCP.php
+++ b/CRM/PCP/BAO/PCP.php
@@ -117,7 +117,7 @@ WHERE  civicrm_pcp.contact_id = civicrm_contact.id
     $links = self::pcpLinks();
 
     $query = "
-SELECT * FROM civicrm_pcp pcp
+SELECT pcp.*, block.is_tellfriend_enabled FROM civicrm_pcp pcp
 LEFT JOIN civicrm_pcp_block block ON block.id = pcp.pcp_block_id
 WHERE pcp.is_active = 1
   AND pcp.contact_id = %1


### PR DESCRIPTION
Now you can peek, this query is looking for PCP in database, and showing all tables of civicrm_pcp and civicrm_pcp_block, this include their "**ID**", it can be fail because depend the configuration of database server the result, i mean, the server will select between pcp_block's(table) ID or pcp's(table) ID(**In my case, my database server, selected the block ID instead of PCP ID**), it's bad because pcp(table) and pcp_block(table) they has the same ID field name, but, it's good structure schema in database, the problem is the query, and can be solve.

---
- [CRM-19315: Block ID and PCP ID are bugging result on getPcpDashboardInfo function(SOLVED)](https://issues.civicrm.org/jira/browse/CRM-19315)
