### PR TITLE
CRM-20032 Define permission requirements for payment_processor_get

### DIFF
--- a/CRM/Core/DAO/permissions.php
+++ b/CRM/Core/DAO/permissions.php
@@ -488,6 +488,13 @@ function _civicrm_api3_permissions($entity, $action, &$params) {
     ),
   );
 
+  $permissions['payment_processor'] = array(
+    'get' => array(
+      'access CiviEvent',
+      'edit all events',
+    )
+  );
+
   // Pledge permissions
   $permissions['pledge'] = array(
     'create' => array(


### PR DESCRIPTION
* [CRM-20032: event config: payment processor selection requires administer CiviCRM permission](https://issues.civicrm.org/jira/browse/CRM-20032)