### PR TITLE
WIP CRM-20928 Replace all http get/post/download functions with guzzlehttp library (pending PHP5.4 deprecation)

### DIFF
--- a/CRM/Core/CommunityMessages.php
+++ b/CRM/Core/CommunityMessages.php
@@ -130,11 +130,12 @@ class CRM_Core_CommunityMessages {
    *   parsed JSON
    */
   public function fetchDocument() {
-    list($status, $json) = $this->client->get($this->getRenderedUrl());
-    if ($status != CRM_Utils_HttpClient::STATUS_OK || empty($json)) {
+    $httpget = CRM_Utils_Http::get($this->getRenderedUrl());
+    if (!$httpget['status']) {
+      Civi::log()->warning('CommunityMessages fetchDocument() error: '.$httpget['message']);
       return NULL;
     }
-    $doc = json_decode($json, TRUE);
+    $doc = $httpget['response']->json();
     if (empty($doc) || json_last_error() != JSON_ERROR_NONE) {
       return NULL;
     }

--- a/CRM/Dashlet/Page/Blog.php
+++ b/CRM/Dashlet/Page/Blog.php
@@ -117,12 +117,12 @@ class CRM_Dashlet_Page_Blog extends CRM_Core_Page {
    *   array of blog items; or NULL if not available
    */
   protected function getFeed($url) {
-    $httpClient = new CRM_Utils_HttpClient(self::CHECK_TIMEOUT);
-    list ($status, $rawFeed) = $httpClient->get($url);
-    if ($status !== CRM_Utils_HttpClient::STATUS_OK) {
+    $httpget = CRM_Utils_Http::get($url, array(), self::CHECK_TIMEOUT);
+    if (!$httpget['status']) {
+      Civi::log()->warning('Blog getFeed() error: '.$httpget['message']);
       return NULL;
     }
-    return @simplexml_load_string($rawFeed);
+    return @simplexml_load_string($httpget['response']->getBody());
   }
 
   /**

--- a/CRM/Dashlet/Page/GettingStarted.php
+++ b/CRM/Dashlet/Page/GettingStarted.php
@@ -115,13 +115,12 @@ class CRM_Dashlet_Page_GettingStarted extends CRM_Core_Page {
    *   array of gettingStarted items; or NULL if not available
    */
   public function _getHtml($url) {
-
-    $httpClient = new CRM_Utils_HttpClient(self::CHECK_TIMEOUT);
-    list ($status, $html) = $httpClient->get($url);
-    if ($status !== CRM_Utils_HttpClient::STATUS_OK) {
+    $httpget = CRM_Utils_Http::get($url, array(), self::CHECK_TIMEOUT);
+    if (!$httpget['status']) {
+      Civi::log()->warning('GettingStarted _getHtml() error: '.$httpget['message']);
       return NULL;
     }
-
+    $html = $httpget['response']->getBody();
     $tokensList = CRM_Utils_Token::getTokens($html);
     $this->replaceLinkToken($tokensList, $html);
     if ($html) {

--- a/CRM/Extension/Downloader.php
+++ b/CRM/Extension/Downloader.php
@@ -110,7 +110,9 @@ class CRM_Extension_Downloader {
       CRM_Core_Error::fatal('Cannot install this extension - downloadUrl is not set!');
     }
 
-    if (!$this->fetch($downloadUrl, $filename)) {
+    $status = CRM_Utils_Http::download($downloadUrl, $filename);
+    if (!$status['status']) {
+      Civi::log()->warning('download() failed: ' . $status['message']);
       return FALSE;
     }
 
@@ -126,27 +128,6 @@ class CRM_Extension_Downloader {
     $this->manager->replace($extractedZipPath);
 
     return TRUE;
-  }
-
-  /**
-   * Download the remote zipfile.
-   *
-   * @param string $remoteFile
-   *   URL of a .zip file.
-   * @param string $localFile
-   *   Path at which to store the .zip file.
-   * @return bool
-   *   Whether the download was successful.
-   */
-  public function fetch($remoteFile, $localFile) {
-    $result = CRM_Utils_HttpClient::singleton()->fetch($remoteFile, $localFile);
-    switch ($result) {
-      case CRM_Utils_HttpClient::STATUS_OK:
-        return TRUE;
-
-      default:
-        return FALSE;
-    }
   }
 
   /**

--- a/CRM/Utils/Geocode/Google.php
+++ b/CRM/Utils/Geocode/Google.php
@@ -121,10 +121,11 @@ class CRM_Utils_Geocode_Google {
 
     $query = 'https://' . self::$_server . self::$_uri . $add;
 
-    require_once 'HTTP/Request.php';
-    $request = new HTTP_Request($query);
-    $request->sendRequest();
-    $string = $request->getResponseBody();
+    $response = CRM_Utils_Http::get($query);
+    if (!$response['status']) {
+      CRM_Core_Error::debug_var('Geocoding request failed: '. $response['message']);
+    }
+    $string = $response['response']->getBody();
 
     libxml_use_internal_errors(TRUE);
     $xml = @simplexml_load_string($string);

--- a/CRM/Utils/Geocode/Yahoo.php
+++ b/CRM/Utils/Geocode/Yahoo.php
@@ -122,10 +122,12 @@ class CRM_Utils_Geocode_Yahoo {
 
     $query = 'http://' . self::$_server . self::$_uri . '?' . $add;
 
-    require_once 'HTTP/Request.php';
-    $request = new HTTP_Request($query);
-    $request->sendRequest();
-    $string = $request->getResponseBody();
+    $response = CRM_Utils_Http::get($query);
+    if (!$response['status']) {
+      CRM_Core_Error::debug_var('Geocoding request failed: '. $response['message']);
+    }
+    $string = $response['response']->getBody();
+
     // see CRM-11359 for why we suppress errors with @
     $xml = @simplexml_load_string($string);
     CRM_Utils_Hook::geocoderFormat('Yahoo', $values, $xml);

--- a/CRM/Utils/Http.php
+++ b/CRM/Utils/Http.php
@@ -77,4 +77,62 @@ class CRM_Utils_Http {
     return $result;
   }
 
+  public static function download($fromUrl, $toFile, $timeout=5) {
+    $client = new GuzzleHttp\Client();
+    $options = array(
+      'timeout' => $timeout,
+      'save_to' => $toFile,
+    );
+    try {
+      $response = $client->get($fromUrl, $options);
+    } catch (Exception $e) {
+      $return['status'] = FALSE;
+      $return['message'] = $e->getMessage();
+      return $return;
+    }
+    $return['status'] = TRUE;
+    $return['message'] = NULL;
+    return $return;
+  }
+
+  public static function get($url, $headers=array(), $timeout=5) {
+    $client = new GuzzleHttp\Client();
+    $options = array(
+      'headers' => $headers,
+      'timeout' => $timeout,
+    );
+
+    try {
+      $response = $client->get($url, $options);
+    } catch (GuzzleHttp\Exception\RequestException $e) {
+      $return['status'] = FALSE;
+      $return['message'] = $e->getMessage();
+      return $return;
+    }
+    $return['status'] = TRUE;
+    $return['message'] = NULL;
+    $return['response'] = $response;
+    return $return;
+  }
+
+  public static function post($url, $body, $headers=array(), $timeout=5) {
+    $client = new GuzzleHttp\Client();
+    $options = array(
+      'headers' => $headers,
+      'body' => $body,
+      'timeout' => $timeout,
+    );
+
+    try {
+      $response = $client->post($url, $options);
+    } catch (GuzzleHttp\Exception\RequestException $e) {
+      $return['status'] = FALSE;
+      $return['message'] = $e->getMessage();
+      return $return;
+    }
+    $return['status'] = TRUE;
+    $return['message'] = NULL;
+    $return['response'] = $response;
+    return $return;
+  }
 }

--- a/api/v3/Cxn.php
+++ b/api/v3/Cxn.php
@@ -69,11 +69,11 @@ function _civicrm_api3_cxn_register_spec(&$spec) {
  */
 function civicrm_api3_cxn_register($params) {
   if (!empty($params['app_meta_url'])) {
-    list ($status, $json) = CRM_Utils_HttpClient::singleton()->get($params['app_meta_url']);
-    if (CRM_Utils_HttpClient::STATUS_OK != $status) {
-      throw new API_Exception("Failed to download appMeta. (Bad HTTP response)");
+    $httpget = CRM_Utils_Http::get($params['app_meta_url']);
+    if (!$httpget['status']) {
+      throw new API_Exception("Failed to download appMeta. (Bad HTTP response): " . $httpget['message']);
     }
-    $appMeta = json_decode($json, TRUE);
+    $appMeta = $httpget['response']->json();
     if (empty($appMeta)) {
       throw new API_Exception("Failed to download appMeta. (Malformed)");
     }

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
     "civicrm/civicrm-cxn-rpc": "~0.16.12.05",
     "pear/Auth_SASL": "1.1.0",
     "pear/Net_SMTP": "1.6.*",
-    "pear/Net_socket": "1.0.*"
+    "pear/Net_socket": "1.0.*",
+    "guzzlehttp/guzzle": "~5.0"
   },
   "repositories": [
     {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "85e3f6961c584d986a5a686b04bbed3d",
+    "content-hash": "dba9e4d4856fc298186022f63a6ec266",
     "packages": [
         {
             "name": "civicrm/civicrm-cxn-rpc",
@@ -147,6 +147,159 @@
             "description": "phpQuery is a server-side, chainable, CSS3 selector driven Document Object Model (DOM) API based on jQuery JavaScript Library",
             "homepage": "http://code.google.com/p/phpquery/",
             "time": "2013-03-21T12:39:33+00:00"
+        },
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "5.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "70f1fa53b71c4647bf2762c09068a95f77e12fb8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/70f1fa53b71c4647bf2762c09068a95f77e12fb8",
+                "reference": "70f1fa53b71c4647bf2762c09068a95f77e12fb8",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/ringphp": "^1.1",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "^4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library and framework for building RESTful web service clients",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "rest",
+                "web service"
+            ],
+            "time": "2016-07-15T19:28:39+00:00"
+        },
+        {
+            "name": "guzzlehttp/ringphp",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/RingPHP.git",
+                "reference": "dbbb91d7f6c191e5e405e900e3102ac7f261bc0b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/RingPHP/zipball/dbbb91d7f6c191e5e405e900e3102ac7f261bc0b",
+                "reference": "dbbb91d7f6c191e5e405e900e3102ac7f261bc0b",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/streams": "~3.0",
+                "php": ">=5.4.0",
+                "react/promise": "~2.0"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "~4.0"
+            },
+            "suggest": {
+                "ext-curl": "Guzzle will use specific adapters if cURL is present"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Ring\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Provides a simple API and specification that abstracts away the details of HTTP into a single PHP function.",
+            "time": "2015-05-20T03:37:09+00:00"
+        },
+        {
+            "name": "guzzlehttp/streams",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/streams.git",
+                "reference": "47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/streams/zipball/47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5",
+                "reference": "47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Stream\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Provides a simple abstraction over streams of data",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "Guzzle",
+                "stream"
+            ],
+            "time": "2014-10-12T19:18:40+00:00"
         },
         {
             "name": "pclzip/pclzip",
@@ -815,6 +968,52 @@
                 "psr-3"
             ],
             "time": "2012-12-21T11:40:51+00:00"
+        },
+        {
+            "name": "react/promise",
+            "version": "v2.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/promise.git",
+                "reference": "62785ae604c8d69725d693eb370e1d67e94c4053"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/62785ae604c8d69725d693eb370e1d67e94c4053",
+                "reference": "62785ae604c8d69725d693eb370e1d67e94c4053",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com"
+                }
+            ],
+            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
+            "keywords": [
+                "promise",
+                "promises"
+            ],
+            "time": "2017-03-25T12:08:31+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",


### PR DESCRIPTION
Overview
----------------------------------------
Various parts of the code implement different functions to perform http get/post requests.  This replaces all of those with a single library (guzzlehttp) which does all the work automatically so we don't need to worry if the server can do file_get_contents or use cURL.  Should also help with TLS issues on some clients.

Before
----------------------------------------
Various different methods for http requests, each of which fail in certain server configurations

After
----------------------------------------
One method for all http requests, which will try and find the best method automatically for each server.  In addition it reports nice errors into the log file when something does fail so you know exactly where to look if there is a problem.

Technical Details
----------------------------------------
Adds a dependency via composer for guzzlehttp version 5.x.  Note that this requires php 5.4 so can't be merged until we drop php 5.3 support.

Comments
----------------------------------------
* USPS and yahoo geocode function has not been tested, but google one is working. Also cxn function has not been tested.  All other functions are tested.
* Some unit tests use CRM_Utils_HttpClient and these should be updated to remove that dependency too.  Then we can completely remove the libraries CRM_Utils_HttpClient and Http_Request.

---

 * [CRM-20928: Use cUrl not file_get_contents for update check](https://issues.civicrm.org/jira/browse/CRM-20928)