### PR TITLE
CRM-21068 - getLastModified fails more gracefully now.

### DIFF
--- a/CRM/Core/BAO/Log.php
+++ b/CRM/Core/BAO/Log.php
@@ -42,6 +42,7 @@ class CRM_Core_BAO_Log extends CRM_Core_DAO_Log {
    * @param string $table
    *
    * @return array|null
+   *
    */
   public static function &lastModified($id, $table = 'civicrm_contact') {
 
@@ -51,9 +52,11 @@ class CRM_Core_BAO_Log extends CRM_Core_DAO_Log {
     $log->entity_id = $id;
     $log->orderBy('modified_date desc');
     $log->limit(1);
-    $result = NULL;
+    $displayName = $result = $contactImage = NULL;
     if ($log->find(TRUE)) {
-      list($displayName, $contactImage) = CRM_Contact_BAO_Contact::getDisplayAndImage($log->modified_id);
+      if ($log->modified_id) {
+        list($displayName, $contactImage) = CRM_Contact_BAO_Contact::getDisplayAndImage($log->modified_id);
+      }
       $result = array(
         'id' => $log->modified_id,
         'name' => $displayName,


### PR DESCRIPTION
Overview
----------------------------------------
_This helps resolve some errors when trying to view contacts._

Before
----------------------------------------
_Without this change, there were cases were some contacts were throwing Not Of Type Integer errors in the Contact Summary view (from getDisplayAndImage)._

After
----------------------------------------
_This change makes the getLastModified fail more gracefully, so it doesn't display an error if something is missing for a contact when getDisplayAndImage is called from the Summary View._

Technical Details
----------------------------------------


Comments
----------------------------------------


---

 * [CRM-21068: &lastModified\(\) fails more gracefully.](https://issues.civicrm.org/jira/browse/CRM-21068)