### PR TITLE
CRM-20581 - Allow access to 'get' on StateProvince API with 'Access CiviEvent' - 4.20-rc

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1135,7 +1135,7 @@ class CRM_Core_Permission {
     $permissions['state_province'] = array(
       'get' => array(
         'access CiviCRM',
-      )
+      ),
     );
 
     // Price sets are shared by several components, user needs access to at least one of them

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1132,6 +1132,12 @@ class CRM_Core_Permission {
     // Loc block is only used for events
     $permissions['loc_block'] = $permissions['event'];
 
+    $permissions['state_province'] = array(
+      'get' => array(
+        'access CiviCRM',
+      )
+    );
+
     // Price sets are shared by several components, user needs access to at least one of them
     $permissions['price_set'] = array(
       'default' => array(


### PR DESCRIPTION
This is a critical regression.

---

 * [CRM-20581: Civi event users do not have access to StateProvince entity via the API](https://issues.civicrm.org/jira/browse/CRM-20581)