### PR TITLE
NFC remove some unused vars, fix comment

### DIFF
--- a/CRM/Contact/Form/Task.php
+++ b/CRM/Contact/Form/Task.php
@@ -459,7 +459,6 @@ class CRM_Contact_Form_Task extends CRM_Core_Form {
     // If contact list has changed, households will probably be at the end of
     // the list. Sort it again by sort_name.
     if (implode(',', $this->_contactIds) != $relID) {
-      $contact_sort = array();
       $result = civicrm_api3('Contact', 'get', array(
         'return' => array('id'),
         'id' => array('IN' => $this->_contactIds),
@@ -484,7 +483,6 @@ class CRM_Contact_Form_Task extends CRM_Core_Form {
     $searchParams = $this->controller->exportValues();
     if ($searchParams['radio_ts'] == 'ts_sel') {
       // Create a static group.
-
       $randID = md5(time() . rand(1, 1000)); // groups require a unique name
       $grpTitle = "Hidden Group {$randID}";
       $grpID = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Group', $grpTitle, 'id', 'title');
@@ -509,7 +507,7 @@ class CRM_Contact_Form_Task extends CRM_Core_Form {
           'title' => $newGroupTitle,
           'group_type' => array('2' => 1),
         );
-        $group = CRM_Contact_BAO_Group::create($groupParams);
+        CRM_Contact_BAO_Group::create($groupParams);
       }
 
       // note at this point its a static group
@@ -517,7 +515,6 @@ class CRM_Contact_Form_Task extends CRM_Core_Form {
     }
     else {
       // Create a smart group.
-
       $ssId = $this->get('ssID');
       $hiddenSmartParams = array(
         'group_type' => array('2' => 1),

--- a/CRM/Event/Form/Task/Badge.php
+++ b/CRM/Event/Form/Task/Badge.php
@@ -29,13 +29,10 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2017
- * $Id$
- *
  */
 
 /**
- * This class helps to print the labels for contacts
- *
+ * This class helps to print the labels for contacts.
  */
 class CRM_Event_Form_Task_Badge extends CRM_Event_Form_Task {
 
@@ -83,9 +80,6 @@ class CRM_Event_Form_Task_Badge extends CRM_Event_Form_Task {
 
   /**
    * Build the form object.
-   *
-   *
-   * @return void
    */
   public function buildQuickForm() {
     CRM_Utils_System::setTitle(ts('Make Name Badges'));
@@ -111,9 +105,6 @@ class CRM_Event_Form_Task_Badge extends CRM_Event_Form_Task {
 
   /**
    * Process the form after the input has been submitted and validated.
-   *
-   *
-   * @return void
    */
   public function postProcess() {
     $params = $this->controller->exportValues($this->_name);

--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -47,7 +47,7 @@ class CRM_Utils_String {
   /**
    * Convert a display name into a potential variable name.
    *
-   * @param $title title of the string
+   * @param string $title title of the string
    * @param int $maxLength
    *
    * @return string


### PR DESCRIPTION
Overview
----------------------------------------
Non functional tidy ups

Before
----------------------------------------
some unused vars are declared, comment type is missing

After
----------------------------------------
Unused vars removed

Technical Details
----------------------------------------
I removed the lines after the comments as our full coding standard requires that (our phpcs does not enforce but phpstorm highlights)

Comments
----------------------------------------

