### PR TITLE
CRM-20680 - Only spin the logo in the menubar

### DIFF
--- a/templates/CRM/common/navigation.js.tpl
+++ b/templates/CRM/common/navigation.js.tpl
@@ -209,6 +209,6 @@ $('#civicrm-menu').ready(function() {
 });
 $('#civicrm-menu').menuBar({arrowSrc: CRM.config.resourceBase + 'packages/jquery/css/images/arrow.png'});
 $(window).on("beforeunload", function() {
-  $('.crm-logo-sm').addClass('crm-i fa-spin fa-pulse');
+  $('.crm-logo-sm', '#civicrm-menu').addClass('crm-i fa-spin fa-pulse');
 });
 })(CRM.$);{/literal}


### PR DESCRIPTION
CRM-20680 introduced a style tweak which would spin the civi logo in the menubar when reloading the page. This had the unintended side-effect of spinning every logo on the page, not just the one in the menubar.

* [CRM-20680: Make the CiviCRM logo spin while waiting for next page to load](https://issues.civicrm.org/jira/browse/CRM-20680)