### PR TITLE
Test for CRM-19610

### DIFF
--- a/tests/phpunit/Civi/Core/SettingsBagTest.php
+++ b/tests/phpunit/Civi/Core/SettingsBagTest.php
@@ -1,0 +1,33 @@
+<?php
+namespace Civi\Core;
+
+class SettingsBagTest extends \CiviUnitTestCase {
+
+  protected $origSetting;
+
+  protected function setUp() {
+    $this->origSetting = $GLOBALS['civicrm_setting'];
+
+    parent::setUp();
+    $this->useTransaction(TRUE);
+
+    $this->mandates = array();
+  }
+
+  public function tearDown() {
+    $GLOBALS['civicrm_setting'] = $this->origSetting;
+    parent::tearDown();
+  }
+
+  /**
+   * CRM-19610 - Ensure InnoDb FTS doesn't break search preferenes when disabled.
+   */
+  public function testInnoDbFTS() {
+
+    $settingsBag = \Civi::settings();
+
+    $settingsBag->set("enable_innodb_fts", "0");
+    $this->assertEquals(0, $settingsBag->get('enable_innodb_fts'));
+  }
+
+}


### PR DESCRIPTION
* [CRM-19610: Fatal when creating InnoDB fts indexes](https://issues.civicrm.org/jira/browse/CRM-19610)