### PR TITLE
CRM-20206 Fix encoding in plain text checksum links

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1469,7 +1469,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
     if ($type == 'embedded_url') {
       $embed_data = array();
       foreach ($token as $t) {
-        $embed_data[] = $this->getTokenData($t, $html = FALSE, $contact, $verp, $urls, $event_queue_id);
+        $embed_data[] = $this->getTokenData($t, $html, $contact, $verp, $urls, $event_queue_id);
       }
       $numSlices = count($embed_data);
       $url = '';
@@ -1488,6 +1488,9 @@ ORDER BY   civicrm_email.is_bulkmail DESC
         $url .= '"';
       }
       $data = $url;
+      if (empty($html)) {
+        $data = str_replace('&amp;', '&', $data);
+      }
     }
     elseif ($type == 'url') {
       if ($this->url_tracking) {

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1488,8 +1488,9 @@ ORDER BY   civicrm_email.is_bulkmail DESC
         $url .= '"';
       }
       $data = $url;
+      // CRM-20206 Fix ampersand encoding in plain text emails
       if (empty($html)) {
-        $data = str_replace('&amp;', '&', $data);
+        $data = CRM_Utils_String::unstupifyUrl($data);
       }
     }
     elseif ($type == 'url') {


### PR DESCRIPTION
* [CRM-20206: & encoded to &amp; in plain text email checksum links](https://issues.civicrm.org/jira/browse/CRM-20206)