### PR TITLE
CRM-20861 : Location type does not show for custom address fields

### DIFF
--- a/CRM/UF/Form/Field.php
+++ b/CRM/UF/Form/Field.php
@@ -196,6 +196,7 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
       ));
       return;
     }
+    $addressCustomFields = array_keys(CRM_Core_BAO_CustomField::getFieldsForImport('Address'));
 
     if (isset($this->_id)) {
       $params = array('id' => $this->_id);
@@ -204,8 +205,7 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
       // set it to null if so (avoids crappy E_NOTICE errors below
       $defaults['location_type_id'] = CRM_Utils_Array::value('location_type_id', $defaults);
 
-      $specialFields = CRM_Core_BAO_UFGroup::getLocationFields();
-
+      $specialFields = array_merge(CRM_Core_BAO_UFGroup::getLocationFields(), $addressCustomFields);
       if (!$defaults['location_type_id'] &&
         $defaults["field_type"] != "Formatting" &&
         in_array($defaults['field_name'], $specialFields)
@@ -245,7 +245,6 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
     $fields = CRM_Core_BAO_UFField::getAvailableFields($this->_gid, $defaults);
 
     $noSearchable = $hasWebsiteTypes = array();
-    $addressCustomFields = array_keys(CRM_Core_BAO_CustomField::getFieldsForImport('Address'));
 
     foreach ($fields as $key => $value) {
       foreach ($value as $key1 => $value1) {

--- a/CRM/UF/Form/Field.php
+++ b/CRM/UF/Form/Field.php
@@ -205,6 +205,7 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
       // set it to null if so (avoids crappy E_NOTICE errors below
       $defaults['location_type_id'] = CRM_Utils_Array::value('location_type_id', $defaults);
 
+      //CRM-20861 - Include custom fields defined for address to set its default location type to 0.
       $specialFields = array_merge(CRM_Core_BAO_UFGroup::getLocationFields(), $addressCustomFields);
       if (!$defaults['location_type_id'] &&
         $defaults["field_type"] != "Formatting" &&


### PR DESCRIPTION
`$specialFields` here sets `0`(Primary) for all the core location fields. It should also set them for address custom fields.

---

 * [CRM-20861: Location type does not show for custom address fields](https://issues.civicrm.org/jira/browse/CRM-20861)