### PR TITLE
 CRM-19718 Activities: make priority_id available for profiles

### DIFF
--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -2222,6 +2222,9 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
     elseif ($fieldName == 'activity_date_time') {
       $form->addDateTime($name, $title, $required, array('formatType' => 'activityDateTime'));
     }
+    elseif ($fieldName == 'priority_id') {
+      $form->add('select', $name, $title, CRM_Activity_BAO_Activity::buildOptions('priority_id'), $required, $selectAttributes);
+    }
     elseif ($fieldName == 'participant_status') {
       $cond = NULL;
       if ($online == TRUE) {

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -335,7 +335,7 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
       $query .= " AND $permissionClause ";
     }
 
-    if ($orderProfiles AND count($profileIds) > 1) {
+    if ($orderProfiles && count($profileIds) > 1) {
       $query .= " ORDER BY FIELD(  g.id, {$gids} )";
     }
     $group = CRM_Core_DAO::executeQuery($query, $params);
@@ -453,9 +453,9 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
 
     $addressCustom = FALSE;
     if (in_array($permissionType, array(
-        CRM_Core_Permission::CREATE,
-        CRM_Core_Permission::EDIT,
-      )) &&
+      CRM_Core_Permission::CREATE,
+      CRM_Core_Permission::EDIT,
+    )) &&
       in_array($field->field_name, array_keys($addressCustomFields))
     ) {
       $addressCustom = TRUE;
@@ -1877,9 +1877,9 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
       $form->addChainSelect($name, array('label' => $title, 'required' => $required));
       $config = CRM_Core_Config::singleton();
       if (!in_array($mode, array(
-          CRM_Profile_Form::MODE_EDIT,
-          CRM_Profile_Form::MODE_SEARCH,
-        )) &&
+        CRM_Profile_Form::MODE_EDIT,
+        CRM_Profile_Form::MODE_SEARCH,
+      )) &&
         $config->defaultContactStateProvince
       ) {
         $defaultValues[$name] = $config->defaultContactStateProvince;
@@ -1890,9 +1890,9 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
       $form->add('select', $name, $title, array('' => ts('- select -')) + CRM_Core_PseudoConstant::country(), $required, $selectAttributes);
       $config = CRM_Core_Config::singleton();
       if (!in_array($mode, array(
-          CRM_Profile_Form::MODE_EDIT,
-          CRM_Profile_Form::MODE_SEARCH,
-        )) &&
+        CRM_Profile_Form::MODE_EDIT,
+        CRM_Profile_Form::MODE_SEARCH,
+      )) &&
         $config->defaultContactCountry
       ) {
         $defaultValues[$name] = $config->defaultContactCountry;
@@ -2030,11 +2030,11 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
       $profileType = CRM_Core_BAO_UFField::getProfileType($gId, TRUE, FALSE, TRUE);
 
       if (empty($profileType) || in_array($profileType, array(
-          'Contact',
-          'Contribution',
-          'Participant',
-          'Membership',
-        ))
+        'Contact',
+        'Contribution',
+        'Participant',
+        'Membership',
+      ))
       ) {
         $profileType = 'Individual';
       }
@@ -2164,10 +2164,10 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
       $contributionStatuses = CRM_Contribute_PseudoConstant::contributionStatus();
       $statusName = CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name');
       foreach (array(
-                 'In Progress',
-                 'Overdue',
-                 'Refunded',
-               ) as $suppress) {
+        'In Progress',
+        'Overdue',
+        'Refunded',
+      ) as $suppress) {
         unset($contributionStatuses[CRM_Utils_Array::key($suppress, $statusName)]);
       }
 

--- a/xml/schema/Activity/Activity.xml
+++ b/xml/schema/Activity/Activity.xml
@@ -266,6 +266,7 @@
     <name>priority_id</name>
     <type>int unsigned</type>
     <title>Priority</title>
+    <import>true</import>
     <comment>ID of the priority given to this activity. Foreign key to civicrm_option_value.</comment>
     <add>2.0</add>
     <pseudoconstant>


### PR DESCRIPTION
* [CRM-19718: Allow activity Priority field to be included in profiles](https://issues.civicrm.org/jira/browse/CRM-19718)