### PR TITLE
Remove CRM_Core_Form::generateID().

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -272,12 +272,6 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
   }
 
   /**
-   * Generate ID for some reason & purpose that is unknown & undocumented.
-   */
-  public static function generateID() {
-  }
-
-  /**
    * Add one or more css classes to the form.
    *
    * @param string $className


### PR DESCRIPTION
* This function is documented as not documented.
* This function is not used.
* This function does nothing.

CRM-20249

---

 * [CRM-20249: Remove CRM_Core_Form::generateID\(\)](https://issues.civicrm.org/jira/browse/CRM-20249)