### PR TITLE
CRM-19313: Fix custom group page warnings

### DIFF
--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -551,9 +551,7 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
       }
     }
 
-    if (empty($contactSubType)) {
-      $contactSubType = array();
-    }
+    $contactSubType = (array) $contactSubType;
     if ($contactId) {
       $contactType = CRM_Contact_BAO_Contact::getContactType($contactId);
       $contactSubType = CRM_Contact_BAO_Contact::getContactSubType($contactId);


### PR DESCRIPTION
@colemanw Following the comment on https://github.com/civicrm/civicrm-core/pull/9287#issuecomment-254725936, there are [still warnings displayed](http://dmaster.demo.civicrm.org/civicrm/admin/custom/group?reset=1)  on custom group page. Typecasting instead fixes it.

---
- [CRM-19313: Can't assign custom group to relationships with two contact subtypes involved](https://issues.civicrm.org/jira/browse/CRM-19313)
