### PR TITLE
CRM-20875 - Fix membership import to avoid notice error to be thrown

### DIFF
--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -279,7 +279,8 @@ class CRM_Member_Import_Parser_Membership extends CRM_Member_Import_Parser {
       $session = CRM_Core_Session::singleton();
       $dateType = $session->get('dateTypes');
       $formatted = array();
-      $customFields = CRM_Core_BAO_CustomField::getFields(CRM_Utils_Array::value('contact_type', $params));
+      $customDataType = !empty($params['contact_type']) ? $params['contact_type'] : 'Membership';
+      $customFields = CRM_Core_BAO_CustomField::getFields($customDataType);
 
       // don't add to recent items, CRM-4399
       $formatted['skipRecentView'] = TRUE;


### PR DESCRIPTION
* [CRM-20875: Import of membership custom data throws notice errors.](https://issues.civicrm.org/jira/browse/CRM-20875)