### PR TITLE
Fix permission check

### DIFF
--- a/CRM/Event/Page/EventInfo.php
+++ b/CRM/Event/Page/EventInfo.php
@@ -242,15 +242,11 @@ class CRM_Event_Page_EventInfo extends CRM_Core_Page {
       $this->assign('mapURL', $mapURL);
     }
 
-    if (CRM_Core_Permission::check('view event participants') &&
-      CRM_Core_Permission::check('view all contacts')
-    ) {
-      $statusTypes = CRM_Event_PseudoConstant::participantStatus(NULL, 'is_counted = 1', 'label');
-      $statusTypesPending = CRM_Event_PseudoConstant::participantStatus(NULL, 'is_counted = 0', 'label');
-      $findParticipants['statusCounted'] = implode(', ', array_values($statusTypes));
-      $findParticipants['statusNotCounted'] = implode(', ', array_values($statusTypesPending));
-      $this->assign('findParticipants', $findParticipants);
-    }
+    $statusTypes = CRM_Event_PseudoConstant::participantStatus(NULL, 'is_counted = 1', 'label');
+    $statusTypesPending = CRM_Event_PseudoConstant::participantStatus(NULL, 'is_counted = 0', 'label');
+    $findParticipants['statusCounted'] = implode(', ', array_values($statusTypes));
+    $findParticipants['statusNotCounted'] = implode(', ', array_values($statusTypesPending));
+    $this->assign('findParticipants', $findParticipants);
 
     $participantListingID = CRM_Utils_Array::value('participant_listing_id', $values['event']);
     if ($participantListingID) {

--- a/CRM/Event/Page/EventInfo.php
+++ b/CRM/Event/Page/EventInfo.php
@@ -242,11 +242,13 @@ class CRM_Event_Page_EventInfo extends CRM_Core_Page {
       $this->assign('mapURL', $mapURL);
     }
 
-    $statusTypes = CRM_Event_PseudoConstant::participantStatus(NULL, 'is_counted = 1', 'label');
-    $statusTypesPending = CRM_Event_PseudoConstant::participantStatus(NULL, 'is_counted = 0', 'label');
-    $findParticipants['statusCounted'] = implode(', ', array_values($statusTypes));
-    $findParticipants['statusNotCounted'] = implode(', ', array_values($statusTypesPending));
-    $this->assign('findParticipants', $findParticipants);
+    if (CRM_Core_Permission::check('view event participants')) {
+      $statusTypes = CRM_Event_PseudoConstant::participantStatus(NULL, 'is_counted = 1', 'label');
+      $statusTypesPending = CRM_Event_PseudoConstant::participantStatus(NULL, 'is_counted = 0', 'label');
+      $findParticipants['statusCounted'] = implode(', ', array_values($statusTypes));
+      $findParticipants['statusNotCounted'] = implode(', ', array_values($statusTypesPending));
+      $this->assign('findParticipants', $findParticipants);
+    }
 
     $participantListingID = CRM_Utils_Array::value('participant_listing_id', $values['event']);
     if ($participantListingID) {


### PR DESCRIPTION
Even participant listing check and excludes contacts the current user doesn't have permissions to view. There is no reason to require the "view all contacts" permission to have these links.

The Events Mange page has the same drop down, but does not have this check on them.
