### PR TITLE
CRM 20672 - Fix access to fields for relationship with target type all contacts in export mapping

### DIFF
--- a/CRM/Core/BAO/Mapping.php
+++ b/CRM/Core/BAO/Mapping.php
@@ -604,7 +604,8 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping {
                 }
                 //CRM-20672 If contact target type not set e.g. "All Contacts" relationship - present user with all field options and let them determine what they expect to work
                 else {
-                  foreach ($contactTypes as $contactType => $label) {
+                  $types = CRM_Contact_BAO_ContactType::basicTypes(FALSE);
+                  foreach ($types as $contactType => $label) {
                     $relatedFields = array_merge($relatedFields, (array) $relatedMapperFields[$label]);
                   }
                   $relatedFields = array_merge($relatedFields, (array) $relationshipCustomFields);

--- a/CRM/Core/BAO/Mapping.php
+++ b/CRM/Core/BAO/Mapping.php
@@ -602,6 +602,13 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping {
                 elseif (isset($relationshipType->$target_type)) {
                   $relatedFields = array_merge((array) $relatedMapperFields[$relationshipType->$target_type], (array) $relationshipCustomFields);
                 }
+				//CRM-20672 If contact target type not set e.g. "All Contacts" relationship - present user with all field options and let them determine what they expect to work
+				else {
+				  foreach ($contactTypes as $contactType => $label) {
+				    $relatedFields = array_merge($relatedFields, (array) $relatedMapperFields[$label]);
+				  }
+				  $relatedFields = array_merge($relatedFields, (array) $relationshipCustomFields);
+				}
               }
               $relationshipType->free();
               asort($relatedFields);

--- a/CRM/Core/BAO/Mapping.php
+++ b/CRM/Core/BAO/Mapping.php
@@ -602,13 +602,13 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping {
                 elseif (isset($relationshipType->$target_type)) {
                   $relatedFields = array_merge((array) $relatedMapperFields[$relationshipType->$target_type], (array) $relationshipCustomFields);
                 }
-				//CRM-20672 If contact target type not set e.g. "All Contacts" relationship - present user with all field options and let them determine what they expect to work
-				else {
-				  foreach ($contactTypes as $contactType => $label) {
-				    $relatedFields = array_merge($relatedFields, (array) $relatedMapperFields[$label]);
-				  }
-				  $relatedFields = array_merge($relatedFields, (array) $relationshipCustomFields);
-				}
+                //CRM-20672 If contact target type not set e.g. "All Contacts" relationship - present user with all field options and let them determine what they expect to work
+                else {
+                  foreach ($contactTypes as $contactType => $label) {
+                    $relatedFields = array_merge($relatedFields, (array) $relatedMapperFields[$label]);
+                  }
+                  $relatedFields = array_merge($relatedFields, (array) $relationshipCustomFields);
+                }
               }
               $relationshipType->free();
               asort($relatedFields);


### PR DESCRIPTION
Seems to be happening because when Contact Type A / B are set to "All Contacts", they're just not set. It seems like that may be a feature, rather than a bug, and it may not make sense to change - my thought is to instead add a sort of 'default' for all contacts related field mapping e.g. "If we don't know what type of contact fields to present, just present them all and let the user choose the fields they expect to work".

Thoughts?