### PR TITLE
Fix regression in CRM-19490 where input field wasn't being properly set

### DIFF
--- a/templates/CRM/UF/Form/Block.tpl
+++ b/templates/CRM/UF/Form/Block.tpl
@@ -124,8 +124,12 @@
               ( $form.formName neq 'Confirm' )  AND
               ( $form.formName neq 'ThankYou' ) }
                 {include file="CRM/common/jcalendar.tpl" elementName=$n}
-              {elseif ( $n|substr:-5:5 eq '_date' )}
-                {$form.$n.value|date_format:"%Y-%m-%d"|crmDate:$config->dateformatshortdate}
+              {elseif ( $n|substr:-5:5 eq '_date' ) }
+                {assign var="date_value" value=$form.$n.value}
+                <span class="crm-frozen-field">
+                  {$date_value|date_format:"%Y-%m-%d"|crmDate:$config->dateformatshortdate}
+                  <input type="hidden" name="{$form.$n.name}" value="{$form.$n.value}" id="{$form.$n.name}">
+                </span>
               {elseif $n|substr:0:5 eq 'phone'}
                 {assign var="phone_ext_field" value=$n|replace:'phone':'phone_ext'}
                 {if $prefix}{$form.$prefix.$n.html}{else}{$form.$n.html}{/if}


### PR DESCRIPTION
* [CRM-19490: Profile date fields don't respect localisation on the Contribution Page confirmation screen](https://issues.civicrm.org/jira/browse/CRM-19490)