### PR TITLE
GenCode - Reduce merge-conflicts on AllCoreTables

### DIFF
--- a/CRM/Core/CodeGen/Reflection.php
+++ b/CRM/Core/CodeGen/Reflection.php
@@ -21,9 +21,11 @@ class CRM_Core_CodeGen_Reflection extends CRM_Core_CodeGen_BaseTask {
       return TRUE;
     }
 
-    if ($this->getSchemaChecksum() !== self::extractRegex($this->getAbsFileName(), ';\(GenCodeChecksum:([a-zA-Z0-9]+)\);')) {
-      return TRUE;
-    }
+    // Generating this file is fairly cheap, and we don't have robust heuristic
+    // for the checksum.
+    //    if ($this->getSchemaChecksum() !== self::extractRegex($this->getAbsFileName(), ';\(GenCodeChecksum:([a-zA-Z0-9]+)\);')) {
+    //      return TRUE;
+    //    }
 
     return !$this->isApproxPhpMatch(
       file_get_contents($this->getAbsFileName()),
@@ -38,7 +40,7 @@ class CRM_Core_CodeGen_Reflection extends CRM_Core_CodeGen_BaseTask {
     echo "Generating table list\n";
     $template = new CRM_Core_CodeGen_Util_Template('php');
     $template->assign('tables', $this->tables);
-    $template->assign('genCodeChecksum', $this->getSchemaChecksum());
+    $template->assign('genCodeChecksum', 'IGNORE');
     $template->run('listAll.tpl', $this->getAbsFileName());
   }
 
@@ -66,18 +68,18 @@ class CRM_Core_CodeGen_Reflection extends CRM_Core_CodeGen_BaseTask {
     return $this->config->CoreDAOCodePath . "AllCoreTables.data.php";
   }
 
-  /**
-   * Get the checksum for the schema.
-   *
-   * @return string
-   */
-  protected function getSchemaChecksum() {
-    if (!$this->checksum) {
-      CRM_Utils_Array::flatten($this->tables, $flat);
-      ksort($flat);
-      $this->checksum = md5(json_encode($flat));
-    }
-    return $this->checksum;
-  }
+  //   /**
+  //    * Get the checksum for the schema.
+  //    *
+  //    * @return string
+  //    */
+  //   protected function getSchemaChecksum() {
+  //     if (!$this->checksum) {
+  //       CRM_Utils_Array::flatten($this->tables, $flat);
+  //       ksort($flat);
+  //       $this->checksum = md5(json_encode($flat));
+  //     }
+  //     return $this->checksum;
+  //   }
 
 }

--- a/CRM/Core/DAO/AllCoreTables.data.php
+++ b/CRM/Core/DAO/AllCoreTables.data.php
@@ -24,7 +24,7 @@
 | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
 +--------------------------------------------------------------------+
 */
-// (GenCodeChecksum:345a72fb0f5f60672c3145e2fd078a37)
+// (GenCodeChecksum:IGNORE)
 return array(
   'CRM_Core_DAO_AddressFormat' => array(
     'name' => 'AddressFormat',


### PR DESCRIPTION
The previous checksum was based on the full schema spec.  This is
technically safe, but many irrelevant schema changes (such as editing field
comments) will ding the checksum.

The main goal here is to avoid `$template->run()` (line ~44) and its
code-beautifier (which is expensive/slow).  This revised algorithm for
`needsUpdate()` should:

 * Still be "fast enough" (given that it's a singular file built from a simple template)
 * Still be "accurate enough" (given that `getRaw()` is a fair predictor of `run()`)
 * Be less prone to merge-conflics (given that it doesn't use the checksum)

Ping @colemanw 