### PR TITLE
CRM-21047, fixed JS error on new contribution form

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -572,7 +572,9 @@ function buildAmount( priceSetId, financialtypeIds ) {
   cj("#price_set_id option[value='']").html( manual );
 
   cj('label[for="total_amount"]').text('{/literal}{ts}Price Sets{/ts}{literal}');
-  cj("#financial_type_id option[value="+financialtypeIds[priceSetId]+"]").prop('selected', true);
+  if (financialtypeIds) {
+    cj("#financial_type_id option[value="+financialtypeIds[priceSetId]+"]").prop('selected', true);
+  }
   cj(".crm-contribution-form-block-financial_type_id").css("display", "none");
 }
 


### PR DESCRIPTION
----------------------------------------
* CRM-21047: TypeError: financialtypeIds is undefined, on contribution form
  https://issues.civicrm.org/jira/browse/CRM-21047

Overview
----------------------------------------
This PR fixes JS error when new contribution form using price set throws validation error

Before
----------------------------------------
![jserror](https://user-images.githubusercontent.com/2053075/29123356-1f2d2266-7d33-11e7-8d5c-98d7b8653375.png)


After
----------------------------------------
![after](https://user-images.githubusercontent.com/2053075/29123385-38af47aa-7d33-11e7-852d-0bf41bdf7b69.png)
