### PR TITLE
CRM-19706 - Fix setDefault on status id smart group formvalues

### DIFF
--- a/CRM/Activity/BAO/Query.php
+++ b/CRM/Activity/BAO/Query.php
@@ -431,7 +431,14 @@ class CRM_Activity_BAO_Query {
     $form->addSelect('status_id',
       array('entity' => 'activity', 'multiple' => 'multiple', 'option_url' => NULL, 'placeholder' => ts('- any -'))
     );
-    $form->setDefaults(array('status_id' => array($activityStatus['Completed'], $activityStatus['Scheduled'])));
+    $ssID = $form->get('ssID');
+    $status = array($activityStatus['Completed'], $activityStatus['Scheduled']);
+    //If status is saved in smart group.
+    if (!empty($ssID) && !empty($form->_formValues['activity_status_id'])) {
+      $status = $form->_formValues['activity_status_id'];
+    }
+    $form->setDefaults(array('status_id' => $status));
+
     $form->addElement('text', 'activity_text', ts('Activity Text'), CRM_Core_DAO::getAttribute('CRM_Contact_DAO_Contact', 'sort_name'));
 
     $form->addRadio('activity_option', '', CRM_Core_SelectValues::activityTextOptions());


### PR DESCRIPTION
* [CRM-19706: Smart Group criteria \(Activity Status\) are not being retained when using 'Edit Smart Group criteria'](https://issues.civicrm.org/jira/browse/CRM-19706)