### PR TITLE
CRM-20012, CRM-19490 (now merged & closed), CRM-18387(merged& closed), CRM-20011 (in separate pr), CRM-15948(resolved by arlready-merged-part), CRM-19911 profile date fixes & code improvement

### DIFF
--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -380,13 +380,12 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
 
     // for add mode set smart defaults
     if ($this->_action & CRM_Core_Action::ADD) {
-      list($currentDate, $currentTime) = CRM_Utils_Date::setDateDefaults(NULL, 'activityDateTime');
+      $currentDate = date('Y-m-d H-i-s');
 
       $completeStatus = CRM_Contribute_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed');
       $specialFields = array(
         'join_date' => date('Y-m-d'),
         'receive_date' => $currentDate,
-        'receive_date_time' => $currentTime,
         'contribution_status_id' => $completeStatus,
       );
 
@@ -447,12 +446,6 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
    * @return bool
    */
   private function processContribution(&$params) {
-    $dates = array(
-      'receive_date',
-      'receipt_date',
-      'thankyou_date',
-      'cancel_date',
-    );
 
     // get the price set associated with offline contribution record.
     $priceSetId = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', 'default_contribution_amount', 'id', 'name');
@@ -503,12 +496,6 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
           NULL,
           'Contribution'
         );
-
-        foreach ($dates as $val) {
-          if (!empty($value[$val])) {
-            $value[$val] = CRM_Utils_Date::processDate($value[$val], $value[$val . '_time'], TRUE);
-          }
-        }
 
         if (!empty($value['send_receipt'])) {
           $value['receipt_date'] = date('Y-m-d His');
@@ -713,10 +700,6 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
           else {
             $value['soft_credit'][$key]['soft_credit_type_id'] = CRM_Core_OptionGroup::getValue('soft_credit_type', 'Gift', 'name');
           }
-        }
-
-        if (!empty($value['receive_date'])) {
-          $value['receive_date'] = CRM_Utils_Date::processDate($value['receive_date'], $value['receive_date_time'], TRUE);
         }
 
         $params['actualBatchTotal'] += $value['total_amount'];

--- a/templates/CRM/Batch/Form/Entry.tpl
+++ b/templates/CRM/Batch/Form/Entry.tpl
@@ -93,13 +93,7 @@
         {/if}
         {foreach from=$fields item=field key=fieldName}
           {assign var=n value=$field.name}
-          {if in_array( $n, array( 'thankyou_date', 'cancel_date', 'receipt_date', 'receive_date') ) }
-            <div class="compressed crm-grid-cell">
-              <span class="crm-batch-{$n}-{$rowNumber}">
-                {include file="CRM/common/jcalendar.tpl" elementName=$n elementIndex=$rowNumber batchUpdate=1}
-              </span>
-            </div>
-          {elseif $n eq 'soft_credit'}
+          {if $n eq 'soft_credit'}
             <div class="compressed crm-grid-cell">
               {$form.soft_credit_contact_id.$rowNumber.html|crmAddClass:big}
               {$form.soft_credit_amount.$rowNumber.label}&nbsp;{$form.soft_credit_amount.$rowNumber.html|crmAddClass:eight}

--- a/templates/CRM/Contribute/Form/Task/Batch.tpl
+++ b/templates/CRM/Contribute/Form/Task/Batch.tpl
@@ -48,11 +48,7 @@
 
               {foreach from=$fields item=field key=fieldName}
                 {assign var=n value=$field.name}
-                {if ( $n eq 'thankyou_date' ) or ( $n eq 'cancel_date' ) or ( $n eq 'receipt_date' ) or ( $n eq 'receive_date' )}
-                   <td class="compressed">{include file="CRM/common/jcalendar.tpl" elementName=$n elementIndex=$cid batchUpdate=1}</td>
-                {else}
-                   <td class="compressed">{$form.field.$cid.$n.html}</td>
-                {/if}
+                 <td class="compressed">{$form.field.$cid.$n.html}</td>
               {/foreach}
              </tr>
             {/foreach}

--- a/templates/CRM/UF/Form/Fields.tpl
+++ b/templates/CRM/UF/Form/Fields.tpl
@@ -97,8 +97,6 @@
                value="{$form.$profileFieldName.value}" id="{$form.$profileFieldName.name}"
               >
             </span>
-          {elseif $field.is_legacy_date}
-            {include file="CRM/common/jcalendar.tpl" elementName=$profileFieldName}
           {elseif $profileFieldName|substr:0:5 eq 'phone'}
             {assign var="phone_ext_field" value=$profileFieldName|replace:'phone':'phone_ext'}
             {if $prefix}{$form.$prefix.$profileFieldName.html}{else}{$form.$profileFieldName.html}{/if}

--- a/tests/phpunit/CRM/Batch/Form/EntryTest.php
+++ b/tests/phpunit/CRM/Batch/Form/EntryTest.php
@@ -234,9 +234,9 @@ class CRM_Batch_Form_EntryTest extends CiviUnitTestCase {
 
     // explicitly specify start and end dates
     $params['field'][2]['membership_type'] = array(0 => $this->_orgContactID2, 1 => $this->_membershipTypeID2);
-    $params['field'][2]['membership_start_date'] = "04/01/2016";
-    $params['field'][2]['membership_end_date'] = "03/31/2017";
-    $params['field'][2]['receive_date'] = "04/01/2016";
+    $params['field'][2]['membership_start_date'] = "2016-04-01";
+    $params['field'][2]['membership_end_date'] = "2017-03-31";
+    $params['field'][2]['receive_date'] = "2016-04-01";
 
     $this->assertTrue($form->testProcessMembership($params));
     $result = $this->callAPISuccess('membership', 'get', array());
@@ -268,13 +268,13 @@ class CRM_Batch_Form_EntryTest extends CiviUnitTestCase {
       'field' => array(
         1 => array(
           'membership_type' => array(0 => $this->_orgContactID, 1 => $this->_membershipTypeID),
-          'join_date' => '07/22/2013',
+          'join_date' => '2013-07-22',
           'membership_start_date' => NULL,
           'membership_end_date' => NULL,
           'membership_source' => NULL,
           'financial_type' => 2,
           'total_amount' => 1,
-          'receive_date' => '07/24/2013',
+          'receive_date' => '2013-07-24',
           'receive_date_time' => NULL,
           'payment_instrument' => 1,
           'trxn_id' => 'TX101',
@@ -283,13 +283,13 @@ class CRM_Batch_Form_EntryTest extends CiviUnitTestCase {
         ),
         2 => array(
           'membership_type' => array(0 => $this->_orgContactID, 1 => $this->_membershipTypeID),
-          'join_date' => '07/03/2013',
-          'membership_start_date' => '02/03/2013',
+          'join_date' => '2013-07-03',
+          'membership_start_date' => '2013-02-03',
           'membership_end_date' => NULL,
           'membership_source' => NULL,
           'financial_type' => 2,
           'total_amount' => 1,
-          'receive_date' => '07/17/2013',
+          'receive_date' => '2013-07-17',
           'receive_date_time' => NULL,
           'payment_instrument' => NULL,
           'trxn_id' => 'TX102',
@@ -305,7 +305,7 @@ class CRM_Batch_Form_EntryTest extends CiviUnitTestCase {
           'membership_source' => NULL,
           'financial_type' => 2,
           'total_amount' => 1,
-          'receive_date' => '07/17/2013',
+          'receive_date' => '2013-07-17',
           'receive_date_time' => NULL,
           'payment_instrument' => NULL,
           'trxn_id' => 'TX103',
@@ -335,7 +335,7 @@ class CRM_Batch_Form_EntryTest extends CiviUnitTestCase {
         1 => array(
           'financial_type' => 1,
           'total_amount' => 15,
-          'receive_date' => '07/24/2013',
+          'receive_date' => '2013-07-24',
           'receive_date_time' => NULL,
           'payment_instrument' => 1,
           'check_number' => NULL,
@@ -344,7 +344,7 @@ class CRM_Batch_Form_EntryTest extends CiviUnitTestCase {
         2 => array(
           'financial_type' => 1,
           'total_amount' => 15,
-          'receive_date' => '07/24/2013',
+          'receive_date' => '2013-07-24',
           'receive_date_time' => NULL,
           'payment_instrument' => 1,
           'check_number' => NULL,


### PR DESCRIPTION
This came out of a patch I was asked to review to fix CRM-19490. The patch added a bit of an extra hack onto some existing toxic code. Coleman pointed out that out the direction we were moving to was to add the datepicker & I went down that (ever growing) path. I concluded to add metadata to decide what to do with the field (sadly not entirely smoothly in a commit 20 days ago) and to try to add the datepicker based on that, with much more common handling between core & custom data fields.

The datepicker widget includes the date field with data in ISO format but the presentation in the custom format. Thus instead of 3 fields activity_date_time_time and activity_date_time on the page there will be only one and the data, as far as php knows, is in ISO format.

After making the changes I went through a bunch of tickets to try to replicate them on the metadata driven code. Many were already fixed & others leant themselves to easy fixing at that point.

One issue is there was test breakage on the profile api.I have altered the test to reflect the change https://github.com/civicrm/civicrm-core/pull/9729/commits/bf808201f28bc7ab9500068c3ba7c32ff7d85626 - this could reasonably be argued to be a breach of test contract, on the other hand the expectation of the profile api is that it advertises & describes the fields required for the profile. A mitigating factor is that the profile api has had very little uptake - although some have tried & failed to use it. @jackrabbithanna as Skvare is the only org that seems to have success with this api do you feel the need to push back against a 'allow test contract change in accordance with the above patch & announce to the dev list' approach?


 * [CRM-19490: Profile date fields don't respect localisation on the Contribution Page confirmation screen](https://issues.civicrm.org/jira/browse/CRM-19490)

---

 * [CRM-18387: Contribution confirmation page forces custom date fields always to be format yyyy-mm-dd](https://issues.civicrm.org/jira/browse/CRM-18387)
 * [CRM-20012: contribution batch update: can't unset thank you date value](https://issues.civicrm.org/jira/browse/CRM-20012)
 * [CRM-20011: Profile date fields using YYYY-MM or MM YY don't work](https://issues.civicrm.org/jira/browse/CRM-20011)
 * [CRM-15948: date format not always respected in profile when in Edit mode for drupal user](https://issues.civicrm.org/jira/browse/CRM-15948)

---

 * [CRM-19911: Date problem in profile edit Custom date field](https://issues.civicrm.org/jira/browse/CRM-19911)