### PR TITLE
[ready for core team review] CRM-20793, CRM-20799: Add filter - activity date and status on search criteria of activity listing AND make activity filter user preference an optional setting

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1234,7 +1234,21 @@ LEFT JOIN   civicrm_case_activity ON ( civicrm_case_activity.activity_id = tbl.a
       "civicrm_activity.is_test= 0",
     );
 
-    if ($input['context'] != 'activity') {
+    if (isset($input['activity_date_relative']) ||
+        (!empty($input['activity_date_low']) || !empty($input['activity_date_high']))
+    ) {
+      list($from, $to) = CRM_Utils_Date::getFromTo(
+        CRM_Utils_Array::value('activity_date_relative', $input, 0),
+        CRM_Utils_Array::value('activity_date_low', $input),
+        CRM_Utils_Array::value('activity_date_high', $input)
+      );
+      $commonClauses[] = sprintf('civicrm_activity.activity_date_time BETWEEN "%s" AND "%s" ', $from, $to);
+    }
+
+    if (!empty($input['activity_status_id'])) {
+      $commonClauses[] = sprintf("civicrm_activity.status_id IN (%s)", $input['activity_status_id']);
+    }
+    elseif ($input['context'] != 'activity') {
       $commonClauses[] = "civicrm_activity.status_id = 1";
     }
 

--- a/CRM/Activity/Form/ActivityFilter.php
+++ b/CRM/Activity/Form/ActivityFilter.php
@@ -42,6 +42,16 @@ class CRM_Activity_Form_ActivityFilter extends CRM_Core_Form {
 
     $this->add('select', 'activity_type_filter_id', ts('Include'), array('' => ts('- all activity type(s) -')) + $activityOptions);
     $this->add('select', 'activity_type_exclude_filter_id', ts('Exclude'), array('' => ts('- select activity type -')) + $activityOptions);
+    CRM_Core_Form_Date::buildDateRange(
+      $this, 'activity_date', 1,
+      '_low', '_high', ts('From:'),
+      FALSE, array(), 'searchDate',
+      FALSE, array('class' => 'crm-select2 medium')
+    );
+    $this->addSelect('status_id',
+      array('entity' => 'activity', 'multiple' => 'multiple', 'option_url' => NULL, 'placeholder' => ts('- any -'))
+    );
+
     $this->assign('suppressForm', TRUE);
   }
 

--- a/CRM/Activity/Form/ActivityFilter.php
+++ b/CRM/Activity/Form/ActivityFilter.php
@@ -67,8 +67,7 @@ class CRM_Activity_Form_ActivityFilter extends CRM_Core_Form {
   public function setDefaultValues() {
     // CRM-11761 retrieve user's activity filter preferences
     $defaults = array();
-    $userID = CRM_Core_Session::getLoggedInContactID();
-    if ($userID) {
+    if (Civi::settings()->get('preserve_activity_tab_filter') && ($userID = CRM_Core_Session::getLoggedInContactID())) {
       $defaults = Civi::service('settings_manager')
         ->getBagByContact(NULL, $userID)
         ->get('activity_tab_filter');

--- a/CRM/Activity/Page/AJAX.php
+++ b/CRM/Activity/Page/AJAX.php
@@ -403,6 +403,10 @@ class CRM_Activity_Page_AJAX {
       'context' => 'String',
       'activity_type_id' => 'Integer',
       'activity_type_exclude_id' => 'Integer',
+      'activity_status_id' => 'String',
+      'activity_date_relative' => 'String',
+      'activity_date_low' => 'String',
+      'activity_date_high' => 'String',
     );
 
     $params = CRM_Core_Page_AJAX::defaultSortAndPagerParams();

--- a/CRM/Activity/Page/AJAX.php
+++ b/CRM/Activity/Page/AJAX.php
@@ -433,13 +433,22 @@ class CRM_Activity_Page_AJAX {
     }
 
     // store the activity filter preference CRM-11761
-    $session = CRM_Core_Session::singleton();
-    $userID = $session->get('userID');
-    if ($userID) {
-      $activityFilter = array(
-        'activity_type_filter_id' => empty($params['activity_type_id']) ? '' : CRM_Utils_Type::escape($params['activity_type_id'], 'Integer'),
-        'activity_type_exclude_filter_id' => empty($params['activity_type_exclude_id']) ? '' : CRM_Utils_Type::escape($params['activity_type_exclude_id'], 'Integer'),
-      );
+    if (Civi::settings()->get('preserve_activity_tab_filter') && ($userID = CRM_Core_Session::getLoggedInContactID())) {
+      unset($optionalParameters['context']);
+      foreach ($optionalParameters as $searchField => $dataType) {
+        if (!empty($params[$searchField])) {
+          $activityFilter[$searchField] = CRM_Utils_Type::escape($params[$searchField], $dataType);
+          if (in_array($searchField, array('activity_date_low', 'activity_date_high'))) {
+            $activityFilter['activity_date_relative'] = 0;
+          }
+          elseif ($searchField == 'activity_status_id') {
+            $activityFilter['status_id'] = explode(',', $activityFilter[$searchField]);
+          }
+        }
+        elseif (in_array($searchField, array('activity_type_id', 'activity_type_exclude_id'))) {
+          $activityFilter[$searchField] = '';
+        }
+      }
 
       /**
        * @var \Civi\Core\SettingsBag $cSettings

--- a/CRM/Admin/Form/Preferences/Display.php
+++ b/CRM/Admin/Form/Preferences/Display.php
@@ -70,34 +70,39 @@ class CRM_Admin_Form_Preferences_Display extends CRM_Admin_Form_Preferences {
           'title' => ts('Include ICal Invite to Activity Assignees'),
           'weight' => 6,
         ),
+        'preserve_activity_tab_filter' => array(
+          'html_type' => 'checkbox',
+          'title' => ts('Preserve activity filters as a user preference'),
+          'weight' => 7,
+        ),
         'contact_ajax_check_similar' => array(
           'html_type' => 'checkbox',
           'title' => ts('Check for Similar Contacts'),
-          'weight' => 7,
+          'weight' => 8,
         ),
         'user_dashboard_options' => array(
           'html_type' => 'checkboxes',
           'title' => ts('Contact Dashboard'),
-          'weight' => 8,
+          'weight' => 9,
         ),
         'display_name_format' => array(
           'html_type' => 'textarea',
           'title' => ts('Individual Display Name Format'),
-          'weight' => 9,
+          'weight' => 10,
         ),
         'sort_name_format' => array(
           'html_type' => 'textarea',
           'title' => ts('Individual Sort Name Format'),
-          'weight' => 10,
+          'weight' => 11,
         ),
         'editor_id' => array(
           'html_type' => NULL,
-          'weight' => 11,
+          'weight' => 12,
         ),
         'ajaxPopupsEnabled' => array(
           'html_type' => 'checkbox',
           'title' => ts('Enable Popup Forms'),
-          'weight' => 12,
+          'weight' => 13,
         ),
       ),
     );

--- a/CRM/Core/Form/Date.php
+++ b/CRM/Core/Form/Date.php
@@ -81,12 +81,14 @@ class CRM_Core_Form_Date {
    *   Additional value pairs to add.
    * @param string $dateFormat
    * @param bool|string $displayTime
+   * @param array $attributes
    */
   public static function buildDateRange(
     &$form, $fieldName, $count = 1,
     $from = '_from', $to = '_to', $fromLabel = 'From:',
     $required = FALSE, $operators = array(),
-    $dateFormat = 'searchDate', $displayTime = FALSE
+    $dateFormat = 'searchDate', $displayTime = FALSE,
+    $attributes = array('class' => 'crm-select2')
   ) {
     $selector
       = CRM_Core_Form_Date::returnDateRangeSelector(
@@ -98,7 +100,8 @@ class CRM_Core_Form_Date {
     CRM_Core_Form_Date::addDateRangeToForm(
       $form, $fieldName, $selector,
       $from, $to, $fromLabel,
-      $required, $dateFormat, $displayTime
+      $required, $dateFormat, $displayTime,
+      $attributes
     );
   }
 
@@ -165,14 +168,26 @@ class CRM_Core_Form_Date {
    * @param bool $required
    * @param string $dateFormat
    * @param bool $displayTime
+   * @param array $attributes
    */
-  public static function addDateRangeToForm(&$form, $fieldName, $selector, $from = '_from', $to = '_to', $fromLabel = 'From:', $required = FALSE, $dateFormat = 'searchDate', $displayTime = FALSE) {
+  public static function addDateRangeToForm(
+    &$form,
+    $fieldName,
+    $selector,
+    $from = '_from',
+    $to = '_to',
+    $fromLabel = 'From:',
+    $required = FALSE,
+    $dateFormat = 'searchDate',
+    $displayTime = FALSE,
+    $attributes
+  ) {
     $form->add('select',
       "{$fieldName}_relative",
       ts('Relative Date Range'),
       $selector,
       $required,
-      array('class' => 'crm-select2')
+      $attributes
     );
 
     $form->addDateRange($fieldName, $from, $to, $fromLabel, $dateFormat, FALSE, $displayTime);

--- a/settings/Core.setting.php
+++ b/settings/Core.setting.php
@@ -953,4 +953,18 @@ return array(
     'description' => 'If enabled, then CMS email id will be syncronised with CiviCRM contacts\'s primary email.',
     'help_text' => NULL,
   ),
+  'preserve_activity_tab_filter' => array(
+    'group_name' => 'CiviCRM Preferences',
+    'group' => 'core',
+    'name' => 'preserve_activity_tab_filter',
+    'type' => 'String',
+    'html_type' => 'Text',
+    'default' => '0',
+    'add' => '4.7',
+    'title' => 'Preserve activity filters as a user preference',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => 'When enabled, any filter settings a user selects on the contact\'s Activity tab will be remembered as they visit other contacts',
+    'help_text' => NULL,
+  ),
 );

--- a/templates/CRM/Activity/Selector/Selector.tpl
+++ b/templates/CRM/Activity/Selector/Selector.tpl
@@ -39,7 +39,7 @@
           </td>
           {include file="CRM/Core/DateRange.tpl" fieldName="activity_date" from='_low' to='_high' label='Date'}
           <td class="crm-contact-form-block-activity_status_filter_id crm-inline-edit-field">
-            {ts}Status{/ts}: {$form.status_id.html|crmAddClass:medium}
+            {ts}Status{/ts}<br /> {$form.status_id.html|crmAddClass:medium}
           </td>
         </tr>
       </table>

--- a/templates/CRM/Activity/Selector/Selector.tpl
+++ b/templates/CRM/Activity/Selector/Selector.tpl
@@ -26,17 +26,23 @@
 <div class="crm-activity-selector-{$context}">
   <div class="crm-accordion-wrapper crm-search_filters-accordion">
     <div class="crm-accordion-header">
-    {ts}Filter by Activity Type{/ts}</a>
+    {ts}Filter by Activity{/ts}</a>
     </div><!-- /.crm-accordion-header -->
     <div class="crm-accordion-body">
-      <div class="no-border form-layout-compressed activity-search-options">
-          <div class="crm-contact-form-block-activity_type_filter_id crm-inline-edit-field">
-            {$form.activity_type_filter_id.label} {$form.activity_type_filter_id.html|crmAddClass:big}
-          </div>
-          <div class="crm-contact-form-block-activity_type_exclude_filter_id crm-inline-edit-field">
-            {$form.activity_type_exclude_filter_id.label} {$form.activity_type_exclude_filter_id.html|crmAddClass:big}
-          </div>
-      </div>
+      <table class="no-border form-layout-compressed activity-search-options">
+        <tr>
+          <td class="crm-contact-form-block-activity_type_filter_id crm-inline-edit-field">
+            {$form.activity_type_filter_id.label}<br /> {$form.activity_type_filter_id.html|crmAddClass:medium}
+          </td>
+          <td class="crm-contact-form-block-activity_type_exclude_filter_id crm-inline-edit-field">
+            {$form.activity_type_exclude_filter_id.label}<br /> {$form.activity_type_exclude_filter_id.html|crmAddClass:medium}
+          </td>
+          {include file="CRM/Core/DateRange.tpl" fieldName="activity_date" from='_low' to='_high' label='Date'}
+          <td class="crm-contact-form-block-activity_status_filter_id crm-inline-edit-field">
+            {ts}Status{/ts}: {$form.status_id.html|crmAddClass:medium}
+          </td>
+        </tr>
+      </table>
     </div><!-- /.crm-accordion-body -->
   </div><!-- /.crm-accordion-wrapper -->
   <table class="contact-activity-selector-{$context} crm-ajax-table">
@@ -62,8 +68,13 @@
           "ajax": {
             "url": {/literal}'{crmURL p="civicrm/ajax/contactactivity" h=0 q="snippet=4&context=$context&cid=$contactId"}'{literal},
             "data": function (d) {
+              var status_id = $('.crm-activity-selector-' + context + ' select#status_id').val() || [];
               d.activity_type_id = $('.crm-activity-selector-' + context + ' select#activity_type_filter_id').val(),
-              d.activity_type_exclude_id = $('.crm-activity-selector-' + context + ' select#activity_type_exclude_filter_id').val()
+              d.activity_type_exclude_id = $('.crm-activity-selector-' + context + ' select#activity_type_exclude_filter_id').val(),
+              d.activity_date_relative = $('select#activity_date_relative').val(),
+              d.activity_date_low = $('#activity_date_low').val(),
+              d.activity_date_high = $('#activity_date_high').val(),
+              d.activity_status_id = status_id.join(',')
             }
           }
         });

--- a/templates/CRM/Admin/Form/Preferences/Display.tpl
+++ b/templates/CRM/Admin/Form/Preferences/Display.tpl
@@ -143,6 +143,16 @@
       </td>
     </tr>
 
+    <tr class="crm-preferences-display-form-block-preserve_activity_tab_filter">
+      <td class="label"></td>
+      <td>{$form.preserve_activity_tab_filter.html} {$form.preserve_activity_tab_filter.label}</td>
+    </tr>
+    <tr class="crm-preferences-display-form-block-description">
+      <td>&nbsp;</td>
+      <td class="description">{ts}When enabled, any filter settings a user selects on the contact's Activity tab will be remembered as they visit other contacts.{/ts}
+      </td>
+    </tr>
+
     <tr class="crm-preferences-display-form-block-user_dashboard_options">
       <td class="label">{$form.user_dashboard_options.label}</td>
       <td>{$form.user_dashboard_options.html}<span id="invoice_help">  {help id="id-invoices_id"}</span></td>

--- a/templates/CRM/Core/DateRange.tpl
+++ b/templates/CRM/Core/DateRange.tpl
@@ -26,6 +26,9 @@
 {*this is included inside a table row*}
 {assign var=relativeName   value=$fieldName|cat:"_relative"}
 <td colspan=2>
+  {if $label}
+   {ts}{$label}{/ts}
+  {/if}
   {$form.$relativeName.html}<br />
   <span class="crm-absolute-date-range">
     <span class="crm-absolute-date-from">

--- a/templates/CRM/Core/DateRange.tpl
+++ b/templates/CRM/Core/DateRange.tpl
@@ -27,7 +27,7 @@
 {assign var=relativeName   value=$fieldName|cat:"_relative"}
 <td colspan=2>
   {if $label}
-   {ts}{$label}{/ts}
+   {ts}{$label}{/ts}<br />
   {/if}
   {$form.$relativeName.html}<br />
   <span class="crm-absolute-date-range">

--- a/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
@@ -732,6 +732,163 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
   }
 
   /**
+   * CRM-20793 : Test getActivities by using activity date and status filter
+   */
+  public function testbyActivityDateAndStatus() {
+    $op = new PHPUnit_Extensions_Database_Operation_Insert();
+    $op->execute($this->_dbconn,
+      $this->createFlatXMLDataSet(
+        dirname(__FILE__) . '/activities_for_dashboard_count.xml'
+      )
+    );
+
+    // activity IDs catagorised by date
+    $lastWeekActivities = array(1, 2, 3);
+    $todayActivities = array(4, 5, 6, 7);
+    $lastMonthActivities = array(8, 9, 10, 11);
+    $lastYearActivties = array(12, 13, 14, 15, 16);
+
+    // date values later used to set activity date value
+    $lastWeekDate = date('YmdHis', strtotime('1 week ago'));
+    $today = date('YmdHis');
+    $lastMonthDate = date('YmdHis', strtotime('1 month ago'));
+    $lastYearDate = date('YmdHis', strtotime('1 year ago'));
+    for ($i = 1; $i <= 16; $i++) {
+      if (in_array($i, $lastWeekActivities)) {
+        $date = $lastWeekDate;
+      }
+      elseif (in_array($i, $lastMonthActivities)) {
+        $date = $lastMonthDate;
+      }
+      elseif (in_array($i, $lastYearActivties)) {
+        $date = $lastYearDate;
+      }
+      elseif (in_array($i, $todayActivities)) {
+        $date = $today;
+      }
+      $this->callAPISuccess('Activity', 'create', array(
+        'id' => $i,
+        'activity_date_time' => $date,
+      ));
+    }
+
+    // parameters for different test cases, check each array key for the specific test-case
+    $testCases = array(
+      'todays-activity' => array(
+        'params' => array(
+          'contact_id' => 1,
+          'admin' => TRUE,
+          'caseId' => NULL,
+          'context' => 'activity',
+          'activity_date_relative' => 'this.day',
+          'activity_type_id' => NULL,
+          'offset' => 0,
+          'rowCount' => 0,
+          'sort' => NULL,
+        ),
+      ),
+      'todays-activity-filtered-by-range' => array(
+        'params' => array(
+          'contact_id' => 1,
+          'admin' => TRUE,
+          'caseId' => NULL,
+          'context' => 'activity',
+          'activity_date_low' => date('Y/m/d', strtotime('yesterday')),
+          'activity_date_high' => date('Y/m/d'),
+          'activity_type_id' => NULL,
+          'offset' => 0,
+          'rowCount' => 0,
+          'sort' => NULL,
+        ),
+      ),
+      'last-week-activity' => array(
+        'params' => array(
+          'contact_id' => 1,
+          'admin' => TRUE,
+          'caseId' => NULL,
+          'context' => 'activity',
+          'activity_date_relative' => 'previous.week',
+          'activity_type_id' => NULL,
+          'offset' => 0,
+          'rowCount' => 0,
+          'sort' => NULL,
+        ),
+      ),
+      'last-month-activity' => array(
+        'params' => array(
+          'contact_id' => 1,
+          'admin' => TRUE,
+          'caseId' => NULL,
+          'context' => 'activity',
+          'activity_date_relative' => 'previous.month',
+          'activity_type_id' => NULL,
+          'offset' => 0,
+          'rowCount' => 0,
+          'sort' => NULL,
+        ),
+      ),
+      'last-year-activity' => array(
+        'params' => array(
+          'contact_id' => 1,
+          'admin' => TRUE,
+          'caseId' => NULL,
+          'context' => 'activity',
+          'activity_date_relative' => 'previous.year',
+          'activity_type_id' => NULL,
+          'offset' => 0,
+          'rowCount' => 0,
+          'sort' => NULL,
+        ),
+      ),
+      'activity-of-all-statuses' => array(
+        'params' => array(
+          'contact_id' => 1,
+          'admin' => TRUE,
+          'caseId' => NULL,
+          'context' => 'activity',
+          'activity_status_id' => '1,2',
+          'activity_type_id' => NULL,
+          'offset' => 0,
+          'rowCount' => 0,
+          'sort' => NULL,
+        ),
+      ),
+    );
+
+    foreach ($testCases as $caseName => $testCase) {
+      $activitiesDep = CRM_Activity_BAO_Activity::deprecatedGetActivities($testCase['params']);
+      $activityCount = CRM_Activity_BAO_Activity::deprecatedGetActivitiesCount($testCase['params']);
+      asort($activitiesDep);
+      $activityIDs = array_keys($activitiesDep);
+
+      if ($caseName == 'todays-activity' || $caseName == 'todays-activity-filtered-by-range') {
+        $this->assertEquals(count($todayActivities), $activityCount);
+        $this->assertEquals(count($todayActivities), count($activitiesDep));
+        $this->checkArrayEquals($todayActivities, $activityIDs);
+      }
+      elseif ($caseName == 'last-week-activity') {
+        $this->assertEquals(count($lastWeekActivities), $activityCount);
+        $this->assertEquals(count($lastWeekActivities), count($activitiesDep));
+        $this->checkArrayEquals($lastWeekActivities, $activityIDs);
+      }
+      elseif ($caseName == 'last-month-activity') {
+        $this->assertEquals(count($lastMonthActivities), $activityCount);
+        $this->assertEquals(count($lastMonthActivities), count($activitiesDep));
+        $this->checkArrayEquals($lastMonthActivities, $activityIDs);
+      }
+      elseif ($caseName == 'last-year-activity') {
+        $this->assertEquals(count($lastYearActivties), $activityCount);
+        $this->assertEquals(count($lastYearActivties), count($activitiesDep));
+        $this->checkArrayEquals($lastYearActivties, $activityIDs);
+      }
+      elseif ($caseName == 'activity-of-all-statuses') {
+        $this->assertEquals(16, $activityCount);
+        $this->assertEquals(16, count($activitiesDep));
+      }
+    }
+  }
+
+  /**
    * CRM-20308: Test from email address when a 'copy of Activity' event occur
    */
   public function testEmailAddressOfActivityCopy() {

--- a/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
@@ -745,20 +745,20 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
     // activity IDs catagorised by date
     $lastWeekActivities = array(1, 2, 3);
     $todayActivities = array(4, 5, 6, 7);
-    $lastMonthActivities = array(8, 9, 10, 11);
+    $lastTwoMonthsActivities = array(8, 9, 10, 11);
     $lastYearActivties = array(12, 13, 14, 15, 16);
 
     // date values later used to set activity date value
     $lastWeekDate = date('YmdHis', strtotime('1 week ago'));
     $today = date('YmdHis');
-    $lastMonthDate = date('YmdHis', strtotime('1 month ago'));
+    $lastTwoMonthAgoDate = date('YmdHis', strtotime('2 months ago'));
     $lastYearDate = date('YmdHis', strtotime('1 year ago'));
     for ($i = 1; $i <= 16; $i++) {
       if (in_array($i, $lastWeekActivities)) {
         $date = $lastWeekDate;
       }
-      elseif (in_array($i, $lastMonthActivities)) {
-        $date = $lastMonthDate;
+      elseif (in_array($i, $lastTwoMonthsActivities)) {
+        $date = $lastTwoMonthAgoDate;
       }
       elseif (in_array($i, $lastYearActivties)) {
         $date = $lastYearDate;
@@ -814,13 +814,13 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
           'sort' => NULL,
         ),
       ),
-      'last-month-activity' => array(
+      'this-quarter-activity' => array(
         'params' => array(
           'contact_id' => 1,
           'admin' => TRUE,
           'caseId' => NULL,
           'context' => 'activity',
-          'activity_date_relative' => 'previous.month',
+          'activity_date_relative' => 'this.quarter',
           'activity_type_id' => NULL,
           'offset' => 0,
           'rowCount' => 0,
@@ -871,10 +871,10 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
         $this->assertEquals(count($lastWeekActivities), count($activitiesDep));
         $this->checkArrayEquals($lastWeekActivities, $activityIDs);
       }
-      elseif ($caseName == 'last-month-activity') {
-        $this->assertEquals(count($lastMonthActivities), $activityCount);
-        $this->assertEquals(count($lastMonthActivities), count($activitiesDep));
-        $this->checkArrayEquals($lastMonthActivities, $activityIDs);
+      elseif ($caseName == 'lhis-quarter-activity') {
+        $this->assertEquals(count($lastTwoMonthsActivities), $activityCount);
+        $this->assertEquals(count($lastTwoMonthsActivities), count($activitiesDep));
+        $this->checkArrayEquals($lastTwoMonthsActivities, $activityIDs);
       }
       elseif ($caseName == 'last-year-activity') {
         $this->assertEquals(count($lastYearActivties), $activityCount);


### PR DESCRIPTION
* [CRM-20793: Add filter - activity date and status on search criteria of activity listing  ](https://issues.civicrm.org/jira/browse/CRM-20793)

---

 * [CRM-20799: make activity filter user preference an optional setting](https://issues.civicrm.org/jira/browse/CRM-20799)