### PR TITLE
CRM-20716 Fix Array to string error because subject is an array not string

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -2140,6 +2140,10 @@ WHERE      activity.id IN ($activityIds)";
         $membershipType = CRM_Member_PseudoConstant::membershipType($entityObj->membership_type_id);
         $subject = $membershipType ? $membershipType : ts('Membership');
 
+        if (is_array($subject)) {
+          $subject = implode(", ", $subject);
+        }
+
         if (!CRM_Utils_System::isNull($entityObj->source)) {
           $subject .= " - {$entityObj->source}";
         }


### PR DESCRIPTION
* [CRM-20716: Array to string issue on php7 when creating membership activity](https://issues.civicrm.org/jira/browse/CRM-20716)