### PR TITLE
fixes for CRM-20187

### DIFF
--- a/templates/CRM/Activity/Form/ActivityLinks.tpl
+++ b/templates/CRM/Activity/Form/ActivityLinks.tpl
@@ -68,7 +68,8 @@
 {if $hookLinks}
    {foreach from=$hookLinks item=link}
     <li>
-        <a href="{$link.url}" data-tab="activity"{if !empty($link.title)} title="{$link.title}"{/if}>
+        <a href="{$link.url}" data-tab="activity"{if !empty($link.title)} title="{$link.title}"{/if}
+        {if !empty($link.class)} class="{$link.class}"{/if}>
           {if $link.img}
                 <img src="{$link.img}" alt="{$link.title}" />&nbsp;
           {/if}


### PR DESCRIPTION
* [CRM-20187: allow class parameter for hook_civicrm_links\(\) ](https://issues.civicrm.org/jira/browse/CRM-20187)