### PR TITLE
CRM-19385 revert changes to order by id on prevnext_cache.

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -4788,9 +4788,11 @@ civicrm_relationship.is_permission_a_b = 0
     $onlyDeleted = in_array(array('deleted_contacts', '=', '1', '0', '0'), $this->_params);
     list($select, $from, $where) = $this->query(FALSE, FALSE, FALSE, $onlyDeleted);
     $from = " FROM civicrm_prevnext_cache pnc INNER JOIN civicrm_contact contact_a ON contact_a.id = pnc.entity_id1 AND pnc.cacheKey = '$cacheKey' " . substr($from, 31);
-    $groupBy = self::getGroupByFromSelectColumns($this->_select, array('contact_a.id'));
+    $order = " ORDER BY pnc.id";
+    $groupByCol = array('contact_a.id', 'pnc.id');
+    $groupBy = self::getGroupByFromSelectColumns($this->_select, $groupByCol);
     $limit = " LIMIT $offset, $rowCount";
-    $query = "$select $from $where $groupBy $limit";
+    $query = "$select $from $where $groupBy $order $limit";
 
     return CRM_Core_DAO::executeQuery($query);
   }

--- a/CRM/Core/BAO/PrevNextCache.php
+++ b/CRM/Core/BAO/PrevNextCache.php
@@ -506,6 +506,7 @@ SELECT entity_id1, entity_id2 FROM civicrm_prevnext_cache
 WHERE cacheKey LIKE %1
       $actionGet
       $entity_whereClause
+ORDER BY id
 ";
       $params[1] = array("{$cacheKey}%", 'String');
 


### PR DESCRIPTION
After PR #10019 was merged @bhahumanists reported on #9801 that smart group ordering was broken. The
report is lacking detail and I could not replicate it, but am reverting the search changes for safety.

After this revert sites can still experiment with dropping/altering the primary key on
-civicrm_cache
-civicrm_group_contact_cache
-civicrm_acl_cache

But not civicrm_prevnext_cache.

Although I could not replicate the search issue it seems to me that our Ubuntu test suite
is failing where the other one is not on search-related items, suggesting that
for some reason Ubuntu does not default to the natural search order, due to
some config or other difference

---

 * [CRM-19385: Look at REMOVING id column from cache tables](https://issues.civicrm.org/jira/browse/CRM-19385)