### PR TITLE
CRM-20941 Bump Minimum PHP Version to 5.6, Add in pre-upgrade message…

### DIFF
--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -41,7 +41,12 @@ class CRM_Upgrade_Incremental_General {
   /**
    * The recommended PHP version.
    */
-  const MIN_RECOMMENDED_PHP_VER = '5.5';
+  const MIN_RECOMMENDED_PHP_VER = '5.6';
+
+  /**
+   * The previous recommended PHP version.
+   */
+  const PREVIOUS_MIN_RECOMMENDED_PHP_VER = '5.5';
 
   /**
    * The minimum PHP version required to install Civi.
@@ -65,13 +70,28 @@ class CRM_Upgrade_Incremental_General {
    * @param $latestVer
    */
   public static function setPreUpgradeMessage(&$preUpgradeMessage, $currentVer, $latestVer) {
+    $dateFormat = Civi::Settings()->get('dateformatshortdate');
     if (version_compare(phpversion(), self::MIN_RECOMMENDED_PHP_VER) < 0) {
-      $preUpgradeMessage .= '<p>' .
-        ts('This webserver is running an outdated version of PHP (%1). It is strongly recommended to upgrade to PHP %2 or later, as older versions can present a security risk.', array(
-          1 => phpversion(),
-          2 => self::MIN_RECOMMENDED_PHP_VER,
-        )) .
-        '</p>';
+      $preUpgradeMessage .= '<p>';
+      // CRM-20941 PHP 5.3 end date of End of 2017, PHP 5.4 End date End of Feb 2018 Recommend anyone on PHP 5.5 to move up to 5.6 or later e.g. 7.0
+      if (version_compare(phpversion(), self::PREVIOUS_MIN_RECOMMENDED_PHP_VER) >= 0) {
+        $preUpgradeMessage .= ts('You may proceed with the upgrade and CiviCRM %1 will continue working normally, but future releases will require PHP %2 or above. We recommend you use the most recent php version you can', array(
+           1 => $currentVer,
+           2 => self::MIN_RECOMMENDED_PHP_VER,
+        ));
+      }
+      elseif (version_compare(phpversion(), 5.5) < 0) {
+        $date = CRM_Utils_Date::customFormat('2018-02-28', $dateFormat);
+        if (version_compare(phpversion(), 5.4) < 0) {
+          $date = CRM_Utils_Date::customFormat('2017-12-31', $dateFormat);
+        }
+        $preUpgradeMessage .= ts('You may proceed with the upgrade and CiviCRM %1 will continue working normally, but PHP %2 will not work in releases published after %3. We recommend you use the most recent php version you can', array(
+          1 => $currentVer,
+          2 => phpversion(),
+          3 => $date,
+        ));
+      }
+      $preUpgradeMessage .= '</p>';
     }
 
     // http://issues.civicrm.org/jira/browse/CRM-13572

--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -85,10 +85,11 @@ class CRM_Upgrade_Incremental_General {
         if (version_compare(phpversion(), 5.4) < 0) {
           $date = CRM_Utils_Date::customFormat('2017-12-31', $dateFormat);
         }
-        $preUpgradeMessage .= ts('You may proceed with the upgrade and CiviCRM %1 will continue working normally, but PHP %2 will not work in releases published after %3. We recommend you use the most recent php version you can', array(
+        $preUpgradeMessage .= ts('You may proceed with the upgrade and CiviCRM %1 will continue working normally, but PHP %2 will not work in releases published after %3. We recommend you use the most recent php version you can. For more explanation see <a href="%4">the announcement</a>', array(
           1 => $currentVer,
           2 => phpversion(),
           3 => $date,
+          4 => 'https://civicrm.org/blog/totten/end-of-zombies-php-53-and-54',
         ));
       }
       $preUpgradeMessage .= '</p>';

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -76,11 +76,12 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
       }
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
-        ts('This system uses PHP version %1. CiviCRM can be installed on this version, However PHP version %1, will not work in releases published after %2, and version %3 is recommended.',
+        ts('This system uses PHP version %1. CiviCRM can be installed on this version. However PHP version %1 will not work in releases published after %2, and version %3 is recommended. For more explanation see <a href="%4"> the announcement</a>',
           array(
             1 => phpversion(),
             2 => $date,
             3 => CRM_Upgrade_Incremental_General::MIN_RECOMMENDED_PHP_VER,
+            4 => 'https://civicrm.org/blog/totten/end-of-zombies-php-53-and-54',
           )),
         ts('PHP Out-of-Date'),
         \Psr\Log\LogLevel::WARNING,

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -51,7 +51,7 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
         'fa-server'
       );
     }
-    elseif (version_compare(phpversion(), CRM_Upgrade_Incremental_General::MIN_DEFECT_PHP_VER) >= 0) {
+    elseif (version_compare(phpversion(), CRM_Upgrade_Incremental_General::PREVIOUS_MIN_RECOMMENDED_PHP_VER) >= 0) {
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
         ts('This system uses PHP version %1. While this meets the minimum requirements for CiviCRM to function, upgrading to PHP version %2 or newer is recommended for maximum compatibility.',
@@ -66,13 +66,21 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
       );
     }
     else {
+      $date = '';
+      $dateFormat = Civi::Settings()->get('dateformatshortdate');
+      if (version_compare(phpversion(), 5.4) < 0) {
+        $date = CRM_Utils_Date::customFormat('2017-12-31', $dateFormat);
+      }
+      elseif (version_compare(phpversion(), 5.5) < 0) {
+        $date = CRM_Utils_Date::customFormat('2018-02-28', $dateFormat);
+      }
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
-        ts('This system uses PHP version %1. CiviCRM can be installed on this version, but some specific features are known to fail or degrade. Version %3 is the bare minimum to avoid known issues, and version %2 is recommended.',
+        ts('This system uses PHP version %1. CiviCRM can be installed on this version, However PHP version %1, will not work in releases published after %2, and version %3 is recommended.',
           array(
             1 => phpversion(),
-            2 => CRM_Upgrade_Incremental_General::MIN_RECOMMENDED_PHP_VER,
-            3 => CRM_Upgrade_Incremental_General::MIN_DEFECT_PHP_VER,
+            2 => $date,
+            3 => CRM_Upgrade_Incremental_General::MIN_RECOMMENDED_PHP_VER,
           )),
         ts('PHP Out-of-Date'),
         \Psr\Log\LogLevel::WARNING,


### PR DESCRIPTION
…s specific to 5.4 and 5.3 and alter Status Check message accordingly

Overview
----------------------------------------
Increases CiviCRM 4.7 Minimum php level to 5.6 and adds messages accordingly to notify site administrators

Before
----------------------------------------
Minimum php level was 5.3

After
----------------------------------------
Minimum php level is not 5.6

Technical Details
----------------------------------------
N/a
Comments
----------------------------------------
This also adds some flexibility in for future Minimum PHP release bumps by adding in a constant PREVIOUS_MIN_RECOMMENDED_PHP_VER  which can be altered and will present the same style message we are using for php5.5
