### PR TITLE
CRM-19487 Tidy up contact reports to fix contact subtype not displaying correctly

### DIFF
--- a/CRM/Report/Form/Contact/CurrentEmployer.php
+++ b/CRM/Report/Form/Contact/CurrentEmployer.php
@@ -352,6 +352,7 @@ FROM civicrm_contact {$this->_aliases['civicrm_contact']}
           $this->_absoluteUrl, $this->_id, $this->_drilldownReport
         );
         $rows[$rowNum]['civicrm_employer_organization_name_link'] = $url;
+        $rows[$rowNum]['civicrm_employer_organization_name_hover'] = ts('View Contact Detail Report for this contact');
         $entryFound = TRUE;
       }
 
@@ -371,14 +372,8 @@ FROM civicrm_contact {$this->_aliases['civicrm_contact']}
         }
       }
 
-      //handle gender
-      if (array_key_exists('civicrm_contact_gender_id', $row)) {
-        if ($value = $row['civicrm_contact_gender_id']) {
-          $gender = CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'gender_id');
-          $rows[$rowNum]['civicrm_contact_gender_id'] = $gender[$value];
-        }
-        $entryFound = TRUE;
-      }
+      // Handle ID to label conversion for contact fields
+      $entryFound = $this->alterDisplayContactFields($row, $rows, $rowNum, 'contact/currentEmployer', 'View Contact Detail') ? TRUE : $entryFound;
 
       // display birthday in the configured custom format
       if (array_key_exists('civicrm_contact_birth_date', $row)) {
@@ -390,14 +385,15 @@ FROM civicrm_contact {$this->_aliases['civicrm_contact']}
       }
 
       // convert employee name to links
-      if (array_key_exists('civicrm_contact_display_name', $row) &&
+      if (array_key_exists('civicrm_contact_sort_name', $row) &&
         array_key_exists('civicrm_contact_id', $row)
       ) {
         $url = CRM_Report_Utils_Report::getNextUrl('contact/detail',
           'reset=1&force=1&id_op=eq&id_value=' . $row['civicrm_contact_id'],
           $this->_absoluteUrl, $this->_id, $this->_drilldownReport
         );
-        $rows[$rowNum]['civicrm_contact_display_name_link'] = $url;
+        $rows[$rowNum]['civicrm_contact_sort_name_link'] = $url;
+        $rows[$rowNum]['civicrm_contact_sort_name_hover'] = ts('View Contact Detail Report for this contact');
         $entryFound = TRUE;
       }
 

--- a/CRM/Report/Form/Contact/Detail.php
+++ b/CRM/Report/Form/Contact/Detail.php
@@ -854,7 +854,7 @@ class CRM_Report_Form_Contact_Detail extends CRM_Report_Form {
       }
 
       // Handle ID to label conversion for contact fields
-      $entryFound = $this->alterDisplayContactFields($row, $rows, $rowNum, 'contact/detail', 'View Contact Detail') ? TRUE : $entryFound;
+      $entryFound = $this->alterDisplayContactFields($row, $rows, $rowNum, NULL, NULL) ? TRUE : $entryFound;
 
       // display birthday in the configured custom format
       if (array_key_exists('civicrm_contact_birth_date', $row)) {

--- a/CRM/Report/Form/Contact/Detail.php
+++ b/CRM/Report/Form/Contact/Detail.php
@@ -849,18 +849,12 @@ class CRM_Report_Form_Contact_Detail extends CRM_Report_Form {
           $this->_absoluteUrl
         );
         $rows[$rowNum]['civicrm_contact_sort_name_link'] = $url;
-        $rows[$rowNum]['civicrm_contact_sort_name_hover'] = ts('View Contact Summary for this Contact');
+        $rows[$rowNum]['civicrm_contact_sort_name_hover'] = ts('View Contact Record');
         $entryFound = TRUE;
       }
 
-      //handle gender
-      if (array_key_exists('civicrm_contact_gender_id', $row)) {
-        if ($value = $row['civicrm_contact_gender_id']) {
-          $gender = CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'gender_id');
-          $rows[$rowNum]['civicrm_contact_gender_id'] = $gender[$value];
-        }
-        $entryFound = TRUE;
-      }
+      // Handle ID to label conversion for contact fields
+      $entryFound = $this->alterDisplayContactFields($row, $rows, $rowNum, 'contact/detail', 'View Contact Detail') ? TRUE : $entryFound;
 
       // display birthday in the configured custom format
       if (array_key_exists('civicrm_contact_birth_date', $row)) {

--- a/CRM/Report/Form/Contact/Relationship.php
+++ b/CRM/Report/Form/Contact/Relationship.php
@@ -633,6 +633,7 @@ class CRM_Report_Form_Contact_Relationship extends CRM_Report_Form {
       $entryFound = $this->alterDisplayContactFields($row, $rows, $rowNum, 'contact/relationship', 'View Relationships') ? TRUE : $entryFound;
 
       // Handle contact subtype A
+      // @todo refactor into separate function
       if (array_key_exists('civicrm_contact_contact_sub_type_a', $row)) {
         if ($value = $row['civicrm_contact_contact_sub_type_a']) {
           $rowValues = explode(CRM_Core_DAO::VALUE_SEPARATOR, $value);
@@ -648,6 +649,7 @@ class CRM_Report_Form_Contact_Relationship extends CRM_Report_Form {
       }
 
       // Handle contact subtype B
+      // @todo refactor into separate function
       if (array_key_exists('civicrm_contact_b_contact_sub_type_b', $row)) {
         if ($value = $row['civicrm_contact_b_contact_sub_type_b']) {
           $rowValues = explode(CRM_Core_DAO::VALUE_SEPARATOR, $value);
@@ -662,7 +664,8 @@ class CRM_Report_Form_Contact_Relationship extends CRM_Report_Form {
         $entryFound = TRUE;
       }
 
-      // Handle country.
+      // Handle country
+      // @todo use alterDisplayAddressFields function
       if (array_key_exists('civicrm_address_country_id', $row)) {
         if ($value = $row['civicrm_address_country_id']) {
           $rows[$rowNum]['civicrm_address_country_id'] = CRM_Core_PseudoConstant::country($value, FALSE);
@@ -670,6 +673,8 @@ class CRM_Report_Form_Contact_Relationship extends CRM_Report_Form {
         $entryFound = TRUE;
       }
 
+      // Handle state/province
+      // @todo use alterDisplayAddressFields function
       if (array_key_exists('civicrm_address_state_province_id', $row)) {
         if ($value = $row['civicrm_address_state_province_id']) {
           $rows[$rowNum]['civicrm_address_state_province_id'] = CRM_Core_PseudoConstant::stateProvince($value, FALSE);
@@ -677,6 +682,8 @@ class CRM_Report_Form_Contact_Relationship extends CRM_Report_Form {
         $entryFound = TRUE;
       }
 
+      // Handle contact name A
+      // @todo refactor into separate function
       if (array_key_exists('civicrm_contact_sort_name_a', $row) &&
         array_key_exists('civicrm_contact_id', $row)
       ) {
@@ -692,6 +699,8 @@ class CRM_Report_Form_Contact_Relationship extends CRM_Report_Form {
         $entryFound = TRUE;
       }
 
+      // Handle contact name B
+      // @todo refactor into separate function
       if (array_key_exists('civicrm_contact_b_sort_name_b', $row) &&
         array_key_exists('civicrm_contact_b_id', $row)
       ) {
@@ -707,6 +716,7 @@ class CRM_Report_Form_Contact_Relationship extends CRM_Report_Form {
         $entryFound = TRUE;
       }
 
+      // Handle relationship
       if (array_key_exists('civicrm_relationship_relationship_id', $row) &&
         array_key_exists('civicrm_contact_id', $row)
       ) {

--- a/CRM/Report/Form/Contact/Relationship.php
+++ b/CRM/Report/Form/Contact/Relationship.php
@@ -629,6 +629,39 @@ class CRM_Report_Form_Contact_Relationship extends CRM_Report_Form {
 
     foreach ($rows as $rowNum => $row) {
 
+      // Handle ID to label conversion for contact fields
+      $entryFound = $this->alterDisplayContactFields($row, $rows, $rowNum, 'contact/relationship', 'View Relationships') ? TRUE : $entryFound;
+
+      // Handle contact subtype A
+      if (array_key_exists('civicrm_contact_contact_sub_type_a', $row)) {
+        if ($value = $row['civicrm_contact_contact_sub_type_a']) {
+          $rowValues = explode(CRM_Core_DAO::VALUE_SEPARATOR, $value);
+          $rowLabels = array();
+          foreach ($rowValues as $rowValue) {
+            if ($rowValue) {
+              $rowLabels[] = CRM_Core_Pseudoconstant::getLabel('CRM_Contact_BAO_Contact', 'contact_sub_type', $rowValue);
+            }
+          }
+          $rows[$rowNum]['civicrm_contact_contact_sub_type_a'] = implode(', ', $rowLabels);
+        }
+        $entryFound = TRUE;
+      }
+
+      // Handle contact subtype B
+      if (array_key_exists('civicrm_contact_b_contact_sub_type_b', $row)) {
+        if ($value = $row['civicrm_contact_b_contact_sub_type_b']) {
+          $rowValues = explode(CRM_Core_DAO::VALUE_SEPARATOR, $value);
+          $rowLabels = array();
+          foreach ($rowValues as $rowValue) {
+            if ($rowValue) {
+              $rowLabels[] = CRM_Core_Pseudoconstant::getLabel('CRM_Contact_BAO_Contact', 'contact_sub_type', $rowValue);
+            }
+          }
+          $rows[$rowNum]['civicrm_contact_b_contact_sub_type_b'] = implode(', ', $rowLabels);
+        }
+        $entryFound = TRUE;
+      }
+
       // Handle country.
       if (array_key_exists('civicrm_address_country_id', $row)) {
         if ($value = $row['civicrm_address_country_id']) {
@@ -655,7 +688,7 @@ class CRM_Report_Form_Contact_Relationship extends CRM_Report_Form {
           = $rows[$rowNum]['civicrm_contact_sort_name_a'] . ' (' .
           $rows[$rowNum]['civicrm_contact_id'] . ')';
         $rows[$rowNum]['civicrm_contact_sort_name_a_link'] = $url;
-        $rows[$rowNum]['civicrm_contact_sort_name_a_hover'] = ts("View Contact details for this contact.");
+        $rows[$rowNum]['civicrm_contact_sort_name_a_hover'] = ts('View Contact Detail Report for this contact');
         $entryFound = TRUE;
       }
 
@@ -670,18 +703,7 @@ class CRM_Report_Form_Contact_Relationship extends CRM_Report_Form {
           = $rows[$rowNum]['civicrm_contact_b_sort_name_b'] . ' (' .
           $rows[$rowNum]['civicrm_contact_b_id'] . ')';
         $rows[$rowNum]['civicrm_contact_b_sort_name_b_link'] = $url;
-        $rows[$rowNum]['civicrm_contact_b_sort_name_b_hover'] = ts("View Contact details for this contact.");
-        $entryFound = TRUE;
-      }
-
-      if (array_key_exists('civicrm_relationship_relationship_id', $row) &&
-        array_key_exists('civicrm_contact_id', $row)
-      ) {
-        $url = "/civicrm/contact/view/rel?reset=1&action=update&rtype=a_b&cid=" .
-          $row['civicrm_contact_id'] . "&id=" .
-          $row['civicrm_relationship_relationship_id'];
-        $rows[$rowNum]['civicrm_relationship_relationship_id_link'] = $url;
-        $rows[$rowNum]['civicrm_relationship_relationship_id_hover'] = ts("Edit this relationship.");
+        $rows[$rowNum]['civicrm_contact_b_sort_name_b_hover'] = ts('View Contact Detail Report for this contact');
         $entryFound = TRUE;
       }
 

--- a/CRM/Report/Form/Contact/Relationship.php
+++ b/CRM/Report/Form/Contact/Relationship.php
@@ -707,6 +707,17 @@ class CRM_Report_Form_Contact_Relationship extends CRM_Report_Form {
         $entryFound = TRUE;
       }
 
+      if (array_key_exists('civicrm_relationship_relationship_id', $row) &&
+        array_key_exists('civicrm_contact_id', $row)
+      ) {
+        $url = "/civicrm/contact/view/rel?reset=1&action=update&rtype=a_b&cid=" .
+          $row['civicrm_contact_id'] . "&id=" .
+          $row['civicrm_relationship_relationship_id'];
+        $rows[$rowNum]['civicrm_relationship_relationship_id_link'] = $url;
+        $rows[$rowNum]['civicrm_relationship_relationship_id_hover'] = ts("Edit this relationship.");
+        $entryFound = TRUE;
+      }
+
       // skip looking further in rows, if first row itself doesn't
       // have the column we need
       if (!$entryFound) {

--- a/CRM/Report/Form/Contact/Summary.php
+++ b/CRM/Report/Form/Contact/Summary.php
@@ -255,7 +255,7 @@ class CRM_Report_Form_Contact_Summary extends CRM_Report_Form {
           $this->_absoluteUrl, $this->_id, $this->_drilldownReport
         );
         $rows[$rowNum]['civicrm_contact_sort_name_link'] = $url;
-        $rows[$rowNum]['civicrm_contact_sort_name_hover'] = ts("View Constituent Detail Report for this contact.");
+        $rows[$rowNum]['civicrm_contact_sort_name_hover'] = ts('View Contact Detail Report for this contact');
         $entryFound = TRUE;
       }
 


### PR DESCRIPTION
This fixes an issue where the contact subtype was not displaying correctly on contact reports.

It is very similar to the bug reported in https://issues.civicrm.org/jira/browse/CRM-19337 which relates to the Constituency Summary report.  This was fixed in PR #9212.

This patch fixes the same bug in the following reports:
- Constituency Detail
- Current Employers
- Relationships

---
- [CRM-19487: Contact subtype not displaying correctly in Contact reports](https://issues.civicrm.org/jira/browse/CRM-19487)
