### PR TITLE
CRM-20181. Deprecate CRM_Core_Error::fatal().

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -318,6 +318,8 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    *   The email address to notify of this situation.
    *
    * @throws Exception
+   *
+   * @deprecated
    */
   public static function fatal($message = NULL, $code = NULL, $email = NULL) {
     $vars = array(

--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -310,6 +310,11 @@ class CRM_Core_Error extends PEAR_ErrorStack {
   /**
    * Display an error page with an error message describing what happened.
    *
+   * @deprecated
+   *  This is a really annoying function. We ❤ exceptions. Be exceptional!
+   *
+   * @see CRM-20181
+   *
    * @param string $message
    *   The error message.
    * @param string $code
@@ -318,8 +323,6 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    *   The email address to notify of this situation.
    *
    * @throws Exception
-   *
-   * @deprecated
    */
   public static function fatal($message = NULL, $code = NULL, $email = NULL) {
     $vars = array(


### PR DESCRIPTION
Mark `CRM_Core_Error::fatal()` as deprecated.

---

 * [CRM-20181: Deprecate CRM_Core_Error::fatal\(\)](https://issues.civicrm.org/jira/browse/CRM-20181)