### PR TITLE
CRM-19725 CiviContribute: exclude donor from potential honoree dedupe matches

### DIFF
--- a/CRM/Contribute/BAO/ContributionSoft.php
+++ b/CRM/Contribute/BAO/ContributionSoft.php
@@ -155,7 +155,13 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
       $profileContactType = CRM_Core_BAO_UFGroup::getContactType($form->_values['honoree_profile_id']);
       $dedupeParams = CRM_Dedupe_Finder::formatParams($params['honor'], $profileContactType);
       $dedupeParams['check_permission'] = FALSE;
-      $ids = CRM_Dedupe_Finder::dupesByParams($dedupeParams, $profileContactType);
+      // honoree should never be the donor
+      $exceptKeys = array(
+        'contactID' => 0,
+        'onbehalf_contact_id' => 0,
+      );
+      $except = array_values(array_intersect_key($params, $exceptKeys));
+      $ids = CRM_Dedupe_Finder::dupesByParams($dedupeParams, $profileContactType, 'Unsupervised', $except);
       if (count($ids)) {
         $honorId = CRM_Utils_Array::value(0, $ids);
       }


### PR DESCRIPTION
Uses the handy `$except` argument from `CRM_Dedupe_Finder::dupesByParams()` to do it.

---

 * [CRM-19725: Honoree should never be same as donor](https://issues.civicrm.org/jira/browse/CRM-19725)