### PR TITLE
CRM-18177 - Fix param updated in previous PR #10173

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -1734,7 +1734,8 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
             if ($contriId == $contributionId) {
               continue;
             }
-            if (CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $contriId) === 'Completed') {
+            $statusId = CRM_Core_DAO::getFieldValue('CRM_Contribute_BAO_Contribution', $contriId, 'contribution_status_id');
+            if (CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $statusId) === 'Completed') {
               $update = FALSE;
             }
           }
@@ -1795,7 +1796,8 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
             if ($contriId == $contributionId) {
               continue;
             }
-            if (CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $contriId) === 'Completed') {
+            $statusId = CRM_Core_DAO::getFieldValue('CRM_Contribute_BAO_Contribution', $contriId, 'contribution_status_id');
+            if (CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $statusId) === 'Completed') {
               $update = FALSE;
             }
           }


### PR DESCRIPTION
@eileenmcnaughton In order to satisfy [this comment](https://github.com/civicrm/civicrm-core/pull/10173#discussion_r116367485) on #10173, the second commit contained an incorrect passing of param (It should be `status_id` instead of `$contriId`)

As status and contribution id both contained a value of 1, it passed the unit test added in the previous PR.

Can be replicated using steps provided here - https://issues.civicrm.org/jira/browse/CRM-18177?focusedCommentId=106100&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-106100