### PR TITLE
CRM-20254: add cache buster string for custom CSS

### DIFF
--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -887,22 +887,9 @@ class CRM_Core_Resources {
    * @return string
    */
   public function addCacheCode($url) {
-    parse_str(parse_url($url, PHP_URL_QUERY), $queryParts);
-    $existing = isset($queryParts['r']) ? $queryParts['r'] : NULL;
-    $latest = $this->cacheCode;
+    $hasQuery = strpos($url, '?') !== false;
+    $operator = $hasQuery ? '&' : '?';
 
-    if ($existing) {
-      if ($existing === $latest) {
-        return $url; // no need to update
-      }
-      else {
-        return str_replace('r=' . $existing, 'r=' . $latest, $url);
-      }
-    }
-
-    $operator = empty($queryParts) ? '?' : '&';
-
-    return $url . $operator . 'r=' . $latest;
+    return $url . $operator . 'r=' . $this->cacheCode;
   }
-
 }

--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -887,9 +887,10 @@ class CRM_Core_Resources {
    * @return string
    */
   public function addCacheCode($url) {
-    $hasQuery = strpos($url, '?') !== false;
+    $hasQuery = strpos($url, '?') !== FALSE;
     $operator = $hasQuery ? '&' : '?';
 
     return $url . $operator . 'r=' . $this->cacheCode;
   }
+
 }

--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -500,7 +500,7 @@ class CRM_Core_Resources {
       $file = '';
     }
     if ($addCacheCode) {
-      $file .= '?r=' . $this->getCacheCode();
+      $file = $this->addCacheCode($file);
     }
     // TODO consider caching results
     $base = $this->paths->hasVariable($ext)
@@ -643,7 +643,8 @@ class CRM_Core_Resources {
       // Load custom or core css
       $config = CRM_Core_Config::singleton();
       if (!empty($config->customCSSURL)) {
-        $this->addStyleUrl($config->customCSSURL, 99, $region);
+        $customCSSURL = $this->addCacheCode($config->customCSSURL);
+        $this->addStyleUrl($customCSSURL, 99, $region);
       }
       if (!Civi::settings()->get('disable_core_css')) {
         $this->addStyleFile('civicrm', 'css/civicrm.css', -99, $region);
@@ -879,6 +880,29 @@ class CRM_Core_Resources {
         $fileName = $nonMiniFile;
       }
     }
+  }
+
+  /**
+   * @param string $url
+   * @return string
+   */
+  public function addCacheCode($url) {
+    parse_str(parse_url($url, PHP_URL_QUERY), $queryParts);
+    $existing = isset($queryParts['r']) ? $queryParts['r'] : NULL;
+    $latest = $this->cacheCode;
+
+    if ($existing) {
+      if ($existing === $latest) {
+        return $url; // no need to update
+      }
+      else {
+        return str_replace('r=' . $existing, 'r=' . $latest, $url);
+      }
+    }
+
+    $operator = empty($queryParts) ? '?' : '&';
+
+    return $url . $operator . 'r=' . $latest;
   }
 
 }

--- a/tests/phpunit/CRM/Core/ResourcesTest.php
+++ b/tests/phpunit/CRM/Core/ResourcesTest.php
@@ -379,10 +379,6 @@ class CRM_Core_ResourcesTest extends CiviUnitTestCase {
         'www.civicrm.org/custom.css?foo=bar&r=' . $this->cacheBusterString,
       ),
       array(
-        'civicrm.org/custom.css?r=old&foo=bar',
-        'civicrm.org/custom.css?r=' . $this->cacheBusterString . '&foo=bar',
-      ),
-      array(
         'civicrm.org/custom.css?car=blue&foo=bar',
         'civicrm.org/custom.css?car=blue&foo=bar&r=' . $this->cacheBusterString,
       ),

--- a/tests/phpunit/CRM/Core/ResourcesTest.php
+++ b/tests/phpunit/CRM/Core/ResourcesTest.php
@@ -361,6 +361,7 @@ class CRM_Core_ResourcesTest extends CiviUnitTestCase {
    */
   public function testAddingCacheCode($url, $expected) {
     $resources = CRM_Core_Resources::singleton();
+    $resources->setCacheCode($this->cacheBusterString);
     $this->assertEquals($expected, $resources->addCacheCode($url));
   }
 

--- a/tests/phpunit/CRM/Core/ResourcesTest.php
+++ b/tests/phpunit/CRM/Core/ResourcesTest.php
@@ -41,6 +41,11 @@ class CRM_Core_ResourcesTest extends CiviUnitTestCase {
    */
   protected $mapper;
 
+  /**
+   * @var string for testing cache buster generation
+   */
+  protected $cacheBusterString = 'xBkdk3';
+
   protected $originalRequest;
   protected $originalGet;
 
@@ -346,6 +351,41 @@ class CRM_Core_ResourcesTest extends CiviUnitTestCase {
     $c = new CRM_Extension_Container_Basic($basedir, 'http://ext-dir', $cache, $cacheKey);
     $mapper = new CRM_Extension_Mapper($c, NULL, NULL, '/pathto/civicrm', 'http://core-app');
     return array($basedir, $c, $mapper);
+  }
+
+  /**
+   * @param string $url
+   * @param string $expected
+   *
+   * @dataProvider urlForCacheCodeProvider
+   */
+  public function testAddingCacheCode($url, $expected) {
+    $resources = CRM_Core_Resources::singleton();
+    $this->assertEquals($expected, $resources->addCacheCode($url));
+  }
+
+  /**
+   * @return array
+   */
+  public function urlForCacheCodeProvider() {
+    return array(
+      array(
+        'http://www.civicrm.org',
+        'http://www.civicrm.org?r=' . $this->cacheBusterString,
+      ),
+      array(
+        'www.civicrm.org/custom.css?foo=bar',
+        'www.civicrm.org/custom.css?foo=bar&r=' . $this->cacheBusterString,
+      ),
+      array(
+        'civicrm.org/custom.css?r=old&foo=bar',
+        'civicrm.org/custom.css?r=' . $this->cacheBusterString . '&foo=bar',
+      ),
+      array(
+        'civicrm.org/custom.css?car=blue&foo=bar',
+        'civicrm.org/custom.css?car=blue&foo=bar&r=' . $this->cacheBusterString,
+      ),
+    );
   }
 
 }


### PR DESCRIPTION
As mentioned in [Jira](https://issues.civicrm.org/jira/browse/CRM-20254) this adds the cache buster string for custom CSS files. 
It also improves on the appending of the cache buster string to URLs by detecting for an existing query string or an existing cache buster string.

I originally opened a [PR on the 4.6 branch](https://github.com/civicrm/civicrm-core/pull/9977), this is a replacement for that