### PR TITLE
CRM-20850 Replace fatal with statusBounce

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -182,7 +182,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
       $contributionID = CRM_Member_BAO_Membership::getMembershipContributionId($this->_id);
       // check delete permission for contribution
       if ($this->_id && $contributionID && !CRM_Core_Permission::checkActionPermission('CiviContribute', $this->_action)) {
-        CRM_Core_Error::fatal(ts("This Membership is linked to a contribution. You must have 'delete in CiviContribute' permission in order to delete this record."));
+        CRM_Core_Error::statusBounce(ts("This Membership is linked to a contribution. You must have 'delete in CiviContribute' permission in order to delete this record."));
       }
     }
 


### PR DESCRIPTION
Ref CRM-20772 @eileenmcnaughton

---

 * [CRM-20850: Replace fatal with statusBounce in membership form](https://issues.civicrm.org/jira/browse/CRM-20850)
 * [CRM-20772: \(WIP\) Price set calculation precision when sales tax enabled](https://issues.civicrm.org/jira/browse/CRM-20772)