### PR TITLE
CRM-19853 replace interval controls with numeric

### DIFF
--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -162,7 +162,7 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
     $this->_freqUnits = CRM_Core_SelectValues::getRecurringFrequencyUnits();
 
     //reminder_interval
-    $this->add('number', 'start_action_offset', ts('When'), array('style' => 'width:5em'));
+    $this->add('number', 'start_action_offset', ts('When'), array('class' => 'six', 'min' => 1));
     $this->addRule('start_action_offset', ts('Value should be a positive number'), 'positiveInteger');
 
     $isActive = ts('Send email');
@@ -208,11 +208,11 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
     );
 
     $this->add('select', 'repetition_frequency_unit', ts('every'), $freqUnitsDisplay);
-    $this->add('number', 'repetition_frequency_interval', ts('every'), array('style' => 'width:5em'));
+    $this->add('number', 'repetition_frequency_interval', ts('every'), array('class' => 'six', 'min' => 1));
     $this->addRule('repetition_frequency_interval', ts('Value should be a positive number'), 'positiveInteger');
 
     $this->add('select', 'end_frequency_unit', ts('until'), $freqUnitsDisplay);
-    $this->add('number', 'end_frequency_interval', ts('until'), array('style' => 'width:5em'));
+    $this->add('number', 'end_frequency_interval', ts('until'), array('class' => 'six', 'min' => 1));
     $this->addRule('end_frequency_interval', ts('Value should be a positive number'), 'positiveInteger');
 
     $this->add('select', 'end_action', ts('Repetition Condition'), $condition, TRUE);

--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -162,7 +162,7 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
     $this->_freqUnits = CRM_Core_SelectValues::getRecurringFrequencyUnits();
 
     //reminder_interval
-    $this->add('number', 'start_action_offset', ts('When'), array('class' => 'six', 'min' => 1));
+    $this->add('number', 'start_action_offset', ts('When'), array('class' => 'six', 'min' => 0));
     $this->addRule('start_action_offset', ts('Value should be a positive number'), 'positiveInteger');
 
     $isActive = ts('Send email');
@@ -208,11 +208,11 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
     );
 
     $this->add('select', 'repetition_frequency_unit', ts('every'), $freqUnitsDisplay);
-    $this->add('number', 'repetition_frequency_interval', ts('every'), array('class' => 'six', 'min' => 1));
+    $this->add('number', 'repetition_frequency_interval', ts('every'), array('class' => 'six', 'min' => 0));
     $this->addRule('repetition_frequency_interval', ts('Value should be a positive number'), 'positiveInteger');
 
     $this->add('select', 'end_frequency_unit', ts('until'), $freqUnitsDisplay);
-    $this->add('number', 'end_frequency_interval', ts('until'), array('class' => 'six', 'min' => 1));
+    $this->add('number', 'end_frequency_interval', ts('until'), array('class' => 'six', 'min' => 0));
     $this->addRule('end_frequency_interval', ts('Value should be a positive number'), 'positiveInteger');
 
     $this->add('select', 'end_action', ts('Repetition Condition'), $condition, TRUE);

--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -161,10 +161,10 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
     //get the frequency units.
     $this->_freqUnits = CRM_Core_SelectValues::getRecurringFrequencyUnits();
 
-    $numericOptions = CRM_Core_SelectValues::getNumericOptions(0, 30);
-
     //reminder_interval
-    $this->add('select', 'start_action_offset', ts('When'), $numericOptions);
+    $this->add('number', 'start_action_offset', ts('When'), array('style' => 'width:5em'));
+    $this->addRule('start_action_offset', ts('Value should be a positive number'), 'positiveInteger');
+
     $isActive = ts('Send email');
     $recordActivity = ts('Record activity for automated email');
     if ($providersCount) {
@@ -208,9 +208,13 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
     );
 
     $this->add('select', 'repetition_frequency_unit', ts('every'), $freqUnitsDisplay);
-    $this->add('select', 'repetition_frequency_interval', ts('every'), $numericOptions);
+    $this->add('number', 'repetition_frequency_interval', ts('every'), array('style' => 'width:5em'));
+    $this->addRule('repetition_frequency_interval', ts('Value should be a positive number'), 'positiveInteger');
+
     $this->add('select', 'end_frequency_unit', ts('until'), $freqUnitsDisplay);
-    $this->add('select', 'end_frequency_interval', ts('until'), $numericOptions);
+    $this->add('number', 'end_frequency_interval', ts('until'), array('style' => 'width:5em'));
+    $this->addRule('end_frequency_interval', ts('Value should be a positive number'), 'positiveInteger');
+
     $this->add('select', 'end_action', ts('Repetition Condition'), $condition, TRUE);
     $this->add('select', 'end_date', ts('Date Field'), $selectedMapping->getDateFields(), TRUE);
 


### PR DESCRIPTION
Replace the interval select controls with options numbered 1-30 with numeric controls.

---

 * [CRM-19853: Change interval select controls in Scheduled Reminders with number controls](https://issues.civicrm.org/jira/browse/CRM-19853)