### PR TITLE
CRM-19394: Fix relative dates in “smart groups”.

### DIFF
--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -117,7 +117,17 @@ class CRM_Contact_BAO_SavedSearch extends CRM_Contact_DAO_SavedSearch {
           $entityName = strstr($id, '_date', TRUE);
           if (!empty($result['relative_dates']) && array_key_exists($entityName, $result['relative_dates'])) {
             $result[$id] = NULL;
-            $result["{$entityName}_date_relative"] = $result['relative_dates'][$entityName];
+
+            /*
+             * CRM-19625: we need to “push” the `_date_relative` entry
+             * before the `_date_low` and `_date_high` so the
+             * `CRM_Contact_BAO_Query::fixDateValues()` could fill
+             * them correctly.
+             *
+             * Here the `_date_relative` is push at the very top of
+             * the `$result` array.
+             */
+            $result = array("{$entityName}_date_relative" => $result['relative_dates'][$entityName]) + $result;
           }
           else {
             $result[$id] = $value;


### PR DESCRIPTION
When using a relative date, `member_join_date_relative` should be converted into two a `_high` and a `_low` variables. But this operation didn’t work correctly and only the `_high` value was kept in the final SQL query.

The problem comes from `CRM_Contact_BAO_Query::convertFormValues()`, when `CRM_Contact_BAO_Query::fixDateValues()` is called and to update the content of `$formValues`. But since the main “foreach” loop in `CRM_Contact_BAO_Query::convertFormValues()` already iterated over the `_low` value (which was empty), this value will be missed.

The fix is to change `CRM_Contact_BAO_SavedSearch::getFormValues()` and to push the `_relative_date` at the top of the array that will be treated by `CRM_Contact_BAO_Query::convertFormValues()`.

(More information is available in CRM-19625).
