### PR TITLE
CRM-19832: Ensure that searchTasks hook get invoked once

### DIFF
--- a/CRM/Activity/Task.php
+++ b/CRM/Activity/Task.php
@@ -134,9 +134,11 @@ class CRM_Activity_Task {
       if (!CRM_Core_Permission::check('delete activities')) {
         unset(self::$_tasks[1]);
       }
+
+      CRM_Utils_Hook::searchTasks('activity', self::$_tasks);
+      asort(self::$_tasks);
     }
-    CRM_Utils_Hook::searchTasks('activity', self::$_tasks);
-    asort(self::$_tasks);
+
     return self::$_tasks;
   }
 

--- a/CRM/Campaign/Task.php
+++ b/CRM/Campaign/Task.php
@@ -91,11 +91,10 @@ class CRM_Campaign_Task {
           'result' => FALSE,
         ),
       );
+
+      CRM_Utils_Hook::searchTasks('campaign', self::$_tasks);
+      asort(self::$_tasks);
     }
-
-    CRM_Utils_Hook::searchTasks('campaign', self::$_tasks);
-
-    asort(self::$_tasks);
 
     return self::$_tasks;
   }

--- a/CRM/Case/Task.php
+++ b/CRM/Case/Task.php
@@ -92,14 +92,16 @@ class CRM_Case_Task {
           'result' => FALSE,
         ),
       );
+
       //CRM-4418, check for delete
       if (!CRM_Core_Permission::check('delete in CiviCase')) {
         unset(self::$_tasks[1]);
       }
+
+      CRM_Utils_Hook::searchTasks('case', self::$_tasks);
+      asort(self::$_tasks);
     }
 
-    CRM_Utils_Hook::searchTasks('case', self::$_tasks);
-    asort(self::$_tasks);
     return self::$_tasks;
   }
 

--- a/CRM/Contribute/Task.php
+++ b/CRM/Contribute/Task.php
@@ -131,6 +131,7 @@ class CRM_Contribute_Task {
       if (!$invoicing) {
         unset(self::$_tasks[9]);
       }
+
       CRM_Utils_Hook::searchTasks('contribution', self::$_tasks);
       asort(self::$_tasks);
     }

--- a/CRM/Event/Task.php
+++ b/CRM/Event/Task.php
@@ -145,9 +145,9 @@ class CRM_Event_Task {
       if (!CRM_Core_Permission::check('edit event participants')) {
         unset(self::$_tasks[4], self::$_tasks[5], self::$_tasks[15]);
       }
-    }
 
-    CRM_Utils_Hook::searchTasks('event', self::$_tasks);
+      CRM_Utils_Hook::searchTasks('event', self::$_tasks);
+    }
 
     return self::$_tasks;
   }

--- a/CRM/Grant/Task.php
+++ b/CRM/Grant/Task.php
@@ -89,12 +89,15 @@ class CRM_Grant_Task {
           'result' => FALSE,
         ),
       );
+
+      if (!CRM_Core_Permission::check('delete in CiviGrant')) {
+        unset(self::$_tasks[1]);
+      }
+
+      CRM_Utils_Hook::searchTasks('grant', self::$_tasks);
+      asort(self::$_tasks);
     }
-    if (!CRM_Core_Permission::check('delete in CiviGrant')) {
-      unset(self::$_tasks[1]);
-    }
-    CRM_Utils_Hook::searchTasks('grant', self::$_tasks);
-    asort(self::$_tasks);
+
     return self::$_tasks;
   }
 

--- a/CRM/Member/Task.php
+++ b/CRM/Member/Task.php
@@ -119,9 +119,11 @@ class CRM_Member_Task {
       if (!CRM_Core_Permission::check('edit memberships')) {
         unset(self::$_tasks[5]);
       }
+
+      CRM_Utils_Hook::searchTasks('membership', self::$_tasks);
+      asort(self::$_tasks);
     }
-    CRM_Utils_Hook::searchTasks('membership', self::$_tasks);
-    asort(self::$_tasks);
+
     return self::$_tasks;
   }
 

--- a/CRM/Pledge/Task.php
+++ b/CRM/Pledge/Task.php
@@ -85,9 +85,11 @@ class CRM_Pledge_Task {
       if (!CRM_Core_Permission::check('delete in CiviPledge')) {
         unset(self::$_tasks[1]);
       }
+
+      CRM_Utils_Hook::searchTasks('pledge', self::$_tasks);
+      asort(self::$_tasks);
     }
-    CRM_Utils_Hook::searchTasks('pledge', self::$_tasks);
-    asort(self::$_tasks);
+
     return self::$_tasks;
   }
 


### PR DESCRIPTION
## Problem 

When your extensions implements hook_civicrm_searchTasks  and in case you did a participant search page then in the result page, the action you added via this hook will appear twice in the actions box :

<img width="415" alt="screen shot 2016-11-04 at 15 43 08" src="https://cloud.githubusercontent.com/assets/6275540/21646725/fcdbff9a-d29f-11e6-81a1-747f9db63642.png">


This happens because the *hook_civicrm_searchTasks* hook get invoked twice for each extension when Search Participates result page get opened ..

The reason why it does not happen at contact page is because the code that generate the menu items list will not call the hook if the menu items are already set , see :
https://github.com/civicrm/civicrm-core/blob/master/CRM/Contact/Task.php#L253
https://github.com/civicrm/civicrm-core/blob/master/CRM/Contact/Task.php#L80

Unlike Event class which call the hook even if the tasks are already set :
https://github.com/civicrm/civicrm-core/blob/master/CRM/Event/Task.php#L70
https://github.com/civicrm/civicrm-core/blob/master/CRM/Event/Task.php#L150


from looking into the code , these entities should suffer from the same issue but I didn't test that though :
- Campaign
- Case
- Contribute
- Grant
- Member
- Pledge


## Solution 

Following how it is already handled for Contact Entity , I followed the same and moved the line that invoke the hook to run only if the search tasks are not already set.

---

 * [CRM-19832: hook_civicrm_searchTasks get invoked twice for some entities](https://issues.civicrm.org/jira/browse/CRM-19832)