### PR TITLE
CRM-19335

### DIFF
--- a/CRM/Mailing/Event/BAO/Bounce.php
+++ b/CRM/Mailing/Event/BAO/Bounce.php
@@ -75,7 +75,7 @@ class CRM_Mailing_Event_BAO_Bounce extends CRM_Mailing_Event_DAO_Bounce {
     }
 
     // CRM-11989
-    $params['bounce_reason'] = substr($params['bounce_reason'], 0, 254);
+    $params['bounce_reason'] = mb_strcut($params['bounce_reason'], 0, 254);
 
     $bounce->copyValues($params);
     $bounce->save();


### PR DESCRIPTION
This creates a multibyte aware substring.
Since we are using MySQL >= 5 we could also use mb_substr($params['bounce_reason'], 0, 255) to fully use that varchar(255).

---
- [CRM-19335: CiviMail bounce processing: substring for bounce reason is not multibyte aware](https://issues.civicrm.org/jira/browse/CRM-19335)
