### PR TITLE
CRM-19956: Fix case getlist api with 'id' and 'case_id' param

### DIFF
--- a/api/v3/Case.php
+++ b/api/v3/Case.php
@@ -453,6 +453,11 @@ function _civicrm_api3_case_format_params(&$params) {
 function civicrm_api3_case_getList($params) {
   require_once 'api/v3/Generic/Getlist.php';
   require_once 'api/v3/CaseContact.php';
+  //CRM:19956 - Assign case_id param if both id and case_id is passed to retrieve the case
+  if (!empty($params['id']) && !empty($params['params']) && !empty($params['params']['case_id'])) {
+    $params['params']['case_id'] = array('IN' => $params['id']);
+    unset($params['id']);
+  }
   $params['id_field'] = 'case_id';
   $params['label_field'] = $params['search_field'] = 'contact_id.sort_name';
   $params['description_field'] = array(
@@ -463,6 +468,7 @@ function civicrm_api3_case_getList($params) {
     'case_id.start_date',
   );
   $apiRequest = array(
+    'version' => 3,
     'entity' => 'CaseContact',
     'action' => 'getlist',
     'params' => $params,

--- a/tests/phpunit/api/v3/CaseTest.php
+++ b/tests/phpunit/api/v3/CaseTest.php
@@ -97,6 +97,38 @@ class api_v3_CaseTest extends CiviCaseTestCase {
   }
 
   /**
+   * Test Getlist with id and case_id
+   */
+  public function testCaseGetListById() {
+    $params = $this->_params;
+    $params['contact_id'] = $this->individualCreate();
+
+    //Create 3 sample Cases.
+    $case1 = $this->callAPISuccess('case', 'create', $params);
+    $params['subject'] = 'Test Case 2';
+    $case2 = $this->callAPISuccess('case', 'create', $params);
+    $params['subject'] = 'Test Case 3';
+    $case3 = $this->callAPISuccess('case', 'create', $params);
+
+    $getParams = array(
+      'id' => array($case1['id']),
+      'extra' => array('contact_id'),
+      'params' => array(
+        'version' => 3,
+        'case_id' => array('!=' => $case2['id']),
+        'case_id.is_deleted' => 0,
+        'case_id.status_id' => array('!=' => "Closed"),
+        'case_id.end_date' => array('IS NULL' => 1),
+      ),
+    );
+    $result = $this->callAPISuccess('case', 'getlist', $getParams);
+
+    //Only 1 case should be returned.
+    $this->assertEquals(count($result['values']), 1);
+    $this->assertEquals($result['values'][0]['id'], $case1['id']);
+  }
+
+  /**
    * Test create function with valid parameters.
    */
   public function testCaseCreate() {


### PR DESCRIPTION
With converting case autocomplete field to EntityRef, this now uses `id => val` [to retrieve the case value](https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/Form/Renderer.php#L244) when it is set by default. As we have a special handling for case getlist to use `case_contact` api, modifying the id to use `case_id` param.

---

 * [CRM-19956: Moving\/Copying activities between Cases](https://issues.civicrm.org/jira/browse/CRM-19956)