### PR TITLE
CRM-20219 Update activity fields in profiles to use date picker

### DIFF
--- a/CRM/Activity/Form/Task/Batch.php
+++ b/CRM/Activity/Form/Task/Batch.php
@@ -95,7 +95,7 @@ class CRM_Activity_Form_Task_Batch extends CRM_Activity_Form_Task {
     $ufGroupId = $this->get('ufGroupId');
 
     if (!$ufGroupId) {
-      CRM_Core_Error::fatal('ufGroupId is missing');
+      throw new CRM_Core_Exception('The profile id is missing');
     }
     $this->_title = ts('Update multiple activities') . ' - ' . CRM_Core_BAO_UFGroup::getTitle($ufGroupId);
     CRM_Utils_System::setTitle($this->_title);
@@ -108,7 +108,7 @@ class CRM_Activity_Form_Task_Batch extends CRM_Activity_Form_Task {
     $suppressFields = FALSE;
     $removehtmlTypes = array('File', 'Autocomplete-Select');
     foreach ($this->_fields as $name => $field) {
-      if ($cfID = CRM_Core_BAO_CustomField::getKeyID($name) &&
+      if (CRM_Core_BAO_CustomField::getKeyID($name) &&
         in_array($this->_fields[$name]['html_type'], $removehtmlTypes)
       ) {
         $suppressFields = TRUE;
@@ -150,6 +150,10 @@ class CRM_Activity_Form_Task_Batch extends CRM_Activity_Form_Task {
     }
 
     $customFields = CRM_Core_BAO_CustomField::getFields('Activity');
+    // It is possible to have fields that are required in CiviCRM not be required in the
+    // profile. Overriding that here. Perhaps a better approach would be to
+    // make them required in the schema & read that up through getFields functionality.
+    $requiredFields = array('activity_date_time');
 
     foreach ($this->_activityHolderIds as $activityId) {
       $typeId = CRM_Core_DAO::getFieldValue("CRM_Activity_DAO_Activity", $activityId, 'activity_type_id');
@@ -169,6 +173,9 @@ class CRM_Activity_Form_Task_Batch extends CRM_Activity_Form_Task {
         }
         else {
           // Handle non custom fields.
+          if (in_array($field['name'], $requiredFields)) {
+            $field['is_required'] = TRUE;
+          }
           CRM_Core_BAO_UFGroup::buildProfile($this, $field, NULL, $activityId);
         }
       }
@@ -216,20 +223,12 @@ class CRM_Activity_Form_Task_Batch extends CRM_Activity_Form_Task {
         );
         $value['id'] = $key;
 
-        if (!empty($value['activity_date_time'])) {
-          $value['activity_date_time'] = CRM_Utils_Date::processDate($value['activity_date_time'], $value['activity_date_time_time']);
-        }
-
         if (!empty($value['activity_status_id'])) {
           $value['status_id'] = $value['activity_status_id'];
         }
 
         if (!empty($value['activity_details'])) {
           $value['details'] = $value['activity_details'];
-        }
-
-        if (!empty($value['activity_duration'])) {
-          $value['duration'] = $value['activity_duration'];
         }
 
         if (!empty($value['activity_location'])) {
@@ -240,30 +239,9 @@ class CRM_Activity_Form_Task_Batch extends CRM_Activity_Form_Task {
           $value['subject'] = $value['activity_subject'];
         }
 
-        $query = "
-SELECT a.activity_type_id, ac.contact_id
-FROM   civicrm_activity a
-JOIN   civicrm_activity_contact ac ON ( ac.activity_id = a.id
-AND    ac.record_type_id = %2 )
-WHERE  a.id = %1 ";
-        $activityContacts = CRM_Core_OptionGroup::values('activity_contacts', FALSE, FALSE, FALSE, NULL, 'name');
-        $sourceID = CRM_Utils_Array::key('Activity Source', $activityContacts);
-        $params = array(1 => array($key, 'Integer'), 2 => array($sourceID, 'Integer'));
-        $dao = CRM_Core_DAO::executeQuery($query, $params);
-        $dao->fetch();
+        $activityId = civicrm_api3('activity', 'create', $value);
 
-        // Get Activity Type ID
-        $value['activity_type_id'] = $dao->activity_type_id;
-
-        // Get Conatct ID
-        $value['source_contact_id'] = $dao->contact_id;
-
-        // make call use API 3
-        $value['version'] = 3;
-
-        $activityId = civicrm_api('activity', 'update', $value);
-
-        // add custom field values
+        // @todo this would be done by the api call above if the parames were passed through.
         if (!empty($value['custom']) &&
           is_array($value['custom'])
         ) {

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -2337,7 +2337,6 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
       'receipt_date' => 'activityDateTime',
       'thankyou_date' => 'activityDateTime',
       'cancel_date' => 'activityDateTime',
-      'activity_date_time' => 'activityDateTime',
     );
   }
 

--- a/templates/CRM/Activity/Form/Task/Batch.tpl
+++ b/templates/CRM/Activity/Form/Task/Batch.tpl
@@ -47,12 +47,8 @@
            <td>{$contactDetails.$activityId.$fName}</td>
         {/foreach}
                 {foreach from=$fields item=field key=fieldName}
-                {assign var=n value=$field.name}
-                {if $fields.$n.name eq 'activity_date_time' }
-                <td class="compressed">{include file="CRM/common/jcalendar.tpl" elementName=$fieldName elementIndex=$activityId batchUpdate=1}</td>
-                {else}
+                  {assign var=n value=$field.name}
                    <td class="compressed">{$form.field.$activityId.$n.html}</td>
-                {/if}
               {/foreach}
              </tr>
               {/foreach}

--- a/templates/CRM/Profile/Form/Dynamic.tpl
+++ b/templates/CRM/Profile/Form/Dynamic.tpl
@@ -171,11 +171,7 @@
                 &nbsp;{$form.$phone_ext_field.html}
                 {/if}
               {else}
-                {if $n eq 'activity_date_time' and $field.is_view neq 1 }
-                {include file="CRM/common/jcalendar.tpl" elementName=$n}
-                {else}
-                  {$form.$n.html}
-                {/if}
+                {$form.$n.html}
                 {if $field.html_type eq 'Autocomplete-Select'}
                   {if $field.data_type eq 'ContactReference'}
                     {include file="CRM/Custom/Form/ContactReference.tpl" element_name = $n}

--- a/tests/phpunit/api/v3/ProfileTest.php
+++ b/tests/phpunit/api/v3/ProfileTest.php
@@ -606,7 +606,7 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
       'activity_subject' => 'Test Meeting',
       'activity_details' => 'a test activity details',
       'activity_duration' => '100',
-      'activity_date_time' => '03/08/2010',
+      'activity_date_time' => '2010-03-08 00:00:00',
       'activity_status_id' => '2',
     );
     $profileParams = array_merge($params, $updateParams);
@@ -799,7 +799,7 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
       'assignee_contact_id' => $contactId,
       'activity_type_id' => '1',
       'subject' => 'Make-it-Happen Meeting',
-      'activity_date_time' => '20110316',
+      'activity_date_time' => '2011-03-16 00:00:00',
       'duration' => '120',
       'location' => 'Pensulvania',
       'details' => 'a test activity',
@@ -825,8 +825,7 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
       'activity_subject' => 'Make-it-Happen Meeting',
       'activity_details' => 'a test activity',
       'activity_duration' => '120',
-      'activity_date_time_time' => '12:00AM',
-      'activity_date_time' => '03/16/2011',
+      'activity_date_time' => '2011-03-16 00:00:00',
       'activity_status_id' => '1',
     );
 


### PR DESCRIPTION
* [CRM-20219: Switch activity date time to use datepicker in profiles](https://issues.civicrm.org/jira/browse/CRM-20219)