### PR TITLE
CRM-19333 - Advanced Search issue when searching using Group Type(s)

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -1802,7 +1802,9 @@ class CRM_Contact_BAO_Query {
         $values[1] = 'IN';
         $this->_paramLookup['group'][0][0] = 'group';
         $this->_paramLookup['group'][0][1] = 'IN';
-        $this->_paramLookup['group'][0][2] = $values[2] = $this->getGroupsFromTypeCriteria($value);
+        $this->_paramLookup['group'][0][2] = $this->getGroupsFromTypeCriteria($value);
+        $this->_paramLookup['group'][0][3] = $grouping;
+        $this->_paramLookup['group'][0][4] = $wildcard;
         $this->group($values);
         return;
 


### PR DESCRIPTION
See https://issues.civicrm.org/jira/browse/CRM-19333 for more details about the issue.

Previously $values[2] was containing an array for building WHERE query by Group Types:
```
array(5) {
  [0]=>
  string(10) "group_type"
  [1]=>
  string(2) "IN"
  [2]=>
  array(2) {  // Group Types IDs
    [0]=>
    string(1) "1"
    [1]=>
    string(1) "2"
  }
  [3]=>
  int(0)
  [4]=>
  int(0)
}
```
and then it was replaced by assigning $this->getGroupsFromTypeCriteria($value) to it:
```
array(4) {
  [1]=>
  string(14) "Administrators"
  [4]=>
  string(14) "Advisory Board"
  [2]=>
  string(22) "Newsletter Subscribers"
  [3]=>
  string(25) "Summer Program Volunteers"
}
```

This was causing SQL syntax error as the strings above were inserted into SQL query:
`WHERE ( ( ( `civicrm_group_contact-Administrators,Advisory Board,Newsletter Subscribers,Summer Program Volunteers`.group_id **IN ( Administrators,Advisory Board,Newsletter Subscribers,Summer Program Volunteers )** )`


This PR covers:
- Modifying whereClauseSingle() method for 'group_type' case to fix Group Type names listing as labels instead of IDs in SQL query.
- Fixing 'Undefined offset' notices by defining values for missing elements of _paramLookup array.

