### PR TITLE
CRM-20939 CRM-19941 Fix issue where $_recent variable is initialised as a strin…

### DIFF
--- a/CRM/Utils/Recent.php
+++ b/CRM/Utils/Recent.php
@@ -162,7 +162,7 @@ class CRM_Utils_Recent {
     self::initialize();
     $tempRecent = self::$_recent;
 
-    self::$_recent = '';
+    self::$_recent = array();
 
     // make sure item is not already present in list
     for ($i = 0; $i < count($tempRecent); $i++) {
@@ -189,7 +189,7 @@ class CRM_Utils_Recent {
 
     $tempRecent = self::$_recent;
 
-    self::$_recent = '';
+    self::$_recent = array();
 
     // rebuild recent.
     for ($i = 0; $i < count($tempRecent); $i++) {


### PR DESCRIPTION
…g when should be array

- [CRM-20939 $_recent variable initialised as a string in CRM_Utils_Recent when should be an array](https://issues.civicrm.org/jira/browse/CRM-20939)