### PR TITLE
Correct labelling of new Short Date format

### DIFF
--- a/settings/Localization.setting.php
+++ b/settings/Localization.setting.php
@@ -361,7 +361,7 @@ return array(
       'maxlength' => '60',
     ),
     'default' => '%m/%d/%Y',
-    'title' => 'Date Format: Short date Day Month Year',
+    'title' => 'Date Format: Short date Month Day Year',
     'description' => '',
   ),
   'dateInputFormat' => array(


### PR DESCRIPTION
New date field is %m/%d/%Y, but label was Day Month Year. Fixing label.

CRM-19490

---

 * [CRM-19490: Profile date fields don't respect localisation on the Contribution Page confirmation screen](https://issues.civicrm.org/jira/browse/CRM-19490)