### PR TITLE
CRM-21098

### DIFF
--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -1017,12 +1017,13 @@ AND    u.status = 1
   }
 
   /**
-   * Append Backdrop CSS to coreResourcesList.
+   * Append Backdrop CSS and JS to coreResourcesList.
    *
    * @param array $list
    */
   public function appendCoreResources(&$list) {
     $list[] = 'css/backdrop.css';
+    $list[] = 'js/crm.backdrop.js';
   }
 
 }

--- a/js/crm.backdrop.js
+++ b/js/crm.backdrop.js
@@ -4,9 +4,7 @@ CRM.$(function($) {
   $('.crm-hidemenu').click(function(e) {
     $('#admin-bar').css('display', 'block');
   });
-  $('#crm-notification-container').click(function(e) {
-    if ($('#civicrm-menu').css('display') != 'none') {
-      $('#admin-bar').css('display', 'none');
-    }
+  $('#crm-notification-container').on('click', '#crm-restore-menu', function() {
+    $('#admin-bar').css('display', 'none');
   });
 });

--- a/js/crm.backdrop.js
+++ b/js/crm.backdrop.js
@@ -1,0 +1,12 @@
+// http://civicrm.org/licensing
+CRM.$(function($) {
+  $('#admin-bar').css('display', 'none');
+  $('.crm-hidemenu').click(function(e) {
+    $('#admin-bar').css('display', 'block');
+  });
+  $('#crm-notification-container').click(function(e) {
+    if ($('#civicrm-menu').css('display') != 'none') {
+      $('#admin-bar').css('display', 'none');
+    }
+  });
+});


### PR DESCRIPTION
Overview
----------------------------------------
Prevent Backdrop admin menu dropdowns appearing beneath the CiviCRM admin menu by hiding the Backdrop admin menu when the CiviCRM admin menu is visible and also to show the Backdrop admin menu when the CiviCRM admin is hidden.

Before
----------------------------------------
Backdrop admin menu is visible beneath the CiviCRM admin menu.

![backdrop-civicrm-menus](https://user-images.githubusercontent.com/1071483/29629177-e0fe16f2-8805-11e7-9e7f-5012f3925eda.png)


After
----------------------------------------
Backdrop admin menu is hidden when CiviCRM admin menu is visible.

Technical Details
----------------------------------------
Adds a crm.backdrop.js file for Backdrop installs.

Comments
----------------------------------------
This PR might need to be slightly updated if https://github.com/civicrm/civicrm-core/pull/10891 is merged first.

---

 * [CRM-21098: Prevent Backdrop admin drop-down menus from appearing beneath CiviCRM admin menu](https://issues.civicrm.org/jira/browse/CRM-21098)