### PR TITLE
CRM-20984: Move placement of payment processor field

### DIFF
--- a/templates/CRM/Contribute/Form/AdditionalPayment.tpl
+++ b/templates/CRM/Contribute/Form/AdditionalPayment.tpl
@@ -56,9 +56,6 @@
     <tr>
       <td class="font-size12pt label"><strong>{if $component eq 'event'}{ts}Participant{/ts}{else}{ts}Contact{/ts}{/if}</strong></td><td class="font-size12pt"><strong>{$displayName}</strong></td>
     </tr>
-    {if $contributionMode}
-      <tr class="crm-payment-form-block-payment_processor_id"><td class="label nowrap">{$form.payment_processor_id.label}<span class="crm-marker"> * </span></td><td>{$form.payment_processor_id.html}</td></tr>
-    {/if}
     {if $eventName}
       <tr>
         <td class='label'>{ts}Event{/ts}</td><td>{$eventName}</td>
@@ -82,6 +79,9 @@
           <td class="label">{$form.from_email_address.label}</td>
           <td>{$form.from_email_address.html}</td>
         </tr>
+      {/if}
+      {if $contributionMode}
+        <tr class="crm-payment-form-block-payment_processor_id"><td class="label nowrap">{$form.payment_processor_id.label}<span class="crm-marker"> * </span></td><td>{$form.payment_processor_id.html}</td></tr>
       {/if}
     </tr>
    </table>

--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -80,9 +80,6 @@
       <td class="label">{$form.contact_id.label}</td>
       <td>{$form.contact_id.html}</td>
     {/if}
-    {if $contributionMode}
-      <tr class="crm-contribution-form-block-payment_processor_id"><td class="label nowrap">{$form.payment_processor_id.label}<span class="crm-marker"> * </span></td><td>{$form.payment_processor_id.html}</td></tr>
-    {/if}
     <tr class="crm-contribution-form-block-contribution_type_id crm-contribution-form-block-financial_type_id">
       <td class="label">{$form.financial_type_id.label}</td><td{$valueStyle}>{$form.financial_type_id.html}&nbsp;
       {if $is_test}
@@ -242,7 +239,9 @@
         <span class="description">{ts}Date that a receipt was sent to the contributor.{/ts}</span>
       </td>
     </tr>
-
+    {if $contributionMode}
+      <tr class="crm-contribution-form-block-payment_processor_id"><td class="label nowrap">{$form.payment_processor_id.label}<span class="crm-marker"> * </span></td><td>{$form.payment_processor_id.html}</td></tr>
+    {/if}
   </table>
 
   {if !$contributionMode}

--- a/templates/CRM/Event/Form/Participant.tpl
+++ b/templates/CRM/Event/Form/Participant.tpl
@@ -249,12 +249,6 @@
               </tr>
             {/if}
           {/if}
-          {if $participantMode}
-            <tr class="crm-participant-form-block-payment_processor_id">
-              <td class="label nowrap">{$form.payment_processor_id.label}</td>
-              <td>{$form.payment_processor_id.html}</td>
-            </tr>
-          {/if}
           <tr class="crm-participant-form-block-event_id">
             <td class="label">{$form.event_id.label}</td>
             <td class="view-value">
@@ -292,6 +286,12 @@
             <td class="label">{$form.source.label}</td><td>{$form.source.html|crmAddClass:huge}<br />
             <span class="description">{ts}Source for this registration (if applicable).{/ts}</span></td>
           </tr>
+          {if $participantMode}
+            <tr class="crm-participant-form-block-payment_processor_id">
+              <td class="label nowrap">{$form.payment_processor_id.label}</td>
+              <td>{$form.payment_processor_id.html}</td>
+            </tr>
+          {/if}
         </table>
        {if $participantId and $hasPayment}
         <table class='form-layout'>

--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -93,12 +93,6 @@
           <td class="label">{$form.contact_id.label}</td>
           <td>{$form.contact_id.html}</td>
         {/if}
-        {if $membershipMode}
-          <tr>
-            <td class="label">{$form.payment_processor_id.label}</td>
-            <td>{$form.payment_processor_id.html}</td>
-          </tr>
-        {/if}
         <tr class="crm-membership-form-block-membership_type_id">
           <td class="label">{$form.membership_type_id.label}</td>
           <td><span id='mem_type_id'>{$form.membership_type_id.html}</span>
@@ -183,7 +177,6 @@
             <fieldset id="recordContribution"><legend>{ts}Membership Payment and Receipt{/ts}</legend>
         {/if}
         {include file="CRM/Member/Form/MembershipCommon.tpl"}
-
         {if $emailExists and $isEmailEnabledForSite}
           <tr id="send-receipt" class="crm-membership-form-block-send_receipt">
             <td class="label">{$form.send_receipt.label}</td><td>{$form.send_receipt.html}<br />

--- a/templates/CRM/Member/Form/MembershipCommon.tpl
+++ b/templates/CRM/Member/Form/MembershipCommon.tpl
@@ -100,7 +100,12 @@
 
   <div class="spacer"></div>
 {/if}
-
+{if $membershipMode}
+  <tr>
+    <td class="label">{$form.payment_processor_id.label}</td>
+    <td>{$form.payment_processor_id.html}</td>
+  </tr>
+{/if}
 <tr class="crm-membership-form-block-billing">
   <td colspan="2">
     {include file='CRM/Core/BillingBlockWrapper.tpl'}


### PR DESCRIPTION
Overview
----------------------------------------
_Currently, on 'Submit Credit Card Contribution' or any live payment form there is a visual disconnect between payment processor field and its billing block. To resolve that move the processor field just above the billing block section kind of placement we already have in online contribution page registration form._

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/3735621/28756934-568dd0ec-7596-11e7-8b5a-5bf9e0fb0520.png)


After
----------------------------------------
![image](https://user-images.githubusercontent.com/3735621/28756935-5f14b5b4-7596-11e7-95e7-c8d6306762a5.png)


Technical Details
----------------------------------------
Above screenshots depict the UI change in 'Submit Credit Card Contribution' form. Similarly, the changes are made in following forms:
1. Submit Credit Card Event Registration
2. Submit Credit Card Membership
3. Submit Credit Card payment (additional payment)
4. Submit Credit Card Membership Renewal

---

 * [CRM-20984: Move placement of payment processor field on live mode](https://issues.civicrm.org/jira/browse/CRM-20984)