### PR TITLE
CRM-20935 Remove related profile links when event deleted

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1031,7 +1031,6 @@ ORDER BY civicrm_custom_group.weight,
     );
 
     // create select
-    $select = "SELECT";
     $s = array();
     foreach ($tableData as $tableName => $tableColumn) {
       foreach ($tableColumn as $columnName) {

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -186,15 +186,26 @@ class CRM_Event_BAO_Event extends CRM_Event_DAO_Event {
     $extends = array('event');
     $groupTree = CRM_Core_BAO_CustomGroup::getGroupDetail(NULL, NULL, $extends);
     foreach ($groupTree as $values) {
-      $query = "DELETE FROM " . $values['table_name'] . " WHERE entity_id = " . $id;
-
-      $params = array(
-        1 => array($values['table_name'], 'string'),
-        2 => array($id, 'integer'),
-      );
-
-      CRM_Core_DAO::executeQuery($query);
+      $query = "DELETE FROM %1 WHERE entity_id = %2";
+      CRM_Core_DAO::executeQuery($query, array(
+        1 => array($values['table_name'], 'String', CRM_Core_DAO::QUERY_FORMAT_NO_QUOTES),
+        2 => array($id, 'Integer'),
+      ));
     }
+
+    // Clean up references to profiles used by the event (CRM-20935)
+    $ufJoinParams = array(
+      'module' => 'CiviEvent',
+      'entity_table' => 'civicrm_event',
+      'entity_id' => $id,
+    );
+    CRM_Core_BAO_UFJoin::deleteAll($ufJoinParams);
+    $ufJoinParams = array(
+      'module' => 'CiviEvent_Additional',
+      'entity_table' => 'civicrm_event',
+      'entity_id' => $id,
+    );
+    CRM_Core_BAO_UFJoin::deleteAll($ufJoinParams);
 
     // price set cleanup, CRM-5527
     CRM_Price_BAO_PriceSet::removeFrom('civicrm_event', $id);

--- a/CRM/Upgrade/Incremental/sql/4.7.25.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.7.25.mysql.tpl
@@ -13,3 +13,10 @@ INSERT INTO civicrm_option_value (option_group_id, {localize field='label'}label
     (@option_group_id_env, {localize}'{ts escape="sql"}Production{/ts}'{/localize}, 'Production', 'Production', NULL, 0, 1, 1, {localize}'{ts escape="sql"}Production Environment{/ts}'{/localize}, 0, 0, 1, NULL, NULL),
     (@option_group_id_env, {localize}'{ts escape="sql"}Staging{/ts}'{/localize}, 'Staging', 'Staging', NULL, 0, NULL, 2, {localize}'{ts escape="sql"}Staging Environment{/ts}'{/localize}, 0, 0, 1, NULL, NULL),
     (@option_group_id_env, {localize}'{ts escape="sql"}Development{/ts}'{/localize}, 'Development', 'Development', NULL, 0, NULL, 3, {localize}'{ts escape="sql"}Development Environment{/ts}'{/localize}, 0, 0, 1, NULL, NULL);
+
+-- CRM-20935 Clean up orphaned profile links for deleted events
+DELETE civicrm_uf_join
+FROM civicrm_uf_join
+LEFT JOIN civicrm_event e on civicrm_uf_join.entity_id = e.id
+WHERE (civicrm_uf_join.module = 'CiviEvent' OR civicrm_uf_join.module = 'CiviEvent_Additional')
+AND e.id IS NULL;


### PR DESCRIPTION
* [CRM-20935: Deleting an event does not delete links to profiles it used](https://issues.civicrm.org/jira/browse/CRM-20935)