### PR TITLE
tools/scripts/phpunit-ls - Fix PhpStorm lookup of PHPUnit_Framework_TestCase

### DIFF
--- a/tools/scripts/phpunit-ls
+++ b/tools/scripts/phpunit-ls
@@ -9,9 +9,12 @@ if (!class_exists('PHPUnit_Framework_TestCase')) {
   // but the scanner will try to read metadata about our test-classes, and
   // that requires having the parent-classes defined.
 
+  // Note: Use eval() to prevent IDE scanners from tripping up on this.
+  eval('
   class PHPUnit_Framework_TestCase {}
   class PHPUnit_Extensions_Database_TestCase {}
   class PHPUnit_Extensions_SeleniumTestCase {}
+  \');
 }
 
 \Civi\CiUtil\Command\LsCommand::main($argv);


### PR DESCRIPTION
When using PhpStorm, code completion doesn't work smoothly on classes which
extend `PHPUnit_Framework_TestCase` because there are two copies: the real
copy and then a placeholder class used by `tools/scripts/phpunit-ls`.

Wrapping the placeholder copy in `eval()` prevents PhpStorm from
identifying.