### PR TITLE
CRM-19303 - Refactor getDefaultFileStorage() function

### DIFF
--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -552,50 +552,15 @@ abstract class CRM_Utils_System_Base {
   /**
    * Determine the default location for file storage.
    *
-   * FIXME:
-   *  1. This was pulled out from a bigger function. It should be split
-   *     into even smaller pieces and marked abstract.
-   *  2. This would be easier to compute by a calling a CMS API, but
-   *     for whatever reason Civi gets it from config data.
-   *
    * @return array
    *   - url: string. ex: "http://example.com/sites/foo.com/files/civicrm"
    *   - path: string. ex: "/var/www/sites/foo.com/files/civicrm"
+   * @throws \CRM_Core_Exception
    */
   public function getDefaultFileStorage() {
-    global $civicrm_root;
     $config = CRM_Core_Config::singleton();
-    $baseURL = CRM_Utils_System::languageNegotiationURL($config->userFrameworkBaseURL, FALSE, TRUE);
-
-    $filesURL = NULL;
-    $filesPath = NULL;
-
-    if ($config->userFramework == 'Joomla') {
-      // gross hack
-      // we need to remove the administrator/ from the end
-      $tempURL = str_replace("/administrator/", "/", $baseURL);
-      $filesURL = $tempURL . "media/civicrm/";
-    }
-    elseif ($this->is_drupal) {
-      $siteName = $config->userSystem->parseDrupalSiteName($civicrm_root);
-      if ($siteName) {
-        $filesURL = $baseURL . "sites/$siteName/files/civicrm/";
-      }
-      else {
-        $filesURL = $baseURL . "sites/default/files/civicrm/";
-      }
-    }
-    elseif ($config->userFramework == 'UnitTests') {
-      $filesURL = $baseURL . "sites/default/files/civicrm/";
-    }
-    else {
-      throw new CRM_Core_Exception("Failed to locate default file storage ($config->userFramework)");
-    }
-
-    return array(
-      'url' => $filesURL,
-      'path' => CRM_Utils_File::baseFilePath(),
-    );
+    throw new CRM_Core_Exception("Failed to locate default file storage ($config->userFramework)");
+    return array();
   }
 
   /**

--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -568,4 +568,18 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
     return $siteName;
   }
 
+  /**
+   * @inheritDoc
+   */
+  public function getDefaultFileStorage() {
+    $path = CRM_Utils_File::baseFilePath();
+    $drupalRoot = $this->cmsRootPath();
+    $url = CRM_Utils_System::url(trim(str_replace($drupalRoot, '', $path), '\\/'), NULL, TRUE);
+
+    return array(
+      'url' => CRM_Utils_File::addTrailingSlash($url, '/'),
+      'path' => $path,
+    );
+  }
+
 }

--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -827,4 +827,22 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
     );
   }
 
+  /**
+   * @inheritDoc
+   */
+  public function getDefaultFileStorage() {
+    $config = CRM_Core_Config::singleton();
+    $baseURL = CRM_Utils_System::languageNegotiationURL($config->userFrameworkBaseURL, FALSE, TRUE);
+
+    // gross hack
+    // we need to remove the administrator/ from the end
+    $tempURL = str_replace("/administrator/", "/", $baseURL);
+    $filesURL = $tempURL . "media/civicrm/";
+
+    return array(
+      'url' => $filesURL,
+      'path' => CRM_Utils_File::baseFilePath(),
+    );
+  }
+
 }

--- a/CRM/Utils/System/UnitTests.php
+++ b/CRM/Utils/System/UnitTests.php
@@ -172,4 +172,16 @@ class CRM_Utils_System_UnitTests extends CRM_Utils_System_Base {
     throw new Exception("Method not implemented: getLoginURL");
   }
 
+  /**
+   * @inheritDoc
+   */
+  public function getDefaultFileStorage() {
+    $config = CRM_Core_Config::singleton();
+
+    return array(
+      'url' => $config->userFrameworkBaseURL . "sites/default/files/civicrm/",
+      'path' => CRM_Utils_File::baseFilePath(),
+    );
+  }
+
 }

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -73,7 +73,7 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
   }
 
   /**
-   * Moved from CRM_Utils_System_Base
+   * @inheritDoc
    */
   public function getDefaultFileStorage() {
     $config = CRM_Core_Config::singleton();


### PR DESCRIPTION
* [CRM-19303: CKEditor configuration can't be edited on a Drupal multisite installation](https://issues.civicrm.org/jira/browse/CRM-19303)