### PR TITLE
CRM-21128 Personal Campaign Page selection with force=1 in Find Contributions

### DIFF
--- a/CRM/Contribute/Form/Search.php
+++ b/CRM/Contribute/Form/Search.php
@@ -394,10 +394,10 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
     if ($pcpid) {
       // Add new pcpid to the tail of the array...
       foreach ($pcpid as $pcpIdList) {
-        $this->_formValues['contribution_pcp_made_through_id'][]=$pcpIdList;
+        $this->_formValues['contribution_pcp_made_through_id'][] = $pcpIdList;
       }
-    // and avoid any duplicate
-      $this->_formValues['contribution_pcp_made_through_id']=array_unique($this->_formValues['contribution_pcp_made_through_id']);
+      // and avoid any duplicate
+      $this->_formValues['contribution_pcp_made_through_id'] = array_unique($this->_formValues['contribution_pcp_made_through_id']);
     }
 
     $cid = CRM_Utils_Request::retrieve('cid', 'Positive', $this);

--- a/CRM/Contribute/Form/Search.php
+++ b/CRM/Contribute/Form/Search.php
@@ -390,6 +390,11 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
       $this->_defaults['contribution_status_id'] = array($status => 1);
     }
 
+    $pcpid=CRM_Utils_Request::retrieve('pcpid', 'Positive', $this);
+    if ($pcpid) {
+    	$this->_formValues['contribution_pcp_made_through_id'][0]=$pcpid;
+    }
+
     $cid = CRM_Utils_Request::retrieve('cid', 'Positive', $this);
 
     if ($cid) {

--- a/CRM/Contribute/Form/Search.php
+++ b/CRM/Contribute/Form/Search.php
@@ -394,7 +394,7 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
     if ($pcpid) {
     	// Add new pcpid to the tail of the array...
     	foreach ($pcpid as $pcpIdList) {
-    		$this->_formValues['contribution_pcp_made_through_id'][]=$pcpIdList; $n++;
+    		$this->_formValues['contribution_pcp_made_through_id'][]=$pcpIdList;
     	}
     	// and avoid any duplicate
     	$this->_formValues['contribution_pcp_made_through_id']=array_unique($this->_formValues['contribution_pcp_made_through_id']);

--- a/CRM/Contribute/Form/Search.php
+++ b/CRM/Contribute/Form/Search.php
@@ -390,14 +390,14 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
       $this->_defaults['contribution_status_id'] = array($status => 1);
     }
 
-    $pcpid=(array)CRM_Utils_Request::retrieve('pcpid', 'String', $this);
+    $pcpid = (array) CRM_Utils_Request::retrieve('pcpid', 'String', $this);
     if ($pcpid) {
-    	// Add new pcpid to the tail of the array...
-    	foreach ($pcpid as $pcpIdList) {
-    		$this->_formValues['contribution_pcp_made_through_id'][]=$pcpIdList;
-    	}
-    	// and avoid any duplicate
-    	$this->_formValues['contribution_pcp_made_through_id']=array_unique($this->_formValues['contribution_pcp_made_through_id']);
+      // Add new pcpid to the tail of the array...
+      foreach ($pcpid as $pcpIdList) {
+        $this->_formValues['contribution_pcp_made_through_id'][]=$pcpIdList;
+      }
+    // and avoid any duplicate
+      $this->_formValues['contribution_pcp_made_through_id']=array_unique($this->_formValues['contribution_pcp_made_through_id']);
     }
 
     $cid = CRM_Utils_Request::retrieve('cid', 'Positive', $this);

--- a/CRM/Contribute/Form/Search.php
+++ b/CRM/Contribute/Form/Search.php
@@ -390,9 +390,14 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
       $this->_defaults['contribution_status_id'] = array($status => 1);
     }
 
-    $pcpid=CRM_Utils_Request::retrieve('pcpid', 'Positive', $this);
+    $pcpid=(array)CRM_Utils_Request::retrieve('pcpid', 'String', $this);
     if ($pcpid) {
-    	$this->_formValues['contribution_pcp_made_through_id'][0]=$pcpid;
+    	// Add new pcpid to the tail of the array...
+    	foreach ($pcpid as $pcpIdList) {
+    		$this->_formValues['contribution_pcp_made_through_id'][]=$pcpIdList; $n++;
+    	}
+    	// and avoid any duplicate
+    	$this->_formValues['contribution_pcp_made_through_id']=array_unique($this->_formValues['contribution_pcp_made_through_id']);
     }
 
     $cid = CRM_Utils_Request::retrieve('cid', 'Positive', $this);


### PR DESCRIPTION
As per: Option 1: 3\* - Personal Campaign Pages - Contact tab

This change is need to avoid  overriding this file in the extrension code

---

 * [CRM-21128: Personal Campaign Page selection with force=1 in Find Contributions](https://issues.civicrm.org/jira/browse/CRM-21128)