### PR TITLE
CRM-19936, initialized array for line items

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1527,6 +1527,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
       $i = 1;
       foreach ($membershipTypeIDs as $memType) {
+        $membershipLineItems = array();
         if ($i < count($membershipTypeIDs)) {
           $membershipLineItems[$priceSetID][$membershipLines[$memType]] = $unprocessedLineItems[$priceSetID][$membershipLines[$memType]];
           unset($unprocessedLineItems[$priceSetID][$membershipLines[$memType]]);


### PR DESCRIPTION
Critical bug backport for 4.7.16
----------------------------------------
* CRM-19936: Membership line items are doubled when a membersip is renewed using online contribution page
  https://issues.civicrm.org/jira/browse/CRM-19936