### PR TITLE
CRM-19327 - remove invalid SQL character

### DIFF
--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -544,7 +544,7 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
                         AND     $ebTable.id IS null
                         AND    ( contact_a.is_opt_out = 0
                         OR       contact_a.do_not_sms = 0 )
-                        $aclWhere}";
+                        $aclWhere";
     }
     $eq->query($query);
 


### PR DESCRIPTION
resolve issue CRM-19327
 posted to SE: https://civicrm.stackexchange.com/questions/12647/what-causes-the-sms-system-to-stop-working-and-throw-db-errors

---
- [CRM-19327: DB error for SMS mailing job](https://issues.civicrm.org/jira/browse/CRM-19327)
