### PR TITLE
CRM-19739 : New Account Relationship Option Screen does not show excep…

### DIFF
--- a/CRM/Financial/BAO/FinancialTypeAccount.php
+++ b/CRM/Financial/BAO/FinancialTypeAccount.php
@@ -273,7 +273,7 @@ WHERE cog.name = 'payment_instrument' ";
    *
    * @param obj $financialTypeAccount of CRM_Financial_DAO_EntityFinancialAccount
    *
-  * @throws CRM_Core_Exception
+   * @throws CRM_Core_Exception
    */
   public static function validateRelationship($financialTypeAccount) {
     $financialAccountLinks = CRM_Financial_BAO_FinancialAccount::getfinancialAccountRelations();

--- a/CRM/Financial/BAO/FinancialTypeAccount.php
+++ b/CRM/Financial/BAO/FinancialTypeAccount.php
@@ -91,7 +91,10 @@ class CRM_Financial_BAO_FinancialTypeAccount extends CRM_Financial_DAO_EntityFin
       $financialTypeAccount->find(TRUE);
     }
     $financialTypeAccount->copyValues($params);
-    self::validateRelationship($financialTypeAccount);
+    $valid = self::validateRelationship($financialTypeAccount);
+    if (!$valid) {
+      return FALSE;
+    }
     $financialTypeAccount->save();
     return $financialTypeAccount;
   }
@@ -102,6 +105,7 @@ class CRM_Financial_BAO_FinancialTypeAccount extends CRM_Financial_DAO_EntityFin
    * @param int $financialTypeAccountId
    * @param int $accountId
    *
+   * @return bool
    */
   public static function del($financialTypeAccountId, $accountId = NULL) {
     // check if financial type is present
@@ -282,8 +286,10 @@ WHERE cog.name = 'payment_instrument' ";
       $params = array(
         1 => $accountRelationships[$financialTypeAccount->account_relationship],
       );
-      throw new Exception(ts("This financial account cannot have '%1' relationship.", $params));
+      CRM_Core_Session::setStatus(ts('This financial account cannot have \'%1\' relationship.', $params), ts('Error'), 'error');
+      return FALSE;
     }
+    return TRUE;
   }
 
 }

--- a/CRM/Financial/BAO/FinancialTypeAccount.php
+++ b/CRM/Financial/BAO/FinancialTypeAccount.php
@@ -91,10 +91,7 @@ class CRM_Financial_BAO_FinancialTypeAccount extends CRM_Financial_DAO_EntityFin
       $financialTypeAccount->find(TRUE);
     }
     $financialTypeAccount->copyValues($params);
-    $valid = self::validateRelationship($financialTypeAccount);
-    if (!$valid) {
-      return FALSE;
-    }
+    self::validateRelationship($financialTypeAccount);
     $financialTypeAccount->save();
     return $financialTypeAccount;
   }
@@ -105,7 +102,6 @@ class CRM_Financial_BAO_FinancialTypeAccount extends CRM_Financial_DAO_EntityFin
    * @param int $financialTypeAccountId
    * @param int $accountId
    *
-   * @return bool
    */
   public static function del($financialTypeAccountId, $accountId = NULL) {
     // check if financial type is present
@@ -277,6 +273,7 @@ WHERE cog.name = 'payment_instrument' ";
    *
    * @param obj $financialTypeAccount of CRM_Financial_DAO_EntityFinancialAccount
    *
+  * @throws CRM_Core_Exception
    */
   public static function validateRelationship($financialTypeAccount) {
     $financialAccountLinks = CRM_Financial_BAO_FinancialAccount::getfinancialAccountRelations();
@@ -286,10 +283,8 @@ WHERE cog.name = 'payment_instrument' ";
       $params = array(
         1 => $accountRelationships[$financialTypeAccount->account_relationship],
       );
-      CRM_Core_Session::setStatus(ts('This financial account cannot have \'%1\' relationship.', $params), ts('Error'), 'error');
-      return FALSE;
+      throw new CRM_Core_Exception(ts("This financial account cannot have '%1' relationship.", $params));
     }
-    return TRUE;
   }
 
 }

--- a/CRM/Financial/Form/FinancialTypeAccount.php
+++ b/CRM/Financial/Form/FinancialTypeAccount.php
@@ -299,10 +299,13 @@ class CRM_Financial_Form_FinancialTypeAccount extends CRM_Contribute_Form {
       if ($this->_action & CRM_Core_Action::ADD) {
         $params['entity_id'] = $this->_aid;
       }
-      $financialTypeAccount = CRM_Financial_BAO_FinancialTypeAccount::add($params, $ids);
-      if ($financialTypeAccount) {
-        CRM_Core_Session::setStatus(ts('The financial type Account has been saved.'));
+      try {
+        $financialTypeAccount = CRM_Financial_BAO_FinancialTypeAccount::add($params, $ids);
       }
+      catch (CRM_Core_Exception $e) {
+        CRM_Core_Error::statusBounce($e->getMessage());
+      }
+      CRM_Core_Session::setStatus(ts('The financial type Account has been saved.'));
     }
 
     $buttonName = $this->controller->getButtonName();

--- a/CRM/Financial/Form/FinancialTypeAccount.php
+++ b/CRM/Financial/Form/FinancialTypeAccount.php
@@ -300,7 +300,9 @@ class CRM_Financial_Form_FinancialTypeAccount extends CRM_Contribute_Form {
         $params['entity_id'] = $this->_aid;
       }
       $financialTypeAccount = CRM_Financial_BAO_FinancialTypeAccount::add($params, $ids);
-      CRM_Core_Session::setStatus(ts('The financial type Account has been saved.'));
+      if ($financialTypeAccount) {
+        CRM_Core_Session::setStatus(ts('The financial type Account has been saved.'));
+      }
     }
 
     $buttonName = $this->controller->getButtonName();

--- a/CRM/Financial/Form/FinancialTypeAccount.php
+++ b/CRM/Financial/Form/FinancialTypeAccount.php
@@ -301,11 +301,11 @@ class CRM_Financial_Form_FinancialTypeAccount extends CRM_Contribute_Form {
       }
       try {
         $financialTypeAccount = CRM_Financial_BAO_FinancialTypeAccount::add($params, $ids);
+        CRM_Core_Session::setStatus(ts('The financial type Account has been saved.'), ts('Saved'), 'success');
       }
       catch (CRM_Core_Exception $e) {
         CRM_Core_Error::statusBounce($e->getMessage());
       }
-      CRM_Core_Session::setStatus(ts('The financial type Account has been saved.'));
     }
 
     $buttonName = $this->controller->getButtonName();

--- a/tests/phpunit/CRM/Financial/BAO/FinancialTypeAccountTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/FinancialTypeAccountTest.php
@@ -131,8 +131,14 @@ class CRM_Financial_BAO_FinancialTypeAccountTest extends CiviUnitTestCase {
     $financialAccountType->entity_id = array_search('Member Dues', $financialType);
     $financialAccountType->account_relationship = array_search('Credit/Contra Revenue Account is', $accountRelationships);
     $financialAccountType->financial_account_id = array_search('Liability', $financialAccount);
-    $valid = CRM_Financial_BAO_FinancialTypeAccount::validateRelationship($financialAccountType);
-    $this->assertFalse($valid);
+    try {
+      CRM_Financial_BAO_FinancialTypeAccount::validateRelationship($financialAccountType);
+      $this->fail("Missed expected exception");
+    }
+    catch (Exception $e) {
+      $this->assertTrue(TRUE, 'Received expected exception');
+      $this->assertEquals($e->getMessage(), "This financial account cannot have 'Credit/Contra Revenue Account is' relationship.");
+    }
   }
 
   /**

--- a/tests/phpunit/CRM/Financial/BAO/FinancialTypeAccountTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/FinancialTypeAccountTest.php
@@ -131,14 +131,8 @@ class CRM_Financial_BAO_FinancialTypeAccountTest extends CiviUnitTestCase {
     $financialAccountType->entity_id = array_search('Member Dues', $financialType);
     $financialAccountType->account_relationship = array_search('Credit/Contra Revenue Account is', $accountRelationships);
     $financialAccountType->financial_account_id = array_search('Liability', $financialAccount);
-    try {
-      CRM_Financial_BAO_FinancialTypeAccount::validateRelationship($financialAccountType);
-      $this->fail("Missed expected exception");
-    }
-    catch (Exception $e) {
-      $this->assertTrue(TRUE, 'Received expected exception');
-      $this->assertEquals($e->getMessage(), "This financial account cannot have 'Credit/Contra Revenue Account is' relationship.");
-    }
+    $valid = CRM_Financial_BAO_FinancialTypeAccount::validateRelationship($financialAccountType);
+    $this->assertFalse($valid);
   }
 
   /**


### PR DESCRIPTION
…tion 

Exception fails to show message on ajax pop-up, hence replaced it with `setStatus()` and returned false if relationship isn't calculated as valid.

---

 * [CRM-19739: "New Account Relationship Option Screen" does not show exception](https://issues.civicrm.org/jira/browse/CRM-19739)