### PR TITLE
CRM-19853 replace interval controls with numeric

### DIFF
--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -161,10 +161,10 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
     //pass the mapping ID in UPDATE mode
     $mappings = CRM_Core_BAO_ActionSchedule::getMapping($mappingID);
 
-    $numericOptions = CRM_Core_SelectValues::getNumericOptions(0, 30);
-
     //reminder_interval
-    $this->add('select', 'start_action_offset', ts('When'), $numericOptions);
+    $this->add('text', 'start_action_offset', ts('When'), array('class' => 'six', 'min' => 1));
+    $this->addRule('start_action_offset', ts('Value should be a positive number'), 'positiveInteger');
+
     $isActive = ts('Send email');
     $recordActivity = ts('Record activity for automated email');
     if ($providersCount) {
@@ -208,9 +208,13 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
     );
 
     $this->add('select', 'repetition_frequency_unit', ts('every'), $freqUnitsDisplay);
-    $this->add('select', 'repetition_frequency_interval', ts('every'), $numericOptions);
+    $this->add('text', 'repetition_frequency_interval', ts('every'), array('class' => 'six', 'min' => 1));
+    $this->addRule('repetition_frequency_interval', ts('Value should be a positive number'), 'positiveInteger');
+
     $this->add('select', 'end_frequency_unit', ts('until'), $freqUnitsDisplay);
-    $this->add('select', 'end_frequency_interval', ts('until'), $numericOptions);
+    $this->add('text', 'end_frequency_interval', ts('until'), array('class' => 'six', 'min' => 1));
+    $this->addRule('end_frequency_interval', ts('Value should be a positive number'), 'positiveInteger');
+
     $this->add('select', 'end_action', ts('Repetition Condition'), $condition, TRUE);
     $this->add('select', 'end_date', ts('Date Field'), $sel4, TRUE);
 

--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -162,7 +162,7 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
     $mappings = CRM_Core_BAO_ActionSchedule::getMapping($mappingID);
 
     //reminder_interval
-    $this->add('text', 'start_action_offset', ts('When'), array('class' => 'six', 'min' => 1));
+    $this->add('text', 'start_action_offset', ts('When'), array('class' => 'six'));
     $this->addRule('start_action_offset', ts('Value should be a positive number'), 'positiveInteger');
 
     $isActive = ts('Send email');
@@ -208,11 +208,11 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
     );
 
     $this->add('select', 'repetition_frequency_unit', ts('every'), $freqUnitsDisplay);
-    $this->add('text', 'repetition_frequency_interval', ts('every'), array('class' => 'six', 'min' => 1));
+    $this->add('text', 'repetition_frequency_interval', ts('every'), array('class' => 'six'));
     $this->addRule('repetition_frequency_interval', ts('Value should be a positive number'), 'positiveInteger');
 
     $this->add('select', 'end_frequency_unit', ts('until'), $freqUnitsDisplay);
-    $this->add('text', 'end_frequency_interval', ts('until'), array('class' => 'six', 'min' => 1));
+    $this->add('text', 'end_frequency_interval', ts('until'), array('class' => 'six'));
     $this->addRule('end_frequency_interval', ts('Value should be a positive number'), 'positiveInteger');
 
     $this->add('select', 'end_action', ts('Repetition Condition'), $condition, TRUE);


### PR DESCRIPTION
Replace the interval select controls with options numbered 1-30 with numeric controls.

---

 * [CRM-19853: Change interval select controls in Scheduled Reminders with number controls](https://issues.civicrm.org/jira/browse/CRM-19853)