### PR TITLE
CRM-21100 Hotfix to ensure that testGroup list is still the same as p…

### DIFF
--- a/CRM/Mailing/Info.php
+++ b/CRM/Mailing/Info.php
@@ -95,7 +95,11 @@ class CRM_Mailing_Info extends CRM_Core_Component_Info {
       'options' => array('limit' => 0),
       'sequential' => 1,
     );
-
+    $groupNames = civicrm_api3('Group', 'get', $params + array(
+      'is_active' => 1,
+      'check_permissions' => TRUE,
+      'return' => array('title', 'visibility', 'group_type', 'is_hidden'),
+    ));
     $headerfooterList = civicrm_api3('MailingComponent', 'get', $params + array(
       'is_active' => 1,
       'return' => array('name', 'component_type', 'is_default', 'body_html', 'body_text'),
@@ -130,6 +134,8 @@ class CRM_Mailing_Info extends CRM_Core_Component_Info {
           'civiMails' => array(),
           'campaignEnabled' => in_array('CiviCampaign', $config->enableComponents),
           'groupNames' => array(),
+          // @todo see if we can remove this by dynamically generating the test group list
+          'testGroupNames' => $groupNames['values'],
           'headerfooterList' => $headerfooterList['values'],
           'mesTemplate' => $mesTemplate['values'],
           'emailAdd' => $emailAdd['values'],

--- a/ang/crmMailing/BlockPreview.html
+++ b/ang/crmMailing/BlockPreview.html
@@ -49,7 +49,7 @@ Vars: mailing:obj, testContact:obj, testGroup:obj, crmMailing:FormController
         ui-jq="crmSelect2"
         ui-options="{dropdownAutoWidth : true, allowClear: true, placeholder: ts('Select Group')}"
         ng-model="testGroup.gid"
-        ng-options="group.id as group.title for group in crmMailingConst.groupNames|orderBy:'title'"
+        ng-options="group.id as group.title for group in crmMailingConst.testGroupNames|orderBy:'title'"
         class="crm-action-menu fa-envelope-o"
         >
         <option value=""></option>

--- a/ang/crmMailing/BlockPreview.js
+++ b/ang/crmMailing/BlockPreview.js
@@ -29,7 +29,7 @@
         scope.previewTestGroup = function(e) {
           var $dialog = $(this);
           $dialog.html('<div class="crm-loading-element"></div>').parent().find('button[data-op=yes]').prop('disabled', true);
-          $dialog.dialog('option', 'title', ts('Send to %1', {1: _.pluck(_.where(scope.crmMailingConst.groupNames, {id: scope.testGroup.gid}), 'title')[0]}));
+          $dialog.dialog('option', 'title', ts('Send to %1', {1: _.pluck(_.where(scope.crmMailingConst.testGroupNames, {id: scope.testGroup.gid}), 'title')[0]}));
           CRM.api3('contact', 'get', {
             group: scope.testGroup.gid,
             options: {limit: 0},


### PR DESCRIPTION
…revious, need to work on converting to AJAX list

Overview
----------------------------------------
With Changes made in CRM-20521 this changed how the groupNames variable was constructed to be more dynamic. This had the unintended consequence of limiting the test group list. This resurrects the test group list as it was before. This should be properly fixed later. 

ping @mlutfy 
