### PR TITLE
Document inconsistent function signature.

### DIFF
--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1418,6 +1418,15 @@ class CRM_Utils_Token {
   /**
    * Replace existing greeting tokens in message/subject.
    *
+   * This function operates by reference, modifying the first parameter. Other
+   * methods for token replacement in this class return the modified string.
+   * This leads to inconsistency in how these methods must be applied.
+   *
+   * @TODO Remove that inconsistency in usage.
+   *
+   * ::replaceContactTokens() may need to be called after this method, to
+   * replace tokens supplied from this method.
+   *
    * @param string $tokenString
    * @param array $contactDetails
    * @param int $contactId


### PR DESCRIPTION
CRM-19768

---

 * [CRM-19768: CRM_Utils_Token::replace\*Tokens\(\) usage is inconsistent](https://issues.civicrm.org/jira/browse/CRM-19768)