### PR TITLE
CRM-18177 - Do not update existing membership status if renewal payme…

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -1727,7 +1727,19 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
     if ($contributionStatusId == array_search('Cancelled', $contributionStatuses)) {
       if (is_array($memberships)) {
         foreach ($memberships as $membership) {
-          if ($membership) {
+          $update = TRUE;
+          //Update Membership status if there is no other completed contribution associated with the membership.
+          $relatedContributions = CRM_Member_BAO_Membership::getMembershipContributionId($membership->id, TRUE);
+          foreach ($relatedContributions as $contriId) {
+            if ($contriId == $contributionId) {
+              continue;
+            }
+            $status = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $contriId, 'contribution_status_id');
+            if ($status == array_search('Completed', $contributionStatuses)) {
+              $update = FALSE;
+            }
+          }
+          if ($membership && $update) {
             $newStatus = array_search('Cancelled', $membershipStatuses);
 
             // Create activity
@@ -1777,7 +1789,19 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
     elseif ($contributionStatusId == array_search('Failed', $contributionStatuses)) {
       if (is_array($memberships)) {
         foreach ($memberships as $membership) {
-          if ($membership) {
+          $update = TRUE;
+          //Update Membership status if there is no other completed contribution associated with the membership.
+          $relatedContributions = CRM_Member_BAO_Membership::getMembershipContributionId($membership->id, TRUE);
+          foreach ($relatedContributions as $contriId) {
+            if ($contriId == $contributionId) {
+              continue;
+            }
+            $status = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $contriId, 'contribution_status_id');
+            if ($status == array_search('Completed', $contributionStatuses)) {
+              $update = FALSE;
+            }
+          }
+          if ($membership && $update) {
             $membership->status_id = array_search('Expired', $membershipStatuses);
             $membership->save();
 

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -1734,8 +1734,7 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
             if ($contriId == $contributionId) {
               continue;
             }
-            $status = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $contriId, 'contribution_status_id');
-            if ($status == array_search('Completed', $contributionStatuses)) {
+            if (CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $contriId) === 'Completed') {
               $update = FALSE;
             }
           }
@@ -1796,8 +1795,7 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
             if ($contriId == $contributionId) {
               continue;
             }
-            $status = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $contriId, 'contribution_status_id');
-            if ($status == array_search('Completed', $contributionStatuses)) {
+            if (CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $contriId) === 'Completed') {
               $update = FALSE;
             }
           }

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -2121,14 +2121,24 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = membership.contact_id AND 
    *
    * @param int $membershipId
    *   Membership id.
+   * @all bool
+   *   if more than one payment associated with membership id need to be returned.
    *
    * @return int
    *   contribution id
    */
-  public static function getMembershipContributionId($membershipId) {
+  public static function getMembershipContributionId($membershipId, $all = FALSE) {
 
     $membershipPayment = new CRM_Member_DAO_MembershipPayment();
     $membershipPayment->membership_id = $membershipId;
+    if ($all && $membershipPayment->find()) {
+      $contributionIds = array();
+      while ($membershipPayment->fetch()) {
+        $contributionIds[] = $membershipPayment->contribution_id;
+      }
+      return $contributionIds;
+    }
+
     if ($membershipPayment->find(TRUE)) {
       return $membershipPayment->contribution_id;
     }


### PR DESCRIPTION
…nt is failed

Updating a contribution to `Failed` or `Cancelled` updates the existing membership to Expired even if the membership has a completed contribution attached to it. This patch + unit test avoids such update if a membership has a completed payment associated with it.

https://issues.civicrm.org/jira/browse/CRM-18177