### PR TITLE
CRM-21110 Do not run same/similar query twice when generating Relatio…

### DIFF
--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -1233,6 +1233,8 @@ LEFT JOIN  civicrm_country ON (civicrm_address.country_id = civicrm_country.id)
    * @param bool $permissionedContact
    *   to return only permissioned Contact
    * @param array $params
+   * @param bool $includeTotalCount
+   *   Should we return a count of total accessable relationships
    *
    * @return array|int
    *   relationship records
@@ -1243,7 +1245,7 @@ LEFT JOIN  civicrm_country ON (civicrm_address.country_id = civicrm_country.id)
     $count = 0, $relationshipId = 0,
     $links = NULL, $permissionMask = NULL,
     $permissionedContact = FALSE,
-    $params = array()
+    $params = array(), $includeTotalCount = FALSE
   ) {
     $values = array();
     if (!$contactId && !$relationshipId) {
@@ -1277,7 +1279,8 @@ LEFT JOIN  civicrm_country ON (civicrm_address.country_id = civicrm_country.id)
     }
 
     // building the query string
-    $queryString = $select1 . $from1 . $where1 . $select2 . $from2 . $where2 . $order . $limit;
+    CRM_Core_DAO::executeQuery("CREATE TEMPORARY TABLE civicrm_contact_relationships " . $select1 . $from1 . $where1 . $select2 . $from2 . $where2);
+    $queryString = "SELECT * FROM civicrm_contact_relationships " . $order . $limit;
 
     $relationship = new CRM_Contact_DAO_Relationship();
 
@@ -1291,6 +1294,10 @@ LEFT JOIN  civicrm_country ON (civicrm_address.country_id = civicrm_country.id)
       return $relationshipCount;
     }
     else {
+
+      if ($includeTotalCount) {
+        $values['total_relationships'] = CRM_Core_DAO::singleValueQuery("SELECT count(*) FROM civicrm_contact_relationships");
+      }
 
       $mask = NULL;
       if ($status != self::INACTIVE) {
@@ -2067,20 +2074,13 @@ AND cc.sort_name LIKE '%$name%'";
       $params['rp'], 0, 0,
       $links, $mask,
       $permissionedContacts,
-      $params
+      $params, TRUE
     );
 
     $contactRelationships = array();
-    $params['total'] = 0;
+    $params['total'] = $relationships['total_relationships'];
+    unset($relationships['total_relationships']);
     if (!empty($relationships)) {
-      // FIXME: we cannot directly determine total permissioned relationship, hence re-fire query
-      $permissionedRelationships = CRM_Contact_BAO_Relationship::getRelationship($params['contact_id'],
-        $relationshipStatus,
-        0, 0, 0,
-        NULL, NULL,
-        $permissionedContacts
-      );
-      $params['total'] = count($permissionedRelationships);
 
       // format params
       foreach ($relationships as $relationshipId => $values) {

--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -1291,6 +1291,7 @@ LEFT JOIN  civicrm_country ON (civicrm_address.country_id = civicrm_country.id)
       while ($relationship->fetch()) {
         $relationshipCount += $relationship->cnt1 + $relationship->cnt2;
       }
+      CRM_Core_DAO::executeQuery("DROP TEMPORARY TABLE IF EXISTS civicrm_contact_relationships");
       return $relationshipCount;
     }
     else {
@@ -1444,6 +1445,7 @@ LEFT JOIN  civicrm_country ON (civicrm_address.country_id = civicrm_country.id)
       }
 
       $relationship->free();
+      CRM_Core_DAO::executeQuery("DROP TEMPORARY TABLE IF EXISTS civicrm_contact_relationships");
       return $values;
     }
   }


### PR DESCRIPTION
…nships Tab in CiviCRM

Overview
----------------------------------------
Previously two queries would be run every time when listing active and inactive relationships for a contact in the Relationships tab. The 2nd query was only to a total number of relationships which seemed very expensive

Before
----------------------------------------
Two very similar queries were run

After
----------------------------------------
1 round of queries are run and are more performent now

Comments
----------------------------------------
@eileenmcnaughton i would appreciate your thoughts on this, i think this is sane but would like your feedback on this
