### PR TITLE
CRM-18199 CRM_Utils_File::sourceSQLFile too greedy

### DIFF
--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -324,7 +324,7 @@ class CRM_Utils_File {
 
     // get rid of comments starting with # and --
 
-    $string = preg_replace("/^(#|--)[^\R]*$/m", "", $string);
+    $string = preg_replace("/^(#|--).*\R*/m", "", $string);
 
     $queries = preg_split('/;\s*$/m', $string);
     foreach ($queries as $query) {

--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -324,8 +324,7 @@ class CRM_Utils_File {
 
     // get rid of comments starting with # and --
 
-    $string = preg_replace("/^#[^\n]*$/m", "\n", $string);
-    $string = preg_replace("/^(--[^-]).*/m", "\n", $string);
+    $string = preg_replace("/^(#|--)[^\R]*$/m", "", $string);
 
     $queries = preg_split('/;\s*$/m', $string);
     foreach ($queries as $query) {

--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -350,7 +350,7 @@ class CRM_Utils_File {
    * @param string $string
    *
    * @return string
-   *  stripped string
+   *   stripped string
    */
   public static function stripComments($string) {
     return preg_replace("/^(#|--).*\R*/m", "", $string);

--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -324,7 +324,7 @@ class CRM_Utils_File {
 
     // get rid of comments starting with # and --
 
-    $string = preg_replace("/^(#|--).*\R*/m", "", $string);
+    $string = self::stripComments($string);
 
     $queries = preg_split('/;\s*$/m', $string);
     foreach ($queries as $query) {
@@ -342,6 +342,18 @@ class CRM_Utils_File {
         }
       }
     }
+  }
+  /**
+   *
+   * Strips comment from a possibly multiline SQL string
+   *
+   * @param string $string
+   *
+   * @return string
+   *  stripped string
+   */
+  public static function stripComments($string) {
+    return preg_replace("/^(#|--).*\R*/m", "", $string);
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/FileTest.php
+++ b/tests/phpunit/CRM/Utils/FileTest.php
@@ -25,21 +25,21 @@ class CRM_Utils_FileTest extends CiviUnitTestCase {
   }
   public function testStripComment() {
     $strings = array(
-        "\nab\n-- cd\nef" => "\nab\nef",
-        "ab\n-- cd\nef" => "ab\nef",
-        "ab\n-- cd\nef\ngh" => "ab\nef\ngh",
-        "ab\n--cd\nef" => "ab\nef",
-        "ab\n--cd\nef\n" => "ab\nef\n",
-        "ab\n#cd\nef\n" => "ab\nef\n",
-        "ab\n--cd\nef" => "ab\nef",
-        "ab\n#cd\nef" => "ab\nef",
-        "ab\nfoo#cd\nef" => "ab\nfoo#cd\nef",
-        "ab\r\n--cd\r\nef" => "ab\r\nef",
-        "ab\r\n#cd\r\nef" => "ab\r\nef",
-        "ab\r\nfoo#cd\r\nef" => "ab\r\nfoo#cd\r\nef",
+      "\nab\n-- cd\nef" => "\nab\nef",
+      "ab\n-- cd\nef" => "ab\nef",
+      "ab\n-- cd\nef\ngh" => "ab\nef\ngh",
+      "ab\n--cd\nef" => "ab\nef",
+      "ab\n--cd\nef\n" => "ab\nef\n",
+      "ab\n#cd\nef\n" => "ab\nef\n",
+      "ab\n--cd\nef" => "ab\nef",
+      "ab\n#cd\nef" => "ab\nef",
+      "ab\nfoo#cd\nef" => "ab\nfoo#cd\nef",
+      "ab\r\n--cd\r\nef" => "ab\r\nef",
+      "ab\r\n#cd\r\nef" => "ab\r\nef",
+      "ab\r\nfoo#cd\r\nef" => "ab\r\nfoo#cd\r\nef",
     );
     foreach ($strings as $string => $check) {
-      $test=CRM_Utils_File::stripComments($string);
+      $test = CRM_Utils_File::stripComments($string);
       $this->assertEquals($test,
           $check,
           sprintf("original=[%s]\nstripped=[%s]\nexpected=[%s]",

--- a/tests/phpunit/CRM/Utils/FileTest.php
+++ b/tests/phpunit/CRM/Utils/FileTest.php
@@ -25,18 +25,18 @@ class CRM_Utils_FileTest extends CiviUnitTestCase {
   }
   public function testStripComment() {
     $strings = array(
-        "\nab\n-- cd\nef"=>"\nab\nef",
-        "ab\n-- cd\nef"=>"ab\nef",
-        "ab\n-- cd\nef\ngh"=>"ab\nef\ngh",
-        "ab\n--cd\nef"=>"ab\nef",
-        "ab\n--cd\nef\n"=>"ab\nef\n",
-        "ab\n#cd\nef\n"=>"ab\nef\n",
-        "ab\n--cd\nef"=>"ab\nef",
-        "ab\n#cd\nef"=>"ab\nef",
-        "ab\nfoo#cd\nef"=>"ab\nfoo#cd\nef",
-        "ab\r\n--cd\r\nef"=>"ab\r\nef",
-        "ab\r\n#cd\r\nef"=>"ab\r\nef",
-        "ab\r\nfoo#cd\r\nef"=>"ab\r\nfoo#cd\r\nef",
+        "\nab\n-- cd\nef" => "\nab\nef",
+        "ab\n-- cd\nef" => "ab\nef",
+        "ab\n-- cd\nef\ngh" => "ab\nef\ngh",
+        "ab\n--cd\nef" => "ab\nef",
+        "ab\n--cd\nef\n" => "ab\nef\n",
+        "ab\n#cd\nef\n" => "ab\nef\n",
+        "ab\n--cd\nef" => "ab\nef",
+        "ab\n#cd\nef" => "ab\nef",
+        "ab\nfoo#cd\nef" => "ab\nfoo#cd\nef",
+        "ab\r\n--cd\r\nef" => "ab\r\nef",
+        "ab\r\n#cd\r\nef" => "ab\r\nef",
+        "ab\r\nfoo#cd\r\nef" => "ab\r\nfoo#cd\r\nef",
     );
     foreach ($strings as $string => $check) {
       $test=CRM_Utils_File::stripComments($string);

--- a/tests/phpunit/CRM/Utils/FileTest.php
+++ b/tests/phpunit/CRM/Utils/FileTest.php
@@ -23,5 +23,32 @@ class CRM_Utils_FileTest extends CiviUnitTestCase {
       ));
     }
   }
+  public function testStripComment() {
+    $strings = array(
+        "\nab\n-- cd\nef"=>"\nab\nef",
+        "ab\n-- cd\nef"=>"ab\nef",
+        "ab\n-- cd\nef\ngh"=>"ab\nef\ngh",
+        "ab\n--cd\nef"=>"ab\nef",
+        "ab\n--cd\nef\n"=>"ab\nef\n",
+        "ab\n#cd\nef\n"=>"ab\nef\n",
+        "ab\n--cd\nef"=>"ab\nef",
+        "ab\n#cd\nef"=>"ab\nef",
+        "ab\nfoo#cd\nef"=>"ab\nfoo#cd\nef",
+        "ab\r\n--cd\r\nef"=>"ab\r\nef",
+        "ab\r\n#cd\r\nef"=>"ab\r\nef",
+        "ab\r\nfoo#cd\r\nef"=>"ab\r\nfoo#cd\r\nef",
+    );
+    foreach ($strings as $string => $check) {
+      $test=CRM_Utils_File::stripComments($string);
+      $this->assertEquals($test,
+          $check,
+          sprintf("original=[%s]\nstripped=[%s]\nexpected=[%s]",
+              json_encode($string),
+              json_encode($test),
+              json_encode($check)
+           )
+      );
+    }
+  }
 
 }


### PR DESCRIPTION
Refactored the 2 comment stripping regexp in just one and fixed the
greedyness

---
- [CRM-18199: CRM_Utils_File::sourceSQLFile too greedy when stripping comments](https://issues.civicrm.org/jira/browse/CRM-18199)
