### PR TITLE
CRM-20892: Prevent cross-editing of mailings between multiple browser/tab instances

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1734,9 +1734,15 @@ ORDER BY   civicrm_email.is_bulkmail DESC
             $changeCountDB = $dao->change_count;
         }
         
-        //The browser has made a new change so it should be one ahead of the DB.
-        if ($changeCountDB != ($params['change_count']-1)) {
-            throw new CRM_Core_Exception("Unable to save changes. This mailing is already being changed in another window");
+        //If the change_count in the DB is 0, it has been reset by a continue operation.
+        //Do not throw an exception in this case, and just let the DB's change_count sync again
+        //with the browser's
+        if ($changeCountDB != 0)
+        {
+            //The browser has made a new change so it should be one ahead of the DB.
+            if ($changeCountDB != ($params['change_count']-1)) {
+                throw new CRM_Core_Exception("Unable to save changes. This mailing is already being changed in another window");
+            }
         }
     }
     

--- a/CRM/Mailing/Controller/Send.php
+++ b/CRM/Mailing/Controller/Send.php
@@ -60,6 +60,11 @@ class CRM_Mailing_Controller_Send extends CRM_Core_Controller {
       }
       else {
         $redirect = CRM_Utils_System::url('civicrm/a/', NULL, TRUE, '/mailing/' . $mid);
+        
+        //When continuing to edit an existing mailing, we need to reset the last_modified 
+        //stored in the DB to keep it in sync with the browser's value (See CRM-20892)
+        $query = "UPDATE `civicrm_mailing` SET `last_modified` = '0' WHERE `civicrm_mailing`.`id` = " . $mid;
+        $dao = CRM_Core_DAO::executeQuery($query);
       }
       CRM_Utils_System::redirect($redirect);
     }

--- a/CRM/Mailing/Controller/Send.php
+++ b/CRM/Mailing/Controller/Send.php
@@ -60,6 +60,12 @@ class CRM_Mailing_Controller_Send extends CRM_Core_Controller {
       }
       else {
         $redirect = CRM_Utils_System::url('civicrm/a/', NULL, TRUE, '/mailing/' . $mid);
+        
+        //When continuing to edit an existing mailing, we need to reset the change_count stored in 
+        //the DB to keep it in sync with the browser's change count, which will start again at 0 
+        //(See CRM-20892)
+        $query = "UPDATE `civicrm_mailing` SET `change_count` = '0' WHERE `civicrm_mailing`.`id` = " . $mid;
+        $dao = CRM_Core_DAO::executeQuery($query);
       }
       CRM_Utils_System::redirect($redirect);
     }

--- a/CRM/Mailing/DAO/Mailing.php
+++ b/CRM/Mailing/DAO/Mailing.php
@@ -908,6 +908,17 @@ class CRM_Mailing_DAO_Mailing extends CRM_Core_DAO {
             'optionEditPath' => 'civicrm/admin/options/languages',
           )
         ) ,
+        //For issue CRM-20892
+        'change_count' => array(
+          'name' => 'change_count',
+          'type' => CRM_Utils_Type::T_INT,
+          'title' => ts('Mailing Change Count') ,
+          'required' => true,
+          'table_name' => 'civicrm_mailing',
+          'entity' => 'Mailing',
+          'bao' => 'CRM_Mailing_BAO_Mailing',
+          'localizable' => 0,
+        ) ,
       );
       CRM_Core_DAO_AllCoreTables::invoke(__CLASS__, 'fields_callback', Civi::$statics[__CLASS__]['fields']);
     }

--- a/CRM/Mailing/DAO/Mailing.php
+++ b/CRM/Mailing/DAO/Mailing.php
@@ -300,6 +300,12 @@ class CRM_Mailing_DAO_Mailing extends CRM_Core_DAO {
    */
   public $language;
   /**
+   * Number of times the browser has changed the mailing
+   *
+   * @var int unsigned
+   */
+  public $change_count;
+  /**
    * Class constructor.
    */
   function __construct() {

--- a/CRM/Mailing/DAO/Mailing.php
+++ b/CRM/Mailing/DAO/Mailing.php
@@ -300,8 +300,14 @@ class CRM_Mailing_DAO_Mailing extends CRM_Core_DAO {
    */
   public $language;
   /**
-   * Class constructor.
+   * Who last modified this mailing? Prevents cross-editing between browser instances.
+   *
+   * @var int unsigned
    */
+  public $last_modified;
+    /**
+    * Class constructor.
+    */
   function __construct() {
     $this->__table = 'civicrm_mailing';
     parent::__construct();
@@ -907,6 +913,18 @@ class CRM_Mailing_DAO_Mailing extends CRM_Core_DAO {
             'keyColumn' => 'name',
             'optionEditPath' => 'civicrm/admin/options/languages',
           )
+        ) ,
+        //For issue CRM-20892
+        'last_modified' => array(
+          'name' => 'last_modified',
+          'type' => CRM_Utils_Type::T_INT,
+          'title' => ts('Who Last Modified Mailing?') ,
+          'description' => 'Who last modified this mailing?',
+          'required' => true,
+          'table_name' => 'civicrm_mailing',
+          'entity' => 'Mailing',
+          'bao' => 'CRM_Mailing_BAO_Mailing',
+          'localizable' => 0,
         ) ,
       );
       CRM_Core_DAO_AllCoreTables::invoke(__CLASS__, 'fields_callback', Civi::$statics[__CLASS__]['fields']);

--- a/CRM/Upgrade/Incremental/sql/4.7.25.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.7.25.mysql.tpl
@@ -5,3 +5,9 @@ ADD COLUMN `module_data` text    COMMENT 'All other menu metadata not stored in 
 
 --CRM-21061 Increase report_id size from 64 to 512 to match civicrm_option_value.value column
 ALTER TABLE civicrm_report_instance CHANGE COLUMN report_id report_id varchar(512) COMMENT 'FK to civicrm_option_value for the report template';
+
+--CRM-20892 Add a last_modified field to prevent cross-editing between browser instances
+ALTER TABLE `civicrm_mailing`
+ADD COLUMN `last_modified` INT( 10 ) UNSIGNED NOT NULL DEFAULT '0' COMMENT 'Who last modified this mailing?';
+
+

--- a/ang/crmMailing/services.js
+++ b/ang/crmMailing/services.js
@@ -95,6 +95,7 @@
   // The crmMailingMgr service provides business logic for loading, saving, previewing, etc
   angular.module('crmMailing').factory('crmMailingMgr', function ($q, crmApi, crmFromAddresses, crmQueue) {
     var qApi = crmQueue(crmApi);
+    var saveCount = 0;
     var pickDefaultMailComponent = function pickDefaultMailComponent(type) {
       var mcs = _.where(CRM.crmMailing.headerfooterList, {
         component_type: type,
@@ -339,7 +340,13 @@
             mailing[key] = '';
           }
         });
-
+        
+        //CRM-20892: Keep track of the amount of times this browser instance requests a change to a
+        //mailing and store it in the DB in the change_count field. This will be used to prevent
+        //cross-editing between multiple open browsers/tabs editing the same mailing.
+        saveCount++;
+        params.change_count = saveCount;
+        
         // WORKAROUND: Mailing.create (aka CRM_Mailing_BAO_Mailing::create()) interprets scheduled_date
         // as an *intent* to schedule and creates tertiary records. Saving a draft with a scheduled_date
         // is therefore not allowed. Remove this after fixing Mailing.create's contract.

--- a/ang/crmMailing/services.js
+++ b/ang/crmMailing/services.js
@@ -95,7 +95,9 @@
   // The crmMailingMgr service provides business logic for loading, saving, previewing, etc
   angular.module('crmMailing').factory('crmMailingMgr', function ($q, crmApi, crmFromAddresses, crmQueue) {
     var qApi = crmQueue(crmApi);
-    var saveCount = 0;
+    //CRM-20892: If the change_count is based on the number seconds since the epoch, it will
+    //always be unique between browser instances if we only increment the counter by one each change
+    var saveCount = Math.floor(Date.now() / 1000);
     var pickDefaultMailComponent = function pickDefaultMailComponent(type) {
       var mcs = _.where(CRM.crmMailing.headerfooterList, {
         component_type: type,
@@ -372,6 +374,7 @@
         var crmMailingMgr = this;
         var params = {
           id: mailing.id,
+          change_count: saveCount+1,
           approval_date: 'now',
           scheduled_date: mailing.scheduled_date ? mailing.scheduled_date : 'now'
         };

--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -150,6 +150,7 @@ function _civicrm_api3_mailing_create_spec(&$params) {
   $params['reply_id']['api.default'] = CRM_Mailing_PseudoConstant::defaultComponent('Reply', '');
   $params['resubscribe_id']['api.default'] = CRM_Mailing_PseudoConstant::defaultComponent('Resubscribe', '');
   $params['unsubscribe_id']['api.default'] = CRM_Mailing_PseudoConstant::defaultComponent('Unsubscribe', '');
+  $params['change_count']['api.default'] = 0;
   $params['mailing_type']['api.default'] = 'standalone';
   $defaultAddress = CRM_Core_OptionGroup::values('from_email_address', NULL, NULL, NULL, ' AND is_default = 1');
   foreach ($defaultAddress as $value) {

--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -301,6 +301,7 @@ function civicrm_api3_mailing_submit($params) {
 
   $updateParams = array();
   $updateParams['id'] = $params['id'];
+  $updateParams['change_count'] = $params['change_count'];
 
   // Note: we'll pass along scheduling/approval fields, but they may get ignored
   // if we don't have permission.

--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -150,6 +150,7 @@ function _civicrm_api3_mailing_create_spec(&$params) {
   $params['reply_id']['api.default'] = CRM_Mailing_PseudoConstant::defaultComponent('Reply', '');
   $params['resubscribe_id']['api.default'] = CRM_Mailing_PseudoConstant::defaultComponent('Resubscribe', '');
   $params['unsubscribe_id']['api.default'] = CRM_Mailing_PseudoConstant::defaultComponent('Unsubscribe', '');
+  $params['last_modified']['api.default'] = 0;
   $params['mailing_type']['api.default'] = 'standalone';
   $defaultAddress = CRM_Core_OptionGroup::values('from_email_address', NULL, NULL, NULL, ' AND is_default = 1');
   foreach ($defaultAddress as $value) {
@@ -300,6 +301,7 @@ function civicrm_api3_mailing_submit($params) {
 
   $updateParams = array();
   $updateParams['id'] = $params['id'];
+  $updateParams['last_modified'] = $params['last_modified'];
 
   // Note: we'll pass along scheduling/approval fields, but they may get ignored
   // if we don't have permission.

--- a/xml/schema/Mailing/Mailing.xml
+++ b/xml/schema/Mailing/Mailing.xml
@@ -487,4 +487,12 @@
       <type>Select</type>
     </html>
   </field>
+  <field>
+    <name>last_modified</name>
+    <title>Who Last Modified Mailing?</title>
+    <type>int unsigned</type>
+    <required>true</required>
+    <comment>Who last modified this mailing?</comment>
+    <default>0</default>
+  </field>
 </table>


### PR DESCRIPTION
Overview
----------------------------------------
CRM-20892: Prevent cross-editing of mailings between multiple browser/tab instances

Before
----------------------------------------
When the same mailing is open in two different tabs, changes from one can overwrite changes from the other even if the mailing has been submitted!

Steps to recreate:
1) On Tab A: Create a new mailing, add a name, title, recipients, subject and some text. Then click Save Draft or wait until an autosave. Click next, schedule the mailing and submit it.
2) Copy the URL of the mailing, paste it into a new tab (B)
3) On tab B: Change the mailing parameters and click Save Draft or wait for an autosave.
4) Notice the parameters in the database coincide with step 3, those in step 2 were overwritten
  
This can happen with multiple tabs on the same PC, or different users on different PCs (if two people end up working on the same mailing).

After
----------------------------------------
Add a new column `last_modified` to the civicrm_mailing table in the DB to keep track of the last browser instance to change the DB. This id will be based on the number of seconds since the epoch at the time the mailing was created or continued to ensure that it is always unique.

Each browser instance keeps its own unique last modified ID as described above. When a change is made in a browser instance, before it is saved to the DB check if the browser's ID matches that stored in the database for that mailing. If they do not match, bock the change and throw an appropriate error message.

Technical Details
----------------------------------------
Add `last_modified` column to the `civicrm_mailing` table in mysql incremental upgrade file for version 4.7.25


Comments
----------------------------------------
None

---

 * [CRM-20892: Same mailing open in two windows can overwrite data on scheduled mailings](https://issues.civicrm.org/jira/browse/CRM-20892)