### PR TITLE
CRM-19922 - CRM_Utils_File::findFiles should sort files alphabetically

### DIFF
--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -742,6 +742,7 @@ HTACCESS;
         closedir($dh);
       }
     }
+    sort($result);
     return $result;
   }
 


### PR DESCRIPTION
* [CRM-19922: CRM_Utils_File::findFiles should sort files alphabetically](https://issues.civicrm.org/jira/browse/CRM-19922)