### PR TITLE
[NFC] add comments & extract function in contribution search

### DIFF
--- a/CRM/Batch/BAO/Batch.php
+++ b/CRM/Batch/BAO/Batch.php
@@ -708,6 +708,8 @@ LEFT JOIN civicrm_contribution_soft ON civicrm_contribution_soft.contribution_id
           $values['contribution_date_high'] = $date['to'];
         }
         $searchParams = CRM_Contact_BAO_Query::convertFormValues($values);
+        // @todo the use of defaultReturnProperties means the search will be inefficient
+        // as slow-unneeded properties are included.
         $query = new CRM_Contact_BAO_Query($searchParams,
           CRM_Contribute_BAO_Query::defaultReturnProperties(CRM_Contact_BAO_Query::MODE_CONTRIBUTE,
             FALSE

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -468,6 +468,10 @@ class CRM_Contact_BAO_Query {
 
   /**
    * Function which actually does all the work for the constructor.
+   *
+   * @param string $apiEntity
+   *   The api entity being called.
+   *   This sort-of duplicates $mode in a confusing way. Probably not by design.
    */
   public function initialize($apiEntity = NULL) {
     $this->_select = array();
@@ -525,7 +529,7 @@ class CRM_Contact_BAO_Query {
    * versus search builder.
    *
    * The direction we are going is having the form convert values to a standardised format &
-   * moving away from wierd & wonderful where clause switches.
+   * moving away from weird & wonderful where clause switches.
    *
    * Fix and handle contact deletion nicely.
    *
@@ -588,7 +592,7 @@ class CRM_Contact_BAO_Query {
         $this->_paramLookup[$value[0]] = array();
       }
       if ($value[0] !== 'group') {
-        // Just trying to unravel how group interacts here! This whole function is wieid.
+        // Just trying to unravel how group interacts here! This whole function is weird.
         $this->_paramLookup[$value[0]][] = $value;
       }
     }
@@ -596,6 +600,10 @@ class CRM_Contact_BAO_Query {
 
   /**
    * Some composite fields do not appear in the fields array hack to make them part of the query.
+   *
+   * @param $apiEntity
+   *   The api entity being called.
+   *   This sort-of duplicates $mode in a confusing way. Probably not by design.
    */
   public function addSpecialFields($apiEntity) {
     static $special = array('contact_type', 'contact_sub_type', 'sort_name', 'display_name');
@@ -624,6 +632,10 @@ class CRM_Contact_BAO_Query {
    * clauses. Note that since the where clause introduces new
    * tables, the initial attempt also retrieves all variables used
    * in the params list
+   *
+   * @param string $apiEntity
+   *   The api entity being called.
+   *   This sort-of duplicates $mode in a confusing way. Probably not by design.
    */
   public function selectClause($apiEntity = NULL) {
 
@@ -666,6 +678,9 @@ class CRM_Contact_BAO_Query {
       if (in_array($name, array('groups', 'tags', 'notes'))
         && isset($this->_returnProperties[substr($name, 0, -1)])
       ) {
+        // @todo instead of setting make exception to get us into
+        // an if clause that has handling for these fields buried with in it
+        // move the handling to here.
         $makeException = TRUE;
       }
 
@@ -865,6 +880,7 @@ class CRM_Contact_BAO_Query {
           }
         }
         elseif ($name === 'tags') {
+          //@todo move this handling outside the big IF & ditch $makeException
           $this->_useGroupBy = TRUE;
           $this->_select[$name] = "GROUP_CONCAT(DISTINCT(civicrm_tag.name)) as tags";
           $this->_element[$name] = 1;
@@ -872,6 +888,7 @@ class CRM_Contact_BAO_Query {
           $this->_tables['civicrm_entity_tag'] = 1;
         }
         elseif ($name === 'groups') {
+          //@todo move this handling outside the big IF & ditch $makeException
           $this->_useGroupBy = TRUE;
           // Duplicates will be created here but better to sort them out in php land.
           $this->_select[$name] = "
@@ -889,6 +906,7 @@ class CRM_Contact_BAO_Query {
           );
         }
         elseif ($name === 'notes') {
+          //@todo move this handling outside the big IF & ditch $makeException
           // if note field is subject then return subject else body of the note
           $noteColumn = 'note';
           if (isset($noteField) && $noteField == 'note_subject') {
@@ -2331,7 +2349,6 @@ class CRM_Contact_BAO_Query {
     }
   }
 
-
   /**
    * @param $where
    * @param $locType
@@ -2834,9 +2851,9 @@ class CRM_Contact_BAO_Query {
   }
 
   /**
-   * Where / qill clause for contact_sub_type
+   * Where / qill clause for contact_sub_type.
    *
-   * @param $values
+   * @param array $values
    */
   public function contactSubType(&$values) {
     list($name, $op, $value, $grouping, $wildcard) = $values;
@@ -3140,7 +3157,7 @@ WHERE  $smartGroupClause
   }
 
   /**
-   * Where / qill clause for tag
+   * Where / qill clause for tag.
    *
    * @param array $values
    */
@@ -4299,6 +4316,9 @@ civicrm_relationship.is_permission_a_b = 0
    *   Should permissions be ignored or should the logged in user's permissions be applied.
    * @param int $mode
    *   This basically correlates to the component.
+   * @param string $apiEntity
+   *   The api entity being called.
+   *   This sort-of duplicates $mode in a confusing way. Probably not by design.
    *
    * @return array
    */

--- a/CRM/Contribute/BAO/Query.php
+++ b/CRM/Contribute/BAO/Query.php
@@ -44,7 +44,9 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
   static $_contribRecurPayment = NULL;
 
   /**
-   * Function get the import/export fields for contribution.
+   * Function get the searchable fields for contribution.
+   *
+   * This is basically the contribution fields plus some related entity fields.
    *
    * @param bool $checkPermission
    *

--- a/CRM/Contribute/BAO/Query.php
+++ b/CRM/Contribute/BAO/Query.php
@@ -157,80 +157,6 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
       $query->_tables['civicrm_contribution'] = 1;
     }
 
-    // LCD 716
-    $includeSoftCredits = self::isSoftCreditOptionEnabled($query->_params);
-    if (!empty($query->_returnProperties['contribution_soft_credit_name'])) {
-      if ($includeSoftCredits) {
-        $query->_select['contribution_soft_credit_name'] = "civicrm_contact_d.sort_name as contribution_soft_credit_name";
-        // also include contact id. Will help build hyperlinks
-        $query->_select['contribution_soft_credit_contact_id'] = "civicrm_contact_d.id as contribution_soft_credit_contact_id";
-      }
-      $query->_element['contribution_soft_credit_name'] = 1;
-      $query->_element['contribution_soft_credit_contact_id'] = 1;
-
-      $query->_tables['civicrm_contribution'] = 1;
-      $query->_tables['civicrm_contribution_soft'] = 1;
-      $query->_tables['civicrm_contribution_soft_contact'] = 1;
-    }
-
-    if (!empty($query->_returnProperties['contribution_soft_credit_contact_id'])) {
-      $query->_tables['civicrm_contribution'] = 1;
-      $query->_tables['civicrm_contribution_soft'] = 1;
-      $query->_tables['civicrm_contribution_soft_contact'] = 1;
-    }
-
-    if (!empty($query->_returnProperties['contribution_soft_credit_amount'])) {
-      if ($includeSoftCredits) {
-        $query->_select['contribution_soft_credit_amount'] = "civicrm_contribution_soft.amount as contribution_soft_credit_amount";
-      }
-      $query->_element['contribution_soft_credit_amount'] = 1;
-      $query->_tables['civicrm_contribution'] = 1;
-      $query->_tables['civicrm_contribution_soft'] = 1;
-    }
-
-    if (!empty($query->_returnProperties['contribution_soft_credit_type'])) {
-      if ($includeSoftCredits) {
-        $query->_select['contribution_soft_credit_type'] = "contribution_softcredit_type.label as contribution_soft_credit_type";
-      }
-      $query->_element['contribution_soft_credit_type'] = 1;
-      $query->_tables['civicrm_contribution'] = 1;
-      $query->_tables['contribution_softcredit_type'] = 1;
-    }
-
-    if (!empty($query->_returnProperties['contribution_soft_credit_contribution_id'])) {
-      if ($includeSoftCredits) {
-        $query->_select['contribution_soft_credit_contribution_id'] = "civicrm_contribution_soft.contribution_id as contribution_soft_credit_contribution_id";
-      }
-      $query->_element['contribution_soft_credit_contribution_id'] = 1;
-      $query->_tables['civicrm_contribution'] = 1;
-      $query->_tables['civicrm_contribution_soft'] = 1;
-    }
-
-    if (!empty($query->_returnProperties['contribution_soft_credit_email'])) {
-      $query->_select['contribution_soft_credit_email'] = "soft_email.email as contribution_soft_credit_email";
-      $query->_element['contribution_soft_credit_email'] = 1;
-      $query->_tables['civicrm_contribution'] = 1;
-      $query->_tables['civicrm_contribution_soft'] = 1;
-      $query->_tables['civicrm_contribution_soft_contact'] = 1;
-      $query->_tables['civicrm_contribution_soft_email'] = 1;
-    }
-
-    if (!empty($query->_returnProperties['contribution_soft_credit_phone'])) {
-      $query->_select['contribution_soft_credit_email'] = "soft_phone.phone as contribution_soft_credit_phone";
-      $query->_element['contribution_soft_credit_phone'] = 1;
-      $query->_tables['civicrm_contribution'] = 1;
-      $query->_tables['civicrm_contribution_soft'] = 1;
-      $query->_tables['civicrm_contribution_soft_contact'] = 1;
-      $query->_tables['civicrm_contribution_soft_phone'] = 1;
-    }
-
-    if (!empty($query->_returnProperties['contribution_soft_credit_pcp_id'])) {
-      $query->_select['contribution_soft_credit_pcp_id'] = "civicrm_contribution_soft.pcp_id as contribution_soft_credit_pcp_id";
-      $query->_element['contribution_soft_credit_pcp_id'] = 1;
-      $query->_tables['civicrm_contribution'] = 1;
-      $query->_tables['civicrm_contribution_soft'] = 1;
-    }
-
     if (!empty($query->_returnProperties['contribution_campaign_title'])) {
       $query->_select['contribution_campaign_title'] = "civicrm_campaign.title as contribution_campaign_title";
       $query->_element['contribution_campaign_title'] = $query->_tables['civicrm_campaign'] = 1;
@@ -251,6 +177,8 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
       $query->_element['financial_type_id'] = $query->_tables['civicrm_contribution'] = 1;
     }
     // LCD 716 END
+
+    self::addSoftCreditFields($query);
   }
 
   /**
@@ -1205,6 +1133,88 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
     CRM_Utils_Rule::validDateRange($fields, 'contribution_date', $errors, ts('Date Received'));
 
     return empty($errors) ? TRUE : $errors;
+  }
+
+  /**
+   * Add the soft credit fields to the select fields.
+   *
+   * Extracted into separate function to improve readability of main select function.
+   *
+   * @param $query
+   */
+  private static function addSoftCreditFields(&$query) {
+    $includeSoftCredits = self::isSoftCreditOptionEnabled($query->_params);
+    if (!empty($query->_returnProperties['contribution_soft_credit_name'])) {
+      if ($includeSoftCredits) {
+        $query->_select['contribution_soft_credit_name'] = "civicrm_contact_d.sort_name as contribution_soft_credit_name";
+        // also include contact id. Will help build hyperlinks
+        $query->_select['contribution_soft_credit_contact_id'] = "civicrm_contact_d.id as contribution_soft_credit_contact_id";
+      }
+      $query->_element['contribution_soft_credit_name'] = 1;
+      $query->_element['contribution_soft_credit_contact_id'] = 1;
+
+      $query->_tables['civicrm_contribution'] = 1;
+      $query->_tables['civicrm_contribution_soft'] = 1;
+      $query->_tables['civicrm_contribution_soft_contact'] = 1;
+    }
+
+    if (!empty($query->_returnProperties['contribution_soft_credit_contact_id'])) {
+      $query->_tables['civicrm_contribution'] = 1;
+      $query->_tables['civicrm_contribution_soft'] = 1;
+      $query->_tables['civicrm_contribution_soft_contact'] = 1;
+    }
+
+    if (!empty($query->_returnProperties['contribution_soft_credit_amount'])) {
+      if ($includeSoftCredits) {
+        $query->_select['contribution_soft_credit_amount'] = "civicrm_contribution_soft.amount as contribution_soft_credit_amount";
+      }
+      $query->_element['contribution_soft_credit_amount'] = 1;
+      $query->_tables['civicrm_contribution'] = 1;
+      $query->_tables['civicrm_contribution_soft'] = 1;
+    }
+
+    if (!empty($query->_returnProperties['contribution_soft_credit_type'])) {
+      if ($includeSoftCredits) {
+        $query->_select['contribution_soft_credit_type'] = "contribution_softcredit_type.label as contribution_soft_credit_type";
+      }
+      $query->_element['contribution_soft_credit_type'] = 1;
+      $query->_tables['civicrm_contribution'] = 1;
+      $query->_tables['contribution_softcredit_type'] = 1;
+    }
+
+    if (!empty($query->_returnProperties['contribution_soft_credit_contribution_id'])) {
+      if ($includeSoftCredits) {
+        $query->_select['contribution_soft_credit_contribution_id'] = "civicrm_contribution_soft.contribution_id as contribution_soft_credit_contribution_id";
+      }
+      $query->_element['contribution_soft_credit_contribution_id'] = 1;
+      $query->_tables['civicrm_contribution'] = 1;
+      $query->_tables['civicrm_contribution_soft'] = 1;
+    }
+
+    if (!empty($query->_returnProperties['contribution_soft_credit_email'])) {
+      $query->_select['contribution_soft_credit_email'] = "soft_email.email as contribution_soft_credit_email";
+      $query->_element['contribution_soft_credit_email'] = 1;
+      $query->_tables['civicrm_contribution'] = 1;
+      $query->_tables['civicrm_contribution_soft'] = 1;
+      $query->_tables['civicrm_contribution_soft_contact'] = 1;
+      $query->_tables['civicrm_contribution_soft_email'] = 1;
+    }
+
+    if (!empty($query->_returnProperties['contribution_soft_credit_phone'])) {
+      $query->_select['contribution_soft_credit_email'] = "soft_phone.phone as contribution_soft_credit_phone";
+      $query->_element['contribution_soft_credit_phone'] = 1;
+      $query->_tables['civicrm_contribution'] = 1;
+      $query->_tables['civicrm_contribution_soft'] = 1;
+      $query->_tables['civicrm_contribution_soft_contact'] = 1;
+      $query->_tables['civicrm_contribution_soft_phone'] = 1;
+    }
+
+    if (!empty($query->_returnProperties['contribution_soft_credit_pcp_id'])) {
+      $query->_select['contribution_soft_credit_pcp_id'] = "civicrm_contribution_soft.pcp_id as contribution_soft_credit_pcp_id";
+      $query->_element['contribution_soft_credit_pcp_id'] = 1;
+      $query->_tables['civicrm_contribution'] = 1;
+      $query->_tables['civicrm_contribution_soft'] = 1;
+    }
   }
 
 }

--- a/CRM/Core/OptionValue.php
+++ b/CRM/Core/OptionValue.php
@@ -306,6 +306,10 @@ class CRM_Core_OptionValue {
 
       $nameTitle = array();
       if ($mode == 'contribute') {
+        // This is part of a move towards standardising option values but we
+        // should derive them from the fields array so am deprecating it again...
+        // note that the reason this was needed was that payment_instrument_id was
+        // not set to exportable.
         $nameTitle = array(
           'payment_instrument' => array(
             'name' => 'payment_instrument',

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -1528,7 +1528,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'non_deductible_amount' => 10.00,
       'net_amount' => 100.00,
       'contribution_status_id' => 1,
-      'note' => 'Donating for Nobel Cause',
+      'note' => 'Donating for Noble Cause',
 
     );
 
@@ -1538,19 +1538,20 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'contribution_id' => $contribution['id'],
 
     );
-    $contribution = $this->callAPISuccess('contribution', 'get', $new_params);
+    $contribution = $this->callAPISuccessGetSingle('contribution', $new_params);
 
-    $this->assertEquals($contribution['values'][$contributionID]['contact_id'], $this->_individualId);
-    $this->assertEquals($contribution['values'][$contributionID]['total_amount'], 110.00);
-    $this->assertEquals($contribution['values'][$contributionID]['financial_type_id'], $this->_financialTypeId);
-    $this->assertEquals($contribution['values'][$contributionID]['instrument_id'], $old_payment_instrument);
-    $this->assertEquals($contribution['values'][$contributionID]['non_deductible_amount'], 10.00);
-    $this->assertEquals($contribution['values'][$contributionID]['fee_amount'], $old_fee_amount);
-    $this->assertEquals($contribution['values'][$contributionID]['net_amount'], 100.00);
-    $this->assertEquals($contribution['values'][$contributionID]['trxn_id'], $old_trxn_id);
-    $this->assertEquals($contribution['values'][$contributionID]['invoice_id'], $old_invoice_id);
-    $this->assertEquals($contribution['values'][$contributionID]['contribution_source'], $old_source);
-    $this->assertEquals($contribution['values'][$contributionID]['contribution_status'], 'Completed');
+    $this->assertEquals($contribution['contact_id'], $this->_individualId);
+    $this->assertEquals($contribution['total_amount'], 110.00);
+    $this->assertEquals($contribution['financial_type_id'], $this->_financialTypeId);
+    $this->assertEquals($contribution['financial_type'], 'Donation');
+    $this->assertEquals($contribution['instrument_id'], $old_payment_instrument);
+    $this->assertEquals($contribution['non_deductible_amount'], 10.00);
+    $this->assertEquals($contribution['fee_amount'], $old_fee_amount);
+    $this->assertEquals($contribution['net_amount'], 100.00);
+    $this->assertEquals($contribution['trxn_id'], $old_trxn_id);
+    $this->assertEquals($contribution['invoice_id'], $old_invoice_id);
+    $this->assertEquals($contribution['contribution_source'], $old_source);
+    $this->assertEquals($contribution['contribution_status'], 'Completed');
     $params = array(
       'contribution_id' => $contributionID,
 
@@ -1558,8 +1559,6 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $result = $this->callAPISuccess('contribution', 'delete', $params);
     $this->assertAPISuccess($result);
   }
-
-  ///////////////// civicrm_contribution_delete methods
 
   /**
    * Attempt (but fail) to delete a contribution without parameters.


### PR DESCRIPTION
This is the NFC part of #9631 - I think the main part can wait until after the cut off but the comment additions & database extraction allow simplification of that PR for review.

Note the only non-comment & non-test change is to extract the setting on soft credit options into it's own function