### PR TITLE
CRM-21114: copy assignees on file on case

### DIFF
--- a/CRM/Activity/Page/AJAX.php
+++ b/CRM/Activity/Page/AJAX.php
@@ -361,8 +361,8 @@ class CRM_Activity_Page_AJAX {
       CRM_Activity_BAO_ActivityContact::create($targ_params);
     }
 
-    // typically this will be empty, since assignees on another case may be completely different
-    $assigneeContacts = array();
+    //CRM-21114 retrieve assignee contacts from original case; allow overriding from params
+    $assigneeContacts = CRM_Activity_BAO_ActivityContact::retrieveContactIdsByActivityId($params['activityID'], $assigneeID);
     if (!empty($params['assigneeContactIds'])) {
       $assigneeContacts = array_unique(explode(',', $params['assigneeContactIds']));
     }


### PR DESCRIPTION
Overview
----------------------------------------
When filing an activity on a case, also copy the original assignees.

Before
----------------------------------------
File on case would ignore existing activity assignees.

After
----------------------------------------
Assignees are now copied to the new activity in the case record.

---

 * [CRM-21114: file to case doesn't transfer activity assignees](https://issues.civicrm.org/jira/browse/CRM-21114)