### PR TITLE
Extension.download API - Allow downloading without installing

### DIFF
--- a/api/v3/Extension.php
+++ b/api/v3/Extension.php
@@ -244,7 +244,9 @@ function civicrm_api3_extension_download($params) {
   }
   CRM_Extension_System::singleton()->getCache()->flush();
   CRM_Extension_System::singleton(TRUE);
-  CRM_Extension_System::singleton()->getManager()->install(array($params['key']));
+  if (CRM_Utils_Array::value('install', $params, TRUE)) {
+    CRM_Extension_System::singleton()->getManager()->install(array($params['key']));
+  }
 
   return civicrm_api3_create_success();
 }
@@ -264,6 +266,12 @@ function _civicrm_api3_extension_download_spec(&$fields) {
     'title' => 'Download URL',
     'type' => CRM_Utils_Type::T_STRING,
     'description' => 'Optional as the system can determine the url automatically for public extensions',
+  );
+  $fields['install'] = array(
+    'title' => 'Auto-install',
+    'type' => CRM_Utils_Type::T_STRING,
+    'description' => 'Automatically install the downloaded extension',
+    'api.default' => TRUE,
   );
 }
 


### PR DESCRIPTION
The current `download` action does both download and install. This option
preserves the default behavior but allows one to opt-out of installation.