### PR TITLE
CRM-20834 - Drupal user not created via Profile due to missing email …

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -2046,6 +2046,14 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     if (!empty($this->_ccid)) {
       $this->_params['contribution_id'] = $this->_ccid;
     }
+    //Set email-bltID if pre/post profile contains an email.
+    if ($this->_emailExists == TRUE) {
+      foreach ($this->_params as $key => $val) {
+        if (substr($key, 0, 6) == 'email-' && empty($this->_params["email-{$this->_bltID}"])) {
+          $this->_params["email-{$this->_bltID}"] = $this->_params[$key];
+        }
+      }
+    }
     // add a description field at the very beginning
     $this->_params['description'] = ts('Online Contribution') . ': ' . (($this->_pcpInfo['title']) ? $this->_pcpInfo['title'] : $this->_values['title']);
 

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -227,6 +227,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       // lets just bump this to a regular session error and redirect user to main page
       $this->controller->invalidKeyRedirect();
     }
+    $this->_emailExists = $this->get('emailExists');
 
     // this was used prior to the cleverer this_>getContactID - unsure now
     $this->_userID = CRM_Core_Session::singleton()->getLoggedInContactID();
@@ -652,6 +653,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
               !in_array($profileContactType, array('honor', 'onbehalf'))
           ) {
             $this->_emailExists = TRUE;
+            $this->set('emailExists', TRUE);
           }
         }
 


### PR DESCRIPTION
…field. https://issues.civicrm.org/jira/browse/CRM-20834

Instead of reverting https://github.com/civicrm/civicrm-core/pull/10349, this PR sets main email with the value entered in profile email field. So, the flow would be-

1/ Populate profile email field and don't build main `email-bltId` field on main page.
2/ On confirming the contribution, fill `email-5` with the value entered in the above field(of profile) so that it takes care of additional functionalities that are progressed with `email-5` value. Eg creating drupal user etc. 

Thoughts?