### PR TITLE
CRM-20288 Contact reference field on membership renewal form missing default

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -138,10 +138,12 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
         //don't set custom data Used for Contribution (CRM-1344)
         if (substr($name, 0, 7) == 'custom_') {
           $id = substr($name, 7);
-          if (!CRM_Core_BAO_CustomGroup::checkCustomField($id, $removeCustomFieldTypes)) {
-            continue;
+          if ((!CRM_Core_BAO_CustomGroup::checkCustomField($id, $removeCustomFieldTypes))) {
+            if ($dontCare['data_type'] === 'ContactReference') {
+            } else {
+                continue;
+            }
           }
-          // ignore component fields
         }
         elseif (array_key_exists($name, $contribFields) || (substr($name, 0, 11) == 'membership_') || (substr($name, 0, 13) == 'contribution_')) {
           continue;


### PR DESCRIPTION
Fix for https://issues.civicrm.org/jira/browse/CRM-20288