### PR TITLE
CRM-20419 jQuery.isEmptyObject misused

### DIFF
--- a/ang/crmCxn/ManageCtrl.html
+++ b/ang/crmCxn/ManageCtrl.html
@@ -111,7 +111,7 @@
   </table>
 </div>
 
-<div ng-show="$.isEmptyObject(appMetas)" class="messages status no-popup">
+<div ng-show="appMetas.length === 0" class="messages status no-popup">
   <i class="crm-i fa-info-circle"></i>
   {{ts('No available applications')}}
 </div>

--- a/ang/crmMailingAB/ListCtrl.html
+++ b/ang/crmMailingAB/ListCtrl.html
@@ -25,7 +25,7 @@ Required vars: mailingABList
   </form>
 </div>
 
-<div ng-show="!$.isEmptyObject(mailingABList)">
+<div ng-show="mailingABList.length">
   <table class="display">
     <thead>
     <tr>
@@ -51,7 +51,7 @@ Required vars: mailingABList
   </table>
 </div>
 
-<div ng-show="$.isEmptyObject(mailingABList)" class="messages status no-popup">
+<div ng-show="mailingABList.length === 0" class="messages status no-popup">
   <i class="crm-i fa-info-circle"></i>
   {{ts('You have no A/B mailings')}}
 </div>

--- a/js/jquery/jquery.crmProfileSelector.js
+++ b/js/jquery/jquery.crmProfileSelector.js
@@ -34,7 +34,7 @@
         matchingUfGroups = ufGroupCollection.subcollection({
           filter: function(ufGroupModel) {
             //CRM-16915 - filter with module used by the profile
-            if (!$.isEmptyObject(options.usedByFilter)) {
+            if (options.usedByFilter.length) {
               usedByFilter = options.usedByFilter;
             }
             return ufGroupModel.checkGroupType(options.groupTypeFilter, options.allowAllSubtypes, usedByFilter);
@@ -45,7 +45,7 @@
       }
 
       //CRM-15427 check for valid subtypes raise a warning if not valid
-      if (options.allowAllSubtypes && $.isEmptyObject(validTypesId)) {
+      if (options.allowAllSubtypes && validTypesId.length === 0) {
         validTypes = ufGroupCollection.subcollection({
           filter: function(ufGroupModel) {
             return ufGroupModel.checkGroupType(options.groupTypeFilter);
@@ -55,7 +55,7 @@
           validTypesId.push(validTypesattr.id);
         });
       }
-      if (!$.isEmptyObject(validTypesId) && $.inArray($select.val(), validTypesId) == -1) {
+      if (validTypesId.length && $.inArray($select.val(), validTypesId) == -1) {
         var civiComponent;
         if (options.groupTypeFilter.indexOf('Membership') !== -1) {
           civiComponent = 'Membership';

--- a/js/model/crm.uf.js
+++ b/js/model/crm.uf.js
@@ -110,7 +110,7 @@
       case 'Case':
         return 'case_1';
       default:
-        if (!$.isEmptyObject(CRM.contactSubTypes) && ($.inArray(field_type,CRM.contactSubTypes) > -1)) {
+        if (CRM.contactSubTypes.length && ($.inArray(field_type,CRM.contactSubTypes) > -1)) {
           return 'contact_1';
         }
         else {


### PR DESCRIPTION
This fixes a bunch of places where `$.isEmptyObject()` is used on arrays and strings.  The method's [documentation](https://api.jquery.com/jQuery.isEmptyObject/) is clear that it may yield inconsistent results when used on anything other than a basic object.  In practice, at least some Joomla sites have had problems where `CRM.$.isEmptyObject()` returns `false` on an empty array or string despite returning `true` in most other environments.

This replaces all instances of `$.isEmptyObject()` in the codebase aside from the couple that actually evaluate objects.

---

 * [CRM-20419: Profile selector broken on event registration \(some version\/CMS\/browser combos\)](https://issues.civicrm.org/jira/browse/CRM-20419)