### PR TITLE
CRM-19589: Search for contacts in Smart Groups based on group status shows incorrect results

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2933,7 +2933,8 @@ class CRM_Contact_BAO_Query {
 
     //CRM-19589: contact(s) removed from a Smart Group, resides in civicrm_group_contact table
     $ssClause = NULL;
-    if (in_array("'Added'", $statii) ||  // if both Added and Removed statuses are selected
+    if (empty($gcsValues) || // if no status selected
+      in_array("'Added'", $statii) ||  // if both Added and Removed statuses are selected
       (count($statii) == 1 && $statii[0] == 'Removed') // if only Removed status is selected
     ) {
       $ssClause = $this->addGroupContactCache($value, NULL, "contact_a", $op);

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2931,7 +2931,14 @@ class CRM_Contact_BAO_Query {
       $statii[] = '"Added"';
     }
 
-    $ssClause = $this->addGroupContactCache($value, NULL, "contact_a", $op);
+    //CRM-19589: contact(s) removed from a Smart Group, resides in civicrm_group_contact table
+    $ssClause = NULL;
+    if (in_array("'Added'", $statii) ||  // if both Added and Removed statuses are selected
+      (count($statii) == 1 && $statii[0] == 'Removed') // if only Removed status is selected
+    ) {
+      $ssClause = $this->addGroupContactCache($value, NULL, "contact_a", $op);
+    }
+
     $isSmart = (!$ssClause) ? FALSE : TRUE;
     if (!is_array($value) &&
       count($statii) == 1 &&
@@ -2944,7 +2951,7 @@ class CRM_Contact_BAO_Query {
     }
     $groupClause = NULL;
 
-    if (!$isSmart) {
+    if (!$isSmart || in_array("'Added'", $statii)) {
       $groupIds = implode(',', (array) $value);
       $gcTable = "`civicrm_group_contact-{$groupIds}`";
       $joinClause = array("contact_a.id = {$gcTable}.contact_id");
@@ -2978,6 +2985,7 @@ class CRM_Contact_BAO_Query {
     if (strpos($op, 'NULL') === FALSE) {
       $this->_qill[$grouping][] = ts("Group Status %1", array(1 => implode(' ' . ts('or') . ' ', $statii)));
     }
+
     if ($groupClause) {
       $this->_where[$grouping][] = $groupClause;
     }


### PR DESCRIPTION
* [CRM-19589: Search for contacts in Smart Groups based on group status shows incorrect results](https://issues.civicrm.org/jira/browse/CRM-19589)