### PR TITLE
CRM-18248 - Set quietMillis to 300 for EntityRef ajax

### DIFF
--- a/js/Common.js
+++ b/js/Common.js
@@ -443,6 +443,7 @@ if (!CRM.vars) CRM.vars = {};
         // Use select2 ajax helper instead of CRM.api3 because it provides more value
         ajax: {
           url: CRM.url('civicrm/ajax/rest'),
+          quietMillis: 300,
           data: function (input, page_num) {
             var params = getEntityRefApiParams($el);
             params.input = input;

--- a/templates/CRM/Custom/Form/ContactReference.tpl
+++ b/templates/CRM/Custom/Form/ContactReference.tpl
@@ -35,6 +35,7 @@
       minimumInputLength: 1,
       ajax: {
         url: {/literal}"{$customUrls.$element_name}"{literal},
+        quietMillis: 300,
         data: function(term) {
           return {term: term};
         },


### PR DESCRIPTION
* [CRM-18248: Performance - select2 based contact autocomplete spams the DB server with potentially long running queries](https://issues.civicrm.org/jira/browse/CRM-18248)