### PR TITLE
CRM-19612 Fix temp table problems caused by union

### DIFF
--- a/CRM/Dedupe/BAO/Rule.php
+++ b/CRM/Dedupe/BAO/Rule.php
@@ -134,9 +134,11 @@ class CRM_Dedupe_BAO_Rule extends CRM_Dedupe_DAO_Rule {
     // if there are params provided, id1 should be 0
     if ($this->params) {
       $select = "t1.$id id1, {$this->rule_weight} weight";
+      $subSelect = 'id1, weight';
     }
     else {
       $select = "t1.$id id1, t2.$id id2, {$this->rule_weight} weight";
+      $subSelect = 'id1, id2, weight';
     }
 
     // build FROM (and WHERE, if it's a parametrised search)
@@ -184,6 +186,9 @@ class CRM_Dedupe_BAO_Rule extends CRM_Dedupe_DAO_Rule {
         $query .= " AND t1.$id IN (" . implode(',', $cids) . ")
         UNION $query AND  t2.$id IN (" . implode(',', $cids) . ")";
       }
+      // The `weight` is ambiguous in the context of the union; put the whole
+      // thing in a subquery.
+      $query = "SELECT $subSelect FROM ($query) subunion";
     }
 
     return $query;

--- a/CRM/Dedupe/BAO/RuleGroup.php
+++ b/CRM/Dedupe/BAO/RuleGroup.php
@@ -238,6 +238,18 @@ class CRM_Dedupe_BAO_RuleGroup extends CRM_Dedupe_DAO_RuleGroup {
 
             preg_match($patternColumn, $query, $matches);
             $query = str_replace(' WHERE ', str_replace('column', $matches[1], $dupeCopyJoin), $query);
+
+            // CRM-19612: If there's a union, there will be two WHEREs, and you
+            // can't use the temp table twice.
+            if (preg_match('/dedupe_copy[\S\s]*(union)[\S\s]*dedupe_copy/i', $query, $matches, PREG_OFFSET_CAPTURE)) {
+              // Make a second temp table:
+              $dao->query("DROP TEMPORARY TABLE IF EXISTS dedupe_copy_2");
+              $dao->query("CREATE TEMPORARY TABLE dedupe_copy_2 SELECT * FROM dedupe WHERE weight >= {$weightSum}");
+              $dao->free();
+              // After the union, use that new temp table:
+              $part1 = substr($query, 0, $matches[1][1]);
+              $query = $part1 . str_replace('dedupe_copy', 'dedupe_copy_2', substr($query, $matches[1][1]));
+            }
           }
           $searchWithinDupes = 1;
 


### PR DESCRIPTION
This addresses problems where finding duplicates would get a database error when:
- a rule has more than one field and
- it's used on a group rather than all contacts.

The issue is a temp table that the query uses.  The union that was introduced in #8694 repeats the bulk of the query on both sides of that union, including the temp table.  The result was a database error, `Can't reopen table: 'dedupe_copy'`.  This works around it by creating a second identical temp table in this case.

Once that was solved, a separate problem involved the ambiguity of the `weight` field because it's on both sides of the union.  This puts all that within a subquery to solve that.

Finally, I added a test case for CRM-19612.  It gets an error when run without these changes, and it succeeds when run alongside them.

---

 * [CRM-19612: DB error deduping a group when rule has more than one field ](https://issues.civicrm.org/jira/browse/CRM-19612)