### PR TITLE
CRM-21100 Convert list of test groups into AJAX based select2 like r…

### DIFF
--- a/CRM/Mailing/Info.php
+++ b/CRM/Mailing/Info.php
@@ -138,7 +138,7 @@ class CRM_Mailing_Info extends CRM_Core_Component_Info {
           'civiMails' => array(),
           'campaignEnabled' => in_array('CiviCampaign', $config->enableComponents),
           'groupNames' => array(),
-          // @todo see if we can remove this by dynamically generating the test group list
+          // @todo this is not used in core. Remove once Mosaico no longer depends on it.
           'testGroupNames' => $groupNames['values'],
           'headerfooterList' => $headerfooterList['values'],
           'mesTemplate' => $mesTemplate['values'],

--- a/ang/crmMailing/BlockMailing.html
+++ b/ang/crmMailing/BlockMailing.html
@@ -41,15 +41,13 @@ It could perhaps be thinned by 30-60% by making more directives.
     </div>
     <span ng-controller="EditUnsubGroupCtrl">
       <div crm-ui-field="{name: 'subform.baseGroup', title: ts('Unsubscribe Group')}" ng-if="isUnsubGroupRequired(mailing)">
-        <select
+        <input
+          crm-entityref="{entity: 'Group', api: {params: {is_hidden: 0, is_active: 1}}, select: {allowClear:true, minimumInputLength: 0}}"
           crm-ui-id="subform.baseGroup"
-          crm-ui-select
           name="baseGroup"
           ng-model="mailing.recipients.groups.base[0]"
           ng-required="true"
-          >
-          <option ng-repeat="grp in crmMailingConst.testGroupNames | filter:{is_hidden:0} | orderBy:'title'" value="{{grp.id}}">{{grp.title}}</option>
-        </select>
+        />
       </div>
     </span>
     <div crm-ui-field="{name: 'subform.subject', title: ts('Subject')}">

--- a/ang/crmMailing/BlockPreview.html
+++ b/ang/crmMailing/BlockPreview.html
@@ -46,7 +46,7 @@ Vars: mailing:obj, testContact:obj, testGroup:obj, crmMailing:FormController
     </div>
     <div>
       <input
-        crm-entityref="{entity: 'Group', select: {allowClear:true}}"
+        crm-entityref="{entity: 'Group', api: {params: {is_hidden: 0, is_active: 1}}, select: {allowClear:true, minimumInputLength: 0}}"
         ng-model="testGroup.gid"
         class="crm-action-menu fa-envelope-o"
         />

--- a/ang/crmMailing/BlockPreview.html
+++ b/ang/crmMailing/BlockPreview.html
@@ -45,16 +45,11 @@ Vars: mailing:obj, testContact:obj, testGroup:obj, crmMailing:FormController
       <a crm-ui-help="hs({id: 'test', title: ts('Test Email')})"></a>
     </div>
     <div>
-      <select
-        name="preview_test_group"
-        ui-jq="crmSelect2"
-        ui-options="{dropdownAutoWidth : true, allowClear: true, placeholder: ts('Select Group')}"
+      <input
+        crm-entityref="{entity: 'Group', select: {allowClear:true}}"
         ng-model="testGroup.gid"
-        ng-options="group.id as group.title for group in crmMailingConst.testGroupNames|orderBy:'title'"
         class="crm-action-menu fa-envelope-o"
-        >
-        <option value=""></option>
-      </select>
+        />
     </div>
     <button crm-icon="fa-paper-plane" title="{{crmMailing.$invalid || !testGroup.gid ? ts('Complete all required fields first') : ts('Send test message to group')}}" ng-disabled="crmMailing.$invalid || !testGroup.gid" crm-confirm="{resizable: true, width: '40%', height: '40%', open: previewTestGroup}" on-yes="doSend({gid: testGroup.gid})">{{ts('Send test')}}</button>
   </div>

--- a/ang/crmMailing/BlockPreview.js
+++ b/ang/crmMailing/BlockPreview.js
@@ -29,33 +29,35 @@
         scope.previewTestGroup = function(e) {
           var $dialog = $(this);
           $dialog.html('<div class="crm-loading-element"></div>').parent().find('button[data-op=yes]').prop('disabled', true);
-          $dialog.dialog('option', 'title', ts('Send to %1', {1: _.pluck(_.where(scope.crmMailingConst.testGroupNames, {id: scope.testGroup.gid}), 'title')[0]}));
-          CRM.api3('contact', 'get', {
-            group: scope.testGroup.gid,
-            options: {limit: 0},
-            return: 'display_name,email'
-          }).done(function(data) {
-            var count = 0,
-            // Fixme: should this be in a template?
+          CRM.api3('group', 'getsingle', {id: scope.testGroup.gid, return: 'title'}).done(function(group) {
+            $dialog.dialog('option', 'title', ts('Send to %1', {1: group.title}));
+            CRM.api3('contact', 'get', {
+              group: scope.testGroup.gid,
+              options: {limit: 0},
+              return: 'display_name,email'
+            }).done(function(data) {
+              var count = 0,
+              // Fixme: should this be in a template?
               markup = '<ol>';
-            _.each(data.values, function(row) {
-              // Fixme: contact api doesn't seem capable of filtering out contacts with no email, so we're doing it client-side
-              if (row.email) {
-                count++;
-                markup += '<li>' + row.display_name + ' - ' + row.email + '</li>';
+              _.each(data.values, function(row) {
+                // Fixme: contact api doesn't seem capable of filtering out contacts with no email, so we're doing it client-side
+                if (row.email) {
+                  count++;
+                  markup += '<li>' + row.display_name + ' - ' + row.email + '</li>';
+                }
+              });
+              markup += '</ol>';
+              markup = '<h4>' + ts('A test message will be sent to %1 people:', {1: count}) + '</h4>' + markup;
+              if (!count) {
+                markup = '<div class="messages status"><i class="crm-i fa-exclamation-triangle"></i> ' +
+                (data.count ? ts('None of the contacts in this group have an email address.') : ts('Group is empty.')) +
+                '</div>';
               }
+              $dialog
+                .html(markup)
+                .trigger('crmLoad')
+                .parent().find('button[data-op=yes]').prop('disabled', !count);
             });
-            markup += '</ol>';
-            markup = '<h4>' + ts('A test message will be sent to %1 people:', {1: count}) + '</h4>' + markup;
-            if (!count) {
-              markup = '<div class="messages status"><i class="crm-i fa-exclamation-triangle"></i> ' +
-              (data.count ? ts('None of the contacts in this group have an email address.') : ts('Group is empty.')) +
-              '</div>';
-            }
-            $dialog
-              .html(markup)
-              .trigger('crmLoad')
-              .parent().find('button[data-op=yes]').prop('disabled', !count);
           });
         };
       }

--- a/ang/crmMailing/BlockPreview.js
+++ b/ang/crmMailing/BlockPreview.js
@@ -29,35 +29,32 @@
         scope.previewTestGroup = function(e) {
           var $dialog = $(this);
           $dialog.html('<div class="crm-loading-element"></div>').parent().find('button[data-op=yes]').prop('disabled', true);
-          CRM.api3('group', 'getsingle', {id: scope.testGroup.gid, return: 'title'}).done(function(group) {
-            $dialog.dialog('option', 'title', ts('Send to %1', {1: group.title}));
-            CRM.api3('contact', 'get', {
-              group: scope.testGroup.gid,
-              options: {limit: 0},
-              return: 'display_name,email'
-            }).done(function(data) {
-              var count = 0,
-              // Fixme: should this be in a template?
-              markup = '<ol>';
-              _.each(data.values, function(row) {
-                // Fixme: contact api doesn't seem capable of filtering out contacts with no email, so we're doing it client-side
-                if (row.email) {
-                  count++;
-                  markup += '<li>' + row.display_name + ' - ' + row.email + '</li>';
-                }
-              });
-              markup += '</ol>';
-              markup = '<h4>' + ts('A test message will be sent to %1 people:', {1: count}) + '</h4>' + markup;
-              if (!count) {
-                markup = '<div class="messages status"><i class="crm-i fa-exclamation-triangle"></i> ' +
-                (data.count ? ts('None of the contacts in this group have an email address.') : ts('Group is empty.')) +
-                '</div>';
+          CRM.api3({
+            contact: ['contact', 'get', {group: scope.testGroup.gid, options: {limit: 0}, return: 'display_name,email'}],
+            group: ['group', 'getsingle', {id: scope.testGroup.gid, return: 'title'}]
+          }).done(function(data) {
+            $dialog.dialog('option', 'title', ts('Send to %1', {1: data.group.title}));
+            var count = 0,
+            // Fixme: should this be in a template?
+            markup = '<ol>';
+            _.each(data.contact.values, function(row) {
+              // Fixme: contact api doesn't seem capable of filtering out contacts with no email, so we're doing it client-side
+              if (row.email) {
+                count++;
+                markup += '<li>' + row.display_name + ' - ' + row.email + '</li>';
               }
-              $dialog
-                .html(markup)
-                .trigger('crmLoad')
-                .parent().find('button[data-op=yes]').prop('disabled', !count);
             });
+            markup += '</ol>';
+            markup = '<h4>' + ts('A test message will be sent to %1 people:', {1: count}) + '</h4>' + markup;
+            if (!count) {
+              markup = '<div class="messages status"><i class="crm-i fa-exclamation-triangle"></i> ' +
+              (data.contact.count ? ts('None of the contacts in this group have an email address.') : ts('Group is empty.')) +
+              '</div>';
+            }
+            $dialog
+              .html(markup)
+              .trigger('crmLoad')
+              .parent().find('button[data-op=yes]').prop('disabled', !count);
           });
         };
       }


### PR DESCRIPTION
…eceipients box

Overview
----------------------------------------
Previously the Test Group box was generated using a list of groups put into the DOM. Now it works off an AJAX based API call in the same style as the Recipients box

Technical Details
----------------------------------------
This removes the need to load the groups in through items that are loaded as the Angular initializes to using AJAX based API call to retrieve a list of groups and their titles

Comments
----------------------------------------
@mlutfy are you able to test this out, You will need to clear caches for this to work
