### PR TITLE
CRM-16243 Dependency management for extensions

### DIFF
--- a/CRM/Admin/Form/Extensions.php
+++ b/CRM/Admin/Form/Extensions.php
@@ -42,6 +42,13 @@ class CRM_Admin_Form_Extensions extends CRM_Admin_Form {
   public function preProcess() {
     parent::preProcess();
 
+    $mainPage = new CRM_Admin_Page_Extensions();
+    $localExtensionRows = $mainPage->formatLocalExtensionRows();
+    $this->assign('localExtensionRows', $localExtensionRows);
+
+    $remoteExtensionRows = $mainPage->formatRemoteExtensionRows($localExtensionRows);
+    $this->assign('remoteExtensionRows', $remoteExtensionRows);
+
     $this->_key = CRM_Utils_Request::retrieve('key', 'String',
       $this, FALSE, 0
     );

--- a/CRM/Admin/Form/Extensions.php
+++ b/CRM/Admin/Form/Extensions.php
@@ -178,12 +178,12 @@ class CRM_Admin_Form_Extensions extends CRM_Admin_Form {
     }
 
     if ($this->_action & CRM_Core_Action::ADD) {
-      CRM_Extension_System::singleton()->getManager()->install(array($this->_key));
+      civicrm_api3('Extension', 'install', array('keys' => $this->_key));
       CRM_Core_Session::setStatus("", ts('Extension Installed'), "success");
     }
 
     if ($this->_action & CRM_Core_Action::ENABLE) {
-      CRM_Extension_System::singleton()->getManager()->enable(array($this->_key));
+      civicrm_api3('Extension', 'enable', array('keys' => $this->_key));
       CRM_Core_Session::setStatus("", ts('Extension Enabled'), "success");
     }
 

--- a/CRM/Admin/Page/Extensions.php
+++ b/CRM/Admin/Page/Extensions.php
@@ -255,8 +255,10 @@ class CRM_Admin_Page_Extensions extends CRM_Core_Page_Basic {
         $row['id']
       );
       if (isset($localExtensionRows[$info->key])) {
-        if (version_compare($localExtensionRows[$info->key]['version'], $info->version, '<')) {
-          $row['is_upgradeable'] = TRUE;
+        if (array_key_exists('version', $localExtensionRows[$info->key])) {
+          if (version_compare($localExtensionRows[$info->key]['version'], $info->version, '<')) {
+            $row['is_upgradeable'] = TRUE;
+          }
         }
       }
       $remoteExtensionRows[$row['id']] = $row;

--- a/CRM/Admin/Page/Extensions.php
+++ b/CRM/Admin/Page/Extensions.php
@@ -125,8 +125,6 @@ class CRM_Admin_Page_Extensions extends CRM_Core_Page_Basic {
    * Browse all options.
    */
   public function browse() {
-    $mapper = CRM_Extension_System::singleton()->getMapper();
-    $manager = CRM_Extension_System::singleton()->getManager();
 
     // build announcements at the top of the page
     $this->assign('extAddNewEnabled', CRM_Extension_System::singleton()->getBrowser()->isEnabled());
@@ -145,7 +143,23 @@ class CRM_Admin_Page_Extensions extends CRM_Core_Page_Basic {
     // TODO: Debate whether to immediately detect changes in underlying source tree
     // $manager->refresh();
 
-    // build list of local extensions
+    $localExtensionRows = $this->formatLocalExtensionRows();
+    $this->assign('localExtensionRows', $localExtensionRows);
+
+    $remoteExtensionRows = $this->formatRemoteExtensionRows($localExtensionRows);
+    $this->assign('remoteExtensionRows', $remoteExtensionRows);
+  }
+
+  /**
+   * Get the list of local extensions and format them as a table with
+   * status and action data.
+   *
+   * @return array
+   */
+  public function formatLocalExtensionRows() {
+    $mapper = CRM_Extension_System::singleton()->getMapper();
+    $manager = CRM_Extension_System::singleton()->getManager();
+
     $localExtensionRows = array(); // array($pseudo_id => extended_CRM_Extension_Info)
     $keys = array_keys($manager->getStatuses());
     sort($keys);
@@ -203,8 +217,17 @@ class CRM_Admin_Page_Extensions extends CRM_Core_Page_Basic {
 
       $localExtensionRows[$row['id']] = $row;
     }
-    $this->assign('localExtensionRows', $localExtensionRows);
+    return $localExtensionRows;
+  }
 
+  /**
+   * Get the list of local extensions and format them as a table with
+   * status and action data.
+   *
+   * @param array $localExtensionRows
+   * @return array
+   */
+  public function formatRemoteExtensionRows($localExtensionRows) {
     try {
       $remoteExtensions = CRM_Extension_System::singleton()->getBrowser()->getExtensions();
     }
@@ -238,7 +261,8 @@ class CRM_Admin_Page_Extensions extends CRM_Core_Page_Basic {
       }
       $remoteExtensionRows[$row['id']] = $row;
     }
-    $this->assign('remoteExtensionRows', $remoteExtensionRows);
+
+    return $remoteExtensionRows;
   }
 
   /**

--- a/CRM/Extension/Manager.php
+++ b/CRM/Extension/Manager.php
@@ -614,7 +614,7 @@ class CRM_Extension_Manager {
       }
       elseif ($info && $info->requires) {
         $sorter->add($key, $info->requires);
-        $todoKeys = array_merge($todoKeys, $info->requires);
+        $todoKeys = array_merge($todoKeys, array($info->requires));
       }
       else {
         $sorter->add($key, array());

--- a/CRM/Extension/Manager.php
+++ b/CRM/Extension/Manager.php
@@ -610,7 +610,7 @@ class CRM_Extension_Manager {
       $info = @$infos[$key];
 
       if ($this->getStatus($key) === self::STATUS_INSTALLED) {
-        // skip
+        $sorter->add($key, $info->requires);
       }
       elseif ($info && $info->requires) {
         $sorter->add($key, $info->requires);

--- a/CRM/Extension/Manager.php
+++ b/CRM/Extension/Manager.php
@@ -222,6 +222,11 @@ class CRM_Extension_Manager {
           $typeManager->onPreEnable($info);
           $this->_setExtensionActive($info, 1);
           $typeManager->onPostEnable($info);
+
+          // A full refresh would be preferrable but very slow. This at least allows
+          // later extensions to access classes from earlier extensions.
+          $this->statuses = NULL;
+          $this->mapper->refresh();
           break;
 
         case self::STATUS_UNINSTALLED:
@@ -229,6 +234,11 @@ class CRM_Extension_Manager {
           $typeManager->onPreInstall($info);
           $this->_createExtensionEntry($info);
           $typeManager->onPostInstall($info);
+
+          // A full refresh would be preferrable but very slow. This at least allows
+          // later extensions to access classes from earlier extensions.
+          $this->statuses = NULL;
+          $this->mapper->refresh();
           break;
 
         case self::STATUS_UNKNOWN:

--- a/CRM/Extension/Manager.php
+++ b/CRM/Extension/Manager.php
@@ -292,6 +292,13 @@ class CRM_Extension_Manager {
     // TODO: to mitigate the risk of crashing during installation, scan
     // keys/statuses/types before doing anything
 
+    sort($keys);
+    $disableRequirements = $this->findDisableRequirements($keys);
+    sort($disableRequirements); // This munges order, but makes it comparable.
+    if ($keys !== $disableRequirements) {
+      throw new CRM_Extension_Exception_DependencyException("Cannot disable extension due dependencies. Consider disabling all these: " . implode(',', $disableRequirements));
+    }
+
     foreach ($keys as $key) {
       switch ($origStatuses[$key]) {
         case self::STATUS_INSTALLED:
@@ -566,6 +573,98 @@ class CRM_Extension_Manager {
     else {
       return NULL;
     }
+  }
+
+  /**
+   * Build a list of extensions to install, in an order that will satisfy dependencies.
+   *
+   * @param array $keys
+   *   List of extensions to install.
+   * @return array
+   *   List of extension keys, including dependencies, in order of installation.
+   */
+  public function findInstallRequirements($keys) {
+    $infos = $this->mapper->getAllInfos();
+    $todoKeys = array_unique($keys); // array(string $key).
+    $doneKeys = array(); // array(string $key => 1);
+    $sorter = new \MJS\TopSort\Implementations\FixedArraySort();
+
+    while (!empty($todoKeys)) {
+      $key = array_shift($todoKeys);
+      if (isset($doneKeys[$key])) {
+        continue;
+      }
+      $doneKeys[$key] = 1;
+
+      /** @var CRM_Extension_Info $info */
+      $info = @$infos[$key];
+
+      if ($this->getStatus($key) === self::STATUS_INSTALLED) {
+        // skip
+      }
+      elseif ($info && $info->requires) {
+        $sorter->add($key, $info->requires);
+        $todoKeys = array_merge($todoKeys, $info->requires);
+      }
+      else {
+        $sorter->add($key, array());
+      }
+    }
+    return $sorter->sort();
+  }
+
+  /**
+   * Build a list of extensions to remove, in an order that will satisfy dependencies.
+   *
+   * @param array $keys
+   *   List of extensions to install.
+   * @return array
+   *   List of extension keys, including dependencies, in order of removal.
+   */
+  public function findDisableRequirements($keys) {
+    $INSTALLED = array(
+      self::STATUS_INSTALLED,
+      self::STATUS_INSTALLED_MISSING,
+    );
+    $installedInfos = $this->filterInfosByStatus($this->mapper->getAllInfos(), $INSTALLED);
+    $revMap = CRM_Extension_Info::buildReverseMap($installedInfos);
+    $todoKeys = array_unique($keys);
+    $doneKeys = array();
+    $sorter = new \MJS\TopSort\Implementations\FixedArraySort();
+
+    while (!empty($todoKeys)) {
+      $key = array_shift($todoKeys);
+      if (isset($doneKeys[$key])) {
+        continue;
+      }
+      $doneKeys[$key] = 1;
+
+      if (isset($revMap[$key])) {
+        $requiredBys = CRM_Utils_Array::collect('key',
+          $this->filterInfosByStatus($revMap[$key], $INSTALLED));
+        $sorter->add($key, $requiredBys);
+        $todoKeys = array_merge($todoKeys, $requiredBys);
+      }
+      else {
+        $sorter->add($key, array());
+      }
+    }
+    return $sorter->sort();
+  }
+
+  /**
+   * @param $infos
+   * @param $filterStatuses
+   * @return array
+   */
+  protected function filterInfosByStatus($infos, $filterStatuses) {
+    $matches = array();
+    foreach ($infos as $k => $v) {
+      if (in_array($this->getStatus($v->key), $filterStatuses)) {
+        $matches[$k] = $v;
+      }
+    }
+    return $matches;
   }
 
 }

--- a/CRM/Extension/Mapper.php
+++ b/CRM/Extension/Mapper.php
@@ -341,6 +341,41 @@ class CRM_Extension_Mapper {
   }
 
   /**
+   * Get a list of extension keys, filtered by the corresponding file path.
+   *
+   * @param string $pattern
+   *   A file path. To search subdirectories, append "*".
+   *   Ex: "/var/www/extensions/*"
+   *   Ex: "/var/www/extensions/org.foo.bar"
+   * @return array
+   *   Array(string $key).
+   *   Ex: array("org.foo.bar").
+   */
+  public function getKeysByPath($pattern) {
+    $keys = array();
+
+    if (CRM_Utils_String::endsWith($pattern, '*')) {
+      $prefix = rtrim($pattern, '*');
+      foreach ($this->container->getKeys() as $key) {
+        $path = CRM_Utils_File::addTrailingSlash($this->container->getPath($key));
+        if (realpath($prefix) == realpath($path) || CRM_Utils_File::isChildPath($prefix, $path)) {
+          $keys[] = $key;
+        }
+      }
+    }
+    else {
+      foreach ($this->container->getKeys() as $key) {
+        $path = CRM_Utils_File::addTrailingSlash($this->container->getPath($key));
+        if (realpath($pattern) == realpath($path)) {
+          $keys[] = $key;
+        }
+      }
+    }
+
+    return $keys;
+  }
+
+  /**
    * @return array
    *   Ex: $result['org.civicrm.foobar'] = new CRM_Extension_Info(...).
    * @throws \CRM_Extension_Exception

--- a/CRM/Extension/Mapper.php
+++ b/CRM/Extension/Mapper.php
@@ -341,6 +341,19 @@ class CRM_Extension_Mapper {
   }
 
   /**
+   * @return array
+   *   Ex: $result['org.civicrm.foobar'] = new CRM_Extension_Info(...).
+   * @throws \CRM_Extension_Exception
+   * @throws \Exception
+   */
+  public function getAllInfos() {
+    foreach ($this->container->getKeys() as $key) {
+      $this->keyToInfo($key);
+    }
+    return $this->infos;
+  }
+
+  /**
    * @param string $name
    *
    * @return bool

--- a/api/v3/Extension.php
+++ b/api/v3/Extension.php
@@ -53,7 +53,8 @@ function civicrm_api3_extension_install($params) {
   }
 
   try {
-    CRM_Extension_System::singleton()->getManager()->install($keys);
+    $manager = CRM_Extension_System::singleton()->getManager();
+    $manager->install($manager->findInstallRequirements($keys));
   }
   catch (CRM_Extension_Exception $e) {
     return civicrm_api3_create_error($e->getMessage());
@@ -124,7 +125,8 @@ function civicrm_api3_extension_enable($params) {
     return civicrm_api3_create_success();
   }
 
-  CRM_Extension_System::singleton()->getManager()->enable($keys);
+  $manager = CRM_Extension_System::singleton()->getManager();
+  $manager->enable($manager->findInstallRequirements($keys));
   return civicrm_api3_create_success();
 }
 

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     "civicrm/civicrm-cxn-rpc": "~0.15.12.04",
     "zetacomponents/base": "1.7.*",
     "zetacomponents/mail": "dev-1.7-civi",
+    "marcj/topsort": "dev-1.0-php53",
     "phpoffice/phpword": "^0.13.0",
     "pear/Validate_Finance_CreditCard": "dev-master"
   },
@@ -28,6 +29,10 @@
     {
       "type": "git",
       "url": "https://github.com/civicrm/zetacomponents-mail.git"
+    },
+    {
+      "type": "git",
+      "url": "https://github.com/totten/topsort.php.git"
     }
   ],
   "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "189ae04cf5b1ca1ee00d56a629a273c3",
-    "content-hash": "c2aba74bbb5b474831736b3e3bcbcb20",
+    "hash": "eb62072cf1f9ecf0cf4c6ff177e39c25",
+    "content-hash": "674fa02010c992f3299495324b4f0a99",
     "packages": [
         {
             "name": "civicrm/civicrm-cxn-rpc",
@@ -107,6 +107,46 @@
             "description": "DOMPDF is a CSS 2.1 compliant HTML to PDF converter",
             "homepage": "https://github.com/dompdf/dompdf",
             "time": "2016-05-11 00:36:29"
+        },
+        {
+            "name": "marcj/topsort",
+            "version": "dev-1.0-php53",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/totten/topsort.php.git",
+                "reference": "2765723d36f0e536d987e42cbc60de52209212bd"
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "codeclimate/php-test-reporter": "dev-master",
+                "phpunit/phpunit": "~4.0",
+                "symfony/console": "~2.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "MJS\\TopSort\\": "src/",
+                    "MJS\\TopSort\\Tests\\": "tests/Tests/"
+                }
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marc J. Schmidt",
+                    "email": "marc@marcjschmidt.de"
+                }
+            ],
+            "description": "High-Performance TopSort/Dependency resolving algorithm",
+            "keywords": [
+                "dependency resolving",
+                "topological sort",
+                "topsort"
+            ],
+            "time": "2016-03-25 21:38:05"
         },
         {
             "name": "pclzip/pclzip",
@@ -610,12 +650,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "d93bb29acfa5cff771cb4aa0fb4a97454ddb41e4"
+                "reference": "c7309e33b719433d5cf3845d0b5b9608609d8c8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/d93bb29acfa5cff771cb4aa0fb4a97454ddb41e4",
-                "reference": "d93bb29acfa5cff771cb4aa0fb4a97454ddb41e4",
+                "url": "https://api.github.com/repos/symfony/config/zipball/c7309e33b719433d5cf3845d0b5b9608609d8c8e",
+                "reference": "c7309e33b719433d5cf3845d0b5b9608609d8c8e",
                 "shasum": ""
             },
             "require": {
@@ -1299,6 +1339,7 @@
     "minimum-stability": "stable",
     "stability-flags": {
         "zetacomponents/mail": 20,
+        "marcj/topsort": 20,
         "pear/validate_finance_creditcard": 20
     },
     "prefer-stable": false,

--- a/templates/CRM/Admin/Page/ExtensionDetails.tpl
+++ b/templates/CRM/Admin/Page/ExtensionDetails.tpl
@@ -40,8 +40,9 @@
                 {elseif array_key_exists($ext, $remoteExtensionRows)}
                     {$remoteExtensionRows.$ext.name} (not downloaded)
                 {else}
-                    {$ext} (not installed locally or available remotely)
+                    {ts}Untitled{/ts}
                 {/if}
+                (<tt>{$ext}</tt>)<br/>
             {/foreach}
         </td>
     </tr>

--- a/templates/CRM/Admin/Page/ExtensionDetails.tpl
+++ b/templates/CRM/Admin/Page/ExtensionDetails.tpl
@@ -36,13 +36,13 @@
         <td>
             {foreach from=$extension.requires item=ext}
                 {if array_key_exists($ext, $localExtensionRows)}
-                    {$localExtensionRows.$ext.name}
+                    {$localExtensionRows.$ext.name} (already downloaded - {$ext})
                 {elseif array_key_exists($ext, $remoteExtensionRows)}
-                    {$remoteExtensionRows.$ext.name} (not downloaded)
+                    {$remoteExtensionRows.$ext.name} (not downloaded - {$ext})
                 {else}
-                    {ts}Untitled{/ts}
+                    {$ext} {ts}(not available){/ts}
                 {/if}
-                (<tt>{$ext}</tt>)<br/>
+                <br/>
             {/foreach}
         </td>
     </tr>

--- a/templates/CRM/Admin/Page/ExtensionDetails.tpl
+++ b/templates/CRM/Admin/Page/ExtensionDetails.tpl
@@ -32,6 +32,20 @@
         <td class="label">{ts}Development stage{/ts}</td><td>{$extension.develStage}</td>
     </tr>
     <tr>
+        <td class="label">{ts}Requires{/ts}</td>
+        <td>
+            {foreach from=$extension.requires item=ext}
+                {if array_key_exists($ext, $localExtensionRows)}
+                    {$localExtensionRows.$ext.name}
+                {elseif array_key_exists($ext, $remoteExtensionRows)}
+                    {$remoteExtensionRows.$ext.name} (not downloaded)
+                {else}
+                    {$ext} (not installed locally or available remotely)
+                {/if}
+            {/foreach}
+        </td>
+    </tr>
+    <tr>
         <td class="label">{ts}Compatible with{/ts}</td>
         <td>
             {foreach from=$extension.compatibility.ver item=ver}

--- a/templates/CRM/Admin/Page/Extensions/Main.tpl
+++ b/templates/CRM/Admin/Page/Extensions/Main.tpl
@@ -34,7 +34,7 @@ Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
         </tr>
         <tr class="hiddenElement" id="crm-extensions-details-{$row.id}">
             <td>
-                {include file="CRM/Admin/Page/ExtensionDetails.tpl" extension=$row}
+                {include file="CRM/Admin/Page/ExtensionDetails.tpl" extension=$row localExtensionRows=$localExtensionRows remoteExtensionRows=$remoteExtensionRows}
             </td>
             <td></td><td></td><td></td><td></td>
         </tr>

--- a/tests/phpunit/CRM/Extension/InfoTest.php
+++ b/tests/phpunit/CRM/Extension/InfoTest.php
@@ -49,6 +49,22 @@ class CRM_Extension_InfoTest extends CiviUnitTestCase {
     $this->assertEquals('test.foo', $info->key);
     $this->assertEquals('foo', $info->file);
     $this->assertEquals('zamboni', $info->typeInfo['extra']);
+    $this->assertEquals(array(), $info->requires);
+  }
+
+  public function testGood_string_extras() {
+    $data = "<extension key='test.bar' type='module'><file>testbar</file>
+      <classloader><psr4 prefix=\"Civi\\\" path=\"Civi\"/></classloader>
+      <requires><ext>org.civicrm.a</ext><ext>org.civicrm.b</ext></requires>
+    </extension>
+    ";
+
+    $info = CRM_Extension_Info::loadFromString($data);
+    $this->assertEquals('test.bar', $info->key);
+    $this->assertEquals('testbar', $info->file);
+    $this->assertEquals('Civi\\', $info->classloader[0]['prefix']);
+    $this->assertEquals('Civi', $info->classloader[0]['path']);
+    $this->assertEquals(array('org.civicrm.a', 'org.civicrm.b'), $info->requires);
   }
 
   public function testBad_string() {

--- a/tests/phpunit/CRM/Extension/ManagerTest.php
+++ b/tests/phpunit/CRM/Extension/ManagerTest.php
@@ -105,6 +105,86 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
   }
 
   /**
+   * This is the same as testInstall_Disable_Uninstall, but we also install and remove a dependency.
+   *
+   * @throws \CRM_Extension_Exception
+   */
+  public function test_InstallAuto_DisableDownstream_UninstallDownstream() {
+    $testingTypeManager = $this->getMock('CRM_Extension_Manager_Interface');
+    $manager = $this->_createManager(array(
+      self::TESTING_TYPE => $testingTypeManager,
+    ));
+    $this->assertEquals('uninstalled', $manager->getStatus('test.foo.bar'));
+    $this->assertEquals('uninstalled', $manager->getStatus('test.foo.downstream'));
+    $this->assertEquals('uninstalled', $manager->getStatus('test.whiz.bang'));
+
+    $testingTypeManager->expects($this->exactly(2))->method('onPreInstall');
+    $testingTypeManager->expects($this->exactly(2))->method('onPostInstall');
+    $this->assertEquals(array('test.foo.bar', 'test.foo.downstream'),
+      $manager->findInstallRequirements(array('test.foo.downstream')));
+    $manager->install(
+      $manager->findInstallRequirements(array('test.foo.downstream')));
+    $this->assertEquals('installed', $manager->getStatus('test.foo.bar'));
+    $this->assertEquals('installed', $manager->getStatus('test.foo.downstream'));
+    $this->assertEquals('uninstalled', $manager->getStatus('test.whiz.bang'));
+
+    $testingTypeManager->expects($this->once())->method('onPreDisable');
+    $testingTypeManager->expects($this->once())->method('onPostDisable');
+    $this->assertEquals(array('test.foo.downstream'),
+      $manager->findDisableRequirements(array('test.foo.downstream')));
+    $manager->disable(array('test.foo.downstream'));
+    $this->assertEquals('installed', $manager->getStatus('test.foo.bar'));
+    $this->assertEquals('disabled', $manager->getStatus('test.foo.downstream'));
+    $this->assertEquals('uninstalled', $manager->getStatus('test.whiz.bang'));
+
+    $testingTypeManager->expects($this->once())->method('onPreUninstall');
+    $testingTypeManager->expects($this->once())->method('onPostUninstall');
+    $manager->uninstall(array('test.foo.downstream'));
+    $this->assertEquals('installed', $manager->getStatus('test.foo.bar'));
+    $this->assertEquals('uninstalled', $manager->getStatus('test.foo.downstream'));
+    $this->assertEquals('uninstalled', $manager->getStatus('test.whiz.bang'));
+  }
+
+  public function test_InstallAuto_DisableUpstream() {
+    $testingTypeManager = $this->getMock('CRM_Extension_Manager_Interface');
+    $manager = $this->_createManager(array(
+      self::TESTING_TYPE => $testingTypeManager,
+    ));
+    $this->assertEquals('uninstalled', $manager->getStatus('test.foo.bar'));
+    $this->assertEquals('uninstalled', $manager->getStatus('test.foo.downstream'));
+    $this->assertEquals('uninstalled', $manager->getStatus('test.whiz.bang'));
+
+    $testingTypeManager->expects($this->exactly(2))->method('onPreInstall');
+    $testingTypeManager->expects($this->exactly(2))->method('onPostInstall');
+    $this->assertEquals(array('test.foo.bar', 'test.foo.downstream'),
+      $manager->findInstallRequirements(array('test.foo.downstream')));
+    $manager->install(
+      $manager->findInstallRequirements(array('test.foo.downstream')));
+    $this->assertEquals('installed', $manager->getStatus('test.foo.bar'));
+    $this->assertEquals('installed', $manager->getStatus('test.foo.downstream'));
+    $this->assertEquals('uninstalled', $manager->getStatus('test.whiz.bang'));
+
+    $testingTypeManager->expects($this->never())->method('onPreDisable');
+    $testingTypeManager->expects($this->never())->method('onPostDisable');
+    $this->assertEquals(array('test.foo.downstream', 'test.foo.bar'),
+      $manager->findDisableRequirements(array('test.foo.bar')));
+
+    try {
+      $manager->disable(array('test.foo.bar'));
+      $this->fail('Expected disable to fail due to dependency');
+    }
+    catch (CRM_Extension_Exception $e) {
+      $this->assertRegExp('/test.foo.downstream/', $e->getMessage());
+    }
+
+    // Status unchanged
+    $this->assertEquals('installed', $manager->getStatus('test.foo.bar'));
+    $this->assertEquals('installed', $manager->getStatus('test.foo.downstream'));
+    $this->assertEquals('uninstalled', $manager->getStatus('test.whiz.bang'));
+  }
+
+
+  /**
    * Install an extension and then harshly remove the underlying source.
    * Subseuently disable and uninstall.
    */
@@ -420,6 +500,9 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
     mkdir("$basedir/weird/whizbang");
     file_put_contents("$basedir/weird/whizbang/info.xml", "<extension key='test.whiz.bang' type='" . self::TESTING_TYPE . "'><file>oddball</file></extension>");
     // not needed for now // file_put_contents("$basedir/weird/whizbang/oddball.php", "<?php\n");
+    mkdir("$basedir/weird/downstream");
+    file_put_contents("$basedir/weird/downstream/info.xml", "<extension key='test.foo.downstream' type='" . self::TESTING_TYPE . "'><file>oddball</file><requires><ext>test.foo.bar</ext></requires></extension>");
+    // not needed for now // file_put_contents("$basedir/weird/downstream/oddball.php", "<?php\n");
     $c = new CRM_Extension_Container_Basic($basedir, 'http://example/basedir', $cache, $cacheKey);
     return array($basedir, $c);
   }

--- a/tests/phpunit/CRM/Extension/MapperTest.php
+++ b/tests/phpunit/CRM/Extension/MapperTest.php
@@ -5,6 +5,22 @@
  * @group headless
  */
 class CRM_Extension_MapperTest extends CiviUnitTestCase {
+
+  /**
+   * @var string
+   */
+  protected $basedir, $basedir2;
+
+  /**
+   * @var CRM_Extension_Container_Interface
+   */
+  protected $container, $containerWithSlash;
+
+  /**
+   * @var CRM_Extension_Mapper
+   */
+  protected $mapper, $mapperWithSlash;
+
   public function setUp() {
     parent::setUp();
     list ($this->basedir, $this->container) = $this->_createContainer();
@@ -70,6 +86,27 @@ class CRM_Extension_MapperTest extends CiviUnitTestCase {
     $config = CRM_Core_Config::singleton();
     $this->assertEquals(rtrim($config->resourceBase, '/'), $this->mapper->keyToUrl('civicrm'));
     $this->assertEquals(rtrim($config->resourceBase, '/'), $this->mapperWithSlash->keyToUrl('civicrm'));
+  }
+
+  public function testGetKeysByPath() {
+    $mappers = array(
+      $this->basedir => $this->mapper,
+      $this->basedir2 => $this->mapperWithSlash,
+    );
+    foreach ($mappers as $basedir => $mapper) {
+      /** @var CRM_Extension_Mapper $mapper */
+      $this->assertEquals(array(), $mapper->getKeysByPath($basedir));
+      $this->assertEquals(array(), $mapper->getKeysByPath($basedir . '/weird'));
+      $this->assertEquals(array(), $mapper->getKeysByPath($basedir . '/weird/'));
+      $this->assertEquals(array(), $mapper->getKeysByPath($basedir . '/weird//'));
+      $this->assertEquals(array('test.foo.bar'), $mapper->getKeysByPath($basedir . '/*'));
+      $this->assertEquals(array('test.foo.bar'), $mapper->getKeysByPath($basedir . '//*'));
+      $this->assertEquals(array('test.foo.bar'), $mapper->getKeysByPath($basedir . '/weird/*'));
+      $this->assertEquals(array('test.foo.bar'), $mapper->getKeysByPath($basedir . '/weird/foobar'));
+      $this->assertEquals(array('test.foo.bar'), $mapper->getKeysByPath($basedir . '/weird/foobar/'));
+      $this->assertEquals(array('test.foo.bar'), $mapper->getKeysByPath($basedir . '/weird/foobar//'));
+      $this->assertEquals(array('test.foo.bar'), $mapper->getKeysByPath($basedir . '/weird/foobar/*'));
+    }
   }
 
   /**


### PR DESCRIPTION
Extensions support requires tags, to automatically install extension dependencies.
Contains contributions from myself and @totten at CiviSprint UK 2016.

---

 * [CRM-16243: Dependency management for extensions](https://issues.civicrm.org/jira/browse/CRM-16243)