### PR TITLE
Remove phony fk info from case api

### DIFF
--- a/api/v3/Case.php
+++ b/api/v3/Case.php
@@ -140,13 +140,11 @@ function _civicrm_api3_case_get_spec(&$params) {
     'title' => 'Case Client',
     'description' => 'Contact id of one or more clients to retrieve cases for',
     'type' => CRM_Utils_Type::T_INT,
-    'FKApiName' => 'Contact',
   );
   $params['activity_id'] = array(
     'title' => 'Case Activity',
     'description' => 'Id of an activity in the case',
     'type' => CRM_Utils_Type::T_INT,
-    'FKApiName' => 'Activity',
   );
 }
 
@@ -163,7 +161,6 @@ function _civicrm_api3_case_create_spec(&$params) {
     'description' => 'Contact id of case client(s)',
     'api.required' => 1,
     'type' => CRM_Utils_Type::T_INT,
-    'FKApiName' => 'Contact',
   );
   $params['status_id']['api.default'] = 1;
   $params['status_id']['api.aliases'] = array('case_status');


### PR DESCRIPTION
This was messing up the api explorer's discovery of joins, and iirc was only added as a hack to make the api explorer render those fields more nicely.
