### PR TITLE
CRM-19556 CiviMember: wording on "current" membership search

### DIFF
--- a/CRM/Member/BAO/Query.php
+++ b/CRM/Member/BAO/Query.php
@@ -261,7 +261,7 @@ class CRM_Member_BAO_Query extends CRM_Core_BAO_Query {
       case 'membership_is_current_member':
         // We don't want to include all tests for sql OR CRM-7827
         $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause("civicrm_membership_status.is_current_member", $op, $value, "Boolean");
-        $query->_qill[$grouping][] = ts('Is an %1 Member', array(1 => $value ? 'Active' : 'Inactive'));
+        $query->_qill[$grouping][] = $value ? ts('Is a current member') : ts('Is a non-current member');
         $query->_tables['civicrm_membership_status'] = $query->_whereTables['civicrm_membership_status'] = 1;
         return;
 
@@ -500,7 +500,7 @@ class CRM_Member_BAO_Query extends CRM_Core_BAO_Query {
 
     $form->addFormRule(array('CRM_Member_BAO_Query', 'formRule'), $form);
 
-    $form->addYesNo('membership_is_current_member', ts('Active Member?'), TRUE);
+    $form->addYesNo('membership_is_current_member', ts('Current Member?'), TRUE);
     $form->addYesNo('member_is_primary', ts('Primary Member?'), TRUE);
     $form->addYesNo('member_pay_later', ts('Pay Later?'), TRUE);
 


### PR DESCRIPTION
The work by @liedekef for searching memberships that are in "current" statuses is great.  There are a couple of issues this addresses:

* The use of `ts()` with `Active` or `Inactive` as a variable means that the English word "Active" would be in there no matter what language.  Of course, we could wrap "Active" with another `ts()`, but the translator would have no context for this.  Sometimes it's better to repeat yourself if it involves translated strings.
* The `is_current_member` label is called "Current Membership" when editing membership types, so we should be consistent with that.

`<rant>`
Meanwhile, I happen to think the "current" term is terribly confusing in a couple of ways, but it's outside the scope of this fix.  My concerns are:

* The obvious confusion that multiple statuses can be current while CiviCRM ships with a status named "current".  The use of "Active" is much better in my mind; it just needs to be consistent across everything.

* The help text for the "current membership" field indicates that it marks whether someone is a member "in good standing".  From that perspective, a member in a grace period *should not* be considered "current": they owe a renewal.  

  On the other hand, the "current membership" field determines whether a renewal extends the old membership term (with the same start date and an end date extended by a term) or sets a new start date and calculates the end date from there.  From this perspective, a member in a grace period *should* be considered "current": when they renew, there should be no lapse.

  This is an issue for another day, but those concepts should be split: one field should indicate which statuses are "active" from the perspective of being paid-up and/or receiving member benefits, and another field should indicate whether renewing a membership in that status should leave a lapse.

`</rant>`

---

 * [CRM-19556: Allow to search on active membership](https://issues.civicrm.org/jira/browse/CRM-19556)