### PR TITLE
CRM-19835 Use host rather than server and put in port if supplied

### DIFF
--- a/Civi/Install/Requirements.php
+++ b/Civi/Install/Requirements.php
@@ -102,6 +102,17 @@ class Requirements {
   }
 
   /**
+   * Generates a mysql connection
+   *
+   * @param $db_confic array
+   * @return object mysqli connection
+   */
+  protected function connect($db_config) {
+    $conn = @mysqli_connect($db_config['host'], $db_config['username'], $db_config['password'], $db_config['database'], isset($db_config['port']) ? $db_config['port'] : NULL);
+    return $donn;
+  }
+
+  /**
    * Check configured php Memory.
    * @return array
    */
@@ -227,8 +238,7 @@ class Requirements {
       'details' => "Connected",
     );
 
-    $host = isset($db_config['server']) ? $db_config['server'] : $db_config['host'];
-    $conn = @mysqli_connect($host, $db_config['username'], $db_config['password']);
+    $conn = $this->connect($db_config);
 
     if (!$conn) {
       $results['details'] = mysqli_connect_error();
@@ -257,8 +267,7 @@ class Requirements {
       'severity' => $this::REQUIREMENT_OK,
     );
 
-    $host = isset($db_config['server']) ? $db_config['server'] : $db_config['host'];
-    $conn = @mysqli_connect($host, $db_config['username'], $db_config['password']);
+    $conn = $this->connect($db_config);
     if (!$conn || !($info = mysqli_get_server_info($conn))) {
       $results['severity'] = $this::REQUIREMENT_WARNING;
       $results['details'] = "Cannot determine the version of MySQL installed. Please ensure at least version {$min} is installed.";
@@ -287,7 +296,7 @@ class Requirements {
       'details' => 'Could not determine if MySQL has InnoDB support. Assuming none.',
     );
 
-    $conn = @mysqli_connect($db_config['host'], $db_config['username'], $db_config['password']);
+    $conn = $this->connect($db_config);
     if (!$conn) {
       return $results;
     }
@@ -322,7 +331,7 @@ class Requirements {
       'details' => 'MySQL server supports temporary tables',
     );
 
-    $conn = @mysqli_connect($db_config['host'], $db_config['username'], $db_config['password']);
+    $conn = $this->connect($db_config);
     if (!$conn) {
       $results['severity'] = $this::REQUIREMENT_ERROR;
       $results['details'] = "Could not connect to database";
@@ -358,7 +367,7 @@ class Requirements {
       'details' => 'Database supports MySQL triggers',
     );
 
-    $conn = @mysqli_connect($db_config['host'], $db_config['username'], $db_config['password']);
+    $conn = $this->connect($db_config);
     if (!$conn) {
       $results['severity'] = $this::REQUIREMENT_ERROR;
       $results['details'] = 'Could not connect to database';
@@ -403,7 +412,7 @@ class Requirements {
       'details' => 'MySQL server auto_increment_increment is 1',
     );
 
-    $conn = @mysqli_connect($db_config['host'], $db_config['username'], $db_config['password']);
+    $conn = $this->connect($db_config);
     if (!$conn) {
       $results['severity'] = $this::REQUIREMENT_ERROR;
       $results['details'] = 'Could not connect to database';
@@ -439,8 +448,7 @@ class Requirements {
       'details' => 'MySQL thread_stack is OK',
     );
 
-    $host = isset($db_config['server']) ? $db_config['server'] : $db_config['host'];
-    $conn = @mysqli_connect($host, $db_config['username'], $db_config['password']);
+    $conn = $this->connect($db_config);
     if (!$conn) {
       $results['severity'] = $this::REQUIREMENT_ERROR;
       $results['details'] = 'Could not connect to database';
@@ -481,8 +489,7 @@ class Requirements {
       'details' => 'Can successfully lock and unlock tables',
     );
 
-    $host = isset($db_config['server']) ? $db_config['server'] : $db_config['host'];
-    $conn = @mysqli_connect($host, $db_config['username'], $db_config['password']);
+    $conn = $this->connect($db_config);
     if (!$conn) {
       $results['severity'] = $this::REQUIREMENT_ERROR;
       $results['details'] = 'Could not connect to database';

--- a/Civi/Install/Requirements.php
+++ b/Civi/Install/Requirements.php
@@ -108,8 +108,15 @@ class Requirements {
    * @return object mysqli connection
    */
   protected function connect($db_config) {
-    $conn = @mysqli_connect($db_config['host'], $db_config['username'], $db_config['password'], $db_config['database'], isset($db_config['port']) ? $db_config['port'] : NULL);
-    return $donn;
+    $host = NULL;
+    if (!empty($db_config['host'])) {
+      $host = $db_config['host'];
+    }
+    elseif (!empty($db_config['server'])) {
+      $host = $db_config['server'];
+    }
+    $conn = @mysqli_connect($host, $db_config['username'], $db_config['password'], $db_config['database'], !empty($db_config['port']) ? $db_config['port'] : NULL);
+    return $conn;
   }
 
   /**

--- a/install/civicrm.php
+++ b/install/civicrm.php
@@ -97,8 +97,13 @@ function civicrm_main(&$config) {
     civicrm_setup($files_dirname);
   }
 
-  $dsn = "mysql://{$config['mysql']['username']}:{$config['mysql']['password']}@{$config['mysql']['server']}/{$config['mysql']['database']}?new_link=true";
+  $parts = explode(':', $config['mysql']['server']);
+  if (empty($parts[1])) {
+    $parts[1] = 3306;
+  }
+  $config['mysql']['server'] = implode(':', $parts);
 
+  $dsn = "mysql://{$config['mysql']['username']}:{$config['mysql']['password']}@{$config['mysql']['server']}/{$config['mysql']['database']}?new_link=true";
   civicrm_source($dsn, $sqlPath . DIRECTORY_SEPARATOR . 'civicrm.mysql');
 
   if (!empty($config['loadGenerated'])) {
@@ -224,7 +229,14 @@ function civicrm_config(&$config) {
 
   $params['baseURL'] = isset($config['base_url']) ? $config['base_url'] : civicrm_cms_base();
   if ($installType == 'drupal' && defined('VERSION')) {
-    if (version_compare(VERSION, '7.0-rc1') >= 0) {
+    if (version_compare(VERSION, '8.0') >= 0) {
+      $params['cms'] = 'Drupal';
+      $params['CMSdbUser'] = addslashes($config['drupal']['username']);
+      $params['CMSdbPass'] = addslashes($config['drupal']['password']);
+      $params['CMSdbHost'] = $config['drupal']['host'] . ":" . !empty($config['drupal']['port']) ? $config['drupal']['port'] : "3306";
+      $params['CMSdbName'] = addslashes($config['drupal']['database']);
+    }
+    elseif (version_compare(VERSION, '7.0-rc1') >= 0) {
       $params['cms'] = 'Drupal';
       $params['CMSdbUser'] = addslashes($config['drupal']['username']);
       $params['CMSdbPass'] = addslashes($config['drupal']['password']);


### PR DESCRIPTION
* [CRM-19835: Installing into D8, DB requirements fail using non-standard port for MySQL](https://issues.civicrm.org/jira/browse/CRM-19835)