### PR TITLE
CRM-20884 Remove vendor/pear/net_smtp/README.rst also.

### DIFF
--- a/tools/scripts/composer/net-smtp-fix.sh
+++ b/tools/scripts/composer/net-smtp-fix.sh
@@ -39,4 +39,4 @@ if grep -q '&Auth_SASL::factory' vendor/pear/net_smtp/Net/SMTP.php; then
   patch vendor/pear/net_smtp/Net/SMTP.php < tools/scripts/composer/patches/net-smtp-ref-patch.txt
 fi
 
-safe_delete vendor/pear/net_smtp/{examples,phpdoc.sh,tests}
+safe_delete vendor/pear/net_smtp/{README.rst,examples,phpdoc.sh,tests}


### PR DESCRIPTION
@jackrabbithanna Mark this is a port of Chris' patch here https://github.com/civicrm/civicrm-core/pull/10676

---

 * [CRM-20884: broken symlink in net_smtp packages](https://issues.civicrm.org/jira/browse/CRM-20884)