### PR TITLE
[NFC] Date metadata fixes towards CRM-19490, CRM-18387, CRM-20012, CRM-20011, CRM-15948, CRM-19911 

### DIFF
--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -476,6 +476,7 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
     if (isset($field->phone_type_id)) {
       $name .= "-{$field->phone_type_id}";
     }
+    $fieldMetaData = CRM_Utils_Array::value($name, $importableFields, (isset($importableFields[$field->field_name]) ? $importableFields[$field->field_name] : array()));
 
     // No lie: this is bizarre; why do we need to mix so many UFGroup properties into UFFields?
     // I guess to make field self sufficient with all the required data and avoid additional calls
@@ -513,7 +514,10 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
         CRM_Utils_Array::value($field->field_name, $importableFields)
       ),
       'skipDisplay' => 0,
+      'data_type' => CRM_Utils_Type::getDataTypeFromFieldMetadata($fieldMetaData),
     );
+
+    $formattedField = CRM_Utils_Date::addDateMetadataToField($fieldMetaData, $formattedField);
 
     //adding custom field property
     if (substr($field->field_name, 0, 6) == 'custom' ||
@@ -525,12 +529,16 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
         $formattedField['is_search_range'] = $customFields[$field->field_name]['is_search_range'];
         // fix for CRM-1994
         $formattedField['options_per_line'] = $customFields[$field->field_name]['options_per_line'];
-        $formattedField['data_type'] = $customFields[$field->field_name]['data_type'];
         $formattedField['html_type'] = $customFields[$field->field_name]['html_type'];
 
         if (CRM_Utils_Array::value('html_type', $formattedField) == 'Select Date') {
           $formattedField['date_format'] = $customFields[$field->field_name]['date_format'];
           $formattedField['time_format'] = $customFields[$field->field_name]['time_format'];
+          $formattedField['php_datetime_format'] = CRM_Utils_Date::getPhpDateFormatFromInputStyleDateFormat($customFields[$field->field_name]['date_format']);
+          if ($formattedField['time_format']) {
+            $formattedField['php_datetime_format'] .= ' H-i-s';
+          }
+          $formattedField['is_datetime_field'] = TRUE;
         }
 
         $formattedField['is_multi_summary'] = $field->is_multi_summary;

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -337,6 +337,8 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    * @param bool $required
    * @param array $extra
    *   (attributes for select elements).
+   *   For datepicker elements this is consistent with the data
+   *   from CRM_Utils_Date::getDatePickerExtra
    *
    * @return HTML_QuickForm_Element
    *   Could be an error object

--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -311,7 +311,8 @@ class CRM_Core_SelectValues {
    * @return array
    *   the date array
    */
-  public static function date($type = NULL, $format = NULL, $minOffset = NULL, $maxOffset = NULL) {
+  public static function date($type = NULL, $format = NULL, $minOffset = NULL, $maxOffset = NULL, $context = 'display') {
+    // These options are deprecated. Definitely not used in datepicker. Possibly not even in jcalendar+addDateTime.
     $date = array(
       'addEmptyOption' => TRUE,
       'emptyOptionText' => ts('- select -'),
@@ -328,25 +329,34 @@ class CRM_Core_SelectValues {
         if (!$dao->find(TRUE)) {
           CRM_Core_Error::fatal();
         }
-      }
+        if (!$maxOffset) {
+          $maxOffset = $dao->end;
+        }
+        if (!$minOffset) {
+          $minOffset = $dao->start;
+        }
 
-      if ($type == 'creditCard') {
-        $minOffset = $dao->start;
-        $maxOffset = $dao->end;
         $date['format'] = $dao->date_format;
-        $date['addEmptyOption'] = TRUE;
-        $date['emptyOptionText'] = ts('- select -');
-        $date['emptyOptionValue'] = '';
+        $date['time'] = (bool) $dao->time_format;
       }
 
       if (empty($date['format'])) {
-        $date['format'] = 'M d';
+        if ($context == 'Input') {
+          $date['format'] = Civi::settings()->get('dateInputFormat');
+          $date['php_datetime_format'] = self::datePluginToPHPFormats(Civi::settings()->get('dateInputFormat'));
+        }
+        else {
+          $date['format'] = 'M d';
+        }
       }
+    }
+    if (!isset($date['time'])) {
+      $date['time'] = FALSE;
     }
 
     $year = date('Y');
-    $date['minYear'] = $year - $minOffset;
-    $date['maxYear'] = $year + $maxOffset;
+    $date['minYear'] = $year - (int) $minOffset;
+    $date['maxYear'] = $year + (int) $maxOffset;
     return $date;
   }
 

--- a/CRM/Price/Form/Field.php
+++ b/CRM/Price/Form/Field.php
@@ -327,13 +327,6 @@ class CRM_Price_Form_Field extends CRM_Core_Form {
       CRM_Core_DAO::getAttribute('CRM_Price_DAO_PriceField', 'help_post')
     );
 
-    // active_on
-    $date_options = array(
-      'format' => 'dmY His',
-      'minYear' => date('Y') - 1,
-      'maxYear' => date('Y') + 5,
-      'addEmptyOption' => TRUE,
-    );
     $this->addDateTime('active_on', ts('Active On'), FALSE, array('formatType' => 'activityDateTime'));
 
     // expire_on

--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -1742,6 +1742,106 @@ class CRM_Utils_Date {
   }
 
   /**
+   * Convert a Civi-special date string to a standard php date string.
+   *
+   * For historical reasons CiviCRM has it's own (possibly Smarty derived)
+   * format for defined date strings. This renders something php can use.
+   *
+   * @param string $dateFormatString
+   *   e.g mm/dd/yy
+   *   These map to the values used in the date_format field in civicrm_custom_field.date_format.
+   *
+   * @return string
+   *   A proper php strotime formatted equivalent of the string.
+   *   eg m/d/y for the above.
+   *
+   *   http://php.net/manual/en/function.strtotime.php
+   */
+  public static function getPhpDateFormatFromInputStyleDateFormat($dateFormatString) {
+    $formats = CRM_Core_SelectValues::datePluginToPHPFormats();
+    return $formats[$dateFormatString];
+  }
+
+  /**
+   * Add the metadata about a date field to the field.
+   *
+   * This metadata will work with the call $form->add('datepicker', ...
+   *
+   * @param array $fieldMetaData
+   * @param array $field
+   *
+   * @return array
+   */
+  public static function addDateMetadataToField($fieldMetaData, $field) {
+    if (isset($fieldMetaData['html'])) {
+      $field['html_type'] = $fieldMetaData['html']['type'];
+      if ($field['html_type'] === 'Select Date' && !isset($field['date_format'])) {
+        $dateAttributes = CRM_Core_SelectValues::date($fieldMetaData['html']['formatType'], NULL, NULL, NULL, 'Input');
+        $field['start_date_years'] = $dateAttributes['minYear'];
+        $field['end_date_years'] = $dateAttributes['maxYear'];
+        $field['date_format'] = $dateAttributes['format'];
+        $field['is_datetime_field'] = TRUE;
+        $field['time_format'] = $dateAttributes['time'];
+        $field['php_datetime_format'] = CRM_Utils_Date::getPhpDateFormatFromInputStyleDateFormat($field['date_format']);
+        if ($field['time_format']) {
+          $field['php_datetime_format'] .= ' H-i-s';
+        }
+      }
+      $field['datepicker']['extra'] = self::getDatePickerExtra($field);
+      $field['datepicker']['attributes'] = self::getDatePickerAttributes($field);
+    }
+    return $field;
+  }
+
+
+  /**
+   * Get the fields required for the 'extra' parameter when adding a datepicker.
+   *
+   * @param array $field
+   *
+   * @return array
+   */
+  public static function getDatePickerExtra($field) {
+    $extra = array();
+    if (isset($field['date_format'])) {
+      $extra['date'] = $field['date_format'];
+      $extra['time'] = $field['time_format'];
+    }
+    $thisYear = date('Y');
+    if (isset($field['start_date_years'])) {
+      $extra['minDate'] = date('Y-m-d', strtotime('-' . ($thisYear - $field['start_date_years']) . ' years'));
+    }
+    if (isset($field['end_date_years'])) {
+      $extra['maxDate'] = date('Y-m-d', strtotime('-' . ($thisYear - $field['end_date_years']) . ' years'));
+    }
+    return $extra;
+  }
+
+  /**
+   * Get the attributes parameters required for datepicker.
+   *
+   * @param array $field
+   *   Field metadata
+   *
+   * @return array
+   *   Array ready to pass to $this->addForm('datepicker' as attributes.
+   */
+  public static function getDatePickerAttributes(&$field) {
+    $attributes = array();
+    $dateAttributes = array(
+      'start_date_years' => 'minYear',
+      'end_date_years' => 'maxYear',
+      'date_format' => 'format',
+    );
+    foreach ($dateAttributes as $dateAttribute => $mapTo) {
+      if (isset($field[$dateAttribute])) {
+        $attributes[$mapTo] = $field[$dateAttribute];
+      }
+    }
+    return $attributes;
+  }
+
+  /**
    * Function to convert mysql to date plugin format.
    *
    * @param string $mysqlDate

--- a/CRM/Utils/Type.php
+++ b/CRM/Utils/Type.php
@@ -144,6 +144,28 @@ class CRM_Utils_Type {
   }
 
   /**
+   * Get the data_type for the field.
+   *
+   * @param array $fieldMetadata
+   *   Metadata about the field.
+   *
+   * @return string
+   */
+  public static function getDataTypeFromFieldMetadata($fieldMetadata) {
+    if (isset($fieldMetadata['data_type'])) {
+      return $fieldMetadata['data_type'];
+    }
+    if (empty($fieldMetadata['type'])) {
+      // I would prefer to throw an e-notice but there is some,
+      // probably unnecessary logic, that only retrieves activity fields
+      // if they are 'in the profile' and probably they are not 'in'
+      // until they are added - which might lead to ? who knows!
+      return '';
+    }
+    return self::typeToString($fieldMetadata['type']);
+  }
+
+  /**
    * Helper function to call escape on arrays.
    *
    * @see escape


### PR DESCRIPTION
These commits are the NFC changes towards a bunch of date issues. Basically most of the problems go away once we swap custom handling for metadata-based date picker fields. Date picker fields use only ISO data format at the php level so a lot of non-robust custom data handling can go - & with it a bunch of problems.

This patch simply works to make the metadata available for the switch. I am trying to make the actual switch in a bunch of small changes in order to try to find any gotchas

---

 * [CRM-19490: Profile date fields don't respect localisation on the Contribution Page confirmation screen](https://issues.civicrm.org/jira/browse/CRM-19490)
 * [CRM-18387: Contribution confirmation page forces custom date fields always to be format yyyy-mm-dd](https://issues.civicrm.org/jira/browse/CRM-18387)
 * [CRM-20012: contribution batch update: can't unset thank you date value](https://issues.civicrm.org/jira/browse/CRM-20012)
 * [CRM-20011: Profile date fields using YYYY-MM or MM YY don't work](https://issues.civicrm.org/jira/browse/CRM-20011)
 * [CRM-15948: date format not always respected in profile when in Edit mode for drupal user](https://issues.civicrm.org/jira/browse/CRM-15948)
 * [CRM-19911: Date problem in profile edit Custom date field](https://issues.civicrm.org/jira/browse/CRM-19911)