### PR TITLE
CRM-19863 - 'item_name' unnecessarily truncated when passed to PayPal

### DIFF
--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -834,7 +834,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
     $paypalParams = array(
       'business' => $this->_paymentProcessor['user_name'],
       'notify_url' => $notifyURL,
-      'item_name' => $this->getPaymentDescription($params),
+      'item_name' => $this->getPaymentDescription($params, 127),
       'quantity' => 1,
       'undefined_quantity' => 0,
       'cancel_return' => $cancelURL,


### PR DESCRIPTION
* [CRM-19863: 'item_name' unnecessarily truncated when passed to PayPal](https://issues.civicrm.org/jira/browse/CRM-19863)