### PR TITLE
CRM-20849: Allow duplicate PSR-4 prefixes

### DIFF
--- a/CRM/Extension/ClassLoader.php
+++ b/CRM/Extension/ClassLoader.php
@@ -114,7 +114,7 @@ class CRM_Extension_ClassLoader {
         foreach ($info->classloader as $mapping) {
           switch ($mapping['type']) {
             case 'psr4':
-              $loader->setPsr4($mapping['prefix'], $path . '/' . $mapping['path']);
+              $loader->addPsr4($mapping['prefix'], $path . '/' . $mapping['path']);
               break;
           }
           $result[] = $mapping;


### PR DESCRIPTION
## Overview

Currently when adding prefixes from an extension `info.xml` it uses the method `setPsr4` which replaces and existing PSR-4 mapping with the same prefix.

We should allow multiple extensions to use the same namespace, particularly since the `Civi\` namespace (which is used by core) is likely to be copied by extension authors.

## Before

Two extensions using the same PSR-4 prefix will only allow classes from one to be autoloaded.

## After

Multiple extensions can use the same PSR-4 prefix.

---

 * [CRM-20849: Multiple extensions using the same autoloader prefix will overwrite previous](https://issues.civicrm.org/jira/browse/CRM-20849)