### PR TITLE
CRM-19298 further fix on templates.

### DIFF
--- a/CRM/Upgrade/4.7.14.msg_template/message_templates/membership_online_receipt_html.tpl
+++ b/CRM/Upgrade/4.7.14.msg_template/message_templates/membership_online_receipt_html.tpl
@@ -91,8 +91,7 @@
          {$membership_amount|crmMoney}
         </td>
        </tr>
-       {if $amount}
-        {if ! $is_separate_payment }
+       {if $amount && !$is_separate_payment}
          <tr>
           <td {$labelStyle}>
            {ts}Contribution Amount{/ts}
@@ -101,13 +100,12 @@
            {$amount|crmMoney}
           </td>
          </tr>
-       {/if}
          <tr>
-          <td {$labelStyle}>
-             {ts}Total{/ts}
+           <td {$labelStyle}>
+            {ts}Total{/ts}
            </td>
            <td {$valueStyle}>
-             {$amount+$membership_amount|crmMoney}
+            {$amount+$membership_amount|crmMoney}
            </td>
          </tr>
        {/if}

--- a/CRM/Upgrade/4.7.14.msg_template/message_templates/membership_online_receipt_text.tpl
+++ b/CRM/Upgrade/4.7.14.msg_template/message_templates/membership_online_receipt_text.tpl
@@ -30,12 +30,10 @@
 ===========================================================
 {if !$useForMember && $membership_amount && $is_quick_config}
 {ts 1=$membership_name}%1 Membership{/ts}: {$membership_amount|crmMoney}
-{if $amount}
-{if ! $is_separate_payment }
+{if $amount && !$is_separate_payment }
 {ts}Contribution Amount{/ts}: {$amount|crmMoney}
 -------------------------------------------
 {ts}Total{/ts}: {$amount+$membership_amount|crmMoney}
-{/if}
 {/if}
 {elseif !$useForMember && $lineItem and $priceSetID & !$is_quick_config}
 {foreach from=$lineItem item=value key=priceset}

--- a/xml/templates/message_templates/membership_online_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_online_receipt_html.tpl
@@ -91,8 +91,7 @@
          {$membership_amount|crmMoney}
         </td>
        </tr>
-       {if $amount}
-        {if ! $is_separate_payment }
+       {if $amount && !$is_separate_payment }
          <tr>
           <td {$labelStyle}>
            {ts}Contribution Amount{/ts}
@@ -109,8 +108,7 @@
             {$amount+$membership_amount|crmMoney}
            </td>
          </tr>
-        {/if}
-      {/if}
+       {/if}
 
       {elseif !$useForMember && $lineItem and $priceSetID and !$is_quick_config}
 

--- a/xml/templates/message_templates/membership_online_receipt_text.tpl
+++ b/xml/templates/message_templates/membership_online_receipt_text.tpl
@@ -30,12 +30,10 @@
 ===========================================================
 {if !$useForMember && $membership_amount && $is_quick_config}
 {ts 1=$membership_name}%1 Membership{/ts}: {$membership_amount|crmMoney}
-{if $amount}
-{if ! $is_separate_payment }
+{if $amount && !$is_separate_payment }
 {ts}Contribution Amount{/ts}: {$amount|crmMoney}
 -------------------------------------------
 {ts}Total{/ts}: {$amount+$membership_amount|crmMoney}
-{/if}
 {/if}
 {elseif !$useForMember && $lineItem and $priceSetID & !$is_quick_config}
 {foreach from=$lineItem item=value key=priceset}


### PR DESCRIPTION
Upgrade version did not seem to have an if ending in the right place. Also, simplify 2 if
statements to one

---

 * [CRM-19298: Membership fee amount doubled in receipt when 'separate membership payment' is configured](https://issues.civicrm.org/jira/browse/CRM-19298)