### PR TITLE
CRM-20228 - CiviMail - Use CRLF instead of LF as EOL for long message…

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1286,7 +1286,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
       );
     }
 
-    $message = new Mail_mime("\n");
+    $message = new Mail_mime("\r\n");
 
     $useSmarty = defined('CIVICRM_MAIL_SMARTY') && CIVICRM_MAIL_SMARTY ? TRUE : FALSE;
     if ($useSmarty) {


### PR DESCRIPTION
… headers

https://issues.civicrm.org/jira/browse/CRM-20228