### PR TITLE
CRM-20630: Search criteria passing with url parameters

### DIFF
--- a/CRM/Activity/Form/Search.php
+++ b/CRM/Activity/Form/Search.php
@@ -98,6 +98,13 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
     }
     else {
       $this->_formValues = $this->get('formValues');
+
+      if ($this->_force) {
+        // If we force the search then merge form values with the defaults
+        // (which include URL parameters) and set submit values to form values.
+        $this->_formValues = array_merge((array)$this->_formValues, $this->_defaults);
+        $this->_submitValues = $this->_formValues;
+      }
     }
 
     if (empty($this->_formValues)) {

--- a/CRM/Core/Controller.php
+++ b/CRM/Core/Controller.php
@@ -450,7 +450,7 @@ class CRM_Core_Controller extends HTML_QuickForm_Controller {
       else {
         require_once str_replace('_', DIRECTORY_SEPARATOR, $className) . '.php';
       }
-      $$stateName = new $className($stateMachine->find($className), $action, 'post', $formName);
+      $$stateName = new $className($stateMachine->find($className), $action, 'post', $formName, CRM_Utils_Request::exportValues());
       if ($title) {
         $$stateName->setTitle($title);
       }

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -232,6 +232,8 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    *   The type of http method used (GET/POST).
    * @param string $name
    *   The name of the form if different from class name.
+   * @param array $defaults
+   *   Form default values.
    *
    * @return \CRM_Core_Form
    */
@@ -239,7 +241,8 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     $state = NULL,
     $action = CRM_Core_Action::NONE,
     $method = 'post',
-    $name = NULL
+    $name = NULL,
+    $defaults = array()
   ) {
 
     if ($name) {
@@ -249,6 +252,8 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       // CRM-15153 - FIXME this name translates to a DOM id and is not always unique!
       $this->_name = CRM_Utils_String::getClassName(CRM_Utils_System::getClassName($this));
     }
+
+    $this->_defaults = $defaults;
 
     parent::__construct($this->_name, $method);
 
@@ -552,6 +557,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     $this->buildQuickForm();
 
     $defaults = $this->setDefaultValues();
+
     unset($defaults['qfKey']);
 
     if (!empty($defaults)) {


### PR DESCRIPTION
This PR allows to make CRM_Core_Controller automatically pick and pass URL parameters into the $$stateName object (as an additional constructor attribute). It allows to use URL parameters as defaults when doing searching in CRM_Activity_Form_Search with 'force' = 1.

Using hooks like hook_civicrm_buildForm or hook_civicrm_preProcess isn't the solution as the hooks are executed after search results are prepared - 'force' = 1 attribute causes CRM_Activity_Form_Search::postProcess() method execute in the middle of preProcess() method.

---

 * [CRM-20630: Find Activities: search criteria passing with URL parameters](https://issues.civicrm.org/jira/browse/CRM-20630)