### PR TITLE
CRM-19222 Export: temp table field length at least 255 for strings

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -1420,7 +1420,8 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
 
             switch ($query->_fields[$field]['data_type']) {
               case 'String':
-                $length = empty($query->_fields[$field]['text_length']) ? 255 : $query->_fields[$field]['text_length'];
+                // May be option labels, which could be up to 512 characters
+                $length = max(512, CRM_Utils_Array::value('text_length', $query->_fields[$field]));
                 $sqlColumns[$fieldName] = "$fieldName varchar($length)";
                 break;
 


### PR DESCRIPTION
---
- CRM-19222: Data too long on export including custom field
  https://issues.civicrm.org/jira/browse/CRM-19222

This is an alternate to https://github.com/civicrm/civicrm-core/pull/8876 and matches what has gone into master
