### PR TITLE
CRM-20679 Spin the civi logo while quicksearch is running

### DIFF
--- a/templates/CRM/common/navigation.js.tpl
+++ b/templates/CRM/common/navigation.js.tpl
@@ -92,6 +92,8 @@ $('#civicrm-menu').ready(function() {
   $('#sort_name_navigation')
     .autocomplete({
       source: function(request, response) {
+        //start spinning the civi logo
+        $('.crm-logo-sm').addClass('crm-i fa-spin fa-pulse');
         var
           option = $('input[name=quickSearchField]:checked'),
           params = {
@@ -117,6 +119,8 @@ $('#civicrm-menu').ready(function() {
             ret.push({value: '0', label: msg});
           }
           response(ret);
+          //stop spinning the civi logo
+          $('.crm-logo-sm').removeClass('crm-i fa-spin fa-pulse');          
         })
       },
       focus: function (event, ui) {


### PR DESCRIPTION
* [CRM-20679: Make the CiviCRM logo spin while quicksearch is running](https://issues.civicrm.org/jira/browse/CRM-20679)