### PR TITLE
CRM-19534 - Avoid db constraint violation when saving report for non-admins

### DIFF
--- a/CRM/Core/BAO/Dashboard.php
+++ b/CRM/Core/BAO/Dashboard.php
@@ -450,9 +450,8 @@ class CRM_Core_BAO_Dashboard extends CRM_Core_DAO_Dashboard {
     $query = "SELECT distinct( contact_id )
               FROM civicrm_dashboard_contact WHERE dashboard_id = {$dashlet->id}";
     $dao = CRM_Core_DAO::executeQuery($query);
-    $skipContactIDs = array();
     while ($dao->fetch()) {
-      if(array_key_exists($dao->contact_id, $contactIDs)) {
+      if (array_key_exists($dao->contact_id, $contactIDs)) {
         unset($contactIDs[$dao->contact_id]);
       }
     }

--- a/CRM/Core/BAO/Dashboard.php
+++ b/CRM/Core/BAO/Dashboard.php
@@ -440,6 +440,7 @@ class CRM_Core_BAO_Dashboard extends CRM_Core_DAO_Dashboard {
     else {
       //Get the id of Logged in User
       $session = CRM_Core_Session::singleton();
+      $contactID = CRM_Core_Session::singleton()->getLoggedInContactID();
       $contactID = $session->get('userID');
       if (!empty($contactID)) {
         $contactIDs[$contactID] = NULL;

--- a/CRM/Core/BAO/Dashboard.php
+++ b/CRM/Core/BAO/Dashboard.php
@@ -439,9 +439,7 @@ class CRM_Core_BAO_Dashboard extends CRM_Core_DAO_Dashboard {
     }
     else {
       //Get the id of Logged in User
-      $session = CRM_Core_Session::singleton();
-      $contactID = CRM_Core_Session::singleton()->getLoggedInContactID();
-      $contactID = $session->get('userID');
+      $contactID = CRM_Core_Session::getLoggedInContactID();
       if (!empty($contactID)) {
         $contactIDs[$contactID] = NULL;
       }

--- a/CRM/Core/BAO/Dashboard.php
+++ b/CRM/Core/BAO/Dashboard.php
@@ -431,15 +431,10 @@ class CRM_Core_BAO_Dashboard extends CRM_Core_DAO_Dashboard {
     $contactIDs = array();
     if ($admin) {
       $query = "SELECT distinct( contact_id )
-                        FROM civicrm_dashboard_contact
-                        WHERE contact_id NOT IN (
-                            SELECT distinct( contact_id )
-                            FROM civicrm_dashboard_contact WHERE dashboard_id = {$dashlet->id}
-                            )";
-
+                        FROM civicrm_dashboard_contact";
       $dao = CRM_Core_DAO::executeQuery($query);
       while ($dao->fetch()) {
-        $contactIDs[] = $dao->contact_id;
+        $contactIDs[$dao->contact_id] = NULL;
       }
     }
     else {
@@ -447,15 +442,25 @@ class CRM_Core_BAO_Dashboard extends CRM_Core_DAO_Dashboard {
       $session = CRM_Core_Session::singleton();
       $contactID = $session->get('userID');
       if (!empty($contactID)) {
-        $contactIDs[] = $session->get('userID');
+        $contactIDs[$contactID] = NULL;
       }
     }
 
+    // Remove contact ids that already have this dashlet to avoid DB
+    // constraint violation.
+    $query = "SELECT distinct( contact_id )
+              FROM civicrm_dashboard_contact WHERE dashboard_id = {$dashlet->id}";
+    $dao = CRM_Core_DAO::executeQuery($query);
+    $skipContactIDs = array();
+    while ($dao->fetch()) {
+      if(array_key_exists($dao->contact_id, $contactIDs)) {
+        unset($contactIDs[$dao->contact_id]);
+      }
+    }
     if (!empty($contactIDs)) {
-      foreach ($contactIDs as $contactID) {
+      foreach ($contactIDs as $contactID => $value) {
         $valuesArray[] = " ( {$dashlet->id}, {$contactID} )";
       }
-
       $valuesString = implode(',', $valuesArray);
       $query = "
                   INSERT INTO civicrm_dashboard_contact ( dashboard_id, contact_id )

--- a/tests/phpunit/api/v3/DashboardTest.php
+++ b/tests/phpunit/api/v3/DashboardTest.php
@@ -62,6 +62,28 @@ class api_v3_DashboardTest extends CiviUnitTestCase {
   }
 
   /**
+   * CRM-19534.
+   *
+   * Ensure that Dashboard create works fine for non admins
+   */
+  public function testDashboardCreateByNonAdmins() {
+    $loggedInContactID = $this->createLoggedInUser();
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = array();
+    $params = array(
+      'label' => 'New Dashlet element',
+      'name' => 'New Dashlet element',
+      'url' => 'civicrm/report/list&reset=1&compid=99',
+      'fullscreen_url' => 'civicrm/report/list&compid=99&reset=1&context=dashletFullscreen',
+    );
+    $dashboard = $this->callAPISuccess('dashboard', 'create', $params);
+    $this->assertTrue(is_numeric($dashboard['id']), "In line " . __LINE__);
+    $this->assertTrue($dashboard['id'] > 0, "In line " . __LINE__);
+
+    $this->callAPISuccess('dashboard', 'create', $params);
+    $this->assertEquals($dashboard['values'][$dashboard['id']]['is_active'], 1);
+  }
+
+  /**
    * CRM-19217.
    *
    * Ensure that where is_active is specifically set to 0 is_active returns 0.


### PR DESCRIPTION
* [CRM-19534: Saving report with dashlet enabled for non admin users can cause a backtrace](https://issues.civicrm.org/jira/browse/CRM-19534)