### PR TITLE
CRM-20461 - Use api instead of query so that post hook gets invoked for additional participants

### DIFF
--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -1207,13 +1207,17 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
       CRM_Core_DAO::setFieldValue('CRM_Event_DAO_Participant', $participantID, 'status_id', $newStatusID);
     }
 
-    $cascadeAdditionalIds = self::getValidAdditionalIds($participantID, $oldStatusID, $newStatusID);
+    $additionalIds = self::getValidAdditionalIds($participantID, $oldStatusID, $newStatusID);
 
-    if (!empty($cascadeAdditionalIds)) {
-      $cascadeAdditionalIds = implode(',', $cascadeAdditionalIds);
+    if (!empty($additionalIds)) {
+      $cascadeAdditionalIds = implode(',', $additionalIds);
       $query = "UPDATE civicrm_participant cp SET cp.status_id = %1 WHERE  cp.id IN ({$cascadeAdditionalIds})";
       $params = array(1 => array($newStatusID, 'Integer'));
       $dao = CRM_Core_DAO::executeQuery($query, $params);
+      //Call post hook after updating additional participant status.
+      foreach ($additionalIds as $id) {
+        CRM_Utils_Hook::post('edit', 'Participant', $id);
+      }
       return TRUE;
     }
     return FALSE;

--- a/tests/phpunit/CRM/Utils/API/ReloadOptionTest.php
+++ b/tests/phpunit/CRM/Utils/API/ReloadOptionTest.php
@@ -109,23 +109,4 @@ class CRM_Utils_API_ReloadOptionTest extends CiviUnitTestCase {
     $this->assertAPISuccess($result['values'][0]['api.Email.create']);
   }
 
-  /**
-   * An implementation of hook_civicrm_post used with all our test cases.
-   *
-   * @param $op
-   * @param string $objectName
-   * @param int $objectId
-   * @param $objectRef
-   */
-  public function onPost($op, $objectName, $objectId, &$objectRef) {
-    if ($op == 'create' && $objectName == 'Individual') {
-      CRM_Core_DAO::executeQuery(
-        "UPDATE civicrm_contact SET nick_name = 'munged' WHERE id = %1",
-        array(
-          1 => array($objectId, 'Integer'),
-        )
-      );
-    }
-  }
-
 }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3812,4 +3812,31 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
     }
   }
 
+  /**
+   * An implementation of hook_civicrm_post used with all our test cases.
+   *
+   * @param $op
+   * @param string $objectName
+   * @param int $objectId
+   * @param $objectRef
+   */
+  public function onPost($op, $objectName, $objectId, &$objectRef) {
+    if ($op == 'create' && $objectName == 'Individual') {
+      CRM_Core_DAO::executeQuery(
+        "UPDATE civicrm_contact SET nick_name = 'munged' WHERE id = %1",
+        array(
+          1 => array($objectId, 'Integer'),
+        )
+      );
+    }
+
+    if ($op == 'edit' && $objectName == 'Participant') {
+      $params = array(
+        1 => array($objectId, 'Integer'),
+      );
+      $query = "UPDATE civicrm_participant SET source = 'Post Hook Update' WHERE id = %1";
+      CRM_Core_DAO::executeQuery($query, $params);
+    }
+  }
+
 }

--- a/tests/phpunit/api/v3/ParticipantTest.php
+++ b/tests/phpunit/api/v3/ParticipantTest.php
@@ -781,4 +781,35 @@ class api_v3_ParticipantTest extends CiviUnitTestCase {
     $this->callAPISuccess('contact', 'delete', array('id' => $result['id']));
   }
 
+  /**
+   * Test participant invoke post hook after status update.
+   */
+  public function testPostHookForAdditionalParticipant() {
+    $participantID = $this->participantCreate(array(
+      'contact_id' => $this->_contactID,
+      'status_id' => 5,
+      'event_id' => $this->_eventID,
+    ));
+    $participantID2 = $this->participantCreate(array(
+      'contact_id' => $this->_contactID2,
+      'event_id' => $this->_eventID,
+      'status_id' => 5,
+      'registered_by_id' => $participantID,
+    ));
+
+    $this->hookClass->setHook('civicrm_post', array($this, 'onPost'));
+    $params = array(
+      'id' => $participantID,
+      'status_id' => 1,
+    );
+    $this->callAPISuccess('Participant', 'create', $params);
+
+    $result = $this->callAPISuccess('Participant', 'get', array('source' => 'Post Hook Update'));
+    $this->assertEquals(2, $result['count']);
+
+    $expected = array($participantID, $participantID2);
+    $actual = array_keys($result['values']);
+    $this->checkArrayEquals($expected, $actual);
+  }
+
 }


### PR DESCRIPTION
* [CRM-20461: post hook not invoked after updating status for additional participants](https://issues.civicrm.org/jira/browse/CRM-20461)