### PR TITLE
CRM-19337 - Contact summary report

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -4437,6 +4437,33 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
   }
 
   /**
+   * Get a set of required contact type fields.
+   *
+   * @return array
+   */
+  public function getBasicContactTypeFields() {
+    return array(
+      'label' => array(
+        'title' => ts('Contact Subtype'),
+      )
+    );
+  }
+
+  /**
+   * Get a set of required contact type filters.
+   *
+   * @return array
+   */
+  public function getBasicContactTypeFilters() {
+    return array(
+      'label' => array(
+        'title' => ts('Contact Subtype'),
+        'type' => CRM_Utils_Type::T_STRING,
+      )
+    );
+  }
+
+  /**
    * Get a standard set of contact fields.
    *
    * @return array
@@ -4475,9 +4502,6 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
       'addressee_display' => array('title' => ts('Addressee')),
       'contact_type' => array(
         'title' => ts('Contact Type'),
-      ),
-      'contact_sub_type' => array(
-        'title' => ts('Contact Subtype'),
       ),
       'gender_id' => array(
         'title' => ts('Gender'),
@@ -4536,9 +4560,6 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
       ),
       'contact_type' => array(
         'title' => ts('Contact Type'),
-      ),
-      'contact_sub_type' => array(
-        'title' => ts('Contact Subtype'),
       ),
       'modified_date' => array(
         'title' => ts('Contact Modified'),

--- a/CRM/Report/Form/Contact/Summary.php
+++ b/CRM/Report/Form/Contact/Summary.php
@@ -101,10 +101,17 @@ class CRM_Report_Form_Contact_Summary extends CRM_Report_Form {
           'contact_type' => array(
             'title' => ts('Contact Type'),
           ),
-          'contact_sub_type' => array(
+        ),
+      ),
+      'civicrm_contact_type' => array(
+        'dao' => 'CRM_Contact_DAO_ContactType',
+        'fields' => $this->getBasicContactTypeFields(),
+        'filters' => $this->getBasicContactTypeFilters(),
+        'order_bys' => array(
+          'label' => array(
             'title' => ts('Contact Subtype'),
           ),
-        ),
+        )
       ),
       'civicrm_email' => array(
         'dao' => 'CRM_Core_DAO_Email',
@@ -189,6 +196,8 @@ class CRM_Report_Form_Contact_Summary extends CRM_Report_Form {
   public function from() {
     $this->_from = "
         FROM civicrm_contact {$this->_aliases['civicrm_contact']} {$this->_aclFrom}
+            LEFT JOIN civicrm_contact_type {$this->_aliases['civicrm_contact_type']}
+                   ON ({$this->_aliases['civicrm_contact']}.contact_sub_type = {$this->_aliases['civicrm_contact_type']}.name)
             LEFT JOIN civicrm_address {$this->_aliases['civicrm_address']}
                    ON ({$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_address']}.contact_id AND
                       {$this->_aliases['civicrm_address']}.is_primary = 1 ) ";


### PR DESCRIPTION
When contact sub-type was included in the report, it was displaying the sub-type as **contact_sub_type from civicrm_contact** table instead of **label from civicrm_contact_type** table as being displayed on the contact summary page.

---
- [CRM-19337: Contact reports display Contact Sub Types by name rather than label](https://issues.civicrm.org/jira/browse/CRM-19337)
