### PR TITLE
CRM-19543: contact_id should be marked as required on grant api

### DIFF
--- a/api/v3/Grant.php
+++ b/api/v3/Grant.php
@@ -56,6 +56,8 @@ function civicrm_api3_grant_create($params) {
 function _civicrm_api3_grant_create_spec(&$params) {
   $params['contact_id']['api.required'] = 1;
   $params['grant_type_id']['api.required'] = 1;
+  $params['status_id']['api.required'] = 1;
+  $params['amount_total']['api.required'] = 1;
   $params['status_id']['api.aliases'] = array('grant_status');
 }
 

--- a/api/v3/Grant.php
+++ b/api/v3/Grant.php
@@ -54,6 +54,7 @@ function civicrm_api3_grant_create($params) {
  *   Array of parameters determined by getfields.
  */
 function _civicrm_api3_grant_create_spec(&$params) {
+  $params['contact_id']['api.required'] = 1;
   $params['grant_type_id']['api.required'] = 1;
   $params['status_id']['api.aliases'] = array('grant_status');
 }


### PR DESCRIPTION
The UI and the API state that this is a required field, but the create_spec does not. Hence adding it.

---
- [CRM-19543: api fields set to '0' are not passed to _civicrm_api3_api_match_pseudoconstant for validation](https://issues.civicrm.org/jira/browse/CRM-19543)
