### PR TITLE
CRM-15861: Offline membership renewal doesn't display priceset choices

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -217,6 +217,10 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     $entityId = $memtypeID = NULL;
     if ($this->_priceSetId) {
       if (($this->_useForMember && !empty($this->_currentMemberships)) || $this->_defaultMemTypeId) {
+        // This logic is pseudo-replicated in PriceSet::setPriceSetDefaultsToLastUsedValues
+        // Created differently because: This doesn't handle same membership types reapeating.
+        // With this code, with different price set options, which price option is picked is random,
+        // as opposed to last one used (which is likely more than acceptable for "on-line" renewals.
         $selectedCurrentMemTypes = array();
         foreach ($this->_priceSet['fields'] as $key => $val) {
           foreach ($val['options'] as $keys => $values) {

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -2541,21 +2541,19 @@ WHERE      civicrm_membership.is_test = 0";
    * Given specified contact, return a map of membership orgs (that contact
    * has ever been member of), and info on the last membership that contact
    * has signed up for this org.
-
    * Initial use case for this method was to return a list of membership
    * type that a contact should be renewed on when renewing using *any*
    * priceset, unlike online renewals which only renew for a specific price set
    *
-   * @param int $contactId, The contact who's memberships we want breakdown for
-   *        int $mostImportMembershipId.  It is possible that a contact may have
+   * @param int $contactId , The contact who's memberships we want breakdown for
+   * @param int $mostImportMembershipId,  It is possible that a contact may have
    *          multiple memberships for the same org (not usually, but some orgs
    *          do this). Any membership that matches this Id will be given
    *          preference and returned (over all other ones for the same org)
-   * @return array
-   *   Array (int $member_of_contact_id =>
-   *      Array (of the fields returned by the results set (see below)
-   *   )
-   *
+   * @return array Array (int $member_of_contact_id =>
+   * Array (int $member_of_contact_id =>
+   * Array (of the fields returned by the results set (see below)
+   * )
    */
   public static function getContactMembershipsByMembershipOrg($contactId, $mostImportMembershipId) {
     $query = "

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -364,6 +364,8 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
       $params['line_item'] = $params['lineItems'];
     }
 
+    //we failed to retrieve an existing membership payment contribution_id, just above.
+    //This means we're dealing with a first contribution.
     //do cleanup line  items if membership edit the Membership type.
     if (empty($ids['contribution']) && !empty($ids['membership'])) {
       CRM_Price_BAO_LineItem::deleteLineItems($ids['membership'], 'civicrm_membership');
@@ -2142,7 +2144,9 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = membership.contact_id AND 
 
   /**
    * Retrieve the contribution id for the associated Membership id.
-   * @todo we should get this off the line item
+   * @todo we should get this off the line item, which may not be easily doable
+   *       since adding memberships using priceSets calls this first to properly
+   *       update line-items that are in fluxing state.
    *
    * @param int $membershipId
    *   Membership id.
@@ -2164,10 +2168,14 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = membership.contact_id AND 
       return $contributionIds;
     }
 
-    if ($membershipPayment->find(TRUE)) {
-      return $membershipPayment->contribution_id;
+    // Pre CRM-15861, only returning first was fine, since when this was called
+    // we only ever had one item.  Post CRM-15861, need to get last.
+    $last = NULL;
+    $membershipPayment->find();
+    while ($membershipPayment->fetch()) {
+      $last = $membershipPayment->contribution_id;
     }
-    return NULL;
+    return $last;
   }
 
   /**
@@ -2526,6 +2534,99 @@ WHERE      civicrm_membership.is_test = 0";
       $cancelledMembershipIds[] = $dao->membership_type_id;
     }
     return $cancelledMembershipIds;
+  }
+
+  /**
+   *
+   * Given specified contact, return a map of membership orgs (that contact
+   * has ever been member of), and info on the last membership that contact
+   * has signed up for this org.
+
+   * Initial use case for this method was to return a list of membership
+   * type that a contact should be renewed on when renewing using *any*
+   * priceset, unlike online renewals which only renew for a specific price set
+   *
+   * @param int $contactId, The contact who's memberships we want breakdown for
+   *        int $mostImportMembershipId.  It is possible that a contact may have
+   *          multiple memberships for the same org (not usually, but some orgs
+   *          do this). Any membership that matches this Id will be given
+   *          preference and returned (over all other ones for the same org)
+   * @return array
+   *   Array (int $member_of_contact_id =>
+   *      Array (of the fields returned by the results set (see below)
+   *   )
+   *
+   */
+  public static function getContactMembershipsByMembershipOrg($contactId, $mostImportMembershipId) {
+    $query = "
+          SELECT org.member_of_contact_id,
+            org.display_name,
+            mem.id AS membership_id,
+            mem.membership_type_id,
+            mem.status_id,
+            st.is_current_member,
+            li.contribution_id,
+            li.price_field_id,
+            li.price_field_value_id,
+            co.receive_date
+          FROM (SELECT DISTINCT member_of_contact_id, con.display_name FROM civicrm_membership_type LEFT JOIN civicrm_contact con ON con.id = member_of_contact_id) org
+              INNER JOIN civicrm_membership mem
+                     ON mem.membership_type_id IN (SELECT id FROM civicrm_membership_type mt2 WHERE mt2.member_of_contact_id = org.member_of_contact_id)
+                     AND mem.contact_id = %1
+            LEFT JOIN civicrm_line_item li
+                   ON li.entity_table = 'civicrm_membership'
+                  AND li.entity_id = mem.id
+                  AND li.price_field_value_id IN (SELECT id FROM civicrm_price_field_value pfv WHERE membership_type_id IN (SELECT id FROM civicrm_membership_type mt2 WHERE mt2.member_of_contact_id  = org.member_of_contact_id))
+            LEFT JOIN civicrm_contribution co
+                ON co.id = li.contribution_id
+            LEFT JOIN civicrm_membership_status st
+                ON st.id = mem.status_id
+          ORDER BY  member_of_contact_id, is_current_member DESC, receive_date DESC, li.contribution_id DESC";
+
+    $dao = CRM_CORE_DAO::executeQuery($query, array(1 => array($contactId, 'Int')));
+    $last = 0;
+    $toReturn = array();
+    while ($dao->fetch()) {
+      // only return one row per member org.  This is easier than creating the crazy
+      // subquery that would be required to get the same result.
+      if ($dao->member_of_contact_id === $last && $mostImportMembershipId != $dao->membership_id) {
+        continue;
+      }
+      $last = $dao->member_of_contact_id;
+      $toReturn[$last] = (array) $dao;
+      $last = $dao->member_of_contact_id;
+    }
+
+    return $toReturn;
+  }
+
+  /**
+   *
+   * @param int $contact_id
+   * @return array
+   *   Array (int, int, int): The membership orgs that contact is part of.
+   */
+  public static function getActiveContactMemberships($contact_id) {
+    $sql = "SELECT DISTINCT member_of_contact_id
+  FROM civicrm_membership
+  	INNER JOIN civicrm_membership_type t ON t.id = civicrm_membership.membership_type_id
+ WHERE status_id IN (SELECT id FROM civicrm_membership_status WHERE is_current_member = 1)
+   AND contact_id = %1
+   ";
+    $params = array(1 => array($contact_id, 'Integer'));
+    $dao = self::executeQuery($sql, $params);
+    $contact_membership_orgs = array();
+    $cnt = 0;
+    while ($dao->fetch()) {
+      array_push($contact_membership_orgs, $dao->member_of_contact_id);
+      $cnt++;
+    }
+    if (empty($contact_membership_orgs) || $cnt < 1) {
+      return NULL;
+    }
+    else {
+      return $contact_membership_orgs;
+    }
   }
 
 }

--- a/CRM/Member/Form.php
+++ b/CRM/Member/Form.php
@@ -33,7 +33,6 @@
 
 /**
  * Base class for offline membership / membership type / membership renewal and membership status forms
- *
  */
 class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
 
@@ -78,6 +77,23 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
   public $_priceSetId;
 
   /**
+   * Used when price set specified.  Used to indicate that form is only to retrieve
+   * price set.  How we use price set is unconventional.  We re-use the same
+   * Membership/MembershipRenewal Form used to enter memberships.  When user selects
+   * a PriceSet, we use JavaScript to inject HTML returned by a recursive call to this form.
+   *
+   * This flag controls this recursive call, short-circuiting it to only retrieve the price
+   * set.
+   *
+   * Field introduced as part of CRM-15861.  Prior to CRM-15861, this was controlled by the
+   * name of the parameter used to request the price set (price_set_id, meant only price set,
+   * in contact->membership->add context, whilst priceSetId meant NOT only price set). Too
+   * confusing & too brittle.  An explicit member variable is now set for this.
+   *
+   */
+  public $_priceSetOnly;
+
+  /**
    * Price set details as an array.
    *
    * @var array
@@ -106,6 +122,24 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
     $params['context'] = CRM_Utils_Request::retrieve('context', 'String', $this, FALSE, 'membership');
     $params['id'] = CRM_Utils_Request::retrieve('id', 'Positive', $this);
     $params['mode'] = CRM_Utils_Request::retrieve('mode', 'String', $this);
+
+    // XXX We have too many ways that we set price set.  TODO: Clean this!
+    // When posting after saving, will come via POST price_set_id (from contact -> add membership)
+    // When posting after saving, from membership renewal will come via POST priceSetId
+    // When requesting via javascript (after user picks price set), will come via REQUEST
+    // When renewing, pre-process will automatically determine one before reverting to parent (us)
+    if (!$this->_priceSetId) {
+      $this->_priceSetId = CRM_Utils_Request::retrieve('priceSetId', 'Int', $this, FALSE);
+    }
+    if (!$this->_priceSetId) {
+      $this->_priceSetId = CRM_Utils_Request::retrieve('priceSetId', 'Int', $this, FALSE, NULL, "POST");
+    }
+    if (!$this->_priceSetId) {
+      $this->_priceSetId = CRM_Utils_Request::retrieve('price_set_id', 'Int', $this, FALSE, NULL, "POST");
+    }
+    $this->_priceSetOnly = CRM_Utils_Request::retrieve('priceSetOnly', 'Boolean');
+    $this->assign('priceSetOnly', $this->_priceSetOnly);
+    $this->assign('priceSetId', $this->_priceSetId);
 
     $this->setContextVariables($params);
 
@@ -167,6 +201,16 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
     }
     else {
       $defaults['membership_type_id'] = $this->_memType;
+    }
+    $defaults['num_terms'] = 1;
+    $defaults['send_receipt'] = 0;
+
+    //set Soft Credit Type to Gift by default
+    $scTypes = CRM_Core_OptionGroup::values("soft_credit_type");
+    $defaults['soft_credit_type_id'] = CRM_Utils_Array::value(ts('Gift'), array_flip($scTypes));
+    $this->assign('member_is_test', CRM_Utils_Array::value('member_is_test', $defaults));
+    if ($this->_mode) {
+      $defaults = $this->getBillingDefaults($defaults);
     }
     return $defaults;
   }
@@ -297,6 +341,37 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
   }
 
   /**
+   * Assign price set to page.
+   *
+   * @return array
+   */
+  protected function assignPriceSet() {
+    if ($this->_action & CRM_Core_Action::ADD || $this->_action == CRM_Core_Action::RENEW) {
+      $priceSets = CRM_Price_BAO_PriceSet::getAssoc(FALSE, 'CiviMember');
+      if (empty($priceSets)) {
+        $this->assign('hasPriceSets', FALSE);
+      }
+      else {
+        $options = array();
+        if ($this->shouldIncludeChoosePriceSetOption()) {
+          $options = $options + array('' => ts('Choose price set'));
+        }
+        $options = $options + $priceSets;
+
+        $this->add('select', 'price_set_id', ts('Choose price set'), $options,
+            NULL, array('onchange' => "buildAmount( this.value );")
+        );
+        $this->assign('hasPriceSets', TRUE);
+      }
+    }
+    return empty($priceSets);
+  }
+
+  protected function shouldIncludeChoosePriceSetOption() {
+    return TRUE;
+  }
+
+  /**
    * Set variables in a way that can be accessed from different places.
    *
    * This is part of refactoring for unit testability on the submit function.
@@ -383,13 +458,13 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
         return;
       }
     }
-    $priceFields = CRM_Member_BAO_Membership::setQuickConfigMembershipParameters(
+if ($this->_priceSet && $this->_priceSet['is_quick_config']) {    $priceFields = CRM_Member_BAO_Membership::setQuickConfigMembershipParameters(
       $formValues['membership_type_id'][0],
       $formValues['membership_type_id'][1],
       CRM_Utils_Array::value('total_amount', $formValues),
       $this->_priceSetId
     );
-    $formValues = array_merge($formValues, $priceFields['price_fields']);
+    $formValues = array_merge($formValues, $priceFields['price_fields']);}
   }
 
   /**

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -561,7 +561,6 @@ WHERE  id = %1";
     return (int) implode('_', array_keys($priceSet['fields'][$priceFieldID]['options']));
   }
 
-
   /**
    * Initiate price set such that various non-BAO things are set on the form.
    *
@@ -943,8 +942,6 @@ WHERE  id = %1";
    * Build the price set form.
    *
    * @param CRM_Core_Form $form
-   *
-   * @return void
    */
   public static function buildPriceSet(&$form) {
     $priceSetId = $form->get('priceSetId');
@@ -1672,7 +1669,7 @@ WHERE       ps.id = %1
   }
 
   /**
-   * Get non-deductible amount from price options
+   * Get non-deductible amount from price options.
    *
    * @param int $priceSetId
    * @param array $lineItem
@@ -1689,6 +1686,236 @@ WHERE       ps.id = %1
     }
 
     return $nonDeductibleAmount;
+
+  }
+
+  /**
+   * Get the last (still active) price set that was used to create that membership.
+   *
+   * If that price set does not exist, is not found or isn't active,
+   * then return the price set that will  cover that membership's record organisation.
+   * As multiple price sets may meet that criteria, the price set that cover's the most
+   * of that contact's membership of organizations will be returned.  As multiple price sets may
+   * still meet that criteria, the first defined price set is returned. Getting
+   * heuristics for determining the best price set here seems impossible.
+   *
+   * @param int $membership_id The membership that is being renewed.
+   *
+   * @return int
+   *     e.g., 9. To indicate that price set #9 is the last price set that as
+   *           used on contact #3.
+   */
+  public static function getLastPriceSetUsed($membership_id) {
+    $sql = "
+SELECT p.contribution_id, c.receive_Date, pf.price_set_id
+  FROM civicrm_membership m
+    LEFT JOIN civicrm_membership_payment p
+           ON p.membership_id = m.id
+     LEFT JOIN civicrm_contribution c
+            ON c.id = p.contribution_id
+    LEFT JOIN civicrm_line_item li
+           ON li.contribution_id = p.contribution_id
+          AND li.entity_table = 'civicrm_membership'
+          AND li.entity_id = m.id
+    LEFT JOIN civicrm_price_field_value pfv
+           ON pfv.id = li.price_field_value_id
+          AND pfv.is_active = 1
+    LEFT JOIN civicrm_price_field pf
+           ON pf.id = pfv.price_field_id
+          AND pf.is_active = 1
+    LEFT JOIN civicrm_price_set ps
+           ON ps.id = pf.price_set_id
+          AND ps.is_active = 1
+ WHERE m.id = %1
+       ORDER BY c.receive_date DESC, p.contribution_id DESC
+    ";
+
+    $params = array(1 => array($membership_id, 'Integer'));
+    $dao = self::executeQuery($sql, $params);
+    $activateByDefault = TRUE;
+    while ($dao->fetch()) {
+      // last price set used on this membership (could be multiple over the course of time)
+      // only select "price set view", if last contribution was for the price set.
+      if ($dao->price_set_id) {
+        return array(
+          'price_set_id' => $dao->price_set_id,
+          'price_set_is_through_contribution' => $activateByDefault,
+        );
+      }
+      $activateByDefault = FALSE;
+    }
+
+    // nothing found.  we want to pick, by default the price set that will cover
+    // the most of this contact's members of organizations (firstly), and the most
+    // of this contact's membership types (secondly)
+    $sql = "
+SELECT ps.id, ps.name,
+			(
+				SELECT COUNT(*)
+				  FROM civicrm_membership m
+				 WHERE m.contact_id = mem_renewed.contact_id
+				   AND EXISTS(SELECT 1 FROM civicrm_price_field_value pfv, civicrm_price_field pf
+				 				  WHERE pfv.membership_type_id = m.membership_type_id
+				 				    AND pfv.is_active
+				 				    AND pfv.price_field_id = pf.id
+				 				    AND pf.is_active = 1
+				 				    AND pf.price_set_id = ps.id
+				 		   )
+		     ) AS match_ps_cnt,
+		     (
+				SELECT COUNT(*)
+				  FROM -- count memberships
+				      civicrm_membership m
+				  	  INNER JOIN civicrm_membership_type mt ON mt.id = m.membership_type_id
+				 WHERE m.contact_id = mem_renewed.contact_id
+				   AND -- for which there exists a price set field value for the same org
+				       EXISTS(SELECT 1 FROM civicrm_price_field_value pfv, civicrm_price_field pf
+				 				  WHERE pfv.membership_type_id IN (SELECT mt2.id
+				 				  						       FROM civicrm_membership_type mt2
+				 				  						      WHERE mt2.member_of_contact_id = mt.member_of_contact_id)
+				 				    AND pfv.is_active
+				 				    AND pfv.price_field_id = pf.id
+				 				    AND pf.is_active = 1
+				 				    AND pf.price_set_id = ps.id
+				 		   )
+		     ) AS match_org_cnt
+  FROM civicrm_price_set ps, civicrm_membership mem_renewed, civicrm_membership_type mt_renewed
+ WHERE mem_renewed.id = %1
+   AND mt_renewed.id = mem_renewed.membership_type_id
+   AND ps.is_active = 1
+   AND ps.is_quick_config = 0
+       -- also make sure price set returned covers org of memebership being renewed
+   AND EXISTS(SELECT 1 
+                FROM civicrm_price_field pf, civicrm_price_field_value pfv 
+               WHERE pf.price_set_id = ps.id
+                 AND pfv.price_field_id = pf.id
+                 AND pfv.membership_type_id IN (SELECT mt.id FROM civicrm_membership_type mt WHERE mt.member_of_contact_id = mt_renewed.member_of_contact_id)
+             )
+ ORDER BY match_org_cnt DESC, match_ps_cnt DESC, ps.id
+ LIMIT 1
+ ";
+
+    $params = array(1 => array($membership_id, 'Integer'));
+    $dao = self::executeQuery($sql, $params);
+    if ($dao->fetch()) {
+      return array(
+        'price_set_id' => $dao->id,
+        'price_set_is_through_contribution' => FALSE,
+      );
+    }
+    else {
+      return array();
+    }
+  }
+
+  /**
+   *
+   * Given a price set and a contact, set (in defaults), the defaults that should be used
+   * in a price set based membership renewal for this contact.
+   *
+   * This function essentially looks up for every member org that this contact is part of
+   * whether there is a price set option that could have resulted in selecting that
+   * contact's membership type for that member org.
+   *
+   * @param $defaults       Where to set the defaults
+   * @param $priceSet       Fully loaded price set to analyze
+   * @param int $contactID  the contact's Id.
+   * @return mixed          the defaults passed in as parameter
+   */
+  public static function setPriceSetDefaultsToLastUsedValues(&$defaults, $priceSet, $contactID) {
+
+    // this is detailed info on how membership orgs, and the best membership type & price set field to use
+    $contactOrgMemberships = CRM_Member_BAO_Membership::getContactMembershipsByMembershipOrg($contactID);
+
+    // we need a list of all membership types, and the org that corresponds to them
+    // we use this later to associate price set mem type to the org it represents.
+    $allMemTypes = array_keys(CRM_Member_BAO_MembershipType::getMembershipTypes(FALSE));
+    $allMemOfByMemTypes = CRM_Member_BAO_MembershipType::getMemberOfContactByMemTypes($allMemTypes, $defaults['id']);
+
+    // go through all price fields & options
+    foreach ($priceSet['fields'] as $priceFieldId => $priceField) {
+      foreach ($priceField['options'] as $optionId => $option) {
+        // price option isn't membership oriented.  Ignore
+        // potential future enhancement: lookup last 'value' used for this price
+        // set (through civicrm_contribution -> civicrm_line_item)
+        if (empty($option['membership_type_id'])) {
+          continue;
+        }
+
+        if (empty(
+            // crazy expression to check that:
+            // given that price set's membership type ($option['membership_type_id'])
+            // we can lookup that type's "main org' ($allMemOfByMemTypes[previous])
+            // and that that contact has had a membership with that org ($contactMemTypesByMemOf[previous])
+            $contactOrgMemberships[$allMemOfByMemTypes[$option['membership_type_id']]]
+        )) {
+          // the price set option's membership type isn't one that this contact was ever part of
+          // Don't select it.
+          // Potential future enhancement: may be we should select it if:
+          //    Nothing gets selected for this 'select'/'radio', and it is default
+          //     OR
+          //    It is a checkbox, and its default is checked.
+          continue;
+        }
+
+        $memOf = $allMemOfByMemTypes[$option['membership_type_id']];
+
+        // this is the option we want to renew with (for the org).  It may or may not exist in the price set.
+        $bestOptionMemTypeId = $contactOrgMemberships[$memOf]['membership_type_id'];
+        $bestOptionIsActive = $contactOrgMemberships[$memOf]['is_current_member'];
+
+        // select if:
+        //  membership types match AND
+        //    is_required (in which case we don't care if active or not, since we need to select something) )
+        //    OR
+        //    is_"active"
+        if ($bestOptionMemTypeId === $option['membership_type_id']
+            && (
+              ($priceField['is_required'] && $priceField['html_type'] == 'Radio' || $priceField['html_type'] == 'Select')
+                ||
+              ($bestOptionIsActive)
+            )
+        ) {
+          $defaultOrgPf[$memOf] = array(
+            'price_field_id' => $priceFieldId,
+            'price_field_value_id' => $optionId,
+            'membership_type_id' => $option['membership_type_id'],
+            'html_type' => $priceField['html_type'],
+          );
+        }
+      }
+    }
+
+    // give preference to price field values from contact (overriding $defaultOrg)
+    // unless membership from which this flow was triggered already matches
+    // membership type (in which case we ignore the 'best' value calculated earlier
+    // in this method).
+    foreach ($contactOrgMemberships as $member_of_contact_id => $membership_info) {
+      $idealPriceFieldId = $membership_info['price_field_id'];
+      $idealPriceValueId = $membership_info['price_field_value_id'];
+
+      if (!empty(
+          // crazy ref to get to the contact's last price set any one of these may not be
+          $priceSet['fields'][$idealPriceFieldId]['options'][$idealPriceValueId]
+      )) {
+        $type = $priceSet['fields'][$idealPriceFieldId]['html_type'];
+        $defaultOrgPf[$member_of_contact_id] = array(
+          'price_field_id' => $idealPriceFieldId,
+          'price_field_value_id' => $idealPriceValueId,
+          'membership_type_id' => $membership_info['membership_type_id'],
+          'html_type' => $type,
+        );
+      }
+    }
+
+    // now go ahead and select
+    foreach ($defaultOrgPf as $member_of_contact_id => $selectOptions) {
+      $priceFieldName = "price_" . $selectOptions['price_field_id'];
+      // old code: self::setDefaultPriceSetField($priceFieldName, $optionId, $priceField['html_type'], $defaults);
+      self::setDefaultPriceSetField($priceFieldName, $selectOptions['price_field_value_id'], $selectOptions['html_type'], $defaults);
+    }
+
+    return $defaults;
   }
 
   /**

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -1825,12 +1825,12 @@ SELECT ps.id, ps.name,
   public static function setPriceSetDefaultsToLastUsedValues(&$defaults, $priceSet, $contactID) {
 
     // this is detailed info on how membership orgs, and the best membership type & price set field to use
-    $contactOrgMemberships = CRM_Member_BAO_Membership::getContactMembershipsByMembershipOrg($contactID);
+    $contactOrgMemberships = CRM_Member_BAO_Membership::getContactMembershipsByMembershipOrg($contactID, $defaults['id']);
 
     // we need a list of all membership types, and the org that corresponds to them
     // we use this later to associate price set mem type to the org it represents.
     $allMemTypes = array_keys(CRM_Member_BAO_MembershipType::getMembershipTypes(FALSE));
-    $allMemOfByMemTypes = CRM_Member_BAO_MembershipType::getMemberOfContactByMemTypes($allMemTypes, $defaults['id']);
+    $allMemOfByMemTypes = CRM_Member_BAO_MembershipType::getMemberOfContactByMemTypes($allMemTypes);
 
     // go through all price fields & options
     foreach ($priceSet['fields'] as $priceFieldId => $priceField) {

--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -31,7 +31,7 @@
   </div>
 {/if}
 <div class="spacer"></div>
-{if $priceSetId}
+{if $priceSetOnly}
   {include file="CRM/Price/Form/PriceSet.tpl" context="standalone" extends="Membership"}
   {literal}
   <script type="text/javascript">
@@ -606,7 +606,7 @@
       cj( "#total_amount" ).val( '' );
       cj('#total_amount').attr("readonly", true);
 
-      var dataUrl = {/literal}"{crmURL h=0 q='snippet=4'}"{literal} + '&priceSetId=' + priceSetId;
+      var dataUrl = {/literal}"{crmURL h=0 q='snippet=4'}"{literal} + '&priceSetOnly=TRUE&priceSetId=' + priceSetId;
 
       var response = cj.ajax({
         url: dataUrl,

--- a/templates/CRM/Member/Form/MembershipPriceSetCommon.tpl
+++ b/templates/CRM/Member/Form/MembershipPriceSetCommon.tpl
@@ -1,0 +1,3 @@
+{if $priceSetId}
+  {include file="CRM/Price/Form/PriceSet.tpl" context="standalone" extends="Membership"}
+{/if}

--- a/templates/CRM/Member/Form/MembershipRenewal.tpl
+++ b/templates/CRM/Member/Form/MembershipRenewal.tpl
@@ -23,6 +23,10 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
+{if $priceSetOnly}
+  {include file="CRM/Member/Form/MembershipPriceSetCommon.tpl"}
+{else}
+
 {* this template is used for renewing memberships for a contact  *}
   {if $membershipMode == 'test' }
     {assign var=registerMode value="TEST"}
@@ -64,19 +68,48 @@
       </tr>
       <tr class="crm-member-membershiprenew-form-block-org_name">
         <td class="label">{ts}Membership Organization and Type{/ts}</td>
-        <td class="html-adjust">{$orgName}&nbsp;&nbsp;-&nbsp;&nbsp;{$memType}
-          {if $member_is_test} {ts}(test){/ts}{/if}
-          &nbsp; <a id="changeMembershipOrgType" href='#'
-                    onclick='adjustMembershipOrgType(); return false;'>{ts}change membership type{/ts}</a>
+        <td class="html-adjust">
+          <table>
+            <tr>
+            <td>
+                {$orgName}&nbsp;&nbsp;-&nbsp;&nbsp;{$memType}
+                      {if $member_is_test} {ts}(test){/ts}{/if}
+            </td>
+            <td>
+                  <a id="changeMembershipOrgType" href='#' onclick='adjustMembershipOrgType(); return false;'>{ts}change membership type{/ts}</a>
+            </td>
+            </tr>
+          </table>
         </td>
       </tr>
       <tr id="membershipOrgType" class="crm-member-membershiprenew-form-block-renew_org_name hiddenElement">
         <td class="label">{$form.membership_type_id.label}</td>
         <td>{$form.membership_type_id.html}
-          {if $member_is_test} {ts}(test){/ts}{/if}<br/>
+          {if $member_is_test} {ts}(test){/ts}{/if}
+          <br/>
           <span class="description">{ts}Select Membership Organization and then Membership Type.{/ts}</span>
         </td>
       </tr>
+      {if $hasPriceSets}
+        {** the price set drop-down and section **}
+        <tr id="membershipPriceSet" class="crm-member-membershiprenew-form-block-renew_priceset">
+          <td class="label">{$form.price_set_id.label}</td>
+          <td>
+            <span id='membershipPriceSetBlockPriceSet' class='hiddenElement'>
+              <span id='selectPriceSet'>{$form.price_set_id.html}</span>
+                &nbsp;<a id="hidePriceSet" href='#' onclick='hidePriceSet(); return false;'>{ts}switch to single membership view{/ts}</a>
+                {* if there is a price set, then we will have one to start, so no need to show a hidden block *}
+                <div id="priceset"><br/>{include file="CRM/Price/Form/PriceSet.tpl" extends="Membership"}</div>
+              </span>
+            </span>
+            <span id='membershipPriceSetBlockSingleMembership'>
+              {ts}This membership does not appear to have been created using a price set.{/ts}<br/>
+              {ts}You may still renew it using a price set by{/ts}
+                <a id="showPriceSet" href='#' onclick='showPriceSet(); return false;'>{ts}clicking here{/ts}</a>.
+            </span>
+          </td>
+        <tr/>
+      {/if}
       <tr class="crm-member-membershiprenew-form-block-membership_status">
         <td class="label">{ts}Membership Status{/ts}</td>
         <td class="html-adjust">&nbsp;{$membershipStatus}<br/>
@@ -219,7 +252,57 @@
     function adjustMembershipOrgType() {
       cj('#membershipOrgType').show();
       cj('#changeMembershipOrgType').hide();
+      cj('#showPriceSet').hide();
     }
+
+    {/literal}
+    {if $priceSet}
+      var priceSet = {$priceSet};
+    {else}
+      var priceSet = '';
+    {/if}
+      {literal}
+      var membershipTypeOrg = cj('#membership_type_id_0').val();
+      var membershipTypeId = cj('#membership_type_id_1').val();
+
+      function showPriceSet() {
+        cj('#price_set_id').val(priceSet);
+        // unset membershiptype and org, so to avoid triggering processing on those, since we're using a price set
+        membershipTypeOrg = cj('#membership_type_id_0').val();
+        membershipTypeId = cj('#membership_type_id_1').val();
+        cj('#membership_type_id_0').val(null);
+        cj('#membership_type_id_1').val(null);
+
+        // We're using a price set.  total_amount is read only *}
+        cj('#total_amount').prop('readonly', 'true');
+        // join date, which is pretty well synonyous to renewal_date, but allowed separately for more flexibility
+        cj('#membershipJoinDate').show();
+
+        cj('#changeMembershipOrgType').hide();
+        cj('#membershipPriceSetBlockSingleMembership').hide();
+        cj('#membershipPriceSetBlockPriceSet').show();
+        cj(".crm-membershiprenew-form-block-financial_type_id").hide();
+      }
+
+      function hidePriceSet() {
+        // unset price set so that we don't submit it
+        priceSet = cj('#price_set_id').val();
+        cj('#price_set_id').val(null);
+
+        //set back membership org & type
+        cj('#membership_type_id_0').val(membershipTypeOrg);
+        cj('#membership_type_id_1').val(membershipTypeId);
+
+        // make total_amount editable again
+        cj('#total_amount').removeProp('readonly');
+
+        cj('#changeMembershipOrgType').show();
+        cj('#membershipPriceSetBlockSingleMembership').show();
+        cj('#membershipPriceSetBlockPriceSet').hide();
+      }
+      {/literal}
+
+  {literal}
 
     function changeNumTerms() {
       cj('#changeNumTerms').show();
@@ -296,5 +379,35 @@
         cj('#record-different-contact').hide();
       }
     }
+
+    function buildAmount( ) {
+        priceSetId = cj("#price_set_id").val( );
+        var fname = '#priceset';
+
+        cj('#total_amount').val( '' );
+        cj('#total_amount').attr("readonly", true);
+
+        var dataUrl = {/literal}"{crmURL h=0 q='snippet=4'}"{literal} + '&priceSetOnly=TRUE&priceSetId=' + priceSetId;
+
+        var response = cj.ajax({
+          url: dataUrl,
+          async: false
+        }).responseText;
+
+        cj( fname ).show().html( response );
+        // freeze total amount text field.
+
+        cj( "#totalAmountORPriceSet" ).hide( );
+        cj( "#mem_type_id" ).hide( );
+        cj( "#num_terms_row" ).hide( );
+        cj(".crm-membershiprenew-form-block-financial_type_id").hide();
+    }
+
+  {/literal}
+  {if $show_price_set}
+      showPriceSet();
+  {/if}
+
   </script>
-{/literal}
+
+{/if}

--- a/tests/phpunit/CRM/Member/Form/MembershipPriceSetRenewalTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipPriceSetRenewalTest.php
@@ -1,0 +1,353 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2017                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *  Tests for MembershipRenewal, testing price set based renewals.
+ *
+ *  (PHP 5)
+ *
+ * @author Marc Brazeau <marc@scibrazeau.ca>
+ */
+
+/**
+ *  Test CRM_Member_Form_MembershipRenewal functions.
+ *
+ * @package   CiviCRM
+ * @group headless
+ */
+class CRM_Member_Form_MembershipPriceSetRenewalTest extends CiviUnitTestCase {
+
+  private $_contactID;
+  private $_paymentProcessorID;
+
+  private $_dataset;
+  private $_mem_date;
+
+  public function setUp() {
+    $this->_apiversion = 3;
+    $this->_mem_date = date('Y-m-d');
+
+    parent::setUp();
+
+    $this->_paymentProcessorID = $this->processorCreate();
+
+    // The CIC is the reference use case for this.  So we'll just go ahead and create their data.
+
+    $op = new PHPUnit_Extensions_Database_Operation_Insert();
+
+    $this->_dataset = $this->createFlatXMLDataSet(
+      dirname(__FILE__) . '/dataset/price_set_renewal_data.xml'
+    );
+
+    $op->execute($this->_dbconn, $this->_dataset);
+    // my xml left 0s out to be a bit more concise.  This creates errors, so use proper value.
+    CRM_Core_DAO::executeQuery("update civicrm_price_field set is_required = 0 where is_required IS NULL");
+
+  }
+
+  public function testFormFieldsMembershipWithNoApplicablePriceSet() {
+    try {
+      $this->_contactID = $this->individualCreate();
+
+      $membershipId = $this->cicContactMembershipCreate(150);
+
+      $form = $this->getForm($membershipId);
+
+      // we expect this to be false, because 150, has no price sets (even though there exists price sets in our data set).
+      $this->assertNull($form->get_template_vars('show_price_sets'));
+      $this->assertNull($form->get_template_vars('hasPriceSets'));
+    }
+    catch (Exception $e) {
+      throw $e;
+    }
+
+  }
+
+
+  public function testFormFieldsMembershipWithMultipleApplicablePriceSetsExpiredMemberships() {
+    $this->_mem_date = '2007-01-21'; // noticed that this caused an exception, while running test below so keeping (good catch).
+    $this->testFormFieldsMembershipWithMultipleApplicablePriceSets();
+  }
+
+  public function testFormFieldsMembershipWithMultipleApplicablePriceSets() {
+    $this->_contactID = $this->individualCreate();
+
+    $memberships[0] = $this->cicContactMembershipCreate(165); // ACCN Print (member of contact #8)
+    $memberships[1] = $this->cicContactMembershipCreate(199); // CSC Full Fee (member of contact #5)
+    $memberships[2] = $this->cicContactMembershipCreate(171); // Member of IUPAC  (member of contact #12).
+
+    for ($i = 0; $i < count($memberships); $i++) {
+      // result is the same, regardless of membership that is renewed.
+      $form = $this->getForm($memberships[$i]);
+
+      // we expect this to be false, because 150, has no price sets (even though there exists price sets in our data set).
+      $hasPriceSets = $form->get_template_vars('hasPriceSets');
+      $showPriceSets = $form->get_template_vars('show_price_set');
+      $price_set_id = $form->get_template_vars('priceSetId');
+      $price_set = $form->get_template_vars('priceSet');
+      $this->assertTrue($hasPriceSets);
+      $this->assertFalse($showPriceSets);
+      $this->assertEquals(32, $price_set_id);
+      $this->assertNotEmpty($price_set);
+    }
+  }
+
+  /**
+   * Test the submit function of the membership form.
+   *
+   * In this test, we start with two memberships (CSC & ACCN).
+   *
+   * We renew, using a price set, picking four memberships:
+   *  767 (CSC Full Fee)
+   *  781 (CSChE Additional Member)
+   *  782 (CSCT Additiona Member)
+   *  783 (ACCN Print & On-Line).
+   *
+   * Expected result is that we now that the 2 previous memberships have had their end date extended,
+   * start & join date remain unchanged.  The 2 new memberships get their join dates set to join_date
+   * specified & start date based on membership rules.
+   */
+  public function testSubmit_RenewPickExistingAndAddNew() {
+    $this->_contactID = $this->individualCreate();
+
+    $nowMinus3Months = strtotime('-3 months', time());
+    $nowPlus9Months = strtotime('+9 months', time());
+    $this->_mem_date = date("m/d/Y", $nowMinus3Months);
+    $memberships[0] = $this->cicContactMembershipCreate(199); // CSC Full Fee (member of contact #5)
+    $memberships[1] = $this->cicContactMembershipCreate(165); // ACCN Print (member of contact #8)
+
+    $form = $this->getForm($memberships[0]);
+    $this->createLoggedInUser();
+    $params = array(
+      'action' => 'renew',
+      'cid' => $this->_contactID,
+      'id' => $memberships[0],
+      'context' => "membership",
+      'selectedChild' => "member",
+      'snippet' => "json",
+
+      'price_set_id' => "32",
+      'price_364' => "767",
+      'price_365' => array(
+        '781' => "1",
+        '782' => "1",
+      ),
+      'price_366' => "783",
+      'renewal_date' => $this->_mem_date,
+      'renewal_date_display_58fd51610b17b' => $this->_mem_date,
+      'record_contribution' => "1",
+      'soft_credit_type_id' => "11",
+      'total_amount' => "206.85",
+      'receive_date' => $this->_mem_date,
+      'receive_date_display_58fd51610dcac' => $this->_mem_date,
+      'receive_date_time' => "09:14PM",
+      'financial_type_id' => "2",
+      // 'payment_instrument_id' => "4",
+      'contribution_status_id' => "1",
+      // This format reflects the 23 being the organisation & the 25 being the type.
+      // when renewing price set, there won't be a membershiptype.
+      'membership_type_id' => array(23, NULL),
+      'auto_renew' => '0',
+      'is_recur' => 0,
+      'max_related' => 0,
+      'num_terms' => '1',
+      'source' => '',
+      //Member dues, see data.xml
+      'soft_credit_contact_id' => '',
+      'from_email_address' => '"Demonstrators Anonymous" <info@example.org>',
+      'receipt_text' => 'Thank you text',
+      'payment_processor_id' => $this->_paymentProcessorID,
+      'credit_card_number' => '4111111111111111',
+      'cvv2' => '123',
+      'credit_card_exp_date' => array(
+        'M' => '9',
+        'Y' => date("Y") + 2,
+      ),
+      'credit_card_type' => 'Visa',
+      'billing_first_name' => 'Test',
+      'billing_middlename' => 'Last',
+      'billing_street_address-5' => '10 Test St',
+      'billing_city-5' => 'Test',
+      'billing_state_province_id-5' => '1003',
+      'billing_postal_code-5' => '90210',
+      'billing_country_id-5' => '1228',
+      'send_receipt' => 1,
+      'join_date' => '',
+      'start_date' => '',
+      'end_date' => '',
+      'campaign_id' => '',
+    );
+    $form->_contactID = $this->_contactID;
+
+    $form->testSubmit($params);
+
+    $actualData = $this->getConnection()->createQueryTable('memberships_etc', '
+    select
+  mem.membership_type_id,
+  mem.join_date,
+  mem.start_date,
+  mem.end_date,
+  mem.status_id as mem_status_id,
+  con.financial_type_id as con_financial_type_id,
+  con.payment_instrument_id,
+  con.total_amount,
+  con.fee_amount,
+  con.net_amount,
+  con.currency as con_currency,
+  con.contribution_status_id,
+  length(con.trxn_id) as trxn_id_ln,
+  length(con.invoice_id) as invoice_id_ln,
+  lit.qty,
+  lit.unit_price,
+  lit.line_total,
+  lit.financial_type_id as lit_financial_type_id,
+  date(fit.created_date) as created_date,
+  date(fit.transaction_date) as transaction_date,
+  fit.description,
+  fit.amount,
+  fit.currency as fit_currency,
+  fit.financial_account_id,
+  fit.status_id as fit_status_id
+from civicrm_membership as mem
+  left join civicrm_membership_payment pay on pay.membership_id = mem.id
+  left join civicrm_contribution con on con.id = pay.contribution_id
+
+  -- Should also be able to get to the financial type for each membership
+  left join civicrm_line_item lit on
+                                    lit.entity_table = \'civicrm_membership\'
+                                    and lit.contribution_id = con.id
+                                    and (select pfv.membership_type_id from civicrm_price_field_value pfv where pfv.id = lit.price_field_value_id) = mem.membership_type_id
+  left join civicrm_financial_item fit on
+                                    fit.entity_table = \'civicrm_line_item\'
+                                    and fit.entity_id = lit.id
+
+
+order by membership_type_id ');
+
+    $expectedData1 = $this->createFlatXmlDataSet(dirname(__FILE__) . "/dataset/price_set_renewal_expected.xml")->getTable("memberships_etc");
+    $expectedData2 = new PHPUnit_Extensions_Database_DataSet_ReplacementTable($expectedData1);
+    $expectedData2->addSubStrReplacement("special-memyear", date("Y", $nowMinus3Months));
+    $expectedData2->addSubStrReplacement("special-now+9m", date("Y-m-d", $nowPlus9Months));
+    $expectedData2->addSubStrReplacement("special-now-3m", date("Y-m-d", $nowMinus3Months));
+    $expectedData2->addSubStrReplacement("special-now", date("Y-m-d"));
+    $this->assertTablesEqual($expectedData2, $actualData);
+
+    // Use this to troubleshoot what's wrong!!!  Probably not required, but in my case, took for ever to realize, that
+    // merge added an extra space in an expected result!
+    //    $expectedRowCnt = $expectedData1->getRowCount();
+    //    $expectedColCnt = sizeof($expectedData1->getRow(0));
+    //    $this->assertEquals($expectedRowCnt, $actualData->getRowCount());
+    //    for ($i = 0; $i < $expectedRowCnt; $i++) {
+    //      $expectedRow = $expectedData1->getRow($i);
+    //      $actualRow = $actualData->getRow($i);
+    //      foreach ($expectedRow as $col => $expectValAsSimpleXMLElement) {
+    //        $actualVal = $actualRow[$col];
+    //        $expectVal = $expectValAsSimpleXMLElement->__toString();
+    //        if ($expectVal == "special-now") {
+    //          $expectVal = date("Y-m-d");
+    //        }
+    //        try {
+    //          $this->assertEquals($expectVal, $actualVal, "Row #$i, column $col");
+    //        } catch (Exception $e) {
+    //          $this->assertEquals($expectVal, $actualVal, "Row #$i, column $col");
+    //        }
+    //      }
+    //    }
+  }
+
+  /**
+   * Clean up after each test.
+   */
+  public function tearDown() {
+    try {
+      // clear these values set when building form.  Tried doing in finally, but style police wasn't happy with that.
+      unset($_SERVER['REQUEST_METHOD']);
+      unset($_REQUEST['cid']);
+      unset($_REQUEST['id']);
+
+      // org contacts created.
+      $this->contactDelete($this->_contactID);
+      $op = new PHPUnit_Extensions_Database_Operation_Delete();
+      $op->execute($this->_dbconn, $this->_dataset);
+
+      $this->quickCleanup(
+        array(
+          'civicrm_address',
+          'civicrm_membership',
+          'civicrm_membership_type',
+        )
+      );
+
+      $this->quickCleanUpFinancialEntities();
+
+      for ($i = 5; $i < 13; $i++) {
+        try {
+          $this->contactDelete($i);
+        }
+        catch (Exception $e) {
+          // ignore
+        }
+      }
+    }
+    catch (Exception $e) {
+      throw $e;
+    }
+  }
+
+  /**
+   * Get a membership form object.
+   *
+   * We need to instantiate the form to run preprocess, which means we have to trick it about the request method.
+   *
+   * @param string $mode
+   *
+   * @return \CRM_Member_Form_MembershipRenewal
+   */
+  protected function getForm($membershipId, $mode = 'test') {
+    $form = new CRM_Member_Form_MembershipRenewal();
+    $_SERVER['REQUEST_METHOD'] = 'GET';
+    $_REQUEST['cid'] = $this->_contactID;
+    $_REQUEST['id'] = $membershipId;
+    $form->controller = new CRM_Core_Controller();
+    $form->_bltID = 5;
+    $form->_mode = $mode;
+    $form->buildForm();
+    return $form;
+  }
+
+  public function cicContactMembershipCreate($membershipTypeId) {
+    return $this->contactMembershipCreate(array(
+      'contact_id' => $this->_contactID,
+      'join_date' => $this->_mem_date,
+      'start_date' => $this->_mem_date,
+      'end_date' => $this->_mem_date,
+      'status_id' => 3,
+      'membership_type_id' => $membershipTypeId,
+    ));
+  }
+
+}

--- a/tests/phpunit/CRM/Member/Form/MembershipRenewalTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipRenewalTest.php
@@ -249,7 +249,7 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
       'cvv2' => '123',
       'credit_card_exp_date' => array(
         'M' => '9',
-        'Y' => '2019', // TODO: Future proof
+        'Y' => date("Y") + 2,
       ),
       'credit_card_type' => 'Visa',
       'billing_first_name' => 'Test',
@@ -581,7 +581,7 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
       'cvv2' => '123',
       'credit_card_exp_date' => array(
         'M' => '9',
-        'Y' => '2019', // TODO: Future proof
+        'Y' => date("Y") + 2,
       ),
       'credit_card_type' => 'Visa',
       'billing_first_name' => 'Test',

--- a/tests/phpunit/CRM/Member/Form/dataset/price_set_renewal_data.xml
+++ b/tests/phpunit/CRM/Member/Form/dataset/price_set_renewal_data.xml
@@ -1,0 +1,929 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--  $Id: data.xml 43570 2012-11-09 12:03:45Z deepak $ -->
+<dataset>
+
+    <civicrm_financial_account id="201" name="CSChE Full Fee 4201 CY" contact_id="1" financial_account_type_id="3" accounting_code="4201" description="CSChE Full Fee 4201 CY" />
+    <civicrm_financial_account id="202" name="CSCT Full Fee 4101 CY" contact_id="1" financial_account_type_id="3" accounting_code="4101" description="CSCT Full Fee 4101 CY" />
+    <civicrm_financial_account id="203" name="CSC Full Fee 2425 FY" contact_id="1" financial_account_type_id="3" accounting_code="2425" description="CSC Full Fee 2425 FY" />
+    <civicrm_financial_account id="204" name="CSChE Full Fee 2225 FY" contact_id="1" financial_account_type_id="3" accounting_code="2225" description="CSChE Full Fee 2225 FY" />
+    <civicrm_financial_account id="205" name="CSCT Full Fee 2025 FY" contact_id="1" financial_account_type_id="3" accounting_code="2025" description="CSCT Full Fee 2025 FY" />
+    <civicrm_financial_account id="206" name="CSC Half Fee AG 4402 CY" contact_id="1" financial_account_type_id="3" accounting_code="4402" description="CSC Half Fee AG 4402 CY" />
+    <civicrm_financial_account id="207" name="CSChE Half Fee AG 4202 CY" contact_id="1" financial_account_type_id="3" accounting_code="4202" description="CSChE Half Fee AG 4202 CY" />
+    <civicrm_financial_account id="208" name="CSCT Half Fee AG 4102 CY" contact_id="1" financial_account_type_id="3" accounting_code="4102" description="CSCT Half Fee AG 4102 CY" />
+    <civicrm_financial_account id="209" name="CSC Half Fee AG 2426 FY" contact_id="1" financial_account_type_id="3" accounting_code="2426" description="CSC Half Fee AG 2426 FY" />
+    <civicrm_financial_account id="210" name="CSChE Half Fee AG 2226 FY" contact_id="1" financial_account_type_id="3" accounting_code="2226" description="CSChE Half Fee AG 2226 FY" />
+    <civicrm_financial_account id="211" name="CSCT Half Fee AG 2026 FY" contact_id="1" financial_account_type_id="3" accounting_code="2026" description="CSCT Half Fee AG 2026 FY" />
+    <civicrm_financial_account id="212" name="CSC Retired 4403 CY" contact_id="1" financial_account_type_id="3" accounting_code="4403" description="CSC Retired 4403 CY" />
+    <civicrm_financial_account id="213" name="CSChE Retired 4203 CY" contact_id="1" financial_account_type_id="3" accounting_code="4203" description="CSChE Retired 4203 CY" />
+    <civicrm_financial_account id="214" name="CSCT Retired 4103 CY" contact_id="1" financial_account_type_id="3" accounting_code="4103" description="CSCT Retired 4103 CY" />
+    <civicrm_financial_account id="215" name="CSC Retired 2427 FY" contact_id="1" financial_account_type_id="3" accounting_code="2427" description="CSC Retired 2427 FY" />
+    <civicrm_financial_account id="216" name="CSChE Retired 2227 FY" contact_id="1" financial_account_type_id="3" accounting_code="2227" description="CSChE Retired 2227 FY" />
+    <civicrm_financial_account id="217" name="CSCT Retired 2027 FY" contact_id="1" financial_account_type_id="3" accounting_code="2027" description="CSCT Retired 2027 FY" />
+    <civicrm_financial_account id="218" name="CSC Undergraduate 4407 CY" contact_id="1" financial_account_type_id="3" accounting_code="4407" description="CSC Undergraduate 4407 CY" />
+    <civicrm_financial_account id="219" name="CSChE Undergraduate 4205 CY" contact_id="1" financial_account_type_id="3" accounting_code="4205" description="CSChE Undergraduate 4205 CY" />
+    <civicrm_financial_account id="220" name="CSCT Undergraduate 4106 CY" contact_id="1" financial_account_type_id="3" accounting_code="4106" description="CSCT Undergraduate 4106 CY" />
+    <civicrm_financial_account id="221" name="CSC Undergraduate 2430 FY" contact_id="1" financial_account_type_id="3" accounting_code="2430" description="CSC Undergraduate 2430 FY" />
+    <civicrm_financial_account id="222" name="CSChE Undergraduate 2229 FY" contact_id="1" financial_account_type_id="3" accounting_code="2229" description="CSChE Undergraduate 2229 FY" />
+    <civicrm_financial_account id="223" name="CSCT Undergraduate 2030 FY" contact_id="1" financial_account_type_id="3" accounting_code="2030" description="CSCT Undergraduate 2030 FY" />
+    <civicrm_financial_account id="224" name="CSC Postdoc Fee 4405 CY" contact_id="1" financial_account_type_id="3" accounting_code="4405" description="CSC Postdoc Fee 4405 CY" />
+    <civicrm_financial_account id="225" name="CSChE Postdoc Fee 4207 CY" contact_id="1" financial_account_type_id="3" accounting_code="4207" description="CSChE Postdoc Fee 4207 CY" />
+    <civicrm_financial_account id="226" name="CSC Postdoc Fee 2433 FY" contact_id="1" financial_account_type_id="3" accounting_code="2433" description="CSC Postdoc Fee 2433 FY" />
+    <civicrm_financial_account id="227" name="CSChE Postdoc Fee 2248 FY" contact_id="1" financial_account_type_id="3" accounting_code="2248" description="CSChE Postdoc Fee 2248 FY" />
+    <civicrm_financial_account id="228" name="CSC Graduate Student 4404 CY" contact_id="1" financial_account_type_id="3" accounting_code="4404" description="CSC Graduate Student 4404 CY" />
+    <civicrm_financial_account id="229" name="CSChE Graduate Student 4204 CY" contact_id="1" financial_account_type_id="3" accounting_code="4204" description="CSChE Graduate Student 4204 CY" />
+    <civicrm_financial_account id="230" name="CSCT Graduate Student 4104 CY" contact_id="1" financial_account_type_id="3" accounting_code="4104" description="CSCT Graduate Student 4104 CY" />
+    <civicrm_financial_account id="231" name="CSC Graduate Student 2428 FY" contact_id="1" financial_account_type_id="3" accounting_code="2428" description="CSC Graduate Student 2428 FY" />
+    <civicrm_financial_account id="232" name="CSChE Graduate Student 2232 FY" contact_id="1" financial_account_type_id="3" accounting_code="2232" description="CSChE Graduate Student 2232 FY" />
+    <civicrm_financial_account id="233" name="CSCT Graduate Student 2031 FY" contact_id="1" financial_account_type_id="3" accounting_code="2031" description="CSCT Graduate Student 2031 FY" />
+    <civicrm_financial_account id="234" name="CSC HS Teacher 4413 CY" contact_id="1" financial_account_type_id="3" accounting_code="4413" description="CSC HS Teacher 4413 CY" />
+    <civicrm_financial_account id="235" name="CSChE HS Teacher 4213 CY" contact_id="1" financial_account_type_id="3" accounting_code="4213" description="CSChE HS Teacher 4213 CY" />
+    <civicrm_financial_account id="236" name="CSCT HS Teacher 4113 CY" contact_id="1" financial_account_type_id="3" accounting_code="4113" description="CSCT HS Teacher 4113 CY" />
+    <civicrm_financial_account id="237" name="CSC HS Teacher 2432 FY" contact_id="1" financial_account_type_id="3" accounting_code="2432" description="CSC HS Teacher 2432 FY" />
+    <civicrm_financial_account id="238" name="CSChE HS Teacher 2233 FY" contact_id="1" financial_account_type_id="3" accounting_code="2233" description="CSChE HS Teacher 2233 FY" />
+    <civicrm_financial_account id="239" name="CSCT HS Teacher 2034 FY" contact_id="1" financial_account_type_id="3" accounting_code="2034" description="CSCT HS Teacher 2034 FY" />
+    <civicrm_financial_account id="240" name="CSC Lifetime 4409 CY" contact_id="1" financial_account_type_id="3" accounting_code="4409" description="CSC Lifetime 4409 CY" />
+    <civicrm_financial_account id="241" name="CSChE Lifetime 4209 CY" contact_id="1" financial_account_type_id="3" accounting_code="4209" description="CSChE Lifetime 4209 CY" />
+    <civicrm_financial_account id="242" name="CSCT Lifetime 4114 CY" contact_id="1" financial_account_type_id="3" accounting_code="4114" description="CSCT Lifetime 4114 CY" />
+    <civicrm_financial_account id="243" name="CSC Lifetime 2435 FY" contact_id="1" financial_account_type_id="3" accounting_code="2435" description="CSC Lifetime 2435 FY" />
+    <civicrm_financial_account id="244" name="CSChE Lifetime 2234 FY" contact_id="1" financial_account_type_id="3" accounting_code="2234" description="CSChE Lifetime 2234 FY" />
+    <civicrm_financial_account id="245" name="CSCT Lifetime 2035 FY" contact_id="1" financial_account_type_id="3" accounting_code="2035" description="CSCT Lifetime 2035 FY" />
+    <civicrm_financial_account id="246" name="CSC Zero Dollar 7000 (exempt)" contact_id="1" financial_account_type_id="3" accounting_code="7000" description="CSC Zero Dollar 7000 (exempt)" />
+    <civicrm_financial_account id="247" name="Addtional CSC 4408 CY" contact_id="1" financial_account_type_id="3" accounting_code="4408" description="Addtional CSC 4408 CY" />
+    <civicrm_financial_account id="248" name="Addtional CSC 2431 FY" contact_id="1" financial_account_type_id="3" accounting_code="2431" description="Addtional CSC 2431 FY" />
+    <civicrm_financial_account id="249" name="Additional CSChE 4208 CY" contact_id="1" financial_account_type_id="3" accounting_code="4208" description="Additional CSChE 4208 CY" />
+    <civicrm_financial_account id="250" name="Additional CSChE 2230 FY" contact_id="1" financial_account_type_id="3" accounting_code="2230" description="Additional CSChE 2230 FY" />
+    <civicrm_financial_account id="251" name="Additional CSCT 4118 CY" contact_id="1" financial_account_type_id="3" accounting_code="4118" description="Additional CSCT 4118 CY" />
+    <civicrm_financial_account id="252" name="Additional CSCT 2029 FY" contact_id="1" financial_account_type_id="3" accounting_code="2029" description="Additional CSCT 2029 FY" />
+    <civicrm_financial_account id="253" name="CJChE Print 4301 CY" contact_id="1" financial_account_type_id="3" accounting_code="4301" description="CJChE Print 4301 CY" />
+    <civicrm_financial_account id="254" name="CJChE Print 2301 FY" contact_id="1" financial_account_type_id="3" accounting_code="2301" description="CJChE Print 2301 FY" />
+    <civicrm_financial_account id="255" name="CamJChem Canada 4042 CY" contact_id="1" financial_account_type_id="3" accounting_code="4042" description="CamJChem Canada 4042 CY" />
+    <civicrm_financial_account id="256" name="CamJChem Canada 2023 FY" contact_id="1" financial_account_type_id="3" accounting_code="2023" description="CamJChem Canada 2023 FY" />
+    <civicrm_financial_account id="257" name="CamJChem Outside Can 4043 CY (exempt)" contact_id="1" financial_account_type_id="3" accounting_code="4043" description="CamJChem Outside Can 4043 CY (exempt)" />
+    <civicrm_financial_account id="258" name="CamJChem Outside Can 2022 FY (exempt)" contact_id="1" financial_account_type_id="3" accounting_code="2022" description="CamJChem Outside Can 2022 FY (exempt)" />
+    <civicrm_financial_account id="259" name="Chemistry &amp; Industry 4045 CY" contact_id="1" financial_account_type_id="3" accounting_code="4045" description="Chemistry &amp; Industry 4045 CY" />
+    <civicrm_financial_account id="260" name="Chemistry &amp; Industry 2021 FY" contact_id="1" financial_account_type_id="3" accounting_code="2021" description="Chemistry &amp; Industry 2021 FY" />
+    <civicrm_financial_account id="261" name="IUPAC Member 4044 CY" contact_id="1" financial_account_type_id="3" accounting_code="4044" description="IUPAC Member 4044 CY" />
+    <civicrm_financial_account id="262" name="IUPAC Member 2024 FY" contact_id="1" financial_account_type_id="3" accounting_code="2024" description="IUPAC Member 2024 FY" />
+    <civicrm_financial_account id="263" name="cCT 4120" contact_id="1" financial_account_type_id="3" accounting_code="4120" description="cCT 4120" />
+    <civicrm_financial_account id="264" name="CAP Discount 4414 CY" contact_id="1" financial_account_type_id="3" accounting_code="4414" description="CAP Discount 4414 CY" />
+    <civicrm_financial_account id="265" name="CAP Discount 2438 FY" contact_id="1" financial_account_type_id="3" accounting_code="2438" description="CAP Discount 2438 FY" />
+    <civicrm_financial_account id="266" name="CSChE CSMB Discount 4214 CY" contact_id="1" financial_account_type_id="3" accounting_code="4214" description="CSChE CSMB Discount 4214 CY" />
+    <civicrm_financial_account id="267" name="CSChE CSMB Discount 2231 FY" contact_id="1" financial_account_type_id="3" accounting_code="2231" description="CSChE CSMB Discount 2231 FY" />
+    <civicrm_financial_account id="268" name="ACS Discount 4415 CY" contact_id="1" financial_account_type_id="3" accounting_code="4415" description="ACS Discount 4415 CY" />
+    <civicrm_financial_account id="269" name="ACS Discount 2434 FY" contact_id="1" financial_account_type_id="3" accounting_code="2434" description="ACS Discount 2434 FY" />
+    <civicrm_financial_account id="270" name="OACETT Discount 4109 CY" contact_id="1" financial_account_type_id="3" accounting_code="4109" description="OACETT Discount 4109 CY" />
+    <civicrm_financial_account id="271" name="OACETT Discount 2032 FY" contact_id="1" financial_account_type_id="3" accounting_code="2032" description="OACETT Discount 2032 FY" />
+    <civicrm_financial_account id="272" name="CSC Over/Short 4410 CY" contact_id="1" financial_account_type_id="3" accounting_code="4410" description="CSC Over/Short 4410 CY" />
+    <civicrm_financial_account id="273" name="CSChE Over/Short 4210 CY" contact_id="1" financial_account_type_id="3" accounting_code="4210" description="CSChE Over/Short 4210 CY" />
+    <civicrm_financial_account id="274" name="CSCT Over/Short 4110 CY" contact_id="1" financial_account_type_id="3" accounting_code="4110" description="CSCT Over/Short 4110 CY" />
+    <civicrm_financial_account id="275" name="CIC Over/Short 4035 CY" contact_id="1" financial_account_type_id="3" accounting_code="4035" description="CIC Over/Short 4035 CY" />
+    <civicrm_financial_account id="276" name="CSC Over/Short 2439 FY" contact_id="1" financial_account_type_id="3" accounting_code="2439" description="CSC Over/Short 2439 FY" />
+    <civicrm_financial_account id="277" name="CSChE Over/Short 2245 FY" contact_id="1" financial_account_type_id="3" accounting_code="2245" description="CSChE Over/Short 2245 FY" />
+    <civicrm_financial_account id="278" name="CSCT Over/Short 2039 FY" contact_id="1" financial_account_type_id="3" accounting_code="2039" description="CSCT Over/Short 2039 FY" />
+    <civicrm_financial_account id="279" name="Bright Memorial Contribution 1063 (exempt)" contact_id="1" financial_account_type_id="3" accounting_code="1063" description="Bright Memorial Contribution 1063 (exempt)" />
+    <civicrm_financial_account id="280" name="R. S. Jane Contribution 2255 (exempt)" contact_id="1" financial_account_type_id="3" accounting_code="2255" description="R. S. Jane Contribution 2255 (exempt)" />
+    <civicrm_financial_account id="281" name="Continuing Education Fund Contribution 1062 (exempt)" contact_id="1" financial_account_type_id="3" accounting_code="1062" description="Continuing Education Fund Contribution 1062 (exempt)" />
+    <civicrm_financial_account id="282" name="National Chemistry Week Contribution 4071 (exempt)" contact_id="1" financial_account_type_id="3" accounting_code="4071" description="National Chemistry Week Contribution 4071 (exempt)" />
+    <civicrm_financial_account id="283" name="ACCN - Individual 4601 CY" contact_id="1" financial_account_type_id="3" accounting_code="4601" description="ACCN - Individual 4601 CY" />
+    <civicrm_financial_account id="284" name="ACCN - Individual 2623 FY" contact_id="1" financial_account_type_id="3" accounting_code="2623" description="ACCN - Individual 2623 FY" />
+    <civicrm_financial_account id="285" name="ACCN - Can. Institute 4602 CY" contact_id="1" financial_account_type_id="3" accounting_code="4602" description="ACCN - Can. Institute 4602 CY" />
+    <civicrm_financial_account id="286" name="ACCN - Can. Institute 2624 FY" contact_id="1" financial_account_type_id="3" accounting_code="2624" description="ACCN - Can. Institute 2624 FY" />
+    <civicrm_financial_account id="287" name="ACCN - Ext. Institute 4603 CY (exempt)" contact_id="1" financial_account_type_id="3" accounting_code="4603" description="ACCN - Ext. Institute 4603 CY (exempt)" />
+    <civicrm_financial_account id="288" name="ACCN - Ext. Institute 2625 FY (exempt)" contact_id="1" financial_account_type_id="3" accounting_code="2625" description="ACCN - Ext. Institute 2625 FY (exempt)" />
+    <civicrm_financial_account id="289" name="ACCN - NAAChE Affiliate 4216 CY" contact_id="1" financial_account_type_id="3" accounting_code="4216" description="ACCN - NAAChE Affiliate 4216 CY" />
+    <civicrm_financial_account id="290" name="ACCN - NAAChE Affiliate 2250 FY" contact_id="1" financial_account_type_id="3" accounting_code="2250" description="ACCN - NAAChE Affiliate 2250 FY" />
+    <civicrm_financial_account id="291" name="Past memberships 4412" contact_id="1" financial_account_type_id="3" accounting_code="4412" description="Past memberships 4412" />
+    <civicrm_financial_account id="292" name="Past memberships 4212" contact_id="1" financial_account_type_id="3" accounting_code="4212" description="Past memberships 4212" />
+    <civicrm_financial_account id="293" name="Past memberships 4112" contact_id="1" financial_account_type_id="3" accounting_code="4112" description="Past memberships 4112" />
+    <civicrm_financial_account id="294" name="CC_PENDING" contact_id="1" financial_account_type_id="3" description="Payments pending approval" />
+    <civicrm_financial_account id="295" name="CIC/SCI Seminar Only Member 4081" contact_id="1" financial_account_type_id="3" accounting_code="4081" description="4081" />
+    <civicrm_financial_account id="296" name="CIC/SCI Seminar Only Non-member 4082" contact_id="1" financial_account_type_id="3" accounting_code="4082" description="4082" />
+    <civicrm_financial_account id="297" name="CIC/SCI Seminar Only Student Non-member 4083" contact_id="1" financial_account_type_id="3" accounting_code="4083" description="4083" />
+    <civicrm_financial_account id="298" name="CIC/SCI Seminar and Banquet Member 4088" contact_id="1" financial_account_type_id="3" accounting_code="4088" description="4088" />
+    <civicrm_financial_account id="299" name="CIC/SCI Seminar and Banquet Non-member 4089" contact_id="1" financial_account_type_id="3" accounting_code="4089" description="4089" />
+    <civicrm_financial_account id="300" name="CIC/SCI Seminar and Banquet Student Member 4090" contact_id="1" financial_account_type_id="3" accounting_code="4090" description="4090" />
+    <civicrm_financial_account id="301" name="CIC/SCI Seminar and Banquet Student Non-member 4091" contact_id="1" financial_account_type_id="3" accounting_code="4091" description="4091" />
+    <civicrm_financial_account id="302" name="CIC/SCI Banquet Only Member 4084" contact_id="1" financial_account_type_id="3" accounting_code="4084" description="4084" />
+    <civicrm_financial_account id="303" name="CIC/SCI Banquet Only Non-member 4085" contact_id="1" financial_account_type_id="3" accounting_code="4085" description="4085" />
+    <civicrm_financial_account id="304" name="CIC/SCI Banquet Only Student Member 4086" contact_id="1" financial_account_type_id="3" accounting_code="4086" description="4086" />
+    <civicrm_financial_account id="305" name="CIC/SCI Banquet Only Student Non-member 4087" contact_id="1" financial_account_type_id="3" accounting_code="4087" description="4087" />
+    <civicrm_financial_account id="306" name="CIC/SCI Sponsored Student 4092" contact_id="1" financial_account_type_id="3" accounting_code="4092" description="4092" />
+    <civicrm_financial_account id="307" name="CIC/SCI Sponsored Table 4093" contact_id="1" financial_account_type_id="3" accounting_code="4093" description="4093" />
+    <civicrm_financial_account id="308" name="CIC/SCI Sponsored Seminar 4095" contact_id="1" financial_account_type_id="3" accounting_code="4095" description="4095" />
+    <civicrm_financial_account id="309" name="Event Tax Account" contact_id="1" financial_account_type_id="2" accounting_code="2005" description="Taxes for CIC/SCI Seminar and Awards Banquet" />
+
+
+    <civicrm_contact id="5" contact_type="Organization" sort_name="CSC" display_name="CSC" legal_name="Canadian Society for Chemistry" preferred_language="en_US" preferred_mail_format="Both" communication_style_id="1" addressee_id="3" addressee_display="CSC" organization_name="CSC" />
+    <civicrm_contact id="6" contact_type="Organization" sort_name="CSChE" display_name="CSChE" legal_name="Canadian Society for Chemical Engineering" preferred_language="en_US" preferred_mail_format="Both" communication_style_id="1" addressee_id="3" addressee_display="CSChE" organization_name="CSChE" />
+    <civicrm_contact id="7" contact_type="Organization" sort_name="CSCT" display_name="CSCT" legal_name="Canadian Society for Chemical Technology" preferred_language="en_US" preferred_mail_format="Both" communication_style_id="1" addressee_id="3" addressee_display="CSCT" organization_name="CSCT" />
+    <civicrm_contact id="8" contact_type="Organization" sort_name="ACCN Subscription" display_name="ACCN Subscription" legal_name="ACCN Subscription" preferred_language="en_US" preferred_mail_format="Both" communication_style_id="1" addressee_id="3" addressee_display="ACCN Subscription" organization_name="ACCN Subscription" />
+    <civicrm_contact id="9" contact_type="Organization" sort_name="CJChE Subscription" display_name="CJChE Subscription" legal_name="CJChE Subscription" preferred_language="en_US" preferred_mail_format="Both" communication_style_id="1" addressee_id="3" addressee_display="CJChE Subscription" organization_name="CJChE Subscription" />
+    <civicrm_contact id="10" contact_type="Organization" sort_name="CanJChem Subscription" display_name="CanJChem Subscription" legal_name="CanJChem Subscription" preferred_language="en_US" preferred_mail_format="Both" communication_style_id="1" addressee_id="3" addressee_display="CanJChem Subscription" organization_name="CanJChem Subscription" />
+    <civicrm_contact id="11" contact_type="Organization" sort_name="Chemistry &amp; Industry Subscription" display_name="Chemistry &amp; Industry Subscription" legal_name="Chemistry &amp; Industry Subscription" preferred_language="en_US" preferred_mail_format="Both" communication_style_id="1" addressee_id="3" addressee_display="Chemistry &amp; Industry Subscription" organization_name="Chemistry &amp; Industry Subscription" />
+    <civicrm_contact id="12" contact_type="Organization" sort_name="IUPAC Member" display_name="IUPAC Member" legal_name="IUPAC Member" preferred_language="en_US" preferred_mail_format="Both" communication_style_id="1" addressee_id="3" addressee_display="IUPAC Member" organization_name="IUPAC Member" />
+
+
+
+    <!-- Scenario #1: Form Fields: Membership for which no price set applies (or no price set at all), form does not show option to pick a price set -->
+    <!-- Scenario #2: Form Fields: No past contributions to elect a price set, form does not show price set by default, but option is available -->
+    <!-- Scenario #3: Form Fields: Last contribution done using a price set, form shows a price set by default -->
+            <!-- Verify: Default membership -->
+
+    <!-- Scenario #4: Submit: Was CSC, Renewing CSCT + ACCN + CJChE
+                Verify: - 3 memberships (CSCT, ACCN, CJChE)
+                        - CSC membership unaffected
+    -->
+
+    <!-- Scenario #5: Submit: CSC, Renewing CSC + ACCN + CJChE
+                Verify: - CSC EndDate = Previous End Date + 1 Year.
+                        - ACCN EndDate = Right Default Date based on Membership Type
+    -->
+
+
+    <civicrm_financial_type id="191" name="CSC Full Fee 4401 CY" description="4401" is_active="1" />
+    <civicrm_financial_type id="192" name="CSChE Full Fee 4201 CY" description="4201" is_active="1" />
+    <civicrm_financial_type id="193" name="CSCT Full Fee 4101 CY" description="4101" is_active="1" />
+    <civicrm_financial_type id="197" name="CSC Half Fee AG 4402 CY" description="4402" is_active="1" />
+    <civicrm_financial_type id="198" name="CSChE Half Fee AG 4202 CY" description="4202" is_active="1" />
+    <civicrm_financial_type id="199" name="CSCT Half Fee AG 4102 CY" description="4102" is_active="1" />
+    <civicrm_financial_type id="203" name="CSC Retired 4403 CY" description="4403" is_active="1" />
+    <civicrm_financial_type id="204" name="CSChE Retired 4203 CY" description="4203" is_active="1" />
+    <civicrm_financial_type id="205" name="CSCT Retired 4103 CY" description="4103" is_active="1" />
+    <civicrm_financial_type id="209" name="CSC Undergraduate 4407 CY" description="4407" is_active="1" />
+    <civicrm_financial_type id="210" name="CSChE Undergraduate 4205 CY" description="4205" is_active="1" />
+    <civicrm_financial_type id="211" name="CSCT Undergraduate 4106 CY" description="4106" is_active="1" />
+    <civicrm_financial_type id="215" name="CSC Postdoc Fee 4405 CY" description="4405" is_active="1" />
+    <civicrm_financial_type id="216" name="CSChE Postdoc Fee 4207 CY" description="4207" is_active="1" />
+    <civicrm_financial_type id="219" name="CSC Graduate Student 4404 CY" description="4404" is_active="1" />
+    <civicrm_financial_type id="220" name="CSChE Graduate Student 4204 CY" description="4204" is_active="1" />
+    <civicrm_financial_type id="221" name="CSCT Graduate Student 4104 CY" description="4104" is_active="1" />
+    <civicrm_financial_type id="225" name="CSC HS Teacher 4413 CY" description="4413" is_active="1" />
+    <civicrm_financial_type id="226" name="CSChE HS Teacher 4213 CY" description="4213" is_active="1" />
+    <civicrm_financial_type id="227" name="CSCT HS Teacher 4113 CY" description="4113" is_active="1" />
+    <civicrm_financial_type id="231" name="CSC Lifetime 4409 CY" description="4409" is_active="1" />
+    <civicrm_financial_type id="232" name="CSChE Lifetime 4209 CY" description="4209" is_active="1" />
+    <civicrm_financial_type id="233" name="CSCT Lifetime 4114 CY" description="4114" is_active="1" />
+    <civicrm_financial_type id="237" name="Zero Dollar 7000" description="7000" is_active="1" />
+    <civicrm_financial_type id="238" name="Addtional CSC 4408 CY" description="4408" is_active="1" />
+    <civicrm_financial_type id="240" name="Additional CSChE 4208 CY" description="4208" is_active="1" />
+    <civicrm_financial_type id="242" name="Additional CSCT 4118 CY" description="4118" is_active="1" />
+    <civicrm_financial_type id="244" name="CJChE Print 4301 CY" description="4301" is_active="1" />
+    <civicrm_financial_type id="246" name="CamJChem Canada 4042 CY" description="4042" is_active="1" />
+    <civicrm_financial_type id="248" name="CamJChem Outside Can 4043 CY (exempt)" description="4043" is_active="1" />
+    <civicrm_financial_type id="250" name="Chemistry &amp; Industry 4045 CY" description="4045" is_active="1" />
+    <civicrm_financial_type id="252" name="IUPAC Member 4044 CY" description="4044" is_active="1" />
+    <civicrm_financial_type id="254" name="cCT 4120" description="4120" is_active="1" />
+    <civicrm_financial_type id="255" name="CAP Discount 4414 CY" description="4414" is_active="1" />
+    <civicrm_financial_type id="257" name="CSChE CSMB Discount 4214 CY" description="4214" is_active="1" />
+    <civicrm_financial_type id="259" name="ACS Discount 4415 CY" description="4415" is_active="1" />
+    <civicrm_financial_type id="261" name="OACETT Discount 4109 CY" description="4109" is_active="1" />
+    <civicrm_financial_type id="263" name="CSC Over/Short 4410 CY" description="4410" is_active="1" />
+    <civicrm_financial_type id="264" name="CSChE Over/Short 4210 CY" description="4210" is_active="1" />
+    <civicrm_financial_type id="265" name="CSCT Over/Short 4110 CY" description="4110" is_active="1" />
+    <civicrm_financial_type id="270" name="Bright Memorial Contribution 1063 (exempt)" description="1063" is_active="1" />
+    <civicrm_financial_type id="271" name="R. S. Jane Contribution 2255 (exempt)" description="2255" is_active="1" />
+    <civicrm_financial_type id="272" name="Continuing Education Fund Contribution 1062 (exempt)" description="1062" is_active="1" />
+    <civicrm_financial_type id="273" name="National Chemistry Week Contribution 4071 (exempt)" description="4071" is_active="1" />
+    <civicrm_financial_type id="274" name="Taxes 2005 (exempt)" description="2005" is_active="1" />
+
+
+
+    <civicrm_membership_type id="150" domain_id="1" member_of_contact_id="2" financial_type_id="2" minimum_fee="20.00" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Public" weight="160" is_active="1" name="Funky Membership" description="Funky Membership" />
+
+    <civicrm_membership_type id="160" domain_id="1" member_of_contact_id="5" financial_type_id="238" minimum_fee="20.00" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Public" weight="160" is_active="1" name="CSC Additional Member" description="CSC Additional Member" />
+    <civicrm_membership_type id="161" domain_id="1" member_of_contact_id="6" financial_type_id="240" minimum_fee="20.00" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Public" weight="170" is_active="1" name="CSChE Additional Member" description="CSChE Additional Member" />
+    <civicrm_membership_type id="162" domain_id="1" member_of_contact_id="7" financial_type_id="242" minimum_fee="20.00" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Public" weight="180" is_active="1" name="CSCT Additional Member" description="CSCT Additional Member" />
+    <civicrm_membership_type id="163" domain_id="1" member_of_contact_id="8" financial_type_id="237" minimum_fee="0.00" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Public" weight="200" is_active="1" name="ACCN Print and Online" description="ACCN Print and Online" />
+    <civicrm_membership_type id="164" domain_id="1" member_of_contact_id="8" financial_type_id="237" minimum_fee="0.00" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Public" weight="210" is_active="1" name="ACCN Online" description="ACCN Online" />
+    <civicrm_membership_type id="165" domain_id="1" member_of_contact_id="8" financial_type_id="237" minimum_fee="0.00" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Admin" weight="220" is_active="1" name="ACCN Print" description="ACCN Print" />
+    <civicrm_membership_type id="166" domain_id="1" member_of_contact_id="9" financial_type_id="244" minimum_fee="135.00" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Public" weight="250" is_active="1" name="CJChE Subscription (print)" description="CJChE Subscription (print)" />
+    <civicrm_membership_type id="167" domain_id="1" member_of_contact_id="9" financial_type_id="244" minimum_fee="90.00" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Public" weight="260" is_active="1" name="CJChE Subscription (online)" description="CJChE Subscription (online)" />
+    <civicrm_membership_type id="168" domain_id="1" member_of_contact_id="9" financial_type_id="244" minimum_fee="160.00" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Public" weight="270" is_active="1" name="CJChE Subscription (both)" description="CJChE Subscription (both)" />
+    <civicrm_membership_type id="169" domain_id="1" member_of_contact_id="10" financial_type_id="246" minimum_fee="235.00" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Public" weight="290" is_active="1" name="CanJChem Subscription" description="CanJChem Subscription" />
+    <civicrm_membership_type id="170" domain_id="1" member_of_contact_id="11" financial_type_id="250" minimum_fee="210.00" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Public" weight="320" is_active="1" name="Chemistry &amp; Industry Subscription" description="Chemistry &amp; Industry Subscription" />
+    <civicrm_membership_type id="171" domain_id="1" member_of_contact_id="12" financial_type_id="252" minimum_fee="50.00" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Public" weight="340" is_active="1" name="IUPAC Member" description="IUPAC Member" />
+    <civicrm_membership_type id="172" domain_id="1" member_of_contact_id="7" financial_type_id="193" minimum_fee="157.00" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Public" weight="10" is_active="1" name="CSCT Full Fee" description="CSCT Full Fee" />
+    <civicrm_membership_type id="173" domain_id="1" member_of_contact_id="7" financial_type_id="199" minimum_fee="78.50" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Public" weight="20" is_active="1" name="CSCT Half Fee AG" description="CSCT Half Fee AG" />
+    <civicrm_membership_type id="174" domain_id="1" member_of_contact_id="7" financial_type_id="199" minimum_fee="78.50" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Admin" weight="30" is_active="1" name="CSCT Half Fee July 1" description="CSCT Half Fee July 1" />
+    <civicrm_membership_type id="175" domain_id="1" member_of_contact_id="7" financial_type_id="199" minimum_fee="78.50" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Public" weight="40" is_active="1" name="CSCT Half Fee Spousal" description="CSCT Half Fee Spousal" />
+    <civicrm_membership_type id="176" domain_id="1" member_of_contact_id="7" financial_type_id="205" minimum_fee="78.50" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Public" weight="50" is_active="1" name="CSCT Retired" description="CSCT Retired" />
+    <civicrm_membership_type id="177" domain_id="1" member_of_contact_id="7" financial_type_id="211" minimum_fee="30.00" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Public" weight="60" is_active="1" name="CSCT Undergraduate" description="CSCT Undergraduate" />
+    <civicrm_membership_type id="178" domain_id="1" member_of_contact_id="7" financial_type_id="221" minimum_fee="50.00" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Public" weight="80" is_active="1" name="CSCT Graduate Student" description="CSCT Graduate Student" />
+    <civicrm_membership_type id="179" domain_id="1" member_of_contact_id="7" financial_type_id="227" minimum_fee="50.00" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Public" weight="90" is_active="1" name="CSCT HS Teacher" description="CSCT HS Teacher" />
+    <civicrm_membership_type id="180" domain_id="1" member_of_contact_id="7" financial_type_id="233" minimum_fee="2975.00" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Public" weight="100" is_active="1" name="CSCT Lifetime" description="CSCT Lifetime" />
+    <civicrm_membership_type id="181" domain_id="1" member_of_contact_id="7" financial_type_id="237" minimum_fee="0.00" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Admin" weight="110" is_active="1" name="CSCT Honorary" description="CSCT Honorary" />
+    <civicrm_membership_type id="182" domain_id="1" member_of_contact_id="7" financial_type_id="237" minimum_fee="0.00" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Admin" weight="120" is_active="1" name="CSCT Free" description="CSCT Free" />
+    <civicrm_membership_type id="183" domain_id="1" member_of_contact_id="7" financial_type_id="237" minimum_fee="0.00" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Admin" weight="130" is_active="1" name="CSCT Unemployed" description="CSCT Unemployed" />
+    <civicrm_membership_type id="184" domain_id="1" member_of_contact_id="7" financial_type_id="237" minimum_fee="0.00" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Admin" weight="140" is_active="1" name="CSCT 50 Yr Member" description="CSCT 50 Yr Member" />
+    <civicrm_membership_type id="185" domain_id="1" member_of_contact_id="6" financial_type_id="192" minimum_fee="157.00" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Public" weight="10" is_active="1" name="CSChE Full Fee" description="CSChE Full Fee" />
+    <civicrm_membership_type id="186" domain_id="1" member_of_contact_id="6" financial_type_id="198" minimum_fee="78.50" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Public" weight="20" is_active="1" name="CSChE Half Fee AG" description="CSChE Half Fee AG" />
+    <civicrm_membership_type id="187" domain_id="1" member_of_contact_id="6" financial_type_id="198" minimum_fee="78.50" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Admin" weight="30" is_active="1" name="CSChE Half Fee July 1" description="CSChE Half Fee July 1" />
+    <civicrm_membership_type id="188" domain_id="1" member_of_contact_id="6" financial_type_id="198" minimum_fee="78.50" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Public" weight="40" is_active="1" name="CSChE Half Fee Spousal" description="CSChE Half Fee Spousal" />
+    <civicrm_membership_type id="189" domain_id="1" member_of_contact_id="6" financial_type_id="204" minimum_fee="78.50" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Public" weight="50" is_active="1" name="CSChE Retired" description="CSChE Retired" />
+    <civicrm_membership_type id="190" domain_id="1" member_of_contact_id="6" financial_type_id="210" minimum_fee="30.00" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Public" weight="60" is_active="1" name="CSChE Undergraduate" description="CSChE Undergraduate" />
+    <civicrm_membership_type id="191" domain_id="1" member_of_contact_id="6" financial_type_id="216" minimum_fee="78.50" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Public" weight="70" is_active="1" name="CSChE Postdoc Fee" description="CSChE Postdoc Fee" />
+    <civicrm_membership_type id="192" domain_id="1" member_of_contact_id="6" financial_type_id="220" minimum_fee="50.00" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Public" weight="80" is_active="1" name="CSChE Graduate Student" description="CSChE Graduate Student" />
+    <civicrm_membership_type id="193" domain_id="1" member_of_contact_id="6" financial_type_id="226" minimum_fee="50.00" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Public" weight="90" is_active="1" name="CSChE HS Teacher" description="CSChE HS Teacher" />
+    <civicrm_membership_type id="194" domain_id="1" member_of_contact_id="6" financial_type_id="232" minimum_fee="2975.00" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Public" weight="100" is_active="1" name="CSChE Lifetime" description="CSChE Lifetime" />
+    <civicrm_membership_type id="195" domain_id="1" member_of_contact_id="6" financial_type_id="237" minimum_fee="0.00" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Admin" weight="110" is_active="1" name="CSChE Honorary" description="CSChE Honorary" />
+    <civicrm_membership_type id="196" domain_id="1" member_of_contact_id="6" financial_type_id="237" minimum_fee="0.00" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Admin" weight="120" is_active="1" name="CSChE Free" description="CSChE Free" />
+    <civicrm_membership_type id="197" domain_id="1" member_of_contact_id="6" financial_type_id="237" minimum_fee="0.00" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Admin" weight="130" is_active="1" name="CSChE Unemployed" description="CSChE Unemployed" />
+    <civicrm_membership_type id="198" domain_id="1" member_of_contact_id="6" financial_type_id="237" minimum_fee="0.00" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Admin" weight="140" is_active="1" name="CSChE 50 Yr Member" description="CSChE 50 Yr Member" />
+    <civicrm_membership_type id="199" domain_id="1" member_of_contact_id="5" financial_type_id="191" minimum_fee="157.00" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Public" weight="10" is_active="1" name="CSC Full Fee" description="CSC Full Fee" />
+    <civicrm_membership_type id="200" domain_id="1" member_of_contact_id="5" financial_type_id="197" minimum_fee="78.50" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Public" weight="20" is_active="1" name="CSC Half Fee AG" description="CSC Half Fee AG" />
+    <civicrm_membership_type id="201" domain_id="1" member_of_contact_id="5" financial_type_id="197" minimum_fee="78.50" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Admin" weight="30" is_active="1" name="CSC Half Fee July 1" description="CSC Half Fee July 1" />
+    <civicrm_membership_type id="202" domain_id="1" member_of_contact_id="5" financial_type_id="197" minimum_fee="78.50" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Public" weight="40" is_active="1" name="CSC Half Fee Spousal" description="CSC Half Fee Spousal" />
+    <civicrm_membership_type id="203" domain_id="1" member_of_contact_id="5" financial_type_id="203" minimum_fee="78.50" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Public" weight="50" is_active="1" name="CSC Retired" description="CSC Retired" />
+    <civicrm_membership_type id="204" domain_id="1" member_of_contact_id="5" financial_type_id="209" minimum_fee="30.00" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Public" weight="60" is_active="1" name="CSC Undergraduate" description="CSC Undergraduate" />
+    <civicrm_membership_type id="205" domain_id="1" member_of_contact_id="5" financial_type_id="215" minimum_fee="78.50" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Public" weight="70" is_active="1" name="CSC Postdoc Fee" description="CSC Postdoc Fee" />
+    <civicrm_membership_type id="206" domain_id="1" member_of_contact_id="5" financial_type_id="219" minimum_fee="50.00" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Public" weight="80" is_active="1" name="CSC Graduate Student" description="CSC Graduate Student" />
+    <civicrm_membership_type id="207" domain_id="1" member_of_contact_id="5" financial_type_id="225" minimum_fee="50.00" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Public" weight="90" is_active="1" name="CSC HS Teacher" description="CSC HS Teacher" />
+    <civicrm_membership_type id="208" domain_id="1" member_of_contact_id="5" financial_type_id="231" minimum_fee="2975.00" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Public" weight="100" is_active="1" name="CSC Lifetime" description="CSC Lifetime" />
+    <civicrm_membership_type id="209" domain_id="1" member_of_contact_id="5" financial_type_id="237" minimum_fee="0.00" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Admin" weight="110" is_active="1" name="CSC Honorary" description="CSC Honorary" />
+    <civicrm_membership_type id="210" domain_id="1" member_of_contact_id="5" financial_type_id="237" minimum_fee="0.00" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Admin" weight="120" is_active="1" name="CSC Free" description="CSC Free" />
+    <civicrm_membership_type id="211" domain_id="1" member_of_contact_id="5" financial_type_id="237" minimum_fee="0.00" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Admin" weight="130" is_active="1" name="CSC Unemployed" description="CSC Unemployed" />
+    <civicrm_membership_type id="212" domain_id="1" member_of_contact_id="5" financial_type_id="237" minimum_fee="0.00" duration_unit="year" duration_interval="1" period_type="fixed" fixed_period_start_day="101" fixed_period_rollover_day="1231" visibility="Admin" weight="140" is_active="1" name="CSC 50 Yr Member" description="CSC 50 Yr Member" />
+
+
+
+
+    <civicrm_price_set id="32" name="CSC" is_active="1" extends="3" financial_type_id="2" title="CSC" />
+    <civicrm_price_set id="33" name="CSCT" is_active="1" extends="3" financial_type_id="2" title="CSCT" />
+    <civicrm_price_set id="34" name="CSChE" is_active="1" extends="3" financial_type_id="2" title="CSChE" />
+
+
+
+
+    <civicrm_price_field id="364" price_set_id="32" name="Membership Type" html_type="Radio" weight="1" is_display_amounts="1" options_per_line="1" is_active="1" is_required="1" visibility_id="1" label="Membership Type" />
+    <civicrm_price_field id="365" price_set_id="32" name="Additional Societies" html_type="CheckBox" weight="15" is_display_amounts="1" options_per_line="1" is_active="1" visibility_id="1" label="Additional Societies" />
+    <civicrm_price_field id="366" price_set_id="32" name="ACCN - Member" html_type="Radio" weight="17" is_display_amounts="1" options_per_line="1" is_active="1" is_required="1" visibility_id="1" label="ACCN - Member" />
+    <civicrm_price_field id="367" price_set_id="32" name="Journal (CJChE Subscription)" html_type="Radio" weight="20" is_display_amounts="1" options_per_line="1" is_active="1" visibility_id="1" label="Journal (CJChE Subscription)" />
+    <civicrm_price_field id="368" price_set_id="32" name="CanJChem" html_type="Radio" weight="23" is_display_amounts="1" options_per_line="1" is_active="1" visibility_id="1" label="CanJChem" />
+    <civicrm_price_field id="369" price_set_id="32" name="Chemistry &amp; Industry" html_type="CheckBox" weight="25" is_display_amounts="1" options_per_line="1" is_active="1" visibility_id="1" label="Chemistry &amp; Industry" />
+    <civicrm_price_field id="370" price_set_id="32" name="IUPAC Member" html_type="CheckBox" weight="26" is_display_amounts="1" options_per_line="1" is_active="1" visibility_id="1" label="IUPAC Member" />
+    <civicrm_price_field id="371" price_set_id="32" name="CSC Discounts" html_type="Radio" weight="27" is_display_amounts="1" options_per_line="1" is_active="1" visibility_id="1" label="CSC Discounts" />
+    <civicrm_price_field id="372" price_set_id="32" name="Other Discounts" html_type="Text" is_enter_qty="1" weight="30" options_per_line="1" is_active="1" visibility_id="1" label="Other Discounts" />
+    <civicrm_price_field id="373" price_set_id="32" name="Over/Short" html_type="Text" is_enter_qty="1" weight="31" options_per_line="1" is_active="1" visibility_id="1" label="Over/Short" />
+    <civicrm_price_field id="374" price_set_id="32" name="Exchange" html_type="Text" is_enter_qty="1" weight="32" options_per_line="1" is_active="1" visibility_id="1" label="Exchange" />
+    <civicrm_price_field id="375" price_set_id="32" name="Bright Memorial Contribution" html_type="Text" is_enter_qty="1" weight="33" options_per_line="1" is_active="1" visibility_id="1" label="Bright Memorial Contribution" />
+    <civicrm_price_field id="376" price_set_id="32" name="R. S. Jane Contribution" html_type="Text" is_enter_qty="1" weight="34" options_per_line="1" is_active="1" visibility_id="1" label="R. S. Jane Contribution" />
+    <civicrm_price_field id="377" price_set_id="32" name="Continuing Education Fund Contribution" html_type="Text" is_enter_qty="1" weight="35" options_per_line="1" is_active="1" visibility_id="1" label="Continuing Education Fund Contribution" />
+    <civicrm_price_field id="378" price_set_id="32" name="National Chemistry Week Contribution" html_type="Text" is_enter_qty="1" weight="36" options_per_line="1" is_active="1" visibility_id="1" label="National Chemistry Week Contribution" />
+    <civicrm_price_field id="379" price_set_id="32" name="Taxes" html_type="Text" is_enter_qty="1" weight="37" options_per_line="1" is_active="1" visibility_id="1" label="Taxes" />
+    <civicrm_price_field id="380" price_set_id="33" name="Membership Type" html_type="Radio" weight="1" is_display_amounts="1" options_per_line="1" is_active="1" is_required="1" visibility_id="1" label="Membership Type" />
+    <civicrm_price_field id="381" price_set_id="33" name="Additional Societies" html_type="CheckBox" weight="14" is_display_amounts="1" options_per_line="1" is_active="1" visibility_id="1" label="Additional Societies" />
+    <civicrm_price_field id="382" price_set_id="33" name="ACCN - Member" html_type="Radio" weight="16" is_display_amounts="1" options_per_line="1" is_active="1" is_required="1" visibility_id="1" label="ACCN - Member" />
+    <civicrm_price_field id="383" price_set_id="33" name="Journal (CJChE Subscription)" html_type="Radio" weight="19" is_display_amounts="1" options_per_line="1" is_active="1" visibility_id="1" label="Journal (CJChE Subscription)" />
+    <civicrm_price_field id="384" price_set_id="33" name="CanJChem" html_type="Radio" weight="22" is_display_amounts="1" options_per_line="1" is_active="1" visibility_id="1" label="CanJChem" />
+    <civicrm_price_field id="385" price_set_id="33" name="Chemistry &amp; Industry" html_type="CheckBox" weight="24" is_display_amounts="1" options_per_line="1" is_active="1" visibility_id="1" label="Chemistry &amp; Industry" />
+    <civicrm_price_field id="386" price_set_id="33" name="cCT" html_type="CheckBox" weight="25" is_display_amounts="1" options_per_line="1" is_active="1" visibility_id="1" label="cCT" />
+    <civicrm_price_field id="387" price_set_id="33" name="CSCT Discounts" html_type="Radio" weight="26" is_display_amounts="1" options_per_line="1" is_active="1" visibility_id="1" label="CSCT Discounts" />
+    <civicrm_price_field id="388" price_set_id="33" name="Other Discounts" html_type="Text" is_enter_qty="1" weight="28" options_per_line="1" is_active="1" visibility_id="1" label="Other Discounts" />
+    <civicrm_price_field id="389" price_set_id="33" name="Over/Short" html_type="Text" is_enter_qty="1" weight="29" options_per_line="1" is_active="1" visibility_id="1" label="Over/Short" />
+    <civicrm_price_field id="390" price_set_id="33" name="Exchange" html_type="Text" is_enter_qty="1" weight="30" options_per_line="1" is_active="1" visibility_id="1" label="Exchange" />
+    <civicrm_price_field id="391" price_set_id="33" name="Bright Memorial Contribution" html_type="Text" is_enter_qty="1" weight="31" options_per_line="1" is_active="1" visibility_id="1" label="Bright Memorial Contribution" />
+    <civicrm_price_field id="392" price_set_id="33" name="R. S. Jane Contribution" html_type="Text" is_enter_qty="1" weight="32" options_per_line="1" is_active="1" visibility_id="1" label="R. S. Jane Contribution" />
+    <civicrm_price_field id="393" price_set_id="33" name="Continuing Education Fund Contribution" html_type="Text" is_enter_qty="1" weight="33" options_per_line="1" is_active="1" visibility_id="1" label="Continuing Education Fund Contribution" />
+    <civicrm_price_field id="394" price_set_id="33" name="National Chemistry Week Contribution" html_type="Text" is_enter_qty="1" weight="34" options_per_line="1" is_active="1" visibility_id="1" label="National Chemistry Week Contribution" />
+    <civicrm_price_field id="395" price_set_id="33" name="Taxes" html_type="Text" is_enter_qty="1" weight="35" options_per_line="1" is_active="1" visibility_id="1" label="Taxes" />
+    <civicrm_price_field id="396" price_set_id="34" name="Membership Type" html_type="Radio" weight="1" is_display_amounts="1" options_per_line="1" is_active="1" is_required="1" visibility_id="1" label="Membership Type" />
+    <civicrm_price_field id="397" price_set_id="34" name="Additional Societies" html_type="CheckBox" weight="15" is_display_amounts="1" options_per_line="1" is_active="1" visibility_id="1" label="Additional Societies" />
+    <civicrm_price_field id="398" price_set_id="34" name="ACCN - Member" html_type="Radio" weight="17" is_display_amounts="1" options_per_line="1" is_active="1" is_required="1" visibility_id="1" label="ACCN - Member" />
+    <civicrm_price_field id="399" price_set_id="34" name="Journal (CJChE Subscription)" html_type="Radio" weight="20" is_display_amounts="1" options_per_line="1" is_active="1" visibility_id="1" label="Journal (CJChE Subscription)" />
+    <civicrm_price_field id="400" price_set_id="34" name="CanJChem" html_type="Radio" weight="23" is_display_amounts="1" options_per_line="1" is_active="1" visibility_id="1" label="CanJChem" />
+    <civicrm_price_field id="401" price_set_id="34" name="Chemistry &amp; Industry" html_type="CheckBox" weight="25" is_display_amounts="1" options_per_line="1" is_active="1" visibility_id="1" label="Chemistry &amp; Industry" />
+    <civicrm_price_field id="402" price_set_id="34" name="CSChE Discounts" html_type="Radio" weight="26" is_display_amounts="1" options_per_line="1" is_active="1" visibility_id="1" label="CSChE Discounts" />
+    <civicrm_price_field id="403" price_set_id="34" name="Other Discounts" html_type="Text" is_enter_qty="1" weight="27" options_per_line="1" is_active="1" visibility_id="1" label="Other Discounts" />
+    <civicrm_price_field id="404" price_set_id="34" name="Over/Short" html_type="Text" is_enter_qty="1" weight="28" options_per_line="1" is_active="1" visibility_id="1" label="Over/Short" />
+    <civicrm_price_field id="405" price_set_id="34" name="Exchange" html_type="Text" is_enter_qty="1" weight="29" options_per_line="1" is_active="1" visibility_id="1" label="Exchange" />
+    <civicrm_price_field id="406" price_set_id="34" name="Bright Memorial Contribution" html_type="Text" is_enter_qty="1" weight="30" options_per_line="1" is_active="1" visibility_id="1" label="Bright Memorial Contribution" />
+    <civicrm_price_field id="407" price_set_id="34" name="R. S. Jane Contribution" html_type="Text" is_enter_qty="1" weight="31" options_per_line="1" is_active="1" visibility_id="1" label="R. S. Jane Contribution" />
+    <civicrm_price_field id="408" price_set_id="34" name="Continuing Education Fund Contribution" html_type="Text" is_enter_qty="1" weight="32" options_per_line="1" is_active="1" visibility_id="1" label="Continuing Education Fund Contribution" />
+    <civicrm_price_field id="409" price_set_id="34" name="National Chemistry Week Contribution" html_type="Text" is_enter_qty="1" weight="33" options_per_line="1" is_active="1" visibility_id="1" label="National Chemistry Week Contribution" />
+    <civicrm_price_field id="410" price_set_id="34" name="Taxes" html_type="Text" is_enter_qty="1" weight="34" options_per_line="1" is_active="1" visibility_id="1" label="Taxes" />
+    <civicrm_price_field id="546" price_set_id="32" name="tax_adjustment" html_type="Text" is_enter_qty="1" weight="38" options_per_line="1" is_active="1" visibility_id="1" label="Tax Adjustment" />
+
+
+
+
+
+    <civicrm_price_field_value id="767" price_field_id="364" name="CSC_Full_Fee_taxable_" amount="157.00" weight="1" membership_type_id="199" membership_num_terms="1" is_active="1" financial_type_id="191" label="CSC Full Fee (taxable)" description="CSC Full Fee (taxable)" />
+    <civicrm_price_field_value id="768" price_field_id="364" name="CSC_Half_Fee_AG_taxable_" amount="78.50" weight="2" membership_type_id="200" membership_num_terms="1" is_active="1" financial_type_id="197" label="CSC Half Fee AG (taxable)" description="CSC Half Fee AG (taxable)" />
+    <civicrm_price_field_value id="769" price_field_id="364" name="CSC_Half_Fee_July_1_taxable_" amount="78.50" weight="3" membership_type_id="201" membership_num_terms="1" is_active="1" financial_type_id="197" label="CSC Half Fee July 1 (taxable)" description="CSC Half Fee July 1 (taxable)" />
+    <civicrm_price_field_value id="770" price_field_id="364" name="CSC_Half_Fee_Spousal_taxable_" amount="78.50" weight="4" membership_type_id="202" membership_num_terms="1" is_active="1" financial_type_id="197" label="CSC Half Fee Spousal (taxable)" description="CSC Half Fee Spousal (taxable)" />
+    <civicrm_price_field_value id="771" price_field_id="364" name="CSC_Retired_taxable_" amount="78.50" weight="5" membership_type_id="203" membership_num_terms="1" is_active="1" financial_type_id="203" label="CSC Retired (taxable)" description="CSC Retired (taxable)" />
+    <civicrm_price_field_value id="772" price_field_id="364" name="CSC_Undergraduate_taxable_" amount="30.00" weight="6" membership_type_id="204" membership_num_terms="1" is_active="1" financial_type_id="209" label="CSC Undergraduate (taxable)" description="CSC Undergraduate (taxable)" />
+    <civicrm_price_field_value id="773" price_field_id="364" name="CSC_Postdoc_Fee_taxable_" amount="78.50" weight="7" membership_type_id="205" membership_num_terms="1" is_active="1" financial_type_id="215" label="CSC Postdoc Fee (taxable)" description="CSC Postdoc Fee (taxable)" />
+    <civicrm_price_field_value id="774" price_field_id="364" name="CSC_Graduate_Student_taxable_" amount="50.00" weight="8" membership_type_id="206" membership_num_terms="1" is_active="1" financial_type_id="219" label="CSC Graduate Student (taxable)" description="CSC Graduate Student (taxable)" />
+    <civicrm_price_field_value id="775" price_field_id="364" name="CSC_HS_Teacher_taxable_" amount="50.00" weight="9" membership_type_id="207" membership_num_terms="1" is_active="1" financial_type_id="225" label="CSC HS Teacher (taxable)" description="CSC HS Teacher (taxable)" />
+    <civicrm_price_field_value id="776" price_field_id="364" name="CSC_Lifetime_taxable_" amount="2975.00" weight="10" membership_type_id="208" membership_num_terms="1" is_active="1" financial_type_id="231" label="CSC Lifetime (taxable)" description="CSC Lifetime (taxable)" />
+    <civicrm_price_field_value id="777" price_field_id="364" name="CSC_Honorary" amount="0.00" weight="11" membership_type_id="209" membership_num_terms="1" is_active="1" financial_type_id="237" label="CSC Honorary" description="CSC Honorary" />
+    <civicrm_price_field_value id="778" price_field_id="364" name="CSC_Free" amount="0.00" weight="12" membership_type_id="210" membership_num_terms="1" is_active="1" financial_type_id="237" label="CSC Free" description="CSC Free" />
+    <civicrm_price_field_value id="779" price_field_id="364" name="CSC_Unemployed" amount="0.00" weight="13" membership_type_id="211" membership_num_terms="1" is_active="1" financial_type_id="237" label="CSC Unemployed" description="CSC Unemployed" />
+    <civicrm_price_field_value id="780" price_field_id="364" name="CSC_50_Yr_Member" amount="0.00" weight="14" membership_type_id="212" membership_num_terms="1" is_active="1" financial_type_id="237" label="CSC 50 Yr Member" description="CSC 50 Yr Member" />
+    <civicrm_price_field_value id="781" price_field_id="365" name="Canadian_Society_for_Chemical_Engineering_CSChE_taxable_" amount="20.00" weight="1" membership_type_id="161" membership_num_terms="1" is_active="1" financial_type_id="240" label="Canadian Society for Chemical Engineering (CSChE) (taxable)" description="Canadian Society for Chemical Engineering (CSChE) (taxable)" />
+    <civicrm_price_field_value id="782" price_field_id="365" name="Canadian_Society_for_Chemical_Technology_CSCT_taxable_" amount="20.00" weight="2" membership_type_id="162" membership_num_terms="1" is_active="1" financial_type_id="242" label="Canadian Society for Chemical Technology (CSCT) (taxable)" description="Canadian Society for Chemical Technology (CSCT) (taxable)" />
+    <civicrm_price_field_value id="783" price_field_id="366" name="Print_and_Online" amount="0.00" weight="1" membership_type_id="163" membership_num_terms="1" is_active="1" financial_type_id="237" label="Print and Online" description="Print and Online" />
+    <civicrm_price_field_value id="784" price_field_id="366" name="Online_Only" amount="0.00" weight="2" membership_type_id="164" membership_num_terms="1" is_active="1" financial_type_id="237" label="Online Only" description="Online Only" />
+    <civicrm_price_field_value id="785" price_field_id="366" name="Print_Only" amount="0.00" weight="3" membership_type_id="165" membership_num_terms="1" is_active="1" financial_type_id="237" label="Print Only" description="Print Only" />
+    <civicrm_price_field_value id="786" price_field_id="367" name="Print_taxable_" amount="135.00" weight="1" membership_type_id="166" membership_num_terms="1" is_active="1" financial_type_id="244" label="Print (taxable)" description="Print (taxable)" />
+    <civicrm_price_field_value id="787" price_field_id="367" name="Member_Online_taxable_" amount="90.00" weight="2" membership_type_id="167" membership_num_terms="1" is_active="1" financial_type_id="244" label="Member Online (taxable)" description="Member Online (taxable)" />
+    <civicrm_price_field_value id="788" price_field_id="367" name="Member_Both_taxable_" amount="160.00" weight="3" membership_type_id="168" membership_num_terms="1" is_active="1" financial_type_id="244" label="Member Both (taxable)" description="Member Both (taxable)" />
+    <civicrm_price_field_value id="789" price_field_id="368" name="Canada_taxable_" amount="235.00" weight="1" membership_type_id="169" membership_num_terms="1" is_active="1" financial_type_id="246" label="Canada (taxable)" description="Canada (taxable)" />
+    <civicrm_price_field_value id="790" price_field_id="368" name="Outside_Canada" amount="310.00" weight="2" membership_type_id="169" membership_num_terms="1" is_active="1" financial_type_id="248" label="Outside Canada" description="Outside Canada" />
+    <civicrm_price_field_value id="791" price_field_id="369" name="Chemistry_Industry_taxable_" amount="210.00" weight="1" membership_type_id="170" membership_num_terms="1" is_active="1" financial_type_id="250" label="Chemistry &amp; Industry (taxable)" description="Chemistry &amp; Industry (taxable)" />
+    <civicrm_price_field_value id="792" price_field_id="370" name="IUPAC_Member_taxable_" amount="50.00" weight="1" membership_type_id="171" membership_num_terms="1" is_active="1" financial_type_id="252" label="IUPAC Member (taxable)" description="IUPAC Member (taxable)" />
+    <civicrm_price_field_value id="793" price_field_id="371" name="CAP_Discount_taxable_" amount="-43.50" weight="1" is_active="1" financial_type_id="255" label="CAP Discount (taxable)" description="CAP Discount (taxable)" />
+    <civicrm_price_field_value id="794" price_field_id="371" name="CSMB_Discount_taxable_" amount="-43.50" weight="2" is_active="1" financial_type_id="255" label="CSMB Discount (taxable)" description="CSMB Discount (taxable)" />
+    <civicrm_price_field_value id="795" price_field_id="371" name="ACS_Discount_taxable_" amount="-29.00" weight="3" is_active="1" financial_type_id="259" label="ACS Discount (taxable)" description="ACS Discount (taxable)" />
+    <civicrm_price_field_value id="796" price_field_id="372" name="Other_Discount_taxable_" amount="1" weight="1" is_active="1" financial_type_id="255" label="Other Discount (taxable)" description="Other Discount (taxable)" />
+    <civicrm_price_field_value id="797" price_field_id="373" name="Over_Short_taxable_" amount="1" weight="1" is_active="1" financial_type_id="263" label="Over/Short (taxable)" description="Over/Short (taxable)" />
+    <civicrm_price_field_value id="798" price_field_id="374" name="Exchange_taxable_" amount="1" weight="1" is_active="1" financial_type_id="263" label="Exchange (taxable)" description="Exchange (taxable)" />
+    <civicrm_price_field_value id="799" price_field_id="375" name="Bright_Memorial_Contribution" amount="1" weight="1" is_active="1" financial_type_id="270" label="Bright Memorial Contribution" description="Bright Memorial Contribution" />
+    <civicrm_price_field_value id="800" price_field_id="376" name="R_S_Jane_Contribution" amount="1" weight="1" is_active="1" financial_type_id="271" label="R. S. Jane Contribution" description="R. S. Jane Contribution" />
+    <civicrm_price_field_value id="801" price_field_id="377" name="Continuing_Education_Fund_Contribution" amount="1" weight="1" is_active="1" financial_type_id="272" label="Continuing Education Fund Contribution" description="Continuing Education Fund Contribution" />
+    <civicrm_price_field_value id="802" price_field_id="378" name="National_Chemistry_Week_Contribution" amount="1" weight="1" is_active="1" financial_type_id="273" label="National Chemistry Week Contribution" description="National Chemistry Week Contribution" />
+    <civicrm_price_field_value id="803" price_field_id="379" name="hidden_taxes" amount="1" weight="1" is_active="1" financial_type_id="274" label="hidden_taxes" description="hidden_taxes" />
+    <civicrm_price_field_value id="1238" price_field_id="546" name="Tax_Adjustment" amount="1.00" weight="38" is_active="1" financial_type_id="274" label="Tax Adjustment" />
+    <civicrm_price_field_value id="804" price_field_id="380" name="CSCT_Full_Fee_taxable_" amount="157.00" weight="1" membership_type_id="172" membership_num_terms="1" is_active="1" financial_type_id="193" label="CSCT Full Fee (taxable)" description="CSCT Full Fee (taxable)" />
+    <civicrm_price_field_value id="805" price_field_id="380" name="CSCT_Half_Fee_AG_taxable_" amount="78.50" weight="2" membership_type_id="173" membership_num_terms="1" is_active="1" financial_type_id="199" label="CSCT Half Fee AG (taxable)" description="CSCT Half Fee AG (taxable)" />
+    <civicrm_price_field_value id="806" price_field_id="380" name="CSCT_Half_Fee_July_1_taxable_" amount="78.50" weight="3" membership_type_id="174" membership_num_terms="1" is_active="1" financial_type_id="199" label="CSCT Half Fee July 1 (taxable)" description="CSCT Half Fee July 1 (taxable)" />
+    <civicrm_price_field_value id="807" price_field_id="380" name="CSCT_Half_Fee_Spousal_taxable_" amount="78.50" weight="4" membership_type_id="175" membership_num_terms="1" is_active="1" financial_type_id="199" label="CSCT Half Fee Spousal (taxable)" description="CSCT Half Fee Spousal (taxable)" />
+    <civicrm_price_field_value id="808" price_field_id="380" name="CSCT_Retired_taxable_" amount="78.50" weight="5" membership_type_id="176" membership_num_terms="1" is_active="1" financial_type_id="205" label="CSCT Retired (taxable)" description="CSCT Retired (taxable)" />
+    <civicrm_price_field_value id="809" price_field_id="380" name="CSCT_Undergraduate_taxable_" amount="30.00" weight="6" membership_type_id="177" membership_num_terms="1" is_active="1" financial_type_id="211" label="CSCT Undergraduate (taxable)" description="CSCT Undergraduate (taxable)" />
+    <civicrm_price_field_value id="810" price_field_id="380" name="CSCT_Graduate_Student_taxable_" amount="50.00" weight="7" membership_type_id="178" membership_num_terms="1" is_active="1" financial_type_id="221" label="CSCT Graduate Student (taxable)" description="CSCT Graduate Student (taxable)" />
+    <civicrm_price_field_value id="811" price_field_id="380" name="CSCT_HS_Teacher_taxable_" amount="50.00" weight="8" membership_type_id="179" membership_num_terms="1" is_active="1" financial_type_id="227" label="CSCT HS Teacher (taxable)" description="CSCT HS Teacher (taxable)" />
+    <civicrm_price_field_value id="812" price_field_id="380" name="CSCT_Lifetime_taxable_" amount="2975.00" weight="9" membership_type_id="180" membership_num_terms="1" is_active="1" financial_type_id="233" label="CSCT Lifetime (taxable)" description="CSCT Lifetime (taxable)" />
+    <civicrm_price_field_value id="813" price_field_id="380" name="CSCT_Honorary" amount="0.00" weight="10" membership_type_id="181" membership_num_terms="1" is_active="1" financial_type_id="237" label="CSCT Honorary" description="CSCT Honorary" />
+    <civicrm_price_field_value id="814" price_field_id="380" name="CSCT_Free" amount="0.00" weight="11" membership_type_id="182" membership_num_terms="1" is_active="1" financial_type_id="237" label="CSCT Free" description="CSCT Free" />
+    <civicrm_price_field_value id="815" price_field_id="380" name="CSCT_Unemployed" amount="0.00" weight="12" membership_type_id="183" membership_num_terms="1" is_active="1" financial_type_id="237" label="CSCT Unemployed" description="CSCT Unemployed" />
+    <civicrm_price_field_value id="816" price_field_id="380" name="CSCT_50_Yr_Member" amount="0.00" weight="13" membership_type_id="184" membership_num_terms="1" is_active="1" financial_type_id="237" label="CSCT 50 Yr Member" description="CSCT 50 Yr Member" />
+    <civicrm_price_field_value id="817" price_field_id="381" name="Canadian_Society_for_Chemistry_CSC_taxable_" amount="20.00" weight="1" membership_type_id="160" membership_num_terms="1" is_active="1" financial_type_id="238" label="Canadian Society for Chemistry (CSC) (taxable)" description="Canadian Society for Chemistry (CSC) (taxable)" />
+    <civicrm_price_field_value id="818" price_field_id="381" name="Canadian_Society_for_Chemical_Engineering_CSChE_taxable_" amount="20.00" weight="2" membership_type_id="161" membership_num_terms="1" is_active="1" financial_type_id="240" label="Canadian Society for Chemical Engineering (CSChE) (taxable)" description="Canadian Society for Chemical Engineering (CSChE) (taxable)" />
+    <civicrm_price_field_value id="819" price_field_id="382" name="Print_and_Online" amount="0.00" weight="1" membership_type_id="163" membership_num_terms="1" is_active="1" financial_type_id="237" label="Print and Online" description="Print and Online" />
+    <civicrm_price_field_value id="820" price_field_id="382" name="Online_Only" amount="0.00" weight="2" membership_type_id="164" membership_num_terms="1" is_active="1" financial_type_id="237" label="Online Only" description="Online Only" />
+    <civicrm_price_field_value id="821" price_field_id="382" name="Print_Only" amount="0.00" weight="3" membership_type_id="165" membership_num_terms="1" is_active="1" financial_type_id="237" label="Print Only" description="Print Only" />
+    <civicrm_price_field_value id="822" price_field_id="383" name="Print_taxable_" amount="135.00" weight="1" membership_type_id="166" membership_num_terms="1" is_active="1" financial_type_id="244" label="Print (taxable)" description="Print (taxable)" />
+    <civicrm_price_field_value id="823" price_field_id="383" name="Member_Online_taxable_" amount="90.00" weight="2" membership_type_id="167" membership_num_terms="1" is_active="1" financial_type_id="244" label="Member Online (taxable)" description="Member Online (taxable)" />
+    <civicrm_price_field_value id="824" price_field_id="383" name="Member_Both_taxable_" amount="160.00" weight="3" membership_type_id="168" membership_num_terms="1" is_active="1" financial_type_id="244" label="Member Both (taxable)" description="Member Both (taxable)" />
+    <civicrm_price_field_value id="825" price_field_id="384" name="Canada_taxable_" amount="235.00" weight="1" membership_type_id="169" membership_num_terms="1" is_active="1" financial_type_id="246" label="Canada (taxable)" description="Canada (taxable)" />
+    <civicrm_price_field_value id="826" price_field_id="384" name="Outside_Canada" amount="310.00" weight="2" membership_type_id="169" membership_num_terms="1" is_active="1" financial_type_id="248" label="Outside Canada" description="Outside Canada" />
+    <civicrm_price_field_value id="827" price_field_id="385" name="Chemistry_Industry_taxable_" amount="210.00" weight="1" membership_type_id="170" membership_num_terms="1" is_active="1" financial_type_id="250" label="Chemistry &amp; Industry (taxable)" description="Chemistry &amp; Industry (taxable)" />
+    <civicrm_price_field_value id="828" price_field_id="386" name="cCT_taxable_" amount="25.00" weight="1" is_active="1" financial_type_id="254" label="cCT (taxable)" description="cCT (taxable)" />
+    <civicrm_price_field_value id="829" price_field_id="387" name="OACETT_Discount_taxable_" amount="-36.25" weight="1" is_active="1" financial_type_id="261" label="OACETT Discount (taxable)" description="OACETT Discount (taxable)" />
+    <civicrm_price_field_value id="830" price_field_id="387" name="NBSCETT_Discount_taxable_" amount="-36.25" weight="2" is_active="1" financial_type_id="261" label="NBSCETT Discount (taxable)" description="NBSCETT Discount (taxable)" />
+    <civicrm_price_field_value id="831" price_field_id="388" name="Other_Discount_taxable_" amount="1" weight="1" is_active="1" financial_type_id="261" label="Other Discount (taxable)" description="Other Discount (taxable)" />
+    <civicrm_price_field_value id="832" price_field_id="389" name="Over_Short_taxable_" amount="1" weight="1" is_active="1" financial_type_id="265" label="Over/Short (taxable)" description="Over/Short (taxable)" />
+    <civicrm_price_field_value id="833" price_field_id="390" name="Exchange_taxable_" amount="1" weight="1" is_active="1" financial_type_id="265" label="Exchange (taxable)" description="Exchange (taxable)" />
+    <civicrm_price_field_value id="834" price_field_id="391" name="Bright_Memorial_Contribution" amount="1" weight="1" is_active="1" financial_type_id="270" label="Bright Memorial Contribution" description="Bright Memorial Contribution" />
+    <civicrm_price_field_value id="835" price_field_id="392" name="R_S_Jane_Contribution" amount="1" weight="1" is_active="1" financial_type_id="271" label="R. S. Jane Contribution" description="R. S. Jane Contribution" />
+    <civicrm_price_field_value id="836" price_field_id="393" name="Continuing_Education_Fund_Contribution" amount="1" weight="1" is_active="1" financial_type_id="272" label="Continuing Education Fund Contribution" description="Continuing Education Fund Contribution" />
+    <civicrm_price_field_value id="837" price_field_id="394" name="National_Chemistry_Week_Contribution" amount="1" weight="1" is_active="1" financial_type_id="273" label="National Chemistry Week Contribution" description="National Chemistry Week Contribution" />
+    <civicrm_price_field_value id="838" price_field_id="395" name="hidden_taxes" amount="1" weight="1" is_active="1" financial_type_id="274" label="hidden_taxes" description="hidden_taxes" />
+    <civicrm_price_field_value id="839" price_field_id="396" name="CSChE_Full_Fee_taxable_" amount="157.00" weight="1" membership_type_id="185" membership_num_terms="1" is_active="1" financial_type_id="192" label="CSChE Full Fee (taxable)" description="CSChE Full Fee (taxable)" />
+    <civicrm_price_field_value id="840" price_field_id="396" name="CSChE_Half_Fee_AG_taxable_" amount="78.50" weight="2" membership_type_id="186" membership_num_terms="1" is_active="1" financial_type_id="198" label="CSChE Half Fee AG (taxable)" description="CSChE Half Fee AG (taxable)" />
+    <civicrm_price_field_value id="841" price_field_id="396" name="CSChE_Half_Fee_July_1_taxable_" amount="78.50" weight="3" membership_type_id="187" membership_num_terms="1" is_active="1" financial_type_id="198" label="CSChE Half Fee July 1 (taxable)" description="CSChE Half Fee July 1 (taxable)" />
+    <civicrm_price_field_value id="842" price_field_id="396" name="CSChE_Half_Fee_Spousal_taxable_" amount="78.50" weight="4" membership_type_id="188" membership_num_terms="1" is_active="1" financial_type_id="198" label="CSChE Half Fee Spousal (taxable)" description="CSChE Half Fee Spousal (taxable)" />
+    <civicrm_price_field_value id="843" price_field_id="396" name="CSChE_Retired_taxable_" amount="78.50" weight="5" membership_type_id="189" membership_num_terms="1" is_active="1" financial_type_id="204" label="CSChE Retired (taxable)" description="CSChE Retired (taxable)" />
+    <civicrm_price_field_value id="844" price_field_id="396" name="CSChE_Undergraduate_taxable_" amount="30.00" weight="6" membership_type_id="190" membership_num_terms="1" is_active="1" financial_type_id="210" label="CSChE Undergraduate (taxable)" description="CSChE Undergraduate (taxable)" />
+    <civicrm_price_field_value id="845" price_field_id="396" name="CSChE_Postdoc_Fee_taxable_" amount="78.50" weight="7" membership_type_id="191" membership_num_terms="1" is_active="1" financial_type_id="216" label="CSChE Postdoc Fee (taxable)" description="CSChE Postdoc Fee (taxable)" />
+    <civicrm_price_field_value id="846" price_field_id="396" name="CSChE_Graduate_Student_taxable_" amount="50.00" weight="8" membership_type_id="192" membership_num_terms="1" is_active="1" financial_type_id="220" label="CSChE Graduate Student (taxable)" description="CSChE Graduate Student (taxable)" />
+    <civicrm_price_field_value id="847" price_field_id="396" name="CSChE_HS_Teacher_taxable_" amount="50.00" weight="9" membership_type_id="193" membership_num_terms="1" is_active="1" financial_type_id="226" label="CSChE HS Teacher (taxable)" description="CSChE HS Teacher (taxable)" />
+    <civicrm_price_field_value id="848" price_field_id="396" name="CSChE_Lifetime_taxable_" amount="2975.00" weight="10" membership_type_id="194" membership_num_terms="1" is_active="1" financial_type_id="232" label="CSChE Lifetime (taxable)" description="CSChE Lifetime (taxable)" />
+    <civicrm_price_field_value id="849" price_field_id="396" name="CSChE_Honorary" amount="0.00" weight="11" membership_type_id="195" membership_num_terms="1" is_active="1" financial_type_id="237" label="CSChE Honorary" description="CSChE Honorary" />
+    <civicrm_price_field_value id="850" price_field_id="396" name="CSChE_Free" amount="0.00" weight="12" membership_type_id="196" membership_num_terms="1" is_active="1" financial_type_id="237" label="CSChE Free" description="CSChE Free" />
+    <civicrm_price_field_value id="851" price_field_id="396" name="CSChE_Unemployed" amount="0.00" weight="13" membership_type_id="197" membership_num_terms="1" is_active="1" financial_type_id="237" label="CSChE Unemployed" description="CSChE Unemployed" />
+    <civicrm_price_field_value id="852" price_field_id="396" name="CSChE_50_Yr_Member" amount="0.00" weight="14" membership_type_id="198" membership_num_terms="1" is_active="1" financial_type_id="237" label="CSChE 50 Yr Member" description="CSChE 50 Yr Member" />
+    <civicrm_price_field_value id="853" price_field_id="397" name="Canadian_Society_for_Chemistry_CSC_taxable_" amount="20.00" weight="1" membership_type_id="160" membership_num_terms="1" is_active="1" financial_type_id="238" label="Canadian Society for Chemistry (CSC) (taxable)" description="Canadian Society for Chemistry (CSC) (taxable)" />
+    <civicrm_price_field_value id="854" price_field_id="397" name="Canadian_Society_for_Chemical_Technology_CSCT_taxable_" amount="20.00" weight="2" membership_type_id="162" membership_num_terms="1" is_active="1" financial_type_id="242" label="Canadian Society for Chemical Technology (CSCT) (taxable)" description="Canadian Society for Chemical Technology (CSCT) (taxable)" />
+    <civicrm_price_field_value id="855" price_field_id="398" name="Print_and_Online" amount="0.00" weight="1" membership_type_id="163" membership_num_terms="1" is_active="1" financial_type_id="237" label="Print and Online" description="Print and Online" />
+    <civicrm_price_field_value id="856" price_field_id="398" name="Online_Only" amount="0.00" weight="2" membership_type_id="164" membership_num_terms="1" is_active="1" financial_type_id="237" label="Online Only" description="Online Only" />
+    <civicrm_price_field_value id="857" price_field_id="398" name="Print_Only" amount="0.00" weight="3" membership_type_id="165" membership_num_terms="1" is_active="1" financial_type_id="237" label="Print Only" description="Print Only" />
+    <civicrm_price_field_value id="858" price_field_id="399" name="Print_taxable_" amount="135.00" weight="1" membership_type_id="166" membership_num_terms="1" is_active="1" financial_type_id="244" label="Print (taxable)" description="Print (taxable)" />
+    <civicrm_price_field_value id="859" price_field_id="399" name="Member_Online_taxable_" amount="90.00" weight="2" membership_type_id="167" membership_num_terms="1" is_active="1" financial_type_id="244" label="Member Online (taxable)" description="Member Online (taxable)" />
+    <civicrm_price_field_value id="860" price_field_id="399" name="Member_Both_taxable_" amount="160.00" weight="3" membership_type_id="168" membership_num_terms="1" is_active="1" financial_type_id="244" label="Member Both (taxable)" description="Member Both (taxable)" />
+    <civicrm_price_field_value id="861" price_field_id="400" name="Canada_taxable_" amount="235.00" weight="1" membership_type_id="169" membership_num_terms="1" is_active="1" financial_type_id="246" label="Canada (taxable)" description="Canada (taxable)" />
+    <civicrm_price_field_value id="862" price_field_id="400" name="Outside_Canada" amount="310.00" weight="2" membership_type_id="169" membership_num_terms="1" is_active="1" financial_type_id="248" label="Outside Canada" description="Outside Canada" />
+    <civicrm_price_field_value id="863" price_field_id="401" name="Chemistry_Industry_taxable_" amount="210.00" weight="1" membership_type_id="170" membership_num_terms="1" is_active="1" financial_type_id="250" label="Chemistry &amp; Industry (taxable)" description="Chemistry &amp; Industry (taxable)" />
+    <civicrm_price_field_value id="864" price_field_id="402" name="CSMB_Discount_taxable_" amount="-43.50" weight="1" is_active="1" financial_type_id="257" label="CSMB Discount (taxable)" description="CSMB Discount (taxable)" />
+    <civicrm_price_field_value id="865" price_field_id="403" name="Other_Discount_taxable_" amount="1" weight="1" is_active="1" financial_type_id="257" label="Other Discount (taxable)" description="Other Discount (taxable)" />
+    <civicrm_price_field_value id="866" price_field_id="404" name="Over_Short_taxable_" amount="1" weight="1" is_active="1" financial_type_id="264" label="Over/Short (taxable)" description="Over/Short (taxable)" />
+    <civicrm_price_field_value id="867" price_field_id="405" name="Exchange_taxable_" amount="1" weight="1" is_active="1" financial_type_id="264" label="Exchange (taxable)" description="Exchange (taxable)" />
+    <civicrm_price_field_value id="868" price_field_id="406" name="Bright_Memorial_Contribution" amount="1" weight="1" is_active="1" financial_type_id="270" label="Bright Memorial Contribution" description="Bright Memorial Contribution" />
+    <civicrm_price_field_value id="869" price_field_id="407" name="R_S_Jane_Contribution" amount="1" weight="1" is_active="1" financial_type_id="271" label="R. S. Jane Contribution" description="R. S. Jane Contribution" />
+    <civicrm_price_field_value id="870" price_field_id="408" name="Continuing_Education_Fund_Contribution" amount="1" weight="1" is_active="1" financial_type_id="272" label="Continuing Education Fund Contribution" description="Continuing Education Fund Contribution" />
+    <civicrm_price_field_value id="871" price_field_id="409" name="National_Chemistry_Week_Contribution" amount="1" weight="1" is_active="1" financial_type_id="273" label="National Chemistry Week Contribution" description="National Chemistry Week Contribution" />
+    <civicrm_price_field_value id="872" price_field_id="410" name="hidden_taxes" amount="1" weight="1" is_active="1" financial_type_id="274" label="hidden_taxes" description="hidden_taxes" />
+
+
+
+
+    <civicrm_entity_financial_account id="1587" entity_table="civicrm_financial_type" entity_id="200" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1588" entity_table="civicrm_financial_type" entity_id="200" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1589" entity_table="civicrm_financial_type" entity_id="200" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1593" entity_table="civicrm_financial_type" entity_id="200" account_relationship="1" financial_account_id="209" />
+    <civicrm_entity_financial_account id="1594" entity_table="civicrm_financial_type" entity_id="201" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1595" entity_table="civicrm_financial_type" entity_id="201" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1596" entity_table="civicrm_financial_type" entity_id="201" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1597" entity_table="civicrm_financial_type" entity_id="201" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1601" entity_table="civicrm_financial_type" entity_id="201" account_relationship="1" financial_account_id="210" />
+    <civicrm_entity_financial_account id="1602" entity_table="civicrm_financial_type" entity_id="202" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1603" entity_table="civicrm_financial_type" entity_id="202" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1604" entity_table="civicrm_financial_type" entity_id="202" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1605" entity_table="civicrm_financial_type" entity_id="202" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1609" entity_table="civicrm_financial_type" entity_id="202" account_relationship="1" financial_account_id="211" />
+    <civicrm_entity_financial_account id="1610" entity_table="civicrm_financial_type" entity_id="203" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1611" entity_table="civicrm_financial_type" entity_id="203" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1612" entity_table="civicrm_financial_type" entity_id="203" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1613" entity_table="civicrm_financial_type" entity_id="203" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1617" entity_table="civicrm_financial_type" entity_id="203" account_relationship="1" financial_account_id="212" />
+    <civicrm_entity_financial_account id="1618" entity_table="civicrm_financial_type" entity_id="204" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1619" entity_table="civicrm_financial_type" entity_id="204" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1620" entity_table="civicrm_financial_type" entity_id="204" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1621" entity_table="civicrm_financial_type" entity_id="204" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1625" entity_table="civicrm_financial_type" entity_id="204" account_relationship="1" financial_account_id="213" />
+    <civicrm_entity_financial_account id="1626" entity_table="civicrm_financial_type" entity_id="205" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1627" entity_table="civicrm_financial_type" entity_id="205" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1628" entity_table="civicrm_financial_type" entity_id="205" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1629" entity_table="civicrm_financial_type" entity_id="205" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1633" entity_table="civicrm_financial_type" entity_id="205" account_relationship="1" financial_account_id="214" />
+    <civicrm_entity_financial_account id="1634" entity_table="civicrm_financial_type" entity_id="206" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1635" entity_table="civicrm_financial_type" entity_id="206" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1636" entity_table="civicrm_financial_type" entity_id="206" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1637" entity_table="civicrm_financial_type" entity_id="206" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1641" entity_table="civicrm_financial_type" entity_id="206" account_relationship="1" financial_account_id="215" />
+    <civicrm_entity_financial_account id="1642" entity_table="civicrm_financial_type" entity_id="207" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1643" entity_table="civicrm_financial_type" entity_id="207" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1644" entity_table="civicrm_financial_type" entity_id="207" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1645" entity_table="civicrm_financial_type" entity_id="207" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1649" entity_table="civicrm_financial_type" entity_id="207" account_relationship="1" financial_account_id="216" />
+    <civicrm_entity_financial_account id="1650" entity_table="civicrm_financial_type" entity_id="208" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1651" entity_table="civicrm_financial_type" entity_id="208" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1652" entity_table="civicrm_financial_type" entity_id="208" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1653" entity_table="civicrm_financial_type" entity_id="208" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1657" entity_table="civicrm_financial_type" entity_id="208" account_relationship="1" financial_account_id="217" />
+    <civicrm_entity_financial_account id="1658" entity_table="civicrm_financial_type" entity_id="209" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1659" entity_table="civicrm_financial_type" entity_id="209" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1660" entity_table="civicrm_financial_type" entity_id="209" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1661" entity_table="civicrm_financial_type" entity_id="209" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1665" entity_table="civicrm_financial_type" entity_id="209" account_relationship="1" financial_account_id="218" />
+    <civicrm_entity_financial_account id="1666" entity_table="civicrm_financial_type" entity_id="210" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1667" entity_table="civicrm_financial_type" entity_id="210" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1668" entity_table="civicrm_financial_type" entity_id="210" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1669" entity_table="civicrm_financial_type" entity_id="210" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1673" entity_table="civicrm_financial_type" entity_id="210" account_relationship="1" financial_account_id="219" />
+    <civicrm_entity_financial_account id="1674" entity_table="civicrm_financial_type" entity_id="211" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1675" entity_table="civicrm_financial_type" entity_id="211" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1676" entity_table="civicrm_financial_type" entity_id="211" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1677" entity_table="civicrm_financial_type" entity_id="211" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1681" entity_table="civicrm_financial_type" entity_id="211" account_relationship="1" financial_account_id="220" />
+    <civicrm_entity_financial_account id="1682" entity_table="civicrm_financial_type" entity_id="212" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1683" entity_table="civicrm_financial_type" entity_id="212" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1684" entity_table="civicrm_financial_type" entity_id="212" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1685" entity_table="civicrm_financial_type" entity_id="212" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1689" entity_table="civicrm_financial_type" entity_id="212" account_relationship="1" financial_account_id="221" />
+    <civicrm_entity_financial_account id="1690" entity_table="civicrm_financial_type" entity_id="213" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1691" entity_table="civicrm_financial_type" entity_id="213" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1692" entity_table="civicrm_financial_type" entity_id="213" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1693" entity_table="civicrm_financial_type" entity_id="213" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1697" entity_table="civicrm_financial_type" entity_id="213" account_relationship="1" financial_account_id="222" />
+    <civicrm_entity_financial_account id="1698" entity_table="civicrm_financial_type" entity_id="214" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1699" entity_table="civicrm_financial_type" entity_id="214" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1700" entity_table="civicrm_financial_type" entity_id="214" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1701" entity_table="civicrm_financial_type" entity_id="214" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1705" entity_table="civicrm_financial_type" entity_id="214" account_relationship="1" financial_account_id="223" />
+    <civicrm_entity_financial_account id="1706" entity_table="civicrm_financial_type" entity_id="215" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1707" entity_table="civicrm_financial_type" entity_id="215" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1708" entity_table="civicrm_financial_type" entity_id="215" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1709" entity_table="civicrm_financial_type" entity_id="215" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1713" entity_table="civicrm_financial_type" entity_id="215" account_relationship="1" financial_account_id="224" />
+    <civicrm_entity_financial_account id="1714" entity_table="civicrm_financial_type" entity_id="216" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1715" entity_table="civicrm_financial_type" entity_id="216" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1716" entity_table="civicrm_financial_type" entity_id="216" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1717" entity_table="civicrm_financial_type" entity_id="216" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1721" entity_table="civicrm_financial_type" entity_id="216" account_relationship="1" financial_account_id="225" />
+    <civicrm_entity_financial_account id="1722" entity_table="civicrm_financial_type" entity_id="217" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1723" entity_table="civicrm_financial_type" entity_id="217" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1724" entity_table="civicrm_financial_type" entity_id="217" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1725" entity_table="civicrm_financial_type" entity_id="217" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1729" entity_table="civicrm_financial_type" entity_id="217" account_relationship="1" financial_account_id="226" />
+    <civicrm_entity_financial_account id="1730" entity_table="civicrm_financial_type" entity_id="218" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1731" entity_table="civicrm_financial_type" entity_id="218" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1732" entity_table="civicrm_financial_type" entity_id="218" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1733" entity_table="civicrm_financial_type" entity_id="218" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1737" entity_table="civicrm_financial_type" entity_id="218" account_relationship="1" financial_account_id="227" />
+    <civicrm_entity_financial_account id="1738" entity_table="civicrm_financial_type" entity_id="219" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1739" entity_table="civicrm_financial_type" entity_id="219" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1740" entity_table="civicrm_financial_type" entity_id="219" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1741" entity_table="civicrm_financial_type" entity_id="219" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1745" entity_table="civicrm_financial_type" entity_id="219" account_relationship="1" financial_account_id="228" />
+    <civicrm_entity_financial_account id="1746" entity_table="civicrm_financial_type" entity_id="220" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1747" entity_table="civicrm_financial_type" entity_id="220" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1748" entity_table="civicrm_financial_type" entity_id="220" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1749" entity_table="civicrm_financial_type" entity_id="220" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1753" entity_table="civicrm_financial_type" entity_id="220" account_relationship="1" financial_account_id="229" />
+    <civicrm_entity_financial_account id="1754" entity_table="civicrm_financial_type" entity_id="221" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1755" entity_table="civicrm_financial_type" entity_id="221" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1756" entity_table="civicrm_financial_type" entity_id="221" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1757" entity_table="civicrm_financial_type" entity_id="221" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1761" entity_table="civicrm_financial_type" entity_id="221" account_relationship="1" financial_account_id="230" />
+    <civicrm_entity_financial_account id="1762" entity_table="civicrm_financial_type" entity_id="222" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1763" entity_table="civicrm_financial_type" entity_id="222" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1764" entity_table="civicrm_financial_type" entity_id="222" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1765" entity_table="civicrm_financial_type" entity_id="222" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1769" entity_table="civicrm_financial_type" entity_id="222" account_relationship="1" financial_account_id="231" />
+    <civicrm_entity_financial_account id="1770" entity_table="civicrm_financial_type" entity_id="223" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1771" entity_table="civicrm_financial_type" entity_id="223" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1772" entity_table="civicrm_financial_type" entity_id="223" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1773" entity_table="civicrm_financial_type" entity_id="223" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1777" entity_table="civicrm_financial_type" entity_id="223" account_relationship="1" financial_account_id="232" />
+    <civicrm_entity_financial_account id="1778" entity_table="civicrm_financial_type" entity_id="224" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1779" entity_table="civicrm_financial_type" entity_id="224" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1780" entity_table="civicrm_financial_type" entity_id="224" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1781" entity_table="civicrm_financial_type" entity_id="224" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1785" entity_table="civicrm_financial_type" entity_id="224" account_relationship="1" financial_account_id="233" />
+    <civicrm_entity_financial_account id="1786" entity_table="civicrm_financial_type" entity_id="225" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1787" entity_table="civicrm_financial_type" entity_id="225" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1788" entity_table="civicrm_financial_type" entity_id="225" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1789" entity_table="civicrm_financial_type" entity_id="225" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1793" entity_table="civicrm_financial_type" entity_id="225" account_relationship="1" financial_account_id="234" />
+    <civicrm_entity_financial_account id="1794" entity_table="civicrm_financial_type" entity_id="226" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1795" entity_table="civicrm_financial_type" entity_id="226" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1796" entity_table="civicrm_financial_type" entity_id="226" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1797" entity_table="civicrm_financial_type" entity_id="226" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1801" entity_table="civicrm_financial_type" entity_id="226" account_relationship="1" financial_account_id="235" />
+    <civicrm_entity_financial_account id="1802" entity_table="civicrm_financial_type" entity_id="227" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1803" entity_table="civicrm_financial_type" entity_id="227" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1804" entity_table="civicrm_financial_type" entity_id="227" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1805" entity_table="civicrm_financial_type" entity_id="227" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1809" entity_table="civicrm_financial_type" entity_id="227" account_relationship="1" financial_account_id="236" />
+    <civicrm_entity_financial_account id="1810" entity_table="civicrm_financial_type" entity_id="228" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1811" entity_table="civicrm_financial_type" entity_id="228" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1812" entity_table="civicrm_financial_type" entity_id="228" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1813" entity_table="civicrm_financial_type" entity_id="228" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1817" entity_table="civicrm_financial_type" entity_id="228" account_relationship="1" financial_account_id="237" />
+    <civicrm_entity_financial_account id="1818" entity_table="civicrm_financial_type" entity_id="229" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1819" entity_table="civicrm_financial_type" entity_id="229" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1820" entity_table="civicrm_financial_type" entity_id="229" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1821" entity_table="civicrm_financial_type" entity_id="229" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1825" entity_table="civicrm_financial_type" entity_id="229" account_relationship="1" financial_account_id="238" />
+    <civicrm_entity_financial_account id="1826" entity_table="civicrm_financial_type" entity_id="230" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1827" entity_table="civicrm_financial_type" entity_id="230" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1828" entity_table="civicrm_financial_type" entity_id="230" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1829" entity_table="civicrm_financial_type" entity_id="230" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1833" entity_table="civicrm_financial_type" entity_id="230" account_relationship="1" financial_account_id="239" />
+    <civicrm_entity_financial_account id="1834" entity_table="civicrm_financial_type" entity_id="231" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1835" entity_table="civicrm_financial_type" entity_id="231" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1836" entity_table="civicrm_financial_type" entity_id="231" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1837" entity_table="civicrm_financial_type" entity_id="231" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1841" entity_table="civicrm_financial_type" entity_id="231" account_relationship="1" financial_account_id="240" />
+    <civicrm_entity_financial_account id="1842" entity_table="civicrm_financial_type" entity_id="232" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1843" entity_table="civicrm_financial_type" entity_id="232" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1844" entity_table="civicrm_financial_type" entity_id="232" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1845" entity_table="civicrm_financial_type" entity_id="232" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1849" entity_table="civicrm_financial_type" entity_id="232" account_relationship="1" financial_account_id="241" />
+    <civicrm_entity_financial_account id="1850" entity_table="civicrm_financial_type" entity_id="233" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1851" entity_table="civicrm_financial_type" entity_id="233" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1852" entity_table="civicrm_financial_type" entity_id="233" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1853" entity_table="civicrm_financial_type" entity_id="233" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1857" entity_table="civicrm_financial_type" entity_id="233" account_relationship="1" financial_account_id="242" />
+    <civicrm_entity_financial_account id="1858" entity_table="civicrm_financial_type" entity_id="234" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1859" entity_table="civicrm_financial_type" entity_id="234" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1860" entity_table="civicrm_financial_type" entity_id="234" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1861" entity_table="civicrm_financial_type" entity_id="234" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1865" entity_table="civicrm_financial_type" entity_id="234" account_relationship="1" financial_account_id="243" />
+    <civicrm_entity_financial_account id="1866" entity_table="civicrm_financial_type" entity_id="235" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1867" entity_table="civicrm_financial_type" entity_id="235" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1868" entity_table="civicrm_financial_type" entity_id="235" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1869" entity_table="civicrm_financial_type" entity_id="235" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1873" entity_table="civicrm_financial_type" entity_id="235" account_relationship="1" financial_account_id="244" />
+    <civicrm_entity_financial_account id="1874" entity_table="civicrm_financial_type" entity_id="236" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1875" entity_table="civicrm_financial_type" entity_id="236" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1876" entity_table="civicrm_financial_type" entity_id="236" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1877" entity_table="civicrm_financial_type" entity_id="236" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1881" entity_table="civicrm_financial_type" entity_id="236" account_relationship="1" financial_account_id="245" />
+    <civicrm_entity_financial_account id="1882" entity_table="civicrm_financial_type" entity_id="237" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1883" entity_table="civicrm_financial_type" entity_id="237" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1884" entity_table="civicrm_financial_type" entity_id="237" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1885" entity_table="civicrm_financial_type" entity_id="237" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1889" entity_table="civicrm_financial_type" entity_id="237" account_relationship="1" financial_account_id="246" />
+    <civicrm_entity_financial_account id="1890" entity_table="civicrm_financial_type" entity_id="238" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1891" entity_table="civicrm_financial_type" entity_id="238" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1892" entity_table="civicrm_financial_type" entity_id="238" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1893" entity_table="civicrm_financial_type" entity_id="238" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1897" entity_table="civicrm_financial_type" entity_id="238" account_relationship="1" financial_account_id="247" />
+    <civicrm_entity_financial_account id="1898" entity_table="civicrm_financial_type" entity_id="239" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1899" entity_table="civicrm_financial_type" entity_id="239" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1900" entity_table="civicrm_financial_type" entity_id="239" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1901" entity_table="civicrm_financial_type" entity_id="239" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1905" entity_table="civicrm_financial_type" entity_id="239" account_relationship="1" financial_account_id="248" />
+    <civicrm_entity_financial_account id="1906" entity_table="civicrm_financial_type" entity_id="240" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1907" entity_table="civicrm_financial_type" entity_id="240" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1908" entity_table="civicrm_financial_type" entity_id="240" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1909" entity_table="civicrm_financial_type" entity_id="240" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1913" entity_table="civicrm_financial_type" entity_id="240" account_relationship="1" financial_account_id="249" />
+    <civicrm_entity_financial_account id="1914" entity_table="civicrm_financial_type" entity_id="241" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1915" entity_table="civicrm_financial_type" entity_id="241" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1916" entity_table="civicrm_financial_type" entity_id="241" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1917" entity_table="civicrm_financial_type" entity_id="241" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1921" entity_table="civicrm_financial_type" entity_id="241" account_relationship="1" financial_account_id="250" />
+    <civicrm_entity_financial_account id="1922" entity_table="civicrm_financial_type" entity_id="242" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1923" entity_table="civicrm_financial_type" entity_id="242" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1924" entity_table="civicrm_financial_type" entity_id="242" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1925" entity_table="civicrm_financial_type" entity_id="242" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1929" entity_table="civicrm_financial_type" entity_id="242" account_relationship="1" financial_account_id="251" />
+    <civicrm_entity_financial_account id="1930" entity_table="civicrm_financial_type" entity_id="243" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1931" entity_table="civicrm_financial_type" entity_id="243" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1932" entity_table="civicrm_financial_type" entity_id="243" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1933" entity_table="civicrm_financial_type" entity_id="243" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1937" entity_table="civicrm_financial_type" entity_id="243" account_relationship="1" financial_account_id="252" />
+    <civicrm_entity_financial_account id="1938" entity_table="civicrm_financial_type" entity_id="244" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1939" entity_table="civicrm_financial_type" entity_id="244" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1940" entity_table="civicrm_financial_type" entity_id="244" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1941" entity_table="civicrm_financial_type" entity_id="244" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1945" entity_table="civicrm_financial_type" entity_id="244" account_relationship="1" financial_account_id="253" />
+    <civicrm_entity_financial_account id="1946" entity_table="civicrm_financial_type" entity_id="245" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1947" entity_table="civicrm_financial_type" entity_id="245" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1948" entity_table="civicrm_financial_type" entity_id="245" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1949" entity_table="civicrm_financial_type" entity_id="245" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1953" entity_table="civicrm_financial_type" entity_id="245" account_relationship="1" financial_account_id="254" />
+    <civicrm_entity_financial_account id="1954" entity_table="civicrm_financial_type" entity_id="246" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1955" entity_table="civicrm_financial_type" entity_id="246" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1956" entity_table="civicrm_financial_type" entity_id="246" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1957" entity_table="civicrm_financial_type" entity_id="246" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1961" entity_table="civicrm_financial_type" entity_id="246" account_relationship="1" financial_account_id="255" />
+    <civicrm_entity_financial_account id="1962" entity_table="civicrm_financial_type" entity_id="247" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1963" entity_table="civicrm_financial_type" entity_id="247" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1964" entity_table="civicrm_financial_type" entity_id="247" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1965" entity_table="civicrm_financial_type" entity_id="247" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1969" entity_table="civicrm_financial_type" entity_id="247" account_relationship="1" financial_account_id="256" />
+    <civicrm_entity_financial_account id="1970" entity_table="civicrm_financial_type" entity_id="248" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1971" entity_table="civicrm_financial_type" entity_id="248" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1972" entity_table="civicrm_financial_type" entity_id="248" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1973" entity_table="civicrm_financial_type" entity_id="248" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1977" entity_table="civicrm_financial_type" entity_id="248" account_relationship="1" financial_account_id="257" />
+    <civicrm_entity_financial_account id="1978" entity_table="civicrm_financial_type" entity_id="249" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1979" entity_table="civicrm_financial_type" entity_id="249" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1980" entity_table="civicrm_financial_type" entity_id="249" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1981" entity_table="civicrm_financial_type" entity_id="249" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1985" entity_table="civicrm_financial_type" entity_id="249" account_relationship="1" financial_account_id="258" />
+    <civicrm_entity_financial_account id="1986" entity_table="civicrm_financial_type" entity_id="250" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1987" entity_table="civicrm_financial_type" entity_id="250" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1988" entity_table="civicrm_financial_type" entity_id="250" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1989" entity_table="civicrm_financial_type" entity_id="250" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="1993" entity_table="civicrm_financial_type" entity_id="250" account_relationship="1" financial_account_id="259" />
+    <civicrm_entity_financial_account id="1994" entity_table="civicrm_financial_type" entity_id="251" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="1995" entity_table="civicrm_financial_type" entity_id="251" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="1996" entity_table="civicrm_financial_type" entity_id="251" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="1997" entity_table="civicrm_financial_type" entity_id="251" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="2001" entity_table="civicrm_financial_type" entity_id="251" account_relationship="1" financial_account_id="260" />
+    <civicrm_entity_financial_account id="2002" entity_table="civicrm_financial_type" entity_id="252" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2003" entity_table="civicrm_financial_type" entity_id="252" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2004" entity_table="civicrm_financial_type" entity_id="252" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2005" entity_table="civicrm_financial_type" entity_id="252" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="2009" entity_table="civicrm_financial_type" entity_id="252" account_relationship="1" financial_account_id="261" />
+    <civicrm_entity_financial_account id="2010" entity_table="civicrm_financial_type" entity_id="253" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2011" entity_table="civicrm_financial_type" entity_id="253" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2012" entity_table="civicrm_financial_type" entity_id="253" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2013" entity_table="civicrm_financial_type" entity_id="253" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="2017" entity_table="civicrm_financial_type" entity_id="253" account_relationship="1" financial_account_id="262" />
+    <civicrm_entity_financial_account id="2018" entity_table="civicrm_financial_type" entity_id="254" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2019" entity_table="civicrm_financial_type" entity_id="254" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2020" entity_table="civicrm_financial_type" entity_id="254" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2021" entity_table="civicrm_financial_type" entity_id="254" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="2025" entity_table="civicrm_financial_type" entity_id="254" account_relationship="1" financial_account_id="263" />
+    <civicrm_entity_financial_account id="2026" entity_table="civicrm_financial_type" entity_id="255" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2027" entity_table="civicrm_financial_type" entity_id="255" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2028" entity_table="civicrm_financial_type" entity_id="255" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2029" entity_table="civicrm_financial_type" entity_id="255" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="2033" entity_table="civicrm_financial_type" entity_id="255" account_relationship="1" financial_account_id="264" />
+    <civicrm_entity_financial_account id="2034" entity_table="civicrm_financial_type" entity_id="256" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2035" entity_table="civicrm_financial_type" entity_id="256" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2036" entity_table="civicrm_financial_type" entity_id="256" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2037" entity_table="civicrm_financial_type" entity_id="256" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="2041" entity_table="civicrm_financial_type" entity_id="256" account_relationship="1" financial_account_id="265" />
+    <civicrm_entity_financial_account id="2042" entity_table="civicrm_financial_type" entity_id="257" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2043" entity_table="civicrm_financial_type" entity_id="257" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2044" entity_table="civicrm_financial_type" entity_id="257" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2045" entity_table="civicrm_financial_type" entity_id="257" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="2049" entity_table="civicrm_financial_type" entity_id="257" account_relationship="1" financial_account_id="266" />
+    <civicrm_entity_financial_account id="2050" entity_table="civicrm_financial_type" entity_id="258" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2051" entity_table="civicrm_financial_type" entity_id="258" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2052" entity_table="civicrm_financial_type" entity_id="258" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2053" entity_table="civicrm_financial_type" entity_id="258" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="2057" entity_table="civicrm_financial_type" entity_id="258" account_relationship="1" financial_account_id="267" />
+    <civicrm_entity_financial_account id="2058" entity_table="civicrm_financial_type" entity_id="259" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2059" entity_table="civicrm_financial_type" entity_id="259" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2060" entity_table="civicrm_financial_type" entity_id="259" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2061" entity_table="civicrm_financial_type" entity_id="259" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="2065" entity_table="civicrm_financial_type" entity_id="259" account_relationship="1" financial_account_id="268" />
+    <civicrm_entity_financial_account id="2066" entity_table="civicrm_financial_type" entity_id="260" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2067" entity_table="civicrm_financial_type" entity_id="260" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2068" entity_table="civicrm_financial_type" entity_id="260" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2069" entity_table="civicrm_financial_type" entity_id="260" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="2073" entity_table="civicrm_financial_type" entity_id="260" account_relationship="1" financial_account_id="269" />
+    <civicrm_entity_financial_account id="2074" entity_table="civicrm_financial_type" entity_id="261" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2075" entity_table="civicrm_financial_type" entity_id="261" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2076" entity_table="civicrm_financial_type" entity_id="261" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2077" entity_table="civicrm_financial_type" entity_id="261" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="2081" entity_table="civicrm_financial_type" entity_id="261" account_relationship="1" financial_account_id="270" />
+    <civicrm_entity_financial_account id="2082" entity_table="civicrm_financial_type" entity_id="262" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2083" entity_table="civicrm_financial_type" entity_id="262" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2084" entity_table="civicrm_financial_type" entity_id="262" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2085" entity_table="civicrm_financial_type" entity_id="262" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="2089" entity_table="civicrm_financial_type" entity_id="262" account_relationship="1" financial_account_id="271" />
+    <civicrm_entity_financial_account id="2090" entity_table="civicrm_financial_type" entity_id="263" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2091" entity_table="civicrm_financial_type" entity_id="263" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2092" entity_table="civicrm_financial_type" entity_id="263" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2093" entity_table="civicrm_financial_type" entity_id="263" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="2097" entity_table="civicrm_financial_type" entity_id="263" account_relationship="1" financial_account_id="272" />
+    <civicrm_entity_financial_account id="2098" entity_table="civicrm_financial_type" entity_id="264" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2099" entity_table="civicrm_financial_type" entity_id="264" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2100" entity_table="civicrm_financial_type" entity_id="264" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2101" entity_table="civicrm_financial_type" entity_id="264" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="2105" entity_table="civicrm_financial_type" entity_id="264" account_relationship="1" financial_account_id="273" />
+    <civicrm_entity_financial_account id="2106" entity_table="civicrm_financial_type" entity_id="265" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2107" entity_table="civicrm_financial_type" entity_id="265" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2108" entity_table="civicrm_financial_type" entity_id="265" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2109" entity_table="civicrm_financial_type" entity_id="265" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="2113" entity_table="civicrm_financial_type" entity_id="265" account_relationship="1" financial_account_id="274" />
+    <civicrm_entity_financial_account id="2114" entity_table="civicrm_financial_type" entity_id="266" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2115" entity_table="civicrm_financial_type" entity_id="266" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2116" entity_table="civicrm_financial_type" entity_id="266" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2117" entity_table="civicrm_financial_type" entity_id="266" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="2121" entity_table="civicrm_financial_type" entity_id="266" account_relationship="1" financial_account_id="275" />
+    <civicrm_entity_financial_account id="2122" entity_table="civicrm_financial_type" entity_id="267" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2123" entity_table="civicrm_financial_type" entity_id="267" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2124" entity_table="civicrm_financial_type" entity_id="267" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2125" entity_table="civicrm_financial_type" entity_id="267" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="2129" entity_table="civicrm_financial_type" entity_id="267" account_relationship="1" financial_account_id="276" />
+    <civicrm_entity_financial_account id="2130" entity_table="civicrm_financial_type" entity_id="268" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2131" entity_table="civicrm_financial_type" entity_id="268" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2132" entity_table="civicrm_financial_type" entity_id="268" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2133" entity_table="civicrm_financial_type" entity_id="268" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="2137" entity_table="civicrm_financial_type" entity_id="268" account_relationship="1" financial_account_id="277" />
+    <civicrm_entity_financial_account id="2138" entity_table="civicrm_financial_type" entity_id="269" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2139" entity_table="civicrm_financial_type" entity_id="269" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2140" entity_table="civicrm_financial_type" entity_id="269" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2141" entity_table="civicrm_financial_type" entity_id="269" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="2145" entity_table="civicrm_financial_type" entity_id="269" account_relationship="1" financial_account_id="278" />
+    <civicrm_entity_financial_account id="2146" entity_table="civicrm_financial_type" entity_id="270" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2147" entity_table="civicrm_financial_type" entity_id="270" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2148" entity_table="civicrm_financial_type" entity_id="270" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2149" entity_table="civicrm_financial_type" entity_id="270" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="2153" entity_table="civicrm_financial_type" entity_id="270" account_relationship="1" financial_account_id="279" />
+    <civicrm_entity_financial_account id="2154" entity_table="civicrm_financial_type" entity_id="271" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2155" entity_table="civicrm_financial_type" entity_id="271" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2156" entity_table="civicrm_financial_type" entity_id="271" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2157" entity_table="civicrm_financial_type" entity_id="271" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="2161" entity_table="civicrm_financial_type" entity_id="271" account_relationship="1" financial_account_id="280" />
+    <civicrm_entity_financial_account id="2162" entity_table="civicrm_financial_type" entity_id="272" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2163" entity_table="civicrm_financial_type" entity_id="272" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2164" entity_table="civicrm_financial_type" entity_id="272" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2165" entity_table="civicrm_financial_type" entity_id="272" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="2169" entity_table="civicrm_financial_type" entity_id="272" account_relationship="1" financial_account_id="281" />
+    <civicrm_entity_financial_account id="2170" entity_table="civicrm_financial_type" entity_id="273" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2171" entity_table="civicrm_financial_type" entity_id="273" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2172" entity_table="civicrm_financial_type" entity_id="273" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2173" entity_table="civicrm_financial_type" entity_id="273" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="2177" entity_table="civicrm_financial_type" entity_id="273" account_relationship="1" financial_account_id="282" />
+    <civicrm_entity_financial_account id="2178" entity_table="civicrm_financial_type" entity_id="274" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2179" entity_table="civicrm_financial_type" entity_id="274" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2180" entity_table="civicrm_financial_type" entity_id="274" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2181" entity_table="civicrm_financial_type" entity_id="274" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="2186" entity_table="civicrm_financial_type" entity_id="275" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2187" entity_table="civicrm_financial_type" entity_id="275" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2188" entity_table="civicrm_financial_type" entity_id="275" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2189" entity_table="civicrm_financial_type" entity_id="275" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="2193" entity_table="civicrm_financial_type" entity_id="275" account_relationship="1" financial_account_id="283" />
+    <civicrm_entity_financial_account id="2194" entity_table="civicrm_financial_type" entity_id="276" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2195" entity_table="civicrm_financial_type" entity_id="276" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2196" entity_table="civicrm_financial_type" entity_id="276" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2197" entity_table="civicrm_financial_type" entity_id="276" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="2201" entity_table="civicrm_financial_type" entity_id="276" account_relationship="1" financial_account_id="284" />
+    <civicrm_entity_financial_account id="2202" entity_table="civicrm_financial_type" entity_id="277" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2203" entity_table="civicrm_financial_type" entity_id="277" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2204" entity_table="civicrm_financial_type" entity_id="277" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2205" entity_table="civicrm_financial_type" entity_id="277" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="2209" entity_table="civicrm_financial_type" entity_id="277" account_relationship="1" financial_account_id="285" />
+    <civicrm_entity_financial_account id="2210" entity_table="civicrm_financial_type" entity_id="278" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2211" entity_table="civicrm_financial_type" entity_id="278" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2212" entity_table="civicrm_financial_type" entity_id="278" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2213" entity_table="civicrm_financial_type" entity_id="278" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="2217" entity_table="civicrm_financial_type" entity_id="278" account_relationship="1" financial_account_id="286" />
+    <civicrm_entity_financial_account id="2218" entity_table="civicrm_financial_type" entity_id="279" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2219" entity_table="civicrm_financial_type" entity_id="279" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2220" entity_table="civicrm_financial_type" entity_id="279" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2221" entity_table="civicrm_financial_type" entity_id="279" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="2225" entity_table="civicrm_financial_type" entity_id="279" account_relationship="1" financial_account_id="287" />
+    <civicrm_entity_financial_account id="2226" entity_table="civicrm_financial_type" entity_id="280" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2227" entity_table="civicrm_financial_type" entity_id="280" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2228" entity_table="civicrm_financial_type" entity_id="280" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2229" entity_table="civicrm_financial_type" entity_id="280" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="2233" entity_table="civicrm_financial_type" entity_id="280" account_relationship="1" financial_account_id="288" />
+    <civicrm_entity_financial_account id="2234" entity_table="civicrm_financial_type" entity_id="281" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2235" entity_table="civicrm_financial_type" entity_id="281" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2236" entity_table="civicrm_financial_type" entity_id="281" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2237" entity_table="civicrm_financial_type" entity_id="281" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="2241" entity_table="civicrm_financial_type" entity_id="281" account_relationship="1" financial_account_id="289" />
+    <civicrm_entity_financial_account id="2242" entity_table="civicrm_financial_type" entity_id="282" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2243" entity_table="civicrm_financial_type" entity_id="282" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2244" entity_table="civicrm_financial_type" entity_id="282" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2245" entity_table="civicrm_financial_type" entity_id="282" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="2249" entity_table="civicrm_financial_type" entity_id="282" account_relationship="1" financial_account_id="290" />
+    <civicrm_entity_financial_account id="2250" entity_table="civicrm_financial_type" entity_id="283" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2251" entity_table="civicrm_financial_type" entity_id="283" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2252" entity_table="civicrm_financial_type" entity_id="283" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2253" entity_table="civicrm_financial_type" entity_id="283" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="2257" entity_table="civicrm_financial_type" entity_id="283" account_relationship="1" financial_account_id="291" />
+    <civicrm_entity_financial_account id="2258" entity_table="civicrm_financial_type" entity_id="284" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2259" entity_table="civicrm_financial_type" entity_id="284" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2260" entity_table="civicrm_financial_type" entity_id="284" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2261" entity_table="civicrm_financial_type" entity_id="284" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="2265" entity_table="civicrm_financial_type" entity_id="284" account_relationship="1" financial_account_id="292" />
+    <civicrm_entity_financial_account id="2266" entity_table="civicrm_financial_type" entity_id="285" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2267" entity_table="civicrm_financial_type" entity_id="285" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2268" entity_table="civicrm_financial_type" entity_id="285" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2269" entity_table="civicrm_financial_type" entity_id="285" account_relationship="12" financial_account_id="14" />
+    <civicrm_entity_financial_account id="2273" entity_table="civicrm_financial_type" entity_id="285" account_relationship="1" financial_account_id="293" />
+    <civicrm_entity_financial_account id="2283" entity_table="civicrm_financial_type" entity_id="286" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2284" entity_table="civicrm_financial_type" entity_id="286" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2285" entity_table="civicrm_financial_type" entity_id="286" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2286" entity_table="civicrm_financial_type" entity_id="286" account_relationship="1" financial_account_id="294" />
+    <civicrm_entity_financial_account id="2287" entity_table="civicrm_financial_type" entity_id="287" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2288" entity_table="civicrm_financial_type" entity_id="287" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2289" entity_table="civicrm_financial_type" entity_id="287" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2290" entity_table="civicrm_financial_type" entity_id="287" account_relationship="1" financial_account_id="295" />
+    <civicrm_entity_financial_account id="2291" entity_table="civicrm_financial_type" entity_id="288" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2292" entity_table="civicrm_financial_type" entity_id="288" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2293" entity_table="civicrm_financial_type" entity_id="288" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2294" entity_table="civicrm_financial_type" entity_id="288" account_relationship="1" financial_account_id="296" />
+    <civicrm_entity_financial_account id="2295" entity_table="civicrm_financial_type" entity_id="289" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2296" entity_table="civicrm_financial_type" entity_id="289" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2297" entity_table="civicrm_financial_type" entity_id="289" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2298" entity_table="civicrm_financial_type" entity_id="289" account_relationship="1" financial_account_id="297" />
+    <civicrm_entity_financial_account id="2299" entity_table="civicrm_financial_type" entity_id="290" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2300" entity_table="civicrm_financial_type" entity_id="290" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2301" entity_table="civicrm_financial_type" entity_id="290" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2302" entity_table="civicrm_financial_type" entity_id="290" account_relationship="1" financial_account_id="298" />
+    <civicrm_entity_financial_account id="2303" entity_table="civicrm_financial_type" entity_id="291" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2304" entity_table="civicrm_financial_type" entity_id="291" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2305" entity_table="civicrm_financial_type" entity_id="291" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2306" entity_table="civicrm_financial_type" entity_id="291" account_relationship="1" financial_account_id="299" />
+    <civicrm_entity_financial_account id="2307" entity_table="civicrm_financial_type" entity_id="292" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2308" entity_table="civicrm_financial_type" entity_id="292" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2309" entity_table="civicrm_financial_type" entity_id="292" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2310" entity_table="civicrm_financial_type" entity_id="292" account_relationship="1" financial_account_id="300" />
+    <civicrm_entity_financial_account id="2311" entity_table="civicrm_financial_type" entity_id="293" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2312" entity_table="civicrm_financial_type" entity_id="293" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2313" entity_table="civicrm_financial_type" entity_id="293" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2314" entity_table="civicrm_financial_type" entity_id="293" account_relationship="1" financial_account_id="301" />
+    <civicrm_entity_financial_account id="2315" entity_table="civicrm_financial_type" entity_id="294" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2316" entity_table="civicrm_financial_type" entity_id="294" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2317" entity_table="civicrm_financial_type" entity_id="294" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2318" entity_table="civicrm_financial_type" entity_id="294" account_relationship="1" financial_account_id="302" />
+    <civicrm_entity_financial_account id="2319" entity_table="civicrm_financial_type" entity_id="295" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2320" entity_table="civicrm_financial_type" entity_id="295" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2321" entity_table="civicrm_financial_type" entity_id="295" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2322" entity_table="civicrm_financial_type" entity_id="295" account_relationship="1" financial_account_id="303" />
+    <civicrm_entity_financial_account id="2323" entity_table="civicrm_financial_type" entity_id="296" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2324" entity_table="civicrm_financial_type" entity_id="296" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2325" entity_table="civicrm_financial_type" entity_id="296" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2326" entity_table="civicrm_financial_type" entity_id="296" account_relationship="1" financial_account_id="304" />
+    <civicrm_entity_financial_account id="2327" entity_table="civicrm_financial_type" entity_id="297" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2328" entity_table="civicrm_financial_type" entity_id="297" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2329" entity_table="civicrm_financial_type" entity_id="297" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2330" entity_table="civicrm_financial_type" entity_id="297" account_relationship="1" financial_account_id="305" />
+    <civicrm_entity_financial_account id="2331" entity_table="civicrm_financial_type" entity_id="298" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2332" entity_table="civicrm_financial_type" entity_id="298" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2333" entity_table="civicrm_financial_type" entity_id="298" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2334" entity_table="civicrm_financial_type" entity_id="298" account_relationship="1" financial_account_id="306" />
+    <civicrm_entity_financial_account id="2335" entity_table="civicrm_financial_type" entity_id="299" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2336" entity_table="civicrm_financial_type" entity_id="299" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2337" entity_table="civicrm_financial_type" entity_id="299" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2338" entity_table="civicrm_financial_type" entity_id="299" account_relationship="1" financial_account_id="307" />
+    <civicrm_entity_financial_account id="2339" entity_table="civicrm_financial_type" entity_id="300" account_relationship="3" financial_account_id="7" />
+    <civicrm_entity_financial_account id="2340" entity_table="civicrm_financial_type" entity_id="300" account_relationship="5" financial_account_id="5" />
+    <civicrm_entity_financial_account id="2341" entity_table="civicrm_financial_type" entity_id="300" account_relationship="7" financial_account_id="9" />
+    <civicrm_entity_financial_account id="2342" entity_table="civicrm_financial_type" entity_id="300" account_relationship="1" financial_account_id="308" />
+    <civicrm_entity_financial_account id="2343" entity_table="civicrm_financial_type" entity_id="294" account_relationship="10" financial_account_id="309" />
+    <civicrm_entity_financial_account id="2344" entity_table="civicrm_financial_type" entity_id="295" account_relationship="10" financial_account_id="309" />
+    <civicrm_entity_financial_account id="2345" entity_table="civicrm_financial_type" entity_id="296" account_relationship="10" financial_account_id="309" />
+    <civicrm_entity_financial_account id="2346" entity_table="civicrm_financial_type" entity_id="293" account_relationship="10" financial_account_id="309" />
+    <civicrm_entity_financial_account id="2347" entity_table="civicrm_financial_type" entity_id="297" account_relationship="10" financial_account_id="309" />
+    <civicrm_entity_financial_account id="2348" entity_table="civicrm_financial_type" entity_id="290" account_relationship="10" financial_account_id="309" />
+    <civicrm_entity_financial_account id="2349" entity_table="civicrm_financial_type" entity_id="291" account_relationship="10" financial_account_id="309" />
+    <civicrm_entity_financial_account id="2350" entity_table="civicrm_financial_type" entity_id="292" account_relationship="10" financial_account_id="309" />
+    <civicrm_entity_financial_account id="2351" entity_table="civicrm_financial_type" entity_id="287" account_relationship="10" financial_account_id="309" />
+    <civicrm_entity_financial_account id="2352" entity_table="civicrm_financial_type" entity_id="288" account_relationship="10" financial_account_id="309" />
+    <civicrm_entity_financial_account id="2353" entity_table="civicrm_financial_type" entity_id="289" account_relationship="10" financial_account_id="309" />
+
+
+
+
+
+
+
+
+</dataset>
+

--- a/tests/phpunit/CRM/Member/Form/dataset/price_set_renewal_expected.xml
+++ b/tests/phpunit/CRM/Member/Form/dataset/price_set_renewal_expected.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--  $Id: data.xml 43570 2012-11-09 12:03:45Z deepak $ -->
+<dataset>
+
+    <!-- new membership, gets current year -->
+    <memberships_etc    membership_type_id="161"                join_date="special-now-3m"      start_date="special-memyear-01-01"         end_date="special-memyear-12-31"
+                        mem_status_id="1"
+
+                        con_financial_type_id="2"               payment_instrument_id="2"   total_amount="206.85"           fee_amount="1.50"
+                        net_amount="205.35"                     con_currency="USD"          contribution_status_id="1"      trxn_id_ln="20"
+                        invoice_id_ln="32"
+
+                        qty="1.00"                              unit_price="20.00"          line_total="20.00"
+                        lit_financial_type_id="240"
+
+                        created_date="special-now"              transaction_date="special-now-3m"
+                        description="Canadian Society for Chemical Engineering (CSChE) (taxable)"
+                        amount="20.00"
+                        fit_currency="USD"                      financial_account_id="249"  fit_status_id="1"/>
+
+
+    <!-- new membership, gets current year -->
+    <memberships_etc    membership_type_id="162"                join_date="special-now-3m"      start_date="special-memyear-01-01"         end_date="special-memyear-12-31"
+                        mem_status_id="1"
+
+                        con_financial_type_id="2"               payment_instrument_id="2"   total_amount="206.85"           fee_amount="1.50"
+                        net_amount="205.35"                     con_currency="USD"          contribution_status_id="1"      trxn_id_ln="20"
+                        invoice_id_ln="32"
+
+                        qty="1.00"                              unit_price="20.00"          line_total="20.00"
+                        lit_financial_type_id="242"
+
+                        created_date="special-now"              transaction_date="special-now-3m"
+                        description="Canadian Society for Chemical Technology (CSCT) (taxable)"
+                        amount="20.00"
+
+                        fit_currency="USD"                      financial_account_id="251"  fit_status_id="1"/>
+
+
+    <!-- existing membership, simply gets extended by 1.  So because manually created to expire based on cyrrent year, will now go after current year. -->
+    <memberships_etc    membership_type_id="163"                join_date="special-now-3m"      start_date="special-now-3m"         end_date="special-now+9m"
+                        mem_status_id="1"
+
+                        con_financial_type_id="2"               payment_instrument_id="2"   total_amount="206.85"           fee_amount="1.50"
+                        net_amount="205.35"                     con_currency="USD"          contribution_status_id="1"      trxn_id_ln="20"
+                        invoice_id_ln="32"
+
+                        qty="1.00"                              unit_price="0.00"           line_total="0.00"
+                        lit_financial_type_id="237"
+
+                        created_date="special-now"              transaction_date="special-now-3m"
+                        description="Print and Online"
+                        amount="0.00"
+
+                        fit_currency="USD"                      financial_account_id="246"  fit_status_id="1"/>
+
+
+    <memberships_etc    membership_type_id="199"                join_date="special-now-3m"      start_date="special-now-3m"         end_date="special-now+9m"
+                        mem_status_id="1"
+
+                        con_financial_type_id="2"               payment_instrument_id="2"   total_amount="206.85"           fee_amount="1.50"
+                        net_amount="205.35"                     con_currency="USD"          contribution_status_id="1"      trxn_id_ln="20"
+                        invoice_id_ln="32"
+
+                        qty="1.00"                              unit_price="157.00"         line_total="157.00"
+                        lit_financial_type_id="191"
+
+                        created_date="special-now"              transaction_date="special-now-3m"
+                        description="CSC Full Fee (taxable)"
+                        amount="157.00"
+
+                        fit_currency="USD"                     fit_status_id="1"/>
+
+
+
+</dataset>

--- a/tests/phpunit/WebTest/Import/MemberTest.php
+++ b/tests/phpunit/WebTest/Import/MemberTest.php
@@ -78,7 +78,7 @@ class WebTest_Import_MemberTest extends ImportCiviSeleniumTestCase {
   }
 
   /**
-   * Helper function to provide data for Membeship import for Individuals.
+   * Helper function to provide data for Membership import for Individuals.
    *
    * @return array
    */
@@ -124,7 +124,7 @@ class WebTest_Import_MemberTest extends ImportCiviSeleniumTestCase {
   }
 
   /**
-   * Helper function to provide data for Membeship import for Households.
+   * Helper function to provide data for Membership import for Households.
    *
    * @return array
    */
@@ -168,7 +168,7 @@ class WebTest_Import_MemberTest extends ImportCiviSeleniumTestCase {
   }
 
   /**
-   * Helper function to provide data for Membeship import for Organizations.
+   * Helper function to provide data for Membership import for Organizations.
    *
    * @return array
    */


### PR DESCRIPTION
This is take two of previous request.  I had last night messed up with a git merge after fetch / rebase instead of git push -f

I expect a few more code style nitpicking, will get those in when they come.

Even though I still don't like that a "non-single membership specific action" is triggered by using an action next to a specific membership, the new flow _is_, after functional review from @agh1, @nganivet, and Virginie (can't find her moniker), _much_ better.  It is more inline with current flows, and doesn't clutter the UI with more buttons as my initial kick at the can.

I will update the JIRA with more details.

---
- [CRM-15861: Offline membership renewal doesn't display priceset choices](https://issues.civicrm.org/jira/browse/CRM-15861)
