### PR TITLE
CRM-20237 Don't add in extra copy of ids and only use most recent id …

### DIFF
--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -1240,12 +1240,13 @@ WHERE  id = %1";
    */
   public static function copy($id) {
     $maxId = CRM_Core_DAO::singleValueQuery("SELECT max(id) FROM civicrm_price_set");
-
+    $oldTitle = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $id, 'title', 'id');
+    $newTitle = preg_replace('/\[Copy id \d+\]$/', "", $oldTitle);
     $title = ts('[Copy id %1]', array(1 => $maxId + 1));
     $fieldsFix = array(
-      'suffix' => array(
-        'title' => ' ' . $title,
-        'name' => '__Copy_id_' . ($maxId + 1) . '_',
+      'replace' => array(
+        'title' => trim($newTitle) . ' ' . $title,
+        'name' => 'Price_Set__id_' . ($maxId + 1) . '_',
       ),
     );
 

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -1240,24 +1240,25 @@ WHERE  id = %1";
    */
   public static function copy($id) {
     $maxId = CRM_Core_DAO::singleValueQuery("SELECT max(id) FROM civicrm_price_set");
-    $oldTitle = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $id, 'title', 'id');
-    $newTitle = preg_replace('/\[Copy id \d+\]$/', "", $oldTitle);
+    $priceSet = civicrm_api3('PriceSet', 'getsingle', array('id' => $id));
+
+    $newTitle = preg_replace('/\[Copy id \d+\]$/', "", $priceSet['title']);
     $title = ts('[Copy id %1]', array(1 => $maxId + 1));
     $fieldsFix = array(
       'replace' => array(
         'title' => trim($newTitle) . ' ' . $title,
-        'name' => 'Price_Set__id_' . ($maxId + 1) . '_',
+        'name' => substr($priceSet['name'], 0, 20) . 'price_set_' . ($maxId + 1),
       ),
     );
 
-    $copy = &CRM_Core_DAO::copyGeneric('CRM_Price_DAO_PriceSet',
+    $copy = CRM_Core_DAO::copyGeneric('CRM_Price_DAO_PriceSet',
       array('id' => $id),
       NULL,
       $fieldsFix
     );
 
     //copying all the blocks pertaining to the price set
-    $copyPriceField = &CRM_Core_DAO::copyGeneric('CRM_Price_DAO_PriceField',
+    $copyPriceField = CRM_Core_DAO::copyGeneric('CRM_Price_DAO_PriceField',
       array('price_set_id' => $id),
       array('price_set_id' => $copy->id)
     );

--- a/tests/phpunit/CRM/Price/BAO/PriceSetTest.php
+++ b/tests/phpunit/CRM/Price/BAO/PriceSetTest.php
@@ -70,10 +70,10 @@ class CRM_Price_BAO_PriceSetTest extends CiviUnitTestCase {
     $priceSetID = $this->eventPriceSetCreate(9);
     $oldPriceSetInfo = $this->callAPISuccess('PriceSet', 'getsingle', array('id' => $priceSetID));
     $newPriceSet = CRM_Price_BAO_PriceSet::copy($priceSetID);
-    $this->assertEquals('Price_Set__id_' . $newPriceSet->id . '_', $newPriceSet->name);
+    $this->assertEquals(substr($oldPriceSetInfo['name'], 0, 20) . 'price_set_' . $newPriceSet->id, $newPriceSet->name);
     $this->assertEquals($oldPriceSetInfo['title'] . ' [Copy id ' . $newPriceSet->id . ']', $newPriceSet->title);
     $new2PriceSet = CRM_Price_BAO_PriceSet::copy($newPriceSet->id);
-    $this->assertEquals('Price_Set__id_' . $new2PriceSet->id . '_', $new2PriceSet->name);
+    $this->assertEquals(substr($newPriceSet->name, 0, 20) . 'price_set_' . $new2PriceSet->id, $new2PriceSet->name);
     $this->assertEquals($oldPriceSetInfo['title'] . ' [Copy id ' . $new2PriceSet->id . ']', $new2PriceSet->title);
     $oldPriceField = $this->callAPISuccess('priceField', 'getsingle', array('price_set_id' => $priceSetID));
     $oldPriceFieldValue = $this->callAPISuccess('priceFieldValue', 'getsingle', array('price_field_id' => $oldPriceField['id']));

--- a/tests/phpunit/CRM/Price/BAO/PriceSetTest.php
+++ b/tests/phpunit/CRM/Price/BAO/PriceSetTest.php
@@ -57,6 +57,39 @@ class CRM_Price_BAO_PriceSetTest extends CiviUnitTestCase {
     $params = array('priceSetId' => $priceSetID, 'price_' . $field['id'] => 1);
     $amountLevel = CRM_Price_BAO_PriceSet::getAmountLevelText($params);
     $this->assertEquals(CRM_Core_DAO::VALUE_SEPARATOR . 'Price Field - 1' . CRM_Core_DAO::VALUE_SEPARATOR, $amountLevel);
+    $priceFieldValue = $this->callAPISuccess('pricefieldvalue', 'getsingle', array('price_field_id' => $field['id']));
+    $this->callAPISuccess('PriceFieldValue', 'delete', array('id' => $priceFieldValue['id']));
+    $this->callAPISuccess('PriceField', 'delete', array('id' => $field['id']));
+    $this->callAPISuccess('PriceSet', 'delete', array('id' => $priceSetID));
+  }
+
+  /**
+   * CRM-20237 Test that Copied price set does not generate long name and unneded information
+   */
+  public function testCopyPriceSet() {
+    $priceSetID = $this->eventPriceSetCreate(9);
+    $oldPriceSetInfo = $this->callAPISuccess('PriceSet', 'getsingle', array('id' => $priceSetID));
+    $newPriceSet = CRM_Price_BAO_PriceSet::copy($priceSetID);
+    $this->assertEquals('Price_Set__id_' . $newPriceSet->id . '_', $newPriceSet->name);
+    $this->assertEquals($oldPriceSetInfo['title'] . ' [Copy id ' . $newPriceSet->id . ']', $newPriceSet->title);
+    $new2PriceSet = CRM_Price_BAO_PriceSet::copy($newPriceSet->id);
+    $this->assertEquals('Price_Set__id_' . $new2PriceSet->id . '_', $new2PriceSet->name);
+    $this->assertEquals($oldPriceSetInfo['title'] . ' [Copy id ' . $new2PriceSet->id . ']', $new2PriceSet->title);
+    $oldPriceField = $this->callAPISuccess('priceField', 'getsingle', array('price_set_id' => $priceSetID));
+    $oldPriceFieldValue = $this->callAPISuccess('priceFieldValue', 'getsingle', array('price_field_id' => $oldPriceField['id']));
+    $this->callAPISuccess('PriceFieldValue', 'delete', array('id' => $oldPriceFieldValue['id']));
+    $this->callAPISuccess('PriceField', 'delete', array('id' => $oldPriceField['id']));
+    $this->callAPISuccess('PriceSet', 'delete', array('id' => $priceSetID));
+    $newPriceField = $this->callAPISuccess('PriceField', 'getsingle', array('price_set_id' => $newPriceSet->id));
+    $newPriceFieldValue = $this->callAPISuccess('PriceFieldValue', 'getsingle', array('price_field_id' => $newPriceField['id']));
+    $this->callAPISuccess('PriceFieldValue', 'delete', array('id' => $newPriceFieldValue['id']));
+    $this->callAPISuccess('PriceField', 'delete', array('id' => $newPriceField['id']));
+    $this->callAPISuccess('PriceSet', 'delete', array('id' => $newPriceSet->id));
+    $new2PriceField = $this->callAPISuccess('PriceField', 'getsingle', array('price_set_id' => $new2PriceSet->id));
+    $new2PriceFieldValue = $this->callAPISuccess('PriceFieldValue', 'getsingle', array('price_field_id' => $new2PriceField['id']));
+    $this->callAPISuccess('PriceFieldValue', 'delete', array('id' => $new2PriceFieldValue['id']));
+    $this->callAPISuccess('PriceField', 'delete', array('id' => $new2PriceField['id']));
+    $this->callAPISuccess('PriceSet', 'delete', array('id' => $new2PriceSet->id));
   }
 
   /**


### PR DESCRIPTION
…copied from in title and don't put copy of details in name for pricesets

Overview
----------------------------------------
Previously when copying a price set it would just continuouly add in copy_id_x etc onto the end of the name and title. Now it only adds the most recent price set id on the title the name is just the new id with Price_set

@eileenmcnaughton does this make sense to you?

- [CRM-20237 Event pricesets copied with long suffix cause DB error](https://issues.civicrm.org/jira/browse/CRM-20237)