### PR TITLE
CRM-19303 Ensure that the folder matches the http_host

### DIFF
--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -646,7 +646,7 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
         }
 
         //Check if files path exists...
-        if ($this->checkFilesExists($basepath, $folder)) {
+        if ($this->checkFilesExists($basepath, $folder) && $folder == $_SERVER['HTTP_HOST']) {
           $correct = $folder;
           break;
         }


### PR DESCRIPTION
* [CRM-19303: CKEditor configuration can't be edited on a Drupal multisite installation](https://issues.civicrm.org/jira/browse/CRM-19303)