### PR TITLE
CRM-20658: Fatal error on Dedupe rule for > 1 match

### DIFF
--- a/CRM/Dedupe/BAO/RuleGroup.php
+++ b/CRM/Dedupe/BAO/RuleGroup.php
@@ -229,20 +229,35 @@ class CRM_Dedupe_BAO_RuleGroup extends CRM_Dedupe_DAO_RuleGroup {
           $fieldWeight = array_keys($tableQueries);
           $fieldWeight = $fieldWeight[0];
           $query = array_shift($tableQueries);
+          $dupeWeightClause = 'ON DUPLICATE KEY UPDATE weight = weight + VALUES(weight)';
 
           if ($searchWithinDupes) {
             // get prepared to search within already found dupes if $searchWithinDupes flag is set
             $dao->query("DROP TEMPORARY TABLE IF EXISTS dedupe_copy");
             $dao->query("CREATE TEMPORARY TABLE dedupe_copy SELECT * FROM dedupe WHERE weight >= {$weightSum}");
-            $dao->free();
 
             preg_match($patternColumn, $query, $matches);
-            $query = str_replace(' WHERE ', str_replace('column', $matches[1], $dupeCopyJoin), $query);
+            $count = substr_count($query, ' WHERE ');
+            if ($count == 2 && strpos($query, 'UNION') !== FALSE) {
+              //Create second copy as single temp table cannot be referred twice in a single query.
+              $dao->query("CREATE TEMPORARY TABLE dedupe_copy_2 SELECT * FROM dedupe WHERE weight >= {$weightSum}");
+              $dupeCopyJoins = array($dupeCopyJoin, str_replace('dedupe_copy', 'dedupe_copy_2', $dupeCopyJoin));
+              $queryArray = explode('UNION', $query);
+              foreach ($queryArray as $key => $value) {
+                $queryArray[$key] = str_replace(' WHERE ', str_replace('column', $matches[1], $dupeCopyJoins[$key]), $queryArray[$key]);
+              }
+              $query = implode(' UNION ', $queryArray);
+              $dupeWeightClause = str_replace('weight', 'dedupe.weight', $dupeWeightClause);
+            }
+            else {
+              $query = str_replace(' WHERE ', str_replace('column', $matches[1], $dupeCopyJoin), $query);
+            }
+            $dao->free();
           }
           $searchWithinDupes = 1;
 
           // construct and execute the intermediate query
-          $query = "{$insertClause} {$query} {$groupByClause} ON DUPLICATE KEY UPDATE weight = weight + VALUES(weight)";
+          $query = "{$insertClause} {$query} {$groupByClause} {$dupeWeightClause}";
           $dao->query($query);
 
           // FIXME: we need to be more acurate with affected rows, especially for insert vs duplicate insert.

--- a/CRM/Dedupe/BAO/RuleGroup.php
+++ b/CRM/Dedupe/BAO/RuleGroup.php
@@ -239,9 +239,10 @@ class CRM_Dedupe_BAO_RuleGroup extends CRM_Dedupe_DAO_RuleGroup {
             preg_match($patternColumn, $query, $matches);
             $count = substr_count($query, ' WHERE ');
             if ($count == 2 && strpos($query, 'UNION') !== FALSE) {
+              $tempTable = 'dedupe_copy' . uniqid();
               //Create second copy as single temp table cannot be referred twice in a single query.
-              $dao->query("CREATE TEMPORARY TABLE dedupe_copy_2 SELECT * FROM dedupe WHERE weight >= {$weightSum}");
-              $dupeCopyJoins = array($dupeCopyJoin, str_replace('dedupe_copy', 'dedupe_copy_2', $dupeCopyJoin));
+              $dao->query("CREATE TEMPORARY TABLE $tempTable SELECT * FROM dedupe WHERE weight >= {$weightSum}");
+              $dupeCopyJoins = array($dupeCopyJoin, str_replace('dedupe_copy', $tempTable, $dupeCopyJoin));
               $queryArray = explode('UNION', $query);
               foreach ($queryArray as $key => $value) {
                 $queryArray[$key] = str_replace(' WHERE ', str_replace('column', $matches[1], $dupeCopyJoins[$key]), $queryArray[$key]);

--- a/tests/phpunit/CRM/Dedupe/DedupeFinderTest.php
+++ b/tests/phpunit/CRM/Dedupe/DedupeFinderTest.php
@@ -59,6 +59,26 @@ class CRM_Dedupe_DedupeFinderTest extends CiviUnitTestCase {
   }
 
   /**
+   * CRM-20658: Test more then one reference for temp table dedupe_copy
+   */
+  public function testMultiSelectForDedupeCopy() {
+    $this->setupForGroupDedupe();
+    //Create test rule group for individual.
+    $ruleGroup = civicrm_api3('RuleGroup', 'create', array(
+      'contact_type' => "Individual",
+      'threshold' => 20,
+      'used' => "General",
+      'name' => "testrule",
+    ));
+    //Insert first and last name as fields to check on.
+    foreach (array('first_name', 'last_name') as $fieldName) {
+      CRM_Core_DAO::executeQuery("INSERT INTO `civicrm_dedupe_rule` VALUES (NULL, {$ruleGroup['id']}, 'civicrm_contact', '{$fieldName}', NULL, '10')");
+    }
+    $foundDupes = CRM_Dedupe_Finder::dupesInGroup($ruleGroup['id'], $this->groupID);
+    $this->assertEquals(count($foundDupes), 4);
+  }
+
+  /**
    * Test the supervised dedupe rule against a group.
    *
    * @throws \Exception


### PR DESCRIPTION
[Docs](https://dev.mysql.com/doc/refman/5.7/en/temporary-table-problems.html) mentions `Can't reopen table:` occurs if temporary tables are referred twice in a single query. Modifying this to create another referral table to join if there are two instances present in a single query string.

Unit test added.

---

 * [CRM-20658: Fatal error on Dedupe rule for \> 1 match](https://issues.civicrm.org/jira/browse/CRM-20658)