### PR TITLE
Deprecated settings group name param

### DIFF
--- a/CRM/Core/BAO/Setting.php
+++ b/CRM/Core/BAO/Setting.php
@@ -64,7 +64,7 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
    * Retrieve the value of a setting from the DB table.
    *
    * @param string $group
-   *   (required) The group name of the item.
+   *   The group name of the item (deprecated).
    * @param string $name
    *   (required) The name under which this item is stored.
    * @param int $componentID
@@ -90,16 +90,14 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
     /** @var \Civi\Core\SettingsManager $manager */
     $manager = \Civi::service('settings_manager');
     $settings = ($contactID === NULL) ? $manager->getBagByDomain($domainID) : $manager->getBagByContact($domainID, $contactID);
-    if (TRUE) {
-      if ($name === NULL) {
-        CRM_Core_Error::debug_log_message("Deprecated: Group='$group'. Name should be provided.\n");
-      }
-      if ($componentID !== NULL) {
-        CRM_Core_Error::debug_log_message("Deprecated: Group='$group'. Name='$name'. Component should be omitted\n");
-      }
-      if ($defaultValue !== NULL) {
-        CRM_Core_Error::debug_log_message("Deprecated: Group='$group'. Name='$name'. Defaults should come from metadata\n");
-      }
+    if ($name === NULL) {
+      CRM_Core_Error::debug_log_message("Deprecated: Group='$group'. Name should be provided.\n");
+    }
+    if ($componentID !== NULL) {
+      CRM_Core_Error::debug_log_message("Deprecated: Group='$group'. Name='$name'. Component should be omitted\n");
+    }
+    if ($defaultValue !== NULL) {
+      CRM_Core_Error::debug_log_message("Deprecated: Group='$group'. Name='$name'. Defaults should come from metadata\n");
     }
     return $name ? $settings->get($name) : $settings->all();
   }
@@ -155,7 +153,7 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
    * @param object $value
    *   (required) The value that will be serialized and stored.
    * @param string $group
-   *   (required) The group name of the item.
+   *   The group name of the item (deprecated).
    * @param string $name
    *   (required) The name of the setting.
    * @param int $componentID
@@ -433,7 +431,7 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
   }
 
   /**
-   * @param $group
+   * @param $group (deprecated)
    * @param string $name
    * @param $value
    * @param bool $system


### PR DESCRIPTION
1. Flagged the group name param as deprecated.
2. Removed an if (TRUE) condition.
