### PR TITLE
CRM-19967 contact query docs

### DIFF
--- a/CRM/Admin/Form/Setting/Search.php
+++ b/CRM/Admin/Form/Setting/Search.php
@@ -49,7 +49,7 @@ class CRM_Admin_Form_Setting_Search extends CRM_Admin_Form_Setting {
     'includeOrderByClause' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
     'smartGroupCacheTimeout' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
     'defaultSearchProfileID' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
-    'searchPrimaryEmailOnly' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
+    'searchPrimaryLocTypes' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
   );
 
   /**

--- a/CRM/Admin/Form/Setting/Search.php
+++ b/CRM/Admin/Form/Setting/Search.php
@@ -49,6 +49,7 @@ class CRM_Admin_Form_Setting_Search extends CRM_Admin_Form_Setting {
     'includeOrderByClause' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
     'smartGroupCacheTimeout' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
     'defaultSearchProfileID' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
+    'searchPrimaryEmailOnly' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
   );
 
   /**

--- a/CRM/Admin/Form/Setting/Search.php
+++ b/CRM/Admin/Form/Setting/Search.php
@@ -49,7 +49,7 @@ class CRM_Admin_Form_Setting_Search extends CRM_Admin_Form_Setting {
     'includeOrderByClause' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
     'smartGroupCacheTimeout' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
     'defaultSearchProfileID' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
-    'searchPrimaryLocTypes' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
+    'searchPrimaryDetailsOnly' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
   );
 
   /**

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2519,16 +2519,23 @@ class CRM_Contact_BAO_Query {
    * Create the from clause.
    *
    * @param array $tables
-   *   Tables that need to be included in this from clause.
-   *                      if null, return mimimal from clause (i.e. civicrm_contact)
+   *   Tables that need to be included in this from clause. If null,
+   *   return mimimal from clause (i.e. civicrm_contact).
    * @param array $inner
    *   Tables that should be inner-joined.
    * @param array $right
    *   Tables that should be right-joined.
-   *
    * @param bool $primaryLocation
+   *   Search on primary location. See note below.
    * @param int $mode
+   *   Determines search mode based on bitwise MODE_* constants.
    * @param string|NULL $apiEntity
+   *   Determines search mode based on entity by string.
+   *
+   * The $primaryLocation flag only seems to be used when
+   * locationType() has been called. This may be a search option
+   * exposed, or perhaps it's a "search all details" approach which
+   * predates decoupling of location types and primary fields?
    *
    * @return string
    *   the from clause

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -514,7 +514,7 @@ class CRM_Contact_BAO_Query {
       CRM_Financial_BAO_FinancialType::buildPermissionedClause($this->_whereClause, $component);
     }
 
-    $this->_fromClause = self::fromClause($this->_tables, NULL, NULL, $this->_primaryLocation, $this->_mode);
+    $this->_fromClause = self::fromClause($this->_tables, NULL, NULL, $this->_primaryLocation, $this->_mode, $apiEntity);
     $this->_simpleFromClause = self::fromClause($this->_whereTables, NULL, NULL, $this->_primaryLocation, $this->_mode);
 
     $this->openedSearchPanes(TRUE);
@@ -2528,11 +2528,12 @@ class CRM_Contact_BAO_Query {
    *
    * @param bool $primaryLocation
    * @param int $mode
+   * @param string|NULL $apiEntity
    *
    * @return string
    *   the from clause
    */
-  public static function fromClause(&$tables, $inner = NULL, $right = NULL, $primaryLocation = TRUE, $mode = 1) {
+  public static function fromClause(&$tables, $inner = NULL, $right = NULL, $primaryLocation = TRUE, $mode = 1, $apiEntity = NULL) {
 
     $from = ' FROM civicrm_contact contact_a';
     if (empty($tables)) {
@@ -2639,7 +2640,11 @@ class CRM_Contact_BAO_Query {
           continue;
 
         case 'civicrm_email':
-          $from .= " $side JOIN civicrm_email ON (contact_a.id = civicrm_email.contact_id AND civicrm_email.is_primary = 1) ";
+          $searchPrimary = '';
+          if (Civi::settings()->get('searchPrimaryEmailOnly') || $apiEntity) {
+            $searchPrimary = " AND civicrm_email.is_primary = 1";
+          }
+          $from .= " $side JOIN civicrm_email ON (contact_a.id = civicrm_email.contact_id) {$searchPrimary}";
           continue;
 
         case 'civicrm_im':

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -39,22 +39,30 @@ class CRM_Contact_BAO_Query {
   /**
    * The various search modes.
    *
+   * As of February 2017, entries not present for 4, 32, 64, 1024.
+   *
+   * MODE_ALL is set to 17407, which can't be composed of available
+   * constants and excludes MODE_CASE, MODE_ACTIVITY, MODE_CAMPAIGN.
+   *
    * @var int
    */
   const
     NO_RETURN_PROPERTIES = 'CRM_Contact_BAO_Query::NO_RETURN_PROPERTIES',
     MODE_CONTACTS = 1,
     MODE_CONTRIBUTE = 2,
+    // There is no 4,
     MODE_MEMBER = 8,
     MODE_EVENT = 16,
+    // No 32, no 64.
     MODE_GRANT = 128,
     MODE_PLEDGEBANK = 256,
     MODE_PLEDGE = 512,
+    // There is no 1024,
     MODE_CASE = 2048,
-    MODE_ALL = 17407,
     MODE_ACTIVITY = 4096,
     MODE_CAMPAIGN = 8192,
-    MODE_MAILING = 16384;
+    MODE_MAILING = 16384,
+    MODE_ALL = 17407;
 
   /**
    * The default set of return properties.
@@ -82,6 +90,7 @@ class CRM_Contact_BAO_Query {
   public $_paramLookup;
 
   public $_sort;
+
   /**
    * The set of output params
    *
@@ -98,42 +107,42 @@ class CRM_Contact_BAO_Query {
 
   /**
    * The name of the elements that are in the select clause
-   * used to extract the values
+   * used to extract the values.
    *
    * @var array
    */
   public $_element;
 
   /**
-   * The tables involved in the query
+   * The tables involved in the query.
    *
    * @var array
    */
   public $_tables;
 
   /**
-   * The table involved in the where clause
+   * The table involved in the where clause.
    *
    * @var array
    */
   public $_whereTables;
 
   /**
-   * The where clause
+   * Array of WHERE clause components.
    *
    * @var array
    */
   public $_where;
 
   /**
-   * The where string
+   * The WHERE clause as a string.
    *
    * @var string
    */
   public $_whereClause;
 
   /**
-   * Additional permission Where Clause
+   * Additional WHERE clause for permissions.
    *
    * @var string
    */
@@ -2484,9 +2493,14 @@ class CRM_Contact_BAO_Query {
   }
 
   /**
-   * Where tables is sometimes used to create the from clause, but, not reliably, set this AND set tables
-   * It's unclear the intent - there is a 'simpleFrom' clause which takes whereTables into account & a fromClause which doesn't
-   * logic may have eroded
+   * Sometimes used to create the from clause, but, not reliably, set
+   * this AND set tables.
+   *
+   * It's unclear the intent - there is a 'simpleFrom' clause which
+   * takes whereTables into account & a fromClause which doesn't.
+   *
+   * logic may have eroded?
+   *
    * @return array
    */
   public function whereTables() {

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2624,31 +2624,29 @@ class CRM_Contact_BAO_Query {
         }
         continue;
       }
+      $searchPrimary = '';
+      if (Civi::settings()->get('searchPrimaryLocTypes') || $apiEntity) {
+        $searchPrimary = " AND {$name}.is_primary = 1";
+      }
       switch ($name) {
         case 'civicrm_address':
-          if ($primaryLocation) {
-            $from .= " $side JOIN civicrm_address ON ( contact_a.id = civicrm_address.contact_id AND civicrm_address.is_primary = 1 )";
+          //CRM-14263 further handling of address joins further down...
+          if (!$primaryLocation) {
+            $searchPrimary = '';
           }
-          else {
-            //CRM-14263 further handling of address joins further down...
-            $from .= " $side JOIN civicrm_address ON ( contact_a.id = civicrm_address.contact_id ) ";
-          }
+          $from .= " $side JOIN civicrm_address ON ( contact_a.id = civicrm_address.contact_id {$searchPrimary} )";
           continue;
 
         case 'civicrm_phone':
-          $from .= " $side JOIN civicrm_phone ON (contact_a.id = civicrm_phone.contact_id AND civicrm_phone.is_primary = 1) ";
+          $from .= " $side JOIN civicrm_phone ON (contact_a.id = civicrm_phone.contact_id {$searchPrimary}) ";
           continue;
 
         case 'civicrm_email':
-          $searchPrimary = '';
-          if (Civi::settings()->get('searchPrimaryEmailOnly') || $apiEntity) {
-            $searchPrimary = " AND civicrm_email.is_primary = 1";
-          }
-          $from .= " $side JOIN civicrm_email ON (contact_a.id = civicrm_email.contact_id) {$searchPrimary}";
+          $from .= " $side JOIN civicrm_email ON (contact_a.id = civicrm_email.contact_id {$searchPrimary})";
           continue;
 
         case 'civicrm_im':
-          $from .= " $side JOIN civicrm_im ON (contact_a.id = civicrm_im.contact_id AND civicrm_im.is_primary = 1) ";
+          $from .= " $side JOIN civicrm_im ON (contact_a.id = civicrm_im.contact_id {$searchPrimary}) ";
           continue;
 
         case 'im_provider':
@@ -2658,7 +2656,7 @@ class CRM_Contact_BAO_Query {
           continue;
 
         case 'civicrm_openid':
-          $from .= " $side JOIN civicrm_openid ON ( civicrm_openid.contact_id = contact_a.id AND civicrm_openid.is_primary = 1 )";
+          $from .= " $side JOIN civicrm_openid ON ( civicrm_openid.contact_id = contact_a.id {$searchPrimary} )";
           continue;
 
         case 'civicrm_worldregion':

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2625,7 +2625,7 @@ class CRM_Contact_BAO_Query {
         continue;
       }
       $searchPrimary = '';
-      if (Civi::settings()->get('searchPrimaryLocTypes') || $apiEntity) {
+      if (Civi::settings()->get('searchPrimaryDetailsOnly') || $apiEntity) {
         $searchPrimary = " AND {$name}.is_primary = 1";
       }
       switch ($name) {

--- a/settings/Search.setting.php
+++ b/settings/Search.setting.php
@@ -197,10 +197,10 @@ return array(
     'description' => 'If set, this will be the default profile used for contact search.',
     'help_text' => NULL,
   ),
-  'searchPrimaryLocTypes' => array(
+  'searchPrimaryDetailsOnly' => array(
     'group_name' => 'Search Preferences',
     'group' => 'Search Preferences',
-    'name' => 'searchPrimaryLocTypes',
+    'name' => 'searchPrimaryDetailsOnly',
     'type' => 'Boolean',
     'quick_form_type' => 'YesNo',
     'default' => 1,

--- a/settings/Search.setting.php
+++ b/settings/Search.setting.php
@@ -205,10 +205,10 @@ return array(
     'quick_form_type' => 'YesNo',
     'default' => 1,
     'add' => '4.7',
-    'title' => 'Search Primary Location Types Only',
+    'title' => 'Search Primary Details Only',
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => 'If enabled, only primary location types(email, phone, etc.) will be included in Basic and Advanced Search results. Disabling this feature will allow users to search by any location type values attached to the contact.',
+    'description' => 'If enabled, only primary details (eg contact\'s primary email, phone, etc) will be included in Basic and Advanced Search results. Disabling this feature will allow users to match contacts using any email, phone etc detail.',
     'help_text' => NULL,
   ),
 );

--- a/settings/Search.setting.php
+++ b/settings/Search.setting.php
@@ -197,4 +197,18 @@ return array(
     'description' => 'If set, this will be the default profile used for contact search.',
     'help_text' => NULL,
   ),
+  'searchPrimaryEmailOnly' => array(
+    'group_name' => 'Search Preferences',
+    'group' => 'Search Preferences',
+    'name' => 'searchPrimaryEmailOnly',
+    'type' => 'Boolean',
+    'quick_form_type' => 'YesNo',
+    'default' => 1,
+    'add' => '4.7',
+    'title' => 'Search Primary Email Only',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => 'If enabled, only primary email address will be included when users search by Email. Secondary emails will only be displayed in Full Text search results. Disabling this feature will allow searching by any emails attached to the contact.',
+    'help_text' => NULL,
+  ),
 );

--- a/settings/Search.setting.php
+++ b/settings/Search.setting.php
@@ -197,18 +197,18 @@ return array(
     'description' => 'If set, this will be the default profile used for contact search.',
     'help_text' => NULL,
   ),
-  'searchPrimaryEmailOnly' => array(
+  'searchPrimaryLocTypes' => array(
     'group_name' => 'Search Preferences',
     'group' => 'Search Preferences',
-    'name' => 'searchPrimaryEmailOnly',
+    'name' => 'searchPrimaryLocTypes',
     'type' => 'Boolean',
     'quick_form_type' => 'YesNo',
     'default' => 1,
     'add' => '4.7',
-    'title' => 'Search Primary Email Only',
+    'title' => 'Search Primary Location Types Only',
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => 'If enabled, only primary email address will be included when users search by Email. Secondary emails will only be displayed in Full Text search results. Disabling this feature will allow searching by any emails attached to the contact.',
+    'description' => 'If enabled, only primary location types(email, phone, etc.) will be included in Basic and Advanced Search results. Disabling this feature will allow users to search by any location type values attached to the contact.',
     'help_text' => NULL,
   ),
 );

--- a/templates/CRM/Admin/Form/Setting/Search.tpl
+++ b/templates/CRM/Admin/Form/Setting/Search.tpl
@@ -37,6 +37,12 @@
             <td>{$form.includeEmailInName.html}<br />
                 <span class="description">{ts}If enabled, email addresses are automatically included when users search by Name. Disabling this feature will speed up search significantly for larger databases, but users will need to use the Email search fields (from Advanced Search, Search Builder, or Profiles) to find contacts by email address.{/ts}</span></td>
         </tr>
+        <tr class="crm-search-setting-form-block-searchPrimaryEmailOnly">
+            <td class="label">{$form.searchPrimaryEmailOnly.label}</td>
+            <td>{$form.searchPrimaryEmailOnly.html}<br />
+                <span class="description">{ts}If enabled, only primary email address will be included when users search by Email. Secondary emails will only be included in Full Text search results. Disabling this feature will allow searching by any emails attached to the contact.{/ts}</span>
+            </td>
+        </tr>
         <tr  class="crm-search-setting-form-block-includeNickNameInName">
             <td class="label">{$form.includeNickNameInName.label}</td>
             <td>{$form.includeNickNameInName.html}<br />

--- a/templates/CRM/Admin/Form/Setting/Search.tpl
+++ b/templates/CRM/Admin/Form/Setting/Search.tpl
@@ -37,10 +37,10 @@
             <td>{$form.includeEmailInName.html}<br />
                 <span class="description">{ts}If enabled, email addresses are automatically included when users search by Name. Disabling this feature will speed up search significantly for larger databases, but users will need to use the Email search fields (from Advanced Search, Search Builder, or Profiles) to find contacts by email address.{/ts}</span></td>
         </tr>
-        <tr class="crm-search-setting-form-block-searchPrimaryEmailOnly">
-            <td class="label">{$form.searchPrimaryEmailOnly.label}</td>
-            <td>{$form.searchPrimaryEmailOnly.html}<br />
-                <span class="description">{ts}If enabled, only primary email address will be included when users search by Email. Secondary emails will only be included in Full Text search results. Disabling this feature will allow searching by any emails attached to the contact.{/ts}</span>
+        <tr class="crm-search-setting-form-block-searchPrimaryLocTypes">
+            <td class="label">{$form.searchPrimaryLocTypes.label}</td>
+            <td>{$form.searchPrimaryLocTypes.html}<br />
+                <span class="description">{ts}If enabled, only primary location types(email, phone, etc.) will be included in Basic and Advanced Search results. Disabling this feature will allow users to search by any location type values attached to the contact.{/ts}</span>
             </td>
         </tr>
         <tr  class="crm-search-setting-form-block-includeNickNameInName">

--- a/templates/CRM/Admin/Form/Setting/Search.tpl
+++ b/templates/CRM/Admin/Form/Setting/Search.tpl
@@ -37,9 +37,9 @@
             <td>{$form.includeEmailInName.html}<br />
                 <span class="description">{ts}If enabled, email addresses are automatically included when users search by Name. Disabling this feature will speed up search significantly for larger databases, but users will need to use the Email search fields (from Advanced Search, Search Builder, or Profiles) to find contacts by email address.{/ts}</span></td>
         </tr>
-        <tr class="crm-search-setting-form-block-searchPrimaryLocTypes">
-            <td class="label">{$form.searchPrimaryLocTypes.label}</td>
-            <td>{$form.searchPrimaryLocTypes.html}<br />
+        <tr class="crm-search-setting-form-block-searchPrimaryDetailsOnly">
+            <td class="label">{$form.searchPrimaryDetailsOnly.label}</td>
+            <td>{$form.searchPrimaryDetailsOnly.html}<br />
                 <span class="description">{ts}If enabled, only primary location types(email, phone, etc.) will be included in Basic and Advanced Search results. Disabling this feature will allow users to search by any location type values attached to the contact.{/ts}</span>
             </td>
         </tr>

--- a/templates/CRM/Admin/Form/Setting/Search.tpl
+++ b/templates/CRM/Admin/Form/Setting/Search.tpl
@@ -40,7 +40,7 @@
         <tr class="crm-search-setting-form-block-searchPrimaryDetailsOnly">
             <td class="label">{$form.searchPrimaryDetailsOnly.label}</td>
             <td>{$form.searchPrimaryDetailsOnly.html}<br />
-                <span class="description">{ts}If enabled, only primary location types(email, phone, etc.) will be included in Basic and Advanced Search results. Disabling this feature will allow users to search by any location type values attached to the contact.{/ts}</span>
+                <span class="description">{ts}If enabled, only primary details (eg contact's primary email, phone, etc) will be included in Basic and Advanced Search results. Disabling this feature will allow users to match contacts using any email, phone etc detail.{/ts}</span>
             </td>
         </tr>
         <tr  class="crm-search-setting-form-block-includeNickNameInName">

--- a/tests/phpunit/CRM/Contact/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTest.php
@@ -152,7 +152,7 @@ class CRM_Contact_BAO_QueryTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test searchPrimaryLocTypes setting.
+   * Test searchPrimaryDetailsOnly setting.
    */
   public function testSearchPrimaryLocTypes() {
     $contactID = $this->individualCreate();
@@ -168,7 +168,7 @@ class CRM_Contact_BAO_QueryTest extends CiviUnitTestCase {
     $this->callAPISuccess('email', 'create', $params);
 
     foreach (array(0, 1) as $searchPrimary) {
-      Civi::settings()->set('searchPrimaryLocTypes', $searchPrimary);
+      Civi::settings()->set('searchPrimaryDetailsOnly', $searchPrimary);
 
       $params = array(
         0 => array(

--- a/tests/phpunit/CRM/Contact/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTest.php
@@ -152,9 +152,9 @@ class CRM_Contact_BAO_QueryTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test searchByPrimaryEmailOnly setting.
+   * Test searchPrimaryLocTypes setting.
    */
-  public function testSearchByPrimaryEmailOnly() {
+  public function testSearchPrimaryLocTypes() {
     $contactID = $this->individualCreate();
     $params = array(
       'contact_id' => $contactID,
@@ -168,7 +168,7 @@ class CRM_Contact_BAO_QueryTest extends CiviUnitTestCase {
     $this->callAPISuccess('email', 'create', $params);
 
     foreach (array(0, 1) as $searchPrimary) {
-      Civi::settings()->set('searchPrimaryEmailOnly', $searchPrimary);
+      Civi::settings()->set('searchPrimaryLocTypes', $searchPrimary);
 
       $params = array(
         0 => array(


### PR DESCRIPTION
DO NOT MERGE until CRM-4287 is merged please. (How can I better submit / flag a PR like this? Maybe I should just PR it without the changes from CRM-4287 at all, but this builds on that work.)

---

 * [CRM-19967: Contact query inline docs improvements from CRM-4287](https://issues.civicrm.org/jira/browse/CRM-19967)
 * [CRM-4287: Contact search for email address \(& other details\) shows only primary detail matches as results](https://issues.civicrm.org/jira/browse/CRM-4287)