### PR TITLE
CRM-20048 Parse "business" not "receiver_email" from IPN

### DIFF
--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -340,7 +340,7 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
     $paymentProcessorID = $this->retrieve('processor_id', 'Integer', FALSE);
     if (empty($paymentProcessorID)) {
       $processorParams = array(
-        'user_name' => $this->retrieve('receiver_email', 'String', FALSE),
+        'user_name' => $this->retrieve('business', 'String', FALSE),
         'payment_processor_type_id' => CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_PaymentProcessorType', 'PayPal_Standard', 'id', 'name'),
         'is_test' => empty($input['is_test']) ? 0 : 1,
       );


### PR DESCRIPTION
* [CRM-20048: PayPal IPNs not processed if "receiver_email" != "business"](https://issues.civicrm.org/jira/browse/CRM-20048)