### PR TITLE
CRM-20201 Fix issue where manage tags page would not display properly…

### DIFF
--- a/CRM/Tag/Page/Tag.php
+++ b/CRM/Tag/Page/Tag.php
@@ -63,7 +63,9 @@ class CRM_Tag_Page_Tag extends CRM_Core_Page {
     foreach ($result['values'] as $id => $tagset) {
       $used = explode(',', CRM_Utils_Array::value('used_for', $tagset, ''));
       $tagset['used_for_label'] = array_values(array_intersect_key($usedFor, array_flip($used)));
-      $tagset['display_name'] = $tagset['created_id.display_name'];
+      if (isset($tagset['created_id.display_name'])) {
+        $tagset['display_name'] = $tagset['created_id.display_name'];
+      }
       unset($tagset['created_id.display_name']);
       $tagsets[$id] = $tagset;
     }

--- a/templates/CRM/Tag/Page/Tag.tpl
+++ b/templates/CRM/Tag/Page/Tag.tpl
@@ -81,9 +81,11 @@
       function formatTagSet(info) {
         info.date = CRM.utils.formatDate(info.created_date);
         info.used_for_label = [];
-        _.each(info.used_for.split(','), function(item) {
-          info.used_for_label.push(usedFor[item]);
-        });
+        if (undefined !== info.used_for) {
+          _.each(info.used_for.split(','), function(item) {
+            info.used_for_label.push(usedFor[item]);
+          });
+        }
       }
 
       _.each(tagSets, formatTagSet);
@@ -471,6 +473,7 @@
 <script type="text/template" id="tagsetHelpTpl">
   <div class="help">
     <% if(is_reserved == 1) {ldelim} %><strong>{ts}Reserved{/ts}</strong><% {rdelim} %>
+    <% if(undefined === display_name) var display_name = null; %>
     {ts 1="<%= used_for_label.join(', ') %>" 2="<%= date %>" 3="<%= display_name %>"}Tag Set for %1 (created %2 by %3).{/ts}
     <% if(typeof description === 'string' && description.length) {ldelim} %><p><em><%- description %></em></p><% {rdelim} %>
   </div>


### PR DESCRIPTION
… if tag set does not have a created by set

[CRM-20201 Manage Tags page does not work if a tag set does not have created by set](https://issues.civicrm.org/jira/browse/CRM-20201)