### PR TITLE
CRM-20999 - Fix multiple auto_renew id on contribution live page

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/MembershipBlock.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/MembershipBlock.tpl
@@ -84,15 +84,16 @@
 CRM.$(function($) {
     //if price set is set we use below below code to show for showing auto renew
     var autoRenewOption =  {/literal}'{$autoRenewOption}'{literal};
-    var autoRenew = $("#auto_renew");
+    var autoRenew = $("#auto_renew_section");
+    var autoRenewCheckbox = $("#auto_renew");
     var forceRenew = $("#force_renew");
     autoRenew.hide();
     forceRenew.hide();
     if ( autoRenewOption == 1 ) {
         autoRenew.show();
     } else if ( autoRenewOption == 2 ) {
-        autoRenew.prop('checked',  true );
-        autoRenew.attr( 'readonly', true );
+        autoRenewCheckbox.prop('checked',  true );
+        autoRenewCheckbox.attr( 'readonly', true );
         autoRenew.hide();
         forceRenew.show();
     }
@@ -248,7 +249,7 @@ function showHideAutoRenew( memTypeId )
   if ( !memTypeId && singleMembership ) memTypeId = cj("input:radio[name="+priceSetName+"]").attr('membership-type');
   var renewOptions  = {/literal}{$autoRenewMembershipTypeOptions}{literal};
   var currentOption = eval( "renewOptions." + 'autoRenewMembershipType_' + memTypeId );
-  var autoRenew = cj('#auto_renew');
+  var autoRenew = cj('#auto_renew_section');
   var autoRenewC = cj('input[name="auto_renew"]');
   var forceRenew = cj("#force_renew");
 

--- a/templates/CRM/Price/Form/PriceSet.tpl
+++ b/templates/CRM/Price/Form/PriceSet.tpl
@@ -107,7 +107,7 @@
                   <div id="allow_auto_renew">
                     <div class='crm-section auto-renew'>
                       <div class='label'></div>
-                      <div class='content' id="auto_renew">
+                      <div class='content' id="auto_renew_section">
                         {if isset($form.auto_renew) }
                           {$form.auto_renew.html}&nbsp;{$form.auto_renew.label}
                         {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Two elements have same `id` attribute on live contribution page

Before
----------------------------------------
<img width="306" alt="image" src="https://user-images.githubusercontent.com/5929648/29108031-bf8cc9d4-7cfa-11e7-873b-8dee5d7fce21.png">

After
----------------------------------------
Single `id` for each element.

Comments
----------------------------------------
This id was added in https://github.com/civicrm/civicrm-core/commit/c843169cd2a563bb91944df92657b2e81d0010b3, hence tagging @mattwire if this looks fine to you.

---

 * [CRM-20999: Multiple elements share same id `auto_renew` value on live contribution page.](https://issues.civicrm.org/jira/browse/CRM-20999)