### PR TITLE
(NFC) gitignore - Remove obsolete entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,16 +12,6 @@ civicrm-version.txt
 civicrm.config.php
 install/langs.php
 node_modules
-packages/.channels
-packages/.depdb
-packages/.depdblock
-packages/.filemap
-packages/.lock
-packages/.registry
-packages/cache
-packages/doc
-packages/temp
-packages/test
 settings_location.php
 sql/case_sample.mysql
 sql/civicrm.mysql


### PR DESCRIPTION
The `packages` directory is actually a separate git repo, with its own copy
of `.gitignore`.

These rules have no effect in there.

The `packages` directory is ignored as a whole with one entry in
`gitignore`.