### PR TITLE
Fix CRM-21099.

### DIFF
--- a/templates/CRM/Contribute/Page/ContributionTotals.tpl
+++ b/templates/CRM/Contribute/Page/ContributionTotals.tpl
@@ -57,7 +57,7 @@
             {/if}
           {/if}
           {if $contributionSummary.cancel.amount}
-            <th class="disabled right contriTotalRight"> &nbsp; {ts}Total Cancelled Amount{/ts} &ndash; {$contributionSummary.cancel.amount}</th>
+            <th class="disabled right contriTotalRight"> &nbsp; {ts}Cancelled/Refunded{/ts} &ndash; {$contributionSummary.cancel.amount}</th>
           {/if}
       </tr>
       {if $contributionSummary.soft_credit.count}


### PR DESCRIPTION
Overview
----------------------------------------
Just a change to a single label: "Total Cancelled Amount" becomes "Cancelled/Refunded"

Before
----------------------------------------
![refunded](https://user-images.githubusercontent.com/759449/29631988-1dcab738-8807-11e7-8319-2a15683756af.png)

After
----------------------------------------
![fixed](https://user-images.githubusercontent.com/759449/29631990-229fb1d2-8807-11e7-8ec6-4a666bea0e8c.png)

Technical Details
----------------------------------------
Nothing notable.

Comments
----------------------------------------
Self-explanatory, I hope. :D

---

 * [CRM-21099: Contribution search: "Total Cancelled Amount" surprisingly includes "refunded" status](https://issues.civicrm.org/jira/browse/CRM-21099)