### PR TITLE
CRM-20719 : Show warning on system status page if reply_id for mailing is not set to any default

### DIFF
--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -836,6 +836,25 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
   }
 
   /**
+   * ensure reply id is set to any default value
+   * @return array
+   */
+  public function checkReplyIdForMailing() {
+    $messages = array();
+
+    if (!CRM_Mailing_PseudoConstant::defaultComponent('Reply', '')) {
+      $messages[] = new CRM_Utils_Check_Message(
+        __FUNCTION__,
+        ts('Reply Auto Responder is not set to any default value in <a %1>Headers, Footers, and Automated Messages</a>. This will disable the submit operation on any mailing created from CiviMail.', array(1 => 'href="' . CRM_Utils_System::url('civicrm/admin/component', 'reset=1') . '"')),
+        ts('No Default value for Auto Responder.'),
+        \Psr\Log\LogLevel::WARNING,
+        'fa-reply'
+      );
+    }
+    return $messages;
+  }
+
+  /**
    * Check for required mbstring extension
    * @return array
    */


### PR DESCRIPTION
* [CRM-20719: Show warning on system status page if reply_id for mailing is not set to any default.](https://issues.civicrm.org/jira/browse/CRM-20719)