### PR TITLE
CRM-20653: Allow non-truthy defaults for retrieval of request parameters.

### DIFF
--- a/CRM/Utils/Request.php
+++ b/CRM/Utils/Request.php
@@ -120,7 +120,7 @@ class CRM_Utils_Request {
       CRM_Core_Error::fatal(ts("Could not find valid value for %1", array(1 => $name)));
     }
 
-    if (!isset($value) && $default) {
+    if (!isset($value)) {
       $value = $default;
     }
 


### PR DESCRIPTION
* [CRM-20653: CRM_Utils_Request::retrieve\(\) does not support non-truthy defaults](https://issues.civicrm.org/jira/browse/CRM-20653)