### PR TITLE
CRM-19512 - Return en_US by default from getLocale

### DIFF
--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -669,7 +669,7 @@ class CRM_Core_I18n {
    */
   public static function getLocale() {
     global $tsLocale;
-    return $tsLocale;
+    return $tsLocale ? $tsLocale : 'en_US';
   }
 
 }


### PR DESCRIPTION
- [CRM-19512: Ensure that language param is always passed in for navigation script url](https://issues.civicrm.org/jira/browse/CRM-19512)
