### PR TITLE
CRM-19937 - ensure amount preceded by $ is still treated as a number

### DIFF
--- a/templates/CRM/Price/Form/Calculate.tpl
+++ b/templates/CRM/Price/Form/Calculate.tpl
@@ -151,7 +151,7 @@ function calculateSelectLineItemValue(priceElement) {
 function calculateText(priceElement) {
   //CRM-16034 - comma acts as decimal in price set text pricing
   //CRM-19937 - dollar sign easy mistake to make by users.
-  var textval = parseFloat(cj(priceElement).val().replace(thousandMarker, '').replace('$', ''));
+  var textval = parseFloat(cj(priceElement).val().replace(thousandMarker, '').replace(symbol, ''));
 
   if (isNaN(textval)) {
     textval = parseFloat(0);

--- a/templates/CRM/Price/Form/Calculate.tpl
+++ b/templates/CRM/Price/Form/Calculate.tpl
@@ -150,7 +150,8 @@ function calculateSelectLineItemValue(priceElement) {
  */
 function calculateText(priceElement) {
   //CRM-16034 - comma acts as decimal in price set text pricing
-  var textval = parseFloat(cj(priceElement).val().replace(thousandMarker, ''));
+  //CRM-19937 - dollar sign easy mistake to make by users.
+  var textval = parseFloat(cj(priceElement).val().replace(thousandMarker, '').replace('$', ''));
 
   if (isNaN(textval)) {
     textval = parseFloat(0);


### PR DESCRIPTION
otherwise the payment fields will not be shown.

---

 * [CRM-19937: entering $ \(dollar sign\) in other amount contribution box makes credit card forms go away](https://issues.civicrm.org/jira/browse/CRM-19937)