### PR TITLE
CRM_Contact_BAO_ContactType_ContactTest.testCRM19133 - Fix flaky test

### DIFF
--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -241,7 +241,7 @@ class CRM_Core_BAO_CustomValueTable {
             $params[$count] = array($entityID, 'Integer');
             $count++;
 
-            $fieldNames = implode(',', array_keys($set));
+            $fieldNames = implode(',', CRM_Utils_Type::escapeAll(array_keys($set), 'MysqlColumnNameOrAlias'));
             $fieldValues = implode(',', array_values($set));
             $query = "$sqlOP ( $fieldNames ) VALUES ( $fieldValues )";
             // for multiple values we dont do on duplicate key update


### PR DESCRIPTION
This test seems to involve creation of a custom-data group with a randomly
generated name. The random name sometimes begins with a number, which leads
to awkward SQL queries like:

```
INSERT INTO civicrm_value_15e5f1d45a5896753463467e8c380144_1  ( 15e5f1d45a5896753463467e8c380144_1,entity_id ) VALUES (...)
```

This patch updates `CRM_Core_BAO_CustomValueTable` to perform proper escaping on the column name.
