### PR TITLE
CRM-20418: Make token insertion work correctly when wysiwig is not loaded on Message Template edit

### DIFF
--- a/js/wysiwyg/crm.wysiwyg.js
+++ b/js/wysiwyg/crm.wysiwyg.js
@@ -34,14 +34,15 @@
     },
     // Fallback function to use when a wysiwyg has not been initialized
     _insertIntoTextarea: function(item, text) {
-      var origVal = $(item).val();
-      var origPos = item[0].selectionStart;
-      var newVal = origVal + text;
-      $(item).val(newVal);
+      itemObj = $(item);
+      var origVal = itemObj.val();
+      var origPos = itemObj[0].selectionStart;
+      var newVal = origVal.substring(0, origPos) + text + origVal.substring(origPos, origPos.length);
+      itemObj.val(newVal);
       var newPos = (origPos + text.length);
-      item[0].selectionStart = newPos;
-      item[0].selectionEnd = newPos;
-      $(item).triggerHandler('change');
+      itemObj[0].selectionStart = newPos;
+      itemObj[0].selectionEnd = newPos;
+      itemObj.triggerHandler('change');
       CRM.wysiwyg.focus(item);
     },
     // Create a "collapsed" textarea that expands into a wysiwyg when clicked

--- a/js/wysiwyg/crm.wysiwyg.js
+++ b/js/wysiwyg/crm.wysiwyg.js
@@ -34,12 +34,13 @@
     },
     // Fallback function to use when a wysiwyg has not been initialized
     _insertIntoTextarea: function(item, text) {
-      itemObj = $(item);
+      var itemObj = $(item);
       var origVal = itemObj.val();
-      var origPos = itemObj[0].selectionStart;
-      var newVal = origVal.substring(0, origPos) + text + origVal.substring(origPos, origPos.length);
+      var origStart = itemObj[0].selectionStart;
+      var origEnd = itemObj[0].selectionEnd;
+      var newVal = origVal.substring(0, origStart) + text + origVal.substring(origEnd);
       itemObj.val(newVal);
-      var newPos = (origPos + text.length);
+      var newPos = (origStart + text.length);
       itemObj[0].selectionStart = newPos;
       itemObj[0].selectionEnd = newPos;
       itemObj.triggerHandler('change');

--- a/templates/CRM/Admin/Form/MessageTemplates.tpl
+++ b/templates/CRM/Admin/Form/MessageTemplates.tpl
@@ -84,7 +84,7 @@
         <tr>
   </table>
 
-      <div id="msg_html" class="crm-accordion-wrapper crm-html_email-accordion ">
+      <div id="msg_html_section" class="crm-accordion-wrapper crm-html_email-accordion ">
         <div class="crm-accordion-header">
             {ts}HTML Format{/ts}
             {help id="id-message-text" file="CRM/Contact/Form/Task/Email.hlp"}
@@ -102,7 +102,7 @@
         </div><!-- /.crm-accordion-body -->
       </div><!-- /.crm-accordion-wrapper -->
 
-      <div id="msg_text" class="crm-accordion-wrapper crm-plaint_text_email-accordion ">
+      <div id="msg_text_section" class="crm-accordion-wrapper crm-plaint_text_email-accordion ">
         <div class="crm-accordion-header">
                 {ts}Plain-Text Format{/ts}
         </div><!-- /.crm-accordion-header -->
@@ -165,8 +165,8 @@
       });
       function showHideUpload(type) {
         var show = (type == 1) ? false : true;
-        $("#msg_html").toggle(show);
-        $("#msg_text, #pdf_format").toggle(show);
+        $("#msg_html_section").toggle(show);
+        $("#msg_text_section, #pdf_format").toggle(show);
         $("#file_id").parent().parent().toggle(!show);
 
         // auto file type validation

--- a/templates/CRM/Admin/Form/MessageTemplates.tpl
+++ b/templates/CRM/Admin/Form/MessageTemplates.tpl
@@ -165,8 +165,7 @@
       });
       function showHideUpload(type) {
         var show = (type == 1) ? false : true;
-        $("#msg_html_section").toggle(show);
-        $("#msg_text_section, #pdf_format").toggle(show);
+        $("#msg_html_section, #msg_text_section, #pdf_format").toggle(show);
         $("#file_id").parent().parent().toggle(!show);
 
         // auto file type validation


### PR DESCRIPTION
Replaces #10149  

On message template forms, when wysiwyg is not loaded, html tokens were not being inserted. Previous PR by @jitendrapurohit fixed duplicate ID problem in the markup, and this PR fixes JS to insert the token in the right spot

* [CRM-20418: Not able to select Tokens from dropdown on Message Template](https://issues.civicrm.org/jira/browse/CRM-20418)