### PR TITLE
Civi\API\ExternalBatch - Improve test for variables_order/$_ENV

### DIFF
--- a/Civi/API/ExternalBatch.php
+++ b/Civi/API/ExternalBatch.php
@@ -52,7 +52,7 @@ class ExternalBatch {
     $this->settingsPath = defined('CIVICRM_SETTINGS_PATH') ? CIVICRM_SETTINGS_PATH : NULL;
     $this->defaultParams = $defaultParams;
     $this->env = $_ENV;
-    if (empty($_ENV)) {
+    if (empty($_ENV['PATH'])) {
       // FIXME: If we upgrade to newer Symfony\Process and use the newer
       // inheritEnv feature, then this becomes unnecessary.
       throw new \CRM_Core_Exception('ExternalBatch cannot detect environment: $_ENV is missing. (Tip: Set variables_order=EGPCS in php.ini.)');


### PR DESCRIPTION
The recent revision #9595 updated `ExternalBatch` to produce a more
informative error message.  However, in the test environment used by
`flexmailer`, there was exactly 1 value in `$_ENV` (even if
`variables_order` was misconfigured).

This should make the test a bit harder to trip-up by affirmatively checking
for the most common environment variable.

Review note: In the known universe, the only direct references to
`ExternalBatch` are in `CiviUnitTestCase`, so this shouldn't impact any
runtime logic.