### PR TITLE
CRM-20740 - Fix issue with check for custom_nn => ['IS NULL' => 1].

### DIFF
--- a/Civi/API/Api3SelectQuery.php
+++ b/Civi/API/Api3SelectQuery.php
@@ -91,7 +91,7 @@ class Api3SelectQuery extends SelectQuery {
       elseif (($cf_id = \CRM_Core_BAO_CustomField::getKeyID($key)) != FALSE) {
         // If we check a custom field on 'IS NULL', it should also work when there is no
         // record in the custom value table, see CRM-20740.
-        $side = empty($value['IS NULL']) ? 'INNER': 'LEFT OUTER';
+        $side = empty($value['IS NULL']) ? 'INNER' : 'LEFT OUTER';
         list($table_name, $column_name) = $this->addCustomField($this->apiFieldSpec['custom_' . $cf_id], $side);
       }
       elseif (strpos($key, '.')) {

--- a/Civi/API/Api3SelectQuery.php
+++ b/Civi/API/Api3SelectQuery.php
@@ -89,7 +89,10 @@ class Api3SelectQuery extends SelectQuery {
         $column_name = $key;
       }
       elseif (($cf_id = \CRM_Core_BAO_CustomField::getKeyID($key)) != FALSE) {
-        list($table_name, $column_name) = $this->addCustomField($this->apiFieldSpec['custom_' . $cf_id], 'INNER');
+        // If we check a custom field on 'IS NULL', it should also work when there is no
+        // record in the custom value table, see CRM-20740.
+        $side = empty($value['IS NULL']) ? 'INNER': 'LEFT OUTER';
+        list($table_name, $column_name) = $this->addCustomField($this->apiFieldSpec['custom_' . $cf_id], $side);
       }
       elseif (strpos($key, '.')) {
         $fkInfo = $this->addFkField($key, 'INNER');

--- a/tests/phpunit/api/v3/EventTest.php
+++ b/tests/phpunit/api/v3/EventTest.php
@@ -421,7 +421,7 @@ class api_v3_EventTest extends CiviUnitTestCase {
     // Search for events having NULL as the value for this custom
     // field. This should return all events created in setUp.
     $check = $this->callAPISuccess($this->_entity, 'get', array(
-        'custom_' . $ids['custom_field_id'] => ['IS NULL' => 1],
+        'custom_' . $ids['custom_field_id'] => array('IS NULL' => 1),
       ));
 
     $this->assertGreaterThan(0, $check['count']);

--- a/tests/phpunit/api/v3/EventTest.php
+++ b/tests/phpunit/api/v3/EventTest.php
@@ -410,6 +410,27 @@ class api_v3_EventTest extends CiviUnitTestCase {
   }
 
   /**
+   * Check searching on custom fields with IS NULL.
+   *
+   * https://issues.civicrm.org/jira/browse/CRM-20740
+   */
+  public function testSearchCustomFieldIsNull() {
+    // create custom group with custom field on event
+    $ids = $this->entityCustomGroupWithSingleFieldCreate(__FUNCTION__, __FILE__);
+
+    // Search for events having NULL as the value for this custom
+    // field. This should return all events created in setUp.
+    $check = $this->callAPISuccess($this->_entity, 'get', array(
+        'custom_' . $ids['custom_field_id'] => ['IS NULL' => 1],
+      ));
+
+    $this->assertGreaterThan(0, $check['count']);
+
+    $this->customFieldDelete($ids['custom_field_id']);
+    $this->customGroupDelete($ids['custom_group_id']);
+  }
+
+  /**
    * Test searching on custom fields returning a contact reference.
    *
    * https://issues.civicrm.org/jira/browse/CRM-16036


### PR DESCRIPTION
This is a quick fix for CRM-20740. Using the API to retrieve entities with a custom field that IS NULL, now also works when there are entities without custom values in the custom field set.

A test would be nice. If I find the time, I will create one.

---

 * [CRM-20740: Api fails to check on custom field is null in some cases](https://issues.civicrm.org/jira/browse/CRM-20740)