### PR TITLE
Fix CRM-20639: Explicitly order extensions by ID.

### DIFF
--- a/CRM/Extension/Mapper.php
+++ b/CRM/Extension/Mapper.php
@@ -292,7 +292,8 @@ class CRM_Extension_Mapper {
         SELECT full_name, file
         FROM civicrm_extension
         WHERE is_active = 1
-        AND type = "module"
+          AND type = "module"
+        ORDER BY id
       ';
       $dao = CRM_Core_DAO::executeQuery($sql);
       while ($dao->fetch()) {


### PR DESCRIPTION
Instead of assuming they'll be automatically ordered by ID.

---

 * [CRM-20639: Make the order in which hooks fire deterministic](https://issues.civicrm.org/jira/browse/CRM-20639)