### PR TITLE
Address fatal errors on PHP7.1 - only vars can be passed by reference.

### DIFF
--- a/api/v3/File.php
+++ b/api/v3/File.php
@@ -116,7 +116,8 @@ function civicrm_api3_file_update($params) {
     $fileDAO->save();
   }
   $file = array();
-  _civicrm_api3_object_to_array(clone($fileDAO), $file);
+  $cloneDAO = clone($fileDAO);
+  _civicrm_api3_object_to_array($cloneDAO, $file);
   return $file;
 }
 

--- a/api/v3/MembershipStatus.php
+++ b/api/v3/MembershipStatus.php
@@ -109,7 +109,8 @@ function civicrm_api3_membership_status_update($params) {
     $membershipStatusBAO->save();
   }
   $membershipStatus = array();
-  _civicrm_api3_object_to_array(clone($membershipStatusBAO), $membershipStatus);
+  $cloneBAO = clone($membershipStatusBAO);
+  _civicrm_api3_object_to_array($cloneBAO, $membershipStatus);
   $membershipStatus['is_error'] = 0;
   return $membershipStatus;
 }


### PR DESCRIPTION
It is not clear why we clone these DAO/BAO objects, but we cannot do it inside the function call.

This fix can probably be improved (e.g. by dropping the `clone()` entirely, but maybe there's some reason it was necessary to have it. Betting it's a PHP4 kind of reason though 😜 ...

CRM-20466