### PR TITLE
CRM-21134 fix enotices in payment processor code assignment.

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -533,8 +533,17 @@ abstract class CRM_Core_Payment {
 
   /**
    * Get array of fields that should be displayed on the payment form.
-   * @todo make payment type an option value & use it in the function name - currently on debit & credit card work
+   *
+   * Common results are
+   *   array('credit_card_type', 'credit_card_number', 'cvv2', 'credit_card_exp_date')
+   *   or
+   *   array('account_holder', 'bank_account_number', 'bank_identification_number', 'bank_name')
+   *   or
+   *   array()
+   *
    * @return array
+   *   Array of payment fields appropriate to the payment processor.
+   *
    * @throws CiviCRM_API3_Exception
    */
   public function getPaymentFormFields() {

--- a/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
@@ -223,14 +223,12 @@
 {crmRegion name="contribution-confirm-billing-block"}
        {if ($credit_card_number or $bank_account_number)}
         <div class="crm-group credit_card-group">
-            <div class="header-dark">
-            {if $paymentProcessor.payment_type & 2}
-                 {ts}Direct Debit Information{/ts}
-            {else}
-                {ts}Credit Card Information{/ts}
+            {if $paymentFieldsetLabel}
+              <div class="header-dark">
+                {$paymentFieldsetLabel}
+              </div>
             {/if}
-            </div>
-            {if $paymentProcessor.payment_type & 2}
+            {if $paymentProcessor.payment_type == 2}
                 <div class="display-block">
                     {ts}Account Holder{/ts}: {$account_holder}<br />
                     {ts}Bank Account Number{/ts}: {$bank_account_number}<br />
@@ -251,7 +249,7 @@
                 <div class="crm-section no-label credit_card_details-section">
                   <div class="content">{$credit_card_type}</div>
                   <div class="content">{$credit_card_number}</div>
-                  <div class="content">{ts}Expires{/ts}: {$credit_card_exp_date|truncate:7:''|crmDate}</div>
+                  <div class="content">{if $credit_card_exp_date}{ts}Expires{/ts}: {$credit_card_exp_date|truncate:7:''|crmDate}{/if}</div>
                   <div class="clear"></div>
                 </div>
             {/if}

--- a/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
@@ -274,14 +274,12 @@
   {if $contributeMode eq 'direct' and ! $is_pay_later and $is_monetary and ( $amount GT 0 OR $minimum_fee GT 0 )}
     {crmRegion name="contribution-thankyou-billing-block"}
       <div class="crm-group credit_card-group">
-        <div class="header-dark">
-          {if $paymentProcessor.payment_type & 2}
-            {ts}Direct Debit Information{/ts}
-          {else}
-            {ts}Credit Card Information{/ts}
-          {/if}
-        </div>
-        {if $paymentProcessor.payment_type & 2}
+        {if $paymentFieldsetLabel}
+          <div class="header-dark">
+            {$paymentFieldsetLabel}
+          </div>
+        {/if}
+        {if $paymentProcessor.payment_type == 2}
           <div class="display-block">
             {ts}Account Holder{/ts}: {$account_holder}<br />
             {ts}Bank Identification Number{/ts}: {$bank_identification_number}<br />
@@ -292,7 +290,7 @@
           <div class="crm-section no-label credit_card_details-section">
             <div class="content">{$credit_card_type}</div>
             <div class="content">{$credit_card_number}</div>
-            <div class="content">{ts}Expires{/ts}: {$credit_card_exp_date|truncate:7:''|crmDate}</div>
+            <div class="content">{if $credit_card_exp_date}{ts}Expires{/ts}: {$credit_card_exp_date|truncate:7:''|crmDate}{/if}</div>
             <div class="clear"></div>
           </div>
         {/if}


### PR DESCRIPTION
Overview
----------------------------------------
This is a code tidy up that prevents enotices in obscure circumstances

Before
----------------------------------------
Direct debit (or credit card fields) show appropriately on the Confirm page

After
----------------------------------------
No visible change.

Technical Details
----------------------------------------
This is generally a code tidy up to push out the principles we have been implementing (ie.
the idea that the processors define their fields. The code can cause e-notices in extensions as is
because it is prescriptive about fields.

I removed the ANDing in the tpl because actually we are not looking to match numbers like 2
2 is the number we have hard-coded for direct debits (we should be using an option group but that
is another story

Comments
----------------------------------------
The enotices occur when the payment processor does not neatly fit into credit card or debit card assumptions. For purposes of review I don't believe these need to be replicated.

---

 * [CRM-21134: e-notice errors when using a processor extension](https://issues.civicrm.org/jira/browse/CRM-21134)