### PR TITLE
CRM-20342: Fatal Error on View Membership

### DIFF
--- a/CRM/Contribute/BAO/Query.php
+++ b/CRM/Contribute/BAO/Query.php
@@ -959,7 +959,7 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
       )
     );
 
-    $form->addField('financial_trxn_card_type', array('entity' => 'FinancialTrxn', 'name' => 'card_type'));
+    $form->addSelect('financial_trxn_card_type', array('entity' => 'FinancialTrxn', 'name' => 'card_type', 'multiple' => TRUE));
 
     // CRM-16713 - contribution search by premiums on 'Find Contribution' form.
     $form->add('select', 'contribution_product_id',


### PR DESCRIPTION
addField() uses getApiEntity() to check the api and eventually breaks into the error on view page. Either we can extend those to support view action as below or proceed with this simple replacement PR.

    diff --git a/CRM/Core/Form.php b/CRM/Core/Form.php
    index 9969e6b894..ca76c918fd 100644
    --- a/CRM/Core/Form.php
    +++ b/CRM/Core/Form.php
    @@ -1245,7 +1245,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
         if ($action & (CRM_Core_Action::UPDATE + CRM_Core_Action::ADD)) {
           return 'create';
         }
    -    if ($action & (CRM_Core_Action::BROWSE + CRM_Core_Action::BASIC + CRM_Core_Action::ADVANCED + CRM_Core_Action::PREVIEW)) {
    +    if ($action & (CRM_Core_Action::VIEW + CRM_Core_Action::BROWSE + CRM_Core_Action::BASIC + CRM_Core_Action::ADVANCED + CRM_Core_Action::PREVIEW)) {
           return 'get';
         }
         // If you get this exception try adding more cases above.

---

 * [CRM-20342: Fatal Error on View Membership](https://issues.civicrm.org/jira/browse/CRM-20342)