### PR TITLE
CRM-21112: Optimize Count On Relationships Tab

### DIFF
--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -2076,11 +2076,11 @@ AND cc.sort_name LIKE '%$name%'";
       // FIXME: we cannot directly determine total permissioned relationship, hence re-fire query
       $permissionedRelationships = CRM_Contact_BAO_Relationship::getRelationship($params['contact_id'],
         $relationshipStatus,
-        0, 0, 0,
+        0, 1, 0,
         NULL, NULL,
         $permissionedContacts
       );
-      $params['total'] = count($permissionedRelationships);
+      $params['total'] = $permissionedRelationships;
 
       // format params
       foreach ($relationships as $relationshipId => $values) {


### PR DESCRIPTION
Overview
----------------------------------------
Relationships tab for contacts with a lot of relationships (over 5000) take a lot of time to load.

Before
----------------------------------------
Relationships tab for contact's summary was loading the table's contents with an AJAX call. This load was counting the total number of relationships by loading ALL relationships into an array and then counting its size, something that brought the system to a crawl on contacts with a lot of relationships
(>20K).

After
----------------------------------------
Fixed by doing the count at DB level, by passing the count flag as 1 to the BAO.

Comments
----------------------------------------
This problem is similar, but different to the one reported on CRM-20594, solved on PR #10371

---

 * [CRM-21112: Optimize Relationship Count on Contact's Relationship Tab](https://issues.civicrm.org/jira/browse/CRM-21112)
 * [CRM-20594: Optimze Relationship Count on Contact Summary View](https://issues.civicrm.org/jira/browse/CRM-20594)