### PR TITLE
(Backport) CRM-20675 - Fix incorrect renewal activity created when membership updated via API

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4601,6 +4601,7 @@ WHERE eft.financial_trxn_id IN ({$trxnId}, {$baseTrxnId['financialTrxnId']})
               'contact_id' => $membership->contact_id,
               'is_test' => $membership->is_test,
               'membership_type_id' => $membership->membership_type_id,
+              'membership_activity_status' => 'Completed',
             );
 
             $currentMembership = CRM_Member_BAO_Membership::getContactMembership($membershipParams['contact_id'],

--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -852,7 +852,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     //Update Status and check activities created.
     $updateStatus = array(
       'id' => $result['id'],
-      'status_id' => 6,
+      'status_id' => CRM_Core_PseudoConstant::getKey('CRM_Member_BAO_Membership', 'status_id', 'Cancelled'),
     );
     $this->callAPISuccess('Membership', 'create', $updateStatus);
     $activities = CRM_Activity_BAO_Activity::getContactActivity($this->_contactID);

--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -848,6 +848,19 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     );
 
     $result = $this->callAPISuccess('membership', 'create', $params);
+
+    //Update Status and check activities created.
+    $updateStatus = array(
+      'id' => $result['id'],
+      'status_id' => 6,
+    );
+    $this->callAPISuccess('Membership', 'create', $updateStatus);
+    $activities = CRM_Activity_BAO_Activity::getContactActivity($this->_contactID);
+    $this->assertEquals(2, count($activities));
+    $activityNames = array_flip(CRM_Utils_Array::collect('activity_name', $activities));
+    $this->assertArrayHasKey('Membership Signup', $activityNames);
+    $this->assertArrayHasKey('Change Membership Status', $activityNames);
+
     $this->callAPISuccess('Membership', 'Delete', array(
       'id' => $result['id'],
     ));


### PR DESCRIPTION
@eileenmcnaughton pointed out that `4.7.21-rc` has a failing test.  The test
was already failing at the time we branched off of `master`, but it was
subsequently fixed in `master` via #10457.

This is a backport of #10457 from `master` to `4.7.21-rc`.

I haven't investigated the merits of the issue - ping @eileenmcnaughton,
@monishdeb, @jitendrapurohit for feedback.

---

 * [CRM-20675: Membership status update creates renewal activity](https://issues.civicrm.org/jira/browse/CRM-20675)