### PR TITLE
CRM-19231 Fixed MultipleRecordFieldsListing.tpl extra th causing TypeError: i is undefined

### DIFF
--- a/templates/CRM/Profile/Page/MultipleRecordFieldsListing.tpl
+++ b/templates/CRM/Profile/Page/MultipleRecordFieldsListing.tpl
@@ -84,7 +84,7 @@
               {foreach from=$headers key=recId item=head}
                 <th>{ts}{$head}{/ts}</th>
               {/foreach}
-              <th></th>
+              
               {foreach from=$dateFields key=fieldId item=v}
                 <th class='hiddenElement'></th>
               {/foreach}


### PR DESCRIPTION
Removed the extra  <th> which is causing TypeError: i is undefined in Javascript

---
- [CRM-19231: MultipleRecordFieldsListing.tpl extra th causing TypeError: i is undefined](https://issues.civicrm.org/jira/browse/CRM-19231)
