### PR TITLE
CRM-19226: Fix loginUrl token in drupal for CiviCRM 4.6.x

### DIFF
--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -166,8 +166,8 @@ class CRM_Utils_System_Drupal extends CRM_Utils_System_DrupalBase {
    * @inheritDoc
    */
   public function getLoginURL($destination = '') {
-    $query = $destination ? array('destination' => $destination) : array();
-    return url('user', array('query' => $query), TRUE);
+    $query = $destination ? array('destination' => $destination) : NULL;
+    return CRM_Utils_System::url('user', $query, TRUE);
   }
 
   /**


### PR DESCRIPTION
----------------------------------------
* CRM-19226: $loginUrl token not populating in Drupal 7
  https://issues.civicrm.org/jira/browse/CRM-19226