### PR TITLE
CRM-19355

### DIFF
--- a/ang/crmMailing/BlockMailing.html
+++ b/ang/crmMailing/BlockMailing.html
@@ -61,7 +61,7 @@ It could perhaps be thinned by 30-60% by making more directives.
           ng-model="mailing.recipients.groups.base[0]"
           ng-required="true"
           >
-          <option ng-repeat="grp in crmMailingConst.groupNames | orderBy:'title'" value="{{grp.id}}">{{grp.title}}</option>
+          <option ng-repeat="grp in crmMailingConst.groupNames | filter:{is_hidden:0} | orderBy:'title'" value="{{grp.id}}">{{grp.title}}</option>
         </select>
       </div>
     </span>


### PR DESCRIPTION
Hide hidden smart group from unsubscribe list

---
- [CRM-19355: Able select a hidden smart group as unsubscribe group for mailing from search results](https://issues.civicrm.org/jira/browse/CRM-19355)
