### PR TITLE
CRM-21087: Payment popup goes weird if you click 'adjust payment amount'

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -104,7 +104,7 @@
             <div id="priceset" class="hiddenElement"></div>
           {/if}
 
-          {if $ppID}{ts}<a href='#' onclick='adjustPayment();'>adjust payment amount</a>{/ts}{help id="adjust-payment-amount"}{/if}
+          {if $ppID}{ts}<a class='action-item crm-hover-button' onclick='adjustPayment();'>adjust payment amount</a>{/ts}{help id="adjust-payment-amount"}{/if}
           <div id="totalAmountBlock">
             {if $hasPriceSets}<span class="description">{ts}Alternatively, you can use a price set.{/ts}</span>{/if}
             <div id="totalTaxAmount" class="label"></div>


### PR DESCRIPTION
Overview
----------------------------------------
Fix page focus on click of anchor tag.

Before
----------------------------------------
Clicking on "adjust payment amount" link on pledge payment ajax popup, the page focus changes to the top of the page, and you have to manually lift the popup up to see the Save button at the bottom.

After
----------------------------------------
works fine.

---

 * [CRM-21087: Payment popup goes weird if you click 'adjust payment amount'.](https://issues.civicrm.org/jira/browse/CRM-21087)