### PR TITLE
CRM-20040 Handle apostrophes and double double quotes in on behalf of Org fields

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -891,7 +891,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
           if (!empty($form->_submitValues['onbehalfof_id'])) {
             $form->assign('submittedOnBehalf', $form->_submitValues['onbehalfof_id']);
           }
-          $form->assign('submittedOnBehalfInfo', json_encode($form->_submitValues['onbehalf']));
+          $form->assign('submittedOnBehalfInfo', json_encode(str_replace('"', '\"', $form->_submitValues['onbehalf']), JSON_HEX_APOS));
         }
 
         $fieldTypes = array('Contact', 'Organization');


### PR DESCRIPTION
Corrected from previous attempt:
1. now handles double quotes correctly.
2. syntax error fixed (missing spaces).

I did some more testing to confirm this is correct. I believe this error has been around for a while, but it's not a critical error so most of the time the console errors were likely just getting ignored.

The best test is somewhat hard to setup:

1. A contact that has multiple org's associated with it. The easiest way to do this is to have those orgs as employers in a default CiviCRM setup.
2. A donation page with onbehalf of org enabled.

When that contact goes (authenticated) to the donation page, they get a drop down of potential orgs to donate to. If any of those orgs have single or double quotes, you'll see console errors when
1. that org is selected by default.
2. you switch orgs via the dropdown.

It sounds fairly obscure, but I noticed it via some routine testing. It was particularly noticeable in my testing because I had some custom js in the footer of the contribution page which was not executing because of the console error.

The handling of the double quotes is even harder to reproduce because the current code won't generate the console error until you do the org switching test - whereas the single quotes shows up immediately, i.e. the double quote issue only shows up when the javascript tries to decode the json object.

---

 * [CRM-20040: On behalf of breaks with apostrophe in organization name.](https://issues.civicrm.org/jira/browse/CRM-20040)