### PR TITLE
CRM-20480 - Exclude event that has a past end date of one year from now

### DIFF
--- a/Civi/ActionSchedule/RecipientBuilder.php
+++ b/Civi/ActionSchedule/RecipientBuilder.php
@@ -477,6 +477,10 @@ class RecipientBuilder {
       // This is weird. Waddupwidat?
       if ($this->mapping->getEntity() == 'civicrm_participant') {
         $startDateClauses[] = $operator . "(!casNow, INTERVAL 1 DAY ) {$op} " . '!casDateField';
+        //Exclude event that has a past end date of one year from now.
+        if ($actionSchedule->start_action_date == 'event_end_date' && $op == '>=') {
+          $startDateClauses[] = "DATE_SUB(!casNow, INTERVAL 1 YEAR) <= !casDateField";
+        }
       }
       else {
         $startDateClauses[] = "DATE_SUB(!casNow, INTERVAL 1 DAY ) <= {$date}";

--- a/tests/phpunit/CRM/Core/BAO/ActionScheduleTest.php
+++ b/tests/phpunit/CRM/Core/BAO/ActionScheduleTest.php
@@ -1623,6 +1623,22 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
     ));
     $c = $this->callAPISuccess('contact', 'create', array_merge($this->fixtures['contact'], array('contact_id' => $participant->contact_id)));
 
+    //Create old event participant with event ending in 1990
+    $this->fixtures['participant']['event_id'] = array(
+      'is_active' => 1,
+      'is_template' => 0,
+      'title' => 'Old Example Event',
+      'start_date' => '19900315',
+      'end_date' => '19900615',
+    );
+    // Create event+participant with start_date = 19900315, end_date = 19900615.
+    $oldParticipant = $this->createTestObject('CRM_Event_DAO_Participant', array_merge($this->fixtures['participant'], array('status_id' => 2)));
+    $this->callAPISuccess('Email', 'create', array(
+      'contact_id' => $oldParticipant->contact_id,
+      'email' => 'old-event@example.com',
+    ));
+    $c = $this->callAPISuccess('contact', 'create', array_merge($this->fixtures['contact'], array('contact_id' => $oldParticipant->contact_id)));
+
     $actionSchedule = $this->fixtures['sched_eventtype_end_2month_repeat_twice_2_weeks'];
     $actionSchedule['entity_value'] = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event', $participant->event_id, 'event_type_id');
     $this->callAPISuccess('action_schedule', 'create', $actionSchedule);


### PR DESCRIPTION
Participant for event ending around 20 years ago would still be receiving reminder mails if schedule reminder is set as 1 hour after event end date. Basically, the test written in this PR need to pass for CRM-20480. It fails without the fix in `Actionschedule.php` as the old participant created gets listed in the actual recipient list.


Update: The change here looks for the event that has been ended one year from now and excludes it from the recipients list. This makes the current test to pass the build. Does this seem reasonable or we need to provide an extra setting on the reminder form ? 

Eg: `Exclude past events ended __ month/year from now.`

---

 * [CRM-20480: Schedule reminder created for 'x' hours after event end date fetches all past event participants.](https://issues.civicrm.org/jira/browse/CRM-20480)