### PR TITLE
Bring 4.7.23 Release notes into 4.7.24

### DIFF
--- a/contributor-key.yml
+++ b/contributor-key.yml
@@ -46,6 +46,9 @@
   name        : Andrew Thompson
   jira        : andrewpthompson
 
+- name        : F. M. Andrimont
+  jira        : andrimont
+
 - github      : anthonylindsay
   name        : Anthony Lindsay
   organization: Annertech
@@ -54,6 +57,10 @@
 - github      : arborrow
   name        : Anthony Borrow
   jira        : arborrow
+
+- github      : AronNovakInovae
+  name        : Aron Novak
+  organization: Gizra
 
 - github      : artem3
   name        : Artem Goncharenko
@@ -136,6 +143,7 @@
 
 - github      : davialexandre
   name        : Davi Alexandre
+  organization: CompuCorp
   jira        : davialexandre
 
 - github      : davidjosephhayes
@@ -189,6 +197,10 @@
   organization: dotPro
   jira        : diegov
 
+- name        : Dina London
+  organization: Jvillage Network
+  jira        : dinalondon
+
 - github      : dvhirst
   name        : Donald Hirst
   jira        : dvhirst
@@ -202,6 +214,11 @@
   name        : Eileen McNaughton
   organization: Fuzion
   jira        : eileen
+
+- github      : ejegg
+  name        : Elliott Eggleston
+  organization: Wikimedia Foundation
+  jira        : ejegg
 
 - github      : elisseck
   name        : Eli Lisseck
@@ -363,6 +380,9 @@
   name        : John Kingsnorth
   jira        : john
 
+- github      : JO0st
+  name        : Joost Fock
+
 - github      : JoeMurray
   name        : Joe Murray
   organization: JMA Consulting
@@ -435,6 +455,11 @@
   name        : Kurund Jalmi
   organization: Web Access
   jira        : kurund
+
+- github      : laryn
+  name        : Laryn Kragt Bakker
+  organization: CEDC
+  jira        : lpkb
 
 - github      : lcdservices
   name        : Brian Shaughnessy
@@ -581,6 +606,13 @@
   name        : Pawel Nowak
   jira        : pnowak
 
+- name        : Peter Bull
+  jira        : peter39
+
+- github      : philmck
+  name        : Phil McKerracher
+  jira        : philmck
+
 - name        : René Nieuwburg
   organization: Comunica2
   jira        : ñull
@@ -606,8 +638,9 @@
 - name        : Dennis Gray
   jira        : ozyank
 
-- github      : PalanteJon
+- github      : MegaphoneJon
   name        : Jon Goldberg
+  organization: Megaphone Technology Consulting
   jira        : palantejon
 
 - name        : Patrick Corbett
@@ -717,6 +750,10 @@
   name        : Stephen Palmstrom
   jira        : spalmstr
 
+- github      : spencerbrooks
+  name        : Spencer Brooks
+  organization: Brooks Digital
+
 - github      : sqweets
   name        : Ellen Hendricks
   organization: Spry Digital
@@ -759,6 +796,9 @@
 - name        : Thomas Mannell
   organization: Registered Nurses' Association of Ontario
   jira        : tom.m
+
+- name        : Torrance Hodgson
+  jira        : torrance123
 
 - github      : totten
   name        : Tim Otten

--- a/contributor-key.yml
+++ b/contributor-key.yml
@@ -185,6 +185,10 @@
   organization: Nubay Services
   jira        : dtarrant
 
+- name        : Diego Viegas
+  organization: dotPro
+  jira        : diegov
+
 - github      : dvhirst
   name        : Donald Hirst
   jira        : dvhirst
@@ -487,6 +491,11 @@
   organization: Minnesota Association of Veterinary Technicians
   jira        : membership
 
+- github      : mepps
+  name        : Maggie Epps
+  organization: Wikimedia Foundation
+  jira        : mepps
+
 - github      : mfb
   name        : Mark Burdett
   organization: Electronic Frontier Foundation
@@ -526,6 +535,10 @@
   name        : Camilo Rodriguez
   organization: CompuCorp
   jira        : Miya27
+
+- name        : Michael Lueck
+  organization: Lueck Data Systems
+  jira        : mdlueck
 
 - github      : mlutfy
   name        : Mathieu Lutfy

--- a/release-notes.md
+++ b/release-notes.md
@@ -14,6 +14,14 @@ Other resources for identifying changes are:
     * https://github.com/civicrm/civicrm-joomla
     * https://github.com/civicrm/civicrm-wordpress
 
+## CiviCRM 4.7.23
+
+Released August 2, 2017
+
+- **[Features](4.7.23.md#features)**
+- **[Bugs resolved](4.7.23.md#bugs)**
+- **[Miscellany](4.7.23.md#misc)**
+- **[Credits](4.7.23.md#credits)**
 
 ## CiviCRM 4.7.22
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -18,16 +18,17 @@ Other resources for identifying changes are:
 
 Released August 2, 2017
 
-- **[Features](4.7.23.md#features)**
-- **[Bugs resolved](4.7.23.md#bugs)**
-- **[Miscellany](4.7.23.md#misc)**
-- **[Credits](4.7.23.md#credits)**
+- **[Features](release-notes/4.7.23.md#features)**
+- **[Bugs resolved](release-notes/4.7.23.md#bugs)**
+- **[Miscellany](release-notes/4.7.23.md#misc)**
+- **[Credits](release-notes/4.7.23.md#credits)**
 
 ## CiviCRM 4.7.22
 
 Released July 12, 2017
 
 - **[Bugs resolved](release-notes/4.7.22.md#bugs)**
+- **[Credits](release-notes/4.7.22.md#credits)**
 
 ## CiviCRM 4.7.21
 

--- a/release-notes/4.7.22.md
+++ b/release-notes/4.7.22.md
@@ -3,6 +3,7 @@
 Released July 12, 2017
 
 - **[Bugs resolved](#bugs)**
+- **[Credits](#credits)**
 
 ## <a name="bugs"></a>Bugs resolved
 
@@ -43,3 +44,19 @@ Released July 12, 2017
 
 - **CiviCRM-related warning when saving Backdrop permissions page
   ([23](https://github.com/civicrm/civicrm-backdrop/issues/23))**
+
+## <a name="credits"></a>Credits
+
+This release was developed by the following code authors:
+
+Australian Greens - Seamus Lee; Circle Interactive - Dave Jenkins; CiviCRM - Tim
+Otten; Freeform Solutions - Herb van den Dool; Fuzion - Jitendra Purohit;
+Wikimedia Foundation - Maggie Epps
+
+Most authors also reviewed code for this release; in addition, the following
+reviewers contributed their comments:
+
+Coop SymbioTIC - Mathieu Lutfy; dotPro - Diego Viegas; Fuzion - Chris Burgess,
+Peter Davis; JMA Consulting - Joe Murray, Monish Deb; Lueck Data Systems -
+Michael Lueck; Tadpole Collective - Kevin Cristiano; Wikimedia Foundation -
+Eileen McNaughton

--- a/release-notes/4.7.23.md
+++ b/release-notes/4.7.23.md
@@ -2,10 +2,14 @@
 
 Released August 2, 2017
 
+- **[Synopsis](#synopsis)**
 - **[Features](#features)**
 - **[Bugs resolved](#bugs)**
 - **[Miscellany](#misc)**
 - **[Credits](#credits)**
+- **[Feedback](#feedback)**
+
+## <a name="synopsis"></a>Synopsis
 
 | Does this version                                               |         |
 |:--------------------------------------------------------------- |:-------:|
@@ -667,3 +671,9 @@ Mitchell; Nathan Brettell; Oxfam Germany - Thomas Schüttler; Peter Bull; Phil
 McKerracher; Semper IT - Karin Gerritsen; Skvare - Mark Hanna; Stephen
 Palmstrom; Tadpole Collective - Kevin Cristiano; Upleaf - Osvaldo Gomez;
 Wikimedia Foundation - Elliott Eggleston
+
+## <a name="feedback"></a>Feedback
+
+These release notes have been made possible by the diligent curation of Andrew Hunt.
+If you'd like to provide feedback on them, please login to https://chat.civicrm.org/civicrm
+and contact `@agh1`.

--- a/release-notes/4.7.23.md
+++ b/release-notes/4.7.23.md
@@ -1,6 +1,6 @@
 # CiviCRM 4.7.23
 
-Released August 2, 2017;
+Released August 2, 2017
 
 - **[Features](#features)**
 - **[Bugs resolved](#bugs)**
@@ -10,7 +10,7 @@ Released August 2, 2017;
 | Does this version                                               |         |
 |:--------------------------------------------------------------- |:-------:|
 | fix security vulnerabilities?                                   | no      |
-| change the database schema?                                     | no      |
+| **change the database schema?**                                 | **yes** |
 | **alter the API?**                                              | **yes** |
 | **require attention to configuration options?**                 | **yes** |
 | **fix problems installing or upgrading to a previous version?** | **yes** |
@@ -115,6 +115,13 @@ Released August 2, 2017;
 
 ### CiviCase
 
+- **[CRM-19778](https://issues.civicrm.org/jira/browse/CRM-19778) Allowed
+  statuses per case-type
+  ([10552](https://github.com/civicrm/civicrm-core/pull/10552))**
+
+  The available options in the API for case status can now be filtered to those
+  appropriate for a given case type.
+
 - **[CRM-20794](https://issues.civicrm.org/jira/browse/CRM-20794) Colors for
   case status ([10586](https://github.com/civicrm/civicrm-core/pull/10586))
   (preliminary work)**
@@ -169,6 +176,11 @@ Released August 2, 2017;
 
   The backend add membership form now has a link to the backend credit card
   membership form.
+
+### Backdrop Integration
+
+- **Port of civicrm_engage to Backdrop
+  ([28](https://github.com/civicrm/civicrm-backdrop/pull/28))**
 
 ### Drupal Integration
 
@@ -225,121 +237,86 @@ Released August 2, 2017;
   contacts with deceased_date not setting is_deceased
   ([10742](https://github.com/civicrm/civicrm-core/pull/10742))**
 
-- **[CRM-20848](https://issues.civicrm.org/jira/browse/CRM-20848) Upgrade to 4.7.19 sets price_field to inactive if default Financial Types are disabled ([10675](https://github.com/civicrm/civicrm-core/pull/10675))**
+- **[CRM-20871](https://issues.civicrm.org/jira/browse/CRM-20871) crmUiSelect
+  fails to update when model changes
+  ([10659](https://github.com/civicrm/civicrm-core/pull/10659))**
 
-- **Clear all Messages when running clearMessages by default ([10669](https://github.com/civicrm/civicrm-core/pull/10669))**
+- **[CRM-20809](https://issues.civicrm.org/jira/browse/CRM-20809) Move
+  extensions cache from $extensionsDir to $uploadDir
+  ([10604](https://github.com/civicrm/civicrm-core/pull/10604))**
 
-- **[CRM-20857](https://issues.civicrm.org/jira/browse/CRM-20857) Deferred Revenue report -  DB Error: unknown error ([10646](https://github.com/civicrm/civicrm-core/pull/10646))**
+  Cached data about extensions was stored in the extensions directory, which may
+  not be an appropriate place and may not be writable.  It is now stored in the
+  upload directory.
 
-- **[CRM-20871](https://issues.civicrm.org/jira/browse/CRM-20871) crmUiSelect fails to update when model changes ([10659](https://github.com/civicrm/civicrm-core/pull/10659))**
+- **[CRM-20828](https://issues.civicrm.org/jira/browse/CRM-20828) Saved field
+  mappings drop down is limited to 1
+  ([10615](https://github.com/civicrm/civicrm-core/pull/10615))**
 
-- **[CRM-20867](https://issues.civicrm.org/jira/browse/CRM-20867) Class not found ([10656](https://github.com/civicrm/civicrm-core/pull/10656))**
+- **[CRM-20509](https://issues.civicrm.org/jira/browse/CRM-20509) Checking
+  Contribution Note field in reports results in no rows
+  ([10631](https://github.com/civicrm/civicrm-core/pull/10631))**
 
-- **Add release notes for 4.7.22 ([10645](https://github.com/civicrm/civicrm-core/pull/10645))**
+  When displaying note fields in reports, the query would limit the results to
+  rows that had notes.
 
-- **[CRM-20850](https://issues.civicrm.org/jira/browse/CRM-20850) Replace fatal with statusBounce in membership form ([10638](https://github.com/civicrm/civicrm-core/pull/10638))**
+- **[CRM-20351](https://issues.civicrm.org/jira/browse/CRM-20351)
+  hook_civicrm_buildForm invoked twice on a bunch of forms
+  ([10068](https://github.com/civicrm/civicrm-core/pull/10068))**
 
-- **[CRM-20809](https://issues.civicrm.org/jira/browse/CRM-20809) Move extensions cache from $extensionsDir to $uploadDir ([10604](https://github.com/civicrm/civicrm-core/pull/10604))**
+- **[CRM-20774](https://issues.civicrm.org/jira/browse/CRM-20774) Add check for
+  existing index keys(different values) while creating missing indices.
+  ([10572](https://github.com/civicrm/civicrm-core/pull/10572) and
+  [10566](https://github.com/civicrm/civicrm-core/pull/10566))**
 
-- **[CRM-20649](https://issues.civicrm.org/jira/browse/CRM-20649) Notice error when creating Price set ([10431](https://github.com/civicrm/civicrm-core/pull/10431))**
+  The check and resolution for missing indexes would previously be unaware of
+  variations in the keys for equivalent indexes.
 
-- **[CRM-20667](https://issues.civicrm.org/jira/browse/CRM-20667) Additonal Line item created from Membership backoffice form ([10450](https://github.com/civicrm/civicrm-core/pull/10450))**
+- **[CRM-20722](https://issues.civicrm.org/jira/browse/CRM-20722) 'Lock wait
+  timeout exceeded' error triggered on smart group cache rebuild
+  ([10498](https://github.com/civicrm/civicrm-core/pull/10498))**
 
-- **[CRM-20834](https://issues.civicrm.org/jira/browse/CRM-20834) Drupal user not created via Profile due to missing email field ([10629](https://github.com/civicrm/civicrm-core/pull/10629))**
+  This avoids an error when rebuilding the smart group cache on sites that have
+  a very large number of smart groups.
 
-- **[CRM-20828](https://issues.civicrm.org/jira/browse/CRM-20828) Saved field mappings drop down is limited to 1 ([10615](https://github.com/civicrm/civicrm-core/pull/10615))**
+- **[CRM-20443](https://issues.civicrm.org/jira/browse/CRM-20443) SQL syntax
+  error creating logging triggers if column name is reserved word
+  ([10530](https://github.com/civicrm/civicrm-core/pull/10530))**
 
-- **[CRM-20805](https://issues.civicrm.org/jira/browse/CRM-20805) Fatal Error when adding new membership type on a contribution page. ([10597](https://github.com/civicrm/civicrm-core/pull/10597))**
+- **[CRM-20950](https://issues.civicrm.org/jira/browse/CRM-20950) Contact import
+  mapping to wrong location type (unreleased regression)
+  ([10736](https://github.com/civicrm/civicrm-core/pull/10736) and
+  [10735](https://github.com/civicrm/civicrm-core/pull/10735))**
 
-- **[CRM-20509](https://issues.civicrm.org/jira/browse/CRM-20509) Checking Contribution Note field in reports results in no rows ([10631](https://github.com/civicrm/civicrm-core/pull/10631))**
+- **[CRM-20754](https://issues.civicrm.org/jira/browse/CRM-20754) memory leak in
+  CLI CSV import ([10537](https://github.com/civicrm/civicrm-core/pull/10537))**
 
-- **[CRM-20351](https://issues.civicrm.org/jira/browse/CRM-20351) hook_civicrm_buildForm invoked twice on a bunch of forms ([10068](https://github.com/civicrm/civicrm-core/pull/10068))**
+  This resolves a problem of accumulating too much data in the
+  `PEAR_DB_DATAOBJECT` cache on large imports.
 
-- **Rename v4.7.22 to v4.7.23 ([10624](https://github.com/civicrm/civicrm-core/pull/10624))**
+- **[CRM-19702](https://issues.civicrm.org/jira/browse/CRM-19702) Fatal error
+  when merging contact records with custom file fields
+  ([9784](https://github.com/civicrm/civicrm-core/pull/9784))**
 
-- **Release notes: Mathieu primary affiliation still Coop SymbioTIC ([10621](https://github.com/civicrm/civicrm-core/pull/10621))**
+- **[CRM-19653](https://issues.civicrm.org/jira/browse/CRM-19653) Custom field
+  checkboxes migrated incorrectly on merge (part deux)
+  ([10407](https://github.com/civicrm/civicrm-core/pull/10407))**
 
-- **Misspelling ([10619](https://github.com/civicrm/civicrm-core/pull/10619))**
+- **[CRM-19821](https://issues.civicrm.org/jira/browse/CRM-19821) Remove
+  performance degrading joins from activity search (& api calls)
+  ([10274](https://github.com/civicrm/civicrm-core/pull/10274))**
 
-- **[CRM-20823](https://issues.civicrm.org/jira/browse/CRM-20823) Price Set field with an Expiry Date still being 'required' after being expired. ([10613](https://github.com/civicrm/civicrm-core/pull/10613))**
+- **[CRM-20743](https://issues.civicrm.org/jira/browse/CRM-20743) users without
+  reserved tag permission may still modify the tag
+  ([10522](https://github.com/civicrm/civicrm-core/pull/10522))**
 
-- **[CRM-20752](https://issues.civicrm.org/jira/browse/CRM-20752) Editing a Cancelled Pledge updates the status of it to Pending/Inprogress ([10535](https://github.com/civicrm/civicrm-core/pull/10535))**
+  While users lacking the "Administer reserved tags" permission were barred from
+  deleting or moving reserved tags, this prevents them from editing the tag name
+  and description.
 
-- **4.7.21 rc ([10616](https://github.com/civicrm/civicrm-core/pull/10616))**
-
-- **[CRM-20633](https://issues.civicrm.org/jira/browse/CRM-20633) custom field set displayed twice on register event Participant ([10551](https://github.com/civicrm/civicrm-core/pull/10551))**
-
-- **[CRM-20797](https://issues.civicrm.org/jira/browse/CRM-20797) Use is_payment to retrieve payments ([10587](https://github.com/civicrm/civicrm-core/pull/10587))**
-
-- **[CRM-20812](https://issues.civicrm.org/jira/browse/CRM-20812) Notice on live contribution when only pay later is selected ([10606](https://github.com/civicrm/civicrm-core/pull/10606))**
-
-- **4.7.21 rc ([10600](https://github.com/civicrm/civicrm-core/pull/10600))**
-
-- **4.7.21 rc ([10593](https://github.com/civicrm/civicrm-core/pull/10593))**
-
-- **Replace a couple of calls to deprecated function ([10527](https://github.com/civicrm/civicrm-core/pull/10527))**
-
-- **[CRM-19914](https://issues.civicrm.org/jira/browse/CRM-19914) civicrmHooks.php issues on windows ([10571](https://github.com/civicrm/civicrm-core/pull/10571))**
-
-- **[CRM-20774](https://issues.civicrm.org/jira/browse/CRM-20774) Add check for existing index keys(different values) while creating missing indices. ([10572](https://github.com/civicrm/civicrm-core/pull/10572) and [10566](https://github.com/civicrm/civicrm-core/pull/10566))**
-
-- **[CRM-19778](https://issues.civicrm.org/jira/browse/CRM-19778) Allowed statuses per case-type ([10552](https://github.com/civicrm/civicrm-core/pull/10552))**
-
-- **Update `master` with latest `4.7.21-rc` ([10570](https://github.com/civicrm/civicrm-core/pull/10570))**
-
-- **[CRM-20668](https://issues.civicrm.org/jira/browse/CRM-20668) Notice error ([10452](https://github.com/civicrm/civicrm-core/pull/10452))**
-
-- **4.7.21 rc ([10560](https://github.com/civicrm/civicrm-core/pull/10560))**
-
-- **4.7.21 rc ([10559](https://github.com/civicrm/civicrm-core/pull/10559))**
-
-- **[CRM-20722](https://issues.civicrm.org/jira/browse/CRM-20722) 'Lock wait timeout exceeded' error triggered on smart group cache rebuild ([10498](https://github.com/civicrm/civicrm-core/pull/10498))**
-
-- **[CRM-20761](https://issues.civicrm.org/jira/browse/CRM-20761) Formrule error when priceset is selected on contribution page ([10549](https://github.com/civicrm/civicrm-core/pull/10549))**
-
-- **[CRM-20758](https://issues.civicrm.org/jira/browse/CRM-20758) Fix deprecated fn call on import screen ([10544](https://github.com/civicrm/civicrm-core/pull/10544))**
-
-- **[CRM-20746](https://issues.civicrm.org/jira/browse/CRM-20746) CiviMail - text part of resubscribe confirmation mail contains html ([10528](https://github.com/civicrm/civicrm-core/pull/10528))**
-
-- **[CRM-20401](https://issues.civicrm.org/jira/browse/CRM-20401) Cancel/modify URL receipt links not correct for Paypal Website Payments Pro ([10424](https://github.com/civicrm/civicrm-core/pull/10424))**
-
-- **[CRM-20443](https://issues.civicrm.org/jira/browse/CRM-20443) SQL syntax error creating logging triggers if column name is reserved word ([10530](https://github.com/civicrm/civicrm-core/pull/10530))**
-
-- **[CRM-20745](https://issues.civicrm.org/jira/browse/CRM-20745) Post date of recur not respected in credit card pledge payment ([10524](https://github.com/civicrm/civicrm-core/pull/10524))**
-
-- **[CRM-20675](https://issues.civicrm.org/jira/browse/CRM-20675) Membership status update creates renewal activity ([10457](https://github.com/civicrm/civicrm-core/pull/10457))**
-
-- **4.7.21 rc ([10526](https://github.com/civicrm/civicrm-core/pull/10526))**
-
-- **[CRM-20541](https://issues.civicrm.org/jira/browse/CRM-20541) Edge case where DB connection is not available ([447](https://github.com/civicrm/civicrm-drupal/pull/447))**
-
-- **Fix spelling to canvass for civicrm_engage ([40](https://github.com/civicrm/civicrm-backdrop/pull/40))**
-
-- **Bug fixes - issues #22, #31, #33 ([39](https://github.com/civicrm/civicrm-backdrop/pull/39))**
-
-- **Improve Views checkbox value handling ([37](https://github.com/civicrm/civicrm-backdrop/pull/37))**
-
-- **add new views handlers to hook_autoload_info ([38](https://github.com/civicrm/civicrm-backdrop/pull/38))**
-
-- **Merge in civicrm/drupal from Dec 15, 2015 to June 21, 2017 ([36](https://github.com/civicrm/civicrm-backdrop/pull/36))**
-
-- **Port of civicrm_engage to Backdrop ([28](https://github.com/civicrm/civicrm-backdrop/pull/28))**
-
-### Import
-
-- **[CRM-20950](https://issues.civicrm.org/jira/browse/CRM-20950) Contact import mapping to wrong location type (unreleased regression) ([10736](https://github.com/civicrm/civicrm-core/pull/10736) and [10735](https://github.com/civicrm/civicrm-core/pull/10735))**
-
-### CiviContribute, CiviMail, CiviMember, WordPress Integration
-
-- **[CRM-19017](https://issues.civicrm.org/jira/browse/CRM-19017) Scheduled membership reminders have stopped working ([10652](https://github.com/civicrm/civicrm-core/pull/10652))**
-
-### CiviCRM API
-
-- **[CRM-20754](https://issues.civicrm.org/jira/browse/CRM-20754) memory leak in CLI CSV import ([10537](https://github.com/civicrm/civicrm-core/pull/10537))**
-
-### Dedupe
-
-- **[CRM-19702](https://issues.civicrm.org/jira/browse/CRM-19702) Fatal error when merging contact records with custom file fields ([9784](https://github.com/civicrm/civicrm-core/pull/9784))**
+- **[CRM-20621](https://issues.civicrm.org/jira/browse/CRM-20621) manage tags:
+  the tag usage count is not accurate
+  ([10441](https://github.com/civicrm/civicrm-core/pull/10441))**
 
 ### CiviCase
 
@@ -369,31 +346,94 @@ Released August 2, 2017;
   Using a contribution page with "separate membership payment" set, a pay-later
   contribution would incorrectly mark the membership contribution completed.
 
-- **[CRM-20773](https://issues.civicrm.org/jira/browse/CRM-20773) Contribution tab shows Receive Date twice instead of Thank You date ([10607](https://github.com/civicrm/civicrm-core/pull/10607))**
+- **[CRM-20848](https://issues.civicrm.org/jira/browse/CRM-20848) Upgrade to
+  4.7.19 sets price_field to inactive if default Financial Types are disabled
+  ([10675](https://github.com/civicrm/civicrm-core/pull/10675))**
 
-- **[CRM-20387](https://issues.civicrm.org/jira/browse/CRM-20387) Sales Tax and Invoicing code overwrites existing CiviCRM invoice ID ([10298](https://github.com/civicrm/civicrm-core/pull/10298))**
+- **[CRM-20857](https://issues.civicrm.org/jira/browse/CRM-20857) Deferred
+  Revenue report -  DB Error: unknown error
+  ([10646](https://github.com/civicrm/civicrm-core/pull/10646))**
 
-- **[CRM-20488](https://issues.civicrm.org/jira/browse/CRM-20488) Lift restrictions for contact type soft credit ([10532](https://github.com/civicrm/civicrm-core/pull/10532) and [10419](https://github.com/civicrm/civicrm-core/pull/10419))**
+  The Deferred Revenue report would have an error on if a database server's
+  `sql_mode` was set to `only_full_group_by`.
 
-- **[CRM-19478](https://issues.civicrm.org/jira/browse/CRM-19478) API not handling Paypal recurring IPN where p=null for Contribution Page ([10447](https://github.com/civicrm/civicrm-core/pull/10447))**
+- **[CRM-20867](https://issues.civicrm.org/jira/browse/CRM-20867) Class not
+  found ([10656](https://github.com/civicrm/civicrm-core/pull/10656))**
 
-- **[CRM-20495](https://issues.civicrm.org/jira/browse/CRM-20495) "Contribution amounts section" checkbox setting on contribution pages always shows as checked. ([10521](https://github.com/civicrm/civicrm-core/pull/10521))**
+  This fixes a fatal error in the additional payment form due to a typo in the
+  name of the `CRM_Contribute_BAO_Contribution` class.
 
-### CiviContribute, CiviMail
+- **[CRM-20649](https://issues.civicrm.org/jira/browse/CRM-20649) Notice error
+  when creating Price set
+  ([10431](https://github.com/civicrm/civicrm-core/pull/10431))**
 
-- **[CRM-20747](https://issues.civicrm.org/jira/browse/CRM-20747) {contribution.campaign} token not working on Contribution ThankYou letter ([10533](https://github.com/civicrm/civicrm-core/pull/10533))**
+  Validation of a price set name would generate a PHP notice if the name was
+  blank.
 
-### CiviMail, NYSS
+- **[CRM-20823](https://issues.civicrm.org/jira/browse/CRM-20823) Price Set
+  field with an Expiry Date still being 'required' after being expired.
+  ([10613](https://github.com/civicrm/civicrm-core/pull/10613))**
 
-- **[CRM-20412](https://issues.civicrm.org/jira/browse/CRM-20412) mailing report: unique opens detail view inaccurate ([10558](https://github.com/civicrm/civicrm-core/pull/10558))**
+- **[CRM-20752](https://issues.civicrm.org/jira/browse/CRM-20752) Editing a
+  Cancelled Pledge updates the status of it to Pending/Inprogress
+  ([10535](https://github.com/civicrm/civicrm-core/pull/10535))**
 
-- **[CRM-20411](https://issues.civicrm.org/jira/browse/CRM-20411) mailing tab listing: MySQL 5.7 group by error ([10562](https://github.com/civicrm/civicrm-core/pull/10562) and [10541](https://github.com/civicrm/civicrm-core/pull/10541))**
+- **[CRM-20812](https://issues.civicrm.org/jira/browse/CRM-20812) Notice on live
+  contribution when only pay later is selected
+  ([10606](https://github.com/civicrm/civicrm-core/pull/10606))**
 
-### CiviCRM API, CiviEvent
+- **[CRM-20761](https://issues.civicrm.org/jira/browse/CRM-20761) Formrule error
+  when priceset is selected on contribution page
+  ([10549](https://github.com/civicrm/civicrm-core/pull/10549))**
 
-- **[CRM-20775](https://issues.civicrm.org/jira/browse/CRM-20775) Wrong is full results for API event get ([10568](https://github.com/civicrm/civicrm-core/pull/10568))**
+  When enabling a contribution amounts section and selecting a price set on a
+  contribution page's settings form, validation would fail, looking for a
+  contribution amount label.
+
+- **[CRM-20401](https://issues.civicrm.org/jira/browse/CRM-20401) Cancel/modify
+  URL receipt links not correct for Paypal Website Payments Pro
+  ([10424](https://github.com/civicrm/civicrm-core/pull/10424))**
+
+- **[CRM-20745](https://issues.civicrm.org/jira/browse/CRM-20745) Post date of
+  recur not respected in credit card pledge payment
+  ([10524](https://github.com/civicrm/civicrm-core/pull/10524))**
+
+- **[CRM-20773](https://issues.civicrm.org/jira/browse/CRM-20773) Contribution
+  tab shows Receive Date twice instead of Thank You date
+  ([10607](https://github.com/civicrm/civicrm-core/pull/10607))**
+
+- **[CRM-20387](https://issues.civicrm.org/jira/browse/CRM-20387) Sales Tax and
+  Invoicing code overwrites existing CiviCRM invoice ID
+  ([10298](https://github.com/civicrm/civicrm-core/pull/10298))**
+
+  A new `invoice_number` field is added to the `civicrm_contribution` table to
+  record the ID of the manually-generated invoice.
+
+- **[CRM-20488](https://issues.civicrm.org/jira/browse/CRM-20488) Lift
+  restrictions for contact type soft credit
+  ([10532](https://github.com/civicrm/civicrm-core/pull/10532) and
+  [10419](https://github.com/civicrm/civicrm-core/pull/10419))**
+
+  Users could not soft-credit an organization if the contribution originated
+  from a contribution page where honor/memory is enabled.
+
+- **[CRM-19478](https://issues.civicrm.org/jira/browse/CRM-19478) API not
+  handling Paypal recurring IPN where p=null for Contribution Page
+  ([10447](https://github.com/civicrm/civicrm-core/pull/10447))**
+
+- **[CRM-20495](https://issues.civicrm.org/jira/browse/CRM-20495) "Contribution
+  amounts section" checkbox setting on contribution pages always shows as
+  checked. ([10521](https://github.com/civicrm/civicrm-core/pull/10521))**
+
+- **[CRM-20747](https://issues.civicrm.org/jira/browse/CRM-20747)
+  {contribution.campaign} token not working on Contribution ThankYou letter
+  ([10533](https://github.com/civicrm/civicrm-core/pull/10533))**
 
 ### CiviMember
+
+- **[CRM-19017](https://issues.civicrm.org/jira/browse/CRM-19017) Scheduled
+  membership reminders have stopped working
+  ([10652](https://github.com/civicrm/civicrm-core/pull/10652))**
 
 - **[CRM-20716](https://issues.civicrm.org/jira/browse/CRM-20716) Array to
   string issue on php7 when creating membership activity
@@ -406,25 +446,51 @@ Released August 2, 2017;
 - **[CRM-18177](https://issues.civicrm.org/jira/browse/CRM-18177) When Renewing
   an existing membership, if CC details are incorrect, Membership is set to
   Cancelled preventing contact from trying again
-  ([10770](https://github.com/civicrm/civicrm-core/pull/10770)) (fix to problem introduced in original bug fix)**
+  ([10770](https://github.com/civicrm/civicrm-core/pull/10770)) (fix to problem
+  introduced in original bug fix)**
 
-- **[CRM-20567](https://issues.civicrm.org/jira/browse/CRM-20567) backoffice membership via price set errors with non-aggregated column ([10346](https://github.com/civicrm/civicrm-core/pull/10346))**
+- **[CRM-20850](https://issues.civicrm.org/jira/browse/CRM-20850) Replace fatal
+  with statusBounce in membership form
+  ([10638](https://github.com/civicrm/civicrm-core/pull/10638))**
 
-- **[CRM-20720](https://issues.civicrm.org/jira/browse/CRM-20720) CIVICRM-128 Unable to sort Price Options for Price Fieldset. Weight values are not being set at all in database. ([10542](https://github.com/civicrm/civicrm-core/pull/10542))**
+  When a user links to edit a linked contribution from a membership and they
+  don't have permission to edit the contribution, they should be redirected with
+  an error notice rather than being shown a fatal error.
 
-- **[CRM-20670](https://issues.civicrm.org/jira/browse/CRM-20670) Cannot edit membership type if lots of members already exist ([10534](https://github.com/civicrm/civicrm-core/pull/10534) and [10455](https://github.com/civicrm/civicrm-core/pull/10455))**
+- **[CRM-20667](https://issues.civicrm.org/jira/browse/CRM-20667) Additonal Line
+  item created from Membership backoffice form
+  ([10450](https://github.com/civicrm/civicrm-core/pull/10450))**
 
-### Dedupe, NYSS
+- **[CRM-20805](https://issues.civicrm.org/jira/browse/CRM-20805) Fatal Error
+  when adding new membership type on a contribution page.
+  ([10597](https://github.com/civicrm/civicrm-core/pull/10597))**
 
-- **[CRM-19653](https://issues.civicrm.org/jira/browse/CRM-19653) Custom field checkboxes migrated incorrectly on merge (part deux) ([10407](https://github.com/civicrm/civicrm-core/pull/10407))**
+- **[CRM-20668](https://issues.civicrm.org/jira/browse/CRM-20668) Notice error
+  ([10452](https://github.com/civicrm/civicrm-core/pull/10452))**
 
-### CiviCRM Search
+  This fixes a PHP notice when creating a membership using a price set on the
+  backend.
 
-- **[CRM-19821](https://issues.civicrm.org/jira/browse/CRM-19821) Remove performance degrading joins from activity search (& api calls) ([10274](https://github.com/civicrm/civicrm-core/pull/10274))**
+- **[CRM-20675](https://issues.civicrm.org/jira/browse/CRM-20675) Membership
+  status update creates renewal activity
+  ([10457](https://github.com/civicrm/civicrm-core/pull/10457))**
 
-### CiviContribute, CiviCRM API
+- **[CRM-20567](https://issues.civicrm.org/jira/browse/CRM-20567) backoffice
+  membership via price set errors with non-aggregated column
+  ([10346](https://github.com/civicrm/civicrm-core/pull/10346))**
 
-- **[CRM-20525](https://issues.civicrm.org/jira/browse/CRM-20525) Webform Pay later sends Receipt email rather than Invoice email ([10306](https://github.com/civicrm/civicrm-core/pull/10306))**
+  This is one of several errors that appear when `sql_mode` was set to
+  `only_full_group_by`.
+
+- **[CRM-20720](https://issues.civicrm.org/jira/browse/CRM-20720) CIVICRM-128
+  Unable to sort Price Options for Price Fieldset. Weight values are not being
+  set at all in database.
+  ([10542](https://github.com/civicrm/civicrm-core/pull/10542))**
+
+- **[CRM-20670](https://issues.civicrm.org/jira/browse/CRM-20670) Cannot edit
+  membership type if lots of members already exist
+  ([10534](https://github.com/civicrm/civicrm-core/pull/10534) and
+  [10455](https://github.com/civicrm/civicrm-core/pull/10455))**
 
 ### CiviEvent
 
@@ -432,7 +498,23 @@ Released August 2, 2017;
   message shown as error
   ([10515](https://github.com/civicrm/civicrm-core/pull/10515))**
 
-- **[CRM-19745](https://issues.civicrm.org/jira/browse/CRM-19745) Image URL field doesn't show up on CiviEvent Additional Participants Profile ([9777](https://github.com/civicrm/civicrm-core/pull/9777))**
+- **[CRM-20633](https://issues.civicrm.org/jira/browse/CRM-20633) custom field
+  set displayed twice on register event Participant
+  ([10551](https://github.com/civicrm/civicrm-core/pull/10551))**
+
+  When switching event types on the backend form to add an event participant,
+  custom fields common to all event types would be added repeatedly.
+
+- **[CRM-20775](https://issues.civicrm.org/jira/browse/CRM-20775) Wrong is full
+  results for API event get
+  ([10568](https://github.com/civicrm/civicrm-core/pull/10568))**
+
+  When Max Number of Participants event field is left empty, the API would
+  return `1` for the `is_full`property instead of `0`.
+
+- **[CRM-19745](https://issues.civicrm.org/jira/browse/CRM-19745) Image URL
+  field doesn't show up on CiviEvent Additional Participants Profile
+  ([9777](https://github.com/civicrm/civicrm-core/pull/9777))**
 
 ### CiviMail
 
@@ -447,17 +529,61 @@ Released August 2, 2017;
   error on Mailing Opened Report
   ([10690](https://github.com/civicrm/civicrm-core/pull/10690))**
 
-- **[CRM-20713](https://issues.civicrm.org/jira/browse/CRM-20713) db error when populating mailing recipients because sms_provider_id is 'null' ([10487](https://github.com/civicrm/civicrm-core/pull/10487))**
+- **[CRM-20746](https://issues.civicrm.org/jira/browse/CRM-20746) CiviMail -
+  text part of resubscribe confirmation mail contains html
+  ([10528](https://github.com/civicrm/civicrm-core/pull/10528))**
 
-### Core CiviCRM, NYSS
+- **[CRM-20412](https://issues.civicrm.org/jira/browse/CRM-20412) mailing
+  report: unique opens detail view inaccurate
+  ([10558](https://github.com/civicrm/civicrm-core/pull/10558))**
 
-- **[CRM-20743](https://issues.civicrm.org/jira/browse/CRM-20743) users without reserved tag permission may still modify the tag ([10522](https://github.com/civicrm/civicrm-core/pull/10522))**
+- **[CRM-20411](https://issues.civicrm.org/jira/browse/CRM-20411) mailing tab
+  listing: MySQL 5.7 group by error
+  ([10562](https://github.com/civicrm/civicrm-core/pull/10562) and
+  [10541](https://github.com/civicrm/civicrm-core/pull/10541))**  
 
-- **[CRM-20621](https://issues.civicrm.org/jira/browse/CRM-20621) manage tags: the tag usage count is not accurate ([10441](https://github.com/civicrm/civicrm-core/pull/10441))**
+- **[CRM-20713](https://issues.civicrm.org/jira/browse/CRM-20713) db error when
+  populating mailing recipients because sms_provider_id is 'null'
+  ([10487](https://github.com/civicrm/civicrm-core/pull/10487))**
 
-### Drupal Integration Modules
+### Backdrop Integration
 
-- **[CRM-19976](https://issues.civicrm.org/jira/browse/CRM-19976) Drush: cannot disable civicrm debug ([457](https://github.com/civicrm/civicrm-drupal/pull/457))**
+- **Fix spelling to canvass for civicrm_engage
+  ([40](https://github.com/civicrm/civicrm-backdrop/pull/40))**
+
+- **Bug fixes - issues #22, #31, #33
+  ([39](https://github.com/civicrm/civicrm-backdrop/pull/39))**
+
+- **Improve Views checkbox value handling
+  ([37](https://github.com/civicrm/civicrm-backdrop/pull/37))**
+
+- **add new views handlers to hook_autoload_info
+  ([38](https://github.com/civicrm/civicrm-backdrop/pull/38))**
+
+- **Merge in civicrm/drupal from Dec 15, 2015 to June 21, 2017
+  ([36](https://github.com/civicrm/civicrm-backdrop/pull/36))**
+
+### Drupal Integration
+
+- **[CRM-20525](https://issues.civicrm.org/jira/browse/CRM-20525) Webform Pay
+  later sends Receipt email rather than Invoice email
+  ([10306](https://github.com/civicrm/civicrm-core/pull/10306))**
+
+- **[CRM-19976](https://issues.civicrm.org/jira/browse/CRM-19976) Drush: cannot
+  disable civicrm debug
+  ([457](https://github.com/civicrm/civicrm-drupal/pull/457))**
+
+  While `drush civicrm-enable-debug` was defined, this adds the
+  `civicrm-disable-debug` command.
+
+### Joomla Integration
+
+- **[CRM-19914](https://issues.civicrm.org/jira/browse/CRM-19914)
+  civicrmHooks.php issues on windows
+  ([10571](https://github.com/civicrm/civicrm-core/pull/10571))**
+
+  This resolves problems locating the `civicrmHooks.php` file on Joomla sites in
+  Windows.
 
 ## <a name="misc"></a>Miscellany
 
@@ -486,6 +612,29 @@ Released August 2, 2017;
   [10625](https://github.com/civicrm/civicrm-core/pull/10625))**
 
   The namespace is now `Civi\Api4\Entity` rather than `Civi\Api4`.
+
+- **[CRM-19726](https://issues.civicrm.org/jira/browse/CRM-19726)
+  `CiviMailUtils::clearMessages()` should clear all messages by default
+  ([10669](https://github.com/civicrm/civicrm-core/pull/10669))**
+
+- **Misspelling ([10619](https://github.com/civicrm/civicrm-core/pull/10619))**
+
+- **[CRM-20797](https://issues.civicrm.org/jira/browse/CRM-20797) Use is_payment
+  to retrieve payments
+  ([10587](https://github.com/civicrm/civicrm-core/pull/10587))**
+
+- **Replace a couple of calls to deprecated function
+  ([10527](https://github.com/civicrm/civicrm-core/pull/10527))**
+
+- **[CRM-20758](https://issues.civicrm.org/jira/browse/CRM-20758) Fix deprecated
+  fn call on import screen
+  ([10544](https://github.com/civicrm/civicrm-core/pull/10544))**
+
+- **[CRM-20541](https://issues.civicrm.org/jira/browse/CRM-20541) Edge case
+  where DB connection is not available
+  ([447](https://github.com/civicrm/civicrm-drupal/pull/447))**
+
+  Certain static variables now use Drupal's built-in system.
 
 ## <a name="credits"></a>Credits
 

--- a/release-notes/4.7.23.md
+++ b/release-notes/4.7.23.md
@@ -7,6 +7,16 @@ Released August 2, 2017;
 - **[Miscellany](#misc)**
 - **[Credits](#credits)**
 
+| Does this version                                               |         |
+|:--------------------------------------------------------------- |:-------:|
+| fix security vulnerabilities?                                   | no      |
+| change the database schema?                                     | no      |
+| **alter the API?**                                              | **yes** |
+| **require attention to configuration options?**                 | **yes** |
+| **fix problems installing or upgrading to a previous version?** | **yes** |
+| **introduce features?**                                         | **yes** |
+| **fix bugs?**                                                   | **yes** |
+
 ## <a name="features"></a>Features
 
 ### Core CiviCRM
@@ -143,6 +153,23 @@ Released August 2, 2017;
   the Thank-you Letter form.  They had been processed, but there was no
   indication that they were available.
 
+- **[CRM-20860](https://issues.civicrm.org/jira/browse/CRM-20860) Add in
+  password type field availability and apply to payment processor fields
+  ([10649](https://github.com/civicrm/civicrm-core/pull/10649))**
+
+  Field metadata can now specify the HTML field type of `Password` which adds a
+  `HTML_QuickForm_password` field element.  This is implemented on payment
+  processor settings fields.
+
+### CiviMember
+
+- **[CRM-20901](https://issues.civicrm.org/jira/browse/CRM-20901) Add submit
+  credit card membership link on membership form
+  ([10689](https://github.com/civicrm/civicrm-core/pull/10689))**
+
+  The backend add membership form now has a link to the backend credit card
+  membership form.
+
 ### Drupal Integration
 
 - **[CRM-20751](https://issues.civicrm.org/jira/browse/CRM-20751) Support Drupal
@@ -156,6 +183,15 @@ Released August 2, 2017;
 ## <a name="bugs"></a>Bugs resolved
 
 ### Core CiviCRM
+
+- **[CRM-20873](https://issues.civicrm.org/jira/browse/CRM-20873) CIVICRM-118 DB
+  Error: no such field / Unknown column 'civicrm_custom_group.is_public' breaks
+  CiviCRM database update process
+  ([10662](https://github.com/civicrm/civicrm-core/pull/10662))**
+
+  This fixes a bug in upgrading from 4.7.18 or earlier to 4.7.19 or later.  Code
+  used by the upgrade to load the available custom data for an entity relies
+  upon a field that is not made available until after the upgrade.
 
 - **[CRM-20849](https://issues.civicrm.org/jira/browse/CRM-20849) Multiple
   extensions using the same autoloader prefix will overwrite previous
@@ -185,17 +221,9 @@ Released August 2, 2017;
   Reports with group filters would display rows twice if multiple groups were
   selected in the filter and contacts were in more than one of those groups.
 
-- **[CRM-20953](https://issues.civicrm.org/jira/browse/CRM-20953) Importing contacts with deceased_date not setting is_deceased ([10742](https://github.com/civicrm/civicrm-core/pull/10742))**
-
-- **[CRM-20891](https://issues.civicrm.org/jira/browse/CRM-20891) Pay later option incorrectly shows as completed when combining membership and donation ([10683](https://github.com/civicrm/civicrm-core/pull/10683))**
-
-- **[CRM-20902](https://issues.civicrm.org/jira/browse/CRM-20902) DB Syntax error on Mailing Opened Report ([10690](https://github.com/civicrm/civicrm-core/pull/10690))**
-
-- **[CRM-20901](https://issues.civicrm.org/jira/browse/CRM-20901) Add submit credit card membership link on membership form ([10689](https://github.com/civicrm/civicrm-core/pull/10689))**
-
-- **[CRM-20860](https://issues.civicrm.org/jira/browse/CRM-20860) Add in password type field availability and apply to payment processor fields ([10649](https://github.com/civicrm/civicrm-core/pull/10649))**
-
-- **[CRM-20873](https://issues.civicrm.org/jira/browse/CRM-20873) CIVICRM-118 DB Error: no such field / Unknown column 'civicrm_custom_group.is_public' breaks CiviCRM database update process ([10662](https://github.com/civicrm/civicrm-core/pull/10662))**
+- **[CRM-20953](https://issues.civicrm.org/jira/browse/CRM-20953) Importing
+  contacts with deceased_date not setting is_deceased
+  ([10742](https://github.com/civicrm/civicrm-core/pull/10742))**
 
 - **[CRM-20848](https://issues.civicrm.org/jira/browse/CRM-20848) Upgrade to 4.7.19 sets price_field to inactive if default Financial Types are disabled ([10675](https://github.com/civicrm/civicrm-core/pull/10675))**
 
@@ -334,6 +362,13 @@ Released August 2, 2017;
   doesn't respect localization
   ([10536](https://github.com/civicrm/civicrm-core/pull/10536))**
 
+- **[CRM-20891](https://issues.civicrm.org/jira/browse/CRM-20891) Pay later
+  option incorrectly shows as completed when combining membership and donation
+  ([10683](https://github.com/civicrm/civicrm-core/pull/10683))**
+
+  Using a contribution page with "separate membership payment" set, a pay-later
+  contribution would incorrectly mark the membership contribution completed.
+
 - **[CRM-20773](https://issues.civicrm.org/jira/browse/CRM-20773) Contribution tab shows Receive Date twice instead of Thank You date ([10607](https://github.com/civicrm/civicrm-core/pull/10607))**
 
 - **[CRM-20387](https://issues.civicrm.org/jira/browse/CRM-20387) Sales Tax and Invoicing code overwrites existing CiviCRM invoice ID ([10298](https://github.com/civicrm/civicrm-core/pull/10298))**
@@ -407,6 +442,10 @@ Released August 2, 2017;
 
   Long values in columns would crowd other columns off the screen or into
   illegibility.
+
+- **[CRM-20902](https://issues.civicrm.org/jira/browse/CRM-20902) DB Syntax
+  error on Mailing Opened Report
+  ([10690](https://github.com/civicrm/civicrm-core/pull/10690))**
 
 - **[CRM-20713](https://issues.civicrm.org/jira/browse/CRM-20713) db error when populating mailing recipients because sms_provider_id is 'null' ([10487](https://github.com/civicrm/civicrm-core/pull/10487))**
 

--- a/release-notes/4.7.23.md
+++ b/release-notes/4.7.23.md
@@ -1,0 +1,325 @@
+# CiviCRM 4.7.23
+
+Released August 2, 2017;
+
+- **[Features](#features)**
+- **[Bugs resolved](#bugs)**
+- **[Miscellany](#misc)**
+- **[Credits](#credits)**
+
+## <a name="features"></a>Features
+
+### Import
+
+- **[CRM-20759](https://issues.civicrm.org/jira/browse/CRM-20759) Import, add 'Primary' as an address location ([10738](https://github.com/civicrm/civicrm-core/pull/10738), [10565](https://github.com/civicrm/civicrm-core/pull/10565), [10594](https://github.com/civicrm/civicrm-core/pull/10594), [10554](https://github.com/civicrm/civicrm-core/pull/10554), and [10547](https://github.com/civicrm/civicrm-core/pull/10547))**
+
+### Core CiviCRM
+
+- **[CRM-20837](https://issues.civicrm.org/jira/browse/CRM-20837) Make setting bug more explicit ([10627](https://github.com/civicrm/civicrm-core/pull/10627))**
+
+- **[CRM-20847](https://issues.civicrm.org/jira/browse/CRM-20847) Support custom api with composite primary keys ([10599](https://github.com/civicrm/civicrm-core/pull/10599))**
+
+- **[CRM-20677](https://issues.civicrm.org/jira/browse/CRM-20677) Use generalised function to retrieve financial account ([10463](https://github.com/civicrm/civicrm-core/pull/10463))**
+
+- **[CRM-20830](https://issues.civicrm.org/jira/browse/CRM-20830) Improve handling of overdue activities ([10618](https://github.com/civicrm/civicrm-core/pull/10618))**
+
+- **[CRM-20794](https://issues.civicrm.org/jira/browse/CRM-20794) Colors for case status ([10586](https://github.com/civicrm/civicrm-core/pull/10586))**
+
+- **[CRM-20849](https://issues.civicrm.org/jira/browse/CRM-20849) Multiple extensions using the same autoloader prefix will overwrite previous ([10637](https://github.com/civicrm/civicrm-core/pull/10637))**
+
+- **[CRM-20321](https://issues.civicrm.org/jira/browse/CRM-20321) Changing membership type should change related contribution ([10642](https://github.com/civicrm/civicrm-core/pull/10642) and [10370](https://github.com/civicrm/civicrm-core/pull/10370))**
+
+- **[CRM-20842](https://issues.civicrm.org/jira/browse/CRM-20842) Change api explorer page title ([10633](https://github.com/civicrm/civicrm-core/pull/10633))**
+
+- **[CRM-20786](https://issues.civicrm.org/jira/browse/CRM-20786) Move deprecated utils functions to the import classes ([10578](https://github.com/civicrm/civicrm-core/pull/10578), [10580](https://github.com/civicrm/civicrm-core/pull/10580), [10579](https://github.com/civicrm/civicrm-core/pull/10579), and [10581](https://github.com/civicrm/civicrm-core/pull/10581))**
+
+- **[CRM-20780](https://issues.civicrm.org/jira/browse/CRM-20780) Add drupal option to define CMS_ROOT ([10574](https://github.com/civicrm/civicrm-core/pull/10574))**
+
+- **[CRM-20778](https://issues.civicrm.org/jira/browse/CRM-20778) Use civicontribute permission for contribution recur.cancel ([10569](https://github.com/civicrm/civicrm-core/pull/10569))**
+
+- **[CRM-20169](https://issues.civicrm.org/jira/browse/CRM-20169) Add support for alterReportVar hook in Activity Report ([9886](https://github.com/civicrm/civicrm-core/pull/9886))**
+
+- **[CRM-20721](https://issues.civicrm.org/jira/browse/CRM-20721) Add parameter to dateQueryBuilder fn to change date value to desired format ([10497](https://github.com/civicrm/civicrm-core/pull/10497))**
+
+- **[CRM-20739](https://issues.civicrm.org/jira/browse/CRM-20739) contact import doesn't add to group on fill if matching without ID ([10507](https://github.com/civicrm/civicrm-core/pull/10507))**
+
+- **[CRM-20771](https://issues.civicrm.org/jira/browse/CRM-20771) Ensure that AddColumn in CRM_Upgrade_Incremental_Base can support translatable columns ([10561](https://github.com/civicrm/civicrm-core/pull/10561))**
+
+- **[CRM-20756](https://issues.civicrm.org/jira/browse/CRM-20756) Multi tab structure ([10545](https://github.com/civicrm/civicrm-core/pull/10545))**
+
+- **[CRM-20666](https://issues.civicrm.org/jira/browse/CRM-20666) enable uploading of files to activities that are up to 255 characters in length ([10449](https://github.com/civicrm/civicrm-core/pull/10449))**
+
+- **[CRM-20682](https://issues.civicrm.org/jira/browse/CRM-20682) Include human readable contribution's custom field label in token widget for Thankyou letter ([10467](https://github.com/civicrm/civicrm-core/pull/10467))**
+
+### Internationalisation
+
+- **[CRM-20803](https://issues.civicrm.org/jira/browse/CRM-20803) Enable Farsi (fa_IR), Serbian (sr_RS), Ukrainian (uk_UA) in the languages option group so that we can install in those languages ([10667](https://github.com/civicrm/civicrm-core/pull/10667))**
+
+### CiviMail, Core CiviCRM
+
+- **[CRM-20600](https://issues.civicrm.org/jira/browse/CRM-20600) Expose AngularJS screens to hooks ([10644](https://github.com/civicrm/civicrm-core/pull/10644))**
+
+### Core CiviCRM, NYSS
+
+- **[CRM-20673](https://issues.civicrm.org/jira/browse/CRM-20673) Tag and group edit form: implement Select2 for tags ([10634](https://github.com/civicrm/civicrm-core/pull/10634))**
+
+- **[CRM-20622](https://issues.civicrm.org/jira/browse/CRM-20622) contact edit: tags and groups panel layout/styling ([10429](https://github.com/civicrm/civicrm-core/pull/10429))**
+
+### CiviCRM API
+
+- **[CRM-20833](https://issues.civicrm.org/jira/browse/CRM-20833) Change namespace for APIv4 entities ([10632](https://github.com/civicrm/civicrm-core/pull/10632) and [10625](https://github.com/civicrm/civicrm-core/pull/10625))**
+
+### CiviCRM Search, NYSS
+
+- **[CRM-20793](https://issues.civicrm.org/jira/browse/CRM-20793) Add filter - activity date and status on search criteria of activity listing   ([10588](https://github.com/civicrm/civicrm-core/pull/10588))**
+
+### CiviCase
+
+- **[CRM-20816](https://issues.civicrm.org/jira/browse/CRM-20816) Case multi/single client settings ([10609](https://github.com/civicrm/civicrm-core/pull/10609))**
+
+- **[CRM-20776](https://issues.civicrm.org/jira/browse/CRM-20776) Menu structure ([10573](https://github.com/civicrm/civicrm-core/pull/10573))**
+
+### CiviReport
+
+- **[CRM-20640](https://issues.civicrm.org/jira/browse/CRM-20640) contribution summary report: duplicates values with group filter ([10603](https://github.com/civicrm/civicrm-core/pull/10603) and [10596](https://github.com/civicrm/civicrm-core/pull/10596))**
+
+### CiviCase, CiviCRM API
+
+- **[CRM-20802](https://issues.civicrm.org/jira/browse/CRM-20802) CaseType.create - Stale definition retained in memory ([10591](https://github.com/civicrm/civicrm-core/pull/10591))**
+
+### CiviMail, NYSS
+
+- **[CRM-20781](https://issues.civicrm.org/jira/browse/CRM-20781) Truncate long text in mail listing  ([10576](https://github.com/civicrm/civicrm-core/pull/10576))**
+
+### CiviMember
+
+- **[CRM-20716](https://issues.civicrm.org/jira/browse/CRM-20716) Array to string issue on php7 when creating membership activity ([10492](https://github.com/civicrm/civicrm-core/pull/10492))**
+
+- **[CRM-20650](https://issues.civicrm.org/jira/browse/CRM-20650) Translate strings (ts) in CiviMember dashboard and Contribute manage ([10432](https://github.com/civicrm/civicrm-core/pull/10432))**
+
+### CiviContribute
+
+- **[CRM-20765](https://issues.civicrm.org/jira/browse/CRM-20765) Missing id for 'onBehalfOfOrg' section ([10550](https://github.com/civicrm/civicrm-core/pull/10550))**
+
+- **[CRM-20753](https://issues.civicrm.org/jira/browse/CRM-20753) Net amount doesn't respect localization ([10536](https://github.com/civicrm/civicrm-core/pull/10536))**
+
+### CiviEvent
+
+- **[CRM-20741](https://issues.civicrm.org/jira/browse/CRM-20741) Cancellation message shown as error ([10515](https://github.com/civicrm/civicrm-core/pull/10515))**
+
+### Drupal Integration Modules
+
+- **[CRM-20751](https://issues.civicrm.org/jira/browse/CRM-20751) Support Drupal aliases for event links in Views ([456](https://github.com/civicrm/civicrm-drupal/pull/456) and [455](https://github.com/civicrm/civicrm-drupal/pull/455))**
+
+## <a name="bugs"></a>Bugs resolved
+
+### CiviContribute, CiviMember
+
+- **[CRM-18177](https://issues.civicrm.org/jira/browse/CRM-18177) When Renewing an existing membership, if CC details are incorrect, Membership is set to Cancelled preventing contact from trying again ([10770](https://github.com/civicrm/civicrm-core/pull/10770))**
+
+### Core CiviCRM
+
+- **[CRM-20953](https://issues.civicrm.org/jira/browse/CRM-20953) Importing contacts with deceased_date not setting is_deceased ([10742](https://github.com/civicrm/civicrm-core/pull/10742))**
+
+- **[CRM-20891](https://issues.civicrm.org/jira/browse/CRM-20891) Pay later option incorrectly shows as completed when combining membership and donation ([10683](https://github.com/civicrm/civicrm-core/pull/10683))**
+
+- **[CRM-20902](https://issues.civicrm.org/jira/browse/CRM-20902) DB Syntax error on Mailing Opened Report ([10690](https://github.com/civicrm/civicrm-core/pull/10690))**
+
+- **[CRM-20901](https://issues.civicrm.org/jira/browse/CRM-20901) Add submit credit card membership link on membership form ([10689](https://github.com/civicrm/civicrm-core/pull/10689))**
+
+- **[CRM-20860](https://issues.civicrm.org/jira/browse/CRM-20860) Add in password type field availability and apply to payment processor fields ([10649](https://github.com/civicrm/civicrm-core/pull/10649))**
+
+- **[CRM-20873](https://issues.civicrm.org/jira/browse/CRM-20873) CIVICRM-118 DB Error: no such field / Unknown column 'civicrm_custom_group.is_public' breaks CiviCRM database update process ([10662](https://github.com/civicrm/civicrm-core/pull/10662))**
+
+- **[CRM-20848](https://issues.civicrm.org/jira/browse/CRM-20848) Upgrade to 4.7.19 sets price_field to inactive if default Financial Types are disabled ([10675](https://github.com/civicrm/civicrm-core/pull/10675))**
+
+- **Clear all Messages when running clearMessages by default ([10669](https://github.com/civicrm/civicrm-core/pull/10669))**
+
+- **[CRM-20857](https://issues.civicrm.org/jira/browse/CRM-20857) Deferred Revenue report -  DB Error: unknown error ([10646](https://github.com/civicrm/civicrm-core/pull/10646))**
+
+- **[CRM-20871](https://issues.civicrm.org/jira/browse/CRM-20871) crmUiSelect fails to update when model changes ([10659](https://github.com/civicrm/civicrm-core/pull/10659))**
+
+- **[CRM-20867](https://issues.civicrm.org/jira/browse/CRM-20867) Class not found ([10656](https://github.com/civicrm/civicrm-core/pull/10656))**
+
+- **Add release notes for 4.7.22 ([10645](https://github.com/civicrm/civicrm-core/pull/10645))**
+
+- **[CRM-20850](https://issues.civicrm.org/jira/browse/CRM-20850) Replace fatal with statusBounce in membership form ([10638](https://github.com/civicrm/civicrm-core/pull/10638))**
+
+- **[CRM-20809](https://issues.civicrm.org/jira/browse/CRM-20809) Move extensions cache from $extensionsDir to $uploadDir ([10604](https://github.com/civicrm/civicrm-core/pull/10604))**
+
+- **[CRM-20649](https://issues.civicrm.org/jira/browse/CRM-20649) Notice error when creating Price set ([10431](https://github.com/civicrm/civicrm-core/pull/10431))**
+
+- **[CRM-20667](https://issues.civicrm.org/jira/browse/CRM-20667) Additonal Line item created from Membership backoffice form ([10450](https://github.com/civicrm/civicrm-core/pull/10450))**
+
+- **[CRM-20834](https://issues.civicrm.org/jira/browse/CRM-20834) Drupal user not created via Profile due to missing email field ([10629](https://github.com/civicrm/civicrm-core/pull/10629))**
+
+- **[CRM-20828](https://issues.civicrm.org/jira/browse/CRM-20828) Saved field mappings drop down is limited to 1 ([10615](https://github.com/civicrm/civicrm-core/pull/10615))**
+
+- **[CRM-20805](https://issues.civicrm.org/jira/browse/CRM-20805) Fatal Error when adding new membership type on a contribution page. ([10597](https://github.com/civicrm/civicrm-core/pull/10597))**
+
+- **[CRM-20509](https://issues.civicrm.org/jira/browse/CRM-20509) Checking Contribution Note field in reports results in no rows ([10631](https://github.com/civicrm/civicrm-core/pull/10631))**
+
+- **[CRM-20351](https://issues.civicrm.org/jira/browse/CRM-20351) hook_civicrm_buildForm invoked twice on a bunch of forms ([10068](https://github.com/civicrm/civicrm-core/pull/10068))**
+
+- **Rename v4.7.22 to v4.7.23 ([10624](https://github.com/civicrm/civicrm-core/pull/10624))**
+
+- **Release notes: Mathieu primary affiliation still Coop SymbioTIC ([10621](https://github.com/civicrm/civicrm-core/pull/10621))**
+
+- **Misspelling ([10619](https://github.com/civicrm/civicrm-core/pull/10619))**
+
+- **[CRM-20823](https://issues.civicrm.org/jira/browse/CRM-20823) Price Set field with an Expiry Date still being 'required' after being expired. ([10613](https://github.com/civicrm/civicrm-core/pull/10613))**
+
+- **[CRM-20752](https://issues.civicrm.org/jira/browse/CRM-20752) Editing a Cancelled Pledge updates the status of it to Pending/Inprogress ([10535](https://github.com/civicrm/civicrm-core/pull/10535))**
+
+- **4.7.21 rc ([10616](https://github.com/civicrm/civicrm-core/pull/10616))**
+
+- **[CRM-20633](https://issues.civicrm.org/jira/browse/CRM-20633) custom field set displayed twice on register event Participant ([10551](https://github.com/civicrm/civicrm-core/pull/10551))**
+
+- **[CRM-20797](https://issues.civicrm.org/jira/browse/CRM-20797) Use is_payment to retrieve payments ([10587](https://github.com/civicrm/civicrm-core/pull/10587))**
+
+- **[CRM-20812](https://issues.civicrm.org/jira/browse/CRM-20812) Notice on live contribution when only pay later is selected ([10606](https://github.com/civicrm/civicrm-core/pull/10606))**
+
+- **4.7.21 rc ([10600](https://github.com/civicrm/civicrm-core/pull/10600))**
+
+- **4.7.21 rc ([10593](https://github.com/civicrm/civicrm-core/pull/10593))**
+
+- **Replace a couple of calls to deprecated function ([10527](https://github.com/civicrm/civicrm-core/pull/10527))**
+
+- **[CRM-19914](https://issues.civicrm.org/jira/browse/CRM-19914) civicrmHooks.php issues on windows ([10571](https://github.com/civicrm/civicrm-core/pull/10571))**
+
+- **[CRM-20774](https://issues.civicrm.org/jira/browse/CRM-20774) Add check for existing index keys(different values) while creating missing indices. ([10572](https://github.com/civicrm/civicrm-core/pull/10572) and [10566](https://github.com/civicrm/civicrm-core/pull/10566))**
+
+- **[CRM-19778](https://issues.civicrm.org/jira/browse/CRM-19778) Allowed statuses per case-type ([10552](https://github.com/civicrm/civicrm-core/pull/10552))**
+
+- **Update `master` with latest `4.7.21-rc` ([10570](https://github.com/civicrm/civicrm-core/pull/10570))**
+
+- **[CRM-20668](https://issues.civicrm.org/jira/browse/CRM-20668) Notice error ([10452](https://github.com/civicrm/civicrm-core/pull/10452))**
+
+- **4.7.21 rc ([10560](https://github.com/civicrm/civicrm-core/pull/10560))**
+
+- **4.7.21 rc ([10559](https://github.com/civicrm/civicrm-core/pull/10559))**
+
+- **[CRM-20722](https://issues.civicrm.org/jira/browse/CRM-20722) 'Lock wait timeout exceeded' error triggered on smart group cache rebuild ([10498](https://github.com/civicrm/civicrm-core/pull/10498))**
+
+- **[CRM-20761](https://issues.civicrm.org/jira/browse/CRM-20761) Formrule error when priceset is selected on contribution page ([10549](https://github.com/civicrm/civicrm-core/pull/10549))**
+
+- **[CRM-20758](https://issues.civicrm.org/jira/browse/CRM-20758) Fix deprecated fn call on import screen ([10544](https://github.com/civicrm/civicrm-core/pull/10544))**
+
+- **[CRM-20746](https://issues.civicrm.org/jira/browse/CRM-20746) CiviMail - text part of resubscribe confirmation mail contains html ([10528](https://github.com/civicrm/civicrm-core/pull/10528))**
+
+- **[CRM-20401](https://issues.civicrm.org/jira/browse/CRM-20401) Cancel/modify URL receipt links not correct for Paypal Website Payments Pro ([10424](https://github.com/civicrm/civicrm-core/pull/10424))**
+
+- **[CRM-20443](https://issues.civicrm.org/jira/browse/CRM-20443) SQL syntax error creating logging triggers if column name is reserved word ([10530](https://github.com/civicrm/civicrm-core/pull/10530))**
+
+- **[CRM-20745](https://issues.civicrm.org/jira/browse/CRM-20745) Post date of recur not respected in credit card pledge payment ([10524](https://github.com/civicrm/civicrm-core/pull/10524))**
+
+- **[CRM-20675](https://issues.civicrm.org/jira/browse/CRM-20675) Membership status update creates renewal activity ([10457](https://github.com/civicrm/civicrm-core/pull/10457))**
+
+- **4.7.21 rc ([10526](https://github.com/civicrm/civicrm-core/pull/10526))**
+
+- **[CRM-20541](https://issues.civicrm.org/jira/browse/CRM-20541) Edge case where DB connection is not available ([447](https://github.com/civicrm/civicrm-drupal/pull/447))**
+
+- **Fix spelling to canvass for civicrm_engage ([40](https://github.com/civicrm/civicrm-backdrop/pull/40))**
+
+- **Bug fixes - issues #22, #31, #33 ([39](https://github.com/civicrm/civicrm-backdrop/pull/39))**
+
+- **Improve Views checkbox value handling ([37](https://github.com/civicrm/civicrm-backdrop/pull/37))**
+
+- **add new views handlers to hook_autoload_info ([38](https://github.com/civicrm/civicrm-backdrop/pull/38))**
+
+- **Merge in civicrm/drupal from Dec 15, 2015 to June 21, 2017 ([36](https://github.com/civicrm/civicrm-backdrop/pull/36))**
+
+- **Port of civicrm_engage to Backdrop ([28](https://github.com/civicrm/civicrm-backdrop/pull/28))**
+
+### Import
+
+- **[CRM-20950](https://issues.civicrm.org/jira/browse/CRM-20950) Contact import mapping to wrong location type (unreleased regression) ([10736](https://github.com/civicrm/civicrm-core/pull/10736) and [10735](https://github.com/civicrm/civicrm-core/pull/10735))**
+
+### CiviContribute, CiviMail, CiviMember, WordPress Integration
+
+- **[CRM-19017](https://issues.civicrm.org/jira/browse/CRM-19017) Scheduled membership reminders have stopped working ([10652](https://github.com/civicrm/civicrm-core/pull/10652))**
+
+### CiviCRM API
+
+- **[CRM-20754](https://issues.civicrm.org/jira/browse/CRM-20754) memory leak in CLI CSV import ([10537](https://github.com/civicrm/civicrm-core/pull/10537))**
+
+### Dedupe
+
+- **[CRM-19702](https://issues.civicrm.org/jira/browse/CRM-19702) Fatal error when merging contact records with custom file fields ([9784](https://github.com/civicrm/civicrm-core/pull/9784))**
+
+### CiviContribute
+
+- **[CRM-20773](https://issues.civicrm.org/jira/browse/CRM-20773) Contribution tab shows Receive Date twice instead of Thank You date ([10607](https://github.com/civicrm/civicrm-core/pull/10607))**
+
+- **[CRM-20387](https://issues.civicrm.org/jira/browse/CRM-20387) Sales Tax and Invoicing code overwrites existing CiviCRM invoice ID ([10298](https://github.com/civicrm/civicrm-core/pull/10298))**
+
+- **[CRM-20488](https://issues.civicrm.org/jira/browse/CRM-20488) Lift restrictions for contact type soft credit ([10532](https://github.com/civicrm/civicrm-core/pull/10532) and [10419](https://github.com/civicrm/civicrm-core/pull/10419))**
+
+- **[CRM-19478](https://issues.civicrm.org/jira/browse/CRM-19478) API not handling Paypal recurring IPN where p=null for Contribution Page ([10447](https://github.com/civicrm/civicrm-core/pull/10447))**
+
+- **[CRM-20495](https://issues.civicrm.org/jira/browse/CRM-20495) "Contribution amounts section" checkbox setting on contribution pages always shows as checked. ([10521](https://github.com/civicrm/civicrm-core/pull/10521))**
+
+### CiviContribute, CiviMail
+
+- **[CRM-20747](https://issues.civicrm.org/jira/browse/CRM-20747) {contribution.campaign} token not working on Contribution ThankYou letter ([10533](https://github.com/civicrm/civicrm-core/pull/10533))**
+
+### CiviMail, NYSS
+
+- **[CRM-20412](https://issues.civicrm.org/jira/browse/CRM-20412) mailing report: unique opens detail view inaccurate ([10558](https://github.com/civicrm/civicrm-core/pull/10558))**
+
+- **[CRM-20411](https://issues.civicrm.org/jira/browse/CRM-20411) mailing tab listing: MySQL 5.7 group by error ([10562](https://github.com/civicrm/civicrm-core/pull/10562) and [10541](https://github.com/civicrm/civicrm-core/pull/10541))**
+
+### CiviCRM API, CiviEvent
+
+- **[CRM-20775](https://issues.civicrm.org/jira/browse/CRM-20775) Wrong is full results for API event get ([10568](https://github.com/civicrm/civicrm-core/pull/10568))**
+
+### CiviMember
+
+- **[CRM-20567](https://issues.civicrm.org/jira/browse/CRM-20567) backoffice membership via price set errors with non-aggregated column ([10346](https://github.com/civicrm/civicrm-core/pull/10346))**
+
+- **[CRM-20720](https://issues.civicrm.org/jira/browse/CRM-20720) CIVICRM-128 Unable to sort Price Options for Price Fieldset. Weight values are not being set at all in database. ([10542](https://github.com/civicrm/civicrm-core/pull/10542))**
+
+- **[CRM-20670](https://issues.civicrm.org/jira/browse/CRM-20670) Cannot edit membership type if lots of members already exist ([10534](https://github.com/civicrm/civicrm-core/pull/10534) and [10455](https://github.com/civicrm/civicrm-core/pull/10455))**
+
+### Dedupe, NYSS
+
+- **[CRM-19653](https://issues.civicrm.org/jira/browse/CRM-19653) Custom field checkboxes migrated incorrectly on merge (part deux) ([10407](https://github.com/civicrm/civicrm-core/pull/10407))**
+
+### CiviCRM Search
+
+- **[CRM-19821](https://issues.civicrm.org/jira/browse/CRM-19821) Remove performance degrading joins from activity search (& api calls) ([10274](https://github.com/civicrm/civicrm-core/pull/10274))**
+
+### CiviContribute, CiviCRM API
+
+- **[CRM-20525](https://issues.civicrm.org/jira/browse/CRM-20525) Webform Pay later sends Receipt email rather than Invoice email ([10306](https://github.com/civicrm/civicrm-core/pull/10306))**
+
+### CiviEvent
+
+- **[CRM-19745](https://issues.civicrm.org/jira/browse/CRM-19745) Image URL field doesn't show up on CiviEvent Additional Participants Profile ([9777](https://github.com/civicrm/civicrm-core/pull/9777))**
+
+### CiviMail
+
+- **[CRM-20713](https://issues.civicrm.org/jira/browse/CRM-20713) db error when populating mailing recipients because sms_provider_id is 'null' ([10487](https://github.com/civicrm/civicrm-core/pull/10487))**
+
+### Core CiviCRM, NYSS
+
+- **[CRM-20743](https://issues.civicrm.org/jira/browse/CRM-20743) users without reserved tag permission may still modify the tag ([10522](https://github.com/civicrm/civicrm-core/pull/10522))**
+
+- **[CRM-20621](https://issues.civicrm.org/jira/browse/CRM-20621) manage tags: the tag usage count is not accurate ([10441](https://github.com/civicrm/civicrm-core/pull/10441))**
+
+### Drupal Integration Modules
+
+- **[CRM-19976](https://issues.civicrm.org/jira/browse/CRM-19976) Drush: cannot disable civicrm debug ([457](https://github.com/civicrm/civicrm-drupal/pull/457))**
+
+## <a name="misc"></a>Miscellany
+
+## <a name="credits"></a>Credits
+
+This release was developed by the following code authors:
+
+AGH Strategies - Andrew Hunt; AronNovakInovae; Arun Singh; Australian Greens - Seamus Lee; Circle Interactive - Dave Jenkins; CiviCRM - Coleman Watts, Tim Otten; CiviDesk - Yashodha Chaku; CompuCorp - Michael Devery; Coop SymbioTIC - Mathieu Lutfy; Dave Greenberg; Electronic Frontier Foundation - Mark Burdett; Francesc Bassas i Bullich; Freeform Solutions - Herb van den Dool; Fuzion - Chris Burgess, Eileen McNaughton, Jitendra Purohit; JMA Consulting - Edsel Lopez, Monish Deb, Pradeep Nayak; JO0st; John Kingsnorth; Joinery - Allen Shaw; Klaas Eikelboom; laryn; Lighthouse Design and Consulting - Brian Shaughnessy; Mattias Michaux; MegaphoneJon; mepps; MJW Consulting - Matthew Wire; Oxfam Germany - Thomas Schüttler; Progressive Technology Project - Jamie McClelland; spencerbrooks; Squiffle Consulting - Aidan Saunders; Wikimedia Foundation - Eileen McNaughton
+
+Most authors also reviewed code for this release; in addition, the following
+reviewers contributed their comments:
+
+AGH Strategies - Andrew Hunt; Agileware - Agileware Team; andrimont; Arkadiusz Rzadkowolski; Australian Greens - Seamus Lee; Blackfly Solutions - Alan Dixon; Circle Interactive - Dave Jenkins; civicrm-builder; CiviCRM - Coleman Watts, Tim Otten; CiviDesk - Nicolas Ganivet, Yashodha Chaku; CompuCorp - Guanhuan Chen, Jamie Novick, Michael Devery, Mirela Stanila; Coop SymbioTIC - Mathieu Lutfy; Davi Alexandre; DevMate - Adam Kwiatkowski; diegov; dinalondon; Donald Hirst; ejegg; Electronic Frontier Foundation - Mark Burdett; Francesc Bassas i Bullich; Freeform Solutions - Herb van den Dool; Fuzion - Chris Burgess, Eileen McNaughton, Jitendra Purohit, Peter Davis; JMA Consulting - Edsel Lopez, Joe Murray, Monish Deb, Pradeep Nayak; JO0st; Johan Vervloet; John Kingsnorth; Joinery - Allen Shaw; Jon Goldberg; Klaas Eikelboom; Korlon - Stuart Gaston; Lighthouse Design and Consulting - Brian Shaughnessy; lpkb; MC3 - Graham Mitchell; mdlueck; MegaphoneJon; mepps; MJW Consulting - Matthew Wire; Nathan Brettell; Oxfam Germany - Thomas Schüttler; peter39; philmck; Progressive Technology Project - Jamie McClelland; Semper IT - Karin Gerritsen; Skvare - Mark Hanna; Squiffle Consulting - Aidan Saunders; Stephen Palmstrom; Tadpole Collective - Kevin Cristiano; torrance123; Upleaf - Osvaldo Gomez; Wikimedia Foundation - Eileen McNaughton

--- a/release-notes/4.7.23.md
+++ b/release-notes/4.7.23.md
@@ -11,7 +11,7 @@ Released August 2, 2017
 
 ## <a name="synopsis"></a>Synopsis
 
-| Does this version...?                                           |         |
+| *Does this version...?*                                           |         |
 |:--------------------------------------------------------------- |:-------:|
 | Fix security vulnerabilities?                                   | no      |
 | **Change the database schema?**                                 | **yes** |

--- a/release-notes/4.7.23.md
+++ b/release-notes/4.7.23.md
@@ -9,115 +9,181 @@ Released August 2, 2017;
 
 ## <a name="features"></a>Features
 
-### Import
-
-- **[CRM-20759](https://issues.civicrm.org/jira/browse/CRM-20759) Import, add 'Primary' as an address location ([10738](https://github.com/civicrm/civicrm-core/pull/10738), [10565](https://github.com/civicrm/civicrm-core/pull/10565), [10594](https://github.com/civicrm/civicrm-core/pull/10594), [10554](https://github.com/civicrm/civicrm-core/pull/10554), and [10547](https://github.com/civicrm/civicrm-core/pull/10547))**
-
 ### Core CiviCRM
 
-- **[CRM-20837](https://issues.civicrm.org/jira/browse/CRM-20837) Make setting bug more explicit ([10627](https://github.com/civicrm/civicrm-core/pull/10627))**
+- **[CRM-20830](https://issues.civicrm.org/jira/browse/CRM-20830) Improve
+  handling of overdue activities
+  ([10618](https://github.com/civicrm/civicrm-core/pull/10618))**
 
-- **[CRM-20847](https://issues.civicrm.org/jira/browse/CRM-20847) Support custom api with composite primary keys ([10599](https://github.com/civicrm/civicrm-core/pull/10599))**
+  Activity statuses can now be edited to denote whether activities with a given
+  status should be considered "complete" or not.  This attribute is now the
+  basis for determining whether an activity is overdue.  In addition to UI
+  indications of being overdue, the API can return this value for each activity.
 
-- **[CRM-20677](https://issues.civicrm.org/jira/browse/CRM-20677) Use generalised function to retrieve financial account ([10463](https://github.com/civicrm/civicrm-core/pull/10463))**
+- **[CRM-20803](https://issues.civicrm.org/jira/browse/CRM-20803) Enable Farsi
+  (fa_IR), Serbian (sr_RS), Ukrainian (uk_UA) in the languages option group so
+  that we can install in those languages
+  ([10667](https://github.com/civicrm/civicrm-core/pull/10667))**
 
-- **[CRM-20830](https://issues.civicrm.org/jira/browse/CRM-20830) Improve handling of overdue activities ([10618](https://github.com/civicrm/civicrm-core/pull/10618))**
+  These languages can now be used for installation of CiviCRM.
 
-- **[CRM-20794](https://issues.civicrm.org/jira/browse/CRM-20794) Colors for case status ([10586](https://github.com/civicrm/civicrm-core/pull/10586))**
+- **[CRM-20759](https://issues.civicrm.org/jira/browse/CRM-20759) Import, add
+  'Primary' as an address location
+  ([10738](https://github.com/civicrm/civicrm-core/pull/10738),
+  [10565](https://github.com/civicrm/civicrm-core/pull/10565),
+  [10594](https://github.com/civicrm/civicrm-core/pull/10594),
+  [10554](https://github.com/civicrm/civicrm-core/pull/10554), and
+  [10547](https://github.com/civicrm/civicrm-core/pull/10547))**
 
-- **[CRM-20849](https://issues.civicrm.org/jira/browse/CRM-20849) Multiple extensions using the same autoloader prefix will overwrite previous ([10637](https://github.com/civicrm/civicrm-core/pull/10637))**
+  Columns in imports can now import to fields in the matching contact's primary
+  address, regardless of location type.
 
-- **[CRM-20321](https://issues.civicrm.org/jira/browse/CRM-20321) Changing membership type should change related contribution ([10642](https://github.com/civicrm/civicrm-core/pull/10642) and [10370](https://github.com/civicrm/civicrm-core/pull/10370))**
+- **[CRM-20793](https://issues.civicrm.org/jira/browse/CRM-20793) Add filter -
+  activity date and status on search criteria of activity listing
+  ([10588](https://github.com/civicrm/civicrm-core/pull/10588))**
 
-- **[CRM-20842](https://issues.civicrm.org/jira/browse/CRM-20842) Change api explorer page title ([10633](https://github.com/civicrm/civicrm-core/pull/10633))**
+  The activity tab on a contact record now allows filtering by date and status
+  besides just activity type.  In addition, a site-wide option toggles whether a
+  user's filters on one contact's activities persist as they visit other
+  contacts.
 
-- **[CRM-20786](https://issues.civicrm.org/jira/browse/CRM-20786) Move deprecated utils functions to the import classes ([10578](https://github.com/civicrm/civicrm-core/pull/10578), [10580](https://github.com/civicrm/civicrm-core/pull/10580), [10579](https://github.com/civicrm/civicrm-core/pull/10579), and [10581](https://github.com/civicrm/civicrm-core/pull/10581))**
+- **[CRM-20847](https://issues.civicrm.org/jira/browse/CRM-20847) Support custom
+  api with composite primary keys
+  ([10599](https://github.com/civicrm/civicrm-core/pull/10599))**
 
-- **[CRM-20780](https://issues.civicrm.org/jira/browse/CRM-20780) Add drupal option to define CMS_ROOT ([10574](https://github.com/civicrm/civicrm-core/pull/10574))**
+  This change adds testing for custom APIs using the basic get function and
+  avoids automatically selecting the `id` field if there is no such field in the
+  spec.
 
-- **[CRM-20778](https://issues.civicrm.org/jira/browse/CRM-20778) Use civicontribute permission for contribution recur.cancel ([10569](https://github.com/civicrm/civicrm-core/pull/10569))**
+- **[CRM-20842](https://issues.civicrm.org/jira/browse/CRM-20842) Change api
+  explorer page title
+  ([10633](https://github.com/civicrm/civicrm-core/pull/10633))**
 
-- **[CRM-20169](https://issues.civicrm.org/jira/browse/CRM-20169) Add support for alterReportVar hook in Activity Report ([9886](https://github.com/civicrm/civicrm-core/pull/9886))**
+  The API Explorer now explicitly states it is demonstrating API v3.
 
-- **[CRM-20721](https://issues.civicrm.org/jira/browse/CRM-20721) Add parameter to dateQueryBuilder fn to change date value to desired format ([10497](https://github.com/civicrm/civicrm-core/pull/10497))**
+- **[CRM-20780](https://issues.civicrm.org/jira/browse/CRM-20780) Add settings
+  file option to define CMS_ROOT
+  ([10574](https://github.com/civicrm/civicrm-core/pull/10574))**
 
-- **[CRM-20739](https://issues.civicrm.org/jira/browse/CRM-20739) contact import doesn't add to group on fill if matching without ID ([10507](https://github.com/civicrm/civicrm-core/pull/10507))**
+  The CiviCRM settings file can now explicitly set the path to the CMS root.
 
-- **[CRM-20771](https://issues.civicrm.org/jira/browse/CRM-20771) Ensure that AddColumn in CRM_Upgrade_Incremental_Base can support translatable columns ([10561](https://github.com/civicrm/civicrm-core/pull/10561))**
+- **[CRM-20169](https://issues.civicrm.org/jira/browse/CRM-20169) Add support
+  for alterReportVar hook in Activity Report
+  ([9886](https://github.com/civicrm/civicrm-core/pull/9886))**
 
-- **[CRM-20756](https://issues.civicrm.org/jira/browse/CRM-20756) Multi tab structure ([10545](https://github.com/civicrm/civicrm-core/pull/10545))**
+  Extensions can now modify the SQL of the Activity Report.
 
-- **[CRM-20666](https://issues.civicrm.org/jira/browse/CRM-20666) enable uploading of files to activities that are up to 255 characters in length ([10449](https://github.com/civicrm/civicrm-core/pull/10449))**
+- **[CRM-20721](https://issues.civicrm.org/jira/browse/CRM-20721) Add parameter
+  to dateQueryBuilder fn to change date value to desired format
+  ([10497](https://github.com/civicrm/civicrm-core/pull/10497))**
 
-- **[CRM-20682](https://issues.civicrm.org/jira/browse/CRM-20682) Include human readable contribution's custom field label in token widget for Thankyou letter ([10467](https://github.com/civicrm/civicrm-core/pull/10467))**
+  Queries on fields formatted in ways other than the typical MySQL date format
+  can now use the standard date query builder method in the contact BAO.
 
-### Internationalisation
+- **[CRM-20600](https://issues.civicrm.org/jira/browse/CRM-20600) Expose
+  AngularJS screens to hooks
+  ([10644](https://github.com/civicrm/civicrm-core/pull/10644)) (follow-up
+  work)**
 
-- **[CRM-20803](https://issues.civicrm.org/jira/browse/CRM-20803) Enable Farsi (fa_IR), Serbian (sr_RS), Ukrainian (uk_UA) in the languages option group so that we can install in those languages ([10667](https://github.com/civicrm/civicrm-core/pull/10667))**
+  A message now displays both before and after upgrade if a site's configuration
+  is likely to prevent successful asset-caching.
 
-### CiviMail, Core CiviCRM
+- **[CRM-20673](https://issues.civicrm.org/jira/browse/CRM-20673) Tag and group
+  edit form: implement Select2 for tags
+  ([10634](https://github.com/civicrm/civicrm-core/pull/10634)) (completes
+  previous work)**
 
-- **[CRM-20600](https://issues.civicrm.org/jira/browse/CRM-20600) Expose AngularJS screens to hooks ([10644](https://github.com/civicrm/civicrm-core/pull/10644))**
+  Tags are now listed in the widget in the same order as they are displayed for
+  management.
 
-### Core CiviCRM, NYSS
+- **[CRM-20622](https://issues.civicrm.org/jira/browse/CRM-20622) contact edit:
+  tags and groups panel layout/styling
+  ([10429](https://github.com/civicrm/civicrm-core/pull/10429))**
 
-- **[CRM-20673](https://issues.civicrm.org/jira/browse/CRM-20673) Tag and group edit form: implement Select2 for tags ([10634](https://github.com/civicrm/civicrm-core/pull/10634))**
-
-- **[CRM-20622](https://issues.civicrm.org/jira/browse/CRM-20622) contact edit: tags and groups panel layout/styling ([10429](https://github.com/civicrm/civicrm-core/pull/10429))**
-
-### CiviCRM API
-
-- **[CRM-20833](https://issues.civicrm.org/jira/browse/CRM-20833) Change namespace for APIv4 entities ([10632](https://github.com/civicrm/civicrm-core/pull/10632) and [10625](https://github.com/civicrm/civicrm-core/pull/10625))**
-
-### CiviCRM Search, NYSS
-
-- **[CRM-20793](https://issues.civicrm.org/jira/browse/CRM-20793) Add filter - activity date and status on search criteria of activity listing   ([10588](https://github.com/civicrm/civicrm-core/pull/10588))**
+  The tag and group editing interface now uses standard markup rather than
+  unique, outdated approaches.
 
 ### CiviCase
 
-- **[CRM-20816](https://issues.civicrm.org/jira/browse/CRM-20816) Case multi/single client settings ([10609](https://github.com/civicrm/civicrm-core/pull/10609))**
+- **[CRM-20794](https://issues.civicrm.org/jira/browse/CRM-20794) Colors for
+  case status ([10586](https://github.com/civicrm/civicrm-core/pull/10586))
+  (preliminary work)**
 
-- **[CRM-20776](https://issues.civicrm.org/jira/browse/CRM-20776) Menu structure ([10573](https://github.com/civicrm/civicrm-core/pull/10573))**
+  When editing case statuses, you may now select a color.  However, case display
+  does not yet show the status colors.
 
-### CiviReport
+- **[CRM-20756](https://issues.civicrm.org/jira/browse/CRM-20756) Multi tab
+  structure ([10545](https://github.com/civicrm/civicrm-core/pull/10545))
+  (preliminary work)**
 
-- **[CRM-20640](https://issues.civicrm.org/jira/browse/CRM-20640) contribution summary report: duplicates values with group filter ([10603](https://github.com/civicrm/civicrm-core/pull/10603) and [10596](https://github.com/civicrm/civicrm-core/pull/10596))**
+  The AngularJS `ui.bootstrap` library is now included in CiviCRM.
 
-### CiviCase, CiviCRM API
+- **[CRM-20816](https://issues.civicrm.org/jira/browse/CRM-20816) Case
+  multi/single client settings
+  ([10609](https://github.com/civicrm/civicrm-core/pull/10609))**
 
-- **[CRM-20802](https://issues.civicrm.org/jira/browse/CRM-20802) CaseType.create - Stale definition retained in memory ([10591](https://github.com/civicrm/civicrm-core/pull/10591))**
-
-### CiviMail, NYSS
-
-- **[CRM-20781](https://issues.civicrm.org/jira/browse/CRM-20781) Truncate long text in mail listing  ([10576](https://github.com/civicrm/civicrm-core/pull/10576))**
-
-### CiviMember
-
-- **[CRM-20716](https://issues.civicrm.org/jira/browse/CRM-20716) Array to string issue on php7 when creating membership activity ([10492](https://github.com/civicrm/civicrm-core/pull/10492))**
-
-- **[CRM-20650](https://issues.civicrm.org/jira/browse/CRM-20650) Translate strings (ts) in CiviMember dashboard and Contribute manage ([10432](https://github.com/civicrm/civicrm-core/pull/10432))**
+  Settings for redacting activity emails, allowing multiple clients per case,
+  and the sort order of activity types can now be modified in an administrative
+  form rather than exclusively in XML files defining case types.
 
 ### CiviContribute
 
-- **[CRM-20765](https://issues.civicrm.org/jira/browse/CRM-20765) Missing id for 'onBehalfOfOrg' section ([10550](https://github.com/civicrm/civicrm-core/pull/10550))**
+- **[CRM-20778](https://issues.civicrm.org/jira/browse/CRM-20778) Use
+  civicontribute permission for contribution recur.cancel
+  ([10569](https://github.com/civicrm/civicrm-core/pull/10569))**
 
-- **[CRM-20753](https://issues.civicrm.org/jira/browse/CRM-20753) Net amount doesn't respect localization ([10536](https://github.com/civicrm/civicrm-core/pull/10536))**
+  The permissions to view, modify, cancel, and delete recurring contributions
+  now mirror the corresponding permissions needed for working with payments.
 
-### CiviEvent
+- **[CRM-20682](https://issues.civicrm.org/jira/browse/CRM-20682) Include human
+  readable contribution's custom field label in token widget for Thankyou letter
+  ([10467](https://github.com/civicrm/civicrm-core/pull/10467))**
 
-- **[CRM-20741](https://issues.civicrm.org/jira/browse/CRM-20741) Cancellation message shown as error ([10515](https://github.com/civicrm/civicrm-core/pull/10515))**
+  Contribution custom field tokens are now listed among the available tokens in
+  the Thank-you Letter form.  They had been processed, but there was no
+  indication that they were available.
 
-### Drupal Integration Modules
+### Drupal Integration
 
-- **[CRM-20751](https://issues.civicrm.org/jira/browse/CRM-20751) Support Drupal aliases for event links in Views ([456](https://github.com/civicrm/civicrm-drupal/pull/456) and [455](https://github.com/civicrm/civicrm-drupal/pull/455))**
+- **[CRM-20751](https://issues.civicrm.org/jira/browse/CRM-20751) Support Drupal
+  aliases for event links in Views
+  ([456](https://github.com/civicrm/civicrm-drupal/pull/456) and
+  [455](https://github.com/civicrm/civicrm-drupal/pull/455))**
+
+  If a CiviCRM event has a Drupal alias set for it, views linking to the event
+  will now link to the alias rather than the CiviCRM URL.
 
 ## <a name="bugs"></a>Bugs resolved
 
-### CiviContribute, CiviMember
-
-- **[CRM-18177](https://issues.civicrm.org/jira/browse/CRM-18177) When Renewing an existing membership, if CC details are incorrect, Membership is set to Cancelled preventing contact from trying again ([10770](https://github.com/civicrm/civicrm-core/pull/10770))**
-
 ### Core CiviCRM
+
+- **[CRM-20849](https://issues.civicrm.org/jira/browse/CRM-20849) Multiple
+  extensions using the same autoloader prefix will overwrite previous
+  ([10637](https://github.com/civicrm/civicrm-core/pull/10637))**
+
+- **[CRM-20739](https://issues.civicrm.org/jira/browse/CRM-20739) contact import
+  doesn't add to group on fill if matching without ID
+  ([10507](https://github.com/civicrm/civicrm-core/pull/10507))**
+
+- **[CRM-20666](https://issues.civicrm.org/jira/browse/CRM-20666) enable
+  uploading of files to activities that are up to 255 characters in length
+  ([10449](https://github.com/civicrm/civicrm-core/pull/10449))**
+
+  File names of activity uploads had previously been capped at 60 characters.
+
+- **[CRM-20776](https://issues.civicrm.org/jira/browse/CRM-20776) Menu structure
+  ([10573](https://github.com/civicrm/civicrm-core/pull/10573))**
+
+  This fixes incorrect handling of URL paths, queries and fragments in the
+  navigation menu.  This was a particular problem for AngularJS pages.
+
+- **[CRM-20640](https://issues.civicrm.org/jira/browse/CRM-20640) contribution
+  summary report: duplicates values with group filter
+  ([10603](https://github.com/civicrm/civicrm-core/pull/10603) and
+  [10596](https://github.com/civicrm/civicrm-core/pull/10596))**
+
+  Reports with group filters would display rows twice if multiple groups were
+  selected in the filter and contacts were in more than one of those groups.
 
 - **[CRM-20953](https://issues.civicrm.org/jira/browse/CRM-20953) Importing contacts with deceased_date not setting is_deceased ([10742](https://github.com/civicrm/civicrm-core/pull/10742))**
 
@@ -247,7 +313,26 @@ Released August 2, 2017;
 
 - **[CRM-19702](https://issues.civicrm.org/jira/browse/CRM-19702) Fatal error when merging contact records with custom file fields ([9784](https://github.com/civicrm/civicrm-core/pull/9784))**
 
+### CiviCase
+
+- **[CRM-20802](https://issues.civicrm.org/jira/browse/CRM-20802)
+  CaseType.create - Stale definition retained in memory
+  ([10591](https://github.com/civicrm/civicrm-core/pull/10591))**
+
+  Cached case type information was retained even after modifying the case type.
+
 ### CiviContribute
+
+- **[CRM-20765](https://issues.civicrm.org/jira/browse/CRM-20765) Missing id for
+  'onBehalfOfOrg' section
+  ([10550](https://github.com/civicrm/civicrm-core/pull/10550))**
+
+  The `<div>` containing on-behalf section on contribution pages lacks the
+  `onBehalfOfOrg` ID attribute that it had in 4.6.
+
+- **[CRM-20753](https://issues.civicrm.org/jira/browse/CRM-20753) Net amount
+  doesn't respect localization
+  ([10536](https://github.com/civicrm/civicrm-core/pull/10536))**
 
 - **[CRM-20773](https://issues.civicrm.org/jira/browse/CRM-20773) Contribution tab shows Receive Date twice instead of Thank You date ([10607](https://github.com/civicrm/civicrm-core/pull/10607))**
 
@@ -275,6 +360,19 @@ Released August 2, 2017;
 
 ### CiviMember
 
+- **[CRM-20716](https://issues.civicrm.org/jira/browse/CRM-20716) Array to
+  string issue on php7 when creating membership activity
+  ([10492](https://github.com/civicrm/civicrm-core/pull/10492))**
+
+- **[CRM-20650](https://issues.civicrm.org/jira/browse/CRM-20650) Translate
+  strings (ts) in CiviMember dashboard and Contribute manage
+  ([10432](https://github.com/civicrm/civicrm-core/pull/10432))**
+
+- **[CRM-18177](https://issues.civicrm.org/jira/browse/CRM-18177) When Renewing
+  an existing membership, if CC details are incorrect, Membership is set to
+  Cancelled preventing contact from trying again
+  ([10770](https://github.com/civicrm/civicrm-core/pull/10770)) (fix to problem introduced in original bug fix)**
+
 - **[CRM-20567](https://issues.civicrm.org/jira/browse/CRM-20567) backoffice membership via price set errors with non-aggregated column ([10346](https://github.com/civicrm/civicrm-core/pull/10346))**
 
 - **[CRM-20720](https://issues.civicrm.org/jira/browse/CRM-20720) CIVICRM-128 Unable to sort Price Options for Price Fieldset. Weight values are not being set at all in database. ([10542](https://github.com/civicrm/civicrm-core/pull/10542))**
@@ -295,9 +393,20 @@ Released August 2, 2017;
 
 ### CiviEvent
 
+- **[CRM-20741](https://issues.civicrm.org/jira/browse/CRM-20741) Cancellation
+  message shown as error
+  ([10515](https://github.com/civicrm/civicrm-core/pull/10515))**
+
 - **[CRM-19745](https://issues.civicrm.org/jira/browse/CRM-19745) Image URL field doesn't show up on CiviEvent Additional Participants Profile ([9777](https://github.com/civicrm/civicrm-core/pull/9777))**
 
 ### CiviMail
+
+- **[CRM-20781](https://issues.civicrm.org/jira/browse/CRM-20781) Truncate long
+  text in mail listing
+  ([10576](https://github.com/civicrm/civicrm-core/pull/10576))**
+
+  Long values in columns would crowd other columns off the screen or into
+  illegibility.
 
 - **[CRM-20713](https://issues.civicrm.org/jira/browse/CRM-20713) db error when populating mailing recipients because sms_provider_id is 'null' ([10487](https://github.com/civicrm/civicrm-core/pull/10487))**
 
@@ -312,6 +421,32 @@ Released August 2, 2017;
 - **[CRM-19976](https://issues.civicrm.org/jira/browse/CRM-19976) Drush: cannot disable civicrm debug ([457](https://github.com/civicrm/civicrm-drupal/pull/457))**
 
 ## <a name="misc"></a>Miscellany
+
+- **[CRM-20837](https://issues.civicrm.org/jira/browse/CRM-20837) Make setting
+  bug more explicit
+  ([10627](https://github.com/civicrm/civicrm-core/pull/10627))**
+
+- **[CRM-20677](https://issues.civicrm.org/jira/browse/CRM-20677) Use
+  generalised function to retrieve financial account
+  ([10463](https://github.com/civicrm/civicrm-core/pull/10463))**
+
+- **[CRM-20786](https://issues.civicrm.org/jira/browse/CRM-20786) Move
+  deprecated utils functions to the import classes
+  ([10578](https://github.com/civicrm/civicrm-core/pull/10578),
+  [10580](https://github.com/civicrm/civicrm-core/pull/10580),
+  [10579](https://github.com/civicrm/civicrm-core/pull/10579), and
+  [10581](https://github.com/civicrm/civicrm-core/pull/10581))**
+
+- **[CRM-20771](https://issues.civicrm.org/jira/browse/CRM-20771) Ensure that
+  AddColumn in CRM_Upgrade_Incremental_Base can support translatable columns
+  ([10561](https://github.com/civicrm/civicrm-core/pull/10561))**
+
+- **[CRM-20833](https://issues.civicrm.org/jira/browse/CRM-20833) Change
+  namespace for APIv4 entities
+  ([10632](https://github.com/civicrm/civicrm-core/pull/10632) and
+  [10625](https://github.com/civicrm/civicrm-core/pull/10625))**
+
+  The namespace is now `Civi\Api4\Entity` rather than `Civi\Api4`.
 
 ## <a name="credits"></a>Credits
 

--- a/release-notes/4.7.23.md
+++ b/release-notes/4.7.23.md
@@ -11,7 +11,7 @@ Released August 2, 2017
 
 ## <a name="synopsis"></a>Synopsis
 
-| Does this version                                               |         |
+| Does this version...?                                           |         |
 |:--------------------------------------------------------------- |:-------:|
 | Fix security vulnerabilities?                                   | no      |
 | **Change the database schema?**                                 | **yes** |

--- a/release-notes/4.7.23.md
+++ b/release-notes/4.7.23.md
@@ -640,9 +640,30 @@ Released August 2, 2017
 
 This release was developed by the following code authors:
 
-AGH Strategies - Andrew Hunt; AronNovakInovae; Arun Singh; Australian Greens - Seamus Lee; Circle Interactive - Dave Jenkins; CiviCRM - Coleman Watts, Tim Otten; CiviDesk - Yashodha Chaku; CompuCorp - Michael Devery; Coop SymbioTIC - Mathieu Lutfy; Dave Greenberg; Electronic Frontier Foundation - Mark Burdett; Francesc Bassas i Bullich; Freeform Solutions - Herb van den Dool; Fuzion - Chris Burgess, Eileen McNaughton, Jitendra Purohit; JMA Consulting - Edsel Lopez, Monish Deb, Pradeep Nayak; JO0st; John Kingsnorth; Joinery - Allen Shaw; Klaas Eikelboom; laryn; Lighthouse Design and Consulting - Brian Shaughnessy; Mattias Michaux; MegaphoneJon; mepps; MJW Consulting - Matthew Wire; Oxfam Germany - Thomas Schüttler; Progressive Technology Project - Jamie McClelland; spencerbrooks; Squiffle Consulting - Aidan Saunders; Wikimedia Foundation - Eileen McNaughton
+AGH Strategies - Andrew Hunt; Arun Singh; Australian Greens - Seamus Lee; Brooks
+Digital - Spencer Brooks; CEDC - Laryn Kragt Bakker; Circle Interactive - Dave
+Jenkins; CiviCRM - Coleman Watts, Tim Otten; CiviDesk - Yashodha Chaku;
+CompuCorp - Michael Devery; Coop SymbioTIC - Mathieu Lutfy; Dave Greenberg;
+Electronic Frontier Foundation - Mark Burdett; Francesc Bassas i Bullich;
+Freeform Solutions - Herb van den Dool; Fuzion - Chris Burgess, Eileen
+McNaughton, Jitendra Purohit; Gizra - Aron Novak; JMA Consulting - Edsel Lopez,
+Monish Deb, Pradeep Nayak; John Kingsnorth; Joinery - Allen Shaw; Joost Fock;
+Klaas Eikelboom; Lighthouse Design and Consulting - Brian Shaughnessy; Mattias
+Michaux; Megaphone Technology Consulting - Jon Goldberg; MJW Consulting -
+Matthew Wire; Oxfam Germany - Thomas Schüttler; Progressive Technology Project -
+Jamie McClelland; Squiffle Consulting - Aidan Saunders; Wikimedia Foundation -
+Eileen McNaughton, Maggie Epps
 
 Most authors also reviewed code for this release; in addition, the following
 reviewers contributed their comments:
 
-AGH Strategies - Andrew Hunt; Agileware - Agileware Team; andrimont; Arkadiusz Rzadkowolski; Australian Greens - Seamus Lee; Blackfly Solutions - Alan Dixon; Circle Interactive - Dave Jenkins; civicrm-builder; CiviCRM - Coleman Watts, Tim Otten; CiviDesk - Nicolas Ganivet, Yashodha Chaku; CompuCorp - Guanhuan Chen, Jamie Novick, Michael Devery, Mirela Stanila; Coop SymbioTIC - Mathieu Lutfy; Davi Alexandre; DevMate - Adam Kwiatkowski; diegov; dinalondon; Donald Hirst; ejegg; Electronic Frontier Foundation - Mark Burdett; Francesc Bassas i Bullich; Freeform Solutions - Herb van den Dool; Fuzion - Chris Burgess, Eileen McNaughton, Jitendra Purohit, Peter Davis; JMA Consulting - Edsel Lopez, Joe Murray, Monish Deb, Pradeep Nayak; JO0st; Johan Vervloet; John Kingsnorth; Joinery - Allen Shaw; Jon Goldberg; Klaas Eikelboom; Korlon - Stuart Gaston; Lighthouse Design and Consulting - Brian Shaughnessy; lpkb; MC3 - Graham Mitchell; mdlueck; MegaphoneJon; mepps; MJW Consulting - Matthew Wire; Nathan Brettell; Oxfam Germany - Thomas Schüttler; peter39; philmck; Progressive Technology Project - Jamie McClelland; Semper IT - Karin Gerritsen; Skvare - Mark Hanna; Squiffle Consulting - Aidan Saunders; Stephen Palmstrom; Tadpole Collective - Kevin Cristiano; torrance123; Upleaf - Osvaldo Gomez; Wikimedia Foundation - Eileen McNaughton
+Agileware - Agileware Team; Arkadiusz Rzadkowolski; Blackfly Solutions - Alan
+Dixon; CiviDesk - Nicolas Ganivet; CompuCorp - Davi Alexandre, Guanhuan Chen,
+Jamie Novick, Mirela Stanila; DevMate - Adam Kwiatkowski; Donald Hirst; DotPro -
+Diego Viegas; F. M. Andrimont; Fuzion - Peter Davis, Torrance Hodgson; JMA
+Consulting - Joe Murray, Pradeep Nayak; Johan Vervloet; Jvillage Network - Dina
+London; Korlon - Stuart Gaston; Lueck Data Systems - Michael Lueck; MC3 - Graham
+Mitchell; Nathan Brettell; Oxfam Germany - Thomas Schüttler; Peter Bull; Phil
+McKerracher; Semper IT - Karin Gerritsen; Skvare - Mark Hanna; Stephen
+Palmstrom; Tadpole Collective - Kevin Cristiano; Upleaf - Osvaldo Gomez;
+Wikimedia Foundation - Elliott Eggleston

--- a/release-notes/4.7.23.md
+++ b/release-notes/4.7.23.md
@@ -9,13 +9,13 @@ Released August 2, 2017
 
 | Does this version                                               |         |
 |:--------------------------------------------------------------- |:-------:|
-| fix security vulnerabilities?                                   | no      |
-| **change the database schema?**                                 | **yes** |
-| **alter the API?**                                              | **yes** |
-| **require attention to configuration options?**                 | **yes** |
-| **fix problems installing or upgrading to a previous version?** | **yes** |
-| **introduce features?**                                         | **yes** |
-| **fix bugs?**                                                   | **yes** |
+| Fix security vulnerabilities?                                   | no      |
+| **Change the database schema?**                                 | **yes** |
+| **Alter the API?**                                              | **yes** |
+| **Require attention to configuration options?**                 | **yes** |
+| **Fix problems installing or upgrading to a previous version?** | **yes** |
+| **Introduce features?**                                         | **yes** |
+| **Fix bugs?**                                                   | **yes** |
 
 ## <a name="features"></a>Features
 


### PR DESCRIPTION
@totten @eileenmcnaughton the release notes for 4.7.23 were never merged into the master branch, So i think we should merge them into the 4.7.24-rc branch and then merge from the rc branch into master so that when 4.7.24 is released it has 4.7.23 release notes in it