### PR TITLE
Correct code docs for CRM_Core_Menu::get()

### DIFF
--- a/CRM/Core/Menu.php
+++ b/CRM/Core/Menu.php
@@ -625,10 +625,10 @@ class CRM_Core_Menu {
 
   /**
    * @param $path string
-   *  Path of menu item to retrieve.
+   *   Path of menu item to retrieve.
    *
    * @return array
-   *  Menu entry array.
+   *   Menu entry array.
    */
   public static function get($path) {
     // return null if menu rebuild

--- a/CRM/Core/Menu.php
+++ b/CRM/Core/Menu.php
@@ -624,9 +624,11 @@ class CRM_Core_Menu {
   }
 
   /**
-   * @param $path
+   * @param $path string
+   *  Path of menu item to retrieve.
    *
-   * @return null
+   * @return array
+   *  Menu entry array.
    */
   public static function get($path) {
     // return null if menu rebuild


### PR DESCRIPTION
a `get()` method which is documented as `@return null` eh ...

I could almost believe in such a thing. `CRM_Utils_Core::getPseudoNullObject()` maybe? 😜 

Anyway, this one returns an array, so updating phpdocs.