### PR TITLE
CRM-20855: Disabling "Search Primary Details Only" causes partial CiviMail delivery failure

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -405,6 +405,12 @@ class CRM_Contact_BAO_Query {
   public $_pseudoConstantsSelect = array();
 
   /**
+   * Set to true when address fields will be always on basis of primary location type
+   * @var Boolean
+   */
+  static $_alwaysSearchByPrimaryOnly = FALSE;
+
+  /**
    * Class constructor which also does all the work.
    *
    * @param array $params
@@ -435,6 +441,11 @@ class CRM_Contact_BAO_Query {
     if ($this->_params == NULL) {
       $this->_params = array();
     }
+
+    // Search by Primary location type ONLY if searchPrimaryDetailsOnly setting is on OR
+    //  search query is trigerred via api OR
+    //  special parameter search_by_primary_details_only = TRUE
+    self::$_alwaysSearchByPrimaryOnly = (Civi::settings()->get('searchPrimaryDetailsOnly') || $apiEntity || !empty($params['search_by_primary_details_only']));
 
     if ($returnProperties === self::NO_RETURN_PROPERTIES) {
       $this->_returnProperties = array();
@@ -2633,10 +2644,9 @@ class CRM_Contact_BAO_Query {
         }
         continue;
       }
-      $searchPrimary = '';
-      if (Civi::settings()->get('searchPrimaryDetailsOnly') || $apiEntity) {
-        $searchPrimary = "AND {$name}.is_primary = 1";
-      }
+
+      $searchPrimary = self::$_alwaysSearchByPrimaryOnly ? "AND {$name}.is_primary = 1" : '';
+
       switch ($name) {
         case 'civicrm_address':
           //CRM-14263 further handling of address joins further down...

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1235,6 +1235,7 @@ class CRM_Utils_Token {
       }
     }
 
+    $params['search_by_primary_details_only'] = CRM_Utils_Array::value('search_by_primary_details_only', $params, TRUE);
     $query = new CRM_Contact_BAO_Query($params, $returnProperties);
 
     $details = $query->apiQuery($params, $returnProperties, NULL, NULL, 0, count($contactIDs));

--- a/tests/phpunit/CRM/Utils/Token.php
+++ b/tests/phpunit/CRM/Utils/Token.php
@@ -16,65 +16,48 @@ class CRM_Utils_TokenTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test getting multiple contacts.
+   * Test getting contacts w/o primary location type
    *
    * Check for situation described in CRM-19876.
    */
-  public function testGetTokenDetailsMultipleEmails() {
-    $i = 0;
+  public function testSearchByPrimaryLocation() {
+    // disable searchPrimaryDetailsOnly civi settings so we could test the functionality without it
+    Civi::settings()->set('searchPrimaryDetailsOnly', '0');
 
-    $params = array(
-      'do_not_phone' => 1,
-      'do_not_email' => 0,
-      'do_not_mail' => 1,
-      'do_not_sms' => 1,
-      'do_not_trade' => 1,
-      'is_opt_out' => 0,
-      'email' => 'guardians@galaxy.com',
-      'legal_identifier' => 'convict 56',
-      'nick_name' => 'bob',
-      'contact_source' => 'bargain basement',
-      'formal_title' => 'Your silliness',
-      'job_title' => 'World Saviour',
-      'gender_id' => '1',
-      'birth_date' => '2017-01-01',
-      // 'city' => 'Metropolis',
-    );
-    $contactIDs = array();
-    while ($i < 27) {
-      $contactIDs[] = $contactID = $this->individualCreate($params);
-      $this->callAPISuccess('Email', 'create', array(
-        'contact_id' => $contactID,
-        'email' => 'goodguy@galaxy.com',
-        'location_type_id' => 'Other',
-        'is_primary' => 0,
-      ));
-      $this->callAPISuccess('Email', 'create', array(
-        'contact_id' => $contactID,
-        'email' => 'villain@galaxy.com',
-        'location_type_id' => 'Work',
-        'is_primary' => 1,
-      ));
-      $i++;
-    }
-    unset($params['email']);
+    // create a contact with multiple email address and among which one is primary
+    $contactID = $this->individualCreate();
+    $primaryEmail = uniqid() . '@primary.com';
+    $this->callAPISuccess('Email', 'create', array(
+      'contact_id' => $contactID,
+      'email' => $primaryEmail,
+      'location_type_id' => 'Other',
+      'is_primary' => 1,
+    ));
+    $this->callAPISuccess('Email', 'create', array(
+      'contact_id' => $contactID,
+      'email' => uniqid() . '@galaxy.com',
+      'location_type_id' => 'Work',
+      'is_primary' => 0,
+    ));
+    $this->callAPISuccess('Email', 'create', array(
+      'contact_id' => $contactID,
+      'email' => uniqid() . '@galaxy.com',
+      'location_type_id' => 'Work',
+      'is_primary' => 0,
+    ));
 
-    $resolvedTokens = CRM_Utils_Token::getTokenDetails($contactIDs);
-    foreach ($contactIDs as $contactID) {
-      $resolvedContactTokens = $resolvedTokens[0][$contactID];
-      $this->assertEquals('Individual', $resolvedContactTokens['contact_type']);
-      $this->assertEquals('Anderson, Anthony', $resolvedContactTokens['sort_name']);
-      $this->assertEquals('en_US', $resolvedContactTokens['preferred_language']);
-      $this->assertEquals('Both', $resolvedContactTokens['preferred_mail_format']);
-      $this->assertEquals(3, $resolvedContactTokens['prefix_id']);
-      $this->assertEquals(3, $resolvedContactTokens['suffix_id']);
-      $this->assertEquals('Mr. Anthony J. Anderson II', $resolvedContactTokens['addressee_display']);
-      $this->assertEquals('villain@galaxy.com', $resolvedContactTokens['email']);
+    // when we are fetching contact details NOT ON basis of primary address fields
+    $extraParams = array('search_by_primary_details_only' => FALSE);
+    $contactIDs = array($contactID);
+    $contactDetails = CRM_Utils_Token::getTokenDetails($contactIDs, NULL, TRUE, TRUE, $extraParams);
+    $this->assertNotEquals($primaryEmail, $contactDetails[0][$contactID]['email']);
 
-      foreach ($params as $key => $value) {
-        $this->assertEquals($value, $resolvedContactTokens[$key]);
-      }
-    }
+    // when we are fetching contact details ON basis of primary address fields
+    $contactDetails = CRM_Utils_Token::getTokenDetails($contactIDs);
+    $this->assertEquals($primaryEmail, $contactDetails[0][$contactID]['email']);
+
+    // restore setting
+    Civi::settings()->set('searchPrimaryDetailsOnly', '1');
   }
 
 }


### PR DESCRIPTION
* [CRM-20855: Disabling "Search Primary Details Only" causes partial CiviMail delivery failure](https://issues.civicrm.org/jira/browse/CRM-20855)