### PR TITLE
CRM-20450: Fix invoice math for partial payments.

### DIFF
--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -105,10 +105,10 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
     }
     $this->_fromEmails = CRM_Core_BAO_Email::getFromEmail();
 
-    $enitityType = NULL;
-    $enitityType = 'contribution';
+    $entityType = NULL;
+    $entityType = 'contribution';
     if ($this->_component == 'event') {
-      $enitityType = 'participant';
+      $entityType = 'participant';
       $this->_contributionId = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_ParticipantPayment', $this->_id, 'contribution_id', 'participant_id');
       $eventId = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Participant', $this->_id, 'event_id', 'id');
       $this->_fromEmails = CRM_Event_BAO_Event::getFromEmailIds($eventId);
@@ -118,7 +118,7 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
       $this->_fromEmails['from_email_id'] = CRM_Core_BAO_Email::getFromEmail();
     }
 
-    $paymentInfo = CRM_Core_BAO_FinancialTrxn::getPartialPaymentWithType($this->_id, $enitityType);
+    $paymentInfo = CRM_Core_BAO_FinancialTrxn::getPartialPaymentWithType($this->_id, $entityType);
     $paymentDetails = CRM_Contribute_BAO_Contribution::getPaymentInfo($this->_id, $this->_component, FALSE, TRUE);
 
     $this->_amtPaid = $paymentDetails['paid'];

--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -105,7 +105,6 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
     }
     $this->_fromEmails = CRM_Core_BAO_Email::getFromEmail();
 
-    $entityType = NULL;
     $entityType = 'contribution';
     if ($this->_component == 'event') {
       $entityType = 'participant';

--- a/CRM/Contribute/Form/Task/Invoice.php
+++ b/CRM/Contribute/Form/Task/Invoice.php
@@ -332,7 +332,7 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
             'contribution_id' => $contribID,
       ));
       $amountPaid = 0;
-      foreach($resultPayments['values'] as $singlePayment) {
+      foreach ($resultPayments['values'] as $singlePayment) {
         // Only count payments that have been (status =) completed.
         if ($singlePayment['status_id'] == 1) {
           $amountPaid += $singlePayment['total_amount'];
@@ -430,7 +430,7 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
         'defaultCurrency' => $config->defaultCurrency,
         'amount' => $contribution->total_amount,
         'amountDue' => $amountDue,
-        'amountPaid'=> $amountPaid,
+        'amountPaid' => $amountPaid,
         'invoice_date' => $invoiceDate,
         'dueDate' => $dueDate,
         'notes' => CRM_Utils_Array::value('notes', $prefixValue),

--- a/CRM/Contribute/Form/Task/Invoice.php
+++ b/CRM/Contribute/Form/Task/Invoice.php
@@ -333,7 +333,7 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
       ));
       $amountPaid = 0;
       foreach($resultPayments['values'] as $singlePayment) {
-        // Only count payments that have been (status =) completed
+        // Only count payments that have been (status =) completed.
         if ($singlePayment['status_id'] == 1) {
           $amountPaid += $singlePayment['total_amount'];
         }

--- a/CRM/Upgrade/4.7.19.msg_template/message_templates/contribution_invoice_receipt_html.tpl
+++ b/CRM/Upgrade/4.7.19.msg_template/message_templates/contribution_invoice_receipt_html.tpl
@@ -1,0 +1,458 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns = "http://www.w3.org/1999/xhtml">
+  <head>
+    <meta http-equiv = "Content-Type" content="text/html; charset=UTF-8" />
+      <title></title>
+  </head>
+  <body>
+    <table style = "margin-top:2px;padding-left:7px;">
+      <tr>
+        <td><img src = "{$resourceBase}/i/civi99.png" height = "34px" width = "99px"></td>
+      </tr>
+    </table>
+    <center>
+      <table style = "padding-right:19px;font-family: Arial, Verdana, sans-serif;" width = "500" height = "100" border = "0" cellpadding = "2" cellspacing = "1">
+        <tr>
+          <td style = "padding-left:15px;" ><b><font size = "4" align = "center">{ts}INVOICE{/ts}</font></b></td>
+          <td colspan = "1"></td>
+          <td style = "padding-left:70px;"><b><font size = "1" align = "center" >{ts}Invoice Date:{/ts}</font></b></td>
+          <td><font size = "1" align = "right">{$domain_organization}</font></td>
+        </tr>
+        <tr>
+          {if $organization_name}
+            <td style = "padding-left:17px;"><font size = "1" align = "center" >{$display_name}  ({$organization_name})</font></td>
+          {else}
+            <td style = "padding-left:15px;"><font size = "1" align = "center" >{$display_name}</font></td>
+          {/if}
+          <td colspan = "1"></td>
+          <td style = "padding-left:70px;"><font size = "1" align = "right">{$invoice_date}</font></td>
+          <td>
+            <font size = "1" align = "right">
+              {if $domain_street_address }{$domain_street_address}{/if}
+              {if $domain_supplemental_address_1 }{$domain_supplemental_address_1}{/if}
+            </font>
+          </td>
+        </tr>
+        <tr>
+          <td style = "padding-left:17px;"><font size = "1" align = "center">{$street_address}   {$supplemental_address_1}</font></td>
+          <td colspan = "1"></td>
+          <td style = "padding-left:70px;"><b><font size = "1" align = "right">{ts}Invoice Number:{/ts}</font></b></td>
+          <td>
+            <font size = "1" align = "right">
+              {if $domain_supplemental_address_2 }{$domain_supplemental_address_2}{/if}
+              {if $domain_state }{$domain_state}{/if}
+            </font>
+          </td>
+        </tr>
+        <tr>
+          <td style = "padding-left:17px;"><font size = "1" align = "center">{$supplemental_address_2}  {$stateProvinceAbbreviation}</font></td>
+          <td colspan="1"></td>
+          <td style = "padding-left:70px;"><font size = "1" align = "right">{$invoice_id}</font></td>
+          <td>
+            <font size = "1" align = "right">
+              {if $domain_city}{$domain_city}{/if}
+              {if $domain_postal_code }{$domain_postal_code}{/if}
+            </font>
+          </td>
+        </tr>
+        <tr>
+          <td style = "padding-left:17px;"><font size = "1" align = "right">{$city}  {$postal_code}</font></td>
+          <td colspan="1"></td>
+          <td height = "10" style = "padding-left:70px;"><b><font size = "1"align = "right">{ts}Reference:{/ts}</font></b></td>
+          <td><font size = "1" align = "right"> {if $domain_country}{$domain_country}{/if}</font></td>
+        </tr>
+        <tr>
+          <td></td>
+          <td></td>
+          <td style = "padding-left:70px;"><font size = "1"align = "right">{$source}</font></td>
+          <td><font size = "1" align = "right"> {if $domain_phone}{$domain_phone}{/if}</font> </td>
+        </tr>
+        <tr>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td><font size = "1" align = "right"> {if $domain_email}{$domain_email}{/if}</font> </td>
+        </tr>
+      </table>
+      <table style = "margin-top:75px;font-family: Arial, Verdana, sans-serif" width = "590" border = "0"cellpadding = "-5" cellspacing = "19" id = "desc">
+        <tr>
+          <td colspan = "2" {$valueStyle}>
+            <table> {* FIXME: style this table so that it looks like the text version (justification, etc.) *}
+              <tr>
+                <th style = "padding-right:34px;text-align:left;font-weight:bold;width:200px;"><font size = "1">{ts}Description{/ts}</font></th>
+                <th style = "padding-left:34px;text-align:right;font-weight:bold;" ><font size = "1">{ts}Quantity{/ts}</font></th>
+                <th style = "padding-left:34px;text-align:right;font-weight:bold;"><font size = "1">{ts}Unit Price{/ts}</font></th>
+                <th style = "padding-left:34px;text-align:right;font-weight:bold;width:20px;"><font size = "1">{$taxTerm} </font></th>
+                <th style = "padding-left:34px;text-align:right;font-weight:bold;"><font size = "1">{ts 1=$defaultCurrency}Amount %1{/ts}</font></th>
+              </tr>
+              {foreach from=$lineItem item=value key=priceset name=taxpricevalue}
+                {if $smarty.foreach.taxpricevalue.index eq 0}
+                  <tr>
+                    <td colspan = "5" ><hr size="3" style = "color:#000;"></hr></td>
+                  </tr>
+                {else}
+                  <tr>
+                    <td  colspan = "5" style = "color:#F5F5F5;"><hr></hr></td>
+                  </tr>
+                {/if}
+                <tr>
+                  <td style="text-align:left;" ><font size = "1">
+                    {if $value.html_type eq 'Text'}
+                      {$value.label}
+                    {else}
+                      {$value.field_title} - {$value.label}
+                    {/if}
+                    {if $value.description}
+                      <div>{$value.description|truncate:30:"..."}</div>
+                    {/if}
+                    </font>
+                  </td>
+                  <td style = "padding-left:34px;text-align:right;"><font size = "1"> {$value.qty}</font></td>
+                  <td style = "padding-left:34px;text-align:right;"><font size = "1"> {$value.unit_price|crmMoney:$currency}</font></td>
+                  {if $value.tax_amount != ''}
+                    <td style = "padding-left:34px;text-align:right;width:20px;"><font size = "1"> {$value.tax_rate}%</font></td>
+                  {else}
+                    <td style = "padding-left:34px;text-align:right;width:20px;"><font size = "1">{ts 1=$taxTerm}No %1{/ts}</font></td>
+                  {/if}
+                  <td style = "padding-left:34px;text-align:right;"><font size = "1">{$value.subTotal|crmMoney:$currency}</font></td>
+                </tr>
+              {/foreach}
+              <tr><td  colspan = "5" style = "color:#F5F5F5;"><hr></hr></td></tr>
+              <tr>
+                <td colspan = "3"></td>
+                <td style = "padding-left:20px;text-align:right;"><font size = "1">{ts}Sub Total{/ts}</font></td>
+                <td style = "padding-left:34px;text-align:right;"><font size = "1"> {$subTotal|crmMoney:$currency}</font></td>
+              </tr>
+              {foreach from = $dataArray item = value key = priceset}
+                <tr>
+                  <td colspan = "3"></td>
+                    {if $priceset}
+                      <td style = "padding-left:20px;text-align:right;"><font size = "1"> {ts 1=$taxTerm 2=$priceset}TOTAL %1 %2%{/ts}</font></td>
+                      <td style = "padding-left:34px;text-align:right"><font size = "1" align = "right">{$value|crmMoney:$currency}</font> </td>
+                    {elseif $priceset == 0}
+                      <td style = "padding-left:20px;text-align:right;"><font size = "1">{ts 1=$taxTerm}TOTAL NO %1{/ts}</font></td>
+                      <td style = "padding-left:34px;text-align:right"><font size = "1" align = "right">{$value|crmMoney:$currency}</font> </td>
+                </tr>
+              {/if}
+              {/foreach}
+              <tr>
+                <td colspan = "3"></td>
+                <td colspan = "2"><hr></hr></td>
+              </tr>
+              <tr>
+                <td colspan = "3"></td>
+                <td style = "padding-left:20px;text-align:right;"><b><font size = "1">{ts 1=$defaultCurrency}TOTAL %1{/ts}</font></b></td>
+                <td style = "padding-left:34px;text-align:right;"><font size = "1">{$amount|crmMoney:$currency}</font></td>
+                <td style = "padding-left:34px;"><font size = "1" align = "right"></fonts></td>
+              </tr>
+              {if $is_pay_later == 0}
+                <tr>
+                  <td colspan = "3"></td>
+                  <td style = "padding-left:20px;text-align:right;"><font size = "1">
+                    {if $contribution_status_id == $refundedStatusId}
+                      {ts}LESS Amount Credited{/ts}
+                    {else}
+                      {ts}LESS Amount Paid{/ts}
+                    {/if}
+                    </font>
+                  </td>
+                  <td style = "padding-left:34px;text-align:right;"><font size = "1">{$amountPaid|crmMoney:$currency}</font></td>
+                </tr>
+                <tr>
+                  <td colspan = "3"></td>
+                  <td colspan = "2" ><hr></hr></td>
+                </tr>
+                <tr>
+                  <td colspan = "3"></td>
+                  <td style = "padding-left:20px;text-align:right;"><b><font size = "1">{ts}AMOUNT DUE:{/ts} </font></b></td>
+                  <td style = "padding-left:34px;text-align:right;"><b><font size = "1">{$amountDue|crmMoney:$currency}</font></b></td>
+                  <td style = "padding-left:34px;"><font size = "1" align = "right"></fonts></td>
+                </tr>
+              {/if}
+              <br/><br/><br/>
+              <tr>
+                <td colspan = "3"></td>
+              </tr>
+              {if $contribution_status_id == $pendingStatusId && $is_pay_later == 1}
+                <tr>
+                  <td><b><font size = "1" align = "center">{ts 1=$dueDate}DUE DATE: %1{/ts}</font></b></td>
+                  <td colspan = "3"></td>
+                </tr>
+              {/if}
+            </table>
+          </td>
+        </tr>
+      </table>
+      {if $contribution_status_id == $pendingStatusId && $is_pay_later == 1}
+        <table style = "margin-top:5px;padding-right:45px;">
+          <tr>
+            <td><img src = "{$resourceBase}/i/contribute/cut_line.png" height = "15" width = "630"></td>
+          </tr>
+        </table>
+        <table style = "margin-top:6px;padding-right:20px;font-family: Arial, Verdana, sans-serif" width = "480" border = "0"cellpadding = "-5" cellspacing="19" id = "desc">
+          <tr>
+            <td width="60%"><b><font size = "4" align = "right">{ts}PAYMENT ADVICE{/ts}</font></b> <br/><br/> <font size = "1" align = "right"><b>{ts}To: {/ts}</b><div style="width:17em;word-wrap:break-word;">
+              {$domain_organization} <br />
+              {$domain_street_address} {$domain_supplemental_address_1} <br />
+              {$domain_supplemental_address_2} {$domain_state} <br />
+              {$domain_city} {$domain_postal_code} <br />
+              {$domain_country} <br />
+              {$domain_phone} <br />
+              {$domain_email}</div>
+              </font><br/><br/><font size="1" align="right">{$notes}</font>
+            </td>
+            <td width="40%">
+              <table  cellpadding = "-10" cellspacing = "22"  align="right" >
+                <tr>
+                  <td colspan = "2"></td>
+                  <td><font size = "1" align = "right" style="font-weight:bold;">{ts}Customer: {/ts}</font></td>
+                  <td ><font size = "1" align = "right">{$display_name}</font></td>
+                </tr>
+                <tr>
+                  <td colspan = "2"></td>
+                  <td><font size = "1" align = "right" style="font-weight:bold;">{ts}Invoice Number: {/ts}</font></td>
+                  <td><font size = "1" align = "right">{$invoice_id}</font></td>
+                </tr>
+                <tr><td colspan = "5"style = "color:#F5F5F5;"><hr></hr></td></tr>
+                {if $is_pay_later == 1}
+                  <tr>
+                    <td colspan = "2"></td>
+                    <td><font size = "1" align = "right" style="font-weight:bold;">{ts}Amount Due:{/ts}</font></td>
+                    <td><font size = "1" align = "right" style="font-weight:bold;">{$amount|crmMoney:$currency}</font></td>
+                  </tr>
+                {else}
+                  <tr>
+                    <td colspan = "2"></td>
+                    <td><font size = "1" align = "right" style="font-weight:bold;">{ts}Amount Due: {/ts}</font></td>
+                    <td><font size = "1" align = "right" style="font-weight:bold;">{$amountDue|crmMoney:$currency}</font></td>
+                  </tr>
+                {/if}
+                <tr>
+                  <td colspan = "2"></td>
+                  <td><font size = "1" align = "right" style="font-weight:bold;">{ts}Due Date:  {/ts}</font></td>
+                  <td><font size = "1" align = "right">{$dueDate}</font></td>
+                </tr>
+                <tr>
+                  <td colspan = "5" style = "color:#F5F5F5;"><hr></hr></td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+        </table>
+      {/if}
+
+      {if $contribution_status_id == $refundedStatusId || $contribution_status_id == $cancelledStatusId}
+        <table style = "margin-top:2px;padding-left:7px;page-break-before: always;">
+          <tr>
+            <td><img src = "{$resourceBase}/i/civi99.png" height = "34px" width = "99px"></td>
+          </tr>
+        </table>
+    <center>
+
+      <table style = "padding-right:19px;font-family: Arial, Verdana, sans-serif" width = "500" height = "100" border = "0" cellpadding = "2" cellspacing = "1">
+        <tr>
+          <td style = "padding-left:15px;" ><b><font size = "4" align = "center">{ts}CREDIT NOTE{/ts}</font></b></td>
+          <td colspan = "1"></td>
+          <td style = "padding-left:70px;"><b><font size = "1" align = "right">{ts}Date:{/ts}</font></b></td>
+          <td><font size = "1" align = "right">{$domain_organization}</font></td>
+        </tr>
+        <tr>
+          {if $organization_name}
+            <td style = "padding-left:17px;"><font size = "1" align = "center">{$display_name}  ({$organization_name})</font></td>
+          {else}
+            <td style = "padding-left:17px;"><font size = "1" align = "center">{$display_name}</font></td>
+          {/if}
+          <td colspan = "1"></td>
+          <td style = "padding-left:70px;"><font size = "1" align = "right">{$invoice_date}</font></td>
+          <td>
+            <font size = "1" align = "right">
+              {if $domain_street_address }{$domain_street_address}{/if}
+              {if $domain_supplemental_address_1 }{$domain_supplemental_address_1}{/if}
+            </font>
+          </td>
+        </tr>
+        <tr>
+          <td style = "padding-left:17px;"><font size = "1" align = "center">{$street_address}   {$supplemental_address_1}</font></td>
+          <td colspan = "1"></td>
+          <td style = "padding-left:70px;"><b><font size = "1" align = "right">{ts}Credit Note Number:{/ts}</font></b></td>
+          <td>
+            <font size = "1" align = "right">
+              {if $domain_supplemental_address_2 }{$domain_supplemental_address_2}{/if}
+              {if $domain_state }{$domain_state}{/if}
+            </font>
+          </td>
+        </tr>
+        <tr>
+          <td style = "padding-left:17px;"><font size = "1" align = "center">{$supplemental_address_2}  {$stateProvinceAbbreviation}</font></td>
+          <td colspan="1"></td>
+          <td style = "padding-left:70px;"><font size = "1" align = "right">{$creditnote_id}</font></td>
+          <td>
+            <font size = "1" align = "right">
+              {if $domain_city}{$domain_city}{/if}
+              {if $domain_postal_code }{$domain_postal_code}{/if}
+            </font>
+          </td>
+        </tr>
+        <tr>
+          <td style = "padding-left:17px;"><font size = "1" align = "right">{$city}  {$postal_code}</font></td>
+          <td colspan="1"></td>
+          <td height = "10" style = "padding-left:70px;"><b><font size = "1"align = "right">{ts}Reference:{/ts}</font></b></td>
+          <td>
+            <font size = "1" align = "right">
+              {if $domain_country}{$domain_country}{/if}
+            </font>
+          </td>
+        </tr>
+        <tr>
+          <td></td>
+          <td></td>
+          <td style = "padding-left:70px;"><font size = "1"align = "right">{$source}</font></td>
+          <td>
+            <font size = "1" align = "right">
+              {if $domain_phone}{$domain_phone}{/if}
+            </font>
+          </td>
+        </tr>
+        <tr>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td>
+            <font size = "1" align = "right">
+              {if $domain_email}{$domain_email}{/if}
+            </font>
+          </td>
+        </tr>
+      </table>
+
+      <table style = "margin-top:75px;font-family: Arial, Verdana, sans-serif" width = "590" border = "0"cellpadding = "-5" cellspacing = "19" id = "desc">
+        <tr>
+          <td colspan = "2" {$valueStyle}>
+            <table> {* FIXME: style this table so that it looks like the text version (justification, etc.) *}
+              <tr>
+                <th style = "padding-right:28px;text-align:left;font-weight:bold;width:200px;"><font size = "1">{ts}Description{/ts}</font></th>
+                <th style = "padding-left:28px;text-align:right;font-weight:bold;"><font size = "1">{ts}Quantity{/ts}</font></th>
+                <th style = "padding-left:28px;text-align:right;font-weight:bold;"><font size = "1">{ts}Unit Price{/ts}</font></th>
+                <th style = "padding-left:28px;text-align:right;font-weight:bold;"><font size = "1">{$taxTerm} </font></th>
+                <th style = "padding-left:28px;text-align:right;font-weight:bold;"><font size = "1">{ts 1=$defaultCurrency}Amount %1{/ts}</font></th>
+              </tr>
+              {foreach from=$lineItem item=value key=priceset name=pricevalue}
+                {if $smarty.foreach.pricevalue.index eq 0}
+                  <tr><td  colspan = "5" ><hr size="3" style = "color:#000;"></hr></td></tr>
+                {else}
+                  <tr><td  colspan = "5" style = "color:#F5F5F5;"><hr></hr></td></tr>
+                {/if}
+                <tr>
+                  <td style ="text-align:left;"  >
+                    <font size = "1">
+                      {if $value.html_type eq 'Text'}
+                        {$value.label}
+                      {else}
+                        {$value.field_title} - {$value.label}
+                      {/if}
+                      {if $value.description}
+                        <div>{$value.description|truncate:30:"..."}</div>
+                      {/if}
+                    </font>
+                  </td>
+                  <td style = "padding-left:28px;text-align:right;"><font size = "1"> {$value.qty}</font></td>
+                  <td style = "padding-left:28px;text-align:right;"><font size = "1"> {$value.unit_price|crmMoney:$currency}</font></td>
+                  {if $value.tax_amount != ''}
+                    <td style = "padding-left:28px;text-align:right;"><font size = "1"> {$value.tax_rate}%</font></td>
+                  {else}
+                    <td style = "padding-left:28px;text-align:right"><font size = "1" >{ts 1=$taxTerm}No %1{/ts}</font></td>
+                  {/if}
+                  <td style = "padding-left:28px;text-align:right;"><font size = "1" >{$value.subTotal|crmMoney:$currency}</font></td>
+                </tr>
+              {/foreach}
+              <tr><td  colspan = "5" style = "color:#F5F5F5;"><hr></hr></td></tr>
+              <tr>
+                <td colspan = "3"></td>
+                <td style = "padding-left:28px;text-align:right;"><font size = "1">{ts}Sub Total{/ts}</font></td>
+                <td style = "padding-left:28px;text-align:right;"><font size = "1"> {$subTotal|crmMoney:$currency}</font></td>
+              </tr>
+              {foreach from = $dataArray item = value key = priceset}
+                <tr>
+                  <td colspan = "3"></td>
+                  {if $priceset}
+                    <td style = "padding-left:28px;text-align:right;"><font size = "1"> {ts 1=$taxTerm 2=$priceset}TOTAL %1 %2%{/ts}</font></td>
+                    <td style = "padding-left:28px;text-align:right;"><font size = "1" align = "right">{$value|crmMoney:$currency}</font> </td>
+                  {elseif $priceset == 0}
+                    <td style = "padding-left:28px;text-align:right;"><font size = "1">{ts 1=$taxTerm}TOTAL NO %1{/ts}</font></td>
+                    <td style = "padding-left:28px;text-align:right;"><font size = "1" align = "right">{$value|crmMoney:$currency}</font> </td>
+                </tr>
+                {/if}
+              {/foreach}
+              <tr>
+                <td colspan = "3"></td>
+                <td colspan = "2"><hr></hr></td>
+              </tr>
+              <tr>
+                <td colspan = "3"></td>
+                <td style = "padding-left:28px;text-align:right;"><b><font size = "1">{ts 1=$defaultCurrency}TOTAL %1{/ts}</font></b></td>
+                <td style = "padding-left:28px;text-align:right;"><font size = "1">{$amount|crmMoney:$currency}</font></td>
+              </tr>
+              {if $is_pay_later == 0}
+                <tr>
+                  <td colspan = "3"></td>
+                  <td style = "padding-left:28px;text-align:right;"><font size = "1" >{ts}LESS Credit to invoice(s){/ts}</font></td>
+                  <td style = "padding-left:28px;text-align:right;"><font size = "1">{$amount|crmMoney:$currency}</font></td>
+                </tr>
+                <tr>
+                  <td colspan = "3"></td>
+                  <td colspan = "2" ><hr></hr></td>
+                </tr>
+                <tr>
+                  <td colspan = "3"></td>
+                  <td style = "padding-left:28px;text-align:right;"><b><font size = "1">{ts}REMAINING CREDIT{/ts}</font></b></td>
+                  <td style = "padding-left:28px;text-align:right;"><b><font size = "1">{$amountDue|crmMoney:$currency}</font></b></td>
+                  <td style = "padding-left:28px;"><font size = "1" align = "right"></fonts></td>
+                </tr>
+              {/if}
+              <br/><br/><br/>
+              <tr>
+                <td colspan = "3"></td>
+              </tr>
+              <tr>
+                <td></td>
+                <td colspan = "3"></td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      </table>
+      <table style = "margin-top:5px;padding-right:45px;">
+        <tr>
+          <td><img src = "{$resourceBase}/i/contribute/cut_line.png" height = "15" width = "630"></td>
+        </tr>
+      </table>
+
+      <table style = "margin-top:6px;padding-right:20px;font-family: Arial, Verdana, sans-serif" width = "507" border = "0"cellpadding = "-5" cellspacing="19" id = "desc">
+        <tr>
+          <td width="60%"><font size = "4" align = "right"><b>{ts}CREDIT ADVICE{/ts}</b><br/><br /><div  style="font-size:10px;max-width:300px;">{ts}Please do not pay on this advice. Deduct the amount of this Credit Note from your next payment to us{/ts}</div><br/></font></td>
+          <td width="40%">
+            <table    align="right" >
+              <tr>
+                <td colspan = "2"></td>
+                <td><font size = "1" align = "right" style="font-weight:bold;">{ts}Customer:{/ts} </font></td>
+                <td><font size = "1" align = "right" >{$display_name}</font></td>
+              </tr>
+              <tr>
+                <td colspan = "2"></td>
+                <td><font size = "1" align = "right" style="font-weight:bold;">{ts}Credit Note#:{/ts} </font></td>
+                <td><font size = "1" align = "right">{$creditnote_id}</font></td>
+              </tr>
+              <tr><td  colspan = "5"style = "color:#F5F5F5;"><hr></hr></td></tr>
+              <tr>
+                <td colspan = "2"></td>
+                <td><font size = "1" align = "right" style="font-weight:bold;">{ts}Credit Amount:{/ts}</font></td>
+                <td width='50px'><font size = "1" align = "right" style="font-weight:bold;">{$amount|crmMoney:$currency}</font></td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      </table>
+    {/if}
+    </center>
+  </body>
+</html>

--- a/xml/templates/message_templates/contribution_invoice_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_invoice_receipt_html.tpl
@@ -101,7 +101,7 @@
                       {$value.label}
                     {else}
                       {$value.field_title} - {$value.label}
-                    {/if} 
+                    {/if}
                     {if $value.description}
                       <div>{$value.description|truncate:30:"..."}</div>
                     {/if}
@@ -143,6 +143,7 @@
                 <td colspan = "3"></td>
                 <td style = "padding-left:20px;text-align:right;"><b><font size = "1">{ts 1=$defaultCurrency}TOTAL %1{/ts}</font></b></td>
                 <td style = "padding-left:34px;text-align:right;"><font size = "1">{$amount|crmMoney:$currency}</font></td>
+                <td style = "padding-left:34px;"><font size = "1" align = "right"></fonts></td>
               </tr>
               {if $is_pay_later == 0}
                 <tr>
@@ -155,7 +156,7 @@
                     {/if}
                     </font>
                   </td>
-                  <td style = "padding-left:34px;text-align:right;"><font size = "1">{$amount|crmMoney:$currency}</font></td>
+                  <td style = "padding-left:34px;text-align:right;"><font size = "1">{$amountPaid|crmMoney:$currency}</font></td>
                 </tr>
                 <tr>
                   <td colspan = "3"></td>
@@ -307,7 +308,7 @@
           <td></td>
           <td style = "padding-left:70px;"><font size = "1"align = "right">{$source}</font></td>
           <td>
-            <font size = "1" align = "right"> 
+            <font size = "1" align = "right">
               {if $domain_phone}{$domain_phone}{/if}
             </font>
           </td>
@@ -317,9 +318,9 @@
           <td></td>
           <td></td>
           <td>
-            <font size = "1" align = "right"> 
+            <font size = "1" align = "right">
               {if $domain_email}{$domain_email}{/if}
-            </font> 
+            </font>
           </td>
         </tr>
       </table>
@@ -348,7 +349,7 @@
                         {$value.label}
                       {else}
                         {$value.field_title} - {$value.label}
-                      {/if} 
+                      {/if}
                       {if $value.description}
                         <div>{$value.description|truncate:30:"..."}</div>
                       {/if}


### PR DESCRIPTION
See screenshot:

![invoicemathpartialpaymentsiswrong](https://cloud.githubusercontent.com/assets/5340555/25208988/527df0ba-2535-11e7-9274-0afa64a04765.png)

 OK the root issue appears to be in this line of code:
 `$amountDue = ($input['amount'] - $input['amount']);`
[looks like it was a placeholder and never got worked out];

This PR also fixes https://issues.civicrm.org/jira/browse/CRM-19837

Re: /Upgrade -> do I simply copy the entire new version of the tpl into 4.7.19.msg_template/message_templates?

---

 * [CRM-20450: Fix invoice math for partial payments](https://issues.civicrm.org/jira/browse/CRM-20450)