### PR TITLE
CRM-16189 - Notice Fix #8848

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -188,7 +188,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
 
     // CRM-16189
     CRM_Financial_BAO_FinancialAccount::checkFinancialTypeHasDeferred($params, $contributionID);
-    if ($contributionID && !empty($params['revenue_recognition_date'])
+    if ($contributionID && !empty($params['revenue_recognition_date']) && !empty($params['prevContribution'])
       && !($contributionStatus[$params['prevContribution']->contribution_status_id] == 'Pending')
       && !self::allowUpdateRevenueRecognitionDate($contributionID)
     ) {


### PR DESCRIPTION
This is an extension of https://github.com/civicrm/civicrm-core/pull/8848 fixing the notice error when `$params` doesn't contain `prevContribution` object.
- [CRM-16189: Improve support for Accrual Method bookkeeping](https://issues.civicrm.org/jira/browse/CRM-16189)

@pradpnayak Can you take a look at this and review if this doesn't affect your requirements ?
