### PR TITLE
CRM-20449: enotices from 'send thankyou letter' on contribution search

### DIFF
--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1249,22 +1249,15 @@ class CRM_Utils_Token {
 
     foreach ($contactIDs as $key => $contactID) {
       if (array_key_exists($contactID, $contactDetails)) {
-        if (CRM_Utils_Array::value('preferred_communication_method', $returnProperties) == 1
-          && array_key_exists('preferred_communication_method', $contactDetails[$contactID])
+        if (!empty($contactDetails[$contactID]['preferred_communication_method'])
         ) {
-          $pcm = CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'preferred_communication_method');
-
-          // communication Preference
-          $contactPcm = explode(CRM_Core_DAO::VALUE_SEPARATOR,
-            $contactDetails[$contactID]['preferred_communication_method']
-          );
-          $result = array();
-          foreach ($contactPcm as $key => $val) {
+          $communicationPreferences = array();
+          foreach ($contactDetails[$contactID]['preferred_communication_method'] as $key => $val) {
             if ($val) {
-              $result[$val] = $pcm[$val];
+              $communicationPreferences[$val] = CRM_Core_PseudoConstant::getLabel('CRM_Contact_DAO_Contact', 'preferred_communication_method', $val);
             }
           }
-          $contactDetails[$contactID]['preferred_communication_method'] = implode(', ', $result);
+          $contactDetails[$contactID]['preferred_communication_method'] = implode(', ', $communicationPreferences);
         }
 
         foreach ($custom as $cfID) {

--- a/tests/phpunit/CRM/Utils/Token.php
+++ b/tests/phpunit/CRM/Utils/Token.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Class CRM_Utils_TokenTest
+ * @group headless
+ */
+class CRM_Utils_TokenTest extends CiviUnitTestCase {
+
+  /**
+   * Basic test on getTokenDetails function.
+   */
+  public function testGetTokenDetails() {
+    $contactID = $this->individualCreate(array('preferred_communication_method' => array('Phone', 'Fax')));
+    $resolvedTokens = CRM_Utils_Token::getTokenDetails(array($contactID));
+    $this->assertEquals('Phone, Fax', $resolvedTokens[0][$contactID]['preferred_communication_method']);
+  }
+
+}


### PR DESCRIPTION
@monishdeb thanks for your work on this issue - I added a test & found I could make it pass by removing lines & not adding any - sadly I still get a negative score due to the additional of the test :-(

I propose this as a replacement for #10196 - due to my feeling it's very safe & due to the fact it is regression related (albeit a minor regression) I have put against the rc

---

 * [CRM-20449: Possible regression - enotices from 'send thankyou letter' on contribution search actions](https://issues.civicrm.org/jira/browse/CRM-20449)