### PR TITLE
CRM-19595 : Adding street address to the survey details report

### DIFF
--- a/CRM/Report/Form/Campaign/SurveyDetails.php
+++ b/CRM/Report/Form/Campaign/SurveyDetails.php
@@ -143,100 +143,6 @@ class CRM_Report_Form_Campaign_SurveyDetails extends CRM_Report_Form {
         ),
         'grouping' => 'location-fields',
       ),
-      'civicrm_address' => array(
-        'dao' => 'CRM_Core_DAO_Address',
-        'fields' => array(
-          'street_number' => array(
-            'name' => 'street_number',
-            'title' => ts('Street Number'),
-            'type' => 1,
-          ),
-          'street_address' => array(
-            'name' => 'street_address',
-            'title' => ts('Street Address'),
-            'type' => 1,
-          ),
-          'street_name' => array(
-            'name' => 'street_name',
-            'title' => ts('Street Name'),
-            'type' => 1,
-          ),
-          'street_unit' => array(
-            'name' => 'street_unit',
-            'title' => ts('Street Unit'),
-            'type' => 1,
-          ),
-          'postal_code' => array(
-            'name' => 'postal_code',
-            'title' => ts('Postal Code'),
-            'type' => 1,
-          ),
-          'city' => array(
-            'name' => 'city',
-            'title' => ts('City'),
-            'type' => 1,
-          ),
-          'state_province_id' => array(
-            'name' => 'state_province_id',
-            'title' => ts('State/Province'),
-          ),
-          'country_id' => array(
-            'name' => 'country_id',
-            'title' => ts('Country'),
-          ),
-        ),
-        'filters' => array(
-          'street_address' => array(
-            'title' => ts('Street Address'),
-            'operator' => 'like',
-            'name' => 'street_address',
-          ),
-          'street_number' => array(
-            'title' => ts('Street Number'),
-            'type' => 1,
-            'name' => 'street_number',
-          ),
-          'street_name' => array(
-            'title' => ts('Street Name'),
-            'name' => 'street_name',
-            'operator' => 'like',
-          ),
-          'postal_code' => array(
-            'title' => ts('Postal Code'),
-            'type' => 1,
-            'name' => 'postal_code',
-          ),
-          'city' => array(
-            'title' => ts('City'),
-            'operator' => 'like',
-            'name' => 'city',
-          ),
-          'state_province_id' => array(
-            'name' => 'state_province_id',
-            'title' => ts('State/Province'),
-            'type' => CRM_Utils_Type::T_INT,
-            'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-            'options' => CRM_Core_PseudoConstant::stateProvince(),
-          ),
-          'country_id' => array(
-            'name' => 'country_id',
-            'title' => ts('Country'),
-            'type' => CRM_Utils_Type::T_INT,
-            'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-            'options' => CRM_Core_PseudoConstant::country(),
-          ),
-        ),
-        'order_bys' => array(
-          'street_name' => array('title' => ts('Street Name')),
-          'street_number_odd_even' => array(
-            'title' => ts('Odd / Even Street Number'),
-            'name' => 'street_number',
-            'dbAlias' => 'address_civireport.street_number%2',
-          ),
-          'street_number' => array('title' => ts('Street Number')),
-        ),
-        'grouping' => 'location-fields',
-      ),
       'civicrm_email' => array(
         'dao' => 'CRM_Core_DAO_Email',
         'fields' => array(
@@ -297,7 +203,7 @@ class CRM_Report_Form_Campaign_SurveyDetails extends CRM_Report_Form {
         ),
         'grouping' => 'survey-activity-fields',
       ),
-    );
+    ) + $this->addAddressFields();
     parent::__construct();
   }
 

--- a/CRM/Report/Form/Campaign/SurveyDetails.php
+++ b/CRM/Report/Form/Campaign/SurveyDetails.php
@@ -151,6 +151,11 @@ class CRM_Report_Form_Campaign_SurveyDetails extends CRM_Report_Form {
             'title' => ts('Street Number'),
             'type' => 1,
           ),
+          'street_address' => array(
+            'name' => 'street_address',
+            'title' => ts('Street Address'),
+            'type' => 1,
+          ),
           'street_name' => array(
             'name' => 'street_name',
             'title' => ts('Street Name'),
@@ -181,6 +186,11 @@ class CRM_Report_Form_Campaign_SurveyDetails extends CRM_Report_Form {
           ),
         ),
         'filters' => array(
+          'street_address' => array(
+            'title' => ts('Street Address'),
+            'operator' => 'like',
+            'name' => 'street_address',
+          ),
           'street_number' => array(
             'title' => ts('Street Number'),
             'type' => 1,


### PR DESCRIPTION
Adding Street Address field to Survey Details Report (previously it only had the street unit and street name)

---

 * [CRM-19595: Adding street address to the survey details report](https://issues.civicrm.org/jira/browse/CRM-19595)