### PR TITLE
CRM-20841 - Dedupe - Show on_hold, is_bulkmail or signature merge…

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -975,7 +975,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
       ),
       'email' => array(
         'label' => 'Email',
-        'displayField' => 'email',
+        'displayField' => 'display',
         'sortString' => 'location_type_id',
         'hasLocation' => TRUE,
         'hasType' => FALSE,
@@ -1171,6 +1171,10 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
             if ($blockName == 'address') {
               CRM_Core_BAO_Address::fixAddress($value);
               $locations[$moniker][$blockName][$cnt]['display'] = CRM_Utils_Address::format($value);
+            }
+            // Fix email display
+            elseif ($blockName == 'email') {
+              $locations[$moniker][$blockName][$cnt]['display'] = CRM_Utils_Mail::format($value);
             }
 
             $cnt++;

--- a/CRM/Utils/Mail.php
+++ b/CRM/Utils/Mail.php
@@ -520,4 +520,42 @@ class CRM_Utils_Mail {
     );
   }
 
+  /**
+   * Format an email string from email fields.
+   *
+   * @param array $fields
+   *   The email fields.
+   * @return string
+   *   The formatted email string.
+   */
+  public static function format($fields) {
+    $formattedEmail = '';
+    if (!empty($fields['email'])) {
+      $formattedEmail = $fields['email'];
+    }
+
+    $formattedSuffix = array();
+    if (!empty($fields['is_bulkmail'])) {
+      $formattedSuffix[] = '(' . ts('Bulk') . ')';
+    }
+    if (!empty($fields['on_hold'])) {
+      if ($fields['on_hold'] == 2) {
+        $formattedSuffix[] = '(' . ts('On Hold - Opt Out') . ')';
+      }
+      else {
+        $formattedSuffix[] = '(' . ts('On Hold') . ')';
+      }
+    }
+    if (!empty($fields['signature_html']) || !empty($fields['signature_text'])) {
+      $formattedSuffix[] = '(' . ts('Signature') . ')';
+    }
+
+    // Add suffixes on a new line, if there is any.
+    if (!empty($formattedSuffix)) {
+      $formattedEmail .= "\n" . implode(' ', $formattedSuffix);
+    }
+
+    return $formattedEmail;
+  }
+
 }

--- a/templates/CRM/Contact/Form/Merge.tpl
+++ b/templates/CRM/Contact/Form/Merge.tpl
@@ -114,8 +114,20 @@
 
           <td>
             {* @TODO check if this is ever an array or a fileName? *}
-            {* This is on one long line for address formatting *}
-            {if $row.title|substr:0:7 == "Address"}<span style="white-space: pre">{else}<span>{/if}{if !is_array($row.other)}{$row.other}{elseif $row.other.fileName}{$row.other.fileName}{else}{', '|implode:$row.other}{/if}</span>
+            {if $row.title|substr:0:5 == "Email"   OR
+                $row.title|substr:0:7 == "Address"}
+              <span style="white-space: pre">
+            {else}
+              <span>
+            {/if}
+            {if !is_array($row.other)}
+              {$row.other}
+            {elseif $row.other.fileName}
+              {$row.other.fileName}
+            {else}
+              {', '|implode:$row.other}
+            {/if}
+            </span>
           </td>
 
           <td style='white-space: nowrap'>
@@ -131,7 +143,8 @@
 
             <td>
               {strip}
-                {if $row.title|substr:0:7 == "Address"}
+                {if $row.title|substr:0:5 == "Email"   OR
+                    $row.title|substr:0:7 == "Address"}
                   <span style="white-space: pre" id="main_{$blockName}_{$blockId}">
                 {else}
                   <span id="main_{$blockName}_{$blockId}">


### PR DESCRIPTION
… conflicts

https://issues.civicrm.org/jira/projects/CRM/issues/CRM-20841

Overview
----------------------------------------
Displays the on_hold, bulkmail and signature status along the email adress in a merge form. If the email together its status differs between original and duplicate contact it is visually highlighted as a conflict.

Before
----------------------------------------
It is not shown that one of the emails is set to on hold and thus you may unitentionally overwrite that status.
![grafik](https://user-images.githubusercontent.com/19712240/37593761-6a19dd3e-2b73-11e8-9e86-79a0699faff5.png)


After
----------------------------------------
![grafik](https://user-images.githubusercontent.com/19712240/37593712-35307ccc-2b73-11e8-8157-a346c20c5566.png)


Technical Details
----------------------------------------
It is using the same technique as for the address handling.

Comments
----------------------------------------
This PR only handles checking whether a signature exists or not, but does not show a conflict if signatures only differ in their contents.