### PR TITLE
CRM-19717: remove inline edit of class from reserved participant status

### DIFF
--- a/templates/CRM/Admin/Page/ParticipantStatusType.tpl
+++ b/templates/CRM/Admin/Page/ParticipantStatusType.tpl
@@ -48,7 +48,7 @@
        <tr id="participant_status_type-{$row.id}" class="crm-entity crm-participant_{$row.id} {cycle values="odd-row,even-row"} {$row.class}{if NOT $row.is_active} disabled{/if}">
           <td class="crmf-label crm-editable" data-field="label">{$row.label}</td>
           <td class="crmf-name">{$row.name} ({$row.id})</td>
-          <td class="crmf-class crm-editable" data-type="select">{$row.class}</td>
+          <td class="crmf-class {if !$row.is_reserved} crm-editable {/if}" data-type="select">{$row.class}</td>
           <td class="center crmf-is_reserved">{if $row.is_reserved}<img src="{$config->resourceBase}i/check.gif" alt="{ts}Reserved{/ts}" />{/if}</td>
         <td id="row_{$row.id}_status" class="crmf-is_active">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
           <td class="center crmf-is_counted">{if $row.is_counted} <img src="{$config->resourceBase}i/check.gif" alt="{ts}Counted{/ts}" />{/if}</td>


### PR DESCRIPTION

As per [code written here](https://github.com/civicrm/civicrm-core/blob/master/CRM/Event/Form/Registration/Confirm.php#L558) a `class = Pending` check is performed for pay later. Modification of this class for reserved status breaks the registration process.


* [CRM-19717: Event registration impossible with "Pending from pay later" status being "positive"](https://issues.civicrm.org/jira/browse/CRM-19717)