### PR TITLE
CRM-21121 - Fix crash with sql_mode is only_full_group_by

### DIFF
--- a/CRM/Report/Form/Event/Summary.php
+++ b/CRM/Report/Form/Event/Summary.php
@@ -202,7 +202,8 @@ class CRM_Report_Form_Event_Summary extends CRM_Report_Form_Event {
                   $this->_participantWhere
 
         GROUP BY civicrm_participant.event_id,
-                 civicrm_participant.status_id";
+                 civicrm_participant.status_id,
+                 civicrm_participant.fee_currency";
 
     $info = CRM_Core_DAO::executeQuery($sql);
     $participant_data = $participant_info = $currency = array();


### PR DESCRIPTION
Overview
----------------------------------------
The Event Income Summary report crashes if your sql_mode is only_full_group_by (which is default on MySQL 5.7.5+)

Before
----------------------------------------
Crash (see JIRA for backtrace)

After
----------------------------------------
No crash.

Technical Details
----------------------------------------
I was concerned about simply grouping by the currency - but then I saw that events don't support multiple currencies (though this report DOES support multiple currencies, just not on the same event).

If that were to change in the future, this SQL statement would need to change anyway, so I believe this is safe.

Comments
----------------------------------------
A tester should ideally have MySQL 5.7.5+ (Ubuntu 16.04+ has it).  Testing is relatively simple, because the SQL generated is pretty straightforward.

---

 * [CRM-21121: Event Income \(Summary\) report backtrace with 'only_full_group_by'](https://issues.civicrm.org/jira/browse/CRM-21121)