### PR TITLE
CRM-19450 Fix adding financial_type_id where clause

### DIFF
--- a/CRM/Price/BAO/PriceFieldValue.php
+++ b/CRM/Price/BAO/PriceFieldValue.php
@@ -182,7 +182,7 @@ class CRM_Price_BAO_PriceFieldValue extends CRM_Price_DAO_PriceFieldValue {
       if (!empty($financialTypes)) {
         $addWhere = "financial_type_id IN (" . implode(',', array_keys($financialTypes)) . ")";
       }
-      $fieldValueDAO->whereAdd($addWhere);
+      $fieldValueDAO->addWhere($addWhere);
     }
     $fieldValueDAO->orderBy($orderBy, 'label');
     if ($isActive) {


### PR DESCRIPTION
- [CRM-19450: GetValues of CRM Price Field does not work when $set is not set](https://issues.civicrm.org/jira/browse/CRM-19450)
