### PR TITLE
CRM-21094 - improve layout order of fields in SurveyDetails report

### DIFF
--- a/CRM/Report/Form/Campaign/SurveyDetails.php
+++ b/CRM/Report/Form/Campaign/SurveyDetails.php
@@ -157,7 +157,8 @@ class CRM_Report_Form_Campaign_SurveyDetails extends CRM_Report_Form {
         ),
         'grouping' => 'location-fields',
       ),
-      'civicrm_activity' => array(
+    ) + $this->getAddressColumns() +
+    array('civicrm_activity' => array(
         'dao' => 'CRM_Activity_DAO_Activity',
         'alias' => 'survey_activity',
         'fields' => array(
@@ -206,8 +207,8 @@ class CRM_Report_Form_Campaign_SurveyDetails extends CRM_Report_Form {
           ),
         ),
         'grouping' => 'survey-activity-fields',
-      ),
-    ) + $this->getAddressColumns();
+      )
+    );
     parent::__construct();
   }
 

--- a/CRM/Report/Form/Campaign/SurveyDetails.php
+++ b/CRM/Report/Form/Campaign/SurveyDetails.php
@@ -158,7 +158,8 @@ class CRM_Report_Form_Campaign_SurveyDetails extends CRM_Report_Form {
         'grouping' => 'location-fields',
       ),
     ) + $this->getAddressColumns() +
-    array('civicrm_activity' => array(
+    array(
+      'civicrm_activity' => array(
         'dao' => 'CRM_Activity_DAO_Activity',
         'alias' => 'survey_activity',
         'fields' => array(
@@ -207,7 +208,7 @@ class CRM_Report_Form_Campaign_SurveyDetails extends CRM_Report_Form {
           ),
         ),
         'grouping' => 'survey-activity-fields',
-      )
+      ),
     );
     parent::__construct();
   }


### PR DESCRIPTION
Overview
----------------------------------------
Re-order the fields displayed in the SurveyDetails report so all contact fields are together.

Before
----------------------------------------
![report-before](https://user-images.githubusercontent.com/4511942/29585647-e16320fc-8755-11e7-8d25-663fe854075a.png)

After
----------------------------------------
![report-after](https://user-images.githubusercontent.com/4511942/29585656-ea2d3ef2-8755-11e7-8158-7251290aa0e9.png)

Technical Details
----------------------------------------
I've simply re-ordered how the fields are added in the constructor.

---

 * [CRM-21094: Minor improvement to display of columns in Survey Details report](https://issues.civicrm.org/jira/browse/CRM-21094)