### PR TITLE
CRM-20910: Check permission param while retrieving participants from api

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -6121,7 +6121,8 @@ AND   displayRelType.is_active = 1
       $pseudoOptions = CRM_Core_PseudoConstant::worldRegion();
     }
     elseif ($daoName == 'CRM_Event_DAO_Event' && $fieldName == 'id') {
-      $pseudoOptions = CRM_Event_BAO_Event::getEvents(0, $fieldValue, TRUE, TRUE, TRUE);
+      $checkPermission = CRM_Utils_Array::value('check_permission', $pseudoExtraParam, TRUE);
+      $pseudoOptions = CRM_Event_BAO_Event::getEvents(0, $fieldValue, TRUE, $checkPermission, TRUE);
     }
     elseif ($fieldName == 'contribution_product_id') {
       $pseudoOptions = CRM_Contribute_PseudoConstant::products();

--- a/CRM/Event/BAO/Query.php
+++ b/CRM/Event/BAO/Query.php
@@ -253,6 +253,10 @@ class CRM_Event_BAO_Query extends CRM_Core_BAO_Query {
    * @param $query
    */
   public static function whereClauseSingle(&$values, &$query) {
+    $checkPermission = TRUE;
+    if (!empty($query->_skipPermission)) {
+      $checkPermission = FALSE;
+    }
     list($name, $op, $value, $grouping, $wildcard) = $values;
     $fields = array_merge(CRM_Event_BAO_Event::fields(), CRM_Event_BAO_Participant::exportableFields());
 
@@ -461,7 +465,7 @@ class CRM_Event_BAO_Query extends CRM_Core_BAO_Query {
         if (!array_key_exists($qillName, $fields)) {
           break;
         }
-        list($op, $value) = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Event_DAO_Event', $name, $value, $op);
+        list($op, $value) = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Event_DAO_Event', $name, $value, $op, array('check_permission' => $checkPermission));
         $query->_qill[$grouping][] = ts('%1 %2 %3', array(1 => $fields[$qillName]['title'], 2 => $op, 3 => $value));
         return;
     }

--- a/CRM/Event/BAO/Query.php
+++ b/CRM/Event/BAO/Query.php
@@ -253,10 +253,7 @@ class CRM_Event_BAO_Query extends CRM_Core_BAO_Query {
    * @param $query
    */
   public static function whereClauseSingle(&$values, &$query) {
-    $checkPermission = TRUE;
-    if (!empty($query->_skipPermission)) {
-      $checkPermission = FALSE;
-    }
+    $checkPermission = empty($query->_skipPermission);
     list($name, $op, $value, $grouping, $wildcard) = $values;
     $fields = array_merge(CRM_Event_BAO_Event::fields(), CRM_Event_BAO_Participant::exportableFields());
 

--- a/tests/phpunit/api/v3/ParticipantTest.php
+++ b/tests/phpunit/api/v3/ParticipantTest.php
@@ -207,6 +207,30 @@ class api_v3_ParticipantTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test permission for participant get.
+   */
+  public function testGetParticipantWithPermission() {
+    $config = CRM_Core_Config::singleton();
+    $config->userPermissionClass->permissions = array();
+    $params = array(
+      'event_id' => $this->_eventID,
+      'check_permissions' => TRUE,
+      'return' => array(
+        'participant_id',
+        'event_id',
+        'participant_register_date',
+        'participant_source',
+      ),
+    );
+    $this->callAPIFailure('participant', 'get', $params);
+
+    $params['check_permissions'] = FALSE;
+    $result = $this->callAPISuccess('participant', 'get', $params);
+    $this->assertEquals($result['is_error'], 0);
+  }
+
+
+  /**
    * Check with params id.
    */
   public function testGetParamsAsIdOnly() {


### PR DESCRIPTION
Unit test added.

* [CRM-20910: API call to Participant.get ignores check_permissons](https://issues.civicrm.org/jira/browse/CRM-20910)

