### PR TITLE
CRM-19918: Price field 'Active on' date ignored in Edit Event Registration > 'Change Selections'

### DIFF
--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -471,17 +471,18 @@ WHERE     cpf.price_set_id = %1";
     $select = 'SELECT ' . implode(',', $priceFields);
     $from = ' FROM civicrm_price_field';
 
-    $params = array();
-    $params[1] = array($setID, 'Integer');
-    $where = '
+    $params = array(
+      1 => array($setID, 'Integer'),
+    );
+    $currentTime = date('YmdHis');
+    $where = "
 WHERE price_set_id = %1
 AND is_active = 1
-';
+AND ( active_on IS NULL OR active_on <= {$currentTime} )
+";
     $dateSelect = '';
     if ($validOnly) {
-      $currentTime = date('YmdHis');
       $dateSelect = "
-AND ( active_on IS NULL OR active_on <= {$currentTime} )
 AND ( expire_on IS NULL OR expire_on >= {$currentTime} )
 ";
     }


### PR DESCRIPTION
* [CRM-19918: Price field "Active on" date ignored in Edit Event Registration \> "Change Selections"](https://issues.civicrm.org/jira/browse/CRM-19918)