### PR TITLE
CRM-20630: Activity Search criteria passing with url parameters

### DIFF
--- a/CRM/Activity/Form/Search.php
+++ b/CRM/Activity/Form/Search.php
@@ -98,6 +98,13 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
     }
     else {
       $this->_formValues = $this->get('formValues');
+
+      if ($this->_force) {
+        // If we force the search then merge form values with the defaults
+        // (which include URL parameters) and set submit values to form values.
+        $this->_formValues = array_merge((array) $this->_formValues, $this->_defaults);
+        $this->_submitValues = $this->_formValues;
+      }
     }
 
     if (empty($this->_formValues)) {

--- a/CRM/Core/Controller.php
+++ b/CRM/Core/Controller.php
@@ -450,7 +450,7 @@ class CRM_Core_Controller extends HTML_QuickForm_Controller {
       else {
         require_once str_replace('_', DIRECTORY_SEPARATOR, $className) . '.php';
       }
-      $$stateName = new $className($stateMachine->find($className), $action, 'post', $formName);
+      $$stateName = new $className($stateMachine->find($className), $action, 'post', $formName, CRM_Utils_Request::exportValues());
       if ($title) {
         $$stateName->setTitle($title);
       }

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -233,6 +233,8 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    *   The type of http method used (GET/POST).
    * @param string $name
    *   The name of the form if different from class name.
+   * @param array $defaults
+   *   Form default values.
    *
    * @return \CRM_Core_Form
    */
@@ -240,7 +242,8 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     $state = NULL,
     $action = CRM_Core_Action::NONE,
     $method = 'post',
-    $name = NULL
+    $name = NULL,
+    $defaults = array()
   ) {
 
     if ($name) {
@@ -250,6 +253,8 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       // CRM-15153 - FIXME this name translates to a DOM id and is not always unique!
       $this->_name = CRM_Utils_String::getClassName(CRM_Utils_System::getClassName($this));
     }
+
+    $this->_defaults = $defaults;
 
     parent::__construct($this->_name, $method);
 


### PR DESCRIPTION
This PR allows to make CRM_Core_Controller automatically pick and pass URL parameters into the $$stateName object (as an additional constructor attribute). It allows to use URL parameters as defaults when doing searching in CRM_Activity_Form_Search with 'force' = 1.

Using hooks like hook_civicrm_buildForm or hook_civicrm_preProcess isn't the solution as the hooks are executed after search results are prepared - 'force' = 1 attribute causes CRM_Activity_Form_Search::postProcess() method execute in the middle of preProcess() method.

This PR contains changes for Activity Search action (see CRM/Activity/Form/Search.php line 102) - the particular Search class needs to include the defaults passed by controller into its submitted values in preProcess() method.

Example URL with search criteria:
/civicrm/activity/search?force=1&cid=4&activity_type_id[]=13&activity_type_id[]=6&activity_type_id[]=8&status_id[]=4&activity_subject=TestSubject&custom_100013=abc

The criteria values specified by this url are automatically included as form values (see screenshot) and the search is executed with these specified criteria values.

![crm-20630-activity-search](https://cloud.githubusercontent.com/assets/8986209/26469019/d50a3064-4198-11e7-820e-a1484385db25.png)

---

 * [CRM-20630: Find Activities: search criteria passing with URL parameters](https://issues.civicrm.org/jira/browse/CRM-20630)