### PR TITLE
CRM-20297 Display contribution having line items with no price set

### DIFF
--- a/CRM/Contribute/Form/ContributionView.php
+++ b/CRM/Contribute/Form/ContributionView.php
@@ -242,14 +242,13 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
   public function buildQuickForm() {
 
     $this->addButtons(array(
-        array(
-          'type' => 'cancel',
-          'name' => ts('Done'),
-          'spacing' => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
-          'isDefault' => TRUE,
-        ),
-      )
-    );
+      array(
+        'type' => 'cancel',
+        'name' => ts('Done'),
+        'spacing' => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
+        'isDefault' => TRUE,
+      ),
+    ));
   }
 
 }

--- a/CRM/Contribute/Form/ContributionView.php
+++ b/CRM/Contribute/Form/ContributionView.php
@@ -155,8 +155,23 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
     if ($id) {
       $lineItems = array(CRM_Price_BAO_LineItem::getLineItemsByContributionID(($id)));
       $firstLineItem = reset($lineItems[0]);
-      $priceSet = civicrm_api3('PriceSet', 'getsingle', array('id' => $firstLineItem['price_set_id'], 'return' => 'is_quick_config, id'));
-      $displayLineItems = !$priceSet['is_quick_config'];
+      if (empty($firstLineItem['price_set_id'])) {
+        // CRM-20297 All we care is that it's not QuickConfig, so no price set
+        // is no problem.
+        $displayLineItems = TRUE;
+      }
+      else {
+        try {
+          $priceSet = civicrm_api3('PriceSet', 'getsingle', array(
+            'id' => $firstLineItem['price_set_id'],
+            'return' => 'is_quick_config, id',
+          ));
+          $displayLineItems = !$priceSet['is_quick_config'];
+        }
+        catch (CiviCRM_API3_Exception $e) {
+          throw new CRM_Core_Exception('Cannot find price set by ID');
+        }
+      }
     }
     $this->assign('lineItem', $lineItems);
     $this->assign('displayLineItems', $displayLineItems);

--- a/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
@@ -70,7 +70,7 @@
                     <strong> -------------------------------------------</strong><br />
                     {ts}Total{/ts}: <strong>{$amount+$minimum_fee|crmMoney}</strong><br />
                 {elseif $amount }
-                    {ts}Amount{/ts}: <strong>{$amount|crmMoney} {if $amount_level } - {$amount_level} {/if}</strong>
+                    {ts}Amount{/ts}: <strong>{$amount|crmMoney} {if $amount_level } &ndash; {$amount_level} {/if}</strong>
                 {else}
                     {$membership_name} {ts}Membership{/ts}: <strong>{$minimum_fee|crmMoney}</strong>
                 {/if}
@@ -79,7 +79,7 @@
                      {ts}Total Tax Amount{/ts}: <strong>{$totalTaxAmount|crmMoney} </strong><br />
                 {/if}
 		{if $amount}
-                    {if $installments}{ts}Installment Amount{/ts}{else}{ts}Total Amount{/ts}{/if} : <strong>{$amount|crmMoney} {if $amount_level } - {$amount_level} {/if}</strong>
+                    {if $installments}{ts}Installment Amount{/ts}{else}{ts}Total Amount{/ts}{/if}: <strong>{$amount|crmMoney}{if $amount_level } &ndash; {$amount_level}{/if}</strong>
                 {else}
                     {$membership_name} {ts}Membership{/ts}: <strong>{$minimum_fee|crmMoney}</strong>
                 {/if}

--- a/templates/CRM/Contribute/Form/Contribution/MembershipBlock.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/MembershipBlock.tpl
@@ -179,7 +179,7 @@ CRM.$(function($) {
                 <span class="bold">{$row.name} &nbsp;
                 {if ($membershipBlock.display_min_fee AND $context EQ "makeContribution") AND $row.minimum_fee GT 0 }
                     {if $is_separate_payment OR ! $form.amount.label}
-                        - {$row.minimum_fee|crmMoney}
+                        &ndash; {$row.minimum_fee|crmMoney}
                     {else}
                         {ts 1=$row.minimum_fee|crmMoney}(contribute at least %1 to be eligible for this membership){/ts}
                     {/if}

--- a/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
@@ -118,7 +118,7 @@
             {if $totalTaxAmount}
               {ts}Tax Amount{/ts}: <strong>{$totalTaxAmount|crmMoney}</strong><br />
             {/if}
-            {if $installments}{ts}Installment Amount{/ts}{else}{ts}Amount{/ts}{/if} : <strong>{$amount|crmMoney} {if $amount_level } - {$amount_level} {/if}</strong>
+            {if $installments}{ts}Installment Amount{/ts}{else}{ts}Amount{/ts}{/if}: <strong>{$amount|crmMoney}{if $amount_level } &ndash; {$amount_level}{/if}</strong>
           {/if}
         {/if}
         {if $receive_date}

--- a/templates/CRM/Contribute/Form/ContributionPage/Amount.tpl
+++ b/templates/CRM/Contribute/Form/ContributionPage/Amount.tpl
@@ -27,7 +27,7 @@
 {crmRegion name="contribute-form-contributionpage-amount-main"}
 <div class="crm-block crm-form-block crm-contribution-contributionpage-amount-form-block">
 <div class="help">
-    {ts}Use this form to configure Contribution Amount options. You can give contributors the ability to enter their own contribution amounts - and/or provide a fixed list of amounts. For fixed amounts, you can enter a label for each 'level' of contribution (e.g. Friend, Sustainer, etc.). If you allow people to enter their own dollar amounts, you can also set minimum and maximum values. Depending on your choice of Payment Processor, you may be able to offer a recurring contribution option.{/ts} {docURL page="user/contributions/payment-processors"}
+    {ts}Use this form to configure Contribution Amount options. You can give contributors the ability to enter their own contribution amounts and/or provide a fixed list of amounts. For fixed amounts, you can enter a label for each 'level' of contribution (e.g. Friend, Sustainer, etc.). If you allow people to enter their own dollar amounts, you can also set minimum and maximum values. Depending on your choice of Payment Processor, you may be able to offer a recurring contribution option.{/ts} {docURL page="user/contributions/payment-processors"}
 </div>
     <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
     {if !$paymentProcessor}
@@ -76,7 +76,7 @@
         <tr class="crm-contribution-contributionpage-amount-form-block-amount_block_is_active">
           <th scope="row" class="label">{$form.amount_block_is_active.label}</th>
           <td>{$form.amount_block_is_active.html}<br />
-          <span class="description">{ts}Uncheck this box if you are using this contribution page for membership signup and renewal only - and you do NOT want users to select or enter any additional contribution amounts.{/ts}</span></td>
+          <span class="description">{ts}Uncheck this box if you are using this contribution page for membership signup and renewal only &ndash; and you do NOT want users to select or enter any additional contribution amounts.{/ts}</span></td>
         </tr>
         <tr id="priceSet" class="crm-contribution-contributionpage-amount-form-block-priceSet">
           <th scope="row" class="label">{$form.price_set_id.label}</th>
@@ -423,7 +423,7 @@
     function setDateDefaults() {
      {/literal}{if !$pledge_calendar_date}{literal}
        cj('#pledge_calendar_date').prop('disabled', 'disabled');
-       cj("#pledge_calendar_date").next('input').prop('disabled', 'disabled'); 
+       cj("#pledge_calendar_date").next('input').prop('disabled', 'disabled');
      {/literal}{/if}
 
      {if !$pledge_calendar_month}{literal}

--- a/templates/CRM/Contribute/Form/ContributionPage/Custom.hlp
+++ b/templates/CRM/Contribute/Form/ContributionPage/Custom.hlp
@@ -28,7 +28,7 @@
 {/htxt}
 {htxt id="contrib-profile"}
 <p>
-  {ts}If you want collect additional information from contributors, you can include one or two CiviCRM Profiles - which are collections of standard or custom fields - in this contribution page. For example, you may need to collect information about the person (e.g. name and address if these are not already required by your payment processor, interest in subscribing to a newsletter or volunteering). You might also want to collect information specific to this contribution (e.g. target one or several projects or funds to support with this contribution).{/ts}
+  {ts}If you want collect additional information from contributors, you can include one or two CiviCRM Profiles&mdash;which are collections of standard or custom fields&mdash;in this contribution page. For example, you may need to collect information about the person (e.g. name and address if these are not already required by your payment processor, interest in subscribing to a newsletter or volunteering). You might also want to collect information specific to this contribution (e.g. target one or several projects or funds to support with this contribution).{/ts}
 </p>
 <p>
   {ts}Your site may already have profile(s) which were previously created for this purpose, in which case you can re-use them for any number of online contribution pages.{/ts}

--- a/templates/CRM/Contribute/Form/ContributionPage/PCP.hlp
+++ b/templates/CRM/Contribute/Form/ContributionPage/PCP.hlp
@@ -51,7 +51,7 @@
 {/htxt}
 {htxt id="id-supporter_profile"}
 {capture assign="createProfileURL"}{crmURL p="civicrm/admin/uf/group" q="reset=1"}{/capture}
-{ts 1=$createProfileURL}This is used to collect or update basic information (e.g. name and email address) from users while they are creating a Personal Campaign Page. The profile you select must be configured with 'Account creation required' (under Profile Settings &raquo; Advanced Settings). You must include an Email address field - and you may include any number of other fields in the profile. If you don't yet have an appropriate Profile configured, you will need to <a href='%1'>create one first</a>, and then return to this form to select it.{/ts}
+{ts 1=$createProfileURL}This is used to collect or update basic information (e.g. name and email address) from users while they are creating a Personal Campaign Page. The profile you select must be configured with 'Account creation required' (under Profile Settings &raquo; Advanced Settings). You must include an Email address field&mdash;and you may include any number of other fields in the profile. If you don't yet have an appropriate Profile configured, you will need to <a href='%1'>create one first</a>, and then return to this form to select it.{/ts}
 {/htxt}
 
 {htxt id="id-is_tellfriend-title"}

--- a/templates/CRM/Contribute/Form/ContributionPage/Premium.tpl
+++ b/templates/CRM/Contribute/Form/ContributionPage/Premium.tpl
@@ -68,7 +68,7 @@
             </td>
             <td class="html-adjust">{$form.premiums_intro_text.html}<br/>
             <span class="description">
-              {ts}Enter content for the introductory message. This will be displayed below the Premiums section title. You may include HTML formatting tags. You can also include images, as long as they are already uploaded to a server - reference them using complete URLs.{/ts}
+              {ts}Enter content for the introductory message. This will be displayed below the Premiums section title. You may include HTML formatting tags. You can also include images, as long as they are already uploaded to a server&mdash;reference them using complete URLs.{/ts}
             </span>
             </td>
           </tr>

--- a/templates/CRM/Contribute/Form/ContributionPage/Settings.hlp
+++ b/templates/CRM/Contribute/Form/ContributionPage/Settings.hlp
@@ -36,7 +36,7 @@
   {ts}Intro Content{/ts}
 {/htxt}
 {htxt id="id-intro_msg"}
-{ts}Enter content for the introductory message. This will be displayed below the page title. You can include images, as long as they are already uploaded to a server - click the "Image" button in the button bar.{/ts}
+{ts}Enter content for the introductory message. This will be displayed below the page title. You can include images, as long as they are already uploaded to a server: click the "Image" button in the button bar.{/ts}
 {/htxt}
 
 {htxt id="id-footer_msg-title"}
@@ -83,4 +83,3 @@
 <p>{ts}When enabled, links allowing people to share this online contribution page with their social network will be displayed (e.g. Facebook "Like", Google+, and Twitter).{/ts}</p>
 <p>{ts}Social media links will be included on the Contribution Thank-you page, Tell-a-Friend page (if enabled), and in contribution receipt emails.{/ts}</p>
 {/htxt}
-

--- a/templates/CRM/Contribute/Form/ContributionPage/Tab.hlp
+++ b/templates/CRM/Contribute/Form/ContributionPage/Tab.hlp
@@ -34,7 +34,7 @@
 </tr>
 <tr>
     <td><a href="{crmURL p='civicrm/admin/contribute/amount' q="reset=1&action=update&id=`$contributionPageID`"}" id="idAmount">&raquo; {ts}Amount{/ts}</a></td>
-    <td>{ts}Use this form to configure Contribution Amount options. You can give contributors the ability to enter their own contribution amounts - and/or provide a fixed list of amounts. For fixed amounts, you can enter a label for each 'level' of contribution (e.g. Friend, Sustainer, etc.). If you allow people to enter their own dollar amounts, you can also set minimum and maximum values. Depending on your choice of Payment Processor, you may be able to offer a recurring contribution option.{/ts}</td>
+    <td>{ts}Use this form to configure Contribution Amount options. You can give contributors the ability to enter their own contribution amounts and/or provide a fixed list of amounts. For fixed amounts, you can enter a label for each 'level' of contribution (e.g. Friend, Sustainer, etc.). If you allow people to enter their own dollar amounts, you can also set minimum and maximum values. Depending on your choice of Payment Processor, you may be able to offer a recurring contribution option.{/ts}</td>
 </tr>
 <tr>
     <td><a href="{crmURL p='civicrm/admin/contribute/membership' q="reset=1&action=update&id=`$contributionPageID`"}" id="idMembership">&raquo; {ts}Memberships{/ts}</a></td>
@@ -42,7 +42,7 @@
 </tr>
 <tr>
     <td><a href="{crmURL p='civicrm/admin/contribute/thankYou' q="reset=1&action=update&id=`$contributionPageID`"}" id="idThanks">&raquo; {ts}Thank-you and Receipting{/ts}</a></td>
-    <td>{ts}Use this form to configure the thank-you message and receipting options. Contributors will see a confirmation and thank-you page after whenever an online contribution is successfully processed. You provide the content and layout of the thank-you section below. You also control whether an electronic receipt is automatically emailed to each contributor - and can add a custom message to that receipt.{/ts}</td>
+    <td>{ts}Use this form to configure the thank-you message and receipting options. Contributors will see a confirmation and thank-you page after whenever an online contribution is successfully processed. You provide the content and layout of the thank-you section below. You also control whether an electronic receipt is automatically emailed to each contributor, and you can add a custom message to that receipt.{/ts}</td>
 </tr>
 <tr>
     <td><a href="{crmURL p='civicrm/admin/contribute/friend' q="reset=1&action=update&id=`$contributionPageID`"}" id="idFriend">&raquo; {ts}Tell a Friend{/ts}</a></td>
@@ -52,7 +52,7 @@
    <td><a href="{crmURL p='civicrm/admin/contribute/custom' q="reset=1&action=update&id=`$contributionPageID`"}" id="idCustom">&raquo; {ts}Include Profiles{/ts}</a></td>
     <td>{ts}You may want to collect information from contributors beyond what is required to make a contribution. For example, you may want to inquire about volunteer availability and skills. Add any number of fields to your contribution form by selecting CiviCRM Profiles (collections of fields) to include at the beginning of the page, and/or at the bottom.{/ts}<br />
 {capture assign=adminGroupURL}{crmURL p="civicrm/admin/uf/group" q="reset=1&action=browse"}{/capture}
-{ts 1=$adminGroupURL}You can use existing CiviCRM Profiles on your page - OR create profile(s) specifically for use in Online Contribution pages. Go to <a href="%1"><strong>Administer CiviCRM Profiles</strong></a> if you need to review, modify or create profiles (you can come back at any time to select or update the Profile(s) used for this page).{/ts}</td>
+{ts 1=$adminGroupURL}You can use existing CiviCRM Profiles on your page or create profile(s) specifically for use in Online Contribution pages. Go to <a href="%1"><strong>Administer CiviCRM Profiles</strong></a> if you need to review, modify or create profiles (you can come back at any time to select or update the Profile(s) used for this page).{/ts}</td>
 </tr>
 <tr>
    <td><a href="{crmURL p='civicrm/admin/contribute/premium q="reset=1&action=update&id=`$contributionPageID`"}" id="idPremium">&raquo; {ts}Premiums{/ts}</a></td>
@@ -60,7 +60,7 @@
 </tr>
 <tr>
    <td><a href="{crmURL p='civicrm/admin/contribute/widget' q="reset=1&action=update&id=`$contributionPageID`"}" id="idWidget">&raquo; {ts}Widget{/ts}</a></td>
-   <td>{ts}Widgets allow you and your supporters to easily promote this fund-raising campaign. Widget code can be added to any web page - and will provide a real-time display of current contribution results, and a direct link to this contribution page.{/ts}</td>
+   <td>{ts}Widgets allow you and your supporters to easily promote this fund-raising campaign. Widget code can be added to any web page.  They will provide a real-time display of current contribution results, and a direct link to this contribution page.{/ts}</td>
 </tr>
 <tr>
   <td><a href="{crmURL p='civicrm/admin/contribute/pcp' q="reset=1&action=update&id=`$contributionPageID`"}" id="idPCP">&raquo; {ts}Personal Campaign Pages{/ts}</a></td>
@@ -68,7 +68,7 @@
 </tr>
 <tr>
   <td><a href="{crmURL p='civicrm/contribute/transact' q="reset=1&action=preview&id=`$contributionPageID`"}" id="idTest">&raquo; {ts}Online Contribution{/ts}</a><br /> ({ts}Test-drive{/ts})</td>
-  <td>{ts}Test-drive the entire contribution process - including custom fields, confirmation, thank-you page, and receipting. Transactions will be directed to your payment processor's test server. No live financial transactions will be submitted. However, a contact record will be created or updated and a test contribution record will be saved to the database. Use obvious test contact names so you can review and delete these records as needed. Test contributions are not visible on the Contributions tab, but can be viewed by searching for 'Test Contributions' in the CiviContribute search form.{/ts}</td>
+  <td>{ts}Test-drive the entire contribution process&mdash;including custom fields, confirmation, thank-you page, and receipting. Transactions will be directed to your payment processor's test server. No live financial transactions will be submitted. However, a contact record will be created or updated and a test contribution record will be saved to the database. Use obvious test contact names so you can review and delete these records as needed. Test contributions are not visible on the Contributions tab, but can be viewed by searching for 'Test Contributions' in the CiviContribute search form.{/ts}</td>
 </tr>
 <tr>
   <td><a href="{crmURL p='civicrm/contribute/transact' q="reset=1&id=`$contributionPageID`"}" id="idLive">&raquo; {ts}Online Contribution{/ts}</a><br /> ({ts}Live{/ts})</td>

--- a/templates/CRM/Contribute/Form/ContributionPage/ThankYou.hlp
+++ b/templates/CRM/Contribute/Form/ContributionPage/ThankYou.hlp
@@ -27,7 +27,7 @@
   {ts}Thank-you and Receipting{/ts}
 {/htxt}
 {htxt id="id_thank"}
-  <p>{ts}Use this form to configure the thank-you message and receipting options for this online contribution page. Contributors will see a thank-you page whenever an online contribution is successfully processed. You provide the content and layout of the thank-you section below. You also control whether an electronic receipt is automatically emailed to each contributor - and can add a custom message to that receipt.{/ts}</p>
+  <p>{ts}Use this form to configure the thank-you message and receipting options for this online contribution page. Contributors will see a thank-you page whenever an online contribution is successfully processed. You provide the content and layout of the thank-you section below. You also control whether an electronic receipt is automatically emailed to each contributor, and you can add a custom message to that receipt.{/ts}</p>
 {/htxt}
 
 {htxt id="id_thankyou-title-title"}

--- a/templates/CRM/Contribute/Form/ContributionPage/Widget.tpl
+++ b/templates/CRM/Contribute/Form/ContributionPage/Widget.tpl
@@ -33,7 +33,7 @@
 {/if}
 <div id="form" class="crm-block crm-form-block crm-contribution-contributionpage-widget-form-block">
     <div class="help">
-        {ts}CiviContribute widgets allow you and your supporters to easily promote this fund-raising campaign. Widget code can be added to any web page - and will provide a real-time display of current contribution results, and a direct link to this contribution page.{/ts} {help id="id-intro"}
+        {ts}CiviContribute widgets allow you and your supporters to easily promote this fund-raising campaign. Widget code can be added to any web page.  It will provide a real-time display of current contribution results and a direct link to this contribution page.{/ts} {help id="id-intro"}
     </div>
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
     <table class="form-layout-compressed">
@@ -47,7 +47,7 @@
             <tr class="crm-contribution-form-block-url_logo"><td class="label">{$form.url_logo.label}</span></td><td>{$form.url_logo.html}</td></tr>
             <tr class="crm-contribution-contributionpage-widget-form-block-button_title"><td class="label">{$form.button_title.label}</td><td>{$form.button_title.html}</td></tr>
             <tr class="crm-contribution-contributionpage-widget-form-block-about"><td class="label">{$form.about.label}<span class="crm-marker"> *</span></td><td>{$form.about.html}
-<br /><span class="description">{ts}Enter content for the about message. You may include HTML formatting tags. You can also include images, as long as they are already uploaded to a server - reference them using complete URLs.{/ts}</span>
+<br /><span class="description">{ts}Enter content for the about message. You may include HTML formatting tags. You can also include images, as long as they are already uploaded to a server&mdash;reference them using complete URLs.{/ts}</span>
 </td></tr>
 
         </table>

--- a/templates/CRM/Contribute/Form/ManagePremiums.tpl
+++ b/templates/CRM/Contribute/Form/ManagePremiums.tpl
@@ -60,7 +60,7 @@
       <td>
       <fieldset><div class="description">
         <p>{ts}You can give this premium a picture that will be displayed on the contribution page. Both a 50 x 50 pixel thumbnail image and a 200 x 200 pixel larger image will be displayed. Images must be in GIF, JPEG, or PNG format.{/ts}</p>
-        <p>{ts}You can upload an image from your computer OR enter a URL for an image already on the Web. If you chose to upload an image file, a 'thumbnail' version will be automatically created for you. If you don't have an image available at this time, you may also choose to display a 'No Image Available' icon - by selecting the 'default image'.{/ts}</p>
+        <p>{ts}You can upload an image from your computer OR enter a URL for an image already on the Web. If you chose to upload an image file, a 'thumbnail' version will be automatically created for you. If you don't have an image available at this time, you may also choose to display a 'No Image Available' icon by selecting the 'default image'.{/ts}</p>
                   </div>
   <table class="form-layout-compressed">
     {if $thumbnailUrl}<tr class="odd-row"><td class="describe-image" colspan="2"><strong>Current Image Thumbnail</strong><br /><img src="{$thumbnailUrl}" /></td></tr>{/if}

--- a/templates/CRM/Contribute/Form/Task/Invoice.hlp
+++ b/templates/CRM/Contribute/Form/Task/Invoice.hlp
@@ -51,13 +51,13 @@
 {/htxt}
 {htxt id="upload-compose"}
 <p>{ts}You can use your favorite editor to create content on your local computer and then <strong>Upload</strong> the files. OR you can <strong>Compose</strong> content directly on the screen.{/ts}</p>
-<p>{ts}If you choose to compose on the screen, a basic WYSIWYG (what-you-see-is-what-you-get) editor is provided which you can use create simple HTML messages. However, if you are planning on creating HTML messages with complex layouts - it is best to use an HTML editor on your local computer. Then locate and upload the saved file(s) by clicking the <strong>Browse</strong> button.{/ts}</p>
+<p>{ts}If you choose to compose on the screen, a basic WYSIWYG (what-you-see-is-what-you-get) editor is provided which you can use create simple HTML messages. However, if you are planning on creating HTML messages with complex layouts, it is best to use an HTML editor on your local computer. Then locate and upload the saved file(s) by clicking the <strong>Browse</strong> button.{/ts}</p>
 {/htxt}
 
 {htxt id="id-message-text-title"}
   {ts}Text Message{/ts}
 {/htxt}
 {htxt id="id-message-text"}
-<p>{ts}You can send your email as a simple text-only message, as an HTML formatted message, or both. Text-only messages are sufficient for most email communication - and some recipients may prefer not to receive HTML formatted messages.{/ts}</p>
-<p>{ts}HTML messages have more visual impact, allow you to include images, and may be more readable if you are including links to website pages. However, different email programs may interpret HTML formats differently - so use this option cautiously unless you have a template format that has been tested with different web and desktop email programs.{/ts}</p>
+<p>{ts}You can send your email as a simple text-only message, as an HTML formatted message, or both. Text-only messages are sufficient for most email communication, and some recipients may prefer not to receive HTML formatted messages.{/ts}</p>
+<p>{ts}HTML messages have more visual impact, allow you to include images, and may be more readable if you are including links to website pages. However, different email programs may interpret HTML formats differently, so use this option cautiously unless you have a template format that has been tested with different web and desktop email programs.{/ts}</p>
 {/htxt}

--- a/templates/CRM/Contribute/Import/Form/DataSource.hlp
+++ b/templates/CRM/Contribute/Import/Form/DataSource.hlp
@@ -29,15 +29,15 @@
 {htxt id='upload'}
     <p>{ts}Files to be imported must be in the 'comma-separated-values' format (CSV). Most applications will allow you to export records in CSV format. Consult the documentation for your application if you're not sure how to do this.{/ts}</p>
 <h1>{ts}Contact Records for Contributors{/ts}</h1>
-    <p>{ts}Contribution import requires that the Contributors already exist as contact records in your CiviCRM database. If you need to import contributions for contributors who haven't been added to CiviCRM yet - you will do this in 2 steps. First, use <strong>Import Contacts</strong> to add the contact records. If possible, include a unique 'External ID' for each new contact which you can then use to match contributions to contributors. Then return to this screen and import the contribution records.{/ts}</p>
+    <p>{ts}Contribution import requires that the Contributors already exist as contact records in your CiviCRM database. If you need to import contributions for contributors who haven't been added to CiviCRM yet, you will do this in 2 steps. First, use <strong>Import Contacts</strong> to add the contact records. If possible, include a unique 'External ID' for each new contact which you can then use to match contributions to contributors. Then return to this screen and import the contribution records.{/ts}</p>
 <h1>{ts}Matching Contributions to Contributors{/ts}</h1>
     <p>{ts}Contribution import files must contain data needed to <strong>match the contribution to the contributor</strong>. This 'matching' can be handled in several different ways:{/ts}</p>
     <ul>
     <li>{ts}Include the data fields used for contact 'matching' based on your configured <strong>Unsupervised Duplicate Matching</strong> rules. For the default duplicate matching rules, you would include a column in each row with the contributors' Email Address.{/ts}</li>
     <li>{ts}If you've stored a unique <strong>External Identifier</strong> for each contact in CiviCRM, you can include that value as a column in your import file. Contributions will then be matched to contributors using their External ID.{/ts}</li>
-    <li>{ts}You can include a column with each contributor's <strong>Internal Contact ID</strong>. This is the unique ID assigned by CiviCRM which is displayed at the bottom of the Contact Summary screen - and can be exported.{/ts}</li>
+    <li>{ts}You can include a column with each contributor's <strong>Internal Contact ID</strong>. This is the unique ID assigned by CiviCRM which is displayed at the bottom of the Contact Summary screen and can be exported.{/ts}</li>
     </ul>
-    <p>{ts}Save the CSV file with your contributions and 'contact matching' data to your local hard drive (or an accessible drive on your network) - and you are now ready for step 1 (Upload Data).{/ts}</p>
+    <p>{ts}Save the CSV file with your contributions and 'contact matching' data to your local hard drive (or an accessible drive on your network).  Now you are ready for step 1 (Upload Data).{/ts}</p>
 {/htxt}
 
 {htxt id="id-onDuplicate-title"}

--- a/templates/CRM/Contribute/Import/Form/Preview.tpl
+++ b/templates/CRM/Contribute/Import/Form/Preview.tpl
@@ -36,13 +36,13 @@
 
     {if $invalidRowCount}
         <p class="error">
-        {ts 1=$invalidRowCount 2=$downloadErrorRecordsUrl}CiviCRM has detected invalid data or formatting errors in %1 records. If you continue, these records will be skipped. OR, you can download a file with just these problem records - <a href='%2'>Download Errors</a>. Then correct them in the original import file, cancel this import and begin again at step 1.{/ts}
+        {ts 1=$invalidRowCount 2=$downloadErrorRecordsUrl}CiviCRM has detected invalid data or formatting errors in %1 records. If you continue, these records will be skipped.  You can download a file with just these problem records: <a href='%2'>Download Errors</a>.  If you wish, you can then correct them in the original import file, cancel this import, and begin again at step 1.{/ts}
         </p>
     {/if}
 
     {if $conflictRowCount}
         <p class="error">
-        {ts 1=$conflictRowCount 2=$downloadConflictRecordsUrl}CiviCRM has detected %1 records with conflicting transaction ids within this data file. If you continue, these records will be skipped. OR, you can download a file with just these problem records - <a href='%2'>Download Conflicts</a>. Then correct them in the original import file, cancel this import and begin again at step 1.{/ts}
+        {ts 1=$conflictRowCount 2=$downloadConflictRecordsUrl}CiviCRM has detected %1 records with conflicting transaction ids within this data file. If you continue, these records will be skipped.  You can download a file with just these problem records: <a href='%2'>Download Conflicts</a>.  If you wish, you can then correct them in the original import file, cancel this import and begin again at step 1.{/ts}
         </p>
     {/if}
 

--- a/templates/CRM/Contribute/Page/ContributionPage.hlp
+++ b/templates/CRM/Contribute/Page/ContributionPage.hlp
@@ -28,7 +28,7 @@
 {/htxt}
 {htxt id="id-intro"}
     {capture assign=newPageURL}{crmURL p='civicrm/admin/contribute/add' q='action=add&reset=1'}{/capture}
-    <p>{ts}CiviContribute allows you to create and maintain any number of Online Contribution Pages. You can create different pages for different programs or campaigns - and customize text, amounts, types of information collected from contributors, etc.{/ts}</p>
+    <p>{ts}CiviContribute allows you to create and maintain any number of Online Contribution Pages. You can create different pages for different programs or campaigns, and you can customize text, amounts, types of information collected from contributors, etc.{/ts}</p>
     {ts}For existing pages{/ts}:
     <ul class="indented">
     <li>{ts}Click <strong>Configure</strong> to view and modify settings, amounts, and text for existing pages.{/ts}</li>

--- a/templates/CRM/Contribute/Page/ContributionPage.tpl
+++ b/templates/CRM/Contribute/Page/ContributionPage.tpl
@@ -25,7 +25,7 @@
 *}
     {capture assign=newPageURL}{crmURL p='civicrm/admin/contribute/add' q='action=add&reset=1'}{/capture}
     <div class="help">
-       {ts}CiviContribute allows you to create and maintain any number of Online Contribution Pages. You can create different pages for different programs or campaigns - and customize text, amounts, types of information collected from contributors, etc.{/ts} {help id="id-intro"}
+       {ts}CiviContribute allows you to create and maintain any number of Online Contribution Pages. You can create different pages for different programs or campaigns, and you can customize text, amounts, types of information collected from contributors, etc.{/ts} {help id="id-intro"}
     </div>
 
     {include file="CRM/Contribute/Form/SearchContribution.tpl"}

--- a/templates/CRM/Contribute/Page/ContributionSoft.tpl
+++ b/templates/CRM/Contribute/Page/ContributionSoft.tpl
@@ -29,12 +29,12 @@
     <table class="form-layout-compressed">
         <tr>
           {if $softCreditTotals.amount}
-            <th class="contriTotalLeft">{ts}Total Soft Credits{/ts} - {$softCreditTotals.amount|crmMoney:$softCreditTotals.currency}</th>
+            <th class="contriTotalLeft">{ts}Total Soft Credits{/ts} &ndash; {$softCreditTotals.amount|crmMoney:$softCreditTotals.currency}</th>
             <th class="right" width="10px"> &nbsp; </th>
-            <th class="right contriTotalRight"> &nbsp; {ts}Avg Soft Credits{/ts} - {$softCreditTotals.avg|crmMoney:$softCreditTotals.currency}</th>
+            <th class="right contriTotalRight"> &nbsp; {ts}Avg Soft Credits{/ts} &ndash; {$softCreditTotals.avg|crmMoney:$softCreditTotals.currency}</th>
           {/if}
           {if $softCreditTotals.cancelAmount}
-            <th class="right contriTotalRight"> &nbsp; {ts}Total Cancelled Soft Credits{/ts} - {$softCreditTotals.cancelAmount|crmMoney:$softCreditTotals.currency}</th>
+            <th class="right contriTotalRight"> &nbsp; {ts}Total Cancelled Soft Credits{/ts} &ndash; {$softCreditTotals.cancelAmount|crmMoney:$softCreditTotals.currency}</th>
           {/if}
         </tr>
     </table>

--- a/templates/CRM/Contribute/Page/ContributionTotals.tpl
+++ b/templates/CRM/Contribute/Page/ContributionTotals.tpl
@@ -29,9 +29,9 @@
 
     {if $annual.count}
         <tr>
-            <th class="contriTotalLeft right">{ts}Current Year-to-Date{/ts} - {$annual.amount}</th>
-            <th class="right"> &nbsp; {ts}# Completed Contributions{/ts} - {$annual.count}</th>
-            <th class="right contriTotalRight"> &nbsp; {ts}Avg Amount{/ts} - {$annual.avg}</th>
+            <th class="contriTotalLeft right">{ts}Current Year-to-Date{/ts} &ndash; {$annual.amount}</th>
+            <th class="right"> &nbsp; {ts}# Completed Contributions{/ts} &ndash; {$annual.count}</th>
+            <th class="right contriTotalRight"> &nbsp; {ts}Avg Amount{/ts} &ndash; {$annual.avg}</th>
             {if $contributionSummary.cancel.amount}
                 <td>&nbsp;</td>
             {/if}
@@ -42,29 +42,29 @@
       <tr>
           {if $contributionSummary.total.amount}
             {if $contributionSummary.total.currencyCount gt 1}
-              <th class="contriTotalLeft right">{ts}Total{/ts} - {$contributionSummary.total.amount}</th>
-              <th class="left contriTotalRight"> &nbsp; {ts}# Completed{/ts} - {$contributionSummary.total.count}</th>
+              <th class="contriTotalLeft right">{ts}Total{/ts} &ndash; {$contributionSummary.total.amount}</th>
+              <th class="left contriTotalRight"> &nbsp; {ts}# Completed{/ts} &ndash; {$contributionSummary.total.count}</th>
             </tr><tr>
-              <th class="contriTotalLeft">{ts}Avg{/ts} - {$contributionSummary.total.avg}</th>
-              <th class="right"> &nbsp; {ts}Median{/ts} - {$contributionSummary.total.median}</th>
-              <th class="right contriTotalRight"> &nbsp; {ts}Mode{/ts} - {$contributionSummary.total.mode}</th>
+              <th class="contriTotalLeft">{ts}Avg{/ts} &ndash; {$contributionSummary.total.avg}</th>
+              <th class="right"> &nbsp; {ts}Median{/ts} &ndash; {$contributionSummary.total.median}</th>
+              <th class="right contriTotalRight"> &nbsp; {ts}Mode{/ts} &ndash; {$contributionSummary.total.mode}</th>
             {else}
-              <th class="contriTotalLeft right">{ts}Total{/ts} - {$contributionSummary.total.amount}</th>
-              <th class="right"> &nbsp; {ts}# Completed{/ts} - {$contributionSummary.total.count}</th>
-              <th class="right"> &nbsp; {ts}Avg{/ts} - {$contributionSummary.total.avg}</th>
-              <th class="right"> &nbsp; {ts}Median{/ts} - {$contributionSummary.total.median}</th>
-              <th class="right contriTotalRight"> &nbsp; {ts}Mode{/ts} - {$contributionSummary.total.mode}</th>
+              <th class="contriTotalLeft right">{ts}Total{/ts} &ndash; {$contributionSummary.total.amount}</th>
+              <th class="right"> &nbsp; {ts}# Completed{/ts} &ndash; {$contributionSummary.total.count}</th>
+              <th class="right"> &nbsp; {ts}Avg{/ts} &ndash; {$contributionSummary.total.avg}</th>
+              <th class="right"> &nbsp; {ts}Median{/ts} &ndash; {$contributionSummary.total.median}</th>
+              <th class="right contriTotalRight"> &nbsp; {ts}Mode{/ts} &ndash; {$contributionSummary.total.mode}</th>
             {/if}
           {/if}
           {if $contributionSummary.cancel.amount}
-            <th class="disabled right contriTotalRight"> &nbsp; {ts}Total Cancelled Amount{/ts} - {$contributionSummary.cancel.amount}</th>
+            <th class="disabled right contriTotalRight"> &nbsp; {ts}Total Cancelled Amount{/ts} &ndash; {$contributionSummary.cancel.amount}</th>
           {/if}
       </tr>
       {if $contributionSummary.soft_credit.count}
       <tr>
-        <th class="contriTotalLeft right">{ts}Total Soft Credit Amount{/ts} - {$contributionSummary.soft_credit.amount}</th>
-        <th class="right"> &nbsp; {ts}# Completed Soft Credits{/ts} - {$contributionSummary.soft_credit.count}</th>
-        <th class="right contriTotalRight"> &nbsp; {ts}Avg Soft Credit Amount{/ts} - {$contributionSummary.soft_credit.avg}</th>
+        <th class="contriTotalLeft right">{ts}Total Soft Credit Amount{/ts} &ndash; {$contributionSummary.soft_credit.amount}</th>
+        <th class="right"> &nbsp; {ts}# Completed Soft Credits{/ts} &ndash; {$contributionSummary.soft_credit.count}</th>
+        <th class="right contriTotalRight"> &nbsp; {ts}Avg Soft Credit Amount{/ts} &ndash; {$contributionSummary.soft_credit.avg}</th>
       </tr>
       {/if}
     {/if}

--- a/templates/CRM/Price/Form/LineItem.tpl
+++ b/templates/CRM/Price/Form/LineItem.tpl
@@ -53,7 +53,7 @@
       </tr>
       {foreach from=$value item=line}
         <tr>
-          <td>{if $line.html_type eq 'Text'}{$line.label}{else}{$line.field_title} - {$line.label}{/if} {if $line.description}
+          <td>{if $line.field_title && $line.html_type neq 'Text'}{$line.field_title} &ndash; {$line.label}{else}{$line.label}{/if} {if $line.description}
               <div class="description">{$line.description}</div>{/if}</td>
           {if $context NEQ "Membership"}
             <td class="right">{$line.qty}</td>

--- a/templates/CRM/Price/Page/LineItem.tpl
+++ b/templates/CRM/Price/Page/LineItem.tpl
@@ -62,7 +62,7 @@
       </tr>
       {foreach from=$value item=line}
         <tr{if $line.qty EQ 0} class="cancelled"{/if}>
-          <td>{if $line.html_type eq 'Text'}{$line.label}{else}{$line.field_title} - {$line.label}{/if} {if $line.description}<div class="description">{$line.description}</div>{/if}</td>
+          <td>{if $line.field_title && $line.html_type neq 'Text'}{$line.field_title} &ndash; {$line.label}{else}{$line.label}{/if} {if $line.description}<div class="description">{$line.description}</div>{/if}</td>
           {if $displayLineItemFinancialType}
             <td>{$line.financial_type}</td>
           {/if}


### PR DESCRIPTION
And while I was at it, I fixed a bunch of hyphens that were being misused as en dashes.

Basically, the API will let you create line items that don't relate to a price field, but the page was assuming that all of them had one.  An unwrapped `civicrm_api3()` call was throwing an exception when viewing the contribution.

---

 * [CRM-20297: Fatal error viewing a contribution having a line item with no price field](https://issues.civicrm.org/jira/browse/CRM-20297)