### PR TITLE
CRM-21069 Fix crash when event_id is not set

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1088,7 +1088,7 @@ FROM   civicrm_domain
       empty($searchValue) ||
       trim(strtolower($searchValue)) == 'null'
     ) {
-      // adding this year since developers forget to check for an id
+      // adding this here since developers forget to check for an id
       // or for the 'null' (which is a bad DAO kludge)
       // and hence we get the first value in the db
       CRM_Core_Error::fatal();

--- a/CRM/Event/Selector/Search.php
+++ b/CRM/Event/Selector/Search.php
@@ -342,6 +342,11 @@ class CRM_Event_Selector_Search extends CRM_Core_Selector_Base implements CRM_Co
         }
       }
 
+      // Skip registration if event_id is NULL
+      if (empty($row['event_id'])) {
+        continue;
+      }
+
       //carry campaign on selectors.
       $row['campaign'] = CRM_Utils_Array::value($result->participant_campaign_id, $allCampaigns);
       $row['campaign_id'] = $result->participant_campaign_id;

--- a/CRM/Event/Selector/Search.php
+++ b/CRM/Event/Selector/Search.php
@@ -344,6 +344,7 @@ class CRM_Event_Selector_Search extends CRM_Core_Selector_Base implements CRM_Co
 
       // Skip registration if event_id is NULL
       if (empty($row['event_id'])) {
+        Civi::log()->warning('Participant record without event ID. You have invalid data in your database!');
         continue;
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
If the user has an event registration but the event has been deleted CiviCRM crashes with a CRM_Core_Error::fatal because the event search still tries to lookup the event details.  This patch checks the event_id is set, and skips the registration if it is not.

Before
----------------------------------------
CiviCRM crashes with CRM_Core_Error::fatal()

After
----------------------------------------
CiviCRM shows all event registrations that have valid events.

Technical Details
----------------------------------------
It is unlikely to happen unless data has been modified directly in the database.

---

 * [CRM-21069: Check event ID exists before calling CRM_Event_BAO_Event::isMonetary](https://issues.civicrm.org/jira/browse/CRM-21069)