### PR TITLE
CRM-19265 - Add Automplete-select to support fieldOptions() hook

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1047,13 +1047,12 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
 
         }
         else {
-          // FIXME: This won't work with customFieldOptions hook
           $attributes += array(
             'entity' => 'option_value',
             'placeholder' => $placeholder,
             'multiple' => $search,
             'api' => array(
-              'params' => array('option_group_id' => $field->option_group_id),
+              'params' => array('option_group_id' => $field->option_group_id, 'autocomplete_cfid' => $field->id),
             ),
           );
           $element = $qf->addEntityRef($elementName, $label, $attributes, $useRequired && !$search);
@@ -2452,6 +2451,49 @@ WHERE cf.id = %1 AND cg.is_multiple = 1";
         'labelColumn' => 'name',
       );
     }
+  }
+
+  /**
+   * Build hook options for Autocomplete-select widget.
+   *
+   * @param array $params
+   * @return array
+   */
+  public static function fieldOptionsForAutoCompleteSelect($params) {
+    $options = array();
+    $field = self::getFieldObject($params['autocomplete_cfid']);
+    $entity = $field->getEntity();
+
+    CRM_Utils_Hook::fieldOptions($entity, "custom_{$params['autocomplete_cfid']}", $options, array('context' => NULL));
+
+    $defaultValue = $filter = '';
+    if (!empty($params['label'])) {
+      $filter = trim($params['label']['LIKE'], '%');
+    }
+    if (!empty($params['value'])) {
+      $defaultValue = current($params['value']['IN']);
+    }
+
+    // Filter based on text search.
+    foreach ($options as $key => $val) {
+      if ($filter && stripos($val, $filter) === FALSE) {
+        unset($options[$key]);
+      }
+      else {
+        $options[$key] = array(
+          'value' => $key,
+          'label' => $val,
+        );
+      }
+    }
+    // Set default value if present.
+    if ($defaultValue && !empty($options)) {
+      $options = array_filter($options, function ($option) use ($defaultValue) {
+        return ($option['value'] == $defaultValue);
+      });
+    }
+
+    return $options;
   }
 
 }

--- a/api/v3/OptionValue.php
+++ b/api/v3/OptionValue.php
@@ -51,8 +51,14 @@ function civicrm_api3_option_value_get($params) {
     }
     $params['option_group_id'] = $optionGroup['id'];
   }
+  $options = _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
 
-  return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  if (!empty($params['autocomplete_cfid'])) {
+    $hookOptions = CRM_Core_BAO_CustomField::fieldOptionsForAutoCompleteSelect($params);
+    $options['values'] = array_merge($options['values'], $hookOptions);
+  }
+
+  return $options;
 }
 
 /**


### PR DESCRIPTION
- [CRM-19265: fieldOptions() hook doesn't load options for Autocomplete-Select widget](https://issues.civicrm.org/jira/browse/CRM-19265)

Options at the hook should be in the form of `$options['value'] = 'label'`. Will update the [docs for fieldOptions()](https://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_fieldOptions) if this gets merged.
