### PR TITLE
CRM-20981 - Allow custom base-pages with less `crmApp` boilerplate

### DIFF
--- a/Civi/Angular/AngularLoader.php
+++ b/Civi/Angular/AngularLoader.php
@@ -74,6 +74,8 @@ class AngularLoader {
 
   /**
    * Register resources required by Angular.
+   *
+   * @return AngularLoader
    */
   public function load() {
     $angular = $this->getAngular();
@@ -135,6 +137,8 @@ class AngularLoader {
         $res->addStyleUrl($url, self::DEFAULT_MODULE_WEIGHT + (++$headOffset), $this->getRegion());
       }
     }
+
+    return $this;
   }
 
   /**
@@ -170,9 +174,11 @@ class AngularLoader {
 
   /**
    * @param \CRM_Core_Resources $res
+   * @return AngularLoader
    */
   public function setRes($res) {
     $this->res = $res;
+    return $this;
   }
 
   /**
@@ -184,9 +190,11 @@ class AngularLoader {
 
   /**
    * @param \Civi\Angular\Manager $angular
+   * @return AngularLoader
    */
   public function setAngular($angular) {
     $this->angular = $angular;
+    return $this;
   }
 
   /**
@@ -198,9 +206,11 @@ class AngularLoader {
 
   /**
    * @param string $region
+   * @return AngularLoader
    */
   public function setRegion($region) {
     $this->region = $region;
+    return $this;
   }
 
   /**
@@ -214,9 +224,11 @@ class AngularLoader {
   /**
    * @param string $pageName
    *   Ex: 'civicrm/a'.
+   * @return AngularLoader
    */
   public function setPageName($pageName) {
     $this->pageName = $pageName;
+    return $this;
   }
 
   /**
@@ -238,9 +250,11 @@ class AngularLoader {
 
   /**
    * @param array $modules
+   * @return AngularLoader
    */
   public function setModules($modules) {
     $this->modules = $modules;
+    return $this;
   }
 
 }

--- a/Civi/Angular/AngularLoader.php
+++ b/Civi/Angular/AngularLoader.php
@@ -220,6 +220,16 @@ class AngularLoader {
   }
 
   /**
+   * @param array|string $modules
+   * @return AngularLoader
+   */
+  public function addModules($modules) {
+    $modules = (array) $modules;
+    $this->modules = array_unique(array_merge($this->modules, $modules));
+    return $this;
+  }
+
+  /**
    * @return array
    */
   public function getModules() {

--- a/Civi/Angular/AngularLoader.php
+++ b/Civi/Angular/AngularLoader.php
@@ -182,8 +182,11 @@ class AngularLoader {
    * @param array $settings
    *   A list of settings. Accepted values:
    *    - activeRoute: string, the route to open up immediately
-   *    - defaultRoute: string, use this to redirect the default route to another page
+   *      Ex: '/case/list'
+   *    - defaultRoute: string, use this to redirect the default route (`/`) to another page
+   *      Ex: '/case/list'
    *    - region: string, the place on the page where we should insert the angular app
+   *      Ex: 'page-body'
    * @return AngularLoader
    * @link https://code.angularjs.org/1.5.11/docs/guide/bootstrap
    */

--- a/Civi/Angular/Page/Main.php
+++ b/Civi/Angular/Page/Main.php
@@ -76,25 +76,12 @@ class Main extends \CRM_Core_Page {
   public function registerResources() {
     $loader = new \Civi\Angular\AngularLoader();
     $loader->setPageName('civicrm/a');
-    $loader->setModules(array('crmApp'));
+    $loader->useApp(array(
+      'activeRoute' => \CRM_Utils_Request::retrieve('route', 'String'),
+      'defaultRoute' => NULL,
+    ));
     $loader->load();
 
-    // If trying to load an Angular page via AJAX, the route must be passed as a
-    // URL parameter, since the server doesn't receive information about
-    // URL fragments (i.e, what comes after the #).
-    \CRM_Core_Resources::singleton()->addSetting(array(
-      'crmApp' => array(
-        'defaultRoute' => NULL,
-      ),
-      'angularRoute' => \CRM_Utils_Request::retrieve('route', 'String'),
-    ));
-  }
-
-  /**
-   * @inheritdoc
-   */
-  public function getTemplateFileName() {
-    return 'Civi/Angular/Page/Main.tpl';
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
This provides API improvements for extensions (such as CiviCase and CiviVolunteer) which implement [custom Angular base-pages](https://docs.civicrm.org/dev/en/master/framework/angular/loader/#other-base-pages).

Before
----------------------------------------
The CiviCase extension created [its own standalone base-page](https://github.com/civicrm/org.civicrm.civicase/blob/master/CRM/Civicase/Page/CaseAngular.php) with this:

```php
  public function run() {
    $loader = new \Civi\Angular\AngularLoader();
    $loader->setPageName('civicrm/case/a');
    $loader->setModules(array('crmApp', 'civicase'));
    $loader->load();
    \Civi::resources()->addSetting(array(
      'crmApp' => array(
        'defaultRoute' => '/case/list',
      ),
    ));
    return parent::run();
  }
  /**
   * @inheritdoc
   */
  public function getTemplateFileName() {
    return 'Civi/Angular/Page/Main.tpl';
  }
```

After
----------------------------------------
The CiviCase extension can create the same page with this:

```php
  public function run() {
    $loader = new \Civi\Angular\AngularLoader();
    $loader->setPageName('civicrm/case/a');
    $loader->setModules(array('civicase'));
    $loader->useApp(array(
      'defaultRoute' => '/case/list',
    ));
    $loader->load();
    return parent::run();
  }
```

Comments
----------------------------------------
 * For backwards compatibility, the `useApp()` function is opt-in. This means that the old code in the CiviCase extension (for both `civicrm/case/a` and for "View Contacts") still works the same.
 * After merging, we should update the dev docs in [loader.md](https://github.com/civicrm/civicrm-dev-docs/blob/master/docs/framework/angular/loader.md).

---

 * [CRM-20981: Allow custom base-pages with less `crmApp` boilerplate](https://issues.civicrm.org/jira/browse/CRM-20981)