### PR TITLE
CRM-19418 Fixes showing cancelled contribution box on 4.6

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3183,6 +3183,21 @@ WHERE  contribution_id = %1 ";
     }
   }
 
+
+  /**
+   * Is this contribution status a reversal.
+   *
+   * If so we would expect to record a negative value in the financial_trxn table.
+   *
+   * @param int $status_id
+   *
+   * @return bool
+   */
+  public static function isContributionStatusNegative($status_id) {
+    $reversalStatuses = array('Cancelled', 'Chargeback', 'Refunded');
+    return in_array(CRM_Contribute_PseudoConstant::contributionStatus($status_id, 'name'), $reversalStatuses);
+  }
+
   /**
    * Check status validation on update of a contribution.
    *

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -707,6 +707,15 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       }
     }
 
+    // define the status IDs that show the cancellation info, see CRM-17589
+    $cancelInfo_show_ids = array();
+    foreach (array_keys($statusName) as $status_id) {
+      if (CRM_Contribute_BAO_Contribution::isContributionStatusNegative($status_id)) {
+        $cancelInfo_show_ids[] = "'$status_id'";
+      }
+    }
+    $this->assign('cancelInfo_show_ids', implode(',', $cancelInfo_show_ids));
+
     if ($this->_id) {
       $contributionStatus = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $this->_id, 'contribution_status_id');
       $name = CRM_Utils_Array::value($contributionStatus, $statusName);

--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -467,6 +467,11 @@
     }
   }
 
+  function status() {
+    cj("#cancel_date").val('');
+    cj("#cancel_reason").val('');
+  }
+  
   </script>
   {/literal}
 
@@ -500,16 +505,16 @@
       }
        );
 
-      function showHideCancelInfo(obj) {
-        if (obj.find(":selected").text() == 'Refunded' || obj.find(":selected").text() == 'Cancelled') {
-          $('#cancelInfo').show( );
-          $('#total_amount').attr('readonly', true);
-        }
-        else {
-          $("#cancel_date").val('');
-          $("#cancel_reason").val('');
-          $('#cancelInfo').hide( );
-          $("#total_amount").removeAttr('readonly');
+     function showHideCancelInfo(obj) {
+       var cancelInfo_show_ids = [{/literal}{$cancelInfo_show_ids}{literal}];
+       if (cancelInfo_show_ids.indexOf(obj.val()) > -1) {
+         $('#cancelInfo').show( );
+         $('#total_amount').attr('readonly', true);
+       }
+       else {
+         status();
+         $('#cancelInfo').hide( );
+         $("#total_amount").removeAttr('readonly');
         }
       }
      });


### PR DESCRIPTION
This pull request is a backport of the changes that finally fixed [CRM-19418](https://issues.civicrm.org/jira/browse/CRM-19418) ([9179](https://github.com/civicrm/civicrm-core/pull/9179)). The issue was filed to fix in 4.6 an issue that had actually been identified before for 4.7 by [CRM-17589](https://issues.civicrm.org/jira/browse/CRM-17589) ([7244](https://github.com/civicrm/civicrm-core/pull/7244)).

The 4.7 references of what I'm implementing are:
- [CRM/Contribute/BAO/Contribution..php](https://github.com/civicrm/civicrm-core/blob/367b5943204ee8253953d5eb2a994901c544766f/CRM/Contribute/BAO/Contribution.php#L3645)
- [CRM/Contribute/Form/Contribution.php](https://github.com/civicrm/civicrm-core/blob/05465712e23b7d9b13a18d9b79017fb8e2628668/CRM/Contribute/Form/Contribution.php#L701)
- [templates/CRM/CRM/Contribute/Form/Contribution.tpl](https://github.com/civicrm/civicrm-core/blob/53fff622a37bb4bccccdc839e0843dab36579125/templates/CRM/Contribute/Form/Contribution.tpl#L502)
