### PR TITLE
CRM-19470 - Notice Fix upon event registration

### DIFF
--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -1722,7 +1722,7 @@ WHERE       ps.id = %1
     $priceSetParams = array();
     foreach ($params as $field => $value) {
       $parts = explode('_', $field);
-      if (count($parts) == 2 && $parts[0] == 'price' && is_numeric($parts[1])) {
+      if (count($parts) == 2 && $parts[0] == 'price' && is_numeric($parts[1]) && is_array($value)) {
         $priceSetParams[$field] = $value;
       }
     }


### PR DESCRIPTION
As we retrieve all the [$priceSetValue ids from the keys of `$value`](https://github.com/civicrm/civicrm-core/blob/master/CRM/Price/BAO/PriceSet.php#L1706), this PR makes sure it is always pushed as an array.
- [CRM-19470: Error upon event registration](https://issues.civicrm.org/jira/browse/CRM-19470)
