### PR TITLE
CRM-20468: HTMLInputCoder: do not escape the content field, breaks attachments

### DIFF
--- a/CRM/Utils/API/HTMLInputCoder.php
+++ b/CRM/Utils/API/HTMLInputCoder.php
@@ -109,6 +109,7 @@ class CRM_Utils_API_HTMLInputCoder extends CRM_Utils_API_AbstractFieldCoder {
         'new', // The 'new' text in word replacements
         'replyto_email', // e.g. '"Full Name" <user@example.org>'
         'operator',
+        'content', // CRM-20468
       );
     }
     return $this->skipFields;


### PR DESCRIPTION
Overview
----------------------------------------

When using the REST API to upload attachments using the Attachment.create API, the "content" field gets escaped by 'CRM_Utils_API_HTMLInputCoder'. This can result in corrupt file attachments if they happen to have a '<' character in them (ex: with a JPG file).

The JIRA issue includes sample Python code.

Before
----------------------------------------

The '<' gets incorrectly escaped, corrupting the file.

After
----------------------------------------

The attachment does not get corrupted.

Technical Details
----------------------------------------

This PR adds 'content' as a whitelisted field to not be escaped on input.

Comments
----------------------------------------

I've been using this patch for a few months, now bundled by default on SymbioTIC's platform.

---

 * [CRM-20468: Attachment.create API HTML escapes the uploaded content](https://issues.civicrm.org/jira/browse/CRM-20468)