### PR TITLE
CRM-20833: Change APIv4 Entity Namespace Again

### DIFF
--- a/Civi/API/Request.php
+++ b/Civi/API/Request.php
@@ -73,7 +73,7 @@ class Request {
         return $apiRequest;
 
       case 4:
-        $callable = array("Civi\\API\\V4\\Entity\\$entity", $action);
+        $callable = array("Civi\\Api4\\Entity\\$entity", $action);
         if (!is_callable($callable)) {
           throw new Exception\NotImplementedException("API ($entity, $action) does not exist (join the API team and implement it!)");
         }


### PR DESCRIPTION
## Overview

Although it was just updated we decided to change the `API\V4` namespace as it's longer than necessary and we would be better sticking to the `Vendor\Package` convention, in this case `Civi\Api4`.

## Before

The APIv4 entity namespace pointed to `Civi\API\V4\Entity`

## After

The APIv4 entity namespace points to `Civi\Api4\Entity`

## Notes

This PR should not be merged before https://github.com/civicrm/api4/pull/69 is merged.

---

 * [CRM-20833: Change namespace for APIv4 entities](https://issues.civicrm.org/jira/browse/CRM-20833)