### PR TITLE
CRM-20966: Do not create membership_payment record for inherited membership (when two memberships created in back end via price set).

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1478,6 +1478,9 @@ WHERE  civicrm_membership.contact_id = civicrm_contact.id
         unset($params['lineItems']);
         unset($params['line_item']);
 
+        // CRM-20966: Do not create membership_payment record for inherited membership.
+        unset($params['relate_contribution_id']);
+
         if (($params['status_id'] == $deceasedStatusId) || ($params['status_id'] == $expiredStatusId)) {
           // related membership is not active so does not count towards maximum
           CRM_Member_BAO_Membership::create($params, $relMemIds);


### PR DESCRIPTION
Please note: this PR fixes a problem that occurs in the specific scenario described at CRM-20966: Contribution deleted when relationship deleted, incorrect line items & membership_payments for second inherited membership created in back end via price set.
In 4.7, in order to replicate this problem you will need to have applied the fix for CRM-20955 = #10745 . Otherwise the second membership won't inherit and so the incorrect line_item and membership_payment records will not occur. See issue description at CRM-20966.

---

 * [CRM-20966: Contribution deleted when relationship deleted, incorrect line items & membership_payments for second inherited membership created in back end via price set](https://issues.civicrm.org/jira/browse/CRM-20966)
 * [CRM-20955: Contact's second membership fails to inherit when created in back end using price set](https://issues.civicrm.org/jira/browse/CRM-20955)