### PR TITLE
CRM-19431: avoid pollution (in EntityTag) and use (in ContactType) of CRM_Core_DAO::$_nullArray. - 4.6

### DIFF
--- a/CRM/Contact/BAO/ContactType.php
+++ b/CRM/Contact/BAO/ContactType.php
@@ -95,8 +95,9 @@ WHERE  parent_id IS NULL
           $sql .= " AND is_active = 1";
         }
 
+        $params = array();
         $dao = CRM_Core_DAO::executeQuery($sql,
-          CRM_Core_DAO::$_nullArray,
+          $params,
           FALSE,
           'CRM_Contact_DAO_ContactType'
         );

--- a/CRM/Core/BAO/EntityTag.php
+++ b/CRM/Core/BAO/EntityTag.php
@@ -412,7 +412,8 @@ class CRM_Core_BAO_EntityTag extends CRM_Core_DAO_EntityTag {
       // Output tag list as nested hierarchy
       // TODO: This will only work when api.entity is "entity_tag". What about others?
       if ($context == 'search' || $context == 'create') {
-        return CRM_Core_BAO_Tag::getTags(CRM_Utils_Array::value('entity_table', $props, 'civicrm_contact'), CRM_Core_DAO::$_nullArray, CRM_Utils_Array::value('parent_id', $params), '- ');
+        $dummyArray = array();
+        return CRM_Core_BAO_Tag::getTags(CRM_Utils_Array::value('entity_table', $props, 'civicrm_contact'), $dummyArray, CRM_Utils_Array::value('parent_id', $params), '- ');
       }
     }
 


### PR DESCRIPTION
4.6 version of #9376.

---

 * [CRM-19431: The empty array that it's not really empty](https://issues.civicrm.org/jira/browse/CRM-19431)