### PR TITLE
CRM-16352: 4.7.13 Upgrade miss

### DIFF
--- a/CRM/Upgrade/Incremental/sql/4.7.13.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.7.13.mysql.tpl
@@ -19,3 +19,6 @@ WHERE `name` = 'New Tag';
 UPDATE civicrm_navigation SET
   `url` = 'civicrm/admin/tag?reset=1'
 WHERE `name` = 'Tags (Categories)';
+
+-- CRM-16352: Add language filter support for mass mailing
+ALTER TABLE civicrm_mailing ADD COLUMN `language` varchar(5) DEFAULT NULL COMMENT 'Language of the content of the mailing. Useful for tokens.';


### PR DESCRIPTION
- [CRM-16352: CiviMail in multilingual sites: allow to define the language of the mailing, for tokens](https://issues.civicrm.org/jira/browse/CRM-16352)
