### PR TITLE
CRM-16228 - Tax INVOICE PDF Tax Rate - Incorrect

### DIFF
--- a/CRM/Contribute/BAO/Contribution/Utils.php
+++ b/CRM/Contribute/BAO/Contribution/Utils.php
@@ -475,7 +475,7 @@ LIMIT 1
    */
   public static function calculateTaxAmount($amount, $taxRate) {
     $taxAmount = array();
-    $taxAmount['tax_amount'] = round(($taxRate / 100) * CRM_Utils_Rule::cleanMoney($amount), 2);
+    $taxAmount['tax_amount'] = round(($taxRate / 100) * CRM_Utils_Rule::cleanMoney($amount), 4);
 
     return $taxAmount;
   }


### PR DESCRIPTION
My preference would be no rounding it all at this stage (this tax_amount is carried into the calculations where it's multiplied by quantity) - but let's be safe and set it to 4 decimals for now;

---

 * [CRM-16228: Tax INVOICE PDF Tax Rate - Incorrect](https://issues.civicrm.org/jira/browse/CRM-16228)