### PR TITLE
CRM-19330 Fix issues with reports for non-privileged users.

### DIFF
--- a/CRM/Report/BAO/ReportInstance.php
+++ b/CRM/Report/BAO/ReportInstance.php
@@ -391,6 +391,11 @@ class CRM_Report_BAO_ReportInstance extends CRM_Report_DAO_ReportInstance {
         ),
       );
     }
+    else {
+      // CRM-19330 Remove the options to save or save a copy.
+      unset($actions['report_instance.save']);
+      unset($actions['report_instance.copy']);
+    }
     return $actions;
   }
 

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -577,6 +577,11 @@ class CRM_Report_Form extends CRM_Core_Form {
       else {
         $this->_formValues = NULL;
       }
+      // CRM-19330 Unprivileged users don't get the task in the form values,
+      // but they appear in the post
+      if (!$this->_formValues['task'] && filter_input(INPUT_POST, 'task') !== NULL) {
+        $this->_formValues['task'] = filter_input(INPUT_POST, 'task');
+      }
 
       $this->setOutputMode();
 
@@ -1493,9 +1498,10 @@ class CRM_Report_Form extends CRM_Core_Form {
 
     $this->assign('instanceForm', $this->_instanceForm);
 
-    // CRM-16274 Determine if user has 'edit all contacts' or equivalent
-    $permission = CRM_Core_Permission::getPermission();
-    if ($permission == CRM_Core_Permission::EDIT &&
+    // CRM-19330 - check that the user has Edit permissions
+    // getPermission() simply returns CRM_Core_Permission::EDIT.
+    $permission = CRM_Core_Permission::check(CRM_Core_Permission::EDIT);
+    if ($permission  &&
       $this->_add2groupSupported
     ) {
       $this->addElement('select', 'groups', ts('Group'),


### PR DESCRIPTION
This does the following to reports:

1. Removes Add Contacts to Group for users who don't have edit contact privileges.
2. Removes Save and Save Copy for users who don't have manage report privileges.
3. Enables Print, Print as PDF and Export as CSV for non-privileged users.  Prior to this PR, those actions did nothing


---

 * [CRM-19330: Add Contacts to Group appears and Action do nothing for non-privileged users under Joomla](https://issues.civicrm.org/jira/browse/CRM-19330)