### PR TITLE
CRM-19663: A scheduled reminder set to use an absolute date does not allow repeats

### DIFF
--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -492,7 +492,6 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
 
     if ($absoluteDate = CRM_Utils_Array::value('absolute_date', $params)) {
       $params['absolute_date'] = CRM_Utils_Date::processDate($absoluteDate);
-      $params['is_repeat'] = 0;
       foreach ($moreKeys as $mkey) {
         $params[$mkey] = 'null';
       }

--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -492,15 +492,12 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
 
     if ($absoluteDate = CRM_Utils_Array::value('absolute_date', $params)) {
       $params['absolute_date'] = CRM_Utils_Date::processDate($absoluteDate);
-      foreach ($moreKeys as $mkey) {
-        $params[$mkey] = 'null';
-      }
     }
     else {
       $params['absolute_date'] = 'null';
-      foreach ($moreKeys as $mkey) {
-        $params[$mkey] = CRM_Utils_Array::value($mkey, $values);
-      }
+    }
+    foreach ($moreKeys as $mkey) {
+      $params[$mkey] = CRM_Utils_Array::value($mkey, $values);
     }
 
     $params['body_text'] = CRM_Utils_Array::value('text_message', $values);

--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -497,6 +497,10 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
       $params['absolute_date'] = 'null';
     }
     foreach ($moreKeys as $mkey) {
+      if ($params['absolute_date'] != 'null' && CRM_Utils_String::startsWith($mkey, 'start_action')) {
+        $params[$mkey] = 'null';
+        continue;
+      }
       $params[$mkey] = CRM_Utils_Array::value($mkey, $values);
     }
 


### PR DESCRIPTION
* [CRM-19663: A scheduled reminder set to use an absolute date does not allow repeats](https://issues.civicrm.org/jira/browse/CRM-19663)