### PR TITLE
CRM-19303 : CKEditor configuration can't be edited on a Drupal multisite installation

### DIFF
--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -582,7 +582,7 @@ abstract class CRM_Utils_System_Base {
         $filesURL = $baseURL . "sites/$siteName/files/civicrm/";
       }
       else {
-        $filesURL = $baseURL . "sites/default/files/civicrm/";
+        $filesURL = $config->userSystem->checkMultisite($civicrm_root, $baseURL);
       }
     }
     elseif ($config->userFramework == 'UnitTests') {

--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -568,4 +568,83 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
     return $siteName;
   }
 
+  /**
+  * @var $basepath String cached basepath to prevent having to parse it repeatedly.
+  **/
+  protected $basepath;
+
+  /**
+  * @var $filesUrl String holds resolved path.
+  **/
+  protected $filesUrl;
+
+  /**
+  *  checkBasePath - Returns root directory with respect to $civicrm_root
+  *
+  * @param $root String
+  * @param $seek String
+  **/
+  public function checkBasePath($root, $seek = "/sites/")
+  {
+    if(!isset($this->basepath)) {
+      $this->basepath = substr($root, 0, stripos($root, $seek)+1);
+    }
+
+    return $this->basepath;
+  }
+
+  /**
+  * check if files exist in path.  Just a simple helper function for viewing
+  * existence of sites.
+  *
+  * @param $basepath string
+  * @param $basepath string
+  **/
+  private function checkFilesExists($basepath, $folder) {
+    return file_exists("{$basepath}sites/$folder/files/civicrm/");
+  }
+
+  /**
+  * Returns the concatenated url for existing path.
+  *
+  * @param $baseUrl string
+  * @param $folder string
+  **/
+  private function getUrl($baseUrl, $folder) {
+    return "{$baseUrl}sites/$folder/files/civicrm/";
+  }
+
+  /**
+  * Returns the location of /sites/SITENAME/files/civicrm depending
+  * on system configuration.
+  *
+  * @fixed CRM-19303
+  * @param $root string
+  * @param $baseUrl string
+  * @param $default string
+  **/
+  public function checkMultisite($root, $baseUrl, $default = "default") {
+    if(isset($this->filesUrl)) return $this->filesUrl;
+
+    $basepath = $this->checkBasePath($root);
+    $correct = null;
+    if($this->checkFilesExists($root, $default)) {
+      $correct = $default;
+    }
+    else {
+      //Check for any other directories if default doesn't exist.
+      $folders = scandir($basepath.'sites/');
+      foreach($folders as $folder) {
+        //Ignore hidden directories/files...
+        if(strpos($folder,'.') === 0 || $folder == 'all') continue;
+        //Check if it is a directory
+        if(!is_dir($basepath.'sites/'.$folder)) continue;
+
+        //Check if files path exists...
+        if($this->checkFilesExists($basepath, $folder)) {
+          $correct = $folder;
+          break;
+        }
+      }
+  }
 }

--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -623,8 +623,9 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
    * @param $default string
    */
   public function checkMultisite($root, $baseUrl, $default = "default") {
-    if (isset($this->filesUrl))
+    if (isset($this->filesUrl)) {
       return $this->filesUrl;
+    }
 
     $basepath = $this->checkBasePath($root);
     $correct = NULL;
@@ -636,11 +637,13 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
       $folders = scandir($basepath . 'sites/');
       foreach ($folders as $folder) {
         //Ignore hidden directories/files...
-        if (strpos($folder, '.') === 0 || $folder == 'all')
+        if (strpos($folder, '.') === 0 || $folder == 'all') {
           continue;
+        }
         //Check if it is a directory
-        if (!is_dir($basepath . 'sites/' . $folder))
+        if (!is_dir($basepath . 'sites/' . $folder)) {
           continue;
+        }
 
         //Check if files path exists...
         if ($this->checkFilesExists($basepath, $folder)) {
@@ -650,4 +653,5 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
       }
     }
   }
+
 }

--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -569,82 +569,84 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
   }
 
   /**
-  * @var $basepath String cached basepath to prevent having to parse it repeatedly.
-  **/
+   * @var $basepath String cached basepath to prevent having to parse it repeatedly.
+   */
   protected $basepath;
 
   /**
-  * @var $filesUrl String holds resolved path.
-  **/
+   * @var $filesUrl String holds resolved path.
+   */
   protected $filesUrl;
 
   /**
-  *  checkBasePath - Returns root directory with respect to $civicrm_root
-  *
-  * @param $root String
-  * @param $seek String
-  **/
-  public function checkBasePath($root, $seek = "/sites/")
-  {
-    if(!isset($this->basepath)) {
-      $this->basepath = substr($root, 0, stripos($root, $seek)+1);
+   *  checkBasePath - Returns root directory with respect to $civicrm_root
+   *
+   * @param $root String
+   * @param $seek String
+   */
+  public function checkBasePath($root, $seek = "/sites/") {
+    if (!isset($this->basepath)) {
+      $this->basepath = substr($root, 0, stripos($root, $seek) + 1);
     }
 
     return $this->basepath;
   }
 
   /**
-  * check if files exist in path.  Just a simple helper function for viewing
-  * existence of sites.
-  *
-  * @param $basepath string
-  * @param $basepath string
-  **/
+   * check if files exist in path.  Just a simple helper function for viewing
+   * existence of sites.
+   *
+   * @param $basepath string
+   * @param $basepath string
+   */
   private function checkFilesExists($basepath, $folder) {
     return file_exists("{$basepath}sites/$folder/files/civicrm/");
   }
 
   /**
-  * Returns the concatenated url for existing path.
-  *
-  * @param $baseUrl string
-  * @param $folder string
-  **/
+   * Returns the concatenated url for existing path.
+   *
+   * @param $baseUrl string
+   * @param $folder string
+   */
   private function getUrl($baseUrl, $folder) {
     return "{$baseUrl}sites/$folder/files/civicrm/";
   }
 
   /**
-  * Returns the location of /sites/SITENAME/files/civicrm depending
-  * on system configuration.
-  *
-  * @fixed CRM-19303
-  * @param $root string
-  * @param $baseUrl string
-  * @param $default string
-  **/
+   * Returns the location of /sites/SITENAME/files/civicrm depending
+   * on system configuration.
+   *
+   * @fixed CRM-19303
+   * @param $root string
+   * @param $baseUrl string
+   * @param $default string
+   */
   public function checkMultisite($root, $baseUrl, $default = "default") {
-    if(isset($this->filesUrl)) return $this->filesUrl;
+    if(isset($this->filesUrl))
+      return $this->filesUrl;
 
     $basepath = $this->checkBasePath($root);
     $correct = null;
-    if($this->checkFilesExists($root, $default)) {
+    if ($this->checkFilesExists($root, $default)) {
       $correct = $default;
     }
     else {
       //Check for any other directories if default doesn't exist.
-      $folders = scandir($basepath.'sites/');
+      $folders = scandir($basepath . 'sites/');
       foreach($folders as $folder) {
         //Ignore hidden directories/files...
-        if(strpos($folder,'.') === 0 || $folder == 'all') continue;
+        if (strpos($folder, '.') === 0 || $folder == 'all')
+          continue;
         //Check if it is a directory
-        if(!is_dir($basepath.'sites/'.$folder)) continue;
+        if (!is_dir($basepath . 'sites/' . $folder))
+          continue;
 
         //Check if files path exists...
-        if($this->checkFilesExists($basepath, $folder)) {
+        if ($this->checkFilesExists($basepath, $folder)) {
           $correct = $folder;
           break;
         }
       }
+    }
   }
-}

--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -623,18 +623,18 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
    * @param $default string
    */
   public function checkMultisite($root, $baseUrl, $default = "default") {
-    if(isset($this->filesUrl))
+    if (isset($this->filesUrl))
       return $this->filesUrl;
 
     $basepath = $this->checkBasePath($root);
-    $correct = null;
+    $correct = NULL;
     if ($this->checkFilesExists($root, $default)) {
       $correct = $default;
     }
     else {
       //Check for any other directories if default doesn't exist.
       $folders = scandir($basepath . 'sites/');
-      foreach($folders as $folder) {
+      foreach ($folders as $folder) {
         //Ignore hidden directories/files...
         if (strpos($folder, '.') === 0 || $folder == 'all')
           continue;
@@ -650,3 +650,4 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
       }
     }
   }
+}


### PR DESCRIPTION
Single Merge

Instead of assuming the default folder exists, it checks, if not it will search nearby directories for the files.

---
- [CRM-19303: CKEditor configuration can't be edited on a Drupal multisite installation](https://issues.civicrm.org/jira/browse/CRM-19303)
