### PR TITLE
Fix for CRM 19881: Clobbered time for receive_date and trxn_date

### DIFF
--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -528,7 +528,7 @@ function _civicrm_api3_contribution_completetransaction_spec(&$params) {
   $params['trxn_date'] = array(
     'title' => 'Transaction Date',
     'description' => 'Date this transaction occurred',
-    'type' => CRM_Utils_Type::T_DATE,
+    'type' => CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME,
   );
 }
 
@@ -680,7 +680,7 @@ function _civicrm_api3_contribution_repeattransaction_spec(&$params) {
   $params['receive_date'] = array(
     'title' => 'Contribution Receive Date',
     'name' => 'receive_date',
-    'type' => CRM_Utils_Type::T_DATE,
+    'type' => CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME,
     'api.default' => 'now',
   );
   $params['trxn_id'] = array(


### PR DESCRIPTION
https://issues.civicrm.org/jira/browse/CRM-19881

Unlike api.contribute.create, api.contribute.repeattransaction and completetransaction zero out the time stamp in parameters receive_date and trxn_date respectively.

What api.contribution.create shows in receive_date is something like:
2017-01-14 16:10:45

However, what api.contribution.repeattransaction shows in receive_date is something like:
2017-01-14 00:00:00

This is because the specification is: 
`'type' => CRM_Utils_Type::T_DATE,`
Instead of:
`'type' => CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME,`

Same issue for completetransaction and it's trxn_date parameter.

