### PR TITLE
CRM-20040 for 4.6

### DIFF
--- a/CRM/Contribute/Form/Contribution/OnBehalfOf.php
+++ b/CRM/Contribute/Form/Contribution/OnBehalfOf.php
@@ -100,7 +100,7 @@ class CRM_Contribute_Form_Contribution_OnBehalfOf {
           if (!empty($form->_submitValues['onbehalfof_id'])) {
             $form->assign('submittedOnBehalf', $form->_submitValues['onbehalfof_id']);
           }
-          $form->assign('submittedOnBehalfInfo', json_encode($form->_submitValues['onbehalf']));
+          $form->assign('submittedOnBehalfInfo', json_encode($form->_submitValues['onbehalf'],JSON_HEX_APOS|JSON_HEX_QUOT));
         }
       }
 


### PR DESCRIPTION
Add args to json_encode to handle special characters in submitted values.

As per http://php.net/manual/en/json.constants.php, these are available since 5.3.0

---

 * [CRM-20040: On behalf of breaks with apostrophe in organization name.](https://issues.civicrm.org/jira/browse/CRM-20040)