### PR TITLE
CRM-19697: No recycling the static _links object when you change it!

### DIFF
--- a/CRM/Contribute/Page/Tab.php
+++ b/CRM/Contribute/Page/Tab.php
@@ -79,21 +79,23 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
     }
 
     if ($recurID) {
+      $links = self::$_links;
       $paymentProcessorObj = CRM_Financial_BAO_PaymentProcessor::getProcessorForEntity($recurID, 'recur', 'obj');
       if (is_object($paymentProcessorObj) && $paymentProcessorObj->supports('cancelRecurring')) {
-        unset(self::$_links[CRM_Core_Action::DISABLE]['extra'], self::$_links[CRM_Core_Action::DISABLE]['ref']);
-        self::$_links[CRM_Core_Action::DISABLE]['url'] = "civicrm/contribute/unsubscribe";
-        self::$_links[CRM_Core_Action::DISABLE]['qs'] = "reset=1&crid=%%crid%%&cid=%%cid%%&context={$context}";
+        unset($links[CRM_Core_Action::DISABLE]['extra'], $links[CRM_Core_Action::DISABLE]['ref']);
+        $links[CRM_Core_Action::DISABLE]['url'] = "civicrm/contribute/unsubscribe";
+        $links[CRM_Core_Action::DISABLE]['qs'] = "reset=1&crid=%%crid%%&cid=%%cid%%&context={$context}";
       }
 
       if (is_object($paymentProcessorObj) && $paymentProcessorObj->isSupported('updateSubscriptionBillingInfo')) {
-        self::$_links[CRM_Core_Action::RENEW] = array(
+        $links[CRM_Core_Action::RENEW] = array(
           'name' => ts('Change Billing Details'),
           'title' => ts('Change Billing Details'),
           'url' => 'civicrm/contribute/updatebilling',
           'qs' => "reset=1&crid=%%crid%%&cid=%%cid%%&context={$context}",
         );
       }
+      return $links;
     }
 
     return self::$_links;


### PR DESCRIPTION
Do not make use of the static _links object when customizing per payment processor for recurring contributions.

---

 * [CRM-19697: Incorrect update billing details link](https://issues.civicrm.org/jira/browse/CRM-19697)