### PR TITLE
CRM-20393 - fix for check if the user already submitted transaction

### DIFF
--- a/CRM/Core/Payment/AuthorizeNet.php
+++ b/CRM/Core/Payment/AuthorizeNet.php
@@ -363,7 +363,7 @@ class CRM_Core_Payment_AuthorizeNet extends CRM_Core_Payment {
     $fields['x_country'] = $this->_getParam('country');
     $fields['x_customer_ip'] = $this->_getParam('ip_address');
     $fields['x_email'] = $this->_getParam('email');
-    $fields['x_invoice_num'] = substr($this->_getParam('invoiceID'), 0, 20);
+    $fields['x_invoice_num'] = $this->_getParam('invoiceID');
     $fields['x_amount'] = $amount;
     $fields['x_currency_code'] = $this->_getParam('currencyID');
     $fields['x_description'] = $this->_getParam('description');


### PR DESCRIPTION
No need to truncate x_invoice_num - and without truncating x_invoice_num which is passed into this function as invoiceId - this can actually work now:

```
  /**
   * Checks to see if invoice_id already exists in db.
   *
   * @param int $invoiceId
   *   The ID to check.
   *
   * @return bool
   *   True if ID exists, else false
   */
  public function _checkDupe($invoiceId) {
    $contribution = new CRM_Contribute_DAO_Contribution();
    $contribution->invoice_id = $invoiceId;
    return $contribution->find();
  }
```

---

 * [CRM-20393: Authorize.net: fix for the "check if the user already submitted this transaction"                                                                                     ](https://issues.civicrm.org/jira/browse/CRM-20393)