### PR TITLE
CRM-21057: pass limit to retrieve all mapping values

### DIFF
--- a/CRM/Core/BAO/Mapping.php
+++ b/CRM/Core/BAO/Mapping.php
@@ -115,7 +115,13 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping {
    *   Array of mapping names, keyed by id.
    */
   public static function getMappings($mappingType) {
-    $result = civicrm_api3('Mapping', 'get', array('mapping_type_id' => $mappingType, 'options' => array('sort' => 'name')));
+    $result = civicrm_api3('Mapping', 'get', array(
+      'mapping_type_id' => $mappingType,
+      'options' => array(
+        'sort' => 'name',
+        'limit' => 0,
+      ),
+    ));
     $mapping = array();
 
     foreach ($result['values'] as $key => $value) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes export saved mapping dropdown to ensure all records are listed.

Before
----------------------------------------
Saved mapping dropdown was limited to API default of 25.

After
----------------------------------------
All records are returned.

---

 * [CRM-21057: export field mapping limited to 25 records](https://issues.civicrm.org/jira/browse/CRM-21057)