### PR TITLE
CRM-19807 MySQL error when adding contacts on a report to a group

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -3317,7 +3317,7 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
       $rowCount = $this->_dashBoardRowCount;
     }
     if ($this->addPaging) {
-      $this->_select = str_ireplace('SELECT ', 'SELECT SQL_CALC_FOUND_ROWS ', $this->_select);
+      $this->_select = preg_replace('/SELECT(\s+SQL_CALC_FOUND_ROWS)?\s+/i', 'SELECT SQL_CALC_FOUND_ROWS ', $this->_select);
 
       $pageId = CRM_Utils_Request::retrieve('crmPID', 'Integer');
 
@@ -4563,16 +4563,7 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
   public function add2group($groupID) {
     if (is_numeric($groupID) && isset($this->_aliases['civicrm_contact'])) {
       $select = "SELECT DISTINCT {$this->_aliases['civicrm_contact']}.id AS addtogroup_contact_id, ";
-
-      // here are we are prepending / adding  contact id field that could be used for adding group
-      // so first check for "SELECT SQL_CALC_FOUND_ROWS" and if does not exist replace "SELECT"
-      if (preg_match('/^SELECT SQL_CALC_FOUND_ROWS/', $this->_select)) {
-        $select = str_ireplace('SELECT SQL_CALC_FOUND_ROWS ', $select, $this->_select);
-      }
-      else {
-        $select = str_ireplace('SELECT ', $select, $this->_select);
-      }
-
+      $select = preg_replace('/SELECT(\s+SQL_CALC_FOUND_ROWS)?\s+/i', $select, $this->_select);
       $sql = "{$select} {$this->_from} {$this->_where} {$this->_groupBy} {$this->_having} {$this->_orderBy}";
       $sql = str_replace('WITH ROLLUP', '', $sql);
       $dao = CRM_Core_DAO::executeQuery($sql);


### PR DESCRIPTION
SYBUNT report was throwing a mysql error when trying to add contacts to a group from it because the limit function was replacing the 'SELECT' with 'SELECT SQL COUNT FOUND ROWS' when $this->_select starts with SELECT SQL COUNT FOUND ROWS this was resulting in the select being 'SELECT SQL COUNT FOUND ROWS SQL COUNT FOUND ROWS' this code looks for both the pattern 'SELECT' and 'SELECT SQL COUNT FOUND ROWS' and replaces it with the appropriate select in both the add2group and limit functions

---

 * [CRM-19807: MySQL error when adding contacts on a report to a group](https://issues.civicrm.org/jira/browse/CRM-19807)