### PR TITLE
CRM-20383: Get priceset only if set_id is available

### DIFF
--- a/CRM/Contribute/Form/ContributionView.php
+++ b/CRM/Contribute/Form/ContributionView.php
@@ -155,8 +155,10 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
     if ($id) {
       $lineItems = array(CRM_Price_BAO_LineItem::getLineItemsByContributionID(($id)));
       $firstLineItem = reset($lineItems[0]);
-      $priceSet = civicrm_api3('PriceSet', 'getsingle', array('id' => $firstLineItem['price_set_id'], 'return' => 'is_quick_config, id'));
-      $displayLineItems = !$priceSet['is_quick_config'];
+      if (!empty($firstLineItem['price_set_id'])) {
+        $priceSet = civicrm_api3('PriceSet', 'getsingle', array('id' => $firstLineItem['price_set_id'], 'return' => 'is_quick_config, id'));
+        $displayLineItems = !$priceSet['is_quick_config'];
+      }
     }
     $this->assign('lineItem', $lineItems);
     $this->assign('displayLineItems', $displayLineItems);


### PR DESCRIPTION
Contributions coming from webform configured amount are not attached to any priceset. Hence viewing them results into error. 

Added an empty check so that if `$firstLineItem['price_set_id']` is NULL in any case doesn't throw an exception as `getsingle` would expect only one result to be returned.

---

 * [CRM-20383: View Contribution throws Exception when payed via webform](https://issues.civicrm.org/jira/browse/CRM-20383)