### PR TITLE
CRM-17789 - foreach fix in PHP 7

### DIFF
--- a/CRM/Custom/Form/Group.php
+++ b/CRM/Custom/Form/Group.php
@@ -530,7 +530,7 @@ class CRM_Custom_Form_Group extends CRM_Core_Form {
   public static function getFormattedList(&$list) {
     $relName = array();
 
-    foreach ($list as $listItemKey => $itemValue) {
+    foreach ($list as $listItemKey => &$itemValue) {
       // Extract the relationship ID.
       $key = substr($listItemKey, 0, strpos($listItemKey, '_'));
       if (isset($list["{$key}_b_a"])) {


### PR DESCRIPTION
- [CRM-17789: Support PHP 7](https://issues.civicrm.org/jira/browse/CRM-17789)

> Notice: Undefined index: 9_a_b in CRM_Custom_Form_Group::getFormattedList() (line 547 of /home/web/civi_master/civicrm/CRM/Custom/Form/Group.php).
> Notice: Undefined index: 1_a_b in CRM_Custom_Form_Group::getFormattedList() (line 547 of /home/web/civi_master/civicrm/CRM/Custom/Form/Group.php).
> Notice: Undefined index: 10_a_b in CRM_Custom_Form_Group::getFormattedList() (line 547 of /home/web/civi_master/civicrm/CRM/Custom/Form/Group.php).
> Notice: Undefined index: 5_a_b in CRM_Custom_Form_Group::getFormattedList() (line 547 of /home/web/civi_master/civicrm/CRM/Custom/Form/Group.php).
> Notice: Undefined index: 6_a_b in CRM_Custom_Form_Group::getFormattedList() (line 547 of /home/web/civi_master/civicrm/CRM/Custom/Form/Group.php).
> Notice: Undefined index: 7_a_b in CRM_Custom_Form_Group::getFormattedList() (line 547 of /home/web/civi_master/civicrm/CRM/Custom/Form/Group.php).
> Notice: Undefined index: 8_a_b in CRM_Custom_Form_Group::getFormattedList() (line 547 of /home/web/civi_master/civicrm/CRM/Custom/Form/Group.php).
