### PR TITLE
CRM-19413 Fix undefined index test_group when testing mailings

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -926,7 +926,7 @@ ORDER BY   {$orderBy}
    * @return void
    */
   public function getTestRecipients($testParams) {
-    if (array_key_exists($testParams['test_group'], CRM_Core_PseudoConstant::group())) {
+    if (!empty($testParams['test_group']) && array_key_exists($testParams['test_group'], CRM_Core_PseudoConstant::group())) {
       $contacts = civicrm_api('contact', 'get', array(
           'version' => 3,
           'group' => $testParams['test_group'],


### PR DESCRIPTION
* [CRM-19413: CiviMail: Test mail notice errors: undefined index](https://issues.civicrm.org/jira/browse/CRM-19413)