### PR TITLE
CRM-21108 - Greatly improve performance of adding contacts

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -2651,10 +2651,9 @@ AND       civicrm_openid.is_primary = 1";
       $contactDefaults = $defaultGreetings[$contact->contact_type];
     }
 
-    // note that contact object not always has required greeting related
-    // fields that are required to calculate greeting and
-    // also other fields used in tokens etc,
-    // hence we need to retrieve it again.
+    // The contact object has not always required the
+    // fields that are required to calculate greetings
+    // so we need to retrieve it again.
     if ($contact->_query !== FALSE) {
       $contact->find(TRUE);
     }

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1366,7 +1366,7 @@ class CRM_Utils_Token {
         $tokenString = CRM_Utils_Token::replaceContactTokens($tokenString, $contactDetails, TRUE, $greetingTokens, TRUE, $escapeSmarty);
       }
 
-      self::removeNullContactTokens($tokenString, $contactDetails[0][$contactId], $greetingTokens);
+      self::removeNullContactTokens($tokenString, $contactDetails, $greetingTokens);
       // check if there are any unevaluated tokens
       $greetingTokens = self::getTokens($tokenString);
 
@@ -1436,6 +1436,11 @@ class CRM_Utils_Token {
   private static function removeNullContactTokens(&$tokenString, $contactDetails, &$greetingTokens) {
     $greetingTokensOriginal = $greetingTokens;
     $contactFieldList = CRM_Contact_DAO_Contact::fields();
+    // Sometimes contactDetails are in a multidemensional array, sometimes a
+    // single-dimension array.
+    if (array_key_exists(0, $contactDetails) && is_array($contactDetails[0])) {
+      $contactDetails = current($contactDetails[0]);
+    }
     $nullFields = array_keys(array_diff_key($contactFieldList, $contactDetails));
 
     // Handle legacy tokens

--- a/tests/phpunit/CRM/Utils/Token.php
+++ b/tests/phpunit/CRM/Utils/Token.php
@@ -16,6 +16,30 @@ class CRM_Utils_TokenTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test for replaceContactTokens.
+   *
+   */
+  public function testReplaceGreetingTokens() {
+    $tokenString = 'First Name: {contact.first_name} Last Name: {contact.last_name} Birth Date: {contact.birth_date} Prefix: {contact.prefix_id} Suffix: {contact.individual_suffix}';
+    $contactDetails = array(
+      array(
+        2811 => array(
+          'id' => '2811',
+          'contact_type' => 'Individual',
+          'first_name' => 'Morticia',
+          'last_name' => 'Addams',
+          'prefix_id' => 2,
+        ),
+      ),
+    );
+    $contactId = 2811;
+    $className = 'CRM_Contact_BAO_Contact';
+    $escapeSmarty = TRUE;
+    CRM_Utils_Token::replaceGreetingTokens($tokenString, $contactDetails, $contactId, $className, $escapeSmarty);
+    $this->assertEquals($tokenString, 'First Name: Morticia Last Name: Addams Birth Date:  Prefix: Ms. Suffix: ');
+  }
+
+  /**
    * Test getting multiple contacts.
    *
    * Check for situation described in CRM-19876.

--- a/tests/phpunit/CRM/Utils/Token.php
+++ b/tests/phpunit/CRM/Utils/Token.php
@@ -16,7 +16,7 @@ class CRM_Utils_TokenTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test for replaceContactTokens.
+   * Test for replaceGreetingTokens.
    *
    */
   public function testReplaceGreetingTokens() {


### PR DESCRIPTION
Overview
----------------------------------------
It currently takes 21 seconds to add 200 contacts using `CRM_Contact_BAO::create()`.  #10905 shaves off 4 seconds from that; this PR shaves off another 10, resulting in a 2x to 3x speedup in creating contacts.

Before
----------------------------------------
Creating 200 contacts takes ~17 seconds (after #10905 is applied), greeting processing takes 13.6 seconds:
![image](https://user-images.githubusercontent.com/1796012/29754777-49d3a74e-8b5a-11e7-88f4-8985106c0998.png)



After
----------------------------------------
Creating 200 contacts takes 6.5 seconds, greeting processing takes 3.0 seconds:
![selection_227](https://user-images.githubusercontent.com/1796012/29754785-7eb01290-8b5a-11e7-9192-49b72223f381.png)


Technical Details
----------------------------------------
Greetings tokens are calculated by loading a contact's data into an array (via `DAO->find()`), replacing tokens with that data, then checking if there are any unreplaced tokens.  If any tokens are unreplaced, Civi makes two (very expensive!) calls to `CRM_Contact_BAO_Query`.  Since non-contact tokens in greetings are rare, this should happen only rarely.

Unfortunately, the greetings code doesn't account for the fact that fields that are NULL in the database won't appear in the object created by `DAO->find()`.  Since the default addressee greeting has 5 tokens, you end up with a very slow greeting replacement unless your contacts have all of the following: prefix, suffix, first name, middle name, last name.

Finally, there need not be two calls to `CRM_Contact_BAO_Query`; one is sufficient.

By identifying and removing contact tokens whose values are null, we avoid the expensive calls.  On the rare occasion such a call is needed, we still save ~6 seconds by calling the function once instead of twice.

Comments
----------------------------------------
You don't need a profiler to confirm this; you can download this file, rename to `contactprofiler.php`, save it in your civiroot, and run it with `php contactprofiler.php`.
[contactprofiler.php.txt](https://github.com/civicrm/civicrm-core/files/1254774/contactprofiler.php.txt)

---

 * [CRM-21108: Creating contacts is slow, part 1 of 2: Calculating Greetings](https://issues.civicrm.org/jira/browse/CRM-21108)