### PR TITLE
allow descendant classes to access the cache array

### DIFF
--- a/CRM/Utils/Cache/ArrayCache.php
+++ b/CRM/Utils/Cache/ArrayCache.php
@@ -39,7 +39,7 @@ class CRM_Utils_Cache_Arraycache implements CRM_Utils_Cache_Interface {
   /**
    * The cache storage container, an in memory array by default
    */
-  private $_cache;
+  protected $_cache;
 
   /**
    * Constructor.


### PR DESCRIPTION
this makes this class into a more flexible base for other classes to inherit from. Background [conversation with Coleman here](http://civicrm.stackexchange.com/questions/16434/private-or-protected-class-properties/16483?noredirect=1#comment18299_16483)