### PR TITLE
Price forms fixes: part of CRM-19517 + cleanup & symptom fix for CRM-19953

### DIFF
--- a/CRM/Financial/BAO/FinancialType.php
+++ b/CRM/Financial/BAO/FinancialType.php
@@ -395,7 +395,33 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType {
   }
 
   /**
-   * Check if FT-ACL is turned on or off
+   * Check if the logged in user has permission to edit the given financial type.
+   *
+   * This is called when determining if they can edit things like option values
+   * in price sets. At the moment it is not possible to change an option value from
+   * a type you do not have permission to to a type that you do.
+   *
+   * @todo it is currently not possible to edit disabled types if you have ACLs on.
+   * Do ACLs still apply once disabled? That question should be resolved if tackling
+   * that gap.
+   *
+   * @param int $financialTypeID
+   *
+   * @return bool
+   */
+  public static function checkPermissionToEditFinancialType($financialTypeID) {
+    if (!self::isACLFinancialTypeStatus()) {
+      return TRUE;
+    }
+    // @todo consider adding back in disabled types here.
+    CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes($financialTypes, CRM_Core_Action::UPDATE);
+    return isset($financialTypes[$financialTypeID]);
+  }
+
+  /**
+   * Check if FT-ACL is turned on or off.
+   *
+   * @todo rename this function e.g isFinancialTypeACLsEnabled.
    *
    * @return bool
    */

--- a/CRM/Price/BAO/PriceFieldValue.php
+++ b/CRM/Price/BAO/PriceFieldValue.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2017
- * $Id$
- *
  */
 
 /**
@@ -43,9 +41,9 @@ class CRM_Price_BAO_PriceFieldValue extends CRM_Price_DAO_PriceFieldValue {
    * Insert/update a new entry in the database.
    *
    * @param array $params
-   *   (reference), array $ids.
    *
-   * @param $ids
+   * @param array $ids
+   *  Deprecated variable.
    *
    * @return CRM_Price_DAO_PriceFieldValue
    */
@@ -157,7 +155,7 @@ class CRM_Price_BAO_PriceFieldValue extends CRM_Price_DAO_PriceFieldValue {
   }
 
   /**
-   * Retrive the all values for given field id.
+   * Retrieve all values for given field id.
    *
    * @param int $fieldId
    *   Price_field_id.

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -29,12 +29,10 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2017
- * $Id$
- *
  */
 
 /**
- * Business object for managing price sets
+ * Business object for managing price sets.
  *
  */
 class CRM_Price_BAO_PriceSet extends CRM_Price_DAO_PriceSet {
@@ -191,7 +189,7 @@ WHERE       ps.name = '{$entityName}'
    *
    * @return array
    */
-  public static function &getUsedBy($id, $simpleReturn = FALSE) {
+  public static function getUsedBy($id, $simpleReturn = FALSE) {
     $usedBy = $forms = $tables = array();
     $queryString = "
 SELECT   entity_table, entity_id
@@ -374,7 +372,7 @@ WHERE     ct.id = cp.financial_type_id AND
   }
 
   /**
-   * Find a price_set_id associatied with the given table, id and usedFor
+   * Find a price_set_id associated with the given table, id and usedFor
    * Used For value for events:1, contribution:2, membership:3
    *
    * @param string $entityTable
@@ -624,7 +622,7 @@ WHERE  id = %1";
    */
   public static function getOnlyPriceFieldID(array $priceSet) {
     if (count($priceSet['fields']) > 1) {
-      throw new CRM_Core_Exception(ts('expected only one price field to be in priceset but multiple are present'));
+      throw new CRM_Core_Exception(ts('expected only one price field to be in price set but multiple are present'));
     }
     return (int) implode('_', array_keys($priceSet['fields']));
   }
@@ -640,7 +638,7 @@ WHERE  id = %1";
   public static function getOnlyPriceFieldValueID(array $priceSet) {
     $priceFieldID = self::getOnlyPriceFieldID($priceSet);
     if (count($priceSet['fields'][$priceFieldID]['options']) > 1) {
-      throw new CRM_Core_Exception(ts('expected only one price field to be in priceset but multiple are present'));
+      throw new CRM_Core_Exception(ts('expected only one price field to be in price set but multiple are present'));
     }
     return (int) implode('_', array_keys($priceSet['fields'][$priceFieldID]['options']));
   }
@@ -666,7 +664,7 @@ WHERE  id = %1";
       $priceSetId = self::getFor($entityTable, $id);
     }
 
-    //check if priceset is is_config
+    //check if price set is is_config
     if (is_numeric($priceSetId)) {
       if (CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $priceSetId, 'is_quick_config') && $form->getVar('_name') != 'Participant') {
         $form->assign('quickConfig', 1);
@@ -714,16 +712,16 @@ WHERE  id = %1";
         //get option count info.
         $form->_priceSet['optionsCountTotal'] = self::getPricesetCount($priceSetId);
         if ($form->_priceSet['optionsCountTotal']) {
-          $optionsCountDeails = array();
+          $optionsCountDetails = array();
           if (!empty($form->_priceSet['fields'])) {
             foreach ($form->_priceSet['fields'] as $field) {
               foreach ($field['options'] as $option) {
                 $count = CRM_Utils_Array::value('count', $option, 0);
-                $optionsCountDeails['fields'][$field['id']]['options'][$option['id']] = $count;
+                $optionsCountDetails['fields'][$field['id']]['options'][$option['id']] = $count;
               }
             }
           }
-          $form->_priceSet['optionsCountDetails'] = $optionsCountDeails;
+          $form->_priceSet['optionsCountDetails'] = $optionsCountDetails;
         }
 
         //get option max value info.
@@ -769,6 +767,7 @@ WHERE  id = %1";
    * @param string $component
    *   This parameter appears to only be relevant to determining whether memberships should be auto-renewed.
    *   (and is effectively a boolean for 'is_membership' which could be calculated from the line items.)
+   * @param int $priceSetID
    */
   public static function processAmount($fields, &$params, &$lineItem, $component = '', $priceSetID = NULL) {
     // using price set
@@ -1190,7 +1189,7 @@ WHERE  id = %1";
       return $defaults;
     }
 
-    foreach ($form->_priceSet['fields'] as $key => $val) {
+    foreach ($form->_priceSet['fields'] as $val) {
       foreach ($val['options'] as $keys => $values) {
         // build price field index which is passed via URL
         // url format will be appended by "&price_5=11"
@@ -1744,7 +1743,7 @@ WHERE       ps.id = %1
   public static function getNonDeductibleAmountFromPriceSet($priceSetId, $lineItem) {
     $nonDeductibleAmount = 0;
     if (!empty($lineItem[$priceSetId])) {
-      foreach ($lineItem[$priceSetId] as $fieldId => $options) {
+      foreach ($lineItem[$priceSetId] as $options) {
         $nonDeductibleAmount += $options['non_deductible_amount'] * $options['qty'];
       }
     }

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -226,7 +226,7 @@ WHERE     cpf.price_set_id = %1";
   }
 
   /**
-   * Delete the price set.
+   * Delete the price set, including the fields.
    *
    * @param int $id
    *   Price Set id.
@@ -237,19 +237,6 @@ WHERE     cpf.price_set_id = %1";
    *
    */
   public static function deleteSet($id) {
-    // remove from all inactive forms
-    $usedBy = self::getUsedBy($id);
-    if (isset($usedBy['civicrm_event'])) {
-      foreach ($usedBy['civicrm_event'] as $eventId => $unused) {
-        $eventDAO = new CRM_Event_DAO_Event();
-        $eventDAO->id = $eventId;
-        $eventDAO->find();
-        while ($eventDAO->fetch()) {
-          self::removeFrom('civicrm_event', $eventDAO->id);
-        }
-      }
-    }
-
     // delete price fields
     $priceField = new CRM_Price_DAO_PriceField();
     $priceField->price_set_id = $id;

--- a/CRM/Price/Form/DeleteSet.php
+++ b/CRM/Price/Form/DeleteSet.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2017
- * $Id$
- *
  */
 
 /**

--- a/CRM/Price/Form/Option.php
+++ b/CRM/Price/Form/Option.php
@@ -115,8 +115,7 @@ class CRM_Price_Form_Option extends CRM_Core_Form {
   public function buildQuickForm() {
     if ($this->_action == CRM_Core_Action::UPDATE) {
       $finTypeId = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceFieldValue', $this->_oid, 'financial_type_id');
-      CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes($financialTypes, CRM_Core_Action::UPDATE);
-      if (!array_key_exists($finTypeId, $financialTypes)) {
+      if (!CRM_Financial_BAO_FinancialType::checkPermissionToEditFinancialType($finTypeId)) {
         CRM_Core_Error::fatal(ts("You do not have permission to access this page"));
       }
     }

--- a/CRM/Price/Page/Option.php
+++ b/CRM/Price/Page/Option.php
@@ -121,8 +121,13 @@ class CRM_Price_Page_Option extends CRM_Core_Page {
    * @return void
    */
   public function browse() {
-    $customOption = array();
-    CRM_Price_BAO_PriceFieldValue::getValues($this->_fid, $customOption);
+    $priceOptions = civicrm_api3('PriceFieldValue', 'get', array(
+        'price_field_id' => $this->_fid,
+         // Explicitly do not check permissions so we are not
+         // restricted by financial type, so we can change them.
+        'check_permissions' => FALSE,
+    ));
+    $customOption = $priceOptions['values'];
 
     // CRM-15378 - check if these price options are in an Event price set
     $isEvent = FALSE;
@@ -134,7 +139,6 @@ class CRM_Price_Page_Option extends CRM_Core_Page {
     }
 
     $config = CRM_Core_Config::singleton();
-    $financialType = CRM_Contribute_PseudoConstant::financialType();
     $taxRate = CRM_Core_PseudoConstant::getTaxRates();
     // display taxTerm for priceFields
     $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
@@ -153,7 +157,7 @@ class CRM_Price_Page_Option extends CRM_Core_Page {
         $customOption[$id]['tax_amount'] = $taxAmount['tax_amount'];
       }
       if (!empty($values['financial_type_id'])) {
-        $customOption[$id]['financial_type_id'] = $financialType[$values['financial_type_id']];
+        $customOption[$id]['financial_type_id'] = CRM_Contribute_PseudoConstant::financialType($values['financial_type_id']);
       }
       // update enable/disable links depending on price_field properties.
       if ($this->_isSetReserved) {

--- a/CRM/Price/Page/Set.php
+++ b/CRM/Price/Page/Set.php
@@ -143,7 +143,6 @@ class CRM_Price_Page_Set extends CRM_Core_Page {
       $this->preview($sid);
     }
     elseif ($action & CRM_Core_Action::COPY) {
-      $session = CRM_Core_Session::singleton();
       CRM_Core_Session::setStatus(ts('A copy of the price set has been created'), ts('Saved'), 'success');
       $this->copy();
     }
@@ -155,10 +154,8 @@ class CRM_Price_Page_Set extends CRM_Core_Page {
 
         if (empty($usedBy)) {
           // prompt to delete
-          $session = CRM_Core_Session::singleton();
-          $session->pushUserContext(CRM_Utils_System::url('civicrm/admin/price', 'action=browse'));
+          CRM_Core_Session::singleton()->pushUserContext(CRM_Utils_System::url('civicrm/admin/price', 'action=browse'));
           $controller = new CRM_Core_Controller_Simple('CRM_Price_Form_DeleteSet', 'Delete Price Set', NULL);
-          // $id = CRM_Utils_Request::retrieve('sid', 'Positive', $this, false, 0);
           $controller->set('sid', $sid);
           $controller->setEmbedded(TRUE);
           $controller->process();

--- a/CRM/Utils/Check/Component/PriceFields.php
+++ b/CRM/Utils/Check/Component/PriceFields.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2016                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2016
+ */
+class CRM_Utils_Check_Component_PriceFields extends CRM_Utils_Check_Component {
+
+  /**
+   * Display warning about invalid priceFields
+   *
+   */
+  public function checkPriceFields() {
+    $sql = "SELECT DISTINCT ps.title as ps_title, ps.id as ps_id, psf.label as psf_label
+      FROM civicrm_price_set ps
+      INNER JOIN civicrm_price_field psf ON psf.price_set_id = ps.id
+      INNER JOIN civicrm_price_field_value pfv ON pfv.price_field_id = psf.id
+      LEFT JOIN civicrm_financial_type cft ON cft.id = pfv.financial_type_id
+      WHERE cft.id IS NULL OR cft.is_active = 0";
+    $dao = CRM_Core_DAO::executeQuery($sql);
+    $count = 0;
+    $html = '';
+    $messages = array();
+    while ($dao->fetch()) {
+      $count++;
+      $url = CRM_Utils_System::url('civicrm/admin/price/field', array(
+        'reset' => 1,
+        'action' => 'browse',
+        'sid' => $dao->ps_id));
+      $html .= "<tr><td>$dao->ps_title</td><td>$dao->psf_label</td><td><a href='$url'>View Price Set Fields</a></td></tr>";
+    }
+    if ($count > 0) {
+      $msg = "<p>the following Price Set Fields use disabled or invalid financial types and need to be fixed if they are to still be used.<p>
+          <p><table><thead><tr><th>Price Set</th><th>Price Set Field</th><th>Action Link</th>
+          </tr></thead><tbody>
+          $html
+          </tbody></table></p>";
+      $messages[] = new CRM_Utils_Check_Message(
+        __FUNCTION__,
+       ts($msg),
+       ts('Invalid Price Fields'),
+       \Psr\Log\LogLevel::WARNING,
+       'fa-lock'
+      );
+    }
+    return $messages;
+  }
+
+}

--- a/api/v3/PriceSet.php
+++ b/api/v3/PriceSet.php
@@ -91,9 +91,11 @@ function civicrm_api3_price_set_get($params) {
     return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
   }
   $result = _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params, FALSE);
-  // Fetch associated entities
-  foreach ($result as &$item) {
-    $item['entity'] = CRM_Price_BAO_PriceSet::getUsedBy($item['id'], 'entity');
+  // Fetch associated entities if the return has not been previously limited.
+  if (!isset($params['return'])) {
+    foreach ($result as &$item) {
+      $item['entity'] = CRM_Price_BAO_PriceSet::getUsedBy($item['id'], 'entity');
+    }
   }
   return civicrm_api3_create_success($result, $params);
 }


### PR DESCRIPTION
I pulled in a portion of @seamuslee001 PR for CRM-19517 - ie the part with the component check & making it editable. I made some changes to it
- added a distinct into the component query
- used the api rather than changing the BAO function. Ideally we would add a unit test to the api to enforce respect for 'check_permissions'
- altered the edit form to load - I was still hitting a permission error there.

I didn't pull in all parts because I felt these changes stood alone and could go in without the rest. I had reservations about some of the other part I looked at because I saw the contribution forms were using a shared process to add price fields to the form & the event fields were using different methods & I felt they really needed to be consolidated.

This PR contains fix in a related area of code - basically tidy up around the getUsedFor function to 
- extract the chunks of code within the function  & add comments
- Remove call to the (sometimes slow) getUserFor from DeleteSet as delete set is only called in one place, which is right after the same call has been checked
- only call getUsedFor from the api if 'return' has not been set. This fixes the immediate issue - ie. the contribution view page which calls that api with 'return' and can hit slowness

---

 * [CRM-19517: Show price field Options that use disabled Financial Types so they can be edited. ](https://issues.civicrm.org/jira/browse/CRM-19517)
 * [CRM-19953: Performance issues on price set retrieval](https://issues.civicrm.org/jira/browse/CRM-19953)