### PR TITLE
CRM-19192 - Use Form field separator instead of default for Import.

### DIFF
--- a/CRM/Activity/Import/Form/MapField.php
+++ b/CRM/Activity/Import/Form/MapField.php
@@ -376,10 +376,8 @@ class CRM_Activity_Import_Form_MapField extends CRM_Import_Form_MapField {
     }
 
     $fileName = $this->controller->exportValue('DataSource', 'uploadFile');
+    $seperator = $this->controller->exportValue('DataSource', 'fieldSeparator');
     $skipColumnHeader = $this->controller->exportValue('DataSource', 'skipColumnHeader');
-
-    $config = CRM_Core_Config::singleton();
-    $seperator = $config->fieldSeparator;
 
     $mapperKeys = array();
     $mapper = array();

--- a/CRM/Activity/Import/Form/Preview.php
+++ b/CRM/Activity/Import/Form/Preview.php
@@ -107,13 +107,11 @@ class CRM_Activity_Import_Form_Preview extends CRM_Import_Form_Preview {
    */
   public function postProcess() {
     $fileName = $this->controller->exportValue('DataSource', 'uploadFile');
+    $seperator = $this->controller->exportValue('DataSource', 'fieldSeparator');
     $skipColumnHeader = $this->controller->exportValue('DataSource', 'skipColumnHeader');
     $invalidRowCount = $this->get('invalidRowCount');
     $conflictRowCount = $this->get('conflictRowCount');
     $onDuplicate = $this->get('onDuplicate');
-
-    $config = CRM_Core_Config::singleton();
-    $seperator = $config->fieldSeparator;
 
     $mapper = $this->controller->exportValue('MapField', 'mapper');
     $mapperKeys = array();

--- a/CRM/Contribute/Import/Form/MapField.php
+++ b/CRM/Contribute/Import/Form/MapField.php
@@ -482,10 +482,8 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
     }
 
     $fileName = $this->controller->exportValue('DataSource', 'uploadFile');
+    $seperator = $this->controller->exportValue('DataSource', 'fieldSeparator');
     $skipColumnHeader = $this->controller->exportValue('DataSource', 'skipColumnHeader');
-
-    $config = CRM_Core_Config::singleton();
-    $seperator = $config->fieldSeparator;
 
     $mapper = $mapperKeys = $mapperKeysMain = $mapperSoftCredit = $softCreditFields = $mapperPhoneType = $mapperSoftCreditType = array();
     $mapperKeys = $this->controller->exportValue($this->_name, 'mapper');

--- a/CRM/Contribute/Import/Form/Preview.php
+++ b/CRM/Contribute/Import/Form/Preview.php
@@ -109,14 +109,12 @@ class CRM_Contribute_Import_Form_Preview extends CRM_Import_Form_Preview {
    */
   public function postProcess() {
     $fileName = $this->controller->exportValue('DataSource', 'uploadFile');
+    $seperator = $this->controller->exportValue('DataSource', 'fieldSeparator');
     $skipColumnHeader = $this->controller->exportValue('DataSource', 'skipColumnHeader');
     $invalidRowCount = $this->get('invalidRowCount');
     $conflictRowCount = $this->get('conflictRowCount');
     $onDuplicate = $this->get('onDuplicate');
     $mapperSoftCreditType = $this->get('mapperSoftCreditType');
-
-    $config = CRM_Core_Config::singleton();
-    $seperator = $config->fieldSeparator;
 
     $mapper = $this->controller->exportValue('MapField', 'mapper');
     $mapperKeys = array();

--- a/CRM/Custom/Import/Form/MapField.php
+++ b/CRM/Custom/Import/Form/MapField.php
@@ -136,11 +136,9 @@ class CRM_Custom_Import_Form_MapField extends CRM_Contact_Import_Form_MapField {
     }
 
     $fileName = $this->controller->exportValue('DataSource', 'uploadFile');
+    $separator = $this->controller->exportValue('DataSource', 'fieldSeparator');
     $skipColumnHeader = $this->controller->exportValue('DataSource', 'skipColumnHeader');
     $this->_entity = $this->controller->exportValue('DataSource', 'entity');
-
-    $config = CRM_Core_Config::singleton();
-    $separator = $config->fieldSeparator;
 
     $mapperKeys = array();
     $mapper = array();

--- a/CRM/Custom/Import/Form/Preview.php
+++ b/CRM/Custom/Import/Form/Preview.php
@@ -82,14 +82,12 @@ class CRM_Custom_Import_Form_Preview extends CRM_Import_Form_Preview {
    */
   public function postProcess() {
     $fileName = $this->controller->exportValue('DataSource', 'uploadFile');
+    $separator = $this->controller->exportValue('DataSource', 'fieldSeparator');
     $skipColumnHeader = $this->controller->exportValue('DataSource', 'skipColumnHeader');
     $invalidRowCount = $this->get('invalidRowCount');
     $conflictRowCount = $this->get('conflictRowCount');
     $onDuplicate = $this->get('onDuplicate');
     $entity = $this->get('_entity');
-
-    $config = CRM_Core_Config::singleton();
-    $separator = $config->fieldSeparator;
 
     $mapper = $this->controller->exportValue('MapField', 'mapper');
     $mapperKeys = array();

--- a/CRM/Event/Import/Form/MapField.php
+++ b/CRM/Event/Import/Form/MapField.php
@@ -408,17 +408,10 @@ class CRM_Event_Import_Form_MapField extends CRM_Import_Form_MapField {
     }
 
     $fileName = $this->controller->exportValue('DataSource', 'uploadFile');
+    $seperator = $this->controller->exportValue('DataSource', 'fieldSeparator');
     $skipColumnHeader = $this->controller->exportValue('DataSource', 'skipColumnHeader');
 
-    $config = CRM_Core_Config::singleton();
-      /* CRM - 19192 */
-      $seperator = $this->controller->exportValue('DataSource', 'fieldSeparator');
-      if(is_null($seperator)) {
-          $seperator = $config->fieldSeparator;
-      }
-
-
-      $mapperKeys = array();
+    $mapperKeys = array();
     $mapper = array();
     $mapperKeys = $this->controller->exportValue($this->_name, 'mapper');
     $mapperKeysMain = array();

--- a/CRM/Event/Import/Form/MapField.php
+++ b/CRM/Event/Import/Form/MapField.php
@@ -411,9 +411,14 @@ class CRM_Event_Import_Form_MapField extends CRM_Import_Form_MapField {
     $skipColumnHeader = $this->controller->exportValue('DataSource', 'skipColumnHeader');
 
     $config = CRM_Core_Config::singleton();
-    $seperator = $config->fieldSeparator;
+      /* CRM - 19192 */
+      $seperator = $this->controller->exportValue('DataSource', 'fieldSeparator');
+      if(is_null($seperator)) {
+          $seperator = $config->fieldSeparator;
+      }
 
-    $mapperKeys = array();
+
+      $mapperKeys = array();
     $mapper = array();
     $mapperKeys = $this->controller->exportValue($this->_name, 'mapper');
     $mapperKeysMain = array();

--- a/CRM/Event/Import/Form/Preview.php
+++ b/CRM/Event/Import/Form/Preview.php
@@ -113,20 +113,13 @@ class CRM_Event_Import_Form_Preview extends CRM_Import_Form_Preview {
    */
   public function postProcess() {
     $fileName = $this->controller->exportValue('DataSource', 'uploadFile');
+    $seperator = $this->controller->exportValue('DataSource', 'fieldSeparator');
     $skipColumnHeader = $this->controller->exportValue('DataSource', 'skipColumnHeader');
     $invalidRowCount = $this->get('invalidRowCount');
     $conflictRowCount = $this->get('conflictRowCount');
     $onDuplicate = $this->get('onDuplicate');
 
-    $config = CRM_Core_Config::singleton();
-      /* CRM - 19192 */
-      $seperator = $this->controller->exportValue('DataSource', 'fieldSeparator');
-      if (is_null($seperator)) {
-          $seperator = $config->fieldSeparator;
-      }
-
-
-      $mapper = $this->controller->exportValue('MapField', 'mapper');
+    $mapper = $this->controller->exportValue('MapField', 'mapper');
     $mapperKeys = array();
 
     foreach ($mapper as $key => $value) {

--- a/CRM/Event/Import/Form/Preview.php
+++ b/CRM/Event/Import/Form/Preview.php
@@ -119,9 +119,14 @@ class CRM_Event_Import_Form_Preview extends CRM_Import_Form_Preview {
     $onDuplicate = $this->get('onDuplicate');
 
     $config = CRM_Core_Config::singleton();
-    $seperator = $config->fieldSeparator;
+      /* CRM - 19192 */
+      $seperator = $this->controller->exportValue('DataSource', 'fieldSeparator');
+      if (is_null($seperator)) {
+          $seperator = $config->fieldSeparator;
+      }
 
-    $mapper = $this->controller->exportValue('MapField', 'mapper');
+
+      $mapper = $this->controller->exportValue('MapField', 'mapper');
     $mapperKeys = array();
 
     foreach ($mapper as $key => $value) {

--- a/CRM/Member/Import/Form/MapField.php
+++ b/CRM/Member/Import/Form/MapField.php
@@ -419,10 +419,8 @@ class CRM_Member_Import_Form_MapField extends CRM_Import_Form_MapField {
     }
 
     $fileName = $this->controller->exportValue('DataSource', 'uploadFile');
+    $seperator = $this->controller->exportValue('DataSource', 'fieldSeparator');
     $skipColumnHeader = $this->controller->exportValue('DataSource', 'skipColumnHeader');
-
-    $config = CRM_Core_Config::singleton();
-    $seperator = $config->fieldSeparator;
 
     $mapperKeys = array();
     $mapper = array();

--- a/CRM/Member/Import/Form/Preview.php
+++ b/CRM/Member/Import/Form/Preview.php
@@ -113,13 +113,11 @@ class CRM_Member_Import_Form_Preview extends CRM_Import_Form_Preview {
    */
   public function postProcess() {
     $fileName = $this->controller->exportValue('DataSource', 'uploadFile');
+    $seperator = $this->controller->exportValue('DataSource', 'fieldSeparator');
     $skipColumnHeader = $this->controller->exportValue('DataSource', 'skipColumnHeader');
     $invalidRowCount = $this->get('invalidRowCount');
     $conflictRowCount = $this->get('conflictRowCount');
     $onDuplicate = $this->get('onDuplicate');
-
-    $config = CRM_Core_Config::singleton();
-    $seperator = $config->fieldSeparator;
 
     $mapper = $this->controller->exportValue('MapField', 'mapper');
     $mapperKeys = array();


### PR DESCRIPTION
As `fieldSeparator` is a required field on import, this would be always available from dataSource.

---
- [CRM-19192: Event participant (and possibly other entity) imports do not handle "non-comma CSV"](https://issues.civicrm.org/jira/browse/CRM-19192)
