### PR TITLE
CRM-19968 SQL tweaks to make it more likely that reverting to single language w…

### DIFF
--- a/CRM/Core/I18n/Schema.php
+++ b/CRM/Core/I18n/Schema.php
@@ -188,18 +188,20 @@ class CRM_Core_I18n_Schema {
       }
     }
 
+    $dao = new CRM_Core_DAO();
     // deal with columns
     foreach ($columns[$table] as $column => $type) {
-      $queries[] = "ALTER TABLE {$table} ADD {$column} {$type}";
-      $queries[] = "UPDATE {$table} SET {$column} = {$column}_{$retain}";
+      $queries[] = "ALTER TABLE {$table} CHANGE `{$column}_{$retain}` `{$column}` {$type}";
       foreach ($locales as $loc) {
-        $dropQueries[] = "ALTER TABLE {$table} DROP {$column}_{$loc}";
+        if (strcmp($loc,$retain) !== 0) {
+          $dropQueries[] = "ALTER TABLE {$table} DROP {$column}_{$loc}";
+        }
       }
     }
 
     // drop views
     foreach ($locales as $loc) {
-      $queries[] = "DROP VIEW {$table}_{$loc}";
+      $queries[] = "DROP VIEW IF EXISTS {$table}_{$loc}";
     }
 
     // add original indices

--- a/CRM/Core/I18n/Schema.php
+++ b/CRM/Core/I18n/Schema.php
@@ -193,7 +193,7 @@ class CRM_Core_I18n_Schema {
     foreach ($columns[$table] as $column => $type) {
       $queries[] = "ALTER TABLE {$table} CHANGE `{$column}_{$retain}` `{$column}` {$type}";
       foreach ($locales as $loc) {
-        if (strcmp($loc,$retain) !== 0) {
+        if (strcmp($loc, $retain) !== 0) {
           $dropQueries[] = "ALTER TABLE {$table} DROP {$column}_{$loc}";
         }
       }


### PR DESCRIPTION
…ill actually work.
Disabling multiple languages is almost certain to fail on an existing reasonably well populated system due to row size constraints. This patch makes a couple of simple tweaks to the SQL queries so that it is much more likely to succeed!
1. Column is renamed instead of created and copied, as the copy often leads to a row size constraint (eg. in civicrm_event when you have some text in intro_text_lang).
2. Use DROP VIEW IF EXISTS instead of DROP VIEW (supported in mysql 5.1+). There is more support for IF EXISTS on other SQL functions in new versions of mysql but we can't use them if we're maintaining compatibility.