### PR TITLE
CRM-19729

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -118,13 +118,18 @@ else {
 }
 
 if ($installType == 'wordpress') {
-  //WP Database Data
+  // Load WP database config
+  if (isset($_POST['mysql'])) {
+    $databaseConfig = $_POST['mysql'];
+  }
+  else {
   $databaseConfig = array(
     "server"   => DB_HOST,
     "username" => DB_USER,
     "password" => DB_PASSWORD,
     "database" => DB_NAME,
   );
+  }
 }
 
 if ($installType == 'drupal') {

--- a/install/index.php
+++ b/install/index.php
@@ -123,12 +123,12 @@ if ($installType == 'wordpress') {
     $databaseConfig = $_POST['mysql'];
   }
   else {
-  $databaseConfig = array(
-    "server"   => DB_HOST,
-    "username" => DB_USER,
-    "password" => DB_PASSWORD,
-    "database" => DB_NAME,
-  );
+    $databaseConfig = array(
+      "server"   => DB_HOST,
+      "username" => DB_USER,
+      "password" => DB_PASSWORD,
+      "database" => DB_NAME,
+    );
   }
 }
 


### PR DESCRIPTION
Fix CiviCRM databaseConfig for WordPress.  Default to existing WP database, but allow override.  Thsi will ensure re-check requirements does not overwrite the settings

---
- [CRM-19729](https://issues.civicrm.org/jira/browse/CRM-19729)
