### PR TITLE
CRM-19460 - Fix brackets in file uploads

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -640,7 +640,10 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
             $field['data_type'] == 'File' || ($viewOnly && $field['name'] == 'image_URL')
           ) {
             //retrieve file value from submitted values on basis of $profileContactType
-            $fileValue = empty($profileContactType) ? CRM_Utils_Array::value($key, $this->_params) : CRM_Utils_Array::value(sprintf('%s[%s]', $profileContactType, $key), $this->_params);
+            $fileValue = CRM_Utils_Array::value($key, $this->_params);
+            if (!empty($profileContactType) && !empty($this->_params[$profileContactType])) {
+              $fileValue = CRM_Utils_Array::value($key, $this->_params[$profileContactType]);
+            }
 
             if ($fileValue) {
               $path = CRM_Utils_Array::value('name', $fileValue);

--- a/CRM/Core/QuickForm/Action/Upload.php
+++ b/CRM/Core/QuickForm/Action/Upload.php
@@ -105,10 +105,13 @@ class CRM_Core_QuickForm_Action_Upload extends CRM_Core_QuickForm_Action {
           @unlink($this->_uploadDir . $data['values'][$pageName][$uploadName]);
         }
 
-        $data['values'][$pageName][$uploadName] = array(
+        $value = array(
           'name' => $this->_uploadDir . $newName,
           'type' => $value['type'],
         );
+        //CRM-19460 handle brackets if present in $uploadName, similar things we do it for all other inputs.
+        $value = $element->_prepareValue($value, TRUE);
+        $data['values'][$pageName] = HTML_QuickForm::arrayMerge($data['values'][$pageName], $value);
       }
     }
   }


### PR DESCRIPTION
Current code does not handle the case when bracket is present in file uploads : 

Eg: An element with name `onbehalf['file_input']` would be exported as `$params[onbehalf['file_input']] = $val` instead of `$params[onbehalf]['file_input'] = $val`.

All other inputs are passed through `_prepareValue()` function where this handling is being done except file input.
- [CRM-19460: Custom field(file type) included in onbehalf profile is not saved](https://issues.civicrm.org/jira/browse/CRM-19460)
