### PR TITLE
CRM-19435 - show static assignments to smart groups in group tab

### DIFF
--- a/CRM/Contact/BAO/GroupContact.php
+++ b/CRM/Contact/BAO/GroupContact.php
@@ -357,7 +357,7 @@ class CRM_Contact_BAO_GroupContact extends CRM_Contact_DAO_GroupContact {
                     civicrm_subscription_history.method as method';
     }
 
-    $where = " WHERE contact_a.id = %1 AND civicrm_group.is_active = 1 AND saved_search_id IS NULL";
+    $where = " WHERE contact_a.id = %1 AND civicrm_group.is_active = 1";
 
     if ($excludeHidden) {
       $where .= " AND civicrm_group.is_hidden = 0 ";


### PR DESCRIPTION
## This restores listing of groups for a contact when it is manually assigned to a smart group.
- CRM-19435: Static assignments to smart groups not shown in group tab
  https://issues.civicrm.org/jira/browse/CRM-19435
