### PR TITLE
CRM-19876: Fix grouping by contact id when queriing email recipients

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -4359,7 +4359,8 @@ civicrm_relationship.is_permission_a_b = 0
       $skipPermissions,
       TRUE, $smartGroupCache,
       NULL, 'AND',
-      $apiEntity
+      $apiEntity,
+   	  $useGroupBy = FALSE
     );
 
     //this should add a check for view deleted if permissions are enabled
@@ -4371,6 +4372,8 @@ civicrm_relationship.is_permission_a_b = 0
     // note : this modifies _fromClause and _simpleFromClause
     $query->includePseudoFieldsJoin($sort);
 
+	   $query->_useGroupBy = $useGroupBy;
+   
     list($select, $from, $where, $having) = $query->query($count);
 
     $options = $query->_options;

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -4336,6 +4336,8 @@ civicrm_relationship.is_permission_a_b = 0
    * @param string $apiEntity
    *   The api entity being called.
    *   This sort-of duplicates $mode in a confusing way. Probably not by design.
+   * @param bool $useGroupBy
+   *   Should the query be grouped by contact id?
    *
    * @return array
    */
@@ -4350,7 +4352,8 @@ civicrm_relationship.is_permission_a_b = 0
     $count = FALSE,
     $skipPermissions = TRUE,
     $mode = CRM_Contact_BAO_Query::MODE_CONTACTS,
-    $apiEntity = NULL
+    $apiEntity = NULL,
+    $useGroupBy = FALSE
   ) {
 
     $query = new CRM_Contact_BAO_Query(
@@ -4359,8 +4362,7 @@ civicrm_relationship.is_permission_a_b = 0
       $skipPermissions,
       TRUE, $smartGroupCache,
       NULL, 'AND',
-      $apiEntity,
-   	  $useGroupBy = FALSE
+      $apiEntity
     );
 
     //this should add a check for view deleted if permissions are enabled
@@ -4372,8 +4374,8 @@ civicrm_relationship.is_permission_a_b = 0
     // note : this modifies _fromClause and _simpleFromClause
     $query->includePseudoFieldsJoin($sort);
 
-	   $query->_useGroupBy = $useGroupBy;
-   
+    $query->_useGroupBy = $useGroupBy;
+
     list($select, $from, $where, $having) = $query->query($count);
 
     $options = $query->_options;

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1243,7 +1243,19 @@ class CRM_Utils_Token {
     $numberofContacts = count($contactIDs);
     $query = new CRM_Contact_BAO_Query($params, $returnProperties);
 
-    $details = $query->apiQuery($params, $returnProperties, NULL, NULL, 0, $numberofContacts, TRUE, FALSE, TRUE, CRM_Contact_BAO_Query::MODE_CONTACTS, NULL, TRUE);
+    $details = $query->apiQuery(
+        $params,
+        $returnProperties,
+        NULL,
+        NULL,
+        0,
+        $numberofContacts,
+        TRUE,
+        FALSE,
+        TRUE,
+        CRM_Contact_BAO_Query::MODE_CONTACTS,
+        NULL,
+        TRUE);
 
     $contactDetails = &$details[0];
 

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1243,7 +1243,7 @@ class CRM_Utils_Token {
     $numberofContacts = count($contactIDs);
     $query = new CRM_Contact_BAO_Query($params, $returnProperties);
 
-    $details = $query->apiQuery($params, $returnProperties, NULL, NULL, 0, $numberofContacts);
+    $details = $query->apiQuery($params, $returnProperties, NULL, NULL, 0, $numberofContacts, TRUE, FALSE, TRUE, CRM_Contact_BAO_Query::MODE_CONTACTS, NULL, TRUE);
 
     $contactDetails = &$details[0];
 


### PR DESCRIPTION
* [CRM-19876: Civi won't send simple mails to all email recpients if some hold multiple addresses](https://issues.civicrm.org/jira/browse/CRM-19876)