### PR TITLE
Fix for CRM-16838.

### DIFF
--- a/CRM/Contact/Form/Task.php
+++ b/CRM/Contact/Form/Task.php
@@ -443,6 +443,21 @@ class CRM_Contact_Form_Task extends CRM_Core_Form {
       }
       $householdsDAO->free();
     }
+
+    // If contact list has changed, households will probably be at the end of
+    // the list. Sort it again by sort_name.
+    if (implode(',', $this->_contactIds) != $relID) {
+      $contact_sort = array();
+      $result = civicrm_api3('Contact', 'get', array(
+        'return' => array('id'),
+        'id' => array('IN' => $this->_contactIds),
+        'options' => array(
+          'limit' => 0,
+          'sort' => "sort_name"
+        ),
+      ));
+      $this->_contactIds = array_keys($result['values']);
+    }
   }
 
   /**

--- a/CRM/Contact/Form/Task.php
+++ b/CRM/Contact/Form/Task.php
@@ -453,7 +453,7 @@ class CRM_Contact_Form_Task extends CRM_Core_Form {
         'id' => array('IN' => $this->_contactIds),
         'options' => array(
           'limit' => 0,
-          'sort' => "sort_name"
+          'sort' => "sort_name",
         ),
       ));
       $this->_contactIds = array_keys($result['values']);


### PR DESCRIPTION
- [CRM-16838: Mailing Label Merge by Household loses sort](https://issues.civicrm.org/jira/browse/CRM-16838)
