### PR TITLE
CRM-20600 - Purify Angular HTML

### DIFF
--- a/ang/crmCaseType/activityTypesTable.html
+++ b/ang/crmCaseType/activityTypesTable.html
@@ -22,7 +22,7 @@ Required vars: caseType
       {{ activityType.name }}
     </td>
     <td>
-      <input class="crm-form-text number" type="text" ng-pattern="/^[1-9][0-9]*$/" ng-model="activityType.max_instances" />
+      <input class="crm-form-text number" type="text" ng-pattern="/^[1-9][0-9]*$/" ng-model="activityType.max_instances">
     </td>
     <td>
       <a crm-icon="fa-trash" class="crm-hover-button" ng-click="removeItem(caseType.definition.activityTypes, activityType)" title="{{ts('Remove')}}"></a>
@@ -39,7 +39,7 @@ Required vars: caseType
            crm-var="newActivity"
            crm-on-add="addActivityType(newActivity)"
            placeholder="{{ts('Add activity type')}}"
-              />
+      ></span>
     </td>
   </tr>
   </tfoot>

--- a/ang/crmCaseType/rolesTable.html
+++ b/ang/crmCaseType/rolesTable.html
@@ -14,8 +14,8 @@ Required vars: caseType
   <tbody>
 	  <tr ng-repeat="relType in caseType.definition.caseRoles | orderBy:'name'" ng-class-even="'crm-entity even-row even'" ng-class-odd="'crm-entity odd-row odd'">
 	    <td>{{relType.name}}</td>
-	    <td><input type="checkbox" ng-model="relType.creator" ng-true-value="'1'" ng-false-value="'0'"/></td>
-	    <td><input type="radio" ng-model="relType.manager" value="1" ng-change="onManagerChange(relType)"/></td>
+	    <td><input type="checkbox" ng-model="relType.creator" ng-true-value="'1'" ng-false-value="'0'"></td>
+	    <td><input type="radio" ng-model="relType.manager" value="1" ng-change="onManagerChange(relType)"></td>
 	    <td>
 	      <a crm-icon="fa-trash" class="crm-hover-button" ng-click="removeItem(caseType.definition.caseRoles,relType)" title="{{ts('Remove')}}"></a>
 	    </td>
@@ -30,7 +30,7 @@ Required vars: caseType
 	           crm-var="newRole"
 	           crm-on-add="addRole(caseType.definition.caseRoles, newRole)"
              placeholder="{{ts('Add role')}}"
-	              />
+	              ></span>
 	    </td>
 	  </tr>
   </tfoot>

--- a/ang/crmCaseType/sequenceTable.html
+++ b/ang/crmCaseType/sequenceTable.html
@@ -34,7 +34,7 @@ Required vars: activitySet
            crm-var="newActivity"
            crm-on-add="addActivity(activitySet, newActivity)"
            placeholder="{{ts('Add activity')}}"
-              />
+      ></span>
     </td>
   </tr>
   </tfoot>

--- a/ang/crmCaseType/timelineTable.html
+++ b/ang/crmCaseType/timelineTable.html
@@ -53,7 +53,7 @@ Required vars: activitySet
         ng-model="activity.reference_offset"
         ng-hide="activity.name == 'Open Case'"
         ng-required="activity.name != 'Open Case'"
-        />
+        >
     </td>
     <td>
       <select
@@ -80,12 +80,12 @@ Required vars: activitySet
   <tfoot>
   <tr class="addRow">
     <td colspan="6">
-      <span crm-add-name
+      <span crm-add-name=""
            crm-options="activityTypeOptions"
            crm-var="newActivity"
            crm-on-add="addActivity(activitySet, newActivity)"
            placeholder="{{ts('Add activity')}}"
-              />
+      ></span>
     </td>
   </tr>
   </tfoot>

--- a/ang/crmCxn/PermTable.html
+++ b/ang/crmCxn/PermTable.html
@@ -21,7 +21,7 @@
             <em ng-show="api.actions == '*'">{{ts('Any')}}</em>
             <code ng-hide="api.actions == '*'">{{api.actions}}</code>
           </span>
-          <span ng-switch-default>
+          <span ng-switch-default="">
             <span ng-repeat="action in api.actions"><code>{{action}}</code><span ng-show="!$last">, </span></span>
           </span>
       </div>

--- a/ang/crmExample/example.html
+++ b/ang/crmExample/example.html
@@ -20,16 +20,15 @@
 
           <div class="crmMailing-schedule-inner">
             <div>
-              <input ng-model="schedule.mode" type="radio" name="send_{{exName}}" value="now" id="schedule-send-now"/>
+              <input ng-model="schedule.mode" type="radio" name="send_{{exName}}" value="now" id="schedule-send-now">
               <label for="schedule-send-now">{{ts('Send immediately')}}</label>
             </div>
             <div>
-              <input ng-model="schedule.mode" type="radio" name="send_{{exName}}" value="at" id="schedule-send-at"/>
+              <input ng-model="schedule.mode" type="radio" name="send_{{exName}}" value="at" id="schedule-send-at">
               <label for="schedule-send-at">{{ts('Send at:')}}</label>
-              <input crm-ui-datepicker ng-model="schedule.datetime" ng-required="schedule.mode == 'at'"/>
+              <input crm-ui-datepicker ng-model="schedule.datetime" ng-required="schedule.mode == 'at'">
             </div>
           </div>
-        </div>
         </div>
       </td>
       <td>

--- a/ang/crmMailing/BlockPreview.html
+++ b/ang/crmMailing/BlockPreview.html
@@ -22,7 +22,7 @@ Vars: mailing:obj, testContact:obj, testGroup:obj, crmMailing:FormController
     </div>
     -->
   </div>
-  <div class="preview-contact" ng-form>
+  <div class="preview-contact" ng-form="">
     <div>
       {{ts('Send test email to:')}}
       <a crm-ui-help="hs({id: 'test', title: ts('Test Email')})"></a>
@@ -38,7 +38,7 @@ Vars: mailing:obj, testContact:obj, testGroup:obj, crmMailing:FormController
     </div>
     <button crm-icon="fa-paper-plane" title="{{crmMailing.$invalid || !testContact.email ? ts('Complete all required fields first') : ts('Send test message to %1', {1: testContact.email})}}" ng-disabled="crmMailing.$invalid || !testContact.email" ng-click="doSend({email: testContact.email})">{{ts('Send test')}}</button>
   </div>
-  <div class="preview-group" ng-form>
+  <div class="preview-group" ng-form="">
     <div>
       {{ts('Send test email to group:')}}
       <a crm-ui-help="hs({id: 'test', title: ts('Test Email')})"></a>
@@ -55,7 +55,7 @@ Vars: mailing:obj, testContact:obj, testGroup:obj, crmMailing:FormController
         <option value=""></option>
       </select>
     </div>
-    <button crm-icon="fa-paper-plane" title="{{crmMailing.$invalid || !testGroup.gid ? ts('Complete all required fields first') : ts('Send test message to group')}}"ng-disabled="crmMailing.$invalid || !testGroup.gid" crm-confirm="{resizable: true, width: '40%', height: '40%', open: previewTestGroup}" on-yes="doSend({gid: testGroup.gid})">{{ts('Send test')}}</button>
+    <button crm-icon="fa-paper-plane" title="{{crmMailing.$invalid || !testGroup.gid ? ts('Complete all required fields first') : ts('Send test message to group')}}" ng-disabled="crmMailing.$invalid || !testGroup.gid" crm-confirm="{resizable: true, width: '40%', height: '40%', open: previewTestGroup}" on-yes="doSend({gid: testGroup.gid})">{{ts('Send test')}}</button>
   </div>
   <div class="clear"></div>
 </div>

--- a/ang/crmMailing/BlockRecipients.html
+++ b/ang/crmMailing/BlockRecipients.html
@@ -1,6 +1,6 @@
 <div ng-controller="EditRecipCtrl" class="crm-mailing-recipients-row">
   <div style="float: right;">
-    <div class='crmMailing-recip-est'>
+    <div class="crmMailing-recip-est">
       <a href="" ng-click="previewRecipients()" title="{{ts('Preview a List of Recipients')}}">{{getRecipientsEstimate()}}</a>
     </div>
   </div>

--- a/ang/crmMailing/BodyHtml.html
+++ b/ang/crmMailing/BodyHtml.html
@@ -4,13 +4,14 @@ Required vars: mailing
 <div ng-form="htmlForm" crm-ui-id-scope>
   <div ng-controller="EmailBodyCtrl">
     <div style="float: right;">
-      <input crm-mailing-token on-select="$broadcast('insert:body_html', token.name)" tabindex="-1" style="z-index:1"/>
+      <input crm-mailing-token on-select="$broadcast('insert:body_html', token.name)" tabindex="-1" style="z-index:1">
     </div>
 
     <div>
       <textarea
         crm-ui-id="htmlForm.body_html"
-        crm-ui-richtext name="body_html"
+        crm-ui-richtext
+        name="body_html"
         crm-ui-insert-rx="insert:body_html"
         ng-model="mailing.body_html"
         ng-blur="checkTokens(mailing, 'body_html', 'insert:body_html')"

--- a/ang/crmMailing/EditMailingCtrl/2step.html
+++ b/ang/crmMailing/EditMailingCtrl/2step.html
@@ -4,42 +4,42 @@
       <div crm-ui-wizard-step crm-title="ts('Define Mailing')" ng-form="defineForm">
         <div crm-ui-tab-set>
           <div crm-ui-tab id="tab-mailing" crm-title="ts('Mailing')">
-            <div crm-mailing-block-summary crm-mailing="mailing"/>
-            <div crm-mailing-block-mailing crm-mailing="mailing"/>
-            <div crm-ui-accordion="{title: ts('HTML'), help: hs('html')}" >
-              <div crm-mailing-body-html crm-mailing="mailing"/>
+            <div crm-mailing-block-summary crm-mailing="mailing"></div>
+            <div crm-mailing-block-mailing crm-mailing="mailing"></div>
+            <div crm-ui-accordion="{title: ts('HTML'), help: hs('html')}">
+              <div crm-mailing-body-html crm-mailing="mailing"></div>
             </div>
             <div crm-ui-accordion="{title: ts('Plain Text'), collapsed: !mailing.body_text, help: hs('text')}">
-              <div crm-mailing-body-text crm-mailing="mailing"/>
+              <div crm-mailing-body-text crm-mailing="mailing"></div>
             </div>
             <span ng-model="placeholder" crm-ui-validate="mailing.body_html || mailing.body_text"></span>
           </div>
           <div crm-ui-tab id="tab-attachment" crm-title="ts('Attachments')">
-            <div crm-attachments="attachments"/>
+            <div crm-attachments="attachments"></div>
           </div>
           <div crm-ui-tab id="tab-header" crm-title="ts('Header and Footer')">
-            <div crm-mailing-block-header-footer crm-mailing="mailing"/>
+            <div crm-mailing-block-header-footer crm-mailing="mailing"></div>
           </div>
           <div crm-ui-tab id="tab-pub" crm-title="ts('Publication')">
-            <div crm-mailing-block-publication crm-mailing="mailing"/>
+            <div crm-mailing-block-publication crm-mailing="mailing"></div>
           </div>
           <div crm-ui-tab id="tab-response" crm-title="ts('Responses')">
-            <div crm-mailing-block-responses crm-mailing="mailing"/>
+            <div crm-mailing-block-responses crm-mailing="mailing"></div>
           </div>
           <div crm-ui-tab id="tab-tracking" crm-title="ts('Tracking')">
-            <div crm-mailing-block-tracking crm-mailing="mailing"/>
+            <div crm-mailing-block-tracking crm-mailing="mailing"></div>
           </div>
         </div>
-        <div crm-ui-accordion="{title: ts('Preview')}" >
-          <div crm-mailing-block-preview crm-mailing="mailing" on-preview="previewMailing(mailing, preview.mode)" on-send="sendTest(mailing, attachments, preview.recipient)" />
+        <div crm-ui-accordion="{title: ts('Preview')}">
+          <div crm-mailing-block-preview crm-mailing="mailing" on-preview="previewMailing(mailing, preview.mode)" on-send="sendTest(mailing, attachments, preview.recipient)"></div>
         </div>
       </div>
       <div crm-ui-wizard-step crm-title="ts('Review and Schedule')" ng-form="reviewForm">
-        <div crm-ui-accordion="{title: ts('Review')}" >
-          <div crm-mailing-block-review crm-mailing="mailing" crm-mailing-attachments="attachments"/>
+        <div crm-ui-accordion="{title: ts('Review')}">
+          <div crm-mailing-block-review crm-mailing="mailing" crm-mailing-attachments="attachments"></div>
         </div>
-        <div crm-ui-accordion="{title: ts('Schedule')}" >
-          <div crm-mailing-block-schedule crm-mailing="mailing"/>
+        <div crm-ui-accordion="{title: ts('Schedule')}">
+          <div crm-mailing-block-schedule crm-mailing="mailing"></div>
         </div>
         <center>
           <a class="button crmMailing-submit-button" ng-click="submit()" ng-class="{blocking: block.check(), disabled: crmMailingSubform.$invalid}">

--- a/ang/crmMailing/EditMailingCtrl/unified.html
+++ b/ang/crmMailing/EditMailingCtrl/unified.html
@@ -1,40 +1,40 @@
 <div ng-form="crmMailingSubform">
   <div class="crm-block crm-form-block crmMailing">
 
-    <div crm-mailing-block-summary crm-mailing="mailing"/>
-    <div crm-mailing-block-mailing crm-mailing="mailing"/>
+    <div crm-mailing-block-summary crm-mailing="mailing"></div>
+    <div crm-mailing-block-mailing crm-mailing="mailing"></div>
 
     <div crm-ui-tab-set>
       <div crm-ui-tab id="tab-html" crm-title="ts('HTML')">
-        <div crm-mailing-body-html crm-mailing="mailing"/>
+        <div crm-mailing-body-html crm-mailing="mailing"></div>
       </div>
       <div crm-ui-tab id="tab-text" crm-title="ts('Plain Text')">
-        <div crm-mailing-body-text crm-mailing="mailing"/>
+        <div crm-mailing-body-text crm-mailing="mailing"></div>
       </div>
       <span ng-model="placeholder" crm-ui-validate="mailing.body_html || mailing.body_text"></span>
       <div crm-ui-tab id="tab-attachment" crm-title="ts('Attachments')">
-        <div crm-attachments="attachments"/>
+        <div crm-attachments="attachments"></div>
       </div>
       <div crm-ui-tab id="tab-header" crm-title="ts('Header and Footer')">
-        <div crm-mailing-block-header-footer crm-mailing="mailing"/>
+        <div crm-mailing-block-header-footer crm-mailing="mailing"></div>
       </div>
       <div crm-ui-tab id="tab-pub" crm-title="ts('Publication')">
-        <div crm-mailing-block-publication crm-mailing="mailing"/>
+        <div crm-mailing-block-publication crm-mailing="mailing"></div>
       </div>
       <div crm-ui-tab id="tab-response" crm-title="ts('Responses')">
-        <div crm-mailing-block-responses crm-mailing="mailing"/>
+        <div crm-mailing-block-responses crm-mailing="mailing"></div>
       </div>
       <div crm-ui-tab id="tab-tracking" crm-title="ts('Tracking')">
-        <div crm-mailing-block-tracking crm-mailing="mailing"/>
+        <div crm-mailing-block-tracking crm-mailing="mailing"></div>
       </div>
     </div>
 
-    <div crm-ui-accordion="{title: ts('Preview')}" >
-      <div crm-mailing-block-preview crm-mailing="mailing" on-preview="previewMailing(mailing, preview.mode)" on-send="sendTest(mailing, attachments, preview.recipient)" />
+    <div crm-ui-accordion="{title: ts('Preview')}">
+      <div crm-mailing-block-preview crm-mailing="mailing" on-preview="previewMailing(mailing, preview.mode)" on-send="sendTest(mailing, attachments, preview.recipient)"></div>
     </div>
 
-    <div crm-ui-accordion="{title: ts('Schedule')}" >
-      <div crm-mailing-block-schedule crm-mailing="mailing"/>
+    <div crm-ui-accordion="{title: ts('Schedule')}">
+      <div crm-mailing-block-schedule crm-mailing="mailing"></div>
     </div>
 
     <button crm-icon="fa-paper-plane" ng-disabled="block.check() || crmMailingSubform.$invalid" ng-click="submit()">{{ts('Submit Mailing')}}</button>

--- a/ang/crmMailing/EditMailingCtrl/unified2.html
+++ b/ang/crmMailing/EditMailingCtrl/unified2.html
@@ -1,36 +1,36 @@
 <div ng-form="crmMailingSubform">
   <div class="crm-block crm-form-block crmMailing">
 
-    <div crm-mailing-block-summary crm-mailing="mailing"/>
-    <div crm-mailing-block-mailing crm-mailing="mailing"/>
+    <div crm-mailing-block-summary crm-mailing="mailing"></div>
+    <div crm-mailing-block-mailing crm-mailing="mailing"></div>
 
-    <div crm-ui-accordion="{title: ts('HTML'), help: hs('html')}" >
-      <div crm-mailing-body-html crm-mailing="mailing"/>
+    <div crm-ui-accordion="{title: ts('HTML'), help: hs('html')}">
+      <div crm-mailing-body-html crm-mailing="mailing"></div>
     </div>
     <div crm-ui-accordion="{title: ts('Plain Text'), collapsed: !mailing.body_text, help: hs('text')}">
-      <div crm-mailing-body-text crm-mailing="mailing"/>
+      <div crm-mailing-body-text crm-mailing="mailing"></div>
     </div>
     <span ng-model="placeholder" crm-ui-validate="mailing.body_html || mailing.body_text"></span>
-    <div crm-ui-accordion="{title: ts('Header and Footer'), collapsed: true}" id="tab-header" >
-      <div crm-mailing-block-header-footer crm-mailing="mailing"/>
+    <div crm-ui-accordion="{title: ts('Header and Footer'), collapsed: true}" id="tab-header">
+      <div crm-mailing-block-header-footer crm-mailing="mailing"></div>
     </div>
-    <div crm-ui-accordion="{title: ts('Attachments'), collapsed: true}" id="tab-attachment" >
-      <div crm-attachments="attachments"/>
+    <div crm-ui-accordion="{title: ts('Attachments'), collapsed: true}" id="tab-attachment">
+      <div crm-attachments="attachments"></div>
     </div>
-    <div crm-ui-accordion="{title: ts('Publication'), collapsed: true}" id="tab-pub" >
-      <div crm-mailing-block-publication crm-mailing="mailing"/>
+    <div crm-ui-accordion="{title: ts('Publication'), collapsed: true}" id="tab-pub">
+      <div crm-mailing-block-publication crm-mailing="mailing"></div>
     </div>
-    <div crm-ui-accordion="{title: ts('Responses'), collapsed: true}" id="tab-response" >
-      <div crm-mailing-block-responses crm-mailing="mailing"/>
+    <div crm-ui-accordion="{title: ts('Responses'), collapsed: true}" id="tab-response">
+      <div crm-mailing-block-responses crm-mailing="mailing"></div>
     </div>
-    <div crm-ui-accordion="{title: ts('Tracking'), collapsed: true}" id="tab-tracking" >
-      <div crm-mailing-block-tracking crm-mailing="mailing"/>
+    <div crm-ui-accordion="{title: ts('Tracking'), collapsed: true}" id="tab-tracking">
+      <div crm-mailing-block-tracking crm-mailing="mailing"></div>
     </div>
-    <div crm-ui-accordion="{title: ts('Preview')}" >
-      <div crm-mailing-block-preview crm-mailing="mailing" on-preview="previewMailing(mailing, preview.mode)" on-send="sendTest(mailing, attachments, preview.recipient)" />
+    <div crm-ui-accordion="{title: ts('Preview')}">
+      <div crm-mailing-block-preview crm-mailing="mailing" on-preview="previewMailing(mailing, preview.mode)" on-send="sendTest(mailing, attachments, preview.recipient)"></div>
     </div>
-    <div crm-ui-accordion="{title: ts('Schedule')}" id="tab-schedule" >
-      <div crm-mailing-block-schedule crm-mailing="mailing"/>
+    <div crm-ui-accordion="{title: ts('Schedule')}" id="tab-schedule">
+      <div crm-mailing-block-schedule crm-mailing="mailing"></div>
     </div>
 
     <button crm-icon="fa-paper-plane" ng-disabled="block.check() || crmMailingSubform.$invalid" ng-click="submit()">{{ts('Submit Mailing')}}</button>

--- a/ang/crmMailing/EditMailingCtrl/wizard.html
+++ b/ang/crmMailing/EditMailingCtrl/wizard.html
@@ -4,45 +4,45 @@
     <div crm-ui-wizard>
 
       <div crm-ui-wizard-step crm-title="ts('Content')" ng-form="contentForm">
-        <div crm-mailing-block-summary crm-mailing="mailing"/>
-        <div crm-mailing-block-mailing crm-mailing="mailing"/>
-        <div crm-ui-accordion="{title: ts('HTML'), help: hs('html')}" >
-          <div crm-mailing-body-html crm-mailing="mailing"/>
+        <div crm-mailing-block-summary crm-mailing="mailing"></div>
+        <div crm-mailing-block-mailing crm-mailing="mailing"></div>
+        <div crm-ui-accordion="{title: ts('HTML'), help: hs('html')}">
+          <div crm-mailing-body-html crm-mailing="mailing"></div>
         </div>
         <div crm-ui-accordion="{title: ts('Plain Text'), collapsed: !mailing.body_text, help: hs('text')}">
-          <div crm-mailing-body-text crm-mailing="mailing"/>
+          <div crm-mailing-body-text crm-mailing="mailing"></div>
         </div>
         <span ng-model="placeholder" crm-ui-validate="mailing.body_html || mailing.body_text"></span>
         <div crm-ui-accordion="{title: ts('Header and Footer'), collapsed: true}">
-          <div crm-mailing-block-header-footer crm-mailing="mailing"/>
+          <div crm-mailing-block-header-footer crm-mailing="mailing"></div>
         </div>
         <div crm-ui-accordion="{title: ts('Attachments'), collapsed: true}">
-          <div crm-attachments="attachments"/>
+          <div crm-attachments="attachments"></div>
         </div>
-        <div crm-ui-accordion="{title: ts('Preview')}" >
-          <div crm-mailing-block-preview crm-mailing="mailing" on-preview="previewMailing(mailing, preview.mode)" on-send="sendTest(mailing, attachments, preview.recipient)" />
+        <div crm-ui-accordion="{title: ts('Preview')}">
+          <div crm-mailing-block-preview crm-mailing="mailing" on-preview="previewMailing(mailing, preview.mode)" on-send="sendTest(mailing, attachments, preview.recipient)"></div>
         </div>
       </div>
 
       <div crm-ui-wizard-step crm-title="ts('Options')" ng-form="optionsForm">
-        <div crm-ui-accordion="{title: ts('Schedule')}" >
-          <div crm-mailing-block-schedule crm-mailing="mailing"/>
+        <div crm-ui-accordion="{title: ts('Schedule')}">
+          <div crm-mailing-block-schedule crm-mailing="mailing"></div>
         </div>
 
         <div crm-ui-accordion="{title: ts('Responses'), collapsed: true}">
-          <div crm-mailing-block-responses crm-mailing="mailing"/>
+          <div crm-mailing-block-responses crm-mailing="mailing"></div>
         </div>
         <div crm-ui-accordion="{title: ts('Tracking'), collapsed: true}">
-          <div crm-mailing-block-tracking crm-mailing="mailing"/>
+          <div crm-mailing-block-tracking crm-mailing="mailing"></div>
         </div>
         <div crm-ui-accordion="{title: ts('Publication'), collapsed: true}">
-          <div crm-mailing-block-publication crm-mailing="mailing"/>
+          <div crm-mailing-block-publication crm-mailing="mailing"></div>
         </div>
       </div>
 
       <div crm-ui-wizard-step crm-title="ts('Review')" ng-form="reviewForm">
-        <div crm-ui-accordion="{title: ts('Review')}" >
-          <div crm-mailing-block-review crm-mailing="mailing" crm-mailing-attachments="attachments"/>
+        <div crm-ui-accordion="{title: ts('Review')}">
+          <div crm-mailing-block-review crm-mailing="mailing" crm-mailing-attachments="attachments"></div>
         </div>
         <center>
           <a class="button crmMailing-submit-button" ng-click="submit()" ng-class="{blocking: block.check(), disabled: crmMailingSubform.$invalid}">

--- a/ang/crmMailing/EditMailingCtrl/workflow.html
+++ b/ang/crmMailing/EditMailingCtrl/workflow.html
@@ -4,47 +4,47 @@
     <div crm-ui-wizard>
 
       <div crm-ui-wizard-step="10" crm-title="ts('Content')" ng-form="contentForm" ng-if="checkPerm('create mailings') || checkPerm('access CiviMail')">
-        <div crm-mailing-block-summary crm-mailing="mailing"/>
-        <div crm-mailing-block-mailing crm-mailing="mailing"/>
-        <div crm-ui-accordion="{title: ts('HTML'), help: hs('html')}" >
-          <div crm-mailing-body-html crm-mailing="mailing"/>
+        <div crm-mailing-block-summary crm-mailing="mailing"></div>
+        <div crm-mailing-block-mailing crm-mailing="mailing"></div>
+        <div crm-ui-accordion="{title: ts('HTML'), help: hs('html')}">
+          <div crm-mailing-body-html crm-mailing="mailing"></div>
         </div>
         <div crm-ui-accordion="{title: ts('Plain Text'), collapsed: !mailing.body_text, help: hs('text')}">
-          <div crm-mailing-body-text crm-mailing="mailing"/>
+          <div crm-mailing-body-text crm-mailing="mailing"></div>
         </div>
         <span ng-model="placeholder" crm-ui-validate="mailing.body_html || mailing.body_text"></span>
         <div crm-ui-accordion="{title: ts('Header and Footer'), collapsed: true}">
-          <div crm-mailing-block-header-footer crm-mailing="mailing"/>
+          <div crm-mailing-block-header-footer crm-mailing="mailing"></div>
         </div>
         <div crm-ui-accordion="{title: ts('Attachments'), collapsed: true}">
-          <div crm-attachments="attachments"/>
+          <div crm-attachments="attachments"></div>
         </div>
-        <div crm-ui-accordion="{title: ts('Preview')}" >
-          <div crm-mailing-block-preview crm-mailing="mailing" on-preview="previewMailing(mailing, preview.mode)" on-send="sendTest(mailing, attachments, preview.recipient)" />
+        <div crm-ui-accordion="{title: ts('Preview')}">
+          <div crm-mailing-block-preview crm-mailing="mailing" on-preview="previewMailing(mailing, preview.mode)" on-send="sendTest(mailing, attachments, preview.recipient)"></div>
         </div>
       </div>
 
       <div crm-ui-wizard-step="20" crm-title="ts('Options')" ng-form="optionsForm" ng-if="checkPerm('create mailings') || checkPerm('access CiviMail')">
         <div crm-ui-accordion="{title: ts('Responses'), collapsed: true}">
-          <div crm-mailing-block-responses crm-mailing="mailing"/>
+          <div crm-mailing-block-responses crm-mailing="mailing"></div>
         </div>
         <div crm-ui-accordion="{title: ts('Tracking'), collapsed: true}">
-          <div crm-mailing-block-tracking crm-mailing="mailing"/>
+          <div crm-mailing-block-tracking crm-mailing="mailing"></div>
         </div>
         <div crm-ui-accordion="{title: ts('Publication'), collapsed: true}">
-          <div crm-mailing-block-publication crm-mailing="mailing"/>
+          <div crm-mailing-block-publication crm-mailing="mailing"></div>
         </div>
       </div>
 
       <div crm-ui-wizard-step="40" crm-title="ts('Review')" ng-form="schedForm" ng-if="checkPerm('schedule mailings') || checkPerm('access CiviMail')">
-        <div crm-ui-accordion="{title: ts('Review')}" >
-          <div crm-mailing-block-review crm-mailing="mailing" crm-mailing-attachments="attachments"/>
+        <div crm-ui-accordion="{title: ts('Review')}">
+          <div crm-mailing-block-review crm-mailing="mailing" crm-mailing-attachments="attachments"></div>
         </div>
-        <div crm-ui-accordion="{title: ts('Schedule')}" >
-          <div crm-mailing-block-schedule crm-mailing="mailing"/>
+        <div crm-ui-accordion="{title: ts('Schedule')}">
+          <div crm-mailing-block-schedule crm-mailing="mailing"></div>
         </div>
-        <div crm-ui-accordion="{title: ts('Approval')}"  ng-if="checkPerm('approve mailings') || checkPerm('access CiviMail')">
-          <div crm-mailing-block-approve crm-mailing="mailing"/>
+        <div crm-ui-accordion="{title: ts('Approval')}" ng-if="checkPerm('approve mailings') || checkPerm('access CiviMail')">
+          <div crm-mailing-block-approve crm-mailing="mailing"></div>
         </div>
         <center ng-if="!checkPerm('approve mailings') && !checkPerm('access CiviMail')">
           <a class="button crmMailing-submit-button" ng-click="submit()" ng-class="{blocking: block.check(), disabled: crmMailingSubform.$invalid}">

--- a/ang/crmMailing/EditRecipOptionsDialogCtrl.html
+++ b/ang/crmMailing/EditRecipOptionsDialogCtrl.html
@@ -4,11 +4,11 @@
 
       <div crm-ui-field="{title: ts('Dedupe by email'), help: hs('dedupe_email')}" crm-layout="checkbox">
         <input
-          type='checkbox'
-          ng-model='model.mailing.dedupe_email'
+          type="checkbox"
+          ng-model="model.mailing.dedupe_email"
           ng-true-value="'1'"
           ng-false-value="'0'"
-          />
+          >
       </div>
 
       <div crm-ui-field="{name: 'editRecipOptionsForm.location_type_id', title: ts('Location Type')}">

--- a/ang/crmMailing/EmailBodyCtrl/tokenAlert.html
+++ b/ang/crmMailing/EmailBodyCtrl/tokenAlert.html
@@ -6,7 +6,7 @@
 <div ng-show="missing['domain.address'] && insertable">
   <a ng-click="insertToken('domain.address')" class="button"><span><i class="crm-i fa-plus-circle"></i> {{ts('Address')}}</span></a>
 
-  <div class="clear"/>
+  <div class="clear"></div>
 </div>
 
 <p ng-show="missing['action.optOut']">

--- a/ang/crmMailingAB/EditCtrl/edit.html
+++ b/ang/crmMailingAB/EditCtrl/edit.html
@@ -174,4 +174,5 @@
         <button crm-icon="fa-floppy-o" ng-disabled="block.check()" ng-click="save().then(leave) ">{{ts('Save Draft')}}</button>
       </span>
     </div>
+  </div>
 </div>

--- a/ang/crmMailingAB/EditCtrl/edit.html
+++ b/ang/crmMailingAB/EditCtrl/edit.html
@@ -49,35 +49,35 @@
                 subjectB: 1
                 }"
               crm-abtest="abtest"></div>
-            <div crm-ui-accordion="{title: ts('HTML')}" >
-              <div crm-mailing-body-html crm-mailing="abtest.mailings.a"/>
+            <div crm-ui-accordion="{title: ts('HTML')}">
+              <div crm-mailing-body-html crm-mailing="abtest.mailings.a"></div>
             </div>
             <div crm-ui-accordion="{title: ts('Plain Text'), collapsed: !abtest.mailings.a.body_text}">
-              <div crm-mailing-body-text crm-mailing="abtest.mailings.a"/>
+              <div crm-mailing-body-text crm-mailing="abtest.mailings.a"></div>
             </div>
           </div>
           <!--
           FIXME: Attachment UI works, but we haven't implemented backend logic for copying/sharing
           of attachments among mailings A/B/C.
           <div crm-ui-tab id="tab-attachment" crm-title="ts('Attachments')">
-            <div crm-attachments="abtest.attachments.a"/>
+            <div crm-attachments="abtest.attachments.a"></div>
           </div>
           -->
           <div crm-ui-tab id="tab-header" crm-title="ts('Header and Footer')">
-            <div crm-mailing-block-header-footer crm-mailing="abtest.mailings.a"/>
+            <div crm-mailing-block-header-footer crm-mailing="abtest.mailings.a"></div>
           </div>
           <div crm-ui-tab id="tab-pub" crm-title="ts('Publication')">
-            <div crm-mailing-block-publication crm-mailing="abtest.mailings.a"/>
+            <div crm-mailing-block-publication crm-mailing="abtest.mailings.a"></div>
           </div>
           <div crm-ui-tab id="tab-response" crm-title="ts('Responses')">
-            <div crm-mailing-block-responses crm-mailing="abtest.mailings.a"/>
+            <div crm-mailing-block-responses crm-mailing="abtest.mailings.a"></div>
           </div>
         </div>
-        <div crm-ui-accordion="{title: ts('Preview (A)')}" >
-          <div crm-mailing-block-preview crm-mailing="abtest.mailings.a" on-preview="previewMailing('a', preview.mode)" on-send="sendTest('a', preview.recipient)" />
+        <div crm-ui-accordion="{title: ts('Preview (A)')}">
+          <div crm-mailing-block-preview crm-mailing="abtest.mailings.a" on-preview="previewMailing('a', preview.mode)" on-send="sendTest('a', preview.recipient)"></div>
         </div>
-        <div crm-ui-accordion="{title: ts('Preview (B)')}" >
-          <div crm-mailing-block-preview crm-mailing="abtest.mailings.b" on-preview="previewMailing('b', preview.mode)" on-send="sendTest('b', preview.recipient)" />
+        <div crm-ui-accordion="{title: ts('Preview (B)')}">
+          <div crm-mailing-block-preview crm-mailing="abtest.mailings.b" on-preview="previewMailing('b', preview.mode)" on-send="sendTest('b', preview.recipient)"></div>
         </div>
       </div>
       <div crm-ui-wizard-step="21" crm-title="ts('Compose (A)')" ng-if="abtest.ab.testing_criteria == 'full_email'" ng-form="composeAForm">
@@ -91,28 +91,28 @@
                 subjectA: 1
                 }"
               crm-abtest="abtest"></div>
-            <div crm-ui-accordion="{title: ts('HTML')}" >
-              <div crm-mailing-body-html crm-mailing="abtest.mailings.a"/>
+            <div crm-ui-accordion="{title: ts('HTML')}">
+              <div crm-mailing-body-html crm-mailing="abtest.mailings.a"></div>
             </div>
             <div crm-ui-accordion="{title: ts('Plain Text'), collapsed: !abtest.mailings.a.body_text}">
-              <div crm-mailing-body-text crm-mailing="abtest.mailings.a"/>
+              <div crm-mailing-body-text crm-mailing="abtest.mailings.a"></div>
             </div>
           </div>
           <div crm-ui-tab id="tab-attachmentA" crm-title="ts('Attachments')">
-            <div crm-attachments="abtest.attachments.a"/>
+            <div crm-attachments="abtest.attachments.a"></div>
           </div>
           <div crm-ui-tab id="tab-headerA" crm-title="ts('Header and Footer')">
-            <div crm-mailing-block-header-footer crm-mailing="abtest.mailings.a"/>
+            <div crm-mailing-block-header-footer crm-mailing="abtest.mailings.a"></div>
           </div>
           <div crm-ui-tab id="tab-pubA" crm-title="ts('Publication')">
-            <div crm-mailing-block-publication crm-mailing="abtest.mailings.a"/>
+            <div crm-mailing-block-publication crm-mailing="abtest.mailings.a"></div>
           </div>
           <div crm-ui-tab id="tab-responseA" crm-title="ts('Responses')">
-            <div crm-mailing-block-responses crm-mailing="abtest.mailings.a"/>
+            <div crm-mailing-block-responses crm-mailing="abtest.mailings.a"></div>
           </div>
         </div>
-        <div crm-ui-accordion="{title: ts('Preview')}" >
-          <div crm-mailing-block-preview crm-mailing="abtest.mailings.a" on-preview="previewMailing('a', preview.mode)" on-send="sendTest('a', preview.recipient)" />
+        <div crm-ui-accordion="{title: ts('Preview')}">
+          <div crm-mailing-block-preview crm-mailing="abtest.mailings.a" on-preview="previewMailing('a', preview.mode)" on-send="sendTest('a', preview.recipient)"></div>
         </div>
       </div>
       <div crm-ui-wizard-step="22" crm-title="ts('Compose (B)')" ng-if="abtest.ab.testing_criteria == 'full_email'" ng-form="composeBForm">
@@ -126,28 +126,28 @@
                 subjectB: 1
                 }"
               crm-abtest="abtest"></div>
-            <div crm-ui-accordion="{title: ts('HTML')}" >
-              <div crm-mailing-body-html crm-mailing="abtest.mailings.b"/>
+            <div crm-ui-accordion="{title: ts('HTML')}">
+              <div crm-mailing-body-html crm-mailing="abtest.mailings.b"></div>
             </div>
             <div crm-ui-accordion="{title: ts('Plain Text'), collapsed: !abtest.mailings.b.body_text}">
-              <div crm-mailing-body-text crm-mailing="abtest.mailings.b"/>
+              <div crm-mailing-body-text crm-mailing="abtest.mailings.b"></div>
             </div>
           </div>
           <div crm-ui-tab id="tab-attachmentB" crm-title="ts('Attachments')">
-            <div crm-attachments="abtest.attachments.b"/>
+            <div crm-attachments="abtest.attachments.b"></div>
           </div>
           <div crm-ui-tab id="tab-headerB" crm-title="ts('Header and Footer')">
-            <div crm-mailing-block-header-footer crm-mailing="abtest.mailings.b"/>
+            <div crm-mailing-block-header-footer crm-mailing="abtest.mailings.b"></div>
           </div>
           <div crm-ui-tab id="tab-pubB" crm-title="ts('Publication')">
-            <div crm-mailing-block-publication crm-mailing="abtest.mailings.b"/>
+            <div crm-mailing-block-publication crm-mailing="abtest.mailings.b"></div>
           </div>
           <div crm-ui-tab id="tab-responseB" crm-title="ts('Responses')">
-            <div crm-mailing-block-responses crm-mailing="abtest.mailings.b"/>
+            <div crm-mailing-block-responses crm-mailing="abtest.mailings.b"></div>
           </div>
         </div>
-        <div crm-ui-accordion="{title: ts('Preview')}" >
-          <div crm-mailing-block-preview crm-mailing="abtest.mailings.b" on-preview="previewMailing('b', preview.mode)" on-send="sendTest('b', preview.recipient)" />
+        <div crm-ui-accordion="{title: ts('Preview')}">
+          <div crm-mailing-block-preview crm-mailing="abtest.mailings.b" on-preview="previewMailing('b', preview.mode)" on-send="sendTest('b', preview.recipient)"></div>
         </div>
       </div>
       <div crm-ui-wizard-step="30" crm-title="ts('Schedule')" ng-form="schedForm">

--- a/ang/crmUi/tabset.html
+++ b/ang/crmUi/tabset.html
@@ -8,5 +8,5 @@
       </a>
     </li>
   </ul>
-  <div ng-transclude/>
+  <div ng-transclude></div>
 </div>

--- a/ang/crmUi/wizard.html
+++ b/ang/crmUi/wizard.html
@@ -7,7 +7,7 @@
       <!-- Don't know a good way to localize text like "1. Title" -->
     </li>
   </ul>
-  <div class="crm-wizard-body" ng-transclude/>
+  <div class="crm-wizard-body" ng-transclude></div>
   <div class="crm-wizard-buttons">
     <button crm-icon="fa-chevron-left" ng-click="crmUiWizardCtrl.previous()" ng-show="!crmUiWizardCtrl.$first()">{{ts('Previous')}}</button>
     <button crm-icon="fa-chevron-right" title="{{!crmUiWizardCtrl.$validStep() ? ts('Complete all required fields first') : ts('Next step')}}" ng-click="crmUiWizardCtrl.next()" ng-show="!crmUiWizardCtrl.$last()" ng-disabled="!crmUiWizardCtrl.$validStep()">{{ts('Next')}}</button>


### PR DESCRIPTION
## Overview

Organic HTML documents have small discrepancies in notation (e.g. `<div/>` vs `<div></div>`; `<img foo-bar>` vs `<img foo-bar="">`). If you parse one of these documents and then re-encode it, the content may change in several ways. Those trivial differences make it hard to perform sanity checks. 

This PR puts the Angular HTML into a format that will appear consistent across decode/encode cycles.

Note: This PR originated as part of #10085, but it should be safe on its own. This PR is just cleanup on this existing HTML. Breaking it out reduces the mental-load of reviewing #10085. 

## Acceptance Criteria

 * The HTML should pass through PHP `DOMDocument` system (decoding and then re-encoding) with minimal changes.
 * The existing Angular UI's ("New Mailing", "Manage Case Types", "Manage Connections") should still work as before.

---

 * [CRM-20600: Expose AngularJS screens to hooks](https://issues.civicrm.org/jira/browse/CRM-20600)