### PR TITLE
CRM-20172: "Separate Membership Payment" with Memberships enabled and additional contribution causes incorrect authorize.net transactions

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1475,9 +1475,8 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         $isTest,
         $isRecurForFirstTransaction
       );
-      $paymentResults[] = array('contribution_id' => $paymentResult['contribution']->id, 'result' => $paymentResult);
-
       if (!empty($paymentResult['contribution'])) {
+        $paymentResults[] = array('contribution_id' => $paymentResult['contribution']->id, 'result' => $paymentResult);
         $this->postProcessPremium($premiumParams, $paymentResult['contribution']);
         //note that this will be over-written if we are using a separate membership transaction. Otherwise there is only one
         $membershipContribution = $paymentResult['contribution'];
@@ -1786,12 +1785,17 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
     $result = array();
 
-    if ($tempParams['skipLineItem']) {
-      // We are not processing the line item here because we are processing a membership.
-      // So unset the total_amount param, which stores the non-membership contribution amount.
-      $tempParams['total_amount'] = $membershipContribution->total_amount;
-      $tempParams['contributionID'] = $membershipContribution->id;
-    }
+    // We're not processing the line item here because we are processing a membership.
+    // To ensure processing of the correct parameters, replace relevant parameters
+    // in $tempParams with those in $membershipContribution.
+    $tempParams['amount_level'] = $membershipContribution->amount_level;
+    $tempParams['total_amount'] = $membershipContribution->total_amount;
+    $tempParams['tax_amount'] = $membershipContribution->tax_amount;
+    $tempParams['contactID'] = $membershipContribution->contact_id;
+    $tempParams['financialTypeID'] = $membershipContribution->financial_type_id;
+    $tempParams['invoiceID'] = $membershipContribution->invoice_id;
+    $tempParams['trxn_id'] = $membershipContribution->trxn_id;
+    $tempParams['contributionID'] = $membershipContribution->id;
 
     if ($form->_values['is_monetary'] && !$form->_params['is_pay_later'] && $minimumFee > 0.0) {
       // At the moment our tests are calling this form in a way that leaves 'object' empty. For

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -41,6 +41,7 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
   protected $_entity = 'contribution_page';
   protected $contribution_result = NULL;
   protected $_priceSetParams = array();
+  protected $_membershipBlockAmount = 2;
   /**
    * Payment processor details.
    * @var array
@@ -627,6 +628,79 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test submit with a membership block in place.
+   *
+   * Ensure a separate payment for the membership vs the contribution, with
+   * correct amounts.
+   */
+  public function testSubmitMembershipBlockIsSeparatePaymentPaymentProcessorNowChargesCorrectAmounts() {
+    $this->setUpMembershipContributionPage(TRUE);
+    $processor = Civi\Payment\System::singleton()->getById($this->_paymentProcessor['id']);
+    $processor->setDoDirectPaymentResult(array('fee_amount' => .72));
+    $test_uniq = uniqid();
+    $contributionPageAmount = 10;
+    $submitParams = array(
+      'price_' . $this->_ids['price_field'][0] => reset($this->_ids['price_field_value']),
+      'id' => (int) $this->_ids['contribution_page'],
+      'amount' => $contributionPageAmount,
+      'billing_first_name' => 'Billy',
+      'billing_middle_name' => 'Goat',
+      'billing_last_name' => 'Gruff',
+      'email-Primary' => 'henry@8th.king',
+      'selectMembership' => $this->_ids['membership_type'],
+      'payment_processor_id' => $this->_paymentProcessor['id'],
+      'credit_card_number' => '4111111111111111',
+      'credit_card_type' => 'Visa',
+      'credit_card_exp_date' => array('M' => 9, 'Y' => 2040),
+      'cvv2' => 123,
+      'TEST_UNIQ' => $test_uniq,
+    );
+
+    // set custom hook
+    $this->hookClass->setHook('civicrm_alterPaymentProcessorParams', array($this, 'hook_civicrm_alterPaymentProcessorParams'));
+
+    $this->callAPISuccess('contribution_page', 'submit', $submitParams, __FUNCTION__, __FILE__, 'submit contribution page', NULL);
+    $contributions = $this->callAPISuccess('contribution', 'get', array(
+      'contribution_page_id' => $this->_ids['contribution_page'],
+      'contribution_status_id' => 1,
+    ));
+
+    $result = civicrm_api3('SystemLog', 'get', array(
+      'sequential' => 1,
+      'message' => array('LIKE' => "%{$test_uniq}%"),
+    ));
+    $this->assertCount(2, $result['values'], "Expected exactly 2 log entries matching {$test_uniq}.");
+
+    // Examine logged entries to ensure correct values.
+    $contribution_ids = array();
+    $found_membership_amount = $found_contribution_amount = FALSE;
+    foreach ($result['values'] as $value) {
+      list($junk, $json) = explode("$test_uniq:", $value['message']);
+      $logged_contribution = json_decode($json, TRUE);
+      $contribution_ids[] = $logged_contribution['contributionID'];
+      if (!empty($logged_contribution['total_amount'])) {
+        $amount = $logged_contribution['total_amount'];
+      }
+      else {
+        $amount = $logged_contribution['amount'];
+      }
+
+      if ($amount == $this->_membershipBlockAmount) {
+        $found_membership_amount = TRUE;
+      }
+      if ($amount == $contributionPageAmount) {
+        $found_contribution_amount = TRUE;
+      }
+    }
+
+    $distinct_contribution_ids = array_unique($contribution_ids);
+    $this->assertCount(2, $distinct_contribution_ids, "Expected exactly 2 log contributions with distinct contributionIDs.");
+    $this->assertTrue($found_contribution_amount, "Expected one log contribution with amount '$contributionPageAmount' (the contribution page amount)");
+    $this->assertTrue($found_membership_amount, "Expected one log contribution with amount '$this->_membershipBlockAmount' (the membership amount)");
+
+  }
+
+  /**
    * Test that when a transaction fails the pending contribution remains.
    *
    * An activity should also be created. CRM-16417.
@@ -1150,7 +1224,7 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
       $priceFieldValue = $this->callAPISuccess('price_field_value', 'create', array(
         'name' => 'membership_amount',
         'label' => 'Membership Amount',
-        'amount' => 2,
+        'amount' => $this->_membershipBlockAmount,
         'financial_type_id' => 'Donation',
         'format.only_id' => TRUE,
         'membership_type_id' => $membershipTypeID,
@@ -1527,6 +1601,26 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
 
     // Compare this to what it should be!
     $this->assertEquals($lineItem_TaxAmount, round($submitParams['tax_amount'], 2), 'Wrong Sales Tax Amount is calculated and stored.');
+  }
+
+  public function hook_civicrm_alterPaymentProcessorParams($paymentObj, &$rawParams, &$cookedParams) {
+    // Ensure total_amount are the same if they're both given.
+    $total_amount = CRM_Utils_Array::value('total_amount', $rawParams);
+    $amount = CRM_Utils_Array::value('amount', $rawParams);
+    if (!empty($total_amount) && !empty($amount) && $total_amount != $amount) {
+      throw new Exception("total_amount '$total_amount' and amount '$amount' differ.");
+    }
+
+    // Log parameters for later debugging and testing.
+    $message = __FUNCTION__ . ": {$rawParams['TEST_UNIQ']}:";
+    $log_params = array_intersect_key($rawParams, array(
+      'amount' => 1,
+      'total_amount' => 1,
+      'contributionID' => 1,
+    ));
+    $message .= json_encode($log_params);
+    $log = new CRM_Utils_SystemLogger();
+    $log->debug($message, $_REQUEST);
   }
 
 }


### PR DESCRIPTION
I'm trying to start by creating test(s) first, then aiming to develop until the test passes.

I believe this can be reproduced with the Dummy processor (which is easier to test than Authorize.net, AFAIK). It doesn't /seem/ to repro with Dummy because Dummy doesn't record transactions they way Authorize.net does.  However, examining the parameters sent to doDirectPayment(), whether in Dummy or in Authorize.net, I see two consistent misbehaviors:

1. doDirectPayment() is called 3 times instead of 2 times.
2. The total_amount parameter that's sent to doDirectPament() is incorrect: it's always the non-membership amount.

I've added logging in the Dummy processor's doDirectPayment, to log all parameters to civicrm_system_log. My idea here is to test the logged parameters and the number of entries (should be 2, not 3).

Also, I've stubbed out an empty web test for this, since I think this needs to submit through the browser. This test will be similar to testOnlineMembershipCreate() but set up a simpler contribution page and test for more specific requirements.

@eileenmcnaughton Could you help me understand a couple of things about testing this?
1. Is it likely that a web test is required here, or should I try harder at a non-selenium phpunit test?
2. Is this idea of testing the logged parameters likely to yield a robust test? 
3. Is it acceptable to leave this logging in the Dummy processor for every Dummy transaction? Or if not, is there a more elegant way to log parameters only when we're testing?

Thanks!

---

 * [CRM-20172: "Separate Membership Payment" with Memberships enabled and additional contribution causes incorrect authorize.net transactions](https://issues.civicrm.org/jira/browse/CRM-20172)