### PR TITLE
CRM-20154 Dedupe - remove unused autoflip parameter

### DIFF
--- a/CRM/Contact/Page/DedupeFind.php
+++ b/CRM/Contact/Page/DedupeFind.php
@@ -88,7 +88,7 @@ class CRM_Contact_Page_DedupeFind extends CRM_Core_Page_Basic {
     }
     elseif ($action & CRM_Core_Action::MAP) {
       // do a batch merge if requested
-      $result = CRM_Dedupe_Merger::batchMerge($rgid, $gid, 'safe', TRUE, 75);
+      $result = CRM_Dedupe_Merger::batchMerge($rgid, $gid, 'safe', 75);
 
       $skippedCount = CRM_Utils_Request::retrieve('skipped', 'Positive', $this, FALSE, 0);
       $skippedCount = $skippedCount + count($result['skipped']);

--- a/CRM/Contact/Page/DedupeMerge.php
+++ b/CRM/Contact/Page/DedupeMerge.php
@@ -126,17 +126,13 @@ class CRM_Contact_Page_DedupeMerge extends CRM_Core_Page {
    * @param int $gid
    * @param string $mode
    *   'safe' mode or 'force' mode.
-   * @param bool $autoFlip
-   *   Override the values in the prevnext table & use the lowest value?
-   *   As the form offers the user to flip the values themselves this should
-   *   only be TRUE if you wish to ignore the user.
    * @param int $batchLimit
    * @param int $isSelected
    *
    * @return int
    */
-  public static function callBatchMerge(CRM_Queue_TaskContext $ctx, $rgid, $gid, $mode = 'safe', $autoFlip, $batchLimit, $isSelected) {
-    CRM_Dedupe_Merger::batchMerge($rgid, $gid, $mode, $autoFlip, $batchLimit, $isSelected);
+  public static function callBatchMerge(CRM_Queue_TaskContext $ctx, $rgid, $gid, $mode = 'safe', $batchLimit, $isSelected) {
+    CRM_Dedupe_Merger::batchMerge($rgid, $gid, $mode, $batchLimit, $isSelected);
     return CRM_Queue_Task::TASK_SUCCESS;
   }
 

--- a/CRM/Contact/Page/DedupeMerge.php
+++ b/CRM/Contact/Page/DedupeMerge.php
@@ -98,7 +98,7 @@ class CRM_Contact_Page_DedupeMerge extends CRM_Core_Page {
     for ($i = 1; $i <= ceil($total / self::BATCHLIMIT); $i++) {
       $task  = new CRM_Queue_Task(
         array('CRM_Contact_Page_DedupeMerge', 'callBatchMerge'),
-        array($rgid, $gid, $mode, FALSE, self::BATCHLIMIT, $isSelected),
+        array($rgid, $gid, $mode, self::BATCHLIMIT, $isSelected),
         "Processed " . $i * self::BATCHLIMIT . " pair of duplicates out of " . $total
       );
 

--- a/CRM/Core/OptionGroup.php
+++ b/CRM/Core/OptionGroup.php
@@ -262,9 +262,9 @@ WHERE  v.option_group_id = g.id
   }
 
   /**
-   * Lookup titles OR ids for a set of option_value populated fields. The retrieved value
-   * is assigned a new fieldname by id or id's by title
-   * (each within a specificied option_group)
+   * Lookup titles OR ids for a set of option_value populated fields. The
+   * retrieved value is assigned a new field name by id or id's by title
+   * (each within a specified option_group).
    *
    * @param array $params
    *   Reference array of values submitted by the form. Based on.
@@ -274,10 +274,9 @@ WHERE  v.option_group_id = g.id
    *   If $flip = true, adds actual field name => id
    *
    * @param array $names
-   *   Reference array of fieldnames we want transformed.
+   *   Array of field names we want transformed.
    *   Array key = 'postName' (field name submitted by form in $params).
    *   Array value = array('newName' => $newName, 'groupName' => $groupName).
-   *
    *
    * @param bool $flip
    */

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -589,8 +589,6 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
    *   Helps decide how to behave when there are conflicts.
    *   A 'safe' value skips the merge if there are any un-resolved conflicts, wheras 'aggressive'
    *   mode does a force merge.
-   * @param bool $autoFlip to let api decide which contact to retain and which to delete.
-   *   Whether to let api decide which contact to retain and which to delete.
    * @param int $batchLimit number of merges to carry out in one batch.
    * @param int $isSelected if records with is_selected column needs to be processed.
    *
@@ -602,7 +600,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
    *
    * @return array|bool
    */
-  public static function batchMerge($rgid, $gid = NULL, $mode = 'safe', $autoFlip = TRUE, $batchLimit = 1, $isSelected = 2, $criteria = array(), $checkPermissions = TRUE) {
+  public static function batchMerge($rgid, $gid = NULL, $mode = 'safe', $batchLimit = 1, $isSelected = 2, $criteria = array(), $checkPermissions = TRUE) {
     $redirectForPerformance = ($batchLimit > 1) ? TRUE : FALSE;
     $reloadCacheIfEmpty = (!$redirectForPerformance && $isSelected == 2);
     $dupePairs = self::getDuplicatePairs($rgid, $gid, $reloadCacheIfEmpty, $batchLimit, $isSelected, '', ($mode == 'aggressive'), $criteria, $checkPermissions);

--- a/api/v3/Job.php
+++ b/api/v3/Job.php
@@ -487,11 +487,9 @@ function civicrm_api3_job_process_batch_merge($params) {
     ));
   }
   $gid = CRM_Utils_Array::value('gid', $params);
-
   $mode = CRM_Utils_Array::value('mode', $params, 'safe');
-  $autoFlip = CRM_Utils_Array::value('auto_flip', $params, TRUE);
 
-  $result = CRM_Dedupe_Merger::batchMerge($rule_group_id, $gid, $mode, $autoFlip, 1, 2, CRM_Utils_Array::value('criteria', $params, array()), CRM_Utils_Array::value('check_permissions', $params));
+  $result = CRM_Dedupe_Merger::batchMerge($rule_group_id, $gid, $mode, 1, 2, CRM_Utils_Array::value('criteria', $params, array()), CRM_Utils_Array::value('check_permissions', $params));
 
   return civicrm_api3_create_success($result, $params);
 }

--- a/tests/phpunit/CRM/Dedupe/MergerTest.php
+++ b/tests/phpunit/CRM/Dedupe/MergerTest.php
@@ -176,7 +176,7 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
     $this->assertEquals($pnDupePairs[0]['is_selected'], 1, 'Check if second record in dupe pairs is marked as selected.');
 
     // batch merge selected dupes
-    $result = CRM_Dedupe_Merger::batchMerge($dao->id, $this->_groupId, 'safe', TRUE, 5, 1);
+    $result = CRM_Dedupe_Merger::batchMerge($dao->id, $this->_groupId, 'safe', 5, 1);
     $this->assertEquals(count($result['merged']), 2, 'Check number of merged pairs.');
 
     // retrieve pairs from prev next cache table
@@ -232,7 +232,7 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
     $this->assertEquals(count($foundDupes), count($pnDupePairs), 'Check number of dupe pairs in prev next cache.');
 
     // batch merge all dupes
-    $result = CRM_Dedupe_Merger::batchMerge($dao->id, $this->_groupId, 'safe', TRUE, 5, 2);
+    $result = CRM_Dedupe_Merger::batchMerge($dao->id, $this->_groupId, 'safe', 5, 2);
     $this->assertEquals(count($result['merged']), 3, 'Check number of merged pairs.');
 
     // retrieve pairs from prev next cache table


### PR DESCRIPTION
Remove unused autoflips and code improvement in optiongroup lookup

---

 * [CRM-20154: dedupe code improvement, remove unused autoflip parameter](https://issues.civicrm.org/jira/browse/CRM-20154)