### PR TITLE
Civi\API\ExternalBatch - Verify that $_ENV is working

### DIFF
--- a/Civi/API/ExternalBatch.php
+++ b/Civi/API/ExternalBatch.php
@@ -52,6 +52,11 @@ class ExternalBatch {
     $this->settingsPath = defined('CIVICRM_SETTINGS_PATH') ? CIVICRM_SETTINGS_PATH : NULL;
     $this->defaultParams = $defaultParams;
     $this->env = $_ENV;
+    if (empty($_ENV)) {
+      // FIXME: If we upgrade to newer Symfony\Process and use the newer
+      // inheritEnv feature, then this becomes unnecessary.
+      throw new \CRM_Core_Exception('ExternalBatch cannot detect environment: $_ENV is missing. (Tip: Set variables_order=EGPCS in php.ini.)');
+    }
   }
 
   /**


### PR DESCRIPTION
This aims to improve error messaging in the situation where a Debian/Ubuntu
user runs `api_v3_JobProcessMailingTest` (and, theoretically, in any
situation where `ExternalBatch` runs without the required `$_ENV`).

For more background, see https://github.com/symfony/symfony/issues/18796