### PR TITLE
MailingGroup API - Tighten up deprecations

### DIFF
--- a/api/v3/MailingGroup.php
+++ b/api/v3/MailingGroup.php
@@ -40,7 +40,13 @@
  *   to indicate this entire api entity is deprecated
  */
 function _civicrm_api3_mailing_group_deprecation() {
-  return 'The MailingGroup api is deprecated. Use the mailing_event apis instead.';
+  $message = 'This action is deprecated. Use the mailing_event API instead.';
+  return array(
+    'event_unsubscribe' => $message,
+    'event_domain_unsubscribe' => $message,
+    'event_resubscribe' => $message,
+    'event_subscribe' => $message,
+  );
 }
 
 /**


### PR DESCRIPTION
The `MailingGroup.php` includes some very different APIs, e.g.
 * Several 'event'(subscribue/resubscribe) APIs
 * Some CRUD APIs for mailing data

The deprecation applies to the 'event' (subscribe/resubscribe) APIs --
because those can be done another way.  However, the CRUD for `MailingGroup`
records is the only way to do access that data.