### PR TITLE
Explain more clearly when changing participant status sends email

### DIFF
--- a/CRM/Event/Form/Task/Batch.php
+++ b/CRM/Event/Form/Task/Batch.php
@@ -521,12 +521,10 @@ class CRM_Event_Form_Task_Batch extends CRM_Event_Form_Task {
   public function assignToTemplate() {
     $notifyingStatuses = array('Pending from waitlist', 'Pending from approval', 'Expired', 'Cancelled');
     $notifyingStatuses = array_intersect($notifyingStatuses, CRM_Event_PseudoConstant::participantStatus());
-    $statuses = implode(', ', $notifyingStatuses);
-    $status = ts('Participants whose status is changed FROM Pending Pay Later TO Registered or Attended will receive a confirmation email and their payment status will be set to completed. If this is not you want to do, you can change their participant status by editing their event registration record directly.');
+    $this->assign('status', TRUE);
     if (!empty($notifyingStatuses)) {
-      $status .= '<br />' . ts("Participants whose status is changed TO any of the following will be automatically notified via email: %1", array(1 => $statuses));
+      $this->assign('notifyingStatuses', implode(', ', $notifyingStatuses));
     }
-    $this->assign('status', $status);
   }
 
 }

--- a/CRM/Event/Form/Task/Batch.php
+++ b/CRM/Event/Form/Task/Batch.php
@@ -523,7 +523,8 @@ class CRM_Event_Form_Task_Batch extends CRM_Event_Form_Task {
     $notifyingStatuses = array_intersect($notifyingStatuses, CRM_Event_PseudoConstant::participantStatus());
     $this->assign('status', TRUE);
     if (!empty($notifyingStatuses)) {
-      $this->assign('notifyingStatuses', implode(', ', $notifyingStatuses));
+      $s = '<em>' . implode('</em>, <em>', $notifyingStatuses) . '</em>';
+      $this->assign('notifyingStatuses', $s);
     }
   }
 

--- a/CRM/Event/Task.php
+++ b/CRM/Event/Task.php
@@ -116,7 +116,7 @@ class CRM_Event_Task {
           'result' => TRUE,
         ),
         15 => array(
-          'title' => ts('Participant status - change (emails sent)'),
+          'title' => ts('Participant status - change'),
           'class' => 'CRM_Event_Form_Task_ParticipantStatus',
           'result' => TRUE,
         ),

--- a/templates/CRM/Event/Form/Task/Batch.tpl
+++ b/templates/CRM/Event/Form/Task/Batch.tpl
@@ -27,15 +27,17 @@
 <fieldset>
   <div class="help">
     {if $context EQ 'statusChange'} {* Update Participant Status task *}
-      {ts}Update the status for each participant individually, OR change all statuses to:{/ts}
+      {ts}Update the status for each participant individually below, or change all statuses to:{/ts}
       {$form.status_change.html}  {help id="id-status_change"}
       {if $status}
         <div class="status">
-          {ts}Participants whose status is changed FROM Pending Pay Later TO Registered or Attended will receive a confirmation email and their payment status will be set to completed. If this is not you want to do, you can change their participant status by editing their event registration record directly.{/ts}
+          <p>{ts}This form <strong>will send email</strong> to contacts only in certain circumstances:{/ts}</p>
+          <ul>
+            <li>{ts}<strong>Resolving "Pay Later" registrations:</strong> Participants whose status is changed from <em>Pending Pay Later</em> to <em>Registered</em> or <em>Attended</em> will receive a confirmation email and their payment status will be set to completed. If this is not you want to do, you can change their participant status by editing their event registration record directly.{/ts}</li>
           {if $notifyingStatuses}
-            <br />
-            {ts 1=$notifyingStatuses}Participants whose status is changed TO any of the following will be automatically notified via email: %1{/ts}
+            <li>{ts 1=$notifyingStatuses}<strong>Special statuses:</strong> Participants whose status is changed to any of the following will be automatically notified via email: %1{/ts}</li>
           {/if}
+          </ul>
         </div>
       {/if}
     {else}

--- a/templates/CRM/Event/Form/Task/Batch.tpl
+++ b/templates/CRM/Event/Form/Task/Batch.tpl
@@ -29,7 +29,15 @@
     {if $context EQ 'statusChange'} {* Update Participant Status task *}
       {ts}Update the status for each participant individually, OR change all statuses to:{/ts}
       {$form.status_change.html}  {help id="id-status_change"}
-      <div class="status">{$status}</div>
+      {if $status}
+        <div class="status">
+          {ts}Participants whose status is changed FROM Pending Pay Later TO Registered or Attended will receive a confirmation email and their payment status will be set to completed. If this is not you want to do, you can change their participant status by editing their event registration record directly.{/ts}
+          {if $notifyingStatuses}
+            <br />
+            {ts 1=$notifyingStatuses}Participants whose status is changed TO any of the following will be automatically notified via email: %1{/ts}
+          {/if}
+        </div>
+      {/if}
     {else}
       {if $statusProfile EQ 1} {* Update Participant Status in batch task *}
         <div class="status">{$status}</div>


### PR DESCRIPTION
This also moves the markup from the code to the template.
