### PR TITLE
CRM-21002: Credit card type icons are incorrectly populated on backoffice live mode

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -360,7 +360,8 @@ WHERE  contribution_id = {$id}
         }
       }
     }
-    CRM_Financial_Form_Payment::addCreditCardJs($id);
+    // CRM-21002: pass the default payment processor ID whose credit card type icons should be populated first
+    CRM_Financial_Form_Payment::addCreditCardJs($this->_paymentProcessor['id']);
 
     $this->assign('recurringPaymentProcessorIds',
       empty($this->_recurPaymentProcessors) ? '' : implode(',', array_keys($this->_recurPaymentProcessors))


### PR DESCRIPTION
Overview
----------------------------------------
_On backoffice live mode, when the form loads, if the selected payment processor support few  Credit Card type, then this setting is not maintained and all card type icons are populated_

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/3735621/28841821-0bfa91c6-7719-11e7-817a-949535116bc5.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/3735621/28841602-674fb354-7718-11e7-8adf-4a940772df86.png)

---

 * [CRM-21002: Credit card type icons are incorrectly populated on backoffice live mode ](https://issues.civicrm.org/jira/browse/CRM-21002)