### PR TITLE
WIP: CRM-20240: Catch CRM_Extension_Exception_MissingException.

### DIFF
--- a/Civi/Angular/Page/Main.php
+++ b/Civi/Angular/Page/Main.php
@@ -75,9 +75,16 @@ class Main extends \CRM_Core_Page {
     $page = $this; // PHP 5.3 does not propagate $this to inner functions.
 
     $this->res->addSettingsFactory(function () use (&$modules, $page) {
+      try {
+        $activeModuleUrls = \CRM_Extension_System::singleton()->getMapper()->getActiveModuleUrls();
+      }
+      catch (\CRM_Extension_Exception_MissingException $e) {
+        $activeModuleUrls = array();
+      }
+
       // TODO optimization; client-side caching
       return array_merge($page->angular->getResources(array_keys($modules), 'settings', 'settings'), array(
-        'resourceUrls' => \CRM_Extension_System::singleton()->getMapper()->getActiveModuleUrls(),
+        'resourceUrls' => $activeModuleUrls,
         'angular' => array(
           'modules' => array_merge(array('ngRoute'), array_keys($modules)),
           'cacheCode' => $page->res->getCacheCode(),


### PR DESCRIPTION
I could use some input on whether this change is both sufficient and of low regression potential.

- Webtest is here: https://github.com/nganivet/civicrm-webtest/blob/master/tests/acceptance/Core/Authenticated/Drupal/AngularPageLoadWhenExtensionsFilesAreMissingCept.php It fails without this fix, and passes with the fix.
- The usual warning "Error loading module file (). Please restore the file or disable the module." still appears on all CiviCRM pages with this fix.

@colemanw this is the one we were looking at together at the STL sprint.

---

 * [CRM-20240: Fatal error on all Angular pages if an extension is missing](https://issues.civicrm.org/jira/browse/CRM-20240)