### PR TITLE
CRM-19330

### DIFF
--- a/CRM/Report/BAO/ReportInstance.php
+++ b/CRM/Report/BAO/ReportInstance.php
@@ -390,6 +390,10 @@ class CRM_Report_BAO_ReportInstance extends CRM_Report_DAO_ReportInstance {
           'confirm_message' => ts('Are you sure you want delete this report? This action cannot be undone.'),
         ),
       );
+    } else  {
+      // Remove the options to save or save a copy
+      unset($actions['report_instance.save']);
+      unset($actions['report_instance.copy']);
     }
     return $actions;
   }

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -1498,9 +1498,9 @@ class CRM_Report_Form extends CRM_Core_Form {
 
     $this->assign('instanceForm', $this->_instanceForm);
 
-    // CRM-16274 Determine if user has 'edit all contacts' or equivalent
-    $permission = CRM_Core_Permission::getPermission();
-    if ($permission == CRM_Core_Permission::EDIT &&
+    // CRM-19330 - check that the user has Edit All Groups permissions.
+    $permission = CRM_Core_Permission::check(CRM_Core_Permission::EDIT_GROUPS);
+    if ($permission  &&
       $this->_add2groupSupported
     ) {
       $this->addElement('select', 'groups', ts('Group'),
@@ -3884,13 +3884,13 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
     if (!empty($prop['filters']) && $this->_customGroupFilters) {
       foreach ($prop['filters'] as $fieldAlias => $val) {
         foreach (array(
-                   'value',
-                   'min',
-                   'max',
-                   'relative',
-                   'from',
-                   'to',
-                 ) as $attach) {
+          'value',
+          'min',
+          'max',
+          'relative',
+          'from',
+          'to',
+        ) as $attach) {
           if (isset($this->_params[$fieldAlias . '_' . $attach]) &&
             (!empty($this->_params[$fieldAlias . '_' . $attach])
               || ($attach != 'relative' &&
@@ -4779,6 +4779,16 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
       FALSE,
       CRM_Utils_Array::value('task', $this->_params)
     ));
+    if ($this->_outputMode !==NULL) {
+      // We didn't get it using output, so we now try with task.
+        $this->_outputMode = str_replace('report_instance.', '', CRM_Utils_Request::retrieve(
+          'task',
+          'String',
+          CRM_Core_DAO::$_nullObject,
+          FALSE,
+          CRM_Utils_Array::value('task', $this->_params)
+      ));
+    }
     // if contacts are added to group
     if (!empty($this->_params['groups']) && empty($this->_outputMode)) {
       $this->_outputMode = 'group';

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -1498,9 +1498,9 @@ class CRM_Report_Form extends CRM_Core_Form {
 
     $this->assign('instanceForm', $this->_instanceForm);
 
-    // CRM-16274 Determine if user has 'edit all contacts' or equivalent
-    $permission = CRM_Core_Permission::getPermission();
-    if ($permission == CRM_Core_Permission::EDIT &&
+    // CRM-19330 - check that the user has Edit All Groups permissions.
+    $permission = CRM_Core_Permission::check(CRM_Core_Permission::EDIT_GROUPS);
+    if ($permission  &&
       $this->_add2groupSupported
     ) {
       $this->addElement('select', 'groups', ts('Group'),
@@ -4779,6 +4779,16 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
       FALSE,
       CRM_Utils_Array::value('task', $this->_params)
     ));
+    if ($this->_outputMode !==NULL) {
+      // We didn't get it using output, so we now try with task.
+        $this->_outputMode = str_replace('report_instance.', '', CRM_Utils_Request::retrieve(
+          'task',
+          'String',
+          CRM_Core_DAO::$_nullObject,
+          FALSE,
+          CRM_Utils_Array::value('task', $this->_params)
+      ));
+    }
     // if contacts are added to group
     if (!empty($this->_params['groups']) && empty($this->_outputMode)) {
       $this->_outputMode = 'group';

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -4780,7 +4780,8 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
       CRM_Utils_Array::value('task', $this->_params)
     ));
     if ($this->_outputMode !==NULL) {
-      // We didn't get it using output, so we now try with task.
+      // We didn't get it using output, so we now try with task.  This seems to
+      // happen when the user isn't privileged.
         $this->_outputMode = str_replace('report_instance.', '', CRM_Utils_Request::retrieve(
           'task',
           'String',


### PR DESCRIPTION
Suppress Add Contacts to Group where user does not have Edit All Groups permission.

---
- [CRM-19330: Add Contacts to Group appears in reports where user can't even view all contacts under Joomla](https://issues.civicrm.org/jira/browse/CRM-19330)
