### PR TITLE
CRM-20838 - Add check for missing log tables on system status

### DIFF
--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -934,4 +934,16 @@ COLS;
     return array_intersect($tables, $this->tables);
   }
 
+  /**
+   * Retrieve missing log tables.
+   *
+   * @return array
+   */
+  public function getMissingLogTables() {
+    if ($this->tablesExist()) {
+      return array_diff($this->tables, array_keys($this->logs));
+    }
+    return array();
+  }
+
 }

--- a/CRM/Utils/Check/Component/Schema.php
+++ b/CRM/Utils/Check/Component/Schema.php
@@ -76,4 +76,31 @@ class CRM_Utils_Check_Component_Schema extends CRM_Utils_Check_Component {
     return $messages;
   }
 
+  /**
+   * @return array
+   */
+  public function checkMissingLogTables() {
+    $messages = array();
+    $logging = new CRM_Logging_Schema();
+    $missingLogTables = $logging->getMissingLogTables();
+
+    if ($missingLogTables) {
+      $msg = new CRM_Utils_Check_Message(
+        __FUNCTION__,
+        ts("You don't have logging enabled for some tables. This may cause errors on performing insert/update actions on them."),
+        ts('Missing Log Tables'),
+        \Psr\Log\LogLevel::WARNING,
+        'fa-server'
+      );
+      $msg->addAction(
+        ts('Update Log Tables'),
+        ts('Update logging now? This may take few minutes.'),
+        'api3',
+        array('System', 'updatelogtables')
+      );
+      $messages[] = $msg;
+    }
+    return $messages;
+  }
+
 }

--- a/CRM/Utils/Check/Component/Schema.php
+++ b/CRM/Utils/Check/Component/Schema.php
@@ -87,16 +87,16 @@ class CRM_Utils_Check_Component_Schema extends CRM_Utils_Check_Component {
     if ($missingLogTables) {
       $msg = new CRM_Utils_Check_Message(
         __FUNCTION__,
-        ts("You don't have logging enabled for some tables. This may cause errors on performing insert/update actions on them."),
+        ts("You don't have logging enabled on some tables. This may cause errors on performing insert/update operation on them."),
         ts('Missing Log Tables'),
         \Psr\Log\LogLevel::WARNING,
         'fa-server'
       );
       $msg->addAction(
-        ts('Update Log Tables'),
-        ts('Update logging now? This may take few minutes.'),
+        ts('Create Missing Log Tables'),
+        ts('Create missing log tables now? This may take few minutes.'),
         'api3',
-        array('System', 'updatelogtables')
+        array('System', 'createmissinglogtables')
       );
       $messages[] = $msg;
     }

--- a/api/v3/System.php
+++ b/api/v3/System.php
@@ -398,12 +398,6 @@ function _civicrm_api3_system_get_whitelist($whitelistFile) {
  */
 function civicrm_api3_system_updatelogtables() {
   $schema = new CRM_Logging_Schema();
-  $missingLogTables = $schema->getMissingLogTables();
-  if (!empty($missingLogTables)) {
-    foreach ($missingLogTables as $tableName) {
-      $schema->fixSchemaDifferencesFor($tableName, NULL, FALSE);
-    }
-  }
   $schema->updateLogTableSchema();
   return civicrm_api3_create_success(1);
 }
@@ -416,5 +410,21 @@ function civicrm_api3_system_updatelogtables() {
 function civicrm_api3_system_updateindexes() {
   list($missingIndices) = CRM_Core_BAO_SchemaHandler::getMissingIndices();
   CRM_Core_BAO_SchemaHandler::createMissingIndices($missingIndices);
+  return civicrm_api3_create_success(1);
+}
+
+/**
+ * Creates missing log tables.
+ *
+ * CRM-20838 - This adds any missing log tables into the database.
+ */
+function civicrm_api3_system_createmissinglogtables() {
+  $schema = new CRM_Logging_Schema();
+  $missingLogTables = $schema->getMissingLogTables();
+  if (!empty($missingLogTables)) {
+    foreach ($missingLogTables as $tableName) {
+      $schema->fixSchemaDifferencesFor($tableName, NULL, FALSE);
+    }
+  }
   return civicrm_api3_create_success(1);
 }

--- a/api/v3/System.php
+++ b/api/v3/System.php
@@ -398,6 +398,12 @@ function _civicrm_api3_system_get_whitelist($whitelistFile) {
  */
 function civicrm_api3_system_updatelogtables() {
   $schema = new CRM_Logging_Schema();
+  $missingLogTables = $schema->getMissingLogTables();
+  if (!empty($missingLogTables)) {
+    foreach ($missingLogTables as $tableName) {
+      $schema->fixSchemaDifferencesFor($tableName, NULL, FALSE);
+    }
+  }
   $schema->updateLogTableSchema();
   return civicrm_api3_create_success(1);
 }

--- a/tests/phpunit/api/v3/LoggingTest.php
+++ b/tests/phpunit/api/v3/LoggingTest.php
@@ -128,6 +128,18 @@ class api_v3_LoggingTest extends CiviUnitTestCase {
   }
 
   /**
+   * Check if we can create missing log tables using api.
+   */
+  public function testCreateMissingLogTables() {
+    $this->callAPISuccess('Setting', 'create', array('logging' => TRUE));
+    CRM_Core_DAO::executeQuery("DROP TABLE log_civicrm_contact");
+    $this->callAPISuccess('System', 'createmissinglogtables', array());
+
+    //Assert if log_civicrm_contact is created.
+    $this->checkLogTableCreated();
+  }
+
+  /**
    * Check we can update legacy log tables using the api function.
    */
   public function testUpdateLogTableHookINNODB() {


### PR DESCRIPTION
If drupal and civicrm share same db, drupal modules don't create log tables which result into db error while using them. Check [issue description ](https://issues.civicrm.org/jira/browse/CRM-20838) for when this could happen.

Instead of handling this on update or installation hook within module, this PR checks for missing log table and displays a message + button (just like `Update Indices`) on  system status page which calls `System - updatelogtable` api and creates missing log tables.

---

 * [CRM-20838: Cannot use any civi-drupal modules if logging is enabled](https://issues.civicrm.org/jira/browse/CRM-20838)