### PR TITLE
CRM-17157 support multiple decimalplaces formrule money

### DIFF
--- a/CRM/Utils/Rule.php
+++ b/CRM/Utils/Rule.php
@@ -574,7 +574,10 @@ class CRM_Utils_Rule {
       return TRUE;
     }
 
-    return preg_match('/(^-?\d+\.\d?\d?$)|(^-?\.\d\d?$)/', $value) ? TRUE : FALSE;
+    // Allow values such as -0, 1.024555, -.1
+    // We need to support multiple decimal places here, not just the number allowed by locale
+    //  otherwise tax calculations break when you want the inclusive amount to be a round number (eg. £10 inc. VAT requires 8.333333333 here).
+    return preg_match('/(^-?\d+\.?\d*$)|(^-?\.\d+$)/', $value) ? TRUE : FALSE;
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/RuleTest.php
+++ b/tests/phpunit/CRM/Utils/RuleTest.php
@@ -79,4 +79,36 @@ class CRM_Utils_RuleTest extends CiviUnitTestCase {
     );
   }
 
+  /**
+   * @dataProvider moneyDataProvider
+   * @param $inputData
+   * @param $expectedResult
+   */
+  public function testMoney($inputData, $expectedResult) {
+    $this->assertEquals($expectedResult, CRM_Utils_Rule::money($inputData));
+  }
+
+  /**
+   * @return array
+   */
+  public function moneyDataProvider() {
+    return array(
+      array(10, TRUE),
+      array('145.0E+3', FALSE),
+      array('10', TRUE),
+      array(-10, TRUE),
+      array('-10', TRUE),
+      array('-10foo', FALSE),
+      array('-10.0345619', TRUE),
+      array('-10.010,4345619', TRUE),
+      array('10.0104345619', TRUE),
+      array('-0', TRUE),
+      array('-.1', TRUE),
+      array('.1', TRUE),
+      // Test currency symbols too, default locale uses $, so if we wanted to test others we'd need to reconfigure locale
+      array('$500.3333', TRUE),
+      array('-$500.3333', TRUE),
+      array('$-500.3333', TRUE),
+    );
+  }
 }

--- a/tests/phpunit/CRM/Utils/RuleTest.php
+++ b/tests/phpunit/CRM/Utils/RuleTest.php
@@ -111,4 +111,5 @@ class CRM_Utils_RuleTest extends CiviUnitTestCase {
       array('$-500.3333', TRUE),
     );
   }
+
 }


### PR DESCRIPTION
Ref CRM-20772 and CRM-17157.  CRM_Utils_Rule::money currently assumes all currencies have 2 decimal places (this is not true, eg. bitcoin).  Also to allow proper calculation of tax where the tax inclusive amount should be a round number we have to save more than 2 decimal places in the database.  This is part of that puzzle!

I've also added a unit test :-)
@eileenmcnaughton

---

 * [CRM-17157: CiviCRM money validation should allow more decimal places](https://issues.civicrm.org/jira/browse/CRM-17157)
 * [CRM-20772: \(WIP\) Price set calculation precision when sales tax enabled](https://issues.civicrm.org/jira/browse/CRM-20772)