### PR TITLE
Fix CRM-15984: "Add campaign field on Email activity form" 

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1420,7 +1420,8 @@ LEFT JOIN civicrm_activity_contact src ON (src.activity_id = ac.activity_id AND 
     $bcc = NULL,
     $contactIds = NULL,
     $additionalDetails = NULL,
-    $contributionIds = NULL
+    $contributionIds = NULL,
+    $campaign_id = NULL
   ) {
     // get the contact details of logged in contact, which we set as from email
     if ($userID == NULL) {
@@ -1469,6 +1470,7 @@ LEFT JOIN civicrm_activity_contact src ON (src.activity_id = ac.activity_id AND 
       'details' => $details,
       // FIXME: check for name Completed and get ID from that lookup
       'status_id' => 2,
+      'campaign_id' => $campaign_id,
     );
 
     // CRM-5916: strip [case #…] before saving the activity (if present in subject)

--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1403,6 +1403,8 @@ LEFT JOIN civicrm_activity_contact src ON (src.activity_id = ac.activity_id AND 
    *   Contact ids.
    * @param string $additionalDetails
    *   The additional information of CC and BCC appended to the activity Details.
+   * @param array $contributionIds
+   * @param int $campaignId
    *
    * @return array
    *   ( sent, activityId) if any email is sent and activityId
@@ -1421,7 +1423,7 @@ LEFT JOIN civicrm_activity_contact src ON (src.activity_id = ac.activity_id AND 
     $contactIds = NULL,
     $additionalDetails = NULL,
     $contributionIds = NULL,
-    $campaign_id = NULL
+    $campaignId = NULL
   ) {
     // get the contact details of logged in contact, which we set as from email
     if ($userID == NULL) {
@@ -1470,7 +1472,7 @@ LEFT JOIN civicrm_activity_contact src ON (src.activity_id = ac.activity_id AND 
       'details' => $details,
       // FIXME: check for name Completed and get ID from that lookup
       'status_id' => 2,
-      'campaign_id' => $campaign_id,
+      'campaign_id' => $campaignId,
     );
 
     // CRM-5916: strip [case #…] before saving the activity (if present in subject)

--- a/CRM/Contact/Form/Task/EmailCommon.php
+++ b/CRM/Contact/Form/Task/EmailCommon.php
@@ -370,6 +370,9 @@ class CRM_Contact_Form_Task_EmailCommon {
       }
     }
 
+    //Added for CRM-15984: Add campaign field
+    CRM_Campaign_BAO_Campaign::addCampaign($form);
+
     $form->addFormRule(array('CRM_Contact_Form_Task_EmailCommon', 'formRule'), $form);
     CRM_Core_Resources::singleton()->addScriptFile('civicrm', 'templates/CRM/Contact/Form/Task/EmailCommon.js', 0, 'html-header');
   }
@@ -531,7 +534,8 @@ class CRM_Contact_Form_Task_EmailCommon {
       $bcc,
       array_keys($form->_toContactDetails),
       $additionalDetails,
-      $contributionIds
+      $contributionIds,
+      CRM_Utils_Array::value('campaign_id', $formValues)
     );
 
     $followupStatus = '';

--- a/templates/CRM/Contact/Form/Task/Email.tpl
+++ b/templates/CRM/Contact/Form/Task/Email.tpl
@@ -79,6 +79,8 @@
          {help id="id-token-subject" tplFile=$tplFile isAdmin=$isAdmin file="CRM/Contact/Form/Task/Email.hlp"}
        </td>
     </tr>
+  {* CRM-15984 --add campaign to email activities *}
+  {include file="CRM/Campaign/Form/addCampaignToComponent.tpl" campaignTrClass="crm-contactEmail-form-block-campaign_id"}
 </table>
 
 {include file="CRM/Contact/Form/Task/EmailCommon.tpl"}

--- a/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
@@ -5,10 +5,8 @@
  * @group headless
  */
 class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
-
   public function setUp() {
     parent::setUp();
-
     $this->prepareForACLs();
     CRM_Core_Config::singleton()->userPermissionClass->permissions = array('view all contacts', 'access CiviCRM');
   }
@@ -18,7 +16,6 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
    */
   public function tearDown() {
     $tablesToTruncate = array(
-      'civicrm_contact',
       'civicrm_activity',
       'civicrm_activity_contact',
       'civicrm_uf_match',
@@ -915,6 +912,7 @@ $text
       $bcc = NULL,
       $contactIds = NULL,
       $additionalDetails = NULL,
+      NULL,
       $campaign_id
     );
     $activity = $this->civicrm_api('activity', 'getsingle', array('id' => $activity_id, 'version' => $this->_apiversion));

--- a/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
@@ -5,8 +5,10 @@
  * @group headless
  */
 class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
+
   public function setUp() {
     parent::setUp();
+
     $this->prepareForACLs();
     CRM_Core_Config::singleton()->userPermissionClass->permissions = array('view all contacts', 'access CiviCRM');
   }
@@ -15,7 +17,14 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
    * Clean up after tests.
    */
   public function tearDown() {
-    $tablesToTruncate = array('civicrm_activity', 'civicrm_activity_contact', 'civicrm_email');
+    $tablesToTruncate = array(
+      'civicrm_contact',
+      'civicrm_activity',
+      'civicrm_activity_contact',
+      'civicrm_uf_match',
+      'civicrm_campaign',
+      'civicrm_email',
+    );
     $this->quickCleanup($tablesToTruncate);
     $this->cleanUpAfterACLs();
     parent::tearDown();
@@ -806,6 +815,110 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
       'rowCount' => 0,
       'sort' => NULL,
     );
+  }
+
+  public function testSendEmailBasic() {
+    $contactId = $this->individualCreate();
+
+    // create a logged in USER since the code references it for sendEmail user.
+    $this->createLoggedInUser();
+    $session = CRM_Core_Session::singleton();
+    $loggedInUser = $session->get('userID');
+
+    $contact = $this->civicrm_api('contact', 'getsingle', array('id' => $contactId, 'version' => $this->_apiversion));
+    $contactDetailsIntersectKeys = array(
+      'contact_id' => '',
+      'sort_name' => '',
+      'display_name' => '',
+      'do_not_email' => '',
+      'preferred_mail_format' => '',
+      'is_deceased' => '',
+      'email' => '',
+      'on_hold' => '',
+    );
+    $contactDetails = array(
+      array_intersect_key($contact, $contactDetailsIntersectKeys),
+    );
+
+    $subject = __FUNCTION__ . ' subject';
+    $html = __FUNCTION__ . ' html';
+    $text = __FUNCTION__ . ' text';
+    $userID = $loggedInUser;
+
+    list($sent, $activity_id) = $email_result = CRM_Activity_BAO_Activity::sendEmail(
+      $contactDetails,
+      $subject,
+      $text,
+      $html,
+      $contact['email'],
+      $userID,
+      $from = __FUNCTION__ . '@example.com'
+    );
+
+    $activity = $this->civicrm_api('activity', 'getsingle', array('id' => $activity_id, 'version' => $this->_apiversion));
+    $details = "-ALTERNATIVE ITEM 0-
+$html
+-ALTERNATIVE ITEM 1-
+$text
+-ALTERNATIVE END-
+";
+    $this->assertEquals($activity['details'], $details, 'Activity details does not match.');
+    $this->assertEquals($activity['subject'], $subject, 'Activity subject does not match.');
+  }
+
+  public function testSendEmailWithCampaign() {
+    // Create a contact and contactDetails array.
+    $contactId = $this->individualCreate();
+
+    // create a logged in USER since the code references it for sendEmail user.
+    $this->createLoggedInUser();
+    $session = CRM_Core_Session::singleton();
+    $loggedInUser = $session->get('userID');
+
+    $contact = $this->civicrm_api('contact', 'getsingle', array('id' => $contactId, 'version' => $this->_apiversion));
+    $contactDetailsIntersectKeys = array(
+      'contact_id' => '',
+      'sort_name' => '',
+      'display_name' => '',
+      'do_not_email' => '',
+      'preferred_mail_format' => '',
+      'is_deceased' => '',
+      'email' => '',
+      'on_hold' => '',
+    );
+    $contactDetails = array(
+      array_intersect_key($contact, $contactDetailsIntersectKeys),
+    );
+
+    // Create a campaign.
+    $result = $this->civicrm_api('Campaign', 'create', array(
+      'version' => $this->_apiversion,
+      'title' => __FUNCTION__ . ' campaign',
+    ));
+    $campaign_id = $result['id'];
+
+    $subject = __FUNCTION__ . ' subject';
+    $html = __FUNCTION__ . ' html';
+    $text = __FUNCTION__ . ' text';
+    $userID = $loggedInUser;
+
+    list($sent, $activity_id) = $email_result = CRM_Activity_BAO_Activity::sendEmail(
+      $contactDetails,
+      $subject,
+      $text,
+      $html,
+      $contact['email'],
+      $userID,
+      $from = __FUNCTION__ . '@example.com',
+      $attachments = NULL,
+      $cc = NULL,
+      $bcc = NULL,
+      $contactIds = NULL,
+      $additionalDetails = NULL,
+      $campaign_id
+    );
+    $activity = $this->civicrm_api('activity', 'getsingle', array('id' => $activity_id, 'version' => $this->_apiversion));
+    $this->assertEquals($activity['campaign_id'], $campaign_id, 'Activity campaign_id does not match.');
   }
 
 }


### PR DESCRIPTION
This is a re-submission of https://github.com/civicrm/civicrm-core/pull/9737 with rebase and minor fixes.

---

 * [CRM-15984: Add campaign field on Email activity form](https://issues.civicrm.org/jira/browse/CRM-15984)