### PR TITLE
CRM-20059: Prevent rebuilding menu, cache and managed entities before running upgraders from API

### DIFF
--- a/api/v3/Extension.php
+++ b/api/v3/Extension.php
@@ -83,7 +83,6 @@ function _civicrm_api3_extension_install_spec(&$fields) {
  *   API result
  */
 function civicrm_api3_extension_upgrade() {
-  CRM_Core_Invoke::rebuildMenuAndCaches(TRUE);
   $queue = CRM_Extension_Upgrades::createQueue();
   $runner = new CRM_Queue_Runner(array(
     'title' => 'Extension Upgrades',


### PR DESCRIPTION
Removing this line fixes the following scenario but it could be also happen with different scenarios :

1- Your extension use **hook_civicrm_managed** or **hook_civicrm_caseTypes** to create a case type (let's say its create a one called 'test').

2- Your extension is deployed to many sites but then you have decided to remove this case type from you extension for whatever reason.

3- You removed hook_civicrm_managed or hook_caseTypes implementation from the extension and wrote a new upgrader to remove the managed record from civicrm_managed table.

4- You deployed the new extension code to all exiting sites which have this extension and then run the upgraders via this API end point (civicrm_ap3_extension_upgrade).

5- Since before running upgraders via API **rebuildMenuAndCaches**  will get invoked which invokes managed entities handler , and because you managed entity hook implementation is
not exist anymore but it is still defined on the site civicrm_managed table (since the upgrader which removes the records from civicrm_managed does not get executed yet)
then managed entity handler will try to remove these case types which is fine.

6- but if this case type is linked to any existing case record, and due to how case delete is designed an exception will be thrown preventing you from running any upgrader.

7- also it doesn't matter what you put in 'cleanup' field for the managed case type , the error will always appear.

While this could be fixed at case delete BAO method, you cannot know on which other entity it will also appear  and it also doesn't make much sense to run managed entity handler
before running extension upgraders.

 removing this will give developers better way to remove managed entity records via their upgraders for existing sites without having any problem with that in the future .

---

 * [CRM-20059: running managed entites handler , clear cache and rebuild menus when running extension upgraders from UI](https://issues.civicrm.org/jira/browse/CRM-20059)