### PR TITLE
CRM-19685: Contacts preferred_mail_format can't be NULL

### DIFF
--- a/CRM/Upgrade/Incremental/sql/4.7.15.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.7.15.mysql.tpl
@@ -1,1 +1,4 @@
 {* file to handle db changes in 4.7.15 during upgrade *}
+
+-- CRM-19685 (fix for inconsistencies)
+UPDATE civicrm_contact SET preferred_mail_format = 'Both' WHERE preferred_mail_format IS NULL;


### PR DESCRIPTION
* [CRM-19685: Contacts preferred_mail_format can't be NULL](https://issues.civicrm.org/jira/browse/CRM-19685)