### PR TITLE
regen.sh - Fix stale function call in sql/GenerateData.php

### DIFF
--- a/sql/GenerateData.php
+++ b/sql/GenerateData.php
@@ -1843,7 +1843,7 @@ order by cc.id; ";
     $select = 'SELECT contribution.id contribution_id, cli.id as line_item_id, contribution.contact_id, contribution.receive_date, contribution.total_amount, contribution.currency, cli.label,
       cli.financial_type_id,  cefa.financial_account_id, contribution.payment_instrument_id, contribution.check_number, contribution.trxn_id';
     $where = 'WHERE cefa.account_relationship = 1';
-    $financialAccountId = CRM_Financial_BAO_FinancialTypeAccount::getInstrumentFinancialAccount();
+    $financialAccountId = CRM_Financial_BAO_FinancialTypeAccount::getInstrumentFinancialAccount(4);
     foreach ($components as $component) {
       if ($component == 'contribution') {
         $from = 'FROM `civicrm_contribution` contribution';


### PR DESCRIPTION
In [#10463](https://github.com/civicrm/civicrm-core/pull/10463), the
function signature of `getInstrumentFinancialAccount()` changed slightly -- in that
the parameter became mandatory.

Grepping for other calls to `getInstrumentFinancialAccount()` shows that one of the unit-tests
works with example input `4`, so this does the same.

Before
======

Running "regen.sh" fails -- because `getInstrumentFinancialAccount` is called without a parameter.

After
=====

Running "regen.sh" completes -- because `getInstrumentFinancialAccount` is called with `4`.

Acceptance Prompts
==================

 * The example data produced by `regen.sh` should contain suitable/similar values for financial records.
 * Determine whether `4` is a suitable value.

(Ping participants from previous PR: @pradpnayak @monishdeb @colemanw)