### PR TITLE
CRM-21116 - Refactor event notification code (Messagetemplates and activities)

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -2056,7 +2056,7 @@ WHERE      activity.id IN ($activityIds)";
   }
 
   /**
-   * Add activity for Membership/Event/Contribution.
+   * Add activity for Membership/Contribution.
    *
    * @param object $activity
    *   (reference) particular component object.
@@ -2077,12 +2077,6 @@ WHERE      activity.id IN ($activityIds)";
     $date = date('YmdHis');
     if ($activity->__table == 'civicrm_membership') {
       $component = 'Membership';
-    }
-    elseif ($activity->__table == 'civicrm_participant') {
-      if ($activityType != 'Email') {
-        $activityType = 'Event Registration';
-      }
-      $component = 'Event';
     }
     elseif ($activity->__table == 'civicrm_contribution') {
       // create activity record only for Completed Contributions
@@ -2176,21 +2170,6 @@ WHERE      activity.id IN ($activityIds)";
         }
 
         $subject .= " - Status: " . CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipStatus', $entityObj->status_id, 'label');
-        return $subject;
-
-      case 'civicrm_participant':
-        $event = CRM_Event_BAO_Event::getEvents(1, $entityObj->event_id, TRUE, FALSE);
-        $roles = CRM_Event_PseudoConstant::participantRole();
-        $status = CRM_Event_PseudoConstant::participantStatus();
-        $subject = $event[$entityObj->event_id];
-
-        if (!empty($roles[$entityObj->role_id])) {
-          $subject .= ' - ' . $roles[$entityObj->role_id];
-        }
-        if (!empty($status[$entityObj->status_id])) {
-          $subject .= ' - ' . $status[$entityObj->status_id];
-        }
-
         return $subject;
 
       case 'civicrm_contribution':

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1738,8 +1738,23 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
           $sent[] = $contactID;
           foreach ($participants as $ids => $values) {
             if ($values->contact_id == $contactID) {
-              $values->details = CRM_Utils_Array::value('receipt_text', $params);
-              CRM_Activity_BAO_Activity::addActivity($values, 'Email');
+              $activityParams = array(
+                'source_contact_id' => $values->contact_id,
+                'source_record_id' => $values->id,
+                'activity_type_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Email'),
+                'is_test' => $values->is_test,
+                'skipRecentView' => TRUE,
+                'campaign_id' => $values->campaign_id,
+                'details' => CRM_Utils_Array::value('receipt_text', $params),
+              );
+
+              // create activity with target contacts
+              $id = CRM_Core_Session::getLoggedInContactID();
+              if ($id) {
+                $activityParams['source_contact_id'] = $id;
+                $activityParams['target_contact_id'][] = $values->contact_id;
+              }
+              CRM_Event_BAO_Participant::addActivity($activityParams);
               break;
             }
           }

--- a/CRM/Event/Form/SelfSvcTransfer.php
+++ b/CRM/Event/Form/SelfSvcTransfer.php
@@ -513,7 +513,7 @@ class CRM_Event_Form_SelfSvcTransfer extends CRM_Core_Form {
       $contactDetails[$this->_from_contact_id] = $contactValues;
     }
     //send a 'cancelled' email to user, and cc the event's cc_confirm email
-    $mail = CRM_Event_BAO_Participant::sendTransitionParticipantMail($this->_from_participant_id,
+    $mail = CRM_Event_BAO_Participant::sendTransitionParticipantMail(
       $participantDetails[$this->_from_participant_id],
       $eventDetails[$this->_event_id],
       $contactDetails[$this->_from_contact_id],

--- a/CRM/Event/Form/SelfSvcUpdate.php
+++ b/CRM/Event/Form/SelfSvcUpdate.php
@@ -347,7 +347,7 @@ class CRM_Event_Form_SelfSvcUpdate extends CRM_Core_Form {
       $contactDetails[$this->_contact_id] = $contactValues;
     }
     //send a 'cancelled' email to user, and cc the event's cc_confirm email
-    $mail = CRM_Event_BAO_Participant::sendTransitionParticipantMail($this->_participant_id,
+    $mail = CRM_Event_BAO_Participant::sendTransitionParticipantMail(
       $participantDetails[$this->_participant_id],
       $eventDetails[$this->_event_id],
       $contactDetails[$this->_contact_id],


### PR DESCRIPTION
Overview
----------------------------------------
Refactor event notification code so that all code for sending emails and creating related activities is in CRM_Event_BAO_Participant instead of spread all over the place!
Makes the code in this area a little cleaner and easier to maintain.  I started this because I couldn't see what params were set in an event template.  Code has been consolidated where possible and should encourage consistency in future for sending event related messages.

Before
----------------------------------------
Notification code spread across various form/BAO code

After
----------------------------------------
Notification centralised in Event_BAO_Participant

---

 * [CRM-21116: NFC - Refactor event notification code \(Messagetemplates and activities\)](https://issues.civicrm.org/jira/browse/CRM-21116)