### PR TITLE
Fix against PHP warning; Notice: Array to string conversion

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -633,7 +633,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
 
         //remove common fields only if profile is not configured for onbehalf/honor
         if (!in_array($profileContactType, array('honor', 'onbehalf'))) {
-          $fields = array_diff_assoc($fields, $this->_fields);
+          $fields = array_diff_key($fields, $this->_fields);
         }
 
         CRM_Core_BAO_Address::checkContactSharedAddressFields($fields, $contactID);


### PR DESCRIPTION
Change array comparing difference function to fix
the PHP warning message of Notice: Array to string conversion appear
when configure profile contain common field with contribution page.