### PR TITLE
CRM-20040: Use Smarty escape modifier for variable in Javascript context

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/OnBehalfOf.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/OnBehalfOf.tpl
@@ -123,7 +123,7 @@
  function setLocationDetails(contactID , reset) {
    resetValues();
    var locationUrl = {/literal}'{$locDataURL}'{literal} + contactID;
-   var submittedOnBehalfInfo = {/literal}'{$submittedOnBehalfInfo}'{literal};
+   var submittedOnBehalfInfo = {/literal}'{$submittedOnBehalfInfo|escape:'javascript'}'{literal};
    var submittedCID = {/literal}"{$submittedOnBehalf}"{literal};
 
    if (submittedOnBehalfInfo) {


### PR DESCRIPTION
Use Smarty escape modifier for variable in Javascript context

See http://www.smarty.net/docsv2/en/language.modifier.escape.tpl

CRM-20040

---

 * [CRM-20040](https://issues.civicrm.org/jira/browse/CRM-20040)