### PR TITLE
CRM-19984 don't renew membership using repeattransaction failed

### DIFF
--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -640,6 +640,15 @@ function civicrm_api3_contribution_repeattransaction(&$params) {
     );
     $input = array_intersect_key($params, array_fill_keys($passThroughParams, NULL));
 
+    // CRM-19984 Don't give free memberships with repeattrasaction.
+    $notRenewing = ['Failed', 'In Progress','Overdue', 'Refunded', 'Partially paid', 'Pending refund', 'Chargeback' ];
+    $contributionStatuses = CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name');
+    // It's OK to throw away the membership array here becasue we decided that we
+    // will only be repeating competed contribtuions. (CRM-19945)
+    if (isset($params['contribution_status_id']) && isset($contribution->_relatedObjects['membership']) && in_array($contributionStatuses[$params['contribution_status_id']], $notRenewing)) {
+      unset($contribution->_relatedObjects['membership']);
+    }
+
     return _ipn_process_transaction($params, $contribution, $input, $ids, $original_contribution);
   }
   catch(Exception $e) {


### PR DESCRIPTION
My solution was to unset the membership array in the contribution object if the contribution_status_id is any non-completed status.  

We shouldn't need the this because we decided we only want to use a completed contribution as the template when we run repeattransaction.

---

 * [CRM-19984: repeattransaction renews memebrship when contribution_status_id =\> Failed](https://issues.civicrm.org/jira/browse/CRM-19984)