### PR TITLE
CRM-19348 - membership-api: max_related is ignored

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -284,7 +284,7 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
     // data cleanup only: all verifications on number of related memberships are done upstream in:
     // CRM_Member_BAO_Membership::createRelatedMemberships()
     // CRM_Contact_BAO_Relationship::relatedMemberships()
-    if (isset($params['owner_membership_id'])) {
+    if (!empty($params['owner_membership_id'])) {
       unset($params['max_related']);
     }
     else {


### PR DESCRIPTION
- [CRM-19348: membership api\/bao: max_related is ignored if ownder_membership_id isset](https://issues.civicrm.org/jira/browse/CRM-19348)
