### PR TITLE
CRM-21135 - Activity filter preference are not remembered when enable…

### DIFF
--- a/CRM/Activity/Page/AJAX.php
+++ b/CRM/Activity/Page/AJAX.php
@@ -437,7 +437,14 @@ class CRM_Activity_Page_AJAX {
       unset($optionalParameters['context']);
       foreach ($optionalParameters as $searchField => $dataType) {
         if (!empty($params[$searchField])) {
-          $activityFilter[$searchField] = CRM_Utils_Type::escape($params[$searchField], $dataType);
+          $formSearchField = $searchField;
+          if ($searchField == 'activity_type_id') {
+            $formSearchField = 'activity_type_filter_id';
+          }
+          elseif ($searchField == 'activity_type_exclude_id') {
+            $formSearchField = 'activity_type_exclude_filter_id';
+          }
+          $activityFilter[$formSearchField] = CRM_Utils_Type::escape($params[$searchField], $dataType);
           if (in_array($searchField, array('activity_date_low', 'activity_date_high'))) {
             $activityFilter['activity_date_relative'] = 0;
           }

--- a/CRM/Activity/Page/AJAX.php
+++ b/CRM/Activity/Page/AJAX.php
@@ -420,10 +420,6 @@ class CRM_Activity_Page_AJAX {
     // get the contact activities
     $activities = CRM_Activity_BAO_Activity::getContactActivitySelector($params);
 
-    if (!empty($_GET['is_unit_test'])) {
-      return $activities;
-    }
-
     foreach ($activities['data'] as $key => $value) {
       // Check if recurring activity.
       if (!empty($value['is_recurring_activity'])) {
@@ -436,14 +432,14 @@ class CRM_Activity_Page_AJAX {
     if (Civi::settings()->get('preserve_activity_tab_filter') && ($userID = CRM_Core_Session::getLoggedInContactID())) {
       unset($optionalParameters['context']);
       foreach ($optionalParameters as $searchField => $dataType) {
+        $formSearchField = $searchField;
+        if ($searchField == 'activity_type_id') {
+          $formSearchField = 'activity_type_filter_id';
+        }
+        elseif ($searchField == 'activity_type_exclude_id') {
+          $formSearchField = 'activity_type_exclude_filter_id';
+        }
         if (!empty($params[$searchField])) {
-          $formSearchField = $searchField;
-          if ($searchField == 'activity_type_id') {
-            $formSearchField = 'activity_type_filter_id';
-          }
-          elseif ($searchField == 'activity_type_exclude_id') {
-            $formSearchField = 'activity_type_exclude_filter_id';
-          }
           $activityFilter[$formSearchField] = CRM_Utils_Type::escape($params[$searchField], $dataType);
           if (in_array($searchField, array('activity_date_low', 'activity_date_high'))) {
             $activityFilter['activity_date_relative'] = 0;
@@ -453,7 +449,7 @@ class CRM_Activity_Page_AJAX {
           }
         }
         elseif (in_array($searchField, array('activity_type_id', 'activity_type_exclude_id'))) {
-          $activityFilter[$searchField] = '';
+          $activityFilter[$formSearchField] = '';
         }
       }
 
@@ -462,6 +458,9 @@ class CRM_Activity_Page_AJAX {
        */
       $cSettings = Civi::service('settings_manager')->getBagByContact(CRM_Core_Config::domainID(), $userID);
       $cSettings->set('activity_tab_filter', $activityFilter);
+    }
+    if (!empty($_GET['is_unit_test'])) {
+      return array($activities, $activityFilter);
     }
 
     CRM_Utils_JSON::output($activities);


### PR DESCRIPTION
…d in display preference

Overview
----------------------------------------
Fix Activity filter to be remembered if enabled in settings. 

Before
----------------------------------------
Reload of a page removes the filter setting saved in the database.

After
----------------------------------------
works fine.

Technical Details
----------------------------------------
This seem to be due to the difference in form fields which is `activity_type_filter_id` and `activity_type_exclude_filter_id` and the setting saved in db does not include `filter` text in it - `activity_type_id` and `activity_type_exclude_id` respectively.

Either this need to handled by:
- changing the form id of this field to be the same as of db setting key OR
- replace db id with the form id as done in this PR(used to be the same in previous versions).

Comments
----------------------------------------
Tagging as wip until the unit test is covered for this use-case.

---

 * [CRM-21135: Activity filter preference are not remembered when enabled in display preference](https://issues.civicrm.org/jira/browse/CRM-21135)