### PR TITLE
Fix startdate for testMembershipJoinDateFixed

### DIFF
--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -1154,10 +1154,15 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     $joinDate = date('Y-m-d');
     $year = date('Y');
     $startDate = date('Y-m-d', strtotime(date('Y-03-01')));
+    $rollOver = TRUE;
+    if (strtotime($startDate) > time()) {
+      $rollOver = FALSE;
+      $startDate = date('Y-m-d', strtotime(date('Y-03-01') . '- 1 year'));
+    }
     $membershipTypeDetails = CRM_Member_BAO_MembershipType::getMembershipTypeDetails($this->_membershipTypeID2);
     $fixedPeriodRollover = CRM_Member_BAO_MembershipType::isDuringFixedAnnualRolloverPeriod($joinDate, $membershipTypeDetails, $year, $startDate);
     $y = 1;
-    if ($fixedPeriodRollover) {
+    if ($fixedPeriodRollover && $rollOver) {
       $y += 1;
     }
 


### PR DESCRIPTION
`start_date` in the test is set to a date in future when the current month is 1 or 2. `Fixed` membership would correctly calculate and update the `start_date` to eg. `2016-03-01` when the current date is `2017-01` - `2017-02` and `fixed_period_start_day` is set to `03-01` for the membership type.

Modifying the expected `start_date` to the same as the functionality seems to be correct and a miss in the test.

Fix for https://test.civicrm.org/job/CiviCRM-Core-PR/13196/testReport/(root)/api_v3_MembershipTest/testMembershipJoinDateFixed/