### PR TITLE
CRM-19543: Fix integer 0 validation for pseudoconstants

### DIFF
--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -2172,7 +2172,7 @@ function _civicrm_api3_validate_integer(&$params, &$fieldName, &$fieldInfo, $ent
     return;
   }
 
-  if (isset($fieldValue)) {
+  if (!empty($fieldValue)) {
     // if value = 'user_contact_id' (or similar), replace value with contact id
     if (!is_numeric($fieldValue) && is_scalar($fieldValue)) {
       $realContactId = _civicrm_api3_resolve_contactID($fieldValue);
@@ -2201,6 +2201,9 @@ function _civicrm_api3_validate_integer(&$params, &$fieldName, &$fieldInfo, $ent
         2100, array('field' => $fieldName, "max_length" => $fieldInfo['maxlength'])
       );
     }
+  }
+  elseif ($fieldValue === 0 && (!empty($fieldInfo['pseudoconstant']) || !empty($fieldInfo['options']))) {
+    throw new API_Exception("'0' is not a valid option for field $fieldName", 2001, array('error_field' => $fieldName));
   }
 
   if (!empty($op)) {
@@ -2389,9 +2392,8 @@ function _civicrm_api3_api_match_pseudoconstant_value(&$value, $options, $fieldN
     return;
   }
 
-  // Translate value into key. Use strict param to avoid
-  // incorrect return of first key when $value is 0.
-  $newValue = array_search($value, $options, TRUE);
+  // Translate value into key.
+  $newValue = array_search($value, $options);
   if ($newValue !== FALSE) {
     $value = $newValue;
     return;

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -2172,7 +2172,7 @@ function _civicrm_api3_validate_integer(&$params, &$fieldName, &$fieldInfo, $ent
     return;
   }
 
-  if (!empty($fieldValue)) {
+  if (isset($fieldValue)) {
     // if value = 'user_contact_id' (or similar), replace value with contact id
     if (!is_numeric($fieldValue) && is_scalar($fieldValue)) {
       $realContactId = _civicrm_api3_resolve_contactID($fieldValue);
@@ -2389,8 +2389,9 @@ function _civicrm_api3_api_match_pseudoconstant_value(&$value, $options, $fieldN
     return;
   }
 
-  // Translate value into key
-  $newValue = array_search($value, $options);
+  // Translate value into key. Use strict param to avoid
+  // incorrect return of first key when $value is 0.
+  $newValue = array_search($value, $options, TRUE);
   if ($newValue !== FALSE) {
     $value = $newValue;
     return;

--- a/tests/phpunit/api/v3/ValidateTest.php
+++ b/tests/phpunit/api/v3/ValidateTest.php
@@ -86,4 +86,27 @@ class api_v3_ValidateTest extends CiviUnitTestCase {
     $this->assertEquals($validation['values'][0], $expectedOut);
   }
 
+  /**
+   * Test Grant status with `0` value.
+   */
+  public function testGrantWithZeroStatus() {
+    $params = array(
+      'action' => 'create',
+      'grant_type_id' => "Emergency",
+      'amount_total' => 100,
+      'contact_id' => "1",
+      'status_id' => 0,
+    );
+    $validation = $this->callAPISuccess('Grant', 'validate', $params);
+
+    $expectedOut = array(
+      'status_id' => array(
+        'message' => "'0' is not a valid option for field status_id",
+        'code' => "incorrect_value",
+      ),
+    );
+
+    $this->assertEquals($validation['values'][0], $expectedOut);
+  }
+
 }


### PR DESCRIPTION
`array_search` incorrectly returns the first key when integer 0 is searched on an array of strings. This creates an entity with first value of a pseudocontant. 

For eg: `Grant` is created with `Submitted` status, Membership is created with `New` status, etc.

Update: Instead of handling it with `array_search`, moved this validation to a separate if check as it was failing only for `0` value.

@colemanw  Any thoughts ?

---
- [CRM-19543: api fields set to '0' are not passed to _civicrm_api3_api_match_pseudoconstant for validation](https://issues.civicrm.org/jira/browse/CRM-19543)
