### PR TITLE
CRM-17281 Pledge payments: fix rounding bug with miscalculation for multiple payments against a pledge

### DIFF
--- a/CRM/Pledge/BAO/PledgePayment.php
+++ b/CRM/Pledge/BAO/PledgePayment.php
@@ -858,7 +858,7 @@ WHERE civicrm_pledge_payment.contribution_id = {$paymentContributionId}
           $paymentId = array($oldestPayment['id']);
           self::updatePledgePayments($pledgeID, array_search('Completed', $allStatus), $paymentId, 0, $paymentContributionId);
           CRM_Core_DAO::setFieldValue('CRM_Pledge_DAO_PledgePayment', $oldestPayment['id'], 'scheduled_amount', 0, 'id');
-          $oldestPayment = self::getOldestPledgePayment($pledgeID);
+
           if (!$paymentContributionId) {
             // means we are editing payment scheduled payment.
             $oldestPaymentAmount = self::getOldestPledgePayment($pledgeID, 2);

--- a/CRM/Pledge/BAO/PledgePayment.php
+++ b/CRM/Pledge/BAO/PledgePayment.php
@@ -288,16 +288,13 @@ WHERE     pledge_id = %1
    * @return bool
    */
   public static function resetPledgePayment($contributionID) {
-    // get all status
-    $allStatus = CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name');
-
     $transaction = new CRM_Core_Transaction();
 
     $payment = new CRM_Pledge_DAO_PledgePayment();
     $payment->contribution_id = $contributionID;
     if ($payment->find(TRUE)) {
       $payment->contribution_id = 'null';
-      $payment->status_id = array_search('Pending', $allStatus);
+      $payment->status_id = CRM_Core_PseudoConstant::getKey('CRM_Pledge_BAO_Pledge', 'status_id', 'Pending');
       $payment->scheduled_date = NULL;
       $payment->reminder_date = NULL;
       $payment->scheduled_amount = $payment->actual_amount;
@@ -320,18 +317,18 @@ WHERE     pledge_id = %1
    * Update Pledge Payment Status.
    *
    * @param int $pledgeID
-   *   , id of pledge.
+   *   Id of pledge.
    * @param array $paymentIDs
-   *   , ids of pledge payment(s) to update.
+   *   Ids of pledge payment(s) to update.
    * @param int $paymentStatusID
-   *   , payment status to set.
+   *   Payment status to set.
    * @param int $pledgeStatusID
    *   Pledge status to change (if needed).
    * @param float|int $actualAmount , actual amount being paid
    * @param bool $adjustTotalAmount
-   *   , is amount being paid different from scheduled amount?.
+   *   Is amount being paid different from scheduled amount?.
    * @param bool $isScriptUpdate
-   *   , is function being called from bin script?.
+   *   Is function being called from bin script?.
    *
    * @return int
    *   $newStatus, updated status id (or 0)

--- a/CRM/Pledge/BAO/PledgePayment.php
+++ b/CRM/Pledge/BAO/PledgePayment.php
@@ -688,10 +688,7 @@ WHERE  civicrm_pledge_payment.pledge_id = %1
        {$paymentClause}
 ";
 
-    // get all status
-    $params = array(1 => array($pledgeId, 'Integer'));
-
-    $dao = CRM_Core_DAO::executeQuery($query, $params);
+    CRM_Core_DAO::executeQuery($query, array(1 => array($pledgeId, 'Integer')));
   }
 
   /**
@@ -772,7 +769,8 @@ LIMIT 0, %2
    */
   public static function adjustPledgePayment($pledgeID, $actualAmount, $pledgeScheduledAmount, $paymentContributionId = NULL, $pPaymentId = NULL, $paymentStatusID = NULL) {
     $allStatus = CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name');
-    if ($paymentStatusID == array_search('Cancelled', $allStatus) || $paymentStatusID == array_search('Refunded', $allStatus)) {
+    $paymentStatusName = CRM_Core_PseudoConstant::getName('CRM_Pledge_BAO_PledgePayment', 'status_id', $paymentStatusID);
+    if ($paymentStatusName == 'Cancelled'|| $paymentStatusName == 'Refunded') {
       $query = "
 SELECT civicrm_pledge_payment.id id
 FROM  civicrm_pledge_payment

--- a/CRM/Pledge/BAO/PledgePayment.php
+++ b/CRM/Pledge/BAO/PledgePayment.php
@@ -367,8 +367,9 @@ WHERE     pledge_id = %1
     }
 
     // if payment ids are passed, we update payment table first, since payments statuses are not dependent on pledge status
-    if ((!empty($paymentIDs) || $pledgeStatusID == array_search('Cancelled', $allStatus)) && (!$editScheduled || $isScriptUpdate)) {
-      if ($pledgeStatusID == array_search('Cancelled', $allStatus)) {
+    $pledgeStatusName = CRM_Core_PseudoConstant::getName('CRM_Pledge_BAO_Pledge', 'status_id', $pledgeStatusID);
+    if ((!empty($paymentIDs) || $pledgeStatusName == 'Cancelled') && (!$editScheduled || $isScriptUpdate)) {
+      if ($pledgeStatusName == 'Cancelled') {
         $paymentStatusID = $pledgeStatusID;
       }
 

--- a/CRM/Pledge/BAO/PledgePayment.php
+++ b/CRM/Pledge/BAO/PledgePayment.php
@@ -863,7 +863,7 @@ WHERE civicrm_pledge_payment.contribution_id = {$paymentContributionId}
             // means we are editing payment scheduled payment.
             $oldestPaymentAmount = self::getOldestPledgePayment($pledgeID, 2);
           }
-          $newActualAmount = ($actualAmount - $pledgeScheduledAmount);
+          $newActualAmount = round(($actualAmount - $pledgeScheduledAmount), CRM_Utils_Money::getCurrencyPrecision());
           $newPledgeScheduledAmount = $oldestPayment['amount'];
           if (!$paymentContributionId) {
             $newActualAmount = ($actualAmount - $pledgeScheduledAmount);

--- a/CRM/Utils/Money.php
+++ b/CRM/Utils/Money.php
@@ -125,4 +125,20 @@ class CRM_Utils_Money {
     return strtr($format, $replacements);
   }
 
+  /**
+   * This is a placeholder function for calculating the number of decimal places for a currency.
+   *
+   * Currently code assumes 2 decimal places but some currencies (bitcoin, middle eastern) have
+   * more. By using this function we can signpost the locations where the number of decimal places is
+   * currency specific for future enhancement.
+   *
+   * @param string $currency
+   *
+   * @return int
+   *   Number of decimal places.
+   */
+  public static function getCurrencyPrecision($currency = NULL) {
+    return 2;
+  }
+
 }

--- a/tests/phpunit/CRM/Pledge/BAO/PledgePaymentTest.php
+++ b/tests/phpunit/CRM/Pledge/BAO/PledgePaymentTest.php
@@ -344,4 +344,186 @@ class CRM_Pledge_BAO_PledgePaymentTest extends CiviUnitTestCase {
     $this->assertEquals('20140510000000', $date);
   }
 
+  /**
+   * Test pledge payments that cover multiple pledge installments (CRM-17281).
+   * Check for rounding bugs. NB: this cannot be done in the API, because the
+   * API does not call CRM_Contribute_BAO_Contribution::updateRelatedPledge().
+   */
+  public function testCreatePledgePaymentForMultipleInstallments() {
+    $scheduled_date = date('Ymd', mktime(0, 0, 0, date("m"), date("d") + 2, date("y")));
+    $contact_id = 2;
+
+    $pledge = $this->callAPISuccess('Pledge', 'create', array(
+      'contact_id' => $contact_id,
+      'pledge_create_date' => date('Ymd'),
+      'start_date' => date('Ymd'),
+      'scheduled_date' => $scheduled_date,
+      'amount' => 1618.80,
+      'pledge_status_id' => 2,
+      'pledge_financial_type_id' => 1,
+      'pledge_original_installment_amount' => 134.90,
+      'original_installment_amount' => 134.90,
+      'frequency_interval' => 1,
+      'frequency_unit' => 'month',
+      'frequency_day' => 1,
+      'installments' => 12,
+      'sequential' => 1,
+    ));
+
+    $contributionID = $this->contributionCreate(array(
+      'contact_id' => $contact_id,
+      'financial_type_id' => 1,
+      'invoice_id' => 46,
+      'trxn_id' => 46,
+      'total_amount' => 404.70,
+      'fee_amount' => 0.00,
+      'net_amount' => 404.70,
+      'payment_instrument_id' => 1,
+      'non_deductible_amount' => 0.00,
+    ));
+
+    // Fetch the first planned pledge payment/installment
+    $pledgePayments = civicrm_api3('PledgePayment', 'get', array(
+      'pledge_id' => $pledge['id'],
+      'sequential' => 1,
+    ));
+
+    // Does all sorts of shenanigans if the amount was not the expected amount,
+    // and this is what we really want to test in this function.
+    CRM_Contribute_BAO_Contribution::updateRelatedPledge(
+      CRM_Core_Action::ADD,
+      $pledgePayments['values'][0]['id'],
+      $contributionID,
+      NULL, // adjustTotalAmount
+      404.70,
+      134.90,
+      1, // contribution_status_id
+      NULL // original_contribution_status_id
+    );
+
+    // Fetch the pledge payments again to see if the amounts and statuses
+    // have been updated correctly.
+    $pledgePayments = $this->callAPISuccess('pledge_payment', 'get', array(
+      'pledge_id' => $pledge['id'],
+      'sequential' => 1,
+    ));
+
+    // The status of the first 3 pledges should be set to complete
+    $this->assertEquals($pledgePayments['values'][0]['status_id'], 1);
+    $this->assertEquals($pledgePayments['values'][0]['actual_amount'], 404.70);
+
+    $this->assertEquals($pledgePayments['values'][1]['status_id'], 1);
+    $this->assertEquals($pledgePayments['values'][1]['actual_amount'], 0);
+
+    $this->assertEquals($pledgePayments['values'][2]['status_id'], 1);
+    $this->assertEquals($pledgePayments['values'][2]['actual_amount'], 0);
+
+    // Fourth pledge should still be pending
+    $this->assertEquals($pledgePayments['values'][3]['status_id'], 2);
+
+    // Cleanup
+    civicrm_api3('Pledge', 'delete', array(
+      'id' => $pledge['id'],
+    ));
+  }
+
+  /**
+   * Test pledge payments that cover multiple pledge installments (CRM-17281).
+   * Check for rounding bugs and correct status of the last pledge payment.
+   *
+   * More specifically, in the UI this would be equivalent to creating a $100
+   * pledge to be paid in 11 installments of $8.33 and one installment of $8.37
+   * (to compensate the missing $0.04 from round(100/12)*12.
+   * The API does not allow to do this kind of pledge, because the BAO recalculates
+   * the 'amount' using original_installment_amount * installment.
+   */
+  public function testCreatePledgePaymentForMultipleInstallments2() {
+    $scheduled_date = date('Ymd', mktime(0, 0, 0, date("m"), date("d") + 2, date("y")));
+    $contact_id = 2;
+
+    $params = array(
+      'contact_id' => $contact_id,
+      'pledge_create_date' => date('Ymd'),
+      'start_date' => date('Ymd'),
+      'scheduled_date' => $scheduled_date,
+      'amount' => 100.00,
+      'pledge_status_id' => 2,
+      'pledge_financial_type_id' => 1,
+      'original_installment_amount' => (100 / 12), // the API does not allow this
+      'frequency_interval' => 1,
+      'frequency_unit' => 'month',
+      'frequency_day' => 1,
+      'installments' => 12,
+      'sequential' => 1,
+    );
+
+    $pledge = CRM_Pledge_BAO_Pledge::create($params);
+
+    $contributionID = $this->contributionCreate(array(
+      'contact_id' => $contact_id,
+      'financial_type_id' => 1,
+      'invoice_id' => 47,
+      'trxn_id' => 47,
+      'total_amount' => 100.00,
+      'fee_amount' => 0.00,
+      'net_ammount' => 100.00,
+      'financial_type_id' => 1,
+      'payment_instrument_id' => 1,
+      'non_deductible_amount' => 0.00,
+    ));
+
+    // Fetch the first planned pledge payment/installment
+    $pledgePayments = civicrm_api3('PledgePayment', 'get', array(
+      'pledge_id' => $pledge->id,
+      'sequential' => 1,
+    ));
+
+    // The last pledge payment is 8.37 because 12*8.33 = 99.96
+    // So CiviCRM automatically creates a larger final pledge to catch the missing cents.
+    $last_pp_idx = count($pledgePayments['values']) - 1;
+    $this->assertEquals(8.37, $pledgePayments['values'][$last_pp_idx]['scheduled_amount'], '', 0.01);
+
+    // Does all sorts of shenanigans if the amount was not the expected amount,
+    // and this is what we really want to test in this function.
+    // This tests an old bug where, given a pledge of 100 in 12 installments,
+    // the last pledge payment would have 4¢ left and still be pending.
+    CRM_Contribute_BAO_Contribution::updateRelatedPledge(
+      CRM_Core_Action::ADD,
+      $pledgePayments['values'][0]['id'],
+      $contributionID,
+      NULL, // adjustTotalAmount
+      100.00,
+      100.00,
+      1, // contribution_status_id
+      NULL // original_contribution_status_id
+    );
+
+    // Fetch the pledge payments again to see if the amounts and statuses
+    // have been updated correctly.
+    $pledgePayments = $this->callAPISuccess('pledge_payment', 'get', array(
+      'pledge_id' => $pledge->id,
+      'sequential' => 1,
+    ));
+
+    foreach ($pledgePayments['values'] as $key => $pp) {
+      if ($key == 0) {
+        // First pledge payment has the full amount.
+        $this->assertEquals(8.33, $pp['scheduled_amount']);
+        $this->assertEquals(100.00, $pp['actual_amount']);
+      }
+      else {
+        $this->assertEquals(0, $pp['scheduled_amount']);
+        $this->assertEquals(0, $pp['actual_amount']);
+      }
+
+      // All pledge payments must be set as 'completed'.
+      $this->assertEquals(1, $pp['status_id']);
+    }
+
+    // Cleanup
+    civicrm_api3('Pledge', 'delete', array(
+      'id' => $pledge->id,
+    ));
+  }
+
 }

--- a/tests/phpunit/CRM/Pledge/BAO/PledgePaymentTest.php
+++ b/tests/phpunit/CRM/Pledge/BAO/PledgePaymentTest.php
@@ -466,8 +466,7 @@ class CRM_Pledge_BAO_PledgePaymentTest extends CiviUnitTestCase {
       'trxn_id' => 47,
       'total_amount' => 100.00,
       'fee_amount' => 0.00,
-      'net_ammount' => 100.00,
-      'financial_type_id' => 1,
+      'net_amount' => 100.00,
       'payment_instrument_id' => 1,
       'non_deductible_amount' => 0.00,
     ));


### PR DESCRIPTION
Overview
----------------------------------------
FIX miscalculation of remaining pledge payments when a payment is made that exceeds them and the cent values do not accurately spread over the payments (e.g 12 payments to pay $100)
FROM @mlutfy #9585

Before
----------------------------------------
No test, payment miscalculates remaining payments when a payment is made that pays off multiple payments 


![screenshot 2017-08-15 16 46 36](https://user-images.githubusercontent.com/336308/29335725-9e38f436-81d9-11e7-8170-a053a92cc9c1.png)

After
----------------------------------------
Payments covered are set to zero rather than the overhang value remaining outstanding

Technical Details
----------------------------------------
Note that we added a placeholder function for the number of decimal places a payment can be in, rather than hard-coding it.

Comments
----------------------------------------

---

 * [CRM-17281: Pledges miscalculate when total amount is not an integer and a payment is received that covers three installments](https://issues.civicrm.org/jira/browse/CRM-17281)