### PR TITLE
CRM-21004 only remove html snippet task if setting enabled

### DIFF
--- a/CRM/UF/Page/Group.php
+++ b/CRM/UF/Page/Group.php
@@ -360,7 +360,11 @@ class CRM_UF_Page_Group extends CRM_Core_Page {
         $action -= CRM_Core_Action::ADD;
         $action -= CRM_Core_Action::ADVANCED;
         $action -= CRM_Core_Action::BASIC;
-        $action -= CRM_Core_Action::PROFILE;
+
+        //CRM-21004
+        if (Civi::settings()->get('remote_profile_submissions')) {
+          $action -= CRM_Core_Action::PROFILE;
+        }
       }
 
       $ufGroup[$id]['group_type'] = self::formatGroupTypes($groupTypes);

--- a/CRM/UF/Page/Group.php
+++ b/CRM/UF/Page/Group.php
@@ -362,7 +362,7 @@ class CRM_UF_Page_Group extends CRM_Core_Page {
         $action -= CRM_Core_Action::BASIC;
 
         //CRM-21004
-        if (Civi::settings()->get('remote_profile_submissions')) {
+        if (array_key_exists(CRM_Core_Action::PROFILE, self::$_actionLinks)) {
           $action -= CRM_Core_Action::PROFILE;
         }
       }


### PR DESCRIPTION
Overview
----------------------------------------
Enable profile copy for mixed use profiles when html snippet is disabled.

Technical Details
----------------------------------------
Fixes a regression since the "accept profile submissions from external sites" setting was added. The html snippet action was getting removed twice if that setting was turned off, which resulted in the copy action also being removed.

---

 * [CRM-21004: profile: unable to copy profiles used for events\/contribs\/etc.](https://issues.civicrm.org/jira/browse/CRM-21004)