### PR TITLE
CRM-21020 add context details to alterMailContent hook

### DIFF
--- a/CRM/Core/BAO/MessageTemplate.php
+++ b/CRM/Core/BAO/MessageTemplate.php
@@ -406,6 +406,9 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate {
       'text' => $dao->text,
       'html' => $dao->html,
       'format' => $dao->format,
+      'groupName' => $params['groupName'],
+      'valueName' => $params['valueName'],
+      'messageTemplateID' => $params['messageTemplateID'],
     );
     $dao->free();
 


### PR DESCRIPTION
Overview
----------------------------------------
The alterMailContent hook can be used to alter templates and email content before token processing occurs. Currently it only passes the subject, html, and text content to the hook, which means you have very little context to work with.

When this is triggered via msg template generation, include details about the template so the hook implementation can be conditioned meaningfully.

Technical Details
----------------------------------------
Includes template groupName, valueName, messageTemplateID when the hook is called from the message template context.

---

 * [CRM-21020: alterMailContent hook: pass additional contextual details](https://issues.civicrm.org/jira/browse/CRM-21020)