### PR TITLE
CRM-20761 : Formrule error when priceset is selected on contribution page

### DIFF
--- a/CRM/Contribute/Form/ContributionPage/Amount.php
+++ b/CRM/Contribute/Form/ContributionPage/Amount.php
@@ -351,7 +351,7 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
     }
 
     //check for the amount label (mandatory)
-    if (!empty($fields['amount_block_is_active']) && empty($fields['amount_label'])) {
+    if (!empty($fields['amount_block_is_active']) && empty($fields['price_set_id']) && empty($fields['amount_label'])) {
       $errors['amount_label'] = ts('Please enter the contribution amount label.');
     }
     $minAmount = CRM_Utils_Array::value('min_amount', $fields);

--- a/templates/CRM/Contribute/Form/ContributionPage/Amount.tpl
+++ b/templates/CRM/Contribute/Form/ContributionPage/Amount.tpl
@@ -160,7 +160,7 @@
                 {if $futurePaymentProcessor}
                     <tr id="adjustRecurringFields" class="crm-contribution-form-block-adjust_recur_start_date"><th scope="row" class="label">{$form.adjust_recur_start_date.label}</th>
                         <td>{$form.adjust_recur_start_date.html}<br/>
-			  <div id="recurDefaults">
+                          <div id="recurDefaults">
                             <span class="description">{$form.pledge_default_toggle.label}</span>
                             <table class="form-layout-compressed">
                               <tr class="crm-contribution-form-block-date_of_recurring_contribution">
@@ -345,6 +345,9 @@
       case 'price_set_id':
         if (element) {
           cj('#amountFields').hide();
+        }
+        else {
+          cj('#amountFields').show();
         }
         break;
 


### PR DESCRIPTION
This also fixes amount field not loading when priceset is set to none caused by #10521.

---

 * [CRM-20761: Formrule error when priceset is selected on contribution page](https://issues.civicrm.org/jira/browse/CRM-20761)