### PR TITLE
CRM-20561 Use composer for Net_SMTP and Net_Socket and patch for TLS and CiviCRM Custom Error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,16 +16,22 @@
     "symfony/finder": "2.3.*",
     "tecnickcom/tcpdf" : "6.2.*",
     "totten/ca-config": "~13.02",
-    "civicrm/civicrm-cxn-rpc": "~0.15.12.04"
+    "civicrm/civicrm-cxn-rpc": "~0.15.12.04",
+    "pear/Net_SMTP": "1.6.*",
+    "pear/Net_socket": "1.0.*"
   },
   "scripts": {
     "post-install-cmd": [
       "bash tools/scripts/composer/dompdf-cleanup.sh",
-      "bash tools/scripts/composer/tcpdf-cleanup.sh"
+      "bash tools/scripts/composer/tcpdf-cleanup.sh",
+      "bash tools/scripts/composer/pear-exception-fix.sh",
+      "bash tools/scripts/composer/net-smtp-fix.sh"
     ],
     "post-update-cmd": [
       "bash tools/scripts/composer/dompdf-cleanup.sh",
-      "bash tools/scripts/composer/tcpdf-cleanup.sh"
+      "bash tools/scripts/composer/tcpdf-cleanup.sh",
+      "bash tools/scripts/composer/pear-exception-fix.sh",
+      "bash tools/scripts/composer/net-smtp-fix.sh"
     ]
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "fd3f59bfad9a391951d4e773230a4752",
-    "content-hash": "5ac26ca66347ff4485584db892ed4341",
+    "hash": "920f618f68514022e41c85825538ee53",
+    "content-hash": "f9426450ebd69166494ad68f61d53729",
     "packages": [
         {
             "name": "civicrm/civicrm-cxn-rpc",
@@ -107,6 +107,174 @@
             "description": "DOMPDF is a CSS 2.1 compliant HTML to PDF converter",
             "homepage": "https://github.com/dompdf/dompdf",
             "time": "2016-05-11 00:36:29"
+        },
+        {
+            "name": "pear/net_smtp",
+            "version": "1.6.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pear/Net_SMTP.git",
+                "reference": "7b6240761adf6ee245098e238a25d5c35650d82c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pear/Net_SMTP/zipball/7b6240761adf6ee245098e238a25d5c35650d82c",
+                "reference": "7b6240761adf6ee245098e238a25d5c35650d82c",
+                "shasum": ""
+            },
+            "require": {
+                "pear/net_socket": "*",
+                "pear/pear_exception": "*",
+                "php": ">=4.0.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "*"
+            },
+            "suggest": {
+                "pear/auth_sasl": "Install optionally via your project's composer.json"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Net": "./"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "./"
+            ],
+            "license": [
+                "PHP License"
+            ],
+            "authors": [
+                {
+                    "name": "Jon Parise",
+                    "email": "jon@php.net",
+                    "homepage": "http://www.indelible.org",
+                    "role": "Lead"
+                },
+                {
+                    "name": "Chuck Hagenbuch",
+                    "email": "chuck@horde.org",
+                    "role": "Lead"
+                }
+            ],
+            "description": "An implementation of the SMTP protocol",
+            "homepage": "http://pear.github.io/Net_SMTP/",
+            "keywords": [
+                "email",
+                "mail",
+                "smtp"
+            ],
+            "time": "2015-08-02 17:20:17"
+        },
+        {
+            "name": "pear/net_socket",
+            "version": "1.0.14",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pear/Net_Socket.git",
+                "reference": "fcd33efd77e4b35ce85489141ab9145343579fe8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pear/Net_Socket/zipball/fcd33efd77e4b35ce85489141ab9145343579fe8",
+                "reference": "fcd33efd77e4b35ce85489141ab9145343579fe8",
+                "shasum": ""
+            },
+            "require": {
+                "pear/pear_exception": "*"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Net": "./"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "./"
+            ],
+            "license": [
+                "PHP License"
+            ],
+            "authors": [
+                {
+                    "name": "Chuck Hagenbuch",
+                    "email": "chuck@horde.org",
+                    "role": "Lead"
+                },
+                {
+                    "name": "Aleksander Machniak",
+                    "email": "alec@php.net",
+                    "role": "Lead"
+                },
+                {
+                    "name": "Stig Bakken",
+                    "email": "stig@php.net",
+                    "role": "Lead"
+                }
+            ],
+            "description": "More info available on: http://pear.php.net/package/Net_Socket",
+            "time": "2014-02-20 19:27:06"
+        },
+        {
+            "name": "pear/pear_exception",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pear/PEAR_Exception.git",
+                "reference": "8c18719fdae000b690e3912be401c76e406dd13b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pear/PEAR_Exception/zipball/8c18719fdae000b690e3912be401c76e406dd13b",
+                "reference": "8c18719fdae000b690e3912be401c76e406dd13b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=4.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "*"
+            },
+            "type": "class",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "PEAR": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "."
+            ],
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Helgi Thormar",
+                    "email": "dufuz@php.net"
+                },
+                {
+                    "name": "Greg Beaver",
+                    "email": "cellog@php.net"
+                }
+            ],
+            "description": "The PEAR Exception base class.",
+            "homepage": "https://github.com/pear/PEAR_Exception",
+            "keywords": [
+                "exception"
+            ],
+            "time": "2015-02-10 20:07:52"
         },
         {
             "name": "phenx/php-font-lib",

--- a/tools/scripts/composer/net-smtp-fix.sh
+++ b/tools/scripts/composer/net-smtp-fix.sh
@@ -18,3 +18,6 @@ fi
 if ! grep -q '@STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT' vendor/pear/net_smtp/Net/SMTP.php; then
 patch vendor/pear/net_smtp/Net/SMTP.php < tools/scripts/composer/patches/net-smtp-tls-patch.txt
 fi
+if ! grep -q 'function __construct' vendor/pear/net_smtp/Net/SMTP.php; then
+patch vendor/pear/net_smtp/Net/SMTP.php < tools/scripts/composer/patches/net-smtp-php7-patch.txt
+fi

--- a/tools/scripts/composer/net-smtp-fix.sh
+++ b/tools/scripts/composer/net-smtp-fix.sh
@@ -21,3 +21,6 @@ fi
 if ! grep -q 'function __construct' vendor/pear/net_smtp/Net/SMTP.php; then
 patch vendor/pear/net_smtp/Net/SMTP.php < tools/scripts/composer/patches/net-smtp-php7-patch.txt
 fi
+if grep -q '&Auth_SASL::factory' vendor/pear/net_smtp/Net/SMTP.php; then
+patch vendor/pear/net_smtp/Net/SMTP.php < tools/scripts/composer/patches/net-smtp-ref-patch.txt
+fi

--- a/tools/scripts/composer/net-smtp-fix.sh
+++ b/tools/scripts/composer/net-smtp-fix.sh
@@ -11,6 +11,20 @@
 ## Replace a line in a file
 ## This is a bit like 'sed -i', but dumber and more cross-platform.
 
+##############################################################################
+## usage: safe_delete <relpath...>
+function safe_delete() {
+  for file in "$@" ; do
+    if [ -z "$file" ]; then
+      echo "Skip: empty file name"
+    elif [ -e "$file" ]; then
+      rm -rf "$file"
+    fi
+  done
+}
+
+
+##############################################################################
 # Add in CiviCRM custom error message for CRM-8744.
 if ! grep -q 'CRM-8744' vendor/pear/net_smtp/Net/SMTP.php; then
 patch vendor/pear/net_smtp/Net/SMTP.php < tools/scripts/composer/patches/net-smtp-patch.txt
@@ -24,3 +38,5 @@ fi
 if grep -q '&Auth_SASL::factory' vendor/pear/net_smtp/Net/SMTP.php; then
 patch vendor/pear/net_smtp/Net/SMTP.php < tools/scripts/composer/patches/net-smtp-ref-patch.txt
 fi
+
+safe_delete vendor/pear/net_smtp/{examples,phpdoc.sh,tests}

--- a/tools/scripts/composer/net-smtp-fix.sh
+++ b/tools/scripts/composer/net-smtp-fix.sh
@@ -27,16 +27,16 @@ function safe_delete() {
 ##############################################################################
 # Add in CiviCRM custom error message for CRM-8744.
 if ! grep -q 'CRM-8744' vendor/pear/net_smtp/Net/SMTP.php; then
-patch vendor/pear/net_smtp/Net/SMTP.php < tools/scripts/composer/patches/net-smtp-patch.txt
+  patch vendor/pear/net_smtp/Net/SMTP.php < tools/scripts/composer/patches/net-smtp-patch.txt
 fi
 if ! grep -q '@STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT' vendor/pear/net_smtp/Net/SMTP.php; then
-patch vendor/pear/net_smtp/Net/SMTP.php < tools/scripts/composer/patches/net-smtp-tls-patch.txt
+  patch vendor/pear/net_smtp/Net/SMTP.php < tools/scripts/composer/patches/net-smtp-tls-patch.txt
 fi
 if ! grep -q 'function __construct' vendor/pear/net_smtp/Net/SMTP.php; then
-patch vendor/pear/net_smtp/Net/SMTP.php < tools/scripts/composer/patches/net-smtp-php7-patch.txt
+  patch vendor/pear/net_smtp/Net/SMTP.php < tools/scripts/composer/patches/net-smtp-php7-patch.txt
 fi
 if grep -q '&Auth_SASL::factory' vendor/pear/net_smtp/Net/SMTP.php; then
-patch vendor/pear/net_smtp/Net/SMTP.php < tools/scripts/composer/patches/net-smtp-ref-patch.txt
+  patch vendor/pear/net_smtp/Net/SMTP.php < tools/scripts/composer/patches/net-smtp-ref-patch.txt
 fi
 
 safe_delete vendor/pear/net_smtp/{examples,phpdoc.sh,tests}

--- a/tools/scripts/composer/net-smtp-fix.sh
+++ b/tools/scripts/composer/net-smtp-fix.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+## Cleanup the vendor tree. The main issue here is that civi Civi is
+## deployed as a module inside a CMS, so all its source-code gets published.
+## Some libraries distribute admin tools and sample files which should not
+## be published.
+##
+## This script should be idempotent -- if you rerun it several times, it
+## should always produce the same post-condition.
+
+## Replace a line in a file
+## This is a bit like 'sed -i', but dumber and more cross-platform.
+
+# Add in CiviCRM custom error message for CRM-8744.
+if ! grep -q 'CRM-8744' vendor/pear/net_smtp/Net/SMTP.php; then
+patch vendor/pear/net_smtp/Net/SMTP.php < tools/scripts/composer/patches/net-smtp-patch.txt
+fi
+if ! grep -q '@STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT' vendor/pear/net_smtp/Net/SMTP.php; then
+patch vendor/pear/net_smtp/Net/SMTP.php < tools/scripts/composer/patches/net-smtp-tls-patch.txt
+fi

--- a/tools/scripts/composer/patches/net-smtp-patch.txt
+++ b/tools/scripts/composer/patches/net-smtp-patch.txt
@@ -1,0 +1,15 @@
+--- SMTP.php	2017-01-15 05:19:55.000000000 +1100
++++ SMTP.php.new	2017-05-20 09:01:52.832373840 +1000
+@@ -368,8 +368,10 @@
+             return true;
+         }
+
+-        return PEAR::raiseError('Invalid response code received from server',
+-                                $this->_code, PEAR_ERROR_RETURN);
++        // CRM-8744
++        $errorMessage = 'Invalid response code received from SMTP server while sending email.  This is often caused by a misconfiguration in Outbound Email settings. Please verify the settings at Administer CiviCRM >> Global Settings >> Outbound Email (SMTP).';
++        return PEAR::raiseError($errorMessage, $this->_code, PEAR_ERROR_RETURN);
++
+     }
+
+     /**

--- a/tools/scripts/composer/patches/net-smtp-php7-patch.txt
+++ b/tools/scripts/composer/patches/net-smtp-php7-patch.txt
@@ -1,0 +1,11 @@
+--- SMTP.php    2017-05-20 11:50:53.716664059 +1000
++++ SMTP.php.new        2017-05-20 12:38:36.271530119 +1000
+@@ -167,7 +167,7 @@
+      * @access  public
+      * @since   1.0
+      */
+-    function Net_SMTP($host = null, $port = null, $localhost = null,
++    function __construct($host = null, $port = null, $localhost = null,
+         $pipelining = false, $timeout = 0, $socket_options = null)
+     {
+         if (isset($host)) {

--- a/tools/scripts/composer/patches/net-smtp-ref-patch.txt
+++ b/tools/scripts/composer/patches/net-smtp-ref-patch.txt
@@ -1,0 +1,22 @@
+--- SMTP.php	2017-06-15 20:08:34.696988543 -0700
++++ SMTP.php.new	2017-06-15 20:08:25.951703778 -0700
+@@ -732,7 +732,8 @@
+         }
+ 
+         $challenge = base64_decode($this->_arguments[0]);
+-        $digest = &Auth_SASL::factory('digest-md5');
++        // CRM-8597
++        $digest = Auth_SASL::factory('digest-md5');
+         $auth_str = base64_encode($digest->getResponse($uid, $pwd, $challenge,
+                                                        $this->host, "smtp",
+                                                        $authz));
+@@ -784,7 +785,8 @@
+         }
+ 
+         $challenge = base64_decode($this->_arguments[0]);
+-        $cram = &Auth_SASL::factory('cram-md5');
++        // CRM-8597
++        $cram = Auth_SASL::factory('cram-md5');
+         $auth_str = base64_encode($cram->getResponse($uid, $pwd, $challenge));
+ 
+         if (PEAR::isError($error = $this->_put($auth_str))) {

--- a/tools/scripts/composer/patches/net-smtp-tls-patch.txt
+++ b/tools/scripts/composer/patches/net-smtp-tls-patch.txt
@@ -1,0 +1,23 @@
+diff --git a/Net/SMTP.php b/Net/SMTP.php
+index 28eae8c..8f4e92b 100644
+--- a/Net/SMTP.php
++++ b/Net/SMTP.php
+@@ -602,7 +602,17 @@
+             if (PEAR::isError($result = $this->_parseResponse(220))) {
+                 return $result;
+             }
+-            if (PEAR::isError($result = $this->_socket->enableCrypto(true, STREAM_CRYPTO_METHOD_TLS_CLIENT))) {
++            if (isset($this->socket_options['ssl']['crypto_method'])) {
++                $crypto_method = $this->socket_options['ssl']['crypto_method'];
++            } else {
++                /* STREAM_CRYPTO_METHOD_TLS_ANY_CLIENT constant does not exist
++                 * and STREAM_CRYPTO_METHOD_SSLv23_CLIENT constant is
++                 * inconsistent across PHP versions. */
++                $crypto_method = STREAM_CRYPTO_METHOD_TLS_CLIENT
++                                 | @STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT
++                                 | @STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT;
++            }
++            if (PEAR::isError($result = $this->socket->enableCrypto(true, $crypto_method))) {
+                 return $result;
+             } elseif ($result !== true) {
+                 return PEAR::raiseError('STARTTLS failed');

--- a/tools/scripts/composer/pear-exception-fix.sh
+++ b/tools/scripts/composer/pear-exception-fix.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+## Cleanup the vendor tree. The main issue here is that civi Civi is
+## deployed as a module inside a CMS, so all its source-code gets published.
+## Some libraries distribute admin tools and sample files which should not
+## be published.
+##
+## This script should be idempotent -- if you rerun it several times, it
+## should always produce the same post-condition.
+
+## Replace a line in a file
+## This is a bit like 'sed -i', but dumber and more cross-platform.
+function simple_replace() {
+  php -r 'file_put_contents($argv[1], preg_replace($argv[2], $argv[3], file_get_contents($argv[1])));' "$@"
+}
+
+
+# add in class_exists test as per CRM-8921.
+if ! grep -q 'CRM-8921' vendor/pear/pear_exception/PEAR/Exception.php; then
+simple_replace vendor/pear/pear_exception/PEAR/Exception.php '^\<\?php^' '<?php if (class_exists("'"PEAR_Exception"'")) return; /* CRM-8921 */'
+fi


### PR DESCRIPTION
* [CRM-20561: Load Net_SMTP, Auth_SASL, Net_Socket via Composer](https://issues.civicrm.org/jira/browse/CRM-20561)