### PR TITLE
CRM-19683: Can now change word replacements if you have more than one language

### DIFF
--- a/CRM/Admin/Form/WordReplacements.php
+++ b/CRM/Admin/Form/WordReplacements.php
@@ -226,7 +226,8 @@ class CRM_Admin_Form_WordReplacements extends CRM_Core_Form {
     CRM_Core_BAO_WordReplacement::setLocaleCustomStrings($config->lcMessages, $overrides);
 
     // This controller was originally written to CRUD $config->locale_custom_strings,
-    // but that's no longer the canonical store. Sync changes to canonical store.
+    // but that's no longer the canonical store. Sync changes to canonical store
+    // (civicrm_word_replacement table in the database).
     // This is inefficient - at some point, we should rewrite this UI.
     CRM_Core_BAO_WordReplacement::rebuildWordReplacementTable();
 

--- a/CRM/Core/BAO/WordReplacement.php
+++ b/CRM/Core/BAO/WordReplacement.php
@@ -205,8 +205,9 @@ WHERE  domain_id = %1
   /**
    * Get word replacements for the api.
    *
-   * Get all the word-replacements stored in config-arrays
-   * and convert them to params for the WordReplacement.create API.
+   * Get all the word-replacements stored in config-arrays for the
+   * configured language, and convert them to params for the
+   * WordReplacement.create API.
    *
    * Note: This function is duplicated in CRM_Core_BAO_WordReplacement and
    * CRM_Upgrade_Incremental_php_FourFour to ensure that the incremental upgrade
@@ -222,6 +223,11 @@ WHERE  domain_id = %1
    * @see CRM_Core_BAO_WordReplacement::convertConfigArraysToAPIParams
    */
   public static function getConfigArraysAsAPIParams($rebuildEach) {
+    $settingsResult = civicrm_api3('Setting', 'get', array(
+      'return' => 'lcMessages',
+    ));
+    $lang = CRM_Utils_Array::first($settingsResult['values'])['lcMessages'];
+
     $wordReplacementCreateParams = array();
     // get all domains
     $result = civicrm_api3('domain', 'get', array(
@@ -236,19 +242,20 @@ WHERE  domain_id = %1
         $localeCustomArray = unserialize($value["locale_custom_strings"]);
         if (!empty($localeCustomArray)) {
           $wordMatchArray = array();
-          // Traverse Language array
-          foreach ($localeCustomArray as $localCustomData) {
-            // Traverse status array "enabled" "disabled"
-            foreach ($localCustomData as $status => $matchTypes) {
-              $params["is_active"] = ($status == "enabled") ? TRUE : FALSE;
-              // Traverse Match Type array "wildcardMatch" "exactMatch"
-              foreach ($matchTypes as $matchType => $words) {
-                $params["match_type"] = $matchType;
-                foreach ($words as $word => $replace) {
-                  $params["find_word"] = $word;
-                  $params["replace_word"] = $replace;
-                  $wordReplacementCreateParams[] = $params;
-                }
+          // Only return the replacement strings of the current language,
+          // otherwise some replacements will be duplicated, which will
+          // lead to undesired results, like CRM-19683.
+          $localCustomData = $localeCustomArray[$lang];
+          // Traverse status array "enabled" "disabled"
+          foreach ($localCustomData as $status => $matchTypes) {
+            $params["is_active"] = ($status == "enabled") ? TRUE : FALSE;
+            // Traverse Match Type array "wildcardMatch" "exactMatch"
+            foreach ($matchTypes as $matchType => $words) {
+              $params["match_type"] = $matchType;
+              foreach ($words as $word => $replace) {
+                $params["find_word"] = $word;
+                $params["replace_word"] = $replace;
+                $wordReplacementCreateParams[] = $params;
               }
             }
           }

--- a/CRM/Core/BAO/WordReplacement.php
+++ b/CRM/Core/BAO/WordReplacement.php
@@ -226,7 +226,8 @@ WHERE  domain_id = %1
     $settingsResult = civicrm_api3('Setting', 'get', array(
       'return' => 'lcMessages',
     ));
-    $lang = CRM_Utils_Array::first($settingsResult['values'])['lcMessages'];
+    $returnValues = CRM_Utils_Array::first($settingsResult['values']);
+    $lang = $returnValues['lcMessages'];
 
     $wordReplacementCreateParams = array();
     // get all domains


### PR DESCRIPTION
CRM-19683

---

 * [CRM-19683: Changing word replacement strings does not work if you have more than one set in civicrm_domain](https://issues.civicrm.org/jira/browse/CRM-19683)