### PR TITLE
CRM_Utils_SQL_Select - Allow fluent query execution

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1033,6 +1033,22 @@ FROM   civicrm_domain
   }
 
   /**
+   * Returns a singular value.
+   *
+   * @return mixed|NULL
+   */
+  public function fetchValue() {
+    $result = $this->getDatabaseResult();
+    $row = $result->fetchRow();
+    $ret = NULL;
+    if ($row) {
+      $ret = $row[0];
+    }
+    $this->free();
+    return $ret;
+  }
+
+  /**
    * Get all the result records as mapping between columns.
    *
    * @param string $keyColumn

--- a/CRM/Utils/SQL/Select.php
+++ b/CRM/Utils/SQL/Select.php
@@ -594,6 +594,25 @@ class CRM_Utils_SQL_Select implements ArrayAccess {
   }
 
   /**
+   * @return CRM_Core_DAO
+   */
+  public function execute($daoName = NULL, $i18nRewrite = TRUE) {
+    // Don't pass through $params. toSQL() handles interpolation.
+    $params = array();
+
+    // Don't pass through $abort, $trapException. Just use straight-up exceptions.
+    $abort = TRUE;
+    $trapException = FALSE;
+    $errorScope = CRM_Core_TemporaryErrorScope::useException();
+
+    // Don't pass through freeDAO. You can do it yourself.
+    $freeDAO = FALSE;
+
+    return CRM_Core_DAO::executeQuery($this->toSQL(), $params, $abort, $daoName,
+      $freeDAO, $i18nRewrite, $trapException);
+  }
+
+  /**
    * Has an offset been set.
    *
    * @param string $offset

--- a/CRM/Utils/SQL/Select.php
+++ b/CRM/Utils/SQL/Select.php
@@ -594,7 +594,20 @@ class CRM_Utils_SQL_Select implements ArrayAccess {
   }
 
   /**
+   * Execute the query.
+   *
+   * To examine the results, use a function like `fetch()`, `fetchAll()`,
+   * `fetchValue()`, or `fetchMap()`.
+   *
+   * @param string|NULL $daoName
+   *   The return object should be an instance of this class.
+   *   Ex: 'CRM_Contact_BAO_Contact'.
+   * @param bool $i18nRewrite
+   *   If the system has multilingual features, should the field/table
+   *   names be rewritten?
    * @return CRM_Core_DAO
+   * @see CRM_Core_DAO::executeQuery
+   * @see CRM_Core_I18n_Schema::rewriteQuery
    */
   public function execute($daoName = NULL, $i18nRewrite = TRUE) {
     // Don't pass through $params. toSQL() handles interpolation.

--- a/tests/phpunit/CRM/Utils/SQL/SelectTest.php
+++ b/tests/phpunit/CRM/Utils/SQL/SelectTest.php
@@ -10,13 +10,12 @@ class CRM_Utils_SQL_SelectTest extends CiviUnitTestCase {
     $this->assertLike('SELECT * FROM foo bar', $select->toSQL());
   }
 
-  public function testExecute_OK() {
-    // We need some SQL query.
-    $select = CRM_Utils_SQL_Select::from('civicrm_contact')
-      ->select('count(*) as cnt');
+  public function testExecute_OK_fetch() {
+    $select = CRM_Utils_SQL_Select::from('civicrm_contact')->select('count(*) as cnt');
     $this->assertLike('SELECT count(*) as cnt FROM civicrm_contact', $select->toSQL());
 
-    // Try with typical fetch().
+    $select = CRM_Utils_SQL_Select::from('civicrm_contact')
+      ->select('count(*) as cnt');
     $rows = 0;
     $dao = $select->execute();
     while ($dao->fetch()) {
@@ -24,18 +23,26 @@ class CRM_Utils_SQL_SelectTest extends CiviUnitTestCase {
       $this->assertTrue(is_numeric($dao->cnt), "Expect query to execute");
     }
     $this->assertEquals(1, $rows);
+  }
 
-    // Try with fetchValue().
+  public function testExecute_OK_fetchValue() {
+    $select = CRM_Utils_SQL_Select::from('civicrm_contact')->select('count(*) as cnt');
+    $this->assertLike('SELECT count(*) as cnt FROM civicrm_contact', $select->toSQL());
     $this->assertTrue(is_numeric($select->execute()->fetchValue()));
+  }
 
-    // Try with fetchAll()
+  public function testExecute_OK_fetchAll() {
+    $select = CRM_Utils_SQL_Select::from('civicrm_contact')->select('count(*) as cnt');
+    $this->assertLike('SELECT count(*) as cnt FROM civicrm_contact', $select->toSQL());
     $records = $select->execute()->fetchAll();
     $this->assertTrue(is_numeric($records[0]['cnt']));
   }
 
   public function testExecute_Error() {
+    $select = CRM_Utils_SQL_Select::from('civicrm_contact')->select('snarb;barg');
+
     try {
-      CRM_Utils_SQL_Select::from('civicrm_contact')->select('snarb;barg')->execute();
+      $select->execute();
       $this->fail('Expected an exception');
     }
     catch (PEAR_Exception $e) {

--- a/tests/phpunit/CRM/Utils/SQL/SelectTest.php
+++ b/tests/phpunit/CRM/Utils/SQL/SelectTest.php
@@ -10,6 +10,39 @@ class CRM_Utils_SQL_SelectTest extends CiviUnitTestCase {
     $this->assertLike('SELECT * FROM foo bar', $select->toSQL());
   }
 
+  public function testExecute_OK() {
+    // We need some SQL query.
+    $select = CRM_Utils_SQL_Select::from('civicrm_contact')
+      ->select('count(*) as cnt');
+    $this->assertLike('SELECT count(*) as cnt FROM civicrm_contact', $select->toSQL());
+
+    // Try with typical fetch().
+    $rows = 0;
+    $dao = $select->execute();
+    while ($dao->fetch()) {
+      $rows++;
+      $this->assertTrue(is_numeric($dao->cnt), "Expect query to execute");
+    }
+    $this->assertEquals(1, $rows);
+
+    // Try with fetchValue().
+    $this->assertTrue(is_numeric($select->execute()->fetchValue()));
+
+    // Try with fetchAll()
+    $records = $select->execute()->fetchAll();
+    $this->assertTrue(is_numeric($records[0]['cnt']));
+  }
+
+  public function testExecute_Error() {
+    try {
+      CRM_Utils_SQL_Select::from('civicrm_contact')->select('snarb;barg')->execute();
+      $this->fail('Expected an exception');
+    }
+    catch (PEAR_Exception $e) {
+      $this->assertTrue(TRUE, "Received expected exception");
+    }
+  }
+
   public function testGetFields() {
     $select = CRM_Utils_SQL_Select::from('foo')
       ->select('bar')


### PR DESCRIPTION
When I first wrote `CRM_Utils_SQL_Select`, I was a bit dogmatic about
loose-coupling and wanted the class to be entirely independent of the SQL
runtime. But this is a bit annoying in usage and training.

Before
======

To build and execute query, you had to pass the rendered SQL to the execute
function, eg

```php
$select = CRM_Utils_SQL_Select::from('mytable')
  ->select('...')
$dao = CRM_Core_DAO::executeQuery($select->toSQL());
while ($dao->fetch()) { ... }
```

After
=====

You can use more fluent style:

```php
$dao = CRM_Utils_SQL_Select::from('mytable')
  ->select('...')
  ->execute();
while ($dao->fetch()) { ... }
```

And you can chain with other DAO functions like `fetchAll()`,
`fetchValue()`, or `fetchMap()`.

```php
$records = CRM_Utils_SQL_Select::from('mytable')
  ->select('...')
  ->execute()
  ->fetchAll();
```