### PR TITLE
CRM-20508 - Civicrm_Core - create field with non-ascii chars only

### DIFF
--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -83,8 +83,7 @@ class CRM_Utils_String {
     // we only use the ascii character set since mysql does not create table names / field names otherwise
     // CRM-11744
     $name = preg_replace('/[^a-zA-Z0-9]+/', $char, trim($name));
-
-      //var_dump($name);exit;
+      
 
     //If there are no ascii characters present.
     if ($name == $char) {

--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -84,6 +84,14 @@ class CRM_Utils_String {
     // CRM-11744
     $name = preg_replace('/[^a-zA-Z0-9]+/', $char, trim($name));
 
+      //var_dump($name);exit;
+
+    //If there are no ascii characters present.
+    if ($name == $char) {
+      $name = self::createRandom($len, self::ALPHANUMERIC);
+    }
+
+
     if ($len) {
       // lets keep variable names short
       return substr($name, 0, $len);

--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -83,13 +83,11 @@ class CRM_Utils_String {
     // we only use the ascii character set since mysql does not create table names / field names otherwise
     // CRM-11744
     $name = preg_replace('/[^a-zA-Z0-9]+/', $char, trim($name));
-      
 
     //If there are no ascii characters present.
     if ($name == $char) {
       $name = self::createRandom($len, self::ALPHANUMERIC);
     }
-
 
     if ($len) {
       // lets keep variable names short


### PR DESCRIPTION
It's generated a random and unique name for custom fields when it's label field has only non-ascii chars when creating a new custom field.

---

 * [CRM-20508: Unable to use non-roman characters in Custom fields](https://issues.civicrm.org/jira/browse/CRM-20508)