### PR TITLE
CRM-19966 Unfair Double Taxation and net_amounts.

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -5371,22 +5371,6 @@ LEFT JOIN  civicrm_contribution on (civicrm_contribution.contact_id = civicrm_co
   }
 
   /**
-   * Calculate net amount.
-   *
-   * @param array $netAmount
-   *
-   * @param float $taxAmount
-   *
-   * @return array
-   */
-  public static function calculateNetAmount($netAmount, $taxAmount) {
-    if ($taxAmount) {
-      $netAmount -= $taxAmount;
-    }
-    return CRM_Utils_Money::format($netAmount, NULL, '%a');
-  }
-
-  /**
    * Retrieve Sales Tax Financial Accounts.
    *
    *

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -377,10 +377,6 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       $defaults['fee_amount'] = CRM_Utils_Money::format($defaults['fee_amount'], NULL, '%a');
     }
 
-    if (isset($defaults['net_amount'])) {
-      $defaults['net_amount'] = CRM_Contribute_BAO_Contribution::calculateNetAmount($defaults['net_amount'], CRM_Utils_Array::value('tax_amount', $defaults));
-    }
-
     if ($this->_contributionType) {
       $defaults['financial_type_id'] = $this->_contributionType;
     }
@@ -1589,7 +1585,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     }
 
     if (!isset($submittedValues['total_amount'])) {
-      $submittedValues['total_amount'] = CRM_Utils_Array::value('total_amount', $this->_values);
+      $submittedValues['total_amount'] = CRM_Utils_Array::value('total_amount', $this->_values) - CRM_Utils_Array::value('tax_amount', $this->_values);
     }
     $this->assign('lineItem', !empty($lineItem) && !$isQuickConfig ? $lineItem : FALSE);
 

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -287,7 +287,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       empty($lineItem) ? NULL : $this->_lineItems[] = $lineItem;
     }
 
-    $this->assign('lineItem', empty($lineItem) ? FALSE : $lineItem);
+    $this->assign('lineItem', empty($lineItem) ? FALSE : array($lineItem));
 
     // Set title
     if ($this->_mode && $this->_id) {

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -283,10 +283,11 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       else {
         $lineItem = CRM_Price_BAO_LineItem::getLineItems($this->_id, 'contribution', 1, TRUE, TRUE);
       }
+      // wtf?
       empty($lineItem) ? NULL : $this->_lineItems[] = $lineItem;
     }
 
-    $this->assign('lineItem', empty($this->_lineItems) ? FALSE : $this->_lineItems);
+    $this->assign('lineItem', empty($lineItem) ? FALSE : $lineItem);
 
     // Set title
     if ($this->_mode && $this->_id) {
@@ -1432,7 +1433,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
    * @throws \Exception
    */
   protected function submit($submittedValues, $action, $pledgePaymentID) {
-    $softIDs = array();
+
     $pId = $contribution = $isRelatedId = FALSE;
     $this->_params = $submittedValues;
     $this->beginPostProcess();
@@ -1797,13 +1798,8 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     }
     $taxRate = array();
     $getTaxDetails = FALSE;
-    if ($action & CRM_Core_Action::ADD) {
-      $line = $lineItem;
-    }
-    elseif ($action & CRM_Core_Action::UPDATE) {
-      $line = $this->_lineItems;
-    }
-    foreach ($line as $key => $value) {
+
+    foreach ($lineItem as $key => $value) {
       foreach ($value as $v) {
         if (isset($taxRate[(string) CRM_Utils_Array::value('tax_rate', $v)])) {
           $taxRate[(string) $v['tax_rate']] = $taxRate[(string) $v['tax_rate']] + CRM_Utils_Array::value('tax_amount', $v);

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -1006,39 +1006,6 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
   }
 
   /**
-   * Test calculateNetAmount.
-   */
-  public function testcalculateNetAmount() {
-    $testParams = array(
-      array(
-        'net_amount' => 100,
-        'tax_amount' => 10,
-        'expectedNetAmount' => 90,
-      ),
-      array(
-        'net_amount' => 200,
-        'tax_amount' => 0,
-        'expectedNetAmount' => 200,
-      ),
-      array(
-        'net_amount' => 300,
-        'tax_amount' => NULL,
-        'expectedNetAmount' => 300,
-      ),
-      array(
-        'net_amount' => -100,
-        'tax_amount' => 20,
-        'expectedNetAmount' => -120,
-      ),
-    );
-
-    foreach ($testParams as $params) {
-      $netAmount = CRM_Contribute_BAO_Contribution::calculateNetAmount($params['net_amount'], $params['tax_amount']);
-      $this->assertEquals($netAmount, $params['expectedNetAmount'], 'Invalid Net amount.');
-    }
-  }
-
-  /**
    * Test recording of amount with comma separator.
    */
   public function testCommaSeparatorAmount() {

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -851,4 +851,58 @@ Price Field - Price Field 1        1   $ 100.00      $ 100.00
     $this->assertTrue(empty($lineItem['tax_amount']));
   }
 
+  public function testReSubmitSaleTax() {
+    // KG I need to do an Edit of a View Contribution
+    $this->enableTaxAndInvoicing();
+    $this->relationForFinancialTypeWithFinancialAccount($this->_financialTypeId);
+    $form = new CRM_Contribute_Form_Contribution();
+
+    $form->testSubmit(array(
+      'total_amount' => 100,
+      'financial_type_id' => $this->_financialTypeId,
+      'receive_date' => '04/21/2015',
+      'receive_date_time' => '11:27PM',
+      'contact_id' => $this->_individualId,
+      'payment_instrument_id' => array_search('Check', $this->paymentInstruments),
+      'contribution_status_id' => 1,
+      'price_set_id' => 0,
+    ),
+      CRM_Core_Action::ADD
+    );
+    $contribution = $this->callAPISuccessGetSingle('Contribution',
+      array(
+        'contribution_id' => 1,
+        'return' => array('tax_amount', 'total_amount', 'net_amount', 'financial_type_id', 'receive_date', 'payment_instrument_id'),
+      )
+    );
+
+    $test = 1;
+    $form->testSubmit(array(
+      'contribution_id' => $contribution['id'],
+      'total_amount' => $contribution['total_amount'],
+      'net_amount' => $contribution['net_amount'],
+      'tax_amount' => $contribution['tax_amount'],
+      'financial_type_id' => $contribution['financial_type_id'],
+      'receive_date' => $contribution['receive_date'],
+      'payment_instrument_id' => $contribution['payment_instrument_id'],
+      'price_set_id' => 0,
+      'check_number' => 12345,
+    ),
+      CRM_Core_Action::UPDATE
+    );
+    $contribution = $this->callAPISuccessGetSingle('Contribution',
+      array(
+        'contact_id' => $this->_individualId,
+      )
+    );
+
+    $this->assertEquals(110, $contribution['total_amount']);
+    $this->assertEquals(10, $contribution['tax_amount']);
+    $this->callAPISuccessGetCount('FinancialTrxn', array(), 1);
+    $this->callAPISuccessGetCount('FinancialItem', array(), 2);
+    $lineItem = $this->callAPISuccessGetSingle('LineItem', array('contribution_id' => $contribution['id']));
+    $this->assertEquals(100, $lineItem['line_total']);
+    $this->assertEquals(10, $lineItem['tax_amount']);
+  }
+
 }

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -852,7 +852,7 @@ Price Field - Price Field 1        1   $ 100.00      $ 100.00
   }
 
   /**
-   * Create a contribution & then edit it via backoffice form, checking tax.
+   * Create a contribution & then edit it via backoffice form, checking tax with: default price_set
    *
    * @throws \Exception
    */
@@ -881,12 +881,12 @@ Price Field - Price Field 1        1   $ 100.00      $ 100.00
     );
     $this->assertEquals(110, $contribution['total_amount']);
     $this->assertEquals(10, $contribution['tax_amount']);
+    $this->assertEquals(110, $contribution['net_amount']);
 
     $mut = new CiviMailUtils($this, TRUE);
+    // Testing here if when we edit something trivial like adding a check_number tax, net, total amount stay the same:
     $form->testSubmit(array(
       'id' => $contribution['id'],
-      'total_amount' => $contribution['total_amount'],
-      'net_amount' => $contribution['net_amount'],
       'tax_amount' => $contribution['tax_amount'],
       'financial_type_id' => $contribution['financial_type_id'],
       'receive_date' => $contribution['receive_date'],
@@ -901,28 +901,25 @@ Price Field - Price Field 1        1   $ 100.00      $ 100.00
     );
     $contribution = $this->callAPISuccessGetSingle('Contribution',
       array(
-        'contact_id' => $this->_individualId,
+        'contribution_id' => 1,
+        'return' => array('tax_amount', 'total_amount', 'net_amount', 'financial_type_id', 'receive_date', 'payment_instrument_id'),
       )
     );
+    $this->assertEquals(110, $contribution['total_amount']);
+    $this->assertEquals(10, $contribution['tax_amount']);
+    $this->assertEquals(110, $contribution['net_amount']);
+
     $strings = array(
-      'Financial Type: Donation',
-      'Amount before Tax : $ 110.00',
-      'Sales Tax 10.00% : $ 11.00',
-      'Total Tax Amount : $ 11.00',
-      'Total Amount : $ 121.00',
+      'Total Tax Amount : $ 10.00',
+      'Total Amount : $ 110.00',
       'Date Received: April 21st, 2015',
       'Paid By: Check',
       'Check Number: 12345',
     );
 
     $mut->checkMailLog($strings);
-    $this->assertEquals(110, $contribution['total_amount']);
-    $this->assertEquals(10, $contribution['tax_amount']);
-    $this->callAPISuccessGetCount('FinancialTrxn', array(), 1);
+    $this->callAPISuccessGetCount('FinancialTrxn', array(), 3);
     $this->callAPISuccessGetCount('FinancialItem', array(), 2);
-    $lineItem = $this->callAPISuccessGetSingle('LineItem', array('contribution_id' => $contribution['id']));
-    $this->assertEquals(100, $lineItem['line_total']);
-    $this->assertEquals(10, $lineItem['tax_amount']);
   }
 
 }

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -1497,7 +1497,6 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
    * CHANGE: we require the API to do an incremental update
    */
   public function testCreateUpdateContribution() {
-
     $contributionID = $this->contributionCreate(array(
       'contact_id' => $this->_individualId,
       'trxn_id' => 212355,
@@ -1529,13 +1528,12 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $params = array(
       'id' => $contributionID,
       'contact_id' => $this->_individualId,
-      'total_amount' => 110.00,
+      'total_amount' => 105.00,
+      'fee_amount' => 7.00,
       'financial_type_id' => $this->_financialTypeId,
-      'non_deductible_amount' => 10.00,
-      'net_amount' => 100.00,
+      'non_deductible_amount' => 22.00,
       'contribution_status_id' => 1,
       'note' => 'Donating for Noble Cause',
-
     );
 
     $contribution = $this->callAPISuccess('contribution', 'create', $params);
@@ -1547,17 +1545,19 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $contribution = $this->callAPISuccessGetSingle('contribution', $new_params);
 
     $this->assertEquals($contribution['contact_id'], $this->_individualId);
-    $this->assertEquals($contribution['total_amount'], 110.00);
+    $this->assertEquals($contribution['total_amount'], 105.00);
     $this->assertEquals($contribution['financial_type_id'], $this->_financialTypeId);
     $this->assertEquals($contribution['financial_type'], 'Donation');
     $this->assertEquals($contribution['instrument_id'], $old_payment_instrument);
-    $this->assertEquals($contribution['non_deductible_amount'], 10.00);
-    $this->assertEquals($contribution['fee_amount'], $old_fee_amount);
-    $this->assertEquals($contribution['net_amount'], 100.00);
+    $this->assertEquals($contribution['non_deductible_amount'], 22.00);
+    $this->assertEquals($contribution['fee_amount'], 7.00);
     $this->assertEquals($contribution['trxn_id'], $old_trxn_id);
     $this->assertEquals($contribution['invoice_id'], $old_invoice_id);
     $this->assertEquals($contribution['contribution_source'], $old_source);
     $this->assertEquals($contribution['contribution_status'], 'Completed');
+
+    $this->assertEquals($contribution['net_amount'], $contribution['total_amount'] - $contribution['fee_amount']);
+
     $params = array(
       'contribution_id' => $contributionID,
 


### PR DESCRIPTION
1. if the total_amount is not in the currently submittedValues -> then it needs to be retrieved from $this->_values - however that total_amount is 'after' sales tax was previously added to it. Hence the subtraction. If we don't subtract it here - you end up being charged sales_tax on top of sales_tax - hence the screenshots in the JIRA issue

2. net_amount is defined as 
"Net value of the contribution (Total Amount minus Fee)."
fee_amount is defined as:
"Processing fee for this transaction (if applicable)."
Neither are related to sales taxes

---

 * [CRM-19966: Remove unfair double taxation](https://issues.civicrm.org/jira/browse/CRM-19966)