### PR TITLE
CRM-20217 - ensure phone fields are dupe-matched on import.

### DIFF
--- a/CRM/Dedupe/Finder.php
+++ b/CRM/Dedupe/Finder.php
@@ -338,6 +338,16 @@ class CRM_Dedupe_Finder {
             }
           }
         }
+        if ($table == 'civicrm_phone') {
+          $fixes = array(
+            'phone' => 'phone_numeric'
+          );
+          foreach ($fixes as $orig => $target) {
+            if (!empty($flat[$orig])) {
+              $params[$table][$target] = $flat[$orig];
+            }
+          }
+        }
         foreach ($fields as $field => $title) {
           if (!empty($flat[$field])) {
             $params[$table][$field] = $flat[$field];

--- a/CRM/Dedupe/Finder.php
+++ b/CRM/Dedupe/Finder.php
@@ -340,7 +340,7 @@ class CRM_Dedupe_Finder {
         }
         if ($table == 'civicrm_phone') {
           $fixes = array(
-            'phone' => 'phone_numeric'
+            'phone' => 'phone_numeric',
           );
           foreach ($fixes as $orig => $target) {
             if (!empty($flat[$orig])) {

--- a/CRM/Dedupe/Finder.php
+++ b/CRM/Dedupe/Finder.php
@@ -145,6 +145,10 @@ class CRM_Dedupe_Finder {
     }
     $params['check_permission'] = CRM_Utils_Array::value('check_permission', $params, TRUE);
 
+    if (isset($params['civicrm_phone']['phone_numeric'])) {
+      $orig = $params['civicrm_phone']['phone_numeric'];
+      $params['civicrm_phone']['phone_numeric'] = preg_replace('/[^\d]/', '', $orig);
+    }
     $rgBao->params = $params;
     $rgBao->fillTable();
     $dao = new CRM_Core_DAO();


### PR DESCRIPTION
* [CRM-20217: phone based dedupe rule fails to match when importing](https://issues.civicrm.org/jira/browse/CRM-20217)