### PR TITLE
CRM-17236 - Custom dates fields displayed as (01/01/1970) in Events confirmation receipt

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1234,8 +1234,8 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
                 break;
 
               default:
-                // if time is not selected remove time from value
-                $value = substr($value, 0, 10);
+                //If time is not selected remove time from value.
+                $value = $value ? date('Y-m-d', strtotime($value)) : '';
             }
             $customFormat = implode(" ", $customTimeFormat);
           }

--- a/tests/phpunit/CRM/Core/BAO/CustomQueryTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomQueryTest.php
@@ -81,6 +81,10 @@ class CRM_Core_BAO_CustomQueryTest extends CiviUnitTestCase {
       $queryObj->_where[0][0]
     );
     $this->assertEquals($queryObj->_qill[0][0], "date field BETWEEN 'June 6th, 2014 12:00 AM AND June 6th, 2015 11:59 PM'");
+
+    //CRM-17236 - Test custom date is correctly displayed without time.
+    $formattedValue = CRM_Core_BAO_CustomField::displayValue(date('Ymdhms'), $dateCustomField['id']);
+    $this->assertEquals(date('m/d/Y'), $formattedValue);
   }
 
   /**


### PR DESCRIPTION
Date string passed as `yyyymmdd` is `8` chars in a datetime value. As `formatDisplayValue` here extracts 10 char of a string, this change makes sure we have 10 char as a date value.

* [CRM-17236: Custom dates fields displayed as \(01\/01\/1970\) in Events Confirmation Reciept](https://issues.civicrm.org/jira/browse/CRM-17236)