### PR TITLE
Towards CRM-20037 edit template to be more flexible.

### DIFF
--- a/CRM/Contribute/Selector/Search.php
+++ b/CRM/Contribute/Selector/Search.php
@@ -510,6 +510,7 @@ class CRM_Contribute_Selector_Search extends CRM_Core_Selector_Base implements C
         'name' => $this->_includeSoftCredits ? ts('Contribution Amount') : ts('Amount'),
         'sort' => 'total_amount',
         'direction' => CRM_Utils_Sort::DONTCARE,
+        'field_name' => 'total_amount',
       ),
     );
     if ($this->_includeSoftCredits) {
@@ -520,6 +521,7 @@ class CRM_Contribute_Selector_Search extends CRM_Core_Selector_Base implements C
             array(
               'name' => ts('Soft Credit Amount'),
               'sort' => 'contribution_soft_credit_amount',
+              'field_name' => 'contribution_soft_credit_amount',
               'direction' => CRM_Utils_Sort::DONTCARE,
             ),
           )
@@ -532,31 +534,39 @@ class CRM_Contribute_Selector_Search extends CRM_Core_Selector_Base implements C
           array(
             'name' => ts('Type'),
             'sort' => 'financial_type',
+            'field_name' => 'financial_type',
             'direction' => CRM_Utils_Sort::DONTCARE,
           ),
           array(
             'name' => ts('Source'),
             'sort' => 'contribution_source',
+            'field_name' => 'contribution_source',
             'direction' => CRM_Utils_Sort::DONTCARE,
           ),
           array(
             'name' => ts('Received'),
             'sort' => 'receive_date',
+            'field_name' => 'receive_date',
+            'type' => 'date',
             'direction' => CRM_Utils_Sort::DESCENDING,
           ),
           array(
             'name' => ts('Thank-you Sent'),
             'sort' => 'thankyou_date',
+            'field_name' => 'receive_date',
+            'type' => 'date',
             'direction' => CRM_Utils_Sort::DONTCARE,
           ),
           array(
             'name' => ts('Status'),
             'sort' => 'contribution_status',
+            'field_name' => 'contribution_status',
             'direction' => CRM_Utils_Sort::DONTCARE,
           ),
           array(
             'name' => ts('Premium'),
             'sort' => 'product_name',
+            'field_name' => 'product_name',
             'direction' => CRM_Utils_Sort::DONTCARE,
           ),
         )
@@ -591,9 +601,14 @@ class CRM_Contribute_Selector_Search extends CRM_Core_Selector_Base implements C
     self::$_columnHeaders
       = array_merge(
         self::$_columnHeaders, array(
-          array('desc' => ts('Actions')),
+          array('desc' => ts('Actions'), 'type' => 'actions'),
         )
       );
+    foreach (array_keys(self::$_columnHeaders) as $index) {
+      // Add weight & space it out a bit to allow headers to be inserted.
+      self::$_columnHeaders[$index]['weight'] = $index * 10;
+    }
+
     CRM_Core_Smarty::singleton()->assign('softCreditColumns', $this->_includeSoftCredits);
     return self::$_columnHeaders;
   }

--- a/CRM/Core/Selector/Controller.php
+++ b/CRM/Core/Selector/Controller.php
@@ -339,12 +339,24 @@ class CRM_Core_Selector_Controller {
       // output requires paging/sorting capability
       $rows = self::getRows($this);
       CRM_Utils_Hook::searchColumns($contextName, $columnHeaders, $rows, $this);
+      $reorderedHeaders = array();
+      foreach ($columnHeaders as $key => $columnHeader) {
+        // So far only contribution selector sets weight, so just use key if not.
+        // Extension writers will need to fix other getColumnHeaders (or add a wrapper)
+        // to extend.
+        if (isset($columnHeader['weight'])) {
+          $reorderedHeaders[$columnHeader['weight']] = $columnHeader;
+        }
+        else {
+          $reorderedHeaders[$key] = $columnHeader;
+        }
+      }
       $rowsEmpty = count($rows) ? FALSE : TRUE;
       $qill = $this->getQill();
       $summary = $this->getSummary();
       // if we need to store in session, lets update session
       if ($this->_output & self::SESSION) {
-        $this->_store->set("{$this->_prefix}columnHeaders", $columnHeaders);
+        $this->_store->set("{$this->_prefix}columnHeaders", $reorderedHeaders);
         if ($this->_dynamicAction) {
           $this->_object->removeActions($rows);
         }

--- a/templates/CRM/Contribute/Form/Selector.tpl
+++ b/templates/CRM/Contribute/Form/Selector.tpl
@@ -72,25 +72,30 @@
             <span class="nowrap">{$row.contribution_soft_credit_amount|crmMoney:$row.currency}</span>
           </td>
         {/if}
-        <td class="crm-contribution-type crm-contribution-type_{$row.financial_type_id} crm-financial-type crm-financial-type_{$row.financial_type_id}">
-          {$row.financial_type}
-        </td>
-        <td class="crm-contribution-source">
-          {$row.contribution_source}
-        </td>
-        <td class="crm-contribution-receive_date">
-          {$row.receive_date|crmDate}
-        </td>
-        <td class="crm-contribution-thankyou_date">
-          {$row.thankyou_date|crmDate}
-        </td>
-        <td class="crm-contribution-status">
-          {$row.contribution_status}<br/>
-          {if $row.cancel_date}
-            {$row.cancel_date|crmDate}
+      {foreach from=$columnHeaders item=column}
+        {assign var='columnName' value=$column.field_name}
+        {if !$columnName}{* if field_name has not been set skip, this helps with not changing anything not specifically edited *}
+        {elseif $columnName === 'total_amount'}{* rendered above as soft credit columns = confusing *}
+        {elseif $column.type === 'actions'}{* rendered below as soft credit column handling = not fixed *}
+        {elseif $columnName == 'contribution-status'}
+          <td class="crm-contribution-status">
+            {$row.contribution_status}<br/>
+            {if $row.cancel_date}
+              {$row.cancel_date|crmDate}
+            {/if}
+          </td>
+        {else}
+          {if $column.type == 'date'}
+            <td class="crm-contribution-{$columnName}">
+              {$row.$columnName|crmDate}
+            </td>
+          {else}
+          <td class="crm-{$columnName} crm-{$columnName}_{$row.columnName}">
+            {$row.$columnName}
+          </td>
           {/if}
-        </td>
-        <td class="crm-contribution-product_name">{$row.product_name}</td>
+        {/if}
+      {/foreach}
         {if $softCreditColumns}
           <td class="crm-contribution-soft_credit_name">
             <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.contribution_soft_credit_contact_id`"}">{$row.contribution_soft_credit_name}</a>


### PR DESCRIPTION
This commit changes the way the Selector.tpl is structured to be 'driven' by the  array,
meaning that if people alter the order, or the array, their changes are more easily reflected in the tpl.

I've kind of ignored the soft credit fields but this does set a direction for setting them in
 and not having special handling in the tpl - ie. replace  {if $softCreditColumns}
 
with columnHeader wrangling

---

 * [CRM-20037: Change Contribution tab to show balance due](https://issues.civicrm.org/jira/browse/CRM-20037)