### PR TITLE
CRM-19744 Bugfix get_options_from_params in api utils

### DIFF
--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -813,12 +813,6 @@ function _civicrm_api3_get_options_from_params(&$params, $queryObject = FALSE, $
       $returnProperties[$lowercase_entity . '_id'] = 1;
       unset($returnProperties['id']);
     }
-    switch (trim(strtolower($sort))) {
-      case 'id':
-      case 'id desc':
-      case 'id asc':
-        $sort = str_replace('id', $lowercase_entity . '_id', $sort);
-    }
   }
 
   $options = array(
@@ -828,10 +822,19 @@ function _civicrm_api3_get_options_from_params(&$params, $queryObject = FALSE, $
     'return' => !empty($returnProperties) ? $returnProperties : array(),
   );
 
-  $finalSort = array();
   $options['sort'] = NULL;
   if (!empty($sort)) {
+    $finalSort = array();
     foreach ((array) $sort as $s) {
+      // qualify any sorting by id to the original entity request
+      if ($entity && $action == 'get') {
+        switch (trim(strtolower($s))) {
+          case 'id':
+          case 'id desc':
+          case 'id asc':
+            $s = str_replace('id', $lowercase_entity . '_id', $s);
+        }
+      }
       if (CRM_Utils_Rule::mysqlOrderBy($s)) {
         $finalSort[] = $s;
       }


### PR DESCRIPTION
This is the underlying cause of CRM-19742, about how the api handles sort array values that include unqualified id when there is more than one entity involved.

Should get backported to 4.6 if we're sure it doesn't have unexpected side-effects.

For example - 19742 was actually triggered by some code improvements in here.

---

 * [CRM-19744: Bad handling of array arguments to sort in api](https://issues.civicrm.org/jira/browse/CRM-19744)
 * [CRM-19742: Unable to view or edit recurring contributions](https://issues.civicrm.org/jira/browse/CRM-19742)