### PR TITLE
Set a value for iDisplayLength

### DIFF
--- a/templates/CRM/common/jsortable.tpl
+++ b/templates/CRM/common/jsortable.tpl
@@ -118,6 +118,7 @@
       var oTable;
       if ( useAjax ) {
         oTable = $(tabId).dataTable({
+          "iDisplayLength": 25,
           "bFilter": false,
           "bAutoWidth": false,
           "aaSorting": sortColumn,


### PR DESCRIPTION
The default (if none is set) turns out to be 10. Eileen said (and I quote): "if you wanted to propose an increase in core to 25 that would be an easy sell I think" :-)