### PR TITLE
CRM-19690 - Enable FlexMailer (if present)

### DIFF
--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -189,7 +189,12 @@ class CRM_Mailing_BAO_MailingJob extends CRM_Mailing_DAO_MailingJob {
       }
 
       // Compose and deliver each child job
-      $isComplete = $job->deliver($mailer, $testParams);
+      if (\CRM_Utils_Constant::value('CIVICRM_FLEXMAILER_HACK_DELIVER')) {
+        $isComplete = Civi\Core\Resolver::singleton()->call(CIVICRM_FLEXMAILER_HACK_DELIVER, array($job, $mailer, $testParams));
+      }
+      else {
+        $isComplete = $job->deliver($mailer, $testParams);
+      }
 
       CRM_Utils_Hook::post('create', 'CRM_Mailing_DAO_Spool', $job->id, $isComplete);
 
@@ -492,6 +497,10 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
    * @param array $testParams
    */
   public function deliver(&$mailer, $testParams = NULL) {
+    if (\Civi::settings()->get('experimentalFlexMailerEngine')) {
+      throw new \RuntimeException("Cannot use legacy deliver() when experimentalFlexMailerEngine is enabled");
+    }
+
     $mailing = new CRM_Mailing_BAO_Mailing();
     $mailing->id = $this->mailing_id;
     $mailing->find(TRUE);

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -215,6 +215,10 @@ class Container {
       ))->addTag('kernel.event_subscriber');
     }
 
+    if (\CRM_Utils_Constant::value('CIVICRM_FLEXMAILER_HACK_SERVICES')) {
+      \Civi\Core\Resolver::singleton()->call(CIVICRM_FLEXMAILER_HACK_SERVICES, array($container));
+    }
+
     \CRM_Utils_Hook::container($container);
 
     return $container;
@@ -252,6 +256,10 @@ class Container {
     $dispatcher->addListener(\Civi\ActionSchedule\Events::MAPPINGS, array('CRM_Contribute_ActionMapping_ByType', 'onRegisterActionMappings'));
     $dispatcher->addListener(\Civi\ActionSchedule\Events::MAPPINGS, array('CRM_Event_ActionMapping', 'onRegisterActionMappings'));
     $dispatcher->addListener(\Civi\ActionSchedule\Events::MAPPINGS, array('CRM_Member_ActionMapping', 'onRegisterActionMappings'));
+
+    if (\CRM_Utils_Constant::value('CIVICRM_FLEXMAILER_HACK_LISTENERS')) {
+      \Civi\Core\Resolver::singleton()->call(CIVICRM_FLEXMAILER_HACK_LISTENERS, array($dispatcher));
+    }
 
     return $dispatcher;
   }


### PR DESCRIPTION
FlexMailer (https://github.com/civicrm/org.civicrm.flexmailer/) is a
refactoring of the email-delivery logic from the Mailing BAOs.  The primary
goal is to make the email-delivery logic more extensible by exposing a
better set of events for extension-authors.  Sadly, the original code is a
bit toxic (originally lacking in tests; thick with many features; using some
quirky dataflows), which means:

 1. Any refactoring of it poses a high risk.
 2. The refactoring should ideally be done with iteration/validation as
    an optional extension.

This patch aims to be the bare-minimum core patch required to facilitate a
better 'leap by extension'.  The main priorities are:

 1. Minimize risk -- no impact on existing users who can continue using existing logic.
 2. Enable iteration/testing/deployment of an optional extension in real-world scenarios.
 3. Keep any core hacks clear and isolated - don't rashly commit to new, public APIs.

---

 * [CRM-19690: Allow alternative email templating systems](https://issues.civicrm.org/jira/browse/CRM-19690)