### PR TITLE
CRM-20499 - ensure date ranges work with custom fields.

### DIFF
--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -405,7 +405,7 @@ LEFT JOIN civicrm_email ON (contact_a.id = civicrm_email.contact_id AND civicrm_
   public static function saveRelativeDates(&$queryParams, $formValues) {
     $relativeDates = array('relative_dates' => array());
     foreach ($formValues as $id => $value) {
-      if (preg_match('/_date_relative$/', $id) && !empty($value)) {
+      if (preg_match('/(_date|custom_[0-9]+)_relative$/', $id) && !empty($value)) {
         $entityName = strstr($id, '_date', TRUE);
         $relativeDates['relative_dates'][$entityName] = $value;
       }

--- a/tests/phpunit/CRM/Contact/BAO/SavedSearchTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/SavedSearchTest.php
@@ -99,6 +99,56 @@ class CRM_Contact_BAO_SavedSearchTest extends CiviUnitTestCase {
 
 
   /**
+   * Test relative dates
+   *
+   * The function saveRelativeDates should detect whether a field is using
+   * a relative date range and include in the fromValues a relative_date
+   * index so it is properly detects when executed.
+   */
+  public function testRelativeDates() {
+    // First test using a core field.
+    $queryParams = array(
+      0 => array(
+        0 => 'activity_date_low',
+        1 => '=',
+        2 => '20170425000000'
+      ),
+      1 => array(
+        0 => 'activity_date_high',
+        1 => '=',
+        2 => '20170501235959'
+      )
+    );
+    $formValues = array(
+      'activity_date_relative' => 'ending.week'
+    );
+    CRM_Contact_BAO_SavedSearch::saveRelativeDates($queryParams, $formValues);
+    $this->assertArrayHasKey('activity', $queryParams['relative_dates'], 'Relative date in activity date smart group failed.');
+
+    // Now test using a custom field.
+    $queryParams = array(
+      0 => array(
+        0 => 'custom_13_low',
+        1 => '=',
+        2 => '20170425000000'
+      ),
+      1 => array(
+        0 => 'custom_13_high',
+        1 => '=',
+        2 => '20170501235959'
+      )
+    );
+    $formValues = array(
+      'custom_13_relative' => 'ending.week'
+    );
+    CRM_Contact_BAO_SavedSearch::saveRelativeDates($queryParams, $formValues);
+    // Since custom_13 doesn't have the word 'date' in it, the key is
+    // set to 0, rather than the field name.
+    $this->assertArrayHasKey('0', $queryParams['relative_dates'], 'Relative date in custom field smart group creation failed.');
+
+  }
+
+  /**
    * Get variants of the fields we want to test.
    *
    * @return array

--- a/tests/phpunit/CRM/Contact/BAO/SavedSearchTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/SavedSearchTest.php
@@ -117,7 +117,7 @@ class CRM_Contact_BAO_SavedSearchTest extends CiviUnitTestCase {
         0 => 'activity_date_high',
         1 => '=',
         2 => '20170501235959',
-      )
+      ),
     );
     $formValues = array(
       'activity_date_relative' => 'ending.week',
@@ -137,7 +137,7 @@ class CRM_Contact_BAO_SavedSearchTest extends CiviUnitTestCase {
         0 => 'custom_13_high',
         1 => '=',
         2 => '20170501235959',
-      )
+      ),
     );
     $formValues = array(
       'custom_13_relative' => 'ending.week',

--- a/tests/phpunit/CRM/Contact/BAO/SavedSearchTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/SavedSearchTest.php
@@ -111,40 +111,42 @@ class CRM_Contact_BAO_SavedSearchTest extends CiviUnitTestCase {
       0 => array(
         0 => 'activity_date_low',
         1 => '=',
-        2 => '20170425000000'
+        2 => '20170425000000',
       ),
       1 => array(
         0 => 'activity_date_high',
         1 => '=',
-        2 => '20170501235959'
+        2 => '20170501235959',
       )
     );
     $formValues = array(
-      'activity_date_relative' => 'ending.week'
+      'activity_date_relative' => 'ending.week',
     );
     CRM_Contact_BAO_SavedSearch::saveRelativeDates($queryParams, $formValues);
-    $this->assertArrayHasKey('activity', $queryParams['relative_dates'], 'Relative date in activity date smart group failed.');
+    $err = 'Relative date in activity date smart group failed.';
+    $this->assertArrayHasKey('activity', $queryParams['relative_dates'], $err);
 
     // Now test using a custom field.
     $queryParams = array(
       0 => array(
         0 => 'custom_13_low',
         1 => '=',
-        2 => '20170425000000'
+        2 => '20170425000000',
       ),
       1 => array(
         0 => 'custom_13_high',
         1 => '=',
-        2 => '20170501235959'
+        2 => '20170501235959',
       )
     );
     $formValues = array(
-      'custom_13_relative' => 'ending.week'
+      'custom_13_relative' => 'ending.week',
     );
     CRM_Contact_BAO_SavedSearch::saveRelativeDates($queryParams, $formValues);
     // Since custom_13 doesn't have the word 'date' in it, the key is
     // set to 0, rather than the field name.
-    $this->assertArrayHasKey('0', $queryParams['relative_dates'], 'Relative date in custom field smart group creation failed.');
+    $err = 'Relative date in custom field smart group creation failed.';
+    $this->assertArrayHasKey('0', $queryParams['relative_dates'], $err);
 
   }
 


### PR DESCRIPTION
* [CRM-20499: When using custom fields for smart group criteria, relative dates create static dates instead](https://issues.civicrm.org/jira/browse/CRM-20499)