### PR TITLE
CRM-16633 - Allow user to change case subject

### DIFF
--- a/CRM/Upgrade/Incremental/php/FourSeven.php
+++ b/CRM/Upgrade/Incremental/php/FourSeven.php
@@ -340,6 +340,7 @@ class CRM_Upgrade_Incremental_php_FourSeven extends CRM_Upgrade_Incremental_Base
       'civicrm_sms_provider', 'domain_id', 'int(10) unsigned', "Which Domain is this sms provier for");
     $this->addTask('CRM-19961 - Populate domain id table and perhaps add foreign key', 'populateSMSProviderDomainId');
     $this->addTask(ts('Upgrade DB to %1: SQL', array(1 => $rev)), 'runSql', $rev);
+    $this->addTask('CRM-16633 - Add "Change Case Subject" activity', 'addChangeCaseSubjectActivityType');
     $this->addTask('Add is_public column to civicrm_custom_group', 'addColumn',
       'civicrm_custom_group', 'is_public', "boolean DEFAULT '1' COMMENT 'Is this property public?'");
   }
@@ -1088,6 +1089,25 @@ FROM `civicrm_dashboard_contact` JOIN `civicrm_contact` WHERE civicrm_dashboard_
       ON DELETE SET NULL");
 
     CRM_Core_DAO::executeQuery("SET FOREIGN_KEY_CHECKS = 1;");
+    return TRUE;
+  }
+
+  /**
+   * CRM-16633 - Add activity type for Change Case Status
+   *
+   * @param \CRM_Queue_TaskContext $ctx
+   *
+   * @return bool
+   */
+  public static function addChangeCaseSubjectActivityType(CRM_Queue_TaskContext $ctx) {
+    CRM_Core_BAO_OptionValue::ensureOptionValueExists(array(
+      'option_group_id' => 'activity_type',
+      'name' => 'Change Case Subject',
+      'label' => ts('Change Case Subject'),
+      'is_active' => TRUE,
+      'component_id' => 'CiviCase',
+      'icon' => 'fa-pencil-square-o',
+    ));
     return TRUE;
   }
 

--- a/js/Common.js
+++ b/js/Common.js
@@ -243,10 +243,13 @@ if (!CRM.vars) CRM.vars = {};
       var script = document.createElement('script');
       scriptsLoaded[url] = $.Deferred();
       script.onload = function () {
-        if (window.jQuery === CRM.$ && CRM.CMSjQuery) {
-          window.jQuery = CRM.CMSjQuery;
-        }
-        scriptsLoaded[url].resolve();
+        // Give the script time to execute
+        window.setTimeout(function () {
+          if (window.jQuery === CRM.$ && CRM.CMSjQuery) {
+            window.jQuery = CRM.CMSjQuery;
+          }
+          scriptsLoaded[url].resolve();
+        }, 100);
       };
       // Make jQuery global available while script is loading
       if (window.jQuery !== CRM.$) {

--- a/js/jquery/jquery.crmEditable.js
+++ b/js/jquery/jquery.crmEditable.js
@@ -159,7 +159,7 @@
               var options = optionsCache[$el.data('optionsHashKey')];
               value = options && options[value] ? options[value] : '';
             }
-            $el.trigger('crmFormSuccess');
+            $el.trigger('crmFormSuccess', [value]);
             editableSettings.success.call($el[0], info.entity, info.field, value, data, settings);
           })
           .fail(function(data) {

--- a/templates/CRM/Case/Form/CaseView.js
+++ b/templates/CRM/Case/Form/CaseView.js
@@ -206,6 +206,18 @@
           $(this).select2('val', '');
         }
       })
+      // When changing case subject, record an activity
+      .on('crmFormSuccess', '[data-field=subject]', function(e, value) {
+        var id = caseId();
+        CRM.api3('Activity', 'create', {
+          case_id: id,
+          activity_type_id: 'Change Case Subject',
+          subject: value,
+          status_id: 'Completed'
+        }).done(function() {
+          $('#case_id_' + id).dataTable().api().draw();
+        });
+      })
       .on('click', 'a.case-miniform', function(e) {
         var dialog,
           $el = $(this),

--- a/templates/CRM/Case/Form/CaseView.tpl
+++ b/templates/CRM/Case/Form/CaseView.tpl
@@ -80,7 +80,7 @@
         </td>
       {/if}
       <td class="crm-case-caseview-case_subject label">
-        <span class="crm-case-summary-label">{ts}Subject{/ts}:</span>&nbsp;{$caseDetails.case_subject}
+        <span class="crm-case-summary-label">{ts}Subject{/ts}:</span>&nbsp;<span class="crm-editable" data-field="subject">{$caseDetails.case_subject}</span>
       </td>
       <td class="crm-case-caseview-case_type label">
         <span class="crm-case-summary-label">{ts}Type{/ts}:</span>&nbsp;{$caseDetails.case_type}&nbsp;<a class="crm-hover-button crm-popup"  href="{crmURL p='civicrm/case/activity' q="action=add&reset=1&cid=`$contactId`&caseid=`$caseId`&selectedChild=activity&atype=`$changeCaseTypeId`"}" title="{ts}Change case type (creates activity record){/ts}"><i class="crm-i fa-pencil"></i></a>
@@ -325,3 +325,31 @@
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 {/if} {* view related cases if end *}
 </div>
+{literal}
+<style type="text/css">
+  .crm-case-caseview-case_subject span.crm-editable {
+    padding-right: 32px;
+    position: relative;
+  }
+  .crm-case-caseview-case_subject span.crm-editable:before {
+    position: absolute;
+    font-family: 'FontAwesome';
+    top: 0;
+    right: 10px;
+    content: "\f040";
+    opacity: 0.7;
+    color: #000;
+    font-size: .92em;
+  }
+  .crm-case-caseview-case_subject span.crm-editable-editing {
+    padding-right: 0;
+  }
+  .crm-case-caseview-case_subject span.crm-editable-editing form > input {
+    min-width: 20em;
+    padding: 3px;
+  }
+  .crm-case-caseview-case_subject span.crm-editable-editing:before {
+    content: "";
+  }
+</style>
+{/literal}

--- a/xml/templates/civicrm_data.tpl
+++ b/xml/templates/civicrm_data.tpl
@@ -327,6 +327,8 @@ VALUES
    (@option_group_id_act, '{ts escape="sql"}Follow up{/ts}',          14, 'Follow up',          NULL, 0,  0, 14, '', 0, 1, 1, @caseCompId, NULL, 'fa-share-square-o'),
    (@option_group_id_act, '{ts escape="sql"}Change Case Type{/ts}',   15, 'Change Case Type',   NULL, 0,  0, 15, '', 0, 1, 1, @caseCompId, NULL, 'fa-random'),
    (@option_group_id_act, '{ts escape="sql"}Change Case Status{/ts}', 16, 'Change Case Status', NULL, 0,  0, 16, '', 0, 1, 1, @caseCompId, NULL, 'fa-pencil-square-o'),
+   (@option_group_id_act, '{ts escape="sql"}Change Case Subject{/ts}',53, 'Change Case Subject',NULL, 0,  0, 53, '', 0, 1, 1, @caseCompId, NULL, 'fa-pencil-square-o'),
+   (@option_group_id_act, '{ts escape="sql"}Change Custom Data{/ts}', 33, 'Change Custom Data', NULL, 0,  0, 33, '', 0, 1, 1, @caseCompId, NULL, 'fa-table'),
 
    (@option_group_id_act, '{ts escape="sql"}Membership Renewal Reminder{/ts}',        17, 'Membership Renewal Reminder',  NULL, 1, NULL, 17, '{ts escape="sql"}offline membership renewal reminder.{/ts}',                      0, 1, 1, @memberCompId, NULL, NULL),
    (@option_group_id_act, '{ts escape="sql"}Change Case Start Date{/ts}',             18, 'Change Case Start Date',         NULL, 0,  0, 18, '', 0, 1, 1, @caseCompId, NULL , 'fa-calendar'),
@@ -345,11 +347,8 @@ VALUES
    (@option_group_id_act, '{ts escape="sql"}Canvass{/ts}',                            29, 'Canvass', NULL,0, 0, 28, '', 0, 1, 1, @campaignCompId, NULL, NULL),
    (@option_group_id_act, '{ts escape="sql"}PhoneBank{/ts}',                          30, 'PhoneBank', NULL,0, 0, 29, '', 0, 1, 1, @campaignCompId, NULL, NULL),
    (@option_group_id_act, '{ts escape="sql"}WalkList{/ts}',                           31, 'WalkList', NULL,0, 0, 30, '', 0, 1, 1, @campaignCompId, NULL, NULL),
-   (@option_group_id_act, '{ts escape="sql"}Petition Signature{/ts}',                           32, 'Petition', NULL,0, 0, 31, '', 0, 1, 1, @campaignCompId, NULL, NULL),
+   (@option_group_id_act, '{ts escape="sql"}Petition Signature{/ts}',                 32, 'Petition', NULL,0, 0, 31, '', 0, 1, 1, @campaignCompId, NULL, NULL),
    (@option_group_id_act, '{ts escape="sql"}Mass SMS{/ts}',                           34, 'Mass SMS',         NULL, 1, NULL, 34, '{ts escape="sql"}Mass SMS{/ts}',                                                    0, 1, 1, NULL, NULL, NULL),
-
--- Activity Types for CiviCampaign CiviCase
-   (@option_group_id_act, '{ts escape="sql"}Change Custom Data{/ts}',                 33, 'Change Custom Data', NULL,0, 0, 33, '', 0, 1, 1, @caseCompId, NULL, 'fa-table'),
 
 -- Additional Membership-related Activity Types
    (@option_group_id_act, '{ts escape="sql"}Change Membership Status{/ts}',           35, 'Change Membership Status',   NULL, 1, NULL, 35, '{ts escape="sql"}Change Membership Status.{/ts}',                         0, 1, 1, @memberCompId, NULL, NULL),
@@ -386,7 +385,7 @@ VALUES
    (@option_group_id_act, '{ts escape="sql"}Contact Deleted by Merge{/ts}', 52, 'Contact Deleted by Merge', NULL, 1, NULL, 52, '{ts escape="sql"}Contact was merged into another contact{/ts}',0, 1, 1, NULL, NULL, NULL),
 
   -- Activity Type for failed payment
-   (@option_group_id_act, 'Failed Payment', 53, 'Failed Payment', NULL, 1, 0, 53, 'Failed Payment', 0, 1, 1, @contributeCompId, NULL, NULL),
+   (@option_group_id_act, 'Failed Payment', 54, 'Failed Payment', NULL, 1, 0, 54, 'Failed Payment', 0, 1, 1, @contributeCompId, NULL, NULL),
 
    (@option_group_id_gender, '{ts escape="sql"}Female{/ts}', 1, 'Female', NULL, 0, NULL, 1, NULL, 0, 0, 1, NULL, NULL, NULL),
    (@option_group_id_gender, '{ts escape="sql"}Male{/ts}',   2, 'Male',   NULL, 0, NULL, 2, NULL, 0, 0, 1, NULL, NULL, NULL),


### PR DESCRIPTION
This allows the user to edit the case subject in-place, while creating an "Change Case Subject" activity record in the background.
![changecasesubject](https://cloud.githubusercontent.com/assets/2874912/24769447/9312da3e-1ad4-11e7-81ef-4c4a5f465a8c.png)


* [CRM-16633: Case Subject not Editable](https://issues.civicrm.org/jira/browse/CRM-16633)