### PR TITLE
comment possible breakage from CRM-16460

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1478,6 +1478,9 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       ) {
         unset($submittedValues['tax_amount']);
       }
+      // @todo - look to remove this line. I believe it relates to CRM-16460
+      // and possibly contributes to fixing the issue described there but
+      // would cause breakage for negative values in some cases.
       $submittedValues['total_amount'] = CRM_Utils_Array::value('amount', $submittedValues);
     }
     if ($this->_id) {

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -838,6 +838,8 @@ WHERE  id = %1";
         $params['amount_level'] = CRM_Core_DAO::VALUE_SEPARATOR . implode(CRM_Core_DAO::VALUE_SEPARATOR, $amount_level) . $displayParticipantCount . CRM_Core_DAO::VALUE_SEPARATOR;
       }
     }
+    // @todo this was a fix for CRM-16460 but is too deep in the system for formatting
+    // and probably causes negative amounts to save as $0 depending on server config.
     $params['amount'] = CRM_Utils_Money::format($totalPrice, NULL, NULL, TRUE);
     $params['tax_amount'] = $totalTax;
     if ($component) {

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -696,7 +696,11 @@ Price Field - Price Field 1        1   $ 100.00      $ 100.00
   }
 
   /**
-   * Test that if a negative contribution is entered it does not get reset to $0
+   * Test that if a negative contribution is entered it does not get reset to $0.
+   *
+   * Note that this fails locally for me & I believe there may be an issue for some sites
+   * with negative numbers. Grep for CRM-16460 to find the places I think that might
+   * be affected if you hit this.
    */
   public function testEnterNegativeContribution() {
     $form = new CRM_Contribute_Form_Contribution();


### PR DESCRIPTION
I only saw this breakage in a test, but speculate that config-dependent it would affect people.
Have added comments to help anyone who actually does hit it

---

 * [CRM-16460: PayPal Standard needs two digits of cents](https://issues.civicrm.org/jira/browse/CRM-16460)