### PR TITLE
CRM-19979 Fix issue where contacts cannot be removed from group or deleted if in status of pending

### DIFF
--- a/api/v3/GroupContact.php
+++ b/api/v3/GroupContact.php
@@ -158,7 +158,7 @@ function civicrm_api3_group_contact_delete($params) {
   }
   $groupContact = civicrm_api3('GroupContact', 'get', $checkParams);
   if ($groupContact['count'] == 0 && !empty($params['skip_undelete'])) {
-    $checkParams['status'] = 'removed';
+    $checkParams['status'] = array('IN' => array('Removed', 'Pending'));
   }
   $groupContact2 = civicrm_api3('GroupContact', 'get', $checkParams);
   if ($groupContact['count'] == 0 && $groupContact2['count'] == 0) {

--- a/api/v3/GroupContact.php
+++ b/api/v3/GroupContact.php
@@ -161,7 +161,8 @@ function civicrm_api3_group_contact_delete($params) {
     $checkParams['status'] = 'removed';
   }
   $groupContact2 = civicrm_api3('GroupContact', 'get', $checkParams);
-  if ($groupContact['count'] == 0 && $groupContact2['count'] == 0) {
+  $groupContact3 = civicrm_api3('GroupContact', 'get', array_merge($checkParams, array('status' => 'Pending')));
+  if ($groupContact['count'] == 0 && $groupContact2['count'] == 0 && $groupContact3['count'] == 0) {
     throw new API_Exception('Cannot Delete GroupContact');
   }
   $params['status'] = CRM_Utils_Array::value('status', $params, empty($params['skip_undelete']) ? 'Removed' : 'Deleted');

--- a/api/v3/GroupContact.php
+++ b/api/v3/GroupContact.php
@@ -148,10 +148,10 @@ function civicrm_api3_group_contact_create($params) {
 function civicrm_api3_group_contact_delete($params) {
   $checkParams = $params;
   if (!empty($checkParams['status']) && in_array($checkParams['status'], array('Removed', 'Deleted'))) {
-    $checkParams['status'] = 'Added';
+    $checkParams['status'] = array('IN' => array('Added', 'Pending'));
   }
   elseif (!empty($checkParams['status']) && $checkParams['status'] == 'Added') {
-    $checkParams['status'] = 'Removed';
+    $checkParams['status'] = array('IN' => array('Pending', 'Removed'));
   }
   elseif (!empty($checkParams['status'])) {
     unset($checkParams['status']);
@@ -161,8 +161,7 @@ function civicrm_api3_group_contact_delete($params) {
     $checkParams['status'] = 'removed';
   }
   $groupContact2 = civicrm_api3('GroupContact', 'get', $checkParams);
-  $groupContact3 = civicrm_api3('GroupContact', 'get', array_merge($checkParams, array('status' => 'Pending')));
-  if ($groupContact['count'] == 0 && $groupContact2['count'] == 0 && $groupContact3['count'] == 0) {
+  if ($groupContact['count'] == 0 && $groupContact2['count'] == 0) {
     throw new API_Exception('Cannot Delete GroupContact');
   }
   $params['status'] = CRM_Utils_Array::value('status', $params, empty($params['skip_undelete']) ? 'Removed' : 'Deleted');

--- a/tests/phpunit/api/v3/GroupContactTest.php
+++ b/tests/phpunit/api/v3/GroupContactTest.php
@@ -260,7 +260,6 @@ class api_v3_GroupContactTest extends CiviUnitTestCase {
     $this->callAPISuccess('groupContact', 'delete', array('id' => $groupGetContact['id'], 'status' => 'Removed'));
   }
 
-
   /**
    * CRM-16945 duplicate groups are showing up when contacts are hard-added to child groups or smart groups.
    *

--- a/tests/phpunit/api/v3/GroupContactTest.php
+++ b/tests/phpunit/api/v3/GroupContactTest.php
@@ -239,6 +239,29 @@ class api_v3_GroupContactTest extends CiviUnitTestCase {
   }
 
   /**
+   * CRM-19979 test that group cotnact delete action works when contact is in status of pendin.
+   */
+  public function testDeleteWithPending() {
+    $groupId3 = $this->groupCreate(array(
+      'name' => 'Test Group 3',
+      'domain_id' => 1,
+      'title' => 'New Test Group3 Created',
+      'description' => 'New Test Group3 Created',
+      'is_active' => 1,
+      'visibility' => 'User and User Admin Only',
+    ));
+    $groupContactCreateParams = array(
+      'contact_id' => $this->_contactId,
+      'group_id' => $groupId3,
+      'status' => 'Pending',
+    );
+    $groupContact = $this->callAPISuccess('groupContact', 'create', $groupContactCreateParams);
+    $groupGetContact = $this->CallAPISuccess('groupContact', 'get', $groupContactCreateParams);
+    $this->callAPISuccess('groupContact', 'delete', array('id' => $groupGetContact['id'], 'status' => 'Removed'));
+  }
+
+
+  /**
    * CRM-16945 duplicate groups are showing up when contacts are hard-added to child groups or smart groups.
    *
    * Fix documented in

--- a/tests/phpunit/api/v3/GroupContactTest.php
+++ b/tests/phpunit/api/v3/GroupContactTest.php
@@ -258,6 +258,31 @@ class api_v3_GroupContactTest extends CiviUnitTestCase {
     $groupContact = $this->callAPISuccess('groupContact', 'create', $groupContactCreateParams);
     $groupGetContact = $this->CallAPISuccess('groupContact', 'get', $groupContactCreateParams);
     $this->callAPISuccess('groupContact', 'delete', array('id' => $groupGetContact['id'], 'status' => 'Removed'));
+    $this->callAPISuccess('groupContact', 'delete', array('id' => $groupGetContact['id'], 'skip_undelete' => TRUE));
+    $this->callAPISuccess('group', 'delete', array('id' => $groupId3));
+  }
+
+  /**
+   * CRM-19979 test that group cotnact delete action works when contact is in status of pendin and is a permanent delete.
+   */
+  public function testPermanentDeleteWithPending() {
+    $groupId3 = $this->groupCreate(array(
+      'name' => 'Test Group 3',
+      'domain_id' => 1,
+      'title' => 'New Test Group3 Created',
+      'description' => 'New Test Group3 Created',
+      'is_active' => 1,
+      'visibility' => 'User and User Admin Only',
+    ));
+    $groupContactCreateParams = array(
+      'contact_id' => $this->_contactId,
+      'group_id' => $groupId3,
+      'status' => 'Pending',
+    );
+    $groupContact = $this->callAPISuccess('groupContact', 'create', $groupContactCreateParams);
+    $groupGetContact = $this->CallAPISuccess('groupContact', 'get', $groupContactCreateParams);
+    $this->callAPISuccess('groupContact', 'delete', array('id' => $groupGetContact['id'], 'skip_undelete' => TRUE));
+    $this->callAPISuccess('group', 'delete', array('id' => $groupId3));
   }
 
   /**


### PR DESCRIPTION
* [CRM-19979: GroupContact.delete does not work for contacts with status of Pending](https://issues.civicrm.org/jira/browse/CRM-19979)