### PR TITLE
CRM 19453 CRM-19453: System->Directories fails to display under Joomla

### DIFF
--- a/templates/CRM/Admin/Form/Setting/Path.hlp
+++ b/templates/CRM/Admin/Form/Setting/Path.hlp
@@ -4,7 +4,7 @@
     <tbody>
     <tr>
       <td><tt>[cms.root]</tt></td>
-      <td><tt>{crmResPath ext='cms.root'}</tt></td>
+      <td><tt>{crmResURL ext='cms.root'}</tt></td>
     </tr>
     <tr>
       <td><tt>[civicrm.root]</tt></td>

--- a/templates/CRM/Admin/Form/Setting/Path.hlp
+++ b/templates/CRM/Admin/Form/Setting/Path.hlp
@@ -4,7 +4,7 @@
     <tbody>
     <tr>
       <td><tt>[cms.root]</tt></td>
-      <td><tt>{crmResURL ext='cms.root'}</tt></td>
+      <td><tt>{crmResPath ext='cms.root'}</tt></td>
     </tr>
     <tr>
       <td><tt>[civicrm.root]</tt></td>


### PR DESCRIPTION
This fixes the error described in CRM-19453.

---
- [CRM-19453: System->Directories fails to display under Joomla](https://issues.civicrm.org/jira/browse/CRM-19453)
