### PR TITLE
CRM-18549 - Don't store empty array value of a setting as NULL.

### DIFF
--- a/Civi/Core/SettingsBag.php
+++ b/Civi/Core/SettingsBag.php
@@ -364,7 +364,7 @@ class SettingsBag {
       }
     }
 
-    if (\CRM_Utils_System::isNull($value)) {
+    if (!is_array($value) && \CRM_Utils_System::isNull($value)) {
       $dao->value = 'null';
     }
     else {


### PR DESCRIPTION
- [CRM-18549: The last remaining enabled component cannot be disabled.](https://issues.civicrm.org/jira/browse/CRM-18549)
