### PR TITLE
CRM-19016 - Order mail processing by contact type to let individuals take precedence

### DIFF
--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -522,7 +522,8 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
                     WHERE       $eqTable.job_id = " . $this->id . "
                         AND     $edTable.id IS null
                         AND     $ebTable.id IS null
-                        AND    $contactTable.is_opt_out = 0";
+                        AND     $contactTable.is_opt_out = 0
+                    ORDER BY    $contactTable.contact_type";
 
     if ($mailing->sms_provider_id) {
       $query = "


### PR DESCRIPTION
When sending mass mailings some groups may contain organizations and individuals. If a pair of them share the same mail address (let's say »office@school.org«) and deduping is engaged, either the organization or the person will receive the mailing by random. But those emails may differ by token substitutions and thus greeting phrases. The organization would get an impersonal opening like »dear sirs and madams« while the person would get a personal salutation like "Dear Jane Doe". A team like a school's teaching stuff working with a shared email account would know to whom the mail concerns if we could guarantee that the persons get served first.

See [Improvement CRM-19016](https://issues.civicrm.org/jira/browse/CRM-19016)

Although a perfect solution would include a better handling of dýnamically changing contact type names, I just added a simple order by clause because performance tests with ~200k contacts increased consumed time by factor 10. And "Individual" comes before "Organization" in standard installations.
See line comment. 
