### PR TITLE
CRM-19690 - Task_AdhocMailing - Use highest-priority template type

### DIFF
--- a/CRM/Mailing/Form/Task/AdhocMailing.php
+++ b/CRM/Mailing/Form/Task/AdhocMailing.php
@@ -38,11 +38,14 @@ class CRM_Mailing_Form_Task_AdhocMailing extends CRM_Contact_Form_Task {
 
   public function preProcess() {
     parent::preProcess();
+    $templateTypes = CRM_Mailing_BAO_Mailing::getTemplateTypes();
     list ($groupId, $ssId) = $this->createHiddenGroup();
     $mailing = civicrm_api3('Mailing', 'create', array(
       'name' => "",
       'campaign_id' => NULL,
       'replyto_email' => "",
+      'template_type' => $templateTypes[0]['name'],
+      'template_options' => array('nonce' => 1),
       'subject' => "",
       'body_html' => "",
       'body_text' => "",


### PR DESCRIPTION
If you perform a contact search and create a new mailing, it would use
`template_type=traditional`, even if another template type had greater
priority. With this patch,  it respects the priority.

Note: I considered changing the default in Mailing.create API to always
match most-preferred template-type.  However, that would break some existing
API consumers (e.g.  headless consumers or ones who define their own UI).
For external API-based integrations, we should preserve the default
semantics of `body_text`/`body_html` by defaulting to
`template_type=traditional`.

The preference in CRM-19690 is that any use-case based on the screen
`civicrm/a/#/mailing/{id}` should have its default determined by weight.

---

 * [CRM-19690: Allow alternative email templating systems](https://issues.civicrm.org/jira/browse/CRM-19690)