### PR TITLE
CRM-21126: fix default selection of member_is_primary input

### DIFF
--- a/CRM/Member/Form/Search.php
+++ b/CRM/Member/Form/Search.php
@@ -353,7 +353,7 @@ class CRM_Member_Form_Search extends CRM_Core_Form_Search {
 
     //LCD also allow restrictions to membership owner via GET
     $owner = CRM_Utils_Request::retrieve('owner', 'String');
-    if (!is_null($owner)) {
+    if (in_array($owner, array('0', '1'))) {
       $this->_formValues['member_is_primary'] = $this->_defaults['member_is_primary'] = $owner;
     }
   }

--- a/CRM/Member/Form/Search.php
+++ b/CRM/Member/Form/Search.php
@@ -353,8 +353,8 @@ class CRM_Member_Form_Search extends CRM_Core_Form_Search {
 
     //LCD also allow restrictions to membership owner via GET
     $owner = CRM_Utils_Request::retrieve('owner', 'String');
-    if ($owner) {
-      $this->_formValues['member_is_primary'] = $this->_defaults['member_is_primary'] = 2;
+    if (!is_null($owner)) {
+      $this->_formValues['member_is_primary'] = $this->_defaults['member_is_primary'] = $owner;
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
default selection of member_is_primary input is not done on passing param through URL.

Before
----------------------------------------
Passing `owner` in the url does not enable any option in `member_is_primary` radio input. 

Eg.  http://dmaster.demo.civicrm.org/civicrm/member/search?reset=1&force=1&status=1,2,3&type=12&owner=1 screen would not select `Primary Member?` input in the membership search form. This would lead to incorrect contacts in export and various task.

<img width="355" alt="image" src="https://user-images.githubusercontent.com/5929648/29866497-313c7ec0-8d96-11e7-9f68-5811ffec3ef4.png">

After
----------------------------------------
`Primary Member?` is correctly selected.

---

 * [CRM-21126: member_is_primary not set by default on passing owner in the url](https://issues.civicrm.org/jira/browse/CRM-21126)