### PR TITLE
CRM-21363 Test using ONLY_FULL_GROUP_BY sqlmode as well

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -4716,7 +4716,7 @@ civicrm_relationship.is_permission_a_b = 0
     $sqlMode = CRM_Core_DAO::singleValueQuery('SELECT @@sql_mode');
 
     //return if ONLY_FULL_GROUP_BY is not enabled.
-    if (CRM_Core_DAO::supportsFullGroupBy() && !empty($sqlMode) && in_array('ONLY_FULL_GROUP_BY', explode(',', $sqlMode))) {
+    if (CRM_Utils_SQL::supportsFullGroupBy() && !empty($sqlMode) && in_array('ONLY_FULL_GROUP_BY', explode(',', $sqlMode))) {
       $regexToExclude = '/(ROUND|AVG|COUNT|GROUP_CONCAT|SUM|MAX|MIN)\(/i';
       foreach ($selectClauses as $key => $val) {
         $aliasArray = preg_split('/ as /i', $val);

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -4716,7 +4716,7 @@ civicrm_relationship.is_permission_a_b = 0
     $sqlMode = CRM_Core_DAO::singleValueQuery('SELECT @@sql_mode');
 
     //return if ONLY_FULL_GROUP_BY is not enabled.
-    if (!version_compare($mysqlVersion, '5.7', '<') && !empty($sqlMode) && in_array('ONLY_FULL_GROUP_BY', explode(',', $sqlMode))) {
+    if (CRM_Core_DAO::supportsFullGroupBy() && !empty($sqlMode) && in_array('ONLY_FULL_GROUP_BY', explode(',', $sqlMode))) {
       $regexToExclude = '/(ROUND|AVG|COUNT|GROUP_CONCAT|SUM|MAX|MIN)\(/i';
       foreach ($selectClauses as $key => $val) {
         $aliasArray = preg_split('/ as /i', $val);

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -118,10 +118,9 @@ class CRM_Core_DAO extends DB_DataObject {
     }
     $factory = new CRM_Contact_DAO_Factory();
     CRM_Core_DAO::setFactory($factory);
-    $currentSqlMode = CRM_Core_DAO::singleValueQuery("SELECT @@GLOBAL.sql_mode");
-    $currentModes = explode(',', $currentSqlMode);
+    $currentModes = CRM_Utils_SQL::getSqlModes();
     if (CRM_Utils_Constant::value('CIVICRM_MYSQL_STRICT', CRM_Utils_System::isDevelopment())) {
-      if (self::supportsFullGroupBy() && !in_array('ONLY_FULL_GROUP_BY', $currentModes)) {
+      if (CRM_Utils_SQL::supportsFullGroupBy() && !in_array('ONLY_FULL_GROUP_BY', $currentModes)) {
         $currentModes[] = 'ONLY_FULL_GROUP_BY';
       }
       if (!in_array('STRICT_TRANS_TABLES', $currentModes)) {
@@ -408,14 +407,6 @@ class CRM_Core_DAO extends DB_DataObject {
       echo "Inconsistent system initialization sequence. Premature access of (" . get_class($this) . ")";
       CRM_Utils_System::civiExit();
     }
-  }
-
-  /**
-   * Does this System support the MYSQL mode ONLY_FULL_GROUP_BY
-   * @return mixed
-   */
-  public static function supportsFullGroupBy() {
-    return version_compare(CRM_Core_DAO::singleValueQuery('SELECT VERSION()'), '5.7', '>=');
   }
 
   /**

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -119,7 +119,12 @@ class CRM_Core_DAO extends DB_DataObject {
     $factory = new CRM_Contact_DAO_Factory();
     CRM_Core_DAO::setFactory($factory);
     if (CRM_Utils_Constant::value('CIVICRM_MYSQL_STRICT', CRM_Utils_System::isDevelopment())) {
-      CRM_Core_DAO::executeQuery('SET SESSION sql_mode = STRICT_TRANS_TABLES');
+      if (self::supportsFullGroupBy()) {
+        CRM_Core_DAO::executeQuery("SET SESSION sql_mode = 'ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES'");
+      }
+      else {
+        CRM_Core_DAO::executeQuery("SET SESSION sql_mode = 'STRICT_TRANS_TABLES'");
+      }
     }
     CRM_Core_DAO::executeQuery('SET NAMES utf8');
     CRM_Core_DAO::executeQuery('SET @uniqueID = %1', array(1 => array(CRM_Utils_Request::id(), 'String')));
@@ -400,6 +405,14 @@ class CRM_Core_DAO extends DB_DataObject {
       echo "Inconsistent system initialization sequence. Premature access of (" . get_class($this) . ")";
       CRM_Utils_System::civiExit();
     }
+  }
+
+  /**
+   * Does this System support the MYSQL mode ONLY_FULL_GROUP_BY
+   * @return mixed
+   */
+  public static function supportsFullGroupBy() {
+    return version_compare(CRM_Core_DAO::singleValueQuery('SELECT VERSION()'), '5.7.0', '>=');
   }
 
   /**

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -121,10 +121,13 @@ class CRM_Core_DAO extends DB_DataObject {
     $currentSqlMode = CRM_Core_DAO::singleValueQuery("SELECT @@GLOBAL.sql_mode");
     $currentModes = explode(',', $currentSqlMode);
     if (CRM_Utils_Constant::value('CIVICRM_MYSQL_STRICT', CRM_Utils_System::isDevelopment())) {
-      if (!in_array('STRICT_TRANS_TABLES', $currentModes)) {
-        $modes = array_merge(array('STRICT_TRANS_TABLES'), $currentModes);
-        CRM_Core_DAO::executeQuery("SET SESSION sql_mode = %1", array(1 => array(implode(',', $modes), 'String')));
+      if (self::supportsFullGroupBy() && !in_array('ONLY_FULL_GROUP_BY', $currentModes)) {
+        $currentModes[] = 'ONLY_FULL_GROUP_BY';
       }
+      if (!in_array('STRICT_TRANS_TABLES', $currentModes)) {
+        $currentModes = array_merge(array('STRICT_TRANS_TABLES'), $currentModes);
+      }
+      CRM_Core_DAO::executeQuery("SET SESSION sql_mode = %1", array(1 => array(implode(',', $currentModes), 'String')));
     }
     CRM_Core_DAO::executeQuery('SET NAMES utf8');
     CRM_Core_DAO::executeQuery('SET @uniqueID = %1', array(1 => array(CRM_Utils_Request::id(), 'String')));

--- a/CRM/Utils/SQL.php
+++ b/CRM/Utils/SQL.php
@@ -59,4 +59,21 @@ class CRM_Utils_SQL {
     return $clauses;
   }
 
+  /**
+   * Get current sqlModes of the session
+   * @return array
+   */
+  public static function getSqlModes() {
+    $sqlModes = explode(',', CRM_Core_DAO::singleValueQuery('SELECT @@sql_mode'));
+    return $sqlModes;
+  }
+
+  /**
+   * Does this System support the MYSQL mode ONLY_FULL_GROUP_BY
+   * @return mixed
+   */
+  public static function supportsFullGroupBy() {
+    return version_compare(CRM_Core_DAO::singleValueQuery('SELECT VERSION()'), '5.7', '>=');
+  }
+
 }

--- a/tests/phpunit/CRM/Core/DAOTest.php
+++ b/tests/phpunit/CRM/Core/DAOTest.php
@@ -380,4 +380,17 @@ class CRM_Core_DAOTest extends CiviUnitTestCase {
     $this->checkArrayEquals($contactsFetchedFromBufferedQuery, $contactsFetchedFromUnbufferedQuery);
   }
 
+  /**
+   * Test that known sql modes are present in session.
+   */
+  public function testSqlModePresent() {
+    $currentSqlModes = CRM_Core_DAO::singleValueQuery("SELECT @@sql_mode");
+    $sqlModes = explode(',', $currentSqlModes);
+    // assert we have strict trans
+    $this->assertContains('STRICT_TRANS_TABLES', $sqlModes);
+    if (CRM_Core_DAO::supportsFullGroupBy()) {
+      $this->assertContains('ONLY_FULL_GROUP_BY', $sqlModes);
+    }
+  }
+
 }

--- a/tests/phpunit/CRM/Core/DAOTest.php
+++ b/tests/phpunit/CRM/Core/DAOTest.php
@@ -384,11 +384,10 @@ class CRM_Core_DAOTest extends CiviUnitTestCase {
    * Test that known sql modes are present in session.
    */
   public function testSqlModePresent() {
-    $currentSqlModes = CRM_Core_DAO::singleValueQuery("SELECT @@sql_mode");
-    $sqlModes = explode(',', $currentSqlModes);
+    $sqlModes = CRM_Utils_SQL::getSqlModes();
     // assert we have strict trans
     $this->assertContains('STRICT_TRANS_TABLES', $sqlModes);
-    if (CRM_Core_DAO::supportsFullGroupBy()) {
+    if ($this->_supportFullGroupBy) {
       $this->assertContains('ONLY_FULL_GROUP_BY', $sqlModes);
     }
   }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -65,6 +65,11 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
   private static $dbInit = FALSE;
 
   /**
+   * Does the current setup support ONLY_FULL_GROUP_BY mode
+   */
+  protected $_supportFullGroupBy;
+
+  /**
    *  Database connection.
    *
    * @var PHPUnit_Extensions_Database_DB_IDatabaseConnection
@@ -290,6 +295,8 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
 
     //  Get and save a connection to the database
     $this->_dbconn = $this->getConnection();
+
+    $this->_supportFullGroupBy = CRM_Utils_SQL::supportsFullGroupBy();
 
     // reload database before each test
     //        $this->_populateDB();


### PR DESCRIPTION
Overview
----------------------------------------
Ensure that testing occurs using `ONLY_FULL_GROUP_BY` sqlmode if able to ping @totten

---

 * [CRM-21363: Ensure that tests run using ONLY_FULL_GROUP_BY sql_mode for mysql 5.7](https://issues.civicrm.org/jira/browse/CRM-21363)