### PR TITLE
CRM-19678: Create membership signup activity instead of Membership Renewal on Pay later

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -2042,7 +2042,7 @@ WHERE      activity.id IN ($activityIds)";
    *   For Membership Signup or Renewal.
    * @param int $targetContactID
    * @param array $params
-   *   Activity params to override
+   *   Activity params to override.
    *
    * @return bool|NULL
    */
@@ -2127,10 +2127,10 @@ WHERE      activity.id IN ($activityIds)";
   }
 
   /**
-   * Get activity subject on basis of component object
+   * Get activity subject on basis of component object.
    *
    * @param object $entityObj
-   *   (reference) particular component object.
+   *   particular component object.
    *
    * @return string
    */

--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -2068,6 +2068,14 @@ WHERE      activity.id IN ($activityIds)";
         return NULL;
       }
 
+      // retrieve existing activity based on source_record_id and activity_type
+      if (empty($params['id'])) {
+        $params['id'] = CRM_Utils_Array::value('id', civicrm_api3('Activity', 'Get', array(
+          'source_record_id' => $activity->id,
+          'activity_type_id' => $activityType,
+        )));
+      }
+
       $date = CRM_Utils_Date::isoToMysql($activity->receive_date);
       $activityType = $component = 'Contribution';
     }

--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -2075,6 +2075,10 @@ WHERE      activity.id IN ($activityIds)";
           'activity_type_id' => $activityType,
         )));
       }
+      if (!empty($params['id'])) {
+        // CRM-13237 : if activity record found, update it with campaign id of contribution
+        $params['campaign_id'] = $activity->campaign_id;
+      }
 
       $date = CRM_Utils_Date::isoToMysql($activity->receive_date);
       $activityType = $component = 'Contribution';
@@ -2101,11 +2105,9 @@ WHERE      activity.id IN ($activityIds)";
       $activityParams['id'] = $activity->activity_id;
     }
     // create activity with target contacts
-    if (!empty($activityParams['source_contact_id'])) {
-      $id = CRM_Core_Session::getLoggedInContactID();
-      if ($id) {
-        $activityParams['source_contact_id'] = $id;
-      }
+    $id = CRM_Core_Session::getLoggedInContactID();
+    if ($id) {
+      $activityParams['source_contact_id'] = $id;
     }
 
     // CRM-14945

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4608,8 +4608,6 @@ LIMIT 1;";
             $var = TRUE;
             CRM_Member_BAO_Membership::createRelatedMemberships($var, $var, TRUE);
             civicrm_api3('Membership', 'create', $membershipParams);
-            //CRM-19600: Add Membership Renewal activity
-            CRM_Activity_BAO_Activity::addActivity($membership, 'Membership Renewal', $membership->contact_id);
           }
         }
       }

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -1939,10 +1939,14 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
                     'source_record_id' => $membership->id,
                     'activity_type_id' => $activityType,
                     'status_id' => 'Scheduled',
+                    'options' => array(
+                      'limit' => 1,
+                      'sort' => 'id DESC',
+                    ),
                   )
                 )
               );
-              // 1. Update Schedule Membership Signup/Renwal activity to completed on successful payment of pending membership
+              // 1. Update Schedule Membership Signup/Renewal activity to completed on successful payment of pending membership
               // 2. OR Create renewal activity scheduled if its membership renewal will be paid later
               if ($scheduledActivityID) {
                 CRM_Activity_BAO_Activity::addActivity($membership, $activityType, $membership->contact_id, array('id' => $scheduledActivityID));
@@ -1959,7 +1963,7 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
                 array(
                   'subject' => "Status changed from {$allStatus[$oldStatus]} to {$allStatus[$membership->status_id]}",
                   'source_contact_id' => $membershipLog['modified_id'],
-                  'priority_id' => 2,
+                  'priority_id' => 'Normal',
                 )
               );
             }

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -579,7 +579,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
     if (empty($contribution->contact_id)) {
       $contribution->find(TRUE);
     }
-    CRM_Activity_BAO_Activity::addActivity($contribution, 'Offline');
+    CRM_Activity_BAO_Activity::addActivity($contribution, 'Contribution');
 
     // do not add to recent items for import, CRM-4399
     if (empty($params['skipRecentView'])) {
@@ -1882,6 +1882,7 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
             }
 
             if ($currentMembership) {
+              $oldStatus = $currentMembership['status_id'];
               CRM_Member_BAO_Membership::fixMembershipStatusBeforeRenew($currentMembership, NULL);
               $dates = CRM_Member_BAO_MembershipType::getRenewalDatesForMembershipType($membership->id, NULL, NULL, $numterms);
               $dates['join_date'] = CRM_Utils_Date::customFormat($currentMembership['join_date'], $format);
@@ -1931,8 +1932,37 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
             //update related Memberships.
             CRM_Member_BAO_Membership::updateRelatedMemberships($membership->id, $formattedParams);
 
-            //CRM-19678: No Membership Renewal Activity is created when a Pay Later is set to Completed
-            CRM_Activity_BAO_Activity::addActivity($membership, 'Membership Renewal', $membership->contact_id);
+            foreach (array('Membership Signup', 'Membership Renewal') as $activityType) {
+              $scheduledActivityID = CRM_Utils_Array::value('id',
+                civicrm_api3('Activity', 'Get',
+                  array(
+                    'source_record_id' => $membership->id,
+                    'activity_type_id' => $activityType,
+                    'status_id' => 'Scheduled',
+                  )
+                )
+              );
+              // 1. Update Schedule Membership Signup/Renwal activity to completed on successful payment of pending membership
+              // 2. OR Create renewal activity scheduled if its membership renewal will be paid later
+              if ($scheduledActivityID) {
+                CRM_Activity_BAO_Activity::addActivity($membership, $activityType, $membership->contact_id, array('id' => $scheduledActivityID));
+                break;
+              }
+            }
+
+            // track membership status change if any
+            if (!empty($oldStatus) && $membership->status_id != $oldStatus) {
+              $allStatus = CRM_Member_BAO_Membership::buildOptions('status_id', 'get');
+              CRM_Activity_BAO_Activity::addActivity($membership,
+                'Change Membership Status',
+                NULL,
+                array(
+                  'subject' => "Status changed from {$allStatus[$oldStatus]} to {$allStatus[$membership->status_id]}",
+                  'source_contact_id' => $membershipLog['modified_id'],
+                  'priority_id' => 2,
+                )
+              );
+            }
 
             $updateResult['membership_end_date'] = CRM_Utils_Date::customFormat($dates['end_date'],
               '%B %E%f, %Y'

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1880,6 +1880,10 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = membership.contact_id AND 
         if ($contributionRecurID) {
           $memParams['contribution_recur_id'] = $contributionRecurID;
         }
+        //CRM-19678 : Pay later chosen on current membership then create 'Membership Signup' Activity to track
+        if ($isPayLater) {
+          $activityType = 'Membership Signup';
+        }
         $membership = self::create($memParams, $ids, FALSE, $activityType);
         return array($membership, $renewalMode, $dates);
       }

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -139,11 +139,11 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
     // reset the group contact cache since smart groups might be affected due to this
     CRM_Contact_BAO_GroupContactCache::opportunisticCacheFlush();
 
-    $activityParams = array();
     $allStatus = CRM_Member_BAO_Membership::buildOptions('status_id', 'get');
-    if (!empty($params['is_pay_later']) ||
-      in_array($allStatus[$membership->status_id], array('Pending', 'Grace'))
-    ) {
+    $activityParams = array(
+      'status_id' => CRM_Utils_Array::value('membership_activity_status', $params, 'Completed'),
+    );
+    if (in_array($allStatus[$membership->status_id], array('Pending', 'Grace'))) {
       $activityParams['status_id'] = CRM_Core_OptionGroup::getValue('activity_status', 'Scheduled', 'name');
     }
 
@@ -159,7 +159,7 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
           array(
             'subject' => "Status changed from {$allStatus[$oldStatus]} to {$allStatus[$membership->status_id]}",
             'source_contact_id' => $membershipLog['modified_id'],
-            'priority_id' => 2,
+            'priority_id' => 'Normal',
           )
         );
       }
@@ -171,7 +171,7 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
           array(
             'subject' => "Type changed from {$membershipTypes[$oldType]} to {$membershipTypes[$membership->membership_type_id]}",
             'source_contact_id' => $membershipLog['modified_id'],
-            'priority_id' => 2,
+            'priority_id' => 'Normal',
           )
         );
       }
@@ -1853,7 +1853,7 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = membership.contact_id AND 
           'join_date' => $currentMembership['join_date'],
           'membership_type_id' => $membershipTypeID,
           'max_related' => !empty($membershipTypeDetails['max_related']) ? $membershipTypeDetails['max_related'] : NULL,
-          'is_pay_later' => $isPayLater,
+          'membership_activity_status' => $isPayLater ? 'Scheduled' : 'Completed',
         );
         if ($contributionRecurID) {
           $memParams['contribution_recur_id'] = $contributionRecurID;

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -2765,6 +2765,13 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     );
     $this->setUpPendingContribution($this->_ids['price_field_value'][0]);
     $this->callAPISuccess('membership', 'getsingle', array('id' => $this->_ids['membership']));
+    // Case 1: Assert that Membership Signup Activity is created on Pending (Pay later) to Completed Contribution via backoffice
+    $activity = $this->callAPISuccess('Activity', 'get', array(
+      'activity_type_id' => 'Membership Signup',
+      'source_record_id' => $this->_ids['membership'],
+      'status_id' => 'Scheduled',
+    ));
+    $this->assertEquals(1, $activity['count']);
 
     // change pending contribution to completed
     $form = new CRM_Contribute_Form_Contribution();
@@ -2806,34 +2813,29 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     catch (Civi\Payment\Exception\PaymentProcessorException $e) {
       $error = TRUE;
     }
-    // Case 1: Assert that Membership Renewal Activity is created on Pending (Pay later) to Completed Contribution via backoffice
-    $activity = $this->callAPISuccess('Activity', 'get', array(
-      'activity_type_id' => 'Membership Renewal',
-      'source_record_id' => $this->_ids['contribution'],
-    ));
-    $this->assertEquals(1, $activity['count']);
-
-    // Case 2: Assert that Membership Signup Activity is created on Pending (Pay later) Contribution on current membership
-    $this->setUpPendingContribution($this->_ids['price_field_value'][0], array('trxn_id' => 'xoa12', 'invoice_id' => '12mv'));
+    // Case 2: After successful payment for Pending (Pay later) backoffice there are three activities created
+    //  2.a Update status of existing Scheduled Membership Signup (created in step 1) to Completed
     $activity = $this->callAPISuccess('Activity', 'get', array(
       'activity_type_id' => 'Membership Signup',
-      'source_record_id' => $this->_ids['contribution'],
+      'source_record_id' => $this->_ids['membership'],
+      'status_id' => 'Completed',
     ));
     $this->assertEquals(1, $activity['count']);
-    // Case 3: Assert that no Membership Renewal Activity is created on Pending (Pay later) Contribution on current membership
+    // 2.b Contribution activity created to record successful payment
     $activity = $this->callAPISuccess('Activity', 'get', array(
-      'activity_type_id' => 'Membership Renewal',
+      'activity_type_id' => 'Contribution',
       'source_record_id' => $this->_ids['contribution'],
-    ));
-    $this->assertEquals(0, $activity['count']);
-
-    //Case 4 (CRM-19600): Assert that Membership Renewal Activity is created via online contribution
-    $this->callAPISuccess('contribution', 'completetransaction', array('id' => $this->_ids['contribution']));
-    $activity = $this->callAPISuccess('Activity', 'get', array(
-      'activity_type_id' => 'Membership Renewal',
-      'source_record_id' => $this->_ids['contribution'],
+      'status_id' => 'Completed',
     ));
     $this->assertEquals(1, $activity['count']);
+    // 2.c 'Change membership type' activity created to record Membership status change from Grace to Current
+    $activity = $this->callAPISuccess('Activity', 'get', array(
+      'activity_type_id' => 'Change Membership Status',
+      'source_record_id' => $this->_ids['membership'],
+      'status_id' => 'Completed',
+    ));
+    $this->assertEquals(1, $activity['count']);
+    $this->assertEquals('Status changed from Grace to Current', $activity['values'][$activity['id']]['subject']);
   }
 
   /**

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -2739,7 +2739,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     ));
     $this->assertEquals(1, $logs['count']);
     $this->assertEquals($stateOfGrace, $membership['status_id']);
-    $contribution = $this->callAPISuccess('contribution', 'completetransaction', array('id' => $this->_ids['contribution']));
+    $this->callAPISuccess('contribution', 'completetransaction', array('id' => $this->_ids['contribution']));
     $membership = $this->callAPISuccess('membership', 'getsingle', array('id' => $this->_ids['membership']));
     $this->assertEquals(date('Y-m-d', strtotime('yesterday + 1 year')), $membership['end_date']);
     $this->callAPISuccessGetSingle('LineItem', array(
@@ -2749,12 +2749,6 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $logs = $this->callAPISuccess('MembershipLog', 'get', array(
       'membership_id' => $this->_ids['membership'],
     ));
-    //CRM-19600: Ensure that 'Membership Renewal' activity is created after successful membership regsitration
-    $activity = $this->callAPISuccess('Activity', 'get', array(
-      'activity_type_id' => 'Membership Renewal',
-      'source_record_id' => $contribution['id'],
-    ));
-    $this->assertEquals(1, $activity['count']);
     $this->assertEquals(2, $logs['count']);
     $this->assertNotEquals($stateOfGrace, $logs['values'][2]['status_id']);
     $this->cleanUpAfterPriceSets();
@@ -2832,6 +2826,14 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'source_record_id' => $this->_ids['contribution'],
     ));
     $this->assertEquals(0, $activity['count']);
+
+    //Case 4 (CRM-19600): Assert that Membership Renewal Activity is created via online contribution
+    $this->callAPISuccess('contribution', 'completetransaction', array('id' => $this->_ids['contribution']));
+    $activity = $this->callAPISuccess('Activity', 'get', array(
+      'activity_type_id' => 'Membership Renewal',
+      'source_record_id' => $this->_ids['contribution'],
+    ));
+    $this->assertEquals(1, $activity['count']);
   }
 
   /**

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -2765,7 +2765,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     );
     $this->setUpPendingContribution($this->_ids['price_field_value'][0]);
     $this->callAPISuccess('membership', 'getsingle', array('id' => $this->_ids['membership']));
-    // Case 1: Assert that Membership Signup Activity is created on Pending (Pay later) to Completed Contribution via backoffice
+    // Case 1: Assert that Membership Signup Activity is created on Pending to Completed Contribution via backoffice
     $activity = $this->callAPISuccess('Activity', 'get', array(
       'activity_type_id' => 'Membership Signup',
       'source_record_id' => $this->_ids['membership'],
@@ -2813,7 +2813,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     catch (Civi\Payment\Exception\PaymentProcessorException $e) {
       $error = TRUE;
     }
-    // Case 2: After successful payment for Pending (Pay later) backoffice there are three activities created
+    // Case 2: After successful payment for Pending backoffice there are three activities created
     //  2.a Update status of existing Scheduled Membership Signup (created in step 1) to Completed
     $activity = $this->callAPISuccess('Activity', 'get', array(
       'activity_type_id' => 'Membership Signup',

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -2812,11 +2812,26 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     catch (Civi\Payment\Exception\PaymentProcessorException $e) {
       $error = TRUE;
     }
+    // Case 1: Assert that Membership Renewal Activity is created on Pending (Pay later) to Completed Contribution via backoffice
     $activity = $this->callAPISuccess('Activity', 'get', array(
       'activity_type_id' => 'Membership Renewal',
       'source_record_id' => $this->_ids['contribution'],
     ));
     $this->assertEquals(1, $activity['count']);
+
+    // Case 2: Assert that Membership Signup Activity is created on Pending (Pay later) Contribution on current membership
+    $this->setUpPendingContribution($this->_ids['price_field_value'][0], array('trxn_id' => 'xoa12', 'invoice_id' => '12mv'));
+    $activity = $this->callAPISuccess('Activity', 'get', array(
+      'activity_type_id' => 'Membership Signup',
+      'source_record_id' => $this->_ids['contribution'],
+    ));
+    $this->assertEquals(1, $activity['count']);
+    // Case 3: Assert that no Membership Renewal Activity is created on Pending (Pay later) Contribution on current membership
+    $activity = $this->callAPISuccess('Activity', 'get', array(
+      'activity_type_id' => 'Membership Renewal',
+      'source_record_id' => $this->_ids['contribution'],
+    ));
+    $this->assertEquals(0, $activity['count']);
   }
 
   /**
@@ -2841,7 +2856,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
    *
    * @param int $priceFieldValueID
    */
-  public function setUpPendingContribution($priceFieldValueID) {
+  public function setUpPendingContribution($priceFieldValueID, $contriParams = array()) {
     $contactID = $this->individualCreate();
     $membership = $this->callAPISuccess('membership', 'create', array(
       'contact_id' => $contactID,
@@ -2850,7 +2865,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'end_date' => 'yesterday',
       'join_date' => 'yesterday - 1 year',
     ));
-    $contribution = $this->callAPISuccess('contribution', 'create', array(
+    $contribution = $this->callAPISuccess('contribution', 'create', array_merge(array(
       'domain_id' => 1,
       'contact_id' => $contactID,
       'receive_date' => date('Ymd'),
@@ -2864,7 +2879,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'contribution_status_id' => 2,
       'contribution_page_id' => $this->_ids['contribution_page'],
       'api.membership_payment.create' => array('membership_id' => $membership['id']),
-    ));
+    ), $contriParams));
 
     $this->callAPISuccess('line_item', 'create', array(
       'entity_id' => $contribution['id'],

--- a/tests/phpunit/api/v3/JobTest.php
+++ b/tests/phpunit/api/v3/JobTest.php
@@ -369,10 +369,10 @@ class api_v3_JobTest extends CiviUnitTestCase {
     $this->callAPISuccessGetCount('Membership', array('contact_id' => $contact2ID), 0);
     $this->callAPISuccessGetCount('EntityTag', array('contact_id' => $contactID), 2);
     $this->callAPISuccessGetCount('EntityTag', array('contact_id' => $contact2ID), 0);
-    // 12 activities is one for each contribution (2), one for each membership (+2 = 4)
-    // 3 for each of the added activities as there are 3 roles (+6 = 10
-    // 2 for the (source & target) contact merged activity (+2 = 12)
-    $this->callAPISuccessGetCount('ActivityContact', array('contact_id' => $contactID), 12);
+    // 14 activities is one for each contribution (2), two (source + target) for each membership (+(2x2) = 6)
+    // 3 for each of the added activities as there are 3 roles (+6 = 12
+    // 2 for the (source & target) contact merged activity (+2 = 14)
+    $this->callAPISuccessGetCount('ActivityContact', array('contact_id' => $contactID), 14);
     // 2 for the connection to the deleted by merge activity (source & target)
     $this->callAPISuccessGetCount('ActivityContact', array('contact_id' => $contact2ID), 2);
   }


### PR DESCRIPTION
* [CRM-19678: No Membership Renewal Activity is created when a Pay Later is set to Completed](https://issues.civicrm.org/jira/browse/CRM-19678)