### PR TITLE
CRM-20995 - API - Extension get - Filter by full_name

### DIFF
--- a/api/v3/Extension.php
+++ b/api/v3/Extension.php
@@ -47,7 +47,7 @@ define('API_V3_EXTENSION_DELIMITER', ',');
  * @return array
  */
 function civicrm_api3_extension_install($params) {
-  $keys = _civicrm_api3_getKeys($params);
+  $keys = _civicrm_api3_getKeys($params, 'keys');
   if (!$keys) {
     return civicrm_api3_create_success();
   }
@@ -119,7 +119,7 @@ function civicrm_api3_extension_upgrade() {
  * @return array
  */
 function civicrm_api3_extension_enable($params) {
-  $keys = _civicrm_api3_getKeys($params);
+  $keys = _civicrm_api3_getKeys($params, 'keys');
   if (count($keys) == 0) {
     return civicrm_api3_create_success();
   }
@@ -149,7 +149,7 @@ function _civicrm_api3_extension_enable_spec(&$fields) {
  * @return array
  */
 function civicrm_api3_extension_disable($params) {
-  $keys = _civicrm_api3_getKeys($params);
+  $keys = _civicrm_api3_getKeys($params, 'keys');
   if (count($keys) == 0) {
     return civicrm_api3_create_success();
   }
@@ -181,7 +181,7 @@ function _civicrm_api3_extension_disable_spec(&$fields) {
  * @return array
  */
 function civicrm_api3_extension_uninstall($params) {
-  $keys = _civicrm_api3_getKeys($params);
+  $keys = _civicrm_api3_getKeys($params, 'keys');
   if (count($keys) == 0) {
     return civicrm_api3_create_success();
   }
@@ -332,7 +332,9 @@ function _civicrm_api3_extension_refresh_spec(&$fields) {
  *   API result
  */
 function civicrm_api3_extension_get($params) {
-  $keys = isset($params['key']) ? (array) $params['key'] : NULL;
+  $full_names = _civicrm_api3_getKeys($params, 'full_name');
+  $keys = _civicrm_api3_getKeys($params, 'key');
+  $keys = array_merge($full_names, $keys);
   $statuses = CRM_Extension_System::singleton()->getManager()->getStatuses();
   $mapper = CRM_Extension_System::singleton()->getMapper();
   $result = array();
@@ -347,7 +349,7 @@ function civicrm_api3_extension_get($params) {
     }
     $info = CRM_Extension_System::createExtendedInfo($obj);
     $info['id'] = $id++; // backward compatibility with indexing scheme
-    if (!empty($params['key'])) {
+    if (!empty($keys)) {
       if (in_array($key, $keys)) {
         $result[] = $info;
       }
@@ -386,16 +388,17 @@ function civicrm_api3_extension_getremote($params) {
  * Determine the list of extension keys.
  *
  * @param array $params
+ * @param string $key
  *   API request params with 'keys'.
  *
  * @return array
  */
-function _civicrm_api3_getKeys($params) {
-  if (is_array($params['keys'])) {
-    return $params['keys'];
+function _civicrm_api3_getKeys($params, $key) {
+  if (is_array($params[$key])) {
+    return $params[$key];
   }
-  if ($params['keys'] == '') {
+  if ($params[$key] == '') {
     return array();
   }
-  return explode(API_V3_EXTENSION_DELIMITER, $params['keys']);
+  return explode(API_V3_EXTENSION_DELIMITER, $params[$key]);
 }

--- a/api/v3/Extension.php
+++ b/api/v3/Extension.php
@@ -402,7 +402,8 @@ function _civicrm_api3_getKeys($params, $key) {
       return array();
     }
     return explode(API_V3_EXTENSION_DELIMITER, $params[$key]);
-  } else {
+  }
+  else {
     return array();
   }
 }

--- a/api/v3/Extension.php
+++ b/api/v3/Extension.php
@@ -47,7 +47,7 @@ define('API_V3_EXTENSION_DELIMITER', ',');
  * @return array
  */
 function civicrm_api3_extension_install($params) {
-  $keys = _civicrm_api3_getKeys($params, 'keys');
+  $keys = _civicrm_api3_getKeys($params);
   if (!$keys) {
     return civicrm_api3_create_success();
   }
@@ -119,7 +119,7 @@ function civicrm_api3_extension_upgrade() {
  * @return array
  */
 function civicrm_api3_extension_enable($params) {
-  $keys = _civicrm_api3_getKeys($params, 'keys');
+  $keys = _civicrm_api3_getKeys($params);
   if (count($keys) == 0) {
     return civicrm_api3_create_success();
   }
@@ -149,7 +149,7 @@ function _civicrm_api3_extension_enable_spec(&$fields) {
  * @return array
  */
 function civicrm_api3_extension_disable($params) {
-  $keys = _civicrm_api3_getKeys($params, 'keys');
+  $keys = _civicrm_api3_getKeys($params);
   if (count($keys) == 0) {
     return civicrm_api3_create_success();
   }
@@ -181,7 +181,7 @@ function _civicrm_api3_extension_disable_spec(&$fields) {
  * @return array
  */
 function civicrm_api3_extension_uninstall($params) {
-  $keys = _civicrm_api3_getKeys($params, 'keys');
+  $keys = _civicrm_api3_getKeys($params);
   if (count($keys) == 0) {
     return civicrm_api3_create_success();
   }
@@ -393,7 +393,7 @@ function civicrm_api3_extension_getremote($params) {
  *
  * @return array
  */
-function _civicrm_api3_getKeys($params, $key) {
+function _civicrm_api3_getKeys($params, $key = 'keys') {
   if (isset($params[$key])) {
     if (is_array($params[$key])) {
       return $params[$key];

--- a/api/v3/Extension.php
+++ b/api/v3/Extension.php
@@ -394,11 +394,15 @@ function civicrm_api3_extension_getremote($params) {
  * @return array
  */
 function _civicrm_api3_getKeys($params, $key) {
-  if (is_array($params[$key])) {
-    return $params[$key];
-  }
-  if ($params[$key] == '') {
+  if (isset($params[$key])) {
+    if (is_array($params[$key])) {
+      return $params[$key];
+    }
+    if ($params[$key] == '') {
+      return array();
+    }
+    return explode(API_V3_EXTENSION_DELIMITER, $params[$key]);
+  } else {
     return array();
   }
-  return explode(API_V3_EXTENSION_DELIMITER, $params[$key]);
 }

--- a/tests/phpunit/api/v3/ExtensionTest.php
+++ b/tests/phpunit/api/v3/ExtensionTest.php
@@ -97,4 +97,12 @@ class api_v3_ExtensionTest extends CiviUnitTestCase {
     $this->assertEquals(2, $result['count']);
   }
 
+  /**
+   * Test that extension get works with api request with parameter full_name as build by api explorer.
+   */
+  public function testGetMultipleExtensionsApiExplorer() {
+    $result = $this->callAPISuccess('extension', 'get', array('full_name' => array('test.extension.manager.paymenttest', 'test.extension.manager.moduletest')));
+    $this->assertEquals(2, $result['count']);
+  }
+
 }


### PR DESCRIPTION
----------------------------------------
* CRM-20995: API - Extension get - Ignores parameter full_name as created by API explorer
  https://issues.civicrm.org/jira/browse/CRM-20995

Overview
----------------------------------------
This PR allows to filter Extensions by full_name as generated by API explorer.

Before
----------------------------------------
![crm-20995-before](https://user-images.githubusercontent.com/19712240/28775155-d41b8b30-75f0-11e7-8524-b875915320e8.png)


After
----------------------------------------
![crm-20995-after](https://user-images.githubusercontent.com/19712240/28775160-d7dedfba-75f0-11e7-8950-1e13f6903159.png)


Technical Details
----------------------------------------
It seems a bit confusing to have full_name, key, and keys all refering to the same DAO field full_name. 
This PR merges the two parameters full_name and keys to the already used one named keys.

Comments
----------------------------------------
Almost all parameter and return fields seem to be currently ignored.
