### PR TITLE
CRM-20389 ignore mailing_type when cloning

### DIFF
--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -194,6 +194,7 @@ function civicrm_api3_mailing_clone($params) {
     'approval_note',
     'is_archived',
     'hash',
+    'mailing_type',
   );
 
   $get = civicrm_api3('Mailing', 'getsingle', array('id' => $params['id']));


### PR DESCRIPTION
A clone mailing is always of type standalone, even if the original mailing was an experiment or a winner. This patch adds `mailing_type` to the list of ignored parameters during cloning, so that the default standalone type is set, as it should be.

---

 * [CRM-20389: Cloned experiment or winner mailing should have type standalone](https://issues.civicrm.org/jira/browse/CRM-20389)