### PR TITLE
CRM-20933 - Updating Pay later event registration from backend produc…

### DIFF
--- a/CRM/Event/Form/EventFees.php
+++ b/CRM/Event/Form/EventFees.php
@@ -226,6 +226,7 @@ class CRM_Event_Form_EventFees {
 
     // CRM-4395
     if ($contriId = $form->get('onlinePendingContributionId')) {
+      $defaults[$form->_pId]['record_contribution'] = 1;
       $contribution = new CRM_Contribute_DAO_Contribution();
       $contribution->id = $contriId;
       $contribution->find(TRUE);

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -823,7 +823,9 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       if (empty($values['payment_instrument_id'])) {
         $errorMsg['payment_instrument_id'] = ts('Payment Method is a required field.');
       }
-      CRM_Price_BAO_PriceField::priceSetValidation($values['priceSetId'], $values, $errorMsg);
+      if (!empty($values['priceSetId'])) {
+        CRM_Price_BAO_PriceField::priceSetValidation($values['priceSetId'], $values, $errorMsg);
+      }
     }
 
     // validate contribution status for 'Failed'.


### PR DESCRIPTION
…es formRule error

As we display Payment Section when there is an online contribution pending for a contact([$onlinePendingContributionId](https://github.com/civicrm/civicrm-core/blob/master/templates/CRM/Event/Form/EventFees.tpl#L70)), we should also enable `Record Payment` checkbox. More details mentioned on the issue description.

https://issues.civicrm.org/jira/browse/CRM-20933