### PR TITLE
CRM-20264 make pan_truncation save on contribution form, additional payment, event

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3223,6 +3223,9 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       if (!empty($financialTrxnValues)) {
         $trxnParams = array_merge($trxnParams, $financialTrxnValues);
       }
+      if (empty($trxnParams['payment_processor_id'])) {
+        unset($trxnParams['payment_processor_id']);
+      }
 
       $params['trxnParams'] = $trxnParams;
 

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3381,6 +3381,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
         // records finanical trxn and entity financial trxn
         // also make it available as return value
         self::recordAlwaysAccountsReceivable($trxnParams, $params);
+        $trxnParams['pan_truncation'] = CRM_Utils_Array::value('pan_truncation', $params);
         $return = $financialTxn = CRM_Core_BAO_FinancialTrxn::create($trxnParams);
         $params['entity_id'] = $financialTxn->id;
         if (empty($params['partial_payment_total']) && empty($params['partial_amount_pay'])) {
@@ -3803,6 +3804,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       $params['partial_payment_total'] = $contributionDAO->total_amount;
       $params['partial_amount_pay'] = $trxnsData['total_amount'];
       $trxnsData['net_amount'] = !empty($trxnsData['net_amount']) ? $trxnsData['net_amount'] : $trxnsData['total_amount'];
+      $params['pan_truncation'] = CRM_Utils_Array::value('pan_truncation', $trxnsData);
 
       // record the entry
       $financialTrxn = CRM_Contribute_BAO_Contribution::recordFinancialAccounts($params, $trxnsData);

--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -221,6 +221,7 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
     CRM_Core_Resources::singleton()->addVars('coreForm', array('contact_id' => (int) $this->_contactID));
     $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'add');
     $this->_mode = empty($this->_mode) ? CRM_Utils_Request::retrieve('mode', 'String', $this) : $this->_mode;
+    $this->assignPaymentRelatedVariables();
   }
 
   /**
@@ -643,6 +644,19 @@ WHERE  contribution_id = {$id}
 
     $billingDefaults = $this->getProfileDefaults('Billing', $this->_contactID);
     return array_merge($defaults, $billingDefaults);
+  }
+
+  /**
+   * Get the default payment instrument id.
+   *
+   * @return int
+   */
+  protected function getDefaultPaymentInstrumentId() {
+    $paymentInstrumentID = CRM_Utils_Request::retrieve('payment_instrument_id', 'Integer');
+    if ($paymentInstrumentID) {
+      return $paymentInstrumentID;
+    }
+    return key(CRM_Core_OptionGroup::values('payment_instrument', FALSE, FALSE, FALSE, 'AND is_default = 1'));
   }
 
 }

--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -53,6 +53,11 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
 
   protected $_refund = NULL;
 
+  /**
+   * @deprecated - use parent $this->contactID
+   *
+   * @var int
+   */
   protected $_contactId = NULL;
 
   protected $_contributorDisplayName = NULL;
@@ -77,10 +82,10 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
 
     parent::preProcess();
     $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this, TRUE);
+    // @todo don't set this - rely on parent $this->contactID
     $this->_contactId = CRM_Utils_Request::retrieve('cid', 'Positive', $this, TRUE);
     $this->_component = CRM_Utils_Request::retrieve('component', 'String', $this, TRUE);
     $this->_view = CRM_Utils_Request::retrieve('view', 'String', $this, FALSE);
-    $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE);
     $this->assign('component', $this->_component);
     $this->assign('id', $this->_id);
     $this->assign('suppressPaymentFormButtons', $this->isBeingCalledFromSelectorContext());
@@ -136,8 +141,6 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
     }
 
     list($this->_contributorDisplayName, $this->_contributorEmail) = CRM_Contact_BAO_Contact_Location::getEmailDetails($this->_contactId);
-
-    $this->assignPaymentRelatedVariables();
 
     $this->assign('contributionMode', $this->_mode);
     $this->assign('contactId', $this->_contactId);

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -253,7 +253,6 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     $this->assign('showCheckNumber', TRUE);
 
     $this->_fromEmails = CRM_Core_BAO_Email::getFromEmail();
-    $this->assignPaymentRelatedVariables();
 
     if (in_array('CiviPledge', CRM_Core_Config::singleton()->enableComponents) && !$this->_formType) {
       $this->preProcessPledge();
@@ -1897,19 +1896,6 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     }
 
     return 0;
-  }
-
-  /**
-   * Get the default payment instrument id.
-   *
-   * @return int
-   */
-  protected function getDefaultPaymentInstrumentId() {
-    $paymentInstrumentID = CRM_Utils_Request::retrieve('payment_instrument_id', 'Integer');
-    if ($paymentInstrumentID) {
-      return $paymentInstrumentID;
-    }
-    return key(CRM_Core_OptionGroup::values('payment_instrument', FALSE, FALSE, FALSE, 'AND is_default = 1'));
   }
 
 }

--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -61,18 +61,6 @@ abstract class CRM_Core_Payment {
     BILLING_MODE_NOTIFY = 4;
 
   /**
-   * Which payment type(s) are we using?
-   *
-   * credit card
-   * direct debit
-   * or both
-   * @todo create option group - nb omnipay uses a 3rd type - transparent redirect cc
-   */
-  const
-    PAYMENT_TYPE_CREDIT_CARD = 1,
-    PAYMENT_TYPE_DIRECT_DEBIT = 2;
-
-  /**
    * Subscription / Recurring payment Status
    * START, END
    */

--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -774,6 +774,26 @@ abstract class CRM_Core_Payment {
         'is_required' => TRUE,
 
       ),
+      'check_number' => array(
+        'htmlType' => 'text',
+        'name' => 'check_number',
+        'title' => ts('Check Number'),
+        'is_required' => FALSE,
+        'cc_field' => TRUE,
+        'attributes' => NULL,
+      ),
+      'pan_truncation' => array(
+        'htmlType' => 'text',
+        'name' => 'pan_truncation',
+        'title' => ts('Last 4 digits of the card'),
+        'is_required' => FALSE,
+        'cc_field' => TRUE,
+        'attributes' => array(
+          'size' => 4,
+          'maxlength' => 4,
+          'autocomplete' => 'off',
+        ),
+      ),
     );
   }
 

--- a/CRM/Core/Payment/Manual.php
+++ b/CRM/Core/Payment/Manual.php
@@ -181,7 +181,7 @@ class CRM_Core_Payment_Manual extends CRM_Core_Payment {
    * @return string
    */
   public function getPaymentTypeLabel() {
-    return 'Payment';
+    return CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', $this->getPaymentInstrumentID());
   }
 
   /**

--- a/CRM/Core/Payment/Manual.php
+++ b/CRM/Core/Payment/Manual.php
@@ -84,8 +84,28 @@ class CRM_Core_Payment_Manual extends CRM_Core_Payment {
    * @return array
    */
   public function getPaymentFormFields() {
+    if (!$this->isBackOffice()) {
+      return array();
+    }
+
+    $paymentInstrument = CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', $this->getPaymentInstrumentID());
+    if ($paymentInstrument === 'Credit Card') {
+      // @todo - return credit_card_type field once the underlying code works to extract this field.
+      // Note the problem is this should be stored in civicrm_financial_trxn.credit_card_type.
+      // However there is an ambiguity as that field is an integer & should hence be called
+      // credit_card_type_id, or it should store 'visa' It probably makes sense to fix that before going much
+      // further as the code I've seen makes it clear that it will require work arounds.
+      return array('pan_truncation');
+    }
+    elseif ($paymentInstrument === 'Check') {
+      // Really we should render check_number here, but we need to review how we edit
+      // check_numebr since we expose it as editable on the contribution form,
+      // even though it should only be editable from a transation specific form.
+      return array();
+    }
     return array();
   }
+
   /**
    * Process payment.
    *
@@ -161,7 +181,7 @@ class CRM_Core_Payment_Manual extends CRM_Core_Payment {
    * @return string
    */
   public function getPaymentTypeLabel() {
-    return '';
+    return 'Payment';
   }
 
   /**

--- a/CRM/Event/Form/EventFees.php
+++ b/CRM/Event/Form/EventFees.php
@@ -410,10 +410,9 @@ SELECT  id, html_type
         CRM_Core_Session::setStatus(ts('You do not have all the permissions needed for this page.'), 'Permission Denied', 'error');
         return FALSE;
       }
-      if ($form->_mode) {
-        CRM_Core_Payment_Form::buildPaymentForm($form, $form->_paymentProcessor, FALSE, TRUE);
-      }
-      elseif (!$form->_mode) {
+
+      CRM_Core_Payment_Form::buildPaymentForm($form, $form->_paymentProcessor, FALSE, TRUE, self::getDefaultPaymentInstrumentId());
+      if (!$form->_mode) {
         $form->addElement('checkbox', 'record_contribution', ts('Record Payment?'), NULL,
           array('onclick' => "return showHideByValue('record_contribution','','payment_information','table-row','radio',false);")
         );
@@ -510,6 +509,21 @@ SELECT  id, html_type
     $mailingInfo = Civi::settings()->get('mailing_backend');
     $form->assign('outBound_option', $mailingInfo['outBound_option']);
     $form->assign('hasPayment', $form->_paymentId);
+  }
+
+  /**
+   * Get the default payment instrument id.
+   *
+   * @todo resolve relationship between this form & abstractEdit -which should be it's parent.
+   *
+   * @return int
+   */
+  protected static function getDefaultPaymentInstrumentId() {
+    $paymentInstrumentID = CRM_Utils_Request::retrieve('payment_instrument_id', 'Integer');
+    if ($paymentInstrumentID) {
+      return $paymentInstrumentID;
+    }
+    return key(CRM_Core_OptionGroup::values('payment_instrument', FALSE, FALSE, FALSE, 'AND is_default = 1'));
   }
 
 }

--- a/CRM/Member/Form.php
+++ b/CRM/Member/Form.php
@@ -167,9 +167,8 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
         $this->_processors, TRUE,
         array('onChange' => "buildAutoRenew( null, this.value, '{$this->_mode}');")
       );
-      CRM_Core_Payment_Form::buildPaymentForm($this, $this->_paymentProcessor, FALSE, TRUE);
     }
-
+    CRM_Core_Payment_Form::buildPaymentForm($this, $this->_paymentProcessor, FALSE, TRUE, $this->getDefaultPaymentInstrumentId());
     // Build the form for auto renew. This is displayed when in credit card mode or update mode.
     // The reason for showing it in update mode is not that clear.
     if ($this->_mode || ($this->_action & CRM_Core_Action::UPDATE)) {
@@ -302,8 +301,6 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
         $this->$classVar = $params[$paramKey];
       }
     }
-
-    $this->assignPaymentRelatedVariables();
 
     if ($this->_id) {
       $this->_memType = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_Membership', $this->_id, 'membership_type_id');

--- a/templates/CRM/Contribute/Form/AdditionalPayment.tpl
+++ b/templates/CRM/Contribute/Form/AdditionalPayment.tpl
@@ -99,7 +99,9 @@
       </td>
     </tr>
    </table>
+
     <div class="crm-accordion-wrapper crm-accordion_title-accordion crm-accordion-processed" id="paymentDetails_Information">
+      {if !$contributionMode}
       <div class="crm-accordion-header">
         {if $paymentType EQ 'refund'}{ts}Refund Details{/ts}{else}{ts}Payment Details{/ts}{/if}
       </div>
@@ -152,6 +154,7 @@
             <span class="description">{ts}Net value of the payment (Total Amount minus Fee).{/ts}</span></td></tr>
         </table>
       </div>
+      {/if}
       {include file='CRM/Core/BillingBlockWrapper.tpl'}
     </div>
 

--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -235,11 +235,6 @@
   </table>
 
   {if !$contributionMode}
-    <div class="crm-accordion-wrapper crm-accordion_title-accordion crm-accordion-processed" id="paymentDetails_Information">
-      <div class="crm-accordion-header">
-        {ts}Payment Details{/ts}
-      </div>
-      <div class="crm-accordion-body">
         <table class="form-layout-compressed" >
           <tr class="crm-contribution-form-block-receive_date">
             <td class="label">{$form.receive_date.label}</td>
@@ -287,8 +282,6 @@
             <td>{$form.from_email_address.html}</td>
           </tr>
         </table>
-      </div>
-    </div>
   {/if}
 
   {include file='CRM/Core/BillingBlockWrapper.tpl'}

--- a/templates/CRM/Event/Form/EventFees.tpl
+++ b/templates/CRM/Event/Form/EventFees.tpl
@@ -97,26 +97,13 @@
            </fieldset>
            </td>
         </tr>
-
-        {* Record contribution field only present if we are NOT in submit credit card mode (! participantMode). *}
-        {include file="CRM/common/showHideByFieldValue.tpl"
-            trigger_field_id    ="record_contribution"
-            trigger_value       =""
-            target_element_id   ="payment_information"
-            target_element_type ="table-row"
-            field_type          ="radio"
-            invert              = 0
-        }
     {/if}
     </table>
 
 {/if}
 
-{* credit card block when it is live or test mode*}
-{if $participantMode and $paid}
-  <div class="spacer"></div>
-  {include file='CRM/Core/BillingBlockWrapper.tpl'}
-{/if}
+{include file='CRM/Core/BillingBlockWrapper.tpl'}
+
 {if ($email OR $batchEmail) and $outBound_option != 2}
     <fieldset id="send_confirmation_receipt"><legend>{if $paid}{ts}Registration Confirmation and Receipt{/ts}{else}{ts}Registration Confirmation{/ts}{/if}</legend>
       <table class="form-layout" style="width:auto;">

--- a/templates/CRM/common/paymentBlock.tpl
+++ b/templates/CRM/common/paymentBlock.tpl
@@ -133,6 +133,10 @@
         buildPaymentBlock($(this).val());
     });
 
+    $('#payment_instrument_id').on('change.paymentBlock', function() {
+      buildPaymentBlock(0);
+    });
+
     $('#billing-payment-block').on('crmLoad', function() {
       $('.crm-submit-buttons input').prop('disabled', false);
     })

--- a/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
@@ -127,7 +127,7 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
 
   /**
    * Test the submit function that completes the partially paid Contribution using Credit Card.
-
+   */
   public function testAddPaymentUsingCreditCardForPartialyPaidContribution() {
     $this->createContribution('Partially paid');
 
@@ -135,7 +135,6 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
     $this->submitPayment(70, 'live');
     $this->checkResults(array(30, 70), 2);
   }
-   */
 
   /**
    * Test the submit function that completes the partially paid Contribution.
@@ -163,10 +162,11 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
     $this->submitPayment(20);
     $this->checkResults(array(30, 50, 20), 3);
   }
+
   /**
    * Test the submit function that completes the partially paid Contribution with multiple payments.
-   *
-  public function testMultiplePaymentForPartialyPaidContributionWithOneCreditCardPayment() {
+   */
+  public function testMultiplePaymentForPartiallyPaidContributionWithOneCreditCardPayment() {
     $this->createContribution('Partially paid');
 
     // pay additional amount
@@ -179,10 +179,9 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
     $this->checkResults(array(30, 50, 20), 3);
   }
 
-
   /**
    * Test the submit function that completes the pending pay later Contribution using Credit Card.
-   *
+   */
   public function testAddPaymentUsingCreditCardForPendingPayLaterContribution() {
     $this->createContribution('Pending');
 
@@ -190,7 +189,6 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
     $this->submitPayment(100, 'live');
     $this->checkResults(array(100), 1);
   }
-   */
 
   /**
    * Test the submit function that completes the pending pay later Contribution.
@@ -233,7 +231,7 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
 
   /**
    * Test the submit function that completes the pending pay later Contribution with multiple payments.
-   *
+   */
   public function testMultiplePaymentForPendingPayLaterContributionWithOneCreditCardPayment() {
     $this->createContribution('Pending');
 
@@ -253,7 +251,6 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
     $this->submitPayment(10, 'live');
     $this->checkResults(array(50, 20, 20, 10), 4);
   }
-   */
 
   /**
    * Function to create pending pay later or partially paid conntribution.
@@ -303,6 +300,7 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
       'receive_date' => '04/21/2015',
       'receive_date_time' => '11:27PM',
       'trxn_date' => '2017-04-11 13:05:11',
+      'payment_processor_id' => 0,
     );
     if ($mode) {
       $submitParams += array(

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -431,6 +431,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
    */
   public function testSubmit() {
     $form = $this->getForm();
+    $form->preProcess();
     $this->mut = new CiviMailUtils($this, TRUE);
     $form->_mode = 'test';
     $this->createLoggedInUser();
@@ -538,6 +539,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
    */
   public function testFormStatusUpdate() {
     $form = $this->getForm();
+    $form->preProcess();
     $this->_individualId = $this->createLoggedInUser();
     $memParams = array(
       'contact_id' => $this->_individualId,
@@ -580,6 +582,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
    */
   public function testSubmitPayLaterWithBilling() {
     $form = $this->getForm(NULL);
+    $form->preProcess();
     $this->createLoggedInUser();
     $params = array(
       'cid' => $this->_individualId,
@@ -706,6 +709,7 @@ Expires: ',
    */
   public function testFormWithFailedContribution() {
     $form = $this->getForm();
+    $form->preProcess();
     $this->createLoggedInUser();
     $params = $this->getBaseSubmitParams();
     unset($params['price_set_id']);
@@ -739,7 +743,6 @@ Expires: ',
     $form = new CRM_Member_Form_Membership();
     $_SERVER['REQUEST_METHOD'] = 'GET';
     $form->controller = new CRM_Core_Controller();
-    $form->_bltID = 5;
     return $form;
   }
 


### PR DESCRIPTION
@monishdeb here is what it takes to get the event form working - see the last commit

Note I moved
    $this->assignPaymentRelatedVariables();

to the shared preProcess function rather than just add it to one form

---

 * [CRM-20264: Store CC type and last 4 digits from Contribution form](https://issues.civicrm.org/jira/browse/CRM-20264)