### PR TITLE
CRM-20270 - composer.lock - Fix multibyte warnings by updating ezcMail

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,6 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "94c7ae299e411a3b9013da64e1232669",
     "content-hash": "36ffd76fc5e7344ac6e587d11779ceeb",
     "packages": [
         {
@@ -45,7 +44,7 @@
                 }
             ],
             "description": "RPC library for CiviConnect",
-            "time": "2016-12-06 04:32:51"
+            "time": "2016-12-06T04:32:51+00:00"
         },
         {
             "name": "dompdf/dompdf",
@@ -106,7 +105,7 @@
             ],
             "description": "DOMPDF is a CSS 2.1 compliant HTML to PDF converter",
             "homepage": "https://github.com/dompdf/dompdf",
-            "time": "2016-05-11 00:36:29"
+            "time": "2016-05-11T00:36:29+00:00"
         },
         {
             "name": "pclzip/pclzip",
@@ -143,7 +142,7 @@
                 "php",
                 "zip"
             ],
-            "time": "2014-06-05 11:42:24"
+            "time": "2014-06-05T11:42:24+00:00"
         },
         {
             "name": "pear/pear_exception",
@@ -198,7 +197,7 @@
             "keywords": [
                 "exception"
             ],
-            "time": "2015-02-10 20:07:52"
+            "time": "2015-02-10T20:07:52+00:00"
         },
         {
             "name": "pear/validate_finance_creditcard",
@@ -276,7 +275,7 @@
             ],
             "description": "A library to read, parse, export and make subsets of different types of font files.",
             "homepage": "https://github.com/PhenX/php-font-lib",
-            "time": "2015-05-06 20:02:39"
+            "time": "2015-05-06T20:02:39+00:00"
         },
         {
             "name": "phenx/php-svg-lib",
@@ -310,7 +309,7 @@
             ],
             "description": "A library to read, parse and export to PDF SVG files.",
             "homepage": "https://github.com/PhenX/php-svg-lib",
-            "time": "2015-05-06 18:49:49"
+            "time": "2015-05-06T18:49:49+00:00"
         },
         {
             "name": "phpoffice/common",
@@ -365,7 +364,7 @@
                 "office",
                 "php"
             ],
-            "time": "2016-07-07 17:26:55"
+            "time": "2016-07-07T17:26:55+00:00"
         },
         {
             "name": "phpoffice/phpword",
@@ -465,7 +464,7 @@
                 "word",
                 "writer"
             ],
-            "time": "2016-07-31 08:53:39"
+            "time": "2016-07-31T08:53:39+00:00"
         },
         {
             "name": "phpseclib/phpseclib",
@@ -564,7 +563,7 @@
                 "x.509",
                 "x509"
             ],
-            "time": "2016-10-22 17:53:16"
+            "time": "2016-10-22T17:53:16+00:00"
         },
         {
             "name": "psr/log",
@@ -602,7 +601,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2012-12-21 11:40:51"
+            "time": "2012-12-21T11:40:51+00:00"
         },
         {
             "name": "symfony/config",
@@ -650,7 +649,7 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "http://symfony.com",
-            "time": "2015-01-03 08:01:13"
+            "time": "2015-01-03T08:01:13+00:00"
         },
         {
             "name": "symfony/dependency-injection",
@@ -707,7 +706,7 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "http://symfony.com",
-            "time": "2015-01-25 04:37:39"
+            "time": "2015-01-25T04:37:39+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -764,7 +763,7 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "http://symfony.com",
-            "time": "2015-01-29 18:20:43"
+            "time": "2015-01-29T18:20:43+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -811,7 +810,7 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "http://symfony.com",
-            "time": "2015-01-03 21:04:44"
+            "time": "2015-01-03T21:04:44+00:00"
         },
         {
             "name": "symfony/finder",
@@ -858,7 +857,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "http://symfony.com",
-            "time": "2015-01-03 08:01:13"
+            "time": "2015-01-03T08:01:13+00:00"
         },
         {
             "name": "symfony/process",
@@ -905,7 +904,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "http://symfony.com",
-            "time": "2015-02-08 07:07:45"
+            "time": "2015-02-08T07:07:45+00:00"
         },
         {
             "name": "tecnickcom/tcpdf",
@@ -968,7 +967,7 @@
                 "pdf417",
                 "qrcode"
             ],
-            "time": "2015-09-12 10:08:34"
+            "time": "2015-09-12T10:08:34+00:00"
         },
         {
             "name": "totten/ca-config",
@@ -1005,7 +1004,7 @@
             ],
             "description": "Default configuration for certificate authorities",
             "homepage": "https://github.com/totten/ca_config",
-            "time": "2013-02-13 03:40:18"
+            "time": "2013-02-13T03:40:18+00:00"
         },
         {
             "name": "zendframework/zend-escaper",
@@ -1050,7 +1049,7 @@
                 "escaper",
                 "zf2"
             ],
-            "time": "2015-05-07 14:55:31"
+            "time": "2015-05-07T14:55:31+00:00"
         },
         {
             "name": "zendframework/zend-stdlib",
@@ -1105,7 +1104,7 @@
                 "stdlib",
                 "zf2"
             ],
-            "time": "2015-07-21 13:55:46"
+            "time": "2015-07-21T13:55:46+00:00"
         },
         {
             "name": "zendframework/zend-validator",
@@ -1170,7 +1169,7 @@
                 "validator",
                 "zf2"
             ],
-            "time": "2015-09-08 21:04:17"
+            "time": "2015-09-08T21:04:17+00:00"
         },
         {
             "name": "zetacomponents/base",
@@ -1230,7 +1229,7 @@
             ],
             "description": "The Base package provides the basic infrastructure that all packages rely on. Therefore every component relies on this package.",
             "homepage": "https://github.com/zetacomponents",
-            "time": "2009-06-29 10:47:39"
+            "time": "2009-06-29T10:47:39+00:00"
         },
         {
             "name": "zetacomponents/mail",
@@ -1238,7 +1237,7 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/civicrm/zetacomponents-mail.git",
-                "reference": "19f5af66cdde19bc20f41671fe453b37f4121eb1"
+                "reference": "e0feff0e1860f16fa2b3c42795c0351db58120a0"
             },
             "type": "library",
             "autoload": {
@@ -1292,7 +1291,7 @@
             ],
             "description": "The component allows you construct and/or parse Mail messages conforming to  the mail standard. It has support for attachments, multipart messages and HTML  mail. It also interfaces with SMTP to send mail or IMAP, POP3 or mbox to  retrieve e-mail.",
             "homepage": "https://github.com/zetacomponents",
-            "time": "2016-01-08 01:15:38"
+            "time": "2017-03-14 06:51:24"
         }
     ],
     "packages-dev": [],


### PR DESCRIPTION
On many systems, the test suite outputs a long message which begins with:

```
PHP Warning: declare(encoding=...) ignored because Zend multibyte feature is turned off by settings in /path/to/sites/all/modules/civicrm/vendor/zetacomponents/mail/src/transports/variable/var_set.php on line 2
```

This patch addresses the warning by updating the version of ezcMail (aka `zetacomponents/mail`).  See also:

 * https://github.com/civicrm/zetacomponents-mail/pull/1
 * http://civicrm.stackexchange.com/questions/16314/does-civicrm-have-a-recommended-setting-for-zend-multibyte

Possible interested parties: @mollux @xurizaemon @tschuettler @bgm

---

 * [CRM-20270: Test suite displays "PHP Warning: declare\(encoding=...\) ignored because Zend multibyte feature is turned off by settings in"](https://issues.civicrm.org/jira/browse/CRM-20270)