### PR TITLE
CRM-20774 - Add check for existing key index in table

### DIFF
--- a/CRM/Utils/Check/Component/Schema.php
+++ b/CRM/Utils/Check/Component/Schema.php
@@ -54,7 +54,7 @@ class CRM_Utils_Check_Component_Schema extends CRM_Utils_Check_Component {
     }
     if ($missingIndices || $existingKeyIndices) {
       $message = "You have missing indices on some tables. This may cause poor performance.";
-      if ($keyMessage) {
+      if (!empty($keyMessage)) {
         $message = $keyMessage;
       }
       $msg = new CRM_Utils_Check_Message(

--- a/CRM/Utils/Check/Component/Schema.php
+++ b/CRM/Utils/Check/Component/Schema.php
@@ -37,11 +37,29 @@ class CRM_Utils_Check_Component_Schema extends CRM_Utils_Check_Component {
    */
   public function checkIndices() {
     $messages = array();
-    $missingIndices = CRM_Core_BAO_SchemaHandler::getMissingIndices();
-    if ($missingIndices) {
+    list($missingIndices, $existingKeyIndices) = CRM_Core_BAO_SchemaHandler::getMissingIndices();
+    if ($existingKeyIndices) {
+      $html = '';
+      foreach ($existingKeyIndices as $tableName => $indices) {
+        foreach ($indices as $index) {
+          $fields = implode(', ', $index['field']);
+          $html .= "<tr><td>{$tableName}</td><td>{$index['name']}</td><td>$fields</td>";
+        }
+      }
+      $keyMessage = "<p>The following tables have an index key with a mismatch in value. Please delete the key indices listed from the below table and then click on 'Update Indices' button. <p>
+        <p><table><thead><tr><th>Table Name</th><th>Key Name</th><th>Fields</th>
+        </tr></thead><tbody>
+        $html
+        </tbody></table></p>";
+    }
+    if ($missingIndices || $existingKeyIndices) {
+      $message = "You have missing indices on some tables. This may cause poor performance.";
+      if ($keyMessage) {
+        $message = $keyMessage;
+      }
       $msg = new CRM_Utils_Check_Message(
         __FUNCTION__,
-        ts('You have missing indices on some tables. This may cause poor performance.'),
+        ts($message),
         ts('Performance warning: Missing indices'),
         \Psr\Log\LogLevel::WARNING,
         'fa-server'

--- a/api/v3/System.php
+++ b/api/v3/System.php
@@ -408,6 +408,7 @@ function civicrm_api3_system_updatelogtables() {
  * This adds any indexes that exist in the schema but not the database.
  */
 function civicrm_api3_system_updateindexes() {
-  CRM_Core_BAO_SchemaHandler::createMissingIndices(CRM_Core_BAO_SchemaHandler::getMissingIndices());
+  list($missingIndices) = CRM_Core_BAO_SchemaHandler::getMissingIndices();
+  CRM_Core_BAO_SchemaHandler::createMissingIndices($missingIndices);
   return civicrm_api3_create_success(1);
 }

--- a/tests/phpunit/CRM/Core/BAO/SchemaHandlerTest.php
+++ b/tests/phpunit/CRM/Core/BAO/SchemaHandlerTest.php
@@ -184,7 +184,7 @@ class CRM_Core_BAO_SchemaHandlerTest extends CiviUnitTestCase {
    * Check there are no missing indices
    */
   public function testGetMissingIndices() {
-    $missingIndices = CRM_Core_BAO_SchemaHandler::getMissingIndices();
+    list($missingIndices) = CRM_Core_BAO_SchemaHandler::getMissingIndices();
     $this->assertTrue(empty($missingIndices));
   }
 
@@ -230,7 +230,7 @@ class CRM_Core_BAO_SchemaHandlerTest extends CiviUnitTestCase {
    */
   public function testReconcileMissingIndices() {
     CRM_Core_DAO::executeQuery('ALTER TABLE civicrm_contact DROP INDEX index_sort_name');
-    $missingIndices = CRM_Core_BAO_SchemaHandler::getMissingIndices();
+    list($missingIndices) = CRM_Core_BAO_SchemaHandler::getMissingIndices();
     $this->assertEquals(array(
       'civicrm_contact' => array(
         array(
@@ -242,7 +242,7 @@ class CRM_Core_BAO_SchemaHandlerTest extends CiviUnitTestCase {
       ),
     ), $missingIndices);
     $this->callAPISuccess('System', 'updateindexes', array());
-    $missingIndices = CRM_Core_BAO_SchemaHandler::getMissingIndices();
+    list($missingIndices) = CRM_Core_BAO_SchemaHandler::getMissingIndices();
     $this->assertTrue(empty($missingIndices));
   }
 


### PR DESCRIPTION
`getMissingIndices()` retrieves the indices based on the value and not on the key. So there is a possibility that it'll also fetch the value -

- if they exist in wrong order.
- some column missing for the index key.

For eg.

    $requiredIndex = index_all - (cacheKey, entity1, entity2, entity3, is_selected).

    $existingIndex = index_all - (cacheKey, entity1, entity2, entity3).

As `is_selected` is not in the table, `updateindices` would attempt to re-create the index which will lead to duplicate `index_all` key error.

This PR displays the existing keys on system status page and ask the user to drop the index so that civi creates the correct one with all columns again.

Test added.

---

 * [CRM-20774: Add check for existing index keys\(different values\) while creating missing indices.](https://issues.civicrm.org/jira/browse/CRM-20774)