### PR TITLE
WIP CRM-20772 Price set calculation precision when sales tax enabled

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -355,7 +355,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       if (!empty($defaults['tax_amount'])) {
         $componentDetails = CRM_Contribute_BAO_Contribution::getComponentDetails($this->_id);
         if (!(CRM_Utils_Array::value('membership', $componentDetails) || CRM_Utils_Array::value('participant', $componentDetails))) {
-          $defaults['total_amount'] = CRM_Utils_Money::format($defaults['total_amount'] - $defaults['tax_amount'], NULL, '%a');
+          $defaults['total_amount'] = CRM_Utils_Money::format($defaults['total_amount'] - $defaults['tax_amount'], NULL, '%a', TRUE);
         }
       }
       else {

--- a/CRM/Contribute/Form/Task/Invoice.php
+++ b/CRM/Contribute/Form/Task/Invoice.php
@@ -287,11 +287,11 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
       // to get billing address if present
       $billingAddress = array();
       foreach ($addressDetails as $address) {
-        if ((isset($address['is_billing']) && $address['is_billing'] == 1) && (isset($address['is_primary']) && $address['is_primary'] == 1) && $address['contact_id'] == $contribution->contact_id) {
+        if (($address['is_billing'] == 1) && ($address['is_primary'] == 1) && ($address['contact_id'] == $contribution->contact_id)) {
           $billingAddress[$address['contact_id']] = $address;
           break;
         }
-        elseif (($address['is_billing'] == 0 && $address['is_primary'] == 1) || (isset($address['is_billing']) && $address['is_billing'] == 1) && $address['contact_id'] == $contribution->contact_id) {
+        elseif (($address['is_billing'] == 0 && $address['is_primary'] == 1) || ($address['is_billing'] == 1) && ($address['contact_id'] == $contribution->contact_id)) {
           $billingAddress[$address['contact_id']] = $address;
         }
       }

--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -542,10 +542,10 @@ class CRM_Core_BAO_Address extends CRM_Core_DAO_Address {
 
       $addresses[$count] = $values;
 
-      //unset is_primary after first block. Due to some bug in earlier version
-      //there might be more than one primary blocks, hence unset is_primary other than first
+      //There should never be more than one primary blocks, hence set is_primary = 0 other than first
+      // Calling functions expect the key is_primary to be set, so do not unset it here!
       if ($count > 1) {
-        unset($addresses[$count]['is_primary']);
+        $addresses[$count]['is_primary'] = 0;
       }
 
       $count++;

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -182,7 +182,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
       $contributionID = CRM_Member_BAO_Membership::getMembershipContributionId($this->_id);
       // check delete permission for contribution
       if ($this->_id && $contributionID && !CRM_Core_Permission::checkActionPermission('CiviContribute', $this->_action)) {
-        CRM_Core_Error::fatal(ts("This Membership is linked to a contribution. You must have 'delete in CiviContribute' permission in order to delete this record."));
+        CRM_Core_Error::statusBounce(ts("This Membership is linked to a contribution. You must have 'delete in CiviContribute' permission in order to delete this record."));
       }
     }
 

--- a/CRM/Member/Form/MembershipConfig.php
+++ b/CRM/Member/Form/MembershipConfig.php
@@ -83,7 +83,8 @@ class CRM_Member_Form_MembershipConfig extends CRM_Core_Form {
     }
 
     if (isset($defaults['minimum_fee'])) {
-      $defaults['minimum_fee'] = CRM_Utils_Money::format($defaults['minimum_fee'], NULL, '%a');
+      // Don't use CRM_Utils_Money::format here as we need to allow more decimal places so sales tax can be calculated with recurring amounts.
+      $defaults['minimum_fee'] = filter_var($defaults['minimum_fee'], FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION);
     }
 
     if (isset($defaults['status'])) {

--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -302,7 +302,7 @@ WHERE li.contribution_id = %1";
       if (isset($lineItems[$dao->id]['financial_type_id']) && array_key_exists($lineItems[$dao->id]['financial_type_id'], $taxRates)) {
         // We are close to output/display here - so apply some rounding at output/display level - to not show Tax Rate in all 8 decimals
         // Cast to float so trailing zero decimals are removed.
-        $lineItems[$dao->id]['tax_rate'] = (float)round($taxRates[$lineItems[$dao->id]['financial_type_id']], 3);
+        $lineItems[$dao->id]['tax_rate'] = (float) round($taxRates[$lineItems[$dao->id]['financial_type_id']], 3);
       }
       else {
         // There is no Tax Rate associated with this Financial Type

--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -301,7 +301,8 @@ WHERE li.contribution_id = %1";
       $taxRates = CRM_Core_PseudoConstant::getTaxRates();
       if (isset($lineItems[$dao->id]['financial_type_id']) && array_key_exists($lineItems[$dao->id]['financial_type_id'], $taxRates)) {
         // We are close to output/display here - so apply some rounding at output/display level - to not show Tax Rate in all 8 decimals
-        $lineItems[$dao->id]['tax_rate'] = round($taxRates[$lineItems[$dao->id]['financial_type_id']], 3);
+        // Cast to float so trailing zero decimals are removed.
+        $lineItems[$dao->id]['tax_rate'] = (float)round($taxRates[$lineItems[$dao->id]['financial_type_id']], 3);
       }
       else {
         // There is no Tax Rate associated with this Financial Type

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -838,9 +838,8 @@ WHERE  id = %1";
         $params['amount_level'] = CRM_Core_DAO::VALUE_SEPARATOR . implode(CRM_Core_DAO::VALUE_SEPARATOR, $amount_level) . $displayParticipantCount . CRM_Core_DAO::VALUE_SEPARATOR;
       }
     }
-    // @todo this was a fix for CRM-16460 but is too deep in the system for formatting
-    // and probably causes negative amounts to save as $0 depending on server config.
-    $params['amount'] = CRM_Utils_Money::format($totalPrice, NULL, NULL, TRUE);
+    // Don't use CRM_Utils_Money::format here as we need to allow more decimal places so sales tax can be calculated with recurring amounts.
+    $params['amount'] = filter_var($totalPrice, FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION);
     $params['tax_amount'] = $totalTax;
     if ($component) {
       foreach ($autoRenew as $dontCare => $eachAmount) {

--- a/CRM/Price/Page/Option.php
+++ b/CRM/Price/Page/Option.php
@@ -154,7 +154,7 @@ class CRM_Price_Page_Option extends CRM_Core_Page {
       // Adding the required fields in the array
       if (isset($taxRate[$values['financial_type_id']])) {
         // Cast to float so trailing zero decimals are removed
-        $customOption[$id]['tax_rate'] = (float)$taxRate[$values['financial_type_id']];
+        $customOption[$id]['tax_rate'] = (float) $taxRate[$values['financial_type_id']];
         if ($invoicing && isset($customOption[$id]['tax_rate'])) {
           $getTaxDetails = TRUE;
         }

--- a/CRM/Price/Page/Option.php
+++ b/CRM/Price/Page/Option.php
@@ -153,7 +153,8 @@ class CRM_Price_Page_Option extends CRM_Core_Page {
       $action = array_sum(array_keys(self::actionLinks()));
       // Adding the required fields in the array
       if (isset($taxRate[$values['financial_type_id']])) {
-        $customOption[$id]['tax_rate'] = $taxRate[$values['financial_type_id']];
+        // Cast to float so trailing zero decimals are removed
+        $customOption[$id]['tax_rate'] = (float)$taxRate[$values['financial_type_id']];
         if ($invoicing && isset($customOption[$id]['tax_rate'])) {
           $getTaxDetails = TRUE;
         }

--- a/CRM/Upgrade/Incremental/Base.php
+++ b/CRM/Upgrade/Incremental/Base.php
@@ -187,9 +187,9 @@ class CRM_Upgrade_Incremental_Base {
    * @param CRM_Queue_TaskContext $ctx
    * @param string $table
    * @param string $column
-   * @param string $newColumn (new name for column)
    * @param string $properties
    * @param bool $localizable is this a field that should be localized
+   * @param string $newColumn (new name for column)
    * @return bool
    */
   public static function alterColumn($ctx, $table, $column, $properties, $localizable = FALSE, $newColumn = NULL) {

--- a/CRM/Upgrade/Incremental/Base.php
+++ b/CRM/Upgrade/Incremental/Base.php
@@ -182,6 +182,51 @@ class CRM_Upgrade_Incremental_Base {
   }
 
   /**
+   * Modify a column in a table
+   *
+   * @param CRM_Queue_TaskContext $ctx
+   * @param string $table
+   * @param string $column
+   * @param string $newColumn (new name for column)
+   * @param string $properties
+   * @param bool $localizable is this a field that should be localized
+   * @return bool
+   */
+  public static function alterColumn($ctx, $table, $column, $properties, $localizable = FALSE, $newColumn = NULL) {
+    if (!isset($newColumn)) {
+      // Option to rename column
+      $newColumn = $column;
+    }
+    $domain = new CRM_Core_DAO_Domain();
+    $domain->find(TRUE);
+    $queries = array();
+    if (!CRM_Core_BAO_SchemaHandler::checkIfFieldExists($table, $column)) {
+      if ($domain->locales) {
+        if ($localizable) {
+          $locales = explode(CRM_Core_DAO::VALUE_SEPARATOR, $domain->locales);
+          foreach ($locales as $locale) {
+            $queries[] = "ALTER TABLE `$table` CHANGE `{$column}_{$locale}` `{$newColumn}_{$locale}` $properties";
+          }
+        }
+        else {
+          $queries[] = "ALTER TABLE `$table` CHANGE `$column` `$newColumn` $properties";
+        }
+      }
+      else {
+        $queries[] = "ALTER TABLE `$table` CHANGE `$column` `$newColumn` $properties";
+      }
+      foreach ($queries as $query) {
+        CRM_Core_DAO::executeQuery($query, array(), TRUE, NULL, FALSE, FALSE);
+      }
+    }
+    if ($domain->locales) {
+      $locales = explode(CRM_Core_DAO::VALUE_SEPARATOR, $domain->locales);
+      CRM_Core_I18n_Schema::rebuildMultilingualSchema($locales, NULL);
+    }
+    return TRUE;
+  }
+
+  /**
    * Drop a column from a table if it exist.
    *
    * @param CRM_Queue_TaskContext $ctx

--- a/CRM/Upgrade/Incremental/php/FourSeven.php
+++ b/CRM/Upgrade/Incremental/php/FourSeven.php
@@ -371,6 +371,8 @@ class CRM_Upgrade_Incremental_php_FourSeven extends CRM_Upgrade_Incremental_Base
   public function upgrade_4_7_22($rev) {
     $this->addTask('CRM-20387 - Add invoice_number column to civicrm_contribution', 'addColumn',
       'civicrm_contribution', 'invoice_number', "varchar(255) COMMENT 'Human readable invoice number' DEFAULT NULL");
+    $this->addTask('CRM-20772 - Price set calculation precision when sales tax enabled', 'alterColumn',
+      'civicrm_membership_type', 'minimum_fee', "VARCHAR(512) NULL DEFAULT '0.00' COMMENT 'Minimum fee for this membership (0 for free/complimentary memberships).'");
     $this->addTask(ts('Upgrade DB to %1: SQL', array(1 => $rev)), 'runSql', $rev);
   }
 

--- a/CRM/Utils/Rule.php
+++ b/CRM/Utils/Rule.php
@@ -574,7 +574,10 @@ class CRM_Utils_Rule {
       return TRUE;
     }
 
-    return preg_match('/(^-?\d+\.\d?\d?$)|(^-?\.\d\d?$)/', $value) ? TRUE : FALSE;
+    // Allow values such as -0, 1.024555, -.1
+    // We need to support multiple decimal places here, not just the number allowed by locale
+    //  otherwise tax calculations break when you want the inclusive amount to be a round number (eg. £10 inc. VAT requires 8.333333333 here).
+    return preg_match('/(^-?\d+\.?\d*$)|(^-?\.\d+$)/', $value) ? TRUE : FALSE;
   }
 
   /**

--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -647,6 +647,7 @@ CRM.$(function($) {
       if (!freezeFinancialType) {
         var financialType = $('#financial_type_id').val();
         var taxRates = '{/literal}{$taxRates}{literal}';
+        var taxTerm = '{/literal}{$taxTerm}{literal}';
         taxRates = JSON.parse(taxRates);
         var currencies = '{/literal}{$currencies}{literal}';
         currencies = JSON.parse(currencies);
@@ -673,7 +674,7 @@ CRM.$(function($) {
         var totalTaxAmount = taxAmount + Number(totalAmount);
         totalTaxAmount = formatMoney( totalTaxAmount, 2, separator, thousandMarker );
 
-        $("#totalTaxAmount" ).html('Amount with tax : <span id="currencySymbolShow">' + currencySymbol + '</span> '+ totalTaxAmount);
+        $("#totalTaxAmount" ).html('Amount with ' + taxTerm + ' : <span id="currencySymbolShow">' + currencySymbol + '</span> '+ totalTaxAmount);
       }
       event.handled = true;
     }

--- a/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
@@ -76,7 +76,7 @@
                 {/if}
               {else}
                 {if $totalTaxAmount }
-                     {ts}Total Tax Amount{/ts}: <strong>{$totalTaxAmount|crmMoney} </strong><br />
+                     {ts}Total {$taxTerm} Amount{/ts}: <strong>{$totalTaxAmount|crmMoney} </strong><br />
                 {/if}
 		{if $amount}
                     {if $installments}{ts}Installment Amount{/ts}{else}{ts}Total Amount{/ts}{/if}: <strong>{$amount|crmMoney}{if $amount_level } &ndash; {$amount_level}{/if}</strong>

--- a/templates/CRM/Contribute/Form/ContributionView.tpl
+++ b/templates/CRM/Contribute/Form/ContributionView.tpl
@@ -104,7 +104,7 @@
   {/if}
   {if $invoicing && $tax_amount}
     <tr>
-      <td class="label">{ts}Total Tax Amount{/ts}</td>
+      <td class="label">{ts}Total {$taxTerm} Amount{/ts}</td>
       <td>{$tax_amount|crmMoney:$currency}</td>
     </tr>
   {/if}

--- a/templates/CRM/Event/Form/Registration/Confirm.tpl
+++ b/templates/CRM/Event/Form/Registration/Confirm.tpl
@@ -119,7 +119,7 @@
             </div>
                 {if $totalTaxAmount}
                   <div class="crm-section no-label total-amount-section">
-                  <div class="content bold">{ts}Total Tax Amount{/ts}:&nbsp;&nbsp;{$totalTaxAmount|crmMoney}</div>
+                  <div class="content bold">{ts}Total {$taxTerm} Amount{/ts}:&nbsp;&nbsp;{$totalTaxAmount|crmMoney}</div>
                   <div class="clear"></div>
                   </div>
                 {/if}

--- a/templates/CRM/Price/Form/Field.tpl
+++ b/templates/CRM/Price/Form/Field.tpl
@@ -209,7 +209,7 @@
     var postUrl = "{/literal}{crmURL p='civicrm/ajax/memType' h=0}{literal}";
 
     cj.post( postUrl, {mtype: mtype}, function(data) {
-      cj("#option_amount_"+ row).val(data.total_amount);
+      cj("#option_amount_"+ row).val(data.total_amount_numeric);
       cj("#option_label_"+ row).val(data.name);
       cj("#option_financial_type_id_"+ row).val(data.financial_type_id);
       if (data.name) {

--- a/templates/CRM/Price/Form/Option.tpl
+++ b/templates/CRM/Price/Form/Option.tpl
@@ -115,7 +115,7 @@
         var mtype = cj("#membership_type_id").val();
         var postUrl = "{/literal}{crmURL p='civicrm/ajax/memType' h=0}{literal}";
         cj.post( postUrl, {mtype: mtype}, function( data ) {
-          cj("#amount").val( data.total_amount );
+          cj("#amount").val( data.total_amount_numeric );
           cj("#label").val( data.name );
 
         }, 'json');

--- a/templates/CRM/Price/Page/LineItem.tpl
+++ b/templates/CRM/Price/Page/LineItem.tpl
@@ -78,7 +78,7 @@
     {if $getTaxDetails}
       <td class="right">{$line.line_total|crmMoney}</td>
       {if $line.tax_rate != "" || $line.tax_amount != ""}
-        <td class="right">{$taxTerm} ({$line.tax_rate|string_format:"%.3f"}%)</td>
+        <td class="right">{$taxTerm} ({$line.tax_rate}%)</td>
         <td class="right">{$line.tax_amount|crmMoney}</td>
       {else}
         <td></td>
@@ -98,7 +98,7 @@
 <div class="crm-section no-label total_amount-section">
   <div class="content bold">
     {if $getTaxDetails && $totalTaxAmount}
-      {ts}Total Tax Amount{/ts}: {$totalTaxAmount|crmMoney}<br />
+      {ts}Total {$taxTerm} Amount{/ts}: {$totalTaxAmount|crmMoney}<br />
     {/if}
     {if $context EQ "Contribution"}
       {ts}Contribution Total{/ts}:

--- a/templates/CRM/Price/Page/Option.tpl
+++ b/templates/CRM/Price/Page/Option.tpl
@@ -89,7 +89,7 @@
               <td class="nowrap crm-price-option-order">{$row.weight}</td>
               {if $getTaxDetails}
                 <td>{if $row.tax_rate != '' }
-                      {$taxTerm} ({$row.tax_rate|string_format:"%.2f"}%)
+                      {$taxTerm} ({$row.tax_rate}%)
                     {/if}
                 </td>
                 <td>{$row.tax_amount|crmMoney}</td>

--- a/xml/schema/Member/MembershipType.xml
+++ b/xml/schema/Member/MembershipType.xml
@@ -115,7 +115,8 @@
   <field>
     <name>minimum_fee</name>
     <title>membership Type Minimum Fee</title>
-    <type>decimal</type>
+    <type>varchar</type>
+    <length>512</length>
     <comment>Minimum fee for this membership (0 for free/complimentary memberships).</comment>
     <default>0</default>
     <add>1.5</add>


### PR DESCRIPTION
The aim of this PR is to allow sales tax to be calculated properly where it is the inclusive amount that needs to be a round number, not the exclusive amount. So this allows the user to enter multiple decimal places for the exclusive amounts, which is used for the calculations.  Where it is displayed to the user it is still rounded to 2dp (or whatever the local currency supports).

---

 * [CRM-20772: \(WIP\) Price set calculation precision when sales tax enabled](https://issues.civicrm.org/jira/browse/CRM-20772)