### PR TITLE
CRM-21054 - Fix is_create_activities param for fetch_activities job

### DIFF
--- a/CRM/Utils/Mail/EmailProcessor.php
+++ b/CRM/Utils/Mail/EmailProcessor.php
@@ -89,8 +89,10 @@ class CRM_Utils_Mail_EmailProcessor {
 
   /**
    * Process the mailboxes that aren't default (ie. that aren't used by civiMail for the bounce).
+   * @param bool $is_create_activities
+   *   Should activities be created?
    */
-  public static function processActivities() {
+  public static function processActivities($is_create_activities) {
     $dao = new CRM_Core_DAO_MailSettings();
     $dao->domain_id = CRM_Core_Config::domainID();
     $dao->is_default = FALSE;

--- a/CRM/Utils/Mail/EmailProcessor.php
+++ b/CRM/Utils/Mail/EmailProcessor.php
@@ -89,10 +89,8 @@ class CRM_Utils_Mail_EmailProcessor {
 
   /**
    * Process the mailboxes that aren't default (ie. that aren't used by civiMail for the bounce).
-   * @param bool $is_create_activities
-   *   Should activities be created?
    */
-  public static function processActivities($is_create_activities) {
+  public static function processActivities() {
     $dao = new CRM_Core_DAO_MailSettings();
     $dao->domain_id = CRM_Core_Config::domainID();
     $dao->is_default = FALSE;
@@ -100,7 +98,7 @@ class CRM_Utils_Mail_EmailProcessor {
     $found = FALSE;
     while ($dao->fetch()) {
       $found = TRUE;
-      self::_process(FALSE, $dao, $is_create_activities);
+      self::_process(FALSE, $dao, TRUE);
     }
     if (!$found) {
       CRM_Core_Error::fatal(ts('No mailboxes have been configured for Email to Activity Processing'));

--- a/api/v3/Job.php
+++ b/api/v3/Job.php
@@ -378,19 +378,6 @@ function _civicrm_api3_job_fetch_bounces_spec(&$params) {
 }
 
 /**
- * Metadata for activities function.
- *
- * @param array $params
- */
-function _civicrm_api3_job_fetch_activities_spec(&$params) {
-  $params['is_create_activities'] = array(
-    'api.default' => 0,
-    'type' => CRM_Utils_Type::T_BOOLEAN,
-    'title' => ts('Create activities for replies?'),
-  );
-}
-
-/**
  * Job to get mail and create activities.
  *
  * @param array $params
@@ -404,7 +391,7 @@ function civicrm_api3_job_fetch_activities($params) {
   }
 
   try {
-    CRM_Utils_Mail_EmailProcessor::processActivities($params['is_create_activities']);
+    CRM_Utils_Mail_EmailProcessor::processActivities();
     $values = array();
     $lock->release();
     return civicrm_api3_create_success($values, $params, 'Job', 'fetch_activities');

--- a/api/v3/Job.php
+++ b/api/v3/Job.php
@@ -378,6 +378,19 @@ function _civicrm_api3_job_fetch_bounces_spec(&$params) {
 }
 
 /**
+ * Metadata for activities function.
+ *
+ * @param array $params
+ */
+function _civicrm_api3_job_fetch_activities_spec(&$params) {
+  $params['is_create_activities'] = array(
+    'api.default' => 0,
+    'type' => CRM_Utils_Type::T_BOOLEAN,
+    'title' => ts('Create activities for replies?'),
+  );
+}
+
+/**
  * Job to get mail and create activities.
  *
  * @param array $params
@@ -391,7 +404,7 @@ function civicrm_api3_job_fetch_activities($params) {
   }
 
   try {
-    CRM_Utils_Mail_EmailProcessor::processActivities();
+    CRM_Utils_Mail_EmailProcessor::processActivities($params['is_create_activities']);
     $values = array();
     $lock->release();
     return civicrm_api3_create_success($values, $params, 'Job', 'fetch_activities');


### PR DESCRIPTION
Overview
----------------------------------------
Fixes is_create_activities param for fetch_activities

Before
----------------------------------------
Process Activities job execution results into notice error.

After
----------------------------------------
Job executes correctly without errors.

Technical Details
----------------------------------------
`is_create_activities` param was introduced in #9655, but it missed the initialization of param in `processActivities()` function. This PR adds those params with specs as done for bounces.

---

 * [CRM-21054: `is_create_activities` param not defined for fetch_activities job](https://issues.civicrm.org/jira/browse/CRM-21054)