### PR TITLE
CRM-20350: Don't escape double-quotes in icalendar.

### DIFF
--- a/CRM/Utils/ICalendar.php
+++ b/CRM/Utils/ICalendar.php
@@ -49,7 +49,6 @@ class CRM_Utils_ICalendar {
    */
   public static function formatText($text) {
     $text = strip_tags($text);
-    $text = str_replace("\"", "DQUOTE", $text);
     $text = str_replace("\\", "\\\\", $text);
     $text = str_replace(',', '\,', $text);
     $text = str_replace(';', '\;', $text);


### PR DESCRIPTION
* [CRM-20350: Incorrect escaping of double-quotes in iCalendar text values](https://issues.civicrm.org/jira/browse/CRM-20350)