### PR TITLE
CRM-19926: Include child groups when filtered with parent group in Reports

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -3433,6 +3433,9 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
     if (!is_array($value)) {
       $value = array($value);
     }
+    //include child groups if any
+    $value = array_merge($value, CRM_Contact_BAO_Group::getChildGroupIds($value));
+
     $clause = "{$field['dbAlias']} IN (" . implode(', ', $value) . ")";
 
     $contactAlias = $this->_aliases['civicrm_contact'];


### PR DESCRIPTION
* [CRM-19926: Constituent Summary Report Filtered by Groups ignores children groups](https://issues.civicrm.org/jira/browse/CRM-19926)