### PR TITLE
CRM-19490 - date profile custom field display fix in contribution confirm and thank you page

### DIFF
--- a/templates/CRM/UF/Form/Block.tpl
+++ b/templates/CRM/UF/Form/Block.tpl
@@ -136,6 +136,14 @@
                 {if $form.$phone_ext_field.html}
                   &nbsp;{$form.$phone_ext_field.html}
                 {/if}
+			  {elseif ( $field.data_type eq 'Date' ) AND
+              (( $form.formName eq 'Confirm' )  or
+              ( $form.formName eq 'ThankYou' )) }
+                <span class="crm-frozen-field">
+                    {assign var="date_value" value=$form.$n.value}
+                    {$date_value|crmDate}
+                    <input type="hidden" name="{$form.$n.name}" value="{$form.$n.value}" id="{$form.$n.name}">
+                </span>
               {else}
                 {if $prefix}
                   {if $n eq 'organization_name' && !empty($form.onbehalfof_id)}


### PR DESCRIPTION
Date custom field in profile in conribution page does not take care localization date format in confirm and thank you page.

This pr fixes that

---

 * [CRM-19490: Profile date fields don't respect localisation on the Contribution Page confirmation screen](https://issues.civicrm.org/jira/browse/CRM-19490)