### PR TITLE
CRM-20765 - Missing id for 'onBehalfOfOrg' section

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -184,7 +184,7 @@
       <div class="clear"></div>
     </div>
 
-    <div class="crm-public-form-item crm-section">
+    <div id='onBehalfOfOrg' class="crm-public-form-item crm-section">
       {include file="CRM/Contribute/Form/Contribution/OnBehalfOf.tpl"}
     </div>
 


### PR DESCRIPTION
* [CRM-20765: Missing id for 'onBehalfOfOrg' section](https://issues.civicrm.org/jira/browse/CRM-20765)