### PR TITLE
CRM-20610 add a form for editing payment details 

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4133,7 +4133,7 @@ WHERE eft.financial_trxn_id IN ({$trxnId}, {$baseTrxnId['financialTrxnId']})
         SELECT GROUP_CONCAT(fa.`name`) as financial_account,
           ft.total_amount,
           ft.payment_instrument_id,
-          ft.trxn_date, ft.trxn_id, ft.status_id, ft.check_number, ft.currency, ft.pan_truncation, ft.card_type_id
+          ft.trxn_date, ft.trxn_id, ft.status_id, ft.check_number, ft.currency, ft.pan_truncation, ft.card_type_id, ft.id
 
         FROM civicrm_contribution con
           LEFT JOIN civicrm_entity_financial_trxn eft ON (eft.entity_id = con.id AND eft.entity_table = 'civicrm_contribution')
@@ -4163,6 +4163,27 @@ WHERE eft.financial_trxn_id IN ({$trxnId}, {$baseTrxnId['financialTrxnId']})
           }
           $paidByLabel .= " ({$creditCardType}{$pantruncation})";
         }
+
+        // show payment edit link only for payments done via backoffice form
+        $paymentEditLink = '';
+        if (empty($resultDAO->payment_processor_id) && CRM_Core_Permission::check('edit contributions')) {
+          $links = array(
+            CRM_Core_Action::UPDATE => array(
+              'name' => "<i class='crm-i fa-pencil'></i>",
+              'url' => 'civicrm/payment/edit',
+              'qs' => "reset=1&id=%%id%%",
+              'title' => ts('Edit Payment'),
+            ),
+          );
+          $paymentEditLink = CRM_Core_Action::formLink(
+            $links,
+            CRM_Core_Action::mask(array(CRM_Core_Permission::EDIT)),
+            array(
+              'id' => $resultDAO->id,
+            )
+          );
+        }
+
         $val = array(
           'total_amount' => $resultDAO->total_amount,
           'financial_type' => $resultDAO->financial_account,
@@ -4171,6 +4192,7 @@ WHERE eft.financial_trxn_id IN ({$trxnId}, {$baseTrxnId['financialTrxnId']})
           'trxn_id' => $resultDAO->trxn_id,
           'status' => $statuses[$resultDAO->status_id],
           'currency' => $resultDAO->currency,
+          'action' => $paymentEditLink,
         );
         if ($paidByName == 'Check') {
           $val['check_number'] = $resultDAO->check_number;

--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -92,7 +92,6 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
 
     if ($this->_view == 'transaction' && ($this->_action & CRM_Core_Action::BROWSE)) {
       $paymentInfo = CRM_Contribute_BAO_Contribution::getPaymentInfo($this->_id, $this->_component, TRUE);
-      $transactionRows = $paymentInfo['transaction'];
       $title = ts('View Payment');
       if ($this->_component == 'event') {
         $info = CRM_Event_BAO_Participant::participantDetails($this->_id);
@@ -100,7 +99,7 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
       }
       CRM_Utils_System::setTitle($title);
       $this->assign('transaction', TRUE);
-      $this->assign('rows', $transactionRows);
+      $this->assign('payments', $paymentInfo['transaction']);
       return;
     }
     $this->_fromEmails = CRM_Core_BAO_Email::getFromEmail();

--- a/CRM/Core/xml/Menu/payment.xml
+++ b/CRM/Core/xml/Menu/payment.xml
@@ -8,4 +8,10 @@
     <is_public>true</is_public>
     <weight>0</weight>
   </item>
+  <item>
+    <path>civicrm/payment/edit</path>
+    <page_callback>CRM_Financial_Form_PaymentEdit</page_callback>
+    <access_arguments>access CiviContribute</access_arguments>
+    <component>CiviContribute</component>
+  </item>
 </menu>

--- a/CRM/Financial/Form/Payment.php
+++ b/CRM/Financial/Form/Payment.php
@@ -108,17 +108,18 @@ class CRM_Financial_Form_Payment extends CRM_Core_Form {
    * Add JS to show icons for the accepted credit cards.
    *
    * @param int $paymentProcessorID
+   * @param string $region
    */
-  public static function addCreditCardJs($paymentProcessorID = NULL) {
+  public static function addCreditCardJs($paymentProcessorID = NULL, $region = 'billing-block') {
     $creditCards = CRM_Financial_BAO_PaymentProcessor::getCreditCards($paymentProcessorID);
     $creditCardTypes = CRM_Core_Payment_Form::getCreditCardCSSNames($creditCards);
     CRM_Core_Resources::singleton()
       // CRM-20516: add BillingBlock script on billing-block region
       //  to support this feature in payment form snippet too.
-      ->addScriptFile('civicrm', 'templates/CRM/Core/BillingBlock.js', 10, 'billing-block', FALSE)
+      ->addScriptFile('civicrm', 'templates/CRM/Core/BillingBlock.js', 10, $region, FALSE)
       // workaround for CRM-13634
       // ->addSetting(array('config' => array('creditCardTypes' => $creditCardTypes)));
-      ->addScript('CRM.config.creditCardTypes = ' . json_encode($creditCardTypes) . ';', '-9999', 'billing-block');
+      ->addScript('CRM.config.creditCardTypes = ' . json_encode($creditCardTypes) . ';', '-9999', $region);
   }
 
 }

--- a/CRM/Financial/Form/PaymentEdit.php
+++ b/CRM/Financial/Form/PaymentEdit.php
@@ -1,0 +1,205 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2017                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2017
+ */
+class CRM_Financial_Form_PaymentEdit extends CRM_Core_Form {
+
+  /**
+   * The id of the financial trxn.
+   *
+   * @var int
+   */
+  protected $_id;
+
+  /**
+   * The variable which holds the information of a financial transaction
+   *
+   * @var array
+   */
+  protected $_values;
+
+  /**
+   * Set variables up before form is built.
+   */
+  public function preProcess() {
+    parent::preProcess();
+    $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
+    $this->assign('id', $this->_id);
+
+    $this->_values = civicrm_api3('FinancialTrxn', 'getsingle', array('id' => $this->_id));
+    if (!empty($this->_values['payment_processor_id'])) {
+      CRM_Core_Error::statusBounce(ts('You cannot update this payment'));
+    }
+  }
+
+  /**
+   * Set default values.
+   *
+   * @return array
+   */
+  public function setDefaultValues() {
+    $defaults = $this->_values;
+    if (!empty($defaults['card_type_id'])) {
+      $defaults['credit_card_type'] = CRM_Core_PseudoConstant::getName('CRM_Financial_DAO_FinancialTrxn', 'card_type_id', $defaults['card_type_id']);
+    }
+
+    return $defaults;
+  }
+
+  /**
+   * Build quickForm.
+   */
+  public function buildQuickForm() {
+    CRM_Utils_System::setTitle(ts('Update Payment details'));
+
+    $paymentFields = $this->getPaymentFields();
+    $this->assign('paymentFields', $paymentFields);
+    foreach ($paymentFields as $name => $paymentField) {
+      $this->add($paymentField['htmlType'],
+        $paymentField['name'],
+        $paymentField['title'],
+        $paymentField['attributes'],
+        TRUE
+      );
+      if (!empty($paymentField['rules'])) {
+        foreach ($paymentField['rules'] as $rule) {
+          $this->addRule($name,
+            $rule['rule_message'],
+            $rule['rule_name'],
+            $rule['rule_parameters']
+          );
+        }
+      }
+    }
+
+    $this->assign('currency', CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_Currency', $this->_values['currency'], 'symbol', 'name'));
+    $this->addButtons(array(
+      array(
+        'type' => 'submit',
+        'name' => ts('Update'),
+        'isDefault' => TRUE,
+      ),
+      array(
+        'type' => 'cancel',
+        'name' => ts('Cancel'),
+      ),
+    ));
+  }
+
+  /**
+   * Process the form submission.
+   */
+  public function postProcess() {
+    $params = array(
+      'id' => $this->_id,
+      'check_number' => CRM_Utils_Array::value('check_number', $this->_submitValues),
+      'pan_truncation' => CRM_Utils_Array::value('pan_truncation', $this->_submitValues),
+      'trxn_date' => CRM_Utils_Array::value('trxn_date', $this->_submitValues, date('YmdHis')),
+    );
+    if (!empty($this->_submitValues['credit_card_type'])) {
+      $params['card_type_id'] = CRM_Core_PseudoConstant::getKey(
+        'CRM_Financial_DAO_FinancialTrxn',
+        'card_type_id',
+        $this->_submitValues['credit_card_type']
+      );
+    }
+    // update the financial trxn
+    civicrm_api3('FinancialTrxn', 'create', $params);
+    CRM_Core_Session::singleton()->pushUserContext(CRM_Utils_System::url(CRM_Utils_System::currentPath()));
+  }
+
+  /**
+   * Get payment fields
+   */
+  public function getPaymentFields() {
+    $paymentFields = array();
+    $paymentInstrument = CRM_Core_PseudoConstant::getName('CRM_Financial_DAO_FinancialTrxn', 'payment_instrument_id', $this->_values['payment_instrument_id']);
+    if ($paymentInstrument == 'Check') {
+      $paymentFields['check_number'] = array(
+        'htmlType' => 'text',
+        'name' => 'check_number',
+        'title' => ts('Check Number'),
+        'is_required' => FALSE,
+        'attributes' => NULL,
+      );
+    }
+    elseif ($paymentInstrument == 'Credit Card') {
+      CRM_Financial_Form_Payment::addCreditCardJs(NULL, 'payment-edit-block');
+      $paymentFields['credit_card_type'] = array(
+        'htmlType' => 'select',
+        'name' => 'credit_card_type',
+        'title' => ts('Card Type'),
+        'attributes' => array('' => ts('- select -')) + CRM_Contribute_PseudoConstant::creditCard(),
+      );
+      $paymentFields['pan_truncation'] = array(
+        'htmlType' => 'text',
+        'name' => 'pan_truncation',
+        'title' => ts('Last 4 digits of the card'),
+        'attributes' => array(
+          'size' => 4,
+          'maxlength' => 4,
+          'minlength' => 4,
+          'autocomplete' => 'off',
+        ),
+        'rules' => array(
+          array(
+            'rule_message' => ts('Please enter valid last 4 digit card number.'),
+            'rule_name' => 'numeric',
+            'rule_parameters' => NULL,
+          ),
+        ),
+      );
+    }
+    $paymentFields += array(
+      'trxn_date' => array(
+        'htmlType' => 'datepicker',
+        'name' => 'trxn_date',
+        'title' => ts('Transaction Date'),
+        'attributes' => array(
+          'date' => 'yyyy-mm-dd',
+          'time' => 24,
+        ),
+      ),
+      'total_amount' => array(
+        'htmlType' => 'text',
+        'name' => 'total_amount',
+        'title' => ts('Total Amount'),
+        'attributes' => array(
+          'readonly' => TRUE,
+          'size' => 6,
+        ),
+      ),
+    );
+
+    return $paymentFields;
+  }
+
+}

--- a/templates/CRM/Contribute/Form/AdditionalPayment.tpl
+++ b/templates/CRM/Contribute/Form/AdditionalPayment.tpl
@@ -24,35 +24,7 @@
  +--------------------------------------------------------------------+
 *}
 {if $transaction}
-  {if !empty($rows)}
-   <table id='info'>
-     <tr class="columnheader">
-       <th>{ts}Amount{/ts}</th>
-       <th>{ts}Type{/ts}</th>
-       <th>{ts}Payment Method{/ts}</th>
-       <th>{ts}Received{/ts}</th>
-       <th>{ts}Transaction ID{/ts}</th>
-       <th>{ts}Status{/ts}</th>
-     </tr>
-     {foreach from=$rows item=row}
-     <tr>
-       <td>{$row.total_amount|crmMoney:$row.currency}</td>
-       <td>{$row.financial_type}</td>
-       <td>{$row.payment_instrument}{if $row.check_number} (#{$row.check_number}){/if}</td>
-       <td>{$row.receive_date|crmDate}</td>
-       <td>{$row.trxn_id}</td>
-       <td>{$row.status}</td>
-     </tr>
-     {/foreach}
-    <table>
-  {else}
-     {if $component eq 'event'}
-       {assign var='entity' value='participant'}
-     {else}
-       {assign var='entity' value=$component}
-     {/if}
-     {ts 1=$entity}No payments found for this %1 record{/ts}
-  {/if}
+  {include file="CRM/Contribute/Form/PaymentInfoBlock.tpl"}
   {if !$suppressPaymentFormButtons}
     <div class="crm-submit-buttons">
        {include file="CRM/common/formButtons.tpl"}

--- a/templates/CRM/Contribute/Form/PaymentInfoBlock.tpl
+++ b/templates/CRM/Contribute/Form/PaymentInfoBlock.tpl
@@ -1,0 +1,58 @@
+{*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2017                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*}
+{crmRegion name="payment-info-block"}
+{if !empty($payments)}
+  <table class="selector row-highlight">
+    <tr>
+      <th></th>
+      <th>{ts}Amount{/ts}</th>
+      <th>{ts}Type{/ts}</th>
+      <th>{ts}Payment Method{/ts}</th>
+      <th>{ts}Received{/ts}</th>
+      <th>{ts}Transaction ID{/ts}</th>
+      <th>{ts}Status{/ts}</th>
+    </tr>
+    {foreach from=$payments item=payment}
+      <tr class="{cycle values="odd-row,even-row"}">
+        <td>{$payment.action}</td>
+        <td>{$payment.total_amount|crmMoney:$payment.currency}</td>
+        <td>{$payment.financial_type}</td>
+        <td>{$payment.payment_instrument}{if $payment.check_number} (#{$payment.check_number}){/if}</td>
+        <td>{$payment.receive_date|crmDate}</td>
+        <td>{$payment.trxn_id}</td>
+        <td>{$payment.status}</td>
+      </tr>
+    {/foreach}
+  </table>
+{else}
+   {if $component eq 'event'}
+     {assign var='entity' value='participant'}
+   {else}
+     {assign var='entity' value=$component}
+   {/if}
+   {ts 1=$entity}No payments found for this %1 record{/ts}
+{/if}
+{/crmRegion}

--- a/templates/CRM/Core/BillingBlock.js
+++ b/templates/CRM/Core/BillingBlock.js
@@ -24,6 +24,20 @@
       // Hide the CC type field (redundant)
       $('#credit_card_type, .label', '.crm-container .credit_card_type-section').hide();
 
+      // set the card type value as default if any found
+      var cardtype = $('#credit_card_type').val();
+      if (cardtype) {
+        $.each(CRM.config.creditCardTypes, function(key, value) {
+          // highlight the selected card type icon
+          if (value == cardtype) {
+            $('.crm-container .credit_card_type-section .crm-credit_card_type-icon-' + key).css('opacity', 1);
+          }
+          else {
+            $('.crm-container .credit_card_type-section .crm-credit_card_type-icon-' + key).css('opacity', 0.25);
+          }
+        });
+      }
+
       // Select according to the number entered
       $('.crm-container input#credit_card_number').change(function() {
         var ccnumber = cj(this).val();
@@ -55,22 +69,13 @@
       'unionpay': '62(?:[0-9]{14}|[0-9]{17})'
     };
 
-    var card_values = {
-      'mastercard': 'MasterCard',
-      'visa': 'Visa',
-      'amex': 'Amex',
-      'dinersclub': 'Diners Club',
-      'carteblanche': 'Carte Blanche',
-      'discover': 'Discover',
-      'jcb': 'JCB',
-      'unionpay': 'UnionPay'
-    };
+    var card_values = CRM.config.creditCardTypes;
 
     $.each(card_types, function(key, pattern) {
       if (ccnumber.match('^' + pattern + '$')) {
         var value = card_values[key];
         //$.each(CRM.config.creditCardTypes, function(key2, val) {
-        //  if (value == val) { 
+        //  if (value == val) {
             $('.crm-container .credit_card_type-section .crm-credit_card_type-icon-' + key).css('opacity', 1);
             $('select#credit_card_type').val(value);
             return false;

--- a/templates/CRM/Financial/Form/PaymentEdit.tpl
+++ b/templates/CRM/Financial/Form/PaymentEdit.tpl
@@ -1,0 +1,47 @@
+{*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2017                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*}
+
+{crmRegion name="payment-edit-block"}
+   <div id="payment-edit-section" class="crm-section billing_mode-section">
+     {foreach from=$paymentFields item=paymentField}
+       {assign var='name' value=$paymentField.name}
+       <div class="crm-container {$name}-section">
+         <div class="label">{$form.$name.label}
+           {if $requiredPaymentFields.$name}<span class="crm-marker" title="{ts}This field is required.{/ts}">*</span>{/if}
+         </div>
+         <div class="content">{if $name eq 'total_amount'}{$currency}&nbsp;&nbsp;{/if}{$form.$name.html}
+           {if $name == 'credit_card_type'}
+             <div class="crm-credit_card_type-icons"></div>
+           {/if}
+         </div>
+         <div class="clear"></div>
+       </div>
+     {/foreach}
+   </div>
+{/crmRegion}
+<div class="crm-submit-buttons">
+  {include file="CRM/common/formButtons.tpl" location="bottom"}
+</div>


### PR DESCRIPTION
@monishdeb  I started looking at #10729 - but there appear to be a few changes in there that I need to work through. This PR here represents the portion of that PR that I have reviewed, tested & approved. 

Can you please check this still looks good to you & merge it.

Note the change included in this is the addition of the payment form, available from contribution tab when expanded. I have not reviewed the addition of this to the contribution edit form yet, or any other changes to that form as yet. It will require a rebase of the other PR but I think it won't be too bad. I did alter the query change in getPaymentInfo a little, to only get one extra field

![screenshot 2017-07-27 21 08 56](https://user-images.githubusercontent.com/336308/28662915-e48bb32a-730f-11e7-9231-784ad63ab284.png)

---

 * [CRM-20610: Replace payment details block with editable payment list on 'Edit Contribution' form](https://issues.civicrm.org/jira/browse/CRM-20610)