### PR TITLE
CRM-20254: add cache buster string for custom CSS

### DIFF
--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -816,13 +816,14 @@ class CRM_Core_Resources {
    */
   public function addCacheCode($url) {
     parse_str(parse_url($url, PHP_URL_QUERY), $queryParts);
-    $existing = isset($queryParts['r']) ? $queryParts['r'] : null;
+    $existing = isset($queryParts['r']) ? $queryParts['r'] : NULL;
     $latest = $this->cacheCode;
 
     if ($existing) {
       if ($existing === $latest) {
         return $url; // no need to update
-      } else {
+      }
+      else {
         return str_replace('r=' . $existing, 'r=' . $latest, $url);
       }
     }
@@ -831,4 +832,5 @@ class CRM_Core_Resources {
 
     return $url . $operator . 'r=' . $latest;
   }
+
 }

--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -501,7 +501,7 @@ class CRM_Core_Resources {
       $file = '';
     }
     if ($addCacheCode) {
-      $file .= '?r=' . $this->getCacheCode();
+      $file = $this->addCacheCode($file);
     }
     // TODO consider caching results
     return $this->extMapper->keyToUrl($ext) . '/' . $file;
@@ -637,7 +637,8 @@ class CRM_Core_Resources {
       // Load custom or core css
       $config = CRM_Core_Config::singleton();
       if (!empty($config->customCSSURL)) {
-        $this->addStyleUrl($config->customCSSURL, 99, $region);
+        $customCSSURL = $this->addCacheCode($config->customCSSURL);
+        $this->addStyleUrl($customCSSURL, 99, $region);
       }
       if (!CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME, 'disable_core_css')) {
         $this->addStyleFile('civicrm', 'css/civicrm.css', -99, $region);
@@ -809,4 +810,25 @@ class CRM_Core_Resources {
     return $filters;
   }
 
+  /**
+   * @param string $url
+   * @return string
+   */
+  public function addCacheCode($url) {
+    parse_str(parse_url($url, PHP_URL_QUERY), $queryParts);
+    $existing = isset($queryParts['r']) ? $queryParts['r'] : null;
+    $latest = $this->cacheCode;
+
+    if ($existing) {
+      if ($existing === $latest) {
+        return $url; // no need to update
+      } else {
+        return str_replace('r=' . $existing, 'r=' . $latest, $url);
+      }
+    }
+
+    $operator = empty($queryParts) ? '?' : '&';
+
+    return $url . $operator . 'r=' . $latest;
+  }
 }

--- a/tests/phpunit/CRM/Core/ResourcesTest.php
+++ b/tests/phpunit/CRM/Core/ResourcesTest.php
@@ -42,6 +42,11 @@ class CRM_Core_ResourcesTest extends CiviUnitTestCase {
    */
   protected $mapper;
 
+  /**
+   * @var string for testing cache buster generation
+   */
+  protected $cacheBusterString = 'xBkdk3';
+
   public function setUp() {
     parent::setUp();
 
@@ -318,4 +323,38 @@ class CRM_Core_ResourcesTest extends CiviUnitTestCase {
     return array($basedir, $c, $mapper);
   }
 
+  /**
+   * @param string $url
+   * @param string $expected
+   *
+   * @dataProvider urlForCacheCodeProvider
+   */
+  public function testAddingCacheCode($url, $expected) {
+    $resources = CRM_Core_Resources::singleton();
+    $this->assertEquals($expected, $resources->addCacheCode($url));
+  }
+
+  /**
+   * @return array
+   */
+  public function urlForCacheCodeProvider() {
+    return array(
+      array(
+        'http://www.civicrm.org',
+        'http://www.civicrm.org?r=' . $this->cacheBusterString,
+      ),
+      array(
+        'www.civicrm.org/custom.css?foo=bar',
+        'www.civicrm.org/custom.css?foo=bar&r=' . $this->cacheBusterString,
+      ),
+      array(
+        'civicrm.org/custom.css?r=old&foo=bar',
+        'civicrm.org/custom.css?r=' . $this->cacheBusterString . '&foo=bar',
+      ),
+      array(
+        'civicrm.org/custom.css?car=blue&foo=bar',
+        'civicrm.org/custom.css?car=blue&foo=bar&r=' . $this->cacheBusterString,
+      ),
+    );
+  }
 }

--- a/tests/phpunit/CRM/Core/ResourcesTest.php
+++ b/tests/phpunit/CRM/Core/ResourcesTest.php
@@ -357,4 +357,5 @@ class CRM_Core_ResourcesTest extends CiviUnitTestCase {
       ),
     );
   }
+
 }


### PR DESCRIPTION
As mentioned in [Jira](https://issues.civicrm.org/jira/browse/CRM-20254) this adds the cache buster string for custom CSS files. 
It also improves on the appending of the cache buster string to URLs by detecting for an existing query string or an existing cache buster string.