### PR TITLE
CRM-19806 make CiviCase only call formlinks once to create action links

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -661,19 +661,6 @@ AND civicrm_case.status_id != $closedId";
             'Case',
             $result->case_id
           );
-          $casesList[$result->case_id]['moreActions'] = CRM_Core_Action::formLink($actions['moreActions'],
-            $mask,
-            array(
-              'id' => $result->case_id,
-              'cid' => $result->contact_id,
-              'cxt' => $context,
-            ),
-            ts('more'),
-            TRUE,
-            'case.actions.more',
-            'Case',
-            $result->case_id
-          );
         }
         elseif ($field == 'case_status') {
           if (in_array($result->$field, $caseStatus)) {

--- a/CRM/Case/Selector/Search.php
+++ b/CRM/Case/Selector/Search.php
@@ -224,12 +224,7 @@ class CRM_Case_Selector_Search extends CRM_Core_Selector_Base {
 
     $actionLinks = array();
     foreach (self::$_links as $key => $value) {
-      if ($value['ref'] == 'reassign') {
-        $actionLinks['moreActions'][$key] = $value;
-      }
-      else {
-        $actionLinks['primaryActions'][$key] = $value;
-      }
+      $actionLinks['primaryActions'][$key] = $value;
     }
 
     return $actionLinks;
@@ -345,18 +340,6 @@ class CRM_Case_Selector_Search extends CRM_Core_Selector_Base {
         ts('more'),
         FALSE,
         'case.selector.actions',
-        'Case',
-        $result->case_id
-      );
-      $row['moreActions'] = CRM_Core_Action::formLink(CRM_Utils_Array::value('moreActions', $links),
-        $mask, array(
-          'id' => $result->case_id,
-          'cid' => $result->contact_id,
-          'cxt' => $this->_context,
-        ),
-        ts('more'),
-        TRUE,
-        'case.selector.moreActions',
         'Case',
         $result->case_id
       );


### PR DESCRIPTION
* [CRM-19806: CiviCase using two formlinks when it only needs one](https://issues.civicrm.org/jira/browse/CRM-19806)