### PR TITLE
CRM_Extension_Browser - Allow different cache files for different feeds

### DIFF
--- a/CRM/Extension/Browser.php
+++ b/CRM/Extension/Browser.php
@@ -216,8 +216,11 @@ class CRM_Extension_Browser {
    * @return string
    */
   private function grabCachedJson() {
-    $filename = $this->cacheDir . DIRECTORY_SEPARATOR . self::CACHE_JSON_FILE;
-    $json = file_get_contents($filename);
+    $filename = $this->cacheDir . DIRECTORY_SEPARATOR . self::CACHE_JSON_FILE . '.' . md5($this->getRepositoryUrl());
+    $json = NULL;
+    if (file_exists($filename)) {
+      $json = file_get_contents($filename);
+    }
     if (empty($json)) {
       $json = $this->grabRemoteJson();
     }
@@ -246,7 +249,7 @@ class CRM_Extension_Browser {
       return array();
     }
 
-    $filename = $this->cacheDir . DIRECTORY_SEPARATOR . self::CACHE_JSON_FILE;
+    $filename = $this->cacheDir . DIRECTORY_SEPARATOR . self::CACHE_JSON_FILE . '.' . md5($this->getRepositoryUrl());
     $url = $this->getRepositoryUrl() . $this->indexPath;
     $status = CRM_Utils_HttpClient::singleton()->fetch($url, $filename);
 


### PR DESCRIPTION
The motivation here is to support these two different CLI commands:

```
cv dl myextension
cv dl myextension --dev
```

The two commands differ in that they pull from different feeds -- e.g.  the
stable feed `https://civicrm.org/extdir/ver={ver}|cms={uf}` vs the
developmental feed `https://civicrm.org/extdir/ver={ver}|cms={uf}|status=`.
However, this creates the real possibility that the user might go back/forth
among different feeds (omitting/enabling the `--dev` option per whim).