### PR TITLE
fix and test for CRM-19945

### DIFF
--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -605,6 +605,7 @@ function civicrm_api3_contribution_repeattransaction(&$params) {
     //  CRM-19873 call with test mode.
     $params['original_contribution_id'] = civicrm_api3('contribution', 'getvalue', array(
       'return' => 'id',
+      'contribution_status_id' => array('IN' => array('Completed')),
       'contribution_recur_id' => $params['contribution_recur_id'],
       'contribution_test' => CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_ContributionRecur', $params['contribution_recur_id'], 'is_test'),
       'options' => array('limit' => 1, 'sort' => 'id DESC'),

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -3217,7 +3217,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'minimum_fee' => 100,
     ));
     $contributionRecur = $this->callAPISuccess('contribution_recur', 'create', array_merge(array(
-      'contact_id' => $newContact['id'], 
+      'contact_id' => $newContact['id'],
       'installments' => '12',
       'frequency_interval' => '1',
       'amount' => '100',
@@ -3241,7 +3241,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'contact_id' => $newContact['id'],
       'contribution_recur_id' => $contributionRecur['id'],
       'financial_type_id' => "Member Dues",
-      'membership_type_id' => $membershipType['id'], 
+      'membership_type_id' => $membershipType['id'],
       'num_terms' => 1,
     ));
 

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -2094,6 +2094,42 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $this->assertEquals($contributionRecur['values'][1]['is_test'], $repeatedContribution['values'][2]['is_test']);
     $this->quickCleanUpFinancialEntities();
   }
+  /**
+   * CRM-19945 Tests repeattransaction is using a completed contribution for the template.
+   *  ( Tests membership is renewed after repeattransaction. )
+   */
+  public function testRepeatTransactionUsesCompleted() {
+    list($originalContribution, $membership) = $this->setUpAutoRenewMembership();
+
+    $this->callAPISuccess('contribution', 'create', array(
+          'contact_id' => $originalContribution['values'][1]['contact_id'],
+          'financial_type_id' => $originalContribution['values'][1]['financial_type_id'],
+          'total_amount' => $originalContribution['values'][1]['total_amount'],
+          'contribution_recur_id' => $originalContribution['values'][1]['contribution_recur_id'],
+          'contribution_status_id' => "Failed",
+    ));
+
+    $this->callAPISuccess('membership', 'create', array(
+       'id' => $membership['id'],
+       'end_date' => 'yesterday',
+       'status_id' => 4,
+    ));
+
+    $this->callAPISuccess('contribution', 'repeattransaction', array(
+       'contribution_recur_id' => $originalContribution['values'][1]['contribution_recur_id'],
+       'contribution_status_id' => 'Completed',
+       'trxn_id' => uniqid(),
+    ));
+
+    $membershipStatus = $this->callAPISuccess('membership', 'getvalue', array(
+      'id' => $membership['id'],
+      'return' => 'status_id',
+    ));
+
+    $this->assertEquals('1', $membershipStatus);
+    $this->quickCleanUpFinancialEntities();
+    $this->contactDelete($originalContribution['values'][1]['contact_id']);
+  }
 
   /**
    * CRM-16397 test appropriate action if total amount has changed for single line items.
@@ -3146,6 +3182,75 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     return $originalContribution;
   }
 
+  /**
+   * Set up a basic auto-renew membership for tests.
+   *
+   * @param array $generalParams
+   *   Parameters that can be merged into the recurring AND the contribution.
+   *
+   * @param array $recurParams
+   *   Parameters to merge into the recur only.
+   *
+   * @return array|int
+   */
+  protected function setUpAutoRenewMembership($generalParams = array(), $recurParams = array()) {
+    $newContact = $this->callAPISuccess('Contact', 'create', array(
+       'contact_type' => 'Individual',
+       'sort_name' => 'McTesterson, Testy',
+       'display_name' => 'Testy McTesterson',
+       'preferred_language' => 'en_US',
+       'preferred_mail_format' => 'Both',
+       'first_name' => 'Testy',
+       'last_name' => 'McTesterson',
+       'contact_is_deleted' => '0',
+       'email_id' => '4',
+       'email' => 'tmctesterson@example.com',
+       'on_hold' => '0',
+    ));
+    $membershipType = $this->callAPISuccess('MembershipType', 'create', array(
+      'domain_id' => "Default Domain Name",
+      'member_of_contact_id' => 1,
+      'financial_type_id' => "Member Dues",
+      'duration_unit' => "month",
+      'duration_interval' => 1,
+      'name' => "Standard Member",
+      'minimum_fee' => 100,
+    ));
+    $contributionRecur = $this->callAPISuccess('contribution_recur', 'create', array_merge(array(
+      'contact_id' => $newContact['id'], 
+      'installments' => '12',
+      'frequency_interval' => '1',
+      'amount' => '100',
+      'contribution_status_id' => 1,
+      'start_date' => '2012-01-01 00:00:00',
+      'currency' => 'USD',
+      'frequency_unit' => 'month',
+      'payment_processor_id' => $this->paymentProcessorID,
+    ), $generalParams, $recurParams));
+    $originalContribution = $this->callAPISuccess('contribution', 'create', array_merge(
+      $this->_params,
+      array(
+        'contact_id' => $newContact['id'],
+        'contribution_recur_id' => $contributionRecur['id'],
+        'financial_type_id' => "Member Dues",
+        'contribution_status_id' => 1,
+        'invoice_id' => uniqid(),
+      ), $generalParams)
+    );
+    $membership = $this->callAPISuccess('membership', 'create', array(
+      'contact_id' => $newContact['id'],
+      'contribution_recur_id' => $contributionRecur['id'],
+      'financial_type_id' => "Member Dues",
+      'membership_type_id' => $membershipType['id'], 
+      'num_terms' => 1,
+    ));
+
+    $this->callAPISuccess('MembershipPayment', 'create', array(
+        'contribution_id' => $originalContribution['id'],
+        'membership_id' => $membership['id'],
+    ));
+    return array($originalContribution, $membership);
+  }
   /**
    * Set up a repeat transaction.
    *


### PR DESCRIPTION
This makes sure we are always using a completed contribution as the template for a repeated contribution.   

If we don't do this, we run the risk of repeating a non-completed contribution, which results in a membership not renewing when it should.  

This also tests that a membership is renewed when repeattransaction is run.

---

 * [CRM-19945: api.contribute.repeattransaction fails to renew membership under certain conditions](https://issues.civicrm.org/jira/browse/CRM-19945)