### PR TITLE
CRM-20965: Add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## Overview
+_A brief description of the pull request. Try to keep it non-technical._
+
+## Before
+_The current status. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._
+
+## After
+_What has been changed. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._
+
+## Technical Details
+_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_
+
+## Comments
+_Anything else you would like the reviewer to note_


### PR DESCRIPTION
## Overview
Github offers [pull request templates](https://github.com/blog/2111-issue-and-pull-request-templates) to standardize the content of pull requests. This should help improve the description of pull requests to core.

## Before
There is no pull request template, or structure.

## After
A new template is added which will be automatically added to the description input whenever a new pull request is created.

## Comments
- This pull request description uses the new template.
- This template is modified from the [CiviHR version](https://github.com/civicrm/civihr/blob/staging/.github/PULL_REQUEST_TEMPLATE.md)
- Please feel free to suggest a better format for the template

---

 * [CRM-20965: Add Pull Request Template](https://issues.civicrm.org/jira/browse/CRM-20965)