### PR TITLE
CRM-20027 - Fix Address.get for loc block addresses.

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2490,6 +2490,11 @@ SELECT contact_id
       $clauses[$field] = NULL;
       if ($vals) {
         $clauses[$field] = "`$tableAlias`.`$field` " . implode(" AND `$tableAlias`.`$field` ", (array) $vals);
+        // Hack around CRM-20027. (Don't care about the contact ID of an
+        // address if there is no contact ID.)
+        if ($field == 'contact_id' && $bao->tableName() == 'civicrm_address') {
+          $clauses[$field] = "`$tableAlias`.`$field` IS NULL OR (" . $clauses[$field] . ")";
+        }
       }
     }
     return $clauses;


### PR DESCRIPTION
If your user doesn't have 'access deleted contact' permissions, you
cannot retrieve addresses with contact_id NULL using the API.

This is a hacky workaround: If an address has no contact_id, ignore contact_id clauses.

Now let's see if it passes the unit tests :-)

---

 * [CRM-20027: Need 'access deleted contacts' permission to retrieve loc block addresses using API](https://issues.civicrm.org/jira/browse/CRM-20027)