### PR TITLE
[wip] CRM-20147 Wrong user roles array indexing on Drupal8

### DIFF
--- a/CRM/Report/Form/Instance.php
+++ b/CRM/Report/Form/Instance.php
@@ -132,7 +132,7 @@ class CRM_Report_Form_Instance {
       if (function_exists('user_roles')) {
         $user_roles_array = user_roles();
         foreach ($user_roles_array as $key => $value) {
-          $user_roles[$value] = $value;
+          $user_roles[$key] = $key;
         }
         $grouprole = &$form->addElement('advmultiselect',
           'grouprole',


### PR DESCRIPTION
As the array was trying to be indexed by another array, changed it to be indexed by a String - in the same lines as it behaves in Civicrm for D7. Confirmed it to be working

---

 * [CRM-20147: Drupal8 All menus under 'Reports' gives php warning stating Warning: Illegal offset type in CRM_Report_Form_Instance::buildForm\(\) \(line 138 of \/Users\/vasanthakaje\/Sites\/devdesktop\/drupal819\/libraries\/civicrm\/CRM\/Report\/Form\/Instance.php\). =\> Array](https://issues.civicrm.org/jira/browse/CRM-20147)