### PR TITLE
WIP CRM-21115 messagetemplate api

### DIFF
--- a/CRM/Core/BAO/MessageTemplate.php
+++ b/CRM/Core/BAO/MessageTemplate.php
@@ -122,7 +122,7 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate {
   public static function del($messageTemplatesID) {
     // make sure messageTemplatesID is an integer
     if (!CRM_Utils_Rule::positiveInteger($messageTemplatesID)) {
-      CRM_Core_Error::fatal(ts('Invalid Message template'));
+      throw new Exception('Invalid Message template');
     }
 
     // Set mailing msg template col to NULL
@@ -299,7 +299,7 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate {
     $diverted->find(1);
 
     if ($diverted->N != 1) {
-      CRM_Core_Error::fatal(ts('Did not find a message template with id of %1.', array(1 => $id)));
+      throw new Exception('Did not find a message template with id of %1.', array(1 => $id));
     }
 
     $orig = new CRM_Core_BAO_MessageTemplate();
@@ -308,7 +308,7 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate {
     $orig->find(1);
 
     if ($orig->N != 1) {
-      CRM_Core_Error::fatal(ts('Message template with id of %1 does not have a default to revert to.', array(1 => $id)));
+      throw new Exception('Message template with id of %1 does not have a default to revert to.', array(1 => $id));
     }
 
     $diverted->msg_subject = $orig->msg_subject;
@@ -362,55 +362,7 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate {
 
     CRM_Utils_Hook::alterMailParams($params, 'messageTemplate');
 
-    if ((!$params['groupName'] ||
-        !$params['valueName']
-      ) &&
-      !$params['messageTemplateID']
-    ) {
-      CRM_Core_Error::fatal(ts("Message template's option group and/or option value or ID missing."));
-    }
-
-    if ($params['messageTemplateID']) {
-      // fetch the three elements from the db based on id
-      $query = 'SELECT msg_subject subject, msg_text text, msg_html html, pdf_format_id format
-                      FROM civicrm_msg_template mt
-                      WHERE mt.id = %1 AND mt.is_default = 1';
-      $sqlParams = array(1 => array($params['messageTemplateID'], 'String'));
-    }
-    else {
-      // fetch the three elements from the db based on option_group and option_value names
-      $query = 'SELECT msg_subject subject, msg_text text, msg_html html, pdf_format_id format
-                      FROM civicrm_msg_template mt
-                      JOIN civicrm_option_value ov ON workflow_id = ov.id
-                      JOIN civicrm_option_group og ON ov.option_group_id = og.id
-                      WHERE og.name = %1 AND ov.name = %2 AND mt.is_default = 1';
-      $sqlParams = array(1 => array($params['groupName'], 'String'), 2 => array($params['valueName'], 'String'));
-    }
-    $dao = CRM_Core_DAO::executeQuery($query, $sqlParams);
-    $dao->fetch();
-
-    if (!$dao->N) {
-      if ($params['messageTemplateID']) {
-        CRM_Core_Error::fatal(ts('No such message template: id=%1.', array(1 => $params['messageTemplateID'])));
-      }
-      else {
-        CRM_Core_Error::fatal(ts('No such message template: option group %1, option value %2.', array(
-              1 => $params['groupName'],
-              2 => $params['valueName'],
-            )));
-      }
-    }
-
-    $mailContent = array(
-      'subject' => $dao->subject,
-      'text' => $dao->text,
-      'html' => $dao->html,
-      'format' => $dao->format,
-      'groupName' => $params['groupName'],
-      'valueName' => $params['valueName'],
-      'messageTemplateID' => $params['messageTemplateID'],
-    );
-    $dao->free();
+    $mailContent = self::getMessageTemplate($params);
 
     CRM_Utils_Hook::alterMailContent($mailContent);
 
@@ -511,6 +463,7 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate {
     foreach ($params['tplParams'] as $name => $value) {
       $smarty->assign($name, $value);
     }
+
     foreach (array(
       'subject',
       'text',
@@ -572,6 +525,48 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate {
     }
 
     return array($sent, $mailContent['subject'], $mailContent['text'], $mailContent['html']);
+  }
+
+  /**
+   * Retrieve the actual message template
+   * @param $params
+   *
+   * @return array
+   */
+  public static function getMessageTemplate($params) {
+    if ((!$params['groupName'] ||
+        !$params['valueName']
+      ) &&
+      !$params['messageTemplateID']
+    ) {
+      throw new Exception("Message template's option group and/or option value or ID missing.");
+    }
+
+    if (empty($params['is_default'])) {
+      $params['is_default'] = 1;
+    }
+
+    if ($params['messageTemplateID']) {
+      $params['id'] = $params['messageTemplateID'];
+    }
+
+    try {
+      $content = civicrm_api3('MessageTemplate', 'getsingle', $params);
+    }
+    catch (Exception $e) {
+      throw new Exception('No such message template: id=%1. groupName=%2. valueName=%3', array(
+          1 => $params['id'], 2 => $params['groupName'], 3 => $params['valueName'])
+      );
+    }
+    return array(
+      'subject' => CRM_Utils_Array::value('msg_subject', $content),
+      'text' => CRM_Utils_Array::value('msg_text', $content),
+      'html' => CRM_Utils_Array::value('msg_html', $content),
+      'format' => isset($content['pdf_format_id']) ? $content['pdf_format_id'] : NULL,
+      'groupName' => $params['groupName'],
+      'valueName' => $params['valueName'],
+      'messageTemplateID' => $params['messageTemplateID'],
+    );
   }
 
 }

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1056,6 +1056,21 @@ class CRM_Utils_Token {
   }
 
   /**
+   * Strip all tokens from a string
+   * @param $str
+   *
+   * @return mixed
+   */
+  public static function stripTokens($str) {
+    preg_match_all('/(\{\w+\.\w+\})/', $str, $match);
+    $unMatched = $match[1];
+    foreach ($unMatched as $token) {
+      $str = str_replace($token, '', $str);
+    }
+    return $str;
+  }
+
+  /**
    * Find and replace tokens for each component.
    *
    * @param string $str

--- a/api/v3/MessageTemplate.php
+++ b/api/v3/MessageTemplate.php
@@ -117,7 +117,7 @@ function civicrm_api3_message_template_get($params) {
       $optionGroup = civicrm_api3('OptionGroup', 'getsingle', array('name' => $params['option_group_name']));
       $optionValue = civicrm_api3('OptionValue', 'getsingle', array(
         'name' => $params['option_value_name'],
-        'option_group_id' => $optionGroup['id']
+        'option_group_id' => $optionGroup['id'],
       ));
     }
     catch (Exception $e) {

--- a/api/v3/MessageTemplate.php
+++ b/api/v3/MessageTemplate.php
@@ -80,6 +80,17 @@ function civicrm_api3_message_template_delete($params) {
 function _civicrm_api3_message_template_get_spec(&$params) {
   // fetch active records by default
   $params['is_active']['api.default'] = 1;
+  $params['is_reserved']['api.default'] = 0;
+
+  $params['option_group_name']['description'] = 'option group name of the template (required if no id supplied)';
+  $params['option_group_name']['title'] = 'Option Group Name';
+  $params['option_group_name']['api.aliases'] = array('groupName');
+  $params['option_group_name']['type'] = CRM_Utils_Type::T_STRING;
+
+  $params['option_value_name']['description'] = 'option value name of the template (required if no id supplied)';
+  $params['option_value_name']['title'] = 'Option Value Name';
+  $params['option_value_name']['api.aliases'] = array('valueName');
+  $params['option_value_name']['type'] = CRM_Utils_Type::T_STRING;
 }
 
 /**
@@ -92,6 +103,32 @@ function _civicrm_api3_message_template_get_spec(&$params) {
  *   API result array.
  */
 function civicrm_api3_message_template_get($params) {
+  // Get option group params if set
+  if ((empty($params['option_group_name']) && !empty($params['groupName']))) {
+    $params['option_group_name'] = $params['groupName'];
+  }
+  if ((empty($params['option_value_name']) && !empty($params['valueName']))) {
+    $params['option_value_name'] = $params['valueName'];
+  }
+
+  // If we have option_group_name and option_group_id then lookup workflow_id so we can retrieve a single message template
+  if (empty($params['id']) && !empty($params['option_group_name']) && !empty($params['option_value_name'])) {
+    try {
+      $optionGroup = civicrm_api3('OptionGroup', 'getsingle', array('name' => $params['option_group_name']));
+      $optionValue = civicrm_api3('OptionValue', 'getsingle', array(
+        'name' => $params['option_value_name'],
+        'option_group_id' => $optionGroup['id']
+      ));
+    }
+    catch (Exception $e) {
+      throw new API_Exception('Could not find option_group_name or option_value_name');
+    }
+    unset($params['option_group_name']);
+    unset($params['option_value_name']);
+    $params['workflow_id'] = $optionValue['id'];
+  }
+
+  // Perform the basic get.  If workflow_id or id was set above then we return a single template, otherwise we return all
   return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
 }
 

--- a/api/v3/MessageTemplate.php
+++ b/api/v3/MessageTemplate.php
@@ -80,7 +80,6 @@ function civicrm_api3_message_template_delete($params) {
 function _civicrm_api3_message_template_get_spec(&$params) {
   // fetch active records by default
   $params['is_active']['api.default'] = 1;
-  $params['is_reserved']['api.default'] = 0;
 
   $params['option_group_name']['description'] = 'option group name of the template (required if no id supplied)';
   $params['option_group_name']['title'] = 'Option Group Name';

--- a/tests/phpunit/CRM/Utils/TokenTest.php
+++ b/tests/phpunit/CRM/Utils/TokenTest.php
@@ -141,5 +141,12 @@ class CRM_Utils_TokenTest extends CiviUnitTestCase {
       }
     }
   }
+  
+  public function testStripTokens() {
+    $testString = 'Test with {$smarty} and {$smarty.s} and {literal} and {non.smarty}';
+    $expectedResult = 'Test with {$smarty} and {$smarty.s} and {literal} and ';
+    $result = CRM_Utils_Token::stripTokens($testString);
+    $this->assertEquals($expectedResult, $result, 'String with stripped tokens doesn\'t match expected result');
+  }
 
 }

--- a/tests/phpunit/CRM/Utils/TokenTest.php
+++ b/tests/phpunit/CRM/Utils/TokenTest.php
@@ -141,7 +141,7 @@ class CRM_Utils_TokenTest extends CiviUnitTestCase {
       }
     }
   }
-  
+
   public function testStripTokens() {
     $testString = 'Test with {$smarty} and {$smarty.s} and {literal} and {non.smarty}';
     $expectedResult = 'Test with {$smarty} and {$smarty.s} and {literal} and ';

--- a/tests/phpunit/api/v3/MessageTemplateTest.php
+++ b/tests/phpunit/api/v3/MessageTemplateTest.php
@@ -78,6 +78,26 @@ class api_v3_MessageTemplateTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test get with alternative (optiongroup/optionvalue) parameters
+   */
+  public function testGetOptionValue() {
+    $params['groupName'] = 'msg_tpl_workflow_event';
+    $params['valueName'] = 'event_offline_receipt';
+    $result = $this->callAPISuccessGetSingle('MessageTemplate', $params);
+    $this->assertEquals('Events - Registration Confirmation and Receipt (off-line)', $result['msg_title'], 'Wrong message template returned');
+  }
+
+  /**
+   * Test get with alternative (optiongroup/optionvalue) parameters
+   */
+  public function testGetOptionValueParams() {
+    $params['option_group_name'] = 'msg_tpl_workflow_event';
+    $params['option_value_name'] = 'event_offline_receipt';
+    $result = $this->callAPISuccessGetSingle('MessageTemplate', $params);
+    $this->assertEquals('Events - Registration Confirmation and Receipt (off-line)', $result['msg_title'], 'Wrong message template returned');
+  }
+
+  /**
    * Check the delete function succeeds.
    */
   public function testDelete() {


### PR DESCRIPTION
Overview
----------------------------------------
Support groupName/valueName parameters in MessageTemplate.get API as used throughout the codebase.  Fix PHP warnings when tokens are passed to the smarty processor.

Before
----------------------------------------
Direct SQL queries as API didn't support required parameters.

After
----------------------------------------
Single API function using basic_get to retrieve message templates

---

 * [CRM-21115: Improve MessageTemplate.Get API to support groupName\/valueName params](https://issues.civicrm.org/jira/browse/CRM-21115)