### PR TITLE
CRM-20642 - Activity.get - Fix "IS NULL" filtering for case_id, tag_id, file_id

### DIFF
--- a/tests/phpunit/api/v3/ActivityCaseTest.php
+++ b/tests/phpunit/api/v3/ActivityCaseTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ *  Test Activity.get API with the case_id field
+ *
+ * @package CiviCRM_APIv3
+ * @group headless
+ */
+class api_v3_ActivityCaseTest extends CiviCaseTestCase {
+  protected $_params;
+  protected $_entity;
+  protected $_cid;
+
+  /**
+   * @var array
+   *  APIv3 Result (Case.create)
+   */
+  protected $_case;
+
+  /**
+   * @var array
+   *  APIv3 Result (Activity.create)
+   */
+  protected $_otherActivity;
+
+  /**
+   * Test setup for every test.
+   *
+   * Connect to the database, truncate the tables that will be used
+   * and redirect stdin to a temporary file.
+   */
+  public function setUp() {
+    $this->_entity = 'case';
+
+    parent::setUp();
+
+    $this->_cid = $this->individualCreate();
+
+    $this->_case = $this->callAPISuccess('case', 'create', array(
+      'case_type_id' => $this->caseTypeId,
+      'subject' => __CLASS__,
+      'contact_id' => $this->_cid,
+    ));
+
+    $this->_otherActivity = $this->callAPISuccess('Activity', 'create', array(
+      'source_contact_id' => $this->_cid,
+      'activity_type_id' => 'Phone Call',
+      'subject' => 'Ask not what your API can do for you, but what you can do for your API.',
+    ));
+  }
+
+  public function testGet() {
+    $this->assertTrue(is_numeric($this->_case['id']));
+    $this->assertTrue(is_numeric($this->_otherActivity['id']));
+
+    $getByCaseId = $this->callAPIAndDocument('Activity', 'get', array(
+      'case_id' => $this->_case['id'],
+    ), __FUNCTION__, __FILE__);
+    $this->assertNotEmpty($getByCaseId['values']);
+    $getByCaseId_ids = array_keys($getByCaseId['values']);
+
+    $getByCaseNotNull = $this->callAPIAndDocument('Activity', 'get', array(
+      'case_id' => array('IS NOT NULL' => 1),
+    ), __FUNCTION__, __FILE__);
+    $this->assertNotEmpty($getByCaseNotNull['values']);
+    $getByCaseNotNull_ids = array_keys($getByCaseNotNull['values']);
+
+    $getByCaseNull = $this->callAPIAndDocument('Activity', 'get', array(
+      'case_id' => array('IS NULL' => 1),
+    ), __FUNCTION__, __FILE__);
+    $this->assertNotEmpty($getByCaseNull['values']);
+    $getByCaseNull_ids = array_keys($getByCaseNull['values']);
+
+    $this->assertTrue(in_array($this->_otherActivity['id'], $getByCaseNull_ids));
+    $this->assertNotTrue(in_array($this->_otherActivity['id'], $getByCaseId_ids));
+    $this->assertEquals($getByCaseId_ids, $getByCaseNotNull_ids);
+    $this->assertEquals(array(), array_intersect($getByCaseId_ids, $getByCaseNull_ids));
+  }
+
+}


### PR DESCRIPTION
## Context

You could call `Activity.get` with the field `case_id`, `tag_id`, or `file_id`. The field could specify a number or an array (e.g. `array('IS NOT NULL'=>1)` or `array('>'=>100)`).

## Before

Specifying a filter like `case_id => array('IS NULL'=>1)` was meaningless. It led to an incorrect subquery.

## After

`IS NULL` filtering leads to a `LEFT JOIN` and `WHERE the_column IS NULL`.

## Acceptance Criteria

 * Previously supported queries continue to work the same as before.
 * Queries using `IS NULL` also work.

---

 * [CRM-20642: Show\/Hide Case activity toggle](https://issues.civicrm.org/jira/browse/CRM-20642)