### PR TITLE
CRM-21113: find case - search by id, subject

### DIFF
--- a/CRM/Case/BAO/Query.php
+++ b/CRM/Case/BAO/Query.php
@@ -481,11 +481,11 @@ class CRM_Case_BAO_Query extends CRM_Core_BAO_Query {
       case 'case_tags':
         $tags = CRM_Core_PseudoConstant::get('CRM_Core_DAO_EntityTag', 'tag_id', array('onlyActive' => FALSE));
 
-        if (is_array($value)) {
-          foreach ($value as $k => $v) {
+        if (!empty($value)) {
+          $val = explode(',', $value);
+          foreach ($val as $v) {
             if ($v) {
-              $val[$k] = $k;
-              $names[] = $tags[$k];
+              $names[] = $tags[$v];
             }
           }
         }
@@ -701,12 +701,10 @@ case_relation_type.id = case_relationship.relationship_type_id )";
     }
     $form->assign('accessAllCases', $accessAllCases);
 
-    $caseTags = CRM_Core_BAO_Tag::getTags('civicrm_case');
+    $caseTags = CRM_Core_BAO_Tag::getColorTags('civicrm_case');
 
     if ($caseTags) {
-      foreach ($caseTags as $tagID => $tagName) {
-        $form->_tagElement = &$form->addElement('checkbox', "case_tags[$tagID]", NULL, $tagName);
-      }
+      $form->add('select2', 'case_tags', ts('Case Tag(s)'), $caseTags, FALSE, array('class' => 'big', 'placeholder' => ts('- select -'), 'multiple' => TRUE));
     }
 
     $parentNames = CRM_Core_BAO_Tag::getTagSet('civicrm_case');

--- a/CRM/Case/BAO/Query.php
+++ b/CRM/Case/BAO/Query.php
@@ -716,6 +716,16 @@ case_relation_type.id = case_relationship.relationship_type_id )";
       $form->addElement('checkbox', 'case_deleted', ts('Deleted Cases'));
     }
 
+    $form->addElement( 'text',
+      'case_subject',
+      ts('Case Subject'),
+      array('class' => 'huge')
+    );
+    $form->addElement( 'text',
+      'case_id',
+      ts('Case ID')
+    );
+
     self::addCustomFormFields($form, array('Case'));
 
     $form->setDefaults(array('case_owner' => 1));

--- a/CRM/Case/BAO/Query.php
+++ b/CRM/Case/BAO/Query.php
@@ -716,12 +716,12 @@ case_relation_type.id = case_relationship.relationship_type_id )";
       $form->addElement('checkbox', 'case_deleted', ts('Deleted Cases'));
     }
 
-    $form->addElement( 'text',
+    $form->addElement('text',
       'case_subject',
       ts('Case Subject'),
       array('class' => 'huge')
     );
-    $form->addElement( 'text',
+    $form->addElement('text',
       'case_id',
       ts('Case ID')
     );

--- a/templates/CRM/Case/Form/Search.tpl
+++ b/templates/CRM/Case/Form/Search.tpl
@@ -45,7 +45,7 @@
             {include file="CRM/Case/Form/Search/Common.tpl"}
 
             <tr>
-               <td colspan="2" class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</td>
+               <td colspan="3" class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</td>
             </tr>
             </table>
         {/strip}

--- a/templates/CRM/Case/Form/Search/Common.tpl
+++ b/templates/CRM/Case/Form/Search/Common.tpl
@@ -31,11 +31,10 @@
       {$form.case_id.label}<br />
       {$form.case_id.html}
     </td>
-    <td class="crm-case-common-form-block-case_subject">
+    <td class="crm-case-common-form-block-case_subject" colspan="2">
       {$form.case_subject.label}<br />
       {$form.case_subject.html}
     </td>
-    <td></td>
   </tr>
 
   <tr>
@@ -71,15 +70,9 @@
       {/if}
     </td>
     <td class="crm-case-common-form-block-case_tags">
-      {if $form.case_tags}
-        <label>{ts}Case Tag(s){/ts}</label>
-        <div id="Tag" class="listing-box">
-          {foreach from=$form.case_tags item="tag_val"}
-            <div class="{cycle values='odd-row,even-row'}">
-              {$tag_val.html}
-            </div>
-          {/foreach}
-        </div>
+      {if $form.case_tags.html}
+        {$form.case_tags.label}<br />
+        {$form.case_tags.html}
       {/if}
     </td>
   </tr>

--- a/templates/CRM/Case/Form/Search/Common.tpl
+++ b/templates/CRM/Case/Form/Search/Common.tpl
@@ -24,56 +24,76 @@
  +--------------------------------------------------------------------+
 *}
 {if $notConfigured} {* Case types not present. Component is not configured for use. *}
-{include file="CRM/Case/Page/ConfigureError.tpl"}
+  {include file="CRM/Case/Page/ConfigureError.tpl"}
 {else}
-<tr>
-  <td><label>{ts}Case Start Date{/ts}</label></td>{include file="CRM/Core/DateRange.tpl" fieldName="case_from" from='_start_date_low' to='_start_date_high'}
-</tr>
-<tr>
-  <td><label>{ts}Case End Date{/ts}</label></td>{include file="CRM/Core/DateRange.tpl" fieldName="case_to" from='_end_date_low' to='_end_date_high'}
-</tr>
-
-<tr id='case_search_form'>
-  <td colspan="2" class="crm-case-common-form-block-case_type" width="25%">
-     <label>{$form.case_type_id.label}</label> <br />
-      {$form.case_type_id.html}
-  </td>
-
-  <td class="crm-case-common-form-block-case_status_id" width="25%">
-      <label>{$form.case_status_id.label}</label> <br />
-      {$form.case_status_id.html}
-    {if $accessAllCases}
-      <br />
-      {$form.case_owner.html}
-    {/if}
-    {if $form.case_deleted}
-      <br />
-      {$form.case_deleted.html}
-      {$form.case_deleted.label}
-    {/if}
-  </td>
-  {if $form.case_tags}
-    <td class="crm-case-common-form-block-case_tags">
-      <label>{ts}Case Tag(s){/ts}</label>
-      <div id="Tag" class="listing-box">
-        {foreach from=$form.case_tags item="tag_val"}
-          <div class="{cycle values='odd-row,even-row'}">
-            {$tag_val.html}
-          </div>
-        {/foreach}
-    </td>
-  {/if}
-</tr>
-
-<tr><td colspan="3">{include file="CRM/common/Tagset.tpl" tagsetType='case'}</td></tr>
-
-  {if $caseGroupTree}
   <tr>
-    <td colspan="4">
-    {include file="CRM/Custom/Form/Search.tpl" groupTree=$caseGroupTree showHideLinks=false}
+    <td class="crm-case-common-form-block-case_id">
+      {$form.case_id.label}<br />
+      {$form.case_id.html}
+    </td>
+    <td class="crm-case-common-form-block-case_subject">
+      {$form.case_subject.label}<br />
+      {$form.case_subject.html}
+    </td>
+    <td></td>
+  </tr>
+
+  <tr>
+    <td>
+      <label>{ts}Case Start Date{/ts}</label>
+    </td>
+    {include file="CRM/Core/DateRange.tpl" fieldName="case_from" from='_start_date_low' to='_start_date_high'}
+  </tr>
+  <tr>
+    <td>
+      <label>{ts}Case End Date{/ts}</label>
+    </td>
+    {include file="CRM/Core/DateRange.tpl" fieldName="case_to" from='_end_date_low' to='_end_date_high'}
+  </tr>
+
+  <tr id='case_search_form'>
+    <td class="crm-case-common-form-block-case_type">
+      {$form.case_type_id.label}<br />
+      {$form.case_type_id.html}
+    </td>
+
+    <td class="crm-case-common-form-block-case_status_id">
+      {$form.case_status_id.label}<br />
+      {$form.case_status_id.html}
+      {if $accessAllCases}
+        <br />
+        {$form.case_owner.html}
+      {/if}
+      {if $form.case_deleted}
+        <br />
+        {$form.case_deleted.html}
+        {$form.case_deleted.label}
+      {/if}
+    </td>
+    <td class="crm-case-common-form-block-case_tags">
+      {if $form.case_tags}
+        <label>{ts}Case Tag(s){/ts}</label>
+        <div id="Tag" class="listing-box">
+          {foreach from=$form.case_tags item="tag_val"}
+            <div class="{cycle values='odd-row,even-row'}">
+              {$tag_val.html}
+            </div>
+          {/foreach}
+        </div>
+      {/if}
     </td>
   </tr>
+
+  <tr>
+    <td colspan="3">{include file="CRM/common/Tagset.tpl" tagsetType='case'}</td>
+  </tr>
+
+  {if $caseGroupTree}
+    <tr>
+      <td colspan="3">
+        {include file="CRM/Custom/Form/Search.tpl" groupTree=$caseGroupTree showHideLinks=false}
+      </td>
+    </tr>
   {/if}
 
 {/if}
-


### PR DESCRIPTION
Overview
----------------------------------------
Include Case ID and Case Subject in Find Cases tool

Technical Details
----------------------------------------
This PR also cleans up the Find Case layout. It is built on a table structure but had an inconsistent number of columns in certain rows depending on what fields were potentially displayed. This implements a consistent three column layout. It also removes some duplicate label tags.

---

 * [CRM-21113: find cases: search by case ID and subject](https://issues.civicrm.org/jira/browse/CRM-21113)