### PR TITLE
CRM-21026 fix issue with ContributionCount not including disabled fin…

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -604,8 +604,8 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
       if ($retrieveRequired == 1) {
         $contribution->find(TRUE);
       }
-      $contributionType = CRM_Contribute_PseudoConstant::financialType($contribution->financial_type_id);
-      $title = CRM_Contact_BAO_Contact::displayName($contribution->contact_id) . ' - (' . CRM_Utils_Money::format($contribution->total_amount, $contribution->currency) . ' ' . ' - ' . $contributionType . ')';
+      $financialType = CRM_Contribute_PseudoConstant::financialType($contribution->financial_type_id);
+      $title = CRM_Contact_BAO_Contact::displayName($contribution->contact_id) . ' - (' . CRM_Utils_Money::format($contribution->total_amount, $contribution->currency) . ' ' . ' - ' . $financialType . ')';
 
       $recentOther = array();
       if (CRM_Core_Permission::checkActionPermission('CiviContribute', CRM_Core_Action::UPDATE)) {
@@ -2132,7 +2132,7 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
     if (!$contactId) {
       return 0;
     }
-    CRM_Financial_BAO_FinancialType::getAllAvailableFinancialTypes($financialTypes);
+    $financialTypes = CRM_Financial_BAO_FinancialType::getAllAvailableFinancialTypes();
     $additionalWhere = " AND contribution.financial_type_id IN (0)";
     $liWhere = " AND i.financial_type_id IN (0)";
     if (!empty($financialTypes)) {

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -604,8 +604,8 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
       if ($retrieveRequired == 1) {
         $contribution->find(TRUE);
       }
-      $contributionTypes = CRM_Contribute_PseudoConstant::financialType();
-      $title = CRM_Contact_BAO_Contact::displayName($contribution->contact_id) . ' - (' . CRM_Utils_Money::format($contribution->total_amount, $contribution->currency) . ' ' . ' - ' . $contributionTypes[$contribution->financial_type_id] . ')';
+      $contributionType = CRM_Contribute_PseudoConstant::financialType($contribution->financial_type_id);
+      $title = CRM_Contact_BAO_Contact::displayName($contribution->contact_id) . ' - (' . CRM_Utils_Money::format($contribution->total_amount, $contribution->currency) . ' ' . ' - ' . $contributionType . ')';
 
       $recentOther = array();
       if (CRM_Core_Permission::checkActionPermission('CiviContribute', CRM_Core_Action::UPDATE)) {
@@ -2132,7 +2132,7 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
     if (!$contactId) {
       return 0;
     }
-    CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes($financialTypes);
+    CRM_Financial_BAO_FinancialType::getAllAvailableFinancialTypes($financialTypes);
     $additionalWhere = " AND contribution.financial_type_id IN (0)";
     $liWhere = " AND i.financial_type_id IN (0)";
     if (!empty($financialTypes)) {

--- a/CRM/Contribute/PseudoConstant.php
+++ b/CRM/Contribute/PseudoConstant.php
@@ -101,13 +101,17 @@ class CRM_Contribute_PseudoConstant extends CRM_Core_PseudoConstant {
    *
    *
    * @param int $id
+   * @param bool $includeDisabled
    *
    * @return array
    *   array reference of all financial types if any
    */
-  public static function &financialType($id = NULL) {
+  public static function &financialType($id = NULL, $includeDisabled = FALSE) {
     if (!self::$financialType) {
-      $condition = " is_active = 1 ";
+      $condition = "";
+      if (!$includeDisabled) {
+        $condition = " is_active = 1 ";
+      }
       CRM_Core_PseudoConstant::populate(
         self::$financialType,
         'CRM_Financial_DAO_FinancialType',

--- a/CRM/Financial/BAO/FinancialType.php
+++ b/CRM/Financial/BAO/FinancialType.php
@@ -246,8 +246,8 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType {
   }
 
   /**
-   * Get available Financial Types.
-   *
+   * CRM-21026
+   * Wrapper aroung getAvaliableFinancialTypes to get all including disabled FinancialTypes
    * @param array $financialTypes
    *   (reference ) an array of financial types
    * @param int|string $action
@@ -257,9 +257,47 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType {
    *
    * @return array
    */
-  public static function getAvailableFinancialTypes(&$financialTypes = NULL, $action = CRM_Core_Action::VIEW, $resetCache = FALSE) {
+  public static function getAllAvailableFinancialTypes(&$financialTypes = NULL, $action = CRM_Core_Action::VIEW, $resetCache = FALSE) {
+    // Flush pseudoconstant cache
+    CRM_Contribute_PseudoConstant::flush('financialType');
+    self::getAvailableFinancialTypes($financialTypes, $action, $resetCache, TRUE);
+    return $financialTypes;
+  }
+
+  /**
+   * CRM-21026
+   * Wrapper aroung getAvaliableFinancialTypes to get all FinancialTypes Excluding Disabled ones.
+   * @param array $financialTypes
+   *   (reference ) an array of financial types
+   * @param int|string $action
+   *   the type of action, can be add, view, edit, delete
+   * @param bool $resetCache
+   *   load values from static cache
+   *
+   * @return array
+   */
+  public static function getAllEnabledAvailableFinancialTypes(&$financialTypes = NULL, $action = CRM_Core_Action::VIEW, $resetCache = FALSE) {
+    self::getAvailableFinancialTypes($financialTypes, $action, $resetCache);
+    return $financialTypes;
+  }
+
+  /**
+   * Get available Financial Types.
+   *
+   * @param array $financialTypes
+   *   (reference ) an array of financial types
+   * @param int|string $action
+   *   the type of action, can be add, view, edit, delete
+   * @param bool $resetCache
+   *   load values from static cache
+   * @param bool $includeDisabled
+   *   Whether we should load in disabled FinancialTypes or Not
+   *
+   * @return array
+   */
+  public static function getAvailableFinancialTypes(&$financialTypes = NULL, $action = CRM_Core_Action::VIEW, $resetCache = FALSE, $includeDisabled = FALSE) {
     if (empty($financialTypes)) {
-      $financialTypes = CRM_Contribute_PseudoConstant::financialType();
+      $financialTypes = CRM_Contribute_PseudoConstant::financialType(NULL, $includeDisabled);
     }
     if (!self::isACLFinancialTypeStatus()) {
       return $financialTypes;

--- a/CRM/Financial/BAO/FinancialType.php
+++ b/CRM/Financial/BAO/FinancialType.php
@@ -246,7 +246,7 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType {
   }
 
   /**
-   * Wrapper aroung getAvaliableFinancialTypes to get all including disabled FinancialTypes
+   * Wrapper aroung getAvailableFinancialTypes to get all including disabled FinancialTypes
    * @param int|string $action
    *   the type of action, can be add, view, edit, delete
    * @param bool $resetCache
@@ -263,7 +263,7 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType {
   }
 
   /**
-   * Wrapper aroung getAvaliableFinancialTypes to get all FinancialTypes Excluding Disabled ones.
+   * Wrapper aroung getAvailableFinancialTypes to get all FinancialTypes Excluding Disabled ones.
    * @param int|string $action
    *   the type of action, can be add, view, edit, delete
    * @param bool $resetCache
@@ -377,7 +377,7 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType {
     }
     else {
       if ($component == 'contribution') {
-        self::getAvailableFinancialTypes($types);
+        $types = self::getAllEnabledAvailableFinancialTypes();
         $column = "financial_type_id";
       }
       if ($component == 'membership') {
@@ -447,8 +447,7 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType {
     if (!self::isACLFinancialTypeStatus()) {
       return TRUE;
     }
-    // @todo consider adding back in disabled types here.
-    CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes($financialTypes, CRM_Core_Action::UPDATE);
+    $financialTypes = CRM_Financial_BAO_FinancialType::getAllAvailableFinancialTypes(CRM_Core_Action::UPDATE);
     return isset($financialTypes[$financialTypeID]);
   }
 

--- a/CRM/Financial/BAO/FinancialType.php
+++ b/CRM/Financial/BAO/FinancialType.php
@@ -249,7 +249,7 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType {
    * CRM-21026
    * Wrapper aroung getAvaliableFinancialTypes to get all including disabled FinancialTypes
    * @param array $financialTypes
-   *   (reference ) an array of financial types
+   *   an array of financial types
    * @param int|string $action
    *   the type of action, can be add, view, edit, delete
    * @param bool $resetCache
@@ -257,18 +257,18 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType {
    *
    * @return array
    */
-  public static function getAllAvailableFinancialTypes(&$financialTypes = NULL, $action = CRM_Core_Action::VIEW, $resetCache = FALSE) {
+  public static function getAllAvailableFinancialTypes($financialTypes = NULL, $action = CRM_Core_Action::VIEW, $resetCache = FALSE) {
     // Flush pseudoconstant cache
     CRM_Contribute_PseudoConstant::flush('financialType');
-    self::getAvailableFinancialTypes($financialTypes, $action, $resetCache, TRUE);
-    return $financialTypes;
+    $fTypes = self::getAvailableFinancialTypes($financialTypes, $action, $resetCache, TRUE);
+    return $fTypes;
   }
 
   /**
    * CRM-21026
    * Wrapper aroung getAvaliableFinancialTypes to get all FinancialTypes Excluding Disabled ones.
    * @param array $financialTypes
-   *   (reference ) an array of financial types
+   *   an array of financial types
    * @param int|string $action
    *   the type of action, can be add, view, edit, delete
    * @param bool $resetCache
@@ -276,9 +276,9 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType {
    *
    * @return array
    */
-  public static function getAllEnabledAvailableFinancialTypes(&$financialTypes = NULL, $action = CRM_Core_Action::VIEW, $resetCache = FALSE) {
-    self::getAvailableFinancialTypes($financialTypes, $action, $resetCache);
-    return $financialTypes;
+  public static function getAllEnabledAvailableFinancialTypes($financialTypes = NULL, $action = CRM_Core_Action::VIEW, $resetCache = FALSE) {
+    $fTypes = self::getAvailableFinancialTypes($financialTypes, $action, $resetCache);
+    return $fTypes;
   }
 
   /**
@@ -371,7 +371,7 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType {
       return FALSE;
     }
     if (is_array($whereClauses)) {
-      self::getAvailableFinancialTypes($types);
+      $types = self::getAllEnabledAvailableFinancialTypes();
       if (empty($types)) {
         $whereClauses[] = ' ' . $alias . '.financial_type_id IN (0)';
       }

--- a/CRM/Financial/BAO/FinancialType.php
+++ b/CRM/Financial/BAO/FinancialType.php
@@ -246,10 +246,7 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType {
   }
 
   /**
-   * CRM-21026
    * Wrapper aroung getAvaliableFinancialTypes to get all including disabled FinancialTypes
-   * @param array $financialTypes
-   *   an array of financial types
    * @param int|string $action
    *   the type of action, can be add, view, edit, delete
    * @param bool $resetCache
@@ -257,18 +254,16 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType {
    *
    * @return array
    */
-  public static function getAllAvailableFinancialTypes($financialTypes = NULL, $action = CRM_Core_Action::VIEW, $resetCache = FALSE) {
+  public static function getAllAvailableFinancialTypes($action = CRM_Core_Action::VIEW, $resetCache = FALSE) {
     // Flush pseudoconstant cache
     CRM_Contribute_PseudoConstant::flush('financialType');
-    $fTypes = self::getAvailableFinancialTypes($financialTypes, $action, $resetCache, TRUE);
-    return $fTypes;
+    $thisIsAUselessVariableButSolvesPHPError = NULL;
+    $financialTypes = self::getAvailableFinancialTypes($thisIsAUselessVariableButSolvesPHPError, $action, $resetCache, TRUE);
+    return $financialTypes;
   }
 
   /**
-   * CRM-21026
    * Wrapper aroung getAvaliableFinancialTypes to get all FinancialTypes Excluding Disabled ones.
-   * @param array $financialTypes
-   *   an array of financial types
    * @param int|string $action
    *   the type of action, can be add, view, edit, delete
    * @param bool $resetCache
@@ -276,9 +271,10 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType {
    *
    * @return array
    */
-  public static function getAllEnabledAvailableFinancialTypes($financialTypes = NULL, $action = CRM_Core_Action::VIEW, $resetCache = FALSE) {
-    $fTypes = self::getAvailableFinancialTypes($financialTypes, $action, $resetCache);
-    return $fTypes;
+  public static function getAllEnabledAvailableFinancialTypes($action = CRM_Core_Action::VIEW, $resetCache = FALSE) {
+    $thisIsAUselessVariableButSolvesPHPError = NULL;
+    $financialTypes = self::getAvailableFinancialTypes($thisIsAUselessVariableButSolvesPHPError, $action, $resetCache);
+    return $financialTypes;
   }
 
   /**

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -147,6 +147,41 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
   }
 
   /**
+   * CRM-21026 Test ContributionCount after contribution created with disabled FT
+   */
+  public function testContributionCountDisabledFinancialType() {
+    $contactId = $this->individualCreate();
+    $financialType = array(
+      'name' => 'grassvariety1' . substr(sha1(rand()), 0, 7),
+      'is_reserved' => 0,
+      'is_active' => 0,
+    );
+    $finType = $this->callAPISuccess('financial_type', 'create', $financialType);
+    $params = array(
+      'contact_id' => $contactId,
+      'currency' => 'USD',
+      'financial_type_id' => $finType['id'],
+      'contribution_status_id' => 1,
+      'payment_instrument_id' => 1,
+      'source' => 'STUDENT',
+      'receive_date' => '20080522000000',
+      'receipt_date' => '20080522000000',
+      'id' => NULL,
+      'non_deductible_amount' => 0.00,
+      'total_amount' => 200.00,
+      'fee_amount' => 5,
+      'net_amount' => 195,
+      'trxn_id' => '22ereerwww322323',
+      'invoice_id' => '22ed39c9e9ee6ef6031621ce0eafe6da70',
+      'thankyou_date' => '20080522',
+    );
+    $contribution = CRM_Contribute_BAO_Contribution::create($params);
+    $testResult = $this->callAPISuccess('financial_type', 'create', array('is_active' => 0, 'id' => $finType['id']));
+    $contributionCount = CRM_Contribute_BAO_Contribution::contributionCount($contactId);
+    $this->assertEquals(1, $contributionCount);
+  }
+
+  /**
    * DeleteContribution() method
    */
   public function testDeleteContribution() {


### PR DESCRIPTION
…ancialtypes

Overview
----------------------------------------
At present when calling ContributionCount it by default due to the addition of is_active = 1 clause in the pseduoConstant function excludes contributions with Disabled Financial Types

Before
----------------------------------------
Contribution count on tab is incorrect

After
----------------------------------------
Contribution count is correct

Technical Details
----------------------------------------
_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_

Comments
----------------------------------------

