### PR TITLE
CRM-19812 - Display related contact names in activity.get api

### DIFF
--- a/api/v3/Activity.php
+++ b/api/v3/Activity.php
@@ -328,23 +328,43 @@ function _civicrm_api3_activity_get_formatResult($params, $activities) {
   }
 
   $returns['source_contact_id'] = 1;
+  if (!empty($returns['target_contact_name'])) {
+    $returns['target_contact_id'] = 1;
+  }
+  if (!empty($returns['assignee_contact_name'])) {
+    $returns['assignee_contact_id'] = 1;
+  }
+
   foreach ($returns as $n => $v) {
     switch ($n) {
       case 'assignee_contact_id':
         foreach ($activities as $key => $activityArray) {
-          $activities[$key]['assignee_contact_id'] = CRM_Activity_BAO_ActivityAssignment::retrieveAssigneeIdsByActivityId($activityArray['id']);
+          $cids = $activities[$key]['assignee_contact_id'] = CRM_Activity_BAO_ActivityAssignment::retrieveAssigneeIdsByActivityId($activityArray['id']);
+          if ($cids && !empty($returns['assignee_contact_name'])) {
+            foreach ($cids as $cid) {
+              $activities[$key]['assignee_contact_name'][$cid] = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $cid, 'display_name');
+            }
+          }
         }
         break;
 
       case 'target_contact_id':
         foreach ($activities as $key => $activityArray) {
-          $activities[$key]['target_contact_id'] = CRM_Activity_BAO_ActivityTarget::retrieveTargetIdsByActivityId($activityArray['id']);
+          $cids = $activities[$key]['target_contact_id'] = CRM_Activity_BAO_ActivityTarget::retrieveTargetIdsByActivityId($activityArray['id']);
+          if ($cids && !empty($returns['target_contact_name'])) {
+            foreach ($cids as $cid) {
+              $activities[$key]['target_contact_name'][$cid] = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $cid, 'display_name');
+            }
+          }
         }
         break;
 
       case 'source_contact_id':
         foreach ($activities as $key => $activityArray) {
-          $activities[$key]['source_contact_id'] = CRM_Activity_BAO_Activity::getSourceContactID($activityArray['id']);
+          $cid = $activities[$key]['source_contact_id'] = CRM_Activity_BAO_Activity::getSourceContactID($activityArray['id']);
+          if ($cid && !empty($returns['source_contact_name'])) {
+            $activities[$key]['source_contact_name'] = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $cid, 'display_name');
+          }
         }
         break;
 

--- a/api/v3/examples/Activity/GetTargetandAssigneeName.php
+++ b/api/v3/examples/Activity/GetTargetandAssigneeName.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Test Generated example demonstrating the Activity.getsingle API.
+ *
+ * Demonstrates retrieving activity target & source contact names.
+ *
+ * @return array
+ *   API result array
+ */
+function activity_getsingle_example() {
+  $params = array(
+    'id' => 1,
+    'return' => array(
+      'subject',
+      'source_contact_name',
+      'target_contact_name',
+      'assignee_contact_name',
+    ),
+  );
+
+  try{
+    $result = civicrm_api3('Activity', 'getsingle', $params);
+  }
+  catch (CiviCRM_API3_Exception $e) {
+    // Handle error here.
+    $errorMessage = $e->getMessage();
+    $errorCode = $e->getErrorCode();
+    $errorData = $e->getExtraParams();
+    return array(
+      'is_error' => 1,
+      'error_message' => $errorMessage,
+      'error_code' => $errorCode,
+      'error_data' => $errorData,
+    );
+  }
+
+  return $result;
+}
+
+/**
+ * Function returns array of result expected from previous function.
+ *
+ * @return array
+ *   API result array
+ */
+function activity_getsingle_expectedresult() {
+
+  $expectedResult = array(
+    'id' => '1',
+    'subject' => 'Make-it-Happen Meeting',
+    'source_contact_id' => '8',
+    'source_contact_name' => 'D Bug',
+    'target_contact_id' => array('5', '6'),
+    'target_contact_name' => array(
+      '5' => 'A Cat',
+      '6' => 'B Good',
+    ),
+    'assignee_contact_id' => array('7'),
+    'assignee_contact_name' => array(
+      '7' => 'C Shore',
+    ),
+  );
+
+  return $expectedResult;
+}
+
+/*
+* This example has been generated from the API test suite.
+* The test that created it is called "testActivityReturnTargetAssigneeName"
+* and can be found at:
+* https://github.com/civicrm/civicrm-core/blob/master/tests/phpunit/api/v3/ActivityTest.php
+*
+* You can see the outcome of the API tests at
+* https://test.civicrm.org/job/CiviCRM-master-git/
+*
+* To Learn about the API read
+* http://wiki.civicrm.org/confluence/display/CRMDOC/Using+the+API
+*
+* Browse the api on your own site with the api explorer
+* http://MYSITE.ORG/path/to/civicrm/api
+*
+* Read more about testing here
+* http://wiki.civicrm.org/confluence/display/CRM/Testing
+*
+* API Standards documentation:
+* http://wiki.civicrm.org/confluence/display/CRM/API+Architecture+Standards
+*/

--- a/tests/phpunit/api/v3/ActivityTest.php
+++ b/tests/phpunit/api/v3/ActivityTest.php
@@ -365,6 +365,43 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test get returns target and assignee contact names.
+   */
+  public function testActivityReturnTargetAssigneeName() {
+
+    $description = "Demonstrates retrieving activity target & source contact names.";
+    $subfile = "GetTargetandAssigneeName";
+    $target1 = $this->callAPISuccess('Contact', 'create', array('contact_type' => 'Individual', 'first_name' => 'A', 'last_name' => 'Cat'));
+    $target2 = $this->callAPISuccess('Contact', 'create', array('contact_type' => 'Individual', 'first_name' => 'B', 'last_name' => 'Good'));
+    $assignee = $this->callAPISuccess('Contact', 'create', array('contact_type' => 'Individual', 'first_name' => 'C', 'last_name' => 'Shore'));
+    $source = $this->callAPISuccess('Contact', 'create', array('contact_type' => 'Individual', 'first_name' => 'D', 'last_name' => 'Bug'));
+
+    $params = array(
+      'source_contact_id' => $source['id'],
+      'subject' => 'Make-it-Happen Meeting',
+      'activity_date_time' => '20170316',
+      'status_id' => 1,
+      'activity_type_id' => 1,
+      'target_contact_id' => array($target1['id'], $target2['id']),
+      'assignee_contact_id' => $assignee['id'],
+    );
+
+    $result = $this->callAPISuccess('activity', 'create', $params);
+    $result = $this->callAPIAndDocument('activity', 'getsingle', array(
+      'id' => $result['id'],
+      'return' => array('source_contact_name', 'target_contact_name', 'assignee_contact_name', 'subject'),
+    ), __FUNCTION__, __FILE__, $description, $subfile);
+
+    $this->assertEquals($params['subject'], $result['subject']);
+    $this->assertEquals($source['id'], $result['source_contact_id']);
+    $this->assertEquals('D Bug', $result['source_contact_name']);
+    $this->assertEquals('A Cat', $result['target_contact_name'][$target1['id']]);
+    $this->assertEquals('B Good', $result['target_contact_name'][$target2['id']]);
+    $this->assertEquals('C Shore', $result['assignee_contact_name'][$assignee['id']]);
+    $this->assertEquals($assignee['id'], $result['assignee_contact_id'][0]);
+  }
+
+  /**
    * Test civicrm_activity_create() using example code.
    */
   public function testActivityCreateExample() {


### PR DESCRIPTION
* [CRM-19812: Display related contact names in activity.get api](https://issues.civicrm.org/jira/browse/CRM-19812)