### PR TITLE
CRM-20949 - Fix payment processor assignment

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -368,7 +368,7 @@ WHERE  contribution_id = {$id}
 
     // this required to show billing block
     // @todo remove this assignment the billing block is now designed to be always included but will not show fieldsets unless those sets of fields are assigned
-    $this->assign_by_ref('paymentProcessor', $processor);
+    $this->assign_by_ref('paymentProcessor', $this->_paymentProcessor);
   }
 
   /**


### PR DESCRIPTION
* [CRM-20949: BillingBlock.tpl contains wrong paymentProcessor object on initial load of backend Contribution page.](https://issues.civicrm.org/jira/browse/CRM-20949)