### PR TITLE
CRM-19048 - Additional fix

### DIFF
--- a/CRM/Utils/QueryFormatter.php
+++ b/CRM/Utils/QueryFormatter.php
@@ -295,7 +295,7 @@ class CRM_Utils_QueryFormatter {
         $csid = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionValue', 'CRM_Contact_Form_Search_Custom_FullText', 'value', 'name');
         $url = CRM_Utils_System::url("civicrm/contact/search/custom", "csid={$csid}&reset=1");
         $operators = implode("', '", $operators);
-        CRM_Core_Error::statusBounce("InnoDB Full-Text Search does not support the use of a string ending with any of these operators ('{$operators}' or a single '@') in boolean mode. These invalid queries return a syntax error.", $url);
+        CRM_Core_Error::statusBounce("Full-Text Search does not support the use of a search string ending with any of these operators ('{$operators}' or a single '@'). Please adjust your search term and try again.", $url);
       }
     }
 

--- a/CRM/Utils/QueryFormatter.php
+++ b/CRM/Utils/QueryFormatter.php
@@ -287,6 +287,17 @@ class CRM_Utils_QueryFormatter {
    */
   protected function _formatFtsBool($text, $mode) {
     $result = NULL;
+    $operators = array('+', '-', '~', '(', ')');
+
+    //Return if searched string ends with an unsupported operator.
+    foreach ($operators as $val) {
+      if ($text == '@' || CRM_Utils_String::endsWith($text, $val)) {
+        $csid = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionValue', 'CRM_Contact_Form_Search_Custom_FullText', 'value', 'name');
+        $url = CRM_Utils_System::url("civicrm/contact/search/custom", "csid={$csid}&reset=1");
+        $operators = implode("', '", $operators);
+        CRM_Core_Error::statusBounce("InnoDB Full-Text Search does not support the use of a string ending with any of these operators ('{$operators}' or a single '@') in boolean mode. These invalid queries return a syntax error.", $url);
+      }
+    }
 
     // normalize user-inputted wildcards
     $text = str_replace('%', '*', $text);
@@ -309,7 +320,7 @@ class CRM_Utils_QueryFormatter {
     else {
       switch ($mode) {
         case self::MODE_NONE:
-          $result = $this->mapWords($text, '+word');
+          $result = $this->mapWords($text, '+word', TRUE);
           break;
 
         case self::MODE_PHRASE:
@@ -380,11 +391,13 @@ class CRM_Utils_QueryFormatter {
    *   User-supplied query string.
    * @param string $template
    *   A prototypical description of each word, eg "word%" or "word*" or "*word*".
+   * @param bool $quotes
+   *   True if each searched keyword need to be surrounded with quotes.
    * @return string
    */
-  protected function mapWords($text, $template) {
+  protected function mapWords($text, $template, $quotes = FALSE) {
     $result = array();
-    foreach ($this->parseWords($text) as $word) {
+    foreach ($this->parseWords($text, $quotes) as $word) {
       $result[] = str_replace('word', $word, $template);
     }
     return implode(' ', $result);
@@ -392,9 +405,10 @@ class CRM_Utils_QueryFormatter {
 
   /**
    * @param $text
+   * @bool $quotes
    * @return array
    */
-  protected function parseWords($text) {
+  protected function parseWords($text, $quotes) {
     //NYSS 9692 special handling for emails
     if (preg_match('/^([a-z0-9_\.-]+)@([\da-z\.-]+)\.([a-z\.]{2,6})$/', $text)) {
       $parts = explode('@', $text);
@@ -403,7 +417,19 @@ class CRM_Utils_QueryFormatter {
     }
 
     //NYSS also replace other occurrences of @
-    return explode(' ', preg_replace('/[ \r\n\t\@]+/', ' ', trim($text)));
+    $replacedText = preg_replace('/[ \r\n\t\@]+/', ' ', trim($text));
+    //filter empty values if any
+    $keywords = array_filter(explode(' ', $replacedText));
+
+    //Ensure each searched keywords are wrapped in double quotes.
+    if ($quotes) {
+      foreach ($keywords as &$val) {
+        if (!is_numeric($val)) {
+          $val = "\"{$val}\"";
+        }
+      }
+    }
+    return $keywords;
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/QueryFormatterTest.php
+++ b/tests/phpunit/CRM/Utils/QueryFormatterTest.php
@@ -74,7 +74,7 @@ class CRM_Utils_QueryFormatterTest extends CiviUnitTestCase {
     $cases[] = array('someone@example.com', 'fts', 'wildwords', '*someone* *example*', $allEmailRows);
     $cases[] = array('someone@example.com', 'fts', 'wildwords-suffix', 'someone* example*', $allEmailRows);
 
-    $cases[] = array('someone@example.com', 'ftsbool', 'simple', '+someone +example', $allEmailRows);
+    $cases[] = array('someone@example.com', 'ftsbool', 'simple', '+"someone" +"example"', $allEmailRows);
     $cases[] = array('someone@example.com', 'ftsbool', 'phrase', '+"someone@example.com"', $allEmailRows);
     $cases[] = array('someone@example.com', 'ftsbool', 'wildphrase', '+"*someone@example.com*"', $allEmailRows);
     $cases[] = array('someone@example.com', 'ftsbool', 'wildwords', '+*someone* +*example*', $allEmailRows);
@@ -92,7 +92,7 @@ class CRM_Utils_QueryFormatterTest extends CiviUnitTestCase {
     $cases[] = array('first second', 'fts', 'wildwords', '*first* *second*', array(3, 4, 5, 7));
     $cases[] = array('first second', 'fts', 'wildwords-suffix', 'first* second*', array(3, 4, 5, 7));
 
-    $cases[] = array('first second', 'ftsbool', 'simple', '+first +second', array(3, 4, 5));
+    $cases[] = array('first second', 'ftsbool', 'simple', '+"first" +"second"', array(3, 4, 5));
     $cases[] = array('first second', 'ftsbool', 'phrase', '+"first second"', array(3, 4, 5));
     $cases[] = array('first second', 'ftsbool', 'wildphrase', '+"*first second*"', array(3, 4, 5));
     $cases[] = array('first second', 'ftsbool', 'wildwords', '+*first* +*second*', array(3, 4, 5, 7));
@@ -103,6 +103,9 @@ class CRM_Utils_QueryFormatterTest extends CiviUnitTestCase {
     $cases[] = array('first second', 'solr', 'wildphrase', '"*first second*"', NULL);
     $cases[] = array('first second', 'solr', 'wildwords', '*first* *second*', NULL);
     $cases[] = array('first second', 'solr', 'wildwords-suffix', 'first* second*', NULL);
+
+    $cases[] = array('someone@', 'ftsbool', 'simple', '+"someone"', $allEmailRows);
+    $cases[] = array('@example.com', 'ftsbool', 'simple', '+"example.com"', $allEmailRows);
 
     // If user supplies wildcards, then ignore mode.
     foreach (array(


### PR DESCRIPTION
This works for following text searches.

1) `@domain.com` works and returns result containing `@domain.com` and not `@domain.org`.
2) `some@` works fine.
3) Bounces back to the search page if unsupported operator are used (in boolean mode) at the end of the string. For eg - `@`, `+-`, `some+`, etc as mentioned [in the doc file](http://dev.mysql.com/doc/refman/5.6/en/fulltext-boolean.html).

---

 * [CRM-19048: FullText - Search by email, blank](https://issues.civicrm.org/jira/browse/CRM-19048)