### PR TITLE
CRM-17789 Allow end users to stop the switch to mysqli for the dsn

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -32,6 +32,10 @@
  * @copyright CiviCRM LLC (c) 2004-2016
  */
 
+if (!defined('DB_DSN_MODE')) {
+  define('DB_DSN_MODE', 'auto');
+}
+
 require_once 'PEAR.php';
 require_once 'DB/DataObject.php';
 


### PR DESCRIPTION
ping @totten

---
- [CRM-17789: Support PHP 7](https://issues.civicrm.org/jira/browse/CRM-17789)
