### PR TITLE
CRM-19610 : Search preferences changes are not updated

### DIFF
--- a/Civi/Core/SettingsBag.php
+++ b/Civi/Core/SettingsBag.php
@@ -352,7 +352,7 @@ class SettingsBag {
     }
     $dao->find(TRUE);
 
-    if (isset($metadata['on_change'])) {
+    if (isset($metadata['on_change']) && $value != 0 && !($dao->value === NULL || unserialize($dao->value) == 0)) {
       foreach ($metadata['on_change'] as $callback) {
         call_user_func(
           \Civi\Core\Resolver::singleton()->get($callback),

--- a/Civi/Core/SettingsBag.php
+++ b/Civi/Core/SettingsBag.php
@@ -352,7 +352,7 @@ class SettingsBag {
     }
     $dao->find(TRUE);
 
-    if (isset($metadata['on_change']) && $value != 0 && !($dao->value === NULL || unserialize($dao->value) == 0)) {
+    if (isset($metadata['on_change']) && !empty($value) && !($dao->value === NULL || unserialize($dao->value) == 0)) {
       foreach ($metadata['on_change'] as $callback) {
         call_user_func(
           \Civi\Core\Resolver::singleton()->get($callback),


### PR DESCRIPTION
After saving a 0 value, the db gets updated to a serialized value of it for the field. Either we can avoid the entry of 0 [at this point](https://github.com/civicrm/civicrm-core/blob/master/Civi/Core/SettingsBag.php#L371) or check for unserialized() value as done here.

---

 * [CRM-19610: Fatal when creating InnoDB fts indexes](https://issues.civicrm.org/jira/browse/CRM-19610)