### PR TITLE
CRM-20035 retain preferred comm method values on billing address update

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1136,6 +1136,12 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       $this->assign('displayName', $this->userDisplayName);
     }
 
+    //CRM-20035 get preferred communication methods so existing values retained
+    $this->_params['preferred_communication_method'] =
+      CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $contactID,
+        'preferred_communication_method'
+      );
+
     $this->_contributorEmail = $this->userEmail;
     $this->_contributorContactID = $contactID;
     $this->processBillingAddress();

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1137,8 +1137,8 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     }
 
     //CRM-20035 get preferred communication methods so existing values retained
-    $this->_params['preferred_communication_method'] =
-      CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $contactID,
+    $this->_params['preferred_communication_method']
+      = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $contactID,
         'preferred_communication_method'
       );
 

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -517,6 +517,25 @@ class api_v3_ContactTest extends CiviUnitTestCase {
   }
 
   /**
+   * CRM-20035 test that communication method is not unset when not passed in.
+   */
+  public function testCreatePreferredCommunicationNotUnset() {
+    $contact = $this->callAPISuccess('Contact', 'create', array(
+        'first_name' => 'Snoop',
+        'last_name' => 'Dog',
+        'contact_type' => 'Individual',
+        'preferred_communication_method' => array('Phone', 'Fax')
+      )
+    );
+    $result = $this->callAPISuccessGetSingle('Contact', array('id' => $contact['id'], 'return' => 'preferred_communication_method'));
+    $this->assertEquals(array('Phone', 'Fax'), $result['preferred_communication_method']);
+
+    $this->callAPISuccess('Contact', 'create', array('id' => $contact['id'], 'first_name' => 'Hot Diggity'));
+    $result = $this->callAPISuccessGetSingle('Contact', array('id' => $contact['id'], 'return' => 'preferred_communication_method'));
+    $this->assertEquals(array('Phone', 'Fax'), $result['preferred_communication_method']);
+  }
+
+  /**
    * CRM-14232 test preferred language returns setting if not passed where setting is NULL.
    */
   public function testCreatePreferredLanguageNull() {


### PR DESCRIPTION
* [CRM-20035: credit card backend contribution alters communication preferences](https://issues.civicrm.org/jira/browse/CRM-20035)