### PR TITLE
CRM-19838 - Fix menujs path for D8

### DIFF
--- a/CRM/Core/Smarty/plugins/function.crmNavigationMenu.php
+++ b/CRM/Core/Smarty/plugins/function.crmNavigationMenu.php
@@ -59,12 +59,11 @@ function smarty_function_crmNavigationMenu($params, &$smarty) {
     $contactID = $session->get('userID');
     if ($contactID) {
       // These params force the browser to refresh the js file when switching user, domain, or language
-      // We don't put them as a query string because some browsers will refuse to cache a page with a ? in the url
       // @see CRM_Admin_Page_AJAX::getNavigationMenu
       $lang = CRM_Core_I18n::getLocale();
       $domain = CRM_Core_Config::domainID();
       $key = CRM_Core_BAO_Navigation::getCacheKey($contactID);
-      $src = CRM_Utils_System::url("civicrm/ajax/menujs/$contactID/$lang/$domain/$key");
+      $src = CRM_Utils_System::url("civicrm/ajax/menujs", array('cid' => $contactID, 'lang' => $lang, 'domain' => $domain, 'key' => $key));
       // CRM-15493 QFkey needed for quicksearch bar - must be unique on each page refresh so adding it directly to markup
       $qfKey = CRM_Core_Key::get('CRM_Contact_Controller_Search', TRUE);
       return '<script id="civicrm-navigation-menu" type="text/javascript" src="' . $src . '" data-qfkey=' . json_encode($qfKey) . '></script>';


### PR DESCRIPTION
* [CRM-19838: D8 - CiviCRM Pages won't load, CiviCRM Menu MIA](https://issues.civicrm.org/jira/browse/CRM-19838)