### PR TITLE
CRM-20567: backoffice membership via price set errors with non-aggregated column

### DIFF
--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -1341,11 +1341,11 @@ INNER JOIN  civicrm_price_set pset    ON ( pset.id = field.price_set_id )
    */
   public static function getMembershipCount($ids) {
     $queryString = "
-SELECT       count( pfv.id ) AS count, pfv.id AS id
+SELECT       count( pfv.id ) AS count, mt.member_of_contact_id AS id
 FROM         civicrm_price_field_value pfv
 INNER JOIN    civicrm_membership_type mt ON mt.id = pfv.membership_type_id
 WHERE        pfv.id IN ( $ids )
-GROUP BY     mt.member_of_contact_id";
+GROUP BY     mt.member_of_contact_id ";
 
     $crmDAO = CRM_Core_DAO::executeQuery($queryString);
     $count = array();

--- a/tests/phpunit/CRM/Price/BAO/PriceSetTest.php
+++ b/tests/phpunit/CRM/Price/BAO/PriceSetTest.php
@@ -59,4 +59,71 @@ class CRM_Price_BAO_PriceSetTest extends CiviUnitTestCase {
     $this->assertEquals(CRM_Core_DAO::VALUE_SEPARATOR . 'Price Field - 1' . CRM_Core_DAO::VALUE_SEPARATOR, $amountLevel);
   }
 
+  /**
+   * Test CRM_Price_BAO_PriceSet::getMembershipCount() that return correct number of
+   *   membership type occurances against it's corresponding member orgaisation
+   */
+  public function testGetMembershipCount() {
+    // create two organisations
+    $organization1 = $this->organizationCreate();
+    $organization2 = $this->organizationCreate();
+
+    // create three membership type where first two belong to same organisation
+    $membershipType1 = $this->membershipTypeCreate(array(
+      'name' => 'Membership Type 1',
+      'member_of_contact_id' => $organization1,
+    ));
+    $membershipType2 = $this->membershipTypeCreate(array(
+      'name' => 'Membership Type 2',
+      'member_of_contact_id' => $organization1,
+    ));
+    $membershipType3 = $this->membershipTypeCreate(array(
+      'name' => 'Membership Type 3',
+      'member_of_contact_id' => $organization2,
+    ));
+
+    $priceDetails = CRM_Price_BAO_PriceSet::getSetDetail(CRM_Core_DAO::getFieldValue(
+      'CRM_Price_DAO_PriceSet',
+      'default_membership_type_amount',
+      'id', 'name'
+    ));
+    // fetch price field value IDs in array('membership_type_id' => 'price_field_value_id') format
+    $priceFieldValueIDs = array();
+    foreach ($priceDetails as $priceFields) {
+      foreach ($priceFields['fields'] as $priceField) {
+        foreach ($priceField['options'] as $id => $priceFieldValue) {
+          if (in_array($priceFieldValue['membership_type_id'], array($membershipType1, $membershipType2, $membershipType3))) {
+            $priceFieldValueIDs[$priceFieldValue['membership_type_id']] = $id;
+          }
+        }
+      }
+    }
+
+    // CASE 1: when two price field value IDs of membership type that belong to same organization, are chosen
+    $sameOrgPriceFieldIDs = implode(', ', array(
+      $priceFieldValueIDs[$membershipType1],
+      $priceFieldValueIDs[$membershipType2],
+    ));
+    $occurences = CRM_Price_BAO_PriceSet::getMembershipCount($sameOrgPriceFieldIDs);
+    // total number of membership type occurences of same organisation is one
+    $this->assertEquals(1, count($occurences));
+    $this->assertTrue(array_key_exists($organization1, $occurences));
+    // assert that two membership types were chosen from same organisation
+    $this->assertEquals(2, $occurences[$organization1]);
+
+    // CASE 2: when two price field value IDs of membership type that belong to different organizations, are chosen
+    $differentOrgPriceFieldIDs = implode(', ', array(
+      $priceFieldValueIDs[$membershipType1],
+      $priceFieldValueIDs[$membershipType3],
+    ));
+    $occurences = CRM_Price_BAO_PriceSet::getMembershipCount($differentOrgPriceFieldIDs);
+    // total number of membership type occurences of different organisation is two
+    $this->assertEquals(2, count($occurences));
+    $this->assertTrue(array_key_exists($organization1, $occurences));
+    $this->assertTrue(array_key_exists($organization2, $occurences));
+    // assert that two membership types were chosen from different organisation
+    $this->assertEquals(1, $occurences[$organization1]);
+    $this->assertEquals(1, $occurences[$organization2]);
+  }
+
 }


### PR DESCRIPTION
* [CRM-20567: backoffice membership via price set errors with non-aggregated column](https://issues.civicrm.org/jira/browse/CRM-20567)