### PR TITLE
CRM-20611: fix financial records of cancelled line_items on event fee  change selection 

### DIFF
--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -2185,6 +2185,7 @@ WHERE (entity_table = 'civicrm_participant' AND entity_id = {$participantId} AND
         'from_financial_account_id' => NULL,
         'to_financial_account_id' => $toFinancialAccount,
         'total_amount' => $balanceAmt,
+        'net_amount' => $balanceAmt,
         'status_id' => $completedStatusId,
         'payment_instrument_id' => $updatedContribution->payment_instrument_id,
         'contribution_id' => $updatedContribution->id,


### PR DESCRIPTION
* [CRM-20611: Cancelling a line-item by changing fee selection of event, leads to incorrect financial records](https://issues.civicrm.org/jira/browse/CRM-20611)