### PR TITLE
CRM-20829 Set port to null on default to stop failing requirements

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -570,7 +570,7 @@ class InstallRequirements {
       $host = implode(':', $hostParts);
     }
     else {
-      $port = '';
+      $port = null;
     }
     $conn = @mysqli_connect($host, $username, $password, $database, $port);
     return $conn;

--- a/install/index.php
+++ b/install/index.php
@@ -570,7 +570,7 @@ class InstallRequirements {
       $host = implode(':', $hostParts);
     }
     else {
-      $port = null;
+      $port = NULL;
     }
     $conn = @mysqli_connect($host, $username, $password, $database, $port);
     return $conn;


### PR DESCRIPTION
* [CRM-20829: Install requirements fail because of port string](https://issues.civicrm.org/jira/browse/CRM-20829)