### PR TITLE
CRM-19877: Blacklisted params extraneously passed by Joomla to the settings API.

### DIFF
--- a/CRM/Core/BAO/Setting.php
+++ b/CRM/Core/BAO/Setting.php
@@ -256,6 +256,9 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
       'noheader',
       // CRM-18347: ignore params unintentionally passed by wp CLI tool
       '',
+      // CRM-19877: ignore params extraneously passed by Joomla
+      'option',
+      'task',
     );
     $settingParams = array_diff_key($params, array_fill_keys($ignoredParams, TRUE));
     $getFieldsParams = array('version' => 3);


### PR DESCRIPTION
* [CRM-19877: on Joomla. api.Setting.create fails with "option,task not valid settings"](https://issues.civicrm.org/jira/browse/CRM-19877)