### PR TITLE
CRM-21039, Trying to add Asset account relationship throws validation error

### DIFF
--- a/CRM/Financial/Form/FinancialTypeAccount.php
+++ b/CRM/Financial/Form/FinancialTypeAccount.php
@@ -241,6 +241,7 @@ class CRM_Financial_Form_FinancialTypeAccount extends CRM_Contribute_Form {
       $params = array(
         'account_relationship' => $values['account_relationship'],
         'entity_id' => $self->_aid,
+        'entity_table' => 'civicrm_financial_type',
       );
       $defaults = array();
       if ($self->_action == CRM_Core_Action::ADD) {


### PR DESCRIPTION
----------------------------------------
* CRM-21039: Trying to add Asset account relationship throws validation error
  https://issues.civicrm.org/jira/browse/CRM-21039

Overview
----------------------------------------
When trying to add relationship 'Asset account', the form throws validation error 'This account relationship already exits'

Before
----------------------------------------
![before1](https://user-images.githubusercontent.com/2053075/29024167-637c710c-7b8e-11e7-8bf9-310270ef572b.png)
![before2](https://user-images.githubusercontent.com/2053075/29024169-668545ae-7b8e-11e7-8fc7-1d23593e29a9.png)


After
----------------------------------------
No Error, Account relationship is added successfully.

