### PR TITLE
Closes CRM-19869 - table layout problem multiple page PDF.

### DIFF
--- a/css/print.css
+++ b/css/print.css
@@ -124,3 +124,8 @@ table.form-layout td, table.form-layout th {
     font-style       : italic;
     float            : right;
 }
+
+/* Fix for CRM-19869 */
+tr {
+    page-break-inside: avoid;
+}


### PR DESCRIPTION
This fixes the layout of tables in multiple page PDFs, see CRM-19869. See this [comment](https://github.com/wkhtmltopdf/wkhtmltopdf/issues/1524#issuecomment-85072480) from the wkhtmltopdf issue tracker.

---

 * [CRM-19869: CiviReport: Layout problem multiple-page PDF](https://issues.civicrm.org/jira/browse/CRM-19869)