### PR TITLE
CRM-19908 - Fundamental Fixes for TaxMath Calculations 4.6

### DIFF
--- a/CRM/Contribute/BAO/Contribution/Utils.php
+++ b/CRM/Contribute/BAO/Contribution/Utils.php
@@ -931,7 +931,8 @@ LIMIT 1
    */
   public static function calculateTaxAmount($amount, $taxRate) {
     $taxAmount = array();
-    $taxAmount['tax_amount'] = round(($taxRate / 100) * CRM_Utils_Rule::cleanMoney($amount), 2);
+    // There can not be any rounding at this stage - as this is prior to quantity multiplication
+    $taxAmount['tax_amount'] = ($taxRate / 100) * CRM_Utils_Rule::cleanMoney($amount);
 
     return $taxAmount;
   }

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -1536,11 +1536,12 @@ WHERE       ps.id = %1
    * @return array
    */
   public static function setLineItem($field, $lineItem, $optionValueId) {
+    // Here we round - i.e. after multiplying by quantity
     if ($field['html_type'] == 'Text') {
-      $taxAmount = $field['options'][$optionValueId]['tax_amount'] * $lineItem[$optionValueId]['qty'];
+      $taxAmount = round($field['options'][$optionValueId]['tax_amount'] * $lineItem[$optionValueId]['qty'], 2);
     }
     else {
-      $taxAmount = $field['options'][$optionValueId]['tax_amount'];
+      $taxAmount = round($field['options'][$optionValueId]['tax_amount'], 2);
     }
     $taxRate = $field['options'][$optionValueId]['tax_rate'];
     $lineItem[$optionValueId]['tax_amount'] = $taxAmount;

--- a/templates/CRM/Price/Page/LineItem.tpl
+++ b/templates/CRM/Price/Page/LineItem.tpl
@@ -72,7 +72,7 @@
     {if $getTaxDetails}
       <td class="right">{$line.line_total|crmMoney}</td>
       {if $line.tax_rate != "" || $line.tax_amount != ""}
-        <td class="right">{$taxTerm} ({$line.tax_rate|string_format:"%.2f"}%)</td>
+        <td class="right">{$taxTerm} ({$line.tax_rate|string_format:"%.3f"}%)</td>
         <td class="right">{$line.tax_amount|crmMoney}</td>
       {else}
         <td></td>


### PR DESCRIPTION
Please see https://issues.civicrm.org/jira/browse/CRM-19908 for full description/rationale.

This PR addresses two fundamentally wrong operations:

- do math - do rounding - do math again
- calculate tax rate using tax amount that was previously calculated using tax rate

Purpose of these edits - three fold: to make the minimal edits required to:
1) **to make the sales Tax Amounts accurate** [by moving premature rounding from the basic Utils function to -after- quantity has been taken into account] - right now they are not - and that's highly critical to organizations that are collecting GST. 
2) **to remove/replace the backwards calculation of Tax Rate** [do not calculate it based on the Tax Amount that used Tax Rate in the first place]
3) **to round close to output/display** - and show three decimals (if needed); one of our provinces in Canada e.g. 9.975% - previously everything was always rounded to two decimals

**Note:** a PHPUnit test has been added to the 4.7 PR

This is the BEFORE: note Tax Rate is **5.01%** and Tax Amount on that lineItem is **$15.30** - this is incorrect:
![5 01taxb](https://cloud.githubusercontent.com/assets/5340555/22191488/655cda52-e0e8-11e6-885e-806cd918d98b.png)

This is the AFTER: note Tax Rate is **5%** and Tax Amount on that lineItem is **$15.26** - this is correct:
![5tax](https://cloud.githubusercontent.com/assets/5340555/22191492/6fb4cd0c-e0e8-11e6-8556-2c0b3e5bbd7a.png)

