### PR TITLE
CRM-20904 : joomla cron run - load all daos defined in extensions

### DIFF
--- a/CRM/Utils/Hook/Joomla.php
+++ b/CRM/Utils/Hook/Joomla.php
@@ -123,6 +123,12 @@ class CRM_Utils_Hook_Joomla extends CRM_Utils_Hook {
       }
       return $result;
     }
+    else {
+      // CRM-20904: We should still call Civi extension hooks even if Joomla isn't online yet.
+      return $this->commonInvoke($numParams,
+        $arg1, $arg2, $arg3, $arg4, $arg5, $arg6,
+        $fnSuffix, 'joomla');
+    }
   }
 
 }


### PR DESCRIPTION
Joomla doesn't invoke any hooks [until J_EXEC is set](https://github.com/civicrm/civicrm-core/blob/master/CRM/Utils/Hook/Joomla.php#L73-L76). 

And when cron job is executed via URL - Config run loads all core [DAO's in `$self::entityTypes`](https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/DAO/AllCoreTables.php#L46) before joomla is actually bootstraped, this value is unchanged and only keeps core value defined in it.

Fix here does a fresh load of all the DAO's defined in extensions, custom modules, etc soon after the bootstrap is done successfully.

---

 * [CRM-20904: Joomla - Fatal Error when schedule job is executed from cron.php](https://issues.civicrm.org/jira/browse/CRM-20904)