### PR TITLE
Fix CRM-20660: Total Opens should count without DISTINCT keyword.

### DIFF
--- a/CRM/Report/Form/Mailing/Summary.php
+++ b/CRM/Report/Form/Mailing/Summary.php
@@ -358,7 +358,7 @@ class CRM_Report_Form_Mailing_Summary extends CRM_Report_Form {
     // is the key in $this->_columns, and $fieldName is the key in that array's
     // ['fields'] array.
     // Reference: CRM-20660
-    $distinct_count_columns = array(
+    $distinctCountColumns = array(
       'civicrm_mailing_event_queue.queue_count',
       'civicrm_mailing_event_delivered.delivered_count',
       'civicrm_mailing_event_bounce.bounce_count',
@@ -393,11 +393,9 @@ class CRM_Report_Form_Mailing_Summary extends CRM_Report_Form {
               if (in_array($tableName, $count_tables)) {
                 // Use the DISTINCT keyword appropriately, based on the contents
                 // of $distinct_count_columns.
-                if (in_array("{$tableName}.{$fieldName}", $distinct_count_columns)) {
+                $distinct = '';
+                if (in_array("{$tableName}.{$fieldName}", $distinctCountColumns)) {
                   $distinct = 'DISTINCT';
-                }
-                else {
-                  $distinct = '';
                 }
                 $select[] = "count($distinct {$field['dbAlias']}) as {$tableName}_{$fieldName}";
               }

--- a/CRM/Report/Form/Mailing/Summary.php
+++ b/CRM/Report/Form/Mailing/Summary.php
@@ -350,6 +350,24 @@ class CRM_Report_Form_Mailing_Summary extends CRM_Report_Form {
       'civicrm_mailing_event_unsubscribe',
     );
 
+    // Define a list of columns that should be counted with the DISTINCT
+    // keyword. For example, civicrm_mailing_event_opened.unique_open_count
+    // should display the number of unique records, whereas something like
+    // civicrm_mailing_event_opened.open_count should display the total number.
+    // Each string here is in the form $tableName.$fieldName, where $tableName
+    // is the key in $this->_columns, and $fieldName is the key in that array's
+    // ['fields'] array.
+    // Reference: CRM-20660
+    $distinct_count_columns = array(
+      'civicrm_mailing_event_queue.queue_count',
+      'civicrm_mailing_event_delivered.delivered_count',
+      'civicrm_mailing_event_bounce.bounce_count',
+      'civicrm_mailing_event_opened.unique_open_count',
+      'civicrm_mailing_event_trackable_url_open.click_count',
+      'civicrm_mailing_event_unsubscribe.unsubscribe_count',
+      'civicrm_mailing_event_unsubscribe.optout_count',
+    );
+
     $select = array();
     $this->_columnHeaders = array();
     foreach ($this->_columns as $tableName => $table) {
@@ -373,7 +391,15 @@ class CRM_Report_Form_Mailing_Summary extends CRM_Report_Form {
             }
             else {
               if (in_array($tableName, $count_tables)) {
-                $select[] = "count(DISTINCT {$field['dbAlias']}) as {$tableName}_{$fieldName}";
+                // Use the DISTINCT keyword appropriately, based on the contents
+                // of $distinct_count_columns.
+                if (in_array("{$tableName}.{$fieldName}", $distinct_count_columns)) {
+                  $distinct = 'DISTINCT';
+                }
+                else {
+                  $distinct = '';
+                }
+                $select[] = "count($distinct {$field['dbAlias']}) as {$tableName}_{$fieldName}";
               }
               else {
                 $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";


### PR DESCRIPTION
WIP until all checks pass.

---

 * [CRM-20660: Mail Summary Report showing same number for Total Opens and Unique Opens](https://issues.civicrm.org/jira/browse/CRM-20660)