### PR TITLE
CRM-20802 - CaseType - Flush any in-memory caches that might reference case-type

### DIFF
--- a/CRM/Case/BAO/CaseType.php
+++ b/CRM/Case/BAO/CaseType.php
@@ -80,7 +80,9 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType {
     }
 
     $caseTypeDAO->copyValues($params);
-    return $caseTypeDAO->save();
+    $result = $caseTypeDAO->save();
+    CRM_Case_XMLRepository::singleton()->flush();
+    return $result;
   }
 
   /**

--- a/CRM/Case/XMLRepository.php
+++ b/CRM/Case/XMLRepository.php
@@ -63,6 +63,13 @@ class CRM_Case_XMLRepository {
     return self::$singleton;
   }
 
+  public function flush() {
+    $this->xml = array();
+    $this->hookCache = NULL;
+    $this->allCaseTypes = NULL;
+    CRM_Core_DAO::$_dbColumnValueCache = array();
+  }
+
   /**
    * Class constructor.
    *


### PR DESCRIPTION
== Description

Suppose we're running this snippet:


```php
addToTimeline('housing_support', array('name' => 'Case Task', 'reference_activity' => 'Open Case', 'reference_offset' => '9', 'reference_select' => 'newest'));
civicrm_api3('Case', 'create', array(...'housing_support'...));

function addToTimeline($caseType, $timelineEntry) {
  $caseType = civicrm_api3('CaseType', 'getsingle', array('name' => $caseType));

  foreach ($caseType['definition']['activitySets'] as &$actSet) {
    if ($actSet['name'] === 'standard_timeline') {
      $actSet['activityTypes'][] = $timelineEntry;
    }
  }

  civicrm_api3('CaseType', 'create', array(
    'id' => $caseType['id'],
    'definition' => $caseType['definition'],
  ));
}
```

== Before

The resulting `Case` record does not have the `Case Task` activity.

== After

The resulting `Case` record does have the `Case Task` activity.

---

 * [CRM-20802: CaseType.create - Stale definition retained in memory](https://issues.civicrm.org/jira/browse/CRM-20802)