### PR TITLE
(Port from master) CRM_Utils_HttpClientTest - Use special purpose hostnames

### DIFF
--- a/tests/phpunit/CRM/Utils/HttpClientTest.php
+++ b/tests/phpunit/CRM/Utils/HttpClientTest.php
@@ -6,12 +6,12 @@ require_once 'CiviTest/CiviUnitTestCase.php';
  */
 class CRM_Utils_HttpClientTest extends CiviUnitTestCase {
 
-  const VALID_HTTP_URL = 'http://sandbox.civicrm.org/';
-  const VALID_HTTP_REGEX = '/<html/';
-  const VALID_HTTPS_URL = 'https://civicrm.org/INSTALL.mysql.txt';
-  const VALID_HTTPS_REGEX = '/MySQL/';
-  const SELF_SIGNED_HTTPS_URL = 'https://www-test.civicrm.org:4433/index.html';
-  const SELF_SIGNED_HTTPS_REGEX = '/self-signed/';
+  const VALID_HTTP_URL = 'http://httpclienttest-http.civicrm.org/index.html';
+  const VALID_HTTP_REGEX = '/This is httpclienttest-http\./';
+  const VALID_HTTPS_URL = 'https://httpclienttest-https.civicrm.org/index.html';
+  const VALID_HTTPS_REGEX = '/This is httpclienttest-https\./';
+  const SELF_SIGNED_HTTPS_URL = 'https://httpclienttest-selfsign.civicrm.org:4433/index.html';
+  const SELF_SIGNED_HTTPS_REGEX = '/This is httpclienttest-selfsign\./';
 
   /**
    * @var string path to which we can store temp file


### PR DESCRIPTION
This test issues a few real HTTP requests which are supposed to succeed or
fail in a prescribed way.  However, the examples were chosen for expedience
and leached off other/unrelated sites...  but this tends to break from
time-to-time (when the example system goes to HTTPS-only or changes their
content).

With this patch, all the examples point to dedicated sites which are
purpose-built for supporting integration tests.