### PR TITLE
CRM-19900 Enable/Disable payment processor from summary page only disables live

### DIFF
--- a/CRM/Admin/Form/PaymentProcessor.php
+++ b/CRM/Admin/Form/PaymentProcessor.php
@@ -166,8 +166,22 @@ class CRM_Admin_Form_PaymentProcessor extends CRM_Admin_Form {
   public function buildQuickForm($check = FALSE) {
     parent::buildQuickForm();
 
-    if ($this->_action & CRM_Core_Action::DELETE) {
-      return;
+    switch ($this->_action) {
+      case CRM_Core_Action::DELETE:
+        return;
+        break;
+      case CRM_Core_Action::DISABLE:
+        CRM_Financial_BAO_PaymentProcessor::enable($this->_id, false);
+        CRM_Utils_System::redirect('/civicrm/admin/paymentProcessor?reset=1');
+        CRM_Core_Session::setStatus("", ts('Payment Processor Disabled.'), "success");
+        return;
+        break;
+      case CRM_Core_Action::ENABLE:
+        CRM_Financial_BAO_PaymentProcessor::enable($this->_id, true);
+        CRM_Utils_System::redirect('/civicrm/admin/paymentProcessor?reset=1');
+        CRM_Core_Session::setStatus("", ts('Payment Processor Enabled.'), "success");
+        return;
+        break;
     }
 
     $attributes = CRM_Core_DAO::getAttribute('CRM_Financial_DAO_PaymentProcessor');

--- a/CRM/Admin/Page/PaymentProcessor.php
+++ b/CRM/Admin/Page/PaymentProcessor.php
@@ -70,12 +70,14 @@ class CRM_Admin_Page_PaymentProcessor extends CRM_Core_Page_Basic {
         ),
         CRM_Core_Action::DISABLE => array(
           'name' => ts('Disable'),
-          'ref' => 'crm-enable-disable',
+          'url' => 'civicrm/admin/paymentProcessor',
+          'qs' => 'action=disable&id=%%id%%',
           'title' => ts('Disable Payment Processor'),
         ),
         CRM_Core_Action::ENABLE => array(
           'name' => ts('Enable'),
-          'ref' => 'crm-enable-disable',
+          'url' => 'civicrm/admin/paymentProcessor',
+          'qs' => 'action=enable&id=%%id%%',
           'title' => ts('Enable Payment Processor'),
         ),
         CRM_Core_Action::DELETE => array(

--- a/CRM/Core/I18n/Schema.php
+++ b/CRM/Core/I18n/Schema.php
@@ -188,20 +188,18 @@ class CRM_Core_I18n_Schema {
       }
     }
 
-    $dao = new CRM_Core_DAO();
     // deal with columns
     foreach ($columns[$table] as $column => $type) {
-      $queries[] = "ALTER TABLE {$table} CHANGE `{$column}_{$retain}` `{$column}` {$type}";
+      $queries[] = "ALTER TABLE {$table} ADD {$column} {$type}";
+      $queries[] = "UPDATE {$table} SET {$column} = {$column}_{$retain}";
       foreach ($locales as $loc) {
-        if (strcmp($loc, $retain) !== 0) {
-          $dropQueries[] = "ALTER TABLE {$table} DROP {$column}_{$loc}";
-        }
+        $dropQueries[] = "ALTER TABLE {$table} DROP {$column}_{$loc}";
       }
     }
 
     // drop views
     foreach ($locales as $loc) {
-      $queries[] = "DROP VIEW IF EXISTS {$table}_{$loc}";
+      $queries[] = "DROP VIEW {$table}_{$loc}";
     }
 
     // add original indices

--- a/CRM/Core/I18n/Schema.php
+++ b/CRM/Core/I18n/Schema.php
@@ -188,18 +188,20 @@ class CRM_Core_I18n_Schema {
       }
     }
 
+    $dao = new CRM_Core_DAO();
     // deal with columns
     foreach ($columns[$table] as $column => $type) {
-      $queries[] = "ALTER TABLE {$table} ADD {$column} {$type}";
-      $queries[] = "UPDATE {$table} SET {$column} = {$column}_{$retain}";
+      $queries[] = "ALTER TABLE {$table} CHANGE `{$column}_{$retain}` `{$column}` {$type}";
       foreach ($locales as $loc) {
-        $dropQueries[] = "ALTER TABLE {$table} DROP {$column}_{$loc}";
+        if (strcmp($loc,$retain) !== 0) {
+          $dropQueries[] = "ALTER TABLE {$table} DROP {$column}_{$loc}";
+        }
       }
     }
 
     // drop views
     foreach ($locales as $loc) {
-      $queries[] = "DROP VIEW {$table}_{$loc}";
+      $queries[] = "DROP VIEW IF EXISTS {$table}_{$loc}";
     }
 
     // add original indices

--- a/CRM/Core/I18n/Schema.php
+++ b/CRM/Core/I18n/Schema.php
@@ -193,7 +193,7 @@ class CRM_Core_I18n_Schema {
     foreach ($columns[$table] as $column => $type) {
       $queries[] = "ALTER TABLE {$table} CHANGE `{$column}_{$retain}` `{$column}` {$type}";
       foreach ($locales as $loc) {
-        if (strcmp($loc,$retain) !== 0) {
+        if (strcmp($loc, $retain) !== 0) {
           $dropQueries[] = "ALTER TABLE {$table} DROP {$column}_{$loc}";
         }
       }

--- a/CRM/Financial/BAO/PaymentProcessor.php
+++ b/CRM/Financial/BAO/PaymentProcessor.php
@@ -146,6 +146,36 @@ class CRM_Financial_BAO_PaymentProcessor extends CRM_Financial_DAO_PaymentProces
   }
 
   /**
+   * Enable/Disable payment processor.
+   *
+   * @param int $paymentProcessorID
+   * @param bool $is_active
+   *
+   * @return null
+   */
+  public static function enable($paymentProcessorID, $is_active) {
+    if (!$paymentProcessorID) {
+      CRM_Core_Error::fatal(ts('Invalid value passed to enable function.'));
+    }
+
+    $dao = new CRM_Financial_DAO_PaymentProcessor();
+    $dao->id = $paymentProcessorID;
+    if (!$dao->find(TRUE)) {
+      return NULL;
+    }
+    self::setIsActive($dao->id, $is_active);
+
+    $testDAO = new CRM_Financial_DAO_PaymentProcessor();
+    $testDAO->name = $dao->name;
+    $testDAO->is_test = 1;
+      if (!$testDAO->find(TRUE)) {
+      return NULL;
+    }
+    self::setIsActive($testDAO->id, $is_active);
+    Civi\Payment\System::singleton()->flushProcessors();
+  }
+
+  /**
    * Retrieve the default payment processor.
    *
    * @return CRM_Financial_DAO_PaymentProcessor|null

--- a/templates/CRM/Admin/Page/PaymentProcessor.tpl
+++ b/templates/CRM/Admin/Page/PaymentProcessor.tpl
@@ -34,8 +34,6 @@
 {if $rows}
 <div id="ltype">
         {strip}
-        {* handle enable/disable actions*}
-   {include file="CRM/common/enableDisableApi.tpl"}
         <table class="selector row-highlight">
         <tr class="columnheader">
             <th >{ts}Name{/ts}</th>


### PR DESCRIPTION
Don't use generic javascript function on summary screen as this calls setIsActive which only works on the current Payment Processor ID (which will be the live one). Add a function in Financial BAO Paymentprocessor to enable/disable payment processor and trigger this instead.

---

 * [CRM-19900: Enable\/Disable payment processor from summary page only disables live](https://issues.civicrm.org/jira/browse/CRM-19900)