### PR TITLE
CRM-21086: Allow Inline Download of Files

### DIFF
--- a/CRM/Core/Page/File.php
+++ b/CRM/Core/Page/File.php
@@ -42,6 +42,8 @@ class CRM_Core_Page_File extends CRM_Core_Page {
     $path = CRM_Core_Config::singleton()->customFileUploadDir . $fileName;
     $mimeType = CRM_Utils_Request::retrieve('mime-type', 'String', $this);
     $action = CRM_Utils_Request::retrieve('action', 'String', $this);
+    $download = CRM_Utils_Request::retrieve('download', 'Integer', $this, FALSE, 1);
+    $disposition = $download === 0 ? 'inline' : 'download';
 
     // if we are not providing essential parameter needed for file preview then
     if (empty($fileName) && empty($mimeType)) {
@@ -76,7 +78,10 @@ class CRM_Core_Page_File extends CRM_Core_Page {
       CRM_Utils_System::download(
         CRM_Utils_File::cleanFileName(basename($path)),
         $mimeType,
-        $buffer
+        $buffer,
+        NULL,
+        TRUE,
+        $disposition
       );
     }
   }

--- a/CRM/Core/Page/File.php
+++ b/CRM/Core/Page/File.php
@@ -43,7 +43,7 @@ class CRM_Core_Page_File extends CRM_Core_Page {
     $mimeType = CRM_Utils_Request::retrieve('mime-type', 'String', $this);
     $action = CRM_Utils_Request::retrieve('action', 'String', $this);
     $download = CRM_Utils_Request::retrieve('download', 'Integer', $this, FALSE, 1);
-    $disposition = $download === 0 ? 'inline' : 'download';
+    $disposition = $download == 0 ? 'inline' : 'download';
 
     // if we are not providing essential parameter needed for file preview then
     if (empty($fileName) && empty($mimeType)) {


### PR DESCRIPTION
Overview
----------------------------------------
Using the `/civicrm/file` endpoint to access a file will always download them without giving the option to view in the browser. By adding a query parameter we can allow browsers to show the content inline, if it is supported.

Before
----------------------------------------
Files served from `/civicrm/file` will always be downloaded.

![anim](https://user-images.githubusercontent.com/6374064/30125335-08831094-9330-11e7-8fae-f3ebdc27bd3f.gif)

After
----------------------------------------
Files served from `/civicrm/file` with the query param download=0 will be shown inline in the browser, if the browser supports it.

In order to show how this worked I changed a line in [attachment.tpl](https://github.com/civicrm/civicrm-core/blob/master/templates/CRM/Form/attachment.tpl#L34)

`<a target="_blank" href="{$attVal.url}">`

to

`<a target="_blank" href="{$attVal.url}&download=0">`

![anim](https://user-images.githubusercontent.com/6374064/30125275-cdbea270-932f-11e7-8bdb-f37f81f766aa.gif)

---

 * [CRM-21086: Allow Inline View of Files Instead of Download](https://issues.civicrm.org/jira/browse/CRM-21086)