### PR TITLE
CRM-7265, CRM-14207 - Store relative URLs in the database field when …

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -1024,7 +1024,7 @@ WHERE id={$id}; ";
 
     if (in_array($params[$imageIndex]['type'], $mimeType)) {
       $photo = basename($params[$imageIndex]['name']);
-      $params[$imageIndex] = CRM_Utils_System::url('civicrm/contact/imagefile', 'photo=' . $photo, TRUE, NULL, TRUE, TRUE);
+      $params[$imageIndex] = CRM_Utils_System::url('civicrm/contact/imagefile', 'photo=' . $photo, FALSE, NULL, TRUE, TRUE);
       return TRUE;
     }
     else {

--- a/CRM/Contact/Page/View.php
+++ b/CRM/Contact/Page/View.php
@@ -160,12 +160,7 @@ class CRM_Contact_Page_View extends CRM_Core_Page {
     CRM_Utils_System::appendBreadCrumb(array(array('title' => ts('View Contact'), 'url' => $path)));
 
     if ($image_URL = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $this->_contactId, 'image_URL')) {
-      //CRM-7265 --time being fix.
-      $config = CRM_Core_Config::singleton();
-      $image_URL = str_replace('https://', 'http://', $image_URL);
-      if (Civi::settings()->get('enableSSL')) {
-        $image_URL = str_replace('http://', 'https://', $image_URL);
-      }
+      $image_URL = CRM_Utils_System::absoluteURL($image_URL);
 
       list($imageWidth, $imageHeight) = getimagesize(CRM_Utils_String::unstupifyUrl($image_URL));
       list($imageThumbWidth, $imageThumbHeight) = CRM_Contact_BAO_Contact::getThumbSize($imageWidth, $imageHeight);


### PR DESCRIPTION
Creates dynamic image URL in the database, otherwise URL are hard coded (http(s)://domain/) into the image field in the database. Adjusted the existing HTTPs and HTTP replace code which appears no longer required, as the absolute URL will dynamically select HTTP or HTTPs depending on the protocol being accessed (tested both scenarios). The PHP getimagesize function relies on an absolute URL being present, or will produce PHP warning messages.
