### PR TITLE
CRM-20020 - fix search with parent groups + other criteria

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2993,7 +2993,7 @@ class CRM_Contact_BAO_Query {
         $gcTable = ($op == '!=') ? 'cgc' : $gcTable;
         $childClause = " OR {$gcTable}.group_id IN (" . implode(',', $childGroupIds) . ") ";
       }
-      $groupClause[] = sprintf($clause, $childClause);
+      $groupClause[] = '(' . sprintf($clause, $childClause) . ')';
     }
 
     //CRM-19589: contact(s) removed from a Smart Group, resides in civicrm_group_contact table

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -3002,7 +3002,7 @@ class CRM_Contact_BAO_Query {
     }
 
     $and = ($op == 'IS NULL') ? ' AND ' : ' OR ';
-    $this->_where[$grouping][] = implode($and, $groupClause);
+    $this->_where[$grouping][] = ' ( ' . implode($and, $groupClause) . ' ) ';
 
     list($qillop, $qillVal) = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Contact_DAO_Group', 'id', $value, $op);
     $this->_qill[$grouping][] = ts("Group(s) %1 %2", array(1 => $qillop, 2 => $qillVal));


### PR DESCRIPTION
Previously, search always returned all contacts in the specified
group rather than contacts who also met the added criteria.

---

 * [CRM-20020: Advanced search for parent group + another criteria ignores other criteria - shows all group members always](https://issues.civicrm.org/jira/browse/CRM-20020)