### PR TITLE
CRM-21089 - CiviSurvey - Fix fatal error on 'Interview Respondents'

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2761,6 +2761,10 @@ class CRM_Contact_BAO_Query {
             $from .= CRM_Mailing_BAO_Query::from($name, $mode, $side);
             continue;
           }
+          elseif ($mode & CRM_Contact_BAO_Query::MODE_CAMPAIGN) {
+            $from .= CRM_Campaign_BAO_Query::from($name, $mode, $side);
+            continue;
+          }
 
         case 'civicrm_website':
           $from .= " $side JOIN civicrm_website ON contact_a.id = civicrm_website.contact_id ";


### PR DESCRIPTION
Overview
----------------------------------------
Attempting to use "Interview Respondents" in CiviSurvey results in a fatal error.  See [CRM-21089](https://issues.civicrm.org/jira/browse/CRM-21089) for details on how to replicate.

Before
----------------------------------------
See above.

After
----------------------------------------
Fatal error no longer exists.

Technical Details
----------------------------------------
This is a SQL error that results from `civicrm_campaign` not being added to the FROM clause of the SQL statement.  This patch calls the function that adds the correct FROM statement when building a query from within CiviSurvey.