### PR TITLE
CRM-20964: Include queue id while retrieving rows from Event Queue

### DIFF
--- a/CRM/Mailing/Event/BAO/Queue.php
+++ b/CRM/Mailing/Event/BAO/Queue.php
@@ -206,7 +206,8 @@ class CRM_Mailing_Event_BAO_Queue extends CRM_Mailing_Event_DAO_Queue {
     }
 
     $query = "
-            SELECT      $contact.display_name as display_name,
+            SELECT      $queue.id as queue_id,
+                        $contact.display_name as display_name,
                         $contact.id as contact_id,
                         $email.email as email,
                         $job.start_date as date
@@ -241,7 +242,7 @@ class CRM_Mailing_Event_BAO_Queue extends CRM_Mailing_Event_DAO_Queue {
       $url = CRM_Utils_System::url('civicrm/contact/view',
         "reset=1&cid={$dao->contact_id}"
       );
-      $results[] = array(
+      $results[$dao->queue_id] = array(
         'name' => "<a href=\"$url\">{$dao->display_name}</a>",
         'email' => $dao->email,
         'date' => CRM_Utils_Date::customFormat($dao->date),


### PR DESCRIPTION
`CRM_Mailing_Event_BAO_Queue::getRows();` return rows for each intended recipients, but doesn't include any info which differentiates each row.

This adds a queue_id in the key column of the `$result` array which enables hooks to know which row is getting displayed.

It seems safe to add key here as getRows() is only called at [this point](https://github.com/civicrm/civicrm-core/blob/master/CRM/Mailing/Selector/Browse.php#L334) which doesn't use the key info for manipulation.

---

 * [CRM-20964: Include queue id while retrieving rows from Event Queue.](https://issues.civicrm.org/jira/browse/CRM-20964)