### PR TITLE
Drupal bootstrap failures should throw debuggable exception

### DIFF
--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -487,6 +487,8 @@ AND    u.status = 1
     @drupal_bootstrap(DRUPAL_BOOTSTRAP_FULL);
 
     // explicitly setting error reporting, since we cannot handle drupal related notices
+    // @todo 1 = E_ERROR, but more to the point setting error reporting deep in code
+    // causes grief with debugging scripts
     error_reporting(1);
     if (!function_exists('module_exists')) {
       if ($throwError) {

--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -467,8 +467,7 @@ AND    u.status = 1
 
     if (!file_exists("$cmsPath/includes/bootstrap.inc")) {
       if ($throwError) {
-        echo '<br />Sorry, could not locate bootstrap.inc\n';
-        exit();
+        throw new Exception('Sorry, could not locate bootstrap.inc');
       }
       return FALSE;
     }
@@ -489,10 +488,15 @@ AND    u.status = 1
 
     // explicitly setting error reporting, since we cannot handle drupal related notices
     error_reporting(1);
-    if (!function_exists('module_exists') || !module_exists('civicrm')) {
+    if (!function_exists('module_exists')) {
       if ($throwError) {
-        echo '<br />Sorry, could not load drupal bootstrap.';
-        exit();
+        throw new Exception('Sorry, could not load drupal bootstrap.');
+      }
+      return FALSE;
+    }
+    if (!module_exists('civicrm')) {
+      if ($throwError) {
+        throw new Exception('Sorry, drupal cannot find CiviCRM');
       }
       return FALSE;
     }
@@ -524,8 +528,7 @@ AND    u.status = 1
         $uid = user_authenticate($name, $pass);
         if (!$uid) {
           if ($throwError) {
-            echo '<br />Sorry, unrecognized username or password.';
-            exit();
+            throw new Exception('Sorry, unrecognized username or password.');
           }
           return FALSE;
         }
@@ -542,8 +545,7 @@ AND    u.status = 1
     }
 
     if ($throwError) {
-      echo '<br />Sorry, can not load CMS user account.';
-      exit();
+      throw new Exception('Sorry, can not load CMS user account.');
     }
 
     // CRM-6948: When using loadBootStrap, it's implicit that CiviCRM has already loaded its settings


### PR DESCRIPTION
### Updated Description

Suppose one is submitting a request to a backend entry-point (such as `rest.php` or `cv`). If the system an incompatible/incomplete configuration, it could produce a hard exit with the error like `Sorry, could not locate bootstrap.inc`. However, tracing this error was often difficult because the hard exit did not report a backtrace. This makes the error condition more debuggable.

### Original Description

As [discussed with @totten](https://chat.civicrm.org/civicrm/pl/7xerz3qae7ncdeuy67czab93be) in the chat.

I'd like to fix that `error_reporting` call too but need some guidance first.