### PR TITLE
CRM-19908 - Fundamental Fixes for TaxMath Calculations 4.7

### DIFF
--- a/CRM/Contribute/BAO/Contribution/Utils.php
+++ b/CRM/Contribute/BAO/Contribution/Utils.php
@@ -475,7 +475,8 @@ LIMIT 1
    */
   public static function calculateTaxAmount($amount, $taxRate) {
     $taxAmount = array();
-    $taxAmount['tax_amount'] = round(($taxRate / 100) * CRM_Utils_Rule::cleanMoney($amount), 2);
+    // There can not be any rounding at this stage - as this is prior to quantity multiplication
+    $taxAmount['tax_amount'] = ($taxRate / 100) * CRM_Utils_Rule::cleanMoney($amount);
 
     return $taxAmount;
   }

--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -298,7 +298,15 @@ WHERE li.contribution_id = %1";
         'tax_amount' => $dao->tax_amount,
         'price_set_id' => $dao->price_set_id,
       );
-      $lineItems[$dao->id]['tax_rate'] = CRM_Price_BAO_LineItem::calculateTaxRate($lineItems[$dao->id]);
+      $taxRates = CRM_Core_PseudoConstant::getTaxRates();
+      if (isset($lineItems[$dao->id]['financial_type_id']) && array_key_exists($lineItems[$dao->id]['financial_type_id'], $taxRates)) {
+        // We are close to output/display here - so apply some rounding at output/display level - to not show Tax Rate in all 8 decimals
+        $lineItems[$dao->id]['tax_rate'] = round($taxRates[$lineItems[$dao->id]['financial_type_id']], 3);
+      }
+      else {
+        // There is no Tax Rate associated with this Financial Type
+        $lineItems[$dao->id]['tax_rate'] = FALSE;
+      }
       $lineItems[$dao->id]['subTotal'] = $lineItems[$dao->id]['qty'] * $lineItems[$dao->id]['unit_price'];
       if ($lineItems[$dao->id]['tax_amount'] != '') {
         $getTaxDetails = TRUE;
@@ -595,28 +603,6 @@ WHERE li.contribution_id = %1";
         }
       }
     }
-  }
-
-  /**
-   * Calculate tax rate in percentage.
-   *
-   * @param array $lineItemId
-   *   An assoc array of lineItem.
-   *
-   * @return int|void
-   *   tax rate
-   */
-  public static function calculateTaxRate($lineItemId) {
-    if ($lineItemId['unit_price'] == 0 || $lineItemId['qty'] == 0) {
-      return FALSE;
-    }
-    if ($lineItemId['html_type'] == 'Text') {
-      $tax = round($lineItemId['tax_amount'] / ($lineItemId['unit_price'] * $lineItemId['qty']) * 100, 2);
-    }
-    else {
-      $tax = round(($lineItemId['tax_amount'] / $lineItemId['unit_price']) * 100, 2);
-    }
-    return $tax;
   }
 
 }

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -1666,11 +1666,12 @@ WHERE       ps.id = %1
    * @return array
    */
   public static function setLineItem($field, $lineItem, $optionValueId, &$totalTax) {
+    // Here we round - i.e. after multiplying by quantity
     if ($field['html_type'] == 'Text') {
-      $taxAmount = $field['options'][$optionValueId]['tax_amount'] * $lineItem[$optionValueId]['qty'];
+      $taxAmount = round($field['options'][$optionValueId]['tax_amount'] * $lineItem[$optionValueId]['qty'], 2);
     }
     else {
-      $taxAmount = $field['options'][$optionValueId]['tax_amount'];
+      $taxAmount = round($field['options'][$optionValueId]['tax_amount'], 2);
     }
     $taxRate = $field['options'][$optionValueId]['tax_rate'];
     $lineItem[$optionValueId]['tax_amount'] = $taxAmount;

--- a/templates/CRM/Price/Page/LineItem.tpl
+++ b/templates/CRM/Price/Page/LineItem.tpl
@@ -78,7 +78,7 @@
     {if $getTaxDetails}
       <td class="right">{$line.line_total|crmMoney}</td>
       {if $line.tax_rate != "" || $line.tax_amount != ""}
-        <td class="right">{$taxTerm} ({$line.tax_rate|string_format:"%.2f"}%)</td>
+        <td class="right">{$taxTerm} ({$line.tax_rate|string_format:"%.3f"}%)</td>
         <td class="right">{$line.tax_amount|crmMoney}</td>
       {else}
         <td></td>


### PR DESCRIPTION
Please see https://issues.civicrm.org/jira/browse/CRM-19908 for full description/rationale.

This PR addresses two fundamentally wrong operations:

- do math - do rounding - do math again
- calculate tax rate using tax amount that was previously calculated using tax rate

Purpose of these edits - three fold: to make the minimal edits required to:
1) **to make the sales Tax Amounts accurate** [by moving premature rounding from the basic Utils function to -after- quantity has been taken into account] - right now they are not - and that's highly critical to organizations that are collecting GST. 
2) **to remove/replace the backwards calculation of Tax Rate** [do not calculate it based on the Tax Amount that used Tax Rate in the first place]
3) **to round close to output/display** - and show three decimals (if needed); one of our provinces in Canada e.g. 9.975% - previously everything was always rounded to two decimals

**Note:** I've not added a PHP Unit test for 1) to add a test would require edits to CiviCRM Core (contribution.php and confirm.php) itself [right now you can't test line_items w/ quantity within the TEST framework] - that in itself it not without risk. I strongly believe we need to get the fundamentals right first. 

This is the BEFORE: note Tax Rate is **5.01%** and Tax Amount on that lineItem is **$15.30** - this is incorrect:
![5 01taxb](https://cloud.githubusercontent.com/assets/5340555/22192495/d93b7510-e0f1-11e6-8ec3-78abeb0d543d.png)

This is the AFTER: note Tax Rate is **5%** and Tax Amount on that lineItem is **$15.26** - this is correct:
![5tax](https://cloud.githubusercontent.com/assets/5340555/22192491/d26dd516-e0f1-11e6-82d4-256e14cdfc2c.png)

