### PR TITLE
CRM-21130 - Search builder throws error if location type has space

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2793,8 +2793,8 @@ class CRM_Contact_BAO_Query {
             $parts = explode('-', $name);
             $locationTypes = CRM_Core_BAO_Address::buildOptions('location_type_id', 'get');
             foreach ($locationTypes as $locationTypeID => $locationType) {
-	      if ($parts[0] == str_replace(' ', '_', $locationType)) {
-		$locationID = $locationTypeID;
+              if ($parts[0] == str_replace(' ', '_', $locationType)) {
+                $locationID = $locationTypeID;
               }
             }
             $from .= " $side JOIN civicrm_{$locationTypeName} `{$name}` ON ( contact_a.id = `{$name}`.contact_id ) and `{$name}`.location_type_id = $locationID ";

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2791,7 +2791,12 @@ class CRM_Contact_BAO_Query {
           if ($locationTypeName) {
             //we have a join on an location table - possibly in conjunction with search builder - CRM-14263
             $parts = explode('-', $name);
-            $locationID = array_search($parts[0], CRM_Core_BAO_Address::buildOptions('location_type_id', 'get', array('name' => $parts[0])));
+            $locationTypes = CRM_Core_BAO_Address::buildOptions('location_type_id', 'get');
+            foreach ($locationTypes as $locationTypeID => $locationType) {
+	      if ($parts[0] == str_replace(' ', '_', $locationType)) {
+		$locationID = $locationTypeID;
+              }
+            }
             $from .= " $side JOIN civicrm_{$locationTypeName} `{$name}` ON ( contact_a.id = `{$name}`.contact_id ) and `{$name}`.location_type_id = $locationID ";
           }
           else {

--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -1248,6 +1248,7 @@ SELECT DISTINCT 'civicrm_contact', contact_a.id, contact_a.id, '$cacheKey', cont
         foreach ($value as $n => $v) {
           foreach ($v as $n1 => $v1) {
             if (!strpos('_id', $n1) && $n1 != 'location_type') {
+              $n = str_replace(' ', '_', $n);
               $properties[] = "{$n}-{$n1}";
             }
           }


### PR DESCRIPTION
Overview
----------------------------------------
Search builder throws error if location type has space

Before
----------------------------------------
![demo_search](https://user-images.githubusercontent.com/3455173/29931843-155bf988-8e90-11e7-83b1-9477f608ebfd.png)


After
----------------------------------------
![after_patch](https://user-images.githubusercontent.com/3455173/29931923-59485c22-8e90-11e7-9084-a6fa33f3c595.png)


Technical Details
----------------------------------------
Database Error Code: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'JOIN civicrm_location_type `Mentor_Directory-location_type` ON ( ( `Mentor_Dire' at line 2, 1064
Additional Details: 
Array ( [callback] => Array ( [0] => CRM_Core_Error [1] => handle ) [code] => -2 [message] => DB Error: syntax error [mode] => 16 [debug_info] => SELECT DISTINCT UPPER(LEFT(contact_a.sort_name, 1)) as sort_name FROM civicrm_contact contact_a LEFT JOIN civicrm_email `Mentor_Directory-email` ON ( contact_a.id = `Mentor_Directory-email`.contact_id ) and `Mentor_Directory-email`.location_type_id = LEFT JOIN civicrm_location_type `Mentor_Directory-location_type` ON ( ( `Mentor_Directory-email`.location_type_id = `Mentor_Directory-location_type`.id ) ) WHERE ( ( LOWER(`Mentor_Directory-email`.email) IS NULL ) ) AND (contact_a.is_deleted = 0) GROUP BY contact_a.id ORDER BY UPPER(LEFT(contact_a.sort_name, 1)) asc [nativecode=1064 ** You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'JOIN civicrm_location_type `Mentor_Directory-location_type` ON ( ( `Mentor_Dire' at line 2] [type] => DB_Error [user_info] => SELECT DISTINCT UPPER(LEFT(contact_a.sort_name, 1)) as sort_name FROM civicrm_contact contact_a LEFT JOIN civicrm_email `Mentor_Directory-email` ON ( contact_a.id = `Mentor_Directory-email`.contact_id ) and `Mentor_Directory-email`.location_type_id = LEFT JOIN civicrm_location_type `Mentor_Directory-location_type` ON ( ( `Mentor_Directory-email`.location_type_id = `Mentor_Directory-location_type`.id ) ) WHERE ( ( LOWER(`Mentor_Directory-email`.email) IS NULL ) ) AND (contact_a.is_deleted = 0) GROUP BY contact_a.id ORDER BY UPPER(LEFT(contact_a.sort_name, 1)) asc [nativecode=1064 ** You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'JOIN civicrm_location_type `Mentor_Directory-location_type` ON ( ( `Mentor_Dire' at line 2] [to_string] => [db_error: message="DB Error: syntax error" code=-2 mode=callback callback=CRM_Core_Error::handle prefix="" info="SELECT DISTINCT UPPER(LEFT(contact_a.sort_name, 1)) as sort_name FROM civicrm_contact contact_a LEFT JOIN civicrm_email `Mentor_Directory-email` ON ( contact_a.id = `Mentor_Directory-email`.contact_id ) and `Mentor_Directory-email`.location_type_id = LEFT JOIN civicrm_location_type `Mentor_Directory-location_type` ON ( ( `Mentor_Directory-email`.location_type_id = `Mentor_Directory-location_type`.id ) ) WHERE ( ( LOWER(`Mentor_Directory-email`.email) IS NULL ) ) AND (contact_a.is_deleted = 0) GROUP BY contact_a.id ORDER BY UPPER(LEFT(contact_a.sort_name, 1)) asc [nativecode=1064 ** You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'JOIN civicrm_location_type `Mentor_Directory-location_type` ON ( ( `Mentor_Dire' at line 2]"]

---

 * [CRM-21130: Search builder throws error if location type has space](https://issues.civicrm.org/jira/browse/CRM-21130)