### PR TITLE
CRM-20643 Fix invalid bounce type filter for bounce report

### DIFF
--- a/CRM/Report/Form/Mailing/Bounce.php
+++ b/CRM/Report/Form/Mailing/Bounce.php
@@ -441,7 +441,7 @@ class CRM_Report_Form_Mailing_Bounce extends CRM_Report_Form {
    */
   public function bounce_type() {
 
-    $data = array('' => ts('--Please Select--'));
+    $data = array();
 
     $bounce_type = new CRM_Mailing_DAO_BounceType();
     $query = "SELECT name FROM civicrm_mailing_bounce_type";


### PR DESCRIPTION
When building the options for bounce type filter an invalid option is added first " – please select --".  This causes the report to default to this value and not load any data.