### PR TITLE
CRM-19404 - Add message around bare minimum php version

### DIFF
--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -38,7 +38,7 @@
  */
 class CRM_Upgrade_Incremental_General {
   const MIN_RECOMMENDED_PHP_VER = '5.5';
-
+  const BARE_MIN_PHP_VER = '5.3.23';
   /**
    * Compute any messages which should be displayed before upgrade.
    *

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -41,10 +41,11 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
     if (version_compare(phpversion(), CRM_Upgrade_Incremental_General::MIN_RECOMMENDED_PHP_VER) < 0) {
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
-        ts('This system uses PHP version %1. While this meets the minimum requirements for CiviCRM to function, upgrading to PHP version %2 or newer is recommended for maximum compatibility.',
+        ts('This system uses PHP version %1. While this meets the minimum requirements for CiviCRM to function, upgrading to PHP version %2 or newer is recommended for maximum compatibility. The bare minimum php version is %3',
           array(
             1 => phpversion(),
             2 => CRM_Upgrade_Incremental_General::MIN_RECOMMENDED_PHP_VER,
+            3 => CRM_Upgrade_Incremental_General::BARE_MIN_PHP_VER,
           )),
         ts('PHP Out-of-Date'),
         \Psr\Log\LogLevel::NOTICE,

--- a/install/index.php
+++ b/install/index.php
@@ -557,7 +557,7 @@ class InstallRequirements {
 
     $this->errors = NULL;
 
-    $this->requirePHPVersion('5.3.4', array(
+    $this->requirePHPVersion('5.3.23', array(
       ts("PHP Configuration"),
       ts("PHP5 installed"),
       NULL,


### PR DESCRIPTION
ping @totten

---
- [CRM-19404: Set Bare minimum version of php to 5.3.23](https://issues.civicrm.org/jira/browse/CRM-19404)
