### PR TITLE
CRM-21120 Add environment check for existence of encryption function

### DIFF
--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -125,8 +125,8 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
     if ($encrypted_test_pass == base64_encode($test_pass)) {
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
-        ts('Your PHP does not include the recommended encryption functions. Some passwords will not be stored encrypted, and if you have recently upgraded from a PHP that does include these functions, your encrypted passwords will not be decrypted correctly. If you are using PHP 7.0 or earlier, you probably want to include the "%1" extension.'
-          array('1' => 'mcrypt'),
+        ts('Your PHP does not include the recommended encryption functions. Some passwords will not be stored encrypted, and if you have recently upgraded from a PHP that does include these functions, your encrypted passwords will not be decrypted correctly. If you are using PHP 7.0 or earlier, you probably want to include the "%1" extension.',
+          array('1' => 'mcrypt')
         ),
         ts('PHP Missing Extension "mcrypt"'),
         \Psr\Log\LogLevel::WARNING,

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -121,7 +121,7 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
   public function checkPhpEcrypt() {
     $messages = array();
     $test_pass = 'iAmARandomString';
-    $encrypted_test_pass = CRM_Utils_Crypt::encrypt($test_pass) 
+    $encrypted_test_pass = CRM_Utils_Crypt::encrypt($test_pass);
     if ($encrypted_test_pass == base64_encode($test_pass)) {
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -120,14 +120,14 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
    */
   public function checkPhpEcrypt() {
     $messages = array();
-    if (!function_exists('mcrypt_module_open')) {
+    $test_pass = 'iAmARandomString';
+    $encrypted_test_pass = CRM_Utils_Crypt::encrypt($test_pass) 
+    if ($encrypted_test_pass == base64_encode($test_pass)) {
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
-        ts('Your version of PHP does not include the <a href="%1">mcrypt functions</a>. You likely should include the extension "%2". Some passwords will not be stored encrypted, and if you have recently upgraded from a PHP that does include these functions, your encrypted passwords will not be decrypted correctly.',
-          array(
-            1 => 'http://php.net/manual/en/book.mcrypt.php',
-            2 => 'mcrypt',
-          )),
+        ts('Your PHP does not include the recommended encryption functions. Some passwords will not be stored encrypted, and if you have recently upgraded from a PHP that does include these functions, your encrypted passwords will not be decrypted correctly. If you are using PHP 7.0 or earlier, you probably want to include the "%1" extension.'
+          array('1' => 'mcrypt'),
+        ),
         ts('PHP Missing Extension "mcrypt"'),
         \Psr\Log\LogLevel::WARNING,
         'fa-server'

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -116,6 +116,27 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
   }
 
   /**
+   * @return array
+   */
+  public function checkPhpEcrypt() {
+    $messages = array();
+    if (!function_exists('mcrypt_module_open')) {
+      $messages[] = new CRM_Utils_Check_Message(
+        __FUNCTION__,
+        ts('Your version of PHP does not include the <a href="%1">mcrypt functions</a>. You likely should include the extension "%2". Some passwords will not be stored encrypted, and if you have recently upgraded from a PHP that does include these functions, your encrypted passwords will not be decrypted correctly.',
+          array(
+            1 => 'http://php.net/manual/en/book.mcrypt.php',
+            2 => 'mcrypt',
+          )),
+        ts('PHP Missing Extension "mcrypt"'),
+        \Psr\Log\LogLevel::WARNING,
+        'fa-server'
+      );
+    }
+    return $messages;
+  }
+
+  /**
    * Check that the MySQL time settings match the PHP time settings.
    *
    * @return array<CRM_Utils_Check_Message> an empty array, or a list of warnings


### PR DESCRIPTION
Overview
----------------------------------------
Simple environmental check for presence of mcrypt function.

Before
----------------------------------------
A missing mcrypt function will cause different behaviour by the encrypt function without notice.

After
----------------------------------------
Adds a warning to the status page.

Comments
----------------------------------------
The bigger issue is addressed in https://issues.civicrm.org/jira/browse/CRM-21085

---

 * [CRM-21120: Warn if no crypt functions available](https://issues.civicrm.org/jira/browse/CRM-21120)