### PR TITLE
CRM-21063 Add date to survey/details report

### DIFF
--- a/CRM/Report/Form/Campaign/SurveyDetails.php
+++ b/CRM/Report/Form/Campaign/SurveyDetails.php
@@ -185,7 +185,7 @@ class CRM_Report_Form_Campaign_SurveyDetails extends CRM_Report_Form {
           'activity_date_time' => array(
             'name' => 'activity_date_time',
             'title' => ts('Date'),
-            'type' => CRM_Utils_Type::T_DATE,
+            'type' => CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME,
           ),
         ),
         'filters' => array(
@@ -211,7 +211,7 @@ class CRM_Report_Form_Campaign_SurveyDetails extends CRM_Report_Form {
           ),
           'activity_date_time' => array(
             'title' => ts('Date'),
-            'type' => CRM_Utils_Type::T_DATE,
+            'type' => CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME,
             'operatorType' => CRM_Report_Form::OP_DATE,
           ),
         ),

--- a/CRM/Report/Form/Campaign/SurveyDetails.php
+++ b/CRM/Report/Form/Campaign/SurveyDetails.php
@@ -182,6 +182,11 @@ class CRM_Report_Form_Campaign_SurveyDetails extends CRM_Report_Form {
             'required' => TRUE,
             'title' => ts('Survey Result'),
           ),
+          'activity_date_time' => array(
+            'name' => 'activity_date_time',
+            'title' => ts('Date'),
+            'type' => CRM_Utils_Type::T_DATE,
+          ),
         ),
         'filters' => array(
           'survey_id' => array(
@@ -204,8 +209,18 @@ class CRM_Report_Form_Campaign_SurveyDetails extends CRM_Report_Form {
             'operatorType' => CRM_Report_Form::OP_MULTISELECT,
             'options' => $resultOptions,
           ),
+          'activity_date_time' => array(
+            'title' => ts('Date'),
+            'type' => CRM_Utils_Type::T_DATE,
+            'operatorType' => CRM_Report_Form::OP_DATE,
+          ),
         ),
         'grouping' => 'survey-activity-fields',
+        'order_bys' => array(
+          'activity_date_time' => array(
+            'title' => ts('Date'),
+          ),
+        ),
       ),
     ) + $this->getAddressColumns();
     parent::__construct();


### PR DESCRIPTION
Overview
----------------------------------------
As per issue, add the date field from the civicrm_activity table to make the campaign survey/details report more useful.

After
----------------------------------------
Added the date field to Columns, Sorting and Filter tabs of the report.

---

 * [CRM-21063: Survey detail report lacks date options](https://issues.civicrm.org/jira/browse/CRM-21063)