### PR TITLE
CRM-19798: Memory leak in API3 EntityTag get operations

### DIFF
--- a/Civi/API/Kernel.php
+++ b/Civi/API/Kernel.php
@@ -98,6 +98,11 @@ class Kernel {
 
     try {
       $apiResponse = $this->runRequest($apiRequest);
+
+      // CRM-19798: clear unwanted resources for next api calls and avoid huge
+      // memory leak
+      \CRM_Core_DAO::freeResult();
+
       return $this->formatResult($apiRequest, $apiResponse);
     }
     catch (\Exception $e) {


### PR DESCRIPTION
Overview
----------------------------------------

The query results were kept in a global array and never freed, causing memory leak for multiple API calls in the same script.

Before
----------------------------------------

![Bob Silvern script being executed without freed the resources](https://user-images.githubusercontent.com/3278419/29155090-eb0b9142-7d6f-11e7-8ac5-a66329937a4b.png)

After
----------------------------------------

![Bob Silvern script being executed with resources freed](https://user-images.githubusercontent.com/3278419/29155093-efb89866-7d6f-11e7-8a40-9e882ac6a0d0.png)

Comments
----------------------------------------

- I did a slight modification in the script so I could define which API call should be used in command line, instead of using it hard coded;
- It's possible to note that there's still a small memory leak, this one is not related to query results but could possibly be related to global objects being kept through API calls.

---

 * [CRM-19798: Memory leak in API3 EntityTag get operations](https://issues.civicrm.org/jira/browse/CRM-19798)