### PR TITLE
CRM-20353 move finder functions to finder class

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -603,7 +603,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
   public static function batchMerge($rgid, $gid = NULL, $mode = 'safe', $batchLimit = 1, $isSelected = 2, $criteria = array(), $checkPermissions = TRUE) {
     $redirectForPerformance = ($batchLimit > 1) ? TRUE : FALSE;
     $reloadCacheIfEmpty = (!$redirectForPerformance && $isSelected == 2);
-    $dupePairs = self::getDuplicatePairs($rgid, $gid, $reloadCacheIfEmpty, $batchLimit, $isSelected, '', ($mode == 'aggressive'), $criteria, $checkPermissions);
+    $dupePairs = CRM_Dedupe_Finder::getDuplicatePairs($rgid, $gid, $reloadCacheIfEmpty, $batchLimit, $isSelected, '', ($mode == 'aggressive'), $criteria, $checkPermissions);
 
     $cacheParams = array(
       'cache_key_string' => self::getMergeCacheKeyString($rgid, $gid, $criteria, $checkPermissions),
@@ -1861,41 +1861,6 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
         'status_id' => 'Completed',
       ));
     }
-  }
-
-  /**
-   * Get Duplicate Pairs based on a rule for a group.
-   *
-   * @param int $rule_group_id
-   * @param int $group_id
-   * @param bool $reloadCacheIfEmpty
-   * @param int $batchLimit
-   * @param bool $isSelected
-   * @param array|string $orderByClause
-   * @param bool $includeConflicts
-   * @param array $criteria
-   *   Additional criteria to narrow down the merge group.
-   *
-   * @param bool $checkPermissions
-   *   Respect logged in user permissions.
-   *
-   * @return array
-   *    Array of matches meeting the criteria.
-   */
-  public static function getDuplicatePairs($rule_group_id, $group_id, $reloadCacheIfEmpty, $batchLimit, $isSelected, $orderByClause = '', $includeConflicts = TRUE, $criteria = array(), $checkPermissions = TRUE) {
-    $where = self::getWhereString($batchLimit, $isSelected);
-    $cacheKeyString = self::getMergeCacheKeyString($rule_group_id, $group_id, $criteria, $checkPermissions);
-    $join = self::getJoinOnDedupeTable();
-    $dupePairs = CRM_Core_BAO_PrevNextCache::retrieve($cacheKeyString, $join, $where, 0, 0, array(), $orderByClause, $includeConflicts);
-    if (empty($dupePairs) && $reloadCacheIfEmpty) {
-      // If we haven't found any dupes, probably cache is empty.
-      // Try filling cache and give another try. We don't need to specify include conflicts here are there will not be any
-      // until we have done some processing.
-      CRM_Core_BAO_PrevNextCache::refillCache($rule_group_id, $group_id, $cacheKeyString, $criteria, $checkPermissions);
-      $dupePairs = CRM_Core_BAO_PrevNextCache::retrieve($cacheKeyString, $join, $where, 0, 0, array(), $orderByClause, $includeConflicts);
-      return $dupePairs;
-    }
-    return $dupePairs;
   }
 
   /**

--- a/tests/phpunit/CRM/Dedupe/MergerTest.php
+++ b/tests/phpunit/CRM/Dedupe/MergerTest.php
@@ -274,7 +274,7 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
    */
   public function testGetMatches() {
     $this->setupMatchData();
-    $pairs = CRM_Dedupe_Merger::getDuplicatePairs(
+    $pairs = CRM_Dedupe_Finder::getDuplicatePairs(
       1,
       NULL,
       TRUE,
@@ -311,7 +311,7 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
     $this->setupMatchData();
     $ruleGroups = $this->callAPISuccessGetSingle('RuleGroup', array('contact_type' => 'Organization', 'used' => 'Supervised'));
 
-    $pairs = CRM_Dedupe_Merger::getDuplicatePairs(
+    $pairs = CRM_Dedupe_Finder::getDuplicatePairs(
       $ruleGroups['id'],
       NULL,
       TRUE,
@@ -385,7 +385,7 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
 
     $this->callAPISuccess('GroupContact', 'create', array('group_id' => $groupID, 'contact_id' => $this->contacts[4]['id']));
 
-    $pairs = CRM_Dedupe_Merger::getDuplicatePairs(
+    $pairs = CRM_Dedupe_Finder::getDuplicatePairs(
       $ruleGroups['id'],
       $groupID,
       TRUE,
@@ -414,7 +414,7 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
 
     $this->callAPISuccess('GroupContact', 'create', array('group_id' => $groupID, 'contact_id' => $this->contacts[5]['id']));
     CRM_Core_DAO::executeQuery("DELETE FROM civicrm_prevnext_cache");
-    $pairs = CRM_Dedupe_Merger::getDuplicatePairs(
+    $pairs = CRM_Dedupe_Finder::getDuplicatePairs(
       $ruleGroups['id'],
       $groupID,
       TRUE,
@@ -463,7 +463,7 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
 
     $this->callAPISuccess('GroupContact', 'create', array('group_id' => $groupID, 'contact_id' => $this->contacts[3]['id']));
 
-    $pairs = CRM_Dedupe_Merger::getDuplicatePairs(
+    $pairs = CRM_Dedupe_Finder::getDuplicatePairs(
       1,
       $groupID,
       TRUE,


### PR DESCRIPTION
* [CRM-20353: Move functions that belong to dedupe finding to Dedupe_Finder class](https://issues.civicrm.org/jira/browse/CRM-20353)