### PR TITLE
CRM-20871 - crmUiSelect - UI should stay in sync with model

### DIFF
--- a/ang/crmUi.js
+++ b/ang/crmUi.js
@@ -576,6 +576,7 @@
     .directive('crmUiSelect', function ($parse, $timeout) {
       return {
         require: '?ngModel',
+        priority: 1,
         scope: {
           crmUiSelect: '='
         },
@@ -611,7 +612,6 @@
             element.crmSelect2(scope.crmUiSelect || {});
             if (ngModel) {
               element.on('change', refreshModel);
-              $timeout(ngModel.$render);
             }
           }
 


### PR DESCRIPTION
The `crmUiSelect` defines the function `$render()` -- whenever the model changes, it should execute `$render()` to update the UI.  But it doesn't.

This issue is discussed more in https://stackoverflow.com/questions/21084088/why-ngmodels-render-is-not-called-when-the-model-changes-in-angularjs

== Before ==

The `$render()` function for directive `crm-ui-select` is not called because the `select`
directive overrides it.

== After ==

The `$render()` function for directive `crm-ui-select` is called, even if
used on a `select` element.

== Acceptance Criteria ==

1. In "org.civicrm.civicase", the "Clear filters" and "Activity Category" stay synchronized.

2. In "[org.example.angpage](https://github.com/totten/org.example.angpage)" ("civicrm/a/#/play"), all element stay synchronized.

3. Existing screens which use the crmUiSelect element work as expected. (For ideas, perhaps grep the codebase and also check the history from CRM-20390.) 

---

 * [CRM-20871: crmUiSelect fails to update when model changes](https://issues.civicrm.org/jira/browse/CRM-20871)

---

 * [CRM-20390: Data type mismatch in angular select2 bindings](https://issues.civicrm.org/jira/browse/CRM-20390)