### PR TITLE
CRM-20513 Fix recur status update & et next recur date based on payme…

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -236,7 +236,8 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
     if (self::isUpdateToRecurringContribution($params)) {
       CRM_Contribute_BAO_ContributionRecur::updateOnNewPayment(
         (!empty($params['contribution_recur_id']) ? $params['contribution_recur_id'] : $params['prevContribution']->contribution_recur_id),
-        $contributionStatus[$params['contribution_status_id']]
+        $contributionStatus[$params['contribution_status_id']],
+        CRM_Utils_Array::value('receive_date', $params)
       );
     }
 


### PR DESCRIPTION
…nt date not current date.

The code to set a recurring sequence to Completed when all contributions received turned out
to be flawed. This fixes that.

This commit extends the test on how dates are being extended. I didn't replicate the problem
I was expecting to see but it makes sense that recurring transactions could be imported on
a different day to the current one and that date is the important one