### PR TITLE
CRM-20436 Make method updateKenyanProvinces Static

### DIFF
--- a/CRM/Upgrade/Incremental/php/FourSeven.php
+++ b/CRM/Upgrade/Incremental/php/FourSeven.php
@@ -1027,7 +1027,7 @@ FROM `civicrm_dashboard_contact` JOIN `civicrm_contact` WHERE civicrm_dashboard_
    *
    * @param \CRM_Queue_TaskContext $ctx
    */
-  public function updateKenyanProvinces(CRM_Queue_TaskContext $ctx) {
+  public static function updateKenyanProvinces(CRM_Queue_TaskContext $ctx) {
     $kenyaCountryID = CRM_Core_DAO::singleValueQuery('SELECT max(id) from civicrm_country where iso_code = "KE"');
     $oldProvinces = array(
       'Nairobi Municipality',


### PR DESCRIPTION
* [CRM-20436: Non Static method CRM_Upgrade_Incremental_php_FourSeven::updateKenyanProvinces should be static](https://issues.civicrm.org/jira/browse/CRM-20436)