### PR TITLE
CRM-19543 - Fix integer 0 matching for api pseudoconstants

### DIFF
--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -2172,7 +2172,7 @@ function _civicrm_api3_validate_integer(&$params, &$fieldName, &$fieldInfo, $ent
     return;
   }
 
-  if (!empty($fieldValue)) {
+  if (!empty($fieldValue) || $fieldValue === '0' || $fieldValue === 0) {
     // if value = 'user_contact_id' (or similar), replace value with contact id
     if (!is_numeric($fieldValue) && is_scalar($fieldValue)) {
       $realContactId = _civicrm_api3_resolve_contactID($fieldValue);
@@ -2390,7 +2390,8 @@ function _civicrm_api3_api_match_pseudoconstant_value(&$value, $options, $fieldN
   }
 
   // Translate value into key
-  $newValue = array_search($value, $options);
+  // Cast $value to string to avoid a bug in array_search
+  $newValue = array_search((string) $value, $options);
   if ($newValue !== FALSE) {
     $value = $newValue;
     return;

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -2184,7 +2184,7 @@ function _civicrm_api3_validate_integer(&$params, &$fieldName, &$fieldInfo, $ent
       }
     }
     if (!empty($fieldInfo['pseudoconstant']) || !empty($fieldInfo['options'])) {
-      _civicrm_api3_api_match_pseudoconstant($fieldValue, $entity, $fieldName, $fieldInfo);
+      _civicrm_api3_api_match_pseudoconstant($fieldValue, $entity, $fieldName, $fieldInfo, $op);
     }
 
     // After swapping options, ensure we have an integer(s)
@@ -2305,7 +2305,7 @@ function _civicrm_api3_validate_string(&$params, &$fieldName, &$fieldInfo, $enti
     }
   }
   if (!empty($fieldInfo['pseudoconstant']) || !empty($fieldInfo['options'])) {
-    _civicrm_api3_api_match_pseudoconstant($fieldValue, $entity, $fieldName, $fieldInfo);
+    _civicrm_api3_api_match_pseudoconstant($fieldValue, $entity, $fieldName, $fieldInfo, $op);
   }
   // Check our field length
   elseif (is_string($fieldValue) && !empty($fieldInfo['maxlength']) && strlen(utf8_decode($fieldValue)) > $fieldInfo['maxlength']) {
@@ -2329,10 +2329,15 @@ function _civicrm_api3_validate_string(&$params, &$fieldName, &$fieldInfo, $enti
  * @param string $entity : api entity name
  * @param string $fieldName : field name used in api call (not necessarily the canonical name)
  * @param array $fieldInfo : getfields meta-data
+ * @param string $op
  *
  * @throws \API_Exception
  */
-function _civicrm_api3_api_match_pseudoconstant(&$fieldValue, $entity, $fieldName, $fieldInfo) {
+function _civicrm_api3_api_match_pseudoconstant(&$fieldValue, $entity, $fieldName, $fieldInfo, $op = '=') {
+  if (in_array($op, array('>', '<', '>=', '<=', 'LIKE', 'NOT LIKE'))) {
+    return;
+  }
+
   $options = CRM_Utils_Array::value('options', $fieldInfo);
 
   if (!$options) {

--- a/tests/phpunit/api/v3/GrantTest.php
+++ b/tests/phpunit/api/v3/GrantTest.php
@@ -143,4 +143,27 @@ class api_v3_GrantTest extends CiviUnitTestCase {
     $this->assertEquals(0, $checkDeleted['count']);
   }
 
+  /**
+   * Test Grant status with `0` value.
+   */
+  public function testGrantWithZeroStatus() {
+    $params = array(
+      'action' => 'create',
+      'grant_type_id' => "Emergency",
+      'amount_total' => 100,
+      'contact_id' => "1",
+      'status_id' => 0,
+      'id' => 1,
+    );
+    $validation = $this->callAPISuccess('Grant', 'validate', $params);
+
+    $expectedOut = array(
+      'status_id' => array(
+        'message' => "'0' is not a valid option for field status_id",
+        'code' => "incorrect_value",
+      ),
+    );
+    $this->assertEquals($validation['values'][0], $expectedOut);
+  }
+
 }


### PR DESCRIPTION
- [CRM-19543: api fields set to '0' are not passed to _civicrm_api3_api_match_pseudoconstant for validation](https://issues.civicrm.org/jira/browse/CRM-19543)
