### PR TITLE
CRM-19962 - Wider name field for A/B mailings

### DIFF
--- a/ang/crmMailingAB/BlockSetup.html
+++ b/ang/crmMailingAB/BlockSetup.html
@@ -4,7 +4,7 @@
       {{ts('A/B testing allows you to send two test mailings to a random subset of your recipients. After collecting and comparing metrics, the more successful mailing will be sent to the remaining recipients.')}}
     </div>
     <div crm-ui-field="{name: 'setupForm.abName', title: ts('Name'), help: hs('name')}" ng-if="fields.abName">
-      <input
+      <input type="text"
         crm-ui-id="setupForm.abName"
         name="abName"
         ng-model="abtest.ab.name"


### PR DESCRIPTION
Add type attribute to name input so that the appropriate style applies (PR 9778, on correct base branch this time).

---

 * [CRM-19962: Name field of AB mailing too short](https://issues.civicrm.org/jira/browse/CRM-19962)