### PR TITLE
CRM-19447 activity details search

### DIFF
--- a/CRM/Activity/BAO/Query.php
+++ b/CRM/Activity/BAO/Query.php
@@ -192,6 +192,10 @@ class CRM_Activity_BAO_Query {
       case 'activity_engagement_level':
       case 'activity_id':
       case 'activity_campaign_id':
+        // We no longer expect "subject" as a specific criteria (as of CRM-19447),
+        // but I'm leaving this case just to reduce the chance of introducing a
+        // regression.
+      case 'activity_subject':
 
         $qillName = $name;
         if (in_array($name, array('activity_engagement_level', 'activity_id'))) {

--- a/CRM/Activity/BAO/Query.php
+++ b/CRM/Activity/BAO/Query.php
@@ -190,7 +190,6 @@ class CRM_Activity_BAO_Query {
       case 'activity_type_id':
       case 'activity_status_id':
       case 'activity_engagement_level':
-      case 'activity_subject':
       case 'activity_id':
       case 'activity_campaign_id':
 
@@ -198,7 +197,7 @@ class CRM_Activity_BAO_Query {
         if (in_array($name, array('activity_engagement_level', 'activity_id'))) {
           $name = $qillName = str_replace('activity_', '', $name);
         }
-        if (in_array($name, array('activity_status_id', 'activity_subject'))) {
+        if (in_array($name, array('activity_status_id'))) {
           $name = str_replace('activity_', '', $name);
           $qillName = str_replace('_id', '', $qillName);
         }
@@ -211,6 +210,12 @@ class CRM_Activity_BAO_Query {
         $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause("civicrm_activity.$name", $op, $value, $dataType);
         list($op, $value) = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Activity_DAO_Activity', $name, $value, $op);
         $query->_qill[$grouping][] = ts('%1 %2 %3', array(1 => $fields[$qillName]['title'], 2 => $op, 3 => $value));
+        break;
+
+      case 'activity':
+      case 'activity_details':
+      case 'activity_subject':
+        self::activity($values, $query);
         break;
 
       case 'activity_type':
@@ -426,7 +431,15 @@ class CRM_Activity_BAO_Query {
       array('entity' => 'activity', 'multiple' => 'multiple', 'option_url' => NULL, 'placeholder' => ts('- any -'))
     );
     $form->setDefaults(array('status_id' => array($activityStatus['Completed'], $activityStatus['Scheduled'])));
-    $form->addElement('text', 'activity_subject', ts('Subject'), CRM_Core_DAO::getAttribute('CRM_Contact_DAO_Contact', 'sort_name'));
+    $form->addElement('text', 'activity', ts('Activity Text'), CRM_Core_DAO::getAttribute('CRM_Contact_DAO_Contact', 'sort_name'));
+    $activity_options = array(
+      2 => ts('Details Only'),
+      3 => ts('Subject Only'),
+      6 => ts('Both'),
+    );
+    $form->addRadio('activity_option', '', $activity_options);
+    $form->setDefaults(array('activity_option' => 6));
+
     $form->addYesNo('activity_test', ts('Activity is a Test?'));
     $activity_tags = CRM_Core_BAO_Tag::getTags('civicrm_activity');
     if ($activity_tags) {
@@ -556,6 +569,48 @@ class CRM_Activity_BAO_Query {
     CRM_Utils_Rule::validDateRange($fields, 'activity_date', $errors, ts('Activity Date'));
 
     return empty($errors) ? TRUE : $errors;
+  }
+
+  /**
+   * Where/qill clause for notes
+   *
+   * @param array $values
+   */
+  public static function activity(&$values, &$query) {
+    list($name, $op, $value, $grouping, $wildcard) = $values;
+
+    $activityOptionValues = $query->getWhereValues('activity_option', $grouping);
+    $activityOption = CRM_Utils_Array::value('2', $activityOptionValues, '6');
+    $activityOption = ($name == 'activity_details') ? 2 : (($name == 'activity_subject') ? 3 : $activityOption);
+
+    $query->_useDistinct = TRUE;
+
+    $strtolower = function_exists('mb_strtolower') ? 'mb_strtolower' : 'strtolower';
+    $n = trim($value);
+    $value = $strtolower(CRM_Core_DAO::escapeString($n));
+    if ($wildcard) {
+      if (strpos($value, '%') === FALSE) {
+        $value = "%$value%";
+      }
+      $op = 'LIKE';
+    }
+    elseif ($op == 'IS NULL' || $op == 'IS NOT NULL') {
+      $value = NULL;
+    }
+
+    $label = NULL;
+    $clauses = array();
+    if ($activityOption % 2 == 0) {
+      $clauses[] = $query->buildClause('civicrm_activity.details', $op, $value, 'String');
+      $label = ts('Activity: Details Only');
+    }
+    if ($activityOption % 3 == 0) {
+      $clauses[] = $query->buildClause('civicrm_activity.subject', $op, $value, 'String');
+      $label = $label ? ts('Activity: Details or Subject') : ts('Activity: Subject Only');
+    }
+    $query->_where[$grouping][] = "( " . implode(' OR ', $clauses) . " )";
+    list($qillOp, $qillVal) = $query->buildQillForFieldValue(NULL, $name, $n, $op);
+    $query->_qill[$grouping][] = ts("%1 %2 %3", array(1 => $label, 2 => $qillOp, 3 => $qillVal));
   }
 
 }

--- a/CRM/Activity/Form/Search.php
+++ b/CRM/Activity/Form/Search.php
@@ -195,6 +195,7 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
       $specialParams = array(
         'activity_type_id',
         'status_id',
+        'activity_text',
       );
       $changeNames = array('status_id' => 'activity_status_id');
       CRM_Contact_BAO_Query::processSpecialFormValue($this->_formValues, $specialParams, $changeNames);

--- a/CRM/Activity/Form/Search.php
+++ b/CRM/Activity/Form/Search.php
@@ -195,8 +195,6 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
       $specialParams = array(
         'activity_type_id',
         'status_id',
-        'activity_subject',
-        'activity_details',
       );
       $changeNames = array('status_id' => 'activity_status_id');
       CRM_Contact_BAO_Query::processSpecialFormValue($this->_formValues, $specialParams, $changeNames);

--- a/CRM/Activity/Form/Search.php
+++ b/CRM/Activity/Form/Search.php
@@ -196,6 +196,7 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
         'activity_type_id',
         'status_id',
         'activity_subject',
+        'activity_details',
       );
       $changeNames = array('status_id' => 'activity_status_id');
       CRM_Contact_BAO_Query::processSpecialFormValue($this->_formValues, $specialParams, $changeNames);

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -1886,10 +1886,8 @@ class CRM_Contact_BAO_Query {
       case 'followup_parent_id':
       case 'parent_id':
       case 'source_contact_id':
-      case 'activity':
+      case 'activity_text':
       case 'activity_option':
-      case 'activity_details':
-      case 'activity_subject':
       case 'test_activities':
       case 'activity_type_id':
       case 'activity_type':

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -1886,6 +1886,9 @@ class CRM_Contact_BAO_Query {
       case 'followup_parent_id':
       case 'parent_id':
       case 'source_contact_id':
+      case 'activity':
+      case 'activity_option':
+      case 'activity_details':
       case 'activity_subject':
       case 'test_activities':
       case 'activity_type_id':
@@ -4262,7 +4265,8 @@ civicrm_relationship.is_permission_a_b = 0
     list($select, $from, $where, $having) = $query->query();
     $groupBy = ($query->_useGroupBy) ? 'GROUP BY contact_a.id' : '';
 
-    return "$select $from $where $groupBy $having";
+    $query = "$select $from $where $groupBy $having";
+    return $query;
   }
 
   /**

--- a/CRM/Contact/Form/Search/Advanced.php
+++ b/CRM/Contact/Form/Search/Advanced.php
@@ -343,6 +343,7 @@ class CRM_Contact_Form_Search_Advanced extends CRM_Contact_Form_Search {
       'activity_type_id',
       'status_id',
       'activity_subject',
+      'activity_details',
       'contribution_page_id',
       'contribution_product_id',
       'payment_instrument_id',

--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -1110,4 +1110,17 @@ class CRM_Core_SelectValues {
     );
   }
 
+  /**
+   * Activity Text options.
+   *
+   * @return array
+   */
+  public static function activityTextOptions() {
+    return array(
+      2 => ts('Details Only'),
+      3 => ts('Subject Only'),
+      6 => ts('Both'),
+    );
+  }
+
 }

--- a/templates/CRM/Activity/Form/Search/Common.tpl
+++ b/templates/CRM/Activity/Form/Search/Common.tpl
@@ -96,8 +96,8 @@
 </tr>
 <tr>
   <td>
-    {$form.activity.label}<br/>
-    {$form.activity.html|crmAddClass:big}<br/>
+    {$form.activity_text.label}<br/>
+    {$form.activity_text.html|crmAddClass:big}<br/>
     {$form.activity_option.html}<br/>
   </td>
   <td colspan="2">

--- a/templates/CRM/Activity/Form/Search/Common.tpl
+++ b/templates/CRM/Activity/Form/Search/Common.tpl
@@ -96,8 +96,9 @@
 </tr>
 <tr>
   <td>
-    {$form.activity_subject.label}<br/>
-    {$form.activity_subject.html|crmAddClass:big}
+    {$form.activity.label}<br/>
+    {$form.activity.html|crmAddClass:big}<br/>
+    {$form.activity_option.html}<br/>
   </td>
   <td colspan="2">
     {$form.status_id.label}<br/>

--- a/tests/phpunit/CRM/Contact/BAO/ActivitySearchTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ActivitySearchTest.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * @file
+ *  File for the ActivitySearchTest class
+ *
+ *  (PHP 5)
+ *
+ * @copyright Copyright CiviCRM LLC (C) 2009
+ * @license   http://www.fsf.org/licensing/licenses/agpl-3.0.html
+ *              GNU Affero General Public License version 3
+ * @package   CiviCRM
+ *
+ *   This file is part of CiviCRM
+ *
+ *   CiviCRM is free software; you can redistribute it and/or
+ *   modify it under the terms of the GNU Affero General Public License
+ *   as published by the Free Software Foundation; either version 3 of
+ *   the License, or (at your option) any later version.
+ *
+ *   CiviCRM is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public
+ *   License along with this program.  If not, see
+ *   <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ *  Include class definitions
+ */
+
+/**
+ * Test APIv3 civicrm_activity_* functions
+ *
+ * @package CiviCRM_APIv3
+ * @subpackage API_Activity
+ * @group headless
+ */
+class CRM_Contact_BAO_ActivitySearchTest extends CiviUnitTestCase {
+  protected $_contactID;
+  protected $_params;
+  protected $test_activity_type_value;
+
+
+  /**
+   * Test setup for every test.
+   *
+   * Connect to the database, truncate the tables that will be used
+   * and redirect stdin to a temporary file
+   */
+  public function setUp() {
+    // Connect to the database
+    parent::setUp();
+
+    $this->_contactID = $this->individualCreate();
+    //create activity types
+    $activityTypes = $this->callAPISuccess('option_value', 'create', array(
+      'option_group_id' => 2,
+      'name' => 'Test activity type',
+      'label' => 'Test activity type',
+      'sequential' => 1,
+    ));
+    $this->test_activity_type_id = $activityTypes['id'];
+    $this->_params = array(
+      'source_contact_id' => $this->_contactID,
+      'activity_type_id' => $activityTypes['values'][0]['value'],
+      'subject' => 'test activity type id',
+      'activity_date_time' => '2011-06-02 14:36:13',
+      'status_id' => 2,
+      'priority_id' => 1,
+      'duration' => 120,
+      'location' => 'Pennsylvania',
+      'details' => 'a test activity',
+    );
+    // create a logged in USER since the code references it for source_contact_id
+    $this->createLoggedInUser();
+  }
+
+  /**
+   * Tears down the fixture, for example, closes a network connection.
+   *
+   * This method is called after a test is executed.
+   */
+  public function tearDown() {
+    $tablesToTruncate = array(
+      'civicrm_contact',
+      'civicrm_activity',
+      'civicrm_activity_contact',
+      'civicrm_uf_match',
+    );
+    $this->quickCleanup($tablesToTruncate, TRUE);
+    $type = $this->callAPISuccess('optionValue', 'get', array('id' => $this->test_activity_type_id));
+    if (!empty($type['count'])) {
+      $this->callAPISuccess('option_value', 'delete', array('id' => $this->test_activity_type_id));
+    }
+  }
+
+  /**
+   * Test that activity.get api works when filtering on subject.
+   */
+  public function testSearchBySubjectOnly() {
+    $subject = 'test activity ' . __FUNCTION__;
+    $params = $this->_params;
+    $params['subject'] = $subject;
+    $activity = $this->callAPISuccess('Activity', 'Create', $params);
+
+    $case = array(
+      'form_value' => array(
+        'activity_text' => $subject,
+        'activity_option' => 3,
+      ),
+      'expected_count' => 1,
+      'expected_contact' => array($this->_contactID),
+    );
+    $query = new CRM_Contact_BAO_Query(CRM_Contact_BAO_Query::convertFormValues($case['form_value']));
+    list($select, $from, $where, $having) = $query->query();
+    $groupContacts = CRM_Core_DAO::executeQuery("SELECT DISTINCT contact_a.id $from $where")->fetchAll();
+    foreach ($groupContacts as $key => $value) {
+      $groupContacts[$key] = $value['id'];
+    }
+    $this->assertEquals($case['expected_count'], count($groupContacts));
+    $this->checkArrayEquals($case['expected_contact'], $groupContacts);
+  }
+
+  /**
+   * Test that activity.get api works when filtering on subject.
+   */
+  public function testSearchBySubjectBoth() {
+    $subject = 'test activity ' . __FUNCTION__;
+    $params = $this->_params;
+    $params['subject'] = $subject;
+    $activity = $this->callAPISuccess('Activity', 'Create', $params);
+
+    $case = array(
+      'form_value' => array(
+        'activity_text' => $subject,
+        'activity_option' => 6,
+      ),
+      'expected_count' => 1,
+      'expected_contact' => array($this->_contactID),
+    );
+    $query = new CRM_Contact_BAO_Query(CRM_Contact_BAO_Query::convertFormValues($case['form_value']));
+    list($select, $from, $where, $having) = $query->query();
+    $groupContacts = CRM_Core_DAO::executeQuery("SELECT DISTINCT contact_a.id $from $where")->fetchAll();
+    foreach ($groupContacts as $key => $value) {
+      $groupContacts[$key] = $value['id'];
+    }
+    $this->assertEquals($case['expected_count'], count($groupContacts));
+    $this->checkArrayEquals($case['expected_contact'], $groupContacts);
+  }
+
+  /**
+   * Test that activity.get api works when filtering on subject.
+   */
+  public function testSearchByDetailsOnly() {
+    $details = 'test activity ' . __FUNCTION__;
+    $params = $this->_params;
+    $params['details'] = $details;
+    $activity = $this->callAPISuccess('Activity', 'Create', $params);
+
+    $case = array(
+      'form_value' => array(
+        'activity_text' => $details,
+        'activity_option' => 2,
+      ),
+      'expected_count' => 1,
+      'expected_contact' => array($this->_contactID),
+    );
+    $query = new CRM_Contact_BAO_Query(CRM_Contact_BAO_Query::convertFormValues($case['form_value']));
+    list($select, $from, $where, $having) = $query->query();
+    $groupContacts = CRM_Core_DAO::executeQuery("SELECT DISTINCT contact_a.id $from $where")->fetchAll();
+    foreach ($groupContacts as $key => $value) {
+      $groupContacts[$key] = $value['id'];
+    }
+    $this->assertEquals($case['expected_count'], count($groupContacts));
+    $this->checkArrayEquals($case['expected_contact'], $groupContacts);
+  }
+
+  /**
+   * Test that activity.get api works when filtering on details.
+   */
+  public function testSearchByDetailsBoth() {
+    $details = 'test activity ' . __FUNCTION__;
+    $params = $this->_params;
+    $params['details'] = $details;
+    $activity = $this->callAPISuccess('Activity', 'Create', $params);
+
+    $case = array(
+      'form_value' => array(
+        'activity_text' => $details,
+        'activity_option' => 6,
+      ),
+      'expected_count' => 1,
+      'expected_contact' => array($this->_contactID),
+    );
+    $query = new CRM_Contact_BAO_Query(CRM_Contact_BAO_Query::convertFormValues($case['form_value']));
+    list($select, $from, $where, $having) = $query->query();
+    $groupContacts = CRM_Core_DAO::executeQuery("SELECT DISTINCT contact_a.id $from $where")->fetchAll();
+    foreach ($groupContacts as $key => $value) {
+      $groupContacts[$key] = $value['id'];
+    }
+    $this->assertEquals($case['expected_count'], count($groupContacts));
+    $this->checkArrayEquals($case['expected_contact'], $groupContacts);
+  }
+
+}

--- a/tests/phpunit/api/v3/ActivityTest.php
+++ b/tests/phpunit/api/v3/ActivityTest.php
@@ -639,6 +639,30 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
     }
   }
 
+  public function testActivityGetSubjectFilter() {
+    $subject = 'test activity ' . __FUNCTION__;
+    $params = $this->_params;
+    $params['subject'] = $subject;
+    $activity = $this->callAPISuccess('Activity', 'Create', $params);
+    $activityget = $this->callAPISuccess('activity', 'getsingle', array(
+      'subject' => $subject,
+      'id' => $activity['id'],
+    ));
+    $this->assertEquals($activityget['subject'], $subject);
+  }
+
+  public function testActivityGetDetailsFilter() {
+    $details = 'test activity ' . __FUNCTION__;
+    $params = $this->_params;
+    $params['details'] = $details;
+    $activity = $this->callAPISuccess('Activity', 'Create', $params);
+    $activityget = $this->callAPISuccess('activity', 'getsingle', array(
+      'details' => $details,
+      'id' => $activity['id'],
+    ));
+    $this->assertEquals($activityget['details'], $details);
+  }
+
   /**
    * test that get functioning does filtering.
    */

--- a/tests/phpunit/api/v3/ActivityTest.php
+++ b/tests/phpunit/api/v3/ActivityTest.php
@@ -639,6 +639,9 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
     }
   }
 
+  /**
+   * Test that activity.get api works when filtering on subject.
+   */
   public function testActivityGetSubjectFilter() {
     $subject = 'test activity ' . __FUNCTION__;
     $params = $this->_params;
@@ -651,6 +654,9 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
     $this->assertEquals($activityget['subject'], $subject);
   }
 
+  /**
+   * Test that activity.get api works when filtering on details.
+   */
   public function testActivityGetDetailsFilter() {
     $details = 'test activity ' . __FUNCTION__;
     $params = $this->_params;


### PR DESCRIPTION
This applies the requested changes from CRM-19447, on both the Activity Search and the Advanced Search.

---

 * [CRM-19447: Improve Activity Subject\/Details text search to be similiar to Notes Subject\/Body](https://issues.civicrm.org/jira/browse/CRM-19447)