### PR TITLE
Changes to Membership Renewal for issue CRM-20571

### DIFF
--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -338,10 +338,10 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
     }
 
     $this->applyFilter('__ALL__', 'trim');
-    
+
     // CRM-20571
     // Get the Join Date from Membership info as it is not available in the Renew form
-    $joinDate =  CRM_Core_DAO::getFieldValue('CRM_Member_DAO_Membership', $this->_id, 'join_date');
+    $joinDate = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_Membership', $this->_id, 'join_date');
     // Save its value in a hidden field
     $this->addElement('hidden', 'join_date', $joinDate);
 


### PR DESCRIPTION
Overview
----------------------------------------
Modifications required to compare join_date with renewal date before allowing the renewal to be accepted.

Before
----------------------------------------
Any renewal date can be specified and if it is before the join_date then the form gives error.

After
----------------------------------------
If the renewal date is before the join_date then the form reports an error indicating it must be after join_date, i.e. date of membership start.

Technical Details
----------------------------------------
Explained it in inline comments
// CRM-20571
Get the Join Date from Membership info as it is not available in the Renew form
Save its value in a hidden field

// CRM-20571: Check if the renewal date is not before Join Date, if it is then add to 'errors' array
The fields in Renewal form come into this routine in $params array. 'renewal_date' is already in the form and we added 'join_date' as a hidden field in the buildForm routine with member join date value
We process both the dates before comparison using CRM utils so that they are in same date format

Comments
----------------------------------------

---

 * [CRM-20571: Offline \/ Back Office Renewal fatal error when "renewal_date" set to far back.](https://issues.civicrm.org/jira/browse/CRM-20571)