### PR TITLE
CRM-20931 - Allow contact custom fields to be added to Contribution Detail report

### DIFF
--- a/CRM/Report/Form/Member/ContributionDetail.php
+++ b/CRM/Report/Form/Member/ContributionDetail.php
@@ -40,6 +40,7 @@ class CRM_Report_Form_Member_ContributionDetail extends CRM_Report_Form {
   protected $_customGroupExtends = array(
     'Contribution',
     'Membership',
+    'Contact',
   );
 
   /**
@@ -81,6 +82,10 @@ class CRM_Report_Form_Member_ContributionDetail extends CRM_Report_Form {
           ),
           'last_name' => array(
             'title' => ts('Last Name'),
+            'no_repeat' => TRUE,
+          ),
+          'nick_name' => array(
+            'title' => ts('Nickname'),
             'no_repeat' => TRUE,
           ),
           'contact_type' => array(


### PR DESCRIPTION
This patch allows contact custom fields to be added to the Contribution Details report.

As a bonus it also adds nickname column to the report :)

---

 * [CRM-20931: Allow contact custom fields to be added to Contribution Detail report](https://issues.civicrm.org/jira/browse/CRM-20931)