### PR TITLE
CRM-20009 throw exception for repeattransaction "In Progress"

### DIFF
--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -601,6 +601,9 @@ function _civicrm_api3_contribution_completetransaction_spec(&$params) {
 function civicrm_api3_contribution_repeattransaction(&$params) {
   $input = $ids = array();
   civicrm_api3_verify_one_mandatory($params, NULL, array('contribution_recur_id', 'original_contribution_id'));
+  if (CRM_Contribute_PseudoConstant::contributionStatus($params['contribution_status_id'], 'name') == 'In Progress') {
+    throw new API_Exception('In Progress is not a valid contribution status id. Not implemented.', array('error_code' => 'NOT_IMPLEMENTED'));
+  }
   if (empty($params['original_contribution_id'])) {
     //  CRM-19873 call with test mode.
     $params['original_contribution_id'] = civicrm_api3('contribution', 'getvalue', array(

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -2202,6 +2202,20 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
   }
 
   /**
+   * CRM-20009 test repeatransaction 'In Progress' returns not implemented.
+   */
+  public function testRepeatTransactionInProgressNotImplemented() {
+    $originalContribution = $this->setUpRecurringContribution();
+
+    $this->callAPIFailure('contribution', 'repeattransaction', array(
+      'original_contribution_id' => $originalContribution['id'],
+      'contribution_status_id' => 'In Progress',
+      'trxn_id' => uniqid(),
+      'financial_type_id' => 2,
+    ), 'In Progress is not a valid contribution status id. Not implemented.');
+  }
+
+  /**
    * CRM-17718 test appropriate action if financial type has changed for single line items.
    */
   public function testRepeatTransactionPassedInFinancialType() {


### PR DESCRIPTION
@eileenmcnaughton  says "In Progress" is not a valid contribution_status_id, so we're throwing an api exception if it's used with repeattransaction.

---

 * [CRM-20009: repeattransaction using contribtuion_status_id =\> "In Progress" should throw exception](https://issues.civicrm.org/jira/browse/CRM-20009)