### PR TITLE
CRM-20833: Change APIv4 Entity Namespace

### DIFF
--- a/Civi/API/Request.php
+++ b/Civi/API/Request.php
@@ -73,7 +73,7 @@ class Request {
         return $apiRequest;
 
       case 4:
-        $callable = array("Civi\\Api4\\$entity", $action);
+        $callable = array("Civi\\API\\V4\\Entity\\$entity", $action);
         if (!is_callable($callable)) {
           throw new Exception\NotImplementedException("API ($entity, $action) does not exist (join the API team and implement it!)");
         }


### PR DESCRIPTION
## Overview

After a restructure in https://github.com/civicrm/api4/pull/67 the namespace for APIv4 entities has changed. Because of a hardcoded reference to this namespace in core code it needs to be updated

## Before

The APIv4 entity namespace pointed to `Civi\Api4`

## After

The APIv4 entity namespace points to `Civi\API\V4\Entity`

## Notes

This PR should not be merged before https://github.com/civicrm/api4/pull/67 is merged.

---

 * [CRM-20833: Change namespace for APIv4 entities](https://issues.civicrm.org/jira/browse/CRM-20833)