### PR TITLE
CRM-20710: Add function to return valid types

### DIFF
--- a/CRM/Utils/Type.php
+++ b/CRM/Utils/Type.php
@@ -144,6 +144,28 @@ class CRM_Utils_Type {
   }
 
   /**
+   * @return array
+   *   An array of type in the form 'type name' => 'int representing type'
+   */
+  public static function getValidTypes() {
+    return array(
+      'Int' => self::T_INT,
+      'String' => self::T_STRING,
+      'Enum' => self::T_ENUM,
+      'Date' => self::T_DATE,
+      'Time' => self::T_TIME,
+      'Boolean' => self::T_BOOLEAN,
+      'Text' => self::T_TEXT,
+      'Blob' => self::T_BLOB,
+      'Timestamp' => self::T_TIMESTAMP,
+      'Float' => self::T_FLOAT,
+      'Money' => self::T_MONEY,
+      'Email' => self::T_EMAIL,
+      'Mediumblob' => self::T_MEDIUMBLOB,
+    );
+  }
+
+  /**
    * Get the data_type for the field.
    *
    * @param array $fieldMetadata
@@ -518,7 +540,7 @@ class CRM_Utils_Type {
   }
 
   /**
-   * Get list of avaliable Data Tupes for Option Groups
+   * Get list of avaliable Data Types for Option Groups
    *
    * @return array
    */


### PR DESCRIPTION
To separate validation of data from just validation of type name it would be useful to have a function to return all the valid types. This PR introduces that function.

There is also one minor spelling fix.

---

 * [CRM-20710: Add function to return all valid types](https://issues.civicrm.org/jira/browse/CRM-20710)