### PR TITLE
Put back _ in socket and socket_options to refer correctly to staic v…

### DIFF
--- a/tools/scripts/composer/patches/net-smtp-tls-patch.txt
+++ b/tools/scripts/composer/patches/net-smtp-tls-patch.txt
@@ -7,8 +7,8 @@ index 28eae8c..8f4e92b 100644
                  return $result;
              }
 -            if (PEAR::isError($result = $this->_socket->enableCrypto(true, STREAM_CRYPTO_METHOD_TLS_CLIENT))) {
-+            if (isset($this->socket_options['ssl']['crypto_method'])) {
-+                $crypto_method = $this->socket_options['ssl']['crypto_method'];
++            if (isset($this->_socket_options['ssl']['crypto_method'])) {
++                $crypto_method = $this->_socket_options['ssl']['crypto_method'];
 +            } else {
 +                /* STREAM_CRYPTO_METHOD_TLS_ANY_CLIENT constant does not exist
 +                 * and STREAM_CRYPTO_METHOD_SSLv23_CLIENT constant is
@@ -17,7 +17,7 @@ index 28eae8c..8f4e92b 100644
 +                                 | @STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT
 +                                 | @STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT;
 +            }
-+            if (PEAR::isError($result = $this->socket->enableCrypto(true, $crypto_method))) {
++            if (PEAR::isError($result = $this->_socket->enableCrypto(true, $crypto_method))) {
                  return $result;
              } elseif ($result !== true) {
                  return PEAR::raiseError('STARTTLS failed');


### PR DESCRIPTION
…ariables

@totten @mlutfy @KarinG I think this might solve the issues with CiviSMTP,  Looking at this https://github.com/pear/Net_SMTP/blob/master/Net/SMTP.php#L114 it doesn't have _ in the variable name but their 1.6.x branch does https://github.com/pear/Net_SMTP/blob/1.6.x/Net/SMTP.php#L104