### PR TITLE
CRM-21085 Replace mcrypt functions where possible with openssl versio…

### DIFF
--- a/CRM/Upgrade/Incremental/php/FourSeven.php
+++ b/CRM/Upgrade/Incremental/php/FourSeven.php
@@ -414,6 +414,7 @@ class CRM_Upgrade_Incremental_php_FourSeven extends CRM_Upgrade_Incremental_Base
       'civicrm_menu', 'module_data', "text COMMENT 'All other menu metadata not stored in other fields'");
     $this->addTask('CRM-21052 - Determine activity revision policy', 'pickActivityRevisionPolicy');
     $this->addTask(ts('Upgrade DB to %1: SQL', array(1 => $rev)), 'runSql', $rev);
+    $this->addTask('CRM-21085 - Convert passwords from mcrypt to openssl', 'updateEncryptionMethod');
   }
 
 
@@ -1215,6 +1216,23 @@ FROM `civicrm_dashboard_contact` JOIN `civicrm_contact` WHERE civicrm_dashboard_
     $config = CRM_Core_Config::singleton();
     $check = new CRM_Utils_Check_Component_Security();
     return $config->imageUploadDir && $config->imageUploadURL && $check->isDirAccessible($config->imageUploadDir, $config->imageUploadURL);
+  }
+
+  public static function updateEncryptionMethod() {
+    $mailingInfo = CRM_Core_DAO::executeQuery("SELECT domain_id, value FROM civicrm_setting WHERE name = 'mailing_backend'")->fetchAll();
+    foreach ($mailingInfo as $mailing) {
+      $values = unserialize($mailing['info']);
+      if (!empty($values['smtpPassword'])) {
+        $password = CRM_Utils_Crypt::decrypt($values, TRUE);
+        $values['smtpPassword'] = CRM_Utils_Crypt::encrypt($password);
+      }
+      $values = serialize($values);
+      CRM_Core_DAO::executeQuery("UPDATE civicrm_setting set value = %1 WHERE domain_id = %2 AND name = 'mailing_backend'", array(
+        1 => array($values, 'String'),
+        2 => array($mailing['domain_id'], 'Positive'),
+      ));
+    }
+    return TRUE;
   }
 
 }

--- a/CRM/Upgrade/Incremental/php/FourSeven.php
+++ b/CRM/Upgrade/Incremental/php/FourSeven.php
@@ -1223,8 +1223,7 @@ FROM `civicrm_dashboard_contact` JOIN `civicrm_contact` WHERE civicrm_dashboard_
     foreach ($mailingInfo as $mailing) {
       $values = unserialize($mailing['value']);
       if (!empty($values['smtpPassword'])) {
-        $password = CRM_Utils_Crypt::decrypt($values['smtpPassword'], TRUE);
-        $values['smtpPassword'] = CRM_Utils_Crypt::encrypt($password);
+        $values['smtpPassword'] = CRM_Utils_Crypt::convertMcryptToOpenSSL($values['smtpPassword']);
         $values = serialize($values);
         CRM_Core_DAO::executeQuery("UPDATE civicrm_setting set value = %1 WHERE domain_id = %2 AND name = 'mailing_backend'", array(
           1 => array($values, 'String'),

--- a/CRM/Upgrade/Incremental/php/FourSeven.php
+++ b/CRM/Upgrade/Incremental/php/FourSeven.php
@@ -1221,16 +1221,16 @@ FROM `civicrm_dashboard_contact` JOIN `civicrm_contact` WHERE civicrm_dashboard_
   public static function updateEncryptionMethod() {
     $mailingInfo = CRM_Core_DAO::executeQuery("SELECT domain_id, value FROM civicrm_setting WHERE name = 'mailing_backend'")->fetchAll();
     foreach ($mailingInfo as $mailing) {
-      $values = unserialize($mailing['info']);
+      $values = unserialize($mailing['value']);
       if (!empty($values['smtpPassword'])) {
-        $password = CRM_Utils_Crypt::decrypt($values, TRUE);
+        $password = CRM_Utils_Crypt::decrypt($values['smtpPassword'], TRUE);
         $values['smtpPassword'] = CRM_Utils_Crypt::encrypt($password);
+        $values = serialize($values);
+        CRM_Core_DAO::executeQuery("UPDATE civicrm_setting set value = %1 WHERE domain_id = %2 AND name = 'mailing_backend'", array(
+          1 => array($values, 'String'),
+          2 => array($mailing['domain_id'], 'Positive'),
+        ));
       }
-      $values = serialize($values);
-      CRM_Core_DAO::executeQuery("UPDATE civicrm_setting set value = %1 WHERE domain_id = %2 AND name = 'mailing_backend'", array(
-        1 => array($values, 'String'),
-        2 => array($mailing['domain_id'], 'Positive'),
-      ));
     }
     return TRUE;
   }

--- a/CRM/Utils/Crypt.php
+++ b/CRM/Utils/Crypt.php
@@ -111,4 +111,18 @@ class CRM_Utils_Crypt {
     return $string;
   }
 
+  /**
+   * Convert a Mcrypted sring into one of a openssl encryption
+   * @param string $string base64 encoded mcrypt encoded string
+   * @return string - basee64 encoded OpenSSL string
+   */
+  public static function convertMcryptToOpenSSL($string = NULL) {
+    if (empty($string)) {
+      return $string;
+    }
+    $decodedString = self::decrypt($string, TRUE);
+    $encodedString = self::encrypt($decodedString);
+    return $encodedString;
+  }
+
 }

--- a/tests/phpunit/CRM/Utils/CryptTest.php
+++ b/tests/phpunit/CRM/Utils/CryptTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Class CRM_Utils_CryptTest
+ * @group headless
+ */
+class CRM_Utils_CryptTest extends CiviUnitTestCase {
+
+  public function testMcryptToOpenSSL() {
+    $testString = 'This is a test encrpytion';
+    if (function_exists('mcrypt_module_open') && defined('CIVICRM_SITE_KEY')) {
+      $td = mcrypt_module_open(MCRYPT_RIJNDAEL_256, '', MCRYPT_MODE_ECB, '');
+      // ECB mode - iv not needed - CRM-8198
+      $iv = '00000000000000000000000000000000';
+      $ks = mcrypt_enc_get_key_size($td);
+      $key = substr(sha1(CIVICRM_SITE_KEY), 0, $ks);
+      mcrypt_generic_init($td, $key, $iv);
+      $string = mcrypt_generic($td, $testString);
+      mcrypt_generic_deinit($td);
+      mcrypt_module_close($td);
+      $mcryptString = base64_encode($string);
+      if (function_exists('openssl_encrypt')) {
+        $decrptyedMcryptString = CRM_Utils_Crypt::decrypt($mcryptString, TRUE);
+        $opensslEncrpyt = CRM_Utils_Crypt::encrypt($decrptyedMcryptString);
+        $opensslDecryted = CRM_Utils_Crypt::decrypt($opensslEncrpyt);
+        $this->assertEquals($testString, $opensslDecryted);
+      }
+      else {
+        $this->fail('OpenSSL module not avaliable');
+      }
+    }
+    else {
+      $this->fail('mcrypt is not enabled or site_key is not defined');
+    }
+  }
+
+}


### PR DESCRIPTION
…ns and add in upgrade step to convert

Overview
----------------------------------------
mcrypt functions are deprecated as of PHP7.1 and need to be replaced and there seems to be an obvious openSSL version we can use

Before
----------------------------------------
mcrypt was used to encrypt passwords

After
----------------------------------------
openssl is used for encryption

Technical Details
----------------------------------------
as per description changing encryption styles

Comments
----------------------------------------
@totten @xurizaemon @eileenmcnaughton i think this on the face of it should cover things. However we will need to alert extension authors to this and down stream folks. This is one area that makes it difficult manage but its an issue we need to address
