### PR TITLE
CRM-20413 fix to setting wrong payment_instrument_id, by passing resp…

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2330,7 +2330,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       $ids
     ));
 
-    if (!$paymentProcessorID && $this->contribution_page_id) {
+    if (!isset($input['payment_processor_id']) && !$paymentProcessorID && $this->contribution_page_id) {
       $paymentProcessorID = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_ContributionPage',
         $this->contribution_page_id,
         'payment_processor'

--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -209,7 +209,7 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
       return;
     }
 
-    CRM_Core_Payment_Form::buildPaymentForm($this, $this->_paymentProcessor, FALSE, TRUE);
+    CRM_Core_Payment_Form::buildPaymentForm($this, $this->_paymentProcessor, FALSE, TRUE, CRM_Utils_Request::retrieve('payment_instrument_id', 'Integer'));
     $attributes = CRM_Core_DAO::getAttribute('CRM_Financial_DAO_FinancialTrxn');
 
     $this->add('select', 'payment_processor_id', ts('Payment Processor'), $this->_processors, NULL);

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -188,6 +188,23 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
   public $_isBillingAddressRequiredForPayLater;
 
   /**
+   * Is this a backoffice form
+   * (this will affect whether paypal express code is displayed)
+   * @var bool
+   */
+  public $isBackOffice = FALSE;
+
+  /**
+   * Payment instrument if for the transaction.
+   *
+   * This will generally be drawn from the payment processor and is ignored for
+   * front end forms.
+   *
+   * @var int
+   */
+  public $paymentInstrumentID;
+
+  /**
    * Set variables up before form is built.
    *
    * @throws \CRM_Contribute_Exception_InactiveContributionPageException

--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -120,6 +120,58 @@ abstract class CRM_Core_Payment {
   protected $billingProfile;
 
   /**
+   * Payment instrument ID.
+   *
+   * This is normally retrieved from the payment_processor table.
+   *
+   * @var int
+   */
+  protected $paymentInstrumentID;
+
+  /**
+   * Is this a back office transaction.
+   *
+   * @var bool
+   */
+  protected $backOffice = FALSE;
+
+  /**
+   * @return bool
+   */
+  public function isBackOffice() {
+    return $this->backOffice;
+  }
+
+  /**
+   * Set back office property.
+   *
+   * @param bool $isBackOffice
+   */
+  public function setBackOffice($isBackOffice) {
+    $this->backOffice = $isBackOffice;
+  }
+
+  /**
+   * Get payment instrument id.
+   *
+   * @return int
+   */
+  public function getPaymentInstrumentID() {
+    return $this->paymentInstrumentID ? $this->paymentInstrumentID : $this->_paymentProcessor['payment_instrument_id'];
+  }
+
+  /**
+   * Set payment Instrument id.
+   *
+   * By default we actually ignore the form value. The manual processor takes it more seriously.
+   *
+   * @param int $paymentInstrumentID
+   */
+  public function setPaymentInstrumentID($paymentInstrumentID) {
+    $this->paymentInstrumentID = $this->_paymentProcessor['payment_instrument_id'];
+  }
+
+  /**
    * Set base return path (offsite processors).
    *
    * This is only useful with an internal civicrm form.

--- a/CRM/Core/Payment/Form.php
+++ b/CRM/Core/Payment/Form.php
@@ -52,8 +52,10 @@ class CRM_Core_Payment_Form {
    *   Display billing fields even for pay later.
    * @param bool $isBackOffice
    *   Is this a back office function? If so the option to suppress the cvn needs to be evaluated.
+   * @param int $paymentInstrumentID
+   *   ID of the payment processor.
    */
-  static public function setPaymentFieldsByProcessor(&$form, $processor, $billing_profile_id = NULL, $isBackOffice = FALSE) {
+  static public function setPaymentFieldsByProcessor(&$form, $processor, $billing_profile_id = NULL, $isBackOffice = FALSE, $paymentInstrumentID = NULL) {
     $form->billingFieldSets = array();
     // Load the pay-later processor
     // @todo load this right up where the other processors are loaded initially.
@@ -62,10 +64,13 @@ class CRM_Core_Payment_Form {
     }
 
     $processor['object']->setBillingProfile($billing_profile_id);
+    $processor['object']->setBackOffice($isBackOffice);
+    $processor['object']->setPaymentInstrumentID($paymentInstrumentID);
     $paymentTypeName = self::getPaymentTypeName($processor);
     $paymentTypeLabel = self::getPaymentTypeLabel($processor);
     $form->assign('paymentTypeName', $paymentTypeName);
     $form->assign('paymentTypeLabel', $paymentTypeLabel);
+    $form->assign('isBackOffice', $isBackOffice);
     $form->_paymentFields = $form->billingFieldSets[$paymentTypeName]['fields'] = self::getPaymentFieldMetadata($processor);
     $form->_paymentFields = array_merge($form->_paymentFields, self::getBillingAddressMetadata($processor, $form->_bltID));
     $form->assign('paymentFields', self::getPaymentFields($processor));
@@ -111,6 +116,7 @@ class CRM_Core_Payment_Form {
   protected static function addCommonFields(&$form, $paymentFields) {
     $requiredPaymentFields = array();
     foreach ($paymentFields as $name => $field) {
+      // @todo - remove the cc_field check - no longer useful.
       if (!empty($field['cc_field'])) {
         if ($field['htmlType'] == 'chainSelect') {
           $form->addChainSelect($field['name'], array('required' => FALSE));
@@ -142,8 +148,7 @@ class CRM_Core_Payment_Form {
    * @return array
    */
   public static function getPaymentFields($paymentProcessor) {
-    $paymentProcessorObject = Civi\Payment\System::singleton()->getByProcessor($paymentProcessor);
-    return $paymentProcessorObject->getPaymentFormFields();
+    return $paymentProcessor['object']->getPaymentFormFields();
   }
 
   /**
@@ -152,8 +157,7 @@ class CRM_Core_Payment_Form {
    * @return array
    */
   public static function getPaymentFieldMetadata($paymentProcessor) {
-    $paymentProcessorObject = Civi\Payment\System::singleton()->getByProcessor($paymentProcessor);
-    return array_intersect_key($paymentProcessorObject->getPaymentFormFieldsMetadata(), array_flip(self::getPaymentFields($paymentProcessor)));
+    return array_intersect_key($paymentProcessor['object']->getPaymentFormFieldsMetadata(), array_flip(self::getPaymentFields($paymentProcessor)));
   }
 
   /**
@@ -220,10 +224,12 @@ class CRM_Core_Payment_Form {
    *   although the distinction is losing it's meaning as front end forms are used for back office and a permission
    *   for the 'enter without cvn' is probably more appropriate. Paypal std does not support another user
    *   entering details but once again the issue is not back office but 'another user'.
+   * @param int $paymentInstrumentID
+   *   Payment instrument ID.
    *
    * @return bool
    */
-  public static function buildPaymentForm(&$form, $processor, $billing_profile_id, $isBackOffice) {
+  public static function buildPaymentForm(&$form, $processor, $billing_profile_id, $isBackOffice, $paymentInstrumentID = NULL) {
     //if the form has address fields assign to the template so the js can decide what billing fields to show
     $profileAddressFields = $form->get('profileAddressFields');
     if (!empty($profileAddressFields)) {
@@ -234,7 +240,7 @@ class CRM_Core_Payment_Form {
       return NULL;
     }
 
-    self::setPaymentFieldsByProcessor($form, $processor, $billing_profile_id, $isBackOffice);
+    self::setPaymentFieldsByProcessor($form, $processor, $billing_profile_id, $isBackOffice, $paymentInstrumentID);
     self::addCommonFields($form, $form->_paymentFields);
     self::addRules($form, $form->_paymentFields);
     return (!empty($form->_paymentFields));

--- a/CRM/Core/Payment/Manual.php
+++ b/CRM/Core/Payment/Manual.php
@@ -138,6 +138,15 @@ class CRM_Core_Payment_Manual extends CRM_Core_Payment {
   }
 
   /**
+   * Set payment instrument id.
+   *
+   * @param int $paymentInstrumentID
+   */
+  public function setPaymentInstrumentID($paymentInstrumentID) {
+    $this->paymentInstrumentID = $paymentInstrumentID;
+  }
+
+  /**
    * Get the name of the payment type.
    *
    * @return string
@@ -170,6 +179,15 @@ class CRM_Core_Payment_Manual extends CRM_Core_Payment {
    * @return bool
    */
   public function supportsEditRecurringContribution() {
+    return TRUE;
+  }
+
+  /**
+   * Are back office payments supported.
+   *
+   * @return bool
+   */
+  protected function supportsBackOffice() {
     return TRUE;
   }
 

--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -137,6 +137,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
    * @param CRM_Core_Form $form
    */
   protected function addPaypalExpressCode(&$form) {
+    // @todo use $this->isBackOffice() instead, test.
     if (empty($form->isBackOffice)) {
       $form->_expressButtonName = $form->getButtonName('upload', 'express');
       $form->assign('expressButtonName', $form->_expressButtonName);

--- a/CRM/Core/Payment/ProcessorForm.php
+++ b/CRM/Core/Payment/ProcessorForm.php
@@ -54,6 +54,7 @@ class CRM_Core_Payment_ProcessorForm {
     }
 
     if ($form->_type) {
+      // @todo not sure when this would be true. Never passed in.
       $form->_paymentProcessor = CRM_Financial_BAO_PaymentProcessor::getPayment($form->_type, $form->_mode);
     }
 
@@ -63,6 +64,11 @@ class CRM_Core_Payment_ProcessorForm {
     }
     $form->set('paymentProcessor', $form->_paymentProcessor);
     $form->_paymentObject = System::singleton()->getByProcessor($form->_paymentProcessor);
+    if ($form->paymentInstrumentID) {
+      $form->_paymentObject->setPaymentInstrumentID($form->paymentInstrumentID);
+    }
+    $form->_paymentObject->setBackOffice($form->isBackOffice);
+    $form->assign('isBackOffice', $form->isBackOffice);
 
     $form->assign('suppressSubmitButton', $form->_paymentObject->isSuppressSubmitButtons());
 
@@ -92,7 +98,9 @@ class CRM_Core_Payment_ProcessorForm {
     CRM_Core_Payment_Form::setPaymentFieldsByProcessor(
       $form,
       $form->_paymentProcessor,
-      CRM_Utils_Request::retrieve('billing_profile_id', 'String')
+      CRM_Utils_Request::retrieve('billing_profile_id', 'String'),
+      $form->isBackOffice,
+      $form->paymentInstrumentID
     );
 
     $form->assign_by_ref('paymentProcessor', $form->_paymentProcessor);
@@ -131,7 +139,7 @@ class CRM_Core_Payment_ProcessorForm {
    *
    * @param CRM_Core_Form $form
    */
-  public static function buildQuickform(&$form) {
+  public static function buildQuickForm(&$form) {
     //@todo document why this addHidden is here
     //CRM-15743 - we should not set/create hidden element for pay later
     // because payment processor is not selected
@@ -143,7 +151,7 @@ class CRM_Core_Payment_ProcessorForm {
     if (!empty($processorId)) {
       $form->addElement('hidden', 'hidden_processor', 1);
     }
-    CRM_Core_Payment_Form::buildPaymentForm($form, $form->_paymentProcessor, $billing_profile_id, FALSE);
+    CRM_Core_Payment_Form::buildPaymentForm($form, $form->_paymentProcessor, $billing_profile_id, $form->isBackOffice, $form->paymentInstrumentID);
   }
 
 }

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -167,7 +167,29 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
 
   public $_forcePayement;
 
+  /**
+   * @deprecated
+   *
+   * @var
+   */
   public $_isBillingAddressRequiredForPayLater;
+
+  /**
+   * Is this a back office form
+   *
+   * @var bool
+   */
+  public $isBackOffice = FALSE;
+
+  /**
+   * Payment instrument iD for the transaction.
+   *
+   * This will generally be drawn from the payment processor and is ignored for
+   * front end forms.
+   *
+   * @var int
+   */
+  public $paymentInstrumentID;
 
   /**
    * Set variables up before form is built.

--- a/CRM/Financial/BAO/PaymentProcessor.php
+++ b/CRM/Financial/BAO/PaymentProcessor.php
@@ -346,11 +346,11 @@ class CRM_Financial_BAO_PaymentProcessor extends CRM_Financial_DAO_PaymentProces
       'name' => 'pay_later',
       'billing_mode' => '',
       'is_default' => 0,
-      // This should ideally be retrieved from the DB but existing default is check so we'll code that for now.
-      'payment_instrument_id' => CRM_Core_OptionGroup::getValue('payment_instrument', 'Check', 'name'),
+      'payment_instrument_id' => key(CRM_Core_OptionGroup::values('payment_instrument', FALSE, FALSE, FALSE, 'AND is_default = 1')),
       // Making this optionally recur would give lots of options -but it should
       // be a row in the payment processor table before we do that.
       'is_recur' => FALSE,
+      'is_test' => FALSE,
     );
 
     CRM_Utils_Cache::singleton()->set($cacheKey, $processors['values']);
@@ -376,7 +376,6 @@ class CRM_Financial_BAO_PaymentProcessor extends CRM_Financial_DAO_PaymentProces
    *   available processors
    */
   public static function getPaymentProcessors($capabilities = array(), $ids = FALSE) {
-    $mode = NULL;
     $testProcessors = in_array('TestMode', $capabilities) ? self::getAllPaymentProcessors('test') : array();
     if (is_array($ids)) {
       $processors = self::getAllPaymentProcessors('all', TRUE, FALSE);

--- a/CRM/Financial/Form/Payment.php
+++ b/CRM/Financial/Form/Payment.php
@@ -43,6 +43,12 @@ class CRM_Financial_Form_Payment extends CRM_Core_Form {
    * @var array
    */
   public $_paymentProcessor;
+
+  /**
+   * @var bool
+   */
+  public $isBackOffice = FALSE;
+
   /**
    * Set variables up before form is built.
    */
@@ -55,6 +61,9 @@ class CRM_Financial_Form_Payment extends CRM_Core_Form {
       TRUE);
     $this->currency = CRM_Utils_Request::retrieve('currency', 'String', CRM_Core_DAO::$_nullObject,
       TRUE);
+
+    $this->paymentInstrumentID = CRM_Utils_Request::retrieve('payment_instrument_id', 'Integer');
+    $this->isBackOffice = CRM_Utils_Request::retrieve('is_back_office', 'Integer');
 
     $this->assignBillingType();
 
@@ -100,7 +109,6 @@ class CRM_Financial_Form_Payment extends CRM_Core_Form {
    * @param int $paymentProcessorID
    */
   public static function addCreditCardJs($paymentProcessorID = NULL) {
-    $creditCards = array();
     $creditCards = CRM_Financial_BAO_PaymentProcessor::getCreditCards($paymentProcessorID);
     $creditCardTypes = CRM_Core_Payment_Form::getCreditCardCSSNames($creditCards);
     CRM_Core_Resources::singleton()

--- a/CRM/Member/Form.php
+++ b/CRM/Member/Form.php
@@ -169,6 +169,7 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
       );
       CRM_Core_Payment_Form::buildPaymentForm($this, $this->_paymentProcessor, FALSE, TRUE);
     }
+
     // Build the form for auto renew. This is displayed when in credit card mode or update mode.
     // The reason for showing it in update mode is not that clear.
     if ($this->_mode || ($this->_action & CRM_Core_Action::UPDATE)) {
@@ -189,7 +190,6 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
         ts('Membership renewed automatically')
       );
 
-      $this->assignPaymentRelatedVariables();
     }
     $this->assign('autoRenewOptions', json_encode($this->membershipTypeRenewalStatus));
 
@@ -303,9 +303,7 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
       }
     }
 
-    if ($this->_mode) {
-      $this->assignPaymentRelatedVariables();
-    }
+    $this->assignPaymentRelatedVariables();
 
     if ($this->_id) {
       $this->_memType = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_Membership', $this->_id, 'membership_type_id');
@@ -441,6 +439,7 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
    * @param array $formValues
    */
   public function testSubmit($formValues) {
+    $this->setContextVariables($formValues);
     $this->_memType = $formValues['membership_type_id'][1];
     $this->_params = $formValues;
     $this->submit();

--- a/templates/CRM/common/paymentBlock.tpl
+++ b/templates/CRM/common/paymentBlock.tpl
@@ -105,7 +105,11 @@
         {capture assign='profilePathVar'}{/capture}
       {/if}
 
-      var dataUrl = "{crmURL p='civicrm/payment/form' h=0 q="currency=`$currency`&`$urlPathVar``$profilePathVar``$contributionPageID``$preProfileID`processor_id="}" + type;
+      {capture assign='isBackOfficePathVar'}&is_back_office={$isBackOffice}&{/capture}
+
+      var payment_instrument_id = $('#payment_instrument_id').val();
+
+      var dataUrl = "{crmURL p='civicrm/payment/form' h=0 q="&currency=`$currency`&`$urlPathVar``$isBackOfficePathVar``$profilePathVar``$contributionPageID``$preProfileID`processor_id="}" + type;
       {literal}
       if (typeof(CRM.vars) != "undefined") {
         if (typeof(CRM.vars.coreForm) != "undefined") {
@@ -118,6 +122,7 @@
           }
         }
       }
+      dataUrl =  dataUrl + "&payment_instrument_id=" + payment_instrument_id;
 
       // Processors like pp-express will hide the form submit buttons, so re-show them when switching
       $('.crm-submit-buttons', $form).show().find('input').prop('disabled', true);
@@ -127,6 +132,7 @@
     $('[name=payment_processor_id]').on('change.paymentBlock', function() {
         buildPaymentBlock($(this).val());
     });
+
     $('#billing-payment-block').on('crmLoad', function() {
       $('.crm-submit-buttons input').prop('disabled', false);
     })

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -411,6 +411,7 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
       'billing_last_name' => 'Gruffier',
       'selectMembership' => $this->_ids['membership_type'],
       'email-Primary' => 'billy-goat@the-new-bridge.net',
+      'payment_processor_id' => $this->params['payment_processor_id'],
     );
 
     $this->callAPISuccess('contribution_page', 'submit', $submitParams);


### PR DESCRIPTION
…onsibility to the processor.

This also reflects work towards allowing payment_instrument specific fields on the payment form - ie. check, credit_card_type, pan_truncation.

This idea is to finish the code allowing pay-later to be the manual payment processor indexed with a 0 on all payment forms, and have the
form render with appropriate fields. Note that I got this working on multiple forms, this commit reflects the smallest piece I could
break off that is complete within itself, and resolves an issue

I tested that it was still possible to enter checks on the offline contribution as well as membership & additional payment forms, and the
check number still shows up.

I also tested front end contribution credit card & pay later & front end event forms