### PR TITLE
CRM-19609 - Force HTTPS for REST API calls if enableSSL is set

### DIFF
--- a/CRM/Utils/REST.php
+++ b/CRM/Utils/REST.php
@@ -688,6 +688,15 @@ class CRM_Utils_REST {
       // Therefore we have reasonably well-formed "?q=civicrm/X/Y"
     }
 
+    // FIXME: Shouldn't the X-Forwarded-Proto check be part of CRM_Utils_System::isSSL()?
+    if (Civi::settings()->get('enableSSL') &&
+      !CRM_Utils_System::isSSL() &&
+      strtolower(CRM_Utils_Array::value('X_FORWARDED_PROTO', CRM_Utils_System::getRequestHeaders())) != 'https'
+    ) {
+      CRM_Utils_System::loadBootStrap(array(), FALSE, FALSE);
+      CRM_Utils_System::redirectToSSL();
+    }
+
     if (!CRM_Utils_System::authenticateKey(FALSE)) {
       // FIXME: At time of writing, this doesn't actually do anything because
       // authenticateKey abends, but that's a bad behavior which sends a

--- a/CRM/Utils/REST.php
+++ b/CRM/Utils/REST.php
@@ -546,6 +546,14 @@ class CRM_Utils_REST {
       );
       CRM_Utils_JSON::output($error);
     }
+    // FIXME: Shouldn't the X-Forwarded-Proto check be part of CRM_Utils_System::isSSL()?
+    if (Civi::settings()->get('enableSSL') &&
+      !CRM_Utils_System::isSSL() &&
+      strtolower(CRM_Utils_Array::value('X_FORWARDED_PROTO', CRM_Utils_System::getRequestHeaders())) != 'https'
+    ) {
+      CRM_Utils_System::loadBootStrap(array(), FALSE, FALSE);
+      CRM_Utils_System::redirectToSSL();
+    }
     if (empty($requestParams['entity'])) {
       CRM_Utils_JSON::output(civicrm_api3_create_error('missing entity param'));
     }
@@ -608,6 +616,15 @@ class CRM_Utils_REST {
         )
       );
       CRM_Utils_JSON::output($error);
+    }
+
+    // FIXME: Shouldn't the X-Forwarded-Proto check be part of CRM_Utils_System::isSSL()?
+    if (Civi::settings()->get('enableSSL') &&
+      !CRM_Utils_System::isSSL() &&
+      strtolower(CRM_Utils_Array::value('X_FORWARDED_PROTO', CRM_Utils_System::getRequestHeaders())) != 'https'
+    ) {
+      CRM_Utils_System::loadBootStrap(array(), FALSE, FALSE);
+      CRM_Utils_System::redirectToSSL();
     }
 
     $q = CRM_Utils_Array::value('fnName', $requestParams);


### PR DESCRIPTION
This patch attempts to force HTTPS for REST API calls if the enableSSL option has been set.

It works, but I'm not certain if this is the best method/place for it - this is what I was able to come up with, based on looking at how it was enforced elsewhere.

---

 * [CRM-19609: API HTTPS Bypass](https://issues.civicrm.org/jira/browse/CRM-19609)