### PR TITLE
CRM-17879 PDF formats in Message Templates not loading

### DIFF
--- a/templates/CRM/Contact/Form/Task/PDFLetterCommon.tpl
+++ b/templates/CRM/Contact/Form/Task/PDFLetterCommon.tpl
@@ -247,15 +247,12 @@ function selectFormat( val, bind ) {
   if (!val) {
     val = 0;
     bind = false;
-    var dataUrl = {/literal}"{crmURL p='civicrm/ajax/pdfFormat' h=0 }"{literal};
-    cj.post( dataUrl, {formatId: val}, function( data ) {
-      fillFormatInfo(data, bind);
-      }, 'json');
   }
-  else {
-    data=JSON.parse(val);
+
+  var dataUrl = {/literal}"{crmURL p='civicrm/ajax/pdfFormat' h=0 }"{literal};
+  cj.post( dataUrl, {formatId: val}, function( data ) {
     fillFormatInfo(data, bind);
-  }
+  }, 'json');
 }
 
 function selectPaper( val )


### PR DESCRIPTION
* [CRM-17879: PDF formats in Message Templates not loading.](https://issues.civicrm.org/jira/browse/CRM-17879)