### PR TITLE
CRM-21070 Remove reference to outdated template url file

### DIFF
--- a/ang/crmMailing/Recipients.js
+++ b/ang/crmMailing/Recipients.js
@@ -8,7 +8,6 @@
       scope: {
         ngRequired: '@'
       },
-      templateUrl: '~/crmMailing/Recipients.html',
       link: function(scope, element, attrs, ngModel) {
         scope.recips = ngModel.$viewValue;
         scope.groups = scope.$parent.$eval(attrs.crmAvailGroups);


### PR DESCRIPTION
Overview
----------------------------------------
In wordpress it would appear that this line causes it to try and load the template file that has now been removed. This was a change introduced in 4.7.24

ping @monishdeb @eileenmcnaughton

---

 * [CRM-21070: Unable to set Recipients in CiviMail in 4.7.24-rc](https://issues.civicrm.org/jira/browse/CRM-21070)