### PR TITLE
CRM-19506 - Fix api alias swapping

### DIFF
--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -942,6 +942,23 @@ class CRM_Utils_Array {
   }
 
   /**
+   * Index an array of arrays by an item in each array
+   *
+   * @param string|int $indexKey
+   * @param array $array
+   *
+   * @return array
+   */
+  public static function indexBy($indexKey, $array) {
+    $result = array();
+    foreach ($array as $key => $value) {
+      $newKey = CRM_Utils_Array::value($indexKey, $value, $key);
+      $result[$newKey] = $value;
+    }
+    return $result;
+  }
+
+  /**
    * Copy all properties of $other into $array (recursively).
    *
    * @param array|ArrayAccess $array

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -581,9 +581,18 @@ function _civicrm_api3_get_using_query_object($entity, $params, $additional_opti
   if (empty($returnProperties)) {
     $returnProperties = $defaultReturnProperties;
   }
+
+  $fields = civicrm_api($entity, 'getfields', array('version' => 3, 'action' => 'get'));
+
+  // Translate field names to unique names for the query builder
+  foreach ($fields['values'] as $uniqueName => $field) {
+    if (isset($field['name']) && isset($inputParams[$field['name']]) && $field['name'] != $uniqueName) {
+      $inputParams[$uniqueName] = $params[$field['name']];
+      unset($inputParams[$field['name']]);
+    }
+  }
+
   if (!empty($params['check_permissions'])) {
-    // we will filter query object against getfields
-    $fields = civicrm_api($entity, 'getfields', array('version' => 3, 'action' => 'get'));
     // we need to add this in as earlier in this function 'id' was unset in favour of $entity_id
     $fields['values'][$lowercase_entity . '_id'] = array();
     $varsToFilter = array('returnProperties', 'inputParams');

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -2116,6 +2116,7 @@ function _getStandardTypeFromCustomDataType($value) {
  */
 function _civicrm_api3_swap_out_aliases(&$apiRequest, $fields) {
   foreach ($fields as $field => $values) {
+    $field = CRM_Utils_Array::value('name', $values, $field);
     $uniqueName = CRM_Utils_Array::value('uniqueName', $values);
     if (!empty($values['api.aliases'])) {
       // if aliased field is not set we try to use field alias
@@ -2128,15 +2129,6 @@ function _civicrm_api3_swap_out_aliases(&$apiRequest, $fields) {
           // out of the woodwork but will be implementing only as _spec function extended
           unset($apiRequest['params'][$alias]);
         }
-      }
-    }
-    if (!isset($apiRequest['params'][$field]) && !empty($values['name']) && $field != $values['name']
-      && isset($apiRequest['params'][$values['name']])
-    ) {
-      $apiRequest['params'][$field] = $apiRequest['params'][$values['name']];
-      // note that it would make sense to unset the original field here but tests need to be in place first
-      if ($field != 'domain_version') {
-        unset($apiRequest['params'][$values['name']]);
       }
     }
     if (!isset($apiRequest['params'][$field])

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -1674,6 +1674,7 @@ function _civicrm_api3_validate_fields($entity, $action, &$params, $fields) {
       }
     }
   }
+  $fields = CRM_Utils_Array::indexBy('name', $fields);
   $fields = array_intersect_key($fields, $params);
   if (!empty($chainApiParams)) {
     $fields = array_merge($fields, $chainApiParams);

--- a/tests/phpunit/api/v3/CaseContactTest.php
+++ b/tests/phpunit/api/v3/CaseContactTest.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * @file
+ * File for the TestCase class
+ *
+ *  (PHP 5)
+ *
+ * @author Walt Haas <walt@dharmatech.org> (801) 534-1262
+ * @copyright Copyright CiviCRM LLC (C) 2009
+ * @license   http://www.fsf.org/licensing/licenses/agpl-3.0.html
+ *              GNU Affero General Public License version 3
+ * @version   $Id: ActivityTest.php 31254 2010-12-15 10:09:29Z eileen $
+ * @package   CiviCRM
+ *
+ *   This file is part of CiviCRM
+ *
+ *   CiviCRM is free software; you can redistribute it and/or
+ *   modify it under the terms of the GNU Affero General Public License
+ *   as published by the Free Software Foundation; either version 3 of
+ *   the License, or (at your option) any later version.
+ *
+ *   CiviCRM is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public
+ *   License along with this program.  If not, see
+ *   <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Include class definitions
+ */
+
+/**
+ *  Test APIv3 civicrm_case_* functions
+ *
+ * @package CiviCRM_APIv3
+ * @group headless
+ */
+class api_v3_CaseContactTest extends CiviCaseTestCase {
+  protected $_params;
+  protected $_entity;
+  protected $_cid;
+  /**
+   * Activity ID of created case.
+   *
+   * @var int
+   */
+  protected $_caseActivityId;
+
+  /**
+   * Test setup for every test.
+   *
+   * Connect to the database, truncate the tables that will be used
+   * and redirect stdin to a temporary file.
+   */
+  public function setUp() {
+    $this->_entity = 'case';
+
+    parent::setUp();
+
+    $this->_cid = $this->individualCreate();
+
+    $this->_case = $this->callAPISuccess('case', 'create', array(
+      'case_type_id' => $this->caseTypeId,
+      'subject' => __CLASS__,
+      'contact_id' => $this->_cid,
+    ));
+  }
+
+  public function testCaseContactGet() {
+    $result = $this->callAPIAndDocument('CaseContact', 'get', array(
+      'contact_id' => $this->_cid,
+    ), __FUNCTION__, __FILE__);
+    $this->assertEquals($this->_case['id'], $result['id']);
+  }
+
+}


### PR DESCRIPTION
- [CRM-19506: API Regression - uniquenames being passed to query builder](https://issues.civicrm.org/jira/browse/CRM-19506)
