### PR TITLE
CRM-20670 (NFC) Style alter as per Eileen

### DIFF
--- a/CRM/Member/Form/MembershipType.php
+++ b/CRM/Member/Form/MembershipType.php
@@ -188,7 +188,7 @@ class CRM_Member_Form_MembershipType extends CRM_Member_Form_MembershipConfig {
     $membershipRecords = FALSE;
     if ($this->_action & CRM_Core_Action::UPDATE) {
       $result = civicrm_api3("Membership", "get", array("membership_type_id" => $this->_id, "options" => array("limit" => 1)));
-      $membershipRecords = $result["count"] > 0;
+      $membershipRecords = ($result["count"] > 0);
       if ($membershipRecords) {
         $memberRel->freeze();
       }


### PR DESCRIPTION
ping @eileenmcnaughton

---

 * [CRM-20670: Cannot edit membership type if lots of members already exist](https://issues.civicrm.org/jira/browse/CRM-20670)