### PR TITLE
CRM-20965 - PULL_REQUEST_TEMPLATE - Change header notation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,19 @@
-## Overview
+Overview
+----------------------------------------
 _A brief description of the pull request. Try to keep it non-technical._
 
-## Before
+Before
+----------------------------------------
 _The current status. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._
 
-## After
+After
+----------------------------------------
 _What has been changed. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._
 
-## Technical Details
+Technical Details
+----------------------------------------
 _If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_
 
-## Comments
+Comments
+----------------------------------------
 _Anything else you would like the reviewer to note_


### PR DESCRIPTION
## Overview

The Github CLI (`hub pull-request`) uses `#` to indicate comment lines, e.g.

<img width="841" alt="screen shot 2017-07-28 at 5 19 10 pm" src="https://user-images.githubusercontent.com/1336047/28740505-5f882bb2-73ba-11e7-88a2-b6080c1adf50.png">

## Before

Headers are marked with `##`, which conflicts with the comment `#`.

## After

Headers are marked with `-----`, which does not conflict.

## Comments

 * To test this, use the current pre-release of `hub` (2.3.0-pre10). The current stable release of `hub` (v2.2.9) does not seem to respect `PULL_REQUEST_TEMPLATE` at all.
 * Thought about making the `----` lines match the width of the titles. (That's common in Markdown.) However, that looks weird when you fill out the template on a web-browser. (In a browser, the width of `-` may not match your other characters.). So I just went with a really long `----` line.

---

 * [CRM-20965: Add Pull Request Template](https://issues.civicrm.org/jira/browse/CRM-20965)