### PR TITLE
CRM-20756 - Add Angular `ui.bootstrap` library

### DIFF
--- a/Civi/Angular/Manager.php
+++ b/Civi/Angular/Manager.php
@@ -89,6 +89,7 @@ class Manager {
       $angularModules['ngRoute'] = include "$civicrm_root/ang/ngRoute.ang.php";
       $angularModules['ngSanitize'] = include "$civicrm_root/ang/ngSanitize.ang.php";
       $angularModules['ui.utils'] = include "$civicrm_root/ang/ui.utils.ang.php";
+      $angularModules['ui.bootstrap'] = include "$civicrm_root/ang/ui.bootstrap.ang.php";
       $angularModules['ui.sortable'] = include "$civicrm_root/ang/ui.sortable.ang.php";
       $angularModules['unsavedChanges'] = include "$civicrm_root/ang/unsavedChanges.ang.php";
       $angularModules['statuspage'] = include "$civicrm_root/ang/crmStatusPage.ang.php";

--- a/ang/ui.bootstrap.ang.php
+++ b/ang/ui.bootstrap.ang.php
@@ -1,0 +1,11 @@
+<?php
+// This file declares an Angular module which can be autoloaded
+// in CiviCRM. See also:
+// http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
+
+return array(
+  'ext' => 'civicrm',
+  'basePages' => array(),
+  'js' => array('bower_components/angular-bootstrap/ui-bootstrap-tpls.min.js'),
+  'css' => array('bower_components/angular-bootstrap/ui-bootstrap-csp.css', 'ang/ui.bootstrap.css'),
+);

--- a/ang/ui.bootstrap.css
+++ b/ang/ui.bootstrap.css
@@ -1,0 +1,1 @@
+.nav, .pagination, .carousel, .panel-title a { cursor: pointer; }

--- a/bower.json
+++ b/bower.json
@@ -25,6 +25,7 @@
     "jstree": "~3",
     "ckeditor": "~4.5",
     "font-awesome": "~4",
+    "angular-bootstrap": "^2.5.0",
     "angular-sanitize": "~1.5.0",
     "phantomjs-polyfill": "^0.0.2"
   },


### PR DESCRIPTION
This adds the library [ui.bootstrap](https://angular-ui.github.io/bootstrap/), which makes it easier to include the functional elements of Bootstrap in AngularJS pages.

In the past, adding this was problematic, but now the situation has improved:

1.  civicrm-core has upgraded to AngularJS 1.5.  (In the past, civicrm-core
used AngularJS 1.3, which was incompatible.)

2.  civicrm-core allows optional AngularJS modules.  (In the past, all
modules were loaded unconditionally, which could result in loading
new/unnecessary code for legacy users.  Now, you can opt-out of this
behavior with `basePages=>array()`.)

---

 * [CRM-20756: Multi tab structure](https://issues.civicrm.org/jira/browse/CRM-20756)