### PR TITLE
Issue #CRM-19271 Fixed:  Repeat event: cannot repeat an event for more than 3 days

### DIFF
--- a/xml/schema/Core/ActionSchedule.xml
+++ b/xml/schema/Core/ActionSchedule.xml
@@ -82,7 +82,7 @@
   <field>
     <name>start_action_condition</name>
     <type>varchar</type>
-    <length>32</length>
+    <length>62</length>
     <comment>Reminder Action</comment>
     <add>3.4</add>
   </field>


### PR DESCRIPTION
The xml schema definition of the action_schedule table is wrong. The start_action_condition column allows only 32 characters. 

I figured this out and made a little change by increasing it to 62.
