### PR TITLE
CRM-21029 - Report - Fix Activity Report SQL Syntax Error

### DIFF
--- a/CRM/Report/Form/Activity.php
+++ b/CRM/Report/Form/Activity.php
@@ -863,17 +863,21 @@ GROUP BY civicrm_activity_id $having {$this->_orderBy}";
     $this->limit();
     $groupByFromSelect = CRM_Contact_BAO_Query::getGroupByFromSelectColumns($this->_selectClauses, 'civicrm_activity_id');
 
-    $this->_aclWhere = "";
+    $this->_where = " WHERE (1)";
     $this->buildPermissionClause();
+    if ($this->_aclWhere) {
+      $this->_where .= " AND {$this->_aclWhere} ";
+    }
 
     $sql = "{$this->_select}
       FROM civireport_activity_temp_target tar
       INNER JOIN civicrm_activity {$this->_aliases['civicrm_activity']} ON {$this->_aliases['civicrm_activity']}.id = tar.civicrm_activity_id
       INNER JOIN civicrm_activity_contact {$this->_aliases['civicrm_activity_contact']} ON {$this->_aliases['civicrm_activity_contact']}.activity_id = {$this->_aliases['civicrm_activity']}.id
       AND {$this->_aliases['civicrm_activity_contact']}.record_type_id = {$sourceID}
-      LEFT JOIN civicrm_contact contact_civireport ON contact_civireport.id = {$this->_aliases['civicrm_activity_contact']}.contact_id 
-      WHERE (1) AND {$this->_aclWhere} {$groupByFromSelect} {$this->_having} {$this->_orderBy} {$this->_limit}";
+      LEFT JOIN civicrm_contact contact_civireport ON contact_civireport.id = {$this->_aliases['civicrm_activity_contact']}.contact_id
+      {$this->_where} {$groupByFromSelect} {$this->_having} {$this->_orderBy} {$this->_limit}";
 
+    $this->addToDeveloperTab($sql);
     $this->buildRows($sql, $rows);
 
     // format result set.


### PR DESCRIPTION
* [CRM-21029: Activity report SQL syntax error](https://issues.civicrm.org/jira/browse/CRM-21029)

Overview
----------------------------------------
Fixes syntax error caused by empty `$this->aclWhere` variable.

Before
----------------------------------------
```
[info] $Fatal Error Details = Array
(
    [callback] => Array
        (
            [0] => CRM_Core_Error
            [1] => handle
        )

    [code] => -2
    [message] => DB Error: syntax error
    [mode] => 16
    [debug_info] => SELECT SQL_CALC_FOUND_ROWS GROUP_CONCAT(civicrm_contact_contact_assignee SEPARATOR ';') as civicrm_contact_contact_assignee, GROUP_CONCAT(civicrm_contact_contact_target SEPARATOR ';') as civicrm_contact_contact_target, GROUP_CONCAT(civicrm_contact_contact_source_id SEPARATOR ';') as civicrm_contact_contact_source_id, GROUP_CONCAT(civicrm_contact_contact_assignee_id SEPARATOR ';') as civicrm_contact_contact_assignee_id, GROUP_CONCAT(civicrm_contact_contact_target_id SEPARATOR ';') as civicrm_contact_contact_target_id, civicrm_activity_id, civicrm_activity_source_record_id, civicrm_activity_activity_type_id, civicrm_activity_activity_subject, civicrm_activity_activity_date_time, civicrm_activity_status_id 
      FROM civireport_activity_temp_target tar
      INNER JOIN civicrm_activity activity_civireport ON activity_civireport.id = tar.civicrm_activity_id
      INNER JOIN civicrm_activity_contact activity_contact_civireport ON activity_contact_civireport.activity_id = activity_civireport.id
      AND activity_contact_civireport.record_type_id = 2
      LEFT JOIN civicrm_contact contact_civireport ON contact_civireport.id = activity_contact_civireport.contact_id 
      WHERE (1) AND   GROUP BY civicrm_activity_id  ORDER BY civicrm_activity_activity_date_time ASC, field(civicrm_activity_activity_type_id, 19, 37, 35, 36, 48, 52, 51, 6, 42, 49, 43, 3, 50, 5, 41, 54, 12, 45, 55, 34, 1, 8, 17, 7, 4, 46, 2, 10, 11, 22, 47, 40, 44, 9, 39, 38) ASC  LIMIT 0, 50 [nativecode=1064 ** You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'GROUP BY civicrm_activity_id  ORDER BY civicrm_activity_activity_date_time ASC, ' at line 7]
    [type] => DB_Error
    [user_info] => SELECT SQL_CALC_FOUND_ROWS GROUP_CONCAT(civicrm_contact_contact_assignee SEPARATOR ';') as civicrm_contact_contact_assignee, GROUP_CONCAT(civicrm_contact_contact_target SEPARATOR ';') as civicrm_contact_contact_target, GROUP_CONCAT(civicrm_contact_contact_source_id SEPARATOR ';') as civicrm_contact_contact_source_id, GROUP_CONCAT(civicrm_contact_contact_assignee_id SEPARATOR ';') as civicrm_contact_contact_assignee_id, GROUP_CONCAT(civicrm_contact_contact_target_id SEPARATOR ';') as civicrm_contact_contact_target_id, civicrm_activity_id, civicrm_activity_source_record_id, civicrm_activity_activity_type_id, civicrm_activity_activity_subject, civicrm_activity_activity_date_time, civicrm_activity_status_id 
      FROM civireport_activity_temp_target tar
      INNER JOIN civicrm_activity activity_civireport ON activity_civireport.id = tar.civicrm_activity_id
      INNER JOIN civicrm_activity_contact activity_contact_civireport ON activity_contact_civireport.activity_id = activity_civireport.id
      AND activity_contact_civireport.record_type_id = 2
      LEFT JOIN civicrm_contact contact_civireport ON contact_civireport.id = activity_contact_civireport.contact_id 
      WHERE (1) AND   GROUP BY civicrm_activity_id  ORDER BY civicrm_activity_activity_date_time ASC, field(civicrm_activity_activity_type_id, 19, 37, 35, 36, 48, 52, 51, 6, 42, 49, 43, 3, 50, 5, 41, 54, 12, 45, 55, 34, 1, 8, 17, 7, 4, 46, 2, 10, 11, 22, 47, 40, 44, 9, 39, 38) ASC  LIMIT 0, 50 [nativecode=1064 ** You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'GROUP BY civicrm_activity_id  ORDER BY civicrm_activity_activity_date_time ASC, ' at line 7]
    [to_string] => [db_error: message="DB Error: syntax error" code=-2 mode=callback callback=CRM_Core_Error::handle prefix="" info="SELECT SQL_CALC_FOUND_ROWS GROUP_CONCAT(civicrm_contact_contact_assignee SEPARATOR ';') as civicrm_contact_contact_assignee, GROUP_CONCAT(civicrm_contact_contact_target SEPARATOR ';') as civicrm_contact_contact_target, GROUP_CONCAT(civicrm_contact_contact_source_id SEPARATOR ';') as civicrm_contact_contact_source_id, GROUP_CONCAT(civicrm_contact_contact_assignee_id SEPARATOR ';') as civicrm_contact_contact_assignee_id, GROUP_CONCAT(civicrm_contact_contact_target_id SEPARATOR ';') as civicrm_contact_contact_target_id, civicrm_activity_id, civicrm_activity_source_record_id, civicrm_activity_activity_type_id, civicrm_activity_activity_subject, civicrm_activity_activity_date_time, civicrm_activity_status_id 
      FROM civireport_activity_temp_target tar
      INNER JOIN civicrm_activity activity_civireport ON activity_civireport.id = tar.civicrm_activity_id
      INNER JOIN civicrm_activity_contact activity_contact_civireport ON activity_contact_civireport.activity_id = activity_civireport.id
      AND activity_contact_civireport.record_type_id = 2
      LEFT JOIN civicrm_contact contact_civireport ON contact_civireport.id = activity_contact_civireport.contact_id 
      WHERE (1) AND   GROUP BY civicrm_activity_id  ORDER BY civicrm_activity_activity_date_time ASC, field(civicrm_activity_activity_type_id, 19, 37, 35, 36, 48, 52, 51, 6, 42, 49, 43, 3, 50, 5, 41, 54, 12, 45, 55, 34, 1, 8, 17, 7, 4, 46, 2, 10, 11, 22, 47, 40, 44, 9, 39, 38) ASC  LIMIT 0, 50 [nativecode=1064 ** You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'GROUP BY civicrm_activity_id  ORDER BY civicrm_activity_activity_date_time ASC, ' at line 7]"]
)
```

```
[info] $backTrace = #0 /opt/buildkit/build/dmaster/sites/all/modules/civicrm/CRM/Core/Error.php(229): CRM_Core_Error::backtrace("backTrace", TRUE)
#1 [internal function](): CRM_Core_Error::handle(Object(DB_Error))
#2 /opt/buildkit/build/dmaster/sites/all/modules/civicrm/packages/PEAR.php(921): call_user_func((Array:2), Object(DB_Error))
#3 /opt/buildkit/build/dmaster/sites/all/modules/civicrm/packages/DB.php(985): PEAR_Error->__construct("DB Error: syntax error", -2, 16, (Array:2), "SELECT SQL_CALC_FOUND_ROWS GROUP_CONCAT(civicrm_contact_contact_assignee SEPA...")
#4 /opt/buildkit/build/dmaster/sites/all/modules/civicrm/packages/PEAR.php(575): DB_Error->__construct(-2, 16, (Array:2), "SELECT SQL_CALC_FOUND_ROWS GROUP_CONCAT(civicrm_contact_contact_assignee SEPA...")
#5 [internal function](): PEAR->_raiseError(Object(DB_mysqli), NULL, -2, NULL, NULL, "SELECT SQL_CALC_FOUND_ROWS GROUP_CONCAT(civicrm_contact_contact_assignee SEPA...", "DB_Error", TRUE)
#6 /opt/buildkit/build/dmaster/sites/all/modules/civicrm/packages/PEAR.php(224): call_user_func_array((Array:2), (Array:8))
#7 /opt/buildkit/build/dmaster/sites/all/modules/civicrm/packages/DB/common.php(1905): PEAR->__call("raiseError", (Array:7))
#8 /opt/buildkit/build/dmaster/sites/all/modules/civicrm/packages/DB/common.php(1905): PEAR->raiseError(NULL, -2, NULL, NULL, "SELECT SQL_CALC_FOUND_ROWS GROUP_CONCAT(civicrm_contact_contact_assignee SEPA...", "DB_Error", TRUE)
#9 /opt/buildkit/build/dmaster/sites/all/modules/civicrm/packages/DB/mysqli.php(933): DB_common->raiseError(-2, NULL, NULL, NULL, "1064 ** You have an error in your SQL syntax; check the manual that correspon...")
#10 /opt/buildkit/build/dmaster/sites/all/modules/civicrm/packages/DB/mysqli.php(403): DB_mysqli->mysqliRaiseError()
#11 /opt/buildkit/build/dmaster/sites/all/modules/civicrm/packages/DB/common.php(1216): DB_mysqli->simpleQuery("SELECT SQL_CALC_FOUND_ROWS GROUP_CONCAT(civicrm_contact_contact_assignee SEPA...")
#12 /opt/buildkit/build/dmaster/sites/all/modules/civicrm/packages/DB/DataObject.php(2446): DB_common->query("SELECT SQL_CALC_FOUND_ROWS GROUP_CONCAT(civicrm_contact_contact_assignee SEPA...")
#13 /opt/buildkit/build/dmaster/sites/all/modules/civicrm/packages/DB/DataObject.php(1635): DB_DataObject->_query("SELECT SQL_CALC_FOUND_ROWS GROUP_CONCAT(civicrm_contact_contact_assignee SEPA...")
#14 /opt/buildkit/build/dmaster/sites/all/modules/civicrm/CRM/Core/DAO.php(362): DB_DataObject->query("SELECT SQL_CALC_FOUND_ROWS GROUP_CONCAT(civicrm_contact_contact_assignee SEPA...")
#15 /opt/buildkit/build/dmaster/sites/all/modules/civicrm/CRM/Core/DAO.php(1331): CRM_Core_DAO->query("SELECT SQL_CALC_FOUND_ROWS GROUP_CONCAT(civicrm_contact_contact_assignee SEPA...", TRUE)
#16 /opt/buildkit/build/dmaster/sites/all/modules/civicrm/CRM/Report/Form.php(2758): CRM_Core_DAO::executeQuery("SELECT SQL_CALC_FOUND_ROWS GROUP_CONCAT(civicrm_contact_contact_assignee SEPA...")
#17 /opt/buildkit/build/dmaster/sites/all/modules/civicrm/CRM/Report/Form/Activity.php(877): CRM_Report_Form->buildRows("SELECT SQL_CALC_FOUND_ROWS GROUP_CONCAT(civicrm_contact_contact_assignee SEPA...", (Array:0))
#18 /opt/buildkit/build/dmaster/sites/all/modules/civicrm/CRM/Report/Form.php(846): CRM_Report_Form_Activity->postProcess()
#19 /opt/buildkit/build/dmaster/sites/all/modules/civicrm/CRM/Core/Form.php(543): CRM_Report_Form->preProcess()
#20 /opt/buildkit/build/dmaster/sites/all/modules/civicrm/CRM/Core/QuickForm/Action/Display.php(92): CRM_Core_Form->buildForm()
#21 /opt/buildkit/build/dmaster/sites/all/modules/civicrm/packages/HTML/QuickForm/Controller.php(203): CRM_Core_QuickForm_Action_Display->perform(Object(CRM_Report_Form_Activity), "display")
#22 /opt/buildkit/build/dmaster/sites/all/modules/civicrm/packages/HTML/QuickForm/Page.php(103): HTML_QuickForm_Controller->handle(Object(CRM_Report_Form_Activity), "display")
#23 /opt/buildkit/build/dmaster/sites/all/modules/civicrm/CRM/Core/Controller.php(351): HTML_QuickForm_Page->handle("display")
#24 /opt/buildkit/build/dmaster/sites/all/modules/civicrm/CRM/Utils/Wrapper.php(113): CRM_Core_Controller->run()
#25 /opt/buildkit/build/dmaster/sites/all/modules/civicrm/CRM/Report/Page/Instance.php(89): CRM_Utils_Wrapper->run("CRM_Report_Form_Activity", NULL, NULL)
#26 /opt/buildkit/build/dmaster/sites/all/modules/civicrm/CRM/Core/Invoke.php(309): CRM_Report_Page_Instance->run((Array:4), NULL)
#27 /opt/buildkit/build/dmaster/sites/all/modules/civicrm/CRM/Core/Invoke.php(84): CRM_Core_Invoke::runItem((Array:14))
#28 /opt/buildkit/build/dmaster/sites/all/modules/civicrm/CRM/Core/Invoke.php(52): CRM_Core_Invoke::_invoke((Array:4))
#29 /opt/buildkit/build/dmaster/sites/all/modules/civicrm/drupal/civicrm.module(448): CRM_Core_Invoke::invoke((Array:4))
#30 [internal function](): civicrm_invoke("report", "instance", "3")
#31 /opt/buildkit/build/dmaster/includes/menu.inc(527): call_user_func_array("civicrm_invoke", (Array:3))
#32 /opt/buildkit/build/dmaster/index.php(21): menu_execute_active_handler()
#33 {main}
```

After
----------------------------------------
Report can be displayed again.
Final select query is added to developper tab.