### PR TITLE
CRM-19914 - CRM_Utils_Hook - Fix `civicrmHooks.php` on Joomla

### DIFF
--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -207,10 +207,11 @@ abstract class CRM_Utils_Hook {
       $this->commonIncluded = TRUE;
 
       $config = CRM_Core_Config::singleton();
-      if (!empty($config->customPHPPathDir) &&
-        file_exists("{$config->customPHPPathDir}/civicrmHooks.php")
-      ) {
-        @include_once "civicrmHooks.php";
+      if (!empty($config->customPHPPathDir)) {
+        $civicrmHooksFile = CRM_Utils_File::addTrailingSlash($config->customPHPPathDir) . 'civicrmHooks.php';
+        if (file_exists($civicrmHooksFile)) {
+          @include_once $civicrmHooksFile;
+        }
       }
 
       if (!empty($fnPrefix)) {


### PR DESCRIPTION
== Use Case

 * Install Joomla
 * Install CiviCRM
 * Create a "Custom PHP folder"
 * Add a file "civicrmHooks.php" with a function `joomla_civicrm_config()`.

== Before

 * The `civicrmHooks.php` is never loaded. At the time when it attempts to
   load, the `include_path` has not been set to support the "Custom PHP
   folder".

== After

 * The `civicrmHooks.php` loads at the expected time.

---

 * [CRM-19914: civicrmHooks.php issues on windows](https://issues.civicrm.org/jira/browse/CRM-19914)