### PR TITLE
CRM-20983, fixed cms path root when ran using wp-cli method

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -493,6 +493,10 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
         $valid = TRUE;
       }
     }
+    elseif (!empty($_SERVER['DOCUMENT_ROOT'])) {
+      $cmsRoot = $_SERVER['DOCUMENT_ROOT'];
+      $valid = TRUE;
+    }
     else {
       $pathVars = explode('/', str_replace('\\', '/', $_SERVER['SCRIPT_FILENAME']));
 


### PR DESCRIPTION
----------------------------------------
* CRM-20983: 'Cannot resolve path using "cms.root.path"
  https://issues.civicrm.org/jira/browse/CRM-20983

Overview
----------------------------------------
Fatal error when trying to run schedule job using wp-cli method since $_SERVER['SCRIPT_FILENAME'] was set /path/to/wp-cli. The fix includes to check if DOCUMENT_ROOT is !empty then set cms.root as DOCUMENT_ROOT else try to get it from SCRIPT_FILENAME.
  
Before
----------------------------------------
PHP Fatal error:  Uncaught exception 'RuntimeException' with message 'Cannot resolve path using "cms.root.path"' in /var/www/wordpress/wp-content/plugins/civicrm/civicrm/Civi/Core/Paths.php:104
Stack trace:


After
----------------------------------------
Schedule Job was executed successfully. 

