### PR TITLE
CRM-19465 - Capitalization displaying contries when in mailing mode

### DIFF
--- a/CRM/Utils/Address.php
+++ b/CRM/Utils/Address.php
@@ -105,7 +105,8 @@ class CRM_Utils_Address {
           $fields['country'] = NULL;
         }
         else {
-          $fields['country'] = strtoupper($fields['country']);
+          //Capitalization display on uppercase to contries with special characters
+          $fields['country'] = mb_convert_case($fields['country'], MB_CASE_TITLE,"UTF8");
         }
       }
       else {

--- a/CRM/Utils/Address.php
+++ b/CRM/Utils/Address.php
@@ -106,7 +106,7 @@ class CRM_Utils_Address {
         }
         else {
           //Capitalization display on uppercase to contries with special characters
-          $fields['country'] = mb_convert_case($fields['country'], MB_CASE_TITLE,"UTF8");
+          $fields['country'] = mb_convert_case($fields['country'], MB_CASE_UPPER,"UTF-8");
         }
       }
       else {

--- a/CRM/Utils/Address.php
+++ b/CRM/Utils/Address.php
@@ -106,11 +106,11 @@ class CRM_Utils_Address {
         }
         else {
           //Capitalization display on uppercase to contries with special characters
-          $fields['country'] = mb_convert_case($fields['country'], MB_CASE_UPPER,"UTF-8");
+          $fields['country'] = mb_convert_case($fields['country'], MB_CASE_UPPER, "UTF-8");
         }
       }
       else {
-        $fields['country'] = strtoupper($fields['country']);
+          $fields['country'] = mb_convert_case($fields['country'], MB_CASE_UPPER, "UTF-8");
       }
     }
 

--- a/CRM/Utils/Address.php
+++ b/CRM/Utils/Address.php
@@ -110,7 +110,7 @@ class CRM_Utils_Address {
         }
       }
       else {
-          $fields['country'] = mb_convert_case($fields['country'], MB_CASE_UPPER, "UTF-8");
+        $fields['country'] = mb_convert_case($fields['country'], MB_CASE_UPPER, "UTF-8");
       }
     }
 


### PR DESCRIPTION
Avoiding possible issues with special characters.

---
- [CRM-19465: 'BELGIë' on our address labels](https://issues.civicrm.org/jira/browse/CRM-19465)
