### PR TITLE
CRM-20876 - ensure honor block variable is passed to template

### DIFF
--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -385,6 +385,7 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
         'is_pay_later' => $values['is_pay_later'],
         'receipt_date' => !$values['receipt_date'] ? NULL : date('YmdHis', strtotime($values['receipt_date'])),
         'pay_later_receipt' => CRM_Utils_Array::value('pay_later_receipt', $values),
+        'honor_block_is_active' => CRM_Utils_Array::value('honor_block_is_active', $values),
       );
 
       if ($contributionTypeId = CRM_Utils_Array::value('financial_type_id', $values)) {


### PR DESCRIPTION
Otherwise, it's not on the receipt.

---

 * [CRM-20876: in honor of does not show up on contribution receipt](https://issues.civicrm.org/jira/browse/CRM-20876)