### PR TITLE
CRM-21077 Add warning when CIVICRM_MAIL_LOG is set and you are testing outbound…

### DIFF
--- a/CRM/Admin/Form/Setting/Smtp.php
+++ b/CRM/Admin/Form/Setting/Smtp.php
@@ -166,7 +166,10 @@ class CRM_Admin_Form_Setting_Smtp extends CRM_Admin_Form_Setting {
         $errorScope = CRM_Core_TemporaryErrorScope::ignoreException();
         $result = $mailer->send($toEmail, $headers, $message);
         unset($errorScope);
-        if (!is_a($result, 'PEAR_Error')) {
+        if (defined('CIVICRM_MAIL_LOG')) {
+          CRM_Core_Session::setStatus($testMailStatusMsg . ts('You have defined CIVICRM_MAIL_LOG - no mail will be sent.  Your %1 settings have not been tested.', array(1 => strtoupper($mailerName))), ts("Mail not sent"), "warning");
+        }
+        elseif (!is_a($result, 'PEAR_Error')) {
           CRM_Core_Session::setStatus($testMailStatusMsg . ts('Your %1 settings are correct. A test email has been sent to your email address.', array(1 => strtoupper($mailerName))), ts("Mail Sent"), "success");
         }
         else {


### PR DESCRIPTION
… mail settings

Overview
----------------------------------------
When the environment variable CIVICRM_MAIL_LOG is set CiviCRM won't try to send mail via any of the methods, but it will return success indicating that it did send mail.  Normally that's fine, except when you forget you've got that configured (or didn't realise - buildkit does it by default).  With this patch, when testing outbound email settings you will get a warning message if CIVICRM_MAIL_LOG is set so you don't scratch your head for ages wondering why email is not being sent out!