### PR TITLE
CRM-21109 Don't clear smart group cache while importing via CLI

### DIFF
--- a/bin/cli.class.php
+++ b/bin/cli.class.php
@@ -240,6 +240,9 @@ class civicrm_cli {
 
     $this->_config = CRM_Core_Config::singleton();
 
+    // Don't reset smart group cache on import, it's database-intensive.
+    $this->_config->doNotResetCache = 1;
+
     // HTTP_HOST will be 'localhost' unless overwritten with the -s argument.
     // Now we have a Config object, we can set it from the Base URL.
     if ($_SERVER['HTTP_HOST'] == 'localhost') {


### PR DESCRIPTION
Overview
----------------------------------------
When you import via the CSV CLI, the smart group cache is cleared on every contact you import, which adds a lot of time to the import.  This is explicitly prevented on the GUI import.  This patch prevents the cache being cleared on CLI import.

Before
----------------------------------------
Importing contacts takes longer (~20.8 seconds):
![image](https://user-images.githubusercontent.com/1796012/29754466-c22a326e-8b53-11e7-8c55-6e35b4f05f04.png)


After
----------------------------------------
Importing contacts is shorter (~16.9 seconds):
![image](https://user-images.githubusercontent.com/1796012/29754471-c62d4798-8b53-11e7-91d8-44b19ccd07d6.png)

Technical Details
----------------------------------------
You don't need to set up a profiler to confirm this; you can run this script, which shows how long it takes to import 200 contacts:
[contactprofiler.txt](https://github.com/civicrm/civicrm-core/files/1254753/contactprofiler.txt)

---

 * [CRM-21109: Creating contacts is slow, part 2 of 2: Smart group caching](https://issues.civicrm.org/jira/browse/CRM-21109)