### PR TITLE
CRM-19826 - CRM_Extension_System - Fix extra slash in `vendor` URLs

### DIFF
--- a/CRM/Extension/System.php
+++ b/CRM/Extension/System.php
@@ -144,7 +144,7 @@ class CRM_Extension_System {
         if (is_dir($vendorPath)) {
           $containers['cmsvendor'] = new CRM_Extension_Container_Basic(
             $vendorPath,
-            $this->parameters['userFrameworkBaseURL'] . DIRECTORY_SEPARATOR . 'vendor',
+            CRM_Utils_File::addTrailingSlash($this->parameters['userFrameworkBaseURL'], '/') . 'vendor',
             $this->getCache(),
             'cmsvendor'
           );


### PR DESCRIPTION
If you install an extension under `$cmsRoot/vendor/org.example.foo`, the
resulting URL contains an extraneous `/` (eg
`http://example.org//vendor/org.example.foo`).  (In Windows, I suspect it's
even worse because it uses DIRECTORY_SEPARATOR in the URl -- eg
`http://example.org/\vendor/org.example.foo`.)

This patch checks for and removes the extraneous slash -- and always
constructs the URL with the appropriate delimiter (`/`).

Problem observed in `dmaster`.

---

 * [CRM-19826: Extensions in "vendor" folder have errant slash](https://issues.civicrm.org/jira/browse/CRM-19826)