### PR TITLE
CRM-19920 optimize process membership

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -2170,7 +2170,6 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = membership.contact_id AND 
 
     //get all active statuses of membership, CRM-3984
     $allStatus = CRM_Member_PseudoConstant::membershipStatus();
-    $statusLabels = CRM_Member_PseudoConstant::membershipStatus(NULL, NULL, 'label');
     $allTypes = CRM_Member_PseudoConstant::membershipType();
 
     // This query retrieves ALL memberships of active types.
@@ -2196,9 +2195,6 @@ WHERE      civicrm_membership.is_test = 0 ";
     $processCount = 0;
     $updateCount = 0;
 
-    // ??
-    $smarty = CRM_Core_Smarty::singleton();
-
     // Handle membership status of deceased contacts.
     $deceasedQuery = $baseQuery . " AND civicrm_contact.is_deceased <> 0 AND civicrm_membership.status_id <> %1 ";
 
@@ -2221,10 +2217,6 @@ WHERE      civicrm_membership.is_test = 0 ";
 
     while ($dao1->fetch()) {
       $processCount++;
-      //since there is change in status.
-      $statusChange = array('status_id' => $deceaseStatusId);
-      // I don't know what this is about. It was already there. :-/
-      $smarty->append_by_ref('memberParams', $statusChange, TRUE);
 
       $deceasedMembership = array(
         'id' => $dao1->membership_id,
@@ -2275,8 +2267,6 @@ WHERE      civicrm_membership.is_test = 0 ";
         'skipRecentView' => TRUE,
       );
 
-      $smarty->assign_by_ref('memberParams', $memberParams);
-
       // CRM-7248: added excludeIsAdmin param to the following fn call to prevent moving to admin statuses
       //get the membership status as per id.
       $newStatus = civicrm_api('membership_status', 'calc',
@@ -2311,8 +2301,6 @@ WHERE      civicrm_membership.is_test = 0 ";
           $memParams['source']
         );
         //since there is change in status.
-        $statusChange = array('status_id' => $statusId);
-        $smarty->append_by_ref('memberParams', $statusChange, TRUE);
 
         //process member record.
         civicrm_api('membership', 'create', $memParams);

--- a/CRM/Member/BAO/MembershipStatus.php
+++ b/CRM/Member/BAO/MembershipStatus.php
@@ -292,34 +292,35 @@ class CRM_Member_BAO_MembershipStatus extends CRM_Member_DAO_MembershipStatus {
       foreach ($events as $eve) {
         foreach ($dates as $dat) {
           // calculate start-event/date and end-event/date
-          if ((CRM_Member_PseudoConstant::membershipStatus($statusId, $eve . '_event') == $dat . '_date') &&
+          $statusEvent = CRM_Member_PseudoConstant::membershipStatus($statusId, NULL, $eve . '_event');
+          if (($statusEvent == $dat . '_date') &&
             ${$dat . 'Date'}
           ) {
-            if (CRM_Member_PseudoConstant::membershipStatus($statusId, $eve . '_event_adjust_unit') &&
-              CRM_Member_PseudoConstant::membershipStatus($statusId, $eve . '_event_adjust_interval')
+            if (CRM_Member_PseudoConstant::membershipStatus($statusId, NULL, $eve . '_event_adjust_unit') &&
+              CRM_Member_PseudoConstant::membershipStatus($statusId, NULL, $eve . '_event_adjust_interval')
             ) {
               // add in months
-              if (CRM_Member_PseudoConstant::membershipStatus($statusId, $eve . '_event_adjust_unit') == 'month') {
+              if (CRM_Member_PseudoConstant::membershipStatus($statusId, NULL, $eve . '_event_adjust_unit') == 'month') {
                 ${$eve . 'Event'} = date('Ymd', mktime($hour, $minute, $second,
-                  ${$dat . 'Month'} + CRM_Member_PseudoConstant::membershipStatus($statusId, $eve . '_event_adjust_interval'),
+                  ${$dat . 'Month'} + CRM_Member_PseudoConstant::membershipStatus($statusId, NULL, $eve . '_event_adjust_interval'),
                   ${$dat . 'Day'},
                   ${$dat . 'Year'}
                 ));
               }
               // add in days
-              if (CRM_Member_PseudoConstant::membershipStatus($statusId, $eve . '_event_adjust_unit') == 'day') {
+              if (CRM_Member_PseudoConstant::membershipStatus($statusId, NULL, $eve . '_event_adjust_unit') == 'day') {
                 ${$eve . 'Event'} = date('Ymd', mktime($hour, $minute, $second,
                   ${$dat . 'Month'},
-                  ${$dat . 'Day'} + CRM_Member_PseudoConstant::membershipStatus($statusId, $eve . '_event_adjust_interval'),
+                  ${$dat . 'Day'} + CRM_Member_PseudoConstant::membershipStatus($statusId, NULL, $eve . '_event_adjust_interval'),
                   ${$dat . 'Year'}
                 ));
               }
               // add in years
-              if (CRM_Member_PseudoConstant::membershipStatus($statusId, $eve . '_event_adjust_unit') == 'year') {
+              if (CRM_Member_PseudoConstant::membershipStatus($statusId, NULL, $eve . '_event_adjust_unit') == 'year') {
                 ${$eve . 'Event'} = date('Ymd', mktime($hour, $minute, $second,
                   ${$dat . 'Month'},
                   ${$dat . 'Day'},
-                  ${$dat . 'Year'} + CRM_Member_PseudoConstant::membershipStatus($statusId, $eve . '_event_adjust_interval')
+                  ${$dat . 'Year'} + CRM_Member_PseudoConstant::membershipStatus($statusId, NULL, $eve . '_event_adjust_interval')
                 ));
               }
               // if no interval and unit, present

--- a/CRM/Member/BAO/MembershipStatus.php
+++ b/CRM/Member/BAO/MembershipStatus.php
@@ -335,19 +335,28 @@ class CRM_Member_BAO_MembershipStatus extends CRM_Member_DAO_MembershipStatus {
       // check if statusDate is in the range of start & end events.
       if ($startEvent && $endEvent) {
         if (($statusDate >= $startEvent) && ($statusDate <= $endEvent)) {
-          $membershipDetails['id'] = $statusId;
+          // I use strval because fixMembershipStatusBeforeRenew in
+          // CRM/Member/BAO/Membership.php:1193 expects the id to be
+          // a string (!== comparison).
+          // If I would just return the integer value, the unit test
+          // testCompleteTransactionMembershipPriceSet from
+          // api_v3_ContributionTest would fail, because a membership
+          // status will be changed to that same status, which causes
+          // too many entries in MembershipLog.
+          // This might be a bug in the Membership BAO.
+          $membershipDetails['id'] = strval($statusId);
           $membershipDetails['name'] = $statusName;
         }
       }
       elseif ($startEvent) {
         if ($statusDate >= $startEvent) {
-          $membershipDetails['id'] = $statusId;
+          $membershipDetails['id'] = strval($statusId);
           $membershipDetails['name'] = $statusName;
         }
       }
       elseif ($endEvent) {
         if ($statusDate <= $endEvent) {
-          $membershipDetails['id'] = $statusId;
+          $membershipDetails['id'] = strval($statusId);
           $membershipDetails['name'] = $statusName;
         }
       }


### PR DESCRIPTION
I rewrote `updateAllMembershipStatus()` so that it handles the deceased people first, and then only processes the memberships of the types that are not excluded.

I also removed the database query in `getMembershipStatusByDate`, and use pseudoconstants instead, so that the CiviCRM cache is used.

---

 * [CRM-19920: Job.process_membership uses too much memory](https://issues.civicrm.org/jira/browse/CRM-19920)