### PR TITLE
CRM-20311 - Membership cancelation via contribution doesn't create me…

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -1731,7 +1731,7 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
               'source_contact_id' => CRM_Core_Session::singleton()->get('userID'),
               'target_contact_id' => $membership->contact_id,
               'source_record_id' => $membership->id,
-              'activity_type_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Change Membership Status'),
+              'activity_type_id' => 'Change Membership Status',
               'status_id' => 2,
               'priority_id' => 2,
               'activity_date_time' => date('Y-m-d H:i:s'),

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -1732,9 +1732,9 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
               'target_contact_id' => $membership->contact_id,
               'source_record_id' => $membership->id,
               'activity_type_id' => 'Change Membership Status',
-              'status_id' => 2,
-              'priority_id' => 2,
-              'activity_date_time' => date('Y-m-d H:i:s'),
+              'status_id' => 'Completed',
+              'priority_id' => 'Normal',
+              'activity_date_time' => 'now',
             );
 
             $membership->status_id = $newStatus;


### PR DESCRIPTION
…mbership status change activity

Proposed fix adds the activity bit of code to the deprecated function in CRM_Contribute_BAO_Contribution.
This isn't a great fix but given that the function is deprecated anyway, anything long term will depend on how this whole transition is handled in the future.