### PR TITLE
CRM-20698 - better CSS for disabled table rows

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -2798,7 +2798,9 @@ tbody.scrollContent tr.alternateRow {
 }
 
 .crm-container .disabled,
+.crm-container .disabled td,
 .crm-container .cancelled,
+.crm-container .cancelled td,
 .crm-container li.disabled a.ui-tabs-anchor,
 .crm-container li.crm-count-0 a.ui-tabs-anchor,
 .crm-container li.crm-count-0 a.ui-tabs-anchor em {


### PR DESCRIPTION
The commonly-used *Drupal Seven* theme (and perhaps others), uses a CSS rule for `td` elements which interferes with some style in `civicrm.css` designed to turn the text within disabled table rows grey. I added a couple new CSS selectors to make CiviCRM's intended style work within themes like this.  

### Before

(All rows look the same, despite the last three being disabled.)

![screenshot55](https://user-images.githubusercontent.com/42411/26906070-0fb4cae4-4ba8-11e7-9ddf-18fefe803c29.png)

### After

(The disabled rows appear with grey text.)

![screenshot57](https://user-images.githubusercontent.com/42411/26906156-9ae9706a-4ba8-11e7-9e84-e70bce670989.png)

---

 * [CRM-20698: Make "disabled" table rows appear greyed-out](https://issues.civicrm.org/jira/browse/CRM-20698)