### PR TITLE
CRM-19422. Correct exception from job.group_rebuild

### DIFF
--- a/api/v3/Job.php
+++ b/api/v3/Job.php
@@ -634,7 +634,7 @@ function civicrm_api3_job_disable_expired_relationships($params) {
 function civicrm_api3_job_group_rebuild($params) {
   $lock = Civi::lockManager()->acquire('worker.core.GroupRebuild');
   if (!$lock->isAcquired()) {
-    throw new API_Exception('Could not acquire lock, another EmailProcessor process is running');
+    throw new API_Exception('Could not acquire lock, another GroupRebuild process is running');
   }
 
   $limit = CRM_Utils_Array::value('limit', $params, 0);


### PR DESCRIPTION
- [CRM-19422: Correct copypasta in GroupRebuild exception](https://issues.civicrm.org/jira/browse/CRM-19422)
