### PR TITLE
CRM-19955 file display in contact record

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1443,7 +1443,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
           $entityId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_EntityFile',
             $fileID,
             'entity_id',
-            'id'
+            'file_id'
           );
           list($path) = CRM_Core_BAO_File::path($fileID, $entityId, NULL, NULL);
           $url = CRM_Utils_System::url('civicrm/file',


### PR DESCRIPTION
* [CRM-19955: custom field image display in contact record retrieve incorrectly](https://issues.civicrm.org/jira/browse/CRM-19955)