### PR TITLE
CRM-21043 - Dupe check of on behalf organisation not working

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1189,11 +1189,11 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
     if (!$orgID) {
       // check if matching organization contact exists
-      $dupeID = CRM_Contact_BAO_Contact::getFirstDuplicateContact($behalfOrganization, 'Organization', 'Unsupervised', array(), FALSE);
+      $dupeIDs = CRM_Contact_BAO_Contact::getDuplicateContacts($behalfOrganization, 'Organization', 'Unsupervised', array(), FALSE);
 
       // CRM-6243 says to pick the first org even if more than one match
       if (count($dupeIDs) >= 1) {
-        $behalfOrganization['contact_id'] = $orgID = $dupeID;
+        $behalfOrganization['contact_id'] = $orgID = $dupeIDs[0];
         // don't allow name edit
         unset($behalfOrganization['organization_name']);
       }

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -1192,6 +1192,84 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
   }
 
   /**
+   * Test processOnBehalfOrganization() function.
+   */
+  public function testProcessOnBehalfOrganization() {
+    $orgInfo = array(
+      'phone' => '11111111',
+      'email' => 'testorg@gmail.com',
+      'street_address' => 'test Street',
+      'city' => 'test City',
+      'state_province' => 'AA',
+      'postal_code' => '222222',
+      'country' => 'United States',
+    );
+    $contactID = $this->individualCreate();
+    $orgId = $this->organizationCreate(array('organization_name' => 'testorg1'));
+    $orgCount = $this->callAPISuccessGetCount('Contact', array(
+      'contact_type' => "Organization",
+      'organization_name' => "testorg1",
+    ));
+    $this->assertEquals($orgCount, 1);
+
+    $values = $params = array();
+    $behalfOrganization = array(
+      'organization_name' => 'testorg1',
+      'phone' => array(
+        1 => array(
+          'phone' => $orgInfo['phone'],
+          'is_primary' => 1,
+        ),
+      ),
+      'email' => array(
+        1 => array(
+          'email' => $orgInfo['email'],
+          'is_primary' => 1,
+        ),
+      ),
+      'address' => array(
+        3 => array(
+          'street_address' => $orgInfo['street_address'],
+          'city' => $orgInfo['city'],
+          'location_type_id' => 3,
+          'postal_code' => $orgInfo['postal_code'],
+          'country' => 'US',
+          'state_province' => 'AA',
+          'is_primary' => 1,
+        ),
+      ),
+    );
+    $fields = array(
+      'organization_name' => 1,
+      'phone-3-1' => 1,
+      'email-3' => 1,
+      'street_address-3' => 1,
+      'city-3' => 1,
+      'postal_code-3' => 1,
+      'country-3' => 1,
+      'state_province-3' => 1,
+    );
+    CRM_Contribute_Form_Contribution_Confirm::processOnBehalfOrganization($behalfOrganization, $contactID, $values, $params, $fields);
+
+    //Check whether new organisation is not created.
+    $result = $this->callAPISuccess('Contact', 'get', array(
+      'contact_type' => "Organization",
+      'organization_name' => "testorg1",
+    ));
+    $this->assertEquals($result['count'], 1);
+
+    //Assert all org values are updated.
+    foreach ($orgInfo as $key => $val) {
+      $this->assertEquals($result['values'][$orgId][$key], $val);
+    }
+
+    //Check if alert is assigned to params if more than 1 dupe exists.
+    $orgId = $this->organizationCreate(array('organization_name' => 'testorg1', 'email' => 'testorg@gmail.com'));
+    CRM_Contribute_Form_Contribution_Confirm::processOnBehalfOrganization($behalfOrganization, $contactID, $values, $params, $fields);
+    $this->assertEquals($params['onbehalf_dupe_alert'], 1);
+  }
+
+  /**
    * Test for replaceContributionTokens.
    *   This function tests whether the contribution tokens are replaced with values from contribution.
    */


### PR DESCRIPTION
Overview
----------------------------------------
Fixes check for dupe for onbehalf organization.

Before
----------------------------------------
When submitting live contribution with onbehalf - duplicate name doesn't update the organization contact.

After
----------------------------------------
works fine and correctly updates existing org contact if any.

Technical Details
----------------------------------------
`getFirstDuplicateContact()` returns only one dupe contact, but seems we need a count of all dupes here in order to set [`onbehalf_dupe_alert` in $params.](https://github.com/civicrm/civicrm-core/blob/master/CRM/Contribute/Form/Contribution/Confirm.php#L1225)

Comments
----------------------------------------
Added unit test.

---

 * [CRM-21043: Dupe check of on behalf organisation not working](https://issues.civicrm.org/jira/browse/CRM-21043)