### PR TITLE
CRM-19736: PHP 7 Fatal Error on printing labels for members

### DIFF
--- a/CRM/Contact/Form/Task/Label.php
+++ b/CRM/Contact/Form/Task/Label.php
@@ -48,27 +48,34 @@ class CRM_Contact_Form_Task_Label extends CRM_Contact_Form_Task {
    * Build the form object.
    */
   public function buildQuickForm() {
+    self::buildLabelForm($this);
+  }
+
+  /**
+   * Common Function to build Mailing Label Form.
+   */
+  public static function buildLabelForm($form) {
     CRM_Utils_System::setTitle(ts('Make Mailing Labels'));
 
     //add select for label
     $label = CRM_Core_BAO_LabelFormat::getList(TRUE);
 
-    $this->add('select', 'label_name', ts('Select Label'), array('' => ts('- select label -')) + $label, TRUE);
+    $form->add('select', 'label_name', ts('Select Label'), array('' => ts('- select label -')) + $label, TRUE);
 
     // add select for Location Type
-    $this->addElement('select', 'location_type_id', ts('Select Location'),
+    $form->addElement('select', 'location_type_id', ts('Select Location'),
       array(
         '' => ts('Primary'),
       ) + CRM_Core_PseudoConstant::get('CRM_Core_DAO_Address', 'location_type_id'), TRUE
     );
 
     // checkbox for SKIP contacts with Do Not Mail privacy option
-    $this->addElement('checkbox', 'do_not_mail', ts('Do not print labels for contacts with "Do Not Mail" privacy option checked'));
+    $form->addElement('checkbox', 'do_not_mail', ts('Do not print labels for contacts with "Do Not Mail" privacy option checked'));
 
-    $this->add('checkbox', 'merge_same_address', ts('Merge labels for contacts with the same address'), NULL);
-    $this->add('checkbox', 'merge_same_household', ts('Merge labels for contacts belonging to the same household'), NULL);
+    $form->add('checkbox', 'merge_same_address', ts('Merge labels for contacts with the same address'), NULL);
+    $form->add('checkbox', 'merge_same_household', ts('Merge labels for contacts belonging to the same household'), NULL);
 
-    $this->addButtons(array(
+    $form->addButtons(array(
       array(
         'type' => 'submit',
         'name' => ts('Make Mailing Labels'),

--- a/CRM/Member/Form/Task/Label.php
+++ b/CRM/Member/Form/Task/Label.php
@@ -57,7 +57,7 @@ class CRM_Member_Form_Task_Label extends CRM_Member_Form_Task {
    * @return void
    */
   public function buildQuickForm() {
-    CRM_Contact_Form_Task_Label::buildQuickForm($this);
+    CRM_Contact_Form_Task_Label::buildLabelForm($this);
     $this->addElement('checkbox', 'per_membership', ts('Print one label per Membership (rather than per contact)'));
   }
 


### PR DESCRIPTION
* [CRM-19736: Error thrown when printing labels for members](https://issues.civicrm.org/jira/browse/CRM-19736)