### PR TITLE
CRM-20036 Don't retrieve all soft contributions if not needed.

### DIFF
--- a/CRM/Contribute/BAO/ContributionSoft.php
+++ b/CRM/Contribute/BAO/ContributionSoft.php
@@ -236,11 +236,13 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
   public static function del($params) {
     //delete from contribution soft table
     $contributionSoft = new CRM_Contribute_DAO_ContributionSoft();
-    $contributionSoft->id = CRM_Utils_Array::value('id', $params);
-    if (!$contributionSoft->find()) {
-      return FALSE;
+    if (!empty(CRM_Utils_Array::value('id', $params))) {
+      $contributionSoft->id = CRM_Utils_Array::value('id', $params);
+      if (!$contributionSoft->find()) {
+        return FALSE;
+      }
+      unset($params['id']);
     }
-    unset($params['id']);
     foreach ($params as $column => $value) {
       $contributionSoft->$column = $value;
     }

--- a/CRM/Contribute/BAO/ContributionSoft.php
+++ b/CRM/Contribute/BAO/ContributionSoft.php
@@ -236,11 +236,12 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
   public static function del($params) {
     //delete from contribution soft table
     $contributionSoft = new CRM_Contribute_DAO_ContributionSoft();
-    if (!empty(CRM_Utils_Array::value('id', $params))) {
+    if (!empty($params['id'])) {
       $contributionSoft->id = CRM_Utils_Array::value('id', $params);
       if (!$contributionSoft->find()) {
         return FALSE;
       }
+      // Are we really sure about this??
       unset($params['id']);
     }
     foreach ($params as $column => $value) {


### PR DESCRIPTION
This is a fix for CRM-20036. See JIRA for details.

---

 * [CRM-20036: Memory problem when updating a contribution without soft contributions](https://issues.civicrm.org/jira/browse/CRM-20036)