### PR TITLE
CRM-19933 proposed fix for import wiping out preferred comm method (possibly CRM-20035 too) 

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -151,16 +151,11 @@ class CRM_Contact_BAO_Contact extends CRM_Contact_DAO_Contact {
       $params['source'] = $params['contact_source'];
     }
 
-    // Fix for preferred communication method.
-    $prefComm = CRM_Utils_Array::value('preferred_communication_method', $params, '');
-    if ($prefComm && is_array($prefComm)) {
+    if (isset($params['preferred_communication_method']) && is_array($params['preferred_communication_method'])) {
+      CRM_Utils_Array::formatArrayKeys($params['preferred_communication_method']);
+      $contact->preferred_communication_method = CRM_Utils_Array::implodePadded($params['preferred_communication_method']);
       unset($params['preferred_communication_method']);
-
-      CRM_Utils_Array::formatArrayKeys($prefComm);
-      $prefComm = CRM_Utils_Array::implodePadded($prefComm);
     }
-
-    $contact->preferred_communication_method = $prefComm;
 
     $allNull = $contact->copyValues($params);
 

--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -853,6 +853,10 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
 
     //get the submitted values in an array
     $params = $this->controller->exportValues($this->_name);
+    if (!isset($params['preferred_communication_method'])) {
+      // If this field is empty QF will trim it so we have to add it in.
+      $params['preferred_communication_method'] = 'null';
+    }
 
     $group = CRM_Utils_Array::value('group', $params);
     if (!empty($group) && is_array($group)) {

--- a/CRM/Contact/Form/Inline/CommunicationPreferences.php
+++ b/CRM/Contact/Form/Inline/CommunicationPreferences.php
@@ -98,6 +98,9 @@ class CRM_Contact_Form_Inline_CommunicationPreferences extends CRM_Contact_Form_
       $params['contact_sub_type'] = $this->_contactSubType;
     }
 
+    if (!isset($params['preferred_communication_method'])) {
+      $params['preferred_communication_method'] = 'null';
+    }
     CRM_Contact_BAO_Contact::create($params);
 
     $this->response();

--- a/api/v3/Contact.php
+++ b/api/v3/Contact.php
@@ -524,11 +524,6 @@ function _civicrm_api3_contact_check_params(&$params) {
       break;
   }
 
-  // Fixme: This really needs to be handled at a lower level. @See CRM-13123
-  if (isset($params['preferred_communication_method'])) {
-    $params['preferred_communication_method'] = CRM_Utils_Array::implodePadded($params['preferred_communication_method']);
-  }
-
   if (!empty($params['contact_sub_type']) && !empty($params['contact_type'])) {
     if (!(CRM_Contact_BAO_ContactType::isExtendsContactType($params['contact_sub_type'], $params['contact_type']))) {
       throw new API_Exception("Invalid or Mismatched Contact Subtype: " . implode(', ', (array) $params['contact_sub_type']));

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -237,7 +237,6 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   }
 
-
   /**
    * Verify that attempt to create contact with empty params fails.
    */
@@ -1713,6 +1712,29 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     $this->assertEquals('man2@yahoo.com', $result['values'][$result['id']]['email']);
 
     $this->callAPISuccess('contact', 'delete', $contact);
+  }
+
+  /**
+   * Ensure consistent return format for option group fields.
+   */
+  public function testSetPreferredCommunicationNull() {
+    $contact = $this->callAPISuccess('contact', 'create', array_merge($this->_params, array(
+      'preferred_communication_method' => array('Phone', 'SMS'),
+    )));
+    $preferredCommunicationMethod = $this->callAPISuccessGetValue('Contact', array(
+      'id' => $contact['id'],
+      'return' => 'preferred_communication_method',
+    ));
+    $this->assertNotEmpty($preferredCommunicationMethod);
+    $contact = $this->callAPISuccess('contact', 'create', array_merge($this->_params, array(
+      'preferred_communication_method' => 'null',
+      'id' => $contact['id'],
+    )));
+    $preferredCommunicationMethod = $this->callAPISuccessGetValue('Contact', array(
+      'id' => $contact['id'],
+      'return' => 'preferred_communication_method',
+    ));
+    $this->assertEmpty($preferredCommunicationMethod);
   }
 
   /**


### PR DESCRIPTION
@lcdservices just took a quick look at the prefferred_communication_method issue & it appears to me that we need to stop the BAO setting it & then force-set it on the 2 forms that display it for editing (ie QF is trimming it)

No unit test as yet :-(

---

 * [CRM-19933: Importing contacts clears out preferred communication method](https://issues.civicrm.org/jira/browse/CRM-19933)

---

 * [CRM-20035: credit card backend contribution alters communication preferences](https://issues.civicrm.org/jira/browse/CRM-20035)