### PR TITLE
(WIP) CRM-20160 - Remove restriction on which entities the Attachment api supports

### DIFF
--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -326,8 +326,7 @@ class Container {
        FROM civicrm_custom_field fld
        INNER JOIN civicrm_custom_group grp ON fld.custom_group_id = grp.id
        WHERE fld.data_type = "File"
-      ',
-      array('civicrm_activity', 'civicrm_mailing', 'civicrm_contact', 'civicrm_grant')
+      '
     ));
 
     $kernel->setApiProviders(array(

--- a/tests/phpunit/api/v3/AttachmentTest.php
+++ b/tests/phpunit/api/v3/AttachmentTest.php
@@ -153,16 +153,6 @@ class api_v3_AttachmentTest extends CiviUnitTestCase {
       ),
       "/Malformed name/",
     );
-    $cases[] = array(
-      'CRM_Core_DAO_Domain',
-      array(
-        'name' => self::getFilePrefix() . 'exampleFromContent.txt',
-        'mime_type' => 'text/plain',
-        'description' => 'My test description',
-        'content' => 'My test content',
-      ),
-      "/Unrecognized target entity/",
-    );
 
     return $cases;
   }


### PR DESCRIPTION
* [CRM-20160: Attachment api does not work with all entities](https://issues.civicrm.org/jira/browse/CRM-20160)