### PR TITLE
CRM-19668 display subtype icon in relationship listing when valid

### DIFF
--- a/CRM/Contact/BAO/Contact/Utils.php
+++ b/CRM/Contact/BAO/Contact/Utils.php
@@ -49,7 +49,7 @@ class CRM_Contact_BAO_Contact_Utils {
   public static function getImage($contactType, $urlOnly = FALSE, $contactId = NULL, $addProfileOverlay = TRUE) {
     static $imageInfo = array();
 
-    $contactType = explode(CRM_Core_DAO::VALUE_SEPARATOR, trim($contactType, CRM_Core_DAO::VALUE_SEPARATOR));
+    $contactType = CRM_Utils_Array::explodePadded($contactType);
     $contactType = $contactType[0];
 
     if (!array_key_exists($contactType, $imageInfo)) {

--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -1111,6 +1111,7 @@ WHERE  relationship_type_id = " . CRM_Utils_Type::escape($type, 'Integer');
                               civicrm_country.name as country,
                               civicrm_email.email as email,
                               civicrm_contact.contact_type as contact_type,
+                              civicrm_contact.contact_sub_type as contact_sub_type,
                               civicrm_phone.phone as phone,
                               civicrm_contact.id as civicrm_contact_id,
                               civicrm_relationship.contact_id_b as contact_id_b,
@@ -1334,6 +1335,7 @@ LEFT JOIN  civicrm_country ON (civicrm_address.country_id = civicrm_country.id)
         $values[$rid]['contact_id_a'] = $relationship->contact_id_a;
         $values[$rid]['contact_id_b'] = $relationship->contact_id_b;
         $values[$rid]['contact_type'] = $relationship->contact_type;
+        $values[$rid]['contact_sub_type'] = $relationship->contact_sub_type;
         $values[$rid]['relationship_type_id'] = $relationship->civicrm_relationship_type_id;
         $values[$rid]['relation'] = $relationship->relation;
         $values[$rid]['name'] = $relationship->sort_name;
@@ -2090,8 +2092,9 @@ AND cc.sort_name LIKE '%$name%'";
         $relationship['DT_RowAttr']['data-entity'] = 'relationship';
         $relationship['DT_RowAttr']['data-id'] = $values['id'];
 
-        //Add image icon for related contacts: CRM-14919
-        $icon = CRM_Contact_BAO_Contact_Utils::getImage($values['contact_type'],
+        //Add image icon for related contacts: CRM-14919; CRM-19668
+        $contactType = (!empty($values['contact_sub_type'])) ? $values['contact_sub_type'] : $values['contact_type'];
+        $icon = CRM_Contact_BAO_Contact_Utils::getImage($contactType,
           FALSE,
           $values['cid']
         );


### PR DESCRIPTION
* [CRM-19668: contact relationship list doesn't display correct icon for subtypes](https://issues.civicrm.org/jira/browse/CRM-19668)