### PR TITLE
CRM-20979 -  expose pre help for price fields to the UI

### DIFF
--- a/CRM/Price/Form/Field.php
+++ b/CRM/Price/Form/Field.php
@@ -322,8 +322,12 @@ class CRM_Price_Form_Field extends CRM_Core_Form {
     $this->add('text', 'options_per_line', ts('Options Per Line'));
     $this->addRule('options_per_line', ts('must be a numeric value'), 'numeric');
 
+    $this->add('textarea', 'help_pre', ts('Pre Field Help'),
+      CRM_Core_DAO::getAttribute('CRM_Price_DAO_PriceField', 'help_post')
+    );
+
     // help post, mask, attributes, javascript ?
-    $this->add('textarea', 'help_post', ts('Field Help'),
+    $this->add('textarea', 'help_post', ts('Post Field Help'),
       CRM_Core_DAO::getAttribute('CRM_Price_DAO_PriceField', 'help_post')
     );
 

--- a/templates/CRM/Price/Form/Field.tpl
+++ b/templates/CRM/Price/Form/Field.tpl
@@ -158,11 +158,20 @@
       </td>
     </tr>
 
+    <tr class="crm-price-field-form-block-help_pre">
+      <td class="label">{$form.help_pre.label}</td>
+      <td>{if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_price_field' field='help_pre' id=$fid}{/if}{$form.help_pre.html|crmAddClass:huge}&nbsp;
+      {if $action neq 4}
+        <div class="description">{ts}Explanatory text displayed to users at the beginning of this field.{/ts}</div>
+      {/if}
+      </td>
+    </tr>
+
     <tr class="crm-price-field-form-block-help_post">
       <td class="label">{$form.help_post.label}</td>
       <td>{if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_price_field' field='help_post' id=$fid}{/if}{$form.help_post.html|crmAddClass:huge}&nbsp;
       {if $action neq 4}
-        <div class="description">{ts}Explanatory text displayed to users for this field.{/ts}</div>
+        <div class="description">{ts}Explanatory text displayed to users below this field.{/ts}</div>
       {/if}
       </td>
     </tr>

--- a/templates/CRM/Price/Form/PriceSet.tpl
+++ b/templates/CRM/Price/Form/PriceSet.tpl
@@ -37,14 +37,12 @@
     {foreach from=$priceSet.fields item=element key=field_id}
         {* Skip 'Admin' visibility price fields WHEN this tpl is used in online registration unless user has administer CiviCRM permission. *}
         {if $element.visibility EQ 'public' || ($element.visibility EQ 'admin' && $adminFld EQ true) || $context eq 'standalone' || $context eq 'advanced' || $context eq 'search' || $context eq 'participant' || $context eq 'dashboard' || $action eq 1024}
+            {if $element.help_pre}<span class="content description">{$element.help_pre}</span><br />{/if}
             <div class="crm-section {$element.name}-section">
             {if ($element.html_type eq 'CheckBox' || $element.html_type == 'Radio') && $element.options_per_line}
               {assign var="element_name" value="price_"|cat:$field_id}
               <div class="label">{$form.$element_name.label}</div>
               <div class="content {$element.name}-content">
-                {if $element.help_pre}
-                  <div class="description">{$element.help_pre}</div>
-                {/if}
                 {assign var="elementCount" value="0"}
                 {assign var="optionCount" value="0"}
                 {assign var="rowCount" value="0"}
@@ -73,7 +71,6 @@
 
                 <div class="label">{$form.$element_name.label}</div>
                 <div class="content {$element.name}-content">
-                  {if $element.help_pre}<span class="description">{$element.help_pre}</span><br />{/if}
                   {$form.$element_name.html}
                   {if $element.html_type eq 'Text'}
                     {if $element.is_display_amounts}

--- a/templates/CRM/Price/Form/PriceSet.tpl
+++ b/templates/CRM/Price/Form/PriceSet.tpl
@@ -42,6 +42,9 @@
               {assign var="element_name" value="price_"|cat:$field_id}
               <div class="label">{$form.$element_name.label}</div>
               <div class="content {$element.name}-content">
+                {if $element.help_pre}
+                  <div class="description">{$element.help_pre}</div>
+                {/if}
                 {assign var="elementCount" value="0"}
                 {assign var="optionCount" value="0"}
                 {assign var="rowCount" value="0"}
@@ -69,7 +72,9 @@
                 {assign var="element_name" value="price_"|cat:$field_id}
 
                 <div class="label">{$form.$element_name.label}</div>
-                <div class="content {$element.name}-content">{$form.$element_name.html}
+                <div class="content {$element.name}-content">
+                  {if $element.help_pre}<span class="description">{$element.help_pre}</span><br />{/if}
+                  {$form.$element_name.html}
                   {if $element.html_type eq 'Text'}
                     {if $element.is_display_amounts}
                     <span class="price-field-amount{if $form.$element_name.frozen EQ 1} sold-out-option{/if}">


### PR DESCRIPTION
[Price Field form has `Field Help`](http://dmaster.demo.civicrm.org/civicrm/admin/price/field?reset=1&action=add&sid=11) which act as a post help text. We have a [column to store](https://github.com/civicrm/civicrm-core/blob/master/xml/schema/Price/PriceField.xml#L90-L102) pre_help in `civicrm_price_field`, but no field in UI to accept and insert the value in the table.

---

 * [CRM-20979: pre help for price fields not exposed to UI.](https://issues.civicrm.org/jira/browse/CRM-20979)