### PR TITLE
CRM-20023: Do not require state_province value to use state_province_id value.

### DIFF
--- a/CRM/Utils/Geocode/Google.php
+++ b/CRM/Utils/Geocode/Google.php
@@ -82,7 +82,7 @@ class CRM_Utils_Geocode_Google {
       $add .= ',+';
     }
 
-    if (!empty($values['state_province'])) {
+    if (!empty($values['state_province']) || !empty($values['state_province_id'])) {
       if (!empty($values['state_province_id'])) {
         $stateProvince = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_StateProvince', $values['state_province_id']);
       }

--- a/CRM/Utils/Geocode/Yahoo.php
+++ b/CRM/Utils/Geocode/Yahoo.php
@@ -79,7 +79,7 @@ class CRM_Utils_Geocode_Yahoo {
       $whereComponents['city'] = $city;
     }
 
-    if (!empty($values['state_province'])) {
+    if (!empty($values['state_province']) || !empty($values['state_province_id'])) {
       if (!empty($values['state_province_id'])) {
         $stateProvince = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_StateProvince', $values['state_province_id']);
       }


### PR DESCRIPTION
Both Google and Yahoo geocoders would ignore a passed in 'state_province_id' unless it was accompanied by a non-empty 'state_province' value.

This resolved only to "U.S.A" -

    CRM_Utils_Geocoder_Google::format([
      'state_province_id' => '1022',
      'country' => 'U.S.A'
    ]);

But this trickery would resolve to "Minnesota, U.S.A"

    CRM_Utils_Geocoder_Google::format([
      'state_province' => 'Blueberry muffin',
      'state_province_id' => '1022',
      'country' => 'U.S.A'
    ]);

With the submitted patch, the former will correctly resolve the state_province_id.

---

 * [CRM-20023: Accept state_province_id without state_province in CRM_Utils_Geocode_\*](https://issues.civicrm.org/jira/browse/CRM-20023)