### PR TITLE
CRM-20404: Add YAML support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     "symfony/event-dispatcher": "~2.5.0",
     "symfony/filesystem": "~2.5.0",
     "symfony/process": "~2.5.0",
+    "symfony/yaml": "~2.5.0",
     "psr/log": "1.0.0",
     "symfony/finder": "~2.5.0",
     "tecnickcom/tcpdf" : "6.2.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "36ffd76fc5e7344ac6e587d11779ceeb",
+    "content-hash": "c5b3ba428ad16aad6bf09e258cf0e950",
     "packages": [
         {
             "name": "civicrm/civicrm-cxn-rpc",
@@ -905,6 +905,53 @@
             "description": "Symfony Process Component",
             "homepage": "http://symfony.com",
             "time": "2015-02-08T07:07:45+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v2.5.12",
+            "target-dir": "Symfony/Component/Yaml",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Yaml.git",
+                "reference": "6eb40abc613d80828d55a40811c7a3ca491bc926"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Yaml/zipball/6eb40abc613d80828d55a40811c7a3ca491bc926",
+                "reference": "6eb40abc613d80828d55a40811c7a3ca491bc926",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Yaml\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "http://symfony.com",
+            "time": "2015-01-25T04:37:39+00:00"
         },
         {
             "name": "tecnickcom/tcpdf",


### PR DESCRIPTION
Since CiviCRM now allows registering of services in the container using the hook_civicrm_container, I would like to allow loading of a YAML service definition file.

As it stands the existing dependencies allow using XML, PHP or ini file loaders. Since YAML is the default Symfony method for service definitions, I think we should at least offer the possibility of using it, and then debate on which method to push for in a best practices section.

I've used version ~2.5.0 just to keep it in sync with the other Symfony components.

---

 * [CRM-20404: Add YAML support](https://issues.civicrm.org/jira/browse/CRM-20404)