### PR TITLE
CRM-20091 - Fix return value in api.customValue.gettree

### DIFF
--- a/api/v3/CustomValue.php
+++ b/api/v3/CustomValue.php
@@ -363,13 +363,13 @@ function civicrm_api3_custom_value_gettree($params) {
       unset($field['customValue']);
       if (!empty($fieldInfo['customValue'])) {
         $field['value'] = CRM_Utils_Array::first($fieldInfo['customValue']);
+        if (!$toReturn['custom_value'] || in_array('display', $toReturn['custom_value'])) {
+          $field['value']['display'] = CRM_Core_BAO_CustomField::displayValue($field['value']['data'], $fieldInfo);
+        }
         foreach (array_keys($field['value']) as $key) {
           if ($toReturn['custom_value'] && !in_array($key, $toReturn['custom_value'])) {
             unset($field['value'][$key]);
           }
-        }
-        if (!$toReturn['custom_value'] || in_array('display', $toReturn['custom_value'])) {
-          $field['value']['display'] = CRM_Core_BAO_CustomField::displayValue($field['value']['data'], $fieldInfo);
         }
       }
       if (empty($params['sequential'])) {

--- a/tests/phpunit/api/v3/CustomValueTest.php
+++ b/tests/phpunit/api/v3/CustomValueTest.php
@@ -428,7 +428,19 @@ class api_v3_CustomValueTest extends CiviUnitTestCase {
       ),
     ));
     $this->assertEquals(array('2', '3'), $tree['values']['TestGettree']['fields']['got_options']['value']['data']);
+    $this->assertEquals('Two, Three', $tree['values']['TestGettree']['fields']['got_options']['value']['display']);
     $this->assertEquals(array('id', 'fields'), array_keys($tree['values']['TestGettree']));
+
+    // Ensure display values are returned even if data is not
+    $tree = $this->callAPISuccess('CustomValue', 'gettree', array(
+      'entity_type' => 'Contact',
+      'entity_id' => $contact,
+      'return' => array(
+        'custom_value.display',
+      ),
+    ));
+    $this->assertEquals('Two, Three', $tree['values']['TestGettree']['fields']['got_options']['value']['display']);
+    $this->assertFalse(isset($tree['values']['TestGettree']['fields']['got_options']['value']['data']));
 
     // Verify that custom set appears for individuals even who don't have any custom data
     $contact2 = $this->individualCreate();


### PR DESCRIPTION
* [CRM-20091: Case custom fields blocks](https://issues.civicrm.org/jira/browse/CRM-20091)