### PR TITLE
CRM-19353 - 'Dedupe by email' not working - with test

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -542,7 +542,7 @@ WHERE  mailing_id = %1
       $groupBy = $groupJoin = '';
       if ($dedupeEmail) {
         $groupJoin = " INNER JOIN civicrm_email e ON e.id = i.email_id";
-        $groupBy = " GROUP BY e.email, i.contact_id ";
+        $groupBy = " GROUP BY e.email ";
       }
 
       $sql = "


### PR DESCRIPTION
Incorporates patch from #9036

---
- [CRM-19353: 'Dedupe by email' not working](https://issues.civicrm.org/jira/browse/CRM-19353)
