### PR TITLE
CRM-19836 Enable activity create from replies to CiviMail.

### DIFF
--- a/api/v3/Job.php
+++ b/api/v3/Job.php
@@ -358,15 +358,23 @@ function civicrm_api3_job_fetch_bounces($params) {
   if (!$lock->isAcquired()) {
     return civicrm_api3_create_error('Could not acquire lock, another EmailProcessor process is running');
   }
-  if (!CRM_Utils_Mail_EmailProcessor::processBounces()) {
-    $lock->release();
-    return civicrm_api3_create_error('Process Bounces failed');
-  }
+  CRM_Utils_Mail_EmailProcessor::processBounces($params['is_create_activities']);
   $lock->release();
 
-  // FIXME: processBounces doesn't return true/false on success/failure
-  $values = array();
-  return civicrm_api3_create_success($values, $params, 'Job', 'fetch_bounces');
+  return civicrm_api3_create_success(1, $params, 'Job', 'fetch_bounces');
+}
+
+/**
+ * Metadata for bounce function.
+ *
+ * @param array $params
+ */
+function _civicrm_api3_job_fetch_bounces_spec(&$params) {
+  $params['is_create_activities'] = array(
+    'api.default' => 0,
+    'type' => CRM_Utils_Type::T_BOOLEAN,
+    'title' => ts('Create activities for replies?'),
+  );
 }
 
 /**


### PR DESCRIPTION
This relies on a parameter being added to the api call:

civicrm_api3('Job', 'fetch_bounces', array('is_create_activities' => TRUE));

---

 * [CRM-19836: Allow mail bounce processing to create activities for inbound email](https://issues.civicrm.org/jira/browse/CRM-19836)