### PR TITLE
CRM-20855: Disabling "Search Primary Details Only" causes partial CiviMail delivery failure

### DIFF
--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1235,7 +1235,7 @@ class CRM_Utils_Token {
       }
     }
 
-    $details = CRM_Contact_BAO_Query::apiQuery($params, $returnProperties, NULL, NULL, 0, count($contactIDs));
+    $details = CRM_Contact_BAO_Query::apiQuery($params, $returnProperties, NULL, NULL, 0, count($contactIDs), TRUE, FALSE, TRUE, CRM_Contact_BAO_Query::MODE_CONTACTS, NULL, TRUE);
 
     $contactDetails = &$details[0];
 

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -570,7 +570,8 @@ function _civicrm_api3_get_using_query_object($entity, $params, $additional_opti
     $getCount,
     $skipPermissions,
     $mode,
-    $entity
+    $entity,
+    TRUE
   );
 
   return $entities;
@@ -603,7 +604,8 @@ function _civicrm_api3_get_query_object($params, $mode, $entity) {
   $newParams = CRM_Contact_BAO_Query::convertFormValues($inputParams, 0, FALSE, $entity);
   $query = new CRM_Contact_BAO_Query($newParams, $returnProperties, NULL,
     FALSE, FALSE, $mode,
-    empty($params['check_permissions'])
+    empty($params['check_permissions']),
+    TRUE, TRUE, NULL, 'AND', 'NULL', TRUE
   );
   list($select, $from, $where, $having) = $query->query();
 


### PR DESCRIPTION
Overview
----------------------------------------
Alternate to #10746, fixing a problem when some contacts are missed when the 'search primary details only' setting is disabled.

Before
----------------------------------------
When a contact has 2 emails & the setting for search primary only is off, calling the tokens query gets 2 rows but truncates by the number of contacts, resulting in one being lost.

After
----------------------------------------
Test in place demonstrating that the retrieval works.

Technical Details
----------------------------------------
Replaces  #10746  - the unit tests in there replicate some or all of the problem. This is just stylistic changes on top of that.

Comments
----------------------------------------
I'm not 100% sure if this solves the whole problem or one manifestation - we should confirm when closing JIRA.

---

 * [CRM-20855: Disabling "Search Primary Details Only" causes partial CiviMail delivery failure](https://issues.civicrm.org/jira/browse/CRM-20855)