### PR TITLE
CRM-19907 Fix error where show events setting is NULL

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -386,7 +386,7 @@ WHERE      civicrm_event.is_active = 1 AND
     // Get the event summary display preferences
     $show_max_events = Civi::settings()->get('show_events');
     // show all events if show_events is set to a negative value
-    if ($show_max_events >= 0) {
+    if (isset($show_max_events) && $show_max_events >= 0) {
       $event_summary_limit = "LIMIT      0, $show_max_events";
     }
     else {


### PR DESCRIPTION
* [CRM-19907: Syntax error generated on CiviEvent Dashboard when show_events is null](https://issues.civicrm.org/jira/browse/CRM-19907)