### PR TITLE
CRM-20027 add test for locBlock permission issue

### DIFF
--- a/tests/phpunit/api/v3/ACLPermissionTest.php
+++ b/tests/phpunit/api/v3/ACLPermissionTest.php
@@ -115,6 +115,23 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
   }
 
   /**
+   * Ensure contact permissions do not block contact-less location entities.
+   */
+  public function testAddressWithoutContactIDAccess() {
+    $ownID = $this->createLoggedInUser();
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = array('access CiviCRM', 'view all contacts');
+    $this->callAPISuccess('Address', 'create', array(
+      'city' => 'Mouseville',
+      'location_type_id' => 'Main',
+      'api.LocBlock.create' => 1,
+      'contact_id' => $ownID,
+    ));
+    $this->callAPISuccessGetSingle('Address', array('city' => 'Mouseville', 'check_permissions' => 1));
+    CRM_Core_DAO::executeQuery('UPDATE civicrm_address SET contact_id = NULL WHERE contact_id = %1', array(1 => array($ownID, 'Integer')));
+    $this->callAPISuccessGetSingle('Address', array('city' => 'Mouseville', 'check_permissions' => 1));
+  }
+
+  /**
    * Ensure contact permissions extend to related entities like email
    */
   public function testRelatedEntityPermissions() {


### PR DESCRIPTION
Overview
----------------------------------------
Adds unit test for issue addressed in PR #9840

Before
----------------------------------------
No unit test, unsure if problem fixed

After
----------------------------------------
Unit test. Problem appears fixed & on further checks the change in the open PR is in core

---

 * [CRM-20027: Need 'access deleted contacts' permission to retrieve loc block addresses using API](https://issues.civicrm.org/jira/browse/CRM-20027)