### PR TITLE
CRM-19226: Fix loginUrl token in drupal

### DIFF
--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -163,8 +163,7 @@ class CRM_Utils_System_Drupal extends CRM_Utils_System_DrupalBase {
    */
   public function getLoginURL($destination = '') {
     $query = $destination ? array('destination' => $destination) : NULL;
-    $loginURL = CRM_Utils_System::url('user', $query, TRUE);
-    return $loginURL;
+    return CRM_Utils_System::url('user', $query, TRUE);
   }
 
   /**

--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -162,8 +162,9 @@ class CRM_Utils_System_Drupal extends CRM_Utils_System_DrupalBase {
    * @inheritDoc
    */
   public function getLoginURL($destination = '') {
-    $query = $destination ? array('destination' => $destination) : array();
-    return url('user', array('query' => $query), TRUE);
+    $query = $destination ? array('destination' => $destination) : NULL;
+    $loginURL = CRM_Utils_System::url('user', $query, TRUE);
+    return $loginURL;
   }
 
   /**


### PR DESCRIPTION
* [CRM-19226: $loginUrl token not populating in Drupal 7](https://issues.civicrm.org/jira/browse/CRM-19226)