### PR TITLE
CRM-20706: Notice error on using Contribution.Getfield API

### DIFF
--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -356,7 +356,7 @@ function _civicrm_api3_contribution_get_spec(&$params) {
 
   $params['financial_type_id']['api.aliases'] = array('contribution_type_id');
   $params['payment_instrument_id']['api.aliases'] = array('contribution_payment_instrument', 'payment_instrument');
-  $params['contact_id'] = $params['contribution_contact_id'];
+  $params['contact_id'] = CRM_Utils_Array::value('contribution_contact_id', $params);
   $params['contact_id']['api.aliases'] = array('contribution_contact_id');
   unset($params['contribution_contact_id']);
 }


### PR DESCRIPTION
* [CRM-20706: Notice error on using Contribution.getfield API](https://issues.civicrm.org/jira/browse/CRM-20706)