### PR TITLE
CRM-20243 - bower.json - Upgrade to Angular 1.5.x (Port of Tim's patch)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,11 +5,11 @@
   "license": "AGPL-3.0",
   "private": true,
   "dependencies": {
-    "angular": "~1.3.8",
+    "angular": "~1.5.0",
     "angular-file-upload": ">=1.1.5 <=1.1.6",
     "angular-jquery-dialog-service": "totten/angular-jquery-dialog-service#civicrm",
-    "angular-mocks": "~1.3.8",
-    "angular-route": "~1.3.8",
+    "angular-mocks": "~1.5.0",
+    "angular-route": "~1.5.0",
     "angular-ui-sortable": "0.12.x",
     "angular-ui-utils": "0.1.x",
     "angular-unsavedChanges": "~0.1.1",
@@ -21,9 +21,10 @@
     "google-code-prettify": "~1.0",
     "select2": "colemanw/select2#stable/3.5",
     "jquery-validation": "~1.13",
-    "angular-sanitize": "~1.3.15"
+    "angular-sanitize": "~1.5.0",
+    "phantomjs-polyfill": "^0.0.2"
   },
   "resolutions": {
-    "angular": "~1.3.8"
+    "angular": "~1.5.11"
   }
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -5,6 +5,7 @@ module.exports = function(config) {
     exclude: [
     ],
     files: [
+      'bower_components/phantomjs-polyfill/bind-polyfill.js',
       'bower_components/jquery/dist/jquery.min.js',
       'bower_components/jquery-ui/jquery-ui.min.js',
       'bower_components/lodash-compat/lodash.min.js',


### PR DESCRIPTION
Two reasons:
 * Angular 1.3.x is no longer maintained.
 * This is one step toward bringing the CiviCRM and CiviHR codebases into alignment.

---

 * [CRM-20243](https://issues.civicrm.org/jira/browse/CRM-20243)