### PR TITLE
CRM-19832: Backporting #9637 to 4.6

### DIFF
--- a/CRM/Activity/Task.php
+++ b/CRM/Activity/Task.php
@@ -137,9 +137,11 @@ class CRM_Activity_Task {
       if (!CRM_Core_Permission::check('delete activities')) {
         unset(self::$_tasks[1]);
       }
+
+      CRM_Utils_Hook::searchTasks('activity', self::$_tasks);
+      asort(self::$_tasks);
     }
-    CRM_Utils_Hook::searchTasks('activity', self::$_tasks);
-    asort(self::$_tasks);
+
     return self::$_tasks;
   }
 

--- a/CRM/Campaign/Task.php
+++ b/CRM/Campaign/Task.php
@@ -94,11 +94,10 @@ class CRM_Campaign_Task {
           'result' => FALSE,
         ),
       );
+
+      CRM_Utils_Hook::searchTasks('campaign', self::$_tasks);
+      asort(self::$_tasks);
     }
-
-    CRM_Utils_Hook::searchTasks('campaign', self::$_tasks);
-
-    asort(self::$_tasks);
 
     return self::$_tasks;
   }

--- a/CRM/Case/Task.php
+++ b/CRM/Case/Task.php
@@ -93,10 +93,11 @@ class CRM_Case_Task {
       if (!CRM_Core_Permission::check('delete in CiviCase')) {
         unset(self::$_tasks[1]);
       }
+
+      CRM_Utils_Hook::searchTasks('case', self::$_tasks);
+      asort(self::$_tasks);
     }
 
-    CRM_Utils_Hook::searchTasks('case', self::$_tasks);
-    asort(self::$_tasks);
     return self::$_tasks;
   }
 

--- a/CRM/Contribute/Task.php
+++ b/CRM/Contribute/Task.php
@@ -133,6 +133,7 @@ class CRM_Contribute_Task {
       if (!$invoicing) {
         unset(self::$_tasks[9]);
       }
+
       CRM_Utils_Hook::searchTasks('contribution', self::$_tasks);
       asort(self::$_tasks);
     }

--- a/CRM/Event/Task.php
+++ b/CRM/Event/Task.php
@@ -140,10 +140,11 @@ class CRM_Event_Task {
       if (!CRM_Core_Permission::check('edit event participants')) {
         unset(self::$_tasks[4], self::$_tasks[5], self::$_tasks[15]);
       }
+
+      CRM_Utils_Hook::searchTasks('event', self::$_tasks);
+      asort(self::$_tasks);
     }
 
-    CRM_Utils_Hook::searchTasks('event', self::$_tasks);
-    asort(self::$_tasks);
     return self::$_tasks;
   }
 

--- a/CRM/Grant/Task.php
+++ b/CRM/Grant/Task.php
@@ -89,12 +89,15 @@ class CRM_Grant_Task {
           'result' => FALSE,
         ),
       );
+
+      if (!CRM_Core_Permission::check('delete in CiviGrant')) {
+        unset(self::$_tasks[1]);
+      }
+
+      CRM_Utils_Hook::searchTasks('grant', self::$_tasks);
+      asort(self::$_tasks);
     }
-    if (!CRM_Core_Permission::check('delete in CiviGrant')) {
-      unset(self::$_tasks[1]);
-    }
-    CRM_Utils_Hook::searchTasks('grant', self::$_tasks);
-    asort(self::$_tasks);
+
     return self::$_tasks;
   }
 

--- a/CRM/Member/Task.php
+++ b/CRM/Member/Task.php
@@ -119,9 +119,11 @@ class CRM_Member_Task {
       if (!CRM_Core_Permission::check('edit memberships')) {
         unset(self::$_tasks[5]);
       }
+
+      CRM_Utils_Hook::searchTasks('membership', self::$_tasks);
+      asort(self::$_tasks);
     }
-    CRM_Utils_Hook::searchTasks('membership', self::$_tasks);
-    asort(self::$_tasks);
+
     return self::$_tasks;
   }
 

--- a/CRM/Pledge/Task.php
+++ b/CRM/Pledge/Task.php
@@ -89,9 +89,11 @@ class CRM_Pledge_Task {
       if (!CRM_Core_Permission::check('delete in CiviPledge')) {
         unset(self::$_tasks[1]);
       }
+
+      CRM_Utils_Hook::searchTasks('pledge', self::$_tasks);
+      asort(self::$_tasks);
     }
-    CRM_Utils_Hook::searchTasks('pledge', self::$_tasks);
-    asort(self::$_tasks);
+
     return self::$_tasks;
   }
 


### PR DESCRIPTION
Backporting https://github.com/civicrm/civicrm-core/pull/9637

---

 * [CRM-19832: hook_civicrm_searchTasks get invoked twice for some entities](https://issues.civicrm.org/jira/browse/CRM-19832)