### PR TITLE
CRM-19093 - i18n executeQuery regex pb

### DIFF
--- a/CRM/Core/I18n/Schema.php
+++ b/CRM/Core/I18n/Schema.php
@@ -361,6 +361,9 @@ class CRM_Core_I18n_Schema {
     global $dbLocale;
     $tables = self::schemaStructureTables();
     foreach ($tables as $table) {
+      // CRM-19093
+      // should match the civicrm table name such as: civicrm_event
+      // but must not match the table name if it's a substring of another table: civicrm_events_in_cart
       $query = preg_replace("/([^'\"])({$table})([^a-z_'\"])/", "\\1\\2{$dbLocale}\\3", $query);
     }
     // uncomment the below to rewrite the civicrm_value_* queries

--- a/CRM/Core/I18n/Schema.php
+++ b/CRM/Core/I18n/Schema.php
@@ -361,7 +361,7 @@ class CRM_Core_I18n_Schema {
     global $dbLocale;
     $tables = self::schemaStructureTables();
     foreach ($tables as $table) {
-      $query = preg_replace("/([^'\"])({$table})([^_'\"])/", "\\1\\2{$dbLocale}\\3", $query);
+      $query = preg_replace("/([^'\"])({$table})([^a-z_'\"])/", "\\1\\2{$dbLocale}\\3", $query);
     }
     // uncomment the below to rewrite the civicrm_value_* queries
     // $query = preg_replace("/(civicrm_value_[a-z0-9_]+_\d+)([^_])/", "\\1{$dbLocale}\\2", $query);


### PR DESCRIPTION
Small fix that can have a big impact on multilingual installation of CiviCRM.
I have done a fair amount of test but a regex expert could help ensure it's the good approach.

The goal is to avoid having `civicrm_events_in_cart` being replaced by `civicrm_event_fr_CAs_in_cart` because the name contains the full name of another table, i.e. `civicrm_event`.

---
- [CRM-19093: executeQuery in i18n regex not working 100%](https://issues.civicrm.org/jira/browse/CRM-19093)
