### PR TITLE
CRM-19017 : Load default params for fragment query object and fix db error.

### DIFF
--- a/CRM/Member/ActionMapping.php
+++ b/CRM/Member/ActionMapping.php
@@ -80,7 +80,7 @@ class CRM_Member_ActionMapping extends \Civi\ActionSchedule\Mapping {
     $selectedValues = (array) \CRM_Utils_Array::explodePadded($schedule->entity_value);
     $selectedStatuses = (array) \CRM_Utils_Array::explodePadded($schedule->entity_status);
 
-    $query = \CRM_Utils_SQL_Select::from("{$this->entity} e")->param($defaultParams);;
+    $query = \CRM_Utils_SQL_Select::from("{$this->entity} e")->param($defaultParams);
     $query['casAddlCheckFrom'] = 'civicrm_membership e';
     $query['casContactIdField'] = 'e.contact_id';
     $query['casEntityIdField'] = 'e.id';


### PR DESCRIPTION
I've got these errors while executing the SR for the screenshot attached in the issue.

1. Cannot build query. Variable "@memberTypeValues" is unknown."
2. Cannot build query. Variable "!casActionScheduleId" is unknown."
3. Cannot build query. Variable "!casNow" is unknown."
4. DB Syntax error for missing closing brace in having clause.

---

 * [CRM-19017: Scheduled membership reminders have stopped working](https://issues.civicrm.org/jira/browse/CRM-19017)