### PR TITLE
CRM-19960 Hide page title when is supposed to be removed

### DIFF
--- a/js/crm.drupal.js
+++ b/js/crm.drupal.js
@@ -10,5 +10,13 @@ CRM.$(function($) {
         // D7 hack, restore toolbar position (CRM-15341)
         $('#toolbar').css('z-index', '');
       }
-    });
+    })
+   // d8 Hack to hide title when it should be (CRM-19960)
+   .ready(function() {
+     var pageTitle = $('.page-title');
+     var title = $('.page-title').text();
+     if ('<span id="crm-remove-title" style="display:none">CiviCRM</span>' == title) {
+       pageTitle.hide();
+     }
+   });
 });


### PR DESCRIPTION
ping @jackrabbithanna @VasanthaKaje

---

 * [CRM-19960: Drupal 8 Standard Page title does not immediately disappear on contact record screen](https://issues.civicrm.org/jira/browse/CRM-19960)