### PR TITLE
CRM-20140: Fix alterMailParams hook to accept custom subject tokens

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1327,11 +1327,10 @@ ORDER BY   civicrm_email.is_bulkmail DESC
 
     $mailParams['attachments'] = $attachments;
 
-    $mailingSubject = CRM_Utils_Array::value('subject', $pEmails);
-    if (is_array($mailingSubject)) {
-      $mailingSubject = implode('', $mailingSubject);
+    $mailParams['Subject'] = CRM_Utils_Array::value('subject', $pEmails);
+    if (is_array($mailParams['Subject'])) {
+      $mailParams['Subject'] = implode('', $mailParams['Subject']);
     }
-    $mailParams['Subject'] = $mailingSubject;
 
     $mailParams['toName'] = CRM_Utils_Array::value('display_name',
       $contact
@@ -1400,7 +1399,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
 
     //CRM-5058
     //token replacement of subject
-    $headers['Subject'] = $mailingSubject;
+    $headers['Subject'] = $mailParams['Subject'];
 
     CRM_Utils_Mail::setMimeParams($message);
     $headers = $message->headers($headers);


### PR DESCRIPTION
## Problem

When trying to use  hook_civicrm_alterMailParams hook to alter the email subject (e.g : to replace custom tokens) , nothing will happen and your modifications to the mail subject will not have any affect on the sent email.  This is happening because the code assign $mailingSubject  to the mail subject where the actually variable that contain the subject with correct replaced values via alterMailParams is $mailParams['Subject'] which is get passed by reference to the hook. I have just changed the mailing bao class to use it instead.


## The problem in action 

if your myextension.php file contain this :

```php
function myextension_civicrm_alterMailParams(&$params, $context) {
  $params['Subject'] = 'aaa';
  $params['html'] = 'aaa';
}
```php

and no matter what the original email subject and body is , you should recienve an email with subject 'aaa' and body 'aaa' but what you will actually get is an email with only body = 'aaa' and the subject will equal the original assgined to it from UI.

This PR fixes this so in the case above you will have both subject and body = 'aaa'

---

 * [CRM-20140: CiviCRM alterMailParams hook does not work on subject ](https://issues.civicrm.org/jira/browse/CRM-20140)