### PR TITLE
CRM-19755 reverse order of html and text

### DIFF
--- a/templates/CRM/Mailing/Form/Component.tpl
+++ b/templates/CRM/Mailing/Form/Component.tpl
@@ -30,8 +30,8 @@
     <tr class="crm-mailing-component-form-block-name"><td class="label">{$form.name.label}</td><td>{$form.name.html}</td>
     <tr class="crm-mailing-component-form-block-component_type"><td class="label">{$form.component_type.label}</td><td>{$form.component_type.html}</td>
     <tr class="crm-mailing-component-form-block-subject"><td class="label">{$form.subject.label}</td><td>{$form.subject.html}</td>
-    <tr class="crm-mailing-component-form-block-body_text"><td class="label">{$form.body_text.label}</td><td>{$form.body_text.html}</td>
     <tr class="crm-mailing-component-form-block-body_html"><td class="label">{$form.body_html.label}</td><td>{$form.body_html.html}</td>
+    <tr class="crm-mailing-component-form-block-body_text"><td class="label">{$form.body_text.label}</td><td>{$form.body_text.html}</td>
     <tr class="crm-mailing-component-form-block-is_default"><td class="label">{$form.is_default.label}</td><td>{$form.is_default.html}</td>
     <tr class="crm-mailing-component-form-block-is_active"><td class="label">{$form.is_active.label}</td><td>{$form.is_active.html}</td>
   </table>

--- a/templates/CRM/Mailing/Page/Component.tpl
+++ b/templates/CRM/Mailing/Page/Component.tpl
@@ -49,8 +49,8 @@
            <td class="crm-editable" data-field="name">{$row.name}</td>
            <td>{$row.component_type}</td>
            <td>{$row.subject}</td>
-           <td>{$row.body_text|escape}</td>
            <td>{$row.body_html|escape}</td>
+           <td>{$row.body_text|escape}</td>
            <td>{if $row.is_default eq 1}<img src="{$config->resourceBase}i/check.gif" alt="{ts}Default{/ts}" />{/if}&nbsp;</td>
      <td id="row_{$row.id}_status">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
            <td>{$row.action|replace:'xx':$row.id}</td>

--- a/templates/CRM/Mailing/Page/Component.tpl
+++ b/templates/CRM/Mailing/Page/Component.tpl
@@ -38,8 +38,8 @@
         <th>{ts}Name{/ts}</th>
         <th>{ts}Type{/ts}</th>
         <th>{ts}Subject{/ts}</th>
-        <th>{ts}Body Text{/ts}</th>
         <th>{ts}Body HTML{/ts}</th>
+        <th>{ts}Body Text{/ts}</th>
         <th>{ts}Default?{/ts}</th>
         <th>{ts}Enabled?{/ts}</th>
         <th></th>


### PR DESCRIPTION
Make order same as rest of CiviMail

---

 * [CRM-19755: reverse order of html and text on CRM\/Mailing\/Page\/Component.php](https://issues.civicrm.org/jira/browse/CRM-19755)