### PR TITLE
CRM-19325 - enable search for contributions that are not in any batch.

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -1733,6 +1733,12 @@ class CRM_Contact_BAO_Query {
     ) {
       $result = array($id, 'IN', $values, 0, $wildcard);
     }
+    // Hack for CRM-19325. This is ugly because it creates a dependency
+    // to the form, that returns the string 'NULL' if the user wants
+    // contributions that are not contained in any batch.
+    else if ($id == 'contribution_batch_id' && $values == 'NULL') {
+      $result = array($id, 'IS', 'NULL', 0, 0);
+    }
     else {
       $result = array($id, '=', $values, 0, $wildcard);
     }

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -1736,7 +1736,7 @@ class CRM_Contact_BAO_Query {
     // Hack for CRM-19325. This is ugly because it creates a dependency
     // to the form, that returns the string 'NULL' if the user wants
     // contributions that are not contained in any batch.
-    else if ($id == 'contribution_batch_id' && $values == 'NULL') {
+    elseif ($id == 'contribution_batch_id' && $values == 'NULL') {
       $result = array($id, 'IS', 'NULL', 0, 0);
     }
     else {

--- a/CRM/Contribute/BAO/Query.php
+++ b/CRM/Contribute/BAO/Query.php
@@ -568,6 +568,9 @@ class CRM_Contribute_BAO_Query {
 
       case 'contribution_batch_id':
         $batches = CRM_Contribute_PseudoConstant::batch();
+        // The key 'NULL' indicates that the user is looking for contributions
+        // that are not contained in a batch, see CRM-19325.
+        $batches['NULL'] = ts('(none)');
         $query->_where[$grouping][] = " civicrm_entity_batch.batch_id $op $value";
         $query->_qill[$grouping][] = ts('Batch Name %1 %2', array(1 => $op, 2 => $batches[$value]));
         $query->_tables['civicrm_contribution'] = $query->_whereTables['civicrm_contribution'] = 1;
@@ -1134,7 +1137,11 @@ class CRM_Contribute_BAO_Query {
     if (!empty($batches)) {
       $form->add('select', 'contribution_batch_id',
         ts('Batch Name'),
-        array('' => ts('- any -')) + $batches,
+        array(
+          '' => ts('- any -'),
+          // CRM-19325
+          'NULL' => ts('None'),
+        ) + $batches,
         FALSE, array('class' => 'crm-select2')
       );
     }

--- a/CRM/Contribute/Form/Search.php
+++ b/CRM/Contribute/Form/Search.php
@@ -337,6 +337,7 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
       );
     }
 
+    // Why is this called twice? (see line 317)
     $this->_queryParams = CRM_Contact_BAO_Query::convertFormValues($this->_formValues);
     $selector = new CRM_Contribute_Selector_Search($this->_queryParams,
       $this->_action,


### PR DESCRIPTION
I added 'none' to the 'contribution name' drop down on the contribution search form. This allows searching for contributions not in any batch.

---
- [CRM-19325: Search contributions that are not in any batch](https://issues.civicrm.org/jira/browse/CRM-19325)
