### PR TITLE
(NFC) Improve docs in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,76 +1,20 @@
-CiviCRM is a community-driven open-source project. It has a small,
-full-time "core team" which facilitates development and works on critical
-issues. However, many improvements are driven by the active contributors.
+CiviCRM is a community-driven open-source project. It has a small, full-time 
+[core team](https://civicrm.org/core-team)
+which facilitates development and works on critical issues. 
+Additionally, a large community of active contributors and 
+[partner organizations](https://civicrm.org/partners-contributors)
+drive much of the development work. 
 
-This document provides important information about how to contribute.
+For developers, CiviCRM maintains a comprehensive
+[Developer Guide](https://docs.civicrm.org/dev/en/latest).
+Topics of particular importance while submitting pull requests include:
 
-## Review/Release Process
+* [Contributing to CiviCRM core](https://docs.civicrm.org/dev/en/latest/core/contributing/)
+* [Pull requests](https://docs.civicrm.org/dev/en/latest/tools/git/#pr)
+* [Git workflow overview](https://docs.civicrm.org/dev/en/latest/tools/git/#contributing)
+* [Writing automated tests](https://docs.civicrm.org/dev/en/latest/testing/setup/)
+* [Jenkins continuous integration](https://docs.civicrm.org/dev/en/latest/tools/jenkins/)
+* [Release Process](https://docs.civicrm.org/dev/en/latest/core/release-process/)
+* [Developer Community](https://docs.civicrm.org/dev/en/latest/basics/community/)
 
-Releases are developed on a monthly cycle.  At the start of the month, the
-release-manager will send an invitation to developers who have open PRs,
-encouraging them to participate in the release-cycle.  Participation
-provides a way to exchange feedback with other developers, get PRs merged,
-and ensure the next release works -- all with a predictable timeline.
-
- * For a high-level summary of the release process, see the
-   [Release Management README](https://github.com/civicrm/release-management/blob/master/README.md).
- * For an example invitation, see the previous [invitation for the April-May 2016](https://github.com/civicrm/release-management/issues/1).
-
-## Pull-Request Scope
-
-A good pull request (PR) addresses a clearly-defined problem. There should be a detailed description logged in the [issue tracker](http://issues.civicrm.org/). Excellent PRs also increase test coverage. If you are tempted to do additional tweaks or code cleanup outside the scope of that issue, you could make a separate commit and include them in the PR if they are minor & non-controversial, or create a seperate PR if they are more complex.
-
-There is no size limit for PRs as long as they are focused on completely solving a discreet problem. As a practical matter, though, bigger PRs may take longer to review and merge. When possible, split "epic" issues into bite-sized chunks as long as each seperate PR is functionally complete and does not cause merge conflicts with your other PRs. In the latter case, add commits to an existing PR.
-
-## Pull-Request Subject
-
-When filing a pull-request, use a descriptive subject. These are good examples:
-
- * `CRM-12345 - Fix Paypal IPNs when moon is at half-crescent (waxing)`
- * `(WIP) CRM-67890 - Refactor SMS callback endpoint`
- * `(NFC) CRM_Utils_PDF - Improve docblocks`
-
-A few elements to include:
-
- * **CRM-_XXXXX_** - This is a reference to the [CiviCRM issue tracker](http://issues.civicrm.org/)
-   (JIRA). A bot will setup crosslinks between JIRA and GitHub.
- * **Description** - Provide a brief description of what the pull-request does.
- * **(WIP)** - "Work in Progress" - If you are still developing a set of
-   changes, it may be useful to submit a pull-request and flag it as
-   `(WIP)`. This allows you to have discussion with other developers and
-   check test results. Once the change is ready, update the subject line
-   to remove `(WIP)`.
- * **(NFC)** - "Non-Functional Change" - Most patches are designed to
-   change functionality (e.g. fix an error message or add a new button).
-   However, some changes are non-functional -- e.g. they cleanup the
-   code-style, improve the comments, or improve the test-suite.
-
-## Testing
-
-Pull-requests are tested automatically by a build-bot. Key things to know:
-
- * If you are a new contributor, the tests may be placed on hold pending a
-   cursory review. One of the administrators will post a comment like
-   `jenkins, ok to test` or `jenkins, add to whitelist`.
- * The pull-request will have a colored dot indicating its status:
-   * **Yellow**: The automated tests are running.
-   * **Red**: The automated tests have failed.
-   * **Green**: The automated tests have passed.
- * If the automated test fails, click on the red dot to investigate details. Check for information in:
-   * The initial summary. Ordinarily, this will list test failures and error messages.
-   * The console output. If the test-suite encountered a significant error (such as a PHP crash),
-     the key details will only appear in the console.
- * Code-style tests are executed first. If the code-style in this patch is inconsistent, the remaining tests will be skipped.
- * The primary tests may take 20-120 min to execute. This includes the following suites: `api_v3_AllTests`, `CRM_AllTests`, `Civi\AllTests`, `civicrm-upgrade-test`, and `karma`
- * There are a handful of unit tests which are time-sensitive and which fail sporadically. See: https://forum.civicrm.org/index.php?topic=36964.0
- * The web test suite (`WebTest_AllTests`) takes several hours to execute. [It runs separately -- after the PR has been merged.](https://test.civicrm.org/job/CiviCRM-WebTest-Matrix/)
-
-For detailed discussion about automated tests, see http://wiki.civicrm.org/confluence/display/CRMDOC/Testing
-
-## Updating a pull-request
-
-During review, there may be some feedback about problems or additional
-changes required for acceptance.  If you've never updated a pull-request
-before, see [Stackoverflow: How to update a pull request](http://stackoverflow.com/questions/9790448/how-to-update-a-pull-request).
-
-When you push the update to the pull-request, the test suite will re-execute.
+CiviCRM thanks you for your contributions and invites you to [log your time spent](https://civicrm.org/contributor-log) so that you (or your organization) may receive public recognition and promotion for your efforts.


### PR DESCRIPTION
Overview
----------------------------------------

* This is a non-functional change.
* This PR depends on https://github.com/civicrm/civicrm-dev-docs/pull/275
    * In that PR, I migrated some of the content from `CONTRIBUTING.md` into the Developer Guide. Now this PR removes that content from `CONTRIBUTING.md` and puts hyerlinks in its place.

Before
----------------------------------------

* `CONTRIBUTING.md` contained some useful information which was not in (or discoverable from) the Developer Guide
* Other useful content from the Developer Guide was not discoverable from `CONTRIBUTING.md`

After
----------------------------------------

* Content generally related to contributing is more consolidated within the Developer Guide
* `CONTRIBUTING.md` makes that content easily discoverable