### PR TITLE
CRM-20759 (follow up fix) Primary address is 'distributed' over sever…

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -2466,17 +2466,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
         $params['address'] = array();
       }
 
-      $addressCnt = 1;
-      foreach ($params['address'] as $cnt => $addressBlock) {
-        if (CRM_Utils_Array::value('location_type_id', $values) ==
-          CRM_Utils_Array::value('location_type_id', $addressBlock)
-        ) {
-          $addressCnt = $cnt;
-          break;
-        }
-        $addressCnt++;
-      }
-
       if (!array_key_exists('Address', $fields)) {
         $fields['Address'] = CRM_Core_DAO_Address::fields();
       }
@@ -2529,7 +2518,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
         $values = $newValues;
       }
 
-      _civicrm_api3_store_values($fields['Address'], $values, $params['address'][$addressCnt]);
+      _civicrm_api3_store_values($fields['Address'], $values, $params['address'][$values['location_type_id']]);
 
       $addressFields = array(
         'county',
@@ -2546,7 +2535,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
           if (!array_key_exists('address', $params)) {
             $params['address'] = array();
           }
-          $params['address'][$addressCnt][$field] = $values[$field];
+          $params['address'][$values['location_type_id']][$field] = $values[$field];
         }
       }
 
@@ -2555,14 +2544,9 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
           $primary = civicrm_api3('Address', 'get', array('return' => 'location_type_id', 'contact_id' => $params['id'], 'is_primary' => 1, 'sequential' => 1));
         }
         $defaultLocationType = CRM_Core_BAO_LocationType::getDefault();
-        $params['address'][$addressCnt]['location_type_id'] = (isset($primary) && $primary['count']) ? $primary['values'][0]['location_type_id'] : $defaultLocationType->id;
-        $params['address'][$addressCnt]['is_primary'] = 1;
+        $params['address'][$values['location_type_id']]['location_type_id'] = (isset($primary) && $primary['count']) ? $primary['values'][0]['location_type_id'] : $defaultLocationType->id;
+        $params['address'][$values['location_type_id']]['is_primary'] = 1;
 
-      }
-
-      if ($addressCnt == 1) {
-
-        $params['address'][$addressCnt]['is_primary'] = TRUE;
       }
       return TRUE;
     }

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -175,6 +175,7 @@ class CRM_Contact_Imports_Parser_ContactTest extends CiviUnitTestCase {
     $this->runImport($contactValues, CRM_Import_Parser::DUPLICATE_UPDATE, CRM_Import_Parser::VALID, array(0 => NULL, 1 => NULL, 2 => NULL, 3 => NULL, 4 => NULL, 5 => 'Primary', 6 => 'Primary'));
     $address = $this->callAPISuccessGetSingle('Address', array('street_address' => 'Big Mansion'));
     $this->assertEquals(1, $address['location_type_id']);
+    $this->assertEquals(1, $address['is_primary']);
 
     $phone = $this->callAPISuccessGetSingle('Phone', array('phone' => '12334'));
     $this->assertEquals(1, $phone['location_type_id']);
@@ -271,12 +272,14 @@ class CRM_Contact_Imports_Parser_ContactTest extends CiviUnitTestCase {
     $contactValues['nick_name'] = 'Old Bill';
     $contactValues['external_identifier'] = 'android';
     $contactValues['street_address'] = 'Big Mansion';
+    $contactValues['city'] = 'Big City';
     $contactID = $this->callAPISuccessGetValue('Contact', array('external_identifier' => 'android', 'return' => 'id'));
     $originalAddress = $this->callAPISuccess('Address', 'create', array('location_type_id' => 2, 'street_address' => 'small house', 'contact_id' => $contactID));
-    $this->runImport($contactValues, CRM_Import_Parser::DUPLICATE_UPDATE, CRM_Import_Parser::VALID, array(0 => NULL, 1 => NULL, 2 => NULL, 3 => NULL, 4 => NULL, 5 => 'Primary'));
+    $this->runImport($contactValues, CRM_Import_Parser::DUPLICATE_UPDATE, CRM_Import_Parser::VALID, array(0 => NULL, 1 => NULL, 2 => NULL, 3 => NULL, 4 => NULL, 5 => 'Primary', 6 => 'Primary'));
     $address = $this->callAPISuccessGetSingle('Address', array('street_address' => 'Big Mansion'));
     $this->assertEquals(2, $address['location_type_id']);
     $this->assertEquals($originalAddress['id'], $address['id']);
+    $this->assertEquals('Big City', $address['city']);
     $this->callAPISuccessGetSingle('Contact', $contactValues);
   }
 


### PR DESCRIPTION
…al ID

This wasn't picked up originally in the test as it was only using one field of the primary type.

The old code was indexing by 'addressCnt' (checking that the location type id was different each time). I
have switched to index by location_type_id - we should only have one address per location type per contact.

I also removed the code that sets 'is_primary' if we are importing the first address for a contact.
That has been handled by the BAO for some time