### PR TITLE
CRM-19453 - Make site root OS independent by using JPATH_SITE constant.

### DIFF
--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -710,11 +710,8 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
       '',
       $config->userFrameworkBaseURL
     );
-    $siteRoot = preg_replace(
-      '|/media/civicrm/.*$|',
-      '',
-      $config->imageUploadDir
-    );
+    // CRM-19453 - This makes it OS independent.
+    $siteRoot = JPATH_SITE;
     return array($url, NULL, $siteRoot);
   }
 


### PR DESCRIPTION
This uses JPATH_SITE instead of editing a directory path to generate $siteRoot.  This makes the call operating system independent, as it failed under Windows before. 

I gave up on trying to rebase my repository on the base fork, and instead deleted and recreated my fork as that seemed the only way to get the two master branches aligned - rebase did not achieve that. I then deleted my local repository and cloned it from the fork.  CiviCRM no longer works locally as I suspect I am missing some files, but at least I hope the PR will now work.

---

 * [CRM-19453: System-\>Directories fails to display under Joomla](https://issues.civicrm.org/jira/browse/CRM-19453)