### PR TITLE
CRM-18231 Remove need for define statement and replace with new setti…

### DIFF
--- a/CRM/Admin/Form/Setting/Debugging.php
+++ b/CRM/Admin/Form/Setting/Debugging.php
@@ -54,8 +54,7 @@ class CRM_Admin_Form_Setting_Debugging extends CRM_Admin_Form_Setting {
     }
 
     parent::buildQuickForm();
-
-    if (defined('CIVICRM_ENVIRONMENT')) {
+    if (Civi::settings()->getMandatory('environment') !== NULL) {
       $element = $this->getElement('environment');
       $element->freeze();
       CRM_Core_Session::setStatus(ts('The environment settings have been disabled because it has been overridden in the settings file.'), ts('Environment settings'), 'info');

--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -274,14 +274,7 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
       $environment = $env;
     }
     if ($reset || empty($environment)) {
-      if (defined('CIVICRM_ENVIRONMENT')) {
-        $environment = CIVICRM_ENVIRONMENT;
-        global $civicrm_setting;
-        $civicrm_setting[CRM_Core_BAO_Setting::DEVELOPER_PREFERENCES_NAME]['environment'] = $environment;
-      }
-      else {
-        $environment = Civi::settings()->get('environment');
-      }
+      $environment = Civi::settings()->get('environment');
     }
     if (!$environment) {
       $environment = 'Production';

--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -313,11 +313,10 @@ if (!defined('CIVICRM_DOMAIN_ID')) {
  * Note the setting here must be value from the option group 'Environment', 
  * (see Administration > System Settings > Option Groups, Options beside Environment) 
  * which by default has three option values: 'Production', 'Staging', 'Development'. 
- * NB: defining a value from CIVICRM_ENVIRONMENT here prevents it from being set 
+ * NB: defining a value for environment here prevents it from being set
  * via the browser. 
  */ 
-
-// define( 'CIVICRM_ENVIRONMENT', 'Production' ); 
+// $civicrm_setting[CRM_Core_BAO_Setting::DEVELOPER_PREFERENCES_NAME]['environment'] = 'Production'; 
 
 /**
  * Settings to enable external caching using a cache server.  This is an

--- a/tests/phpunit/CRM/Core/BAO/SettingTest.php
+++ b/tests/phpunit/CRM/Core/BAO/SettingTest.php
@@ -188,8 +188,9 @@ class CRM_Core_BAO_SettingTest extends CiviUnitTestCase {
     CRM_Core_BAO_Setting::setItem('Staging', CRM_Core_BAO_Setting::DEVELOPER_PREFERENCES_NAME, 'environment');
     $values = CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::DEVELOPER_PREFERENCES_NAME, 'environment');
     $this->assertEquals('Staging', $values);
-
-    define('CIVICRM_ENVIRONMENT', 'Development');
+    global $civicrm_setting;
+    $civicrm_setting[CRM_Core_BAO_Setting::DEVELOPER_PREFERENCES_NAME]['environment'] = 'Development';
+    Civi::service('settings_manager')->useMandatory();
     $environment = CRM_Core_Config::environment();
     $this->assertEquals('Development', $environment);
   }


### PR DESCRIPTION
…ng not settable in UI and always use settings to get information

Overview
----------------------------------------
This replaces a defined constant with a new setting and uses the normal settings set override proceedure  in the civicrm.settings.php file for the environment setting

Technical Details
----------------------------------------
This adds a new setting environmentManual to prevent setting of the environment variable in the UI

Comments
----------------------------------------
ping @monishdeb @totten @eileenmcnaughton i think this will resolve the concerns raised whilst still keeping the general idea of not allowing environment setting to be changed if its set in the civicrm.settings.php file 