### PR TITLE
Fix for CRM-19537 -- backporting fix to make smartGroupCacheTimeout of 0 possible

### DIFF
--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -600,8 +600,7 @@ AND  civicrm_group_contact.group_id = $groupID ";
 
     if (
       isset($config->smartGroupCacheTimeout) &&
-      is_numeric($config->smartGroupCacheTimeout) &&
-      $config->smartGroupCacheTimeout > 0
+      is_numeric($config->smartGroupCacheTimeout)
     ) {
       return $config->smartGroupCacheTimeout;
     }


### PR DESCRIPTION
- [CRM-19537: Smart Groups with 0 min cache timeouts taking more than 0 minutes to timeout](https://issues.civicrm.org/jira/browse/CRM-19537)
