### PR TITLE
CRM-20508: test fix for non-ascii chars in custom field

### DIFF
--- a/tests/phpunit/api/v3/CustomFieldTest.php
+++ b/tests/phpunit/api/v3/CustomFieldTest.php
@@ -247,6 +247,28 @@ class api_v3_CustomFieldTest extends CiviUnitTestCase {
   }
 
   /**
+   * Check with non-ascii labels
+   */
+  public function testCustomFieldCreateWithNonAsciiLabel() {
+    $customGroup = $this->customGroupCreate(array('extends' => 'Contact', 'title' => 'select_test_group'));
+    $params = array(
+      'custom_group_id' => $customGroup['id'],
+      'label' => 'ôôôô',
+      'html_type' => 'Select',
+      'data_type' => 'String',
+      'weight' => 4,
+      'is_required' => 1,
+      'is_searchable' => 0,
+      'is_active' => 1,
+    );
+    $customField = $this->callAPISuccess('custom_field', 'create', $params);
+    $this->assertNotNull($customField['id']);
+    $params['label'] = 'ààà';
+    $customField = $this->callAPISuccess('custom_field', 'create', $params);
+    $this->assertNotNull($customField['id']);
+  }
+
+  /**
    * Test custom field with existing option group.
    */
   public function testCustomFieldExistingOptionGroup() {


### PR DESCRIPTION
Test to check for https://github.com/civicrm/civicrm-core/pull/10328

---

 * [CRM-20508: Unable to use non-roman characters in Custom fields](https://issues.civicrm.org/jira/browse/CRM-20508)