### PR TITLE
CRM-20036, CRM-20018 Don't retrieve all soft contributions if not needed.

### DIFF
--- a/CRM/Contribute/BAO/ContributionSoft.php
+++ b/CRM/Contribute/BAO/ContributionSoft.php
@@ -94,8 +94,7 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
     }
     //Delete PCP against this contribution and create new on submitted PCP information
     elseif (array_key_exists('pcp', $params) && $pcpId) {
-      $deleteParams = array('id' => $pcpId);
-      CRM_Contribute_BAO_ContributionSoft::del($deleteParams);
+      civicrm_api3('ContributionSoft', 'delete', array('id' => $pcpId));
     }
     if (isset($params['soft_credit'])) {
       $softParams = $params['soft_credit'];
@@ -117,8 +116,7 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
       // delete any extra soft-credit while updating back-office contribution
       foreach ((array) $softIDs as $softID) {
         if (!in_array($softID, $params['soft_credit_ids'])) {
-          $deleteParams = array('id' => $softID);
-          CRM_Contribute_BAO_ContributionSoft::del($deleteParams);
+          civicrm_api3('ContributionSoft', 'delete', array('id' => $softID));
         }
       }
     }
@@ -229,27 +227,6 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
       return $contributionSoft;
     }
     return NULL;
-  }
-
-  /**
-   * Delete soft credits.
-   *
-   * @param array $params
-   *
-   */
-  public static function del($params) {
-    //delete from contribution soft table
-    $contributionSoft = new CRM_Contribute_DAO_ContributionSoft();
-    $contributionSoft->id = CRM_Utils_Array::value('id', $params);
-    if (!$contributionSoft->find()) {
-      return FALSE;
-    }
-    unset($params['id']);
-    foreach ($params as $column => $value) {
-      $contributionSoft->$column = $value;
-    }
-    $contributionSoft->delete();
-    return TRUE;
   }
 
   /**

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1594,8 +1594,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
 
     $isEmpty = array_keys(array_flip($submittedValues['soft_credit_contact_id']));
     if ($this->_id && count($isEmpty) == 1 && key($isEmpty) == NULL) {
-      //Delete existing soft credit records if soft credit list is empty on update
-      CRM_Contribute_BAO_ContributionSoft::del(array('contribution_id' => $this->_id, 'pcp_id' => 0));
+      civicrm_api3('ContributionSoft', 'get', array('contribution_id' => $this->_id, 'pcp_id' => 0, 'api.ContributionSoft.delete' => 1));
     }
 
     // set the contact, when contact is selected

--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -407,11 +407,10 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Contribute_Import_Pa
             if (isset($existingSoftCredit['soft_credit']) && !empty($existingSoftCredit['soft_credit'])) {
               foreach ($existingSoftCredit['soft_credit'] as $key => $existingSoftCreditValues) {
                 if (!empty($existingSoftCreditValues['soft_credit_id'])) {
-                  $deleteParams = array(
+                  civicrm_api3('ContributionSoft', 'delete', array(
                     'id' => $existingSoftCreditValues['soft_credit_id'],
                     'pcp_id' => NULL,
-                  );
-                  CRM_Contribute_BAO_ContributionSoft::del($deleteParams);
+                  ));
                 }
               }
             }

--- a/api/v3/ContributionSoft.php
+++ b/api/v3/ContributionSoft.php
@@ -62,15 +62,14 @@ function _civicrm_api3_contribution_soft_create_spec(&$params) {
  * Deletes an existing Soft Credit.
  *
  * @param array $params
+ *
+ * @return array
+ *   Api formatted result.
+ *
  * @throws API_Exception
  */
 function civicrm_api3_contribution_soft_delete($params) {
-  // Non standard BAO - we have to write custom code to cope.
-  $result = CRM_Contribute_BAO_ContributionSoft::del(array('id' => $params['id']));
-  if (!$result) {
-    throw new API_Exception('Cannot delete contributionSoft ' . $params['id']);
-  }
-  civicrm_api3_create_success(TRUE);
+  return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
 }
 
 /**

--- a/tests/phpunit/api/v3/ContributionSoftTest.php
+++ b/tests/phpunit/api/v3/ContributionSoftTest.php
@@ -291,7 +291,7 @@ class api_v3_ContributionSoftTest extends CiviUnitTestCase {
     $params = array(
       'id' => $softcontributionID,
     );
-    $result = $this->callAPISuccess('contribution_soft', 'delete', $params);
+    $this->callAPISuccess('contribution_soft', 'delete', $params);
   }
 
   /**
@@ -307,7 +307,7 @@ class api_v3_ContributionSoftTest extends CiviUnitTestCase {
     $params = array(
       'contribution_source' => 'SSF',
     );
-    $softcontribution = $this->callAPIFailure('contribution_soft', 'delete', $params);
+    $this->callAPIFailure('contribution_soft', 'delete', $params);
   }
 
   public function testDeleteContributionSoft() {
@@ -324,7 +324,7 @@ class api_v3_ContributionSoftTest extends CiviUnitTestCase {
     $params = array(
       'id' => $softcontributionID,
     );
-    $result = $this->callAPIAndDocument('contribution_soft', 'delete', $params, __FUNCTION__, __FILE__);
+    $this->callAPIAndDocument('contribution_soft', 'delete', $params, __FUNCTION__, __FILE__);
   }
 
   ///////////////// civicrm_contribution_search methods


### PR DESCRIPTION
This is an alternate fix to https://github.com/civicrm/civicrm-core/pull/9849 which basically removes the entire function. There appears to be only one place where it is called without id being set so we should simply require id & just handle that. In that one place we can use the api to do what the function was doing

---

 * [CRM-20036: Memory problem when updating a contribution without soft contributions](https://issues.civicrm.org/jira/browse/CRM-20036)
 * [CRM-20018: Not showing Contributions popup on big DB. Allowed memory size exhausted](https://issues.civicrm.org/jira/browse/CRM-20018)