### PR TITLE
CRM-19952 - ensure group settings (ACL/Mailing) used on import

### DIFF
--- a/CRM/Contact/Import/Form/Preview.php
+++ b/CRM/Contact/Import/Form/Preview.php
@@ -271,7 +271,7 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
       'dedupe' => $this->get('dedupe'),
       'newGroupName' => $this->controller->exportValue($this->_name, 'newGroupName'),
       'newGroupDesc' => $this->controller->exportValue($this->_name, 'newGroupDesc'),
-      'newGroupType' => $this->controller->exportValue($this->_name, 'newGroupType'),
+      'newGroupType' => array_keys($this->controller->exportValue($this->_name, 'newGroupType')),
       'groups' => $this->controller->exportValue($this->_name, 'groups'),
       'allGroups' => $this->get('groups'),
       'newTagName' => $this->controller->exportValue($this->_name, 'newTagName'),


### PR DESCRIPTION
Not sure this is the right fix... but it seems to work. Is there a more standard way to flip the values?

---

 * [CRM-19952: specifying mailing list for group when importing creates access group instead](https://issues.civicrm.org/jira/browse/CRM-19952)