### PR TITLE
CRM-20367 - Allow addIndex $column to be an array

### DIFF
--- a/CRM/Upgrade/Incremental/Base.php
+++ b/CRM/Upgrade/Incremental/Base.php
@@ -170,11 +170,11 @@ class CRM_Upgrade_Incremental_Base {
    *
    * @param CRM_Queue_TaskContext $ctx
    * @param string $table
-   * @param string $column
+   * @param string|array $column
    * @return bool
    */
   public static function addIndex($ctx, $table, $column) {
-    $tables = array($table => array($column));
+    $tables = array($table => (array) $column);
     CRM_Core_BAO_SchemaHandler::createIndexes($tables);
 
     return TRUE;


### PR DESCRIPTION
* [CRM-20367: Add wrapper function for adding and dropping Index in Upgrader](https://issues.civicrm.org/jira/browse/CRM-20367)