### PR TITLE
Add "details" input to IDS exceptions.

### DIFF
--- a/CRM/Core/IDS.php
+++ b/CRM/Core/IDS.php
@@ -160,6 +160,7 @@ class CRM_Core_IDS {
     exceptions[]        = instructions
     exceptions[]        = suggested_message
     exceptions[]        = page_text
+    exceptions[]        = details
 ";
     if (file_put_contents($configFile, $contents) === FALSE) {
       CRM_Core_Error::movedSiteError($configFile);


### PR DESCRIPTION
Matches CRM_Utils_API_HTMLInputCoder::$skipfields list, refs CRM-19476.

---
- [CRM-19476: Add 'details' to IDS exclusion](https://issues.civicrm.org/jira/browse/CRM-19476)
