### PR TITLE
CRM-19186 / CRM-20959 Subsequent Installments of Recurring Credit Card Contributions Indicate a Payment Instrument of Check

### DIFF
--- a/tests/phpunit/CRM/Core/Payment/PayPalProIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/PayPalProIPNTest.php
@@ -95,6 +95,7 @@ class CRM_Core_Payment_PayPalProIPNTest extends CiviUnitTestCase {
       ));
     $this->assertEquals(2, $contribution['count']);
     $this->assertEquals('secondone', $contribution['values'][1]['trxn_id']);
+    $this->assertEquals('Debit Card', $contribution['values'][1]['payment_instrument']);
   }
 
   /**


### PR DESCRIPTION
CRM-19186
CRM-20959

---

 * [CRM-19186: Subsequent Installments of Recurring Credit Card Contributions Indicate a Payment Instrument of Check](https://issues.civicrm.org/jira/browse/CRM-19186)
 * [CRM-20959: IPN recording incorrect contribution data](https://issues.civicrm.org/jira/browse/CRM-20959)
