### PR TITLE
Fixed CRM-20333: search menu visible even when a user does not has access to any contacts.

### DIFF
--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -477,17 +477,6 @@ ORDER BY parent_id, weight";
       return FALSE;
     }
 
-    //we need to check core view/edit or supported acls.
-    if (in_array($menuName, array(
-      'Search...',
-      'Contacts',
-    ))) {
-      if (!CRM_Core_Permission::giveMeAllACLs()) {
-        $skipMenuItems[] = $navID;
-        return FALSE;
-      }
-    }
-
     $config = CRM_Core_Config::singleton();
 
     $makeLink = FALSE;

--- a/templates/CRM/common/navigation.js.tpl
+++ b/templates/CRM/common/navigation.js.tpl
@@ -25,7 +25,6 @@
 *}// http://civicrm.org/licensing
 {capture assign=menuMarkup}{strip}
   <ul id="civicrm-menu">
-    {if call_user_func(array('CRM_Core_Permission','giveMeAllACLs'))}
       <li id="crm-qsearch" class="menumain">
         <form action="{crmURL p='civicrm/contact/search/advanced' h=0 }" name="search_block" id="id_search_block" method="post">
           <div id="quickSearch">
@@ -50,7 +49,6 @@
           <li><label class="crm-quickSearchField"><input type="radio" data-tablename="cc" value="job_title" name="quickSearchField"> {ts}Job Title{/ts}</label></li>
         </ul>
       </li>
-    {/if}
     {$navigation}
   </ul>
 {/strip}{/capture}// <script> Generated {$smarty.now|date_format:'%d %b %Y %H:%M:%S'}


### PR DESCRIPTION
See https://issues.civicrm.org/jira/browse/CRM-20333

This is a breakdown of the solution and refactor for issue CRM-19934

---

 * [CRM-19934: Performance improvement on civicrm_acl_contact_cache](https://issues.civicrm.org/jira/browse/CRM-19934)