### PR TITLE
(NFC) SettingsStack - Add test coverage for new helper class

### DIFF
--- a/Civi/Core/SettingsStack.php
+++ b/Civi/Core/SettingsStack.php
@@ -4,7 +4,12 @@ namespace Civi\Core;
 /**
  * Class SettingsStack
  *
- * The settings stack allows you to temporarily apply settings.
+ * The settings stack allows you to temporarily change (then restore) settings. It's intended
+ * primarily for use in testing.
+ *
+ * Like the global `$civicrm_setting` variable, it works best with typical inert settings that
+ * do not trigger extra activation logic. A handful of settings (such as `enable_components`
+ * and ~5 others)
  *
  * @package Civi\Core
  */

--- a/tests/phpunit/Civi/Core/SettingsStackTest.php
+++ b/tests/phpunit/Civi/Core/SettingsStackTest.php
@@ -1,0 +1,33 @@
+<?php
+namespace Civi\Core;
+
+class SettingsStackTest extends \CiviUnitTestCase {
+
+  protected function setUp() {
+    parent::setUp();
+    $this->useTransaction(TRUE);
+  }
+
+  public function tearDown() {
+    parent::tearDown();
+  }
+
+  /**
+   * Temporarily modify -- then restore -- settings.
+   */
+  public function testStack() {
+    $origVal = \Civi::settings()->get('show_events');
+
+    $settingsStack = new \Civi\Core\SettingsStack();
+
+    $settingsStack->push('show_events', 9);
+    $this->assertEquals(9, \Civi::settings()->get('show_events'));
+
+    $settingsStack->push('show_events', 8);
+    $this->assertEquals(8, \Civi::settings()->get('show_events'));
+
+    $settingsStack->popAll();
+    $this->assertEquals($origVal, \Civi::settings()->get('show_events'));
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
The `SettingsStack` class was recently added as a helper for another unit-test, but it
didn't have its own coverage.  This is a quick/simple test for it.

Before
----------------------------------------
Does not have unit-test.

After
----------------------------------------
Does have unit-test.