### PR TITLE
CRM-19883: add priority to filter

### DIFF
--- a/CRM/Report/Form/Activity.php
+++ b/CRM/Report/Form/Activity.php
@@ -283,6 +283,11 @@ class CRM_Report_Form_Activity extends CRM_Report_Form {
             'title' => ts('Activity Details'),
             'type' => CRM_Utils_Type::T_TEXT,
           ),
+          'priority_id' => array(
+            'title' => ts('Activity Priority'),
+            'operatorType' => CRM_Report_Form::OP_MULTISELECT,
+            'options' => CRM_Core_PseudoConstant::get('CRM_Activity_DAO_Activity', 'priority_id'),
+          ),
         ),
         'order_bys' => array(
           'activity_date_time' => array(

--- a/CRM/Report/Form/ActivitySummary.php
+++ b/CRM/Report/Form/ActivitySummary.php
@@ -155,7 +155,7 @@ class CRM_Report_Form_ActivitySummary extends CRM_Report_Form {
             'options' => CRM_Core_PseudoConstant::activityStatus(),
           ),
           'priority_id' => array(
-            'title' => ts('Priority'),
+            'title' => ts('Activity Priority'),
             'type' => CRM_Utils_Type::T_INT,
             'operatorType' => CRM_Report_Form::OP_MULTISELECT,
             'options' => CRM_Core_PseudoConstant::get('CRM_Activity_DAO_Activity', 'priority_id'),


### PR DESCRIPTION
* [CRM-19883: Activity Priority Field is Not Included in Advanced Search or Activity Reports ](https://issues.civicrm.org/jira/browse/CRM-19883)