### PR TITLE
CRM-20969 alternate approach to resolving php 7.1 errors

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -361,6 +361,12 @@ class CRM_Report_Form extends CRM_Core_Form {
   public $_orderBy = NULL;
   public $_orderByFields = array();
   public $_orderByArray = array();
+  /**
+   * Array of clauses to group by.
+   *
+   * @var array
+   */
+  protected $_groupByArray = array();
   public $_groupBy = NULL;
   public $_whereClauses = array();
   public $_havingClauses = array();
@@ -2637,7 +2643,6 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
    * Build group by clause.
    */
   public function groupBy() {
-    $groupBys = array();
     if (!empty($this->_params['group_bys']) &&
       is_array($this->_params['group_bys'])
     ) {
@@ -2645,15 +2650,15 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
         if (array_key_exists('group_bys', $table)) {
           foreach ($table['group_bys'] as $fieldName => $field) {
             if (!empty($this->_params['group_bys'][$fieldName])) {
-              $groupBys[] = $field['dbAlias'];
+              $this->_groupByArray[] = $field['dbAlias'];
             }
           }
         }
       }
     }
 
-    if (!empty($groupBys)) {
-      $this->_groupBy = CRM_Contact_BAO_Query::getGroupByFromSelectColumns($this->_selectClauses, $groupBys);
+    if (!empty($this->_groupByArray)) {
+      $this->_groupBy = CRM_Contact_BAO_Query::getGroupByFromSelectColumns($this->_selectClauses, $this->_groupByArray);
     }
   }
 

--- a/CRM/Report/Form/Member/Summary.php
+++ b/CRM/Report/Form/Member/Summary.php
@@ -362,7 +362,7 @@ class CRM_Report_Form_Member_Summary extends CRM_Report_Form {
     if (is_array($this->_params['group_bys']) &&
       !empty($this->_params['group_bys'])
     ) {
-      foreach ($this->_columns as $tableName => $table) {
+      foreach ($this->_columns as $table) {
         if (array_key_exists('group_bys', $table)) {
           foreach ($table['group_bys'] as $fieldName => $field) {
             if (!empty($this->_params['group_bys'][$fieldName])) {
@@ -379,12 +379,12 @@ class CRM_Report_Form_Member_Summary extends CRM_Report_Form {
                 )) {
                   $append = '';
                 }
-                $this->_groupBy[] = $append;
-                $this->_groupBy[] = "{$this->_params['group_bys_freq'][$fieldName]}({$field['dbAlias']})";
+                $this->_groupByArray[] = $append;
+                $this->_groupByArray[] = "{$this->_params['group_bys_freq'][$fieldName]}({$field['dbAlias']})";
                 $append = TRUE;
               }
               else {
-                $this->_groupBy[] = $field['dbAlias'];
+                $this->_groupByArray[] = $field['dbAlias'];
               }
             }
           }
@@ -392,8 +392,8 @@ class CRM_Report_Form_Member_Summary extends CRM_Report_Form {
       }
 
       $this->_rollup = ' WITH ROLLUP';
-      $this->_select = CRM_Contact_BAO_Query::appendAnyValueToSelect($this->_selectClauses, array_filter($this->_groupBy));
-      $this->_groupBy = 'GROUP BY ' . implode(', ', array_filter($this->_groupBy)) .
+      $this->_select = CRM_Contact_BAO_Query::appendAnyValueToSelect($this->_selectClauses, array_filter($this->_groupByArray));
+      $this->_groupBy = 'GROUP BY ' . implode(', ', array_filter($this->_groupByArray)) .
         " {$this->_rollup} ";
     }
     else {


### PR DESCRIPTION
I am proposing this as an alternate approach for fixing the 7.1 errors.

Note this only covers one report - I think we should move that function which is actually
generic to the parent class, however I think the one in contribute.summary is
a bit more nuanced.

Note this is also the approach taken by the extendedreport
extension (which takes it a little further). I will remove the declaration of
groupByArray from that extension if we add it here

I do have a medium term plan to move a lot of the helpers from extended report back into core.

Change-Id: I377d33a7417ff93169f12ccbda77f3662da5bac1

---

 * [CRM-20969: Fix issue in reports where we try and append a new array key to string](https://issues.civicrm.org/jira/browse/CRM-20969)