### PR TITLE
CRM-19345: token santizes HTML when it shouldn't in Schedule reminder

### DIFF
--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -632,7 +632,8 @@ FROM civicrm_action_schedule cas
         $tokenRow->context['contact']['preferred_mail_format'] == 'Both'
       )
     ) {
-      $mailParams['html'] = $body_html;
+      //CRM-19345 : unsanitize HTML tags for HTML content
+      $mailParams['html'] = htmlspecialchars($body_html);
     }
     $result = CRM_Utils_Mail::send($mailParams);
     if (!$result || is_a($result, 'PEAR_Error')) {


### PR DESCRIPTION
- [CRM-19345: {event.description} token santizes HTML when it shouldn't](https://issues.civicrm.org/jira/browse/CRM-19345)
