### PR TITLE
Fix CRM-20401: use native CiviCRM recurring links

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2467,6 +2467,9 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       $ids['paymentProcessor'] = $paymentProcessorID;
       $this->_relatedObjects['paymentProcessor'] = $paymentProcessor;
     }
+
+    // Add contribution id to $ids. CRM-20401
+    $ids['contribution'] = $this->id;
     return TRUE;
   }
 

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -2473,7 +2473,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
 
     $this->mut->checkMailLog(array(
       'is_recur:::1',
-      'cancelSubscriptionUrl:::http://dummy.com',
+      'cancelSubscriptionUrl:::'. CIVICRM_UF_BASEURL,
     ));
     $this->mut->stop();
     $this->revertTemplateToReservedTemplate();

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -2473,7 +2473,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
 
     $this->mut->checkMailLog(array(
       'is_recur:::1',
-      'cancelSubscriptionUrl:::'. CIVICRM_UF_BASEURL,
+      'cancelSubscriptionUrl:::' . CIVICRM_UF_BASEURL,
     ));
     $this->mut->stop();
     $this->revertTemplateToReservedTemplate();


### PR DESCRIPTION
This just adds the contribution ID to $ids if it's available. I'm unsure why that's not already being done, despite being expected by CRM_Contribute_BAO_Contribution::composeMessageArray() .

---

 * [CRM-20401: Cancel\/modify URL receipt links not correct for Paypal Website Payments Pro](https://issues.civicrm.org/jira/browse/CRM-20401)