### PR TITLE
(WIP) CRM-20477: acl_role_id field is improperly aliased to id field in the aclRole API

### DIFF
--- a/api/v3/Generic.php
+++ b/api/v3/Generic.php
@@ -113,7 +113,10 @@ function civicrm_api3_generic_getfields($apiRequest, $unique = TRUE) {
           $metadata['id']['api.aliases'] = array($lowercase_entity . '_id');
         }
       }
-      else {
+      // dirty hack to exclude acl_role entity from auto-aliasing, since acl_role_id is the name of an actual
+      // field in that entity's table. without this, values intended to be passed to acl_role_id are instead
+      // passed to field id, rendering the API unusable
+      elseif ($lowercase_entity !== 'acl_role') {
         // really the preference would be to set the unique name in the xml
         // question is which is a less risky fix this close to a release - setting in xml for the known failure
         // (note) or setting for all api where fields is returning 'id' & we want to accept 'note_id' @ the api layer


### PR DESCRIPTION
The progress on this PR so far is not merge-ready. It is a starting point to demonstrate that the surrounding code is indeed responsible for the misbehavior.

A more elegant solution and some unit testing are clearly called for.

For the more elegant solution, it seems likely we can test for the existence of `$lowercase_entity . '_id'` in the `$metadata` array before aliasing the former to the ID field. This is a little more generic and ensures that no existing, bona fide field is ever aliased to the ID. That said, I note that there is a very long code comment following my hack; I acknowledge there may be a bigger conversation here that I don't presently have all the context for.

As for the unit tests, my first thought was to write a test or two for the `aclRole` API, which apparently has none and which is where this issue manifested. On the other hand, a more generic test in a different class may be more appropriate since I'm proposing to update the `getfields` method for most entities. If so, I think I need a little guidance on where that test should go and what exactly it should test.

Thanks!

---

 * [CRM-20477: acl_role_id field is improperly aliased to id field in the aclRole API](https://issues.civicrm.org/jira/browse/CRM-20477)