### PR TITLE
CRM-20180 - Documentation URLs should contain "stable" *or* "current", not both

### DIFF
--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1391,7 +1391,7 @@ class CRM_Utils_System {
    * @return mixed
    */
   public static function formatDocUrl($url) {
-    return preg_replace('#^user/((\w\w/)?stable/)?#', 'user/en/stable/', $url);
+    return preg_replace('#^user/((\w\w/)?(stable|current)/)?#', 'user/en/stable/', $url);
   }
 
   /**


### PR DESCRIPTION
Examples:

 * In "Administer => Communications => Scheduled Reminders", the green box has
   a link to "learn more". This links to "https://docs.civicrm.org/user/en/stable/current/email/scheduled-reminders/"
 * In "Search =>= Advanced Search", view the help for "Views for Display Contacts".
   The help message includes a link to "https://docs.civicrm.org/user/en/stable/current/organising-your-data/profiles"

Both examples include the redundant formulation "user/en/stable/current" and
point to non-existent pages.  Use either "stable" or "current".  It would be
silly for one installation to contain a mix of links for "stable" and
"current".  It appears that `formatDocUrl()` aims to normalize these.

---

 * [CRM-20180: Several documentation links are malformed](https://issues.civicrm.org/jira/browse/CRM-20180)