### PR TITLE
Docs fix: update for changed URL of Case Management > Setup page.

### DIFF
--- a/CRM/Case/XMLProcessor/Process.php
+++ b/CRM/Case/XMLProcessor/Process.php
@@ -44,7 +44,7 @@ class CRM_Case_XMLProcessor_Process extends CRM_Case_XMLProcessor {
     $xml = $this->retrieve($caseType);
 
     if ($xml === FALSE) {
-      $docLink = CRM_Utils_System::docURL2("user/case-management/setup");
+      $docLink = CRM_Utils_System::docURL2("user/case-management/set-up");
       CRM_Core_Error::fatal(ts("Configuration file could not be retrieved for case type = '%1' %2.",
         array(1 => $caseType, 2 => $docLink)
       ));
@@ -69,7 +69,7 @@ class CRM_Case_XMLProcessor_Process extends CRM_Case_XMLProcessor {
   public function get($caseType, $fieldSet, $isLabel = FALSE, $maskAction = FALSE) {
     $xml = $this->retrieve($caseType);
     if ($xml === FALSE) {
-      $docLink = CRM_Utils_System::docURL2("user/case-management/setup");
+      $docLink = CRM_Utils_System::docURL2("user/case-management/set-up");
       CRM_Core_Error::fatal(ts("Unable to load configuration file for the referenced case type: '%1' %2.",
         array(1 => $caseType, 2 => $docLink)
       ));
@@ -217,7 +217,7 @@ class CRM_Case_XMLProcessor_Process extends CRM_Case_XMLProcessor {
     $relationshipTypeID = array_search($relationshipTypeName, $relationshipTypes);
 
     if ($relationshipTypeID === FALSE) {
-      $docLink = CRM_Utils_System::docURL2("user/case-management/setup");
+      $docLink = CRM_Utils_System::docURL2("user/case-management/set-up");
       CRM_Core_Error::fatal(ts('Relationship type %1, found in case configuration file, is not present in the database %2',
         array(1 => $relationshipTypeName, 2 => $docLink)
       ));
@@ -421,7 +421,7 @@ AND        a.is_deleted = 0
     $activityTypeInfo = CRM_Utils_Array::value($activityTypeName, $activityTypes);
 
     if (!$activityTypeInfo) {
-      $docLink = CRM_Utils_System::docURL2("user/case-management/setup");
+      $docLink = CRM_Utils_System::docURL2("user/case-management/set-up");
       CRM_Core_Error::fatal(ts('Activity type %1, found in case configuration file, is not present in the database %2',
         array(1 => $activityTypeName, 2 => $docLink)
       ));

--- a/ang/crmCaseType/edit.html
+++ b/ang/crmCaseType/edit.html
@@ -6,7 +6,7 @@ Required vars: caseType
 <form name="editCaseTypeForm" unsaved-warning-form>
 <div class="crm-block crm-form-block crmCaseType">
   <div class="help">
-    {{ts('Use this screen to define or update the Case Roles, Activity Types, and Timelines for a case type.')}} <a href="http://book.civicrm.org/user/current/case-management/setup/" target="_blank">{{ts('Learn more...')}}</a>
+    {{ts('Use this screen to define or update the Case Roles, Activity Types, and Timelines for a case type.')}} <a href="https://docs.civicrm.org/user/en/stable/case-management/set-up/" target="_blank">{{ts('Learn more...')}}</a>
   </div>
   <div class="crm-submit-buttons">
     <button crm-icon="fa-check" ng-click="editCaseTypeForm.$setPristine(); save()" ng-disabled="editCaseTypeForm.$invalid">

--- a/templates/CRM/Admin/Form/Setting/Path.tpl
+++ b/templates/CRM/Admin/Form/Setting/Path.tpl
@@ -58,7 +58,7 @@
                 <td class="label">{$form.customTemplateDir.label}</td>
                 <td>{$form.customTemplateDir.html|crmAddClass:'huge40'}<br />
                     <span class="description">{ts}Path where site specific templates are stored if any. This directory is searched first if set. Custom JavaScript code can be added to templates by creating files named <em>templateFile.extra.tpl</em>.{/ts} {docURL page="Customize Built-in Screens" resource="wiki"}</span><br />
-                    <span class="description">{ts}CiviCase configuration files can also be stored in this custom path.{/ts} {docURL page="user/case-management/setup"}</span>
+                    <span class="description">{ts}CiviCase configuration files can also be stored in this custom path.{/ts} {docURL page="user/case-management/set-up"}</span>
                 </td>
             </tr>
             <tr class="crm-path-form-block-customPHPPathDir">

--- a/templates/CRM/Case/Page/ConfigureError.tpl
+++ b/templates/CRM/Case/Page/ConfigureError.tpl
@@ -25,7 +25,7 @@
 *}
 {* CiviCase Configuration Help - displayed when component is enabled but not yet configured. *}
 
-{capture assign=docLink}{docURL page="user/case-management/setup" text="CiviCase Setup documentation"}{/capture}
+{capture assign=docLink}{docURL page="user/case-management/set-up" text="CiviCase Setup documentation"}{/capture}
 
 <div class="messages status no-popup">
       <div class="icon inform-icon"></div>&nbsp;


### PR DESCRIPTION
Correct link in various locations (was `https://docs.civicrm.org/user/en/stable/case-management/setup`, now `https://docs.civicrm.org/user/en/stable/case-management/set-up`). Might be preferable to revert the change over in docs though?