### PR TITLE
CRM-20276, CRM-20257, CRM-20259, CRM-20260, CRM-20262 : Sale Tax issues

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3653,12 +3653,12 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
 
           // calculate financial item amount
           $amountParams = array(
-            'diff' => $diff,
+            'diff' => self::getMultiplier($params['contribution']->contribution_status_id, $context),
             'line_total' => $lineItemDetails['line_total'],
             'previous_line_total' => CRM_Utils_Array::value('line_total', CRM_Utils_Array::value($lineItemDetails['id'], $previousLineItem)),
             'item_amount' => $itemAmount,
           );
-          $amount = self::calcluateFinancialItemAmount($params, $amountParams, $context, $fieldValues);
+          $amount = self::calculateFinancialItemAmount($params, $amountParams, $context, $fieldValues);
           $itemParams = array(
             'transaction_date' => $receiveDate,
             'contact_id' => $params['prevContribution']->contact_id,
@@ -3675,7 +3675,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
           $params['line_item'][$fieldId][$fieldValueId]['financial_item_id'] = $financialItem->id;
 
           $taxAmount = CRM_Utils_Array::value('tax_amount', $lineItemDetails);
-          $diff = self::getMultiplier($params['contribution']->contribution_status_id, $context);
 
           if ($taxAmount && $taxAmount !== 'null') {
             $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3338,9 +3338,13 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
             }
             self::updateFinancialAccounts($params, 'changeFinancialType');
             $params['financial_account_id'] = $newFinancialAccount;
-            list($changeFTAmount, $ignoreChangeAmount) = self::calcluateFTChangeAmount($params, $trxnParams['total_amount']);
+            list($changeFTAmount, $ignoreChangeAmount, $taxAmounts) = self::calculateFTChangeAmount($params, $trxnParams['total_amount'], $totalAmount);
             $params['total_amount'] = $params['trxnParams']['total_amount'] = $params['trxnParams']['net_amount'] = $changeFTAmount;
             self::updateFinancialAccounts($params);
+            if (isset($taxAmounts['new_tax_amount'])) {
+              $params['tax_amount'] = $taxAmounts['new_tax_amount'];
+              $params['prevContribution']->tax_amount = CRM_Utils_Array::value('previous_tax_amount', $taxAmounts);
+            }
             $params['trxnParams']['to_financial_account_id'] = $trxnParams['to_financial_account_id'];
             $updated = TRUE;
             $params['deferred_financial_account_id'] = $newFinancialAccount;
@@ -3524,7 +3528,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     if ($context == 'changedAmount' || $context == 'changeFinancialType') {
       $itemAmount = $params['trxnParams']['total_amount'] = $params['trxnParams']['net_amount'] = ($params['total_amount'] - $params['prevContribution']->total_amount);
 
-      if (isset($params['tax_amount'])) {
+      if (isset($params['prevContribution']->tax_amount) && $context != 'changeFinancialType') {
         $itemAmount -= CRM_Utils_Array::value('tax_amount', $params, 0);
       }
       if (isset($params['tax_amount'])) {
@@ -3654,7 +3658,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
             'previous_line_total' => CRM_Utils_Array::value('line_total', CRM_Utils_Array::value($lineItemDetails['id'], $previousLineItem)),
             'item_amount' => $itemAmount,
           );
-          $amount = self::calcluateFinancialItemAmount($params, $amountParams, $context);
+          $amount = self::calcluateFinancialItemAmount($params, $amountParams, $context, $fieldValues);
           $itemParams = array(
             'transaction_date' => $receiveDate,
             'contact_id' => $params['prevContribution']->contact_id,
@@ -5504,12 +5508,16 @@ LEFT JOIN  civicrm_contribution on (civicrm_contribution.contact_id = civicrm_co
    * @param array $amountParams
    *
    * @param string $context
+   * @param array $fieldValues
    *
    * @return float
    */
-  public static function calculateFinancialItemAmount($params, $amountParams, $context) {
+  public static function calculateFinancialItemAmount($params, $amountParams, $context, &$fieldValues) {
     if (!empty($params['is_quick_config'])) {
       $amount = $amountParams['item_amount'];
+      if (!empty($params['tax_amount']) && !CRM_Utils_System::isNull($params['tax_amount'])) {
+        $fieldValues['tax_amount'] = $params['tax_amount'];
+      }
       if (!$amount) {
         $amount = $params['total_amount'];
         if ($context === NULL) {

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -5730,4 +5730,37 @@ LEFT JOIN  civicrm_contribution on (civicrm_contribution.contact_id = civicrm_co
     }
   }
 
+  /**
+   * Calculate amounts when Financial type for contribution is changed.
+   *
+   * @param array $params
+   *   contribution params
+   * @param float $trxnAmount
+   *   financial trxn total amount
+   * @param float $totalAmount
+   *   Contribution total amount
+   *
+   * @return array
+   */
+  public static function calculateFTChangeAmount(&$params, $trxnAmount, &$totalAmount) {
+    $changeFTAmount = $trxnAmount;
+    $ignoreChangeAmount = FALSE;
+    $taxAmounts = array(
+      'new_tax_amount' => NULL,
+    );
+    if (isset($params['prevContribution']->total_amount) || isset($params['tax_amount'])) {
+      $taxAmount = CRM_Utils_Array::value('tax_amount', $params, 0);
+      $changesinTaxAmount = $totalAmount - $params['prevContribution']->total_amount + $params['prevContribution']->tax_amount - $taxAmount;
+      $taxAmounts['new_tax_amount'] = $taxAmount;
+      if ($changesinTaxAmount == 0) {
+        $ignoreChangeAmount = TRUE;
+        $changeFTAmount = $totalAmount;
+      }
+      elseif ($taxAmount) {
+        self::calculateTaxForChangeInFinancialType($params, $totalAmount, $taxAmounts, $changeFTAmount);
+      }
+    }
+    return array($changeFTAmount, $ignoreChangeAmount, $taxAmounts);
+  }
+
 }

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -1304,4 +1304,109 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
     ), $checkAgainst);
   }
 
+  /**
+   * Test to assert sale tax calucations if financial type related to line-item is changed
+   */
+  public function testcalculateTaxAfterChangeInFinancialTypeForLineItems() {
+    list($contribution, $financialAccount) = $this->createContributionWithTax();
+    $lineItems = CRM_Price_BAO_LineItem::getLineItemsByContributionID($contribution['id']);
+    foreach ($lineItems as $id => $lineItem) {
+      $lineItems[$id]['line_total'] = 300;
+      $lineItems[$id]['tax_rate'] = 20;
+      $lineItems[$id]['id'] = $id;
+    }
+    $taxAmount = CRM_Contribute_BAO_Contribution::calculateTaxAfterChangeInFinancialTypeForLineItems(array($lineItems), $contribution['id']);
+    $this->assertEquals($taxAmount, 20.00, 'Amount does not match.');
+    foreach ($lineItems as $id => $lineItem) {
+      $lineItems[$id]['line_total'] = 300;
+      $lineItems[$id]['tax_rate'] = 0;
+      $lineItems[$id]['id'] = $id;
+    }
+    $taxAmount = CRM_Contribute_BAO_Contribution::calculateTaxAfterChangeInFinancialTypeForLineItems(array($lineItems), $contribution['id']);
+    $this->assertEquals($taxAmount, 0, 'Amount does not match.');
+  }
+
+  /**
+   * Test to assert sale tax calucations if financial type is changed
+   */
+  public function testcalculateTaxForChangeInFinancialType() {
+    list($contribution, $financialAccount) = $this->createContributionWithTax();
+    $params = $this->alterLineItemsAndOtherParams($contribution, 20, 300);
+    $totalAmount = 360;
+    $oldTaxAmounts = array('new_tax_amount' => 60);
+    $changeFTAmount = 110;
+    CRM_Contribute_BAO_Contribution::calculateTaxForChangeInFinancialType($params, $totalAmount, $oldTaxAmounts, $changeFTAmount);
+    $this->assertEquals($totalAmount, 350, 'Amount does not match.');
+    $this->assertEquals($changeFTAmount, 120, 'Amount does not match.');
+    $this->assertEquals($params['tax_amount'], 20, 'Amount does not match.');
+    $this->assertEquals($oldTaxAmounts['new_tax_amount'], 50, 'Amount does not match.');
+    $this->assertEquals($oldTaxAmounts['previous_tax_amount'], 10, 'Amount does not match.');
+    $params = $this->alterLineItemsAndOtherParams($contribution, 0, 300);
+    $totalAmount = 300;
+    $oldTaxAmounts = array('new_tax_amount' => NULL);
+    $changeFTAmount = 110;
+    CRM_Contribute_BAO_Contribution::calculateTaxForChangeInFinancialType($params, $totalAmount, $oldTaxAmounts, $changeFTAmount);
+    $this->assertEquals($totalAmount, 310, 'Amount does not match.');
+    $this->assertEquals($changeFTAmount, 100, 'Amount does not match.');
+    $this->assertEquals(CRM_Utils_Array::value('tax_amount', $params), NULL, 'Amount does not match.');
+    $this->assertEquals($oldTaxAmounts['new_tax_amount'], NULL, 'Amount does not match.');
+    $this->assertEquals(CRM_Utils_Array::value('previous_tax_amount', $oldTaxAmounts), NULL, 'Amount does not match.');
+    $financialType = $this->createFinancialType();
+    $contributionParams = array(
+      'contact_id' => $contribution['contact_id'],
+      'financial_type_id' => $financialType['id'],
+      'total_amount' => 100,
+      'contribution_status_id' => 1,
+    );
+    $contribution = CRM_Contribute_BAO_Contribution::add($contributionParams);
+    $params = $this->alterLineItemsAndOtherParams($contribution, 10, 300);
+    $totalAmount = 330;
+    $oldTaxAmounts = array('new_tax_amount' => 30);
+    $changeFTAmount = 100;
+    CRM_Contribute_BAO_Contribution::calculateTaxForChangeInFinancialType($params, $totalAmount, $oldTaxAmounts, $changeFTAmount);
+    $this->assertEquals($totalAmount, 320, 'Amount does not match.');
+    $this->assertEquals($changeFTAmount, 110, 'Amount does not match.');
+    $this->assertEquals($params['tax_amount'], 10, 'Amount does not match.');
+    $this->assertEquals($oldTaxAmounts['new_tax_amount'], 20, 'Amount does not match.');
+    $this->assertEquals($oldTaxAmounts['previous_tax_amount'], 0, 'Amount does not match.');
+  }
+
+  /**
+   * Alter Line Item array to calculate tax change and other contribution attributes.
+   *
+   * @param array $contribution
+   *    contribution array
+   * @param float $taxRate
+   *   tax rate of line item
+   * @param float $totalAmount
+   *   Contribution total amount
+   * @param float $taxAmount
+   *  Tax amount
+   *
+   * @return array
+   */
+  public function alterLineItemsAndOtherParams($contribution, $taxRate, $totalAmount, $taxAmount = NULL) {
+    if (is_array($contribution)) {
+      $contributionId = $contribution['id'];
+      $contribution = new CRM_Contribute_DAO_Contribution();
+      $contribution->id = $contributionId;
+      $contribution->find(TRUE);
+    }
+    $params = array(
+      'contribution' => $contribution,
+      'prevContribution' => $contribution,
+    );
+    $lineItems = CRM_Price_BAO_LineItem::getLineItemsByContributionID($contribution->id);
+    foreach ($lineItems as $id => $lineItem) {
+      $lineItems[$id]['tax_rate'] = $taxRate;
+      $lineItems[$id]['line_total'] = $totalAmount;
+      $lineItems[$id]['id'] = $id;
+    }
+    $params['line_item'][1] = $lineItems;
+    if (isset($taxAmount)) {
+      $params['tax_amount'] = $taxAmount;
+    }
+    return $params;
+  }
+
 }

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -1462,4 +1462,60 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
     return $params;
   }
 
+  /**
+   * test for change in FT
+   */
+  public function testChangePaymentInstrumentTax() {
+    $contactId = $this->individualCreate();
+    $this->enableTaxAndInvoicing();
+    $financialType = $this->createFinancialType();
+    $financialAccount = $this->relationForFinancialTypeWithFinancialAccount($financialType['id']);
+    $params = array(
+      'contact_id' => $contactId,
+      'currency' => 'USD',
+      'financial_type_id' => 1,
+      'contribution_status_id' => 1,
+      'payment_instrument_id' => 1,
+      'total_amount' => 200.00,
+      'fee_amount' => 0,
+      'non_deductible_amount' => 0,
+    );
+    $id = $this->contributionCreate($params);
+    $financialTrxn = $this->callAPISuccess('financial_trxn', 'get', array(
+      'trxn_id' => 12345,
+    ));
+    $this->assertEquals($financialTrxn['count'], 1, 'Counts do not match.');
+    $this->assertEquals($financialTrxn['values'][1]['payment_instrument_id'], 1, 'Payment Instrument is not the same.');
+    $this->assertEquals($financialTrxn['values'][1]['total_amount'], 220.00, 'Amount does not match.');
+    $financialItem = $this->callAPISuccess('financial_item', 'get', array(
+      'contact_id' => $contactId,
+    ));
+    $this->assertEquals($financialItem['count'], 2, 'Counts do not match.');
+    $this->assertEquals($financialItem['values'][1]['amount'], 200.00, 'Amount does not match.');
+    $this->assertEquals($financialItem['values'][2]['amount'], 20.00, 'Amount does not match.');
+    $this->assertEquals($financialItem['values'][2]['financial_account_id'], $financialAccount->financial_account_id, 'Account is not sales tax related.');
+    $this->assertEquals($financialItem['values'][2]['description'], 'Sales Tax', 'Account is not sales tax.');
+    // Change payment instrument.
+    $params['id'] = $id;
+    $params['payment_instrument_id'] = 2;
+    $this->contributionCreate($params);
+    $financialTrxn = $this->callAPISuccess('financial_trxn', 'get', array(
+      'trxn_id' => 12345,
+    ));
+    $this->assertEquals($financialTrxn['count'], 3, 'Counts do not match.');
+    $this->assertEquals($financialTrxn['values'][2]['payment_instrument_id'], 1, 'Payment Instrument is not the same.');
+    $this->assertEquals($financialTrxn['values'][2]['total_amount'], -220.00, 'Amount does not match.');
+    $this->assertEquals($financialTrxn['values'][3]['total_amount'], 220.00, 'Amount does not match.');
+    $this->assertEquals($financialTrxn['values'][3]['payment_instrument_id'], 2, 'Payment Instrument is not the same.');
+    // Asserting no changes in financial item.
+    $financialItem = $this->callAPISuccess('financial_item', 'get', array(
+      'contact_id' => $contactId,
+    ));
+    $this->assertEquals($financialItem['count'], 2, 'Counts do not match.');
+    $this->assertEquals($financialItem['values'][1]['amount'], 200.00, 'Amount does not match.');
+    $this->assertEquals($financialItem['values'][2]['amount'], 20.00, 'Amount does not match.');
+    $this->assertEquals($financialItem['values'][2]['financial_account_id'], $financialAccount->financial_account_id, 'Account is not sales tax related.');
+    $this->assertEquals($financialItem['values'][2]['description'], 'Sales Tax', 'Account is not sales tax.');
+  }
+
 }

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -1372,6 +1372,59 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
   }
 
   /**
+   * test for function calculateFTChangeAmount()
+   */
+  public function testCalculateFTChangeAmount() {
+    list($contribution, $financialAccount) = $this->createContributionWithTax();
+
+    $params = $this->alterLineItemsAndOtherParams($contribution, 0, 300, 0);
+    $trxnAmount = 110;
+    $totalAmount = 300;
+    list($changeFTAmount, $ignoreChangeAmount, $oldTaxAmounts) = CRM_Contribute_BAO_Contribution::calculateFTChangeAmount($params, $trxnAmount, $totalAmount);
+    $this->assertEquals($totalAmount, 310, 'Amount does not match.');
+    $this->assertEquals($ignoreChangeAmount, FALSE);
+    $this->assertEquals($changeFTAmount, 100, 'Amount does not match.');
+    $this->assertEquals($oldTaxAmounts['new_tax_amount'], 0, 'Amount does not match.');
+    $this->assertEquals(CRM_Utils_Array::value('previous_tax_amount', $oldTaxAmounts), NULL, 'Amount does not match.');
+
+    $params = $this->alterLineItemsAndOtherParams($contribution, 20, 300, 60);
+    $totalAmount = 360;
+    list($changeFTAmount, $ignoreChangeAmount, $oldTaxAmounts) = CRM_Contribute_BAO_Contribution::calculateFTChangeAmount($params, $trxnAmount, $totalAmount);
+    $this->assertEquals($totalAmount, 350, 'Amount does not match.');
+    $this->assertEquals($ignoreChangeAmount, FALSE);
+    $this->assertEquals($changeFTAmount, 120, 'Amount does not match.');
+    $this->assertEquals($oldTaxAmounts['new_tax_amount'], 50, 'Amount does not match.');
+    $this->assertEquals($oldTaxAmounts['previous_tax_amount'], 10, 'Amount does not match.');
+
+    $params = $this->alterLineItemsAndOtherParams($contribution, 20, 100, 20);
+    $totalAmount = 120;
+    list($changeFTAmount, $ignoreChangeAmount, $oldTaxAmounts) = CRM_Contribute_BAO_Contribution::calculateFTChangeAmount($params, $trxnAmount, $totalAmount);
+    $this->assertEquals($totalAmount, 120, 'Amount does not match.');
+    $this->assertEquals($ignoreChangeAmount, TRUE);
+    $this->assertEquals($changeFTAmount, 120, 'Amount does not match.');
+    $this->assertEquals($oldTaxAmounts['new_tax_amount'], 20, 'Amount does not match.');
+    $this->assertEquals(CRM_Utils_Array::value('previous_tax_amount', $oldTaxAmounts), NULL, 'Amount does not match.');
+
+    $financialType = $this->createFinancialType();
+    $contributionParams = array(
+      'contact_id' => $contribution['contact_id'],
+      'financial_type_id' => $financialType['id'],
+      'total_amount' => 100,
+      'contribution_status_id' => 1,
+    );
+    $contribution = CRM_Contribute_BAO_Contribution::add($contributionParams);
+    $params = $this->alterLineItemsAndOtherParams($contribution, 10, 300, 30);
+    $trxnAmount = 100;
+    $totalAmount = 330;
+    list($changeFTAmount, $ignoreChangeAmount, $oldTaxAmounts) = CRM_Contribute_BAO_Contribution::calculateFTChangeAmount($params, $trxnAmount, $totalAmount);
+    $this->assertEquals($totalAmount, 320, 'Amount does not match.');
+    $this->assertEquals($ignoreChangeAmount, FALSE);
+    $this->assertEquals($changeFTAmount, 110, 'Amount does not match.');
+    $this->assertEquals($oldTaxAmounts['new_tax_amount'], 20, 'Amount does not match.');
+    $this->assertEquals($oldTaxAmounts['previous_tax_amount'], 0, 'Amount does not match.');
+  }
+
+  /**
    * Alter Line Item array to calculate tax change and other contribution attributes.
    *
    * @param array $contribution

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -1158,7 +1158,7 @@ Price Field - Price Field 1        1   $ 100.00      $ 100.00
     $this->assertEquals(100, $items['values'][0]['amount']);
     $this->assertEquals(10, $items['values'][1]['amount']);
     // @todo currently its $110 which is incorrect, the proper value should be $200
-    // $this->assertEquals(200, $items['values'][2]['amount']);
+    $this->assertEquals(200, $items['values'][2]['amount']);
     $this->assertEquals(20, $items['values'][3]['amount']);
   }
 


### PR DESCRIPTION
* [CRM-19585: Sales tax issues](https://issues.civicrm.org/jira/browse/CRM-19585)

---

 * [CRM-20276: When editing a contribution the value in civicrm_financial_item_amount is not updated](https://issues.civicrm.org/jira/browse/CRM-20276)
 * [CRM-20257: Contribution Receipts doesn't include tax details](https://issues.civicrm.org/jira/browse/CRM-20257)
 * [CRM-20259: Update to Contribution with multiple priceset via api updates the total amount and tax amount](https://issues.civicrm.org/jira/browse/CRM-20259)
 * [CRM-20260: Incorrect information is stored in civicrm_financial_item table](https://issues.civicrm.org/jira/browse/CRM-20260)
 * [CRM-20262: Financial records are incorrectly recorded when there is change in contribution](https://issues.civicrm.org/jira/browse/CRM-20262)