### PR TITLE
CRM-19821 performance improvement on the activity search

### DIFF
--- a/CRM/Activity/BAO/Query.php
+++ b/CRM/Activity/BAO/Query.php
@@ -75,12 +75,10 @@ class CRM_Activity_BAO_Query {
     }
 
     if (!empty($query->_returnProperties['activity_status_id'])) {
-      $query->_select['activity_status_id'] = 'activity_status.value as activity_status_id';
+      $query->_select['activity_status_id'] = 'civicrm_activity.status_id as activity_status_id';
       $query->_element['activity_status_id'] = 1;
       $query->_tables['civicrm_activity'] = 1;
-      $query->_tables['activity_status'] = 1;
       $query->_whereTables['civicrm_activity'] = 1;
-      $query->_whereTables['activity_status'] = 1;
     }
 
     if (!empty($query->_returnProperties['activity_status'])) {
@@ -573,6 +571,33 @@ class CRM_Activity_BAO_Query {
         }
       }
     }
+
+    return $properties;
+  }
+
+  /**
+   * Get the list of fields required to populate the selector.
+   *
+   * The default return properties array returns far too many fields for 'everyday use. Every field you add to this array
+   * kills a small kitten so add carefully.
+   */
+  public static function selectorReturnProperties() {
+    $properties = array(
+      'activity_id' => 1,
+      'contact_type' => 1,
+      'contact_sub_type' => 1,
+      'sort_name' => 1,
+      'display_name' => 1,
+      'activity_type_id' => 1,
+      'activity_subject' => 1,
+      'activity_date_time' => 1,
+      'activity_status_id' => 1,
+      'source_contact' => 1,
+      'source_record_id' => 1,
+      'activity_is_test' => 1,
+      'activity_campaign_id' => 1,
+      'activity_engagement_level' => 1,
+    );
 
     return $properties;
   }

--- a/CRM/Activity/Selector/Search.php
+++ b/CRM/Activity/Selector/Search.php
@@ -197,9 +197,7 @@ class CRM_Activity_Selector_Search extends CRM_Core_Selector_Base implements CRM
     // type of selector
     $this->_action = $action;
     $this->_query = new CRM_Contact_BAO_Query($this->_queryParams,
-      CRM_Activity_BAO_Query::defaultReturnProperties(CRM_Contact_BAO_Query::MODE_ACTIVITY,
-        FALSE
-      ),
+      CRM_Activity_BAO_Query::selectorReturnProperties(),
       NULL, FALSE, FALSE,
       CRM_Contact_BAO_Query::MODE_ACTIVITY
     );
@@ -285,6 +283,7 @@ class CRM_Activity_Selector_Search extends CRM_Core_Selector_Base implements CRM
       if (empty($result->activity_id)) {
         continue;
       }
+      $this->_query->convertToPseudoNames($result);
 
       // the columns we are interested in
       foreach (self::$_properties as $property) {

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -677,7 +677,6 @@ class CRM_Contact_BAO_Query {
         ($name == 'parent_id')
       ) {
         CRM_Activity_BAO_Query::select($this);
-        continue;
       }
 
       // if this is a hierarchical name, we ignore it
@@ -859,11 +858,11 @@ class CRM_Contact_BAO_Query {
                 // If we have an option group defined then rather than joining the option value table in
                 // (which is an unindexed join) we render the option value on output.
                 // @todo - extend this to other pseudoconstants.
-                if ($this->pseudoConstantNameIsInReturnProperties($field)) {
+                if ($this->pseudoConstantNameIsInReturnProperties($field, $name)) {
                   $pseudoFieldName = $field['pseudoconstant']['optionGroupName'];
                   $this->_pseudoConstantsSelect[$pseudoFieldName] = array(
                     'pseudoField' => $field['name'],
-                    'idCol' => $field['name'],
+                    'idCol' => $name,
                     'field_name' => $field['name'],
                     'bao' => $field['bao'],
                     'pseudoconstant' => $field['pseudoconstant'],
@@ -6431,10 +6430,12 @@ AND   displayRelType.is_active = 1
    * have been requested. Payment_instrument is the option groun name field value.
    *
    * @param array $field
+   * @param string $fieldName
+   *   The unique name of the field - ie. the one it will be aliased to in the query.
    *
    * @return bool
    */
-  private function pseudoConstantNameIsInReturnProperties($field) {
+  private function pseudoConstantNameIsInReturnProperties($field, $fieldName = NULL) {
     if (!isset($field['pseudoconstant']['optionGroupName'])) {
       return FALSE;
     }
@@ -6442,6 +6443,11 @@ AND   displayRelType.is_active = 1
     if (CRM_Utils_Array::value($field['pseudoconstant']['optionGroupName'], $this->_returnProperties)) {
       return TRUE;
     }
+    if (CRM_Utils_Array::value($fieldName, $this->_returnProperties)) {
+      return TRUE;
+    }
+    // Is this still required - the above goes off the unique name. Test with things like
+    // communication_prefferences & prefix_id.
     if (CRM_Utils_Array::value($field['name'], $this->_returnProperties)) {
       return TRUE;
     }

--- a/CRM/Core/Action.php
+++ b/CRM/Core/Action.php
@@ -236,7 +236,7 @@ class CRM_Core_Action {
 
         if (isset($link['qs']) && !CRM_Utils_System::isNull($link['qs'])) {
           $urlPath = CRM_Utils_System::url(self::replace($link['url'], $values),
-            self::replace($link['qs'], $values), TRUE, NULL, TRUE, $frontend
+            self::replace($link['qs'], $values), FALSE, NULL, TRUE, $frontend
           );
         }
         else {

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2209,7 +2209,7 @@ SELECT contact_id
   public static function buildOptions($fieldName, $context = NULL, $props = array()) {
     // If a given bao does not override this function
     $baoName = get_called_class();
-    return CRM_Core_PseudoConstant::get($baoName, $fieldName, array(), $context);
+    return CRM_Core_PseudoConstant::get($baoName, $fieldName, $props, $context);
   }
 
   /**

--- a/tests/phpunit/CRM/Activity/Form/SearchTest.php
+++ b/tests/phpunit/CRM/Activity/Form/SearchTest.php
@@ -52,7 +52,7 @@ class CRM_Activity_Form_SearchTest extends CiviUnitTestCase {
         'source_contact_name' => 'Anderson, Anthony',
         'checkbox' => 'mark_x_1',
         'mailingId' => '',
-        'action' => '<span><a href="http://dmaster.local/index.php?q=civicrm/contact/view/contribution&amp;action=view&amp;reset=1&amp;id=1&amp;cid=3&amp;context=search&amp;searchContext=activity&amp;key=' . $qfKey . '" class="action-item crm-hover-button" title=\'View Activity\' >View</a></span>',
+        'action' => '<span><a href="/index.php?q=civicrm/contact/view/contribution&amp;action=view&amp;reset=1&amp;id=1&amp;cid=3&amp;context=search&amp;searchContext=activity&amp;key=' . $qfKey . '" class="action-item crm-hover-button" title=\'View Activity\' >View</a></span>',
         'campaign' => NULL,
         'campaign_id' => NULL,
         'repeat' => '',

--- a/tests/phpunit/CRM/Activity/Form/SearchTest.php
+++ b/tests/phpunit/CRM/Activity/Form/SearchTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ *  Include dataProvider for tests
+ * @group headless
+ */
+class CRM_Activity_Form_SearchTest extends CiviUnitTestCase {
+
+  public function setUp() {
+    parent::setUp();
+    $this->individualID = $this->individualCreate();
+    $this->contributionCreate(array('contact_id' => $this->individualID, 'receive_date' => '2017-01-30'));
+  }
+
+  public function tearDown() {
+    $tablesToTruncate = array(
+      'civicrm_activity',
+      'civicrm_activity_contact',
+    );
+    $this->quickCleanup($tablesToTruncate);
+  }
+
+  /**
+   *  Test submitted the search form.
+   */
+  public function testSearch() {
+
+    $form = new CRM_Activity_Form_Search();
+    $_SERVER['REQUEST_METHOD'] = 'GET';
+    $form->controller = new CRM_Activity_Controller_Search();
+    $form->preProcess();
+    $form->postProcess();
+    $qfKey = $form->controller->_key;
+    $rows = $form->controller->get('rows');
+    $this->assertEquals(array(array(
+        'contact_id' => '3',
+        'contact_type' => '<a href="/index.php?q=civicrm/profile/view&amp;reset=1&amp;gid=7&amp;id=3&amp;snippet=4" class="crm-summary-link"><div class="icon crm-icon Individual-icon"></div></a>',
+        'sort_name' => 'Anderson, Anthony',
+        'display_name' => 'Mr. Anthony Anderson II',
+        'activity_id' => '1',
+        'activity_date_time' => '2017-01-30 00:00:00',
+        'activity_status_id' => '2',
+        'activity_status' => 'Completed',
+        'activity_subject' => '$ 100.00 - SSF',
+        'source_record_id' => '1',
+        'activity_type_id' => '6',
+        'activity_type' => 'Contribution',
+        'activity_is_test' => '0',
+        'target_contact_name' => array(),
+        'assignee_contact_name' => array(),
+        'source_contact_id' => '3',
+        'source_contact_name' => 'Anderson, Anthony',
+        'checkbox' => 'mark_x_1',
+        'mailingId' => '',
+        'action' => '<span><a href="http://dmaster.local/index.php?q=civicrm/contact/view/contribution&amp;action=view&amp;reset=1&amp;id=1&amp;cid=3&amp;context=search&amp;searchContext=activity&amp;key=' . $qfKey . '" class="action-item crm-hover-button" title=\'View Activity\' >View</a></span>',
+        'campaign' => NULL,
+        'campaign_id' => NULL,
+        'repeat' => '',
+    )), $rows);
+  }
+
+}

--- a/tests/phpunit/CRM/Contact/BAO/ActivitySearchTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ActivitySearchTest.php
@@ -104,7 +104,7 @@ class CRM_Contact_BAO_ActivitySearchTest extends CiviUnitTestCase {
     $subject = 'test activity ' . __FUNCTION__;
     $params = $this->_params;
     $params['subject'] = $subject;
-    $activity = $this->callAPISuccess('Activity', 'Create', $params);
+    $this->callAPISuccess('Activity', 'Create', $params);
 
     $case = array(
       'form_value' => array(

--- a/tests/phpunit/CRM/Financial/Page/AjaxTest.php
+++ b/tests/phpunit/CRM/Financial/Page/AjaxTest.php
@@ -51,7 +51,7 @@ class CRM_Financial_Page_AjaxTest extends CiviUnitTestCase {
     $json = str_replace(rtrim(CIVICRM_UF_BASEURL, '/'), 'http://FIX ME', $json);
     $this->assertEquals($json, '{"sEcho": 1, "iTotalRecords": 1, "iTotalDisplayRecords": 1, "aaData": [ ["","<a href=\"/index.php?q=civicrm/profile/view&amp;reset=1&amp;gid=7&amp;id=3&amp;snippet=4\" class=\"crm-summary-link\"><div'
     . ' class=\"icon crm-icon Individual-icon\"></div></a>","<a href=/index.php?q=civicrm/contact/view&amp;reset=1&amp;cid=3>Anderson, Anthony</a>","$ 100.00","12345","' . CRM_Utils_Date::customFormat(date('Ymd')) . ' 12:00 AM",'
-    . '"Credit Card","Completed","Donation","<span><a href=\"http://FIX ME/index.php?q=civicrm/contact/view/contribution&amp;reset=1&amp;id=1&amp;cid=3&amp;action=view&amp;context=contribution&amp;'
+    . '"Credit Card","Completed","Donation","<span><a href=\"/index.php?q=civicrm/contact/view/contribution&amp;reset=1&amp;id=1&amp;cid=3&amp;action=view&amp;context=contribution&amp;'
     . 'selectedChild=contribute\" class=\"action-item crm-hover-button\" title=\'View Contribution\' >View</a></span>"]] }');
   }
 

--- a/tests/phpunit/CRM/Group/Page/AjaxTest.php
+++ b/tests/phpunit/CRM/Group/Page/AjaxTest.php
@@ -126,22 +126,16 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
     $params = $this->_params;
     $groups = CRM_Contact_BAO_Group::getGroupListSelector($params);
     $this->assertEquals(2, $groups['recordsTotal']);
-    $this->assertEquals('<span><a href="' . CIVICRM_UF_BASEURL . '/index.php?q=civicrm/group/search&amp;reset=1&amp;force=1&amp;context=smog&amp;gid=4" class="action-item crm-hover-button" title=\'Group Contacts\' >Contacts</a></span>', $groups['data'][0]['links']);
-    $this->assertEquals('<span><a href="' . CIVICRM_UF_BASEURL . '/index.php?q=civicrm/group/search&amp;reset=1&amp;force=1&amp;context=smog&amp;gid=2" class="action-item crm-hover-button" title=\'Group Contacts\' >Contacts</a></span>', $groups['data'][1]['links']);
+    $this->assertEquals('<span><a href="/index.php?q=civicrm/group/search&amp;reset=1&amp;force=1&amp;context=smog&amp;gid=4" class="action-item crm-hover-button" title=\'Group Contacts\' >Contacts</a></span>', $groups['data'][0]['links']);
+    $this->assertEquals('<span><a href="/index.php?q=civicrm/group/search&amp;reset=1&amp;force=1&amp;context=smog&amp;gid=2" class="action-item crm-hover-button" title=\'Group Contacts\' >Contacts</a></span>', $groups['data'][1]['links']);
 
     // as per changes made in PR-6822
     $this->setPermissionAndRequest(array('view all contacts', 'edit groups'));
     $params = $this->_params;
     $groups = CRM_Contact_BAO_Group::getGroupListSelector($params);
     $this->assertEquals(2, $groups['recordsTotal']);
-    $this->assertEquals('<span><a href="'
-      . CIVICRM_UF_BASEURL . '/index.php?q=civicrm/group/search&amp;reset=1&amp;force=1&amp;context=smog&amp;gid=4" class="action-item crm-hover-button" title=\'Group Contacts\' >Contacts</a><a href="'
-      . CIVICRM_UF_BASEURL . '/index.php?q=civicrm/group&amp;reset=1&amp;action=update&amp;id=4" class="action-item crm-hover-button" title=\'Edit Group\' >Settings</a></span><span class=\'btn-slide crm-hover-button\'>more<ul class=\'panel\'><li><a href="#" class="action-item crm-hover-button crm-enable-disable" title=\'Disable Group\' >Disable</a></li><li><a href="'
-      . CIVICRM_UF_BASEURL . '/index.php?q=civicrm/group&amp;reset=1&amp;action=delete&amp;id=4" class="action-item crm-hover-button small-popup" title=\'Delete Group\' >Delete</a></li></ul></span>', $groups['data'][0]['links']);
-    $this->assertEquals('<span><a href="'
-      . CIVICRM_UF_BASEURL . '/index.php?q=civicrm/group/search&amp;reset=1&amp;force=1&amp;context=smog&amp;gid=2" class="action-item crm-hover-button" title=\'Group Contacts\' >Contacts</a><a href="'
-      . CIVICRM_UF_BASEURL . '/index.php?q=civicrm/group&amp;reset=1&amp;action=update&amp;id=2" class="action-item crm-hover-button" title=\'Edit Group\' >Settings</a></span><span class=\'btn-slide crm-hover-button\'>more<ul class=\'panel\'><li><a href="#" class="action-item crm-hover-button crm-enable-disable" title=\'Disable Group\' >Disable</a></li><li><a href="'
-      . CIVICRM_UF_BASEURL . '/index.php?q=civicrm/group&amp;reset=1&amp;action=delete&amp;id=2" class="action-item crm-hover-button small-popup" title=\'Delete Group\' >Delete</a></li></ul></span>', $groups['data'][1]['links']);
+    $this->assertEquals('<span><a href="/index.php?q=civicrm/group/search&amp;reset=1&amp;force=1&amp;context=smog&amp;gid=4" class="action-item crm-hover-button" title=\'Group Contacts\' >Contacts</a><a href="/index.php?q=civicrm/group&amp;reset=1&amp;action=update&amp;id=4" class="action-item crm-hover-button" title=\'Edit Group\' >Settings</a></span><span class=\'btn-slide crm-hover-button\'>more<ul class=\'panel\'><li><a href="#" class="action-item crm-hover-button crm-enable-disable" title=\'Disable Group\' >Disable</a></li><li><a href="/index.php?q=civicrm/group&amp;reset=1&amp;action=delete&amp;id=4" class="action-item crm-hover-button small-popup" title=\'Delete Group\' >Delete</a></li></ul></span>', $groups['data'][0]['links']);
+    $this->assertEquals('<span><a href="/index.php?q=civicrm/group/search&amp;reset=1&amp;force=1&amp;context=smog&amp;gid=2" class="action-item crm-hover-button" title=\'Group Contacts\' >Contacts</a><a href="/index.php?q=civicrm/group&amp;reset=1&amp;action=update&amp;id=2" class="action-item crm-hover-button" title=\'Edit Group\' >Settings</a></span><span class=\'btn-slide crm-hover-button\'>more<ul class=\'panel\'><li><a href="#" class="action-item crm-hover-button crm-enable-disable" title=\'Disable Group\' >Disable</a></li><li><a href="/index.php?q=civicrm/group&amp;reset=1&amp;action=delete&amp;id=2" class="action-item crm-hover-button small-popup" title=\'Delete Group\' >Delete</a></li></ul></span>', $groups['data'][1]['links']);
   }
 
   /**


### PR DESCRIPTION
This is unrelated to the api work - it is simply part of ongoing work to remove bad joins from the various searches


This commit removes 2 bad joins from the activity search
- priority_id - this is just removed from the returnProperties as it is not rendered
- activity_status_id - this is handled as a pseudoconstant rather than the bad join

activity_type_id is partially handled, however, there is a component_id filter
that needs to be fixed before the bad join on this
field can be removed.

---

 * [CRM-19821: Remove performance degrading joins from activity search \(& api calls\)](https://issues.civicrm.org/jira/browse/CRM-19821)