### PR TITLE
CRM-8526, CRM-19786, CRM-18141, CRM-19757 : Fix Schedule Reminder tokens

### DIFF
--- a/CRM/Activity/Tokens.php
+++ b/CRM/Activity/Tokens.php
@@ -110,8 +110,8 @@ class CRM_Activity_Tokens extends \Civi\Token\AbstractTokenSubscriber {
     elseif (isset($actionSearchResult->$field)) {
       $row->tokens($entity, $field, $actionSearchResult->$field);
     }
-    elseif (\CRM_Core_BAO_CustomField::getKeyID($field)) {
-      $row->customToken($entity, $field, $actionSearchResult->entity_id);
+    elseif ($cfID = \CRM_Core_BAO_CustomField::getKeyID($field)) {
+      $row->customToken($entity, $cfID, $actionSearchResult->entity_id);
     }
     else {
       $row->tokens($entity, $field, '');

--- a/CRM/Activity/Tokens.php
+++ b/CRM/Activity/Tokens.php
@@ -49,12 +49,15 @@ class CRM_Activity_Tokens extends \Civi\Token\AbstractTokenSubscriber {
    * CRM_Activity_Tokens constructor.
    */
   public function __construct() {
-    parent::__construct('activity', array(
-      'activity_id' => ts('Activity ID'),
-      'activity_type' => ts('Activity Type'),
-      'subject' => ts('Activity Subject'),
-      'details' => ts('Activity Details'),
-      'activity_date_time' => ts('Activity Date-Time'),
+    parent::__construct('activity', array_merge(
+      array(
+        'activity_id' => ts('Activity ID'),
+        'activity_type' => ts('Activity Type'),
+        'subject' => ts('Activity Subject'),
+        'details' => ts('Activity Details'),
+        'activity_date_time' => ts('Activity Date-Time'),
+      ),
+      $this->getCustomTokens('Activity')
     ));
   }
 
@@ -106,6 +109,9 @@ class CRM_Activity_Tokens extends \Civi\Token\AbstractTokenSubscriber {
     }
     elseif (isset($actionSearchResult->$field)) {
       $row->tokens($entity, $field, $actionSearchResult->$field);
+    }
+    elseif (\CRM_Core_BAO_CustomField::getKeyID($field)) {
+      $row->customToken($entity, $field, $actionSearchResult->entity_id);
     }
     else {
       $row->tokens($entity, $field, '');

--- a/CRM/Contribute/Tokens.php
+++ b/CRM/Contribute/Tokens.php
@@ -85,6 +85,7 @@ class CRM_Contribute_Tokens extends \Civi\Token\AbstractTokenSubscriber {
     $tokens['source'] = ts('Contribution Source');
     $tokens['status'] = ts('Contribution Status');
     $tokens['type'] = ts('Financial Type');
+    $tokens = array_merge($tokens, $this->getCustomTokens('Contribution'));
     parent::__construct('contribution', $tokens);
   }
 
@@ -134,6 +135,9 @@ class CRM_Contribute_Tokens extends \Civi\Token\AbstractTokenSubscriber {
     }
     elseif (isset($aliasTokens[$field])) {
       $row->dbToken($entity, $field, 'CRM_Contribute_BAO_Contribution', $aliasTokens[$field], $fieldValue);
+    }
+    elseif (\CRM_Core_BAO_CustomField::getKeyID($field)) {
+      $row->customToken($entity, $field, $actionSearchResult->entity_id);
     }
     else {
       $row->dbToken($entity, $field, 'CRM_Contribute_BAO_Contribution', $field, $fieldValue);

--- a/CRM/Contribute/Tokens.php
+++ b/CRM/Contribute/Tokens.php
@@ -136,8 +136,8 @@ class CRM_Contribute_Tokens extends \Civi\Token\AbstractTokenSubscriber {
     elseif (isset($aliasTokens[$field])) {
       $row->dbToken($entity, $field, 'CRM_Contribute_BAO_Contribution', $aliasTokens[$field], $fieldValue);
     }
-    elseif (\CRM_Core_BAO_CustomField::getKeyID($field)) {
-      $row->customToken($entity, $field, $actionSearchResult->entity_id);
+    elseif ($cfID = \CRM_Core_BAO_CustomField::getKeyID($field)) {
+      $row->customToken($entity, $cfID, $actionSearchResult->entity_id);
     }
     else {
       $row->dbToken($entity, $field, 'CRM_Contribute_BAO_Contribution', $field, $fieldValue);

--- a/CRM/Event/Tokens.php
+++ b/CRM/Event/Tokens.php
@@ -142,8 +142,8 @@ LEFT JOIN civicrm_phone phone ON phone.id = lb.phone_id
     elseif (isset($actionSearchResult->$field)) {
       $row->tokens($entity, $field, $actionSearchResult->$field);
     }
-    elseif (\CRM_Core_BAO_CustomField::getKeyID($field)) {
-      $row->customToken($entity, $field, $actionSearchResult->entity_id);
+    elseif ($cfID = \CRM_Core_BAO_CustomField::getKeyID($field)) {
+      $row->customToken($entity, $cfID, $actionSearchResult->entity_id);
     }
     else {
       $row->tokens($entity, $field, '');

--- a/CRM/Event/Tokens.php
+++ b/CRM/Event/Tokens.php
@@ -44,21 +44,24 @@ class CRM_Event_Tokens extends \Civi\Token\AbstractTokenSubscriber {
    * Class constructor.
    */
   public function __construct() {
-    parent::__construct('event', array(
-      'event_type' => ts('Event Type'),
-      'title' => ts('Event Title'),
-      'event_id' => ts('Event ID'),
-      'start_date' => ts('Event Start Date'),
-      'end_date' => ts('Event End Date'),
-      'summary' => ts('Event Summary'),
-      'description' => ts('Event Description'),
-      'location' => ts('Event Location'),
-      'info_url' => ts('Event Info URL'),
-      'registration_url' => ts('Event Registration URL'),
-      'fee_amount' => ts('Event Fee'),
-      'contact_email' => ts('Event Contact (Email)'),
-      'contact_phone' => ts('Event Contact (Phone)'),
-      'balance' => ts('Event Balance'),
+    parent::__construct('event', array_merge(
+      array(
+        'event_type' => ts('Event Type'),
+        'title' => ts('Event Title'),
+        'event_id' => ts('Event ID'),
+        'start_date' => ts('Event Start Date'),
+        'end_date' => ts('Event End Date'),
+        'summary' => ts('Event Summary'),
+        'description' => ts('Event Description'),
+        'location' => ts('Event Location'),
+        'info_url' => ts('Event Info URL'),
+        'registration_url' => ts('Event Registration URL'),
+        'fee_amount' => ts('Event Fee'),
+        'contact_email' => ts('Event Contact (Email)'),
+        'contact_phone' => ts('Event Contact (Phone)'),
+        'balance' => ts('Event Balance'),
+      ),
+      $this->getCustomTokens('Event')
     ));
   }
 
@@ -138,6 +141,9 @@ LEFT JOIN civicrm_phone phone ON phone.id = lb.phone_id
     }
     elseif (isset($actionSearchResult->$field)) {
       $row->tokens($entity, $field, $actionSearchResult->$field);
+    }
+    elseif (\CRM_Core_BAO_CustomField::getKeyID($field)) {
+      $row->customToken($entity, $field, $actionSearchResult->entity_id);
     }
     else {
       $row->tokens($entity, $field, '');

--- a/CRM/Member/Tokens.php
+++ b/CRM/Member/Tokens.php
@@ -98,8 +98,8 @@ class CRM_Member_Tokens extends \Civi\Token\AbstractTokenSubscriber {
     elseif (isset($actionSearchResult->$field)) {
       $row->tokens($entity, $field, $actionSearchResult->$field);
     }
-    elseif (\CRM_Core_BAO_CustomField::getKeyID($field)) {
-      $row->customToken($entity, $field, $actionSearchResult->entity_id);
+    elseif ($cfID = \CRM_Core_BAO_CustomField::getKeyID($field)) {
+      $row->customToken($entity, $cfID, $actionSearchResult->entity_id);
     }
     else {
       $row->tokens($entity, $field, '');

--- a/CRM/Member/Tokens.php
+++ b/CRM/Member/Tokens.php
@@ -44,14 +44,17 @@ class CRM_Member_Tokens extends \Civi\Token\AbstractTokenSubscriber {
    * Class constructor.
    */
   public function __construct() {
-    parent::__construct('membership', array(
-      'fee' => ts('Membership Fee'),
-      'id' => ts('Membership ID'),
-      'join_date' => ts('Membership Join Date'),
-      'start_date' => ts('Membership Start Date'),
-      'end_date' => ts('Membership End Date'),
-      'status' => ts('Membership Status'),
-      'type' => ts('Membership Type'),
+    parent::__construct('membership', array_merge(
+      array(
+        'fee' => ts('Membership Fee'),
+        'id' => ts('Membership ID'),
+        'join_date' => ts('Membership Join Date'),
+        'start_date' => ts('Membership Start Date'),
+        'end_date' => ts('Membership End Date'),
+        'status' => ts('Membership Status'),
+        'type' => ts('Membership Type'),
+      ),
+      $this->getCustomTokens('Membership')
     ));
   }
 
@@ -94,6 +97,9 @@ class CRM_Member_Tokens extends \Civi\Token\AbstractTokenSubscriber {
     }
     elseif (isset($actionSearchResult->$field)) {
       $row->tokens($entity, $field, $actionSearchResult->$field);
+    }
+    elseif (\CRM_Core_BAO_CustomField::getKeyID($field)) {
+      $row->customToken($entity, $field, $actionSearchResult->entity_id);
     }
     else {
       $row->tokens($entity, $field, '');

--- a/Civi/Token/AbstractTokenSubscriber.php
+++ b/Civi/Token/AbstractTokenSubscriber.php
@@ -163,12 +163,12 @@ abstract class AbstractTokenSubscriber implements EventSubscriberInterface {
   /**
    * Populate the custom field and other remaining entity token data.
    *
-   * @param TokenRow $e
+   * @param TokenRow $row
    *   The record for which we want token values.
    * @param string $entity
    *   The entity for which we want the token values
    * @param array $tokens
-   *   The array of tokens whose data need to be fetched 
+   *   The array of tokens whose data need to be fetched
    */
   public function evaluateExtraToken(TokenRow $row, $entity, $tokens) {
     if (empty($tokens)) {

--- a/Civi/Token/TokenCompatSubscriber.php
+++ b/Civi/Token/TokenCompatSubscriber.php
@@ -62,17 +62,12 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
           throw new TokenException("Failed to generate token data. Invalid contact ID: " . $row->context['contactId']);
         }
 
-        $contactTokens = \CRM_Utils_Array::value('contact', $messageTokens);
-        if (!empty($contactTokens)) {
-          try {
-            $result = civicrm_api3('Contact', 'getsingle', array(
-              'id' => $contactId,
-              'return' => $contactTokens,
-            ));
-            $contact = array_merge($contact, $result);
-          }
-          catch (CiviCRM_API3_Exception $e) {
-            //do nothing
+        //update value of custom field token
+        if (!empty($messageTokens['contact'])) {
+          foreach ($messageTokens['contact'] as $token) {
+            if (\CRM_Core_BAO_CustomField::getKeyID($token)) {
+              $row->customToken('Contact', $token, $contactId);
+            }
           }
         }
       }

--- a/Civi/Token/TokenCompatSubscriber.php
+++ b/Civi/Token/TokenCompatSubscriber.php
@@ -61,6 +61,20 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
           // FIXME: Need to differentiate errors which kill the batch vs the individual row.
           throw new TokenException("Failed to generate token data. Invalid contact ID: " . $row->context['contactId']);
         }
+
+        $contactTokens = \CRM_Utils_Array::value('contact', $messageTokens);
+        if (!empty($contactTokens)) {
+          try {
+             $result = civicrm_api3('Contact', 'getsingle', array(
+              'id' => $contactId,
+              'return' => $contactTokens,
+             ));
+             $contact = array_merge($contact, $result);
+           }
+           catch (CiviCRM_API3_Exception $e) {
+             //do nothing
+           }
+        }
       }
       else {
         $contact = $row->context['contact'];
@@ -76,7 +90,6 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
 
       // Note: This is a small contract change from the past; data should be missing
       // less randomly.
-      //\CRM_Utils_Hook::tokenValues($contact, $row->context['contactId']);
       \CRM_Utils_Hook::tokenValues($contactArray,
         (array) $contactId,
         empty($row->context['mailingJob']) ? NULL : $row->context['mailingJob']->id,

--- a/Civi/Token/TokenCompatSubscriber.php
+++ b/Civi/Token/TokenCompatSubscriber.php
@@ -65,15 +65,15 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
         $contactTokens = \CRM_Utils_Array::value('contact', $messageTokens);
         if (!empty($contactTokens)) {
           try {
-             $result = civicrm_api3('Contact', 'getsingle', array(
+            $result = civicrm_api3('Contact', 'getsingle', array(
               'id' => $contactId,
               'return' => $contactTokens,
-             ));
-             $contact = array_merge($contact, $result);
-           }
-           catch (CiviCRM_API3_Exception $e) {
-             //do nothing
-           }
+            ));
+            $contact = array_merge($contact, $result);
+          }
+          catch (CiviCRM_API3_Exception $e) {
+            //do nothing
+          }
         }
       }
       else {
@@ -117,12 +117,12 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
     $e->string = \CRM_Utils_Token::replaceDomainTokens($e->string, \CRM_Core_BAO_Domain::getDomain(), $isHtml, $e->message['tokens'], $useSmarty);
 
     if (!empty($e->context['contact'])) {
+      \CRM_Utils_Token::replaceGreetingTokens($e->string, $e->context['contact'], $e->context['contact']['contact_id'], NULL, FALSE);
+
       $e->string = \CRM_Utils_Token::replaceContactTokens($e->string, $e->context['contact'], $isHtml, $e->message['tokens'], FALSE, $useSmarty);
 
       // FIXME: This may depend on $contact being merged with hook values.
       $e->string = \CRM_Utils_Token::replaceHookTokens($e->string, $e->context['contact'], $e->context['hookTokenCategories'], $isHtml, $useSmarty);
-
-      \CRM_Utils_Token::replaceGreetingTokens($e->string, NULL, $e->context['contact']['contact_id'], NULL, $useSmarty);
     }
 
     if ($useSmarty) {

--- a/Civi/Token/TokenCompatSubscriber.php
+++ b/Civi/Token/TokenCompatSubscriber.php
@@ -66,7 +66,10 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
         if (!empty($messageTokens['contact'])) {
           foreach ($messageTokens['contact'] as $token) {
             if (\CRM_Core_BAO_CustomField::getKeyID($token)) {
-              $row->customToken('Contact', $token, $contactId);
+              $contact[$token] = civicrm_api3('Contact', 'getvalue', array(
+                'return' => $token,
+                'id' => $contactId,
+              ));
             }
           }
         }
@@ -112,12 +115,12 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
     $e->string = \CRM_Utils_Token::replaceDomainTokens($e->string, \CRM_Core_BAO_Domain::getDomain(), $isHtml, $e->message['tokens'], $useSmarty);
 
     if (!empty($e->context['contact'])) {
-      \CRM_Utils_Token::replaceGreetingTokens($e->string, $e->context['contact'], $e->context['contact']['contact_id'], NULL, FALSE);
-
-      $e->string = \CRM_Utils_Token::replaceContactTokens($e->string, $e->context['contact'], $isHtml, $e->message['tokens'], FALSE, $useSmarty);
+      $e->string = \CRM_Utils_Token::replaceContactTokens($e->string, $e->context['contact'], $isHtml, $e->message['tokens'], TRUE, $useSmarty);
 
       // FIXME: This may depend on $contact being merged with hook values.
       $e->string = \CRM_Utils_Token::replaceHookTokens($e->string, $e->context['contact'], $e->context['hookTokenCategories'], $isHtml, $useSmarty);
+
+      \CRM_Utils_Token::replaceGreetingTokens($e->string, $e->context['contact'], $e->context['contact']['contact_id'], NULL, $useSmarty);
     }
 
     if ($useSmarty) {

--- a/Civi/Token/TokenRow.php
+++ b/Civi/Token/TokenRow.php
@@ -130,16 +130,23 @@ class TokenRow {
    * Update the value of a custom field token.
    *
    * @param string $entity
-   * @param string $fieldName
-   * @param string $entityID
+   * @param int $customFieldID
+   * @param int $entityID
    * @return TokenRow
    */
-  public function customToken($entity, $fieldName, $entityID) {
+  public function customToken($entity, $customFieldID, $entityID) {
+    $customFieldName = "custom_" . $customFieldID;
     $fieldValue = civicrm_api3($entity, 'getvalue', array(
-      'return' => $fieldName,
+      'return' => $customFieldName,
       'id' => $entityID,
     ));
-    return $this->tokens($entity, $fieldName, $fieldValue);
+
+    // format the raw custom field value into proper display value
+    if ($fieldValue) {
+      $fieldValue = \CRM_Core_BAO_CustomField::displayValue($fieldValue, $customFieldID);
+    }
+
+    return $this->tokens($entity, $customFieldName, $fieldValue);
   }
 
   /**

--- a/Civi/Token/TokenRow.php
+++ b/Civi/Token/TokenRow.php
@@ -127,6 +127,22 @@ class TokenRow {
   }
 
   /**
+   * Update the value of a custom field token.
+   *
+   * @param string $entity
+   * @param string $fieldName
+   * @param string $entityID
+   * @return TokenRow
+   */
+  public function customToken($entity, $fieldName, $entityID) {
+    $fieldValue = civicrm_api3($entity, 'getvalue', array(
+      'return' => $fieldName,
+      'id' => $entityID,
+    ));
+    return $this->tokens($entity, $fieldName, $fieldValue);
+  }
+
+  /**
    * Update the value of a token. Apply formatting based on DB schema.
    *
    * @param string $tokenEntity


### PR DESCRIPTION
* [CRM-18141: Scheduled reminders for activities not rendering custom field tokens](https://issues.civicrm.org/jira/browse/CRM-18141)
 * [CRM-19757: Some tokens stopped working in scheduled reminders](https://issues.civicrm.org/jira/browse/CRM-19757)

---

 * [CRM-8526: Support \[contribution.custom_nn\] tokens in templates](https://issues.civicrm.org/jira/browse/CRM-8526)
 * [CRM-19786: ActionSchedule assumes presence of tokens which are not registered](https://issues.civicrm.org/jira/browse/CRM-19786)