### PR TITLE
CRM-12645

### DIFF
--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -927,8 +927,22 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
     $mapMask = $mask & 4095;
 
     $links = self::links($this->_context, $this->_contextMenu, $this->_key);
+    $editlink = $links[CRM_Core_Action::UPDATE];  // Remember the Edit link
 
     foreach ($rows as $id => & $row) {
+      //
+      // CRM-12645 Check if we have permission to edit the record.  If we have, we enable the link, otherwise
+      // we don't.
+      if (CRM_Contact_BAO_Contact_Permission::allow($row['contact_id'], CRM_Core_Permission::EDIT)) {
+        //enable the edit function
+        $links[CRM_Core_Action::UPDATE] = $editlink;
+      }
+      else {
+        // Suppress the edit function
+        $links[CRM_Core_Action::UPDATE] = array(
+          'name' => '----',
+        );
+    }
       if (!empty($this->_formValues['deleted_contacts']) && CRM_Core_Permission::check('access deleted contacts')
       ) {
         $links = array(

--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -927,8 +927,22 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
     $mapMask = $mask & 4095;
 
     $links = self::links($this->_context, $this->_contextMenu, $this->_key);
+    $editlink = $links[CRM_Core_Action::UPDATE];  // Remember the Edit link
 
     foreach ($rows as $id => & $row) {
+      //
+      // CRM-12645 Check if we have permission to edit the record.  If we have, we enable the link, otherwise
+      // we don't.
+      if (CRM_Contact_BAO_Contact_Permission::allow($row['contact_id'], CRM_Core_Permission::EDIT)) {
+        //enable the edit function
+        $links[CRM_Core_Action::UPDATE] = $editlink;
+      }
+      else {
+        // Suppress the edit function
+        $links[CRM_Core_Action::UPDATE] = array(
+          'name' => '----',
+        );
+        }
       if (!empty($this->_formValues['deleted_contacts']) && CRM_Core_Permission::check('access deleted contacts')
       ) {
         $links = array(

--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -942,7 +942,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
         $links[CRM_Core_Action::UPDATE] = array(
           'name' => '----',
         );
-    }
+      }
       if (!empty($this->_formValues['deleted_contacts']) && CRM_Core_Permission::check('access deleted contacts')
       ) {
         $links = array(


### PR DESCRIPTION
Suppress edit link if user does not have edit permissions.

---
- [CRM-12645: Suppress edit link in list of contacts where they don't have edit rights.](https://issues.civicrm.org/jira/browse/CRM-12645)
