### PR TITLE
CRM-21038 - select default processor if displayed by amount selection.

### DIFF
--- a/templates/CRM/common/paymentBlock.tpl
+++ b/templates/CRM/common/paymentBlock.tpl
@@ -52,6 +52,8 @@
       payment_processor.show();
       payment_information.show();
       billing_block.show();
+      // also set selected payment methods
+      cj('input[name="payment_processor_id"][checked=checked]').prop('checked', true);
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Enable default processor when payment method is displayed by amount selection.

Before
----------------------------------------
When no amount is selected by default on contribution live page, we [hide and disable the checked](https://github.com/civicrm/civicrm-core/blob/master/templates/CRM/common/paymentBlock.tpl#L47-L48) property of payment method. This should again be enabled after it is loaded on selecting a valid amount.

After
----------------------------------------
Payment processor is selected correctly.

---

 * [CRM-21038: Billing and CC fields shown when payment processor not selected.](https://issues.civicrm.org/jira/browse/CRM-21038)