### PR TITLE
CRM-19386: Retrieve Activities custom fields in import parser

### DIFF
--- a/CRM/Activity/Import/Parser/Activity.php
+++ b/CRM/Activity/Import/Parser/Activity.php
@@ -267,7 +267,7 @@ class CRM_Activity_Import_Parser_Activity extends CRM_Activity_Import_Parser {
       $params['source_contact_id'] = $session->get('userID');
     }
 
-    $customFields = CRM_Core_BAO_CustomField::getFields(CRM_Utils_Array::value('contact_type', $params));
+    $customFields = CRM_Core_BAO_CustomField::getFields('Activity');
 
     foreach ($params as $key => $val) {
       if ($customFieldID = CRM_Core_BAO_CustomField::getKeyID($key)) {


### PR DESCRIPTION
Custom fields for Activities should be retrieved - as it's done in [CRM/Activity/Import/Parser.php](https://github.com/civicrm/civicrm-core/blob/master/CRM/Activity/Import/Parser.php#L228) - instead of contact ones when importing activities. Should it also filter custom fields on the `activity_type_id`?

---
- [CRM-19386: Date format is not taken into account for custom filed on activity import](https://issues.civicrm.org/jira/browse/CRM-19386)
