### PR TITLE
CRM-20713 - CiviMail - do not set mode = 'sms' if sms_provider_id = 'null'

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1787,7 +1787,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
       // Populate the recipients.
       if (empty($params['_skip_evil_bao_auto_recipients_'])) {
         // check if it's sms
-        $mode = $mailing->sms_provider_id ? 'sms' : NULL;
+        $mode = $mailing->sms_provider_id && $mailing->sms_provider_id != 'null' ? 'sms' : NULL;
         self::getRecipients($job->id, $mailing->id, TRUE, $mailing->dedupe_email, $mode);
       }
       // Schedule the job now that it has recipients.


### PR DESCRIPTION
* [CRM-20713: db error when populating mailing recipients because sms_provider_id is 'null'](https://issues.civicrm.org/jira/browse/CRM-20713)