### PR TITLE
CRM-19789: Re-add qill getter

### DIFF
--- a/CRM/Core/BAO/Query.php
+++ b/CRM/Core/BAO/Query.php
@@ -59,6 +59,15 @@ class CRM_Core_BAO_Query {
   }
 
   /**
+   * Getter for the qill object.
+   *
+   * @return string
+   */
+  public function qill() {
+    return (isset($this->_qill)) ? $this->_qill : "";
+  }
+
+  /**
    * Possibly unnecessary function.
    *
    * @param $row


### PR DESCRIPTION
* [CRM-19789: Cannot create smart group from 'Find participants'](https://issues.civicrm.org/jira/browse/CRM-19789)