### PR TITLE
CRM-19813 - Only dispatch through EventDispatcher after booting

### DIFF
--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -156,7 +156,7 @@ abstract class CRM_Utils_Hook {
     &$arg1, &$arg2, &$arg3, &$arg4, &$arg5, &$arg6,
     $fnSuffix
   ) {
-    if (is_array($names) && !defined('CIVICRM_FORCE_LEGACY_HOOK')) {
+    if (is_array($names) && !defined('CIVICRM_FORCE_LEGACY_HOOK') && \Civi\Core\Container::isContainerBooted()) {
       $event = \Civi\Core\Event\GenericHookEvent::createOrdered(
         $names,
         array(&$arg1, &$arg2, &$arg3, &$arg4, &$arg5, &$arg6)
@@ -1821,6 +1821,9 @@ abstract class CRM_Utils_Hook {
   /**
    * This hook is called for declaring managed entities via API.
    *
+   * Note: This is a preboot hook. It will dispatch via the extension/module
+   * subsystem but *not* the Symfony EventDispatcher.
+   *
    * @param array[] $entityTypes
    *   List of entity types; each entity-type is an array with keys:
    *   - name: string, a unique short name (e.g. "ReportInstance")
@@ -2133,14 +2136,14 @@ abstract class CRM_Utils_Hook {
    * flush the cache. Additionally, you should relax caching during development.
    * In `civicrm.settings.php`, set define('CIVICRM_CONTAINER_CACHE', 'auto').
    *
+   * Note: This is a preboot hook. It will dispatch via the extension/module
+   * subsystem but *not* the Symfony EventDispatcher.
+   *
    * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
    * @see http://symfony.com/doc/current/components/dependency_injection/index.html
    */
   public static function container(\Symfony\Component\DependencyInjection\ContainerBuilder $container) {
-    // This hook fires during system bootstrap, after CRM_Extension_System
-    // initializes but before the container or dispatcher initialize. Therefore,
-    // we cannot use containerized services (like the dispatcher).
-    self::singleton()->invokeViaUF(1, $container, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_container');
+    self::singleton()->invoke(array('container'), $container, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_container');
   }
 
   /**

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -398,4 +398,13 @@ class Container {
     return \Civi::$statics[__CLASS__]['boot'][$name];
   }
 
+  /**
+   * Determine whether the container services are available.
+   *
+   * @return bool
+   */
+  public static function isContainerBooted() {
+    return isset(\Civi::$statics[__CLASS__]['container']);
+  }
+
 }


### PR DESCRIPTION
After merging #9949, some screens (like the contact-result list or "View
Contact") reported warnings like:

```
Notice: Undefined index: in CRM_Core_BAO_Country::countryLimit() (line 90 of /home/foo/buildkit/build/dmaster/sites/all/modules/civicrm/CRM/Core/BAO/Country.php).
Notice: Undefined index: in CRM_Core_BAO_Country::provinceLimit() (line 62 of /home/foo/buildkit/build/dmaster/sites/all/modules/civicrm/CRM/Core/BAO/Country.php).
```

Bisecting the git history revealed that it stemmed from switching
`hook_civicrm_entityTypes` to go through EventDispatcher.

https://github.com/civicrm/civicrm-core/pull/9949/commits/fb1d9ad2f5116245ba3488a26f8e0b065f328006#diff-8869a8f3c6318eb0580ce2aa04b713bfL1835

This hook is apparently similar to `hook_civicrm_container` in that both
fire pre-boot.  If we attempt to dispatch it through the container in a
pre-boot environment, something initializes incorrectly.

This change proposes a general rule:
 * If you fire a hook before the container or EventDispatcher is available...
 * Then don't try to use the container or EventDispatcher.

---

 * [CRM-19813: Hook priorities and core hooks to support LExIM](https://issues.civicrm.org/jira/browse/CRM-19813)