### PR TITLE
CRM-18591: Fix group_type param in creating group

### DIFF
--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -360,7 +360,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
     if (isset($params['group_type'])) {
       if (is_array($params['group_type'])) {
         $params['group_type'] = CRM_Core_DAO::VALUE_SEPARATOR . implode(CRM_Core_DAO::VALUE_SEPARATOR,
-            $params['group_type']
+            CRM_Utils_Array::convertCheckboxFormatToArray($params['group_type'])
           ) . CRM_Core_DAO::VALUE_SEPARATOR;
       }
       else {

--- a/CRM/Group/Form/Edit.php
+++ b/CRM/Group/Form/Edit.php
@@ -380,17 +380,6 @@ WHERE  title = %1
 
       $params['is_reserved'] = CRM_Utils_Array::value('is_reserved', $params, FALSE);
 
-      $groupTypeIds = array();
-      $groupType = CRM_Utils_Array::value('group_type', $params);
-      if (is_array($groupType)) {
-        foreach ($groupType as $type => $selected) {
-          if ($selected) {
-            $groupTypeIds[] = $type;
-          }
-        }
-      }
-      $params['group_type'] = $groupTypeIds;
-
       $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params,
         $this->_id,
         'Group'

--- a/tests/phpunit/api/v3/GroupTest.php
+++ b/tests/phpunit/api/v3/GroupTest.php
@@ -149,6 +149,18 @@ class api_v3_GroupTest extends CiviUnitTestCase {
     $this->assertEquals($group['parents'], "");
     $this->assertEquals($group['group_type'], $params['group_type']);
 
+    //Pass group_type param in checkbox format.
+    $params = array_merge($params, array(
+        'name' => 'Test Checkbox Format',
+        'title' => 'Test Checkbox Format',
+        'group_type' => array(2 => 1),
+      )
+    );
+    $result = $this->callAPISuccess('Group', 'create', $params);
+    $group = $result['values'][$result['id']];
+    $this->assertEquals($group['name'], "Test Checkbox Format");
+    $this->assertEquals($group['group_type'], array_keys($params['group_type']));
+
     //assert single value for group_type and parent
     $params = array_merge($params, array(
         'name' => 'Test Group 2',


### PR DESCRIPTION
* [CRM-18591: group_type parameter ignored when using API to create group](https://issues.civicrm.org/jira/browse/CRM-18591)