### PR TITLE
CRM-20059: rebuild menu and caches before running extension upgraders

### DIFF
--- a/CRM/Admin/Page/ExtensionsUpgrade.php
+++ b/CRM/Admin/Page/ExtensionsUpgrade.php
@@ -14,6 +14,8 @@ class CRM_Admin_Page_ExtensionsUpgrade extends CRM_Core_Page {
    * Run Page.
    */
   public function run() {
+    CRM_Core_Invoke::rebuildMenuAndCaches(TRUE);
+
     $queue = CRM_Extension_Upgrades::createQueue();
     $runner = new CRM_Queue_Runner(array(
       'title' => ts('Database Upgrades'),


### PR DESCRIPTION
When running extension upgraders from API using Extension.upgrade end-point ( e.g : drush cvapi Extension.upgrade ) then and before running the upgraders, civicrm will call : 

**CRM_Core_Invoke::rebuildMenuAndCaches(TRUE);**

which clear cache, rebuild menus, and most importantly ; it will run managed entity handler which may create,remove , update any managed entity needed .

 The things are different when running upgrader from UI ( from Extension manager page ) where that line of code is not called inside UI upgrader handler code which cause difference when running upgraders from UI vs running them from API if you have an extension that use managed entities .

 Look here to see the difference in code between UI & API : 

- API : https://github.com/omarabuhussein/civicrm-core/blob/master/api/v3/Extension.php#L86 
- UI : https://github.com/omarabuhussein/civicrm-core/blob/master/CRM/Admin/Page/ExtensionsUpgrade.php#L13 

So what is required is to update that UI handler code to call : **CRM_Core_Invoke::rebuildMenuAndCaches(TRUE);** before running upgraders to match what happen at API side .

---

 * [CRM-20059: running managed entites handler , clear cache and rebuild menus when running extension upgraders from UI](https://issues.civicrm.org/jira/browse/CRM-20059)