### PR TITLE
RC - CRM-20591: Fix class_name on update of payment processor

### DIFF
--- a/CRM/Financial/BAO/PaymentProcessor.php
+++ b/CRM/Financial/BAO/PaymentProcessor.php
@@ -53,17 +53,19 @@ class CRM_Financial_BAO_PaymentProcessor extends CRM_Financial_DAO_PaymentProces
     $processor = new CRM_Financial_DAO_PaymentProcessor();
     $processor->copyValues($params);
 
-    $ppTypeDAO = new CRM_Financial_DAO_PaymentProcessorType();
-    $ppTypeDAO->id = $params['payment_processor_type_id'];
-    if (!$ppTypeDAO->find(TRUE)) {
-      CRM_Core_Error::fatal(ts('Could not find payment processor meta information'));
-    }
+    if (empty($params['id'])) {
+      $ppTypeDAO = new CRM_Financial_DAO_PaymentProcessorType();
+      $ppTypeDAO->id = $params['payment_processor_type_id'];
+      if (!$ppTypeDAO->find(TRUE)) {
+        CRM_Core_Error::fatal(ts('Could not find payment processor meta information'));
+      }
 
-    // also copy meta fields from the info DAO
-    $processor->is_recur = $ppTypeDAO->is_recur;
-    $processor->billing_mode = $ppTypeDAO->billing_mode;
-    $processor->class_name = $ppTypeDAO->class_name;
-    $processor->payment_type = $ppTypeDAO->payment_type;
+      // also copy meta fields from the info DAO
+      $processor->is_recur = $ppTypeDAO->is_recur;
+      $processor->billing_mode = $ppTypeDAO->billing_mode;
+      $processor->class_name = $ppTypeDAO->class_name;
+      $processor->payment_type = $ppTypeDAO->payment_type;
+    }
 
     $processor->save();
     // CRM-11826, add entry in civicrm_entity_financial_account

--- a/tests/phpunit/api/v3/PaymentProcessorTest.php
+++ b/tests/phpunit/api/v3/PaymentProcessorTest.php
@@ -79,6 +79,38 @@ class api_v3_PaymentProcessorTest extends CiviUnitTestCase {
   }
 
   /**
+   * Update payment processor.
+   */
+  public function testPaymentProcessorUpdate() {
+    $params = $this->_params;
+    $result = $this->callAPISuccess('payment_processor', 'create', $params);
+    $this->assertNotNull($result['id']);
+
+    $updateParams = array(
+      'id' => $result['id'],
+      'name' => 'Update API Test',
+    );
+    $this->assertDBState('CRM_Financial_DAO_PaymentProcessor', $result['id'], $params);
+    $this->callAPISuccess('payment_processor', 'create', $updateParams);
+    $result = $this->callAPISuccess('payment_processor', 'get', array('id' => $result['id']));
+
+    $expectedResult = array(
+      'id' => $result['id'],
+      'domain_id' => $params['domain_id'],
+      'name' => $updateParams['name'],
+      'payment_processor_type_id' => $params['payment_processor_type_id'],
+      'is_default' => 0,
+      'is_test' => 0,
+      'class_name' => $params['class_name'],
+      'billing_mode' => 1,
+      'is_recur' => $params['is_recur'],
+      'payment_type' => 1,
+      'payment_instrument_id' => 1,
+    );
+    $this->checkArrayEquals($expectedResult, $result['values'][$result['id']]);
+  }
+
+  /**
    * Test  using example code.
    */
   public function testPaymentProcessorCreateExample() {


### PR DESCRIPTION
* [CRM-20591: Disabling a payment processor via UI \(other than Payment_PayPalImpl\) will break live mode](https://issues.civicrm.org/jira/browse/CRM-20591)