### PR TITLE
CRM-19580: Contribution Receipts not including all lines.

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2640,7 +2640,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       }
       // set lineItem for contribution
       if ($this->id) {
-        $lineItem = CRM_Price_BAO_LineItem::getLineItems($this->id, 'contribution', 1);
+        $lineItem = CRM_Price_BAO_LineItem::getLineItemsByContributionID($this->id);
         if (!empty($lineItem)) {
           $itemId = key($lineItem);
           foreach ($lineItem as &$eachItem) {

--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -225,7 +225,8 @@ AND li.entity_id = {$entityId}
 
     if ($relatedEntity) {
       $condition = "li.contribution_id = %2.id ";
-    } else {
+    }
+    else {
       $condition = "li.entity_id = %2.id AND li.entity_table = 'civicrm_%2'";
     }
 

--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -188,8 +188,8 @@ AND li.entity_id = {$entityId}
    * @param string $entity
    *   participant/contribution.
    *
-   * @param null $isQuick
-   * @param bool $isQtyZero
+   * @param null $ignoreQuickConfig
+   * @param bool $allowZeroDollarAmounts
    * @param bool $relatedEntity
    *
    * @param string $overrideWhereClause
@@ -201,7 +201,7 @@ AND li.entity_id = {$entityId}
    * @return array
    *   Array of line items
    */
-  public static function getLineItems($entityId, $entity = 'participant', $isQuick = NULL, $isQtyZero = TRUE, $relatedEntity = FALSE, $overrideWhereClause = '', $invoice = FALSE) {
+  public static function getLineItems($entityId, $entity = 'participant', $ignoreQuickConfig = NULL, $allowZeroDollarAmounts = TRUE, $relatedEntity = FALSE, $overrideWhereClause = '', $invoice = FALSE) {
     $whereClause = $fromClause = NULL;
     $selectClause = "
       SELECT    li.id,
@@ -223,9 +223,10 @@ AND li.entity_id = {$entityId}
       li.tax_amount,
       pfv.description";
 
-    $condition = "li.entity_id = %2.id AND li.entity_table = 'civicrm_%2'";
     if ($relatedEntity) {
       $condition = "li.contribution_id = %2.id ";
+    } else {
+      $condition = "li.entity_id = %2.id AND li.entity_table = 'civicrm_%2'";
     }
 
     $fromClause = "
@@ -246,12 +247,12 @@ AND li.entity_id = {$entityId}
 
     $orderByClause = " ORDER BY pf.weight, pfv.weight";
 
-    if ($isQuick) {
+    if ($ignoreQuickConfig) {
       $fromClause .= " LEFT JOIN civicrm_price_set cps on cps.id = pf.price_set_id ";
       $whereClause .= " and cps.is_quick_config = 0";
     }
 
-    if (!$isQtyZero) {
+    if (!$allowZeroDollarAmounts) {
       $whereClause .= " and li.qty != 0";
     }
 


### PR DESCRIPTION
---
- CRM-19580: LIne items are missing from manual receipts when using a price set with multiple membership organization price fields
  https://issues.civicrm.org/jira/browse/CRM-19580

Also clarified input parameter names in CRM_Price_BAO_LineItem::getLineItems, their names were very misleading!
