### PR TITLE
CRM-19893 - Tweak optionValue template to show grouping field if present

### DIFF
--- a/templates/CRM/Admin/Form/Options.tpl
+++ b/templates/CRM/Admin/Form/Options.tpl
@@ -68,12 +68,6 @@
              </tr>
      {/if}
         {/if}
-      {if $gName eq 'case_status'}
-            <tr class="crm-admin-options-form-block-grouping">
-              <td class="label">{$form.grouping.label}</td>
-                <td>{$form.grouping.html}</td>
-            </tr>
-      {/if}
 
       {if $form.value.html && $gName neq 'redaction_rule'}
         <tr class="crm-admin-options-form-block-value">
@@ -128,6 +122,12 @@
                 <td class="label">{$form.visibility_id.label}</td>
                 <td>{$form.visibility_id.html}</td>
               </tr>
+        {/if}
+        {if $form.grouping.html}
+          <tr class="crm-admin-options-form-block-grouping">
+            <td class="label">{$form.grouping.label}</td>
+            <td>{$form.grouping.html}</td>
+          </tr>
         {/if}
               <tr class="crm-admin-options-form-block-weight">
                 <td class="label">{$form.weight.label}</td>


### PR DESCRIPTION
This simply moves the seldom-used `grouping` field into a nicer place on the form, and removes the hard-coding of only showing it for a single option group.

* [CRM-19893: Activity Type Categories](https://issues.civicrm.org/jira/browse/CRM-19893)