### PR TITLE
CRM-19303 - Drupal - Restore getCiviSourceStorage()

### DIFF
--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -639,6 +639,23 @@ abstract class CRM_Utils_System_Base {
     elseif ($config->userFramework == 'WordPress') {
       $userFrameworkResourceURL = CIVICRM_PLUGIN_URL . "civicrm/";
     }
+    elseif ($this->is_drupal) {
+      // Drupal setting
+      // check and see if we are installed in sites/all (for D5 and above)
+      // we dont use checkURL since drupal generates an error page and throws
+      // the system for a loop on lobo's macosx box
+      // or in modules
+      $cmsPath = $config->userSystem->cmsRootPath();
+      $userFrameworkResourceURL = $baseURL . str_replace("$cmsPath/", '',
+          str_replace('\\', '/', $civicrm_root)
+        );
+
+      $siteName = $config->userSystem->parseDrupalSiteNameFromRoot($civicrm_root);
+      if ($siteName) {
+        $civicrmDirName = trim(basename($civicrm_root));
+        $userFrameworkResourceURL = $baseURL . "sites/$siteName/modules/$civicrmDirName/";
+      }
+    }
     else {
       $userFrameworkResourceURL = NULL;
     }


### PR DESCRIPTION
This partially reverts changes made under CRM-19303:
 * The changes to `getDefaultFileStorage()` are preserved
 * The changes to `getCiviSourceStorage()` are reverted
 * To avoid conflicts, `parseDrupalSiteName()` has been split into the older `parseDrupalSiteNameFromRoot()` and the newer `parseDrupalSiteNameFromRequest()`.
   (IMHO, `parseDrupalSiteNameFromRequest()` is more correct, but `parseDrupalSiteNameFromRoot()` is more compatible with existing deployments).

As discussed in [PR #10513](https://github.com/civicrm/civicrm-core/pull/10513#issuecomment-310506829),
we should stop trying so hard to autodetect these things.  We'll treat the
auto-detection stuff as legacy, and should shift toward a simpler/flatter arrangement
which encourages paths/URLs to be stored in `civicrm.settings.php`.

---

 * [CRM-19303: CKEditor configuration can't be edited on a Drupal multisite installation](https://issues.civicrm.org/jira/browse/CRM-19303)