### PR TITLE
CRM-20469 Event form currency is in a slightly different spot

### DIFF
--- a/CRM/Core/Payment/ProcessorForm.php
+++ b/CRM/Core/Payment/ProcessorForm.php
@@ -72,7 +72,12 @@ class CRM_Core_Payment_ProcessorForm {
 
     $form->assign('suppressSubmitButton', $form->_paymentObject->isSuppressSubmitButtons());
 
-    $form->assign('currency', CRM_Utils_Array::value('currency', $form->_values));
+    $currency = CRM_Utils_Array::value('currency', $form->_values);
+    // For event forms, currency is in a different spot
+    if (empty($currency)) {
+      $currency = CRM_Utils_Array::value('currency', $form->_values['event']);
+    }
+    $form->assign('currency', $currency);
 
     // also set cancel subscription url
     if (!empty($form->_paymentProcessor['is_recur']) && !empty($form->_values['is_recur'])) {


### PR DESCRIPTION
A minor update/fix to this PR: https://github.com/civicrm/civicrm-core/pull/7723 from Feb 16 2016.
It fixes the bug that currency is not set when loading the CRM_Financial_Form_Payment payment form via ajax on an event form.

---

 * [CRM-20469: Currency not set correctly in ajax call from event form](https://issues.civicrm.org/jira/browse/CRM-20469)