### PR TITLE
revert #8937

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -822,7 +822,6 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
       'AdvMulti-Select',
       'CheckBox',
       'Radio',
-      'Autocomplete-Select',
     )));
 
     if ($isSelect) {


### PR DESCRIPTION
@colemanw PR https://github.com/civicrm/civicrm-core/pull/8937 shows the `$options` in the hook for autocomplete select, but doesn't load them in the input field as the options for it gets loaded through `option_value` 'get' API. 

Maybe, we need to call hook after fetching the API values, reverting the original fix for now.
