### PR TITLE
CRM-20982 Configure the SMTP mailer to identify itself to the SMTP se…

### DIFF
--- a/CRM/Utils/Mail.php
+++ b/CRM/Utils/Mail.php
@@ -68,8 +68,20 @@ class CRM_Utils_Mail {
         $params['auth'] = FALSE;
       }
 
-      // set the localhost value, CRM-3153
-      $params['localhost'] = CRM_Utils_Array::value('SERVER_NAME', $_SERVER, 'localhost');
+      /*
+       * Set the localhost value, CRM-3153
+       * Use the host name of the web server, falling back to the base URL
+       * (eg when using the PHP CLI), and then falling back to localhost.
+       */
+      $params['localhost'] = CRM_Utils_Array::value(
+        'SERVER_NAME',
+        $_SERVER,
+        CRM_Utils_Array::value(
+          'host',
+          parse_url(CIVICRM_UF_BASEURL),
+          'localhost'
+        )
+      );
 
       // also set the timeout value, lets set it to 30 seconds
       // CRM-7510


### PR DESCRIPTION
…rver in EHLO/HELO commands as: SERVER_NAME when invoked from the web server; else CIVICRM_UF_BASEURL when invoked from the CLI; and falling back to 'localhost' as the last resort.

Overview
----------------------------------------
Improve the likelihood CiviMails will be delivered. When connecting to some SMTP servers, CiviMail will identify itself in a way that (a) may prevent the server verifying the sender and (b) resembles a spammer. This is a simple fix to improve the way CiviMail identifies itself.

Before
----------------------------------------
1. Configure emails to be sent using SMTP
2. Send a CiviMail using the command line
3. The mailer will identify itself to the SMTP server as "EHLO localhost"
4. In some cases the SMTP server will reject the email 

After
----------------------------------------
1. Configure emails to be sent using SMTP
2. Send a CiviMail using the command line
3. The mailer will identify itself to the SMTP server as "EHLO example.com"
4. The SMTP server will accept the email 

Technical Details
----------------------------------------
Configure the SMTP mailer to identify itself to the SMTP server in EHLO/HELO commands as: SERVER_NAME when invoked from the web server; else CIVICRM_UF_BASEURL when invoked from the CLI; and falling back to 'localhost' as the last resort.

Comments
----------------------------------------
In my experience using G Suite for Non-profits, Google rejects these emails when the mailer identifies itself using "EHLO localhost". The problem rights itself when we replace "localhost" with our host name.
