### PR TITLE
Deal with bootstrap styles being applied to .label on joomla backend …

### DIFF
--- a/css/joomla.css
+++ b/css/joomla.css
@@ -375,3 +375,4 @@ ul#civicrm-menu li#crm-qsearch {
 .crm-container .disabled {
   font-weight: normal;
 }
+


### PR DESCRIPTION
…pages

#crm-container .crm-container .form-layout td.label {
  width: inherit;
}

#crm-container .label {
  background-color: inherit;
  width: inherit;
  display: block;
}