### PR TITLE
CRM-20662 Ensure that the system only tries populating the domain_id …

### DIFF
--- a/CRM/Upgrade/Incremental/php/FourSeven.php
+++ b/CRM/Upgrade/Incremental/php/FourSeven.php
@@ -1094,7 +1094,7 @@ FROM `civicrm_dashboard_contact` JOIN `civicrm_contact` WHERE civicrm_dashboard_
    */
   public static function populateSMSProviderDomainId() {
     $count = CRM_Core_DAO::singleValueQuery("SELECT count(id) FROM civicrm_domain");
-    if ($count = 1) {
+    if ($count == 1) {
       CRM_Core_DAO::executeQuery("UPDATE civicrm_sms_provider SET domain_id = (SELECT id FROM civicrm_domain)");
     }
     if (!parent::checkFKExists('civicrm_sms_provider', 'FK_civicrm_sms_provider_domain_id')) {


### PR DESCRIPTION
…field if there is only 1 domain in the system

ping @eileenmcnaughton @totten i stumbled across this running AUG's upgrade last night i believe this is the correct fix and ran a test of it on a test site of AUG that hadn't been upgraded and it worked as i expected it to. Putting this against the RC as it only broke in .19 and we should fix in .20

[CRM-20662 SMS Domain ID upgrade step breaks on multisite](https://issues.civicrm.org/jira/browse/CRM-20662)