### PR TITLE
CRM-19782 - Don't show 'View' link on printed Participant Listing reports

### DIFF
--- a/CRM/Report/Form/Event/ParticipantListing.php
+++ b/CRM/Report/Form/Event/ParticipantListing.php
@@ -758,7 +758,8 @@ ORDER BY  cv.label
         $participantTitle = ts('View Participant Record');
 
         $rows[$rowNum]['civicrm_contact_sort_name_linked'] = "<a title='$contactTitle' href=$url>$displayName</a>";
-        if ($this->_outputMode !== 'csv') {
+        // Add a "View" link to the participant record if this isn't a CSV/PDF/printed document.
+        if ($this->_outputMode !== 'csv' && $this->_outputMode !== 'pdf' && $this->_outputMode !== 'print') {
           $rows[$rowNum]['civicrm_contact_sort_name_linked'] .=
             "<span style='float: right;'><a title='$participantTitle' href=$viewUrl>" .
             ts('View') . "</a></span>";


### PR DESCRIPTION
* [CRM-19782: "View" link on printed Participant Listing Report renders display name unreadable](https://issues.civicrm.org/jira/browse/CRM-19782)