### PR TITLE
[wip] CRM-20524 - Core CiviCRM/Smarty - programmatically add help icons alternative approach

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -2349,4 +2349,26 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     return $name;
   }
 
+  /**
+   * Add an element to the $_help array, which is used to programmatically
+   * construct help icon markup.
+   *
+   * @param string $name The name of the element to modify.
+   * @param string $id
+   * @param string $hlpFile
+   */
+  protected function addHelp($name, $id, $hlpFile) {
+    $smarty = new CRM_Core_Smarty();
+    $pluginDir = $smarty->singleton()->plugins_dir[1];
+    require_once $pluginDir . 'function.help.php';
+    $params = array(
+      'id' => $id,
+      'file' => $hlpFile,
+      'title' => $name,
+    );
+    $helpHtml = smarty_function_help($params, $smarty);
+    $element = $this->getElement($name);
+    $element->_label .= " $helpHtml";
+  }
+
 }

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -2354,8 +2354,8 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    * construct help icon markup.
    *
    * @param string $name The name of the element to modify.
-   * @param string $id
-   * @param string $hlpFile
+   * @param string $id the htxt id of the help to load from the .hlp file.
+   * @param string $hlpFile The path to the .hlp file, relative to the CiviCRM root.
    */
   protected function addHelp($name, $id, $hlpFile) {
     $smarty = new CRM_Core_Smarty();

--- a/CRM/Core/Smarty/plugins/function.help.php
+++ b/CRM/Core/Smarty/plugins/function.help.php
@@ -45,7 +45,11 @@
  *   the help html to be inserted
  */
 function smarty_function_help($params, &$smarty) {
-  if (!isset($params['id']) || !isset($smarty->_tpl_vars['config'])) {
+  if (!isset($params['id'])) {
+    return NULL;
+  }
+
+  if (!isset($smarty->_tpl_vars['config']) && !isset($params['title'])) {
     return NULL;
   }
 


### PR DESCRIPTION
This places the help icon markup directly into the label.

---

 * [CRM-20524: Programmatically create help icons](https://issues.civicrm.org/jira/browse/CRM-20524)