### PR TITLE
CRM-21129 - CLI API CSV import doesn't allow single-column CSVs

### DIFF
--- a/bin/cli.class.php
+++ b/bin/cli.class.php
@@ -418,9 +418,6 @@ class civicrm_cli_csv_file extends civicrm_cli {
       $this->separator = ";";
       rewind($handle);
       $header = fgetcsv($handle, 0, $this->separator);
-      if (count($header) == 1) {
-        die("Invalid file format for " . $this->_file . ". It must be a valid csv with separator ',' or ';'\n");
-      }
     }
 
     $this->header = $header;


### PR DESCRIPTION
Overview
----------------------------------------
When importing CSVs through the command line tool, you can't import a CSV with a single column.

Before
----------------------------------------
Run the following command:
`php <civiroot>/bin/csv/import.php -e Setting --file /path/to/file/cli_allowed_countries.csv`

"cli_allowed_countries" should have the following contents:
```
"countryLimit"                                                                                                                                                                                                     
"1039, 1076, 1085, 1109, 1228"
```

You'll receive an error:
`Invalid file format for /path/to/file/cli_allowed_countries.csv. It must be a valid csv with separator ',' or ';'`

After
----------------------------------------
After running the command in "Overview", you should have the following Allowed Countries in **Administer » Localization » Languages, Currency, Location** for "Allowed Countries": Canada, France, Greece, Japan, United States.  The output of your import command should be:
`line 2: created Setting id: 1`

Comments
----------------------------------------
This is a very small change in a part of the codebase only touched by technical folks - a quick PR to review :smile: 