### PR TITLE
CRM-19303 - Drupal - Fix computation of `civicrm.files` on multisite

### DIFF
--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -593,15 +593,6 @@ abstract class CRM_Utils_System_Base {
       $tempURL = str_replace("/administrator/", "/", $baseURL);
       $filesURL = $tempURL . "media/civicrm/";
     }
-    elseif ($this->is_drupal) {
-      $siteName = $config->userSystem->parseDrupalSiteName($civicrm_root);
-      if ($siteName) {
-        $filesURL = $baseURL . "sites/$siteName/files/civicrm/";
-      }
-      else {
-        $filesURL = $baseURL . "sites/default/files/civicrm/";
-      }
-    }
     elseif ($config->userFramework == 'UnitTests') {
       $filesURL = $baseURL . "sites/default/files/civicrm/";
     }
@@ -647,23 +638,6 @@ abstract class CRM_Utils_System_Base {
     }
     elseif ($config->userFramework == 'WordPress') {
       $userFrameworkResourceURL = CIVICRM_PLUGIN_URL . "civicrm/";
-    }
-    elseif ($this->is_drupal) {
-      // Drupal setting
-      // check and see if we are installed in sites/all (for D5 and above)
-      // we dont use checkURL since drupal generates an error page and throws
-      // the system for a loop on lobo's macosx box
-      // or in modules
-      $cmsPath = $config->userSystem->cmsRootPath();
-      $userFrameworkResourceURL = $baseURL . str_replace("$cmsPath/", '',
-          str_replace('\\', '/', $civicrm_root)
-        );
-
-      $siteName = $config->userSystem->parseDrupalSiteName($civicrm_root);
-      if ($siteName) {
-        $civicrmDirName = trim(basename($civicrm_root));
-        $userFrameworkResourceURL = $baseURL . "sites/$siteName/modules/$civicrmDirName/";
-      }
     }
     else {
       $userFrameworkResourceURL = NULL;

--- a/Civi/Core/Paths.php
+++ b/Civi/Core/Paths.php
@@ -78,6 +78,9 @@ class Paths {
   public function getVariable($name, $attr) {
     if (!isset($this->variables[$name])) {
       $this->variables[$name] = call_user_func($this->variableFactory[$name]);
+      if (isset($GLOBALS['civicrm_paths'][$name])) {
+        $this->variables[$name] = array_merge($this->variables[$name], $GLOBALS['civicrm_paths'][$name]);
+      }
     }
     if (!isset($this->variables[$name][$attr])) {
       throw new \RuntimeException("Cannot resolve path using \"$name.$attr\"");


### PR DESCRIPTION
Description
-----------

Improve computation of `[civicrm.files]` URL and path when using Drupal
multisite.

A good way to test this is to open multiple tabs:
 * Open `civicrm/admin/setting/url?reset=1` (one tab for each site)
 * Open `civicrm/admin/setting/path?reset=1` (one tab for each site)
 * In each tab, click the "?" help icon and view the variable definitions

Before
------

The `[civicrm.files]` path/URL would always return the `default`
(e.g. `http://example.org/sites/default/civicrm/files`).

The path and URL for `[civicrm.files]` and `[civicrm.root]` are always computed.

After
-----

If a folder named `sites/{$NAME}/civicrm/files` exists, it
will be used. Otherwise, the folder `sites/default/files/civicrm`
will be used.

The path and URL for `[civicrm.files]` and `[civicrm.root]` are computed *by default*. However, as a last-resort, you can explicitly set these variables in `civicrm.settings.php`, as in:

```php
$GLOBALS['civicrm_paths']['civicrm.files'] = array(
  'path' => '/var/www/dmaster/civifiles/',
  'url' => 'http://dmaster.l/civifiles/',
);
```

---

 * [CRM-19303: CKEditor configuration can't be edited on a Drupal multisite installation](https://issues.civicrm.org/jira/browse/CRM-19303)