### PR TITLE
CRM-17331 - Mass SMSes are not being sent - fix for 4.6

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1753,7 +1753,9 @@ ORDER BY   civicrm_email.is_bulkmail DESC
 
       // Populate the recipients.
       if (empty($params['_skip_evil_bao_auto_recipients_'])) {
-        self::getRecipients($job->id, $mailing->id, NULL, NULL, TRUE, $mailing->dedupe_email);
+        // CRM-17331: check if it's an sms
+        $mode = $mailing->sms_provider_id ? 'sms' : NULL;
+        self::getRecipients($job->id, $mailing->id, NULL, NULL, TRUE, $mailing->dedupe_email, $mode);
       }
       // Schedule the job now that it has recipients.
       $job->scheduled_date = $params['scheduled_date'];


### PR DESCRIPTION
* [CRM-17331: Mass SMSes are not being sent, even though "send schedules SMS"-job completes without errors](https://issues.civicrm.org/jira/browse/CRM-17331)