### PR TITLE
CRM-20990 add contributionStatus to online template

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4812,6 +4812,7 @@ LIMIT 1;";
     if (!$returnMessageText) {
       list($values['receipt_from_name'], $values['receipt_from_email']) = self::generateFromEmailAndName($input, $contribution);
     }
+    $values['contribution_status'] = CRM_Core_PseudoConstant::getLabel('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $contribution->contribution_status_id);
     $return = $contribution->composeMessageArray($input, $ids, $values, $returnMessageText);
     // Contribution ID should really always be set. But ?
     if (!$returnMessageText && (!isset($input['receipt_update']) || $input['receipt_update']) && empty($contribution->receipt_date)) {

--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -386,6 +386,7 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
         'receipt_date' => !$values['receipt_date'] ? NULL : date('YmdHis', strtotime($values['receipt_date'])),
         'pay_later_receipt' => CRM_Utils_Array::value('pay_later_receipt', $values),
         'honor_block_is_active' => CRM_Utils_Array::value('honor_block_is_active', $values),
+        'contributionStatus' => CRM_Utils_Array::value('contribution_status', $values),
       );
 
       if ($contributionTypeId = CRM_Utils_Array::value('financial_type_id', $values)) {

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -1741,6 +1741,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'contributeMode:::notify',
       'title:::Contribution',
       'displayName:::Mr. Anthony Anderson II',
+      'contributionStatus:::Completed',
     ));
     $mut->stop();
     $this->revertTemplateToReservedTemplate();

--- a/tests/templates/message_templates/contribution_online_receipt_html.tpl
+++ b/tests/templates/message_templates/contribution_online_receipt_html.tpl
@@ -61,6 +61,7 @@
   price:::{$price}
   customPre_grouptitle:::{$customPre_grouptitle}
   customPost_grouptitle:::{$customPost_grouptitle}
+  contributionStatus:::{$contributionStatus}
  {foreach from=$lineItem item=value key=priceset}
   {foreach from=$value item=line}
      line.html_type:::{$line.html_type}


### PR DESCRIPTION
Overview
----------------------------------------
Add $contributionStatus to templates assigned to Online message template (also used for sending receipts from contribution search)

Before
----------------------------------------
$contributionStatus var not available

After
----------------------------------------
$contributionStatus var available & unit tested

Technical Details
----------------------------------------


Comments
----------------------------------------
@seamuslee001 @monishdeb @jitendrapurohit this gives me the nuance to improve my templates , but I wonder if there is an issue affecting other people regarding changing in pay_later assignment - pinging you guys in case anything is on your radar.

---

 * [CRM-20990: Assign $contributionStatus to the Contribution Online message template](https://issues.civicrm.org/jira/browse/CRM-20990)