### PR TITLE
CRM-19827 Avoid unnecessary core_resources processing during ajax calls

### DIFF
--- a/CRM/Core/Controller.php
+++ b/CRM/Core/Controller.php
@@ -457,8 +457,8 @@ class CRM_Core_Controller extends HTML_QuickForm_Controller {
       if ($options) {
         $$stateName->setOptions($options);
       }
-      if (property_exists($$stateName, 'urlPath') && isset($_GET[CRM_Core_Config::singleton()->userFrameworkURLVar])) {
-        $$stateName->urlPath = explode('/', $_GET[CRM_Core_Config::singleton()->userFrameworkURLVar]);
+      if (property_exists($$stateName, 'urlPath')) {
+        $$stateName->urlPath = explode('/', (string) CRM_Utils_System::getUrlPath());
       }
       $this->addPage($$stateName);
       $this->addAction($stateName, new HTML_QuickForm_Action_Direct());

--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -781,11 +781,15 @@ class CRM_Core_Resources {
    *   is this page request an ajax snippet?
    */
   public static function isAjaxMode() {
-    return in_array(CRM_Utils_Array::value('snippet', $_REQUEST), array(
+    if (in_array(CRM_Utils_Array::value('snippet', $_REQUEST), array(
         CRM_Core_Smarty::PRINT_SNIPPET,
         CRM_Core_Smarty::PRINT_NOFORM,
         CRM_Core_Smarty::PRINT_JSON,
-      ));
+      ))
+    ) {
+      return TRUE;
+    }
+    return strpos(CRM_Utils_System::getUrlPath(), 'civicrm/ajax') === 0;
   }
 
   /**

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -301,6 +301,18 @@ class CRM_Utils_System {
   }
 
   /**
+   * Path of the current page e.g. 'civicrm/contact/view'
+   *
+   * @return string|null
+   */
+  public static function getUrlPath() {
+    if (isset($_GET[CRM_Core_Config::singleton()->userFrameworkURLVar])) {
+      return $_GET[CRM_Core_Config::singleton()->userFrameworkURLVar];
+    }
+    return NULL;
+  }
+
+  /**
    * Get href.
    *
    * @param string $text

--- a/tests/phpunit/CRM/Core/ResourcesTest.php
+++ b/tests/phpunit/CRM/Core/ResourcesTest.php
@@ -41,6 +41,9 @@ class CRM_Core_ResourcesTest extends CiviUnitTestCase {
    */
   protected $mapper;
 
+  protected $originalRequest;
+  protected $originalGet;
+
   public function setUp() {
     parent::setUp();
 
@@ -53,6 +56,17 @@ class CRM_Core_ResourcesTest extends CiviUnitTestCase {
     // Templates injected into regions should normally be file names, but for unit-testing it's handy to use "string:" notation
     require_once 'CRM/Core/Smarty/resources/String.php';
     civicrm_smarty_register_string_resource();
+
+    $this->originalRequest = $_REQUEST;
+    $this->originalGet = $_GET;
+  }
+
+  /**
+   * Restore globals so this test doesn't interfere with others.
+   */
+  public function tearDown() {
+    $_REQUEST = $this->originalRequest;
+    $_GET = $this->originalGet;
   }
 
   public function testAddScriptFile() {

--- a/tests/phpunit/CRM/Core/ResourcesTest.php
+++ b/tests/phpunit/CRM/Core/ResourcesTest.php
@@ -299,6 +299,23 @@ class CRM_Core_ResourcesTest extends CiviUnitTestCase {
   }
 
   /**
+   * @dataProvider ajaxModeData
+   */
+  public function testIsAjaxMode($query, $result) {
+    $_REQUEST = $_GET = $query;
+    $this->assertEquals($result, CRM_Core_Resources::isAjaxMode());
+  }
+
+  public function ajaxModeData() {
+    return array(
+      array(array('q' => 'civicrm/ajax/foo'), TRUE),
+      array(array('q' => 'civicrm/test/page'), FALSE),
+      array(array('q' => 'civicrm/test/page', 'snippet' => 'json'), TRUE),
+      array(array('q' => 'civicrm/test/page', 'snippet' => 'foo'), FALSE),
+    );
+  }
+
+  /**
    * @param CRM_Utils_Cache_Interface $cache
    * @param string $cacheKey
    *


### PR DESCRIPTION
* [CRM-19827: Avoid unnecessary core_resources processing during ajax calls](https://issues.civicrm.org/jira/browse/CRM-19827)