### PR TITLE
CRM-19533 System check: check for writable directories

### DIFF
--- a/CRM/Utils/Check/Component/Security.php
+++ b/CRM/Utils/Check/Component/Security.php
@@ -323,10 +323,15 @@ class CRM_Utils_Check_Component_Security extends CRM_Utils_Check_Component {
     }
 
     $result = FALSE;
-    $file = 'delete-this-' . CRM_Utils_String::createRandom(10, CRM_Utils_String::ALPHANUMERIC);
 
     // this could be a new system with no uploads (yet) -- so we'll make a file
-    file_put_contents("$dir/$file", "delete me");
+    $file = CRM_Utils_File::createFakeFile($dir);
+
+    if ($file === FALSE) {
+      // Couldn't write the file
+      return FALSE;
+    }
+
     $content = @file_get_contents("$url");
     if (stristr($content, $file)) {
       $result = TRUE;
@@ -347,17 +352,18 @@ class CRM_Utils_Check_Component_Security extends CRM_Utils_Check_Component {
    * @return bool
    */
   public function isDirAccessible($dir, $url) {
-    $dir = rtrim($dir, '/');
     $url = rtrim($url, '/');
     if (empty($dir) || empty($url) || !is_dir($dir)) {
       return FALSE;
     }
 
     $result = FALSE;
-    $file = 'delete-this-' . CRM_Utils_String::createRandom(10, CRM_Utils_String::ALPHANUMERIC);
+    $file = CRM_Utils_File::createFakeFile($dir, 'delete me');
 
-    // this could be a new system with no uploads (yet) -- so we'll make a file
-    file_put_contents("$dir/$file", "delete me");
+    if ($file === FALSE) {
+      // Couldn't write the file
+      return FALSE;
+    }
 
     $headers = @get_headers("$url/$file");
     if (stripos($headers[0], '200')) {

--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -287,6 +287,25 @@ class CRM_Utils_File {
   }
 
   /**
+   * Save a fake file somewhere
+   *
+   * @param string $dir
+   *   The directory where the file should be saved.
+   * @param string $contents
+   *   Optional: the contents of the file.
+   *
+   * @return string
+   *   The filename saved, or FALSE on failure.
+   */
+  public static function createFakeFile($dir, $contents = 'delete me') {
+    $dir = self::addTrailingSlash($dir);
+    $file = 'delete-this-' . CRM_Utils_String::createRandom(10, CRM_Utils_String::ALPHANUMERIC);
+    $success = file_put_contents($dir . $file, $contents);
+
+    return ($success === FALSE) ? FALSE : $file;
+  }
+
+  /**
    * @param string|NULL $dsn
    *   Use NULL to load the default/active connection from CRM_Core_DAO.
    *   Otherwise, give a full DSN string.


### PR DESCRIPTION
A couple of other checks use the process of creating a fake file in certain directories.  I pulled that out into its own static method: `CRM_Utils_File::createFakeFile()`.  That then is used to try creating fake files in the four directories listed.

---
- [CRM-19533: System check to see if important folders are writable](https://issues.civicrm.org/jira/browse/CRM-19533)
