### PR TITLE
CRM-20989 Fix Active provider count to know about multisite

### DIFF
--- a/CRM/SMS/BAO/Provider.php
+++ b/CRM/SMS/BAO/Provider.php
@@ -43,7 +43,8 @@ class CRM_SMS_BAO_Provider extends CRM_SMS_DAO_Provider {
    * @return null|string
    */
   public static function activeProviderCount() {
-    $activeProviders = CRM_Core_DAO::singleValueQuery('SELECT MAX(id) FROM civicrm_sms_provider WHERE is_active = 1');
+    $activeProviders = CRM_Core_DAO::singleValueQuery('SELECT count(id) FROM civicrm_sms_provider WHERE is_active = 1 AND (domain_id = %1 OR domain_id IS NULL)',
+       array(1 => array(CRM_Core_Config::domainID(), 'Positive')));
     return $activeProviders;
   }
 

--- a/tests/phpunit/CRM/SMS/BAO/ProviderTest.php
+++ b/tests/phpunit/CRM/SMS/BAO/ProviderTest.php
@@ -78,6 +78,32 @@ class CRM_SMS_BAO_ProviderTest extends CiviUnitTestCase {
   }
 
   /**
+   * CRM-20989
+   * Add unit test to ensure that filtering by domain works in get Active Providers
+   */
+  public function testActiveProviderCount() {
+    $values = array(
+      'domain_id' => NULL,
+      'title' => 'test SMS provider',
+      'username' => 'test',
+      'password' => 'dummpy password',
+      'name' => 1,
+      'is_active' => 1,
+      'api_type' => 1,
+    );
+    $provider = $this->callAPISuccess('SmsProvider', 'create', $values);
+    $provider2 = $this->callAPISuccess('SmsProvider', 'create', array_merge($values, array('domain_id' => 2)));
+    $result = CRM_SMS_BAO_Provider::activeProviderCount();
+    $this->assertEquals(1, $result);
+    $provider3 = $this->callAPISuccess('SmsProvider', 'create', array_merge($values, array('domain_id' => 1)));
+    $result = CRM_SMS_BAO_Provider::activeProviderCount();
+    $this->assertEquals(2, $result);
+    CRM_SMS_BAO_Provider::del($provider['id']);
+    CRM_SMS_BAO_Provider::del($provider2['id']);
+    CRM_SMS_BAO_Provider::del($provider3['id']);
+  }
+
+  /**
    * CRM-19961 Check that when a domain is not passed when saving it defaults to current domain when create
    */
   public function testCreateWithoutDomain() {


### PR DESCRIPTION
Overview
----------------------------------------
At Present CRM_SMS_BAO_Provider::getActiveProviders just checks to see if there is an active provider in the database and not if it is in available for the current domain

Before
----------------------------------------
This can cause scheduled reminders to ask the user to select an SMS provider even when none load due to access issues

After
----------------------------------------
Correctly only adds in SMS requirements to scheduled providers if there are providers available in the db for the domain

Technical Details
----------------------------------------
Swaps out max for count to get an accurate count and adds check on the domain_id column

ping @eileenmcnaughton

---

 * [CRM-20989: SMS Provider check in Scheduled Reminders, breaks for multisite](https://issues.civicrm.org/jira/browse/CRM-20989)