### PR TITLE
CRM-21005, "Record Payment" dialogue lacks required field and is clunky

### DIFF
--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -255,7 +255,7 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
       $this->add('select', 'payment_instrument_id',
         ts('Payment Method'),
         array('' => ts('- select -')) + CRM_Contribute_PseudoConstant::paymentInstrument(),
-        FALSE,
+        TRUE,
         array('onChange' => "return showHideByValue('payment_instrument_id','4','checkNumber','table-row','select',false);")
       );
 

--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -186,6 +186,9 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
     if ($this->_refund) {
       $defaults['total_amount'] = abs($this->_refund);
     }
+    elseif ($this->_owed) {
+      $defaults['total_amount'] = number_format($this->_owed, 2);
+    }
 
     // Set $newCredit variable in template to control whether link to credit card mode is included
     $this->assign('newCredit', CRM_Core_Config::isEnabledBackOfficeCreditCardPayments());

--- a/templates/CRM/Contribute/Form/AdditionalPayment.tpl
+++ b/templates/CRM/Contribute/Form/AdditionalPayment.tpl
@@ -100,7 +100,7 @@
             </td>
           </tr>
           <tr class="crm-payment-form-block-payment_instrument_id">
-            <td class="label">{$form.payment_instrument_id.label}</td>
+            <td class="label">{$form.payment_instrument_id.label} <span class="crm-marker" title="{ts}This field is required.{/ts}">*</span></td>
             <td >{$form.payment_instrument_id.html} {help id="payment_instrument_id"}</td>
             </td>
           </tr>

--- a/templates/CRM/Contribute/Form/AdditionalPayment.tpl
+++ b/templates/CRM/Contribute/Form/AdditionalPayment.tpl
@@ -100,7 +100,7 @@
             </td>
           </tr>
           <tr class="crm-payment-form-block-payment_instrument_id">
-            <td class="label">{$form.payment_instrument_id.label} <span class="crm-marker" title="{ts}This field is required.{/ts}">*</span></td>
+            <td class="label">{$form.payment_instrument_id.label}</td>
             <td >{$form.payment_instrument_id.html} {help id="payment_instrument_id"}</td>
             </td>
           </tr>


### PR DESCRIPTION
Overview
----------------------------------------
This PR holds fix
1. Add required marker for Payment method on Record payment form
2. Set amount default to amount owed on Record payment form

Before
----------------------------------------
![before](https://user-images.githubusercontent.com/2053075/28955738-3344a764-7906-11e7-8a5d-d9b009b366cd.png)


After
----------------------------------------
![after](https://user-images.githubusercontent.com/2053075/28955747-3da73d02-7906-11e7-8fab-1ceef0ac1fad.png)
)

---

 * [CRM-21005: "Record Payment" dialogue lacks required field and is clunky](https://issues.civicrm.org/jira/browse/CRM-21005)