### PR TITLE
CRM-20004 Fix regression Event payment receipt sent twice

### DIFF
--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -429,15 +429,6 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
       if (!empty($submittedValues['is_email_receipt']) && $sendReceipt) {
         $statusMsg .= ' ' . ts('A receipt has been emailed to the contributor.');
       }
-      // email sending
-      if (!empty($result) && !empty($submittedValues['is_email_receipt'])) {
-        $submittedValues['contact_id'] = $this->_contactId;
-        $submittedValues['contribution_id'] = $this->_contributionId;
-        // to get 'from email id' for send receipt
-        $this->fromEmailId = $submittedValues['from_email_address'];
-        $sendReceipt = $this->emailReceipt($submittedValues);
-      }
-
       CRM_Core_Session::setStatus($statusMsg, ts('Saved'), 'success');
 
       $session = CRM_Core_Session::singleton();


### PR DESCRIPTION
@eileenmcnaughton 
Did this:
git checkout -b new upstream/4.7.17rc
(that creates a new branch based off the upstream version of 4.7.17rc)
and then
git cherry-pick 9100f86

Then pushed new to origin and created this PR.

---

 * [CRM-20004: Event payment receipt sent twice](https://issues.civicrm.org/jira/browse/CRM-20004)