### PR TITLE
Towards CRM-20328 remove another call to the duplicate code

### DIFF
--- a/CRM/Event/Form/Registration/AdditionalParticipant.php
+++ b/CRM/Event/Form/Registration/AdditionalParticipant.php
@@ -610,7 +610,7 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
 
     if (!$this->_allowConfirmation) {
       // check if the participant is already registered
-      $params['contact_id'] = CRM_Event_Form_Registration_Register::checkRegistration($params, $this, TRUE, TRUE);
+      $params['contact_id'] = CRM_Event_Form_Registration_Register::getRegistrationContactID($params, $this, TRUE);
     }
 
     //carry campaign to partcipants.

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -965,7 +965,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
     if (!$this->_allowConfirmation) {
       // check if the participant is already registered
       if (!$this->_skipDupeRegistrationCheck) {
-        $params['contact_id'] = self::checkRegistration($params, $this, FALSE, TRUE, TRUE);
+        $params['contact_id'] = self::getRegistrationContactID($params, $this, FALSE);
       }
     }
 
@@ -1176,29 +1176,19 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
    *   Event data.
    * @param bool $isAdditional
    *   Treat isAdditional participants a bit differently.
-   * @param bool $returnContactId
-   *   Just find and return the contactID match to use.
-   * @param bool $useDedupeRules
-   *   Force usage of dedupe rules.
    *
    * @return int
    */
-  public static function checkRegistration($fields, &$self, $isAdditional = FALSE, $returnContactId = FALSE, $useDedupeRules = FALSE) {
+  public static function checkRegistration($fields, &$self, $isAdditional = FALSE) {
     // CRM-3907, skip check for preview registrations
     // CRM-4320 participant need to walk wizard
-    if (!$returnContactId &&
+    if (
       ($self->_mode == 'test' || $self->_allowConfirmation)
     ) {
       return FALSE;
     }
 
     $contactID = self::getRegistrationContactID($fields, $self, $isAdditional);
-
-    if ($returnContactId) {
-      // CRM-7377
-      // return contactID if contact already exists
-      return $contactID;
-    }
 
     if ($contactID) {
       $participant = new CRM_Event_BAO_Participant();
@@ -1224,7 +1214,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
             }
 
             $status = ts("It looks like you are already registered for this event. If you want to change your registration, or you feel that you've received this message in error, please contact the site administrator.") . ' ' . ts('You can also <a href="%1">register another participant</a>.', array(1 => $registerUrl));
-            $session->setStatus($status, ts('Oops.'), 'alert');
+            CRM_Core_Session::singleton()->setStatus($status, ts('Oops.'), 'alert');
             $url = CRM_Utils_System::url('civicrm/event/info',
               "reset=1&id={$self->_values['event']['id']}&noFullMsg=true"
             );
@@ -1241,7 +1231,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
 
           if ($isAdditional) {
             $status = ts("It looks like this participant is already registered for this event. If you want to change your registration, or you feel that you've received this message in error, please contact the site administrator.");
-            $session->setStatus($status, ts('Oops.'), 'alert');
+            CRM_Core_Session::singleton()->setStatus($status, ts('Oops.'), 'alert');
             return $participant->id;
           }
         }

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -95,21 +95,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       $contactID = $self->getContactID();
     }
     if (!$contactID && is_array($fields) && $fields) {
-
-      //CRM-14134 use Unsupervised rule for everyone
-      $dedupeParams = CRM_Dedupe_Finder::formatParams($fields, 'Individual');
-
-      // disable permission based on cache since event registration is public page/feature.
-      $dedupeParams['check_permission'] = FALSE;
-
-      // find event dedupe rule
-      if (CRM_Utils_Array::value('dedupe_rule_group_id', $self->_values['event'], 0) > 0) {
-        $ids = CRM_Dedupe_Finder::dupesByParams($dedupeParams, 'Individual', 'Unsupervised', array(), $self->_values['event']['dedupe_rule_group_id']);
-      }
-      else {
-        $ids = CRM_Dedupe_Finder::dupesByParams($dedupeParams, 'Individual', 'Unsupervised');
-      }
-      $contactID = CRM_Utils_Array::value(0, $ids);
+      $contactID = CRM_Contact_BAO_Contact::getFirstDuplicateContact($fields, 'Individual', 'Unsupervised', array(), FALSE, CRM_Utils_Array::value('dedupe_rule_group_id', $self->_values['event']));
     }
     return $contactID;
   }


### PR DESCRIPTION
@aydun - this is another instance. I did slightly more tidy up because the code was a bit weird - ie. calling a checkRegistration function purely to access one part of the function, and one parameter was unused. Tidy up could go further .. as always

---

 * [CRM-20155: The dedupe code passes has serious maintainability issues, locked in by hooks](https://issues.civicrm.org/jira/browse/CRM-20155)

---

 * [CRM-20328: Remove code duplication when calling Dedupe functions](https://issues.civicrm.org/jira/browse/CRM-20328)