### PR TITLE
(Regression) CRM_Mailing_ActionTokens - Degrade gracefully

### DIFF
--- a/CRM/Mailing/ActionTokens.php
+++ b/CRM/Mailing/ActionTokens.php
@@ -64,6 +64,13 @@ class CRM_Mailing_ActionTokens extends \Civi\Token\AbstractTokenSubscriber {
   /**
    * @inheritDoc
    */
+  public function checkActive(\Civi\Token\TokenProcessor $processor) {
+    return !empty($processor->context['mailingId']) || !empty($processor->context['mailing']);
+  }
+
+  /**
+   * @inheritDoc
+   */
   public function evaluateToken(
     \Civi\Token\TokenRow $row,
     $entity,


### PR DESCRIPTION
Most of the `CRM_*_Tokens` classes include a `checkActive()` function which prevents them from trying to do anything if they don't have the necessary data.  However, this one was missing it, which means that it attempts to evalute `{action.*}` tokens even when they're not valid.

Note: This was reported on [Stack Exchange](http://civicrm.stackexchange.com/questions/17239/scheduled-reminders-problem-in-v-4-7-16). As of this writing, I haven't had a chance to reproduce or test the fix in a full deployment, but I'm opening the PR to get the test-suite and discussion going.