### PR TITLE
CRM-21220 - Tidy duedate format for invoice

### DIFF
--- a/CRM/Contribute/Form/Task/Invoice.php
+++ b/CRM/Contribute/Form/Task/Invoice.php
@@ -327,7 +327,7 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
       //to obtain due date for PDF invoice
       $contributionReceiveDate = date('F j,Y', strtotime(date($input['receive_date'])));
       $invoiceDate = date("F j, Y");
-      $dueDate = date('F j ,Y', strtotime($contributionReceiveDate . "+" . $prefixValue['due_date'] . "" . $prefixValue['due_date_period']));
+      $dueDate = date('F j, Y', strtotime($contributionReceiveDate . "+" . $prefixValue['due_date'] . "" . $prefixValue['due_date_period']));
 
       if ($input['component'] == 'contribute') {
         $eid = $contribID;


### PR DESCRIPTION
Changed the format for invoice duedate from **'F j ,Y'**  to **'F j, Y'** (the comma was closer to the year than to the day)

---

 * [CRM-21220: Invoice due date format spacing correction](https://issues.civicrm.org/jira/browse/CRM-21220)