### PR TITLE
CRM-20296 - order by even then odd numbers as advertised

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -2763,6 +2763,16 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
 
         if (!empty($orderByField)) {
           $this->_orderByFields[$orderByField['tplField']] = $orderByField;
+          if ($orderByField['name'] == 'street_number') {
+            // First order by Odd/Even - list even numbers first, then odd numbers
+            $orderBys[] = "{$orderByField['dbAlias']} % 2 {$orderBy['order']}";
+            // Next order numerically, so all even numbers are listed in numeric
+            // order, followed by all odd numbers in numeric order.
+            $orderBys[] = "{$orderByField['dbAlias']} {$orderBy['order']}";
+          }
+          else {
+            $orderBys[] = "{$orderByField['dbAlias']} {$orderBy['order']}";
+          }
           $orderBys[] = "{$orderByField['dbAlias']} {$orderBy['order']}";
 
           // Record any section headers for assignment to the template

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -2773,7 +2773,6 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
           else {
             $orderBys[] = "{$orderByField['dbAlias']} {$orderBy['order']}";
           }
-          $orderBys[] = "{$orderByField['dbAlias']} {$orderBy['order']}";
 
           // Record any section headers for assignment to the template
           if (!empty($orderBy['section'])) {

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -2764,15 +2764,17 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
         if (!empty($orderByField)) {
           $this->_orderByFields[$orderByField['tplField']] = $orderByField;
           if ($orderByField['name'] == 'street_number') {
-            // First order by Odd/Even - list even numbers first, then odd numbers
+            // First order by Even/Odd - list even numbers first, then odd
+            // numbers. Even numbered addresses are on one side of the
+            // street and odd numbered addresses are on the other side of 
+            // the street so, when door knocking, it is easier to do streets
+            // one side at a time.
             $orderBys[] = "{$orderByField['dbAlias']} % 2 {$orderBy['order']}";
-            // Next order numerically, so all even numbers are listed in numeric
-            // order, followed by all odd numbers in numeric order.
-            $orderBys[] = "{$orderByField['dbAlias']} {$orderBy['order']}";
+            // Below, add order clause as it normally would be added, so all
+            // even numbers are listed in numeric order, followed by all odd
+            // numbers in numeric order.
           }
-          else {
-            $orderBys[] = "{$orderByField['dbAlias']} {$orderBy['order']}";
-          }
+          $orderBys[] = "{$orderByField['dbAlias']} {$orderBy['order']}";
 
           // Record any section headers for assignment to the template
           if (!empty($orderBy['section'])) {

--- a/CRM/Report/Form/Campaign/SurveyDetails.php
+++ b/CRM/Report/Form/Campaign/SurveyDetails.php
@@ -203,7 +203,7 @@ class CRM_Report_Form_Campaign_SurveyDetails extends CRM_Report_Form {
         ),
         'grouping' => 'survey-activity-fields',
       ),
-    ) + $this->addAddressFields();
+    ) + $this->getAddressColumns();
     parent::__construct();
   }
 


### PR DESCRIPTION
I have some mis-givings about this change. Another approach would be to remove the label that says the street numbering will be order by even/add and then put all of this functionality in the Campaign reports. That would keep the core code simpler for functionality that may only be wanted in Campaign mode (which includes the survey components that are typically used to generate these reports in the first place).

---

 * [CRM-20296: Order by street number \(odd\/even\) does not order by odd\/even street numbers](https://issues.civicrm.org/jira/browse/CRM-20296)