### PR TITLE
CRM-20040 - add args to json_encode to handle special characters

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -891,7 +891,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
           if (!empty($form->_submitValues['onbehalfof_id'])) {
             $form->assign('submittedOnBehalf', $form->_submitValues['onbehalfof_id']);
           }
-          $form->assign('submittedOnBehalfInfo', json_encode($form->_submitValues['onbehalf']));
+          $form->assign('submittedOnBehalfInfo', json_encode($form->_submitValues['onbehalf'],JSON_HEX_APOS|JSON_HEX_QUOT));
         }
 
         $fieldTypes = array('Contact', 'Organization');


### PR DESCRIPTION
in submitted values.

As per http://php.net/manual/en/json.constants.php, these are available since 5.3.0

---

 * [CRM-20040: On behalf of breaks with apostrophe in organization name.](https://issues.civicrm.org/jira/browse/CRM-20040)