### PR TITLE
CRM-19497 Fix PHP notice on Activity Summary Report

### DIFF
--- a/CRM/Report/Form/ActivitySummary.php
+++ b/CRM/Report/Form/ActivitySummary.php
@@ -659,7 +659,6 @@ class CRM_Report_Form_ActivitySummary extends CRM_Report_Form {
     $entryFound = FALSE;
     $activityType = CRM_Core_PseudoConstant::activityType(TRUE, TRUE, FALSE, 'label', TRUE);
     $activityStatus = CRM_Core_PseudoConstant::activityStatus();
-    $flagContact = 0;
     $onHover = ts('View Contact Summary for this Contact');
     foreach ($rows as $rowNum => $row) {
       // make count columns point to activity detail report
@@ -703,21 +702,8 @@ class CRM_Report_Form_ActivitySummary extends CRM_Report_Form {
       if (array_key_exists('civicrm_contact_sort_name', $row) && $this->_outputMode != 'csv') {
         if ($value = $row['civicrm_contact_id']) {
 
-          if ($rowNum == 0) {
-            $priviousContact = $value;
-          }
-          else {
-            if ($priviousContact == $value) {
-              $flagContact = 1;
-              $priviousContact = $value;
-            }
-            else {
-              $flagContact = 0;
-              $priviousContact = $value;
-            }
-          }
-
-          if ($flagContact == 1) {
+          // unset the name, email and phone fields if the contact is the same as the previous contact
+          if (isset($previousContact) && $previousContact == $value) {
             $rows[$rowNum]['civicrm_contact_sort_name'] = "";
 
             if (array_key_exists('civicrm_email_email', $row)) {
@@ -736,6 +722,9 @@ class CRM_Report_Form_ActivitySummary extends CRM_Report_Form {
             $rows[$rowNum]['civicrm_contact_sort_name'] = "<a href='$url'>" . $row['civicrm_contact_sort_name'] .
               '</a>';
           }
+
+          // store the contact ID of this contact
+          $previousContact = $value;
           $entryFound = TRUE;
         }
       }


### PR DESCRIPTION
Rewrote the code that checks for a previous contact to avoid a PHP notice for an undefined variable.

---
- [CRM-19497: PHP notice on Activity Summary Report](https://issues.civicrm.org/jira/browse/CRM-19497)
