### PR TITLE
CRM-19963 - Use translated processor name for Paypal in all comparisons

### DIFF
--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -109,15 +109,15 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
    *   Should form building stop at this point?
    */
   public function buildForm(&$form) {
-    if ($this->_processorName == 'PayPal Express' || $this->_processorName == 'PayPal Pro') {
+    if ($this->supportsPreApproval()) {
       $this->addPaypalExpressCode($form);
-      if ($this->_processorName == 'PayPal Express') {
+      if ($this->_processorName == ts('PayPal Express')) {
         CRM_Core_Region::instance('billing-block-post')->add(array(
           'template' => 'CRM/Financial/Form/PaypalExpress.tpl',
           'name' => 'paypal_express',
         ));
       }
-      if ($this->_processorName == 'PayPal Pro') {
+      if ($this->_processorName == ts('PayPal Pro')) {
         CRM_Core_Region::instance('billing-block-pre')->add(array(
           'template' => 'CRM/Financial/Form/PaypalPro.tpl',
         ));


### PR DESCRIPTION
I guess a better would idea would be not to use a translatable string as identifier, but this is a bigger change and I was not sure of the consequences. This small patch makes sure PayPal works in all languages (problem noticed in German).

---

 * [CRM-19963: Paypal Express not working in German](https://issues.civicrm.org/jira/browse/CRM-19963)