### PR TITLE
method cannot be a protected static 

### DIFF
--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -88,7 +88,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
    *
    * @return int|null
    */
-  static function getRegistrationContactID($fields, $self, $isAdditional) {
+  public static function getRegistrationContactID($fields, $self, $isAdditional) {
 
     $contactID = NULL;
     if (!$isAdditional) {

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -88,7 +88,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
    *
    * @return int|null
    */
-  protected static function getRegistrationContactID($fields, $self, $isAdditional) {
+  static function getRegistrationContactID($fields, $self, $isAdditional) {
 
     $contactID = NULL;
     if (!$isAdditional) {


### PR DESCRIPTION
When called from CRM/Event/Form/Registration/AdditionalParticipant.php, the method getRegistrationContactID may not be protected, or the call fails.