### PR TITLE
CRM-18082 - Allow case API create to work with custom data

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -75,7 +75,9 @@ class CRM_Case_BAO_Case extends CRM_Case_DAO_Case {
   public static function add(&$params) {
     $caseDAO = new CRM_Case_DAO_Case();
     $caseDAO->copyValues($params);
-    return $caseDAO->save();
+    $result = $caseDAO->save();
+    $caseDAO->find(TRUE); // Get other case values (required by XML processor), this adds to $result array
+    return $result;
   }
 
   /**

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -273,6 +273,7 @@ WHERE civicrm_case.id = %1";
     $caseContact->case_id = $caseId;
     $caseContact->find();
     $contactArray = array();
+    // FIXME: Why does this return a 1-based array?
     $count = 1;
     while ($caseContact->fetch()) {
       if ($contactID != $caseContact->contact_id) {

--- a/api/v3/Case.php
+++ b/api/v3/Case.php
@@ -82,7 +82,7 @@ function civicrm_api3_case_create($params) {
     }
 
     if (array_key_exists('creator_id', $params)) {
-      throw new API_Exception(ts('You cannot update creator id'));
+      throw new API_Exception('You cannot update creator id');
     }
 
     $mergedCaseId = $origContactIds = array();

--- a/api/v3/Case.php
+++ b/api/v3/Case.php
@@ -67,7 +67,7 @@ function civicrm_api3_case_create($params) {
     civicrm_api3_verify_mandatory($params, NULL, array(
         'contact_id',
         'subject',
-        array('case_type', 'case_type_id')
+        array('case_type', 'case_type_id'),
       )
     );
   }

--- a/api/v3/Case.php
+++ b/api/v3/Case.php
@@ -39,11 +39,13 @@
  * @param array $params
  *
  * @code
- * //REQUIRED:
+ * //REQUIRED for create:
  * 'case_type_id' => int OR
  * 'case_type' => str (provide one or the other)
  * 'contact_id' => int // case client
  * 'subject' => str
+ * //REQUIRED for update:
+ * 'id' => case Id
  *
  * //OPTIONAL
  * 'medium_id' => int // see civicrm option values for possibilities
@@ -123,9 +125,11 @@ function civicrm_api3_case_create($params) {
     throw new API_Exception('Case not created. Please check input params.');
   }
 
-  foreach ((array) $params['contact_id'] as $cid) {
-    $contactParams = array('case_id' => $caseBAO->id, 'contact_id' => $cid);
-    CRM_Case_BAO_CaseContact::create($contactParams);
+  if (isset($params['contact_id'])) {
+    foreach ((array) $params['contact_id'] as $cid) {
+      $contactParams = array('case_id' => $caseBAO->id, 'contact_id' => $cid);
+      CRM_Case_BAO_CaseContact::create($contactParams);
+    }
   }
 
   if (!isset($params['id'])) {

--- a/api/v3/Case.php
+++ b/api/v3/Case.php
@@ -142,11 +142,6 @@ function civicrm_api3_case_create($params) {
   $values = array();
   _civicrm_api3_object_to_array($caseBAO, $values[$caseBAO->id]);
 
-  // Add custom data
-  if (isset($params['custom'])) {
-    _civicrm_api3_custom_data_get($values[$caseBAO->id], TRUE, 'case', $caseBAO->id);
-  }
-
   return civicrm_api3_create_success($values, $params, 'Case', 'create', $caseBAO);
 }
 

--- a/api/v3/Case.php
+++ b/api/v3/Case.php
@@ -495,7 +495,7 @@ function _civicrm_api3_case_deprecation() {
 }
 
 /**
- * Update a specified case.
+ * @deprecated Update a specified case.  Use civicrm_api3_case_create() instead.
  *
  * @param array $params
  *   //REQUIRED:

--- a/api/v3/Case.php
+++ b/api/v3/Case.php
@@ -154,7 +154,9 @@ function civicrm_api3_case_create($params) {
  */
 function _civicrm_api3_case_create_xmlProcessor($params, $caseBAO) {
   // Format params for xmlProcessor
-  if (isset($caseBAO->id)) { $params['id'] = $caseBAO->id; }
+  if (isset($caseBAO->id)) {
+    $params['id'] = $caseBAO->id;
+  }
 
   // Initialize XML processor with $params
   $xmlProcessor = new CRM_Case_XMLProcessor_Process();
@@ -698,7 +700,7 @@ function _civicrm_api3_case_format_params(&$params) {
   $values = array();
   _civicrm_api3_custom_format_params($params, $values, 'Case');
   $params = array_merge($params, $values);
-  
+
   if (empty($params['case_type_id']) && empty($params['case_type'])) {
     return;
   }

--- a/api/v3/Case.php
+++ b/api/v3/Case.php
@@ -91,8 +91,6 @@ function civicrm_api3_case_create($params) {
     if (!empty($params['contact_id'])) {
       $origContactIds = CRM_Case_BAO_Case::retrieveContactIdsByCaseId($params['id']);
       $origContactId = CRM_Utils_Array::first($origContactIds);
-
-
     }
 
     // FIXME: Refactor as separate method to get contactId

--- a/api/v3/Case.php
+++ b/api/v3/Case.php
@@ -89,10 +89,10 @@ function civicrm_api3_case_create($params) {
 
     // get original contact id and creator id of case
     if (!empty($params['contact_id'])) {
-      // FIXME: CRM_Case_BAO_Case::retrieveContactIdsByCaseId returns a 1-based array (1 is the first element)
-      // It should really return a 0-based array for consistency.
       $origContactIds = CRM_Case_BAO_Case::retrieveContactIdsByCaseId($params['id']);
-      $origContactId = $origContactIds[1];
+      $origContactId = CRM_Utils_Array::first($origContactIds);
+
+
     }
 
     // FIXME: Refactor as separate method to get contactId
@@ -529,7 +529,7 @@ function civicrm_api3_case_update($params) {
   // get original contact id and creator id of case
   if (!empty($params['contact_id'])) {
     $origContactIds = CRM_Case_BAO_Case::retrieveContactIdsByCaseId($params['id']);
-    $origContactId = $origContactIds[1];
+    $origContactId = CRM_Utils_Array::first($origContactIds);
   }
 
   if (count($origContactIds) > 1) {


### PR DESCRIPTION
This PR adds support for custom data for Case.Create API in line with other *.Create API functions.  It refactors Case.Create API to support updating as the Case.Update API function is deprecated.  This means a single codepath is now used for creation and updating, inline with other parts of CiviCRM API.

* [CRM-18082: CiviCase API Create ignores custom data](https://issues.civicrm.org/jira/browse/CRM-18082)