### PR TITLE
CRM-20239 Extra tests for the Individual::format function

### DIFF
--- a/tests/phpunit/CRM/Contact/BAO/IndividualTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/IndividualTest.php
@@ -25,4 +25,91 @@ class CRM_Contact_BAO_IndividualTest extends CiviUnitTestCase {
     $this->assertEmpty($contact->deceased_date);
   }
 
+  /**
+   *  Test case to check the formatting of the Display name and Sort name
+   *  Standard formatting is assumed.
+   */
+  public function testFormatDisplayName() {
+
+    $params = array(
+      'contact_type' => 'Individual',
+      'first_name' => 'Ben',
+      'last_name' => 'Lee',
+      'individual_prefix' => 'Mr.',
+      'individual_suffix' => 'Jr.',
+    );
+
+    $contact = new CRM_Contact_DAO_Contact();
+
+    CRM_Contact_BAO_Individual::format($params, $contact);
+
+    $this->assertEquals("Mr. Ben Lee Jr.", $contact->display_name);
+    $this->assertEquals("Lee, Ben", $contact->sort_name);
+  }
+
+  /**
+   *  Testing the use of adding prefix and suffix by id.
+   *  Standard Prefixes and Suffixes are assumed part of
+   *  the test database
+   */
+  public function testFormatDisplayNamePrefixesById() {
+
+    $params = array(
+      'contact_type' => 'Individual',
+      'first_name' => 'Ben',
+      'last_name' => 'Lee',
+      'prefix_id' => 4, // this is the doctor
+      'suffix_id' => 2, // and the doctor is a senior
+    );
+
+    $contact = new CRM_Contact_DAO_Contact();
+
+    CRM_Contact_BAO_Individual::format($params, $contact);
+
+    $this->assertEquals("Dr. Ben Lee Sr.", $contact->display_name);
+  }
+
+  /**
+   *  Testing the use of adding prefix and suffix by id.
+   *  Standard Prefixes and Suffixes are assumed part of
+   *  the test database
+   */
+  public function testFormatDisplayNameNoIndividual() {
+
+    $params = array(
+      'contact_type' => 'Organization',
+      'first_name' => 'Ben',
+      'last_name' => 'Lee',
+    );
+
+    $contact = new CRM_Contact_DAO_Contact();
+
+    CRM_Contact_BAO_Individual::format($params, $contact);
+
+    $this->assertNotEquals("Ben Lee", $contact->display_name);
+  }
+
+  /**
+   *  When no first name or last name are defined, the primary email is used
+   */
+  public function testFormatDisplayNameOnlyEmail() {
+
+    $email['1'] = array('email' => "bleu01@example.com");
+    $email['2'] = array('email' => "bleu02@example.com", 'is_primary' => 1);
+    $email['3'] = array('email' => "bleu03@example.com");
+
+    $params = array(
+      'contact_type' => 'Individual',
+      'email' => $email ,
+    );
+
+    $contact = new CRM_Contact_DAO_Contact();
+
+    CRM_Contact_BAO_Individual::format($params, $contact);
+
+    $this->assertEquals("bleu02@example.com", $contact->display_name);
+    $this->assertEquals("bleu02@example.com", $contact->sort_name);
+
+  }
+
 }


### PR DESCRIPTION
The CRM_Contact_BAO_Individual::format does a lot of work in formatting sort name and display name. It did not have much test coverage. So this patch adds a number of tests

---

 * [CRM-20239: Extra tests for the CRM_Contact_BAO_Individual::format function](https://issues.civicrm.org/jira/browse/CRM-20239)