### PR TITLE
CRM-20424 remove call to deprecated function.

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -579,7 +579,7 @@ LEFT JOIN civicrm_option_group aog ON aog.name='activity_type'
       $condition .= " AND case_relationship.contact_id_b = {$userID} ";
     }
     if ($type == 'upcoming' || $type == 'any') {
-      $closedId = CRM_Core_OptionGroup::getValue('case_status', 'Closed', 'name');
+      $closedId = CRM_Core_PseudoConstant::getKey('CRM_Case_BAO_Case', 'case_status_id', 'Closed');
       $condition .= "
 AND civicrm_case.status_id != $closedId";
     }

--- a/CRM/Case/Info.php
+++ b/CRM/Case/Info.php
@@ -212,15 +212,12 @@ class CRM_Case_Info extends CRM_Core_Component_Info {
     if (CRM_Core_Permission::check('access all cases and activities') ||
       CRM_Core_Permission::check('add cases')
     ) {
-      $atype = CRM_Core_OptionGroup::getValue('activity_type',
-        'Open Case',
-        'name'
-      );
-      if ($atype) {
+      $activityType = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Open Case');
+      if ($activityType) {
         $shortCuts = array_merge($shortCuts, array(
           array(
             'path' => 'civicrm/case/add',
-            'query' => "reset=1&action=add&atype=$atype&context=standalone",
+            'query' => "reset=1&action=add&atype={$activityType}&context=standalone",
             'ref' => 'new-case',
             'title' => ts('Case'),
           ),


### PR DESCRIPTION
This is the one covering the UI with errors. The fact it did not cause any test fails means it is
not covered by unit tests :-(.

As long as the Open Case link is still present for CiviCase users this is working

@davejenx might be worth merging this into the rc? Will clean up the most common source of red ink

---

 * [CRM-20424: Set up method for marking code as deprecated](https://issues.civicrm.org/jira/browse/CRM-20424)