### PR TITLE
CRM-19564 - Refactor multiline options

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -926,15 +926,31 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
         break;
 
       case 'Radio':
-        $choice = array();
+      case 'CheckBox':
+        $choices = array();
+        $i = 0;
         foreach ($options as $v => $l) {
-          $choice[] = $qf->createElement('radio', NULL, '', $l, (string) $v, $field->attributes);
+          if ($widget == 'Radio') {
+            $choice = $qf->createElement('radio', NULL, '', $l, (string) $v, $field->attributes);
+          }
+          else {
+            $choice = $qf->addElement('advcheckbox', $v, NULL, $l, array('data-crm-custom' => $dataCrmCustomVal));
+          }
+          if ($i && !empty($field->options_per_line) && !($i % $field->options_per_line)) {
+            $choice->setPrefix('<br />');
+          }
+          $i++;
+          $choices[] = $choice;
         }
-        $element = $qf->addGroup($choice, $elementName, $label);
+        $element = $qf->addGroup($choices, $elementName, $label);
+        if (!empty($field->options_per_line)) {
+          $element->setPrefix('<div class="crm-multiline-options">');
+          $element->setSuffix('</div>');
+        }
         if ($useRequired && !$search) {
           $qf->addRule($elementName, ts('%1 is a required field.', array(1 => $label)), 'required');
         }
-        else {
+        elseif ($widget == 'Radio') {
           $element->setAttribute('allowClear', TRUE);
         }
         break;
@@ -974,17 +990,6 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
         $element->setButtonAttributes('add', array('value' => ts('Add >>')));
         $element->setButtonAttributes('remove', array('value' => ts('<< Remove')));
 
-        if ($useRequired && !$search) {
-          $qf->addRule($elementName, ts('%1 is a required field.', array(1 => $label)), 'required');
-        }
-        break;
-
-      case 'CheckBox':
-        $check = array();
-        foreach ($options as $v => $l) {
-          $check[] = &$qf->addElement('advcheckbox', $v, NULL, $l, array('data-crm-custom' => $dataCrmCustomVal));
-        }
-        $element = $qf->addGroup($check, $elementName, $label);
         if ($useRequired && !$search) {
           $qf->addRule($elementName, ts('%1 is a required field.', array(1 => $label)), 'required');
         }

--- a/templates/CRM/Case/Page/CustomDataView.tpl
+++ b/templates/CRM/Case/Page/CustomDataView.tpl
@@ -35,18 +35,8 @@
       {foreach from=$cd_edit.fields item=element key=field_id}
         <table class="crm-info-panel">
           <tr>
-            {if $element.options_per_line != 0}
-              <td class="label">{$element.field_title}</td>
-              <td class="html-adjust">
-              {* sort by fails for option per line. Added a variable to iterate through the element array*}
-                {foreach from=$element.field_value item=val}
-                  {$val}<br/>
-                {/foreach}
-              </td>
-              {else}
-                <td class="label">{$element.field_title}</td>
-                <td class="html-adjust">{$element.field_value}</td>
-            {/if}
+            <td class="label">{$element.field_title}</td>
+            <td class="html-adjust">{$element.field_value}</td>
           </tr>
         </table>
       {/foreach}

--- a/templates/CRM/Contact/Form/Edit/Address/CustomField.tpl
+++ b/templates/CRM/Contact/Form/Edit/Address/CustomField.tpl
@@ -31,41 +31,6 @@
             <td class="html-adjust description">{$element.help_pre}</td>
         </tr>
     {/if}
-     {if $element.options_per_line != 0 }
-        <tr>
-            <td class="label">{$form.address.$blockId.$element_name.label}</td>
-            <td class="html-adjust">
-                {assign var="count" value="1"}
-                <table class="form-layout-compressed" style="margin-top: -0.5em;">
-                    <tr>
-                        {* sort by fails for option per line. Added a variable to iterate through the element array*}
-                        {assign var="index" value="1"}
-                        {foreach name=outer key=key item=item from=$form.address.$blockId.$element_name}
-                            {if $index < 10}
-                                {assign var="index" value=`$index+1`}
-                            {else}
-                                <td class="labels font-light">{$form.address.$blockId.$element_name.$key.html}</td>
-                                {if $count == $element.options_per_line}
-                                    </tr>
-                                    <tr>
-                                    {assign var="count" value="1"}
-                                {else}
-                                    {assign var="count" value=`$count+1`}
-                                {/if}
-                            {/if}
-                        {/foreach}
-                    </tr>
-                </table>
-            </td>
-        </tr>
-
-        {if $element.help_post}
-            <tr>
-                <td>&nbsp;</td>
-                <td class="description">{$element.help_post}<br />&nbsp;</td>
-            </tr>
-             {/if}
-    {else}
         <tr>
             <td class="label">{$form.address.$blockId.$element_name.label}</td>
             <td class="html-adjust">
@@ -102,6 +67,5 @@
 <td>&nbsp;</td>
 <td class="description">{$element.help_post}<br />&nbsp;</td>
 </tr>
-        {/if}
     {/if}
 {/if}

--- a/templates/CRM/Contact/Page/View/CustomDataFieldView.tpl
+++ b/templates/CRM/Contact/Page/View/CustomDataFieldView.tpl
@@ -33,15 +33,6 @@
 
     {foreach from=$cd_edit.fields item=element key=field_id}
       <div class="crm-summary-row">
-        {if $element.options_per_line != 0}
-          <div class="crm-label">{$element.field_title}</div>
-          <div class="crm-content crm-custom_data">
-              {* sort by fails for option per line. Added a variable to iterate through the element array*}
-              {foreach from=$element.field_value item=val}
-                {$val}
-              {/foreach}
-          </div>
-        {else}
           <div class="crm-label">{$element.field_title}</div>
           {if $element.field_data_type EQ 'ContactReference' && $element.contact_ref_id}
             {*Contact ref id passed if user has sufficient permissions - so make a link.*}
@@ -55,7 +46,6 @@
           {else}
             <div class="crm-content crm-custom-data">{$element.field_value}</div>
           {/if}
-        {/if}
       </div>
     {/foreach}
   </div>

--- a/templates/CRM/Custom/Form/CustomField.tpl
+++ b/templates/CRM/Custom/Form/CustomField.tpl
@@ -31,35 +31,6 @@
             <td class="html-adjust description">{$element.help_pre}</td>
         </tr>
     {/if}
-     {if $element.options_per_line != 0 }
-        <tr class="custom_field-row {$element.element_name}-row">
-            <td class="label">{$form.$element_name.label}{if $element.help_post}{help id=$element.id file="CRM/Custom/Form/CustomField.hlp" title=$element.label}{/if}</td>
-            <td class="html-adjust">
-                {assign var="count" value="1"}
-                <table class="form-layout-compressed" style="margin-top: -0.5em;">
-                    <tr>
-                        {* sort by fails for option per line. Added a variable to iterate through the element array*}
-                        {assign var="index" value="1"}
-                        {foreach name=outer key=key item=item from=$form.$element_name}
-                            {if $index < 10}
-                                {assign var="index" value=`$index+1`}
-                            {else}
-                                <td class="labels font-light">{$form.$element_name.$key.html}</td>
-                                {if $count == $element.options_per_line}
-                                    </tr>
-                                    <tr>
-                                    {assign var="count" value="1"}
-                                {else}
-                                    {assign var="count" value=`$count+1`}
-                                {/if}
-                            {/if}
-                        {/foreach}
-                    </tr>
-                </table>
-            </td>
-        </tr>
-
-    {else}
         <tr class="custom_field-row {$element.element_name}-row">
             <td class="label">{$form.$element_name.label}{if $element.help_post}{help id=$element.id file="CRM/Custom/Form/CustomField.hlp" title=$element.label}{/if}</td>
             <td class="html-adjust">
@@ -92,4 +63,3 @@
             </td>
         </tr>
 
-    {/if}

--- a/templates/CRM/Custom/Form/Preview.tpl
+++ b/templates/CRM/Custom/Form/Preview.tpl
@@ -49,35 +49,6 @@
         {if $element.help_pre}
             <tr><td class="label"></td><td class="description">{$element.help_pre}</td></tr>
         {/if}
-  {if $element.options_per_line }
-        {*assign var="element_name" value=$element.custom_group_id|cat:_|cat:$field_id|cat:_|cat:$element.name*}
-        {assign var="element_name" value=$element.element_name}
-        <tr>
-         <td class="label">{$form.$element_name.label}{if $element.help_post}{help id=$element.id file="CRM/Custom/Form/CustomField.hlp" title=$form.$element_name.label}{/if}</td>
-         <td>
-            {assign var="count" value="1"}
-                <table class="form-layout-compressed">
-                 <tr>
-                   {* sort by fails for option per line. Added a variable to iterate through the element array*}
-                   {assign var="index" value="1"}
-                   {foreach name=outer key=key item=item from=$form.$element_name}
-                        {if $index < 10}
-                            {assign var="index" value=`$index+1`}
-                        {else}
-                          <td class="labels font-light">{$form.$element_name.$key.html}</td>
-                              {if $count == $element.options_per_line}
-                                {assign var="count" value="1"}
-                           </tr>
-                            {else}
-                                {assign var="count" value=`$count+1`}
-                            {/if}
-                         {/if}
-                    {/foreach}
-                 </tr>
-                </table>
-         </td>
-        </tr>
-  {else}
         {assign var="name" value=`$element.name`}
         {*assign var="element_name" value=$group_id|cat:_|cat:$field_id|cat:_|cat:$element.name*}
         {assign var="element_name" value=$element.element_name}
@@ -91,7 +62,6 @@
                 {/if}
         {/if}
           </td>
-  {/if}
      {/if}
     {/foreach}
     </table>

--- a/templates/CRM/Profile/Form/Dynamic.tpl
+++ b/templates/CRM/Profile/Form/Dynamic.tpl
@@ -111,37 +111,6 @@
             <div class="content description">{$field.help_pre}</div>
           </div>
         {/if}
-        {if $field.options_per_line}
-          <div class="crm-section editrow_{$n}-section form-item" id="editrow-{$n}">
-            <div class="label">{$form.$n.label}</div>
-            <div class="content edit-value">
-              {assign var="count" value="1"}
-              {strip}
-                <table class="form-layout-compressed">
-                <tr>
-                {* sort by fails for option per line. Added a variable to iterate through the element array*}
-                  {assign var="index" value="1"}
-                  {foreach name=outer key=key item=item from=$form.$n}
-                    {if $index < 10}
-                      {assign var="index" value=`$index+1`}
-                    {else}
-                      <td class="labels font-light">{$form.$n.$key.html}</td>
-                      {if $count == $field.options_per_line}
-                      </tr>
-                      <tr>
-                        {assign var="count" value="1"}
-                        {else}
-                        {assign var="count" value=`$count+1`}
-                      {/if}
-                    {/if}
-                  {/foreach}
-                </tr>
-                </table>
-              {/strip}
-            </div>
-            <div class="clear"></div>
-          </div>{* end of main edit section div*}
-          {else}
           <div id="editrow-{$n}" class="crm-section editrow_{$n}-section form-item">
             <div class="label">
               {$form.$n.label}
@@ -191,7 +160,6 @@
             <div class="crm-section file_displayURL-section file_displayURL{$n}-section"><div class="content">{$customFiles.$n.displayURL}</div></div>
             <div class="crm-section file_deleteURL-section file_deleteURL{$n}-section"><div class="content">{$customFiles.$n.deleteURL}</div></div>
           {/if}
-        {/if}
 
       {* Show explanatory text for field if not in 'view' mode *}
         {if $field.help_post && $action neq 4 && $form.$n.html}

--- a/templates/CRM/UF/Form/Block.tpl
+++ b/templates/CRM/UF/Form/Block.tpl
@@ -70,42 +70,6 @@
             <div class="content description">{$field.help_pre}</div>
           </div>
         {/if}
-        {if $field.options_per_line != 0}
-          <div class="crm-section editrow_{$n}-section form-item" id="editrow-{$n}">
-            <div class="label option-label">{if $prefix}{$form.$prefix.$n.label}{else}{$form.$n.label}{/if}</div>
-            <div class="content 3">
-              {assign var="count" value="1"}
-              {strip}
-                <table class="form-layout-compressed">
-                <tr>
-                {* sort by fails for option per line. Added a variable to iterate through the element array*}
-                  {assign var="index" value="1"}
-                  {if $prefix}
-                    {assign var="formElement" value=$form.$prefix.$n}
-                  {else}
-                    {assign var="formElement" value=$form.$n}
-                  {/if}
-                  {foreach name=outer key=key item=item from=$formElement}
-                    {if $index < 10}
-                      {assign var="index" value=`$index+1`}
-                    {else}
-                      <td class="labels font-light">{$formElement.$key.html}</td>
-                      {if $count == $field.options_per_line}
-                      </tr>
-                      <tr>
-                        {assign var="count" value="1"}
-                      {else}
-                        {assign var="count" value=`$count+1`}
-                      {/if}
-                    {/if}
-                  {/foreach}
-                </tr>
-                </table>
-              {/strip}
-            </div>
-            <div class="clear"></div>
-          </div>
-        {else}
           <div class="crm-section editrow_{$n}-section form-item" id="editrow-{$n}">
             <div class="label">
               {if $prefix}{$form.$prefix.$n.label}{else}{$form.$n.label}{/if}
@@ -158,7 +122,6 @@
           </div>
           <div class="clear"></div>
         </div>
-        {/if}
         {* Show explanatory text for field if not in 'view' or 'preview' modes *}
         {if $field.help_post && $action neq 4 && $action neq 1028}
           <div class="crm-section helprow-{$n}-section helprow-post" id="helprow-{$n}">

--- a/templates/CRM/UF/Form/Preview.tpl
+++ b/templates/CRM/UF/Form/Preview.tpl
@@ -71,33 +71,6 @@
           {assign var=n value=$field.name}
           {if $field.field_type eq "Formatting"}
             <tr><td colspan="2">{$field.help_pre}</td></tr>
-          {elseif $field.options_per_line }
-            <tr>
-              <td class="option-label">{$form.$n.label}</td>
-              <td>
-                {assign var="count" value="1"}
-                {strip}
-                  <table class="form-layout-compressed">
-                  <tr>
-                  {* sort by fails for option per line. Added a variable to iterate through the element array*}
-                    {assign var="index" value="1"}
-                    {foreach name=outer key=key item=item from=$form.$n}
-                      {if $index < 10}
-                        {assign var="index" value=`$index+1`}
-                      {else}
-                        <td class="labels font-light">{$form.$n.$key.html}</td>
-                        {if $count == $field.options_per_line}
-                        </tr>
-                          {assign var="count" value="1"}
-                        {else}
-                          {assign var="count" value=`$count+1`}
-                        {/if}
-                      {/if}
-                    {/foreach}
-                  </table>
-                {/strip}
-              </td>
-            </tr>
           {else}
           <tr>
             <td class="label">


### PR DESCRIPTION
This depends on https://github.com/civicrm/civicrm-packages/pull/174

It changes the markup so that checkboxes/radios buttons now appear in-line in a div instead of in table cells, which makes them not line up quite so neatly. Someone might get upset with this change, so marking as WIP.

---
- [CRM-19564: Custom field "Options per line" breaks the "Clear" button](https://issues.civicrm.org/jira/browse/CRM-19564)
