### PR TITLE
CRM-19377 - avoid static function errors on upgrade.

### DIFF
--- a/CRM/Upgrade/Incremental/php/FourSeven.php
+++ b/CRM/Upgrade/Incremental/php/FourSeven.php
@@ -286,7 +286,7 @@ class CRM_Upgrade_Incremental_php_FourSeven extends CRM_Upgrade_Incremental_Base
    * @param CRM_Queue_TaskContext $ctx
    * @return bool
    */
-  public function migrateSettings(CRM_Queue_TaskContext $ctx) {
+  public static function migrateSettings(CRM_Queue_TaskContext $ctx) {
     // Tip: If there are problems with adding the new uniqueness index, try inspecting:
     // SELECT name, domain_id, contact_id, count(*) AS dupes FROM civicrm_setting cs GROUP BY name, domain_id, contact_id HAVING dupes > 1;
 
@@ -386,7 +386,7 @@ class CRM_Upgrade_Incremental_php_FourSeven extends CRM_Upgrade_Incremental_Base
    *
    * @return bool
    */
-  public function addGettingStartedDashlet(CRM_Queue_TaskContext $ctx) {
+  public static function addGettingStartedDashlet(CRM_Queue_TaskContext $ctx) {
     $sql = "SELECT count(*) FROM civicrm_dashboard WHERE name='getting-started'";
     $res = CRM_Core_DAO::singleValueQuery($sql);
     $domainId = CRM_Core_Config::domainID();
@@ -482,7 +482,7 @@ FROM `civicrm_dashboard_contact` JOIN `civicrm_contact` WHERE civicrm_dashboard_
    *
    * @return bool
    */
-  public function migrateRemoteSubmissionsSetting(CRM_Queue_TaskContext $ctx) {
+  public static function migrateRemoteSubmissionsSetting(CRM_Queue_TaskContext $ctx) {
     $domains = CRM_Core_DAO::executeQuery("SELECT DISTINCT d.id FROM civicrm_domain d LEFT JOIN civicrm_setting s ON d.id=s.domain_id AND s.name = 'remote_profile_submissions' WHERE s.id IS NULL");
     while ($domains->fetch()) {
       CRM_Core_DAO::executeQuery(
@@ -507,7 +507,7 @@ FROM `civicrm_dashboard_contact` JOIN `civicrm_contact` WHERE civicrm_dashboard_
    *
    * @return bool
    */
-  public function fixContactTypeInSmartGroups(CRM_Queue_TaskContext $ctx) {
+  public static function fixContactTypeInSmartGroups(CRM_Queue_TaskContext $ctx) {
     $sep = CRM_Core_DAO::VALUE_SEPARATOR;
     $dao = CRM_Core_DAO::executeQuery("SELECT id, form_values FROM civicrm_saved_search WHERE form_values LIKE '%$sep%'");
     while ($dao->fetch()) {
@@ -532,7 +532,7 @@ FROM `civicrm_dashboard_contact` JOIN `civicrm_contact` WHERE civicrm_dashboard_
    *
    * @return bool
    */
-  public function deleteVersionCheckCacheFile(CRM_Queue_TaskContext $ctx) {
+  public static function deleteVersionCheckCacheFile(CRM_Queue_TaskContext $ctx) {
     $config = CRM_Core_Config::singleton();
     $cacheFile = $config->uploadDir . 'version-info-cache.json';
     if (file_exists($cacheFile)) {
@@ -548,7 +548,7 @@ FROM `civicrm_dashboard_contact` JOIN `civicrm_contact` WHERE civicrm_dashboard_
    *
    * @return bool
    */
-  public function disableFlexibleJobsExtension(CRM_Queue_TaskContext $ctx) {
+  public static function disableFlexibleJobsExtension(CRM_Queue_TaskContext $ctx) {
     try {
       civicrm_api3('Extension', 'disable', array('key' => 'com.klangsoft.flexiblejobs'));
     }
@@ -566,7 +566,7 @@ FROM `civicrm_dashboard_contact` JOIN `civicrm_contact` WHERE civicrm_dashboard_
    *
    * @return bool
    */
-  public function addIndexFinancialTrxnTrxnID(CRM_Queue_TaskContext $ctx) {
+  public static function addIndexFinancialTrxnTrxnID(CRM_Queue_TaskContext $ctx) {
     $tables = array('civicrm_financial_trxn' => array('trxn_id'));
     CRM_Core_BAO_SchemaHandler::createIndexes($tables);
     return TRUE;
@@ -579,7 +579,7 @@ FROM `civicrm_dashboard_contact` JOIN `civicrm_contact` WHERE civicrm_dashboard_
    *
    * @return bool
    */
-  public function addIndexContributionCreditNoteID(CRM_Queue_TaskContext $ctx) {
+  public static function addIndexContributionCreditNoteID(CRM_Queue_TaskContext $ctx) {
     $tables = array('civicrm_contribution' => array('creditnote_id'));
     CRM_Core_BAO_SchemaHandler::createIndexes($tables);
     return TRUE;
@@ -594,7 +594,7 @@ FROM `civicrm_dashboard_contact` JOIN `civicrm_contact` WHERE civicrm_dashboard_
    *
    * @return bool
    */
-  public function addCombinedIndexFinancialItemEntityIDEntityType() {
+  public static function addCombinedIndexFinancialItemEntityIDEntityType() {
     CRM_Core_BAO_SchemaHandler::dropIndexIfExists('civicrm_financial_item', 'UI_id');
     CRM_Core_BAO_SchemaHandler::dropIndexIfExists('civicrm_financial_item', 'IX_Entity');
     CRM_Core_BAO_SchemaHandler::createIndexes(array(
@@ -609,7 +609,7 @@ FROM `civicrm_dashboard_contact` JOIN `civicrm_contact` WHERE civicrm_dashboard_
    * Add Chargeback contribution status and Chargeback and Contra account relationships,
    * checking first if one exists.
    */
-  public function addRefundAndChargeBackAccountsIfNotExist() {
+  public static function addRefundAndChargeBackAccountsIfNotExist() {
     // First we enable and edit the record for Credit contra - this exists but is disabled for most sites.
     // Using the ensure function (below) will not enabled a disabled option (by design).
     CRM_Core_DAO::executeQuery("UPDATE civicrm_option_value v
@@ -642,7 +642,7 @@ FROM `civicrm_dashboard_contact` JOIN `civicrm_contact` WHERE civicrm_dashboard_
    *
    * @return bool
    */
-  public function addIndexContributionSource(CRM_Queue_TaskContext $ctx) {
+  public static function addIndexContributionSource(CRM_Queue_TaskContext $ctx) {
     CRM_Core_BAO_SchemaHandler::createIndexes(array('civicrm_contribution' => array('source')));
     return TRUE;
   }
@@ -657,7 +657,7 @@ FROM `civicrm_dashboard_contact` JOIN `civicrm_contact` WHERE civicrm_dashboard_
    *
    * @return bool
    */
-  public function addIndexContributionAmount(CRM_Queue_TaskContext $ctx) {
+  public static function addIndexContributionAmount(CRM_Queue_TaskContext $ctx) {
     CRM_Core_BAO_SchemaHandler::createIndexes(array(
       'civicrm_contribution' => array(array('total_amount', 'receive_date')),
     ));
@@ -674,7 +674,7 @@ FROM `civicrm_dashboard_contact` JOIN `civicrm_contact` WHERE civicrm_dashboard_
    *
    * @return bool
    */
-  public function addDeletedByMergeActivityType(CRM_Queue_TaskContext $ctx) {
+  public static function addDeletedByMergeActivityType(CRM_Queue_TaskContext $ctx) {
     CRM_Core_BAO_OptionValue::ensureOptionValueExists(array(
       'option_group_id' => 'activity_type',
       'name' => 'Contact Deleted by Merge',
@@ -693,7 +693,7 @@ FROM `civicrm_dashboard_contact` JOIN `civicrm_contact` WHERE civicrm_dashboard_
    *
    * @return bool
    */
-  public function addHelpPreAndHelpPostFieldsPriceFieldValue(CRM_Queue_TaskContext $ctx) {
+  public static function addHelpPreAndHelpPostFieldsPriceFieldValue(CRM_Queue_TaskContext $ctx) {
     $domain = new CRM_Core_DAO_Domain();
     $domain->find(TRUE);
     if ($domain->locales) {
@@ -731,7 +731,7 @@ FROM `civicrm_dashboard_contact` JOIN `civicrm_contact` WHERE civicrm_dashboard_
    *
    * @return bool
    */
-  public function upgradeMailingFKs(CRM_Queue_TaskContext $ctx) {
+  public static function upgradeMailingFKs(CRM_Queue_TaskContext $ctx) {
 
     // Safely drop the foreign keys
     CRM_Core_BAO_SchemaHandler::safeRemoveFK('civicrm_mailing_event_queue', 'FK_civicrm_mailing_event_queue_email_id');
@@ -790,7 +790,7 @@ FROM `civicrm_dashboard_contact` JOIN `civicrm_contact` WHERE civicrm_dashboard_
    *
    * @return bool
    */
-  public function dashboardSchemaUpdate(CRM_Queue_TaskContext $ctx) {
+  public static function dashboardSchemaUpdate(CRM_Queue_TaskContext $ctx) {
     if (!CRM_Core_BAO_SchemaHandler::checkIfIndexExists('civicrm_dashboard_contact', 'index_dashboard_id_contact_id')) {
       // Delete any stray duplicate rows and add unique index to prevent new dupes and enable INSERT/UPDATE combo query
       CRM_Core_DAO::executeQuery('DELETE c1 FROM civicrm_dashboard_contact c1, civicrm_dashboard_contact c2 WHERE c1.contact_id = c2.contact_id AND c1.dashboard_id = c2.dashboard_id AND c1.id > c2.id');


### PR DESCRIPTION
- [CRM-19377: Remove static function warning from 4.6 -> 4.7 upgrade](https://issues.civicrm.org/jira/browse/CRM-19377)
