### PR TITLE
CRM-20264: handle submission of CC type and number during 'record payment'

### DIFF
--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -358,10 +358,10 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
       // process credit card
       $this->assign('contributeMode', 'direct');
       $this->processCreditCard($submittedValues);
-      $submittedValues = $this->_params;
     }
 
     $defaults = array();
+    $submittedValues = $this->_params;
     $contribution = civicrm_api3('Contribution', 'getsingle', array(
       'return' => array("contribution_status_id"),
       'id' => $this->_contributionId,


### PR DESCRIPTION
* [CRM-20264: Store CC type and last 4 digits from Contribution form](https://issues.civicrm.org/jira/browse/CRM-20264)