### PR TITLE
CRM-19970 - Too big amount saved despite error

### DIFF
--- a/CRM/Core/Payment/AuthorizeNet.php
+++ b/CRM/Core/Payment/AuthorizeNet.php
@@ -187,7 +187,8 @@ class CRM_Core_Payment_AuthorizeNet extends CRM_Core_Payment {
 
       case self::AUTH_ERROR:
         $params['payment_status_id'] = array_search('Failed', $contributionStatus);
-        break;
+        $errormsg = $response_fields[2] . ' ' . $response_fields[3];
+        return self::error($response_fields[1], $errormsg);
 
       case self::AUTH_DECLINED:
         $errormsg = $response_fields[2] . ' ' . $response_fields[3];


### PR DESCRIPTION
Steps to reproduce:
setup authorize.net payment
issue donation of huge amount (in my case $1,250,000 - one million)
response is error, yet contribution is saved as successful
Problem lies in how authorize net is handling error. It's simply marked as failed (and problably later marked as completed).
Response from auth.net API is: code=3, message=The transaction amount submitted was greater than the maximum amount allowed.

---

 * [CRM-19979](https://issues.civicrm.org/jira/browse/CRM-19979)

---

 * [CRM-19970: Authorize.net - too big amount saved successfully despite error](https://issues.civicrm.org/jira/browse/CRM-19970)