### PR TITLE
(Backport) CRM-19690 - Declare Mailing.template_type, Mailing.template_options, Hook::mailingTemplateTypes

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -3188,4 +3188,76 @@ AND        m.id = %1
     return $fieldPerms;
   }
 
+  /**
+   * Whitelist of possible values for the entity_table field
+   * @return array
+   */
+  public static function mailingGroupEntityTables($context = NULL) {
+    return array(
+      CRM_Contact_BAO_Group::getTableName() => 'Group',
+      CRM_Mailing_BAO_Mailing::getTableName() => 'Mailing',
+    );
+  }
+
+  /**
+   * Get the public view url.
+   *
+   * @param int $id
+   * @param bool $absolute
+   *
+   * @return string
+   */
+  public static function getPublicViewUrl($id, $absolute = TRUE) {
+    if ((civicrm_api3('Mailing', 'getvalue', array('id' => $id, 'return' => 'visibility'))) === 'Public Pages') {
+      return CRM_Utils_System::url('civicrm/mailing/view', array('id' => $id), $absolute, NULL, TRUE, TRUE);
+    }
+  }
+
+  /**
+   * @return array
+   *   A list of template-types, keyed by name. Each defines:
+   *     - editorUrl: string, Angular template name
+   *
+   *   Ex: $templateTypes['mosaico']['editorUrl'] = '~/crmMosaico/editor.html'.
+   */
+  public static function getTemplateTypes() {
+    if (!isset(Civi::$statics[__CLASS__]['templateTypes'])) {
+      $types = array();
+      $types[] = array(
+        'name' => 'traditional',
+        'editorUrl' => CRM_Mailing_Info::workflowEnabled() ? '~/crmMailing/EditMailingCtrl/workflow.html' : '~/crmMailing/EditMailingCtrl/2step.html',
+        'weight' => 0,
+      );
+
+      CRM_Utils_Hook::mailingTemplateTypes($types);
+
+      $defaults = array('weight' => 0);
+      foreach (array_keys($types) as $typeName) {
+        $types[$typeName] = array_merge($defaults, $types[$typeName]);
+      }
+      usort($types, function ($a, $b) {
+        if ($a['weight'] === $b['weight']) {
+          return 0;
+        }
+        return $a['weight'] < $b['weight'] ? -1 : 1;
+      });
+
+      Civi::$statics[__CLASS__]['templateTypes'] = $types;
+    }
+
+    return Civi::$statics[__CLASS__]['templateTypes'];
+  }
+
+  /**
+   * @return array
+   *   Array(string $name => string $label).
+   */
+  public static function getTemplateTypeNames() {
+    $r = array();
+    foreach (self::getTemplateTypes() as $type) {
+      $r[$type['name']] = $type['name'];
+    }
+    return $r;
+  }
+
 }

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -3214,11 +3214,14 @@ AND        m.id = %1
   }
 
   /**
+   * Get a list of template types which can be used as `civicrm_mailing.template_type`.
+   *
    * @return array
-   *   A list of template-types, keyed by name. Each defines:
+   *   A list of template-types, keyed numerically. Each defines:
+   *     - name: string, a short symbolic name
    *     - editorUrl: string, Angular template name
    *
-   *   Ex: $templateTypes['mosaico']['editorUrl'] = '~/crmMosaico/editor.html'.
+   *   Ex: $templateTypes[0] === array('name' => 'mosaico', 'editorUrl' => '~/crmMosaico/editor.html').
    */
   public static function getTemplateTypes() {
     if (!isset(Civi::$statics[__CLASS__]['templateTypes'])) {
@@ -3249,6 +3252,8 @@ AND        m.id = %1
   }
 
   /**
+   * Get a list of template types.
+   *
    * @return array
    *   Array(string $name => string $label).
    */

--- a/CRM/Mailing/Info.php
+++ b/CRM/Mailing/Info.php
@@ -165,6 +165,7 @@ class CRM_Mailing_Info extends CRM_Core_Component_Info {
     CRM_Core_Resources::singleton()
       ->addSetting(array(
         'crmMailing' => array(
+          'templateTypes' => CRM_Mailing_BAO_Mailing::getTemplateTypes(),
           'civiMails' => $civiMails['values'],
           'campaignEnabled' => in_array('CiviCampaign', $config->enableComponents),
           'groupNames' => $groupNames['values'],

--- a/CRM/Upgrade/Incremental/php/FourSix.php
+++ b/CRM/Upgrade/Incremental/php/FourSix.php
@@ -286,6 +286,27 @@ class CRM_Upgrade_Incremental_php_FourSix {
   }
 
   /**
+   * Upgrade function.
+   *
+   * @param string $rev
+   */
+  public function upgrade_4_6_26($rev) {
+    $this->addTask(ts('Upgrade DB to %1: SQL', array(1 => $rev)), 'task_4_6_x_runSql', $rev);
+    $this->addTask('Add new CiviMail fields', 'addMailingTemplateType');
+  }
+
+  public static function addMailingTemplateType() {
+    if (!CRM_Core_DAO::checkFieldExists('civicrm_mailing', 'template_type', FALSE)) {
+      CRM_Core_DAO::executeQuery('
+        ALTER TABLE civicrm_mailing
+        ADD COLUMN `template_type` varchar(64)  NOT NULL DEFAULT \'traditional\' COMMENT \'The language/processing system used for email templates.\',
+        ADD COLUMN `template_options` longtext  COMMENT \'Advanced options used by the email templating system. (JSON encoded)\'
+      ');
+    }
+    return TRUE;
+  }
+
+  /**
    * Add Getting Started dashlet to dashboard
    *
    * @param \CRM_Queue_TaskContext $ctx

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -863,6 +863,23 @@ abstract class CRM_Utils_Hook {
   }
 
   /**
+   * (Experimental) Modify the list of template-types used for CiviMail composition.
+   *
+   * @param array $types
+   *   Sequentially indexed list of template types. Each type specifies:
+   *     - name: string
+   *     - editorUrl: string, Angular template URL
+   *     - weight: int, priority when picking a default value for new mailings
+   * @return mixed
+   */
+  public static function mailingTemplateTypes(&$types) {
+    return self::singleton()->invoke(1, $types, self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      'civicrm_mailingTemplateTypes'
+    );
+  }
+
+  /**
    * This hook is called when composing the array of membershipTypes and their cost during a membership registration
    * (new or renewal).
    * Note the hook is called on initial page load and also reloaded after submit (PRG pattern).

--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -43,6 +43,9 @@
  * @throws \Civi\API\Exception\UnauthorizedException
  */
 function civicrm_api3_mailing_create($params) {
+  if (isset($params['template_options']) && is_array($params['template_options'])) {
+    $params['template_options'] = $params['template_options'] === array() ? '{}' : json_encode($params['template_options']);
+  }
   if (CRM_Mailing_Info::workflowEnabled()) {
     // Note: 'schedule mailings' and 'approve mailings' can update certain fields, but can't create.
 
@@ -64,7 +67,8 @@ function civicrm_api3_mailing_create($params) {
     $safeParams = $params;
   }
   $safeParams['_evil_bao_validator_'] = 'CRM_Mailing_BAO_Mailing::checkSendable';
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $safeParams);
+  $result = _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $safeParams);
+  return _civicrm_api3_mailing_get_formatResult($result);
 
 }
 
@@ -229,7 +233,27 @@ function civicrm_api3_mailing_delete($params) {
  * @return array
  */
 function civicrm_api3_mailing_get($params) {
-  return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  $result = _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_mailing_get_formatResult($result);
+}
+
+/**
+ * Format definition.
+ *
+ * @param array $result
+ *
+ * @return array
+ * @throws \CRM_Core_Exception
+ */
+function _civicrm_api3_mailing_get_formatResult($result) {
+  if (isset($result['values']) && is_array($result['values'])) {
+    foreach ($result['values'] as $key => $caseType) {
+      if (isset($result['values'][$key]['template_options']) && is_string($result['values'][$key]['template_options'])) {
+        $result['values'][$key]['template_options'] = json_decode($result['values'][$key]['template_options'], TRUE);
+      }
+    }
+  }
+  return $result;
 }
 
 /**

--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -44,7 +44,7 @@
  */
 function civicrm_api3_mailing_create($params) {
   if (isset($params['template_options']) && is_array($params['template_options'])) {
-    $params['template_options'] = $params['template_options'] === array() ? '{}' : json_encode($params['template_options']);
+    $params['template_options'] = ($params['template_options'] === array()) ? '{}' : json_encode($params['template_options']);
   }
   if (CRM_Mailing_Info::workflowEnabled()) {
     // Note: 'schedule mailings' and 'approve mailings' can update certain fields, but can't create.

--- a/tests/phpunit/api/v3/MailingTest.php
+++ b/tests/phpunit/api/v3/MailingTest.php
@@ -95,6 +95,44 @@ class api_v3_MailingTest extends CiviUnitTestCase {
   }
 
   /**
+   * The `template_options` field should be treated a JSON object.
+   *
+   * This test will create, read, and update the field.
+   */
+  public function testMailerCreateTemplateOptions() {
+    // 1. Create mailing with template_options.
+    $params = $this->_params;
+    $params['template_options'] = json_encode(array('foo' => 'bar_1'));
+    $createResult = $this->callAPISuccess('mailing', 'create', $params);
+    $id = $createResult['id'];
+    $this->assertDBQuery('{"foo":"bar_1"}', 'SELECT template_options FROM civicrm_mailing WHERE id = %1', array(
+      1 => array($id, 'Int'),
+    ));
+    $this->assertEquals('bar_1', $createResult['values'][$id]['template_options']['foo']);
+
+    // 2. Get mailing with template_options.
+    $getResult = $this->callAPISuccess('mailing', 'get', array(
+      'id' => $id,
+    ));
+    $this->assertEquals('bar_1', $getResult['values'][$id]['template_options']['foo']);
+    $getValueResult = $this->callAPISuccess('mailing', 'getvalue', array(
+      'id' => $id,
+      'return' => 'template_options',
+    ));
+    $this->assertEquals('bar_1', $getValueResult['foo']);
+
+    // 3. Update mailing with template_options.
+    $updateResult = $this->callAPISuccess('mailing', 'create', array(
+      'id' => $id,
+      'template_options' => array('foo' => 'bar_2'),
+    ));
+    $this->assertDBQuery('{"foo":"bar_2"}', 'SELECT template_options FROM civicrm_mailing WHERE id = %1', array(
+      1 => array($id, 'Int'),
+    ));
+    $this->assertEquals('bar_2', $updateResult['values'][$id]['template_options']['foo']);
+  }
+
+  /**
    * The Mailing.create API supports magic properties "groups[include,enclude]" and "mailings[include,exclude]".
    * Make sure these work
    */

--- a/tests/phpunit/api/v3/MailingTest.php
+++ b/tests/phpunit/api/v3/MailingTest.php
@@ -87,6 +87,14 @@ class api_v3_MailingTest extends CiviUnitTestCase {
   }
 
   /**
+   *
+   */
+  public function testTemplateTypeOptions() {
+    $types = $this->callAPISuccess('Mailing', 'getoptions', array('field' => 'template_type'));
+    $this->assertTrue(isset($types['values']['traditional']));
+  }
+
+  /**
    * The Mailing.create API supports magic properties "groups[include,enclude]" and "mailings[include,exclude]".
    * Make sure these work
    */

--- a/xml/schema/Mailing/Mailing.xml
+++ b/xml/schema/Mailing/Mailing.xml
@@ -160,6 +160,24 @@
     </html>
   </field>
   <field>
+    <name>template_type</name>
+    <title>Template Type</title>
+    <type>varchar</type>
+    <length>64</length>
+    <default>'traditional'</default>
+    <required>true</required>
+    <comment>The language/processing system used for email templates.</comment>
+    <pseudoconstant>
+      <callback>CRM_Mailing_BAO_Mailing::getTemplateTypeNames</callback>
+    </pseudoconstant>
+  </field>
+  <field>
+    <name>template_options</name>
+    <title>Template Options (JSON)</title>
+    <type>longtext</type>
+    <comment>Advanced options used by the email templating system. (JSON encoded)</comment>
+  </field>
+  <field>
     <name>subject</name>
     <type>varchar</type>
     <length>128</length>


### PR DESCRIPTION
This is a backport of #9562 which adds two new fields to the schema-- `template_type` and `template_options`:

 * The allowed values for `template_type` can be declared using `hook_civicrm_mailingTemplateTypes`.
 * The `template_options` is an open-ended array/JSON-object (generally in the same style as `CaseType.definition`).

For example, when composing a mailing with Mosaico, one would need to store
additional metadata about the template to support editing and reuse.

For more details, see the commit notes.

---

 * [CRM-19690: Allow alternative email templating systems](https://issues.civicrm.org/jira/browse/CRM-19690)