### PR TITLE
CRM-17789 fix foreach notices by checking if the a_b label is set

### DIFF
--- a/CRM/Custom/Form/Group.php
+++ b/CRM/Custom/Form/Group.php
@@ -544,8 +544,10 @@ class CRM_Custom_Form_Group extends CRM_Core_Form {
       }
       else {
         // If no '_b_a' label exists save the '_a_b' one and unset it from the list
-        $relName["{$key}"] = $list["{$key}_a_b"];
-        unset($list["{$key}_a_b"]);
+        if (isset($list["{$key}_a_b"])) {
+          $relName["{$key}"] = $list["{$key}_a_b"];
+          unset($list["{$key}_a_b"]);
+        }
       }
     }
     return $relName;


### PR DESCRIPTION
Alternate fix to https://github.com/civicrm/civicrm-core/pull/9024 ping @jitendrapurohit @totten

---
- [CRM-17789: Support PHP 7](https://issues.civicrm.org/jira/browse/CRM-17789)
