### PR TITLE
CRM-19961 Make civicrm_sms_provider able to be domain specific

### DIFF
--- a/CRM/Core/DAO/AllCoreTables.data.php
+++ b/CRM/Core/DAO/AllCoreTables.data.php
@@ -24,7 +24,7 @@
 | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
 +--------------------------------------------------------------------+
 */
-// (GenCodeChecksum:fe1a575dafdc824e3ce8a7e0d7fc49bf)
+// (GenCodeChecksum:53f1cd5e913b2f82abfc7097127caafc)
 return array(
   'CRM_Core_DAO_AddressFormat' => array(
     'name' => 'AddressFormat',

--- a/CRM/SMS/BAO/Provider.php
+++ b/CRM/SMS/BAO/Provider.php
@@ -106,11 +106,6 @@ class CRM_SMS_BAO_Provider extends CRM_SMS_DAO_Provider {
    * @param int $providerId
    */
   public static function updateRecord($values, $providerId) {
-    $current_domain_id = CRM_Core_DAO::getFieldValue('CRM_SMS_DAO_Provider', $providerId, 'domain_id');
-    if (isset($current_domain_id) || is_null($current_domain_id)) {
-      $current_domain_id = CRM_Core_Config::domainID();
-    }
-    $values['domain_id'] = CRM_Utils_Array::value('domain_id', $values, $current_domain_id);
     $dao = new CRM_SMS_DAO_Provider();
     $dao->id = $providerId;
     if ($dao->find(TRUE)) {

--- a/CRM/SMS/BAO/Provider.php
+++ b/CRM/SMS/BAO/Provider.php
@@ -77,6 +77,7 @@ class CRM_SMS_BAO_Provider extends CRM_SMS_DAO_Provider {
       $select = implode(',', $selectArr);
       $dao->selectAdd($select);
     }
+    $dao->whereAdd("(domain_id = " . CRM_Core_Config::domainID() . " OR domain_id IS NULL)");
     $dao->orderBy($orderBy);
     $dao->find();
     while ($dao->fetch()) {
@@ -87,19 +88,29 @@ class CRM_SMS_BAO_Provider extends CRM_SMS_DAO_Provider {
   }
 
   /**
+   * Save a new record into the database
+   * @todo create a create function to do this work
    * @param $values
    */
   public static function saveRecord($values) {
+    $values['domain_id'] = CRM_Utils_Array::value('domain_id', $values, CRM_Core_Config::domainID());
     $dao = new CRM_SMS_DAO_Provider();
     $dao->copyValues($values);
     $dao->save();
   }
 
   /**
+   * Update an SMS provider in the database.
+   * @todo combine with saveRecord in a create function
    * @param $values
    * @param int $providerId
    */
   public static function updateRecord($values, $providerId) {
+    $current_domain_id = CRM_Core_DAO::getFieldValue('CRM_SMS_DAO_Provider', $providerId, 'domain_id');
+    if (isset($current_domain_id) || is_null($current_domain_id)) {
+      $current_domain_id = CRM_Core_Config::domainID();
+    }
+    $values['domain_id'] = CRM_Utils_Array::value('domain_id', $values, $current_domain_id);
     $dao = new CRM_SMS_DAO_Provider();
     $dao->id = $providerId;
     if ($dao->find(TRUE)) {
@@ -131,6 +142,7 @@ class CRM_SMS_BAO_Provider extends CRM_SMS_DAO_Provider {
 
     $dao = new CRM_SMS_DAO_Provider();
     $dao->id = $providerID;
+    $dao->whereAdd = "(domain_id = " .  CRM_Core_Config::domainID() . "OR domain_id IS NULL)";
     if (!$dao->find(TRUE)) {
       return NULL;
     }

--- a/CRM/Upgrade/Incremental/php/FourSeven.php
+++ b/CRM/Upgrade/Incremental/php/FourSeven.php
@@ -62,13 +62,6 @@ class CRM_Upgrade_Incremental_php_FourSeven extends CRM_Upgrade_Incremental_Base
     if ($rev == '4.7.13') {
       $preUpgradeMessage .= '<p>' . ts('A new permission has been added called %1 This Permission is now used to control access to the Manage Tags screen', array(1 => 'manage tags')) . '</p>';
     }
-    if ($rev == '4.7.19') {
-      $check = CRM_Core_DAO::singleValueQuery("SELECT count(id) FROM civicrm_domain");
-      $smsCheck = CRM_Core_DAO::singleValueQuery("SELECT count(id) FROM civicrm_sms_provider");
-      if ($check > 1 && (bool) $smsCheck) {
-        $postUpgradeMessage .= '<p>civicrm_sms_provider ' . ts('has now had a domain id column added. As there is more than 1 domains in this install you need to manually set the domain id for the providers in this install') . '</p>';
-      }
-    }
   }
 
   /**
@@ -123,6 +116,11 @@ class CRM_Upgrade_Incremental_php_FourSeven extends CRM_Upgrade_Incremental_Base
     }
     if ($rev == '4.7.19') {
       $postUpgradeMessage .= '<br /><br />' . ts('Default version of the following System Workflow Message Templates have been modified: <ul><li>Additional Payment Receipt or Refund Notification</li></ul> If you have modified these templates, please review the new default versions and implement updates as needed to your copies (Administer > Communications > Message Templates > System Workflow Messages).');
+      $check = CRM_Core_DAO::singleValueQuery("SELECT count(id) FROM civicrm_domain");
+      $smsCheck = CRM_Core_DAO::singleValueQuery("SELECT count(id) FROM civicrm_sms_provider");
+      if ($check > 1 && (bool) $smsCheck) {
+        $postUpgradeMessage .= '<p>civicrm_sms_provider ' . ts('has now had a domain id column added. As there is more than 1 domains in this install you need to manually set the domain id for the providers in this install') . '</p>';
+      }
     }
   }
 

--- a/api/v3/SmsProvider.php
+++ b/api/v3/SmsProvider.php
@@ -43,6 +43,18 @@ function civicrm_api3_sms_provider_create($params) {
 }
 
 /**
+ * Adjust Metadata for Create action.
+ *
+ * The metadata is used for setting defaults, documentation & validation.
+ *
+ * @param array $params
+ *   Array of parameters determined by getfields.
+ */
+function _civicrm_api3_sms_provider_create_spec(&$params) {
+  $params['domain_id']['api.default'] = CRM_Core_Config::domainID();
+}
+
+/**
  * Get an sms_provider.
  *
  * @param array $params

--- a/tests/phpunit/CRM/SMS/BAO/ProviderTest.php
+++ b/tests/phpunit/CRM/SMS/BAO/ProviderTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2017                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+/**
+ *  Test CRM_SMS_BAO_Provider functions
+ *
+ * @package CiviCRM_APIv3
+ * @subpackage API_Contribution
+ * @group headless
+ */
+class CRM_SMS_BAO_ProviderTest extends CiviUnitTestCase {
+
+  /**
+   * Set Up Funtion
+   */
+  public function setUp() {
+    parent::setUp();
+    $option = $this->callAPISuccess('option_value', 'create', array('option_group_id' => 'sms_provider_name', 'name' => 'test_provider_name', 'label' => 'test_provider_name', 'value' => 1));
+    $this->option_value = $option['id'];
+  }
+
+  /**
+   * Clean up after each test.
+   */
+  public function tearDown() {
+    parent::tearDown();
+    $this->callAPISuccess('option_value', 'delete', array('id' => $this->option_value));
+  }
+
+  /**
+   * CRM-19961 Check that when saving and updating a SMS provider with domain as NULL that it stays null
+   */
+  public function testCreateAndUpdateProvider() {
+    $values = array(
+      'domain_id' => NULL,
+      'title' => 'test SMS provider',
+      'username' => 'test',
+      'password' => 'dummpy password',
+      'name' => 1,
+      'is_active' => 1,
+      'api_type' => 1,
+    );
+    CRM_SMS_BAO_Provider::saveRecord($values);
+    $provider = $this->callAPISuccess('SmsProvider', 'getsingle', array('title' => 'test SMS provider'));
+    $domain_id = CRM_Core_DAO::getFieldValue('CRM_SMS_DAO_Provider', $provider['id'], 'domain_id');
+    $this->assertNull($domain_id);
+    $values2 = array('title' => 'Test SMS Provider2');
+    CRM_SMS_BAO_Provider::updateRecord($values2, $provider['id']);
+    $provider = $this->callAPISuccess('SmsProvider', 'getsingle', array('id' => $provider['id']));
+    $this->assertEquals('Test SMS Provider2', $provider['title']);
+    $domain_id = CRM_Core_DAO::getFieldValue('CRM_SMS_DAO_Provider', $provider['id'], 'domain_id');
+    $this->assertNull($domain_id);
+    CRM_SMS_BAO_Provider::del($provider['id']);
+  }
+
+  /**
+   * CRM-19961 Check that when a domain is not passed when saving it defaults to current domain when create
+   */
+  public function testCreateWithoutDomain() {
+    $values = array(
+      'title' => 'test SMS provider',
+      'username' => 'test',
+      'password' => 'dummpy password',
+      'name' => 1,
+      'is_active' => 1,
+      'api_type' => 1,
+    );
+    CRM_SMS_BAO_Provider::saveRecord($values);
+    $provider = $this->callAPISuccess('SmsProvider', 'getsingle', array('title' => 'test SMS provider'));
+    $domain_id = CRM_Core_DAO::getFieldValue('CRM_SMS_DAO_Provider', $provider['id'], 'domain_id');
+    $this->assertEquals(CRM_Core_Config::domainID(), $domain_id);
+    CRM_SMS_BAO_Provider::del($provider['id']);
+  }
+
+}


### PR DESCRIPTION
* [CRM-19961: Make CiviCRM SMS Providers multisite aware](https://issues.civicrm.org/jira/browse/CRM-19961)