### PR TITLE
CRM-20189 "hold_date" not updated at multiple bulk email address

### DIFF
--- a/CRM/Core/BAO/Email.php
+++ b/CRM/Core/BAO/Email.php
@@ -252,7 +252,7 @@ AND    hold_date IS NULL
           $email->reset_date = 'null';
         }
       }
-      elseif ($email->on_hold == 'null') {
+      elseif ($email->on_hold == 'null' || empty($email->on_hold) {
         $sql = "
 SELECT id
 FROM   civicrm_email

--- a/CRM/Core/BAO/Email.php
+++ b/CRM/Core/BAO/Email.php
@@ -252,7 +252,7 @@ AND    hold_date IS NULL
           $email->reset_date = 'null';
         }
       }
-      elseif ($email->on_hold == 'null' || empty($email->on_hold) {
+      elseif ($email->on_hold == 'null' || empty($email->on_hold)) {
         $sql = "
 SELECT id
 FROM   civicrm_email


### PR DESCRIPTION
fixed: CRM-20189 "hold_date" not updated at multiple bulk email address

---

 * [CRM-20189: Select "Enable multiple bulk email address for a contact", "hold_date" can not be updated](https://issues.civicrm.org/jira/browse/CRM-20189)