### PR TITLE
CRM-21045: Multiple email field shown on Contribution Page.

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -347,6 +347,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
           array('size' => 30, 'maxlength' => 60, 'class' => 'email'),
           TRUE
         );
+        $this->assign('showMainEmail', TRUE);
         $this->addRule("email-{$this->_bltID}", ts('Email is not valid.'), 'email');
       }
     }

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -175,14 +175,16 @@
       <div class="clear"></div>
     </div>
     {/if}
-    {assign var=n value=email-$bltID}
-    <div class="crm-public-form-item crm-section {$form.$n.name}-section">
-      <div class="label">{$form.$n.label}</div>
-      <div class="content">
-        {$form.$n.html}
+    {if $showMainEmail}
+      {assign var=n value=email-$bltID}
+      <div class="crm-public-form-item crm-section {$form.$n.name}-section">
+        <div class="label">{$form.$n.label}</div>
+        <div class="content">
+          {$form.$n.html}
+        </div>
+        <div class="clear"></div>
       </div>
-      <div class="clear"></div>
-    </div>
+    {/if}
 
     <div id='onBehalfOfOrg' class="crm-public-form-item crm-section">
       {include file="CRM/Contribute/Form/Contribution/OnBehalfOf.tpl"}


### PR DESCRIPTION
Overview
----------------------------------------
Fix two same emails inputs shown on contribution page.

Before
----------------------------------------
If email billing is added to a profile on contribution page - main email and profile email both are shown on the contribution page with same id `email-5`.

After
----------------------------------------
Only profile email field is shown as per https://github.com/civicrm/civicrm-core/pull/10349

Technical Details
----------------------------------------
Changes assign `showMainEmail` variable and display its html only if it is set.

---

 * [CRM-21045: Multiple email field shown on Contribution Page.](https://issues.civicrm.org/jira/browse/CRM-21045)