### PR TITLE
CRM-19864 - Set url to backend for getting started widget

### DIFF
--- a/CRM/Dashlet/Page/GettingStarted.php
+++ b/CRM/Dashlet/Page/GettingStarted.php
@@ -143,7 +143,7 @@ class CRM_Dashlet_Page_GettingStarted extends CRM_Core_Page {
         if (!empty(self::$_tokens[$categories][$token])) {
           $value = self::$_tokens[$categories][$token];
           if ($categories == 'crmurl') {
-            $value = CRM_Utils_System::url($value, "reset=1", FALSE, NULL, TRUE, TRUE);
+            $value = CRM_Utils_System::url($value, "reset=1");
           }
         }
         CRM_Utils_Token::token_replace($categories, $token, $value, $str);


### PR DESCRIPTION
* [CRM-19864: Incorrect URL in CiviCRM Resources dashlet on Joomla](https://issues.civicrm.org/jira/browse/CRM-19864)