### PR TITLE
CRM-19710 - Preserve is_email_receipt parameter through to email sent

### DIFF
--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -443,6 +443,7 @@ function civicrm_api3_contribution_sendconfirmation($params) {
     'payment_processor_id',
   );
   $input = array_intersect_key($params, array_flip($allowedParams));
+  $input['is_email_receipt'] = TRUE;
   CRM_Contribute_BAO_Contribution::sendMail($input, $ids, $params['id'], $values);
 }
 


### PR DESCRIPTION
* [CRM-19710: Preserve is_email_receipt parameter through to email sent](https://issues.civicrm.org/jira/browse/CRM-19710)