### PR TITLE
Surface errors from API calls to user on status page.

### DIFF
--- a/ang/crmStatusPage.css
+++ b/ang/crmStatusPage.css
@@ -75,3 +75,7 @@
   z-index: 99999;
   font-weight: normal;
 }
+
+.status-debug-information {
+  font-size: smaller;
+}

--- a/ang/crmStatusPage/StatusPageCtrl.js
+++ b/ang/crmStatusPage/StatusPageCtrl.js
@@ -8,7 +8,7 @@
       $scope.statuses = statusData.values;
 
       // Refresh the list. Optionally execute api calls first.
-      function refresh(apiCalls) {
+      function refresh(apiCalls, title) {
         apiCalls = (apiCalls || []).concat([['System', 'check', {sequential: 1}]]);
         $('#crm-status-list').block();
         crmApi(apiCalls, true)
@@ -16,13 +16,13 @@
             $scope.statuses = results[results.length - 1].values;
             results.forEach(function(result) {
               if (result.is_error) {
-                var error_message = ts('result.error_message');
+                var error_message = ts(result.error_message);
                 if (typeof(result.debug_information) !== 'undefined') {
                   error_message += '<div class="status-debug-information">' +
                       '<b>' + ts('Debug information') + ':</b><br>' +
                       result.debug_information + '</div>';
                 }
-                CRM.alert(error_message, ts('API error'), 'error');
+                CRM.alert(error_message, ts('Operation failed: ' + title), 'error');
                 }
               });
             $('#crm-status-list').unblock();
@@ -37,7 +37,7 @@
             ignore_severity: visible ? 0 : status.severity,
             hush_until: until
           }]
-        ]);
+        ], 'Set preference');
       };
       
       $scope.countVisible = function(visibility) {
@@ -54,7 +54,7 @@
               break;
 
             case 'api3':
-              refresh([action.params]);
+              refresh([action.params], action.title);
               break;
           }
         }

--- a/ang/crmStatusPage/StatusPageCtrl.js
+++ b/ang/crmStatusPage/StatusPageCtrl.js
@@ -9,6 +9,7 @@
 
       // Refresh the list. Optionally execute api calls first.
       function refresh(apiCalls, title) {
+        title = title || 'Untitled operation';
         apiCalls = (apiCalls || []).concat([['System', 'check', {sequential: 1}]]);
         $('#crm-status-list').block();
         crmApi(apiCalls, true)

--- a/ang/crmStatusPage/StatusPageCtrl.js
+++ b/ang/crmStatusPage/StatusPageCtrl.js
@@ -16,13 +16,13 @@
             $scope.statuses = results[results.length - 1].values;
             results.forEach(function(result) {
               if (result.is_error) {
-                var error_message = result.error_message;
+                var error_message = ts('result.error_message');
                 if (typeof(result.debug_information) !== 'undefined') {
                   error_message += '<div class="status-debug-information">' +
-                      '<b>Debug information:</b><br>' +
+                      '<b>' + ts('Debug information') + ':</b><br>' +
                       result.debug_information + '</div>';
                 }
-                CRM.alert(error_message, 'API error', 'error');
+                CRM.alert(error_message, ts('API error'), 'error');
                 }
               });
             $('#crm-status-list').unblock();

--- a/ang/crmStatusPage/StatusPageCtrl.js
+++ b/ang/crmStatusPage/StatusPageCtrl.js
@@ -12,8 +12,19 @@
         apiCalls = (apiCalls || []).concat([['System', 'check', {sequential: 1}]]);
         $('#crm-status-list').block();
         crmApi(apiCalls, true)
-          .then(function(result) {
-            $scope.statuses = result[result.length - 1].values;
+          .then(function(results) {
+            $scope.statuses = results[results.length - 1].values;
+            results.forEach(function(result) {
+              if (result.is_error) {
+                var error_message = result.error_message;
+                if (typeof(result.debug_information) !== 'undefined') {
+                  error_message += '<div class="status-debug-information">' +
+                      '<b>Debug information:</b><br>' +
+                      result.debug_information + '</div>';
+                }
+                CRM.alert(error_message, 'API error', 'error');
+                }
+              });
             $('#crm-status-list').unblock();
           });
       }


### PR DESCRIPTION
CRM-20602

This is pretty my-first-angular, so please be firm re where things like .status-debug-information really belong.

If it sees "debug_information" it appends it to the alert. That could get ugly but it's better than nothing; an alternative is to direct people to the debug log (or, make it available but hidden, or both)?

---

 * [CRM-20602: Status page should surface errors when making API calls \(eg system.updateindexes\)](https://issues.civicrm.org/jira/browse/CRM-20602)
 * relates to: [CRM-20533: 'Update Indices' System Status action fails when index name already exists](https://issues.civicrm.org/jira/browse/CRM-20533)