### PR TITLE
CRM-19600: Membership Renewal activity not created through online contribution page

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4603,6 +4603,8 @@ LIMIT 1;";
             $var = TRUE;
             CRM_Member_BAO_Membership::createRelatedMemberships($var, $var, TRUE);
             civicrm_api3('Membership', 'create', $membershipParams);
+            //CRM-19600: Add Membership Renewal activity
+            CRM_Activity_BAO_Activity::addActivity($membership, 'Membership Renewal', $membership->contact_id);
           }
         }
       }

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -2471,7 +2471,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     ));
     $this->assertEquals(1, $logs['count']);
     $this->assertEquals($stateOfGrace, $membership['status_id']);
-    $this->callAPISuccess('contribution', 'completetransaction', array('id' => $this->_ids['contribution']));
+    $contribution = $this->callAPISuccess('contribution', 'completetransaction', array('id' => $this->_ids['contribution']));
     $membership = $this->callAPISuccess('membership', 'getsingle', array('id' => $this->_ids['membership']));
     $this->assertEquals(date('Y-m-d', strtotime('yesterday + 1 year')), $membership['end_date']);
     $this->callAPISuccessGetSingle('LineItem', array(
@@ -2481,6 +2481,12 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $logs = $this->callAPISuccess('MembershipLog', 'get', array(
       'membership_id' => $this->_ids['membership'],
     ));
+    //CRM-19600: Ensure that 'Membership Renewal' activity is created after successful membership regsitration
+    $activity = $this->callAPISuccess('Activity', 'get', array(
+      'activity_type_id' => 'Membership Renewal',
+      'source_record_id' => $contribution['id'],
+    ));
+    $this->assertEquals(1, $activity['count']);
     $this->assertEquals(2, $logs['count']);
     $this->assertNotEquals($stateOfGrace, $logs['values'][2]['status_id']);
     $this->cleanUpAfterPriceSets();


### PR DESCRIPTION
@eileenmcnaughton it's regression due to refactoring changes done in 4.7 and issue arises when we call 
```CRM_Member_BAO_Membership::renewMembership(...)``` [here](https://github.com/civicrm/civicrm-core/blob/master/CRM/Contribute/Form/Contribution/Confirm.php#L1526) before its rightful place i.e. is after ```completeTransaction(...)``` [here](https://github.com/civicrm/civicrm-core/blob/master/CRM/Contribute/Form/Contribution/Confirm.php#L1607) As a result of which additional info is not updated as in here 'Membership Renewal' activity. Although there are other alternatives like handling : 
1.  under ```Membership.update``` api
2. or under ```Membership::create(...)``` BAO fn by fetching current membership info
but I think this patch is more appropriate and safe 

Tried to add unit test to assert membership-renewal activity via online contribution but currently its not possible.

---

 * [CRM-19600: Membership Renewal activity not created through online contribution page](https://issues.civicrm.org/jira/browse/CRM-19600)