### PR TITLE
CRM-20669 - Work around memory issue for form to set an event's location

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1891,7 +1891,7 @@ WHERE  id = $cfID
         FROM civicrm_event e
         JOIN civicrm_loc_block lb ON e.loc_block_id = lb.id
         JOIN civicrm_address a ON lb.address_id = a.id
-        LEFT OUTER JOIN ccciv.civicrm_state_province sp ON a.state_province_id = sp.id
+        LEFT OUTER JOIN civicrm_state_province sp ON a.state_province_id = sp.id
         GROUP BY a.street_address, a.supplemental_address_1, a.supplemental_address_2, a.supplemental_address_3, a.city, sp.name";
     $fields = array(
       'loc_block_id',

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1893,7 +1893,7 @@ WHERE  id = $cfID
         JOIN civicrm_address a ON lb.address_id = a.id
         LEFT OUTER JOIN ccciv.civicrm_state_province sp ON a.state_province_id = sp.id
         GROUP BY a.street_address, a.supplemental_address_1, a.supplemental_address_2, a.supplemental_address_3, a.city, sp.name";
-    $fields = [
+    $fields = array(
       'loc_block_id',
       'name',
       'street_address',
@@ -1902,7 +1902,7 @@ WHERE  id = $cfID
       'supplemental_address_3',
       'city',
       'st_prov',
-    ];
+    );
 
     $dao = CRM_Core_DAO::executeQuery($sql);
     while ($dao->fetch()) {


### PR DESCRIPTION
This is just a workaround. We need to fix this in a more robust way.

---

 * [CRM-20669: Cannot set location of event if lots of events already exist](https://issues.civicrm.org/jira/browse/CRM-20669)