### PR TITLE
CRM-19656 - Ensure user updates to subscription info succeed

### DIFF
--- a/CRM/Contribute/Form/UpdateBilling.php
+++ b/CRM/Contribute/Form/UpdateBilling.php
@@ -50,8 +50,6 @@ class CRM_Contribute_Form_UpdateBilling extends CRM_Core_Form {
    */
   public $_paymentProcessor = array();
 
-  public $_paymentProcessorObj = NULL;
-
   /**
    * Set variables up before form is built.
    */
@@ -60,7 +58,7 @@ class CRM_Contribute_Form_UpdateBilling extends CRM_Core_Form {
     $this->_crid = CRM_Utils_Request::retrieve('crid', 'Integer', $this, FALSE);
     if ($this->_crid) {
       $this->_paymentProcessor = CRM_Financial_BAO_PaymentProcessor::getProcessorForEntity($this->_crid, 'recur', 'info');
-      $this->_paymentProcessorObj = CRM_Financial_BAO_PaymentProcessor::getProcessorForEntity($this->_crid, 'recur', 'obj');
+      $this->_paymentProcessor['object'] = CRM_Financial_BAO_PaymentProcessor::getProcessorForEntity($this->_crid, 'recur', 'obj');
       $this->_subscriptionDetails = CRM_Contribute_BAO_ContributionRecur::getSubscriptionDetails($this->_crid);
 
       // Are we cancelling a recurring contribution that is linked to an auto-renew membership?
@@ -244,9 +242,7 @@ class CRM_Contribute_Form_UpdateBilling extends CRM_Core_Form {
     $processorParams['year'] = $processorParams['credit_card_exp_date']['Y'];
     $processorParams['subscriptionId'] = $this->_subscriptionDetails->subscription_id;
     $processorParams['amount'] = $this->_subscriptionDetails->amount;
-
-    $updateSubscription = $this->_paymentProcessorObj->updateSubscriptionBillingInfo($message, $processorParams);
-
+    $updateSubscription = $this->_paymentProcessor['object']->updateSubscriptionBillingInfo($message, $processorParams);
     if (is_a($updateSubscription, 'CRM_Core_Error')) {
       CRM_Core_Error::displaySessionError($updateSubscription);
     }


### PR DESCRIPTION
Remove redundant variable and consistently use
_paymentProcessor['object']

---

 * [CRM-19656: link for users to update their subscription billing info generates error](https://issues.civicrm.org/jira/browse/CRM-19656)