### PR TITLE
CRM-20201 add in escaped curly braces to ensure nothing unusual happens

### DIFF
--- a/templates/CRM/Tag/Page/Tag.tpl
+++ b/templates/CRM/Tag/Page/Tag.tpl
@@ -473,7 +473,7 @@
 <script type="text/template" id="tagsetHelpTpl">
   <div class="help">
     <% if(is_reserved == 1) {ldelim} %><strong>{ts}Reserved{/ts}</strong><% {rdelim} %>
-    <% if(undefined === display_name) var display_name = null; %>
+    <% if(undefined === display_name) {ldelim} var display_name = null; {rdelim} %>
     {ts 1="<%= used_for_label.join(', ') %>" 2="<%= date %>" 3="<%= display_name %>"}Tag Set for %1 (created %2 by %3).{/ts}
     <% if(typeof description === 'string' && description.length) {ldelim} %><p><em><%- description %></em></p><% {rdelim} %>
   </div>


### PR DESCRIPTION
 * [CRM-20201: Manage Tags page does not work if a tag set does not have created by set](https://issues.civicrm.org/jira/browse/CRM-20201)