### PR TITLE
CRM-19435: IncludeSmartGroups Option added

### DIFF
--- a/CRM/Contact/BAO/GroupContact.php
+++ b/CRM/Contact/BAO/GroupContact.php
@@ -341,7 +341,7 @@ class CRM_Contact_BAO_GroupContact extends CRM_Contact_DAO_GroupContact {
     $onlyPublicGroups = FALSE,
     $excludeHidden = TRUE,
     $groupId = NULL,
-  	$includeSmartGroups = FALSE
+    $includeSmartGroups = FALSE
   ) {
     if ($count) {
       $select = 'SELECT count(DISTINCT civicrm_group_contact.id)';
@@ -359,14 +359,12 @@ class CRM_Contact_BAO_GroupContact extends CRM_Contact_DAO_GroupContact {
     }
 
     $where = " WHERE contact_a.id = %1 AND civicrm_group.is_active = 1";
-	if(!$includeSmartGroups){
-		$where .= " AND saved_search_id IS NULL";
-	}
-    
+    if (!$includeSmartGroups) {
+      $where .= " AND saved_search_id IS NULL";
+    }
     if ($excludeHidden) {
       $where .= " AND civicrm_group.is_hidden = 0 ";
     }
-
     $params = array(1 => array($contactId, 'Integer'));
     if (!empty($status)) {
       $where .= ' AND civicrm_group_contact.status = %2';

--- a/CRM/Contact/BAO/GroupContact.php
+++ b/CRM/Contact/BAO/GroupContact.php
@@ -340,7 +340,8 @@ class CRM_Contact_BAO_GroupContact extends CRM_Contact_DAO_GroupContact {
     $ignorePermission = FALSE,
     $onlyPublicGroups = FALSE,
     $excludeHidden = TRUE,
-    $groupId = NULL
+    $groupId = NULL,
+  	$includeSmartGroups = FALSE
   ) {
     if ($count) {
       $select = 'SELECT count(DISTINCT civicrm_group_contact.id)';
@@ -357,8 +358,11 @@ class CRM_Contact_BAO_GroupContact extends CRM_Contact_DAO_GroupContact {
                     civicrm_subscription_history.method as method';
     }
 
-    $where = " WHERE contact_a.id = %1 AND civicrm_group.is_active = 1 AND saved_search_id IS NULL";
-
+    $where = " WHERE contact_a.id = %1 AND civicrm_group.is_active = 1";
+	if(!$includeSmartGroups){
+		$where .= " AND saved_search_id IS NULL";
+	}
+    
     if ($excludeHidden) {
       $where .= " AND civicrm_group.is_hidden = 0 ";
     }

--- a/CRM/Contact/Page/View/GroupContact.php
+++ b/CRM/Contact/Page/View/GroupContact.php
@@ -37,11 +37,11 @@ class CRM_Contact_Page_View_GroupContact extends CRM_Core_Page {
    */
   public function browse() {
 
-    $count = CRM_Contact_BAO_GroupContact::getContactGroup($this->_contactId, NULL, NULL, TRUE);
+    $count = CRM_Contact_BAO_GroupContact::getContactGroup($this->_contactId, NULL, NULL, TRUE, FALSE, FALSE, TRUE, NULL, TRUE);
 
-    $in = CRM_Contact_BAO_GroupContact::getContactGroup($this->_contactId, 'Added');
-    $pending = CRM_Contact_BAO_GroupContact::getContactGroup($this->_contactId, 'Pending');
-    $out = CRM_Contact_BAO_GroupContact::getContactGroup($this->_contactId, 'Removed');
+    $in = CRM_Contact_BAO_GroupContact::getContactGroup($this->_contactId, 'Added', NULL, FALSE, FALSE, FALSE, TRUE, NULL, TRUE);
+    $pending = CRM_Contact_BAO_GroupContact::getContactGroup($this->_contactId, 'Pending', NULL, FALSE, FALSE, FALSE, TRUE, NULL, TRUE);
+    $out = CRM_Contact_BAO_GroupContact::getContactGroup($this->_contactId, 'Removed', NULL, FALSE, FALSE, FALSE, TRUE, NULL, TRUE);
 
     // keep track of all 'added' contact groups so we can remove them from the smart group
     // section


### PR DESCRIPTION
Added a new parameter "includeSmartGroups" for getContactGroups to include smart groups in the result.

---
- [CRM-19435: Static assignments to smart groups not shown in group tab](https://issues.civicrm.org/jira/browse/CRM-19435)
