### PR TITLE
CRM-19773 - Fix 25 event limit

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -2053,6 +2053,7 @@ WHERE  ce.loc_block_id = $locBlockId";
       $result = civicrm_api3('Event', 'get', array(
         'check_permissions' => 1,
         'return' => 'title',
+        'options' => array('limit' => 0),
       ));
       $allEvents = CRM_Utils_Array::collect('title', $result['values']);
 
@@ -2060,6 +2061,7 @@ WHERE  ce.loc_block_id = $locBlockId";
         'check_permissions' => 1,
         'return' => 'title',
         'created_id' => 'user_contact_id',
+        'options' => array('limit' => 0),
       ));
       $createdEvents = CRM_Utils_Array::collect('title', $result['values']);
 


### PR DESCRIPTION
This fixes a regression where only 25 events are visible, as described in https://civicrm.stackexchange.com/questions/18516/events-missing-after-upgrade-to-4-7-19

* [CRM-19773: Call hook_civicrm_selectWhereClause from the BAOs](https://issues.civicrm.org/jira/browse/CRM-19773)