### PR TITLE
CRM-19359: Resolve fatal error when setting locale programmatically.

### DIFF
--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -568,9 +568,6 @@ class CRM_Core_I18n {
    *   True if the domain was changed for an extension.
    */
   public function setLocale($language) {
-
-    $config = CRM_Core_Config::singleton();
-
     // Change the language of the CMS as well, for URLs.
     CRM_Utils_System::setUFLocale($language);
 
@@ -583,7 +580,7 @@ class CRM_Core_I18n {
       setlocale(LC_MESSAGES, $locale);
       setlocale(LC_CTYPE, $locale);
 
-      bindtextdomain('civicrm', $config->gettextResourceDir);
+      bindtextdomain('civicrm', CRM_Core_I18n::getResourceDir());
       bind_textdomain_codeset('civicrm', 'UTF-8');
       textdomain('civicrm');
 
@@ -595,7 +592,7 @@ class CRM_Core_I18n {
       require_once 'PHPgettext/streams.php';
       require_once 'PHPgettext/gettext.php';
 
-      $mo_file = $config->gettextResourceDir . $language . DIRECTORY_SEPARATOR . 'LC_MESSAGES' . DIRECTORY_SEPARATOR . 'civicrm.mo';
+      $mo_file = CRM_Core_I18n::getResourceDir() . $language . DIRECTORY_SEPARATOR . 'LC_MESSAGES' . DIRECTORY_SEPARATOR . 'civicrm.mo';
 
       $streamer = new FileReader($mo_file);
       $this->_phpgettext = new gettext_reader($streamer);


### PR DESCRIPTION
The use of the config object as related to gettext was factored out some time ago but reintroduced in 07844ccf58c7447e89b759fd85a0fe96cd5c3187.

---
- [CRM-19359: Fatal error when setting locale programmatically](https://issues.civicrm.org/jira/browse/CRM-19359)
