### PR TITLE
CRM-19831 Fix the loading of child groups

### DIFF
--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -1155,7 +1155,7 @@ WHERE  id IN $groupIdString
     // Changing to a for loop execustion takes around 0.02 seconds (20 ms).
     if (isset($tree[$group['id']]) && is_array($tree[$group['id']])) {
       for ($i = 0; $i < count($tree[$group['id']]); $i++) {
-        self::buildGroupHierarchy($hierarchy, $tree[$group['id'][$i]], $tree, $titleOnly, $spacer, $level + 1);
+        self::buildGroupHierarchy($hierarchy, $tree[$group['id']][$i], $tree, $titleOnly, $spacer, $level + 1);
       }
     }
   }


### PR DESCRIPTION
This follows on from @jaapjansma but there was a slight error which generated if you tried creating a new group with a parent. There was issues loading the group information as it was contained in an extra array. 

I have tested this on a local demo and is fine @colemanw

---

 * [CRM-19831: Function CRM_Contact_BAO_Group::getGroupsHierarchy performes bad with 3000 groups](https://issues.civicrm.org/jira/browse/CRM-19831)