### PR TITLE
CRM-19984 don't renew membership when using repeattransaction failed

### DIFF
--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -640,6 +640,16 @@ function civicrm_api3_contribution_repeattransaction(&$params) {
     );
     $input = array_intersect_key($params, array_fill_keys($passThroughParams, NULL));
 
+    $notRenewing = array('Failed', 'Overdue', 'Refunded', 'Partially paid', 'Pending refund', 'Chargeback');
+    $contributionStatuses = CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name');
+
+    // CRM-19984 Don't give free memberships with repeattrasaction.
+    // It's OK to throw away the membership array here becasue we decided that we
+    // will only be repeating competed contribtuions. (CRM-19945)
+    if (isset($params['contribution_status_id']) && isset($contribution->_relatedObjects['membership']) && in_array($contributionStatuses[$params['contribution_status_id']], $notRenewing)) {
+      unset($contribution->_relatedObjects['membership']);
+    }
+
     return _ipn_process_transaction($params, $contribution, $input, $ids, $original_contribution);
   }
   catch(Exception $e) {

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -2132,6 +2132,47 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
   }
 
   /**
+   * CRM-19984 Tests repeattransaction doesn't give free membership.
+   */
+  public function testRepeatTransactionMembershipGratis() {
+    list($originalContribution, $membership) = $this->setUpAutoRenewMembership();
+
+    $this->callAPISuccess('membership', 'create', array(
+       'id' => $membership['id'],
+       'end_date' => 'yesterday',
+       'status_id' => 4,
+    ));
+    $errorCount = 0;
+    // While we're at it, let's test all the other contribtion statuses that shouldn't renew a membership.
+    // 'In Progress' is not a valid contribution status.
+    $nonRenewing = array('Failed', 'Overdue', 'Refunded', 'Partially paid', 'Pending refund', 'Chargeback');
+    foreach ($nonRenewing as $statusId) {
+      $this->callAPISuccess('contribution', 'repeattransaction', array(
+        'contribution_recur_id' => $originalContribution['values'][1]['contribution_recur_id'],
+        'contribution_status_id' => $statusId,
+        'trxn_id' => uniqid(),
+      ));
+
+      $membershipStatus = $this->callAPISuccess('membership', 'getvalue', array(
+        'id' => $membership['id'],
+        'return' => 'status_id',
+      ));
+
+      if ($membershipStatus != 4) {
+        $errorCount++;
+        $this->callAPISuccess('membership', 'create', array(
+          'id' => $membership['id'],
+          'end_date' => 'yesterday',
+          'status_id' => 4,
+        ));
+      }
+    }
+    $this->assertEquals(0, $errorCount);
+    $this->quickCleanUpFinancialEntities();
+    $this->contactDelete($originalContribution['values'][1]['contact_id']);
+  }
+
+  /**
    * CRM-16397 test appropriate action if total amount has changed for single line items.
    */
   public function testRepeatTransactionAlteredAmount() {


### PR DESCRIPTION
My solution was to unset the membership array in the contribution object if the contribution_status_id is any non-completed or non-pending status.

We shouldn't need the this because we decided we only want to use a completed contribution as the template when we run repeattransaction.

---

 * [CRM-19984: repeattransaction renews memebrship when contribution_status_id =\> Failed](https://issues.civicrm.org/jira/browse/CRM-19984)