### PR TITLE
CRM-19620 - restore matching contacts in trash prior to import

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -2193,12 +2193,20 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
     $extIDMatch = NULL;
 
     if (!empty($params['external_identifier'])) {
+      // Check for any match on external id, deleted or otherwise.
       $extIDContact = civicrm_api3('Contact', 'get', array(
         'external_identifier' => $params['external_identifier'],
-        'return' => 'id',
+        'showAll' => 'all',
+        'return' => array('id','is_deleted'),
       ));
       if (isset($extIDContact['id'])) {
         $extIDMatch = $extIDContact['id'];
+        if($extIDContact['is_deleted'] == 1) {
+          // If the contact is deleted, restore it so it can be properly
+          // updated.
+          $params = array('id' => $extIDMatch, 'is_deleted' => 0);
+          civicrm_api3('Contact','Update', $params);
+        }
       }
     }
     $checkParams = array('check_permissions' => FALSE, 'match' => $params);

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -2217,16 +2217,16 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
       $extIDContact = civicrm_api3('Contact', 'get', array(
         'external_identifier' => $params['external_identifier'],
         'showAll' => 'all',
-        'return' => array('id','contact_is_deleted'),
+        'return' => array('id', 'contact_is_deleted'),
       ));
       if (isset($extIDContact['id'])) {
         $extIDMatch = $extIDContact['id'];
 
         if ($extIDContact['values'][$extIDMatch]['contact_is_deleted'] == 1) {
           // If the contact is deleted, update external identifier to be blank
-          // to avoid key error from MySQL. 
+          // to avoid key error from MySQL.
           $params = array('id' => $extIDMatch, 'external_identifier' => '');
-          civicrm_api3('Contact','Update', $params);
+          civicrm_api3('Contact', 'create', $params);
 
           // And now it is no longer a match.
           $extIDMatch = NULL;

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -2223,9 +2223,9 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
         $extIDMatch = $extIDContact['id'];
 
         if ($extIDContact['values'][$extIDMatch]['contact_is_deleted'] == 1) {
-          // If the contact is deleted, restore it so it can be properly
-          // updated.
-          $params = array('id' => $extIDMatch, 'contact_is_deleted' => 0);
+          // If the contact is deleted, update external identifier to be blank
+          // to avoid key error from MySQL. 
+          $params = array('id' => $extIDMatch, 'external_identifier' => '');
           civicrm_api3('Contact','Update', $params);
         }
       }

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -523,8 +523,8 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
             // with an external_identifier that is non-unique. So...
             // we will update this contact to remove the external_identifier
             // and let a new record be created.
-            $params = array('id' => $internalCid, 'external_identifier' => '');
-            civicrm_api3('Contact', 'update', $params);
+            $update_params = array('id' => $internalCid, 'external_identifier' => '');
+            civicrm_api3('Contact', 'update', $update_params);
           }
           else {
             $errorMessage = ts('External ID already exists in Database.');

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -2227,6 +2227,9 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
           // to avoid key error from MySQL. 
           $params = array('id' => $extIDMatch, 'external_identifier' => '');
           civicrm_api3('Contact','Update', $params);
+
+          // And now it is no longer a match.
+          $extIDMatch = NULL;
         }
       }
     }

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -524,7 +524,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
             // we will update this contact to remove the external_identifier
             // and let a new record be created.
             $update_params = array('id' => $internalCid, 'external_identifier' => '');
-            civicrm_api3('Contact', 'update', $update_params);
+            civicrm_api3('Contact', 'create', $update_params);
           }
           else {
             $errorMessage = ts('External ID already exists in Database.');

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -2222,7 +2222,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
       if (isset($extIDContact['id'])) {
         $extIDMatch = $extIDContact['id'];
 
-        if ($extIDResult['values'][$extIDMatch]['contact_is_deleted'] == 1) {
+        if ($extIDContact['values'][$extIDMatch]['contact_is_deleted'] == 1) {
           // If the contact is deleted, restore it so it can be properly
           // updated.
           $params = array('id' => $extIDMatch, 'contact_is_deleted' => 0);


### PR DESCRIPTION
This avoids duplicate key errors. If we don't restore and return the
deleted contact when we have a match on external_identifier, then
we end up with a key error.

---

 * [CRM-19620: importing record with external_identifier that matches with a deleted contact results in traceback](https://issues.civicrm.org/jira/browse/CRM-19620)