### PR TITLE
CRM-20316 - Fix "New Mailing" regression. `subject` should not be required.

### DIFF
--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -134,7 +134,6 @@ function _civicrm_api3_mailing_gettokens_spec(&$params) {
  */
 function _civicrm_api3_mailing_create_spec(&$params) {
   $params['created_id']['api.default'] = 'user_contact_id';
-  $params['subject']['api.required'] = TRUE;
 
   $params['override_verp']['api.default'] = !CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::MAILING_PREFERENCES_NAME, 'track_civimail_replies');
   $params['visibility']['api.default'] = 'Public Pages';

--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -1081,6 +1081,9 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
     if ($Entity === 'Setting') {
       $this->markTestSkipped('It seems OK for setting to skip here as it silently sips invalid params');
     }
+    elseif ($Entity === 'Mailing') {
+      $this->markTestSkipped('It seems OK for "Mailing" to skip here because you can create empty drafts');
+    }
     // should create php complaining that a param is missing
     civicrm_api3($Entity, 'Create');
   }


### PR DESCRIPTION
When you navigate to "New Mailing" (`civicrm/a/#/mailing/new`) in the UI, it
crashes on a white-screen.  Inspecting the console shows that the call to
`Mailing.create` is failing because `subject` is missing.  But at this point
we're only creating a *draft* mailing -- so you don't have or need a
fully-formed mailing yet.

---

 * [CRM-20316: Api mailing create should work without logged in user \(eg. drush\)](https://issues.civicrm.org/jira/browse/CRM-20316)