### PR TITLE
CRM-19773: unit test to check getLocationEvent invokes selectWhereClause() hook

### DIFF
--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3784,4 +3784,16 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
   public function aclWhereHookNoResults($type, &$tables, &$whereTables, &$contactID, &$where) {
   }
 
+  /**
+   * @implements CRM_Utils_Hook::selectWhereClause
+   *
+   * @param string $entity
+   * @param array $clauses
+   */
+  public function selectWhereClauseHook($entity, &$clauses) {
+    if ($entity == 'Event') {
+      $clauses['event_type_id'][] = "IN (2, 3, 4)";
+    }
+  }
+
 }

--- a/tests/phpunit/api/v3/EventTest.php
+++ b/tests/phpunit/api/v3/EventTest.php
@@ -119,6 +119,32 @@ class api_v3_EventTest extends CiviUnitTestCase {
     $this->assertEquals($result['values'][$this->_eventIds[1]]['event_title'], 'Annual CiviCRM meet 2');
   }
 
+  /**
+   * Test getLocationEvents() function invokes selectWhereClause() hook
+   */
+  public function testGetEventWithPermissionHook() {
+    $address = $this->callAPISuccess('address', 'create', array(
+      'contact_id' => 'null',
+      'location_type_id' => 1,
+      'street_address' => '1234567',
+    ));
+    $params = array(
+      'address_id' => $address['id'],
+    );
+    $result = $this->callAPISuccess('loc_block', 'create', $params);
+    $params = array(
+      'id' => $this->_events[1]['id'],
+      'loc_block_id' => $result['id'],
+    );
+    $this->callAPISuccess('Event', 'create', $params);
+    $result = CRM_Event_BAO_Event::getLocationEvents();
+    $this->assertEquals(1, count($result));
+
+    $this->hookClass->setHook('civicrm_selectWhereClause', array($this, 'selectWhereClauseHook'));
+    $result = CRM_Event_BAO_Event::getLocationEvents();
+    $this->assertEquals(0, count($result));
+  }
+
   public function testGetEventByEventTitle() {
 
     $params = array(


### PR DESCRIPTION
This won't pass the build until https://github.com/civicrm/civicrm-core/pull/9544 is merged.

---

 * [CRM-19773: Call hook_civicrm_selectWhereClause from the BAOs](https://issues.civicrm.org/jira/browse/CRM-19773)