### PR TITLE
CRM-21076 - ACL Role Assignments aren't browseable

### DIFF
--- a/CRM/ACL/Page/EntityRole.php
+++ b/CRM/ACL/Page/EntityRole.php
@@ -121,6 +121,7 @@ class CRM_ACL_Page_EntityRole extends CRM_Core_Page_Basic {
 
     // finally browse the acl's
     if ($this->_action & CRM_Core_Action::BROWSE) {
+      $this->browse();
     }
 
     // This replaces parent run, but do parent's parent run


### PR DESCRIPTION
Overview
----------------------------------------
In Civi 4.7.23, a PR (#10068) caused ACL Role Assignments to not appear.

Before
----------------------------------------
![selection_214](https://user-images.githubusercontent.com/1796012/29423375-84733342-8349-11e7-812f-8f4b855b2351.png)


After
----------------------------------------
![selection_215](https://user-images.githubusercontent.com/1796012/29423380-8a83efa6-8349-11e7-8d94-8d56b7bea61e.png)

---

 * [CRM-21076: Can't view\/edit ACL Role Assignments](https://issues.civicrm.org/jira/browse/CRM-21076)