### PR TITLE
CRM-17335 - Remove unnecessary use of CRM_Core_DAO::$_nullObject

### DIFF
--- a/CRM/Activity/Form/Search.php
+++ b/CRM/Activity/Form/Search.php
@@ -84,7 +84,7 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
 
     // we allow the controller to set force/reset externally, useful when we are being
     // driven by the wizard framework
-    $this->_reset = CRM_Utils_Request::retrieve('reset', 'Boolean', CRM_Core_DAO::$_nullObject);
+    $this->_reset = CRM_Utils_Request::retrieve('reset', 'Boolean');
     $this->_force = CRM_Utils_Request::retrieve('force', 'Boolean', $this, FALSE);
     $this->_limit = CRM_Utils_Request::retrieve('limit', 'Positive', $this);
     $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this, FALSE, 'search');
@@ -281,7 +281,7 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
       $this->_defaults['activity_status_id'] = $status;
     }
 
-    $survey = CRM_Utils_Request::retrieve('survey', 'Positive', CRM_Core_DAO::$_nullObject);
+    $survey = CRM_Utils_Request::retrieve('survey', 'Positive');
 
     if ($survey) {
       $this->_formValues['activity_survey_id'] = $this->_defaults['activity_survey_id'] = $survey;

--- a/CRM/Activity/Form/Search.php
+++ b/CRM/Activity/Form/Search.php
@@ -314,9 +314,7 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
 
     // Added for membership search
 
-    $signupType = CRM_Utils_Request::retrieve('signupType', 'Positive',
-      CRM_Core_DAO::$_nullObject
-    );
+    $signupType = CRM_Utils_Request::retrieve('signupType', 'Positive');
 
     if ($signupType) {
       $this->_formValues['activity_role'] = 1;
@@ -342,9 +340,7 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
       }
     }
 
-    $dateLow = CRM_Utils_Request::retrieve('dateLow', 'String',
-      CRM_Core_DAO::$_nullObject
-    );
+    $dateLow = CRM_Utils_Request::retrieve('dateLow', 'String');
 
     if ($dateLow) {
       $dateLow = date('m/d/Y', strtotime($dateLow));
@@ -354,9 +350,7 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
       $this->_defaults['activity_date_low'] = $dateLow;
     }
 
-    $dateHigh = CRM_Utils_Request::retrieve('dateHigh', 'String',
-      CRM_Core_DAO::$_nullObject
-    );
+    $dateHigh = CRM_Utils_Request::retrieve('dateHigh', 'String');
 
     if ($dateHigh) {
       // Activity date time assumes midnight at the beginning of the date

--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -551,7 +551,7 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
         }
         $value['line_item'] = $lineItem;
         //finally call contribution create for all the magic
-        $contribution = CRM_Contribute_BAO_Contribution::create($value, CRM_Core_DAO::$_nullArray);
+        $contribution = CRM_Contribute_BAO_Contribution::create($value);
         $batchTypes = CRM_Core_Pseudoconstant::get('CRM_Batch_DAO_Batch', 'type_id', array('flip' => 1), 'validate');
         if (!empty($this->_batchInfo['type_id']) && ($this->_batchInfo['type_id'] == $batchTypes['Pledge Payment'])) {
           $adjustTotalAmount = FALSE;

--- a/CRM/Campaign/Form/Search.php
+++ b/CRM/Campaign/Form/Search.php
@@ -82,7 +82,7 @@ class CRM_Campaign_Form_Search extends CRM_Core_Form_Search {
     $this->_limit = CRM_Utils_Request::retrieve('limit', 'Positive', $this);
     $this->_force = CRM_Utils_Request::retrieve('force', 'Boolean', $this, FALSE);
     $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this, FALSE, 'search');
-    $this->_reset = CRM_Utils_Request::retrieve('reset', 'Boolean', CRM_Core_DAO::$_nullObject);
+    $this->_reset = CRM_Utils_Request::retrieve('reset', 'Boolean');
 
     //operation for state machine.
     $this->_operation = CRM_Utils_Request::retrieve('op', 'String', $this, FALSE, 'reserve');
@@ -393,14 +393,14 @@ class CRM_Campaign_Form_Search extends CRM_Core_Form_Search {
     // note that this means that GET over-rides POST :)
 
     //since we have qfKey, no need to manipulate set defaults.
-    $qfKey = CRM_Utils_Request::retrieve('qfKey', 'String', CRM_Core_DAO::$_nullObject);
+    $qfKey = CRM_Utils_Request::retrieve('qfKey', 'String');
 
     if (!$this->_force || CRM_Utils_Rule::qfKey($qfKey)) {
       return;
     }
 
     // get survey id
-    $surveyId = CRM_Utils_Request::retrieve('sid', 'Positive', CRM_Core_DAO::$_nullObject);
+    $surveyId = CRM_Utils_Request::retrieve('sid', 'Positive');
 
     if ($surveyId) {
       $surveyId = CRM_Utils_Type::escape($surveyId, 'Integer');

--- a/CRM/Campaign/Page/Petition/Confirm.php
+++ b/CRM/Campaign/Page/Petition/Confirm.php
@@ -38,13 +38,13 @@ class CRM_Campaign_Page_Petition_Confirm extends CRM_Core_Page {
   public function run() {
     CRM_Utils_System::addHTMLHead('<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">');
 
-    $contact_id = CRM_Utils_Request::retrieve('cid', 'Integer', CRM_Core_DAO::$_nullObject);
-    $subscribe_id = CRM_Utils_Request::retrieve('sid', 'Integer', CRM_Core_DAO::$_nullObject);
-    $hash = CRM_Utils_Request::retrieve('h', 'String', CRM_Core_DAO::$_nullObject);
-    $activity_id = CRM_Utils_Request::retrieve('a', 'String', CRM_Core_DAO::$_nullObject);
-    $petition_id = CRM_Utils_Request::retrieve('pid', 'String', CRM_Core_DAO::$_nullObject);
+    $contact_id = CRM_Utils_Request::retrieve('cid', 'Integer');
+    $subscribe_id = CRM_Utils_Request::retrieve('sid', 'Integer');
+    $hash = CRM_Utils_Request::retrieve('h', 'String');
+    $activity_id = CRM_Utils_Request::retrieve('a', 'String');
+    $petition_id = CRM_Utils_Request::retrieve('pid', 'String');
     if (!$petition_id) {
-      $petition_id = CRM_Utils_Request::retrieve('p', 'String', CRM_Core_DAO::$_nullObject);
+      $petition_id = CRM_Utils_Request::retrieve('p', 'String');
     }
 
     if (!$contact_id ||

--- a/CRM/Campaign/Selector/Search.php
+++ b/CRM/Campaign/Selector/Search.php
@@ -267,7 +267,7 @@ class CRM_Campaign_Selector_Search extends CRM_Core_Selector_Base implements CRM
    */
   public function buildPrevNextCache($sort) {
     //for prev/next pagination
-    $crmPID = CRM_Utils_Request::retrieve('crmPID', 'Integer', CRM_Core_DAO::$_nullObject);
+    $crmPID = CRM_Utils_Request::retrieve('crmPID', 'Integer');
 
     if (!$crmPID) {
       $cacheKey = "civicrm search {$this->_key}";

--- a/CRM/Case/Form/ActivityToCase.php
+++ b/CRM/Case/Form/ActivityToCase.php
@@ -40,12 +40,12 @@ class CRM_Case_Form_ActivityToCase extends CRM_Core_Form {
    * Build all the data structures needed to build the form.
    */
   public function preProcess() {
-    $this->_activityId = CRM_Utils_Request::retrieve('activityId', 'Positive', CRM_Core_DAO::$_nullObject);
+    $this->_activityId = CRM_Utils_Request::retrieve('activityId', 'Positive');
     if (!$this->_activityId) {
       CRM_Core_Error::fatal('required activity id is missing.');
     }
 
-    $this->_currentCaseId = CRM_Utils_Request::retrieve('caseId', 'Positive', CRM_Core_DAO::$_nullObject);
+    $this->_currentCaseId = CRM_Utils_Request::retrieve('caseId', 'Positive');
     $this->assign('currentCaseId', $this->_currentCaseId);
     $this->assign('buildCaseActivityForm', TRUE);
   }

--- a/CRM/Case/Form/ActivityView.php
+++ b/CRM/Case/Form/ActivityView.php
@@ -42,8 +42,8 @@ class CRM_Case_Form_ActivityView extends CRM_Core_Form {
   public function preProcess() {
     $contactID = CRM_Utils_Request::retrieve('cid', 'Integer', $this, TRUE);
     $activityID = CRM_Utils_Request::retrieve('aid', 'Integer', $this, TRUE);
-    $revs = CRM_Utils_Request::retrieve('revs', 'Boolean', CRM_Core_DAO::$_nullObject);
-    $caseID = CRM_Utils_Request::retrieve('caseID', 'Boolean', CRM_Core_DAO::$_nullObject);
+    $revs = CRM_Utils_Request::retrieve('revs', 'Boolean');
+    $caseID = CRM_Utils_Request::retrieve('caseID', 'Boolean');
     $activitySubject = CRM_Core_DAO::getFieldValue('CRM_Activity_DAO_Activity',
       $activityID,
       'subject'

--- a/CRM/Case/Form/CaseView.php
+++ b/CRM/Case/Form/CaseView.php
@@ -56,8 +56,8 @@ class CRM_Case_Form_CaseView extends CRM_Core_Form {
     if ($this->_showRelatedCases) {
       $relatedCases = $this->get('relatedCases');
       if (!isset($relatedCases)) {
-        $cId = CRM_Utils_Request::retrieve('cid', 'Integer', CRM_Core_DAO::$_nullObject);
-        $caseId = CRM_Utils_Request::retrieve('id', 'Integer', CRM_Core_DAO::$_nullObject);
+        $cId = CRM_Utils_Request::retrieve('cid', 'Integer');
+        $caseId = CRM_Utils_Request::retrieve('id', 'Integer');
         $relatedCases = CRM_Case_BAO_Case::getRelatedCases($caseId, $cId);
       }
       $this->assign('relatedCases', $relatedCases);
@@ -77,7 +77,7 @@ class CRM_Case_Form_CaseView extends CRM_Core_Form {
       CRM_Core_Error::fatal(ts('You are not authorized to access this page.'));
     }
 
-    $fulltext = CRM_Utils_Request::retrieve('context', 'String', CRM_Core_DAO::$_nullObject);
+    $fulltext = CRM_Utils_Request::retrieve('context', 'String');
     if ($fulltext == 'fulltext') {
       $this->assign('fulltext', $fulltext);
     }

--- a/CRM/Case/Form/Search.php
+++ b/CRM/Case/Form/Search.php
@@ -94,7 +94,7 @@ class CRM_Case_Form_Search extends CRM_Core_Form_Search {
      * driven by the wizard framework
      */
 
-    $this->_reset = CRM_Utils_Request::retrieve('reset', 'Boolean', CRM_Core_DAO::$_nullObject);
+    $this->_reset = CRM_Utils_Request::retrieve('reset', 'Boolean');
     $this->_force = CRM_Utils_Request::retrieve('force', 'Boolean', $this, FALSE);
     $this->_limit = CRM_Utils_Request::retrieve('limit', 'Positive', $this);
     $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this, FALSE, 'search');

--- a/CRM/Case/Form/Search.php
+++ b/CRM/Case/Form/Search.php
@@ -356,33 +356,25 @@ class CRM_Case_Form_Search extends CRM_Core_Form_Search {
       return;
     }
 
-    $caseStatus = CRM_Utils_Request::retrieve('status', 'Positive',
-      CRM_Core_DAO::$_nullObject
-    );
+    $caseStatus = CRM_Utils_Request::retrieve('status', 'Positive');
     if ($caseStatus) {
       $this->_formValues['case_status_id'] = $caseStatus;
       $this->_defaults['case_status_id'] = $caseStatus;
     }
-    $caseType = CRM_Utils_Request::retrieve('type', 'Positive',
-      CRM_Core_DAO::$_nullObject
-    );
+    $caseType = CRM_Utils_Request::retrieve('type', 'Positive');
     if ($caseType) {
       $this->_formValues['case_type_id'] = (array) $caseType;
       $this->_defaults['case_type_id'] = (array) $caseType;
     }
 
-    $caseFromDate = CRM_Utils_Request::retrieve('pstart', 'Date',
-      CRM_Core_DAO::$_nullObject
-    );
+    $caseFromDate = CRM_Utils_Request::retrieve('pstart', 'Date');
     if ($caseFromDate) {
       list($date) = CRM_Utils_Date::setDateDefaults($caseFromDate);
       $this->_formValues['case_start_date_low'] = $date;
       $this->_defaults['case_start_date_low'] = $date;
     }
 
-    $caseToDate = CRM_Utils_Request::retrieve('pend', 'Date',
-      CRM_Core_DAO::$_nullObject
-    );
+    $caseToDate = CRM_Utils_Request::retrieve('pend', 'Date');
     if ($caseToDate) {
       list($date) = CRM_Utils_Date::setDateDefaults($caseToDate);
       $this->_formValues['case_start_date_high'] = $date;
@@ -415,9 +407,7 @@ class CRM_Case_Form_Search extends CRM_Core_Form_Search {
       }
 
       // Now if case_owner is set in the url/post, use that instead.
-      $caseOwner = CRM_Utils_Request::retrieve('case_owner', 'Positive',
-        CRM_Core_DAO::$_nullObject
-      );
+      $caseOwner = CRM_Utils_Request::retrieve('case_owner', 'Positive');
       if ($caseOwner) {
         $this->_formValues['case_owner'] = $caseOwner;
         $this->_defaults['case_owner'] = $caseOwner;

--- a/CRM/Case/XMLProcessor/Report.php
+++ b/CRM/Case/XMLProcessor/Report.php
@@ -811,11 +811,11 @@ LIMIT  1
   }
 
   public static function printCaseReport() {
-    $caseID = CRM_Utils_Request::retrieve('caseID', 'Positive', CRM_Core_DAO::$_nullObject);
-    $clientID = CRM_Utils_Request::retrieve('cid', 'Positive', CRM_Core_DAO::$_nullObject);
-    $activitySetName = CRM_Utils_Request::retrieve('asn', 'String', CRM_Core_DAO::$_nullObject);
-    $isRedact = CRM_Utils_Request::retrieve('redact', 'Boolean', CRM_Core_DAO::$_nullObject);
-    $includeActivities = CRM_Utils_Request::retrieve('all', 'Positive', CRM_Core_DAO::$_nullObject);
+    $caseID = CRM_Utils_Request::retrieve('caseID', 'Positive');
+    $clientID = CRM_Utils_Request::retrieve('cid', 'Positive');
+    $activitySetName = CRM_Utils_Request::retrieve('asn', 'String');
+    $isRedact = CRM_Utils_Request::retrieve('redact', 'Boolean');
+    $includeActivities = CRM_Utils_Request::retrieve('all', 'Positive');
     $params = $otherRelationships = $globalGroupInfo = array();
     $report = new CRM_Case_XMLProcessor_Report($isRedact);
     if ($includeActivities) {

--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -2330,10 +2330,10 @@ ORDER BY civicrm_email.is_primary DESC";
    * @param string $ctype
    *   Contact type.
    *
-   * @return object
+   * @return object|null
    *   $dao contact details
    */
-  public static function &matchContactOnEmail($mail, $ctype = NULL) {
+  public static function matchContactOnEmail($mail, $ctype = NULL) {
     $strtolower = function_exists('mb_strtolower') ? 'mb_strtolower' : 'strtolower';
     $mail = $strtolower(trim($mail));
     $query = "
@@ -2370,7 +2370,7 @@ WHERE      civicrm_email.email = %1 AND civicrm_contact.is_deleted=0";
     if ($dao->fetch()) {
       return $dao;
     }
-    return CRM_Core_DAO::$_nullObject;
+    return NULL;
   }
 
   /**
@@ -2381,10 +2381,10 @@ WHERE      civicrm_email.email = %1 AND civicrm_contact.is_deleted=0";
    * @param string $ctype
    *   Contact type.
    *
-   * @return object
+   * @return object|null
    *   $dao contact details
    */
-  public static function &matchContactOnOpenId($openId, $ctype = NULL) {
+  public static function matchContactOnOpenId($openId, $ctype = NULL) {
     $strtolower = function_exists('mb_strtolower') ? 'mb_strtolower' : 'strtolower';
     $openId = $strtolower(trim($openId));
     $query = "
@@ -2409,7 +2409,7 @@ WHERE      civicrm_openid.openid = %1";
     if ($dao->fetch()) {
       return $dao;
     }
-    return CRM_Core_DAO::$_nullObject;
+    return NULL;
   }
 
   /**

--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -861,7 +861,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
                                ON contact.id = gOrg.organization_id ";
 
       //get the Organization ID
-      $orgID = CRM_Utils_Request::retrieve('oid', 'Positive', CRM_Core_DAO::$_nullObject);
+      $orgID = CRM_Utils_Request::retrieve('oid', 'Positive');
       if ($orgID) {
         $where = " AND gOrg.organization_id = {$orgID}";
       }

--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -374,7 +374,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
         $this->assign('paramSubType', $paramSubType);
       }
 
-      if (CRM_Utils_Request::retrieve('type', 'String', CRM_Core_DAO::$_nullObject)) {
+      if (CRM_Utils_Request::retrieve('type', 'String')) {
         CRM_Contact_Form_Edit_CustomData::preProcess($this);
       }
       else {

--- a/CRM/Contact/Form/Edit/Address.php
+++ b/CRM/Contact/Form/Edit/Address.php
@@ -240,7 +240,7 @@ class CRM_Contact_Form_Edit_Address {
    * @return array|bool
    *   if no errors
    */
-  public static function formRule($fields, $files, $self) {
+  public static function formRule($fields, $files = array(), $self = NULL) {
     $errors = array();
 
     $customDataRequiredFields = array();

--- a/CRM/Contact/Form/Edit/CustomData.php
+++ b/CRM/Contact/Form/Edit/CustomData.php
@@ -42,8 +42,8 @@ class CRM_Contact_Form_Edit_CustomData {
    * @param CRM_Core_Form $form
    */
   public static function preProcess(&$form) {
-    $form->_type = CRM_Utils_Request::retrieve('type', 'String', CRM_Core_DAO::$_nullObject);
-    $form->_subType = CRM_Utils_Request::retrieve('subType', 'String', CRM_Core_DAO::$_nullObject);
+    $form->_type = CRM_Utils_Request::retrieve('type', 'String');
+    $form->_subType = CRM_Utils_Request::retrieve('subType', 'String');
 
     //build the custom data as other blocks.
     //$form->assign( "addBlock", false );

--- a/CRM/Contact/Form/Location.php
+++ b/CRM/Contact/Form/Location.php
@@ -38,8 +38,8 @@ class CRM_Contact_Form_Location {
    * @param CRM_Core_Form $form
    */
   public static function preProcess(&$form) {
-    $form->_addBlockName = CRM_Utils_Request::retrieve('block', 'String', CRM_Core_DAO::$_nullObject);
-    $additionalblockCount = CRM_Utils_Request::retrieve('count', 'Positive', CRM_Core_DAO::$_nullObject);
+    $form->_addBlockName = CRM_Utils_Request::retrieve('block', 'String');
+    $additionalblockCount = CRM_Utils_Request::retrieve('count', 'Positive');
 
     $form->assign('addBlock', FALSE);
     if ($form->_addBlockName && $additionalblockCount) {

--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -762,7 +762,7 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
     $this->_done = TRUE;
 
     //for prev/next pagination
-    $crmPID = CRM_Utils_Request::retrieve('crmPID', 'Integer', CRM_Core_DAO::$_nullObject);
+    $crmPID = CRM_Utils_Request::retrieve('crmPID', 'Integer');
 
     if (array_key_exists($this->_searchButtonName, $_POST) ||
       ($this->_force && !$crmPID)

--- a/CRM/Contact/Form/Search/Custom/Sample.php
+++ b/CRM/Contact/Form/Search/Custom/Sample.php
@@ -42,9 +42,7 @@ class CRM_Contact_Form_Search_Custom_Sample extends CRM_Contact_Form_Search_Cust
     parent::__construct($formValues);
 
     if (!isset($formValues['state_province_id'])) {
-      $this->_stateID = CRM_Utils_Request::retrieve('stateID', 'Integer',
-        CRM_Core_DAO::$_nullObject
-      );
+      $this->_stateID = CRM_Utils_Request::retrieve('stateID', 'Integer');
       if ($this->_stateID) {
         $formValues['state_province_id'] = $this->_stateID;
       }

--- a/CRM/Contact/Page/AJAX.php
+++ b/CRM/Contact/Page/AJAX.php
@@ -226,8 +226,8 @@ class CRM_Contact_Page_AJAX {
   public static function relationship() {
     $relType = CRM_Utils_Request::retrieve('rel_type', 'String', CRM_Core_DAO::$_nullObject, TRUE);
     $relContactID = CRM_Utils_Request::retrieve('rel_contact', 'Positive', CRM_Core_DAO::$_nullObject, TRUE);
-    $originalCid = CRM_Utils_Request::retrieve('cid', 'Positive', CRM_Core_DAO::$_nullObject);
-    $relationshipID = CRM_Utils_Request::retrieve('rel_id', 'Positive', CRM_Core_DAO::$_nullObject);
+    $originalCid = CRM_Utils_Request::retrieve('cid', 'Positive');
+    $relationshipID = CRM_Utils_Request::retrieve('rel_id', 'Positive');
     $caseID = CRM_Utils_Request::retrieve('case_id', 'Positive', CRM_Core_DAO::$_nullObject, TRUE);
 
     if (!CRM_Case_BAO_Case::accessCase($caseID)) {
@@ -295,7 +295,7 @@ class CRM_Contact_Page_AJAX {
     CRM_Utils_System::setHttpHeader('Content-Type', 'text/plain');
     $customValueID = CRM_Utils_Type::escape($_REQUEST['valueID'], 'Positive');
     $customGroupID = CRM_Utils_Type::escape($_REQUEST['groupID'], 'Positive');
-    $contactId = CRM_Utils_Request::retrieve('contactId', 'Positive', CRM_Core_DAO::$_nullObject);
+    $contactId = CRM_Utils_Request::retrieve('contactId', 'Positive');
     CRM_Core_BAO_CustomValue::deleteCustomValue($customValueID, $customGroupID);
     if ($contactId) {
       echo CRM_Contact_BAO_Contact::getCountComponent('custom_' . $customGroupID, $contactId);
@@ -310,8 +310,8 @@ class CRM_Contact_Page_AJAX {
    */
   static public function checkUserName() {
     $signer = new CRM_Utils_Signer(CRM_Core_Key::privateKey(), array('for', 'ts'));
-    $sig = CRM_Utils_Request::retrieve('sig', 'String', CRM_Core_DAO::$_nullObject);
-    $for = CRM_Utils_Request::retrieve('for', 'String', CRM_Core_DAO::$_nullObject);
+    $sig = CRM_Utils_Request::retrieve('sig', 'String');
+    $for = CRM_Utils_Request::retrieve('for', 'String');
     if (
       CRM_Utils_Time::getTimeRaw() > $_REQUEST['ts'] + self::CHECK_USERNAME_TTL
       || $for != 'civicrm/ajax/cmsuser'
@@ -411,8 +411,8 @@ LIMIT {$offset}, {$rowCount}
           // send query to hook to be modified if needed
           CRM_Utils_Hook::contactListQuery($query,
             $name,
-            CRM_Utils_Request::retrieve('context', 'String', CRM_Core_DAO::$_nullObject),
-            CRM_Utils_Request::retrieve('cid', 'Positive', CRM_Core_DAO::$_nullObject)
+            CRM_Utils_Request::retrieve('context', 'String'),
+            CRM_Utils_Request::retrieve('cid', 'Positive')
           );
 
           $dao = CRM_Core_DAO::executeQuery($query);
@@ -436,8 +436,8 @@ LIMIT {$offset}, {$rowCount}
           // send query to hook to be modified if needed
           CRM_Utils_Hook::contactListQuery($query,
             $name,
-            CRM_Utils_Request::retrieve('context', 'String', CRM_Core_DAO::$_nullObject),
-            CRM_Utils_Request::retrieve('cid', 'Positive', CRM_Core_DAO::$_nullObject)
+            CRM_Utils_Request::retrieve('context', 'String'),
+            CRM_Utils_Request::retrieve('cid', 'Positive')
           );
 
           $dao = CRM_Core_DAO::executeQuery($query);
@@ -507,8 +507,8 @@ LIMIT {$offset}, {$rowCount}
       // send query to hook to be modified if needed
       CRM_Utils_Hook::contactListQuery($query,
         $name,
-        CRM_Utils_Request::retrieve('context', 'String', CRM_Core_DAO::$_nullObject),
-        CRM_Utils_Request::retrieve('cid', 'Positive', CRM_Core_DAO::$_nullObject)
+        CRM_Utils_Request::retrieve('context', 'String'),
+        CRM_Utils_Request::retrieve('cid', 'Positive')
       );
 
       $dao = CRM_Core_DAO::executeQuery($query);
@@ -529,7 +529,7 @@ LIMIT {$offset}, {$rowCount}
 
 
   public static function buildSubTypes() {
-    $parent = CRM_Utils_Request::retrieve('parentId', 'Positive', CRM_Core_DAO::$_nullObject);
+    $parent = CRM_Utils_Request::retrieve('parentId', 'Positive');
 
     switch ($parent) {
       case 1:
@@ -551,7 +551,7 @@ LIMIT {$offset}, {$rowCount}
   }
 
   public static function buildDedupeRules() {
-    $parent = CRM_Utils_Request::retrieve('parentId', 'Positive', CRM_Core_DAO::$_nullObject);
+    $parent = CRM_Utils_Request::retrieve('parentId', 'Positive');
 
     switch ($parent) {
       case 1:
@@ -987,7 +987,7 @@ LIMIT {$offset}, {$rowCount}
   }
 
   public static function getAddressDisplay() {
-    $contactId = CRM_Utils_Request::retrieve('contact_id', 'Positive', CRM_Core_DAO::$_nullObject);
+    $contactId = CRM_Utils_Request::retrieve('contact_id', 'Positive');
     if (!$contactId) {
       $addressVal["error_message"] = "no contact id found";
     }

--- a/CRM/Contact/Page/DedupeMerge.php
+++ b/CRM/Contact/Page/DedupeMerge.php
@@ -58,7 +58,7 @@ class CRM_Contact_Page_DedupeMerge extends CRM_Core_Page {
     $rgid = CRM_Utils_Request::retrieve('rgid', 'Positive');
     $gid  = CRM_Utils_Request::retrieve('gid', 'Positive');
     $limit  = CRM_Utils_Request::retrieve('limit', 'Positive');
-    $action = CRM_Utils_Request::retrieve('action', 'String', CRM_Core_DAO::$_nullObject);
+    $action = CRM_Utils_Request::retrieve('action', 'String');
     $mode   = CRM_Utils_Request::retrieve('mode', 'String', CRM_Core_DAO::$_nullObject, FALSE, 'safe');
 
     $cacheKeyString = CRM_Dedupe_Merger::getMergeCacheKeyString($rgid, $gid);

--- a/CRM/Contact/Page/View.php
+++ b/CRM/Contact/Page/View.php
@@ -365,9 +365,7 @@ class CRM_Contact_Page_View extends CRM_Core_Page {
     CRM_Utils_Hook::links('view.contact.activity',
       'Contact',
       $cid,
-      $hookLinks,
-      CRM_Core_DAO::$_nullObject,
-      CRM_Core_DAO::$_nullObject
+      $hookLinks
     );
     if (is_array($hookLinks)) {
       $obj->assign('hookLinks', $hookLinks);

--- a/CRM/Contact/Page/View/Note.php
+++ b/CRM/Contact/Page/View/Note.php
@@ -166,10 +166,7 @@ class CRM_Contact_Page_View_Note extends CRM_Core_Page {
     );
     $session->pushUserContext($url);
 
-    if (CRM_Utils_Request::retrieve('confirmed', 'Boolean',
-      CRM_Core_DAO::$_nullObject
-    )
-    ) {
+    if (CRM_Utils_Request::retrieve('confirmed', 'Boolean')) {
       CRM_Core_BAO_Note::del($this->_id);
       CRM_Utils_System::redirect($url);
     }

--- a/CRM/Contact/Page/View/Relationship.php
+++ b/CRM/Contact/Page/View/Relationship.php
@@ -157,10 +157,7 @@ class CRM_Contact_Page_View_Relationship extends CRM_Core_Page {
 
     $session->pushUserContext($url);
 
-    if (CRM_Utils_Request::retrieve('confirmed', 'Boolean',
-      CRM_Core_DAO::$_nullObject
-    )
-    ) {
+    if (CRM_Utils_Request::retrieve('confirmed', 'Boolean')) {
       if ($this->_caseId) {
         //create an activity for case role removal.CRM-4480
         CRM_Case_BAO_Case::createCaseRoleActivity($this->_caseId, $this->_id);

--- a/CRM/Contact/Page/View/UserDashBoard.php
+++ b/CRM/Contact/Page/View/UserDashBoard.php
@@ -243,9 +243,7 @@ class CRM_Contact_Page_View_UserDashBoard extends CRM_Core_Page {
     CRM_Utils_Hook::links('view.contact.userDashBoard',
       'Contact',
       CRM_Core_DAO::$_nullObject,
-      self::$_links,
-      CRM_Core_DAO::$_nullObject,
-      CRM_Core_DAO::$_nullObject
+      self::$_links
     );
     return self::$_links;
   }

--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -178,7 +178,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
     $contextMenu = NULL
   ) {
     //don't build query constructor, if form is not submitted
-    $force = CRM_Utils_Request::retrieve('force', 'Boolean', CRM_Core_DAO::$_nullObject);
+    $force = CRM_Utils_Request::retrieve('force', 'Boolean');
     if (empty($formValues) && !$force) {
       return;
     }
@@ -862,10 +862,10 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
     // 2. if records are sorted
 
     // get current page requested
-    $pageNum = CRM_Utils_Request::retrieve('crmPID', 'Integer', CRM_Core_DAO::$_nullObject);
+    $pageNum = CRM_Utils_Request::retrieve('crmPID', 'Integer');
 
     // get the current sort order
-    $currentSortID = CRM_Utils_Request::retrieve('crmSID', 'String', CRM_Core_DAO::$_nullObject);
+    $currentSortID = CRM_Utils_Request::retrieve('crmSID', 'String');
 
     $session = CRM_Core_Session::singleton();
 
@@ -891,7 +891,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
     $firstRecord = ($pageNum - 1) * $pageSize;
 
     //for alphabetic pagination selection save
-    $sortByCharacter = CRM_Utils_Request::retrieve('sortByCharacter', 'String', CRM_Core_DAO::$_nullObject);
+    $sortByCharacter = CRM_Utils_Request::retrieve('sortByCharacter', 'String');
 
     //for text field pagination selection save
     $countRow = CRM_Core_BAO_PrevNextCache::getCount($cacheKey, NULL, "entity_table = 'civicrm_contact'");

--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -958,8 +958,7 @@ LEFT JOIN  civicrm_premiums            ON ( civicrm_premiums.entity_id = civicrm
       'output' => 'pdf_invoice',
       'forPage' => 'confirmpage',
     );
-    $pdfHtml = CRM_Contribute_Form_Task_Invoice::printPDF($contributionID,
-      $pdfParams, $contactId, CRM_Core_DAO::$_nullObject);
+    $pdfHtml = CRM_Contribute_Form_Task_Invoice::printPDF($contributionID, $pdfParams, $contactId);
     return $pdfHtml;
   }
 

--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -305,7 +305,7 @@ SELECT r.payment_processor_id
       }
 
       // if there are associated objects, cancel them as well
-      if ($objects == CRM_Core_DAO::$_nullObject) {
+      if (!$objects) {
         $transaction->commit();
         return TRUE;
       }

--- a/CRM/Contribute/Form/CancelSubscription.php
+++ b/CRM/Contribute/Form/CancelSubscription.php
@@ -100,7 +100,7 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Core_Form {
 
     if (
       (!$this->_crid && !$this->_coid && !$this->_mid) ||
-      ($this->_subscriptionDetails == CRM_Core_DAO::$_nullObject)
+      (!$this->_subscriptionDetails)
     ) {
       CRM_Core_Error::fatal('Required information missing.');
     }
@@ -224,7 +224,7 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Core_Form {
         );
       $cancelStatus = CRM_Contribute_BAO_ContributionRecur::cancelRecurContribution(
         $this->_subscriptionDetails->recur_id,
-        CRM_Core_DAO::$_nullObject,
+        NULL,
         $activityParams
       );
 

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -99,7 +99,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     $this->assign('isShare', CRM_Utils_Array::value('is_share', $this->_values));
     $this->assign('isConfirmEnabled', CRM_Utils_Array::value('is_confirm_enabled', $this->_values));
 
-    $this->assign('reset', CRM_Utils_Request::retrieve('reset', 'Boolean', CRM_Core_DAO::$_nullObject));
+    $this->assign('reset', CRM_Utils_Request::retrieve('reset', 'Boolean'));
     $this->assign('mainDisplay', CRM_Utils_Request::retrieve('_qf_Main_display', 'Boolean',
       CRM_Core_DAO::$_nullObject));
 

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -450,7 +450,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
     }
 
     //do check for cancel recurring and clean db, CRM-7696
-    if (CRM_Utils_Request::retrieve('cancel', 'Boolean', CRM_Core_DAO::$_nullObject)) {
+    if (CRM_Utils_Request::retrieve('cancel', 'Boolean')) {
       self::cancelRecurring();
     }
 
@@ -1004,15 +1004,15 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
    * lets delete the recurring and related contribution.
    */
   public function cancelRecurring() {
-    $isCancel = CRM_Utils_Request::retrieve('cancel', 'Boolean', CRM_Core_DAO::$_nullObject);
+    $isCancel = CRM_Utils_Request::retrieve('cancel', 'Boolean');
     if ($isCancel) {
-      $isRecur = CRM_Utils_Request::retrieve('isRecur', 'Boolean', CRM_Core_DAO::$_nullObject);
-      $recurId = CRM_Utils_Request::retrieve('recurId', 'Positive', CRM_Core_DAO::$_nullObject);
+      $isRecur = CRM_Utils_Request::retrieve('isRecur', 'Boolean');
+      $recurId = CRM_Utils_Request::retrieve('recurId', 'Positive');
       //clean db for recurring contribution.
       if ($isRecur && $recurId) {
         CRM_Contribute_BAO_ContributionRecur::deleteRecurContribution($recurId);
       }
-      $contribId = CRM_Utils_Request::retrieve('contribId', 'Positive', CRM_Core_DAO::$_nullObject);
+      $contribId = CRM_Utils_Request::retrieve('contribId', 'Positive');
       if ($contribId) {
         CRM_Contribute_BAO_Contribution::deleteContribution($contribId);
       }

--- a/CRM/Contribute/Form/Search.php
+++ b/CRM/Contribute/Form/Search.php
@@ -80,7 +80,7 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
      * driven by the wizard framework
      */
 
-    $this->_reset = CRM_Utils_Request::retrieve('reset', 'Boolean', CRM_Core_DAO::$_nullObject);
+    $this->_reset = CRM_Utils_Request::retrieve('reset', 'Boolean');
     $this->_force = CRM_Utils_Request::retrieve('force', 'Boolean', $this, FALSE);
     $this->_limit = CRM_Utils_Request::retrieve('limit', 'Positive', $this);
     $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this, FALSE, 'search');

--- a/CRM/Contribute/Form/Search.php
+++ b/CRM/Contribute/Form/Search.php
@@ -382,9 +382,7 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
       return;
     }
 
-    $status = CRM_Utils_Request::retrieve('status', 'String',
-      CRM_Core_DAO::$_nullObject
-    );
+    $status = CRM_Utils_Request::retrieve('status', 'String');
     if ($status) {
       $this->_formValues['contribution_status_id'] = array($status => 1);
       $this->_defaults['contribution_status_id'] = array($status => 1);
@@ -406,18 +404,14 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
       }
     }
 
-    $lowDate = CRM_Utils_Request::retrieve('start', 'Timestamp',
-      CRM_Core_DAO::$_nullObject
-    );
+    $lowDate = CRM_Utils_Request::retrieve('start', 'Timestamp');
     if ($lowDate) {
       $lowDate = CRM_Utils_Type::escape($lowDate, 'Timestamp');
       $date = CRM_Utils_Date::setDateDefaults($lowDate);
       $this->_formValues['contribution_date_low'] = $this->_defaults['contribution_date_low'] = $date[0];
     }
 
-    $highDate = CRM_Utils_Request::retrieve('end', 'Timestamp',
-      CRM_Core_DAO::$_nullObject
-    );
+    $highDate = CRM_Utils_Request::retrieve('end', 'Timestamp');
     if ($highDate) {
       $highDate = CRM_Utils_Type::escape($highDate, 'Timestamp');
       $date = CRM_Utils_Date::setDateDefaults($highDate);
@@ -433,9 +427,7 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
       $this
     );
 
-    $test = CRM_Utils_Request::retrieve('test', 'Boolean',
-      CRM_Core_DAO::$_nullObject
-    );
+    $test = CRM_Utils_Request::retrieve('test', 'Boolean');
     if (isset($test)) {
       $test = CRM_Utils_Type::escape($test, 'Boolean');
       $this->_formValues['contribution_test'] = $test;

--- a/CRM/Contribute/Form/Task/Invoice.php
+++ b/CRM/Contribute/Form/Task/Invoice.php
@@ -223,7 +223,7 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
    */
   public function postProcess() {
     $params = $this->controller->exportValues($this->_name);
-    $this->printPDF($this->_contributionIds, $params, $this->_contactIds, $this);
+    self::printPDF($this->_contributionIds, $params, $this->_contactIds);
   }
 
   /**
@@ -235,10 +235,8 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
    *   Associated array of submitted values.
    * @param array $contactIds
    *   Contact Id.
-   * @param CRM_Core_Form $form
-   *   Form object.
    */
-  public static function printPDF($contribIDs, &$params, $contactIds, &$form) {
+  public static function printPDF($contribIDs, &$params, $contactIds) {
     // get all the details needed to generate a invoice
     $messageInvoice = array();
     $invoiceTemplate = CRM_Core_Smarty::singleton();
@@ -663,7 +661,7 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
     $contributionIDs = array($contributionId);
     $contactId = CRM_Utils_Request::retrieve('cid', 'Positive', CRM_Core_DAO::$_nullObject, FALSE);
     $params = array('output' => 'pdf_invoice');
-    CRM_Contribute_Form_Task_Invoice::printPDF($contributionIDs, $params, $contactId, CRM_Core_DAO::$_nullObject);
+    CRM_Contribute_Form_Task_Invoice::printPDF($contributionIDs, $params, $contactId);
   }
 
 }

--- a/CRM/Contribute/Form/UpdateBilling.php
+++ b/CRM/Contribute/Form/UpdateBilling.php
@@ -86,9 +86,7 @@ class CRM_Contribute_Form_UpdateBilling extends CRM_Core_Form {
       $this->_mode = 'auto_renew';
     }
 
-    if ((!$this->_crid && !$this->_coid && !$this->_mid) ||
-      ($this->_subscriptionDetails == CRM_Core_DAO::$_nullObject)
-    ) {
+    if ((!$this->_crid && !$this->_coid && !$this->_mid) || (!$this->_subscriptionDetails)) {
       CRM_Core_Error::fatal('Required information missing.');
     }
     if (!CRM_Core_Permission::check('edit contributions')) {

--- a/CRM/Contribute/Form/UpdateSubscription.php
+++ b/CRM/Contribute/Form/UpdateSubscription.php
@@ -100,9 +100,7 @@ class CRM_Contribute_Form_UpdateSubscription extends CRM_Core_Form {
       $this->_coid = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $this->contributionRecurID, 'id', 'contribution_recur_id');
     }
 
-    if ((!$this->contributionRecurID) ||
-      ($this->_subscriptionDetails == CRM_Core_DAO::$_nullObject)
-    ) {
+    if (!$this->contributionRecurID || !$this->_subscriptionDetails) {
       CRM_Core_Error::fatal('Required information missing.');
     }
 

--- a/CRM/Contribute/Page/SubscriptionStatus.php
+++ b/CRM/Contribute/Page/SubscriptionStatus.php
@@ -39,8 +39,8 @@ class CRM_Contribute_Page_SubscriptionStatus extends CRM_Core_Page {
    * @return null
    */
   public function run() {
-    $task = CRM_Utils_Request::retrieve('task', 'String', CRM_Core_DAO::$_nullObject);
-    $result = CRM_Utils_Request::retrieve('result', 'Integer', CRM_Core_DAO::$_nullObject);
+    $task = CRM_Utils_Request::retrieve('task', 'String');
+    $result = CRM_Utils_Request::retrieve('result', 'Integer');
 
     $this->assign('task', $task);
     $this->assign('result', $result);

--- a/CRM/Contribute/Selector/Search.php
+++ b/CRM/Contribute/Selector/Search.php
@@ -336,10 +336,10 @@ class CRM_Contribute_Selector_Search extends CRM_Core_Selector_Base implements C
     $componentId = $componentContext = NULL;
     if ($this->_context != 'contribute') {
       // @todo explain the significance of context & why we do not get these i that context.
-      $qfKey = CRM_Utils_Request::retrieve('key', 'String', CRM_Core_DAO::$_nullObject);
-      $componentId = CRM_Utils_Request::retrieve('id', 'Positive', CRM_Core_DAO::$_nullObject);
-      $componentAction = CRM_Utils_Request::retrieve('action', 'String', CRM_Core_DAO::$_nullObject);
-      $componentContext = CRM_Utils_Request::retrieve('compContext', 'String', CRM_Core_DAO::$_nullObject);
+      $qfKey = CRM_Utils_Request::retrieve('key', 'String');
+      $componentId = CRM_Utils_Request::retrieve('id', 'Positive');
+      $componentAction = CRM_Utils_Request::retrieve('action', 'String');
+      $componentContext = CRM_Utils_Request::retrieve('compContext', 'String');
 
       if (!$componentContext &&
         $this->_compContext

--- a/CRM/Core/BAO/File.php
+++ b/CRM/Core/BAO/File.php
@@ -165,7 +165,7 @@ class CRM_Core_BAO_File extends CRM_Core_DAO_File {
 
     //save free tags
     if (isset($fileParams['attachment_taglist']) && !empty($fileParams['attachment_taglist'])) {
-      CRM_Core_Form_Tag::postProcess($fileParams['attachment_taglist'], $entityFileDAO->id, 'civicrm_file', CRM_Core_DAO::$_nullObject);
+      CRM_Core_Form_Tag::postProcess($fileParams['attachment_taglist'], $entityFileDAO->id, 'civicrm_file');
     }
 
     // lets call the post hook here so attachments code can do the right stuff

--- a/CRM/Core/BAO/Log.php
+++ b/CRM/Core/BAO/Log.php
@@ -53,7 +53,7 @@ class CRM_Core_BAO_Log extends CRM_Core_DAO_Log {
     $log->entity_id = $id;
     $log->orderBy('modified_date desc');
     $log->limit(1);
-    $result = CRM_Core_DAO::$_nullObject;
+    $result = NULL;
     if ($log->find(TRUE)) {
       list($displayName, $contactImage) = CRM_Contact_BAO_Contact::getDisplayAndImage($log->modified_id);
       $result = array(

--- a/CRM/Core/BAO/Note.php
+++ b/CRM/Core/BAO/Note.php
@@ -134,13 +134,13 @@ class CRM_Core_BAO_Note extends CRM_Core_DAO_Note {
    * @param array $ids
    *   (deprecated) associated array with note id - preferably set $params['id'].
    *
-   * @return object
+   * @return object|null
    *   $note CRM_Core_BAO_Note object
    */
   public static function add(&$params, $ids = array()) {
     $dataExists = self::dataExists($params);
     if (!$dataExists) {
-      return CRM_Core_DAO::$_nullObject;
+      return NULL;
     }
 
     if (!empty($params['entity_table']) && $params['entity_table'] == 'civicrm_contact' && !empty($params['check_permissions'])) {

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -3301,7 +3301,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
             );
             $groupTree = CRM_Utils_Array::crmArrayMerge($groupTree, $subTree);
           }
-          $formattedGroupTree = CRM_Core_BAO_CustomGroup::formatGroupTree($groupTree, 1, CRM_Core_DAO::$_nullObject);
+          $formattedGroupTree = CRM_Core_BAO_CustomGroup::formatGroupTree($groupTree, 1);
           CRM_Core_BAO_CustomGroup::setDefaults($formattedGroupTree, $defaults);
         }
 

--- a/CRM/Core/Block.php
+++ b/CRM/Core/Block.php
@@ -421,9 +421,7 @@ class CRM_Core_Block {
     CRM_Utils_Hook::links('create.new.shorcuts',
       NULL,
       CRM_Core_DAO::$_nullObject,
-      $values,
-      CRM_Core_DAO::$_nullObject,
-      CRM_Core_DAO::$_nullObject
+      $values
     );
 
     foreach ($values as $key => $val) {

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -47,9 +47,14 @@ require_once 'CRM/Core/I18n.php';
 class CRM_Core_DAO extends DB_DataObject {
 
   /**
-   * A null object so we can pass it as reference if / when needed
+   * @var null
+   * @deprecated
    */
   static $_nullObject = NULL;
+  /**
+   * @var array
+   * @deprecated
+   */
   static $_nullArray = array();
 
   static $_dbColumnValueCache = NULL;
@@ -1529,7 +1534,7 @@ FROM   civicrm_domain
    * @param $toId
    * @param array $newData
    *
-   * @return null
+   * @return CRM_Core_DAO|null
    */
   public static function cascadeUpdate($daoName, $fromId, $toId, $newData = array()) {
     $object = new $daoName();
@@ -1563,7 +1568,7 @@ FROM   civicrm_domain
         return $newObject;
       }
     }
-    return CRM_Core_DAO::$_nullObject;
+    return NULL;
   }
 
   /**

--- a/CRM/Core/Page/File.php
+++ b/CRM/Core/Page/File.php
@@ -60,7 +60,7 @@ class CRM_Core_Page_File extends CRM_Core_Page {
     }
 
     if ($action & CRM_Core_Action::DELETE) {
-      if (CRM_Utils_Request::retrieve('confirmed', 'Boolean', CRM_Core_DAO::$_nullObject)) {
+      if (CRM_Utils_Request::retrieve('confirmed', 'Boolean')) {
         CRM_Core_BAO_File::deleteFileReferences($id, $eid, $fid);
         CRM_Core_Session::setStatus(ts('The attached file has been deleted.'), ts('Complete'), 'success');
 

--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -789,7 +789,7 @@ WHERE  id = %1";
    *
    * @param bool $applyLimit
    *
-   * @return array
+   * @return array|null
    *   array reference of all countries.
    */
   public static function country($id = FALSE, $applyLimit = TRUE) {
@@ -846,7 +846,7 @@ WHERE  id = %1";
         return self::$country[$id];
       }
       else {
-        return CRM_Core_DAO::$_nullObject;
+        return NULL;
       }
     }
     return self::$country;
@@ -1618,12 +1618,12 @@ ORDER BY name";
    *
    * @param int $stateID
    *
-   * @return int
+   * @return int|null
    *   the country id that the state belongs to
    */
   public static function countryIDForStateID($stateID) {
     if (empty($stateID)) {
-      return CRM_Core_DAO::$_nullObject;
+      return NULL;
     }
 
     $query = "

--- a/CRM/Core/QuickForm/Action/Display.php
+++ b/CRM/Core/QuickForm/Action/Display.php
@@ -111,7 +111,7 @@ class CRM_Core_QuickForm_Action_Display extends CRM_Core_QuickForm_Action {
     $form = $page->toSmarty();
 
     // Deprecated - use snippet=6 instead of json=1
-    $json = CRM_Utils_Request::retrieve('json', 'Boolean', CRM_Core_DAO::$_nullObject);
+    $json = CRM_Utils_Request::retrieve('json', 'Boolean');
     if ($json) {
       CRM_Utils_JSON::output($form);
     }

--- a/CRM/Custom/Form/CustomData.php
+++ b/CRM/Custom/Form/CustomData.php
@@ -90,7 +90,7 @@ class CRM_Custom_Form_CustomData {
     $form->assign('cgCount', $form->_groupCount);
 
     //carry qf key, since this form is not inhereting core form.
-    if ($qfKey = CRM_Utils_Request::retrieve('qfKey', 'String', CRM_Core_DAO::$_nullObject)) {
+    if ($qfKey = CRM_Utils_Request::retrieve('qfKey', 'String')) {
       $form->assign('qfKey', $qfKey);
     }
 
@@ -101,8 +101,8 @@ class CRM_Custom_Form_CustomData {
       $form->_entityId = CRM_Utils_Request::retrieve('entityID', 'Positive', $form);
     }
 
-    $typeCheck = CRM_Utils_Request::retrieve('type', 'String', CRM_Core_DAO::$_nullObject);
-    $urlGroupId = CRM_Utils_Request::retrieve('groupID', 'Positive', CRM_Core_DAO::$_nullObject);
+    $typeCheck = CRM_Utils_Request::retrieve('type', 'String');
+    $urlGroupId = CRM_Utils_Request::retrieve('groupID', 'Positive');
     if (isset($typeCheck) && $urlGroupId) {
       $form->_groupID = $urlGroupId;
     }

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1727,7 +1727,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
       CRM_Contact_BAO_Contact::createProfileContact($submitted, CRM_Core_DAO::$_nullArray, $mainId);
     }
 
-    CRM_Utils_Hook::post('merge', 'Contact', $mainId, CRM_Core_DAO::$_nullObject);
+    CRM_Utils_Hook::post('merge', 'Contact', $mainId);
     self::createMergeActivities($mainId, $otherId);
 
     return TRUE;

--- a/CRM/Event/Form/ManageEvent/Location.php
+++ b/CRM/Event/Form/ManageEvent/Location.php
@@ -138,7 +138,7 @@ class CRM_Event_Form_ManageEvent_Location extends CRM_Event_Form_ManageEvent {
    */
   public static function formRule($fields) {
     // check for state/country mapping
-    $errors = CRM_Contact_Form_Edit_Address::formRule($fields, CRM_Core_DAO::$_nullArray, CRM_Core_DAO::$_nullObject);
+    $errors = CRM_Contact_Form_Edit_Address::formRule($fields);
 
     return empty($errors) ? TRUE : $errors;
   }

--- a/CRM/Event/Form/Search.php
+++ b/CRM/Event/Form/Search.php
@@ -405,17 +405,13 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
     // if this search has been forced
     // then see if there are any get values, and if so over-ride the post values
     // note that this means that GET over-rides POST :)
-    $event = CRM_Utils_Request::retrieve('event', 'Positive',
-      CRM_Core_DAO::$_nullObject
-    );
+    $event = CRM_Utils_Request::retrieve('event', 'Positive');
     if ($event) {
       $this->_formValues['event_id'] = $event;
       $this->_formValues['event_name'] = CRM_Event_PseudoConstant::event($event, TRUE);
     }
 
-    $status = CRM_Utils_Request::retrieve('status', 'String',
-      CRM_Core_DAO::$_nullObject
-    );
+    $status = CRM_Utils_Request::retrieve('status', 'String');
 
     if (isset($status)) {
       if ($status === 'true') {
@@ -433,9 +429,7 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
       $this->_formValues['participant_status_id'] = is_array($statusTypes) ? array('IN' => array_keys($statusTypes)) : $statusTypes;
     }
 
-    $role = CRM_Utils_Request::retrieve('role', 'String',
-      CRM_Core_DAO::$_nullObject
-    );
+    $role = CRM_Utils_Request::retrieve('role', 'String');
 
     if (isset($role)) {
       if ($role === 'true') {
@@ -450,9 +444,7 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
       $this->_formValues['participant_role_id'] = is_array($roleTypes) ? array_keys($roleTypes) : $roleTypes;
     }
 
-    $type = CRM_Utils_Request::retrieve('type', 'Positive',
-      CRM_Core_DAO::$_nullObject
-    );
+    $type = CRM_Utils_Request::retrieve('type', 'Positive');
     if ($type) {
       $this->_formValues['event_type'] = $type;
     }

--- a/CRM/Event/Form/Search.php
+++ b/CRM/Event/Form/Search.php
@@ -96,7 +96,7 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
      * we allow the controller to set force/reset externally, useful when we are being
      * driven by the wizard framework
      */
-    $this->_reset = CRM_Utils_Request::retrieve('reset', 'Boolean', CRM_Core_DAO::$_nullObject);
+    $this->_reset = CRM_Utils_Request::retrieve('reset', 'Boolean');
     $this->_force = CRM_Utils_Request::retrieve('force', 'Boolean', $this, FALSE);
     $this->_limit = CRM_Utils_Request::retrieve('limit', 'Positive', $this);
     $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this, FALSE, 'search');

--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -1186,8 +1186,8 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
    * Handle import error file creation.
    */
   public static function invoke() {
-    $type = CRM_Utils_Request::retrieve('type', 'Positive', CRM_Core_DAO::$_nullObject);
-    $parserName = CRM_Utils_Request::retrieve('parser', 'String', CRM_Core_DAO::$_nullObject);
+    $type = CRM_Utils_Request::retrieve('type', 'Positive');
+    $parserName = CRM_Utils_Request::retrieve('parser', 'String');
     if (empty($parserName) || empty($type)) {
       return;
     }

--- a/CRM/Financial/Page/AJAX.php
+++ b/CRM/Financial/Page/AJAX.php
@@ -94,7 +94,7 @@ class CRM_Financial_Page_AJAX {
 
     if ($_GET['_value'] != 'select') {
       $financialAccountType = CRM_Financial_BAO_FinancialAccount::getfinancialAccountRelations(TRUE);
-      $financialAccountId = CRM_Utils_Request::retrieve('_value', 'Positive', CRM_Core_DAO::$_nullObject);
+      $financialAccountId = CRM_Utils_Request::retrieve('_value', 'Positive');
       $financialAccountTypeId = CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_FinancialAccount', $financialAccountId, 'financial_account_type_id');
     }
     $params['orderColumn'] = 'label';
@@ -145,7 +145,7 @@ class CRM_Financial_Page_AJAX {
     ) {
       CRM_Utils_System::civiExit();
     }
-    $productId = CRM_Utils_Request::retrieve('_value', 'Positive', CRM_Core_DAO::$_nullObject);
+    $productId = CRM_Utils_Request::retrieve('_value', 'Positive');
     $elements = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Product', $productId, 'financial_type_id');
     CRM_Utils_JSON::output($elements);
   }

--- a/CRM/Grant/Form/Search.php
+++ b/CRM/Grant/Form/Search.php
@@ -284,9 +284,7 @@ class CRM_Grant_Form_Search extends CRM_Core_Form_Search {
       return;
     }
 
-    $status = CRM_Utils_Request::retrieve('status', 'String',
-      CRM_Core_DAO::$_nullObject
-    );
+    $status = CRM_Utils_Request::retrieve('status', 'String');
     if ($status) {
       $this->_formValues['grant_status_id'] = $status;
       $this->_defaults['grant_status_id'] = $status;

--- a/CRM/Grant/Form/Search.php
+++ b/CRM/Grant/Form/Search.php
@@ -88,7 +88,7 @@ class CRM_Grant_Form_Search extends CRM_Core_Form_Search {
      * driven by the wizard framework
      */
 
-    $this->_reset = CRM_Utils_Request::retrieve('reset', 'Boolean', CRM_Core_DAO::$_nullObject);
+    $this->_reset = CRM_Utils_Request::retrieve('reset', 'Boolean');
     $this->_force = CRM_Utils_Request::retrieve('force', 'Boolean', $this, FALSE);
     $this->_limit = CRM_Utils_Request::retrieve('limit', 'Positive', $this);
     $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this, FALSE, 'search');

--- a/CRM/Grant/Page/Tab.php
+++ b/CRM/Grant/Page/Tab.php
@@ -198,10 +198,7 @@ class CRM_Grant_Page_Tab extends CRM_Contact_Page_View {
     }
     $session->pushUserContext($url);
 
-    if (CRM_Utils_Request::retrieve('confirmed', 'Boolean',
-      CRM_Core_DAO::$_nullObject
-    )
-    ) {
+    if (CRM_Utils_Request::retrieve('confirmed', 'Boolean')) {
       CRM_Grant_BAO_Grant::del($this->_id);
       CRM_Utils_System::redirect($url);
     }

--- a/CRM/Logging/ReportDetail.php
+++ b/CRM/Logging/ReportDetail.php
@@ -352,14 +352,14 @@ class CRM_Logging_ReportDetail extends CRM_Report_Form {
    * Get the properties that might be in the URL.
    */
   protected function parsePropertiesFromUrl() {
-    $this->log_conn_id = CRM_Utils_Request::retrieve('log_conn_id', 'String', CRM_Core_DAO::$_nullObject);
-    $this->log_date = CRM_Utils_Request::retrieve('log_date', 'String', CRM_Core_DAO::$_nullObject);
-    $this->cid = CRM_Utils_Request::retrieve('cid', 'Integer', CRM_Core_DAO::$_nullObject);
-    $this->raw = CRM_Utils_Request::retrieve('raw', 'Boolean', CRM_Core_DAO::$_nullObject);
+    $this->log_conn_id = CRM_Utils_Request::retrieve('log_conn_id', 'String');
+    $this->log_date = CRM_Utils_Request::retrieve('log_date', 'String');
+    $this->cid = CRM_Utils_Request::retrieve('cid', 'Integer');
+    $this->raw = CRM_Utils_Request::retrieve('raw', 'Boolean');
 
-    $this->altered_name = CRM_Utils_Request::retrieve('alteredName', 'String', CRM_Core_DAO::$_nullObject);
-    $this->altered_by = CRM_Utils_Request::retrieve('alteredBy', 'String', CRM_Core_DAO::$_nullObject);
-    $this->altered_by_id = CRM_Utils_Request::retrieve('alteredById', 'Integer', CRM_Core_DAO::$_nullObject);
+    $this->altered_name = CRM_Utils_Request::retrieve('alteredName', 'String');
+    $this->altered_by = CRM_Utils_Request::retrieve('alteredBy', 'String');
+    $this->altered_by_id = CRM_Utils_Request::retrieve('alteredById', 'Integer');
   }
 
 }

--- a/CRM/Mailing/Page/Browse.php
+++ b/CRM/Mailing/Page/Browse.php
@@ -255,15 +255,15 @@ class CRM_Mailing_Page_Browse extends CRM_Core_Page {
       CRM_Utils_System::setTitle(ts('Find Mass SMS'));
     }
 
-    $crmRowCount = CRM_Utils_Request::retrieve('crmRowCount', 'Integer', CRM_Core_DAO::$_nullObject);
-    $crmPID = CRM_Utils_Request::retrieve('crmPID', 'Integer', CRM_Core_DAO::$_nullObject);
+    $crmRowCount = CRM_Utils_Request::retrieve('crmRowCount', 'Integer');
+    $crmPID = CRM_Utils_Request::retrieve('crmPID', 'Integer');
     if ($crmRowCount || $crmPID) {
       $urlParams .= '&force=1';
       $urlParams .= $crmRowCount ? '&crmRowCount=' . $crmRowCount : '';
       $urlParams .= $crmPID ? '&crmPID=' . $crmPID : '';
     }
 
-    $crmSID = CRM_Utils_Request::retrieve('crmSID', 'Integer', CRM_Core_DAO::$_nullObject);
+    $crmSID = CRM_Utils_Request::retrieve('crmSID', 'Integer');
     if ($crmSID) {
       $urlParams .= '&crmSID=' . $crmSID;
     }

--- a/CRM/Mailing/Page/Common.php
+++ b/CRM/Mailing/Page/Common.php
@@ -42,9 +42,9 @@ class CRM_Mailing_Page_Common extends CRM_Core_Page {
    * @throws Exception
    */
   public function run() {
-    $job_id = CRM_Utils_Request::retrieve('jid', 'Integer', CRM_Core_DAO::$_nullObject);
-    $queue_id = CRM_Utils_Request::retrieve('qid', 'Integer', CRM_Core_DAO::$_nullObject);
-    $hash = CRM_Utils_Request::retrieve('h', 'String', CRM_Core_DAO::$_nullObject);
+    $job_id = CRM_Utils_Request::retrieve('jid', 'Integer');
+    $queue_id = CRM_Utils_Request::retrieve('qid', 'Integer');
+    $hash = CRM_Utils_Request::retrieve('h', 'String');
 
     if (!$job_id ||
       !$queue_id ||

--- a/CRM/Mailing/Page/Confirm.php
+++ b/CRM/Mailing/Page/Confirm.php
@@ -38,9 +38,9 @@ class CRM_Mailing_Page_Confirm extends CRM_Core_Page {
   public function run() {
     CRM_Utils_System::addHTMLHead('<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">');
 
-    $contact_id = CRM_Utils_Request::retrieve('cid', 'Integer', CRM_Core_DAO::$_nullObject);
-    $subscribe_id = CRM_Utils_Request::retrieve('sid', 'Integer', CRM_Core_DAO::$_nullObject);
-    $hash = CRM_Utils_Request::retrieve('h', 'String', CRM_Core_DAO::$_nullObject);
+    $contact_id = CRM_Utils_Request::retrieve('cid', 'Integer');
+    $subscribe_id = CRM_Utils_Request::retrieve('sid', 'Integer');
+    $hash = CRM_Utils_Request::retrieve('h', 'String');
 
     if (!$contact_id ||
       !$subscribe_id ||

--- a/CRM/Member/Form/Search.php
+++ b/CRM/Member/Form/Search.php
@@ -296,26 +296,20 @@ class CRM_Member_Form_Search extends CRM_Core_Form_Search {
       return;
     }
 
-    $status = CRM_Utils_Request::retrieve('status', 'String',
-      CRM_Core_DAO::$_nullObject
-    );
+    $status = CRM_Utils_Request::retrieve('status', 'String');
     if ($status) {
       $status = explode(',', $status);
       $this->_formValues['membership_status_id'] = $this->_defaults['membership_status_id'] = (array) $status;
     }
 
-    $membershipType = CRM_Utils_Request::retrieve('type', 'String',
-      CRM_Core_DAO::$_nullObject
-    );
+    $membershipType = CRM_Utils_Request::retrieve('type', 'String');
 
     if ($membershipType) {
       $this->_formValues['membership_type_id'] = array($membershipType);
       $this->_defaults['membership_type_id'] = array($membershipType);
     }
 
-    $cid = CRM_Utils_Request::retrieve('cid', 'Positive',
-      CRM_Core_DAO::$_nullObject
-    );
+    $cid = CRM_Utils_Request::retrieve('cid', 'Positive');
 
     if ($cid) {
       $cid = CRM_Utils_Type::escape($cid, 'Integer');
@@ -330,32 +324,24 @@ class CRM_Member_Form_Search extends CRM_Core_Form_Search {
       }
     }
 
-    $fromDate = CRM_Utils_Request::retrieve('start', 'Date',
-      CRM_Core_DAO::$_nullObject
-    );
+    $fromDate = CRM_Utils_Request::retrieve('start', 'Date');
     if ($fromDate) {
       list($date) = CRM_Utils_Date::setDateDefaults($fromDate);
       $this->_formValues['member_start_date_low'] = $this->_defaults['member_start_date_low'] = $date;
     }
 
-    $toDate = CRM_Utils_Request::retrieve('end', 'Date',
-      CRM_Core_DAO::$_nullObject
-    );
+    $toDate = CRM_Utils_Request::retrieve('end', 'Date');
     if ($toDate) {
       list($date) = CRM_Utils_Date::setDateDefaults($toDate);
       $this->_formValues['member_start_date_high'] = $this->_defaults['member_start_date_high'] = $date;
     }
-    $joinDate = CRM_Utils_Request::retrieve('join', 'Date',
-      CRM_Core_DAO::$_nullObject
-    );
+    $joinDate = CRM_Utils_Request::retrieve('join', 'Date');
     if ($joinDate) {
       list($date) = CRM_Utils_Date::setDateDefaults($joinDate);
       $this->_formValues['member_join_date_low'] = $this->_defaults['member_join_date_low'] = $date;
     }
 
-    $joinEndDate = CRM_Utils_Request::retrieve('joinEnd', 'Date',
-      CRM_Core_DAO::$_nullObject
-    );
+    $joinEndDate = CRM_Utils_Request::retrieve('joinEnd', 'Date');
     if ($joinEndDate) {
       list($date) = CRM_Utils_Date::setDateDefaults($joinEndDate);
       $this->_formValues['member_join_date_high'] = $this->_defaults['member_join_date_high'] = $date;

--- a/CRM/Member/Form/Search.php
+++ b/CRM/Member/Form/Search.php
@@ -366,7 +366,7 @@ class CRM_Member_Form_Search extends CRM_Core_Form_Search {
     );
 
     //LCD also allow restrictions to membership owner via GET
-    $owner = CRM_Utils_Request::retrieve('owner', 'String', CRM_Core_DAO::$_nullObject);
+    $owner = CRM_Utils_Request::retrieve('owner', 'String');
     if ($owner) {
       $this->_formValues['member_is_primary'] = $this->_defaults['member_is_primary'] = 2;
     }

--- a/CRM/Pledge/Form/Search.php
+++ b/CRM/Pledge/Form/Search.php
@@ -369,17 +369,13 @@ class CRM_Pledge_Form_Search extends CRM_Core_Form_Search {
       $this->_defaults['pledge_status_id'] = $statuses;
     }
 
-    $pledgeFromDate = CRM_Utils_Request::retrieve('pstart', 'Date',
-      CRM_Core_DAO::$_nullObject
-    );
+    $pledgeFromDate = CRM_Utils_Request::retrieve('pstart', 'Date');
     if ($pledgeFromDate) {
       list($date) = CRM_Utils_Date::setDateDefaults($pledgeFromDate);
       $this->_formValues['pledge_create_date_low'] = $this->_defaults['pledge_create_date_low'] = $date;
     }
 
-    $pledgeToDate = CRM_Utils_Request::retrieve('pend', 'Date',
-      CRM_Core_DAO::$_nullObject
-    );
+    $pledgeToDate = CRM_Utils_Request::retrieve('pend', 'Date');
     if ($pledgeToDate) {
       list($date) = CRM_Utils_Date::setDateDefaults($pledgeToDate);
       $this->_formValues['pledge_create_date_high'] = $this->_defaults['pledge_create_date_high'] = $date;

--- a/CRM/Pledge/Form/Search.php
+++ b/CRM/Pledge/Form/Search.php
@@ -76,7 +76,7 @@ class CRM_Pledge_Form_Search extends CRM_Core_Form_Search {
     // we allow the controller to set force/reset externally, useful when we are being
     // driven by the wizard framework
 
-    $this->_reset = CRM_Utils_Request::retrieve('reset', 'Boolean', CRM_Core_DAO::$_nullObject);
+    $this->_reset = CRM_Utils_Request::retrieve('reset', 'Boolean');
     $this->_force = CRM_Utils_Request::retrieve('force', 'Boolean', $this, FALSE);
     $this->_limit = CRM_Utils_Request::retrieve('limit', 'Positive', $this);
     $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this, FALSE, 'search');

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -538,7 +538,7 @@ class CRM_Report_Form extends CRM_Core_Form {
       CRM_Core_DAO::$_nullObject
       );
 
-    $this->_section = CRM_Utils_Request::retrieve('section', 'Integer', CRM_Core_DAO::$_nullObject);
+    $this->_section = CRM_Utils_Request::retrieve('section', 'Integer');
 
     $this->assign('section', $this->_section);
     CRM_Core_Region::instance('page-header')->add(array(
@@ -3329,7 +3329,7 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
     if ($this->addPaging) {
       $this->_select = str_ireplace('SELECT ', 'SELECT SQL_CALC_FOUND_ROWS ', $this->_select);
 
-      $pageId = CRM_Utils_Request::retrieve('crmPID', 'Integer', CRM_Core_DAO::$_nullObject);
+      $pageId = CRM_Utils_Request::retrieve('crmPID', 'Integer');
 
       // @todo all http vars should be extracted in the preProcess
       // - not randomly in the class

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -524,19 +524,9 @@ class CRM_Report_Form extends CRM_Core_Form {
    * @throws \Exception
    */
   public function preProcessCommon() {
-    $this->_force
-      = CRM_Utils_Request::retrieve(
-      'force',
-      'Boolean',
-      CRM_Core_DAO::$_nullObject
-      );
+    $this->_force = CRM_Utils_Request::retrieve('force', 'Boolean');
 
-    $this->_dashBoardRowCount
-      = CRM_Utils_Request::retrieve(
-      'rowCount',
-      'Integer',
-      CRM_Core_DAO::$_nullObject
-      );
+    $this->_dashBoardRowCount = CRM_Utils_Request::retrieve('rowCount', 'Integer');
 
     $this->_section = CRM_Utils_Request::retrieve('section', 'Integer');
 

--- a/CRM/Report/Form/Activity.php
+++ b/CRM/Report/Form/Activity.php
@@ -60,7 +60,7 @@ class CRM_Report_Form_Activity extends CRM_Report_Form {
     // Lets hide it for now.
     $this->_exposeContactID = FALSE;
     // if navigated from count link of activity summary reports.
-    $this->_resetDateFilter = CRM_Utils_Request::retrieve('resetDateFilter', 'Boolean', CRM_Core_DAO::$_nullObject);
+    $this->_resetDateFilter = CRM_Utils_Request::retrieve('resetDateFilter', 'Boolean');
 
     $config = CRM_Core_Config::singleton();
     $campaignEnabled = in_array("CiviCampaign", $config->enableComponents);

--- a/CRM/Report/Form/Contribute/TopDonor.php
+++ b/CRM/Report/Form/Contribute/TopDonor.php
@@ -464,7 +464,7 @@ ORDER BY civicrm_contribution_total_amount_sum DESC
     if ($this->_outputMode == 'html' || $this->_outputMode == 'group') {
       // Replace only first occurrence of SELECT.
       $this->_select = preg_replace('/SELECT/', 'SELECT SQL_CALC_FOUND_ROWS ', $this->_select, 1);
-      $pageId = CRM_Utils_Request::retrieve('crmPID', 'Integer', CRM_Core_DAO::$_nullObject);
+      $pageId = CRM_Utils_Request::retrieve('crmPID', 'Integer');
 
       if (!$pageId && !empty($_POST) && isset($_POST['crmPID_B'])) {
         if (!isset($_POST['PagerBottomButton'])) {

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -317,7 +317,7 @@ abstract class CRM_Utils_Hook {
    *   based on op. pre-hooks return a boolean or
    *                           an error message which aborts the operation
    */
-  public static function post($op, $objectName, $objectId, &$objectRef) {
+  public static function post($op, $objectName, $objectId, &$objectRef = NULL) {
     $event = new \Civi\Core\Event\PostEvent($op, $objectName, $objectId, $objectRef);
     \Civi::service('dispatcher')->dispatch("hook_civicrm_post", $event);
     \Civi::service('dispatcher')->dispatch("hook_civicrm_post::$objectName", $event);

--- a/CRM/Utils/Weight.php
+++ b/CRM/Utils/Weight.php
@@ -434,7 +434,7 @@ class CRM_Utils_Weight {
   }
 
   public static function fixOrder() {
-    $signature = CRM_Utils_Request::retrieve('_sgn', 'String', CRM_Core_DAO::$_nullObject);
+    $signature = CRM_Utils_Request::retrieve('_sgn', 'String');
     $signer = new CRM_Utils_Signer(CRM_Core_Key::privateKey(), self::$SIGNABLE_FIELDS);
 
     // Validate $_GET values b/c subsequent code reads $_GET (via CRM_Utils_Request::retrieve)
@@ -443,14 +443,14 @@ class CRM_Utils_Weight {
     }
 
     // Note: Ensure this list matches self::$SIGNABLE_FIELDS
-    $daoName = CRM_Utils_Request::retrieve('dao', 'String', CRM_Core_DAO::$_nullObject);
-    $id = CRM_Utils_Request::retrieve('id', 'Integer', CRM_Core_DAO::$_nullObject);
-    $idName = CRM_Utils_Request::retrieve('idName', 'String', CRM_Core_DAO::$_nullObject);
-    $url = CRM_Utils_Request::retrieve('url', 'String', CRM_Core_DAO::$_nullObject);
-    $filter = CRM_Utils_Request::retrieve('filter', 'String', CRM_Core_DAO::$_nullObject);
-    $src = CRM_Utils_Request::retrieve('src', 'Integer', CRM_Core_DAO::$_nullObject);
-    $dst = CRM_Utils_Request::retrieve('dst', 'Integer', CRM_Core_DAO::$_nullObject);
-    $dir = CRM_Utils_Request::retrieve('dir', 'String', CRM_Core_DAO::$_nullObject);
+    $daoName = CRM_Utils_Request::retrieve('dao', 'String');
+    $id = CRM_Utils_Request::retrieve('id', 'Integer');
+    $idName = CRM_Utils_Request::retrieve('idName', 'String');
+    $url = CRM_Utils_Request::retrieve('url', 'String');
+    $filter = CRM_Utils_Request::retrieve('filter', 'String');
+    $src = CRM_Utils_Request::retrieve('src', 'Integer');
+    $dst = CRM_Utils_Request::retrieve('dst', 'Integer');
+    $dir = CRM_Utils_Request::retrieve('dir', 'String');
     $object = new $daoName();
     $srcWeight = CRM_Core_DAO::getFieldValue($daoName, $src, 'weight', $idName);
     $dstWeight = CRM_Core_DAO::getFieldValue($daoName, $dst, 'weight', $idName);

--- a/api/v3/Generic/Setvalue.php
+++ b/api/v3/Generic/Setvalue.php
@@ -143,7 +143,7 @@ function civicrm_api3_generic_setValue($apiRequest) {
       $params[$field] = '';
     }
     CRM_Core_BAO_CustomValueTable::setValues($params);
-    CRM_Utils_Hook::post('edit', $entity, $id, CRM_Core_DAO::$_nullObject);
+    CRM_Utils_Hook::post('edit', $entity, $id);
   }
   // Core fields
   elseif (CRM_Core_DAO::setFieldValue($dao_name, $id, $field, $params[$field])) {

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -1531,7 +1531,7 @@ function _civicrm_api3_custom_data_get(&$returnArray, $checkPermission, $entity,
     TRUE,
     $checkPermission
   );
-  $groupTree = CRM_Core_BAO_CustomGroup::formatGroupTree($groupTree, 1, CRM_Core_DAO::$_nullObject);
+  $groupTree = CRM_Core_BAO_CustomGroup::formatGroupTree($groupTree, 1);
   $customValues = array();
   CRM_Core_BAO_CustomGroup::setDefaults($groupTree, $customValues);
   $fieldInfo = array();

--- a/extern/widget.php
+++ b/extern/widget.php
@@ -38,10 +38,10 @@ $config = CRM_Core_Config::singleton();
 $template = CRM_Core_Smarty::singleton();
 
 require_once 'CRM/Utils/Request.php';
-$cpageId = CRM_Utils_Request::retrieve('cpageId', 'Positive', CRM_Core_DAO::$_nullObject);
-$widgetId = CRM_Utils_Request::retrieve('widgetId', 'Positive', CRM_Core_DAO::$_nullObject);
-$format = CRM_Utils_Request::retrieve('format', 'Positive', CRM_Core_DAO::$_nullObject);
-$includePending = CRM_Utils_Request::retrieve('includePending', 'Boolean', CRM_Core_DAO::$_nullObject);
+$cpageId = CRM_Utils_Request::retrieve('cpageId', 'Positive');
+$widgetId = CRM_Utils_Request::retrieve('widgetId', 'Positive');
+$format = CRM_Utils_Request::retrieve('format', 'Positive');
+$includePending = CRM_Utils_Request::retrieve('includePending', 'Boolean');
 
 require_once 'CRM/Contribute/BAO/Widget.php';
 

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
@@ -90,7 +90,7 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
    */
   public function testCancelRecur() {
     $contributionRecur = $this->callAPISuccess('contribution_recur', 'create', $this->_params);
-    CRM_Contribute_BAO_ContributionRecur::cancelRecurContribution($contributionRecur['id'], CRM_Core_DAO::$_nullObject);
+    CRM_Contribute_BAO_ContributionRecur::cancelRecurContribution($contributionRecur['id'], NULL);
   }
 
   /**

--- a/tests/phpunit/CRM/Contribute/Form/Task/InvoiceTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Task/InvoiceTest.php
@@ -57,8 +57,6 @@ class CRM_Contribute_Form_Task_InvoiceTest extends CiviUnitTestCase {
       'forPage' => 1,
     );
 
-    $form = new CRM_Contribute_Form_Task_Invoice();
-
     $this->_individualId = $this->individualCreate();
     $contributionParams = array(
       'contact_id' => $this->_individualId,
@@ -78,7 +76,7 @@ class CRM_Contribute_Form_Task_InvoiceTest extends CiviUnitTestCase {
 
     $contactIds[] = $this->_individualId;
     foreach ($contributionIDs as $contributionID) {
-      $invoiceHTML[current($contributionID)] = CRM_Contribute_Form_Task_Invoice::printPDF($contributionID, $params, $contactIds, $form);
+      $invoiceHTML[current($contributionID)] = CRM_Contribute_Form_Task_Invoice::printPDF($contributionID, $params, $contactIds);
     }
 
     $this->assertNotContains('Due Date', $invoiceHTML[$result['id']]);


### PR DESCRIPTION
* [CRM-17335: Stop passing CRM_Core_DAO::$_nullArray  pointlessly](https://issues.civicrm.org/jira/browse/CRM-17335)