### PR TITLE
CRM-19680: Participant.get API generates invalid query when searching…

### DIFF
--- a/CRM/Event/BAO/Query.php
+++ b/CRM/Event/BAO/Query.php
@@ -410,6 +410,8 @@ class CRM_Event_BAO_Query extends CRM_Core_BAO_Query {
         $qillName = $name;
         $name = 'role_id';
 
+        $dataType = !empty($fields[$qillName]['type']) ? CRM_Utils_Type::typeToString($fields[$qillName]['type']) : 'String';
+        $tableName = empty($tableName) ? 'civicrm_participant' : $tableName;
         if (is_array($value) && in_array(key($value), CRM_Core_DAO::acceptedSQLOperators(), TRUE)) {
           $op = key($value);
           $value = $value[$op];

--- a/tests/phpunit/api/v3/ParticipantTest.php
+++ b/tests/phpunit/api/v3/ParticipantTest.php
@@ -99,6 +99,44 @@ class api_v3_ParticipantTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test get participants with role_id.
+   */
+  public function testGetParticipantWithRole() {
+    $roleId = array(1, 2, 3);
+    foreach ($roleId as $role) {
+      $this->participantCreate(array(
+        'contact_id' => $this->individualCreate(),
+        'role_id' => $role,
+        'event_id' => $this->_eventID,
+      ));
+    }
+
+    $params = array(
+      'role_id' => 2,
+    );
+    $result = $this->callAPISuccess('participant', 'get', $params);
+    //Assert all the returned participants has a role_id of 2
+    foreach ($result['values'] as $pid => $values) {
+      $this->assertEquals($values['participant_role_id'], 2);
+    }
+
+    $this->participantCreate(array(
+      'id' => $this->_participantID,
+      'role_id' => NULL,
+      'event_id' => $this->_eventID,
+    ));
+
+    $params['role_id'] = array(
+      'IS NULL' => 1,
+    );
+    $result = $this->callAPISuccess('participant', 'get', $params);
+    foreach ($result['values'] as $pid => $values) {
+      $this->assertEquals($values['participant_role_id'], NULL);
+    }
+
+  }
+
+  /**
    * Check with complete array + custom field
    * Note that the test is written on purpose without any
    * variables specific to participant so it can be replicated into other entities


### PR DESCRIPTION
… for role_id IS NULL  https://issues.civicrm.org/jira/browse/CRM-19680