### PR TITLE
CRM-19535 - Conditionally add is_active param to entityRef

### DIFF
--- a/api/v3/Event.php
+++ b/api/v3/Event.php
@@ -226,10 +226,12 @@ function _civicrm_api3_event_getlist_params(&$request) {
   $fieldsToReturn = array('start_date', 'event_type_id', 'title', 'summary');
   $request['params']['return'] = array_unique(array_merge($fieldsToReturn, $request['extra']));
   $request['params']['options']['sort'] = 'start_date DESC';
-  $request['params'] += array(
-    'is_template' => 0,
-    'is_active' => 1,
-  );
+  if (empty($request['params']['id'])) {
+    $request['params'] += array(
+      'is_template' => 0,
+      'is_active' => 1,
+    );
+  }
 }
 
 /**

--- a/api/v3/MembershipType.php
+++ b/api/v3/MembershipType.php
@@ -109,7 +109,7 @@ function civicrm_api3_membership_type_get($params) {
  *   Array of parameters determined by getfields.
  */
 function _civicrm_api3_membership_type_getlist_params(&$request) {
-  if (!isset($request['params']['is_active'])) {
+  if (!isset($request['params']['is_active']) && empty($request['params']['id'])) {
     $request['params']['is_active'] = 1;
   }
 }


### PR DESCRIPTION
- [CRM-19535: Workflow that inadvertently cancels all registrants all enabled events](https://issues.civicrm.org/jira/browse/CRM-19535)
