### PR TITLE
CRM-16575: Backporting #5913

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -1742,7 +1742,7 @@ class CRM_Report_Form extends CRM_Core_Form {
         if ($value !== NULL && count($value) > 0) {
           $value = CRM_Utils_Type::escapeAll($value, $type);
           $operator = $op == 'mnot' ? 'NOT' : '';
-          $regexp = "[[:cntrl:]]*" . implode('[[:>:]]*|[[:<:]]*', (array) $value) . "[[:cntrl:]]*";
+          $regexp = "([[:cntrl:]]|^)" . implode('([[:cntrl:]]|$)|([[:cntrl:]]|^)', (array) $value) . "([[:cntrl:]]|$)";
           $clause = "{$field['dbAlias']} {$operator} REGEXP '{$regexp}'";
         }
         break;


### PR DESCRIPTION
This is similar to this one https://github.com/civicrm/civicrm-core/pull/9298 but I've implemented the notes I left their too . 

Our QA team already tested it on one of our client sites and it passed testing . I also tried to write unit tests for this but the logic is almost impossible to test and it need a lot of refactoring to be testable so I skipped it ( But if you have an Idea on how it could possible without a lot of refactoring to unit test this I am more than happy to implement it ) .

side note : I really think the main source of this issue is allowing the users to edit the values of custom fields which I think is something that should not matter to the end user .. the end user only care about the label and maybe the name but not its value and the value should be created dynamically ( auto-increment value maybe)  and the user cannot alter it . The same applies for option values . If this was the case then I think we can get back to use the IN operator instead of these non-efficient regex .

---

 * [CRM-16575: Searching\/reporting on similar values in multi select fields breaks](https://issues.civicrm.org/jira/browse/CRM-16575)