### PR TITLE
CRM-19051 improve respect for the offline trigger setting.

### DIFF
--- a/CRM/Admin/Form/Setting/Localization.php
+++ b/CRM/Admin/Form/Setting/Localization.php
@@ -88,7 +88,7 @@ class CRM_Admin_Form_Setting_Localization extends CRM_Admin_Form_Setting {
       $validTriggerPermission = CRM_Core_DAO::checkTriggerViewPermission(TRUE);
 
       if ($validTriggerPermission &&
-        !$config->logging
+        !\Civi::settings()->get('logging')
       ) {
         $this->addElement('checkbox', 'makeMultilingual', ts('Enable Multiple Languages'),
           NULL, array('onChange' => "if (this.checked) CRM.alert($warning, $warningTitle)")

--- a/CRM/Core/BAO/Log.php
+++ b/CRM/Core/BAO/Log.php
@@ -28,9 +28,7 @@
 /**
  *
  * @package CRM
- * @copyright CiviCRM LLC (c) 2004-2017
- * $Id$
- *
+ * @copyright CiviCRM LLC (c) 2004-2016
  */
 
 /**
@@ -166,16 +164,16 @@ UPDATE civicrm_log
   }
 
   /**
-   * Function for find out whether to use logging schema entries for contact.
-   * summary, instead of normal log entries.
+   * Get the id of the report to use to display the change log.
    *
-   * @return int
-   *   report id of Contact Logging Report (Summary) / false
+   * If logging is not enabled a return value of FALSE means to use the
+   * basic change log view.
+   *
+   * @return int|FALSE
+   *   report id of Contact Logging Report (Summary)
    */
   public static function useLoggingReport() {
-    // first check if logging is enabled
-    $config = CRM_Core_Config::singleton();
-    if (!$config->logging) {
+    if (!\Civi::settings()->get('logging')) {
       return FALSE;
     }
 

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1910,10 +1910,13 @@ SELECT contact_id
    * @return bool
    */
   public static function checkTriggerViewPermission($view = TRUE, $trigger = TRUE) {
+    if (\Civi::settings()->get('logging_no_trigger_permission')) {
+      return TRUE;
+    }
     // test for create view and trigger permissions and if allowed, add the option to go multilingual
     // and logging
     // I'm not sure why we use the getStaticProperty for an error, rather than checking for DB_Error
-    $errorScope = CRM_Core_TemporaryErrorScope::ignoreException();
+    CRM_Core_TemporaryErrorScope::ignoreException();
     $dao = new CRM_Core_DAO();
     if ($view) {
       $result = $dao->query('CREATE OR REPLACE VIEW civicrm_domain_view AS SELECT * FROM civicrm_domain');


### PR DESCRIPTION
This adds a check for the setting to the checkTriggerViewPermission function and improves calls to check
settings to use the preferred Civi::settings method

---

 * [CRM-19051: Logging - setting to allow offline triggers not respected in all cases](https://issues.civicrm.org/jira/browse/CRM-19051)