### PR TITLE
CRM-20015 escape output before generating docx

### DIFF
--- a/CRM/Utils/PDF/Document.php
+++ b/CRM/Utils/PDF/Document.php
@@ -115,6 +115,7 @@ class CRM_Utils_PDF_Document {
       $phpWord = \PhpOffice\PhpWord\IOFactory::load($fileName, $formats[$ext]);
     }
 
+    \PhpOffice\PhpWord\Settings::setOutputEscapingEnabled(true); //CRM-20015
     $objWriter = \PhpOffice\PhpWord\IOFactory::createWriter($phpWord, $formats[$ext]);
 
     CRM_Utils_System::setHttpHeader('Content-Type', "application/$ext");

--- a/CRM/Utils/PDF/Document.php
+++ b/CRM/Utils/PDF/Document.php
@@ -115,7 +115,7 @@ class CRM_Utils_PDF_Document {
       $phpWord = \PhpOffice\PhpWord\IOFactory::load($fileName, $formats[$ext]);
     }
 
-    \PhpOffice\PhpWord\Settings::setOutputEscapingEnabled(true); //CRM-20015
+    \PhpOffice\PhpWord\Settings::setOutputEscapingEnabled(TRUE); //CRM-20015
     $objWriter = \PhpOffice\PhpWord\IOFactory::createWriter($phpWord, $formats[$ext]);
 
     CRM_Utils_System::setHttpHeader('Content-Type', "application/$ext");


### PR DESCRIPTION
* [CRM-20015: token values with ampersand cause error when generating docx letter](https://issues.civicrm.org/jira/browse/CRM-20015)