### PR TITLE
CRM-19856 Fix Drupal 8 get User url

### DIFF
--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -252,7 +252,7 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
           'cms:view user account',
         ))
     ) {
-      return url('user/' . $uid);
+      return $this->url('user/' . $uid);
     };
   }
 


### PR DESCRIPTION
* [CRM-19856: Get User record url fails in Drupal 8](https://issues.civicrm.org/jira/browse/CRM-19856)