### PR TITLE
CRM-20428: refactored sourceSQLFile

### DIFF
--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -190,10 +190,16 @@ class CRM_Upgrade_Form extends CRM_Core_Form {
    * @param bool $isQueryString
    */
   public function source($fileName, $isQueryString = FALSE) {
-
-    CRM_Utils_File::sourceSQLFile($this->_config->dsn,
-      $fileName, NULL, $isQueryString
-    );
+    if ($isQueryString) {
+      CRM_Utils_File::runSqlQuery($this->_config->dsn,
+        $fileName, NULL
+      );
+    }
+    else {
+      CRM_Utils_File::sourceSQLFile($this->_config->dsn,
+        $fileName, NULL
+      );
+    }
   }
 
   public function preProcess() {


### PR DESCRIPTION
Refactored sourceSQLFile by creating a separate function to run the SQL piece.

This means that sourceSQLFile no longer has an 'isQueryString' variable, which was used to pass an SQL query in the filename parameter.

This originally arose from https://github.com/civicrm/civicrm-core/commit/cf369463f26d4c3e478611093fa25763e5833207 where a mistake was nearly introduced because the paramerter filename could actually be an SQL query, not a file name, as the name filename implied.

---

 * [CRM-20428: Refactor CRM_Utils_File sourceSQLFile](https://issues.civicrm.org/jira/browse/CRM-20428)