### PR TITLE
Fire hook_civicrm_emailProcessor('activity') if Activity,create successful

### DIFF
--- a/CRM/Utils/Mail/EmailProcessor.php
+++ b/CRM/Utils/Mail/EmailProcessor.php
@@ -259,10 +259,9 @@ class CRM_Utils_Mail_EmailProcessor {
           }
           else {
             $matches = TRUE;
+            CRM_Utils_Hook::emailProcessor('activity', $params, $mail, $result);
             echo "Processed as Activity: {$mail->subject}\n";
           }
-
-          CRM_Utils_Hook::emailProcessor('activity', $params, $mail, $result);
         }
 
         // if $matches is empty, this email is not CiviMail-bound


### PR DESCRIPTION
CRM-19844

If this is triggered when the Activity API call was unsuccessful, it can lead to the mailbox processing being blocked by the rejected email.

Further emails may not be processed.

---

 * [CRM-19844: Inbound activity emails - don't fire hook if activity processing failed](https://issues.civicrm.org/jira/browse/CRM-19844)