### PR TITLE
CRM-20336: Failed contributions should be set as failed, not left as pending

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -1053,6 +1053,15 @@ LEFT JOIN  civicrm_line_item i ON ( i.contribution_id = c.id AND i.entity_table 
       'source_contact_id' => CRM_Core_Session::getLoggedInContactID() ? CRM_Core_Session::getLoggedInContactID() :
         $contactID,
     ));
+
+    // CRM-20336 Make sure that the contribution status is Failed, not Pending.
+    $contributionStatus = CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name');
+    $failed = array_search('Failed', $contributionStatus);
+
+    civicrm_api3('contribution', 'create', array(
+      'id' => $contributionID,
+      'contribution_status_id' => $failed,
+    ));
   }
 
   /**

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -1055,12 +1055,9 @@ LEFT JOIN  civicrm_line_item i ON ( i.contribution_id = c.id AND i.entity_table 
     ));
 
     // CRM-20336 Make sure that the contribution status is Failed, not Pending.
-    $contributionStatus = CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name');
-    $failed = array_search('Failed', $contributionStatus);
-
     civicrm_api3('contribution', 'create', array(
       'id' => $contributionID,
-      'contribution_status_id' => $failed,
+      'contribution_status_id' => 'Failed',
     ));
   }
 

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -231,7 +231,7 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
 
     $this->callAPISuccessGetCount('Contribution', array(
       'contact_id' => $this->_individualId,
-      'contribution_status_id' => $error ? 'Pending' : 'Completed',
+      'contribution_status_id' => $error ? 'Failed' : 'Completed',
       'payment_instrument_id' => $this->callAPISuccessGetValue('PaymentProcessor', array(
         'return' => 'payment_instrument_id',
         'id' => $paymentProcessorID,

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -378,7 +378,7 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
     catch (\Civi\Payment\Exception\PaymentProcessorException $e) {
       $this->callAPISuccessGetCount('Contribution', array(
         'contact_id' => $this->_individualId,
-        'contribution_status_id' => 'Pending',
+        'contribution_status_id' => 'Failed',
       ), 1);
       $lineItem = $this->callAPISuccessGetSingle('line_item', array());
       $this->assertEquals('50.00', $lineItem['unit_price']);

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -646,7 +646,7 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
     $this->callAPISuccess('contribution_page', 'submit', $submitParams);
     $contribution = $this->callAPISuccessGetSingle('contribution', array(
       'contribution_page_id' => $this->_ids['contribution_page'],
-      'contribution_status_id' => 2,
+      'contribution_status_id' => 'Failed',
     ));
 
     $this->callAPISuccessGetSingle('activity', array(


### PR DESCRIPTION
* [CRM-20336: Failed iATS contribution should be set to failed, not pending](https://issues.civicrm.org/jira/browse/CRM-20336)