### PR TITLE
CRM-20728: Store session in drupal before exiting

### DIFF
--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1404,6 +1404,14 @@ class CRM_Utils_System {
     // move things to CiviCRM cache as needed
     CRM_Core_Session::storeSessionObjects();
 
+    if (Civi\Core\Container::isContainerBooted()) {
+      Civi::dispatcher()->dispatch('civi.core.exit');
+    }
+
+    $userSystem = CRM_Core_Config::singleton()->userSystem;
+    if (is_callable(array($userSystem, 'onCiviExit'))) {
+      $userSystem->onCiviExit();
+    }
     exit($status);
   }
 

--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -842,4 +842,15 @@ AND    u.status = 1
     );
   }
 
+  /**
+   * Commit the session before exiting.
+   * Similar to drupal_exit().
+   */
+  public function onCiviExit() {
+    if (!defined('MAINTENANCE_MODE') || MAINTENANCE_MODE != 'update') {
+      module_invoke_all('exit');
+    }
+    drupal_session_commit();
+  }
+
 }


### PR DESCRIPTION
Based on discussion in https://github.com/eileenmcnaughton/nz.co.fuzion.omnipaymultiprocessor/pull/30 - anonymous sessions via webforms are not stored in drupal session table before navigating to the payment page, hence after returning from the site, the session variables eg return urls are lost.

This change follows the same exit protocol as `drupal_exit()` which commits the session before exiting.

---

 * [CRM-20728: Store session in drupal session table before exiting](https://issues.civicrm.org/jira/browse/CRM-20728)