### PR TITLE
CRM-19778 - Case statuses per case type & caseType config ui improvements

### DIFF
--- a/CRM/Admin/Form.php
+++ b/CRM/Admin/Form.php
@@ -90,6 +90,7 @@ class CRM_Admin_Form extends CRM_Core_Form {
    * @return array
    */
   public function setDefaultValues() {
+    // Fetch defaults from the db
     if (isset($this->_id) && empty($this->_values)) {
       $this->_values = array();
       $params = array('id' => $this->_id);
@@ -97,6 +98,15 @@ class CRM_Admin_Form extends CRM_Core_Form {
       $baoName::retrieve($params, $this->_values);
     }
     $defaults = $this->_values;
+
+    // Allow defaults to be set from the url
+    if (empty($this->_id) && $this->_action & CRM_Core_Action::ADD) {
+      foreach ($_GET as $key => $val) {
+        if ($this->elementExists($key)) {
+          $defaults[$key] = $val;
+        }
+      }
+    }
 
     if ($this->_action == CRM_Core_Action::DELETE &&
       isset($defaults['name'])

--- a/CRM/Admin/Form/Options.php
+++ b/CRM/Admin/Form/Options.php
@@ -488,6 +488,8 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
             1 => $this->_gLabel,
             2 => $optionValue->label,
           )), ts('Saved'), 'success');
+
+      $this->ajaxResponse['optionValue'] = $optionValue->toArray();
     }
   }
 

--- a/CRM/Admin/Form/RelationshipType.php
+++ b/CRM/Admin/Form/RelationshipType.php
@@ -137,7 +137,6 @@ class CRM_Admin_Form_RelationshipType extends CRM_Admin_Form {
       CRM_Core_Session::setStatus(ts('Selected Relationship type has been deleted.'), ts('Record Deleted'), 'success');
     }
     else {
-      $params = array();
       $ids = array();
 
       // store the submitted values in an array
@@ -163,7 +162,9 @@ class CRM_Admin_Form_RelationshipType extends CRM_Admin_Form {
       $params['contact_sub_type_a'] = $cTypeA[1] ? $cTypeA[1] : 'NULL';
       $params['contact_sub_type_b'] = $cTypeB[1] ? $cTypeB[1] : 'NULL';
 
-      CRM_Contact_BAO_RelationshipType::add($params, $ids);
+      $result = CRM_Contact_BAO_RelationshipType::add($params, $ids);
+
+      $this->ajaxResponse['relationshipType'] = $result->toArray();
 
       CRM_Core_Session::setStatus(ts('The Relationship Type has been saved.'), ts('Saved'), 'success');
     }

--- a/CRM/Case/BAO/CaseType.php
+++ b/CRM/Case/BAO/CaseType.php
@@ -130,6 +130,14 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType {
       $xmlFile .= "</ActivityTypes>\n";
     }
 
+    if (!empty($definition['statuses'])) {
+      $xmlFile .= "<Statuses>\n";
+      foreach ($definition['statuses'] as $value) {
+        $xmlFile .= "<Status>$value</Status>\n";
+      }
+      $xmlFile .= "</Statuses>\n";
+    }
+
     if (isset($definition['activitySets'])) {
       $xmlFile .= "<ActivitySets>\n";
       foreach ($definition['activitySets'] as $k => $val) {
@@ -222,6 +230,11 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType {
       foreach ($xml->ActivityTypes->ActivityType as $activityTypeXML) {
         $definition['activityTypes'][] = json_decode(json_encode($activityTypeXML), TRUE);
       }
+    }
+
+    // set statuses
+    if (isset($xml->Statuses)) {
+      $definition['statuses'] = (array) $xml->Statuses->Status;
     }
 
     // set activity sets

--- a/CRM/Case/Form/Activity/ChangeCaseStatus.php
+++ b/CRM/Case/Form/Activity/ChangeCaseStatus.php
@@ -72,7 +72,26 @@ class CRM_Case_Form_Activity_ChangeCaseStatus {
     $form->removeElement('status_id');
     $form->removeElement('priority_id');
 
+    $caseTypes = array();
+
     $form->_caseStatus = CRM_Case_PseudoConstant::caseStatus();
+    $statusNames = CRM_Case_PseudoConstant::caseStatus('name');
+
+    // Limit case statuses to allowed types for these case(s)
+    $allCases = civicrm_api3('Case', 'get', array('return' => 'case_type_id', 'id' => array('IN' => (array) $form->_caseId)));
+    foreach ($allCases['values'] as $case) {
+      $caseTypes[$case['case_type_id']] = $case['case_type_id'];
+    }
+    $caseTypes = civicrm_api3('CaseType', 'get', array('id' => array('IN' => $caseTypes)));
+    foreach ($caseTypes['values'] as $ct) {
+      if (!empty($ct['definition']['statuses'])) {
+        foreach ($form->_caseStatus as $id => $label) {
+          if (!in_array($statusNames[$id], $ct['definition']['statuses'])) {
+            unset($form->_caseStatus[$id]);
+          }
+        }
+      }
+    }
 
     foreach ($form->_caseId as $key => $val) {
       $form->_oldCaseStatus[] = $form->_defaultCaseStatus[] = CRM_Core_DAO::getFieldValue('CRM_Case_DAO_Case', $val, 'status_id');
@@ -183,9 +202,6 @@ class CRM_Case_Form_Activity_ChangeCaseStatus {
         $activity->save();
       }
     }
-
-    // FIXME: does this do anything ?
-    $params['statusMsg'] = ts('Case Status changed successfully.');
   }
 
 }

--- a/CRM/Case/Form/Case.php
+++ b/CRM/Case/Form/Case.php
@@ -317,22 +317,18 @@ class CRM_Case_Form_Case extends CRM_Core_Form {
     }
 
     if ($this->_action & CRM_Core_Action::DELETE) {
-      $statusMsg = NULL;
       $caseDelete = CRM_Case_BAO_Case::deleteCase($this->_caseId, TRUE);
       if ($caseDelete) {
-        $statusMsg = ts('The selected case has been moved to the Trash. You can view and / or restore deleted cases by checking the "Deleted Cases" option under Find Cases.<br />');
+        CRM_Core_Session::setStatus(ts('You can view and / or restore deleted cases by checking the "Deleted Cases" option under Find Cases.'), ts('Case Deleted'), 'success');
       }
-      CRM_Core_Session::setStatus($statusMsg, ts('Case Deleted'), 'success');
       return;
     }
 
     if ($this->_action & CRM_Core_Action::RENEW) {
-      $statusMsg = NULL;
       $caseRestore = CRM_Case_BAO_Case::restoreCase($this->_caseId);
       if ($caseRestore) {
-        $statusMsg = ts('The selected case has been restored.<br />');
+        CRM_Core_Session::setStatus(ts('The selected case has been restored.'), ts('Restored'), 'success');
       }
-      CRM_Core_Session::setStatus($statusMsg, ts('Restored'), 'success');
       return;
     }
     // store the submitted values in an array
@@ -348,7 +344,6 @@ class CRM_Case_Form_Case extends CRM_Core_Form {
     if (!empty($params['hidden_custom']) &&
       !isset($params['custom'])
     ) {
-      $customFields = array();
       $params['custom'] = CRM_Core_BAO_CustomField::postProcess(
         $params,
         NULL,
@@ -388,8 +383,7 @@ class CRM_Case_Form_Case extends CRM_Core_Form {
     $url = CRM_Utils_System::url('civicrm/contact/view/case',
       "reset=1&action=view&cid={$this->_currentlyViewedContactId}&id={$caseObj->id}"
     );
-    $session = CRM_Core_Session::singleton();
-    $session->pushUserContext($url);
+    CRM_Core_Session::singleton()->pushUserContext($url);
 
     // 3. format activity custom data
     if (!empty($params['hidden_custom'])) {
@@ -410,9 +404,6 @@ class CRM_Case_Form_Case extends CRM_Core_Form {
       $className::endPostProcess($this, $params);
     }
 
-    // 5. auto populate activities
-
-    // 6. set status
     CRM_Core_Session::setStatus($params['statusMsg'], ts('Saved'), 'success');
   }
 

--- a/CRM/Case/PseudoConstant.php
+++ b/CRM/Case/PseudoConstant.php
@@ -37,30 +37,6 @@
 class CRM_Case_PseudoConstant extends CRM_Core_PseudoConstant {
 
   /**
-   * Case statues
-   * @var array
-   */
-  static $caseStatus = array();
-
-  /**
-   * Redaction rules
-   * @var array
-   */
-  static $redactionRule;
-
-  /**
-   * Case type
-   * @var array
-   */
-  static $caseType = array();
-
-  /**
-   * Encounter Medium
-   * @var array
-   */
-  static $encounterMedium = array();
-
-  /**
    * Activity type
    * @var array
    */
@@ -79,19 +55,15 @@ class CRM_Case_PseudoConstant extends CRM_Core_PseudoConstant {
    *   array reference of all case statues
    */
   public static function caseStatus($column = 'label', $onlyActive = TRUE, $condition = NULL, $fresh = FALSE) {
-    $cacheKey = "{$column}_" . (int) $onlyActive;
     if (!$condition) {
       $condition = 'AND filter = 0';
     }
 
-    if (!isset(self::$caseStatus[$cacheKey]) || $fresh) {
-      self::$caseStatus[$cacheKey] = CRM_Core_OptionGroup::values('case_status',
-        FALSE, FALSE, FALSE, $condition,
-        $column, $onlyActive, $fresh
-      );
-    }
+    return CRM_Core_OptionGroup::values('case_status',
+      FALSE, FALSE, FALSE, $condition,
+      $column, $onlyActive, $fresh
+    );
 
-    return self::$caseStatus[$cacheKey];
   }
 
   /**
@@ -104,22 +76,15 @@ class CRM_Case_PseudoConstant extends CRM_Core_PseudoConstant {
    *   array reference of all redaction rules
    */
   public static function redactionRule($filter = NULL) {
-    // if ( ! self::$redactionRule ) {
-    self::$redactionRule = array();
-
+    $condition = NULL;
     if ($filter === 0) {
       $condition = "  AND (v.filter = 0 OR v.filter IS NULL)";
     }
     elseif ($filter === 1) {
       $condition = "  AND  v.filter = 1";
     }
-    elseif ($filter === NULL) {
-      $condition = NULL;
-    }
 
-    self::$redactionRule = CRM_Core_OptionGroup::values('redaction_rule', TRUE, FALSE, FALSE, $condition);
-    // }
-    return self::$redactionRule;
+    return CRM_Core_OptionGroup::values('redaction_rule', TRUE, FALSE, FALSE, $condition);
   }
 
   /**
@@ -166,15 +131,10 @@ class CRM_Case_PseudoConstant extends CRM_Core_PseudoConstant {
    *   array reference of all Encounter Medium.
    */
   public static function encounterMedium($column = 'label', $onlyActive = TRUE) {
-    $cacheKey = "{$column}_" . (int) $onlyActive;
-    if (!isset(self::$encounterMedium[$cacheKey])) {
-      self::$encounterMedium[$cacheKey] = CRM_Core_OptionGroup::values('encounter_medium',
-        FALSE, FALSE, FALSE, NULL,
-        $column, $onlyActive
-      );
-    }
-
-    return self::$encounterMedium[$cacheKey];
+    return CRM_Core_OptionGroup::values('encounter_medium',
+      FALSE, FALSE, FALSE, NULL,
+      $column, $onlyActive
+    );
   }
 
   /**

--- a/ang/crmCaseType.css
+++ b/ang/crmCaseType.css
@@ -2,7 +2,7 @@
     vertical-align: middle;
     cursor: move;
 }
-.crmCaseType .crm-i {
+.crmCaseType .fa-trash {
     margin: 0.4em 0.2em 0 0;
     cursor: pointer;
 }

--- a/ang/crmCaseType.js
+++ b/ang/crmCaseType.js
@@ -61,12 +61,14 @@
             }];
             reqs.actTypes = ['OptionValue', 'get', {
               option_group_id: 'activity_type',
+              sequential: 1,
               options: {
                 sort: 'name',
                 limit: 0
               }
             }];
             reqs.relTypes = ['RelationshipType', 'get', {
+              sequential: 1,
               options: {
                 sort: CRM.crmCaseType.REL_TYPE_CNAME,
                 limit: 0
@@ -91,14 +93,6 @@
       restrict: 'AE',
       template: '<input class="add-activity crm-action-menu fa-plus" type="hidden" />',
       link: function(scope, element, attrs) {
-        /// Format list of options for select2's "data"
-        var getFormattedOptions = function() {
-          return {
-            results: _.map(scope[attrs.crmOptions], function(option){
-              return {id: option, text: option};
-            })
-          };
-        };
 
         var input = $('input', element);
 
@@ -108,11 +102,12 @@
           scope[attrs.crmVar] = '';
         };
 
-        $(input).select2({
-          data: getFormattedOptions,
+        $(input).crmSelect2({
+          data: scope[attrs.crmOptions],
           createSearchChoice: function(term) {
-            return {id: term, text: term};
+            return {id: term, text: term + ' (' + ts('new') + ')'};
           },
+          createSearchChoicePosition: 'bottom',
           placeholder: attrs.placeholder
         });
         $(input).on('select2-selecting', function(e) {
@@ -123,7 +118,7 @@
         });
 
         scope.$watch(attrs.crmOptions, function(value) {
-          $(input).select2('data', getFormattedOptions);
+          $(input).select2('data', scope[attrs.crmOptions]);
           $(input).select2('val', '');
         });
       }
@@ -131,14 +126,18 @@
   });
 
   crmCaseType.controller('CaseTypeCtrl', function($scope, crmApi, apiCalls) {
-    var ts = $scope.ts = CRM.ts(null);
+    // CRM_Case_XMLProcessor::REL_TYPE_CNAME
+    var REL_TYPE_CNAME = CRM.crmCaseType.REL_TYPE_CNAME,
+
+    ts = $scope.ts = CRM.ts(null);
 
     $scope.activityStatuses = apiCalls.actStatuses.values;
     $scope.caseStatuses = _.indexBy(apiCalls.caseStatuses.values, 'name');
-    $scope.activityTypes = apiCalls.actTypes.values;
-    $scope.activityTypeNames = _.pluck(apiCalls.actTypes.values, 'name');
-    $scope.activityTypes = apiCalls.actTypes.values;
-    $scope.relationshipTypeNames = _.pluck(apiCalls.relTypes.values, CRM.crmCaseType.REL_TYPE_CNAME); // CRM_Case_XMLProcessor::REL_TYPE_CNAME
+    $scope.activityTypes = _.indexBy(apiCalls.actTypes.values, 'name');
+    $scope.activityTypeOptions = _.map(apiCalls.actTypes.values, formatActivityTypeOption);
+    $scope.relationshipTypeOptions = _.map(apiCalls.relTypes.values, function(type) {
+      return {id: type[REL_TYPE_CNAME], text: type.label_b_a};
+    });
     $scope.locks = {caseTypeName: true, activitySetName: true};
 
     $scope.workflows = {
@@ -175,17 +174,38 @@
       });
     };
 
-    /// Add a new activity entry to an activity-set
-    $scope.addActivity = function(activitySet, activityType) {
+    function formatActivityTypeOption(type) {
+      return {id: type.name, text: type.label, icon: type.icon};
+    }
+
+    function addActivityToSet(activitySet, activityTypeName) {
       activitySet.activityTypes.push({
-        name: activityType,
+        name: activityTypeName,
         status: 'Scheduled',
         reference_activity: 'Open Case',
         reference_offset: '1',
         reference_select: 'newest'
       });
-      if (!_.contains($scope.activityTypeNames, activityType)) {
-        $scope.activityTypeNames.push(activityType);
+    }
+
+    function createActivity(name, callback) {
+      CRM.loadForm(CRM.url('civicrm/admin/options/activity_type', {action: 'add', reset: 1, label: name, component_id: 7}))
+        .on('crmFormSuccess', function(e, data) {
+          $scope.activityTypes[data.optionValue.name] = data.optionValue;
+          $scope.activityTypeOptions.push(formatActivityTypeOption(data.optionValue));
+          callback(data.optionValue);
+          $scope.$digest();
+        });
+    }
+
+    // Add a new activity entry to an activity-set
+    $scope.addActivity = function(activitySet, activityType) {
+      if ($scope.activityTypes[activityType]) {
+        addActivityToSet(activitySet, activityType);
+      } else {
+        createActivity(activityType, function(newActivity) {
+          addActivityToSet(activitySet, newActivity.name);
+        });
       }
     };
 
@@ -193,13 +213,14 @@
     $scope.addActivityType = function(activityType) {
       var names = _.pluck($scope.caseType.definition.activityTypes, 'name');
       if (!_.contains(names, activityType)) {
-        $scope.caseType.definition.activityTypes.push({
-          name: activityType
-        });
-
-      }
-      if (!_.contains($scope.activityTypeNames, activityType)) {
-        $scope.activityTypeNames.push(activityType);
+        // Add an activity type that exists
+        if ($scope.activityTypes[activityType]) {
+          $scope.caseType.definition.activityTypes.push({name: activityType});
+        } else {
+          createActivity(activityType, function(newActivity) {
+            $scope.caseType.definition.activityTypes.push({name: newActivity.name});
+          });
+        }
       }
     };
 
@@ -207,12 +228,16 @@
     $scope.addRole = function(roles, roleName) {
       var names = _.pluck($scope.caseType.definition.caseRoles, 'name');
       if (!_.contains(names, roleName)) {
-        roles.push({
-          name: roleName
-        });
-      }
-      if (!_.contains($scope.relationshipTypeNames, roleName)) {
-        $scope.relationshipTypeNames.push(roleName);
+        if (_.where($scope.relationshipTypeOptions, {id: roleName}).length) {
+          roles.push({name: roleName});
+        } else {
+          CRM.loadForm(CRM.url('civicrm/admin/reltype', {action: 'add', reset: 1, label_a_b: roleName, label_b_a: roleName}))
+            .on('crmFormSuccess', function(e, data) {
+              roles.push({name: data.relationshipType[REL_TYPE_CNAME]});
+              $scope.relationshipTypeOptions.push({id: data.relationshipType[REL_TYPE_CNAME], text: data.relationshipType.label_b_a});
+              $scope.$digest();
+            });
+        }
       }
     };
 

--- a/ang/crmCaseType/activityTypesTable.html
+++ b/ang/crmCaseType/activityTypesTable.html
@@ -2,7 +2,7 @@
 Controller: CaseTypeCtrl
 Required vars: caseType
 -->
-<table>
+<table class="row-highlight">
   <thead>
   <tr>
     <th>{{ts('Activity Type')}}</th>

--- a/ang/crmCaseType/activityTypesTable.html
+++ b/ang/crmCaseType/activityTypesTable.html
@@ -5,6 +5,7 @@ Required vars: caseType
 <table class="row-highlight">
   <thead>
   <tr>
+    <th></th>
     <th>{{ts('Activity Type')}}</th>
     <th>{{ts('Max Instances')}}</th>
     <th></th>
@@ -15,10 +16,13 @@ Required vars: caseType
   <tr ng-repeat="activityType in caseType.definition.activityTypes">
     <td>
       <i class="crm-i fa-arrows grip-n-drag"></i>
+    </td>
+    <td>
+      <i class="crm-i {{ activityTypes[activityType.name].icon }}"></i>
       {{ activityType.name }}
     </td>
     <td>
-      <input class="number" type="text" ng-pattern="/^[0-9]*$/" ng-model="activityType.max_instances" />
+      <input class="crm-form-text number" type="text" ng-pattern="/^[1-9][0-9]*$/" ng-model="activityType.max_instances" />
     </td>
     <td>
       <a crm-icon="fa-trash" class="crm-hover-button" ng-click="removeItem(caseType.definition.activityTypes, activityType)" title="{{ts('Remove')}}"></a>
@@ -28,9 +32,10 @@ Required vars: caseType
 
   <tfoot>
   <tr class="addRow">
+    <td></td>
     <td colspan="3">
       <span crm-add-name
-           crm-options="activityTypeNames"
+           crm-options="activityTypeOptions"
            crm-var="newActivity"
            crm-on-add="addActivityType(newActivity)"
            placeholder="{{ts('Add activity type')}}"

--- a/ang/crmCaseType/edit.html
+++ b/ang/crmCaseType/edit.html
@@ -28,6 +28,7 @@ Required vars: caseType
   <div ng-show="isForkable()" class="crmCaseType-acttab" ui-jq="tabs" ui-options="{show: true, hide: true}">
     <ul>
       <li><a href="#acttab-actType">{{ts('Activity Types')}}</a></li>
+      <li><a href="#acttab-statuses">{{ts('Statuses')}}</a></li>
       <li ng-repeat="activitySet in caseType.definition.activitySets">
         <a href="#acttab-{{$index}}">{{ activitySet.label }}</a>
         <span class="crm-i fa-trash" title="{{ts('Remove')}}"
@@ -46,9 +47,9 @@ Required vars: caseType
       </select>
     </ul>
 
-    <div id="acttab-actType">
-      <div ng-include="'~/crmCaseType/activityTypesTable.html'"></div>
-    </div>
+    <div id="acttab-actType" ng-include="'~/crmCaseType/activityTypesTable.html'"></div>
+
+    <div id="acttab-statuses" ng-include="'~/crmCaseType/statusTable.html'"></div>
 
     <div ng-repeat="activitySet in caseType.definition.activitySets" id="acttab-{{$index}}">
       <div ng-include="activityTableTemplate(activitySet)"></div>

--- a/ang/crmCaseType/rolesTable.html
+++ b/ang/crmCaseType/rolesTable.html
@@ -26,7 +26,7 @@ Required vars: caseType
 	  <tr class="addRow">
 	    <td colspan="4">
 	      <span crm-add-name
-	           crm-options="relationshipTypeNames"
+	           crm-options="relationshipTypeOptions"
 	           crm-var="newRole"
 	           crm-on-add="addRole(caseType.definition.caseRoles, newRole)"
              placeholder="{{ts('Add role')}}"

--- a/ang/crmCaseType/sequenceTable.html
+++ b/ang/crmCaseType/sequenceTable.html
@@ -5,6 +5,7 @@ Required vars: activitySet
 <table>
   <thead>
   <tr>
+    <th></th>
     <th>{{ts('Activity')}}</th>
     <th></th>
   </tr>
@@ -14,6 +15,9 @@ Required vars: activitySet
   <tr ng-repeat="activity in activitySet.activityTypes">
     <td>
       <i class="crm-i fa-arrows grip-n-drag"></i>
+    </td>
+    <td>
+      <i class="crm-i {{ activityTypes[activity.name].icon }}"></i>
       {{ activity.name }}
     </td>
     <td>
@@ -26,7 +30,7 @@ Required vars: activitySet
   <tr class="addRow">
     <td colspan="3">
       <span crm-add-name
-           crm-options="activityTypeNames"
+           crm-options="activityTypeOptions"
            crm-var="newActivity"
            crm-on-add="addActivity(activitySet, newActivity)"
            placeholder="{{ts('Add activity')}}"

--- a/ang/crmCaseType/statusTable.html
+++ b/ang/crmCaseType/statusTable.html
@@ -1,0 +1,35 @@
+<!--
+Controller: CaseTypeCtrl
+Required vars: selectedStatuses
+-->
+<table>
+  <thead>
+  <tr>
+    <th></th>
+    <th>{{ts('Name')}}</th>
+    <th>{{ts('Class')}}</th>
+  </tr>
+  </thead>
+
+  <tbody ng-model="selectedStatuses">
+  <tr ng-repeat="(status,sel) in selectedStatuses">
+    <td>
+      <input class="crm-form-checkbox" type="checkbox" ng-model="selectedStatuses[status]"/>
+    </td>
+    <td>
+      {{ caseStatuses[status].label }}
+    </td>
+    <td>
+      {{ caseStatuses[status].grouping }}
+    </td>
+  </tr>
+  </tbody>
+
+  <tfoot>
+  <tr>
+    <td></td>
+    <td><a class="crm-hover-button action-item" ng-click="newStatus()" href><i class="crm-i fa-plus"></i> {{ ts('New Status') }}</a></td>
+    <td></td>
+  </tr>
+  </tfoot>
+</table>

--- a/ang/crmCaseType/timelineTable.html
+++ b/ang/crmCaseType/timelineTable.html
@@ -5,6 +5,7 @@ Required vars: activitySet
 <table>
   <thead>
   <tr>
+    <th></th>
     <th>{{ts('Activity')}}</th>
     <th>{{ts('Status')}}</th>
     <th>{{ts('Reference')}}</th>
@@ -18,6 +19,9 @@ Required vars: activitySet
   <tr ng-repeat="activity in activitySet.activityTypes">
     <td>
       <i class="crm-i fa-arrows grip-n-drag"></i>
+    </td>
+    <td>
+      <i class="crm-i {{ activityTypes[activity.name].icon }}"></i>
       {{ activity.name }}
     </td>
     <td>
@@ -43,7 +47,7 @@ Required vars: activitySet
     </td>
     <td>
       <input
-        class="number"
+        class="number crm-form-text"
         type="text"
         ng-pattern="/^-?[0-9]*$/"
         ng-model="activity.reference_offset"
@@ -77,7 +81,7 @@ Required vars: activitySet
   <tr class="addRow">
     <td colspan="6">
       <span crm-add-name
-           crm-options="activityTypeNames"
+           crm-options="activityTypeOptions"
            crm-var="newActivity"
            crm-on-add="addActivity(activitySet, newActivity)"
            placeholder="{{ts('Add activity')}}"

--- a/templates/CRM/Admin/Form/Options.tpl
+++ b/templates/CRM/Admin/Form/Options.tpl
@@ -73,7 +73,9 @@
         <tr class="crm-admin-options-form-block-value">
           <td class="label">{$form.value.label}</td>
           <td>{$form.value.html}<br />
+            {if $action == 2}
               <span class="description"><i class="crm-i fa-exclamation-triangle"></i> {ts}Changing the Value field will unlink records which have been marked with this option. This change can not be undone except by restoring the previous value.{/ts}</span>
+            {/if}
           </td>
         </tr>
       {/if}

--- a/templates/CRM/Case/Form/Activity/OpenCase.tpl
+++ b/templates/CRM/Case/Form/Activity/OpenCase.tpl
@@ -49,4 +49,28 @@
       </td>
     </tr>
   {/if}
+  {crmAPI var='caseTypes' entity='CaseType' action='get' option_limit=0 sequential=0}
+  {crmAPI var='caseStatusLabels' entity='Case' action='getoptions' option_limit=0 field="case_status_id" context='create'}
+  {crmAPI var='caseStatusNames' entity='Case' action='getoptions' option_limit=0 field="case_status_id" context='validate' sequential=0}
+  {literal}
+  <script type="text/javascript">
+    CRM.$(function($) {
+      var $form = $("form.{/literal}{$form.formClass}{literal}");
+      var caseTypes = {/literal}{$caseTypes.values|@json_encode}{literal};
+      var caseStatusLabels = {/literal}{$caseStatusLabels.values|@json_encode}{literal};
+      var caseStatusNames = {/literal}{$caseStatusNames.values|@json_encode}{literal};
+      if ($('#case_type_id, #status_id', $form).length === 2) {
+        $('#case_type_id', $form).change(function() {
+          if ($(this).val()) {
+            var caseType = caseTypes[$(this).val()].definition;
+            var newOptions = CRM._.filter(caseStatusLabels, function(opt, key) {
+              return !caseType.statuses || !caseType.statuses.length || caseType.statuses.indexOf(caseStatusNames[key]) > -1;
+            });
+            CRM.utils.setOptions($('#status_id', $form), newOptions);
+          }
+        })
+      }
+    });
+  </script>
+  {/literal}
 {/if}

--- a/tests/karma/unit/crmCaseTypeSpec.js
+++ b/tests/karma/unit/crmCaseTypeSpec.js
@@ -6,6 +6,7 @@ describe('crmCaseType', function() {
     CRM.resourceUrls = {
       'civicrm': ''
     };
+    // CRM_Case_XMLProcessor::REL_TYPE_CNAME
     CRM.crmCaseType = {
       'REL_TYPE_CNAME': 'label_b_a'
     };
@@ -30,9 +31,9 @@ describe('crmCaseType', function() {
       compile = $compile;
       timeout = $timeout;
       apiCalls = {
-        'actStatuses': {
-          'values': {
-            "272": {
+        actStatuses: {
+          values: [
+            {
               "id": "272",
               "option_group_id": "25",
               "label": "Scheduled",
@@ -45,7 +46,7 @@ describe('crmCaseType', function() {
               "is_reserved": "1",
               "is_active": "1"
             },
-            "273": {
+            {
               "id": "273",
               "option_group_id": "25",
               "label": "Completed",
@@ -57,11 +58,42 @@ describe('crmCaseType', function() {
               "is_reserved": "1",
               "is_active": "1"
             }
-          }
+          ]
         },
-        'actTypes': {
-          'values': {
-            "784": {
+        caseStatuses: {
+          values: [
+            {
+              "id": "290",
+              "option_group_id": "28",
+              "label": "Ongoing",
+              "value": "1",
+              "name": "Open",
+              "grouping": "Opened",
+              "filter": "0",
+              "is_default": "1",
+              "weight": "1",
+              "is_optgroup": "0",
+              "is_reserved": "1",
+              "is_active": "1"
+            },
+            {
+              "id": "291",
+              "option_group_id": "28",
+              "label": "Resolved",
+              "value": "2",
+              "name": "Closed",
+              "grouping": "Closed",
+              "filter": "0",
+              "weight": "2",
+              "is_optgroup": "0",
+              "is_reserved": "1",
+              "is_active": "1"
+            }
+          ]
+        },
+        actTypes: {
+          values: [
+            {
               "id": "784",
               "option_group_id": "2",
               "label": "ADC referral",
@@ -75,7 +107,7 @@ describe('crmCaseType', function() {
               "is_active": "1",
               "component_id": "7"
             },
-            "32": {
+            {
               "id": "32",
               "option_group_id": "2",
               "label": "Add Client To Case",
@@ -90,11 +122,11 @@ describe('crmCaseType', function() {
               "is_active": "1",
               "component_id": "7"
             }
-          }
+          ]
         },
-        'relTypes': {
-          'values' : {
-            "14": {
+        relTypes: {
+          values: [
+            {
               "id": "14",
               "name_a_b": "Benefits Specialist is",
               "label_a_b": "Benefits Specialist is",
@@ -106,7 +138,7 @@ describe('crmCaseType', function() {
               "is_reserved": "0",
               "is_active": "1"
             },
-            "9": {
+            {
               "id": "9",
               "name_a_b": "Case Coordinator is",
               "label_a_b": "Case Coordinator is",
@@ -118,9 +150,9 @@ describe('crmCaseType', function() {
               "is_reserved": "0",
               "is_active": "1"
             }
-          }
+          ]
         },
-        "caseType": {
+        caseType: {
           "id": "1",
           "name": "housing_support",
           "title": "Housing Support",
@@ -167,11 +199,11 @@ describe('crmCaseType', function() {
     }));
 
     it('should load activity statuses', function() {
-      expect(scope.activityStatuses).toEqualData([apiCalls.actStatuses.values['272'], apiCalls.actStatuses.values['273']]);
+      expect(scope.activityStatuses).toEqualData(apiCalls.actStatuses.values);
     });
 
     it('should load activity types', function() {
-      expect(scope.activityTypes).toEqualData(apiCalls.actTypes.values);
+      expect(scope.activityTypes['ADC referral']).toEqualData(apiCalls.actTypes.values[0]);
     });
 
     it('addActivitySet should add an activitySet to the case type', function() {


### PR DESCRIPTION
This PR adds a new tab to the CaseType Config UI, for setting allowed statuses.

It adds basic support to the existing case UI for respecting configured statuses, so that when opening a case or changing its status, the form will only show options appropriate to that case type.

It also includes a few other improvements to the CaseType Config UI, displaying icons and labels for activity types instead of machine names, and using a popup to add new activity/relationship types so that they can be fully configured.

![casetypeconfig](https://cloud.githubusercontent.com/assets/2874912/22179586/3c1ec64a-e026-11e6-9c14-f29a9ba51b6e.png)

* [CRM-19778: Allowed statuses per case-type](https://issues.civicrm.org/jira/browse/CRM-19778)