### PR TITLE
CRM-19536 - ensure type is defined for campaign_id

### DIFF
--- a/CRM/Report/Form/Member/Lapse.php
+++ b/CRM/Report/Form/Member/Lapse.php
@@ -190,6 +190,7 @@ class CRM_Report_Form_Member_Lapse extends CRM_Report_Form {
         'title' => ts('Campaign'),
         'operatorType' => CRM_Report_Form::OP_MULTISELECT,
         'options' => $this->activeCampaigns,
+        'type' => CRM_Utils_Type::T_INT,
       );
     }
 


### PR DESCRIPTION
- [CRM-19536: Type is not defined for field campaign_id in CRM_Report_Form->whereClause()](https://issues.civicrm.org/jira/browse/CRM-19536)
