### PR TITLE
CRM-19490 handle custom date fields as well as fields ending in _date

### DIFF
--- a/templates/CRM/UF/Form/Block.tpl
+++ b/templates/CRM/UF/Form/Block.tpl
@@ -123,7 +123,11 @@
               {elseif ( ( $n|substr:-5:5 eq '_date' ) OR ( $field.data_type eq 'Date' ) ) AND
               ( $form.formName neq 'Confirm' )  AND
               ( $form.formName neq 'ThankYou' ) }
-                {include file="CRM/common/jcalendar.tpl" elementName=$n}
+                {if ( $n|substr:-5:5 eq '_date' ) }
+                  {include file="CRM/common/jcalendar.tpl" elementName=$n}
+                {else}
+                  {$form.$n.html}
+                {/if}
               {elseif ( ( $n|substr:-5:5 eq '_date' ) OR ( $field.data_type eq 'Date' ) ) }
                 {assign var="date_value" value=$form.$n.value}
                 <span class="crm-frozen-field">

--- a/templates/CRM/UF/Form/Block.tpl
+++ b/templates/CRM/UF/Form/Block.tpl
@@ -120,12 +120,11 @@
                 {include file="CRM/Profile/Form/GreetingType.tpl"}
               {elseif ($n eq 'group' && $form.group) || ($n eq 'tag' && $form.tag)}
                 {include file="CRM/Contact/Form/Edit/TagsAndGroups.tpl" type=$n title=null context="profile"}
-              {elseif ( $n|substr:-5:5 eq '_date' ) AND
+              {elseif ( ( $n|substr:-5:5 eq '_date' ) OR ( $field.data_type eq 'Date' ) ) AND
               ( $form.formName neq 'Confirm' )  AND
               ( $form.formName neq 'ThankYou' ) }
                 {include file="CRM/common/jcalendar.tpl" elementName=$n}
-              {elseif ( ( $n|substr:-5:5 eq '_date' ) OR ( $field.data_type eq 'Date' ) )
-                 AND  ( ( $form.formName eq 'Confirm' ) OR ( $form.formName eq 'ThankYou') ) }
+              {elseif ( ( $n|substr:-5:5 eq '_date' ) OR ( $field.data_type eq 'Date' ) ) }
                 {assign var="date_value" value=$form.$n.value}
                 <span class="crm-frozen-field">
                   {$date_value|date_format:"%Y-%m-%d"|crmDate:$config->dateformatshortdate}

--- a/templates/CRM/UF/Form/Block.tpl
+++ b/templates/CRM/UF/Form/Block.tpl
@@ -124,7 +124,8 @@
               ( $form.formName neq 'Confirm' )  AND
               ( $form.formName neq 'ThankYou' ) }
                 {include file="CRM/common/jcalendar.tpl" elementName=$n}
-              {elseif ( $n|substr:-5:5 eq '_date' ) }
+              {elseif ( ( $n|substr:-5:5 eq '_date' ) OR ( $field.data_type eq 'Date' ) )
+                 AND  ( ( $form.formName eq 'Confirm' ) OR ( $form.formName eq 'ThankYou') ) }
                 {assign var="date_value" value=$form.$n.value}
                 <span class="crm-frozen-field">
                   {$date_value|date_format:"%Y-%m-%d"|crmDate:$config->dateformatshortdate}


### PR DESCRIPTION
* [CRM-19490: Profile date fields don't respect localisation on the Contribution Page confirmation screen](https://issues.civicrm.org/jira/browse/CRM-19490)