### PR TITLE
CRM-19376 - ensure is_for_organization data is transferred.

### DIFF
--- a/CRM/Upgrade/Incremental/php/FourSeven.php
+++ b/CRM/Upgrade/Incremental/php/FourSeven.php
@@ -421,7 +421,7 @@ FROM `civicrm_dashboard_contact` JOIN `civicrm_contact` WHERE civicrm_dashboard_
     $ufGroupDAO->module = 'OnBehalf';
     $ufGroupDAO->find(TRUE);
 
-    $forOrgColums = array();
+    $forOrgColums = array('is_for_organization');
     if ($domain->locales) {
       $locales = explode(CRM_Core_DAO::VALUE_SEPARATOR, $domain->locales);
       foreach ($locales as $locale) {


### PR DESCRIPTION
In 4.6 -> 4.7 migration the is_for_organization flag from the
contribution table was being lost.

---
- [CRM-19376: is_for_orgazation field not being properly migrated from 4.6 to 4.7](https://issues.civicrm.org/jira/browse/CRM-19376)
