### PR TITLE
CRM-19885: Scheduled Reminders: lack of default form values leads to SQL syntax error

### DIFF
--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -368,6 +368,9 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
       $defaults['is_active'] = 1;
       $defaults['mode'] = 'Email';
       $defaults['record_activity'] = 1;
+      $defaults['start_action_offset'] = 0;
+      $defaults['repetition_frequency_interval'] = 0;
+      $defaults['end_frequency_interval'] = 0;
     }
     else {
       $defaults = $this->_values;


### PR DESCRIPTION
Add default values to interval fields in Scheduled Reminders

---

 * [CRM-19885: Scheduled Reminders: lack of default form values leads to SQL syntax error](https://issues.civicrm.org/jira/browse/CRM-19885)