### PR TITLE
CRM-19767 - Add case tokens to email activities

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1405,6 +1405,7 @@ LEFT JOIN civicrm_activity_contact src ON (src.activity_id = ac.activity_id AND 
    *   The additional information of CC and BCC appended to the activity Details.
    * @param array $contributionIds
    * @param int $campaignId
+   * @param int $caseId
    *
    * @return array
    *   ( sent, activityId) if any email is sent and activityId
@@ -1423,7 +1424,8 @@ LEFT JOIN civicrm_activity_contact src ON (src.activity_id = ac.activity_id AND 
     $contactIds = NULL,
     $additionalDetails = NULL,
     $contributionIds = NULL,
-    $campaignId = NULL
+    $campaignId = NULL,
+    $caseId = NULL
   ) {
     // get the contact details of logged in contact, which we set as from email
     if ($userID == NULL) {
@@ -1579,6 +1581,12 @@ LEFT JOIN civicrm_activity_contact src ON (src.activity_id = ac.activity_id AND 
       }
       else {
         $tokenHtml = NULL;
+      }
+
+      if ($caseId) {
+        $tokenSubject = CRM_Utils_Token::replaceCaseTokens($caseId, $tokenSubject, $subjectToken, $escapeSmarty);
+        $tokenText = CRM_Utils_Token::replaceCaseTokens($caseId, $tokenText, $messageToken, $escapeSmarty);
+        $tokenHtml = CRM_Utils_Token::replaceCaseTokens($caseId, $tokenHtml, $messageToken, $escapeSmarty);
       }
 
       if (defined('CIVICRM_MAIL_SMARTY') && CIVICRM_MAIL_SMARTY) {

--- a/CRM/Contact/Form/Task/Email.php
+++ b/CRM/Contact/Form/Task/Email.php
@@ -168,6 +168,9 @@ class CRM_Contact_Form_Task_Email extends CRM_Contact_Form_Task {
    */
   public function listTokens() {
     $tokens = CRM_Core_SelectValues::contactTokens();
+    if ($this->getVar('_caseId')) {
+      $tokens = array_merge($tokens, CRM_Core_SelectValues::caseTokens());
+    }
     return $tokens;
   }
 

--- a/CRM/Contact/Form/Task/EmailCommon.php
+++ b/CRM/Contact/Form/Task/EmailCommon.php
@@ -523,7 +523,8 @@ class CRM_Contact_Form_Task_EmailCommon {
       array_keys($form->_toContactDetails),
       $additionalDetails,
       $contributionIds,
-      CRM_Utils_Array::value('campaign_id', $formValues)
+      CRM_Utils_Array::value('campaign_id', $formValues),
+      $form->getVar('_caseId')
     );
 
     $followupStatus = '';

--- a/CRM/Contact/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contact/Form/Task/PDFLetterCommon.php
@@ -352,6 +352,8 @@ class CRM_Contact_Form_Task_PDFLetterCommon {
    * Process the form after the input has been submitted and validated.
    *
    * @param CRM_Core_Form $form
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public static function postProcess(&$form) {
     $formValues = $form->controller->exportValues($form->getName());
@@ -371,8 +373,15 @@ class CRM_Contact_Form_Task_PDFLetterCommon {
     }
 
     foreach ($form->_contactIds as $item => $contactId) {
-      $caseId = NULL;
       $params = array('contact_id' => $contactId);
+
+      $caseId = $form->getVar('_caseId');
+      if (empty($caseId) && !empty($form->_caseIds[$item])) {
+        $caseId = $form->_caseIds[$item];
+      }
+      if ($caseId) {
+        $params['case_id'] = $caseId;
+      }
 
       list($contact) = CRM_Utils_Token::getTokenDetails($params,
         $returnProperties,
@@ -389,12 +398,7 @@ class CRM_Contact_Form_Task_PDFLetterCommon {
       }
 
       $tokenHtml = CRM_Utils_Token::replaceContactTokens($html_message, $contact[$contactId], TRUE, $messageToken);
-      if (!empty($form->_caseId)) {
-        $caseId = $form->_caseId;
-      }
-      if (empty($caseId) && !empty($form->_caseIds[$item])) {
-        $caseId = $form->_caseIds[$item];
-      }
+
       if ($caseId) {
         $tokenHtml = CRM_Utils_Token::replaceCaseTokens($caseId, $tokenHtml, $messageToken);
       }

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1570,7 +1570,7 @@ class CRM_Utils_Token {
 
   /**
    * @param int $caseId
-   * @param int $str
+   * @param string $str
    * @param array $knownTokens
    * @param bool $escapeSmarty
    * @return string
@@ -1821,7 +1821,7 @@ class CRM_Utils_Token {
       else {
         $split = explode('.', trim($k, '{}'));
         if (isset($split[1])) {
-          $entity = array_key_exists($split[1], CRM_Core_DAO_Address::export()) ? 'Address' : ucfirst($split[0]);
+          $entity = array_key_exists($split[1], CRM_Core_DAO_Address::export()) ? 'Address' : ucwords(str_replace('_', ' ', $split[0]));
         }
         else {
           $entity = 'Contact';


### PR DESCRIPTION
In CiviCRM core, case tokens had only been partially implemented. 

- When doing _Print/Merge Document_ from a case, tokens for `{case.id}`, etc, _were_ available.
- When doing _Send Email_ from a case, the tokens were missing.

This fixes that.

* [CRM-19767: Add Case Tokens to Case Activities](https://issues.civicrm.org/jira/browse/CRM-19767)