### PR TITLE
CRM-19824 - Container::loadContainer - Always compile listeners

### DIFF
--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -69,7 +69,9 @@ class Container {
 
     // In pre-installation environments, don't bother with caching.
     if (!defined('CIVICRM_TEMPLATE_COMPILEDIR') || !defined('CIVICRM_DSN') || $cacheMode === 'never' || \CRM_Utils_System::isInUpgradeMode()) {
-      return $this->createContainer();
+      $containerBuilder = $this->createContainer();
+      $containerBuilder->compile();
+      return $containerBuilder;
     }
 
     $envId = \CRM_Core_Config_Runtime::getId();


### PR DESCRIPTION
In the typical (cache-enabled) flow, the container is compiled to identify
any services tagged with `kernel.event_subscriber`. However, if you disable
caching, then it skipped compilation, and it failed to identify all the
listeners.

With this patch, we always detect the listeners -- even if caching is
disabled.

(This issue identified while working on tests for CRM-19690.

---

 * [CRM-19824: Event listeners are missing if container cache is disabled](https://issues.civicrm.org/jira/browse/CRM-19824)
 * [CRM-19690: Allow alternative email templating systems](https://issues.civicrm.org/jira/browse/CRM-19690)