### PR TITLE
CRM-20171: Use loadXML() instead of load() for reading xml files.

### DIFF
--- a/CRM/Case/Audit/AuditConfig.php
+++ b/CRM/Case/Audit/AuditConfig.php
@@ -61,9 +61,8 @@ class CRM_Case_Audit_AuditConfig {
     $this->includeRules = array();
 
     $doc = new DOMDocument();
-    $oldValue = libxml_disable_entity_loader(FALSE);
-    $load = $doc->load(dirname(__FILE__) . '/' . $this->filename);
-    libxml_disable_entity_loader($oldValue);
+    $xmlString = file_get_contents(dirname(__FILE__) . '/' . $this->filename);
+    $load = $doc->loadXML($xmlString);
     if ($load) {
       $regions = $doc->getElementsByTagName("region");
       foreach ($regions as $region) {

--- a/CRM/Case/Audit/AuditConfig.php
+++ b/CRM/Case/Audit/AuditConfig.php
@@ -61,7 +61,10 @@ class CRM_Case_Audit_AuditConfig {
     $this->includeRules = array();
 
     $doc = new DOMDocument();
-    if ($doc->load(dirname(__FILE__) . '/' . $this->filename)) {
+    $oldValue = libxml_disable_entity_loader(FALSE);
+    $load = $doc->load(dirname(__FILE__) . '/' . $this->filename);
+    libxml_disable_entity_loader($oldValue);
+    if ($load) {
       $regions = $doc->getElementsByTagName("region");
       foreach ($regions as $region) {
         $regionName = $region->getAttribute("name");

--- a/CRM/Case/XMLRepository.php
+++ b/CRM/Case/XMLRepository.php
@@ -136,7 +136,9 @@ class CRM_Case_XMLRepository {
     if ($fileName && file_exists($fileName)) {
       // read xml file
       $dom = new DomDocument();
+      $oldValue = libxml_disable_entity_loader(FALSE);
       $dom->load($fileName);
+      libxml_disable_entity_loader($oldValue);
       $dom->xinclude();
       $fileXml = simplexml_import_dom($dom);
     }

--- a/CRM/Case/XMLRepository.php
+++ b/CRM/Case/XMLRepository.php
@@ -136,9 +136,9 @@ class CRM_Case_XMLRepository {
     if ($fileName && file_exists($fileName)) {
       // read xml file
       $dom = new DomDocument();
-      $oldValue = libxml_disable_entity_loader(FALSE);
-      $dom->load($fileName);
-      libxml_disable_entity_loader($oldValue);
+      $xmlString = file_get_contents($fileName);
+      $dom->loadXML($xmlString);
+      $dom->documentURI = $fileName;
       $dom->xinclude();
       $fileXml = simplexml_import_dom($dom);
     }

--- a/CRM/Core/CodeGen/Util/Xml.php
+++ b/CRM/Core/CodeGen/Util/Xml.php
@@ -11,8 +11,10 @@ class CRM_Core_CodeGen_Util_Xml {
    * @return SimpleXMLElement|bool
    */
   public static function parse($file) {
+    $oldValue = libxml_disable_entity_loader(FALSE);
     $dom = new DomDocument();
     $dom->load($file);
+    libxml_disable_entity_loader($oldValue);
     $dom->xinclude();
     $xml = simplexml_import_dom($dom);
     return $xml;

--- a/CRM/Core/CodeGen/Util/Xml.php
+++ b/CRM/Core/CodeGen/Util/Xml.php
@@ -11,10 +11,10 @@ class CRM_Core_CodeGen_Util_Xml {
    * @return SimpleXMLElement|bool
    */
   public static function parse($file) {
-    $oldValue = libxml_disable_entity_loader(FALSE);
     $dom = new DomDocument();
-    $dom->load($file);
-    libxml_disable_entity_loader($oldValue);
+    $xmlString = file_get_contents($file);
+    $dom->loadXML($xmlString);
+    $dom->documentURI = $file;
     $dom->xinclude();
     $xml = simplexml_import_dom($dom);
     return $xml;

--- a/CRM/Utils/Migrate/Import.php
+++ b/CRM/Utils/Migrate/Import.php
@@ -48,7 +48,10 @@ class CRM_Utils_Migrate_Import {
   public function run($file) {
     // read xml file
     $dom = new DomDocument();
-    if (!$dom->load($file)) {
+    $oldValue = libxml_disable_entity_loader(FALSE);
+    $load = $dom->load($file);
+    libxml_disable_entity_loader($oldValue);
+    if (!$load) {
       throw new CRM_Core_Exception("Failed to parse XML file \"$file\"");
     }
     $dom->xinclude();

--- a/CRM/Utils/Migrate/Import.php
+++ b/CRM/Utils/Migrate/Import.php
@@ -48,9 +48,8 @@ class CRM_Utils_Migrate_Import {
   public function run($file) {
     // read xml file
     $dom = new DomDocument();
-    $oldValue = libxml_disable_entity_loader(FALSE);
-    $load = $dom->load($file);
-    libxml_disable_entity_loader($oldValue);
+    $xmlString = file_get_contents($file);
+    $load = $dom->loadXML($xmlString);
     if (!$load) {
       throw new CRM_Core_Exception("Failed to parse XML file \"$file\"");
     }


### PR DESCRIPTION
Avoid warnings while loading xml files. To make sure security of XXE attacks, restored the previous value at each modification in the file.

* [CRM-20171: Problem with xml file not loaded](https://issues.civicrm.org/jira/browse/CRM-20171)