### PR TITLE
Fix CRM-21058: Add support for events to Personal Campaign Page Report.

### DIFF
--- a/CRM/Report/Form/Contribute/PCP.php
+++ b/CRM/Report/Form/Contribute/PCP.php
@@ -73,10 +73,12 @@ class CRM_Report_Form_Contribute_PCP extends CRM_Report_Form {
       ),
       'civicrm_contribution_page' => array(
         'dao' => 'CRM_Contribute_DAO_ContributionPage',
+        'alias' => 'cp',
         'fields' => array(
           'page_title' => array(
-            'title' => ts('Contribution Page Title'),
+            'title' => ts('Page Title'),
             'name' => 'title',
+            'dbAlias' => 'coalesce(cp_civireport.title, e_civireport.title)',
             'default' => TRUE,
           ),
         ),
@@ -89,12 +91,27 @@ class CRM_Report_Form_Contribute_PCP extends CRM_Report_Form {
         ),
         'grouping' => 'pcp-fields',
       ),
+      'civicrm_event' => array(
+        'alias' => 'e',
+        'filters' => array(
+          'event_title' => array(
+            'title' => ts('Event Title'),
+            'name' => 'title',
+            'type' => CRM_Utils_Type::T_STRING,
+          ),
+        ),
+        'grouping' => 'pcp-fields',
+      ),
       'civicrm_pcp' => array(
         'dao' => 'CRM_PCP_DAO_PCP',
         'fields' => array(
           'title' => array(
             'title' => ts('Personal Campaign Title'),
             'default' => TRUE,
+          ),
+          'page_type' => array(
+            'title' => ts('Page Type'),
+            'default' => FALSE,
           ),
           'goal_amount' => array(
             'title' => ts('Goal Amount'),
@@ -207,7 +224,13 @@ LEFT JOIN civicrm_contact {$this->_aliases['civicrm_contact']}
 
 LEFT JOIN civicrm_contribution_page {$this->_aliases['civicrm_contribution_page']}
           ON {$this->_aliases['civicrm_pcp']}.page_id =
-             {$this->_aliases['civicrm_contribution_page']}.id";
+             {$this->_aliases['civicrm_contribution_page']}.id
+               AND {$this->_aliases['civicrm_pcp']}.page_type = 'contribute'
+
+LEFT JOIN civicrm_event {$this->_aliases['civicrm_event']}
+          ON {$this->_aliases['civicrm_pcp']}.page_id =
+             {$this->_aliases['civicrm_event']}.id
+               AND {$this->_aliases['civicrm_pcp']}.page_type = 'event'";
 
     // for credit card type
     $this->addFinancialTrxnFromClause();
@@ -378,6 +401,11 @@ LEFT JOIN civicrm_contribution_page {$this->_aliases['civicrm_contribution_page'
 
       if (!empty($row['civicrm_financial_trxn_card_type_id'])) {
         $rows[$rowNum]['civicrm_financial_trxn_card_type_id'] = $this->getLabels($row['civicrm_financial_trxn_card_type_id'], 'CRM_Financial_DAO_FinancialTrxn', 'card_type_id');
+        $entryFound = TRUE;
+      }
+
+      if (!empty($row['civicrm_pcp_page_type'])) {
+        $rows[$rowNum]['civicrm_pcp_page_type'] = ucfirst($rows[$rowNum]['civicrm_pcp_page_type']);
         $entryFound = TRUE;
       }
 


### PR DESCRIPTION
Overview
----------------------------------------

Fix for CRM-21058.

Since PCP can now be associated with Events, this PR adds the filter for Event Title alongside the filter for Contribution Page Title. It also renames the column "Contribution Page Title" to "Page Title" and adds a new column, "Page Type," which will say either "Event" or "Contribution".

Before
----------------------------------------
![before_columns](https://user-images.githubusercontent.com/759449/29332882-387c3f7a-81c7-11e7-845f-1bdba77c2b54.png)
![before_filters](https://user-images.githubusercontent.com/759449/29332886-3ceea2a0-81c7-11e7-8ab4-9a7de5aca4d3.png)



After
----------------------------------------
![columns](https://user-images.githubusercontent.com/759449/29332736-ae326cfe-81c6-11e7-9ded-be9f49e844e4.png)
![filters](https://user-images.githubusercontent.com/759449/29332745-b308c80e-81c6-11e7-9c04-e51824f7f0c7.png)


Technical Details
----------------------------------------
Nothing noteworthy.

Comments
----------------------------------------
None.

---

 * [CRM-21058: Add Event filter to PCP contribution report](https://issues.civicrm.org/jira/browse/CRM-21058)