### PR TITLE
CRM-20327 - API chaining - replace $value when using operators.

### DIFF
--- a/CRM/Case/XMLProcessor/Process.php
+++ b/CRM/Case/XMLProcessor/Process.php
@@ -437,12 +437,7 @@ AND        a.is_deleted = 0
       $statusName = 'Scheduled';
     }
 
-    if ($this->_isMultiClient) {
-      $client = $params['clientID'];
-    }
-    else {
-      $client = array(1 => $params['clientID']);
-    }
+    $client = (array) $params['clientID'];
 
     //set order
     $orderVal = '';

--- a/api/v3/Case.php
+++ b/api/v3/Case.php
@@ -272,7 +272,7 @@ function civicrm_api3_case_get($params) {
 
   if (empty($options['is_count']) && !empty($cases['values'])) {
     // For historic reasons we return these by default only when fetching a case by id
-    if (!empty($params['id']) && empty($options['return'])) {
+    if (!empty($params['id']) && is_numeric($params['id']) && empty($options['return'])) {
       $options['return'] = array(
         'contacts' => 1,
         'activities' => 1,


### PR DESCRIPTION
* [CRM-20327: API chaining - replace $value when using operators.](https://issues.civicrm.org/jira/browse/CRM-20327)