### PR TITLE
CRM-19192 - Event participant (and possibly other entity) imports do not handle "non-comma CSV"

### DIFF
--- a/CRM/Event/Import/Form/MapField.php
+++ b/CRM/Event/Import/Form/MapField.php
@@ -411,9 +411,14 @@ class CRM_Event_Import_Form_MapField extends CRM_Import_Form_MapField {
     $skipColumnHeader = $this->controller->exportValue('DataSource', 'skipColumnHeader');
 
     $config = CRM_Core_Config::singleton();
-    $seperator = $config->fieldSeparator;
+      /* CRM - 19192 */
+      $seperator = $this->controller->exportValue('DataSource', 'fieldSeparator');
+      if(is_null($seperator)) {
+          $seperator = $config->fieldSeparator;
+      }
 
-    $mapperKeys = array();
+
+      $mapperKeys = array();
     $mapper = array();
     $mapperKeys = $this->controller->exportValue($this->_name, 'mapper');
     $mapperKeysMain = array();

--- a/CRM/Event/Import/Form/Preview.php
+++ b/CRM/Event/Import/Form/Preview.php
@@ -119,9 +119,14 @@ class CRM_Event_Import_Form_Preview extends CRM_Import_Form_Preview {
     $onDuplicate = $this->get('onDuplicate');
 
     $config = CRM_Core_Config::singleton();
-    $seperator = $config->fieldSeparator;
+      /* CRM - 19192 */
+      $seperator = $this->controller->exportValue('DataSource', 'fieldSeparator');
+      if (is_null($seperator)) {
+          $seperator = $config->fieldSeparator;
+      }
 
-    $mapper = $this->controller->exportValue('MapField', 'mapper');
+
+      $mapper = $this->controller->exportValue('MapField', 'mapper');
     $mapperKeys = array();
 
     foreach ($mapper as $key => $value) {


### PR DESCRIPTION
The default field separator (delimiter) present is config
($config->fieldSeparator | CRM_Core_Config) and this was used without
considering the delimiter presented via the screen. This fix addresses
this issue.

---
- [CRM-19192: Event participant (and possibly other entity) imports do not handle "non-comma CSV"](https://issues.civicrm.org/jira/browse/CRM-19192)
