### PR TITLE
CRM-20010 period_type should be required for parity with UI

### DIFF
--- a/api/v3/MembershipType.php
+++ b/api/v3/MembershipType.php
@@ -66,6 +66,7 @@ function _civicrm_api3_membership_type_create_spec(&$params) {
   $params['name']['api.required'] = 1;
   $params['duration_unit']['api.required'] = 1;
   $params['duration_interval']['api.required'] = 1;
+  $params['period_type']['api.required'] = 1;
   $params['is_active']['api.default'] = 1;
 }
 

--- a/tests/phpunit/CRM/Core/PseudoConstantTest.php
+++ b/tests/phpunit/CRM/Core/PseudoConstantTest.php
@@ -116,6 +116,7 @@ class CRM_Core_PseudoConstantTest extends CiviUnitTestCase {
       'member_of_contact_id' => 1,
       'duration_unit' => 'day',
       'duration_interval' => 1,
+      'period_type' => 'rolling',
     );
     $result = civicrm_api3('membership_type', 'create', $api_params);
 

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -3213,6 +3213,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'financial_type_id' => "Member Dues",
       'duration_unit' => "month",
       'duration_interval' => 1,
+      'period_type' => 'rolling',
       'name' => "Standard Member",
       'minimum_fee' => 100,
     ));

--- a/tests/phpunit/api/v3/MembershipTypeTest.php
+++ b/tests/phpunit/api/v3/MembershipTypeTest.php
@@ -146,6 +146,21 @@ class api_v3_MembershipTypeTest extends CiviUnitTestCase {
   }
 
   /**
+   *  CRM-20010 Tests period_type is required for MemberType create
+   */
+  public function testMemberTypePeriodiTypeRequired() {
+    $this->callAPIFailure('MembershipType', 'create', array(
+      'domain_id' => "Default Domain Name",
+      'member_of_contact_id' => 1,
+      'financial_type_id' => "Member Dues",
+      'duration_unit' => "month",
+      'duration_interval' => 1,
+      'name' => "Standard Member",
+      'minimum_fee' => 100,
+    ));
+  }
+
+  /**
    * Test update.
    */
   public function testUpdate() {


### PR DESCRIPTION
[fixed | rolling] is required to create a MembershipType in the UI. 

It should also be required when we use API MembershipType create.   

---

 * [CRM-20010: Membership period_type is required in frontend but not in API.](https://issues.civicrm.org/jira/browse/CRM-20010)