### PR TITLE
CRM-19330 Fix report actions for non-permissioned users in Joomla

### DIFF
--- a/CRM/Report/BAO/ReportInstance.php
+++ b/CRM/Report/BAO/ReportInstance.php
@@ -390,15 +390,6 @@ class CRM_Report_BAO_ReportInstance extends CRM_Report_DAO_ReportInstance {
           'confirm_message' => ts('Are you sure you want delete this report? This action cannot be undone.'),
         ),
       );
-    } else  {
-      // CRM-19330 Remove the options to save or save a copy
-      unset($actions['report_instance.save']);
-      unset($actions['report_instance.copy']);
-    }
-    else {
-      // CRM-19330 Remove the options to save or save a copy.
-      unset($actions['report_instance.save']);
-      unset($actions['report_instance.copy']);
     }
     else {
       // CRM-19330 Remove the options to save or save a copy.

--- a/CRM/Report/BAO/ReportInstance.php
+++ b/CRM/Report/BAO/ReportInstance.php
@@ -391,6 +391,11 @@ class CRM_Report_BAO_ReportInstance extends CRM_Report_DAO_ReportInstance {
         ),
       );
     }
+    else {
+      // CRM-19330 Remove the options to save or save a copy.
+      unset($actions['report_instance.save']);
+      unset($actions['report_instance.copy']);
+    }
     return $actions;
   }
 

--- a/CRM/Report/BAO/ReportInstance.php
+++ b/CRM/Report/BAO/ReportInstance.php
@@ -390,8 +390,9 @@ class CRM_Report_BAO_ReportInstance extends CRM_Report_DAO_ReportInstance {
           'confirm_message' => ts('Are you sure you want delete this report? This action cannot be undone.'),
         ),
       );
-    } else  {
-      // CRM-19330 Remove the options to save or save a copy
+    }
+    else {
+      // CRM-19330 Remove the options to save or save a copy.
       unset($actions['report_instance.save']);
       unset($actions['report_instance.copy']);
     }

--- a/CRM/Report/BAO/ReportInstance.php
+++ b/CRM/Report/BAO/ReportInstance.php
@@ -390,6 +390,10 @@ class CRM_Report_BAO_ReportInstance extends CRM_Report_DAO_ReportInstance {
           'confirm_message' => ts('Are you sure you want delete this report? This action cannot be undone.'),
         ),
       );
+    } else  {
+      // CRM-19330 Remove the options to save or save a copy
+      unset($actions['report_instance.save']);
+      unset($actions['report_instance.copy']);
     }
     return $actions;
   }

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -577,6 +577,14 @@ class CRM_Report_Form extends CRM_Core_Form {
       else {
         $this->_formValues = NULL;
       }
+      // CRM-19330 Unprivileged users don't get the task in the form values,
+      // but they appear as a POST variable, so we add the task to the form
+      // values so Print, Print to PDF and Export to Excel work even if you
+      // don't have manage report privileges.
+
+      if (!$this->_formValues['task'] && filter_input(INPUT_POST, 'task') !== NULL) {
+        $this->_formValues['task'] = filter_input(INPUT_POST, 'task');
+      }
 
       $this->setOutputMode();
 
@@ -1493,9 +1501,10 @@ class CRM_Report_Form extends CRM_Core_Form {
 
     $this->assign('instanceForm', $this->_instanceForm);
 
-    // CRM-16274 Determine if user has 'edit all contacts' or equivalent
-    $permission = CRM_Core_Permission::getPermission();
-    if ($permission == CRM_Core_Permission::EDIT &&
+    // CRM-19330 - check that the user has Edit permissions
+    // getPermission() simply returns CRM_Core_Permission::EDIT.
+    $permission = CRM_Core_Permission::check(CRM_Core_Permission::EDIT);
+    if ($permission  &&
       $this->_add2groupSupported
     ) {
       $this->addElement('select', 'groups', ts('Group'),


### PR DESCRIPTION
This does the following:
Removes Add to Groups from reports generated by users who do not have edit contact permissions
Removes Save and Save Copy actions from users who do not have manage reports permissions
Enables Print, Print to PDF and Export to Excel for non-privileged users.  These actions did nothing before the change.

---

 * [CRM-19330: Add Contacts to Group appears and Action do nothing for non-privileged users under Joomla](https://issues.civicrm.org/jira/browse/CRM-19330)