### PR TITLE
Comment Fixes for CRM/Profile directory

### DIFF
--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -29,7 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2016
- * $Id$
  *
  */
 
@@ -122,7 +121,7 @@ class CRM_Profile_Form extends CRM_Core_Form {
   protected $_isPermissionedChecksum = FALSE;
 
   /**
-   * THe context from which we came from, allows us to go there if redirect not set
+   * THe context from which we came from, allows us to go there if redirect not set.
    *
    * @var string
    */
@@ -137,7 +136,7 @@ class CRM_Profile_Form extends CRM_Core_Form {
 
   /**
    * Store profile ids if multiple profile ids are passed using comma separated.
-   * Currently lets implement this functionality only for dialog mode
+   * Currently lets implement this functionality only for dialog mode.
    */
   protected $_profileIds = array();
 
@@ -161,7 +160,7 @@ class CRM_Profile_Form extends CRM_Core_Form {
   protected $_recordId = NULL;
 
   /**
-   * Action for multi record profile (create/edit/delete)
+   * Action for multi record profile (create/edit/delete).
    *
    * @var string
    */
@@ -191,10 +190,6 @@ class CRM_Profile_Form extends CRM_Core_Form {
    * Pre processing work done here.
    *
    * gets session variables for table name, id of entity in table, type of entity and stores them.
-   *
-   * @param
-   *
-   * @return void
    */
   public function preProcess() {
     $this->_id = $this->get('id');
@@ -268,7 +263,7 @@ class CRM_Profile_Form extends CRM_Core_Form {
     }
     $this->_isContactActivityProfile = CRM_Core_BAO_UFField::checkContactActivityProfileType($this->_gid);
 
-    //get values for ufGroupName, captch and dupe update.
+    //get values for ufGroupName, captcha and dupe update.
     if ($this->_gid) {
       $dao = new CRM_Core_DAO_UFGroup();
       $dao->id = $this->_gid;
@@ -289,7 +284,7 @@ class CRM_Profile_Form extends CRM_Core_Form {
 
     $gids = empty($this->_profileIds) ? $this->_gid : $this->_profileIds;
 
-    // if we dont have a gid use the default, else just use that specific gid
+    // if we don't have a gid use the default, else just use that specific gid
     if (($this->_mode == self::MODE_REGISTER || $this->_mode == self::MODE_CREATE) && !$this->_gid) {
       $this->_ctype = CRM_Utils_Request::retrieve('ctype', 'String', $this, FALSE, 'Individual', 'REQUEST');
       $this->_fields = CRM_Core_BAO_UFGroup::getRegistrationFields($this->_action, $this->_mode, $this->_ctype);
@@ -313,7 +308,7 @@ class CRM_Profile_Form extends CRM_Core_Form {
         ($this->_action == CRM_Core_Action::ADD) ? CRM_Core_Permission::CREATE : CRM_Core_Permission::EDIT
       );
       $multiRecordFieldListing = FALSE;
-      //using selector for listing of multirecord fields
+      //using selector for listing of multi-record fields
       if ($this->_mode == self::MODE_EDIT && $this->_gid) {
         CRM_Core_BAO_UFGroup::shiftMultiRecordFields($this->_fields, $this->_multiRecordFields);
 
@@ -376,7 +371,7 @@ class CRM_Profile_Form extends CRM_Core_Form {
           )))
         ) {
           CRM_Core_Resources::singleton()->addScriptFile('civicrm', 'js/crm.livePage.js', 1, 'html-header');
-          //multirecord listing page
+          //multi-record listing page
           $multiRecordFieldListing = TRUE;
           $page = new CRM_Profile_Page_MultipleRecordFieldsListing();
           $cs = $this->get('cs');
@@ -428,8 +423,6 @@ class CRM_Profile_Form extends CRM_Core_Form {
    * Set default values for the form. Note that in edit/view mode
    * the default values are retrieved from the database
    *
-   *
-   * @return void
    */
   public function setDefaultsValues() {
     $this->_defaults = array();
@@ -595,7 +588,6 @@ class CRM_Profile_Form extends CRM_Core_Form {
   /**
    * Build the form object.
    *
-   * @return void
    */
   public function buildQuickForm() {
     $this->add('hidden', 'gid', $this->_gid);
@@ -707,7 +699,7 @@ class CRM_Profile_Form extends CRM_Core_Form {
     $admin = TRUE;
     if ($this->_mode == self::MODE_EDIT) {
       $admin = FALSE;
-      // show all fields that are visibile:
+      // show all fields that are visible:
       // if we are a admin OR the same user OR acl-user with access to the profile
       // or we have checksum access to this contact (i.e. the user without a login) - CRM-5909
       if (
@@ -914,7 +906,7 @@ class CRM_Profile_Form extends CRM_Core_Form {
       $register = TRUE;
     }
 
-    // dont check for duplicates during registration validation: CRM-375
+    // don't check for duplicates during registration validation: CRM-375
     if (!$register && empty($fields['_qf_Edit_upload_duplicate'])) {
       // fix for CRM-3240
       if (!empty($fields['email-Primary'])) {
@@ -1076,8 +1068,6 @@ class CRM_Profile_Form extends CRM_Core_Form {
   /**
    * Process the user submitted custom data values.
    *
-   *
-   * @return void
    */
   public function postProcess() {
     $params = $this->controller->exportValues($this->_name);
@@ -1365,9 +1355,6 @@ class CRM_Profile_Form extends CRM_Core_Form {
    *
    * @return string
    */
-  /**
-   * @return string
-   */
   public function getTemplateFileName() {
     $fileName = $this->checkTemplateFileExists();
     return $fileName ? $fileName : parent::getTemplateFileName();
@@ -1377,9 +1364,6 @@ class CRM_Profile_Form extends CRM_Core_Form {
    * Default extra tpl file basically just replaces .tpl with .extra.tpl
    * i.e. we dont override
    *
-   * @return string
-   */
-  /**
    * @return string
    */
   public function overrideExtraTemplateFileName() {

--- a/CRM/Profile/Form/Dynamic.php
+++ b/CRM/Profile/Form/Dynamic.php
@@ -29,7 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2016
- * $Id$
  *
  */
 
@@ -48,7 +47,6 @@ class CRM_Profile_Form_Dynamic extends CRM_Profile_Form {
    *
    * @param
    *
-   * @return void
    */
   public function preProcess() {
     if ($this->get('register')) {
@@ -71,7 +69,6 @@ class CRM_Profile_Form_Dynamic extends CRM_Profile_Form {
   /**
    * Build the form object.
    *
-   * @return void
    */
   public function buildQuickForm() {
     $this->addButtons(array(
@@ -115,9 +112,6 @@ class CRM_Profile_Form_Dynamic extends CRM_Profile_Form {
 
   /**
    * Process the user submitted custom data values.
-   *
-   *
-   * @return void
    */
   public function postProcess() {
     parent::postProcess();

--- a/CRM/Profile/Form/Edit.php
+++ b/CRM/Profile/Form/Edit.php
@@ -29,7 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2016
- * $Id$
  *
  */
 
@@ -55,7 +54,6 @@ class CRM_Profile_Form_Edit extends CRM_Profile_Form {
    *
    * @param
    *
-   * @return void
    */
   public function preProcess() {
     $this->_mode = CRM_Profile_Form::MODE_CREATE;
@@ -153,7 +151,6 @@ SELECT module,is_reserved
   /**
    * Build the form object.
    *
-   * @return void
    */
   public function buildQuickForm() {
     if (empty($this->_ufGroup['id'])) {
@@ -257,8 +254,6 @@ SELECT module,is_reserved
   /**
    * Process the user submitted custom data values.
    *
-   *
-   * @return void
    */
   public function postProcess() {
     parent::postProcess();

--- a/CRM/Profile/Page/Dynamic.php
+++ b/CRM/Profile/Page/Dynamic.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2016
- * $Id$
- *
  */
 
 /**
@@ -177,7 +175,6 @@ class CRM_Profile_Page_Dynamic extends CRM_Core_Page {
    * This method is called after the page is created. It checks for the
    * type of action and executes that action.
    *
-   * @return void
    */
   public function run() {
     $template = CRM_Core_Smarty::singleton();
@@ -416,9 +413,6 @@ class CRM_Profile_Page_Dynamic extends CRM_Core_Page {
    *
    * @return string
    */
-  /**
-   * @return string
-   */
   public function getTemplateFileName() {
     $fileName = $this->checkTemplateFileExists();
     return $fileName ? $fileName : parent::getTemplateFileName();
@@ -428,9 +422,6 @@ class CRM_Profile_Page_Dynamic extends CRM_Core_Page {
    * Default extra tpl file basically just replaces .tpl with .extra.tpl
    * i.e. we dont override
    *
-   * @return string
-   */
-  /**
    * @return string
    */
   public function overrideExtraTemplateFileName() {

--- a/CRM/Profile/Page/Listings.php
+++ b/CRM/Profile/Page/Listings.php
@@ -29,54 +29,53 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2016
- * $Id$
  *
  */
 
 /**
  * This implements the profile page for all contacts. It uses a selector
  * object to do the actual dispay. The fields displayd are controlled by
- * the admin
+ * the admin.
  */
 class CRM_Profile_Page_Listings extends CRM_Core_Page {
 
   /**
-   * All the fields that are listings related
+   * All the fields that are listings related.
    *
    * @var array
    */
   protected $_fields;
 
   /**
-   * The custom fields for this domain
+   * The custom fields for this domain.
    *
    * @var array
    */
   protected $_customFields;
 
   /**
-   * The input params from the request
+   * The input params from the request.
    *
    * @var array
    */
   protected $_params;
 
   /**
-   * The group id that we are editing
+   * The group id that we are editing.
    *
    * @var int
    */
   protected $_gid;
 
   /**
-   * State whether to display search form or not
+   * State whether to display search form or not.
    *
    * @var int
    */
   protected $_search;
 
   /**
-   * Should we display a map
+   * Should we display a map.
    *
    * @var int
    */
@@ -92,7 +91,6 @@ class CRM_Profile_Page_Listings extends CRM_Core_Page {
    * Extracts the parameters from the request and constructs information for
    * the selector object to do a query
    *
-   * @return void
    */
   public function preProcess() {
 
@@ -230,7 +228,7 @@ class CRM_Profile_Page_Listings extends CRM_Core_Page {
           if (in_array($customField['html_type'],
             array('Multi-Select', 'CheckBox', 'Multi-Select State/Province', 'Multi-Select Country', 'Radio', 'Select')
           )) {
-            // only reset on a POST submission if we dont see any value
+            // only reset on a POST submission if we don't see any value
             $value = NULL;
             $this->set($name, $value);
           }
@@ -282,7 +280,6 @@ class CRM_Profile_Page_Listings extends CRM_Core_Page {
   /**
    * Run this page (figure out the action needed and perform it).
    *
-   * @return void
    */
   public function run() {
     $this->preProcess();
@@ -396,7 +393,7 @@ class CRM_Profile_Page_Listings extends CRM_Core_Page {
       $controller->run();
     }
 
-    //CRM-6862 -run form cotroller after
+    //CRM-6862 -run form controller after
     //selector, since it erase $_POST
     $formController->run();
 
@@ -492,9 +489,6 @@ class CRM_Profile_Page_Listings extends CRM_Core_Page {
    *
    * @return string
    */
-  /**
-   * @return string
-   */
   public function getTemplateFileName() {
     $fileName = $this->checkTemplateFileExists();
     return $fileName ? $fileName : parent::getTemplateFileName();
@@ -504,9 +498,6 @@ class CRM_Profile_Page_Listings extends CRM_Core_Page {
    * Default extra tpl file basically just replaces .tpl with .extra.tpl
    * i.e. we dont override
    *
-   * @return string
-   */
-  /**
    * @return string
    */
   public function overrideExtraTemplateFileName() {

--- a/CRM/Profile/Page/MultipleRecordFieldsListing.php
+++ b/CRM/Profile/Page/MultipleRecordFieldsListing.php
@@ -29,7 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2016
- * $Id$
  *
  */
 class CRM_Profile_Page_MultipleRecordFieldsListing extends CRM_Core_Page_Basic {
@@ -137,7 +136,6 @@ class CRM_Profile_Page_MultipleRecordFieldsListing extends CRM_Core_Page_Basic {
    * of action and executes that action. Finally it calls the parent's run
    * method.
    *
-   * @return void
    */
   public function run() {
     // get the requested action, default to 'browse'
@@ -166,7 +164,6 @@ class CRM_Profile_Page_MultipleRecordFieldsListing extends CRM_Core_Page_Basic {
   /**
    * Browse the listing.
    *
-   * @return void
    */
   public function browse() {
     $dateFields = NULL;
@@ -288,7 +285,7 @@ class CRM_Profile_Page_MultipleRecordFieldsListing extends CRM_Core_Page_Basic {
         $customGroupInfo = CRM_Core_BAO_CustomGroup::getGroupTitles($fieldInput);
         $this->_customGroupTitle = $customGroupInfo[$fieldIdInput]['groupTitle'];
       }
-      // $cgcount is defined before 'if' condition as enitiy may have no record
+      // $cgcount is defined before 'if' condition as entity may have no record
       // and $cgcount is used to build new record url
       $cgcount = 1;
       if ($result && !empty($result)) {

--- a/CRM/Profile/Page/Router.php
+++ b/CRM/Profile/Page/Router.php
@@ -29,7 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2016
- * $Id$
  *
  */
 

--- a/CRM/Profile/Page/View.php
+++ b/CRM/Profile/Page/View.php
@@ -29,7 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2016
- * $Id$
  *
  */
 
@@ -57,7 +56,6 @@ class CRM_Profile_Page_View extends CRM_Core_Page {
    * Heart of the viewing process. The runner gets all the meta data for
    * the contact and calls the appropriate type of page to view.
    *
-   * @return void
    */
   public function preProcess() {
     $this->_id = CRM_Utils_Request::retrieve('id', 'Positive',
@@ -163,9 +161,8 @@ class CRM_Profile_Page_View extends CRM_Core_Page {
   }
 
   /**
-   * Build the outcome basing on the CRM_Profile_Page_Dynamic's HTML
+   * Build the outcome basing on the CRM_Profile_Page_Dynamic's HTML.
    *
-   * @return void
    */
   public function run() {
     $this->preProcess();
@@ -202,9 +199,6 @@ class CRM_Profile_Page_View extends CRM_Core_Page {
    *
    * @return string
    */
-  /**
-   * @return string
-   */
   public function getTemplateFileName() {
     $fileName = $this->checkTemplateFileExists();
     return $fileName ? $fileName : parent::getTemplateFileName();
@@ -214,9 +208,6 @@ class CRM_Profile_Page_View extends CRM_Core_Page {
    * Default extra tpl file basically just replaces .tpl with .extra.tpl
    * i.e. we dont override
    *
-   * @return string
-   */
-  /**
    * @return string
    */
   public function overrideExtraTemplateFileName() {

--- a/CRM/Profile/Selector/Listings.php
+++ b/CRM/Profile/Selector/Listings.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2016
- * $Id$
- *
  */
 
 /**
@@ -369,7 +367,7 @@ class CRM_Profile_Selector_Listings extends CRM_Core_Selector_Base implements CR
         }
       }
 
-      // if we dont have any valid columns, dont add the implicit ones
+      // if we don't have any valid columns, don't add the implicit ones
       // this allows the template to check on emptiness of column headers
       if ($empty) {
         self::$_columnHeaders = array();
@@ -792,7 +790,7 @@ class CRM_Profile_Selector_Listings extends CRM_Core_Selector_Base implements CR
     }
 
     //if the field is in selector and not a searchable field
-    //get the proper customvalue table name
+    //get the proper custom value table name
     if ($selectorSet) {
       $this->_multiRecordTableName
         = $multiRecordTableName = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $customGroupId, 'table_name');


### PR DESCRIPTION
This PR contains comment fixes for all files in CRM/Profile directory : 

1. Removed unnecessary @return void statements
2. Removed unnecessary @param statements
3. Removed empty comments.
4. Minor spell checks.