### PR TITLE
CRM-19270 test fix - add crmArrayColumn() function

### DIFF
--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -622,6 +622,28 @@ class CRM_Utils_Array {
   }
 
   /**
+   * Return the values from a single column in the input array.
+   *
+   * @param array $input
+   *   A list of records.
+   * @param int|string $columnKey
+   *   The column of values to return.
+   * @param int|string $indexKey
+   *   An optional column to use as the index/keys for the returned array.
+   *
+   * @return array
+   *   values representing a single column from the input array.
+   */
+  public static function crmArrayColumn($input, $columnKey, $indexKey = NULL) {
+    // use alternate collect() if `array_column` does not exist
+    if (!function_exists('array_column')) {
+      return self::collect($columnKey, $input);
+    }
+
+    return array_column($input, $columnKey, $indexKey);
+  }
+
+  /**
    * Iterates over a list of objects and executes some method on each.
    *
    * Comparison:

--- a/tests/phpunit/CRM/Contact/Page/AjaxTest.php
+++ b/tests/phpunit/CRM/Contact/Page/AjaxTest.php
@@ -230,7 +230,7 @@ class CRM_Contact_Page_AjaxTest extends CiviUnitTestCase {
       $this->groupContactCreate($groupId);
       $contactIds = array_merge($contactIds, CRM_Contact_BAO_Group::getGroupContacts($groupId));
     }
-    $contactIds = CRM_Utils_Array::collect('contact_id', $contactIds);
+    $contactIds = CRM_Utils_Array::crmArrayColumn($contactIds, 'contact_id');
 
     // create custom group with contact reference field
     $customGroup = $this->customGroupCreate(array('extends' => 'Contact', 'title' => 'select_test_group'));
@@ -253,7 +253,7 @@ class CRM_Contact_Page_AjaxTest extends CiviUnitTestCase {
       'is_unit_test' => TRUE,
     );
     $contactList = CRM_Contact_Page_AJAX::contactReference();
-    $contactList = CRM_Utils_Array::collect('id', $contactList);
+    $contactList = CRM_Utils_Array::crmArrayColumn($contactList, 'id');
 
     //assert each returned contact id to be present in group contact
     foreach ($contactList as $contactId) {


### PR DESCRIPTION
@seamuslee001 @totten This adds flexibility to use the latest built-in function(`array_column`) if exist as it provides a little more functionality to add `indexKeys` to the returned array.

waiting for the test build to run clean on PHP 5.3 as well.

---
- [CRM-19270: Can't search contact reference field on contribution form (by profile)](https://issues.civicrm.org/jira/browse/CRM-19270)
