### PR TITLE
CRM-19686 - Dedupe Exceptions Should Link to Contacts(4.6 backport)

### DIFF
--- a/templates/CRM/Contact/Page/DedupeException.tpl
+++ b/templates/CRM/Contact/Page/DedupeException.tpl
@@ -35,9 +35,9 @@
     <tbody>
        {foreach from=$dedupeExceptions item=exception key=id}
        <tr id="dupeRow_{$id}" class="{cycle values="odd-row,even-row"}">
-     <td>{$exception.main.name}</td>
-     <td>{$exception.other.name}</td>
-     <td><a id='duplicateContacts' href="#" title={ts}Remove Exception{/ts} onClick="processDupes( {$exception.main.id}, {$exception.other.id}, 'nondupe-dupe', 'dedupe-exception' );return false;">&raquo; {ts}Remove Exception{/ts}</a></td>
+          <td><a href ={crmURL p='civicrm/contact/view' q="reset=1&cid=`$exception.main.id`"}>{$exception.main.name}</a></td>
+          <td><a href ={crmURL p='civicrm/contact/view' q="reset=1&cid=`$exception.other.id`"}>{$exception.other.name}</a></td>
+          <td><a id='duplicateContacts' href="#" title={ts}Remove Exception{/ts} onClick="processDupes( {$exception.main.id}, {$exception.other.id}, 'nondupe-dupe', 'dedupe-exception' );return false;">&raquo; {ts}Remove Exception{/ts}</a></td>
        </tr>
        {/foreach}
     </tbody>


### PR DESCRIPTION
* [CRM-19686: Dedupe Exceptions Should Link to Contacts](https://issues.civicrm.org/jira/browse/CRM-19686)