### PR TITLE
CRM-21049 - Allow creating relationship types with no contact type specified

### DIFF
--- a/api/v3/RelationshipType.php
+++ b/api/v3/RelationshipType.php
@@ -77,8 +77,6 @@ function civicrm_api3_relationship_type_create($params) {
  *   Array of parameters determined by getfields.
  */
 function _civicrm_api3_relationship_type_create_spec(&$params) {
-  $params['contact_type_a']['api.required'] = 1;
-  $params['contact_type_b']['api.required'] = 1;
   $params['name_a_b']['api.required'] = 1;
   $params['name_b_a']['api.required'] = 1;
   $params['is_active']['api.default'] = 1;

--- a/tests/phpunit/api/v3/RelationshipTypeTest.php
+++ b/tests/phpunit/api/v3/RelationshipTypeTest.php
@@ -94,19 +94,6 @@ class api_v3_RelationshipTypeTest extends CiviUnitTestCase {
   }
 
   /**
-   * Check with no contact type.
-   */
-  public function testRelationshipTypeCreateWithoutContactType() {
-    $relTypeParams = array(
-      'name_a_b' => 'Relation 1 without contact type',
-      'name_b_a' => 'Relation 2 without contact type',
-    );
-    $result = $this->callAPIFailure('relationship_type', 'create', $relTypeParams,
-      'Mandatory key(s) missing from params array: contact_type_a, contact_type_b'
-    );
-  }
-
-  /**
    * Create relationship type.
    */
   public function testRelationshipTypeCreate() {
@@ -190,7 +177,7 @@ class api_v3_RelationshipTypeTest extends CiviUnitTestCase {
   public function testRelationshipTypeUpdateEmpty() {
     $params = array();
     $result = $this->callAPIFailure('relationship_type', 'create', $params);
-    $this->assertEquals($result['error_message'], 'Mandatory key(s) missing from params array: name_a_b, name_b_a, contact_type_a, contact_type_b');
+    $this->assertEquals($result['error_message'], 'Mandatory key(s) missing from params array: name_a_b, name_b_a');
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
The API currently doesn't allow creating a relationship type with contact type of "All Contacts".  This is intended to fix this.

Before
----------------------------------------
The API create spec defines `contact_type_a` and `contact_type_b` as required, and locks this functionality in via a unit test.

After
----------------------------------------
I removed the lines from the spec and removed/updated the unit tests locking in the incorrect behavior.

Comments
----------------------------------------
This code hasn't been touched since Civi was migrated from SVN to git - so it might be that once upon a time there was no way to specify "All Contacts" via leaving `contact_type_a` or `contact_type_b` as NULL.

---

 * [CRM-21049: Can't create a RelationshipType record via API with "All Contacts" as a value](https://issues.civicrm.org/jira/browse/CRM-21049)