### PR TITLE
CRM-20720 CRM-20757 Fix issue where Price Options were not being sort…

### DIFF
--- a/CRM/Price/Page/Option.php
+++ b/CRM/Price/Page/Option.php
@@ -128,6 +128,7 @@ class CRM_Price_Page_Option extends CRM_Core_Page {
         'check_permissions' => FALSE,
         'options' => array(
           'limit' => 0,
+          'sort' => array('weight', 'label'),
         ),
     ));
     $customOption = $priceOptions['values'];


### PR DESCRIPTION
…ed by weight

@agileware Folks can you give this a test and see what happens in some limited testing i have been doing seems to suggest this fixes the problem

- [CRM-20720 Unable to sort Price Options for Price Fieldset. Weight values are not being set at all in database.](https://issues.civicrm.org/jira/browse/CRM-20720)
- [CRM-20757 Price Field Options do not update order on change on weight in browse page](https://issues.civicrm.org/jira/browse/CRM-20757)