### PR TITLE
CRM-19374 - Advanced Search fails on Contribution Receive date filter

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -1538,7 +1538,10 @@ class CRM_Contact_BAO_Query {
 
     self::filterCountryFromValuesIfStateExists($formValues);
 
-    foreach ($formValues as $id => $values) {
+    foreach ($formValues as $id => &$val) {
+      // CRM-19374 - we don't want to change $val in $formValues.
+      // Assign it to a temp variable which operates while iteration.
+      $values = $val;
 
       if (self::isAlreadyProcessedForQueryFormat($values)) {
         $params[] = $values;


### PR DESCRIPTION
@totten Following discussion from https://github.com/civicrm/civicrm-core/pull/9024#issuecomment-247009241, this change fixes the foreach() in `convertFormValues()` function. Inner operation would be carried out by a temp variable which keeps `$formValues[$val]` unaffected.

---
- [CRM-19374: Advanced Search fails on Contribution Receive date filter](https://issues.civicrm.org/jira/browse/CRM-19374)
