### PR TITLE
CRM-20562: Duplicate Activities created during participant registration v…

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -2107,6 +2107,7 @@ WHERE      activity.id IN ($activityIds)";
     $id = CRM_Core_Session::getLoggedInContactID();
     if ($id) {
       $activityParams['source_contact_id'] = $id;
+      $activityParams['target_contact_id'][] = $activity->contact_id;
     }
 
     // CRM-14945
@@ -2115,7 +2116,7 @@ WHERE      activity.id IN ($activityIds)";
     }
     //CRM-4027
     if ($targetContactID) {
-      $activityParams['target_contact_id'] = $targetContactID;
+      $activityParams['target_contact_id'][] = $targetContactID;
     }
     // @todo - use api - remove lots of wrangling above. Remove deprecated fatal & let form layer
     // deal with any exceptions.

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4705,10 +4705,6 @@ LIMIT 1;";
         $contribution->contact_id = $ids['related_contact'];
       }
       CRM_Activity_BAO_Activity::addActivity($contribution, NULL, $targetContactID);
-      // event
-    }
-    else {
-      CRM_Activity_BAO_Activity::addActivity($participant);
     }
 
     // CRM-9132 legacy behaviour was that receipts were sent out in all instances. Still sending

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -2720,7 +2720,9 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $activities = CRM_Activity_BAO_Activity::getContactActivity($this->_individualId);
     $this->assertEquals(3, count($activities));
     $activityNames = array_count_values(CRM_Utils_Array::collect('activity_name', $activities));
+    // record two activities before and after completing payment for Event registration
     $this->assertEquals(2, $activityNames['Event Registration']);
+    // update the original 'Contribution' activity created after completing payment
     $this->assertEquals(1, $activityNames['Contribution']);
 
     $mut->checkMailLog(array(

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -2704,7 +2704,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
   public function testCompleteTransactionWithParticipantRecord() {
     $mut = new CiviMailUtils($this, TRUE);
     $mut->clearMessages();
-    $this->createLoggedInUser();
+    $this->_individualId = $this->createLoggedInUser();
     $contributionID = $this->createPendingParticipantContribution();
     $this->callAPISuccess('contribution', 'completetransaction', array(
         'id' => $contributionID,
@@ -2715,6 +2715,14 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'return' => 'participant_status_id',
     ));
     $this->assertEquals(1, $participantStatus);
+
+    //Assert only three activities are created.
+    $activities = CRM_Activity_BAO_Activity::getContactActivity($this->_individualId);
+    $this->assertEquals(3, count($activities));
+    $activityNames = array_count_values(CRM_Utils_Array::collect('activity_name', $activities));
+    $this->assertEquals(2, $activityNames['Event Registration']);
+    $this->assertEquals(1, $activityNames['Contribution']);
+
     $mut->checkMailLog(array(
       'Annual CiviCRM meet',
       'Event',
@@ -3061,9 +3069,9 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
    */
   public function createPendingParticipantContribution() {
     $event = $this->eventCreate(array('is_email_confirm' => 1, 'confirm_from_email' => 'test@civicrm.org'));
-    $participantID = $this->participantCreate(array('event_id' => $event['id'], 'status_id' => 6));
+    $participantID = $this->participantCreate(array('event_id' => $event['id'], 'status_id' => 6, 'contact_id' => $this->_individualId));
     $this->_ids['participant'] = $participantID;
-    $params = array_merge($this->_params, array('contribution_status_id' => 2, 'financial_type_id' => 'Event Fee'));
+    $params = array_merge($this->_params, array('contact_id' => $this->_individualId, 'contribution_status_id' => 2, 'financial_type_id' => 'Event Fee'));
     $contribution = $this->callAPISuccess('contribution', 'create', $params);
     $this->callAPISuccess('participant_payment', 'create', array(
       'contribution_id' => $contribution['id'],


### PR DESCRIPTION
…ia completetransaction.

As all required activities already gets created above while calling participant create api, writing addActivity() again would be an additional creation on them. Removing this call as I don't find any use-case where these lines might be required.

https://issues.civicrm.org/jira/browse/CRM-20562