### PR TITLE
CRM-19896 - customTranslateFunction not mapped

### DIFF
--- a/CRM/Core/Config/MagicMerge.php
+++ b/CRM/Core/Config/MagicMerge.php
@@ -124,6 +124,7 @@ class CRM_Core_Config_MagicMerge {
       'backtrace' => array('setting'),
       'contact_default_language' => array('setting'),
       'countryLimit' => array('setting'),
+      'customTranslateFunction' => array('setting'),
       'dateInputFormat' => array('setting'),
       'dateformatDatetime' => array('setting'),
       'dateformatFull' => array('setting'),


### PR DESCRIPTION
`customTranslateFunction` is not defined in `getPropertyMap` method with `MagicMerge` class.
It causes Custom Translation Function to not be taken into consideration at all while translating strings.
Solution:
adding `customTranslateFunction' => array('setting'),` key to `getPropertyMap` array resolves the issue.

---

 * [CRM-19896: customTranslateFunction not mapped in MagicMerge](https://issues.civicrm.org/jira/browse/CRM-19896)