### PR TITLE
CRM-19245 - Wrap title and description on manage group page

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -3274,6 +3274,7 @@ div.m ul#civicrm-menu,
   padding-left: 2px;
   border: 2px dashed transparent;
 }
+
 .crm-container .crm-editable-textarea-enabled {
   white-space: normal;
 }
@@ -3373,6 +3374,11 @@ div.m ul#civicrm-menu,
 }
 #crm-container .crm-group-name span.crm-editable-enabled {
   text-indent: 0;
+}
+
+#crm-container .crm-group-name .crm-editable-enabled,
+#crm-container .crm-group-description .crm-editable-enabled{
+  white-space: normal;
 }
 
 #crm-container div.crm-row-parent-name {


### PR DESCRIPTION
- CRM-19245: Text no longer wraps in name and description fields on Manage Groups page
  https://issues.civicrm.org/jira/browse/CRM-19245
