### PR TITLE
Add Unit Test for :CRM-20840 - ensure no receipt for recur payment if contrib page says …

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1423,7 +1423,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     CRM_Contribute_Form_AdditionalInfo::buildPremium($this);
 
     $this->_fields = array();
-    $this->submit(array_merge($defaults, $params), $action, CRM_Utils_Array::value('pledge_payment_id', $params));
+    return $this->submit(array_merge($defaults, $params), $action, CRM_Utils_Array::value('pledge_payment_id', $params));
 
   }
 

--- a/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
@@ -73,7 +73,7 @@ class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
       'billing_first_name' => 'Junko',
       'billing_middle_name' => '',
       'billing_last_name' => 'Adams',
-      'billing_street_address-5' => rand() . ' Lincoln St S',
+      'billing_street_address-5' => time() . ' Lincoln St S',
       'billing_city-5' => 'Maryknoll',
       'billing_state_province_id-5' => 1031,
       'billing_postal_code-5' => 10545,

--- a/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
@@ -35,7 +35,7 @@ class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
   }
   /**
    * Ensure recurring contributions from Contribution Pages
-   * with receipt turned off don't send a receipt. 
+   * with receipt turned off don't send a receipt.
    */
   public function testIPNPaymentRecurNoReceipt() {
     $mut = new CiviMailUtils($this, TRUE);

--- a/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
@@ -46,7 +46,50 @@ class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
     );
     $this->callAPISuccess('contributionPage', 'update', $api_params);
 
-    $this->setupRecurringPaymentProcessorTransaction();
+		// Create initial recurring payment and initial contribution.
+		// Note - we can't use setupRecurringPaymentProcessorTransaction(), which
+    // would be convenient because it does not fully mimic the real user
+    // experience. Using setupRecurringPaymentProcessorTransaction() doesn't
+    // specify is_email_receipt so it is always set to 1. We need to more
+    // closely mimic what happens with a live transaction to test that
+    // is_email_receipt is not set to 1 if the originating contribution page
+    // has is_email_receipt set to 0. 
+		$form = new CRM_Contribute_Form_Contribution();
+    $form->_mode = 'Live';
+		$form->testSubmit(array(
+			'total_amount' => 200,
+			'financial_type_id' => 1,
+			'receive_date' => '04/21/2015',
+			'receive_date_time' => '11:27PM',
+			'contact_id' => $this->_contactID,
+			'contribution_status_id' => 1,
+			'credit_card_number' => 4444333322221111,
+			'cvv2' => 123,
+			'credit_card_exp_date' => array(
+				'M' => 9,
+				'Y' => 2025,
+			),
+			'credit_card_type' => 'Visa',
+			'billing_first_name' => 'Junko',
+			'billing_middle_name' => '',
+			'billing_last_name' => 'Adams',
+			'billing_street_address-5' => '790L Lincoln St S',
+			'billing_city-5' => 'Maryknoll',
+			'billing_state_province_id-5' => 1031,
+			'billing_postal_code-5' => 10545,
+			'billing_country_id-5' => 1228,
+			'frequency_interval' => 1,
+			'frequency_unit' => 'month',
+			'installments' => '',
+			'hidden_AdditionalDetail' => 1,
+			'hidden_Premium' => 1,
+			'payment_processor_id' => $this->_paymentProcessorID,
+			'currency' => 'USD',
+			'source' => 'bob sled race',
+      'contribution_page_id' => $this->_contributionPageID,
+		), CRM_Core_Action::ADD);
+
+		// Process the initial one.
     $IPN = new CRM_Core_Payment_AuthorizeNetIPN($this->getRecurTransaction());
     $IPN->main();
 

--- a/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
@@ -360,7 +360,7 @@ class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
   /**
    * @return array
    */
-  public function getRecurSubsequentTransaction($params) {
+  public function getRecurSubsequentTransaction($params = array()) {
     return array_merge($this->getRecurTransaction(), array(
       'x_trans_id' => 'second_one',
       'x_MD5_Hash' => 'EA7A3CD65A85757827F51212CA1486A8',

--- a/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
@@ -46,59 +46,58 @@ class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
     );
     $this->callAPISuccess('contributionPage', 'update', $api_params);
 
-		// Create initial recurring payment and initial contribution.
-		// Note - we can't use setupRecurringPaymentProcessorTransaction(), which
+    // Create initial recurring payment and initial contribution.
+    // Note - we can't use setupRecurringPaymentProcessorTransaction(), which
     // would be convenient because it does not fully mimic the real user
     // experience. Using setupRecurringPaymentProcessorTransaction() doesn't
     // specify is_email_receipt so it is always set to 1. We need to more
     // closely mimic what happens with a live transaction to test that
     // is_email_receipt is not set to 1 if the originating contribution page
-    // has is_email_receipt set to 0. 
-		$form = new CRM_Contribute_Form_Contribution();
+    // has is_email_receipt set to 0.
+    $form = new CRM_Contribute_Form_Contribution();
     $form->_mode = 'Live';
-		$contribution = $form->testSubmit(array(
-			'total_amount' => 200,
-			'financial_type_id' => 1,
-			'receive_date' => date('m/d/Y'),
-			'receive_date_time' => date('H:i:s'),
-			'contact_id' => $this->_contactID,
-			'contribution_status_id' => 1,
-			'credit_card_number' => 4444333322221111,
-			'cvv2' => 123,
-			'credit_card_exp_date' => array(
-				'M' => 9,
-				'Y' => 2025,
-			),
-			'credit_card_type' => 'Visa',
-			'billing_first_name' => 'Junko',
-			'billing_middle_name' => '',
-			'billing_last_name' => 'Adams',
-			'billing_street_address-5' => rand() . ' Lincoln St S',
-			'billing_city-5' => 'Maryknoll',
-			'billing_state_province_id-5' => 1031,
-			'billing_postal_code-5' => 10545,
-			'billing_country_id-5' => 1228,
-			'frequency_interval' => 1,
-			'frequency_unit' => 'month',
-			'installments' => '',
-			'hidden_AdditionalDetail' => 1,
-			'hidden_Premium' => 1,
-			'payment_processor_id' => $this->_paymentProcessorID,
-			'currency' => 'USD',
-			'source' => 'bob sled race',
+    $contribution = $form->testSubmit(array(
+      'total_amount' => 200,
+      'financial_type_id' => 1,
+      'receive_date' => date('m/d/Y'),
+      'receive_date_time' => date('H:i:s'),
+      'contact_id' => $this->_contactID,
+      'contribution_status_id' => 1,
+      'credit_card_number' => 4444333322221111,
+      'cvv2' => 123,
+      'credit_card_exp_date' => array(
+        'M' => 9,
+        'Y' => 2025,
+      ),
+      'credit_card_type' => 'Visa',
+      'billing_first_name' => 'Junko',
+      'billing_middle_name' => '',
+      'billing_last_name' => 'Adams',
+      'billing_street_address-5' => rand() . ' Lincoln St S',
+      'billing_city-5' => 'Maryknoll',
+      'billing_state_province_id-5' => 1031,
+      'billing_postal_code-5' => 10545,
+      'billing_country_id-5' => 1228,
+      'frequency_interval' => 1,
+      'frequency_unit' => 'month',
+      'installments' => '',
+      'hidden_AdditionalDetail' => 1,
+      'hidden_Premium' => 1,
+      'payment_processor_id' => $this->_paymentProcessorID,
+      'currency' => 'USD',
+      'source' => 'bob sled race',
       'contribution_page_id' => $this->_contributionPageID,
       'is_recur' => TRUE,
-		), CRM_Core_Action::ADD);
-
+    ), CRM_Core_Action::ADD);
 
     $this->_contributionID = $contribution->id;
     $this->_contributionRecurID = $contribution->contribution_recur_id;
     $recur_params = array(
       'id' => $this->_contributionRecurID,
-      'return' => 'processor_id'
+      'return' => 'processor_id',
     );
     $processor_id = civicrm_api3('ContributionRecur', 'getvalue', $recur_params);
-		// Process the initial one.
+    // Process the initial one.
     $IPN = new CRM_Core_Payment_AuthorizeNetIPN(
       $this->getRecurTransaction(array('x_subscription_id' => $processor_id))
     );


### PR DESCRIPTION
…no receipt

Here's a failing test to start with.

Overview
----------------------------------------
Ensure the if a recurring payment is made using a contribution page with receipts turned off, CiviCRM should not send any receipts.

Before
----------------------------------------
If a recurring payment is made using a contribution page with receipts turned off, a receipt is still generated on each payment (tested using authorize).

After
----------------------------------------
WIP - no code changes made.

Technical Details
----------------------------------------


Comments
----------------------------------------
See test