### PR TITLE
CRM-21105 Fixed notice error preventing dupe check for API

### DIFF
--- a/api/v3/Contact.php
+++ b/api/v3/Contact.php
@@ -56,7 +56,7 @@ function civicrm_api3_contact_create($params) {
   }
 
   if (!empty($params['dupe_check'])) {
-    $ids = CRM_Contact_BAO_Contact::getDuplicateContacts($params, $params['contact_type'], 'Unsupervised', array(), $params['check_permission']);
+    $ids = CRM_Contact_BAO_Contact::getDuplicateContacts($params, $params['contact_type'], 'Unsupervised', array(), $params['check_permissions']);
     if (count($ids) > 0) {
       throw new API_Exception("Found matching contacts: " . implode(',', $ids), "duplicate", array("ids" => $ids));
     }


### PR DESCRIPTION
----------------------------------------
* CRM-21105: Undefined index for check_permission when dupe_check is enabled
  https://issues.civicrm.org/jira/browse/CRM-21105

Overview
----------------------------------------
_A brief description of the pull request. Try to keep it non-technical._

Before
----------------------------------------
_The current status. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._

After
----------------------------------------
_What has been changed. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._

Technical Details
----------------------------------------
_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
