### PR TITLE
CRM-17789 - Fix Notice Error on PHP 7

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -107,7 +107,8 @@ class CRM_Core_DAO extends DB_DataObject {
     if (defined('CIVICRM_DAO_DEBUG')) {
       self::DebugLevel(CIVICRM_DAO_DEBUG);
     }
-    CRM_Core_DAO::setFactory(new CRM_Contact_DAO_Factory());
+    $factory = new CRM_Contact_DAO_Factory();
+    CRM_Core_DAO::setFactory($factory);
     if (CRM_Utils_Constant::value('CIVICRM_MYSQL_STRICT', CRM_Utils_System::isDevelopment())) {
       CRM_Core_DAO::executeQuery('SET SESSION sql_mode = STRICT_TRANS_TABLES');
     }


### PR DESCRIPTION
- [CRM-17789: Support PHP 7](https://issues.civicrm.org/jira/browse/CRM-17789)

> Notice: Only variables should be passed by reference in CRM_Core_DAO::init() (line 110 of /home/web/civi_master/civicrm/CRM/Core/DAO.php).
