### PR TITLE
CRM-20800 : User Cannot Cancel Recurring Payment With Paypal

### DIFF
--- a/CRM/Financial/BAO/PaymentProcessor.php
+++ b/CRM/Financial/BAO/PaymentProcessor.php
@@ -543,6 +543,7 @@ INNER JOIN civicrm_contribution       con ON ( mp.contribution_id = con.id )
         // The function looks to load the payment processor ID from the contribution page, which
         // can support multiple processors.
       }
+      $paymentProcessor['payment_processor_type'] = CRM_Core_PseudoConstant::paymentProcessorType(FALSE, $paymentProcessor['payment_processor_type_id'], 'name');
       $result = Civi\Payment\System::singleton()->getByProcessor($paymentProcessor);
     }
     return $result;


### PR DESCRIPTION
Overview
----------------------------------------
The recurring contribution could not be cancelled.
However, if you are logged in and deselect "Notify Paypal" you are able to cancel the recurring payment. It only seems to fail when that box is checked.


Comments
----------------------------------------
It throws notice error on dblog as 
``` Undefined index: payment_processor_type in CRM_Core_Payment_PayPalImpl->cancelSubscription() (line 663 of /var/www/html/sitename/sites/all/modules/civicrm/CRM/Core/Pa‌​yment/PayPalImpl.php‌​)```