### PR TITLE
Klaas Eikelboom (Kainuk Empowerment) is member of CiviCooP

### DIFF
--- a/contributor-key.yml
+++ b/contributor-key.yml
@@ -389,6 +389,7 @@
 
 - github      : kainuk
   name        : Klaas Eikelboom
+  organization: CiviCooP
   jira        : keikelboom
 
 - github      : Kajakaran


### PR DESCRIPTION
Overview
----------------------------------------
Added the organization to the committer kainuk for the release notes.

Technical Details
----------------------------------------
None

