### PR TITLE
CRM-19575 - CRM_Utils_System_Joomla - Fix warning. Define JDEBUG

### DIFF
--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -559,6 +559,10 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
 
     jimport('joomla.application.cli');
 
+    if (!defined('JDEBUG')) {
+      define('JDEBUG', FALSE);
+    }
+
     // CRM-14281 Joomla wasn't available during bootstrap, so hook_civicrm_config never executes.
     $config = CRM_Core_Config::singleton();
     CRM_Utils_Hook::config($config);


### PR DESCRIPTION
Background
==========

When running `cv en <extname>` on Joomla, there are repeated warnings, "Use
of undefined constant JDEBUG", and each includes a backtrace.  This is hard
to read.

The bug appears to affect backend scripts; it's discussed with a solution in:

https://github.com/joomla/joomla-cms/issues/11512#issuecomment-244937966

Before
======

`CRM_Utils_System_Joomla::loadBootStrap()` loads various config files.
However, these may or may not set `JDEBUG`.

After
=====

`CRM_Utils_System_Joomla::loadBootStrap()` defensively sets `JDEBUG` if no
other part of the bootstrap has done so.

---

 * [CRM-20932: Joomla CLI and extern display warning about JDEBUG](https://issues.civicrm.org/jira/browse/CRM-20932)

---

 * [CRM-19575: Cron jobs on Joomla triggers "Use of undefined constant JDEBUG"](https://issues.civicrm.org/jira/browse/CRM-19575)