### PR TITLE
CRM-19813 - Unify Symfony Events and hooks

### DIFF
--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -387,7 +387,7 @@ abstract class CRM_Utils_Hook {
    *   the return value is ignored
    */
   public static function links($op, $objectName, &$objectId, &$links, &$mask = NULL, &$values = array()) {
-    return self::singleton()->invoke(6, $op, $objectName, $objectId, $links, $mask, $values, 'civicrm_links');
+    return self::singleton()->invoke(array('op', 'objectName', 'objectId', 'links', 'mask', 'values'), $op, $objectName, $objectId, $links, $mask, $values, 'civicrm_links');
   }
 
   /**
@@ -403,7 +403,7 @@ abstract class CRM_Utils_Hook {
    */
   public static function preProcess($formName, &$form) {
     return self::singleton()
-      ->invoke(2, $formName, $form, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_preProcess');
+      ->invoke(array('formName', 'form'), $formName, $form, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_preProcess');
   }
 
   /**
@@ -419,7 +419,7 @@ abstract class CRM_Utils_Hook {
    *   the return value is ignored
    */
   public static function buildForm($formName, &$form) {
-    return self::singleton()->invoke(2, $formName, $form,
+    return self::singleton()->invoke(array('formName', 'form'), $formName, $form,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_buildForm'
     );
@@ -438,7 +438,7 @@ abstract class CRM_Utils_Hook {
    *   the return value is ignored
    */
   public static function postProcess($formName, &$form) {
-    return self::singleton()->invoke(2, $formName, $form,
+    return self::singleton()->invoke(array('formName', 'form'), $formName, $form,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_postProcess'
     );
@@ -461,7 +461,8 @@ abstract class CRM_Utils_Hook {
    */
   public static function validateForm($formName, &$fields, &$files, &$form, &$errors) {
     return self::singleton()
-      ->invoke(5, $formName, $fields, $files, $form, $errors, self::$_nullObject, 'civicrm_validateForm');
+      ->invoke(array('formName', 'fields', 'files', 'form', 'errors'),
+        $formName, $fields, $files, $form, $errors, self::$_nullObject, 'civicrm_validateForm');
   }
 
   /**
@@ -481,7 +482,7 @@ abstract class CRM_Utils_Hook {
    */
   public static function custom($op, $groupID, $entityID, &$params) {
     return self::singleton()
-      ->invoke(4, $op, $groupID, $entityID, $params, self::$_nullObject, self::$_nullObject, 'civicrm_custom');
+      ->invoke(array('op', 'groupID', 'entityID', 'params'), $op, $groupID, $entityID, $params, self::$_nullObject, self::$_nullObject, 'civicrm_custom');
   }
 
   /**
@@ -504,7 +505,7 @@ abstract class CRM_Utils_Hook {
    */
   public static function aclWhereClause($type, &$tables, &$whereTables, &$contactID, &$where) {
     return self::singleton()
-      ->invoke(5, $type, $tables, $whereTables, $contactID, $where, self::$_nullObject, 'civicrm_aclWhereClause');
+      ->invoke(array('type', 'tables', 'whereTables', 'contactID', 'where'), $type, $tables, $whereTables, $contactID, $where, self::$_nullObject, 'civicrm_aclWhereClause');
   }
 
   /**
@@ -527,7 +528,7 @@ abstract class CRM_Utils_Hook {
    */
   public static function aclGroup($type, $contactID, $tableName, &$allGroups, &$currentGroups) {
     return self::singleton()
-      ->invoke(5, $type, $contactID, $tableName, $allGroups, $currentGroups, self::$_nullObject, 'civicrm_aclGroup');
+      ->invoke(array('type', 'contactID', 'tableName', 'allGroups', 'currentGroups'), $type, $contactID, $tableName, $allGroups, $currentGroups, self::$_nullObject, 'civicrm_aclGroup');
   }
 
   /**
@@ -537,7 +538,7 @@ abstract class CRM_Utils_Hook {
    */
   public static function selectWhereClause($entity, &$clauses) {
     $entityName = is_object($entity) ? _civicrm_api_get_entity_name_from_dao($entity) : $entity;
-    return self::singleton()->invoke(2, $entityName, $clauses,
+    return self::singleton()->invoke(array('entity', 'clauses'), $entityName, $clauses,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_selectWhereClause'
     );
@@ -553,7 +554,7 @@ abstract class CRM_Utils_Hook {
    *   the return value is ignored
    */
   public static function xmlMenu(&$files) {
-    return self::singleton()->invoke(1, $files,
+    return self::singleton()->invoke(array('files'), $files,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_xmlMenu'
     );
@@ -568,7 +569,7 @@ abstract class CRM_Utils_Hook {
    *   the return value is ignored
    */
   public static function alterMenu(&$items) {
-    return self::singleton()->invoke(1, $items,
+    return self::singleton()->invoke(array('items'), $items,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_alterMenu'
     );

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -596,7 +596,7 @@ abstract class CRM_Utils_Hook {
    *   the return value is ignored
    */
   public static function managed(&$entities) {
-    return self::singleton()->invoke(1, $entities,
+    return self::singleton()->invoke(array('entities'), $entities,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_managed'
     );
@@ -615,7 +615,7 @@ abstract class CRM_Utils_Hook {
    *   the html snippet to include in the dashboard
    */
   public static function dashboard($contactID, &$contentPlacement = self::DASHBOARD_BELOW) {
-    $retval = self::singleton()->invoke(2, $contactID, $contentPlacement,
+    $retval = self::singleton()->invoke(array('contactID', 'contentPlacement'), $contactID, $contentPlacement,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_dashboard'
     );
@@ -641,7 +641,7 @@ abstract class CRM_Utils_Hook {
    * @return array
    */
   public static function recent(&$recentArray) {
-    return self::singleton()->invoke(1, $recentArray,
+    return self::singleton()->invoke(array('recentArray'), $recentArray,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_recent'
     );
@@ -662,7 +662,7 @@ abstract class CRM_Utils_Hook {
    *   Return is not really intended to be used.
    */
   public static function referenceCounts($dao, &$refCounts) {
-    return self::singleton()->invoke(2, $dao, $refCounts,
+    return self::singleton()->invoke(array('dao', 'refCounts'), $dao, $refCounts,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_referenceCounts'
     );
@@ -681,7 +681,7 @@ abstract class CRM_Utils_Hook {
    * @return null
    */
   public static function buildAmount($pageType, &$form, &$amount) {
-    return self::singleton()->invoke(3, $pageType, $form, $amount, self::$_nullObject,
+    return self::singleton()->invoke(array('pageType', 'form', 'amount'), $pageType, $form, $amount, self::$_nullObject,
       self::$_nullObject, self::$_nullObject, 'civicrm_buildAmount');
   }
 
@@ -695,7 +695,7 @@ abstract class CRM_Utils_Hook {
    * @return null
    */
   public static function buildStateProvinceForCountry($countryID, &$states) {
-    return self::singleton()->invoke(2, $countryID, $states,
+    return self::singleton()->invoke(array('countryID', 'states'), $countryID, $states,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_buildStateProvinceForCountry'
     );
@@ -713,7 +713,7 @@ abstract class CRM_Utils_Hook {
    * @deprecated Use tabset() instead.
    */
   public static function tabs(&$tabs, $contactID) {
-    return self::singleton()->invoke(2, $tabs, $contactID,
+    return self::singleton()->invoke(array('tabs', 'contactID'), $tabs, $contactID,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_tabs'
     );
   }
@@ -732,7 +732,7 @@ abstract class CRM_Utils_Hook {
    * @return null
    */
   public static function tabset($tabsetName, &$tabs, $context) {
-    return self::singleton()->invoke(3, $tabsetName, $tabs,
+    return self::singleton()->invoke(array('tabsetName', 'tabs', 'context'), $tabsetName, $tabs,
       $context, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_tabset'
     );
   }
@@ -746,7 +746,7 @@ abstract class CRM_Utils_Hook {
    * @return null
    */
   public static function tokens(&$tokens) {
-    return self::singleton()->invoke(1, $tokens,
+    return self::singleton()->invoke(array('tokens'), $tokens,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_tokens'
     );
   }

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -1158,7 +1158,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function config(&$config) {
-    return self::singleton()->invoke(1, $config,
+    return self::singleton()->invoke(array('config'), $config,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_config'
     );
@@ -1177,7 +1177,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function optionValues(&$options, $name) {
-    return self::singleton()->invoke(2, $options, $name,
+    return self::singleton()->invoke(array('options', 'name'), $options, $name,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_optionValues'
     );
@@ -1192,7 +1192,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function navigationMenu(&$params) {
-    return self::singleton()->invoke(1, $params,
+    return self::singleton()->invoke(array('params'), $params,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_navigationMenu'
     );
@@ -1215,7 +1215,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function merge($type, &$data, $mainId = NULL, $otherId = NULL, $tables = NULL) {
-    return self::singleton()->invoke(5, $type, $data, $mainId, $otherId, $tables, self::$_nullObject, 'civicrm_merge');
+    return self::singleton()->invoke(array('type', 'data', 'mainId', 'otherId', 'tables'), $type, $data, $mainId, $otherId, $tables, self::$_nullObject, 'civicrm_merge');
   }
 
   /**
@@ -1233,7 +1233,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function alterLocationMergeData(&$blocksDAO, $mainId, $otherId, $migrationInfo) {
-    return self::singleton()->invoke(4, $blocksDAO, $mainId, $otherId, $migrationInfo, self::$_nullObject, self::$_nullObject, 'civicrm_alterLocationMergeData');
+    return self::singleton()->invoke(array('blocksDAO', 'mainId', 'otherId', 'migrationInfo'), $blocksDAO, $mainId, $otherId, $migrationInfo, self::$_nullObject, self::$_nullObject, 'civicrm_alterLocationMergeData');
   }
 
   /**
@@ -1245,7 +1245,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function notePrivacy(&$noteValues) {
-    return self::singleton()->invoke(1, $noteValues,
+    return self::singleton()->invoke(array('noteValues'), $noteValues,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_notePrivacy'
     );
@@ -1266,7 +1266,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function export(&$exportTempTable, &$headerRows, &$sqlColumns, &$exportMode) {
-    return self::singleton()->invoke(4, $exportTempTable, $headerRows, $sqlColumns, $exportMode,
+    return self::singleton()->invoke(array('exportTempTable', 'headerRows', 'sqlColumns', 'exportMode'), $exportTempTable, $headerRows, $sqlColumns, $exportMode,
       self::$_nullObject, self::$_nullObject,
       'civicrm_export'
     );
@@ -1285,7 +1285,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function dupeQuery($obj, $type, &$query) {
-    return self::singleton()->invoke(3, $obj, $type, $query,
+    return self::singleton()->invoke(array('obj', 'type', 'query'), $obj, $type, $query,
       self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_dupeQuery'
     );
@@ -1307,7 +1307,7 @@ abstract class CRM_Utils_Hook {
    */
   public static function emailProcessor($type, &$params, $mail, &$result, $action = NULL) {
     return self::singleton()
-      ->invoke(5, $type, $params, $mail, $result, $action, self::$_nullObject, 'civicrm_emailProcessor');
+      ->invoke(array('type', 'params', 'mail', 'result', 'action'), $type, $params, $mail, $result, $action, self::$_nullObject, 'civicrm_emailProcessor');
   }
 
   /**
@@ -1332,7 +1332,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function import($object, $usage, &$objectRef, &$params) {
-    return self::singleton()->invoke(4, $object, $usage, $objectRef, $params,
+    return self::singleton()->invoke(array('object', 'usage', 'objectRef', 'params'), $object, $usage, $objectRef, $params,
       self::$_nullObject, self::$_nullObject,
       'civicrm_import'
     );

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -1642,7 +1642,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function alterReportVar($varType, &$var, &$object) {
-    return self::singleton()->invoke(3, $varType, $var, $object,
+    return self::singleton()->invoke(array('varType', 'var', 'object'), $varType, $var, $object,
       self::$_nullObject,
       self::$_nullObject, self::$_nullObject,
       'civicrm_alterReportVar'
@@ -1663,7 +1663,7 @@ abstract class CRM_Utils_Hook {
    *   FALSE, if $op is 'check' and upgrades are not pending.
    */
   public static function upgrade($op, CRM_Queue_Queue $queue = NULL) {
-    return self::singleton()->invoke(2, $op, $queue,
+    return self::singleton()->invoke(array('op', 'queue'), $op, $queue,
       self::$_nullObject, self::$_nullObject, self::$_nullObject,
       self::$_nullObject,
       'civicrm_upgrade'
@@ -1681,7 +1681,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function postEmailSend(&$params) {
-    return self::singleton()->invoke(1, $params,
+    return self::singleton()->invoke(array('params'), $params,
       self::$_nullObject, self::$_nullObject,
       self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_postEmailSend'
@@ -1697,7 +1697,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function postMailing($mailingId) {
-    return self::singleton()->invoke(1, $mailingId,
+    return self::singleton()->invoke(array('mailingId'), $mailingId,
       self::$_nullObject, self::$_nullObject,
       self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_postMailing'
@@ -1713,7 +1713,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function alterSettingsFolders(&$settingsFolders) {
-    return self::singleton()->invoke(1, $settingsFolders,
+    return self::singleton()->invoke(array('settingsFolders'), $settingsFolders,
       self::$_nullObject, self::$_nullObject,
       self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_alterSettingsFolders'
@@ -1732,7 +1732,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function alterSettingsMetaData(&$settingsMetaData, $domainID, $profile) {
-    return self::singleton()->invoke(3, $settingsMetaData,
+    return self::singleton()->invoke(array('settingsMetaData', 'domainID', 'profile'), $settingsMetaData,
       $domainID, $profile,
       self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_alterSettingsMetaData'
@@ -1751,7 +1751,7 @@ abstract class CRM_Utils_Hook {
    */
   public static function apiWrappers(&$wrappers, $apiRequest) {
     return self::singleton()
-      ->invoke(2, $wrappers, $apiRequest, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      ->invoke(array('wrappers', 'apiRequest'), $wrappers, $apiRequest, self::$_nullObject, self::$_nullObject, self::$_nullObject,
         self::$_nullObject, 'civicrm_apiWrappers'
       );
   }
@@ -1765,7 +1765,7 @@ abstract class CRM_Utils_Hook {
    *   The return value is ignored.
    */
   public static function cron($jobManager) {
-    return self::singleton()->invoke(1,
+    return self::singleton()->invoke(array('jobManager'),
       $jobManager, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_cron'
     );
@@ -1783,7 +1783,7 @@ abstract class CRM_Utils_Hook {
    *   The return value is ignored
    */
   public static function permission(&$permissions) {
-    return self::singleton()->invoke(1, $permissions,
+    return self::singleton()->invoke(array('permissions'), $permissions,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_permission'
     );
@@ -1802,7 +1802,7 @@ abstract class CRM_Utils_Hook {
    *   The return value is ignored
    */
   public static function permission_check($permission, &$granted) {
-    return self::singleton()->invoke(2, $permission, $granted,
+    return self::singleton()->invoke(array('permission', 'granted'), $permission, $granted,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_permission_check'
     );

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -156,8 +156,18 @@ abstract class CRM_Utils_Hook {
     &$arg1, &$arg2, &$arg3, &$arg4, &$arg5, &$arg6,
     $fnSuffix
   ) {
-    $count = is_array($names) ? count($names) : $names;
-    return $this->invokeViaUF($count, $arg1, $arg2, $arg3, $arg4, $arg5, $arg6, $fnSuffix);
+    if (is_array($names) && !defined('CIVICRM_FORCE_LEGACY_HOOK')) {
+      $event = \Civi\Core\Event\GenericHookEvent::createOrdered(
+        $names,
+        array(&$arg1, &$arg2, &$arg3, &$arg4, &$arg5, &$arg6)
+      );
+      \Civi::dispatcher()->dispatch('hook_' . $fnSuffix, $event);
+      return $event->getReturnValues();
+    }
+    else {
+      $count = is_array($names) ? count($names) : $names;
+      return $this->invokeViaUF($count, $arg1, $arg2, $arg3, $arg4, $arg5, $arg6, $fnSuffix);
+    }
   }
 
   /**

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -1833,7 +1833,7 @@ abstract class CRM_Utils_Hook {
    *   The return value is ignored
    */
   public static function entityTypes(&$entityTypes) {
-    return self::singleton()->invoke(1, $entityTypes, self::$_nullObject, self::$_nullObject,
+    return self::singleton()->invoke(array('entityTypes'), $entityTypes, self::$_nullObject, self::$_nullObject,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_entityTypes'
     );
   }
@@ -1845,7 +1845,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function buildProfile($name) {
-    return self::singleton()->invoke(1, $name, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+    return self::singleton()->invoke(array('name'), $name, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       self::$_nullObject, self::$_nullObject, 'civicrm_buildProfile');
   }
 
@@ -1856,7 +1856,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function validateProfile($name) {
-    return self::singleton()->invoke(1, $name, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+    return self::singleton()->invoke(array('name'), $name, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       self::$_nullObject, self::$_nullObject, 'civicrm_validateProfile');
   }
 
@@ -1867,7 +1867,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function processProfile($name) {
-    return self::singleton()->invoke(1, $name, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+    return self::singleton()->invoke(array('name'), $name, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       self::$_nullObject, self::$_nullObject, 'civicrm_processProfile');
   }
 
@@ -1878,7 +1878,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function viewProfile($name) {
-    return self::singleton()->invoke(1, $name, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+    return self::singleton()->invoke(array('name'), $name, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       self::$_nullObject, self::$_nullObject, 'civicrm_viewProfile');
   }
 
@@ -1889,7 +1889,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function searchProfile($name) {
-    return self::singleton()->invoke(1, $name, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+    return self::singleton()->invoke(array('name'), $name, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       self::$_nullObject, self::$_nullObject, 'civicrm_searchProfile');
   }
 
@@ -1910,7 +1910,7 @@ abstract class CRM_Utils_Hook {
    */
   public static function alterBadge($labelName, &$label, &$format, &$participant) {
     return self::singleton()
-      ->invoke(4, $labelName, $label, $format, $participant, self::$_nullObject, self::$_nullObject, 'civicrm_alterBadge');
+      ->invoke(array('labelName', 'label', 'format', 'participant'), $labelName, $label, $format, $participant, self::$_nullObject, self::$_nullObject, 'civicrm_alterBadge');
   }
 
 
@@ -1927,7 +1927,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function alterBarcode(&$data, $type = 'barcode', $context = 'name_badge') {
-    return self::singleton()->invoke(3, $data, $type, $context, self::$_nullObject,
+    return self::singleton()->invoke(array('data', 'type', 'context'), $data, $type, $context, self::$_nullObject,
       self::$_nullObject, self::$_nullObject, 'civicrm_alterBarcode');
   }
 
@@ -1946,7 +1946,7 @@ abstract class CRM_Utils_Hook {
    */
   public static function alterMailer(&$mailer, $driver, $params) {
     return self::singleton()
-      ->invoke(3, $mailer, $driver, $params, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_alterMailer');
+      ->invoke(array('mailer', 'driver', 'params'), $mailer, $driver, $params, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_alterMailer');
   }
 
   /**
@@ -1979,7 +1979,7 @@ abstract class CRM_Utils_Hook {
    */
   public static function queryObjects(&$queryObjects, $type = 'Contact') {
     return self::singleton()
-      ->invoke(2, $queryObjects, $type, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_queryObjects');
+      ->invoke(array('queryObjects', 'type'), $queryObjects, $type, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_queryObjects');
   }
 
   /**

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -330,10 +330,8 @@ abstract class CRM_Utils_Hook {
    */
   public static function pre($op, $objectName, $id, &$params) {
     $event = new \Civi\Core\Event\PreEvent($op, $objectName, $id, $params);
-    \Civi::service('dispatcher')->dispatch("hook_civicrm_pre", $event);
-    \Civi::service('dispatcher')->dispatch("hook_civicrm_pre::$objectName", $event);
-    return self::singleton()
-      ->invoke(4, $op, $objectName, $id, $params, self::$_nullObject, self::$_nullObject, 'civicrm_pre');
+    \Civi::dispatcher()->dispatch('hook_civicrm_pre', $event);
+    return $event->getReturnValues();
   }
 
   /**
@@ -354,10 +352,8 @@ abstract class CRM_Utils_Hook {
    */
   public static function post($op, $objectName, $objectId, &$objectRef = NULL) {
     $event = new \Civi\Core\Event\PostEvent($op, $objectName, $objectId, $objectRef);
-    \Civi::service('dispatcher')->dispatch("hook_civicrm_post", $event);
-    \Civi::service('dispatcher')->dispatch("hook_civicrm_post::$objectName", $event);
-    return self::singleton()
-      ->invoke(4, $op, $objectName, $objectId, $objectRef, self::$_nullObject, self::$_nullObject, 'civicrm_post');
+    \Civi::dispatcher()->dispatch('hook_civicrm_post', $event);
+    return $event->getReturnValues();
   }
 
   /**
@@ -1806,16 +1802,8 @@ abstract class CRM_Utils_Hook {
    *   Reserved for future use.
    */
   public static function unhandledException($exception, $request = NULL) {
-    self::singleton()
-      ->invoke(2, $exception, $request, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_unhandled_exception');
-    // == 4.4 ==
-    // $event = new stdClass();
-    // $event->exception = $exception;
-    // CRM_Core_LegacyErrorHandler::handleException($event);
-
-    // == 4.5+ ==
     $event = new \Civi\Core\Event\UnhandledExceptionEvent($exception, self::$_nullObject);
-    \Civi::service('dispatcher')->dispatch("hook_civicrm_unhandled_exception", $event);
+    \Civi::dispatcher()->dispatch('hook_civicrm_unhandled_exception', $event);
   }
 
   /**
@@ -2087,12 +2075,7 @@ abstract class CRM_Utils_Hook {
    */
   public static function caseChange(\Civi\CCase\Analyzer $analyzer) {
     $event = new \Civi\CCase\Event\CaseChangeEvent($analyzer);
-    \Civi::service('dispatcher')->dispatch("hook_civicrm_caseChange", $event);
-
-    self::singleton()->invoke(1, $analyzer,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
-      'civicrm_caseChange'
-    );
+    \Civi::dispatcher()->dispatch('hook_civicrm_caseChange', $event);
   }
 
   /**

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -1994,7 +1994,7 @@ abstract class CRM_Utils_Hook {
    */
   public static function dashboard_defaults($availableDashlets, &$defaultDashlets) {
     return self::singleton()
-      ->invoke(2, $availableDashlets, $defaultDashlets, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_dashboard_defaults');
+      ->invoke(array('availableDashlets', 'defaultDashlets'), $availableDashlets, $defaultDashlets, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_dashboard_defaults');
   }
 
   /**
@@ -2010,7 +2010,7 @@ abstract class CRM_Utils_Hook {
    */
   public static function pre_case_merge($mainContactId, $mainCaseId = NULL, $otherContactId = NULL, $otherCaseId = NULL, $changeClient = FALSE) {
     return self::singleton()
-      ->invoke(5, $mainContactId, $mainCaseId, $otherContactId, $otherCaseId, $changeClient, self::$_nullObject, 'civicrm_pre_case_merge');
+      ->invoke(array('mainContactId', 'mainCaseId', 'otherContactId', 'otherCaseId', 'changeClient'), $mainContactId, $mainCaseId, $otherContactId, $otherCaseId, $changeClient, self::$_nullObject, 'civicrm_pre_case_merge');
   }
 
   /**
@@ -2026,7 +2026,7 @@ abstract class CRM_Utils_Hook {
    */
   public static function post_case_merge($mainContactId, $mainCaseId = NULL, $otherContactId = NULL, $otherCaseId = NULL, $changeClient = FALSE) {
     return self::singleton()
-      ->invoke(5, $mainContactId, $mainCaseId, $otherContactId, $otherCaseId, $changeClient, self::$_nullObject, 'civicrm_post_case_merge');
+      ->invoke(array('mainContactId', 'mainCaseId', 'otherContactId', 'otherCaseId', 'changeClient'), $mainContactId, $mainCaseId, $otherContactId, $otherCaseId, $changeClient, self::$_nullObject, 'civicrm_post_case_merge');
   }
 
   /**
@@ -2043,7 +2043,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function alterDisplayName(&$displayName, $contactId, $dao) {
-    return self::singleton()->invoke(3,
+    return self::singleton()->invoke(array('displayName', 'contactId', 'dao'),
       $displayName, $contactId, $dao, self::$_nullObject, self::$_nullObject,
       self::$_nullObject, 'civicrm_contact_get_displayname'
     );
@@ -2073,7 +2073,7 @@ abstract class CRM_Utils_Hook {
    * @endcode
    */
   public static function angularModules(&$angularModules) {
-    return self::singleton()->invoke(1, $angularModules,
+    return self::singleton()->invoke(array('angularModules'), $angularModules,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_angularModules'
     );
@@ -2109,7 +2109,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function crudLink($spec, $bao, &$link) {
-    return self::singleton()->invoke(3, $spec, $bao, $link,
+    return self::singleton()->invoke(array('spec', 'bao', 'link'), $spec, $bao, $link,
       self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_crudLink'
     );
@@ -2148,7 +2148,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function fileSearches(&$fileSearches) {
-    return self::singleton()->invoke(1, $fileSearches,
+    return self::singleton()->invoke(array('fileSearches'), $fileSearches,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_fileSearches'
     );
@@ -2163,7 +2163,7 @@ abstract class CRM_Utils_Hook {
    */
   public static function check(&$messages) {
     return self::singleton()
-      ->invoke(1, $messages, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_check');
+      ->invoke(array('messages'), $messages, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_check');
   }
 
   /**
@@ -2174,7 +2174,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function batchQuery(&$query) {
-    return self::singleton()->invoke(1, $query, self::$_nullObject,
+    return self::singleton()->invoke(array('query'), $query, self::$_nullObject,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_batchQuery'
     );
@@ -2195,7 +2195,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function alterDeferredRevenueItems(&$deferredRevenues, $contributionDetails, $update, $context) {
-    return self::singleton()->invoke(4, $deferredRevenues, $contributionDetails, $update, $context,
+    return self::singleton()->invoke(array('deferredRevenues', 'contributionDetails', 'update', 'context'), $deferredRevenues, $contributionDetails, $update, $context,
       self::$_nullObject, self::$_nullObject, 'civicrm_alterDeferredRevenueItems'
     );
   }
@@ -2209,7 +2209,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function batchItems(&$results, &$items) {
-    return self::singleton()->invoke(2, $results, $items,
+    return self::singleton()->invoke(array('results', 'items'), $results, $items,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_batchItems'
     );
@@ -2227,7 +2227,7 @@ abstract class CRM_Utils_Hook {
     // First allow the cms integration to add to the list
     CRM_Core_Config::singleton()->userSystem->appendCoreResources($list);
 
-    self::singleton()->invoke(2, $list, $region,
+    self::singleton()->invoke(array('list', 'region'), $list, $region,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_coreResourceList'
     );
@@ -2241,7 +2241,7 @@ abstract class CRM_Utils_Hook {
    * @param array $filters
    */
   public static function entityRefFilters(&$filters) {
-    self::singleton()->invoke(1, $filters, self::$_nullObject, self::$_nullObject,
+    self::singleton()->invoke(array('filters'), $filters, self::$_nullObject, self::$_nullObject,
       self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_entityRefFilters'
     );
@@ -2255,7 +2255,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function idsException(&$skip) {
-    return self::singleton()->invoke(1, $skip, self::$_nullObject,
+    return self::singleton()->invoke(array('skip'), $skip, self::$_nullObject,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_idsException'
     );
@@ -2271,7 +2271,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function geocoderFormat($geoProvider, &$values, $xml) {
-    return self::singleton()->invoke(3, $geoProvider, $values, $xml,
+    return self::singleton()->invoke(array('geoProvider', 'values', 'xml'), $geoProvider, $values, $xml,
       self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_geocoderFormat'
     );

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2125,7 +2125,10 @@ abstract class CRM_Utils_Hook {
    * @see http://symfony.com/doc/current/components/dependency_injection/index.html
    */
   public static function container(\Symfony\Component\DependencyInjection\ContainerBuilder $container) {
-    self::singleton()->invoke(1, $container, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_container');
+    // This hook fires during system bootstrap, after CRM_Extension_System
+    // initializes but before the container or dispatcher initialize. Therefore,
+    // we cannot use containerized services (like the dispatcher).
+    self::singleton()->invokeViaUF(1, $container, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_container');
   }
 
   /**

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -776,7 +776,7 @@ abstract class CRM_Utils_Hook {
     $className = NULL
   ) {
     return self::singleton()
-      ->invoke(5, $details, $contactIDs, $jobID, $tokens, $className, self::$_nullObject, 'civicrm_tokenValues');
+      ->invoke(array('details', 'contactIDs', 'jobID', 'tokens', 'className'), $details, $contactIDs, $jobID, $tokens, $className, self::$_nullObject, 'civicrm_tokenValues');
   }
 
   /**
@@ -789,7 +789,7 @@ abstract class CRM_Utils_Hook {
    * @return null
    */
   public static function pageRun(&$page) {
-    return self::singleton()->invoke(1, $page,
+    return self::singleton()->invoke(array('page'), $page,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_pageRun'
     );
@@ -807,7 +807,7 @@ abstract class CRM_Utils_Hook {
    * @return null
    */
   public static function copy($objectName, &$object) {
-    return self::singleton()->invoke(2, $objectName, $object,
+    return self::singleton()->invoke(array('objectName', 'object'), $objectName, $object,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_copy'
     );
@@ -833,7 +833,7 @@ abstract class CRM_Utils_Hook {
    */
   public static function unsubscribeGroups($op, $mailingId, $contactId, &$groups, &$baseGroups) {
     return self::singleton()
-      ->invoke(5, $op, $mailingId, $contactId, $groups, $baseGroups, self::$_nullObject, 'civicrm_unsubscribeGroups');
+      ->invoke(array('op', 'mailingId', 'contactId', 'groups', 'baseGroups'), $op, $mailingId, $contactId, $groups, $baseGroups, self::$_nullObject, 'civicrm_unsubscribeGroups');
   }
 
   /**
@@ -857,7 +857,8 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function customFieldOptions($customFieldID, &$options, $detailedFormat = FALSE, $selectAttributes = array()) {
-    return self::singleton()->invoke(3, $customFieldID, $options, $detailedFormat,
+    // Weird: $selectAttributes is inputted but not outputted.
+    return self::singleton()->invoke(array('customFieldID', 'options', 'detailedFormat'), $customFieldID, $options, $detailedFormat,
       self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_customFieldOptions'
     );
@@ -874,7 +875,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function fieldOptions($entity, $field, &$options, $params) {
-    return self::singleton()->invoke(5, $entity, $field, $options, $params,
+    return self::singleton()->invoke(array('entity', 'field', 'options', 'params'), $entity, $field, $options, $params,
       self::$_nullObject, self::$_nullObject,
       'civicrm_fieldOptions'
     );
@@ -900,7 +901,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function searchTasks($objectType, &$tasks) {
-    return self::singleton()->invoke(2, $objectType, $tasks,
+    return self::singleton()->invoke(array('objectType', 'tasks'), $objectType, $tasks,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_searchTasks'
     );
@@ -913,7 +914,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function eventDiscount(&$form, &$params) {
-    return self::singleton()->invoke(2, $form, $params,
+    return self::singleton()->invoke(array('form', 'params'), $form, $params,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_eventDiscount'
     );
@@ -932,7 +933,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function mailingGroups(&$form, &$groups, &$mailings) {
-    return self::singleton()->invoke(3, $form, $groups, $mailings,
+    return self::singleton()->invoke(array('form', 'groups', 'mailings'), $form, $groups, $mailings,
       self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_mailingGroups'
     );

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -950,7 +950,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function mailingTemplateTypes(&$types) {
-    return self::singleton()->invoke(1, $types, self::$_nullObject, self::$_nullObject,
+    return self::singleton()->invoke(array('types'), $types, self::$_nullObject, self::$_nullObject,
       self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_mailingTemplateTypes'
     );
@@ -971,7 +971,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function membershipTypeValues(&$form, &$membershipTypes) {
-    return self::singleton()->invoke(2, $form, $membershipTypes,
+    return self::singleton()->invoke(array('form', 'membershipTypes'), $form, $membershipTypes,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_membershipTypeValues'
     );
@@ -991,7 +991,7 @@ abstract class CRM_Utils_Hook {
    *   The html snippet to include in the contact summary
    */
   public static function summary($contactID, &$content, &$contentPlacement = self::SUMMARY_BELOW) {
-    return self::singleton()->invoke(3, $contactID, $content, $contentPlacement,
+    return self::singleton()->invoke(array('contactID', 'content', 'contentPlacement'), $contactID, $content, $contentPlacement,
       self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_summary'
     );
@@ -1022,7 +1022,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function contactListQuery(&$query, $name, $context, $id) {
-    return self::singleton()->invoke(4, $query, $name, $context, $id,
+    return self::singleton()->invoke(array('query', 'name', 'context', 'id'), $query, $name, $context, $id,
       self::$_nullObject, self::$_nullObject,
       'civicrm_contactListQuery'
     );
@@ -1055,7 +1055,7 @@ abstract class CRM_Utils_Hook {
     &$rawParams,
     &$cookedParams
   ) {
-    return self::singleton()->invoke(3, $paymentObj, $rawParams, $cookedParams,
+    return self::singleton()->invoke(array('paymentObj', 'rawParams', 'cookedParams'), $paymentObj, $rawParams, $cookedParams,
       self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_alterPaymentProcessorParams'
     );
@@ -1073,7 +1073,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function alterMailParams(&$params, $context = NULL) {
-    return self::singleton()->invoke(2, $params, $context,
+    return self::singleton()->invoke(array('params', 'context'), $params, $context,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_alterMailParams'
     );
@@ -1098,7 +1098,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function alterCalculatedMembershipStatus(&$membershipStatus, $arguments, $membership) {
-    return self::singleton()->invoke(3, $membershipStatus, $arguments,
+    return self::singleton()->invoke(array('membershipStatus', 'arguments', 'membership'), $membershipStatus, $arguments,
       $membership, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_alterCalculatedMembershipStatus'
     );
@@ -1113,7 +1113,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function alterMailContent(&$content) {
-    return self::singleton()->invoke(1, $content,
+    return self::singleton()->invoke(array('content'), $content,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_alterMailContent'
     );
@@ -1130,7 +1130,7 @@ abstract class CRM_Utils_Hook {
    *   and the value is an array with keys 'label' and 'value' specifying label/value pairs
    */
   public static function caseSummary($caseID) {
-    return self::singleton()->invoke(1, $caseID,
+    return self::singleton()->invoke(array('caseID'), $caseID,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_caseSummary'
     );
@@ -1145,7 +1145,7 @@ abstract class CRM_Utils_Hook {
    */
   public static function caseTypes(&$caseTypes) {
     return self::singleton()
-      ->invoke(1, $caseTypes, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_caseTypes');
+      ->invoke(array('caseTypes'), $caseTypes, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_caseTypes');
   }
 
   /**

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -101,7 +101,8 @@ abstract class CRM_Utils_Hook {
   }
 
   /**
-   * Invoke hooks.
+   * Invoke a hook through the UF/CMS hook system and the extension-hook
+   * system.
    *
    * @param int $numParams
    *   Number of parameters to pass to the hook.
@@ -122,11 +123,42 @@ abstract class CRM_Utils_Hook {
    *
    * @return mixed
    */
-  public abstract function invoke(
+  public abstract function invokeViaUF(
     $numParams,
     &$arg1, &$arg2, &$arg3, &$arg4, &$arg5, &$arg6,
     $fnSuffix
   );
+
+  /**
+   * Invoke a hook.
+   *
+   * This is a transitional adapter. It supports the legacy syntax
+   * but also accepts enough information to support Symfony Event
+   * dispatching.
+   *
+   * @param array|int $names
+   *   (Recommended) Array of parameter names, in order.
+   *   Using an array is recommended because it enables full
+   *   event-broadcasting behaviors.
+   *   (Legacy) Number of parameters to pass to the hook.
+   *   This is provided for transitional purposes.
+   * @param mixed $arg1
+   * @param mixed $arg2
+   * @param mixed $arg3
+   * @param mixed $arg4
+   * @param mixed $arg5
+   * @param mixed $arg6
+   * @param mixed $fnSuffix
+   * @return mixed
+   */
+  public function invoke(
+    $names,
+    &$arg1, &$arg2, &$arg3, &$arg4, &$arg5, &$arg6,
+    $fnSuffix
+  ) {
+    $count = is_array($names) ? count($names) : $names;
+    return $this->invokeViaUF($count, $arg1, $arg2, $arg3, $arg4, $arg5, $arg6, $fnSuffix);
+  }
 
   /**
    * @param array $numParams

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -1011,7 +1011,7 @@ abstract class CRM_Utils_Hook {
    *   Your query must return two columns:
    *     the contact 'data' to display in the autocomplete dropdown (usually contact.sort_name - aliased as 'data')
    *     the contact IDs
-   * @param string $name
+   * @param string $queryText
    *   The name string to execute the query against (this is the value being typed in by the user).
    * @param string $context
    *   The context in which this ajax call is being made (for example: 'customfield', 'caseview').
@@ -1021,8 +1021,8 @@ abstract class CRM_Utils_Hook {
    *
    * @return mixed
    */
-  public static function contactListQuery(&$query, $name, $context, $id) {
-    return self::singleton()->invoke(array('query', 'name', 'context', 'id'), $query, $name, $context, $id,
+  public static function contactListQuery(&$query, $queryText, $context, $id) {
+    return self::singleton()->invoke(array('query', 'queryText', 'context', 'id'), $query, $queryText, $context, $id,
       self::$_nullObject, self::$_nullObject,
       'civicrm_contactListQuery'
     );
@@ -1171,13 +1171,13 @@ abstract class CRM_Utils_Hook {
    *
    * @param array $options
    *   Associated array of option values / id
-   * @param string $name
+   * @param string $groupName
    *   Option group name
    *
    * @return mixed
    */
-  public static function optionValues(&$options, $name) {
-    return self::singleton()->invoke(array('options', 'name'), $options, $name,
+  public static function optionValues(&$options, $groupName) {
+    return self::singleton()->invoke(array('options', 'groupName'), $options, $groupName,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_optionValues'
     );
@@ -1841,55 +1841,55 @@ abstract class CRM_Utils_Hook {
   /**
    * This hook is called while preparing a profile form.
    *
-   * @param string $name
+   * @param string $profileName
    * @return mixed
    */
-  public static function buildProfile($name) {
-    return self::singleton()->invoke(array('name'), $name, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+  public static function buildProfile($profileName) {
+    return self::singleton()->invoke(array('profileName'), $profileName, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       self::$_nullObject, self::$_nullObject, 'civicrm_buildProfile');
   }
 
   /**
    * This hook is called while validating a profile form submission.
    *
-   * @param string $name
+   * @param string $profileName
    * @return mixed
    */
-  public static function validateProfile($name) {
-    return self::singleton()->invoke(array('name'), $name, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+  public static function validateProfile($profileName) {
+    return self::singleton()->invoke(array('profileName'), $profileName, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       self::$_nullObject, self::$_nullObject, 'civicrm_validateProfile');
   }
 
   /**
    * This hook is called processing a valid profile form submission.
    *
-   * @param string $name
+   * @param string $profileName
    * @return mixed
    */
-  public static function processProfile($name) {
-    return self::singleton()->invoke(array('name'), $name, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+  public static function processProfile($profileName) {
+    return self::singleton()->invoke(array('profileName'), $profileName, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       self::$_nullObject, self::$_nullObject, 'civicrm_processProfile');
   }
 
   /**
    * This hook is called while preparing a read-only profile screen
    *
-   * @param string $name
+   * @param string $profileName
    * @return mixed
    */
-  public static function viewProfile($name) {
-    return self::singleton()->invoke(array('name'), $name, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+  public static function viewProfile($profileName) {
+    return self::singleton()->invoke(array('profileName'), $profileName, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       self::$_nullObject, self::$_nullObject, 'civicrm_viewProfile');
   }
 
   /**
    * This hook is called while preparing a list of contacts (based on a profile)
    *
-   * @param string $name
+   * @param string $profileName
    * @return mixed
    */
-  public static function searchProfile($name) {
-    return self::singleton()->invoke(array('name'), $name, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+  public static function searchProfile($profileName) {
+    return self::singleton()->invoke(array('profileName'), $profileName, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       self::$_nullObject, self::$_nullObject, 'civicrm_searchProfile');
   }
 

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -1352,7 +1352,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function alterAPIPermissions($entity, $action, &$params, &$permissions) {
-    return self::singleton()->invoke(4, $entity, $action, $params, $permissions,
+    return self::singleton()->invoke(array('entity', 'action', 'params', 'permissions'), $entity, $action, $params, $permissions,
       self::$_nullObject, self::$_nullObject,
       'civicrm_alterAPIPermissions'
     );
@@ -1365,7 +1365,7 @@ abstract class CRM_Utils_Hook {
    */
   public static function postSave(&$dao) {
     $hookName = 'civicrm_postSave_' . $dao->getTableName();
-    return self::singleton()->invoke(1, $dao,
+    return self::singleton()->invoke(array('dao'), $dao,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       $hookName
     );
@@ -1382,7 +1382,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function summaryActions(&$actions, $contactID = NULL) {
-    return self::singleton()->invoke(2, $actions, $contactID,
+    return self::singleton()->invoke(array('actions', 'contactID'), $actions, $contactID,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_summaryActions'
     );
@@ -1410,7 +1410,7 @@ abstract class CRM_Utils_Hook {
    *   modify the header and values object to pass the data you need
    */
   public static function searchColumns($objectName, &$headers, &$rows, &$selector) {
-    return self::singleton()->invoke(4, $objectName, $headers, $rows, $selector,
+    return self::singleton()->invoke(array('objectName', 'headers', 'rows', 'selector'), $objectName, $headers, $rows, $selector,
       self::$_nullObject, self::$_nullObject,
       'civicrm_searchColumns'
     );
@@ -1427,7 +1427,7 @@ abstract class CRM_Utils_Hook {
    * @return null
    */
   public static function buildUFGroupsForModule($moduleName, &$ufGroups) {
-    return self::singleton()->invoke(2, $moduleName, $ufGroups,
+    return self::singleton()->invoke(array('moduleName', 'ufGroups'), $moduleName, $ufGroups,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_buildUFGroupsForModule'
     );
@@ -1452,7 +1452,7 @@ abstract class CRM_Utils_Hook {
    * @return null
    */
   public static function emailProcessorContact($email, $contactID, &$result) {
-    return self::singleton()->invoke(3, $email, $contactID, $result,
+    return self::singleton()->invoke(array('email', 'contactID', 'result'), $email, $contactID, $result,
       self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_emailProcessorContact'
     );
@@ -1492,7 +1492,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function alterMailingLabelParams(&$args) {
-    return self::singleton()->invoke(1, $args,
+    return self::singleton()->invoke(array('args'), $args,
       self::$_nullObject, self::$_nullObject,
       self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_alterMailingLabelParams'
@@ -1514,7 +1514,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function alterContent(&$content, $context, $tplName, &$object) {
-    return self::singleton()->invoke(4, $content, $context, $tplName, $object,
+    return self::singleton()->invoke(array('content', 'context', 'tplName', 'object'), $content, $context, $tplName, $object,
       self::$_nullObject, self::$_nullObject,
       'civicrm_alterContent'
     );
@@ -1536,7 +1536,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function alterTemplateFile($formName, &$form, $context, &$tplName) {
-    return self::singleton()->invoke(4, $formName, $form, $context, $tplName,
+    return self::singleton()->invoke(array('formName', 'form', 'context', 'tplName'), $formName, $form, $context, $tplName,
       self::$_nullObject, self::$_nullObject,
       'civicrm_alterTemplateFile'
     );
@@ -1561,7 +1561,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function triggerInfo(&$info, $tableName = NULL) {
-    return self::singleton()->invoke(2, $info, $tableName,
+    return self::singleton()->invoke(array('info', 'tableName'), $info, $tableName,
       self::$_nullObject, self::$_nullObject, self::$_nullObject,
       self::$_nullObject,
       'civicrm_triggerInfo'
@@ -1575,7 +1575,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function alterLogTables(&$logTableSpec) {
-    return self::singleton()->invoke(1, $logTableSpec, $_nullObject,
+    return self::singleton()->invoke(array('logTableSpec'), $logTableSpec, $_nullObject,
       self::$_nullObject, self::$_nullObject, self::$_nullObject,
       self::$_nullObject,
       'civicrm_alterLogTables'

--- a/CRM/Utils/Hook/DrupalBase.php
+++ b/CRM/Utils/Hook/DrupalBase.php
@@ -73,7 +73,7 @@ class CRM_Utils_Hook_DrupalBase extends CRM_Utils_Hook {
    *
    * @return array|bool
    */
-  public function invoke(
+  public function invokeViaUF(
     $numParams,
     &$arg1, &$arg2, &$arg3, &$arg4, &$arg5, &$arg6,
     $fnSuffix) {

--- a/CRM/Utils/Hook/Joomla.php
+++ b/CRM/Utils/Hook/Joomla.php
@@ -65,7 +65,7 @@ class CRM_Utils_Hook_Joomla extends CRM_Utils_Hook {
    *
    * @return mixed
    */
-  public function invoke(
+  public function invokeViaUF(
     $numParams,
     &$arg1, &$arg2, &$arg3, &$arg4, &$arg5, &$arg6,
     $fnSuffix

--- a/CRM/Utils/Hook/Soap.php
+++ b/CRM/Utils/Hook/Soap.php
@@ -65,7 +65,7 @@ class CRM_Utils_Hook_Soap extends CRM_Utils_Hook {
    *
    * @return mixed
    */
-  public function invoke(
+  public function invokeViaUF(
     $numParams,
     &$arg1, &$arg2, &$arg3, &$arg4, &$arg5, &$arg6,
     $fnSuffix

--- a/CRM/Utils/Hook/UnitTests.php
+++ b/CRM/Utils/Hook/UnitTests.php
@@ -99,20 +99,34 @@ class CRM_Utils_Hook_UnitTests extends CRM_Utils_Hook {
     &$arg1, &$arg2, &$arg3, &$arg4, &$arg5, &$arg6,
     $fnSuffix) {
     $params = array(&$arg1, &$arg2, &$arg3, &$arg4, &$arg5, &$arg6);
+
+    $fResult1 = $fResult2 = $fResult3 = NULL;
+
     // run standard hooks
     if ($this->civiModules === NULL) {
       $this->civiModules = array();
       $this->requireCiviModules($this->civiModules);
     }
-    $this->runHooks($this->civiModules, $fnSuffix, $numParams, $arg1, $arg2, $arg3, $arg4, $arg5, $arg6);
+    $fResult1 = $this->runHooks($this->civiModules, $fnSuffix, $numParams, $arg1, $arg2, $arg3, $arg4, $arg5, $arg6);
+
     // run mock object hooks
     if ($this->mockObject && is_callable(array($this->mockObject, $fnSuffix))) {
-      call_user_func(array($this->mockObject, $fnSuffix), $arg1, $arg2, $arg3, $arg4, $arg5, $arg6);
+      $fResult2 = call_user_func(array($this->mockObject, $fnSuffix), $arg1, $arg2, $arg3, $arg4, $arg5, $arg6);
     }
+
     // run adhoc hooks
     if (!empty($this->adhocHooks[$fnSuffix])) {
-      call_user_func_array($this->adhocHooks[$fnSuffix], $params);
+      $fResult3 = call_user_func_array($this->adhocHooks[$fnSuffix], $params);
     }
+
+    $result = array();
+    foreach (array($fResult1, $fResult2, $fResult3) as $fResult) {
+      if (!empty($fResult) && is_array($fResult)) {
+        $result = array_merge($result, $fResult);
+      }
+    }
+
+    return empty($result) ? TRUE : $result;
   }
 
 }

--- a/CRM/Utils/Hook/UnitTests.php
+++ b/CRM/Utils/Hook/UnitTests.php
@@ -94,7 +94,7 @@ class CRM_Utils_Hook_UnitTests extends CRM_Utils_Hook {
    *
    * @return mixed
    */
-  public function invoke(
+  public function invokeViaUF(
     $numParams,
     &$arg1, &$arg2, &$arg3, &$arg4, &$arg5, &$arg6,
     $fnSuffix) {

--- a/CRM/Utils/Hook/WordPress.php
+++ b/CRM/Utils/Hook/WordPress.php
@@ -83,7 +83,7 @@ class CRM_Utils_Hook_WordPress extends CRM_Utils_Hook {
    *
    * @return mixed
    */
-  public function invoke(
+  public function invokeViaUF(
     $numParams,
     &$arg1, &$arg2, &$arg3, &$arg4, &$arg5, &$arg6,
     $fnSuffix

--- a/Civi.php
+++ b/Civi.php
@@ -55,6 +55,15 @@ class Civi {
   }
 
   /**
+   * Get the event dispatcher.
+   *
+   * @return \Symfony\Component\EventDispatcher\EventDispatcherInterface
+   */
+  public static function dispatcher() {
+    return Civi\Core\Container::singleton()->get('dispatcher');
+  }
+
+  /**
    * @return \Civi\Core\Lock\LockManager
    */
   public static function lockManager() {

--- a/Civi/CCase/Event/CaseChangeEvent.php
+++ b/Civi/CCase/Event/CaseChangeEvent.php
@@ -26,12 +26,13 @@
  */
 
 namespace Civi\CCase\Event;
+use Civi\Core\Event\GenericHookEvent;
 
 /**
  * Class CaseChangeEvent
  * @package Civi\API\Event
  */
-class CaseChangeEvent extends \Symfony\Component\EventDispatcher\Event {
+class CaseChangeEvent extends GenericHookEvent {
   /**
    * @var \Civi\CCase\Analyzer
    */
@@ -42,6 +43,13 @@ class CaseChangeEvent extends \Symfony\Component\EventDispatcher\Event {
    */
   public function __construct($analyzer) {
     $this->analyzer = $analyzer;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getHookValues() {
+    return array($this->analyzer);
   }
 
 }

--- a/Civi/Core/CiviEventDispatcher.php
+++ b/Civi/Core/CiviEventDispatcher.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Civi\Core;
+
+use Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Class CiviEventDispatcher
+ * @package Civi\Core
+ *
+ * The CiviEventDispatcher is a Symfony dispatcher. Additionally, if an event
+ * follows the naming convention of "hook_*", then it will also be dispatched
+ * through CRM_Utils_Hook::invoke().
+ *
+ * @see \CRM_Utils_Hook
+ */
+class CiviEventDispatcher extends ContainerAwareEventDispatcher {
+
+  const DEFAULT_HOOK_PRIORITY = -100;
+
+  /**
+   * Track the list of hook-events for which we have autoregistered
+   * the hook adapter.
+   *
+   * @var array
+   *   Array(string $eventName => trueish).
+   */
+  private $autoListeners = array();
+
+  /**
+   * Determine whether $eventName should delegate to the CMS hook system.
+   *
+   * @param string $eventName
+   *   Ex: 'civi.token.eval', 'hook_civicrm_post`.
+   * @return bool
+   */
+  protected function isHookEvent($eventName) {
+    return (substr($eventName, 0, 5) === 'hook_') && (strpos($eventName, '::') === FALSE);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function dispatch($eventName, Event $event = NULL) {
+    $this->bindPatterns($eventName);
+    return parent::dispatch($eventName, $event);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getListeners($eventName = NULL) {
+    $this->bindPatterns($eventName);
+    return parent::getListeners($eventName);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function hasListeners($eventName = NULL) {
+    // All hook_* events have default listeners, so hasListeners(NULL) is a truism.
+    return ($eventName === NULL || $this->isHookEvent($eventName))
+      ? TRUE : parent::hasListeners($eventName);
+  }
+
+  /**
+   * Invoke hooks using an event object.
+   *
+   * @param \Civi\Core\Event\GenericHookEvent $event
+   * @param string $eventName
+   *   Ex: 'hook_civicrm_dashboard'.
+   */
+  public static function delegateToUF($event, $eventName) {
+    $hookName = substr($eventName, 5);
+    $hooks = \CRM_Utils_Hook::singleton();
+    $params = $event->getHookValues();
+    $count = count($params);
+
+    switch ($count) {
+      case 0:
+        $fResult = $hooks->invokeViaUF($count, \CRM_Utils_Hook::$_nullObject, \CRM_Utils_Hook::$_nullObject, \CRM_Utils_Hook::$_nullObject, \CRM_Utils_Hook::$_nullObject, \CRM_Utils_Hook::$_nullObject, \CRM_Utils_Hook::$_nullObject, $hookName);
+        break;
+
+      case 1:
+        $fResult = $hooks->invokeViaUF($count, $params[0], \CRM_Utils_Hook::$_nullObject, \CRM_Utils_Hook::$_nullObject, \CRM_Utils_Hook::$_nullObject, \CRM_Utils_Hook::$_nullObject, \CRM_Utils_Hook::$_nullObject, $hookName);
+        break;
+
+      case 2:
+        $fResult = $hooks->invokeViaUF($count, $params[0], $params[1], \CRM_Utils_Hook::$_nullObject, \CRM_Utils_Hook::$_nullObject, \CRM_Utils_Hook::$_nullObject, \CRM_Utils_Hook::$_nullObject, $hookName);
+        break;
+
+      case 3:
+        $fResult = $hooks->invokeViaUF($count, $params[0], $params[1], $params[2], \CRM_Utils_Hook::$_nullObject, \CRM_Utils_Hook::$_nullObject, \CRM_Utils_Hook::$_nullObject, $hookName);
+        break;
+
+      case 4:
+        $fResult = $hooks->invokeViaUF($count, $params[0], $params[1], $params[2], $params[3], \CRM_Utils_Hook::$_nullObject, \CRM_Utils_Hook::$_nullObject, $hookName);
+        break;
+
+      case 5:
+        $fResult = $hooks->invokeViaUF($count, $params[0], $params[1], $params[2], $params[3], $params[4], \CRM_Utils_Hook::$_nullObject, $hookName);
+        break;
+
+      case 6:
+        $fResult = $hooks->invokeViaUF($count, $params[0], $params[1], $params[2], $params[3], $params[4], $params[5], $hookName);
+        break;
+
+      default:
+        throw new \RuntimeException("hook_{$hookName} cannot support more than 6 parameters");
+    }
+
+    $event->addReturnValues($fResult);
+  }
+
+  /**
+   * @param string $eventName
+   *   Ex: 'civi.api.resolve' or 'hook_civicrm_dashboard'.
+   */
+  protected function bindPatterns($eventName) {
+    if ($eventName !== NULL && !isset($this->autoListeners[$eventName])) {
+      $this->autoListeners[$eventName] = 1;
+      if ($this->isHookEvent($eventName)) {
+        // WISHLIST: For native extensions (and possibly D6/D7/D8/BD), enumerate
+        // the listeners and list them one-by-one. This would make it easier to
+        // inspect via "cv debug:event-dispatcher".
+        $this->addListener($eventName, array(
+          '\Civi\Core\CiviEventDispatcher',
+          'delegateToUF',
+        ), self::DEFAULT_HOOK_PRIORITY);
+      }
+    }
+  }
+
+}

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -244,6 +244,8 @@ class Container {
     $dispatcher = new CiviEventDispatcher($container);
     $dispatcher->addListener(SystemInstallEvent::EVENT_NAME, array('\Civi\Core\InstallationCanary', 'check'));
     $dispatcher->addListener(SystemInstallEvent::EVENT_NAME, array('\Civi\Core\DatabaseInitializer', 'initialize'));
+    $dispatcher->addListener('hook_civicrm_pre', array('\Civi\Core\Event\PreEvent', 'dispatchSubevent'), 100);
+    $dispatcher->addListener('hook_civicrm_post', array('\Civi\Core\Event\PostEvent', 'dispatchSubevent'), 100);
     $dispatcher->addListener('hook_civicrm_post::Activity', array('\Civi\CCase\Events', 'fireCaseChange'));
     $dispatcher->addListener('hook_civicrm_post::Case', array('\Civi\CCase\Events', 'fireCaseChange'));
     $dispatcher->addListener('hook_civicrm_caseChange', array('\Civi\CCase\Events', 'delegateToXmlListeners'));
@@ -254,7 +256,7 @@ class Container {
     $dispatcher->addListener('hook_civicrm_unhandled_exception', array(
       'CRM_Core_LegacyErrorHandler',
       'handleException',
-    ));
+    ), -200);
     $dispatcher->addListener(\Civi\ActionSchedule\Events::MAPPINGS, array('CRM_Activity_ActionMapping', 'onRegisterActionMappings'));
     $dispatcher->addListener(\Civi\ActionSchedule\Events::MAPPINGS, array('CRM_Contact_ActionMapping', 'onRegisterActionMappings'));
     $dispatcher->addListener(\Civi\ActionSchedule\Events::MAPPINGS, array('CRM_Contribute_ActionMapping_ByPage', 'onRegisterActionMappings'));

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -106,6 +106,9 @@ class Container {
     $container->addObjectResource($this);
     $container->setParameter('civicrm_base_path', $civicrm_base_path);
     //$container->set(self::SELF, $this);
+
+    $container->addResource(new \Symfony\Component\Config\Resource\FileResource(__FILE__));
+
     $container->setDefinition(self::SELF, new Definition(
       'Civi\Core\Container',
       array()
@@ -134,7 +137,7 @@ class Container {
       ->setFactoryService(self::SELF)->setFactoryMethod('createAngularManager');
 
     $container->setDefinition('dispatcher', new Definition(
-      'Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher',
+      'Civi\Core\CiviEventDispatcher',
       array(new Reference('service_container'))
     ))
       ->setFactoryService(self::SELF)->setFactoryMethod('createEventDispatcher');
@@ -238,7 +241,7 @@ class Container {
    * @return \Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher
    */
   public function createEventDispatcher($container) {
-    $dispatcher = new ContainerAwareEventDispatcher($container);
+    $dispatcher = new CiviEventDispatcher($container);
     $dispatcher->addListener(SystemInstallEvent::EVENT_NAME, array('\Civi\Core\InstallationCanary', 'check'));
     $dispatcher->addListener(SystemInstallEvent::EVENT_NAME, array('\Civi\Core\DatabaseInitializer', 'initialize'));
     $dispatcher->addListener('hook_civicrm_post::Activity', array('\Civi\CCase\Events', 'fireCaseChange'));

--- a/Civi/Core/Event/GenericHookEvent.php
+++ b/Civi/Core/Event/GenericHookEvent.php
@@ -111,6 +111,22 @@ class GenericHookEvent extends \Symfony\Component\EventDispatcher\Event {
   private $returnValues = array();
 
   /**
+   * List of field names that are prohibited due to conflicts
+   * in the class-hierarchy.
+   *
+   * @var array
+   */
+  private static $BLACKLIST = array(
+    'name',
+    'dispatcher',
+    'propagationStopped',
+    'hookBlacklist',
+    'hookValues',
+    'hookFields',
+    'hookFieldsFlip',
+  );
+
+  /**
    * Create a GenericHookEvent using key-value pairs.
    *
    * @param array $params
@@ -122,6 +138,7 @@ class GenericHookEvent extends \Symfony\Component\EventDispatcher\Event {
     $e->hookValues = array_values($params);
     $e->hookFields = array_keys($params);
     $e->hookFieldsFlip = array_flip($e->hookFields);
+    self::assertValidHookFields($e->hookFields);
     return $e;
   }
 
@@ -142,7 +159,20 @@ class GenericHookEvent extends \Symfony\Component\EventDispatcher\Event {
     $e->hookValues = $hookValues;
     $e->hookFields = $hookFields;
     $e->hookFieldsFlip = array_flip($e->hookFields);
+    self::assertValidHookFields($e->hookFields);
     return $e;
+  }
+
+  /**
+   * @param array $fields
+   *   List of field names.
+   */
+  private static function assertValidHookFields($fields) {
+    $bad = array_intersect($fields, self::$BLACKLIST);
+    if ($bad) {
+      throw new \RuntimeException("Hook relies on conflicted field names: "
+        . implode(', ', $bad));
+    }
   }
 
   /**

--- a/Civi/Core/Event/GenericHookEvent.php
+++ b/Civi/Core/Event/GenericHookEvent.php
@@ -1,0 +1,205 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2017                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Core\Event;
+
+/**
+ * Class GenericHookEvent
+ * @package Civi\API\Event
+ *
+ * The GenericHookEvent is used to expose all traditional hooks to the
+ * Symfony EventDispatcher.
+ *
+ * The traditional notation for a hook is based on a function signature:
+ *
+ *   function hook_civicrm_foo($bar, &$whiz, &$bang);
+ *
+ * Symfony Events are based on a class with properties and methods. This
+ * requires some kind of mapping.
+ *
+ * Implementing new event classes for every hook would produce a large
+ * amount of boilerplate. Symfony Events have an interesting solution to
+ * that problem: use `GenericEvent` instead of custom event classes.
+ * This class (`GenericHookEvent`) is conceptually similar to `GenericEvent`,
+ * but it adds support for (a) altering fields and (b) mapping to hook
+ * notation.
+ *
+ * @code
+ * $event = GenericHookEvent::create(array(
+ *   'first' => $readOnlyData,
+ *   'second' => &readWriteData,
+ * ));
+ * Civi::service('dispatcher')->dispatch('hook_civicrm_foo', $event);
+ * print_r($event->getReturnValues());
+ * @endCode
+ */
+class GenericHookEvent extends \Symfony\Component\EventDispatcher\Event {
+
+  /**
+   * @var array
+   *   Ex: array('contactID' => &$contactID, 'contentPlacement' => &$contentPlacement).
+   */
+  protected $hookValues;
+
+  /**
+   * @var array
+   *   Ex: array(0 => 'contactID', 1 => 'contentPlacement').
+   */
+  protected $hookFields;
+
+  /**
+   * @var array
+   *   Ex: array('contactID' => 0, 'contentPlacement' => 1).
+   */
+  protected $hookFieldsFlip;
+
+  /**
+   * Some legacy hooks expect listener-functions to return a value.
+   * OOP listeners may set the $returnValue.
+   *
+   * This field is not recommended for use in new hooks. The return-value
+   * convention is not portable across different implementations of the hook
+   * system. Instead, it's more portable to provide an alterable, named field.
+   *
+   * @var mixed
+   * @deprecated
+   */
+  private $returnValues = array();
+
+  /**
+   * Create a GenericHookEvent using key-value pairs.
+   *
+   * @param array $params
+   *   Ex: array('contactID' => &$contactID, 'contentPlacement' => &$contentPlacement).
+   * @return \Civi\Core\Event\GenericHookEvent
+   */
+  public static function create($params) {
+    $e = new static();
+    $e->hookValues = array_values($params);
+    $e->hookFields = array_keys($params);
+    $e->hookFieldsFlip = array_flip($e->hookFields);
+    return $e;
+  }
+
+  /**
+   * Create a GenericHookEvent using ordered parameters.
+   *
+   * @param array $hookFields
+   *   Ex: array(0 => 'contactID', 1 => 'contentPlacement').
+   * @param array $hookValues
+   *   Ex: array(0 => &$contactID, 1 => &$contentPlacement).
+   * @return \Civi\Core\Event\GenericHookEvent
+   */
+  public static function createOrdered($hookFields, $hookValues) {
+    $e = new static();
+    if (count($hookValues) > count($hookFields)) {
+      $hookValues = array_slice($hookValues, 0, count($hookFields));
+    }
+    $e->hookValues = $hookValues;
+    $e->hookFields = $hookFields;
+    $e->hookFieldsFlip = array_flip($e->hookFields);
+    return $e;
+  }
+
+  /**
+   * @return array
+   *   Ex: array(0 => &$contactID, 1 => &$contentPlacement).
+   */
+  public function getHookValues() {
+    return $this->hookValues;
+  }
+
+  /**
+   * @return mixed
+   * @deprecated
+   */
+  public function getReturnValues() {
+    return empty($this->returnValues) ? TRUE : $this->returnValues;
+  }
+
+  /**
+   * @param mixed $fResult
+   * @return GenericHookEvent
+   * @deprecated
+   */
+  public function addReturnValues($fResult) {
+    if (!empty($fResult) && is_array($fResult)) {
+      $this->returnValues = array_merge($this->returnValues, $fResult);
+    }
+    return $this;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function &__get($name) {
+    if (isset($this->hookFieldsFlip[$name])) {
+      return $this->hookValues[$this->hookFieldsFlip[$name]];
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function __set($name, $value) {
+    if (isset($this->hookFieldsFlip[$name])) {
+      $this->hookValues[$this->hookFieldsFlip[$name]] = $value;
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function __isset($name) {
+    return isset($this->hookFieldsFlip[$name])
+      && isset($this->hookValues[$this->hookFieldsFlip[$name]]);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function __unset($name) {
+    if (isset($this->hookFieldsFlip[$name])) {
+      // Unset while preserving order.
+      $this->hookValues[$this->hookFieldsFlip[$name]] = NULL;
+    }
+  }
+
+  /**
+   * Determine whether the hook supports the given field.
+   *
+   * The field may or may not be empty. Use isset() or empty() to
+   * check that.
+   *
+   * @param string $name
+   * @return bool
+   */
+  public function hasField($name) {
+    return isset($this->hookFieldsFlip[$name]);
+  }
+
+}

--- a/Civi/Core/Event/PostEvent.php
+++ b/Civi/Core/Event/PostEvent.php
@@ -31,7 +31,18 @@ namespace Civi\Core\Event;
  * Class AuthorizeEvent
  * @package Civi\API\Event
  */
-class PostEvent extends \Symfony\Component\EventDispatcher\Event {
+class PostEvent extends GenericHookEvent {
+
+  /**
+   * This adapter automatically emits a narrower event.
+   *
+   * For example, `hook_civicrm_pre(Contact, ...)` will also dispatch `hook_civicrm_pre::Contact`.
+   *
+   * @param \Civi\Core\Event\PostEvent $event
+   */
+  public static function dispatchSubevent(PostEvent $event) {
+    \Civi::service('dispatcher')->dispatch("hook_civicrm_post::" . $event->entity, $event);
+  }
 
   /**
    * @var string 'create'|'edit'|'delete' etc
@@ -59,11 +70,18 @@ class PostEvent extends \Symfony\Component\EventDispatcher\Event {
    * @param $id
    * @param $object
    */
-  public function __construct($action, $entity, $id, $object) {
+  public function __construct($action, $entity, $id, &$object) {
     $this->action = $action;
     $this->entity = $entity;
     $this->id = $id;
-    $this->object = $object;
+    $this->object = &$object;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getHookValues() {
+    return array($this->action, $this->entity, $this->id, &$this->object);
   }
 
 }

--- a/Civi/Core/Event/PreEvent.php
+++ b/Civi/Core/Event/PreEvent.php
@@ -31,7 +31,18 @@ namespace Civi\Core\Event;
  * Class AuthorizeEvent
  * @package Civi\API\Event
  */
-class PreEvent extends \Symfony\Component\EventDispatcher\Event {
+class PreEvent extends GenericHookEvent {
+
+  /**
+   * This adapter automatically emits a narrower event.
+   *
+   * For example, `hook_civicrm_pre(Contact, ...)` will also dispatch `hook_civicrm_pre::Contact`.
+   *
+   * @param \Civi\Core\Event\PreEvent $event
+   */
+  public static function dispatchSubevent(PreEvent $event) {
+    \Civi::service('dispatcher')->dispatch("hook_civicrm_pre::" . $event->entity, $event);
+  }
 
   /**
    * @var string 'create'|'edit'|'delete' etc
@@ -59,11 +70,18 @@ class PreEvent extends \Symfony\Component\EventDispatcher\Event {
    * @param $id
    * @param $params
    */
-  public function __construct($action, $entity, $id, $params) {
+  public function __construct($action, $entity, $id, &$params) {
     $this->action = $action;
     $this->entity = $entity;
     $this->id = $id;
-    $this->params = $params;
+    $this->params = &$params;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getHookValues() {
+    return array($this->action, $this->entity, $this->id, &$this->params);
   }
 
 }

--- a/Civi/Core/Event/UnhandledExceptionEvent.php
+++ b/Civi/Core/Event/UnhandledExceptionEvent.php
@@ -28,10 +28,10 @@
 namespace Civi\Core\Event;
 
 /**
- * Class AuthorizeEvent
+ * Class UnhandledExceptionEvent
  * @package Civi\API\Event
  */
-class UnhandledExceptionEvent extends \Symfony\Component\EventDispatcher\Event {
+class UnhandledExceptionEvent extends GenericHookEvent {
 
   /**
    * @var \Exception
@@ -50,6 +50,13 @@ class UnhandledExceptionEvent extends \Symfony\Component\EventDispatcher\Event {
   public function __construct($e, $request) {
     $this->request = $request;
     $this->exception = $e;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getHookValues() {
+    return array($this->exception, $this->request);
   }
 
 }

--- a/tests/phpunit/Civi/Core/Event/GenericHookEventTest.php
+++ b/tests/phpunit/Civi/Core/Event/GenericHookEventTest.php
@@ -1,0 +1,108 @@
+<?php
+namespace Civi\Core\Event;
+
+class GenericHookEventTest extends \CiviUnitTestCase {
+
+  public function tearDown() {
+    \CRM_Utils_Hook::singleton()->reset();
+    parent::tearDown();
+  }
+
+  public function testConstructParams() {
+    $event = GenericHookEvent::create(array(
+      'ab' => 123,
+      'cd' => array('foo' => 'bar'),
+      'nothingNull' => NULL,
+      'nothingZero' => 0,
+    ));
+    $this->assertEquals(123, $event->ab);
+    $this->assertEquals('bar', $event->cd['foo']);
+    $this->assertTrue($event->hasField('ab'));
+    $this->assertTrue(isset($event->ab));
+    $this->assertFalse($event->hasField('abc'));
+    $this->assertFalse(isset($event->abc));
+    $this->assertTrue(!isset($event->nothingNull) && empty($event->nothingNull));
+    $this->assertTrue(isset($event->nothingZero) && empty($event->nothingZero));
+  }
+
+  public function testConstructOrdered() {
+    $event = GenericHookEvent::createOrdered(
+      array('alpha', 'beta', 'nothingNull', 'nothingZero'),
+      array(456, array('whiz' => 'bang'), NULL, 0, \CRM_Utils_Hook::$_nullObject)
+    );
+    $this->assertEquals(456, $event->alpha);
+    $this->assertEquals('bang', $event->beta['whiz']);
+    $this->assertTrue($event->hasField('alpha'));
+    $this->assertTrue(isset($event->alpha));
+    $this->assertFalse($event->hasField('ab'));
+    $this->assertFalse(isset($event->ab));
+    $this->assertTrue(!isset($event->nothingNull) && empty($event->nothingNull));
+    $this->assertTrue(isset($event->nothingZero) && empty($event->nothingZero));
+    $this->assertEquals(4, count($event->getHookValues()));
+  }
+
+  public function testDispatch() {
+    \CRM_Utils_Hook::singleton()->setHook('civicrm_ghet',
+      array($this, 'hook_civicrm_ghet'));
+    \Civi::service('dispatcher')->addListener('hook_civicrm_ghet',
+      array($this, 'onGhet'));
+
+    $roString = 'readonly';
+    $rwString = 'readwrite';
+    $roArray = array('readonly');
+    $rwArray = array('readwrite');
+    $plainObj = new \stdClass();
+    $refObj = new \stdClass();
+
+    $returnValue = $this->hookStub($roString, $rwString, $roArray, $rwArray, $plainObj, $refObj);
+
+    $this->assertEquals('readonly', $roString);
+    $this->assertEquals('readwrite added-string-via-event added-string-via-hook', $rwString);
+    $this->assertEquals(array('readonly'), $roArray);
+    $this->assertEquals(array('readwrite', 'added-to-array-via-event', 'added-to-array-via-hook'), $rwArray);
+    $this->assertEquals('added-to-object-via-hook', $plainObj->prop1);
+    $this->assertEquals('added-to-object-via-hook', $refObj->prop2);
+    $this->assertEquals(array('early-running-result', 'late-running-result'), $returnValue);
+  }
+
+  /**
+   * Fire a hook. This stub follows the same coding convention as
+   * CRM_Utils_Hook::*(). This ensures that the coding convention is valid.
+   *
+   * @param $roString
+   * @param $rwString
+   * @param $roArray
+   * @param $rwArray
+   * @param $plainObj
+   * @param $refObj
+   * @return mixed
+   */
+  public function hookStub($roString, &$rwString, $roArray, &$rwArray, $plainObj, &$refObj) {
+    return \CRM_Utils_Hook::singleton()->invoke(
+      array('roString', 'rwString', 'roArray', 'rwArray', 'plainObj', 'refObj'),
+      $roString, $rwString, $roArray, $rwArray, $plainObj, $refObj,
+      'civicrm_ghet'
+    );
+  }
+
+  public function hook_civicrm_ghet(&$roString, &$rwString, &$roArray, &$rwArray, $plainObj, &$refObj) {
+    $roString .= 'changes should not propagate back';
+    $rwString .= ' added-string-via-hook';
+    $roArray[] = 'changes should not propagate back';
+    $rwArray[] = 'added-to-array-via-hook';
+    $plainObj->prop1 = 'added-to-object-via-hook';
+    $refObj->prop2 = 'added-to-object-via-hook';
+    return array('late-running-result');
+  }
+
+  public function onGhet(GenericHookEvent $e) {
+    $e->roString .= 'changes should not propagate back';
+    $e->rwString .= ' added-string-via-event';
+    $e->roArray[] = 'changes should not propagate back';
+    $e->rwArray[] = 'added-to-array-via-event';
+    $e->plainObj->prop1 = 'added-to-object-via-event';
+    $e->refObj->prop2 = 'added-to-object-via-event';
+    $e->addReturnValues(array('early-running-result'));
+  }
+
+}


### PR DESCRIPTION
Civi has three notions of events:

 * __Hooks__: These are available to extensions (either native or CMS-based). They are usually described by a function signature. Hooks are the most recognizable/supported events, but they also have limitations (hard to inspect, prioritize, cancel, etc) because they must meet the lowest-common-denominator of CMS features.
 * __Symfony Events__: These are generally only used within core. They have more advanced features but haven't been presented for downstream usage. There's [documentation](http://symfony.com/doc/current/components/event_dispatcher.html) available from Symfony.
 * __Component-actions__: These are adhoc functions which loop through core's list of "components". These are generally not well-understood.

This PR aims to unify two of them -- hooks and Symfony Events. More specifically:

 * Symfony Event Dispatcher become the **canonical event system**. All events are Symfony events. You can register event subscribers in core (or elsewhere).
 * Hooks are a **special case** in which (a) the event name looks like `hook_civicrm_foo` and (b) the event object extends `GenericHookEvent`. In this special case, the event will be simultaneously emitted through various CMS event systems (Drupal Hooks, WP Actions, etc).

If you were previously unaware that Symfony Events existed in core, then it seem like "yet another way". It is actually a unification of two existing ways. To understand how this unification positions us, consider an analogy to APIv3 CRUD:

 * For APIv3 CRUD, the public API has one set of *semantics* and multiple *syntaxes*. The semantics are based on entities+actions+params. The *syntax* for calling APIv3 varies depending on the technique/context (e.g. PHP logic vs PHP test vs JS vs REST vs CLI). There is a canonical mechanism which supports all features (`civicrm_api(...)`) and can be used in most PHP contexts, but some variants (like Smarty or CLI) can't easily support all features.
 * For hooks/events, the public API has one set of *semantics* and multiple *syntaxes*. The semantics are based on hook-name+params. The *syntax* for listening to an event varies depending on the technique/context (e.g. core code vs Civi extension vs Drupal module vs WordPress plugin vs Joomla plugin). There is a canonical mechanism which supports all features (`Civi::service('dispatcher')`) and can be used in most PHP contexts, but some variants (like Drupal/Joomla/WordPress modules) can't easily support all features.

Additional notes:

 * This means that core code can listen to hooks (the same way it already listens to events).
 * Hooks are the *most visible*/*most accessible* type of events.  However, it's possible for any extension to work with the full features of the event-dispatcher.
 * Use `cv debug:event-dispatcher` to inspect the list of event listeners. 
 * Some discussion of the design of `GenericHookEvent` is included in the relevant commit ("GenericHookEvent - Bridge between Symfony Events and hooks").
 * This is a WIP. There's another hook that I'm working on (for management of dynamic-assets) that is part of the impetus.
 * This is a WIP. To get full support for all hooks in Symfony Events, we need small patches to each stub in `CRM_Utils_Hook`. I've adapted ~1/3 so far.

---

 * [CRM-19813: Hook priorities and core hooks to support LExIM](https://issues.civicrm.org/jira/browse/CRM-19813)