### PR TITLE
CRM-20972 Attempt to handle new type of Exception thrown in php7.1 wh…

### DIFF
--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -680,12 +680,20 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
 
   /**
    * @dataProvider entities
-   * @expectedException PHPUnit_Framework_Error
    * @param $Entity
    */
   public function testWithoutParam_get($Entity) {
     // should get php complaining that a param is missing
-    $result = civicrm_api($Entity, 'Get');
+    try {
+      $result = civicrm_api($Entity, 'Get');
+      $this->fail('Expected an exception. No exception was thrown.');
+    }
+    catch (ArgumentCountError $e) {
+      /* ok */
+    }
+    catch (PHPUnit_Framework_Error $e) {
+      /* ok */
+    }
   }
 
   /**
@@ -1387,12 +1395,20 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
 
   /**
    * @dataProvider entities
-   * @expectedException PHPUnit_Framework_Error
    * @param $Entity
    */
   public function testWithoutParam_delete($Entity) {
     // should delete php complaining that a param is missing
-    $result = civicrm_api($Entity, 'Delete');
+    try {
+      $result = civicrm_api($Entity, 'Delete');
+      $this->fail('Expected an exception. No exception was thrown.');
+    }
+    catch (ArgumentCountError $e) {
+      /* ok */
+    }
+    catch (PHPUnit_Framework_Error $e) {
+      /* ok */
+    }
   }
 
   /**

--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -688,6 +688,7 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
       $result = civicrm_api($Entity, 'Get');
       $this->fail('Expected an exception. No exception was thrown.');
     }
+    // As of php7.1 a new Exception is thrown by PHP ArgumentCountError when not enough params are passed.
     catch (ArgumentCountError $e) {
       /* ok */
     }
@@ -1403,6 +1404,7 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
       $result = civicrm_api($Entity, 'Delete');
       $this->fail('Expected an exception. No exception was thrown.');
     }
+    // As of php7.1 a new Exception is thrown by PHP ArgumentCountError when not enough params are passed.
     catch (ArgumentCountError $e) {
       /* ok */
     }


### PR DESCRIPTION
…en function call has too few variables

- [CRM-20972 PHP7.1 New Exception generated causing failures in API_v3_SyntaxConformanceTests](https://issues.civicrm.org/jira/browse/CRM-20972)