### PR TITLE
Revert "CRM-19245 - Wrap title and description on manage group page"

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -3273,7 +3273,6 @@ div.m ul#civicrm-menu,
   padding-left: 2px;
   border: 2px dashed transparent;
 }
-
 .crm-container .crm-editable-textarea-enabled {
   white-space: normal;
 }
@@ -3373,11 +3372,6 @@ div.m ul#civicrm-menu,
 }
 #crm-container .crm-group-name span.crm-editable-enabled {
   text-indent: 0;
-}
-
-#crm-container .crm-group-name .crm-editable-enabled,
-#crm-container .crm-group-description .crm-editable-enabled{
-  white-space: normal;
 }
 
 #crm-container div.crm-row-parent-name {


### PR DESCRIPTION
This reverts commit 5b2b04cb0d864c637748be99a0282400d80e0317.

Superceded by https://github.com/civicrm/civicrm-core/pull/9173

---
- [CRM-19245: Text no longer wraps in name and description fields on Manage Groups page](https://issues.civicrm.org/jira/browse/CRM-19245)
