### PR TITLE
CRM-19764 - Pass context when fetching custom field options

### DIFF
--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -220,7 +220,7 @@ class CRM_Core_PseudoConstant {
     if (strpos($fieldName, 'custom_') === 0 && is_numeric($fieldName[7])) {
       $customField = new CRM_Core_BAO_CustomField();
       $customField->id = (int) substr($fieldName, 7);
-      $options = $customField->getOptions();
+      $options = $customField->getOptions($context);
       if ($options && $flip) {
         $options = array_flip($options);
       }


### PR DESCRIPTION
* [CRM-19764: Context ignored when fetching custom field options](https://issues.civicrm.org/jira/browse/CRM-19764)