### PR TITLE
CRM-19571: Smart Groups don't save Relation Contact settings

### DIFF
--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -417,6 +417,28 @@ LEFT JOIN civicrm_email ON (contact_a.id = civicrm_email.contact_id AND civicrm_
   }
 
   /**
+   * Store search variables in $queryParams which were skipped while processing query params,
+   * precisely at CRM_Contact_BAO_Query::fixWhereValues(...). But these variable are required in
+   * building smart group criteria otherwise it will cause issues like CRM-18585,CRM-19571
+   *
+   * @param array $queryParams
+   * @param array $formValues
+   */
+  public static function saveSkippedElement(&$queryParams, $formValues) {
+    // these are elements which are skipped in a smart group criteria
+    $specialElements = array(
+      'operator',
+      'component_mode',
+      'display_relationship_type',
+    );
+    foreach ($specialElements as $element) {
+      if (!empty($formValues[$element])) {
+        $queryParams[] = array($element, '=', $formValues[$element], 0, 0);
+      }
+    }
+  }
+
+  /**
    * Decode relative custom fields (converted by CRM_Contact_BAO_Query->convertCustomRelativeFields(...))
    *  into desired formValues
    *

--- a/CRM/Contact/Form/Task/SaveSearch.php
+++ b/CRM/Contact/Form/Task/SaveSearch.php
@@ -183,10 +183,7 @@ class CRM_Contact_Form_Task_SaveSearch extends CRM_Contact_Form_Task {
     $savedSearch = new CRM_Contact_BAO_SavedSearch();
     $savedSearch->id = $this->_id;
     $queryParams = $this->get('queryParams');
-    // CRM-18585 include selected operator in $savedSearch->form_values
-    if (!empty($formValues['operator'])) {
-      $queryParams[] = array('operator', '=', $formValues['operator'], 0, 0);
-    }
+
     // Use the query parameters rather than the form values - these have already been assessed / converted
     // with the extra knowledge that the form has.
     // Note that we want to move towards a standardised way of saving the query that is not
@@ -195,6 +192,7 @@ class CRM_Contact_Form_Task_SaveSearch extends CRM_Contact_Form_Task {
     // sql operator syntax at the query layer.
     if (!$isSearchBuilder) {
       CRM_Contact_BAO_SavedSearch::saveRelativeDates($queryParams, $formValues);
+      CRM_Contact_BAO_SavedSearch::saveSkippedElement($queryParams, $formValues);
       $savedSearch->form_values = serialize($queryParams);
     }
     else {


### PR DESCRIPTION
* [CRM-19571: Smart Groups don't save Relation Contact settings](https://issues.civicrm.org/jira/browse/CRM-19571)