### PR TITLE
CRM-19445: Allow to search on membership ID

### DIFF
--- a/CRM/Member/BAO/Query.php
+++ b/CRM/Member/BAO/Query.php
@@ -473,6 +473,7 @@ class CRM_Member_BAO_Query {
     ));
 
     $form->addElement('text', 'member_source', ts('Source'));
+    $form->addElement('text', 'membership_id', ts('Membership ID'));
 
     CRM_Core_Form_Date::buildDateRange($form, 'member_join_date', 1, '_low', '_high', ts('From'), FALSE);
     $form->addElement('hidden', 'member_join_date_range_error');

--- a/CRM/Member/BAO/Query.php
+++ b/CRM/Member/BAO/Query.php
@@ -473,7 +473,7 @@ class CRM_Member_BAO_Query {
     ));
 
     $form->addElement('text', 'member_source', ts('Source'));
-    $form->addElement('text', 'membership_id', ts('Membership ID'));
+    $form->add('number', 'membership_id', ts('Membership ID'), array('class' => 'four', 'min' => 1));
 
     CRM_Core_Form_Date::buildDateRange($form, 'member_join_date', 1, '_low', '_high', ts('From'), FALSE);
     $form->addElement('hidden', 'member_join_date_range_error');

--- a/templates/CRM/Member/Form/Search/Common.tpl
+++ b/templates/CRM/Member/Form/Search/Common.tpl
@@ -65,6 +65,9 @@
   </td>
 </tr>
 
+<tr><td>{$form.membership_id.label} {$form.membership_id.html}</td>
+</tr>
+
 <tr><td><label>{ts}Member Since{/ts}</label></td></tr>
 <tr>
 {include file="CRM/Core/DateRange.tpl" fieldName="member_join_date" from='_low' to='_high'}

--- a/templates/CRM/Member/Form/Search/Common.tpl
+++ b/templates/CRM/Member/Form/Search/Common.tpl
@@ -65,7 +65,7 @@
   </td>
 </tr>
 
-<tr><td>{$form.membership_id.label} {$form.membership_id.html}</td>
+<tr><td><label>{$form.membership_id.label}</label> {$form.membership_id.html}</td>
 </tr>
 
 <tr><td><label>{ts}Member Since{/ts}</label></td></tr>


### PR DESCRIPTION
The member search didn't had an option to quickly search on ID, this should fix that.

---
- [CRM-19445: Allow to search on membership id](https://issues.civicrm.org/jira/browse/CRM-19445)
