### PR TITLE
CRM-20821 & CRM-20938 - fix bugs in managing premium product images

### DIFF
--- a/CRM/Contribute/BAO/ManagePremiums.php
+++ b/CRM/Contribute/BAO/ManagePremiums.php
@@ -86,17 +86,26 @@ class CRM_Contribute_BAO_ManagePremiums extends CRM_Contribute_DAO_Product {
   }
 
   /**
-   * add the financial types.
+   * Add a premium product to the database, and return it.
    *
    * @param array $params
    *   Reference array contains the values submitted by the form.
    * @param array $ids
    *   Reference array contains the id.
    *
-   *
-   * @return object
+   * @return CRM_Contribute_DAO_Product
    */
   public static function add(&$params, &$ids) {
+    $defaults = array(
+      'id' => CRM_Utils_Array::value('premium', $ids),
+      'image' => '',
+      'thumbnail' => '',
+      'is_active' => FALSE,
+      'is_deductible' => FALSE,
+      'currency' => CRM_Core_Config::singleton()->defaultCurrency,
+    );
+    $params = array_merge($defaults, $params);
+
     // CRM-14283 - strip protocol and domain from image URLs
     $image_type = array('image', 'thumbnail');
     foreach ($image_type as $key) {
@@ -107,21 +116,9 @@ class CRM_Contribute_BAO_ManagePremiums extends CRM_Contribute_DAO_Product {
       }
     }
 
-    $params['is_active'] = CRM_Utils_Array::value('is_active', $params, FALSE);
-    $params['is_deductible'] = CRM_Utils_Array::value('is_deductible', $params, FALSE);
-
-    // action is taken depending upon the mode
+    // Save and return
     $premium = new CRM_Contribute_DAO_Product();
     $premium->copyValues($params);
-
-    $premium->id = CRM_Utils_Array::value('premium', $ids);
-
-    // set currency for CRM-1496
-    if (!isset($premium->currency)) {
-      $config = CRM_Core_Config::singleton();
-      $premium->currency = $config->defaultCurrency;
-    }
-
     $premium->save();
     return $premium;
   }

--- a/CRM/Contribute/BAO/ManagePremiums.php
+++ b/CRM/Contribute/BAO/ManagePremiums.php
@@ -96,19 +96,14 @@ class CRM_Contribute_BAO_ManagePremiums extends CRM_Contribute_DAO_Product {
    * @return CRM_Contribute_DAO_Product
    */
   public static function add(&$params, &$ids) {
-    $defaults = array(
+    $params = array_merge(array(
       'id' => CRM_Utils_Array::value('premium', $ids),
-      'image' => '',
-      'thumbnail' => '',
-      'is_active' => FALSE,
+      'image' => CRM_Utils_String::simplifyURL(CRM_Utils_Array::value('image', $params, ''), TRUE),
+      'thumbnail' => CRM_Utils_String::simplifyURL(CRM_Utils_Array::value('thumbnail', $params, ''), TRUE),
+      'is_active' => 0,
       'is_deductible' => FALSE,
       'currency' => CRM_Core_Config::singleton()->defaultCurrency,
-    );
-    $params = array_merge($defaults, $params);
-
-    // Use local URLs for images when possible
-    $params['image'] = CRM_Utils_String::simplifyURL($params['image'], TRUE);
-    $params['thumbnail'] = CRM_Utils_String::simplifyURL($params['thumbnail'], TRUE);
+    ), $params);
 
     // Save and return
     $premium = new CRM_Contribute_DAO_Product();

--- a/CRM/Contribute/BAO/ManagePremiums.php
+++ b/CRM/Contribute/BAO/ManagePremiums.php
@@ -106,15 +106,9 @@ class CRM_Contribute_BAO_ManagePremiums extends CRM_Contribute_DAO_Product {
     );
     $params = array_merge($defaults, $params);
 
-    // CRM-14283 - strip protocol and domain from image URLs
-    $image_type = array('image', 'thumbnail');
-    foreach ($image_type as $key) {
-      if (isset($params[$key]) && $params[$key]) {
-        $parsedURL = explode('/', $params[$key]);
-        $pathComponents = array_slice($parsedURL, 3);
-        $params[$key] = '/' . implode('/', $pathComponents);
-      }
-    }
+    // Use local URLs for images when possible
+    $params['image'] = CRM_Utils_String::simplifyURL($params['image'], TRUE);
+    $params['thumbnail'] = CRM_Utils_String::simplifyURL($params['thumbnail'], TRUE);
 
     // Save and return
     $premium = new CRM_Contribute_DAO_Product();

--- a/CRM/Contribute/Form/ManagePremiums.php
+++ b/CRM/Contribute/Form/ManagePremiums.php
@@ -201,34 +201,35 @@ class CRM_Contribute_Form_ManagePremiums extends CRM_Contribute_Form {
    *
    * @param array $params
    *   (ref.) an assoc array of name/value pairs.
-   *
    * @param $files
    *
    * @return bool|array
    *   mixed true or array of errors
    */
   public static function formRule($params, $files) {
-    if (isset($params['imageOption'])) {
-      if ($params['imageOption'] == 'thumbnail') {
-        if (!$params['imageUrl']) {
-          $errors['imageUrl'] = ts('Image URL is Required');
-        }
-        if (!$params['thumbnailUrl']) {
-          $errors['thumbnailUrl'] = ts('Thumbnail URL is Required');
-        }
+
+    // If choosing to upload an image, then an image must be provided
+    if (
+      isset($params['imageOption']) &&
+      $params['imageOption'] == 'image' &&
+      empty($files['uploadFile']['name'])
+    ) {
+      $errors['uploadFile'] = ts('A file must be selected');
+    }
+
+    // If choosing to use image URLs, then both URLs must be present
+    if (isset($params['imageOption']) && $params['imageOption'] == 'thumbnail') {
+      if (!$params['imageUrl']) {
+        $errors['imageUrl'] = ts('Image URL is Required');
+      }
+      if (!$params['thumbnailUrl']) {
+        $errors['thumbnailUrl'] = ts('Thumbnail URL is Required');
       }
     }
+
     // CRM-13231 financial type required if product has cost
     if (!empty($params['cost']) && empty($params['financial_type_id'])) {
       $errors['financial_type_id'] = ts('Financial Type is required for product having cost.');
-    }
-    $fileLocation = $files['uploadFile']['tmp_name'];
-    if ($fileLocation != "") {
-      list($width, $height) = getimagesize($fileLocation);
-
-      if (($width < 80 || $width > 500) || ($height < 80 || $height > 500)) {
-        //$errors ['uploadFile'] = "Please Enter files with dimensions between 80 x 80 and 500 x 500," . " Dimensions of this file is ".$width."X".$height;
-      }
     }
 
     if (!$params['period_type']) {

--- a/CRM/Contribute/Form/ManagePremiums.php
+++ b/CRM/Contribute/Form/ManagePremiums.php
@@ -209,16 +209,14 @@ class CRM_Contribute_Form_ManagePremiums extends CRM_Contribute_Form {
   public static function formRule($params, $files) {
 
     // If choosing to upload an image, then an image must be provided
-    if (
-      isset($params['imageOption']) &&
-      $params['imageOption'] == 'image' &&
-      empty($files['uploadFile']['name'])
+    if (CRM_Utils_Array::value('imageOption', $params['imageOption']) == 'image'
+      && empty($files['uploadFile']['name'])
     ) {
       $errors['uploadFile'] = ts('A file must be selected');
     }
 
     // If choosing to use image URLs, then both URLs must be present
-    if (isset($params['imageOption']) && $params['imageOption'] == 'thumbnail') {
+    if (CRM_Utils_Array::value('imageOption', $params['imageOption']) == 'thumbnail') {
       if (!$params['imageUrl']) {
         $errors['imageUrl'] = ts('Image URL is Required');
       }

--- a/CRM/Contribute/Form/ManagePremiums.php
+++ b/CRM/Contribute/Form/ManagePremiums.php
@@ -296,8 +296,8 @@ class CRM_Contribute_Form_ManagePremiums extends CRM_Contribute_Form {
           if ($gdSupport) {
             if ($imageFile) {
               $error = FALSE;
-              $params['image'] = $this->_resizeImage($imageFile, "_full", 200, 200);
-              $params['thumbnail'] = $this->_resizeImage($imageFile, "_thumb", 50, 50);
+              $params['image'] = CRM_Utils_File::resizeImage($imageFile, "_full", 200, 200);
+              $params['thumbnail'] = CRM_Utils_File::resizeImage($imageFile, "_thumb", 50, 50);
             }
           }
           else {
@@ -342,57 +342,6 @@ class CRM_Contribute_Form_ManagePremiums extends CRM_Contribute_Form {
         CRM_Core_Session::setStatus(ts("The Premium '%1' has been saved.", array(1 => $premium->name)), ts('Saved'), 'success');
       }
     }
-  }
-
-  /**
-   * Resize a premium image to a different size.
-   *
-   *
-   * @param string $filename
-   * @param string $resizedName
-   * @param $width
-   * @param $height
-   *
-   * @return string
-   *   Path to image
-   */
-  private function _resizeImage($filename, $resizedName, $width, $height) {
-    // figure out the new filename
-    $pathParts = pathinfo($filename);
-    $newFilename = $pathParts['dirname'] . "/" . $pathParts['filename'] . $resizedName . "." . $pathParts['extension'];
-
-    // get image about original image
-    $imageInfo = getimagesize($filename);
-    $widthOrig = $imageInfo[0];
-    $heightOrig = $imageInfo[1];
-    $image = imagecreatetruecolor($width, $height);
-    if ($imageInfo['mime'] == 'image/gif') {
-      $source = imagecreatefromgif($filename);
-    }
-    elseif ($imageInfo['mime'] == 'image/png') {
-      $source = imagecreatefrompng($filename);
-    }
-    else {
-      $source = imagecreatefromjpeg($filename);
-    }
-
-    // resize
-    imagecopyresized($image, $source, 0, 0, 0, 0, $width, $height, $widthOrig, $heightOrig);
-
-    // save the resized image
-    $fp = fopen($newFilename, 'w+');
-    ob_start();
-    imagejpeg($image);
-    $image_buffer = ob_get_contents();
-    ob_end_clean();
-    imagedestroy($image);
-    fwrite($fp, $image_buffer);
-    rewind($fp);
-    fclose($fp);
-
-    // return the URL to link to
-    $config = CRM_Core_Config::singleton();
-    return $config->imageUploadURL . basename($newFilename);
   }
 
 }

--- a/CRM/Contribute/Form/ManagePremiums.php
+++ b/CRM/Contribute/Form/ManagePremiums.php
@@ -296,8 +296,8 @@ class CRM_Contribute_Form_ManagePremiums extends CRM_Contribute_Form {
           if ($gdSupport) {
             if ($imageFile) {
               $error = FALSE;
-              $params['image'] = CRM_Utils_File::resizeImage($imageFile, "_full", 200, 200);
-              $params['thumbnail'] = CRM_Utils_File::resizeImage($imageFile, "_thumb", 50, 50);
+              $params['image'] = CRM_Utils_File::resizeImage($imageFile, 200, 200, "_full");
+              $params['thumbnail'] = CRM_Utils_File::resizeImage($imageFile, 50, 50, "_thumb");
             }
           }
           else {

--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -929,6 +929,11 @@ HTACCESS;
    *   If supplied, the image will be renamed to include this suffix. For
    *   example if the original file name is "foo.png" and $suffix = "_bar",
    *   then the final file name will be "foo_bar.png".
+   * @param bool $preserveAspect = TRUE
+   *   When TRUE $width and $height will be used as a bounding box, outside of
+   *   which the resized image will not extend.
+   *   When FALSE, the image will be resized exactly to $width and $height, even
+   *   if it means stretching it.
    *
    * @return string
    *   Path to image
@@ -937,7 +942,7 @@ HTACCESS;
    *   - When GD is not available.
    *   - When the source file is not an image.
    */
-  public static function resizeImage($sourceFile, $targetWidth, $targetHeight, $suffix = "") {
+  public static function resizeImage($sourceFile, $targetWidth, $targetHeight, $suffix = "", $preserveAspect = TRUE) {
 
     // Check if GD is installed
     $gdSupport = CRM_Utils_System::getModuleSetting('gd', 'GD Support');
@@ -963,6 +968,18 @@ HTACCESS;
     $sourceInfo = getimagesize($sourceFile);
     $sourceWidth = $sourceInfo[0];
     $sourceHeight = $sourceInfo[1];
+
+    // Adjust target width/height if preserving aspect ratio
+    if ($preserveAspect) {
+      $sourceAspect = $sourceWidth / $sourceHeight;
+      $targetAspect = $targetWidth / $targetHeight;
+      if ($sourceAspect > $targetAspect) {
+        $targetHeight = $targetWidth / $sourceAspect;
+      }
+      if ($sourceAspect < $targetAspect) {
+        $targetWidth = $targetHeight * $sourceAspect;
+      }
+    }
 
     // figure out the new filename
     $pathParts = pathinfo($sourceFile);

--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -790,6 +790,80 @@ class CRM_Utils_String {
   }
 
   /**
+   * When a user supplies a URL (e.g. to an image), we'd like to:
+   *  - Remove the protocol and domain name if the URL points to the current
+   *    site.
+   *  - Keep the domain name for remote URLs.
+   *  - Optionally, force remote URLs to use https instead of http (which is
+   *    useful for images)
+   *
+   * @param string $url
+   *   The URL to simplify. Examples:
+   *     "https://example.org/sites/default/files/coffee-mug.jpg"
+   *     "sites/default/files/coffee-mug.jpg"
+   *     "http://i.stack.imgur.com/9jb2ial01b.png"
+   * @param bool $forceHttps = FALSE
+   *   If TRUE, ensure that remote URLs use https. If a URL with
+   *   http is supplied, then we'll change it to https.
+   *   This is useful for situations like showing a premium product on a
+   *   contribution, because (as reported in CRM-14283) if the user gets a
+   *   browser warning like "page contains insecure elements" on a contribution
+   *   page, that's a very bad thing. Thus, even if changing http to https
+   *   breaks the image, that's better than leaving http content in a
+   *   contribution page.
+   *
+   * @return string
+   *   The simplified URL. Examples:
+   *     "/sites/default/files/coffee-mug.jpg"
+   *     "https://i.stack.imgur.com/9jb2ial01b.png"
+   */
+  public static function simplifyURL($url, $forceHttps = FALSE) {
+    $config = CRM_Core_Config::singleton();
+    $siteURLParts = self::simpleParseUrl($config->userFrameworkBaseURL);
+    $urlParts = self::simpleParseUrl($url);
+
+    // If the image is locally hosted, then only give the path to the image
+    $urlIsLocal
+      = ($urlParts['host+port'] == '')
+      | ($urlParts['host+port'] == $siteURLParts['host+port']);
+    if ($urlIsLocal) {
+      // and make sure it begins with one forward slash
+      return preg_replace('_^/*(?=.)_', '/', $urlParts['path+query']);
+    }
+
+    // If the URL is external, then keep the full URL as supplied
+    else {
+      return $forceHttps ? preg_replace('_^http://_', 'https://', $url) : $url;
+    }
+  }
+
+  /**
+   * A simplified version of PHP's parse_url() function.
+   *
+   * @param string $url
+   *   e.g. "https://example.com:8000/foo/bar/?id=1#fragment"
+   *
+   * @return array
+   *   Will always contain keys 'host+port' and 'path+query', even if they're
+   *   empty strings. Example:
+   *   [
+   *     'host+port' => "example.com:8000",
+   *     'path+query' => "/foo/bar/?id=1",
+   *   ]
+   */
+  public static function simpleParseUrl($url) {
+    $parts = parse_url($url);
+    $host = isset($parts['host']) ? $parts['host'] : '';
+    $port = isset($parts['port']) ? ':' . $parts['port'] : '';
+    $path = isset($parts['path']) ? $parts['path'] : '';
+    $query = isset($parts['query']) ? '?' . $parts['query'] : '';
+    return array(
+      'host+port' => "$host$port",
+      'path+query' => "$path$query",
+    );
+  }
+
+  /**
    * Formats a string of attributes for insertion in an html tag.
    *
    * @param array $attributes

--- a/tests/phpunit/CRM/Utils/StringTest.php
+++ b/tests/phpunit/CRM/Utils/StringTest.php
@@ -252,7 +252,8 @@ class CRM_Utils_StringTest extends CiviUnitTestCase {
   public function simplifyURLProvider() {
 
     $config = CRM_Core_Config::singleton();
-    $localDomain = parse_url($config->userFrameworkBaseURL)['host'];
+    $urlParts = parse_url($config->userFrameworkBaseURL);
+    $localDomain = $urlParts['host'];
     $externalDomain = 'example.org';
 
     // Ensure that $externalDomain really is different from $localDomain

--- a/tests/phpunit/CRM/Utils/StringTest.php
+++ b/tests/phpunit/CRM/Utils/StringTest.php
@@ -250,7 +250,6 @@ class CRM_Utils_StringTest extends CiviUnitTestCase {
    * @return array
    */
   public function simplifyURLProvider() {
-
     $config = CRM_Core_Config::singleton();
     $urlParts = parse_url($config->userFrameworkBaseURL);
     $localDomain = $urlParts['host'];
@@ -262,51 +261,37 @@ class CRM_Utils_StringTest extends CiviUnitTestCase {
     }
 
     return array(
-
-      'prototypical example' =>
-      array(
+      'prototypical example' => array(
         "https://$localDomain/sites/default/files/coffee-mug.jpg",
         FALSE,
         '/sites/default/files/coffee-mug.jpg',
       ),
-
-      'external domain with https' =>
-      array(
+      'external domain with https' => array(
         "https://$externalDomain/sites/default/files/coffee-mug.jpg",
         FALSE,
         "https://$externalDomain/sites/default/files/coffee-mug.jpg",
       ),
-
-      'external domain with http forced to https' =>
-      array(
+      'external domain with http forced to https' => array(
         "http://$externalDomain/sites/default/files/coffee-mug.jpg",
         TRUE,
         "https://$externalDomain/sites/default/files/coffee-mug.jpg",
       ),
-
-      'external domain with http not forced' =>
-      array(
+      'external domain with http not forced' => array(
         "http://$externalDomain/sites/default/files/coffee-mug.jpg",
         FALSE,
         "http://$externalDomain/sites/default/files/coffee-mug.jpg",
       ),
-
-      'local URL' =>
-      array(
+      'local URL' => array(
         "/sites/default/files/coffee-mug.jpg",
         FALSE,
         "/sites/default/files/coffee-mug.jpg",
       ),
-
-      'local URL without a forward slash' =>
-      array(
+      'local URL without a forward slash' => array(
         "sites/default/files/coffee-mug.jpg",
         FALSE,
         "/sites/default/files/coffee-mug.jpg",
       ),
-
-      'empty input' =>
-      array(
+      'empty input' => array(
         '',
         FALSE,
         '',
@@ -334,27 +319,21 @@ class CRM_Utils_StringTest extends CiviUnitTestCase {
    */
   public function parseURLProvider() {
     return array(
-
-      "prototypical example" =>
-      array(
+      "prototypical example" => array(
         "https://example.com:8000/foo/bar/?id=1#fragment",
         array(
           'host+port' => "example.com:8000",
           'path+query' => "/foo/bar/?id=1",
         ),
       ),
-
-      "empty" =>
-      array(
+      "empty" => array(
         "",
         array(
           'host+port' => "",
           'path+query' => "",
         ),
       ),
-
-      "path only" =>
-      array(
+      "path only" => array(
         "/foo/bar/image.png",
         array(
           'host+port' => "",

--- a/tests/phpunit/CRM/Utils/StringTest.php
+++ b/tests/phpunit/CRM/Utils/StringTest.php
@@ -227,4 +227,140 @@ class CRM_Utils_StringTest extends CiviUnitTestCase {
     $this->assertEquals(array_merge($expectedResults, array('noise')), $actualResults);
   }
 
+  /**
+   * CRM-20821
+   * CRM-14283
+   *
+   * @param string $imageURL
+   * @param book $forceHttps
+   * @param string $expected
+   *
+   * @dataProvider simplifyURLProvider
+   */
+  public function testSimplifyURL($imageURL, $forceHttps, $expected) {
+    $this->assertEquals(
+      $expected,
+      CRM_Utils_String::simplifyURL($imageURL, $forceHttps)
+    );
+  }
+
+  /**
+   * Used for testNormalizeImageURL above
+   *
+   * @return array
+   */
+  public function simplifyURLProvider() {
+
+    $config = CRM_Core_Config::singleton();
+    $localDomain = parse_url($config->userFrameworkBaseURL)['host'];
+    $externalDomain = 'example.org';
+
+    // Ensure that $externalDomain really is different from $localDomain
+    if ($externalDomain == $localDomain) {
+      $externalDomain = 'example.net';
+    }
+
+    return array(
+
+      'prototypical example' =>
+      array(
+        "https://$localDomain/sites/default/files/coffee-mug.jpg",
+        FALSE,
+        '/sites/default/files/coffee-mug.jpg',
+      ),
+
+      'external domain with https' =>
+      array(
+        "https://$externalDomain/sites/default/files/coffee-mug.jpg",
+        FALSE,
+        "https://$externalDomain/sites/default/files/coffee-mug.jpg",
+      ),
+
+      'external domain with http forced to https' =>
+      array(
+        "http://$externalDomain/sites/default/files/coffee-mug.jpg",
+        TRUE,
+        "https://$externalDomain/sites/default/files/coffee-mug.jpg",
+      ),
+
+      'external domain with http not forced' =>
+      array(
+        "http://$externalDomain/sites/default/files/coffee-mug.jpg",
+        FALSE,
+        "http://$externalDomain/sites/default/files/coffee-mug.jpg",
+      ),
+
+      'local URL' =>
+      array(
+        "/sites/default/files/coffee-mug.jpg",
+        FALSE,
+        "/sites/default/files/coffee-mug.jpg",
+      ),
+
+      'local URL without a forward slash' =>
+      array(
+        "sites/default/files/coffee-mug.jpg",
+        FALSE,
+        "/sites/default/files/coffee-mug.jpg",
+      ),
+
+      'empty input' =>
+      array(
+        '',
+        FALSE,
+        '',
+      ),
+    );
+  }
+
+  /**
+   * @param string $url
+   * @param array $expected
+   *
+   * @dataProvider parseURLProvider
+   */
+  public function testSimpleParseUrl($url, $expected) {
+    $this->assertEquals(
+      $expected,
+      CRM_Utils_String::simpleParseUrl($url)
+    );
+  }
+
+  /**
+   * Used for testSimpleParseUrl above
+   *
+   * @return array
+   */
+  public function parseURLProvider() {
+    return array(
+
+      "prototypical example" =>
+      array(
+        "https://example.com:8000/foo/bar/?id=1#fragment",
+        array(
+          'host+port' => "example.com:8000",
+          'path+query' => "/foo/bar/?id=1",
+        ),
+      ),
+
+      "empty" =>
+      array(
+        "",
+        array(
+          'host+port' => "",
+          'path+query' => "",
+        ),
+      ),
+
+      "path only" =>
+      array(
+        "/foo/bar/image.png",
+        array(
+          'host+port' => "",
+          'path+query' => "/foo/bar/image.png",
+        ),
+      ),
+    );
+  }
+
 }


### PR DESCRIPTION
### Issues

This PR addresses both 

* [CRM-20821 - Saving an existing premium product breaks the image URLs](https://issues.civicrm.org/jira/browse/CRM-20821)
* [CRM-20938 - The auto-resizing of uploaded premium products images does not preserve aspect ratio](https://issues.civicrm.org/jira/browse/CRM-20938)

Details steps to reproduce are provided in both tickets. 

### Summary

| Before | After |
| -- | -- |
| Editing a premium product (without making changes) breaks its image | Images are preserved while editing |
| Uploading a non-square image for a premium product squishes it into a square, distorting the image | Aspect ratio is preserved while resizing images |
| Long functions, deeply nested code, sparse code comments | Improved code clarity through refactoring |

### Notes

The reason the images were getting broken is because of ffc4d2d06e7e4b2d5c2b31c1291a5bec9af08faf which added logic to "strip protocol and domain from image URLs" but mistakenly ended up being a bit overzealous with its "strip" logic &mdash; it would strip path components off the start of the URL *no matter what*. I improved this logic in 368073f (and added tests to support the new logic).

