### PR TITLE
CRM-20463 - simplify parsing of doc URLs and ensure all work.

### DIFF
--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1391,7 +1391,7 @@ class CRM_Utils_System {
    * @return mixed
    */
   public static function formatDocUrl($url) {
-    return preg_replace('#^user/((\w\w/)?(stable|current)/)?#', 'user/en/stable/', $url);
+    return preg_replace('#^user/#', 'user/en/stable/', $url);
   }
 
   /**

--- a/templates/CRM/ACL/Header.tpl
+++ b/templates/CRM/ACL/Header.tpl
@@ -23,7 +23,7 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-{capture assign=docLink}{docURL page='user/current/initial-set-up/permissions-and-access-control/' text='Access Control Documentation'}{/capture}
+{capture assign=docLink}{docURL page='user/initial-set-up/permissions-and-access-control/' text='Access Control Documentation'}{/capture}
 
 <div class="help">
   <p>{ts 1=$docLink}ACLs allow you to control access to CiviCRM data. An ACL consists of an <strong>Operation</strong> (e.g. 'View' or 'Edit'), a <strong>set of data</strong> that the operation can be performed on (e.g. a group of contacts), and a <strong>Role</strong> that has permission to do this operation. Refer to the %1 for more info.{/ts}</p>

--- a/templates/CRM/Admin/Page/Access.tpl
+++ b/templates/CRM/Admin/Page/Access.tpl
@@ -23,7 +23,7 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-{capture assign=docLink}{docURL page="user/current/initial-set-up/permissions-and-access-control/" text="Access Control Documentation"}{/capture}
+{capture assign=docLink}{docURL page="user/initial-set-up/permissions-and-access-control/" text="Access Control Documentation"}{/capture}
 <div class="help">
     <p>{ts 1=$docLink}ACLs (Access Control Lists) allow you control access to CiviCRM data. An ACL consists of an <strong>Operation</strong> (e.g. 'View' or 'Edit'), a <strong>set of Data</strong> that the operation can be performed on (e.g. a group of contacts), and a <strong>Role</strong> that has permission to do this operation. Refer to the %1 for more info.{/ts}
     {if $config->userSystem->is_drupal EQ '1'}{ts}Note that a CiviCRM ACL Role is not related to the Drupal Role.{/ts}{/if}</p>

--- a/templates/CRM/Admin/Page/MessageTemplates.hlp
+++ b/templates/CRM/Admin/Page/MessageTemplates.hlp
@@ -24,7 +24,7 @@
  +--------------------------------------------------------------------+
 *}
 {capture assign=tokenDocLink}{docURL page="user/common-workflows/tokens-and-mail-merge"}{/capture}
-{capture assign=schedRemindersDocLink}{docURL page="user/current/email/scheduled-reminders/"}{/capture}
+{capture assign=schedRemindersDocLink}{docURL page="user/email/scheduled-reminders/"}{/capture}
 {capture assign=schedRemURL}{crmURL p='civicrm/admin/scheduleReminders' q="reset=1"}{/capture}
 {capture assign=upgradeTemplatesDocLink}{docURL page="Updating System Workflow Message Templates after Upgrades - method 1 - kdiff" resource="wiki"}{/capture}
 {htxt id="id-intro-title"}

--- a/templates/CRM/Admin/Page/ScheduleReminders.tpl
+++ b/templates/CRM/Admin/Page/ScheduleReminders.tpl
@@ -33,7 +33,7 @@
    {include file="CRM/Admin/Form/ScheduleReminders.tpl"}
 {else}
   {if !$component}
-    {capture assign=schedRemindersDocLink}{docURL page="user/current/email/scheduled-reminders/"}{/capture}
+    {capture assign=schedRemindersDocLink}{docURL page="user/email/scheduled-reminders/"}{/capture}
     <div class="help">
       {ts}Scheduled reminders allow you to automatically send messages to contacts regarding their memberships, participation in events, or other activities.{/ts} {$schedRemindersDocLink}
     </div>

--- a/templates/CRM/Contact/Form/Search/Advanced.hlp
+++ b/templates/CRM/Contact/Form/Search/Advanced.hlp
@@ -65,7 +65,7 @@
 {ts}Views For Display Contacts{/ts}
 {/htxt}
 {htxt id="id-search-views"}
-    <p>{ts}If you are displaying the search results as contacts, you can modify the columns displayed by creating a Profile containing a different set of contact fields and then selecting that Profile here. For example you may want to include columns for Gender and Date of Birth, while eliminating Country.{/ts} {docURL page="user/current/organising-your-data/profiles"}</p>
+    <p>{ts}If you are displaying the search results as contacts, you can modify the columns displayed by creating a Profile containing a different set of contact fields and then selecting that Profile here. For example you may want to include columns for Gender and Date of Birth, while eliminating Country.{/ts} {docURL page="user/organising-your-data/profiles"}</p>
 {/htxt}
 
 {htxt id="id-search-operator-title"}

--- a/templates/CRM/Contact/Form/Task/SaveSearch.tpl
+++ b/templates/CRM/Contact/Form/Task/SaveSearch.tpl
@@ -39,7 +39,7 @@
       </ul>
     </div>
     {/if}
-    <p>{docURL page='user/current/organising-your-data/smart-groups/'}</p>
+    <p>{docURL page='user/organising-your-data/smart-groups/'}</p>
   </div>
   <table class="form-layout-compressed">
     <tr class="crm-contact-task-createsmartgroup-form-block-title">

--- a/templates/CRM/Event/Form/Task/SaveSearch.tpl
+++ b/templates/CRM/Event/Form/Task/SaveSearch.tpl
@@ -41,7 +41,7 @@
         </ul>
       </div>
     {/if}
-    <p>{docURL page='user/current/organising-your-data/smart-groups/'}</p>
+    <p>{docURL page='user/organising-your-data/smart-groups/'}</p>
   </div>
 
  <table class="form-layout-compressed">

--- a/templates/CRM/Group/Page/Group.hlp
+++ b/templates/CRM/Group/Page/Group.hlp
@@ -37,7 +37,7 @@
   {ts}Group Type{/ts}
 {/htxt}
 {htxt id="id-group-type"}
-{capture assign=docLinkAccess}{docURL page="user/current/initial-set-up/permissions-and-access-control/"}{/capture}
+{capture assign=docLinkAccess}{docURL page="user/initial-set-up/permissions-and-access-control/"}{/capture}
 {capture assign=docLinkMail}{docURL page="user/email/what-is-civimail" text="CiviMail component"}{/capture}
 <p>{if $config->userFramework neq 'Joomla'}{ts 1=$docLinkAccess}Check 'Access Control' if you want to use this group to assign access permissions to a set of contacts. %1{/ts}{/if} {ts 1=$docLinkMail}Check 'Mailing List' if you are using this group as a mailing list in the %1.{/ts}</p>
 {/htxt} 


### PR DESCRIPTION
It seems far simpler to fix the calls to docURL then it is to try to preg match away the bad data.

---

 * [CRM-20463: Documentation links with "current" in them are broken](https://issues.civicrm.org/jira/browse/CRM-20463)