### PR TITLE
CRM-20987, added batch transaction column

### DIFF
--- a/CRM/Financial/Page/AJAX.php
+++ b/CRM/Financial/Page/AJAX.php
@@ -255,6 +255,7 @@ class CRM_Financial_Page_AJAX {
       3 => 'amount',
       4 => 'trxn_id',
       5 => 'transaction_date',
+      5 => 'receive_date',
       6 => 'payment_method',
       7 => 'status',
       8 => 'name',
@@ -287,6 +288,7 @@ class CRM_Financial_Page_AJAX {
       'contact_a.contact_type',
       'contact_a.contact_sub_type',
       'civicrm_financial_trxn.trxn_date as transaction_date',
+      'civicrm_contribution.receive_date as receive_date',
       'civicrm_financial_type.name',
       'civicrm_financial_trxn.currency as currency',
       'civicrm_financial_trxn.status_id as status',
@@ -298,7 +300,8 @@ class CRM_Financial_Page_AJAX {
       'sort_name' => ts('Contact Name'),
       'amount' => ts('Amount'),
       'trxn_id' => ts('Trxn ID'),
-      'transaction_date' => ts('Received'),
+      'transaction_date' => ts('Transaction Date'),
+      'receive_date' => ts('Received'),
       'payment_method' => ts('Payment Method'),
       'status' => ts('Status'),
       'name' => ts('Type'),
@@ -372,6 +375,9 @@ class CRM_Financial_Page_AJAX {
           $row[$financialItem->id][$columnKey] = CRM_Utils_Money::format($financialItem->$columnKey, $financialItem->currency);
         }
         elseif ($columnKey == 'transaction_date' && $financialItem->$columnKey) {
+          $row[$financialItem->id][$columnKey] = CRM_Utils_Date::customFormat($financialItem->$columnKey);
+        }
+        elseif ($columnKey == 'receive_date' && $financialItem->$columnKey) {
           $row[$financialItem->id][$columnKey] = CRM_Utils_Date::customFormat($financialItem->$columnKey);
         }
         elseif ($columnKey == 'status' && $financialItem->$columnKey) {
@@ -450,6 +456,7 @@ class CRM_Financial_Page_AJAX {
       'amount',
       'trxn_id',
       'transaction_date',
+      'receive_date',
       'payment_method',
       'status',
       'name',

--- a/CRM/Financial/Page/AJAX.php
+++ b/CRM/Financial/Page/AJAX.php
@@ -255,10 +255,10 @@ class CRM_Financial_Page_AJAX {
       3 => 'amount',
       4 => 'trxn_id',
       5 => 'transaction_date',
-      5 => 'receive_date',
-      6 => 'payment_method',
-      7 => 'status',
-      8 => 'name',
+      6 => 'receive_date',
+      7 => 'payment_method',
+      8 => 'status',
+      9 => 'name',
     );
 
     $sEcho = CRM_Utils_Type::escape($_REQUEST['sEcho'], 'Integer');

--- a/templates/CRM/Financial/Form/BatchTransaction.tpl
+++ b/templates/CRM/Financial/Form/BatchTransaction.tpl
@@ -75,6 +75,7 @@
         <th class="crm-contact-name">{ts}Name{/ts}</th>
         <th class="crm-amount">{ts}Amount{/ts}</th>
         <th class="crm-trxnID">{ts}Trxn ID{/ts}</th>
+        <th class="crm-trxn_date">{ts}Transaction Date{/ts}</th>
         <th class="crm-received">{ts}Received{/ts}</th>
         <th class="crm-payment-method">{ts}Pay Method{/ts}</th>
         <th class="crm-status">{ts}Status{/ts}</th>
@@ -196,6 +197,7 @@ function buildTransactionSelectorAssign(filterSearch) {
     {sClass:'crm-contact-name'},
     {sClass:'crm-amount'},
     {sClass:'crm-trxnID'},
+    {sClass:'crm-trxn_date'},
     {sClass:'crm-received'},
     {sClass:'crm-payment-method'},
     {sClass:'crm-status'},
@@ -270,6 +272,7 @@ function buildTransactionSelectorRemove( ) {
     {sClass:'crm-contact-name'},
     {sClass:'crm-amount'},
     {sClass:'crm-trxnID'},
+    {sClass:'crm-trxn_date'},
     {sClass:'crm-received'},
     {sClass:'crm-payment-method'},
     {sClass:'crm-status'},

--- a/templates/CRM/Financial/Page/BatchTransaction.tpl
+++ b/templates/CRM/Financial/Page/BatchTransaction.tpl
@@ -59,10 +59,11 @@
           <th class="crm-contact-type"></th>
           <th class="crm-contact-name">{ts}Name{/ts}</th>
           <th class="crm-amount">{ts}Amount{/ts}</th>
-    <th class="crm-trxnID">{ts}Trxn ID{/ts}</th>
+          <th class="crm-trxnID">{ts}Trxn ID{/ts}</th>
+          <th class="crm-trxn_date">{ts}Transaction Date{/ts}</th>
           <th class="crm-received">{ts}Received{/ts}</th>
           <th class="crm-payment-method">{ts}Pay Method{/ts}</th>
-    <th class="crm-status">{ts}Status{/ts}</th>
+          <th class="crm-status">{ts}Status{/ts}</th>
           <th class="crm-type">{ts}Type{/ts}</th>
           <th class="crm-transaction-links"></th>
         </tr>

--- a/tests/phpunit/CRM/Financial/Page/AjaxTest.php
+++ b/tests/phpunit/CRM/Financial/Page/AjaxTest.php
@@ -50,7 +50,7 @@ class CRM_Financial_Page_AjaxTest extends CiviUnitTestCase {
     $json = CRM_Financial_Page_AJAX::getFinancialTransactionsList();
     $json = str_replace(rtrim(CIVICRM_UF_BASEURL, '/'), 'http://FIX ME', $json);
     $this->assertEquals($json, '{"sEcho": 1, "iTotalRecords": 1, "iTotalDisplayRecords": 1, "aaData": [ ["","<a href=\"/index.php?q=civicrm/profile/view&amp;reset=1&amp;gid=7&amp;id=3&amp;snippet=4\" class=\"crm-summary-link\"><div'
-    . ' class=\"icon crm-icon Individual-icon\"></div></a>","<a href=/index.php?q=civicrm/contact/view&amp;reset=1&amp;cid=3>Anderson, Anthony</a>","$ 100.00","12345","' . CRM_Utils_Date::customFormat(date('Ymd')) . ' 12:00 AM",'
+    . ' class=\"icon crm-icon Individual-icon\"></div></a>","<a href=/index.php?q=civicrm/contact/view&amp;reset=1&amp;cid=3>Anderson, Anthony</a>","$ 100.00","12345","' . CRM_Utils_Date::customFormat(date('Ymd')) . ' 12:00 AM","' . CRM_Utils_Date::customFormat(date('Ymd')) . ' 12:00 AM",'
     . '"Credit Card","Completed","Donation","<span><a href=\"/index.php?q=civicrm/contact/view/contribution&amp;reset=1&amp;id=1&amp;cid=3&amp;action=view&amp;context=contribution&amp;'
     . 'selectedChild=contribute\" class=\"action-item crm-hover-button\" title=\'View Contribution\' >View</a></span>"]] }');
   }


### PR DESCRIPTION
----------------------------------------
* CRM-20987: Add transaction date field to listings of transactions
  https://issues.civicrm.org/jira/browse/CRM-20987

Overview
----------------------------------------
Financial batch listing page lists transaction with transaction date derived from civicrm_financial_trxn table(column name = Received). This PR fixes 
- Renaming  column name from Received to Transaction Date
- Adding column Received derived from civicrm_contribution.receive_date

Before
----------------------------------------
![before](https://user-images.githubusercontent.com/2053075/28761292-3504a934-75cb-11e7-89d5-34e1b788b3ba.png)


After
----------------------------------------
![batch transaction listing](https://user-images.githubusercontent.com/2053075/28761269-1974debe-75cb-11e7-85b6-77dee7820adb.png)


