### PR TITLE
CRM-21000 : Fix DB error on Advance Search Mailings

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2751,6 +2751,17 @@ class CRM_Contact_BAO_Query {
           $from .= CRM_Grant_BAO_Query::from($name, $mode, $side);
           continue;
 
+        case 'civicrm_campaign':
+          //Move to default case if not in either mode.
+          if ($mode & CRM_Contact_BAO_Query::MODE_CONTRIBUTE) {
+            $from .= CRM_Contribute_BAO_Query::from($name, $mode, $side);
+            continue;
+          }
+          elseif ($mode & CRM_Contact_BAO_Query::MODE_MAILING) {
+            $from .= CRM_Mailing_BAO_Query::from($name, $mode, $side);
+            continue;
+          }
+
         case 'civicrm_website':
           $from .= " $side JOIN civicrm_website ON contact_a.id = civicrm_website.contact_id ";
           continue;

--- a/CRM/Mailing/BAO/Query.php
+++ b/CRM/Mailing/BAO/Query.php
@@ -189,6 +189,10 @@ class CRM_Mailing_BAO_Query {
       case 'recipient_email':
         $from = " $side JOIN civicrm_email recipient_email ON recipient_email.id = civicrm_mailing_recipients.email_id";
         break;
+
+      case 'civicrm_campaign':
+        $from = " $side JOIN civicrm_campaign ON civicrm_campaign.id = civicrm_mailing.campaign_id";
+        break;
     }
 
     return $from;


### PR DESCRIPTION
Overview
----------------------------------------
This Fixes DB Error on Advance Search if results are displayed as Mailings.

Before
----------------------------------------
Incorrect join of `civicrm_contribution.campaign_id` in the query leads to DB error.

After
----------------------------------------
Correct joins are formed based on mailing or contribution


Technical Details
----------------------------------------

Campaign Filter was added in https://github.com/civicrm/civicrm-core/pull/6527. This change aims to add join for campaign before `Component::from` is called so that correct join is added for `campaign_id` w.r.t mailing or contribution.

---

 * [CRM-21000: Display result as Mailing on Advance Search produces DB Error](https://issues.civicrm.org/jira/browse/CRM-21000)