### PR TITLE
CRM-20577 - When creating an activity per-contact when sending letters, store the version with rendered tokens

### DIFF
--- a/CRM/Contact/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contact/Form/Task/PDFLetterCommon.php
@@ -36,6 +36,8 @@
  */
 class CRM_Contact_Form_Task_PDFLetterCommon {
 
+  protected static $tokenCategories;
+
   /**
    * @return array
    *   Array(string $machineName => string $label).
@@ -328,9 +330,7 @@ class CRM_Contact_Form_Task_PDFLetterCommon {
       $bao->savePdfFormat($formValues, $formValues['format_id']);
     }
 
-    $tokens = array();
-    CRM_Utils_Hook::tokens($tokens);
-    $categories = array_keys($tokens);
+    $categories = self::getTokenCategories();
 
     //time being hack to strip '&nbsp;'
     //from particular letter line, CRM-6798
@@ -352,6 +352,8 @@ class CRM_Contact_Form_Task_PDFLetterCommon {
    * Process the form after the input has been submitted and validated.
    *
    * @param CRM_Core_Form $form
+   *
+   * @throws \CRM_Core_Exception
    */
   public static function postProcess(&$form) {
     $formValues = $form->controller->exportValues($form->getName());
@@ -602,6 +604,20 @@ class CRM_Contact_Form_Task_PDFLetterCommon {
     else {
       throw new \CRM_Core_Exception("Cannot determine mime type");
     }
+  }
+
+  /**
+   * Get the categories required for rendering tokens.
+   *
+   * @return array
+   */
+  protected static function getTokenCategories() {
+    if (self::$tokenCategories === NULL) {
+      $tokens = array();
+      CRM_Utils_Hook::tokens($tokens);
+      self::$tokenCategories = array_keys($tokens);
+    }
+    return self::$tokenCategories;
   }
 
 }

--- a/CRM/Contribute/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contribute/Form/Task/PDFLetterCommon.php
@@ -334,9 +334,6 @@ class CRM_Contribute_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDF
    * @param int $groupByID
    */
   public static function assignCombinedContributionValues($contact, $contributions, $groupBy, $groupByID) {
-    if (!defined('CIVICRM_MAIL_SMARTY') || !CIVICRM_MAIL_SMARTY) {
-      return;
-    }
     CRM_Core_Smarty::singleton()->assign('contact_aggregate', $contact['contact_aggregate']);
     CRM_Core_Smarty::singleton()
       ->assign('contributions', array_intersect_key($contributions, $contact['contribution_ids'][$groupBy][$groupByID]));

--- a/CRM/Member/Form/Task/PDFLetterCommon.php
+++ b/CRM/Member/Form/Task/PDFLetterCommon.php
@@ -31,7 +31,11 @@ class CRM_Member_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDFLett
         $html_message,
         $categories
       );
-    self::createActivities($form, $html_message, $contactIDs);
+    // This seems silly, but the old behavior was to first check `_cid`
+    // and then use the provided `$contactIds`. Probably not even necessary,
+    // but difficult to audit.
+    $contactIDs = $form->_cid ? array($form->_cid) : $contactIDs;
+    self::createActivities($form, $html_message, $contactIDs, $formValues['subject'], CRM_Utils_Array::value('campaign_id', $formValues));
 
     CRM_Utils_PDF_Utils::html2pdf($html, "CiviLetter.pdf", FALSE, $formValues);
 

--- a/tests/phpunit/CRM/Contribute/Form/Task/PDFLetterCommonTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Task/PDFLetterCommonTest.php
@@ -43,6 +43,15 @@ class CRM_Contribute_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
 
   protected $_contactIds = NULL;
 
+  /**
+   * Count how many times the hookTokens is called.
+   *
+   * This only needs to be called once, check refactoring doesn't change this.
+   *
+   * @var int
+   */
+  protected $hookTokensCalled = 0;
+
   protected function setUp() {
     parent::setUp();
     $this->_individualId = $this->individualCreate(array('first_name' => 'Anthony', 'last_name' => 'Collins'));
@@ -281,6 +290,9 @@ class CRM_Contribute_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
   </tr>
   </tbody>
 </table>", $html[2]);
+    // Checking it is not called multiple times.
+    // once for each contact create + once for the activities.
+    $this->assertEquals(3, $this->hookTokensCalled);
 
   }
 
@@ -288,6 +300,7 @@ class CRM_Contribute_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
    * Implements civicrm_tokens().
    */
   function hook_tokens(&$tokens) {
+    $this->hookTokensCalled++;
     $tokens['aggregate'] = array('rendered_token' => 'rendered_token');
   }
 


### PR DESCRIPTION
In addition to the unit test there is a minor change to not do the early return before assigning variables
if smarty is not set. This doesn't really have any performance advantage, as they are already calculated,
blocks the unit test and also blocks using these variables from outside extensions

---

 * [CRM-20577: When creating an activity per-contact when sending letters, store the version with rendered tokens](https://issues.civicrm.org/jira/browse/CRM-20577)