### PR TITLE
Fix CRM-15505: Make state_province_name return the full name of the state

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -5851,7 +5851,7 @@ AND   displayRelType.is_active = 1
           $dao->$idColumn = $val;
 
           if ($key == 'state_province_name') {
-            $dao->{$value['pseudoField']} = $dao->$key = CRM_Core_PseudoConstant::stateProvinceAbbreviation($val);
+            $dao->{$value['pseudoField']} = $dao->$key = CRM_Core_PseudoConstant::stateProvince($val);
           }
           else {
             $dao->{$value['pseudoField']} = $dao->$key = CRM_Core_PseudoConstant::getLabel($baoName, $value['pseudoField'], $val);

--- a/tests/phpunit/CRM/Contact/BAO/QueryStateNameTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryStateNameTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Class CRM_Contact_BAO_QueryStateNameTest
+ * @group headless
+ */
+class CRM_Contact_BAO_QueryStateNameTest extends CiviUnitTestCase {
+
+  /**
+   * Test case for state_province_name pseudofield
+   *
+   * See CRM-15505: Mailing labels show the state/province name as the abbreviation rather than the full state/province name
+   * Change to CRM_Contact_BAO_query::convertToPseudoNames()
+   */
+  public function testStateName() {
+    $state_name = 'Norfolk';
+    $create_params = array(
+      'contact_type' => 'Individual',
+      'first_name' => 'John',
+      'last_name' => 'Doe',
+      'api.Address.create' => array(
+        'location_type_id' => 'Home',
+        'state_province_id' => $state_name,
+      ),
+    );
+    $create_res = civicrm_api3('Contact', 'Create', $create_params);
+
+    $get_params = array(
+      'id' => $create_res['id'],
+      'sequential' => 1,
+    );
+    $get_res = civicrm_api3('Contact', 'get', $get_params);
+
+    $this->assertEquals($state_name, $get_res['values'][0]['state_province_name']);
+  }
+
+}


### PR DESCRIPTION
Fix CRM-15505: Make state_province_name return the full name of the state, not the abbreviation

Includes a unit test specially for @eileenmcnaughton :-)

---

 * [CRM-15505: Mailing labels show the state\/province name as the abbreviation rather than the full state\/province name](https://issues.civicrm.org/jira/browse/CRM-15505)