### PR TITLE
CRM-20610 expose payment edit form on the contribution page

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -239,6 +239,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     if (!empty($this->_id)) {
       $this->assignPaymentInfoBlock();
       $this->assign('contribID', $this->_id);
+      $this->assign('isUsePaymentBlock', TRUE);
     }
 
     $this->_context = CRM_Utils_Request::retrieve('context', 'String', $this);


### PR DESCRIPTION
@monish this is the portion of #10729 that replaces the PaymentDetails section of the Contribution form. I've put it in this PR for discussion but given the pretty pictures already on that PR we should probably take what we agree back over there

---

 * [CRM-20610: Replace payment details block with editable payment list on 'Edit Contribution' form](https://issues.civicrm.org/jira/browse/CRM-20610)