### PR TITLE
CRM-20638 add hook_civicrm_activityMailRecipients()

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -3076,4 +3076,36 @@ INNER JOIN  civicrm_option_group grp ON ( grp.id = val.option_group_id AND grp.n
     return FALSE;
   }
 
+  /**
+   * Build the mailToContacts array for use in CRM_Activity_BAO_Activity::sendToAssignee()
+   * @param  [array] $recipientIds       recipient cids
+   * @param  [array] $assigneeContacts   data about assignees
+   * @param  [int] $activityId           activity id
+   * @return [array]                     array keyed by email
+   */
+  public static function buildMailToContacts($recipientIds, $assigneeContacts, $activityId) {
+    $mailToContacts = array();
+    // Build an associative array with unique email addresses.
+    foreach ($recipientIds as $id) {
+      if (isset($id) && array_key_exists($id, $assigneeContacts)) {
+        $mailToContacts[$assigneeContacts[$id]['email']] = $assigneeContacts[$id];
+      }
+      else {
+        // Contacts may not be in $assigneeContacts have been added by hook
+        $res = civicrm_api3('Contact', 'get', array(
+          'sequential' => 1,
+          'return' => array('email', 'display_name', 'sort_name', 'contact_id'),
+          'id' => $id,
+        ));
+        if ($res['count'] == 1) {
+          if ($email = $res['values'][0]['email']) {
+            $mailToContacts[$email] = $res['values'][0];
+            $mailToContacts[$email]['activity_id'] = $activityId;
+          }
+        }
+      }
+    }
+    return $mailToContacts;
+  }
+
 }

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2381,4 +2381,21 @@ abstract class CRM_Utils_Hook {
     return self::singleton()->invoke(array('message'), $message, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_inboundSMS');
   }
 
+  /**
+   * This hook is called before emails are sent to activity assignees.
+   *
+   * @param array $recipients
+   * @param Activity object $activity
+   * @param array $params as passed to postProcess()
+   * @param string $context
+   *
+   * @return mixed
+   */
+  public static function activityMailRecipients(&$recipients, $activity, $params, $context) {
+    return self::singleton()->invoke(array('recipients', 'activity', 'params', 'context'),
+      $recipients, $activity, $params, $context, self::$_nullObject, self::$_nullObject,
+      'civicrm_activityMailRecipients'
+    );
+  }
+
 }


### PR DESCRIPTION
New hook hook_civicrm_activityMailRecipients() to allow changes to the
list of assignees receiving a mail.

Refactoring of CRM_Activity_Form_Activity::processActivity() to use new
hook.

---

 * [CRM-20638: Add a hook to modify activity assignee email recipients](https://issues.civicrm.org/jira/browse/CRM-20638)