### PR TITLE
CRM-20988,Don't display option of Export, Delete etc to users who lack that permission

### DIFF
--- a/CRM/Batch/BAO/Batch.php
+++ b/CRM/Batch/BAO/Batch.php
@@ -290,6 +290,7 @@ class CRM_Batch_BAO_Batch extends CRM_Batch_DAO_Batch {
 
         switch ($batchStatusByName[$values['status_id']]) {
           case 'Open':
+          case 'Reopened':
             CRM_Utils_Array::remove($newLinks, 'reopen', 'download');
             break;
 
@@ -299,6 +300,15 @@ class CRM_Batch_BAO_Batch extends CRM_Batch_DAO_Batch {
 
           case 'Exported':
             CRM_Utils_Array::remove($newLinks, 'close', 'edit', 'reopen', 'export');
+        }
+        if (!CRM_Batch_BAO_Batch::checkBatchPermission('edit', $values['created_id'])) {
+          CRM_Utils_Array::remove($newLinks, 'close', 'edit', 'export');
+        }
+        if (!CRM_Batch_BAO_Batch::checkBatchPermission('export', $values['created_id'])) {
+          CRM_Utils_Array::remove($newLinks, 'export', 'download');
+        }
+        if (!CRM_Batch_BAO_Batch::checkBatchPermission('delete', $values['created_id'])) {
+          CRM_Utils_Array::remove($newLinks, 'delete');
         }
       }
       if (!empty($values['type_id'])) {
@@ -773,6 +783,34 @@ WHERE  {$where}
       $batches[$dao->id] = $dao->status_id;
     }
     return $batches;
+  }
+
+  /**
+   * Function to check permission for batch.
+   *
+   * @param string $action
+   * @param int $batchCreatedId
+   *   batch created by contact id
+   *
+   * @return bool
+   */
+  public static function checkBatchPermission($action, $batchCreatedId = NULL) {
+    if (in_array($action, array('reopen', 'close'))) {
+      $action = 'edit';
+    }
+    if (CRM_Core_Permission::check("{$action} all manual batches")) {
+      return TRUE;
+    }
+    if (CRM_Core_Permission::check("{$action} own manual batches")) {
+      $loggedInContactId = CRM_Core_Session::singleton()->get('userID');
+      if ($batchCreatedId == $loggedInContactId) {
+        return TRUE;
+      }
+      elseif (CRM_Utils_System::isNull($batchCreatedId)) {
+        return TRUE;
+      }
+    }
+    return FALSE;
   }
 
 }

--- a/CRM/Batch/BAO/Batch.php
+++ b/CRM/Batch/BAO/Batch.php
@@ -391,6 +391,15 @@ class CRM_Batch_BAO_Batch extends CRM_Batch_DAO_Batch {
       "created_id.sort_name",
       "created_id",
     );
+    if (!CRM_Core_Permission::check("view all manual batches")) {
+      if (CRM_Core_Permission::check("view own manual batches")) {
+        $loggedInContactId = CRM_Core_Session::singleton()->get('userID');
+        $params['created_id'] = $loggedInContactId;
+      }
+      else {
+        $params['created_id'] = 0;
+      }
+    }
     foreach ($return as $field) {
       if (!isset($params[$field])) {
         continue;

--- a/CRM/Financial/Form/BatchTransaction.php
+++ b/CRM/Financial/Form/BatchTransaction.php
@@ -67,7 +67,7 @@ class CRM_Financial_Form_BatchTransaction extends CRM_Contribute_Form {
         $validStatus = TRUE;
       }
       $this->assign('validStatus', $validStatus);
-
+      $this->_values = civicrm_api3('Batch', 'getSingle', array('id' => self::$_entityID));
       $batchTitle = CRM_Core_DAO::getFieldValue('CRM_Batch_BAO_Batch', self::$_entityID, 'title');
       CRM_Utils_System::setTitle(ts('Accounting Batch - %1', array(1 => $batchTitle)));
 
@@ -100,8 +100,12 @@ class CRM_Financial_Form_BatchTransaction extends CRM_Contribute_Form {
     }
 
     parent::buildQuickForm();
-    $this->add('submit', 'close_batch', ts('Close Batch'));
-    $this->add('submit', 'export_batch', ts('Close & Export Batch'));
+    if (CRM_Batch_BAO_Batch::checkBatchPermission('edit', $this->_values['created_id'])) {
+      $this->add('submit', 'close_batch', ts('Close Batch'));
+      if (CRM_Batch_BAO_Batch::checkBatchPermission('export', $this->_values['created_id'])) {
+        $this->add('submit', 'export_batch', ts('Close & Export Batch'));
+      }
+    }
 
     // text for sort_name
     $this->addElement('text',

--- a/CRM/Financial/Form/Search.php
+++ b/CRM/Financial/Form/Search.php
@@ -99,6 +99,11 @@ class CRM_Financial_Form_Search extends CRM_Core_Form {
       'delete' => ts('Delete'),
     );
 
+    foreach ($batchAction as $action => $ignore) {
+      if (!CRM_Batch_BAO_Batch::checkBatchPermission($action)) {
+        unset($batchAction[$action]);
+      }
+    }
     $this->add('select',
       'batch_update',
       ts('Task'),


### PR DESCRIPTION
----------------------------------------
* CRM-20988: Don't display option of Export, Delete etc to users who lack that permission
  https://issues.civicrm.org/jira/browse/CRM-20988

Overview
----------------------------------------
Currently the system allows to Edit, Delete, Export Batch(s) even though the user don't have permission.


Before
----------------------------------------
![before](https://user-images.githubusercontent.com/2053075/28764197-735bbf22-75e1-11e7-9a80-1073ae05ec7b.png)


After
----------------------------------------
![screenshot from 2017-07-31 11-13-37](https://user-images.githubusercontent.com/2053075/28764199-7a577384-75e1-11e7-8c1e-726d90279531.png)


Technical Details
----------------------------------------
This PR check's permission for each batch action like Export, Delete, Close, Open, Reopen etc. 