### PR TITLE
Fix for CRM-21122: "Support selection of smart groups on Contact Dashboard"

### DIFF
--- a/CRM/Contact/Form/GroupContact.php
+++ b/CRM/Contact/Form/GroupContact.php
@@ -80,7 +80,17 @@ class CRM_Contact_Form_GroupContact extends CRM_Core_Form {
     // get the list of all the groups
     if ($this->_context == 'user') {
       $onlyPublicGroups = CRM_Utils_Request::retrieve('onlyPublicGroups', 'Boolean', $this, FALSE);
-      $allGroups = CRM_Core_PseudoConstant::staticGroup($onlyPublicGroups);
+      $ids = CRM_Core_PseudoConstant::allGroup();
+      $heirGroups = CRM_Contact_BAO_Group::getGroupsHierarchy($ids);
+
+      $allGroups = array();
+      foreach ($heirGroups as $id => $group) {
+        // make sure that this group has public visibility
+        if ($onlyPublicGroups && $group['visibility'] == 'User and User Admin Only') {
+          continue;
+        }
+        $allGroups[$id] = $group;
+      }
     }
     else {
       $allGroups = CRM_Core_PseudoConstant::group();

--- a/CRM/Contact/Page/View/UserDashBoard/GroupContact.php
+++ b/CRM/Contact/Page/View/UserDashBoard/GroupContact.php
@@ -40,28 +40,32 @@ class CRM_Contact_Page_View_UserDashBoard_GroupContact extends CRM_Contact_Page_
       $this->_contactId,
       NULL,
       NULL, TRUE, TRUE,
-      $this->_onlyPublicGroups
+      $this->_onlyPublicGroups,
+      NULL, NULL, TRUE
     );
 
     $in = CRM_Contact_BAO_GroupContact::getContactGroup(
       $this->_contactId,
       'Added',
       NULL, FALSE, TRUE,
-      $this->_onlyPublicGroups
+      $this->_onlyPublicGroups,
+      NULL, NULL, TRUE
     );
 
     $pending = CRM_Contact_BAO_GroupContact::getContactGroup(
       $this->_contactId,
       'Pending',
       NULL, FALSE, TRUE,
-      $this->_onlyPublicGroups
+      $this->_onlyPublicGroups,
+      NULL, NULL, TRUE
     );
 
     $out = CRM_Contact_BAO_GroupContact::getContactGroup(
       $this->_contactId,
       'Removed',
       NULL, FALSE, TRUE,
-      $this->_onlyPublicGroups
+      $this->_onlyPublicGroups,
+      NULL, NULL, TRUE
     );
 
     $this->assign('groupCount', $count);

--- a/tests/phpunit/CRM/Contact/Page/View/UserDashboard/GroupContactTest.php
+++ b/tests/phpunit/CRM/Contact/Page/View/UserDashboard/GroupContactTest.php
@@ -1,0 +1,224 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2017                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Test class for CRM_Contact_BAO_GroupContact BAO
+ *
+ * @package   CiviCRM
+ * @group headless
+ */
+class CRM_Contact_Page_View_UserDashboard_GroupContactTest extends CiviUnitTestCase {
+
+  /**
+   * Sets up the fixture, for example, opens a network connection.
+   * This method is called before a test is executed.
+   */
+  protected function setUp() {
+    parent::setUp();
+  }
+
+  /**
+   * Tears down the fixture, for example, closes a network connection.
+   *
+   * This method is called after a test is executed.
+   */
+  protected function tearDown() {
+    parent::tearDown();
+  }
+
+  /**
+   * Test that the list of the contact's joined groups, on the Contact Dashboard,
+   * contains the correct groups.
+   */
+  public function testBrowseDisplaysCorrectListOfAddedGroups() {
+    // create admin-only non-smart group
+    $adminStdGroupTitle = 'The Admin-only Std Group';
+    $adminStdGroup = $this->callAPISuccess('Group', 'create', array(
+      'title' => $adminStdGroupTitle,
+      'visibility' => 'User and User Admin Only',
+      'is_active' => 1,
+    ));
+    // create public non-smart group
+    $publicStdGroupTitle = 'The Public Std Group';
+    $publicStdGroup = $this->callAPISuccess('Group', 'create', array(
+      'title' => $publicStdGroupTitle,
+      'visibility' => 'Public Pages',
+      'is_active' => 1,
+    ));
+
+    // Prepare to create smart groups based on saved criteria Gender = Male.
+    // Start by creating the saved search.
+    $savedSearch = $this->callAPISuccess('SavedSearch', 'create', array(
+      'form_values' => 'a:1:{i:0;a:5:{i:0;s:9:"gender_id";i:1;s:1:"=";i:2;i:2;i:3;i:0;i:4;i:0;}}',
+    ));
+    // Create contact with Gender - Male
+    $savedSearchContact = $this->individualCreate(array(
+      'gender_id' => "Male",
+      'first_name' => 'C',
+    ), 1);
+    // Create admin-only smart group for this saved search.
+    $adminSmartGroupTitle = 'The Admin-only Smart Group';
+    $adminSmartGroup = $this->callAPISuccess('Group', 'create', array(
+      'title' => $adminSmartGroupTitle,
+      'visibility' => 'User and User Admin Only',
+      'saved_search_id' => $savedSearch['id'],
+      'is_active' => 1,
+    ));
+    // Create public smart group for this saved search.
+    $publicSmartGroupTitle = 'The Public Smart Group';
+    $publicSmartGroup = $this->callAPISuccess('Group', 'create', array(
+      'title' => $publicSmartGroupTitle,
+      'visibility' => 'Public Pages',
+      'saved_search_id' => $savedSearch['id'],
+      'is_active' => 1,
+    ));
+
+    // Get logged in user contact ID.
+    $user_id = $this->createLoggedInUser();
+    $_REQUEST['id'] = $user_id;
+
+    // Add current user to the test groups.
+    $publicSmartGroup = $this->callAPISuccess('Contact', 'create', array(
+      'id' => $user_id,
+      'group' => array(
+        $adminStdGroup['id'] => 1,
+        $adminSmartGroup['id'] => 1,
+        $publicStdGroup['id'] => 1,
+        $publicSmartGroup['id'] => 1,
+      ),
+    ));
+
+    // Run the contact dashboard and assert that only the public groups appear
+    // in the variables.
+    $page = new CRM_Contact_Page_View_UserDashBoard_GroupContact();
+    $page->run();
+
+    $groupIn = CRM_Core_Smarty::singleton()->get_template_vars('groupIn');
+    $groupInTitles = CRM_Utils_Array::collect('title', $groupIn);
+    $this->assertContains($publicSmartGroupTitle, $groupInTitles, "Group '$publicSmartGroupTitle' should be in listed groups, but is not.");
+    $this->assertContains($publicStdGroupTitle, $groupInTitles, "Group '$publicStdGroupTitle' should be in listed groups, but is not.");
+    $this->assertNotContains($adminSmartGroupTitle, $groupInTitles, "Group '$adminSmartGroupTitle' should not be in listed groups, but is.");
+    $this->assertNotContains($adminStdGroupTitle, $groupInTitles, "Group '$adminStdGroupTitle' should not be in listed groups, but is.");
+  }
+
+  /**
+   * Test that the select list of available groups, on the Contact Dashboard,
+   * contains the correct groups.
+   */
+  public function testBrowseDisplaysCorrectListOfAVailableGroups() {
+
+    // create admin-only non-smart group
+    $adminStdGroupTitle = 'The Admin-only Std Group' . uniqid();
+    $adminStdGroup = $this->callAPISuccess('Group', 'create', array(
+      'title' => $adminStdGroupTitle,
+      'visibility' => 'User and User Admin Only',
+      'is_active' => 1,
+    ));
+    // create public non-smart group
+    $publicStdGroupTitle = 'The Public Std Group' . uniqid();
+    $publicStdGroup = $this->callAPISuccess('Group', 'create', array(
+      'title' => $publicStdGroupTitle,
+      'visibility' => 'Public Pages',
+      'is_active' => 1,
+    ));
+    // create second public non-smart group
+    $publicStdGroupTitle2 = 'The 2nd Public Std Group' . uniqid();
+    $publicStdGroup2 = $this->callAPISuccess('Group', 'create', array(
+      'title' => $publicStdGroupTitle2,
+      'visibility' => 'Public Pages',
+      'is_active' => 1,
+    ));
+
+    // Prepare to create smart groups based on saved criteria Gender = Male.
+    // Start by creating the saved search.
+    $savedSearch = $this->callAPISuccess('SavedSearch', 'create', array(
+      'form_values' => 'a:1:{i:0;a:5:{i:0;s:9:"gender_id";i:1;s:1:"=";i:2;i:2;i:3;i:0;i:4;i:0;}}',
+    ));
+    // Create contact with Gender - Male
+    $savedSearchContact = $this->individualCreate(array(
+      'gender_id' => "Male",
+      'first_name' => 'C',
+    ), 1);
+    // Create admin-only smart group for this saved search.
+    $adminSmartGroupTitle = 'The Admin-only Smart Group' . uniqid();
+    $adminSmartGroup = $this->callAPISuccess('Group', 'create', array(
+      'title' => $adminSmartGroupTitle,
+      'visibility' => 'User and User Admin Only',
+      'saved_search_id' => $savedSearch['id'],
+      'is_active' => 1,
+    ));
+    // Create public smart group for this saved search.
+    $publicSmartGroupTitle = 'The Public Smart Group' . uniqid();
+    $publicSmartGroup = $this->callAPISuccess('Group', 'create', array(
+      'title' => $publicSmartGroupTitle,
+      'visibility' => 'Public Pages',
+      'saved_search_id' => $savedSearch['id'],
+      'is_active' => 1,
+    ));
+
+    // Get logged in user contact ID.
+    $user_id = $this->createLoggedInUser();
+
+    // Run the contact dashboard and assert that only the public groups appear
+    // in select list of available groups.
+    $_REQUEST['id'] = $user_id;
+    $page = new CRM_Contact_Page_View_UserDashBoard_GroupContact();
+    $page->run();
+
+    $form = CRM_Core_Smarty::singleton()->get_template_vars('form');
+    $group_id_field_html = $form['group_id']['html'];
+    $this->assertContains($publicSmartGroupTitle, $group_id_field_html, "Group '$publicSmartGroupTitle' should be in listed available groups, but is not.");
+    $this->assertContains($publicStdGroupTitle, $group_id_field_html, "Group '$publicStdGroupTitle' should be in listed available groups, but is not.");
+    $this->assertNotContains($adminSmartGroupTitle, $group_id_field_html, "Group '$adminSmartGroupTitle' should not be in listed available groups, but is.");
+    $this->assertNotContains($adminStdGroupTitle, $group_id_field_html, "Group '$adminStdGroupTitle' should not be in listed available groups, but is.");
+
+    // Add current user to the test groups.
+    $publicSmartGroup = $this->callAPISuccess('Contact', 'create', array(
+      'id' => $user_id,
+      'group' => array(
+        $adminStdGroup['id'] => 1,
+        $adminSmartGroup['id'] => 1,
+        $publicStdGroup['id'] => 1,
+        $publicSmartGroup['id'] => 1,
+      ),
+    ));
+
+    // Run the contact dashboard and assert that none of the groups appear
+    // in select list of available groups.
+    $_REQUEST['id'] = $user_id;
+    $page = new CRM_Contact_Page_View_UserDashBoard_GroupContact();
+    $page->run();
+
+    $form = CRM_Core_Smarty::singleton()->get_template_vars('form');
+    $group_id_field_html = $form['group_id']['html'];
+    $this->assertNotContains($publicSmartGroupTitle, $group_id_field_html, "Group '$publicSmartGroupTitle' should not be in listed available groups, but is.");
+    $this->assertNotContains($publicStdGroupTitle, $group_id_field_html, "Group '$publicStdGroupTitle' should not be in listed available groups, but is.");
+    $this->assertNotContains($adminSmartGroupTitle, $group_id_field_html, "Group '$adminSmartGroupTitle' should not be in listed available groups, but is.");
+    $this->assertNotContains($adminStdGroupTitle, $group_id_field_html, "Group '$adminStdGroupTitle' should not be in listed available groups, but is.");
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Changes the Contact Dashboard so that the user can join and leave publicly visible Smart Groups, just as they can on Profiles, as shown in this Profile screenshot:
![profile_before](https://user-images.githubusercontent.com/759449/29899726-c525c026-8db2-11e7-813a-1101448de1fb.png)

Before
----------------------------------------
Without this change, all Smart Groups are excluded from the Contact Dashboard, as shown here:
![before](https://user-images.githubusercontent.com/759449/29899732-d30c8058-8db2-11e7-8d26-f9d41c43e05f.png)

After
----------------------------------------
After this change, Smart Groups which are publicly visible are shown for joining and leaving on the Contact Dashboard, just as on Profiles, as shown here:
![after](https://user-images.githubusercontent.com/759449/29899742-e92a197c-8db2-11e7-837d-044d8825afdb.png)

Technical Details
----------------------------------------
* Besides the Contact Dashboard, this PR touches code that builds the list of groups in other contexts, such as the "Groups" tab on a Contact record. Here's a screenshot of that tab, with this code change in place; note the proper display of all groups, both smart and non-smart, both public and non-public.
![groups_tab_after](https://user-images.githubusercontent.com/759449/29948005-1dcd8d5c-8e72-11e7-9234-13a3c9089a51.png)


Comments
----------------------------------------
Nothing of note.

---

 * [CRM-21122: Support selection of smart groups on Contact Dashboard](https://issues.civicrm.org/jira/browse/CRM-21122)