### PR TITLE
CRM-20828 Remove limit 1 from saved mappings selection

### DIFF
--- a/CRM/Core/BAO/Mapping.php
+++ b/CRM/Core/BAO/Mapping.php
@@ -115,7 +115,7 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping {
    *   Array of mapping names, keyed by id.
    */
   public static function getMappings($mappingType) {
-    $result = civicrm_api3('Mapping', 'get', array('mapping_type_id' => $mappingType, 'options' => array('limit' => 1, 'sort' => 'name')));
+    $result = civicrm_api3('Mapping', 'get', array('mapping_type_id' => $mappingType, 'options' => array('sort' => 'name')));
     $mapping = array();
 
     foreach ($result['values'] as $key => $value) {


### PR DESCRIPTION
* [CRM-20828: Saved field mappings drop down is limited to 1](https://issues.civicrm.org/jira/browse/CRM-20828)