### PR TITLE
CRM-20224 - Cleanup internal event names

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -480,7 +480,7 @@ class CRM_Core_DAO extends DB_DataObject {
 
       if ($hook) {
         $event = new \Civi\Core\DAO\Event\PostUpdate($this);
-        \Civi::service('dispatcher')->dispatch("DAO::post-update", $event);
+        \Civi::service('dispatcher')->dispatch("civi.dao.postUpdate", $event);
       }
     }
     else {
@@ -488,7 +488,7 @@ class CRM_Core_DAO extends DB_DataObject {
 
       if ($hook) {
         $event = new \Civi\Core\DAO\Event\PostUpdate($this);
-        \Civi::service('dispatcher')->dispatch("DAO::post-insert", $event);
+        \Civi::service('dispatcher')->dispatch("civi.dao.postInsert", $event);
       }
     }
     $this->free();
@@ -529,7 +529,7 @@ class CRM_Core_DAO extends DB_DataObject {
     $result = parent::delete($useWhere);
 
     $event = new \Civi\Core\DAO\Event\PostDelete($this, $result);
-    \Civi::service('dispatcher')->dispatch("DAO::post-delete", $event);
+    \Civi::service('dispatcher')->dispatch("civi.dao.postDelete", $event);
     $this->free();
 
     return $result;

--- a/Civi/API/Events.php
+++ b/Civi/API/Events.php
@@ -45,7 +45,7 @@ class Events {
    *
    * @see AuthorizeEvent
    */
-  const AUTHORIZE = 'api.authorize';
+  const AUTHORIZE = 'civi.api.authorize';
 
   /**
    * Determine which API provider executes the given request. For successful
@@ -54,28 +54,28 @@ class Events {
    *
    * @see ResolveEvent
    */
-  const RESOLVE = 'api.resolve';
+  const RESOLVE = 'civi.api.resolve';
 
   /**
    * Apply pre-execution logic
    *
    * @see PrepareEvent
    */
-  const PREPARE = 'api.prepare';
+  const PREPARE = 'civi.api.prepare';
 
   /**
    * Apply post-execution logic
    *
    * @see RespondEvent
    */
-  const RESPOND = 'api.respond';
+  const RESPOND = 'civi.api.respond';
 
   /**
    * Handle any exceptions.
    *
    * @see ExceptionEvent
    */
-  const EXCEPTION = 'api.exception';
+  const EXCEPTION = 'civi.api.exception';
 
   /**
    * Weight - Early

--- a/Civi/API/Subscriber/WrapperAdapter.php
+++ b/Civi/API/Subscriber/WrapperAdapter.php
@@ -33,7 +33,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 /**
  * This is a wrapper for the legacy "API Wrapper" interface which allows
  * wrappers to run through the new kernel. It translates from dispatcher events
- * ('api.prepare', 'api.respond') to wrapper calls ('fromApiInput', 'toApiOutput').
+ * ('civi.api.prepare', 'civi.api.respond') to wrapper calls ('fromApiInput', 'toApiOutput').
  */
 class WrapperAdapter implements EventSubscriberInterface {
 

--- a/Civi/ActionSchedule/Events.php
+++ b/Civi/ActionSchedule/Events.php
@@ -8,12 +8,12 @@ class Events {
    *
    * @see EntityListEvent
    */
-  const MAPPINGS = 'actionSchedule.getMappings';
+  const MAPPINGS = 'civi.actionSchedule.getMappings';
 
   /**
    * Prepare the pre-mailing query. This query loads details about
    * the contact/entity so that they're available for mail-merge.
    */
-  const MAILING_QUERY = 'actionSchedule.prepareMailingQuery';
+  const MAILING_QUERY = 'civi.actionSchedule.prepareMailingQuery';
 
 }

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -245,9 +245,9 @@ class Container {
     $dispatcher->addListener('hook_civicrm_post::Case', array('\Civi\CCase\Events', 'fireCaseChange'));
     $dispatcher->addListener('hook_civicrm_caseChange', array('\Civi\CCase\Events', 'delegateToXmlListeners'));
     $dispatcher->addListener('hook_civicrm_caseChange', array('\Civi\CCase\SequenceListener', 'onCaseChange_static'));
-    $dispatcher->addListener('DAO::post-insert', array('\CRM_Core_BAO_RecurringEntity', 'triggerInsert'));
-    $dispatcher->addListener('DAO::post-update', array('\CRM_Core_BAO_RecurringEntity', 'triggerUpdate'));
-    $dispatcher->addListener('DAO::post-delete', array('\CRM_Core_BAO_RecurringEntity', 'triggerDelete'));
+    $dispatcher->addListener('civi.dao.postInsert', array('\CRM_Core_BAO_RecurringEntity', 'triggerInsert'));
+    $dispatcher->addListener('civi.dao.postUpdate', array('\CRM_Core_BAO_RecurringEntity', 'triggerUpdate'));
+    $dispatcher->addListener('civi.dao.postDelete', array('\CRM_Core_BAO_RecurringEntity', 'triggerDelete'));
     $dispatcher->addListener('hook_civicrm_unhandled_exception', array(
       'CRM_Core_LegacyErrorHandler',
       'handleException',


### PR DESCRIPTION
If you look at the list of events emitted through the EventDispatcher,
you'll find several different formats for the names:

```
  actionSchedule.getMappings
  actionSchedule.prepareMailingQuery
  api.authorize
  api.exception
  api.prepare
  api.resolve
  api.respond
  civi.core.install
  civi.token.eval
  civi.token.list
  civi.token.render
  DAO::post-delete
  DAO::post-insert
  DAO::post-update
  hook_civicrm_caseChange
  hook_civicrm_post::Activity
  hook_civicrm_post::Case
  hook_civicrm_unhandled_exception
```

These patches rename some of the events to follow the conventions described
in CRM-20224.  For each one that's renamed, I've grepped `universe` to see
if any published extensions referenced these events using their internal
name.  None did.

```
fetch-universe ~/buildkit/build/universe
grep -r 'api\.\(respond\|authorize\|prepare\|resolve\|respond\)' ~/buildkit/build/universe
grep -r 'actionSchedule\.' ~/buildkit/build/universe
grep -r 'DAO::post-' ~/buildkit/build/universe
```

---

 * [CRM-20224: Cleanup internal event names](https://issues.civicrm.org/jira/browse/CRM-20224)