### PR TITLE
Accumulated backports for Mosaico support

### DIFF
--- a/CRM/Extension/Browser.php
+++ b/CRM/Extension/Browser.php
@@ -212,8 +212,11 @@ class CRM_Extension_Browser {
    * @return string
    */
   private function grabCachedJson() {
-    $filename = $this->cacheDir . DIRECTORY_SEPARATOR . self::CACHE_JSON_FILE;
-    $json = file_get_contents($filename);
+    $filename = $this->cacheDir . DIRECTORY_SEPARATOR . self::CACHE_JSON_FILE . '.' . md5($this->getRepositoryUrl());
+    $json = NULL;
+    if (file_exists($filename)) {
+      $json = file_get_contents($filename);
+    }
     if (empty($json)) {
       $json = $this->grabRemoteJson();
     }
@@ -242,7 +245,7 @@ class CRM_Extension_Browser {
       return array();
     }
 
-    $filename = $this->cacheDir . DIRECTORY_SEPARATOR . self::CACHE_JSON_FILE;
+    $filename = $this->cacheDir . DIRECTORY_SEPARATOR . self::CACHE_JSON_FILE . '.' . md5($this->getRepositoryUrl());
     $url = $this->getRepositoryUrl() . $this->indexPath;
     $status = CRM_Utils_HttpClient::singleton()->fetch($url, $filename);
     if ($status !== CRM_Utils_HttpClient::STATUS_OK) {

--- a/CRM/Extension/System.php
+++ b/CRM/Extension/System.php
@@ -138,7 +138,7 @@ class CRM_Extension_System {
         if (is_dir($vendorPath)) {
           $containers['cmsvendor'] = new CRM_Extension_Container_Basic(
             $vendorPath,
-            $this->parameters['userFrameworkBaseURL'] . DIRECTORY_SEPARATOR . 'vendor',
+            CRM_Utils_File::addTrailingSlash($this->parameters['userFrameworkBaseURL'], '/') . 'vendor',
             $this->getCache(),
             'cmsvendor'
           );

--- a/CRM/Mailing/ActionTokens.php
+++ b/CRM/Mailing/ActionTokens.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2016                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Class CRM_Mailing_ActionTokens
+ *
+ * Generate "action.*" tokens for mailings.
+ *
+ * To activate these tokens, the TokenProcessor context must specify:
+ * "mailingJobId" (int)
+ * "mailingActionTarget" (array) with keys:
+ *   'id' => int, event queue ID
+ *   'hash' => string, event queue hash code
+ *   'contact_id' => int, contact_id,
+ *   'email' => string, email
+ *   'phone' => string, phone
+ */
+class CRM_Mailing_ActionTokens extends \Civi\Token\AbstractTokenSubscriber {
+
+  /**
+   * Class constructor.
+   */
+  public function __construct() {
+    // TODO: Think about supporting dynamic tokens like "{action.subscribe.\d+}"
+    parent::__construct('action', array(
+      'subscribeUrl' => ts('Subscribe URL (Action)'),
+      'forward' => ts('Forward URL (Action)'),
+      'optOut' => ts('Opt-Out (Action)'),
+      'optOutUrl' => ts('Opt-Out URL (Action)'),
+      'reply' => ts('Reply (Action)'),
+      'unsubscribe' => ts('Unsubscribe (Action)'),
+      'unsubscribeUrl' => ts('Unsubscribe URL (Action)'),
+      'resubscribe' => ts('Resubscribe (Action)'),
+      'resubscribeUrl' => ts('Resubscribe URL (Action)'),
+      'eventQueueId' => ts('Event Queue ID'),
+    ));
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function evaluateToken(
+    \Civi\Token\TokenRow $row,
+    $entity,
+    $field,
+    $prefetch = NULL
+  ) {
+    // Most CiviMail action tokens were implemented via getActionTokenReplacement().
+    // However, {action.subscribeUrl} has a second implementation via
+    // replaceSubscribeInviteTokens(). The two appear mostly the same.
+    // We use getActionTokenReplacement() since it's more consistent. However,
+    // this doesn't provide the dynamic/parameterized tokens of
+    // replaceSubscribeInviteTokens().
+
+    if (empty($row->context['mailingJobId']) || empty($row->context['mailingActionTarget']['hash'])) {
+      throw new \CRM_Core_Exception("Error: Cannot use action tokens unless context defines mailingJobId and mailingActionTarget.");
+    }
+
+    if ($field === 'eventQueueId') {
+      $row->format('text/plain')->tokens($entity, $field, $row->context['mailingActionTarget']['id']);
+      return;
+    }
+
+    list($verp, $urls) = CRM_Mailing_BAO_Mailing::getVerpAndUrls(
+      $row->context['mailingJobId'],
+      $row->context['mailingActionTarget']['id'],
+      $row->context['mailingActionTarget']['hash'],
+      // Note: Behavior is already undefined for SMS/'phone' mailings...
+      $row->context['mailingActionTarget']['email']
+    );
+
+    $row->format('text/plain')->tokens($entity, $field,
+      CRM_Utils_Token::getActionTokenReplacement(
+        $field, $verp, $urls, FALSE));
+    $row->format('text/html')->tokens($entity, $field,
+      CRM_Utils_Token::getActionTokenReplacement(
+        $field, $verp, $urls, TRUE));
+  }
+
+}

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -768,7 +768,7 @@ ORDER BY   i.contact_id, i.{$tempColumn}
    * @return array
    *   reference to an assoc array
    */
-  private function &getTemplates() {
+  public function getTemplates() {
     if (!$this->templates) {
       $this->getHeaderFooter();
       $this->templates = array();
@@ -1063,7 +1063,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
    * @return array
    *   array ref that hold array refs to the verp info, urls, and headers
    */
-  private function getVerpAndUrlsAndHeaders($job_id, $event_queue_id, $hash, $email, $isForward = FALSE) {
+  public function getVerpAndUrlsAndHeaders($job_id, $event_queue_id, $hash, $email, $isForward = FALSE) {
     $config = CRM_Core_Config::singleton();
 
     /**

--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -488,7 +488,7 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
    * @return void
    */
   public function deliver(&$mailer, $testParams = NULL) {
-    if (\Civi::settings()->get('experimentalFlexMailerEngine')) {
+    if (CRM_Core_BAO_Setting::getItem('Mailing Preferences', 'experimentalFlexMailerEngine')) {
       throw new \RuntimeException("Cannot use legacy deliver() when experimentalFlexMailerEngine is enabled");
     }
 

--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -983,9 +983,12 @@ AND    record_type_id = $targetRecordID
   }
 
   /**
+   * Search the mailing-event queue for a list of pending delivery tasks.
+   *
    * @param int $jobId
    * @param string $medium
    *   Ex: 'email' or 'sms'.
+   *
    * @return \CRM_Mailing_Event_BAO_Queue
    *   A query object whose rows provide ('id', 'contact_id', 'hash') and ('email' or 'phone').
    */
@@ -993,7 +996,7 @@ AND    record_type_id = $targetRecordID
     $eq = new CRM_Mailing_Event_BAO_Queue();
     $queueTable = CRM_Mailing_Event_BAO_Queue::getTableName();
     $emailTable = CRM_Core_BAO_Email::getTableName();
-    $phoneTable = CRM_Core_DAO_Phone::getTableName();
+    $phoneTable = CRM_Core_BAO_Phone::getTableName();
     $contactTable = CRM_Contact_BAO_Contact::getTableName();
     $deliveredTable = CRM_Mailing_Event_BAO_Delivered::getTableName();
     $bounceTable = CRM_Mailing_Event_BAO_Bounce::getTableName();

--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -488,57 +488,6 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
     $mailing->find(TRUE);
     $mailing->free();
 
-    $eq = new CRM_Mailing_Event_BAO_Queue();
-    $eqTable = CRM_Mailing_Event_BAO_Queue::getTableName();
-    $emailTable = CRM_Core_BAO_Email::getTableName();
-    $phoneTable = CRM_Core_DAO_Phone::getTableName();
-    $contactTable = CRM_Contact_BAO_Contact::getTableName();
-    $edTable = CRM_Mailing_Event_BAO_Delivered::getTableName();
-    $ebTable = CRM_Mailing_Event_BAO_Bounce::getTableName();
-
-    $query = "  SELECT      $eqTable.id,
-                                $emailTable.email as email,
-                                $eqTable.contact_id,
-                                $eqTable.hash,
-                                NULL as phone
-                    FROM        $eqTable
-                    INNER JOIN  $emailTable
-                            ON  $eqTable.email_id = $emailTable.id
-                    INNER JOIN  $contactTable
-                            ON  $contactTable.id = $emailTable.contact_id
-                    LEFT JOIN   $edTable
-                            ON  $eqTable.id = $edTable.event_queue_id
-                    LEFT JOIN   $ebTable
-                            ON  $eqTable.id = $ebTable.event_queue_id
-                    WHERE       $eqTable.job_id = " . $this->id . "
-                        AND     $edTable.id IS null
-                        AND     $ebTable.id IS null
-                        AND    $contactTable.is_opt_out = 0";
-
-    if ($mailing->sms_provider_id) {
-      $query = "
-                    SELECT      $eqTable.id,
-                                $phoneTable.phone as phone,
-                                $eqTable.contact_id,
-                                $eqTable.hash,
-                                NULL as email
-                    FROM        $eqTable
-                    INNER JOIN  $phoneTable
-                            ON  $eqTable.phone_id = $phoneTable.id
-                    INNER JOIN  $contactTable
-                            ON  $contactTable.id = $phoneTable.contact_id
-                    LEFT JOIN   $edTable
-                            ON  $eqTable.id = $edTable.event_queue_id
-                    LEFT JOIN   $ebTable
-                            ON  $eqTable.id = $ebTable.event_queue_id
-                    WHERE       $eqTable.job_id = " . $this->id . "
-                        AND     $edTable.id IS null
-                        AND     $ebTable.id IS null
-                        AND    ( $contactTable.is_opt_out = 0
-                        OR       $contactTable.do_not_sms = 0 )";
-    }
-    $eq->query($query);
-
     $config = NULL;
 
     if ($config == NULL) {
@@ -567,6 +516,7 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
     $isDelivered = TRUE;
 
     // make sure that there's no more than $config->mailerBatchLimit mails processed in a run
+    $eq = self::findPendingTasks($this->id, $mailing->sms_provider_id ? 'sms' : 'email');
     while ($eq->fetch()) {
       // if ( ( $mailsProcessed % 100 ) == 0 ) {
       // CRM_Utils_System::xMemory( "$mailsProcessed: " );
@@ -1030,6 +980,67 @@ AND    record_type_id = $targetRecordID
     }
 
     return $result;
+  }
+
+  /**
+   * @param int $jobId
+   * @param string $medium
+   *   Ex: 'email' or 'sms'.
+   * @return \CRM_Mailing_Event_BAO_Queue
+   *   A query object whose rows provide ('id', 'contact_id', 'hash') and ('email' or 'phone').
+   */
+  public static function findPendingTasks($jobId, $medium) {
+    $eq = new CRM_Mailing_Event_BAO_Queue();
+    $queueTable = CRM_Mailing_Event_BAO_Queue::getTableName();
+    $emailTable = CRM_Core_BAO_Email::getTableName();
+    $phoneTable = CRM_Core_DAO_Phone::getTableName();
+    $contactTable = CRM_Contact_BAO_Contact::getTableName();
+    $deliveredTable = CRM_Mailing_Event_BAO_Delivered::getTableName();
+    $bounceTable = CRM_Mailing_Event_BAO_Bounce::getTableName();
+
+    $query = "  SELECT      $queueTable.id,
+                                $emailTable.email as email,
+                                $queueTable.contact_id,
+                                $queueTable.hash,
+                                NULL as phone
+                    FROM        $queueTable
+                    INNER JOIN  $emailTable
+                            ON  $queueTable.email_id = $emailTable.id
+                    INNER JOIN  $contactTable
+                            ON  $contactTable.id = $emailTable.contact_id
+                    LEFT JOIN   $deliveredTable
+                            ON  $queueTable.id = $deliveredTable.event_queue_id
+                    LEFT JOIN   $bounceTable
+                            ON  $queueTable.id = $bounceTable.event_queue_id
+                    WHERE       $queueTable.job_id = " . $jobId . "
+                        AND     $deliveredTable.id IS null
+                        AND     $bounceTable.id IS null
+                        AND    $contactTable.is_opt_out = 0";
+
+    if ($medium === 'sms') {
+      $query = "
+                    SELECT      $queueTable.id,
+                                $phoneTable.phone as phone,
+                                $queueTable.contact_id,
+                                $queueTable.hash,
+                                NULL as email
+                    FROM        $queueTable
+                    INNER JOIN  $phoneTable
+                            ON  $queueTable.phone_id = $phoneTable.id
+                    INNER JOIN  $contactTable
+                            ON  $contactTable.id = $phoneTable.contact_id
+                    LEFT JOIN   $deliveredTable
+                            ON  $queueTable.id = $deliveredTable.event_queue_id
+                    LEFT JOIN   $bounceTable
+                            ON  $queueTable.id = $bounceTable.event_queue_id
+                    WHERE       $queueTable.job_id = " . $jobId . "
+                        AND     $deliveredTable.id IS null
+                        AND     $bounceTable.id IS null
+                        AND    ( $contactTable.is_opt_out = 0
+                        OR       $contactTable.do_not_sms = 0 )";
+    }
+    $eq->query($query);
+    return $eq;
   }
 
 }

--- a/CRM/Mailing/Form/Task/AdhocMailing.php
+++ b/CRM/Mailing/Form/Task/AdhocMailing.php
@@ -40,11 +40,14 @@ class CRM_Mailing_Form_Task_AdhocMailing extends CRM_Contact_Form_Task {
 
   public function preProcess() {
     parent::preProcess();
+    $templateTypes = CRM_Mailing_BAO_Mailing::getTemplateTypes();
     list ($groupId, $ssId) = $this->createHiddenGroup();
     $mailing = civicrm_api3('Mailing', 'create', array(
       'name' => "",
       'campaign_id' => NULL,
       'replyto_email' => "",
+      'template_type' => $templateTypes[0]['name'],
+      'template_options' => array('nonce' => 1),
       'subject' => "",
       'body_html' => "",
       'body_text' => "",

--- a/CRM/Mailing/Tokens.php
+++ b/CRM/Mailing/Tokens.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2016                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Class CRM_Mailing_Tokens
+ *
+ * Generate "mailing.*" tokens.
+ *
+ * To activate these tokens, the TokenProcessor context must specify either
+ * "mailingId" (int) or "mailing" (CRM_Mailing_BAO_Mailing).
+ */
+class CRM_Mailing_Tokens extends \Civi\Token\AbstractTokenSubscriber {
+
+  /**
+   * Class constructor.
+   */
+  public function __construct() {
+    parent::__construct('mailing', array(
+      'id' => ts('Mailing ID'),
+      'name' => ts('Mailing Name'),
+      'group' => ts('Mailing Group(s)'),
+      'subject' => ts('Mailing Subject'),
+      'viewUrl' => ts('Mailing URL (View)'),
+      'editUrl' => ts('Mailing URL (Edit)'),
+      'scheduleUrl' => ts('Mailing URL (Schedule)'),
+      'html' => ts('Mailing HTML'),
+      'approvalStatus' => ts('Mailing Approval Status'),
+      'approvalNote' => ts('Mailing Approval Note'),
+      'approveUrl' => ts('Mailing Approval URL'),
+      'creator' => ts('Mailing Creator (Name)'),
+      'creatorEmail' => ts('Mailing Creator (Email)'),
+    ));
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function checkActive(\Civi\Token\TokenProcessor $processor) {
+    return !empty($processor->context['mailingId']) || !empty($processor->context['mailing']);
+  }
+
+  public function prefetch(\Civi\Token\Event\TokenValueEvent $e) {
+    $processor = $e->getTokenProcessor();
+    $mailing = isset($processor->context['mailing'])
+      ? $processor->context['mailing']
+      : CRM_Mailing_BAO_Mailing::findById($processor->context['mailingId']);
+
+    return array(
+      'mailing' => $mailing,
+    );
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function evaluateToken(\Civi\Token\TokenRow $row, $entity, $field, $prefetch = NULL) {
+    $row->format('text/plain')->tokens($entity, $field,
+      (string) CRM_Utils_Token::getMailingTokenReplacement($field, $prefetch['mailing']));
+  }
+
+}

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -1947,6 +1947,31 @@ abstract class CRM_Utils_Hook {
   }
 
   /**
+   * Modify the CiviCRM container - add new services, parameters, extensions, etc.
+   *
+   * @code
+   * use Symfony\Component\Config\Resource\FileResource;
+   * use Symfony\Component\DependencyInjection\Definition;
+   *
+   * function mymodule_civicrm_container($container) {
+   *   $container->addResource(new FileResource(__FILE__));
+   *   $container->setDefinition('mysvc', new Definition('My\Class', array()));
+   * }
+   * @endcode
+   *
+   * Tip: The container configuration will be compiled/cached. The default cache
+   * behavior is aggressive. When you first implement the hook, be sure to
+   * flush the cache. Additionally, you should relax caching during development.
+   * In `civicrm.settings.php`, set define('CIVICRM_CONTAINER_CACHE', 'auto').
+   *
+   * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+   * @see http://symfony.com/doc/current/components/dependency_injection/index.html
+   */
+  public static function container(\Symfony\Component\DependencyInjection\ContainerBuilder $container) {
+    self::singleton()->invoke(1, $container, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_container');
+  }
+
+  /**
    * @param array <CRM_Core_FileSearchInterface> $fileSearches
    * @return mixed
    */

--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -793,4 +793,66 @@ class CRM_Utils_String {
     return ltrim($output);
   }
 
+  /**
+   * Determine if $string starts with $fragment.
+   *
+   * @param string $string
+   *   The long string.
+   * @param string $fragment
+   *   The fragment to look for.
+   * @return bool
+   */
+  public static function startsWith($string, $fragment) {
+    if ($fragment === '') {
+      return TRUE;
+    }
+    $len = strlen($fragment);
+    return substr($string, 0, $len) === $fragment;
+  }
+
+  /**
+   * Determine if $string ends with $fragment.
+   *
+   * @param string $string
+   *   The long string.
+   * @param string $fragment
+   *   The fragment to look for.
+   * @return bool
+   */
+  public static function endsWith($string, $fragment) {
+    if ($fragment === '') {
+      return TRUE;
+    }
+    $len = strlen($fragment);
+    return substr($string, -1 * $len) === $fragment;
+  }
+
+  /**
+   * @param string|array $patterns
+   * @param array $allStrings
+   * @param bool $allowNew
+   *   Whether to return new, unrecognized names.
+   * @return array
+   */
+  public static function filterByWildcards($patterns, $allStrings, $allowNew = FALSE) {
+    $patterns = (array) $patterns;
+    $result = array();
+    foreach ($patterns as $pattern) {
+      if (!\CRM_Utils_String::endsWith($pattern, '*')) {
+        if ($allowNew || in_array($pattern, $allStrings)) {
+          $result[] = $pattern;
+        }
+      }
+      else {
+        $prefix = rtrim($pattern, '*');
+        foreach ($allStrings as $key) {
+          if (\CRM_Utils_String::startsWith($key, $prefix)) {
+            $result[] = $key;
+          }
+        }
+      }
+    }
+    return array_values(array_unique($result));
+  }
+
 }

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1310,7 +1310,7 @@ class CRM_Utils_Token {
    * @return array
    *   contactDetails with hooks swapped out
    */
-  public function getAnonymousTokenDetails($contactIDs = array(
+  public static function getAnonymousTokenDetails($contactIDs = array(
       0,
     ),
                                            $returnProperties = NULL,

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -128,6 +128,10 @@ class Container {
       "CRM_Mailing_Tokens"
     ));//->addTag('kernel.event_subscriber');
 
+    if (\CRM_Utils_Constant::value('CIVICRM_FLEXMAILER_HACK_SERVICES')) {
+      \Civi\Core\Resolver::singleton()->call(CIVICRM_FLEXMAILER_HACK_SERVICES, array($container));
+    }
+
     return $container;
   }
 
@@ -161,6 +165,10 @@ class Container {
     $dispatcher->addSubscriberService('civi_token_compat', 'Civi\Token\TokenCompatSubscriber');
     $dispatcher->addSubscriberService('crm_mailing_tokens', 'CRM_Mailing_Tokens');
     $dispatcher->addSubscriberService('crm_mailing_action_tokens', 'CRM_Mailing_ActionTokens');
+
+    if (\CRM_Utils_Constant::value('CIVICRM_FLEXMAILER_HACK_LISTENERS')) {
+      \Civi\Core\Resolver::singleton()->call(CIVICRM_FLEXMAILER_HACK_LISTENERS, array($dispatcher));
+    }
 
     return $dispatcher;
   }

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -13,6 +13,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher;
 
 // TODO use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
@@ -81,8 +82,8 @@ class Container {
       ->setFactoryService(self::SELF)->setFactoryMethod('createAngularManager');
 
     $container->setDefinition('dispatcher', new Definition(
-      '\Symfony\Component\EventDispatcher\EventDispatcher',
-      array()
+      'Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher',
+      array(new Reference('service_container'))
     ))
       ->setFactoryService(self::SELF)->setFactoryMethod('createEventDispatcher');
 
@@ -117,6 +118,16 @@ class Container {
         ->setFactoryClass($class)->setFactoryMethod('singleton');
     }
 
+    $container->setDefinition('civi_token_compat', new Definition(
+      'Civi\Token\TokenCompatSubscriber'
+    ));//->addTag('kernel.event_subscriber');
+    $container->setDefinition("crm_mailing_action_tokens", new Definition(
+      "CRM_Mailing_ActionTokens"
+    ));//->addTag('kernel.event_subscriber');
+    $container->setDefinition("crm_mailing_tokens", new Definition(
+      "CRM_Mailing_Tokens"
+    ));//->addTag('kernel.event_subscriber');
+
     return $container;
   }
 
@@ -128,10 +139,11 @@ class Container {
   }
 
   /**
-   * @return \Symfony\Component\EventDispatcher\EventDispatcher
+   * @param ContainerInterface $container
+   * @return \Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher
    */
-  public function createEventDispatcher() {
-    $dispatcher = new \Symfony\Component\EventDispatcher\EventDispatcher();
+  public function createEventDispatcher($container) {
+    $dispatcher = new ContainerAwareEventDispatcher($container);
     $dispatcher->addListener('hook_civicrm_post::Activity', array('\Civi\CCase\Events', 'fireCaseChange'));
     $dispatcher->addListener('hook_civicrm_post::Case', array('\Civi\CCase\Events', 'fireCaseChange'));
     $dispatcher->addListener('hook_civicrm_caseChange', array('\Civi\CCase\Events', 'delegateToXmlListeners'));
@@ -143,6 +155,13 @@ class Container {
       'CRM_Core_LegacyErrorHandler',
       'handleException',
     ));
+
+    // Civi v4.6 uses an older version of Symfony Dispatcher which doesn't support
+    // RegisterListenersPass (aka addTag('kernel.event_subscriber').
+    $dispatcher->addSubscriberService('civi_token_compat', 'Civi\Token\TokenCompatSubscriber');
+    $dispatcher->addSubscriberService('crm_mailing_tokens', 'CRM_Mailing_Tokens');
+    $dispatcher->addSubscriberService('crm_mailing_action_tokens', 'CRM_Mailing_ActionTokens');
+
     return $dispatcher;
   }
 

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -132,6 +132,8 @@ class Container {
       \Civi\Core\Resolver::singleton()->call(CIVICRM_FLEXMAILER_HACK_SERVICES, array($container));
     }
 
+    \CRM_Utils_Hook::container($container);
+
     return $container;
   }
 

--- a/Civi/Test.php
+++ b/Civi/Test.php
@@ -1,0 +1,171 @@
+<?php
+namespace Civi;
+
+use PDO;
+use PDOException;
+
+/**
+ * Class Test
+ *
+ * A facade for managing the test environment.
+ */
+class Test {
+
+  /**
+   * @var array
+   */
+  private static $singletons = array();
+
+  /**
+   * Get the data source used for testing.
+   *
+   * @param string|NULL $part
+   *   One of NULL, 'hostspec', 'port', 'username', 'password', 'database'.
+   * @return string|array|NULL
+   *   If $part is omitted, return full DSN array.
+   *   If $part is a string, return that part of the DSN.
+   */
+  public static function dsn($part = NULL) {
+    if (!isset(self::$singletons['dsn'])) {
+      require_once "DB.php";
+      self::$singletons['dsn'] = \DB::parseDSN(CIVICRM_DSN);
+    }
+
+    if ($part === NULL) {
+      return self::$singletons['dsn'];
+    }
+
+    if (isset(self::$singletons['dsn'][$part])) {
+      return self::$singletons['dsn'][$part];
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Get a connection to the test database.
+   *
+   * @return PDO
+   */
+  public static function pdo() {
+    if (!isset(self::$singletons['pdo'])) {
+      $dsninfo = self::dsn();
+      $host = $dsninfo['hostspec'];
+      $port = @$dsninfo['port'];
+      try {
+        self::$singletons['pdo'] = new PDO("mysql:host={$host}" . ($port ? ";port=$port" : ""),
+          $dsninfo['username'], $dsninfo['password'],
+          array(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => TRUE)
+        );
+      }
+      catch (PDOException $e) {
+        echo "Can't connect to MySQL server:" . PHP_EOL . $e->getMessage() . PHP_EOL;
+        exit(1);
+      }
+    }
+    return self::$singletons['pdo'];
+  }
+
+  /**
+   * Create a builder for the headless environment.
+   *
+   * @return \Civi\Test\CiviEnvBuilder
+   *
+   * @code
+   * \Civi\Test::headless()->apply();
+   * \Civi\Test::headless()->sqlFile('ex.sql')->apply();
+   * @endCode
+   */
+  public static function headless() {
+    $civiRoot = dirname(__DIR__);
+    $builder = new \Civi\Test\CiviEnvBuilder('CiviEnvBuilder');
+    $builder
+      ->callback(function ($ctx) {
+        if (CIVICRM_UF !== 'UnitTests') {
+          throw new \RuntimeException("\\Civi\\Test::headless() requires CIVICRM_UF=UnitTests");
+        }
+        $dbName = \Civi\Test::dsn('database');
+        echo "Installing {$dbName} schema\n";
+        \Civi\Test::schema()->dropAll();
+      }, 'headless-drop')
+      ->sqlFile($civiRoot . "/sql/civicrm.mysql")
+      ->sql("DELETE FROM civicrm_extension")
+      ->callback(function ($ctx) {
+        \Civi\Test::data()->populate();
+      }, 'populate');
+    return $builder;
+  }
+
+  /**
+   * Create a builder for end-to-end testing on the live environment.
+   *
+   * @return \Civi\Test\CiviEnvBuilder
+   *
+   * @code
+   * \Civi\Test::e2e()->apply();
+   * \Civi\Test::e2e()->install('foo.bar')->apply();
+   * @endCode
+   */
+  public static function e2e() {
+    $builder = new \Civi\Test\CiviEnvBuilder('CiviEnvBuilder');
+    $builder
+      ->callback(function ($ctx) {
+        if (CIVICRM_UF === 'UnitTests') {
+          throw new \RuntimeException("\\Civi\\Test::e2e() requires a real CMS. Found CIVICRM_UF=UnitTests.");
+        }
+      }, 'e2e-check');
+    return $builder;
+  }
+
+  /**
+   * @return \Civi\Test\Schema
+   */
+  public static function schema() {
+    if (!isset(self::$singletons['schema'])) {
+      self::$singletons['schema'] = new \Civi\Test\Schema();
+    }
+    return self::$singletons['schema'];
+  }
+
+
+  /**
+   * @return \Civi\Test\Data
+   */
+  public static function data() {
+    if (!isset(self::$singletons['data'])) {
+      self::$singletons['data'] = new \Civi\Test\Data('CiviTesterData');
+    }
+    return self::$singletons['data'];
+  }
+
+  /**
+   * Prepare and execute a batch of SQL statements.
+   *
+   * @param string $query
+   * @return bool
+   */
+  public static function execute($query) {
+    $pdo = \Civi\Test::pdo();
+
+    $string = preg_replace("/^#[^\n]*$/m", "\n", $query);
+    $string = preg_replace("/^(--[^-]).*/m", "\n", $string);
+
+    $queries = preg_split('/;\s*$/m', $string);
+    foreach ($queries as $query) {
+      $query = trim($query);
+      if (!empty($query)) {
+        $result = $pdo->query($query);
+        if ($pdo->errorCode() == 0) {
+          continue;
+        }
+        else {
+          var_dump($result);
+          var_dump($pdo->errorInfo());
+          // die( "Cannot execute $query: " . $pdo->errorInfo() );
+        }
+      }
+    }
+    return TRUE;
+  }
+
+}

--- a/Civi/Test/CiviEnvBuilder.php
+++ b/Civi/Test/CiviEnvBuilder.php
@@ -1,0 +1,208 @@
+<?php
+namespace Civi\Test;
+
+use Civi\Test\CiviEnvBuilder\CallbackStep;
+use Civi\Test\CiviEnvBuilder\ExtensionsStep;
+use Civi\Test\CiviEnvBuilder\SqlFileStep;
+use Civi\Test\CiviEnvBuilder\SqlStep;
+use Civi\Test\CiviEnvBuilder\StepInterface;
+use RuntimeException;
+
+/**
+ * Class CiviEnvBuilder
+ *
+ * Provides a fluent interface for tracking a set of steps.
+ * By computing and storing a signature for the list steps, we can
+ * determine whether to (a) do nothing with the list or (b)
+ * reapply all the steps.
+ */
+class CiviEnvBuilder {
+  protected $name;
+
+  private $steps = array();
+
+  /**
+   * @var string|NULL
+   *   A digest of the values in $steps.
+   */
+  private $targetSignature = NULL;
+
+  public function __construct($name) {
+    $this->name = $name;
+  }
+
+  public function addStep(StepInterface $step) {
+    $this->targetSignature = NULL;
+    $this->steps[] = $step;
+    return $this;
+  }
+
+  public function callback($callback, $signature = NULL) {
+    return $this->addStep(new CallbackStep($callback, $signature));
+  }
+
+  public function sql($sql) {
+    return $this->addStep(new SqlStep($sql));
+  }
+
+  public function sqlFile($file) {
+    return $this->addStep(new SqlFileStep($file));
+  }
+
+  /**
+   * Require that an extension be installed.
+   *
+   * @param string|array $names
+   *   One or more extension names. You may use a wildcard '*'.
+   * @return CiviEnvBuilder
+   */
+  public function install($names) {
+    return $this->addStep(new ExtensionsStep('install', $names));
+  }
+
+  /**
+   * Require an extension be installed (identified by its directory).
+   *
+   * @param string $dir
+   *   The current test directory. We'll search for info.xml to
+   *   see what this extension is.
+   * @return CiviEnvBuilder
+   * @throws \CRM_Extension_Exception_ParseException
+   */
+  public function installMe($dir) {
+    return $this->addStep(new ExtensionsStep('install', $this->whoAmI($dir)));
+  }
+
+  /**
+   * Require an extension be uninstalled.
+   *
+   * @param string|array $names
+   *   One or more extension names. You may use a wildcard '*'.
+   * @return CiviEnvBuilder
+   */
+  public function uninstall($names) {
+    return $this->addStep(new ExtensionsStep('uninstall', $names));
+  }
+
+  /**
+   * Require an extension be uninstalled (identified by its directory).
+   *
+   * @param string $dir
+   *   The current test directory. We'll search for info.xml to
+   *   see what this extension is.
+   * @return CiviEnvBuilder
+   * @throws \CRM_Extension_Exception_ParseException
+   */
+  public function uninstallMe($dir) {
+    return $this->addStep(new ExtensionsStep('uninstall', $this->whoAmI($dir)));
+  }
+
+  protected function assertValid() {
+    foreach ($this->steps as $step) {
+      if (!$step->isValid()) {
+        throw new RuntimeException("Found invalid step: " . var_dump($step, 1));
+      }
+    }
+  }
+
+  /**
+   * @return string
+   */
+  protected function getTargetSignature() {
+    if ($this->targetSignature === NULL) {
+      $buf = '';
+      foreach ($this->steps as $step) {
+        $buf .= $step->getSig();
+      }
+      $this->targetSignature = md5($buf);
+    }
+
+    return $this->targetSignature;
+  }
+
+  /**
+   * @return string
+   */
+  protected function getSavedSignature() {
+    $liveSchemaRev = NULL;
+    $pdo = \Civi\Test::pdo();
+    $pdoStmt = $pdo->query(sprintf(
+      "SELECT rev FROM %s.civitest_revs WHERE name = %s",
+      \Civi\Test::dsn('database'),
+      $pdo->quote($this->name)
+    ));
+    foreach ($pdoStmt as $row) {
+      $liveSchemaRev = $row['rev'];
+    }
+    return $liveSchemaRev;
+  }
+
+  /**
+   * @param $newSignature
+   */
+  protected function setSavedSignature($newSignature) {
+    $pdo = \Civi\Test::pdo();
+    $query = sprintf(
+      'INSERT INTO %s.civitest_revs (name,rev) VALUES (%s,%s) '
+      . 'ON DUPLICATE KEY UPDATE rev = %s;',
+      \Civi\Test::dsn('database'),
+      $pdo->quote($this->name),
+      $pdo->quote($newSignature),
+      $pdo->quote($newSignature)
+    );
+
+    if (\Civi\Test::execute($query) === FALSE) {
+      throw new RuntimeException("Failed to flag schema version: $query");
+    }
+  }
+
+  /**
+   * Determine if there's been a change in the preferred configuration.
+   * If the preferred-configuration matches the last test, keep it. Otherwise,
+   * destroy and recreate.
+   *
+   * @param bool $force
+   *   Forcibly execute the build, even if the configuration hasn't changed.
+   *   This will slow-down the tests, but it may be appropriate for some very sloppy
+   *   tests.
+   * @return CiviEnvBuilder
+   */
+  public function apply($force = FALSE) {
+    $dbName = \Civi\Test::dsn('database');
+    $query = "USE {$dbName};"
+      . "CREATE TABLE IF NOT EXISTS civitest_revs (name VARCHAR(64) PRIMARY KEY, rev VARCHAR(64));";
+
+    if (\Civi\Test::execute($query) === FALSE) {
+      throw new \RuntimeException("Failed to flag schema version: $query");
+    }
+
+    $this->assertValid();
+
+    if (!$force && $this->getSavedSignature() === $this->getTargetSignature()) {
+      return $this;
+    }
+    foreach ($this->steps as $step) {
+      $step->run($this);
+    }
+    $this->setSavedSignature($this->getTargetSignature());
+    return $this;
+  }
+
+  /**
+   * @param $dir
+   * @return null
+   * @throws \CRM_Extension_Exception_ParseException
+   */
+  protected function whoAmI($dir) {
+    while ($dir && dirname($dir) !== $dir && !file_exists("$dir/info.xml")) {
+      $dir = dirname($dir);
+    }
+    if (file_exists("$dir/info.xml")) {
+      $info = \CRM_Extension_Info::loadFromFile("$dir/info.xml");
+      $name = $info->key;
+      return $name;
+    }
+    return $name;
+  }
+
+}

--- a/Civi/Test/CiviEnvBuilder/CallbackStep.php
+++ b/Civi/Test/CiviEnvBuilder/CallbackStep.php
@@ -1,0 +1,29 @@
+<?php
+namespace Civi\Test\CiviEnvBuilder;
+class CallbackStep implements StepInterface {
+  private $callback;
+  private $sig;
+
+  /**
+   * CallbackStep constructor.
+   * @param $callback
+   * @param $sig
+   */
+  public function __construct($callback, $sig = NULL) {
+    $this->callback = $callback;
+    $this->sig = $sig === NULL ? md5(var_export($callback, 1)) : $sig;
+  }
+
+  public function getSig() {
+    return $this->sig;
+  }
+
+  public function isValid() {
+    return is_callable($this->callback);
+  }
+
+  public function run($ctx) {
+    call_user_func($this->callback, $ctx);
+  }
+
+}

--- a/Civi/Test/CiviEnvBuilder/ExtensionsStep.php
+++ b/Civi/Test/CiviEnvBuilder/ExtensionsStep.php
@@ -1,0 +1,51 @@
+<?php
+namespace Civi\Test\CiviEnvBuilder;
+class ExtensionsStep implements StepInterface {
+  private $action;
+  private $names;
+
+  /**
+   * ExtensionStep constructor.
+   * @param string $action
+   *   Ex: 'install', 'uninstall'.
+   * @param string|array $names
+   */
+  public function __construct($action, $names) {
+    $this->action = $action;
+    $this->names = (array) $names;
+  }
+
+  public function getSig() {
+    return 'ext:' . implode(',', $this->names);
+  }
+
+  public function isValid() {
+    if (!in_array($this->action, array('install', 'uninstall'))) {
+      return FALSE;
+    }
+    foreach ($this->names as $name) {
+      if (!is_string($name)) {
+        return FALSE;
+      }
+    }
+    return TRUE;
+  }
+
+  public function run($ctx) {
+    $allKeys = \CRM_Extension_System::singleton()->getFullContainer()->getKeys();
+    $names = \CRM_Utils_String::filterByWildcards($this->names, $allKeys, TRUE);
+
+    $manager = \CRM_Extension_System::singleton()->getManager();
+    switch ($this->action) {
+      case 'install':
+        $manager->install($names);
+        break;
+
+      case 'uninstall':
+        $manager->disable($names);
+        $manager->uninstall($names);
+        break;
+    }
+  }
+
+}

--- a/Civi/Test/CiviEnvBuilder/SqlFileStep.php
+++ b/Civi/Test/CiviEnvBuilder/SqlFileStep.php
@@ -1,0 +1,35 @@
+<?php
+namespace Civi\Test\CiviEnvBuilder;
+
+class SqlFileStep implements StepInterface {
+  private $file;
+
+  /**
+   * SqlFileStep constructor.
+   * @param string $file
+   */
+  public function __construct($file) {
+    $this->file = $file;
+  }
+
+
+  public function getSig() {
+    return implode(' ', array(
+      $this->file,
+      filemtime($this->file),
+      filectime($this->file),
+    ));
+  }
+
+  public function isValid() {
+    return is_file($this->file) && is_readable($this->file);
+  }
+
+  public function run($ctx) {
+    /** @var $ctx \CiviEnvBuilder */
+    if (\Civi\Test::execute(@file_get_contents($this->file)) === FALSE) {
+      throw new \RuntimeException("Cannot load {$this->file}. Aborting.");
+    }
+  }
+
+}

--- a/Civi/Test/CiviEnvBuilder/SqlStep.php
+++ b/Civi/Test/CiviEnvBuilder/SqlStep.php
@@ -1,0 +1,30 @@
+<?php
+namespace Civi\Test\CiviEnvBuilder;
+class SqlStep implements StepInterface {
+  private $sql;
+
+  /**
+   * SqlFileStep constructor.
+   * @param string $sql
+   */
+  public function __construct($sql) {
+    $this->sql = $sql;
+  }
+
+
+  public function getSig() {
+    return md5($this->sql);
+  }
+
+  public function isValid() {
+    return TRUE;
+  }
+
+  public function run($ctx) {
+    /** @var $ctx \CiviEnvBuilder */
+    if (\Civi\Test::execute($this->sql) === FALSE) {
+      throw new \RuntimeException("Cannot execute: {$this->sql}");
+    }
+  }
+
+}

--- a/Civi/Test/CiviEnvBuilder/StepInterface.php
+++ b/Civi/Test/CiviEnvBuilder/StepInterface.php
@@ -1,0 +1,11 @@
+<?php
+namespace Civi\Test\CiviEnvBuilder;
+
+interface StepInterface {
+  public function getSig();
+
+  public function isValid();
+
+  public function run($ctx);
+
+}

--- a/Civi/Test/CiviTestListener.php
+++ b/Civi/Test/CiviTestListener.php
@@ -1,0 +1,290 @@
+<?php
+
+namespace Civi\Test;
+
+/**
+ * Class CiviTestListener
+ * @package Civi\Test
+ *
+ * CiviTestListener participates in test-execution, looking for test-classes
+ * which have certain tags. If the tags are found, the listener will perform
+ * additional setup/teardown logic.
+ *
+ * @see EndToEndInterface
+ * @see HeadlessInterface
+ * @see HookInterface
+ */
+class CiviTestListener extends \PHPUnit_Framework_BaseTestListener {
+  /**
+   * @var \CRM_Core_TemporaryErrorScope
+   */
+  private $errorScope;
+
+  /**
+   * @var array
+   *  Ex: $cache['Some_Test_Class']['civicrm_foobar'] = 'hook_civicrm_foobar';
+   *  Array(string $testClass => Array(string $hookName => string $methodName)).
+   */
+  private $cache = array();
+
+  /**
+   * @var \CRM_Core_Transaction|NULL
+   */
+  private $tx;
+
+  public function startTestSuite(\PHPUnit_Framework_TestSuite $suite) {
+    $byInterface = $this->indexTestsByInterface($suite->tests());
+    $this->validateGroups($byInterface);
+    $this->autoboot($byInterface);
+  }
+
+  public function endTestSuite(\PHPUnit_Framework_TestSuite $suite) {
+    $this->cache = array();
+  }
+
+  public function startTest(\PHPUnit_Framework_Test $test) {
+    if ($this->isCiviTest($test)) {
+      error_reporting(E_ALL);
+      $this->errorScope = \CRM_Core_TemporaryErrorScope::useException();
+    }
+
+    if ($test instanceof HeadlessInterface) {
+      $this->bootHeadless($test);
+    }
+
+    if ($test instanceof HookInterface) {
+      // Note: bootHeadless() indirectly resets any hooks, which means that hook_civicrm_config
+      // is unsubscribable. However, after bootHeadless(), we're free to subscribe to hooks again.
+      $this->registerHooks($test);
+    }
+
+    if ($test instanceof TransactionalInterface) {
+      $this->tx = new \CRM_Core_Transaction(TRUE);
+      $this->tx->rollback();
+    }
+    else {
+      $this->tx = NULL;
+    }
+  }
+
+  public function endTest(\PHPUnit_Framework_Test $test, $time) {
+    if ($test instanceof TransactionalInterface) {
+      $this->tx->rollback()->commit();
+      $this->tx = NULL;
+    }
+    if ($test instanceof HookInterface) {
+      \CRM_Utils_Hook::singleton()->reset();
+    }
+    if ($this->isCiviTest($test)) {
+      error_reporting(E_ALL & ~E_NOTICE);
+      $this->errorScope = NULL;
+    }
+  }
+
+  /**
+   * @param HeadlessInterface|\PHPUnit_Framework_Test $test
+   */
+  protected function bootHeadless($test) {
+    if (CIVICRM_UF !== 'UnitTests') {
+      throw new \RuntimeException('HeadlessInterface requires CIVICRM_UF=UnitTests');
+    }
+
+    // Hrm, this seems wrong. Shouldn't we be resetting the entire session?
+    $session = \CRM_Core_Session::singleton();
+    $session->set('userID', NULL);
+
+    $test->setUpHeadless();
+
+    $config = \CRM_Core_Config::singleton(TRUE, TRUE); // ugh, performance
+    \CRM_Utils_System::flushCache();
+    \Civi::reset();
+    \CRM_Core_Session::singleton()->set('userID', NULL);
+
+    if (property_exists($config->userPermissionClass, 'permissions')) {
+      $config->userPermissionClass->permissions = NULL;
+    }
+  }
+
+  /**
+   * @param \Civi\Test\HookInterface $test
+   * @return array
+   *   Array(string $hookName => string $methodName)).
+   */
+  protected function findTestHooks(HookInterface $test) {
+    $class = get_class($test);
+    if (!isset($this->cache[$class])) {
+      $funcs = array();
+      foreach (get_class_methods($class) as $func) {
+        if (preg_match('/^hook_/', $func)) {
+          $funcs[substr($func, 5)] = $func;
+        }
+      }
+      $this->cache[$class] = $funcs;
+    }
+    return $this->cache[$class];
+  }
+
+  /**
+   * @param \PHPUnit_Framework_Test $test
+   * @return bool
+   */
+  protected function isCiviTest(\PHPUnit_Framework_Test $test) {
+    return $test instanceof HookInterface || $test instanceof HeadlessInterface;
+  }
+
+  /**
+   * Find any hook functions in $test and register them.
+   *
+   * @param \Civi\Test\HookInterface $test
+   */
+  protected function registerHooks(HookInterface $test) {
+    if (CIVICRM_UF !== 'UnitTests') {
+      // This is not ideal -- it's just a side-effect of how hooks and E2E tests work.
+      // We can temporarily subscribe to hooks in-process, but for other processes, it gets messy.
+      throw new \RuntimeException('CiviHookTestInterface requires CIVICRM_UF=UnitTests');
+    }
+    \CRM_Utils_Hook::singleton()->reset();
+    /** @var \CRM_Utils_Hook_UnitTests $hooks */
+    $hooks = \CRM_Utils_Hook::singleton();
+    foreach ($this->findTestHooks($test) as $hook => $func) {
+      $hooks->setHook($hook, array($test, $func));
+    }
+  }
+
+  /**
+   * The first time we come across HeadlessInterface or EndToEndInterface, we'll
+   * try to autoboot.
+   *
+   * Once the system is booted, there's nothing we can do -- we're stuck with that
+   * environment. (Thank you, prolific define()s!) If there's a conflict between a
+   * test-class and the active boot-level, then we'll have to bail.
+   *
+   * @param array $byInterface
+   *   List of test classes, keyed by major interface (HeadlessInterface vs EndToEndInterface).
+   */
+  protected function autoboot($byInterface) {
+    if (defined('CIVICRM_UF')) {
+      // OK, nothing we can do. System has booted already.
+    }
+    elseif (!empty($byInterface['HeadlessInterface'])) {
+      putenv('CIVICRM_UF=UnitTests');
+      eval($this->cv('php:boot --level=full', 'phpcode'));
+    }
+    elseif (!empty($byInterface['EndToEndInterface'])) {
+      putenv('CIVICRM_UF=');
+      eval($this->cv('php:boot --level=full', 'phpcode'));
+    }
+
+    $blurb = "Tip: Run the headless tests and end-to-end tests separately, e.g.\n"
+      . "  $ phpunit4 --group headless\n"
+      . "  $ phpunit4 --group e2e  \n";
+
+    if (!empty($byInterface['HeadlessInterface']) && CIVICRM_UF !== 'UnitTests') {
+      $testNames = implode(', ', array_keys($byInterface['HeadlessInterface']));
+      throw new \RuntimeException("Suite includes headless tests ($testNames) which require CIVICRM_UF=UnitTests.\n\n$blurb");
+    }
+    if (!empty($byInterface['EndToEndInterface']) && CIVICRM_UF === 'UnitTests') {
+      $testNames = implode(', ', array_keys($byInterface['EndToEndInterface']));
+      throw new \RuntimeException("Suite includes end-to-end tests ($testNames) which do not support CIVICRM_UF=UnitTests.\n\n$blurb");
+    }
+  }
+
+  /**
+   * Call the "cv" command.
+   *
+   * This duplicates the standalone `cv()` wrapper that is recommended in bootstrap.php.
+   * This duplication is necessary because `cv()` is optional, and downstream implementers
+   * may alter, rename, or omit the wrapper, and (by virtue of its role in bootstrap) there
+   * it is impossible to define it centrally.
+   *
+   * @param string $cmd
+   *   The rest of the command to send.
+   * @param string $decode
+   *   Ex: 'json' or 'phpcode'.
+   * @return string
+   *   Response output (if the command executed normally).
+   * @throws \RuntimeException
+   *   If the command terminates abnormally.
+   */
+  protected function cv($cmd, $decode = 'json') {
+    $cmd = 'cv ' . $cmd;
+    $descriptorSpec = array(0 => array("pipe", "r"), 1 => array("pipe", "w"), 2 => STDERR);
+    $oldOutput = getenv('CV_OUTPUT');
+    putenv("CV_OUTPUT=json");
+    $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
+    putenv("CV_OUTPUT=$oldOutput");
+    fclose($pipes[0]);
+    $result = stream_get_contents($pipes[1]);
+    fclose($pipes[1]);
+    if (proc_close($process) !== 0) {
+      throw new \RuntimeException("Command failed ($cmd):\n$result");
+    }
+    switch ($decode) {
+      case 'raw':
+        return $result;
+
+      case 'phpcode':
+        // If the last output is /*PHPCODE*/, then we managed to complete execution.
+        if (substr(trim($result), 0, 12) !== "/*BEGINPHP*/" || substr(trim($result), -10) !== "/*ENDPHP*/") {
+          throw new \RuntimeException("Command failed ($cmd):\n$result");
+        }
+        return $result;
+
+      case 'json':
+        return json_decode($result, 1);
+
+      default:
+        throw new \RuntimeException("Bad decoder format ($decode)");
+    }
+  }
+
+  /**
+   * @param $tests
+   * @return array
+   */
+  protected function indexTestsByInterface($tests) {
+    $byInterface = array('HeadlessInterface' => array(), 'EndToEndInterface' => array());
+    foreach ($tests as $test) {
+      /** @var \PHPUnit_Framework_Test $test */
+      if ($test instanceof HeadlessInterface) {
+        $byInterface['HeadlessInterface'][get_class($test)] = 1;
+      }
+      if ($test instanceof EndToEndInterface) {
+        $byInterface['EndToEndInterface'][get_class($test)] = 1;
+      }
+    }
+    return $byInterface;
+  }
+
+  /**
+   * Ensure that any tests have sensible groups, e.g.
+   *
+   * `HeadlessInterface` ==> `group headless`
+   * `EndToEndInterface` ==> `group e2e`
+   *
+   * @param array $byInterface
+   */
+  protected function validateGroups($byInterface) {
+    foreach ($byInterface['HeadlessInterface'] as $className => $nonce) {
+      $clazz = new \ReflectionClass($className);
+      $docComment = str_replace("\r\n", "\n", $clazz->getDocComment());
+      if (strpos($docComment, "@group headless\n") === FALSE) {
+        echo "WARNING: Class $className implements HeadlessInterface. It should declare \"@group headless\".\n";
+      }
+      if (strpos($docComment, "@group e2e\n") !== FALSE) {
+        echo "WARNING: Class $className implements HeadlessInterface. It should not declare \"@group e2e\".\n";
+      }
+    }
+    foreach ($byInterface['EndToEndInterface'] as $className => $nonce) {
+      $clazz = new \ReflectionClass($className);
+      $docComment = str_replace("\r\n", "\n", $clazz->getDocComment());
+      if (strpos($docComment, "@group e2e\n") === FALSE) {
+        echo "WARNING: Class $className implements EndToEndInterface. It should declare \"@group e2e\".\n";
+      }
+      if (strpos($docComment, "@group headless\n") !== FALSE) {
+        echo "WARNING: Class $className implements EndToEndInterface. It should not declare \"@group headless\".\n";
+      }
+    }
+  }
+
+}

--- a/Civi/Test/Data.php
+++ b/Civi/Test/Data.php
@@ -1,0 +1,52 @@
+<?php
+namespace Civi\Test;
+
+use RuntimeException;
+
+/**
+ * Class Data
+ */
+class Data {
+
+  /**
+   * @return bool
+   */
+  public function populate() {
+    \Civi\Test::schema()->truncateAll();
+
+    \Civi\Test::schema()->setStrict(FALSE);
+    $sqlDir = dirname(dirname(__DIR__)) . "/sql";
+
+    $query2 = file_get_contents("$sqlDir/civicrm_data.mysql");
+    $query3 = file_get_contents("$sqlDir/test_data.mysql");
+    $query4 = file_get_contents("$sqlDir/test_data_second_domain.mysql");
+    if (\Civi\Test::execute($query2) === FALSE) {
+      throw new RuntimeException("Cannot load civicrm_data.mysql. Aborting.");
+    }
+    if (\Civi\Test::execute($query3) === FALSE) {
+      throw new RuntimeException("Cannot load test_data.mysql. Aborting.");
+    }
+    if (\Civi\Test::execute($query4) === FALSE) {
+      throw new RuntimeException("Cannot load test_data.mysql. Aborting.");
+    }
+
+    unset($query, $query2, $query3);
+
+    \Civi\Test::schema()->setStrict(TRUE);
+
+    // Rebuild triggers
+    civicrm_api('system', 'flush', array('version' => 3, 'triggers' => 1));
+
+    \CRM_Core_BAO_ConfigSetting::setEnabledComponents(array(
+      'CiviEvent',
+      'CiviContribute',
+      'CiviMember',
+      'CiviMail',
+      'CiviReport',
+      'CiviPledge',
+    ));
+
+    return TRUE;
+  }
+
+}

--- a/Civi/Test/EndToEndInterface.php
+++ b/Civi/Test/EndToEndInterface.php
@@ -1,0 +1,28 @@
+<?php
+namespace Civi\Test;
+
+/**
+ * Interface EndToEndInterface
+ * @package Civi\Test
+ *
+ * To run your test against a live, CMS-integrated database, flag it with the the
+ * EndToEndInterface.
+ *
+ * Note: The global variable $_CV should be pre-populated with some interesting data:
+ *
+ * - $_CV['CMS_URL']
+ * - $_CV['ADMIN_USER']
+ * - $_CV['ADMIN_PASS']
+ * - $_CV['ADMIN_EMAIL']
+ * - $_CV['DEMO_USER']
+ * - $_CV['DEMO_PASS']
+ * - $_CV['DEMO_EMAIL']
+ *
+ * Alternatively, if you wish to run a test in a headless environment,
+ * flag it with HeadlessInterface.
+ *
+ * @see HeadlessInterface
+ */
+interface EndToEndInterface {
+
+}

--- a/Civi/Test/HeadlessInterface.php
+++ b/Civi/Test/HeadlessInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Civi\Test;
+
+/**
+ * Interface HeadlessInterface
+ * @package Civi\Test
+ *
+ * To run your test against a fake, headless database, flag it with the
+ * HeadlessInterface. CiviTestListener will automatically boot Civi.
+ *
+ * Alternatively, if you wish to run a test in a live (CMS-enabled) environment,
+ * flag it with EndToEndInterface.
+ *
+ * You may mix-in additional features for headless tests:
+ *  - HookInterface: Auto-register any functions named "hook_civicrm_foo()".
+ *  - TransactionalInterface: Wrap all work in a transaction, and rollback at the end.
+ *
+ * @see EndToEndInterface
+ * @see HookInterface
+ * @see TransactionalInterface
+ */
+interface HeadlessInterface {
+
+  /**
+   * The setupHeadless function runs at the start of each test case, right before
+   * the headless environment reboots.
+   *
+   * It should perform any necessary steps required for putting the database
+   * in a consistent baseline -- such as loading schema and extensions.
+   *
+   * The utility `\Civi\Test::headless()` provides a number of helper functions
+   * for managing this setup, and it includes optimizations to avoid redundant
+   * setup work.
+   *
+   * @see \Civi\Test
+   */
+  public function setUpHeadless();
+
+}

--- a/Civi/Test/HookInterface.php
+++ b/Civi/Test/HookInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Civi\Test;
+
+/**
+ * Interface HookInterface
+ * @package Civi\Test
+ *
+ * This interface allows you to subscribe to hooks as part of the test.
+ * Simply create an eponymous hook function (e.g. `hook_civicrm_post()`).
+ *
+ * @code
+ * class MyTest extends \PHPUnit_Framework_TestCase implements \Civi\Test\HookInterface {
+ *   public function hook_civicrm_post($op, $objectName, $objectId, &$objectRef) {
+ *     echo "Running hook_civicrm_post\n";
+ *   }
+ * }
+ * @endCode
+ *
+ * At time of writing, there are a few limitations in how HookInterface is handled
+ * by CiviTestListener:
+ *
+ *  - The test must execute in-process (aka HeadlessInterface; aka CIVICRM_UF==UnitTests).
+ *    End-to-end tests (multi-process tests) are not supported.
+ *  - Early bootstrap hooks (e.g. hook_civicrm_config) are not supported.
+ *
+ * @see CiviTestListener
+ */
+interface HookInterface {
+}

--- a/Civi/Test/Schema.php
+++ b/Civi/Test/Schema.php
@@ -1,0 +1,128 @@
+<?php
+namespace Civi\Test;
+
+use RuntimeException;
+
+/**
+ * Class Schema
+ *
+ * Manage the entire database. This is useful for destroying or loading the schema.
+ */
+class Schema {
+
+  /**
+   * @param string $type
+   *   'BASE TABLE' or 'VIEW'.
+   * @return array
+   */
+  public function getTables($type) {
+    $pdo = \Civi\Test::pdo();
+    // only consider real tables and not views
+    $query = sprintf(
+      "SELECT table_name FROM INFORMATION_SCHEMA.TABLES
+        WHERE TABLE_SCHEMA = %s AND TABLE_TYPE = %s",
+      $pdo->quote(\Civi\Test::dsn('database')),
+      $pdo->quote($type)
+    );
+    $tables = $pdo->query($query);
+    $result = array();
+    foreach ($tables as $table) {
+      $result[] = $table['table_name'];
+    }
+    return $result;
+  }
+
+  public function setStrict($checks) {
+    $dbName = \Civi\Test::dsn('database');
+    if ($checks) {
+      $queries = array(
+        "USE {$dbName};",
+        "SET global innodb_flush_log_at_trx_commit = 1;",
+        "SET SQL_MODE='STRICT_ALL_TABLES';",
+        "SET foreign_key_checks = 1;",
+      );
+    }
+    else {
+      $queries = array(
+        "USE {$dbName};",
+        "SET foreign_key_checks = 0",
+        "SET SQL_MODE='STRICT_ALL_TABLES';",
+        "SET global innodb_flush_log_at_trx_commit = 2;",
+      );
+    }
+    foreach ($queries as $query) {
+      if (\Civi\Test::execute($query) === FALSE) {
+        throw new RuntimeException("Query failed: $query");
+      }
+    }
+    return $this;
+  }
+
+  public function dropAll() {
+    $queries = array();
+    foreach ($this->getTables('VIEW') as $table) {
+      if (preg_match('/^(civicrm_|log_)/', $table)) {
+        $queries[] = "DROP VIEW $table";
+      }
+    }
+
+    foreach ($this->getTables('BASE TABLE') as $table) {
+      if (preg_match('/^(civicrm_|log_)/', $table)) {
+        $queries[] = "DROP TABLE $table";
+      }
+    }
+
+    $this->setStrict(FALSE);
+    foreach ($queries as $query) {
+      if (\Civi\Test::execute($query) === FALSE) {
+        throw new RuntimeException("dropSchema: Query failed: $query");
+      }
+    }
+    $this->setStrict(TRUE);
+
+    return $this;
+  }
+
+  /**
+   * @return array
+   */
+  public function truncateAll() {
+    $tables = \Civi\Test::schema()->getTables('BASE TABLE');
+
+    $truncates = array();
+    $drops = array();
+    foreach ($tables as $table) {
+      // skip log tables
+      if (substr($table, 0, 4) == 'log_') {
+        continue;
+      }
+
+      // don't change list of installed extensions
+      if ($table == 'civicrm_extension') {
+        continue;
+      }
+
+      if (substr($table, 0, 14) == 'civicrm_value_') {
+        $drops[] = 'DROP TABLE ' . $table . ';';
+      }
+      elseif (substr($table, 0, 9) == 'civitest_') {
+        // ignore
+      }
+      else {
+        $truncates[] = 'TRUNCATE ' . $table . ';';
+      }
+    }
+
+    \Civi\Test::schema()->setStrict(FALSE);
+    $queries = array_merge($truncates, $drops);
+    foreach ($queries as $query) {
+      if (\Civi\Test::execute($query) === FALSE) {
+        throw new RuntimeException("Query failed: $query");
+      }
+    }
+    \Civi\Test::schema()->setStrict(TRUE);
+
+    return $this;
+  }
+
+}

--- a/Civi/Test/TransactionalInterface.php
+++ b/Civi/Test/TransactionalInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Civi\Test;
+
+/**
+ * Interface HeadlessInterface
+ * @package Civi\Test
+ *
+ * Mark a test with TransactionalInterface to instruct CiviTestListener to wrap
+ * each test in a transaction (and rollback).
+ *
+ * Note: At time of writing, CiviTestListener only supports using TransactionalInterface if
+ * the test is in-process and runs with CIVICRM_UF==UnitTests.
+ *
+ * For end-to-end testing, it is expected that the CMS will not participate in the transaction,
+ * so the transaction mechanism will not work.
+ *
+ * @see HeadlessInterface
+ */
+interface TransactionalInterface {
+
+}

--- a/Civi/Token/AbstractTokenSubscriber.php
+++ b/Civi/Token/AbstractTokenSubscriber.php
@@ -1,0 +1,174 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2016                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Token;
+
+use Civi\Token\Event\TokenRegisterEvent;
+use Civi\Token\Event\TokenValueEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Class AbstractTokenSubscriber
+ * @package Civi\Token
+ *
+ * AbstractTokenSubscriber is a base class which may be extended to
+ * implement tokens in a somewhat more concise fashion.
+ *
+ * To implement a new token handler based on this:
+ *   1. Create a subclass.
+ *   2. Override the constructor and set values for $entity and $tokenNames.
+ *   3. Implement the evaluateToken() method.
+ *   4. Optionally, override others:
+ *      + checkActive()
+ *      + prefetch()
+ *   5. Register the new class with the event-dispatcher.
+ *
+ * Note: There's no obligation to use this base class. You could implement
+ * your own class anew -- just subscribe the proper events.
+ */
+abstract class AbstractTokenSubscriber implements EventSubscriberInterface {
+
+  public static function getSubscribedEvents() {
+    return array(
+      Events::TOKEN_REGISTER => 'registerTokens',
+      Events::TOKEN_EVALUATE => 'evaluateTokens',
+    );
+  }
+
+  /**
+   * @var string
+   *   Ex: 'contact' or profile' or 'employer'
+   */
+  public $entity;
+
+  /**
+   * @var array
+   *   Ex: array('viewUrl', 'editUrl').
+   */
+  public $tokenNames;
+
+  /**
+   * @param $entity
+   * @param array $tokenNames
+   *   Array(string $fieldName => string $label).
+   */
+  public function __construct($entity, $tokenNames = array()) {
+    $this->entity = $entity;
+    $this->tokenNames = $tokenNames;
+  }
+
+  /**
+   * Determine whether this token-handler should be used with
+   * the given processor.
+   *
+   * To short-circuit token-processing in irrelevant contexts,
+   * override this.
+   *
+   * @param \Civi\Token\TokenProcessor $processor
+   * @return bool
+   */
+  public function checkActive(\Civi\Token\TokenProcessor $processor) {
+    return TRUE;
+  }
+
+  /**
+   * Register the declared tokens.
+   *
+   * @param TokenRegisterEvent $e
+   *   The registration event. Add new tokens using register().
+   */
+  public function registerTokens(TokenRegisterEvent $e) {
+    if (!$this->checkActive($e->getTokenProcessor())) {
+      return;
+    }
+    foreach ($this->tokenNames as $name => $label) {
+      $e->register(array(
+        'entity' => $this->entity,
+        'field' => $name,
+        'label' => $label,
+      ));
+    }
+  }
+
+  /**
+   * Populate the token data.
+   *
+   * @param TokenValueEvent $e
+   *   The event, which includes a list of rows and tokens.
+   */
+  public function evaluateTokens(TokenValueEvent $e) {
+    if (!$this->checkActive($e->getTokenProcessor())) {
+      return;
+    }
+
+    $messageTokens = $e->getTokenProcessor()->getMessageTokens();
+    if (!isset($messageTokens[$this->entity])) {
+      return;
+    }
+
+    $activeTokens = array_intersect($messageTokens[$this->entity], array_keys($this->tokenNames));
+    if (empty($activeTokens)) {
+      return;
+    }
+
+    $prefetch = $this->prefetch($e);
+
+    foreach ($e->getRows() as $row) {
+      foreach ($activeTokens as $field) {
+        $this->evaluateToken($row, $this->entity, $field, $prefetch);
+      }
+    }
+  }
+
+  /**
+   * To perform a bulk lookup before rendering tokens, override this
+   * function and return the prefetched data.
+   *
+   * @param \Civi\Token\Event\TokenValueEvent $e
+   *
+   * @return mixed
+   */
+  public function prefetch(TokenValueEvent $e) {
+    return NULL;
+  }
+
+  /**
+   * Evaluate the content of a single token.
+   *
+   * @param TokenRow $row
+   *   The record for which we want token values.
+   * @param string $entity
+   *   The name of the token entity.
+   * @param string $field
+   *   The name of the token field.
+   * @param mixed $prefetch
+   *   Any data that was returned by the prefetch().
+   * @return mixed
+   */
+  public abstract function evaluateToken(TokenRow $row, $entity, $field, $prefetch = NULL);
+
+}

--- a/Civi/Token/Event/TokenEvent.php
+++ b/Civi/Token/Event/TokenEvent.php
@@ -1,0 +1,25 @@
+<?php
+namespace Civi\Token\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Class TokenListEvent
+ * @package Civi\Token\Event
+ */
+class TokenEvent extends Event {
+
+  protected $tokenProcessor;
+
+  public function __construct($tokenProcessor) {
+    $this->tokenProcessor = $tokenProcessor;
+  }
+
+  /**
+   * @return \Civi\Token\TokenProcessor
+   */
+  public function getTokenProcessor() {
+    return $this->tokenProcessor;
+  }
+
+}

--- a/Civi/Token/Event/TokenRegisterEvent.php
+++ b/Civi/Token/Event/TokenRegisterEvent.php
@@ -1,0 +1,70 @@
+<?php
+namespace Civi\Token\Event;
+
+/**
+ * Class TokenRegisterEvent
+ * @package Civi\Token\Event
+ *
+ * The TokenRegisterEvent is fired when constructing a list of available
+ * tokens. Listeners may register by specifying the entity/field/label for the token.
+ *
+ * @code
+ * $ev->entity('profile')
+ *    ->register('viewUrl', ts('Default Profile URL (View Mode)')
+ *    ->register('editUrl', ts('Default Profile URL (Edit Mode)');
+ * $ev->register(array(
+ *   'entity' => 'profile',
+ *   'field' => 'viewUrl',
+ *   'label' => ts('Default Profile URL (View Mode)'),
+ * ));
+ * @endcode
+ */
+class TokenRegisterEvent extends TokenEvent {
+
+  /**
+   * Default values to put in new registrations.
+   *
+   * @var array
+   */
+  protected $defaults;
+
+  public function __construct($tokenProcessor, $defaults) {
+    parent::__construct($tokenProcessor);
+    $this->defaults = $defaults;
+  }
+
+  /**
+   * Set the default entity name.
+   *
+   * @param string $entity
+   * @return TokenRegisterEvent
+   */
+  public function entity($entity) {
+    $defaults = $this->defaults;
+    $defaults['entity'] = $entity;
+    return new TokenRegisterEvent($this->tokenProcessor, $defaults);
+  }
+
+  /**
+   * Register a new token.
+   *
+   * @param array|string $paramsOrField
+   * @param NULL|string $label
+   * @return TokenRegisterEvent
+   */
+  public function register($paramsOrField, $label = NULL) {
+    if (is_array($paramsOrField)) {
+      $params = $paramsOrField;
+    }
+    else {
+      $params = array(
+        'field' => $paramsOrField,
+        'label' => $label,
+      );
+    }
+    $params = array_merge($this->defaults, $params);
+    $this->tokenProcessor->addToken($params);
+    return $this;
+  }
+
+}

--- a/Civi/Token/Event/TokenRenderEvent.php
+++ b/Civi/Token/Event/TokenRenderEvent.php
@@ -1,0 +1,44 @@
+<?php
+namespace Civi\Token\Event;
+
+/**
+ * Class TokenRenderEvent
+ * @package Civi\Token\Event
+ *
+ * A TokenRenderEvent is fired after the TokenProcessor has rendered
+ * a message.
+ *
+ * The render event may be used for post-processing the text, but
+ * it's very difficult to do substantive work in a secure, robust
+ * way within this event. The event primarily exists to facilitate
+ * a transition of some legacy code.
+ */
+class TokenRenderEvent extends TokenEvent {
+
+  /**
+   * @var array|\ArrayAccess
+   */
+  public $context;
+
+  /**
+   * @var array|\ArrayAccess
+   *
+   * The original message template.
+   */
+  public $message;
+
+  /**
+   * @var \Civi\Token\TokenRow
+   *
+   * The record for which we're generating date
+   */
+  public $row;
+
+  /**
+   * @var string
+   *
+   * The rendered string, with tokens replaced.
+   */
+  public $string;
+
+}

--- a/Civi/Token/Event/TokenValueEvent.php
+++ b/Civi/Token/Event/TokenValueEvent.php
@@ -1,0 +1,45 @@
+<?php
+namespace Civi\Token\Event;
+
+/**
+ * Class TokenValueEvent
+ * @package Civi\Token\Event
+ *
+ * A TokenValueEvent is fired to convert raw query data into mergeable
+ * tokens. For example:
+ *
+ * @code
+ * $event = new TokenValueEvent($myContext, 'text/html', array(
+ *   array('contact_id' => 123),
+ *   array('contact_id' => 456),
+ * ));
+ *
+ * // Compute tokens one row at a time.
+ * foreach ($event->getRows() as $row) {
+ *   $row->setTokens('contact', array(
+ *     'profileUrl' => CRM_Utils_System::url('civicrm/profile/view', 'reset=1&gid=456&id=' . $row['contact_id']'),
+ *   ));
+ * }
+ *
+ * // Compute tokens with a bulk lookup.
+ * $ids = implode(',', array_filter(CRM_Utils_Array::collect('contact_id', $event->getRows()), 'is_numeric'));
+ * $dao = CRM_Core_DAO::executeQuery("SELECT contact_id, foo, bar FROM foobar WHERE contact_id in ($ids)");
+ * while ($dao->fetch) {
+ *   $row->setTokens('oddball', array(
+ *     'foo' => $dao->foo,
+ *     'bar' => $dao->bar,
+ * ));
+ * }
+ * @encode
+ *
+ */
+class TokenValueEvent extends TokenEvent {
+
+  /**
+   * @return \Traversable<TokenRow>
+   */
+  public function getRows() {
+    return $this->tokenProcessor->getRows();
+  }
+
+}

--- a/Civi/Token/Events.php
+++ b/Civi/Token/Events.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Civi\Token;
+
+class Events {
+  /**
+   * Create a list of supported tokens.
+   *
+   * @see \Civi\Token\Event\TokenRegisterEvent
+   */
+  const TOKEN_REGISTER = 'civi.token.list';
+
+  /**
+   * Create a list of supported tokens.
+   *
+   * @see \Civi\Token\Event\TokenValueEvent
+   */
+  const TOKEN_EVALUATE = 'civi.token.eval';
+
+  /**
+   * Perform post-processing on a rendered message.
+   *
+   * WARNING: It is difficult to develop robust,
+   * secure code using this stage. However, we need
+   * to support it during a transitional period
+   * while the token logic is reorganized.
+   *
+   * @see \Civi\Token\Event\TokenRenderEvent
+   */
+  const TOKEN_RENDER = 'civi.token.render';
+
+}

--- a/Civi/Token/TokenCompatSubscriber.php
+++ b/Civi/Token/TokenCompatSubscriber.php
@@ -1,0 +1,120 @@
+<?php
+namespace Civi\Token;
+
+use Civi\Token\Event\TokenRenderEvent;
+use Civi\Token\Event\TokenValueEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Class TokenCompatSubscriber
+ * @package Civi\Token
+ *
+ * This class provides a compatibility layer for using CRM_Utils_Token
+ * helpers within TokenProcessor.
+ *
+ * THIS IS NOT A GOOD EXAMPLE TO EMULATE. The class exists to two
+ * bridge two different designs. CRM_Utils_Token has some
+ * undesirable elements (like iterative token substitution).
+ * However, if you're refactor CRM_Utils_Token or improve the
+ * bridge, then it makes sense to update this class.
+ */
+class TokenCompatSubscriber implements EventSubscriberInterface {
+
+  /**
+   * @inheritDoc
+   */
+  public static function getSubscribedEvents() {
+    return array(
+      Events::TOKEN_EVALUATE => 'onEvaluate',
+      Events::TOKEN_RENDER => 'onRender',
+    );
+  }
+
+  /**
+   * Load token data.
+   *
+   * @param TokenValueEvent $e
+   * @throws TokenException
+   */
+  public function onEvaluate(TokenValueEvent $e) {
+    // For reasons unknown, replaceHookTokens requires a pre-computed list of
+    // hook *categories* (aka entities aka namespaces). We'll cache
+    // this in the TokenProcessor's context.
+
+    $hookTokens = array();
+    \CRM_Utils_Hook::tokens($hookTokens);
+    $categories = array_keys($hookTokens);
+    $e->getTokenProcessor()->context['hookTokenCategories'] = $categories;
+
+    $messageTokens = $e->getTokenProcessor()->getMessageTokens();
+
+    foreach ($e->getRows() as $row) {
+      $contactId = $row->context['contactId'];
+      if (empty($row->context['contact'])) {
+        $params = array(
+          array('contact_id', '=', $contactId, 0, 0),
+        );
+        list($contact, $_) = \CRM_Contact_BAO_Query::apiQuery($params);
+        $contact = reset($contact); //CRM-4524
+        if (!$contact || is_a($contact, 'CRM_Core_Error')) {
+          // FIXME: Need to differentiate errors which kill the batch vs the individual row.
+          throw new TokenException("Failed to generate token data. Invalid contact ID: " . $row->context['contactId']);
+        }
+      }
+      else {
+        $contact = $row->context['contact'];
+      }
+
+      if (!empty($row->context['tmpTokenParams'])) {
+        // merge activity tokens with contact array
+        // this is pretty weird.
+        $contact = array_merge($contact, $row->context['tmpTokenParams']);
+      }
+
+      $contactArray = !is_array($contactId) ? array($contactId => $contact) : $contact;
+
+      // Note: This is a small contract change from the past; data should be missing
+      // less randomly.
+      //\CRM_Utils_Hook::tokenValues($contact, $row->context['contactId']);
+      \CRM_Utils_Hook::tokenValues($contactArray,
+        (array) $contactId,
+        empty($row->context['mailingJob']) ? NULL : $row->context['mailingJob']->id,
+        $messageTokens,
+        $row->context['controller']
+      );
+
+      // merge the custom tokens in the $contact array
+      if (!empty($contactArray[$contactId])) {
+        $contact = array_merge($contact, $contactArray[$contactId]);
+      }
+      $row->context('contact', $contact);
+    }
+  }
+
+  /**
+   * Apply the various CRM_Utils_Token helpers.
+   *
+   * @param TokenRenderEvent $e
+   */
+  public function onRender(TokenRenderEvent $e) {
+    $isHtml = ($e->message['format'] == 'text/html');
+    $useSmarty = !empty($e->context['smarty']);
+
+    $e->string = \CRM_Utils_Token::replaceDomainTokens($e->string, \CRM_Core_BAO_Domain::getDomain(), $isHtml, $e->message['tokens'], $useSmarty);
+
+    if (!empty($e->context['contact'])) {
+      $e->string = \CRM_Utils_Token::replaceContactTokens($e->string, $e->context['contact'], $isHtml, $e->message['tokens'], FALSE, $useSmarty);
+
+      // FIXME: This may depend on $contact being merged with hook values.
+      $e->string = \CRM_Utils_Token::replaceHookTokens($e->string, $e->context['contact'], $e->context['hookTokenCategories'], $isHtml, $useSmarty);
+
+      \CRM_Utils_Token::replaceGreetingTokens($e->string, NULL, $e->context['contact']['contact_id'], NULL, $useSmarty);
+    }
+
+    if ($useSmarty) {
+      $smarty = \CRM_Core_Smarty::singleton();
+      $e->string = $smarty->fetch("string:" . $e->string);
+    }
+  }
+
+}

--- a/Civi/Token/TokenException.php
+++ b/Civi/Token/TokenException.php
@@ -1,0 +1,6 @@
+<?php
+namespace Civi\Token;
+
+class TokenException extends \CRM_Core_Exception {
+
+}

--- a/Civi/Token/TokenProcessor.php
+++ b/Civi/Token/TokenProcessor.php
@@ -1,0 +1,251 @@
+<?php
+namespace Civi\Token;
+
+use Civi\Token\Event\TokenRegisterEvent;
+use Civi\Token\Event\TokenRenderEvent;
+use Civi\Token\Event\TokenValueEvent;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Traversable;
+
+class TokenProcessor {
+
+  /**
+   * @var array
+   *   Description of the context in which the tokens are being processed.
+   *   Ex: Array('class'=>'CRM_Core_BAO_ActionSchedule', 'schedule' => $dao, 'mapping' => $dao).
+   *   Ex: Array('class'=>'CRM_Mailing_BAO_MailingJob', 'mailing' => $dao).
+   *
+   * For lack of a better place, here's a list of known/intended context values:
+   *
+   *   - controller: string, the class which is managing the mail-merge.
+   *   - smarty: bool, whether to enable smarty support.
+   *   - contactId: int, the main person/org discussed in the message.
+   *   - contact: array, the main person/org discussed in the message.
+   *     (Optional for performance tweaking; if omitted, will load
+   *     automatically from contactId.)
+   *   - actionSchedule: DAO, the rule which triggered the mailing
+   *     [for CRM_Core_BAO_ActionScheduler].
+   */
+  public $context;
+
+  /**
+   * @var EventDispatcherInterface
+   */
+  protected $dispatcher;
+
+  /**
+   * @var array
+   *   Each message is an array with keys:
+   *    - string: Unprocessed message (eg "Hello, {display_name}.").
+   *    - format: Media type (eg "text/plain").
+   *    - tokens: List of tokens which are actually used in this message.
+   */
+  protected $messages;
+
+  /**
+   * DO NOT access field this directly. Use TokenRow. This is
+   * marked as public only to benefit TokenRow.
+   *
+   * @var array
+   *   Array(int $pos => array $keyValues);
+   */
+  public $rowContexts;
+
+  /**
+   * DO NOT access field this directly. Use TokenRow. This is
+   * marked as public only to benefit TokenRow.
+   *
+   * @var array
+   *   Ex: $rowValues[$rowPos][$format][$entity][$field] = 'something';
+   *    Ex: $rowValues[3]['text/plain']['contact']['display_name'] = 'something';
+   */
+  public $rowValues;
+
+  /**
+   * A list of available tokens
+   * @var array
+   *   Array(string $dottedName => array('entity'=>string, 'field'=>string, 'label'=>string)).
+   */
+  protected $tokens = NULL;
+
+  protected $next = 0;
+
+  /**
+   * @param EventDispatcherInterface $dispatcher
+   * @param array $context
+   */
+  public function __construct($dispatcher, $context) {
+    $this->dispatcher = $dispatcher;
+    $this->context = $context;
+  }
+
+  /**
+   * Register a string for which we'll need to merge in tokens.
+   *
+   * @param string $name
+   *   Ex: 'subject', 'body_html'.
+   * @param string $value
+   *   Ex: '<p>Hello {contact.name}</p>'.
+   * @param string $format
+   *   Ex: 'text/html'.
+   * @return TokenProcessor
+   */
+  public function addMessage($name, $value, $format) {
+    $this->messages[$name] = array(
+      'string' => $value,
+      'format' => $format,
+      'tokens' => \CRM_Utils_Token::getTokens($value),
+    );
+    return $this;
+  }
+
+  /**
+   * Add a row of data.
+   *
+   * @return TokenRow
+   */
+  public function addRow() {
+    $key = $this->next++;
+    $this->rowContexts[$key] = array();
+    $this->rowValues[$key] = array(
+      'text/plain' => array(),
+      'text/html' => array(),
+    );
+
+    return new TokenRow($this, $key);
+  }
+
+  /**
+   * @param array $params
+   *   Array with keys:
+   *    - entity: string, e.g. "profile".
+   *    - field: string, e.g. "viewUrl".
+   *    - label: string, e.g. "Default Profile URL (View Mode)".
+   * @return TokenProcessor
+   */
+  public function addToken($params) {
+    $key = $params['entity'] . '.' . $params['field'];
+    $this->tokens[$key] = $params;
+    return $this;
+  }
+
+  /**
+   * @param string $name
+   * @return array
+   *   Keys:
+   *    - string: Unprocessed message (eg "Hello, {display_name}.").
+   *    - format: Media type (eg "text/plain").
+   */
+  public function getMessage($name) {
+    return $this->messages[$name];
+  }
+
+  /**
+   * Get a list of all tokens used in registered messages.
+   *
+   * @return array
+   */
+  public function getMessageTokens() {
+    $tokens = array();
+    foreach ($this->messages as $message) {
+      $tokens = \CRM_Utils_Array::crmArrayMerge($tokens, $message['tokens']);
+    }
+    foreach (array_keys($tokens) as $e) {
+      $tokens[$e] = array_unique($tokens[$e]);
+      sort($tokens[$e]);
+    }
+    return $tokens;
+  }
+
+  public function getRow($key) {
+    return new TokenRow($this, $key);
+  }
+
+  /**
+   * @return \Traversable<TokenRow>
+   */
+  public function getRows() {
+    return new TokenRowIterator($this, new \ArrayIterator($this->rowContexts));
+  }
+
+  /**
+   * Get the list of available tokens.
+   *
+   * @return array
+   *   Ex: $tokens['event'] = array('location', 'start_date', 'end_date').
+   */
+  public function getTokens() {
+    if ($this->tokens === NULL) {
+      $this->tokens = array();
+      $event = new TokenRegisterEvent($this, array('entity' => 'undefined'));
+      $this->dispatcher->dispatch(Events::TOKEN_REGISTER, $event);
+    }
+    return $this->tokens;
+  }
+
+  /**
+   * Compute and store token values.
+   */
+  public function evaluate() {
+    $event = new TokenValueEvent($this);
+    $this->dispatcher->dispatch(Events::TOKEN_EVALUATE, $event);
+    return $this;
+  }
+
+  /**
+   * Render a message.
+   *
+   * @param string $name
+   *   The name previously registered with addMessage().
+   * @param TokenRow|int $row
+   *   The object or ID for the row previously registered with addRow().
+   * @return string
+   *   Fully rendered message, with tokens merged.
+   */
+  public function render($name, $row) {
+    if (!is_object($row)) {
+      $row = $this->getRow($row);
+    }
+
+    $message = $this->getMessage($name);
+    $row->fill($message['format']);
+    $useSmarty = !empty($row->context['smarty']);
+
+    // FIXME preg_callback.
+    $tokens = $this->rowValues[$row->tokenRow][$message['format']];
+    $flatTokens = array();
+    \CRM_Utils_Array::flatten($tokens, $flatTokens, '', '.');
+    $filteredTokens = array();
+    foreach ($flatTokens as $k => $v) {
+      $filteredTokens['{' . $k . '}'] = ($useSmarty ? \CRM_Utils_Token::tokenEscapeSmarty($v) : $v);
+    }
+
+    $event = new TokenRenderEvent($this);
+    $event->message = $message;
+    $event->context = $row->context;
+    $event->row = $row;
+    $event->string = strtr($message['string'], $filteredTokens);
+    $this->dispatcher->dispatch(Events::TOKEN_RENDER, $event);
+    return $event->string;
+  }
+
+}
+
+class TokenRowIterator extends \IteratorIterator {
+
+  protected $tokenProcessor;
+
+  /**
+   * @param TokenProcessor $tokenProcessor
+   * @param Traversable $iterator
+   */
+  public function __construct(TokenProcessor $tokenProcessor, Traversable $iterator) {
+    parent::__construct($iterator); // TODO: Change the autogenerated stub
+    $this->tokenProcessor = $tokenProcessor;
+  }
+
+  public function current() {
+    return new TokenRow($this->tokenProcessor, parent::key());
+  }
+
+}

--- a/Civi/Token/TokenRow.php
+++ b/Civi/Token/TokenRow.php
@@ -1,0 +1,349 @@
+<?php
+namespace Civi\Token;
+
+/**
+ * Class TokenRow
+ * @package Civi\Token
+ *
+ * A TokenRow is a helper providing simplified access to the
+ * TokenProcessor.
+ *
+ * A TokenRow combines two elements:
+ *   - context: This is backend data provided by the controller.
+ *   - tokens: This is frontend data that can be mail-merged.
+ *
+ * The context and tokens can be accessed using either methods
+ * or attributes. The methods are appropriate for updates
+ * (and generally accept a mix of arrays), and the attributes
+ * are appropriate for reads.
+ *
+ * To update the context or the tokens, use the methods.
+ * Note that the methods are fairly flexible about accepting
+ * single values or arrays. If given an array, the values
+ * will be merged recursively.
+ *
+ * @code
+ * $row
+ *   ->context('contact_id', 123)
+ *   ->context(array('contact_id' => 123))
+ *   ->tokens('profile', array('viewUrl' => 'http://example.com'))
+ *   ->tokens('profile', 'viewUrl, 'http://example.com');
+ *
+ * echo $row->context['contact_id'];
+ * echo $row->tokens['profile']['viewUrl'];
+ *
+ * $row->tokens('profile', array(
+ *   'viewUrl' => 'http://example.com/view/' . urlencode($row->context['contact_id'];
+ * ));
+ * @endcode
+ */
+class TokenRow {
+
+  /**
+   * @var TokenProcessor
+   */
+  public $tokenProcessor;
+
+  public $tokenRow;
+
+  public $format;
+
+  /**
+   * @var array|\ArrayAccess
+   *   List of token values.
+   *   Ex: array('contact' => array('display_name' => 'Alice')).
+   */
+  public $tokens;
+
+  /**
+   * @var array|\ArrayAccess
+   *   List of context values.
+   *   Ex: array('controller' => 'CRM_Foo_Bar').
+   */
+  public $context;
+
+  public function __construct(TokenProcessor $tokenProcessor, $key) {
+    $this->tokenProcessor = $tokenProcessor;
+    $this->tokenRow = $key;
+    $this->format('text/plain'); // Set a default.
+    $this->context = new TokenRowContext($tokenProcessor, $key);
+  }
+
+  /**
+   * @param string $format
+   * @return TokenRow
+   */
+  public function format($format) {
+    $this->format = $format;
+    $this->tokens = &$this->tokenProcessor->rowValues[$this->tokenRow][$format];
+    return $this;
+  }
+
+  /**
+   * Update the value of a context element.
+   *
+   * @param string|array $a
+   * @param mixed $b
+   * @return TokenRow
+   */
+  public function context($a = NULL, $b = NULL) {
+    if (is_array($a)) {
+      \CRM_Utils_Array::extend($this->tokenProcessor->rowContexts[$this->tokenRow], $a);
+    }
+    elseif (is_array($b)) {
+      \CRM_Utils_Array::extend($this->tokenProcessor->rowContexts[$this->tokenRow][$a], $b);
+    }
+    else {
+      $this->tokenProcessor->rowContexts[$this->tokenRow][$a] = $b;
+    }
+    return $this;
+  }
+
+  /**
+   * Update the value of a token.
+   *
+   * @param string|array $a
+   * @param string|array $b
+   * @param mixed $c
+   * @return TokenRow
+   */
+  public function tokens($a = NULL, $b = NULL, $c = NULL) {
+    if (is_array($a)) {
+      \CRM_Utils_Array::extend($this->tokens, $a);
+    }
+    elseif (is_array($b)) {
+      \CRM_Utils_Array::extend($this->tokens[$a], $b);
+    }
+    elseif (is_array($c)) {
+      \CRM_Utils_Array::extend($this->tokens[$a][$b], $c);
+    }
+    elseif ($c === NULL) {
+      $this->tokens[$a] = $b;
+    }
+    else {
+      $this->tokens[$a][$b] = $c;
+    }
+    return $this;
+  }
+
+  /**
+   * Update the value of a token. Apply formatting based on DB schema.
+   *
+   * @param string $tokenEntity
+   * @param string $tokenField
+   * @param string $baoName
+   * @param array $baoField
+   * @param mixed $fieldValue
+   */
+  public function dbToken($tokenEntity, $tokenField, $baoName, $baoField, $fieldValue) {
+    if ($fieldValue === NULL || $fieldValue === '') {
+      return $this->tokens($tokenEntity, $tokenField, '');
+    }
+
+    $fields = $baoName::fields();
+    if (!empty($fields[$baoField]['pseudoconstant'])) {
+      $options = $baoName::buildOptions($baoField, 'get');
+      return $this->format('text/plain')->tokens($tokenEntity, $tokenField, $options[$fieldValue]);
+    }
+
+    switch ($fields[$baoField]['type']) {
+      case \CRM_Utils_Type::T_DATE + \CRM_Utils_Type::T_TIME:
+        return $this->format('text/plain')->tokens($tokenEntity, $tokenField, \CRM_Utils_Date::customFormat($fieldValue));
+
+      case \CRM_Utils_Type::T_MONEY:
+        // Is this something you should ever use? Seems like you need more context
+        // to know which currency to use.
+        return $this->format('text/plain')->tokens($tokenEntity, $tokenField, \CRM_Utils_Money::format($fieldValue));
+
+      case \CRM_Utils_Type::T_STRING:
+      case \CRM_Utils_Type::T_BOOLEAN:
+      case \CRM_Utils_Type::T_INT:
+      case \CRM_Utils_Type::T_TEXT:
+        return $this->format('text/plain')->tokens($tokenEntity, $tokenField, $fieldValue);
+
+    }
+
+    throw new \CRM_Core_Exception("Cannot format token for field '$baoField' in '$baoName'");
+  }
+
+  /**
+   * Auto-convert between different formats
+   *
+   * @param string $format
+   *
+   * @return TokenRow
+   */
+  public function fill($format = NULL) {
+    if ($format === NULL) {
+      $format = $this->format;
+    }
+
+    if (!isset($this->tokenProcessor->rowValues[$this->tokenRow]['text/html'])) {
+      $this->tokenProcessor->rowValues[$this->tokenRow]['text/html'] = array();
+    }
+    if (!isset($this->tokenProcessor->rowValues[$this->tokenRow]['text/plain'])) {
+      $this->tokenProcessor->rowValues[$this->tokenRow]['text/plain'] = array();
+    }
+
+    $htmlTokens = &$this->tokenProcessor->rowValues[$this->tokenRow]['text/html'];
+    $textTokens = &$this->tokenProcessor->rowValues[$this->tokenRow]['text/plain'];
+
+    switch ($format) {
+      case 'text/html':
+        // Plain => HTML.
+        foreach ($textTokens as $entity => $values) {
+          foreach ($values as $field => $value) {
+            if (!isset($htmlTokens[$entity][$field])) {
+              // CRM-18420 - Activity Details Field are enclosed within <p>,
+              // hence if $body_text is empty, htmlentities will lead to
+              // conversion of these tags resulting in raw HTML.
+              if ($entity == 'activity' && $field == 'details') {
+                $htmlTokens[$entity][$field] = $value;
+              }
+              else {
+                $htmlTokens[$entity][$field] = htmlentities($value);
+              }
+            }
+          }
+        }
+        break;
+
+      case 'text/plain':
+        // HTML => Plain.
+        foreach ($htmlTokens as $entity => $values) {
+          foreach ($values as $field => $value) {
+            if (!isset($textTokens[$entity][$field])) {
+              $textTokens[$entity][$field] = html_entity_decode(strip_tags($value));
+            }
+          }
+        }
+        break;
+
+      default:
+        throw new \RuntimeException("Invalid format");
+    }
+
+    return $this;
+  }
+
+  /**
+   * Render a message.
+   *
+   * @param string $name
+   *   The name previously registered with TokenProcessor::addMessage.
+   * @return string
+   *   Fully rendered message, with tokens merged.
+   */
+  public function render($name) {
+    return $this->tokenProcessor->render($name, $this);
+  }
+
+}
+
+/**
+ * Class TokenRowContext
+ * @package Civi\Token
+ *
+ * Combine the row-context and general-context into a single array-like facade.
+ */
+class TokenRowContext implements \ArrayAccess, \IteratorAggregate, \Countable {
+
+  /**
+   * @var TokenProcessor
+   */
+  protected $tokenProcessor;
+
+  protected $tokenRow;
+
+  /**
+   * Class constructor.
+   *
+   * @param array $tokenProcessor
+   * @param array $tokenRow
+   */
+  public function __construct($tokenProcessor, $tokenRow) {
+    $this->tokenProcessor = $tokenProcessor;
+    $this->tokenRow = $tokenRow;
+  }
+
+  /**
+   * Does offset exist.
+   *
+   * @param mixed $offset
+   *
+   * @return bool
+   */
+  public function offsetExists($offset) {
+    return
+      isset($this->tokenProcessor->rowContexts[$this->tokenRow][$offset])
+      || isset($this->tokenProcessor->context[$offset]);
+  }
+
+  /**
+   * Get offset.
+   *
+   * @param string $offset
+   *
+   * @return string
+   */
+  public function &offsetGet($offset) {
+    if (isset($this->tokenProcessor->rowContexts[$this->tokenRow][$offset])) {
+      return $this->tokenProcessor->rowContexts[$this->tokenRow][$offset];
+    }
+    if (isset($this->tokenProcessor->context[$offset])) {
+      return $this->tokenProcessor->context[$offset];
+    }
+    $val = NULL;
+    return $val;
+  }
+
+  /**
+   * Set offset.
+   *
+   * @param string $offset
+   * @param mixed $value
+   */
+  public function offsetSet($offset, $value) {
+    $this->tokenProcessor->rowContexts[$this->tokenRow][$offset] = $value;
+  }
+
+  /**
+   * Unset offset.
+   *
+   * @param mixed $offset
+   */
+  public function offsetUnset($offset) {
+    unset($this->tokenProcessor->rowContexts[$this->tokenRow][$offset]);
+  }
+
+  /**
+   * Get iterator.
+   *
+   * @return \ArrayIterator
+   */
+  public function getIterator() {
+    return new \ArrayIterator($this->createMergedArray());
+  }
+
+  /**
+   * Count.
+   *
+   * @return int
+   */
+  public function count() {
+    return count($this->createMergedArray());
+  }
+
+  /**
+   * Create merged array.
+   *
+   * @return array
+   */
+  protected function createMergedArray() {
+    return array_merge(
+      $this->tokenProcessor->rowContexts[$this->tokenRow],
+      $this->tokenProcessor->context
+    );
+  }
+
+}

--- a/ang/crmMailing.js
+++ b/ang/crmMailing.js
@@ -12,41 +12,50 @@
         controller: 'ListMailingsCtrl'
       });
 
-      var editorPaths = {
-        '': '~/crmMailing/EditMailingCtrl/2step.html',
-        '/unified': '~/crmMailing/EditMailingCtrl/unified.html',
-        '/unified2': '~/crmMailing/EditMailingCtrl/unified2.html',
-        '/wizard': '~/crmMailing/EditMailingCtrl/wizard.html'
-      };
-      angular.forEach(editorPaths, function(editTemplate, pathSuffix) {
-        if (CRM && CRM.crmMailing && CRM.crmMailing.workflowEnabled) {
-            editTemplate = '~/crmMailing/EditMailingCtrl/workflow.html'; // override
+      if (!CRM || !CRM.crmMailing) {
+        return;
+      }
+
+      $routeProvider.when('/mailing/new', {
+        template: '<p>' + ts('Initializing...') + '</p>',
+        controller: 'CreateMailingCtrl',
+        resolve: {
+          selectedMail: function(crmMailingMgr) {
+            var m = crmMailingMgr.create({
+              template_type: CRM.crmMailing.templateTypes[0].name
+            });
+            return crmMailingMgr.save(m);
+          }
         }
-        $routeProvider.when('/mailing/new' + pathSuffix, {
-          template: '<p>' + ts('Initializing...') + '</p>',
-          controller: 'CreateMailingCtrl',
-          resolve: {
-            selectedMail: function(crmMailingMgr) {
-              var m = crmMailingMgr.create();
-              return crmMailingMgr.save(m);
-            }
+      });
+
+      $routeProvider.when('/mailing/new/:templateType', {
+        template: '<p>' + ts('Initializing...') + '</p>',
+        controller: 'CreateMailingCtrl',
+        resolve: {
+          selectedMail: function($route, crmMailingMgr) {
+            var m = crmMailingMgr.create({
+              template_type: $route.current.params.templateType
+            });
+            return crmMailingMgr.save(m);
           }
-        });
-        $routeProvider.when('/mailing/:id' + pathSuffix, {
-          templateUrl: editTemplate,
-          controller: 'EditMailingCtrl',
-          resolve: {
-            selectedMail: function($route, crmMailingMgr) {
-              return crmMailingMgr.get($route.current.params.id);
-            },
-            attachments: function($route, CrmAttachments) {
-              var attachments = new CrmAttachments(function () {
-                return {entity_table: 'civicrm_mailing', entity_id: $route.current.params.id};
-              });
-              return attachments.load();
-            }
+        }
+      });
+
+      $routeProvider.when('/mailing/:id', {
+        templateUrl: '~/crmMailing/EditMailingCtrl/base.html',
+        controller: 'EditMailingCtrl',
+        resolve: {
+          selectedMail: function($route, crmMailingMgr) {
+            return crmMailingMgr.get($route.current.params.id);
+          },
+          attachments: function($route, CrmAttachments) {
+            var attachments = new CrmAttachments(function () {
+              return {entity_table: 'civicrm_mailing', entity_id: $route.current.params.id};
+            });
+            return attachments.load();
           }
-        });
+        }
       });
     }
   ]);

--- a/ang/crmMailing/BlockRecipients.html
+++ b/ang/crmMailing/BlockRecipients.html
@@ -1,4 +1,4 @@
-<div ng-controller="EditRecipCtrl">
+<div ng-controller="EditRecipCtrl" class="crm-mailing-recipients-row">
   <div style="float: right;">
     <div class='crmMailing-recip-est'>
       <a href="" ng-click="previewRecipients()" title="{{ts('Preview a List of Recipients')}}">{{getRecipientsEstimate()}}</a>

--- a/ang/crmMailing/CreateMailingCtrl.js
+++ b/ang/crmMailing/CreateMailingCtrl.js
@@ -1,10 +1,7 @@
 (function(angular, $, _) {
 
   angular.module('crmMailing').controller('CreateMailingCtrl', function EditMailingCtrl($scope, selectedMail, $location) {
-    // Transition URL "/mailing/new/foo" => "/mailing/123/foo"
-    var parts = $location.path().split('/'); // e.g. "/mailing/new" or "/mailing/123/wizard"
-    parts[2] = selectedMail.id;
-    $location.path(parts.join('/'));
+    $location.path("/mailing/" + selectedMail.id);
     $location.replace();
   });
 

--- a/ang/crmMailing/EditMailingCtrl.js
+++ b/ang/crmMailing/EditMailingCtrl.js
@@ -13,6 +13,10 @@
     var block = $scope.block = crmBlocker();
     var myAutosave = null;
 
+    var templateTypes = _.where(CRM.crmMailing.templateTypes, {name: selectedMail.template_type});
+    if (!templateTypes[0]) throw 'Unrecognized template type: ' + selectedMail.template_type;
+    $scope.mailingEditorUrl = templateTypes[0].editorUrl;
+
     $scope.isSubmitted = function isSubmitted() {
       return _.size($scope.mailing.jobs) > 0;
     };
@@ -43,7 +47,7 @@
     // @return Promise
     $scope.submit = function submit(options) {
       options = options || {};
-      if (block.check() || $scope.crmMailing.$invalid) {
+      if (block.check()) {
         return;
       }
 

--- a/ang/crmMailing/EditMailingCtrl/2step.html
+++ b/ang/crmMailing/EditMailingCtrl/2step.html
@@ -1,11 +1,4 @@
-<div crm-ui-debug="mailing"></div>
-
-<div ng-show="isSubmitted()">
-  {{ts('This mailing has been submitted.')}}
-</div>
-
-<form name="crmMailing" novalidate ng-hide="isSubmitted()">
-
+<div ng-form="crmMailingSubform">
   <div class="crm-block crm-form-block crmMailing">
     <div crm-ui-wizard>
       <div crm-ui-wizard-step crm-title="ts('Define Mailing')" ng-form="defineForm">
@@ -49,7 +42,7 @@
           <div crm-mailing-block-schedule crm-mailing="mailing"/>
         </div>
         <center>
-          <a class="button crmMailing-submit-button" ng-click="submit()" ng-class="{blocking: block.check(), disabled: crmMailing.$invalid}">
+          <a class="button crmMailing-submit-button" ng-click="submit()" ng-class="{blocking: block.check(), disabled: crmMailingSubform.$invalid}">
             <div>{{ts('Submit Mailing')}}</div>
           </a>
         </center>
@@ -66,4 +59,4 @@
       </span>
     </div>
   </div>
-</form>
+</div>

--- a/ang/crmMailing/EditMailingCtrl/base.html
+++ b/ang/crmMailing/EditMailingCtrl/base.html
@@ -1,0 +1,8 @@
+<div crm-ui-debug="mailing"></div>
+
+<div ng-show="isSubmitted()">
+  {{ts('This mailing has been submitted.')}}
+</div>
+
+<form name="crmMailing" novalidate ng-hide="isSubmitted()" ng-include="mailingEditorUrl">
+</form>

--- a/ang/crmMailing/EditMailingCtrl/unified.html
+++ b/ang/crmMailing/EditMailingCtrl/unified.html
@@ -1,10 +1,4 @@
-<div crm-ui-debug="mailing"></div>
-
-<div ng-show="isSubmitted()">
-  {{ts('This mailing has been submitted.')}}
-</div>
-
-<form name="crmMailing" novalidate ng-hide="isSubmitted()">
+<div ng-form="crmMailingSubform">
   <div class="crm-block crm-form-block crmMailing">
 
     <div crm-mailing-block-summary crm-mailing="mailing"/>
@@ -43,7 +37,7 @@
       <div crm-mailing-block-schedule crm-mailing="mailing"/>
     </div>
 
-    <button crm-icon="check" ng-disabled="block.check() || crmMailing.$invalid" ng-click="submit()">{{ts('Submit Mailing')}}</button>
+    <button crm-icon="check" ng-disabled="block.check() || crmMailingSubform.$invalid" ng-click="submit()">{{ts('Submit Mailing')}}</button>
     <button crm-icon="disk" ng-disabled="block.check()" ng-click="save().then(leave)">{{ts('Save Draft')}}</button>
     <button
       crm-icon="trash"
@@ -52,4 +46,4 @@
       crm-confirm="{title:ts('Delete Draft'), message:ts('Are you sure you want to permanently delete this mailing?')}"
       on-yes="delete()">{{ts('Delete Draft')}}</button>
   </div>
-</form>
+</div>

--- a/ang/crmMailing/EditMailingCtrl/unified2.html
+++ b/ang/crmMailing/EditMailingCtrl/unified2.html
@@ -1,10 +1,4 @@
-<div crm-ui-debug="mailing"></div>
-
-<div ng-show="isSubmitted()">
-  {{ts('This mailing has been submitted.')}}
-</div>
-
-<form name="crmMailing" novalidate ng-hide="isSubmitted()">
+<div ng-form="crmMailingSubform">
   <div class="crm-block crm-form-block crmMailing">
 
     <div crm-mailing-block-summary crm-mailing="mailing"/>
@@ -39,7 +33,7 @@
       <div crm-mailing-block-schedule crm-mailing="mailing"/>
     </div>
 
-    <button crm-icon="check" ng-disabled="block.check() || crmMailing.$invalid" ng-click="submit()">{{ts('Submit Mailing')}}</button>
+    <button crm-icon="check" ng-disabled="block.check() || crmMailingSubform.$invalid" ng-click="submit()">{{ts('Submit Mailing')}}</button>
     <button crm-icon="disk" ng-disabled="block.check()" ng-click="save().then(leave)">{{ts('Save Draft')}}</button>
     <button
       crm-icon="trash"
@@ -48,4 +42,4 @@
       crm-confirm="{title:ts('Delete Draft'), message:ts('Are you sure you want to permanently delete this mailing?')}"
       on-yes="delete()">{{ts('Delete Draft')}}</button>
   </div>
-</form>
+</div>

--- a/ang/crmMailing/EditMailingCtrl/wizard.html
+++ b/ang/crmMailing/EditMailingCtrl/wizard.html
@@ -1,10 +1,4 @@
-<div crm-ui-debug="mailing"></div>
-
-<div ng-show="isSubmitted()">
-  {{ts('This mailing has been submitted.')}}
-</div>
-
-<form name="crmMailing" novalidate ng-hide="isSubmitted()">
+<div ng-form="crmMailingSubform">
   <div class="crm-block crm-form-block crmMailing">
 
     <div crm-ui-wizard>
@@ -51,7 +45,7 @@
           <div crm-mailing-block-review crm-mailing="mailing"/>
         </div>
         <center>
-          <a class="button crmMailing-submit-button" ng-click="submit()" ng-class="{blocking: block.check(), disabled: crmMailing.$invalid}">
+          <a class="button crmMailing-submit-button" ng-click="submit()" ng-class="{blocking: block.check(), disabled: crmMailingSubform.$invalid}">
             <div>{{ts('Submit Mailing')}}</div>
           </a>
         </center>
@@ -68,4 +62,4 @@
       </span>
     </div>
   </div>
-</form>
+</div>

--- a/ang/crmMailing/EditMailingCtrl/workflow.html
+++ b/ang/crmMailing/EditMailingCtrl/workflow.html
@@ -1,10 +1,4 @@
-<div crm-ui-debug="mailing"></div>
-
-<div ng-show="isSubmitted()">
-  {{ts('This mailing has been submitted.')}}
-</div>
-
-<form name="crmMailing" novalidate ng-hide="isSubmitted()">
+<div ng-form="crmMailingSubform">
   <div class="crm-block crm-form-block crmMailing">
 
     <div crm-ui-wizard>
@@ -53,12 +47,12 @@
           <div crm-mailing-block-approve crm-mailing="mailing"/>
         </div>
         <center ng-if="!checkPerm('approve mailings') && !checkPerm('access CiviMail')">
-          <a class="button crmMailing-submit-button" ng-click="submit()" ng-class="{blocking: block.check(), disabled: crmMailing.$invalid}">
+          <a class="button crmMailing-submit-button" ng-click="submit()" ng-class="{blocking: block.check(), disabled: crmMailingSubform.$invalid}">
             <div>{{ts('Submit Mailing')}}</div>
           </a>
         </center>
         <center ng-if="checkPerm('approve mailings') || checkPerm('access CiviMail')">
-          <a class="button crmMailing-submit-button" ng-click="approve('Approved')" ng-class="{blocking: block.check(), disabled: crmMailing.$invalid}">
+          <a class="button crmMailing-submit-button" ng-click="approve('Approved')" ng-class="{blocking: block.check(), disabled: crmMailingSubform.$invalid}">
             <div>{{ts('Submit and Approve Mailing')}}</div>
           </a>
         </center>
@@ -75,4 +69,4 @@
       </span>
     </div>
   </div>
-</form>
+</div>

--- a/ang/crmMailing/services.js
+++ b/ang/crmMailing/services.js
@@ -155,6 +155,9 @@
             groups: {include: [], exclude: [], base: []},
             mailings: {include: [], exclude: []}
           },
+          template_type: "traditional",
+          // Workaround CRM-19756 w/template_options.nonce
+          template_options: {nonce: 1},
           name: "",
           campaign_id: null,
           replyto_email: "",

--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -30,6 +30,25 @@
  */
 
 /**
+ * If ENV[CIVICRM_UF]==UnitTests, switch to alternate config.
+ */
+if (getenv('CIVICRM_UF') === 'UnitTests') {
+  define('CIVICRM_UF', 'UnitTests');
+  $_CIVI_TEST_DIR = rtrim('%%crmRoot%%', '/') . '/tests/phpunit/CiviTest';
+  if (!defined('CIVICRM_SETTINGS_LOCAL_PATH')) {
+    define('CIVICRM_SETTINGS_LOCAL_PATH', $_CIVI_TEST_DIR . '/civicrm.settings.local.php');
+    if (file_exists(CIVICRM_SETTINGS_LOCAL_PATH)) {
+      require_once CIVICRM_SETTINGS_LOCAL_PATH;
+    }
+  }
+
+  if (!defined('CIVICRM_SETTINGS_PATH')) {
+    define('CIVICRM_SETTINGS_PATH', $_CIVI_TEST_DIR . '/civicrm.settings.dist.php');
+  }
+  require_once $_CIVI_TEST_DIR . '/civicrm.settings.dist.php';
+}
+
+/**
  * Content Management System (CMS) Host:
  *
  * CiviCRM can be hosted in either Drupal 6 or 7, Joomla or WordPress.

--- a/tests/phpunit/CRM/Mailing/BaseMailingSystemTest.php
+++ b/tests/phpunit/CRM/Mailing/BaseMailingSystemTest.php
@@ -1,0 +1,407 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2016                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Test that content produced by CiviMail looks the way it's expected.
+ *
+ * @package CiviCRM_APIv3
+ * @subpackage API_Job
+ *
+ * @copyright CiviCRM LLC (c) 2004-2016
+ * @version $Id: Job.php 30879 2010-11-22 15:45:55Z shot $
+ *
+ */
+
+/**
+ * Class CRM_Mailing_MailingSystemTest
+ * @group headless
+ * @see \Civi\FlexMailer\FlexMailerSystemTest
+ * @see CRM_Mailing_MailingSystemTest
+ */
+abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
+
+  public $DBResetRequired = FALSE;
+  public $defaultParams = array();
+  private $_groupID;
+
+  /**
+   * @var CiviMailUtils
+   */
+  private $_mut;
+
+  public function setUp() {
+    $this->useTransaction();
+    parent::setUp();
+    CRM_Mailing_BAO_MailingJob::$mailsProcessed = 0; // DGW
+
+    $this->_groupID = $this->groupCreate();
+    $this->createContactsInGroup(2, $this->_groupID);
+
+    $this->defaultParams = array(
+      'name' => 'mailing name',
+      'created_id' => 1,
+      'groups' => array('include' => array($this->_groupID)),
+      'scheduled_date' => 'now',
+    );
+    $this->_mut = new CiviMailUtils($this, TRUE);
+    $this->callAPISuccess('mail_settings', 'get',
+      array('api.mail_settings.create' => array('domain' => 'chaos.org')));
+  }
+
+  /**
+   */
+  public function tearDown() {
+    $this->_mut->stop();
+    CRM_Utils_Hook::singleton()->reset();
+    CRM_Mailing_BAO_MailingJob::$mailsProcessed = 0; // DGW
+    parent::tearDown();
+  }
+
+  /**
+   * Generate a fully-formatted mailing with standard email headers.
+   */
+  public function testBasicHeaders() {
+    $allMessages = $this->runMailingSuccess(array(
+      'subject' => 'Accidents in cars cause children for {contact.display_name}!',
+      'body_text' => 'BEWARE children need regular infusions of toys. Santa knows your {domain.address}. There is no {action.optOutUrl}.',
+    ));
+    foreach ($allMessages as $k => $message) {
+      /** @var ezcMail $message */
+
+      $offset = $k + 1;
+
+      $this->assertEquals("FIXME", $message->from->name);
+      $this->assertEquals("info@EXAMPLE.ORG", $message->from->email);
+      $this->assertEquals("Mr. Foo{$offset} Anderson II", $message->to[0]->name);
+      $this->assertEquals("mail{$offset}@nul.example.com", $message->to[0]->email);
+
+      $this->assertRegExp('#^text/plain; charset=utf-8#', $message->headers['Content-Type']);
+      $this->assertRegExp(';^b\.[\d\.a-f]+@chaos.org$;', $message->headers['Return-Path']);
+      $this->assertRegExp(';^b\.[\d\.a-f]+@chaos.org$;', $message->headers['X-CiviMail-Bounce'][0]);
+      $this->assertRegExp(';^\<mailto:u\.[\d\.a-f]+@chaos.org\>$;', $message->headers['List-Unsubscribe'][0]);
+      $this->assertEquals('bulk', $message->headers['Precedence'][0]);
+    }
+  }
+
+  /**
+   * Generate a fully-formatted mailing (with body_text content).
+   */
+  public function testText() {
+    $allMessages = $this->runMailingSuccess(array(
+      'subject' => 'Accidents in cars cause children for {contact.display_name}!',
+      'body_text' => 'BEWARE children need regular infusions of toys. Santa knows your {domain.address}. There is no {action.optOutUrl}.',
+      'open_tracking' => 1,
+      // Note: open_tracking does nothing with text, but we'll just verify that it does nothing
+    ));
+    foreach ($allMessages as $k => $message) {
+      /** @var ezcMail $message */
+      /** @var ezcMailText $textPart */
+
+      $this->assertTrue($message->body instanceof ezcMailText);
+
+      $this->assertEquals('plain', $message->body->subType);
+      $this->assertRegExp(
+        ";" .
+        "Sample Header for TEXT formatted content.\n" . // Default header
+        "BEWARE children need regular infusions of toys. Santa knows your .*\\. There is no http.*civicrm/mailing/optout.*\\.\n" .
+        "to unsubscribe: http.*civicrm/mailing/optout" . // Default footer
+        ";",
+        $message->body->text
+      );
+    }
+  }
+
+  /**
+   * Generate a fully-formatted mailing (with body_html content).
+   */
+  public function testHtmlWithOpenTracking() {
+    $allMessages = $this->runMailingSuccess(array(
+      'subject' => 'Example Subject',
+      'body_html' => '<p>You can go to <a href="http://example.net/first?{contact.checksum}">Google</a> or <a href="{action.optOutUrl}">opt out</a>.</p>',
+      'open_tracking' => 1,
+      'url_tracking' => 0,
+    ));
+    foreach ($allMessages as $k => $message) {
+      /** @var ezcMail $message */
+      /** @var ezcMailText $htmlPart */
+      /** @var ezcMailText $textPart */
+
+      $this->assertTrue($message->body instanceof ezcMailMultipartAlternative);
+
+      list($textPart, $htmlPart) = $message->body->getParts();
+
+      $this->assertEquals('html', $htmlPart->subType);
+      $this->assertRegExp(
+        ";" .
+        "Sample Header for HTML formatted content.\n" . // Default header
+        // FIXME: CiviMail puts double " after hyperlink!
+        "<p>You can go to <a href=\"http://example.net/first\\?cs=[0-9a-f_]+\"\"?>Google</a> or <a href=\"http.*civicrm/mailing/optout.*\">opt out</a>.</p>\n" . // body_html
+        "Sample Footer for HTML formatted content" . // Default footer
+        ".*\n" .
+        "<img src=\".*extern/open.php.*\"" .
+        ";",
+        $htmlPart->text
+      );
+
+      $this->assertEquals('plain', $textPart->subType);
+      $this->assertRegExp(
+        ";" .
+        "Sample Header for TEXT formatted content.\n" . // Default header
+        "You can go to Google \\[1\\] or opt out \\[2\\]\\.\n" . //  body_html, filtered
+        "\n" .
+        "Links:\n" .
+        "------\n" .
+        "\\[1\\] http://example.net/first\\?cs=[0-9a-f_]+\n" .
+        "\\[2\\] http.*civicrm/mailing/optout.*\n" .
+        "\n" .
+        "to unsubscribe: http.*civicrm/mailing/optout" . // Default footer
+        ";",
+        $textPart->text
+      );
+    }
+  }
+
+  /**
+   * Generate a fully-formatted mailing (with body_html content).
+   */
+  public function testHtmlWithOpenAndUrlTracking() {
+    $allMessages = $this->runMailingSuccess(array(
+      'subject' => 'Example Subject',
+      'body_html' => '<p>You can go to <a href="http://example.net">Google</a> or <a href="{action.optOutUrl}">opt out</a>.</p>',
+      'open_tracking' => 1,
+      'url_tracking' => 1,
+    ));
+    foreach ($allMessages as $k => $message) {
+      /** @var ezcMail $message */
+      /** @var ezcMailText $htmlPart */
+      /** @var ezcMailText $textPart */
+
+      $this->assertTrue($message->body instanceof ezcMailMultipartAlternative);
+
+      list($textPart, $htmlPart) = $message->body->getParts();
+
+      $this->assertEquals('html', $htmlPart->subType);
+      $this->assertRegExp(
+        ";" .
+        // body_html
+        "<p>You can go to <a href=['\"].*extern/url\.php\?u=\d+&amp\\;qid=\d+['\"]>Google</a>" .
+        " or <a href=\"http.*civicrm/mailing/optout.*\">opt out</a>.</p>\n" .
+        // Default footer
+        "Sample Footer for HTML formatted content" .
+        ".*\n" .
+        // Open-tracking code
+        "<img src=\".*extern/open.php.*\"" .
+        ";",
+        $htmlPart->text
+      );
+
+      $this->assertEquals('plain', $textPart->subType);
+      $this->assertRegExp(
+        ";" .
+        //  body_html, filtered
+        "You can go to Google \\[1\\] or opt out \\[2\\]\\.\n" .
+        "\n" .
+        "Links:\n" .
+        "------\n" .
+        "\\[1\\] .*extern/url\.php\?u=\d+&qid=\d+\n" .
+        "\\[2\\] http.*civicrm/mailing/optout.*\n" .
+        "\n" .
+        // Default footer
+        "to unsubscribe: http.*civicrm/mailing/optout" .
+        ";",
+        $textPart->text
+      );
+    }
+  }
+
+  public function urlTrackingExamples() {
+    $cases = array();
+
+    // Each case comes in four parts:
+    // 1. Mailing HTML (body_html)
+    // 2. Regex to run against final HTML
+    // 3. Regex to run against final text
+    // 4. Additional mailing options
+
+    // Tracking disabled
+
+    $cases[] = array(
+      '<p><a href="http://example.net/">Foo</a></p>',
+      ';<p><a href="http://example\.net/">Foo</a></p>;',
+      ';\\[1\\] http://example\.net/;',
+      array('url_tracking' => 0),
+    );
+    $cases[] = array(
+      '<p><a href="http://example.net/?id={contact.contact_id}">Foo</a></p>',
+      // FIXME: Legacy tracker adds extra quote after URL
+      ';<p><a href="http://example\.net/\?id=\d+""?>Foo</a></p>;',
+      ';\\[1\\] http://example\.net/\?id=\d+;',
+      array('url_tracking' => 0),
+    );
+    $cases[] = array(
+      '<p><a href="{action.optOutUrl}">Foo</a></p>',
+      ';<p><a href="http.*civicrm/mailing/optout.*">Foo</a></p>;',
+      ';\\[1\\] http.*civicrm/mailing/optout.*;',
+      array('url_tracking' => 0),
+    );
+    $cases[] = array(
+      '<p>Look at <img src="http://example.net/foo.png">.</p>',
+      ';<p>Look at <img src="http://example\.net/foo\.png">\.</p>;',
+      ';Look at \.;',
+      array('url_tracking' => 0),
+    );
+    $cases[] = array(
+      // Plain-text URL's are tracked in plain-text emails...
+      // but not in HTML emails.
+      "<p>Please go to: http://example.net/</p>",
+      ";<p>Please go to: http://example\.net/</p>;",
+      ';Please go to: http://example\.net/;',
+      array('url_tracking' => 0),
+    );
+
+    // Tracking enabled
+
+    $cases[] = array(
+      '<p><a href="http://example.net/">Foo</a></p>',
+      ';<p><a href=[\'"].*extern/url\.php\?u=\d+.*[\'"]>Foo</a></p>;',
+      ';\\[1\\] .*extern/url\.php\?u=\d+.*;',
+      array('url_tracking' => 1),
+    );
+    $cases[] = array(
+      // FIXME: CiviMail URL tracking doesn't track tokenized links.
+      '<p><a href="http://example.net/?id={contact.contact_id}">Foo</a></p>',
+      // FIXME: Legacy tracker adds extra quote after URL
+      ';<p><a href="http://example\.net/\?id=\d+""?>Foo</a></p>;',
+      ';\\[1\\] http://example\.net/\?id=\d+;',
+      array('url_tracking' => 1),
+    );
+    $cases[] = array(
+      // It would be redundant/slow to track the action URLs?
+      '<p><a href="{action.optOutUrl}">Foo</a></p>',
+      ';<p><a href="http.*civicrm/mailing/optout.*">Foo</a></p>;',
+      ';\\[1\\] http.*civicrm/mailing/optout.*;',
+      array('url_tracking' => 1),
+    );
+    $cases[] = array(
+      // It would be excessive/slow to track every embedded image.
+      '<p>Look at <img src="http://example.net/foo.png">.</p>',
+      ';<p>Look at <img src="http://example\.net/foo\.png">\.</p>;',
+      ';Look at \.;',
+      array('url_tracking' => 1),
+    );
+    $cases[] = array(
+      // Plain-text URL's are tracked in plain-text emails...
+      // but not in HTML emails.
+      "<p>Please go to: http://example.net/</p>",
+      ";<p>Please go to: http://example\.net/</p>;",
+      ';Please go to: .*extern/url.php\?u=\d+&qid=\d+;',
+      array('url_tracking' => 1),
+    );
+
+    return $cases;
+  }
+
+  /**
+   * Generate a fully-formatted mailing (with body_html content).
+   *
+   * @dataProvider urlTrackingExamples
+   */
+  public function testUrlTracking($inputHtml, $htmlUrlRegex, $textUrlRegex, $params) {
+    $caseName = print_r(array('inputHtml' => $inputHtml, 'params' => $params), 1);
+
+    $allMessages = $this->runMailingSuccess($params + array(
+      'subject' => 'Example Subject',
+      'body_html' => $inputHtml,
+    ));
+    foreach ($allMessages as $k => $message) {
+      /** @var ezcMail $message */
+      /** @var ezcMailText $htmlPart */
+      /** @var ezcMailText $textPart */
+
+      $this->assertTrue($message->body instanceof ezcMailMultipartAlternative);
+
+      list($textPart, $htmlPart) = $message->body->getParts();
+
+      if ($htmlUrlRegex) {
+        $this->assertEquals('html', $htmlPart->subType, "Should have HTML part in case: $caseName");
+        $this->assertRegExp($htmlUrlRegex, $htmlPart->text, "Should have correct HTML in case: $caseName");
+      }
+
+      if ($textUrlRegex) {
+        $this->assertEquals('plain', $textPart->subType, "Should have text part in case: $caseName");
+        $this->assertRegExp($textUrlRegex, $textPart->text, "Should have correct text in case: $caseName");
+      }
+    }
+  }
+
+  /**
+   * Create contacts in group.
+   *
+   * @param int $count
+   * @param int $groupID
+   * @param string $domain
+   */
+  protected function createContactsInGroup(
+    $count,
+    $groupID,
+    $domain = 'nul.example.com'
+  ) {
+    for ($i = 1; $i <= $count; $i++) {
+      $contactID = $this->individualCreate(array(
+        'first_name' => "Foo{$i}",
+        'email' => 'mail' . $i . '@' . $domain,
+      ));
+      $this->callAPISuccess('group_contact', 'create', array(
+        'contact_id' => $contactID,
+        'group_id' => $groupID,
+        'status' => 'Added',
+      ));
+    }
+  }
+
+  /**
+   * Create and execute a mailing. Return the matching messages.
+   *
+   * @param array $params
+   *   List of parameters to send to Mailing.create API.
+   * @return array<ezcMail>
+   */
+  protected function runMailingSuccess($params) {
+    $mailingParams = array_merge($this->defaultParams, $params);
+    $this->callAPISuccess('mailing', 'create', $mailingParams);
+    $this->_mut->assertRecipients(array());
+    $this->callAPISuccess('job', 'process_mailing', array());
+
+    $allMessages = $this->_mut->getAllMessages('ezc');
+    // There are exactly two contacts produced by setUp().
+    $this->assertEquals(2, count($allMessages));
+
+    return $allMessages;
+  }
+
+}

--- a/tests/phpunit/CRM/Mailing/BaseMailingSystemTest.php
+++ b/tests/phpunit/CRM/Mailing/BaseMailingSystemTest.php
@@ -36,6 +36,9 @@
  *
  */
 
+require_once 'CiviTest/CiviUnitTestCase.php';
+require_once 'CiviTest/CiviMailUtils.php';
+
 /**
  * Class CRM_Mailing_MailingSystemTest
  * @group headless
@@ -130,7 +133,7 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
         "Sample Header for TEXT formatted content.\n" . // Default header
         "BEWARE children need regular infusions of toys. Santa knows your .*\\. There is no http.*civicrm/mailing/optout.*\\.\n" .
         "to unsubscribe: http.*civicrm/mailing/optout" . // Default footer
-        ";",
+        ";s",
         $message->body->text
       );
     }
@@ -171,16 +174,14 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
       $this->assertEquals('plain', $textPart->subType);
       $this->assertRegExp(
         ";" .
-        "Sample Header for TEXT formatted content.\n" . // Default header
-        "You can go to Google \\[1\\] or opt out \\[2\\]\\.\n" . //  body_html, filtered
+        "Sample Header for (HTML|TEXT) formatted content..*" . // Default header; note 4.6+4.7 differ
+        "You can go to Google \\[1\\] or opt out \\[2\\]\\..*" . //  body_html, filtered
         "\n" .
         "Links:\n" .
         "------\n" .
         "\\[1\\] http://example.net/first\\?cs=[0-9a-f_]+\n" .
         "\\[2\\] http.*civicrm/mailing/optout.*\n" .
-        "\n" .
-        "to unsubscribe: http.*civicrm/mailing/optout" . // Default footer
-        ";",
+        ";s",
         $textPart->text
       );
     }
@@ -224,16 +225,13 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
       $this->assertRegExp(
         ";" .
         //  body_html, filtered
-        "You can go to Google \\[1\\] or opt out \\[2\\]\\.\n" .
-        "\n" .
+        "You can go to Google \\[1\\] or opt out \\[2\\]\\." .
+        ".*" .
         "Links:\n" .
         "------\n" .
         "\\[1\\] .*extern/url\.php\?u=\d+&qid=\d+\n" .
         "\\[2\\] http.*civicrm/mailing/optout.*\n" .
-        "\n" .
-        // Default footer
-        "to unsubscribe: http.*civicrm/mailing/optout" .
-        ";",
+        ";s",
         $textPart->text
       );
     }

--- a/tests/phpunit/CRM/Mailing/MailingSystemTest.php
+++ b/tests/phpunit/CRM/Mailing/MailingSystemTest.php
@@ -1,0 +1,114 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2016                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Test that content produced by CiviMail looks the way it's expected.
+ *
+ * @package CiviCRM_APIv3
+ * @subpackage API_Job
+ *
+ * @copyright CiviCRM LLC (c) 2004-2016
+ * @version $Id: Job.php 30879 2010-11-22 15:45:55Z shot $
+ *
+ */
+
+/**
+ * Class CRM_Mailing_MailingSystemTest
+ *
+ * MailingSystemTest checks that overall composition and delivery of
+ * CiviMail blasts works. It extends CRM_Mailing_BaseMailingSystemTest
+ * which provides the general test scenarios -- but this variation
+ * checks that certain internal events/hooks fire.
+ *
+ * MailingSystemTest is the counterpart to FlexMailerSystemTest.
+ *
+ * @group headless
+ * @group civimail
+ * @see \Civi\FlexMailer\FlexMailerSystemTest
+ */
+class CRM_Mailing_MailingSystemTest extends CRM_Mailing_BaseMailingSystemTest {
+
+  private $counts;
+
+  public function setUp() {
+    parent::setUp();
+    Civi::settings()->add(array('experimentalFlexMailerEngine' => FALSE));
+
+    $hooks = \CRM_Utils_Hook::singleton();
+    $hooks->setHook('civicrm_alterMailParams',
+      array($this, 'hook_alterMailParams'));
+  }
+
+  /**
+   * @see CRM_Utils_Hook::alterMailParams
+   */
+  public function hook_alterMailParams(&$params, $context = NULL) {
+    $this->counts['hook_alterMailParams'] = 1;
+    $this->assertEquals('civimail', $context);
+  }
+
+  public function tearDown() {
+    parent::tearDown();
+    $this->assertNotEmpty($this->counts['hook_alterMailParams']);
+  }
+
+  // ---- Boilerplate ----
+
+  // The remainder of this class contains dummy stubs which make it easier to
+  // work with the tests in an IDE.
+
+  /**
+   * Generate a fully-formatted mailing (with body_html content).
+   *
+   * @dataProvider urlTrackingExamples
+   */
+  public function testUrlTracking(
+    $inputHtml,
+    $htmlUrlRegex,
+    $textUrlRegex,
+    $params
+  ) {
+    parent::testUrlTracking($inputHtml, $htmlUrlRegex, $textUrlRegex, $params);
+  }
+
+  public function testBasicHeaders() {
+    parent::testBasicHeaders();
+  }
+
+  public function testText() {
+    parent::testText();
+  }
+
+  public function testHtmlWithOpenTracking() {
+    parent::testHtmlWithOpenTracking();
+  }
+
+  public function testHtmlWithOpenAndUrlTracking() {
+    parent::testHtmlWithOpenAndUrlTracking();
+  }
+
+}

--- a/tests/phpunit/CRM/Mailing/MailingSystemTest.php
+++ b/tests/phpunit/CRM/Mailing/MailingSystemTest.php
@@ -36,6 +36,8 @@
  *
  */
 
+require_once 'tests/phpunit/CRM/Mailing/BaseMailingSystemTest.php';
+
 /**
  * Class CRM_Mailing_MailingSystemTest
  *
@@ -56,7 +58,7 @@ class CRM_Mailing_MailingSystemTest extends CRM_Mailing_BaseMailingSystemTest {
 
   public function setUp() {
     parent::setUp();
-    Civi::settings()->add(array('experimentalFlexMailerEngine' => FALSE));
+    CRM_Core_BAO_Setting::setItem(FALSE, 'Mailing Preferences', 'experimentalFlexMailerEngine');
 
     $hooks = \CRM_Utils_Hook::singleton();
     $hooks->setHook('civicrm_alterMailParams',
@@ -104,10 +106,12 @@ class CRM_Mailing_MailingSystemTest extends CRM_Mailing_BaseMailingSystemTest {
   }
 
   public function testHtmlWithOpenTracking() {
+    // $this->markTestSkipped('BaseMailingSystemTest::testHtmlWithOpenTracking does not apply to v4.6. CiviMail in v4.6 has old behavior.');
     parent::testHtmlWithOpenTracking();
   }
 
   public function testHtmlWithOpenAndUrlTracking() {
+    // $this->markTestSkipped('BaseMailingSystemTest::testHtmlWithOpenAndUrlTracking does not apply. CiviMail in v4.6 has old behavior.');
     parent::testHtmlWithOpenAndUrlTracking();
   }
 

--- a/tests/phpunit/CRM/Mailing/TokensTest.php
+++ b/tests/phpunit/CRM/Mailing/TokensTest.php
@@ -1,0 +1,106 @@
+<?php
+
+require_once 'CiviTest/CiviUnitTestCase.php';
+
+/**
+ * @group headless
+ */
+class CRM_Mailing_TokensTest extends \CiviUnitTestCase {
+  protected function setUp() {
+    $this->useTransaction();
+    parent::setUp();
+    $this->callAPISuccess('mail_settings', 'get',
+      array('api.mail_settings.create' => array('domain' => 'chaos.org')));
+  }
+
+  public function getExampleTokens() {
+    $cases = array();
+
+    $cases[] = array('text/plain', 'The {mailing.id}!', ';The [0-9]+!;');
+    $cases[] = array('text/plain', 'The {mailing.name}!', ';The Example Name!;');
+    $cases[] = array('text/plain', 'The {mailing.editUrl}!', ';The http.*civicrm/mailing/send.*!;');
+    $cases[] = array('text/plain', 'To subscribe: {action.subscribeUrl}!', ';To subscribe: http.*civicrm/mailing/subscribe.*!;');
+    $cases[] = array('text/plain', 'To optout: {action.optOutUrl}!', ';To optout: http.*civicrm/mailing/optout.*!;');
+    $cases[] = array('text/plain', 'To unsubscribe: {action.unsubscribe}!', ';To unsubscribe: u\.123\.456\.abcd1234@chaos.org!;');
+
+    // TODO: Think about supporting dynamic tokens like "{action.subscribe.\d+}"
+
+    return $cases;
+  }
+
+  /**
+   * Check that mailing-tokens are generated (given a mailing_id as input).
+   *
+   * @param string $inputTemplateFormat
+   *   Ex: 'text/plain' or 'text/html'
+   * @param string $inputTemplate
+   *   Ex: 'Hello, {contact.first_name}'.
+   * @param string $expectRegex
+   * @dataProvider getExampleTokens
+   */
+  public function testTokensWithMailingId($inputTemplateFormat, $inputTemplate, $expectRegex) {
+    $mailing = CRM_Core_DAO::createTestObject('CRM_Mailing_DAO_Mailing', array(
+      'name' => 'Example Name',
+    ));
+    $contact = CRM_Core_DAO::createTestObject('CRM_Contact_DAO_Contact');
+
+    $p = new \Civi\Token\TokenProcessor(Civi::service('dispatcher'), array(
+      'mailingId' => $mailing->id,
+    ));
+    $p->addMessage('example', $inputTemplate, $inputTemplateFormat);
+    $p->addRow()->context(array(
+      'contactId' => $contact->id,
+      'mailingJobId' => 123,
+      'mailingActionTarget' => array(
+        'id' => 456,
+        'hash' => 'abcd1234',
+        'email' => 'someone@example.com',
+      ),
+    ));
+    $p->evaluate();
+    $count = 0;
+    foreach ($p->getRows() as $row) {
+      $this->assertRegExp($expectRegex, $row->render('example'));
+      $count++;
+    }
+    $this->assertEquals(1, $count);
+  }
+
+  /**
+   * Check that mailing-tokens are generated (given a mailing DAO as input).
+   */
+  public function testTokensWithMailingObject() {
+    // We only need one case to see that the mailing-object works as
+    // an alternative to the mailing-id.
+    $inputTemplateFormat = 'text/plain';
+    $inputTemplate = 'To optout: {action.optOutUrl}!';
+    $expectRegex = ';To optout: http.*civicrm/mailing/optout.*!;';
+
+    $mailing = CRM_Core_DAO::createTestObject('CRM_Mailing_DAO_Mailing', array(
+      'name' => 'Example Name',
+    ));
+    $contact = CRM_Core_DAO::createTestObject('CRM_Contact_DAO_Contact');
+
+    $p = new \Civi\Token\TokenProcessor(Civi::service('dispatcher'), array(
+      'mailing' => $mailing,
+    ));
+    $p->addMessage('example', $inputTemplate, $inputTemplateFormat);
+    $p->addRow()->context(array(
+      'contactId' => $contact->id,
+      'mailingJobId' => 123,
+      'mailingActionTarget' => array(
+        'id' => 456,
+        'hash' => 'abcd1234',
+        'email' => 'someone@example.com',
+      ),
+    ));
+    $p->evaluate();
+    $count = 0;
+    foreach ($p->getRows() as $row) {
+      $this->assertRegExp($expectRegex, $row->render('example'));
+      $count++;
+    }
+    $this->assertEquals(1, $count);
+  }
+
+}

--- a/tests/phpunit/CRM/Mailing/TokensTest.php
+++ b/tests/phpunit/CRM/Mailing/TokensTest.php
@@ -103,4 +103,35 @@ class CRM_Mailing_TokensTest extends \CiviUnitTestCase {
     $this->assertEquals(1, $count);
   }
 
+  /**
+   * Check the behavior in the erroneous situation where someone uses
+   * a mailing-related token without providing a mailing ID.
+   */
+  public function testTokensWithoutMailing() {
+    // We only need one case to see that the mailing-object works as
+    // an alternative to the mailing-id.
+    $inputTemplateFormat = 'text/plain';
+    $inputTemplate = 'To optout: {action.optOutUrl}!';
+
+    $mailing = CRM_Core_DAO::createTestObject('CRM_Mailing_DAO_Mailing', array(
+      'name' => 'Example Name',
+    ));
+    $contact = CRM_Core_DAO::createTestObject('CRM_Contact_DAO_Contact');
+
+    $p = new \Civi\Token\TokenProcessor(Civi::service('dispatcher'), array(
+      'mailing' => $mailing,
+    ));
+    $p->addMessage('example', $inputTemplate, $inputTemplateFormat);
+    $p->addRow()->context(array(
+      'contactId' => $contact->id,
+    ));
+    try {
+      $p->evaluate();
+      $this->fail('TokenProcessor::evaluate() should have thrown an exception');
+    }
+    catch (CRM_Core_Exception $e) {
+      $this->assertRegExp(';Cannot use action tokens unless context defines mailingJobId and mailingActionTarget;', $e->getMessage());
+    }
+  }
+
 }

--- a/tests/phpunit/CRM/Utils/StringTest.php
+++ b/tests/phpunit/CRM/Utils/StringTest.php
@@ -165,4 +165,66 @@ class CRM_Utils_StringTest extends CiviUnitTestCase {
     $this->assertTrue($expected === $actual);
   }
 
+  public function startEndCases() {
+    $cases = array();
+    $cases[] = array('startsWith', 'foo', '', TRUE);
+    $cases[] = array('startsWith', 'foo', 'f', TRUE);
+    $cases[] = array('startsWith', 'foo', 'fo', TRUE);
+    $cases[] = array('startsWith', 'foo', 'foo', TRUE);
+    $cases[] = array('startsWith', 'foo', 'fooo', FALSE);
+    $cases[] = array('startsWith', 'foo', 'o', FALSE);
+    $cases[] = array('endsWith', 'foo', 'f', FALSE);
+    $cases[] = array('endsWith', 'foo', '', TRUE);
+    $cases[] = array('endsWith', 'foo', 'o', TRUE);
+    $cases[] = array('endsWith', 'foo', 'oo', TRUE);
+    $cases[] = array('endsWith', 'foo', 'foo', TRUE);
+    $cases[] = array('endsWith', 'foo', 'fooo', FALSE);
+    $cases[] = array('endsWith', 'foo*', '*', TRUE);
+    return $cases;
+  }
+
+  /**
+   * @param string $func
+   *   One of: 'startsWith' or 'endsWith'.
+   * @param $string
+   * @param $fragment
+   * @param $expectedResult
+   * @dataProvider startEndCases
+   */
+  public function testStartEndWith($func, $string, $fragment, $expectedResult) {
+    $actualResult = \CRM_Utils_String::$func($string, $fragment);
+    $this->assertEquals($expectedResult, $actualResult, "Checking $func($string,$fragment)");
+  }
+
+  public function wildcardCases() {
+    $cases = array();
+    $cases[] = array('*', array('foo.bar.1', 'foo.bar.2', 'foo.whiz', 'bang.bang'));
+    $cases[] = array('foo.*', array('foo.bar.1', 'foo.bar.2', 'foo.whiz'));
+    $cases[] = array('foo.bar.*', array('foo.bar.1', 'foo.bar.2'));
+    $cases[] = array(array('foo.bar.*', 'foo.bar.2'), array('foo.bar.1', 'foo.bar.2'));
+    $cases[] = array(array('foo.bar.2', 'foo.w*'), array('foo.bar.2', 'foo.whiz'));
+    return $cases;
+  }
+
+  /**
+   * @param $patterns
+   * @param $expectedResults
+   * @dataProvider wildcardCases
+   */
+  public function testFilterByWildCards($patterns, $expectedResults) {
+    $data = array('foo.bar.1', 'foo.bar.2', 'foo.whiz', 'bang.bang');
+
+    $actualResults = CRM_Utils_String::filterByWildcards($patterns, $data);
+    $this->assertEquals($expectedResults, $actualResults);
+
+    $patterns = (array) $patterns;
+    $patterns[] = 'noise';
+
+    $actualResults = CRM_Utils_String::filterByWildcards($patterns, $data, FALSE);
+    $this->assertEquals($expectedResults, $actualResults);
+
+    $actualResults = CRM_Utils_String::filterByWildcards($patterns, $data, TRUE);
+    $this->assertEquals(array_merge($expectedResults, array('noise')), $actualResults);
+  }
+
 }

--- a/tests/phpunit/Civi/Angular/ManagerTest.php
+++ b/tests/phpunit/Civi/Angular/ManagerTest.php
@@ -111,7 +111,7 @@ class ManagerTest extends \CiviUnitTestCase {
    */
   public function testGetPartials() {
     $partials = $this->angular->getPartials('crmMailing');
-    $this->assertRegExp('/\<form.*name="crmMailing"/', $partials['~/crmMailing/EditMailingCtrl/2step.html']);
+    $this->assertRegExp('/ng-form="crmMailing/', $partials['~/crmMailing/EditMailingCtrl/2step.html']);
     // If crmMailing changes, feel free to use a different example.
   }
 

--- a/tests/phpunit/Civi/Token/TokenProcessorTest.php
+++ b/tests/phpunit/Civi/Token/TokenProcessorTest.php
@@ -1,0 +1,169 @@
+<?php
+namespace Civi\Token;
+
+require_once 'CiviTest/CiviUnitTestCase.php';
+
+use Civi\Token\Event\TokenRegisterEvent;
+use Civi\Token\Event\TokenValueEvent;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+class TokenProcessorTest extends \CiviUnitTestCase {
+
+  /**
+   * @var EventDispatcher
+   */
+  protected $dispatcher;
+
+  /**
+   * @var array
+   *   Array(string $funcName => int $invocationCount).
+   */
+  protected $counts;
+
+  protected function setUp() {
+    $this->useTransaction(TRUE);
+    parent::setUp();
+    $this->dispatcher = new EventDispatcher();
+    $this->dispatcher->addListener(Events::TOKEN_REGISTER, array($this, 'onListTokens'));
+    $this->dispatcher->addListener(Events::TOKEN_EVALUATE, array($this, 'onEvalTokens'));
+    $this->counts = array(
+      'onListTokens' => 0,
+      'onEvalTokens' => 0,
+    );
+  }
+
+  /**
+   * Check that the TokenRow helper can correctly read/update context
+   * values.
+   */
+  public function testRowContext() {
+    $p = new TokenProcessor($this->dispatcher, array(
+      'controller' => __CLASS__,
+      'omega' => '99',
+    ));
+    $createdRow = $p->addRow()
+      ->context('one', 1)
+      ->context('two', array(2 => 3))
+      ->context(array(
+        'two' => array(4 => 5),
+        'three' => array(6 => 7),
+        'omega' => '98',
+      ));
+    $gotRow = $p->getRow(0);
+    foreach (array($createdRow, $gotRow) as $row) {
+      $this->assertEquals(1, $row->context['one']);
+      $this->assertEquals(3, $row->context['two'][2]);
+      $this->assertEquals(5, $row->context['two'][4]);
+      $this->assertEquals(7, $row->context['three'][6]);
+      $this->assertEquals(98, $row->context['omega']);
+      $this->assertEquals(__CLASS__, $row->context['controller']);
+    }
+  }
+
+  /**
+   * Check that the TokenRow helper can correctly read/update token
+   * values.
+   */
+  public function testRowTokens() {
+    $p = new TokenProcessor($this->dispatcher, array(
+      'controller' => __CLASS__,
+    ));
+    $createdRow = $p->addRow()
+      ->tokens('one', 1)
+      ->tokens('two', array(2 => 3))
+      ->tokens(array(
+        'two' => array(4 => 5),
+        'three' => array(6 => 7),
+      ))
+      ->tokens('four', 8, 9);
+    $gotRow = $p->getRow(0);
+    foreach (array($createdRow, $gotRow) as $row) {
+      $this->assertEquals(1, $row->tokens['one']);
+      $this->assertEquals(3, $row->tokens['two'][2]);
+      $this->assertEquals(5, $row->tokens['two'][4]);
+      $this->assertEquals(7, $row->tokens['three'][6]);
+      $this->assertEquals(9, $row->tokens['four'][8]);
+    }
+  }
+
+  public function testGetMessageTokens() {
+    $p = new TokenProcessor($this->dispatcher, array(
+      'controller' => __CLASS__,
+    ));
+    $p->addMessage('greeting_html', 'Good morning, <p>{contact.display_name}</p>. {custom.foobar}!', 'text/html');
+    $p->addMessage('greeting_text', 'Good morning, {contact.display_name}. {custom.whizbang}, {contact.first_name}!', 'text/plain');
+    $expected = array(
+      'contact' => array('display_name', 'first_name'),
+      'custom' => array('foobar', 'whizbang'),
+    );
+    $this->assertEquals($expected, $p->getMessageTokens());
+  }
+
+  /**
+   * Perform a full mail-merge, substituting multiple tokens for multiple
+   * contacts in multiple messages.
+   */
+  public function testFull() {
+    $p = new TokenProcessor($this->dispatcher, array(
+      'controller' => __CLASS__,
+    ));
+    $p->addMessage('greeting_html', 'Good morning, <p>{contact.display_name}</p>. {custom.foobar} Bye!', 'text/html');
+    $p->addMessage('greeting_text', 'Good morning, {contact.display_name}. {custom.foobar} Bye!', 'text/plain');
+    $p->addRow()
+      ->context(array('contact_id' => 123))
+      ->format('text/plain')->tokens(array(
+        'contact' => array('display_name' => 'What'),
+      ));
+    $p->addRow()
+      ->context(array('contact_id' => 4))
+      ->format('text/plain')->tokens(array(
+        'contact' => array('display_name' => 'Who'),
+      ));
+    $p->addRow()
+      ->context(array('contact_id' => 10))
+      ->format('text/plain')->tokens(array(
+        'contact' => array('display_name' => 'Darth Vader'),
+      ));
+
+    $expectHtml = array(
+      0 => 'Good morning, <p>What</p>. #0123 is a good number. Trickster {contact.display_name}. Bye!',
+      1 => 'Good morning, <p>Who</p>. #0004 is a good number. Trickster {contact.display_name}. Bye!',
+      2 => 'Good morning, <p>Darth Vader</p>. #0010 is a good number. Trickster {contact.display_name}. Bye!',
+    );
+
+    $expectText = array(
+      0 => 'Good morning, What. #0123 is a good number. Trickster {contact.display_name}. Bye!' ,
+      1 => 'Good morning, Who. #0004 is a good number. Trickster {contact.display_name}. Bye!',
+      2 => 'Good morning, Darth Vader. #0010 is a good number. Trickster {contact.display_name}. Bye!',
+    );
+
+    $rowCount = 0;
+    foreach ($p->evaluate()->getRows() as $key => $row) {
+      /** @var TokenRow */
+      $this->assertTrue($row instanceof TokenRow);
+      $this->assertEquals($expectHtml[$key], $row->render('greeting_html'));
+      $this->assertEquals($expectText[$key], $row->render('greeting_text'));
+      $rowCount++;
+    }
+    $this->assertEquals(3, $rowCount);
+    $this->assertEquals(0, $this->counts['onListTokens']); // This may change in the future.
+    $this->assertEquals(1, $this->counts['onEvalTokens']);
+  }
+
+  public function onListTokens(TokenRegisterEvent $e) {
+    $this->counts[__FUNCTION__]++;
+    $e->register('custom', array(
+      'foobar' => 'A special message about foobar',
+    ));
+  }
+
+  public function onEvalTokens(TokenValueEvent $e) {
+    $this->counts[__FUNCTION__]++;
+    foreach ($e->getRows() as $row) {
+      /** @var TokenRow $row */
+      $row->format('text/html');
+      $row->tokens['custom']['foobar'] = sprintf("#%04d is a good number. Trickster {contact.display_name}.", $row->context['contact_id']);
+    }
+  }
+
+}

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -31,13 +31,18 @@ use Civi\Payment\System;
 /**
  *  Include configuration
  */
-define('CIVICRM_SETTINGS_PATH', __DIR__ . '/civicrm.settings.dist.php');
-define('CIVICRM_SETTINGS_LOCAL_PATH', __DIR__ . '/civicrm.settings.local.php');
-
-if (file_exists(CIVICRM_SETTINGS_LOCAL_PATH)) {
-  require_once CIVICRM_SETTINGS_LOCAL_PATH;
+if (!defined('CIVICRM_SETTINGS_LOCAL_PATH')) {
+  define('CIVICRM_SETTINGS_LOCAL_PATH', __DIR__ . '/civicrm.settings.local.php');
+  if (file_exists(CIVICRM_SETTINGS_LOCAL_PATH)) {
+    require_once CIVICRM_SETTINGS_LOCAL_PATH;
+  }
 }
-require_once CIVICRM_SETTINGS_PATH;
+
+if (!defined('CIVICRM_SETTINGS_PATH')) {
+  define('CIVICRM_SETTINGS_PATH', __DIR__ . '/civicrm.settings.dist.php');
+  require_once CIVICRM_SETTINGS_PATH;
+}
+
 /**
  *  Include class definitions
  */

--- a/tests/phpunit/CiviTest/civicrm.settings.dist.php
+++ b/tests/phpunit/CiviTest/civicrm.settings.dist.php
@@ -41,16 +41,6 @@ grant SUPER on *.* to db_username@localhost identified by 'db_password';\n";
   }
 }
 
-
-require_once "DB.php";
-$dsninfo = DB::parseDSN(CIVICRM_DSN);
-
-$GLOBALS['mysql_host'] = $dsninfo['hostspec'];
-$GLOBALS['mysql_port'] = @$dsninfo['port'];
-$GLOBALS['mysql_user'] = $dsninfo['username'];
-$GLOBALS['mysql_pass'] = $dsninfo['password'];
-$GLOBALS['mysql_db'] = $dsninfo['database'];
-
 /**
  * Content Management System (CMS) Host:
  *
@@ -58,12 +48,23 @@ $GLOBALS['mysql_db'] = $dsninfo['database'];
  */
 define('CIVICRM_UF', 'UnitTests');
 
-
 global $civicrm_root;
 if (empty($civicrm_root)) {
   $civicrm_root = dirname(dirname(dirname(dirname(__FILE__))));
 }
-#$civicrm_root = '/var/www/drupal7.dev.civicrm.org/public/sites/devel.drupal7.tests.dev.civicrm.org/modules/civicrm';
+
+$tests_dir = $civicrm_root . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'phpunit';
+$civi_pkgs_dir = $civicrm_root . DIRECTORY_SEPARATOR . 'packages';
+ini_set('safe_mode', 0);
+ini_set('include_path', $civicrm_root . PATH_SEPARATOR . $tests_dir . PATH_SEPARATOR . $civi_pkgs_dir . PATH_SEPARATOR . ini_get('include_path'));
+
+require_once 'DB.php';
+$dsninfo = DB::parseDSN(CIVICRM_DSN);
+$GLOBALS['mysql_host'] = $dsninfo['hostspec'];
+$GLOBALS['mysql_port'] = @$dsninfo['port'];
+$GLOBALS['mysql_user'] = $dsninfo['username'];
+$GLOBALS['mysql_pass'] = $dsninfo['password'];
+$GLOBALS['mysql_db'] = $dsninfo['database'];
 
 // set this to a temporary directory. it defaults to /tmp/civi on linux
 //define( 'CIVICRM_TEMPLATE_COMPILEDIR', 'the/absolute/path/' );

--- a/tests/phpunit/api/v3/JobProcessMailingTest.php
+++ b/tests/phpunit/api/v3/JobProcessMailingTest.php
@@ -41,6 +41,8 @@ require_once 'CiviTest/CiviMailUtils.php';
 
 /**
  * Class api_v3_JobTest
+ * @group headless
+ * @group civimail
  */
 class api_v3_JobProcessMailingTest extends CiviUnitTestCase {
   protected $_apiversion = 3;


### PR DESCRIPTION
This branch contains a number backports to support the updated Mosaico extension on 4.6. There are a lot of them, so let me try to structure them a bit more:

 * ~**Batch 1**: `Mailing` data model (0bda941, 8f03c76, 7d0815d; originally, #9562)~ (*__merged #9645__*)
   * ~This adds `template_type` and `template_options` to schema+API. This is probably the single-most useful thing to merge into mainline 4.6 -- for an administrator looking after a custom-build, schema patches are the most difficult to manage from outside. All the other patches are essentially runtime patches (which you can apply/revert more haphazardly).~
 * **Batch 2**: Extension testing (92a49a3, c829601, 30ef9dd)
   * For developers maintaining extensions with tests, the "testapalooza" project enabled a lot of new flows+tools in v4.7. These patches do not reach full parity with 4.7 -- but they get closer. Specifically, the script [civix: make-example.sh](https://github.com/totten/civix/blob/master/tests/make-example.sh) generates several example tests -- the `headless` and `e2e` tests work on 4.6, but the `legacy` (`CiviUnitTestCase`) don't. I intuitively expect this to be safe, but it's a valid question whether this breaks test routines used by other 4.6 extensions (e.g. CiviVolunteer or CiviRules or CiviSEPA).
 * **Batch 3**: Fix in `vendor` URLs (530ee4d; originally #9618)
   * Fixes a small, clear bug.
 * **Batch 4**:  `CRM_Mailing_MailingSystemTest` and Mailing BAOs (d5c4958, 6fbbc4b, 5c92978, 3c65d1d, 6ce1c8e, 7fb0e12)
   * This is a huge improvement in test coverage and includes some incidental BAO cleanups.
 * **Batch 5**: CiviMail UI (d6c1e51, 8769c52, 720633b; originally #9565, #9566, #9689)
   * These patches make it easier for extensions to tap into the CiviMail UI.
 * **Batch 6**:  `hook_civicrm_container` (d9df759)
   * This allows extensions to manipulate services and listeners through the container. The code itself looks pretty innocuous , but the functionality sits in a complex area where the overall flow is very different in 4.6 and 4.7.
 * **Batch 7**: `TokenProcessor` (1ec5bd0, e1e95d7; originally #9563 and many more)
   * Civi 4.7 introduced a new framework for evaluating tokens -- and adopted it for "Scheduled Reminders". This PR makes the framework available in 4.6 so that extensions can access it -- but it does *not* change of the existing flows for scheduled reminders, CiviMail, etc.
 * **Batch 8**: `FlexMailer` hidden interfaces (2cdf7a3, 86344a2; originally #9619)
 * **Batch 9**: Fix in `CRM_Extension_Browser` (528b869; originally #9693)
   * Fixes a small, clear bug affecting `cv dl` users.

I'm submitting this as a large branch/PR to facilitate both personal-usage and automated-testing of the combined work. However, I wouldn't expect all of these to go into canonical 4.6. Rather, I'll submit the first one (`Mailing` data model) because it feels like the most important. 

If anyone is interested in engaging with testing/refinement of other specific batches/patches, I'll happily submit separate 4.6 PRs.

(Note: I've updated the description after merging batch 1and rebasing. If we need it, the old description is https://gist.github.com/totten/bce6aebdd5a30cbd372311cd98b253c8.)

--
 * [CRM-19690: Allow alternative email templating systems](https://issues.civicrm.org/jira/browse/CRM-19690)