### PR TITLE
CRM-18549 - Don't store empty array value of a setting as NULL.

### DIFF
--- a/CRM/Core/BAO/Setting.php
+++ b/CRM/Core/BAO/Setting.php
@@ -430,8 +430,7 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
         );
       }
     }
-
-    if (CRM_Utils_System::isNull($value)) {
+    if (!is_array($value) && CRM_Utils_System::isNull($value)) {
       $dao->value = 'null';
     }
     else {


### PR DESCRIPTION
- [CRM-18549: The last remaining enabled component cannot be disabled.](https://issues.civicrm.org/jira/browse/CRM-18549)
