### PR TITLE
CRM-21124 fix error on cacheKey when too long

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1914,7 +1914,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
     $cacheKeyString = "merge {$contactType}";
     $cacheKeyString .= $rule_group_id ? "_{$rule_group_id}" : '_0';
     $cacheKeyString .= $group_id ? "_{$group_id}" : '_0';
-    $cacheKeyString .= !empty($criteria) ? serialize($criteria) : '_0';
+    $cacheKeyString .= !empty($criteria) ? md5(serialize($criteria)) : '_0';
     if ($checkPermissions) {
       $contactID = CRM_Core_Session::getLoggedInContactID();
       if (!$contactID) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a rare DB error when merging with a long criteria string, which exceeds the field length

Before
----------------------------------------
Fatal error when calling the batchMerge with a long critieria string (hard to do outside of code or api calls)

After
----------------------------------------
No fatal error

Technical Details
----------------------------------------
By passing criteria through md5() we can ensure it is no longer than 32 char

---

 * [CRM-21124: Fix DB error on deduping by criteria when criteria string is too long](https://issues.civicrm.org/jira/browse/CRM-21124)