### PR TITLE
CRM-19624: Exclude / Include by privacy radio buttons gets reset on Smartgroup re-editing

### DIFF
--- a/CRM/Contact/Form/Search/Advanced.php
+++ b/CRM/Contact/Form/Search/Advanced.php
@@ -196,7 +196,7 @@ class CRM_Contact_Form_Search_Advanced extends CRM_Contact_Form_Search {
   public function setDefaultValues() {
     $defaults = array_merge($this->_formValues, array(
       'privacy_toggle' => 1,
-      'operator' => TRUE,
+      'operator' => 'AND',
     ));
     $this->normalizeDefaultValues($defaults);
 

--- a/CRM/Contact/Form/Search/Advanced.php
+++ b/CRM/Contact/Form/Search/Advanced.php
@@ -194,6 +194,11 @@ class CRM_Contact_Form_Search_Advanced extends CRM_Contact_Form_Search {
    *   the default array reference
    */
   public function setDefaultValues() {
+    // Set ssID for unit tests.
+    if (empty($this->_ssID)) {
+      $this->_ssID = $this->get('ssID');
+    }
+
     $defaults = array_merge($this->_formValues, array(
       'privacy_toggle' => 1,
       'operator' => 'AND',

--- a/CRM/Contact/Form/Search/Advanced.php
+++ b/CRM/Contact/Form/Search/Advanced.php
@@ -194,15 +194,15 @@ class CRM_Contact_Form_Search_Advanced extends CRM_Contact_Form_Search {
    *   the default array reference
    */
   public function setDefaultValues() {
-    $defaults = $this->_formValues;
+    $defaults = array_merge($this->_formValues, array(
+      'privacy_toggle' => 1,
+      'operator' => TRUE,
+    ));
     $this->normalizeDefaultValues($defaults);
 
     if ($this->_context === 'amtg') {
       $defaults['task'] = CRM_Contact_Task::GROUP_CONTACTS;
     }
-
-    $defaults['privacy_toggle'] = 1;
-    $defaults['operator'] = 'AND';
 
     return $defaults;
   }

--- a/tests/phpunit/CRM/Contact/BAO/SavedSearchTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/SavedSearchTest.php
@@ -57,6 +57,31 @@ class CRM_Contact_BAO_SavedSearchTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test setDefaults for privacy radio buttons.
+   */
+  public function testDefaultValues() {
+    $sg = new CRM_Contact_Form_Search_Advanced();
+    $sg->controller = new CRM_Core_Controller();
+    $sg->_formValues = array(
+      'group_search_selected' => 'group',
+      'privacy_options' => array('do_not_email'),
+      'privacy_operator' => 'OR',
+      'privacy_toggle' => 2,
+      'operator' => 'AND',
+      'component_mode' => 1,
+    );
+    CRM_Core_DAO::executeQuery(
+      "INSERT INTO civicrm_saved_search (form_values) VALUES('" . serialize($sg->_formValues) . "')"
+    );
+    $ssID = CRM_Core_DAO::singleValueQuery('SELECT LAST_INSERT_ID()');
+    $sg->set('ssID', $ssID);
+
+    $defaults = $sg->setDefaultValues();
+
+    $this->checkArrayEquals($defaults, $sg->_formValues);
+  }
+
+  /**
    * Test fixValues function.
    *
    * @dataProvider getSavedSearches


### PR DESCRIPTION
* [CRM-19624: Exclude \/ Include by privacy radio buttons gets reset on Smartgroup re-editing](https://issues.civicrm.org/jira/browse/CRM-19624)