### PR TITLE
CRM-19811 fix one instance of referring to LOWER() & comment others.

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2187,13 +2187,11 @@ class CRM_Contact_BAO_Query {
       $this->_qill[$grouping][] = "$field[title] $op \"$value\"";
     }
     elseif ($name === 'current_employer') {
-      $value = $strtolower(CRM_Core_DAO::escapeString($value));
       if ($wildcard) {
         $op = 'LIKE';
         $value = self::getWildCardedValue($wildcard, $op, $value);
       }
-      $wc = self::caseImportant($op) ? "LOWER(contact_a.organization_name)" : "contact_a.organization_name";
-      $ceWhereClause = self::buildClause($wc, $op,
+      $ceWhereClause = self::buildClause("contact_a.organization_name", $op,
         $value
       );
       $ceWhereClause .= " AND contact_a.contact_type = 'Individual'";
@@ -2266,10 +2264,12 @@ class CRM_Contact_BAO_Query {
       }
       else {
         if ($tableName == 'civicrm_contact') {
+          // LOWER roughly translates to 'hurt my database without deriving any benefit' See CRM-19811.
           $fieldName = "LOWER(contact_a.{$fieldName})";
         }
         else {
           if ($op != 'IN' && !is_numeric($value) && !is_array($value)) {
+            // LOWER roughly translates to 'hurt my database without deriving any benefit' See CRM-19811.
             $fieldName = "LOWER({$field['where']})";
           }
           else {
@@ -3335,13 +3335,16 @@ WHERE  $smartGroupClause
       $fieldsub = array();
       $value = "'" . self::getWildCardedValue($wildcard, $op, $value) . "'";
       if ($fieldName == 'sort_name') {
+        // LOWER roughly translates to 'hurt my database without deriving any benefit' See CRM-19811.
         $wc = self::caseImportant($op) ? "LOWER(contact_a.sort_name)" : "contact_a.sort_name";
       }
       else {
+        // LOWER roughly translates to 'hurt my database without deriving any benefit' See CRM-19811.
         $wc = self::caseImportant($op) ? "LOWER(contact_a.display_name)" : "contact_a.display_name";
       }
       $fieldsub[] = " ( $wc $op $value )";
       if ($config->includeNickNameInName) {
+        // LOWER roughly translates to 'hurt my database without deriving any benefit' See CRM-19811.
         $wc = self::caseImportant($op) ? "LOWER(contact_a.nick_name)" : "contact_a.nick_name";
         $fieldsub[] = " ( $wc $op $value )";
       }
@@ -3478,6 +3481,7 @@ WHERE  $smartGroupClause
         $value = "%{$value}%";
       }
       $op = 'LIKE';
+      // LOWER roughly translates to 'hurt my database without deriving any benefit' See CRM-19811.
       $this->_where[$grouping][] = self::buildClause('LOWER(civicrm_address.street_address)', $op, $value, 'String');
       $this->_qill[$grouping][] = ts('Street') . " $op '$n'";
     }
@@ -3514,6 +3518,7 @@ WHERE  $smartGroupClause
     else {
       $value = strtolower($n);
 
+      // LOWER roughly translates to 'hurt my database without deriving any benefit' See CRM-19811.
       $this->_where[$grouping][] = self::buildClause('LOWER(civicrm_address.street_number)', $op, $value, 'String');
       $this->_qill[$grouping][] = ts('Street Number') . " $op '$n'";
     }
@@ -5629,6 +5634,8 @@ AND   displayRelType.is_active = 1
   }
 
   /**
+   * See CRM-19811 for why this is database hurty without apparent benefit.
+   *
    * @param $op
    *
    * @return bool
@@ -5706,6 +5713,7 @@ AND   displayRelType.is_active = 1
       }
     }
     else {
+      // LOWER roughly translates to 'hurt my database without deriving any benefit' See CRM-19811.
       $wc = self::caseImportant($op) ? "LOWER({$field['where']})" : "{$field['where']}";
     }
     if (in_array($name, $pseudoFields)) {

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2182,6 +2182,7 @@ class CRM_Contact_BAO_Query {
         $op = 'LIKE';
         $value = self::getWildCardedValue($wildcard, $op, $value);
       }
+      // LOWER roughly translates to 'hurt my database without deriving any benefit' See CRM-19811.
       $wc = self::caseImportant($op) ? "LOWER({$field['where']})" : "{$field['where']}";
       $this->_where[$grouping][] = self::buildClause($wc, $op, "'$value'");
       $this->_qill[$grouping][] = "$field[title] $op \"$value\"";
@@ -2255,7 +2256,7 @@ class CRM_Contact_BAO_Query {
 
         //get the location name
         list($tName, $fldName) = self::getLocationTableName($field['where'], $locType);
-
+        // LOWER roughly translates to 'hurt my database without deriving any benefit' See CRM-19811.
         $fieldName = "LOWER(`$tName`.$fldName)";
 
         // we set both _tables & whereTables because whereTables doesn't seem to do what the name implies it should

--- a/CRM/Contribute/BAO/Query.php
+++ b/CRM/Contribute/BAO/Query.php
@@ -611,10 +611,9 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
           $dataType = CRM_Utils_Type::typeToString($whereTable['type']);
         }
 
-        $wc = ($op != 'LIKE' && $dataType != 'Date') ? "LOWER($whereTable[where])" : "$whereTable[where]";
-        $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause($wc, $op, $value, $dataType);
+        $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause($whereTable['where'], $op, $value, $dataType);
         $query->_qill[$grouping][] = "$whereTable[title] $op $quoteValue";
-        list($tableName, $fieldName) = explode('.', $whereTable['where'], 2);
+        list($tableName) = explode('.', $whereTable['where'], 2);
         $query->_tables[$tableName] = $query->_whereTables[$tableName] = 1;
         if ($tableName == 'civicrm_contribution_product') {
           $query->_tables['civicrm_product'] = $query->_whereTables['civicrm_product'] = 1;

--- a/CRM/Contribute/BAO/Query.php
+++ b/CRM/Contribute/BAO/Query.php
@@ -538,6 +538,7 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
           $value = "%$value%";
           $op = 'LIKE';
         }
+        // LOWER roughly translates to 'hurt my database without deriving any benefit' See CRM-19811.
         $wc = ($op != 'LIKE') ? "LOWER(civicrm_note.note)" : "civicrm_note.note";
         $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause($wc, $op, $value, "String");
         $query->_qill[$grouping][] = ts('Contribution Note %1 %2', array(1 => $op, 2 => $quoteValue));

--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -959,6 +959,8 @@ AND    option_group_id = %2";
       switch ($params['data_type']) {
         case 'StateProvince':
           $fieldStateProvince = $strtolower($params['default_value']);
+
+          // LOWER in query below roughly translates to 'hurt my database without deriving any benefit' See CRM-19811.
           $query = "
 SELECT id
   FROM civicrm_state_province
@@ -972,6 +974,8 @@ SELECT id
 
         case 'Country':
           $fieldCountry = $strtolower($params['default_value']);
+
+          // LOWER in query below roughly translates to 'hurt my database without deriving any benefit' See CRM-19811.
           $query = "
 SELECT id
   FROM civicrm_country

--- a/CRM/Mailing/BAO/Query.php
+++ b/CRM/Mailing/BAO/Query.php
@@ -260,6 +260,8 @@ class CRM_Mailing_BAO_Query {
           $value = "%$value%";
           $op = 'LIKE';
         }
+
+        // LOWER in query below roughly translates to 'hurt my database without deriving any benefit' See CRM-19811.
         $query->_where[$grouping][] = "LOWER(civicrm_mailing.name) $op '$value'";
         $query->_qill[$grouping][] = "Mailing Namename $op \"$value\"";
         $query->_tables['civicrm_mailing'] = $query->_whereTables['civicrm_mailing'] = 1;

--- a/CRM/Upgrade/Incremental/sql/4.3.4.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.3.4.mysql.tpl
@@ -38,7 +38,7 @@ SELECT @domainContactId := contact_id from civicrm_domain where id = {$domainID}
 
 -- for Accounts Receivable Account is
 SELECT @option_value_rel_id_ar  := value FROM civicrm_option_value WHERE option_group_id = @option_group_id_arel AND name = 'Accounts Receivable Account is';
-SELECT @arAccount := id FROM civicrm_financial_account WHERE LOWER(name) = 'accounts receivable';
+SELECT @arAccount := id FROM civicrm_financial_account WHERE name = 'accounts receivable';
 SELECT @arAccountEntity := financial_account_id FROM civicrm_entity_financial_account
  WHERE account_relationship = @option_value_rel_id_ar AND entity_table = 'civicrm_financial_type' LIMIT 1;
 
@@ -59,7 +59,7 @@ SELECT cft.name, @domainContactId, @opval, cft.name as description, 'INC', 1
 FROM civicrm_financial_type cft
 LEFT JOIN civicrm_entity_financial_account ceft
 ON ceft.entity_id = cft.id AND ceft.account_relationship = @option_value_rel_id AND ceft.entity_table = 'civicrm_financial_type'
-LEFT JOIN civicrm_financial_account ca ON LOWER(ca.name) = LOWER(cft.name)
+LEFT JOIN civicrm_financial_account ca ON ca.name = cft.name
 WHERE ceft.entity_id IS NULL AND ca.id IS NULL;
 
 INSERT INTO civicrm_entity_financial_account(entity_table, entity_id, account_relationship, financial_account_id)
@@ -67,7 +67,7 @@ SELECT 'civicrm_financial_type', cft.id, @option_value_rel_id, ca.id
 FROM civicrm_financial_type cft
 LEFT JOIN civicrm_entity_financial_account ceft
 ON ceft.entity_id = cft.id AND ceft.account_relationship = @option_value_rel_id AND ceft.entity_table = 'civicrm_financial_type'
-LEFT JOIN civicrm_financial_account ca ON LOWER(ca.name) = LOWER(cft.name)
+LEFT JOIN civicrm_financial_account ca ON ca.name = cft.name
 WHERE ceft.entity_id IS NULL;
 
 -- for cost of sales

--- a/CRM/Upgrade/Incremental/sql/4.5.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.5.alpha1.mysql.tpl
@@ -428,7 +428,7 @@ SELECT 'SnapChat' AS website
     UNION ALL
 SELECT 'Vine' AS website
 ) AS temp
-LEFT JOIN civicrm_option_value co ON LOWER(co.name) = LOWER(temp.website)
+LEFT JOIN civicrm_option_value co ON co.name = temp.website
 AND option_group_id = @option_web_id
 WHERE co.id IS NULL;
 
@@ -481,7 +481,7 @@ CASE
    THEN 'Ineligible'
   ELSE 'Submitted'
 END
-WHERE option_group_id = @option_grant_status and LOWER(name) IN ('granted', 'pending', 'approved', 'rejected');
+WHERE option_group_id = @option_grant_status and name IN ('granted', 'pending', 'approved', 'rejected');
 
 SELECT @grant_value := max(cast(value as UNSIGNED)) FROM civicrm_option_value WHERE option_group_id = @option_grant_status;
 SELECT @grant_weight := max(weight) FROM civicrm_option_value WHERE option_group_id = @option_grant_status;
@@ -498,7 +498,7 @@ SELECT 'Awaiting Information' AS grantstatus
     UNION ALL
 SELECT 'Withdrawn' AS grantstatus
 ) AS temp
-LEFT JOIN civicrm_option_value co ON LOWER(co.name) = LOWER(temp.grantstatus)
+LEFT JOIN civicrm_option_value co ON co.name = temp.grantstatus
 AND option_group_id = @option_grant_status
 WHERE co.id IS NULL;
 

--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -336,6 +336,8 @@ class CRM_Utils_System_Backdrop extends CRM_Utils_System_DrupalBase {
       $strtolower = function_exists('mb_strtolower') ? 'mb_strtolower' : 'strtolower';
       $name = $dbBackdrop->escapeSimple($strtolower($name));
       $userFrameworkUsersTableName = $this->getUsersTableName();
+
+      // LOWER in query below roughly translates to 'hurt my database without deriving any benefit' See CRM-19811.
       $sql = "
 SELECT u.*
 FROM   {$userFrameworkUsersTableName} u

--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -349,6 +349,8 @@ class CRM_Utils_System_Drupal extends CRM_Utils_System_DrupalBase {
       $strtolower = function_exists('mb_strtolower') ? 'mb_strtolower' : 'strtolower';
       $name = $dbDrupal->escapeSimple($strtolower($name));
       $userFrameworkUsersTableName = $this->getUsersTableName();
+
+      // LOWER in query below roughly translates to 'hurt my database without deriving any benefit' See CRM-19811.
       $sql = "
 SELECT u.*
 FROM   {$userFrameworkUsersTableName} u

--- a/CRM/Utils/System/Drupal6.php
+++ b/CRM/Utils/System/Drupal6.php
@@ -165,6 +165,7 @@ class CRM_Utils_System_Drupal6 extends CRM_Utils_System_DrupalBase {
       $errors['cms_name'] = $nameError;
     }
 
+    // LOWER in query below roughly translates to 'hurt my database without deriving any benefit' See CRM-19811.
     $sql = "
       SELECT name, mail
       FROM {users}

--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -136,6 +136,8 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
     $query = $db->getQuery(TRUE);
     $query->select('username, email');
     $query->from($JUserTable->getTableName());
+
+    // LOWER in query below roughly translates to 'hurt my database without deriving any benefit' See CRM-19811.
     $query->where('(LOWER(username) = LOWER(\'' . $name . '\')) OR (LOWER(email) = LOWER(\'' . $email . '\'))');
     $db->setQuery($query, 0, 10);
     $users = $db->loadAssocList();

--- a/tests/phpunit/CRM/Contact/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTest.php
@@ -248,6 +248,21 @@ class CRM_Contact_BAO_QueryTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test searches are case insensitive.
+   */
+  public function testCaseInsensitive() {
+    $orgID = $this->organizationCreate(array('organization_name' => 'BOb'));
+    $this->callAPISuccess('Contact', 'create', array('display_name' => 'Minnie Mouse', 'employer_id' => $orgID, 'contact_type' => 'Individual'));
+    $searchParams = array(array('current_employer', '=', 'bob', 0, 1));
+    $query = new CRM_Contact_BAO_Query($searchParams);
+    $result = $query->apiQuery($searchParams);
+    $this->assertEquals(1, count($result[0]));
+    $contact = reset($result[0]);
+    $this->assertEquals('Minnie Mouse', $contact['display_name']);
+    $this->assertEquals('BOb', $contact['current_employer']);
+  }
+
+  /**
    * Test smart groups with non-numeric don't fail on equal queries.
    *
    * CRM-14720

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -541,6 +541,16 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
   }
 
   /**
+   * Check the credit note retrieval is case insensitive.
+   */
+  public function testGetCreditNoteCaseInsensitive() {
+    $this->contributionCreate(array('contact_id' => $this->_individualId));
+    $this->contributionCreate(array('creditnote_id' => 'cN1234', 'contact_id' => $this->_individualId, 'invoice_id' => rand(), 'trxn_id' => rand()));
+    $contribution = $this->callAPISuccess('Contribution', 'getsingle', array('creditnote_id' => 'CN1234'));
+    $this->assertEquals($contribution['creditnote_id'], 'cN1234');
+  }
+
+  /**
    * Test retrieval by total_amount works.
    *
    * @throws Exception


### PR DESCRIPTION
I have tested & removed the current_employer reference & added notes to other references to LOWER. I will track down & remove the one relating to credit notes in the next round

---

 * [CRM-19811: Slow queries due to use of LOWER\(\) in mysql searches](https://issues.civicrm.org/jira/browse/CRM-19811)