### PR TITLE
CRM-20243 - Actively remove old files

### DIFF
--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -567,6 +567,13 @@ SET    version = '$version'
       'reset' => TRUE,
     ));
 
+    $task = new CRM_Queue_Task(
+      array('CRM_Upgrade_Form', 'doFileCleanup'),
+      array($postUpgradeMessageFile),
+      "Cleanup old files"
+    );
+    $queue->createItem($task);
+
     $revisions = $upgrade->getRevisionSequence();
     foreach ($revisions as $rev) {
       // proceed only if $currentVer < $rev
@@ -601,6 +608,47 @@ SET    version = '$version'
     }
 
     return $queue;
+  }
+
+  /**
+   * Find any old, orphaned files that should have been deleted.
+   *
+   * These files can get left behind, eg, if you use the Joomla
+   * upgrade procedure.
+   *
+   * The earlier we can do this, the better - don't want upgrade logic
+   * to inadvertently rely on old/relocated files.
+   *
+   * @param \CRM_Queue_TaskContext $ctx
+   * @param string $postUpgradeMessageFile
+   * @return bool
+   */
+  public static function doFileCleanup(CRM_Queue_TaskContext $ctx, $postUpgradeMessageFile) {
+    $source = new CRM_Utils_Check_Component_Source();
+    $files = $source->findOrphanedFiles();
+    $errors = array();
+    foreach ($files as $file) {
+      if (is_dir($file['path'])) {
+        @rmdir($file['path']);
+      }
+      else {
+        @unlink($file['path']);
+      }
+
+      if (file_exists($file['path'])) {
+        $errors[] = sprintf("<li>%s</li>", htmlentities($file['path']));
+      }
+    }
+
+    if (!empty($errors)) {
+      file_put_contents($postUpgradeMessageFile,
+        '<br/><br/>' . ts('Some old files could not be removed. Please remove them.')
+        . '<ul>' . implode("\n", $errors) . '</ul>',
+        FILE_APPEND
+      );
+    }
+
+    return TRUE;
   }
 
   /**

--- a/CRM/Utils/Check/Component/Source.php
+++ b/CRM/Utils/Check/Component/Source.php
@@ -1,0 +1,129 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2017                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2017
+ */
+class CRM_Utils_Check_Component_Source extends CRM_Utils_Check_Component {
+
+  public function getRemovedFiles() {
+    $files[] = '[civicrm.packages]/Auth/SASL';
+    $files[] = '[civicrm.packages]/Auth/SASL.php';
+    $files[] = '[civicrm.packages]/Auth/SASL/Anonymous.php';
+    $files[] = '[civicrm.packages]/Auth/SASL/Common.php';
+    $files[] = '[civicrm.packages]/Auth/SASL/CramMD5.php';
+    $files[] = '[civicrm.packages]/Auth/SASL/DigestMD5.php';
+    $files[] = '[civicrm.packages]/Auth/SASL/External.php';
+    $files[] = '[civicrm.packages]/Auth/SASL/Login.php';
+    $files[] = '[civicrm.packages]/Auth/SASL/Plain.php';
+    $files[] = '[civicrm.packages]/Net/SMTP.php';
+    $files[] = '[civicrm.packages]/Net/Socket.php';
+    $files[] = '[civicrm.packages]/_ORIGINAL_/Net/SMTP.php';
+    $files[] = '[civicrm.packages]/jquery/plugins/DataTables/Readme.md';
+    $files[] = '[civicrm.packages]/jquery/plugins/DataTables/license.txt';
+    $files[] = '[civicrm.packages]/jquery/plugins/DataTables/media/css/jquery.dataTables.css';
+    $files[] = '[civicrm.packages]/jquery/plugins/DataTables/media/css/jquery.dataTables.min.css';
+    $files[] = '[civicrm.packages]/jquery/plugins/DataTables/media/css/jquery.dataTables_themeroller.css';
+    $files[] = '[civicrm.packages]/jquery/plugins/DataTables/media/js/jquery.dataTables.js';
+    $files[] = '[civicrm.packages]/jquery/plugins/DataTables/media/js/jquery.dataTables.min.js';
+    $files[] = '[civicrm.packages]/jquery/plugins/DataTables/media/js/jquery.js';
+    $files[] = '[civicrm.vendor]/pear/net_smtp/examples';
+    $files[] = '[civicrm.vendor]/pear/net_smtp/tests';
+    $files[] = '[civicrm.vendor]/pear/net_smtp/phpdoc.sh';
+    $files[] = '[civicrm.vendor]/phpoffice/phpword/samples';
+
+    return $files;
+  }
+
+  /**
+   * @return array
+   *   Each item is an array with keys:
+   *     - name: string, an abstract name
+   *     - path: string, a full file path
+   *   Files are returned in deletable order (ie children before parents).
+   */
+  public function findOrphanedFiles() {
+    $orphans = array();
+
+    foreach ($this->getRemovedFiles() as $file) {
+      $path = Civi::paths()->getPath($file);
+      if (empty($path) || strpos('[civicrm', $path) !== FALSE) {
+        Civi::log()->warning('Failed to resolve path of old file \"{file}\" ({path})', array(
+          'file' => $file,
+          'path' => $path,
+        ));
+      }
+      if (file_exists($path)) {
+        $orphans[] = array(
+          'name' => $file,
+          'path' => $path,
+        );
+      }
+    }
+
+    usort($orphans, function ($a, $b) {
+      // Children first, then parents.
+      $diff = strlen($b['name']) - strlen($a['name']);
+      if ($diff !== 0) {
+        return $diff;
+      }
+      if ($a['name'] === $b['name']) {
+        return 0;
+      }
+      return $a['name'] < $b['name'] ? -1 : 1;
+    });
+
+    return $orphans;
+  }
+
+  /**
+   * @return array
+   */
+  public function checkOrphans() {
+    $orphans = $this->findOrphanedFiles();
+    if (empty($orphans)) {
+      return array();
+    }
+
+    $messages = array();
+    $messages[] = new CRM_Utils_Check_Message(
+      __FUNCTION__,
+      ts('The local system includes old files which should not exist: "%1"',
+        array(
+          1 => implode('", "', CRM_Utils_Array::collect('path', $orphans)),
+        )),
+      ts('Old files'),
+      \Psr\Log\LogLevel::WARNING,
+      'fa-server'
+    );
+
+    return $messages;
+  }
+
+}

--- a/CRM/Utils/Check/Component/Source.php
+++ b/CRM/Utils/Check/Component/Source.php
@@ -35,13 +35,6 @@ class CRM_Utils_Check_Component_Source extends CRM_Utils_Check_Component {
   public function getRemovedFiles() {
     $files[] = '[civicrm.packages]/Auth/SASL';
     $files[] = '[civicrm.packages]/Auth/SASL.php';
-    $files[] = '[civicrm.packages]/Auth/SASL/Anonymous.php';
-    $files[] = '[civicrm.packages]/Auth/SASL/Common.php';
-    $files[] = '[civicrm.packages]/Auth/SASL/CramMD5.php';
-    $files[] = '[civicrm.packages]/Auth/SASL/DigestMD5.php';
-    $files[] = '[civicrm.packages]/Auth/SASL/External.php';
-    $files[] = '[civicrm.packages]/Auth/SASL/Login.php';
-    $files[] = '[civicrm.packages]/Auth/SASL/Plain.php';
     $files[] = '[civicrm.packages]/Net/SMTP.php';
     $files[] = '[civicrm.packages]/Net/Socket.php';
     $files[] = '[civicrm.packages]/_ORIGINAL_/Net/SMTP.php';

--- a/Civi/Core/Paths.php
+++ b/Civi/Core/Paths.php
@@ -34,6 +34,24 @@ class Paths {
       ->register('civicrm.root', function () {
         return \CRM_Core_Config::singleton()->userSystem->getCiviSourceStorage();
       })
+      ->register('civicrm.packages', function () {
+        return array(
+          'path' => \Civi::paths()->getPath('[civicrm.root]/packages/'),
+          'url' => \Civi::paths()->getUrl('[civicrm.root]/packages/'),
+        );
+      })
+      ->register('civicrm.vendor', function () {
+        return array(
+          'path' => \Civi::paths()->getPath('[civicrm.root]/vendor/'),
+          'url' => \Civi::paths()->getUrl('[civicrm.root]/vendor/'),
+        );
+      })
+      ->register('civicrm.bower', function () {
+        return array(
+          'path' => \Civi::paths()->getPath('[civicrm.root]/bower_components/'),
+          'url' => \Civi::paths()->getUrl('[civicrm.root]/bower_components/'),
+        );
+      })
       ->register('civicrm.files', function () {
         return \CRM_Core_Config::singleton()->userSystem->getDefaultFileStorage();
       })


### PR DESCRIPTION
In CRM-20243, some files have been removed or relocated.  When applying the
upgrade, this can be OK or problematic depending on how you apply the upgrade:

 * OK: Recommended Drupal/WordPress upgrade (remove old codebase; extract new codebase)
 * Problem: Joomla upgrade
 * Problem: Lazy Drupal/WordPress upgrade (extract new codebase on top of old codebase)

This PR makes multiple efforts to remove old files:

 * As the first upgrade step, try to delete files. (This may not work, depending on permissions.)
 * At the end of the upgrade, display a message if there are old files.
 * In the system status check, display a message if there are old files.

I've tested with this procedure:

 * On local `dmaster` build, setup a DB snapshot for 4.7.20.
 * __Base procedure__: Load the DB snapshot from 4.7.20. Checkout the code for 4.7.21-rc (and this PR). Manually create some files which look like old ones.
 * Try out three ways:
   * __Trial 1__: Run the upgrade. See that the files are deleted.
   * __Trial 2__: Mark the files/folders unwriteableable. Run the upgrade. See post-upgrade message. Files are present.
   * __Trail 3__: As above, then check the System Status. Delete the files and re-check the system status.

---

 * [CRM-20243](https://issues.civicrm.org/jira/browse/CRM-20243)