### PR TITLE
CRM-19510 - Fix multibyte trim breakage in news widget

### DIFF
--- a/templates/CRM/Dashlet/Page/Blog.tpl
+++ b/templates/CRM/Dashlet/Page/Blog.tpl
@@ -61,7 +61,7 @@
       <div class="crm-accordion-wrapper collapsed">
         <div class="crm-accordion-header">
           <span class="crm-news-feed-item-title">{$article.title}</span>
-          <span class="crm-news-feed-item-preview"> - {$article.description|strip_tags|substr:0:100}…</span>
+          <span class="crm-news-feed-item-preview"> - {$article.description|strip_tags|ltrim|mb_substr:0:100}…</span>
         </div>
         <div class="crm-accordion-body">
           <div>{$article.description}</div>


### PR DESCRIPTION
- [CRM-19510: Error message on Civi home page caused by CiviNews dashlet](https://issues.civicrm.org/jira/browse/CRM-19510)
