### PR TITLE
CRM-19914 - civicrmHooks.php issues on windows

### DIFF
--- a/CRM/Utils/Hook/WordPress.php
+++ b/CRM/Utils/Hook/WordPress.php
@@ -179,7 +179,7 @@ class CRM_Utils_Hook_WordPress extends CRM_Utils_Hook {
         if (!empty($config->customPHPPathDir) &&
           file_exists("{$config->customPHPPathDir}/civicrmHooks.php")
         ) {
-          @include_once 'civicrmHooks.php';
+          @include_once "{$config->customPHPPathDir}/civicrmHooks.php";
         }
 
         // initialise with the pre-existing 'wordpress' prefix


### PR DESCRIPTION
The problem is that on Windows path might resolve differently, because of notation. Problem is that even if file exists it will not be included (silent error ignore) in specific cases (directory names).

---

 * [CRM-19914: civicrmHooks.php issues on windows](https://issues.civicrm.org/jira/browse/CRM-19914)