### PR TITLE
CRM-19629 Labels display as pills on joomla backend civicrm pages

### DIFF
--- a/css/joomla.css
+++ b/css/joomla.css
@@ -376,7 +376,8 @@ ul#civicrm-menu li#crm-qsearch {
   font-weight: normal;
 }
 
-#crm-container .crm-container .form-layout td.label {
+#crm-container .form-layout td.label,
+.crm-container .form-layout td.label {
   width: inherit;
 }
 

--- a/css/joomla.css
+++ b/css/joomla.css
@@ -375,3 +375,13 @@ ul#civicrm-menu li#crm-qsearch {
 .crm-container .disabled {
   font-weight: normal;
 }
+
+#crm-container .crm-container .form-layout td.label {
+  width: inherit;
+}
+
+#crm-container .label {
+  background-color: inherit;
+  width: inherit;
+  display: block;
+}


### PR DESCRIPTION
Joomla uses bootstrap (http://getbootstrap.com/) on the backend to style things and the bootstrap styles of labels overide civiCRM's styling of labels and make labels into little inline pill like things, this resets the styling to the civi version of what a label is (only on civi pages)

**before:**
![image](https://cloud.githubusercontent.com/assets/11323624/20122194/f8806eba-a5e3-11e6-9324-81a347c39616.png)

**after:**
![cleanerregisterparticipantpage](https://cloud.githubusercontent.com/assets/11323624/20122209/125ed7c2-a5e4-11e6-880e-fefe4b11f17f.png)

---

 * [CRM-19629: Labels display as pills on joomla backend civicrm pages](https://issues.civicrm.org/jira/browse/CRM-19629)