### PR TITLE
CRM-18006 - CRM_Dedupe_MergerTest - Fix regression

### DIFF
--- a/tests/phpunit/CRM/Dedupe/MergerTest.php
+++ b/tests/phpunit/CRM/Dedupe/MergerTest.php
@@ -319,7 +319,7 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
       FALSE
     );
 
-    $this->assertEquals(array(
+    $expectedPairs = array(
       0 => array(
         'srcID' => $this->contacts[5]['id'],
         'srcName' => 'Walt Disney Ltd',
@@ -352,7 +352,26 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
         'weight' => 10,
         'canMerge' => TRUE,
       ),
-    ), $pairs);
+    );
+    usort($pairs, array(__CLASS__, 'compareDupes'));
+    usort($expectedPairs, array(__CLASS__, 'compareDupes'));
+    $this->assertEquals($expectedPairs, $pairs);
+  }
+
+  /**
+   * Function to sort $duplicate records in a stable way.
+   *
+   * @param array $a
+   * @param array $b
+   * @return int
+   */
+  public static function compareDupes($a, $b) {
+    foreach (array('srcName', 'dstName', 'srcID', 'dstID') as $field) {
+      if ($a[$field] != $b[$field]) {
+        return ($a[$field] < $b[$field]) ? 1 : -1;
+      }
+    }
+    return 0;
   }
 
   /**


### PR DESCRIPTION
InnoDB and MyISAM may have different edge-cases in how the default
orderings.  However, for deduping, the order is arbitrary. This
patch makes the test order-insensitive.

@seamuslee001, this is intended as a possibly more consistent alternative to #9103.

---
- [CRM-18006: Upgrade to 4.7 Uses Wrong DB Engine](https://issues.civicrm.org/jira/browse/CRM-18006)
