### PR TITLE
CRM-20993 - API - Extention get - Fix filtering by ID

### DIFF
--- a/api/v3/Extension.php
+++ b/api/v3/Extension.php
@@ -359,7 +359,10 @@ function civicrm_api3_extension_get($params) {
     }
   }
   $options = _civicrm_api3_get_options_from_params($params);
-  $returnFields = !empty($options['return']) ? $options['return'] : array('id');
+  $returnFields = !empty($options['return']) ? $options['return'] : array();
+  if (!in_array('id', $returnFields)) {
+    $returnFields = array_merge($returnFields, array('id'));
+  }
   return _civicrm_api3_basic_array_get('Extension', $params, $result, 'id', $returnFields);
 }
 

--- a/api/v3/Extension.php
+++ b/api/v3/Extension.php
@@ -359,7 +359,7 @@ function civicrm_api3_extension_get($params) {
     }
   }
   $options = _civicrm_api3_get_options_from_params($params);
-  $returnFields = !empty($options['return']) ? $options['return'] : array();
+  $returnFields = !empty($options['return']) ? $options['return'] : array('id');
   return _civicrm_api3_basic_array_get('Extension', $params, $result, 'id', $returnFields);
 }
 

--- a/tests/phpunit/api/v3/ExtensionTest.php
+++ b/tests/phpunit/api/v3/ExtensionTest.php
@@ -61,7 +61,7 @@ class api_v3_ExtensionTest extends CiviUnitTestCase {
    * Test getting a single extension
    * CRM-20532
    */
-  public function testExtesnionGetSingleExtension() {
+  public function testExtensionGetSingleExtension() {
     $result = $this->callAPISuccess('extension', 'get', array('key' => 'test.extension.manager.moduletest'));
     $this->assertEquals('test.extension.manager.moduletest', $result['values'][$result['id']]['key']);
     $this->assertEquals('module', $result['values'][$result['id']]['type']);
@@ -72,7 +72,7 @@ class api_v3_ExtensionTest extends CiviUnitTestCase {
    * Test single Extension get with specific fields in return
    * CRM-20532
    */
-  public function testSingleExtesnionGetWithReturnFields() {
+  public function testSingleExtensionGetWithReturnFields() {
     $result = $this->callAPISuccess('extension', 'get', array('key' => 'test.extension.manager.moduletest', 'return' => array('name', 'status', 'key')));
     $this->assertEquals('test.extension.manager.moduletest', $result['values'][$result['id']]['key']);
     $this->assertFalse(isset($result['values'][$result['id']]['type']));
@@ -81,11 +81,11 @@ class api_v3_ExtensionTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test Extension Get resturns detailed information
+   * Test Extension Get returns detailed information
    * Note that this is likely to fail locally but will work on Jenkins due to the result count check
    * CRM-20532
    */
-  public function testExtesnionGet() {
+  public function testExtensionGet() {
     $result = $this->callAPISuccess('extension', 'get', array());
     $testExtensionResult = $this->callAPISuccess('extension', 'get', array('key' => 'test.extension.manager.paymenttest'));
     $this->assertNotNull($result['values'][$testExtensionResult['id']]['typeInfo']);
@@ -103,6 +103,14 @@ class api_v3_ExtensionTest extends CiviUnitTestCase {
   public function testGetMultipleExtensionsApiExplorer() {
     $result = $this->callAPISuccess('extension', 'get', array('full_name' => array('test.extension.manager.paymenttest', 'test.extension.manager.moduletest')));
     $this->assertEquals(2, $result['count']);
+  }
+
+  /**
+   * Test that extension get can be filtered by id.
+   */
+  public function testGetExtensionByID() {
+    $result = $this->callAPISuccess('extension', 'get', array('id' => 2));
+    $this->assertEquals(1, $result['count']);
   }
 
 }

--- a/tests/phpunit/api/v3/ExtensionTest.php
+++ b/tests/phpunit/api/v3/ExtensionTest.php
@@ -109,7 +109,7 @@ class api_v3_ExtensionTest extends CiviUnitTestCase {
    * Test that extension get can be filtered by id.
    */
   public function testGetExtensionByID() {
-    $result = $this->callAPISuccess('extension', 'get', array('id' => 2));
+    $result = $this->callAPISuccess('extension', 'get', array('id' => 2, 'return' => array('label')));
     $this->assertEquals(1, $result['count']);
   }
 


### PR DESCRIPTION
----------------------------------------
* CRM-20993: API - Extension get - Cannot filter by ID anymore
  https://issues.civicrm.org/jira/browse/CRM-20993

Overview
----------------------------------------
Restore filtering by ID for API Extension get

Before
----------------------------------------
![crm-20993-before](https://user-images.githubusercontent.com/19712240/28774151-9ae5134e-75ec-11e7-9072-ec0dc7bdf0a6.png)

After
----------------------------------------
![crm-20993-after](https://user-images.githubusercontent.com/19712240/28774155-9e887306-75ec-11e7-8ce0-ae6d1d343d2c.png)
