### PR TITLE
CRM-21027 Fix next recurring payment not accurately calculated

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -816,9 +816,8 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
    * @throws \CiviCRM_API3_Exception
    */
   public static function updateOnNewPayment($recurringContributionID, $paymentStatus, $effectiveDate) {
-    if (empty($effectiveDate)) {
-      $effectiveDate = date('Y-m-d');
-    }
+
+    $effectiveDate = $effectiveDate ? date('Y-m-d', strtotime($effectiveDate)) : date('Y-m-d');
     if (!in_array($paymentStatus, array('Completed', 'Failed'))) {
       return;
     }

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
@@ -99,7 +99,7 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
    */
   public function testSupportFinancialTypeChange() {
     $contributionRecur = $this->callAPISuccess('contribution_recur', 'create', $this->_params);
-    $contribution = $this->callAPISuccess('contribution', 'create', array(
+    $this->callAPISuccess('contribution', 'create', array(
       'contribution_recur_id' => $contributionRecur['id'],
       'total_amount' => '3.00',
       'financial_type_id' => 1,
@@ -107,7 +107,7 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
       'currency' => 'USD',
       'contact_id' => $this->individualCreate(),
       'contribution_status_id' => 1,
-      'recieve_date' => 'yesterday',
+      'receive_date' => 'yesterday',
     ));
     $this->assertTrue(CRM_Contribute_BAO_ContributionRecur::supportsFinancialTypeChange($contributionRecur['id']));
   }

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -2671,6 +2671,16 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'receive_date' => '2012-02-29',
       'expected' => '2012-03-29 00:00:00',
     );
+    $result['receive_date_includes_time']['2012-01-01-1-month'] = array(
+      'data' => array(
+        'start_date' => '2012-01-01',
+        'frequency_interval' => 1,
+        'frequency_unit' => 'month',
+        'next_sched_contribution_date' => '2012-02-29',
+      ),
+      'receive_date' => '2012-02-29 16:00:00',
+      'expected' => '2012-03-29 00:00:00',
+    );
     return $result;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
This pull request fixes a bug that entered the code base in May, causing payment processors that rely on CiviCRM updating the next_sched_contribution_date for recurring to not get it updated.

Before
----------------------------------------
When payments are completed using the completetransaction api with a receive_date passed in with a time component the date for the next scheduled contribution is not updated. This is a critical error to sites affected as customers will be recharged, but mitigated by the fact that relatively few use the combination of components (in my case DPS / Omnipay + recurring payments)

After
----------------------------------------
After processing a payment the next_sched_contribution_date is correctly updated

Technical Details
----------------------------------------
Rather than comparing effectiveDate with today, the date part of effectiveDate ('Y-m-d') is compared with today

Comments
----------------------------------------
I was able to replicate this in a unit test before fixing it & committing the test

---

 * [CRM-21027: Next recurring payment not accurately calculated when effective date passed in](https://issues.civicrm.org/jira/browse/CRM-21027)