### PR TITLE
CRM-20238 - Create hook for inbound SMS

### DIFF
--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2247,4 +2247,27 @@ abstract class CRM_Utils_Hook {
     );
   }
 
+  /**
+   * This hook is called before an inbound SMS is processed.
+   *
+   * @param string $from
+   *   The phone number the message is from, as set by SMS provider
+   * @param int $fromContactID
+   *   Set to override default matching
+   * @param string $to
+   *   The optional phone number the message is to, as set by SMS provider
+   * @param int $toContactID
+   *   Set to override default matching
+   * @param string $body
+   *   The body text of the message
+   * @param string $trackID
+   *   The tracking ID of the message
+   *
+   * @return mixed
+   */
+  public static function inboundSMS(&$from, &$fromContactID = NULL, &$to, &$toContactID = NULL, &$body, &$trackID) {
+    return self::singleton()
+      ->invoke(6, $from, $fromContactID, $to, $toContactID, $body, $trackID, 'civicrm_inboundSMS');
+  }
+
 }


### PR DESCRIPTION
This patch creates hook_civicrm_inboundSMS and tweaks CRM_SMS_Provider to call the hook, and allow the hook to set the fromContactID and toContactID.

Documentation PR: https://github.com/civicrm/civicrm-dev-docs/pull/113

---

 * [CRM-20238: Hook for inbound SMS messages](https://issues.civicrm.org/jira/browse/CRM-20238)