### PR TITLE
CRM-19637 - Showing Dynamically populated Custom data options in reports

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -2055,7 +2055,8 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
         ))) {
           $retValue = $value;
           break;
-        }  else {
+        }  
+        else {
           $customField['options'] = CRM_Core_BAO_CustomOption::getCustomOption($customField['id']);
           $retValue = $customField['options'][$value]['label'];
           break;

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -2055,7 +2055,7 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
         ))) {
           $retValue = $value;
           break;
-        }  
+        }
         else {
           $customField['options'] = CRM_Core_BAO_CustomOption::getCustomOption($customField['id']);
           $retValue = $customField['options'][$value]['label'];

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -2055,7 +2055,12 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
         ))) {
           $retValue = $value;
           break;
+        }  else {
+          $customField['options'] = CRM_Core_BAO_CustomOption::getCustomOption($customField['id']);
+          $retValue = $customField['options'][$value]['label'];
+          break;
         }
+
       case 'StateProvince':
       case 'Country':
 


### PR DESCRIPTION
Calling a report with a CustomField as type 'Select' which has dynamic data inside, does not render it at all (renders empty), even though the value is properly stored inside the DB. While MySQL query returns the results , CRM/Report/Form is unable to translate this into a label, thus returning null.
Issue appears with CustomFields of type Select.

---

 * [CRM-19637: Showing Custom data options in report criteria problem - Part \#2](https://issues.civicrm.org/jira/browse/CRM-19637)