### PR TITLE
CRM-19298 - ensure we get two receipts, with no total line.

### DIFF
--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -449,7 +449,7 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
       ),
       array(
         'Total: $'
-      )
+      ),
     );
     $mut->stop();
     $mut->clearMessages(999);

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -439,10 +439,18 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
     $this->assertTrue(in_array($membershipPayment['contribution_id'], array_keys($contributions['values'])));
     $membership = $this->callAPISuccessGetSingle('membership', array('id' => $membershipPayment['membership_id']));
     $this->assertEquals($membership['contact_id'], $contributions['values'][$membershipPayment['contribution_id']]['contact_id']);
-    $mut->checkAllMailLog(array(
-      '$ 2.00',
-      'Membership Fee',
-    ));
+    // We should have two separate email messages, each with their own amount
+    // line and no total line.
+    $mut->checkAllMailLog(
+      array(
+        'Amount: $ 2.00',
+        'Amount: $ 10.00',
+        'Membership Fee',
+      ),
+      array(
+        'Total: $'
+      )
+    );
     $mut->stop();
     $mut->clearMessages(999);
   }

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -449,7 +449,7 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
       ),
       array(
         'Total: $',
-      ),
+      )
     );
     $mut->stop();
     $mut->clearMessages(999);

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -448,7 +448,7 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
         'Membership Fee',
       ),
       array(
-        'Total: $'
+        'Total: $',
       ),
     );
     $mut->stop();


### PR DESCRIPTION
* [CRM-19298: Membership fee amount doubled in receipt when 'separate membership payment' is configured](https://issues.civicrm.org/jira/browse/CRM-19298)