### PR TITLE
CRM-21125 allow class assignment on report row links

### DIFF
--- a/templates/CRM/Report/Form/Layout/Table.tpl
+++ b/templates/CRM/Report/Form/Layout/Table.tpl
@@ -110,9 +110,10 @@
                 {foreach from=$columnHeaders item=header key=field}
                     {assign var=fieldLink value=$field|cat:"_link"}
                     {assign var=fieldHover value=$field|cat:"_hover"}
+                    {assign var=fieldClass value=$field|cat:"_class"}
                     <td class="crm-report-{$field}{if $header.type eq 1024 OR $header.type eq 1 OR $header.type eq 512} report-contents-right{elseif $row.$field eq 'Subtotal'} report-label{/if}">
                         {if $row.$fieldLink}
-                            <a title="{$row.$fieldHover}" href="{$row.$fieldLink}">
+                            <a title="{$row.$fieldHover}" href="{$row.$fieldLink}"  {if $row.$fieldClass} class="{$row.$fieldClass}"{/if}>
                         {/if}
 
                         {if $row.$field eq 'Subtotal'}


### PR DESCRIPTION
Overview
----------------------------------------
Allows report writers to assign a class when defining a link on a cell

Before
----------------------------------------
Not possible to assign a link

After
----------------------------------------
Possible, but no change in any existing reports / behaviour. Extra steps are required in the reports themselves to leverage

Technical Details
----------------------------------------
an example usage is on JIRA

---

 * [CRM-21125: permit class assignment on links in reports](https://issues.civicrm.org/jira/browse/CRM-21125)