### PR TITLE
CRM-20091 - Add customValue.gettree api

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -377,7 +377,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
 
     if ($this->_action & CRM_Core_Action::VIEW) {
       // Get the tree of custom fields.
-      $this->_groupTree = CRM_Core_BAO_CustomGroup::getTree('Activity', $this,
+      $this->_groupTree = CRM_Core_BAO_CustomGroup::getTree('Activity', NULL,
         $this->_activityId, 0, $this->_activityTypeId
       );
     }

--- a/CRM/Case/Form/CaseView.php
+++ b/CRM/Case/Form/CaseView.php
@@ -162,7 +162,7 @@ class CRM_Case_Form_CaseView extends CRM_Core_Form {
     $entitySubType = !empty($values['case_type_id']) ? $values['case_type_id'] : NULL;
     $this->assign('caseTypeID', $entitySubType);
     $groupTree = CRM_Core_BAO_CustomGroup::getTree('Case',
-      $this,
+      NULL,
       $this->_caseID,
       NULL,
       $entitySubType

--- a/CRM/Case/Form/CustomData.php
+++ b/CRM/Case/Form/CustomData.php
@@ -66,7 +66,7 @@ class CRM_Case_Form_CustomData extends CRM_Core_Form {
     $this->_contactID = CRM_Utils_Request::retrieve('cid', 'Positive', $this, TRUE);
 
     $groupTree = CRM_Core_BAO_CustomGroup::getTree('Case',
-      $this,
+      NULL,
       $this->_entityID,
       $this->_groupID,
       $this->_subTypeID

--- a/CRM/Contact/Form/CustomData.php
+++ b/CRM/Contact/Form/CustomData.php
@@ -231,7 +231,7 @@ class CRM_Contact_Form_CustomData extends CRM_Core_Form {
       if ($this->_copyValueId) {
         // cached tree is fetched
         $groupTree = CRM_Core_BAO_CustomGroup::getTree($this->_type,
-          $this,
+          NULL,
           $this->_entityId,
           $this->_groupID,
           array(),
@@ -261,7 +261,7 @@ class CRM_Contact_Form_CustomData extends CRM_Core_Form {
     }
 
     $groupTree = CRM_Core_BAO_CustomGroup::getTree($this->_contactType,
-      $this,
+      NULL,
       $this->_tableID,
       $this->_groupID,
       $this->_contactSubType
@@ -269,7 +269,7 @@ class CRM_Contact_Form_CustomData extends CRM_Core_Form {
 
     if (empty($_POST['hidden_custom_group_count'])) {
       // custom data building in edit mode (required to handle multi-value)
-      $groupTree = CRM_Core_BAO_CustomGroup::getTree($this->_contactType, $this, $this->_tableID,
+      $groupTree = CRM_Core_BAO_CustomGroup::getTree($this->_contactType, NULL, $this->_tableID,
         $this->_groupID, $this->_contactSubType
       );
       $customValueCount = CRM_Core_BAO_CustomGroup::buildCustomDataView($this, $groupTree, TRUE, $this->_groupID, NULL, NULL, $this->_tableID);

--- a/CRM/Contact/Form/Edit/Address.php
+++ b/CRM/Contact/Form/Edit/Address.php
@@ -163,10 +163,7 @@ class CRM_Contact_Form_Edit_Address {
     $form->assign('geoCode', $geoCode);
 
     // Process any address custom data -
-    $groupTree = CRM_Core_BAO_CustomGroup::getTree('Address',
-      $form,
-      $entityId
-    );
+    $groupTree = CRM_Core_BAO_CustomGroup::getTree('Address', NULL, $entityId);
 
     if (isset($groupTree) && is_array($groupTree)) {
       // use simplified formatted groupTree

--- a/CRM/Contact/Form/Search/Custom/MultipleValues.php
+++ b/CRM/Contact/Form/Search/Custom/MultipleValues.php
@@ -47,10 +47,7 @@ class CRM_Contact_Form_Search_Custom_MultipleValues extends CRM_Contact_Form_Sea
   public function __construct(&$formValues) {
     parent::__construct($formValues);
 
-    $this->_groupTree = CRM_Core_BAO_CustomGroup::getTree("'Contact', 'Individual', 'Organization', 'Household'",
-      CRM_Core_DAO::$_nullObject,
-      NULL, -1
-    );
+    $this->_groupTree = CRM_Core_BAO_CustomGroup::getTree("'Contact', 'Individual', 'Organization', 'Household'", NULL, NULL, -1);
 
     $this->_group = CRM_Utils_Array::value('group', $this->_formValues);
 

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -1750,7 +1750,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
       $modeFill = TRUE;
     }
 
-    $groupTree = CRM_Core_BAO_CustomGroup::getTree($params['contact_type'], CRM_Core_DAO::$_nullObject, $cid, 0, NULL);
+    $groupTree = CRM_Core_BAO_CustomGroup::getTree($params['contact_type'], NULL, $cid, 0, NULL);
     CRM_Core_BAO_CustomGroup::setDefaults($groupTree, $defaults, FALSE, FALSE);
 
     $locationFields = array(

--- a/CRM/Contact/Page/Inline/Address.php
+++ b/CRM/Contact/Page/Inline/Address.php
@@ -83,9 +83,7 @@ class CRM_Contact_Page_Inline_Address extends CRM_Core_Page {
       }
 
       // add custom data of type address
-      $groupTree = CRM_Core_BAO_CustomGroup::getTree('Address',
-        $this, $idValue
-      );
+      $groupTree = CRM_Core_BAO_CustomGroup::getTree('Address', NULL, $idValue);
 
       // we setting the prefix to dnc_ below so that we don't overwrite smarty's grouptree var.
       $currentAddressBlock['address'][$locBlockNo]['custom'] = CRM_Core_BAO_CustomGroup::buildCustomDataView($this, $groupTree, FALSE, NULL, "dnc_");

--- a/CRM/Contact/Page/Inline/CustomData.php
+++ b/CRM/Contact/Page/Inline/CustomData.php
@@ -51,7 +51,7 @@ class CRM_Contact_Page_Inline_CustomData extends CRM_Core_Page {
     //custom groups Inline
     $entityType = CRM_Contact_BAO_Contact::getContactType($contactId);
     $entitySubType = CRM_Contact_BAO_Contact::getContactSubType($contactId);
-    $groupTree = CRM_Core_BAO_CustomGroup::getTree($entityType, $this, $contactId,
+    $groupTree = CRM_Core_BAO_CustomGroup::getTree($entityType, NULL, $contactId,
       $cgId, $entitySubType
     );
     $details = CRM_Core_BAO_CustomGroup::buildCustomDataView($this, $groupTree, FALSE, NULL, NULL, NULL, $contactId);

--- a/CRM/Contact/Page/View/CustomData.php
+++ b/CRM/Contact/Page/View/CustomData.php
@@ -140,7 +140,7 @@ class CRM_Contact_Page_View_CustomData extends CRM_Core_Page {
         if ($this->_multiRecordDisplay == 'single') {
           $groupTitle = CRM_Core_BAO_CustomGroup::getTitle($this->_groupId);
           CRM_Utils_System::setTitle(ts('View %1 Record', array(1 => $groupTitle)));
-          $groupTree = CRM_Core_BAO_CustomGroup::getTree($entityType, $this, $this->_contactId,
+          $groupTree = CRM_Core_BAO_CustomGroup::getTree($entityType, NULL, $this->_contactId,
             $this->_groupId, $entitySubType, NULL, TRUE, NULL, FALSE, TRUE, $this->_cgcount
           );
 
@@ -149,7 +149,7 @@ class CRM_Contact_Page_View_CustomData extends CRM_Core_Page {
           $this->assign('skipTitle', 1);
         }
         else {
-          $groupTree = CRM_Core_BAO_CustomGroup::getTree($entityType, $this, $this->_contactId,
+          $groupTree = CRM_Core_BAO_CustomGroup::getTree($entityType, NULL, $this->_contactId,
             $this->_groupId, $entitySubType
           );
         }

--- a/CRM/Contact/Page/View/Relationship.php
+++ b/CRM/Contact/Page/View/Relationship.php
@@ -86,7 +86,7 @@ class CRM_Contact_Page_View_Relationship extends CRM_Core_Page {
     $viewNote = CRM_Core_BAO_Note::getNote($this->_id);
     $this->assign('viewNote', $viewNote);
 
-    $groupTree = CRM_Core_BAO_CustomGroup::getTree('Relationship', $this, $this->_id, 0, $relType);
+    $groupTree = CRM_Core_BAO_CustomGroup::getTree('Relationship', NULL, $this->_id, 0, $relType);
     CRM_Core_BAO_CustomGroup::buildCustomDataView($this, $groupTree, FALSE, NULL, NULL, NULL, $this->_id);
 
     $rType = CRM_Utils_Array::value('rtype', $viewRelationship[$this->_id]);

--- a/CRM/Contact/Page/View/Summary.php
+++ b/CRM/Contact/Page/View/Summary.php
@@ -57,7 +57,7 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
       );
     }
     $groupTree = CRM_Core_BAO_CustomGroup::getTree($entityType,
-      $this,
+      NULL,
       $this->_contactId,
       NULL,
       $entitySubType
@@ -182,10 +182,7 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
                 $idValue = $blockVal['master_id'];
               }
             }
-            $groupTree = CRM_Core_BAO_CustomGroup::getTree(ucfirst($key),
-              $this,
-              $idValue
-            );
+            $groupTree = CRM_Core_BAO_CustomGroup::getTree(ucfirst($key), NULL, $idValue);
             // we setting the prefix to dnc_ below so that we don't overwrite smarty's grouptree var.
             $defaults[$key][$blockId]['custom'] = CRM_Core_BAO_CustomGroup::buildCustomDataView($this, $groupTree, FALSE, NULL, "dnc_");
           }

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2747,7 +2747,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
 
       CRM_Event_BAO_Event::retrieve($eventParams, $values['event']);
       // add custom fields for event
-      $eventGroupTree = CRM_Core_BAO_CustomGroup::getTree('Event', $this->_relatedObjects['event'], $this->_relatedObjects['event']->id);
+      $eventGroupTree = CRM_Core_BAO_CustomGroup::getTree('Event', NULL, $this->_relatedObjects['event']->id);
 
       $eventCustomGroup = array();
       foreach ($eventGroupTree as $key => $group) {
@@ -2775,7 +2775,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
 
       CRM_Event_BAO_Participant::getValues($participantParams, $values['participant'], $participantIds);
       // add custom fields for event
-      $participantGroupTree = CRM_Core_BAO_CustomGroup::getTree('Participant', $this->_relatedObjects['participant'], $this->_relatedObjects['participant']->id);
+      $participantGroupTree = CRM_Core_BAO_CustomGroup::getTree('Participant', NULL, $this->_relatedObjects['participant']->id);
       $participantCustomGroup = array();
       foreach ($participantGroupTree as $key => $group) {
         if ($key === 'info') {
@@ -2827,7 +2827,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       }
     }
 
-    $groupTree = CRM_Core_BAO_CustomGroup::getTree('Contribution', $this, $this->id);
+    $groupTree = CRM_Core_BAO_CustomGroup::getTree('Contribution', NULL, $this->id);
 
     $customGroup = array();
     foreach ($groupTree as $key => $group) {

--- a/CRM/Contribute/Form/ContributionView.php
+++ b/CRM/Contribute/Form/ContributionView.php
@@ -103,7 +103,7 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
       }
     }
 
-    $groupTree = CRM_Core_BAO_CustomGroup::getTree('Contribution', $this, $id, 0, CRM_Utils_Array::value('financial_type_id', $values));
+    $groupTree = CRM_Core_BAO_CustomGroup::getTree('Contribution', NULL, $id, 0, CRM_Utils_Array::value('financial_type_id', $values));
     CRM_Core_BAO_CustomGroup::buildCustomDataView($this, $groupTree, FALSE, NULL, NULL, NULL, $id);
 
     $premiumId = NULL;

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -385,6 +385,7 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup {
     $tableData = array(
       'civicrm_custom_field' => array(
         'id',
+        'name',
         'label',
         'column_name',
         'data_type',

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -317,8 +317,8 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup {
    *
    * @param string $entityType
    *   Of the contact whose contact type is needed.
-   * @param CRM_Core_Form $deprecated
-   *   Not used.
+   * @param array $toReturn
+   *   What data should be returned. ['custom_group' => ['id', 'name', etc.], 'custom_field' => ['id', 'label', etc.]]
    * @param int $entityID
    * @param int $groupID
    * @param array $subTypes
@@ -331,7 +331,7 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup {
    *   api - through which it is properly tested - so can be refactored with some comfort.)
    *
    * @param bool $checkPermission
-   * @param varchar $singleRecord
+   * @param string|int $singleRecord
    *   holds 'new' or id if view/edit/copy form for a single record is being loaded.
    * @param bool $showPublicOnly
    *
@@ -349,7 +349,7 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup {
    */
   public static function getTree(
     $entityType,
-    $deprecated = NULL,
+    $toReturn = array(),
     $entityID = NULL,
     $groupID = NULL,
     $subTypes = array(),
@@ -381,9 +381,9 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup {
     // create a new tree
     $strWhere = $orderBy = '';
 
-    // using tableData to build the queryString
+    // legacy hardcoded list of data to return
     $tableData = array(
-      'civicrm_custom_field' => array(
+      'custom_field' => array(
         'id',
         'name',
         'label',
@@ -404,7 +404,7 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup {
         'option_group_id',
         'in_selector',
       ),
-      'civicrm_custom_group' => array(
+      'custom_group' => array(
         'id',
         'name',
         'table_name',
@@ -421,13 +421,24 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup {
         'is_public',
       ),
     );
+    if (!$toReturn || !is_array($toReturn)) {
+      $toReturn = $tableData;
+    }
+    else {
+      $toReturn = array_filter($toReturn) + $tableData;
+      // Merge in required fields that we must have
+      $toReturn['custom_field'] = array_unique(array_merge($toReturn['custom_field'], array('id', 'column_name', 'data_type')));
+      $toReturn['custom_group'] = array_unique(array_merge($toReturn['custom_group'], array('id', 'is_multiple', 'table_name', 'name')));
+      // Validate return fields
+      $toReturn['custom_field'] = array_intersect($toReturn['custom_field'], array_keys(CRM_Core_DAO_CustomField::fieldKeys()));
+      $toReturn['custom_group'] = array_intersect($toReturn['custom_group'], array_keys(CRM_Core_DAO_CustomGroup::fieldKeys()));
+    }
 
     // create select
     $select = array();
-    foreach ($tableData as $tableName => $tableColumn) {
+    foreach ($toReturn as $tableName => $tableColumn) {
       foreach ($tableColumn as $columnName) {
-        $alias = $tableName . "_" . $columnName;
-        $select[] = "{$tableName}.{$columnName} as {$tableName}_{$columnName}";
+        $select[] = "civicrm_{$tableName}.{$columnName} as civicrm_{$tableName}_{$columnName}";
       }
     }
     $strSelect = "SELECT " . implode(', ', $select);
@@ -552,7 +563,7 @@ ORDER BY civicrm_custom_group.weight,
           $groupTree[$groupID]['id'] = $groupID;
 
           // populate the group information
-          foreach ($tableData['civicrm_custom_group'] as $fieldName) {
+          foreach ($toReturn['custom_group'] as $fieldName) {
             $fullFieldName = "civicrm_custom_group_$fieldName";
             if ($fieldName == 'id' ||
               is_null($crmDAO->$fullFieldName)
@@ -581,7 +592,7 @@ ORDER BY civicrm_custom_group.weight,
         $customValueTables[$crmDAO->civicrm_custom_group_table_name][$crmDAO->civicrm_custom_field_column_name] = 1;
         $groupTree[$groupID]['fields'][$fieldId]['id'] = $fieldId;
         // populate information for a custom field
-        foreach ($tableData['civicrm_custom_field'] as $fieldName) {
+        foreach ($toReturn['custom_field'] as $fieldName) {
           $fullFieldName = "civicrm_custom_field_$fieldName";
           if ($fieldName == 'id' ||
             is_null($crmDAO->$fullFieldName)

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -3237,7 +3237,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
           //get the groupTree as per subTypes.
           $groupTree = array();
           foreach ($componentSubType as $subType) {
-            $subTree = CRM_Core_BAO_CustomGroup::getTree($componentBAOName, CRM_Core_DAO::$_nullObject,
+            $subTree = CRM_Core_BAO_CustomGroup::getTree($componentBAOName, NULL,
               $componentId, 0, $values[$subType]
             );
             $groupTree = CRM_Utils_Array::crmArrayMerge($groupTree, $subTree);

--- a/CRM/Custom/Form/CustomData.php
+++ b/CRM/Custom/Form/CustomData.php
@@ -163,7 +163,7 @@ class CRM_Custom_Form_CustomData {
     }
 
     $groupTree = CRM_Core_BAO_CustomGroup::getTree($form->_type,
-      $form,
+      NULL,
       $form->_entityId,
       $gid,
       $subType,

--- a/CRM/Dedupe/BAO/RuleGroup.php
+++ b/CRM/Dedupe/BAO/RuleGroup.php
@@ -115,7 +115,7 @@ class CRM_Dedupe_BAO_RuleGroup extends CRM_Dedupe_DAO_RuleGroup {
           }
         }
         // add custom data fields
-        foreach (CRM_Core_BAO_CustomGroup::getTree($ctype, CRM_Core_DAO::$_nullObject, NULL, -1) as $key => $cg) {
+        foreach (CRM_Core_BAO_CustomGroup::getTree($ctype, NULL, NULL, -1) as $key => $cg) {
           if (!is_int($key)) {
             continue;
           }

--- a/CRM/Dedupe/Finder.php
+++ b/CRM/Dedupe/Finder.php
@@ -238,7 +238,7 @@ class CRM_Dedupe_Finder {
     }
 
     // handle custom data
-    $tree = CRM_Core_BAO_CustomGroup::getTree($ctype, CRM_Core_DAO::$_nullObject, NULL, -1);
+    $tree = CRM_Core_BAO_CustomGroup::getTree($ctype, NULL, NULL, -1);
     CRM_Core_BAO_CustomGroup::postProcess($tree, $fields, TRUE);
     foreach ($tree as $key => $cg) {
       if (!is_int($key)) {

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1383,7 +1383,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
     $mainTree = CRM_Core_BAO_CustomGroup::getTree($main['contact_type'], NULL, $mainId, -1,
       CRM_Utils_Array::value('contact_sub_type', $main), NULL, TRUE, NULL, TRUE, $checkPermissions
     );
-    $otherTree = CRM_Core_BAO_CustomGroup::getTree($main['contact_type'], CRM_Core_DAO::$_nullObject, $otherId, -1,
+    $otherTree = CRM_Core_BAO_CustomGroup::getTree($main['contact_type'], NULL, $otherId, -1,
       CRM_Utils_Array::value('contact_sub_type', $other), NULL, TRUE, NULL, TRUE, $checkPermissions
     );
     CRM_Core_DAO::freeResult();
@@ -1515,9 +1515,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
     // fix custom fields so they're edible by createProfileContact()
     static $treeCache = array();
     if (!array_key_exists($migrationInfo['main_details']['contact_type'], $treeCache)) {
-      $treeCache[$migrationInfo['main_details']['contact_type']] = CRM_Core_BAO_CustomGroup::getTree($migrationInfo['main_details']['contact_type'],
-        CRM_Core_DAO::$_nullObject, NULL, -1
-      );
+      $treeCache[$migrationInfo['main_details']['contact_type']] = CRM_Core_BAO_CustomGroup::getTree($migrationInfo['main_details']['contact_type'], NULL, NULL, -1);
     }
 
     $cFields = array();

--- a/CRM/Event/Form/ParticipantView.php
+++ b/CRM/Event/Form/ParticipantView.php
@@ -142,15 +142,15 @@ class CRM_Event_Form_ParticipantView extends CRM_Core_Form {
     $finalTree = array();
 
     foreach ($allRoleIDs as $k => $v) {
-      $roleGroupTree = CRM_Core_BAO_CustomGroup::getTree('Participant', $this, $participantID, NULL, $v, $roleCustomDataTypeID);
-      $eventGroupTree = CRM_Core_BAO_CustomGroup::getTree('Participant', $this, $participantID, NULL,
+      $roleGroupTree = CRM_Core_BAO_CustomGroup::getTree('Participant', NULL, $participantID, NULL, $v, $roleCustomDataTypeID);
+      $eventGroupTree = CRM_Core_BAO_CustomGroup::getTree('Participant', NULL, $participantID, NULL,
         $values[$participantID]['event_id'], $eventNameCustomDataTypeID
       );
       $eventTypeID = CRM_Core_DAO::getFieldValue("CRM_Event_DAO_Event", $values[$participantID]['event_id'], 'event_type_id', 'id');
-      $eventTypeGroupTree = CRM_Core_BAO_CustomGroup::getTree('Participant', $this, $participantID, NULL, $eventTypeID, $eventTypeCustomDataTypeID);
+      $eventTypeGroupTree = CRM_Core_BAO_CustomGroup::getTree('Participant', NULL, $participantID, NULL, $eventTypeID, $eventTypeCustomDataTypeID);
       $groupTree = CRM_Utils_Array::crmArrayMerge($roleGroupTree, $eventGroupTree);
       $groupTree = CRM_Utils_Array::crmArrayMerge($groupTree, $eventTypeGroupTree);
-      $groupTree = CRM_Utils_Array::crmArrayMerge($groupTree, CRM_Core_BAO_CustomGroup::getTree('Participant', $this, $participantID));
+      $groupTree = CRM_Utils_Array::crmArrayMerge($groupTree, CRM_Core_BAO_CustomGroup::getTree('Participant', NULL, $participantID));
       foreach ($groupTree as $treeId => $trees) {
         $finalTree[$treeId] = $trees;
       }

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -814,7 +814,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
           }
 
           //get event custom field information
-          $groupTree = CRM_Core_BAO_CustomGroup::getTree('Event', $this, $this->_eventId, 0, $this->_values['event']['event_type_id']);
+          $groupTree = CRM_Core_BAO_CustomGroup::getTree('Event', NULL, $this->_eventId, 0, $this->_values['event']['event_type_id']);
           $primaryParticipant['eventCustomFields'] = $groupTree;
 
           // call postprocess hook before leaving

--- a/CRM/Event/Page/EventInfo.php
+++ b/CRM/Event/Page/EventInfo.php
@@ -182,7 +182,7 @@ class CRM_Event_Page_EventInfo extends CRM_Core_Page {
     }
 
     //retrieve custom field information
-    $groupTree = CRM_Core_BAO_CustomGroup::getTree('Event', $this, $this->_id, 0, $values['event']['event_type_id'], NULL, TRUE, NULL, FALSE, TRUE, NULL, TRUE);
+    $groupTree = CRM_Core_BAO_CustomGroup::getTree('Event', NULL, $this->_id, 0, $values['event']['event_type_id'], NULL, TRUE, NULL, FALSE, TRUE, NULL, TRUE);
     CRM_Core_BAO_CustomGroup::buildCustomDataView($this, $groupTree, FALSE, NULL, NULL, NULL, $this->_id);
     $this->assign('action', CRM_Core_Action::VIEW);
     //To show the event location on maps directly on event info page

--- a/CRM/Grant/Form/GrantView.php
+++ b/CRM/Grant/Form/GrantView.php
@@ -117,7 +117,7 @@ class CRM_Grant_Form_GrantView extends CRM_Core_Form {
     $this->assign('attachment', $attachment);
 
     $grantType = CRM_Core_DAO::getFieldValue("CRM_Grant_DAO_Grant", $this->_id, "grant_type_id");
-    $groupTree = CRM_Core_BAO_CustomGroup::getTree("Grant", $this, $this->_id, 0, $grantType);
+    $groupTree = CRM_Core_BAO_CustomGroup::getTree("Grant", NULL, $this->_id, 0, $grantType);
     CRM_Core_BAO_CustomGroup::buildCustomDataView($this, $groupTree, FALSE, NULL, NULL, NULL, $this->_id);
 
     $this->assign('id', $this->_id);

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -655,7 +655,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
         $this->_params['paidBy'] = $paymentInstrument[$this->_params['payment_instrument_id']];
       }
       //get the group Tree
-      $this->_groupTree = CRM_Core_BAO_CustomGroup::getTree('Membership', $this, $this->_id, FALSE, $this->_memType);
+      $this->_groupTree = CRM_Core_BAO_CustomGroup::getTree('Membership', NULL, $this->_id, FALSE, $this->_memType);
 
       // retrieve custom data
       $customFields = $customValues = $fo = array();

--- a/CRM/Member/Form/MembershipView.php
+++ b/CRM/Member/Form/MembershipView.php
@@ -377,7 +377,7 @@ SELECT r.id, c.id as cid, c.display_name as name, c.job_title as comment,
 
       $memType = CRM_Core_DAO::getFieldValue("CRM_Member_DAO_Membership", $id, "membership_type_id");
 
-      $groupTree = CRM_Core_BAO_CustomGroup::getTree('Membership', $this, $id, 0, $memType);
+      $groupTree = CRM_Core_BAO_CustomGroup::getTree('Membership', NULL, $id, 0, $memType);
       CRM_Core_BAO_CustomGroup::buildCustomDataView($this, $groupTree, FALSE, NULL, NULL, NULL, $id);
 
       $isRecur = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_Membership', $id, 'contribution_recur_id');

--- a/CRM/Pledge/BAO/Pledge.php
+++ b/CRM/Pledge/BAO/Pledge.php
@@ -613,7 +613,7 @@ GROUP BY  currency
 
     // handle custom data.
     if (!empty($params['hidden_custom'])) {
-      $groupTree = CRM_Core_BAO_CustomGroup::getTree('Pledge', CRM_Core_DAO::$_nullObject, $params['id']);
+      $groupTree = CRM_Core_BAO_CustomGroup::getTree('Pledge', NULL, $params['id']);
       $pledgeParams = array(array('pledge_id', '=', $params['id'], 0, 0));
       $customGroup = array();
       // retrieve custom data

--- a/CRM/Pledge/Form/PledgeView.php
+++ b/CRM/Pledge/Form/PledgeView.php
@@ -63,7 +63,7 @@ class CRM_Pledge_Form_PledgeView extends CRM_Core_Form {
     }
 
     // handle custom data.
-    $groupTree = CRM_Core_BAO_CustomGroup::getTree('Pledge', $this, $params['id']);
+    $groupTree = CRM_Core_BAO_CustomGroup::getTree('Pledge', NULL, $params['id']);
     CRM_Core_BAO_CustomGroup::buildCustomDataView($this, $groupTree, FALSE, NULL, NULL, NULL, $params['id']);
 
     if (!empty($values['contribution_page_id'])) {

--- a/api/v3/CustomValue.php
+++ b/api/v3/CustomValue.php
@@ -256,6 +256,30 @@ function _civicrm_api3_custom_value_gettree_spec(&$spec) {
     'api.required' => 1,
     'options' => array_combine($entities, $entities),
   );
+  // Return params for custom group, field & value
+  foreach (CRM_Core_DAO_CustomGroup::fields() as $field) {
+    $name = 'custom_group.' . $field['name'];
+    $spec[$name] = array('name' => $name) + $field;
+  }
+  foreach (CRM_Core_DAO_CustomField::fields() as $field) {
+    $name = 'custom_field.' . $field['name'];
+    $spec[$name] = array('name' => $name) + $field;
+  }
+  $spec['custom_value.id'] = array(
+    'title' => 'Custom Value Id',
+    'description' => 'Id of record in custom value table',
+    'type' => CRM_Utils_Type::T_INT,
+  );
+  $spec['custom_value.data'] = array(
+    'title' => 'Custom Value (Raw)',
+    'description' => 'Raw value as stored in the database',
+    'type' => CRM_Utils_Type::T_STRING,
+  );
+  $spec['custom_value.display'] = array(
+    'title' => 'Custom Value (Formatted)',
+    'description' => 'Custom value formatted for display',
+    'type' => CRM_Utils_Type::T_STRING,
+  );
 }
 
 /**
@@ -278,6 +302,10 @@ function civicrm_api3_custom_value_gettree($params) {
     if (isset($toReturn[$type])) {
       $toReturn[$type][] = $field;
     }
+  }
+  // We must have a name if not indexing sequentially
+  if (empty($params['sequential']) && $toReturn['custom_field']) {
+    $toReturn['custom_field'][] = 'name';
   }
   switch ($params['entity_type']) {
     case 'Contact':
@@ -316,7 +344,7 @@ function civicrm_api3_custom_value_gettree($params) {
       }
     }
   }
-  $tree = CRM_Core_BAO_CustomGroup::getTree($treeParams['entityType'], NULL, $params['entity_id'], NULL, $treeParams['subTypes'], $treeParams['subName'], TRUE, NULL, FALSE, CRM_Utils_Array::value('check_permissions', $params, TRUE));
+  $tree = CRM_Core_BAO_CustomGroup::getTree($treeParams['entityType'], $toReturn, $params['entity_id'], NULL, $treeParams['subTypes'], $treeParams['subName'], TRUE, NULL, FALSE, CRM_Utils_Array::value('check_permissions', $params, TRUE));
   unset($tree['info']);
   $result = array();
   foreach ($tree as $group) {

--- a/api/v3/CustomValue.php
+++ b/api/v3/CustomValue.php
@@ -233,3 +233,124 @@ function _civicrm_api3_custom_value_get_spec(&$params) {
   $params['entity_id']['api.required'] = 1;
   $params['entity_id']['title'] = 'Entity ID';
 }
+
+/**
+ * CustomValue.gettree API specification
+ *
+ * @param array $spec description of fields supported by this API call
+ * @return void
+ */
+function _civicrm_api3_custom_value_gettree_spec(&$spec) {
+  $spec['entity_id'] = array(
+    'title' => 'Entity Id',
+    'description' => 'Id of entity',
+    'type' => CRM_Utils_Type::T_INT,
+    'api.required' => 1,
+  );
+  $entities = civicrm_api3('Entity', 'get');
+  $entities = array_diff($entities['values'], $entities['deprecated']);
+  $spec['entity_type'] = array(
+    'title' => 'Entity Type',
+    'description' => 'API name of entity type, e.g. "Contact"',
+    'type' => CRM_Utils_Type::T_STRING,
+    'api.required' => 1,
+    'options' => array_combine($entities, $entities),
+  );
+}
+
+/**
+ * CustomValue.gettree API
+ *
+ * @param array $params
+ * @return array API result
+ * @throws API_Exception
+ */
+function civicrm_api3_custom_value_gettree($params) {
+  $ret = array();
+  $options = _civicrm_api3_get_options_from_params($params);
+  $toReturn = array(
+    'custom_group' => array(),
+    'custom_field' => array(),
+    'custom_value' => array(),
+  );
+  foreach (array_keys($options['return']) as $r) {
+    list($type, $field) = explode('.', $r);
+    if (isset($toReturn[$type])) {
+      $toReturn[$type][] = $field;
+    }
+  }
+  switch ($params['entity_type']) {
+    case 'Contact':
+      $ret = array('entityType' => 'contact_type', 'subTypes' => 'contact_sub_type');
+      break;
+
+    case 'Activity':
+    case 'Campaign':
+    case 'Case':
+    case 'Contribution':
+    case 'Event':
+    case 'Grant':
+    case 'Membership':
+    case 'Relationship':
+      $ret = array('subTypes' => strtolower($params['entity_type']) . '_type_id');
+      break;
+
+    case 'Participant':
+      // todo
+  }
+  $treeParams = array(
+    'entityType' => $params['entity_type'],
+    'subTypes' => array(),
+    'subName' => NULL,
+  );
+  // Fetch entity data for custom group type/sub-type
+  // Also verify access permissions (api3 will throw an exception if permission denied)
+  if ($ret || !empty($params['check_permissions'])) {
+    $entityData = civicrm_api3($params['entity_type'], 'getsingle', array(
+      'id' => $params['entity_id'],
+      'return' => array_merge(array('id'), array_values($ret)),
+    ));
+    foreach ($ret as $param => $key) {
+      if (isset($entityData[$key])) {
+        $treeParams[$param] = $entityData[$key];
+      }
+    }
+  }
+  $tree = CRM_Core_BAO_CustomGroup::getTree($treeParams['entityType'], NULL, $params['entity_id'], NULL, $treeParams['subTypes'], $treeParams['subName'], TRUE, NULL, FALSE, CRM_Utils_Array::value('check_permissions', $params, TRUE));
+  unset($tree['info']);
+  $result = array();
+  foreach ($tree as $group) {
+    $result[$group['name']] = array();
+    $groupToReturn = $toReturn['custom_group'] ? $toReturn['custom_group'] : array_keys($group);
+    foreach ($groupToReturn as $item) {
+      $result[$group['name']][$item] = CRM_Utils_Array::value($item, $group);
+    }
+    $result[$group['name']]['fields'] = array();
+    foreach ($group['fields'] as $fieldInfo) {
+      $field = array('value' => NULL);
+      $fieldToReturn = $toReturn['custom_field'] ? $toReturn['custom_field'] : array_keys($fieldInfo);
+      foreach ($fieldToReturn as $item) {
+        $field[$item] = CRM_Utils_Array::value($item, $fieldInfo);
+      }
+      unset($field['customValue']);
+      if (!empty($fieldInfo['customValue'])) {
+        $field['value'] = CRM_Utils_Array::first($fieldInfo['customValue']);
+        foreach (array_keys($field['value']) as $key) {
+          if ($toReturn['custom_value'] && !in_array($key, $toReturn['custom_value'])) {
+            unset($field['value'][$key]);
+          }
+        }
+        if (!$toReturn['custom_value'] || in_array('display', $toReturn['custom_value'])) {
+          $field['value']['display'] = CRM_Core_BAO_CustomField::displayValue($field['value']['data'], $fieldInfo);
+        }
+      }
+      if (empty($params['sequential'])) {
+        $result[$group['name']]['fields'][$fieldInfo['name']] = $field;
+      }
+      else {
+        $result[$group['name']]['fields'][] = $field;
+      }
+    }
+  }
+  return civicrm_api3_create_success($result, $params, 'CustomValue', 'gettree');
+}

--- a/templates/CRM/Admin/Page/APIExplorer.js
+++ b/templates/CRM/Admin/Page/APIExplorer.js
@@ -307,7 +307,7 @@
       populateFields(fields, entity, action, '', required);
       showFields(required);
       renderJoinSelector();
-      if (_.includes(['get', 'getsingle', 'getvalue', 'getstat'], action)) {
+      if (_.includes(['get', 'getsingle', 'getvalue', 'getstat', 'gettree'], action)) {
         showReturn();
       }
     });

--- a/tests/phpunit/api/v3/CustomValueTest.php
+++ b/tests/phpunit/api/v3/CustomValueTest.php
@@ -397,4 +397,24 @@ class api_v3_CustomValueTest extends CiviUnitTestCase {
     $this->assertEquals($params[$controlFieldName], $result[$controlFieldName]);
   }
 
+  public function testGettree() {
+    $cg = $this->callAPISuccess('CustomGroup', 'create', array(
+      'title' => 'TestGettree',
+      'extends' => 'Individual',
+    ));
+    $cf = $this->callAPISuccess('CustomField', 'create', array(
+      'custom_group_id' => $cg['id'],
+      'label' => 'Got Options',
+      'name' => 'got_options',
+      "data_type" => "String",
+      "html_type" => "Multi-Select",
+      'option_values' => array('1' => 'One', '2' => 'Two', '3' => 'Three'),
+    ));
+    $fieldName = 'custom_' . $cf['id'];
+    $contact = $this->individualCreate(array($fieldName => array('2', '3')));
+    $tree = $this->callAPISuccess('CustomValue', 'gettree', array('entity_type' => 'Contact', 'entity_id' => $contact));
+    $this->assertEquals(array('2', '3'), $tree['values']['TestGettree']['fields']['got_options']['value']['data']);
+    $this->assertEquals('Two, Three', $tree['values']['TestGettree']['fields']['got_options']['value']['display']);
+  }
+
 }


### PR DESCRIPTION
This adds a CustomValue.gettree action which returns the entire tree of custom data for a specified entity -
 groups, fields, and values, including the raw and display values. It's intended for use on Angular screens that do not have access to core BAO functions like `CRM_Core_BAO_CustomGroup::getTree`.

* [CRM-20091: Case inline custom fields](https://issues.civicrm.org/jira/browse/CRM-20091)