### PR TITLE
CRM-19494 Refactoring of permission code

### DIFF
--- a/CRM/ACL/API.php
+++ b/CRM/ACL/API.php
@@ -84,6 +84,10 @@ class CRM_ACL_API {
    * @param bool $skipDeleteClause
    *   Don't add delete clause if this is true,.
    *   this means it is handled by generating query
+   * @param bool $skipOwnContactClause
+   *   Do not add 'OR contact_id = $userID' to the where clause.
+   *   This is a hideously inefficient query and should be avoided
+   *   wherever possible.
    *
    * @return string
    *   the group where clause for this user
@@ -94,7 +98,8 @@ class CRM_ACL_API {
     &$whereTables,
     $contactID = NULL,
     $onlyDeleted = FALSE,
-    $skipDeleteClause = FALSE
+    $skipDeleteClause = FALSE,
+    $skipOwnContactClause = FALSE
   ) {
     // the default value which is valid for the final AND
     $deleteClause = ' ( 1 ) ';
@@ -131,9 +136,9 @@ class CRM_ACL_API {
       )
     );
 
-    // Add permission on self
-    if ($contactID && (CRM_Core_Permission::check('edit my contact') ||
-      $type == self::VIEW && CRM_Core_Permission::check('view my contact'))
+    // Add permission on self if we really hate our server or have hardly any contacts.
+    if (!$skipOwnContactClause && $contactID && (CRM_Core_Permission::check('edit my contact') ||
+        $type == self::VIEW && CRM_Core_Permission::check('view my contact'))
     ) {
       $where = "(contact_a.id = $contactID OR ($where))";
     }

--- a/CRM/Contact/BAO/Contact/Permission.php
+++ b/CRM/Contact/BAO/Contact/Permission.php
@@ -183,6 +183,7 @@ WHERE contact_a.id = %1 AND $permission
     if (CRM_Core_DAO::singleValueQuery($query, array(1 => array($id, 'Integer')))) {
       return TRUE;
     }
+    return FALSE;
   }
 
   /**

--- a/CRM/Contact/BAO/Contact/Permission.php
+++ b/CRM/Contact/BAO/Contact/Permission.php
@@ -56,8 +56,8 @@ class CRM_Contact_BAO_Contact_Permission {
     $contact_id_list = implode(',', $contact_ids);
 
     // make sure the the general permissions are given
-    if (   $type == CRM_Core_Permission::VIEW && CRM_Core_Permission::check('view all contacts')
-        || $type == CRM_Core_Permission::EDIT && CRM_Core_Permission::check('edit all contacts')
+    if (   CRM_Core_Permission::check('edit all contacts')
+        || $type == CRM_Core_Permission::VIEW && CRM_Core_Permission::check('view all contacts')
       ) {
 
       // if the general permission is there, all good

--- a/CRM/Contact/BAO/Contact/Permission.php
+++ b/CRM/Contact/BAO/Contact/Permission.php
@@ -63,7 +63,7 @@ class CRM_Contact_BAO_Contact_Permission {
 
       // if the general permission is there, all good
       if (CRM_Core_Permission::check('access deleted contacts')) {
-        // if user can access delted contacts -> fine
+        // if user can access deleted contacts -> fine
         return $contact_ids;
       }
       else {
@@ -534,7 +534,6 @@ SELECT second_degree_relationship.contact_id_{$second_direction['to']} AS contac
     while ($result->fetch()) {
       $result_set[(int) $result->contact_id] = TRUE;
     }
-    $keys = array_keys($result_set);
     return array_keys($result_set);
   }
 

--- a/CRM/Contact/BAO/Contact/Permission.php
+++ b/CRM/Contact/BAO/Contact/Permission.php
@@ -33,7 +33,7 @@
 class CRM_Contact_BAO_Contact_Permission {
 
   /**
-   * Check which of the given contact IDs the logged in user 
+   * Check which of the given contact IDs the logged in user
    *   has permissions for the operation type according
    *
    * Caution: general permissions (like 'edit all contacts')
@@ -56,7 +56,7 @@ class CRM_Contact_BAO_Contact_Permission {
     $contact_id_list = implode(',', $contact_ids);
 
     // make sure the the general permissions are given
-    if (   CRM_Core_Permission::check('edit all contacts')
+    if (CRM_Core_Permission::check('edit all contacts')
         || $type == CRM_Core_Permission::VIEW && CRM_Core_Permission::check('view all contacts')
       ) {
 
@@ -64,8 +64,8 @@ class CRM_Contact_BAO_Contact_Permission {
       if (CRM_Core_Permission::check('access deleted contacts')) {
         // if user can access delted contacts -> fine
         return $contact_ids;
-
-      } else {
+      }
+      else {
         // if the user CANNOT access deleted contacts, these need to be filtered
         $filter_query = "SELECT DISTINCT(id) FROM civicrm_contact WHERE id IN ($contact_id_list) AND is_deleted = 0";
         $query = CRM_Core_DAO::executeQuery($filter_query);
@@ -93,7 +93,7 @@ class CRM_Contact_BAO_Contact_Permission {
     $LEFT_JOIN_DELETED = $CAN_ACCESS_DELETED = '';
     if (!CRM_Core_Permission::check('access deleted contacts')) {
       $LEFT_JOIN_DELETED      = "LEFT JOIN civicrm_contact ON civicrm_contact.id = contact_id";
-      $AND_CAN_ACCESS_DELETED = "AND civicrm_contact.is_deleted = 0"; 
+      $AND_CAN_ACCESS_DELETED = "AND civicrm_contact.is_deleted = 0";
     }
 
     // RUN the query
@@ -110,7 +110,7 @@ WHERE contact_id IN ({$contact_id_list})
       $result_set[(int) $result->contact_id] = TRUE;
     }
 
-    // if some have been rejected, double check for permissions inherited by relationship 
+    // if some have been rejected, double check for permissions inherited by relationship
     if (count($result_set) < count($contact_ids)) {
       $rejected_contacts       = array_diff_key($contact_ids, $result_set);
       $allowed_by_relationship = self::relationshipList($rejected_contacts);
@@ -138,8 +138,8 @@ WHERE contact_id IN ({$contact_id_list})
     $contactID = (int) $session->get('userID');
 
     // first: check if contact is trying to view own contact
-    if (   $type == CRM_Core_Permission::VIEW && CRM_Core_Permission::check('view my contact')
-        || $type == CRM_Core_Permission::EDIT && CRM_Core_Permission::check('edit my contact')
+    if ($type == CRM_Core_Permission::VIEW && CRM_Core_Permission::check('view my contact')
+     || $type == CRM_Core_Permission::EDIT && CRM_Core_Permission::check('edit my contact')
       ) {
       return TRUE;
     }
@@ -188,8 +188,9 @@ WHERE contact_a.id = %1 AND $permission";
    *   Should we force a recompute.
    */
   public static function cache($userID, $type = CRM_Core_Permission::VIEW, $force = FALSE) {
-    static $_processed = array( CRM_Core_Permission::VIEW => array(),
-                                CRM_Core_Permission::EDIT => array());
+    static $_processed = array(
+      CRM_Core_Permission::VIEW => array(),
+      CRM_Core_Permission::EDIT => array());
 
     if ($type == CRM_Core_Permission::VIEW) {
       $operationClause = " operation IN ( 'Edit', 'View' ) ";
@@ -437,7 +438,6 @@ WHERE  (( contact_id_a = %1 AND contact_id_b = %2 AND is_permission_a_b = 1 ) OR
   }
 
 
-
   /**
    * Filter a list of contact_ids by the ones that the
    *  currently active user as a permissioned relationship with
@@ -450,7 +450,7 @@ WHERE  (( contact_id_a = %1 AND contact_id_b = %2 AND is_permission_a_b = 1 ) OR
    */
   public static function relationshipList($contact_ids) {
     $result_set = array();
-    
+
     // no processing empty lists (avoid SQL errors as well)
     if (empty($contact_ids)) {
       return array();
@@ -480,7 +480,7 @@ WHERE  (( contact_id_a = %1 AND contact_id_b = %2 AND is_permission_a_b = 1 ) OR
       $LEFT_JOIN_DELETED = $AND_CAN_ACCESS_DELETED = '';
       if (!CRM_Core_Permission::check('access deleted contacts')) {
         $LEFT_JOIN_DELETED       = "LEFT JOIN civicrm_contact ON civicrm_contact.id = {$contact_id_column} ";
-        $AND_CAN_ACCESS_DELETED  = "AND civicrm_contact.is_deleted = 0"; 
+        $AND_CAN_ACCESS_DELETED  = "AND civicrm_contact.is_deleted = 0";
       }
 
       $queries[] = "
@@ -492,8 +492,7 @@ SELECT DISTINCT(civicrm_relationship.{$contact_id_column}) AS contact_id
    AND civicrm_relationship.is_active = 1
    AND civicrm_relationship.is_permission_{$direction['from']}_{$direction['to']} = 1
    $AND_CAN_ACCESS_DELETED";
-    }      
-    
+    }
 
     if ($config->secondDegRelPermissions) {
       // ADD SECOND DEGREE RELATIONSHIPS
@@ -501,7 +500,7 @@ SELECT DISTINCT(civicrm_relationship.{$contact_id_column}) AS contact_id
         foreach ($directions as $first_direction) {
           foreach ($directions as $second_direction) {
             // add clause for deleted contacts, if the user doesn't have the permission to access them
-            $LEFT_JOIN_DELETED = $AND_CAN_ACCESS_DELETED = '';            
+            $LEFT_JOIN_DELETED = $AND_CAN_ACCESS_DELETED = '';
             if (!CRM_Core_Permission::check('access deleted contacts')) {
               $LEFT_JOIN_DELETED       = "LEFT JOIN civicrm_contact first_degree_contact  ON first_degree_contact.id  = second_degree_relationship.contact_id_{$second_direction['from']}\n";
               $LEFT_JOIN_DELETED      .= "LEFT JOIN civicrm_contact second_degree_contact ON second_degree_contact.id = second_degree_relationship.contact_id_{$second_direction['to']} ";
@@ -535,8 +534,6 @@ SELECT DISTINCT(civicrm_relationship.{$contact_id_column}) AS contact_id
     $keys = array_keys($result_set);
     return array_keys($result_set);
   }
-
-
 
 
   /**

--- a/CRM/Contact/BAO/Contact/Permission.php
+++ b/CRM/Contact/BAO/Contact/Permission.php
@@ -165,6 +165,7 @@ WHERE contact_id IN ({$contact_id_list})
       return TRUE;
     }
 
+    // We should probably do a cheap check whether it's in the cache first.
     // check permission based on ACL
     $tables = array();
     $whereTables = array();
@@ -246,45 +247,6 @@ WHERE    $permission
 AND ac.user_id IS NULL
 ");
     $_processed[$type][$userID] = 1;
-  }
-
-  /**
-   * Check if there are any contacts in cache table.
-   *
-   * @param int|string $type the type of operation (view|edit)
-   * @param int $contactID
-   *   Contact id.
-   *
-   * @return bool
-   */
-  public static function hasContactsInCache(
-    $type = CRM_Core_Permission::VIEW,
-    $contactID = NULL
-  ) {
-    if (!$contactID) {
-      $contactID = CRM_Core_Session::getLoggedInContactID();
-    }
-
-    if ($type = CRM_Core_Permission::VIEW) {
-      $operationClause = " operation IN ( 'Edit', 'View' ) ";
-      $operation = 'View';
-    }
-    else {
-      $operationClause = " operation = 'Edit' ";
-      $operation = 'Edit';
-    }
-
-    // fill cache
-    self::cache($contactID);
-
-    $sql = "
-SELECT id
-FROM   civicrm_acl_contact_cache
-WHERE  user_id = %1
-AND    $operationClause LIMIT 1";
-
-    $params = array(1 => array($contactID, 'Integer'));
-    return (bool) CRM_Core_DAO::singleValueQuery($sql, $params);
   }
 
   /**

--- a/CRM/Contact/BAO/Contact/Permission.php
+++ b/CRM/Contact/BAO/Contact/Permission.php
@@ -188,9 +188,10 @@ WHERE contact_a.id = %1 AND $permission";
    *   Should we force a recompute.
    */
   public static function cache($userID, $type = CRM_Core_Permission::VIEW, $force = FALSE) {
-    static $_processed = array();
+    static $_processed = array( CRM_Core_Permission::VIEW => array(),
+                                CRM_Core_Permission::EDIT => array());
 
-    if ($type = CRM_Core_Permission::VIEW) {
+    if ($type == CRM_Core_Permission::VIEW) {
       $operationClause = " operation IN ( 'Edit', 'View' ) ";
       $operation = 'View';
     }
@@ -200,7 +201,8 @@ WHERE contact_a.id = %1 AND $permission";
     }
 
     if (!$force) {
-      if (!empty($_processed[$userID])) {
+      // skip if already calculated
+      if (!empty($_processed[$type][$userID])) {
         return;
       }
 
@@ -214,7 +216,7 @@ AND    $operationClause
       $params = array(1 => array($userID, 'Integer'));
       $count = CRM_Core_DAO::singleValueQuery($sql, $params);
       if ($count > 0) {
-        $_processed[$userID] = 1;
+        $_processed[$type][$userID] = 1;
         return;
       }
     }
@@ -238,8 +240,7 @@ ON DUPLICATE KEY UPDATE
          contact_id=VALUES(contact_id),
          operation=VALUES(operation)"
     );
-
-    $_processed[$userID] = 1;
+    $_processed[$type][$userID] = 1;
   }
 
   /**

--- a/CRM/Contact/BAO/Contact/Permission.php
+++ b/CRM/Contact/BAO/Contact/Permission.php
@@ -34,13 +34,15 @@ class CRM_Contact_BAO_Contact_Permission {
 
   /**
    * Check which of the given contact IDs the logged in user
-   *   has permissions for the operation type according
-   *
-   * Caution: general permissions (like 'edit all contacts')
+   *   has permissions for the operation type according to:
+   *    - general permissions (e.g. 'edit all contacts')
+   *    - deletion status (unless you have 'access deleted contacts')
+   *    - ACL
+   *    - permissions inherited through relationships (also second degree if enabled)
    *
    * @param array $contact_ids
    *   Contact IDs.
-   * @param int|string $type the type of operation (view|edit)
+   * @param int $type the type of operation (view|edit)
    *
    * @see CRM_Contact_BAO_Contact_Permission::allow
    *
@@ -53,7 +55,6 @@ class CRM_Contact_BAO_Contact_Permission {
       // empty contact lists would cause trouble in the SQL. And be pointless.
       return $result_set;
     }
-    $contact_id_list = implode(',', $contact_ids);
 
     // make sure the the general permissions are given
     if (CRM_Core_Permission::check('edit all contacts')
@@ -67,6 +68,7 @@ class CRM_Contact_BAO_Contact_Permission {
       }
       else {
         // if the user CANNOT access deleted contacts, these need to be filtered
+        $contact_id_list = implode(',', $contact_ids);
         $filter_query = "SELECT DISTINCT(id) FROM civicrm_contact WHERE id IN ($contact_id_list) AND is_deleted = 0";
         $query = CRM_Core_DAO::executeQuery($filter_query);
         while ($query->fetch()) {
@@ -77,8 +79,7 @@ class CRM_Contact_BAO_Contact_Permission {
     }
 
     // get logged in user
-    $session   = CRM_Core_Session::singleton();
-    $contactID = (int) $session->get('userID');
+    $contactID = CRM_Core_Session::getLoggedInContactID();
     if (empty($contactID)) {
       return array();
     }
@@ -97,6 +98,7 @@ class CRM_Contact_BAO_Contact_Permission {
     }
 
     // RUN the query
+    $contact_id_list = implode(',', $contact_ids);
     $query = "
 SELECT contact_id
  FROM civicrm_acl_contact_cache
@@ -134,8 +136,7 @@ WHERE contact_id IN ({$contact_id_list})
    */
   public static function allow($id, $type = CRM_Core_Permission::VIEW) {
     // get logged in user
-    $session   = CRM_Core_Session::singleton();
-    $contactID = (int) $session->get('userID');
+    $contactID = CRM_Core_Session::getLoggedInContactID();
 
     // first: check if contact is trying to view own contact
     if ($type == CRM_Core_Permission::VIEW && CRM_Core_Permission::check('view my contact')
@@ -188,6 +189,10 @@ WHERE contact_a.id = %1 AND $permission";
    *   Should we force a recompute.
    */
   public static function cache($userID, $type = CRM_Core_Permission::VIEW, $force = FALSE) {
+    // FIXME: maybe find a better way of keeping track of this. @eileen pointed out
+    //   that somebody might flush the cache away from under our feet,
+    //   but the altenative would be a SQL call every time this is called,
+    //   and a complete rebuild if the result was an empty set...
     static $_processed = array(
       CRM_Core_Permission::VIEW => array(),
       CRM_Core_Permission::EDIT => array());
@@ -258,8 +263,7 @@ ON DUPLICATE KEY UPDATE
     $contactID = NULL
   ) {
     if (!$contactID) {
-      $session = CRM_Core_Session::singleton();
-      $contactID = $session->get('userID');
+      $contactID = CRM_Core_Session::getLoggedInContactID();
     }
 
     if ($type = CRM_Core_Permission::VIEW) {
@@ -353,12 +357,12 @@ AND    $operationClause LIMIT 1";
    * @return bool
    *   true if logged in user has permission to view
    *   selected contact record else false
+   *
+   * @deprecated should be replaced by a ::relationshipList(array($selectedContactID)) call
    */
   public static function relationship($selectedContactID, $contactID = NULL) {
-    $session = CRM_Core_Session::singleton();
-    $config = CRM_Core_Config::singleton();
     if (!$contactID) {
-      $contactID = $session->get('userID');
+      $contactID = CRM_Core_Session::getLoggedInContactID();
       if (!$contactID) {
         return FALSE;
       }
@@ -369,6 +373,8 @@ AND    $operationClause LIMIT 1";
       return TRUE;
     }
     else {
+      // FIXME: secondDegRelPermissions should be a setting
+      $config  = CRM_Core_Config::singleton();
       if ($config->secondDegRelPermissions) {
         $query = "
 SELECT firstdeg.id
@@ -457,9 +463,7 @@ WHERE  (( contact_id_a = %1 AND contact_id_b = %2 AND is_permission_a_b = 1 ) OR
     }
 
     // get the currently logged in user
-    $config    = CRM_Core_Config::singleton();
-    $session   = CRM_Core_Session::singleton();
-    $contactID = (int) $session->get('userID');
+    $contactID = CRM_Core_Session::getLoggedInContactID();
     if (empty($contactID)) {
       return array();
     }
@@ -484,7 +488,7 @@ WHERE  (( contact_id_a = %1 AND contact_id_b = %2 AND is_permission_a_b = 1 ) OR
       }
 
       $queries[] = "
-SELECT DISTINCT(civicrm_relationship.{$contact_id_column}) AS contact_id
+SELECT civicrm_relationship.{$contact_id_column} AS contact_id
   FROM civicrm_relationship 
   {$LEFT_JOIN_DELETED}
  WHERE civicrm_relationship.{$user_id_column} = {$contactID}
@@ -494,39 +498,38 @@ SELECT DISTINCT(civicrm_relationship.{$contact_id_column}) AS contact_id
    $AND_CAN_ACCESS_DELETED";
     }
 
+    // FIXME: secondDegRelPermissions should be a setting
+    $config = CRM_Core_Config::singleton();
     if ($config->secondDegRelPermissions) {
-      // ADD SECOND DEGREE RELATIONSHIPS
-      if ($config->secondDegRelPermissions) {
-        foreach ($directions as $first_direction) {
-          foreach ($directions as $second_direction) {
-            // add clause for deleted contacts, if the user doesn't have the permission to access them
-            $LEFT_JOIN_DELETED = $AND_CAN_ACCESS_DELETED = '';
-            if (!CRM_Core_Permission::check('access deleted contacts')) {
-              $LEFT_JOIN_DELETED       = "LEFT JOIN civicrm_contact first_degree_contact  ON first_degree_contact.id  = second_degree_relationship.contact_id_{$second_direction['from']}\n";
-              $LEFT_JOIN_DELETED      .= "LEFT JOIN civicrm_contact second_degree_contact ON second_degree_contact.id = second_degree_relationship.contact_id_{$second_direction['to']} ";
-              $AND_CAN_ACCESS_DELETED  = "AND first_degree_contact.is_deleted = 0\n";
-              $AND_CAN_ACCESS_DELETED .= "AND second_degree_contact.is_deleted = 0 ";
-            }
-
-            $queries[] = "
-  SELECT DISTINCT(second_degree_relationship.contact_id_{$second_direction['to']}) AS contact_id
-    FROM civicrm_relationship first_degree_relationship
-    LEFT JOIN civicrm_relationship second_degree_relationship ON first_degree_relationship.contact_id_{$first_direction['to']} = second_degree_relationship.contact_id_{$first_direction['from']}
-    {$LEFT_JOIN_DELETED}
-   WHERE first_degree_relationship.contact_id_{$first_direction['from']} = {$contactID}
-     AND second_degree_relationship.contact_id_{$second_direction['to']} IN ({$contact_id_list})
-     AND first_degree_relationship.is_active = 1
-     AND first_degree_relationship.is_permission_{$first_direction['from']}_{$first_direction['to']} = 1
-     AND second_degree_relationship.is_active = 1
-     AND second_degree_relationship.is_permission_{$second_direction['from']}_{$second_direction['to']} = 1
-     $AND_CAN_ACCESS_DELETED";
+      foreach ($directions as $first_direction) {
+        foreach ($directions as $second_direction) {
+          // add clause for deleted contacts, if the user doesn't have the permission to access them
+          $LEFT_JOIN_DELETED = $AND_CAN_ACCESS_DELETED = '';
+          if (!CRM_Core_Permission::check('access deleted contacts')) {
+            $LEFT_JOIN_DELETED       = "LEFT JOIN civicrm_contact first_degree_contact  ON first_degree_contact.id  = second_degree_relationship.contact_id_{$second_direction['from']}\n";
+            $LEFT_JOIN_DELETED      .= "LEFT JOIN civicrm_contact second_degree_contact ON second_degree_contact.id = second_degree_relationship.contact_id_{$second_direction['to']} ";
+            $AND_CAN_ACCESS_DELETED  = "AND first_degree_contact.is_deleted = 0\n";
+            $AND_CAN_ACCESS_DELETED .= "AND second_degree_contact.is_deleted = 0 ";
           }
+
+          $queries[] = "
+SELECT second_degree_relationship.contact_id_{$second_direction['to']} AS contact_id
+  FROM civicrm_relationship first_degree_relationship
+  LEFT JOIN civicrm_relationship second_degree_relationship ON first_degree_relationship.contact_id_{$first_direction['to']} = second_degree_relationship.contact_id_{$first_direction['from']}
+  {$LEFT_JOIN_DELETED}
+ WHERE first_degree_relationship.contact_id_{$first_direction['from']} = {$contactID}
+   AND second_degree_relationship.contact_id_{$second_direction['to']} IN ({$contact_id_list})
+   AND first_degree_relationship.is_active = 1
+   AND first_degree_relationship.is_permission_{$first_direction['from']}_{$first_direction['to']} = 1
+   AND second_degree_relationship.is_active = 1
+   AND second_degree_relationship.is_permission_{$second_direction['from']}_{$second_direction['to']} = 1
+   $AND_CAN_ACCESS_DELETED";
         }
       }
     }
 
     // finally UNION the queries and call
-    $query = "(" . implode(")\nUNION (", $queries) . ")";
+    $query = "(" . implode(")\nUNION DISTINCT (", $queries) . ")";
     $result = CRM_Core_DAO::executeQuery($query);
     while ($result->fetch()) {
       $result_set[(int) $result->contact_id] = TRUE;

--- a/CRM/Contact/BAO/Contact/Permission.php
+++ b/CRM/Contact/BAO/Contact/Permission.php
@@ -115,6 +115,7 @@ WHERE contact_id IN ({$contact_id_list})
     // if some have been rejected, double check for permissions inherited by relationship
     if (count($result_set) < count($contact_ids)) {
       $rejected_contacts       = array_diff_key($contact_ids, $result_set);
+      // @todo consider storing these to the acl cache for next time, since we have fetched.
       $allowed_by_relationship = self::relationshipList($rejected_contacts);
       foreach ($allowed_by_relationship as $contact_id) {
         $result_set[(int) $contact_id] = TRUE;

--- a/CRM/Contact/BAO/Contact/Permission.php
+++ b/CRM/Contact/BAO/Contact/Permission.php
@@ -140,8 +140,8 @@ WHERE contact_id IN ({$contact_id_list})
     $contactID = CRM_Core_Session::getLoggedInContactID();
 
     // first: check if contact is trying to view own contact
-    if ($type == CRM_Core_Permission::VIEW && CRM_Core_Permission::check('view my contact')
-     || $type == CRM_Core_Permission::EDIT && CRM_Core_Permission::check('edit my contact')
+    if ($contactID == $id && ($type == CRM_Core_Permission::VIEW && CRM_Core_Permission::check('view my contact')
+     || $type == CRM_Core_Permission::EDIT && CRM_Core_Permission::check('edit my contact'))
       ) {
       return TRUE;
     }

--- a/CRM/Contact/BAO/Contact/Permission.php
+++ b/CRM/Contact/BAO/Contact/Permission.php
@@ -91,7 +91,7 @@ class CRM_Contact_BAO_Contact_Permission {
     $operation = ($type == CRM_Core_Permission::VIEW) ? 'View' : 'Edit';
 
     // add clause for deleted contacts, if the user doesn't have the permission to access them
-    $LEFT_JOIN_DELETED = $CAN_ACCESS_DELETED = '';
+    $LEFT_JOIN_DELETED = $AND_CAN_ACCESS_DELETED = '';
     if (!CRM_Core_Permission::check('access deleted contacts')) {
       $LEFT_JOIN_DELETED      = "LEFT JOIN civicrm_contact ON civicrm_contact.id = contact_id";
       $AND_CAN_ACCESS_DELETED = "AND civicrm_contact.is_deleted = 0";

--- a/CRM/Contact/BAO/Contact/Permission.php
+++ b/CRM/Contact/BAO/Contact/Permission.php
@@ -121,6 +121,12 @@ WHERE contact_id IN ({$contact_id_list})
   public static function allow($id, $type = CRM_Core_Permission::VIEW) {
     $tables = array();
     $whereTables = array();
+    // first: check if contact is trying to view own contact
+    if (   $type == CRM_Core_Permission::VIEW && CRM_Core_Permission::check('view my contact')
+        || $type == CRM_Core_Permission::EDIT && CRM_Core_Permission::check('edit my contact')
+      ) {
+      return TRUE;
+    }
 
     # FIXME: push this somewhere below, to not give this permission so many rights
     $isDeleted = (bool) CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $id, 'is_deleted');

--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -507,11 +507,9 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
      * driven by the wizard framework
      */
 
-    $this->_reset = CRM_Utils_Request::retrieve('reset', 'Boolean',
-      CRM_Core_DAO::$_nullObject
-    );
+    $this->_reset = CRM_Utils_Request::retrieve('reset', 'Boolean');
 
-    $this->_force = CRM_Utils_Request::retrieve('force', 'Boolean', CRM_Core_DAO::$_nullObject);
+    $this->_force = CRM_Utils_Request::retrieve('force', 'Boolean');
     $this->_groupID = CRM_Utils_Request::retrieve('gid', 'Positive', $this);
     $this->_amtgID = CRM_Utils_Request::retrieve('amtgID', 'Positive', $this);
     $this->_ssID = CRM_Utils_Request::retrieve('ssID', 'Positive', $this);

--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -928,9 +928,20 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
     // mask value to hide map link if there are not lat/long
     $mapMask = $mask & 4095;
 
-    $links = self::links($this->_context, $this->_contextMenu, $this->_key);
+    // get permissions on an individual level (CRM-12645)
+    $can_edit_list = CRM_Contact_BAO_Contact_Permission::allowList(array_keys($rows), CRM_Core_Permission::EDIT);
+
+    $links_template = self::links($this->_context, $this->_contextMenu, $this->_key);
+
 
     foreach ($rows as $id => & $row) {
+      $links = $links_template;
+
+      // remove edit/view links (CRM-12645)
+      if (isset($links[CRM_Core_Action::UPDATE]) && !in_array($id, $can_edit_list)) {
+        unset($links[CRM_Core_Action::UPDATE]);
+      }
+
       if (!empty($this->_formValues['deleted_contacts']) && CRM_Core_Permission::check('access deleted contacts')
       ) {
         $links = array(

--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -933,7 +933,6 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
 
     $links_template = self::links($this->_context, $this->_contextMenu, $this->_key);
 
-
     foreach ($rows as $id => & $row) {
       $links = $links_template;
 

--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -542,7 +542,6 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
    *   the total number of rows for this action
    */
   public function &getRows($action, $offset, $rowCount, $sort, $output = NULL) {
-    $config = CRM_Core_Config::singleton();
 
     if (($output == CRM_Core_Selector_Controller::EXPORT ||
         $output == CRM_Core_Selector_Controller::SCREEN
@@ -915,16 +914,12 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
    * @param $rows
    */
   public function addActions(&$rows) {
-    $config = CRM_Core_Config::singleton();
 
     $permissions = array(CRM_Core_Permission::getPermission());
     if (CRM_Core_Permission::check('delete contacts')) {
       $permissions[] = CRM_Core_Permission::DELETE;
     }
     $mask = CRM_Core_Action::mask($permissions);
-    // mask value to hide map link if there are not lat/long
-    $mapMask = $mask & 4095;
-
     // mask value to hide map link if there are not lat/long
     $mapMask = $mask & 4095;
 

--- a/tests/phpunit/CRM/ACL/ListTest.php
+++ b/tests/phpunit/CRM/ACL/ListTest.php
@@ -28,7 +28,7 @@ class CRM_ACL_ListTest extends CiviUnitTestCase {
     $contacts = $this->createScenarioPlain();
 
     // test WITH all permissions
-    CRM_Core_Config::singleton()->userPermissionClass->permissions = NULL;
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = NULL; // NULL means 'all permissions' in UnitTests environment
     $result = CRM_Contact_BAO_Contact_Permission::allowList($contacts);
     sort($result);
     $this->assertEquals($result, $contacts, "Contacts should be viewable when 'view all contacts'");
@@ -38,6 +38,12 @@ class CRM_ACL_ListTest extends CiviUnitTestCase {
     $result = CRM_Contact_BAO_Contact_Permission::allowList($contacts, CRM_Core_Permission::VIEW);
     sort($result);
     $this->assertEquals($result, $contacts, "Contacts should be viewable when 'view all contacts'");
+
+    // test WITH EDIT permissions (should imply VIEW)
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = array('edit all contacts');
+    $result = CRM_Contact_BAO_Contact_Permission::allowList($contacts, CRM_Core_Permission::VIEW);
+    sort($result);
+    $this->assertEquals($result, $contacts, "Contacts should be viewable when 'edit all contacts'");
 
     // test WITHOUT permission
     CRM_Core_Config::singleton()->userPermissionClass->permissions = array();

--- a/tests/phpunit/CRM/ACL/ListTest.php
+++ b/tests/phpunit/CRM/ACL/ListTest.php
@@ -24,7 +24,7 @@ class CRM_ACL_ListTest extends CiviUnitTestCase {
    * general test for the 'view all contacts' permission
    */
   public function testViewAllPermission() {
-    // create test contacts    
+    // create test contacts
     $contacts = $this->createScenarioPlain();
 
     // test WITH all permissions
@@ -33,13 +33,11 @@ class CRM_ACL_ListTest extends CiviUnitTestCase {
     sort($result);
     $this->assertEquals($result, $contacts, "Contacts should be viewable when 'view all contacts'");
 
-
     // test WITH explicit permission
     CRM_Core_Config::singleton()->userPermissionClass->permissions = array('view all contacts');
     $result = CRM_Contact_BAO_Contact_Permission::allowList($contacts, CRM_Core_Permission::VIEW);
     sort($result);
     $this->assertEquals($result, $contacts, "Contacts should be viewable when 'view all contacts'");
-
 
     // test WITHOUT permission
     CRM_Core_Config::singleton()->userPermissionClass->permissions = array();
@@ -61,7 +59,6 @@ class CRM_ACL_ListTest extends CiviUnitTestCase {
     $result = CRM_Contact_BAO_Contact_Permission::allowList($contacts, CRM_Core_Permission::EDIT);
     sort($result);
     $this->assertEquals($result, $contacts, "Contacts should be viewable when 'edit all contacts'");
-
 
     // test WITHOUT permission
     CRM_Core_Config::singleton()->userPermissionClass->permissions = array();
@@ -89,14 +86,13 @@ class CRM_ACL_ListTest extends CiviUnitTestCase {
     $result = CRM_Contact_BAO_Contact_Permission::allowList($contacts, CRM_Core_Permission::EDIT);
     sort($result);
     $this->assertNotContains($deleted_contact_id, $result, "Deleted contacts should be excluded");
-    $this->assertEquals(count($result), count($contacts)-1, "Only deleted contacts should be excluded");
-
+    $this->assertEquals(count($result), count($contacts) - 1, "Only deleted contacts should be excluded");
   }
 
 
   /**
    * Test access based on relations
-   * 
+   *
    * There should be the following permission-relationship
    * contact[0] -> contact[1] -> contact[2]
    */
@@ -116,14 +112,13 @@ class CRM_ACL_ListTest extends CiviUnitTestCase {
       $result = CRM_Contact_BAO_Contact_Permission::allowList($contacts, $permission);
       sort($result);
 
-
       $this->assertNotContains($contacts[0], $result, "User[0] should NOT have $permission_label permission on contact[0].");
-      $this->assertContains(   $contacts[1], $result, "User[0] should have $permission_label permission on contact[1].");
+      $this->assertContains($contacts[1], $result, "User[0] should have $permission_label permission on contact[1].");
       $this->assertNotContains($contacts[2], $result, "User[0] should NOT have $permission_label permission on contact[2].");
       $this->assertNotContains($contacts[3], $result, "User[0] should NOT have $permission_label permission on contact[3].");
       $this->assertNotContains($contacts[4], $result, "User[0] should NOT have $permission_label permission on contact[4].");
     }
-    
+
     // run this for SECOND DEGREE relations
     $config->secondDegRelPermissions = TRUE;
     $this->assertTrue($config->secondDegRelPermissions);
@@ -132,8 +127,8 @@ class CRM_ACL_ListTest extends CiviUnitTestCase {
       sort($result);
 
       $this->assertNotContains($contacts[0], $result, "User[0] should NOT have $permission_label permission on contact[0].");
-      $this->assertContains(   $contacts[1], $result, "User[0] should have $permission_label permission on contact[1].");
-      $this->assertContains(   $contacts[2], $result, "User[0] should have second degree $permission_label permission on contact[2].");
+      $this->assertContains($contacts[1], $result, "User[0] should have $permission_label permission on contact[1].");
+      $this->assertContains($contacts[2], $result, "User[0] should have second degree $permission_label permission on contact[2].");
       $this->assertNotContains($contacts[3], $result, "User[0] should NOT have $permission_label permission on contact[3].");
       $this->assertNotContains($contacts[4], $result, "User[0] should NOT have $permission_label permission on contact[4].");
     }
@@ -157,11 +152,11 @@ class CRM_ACL_ListTest extends CiviUnitTestCase {
     $result = CRM_Contact_BAO_Contact_Permission::allowList($contacts);
     sort($result);
 
-    $this->assertContains(   $contacts[0], $result, "User[0] should NOT have an ACL permission on contact[0].");
-    $this->assertContains(   $contacts[1], $result, "User[0] should have an ACL permission on contact[1].");
+    $this->assertContains($contacts[0], $result, "User[0] should NOT have an ACL permission on contact[0].");
+    $this->assertContains($contacts[1], $result, "User[0] should have an ACL permission on contact[1].");
     $this->assertNotContains($contacts[2], $result, "User[0] should NOT have an ACL permission on contact[2].");
     $this->assertNotContains($contacts[3], $result, "User[0] should NOT have an RELATION permission on contact[3].");
-    $this->assertContains(   $contacts[4], $result, "User[0] should NOT have an ACL permission on contact[4].");
+    $this->assertContains($contacts[4], $result, "User[0] should NOT have an ACL permission on contact[4].");
   }
 
 
@@ -183,11 +178,11 @@ class CRM_ACL_ListTest extends CiviUnitTestCase {
     $result = CRM_Contact_BAO_Contact_Permission::allowList($contacts);
     sort($result);
 
-    $this->assertContains(   $contacts[0], $result, "User[0] should have an ACL permission on contact[0].");
-    $this->assertContains(   $contacts[1], $result, "User[0] should have an ACL permission on contact[1].");
-    $this->assertContains(   $contacts[2], $result, "User[0] should have second degree an relation permission on contact[2].");
+    $this->assertContains($contacts[0], $result, "User[0] should have an ACL permission on contact[0].");
+    $this->assertContains($contacts[1], $result, "User[0] should have an ACL permission on contact[1].");
+    $this->assertContains($contacts[2], $result, "User[0] should have second degree an relation permission on contact[2].");
     $this->assertNotContains($contacts[3], $result, "User[0] should NOT have an ACL permission on contact[3].");
-    $this->assertContains(   $contacts[4], $result, "User[0] should have an ACL permission on contact[4].");
+    $this->assertContains($contacts[4], $result, "User[0] should have an ACL permission on contact[4].");
   }
 
   /**
@@ -213,7 +208,7 @@ class CRM_ACL_ListTest extends CiviUnitTestCase {
       foreach ($user_permission_options as $user_permissions) {
         // select the contact range
         $contact_range = $contacts;
-        if (is_array($user_permissions) && count($user_permissions)==0) {
+        if (is_array($user_permissions) && count($user_permissions) == 0) {
           // slight (explainable) deviation on the own contact
           unset($contact_range[0]);
         }
@@ -236,7 +231,8 @@ class CRM_ACL_ListTest extends CiviUnitTestCase {
             // listPermission reports PERMISSION GRANTED
             $this->assertTrue($individual_result, "Permission::allow denies {$permission_label} access for contact[{$contact_index[$contact_id]}], while Permission::allowList grants it. User permission: '{$user_permissions_label}'");
 
-          } else {
+          }
+          else {
             // listPermission reports PERMISSION DENIED
             $this->assertFalse($individual_result, "Permission::allow grantes {$permission_label} access for contact[{$contact_index[$contact_id]}], while Permission::allowList denies it. User permission: '{$user_permissions_label}'");
 
@@ -278,7 +274,7 @@ class CRM_ACL_ListTest extends CiviUnitTestCase {
 
     // create some relationships
     $this->callAPISuccess('Relationship', 'create', array(
-      'relationship_type_id' => 1,  // CHILD OF
+      'relationship_type_id' => 1, // CHILD OF
       'contact_id_a'         => $contacts[1],
       'contact_id_b'         => $contacts[0],
       'is_permission_b_a'    => 1,
@@ -286,7 +282,7 @@ class CRM_ACL_ListTest extends CiviUnitTestCase {
       ));
 
     $this->callAPISuccess('Relationship', 'create', array(
-      'relationship_type_id' => 1,  // CHILD OF
+      'relationship_type_id' => 1, // CHILD OF
       'contact_id_a'         => $contacts[2],
       'contact_id_b'         => $contacts[1],
       'is_permission_b_a'    => 1,
@@ -295,7 +291,7 @@ class CRM_ACL_ListTest extends CiviUnitTestCase {
 
     // create some relationships
     $this->callAPISuccess('Relationship', 'create', array(
-      'relationship_type_id' => 1,  // CHILD OF
+      'relationship_type_id' => 1, // CHILD OF
       'contact_id_a'         => $contacts[4],
       'contact_id_b'         => $contacts[2],
       'is_permission_b_a'    => 1,
@@ -305,13 +301,14 @@ class CRM_ACL_ListTest extends CiviUnitTestCase {
     return $contacts;
   }
 
-  /** 
-   * ACL HOOK implementation for various tests 
+  /**
+   * ACL HOOK implementation for various tests
    */
-  public function hook_civicrm_aclWhereClause($type, &$tables, &$whereTables, &$contactID, &$where ) {
+  public function hook_civicrm_aclWhereClause($type, &$tables, &$whereTables, &$contactID, &$where) {
     if (!empty($this->allowedContactsACL)) {
       $contact_id_list = implode(',', $this->allowedContactsACL);
       $where = " contact_a.id IN ($contact_id_list)";
     }
   }
+
 }

--- a/tests/phpunit/CRM/ACL/ListTest.php
+++ b/tests/phpunit/CRM/ACL/ListTest.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * Class CRM_ACL_Test
+ *
+ * This test focuses on testing the (new) ID list-based functions:
+ *   CRM_Contact_BAO_Contact_Permission::allowList()
+ *   CRM_Contact_BAO_Contact_Permission::relationshipList()
+ * @group headless
+ */
+class CRM_ACL_ListTest extends CiviUnitTestCase {
+
+  /**
+   * Set up function.
+   */
+  public function setUp() {
+    parent::setUp();
+    $this->useTransaction(TRUE);
+  }
+
+  /**
+   * general test for the 'view all contacts' permission
+   */
+  public function testViewAllPermission() {
+    // create test contacts    
+    $contacts = $this->createScenarioA();
+    // CRM_Core_Error::debug_log_message(json_encode($contacts));
+
+    // test WITH permission
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = array('view all contacts');
+    $result = CRM_Contact_BAO_Contact_Permission::allowList($contacts);
+    // CRM_Core_Error::debug_log_message(json_encode($result));
+    $this->assertEqual($result, $contacts, "Contacts should be viewable when 'view all contacts'");
+
+
+    // test WITH explicit permission
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = array('view all contacts');
+    $result = CRM_Contact_BAO_Contact_Permission::allowList($contacts, CRM_Core_Permission::VIEW);
+    // CRM_Core_Error::debug_log_message(json_encode($result));
+    $this->assertEqual($result, $contacts, "Contacts should be viewable when 'view all contacts'");
+
+
+    // test WITHOUT permission
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = array();
+    $result = CRM_Contact_BAO_Contact_Permission::allowList($contacts);
+    $this->assertEmpty($result, "Contacts should NOT be viewable when 'view all contacts' is not set");
+  }
+
+
+  /**
+   * general test for the 'view all contacts' permission
+   */
+  public function testEditAllPermission() {
+    // create test contacts
+
+    $contacts = $this->createScenarioA();
+
+    // test WITH explicit permission
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = array('edit all contacts');
+    $result = CRM_Contact_BAO_Contact_Permission::allowList($contacts, CRM_Core_Permission::EDIT);
+    $this->assertEqual($result, $contacts, "Contacts should be viewable when 'edit all contacts'");
+
+
+    // test WITHOUT permission
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = array();
+    $result = CRM_Contact_BAO_Contact_Permission::allowList($contacts);
+    $this->assertEmpty($result, "Contacts should NOT be viewable when 'edit all contacts' is not set");
+  }
+
+
+  /**
+   * general test for the 'view all contacts' permission
+   */
+  public function testViewEditDeleted() {
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = array('edit all contacts', 'view all contacts');
+    $contacts = $this->createScenarioA();
+
+    
+  }
+
+
+
+
+
+
+
+  /**
+   * create test scenario A
+   */
+  protected function createScenarioA() {
+    // get logged in user
+    $user_id = $this->createLoggedInUser();
+    $this->assertNotEmpty($user_id);
+
+    // create test contacts
+    $bush_sr_id    = $this->individualCreate(array('first_name' => 'George', 'middle_name' => 'W.', 'last_name' => 'Bush'));
+    $bush_jr_id    = $this->individualCreate(array('first_name' => 'George', 'middle_name' => 'H. W.', 'last_name' => 'Bush'));
+    $bush_laura_id = $this->individualCreate(array('first_name' => 'Laura Lane', 'last_name' => 'Bush'));
+    $bush_brbra_id = $this->individualCreate(array('first_name' => 'Barbara', 'last_name' => 'Bush'));
+
+    // create some relationships
+    $this->callAPISuccess('Relationship', 'create', array(
+      'relationship_type_id' => 1,  // CHILD OF
+      'contact_id_a'         => $bush_sr_id,
+      'contact_id_b'         => $user_id,
+      'is_permission_a_b'    => 1,
+      ));
+
+    $this->callAPISuccess('Relationship', 'create', array(
+      'relationship_type_id' => 1,  // CHILD OF
+      'contact_id_a'         => $bush_jr_id,
+      'contact_id_b'         => $bush_sr_id,
+      'is_permission_a_b'    => 1,
+      ));
+
+    // create some relationships
+    $this->callAPISuccess('Relationship', 'create', array(
+      'relationship_type_id' => 1,  // CHILD OF
+      'contact_id_a'         => $bush_brbra_id,
+      'contact_id_b'         => $bush_jr_id,
+      'is_permission_a_b'    => 1,
+      ));
+
+    return array($user_id, $bush_sr_id, $bush_jr_id, $bush_laura_id, $bush_brbra_id);
+  }
+
+}

--- a/tests/phpunit/CRM/ACL/ListTest.php
+++ b/tests/phpunit/CRM/ACL/ListTest.php
@@ -23,26 +23,26 @@ class CRM_ACL_ListTest extends CiviUnitTestCase {
    */
   public function testViewAllPermission() {
     // create test contacts    
-    $contacts = $this->createScenarioA();
-    // CRM_Core_Error::debug_log_message(json_encode($contacts));
+    $contacts = $this->createScenarioPlain();
 
-    // test WITH permission
-    CRM_Core_Config::singleton()->userPermissionClass->permissions = array('view all contacts');
+    // test WITH all permissions
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = NULL;
     $result = CRM_Contact_BAO_Contact_Permission::allowList($contacts);
-    // CRM_Core_Error::debug_log_message(json_encode($result));
-    $this->assertEqual($result, $contacts, "Contacts should be viewable when 'view all contacts'");
+    sort($result);
+    $this->assertEquals($result, $contacts, "Contacts should be viewable when 'view all contacts'");
 
 
     // test WITH explicit permission
     CRM_Core_Config::singleton()->userPermissionClass->permissions = array('view all contacts');
     $result = CRM_Contact_BAO_Contact_Permission::allowList($contacts, CRM_Core_Permission::VIEW);
-    // CRM_Core_Error::debug_log_message(json_encode($result));
-    $this->assertEqual($result, $contacts, "Contacts should be viewable when 'view all contacts'");
+    sort($result);
+    $this->assertEquals($result, $contacts, "Contacts should be viewable when 'view all contacts'");
 
 
     // test WITHOUT permission
     CRM_Core_Config::singleton()->userPermissionClass->permissions = array();
     $result = CRM_Contact_BAO_Contact_Permission::allowList($contacts);
+    sort($result);
     $this->assertEmpty($result, "Contacts should NOT be viewable when 'view all contacts' is not set");
   }
 
@@ -52,42 +52,125 @@ class CRM_ACL_ListTest extends CiviUnitTestCase {
    */
   public function testEditAllPermission() {
     // create test contacts
-
-    $contacts = $this->createScenarioA();
+    $contacts = $this->createScenarioPlain();
 
     // test WITH explicit permission
     CRM_Core_Config::singleton()->userPermissionClass->permissions = array('edit all contacts');
     $result = CRM_Contact_BAO_Contact_Permission::allowList($contacts, CRM_Core_Permission::EDIT);
-    $this->assertEqual($result, $contacts, "Contacts should be viewable when 'edit all contacts'");
+    sort($result);
+    $this->assertEquals($result, $contacts, "Contacts should be viewable when 'edit all contacts'");
 
 
     // test WITHOUT permission
     CRM_Core_Config::singleton()->userPermissionClass->permissions = array();
     $result = CRM_Contact_BAO_Contact_Permission::allowList($contacts);
+    sort($result);
     $this->assertEmpty($result, "Contacts should NOT be viewable when 'edit all contacts' is not set");
   }
 
 
   /**
-   * general test for the 'view all contacts' permission
+   * Test access related to the 'access deleted contact' permission
    */
   public function testViewEditDeleted() {
-    CRM_Core_Config::singleton()->userPermissionClass->permissions = array('edit all contacts', 'view all contacts');
-    $contacts = $this->createScenarioA();
+    // create test contacts
+    $contacts = $this->createScenarioPlain();
 
-    
+    // delete one contact
+    $deleted_contact_id = $contacts[2];
+    $this->callAPISuccess('Contact', 'create', array('id' => $deleted_contact_id, 'contact_is_deleted' => 1));
+    $deleted_contact = $this->callAPISuccess('Contact', 'getsingle', array('id' => $deleted_contact_id));
+    $this->assertEquals($deleted_contact['contact_is_deleted'], 1, "Contact should've been deleted");
+
+    // test WITH explicit permission
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = array('edit all contacts', 'view all contacts');
+    $result = CRM_Contact_BAO_Contact_Permission::allowList($contacts, CRM_Core_Permission::EDIT);
+    sort($result);
+    $this->assertNotContains($deleted_contact_id, $result, "Deleted contacts should be excluded");
+    $this->assertEquals(count($result), count($contacts)-1, "Only deleted contacts should be excluded");
+
   }
 
 
+  /**
+   * Test access related to the 'access deleted contact' permission
+   * 
+   * There should be the following permission-relationship
+   * contact[0] -> contact[1] -> contact[2]
+   */
+  public function testPermissionByRelation() {
+    // create test scenario
+    $contacts = $this->createScenarioRelation();
+
+    // remove all permissions
+    $config = CRM_Core_Config::singleton();
+    $config->userPermissionClass->permissions = array();
+    $permissions_to_check = array(CRM_Core_Permission::VIEW => 'View', CRM_Core_Permission::EDIT => 'Edit');
+
+    // run this for SIMPLE relations
+    $config->secondDegRelPermissions = FALSE;
+    $this->assertFalse($config->secondDegRelPermissions);
+    foreach ($permissions_to_check as $permission => $permission_label) {
+      $result = CRM_Contact_BAO_Contact_Permission::allowList($contacts, $permission);
+      sort($result);
 
 
+      $this->assertNotContains($contacts[0], $result, "Contact[0] should NOT have $permission_label permission on contact[0].");
+      $this->assertContains(   $contacts[1], $result, "Contact[0] should have $permission_label permission on contact[1].");
+      $this->assertNotContains($contacts[2], $result, "Contact[0] should NOT have $permission_label permission on contact[2].");
+      $this->assertNotContains($contacts[3], $result, "Contact[0] should NOT have $permission_label permission on contact[3].");
+      $this->assertNotContains($contacts[4], $result, "Contact[0] should NOT have $permission_label permission on contact[4].");
+    }
+    
+    // run this for SECOND DEGREE relations
+    $config->secondDegRelPermissions = TRUE;
+    $this->assertTrue($config->secondDegRelPermissions);
+    foreach ($permissions_to_check as $permission => $permission_label) {
+      $result = CRM_Contact_BAO_Contact_Permission::allowList($contacts, $permission);
+      sort($result);
 
+      $this->assertNotContains($contacts[0], $result, "Contact[0] should NOT have $permission_label permission on contact[0].");
+      $this->assertContains(   $contacts[1], $result, "Contact[0] should have $permission_label permission on contact[1].");
+      $this->assertContains(   $contacts[2], $result, "Contact[0] should have second degree $permission_label permission on contact[2].");
+      $this->assertNotContains($contacts[3], $result, "Contact[0] should NOT have $permission_label permission on contact[3].");
+      $this->assertNotContains($contacts[4], $result, "Contact[0] should NOT have $permission_label permission on contact[4].");
+    }
+  }
 
 
   /**
-   * create test scenario A
+   * Test access related to the 'access deleted contact' permission
    */
-  protected function createScenarioA() {
+  public function _testPermissionByACL() {
+    // CRM_Core_Config::singleton()->userPermissionClass->permissions = array('edit all contacts', 'view all contacts');
+    // $contacts = $this->createScenarioPlain();
+  }
+
+  /**
+   * Test access related to the 'access deleted contact' permission
+   */
+  public function _testPermissionACLvsRelationship() {
+    // CRM_Core_Config::singleton()->userPermissionClass->permissions = array('edit all contacts', 'view all contacts');
+    // $contacts = $this->createScenarioPlain();
+  }
+
+  /**
+   * Test access related to the 'access deleted contact' permission
+   */
+  public function _testPermissionCompare() {
+    // CRM_Core_Config::singleton()->userPermissionClass->permissions = array('edit all contacts', 'view all contacts');
+    // $contacts = $this->createScenarioPlain();
+  }
+
+
+  /****************************************************
+   *             Scenario Builders                    *
+   ***************************************************/
+
+  /**
+   * create plain test scenario, no relationships/ACLs
+   */
+  protected function createScenarioPlain() {
     // get logged in user
     $user_id = $this->createLoggedInUser();
     $this->assertNotEmpty($user_id);
@@ -98,30 +181,43 @@ class CRM_ACL_ListTest extends CiviUnitTestCase {
     $bush_laura_id = $this->individualCreate(array('first_name' => 'Laura Lane', 'last_name' => 'Bush'));
     $bush_brbra_id = $this->individualCreate(array('first_name' => 'Barbara', 'last_name' => 'Bush'));
 
-    // create some relationships
-    $this->callAPISuccess('Relationship', 'create', array(
-      'relationship_type_id' => 1,  // CHILD OF
-      'contact_id_a'         => $bush_sr_id,
-      'contact_id_b'         => $user_id,
-      'is_permission_a_b'    => 1,
-      ));
-
-    $this->callAPISuccess('Relationship', 'create', array(
-      'relationship_type_id' => 1,  // CHILD OF
-      'contact_id_a'         => $bush_jr_id,
-      'contact_id_b'         => $bush_sr_id,
-      'is_permission_a_b'    => 1,
-      ));
-
-    // create some relationships
-    $this->callAPISuccess('Relationship', 'create', array(
-      'relationship_type_id' => 1,  // CHILD OF
-      'contact_id_a'         => $bush_brbra_id,
-      'contact_id_b'         => $bush_jr_id,
-      'is_permission_a_b'    => 1,
-      ));
-
-    return array($user_id, $bush_sr_id, $bush_jr_id, $bush_laura_id, $bush_brbra_id);
+    $contacts = array($user_id, $bush_sr_id, $bush_jr_id, $bush_laura_id, $bush_brbra_id);
+    sort($contacts);
+    return $contacts;
   }
 
+  /**
+   * create plain test scenario, no relationships/ACLs
+   */
+  protected function createScenarioRelation() {
+    $contacts = $this->createScenarioPlain();
+
+    // create some relationships
+    $this->callAPISuccess('Relationship', 'create', array(
+      'relationship_type_id' => 1,  // CHILD OF
+      'contact_id_a'         => $contacts[1],
+      'contact_id_b'         => $contacts[0],
+      'is_permission_b_a'    => 1,
+      'is_active'            => 1,
+      ));
+
+    $this->callAPISuccess('Relationship', 'create', array(
+      'relationship_type_id' => 1,  // CHILD OF
+      'contact_id_a'         => $contacts[2],
+      'contact_id_b'         => $contacts[1],
+      'is_permission_b_a'    => 1,
+      'is_active'            => 1,
+      ));
+
+    // create some relationships
+    $this->callAPISuccess('Relationship', 'create', array(
+      'relationship_type_id' => 1,  // CHILD OF
+      'contact_id_a'         => $contacts[4],
+      'contact_id_b'         => $contacts[2],
+      'is_permission_b_a'    => 1,
+      'is_active'            => 1,
+      ));
+
+    return $contacts;
+  }
 }


### PR DESCRIPTION
@systopia Do you want to look at this as a proposed replacement for your PR #9242 - Your PR is good except for a couple of things

1) it doesn't actually work
2) after fixing the reason it doesn't actually work it doesn't work for another reason 

:-)

Basically you are assuming an id-indexed list of contact ids is passed in & that is not the case (issue 1). After making them id-indexed it turns out the links function goes & bashes the carefully constructed link list out of the water.

Re performance - I'm feeling OK-ish about this but there is a problem that it actually gets called twice rather than once when creating a form. I think session caching is probably the only way to avoid this. I've added comments about that.

---
- [CRM-19494: Refactoring of permission code](https://issues.civicrm.org/jira/browse/CRM-19494)
