### PR TITLE
CRM-19495 Ensure that no dots appear at the bottom of menu links in d8

### DIFF
--- a/css/civicrmNavigation.css
+++ b/css/civicrmNavigation.css
@@ -91,6 +91,7 @@ li.menu-separator.active{
   display:block;
   font-weight:normal;
   text-decoration:none;
+  border-bottom-style:none;
 }
 
 * html div.menu-item {

--- a/css/civicrmNavigation.css
+++ b/css/civicrmNavigation.css
@@ -91,7 +91,7 @@ li.menu-separator.active{
   display:block;
   font-weight:normal;
   text-decoration:none;
-  border-bottom-style:none;
+  border:0;
 }
 
 * html div.menu-item {


### PR DESCRIPTION
- [CRM-19495: D8 Ensure that menu links do not have dots underneath them](https://issues.civicrm.org/jira/browse/CRM-19495)
