### PR TITLE
CRM-18747

### DIFF
--- a/CRM/Contact/Form/Edit/TagsAndGroups.php
+++ b/CRM/Contact/Form/Edit/TagsAndGroups.php
@@ -122,8 +122,8 @@ class CRM_Contact_Form_Edit_TagsAndGroups {
           }
           else {
             $form->_tagGroup[$fName][$id]['description'] = $group['description'];
-            $elements[] = &$form->addElement('advcheckbox', $id, NULL, $group['title'], $attributes);
-          }
+            $elements[] = &$form->addElement('advcheckbox', $id,NULL, "<b>".$group['title'].'</b>'."<br/>"."<div class='description'>".$group['description']."</div>", $attributes);
+		  }
         }
 
         if ($groupElementType == 'select' && !empty($groupsOptions)) {

--- a/CRM/Contact/Form/Edit/TagsAndGroups.php
+++ b/CRM/Contact/Form/Edit/TagsAndGroups.php
@@ -122,8 +122,8 @@ class CRM_Contact_Form_Edit_TagsAndGroups {
           }
           else {
             $form->_tagGroup[$fName][$id]['description'] = $group['description'];
-            $elements[] = &$form->addElement('advcheckbox', $id,NULL, "<b>".$group['title'].'</b>'."<br/>"."<div class='description'>".$group['description']."</div>", $attributes);
-		  }
+            $elements[] = &$form->addElement('advcheckbox', $id, NULL, $group['title'], $attributes);
+          }
         }
 
         if ($groupElementType == 'select' && !empty($groupsOptions)) {

--- a/templates/CRM/Contact/Form/Edit/TagsAndGroups.tpl
+++ b/templates/CRM/Contact/Form/Edit/TagsAndGroups.tpl
@@ -93,8 +93,17 @@
           <td>
             {if $groupElementType eq 'select'}
               <span class="label">{if $title}{$form.group.label}{/if}</span>
+              {$form.group.html}
+            {else}
+              {foreach key=key item=item from=$tagGroup.group}
+                <div class="group-wrapper">
+                  {$form.group.$key.html}
+                  {if $item.description}
+                    <div class="description">{$item.description}</div>
+                  {/if}
+                </div>
+              {/foreach}
             {/if}
-            {$form.group.html}
           </td>
         {/if}
         {if (!$type || $type eq 'tag') && $tree}


### PR DESCRIPTION
If groups are displayed as a checkbox (non-select), include the group description. This restores a regression introduced with 4.5.

---

 * [CRM-18747: group descriptions no longer included when listing in profiles](https://issues.civicrm.org/jira/browse/CRM-18747)