### PR TITLE
There's a better way to say it than "poor man's".

### DIFF
--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -493,8 +493,9 @@ WHERE  id = %1
   /**
    * Do an opportunistic cache refresh if the site is configured for these.
    *
-   * Sites that do not run the smart group clearing cron job should refresh the caches under an opportunistic mode, akin
-   * to a poor man's cron. The user session will be forced to wait on this so it is less desirable.
+   * Sites that do not run the smart group clearing cron job should refresh the
+   * caches on demand. The user session will be forced to wait so it is less
+   * ideal.
    */
   public static function opportunisticCacheFlush() {
     if (Civi::settings()->get('smart_group_cache_refresh_mode') == 'opportunistic') {

--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -489,7 +489,7 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
    * Conditionally fire an event during the first page run.
    *
    * The install system is currently implemented several times, so it's hard to add
-   * new installation logic. We use a poor-man's method to detect the first run.
+   * new installation logic. We use a makeshift method to detect the first run.
    *
    * Situations to test:
    *  - New installation

--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -680,7 +680,8 @@ class CRM_Core_Error extends PEAR_ErrorStack {
   /**
    * Generate the name of the logfile to use and store it as a static.
    *
-   * This function includes poor man's log file management and a check as to whether the file exists.
+   * This function includes simplistic log rotation and a check as to whether
+   * the file exists.
    *
    * @param string $prefix
    */
@@ -693,9 +694,9 @@ class CRM_Core_Error extends PEAR_ErrorStack {
       $hash = self::generateLogFileHash($config);
       $fileName = $config->configAndLogDir . 'CiviCRM.' . $prefixString . $hash . '.log';
 
-      // Roll log file monthly or if greater than 256M
-      // note that PHP file functions have a limit of 2G and hence
-      // the alternative was introduce
+      // Roll log file monthly or if greater than 256M.
+      // Size-based rotation introduced in response to filesize limits on
+      // certain OS/PHP combos.
       if (file_exists($fileName)) {
         $fileTime = date("Ym", filemtime($fileName));
         $fileSize = filesize($fileName);

--- a/CRM/Import/DataSource/SQL.php
+++ b/CRM/Import/DataSource/SQL.php
@@ -81,7 +81,7 @@ class CRM_Import_DataSource_SQL extends CRM_Import_DataSource {
   public static function formRule($fields, $files, $form) {
     $errors = array();
 
-    // poor man's query validation (case-insensitive regex matching on word boundaries)
+    // Makeshift query validation (case-insensitive regex matching on word boundaries)
     $forbidden = array('ALTER', 'CREATE', 'DELETE', 'DESCRIBE', 'DROP', 'SHOW', 'UPDATE', 'information_schema');
     foreach ($forbidden as $pattern) {
       if (preg_match("/\\b$pattern\\b/i", $fields['sqlQuery'])) {

--- a/CRM/Utils/VersionCheck.php
+++ b/CRM/Utils/VersionCheck.php
@@ -33,7 +33,7 @@
 class CRM_Utils_VersionCheck {
   const
     CACHEFILE_NAME = 'version-info-cache.json',
-    // after this length of time we fall back on poor-man's cron (7+ days)
+    // After which length of time we expire the cached version info (7+ days).
     CACHEFILE_EXPIRE = 605000;
 
   /**
@@ -106,7 +106,7 @@ class CRM_Utils_VersionCheck {
     // Populate remote $versionInfo from cache file
     $this->isInfoAvailable = $this->readCacheFile();
 
-    // Poor-man's cron fallback if scheduled job is enabled but has failed to run
+    // Fallback if scheduled job is enabled but has failed to run.
     $expiryTime = time() - self::CACHEFILE_EXPIRE;
     if (!empty($this->cronJob['is_active']) &&
       (!$this->isInfoAvailable || filemtime($this->cacheFile) < $expiryTime)


### PR DESCRIPTION
"Makeshift", "simplistic" or "inferior" are effective ways to describe a solution you think is less than ideal.

Using the phrase "poor man's" for those meanings suggests to me that poor people get/deserve inferior things, which IMO is incongruous with CiviCRM's goals. Also, why "man"? 🤷‍♂️ 

Avoiding that terminology won't just be more inclusive, it will better express what you really meant!

This PR contains comment changes only. There is no JIRA associated with this PR.