### PR TITLE
CRM-19897 - Remove reference to nonexistant permission

### DIFF
--- a/CRM/Activity/Form/Task.php
+++ b/CRM/Activity/Form/Task.php
@@ -115,7 +115,7 @@ class CRM_Activity_Form_Task extends CRM_Core_Form {
       $components = CRM_Core_Component::getNames();
       $componentClause = array();
       foreach ($components as $componentID => $componentName) {
-        if (!CRM_Core_Permission::check("access $componentName")) {
+        if ($componentName != 'CiviCase' && !CRM_Core_Permission::check("access $componentName")) {
           $componentClause[] = " (activity_type.component_id IS NULL OR activity_type.component_id <> {$componentID}) ";
         }
       }


### PR DESCRIPTION
* [CRM-19897: Cannot edit multiple case activities via profile, because deprecated "access CiviCase" permission is referenced](https://issues.civicrm.org/jira/browse/CRM-19897)