### PR TITLE
[NFC] Simplify method of getting logged in contact ID

### DIFF
--- a/CRM/Profile/Form/Edit.php
+++ b/CRM/Profile/Form/Edit.php
@@ -88,8 +88,7 @@ class CRM_Profile_Form_Edit extends CRM_Profile_Form {
 
     if ($this->get('edit')) {
       // make sure we have right permission to edit this user
-      $session = CRM_Core_Session::singleton();
-      $userID = $session->get('userID');
+      $userID = CRM_Core_Session::getLoggedInContactID();
 
       // Set the ID from the query string, otherwise default to the current user
       $id = CRM_Utils_Request::retrieve('id', 'Positive', $this, FALSE, $userID);


### PR DESCRIPTION
Use the existing utility function getLoggedInContactID, rather than loading the session and then calling get->userID.