### PR TITLE
CRM-20004 Fix regression Event payment receipt sent twice

### DIFF
--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -429,14 +429,6 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
       if (!empty($submittedValues['is_email_receipt']) && $sendReceipt) {
         $statusMsg .= ' ' . ts('A receipt has been emailed to the contributor.');
       }
-      // email sending
-      if (!empty($result) && !empty($submittedValues['is_email_receipt'])) {
-        $submittedValues['contact_id'] = $this->_contactId;
-        $submittedValues['contribution_id'] = $this->_contributionId;
-        // to get 'from email id' for send receipt
-        $this->fromEmailId = $submittedValues['from_email_address'];
-        $sendReceipt = $this->emailReceipt($submittedValues);
-      }
 
       CRM_Core_Session::setStatus($statusMsg, ts('Saved'), 'success');
 


### PR DESCRIPTION
There seems to be duplicate code in /administrator/components/com_civicrm/civicrm/CRM/Contribute/Form/AdditionalPayment.php that causes two confirmation emails to be sent when an additional event payment is made off-line and recorded by an administrator.  This PR removes one of them.

---

 * [CRM-20004: Event payment receipt sent twice](https://issues.civicrm.org/jira/browse/CRM-20004)