### PR TITLE
CRM-20963: Add a hook for compiler passes

### DIFF
--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -25,6 +25,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
 /**
  *
  * @package CiviCRM_Hook
@@ -2209,7 +2211,8 @@ abstract class CRM_Utils_Hook {
   }
 
   /**
-   * Modify the CiviCRM container - add new services, parameters, extensions, etc.
+   * Modify the CiviCRM container - add new services, parameters, extensions,
+   * etc. For compiler passes @see containerCompilerPass
    *
    * @code
    * use Symfony\Component\Config\Resource\FileResource;
@@ -2229,11 +2232,53 @@ abstract class CRM_Utils_Hook {
    * Note: This is a preboot hook. It will dispatch via the extension/module
    * subsystem but *not* the Symfony EventDispatcher.
    *
-   * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
    * @see http://symfony.com/doc/current/components/dependency_injection/index.html
+   *
+   * @param ContainerBuilder $container
    */
-  public static function container(\Symfony\Component\DependencyInjection\ContainerBuilder $container) {
+  public static function container(ContainerBuilder $container) {
     self::singleton()->invoke(array('container'), $container, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_container');
+  }
+
+  /**
+   * Modify the CiviCRM container before compilation.
+   *
+   * Used for container operations after *all* services have been registered,
+   * but before compilation. For example, gathering tagged services
+   * and registering them in another service.
+   *
+   * @code
+   * use Symfony\Component\DependencyInjection\ContainerBuilder;
+   *
+   * function mymodule_civicrm_container_compile(ContainerBuilder $container) {
+   *   $taggedServices = $container->findTaggedServiceIds('my_tag');
+   *   $myRegister = $container->getDefinition('my_register');
+   *
+   *   foreach ($taggedServices as $serviceId => $attributes) {
+   *     $definition = $container->getDefinition($serviceId);
+   *     $myRegister->addMethodCall('register', $definition);
+   *   }
+   * }
+   * @endcode
+   *
+   * Note: This is a preboot hook. It will dispatch via the extension/module
+   * subsystem but *not* the Symfony EventDispatcher.
+   *
+   * @see https://symfony.com/doc/current/service_container/compiler_passes.html
+   *
+   * @param ContainerBuilder $container
+   */
+  public static function containerCompilerPass(ContainerBuilder $container) {
+    self::singleton()->invoke(
+      array('containerCompilerPass'),
+      $container,
+      self::$_nullObject,
+      self::$_nullObject,
+      self::$_nullObject,
+      self::$_nullObject,
+      self::$_nullObject,
+      'civicrm_containerCompilerPass'
+    );
   }
 
   /**

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -1,23 +1,14 @@
 <?php
 namespace Civi\Core;
 
-use Civi\API\Provider\ActionObjectProvider;
 use Civi\Core\Event\SystemInstallEvent;
 use Civi\Core\Lock\LockManager;
-use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\Common\Annotations\AnnotationRegistry;
-use Doctrine\Common\Annotations\FileCacheReader;
-use Doctrine\Common\Cache\FilesystemCache;
-use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
-use Doctrine\ORM\Tools\Setup;
 use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher;
 use Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass;
 
 // TODO use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
@@ -230,6 +221,7 @@ class Container {
     }
 
     \CRM_Utils_Hook::container($container);
+    \CRM_Utils_Hook::containerCompilerPass($container);
 
     return $container;
   }


### PR DESCRIPTION
## Overview

In order to separate service registration from compiler passes we should add a second container hook. This hook will be used to work with tagged services.

I also got rid of some unused `use` statements.

## Before

Only a single container hook was available. The order that this hook was fired is not defined, so if working with tagged services in different extensions we could not be sure that all services were registered at this point.

## After

The hook logic is separated into "registration" (`civicrm_container`) and "compiler passes" (`civicrm_containerCompilerPass`).

## Notes

This is the situation that this PR addresses

Inside superapi extension:
```
superapi_civicrm_container($container) {
  $apis = $container->findTaggedServiceIds('api');
  $register = $container->getDefinition('api_register');

  foreach (array_keys($providers) as $api) {
    $register->addMethodCall('addApi', array(new Reference($api)));
  }
}
```

Inside supervisa extension:
```
supervisa_civicrm_container($container) {
  $container->register('visa.api', MyVisaApi::class)->addTag('api');
}
```

If `supervisa_civicrm_container` is called first all is fine, but if `superapi_civicrm_container` is called first then it won't be aware of the `visa.api` service and it'll never be registered.

---

 * [CRM-20963: Separate "container" and "compiler pass" hooks](https://issues.civicrm.org/jira/browse/CRM-20963)