### PR TITLE
CRM-19552: If no case_id provided to Case API, use the provided ID.

### DIFF
--- a/api/v3/Case.php
+++ b/api/v3/Case.php
@@ -310,6 +310,10 @@ function _civicrm_api3_case_deprecation() {
  *   api result array
  */
 function civicrm_api3_case_update($params) {
+  if (!isset($params['case_id']) && isset($params['id'])) {
+    $params['case_id'] = $params['id'];
+  }
+
   //check parameters
   civicrm_api3_verify_mandatory($params, NULL, array('id'));
 


### PR DESCRIPTION
CRM-19552

---
- [CRM-19552: Case API may throw SQL errors when case_id not provided](https://issues.civicrm.org/jira/browse/CRM-19552)
