### PR TITLE
Fix PHP Warnings. Replace fatal with statusBounce. Mark appendBreadCr…

### DIFF
--- a/CRM/Financial/BAO/ExportFormat/CSV.php
+++ b/CRM/Financial/BAO/ExportFormat/CSV.php
@@ -139,7 +139,9 @@ class CRM_Financial_BAO_ExportFormat_CSV extends CRM_Financial_BAO_ExportFormat 
     $fileName = $config->uploadDir . 'Financial_Transactions_' . $this->_batchIds . '_' . date('YmdHis') . '.' . $this->getFileExtension();
     $this->_downloadFile[] = $config->customFileUploadDir . CRM_Utils_File::cleanFileName(basename($fileName));
     $out = fopen($fileName, 'w');
-    fputcsv($out, $export['headers']);
+    if (!empty($export['headers'])) {
+      fputcsv($out, $export['headers']);
+    }
     unset($export['headers']);
     if (!empty($export)) {
       foreach ($export as $fields) {

--- a/CRM/Financial/Form/BatchTransaction.php
+++ b/CRM/Financial/Form/BatchTransaction.php
@@ -54,7 +54,7 @@ class CRM_Financial_Form_BatchTransaction extends CRM_Contribute_Form {
     // This reuses some styles from search forms
     CRM_Core_Resources::singleton()->addStyleFile('civicrm', 'css/searchForm.css', 1, 'html-header');
 
-    self::$_entityID = CRM_Utils_Request::retrieve('bid', 'Positive') ? CRM_Utils_Request::retrieve('bid', 'Positive') : $_POST['batch_id'];
+    self::$_entityID = CRM_Utils_Request::retrieve('bid', 'Positive') ? CRM_Utils_Request::retrieve('bid', 'Positive') : CRM_Utils_Array::value('batch_id', $_POST);
     $this->assign('entityID', self::$_entityID);
     if (isset(self::$_entityID)) {
       $this->_batchStatusId = CRM_Core_DAO::getFieldValue('CRM_Batch_BAO_Batch', self::$_entityID, 'status_id');

--- a/CRM/Financial/Form/Export.php
+++ b/CRM/Financial/Form/Export.php
@@ -97,7 +97,8 @@ class CRM_Financial_Form_Export extends CRM_Core_Form {
 
     foreach ($batchStatus as $batchStatusId) {
       if ($batchStatusId == $this->_exportStatusId) {
-        CRM_Core_Error::fatal(ts('You cannot exported the batches which were exported earlier.'));
+        $url = CRM_Core_Session::singleton()->readUserContext();
+        CRM_Core_Error::statusBounce(ts('You cannot export batches which have already been exported.'), $url);
       }
     }
 

--- a/CRM/Financial/Page/BatchTransaction.php
+++ b/CRM/Financial/Page/BatchTransaction.php
@@ -97,6 +97,7 @@ class CRM_Financial_Page_BatchTransaction extends CRM_Core_Page_Basic {
     $this->assign('action', $action);
 
     self::$_entityID = CRM_Utils_Request::retrieve('bid', 'Positive');
+    $statusID = NULL;
     if (isset(self::$_entityID)) {
       $statusID = CRM_Core_DAO::getFieldValue('CRM_Batch_BAO_Batch', self::$_entityID, 'status_id');
     }

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -41,7 +41,7 @@
  * @method static mixed permissionDenied() Show access denied screen.
  * @method static mixed logout() Log out the current user.
  * @method static mixed updateCategories() Clear CMS caches related to the user registration/profile forms.
- * @method static appendBreadCrumb(string $breadCrumbs) Append an additional breadcrumb tag to the existing breadcrumbs.
+ * @method static appendBreadCrumb(array $breadCrumbs) Append an additional breadcrumb tag to the existing breadcrumbs.
  * @method static resetBreadCrumb() Reset an additional breadcrumb tag to the existing breadcrumb.
  * @method static addHTMLHead(string $bc) Append a string to the head of the HTML file.
  * @method static string postURL(int $action) Determine the post URL for a form.


### PR DESCRIPTION
…umbs parameter as array instead of string so editors don't give a warning

Overview
----------------------------------------
Fix some PHP Warnings - NFC.
Replace fatal with statusBounce (as the form doesn't redirect when exporting a second click on the export link causes a fatal error).  With this change it redirects and shows a helpful error message.
Mark CRM_Utils_System appendBreadCrumbs parameter as array instead of string so editors don't give a warning.
