### PR TITLE
CRM-19500 - Fix api runAuthorize

### DIFF
--- a/Civi/API/Kernel.php
+++ b/Civi/API/Kernel.php
@@ -130,7 +130,7 @@ class Kernel {
     $apiRequest = Request::create($entity, $action, $params, $extra);
 
     try {
-      $this->boot();
+      $this->boot($apiRequest);
       list($apiProvider, $apiRequest) = $this->resolve($apiRequest);
       $this->authorize($apiProvider, $apiRequest);
       return TRUE;

--- a/tests/phpunit/api/v3/AddressTest.php
+++ b/tests/phpunit/api/v3/AddressTest.php
@@ -348,4 +348,20 @@ class api_v3_AddressTest extends CiviUnitTestCase {
     $this->callAPISuccess('address', 'delete', array('id' => $address1['id']));
   }
 
+  public function testGetWithJoin() {
+    $cid = $this->individualCreate(array(
+      'api.Address.create' => array(
+        'street_address' => __FUNCTION__,
+        'location_type_id' => $this->_locationType->id,
+      ),
+    ));
+    $result = $this->callAPISuccess('address', 'getsingle', array(
+      'check_permissions' => TRUE,
+      'contact_id' => $cid,
+      'street_address' => __FUNCTION__,
+      'return' => 'contact_id.contact_type',
+    ));
+    $this->assertEquals('Individual', $result['contact_id.contact_type']);
+  }
+
 }


### PR DESCRIPTION
- [CRM-19500: API regression - joins no longer work in api explorer - pretty sure it's from the api v4 patch merged yesterday](https://issues.civicrm.org/jira/browse/CRM-19500)
