### PR TITLE
CRM-21118 Add action links at top of page on message template overview

### DIFF
--- a/templates/CRM/Admin/Page/MessageTemplates.tpl
+++ b/templates/CRM/Admin/Page/MessageTemplates.tpl
@@ -112,7 +112,12 @@
           {/if}
           </div>
         <div>
-          <p></p>
+          {if $action ne 1 and $action ne 2 and $type eq 'userTemplates'}
+            <div class="action-link">
+              {crmButton p='civicrm/admin/messageTemplates/add' q="action=add&reset=1" id="newMessageTemplates"  icon="plus-circle"}{ts}Add Message Template{/ts}{/crmButton}
+            </div>
+            <div class="spacer"></div>
+          {/if}
             {if !empty( $template_row) }
               <table class="display">
                 <thead>


### PR DESCRIPTION
Before
----------------------------------------
Action links only shown at bottom

After
----------------------------------------
![buttons at top](https://issues.civicrm.org/jira/secure/attachment/64270/messagetemplate_button_at_top.png)

---

 * [CRM-21118: Add action links for message templates overview at top of page](https://issues.civicrm.org/jira/browse/CRM-21118)