### PR TITLE
CRM-19337 fix contact sub_type display on reports

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -4309,10 +4309,17 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
     // There is no reason not to add links for all fields but it seems a bit odd to be able to click on
     // 'Mrs'. Also, we don't have metadata about the title. So, add selectively to addLinks.
     $addLinks = array('gender_id' => 'Gender');
-    foreach (array('prefix_id', 'suffix_id', 'gender_id') as $fieldName) {
+    foreach (array('prefix_id', 'suffix_id', 'gender_id', 'contact_sub_type', 'preferred_language') as $fieldName) {
       if (array_key_exists('civicrm_contact_' . $fieldName, $row)) {
         if (($value = $row['civicrm_contact_' . $fieldName]) != FALSE) {
-          $rows[$rowNum]['civicrm_contact_' . $fieldName] = CRM_Core_Pseudoconstant::getLabel('CRM_Contact_BAO_Contact', $fieldName, $value);
+          $rowValues = explode(CRM_Core_DAO::VALUE_SEPARATOR, $value);
+          $rowLabels = array();
+          foreach ($rowValues as $rowValue) {
+            if ($rowValue) {
+              $rowLabels[] = CRM_Core_Pseudoconstant::getLabel('CRM_Contact_BAO_Contact', $fieldName, $rowValue);
+            }
+          }
+          $rows[$rowNum]['civicrm_contact_' . $fieldName] = implode(', ', $rowLabels);
           if ($baseUrl && ($title = CRM_Utils_Array::value($fieldName, $addLinks)) != FALSE) {
             $this->addLinkToRow($rows[$rowNum], $baseUrl, $linkText, $value, $fieldName, 'civicrm_contact', $title);
           }
@@ -4513,6 +4520,7 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
       'do_not_sms' => array(),
       'is_opt_out' => array(),
       'is_deceased' => array(),
+      'preferred_language' => array(),
     );
   }
 
@@ -4578,6 +4586,9 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
       'is_opt_out' => array(
         'title' => ts('Do not bulk email'),
         'type' => CRM_Utils_Type::T_BOOLEAN,
+      ),
+      'preferred_language' => array(
+        'title' => ts('Preferred Language'),
       ),
     );
   }

--- a/CRM/Report/Form/Contact/Summary.php
+++ b/CRM/Report/Form/Contact/Summary.php
@@ -233,31 +233,6 @@ class CRM_Report_Form_Contact_Summary extends CRM_Report_Form {
   }
 
   /**
-   * Initialise basic row.
-   *
-   * @param array $rows
-   *
-   * @param bool $entryFound
-   * @param array $row
-   * @param int $rowId
-   * @param int $rowNum
-   * @param array $types
-   *
-   * @return bool
-   */
-  private function _initBasicRow(&$rows, &$entryFound, $row, $rowId, $rowNum, $types) {
-    if (!array_key_exists($rowId, $row)) {
-      return FALSE;
-    }
-
-    $value = $row[$rowId];
-    if ($value) {
-      $rows[$rowNum][$rowId] = $types[$value];
-    }
-    $entryFound = TRUE;
-  }
-
-  /**
    * Alter display of rows.
    *
    * Iterate through the rows retrieved via SQL and make changes for display purposes,


### PR DESCRIPTION
- [CRM-19337: Contact reports display Contact Sub Types by name rather than label](https://issues.civicrm.org/jira/browse/CRM-19337)
