### PR TITLE
CRM-15980 Test for API does not permit PHP to permanently delete a contact

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -789,7 +789,7 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
    * @return bool
    *   Was contact deleted?
    */
-  public static function deleteContact($id, $restore = FALSE, $skipUndelete = FALSE) {
+  public static function deleteContact($id, $restore = FALSE, $skipUndelete = FALSE, $checkPermissions = TRUE) {
 
     if (!$id) {
       return FALSE;
@@ -801,8 +801,8 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
 
     // make sure we have edit permission for this contact
     // before we delete
-    if (($skipUndelete && !CRM_Core_Permission::check('delete contacts')) ||
-      ($restore && !CRM_Core_Permission::check('access deleted contacts'))
+    if ($checkPermissions && (($skipUndelete && !CRM_Core_Permission::check('delete contacts')) ||
+      ($restore && !CRM_Core_Permission::check('access deleted contacts')))
     ) {
       return FALSE;
     }

--- a/api/v3/Contact.php
+++ b/api/v3/Contact.php
@@ -408,7 +408,8 @@ function civicrm_api3_contact_delete($params) {
   if ($skipUndelete && CRM_Financial_BAO_FinancialItem::checkContactPresent(array($contactID), $error)) {
     return civicrm_api3_create_error($error['_qf_default']);
   }
-  if (CRM_Contact_BAO_Contact::deleteContact($contactID, $restore, $skipUndelete)) {
+  if (CRM_Contact_BAO_Contact::deleteContact($contactID, $restore, $skipUndelete,
+    CRM_Utils_Array::value('check_permissions', $params))) {
     return civicrm_api3_create_success();
   }
   else {

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -2250,6 +2250,24 @@ class api_v3_ContactTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test that delete with skip undelete respects permissions.
+   */
+  public function testContactDeletePermissions() {
+    $contactID = $this->individualCreate();
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = array('access CiviCRM');
+    $this->callAPIFailure('Contact', 'delete', array(
+      'id' => $contactID,
+      'check_permissions' => 1,
+      'skip_undelete' => 1,
+    ));
+    $this->callAPISuccess('Contact', 'delete', array(
+      'id' => $contactID,
+      'check_permissions' => 0,
+      'skip_undelete' => 1,
+    ));
+  }
+
+  /**
    * Test update with check permissions set.
    */
   public function testContactUpdatePermissions() {


### PR DESCRIPTION
- [CRM-15980: API does not permit PHP to permanently delete a contact](https://issues.civicrm.org/jira/browse/CRM-15980)
