### PR TITLE
CRM-19643 Remove unused reference to 'selectedSearchContactIds

### DIFF
--- a/CRM/Contact/Form/Merge.php
+++ b/CRM/Contact/Form/Merge.php
@@ -283,13 +283,6 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
   public function postProcess() {
     $formValues = $this->exportValues();
 
-    // reset all selected contact ids from session
-    // when we came from search context, CRM-3526
-    $session = CRM_Core_Session::singleton();
-    if ($session->get('selectedSearchContactIds')) {
-      $session->resetScope('selectedSearchContactIds');
-    }
-
     $formValues['main_details'] = $this->_mainDetails;
     $formValues['other_details'] = $this->_otherDetails;
     $migrationData = array('migration_info' => $formValues);

--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -526,12 +526,6 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
 
     $this->assign('actionButtonName', $this->_actionButtonName);
 
-    // reset from session, CRM-3526
-    $session = CRM_Core_Session::singleton();
-    if ($this->_force && $session->get('selectedSearchContactIds')) {
-      $session->resetScope('selectedSearchContactIds');
-    }
-
     // if we dont get this from the url, use default if one exsts
     $config = CRM_Core_Config::singleton();
     if ($this->_ufGroupID == NULL &&

--- a/CRM/Contact/Page/DedupeFind.php
+++ b/CRM/Contact/Page/DedupeFind.php
@@ -70,16 +70,13 @@ class CRM_Contact_Page_DedupeFind extends CRM_Core_Page_Basic {
     );
     $this->assign('urlQuery', CRM_Utils_System::makeQueryString($urlQry));
 
-    $session = CRM_Core_Session::singleton();
-    $contactIds = $session->get('selectedSearchContactIds');
-    if ($context == 'search' || !empty($contactIds)) {
+    if ($context == 'search') {
       $context = 'search';
-      $this->assign('backURL', $session->readUserContext());
+      $this->assign('backURL', CRM_Core_Session::singleton()->readUserContext());
     }
 
     if ($action & CRM_Core_Action::RENEW) {
       // empty cache
-
       if ($rgid) {
         CRM_Core_BAO_PrevNextCache::deleteItem(NULL, CRM_Dedupe_Merger::getMergeCacheKeyString($rgid, $gid));
       }
@@ -165,13 +162,6 @@ class CRM_Contact_Page_DedupeFind extends CRM_Core_Page_Basic {
           }
           $this->set("dedupe_dupes_$gid", $foundDupes);
         }
-        elseif (!empty($contactIds)) {
-          $foundDupes = $this->get("search_dedupe_dupes_$gid");
-          if (!$foundDupes) {
-            $foundDupes = CRM_Dedupe_Finder::dupes($rgid, $contactIds);
-          }
-          $this->set("search_dedupe_dupes_$gid", $foundDupes);
-        }
         else {
           $foundDupes = $this->get('dedupe_dupes');
           if (!$foundDupes) {
@@ -204,16 +194,15 @@ class CRM_Contact_Page_DedupeFind extends CRM_Core_Page_Basic {
           $this->_rgid = $rgid;
           $this->_mainContacts = $mainContacts;
 
-          $session = CRM_Core_Session::singleton();
           $urlQry['action'] = 'update';
           if ($this->_cid) {
             $urlQry['cid'] = $this->_cid;
-            $session->pushUserContext(CRM_Utils_System::url('civicrm/contact/deduperules',
+            CRM_Core_Session::singleton()->pushUserContext(CRM_Utils_System::url('civicrm/contact/deduperules',
               $urlQry
             ));
           }
           else {
-            $session->pushUserContext(CRM_Utils_System::url('civicrm/contact/dedupefind',
+            CRM_Core_Session::singleton()->pushUserContext(CRM_Utils_System::url('civicrm/contact/dedupefind',
               $urlQry
             ));
           }
@@ -239,7 +228,6 @@ class CRM_Contact_Page_DedupeFind extends CRM_Core_Page_Basic {
     }
     $this->assign('context', $context);
 
-    // parent run
     return parent::run();
   }
 


### PR DESCRIPTION
@JKingsnorth do you think I've missed anything here? I can't find any evidence 

$contactIds = $session->get('selectedSearchContactIds');

would ever retrieve something

---

 * [CRM-19643: Remove unused ref to ](https://issues.civicrm.org/jira/browse/CRM-19643)