### PR TITLE
CRM-19616 Fix urls for Manage Tag and New Tag wrongly set in 4.7.13

### DIFF
--- a/CRM/Upgrade/Incremental/sql/4.7.13.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.7.13.mysql.tpl
@@ -7,17 +7,17 @@ ALTER TABLE  `civicrm_line_item` CHANGE  `deductible_amount`  `non_deductible_am
 
 -- CRM-15371 Manage tags with new *manage tags* permission (used to need *administer CiviCRM* permission)
 UPDATE civicrm_navigation SET
-  `url` = 'civicrm/tag?reset=1&action=add',
+  `url` = 'civicrm/tag?reset=1',
   `permission` = 'manage tags'
 WHERE `name` = 'Manage Tags (Categories)';
 
 UPDATE civicrm_navigation SET
-  `url` = 'civicrm/admin/tag?reset=1',
+  `url` = 'civicrm/tag?reset=1&action=add',
   `permission` = 'manage tags'
 WHERE `name` = 'New Tag';
 
 UPDATE civicrm_navigation SET
-  `url` = 'civicrm/admin/tag?reset=1'
+  `url` = 'civicrm/tag?reset=1'
 WHERE `name` = 'Tags (Categories)';
 
 -- CRM-16352: Add language filter support for mass mailing

--- a/CRM/Upgrade/Incremental/sql/4.7.14.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.7.14.mysql.tpl
@@ -1,1 +1,16 @@
 {* file to handle db changes in 4.7.14 during upgrade *}
+-- CRM-19616 Fix Manage Tags and New Tag Url issues.
+UPDATE civicrm_navigation SET
+  `url` = 'civicrm/tag?reset=1'
+WHERE `name` = 'Manage Tags (Categories)'
+AND `url` = 'civicrm/tag?reset=1&action=add';
+
+UPDATE civicrm_navigation SET
+  `url` = 'civicrm/tag?reset=1&action=add'
+WHERE `name` = 'New Tag'
+AND `url` = 'civicrm/admin/tag?reset=1';
+
+UPDATE civicrm_navigation SET
+  `url` = 'civicrm/tag?reset=1'
+WHERE `name` = 'Tags (Categories)'
+AND `url` = 'civicrm/admin/tag?reset=1';


### PR DESCRIPTION
* [CRM-19616: Incorrect URL for manage tags](https://issues.civicrm.org/jira/browse/CRM-19616)