### PR TITLE
CRM-19456 - avoid horizontal scrolling

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -3270,7 +3270,6 @@ div.m ul#civicrm-menu,
 
 /* in place edit  */
 .crm-container .crm-editable-enabled {
-  white-space: nowrap;
   padding-left: 2px;
   border: 2px dashed transparent;
 }


### PR DESCRIPTION
When no-wrap is specified, pages such as the Manage Groups and the
Activities tab will require horizontal scrolling because the
descriptions won't wrap.

---
- [CRM-19456: allow white space to wrap to avoid horizontal scroll for group listing and activities](https://issues.civicrm.org/jira/browse/CRM-19456)
