### PR TITLE
CRM-20636: Notice fix while updating membership without payment

### DIFF
--- a/CRM/Member/Form.php
+++ b/CRM/Member/Form.php
@@ -371,7 +371,7 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
     $priceFields = CRM_Member_BAO_Membership::setQuickConfigMembershipParameters(
       $formValues['membership_type_id'][0],
       $formValues['membership_type_id'][1],
-      $formValues['total_amount'],
+      CRM_Utils_Array::value('total_amount', $formValues),
       $this->_priceSetId
     );
     $formValues = array_merge($formValues, $priceFields['price_fields']);


### PR DESCRIPTION
Log seems to be recording a notice on updating a membership record without payment.

<img width="1112" alt="image" src="https://cloud.githubusercontent.com/assets/5929648/26385527/f4d5b0da-405d-11e7-87f5-d2933272cc30.png">

---

 * [CRM-20636: Notice fix while updating membership without payment ](https://issues.civicrm.org/jira/browse/CRM-20636)