### PR TITLE
CRM-20768 - Install UI - Accept mysql port

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -551,6 +551,30 @@ class InstallRequirements {
   }
 
   /**
+   * Connect via mysqli.
+   *
+   * This is exactly the same as mysqli_connect(), except that it accepts
+   * the port as part of the `$host`.
+   *
+   * @param $host
+   * @param $username
+   * @param $password
+   * @param string $database
+   * @return \mysqli
+   */
+  protected function connect($host, $username, $password, $database = '') {
+    $hostParts = explode(':', $host);
+    if (count($hostParts) > 1) {
+      list ($host, $port) = $hostParts;
+    }
+    else {
+      $port = '';
+    }
+    $conn = @mysqli_connect($host, $username, $password, $database, $port);
+    return $conn;
+  }
+
+  /**
    * Check everything except the database.
    */
   public function check() {
@@ -950,7 +974,7 @@ class InstallRequirements {
    */
   public function requireMysqlConnection($server, $username, $password, $testDetails) {
     $this->testing($testDetails);
-    $this->conn = @mysqli_connect($server, $username, $password);
+    $this->conn = $this->connect($server, $username, $password);
 
     if ($this->conn) {
       return TRUE;
@@ -967,7 +991,7 @@ class InstallRequirements {
    */
   public function requireMySQLServer($server, $testDetails) {
     $this->testing($testDetails);
-    $conn = @mysqli_connect($server, NULL, NULL);
+    $conn = $this->connect($server, NULL, NULL);
 
     if ($conn || mysqli_connect_errno() < 2000) {
       return TRUE;
@@ -1012,7 +1036,7 @@ class InstallRequirements {
    */
   public function requireMySQLInnoDB($server, $username, $password, $database, $testDetails) {
     $this->testing($testDetails);
-    $conn = @mysqli_connect($server, $username, $password);
+    $conn = $this->connect($server, $username, $password);
     if (!$conn) {
       $testDetails[2] .= ' ' . ts("Could not determine if MySQL has InnoDB support. Assuming no.");
       $this->error($testDetails);
@@ -1047,7 +1071,7 @@ class InstallRequirements {
    */
   public function requireMySQLTempTables($server, $username, $password, $database, $testDetails) {
     $this->testing($testDetails);
-    $conn = @mysqli_connect($server, $username, $password);
+    $conn = $this->connect($server, $username, $password);
     if (!$conn) {
       $testDetails[2] = ts('Could not login to the database.');
       $this->error($testDetails);
@@ -1077,7 +1101,7 @@ class InstallRequirements {
    */
   public function requireMySQLTrigger($server, $username, $password, $database, $testDetails) {
     $this->testing($testDetails);
-    $conn = @mysqli_connect($server, $username, $password);
+    $conn = $this->connect($server, $username, $password);
     if (!$conn) {
       $testDetails[2] = ts('Could not login to the database.');
       $this->error($testDetails);
@@ -1117,7 +1141,7 @@ class InstallRequirements {
    */
   public function requireMySQLLockTables($server, $username, $password, $database, $testDetails) {
     $this->testing($testDetails);
-    $conn = @mysqli_connect($server, $username, $password);
+    $conn = $this->connect($server, $username, $password);
     if (!$conn) {
       $testDetails[2] = ts('Could not connect to the database server.');
       $this->error($testDetails);
@@ -1164,7 +1188,7 @@ class InstallRequirements {
    */
   public function requireMySQLAutoIncrementIncrementOne($server, $username, $password, $testDetails) {
     $this->testing($testDetails);
-    $conn = @mysqli_connect($server, $username, $password);
+    $conn = $this->connect($server, $username, $password);
     if (!$conn) {
       $testDetails[2] = ts('Could not connect to the database server.');
       $this->error($testDetails);
@@ -1198,7 +1222,7 @@ class InstallRequirements {
    */
   public function requireMySQLThreadStack($server, $username, $password, $database, $minValueKB, $testDetails) {
     $this->testing($testDetails);
-    $conn = @mysqli_connect($server, $username, $password);
+    $conn = $this->connect($server, $username, $password);
     if (!$conn) {
       $testDetails[2] = ts('Could not connect to the database server.');
       $this->error($testDetails);
@@ -1242,7 +1266,7 @@ class InstallRequirements {
     $onlyRequire = FALSE
   ) {
     $this->testing($testDetails);
-    $conn = @mysqli_connect($server, $username, $password);
+    $conn = $this->connect($server, $username, $password);
 
     $okay = NULL;
     if (@mysqli_select_db($conn, $database)) {
@@ -1381,7 +1405,7 @@ class Installer extends InstallRequirements {
    * @param $database
    */
   public function createDatabaseIfNotExists($server, $username, $password, $database) {
-    $conn = @mysqli_connect($server, $username, $password);
+    $conn = $this->connect($server, $username, $password);
 
     if (@mysqli_select_db($conn, $database)) {
       // skip if database already present


### PR DESCRIPTION
== Background ==

In previous releases, the web-based installation script allowed you to enter
the MySQL "server" with a `host:port` combination (e.g.  `127.0.0.1:3307`).

I believe this regressed during the mysql=>mysqli transition.

== Before ==

If you use the web-based install UI and enter a `host:port` combination, the
error messages indicate a confusing mix of information (e.g.  some
indicating port 3306, some indicating port 3307).

== After ==

If you use the web-based install UI and enter a `host:port` combination, it
uses the specified port.

----------------------------------------
* CRM-20768: Web-based installation should accept non-standard MySQL port
  https://issues.civicrm.org/jira/browse/CRM-20768