### PR TITLE
civicrm_webtest.install - Restore access to edit message templates and tags

### DIFF
--- a/tools/drupal/modules/civicrm_webtest/civicrm_webtest.install
+++ b/tools/drupal/modules/civicrm_webtest/civicrm_webtest.install
@@ -76,6 +76,7 @@ function civicrm_webtest_enable() {
    'edit pledges',
    'import contacts',
    'make online contributions',
+   'manage tags',
    'merge duplicate contacts',
    'profile create',
    'profile edit',

--- a/tools/drupal/modules/civicrm_webtest/civicrm_webtest.install
+++ b/tools/drupal/modules/civicrm_webtest/civicrm_webtest.install
@@ -69,6 +69,7 @@ function civicrm_webtest_enable() {
    'edit all events',
    'edit contributions',
    'edit event participants',
+   'edit message templates',
    // 'edit grants',
    'edit groups',
    'edit memberships',


### PR DESCRIPTION
This affects demo builds and (theoretically) other test systems.