### PR TITLE
comment changes only

### DIFF
--- a/CRM/Utils/Hook/UnitTests.php
+++ b/CRM/Utils/Hook/UnitTests.php
@@ -52,6 +52,7 @@ class CRM_Utils_Hook_UnitTests extends CRM_Utils_Hook {
    * Use a unit-testing mock object to handle hook invocations.
    *
    * e.g. hook_civicrm_foo === $mockObject->foo()
+   * Mocks with a magic `__call()` method are called for every hook invokation.
    *
    * @param object $mockObject
    */
@@ -60,7 +61,7 @@ class CRM_Utils_Hook_UnitTests extends CRM_Utils_Hook {
   }
 
   /**
-   * Register a piece of code to run when invoking a hook.
+   * Register a function to run when invoking a specific hook.
    * @param string $hook
    *   Hook name, e.g civicrm_pre.
    * @param array $callable
@@ -72,7 +73,7 @@ class CRM_Utils_Hook_UnitTests extends CRM_Utils_Hook {
   }
 
   /**
-   * Invoke hooks.
+   * Invoke standard, mock and ad hoc hooks.
    *
    * @param int $numParams
    *   Number of parameters to pass to the hook.
@@ -93,34 +94,22 @@ class CRM_Utils_Hook_UnitTests extends CRM_Utils_Hook {
    *
    * @return mixed
    */
-  /**
-   * @param int $numParams
-   * @param mixed $arg1
-   * @param mixed $arg2
-   * @param mixed $arg3
-   * @param mixed $arg4
-   * @param mixed $arg5
-   * @param mixed $arg6
-   * @param string $fnSuffix
-   *
-   * @return mixed
-   */
   public function invoke(
     $numParams,
     &$arg1, &$arg2, &$arg3, &$arg4, &$arg5, &$arg6,
     $fnSuffix) {
-
     $params = array(&$arg1, &$arg2, &$arg3, &$arg4, &$arg5, &$arg6);
-
+    // run standard hooks
     if ($this->civiModules === NULL) {
       $this->civiModules = array();
       $this->requireCiviModules($this->civiModules);
     }
     $this->runHooks($this->civiModules, $fnSuffix, $numParams, $arg1, $arg2, $arg3, $arg4, $arg5, $arg6);
-
+    // run mock object hooks
     if ($this->mockObject && is_callable(array($this->mockObject, $fnSuffix))) {
       call_user_func(array($this->mockObject, $fnSuffix), $arg1, $arg2, $arg3, $arg4, $arg5, $arg6);
     }
+    // run adhoc hooks
     if (!empty($this->adhocHooks[$fnSuffix])) {
       call_user_func_array($this->adhocHooks[$fnSuffix], $params);
     }


### PR DESCRIPTION
The magic __call method provides the ability to snoop on all hooks which is awesome (I have tested it and it works like a charm)

there was also a duplicated doc block I cleaned up.

I'm going to answer my SE question [here](http://civicrm.stackexchange.com/questions/17184/how-do-i-write-unit-tests-that-verify-a-hook-is-being-fired) shortly and provide a working unit test example.