### PR TITLE
CRM-19934 improvement on acl cache.

### DIFF
--- a/CRM/Contact/BAO/Contact/Permission.php
+++ b/CRM/Contact/BAO/Contact/Permission.php
@@ -170,7 +170,7 @@ WHERE contact_id IN ({$contact_id_list})
     $tables = array();
     $whereTables = array();
 
-    $permission = CRM_ACL_API::whereClause($type, $tables, $whereTables);
+    $permission = CRM_ACL_API::whereClause($type, $tables, $whereTables, NULL, FALSE, FALSE, TRUE);
     $from = CRM_Contact_BAO_Query::fromClause($whereTables);
 
     $query = "


### PR DESCRIPTION
This change means that when we are checking the allow function we do not add the harmful
OR to the query.

The 'view my contact' & 'edit my contact' permissions have already been checked for.

Adding them into the ACL query with an OR causes serious performance issues, as
elsewhere commented. We can & should avoid it here

---

 * [CRM-19934: Performance improvement on civicrm_acl_contact_cache](https://issues.civicrm.org/jira/browse/CRM-19934)