### PR TITLE
CRM-19676: fix how params are merged

### DIFF
--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -52,7 +52,11 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
    * @throws CRM_Core_Exception
    */
   public function __construct($inputData) {
-    $this->setInputParameters(array_merge($inputData, json_decode($inputData['custom'], TRUE)));
+    //CRM-19676
+    $params = (!empty($inputData['custom'])) ?
+      array_merge($inputData, json_decode($inputData['custom'], TRUE)) :
+      $inputData;
+    $this->setInputParameters($params);
     parent::__construct();
   }
 


### PR DESCRIPTION
* [CRM-19676: PayPal Standard IPN fails with "Invalid input parameters"](https://issues.civicrm.org/jira/browse/CRM-19676)