### PR TITLE
CRM-19490: Profile date fields don't respect localisation on the Cont…

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -5908,7 +5908,7 @@ AND   displayRelType.is_active = 1
         // This is a temporary routine for handling these fields while
         // we figure out how to handled them based on metadata in
         /// export and search builder. CRM-19815, CRM-19830.
-        if (isset($dao->$realField) && is_numeric($dao->$realField)) {
+        if (isset($dao->$realField) && is_numeric($dao->$realField) && isset($dao->$labelField)) {
           $dao->$realField = $dao->$labelField;
         }
       }

--- a/CRM/Core/Smarty/plugins/modifier.crmDate.php
+++ b/CRM/Core/Smarty/plugins/modifier.crmDate.php
@@ -56,6 +56,10 @@ function smarty_modifier_crmDate($dateString, $dateFormat = NULL, $onlyTime = FA
       $config = CRM_Core_Config::singleton();
       $dateFormat = $config->dateformatTime;
     }
+    // Handle possibility we only have a date function style date format.
+    if ($dateFormat && !stristr('%', $dateFormat)) {
+      return date($dateFormat, strtotime($dateString));
+    }
 
     return CRM_Utils_Date::customFormat($dateString, $dateFormat);
   }

--- a/CRM/Core/Smarty/plugins/modifier.crmDate.php
+++ b/CRM/Core/Smarty/plugins/modifier.crmDate.php
@@ -57,7 +57,7 @@ function smarty_modifier_crmDate($dateString, $dateFormat = NULL, $onlyTime = FA
       $dateFormat = $config->dateformatTime;
     }
     // Handle possibility we only have a date function style date format.
-    if ($dateFormat && !stristr('%', $dateFormat)) {
+    if ($dateFormat && !stristr($dateFormat, '%')) {
       return date($dateFormat, strtotime($dateString));
     }
 

--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -1775,20 +1775,22 @@ class CRM_Utils_Date {
   public static function addDateMetadataToField($fieldMetaData, $field) {
     if (isset($fieldMetaData['html'])) {
       $field['html_type'] = $fieldMetaData['html']['type'];
-      if ($field['html_type'] === 'Select Date' && !isset($field['date_format'])) {
-        $dateAttributes = CRM_Core_SelectValues::date($fieldMetaData['html']['formatType'], NULL, NULL, NULL, 'Input');
-        $field['start_date_years'] = $dateAttributes['minYear'];
-        $field['end_date_years'] = $dateAttributes['maxYear'];
-        $field['date_format'] = $dateAttributes['format'];
-        $field['is_datetime_field'] = TRUE;
-        $field['time_format'] = $dateAttributes['time'];
-        $field['php_datetime_format'] = CRM_Utils_Date::getPhpDateFormatFromInputStyleDateFormat($field['date_format']);
-        if ($field['time_format']) {
-          $field['php_datetime_format'] .= ' H-i-s';
+      if ($field['html_type'] === 'Select Date') {
+        if (!isset($field['date_format'])) {
+          $dateAttributes = CRM_Core_SelectValues::date($fieldMetaData['html']['formatType'], NULL, NULL, NULL, 'Input');
+          $field['start_date_years'] = $dateAttributes['minYear'];
+          $field['end_date_years'] = $dateAttributes['maxYear'];
+          $field['date_format'] = $dateAttributes['format'];
+          $field['is_datetime_field'] = TRUE;
+          $field['time_format'] = $dateAttributes['time'];
+          $field['php_datetime_format'] = CRM_Utils_Date::getPhpDateFormatFromInputStyleDateFormat($field['date_format']);
+          if ($field['time_format']) {
+            $field['php_datetime_format'] .= ' H-i-s';
+          }
         }
+        $field['datepicker']['extra'] = self::getDatePickerExtra($field);
+        $field['datepicker']['attributes'] = self::getDatePickerAttributes($field);
       }
-      $field['datepicker']['extra'] = self::getDatePickerExtra($field);
-      $field['datepicker']['attributes'] = self::getDatePickerAttributes($field);
     }
     return $field;
   }

--- a/templates/CRM/UF/Form/Fields.tpl
+++ b/templates/CRM/UF/Form/Fields.tpl
@@ -89,19 +89,17 @@
             {include file="CRM/Profile/Form/GreetingType.tpl"}
           {elseif ($profileFieldName eq 'group' && $form.group) || ($profileFieldName eq 'tag' && $form.tag)}
             {include file="CRM/Contact/Form/Edit/TagsAndGroups.tpl" type=$profileFieldName title=null context="profile"}
-          {elseif ( $profileFieldName|substr:-5:5 eq '_date' ) AND
-          ( $form.formName neq 'Confirm' )  AND
-          ( $form.formName neq 'ThankYou' ) }
-            {include file="CRM/common/jcalendar.tpl" elementName=$profileFieldName}
           {elseif $field.is_datetime_field && $action == 4}
             {assign var="date_value" value=$form.$profileFieldName.value}
             <span class="crm-frozen-field">
-              {$date_value|date_format:"%Y-%m-%d"|crmDate:$field.php_datetime_format}
+              {$date_value|date_format:"%Y-%m-%d"|crmDate:$config->dateformatshortdate}
               <input type="hidden"
                name="{$form.$profileFieldName.name}"
                value="{$form.$profileFieldName.value}" id="{$form.$profileFieldName.name}"
               >
             </span>
+          {elseif $field.is_legacy_date}
+            {include file="CRM/common/jcalendar.tpl" elementName=$profileFieldName}
           {elseif $profileFieldName|substr:0:5 eq 'phone'}
             {assign var="phone_ext_field" value=$profileFieldName|replace:'phone':'phone_ext'}
             {if $prefix}{$form.$prefix.$profileFieldName.html}{else}{$form.$profileFieldName.html}{/if}

--- a/templates/CRM/UF/Form/Fields.tpl
+++ b/templates/CRM/UF/Form/Fields.tpl
@@ -93,12 +93,15 @@
           ( $form.formName neq 'Confirm' )  AND
           ( $form.formName neq 'ThankYou' ) }
             {include file="CRM/common/jcalendar.tpl" elementName=$profileFieldName}
-          {elseif ( $profileFieldName|substr:-5:5 eq '_date' ) }
+          {elseif $field.is_datetime_field && $action == 4}
             {assign var="date_value" value=$form.$profileFieldName.value}
             <span class="crm-frozen-field">
-                  {$date_value|date_format:"%Y-%m-%d"|crmDate:$config->dateformatshortdate}
-              <input type="hidden" name="{$form.$profileFieldName.name}" value="{$form.$profileFieldName.value}" id="{$form.$profileFieldName.name}">
-                </span>
+              {$date_value|date_format:"%Y-%m-%d"|crmDate:$field.php_datetime_format}
+              <input type="hidden"
+               name="{$form.$profileFieldName.name}"
+               value="{$form.$profileFieldName.value}" id="{$form.$profileFieldName.name}"
+              >
+            </span>
           {elseif $profileFieldName|substr:0:5 eq 'phone'}
             {assign var="phone_ext_field" value=$profileFieldName|replace:'phone':'phone_ext'}
             {if $prefix}{$form.$prefix.$profileFieldName.html}{else}{$form.$profileFieldName.html}{/if}

--- a/templates/CRM/UF/Form/Fields.tpl
+++ b/templates/CRM/UF/Form/Fields.tpl
@@ -89,7 +89,7 @@
             {include file="CRM/Profile/Form/GreetingType.tpl"}
           {elseif ($profileFieldName eq 'group' && $form.group) || ($profileFieldName eq 'tag' && $form.tag)}
             {include file="CRM/Contact/Form/Edit/TagsAndGroups.tpl" type=$profileFieldName title=null context="profile"}
-          {elseif $field.is_datetime_field && $action == 4}
+          {elseif $field.is_datetime_field && $action & 4}
             {assign var="date_value" value=$form.$profileFieldName.value}
             <span class="crm-frozen-field">
               {$date_value|date_format:"%Y-%m-%d"|crmDate:$config->dateformatshortdate}


### PR DESCRIPTION
…ribution Page confirmation screen

@seamuslee001 This is a narrow fix for the confirmation screen building on the stuff we've been working on .

The change to the Date file is just a tidy up of a previous commit - I was adding datepicker to all fields rather than only those that need them

The srtftime (posix?) format ALWAYS has a '%' in it - so we can actually make crmDate cope with either posix format or php date format quite easily, however some confusion has come through discussions about whether to use the format configured for the field for view purposes. Discussed with @seamuslee001 & he made the case that the shortDateFormat is most consistent for view purposes