### PR TITLE
Fix placement of call to simplifyURL() function

### DIFF
--- a/CRM/Contribute/BAO/ManagePremiums.php
+++ b/CRM/Contribute/BAO/ManagePremiums.php
@@ -98,12 +98,17 @@ class CRM_Contribute_BAO_ManagePremiums extends CRM_Contribute_DAO_Product {
   public static function add(&$params, &$ids) {
     $params = array_merge(array(
       'id' => CRM_Utils_Array::value('premium', $ids),
-      'image' => CRM_Utils_String::simplifyURL(CRM_Utils_Array::value('image', $params, ''), TRUE),
-      'thumbnail' => CRM_Utils_String::simplifyURL(CRM_Utils_Array::value('thumbnail', $params, ''), TRUE),
+      'image' => '',
+      'thumbnail' => '',
       'is_active' => 0,
       'is_deductible' => FALSE,
       'currency' => CRM_Core_Config::singleton()->defaultCurrency,
     ), $params);
+
+    // Modify the submitted values for 'image' and 'thumbnail' so that we use
+    // local URLs for these images when possible.
+    $params['image'] = CRM_Utils_String::simplifyURL($params['image'], TRUE);
+    $params['thumbnail'] = CRM_Utils_String::simplifyURL($params['thumbnail'], TRUE);
 
     // Save and return
     $premium = new CRM_Contribute_DAO_Product();


### PR DESCRIPTION
Before this commit, the URL simplification was performed within the `$params` array used as the *default* values, so these values got over-written by the submitted values with `array_merge()`.

This is a partial revert of changes made by @monishdeb in bb80d2f in #10720

CC: @colemanw 