### PR TITLE
CRM-19483: remove destination URL size in trackable URLs.

### DIFF
--- a/CRM/Mailing/BAO/TrackableURL.php
+++ b/CRM/Mailing/BAO/TrackableURL.php
@@ -83,9 +83,7 @@ class CRM_Mailing_BAO_TrackableURL extends CRM_Mailing_DAO_TrackableURL {
 
       $tracker->url = $url;
       $tracker->mailing_id = $mailing_id;
-      if (strlen($tracker->url) > 254) {
-        return $url;
-      }
+
       if (!$tracker->find(TRUE)) {
         $tracker->save();
       }


### PR DESCRIPTION
This revert d78d31a1.

See also: CRM-14730 and CRM-15740.

---
- [CRM-19483: Trackable URLs: remove destination URL size](https://issues.civicrm.org/jira/browse/CRM-19483)
- [CRM-14730: over-long urls in CiviMail result in fatal error](https://issues.civicrm.org/jira/browse/CRM-14730)
- [CRM-15740: Really long URLs cause SQL issue in a trackable mass mail](https://issues.civicrm.org/jira/browse/CRM-15740)
