### PR TITLE
CRM-20666 - allow filenames up to 255 characters

### DIFF
--- a/CRM/Core/BAO/File.php
+++ b/CRM/Core/BAO/File.php
@@ -453,7 +453,7 @@ AND       CEF.entity_id    = %2";
 
     // add attachments
     for ($i = 1; $i <= $numAttachments; $i++) {
-      $form->addElement('file', "attachFile_$i", ts('Attach File'), 'size=30 maxlength=60');
+      $form->addElement('file', "attachFile_$i", ts('Attach File'), 'size=30 maxlength=221');
       $form->addUploadElement("attachFile_$i");
       $form->setMaxFileSize($maxFileSize * 1024 * 1024);
       $form->addRule("attachFile_$i",


### PR DESCRIPTION
255 characters is the database limit - and we add 34 characters of
random strings to the end of each name, so the real limit is 221.

---

 * [CRM-20666: enable uploading of files to activities that are up to 255 characters in length](https://issues.civicrm.org/jira/browse/CRM-20666)