### PR TITLE
CRM-19492 Merging: disable location settings if the relevant checkbox isn't selected

### DIFF
--- a/CRM/Contact/Form/Merge.php
+++ b/CRM/Contact/Form/Merge.php
@@ -78,14 +78,8 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
     $this->limit = CRM_Utils_Request::retrieve('limit', 'Positive', $this, FALSE);
     $urlParams = "reset=1&rgid={$this->_rgid}&gid={$this->_gid}&limit=" . $this->limit;
 
-    // Sanity check
-    if ($cid == $oid) {
-      CRM_Core_Error::statusBounce(ts('Cannot merge a contact with itself.'));
-    }
+    $this->bounceIfInvalid($cid, $oid);
 
-    if (!CRM_Dedupe_BAO_Rule::validateContacts($cid, $oid)) {
-      CRM_Core_Error::statusBounce(ts('The selected pair of contacts are marked as non duplicates. If these records should be merged, you can remove this exception on the <a href="%1">Dedupe Exceptions</a> page.', array(1 => CRM_Utils_System::url('civicrm/dedupe/exception', 'reset=1'))));
-    }
     $this->_contactType = civicrm_api3('Contact', 'getvalue', array('id' => $cid, 'return' => 'contact_type'));
 
     $browseUrl = CRM_Utils_System::url('civicrm/contact/dedupefind', $urlParams . '&action=browse');
@@ -110,14 +104,6 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
     $where = "de.id IS NULL";
 
     $pos = CRM_Core_BAO_PrevNextCache::getPositions($cacheKey, $cid, $oid, $this->_mergeId, $join, $where, $flip);
-
-    // Block access if user does not have EDIT permissions for both contacts.
-    if (!(CRM_Contact_BAO_Contact_Permission::allow($cid, CRM_Core_Permission::EDIT) &&
-      CRM_Contact_BAO_Contact_Permission::allow($oid, CRM_Core_Permission::EDIT)
-    )
-    ) {
-      CRM_Utils_System::permissionDenied();
-    }
 
     // get user info of main contact.
     $config = CRM_Core_Config::singleton();
@@ -182,15 +168,6 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
     $this->assign('user', $cmsUser);
 
     $session = CRM_Core_Session::singleton();
-
-    // ensure that oid is not the current user, if so refuse to do the merge
-    if ($session->get('userID') == $oid) {
-      $display_name = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $oid, 'display_name');
-      $message = ts('The contact record which is linked to the currently logged in user account - \'%1\' - cannot be deleted.',
-        array(1 => $display_name)
-      );
-      CRM_Core_Error::statusBounce($message);
-    }
 
     $rowsElementsAndInfo = CRM_Dedupe_Merger::getRowsElementsAndInfo($cid, $oid);
     $main = $this->_mainDetails = &$rowsElementsAndInfo['main_details'];
@@ -364,6 +341,41 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
     }
 
     CRM_Utils_System::redirect($url);
+  }
+
+  /**
+   * Bounce if the merge action is invalid.
+   *
+   * We don't allow the merge if it is nonsensical, marked as a duplicate
+   * or outside the user's permission.
+   *
+   * @param int $cid
+   *   Contact ID to retain
+   * @param int $oid
+   *   Contact ID to delete.
+   */
+  public function bounceIfInvalid($cid, $oid) {
+    if ($cid == $oid) {
+      CRM_Core_Error::statusBounce(ts('Cannot merge a contact with itself.'));
+    }
+
+    if (!CRM_Dedupe_BAO_Rule::validateContacts($cid, $oid)) {
+      CRM_Core_Error::statusBounce(ts('The selected pair of contacts are marked as non duplicates. If these records should be merged, you can remove this exception on the <a href="%1">Dedupe Exceptions</a> page.', array(1 => CRM_Utils_System::url('civicrm/dedupe/exception', 'reset=1'))));
+    }
+
+    if (!(CRM_Contact_BAO_Contact_Permission::allow($cid, CRM_Core_Permission::EDIT) &&
+      CRM_Contact_BAO_Contact_Permission::allow($oid, CRM_Core_Permission::EDIT)
+    )
+    ) {
+      CRM_Utils_System::permissionDenied();
+    }
+    // ensure that oid is not the current user, if so refuse to do the merge
+    if (CRM_Core_Session::singleton()->getLoggedInContactID() == $oid) {
+      $message = ts('The contact record which is linked to the currently logged in user account - \'%1\' - cannot be deleted.',
+        array(1 => CRM_Core_Session::singleton()->getLoggedInContactDisplayName())
+      );
+      CRM_Core_Error::statusBounce($message);
+    }
   }
 
 }

--- a/CRM/Contact/Form/Merge.php
+++ b/CRM/Contact/Form/Merge.php
@@ -95,7 +95,7 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
     }
     $this->assign('browseUrl', $browseUrl);
     if ($browseUrl) {
-      $session->pushUserContext($browseUrl);
+      CRM_Core_Session::singleton()->pushUserContext($browseUrl);
     }
 
     $cacheKey = CRM_Dedupe_Merger::getMergeCacheKeyString($this->_rgid, $gid);
@@ -170,8 +170,8 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
     $session = CRM_Core_Session::singleton();
 
     $rowsElementsAndInfo = CRM_Dedupe_Merger::getRowsElementsAndInfo($cid, $oid);
-    $main = $this->_mainDetails = &$rowsElementsAndInfo['main_details'];
-    $other = $this->_otherDetails = &$rowsElementsAndInfo['other_details'];
+    $main = $this->_mainDetails = $rowsElementsAndInfo['main_details'];
+    $other = $this->_otherDetails = $rowsElementsAndInfo['other_details'];
 
     if ($main['contact_id'] != $cid) {
       CRM_Core_Error::fatal(ts('The main contact record does not exist'));

--- a/CRM/Contact/Form/Merge.php
+++ b/CRM/Contact/Form/Merge.php
@@ -218,22 +218,6 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
     $this->assign('userContextURL', $session->readUserContext());
   }
 
-  /**
-   * This virtual function is used to set the default values of
-   * various form elements
-   *
-   * access        public
-   *
-   * @return array
-   *   reference to the array of default values
-   */
-  /**
-   * @return array
-   */
-  public function setDefaultValues() {
-    return array('deleteOther' => 1);
-  }
-
   public function addRules() {
   }
 

--- a/CRM/Contact/Form/Merge.php
+++ b/CRM/Contact/Form/Merge.php
@@ -199,6 +199,19 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
 
     // add elements
     foreach ($rowsElementsAndInfo['elements'] as $element) {
+      // We could push this down to the getRowsElementsAndInfo function but it's
+      // already so overloaded - let's start moving towards doing form-things
+      // on the form.
+      if (substr($element[1], 0, 13) === 'move_location') {
+        $element[4] = array_merge(
+          (array) CRM_Utils_Array::value(4, $element, array()),
+          array('data-location' => substr($element[1], 14), 'data-is_location' => TRUE));
+      }
+      if (substr($element[1], 0, 15) === 'location_blocks') {
+        // @todo We could add some data elements here to make jquery manipulation more straight-forward
+        // @todo consider enabling if it is an add & defaulting to true.
+        $element[4] = array_merge((array) CRM_Utils_Array::value(4, $element, array()), array('disabled' => TRUE));
+      }
       $this->addElement($element[0],
         $element[1],
         array_key_exists('2', $element) ? $element[2] : NULL,

--- a/templates/CRM/Contact/Form/Merge.tpl
+++ b/templates/CRM/Contact/Form/Merge.tpl
@@ -130,9 +130,24 @@
               $row.title|substr:0:5 == "Phone"}
 
             <td>
-              {* @TODO check if this is ever an array or a fileName? *}
+
               {* This is on one long line for address formatting *}
-              {if $row.title|substr:0:7 == "Address"}<span style="white-space: pre" id="main_{$blockName}_{$blockId}">{else}<span id="main_{$blockName}_{$blockId}">{/if}{if !is_array($row.main)}{$row.main}{elseif $row.main.fileName}{$row.main.fileName}{else}{', '|implode:$row.main}{/if}</span>
+              {if $row.title|substr:0:7 == "Address"}
+                <span style="white-space: pre" id="main_{$blockName}_{$blockId}">
+              {else}
+                <span id="main_{$blockName}_{$blockId}">
+              {/if}
+
+              {* @TODO check if this is ever an array or a fileName? *}
+              {if !is_array($row.main)}
+                {$row.main}
+              {elseif $row.main.fileName}
+                {$row.main.fileName}
+              {else}
+                {', '|implode:$row.main}
+              {/if}
+
+              </span>
             </td>
 
             <td>
@@ -239,7 +254,7 @@
   /**
    * Triggered when a 'location' or 'type' destination is changed, and when
    * the operation or 'set primary' checkboxes are changed.
-   * 
+   *
    * Check to see if the 'main' contact record has a corresponding location
    * block when the destination of a field is changed. Allow existing location
    * fields to be overwritten with data from the 'other' contact.

--- a/templates/CRM/Contact/Form/Merge.tpl
+++ b/templates/CRM/Contact/Form/Merge.tpl
@@ -130,24 +130,22 @@
               $row.title|substr:0:5 == "Phone"}
 
             <td>
-
-              {* This is on one long line for address formatting *}
-              {if $row.title|substr:0:7 == "Address"}
-                <span style="white-space: pre" id="main_{$blockName}_{$blockId}">
-              {else}
-                <span id="main_{$blockName}_{$blockId}">
-              {/if}
-
-              {* @TODO check if this is ever an array or a fileName? *}
-              {if !is_array($row.main)}
-                {$row.main}
-              {elseif $row.main.fileName}
-                {$row.main.fileName}
-              {else}
-                {', '|implode:$row.main}
-              {/if}
-
-              </span>
+              {strip}
+                {if $row.title|substr:0:7 == "Address"}
+                  <span style="white-space: pre" id="main_{$blockName}_{$blockId}">
+                {else}
+                  <span id="main_{$blockName}_{$blockId}">
+                {/if}
+                {* @TODO check if this is ever an array or a fileName? *}
+                {if !is_array($row.main)}
+                  {$row.main}
+                {elseif $row.main.fileName}
+                  {$row.main.fileName}
+                {else}
+                  {', '|implode:$row.main}
+                {/if}
+                </span>
+              {/strip}
             </td>
 
             <td>
@@ -427,8 +425,9 @@
     });
 
     // Call mergeBlock whenever a location type is changed
-    $('select[id$="locTypeId"],select[id$="typeTypeId"],input[id$="[operation]"],input[id$="[set_other_primary]"]').on('change',
-      function(event){
+    // (This is applied to the body because the inputs can be added dynamically
+    // to the form, and we need to catch when they change.)
+    $('body').on('change', 'select[id$="locTypeId"],select[id$="typeTypeId"],input[id$="[operation]"],input[id$="[set_other_primary]"]', function(event){
 
       // All the information we need is held in the id, separated by underscores
       var nameSplit = this.name.split('[');

--- a/templates/CRM/Contact/Form/Merge.tpl
+++ b/templates/CRM/Contact/Form/Merge.tpl
@@ -235,10 +235,6 @@
       {/if}
     {/foreach}
   </table>
-  <div class='form-item'>
-    <!--<p>{$form.moveBelongings.html} {$form.moveBelongings.label}</p>-->
-    <!--<p>{$form.deleteOther.html} {$form.deleteOther.label}</p>-->
-  </div>
 
   <div class="crm-submit-buttons">
     {include file="CRM/common/formButtons.tpl" location="bottom"}

--- a/templates/CRM/Contact/Form/Merge.tpl
+++ b/templates/CRM/Contact/Form/Merge.tpl
@@ -399,29 +399,26 @@
     }
   }
 
+  /**
+   * Toggle the location type and the is_primary on & off depending on whether the merge box is ticked.
+   *
+   * @param element
+   */
+  function toggleRelatedLocationFields(element) {
+    relatedElements = CRM.$(element).parent().siblings('td').find('input,select,label,hidden');
+    if (CRM.$(element).is(':checked')) {
+      relatedElements.removeClass('disabled').attr('disabled', false);
+
+    }
+    else {
+      relatedElements.addClass('disabled').attr('disabled', true);
+    }
+
+  }
+
   CRM.$(function($) {
-
-    $('table td input.form-checkbox').each(function() {
-      var ele = null;
-      var element = $(this).attr('id').split('_',3);
-
-      switch ( element['1'] ) {
-        case 'addressee':
-          ele = '#' + element['0'] + '_' + element['1'];
-          break;
-
-         case 'email':
-         case 'postal':
-           ele = '#' + element['0'] + '_' + element['1'] + '_' + element['2'];
-           break;
-      }
-
-      if( ele ) {
-        $(this).on('click', function() {
-          var val = $(this).prop('checked');
-          $('input' + ele + ', input' + ele + '_custom').prop('checked', val);
-        });
-      }
+    $('input.crm-form-checkbox[data-is_location]').on('click', function(){
+      toggleRelatedLocationFields(this)
     });
 
     // Show/hide matching data rows
@@ -430,7 +427,8 @@
     });
 
     // Call mergeBlock whenever a location type is changed
-    $('body').on('change', 'select[id$="locTypeId"],select[id$="typeTypeId"],input[id$="[operation]"],input[id$="[set_other_primary]"]', function(event){
+    $('select[id$="locTypeId"],select[id$="typeTypeId"],input[id$="[operation]"],input[id$="[set_other_primary]"]').on('change',
+      function(event){
 
       // All the information we need is held in the id, separated by underscores
       var nameSplit = this.name.split('[');


### PR DESCRIPTION
* [CRM-19492: When merging: require row to be taken across before changing row settings](https://issues.civicrm.org/jira/browse/CRM-19492)