### PR TITLE
CRM-21106 Add Warnings about new required extension to support Financ…

### DIFF
--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -126,6 +126,15 @@ class CRM_Upgrade_Incremental_General {
       // advanced feature in the hands of the sysadmin.
       $preUpgradeMessage .= '<br />' . ts('This database uses InnoDB Full Text Search for optimized searching. The upgrade procedure has not been tested with this feature. You should disable (and later re-enable) the feature by navigating to "Administer => System Settings => Miscellaneous".');
     }
+
+    $ftAclSetting = Civi::settings()->get('acl_financial_type');
+    $financialAclExtension = civicrm_api3('extension', 'get', array('key' => 'biz.jmaconsulting.financialaclreport'));
+    if ($ftAclSetting && (($financialAclExtension['count'] == 1 && $financialAclExtension['status'] != 'Installed') || $financialAclExtension['count'] !== 1)) {
+      $preUpgradeMessage .= '<br />' . ts('CiviCRM will in the future require the extension %1 for CiviCRM Reports to work correctly with the Financial Type ACLs. The extension can be downloaded <a href="%2">here</a>', array(
+        1 => 'biz.jmaconsulting.financialaclreport',
+        2 => 'https://github.com/JMAConsulting/biz.jmaconsulting.financialaclreport',
+      ));
+    }
   }
 
   /**

--- a/CRM/Utils/Check/Component/FinancialTypeAcls.php
+++ b/CRM/Utils/Check/Component/FinancialTypeAcls.php
@@ -1,0 +1,55 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2017                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2017
+ */
+class CRM_Utils_Check_Component_FinancialTypeAcls extends CRM_Utils_Check_Component {
+
+  public static function checkFinancialAclReport() {
+    $messages = array();
+    $ftAclSetting = Civi::settings()->get('acl_financial_type');
+    $financialAclExtension = civicrm_api3('extension', 'get', array('key' => 'biz.jmaconsulting.financialaclreport'));
+    if ($ftAclSetting && (($financialAclExtension['count'] == 1 && $financialAclExtension['status'] != 'Installed') || $financialAclExtension['count'] !== 1)) {
+      $messages[] = new CRM_Utils_Check_Message(
+        __FUNCTION__,
+        ts('CiviCRM will in the future require the extension %1 for CiviCRM Reports to work correctly with the Financial Type ACLs. The extension can be downloaded <a href="%2">here</a>', array(
+          1 => 'biz.jmaconsulting.financialaclreport',
+          2 => 'https://github.com/JMAConsulting/biz.jmaconsulting.financialaclreport',
+        )),
+        ts('Extension Missing'),
+        \Psr\Log\LogLevel::WARNING,
+        'fa-server'
+      );
+    }
+
+    return $messages;
+  }
+
+}


### PR DESCRIPTION
…ial Type ACLs in reports

Overview
----------------------------------------
Add in a warning if Financial ACL Report extension is not installed in systems. Which is now required to support the working of the Financial Type Acls

@Stoob @eileenmcnaughton @pradpnayak I think this will help, Is someone able to test this out? This should emit a warning before doing an upgrade and also after an upgrade as a status check message
