### PR TITLE
CRM-20415 hacky workaround for our particular use case.

### DIFF
--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -435,6 +435,10 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
                   $name = "`$locationTypeName-$fieldName`";
                 }
               }
+              else if ($fieldName == 'postal_code') {
+                // HACK. Try to work around CRM-20415.
+                $name = "`$fieldName`";
+              }
               else {
                 $name = "`$locationTypeName-$fieldName`";
               }

--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -435,7 +435,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
                   $name = "`$locationTypeName-$fieldName`";
                 }
               }
-              else if ($fieldName == 'postal_code') {
+              elseif ($fieldName == 'postal_code') {
                 // HACK. Try to work around CRM-20415.
                 $name = "`$fieldName`";
               }


### PR DESCRIPTION
I was able to work around the issue for our specific use case:
printing mailing labels for search results sorted by
postal code, with default contact search profile enabled.

Because I don't have a clue about the purpose of the function
I changed, I only hack around the issue for the specific case
`$fieldName == 'postal_code'`.

So if this hack breaks something else (which it will probably do), 
it will only be broken for postal codes.

I don't recommend merging this pull request yet. But I created it anyway,
so that I can share my workaround, and I can see whether the unit tests
will still pass.

---

 * [CRM-20415: Issue with mailing labels with default contact search profile](https://issues.civicrm.org/jira/browse/CRM-20415)