### PR TITLE
CRM-20692: pass through options.

### DIFF
--- a/ang/crmUi.js
+++ b/ang/crmUi.js
@@ -690,7 +690,8 @@
       return {
         restrict: 'EA',
         scope: {
-          crmUiTabSet: '@'
+          crmUiTabSet: '@',
+          tabSetOptions: '@'
         },
         templateUrl: '~/crmUi/tabset.html',
         transclude: true,

--- a/ang/crmUi/tabset.html
+++ b/ang/crmUi/tabset.html
@@ -1,4 +1,4 @@
-<div ui-jq="tabs" class="crm-tabset">
+<div ui-jq="tabs" ui-options="{{tabSetOptions}}" class="crm-tabset">
   <ul>
     <li ng-repeat="tab in tabs" class="ui-corner-all crm-tab-button crm-count-{{tab.count}}">
       <a href="#{{tab.id}}">


### PR DESCRIPTION
Example:

Template:
```
<div crm-ui-tab-set tab-set-options="{{myTabSetOptions}}">
  <div id="mytab1" crm-ui-tab crm-title="ts('Tab 1')">
    This is Tab 1.
  </div>
  <div id="mytab2" crm-ui-tab crm-title="ts('Tab 2')">
    This is Tab 2.
  </div>
</div>
```

Controller:
```
    $scope.myTabSetOptions = {
      // Make "Tab 2" the selected tab. ("active" option is a zero-based index.)
      "active": 1
    }
```

---

 * [CRM-20692: Support jQuery options in AngularJS crm-ui-tab-set](https://issues.civicrm.org/jira/browse/CRM-20692)