### PR TITLE
CRM-19906 - allow @ on drupal users

### DIFF
--- a/templates/CRM/common/checkUsernameAvailable.tpl
+++ b/templates/CRM/common/checkUsernameAvailable.tpl
@@ -38,7 +38,7 @@ cj("#checkavailability").click(function() {
    var spchar = "\<|\>|\"|\'|\%|\;|\(|\)|\&|\\\\|\/";
 
    {/literal}{if $config->userSystem->is_drupal == "1"}{literal}
-   spchar = spchar + "|\~|\`|\:|\@|\!|\=|\#|\$|\^|\*|\{|\}|\\[|\\]|\+|\?|\,";
+   spchar = spchar + "|\~|\`|\:|\!|\=|\#|\$|\^|\*|\{|\}|\\[|\\]|\+|\?|\,";
    {/literal}{/if}{literal}
    var r = new RegExp( "["+spchar+"]", "i");
    /*regular expression \\ matches a single backslash. this becomes r = /\\/ or r = new RegExp("\\\\").*/


### PR DESCRIPTION
See https://issues.civicrm.org/jira/browse/CRM-19906.

Opted for easiest & safest fix.  Just allowed, '@', which is not contrary to drupal user.module validation code: `[^\x{80}-\x{F7} a-z0-9@_.\'-]`.
