### PR TITLE
CRM-19941 CRM-20943 Fix issue in PHP7.1 using  is non object mode in …

### DIFF
--- a/CRM/Utils/PagerAToZ.php
+++ b/CRM/Utils/PagerAToZ.php
@@ -151,7 +151,7 @@ class CRM_Utils_PagerAToZ {
       $qfKey = CRM_Utils_Array::value('qfKey', $query->_formValues);
     }
     if (empty($qfKey)) {
-      $qfKey = CRM_Utils_Request::retrieve('qfKey', 'String', $this, FALSE, NULL, $_REQUEST);
+      $qfKey = CRM_Utils_Request::retrieve('qfKey', 'String', NULL, FALSE, NULL, $_REQUEST);
     }
 
     $aToZBar = array();


### PR DESCRIPTION
…AtoZ Pager

@spalmstr Stephen can you test this out, I think NULL makes the most amount of sense here rather than some uninitilised variable.

- [CRM-19941 PHP 7.1 Compatability](https://issues.civicrm.org/jira/browse/CRM-19941)
- [CRM-20943 PHP 7.1 Compatability issue with Manage Events](https://issues.civicrm.org/jira/browse/CRM-20943)