### PR TITLE
Fix Case UI - (Case Manager) displaying for wrong role

### DIFF
--- a/CRM/Case/XMLProcessor/Process.php
+++ b/CRM/Case/XMLProcessor/Process.php
@@ -196,7 +196,7 @@ class CRM_Case_XMLProcessor_Process extends CRM_Case_XMLProcessor {
         if (!$isCaseManager) {
           $result[$relationshipTypeID] = $relationshipTypeName;
         }
-        elseif ($relationshipTypeXML->manager) {
+        elseif ($relationshipTypeXML->manager == 1) {
           return $relationshipTypeID;
         }
       }


### PR DESCRIPTION
CiviCase was displaying the (Case Manager) tag for the wrong role, as the XML now populates each role with the <manager></manager> tag with either 1 or 0 to determine whether it is the manager or not.

The existing code was only checking that the tag existed.