### PR TITLE
Make clearMessages() clear all (not just one) message per default.

### DIFF
--- a/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
@@ -165,7 +165,7 @@ class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
     $this->_contributionPageID = NULL;
 
     $this->setupMembershipRecurringPaymentProcessorTransaction(array('is_email_receipt' => TRUE));
-    $mut->clearMessages(99999);
+    $mut->clearMessages();
     $IPN = new CRM_Core_Payment_AuthorizeNetIPN($this->getRecurTransaction(array('x_trans_id' => 'hers')));
     $IPN->main();
 

--- a/tests/phpunit/CiviTest/CiviMailUtils.php
+++ b/tests/phpunit/CiviTest/CiviMailUtils.php
@@ -331,12 +331,13 @@ class CiviMailUtils extends PHPUnit_Framework_TestCase {
    * Remove any sent messages from the log.
    *
    * @param int $limit
+   *  How many recent messages to remove, defaults to 0 (all).
    *
    * @throws \Exception
    */
-  public function clearMessages($limit = 1) {
+  public function clearMessages($limit = 0) {
     if ($this->_webtest) {
-      throw new Exception("Not implementated: clearMessages for WebTest");
+      throw new Exception("Not implemented: clearMessages for WebTest");
     }
     else {
       CRM_Core_DAO::executeQuery('DELETE FROM civicrm_mailing_spool ORDER BY id DESC LIMIT ' . $limit);

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -379,7 +379,7 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
       )
     );
     $mut->stop();
-    $mut->clearMessages(999);
+    $mut->clearMessages();
   }
 
   /**
@@ -453,7 +453,7 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
       )
     );
     $mut->stop();
-    $mut->clearMessages(999);
+    $mut->clearMessages();
   }
 
   /**


### PR DESCRIPTION
Make clearMessages() clear all (not just one) message per default.
Also minor typo fix in exception message.

CRM-19726

---

 * [CRM-19726: CiviMailUtils::clearMessages\(\) should clear all messages by default](https://issues.civicrm.org/jira/browse/CRM-19726)