### PR TITLE
CRM-21142 - CiviCRM installer - Check for XML module before install

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -705,6 +705,13 @@ class InstallRequirements {
       ts("MySQL support not included in PHP."),
     ));
 
+    // Check for XML support
+    $this->requireFunction('simplexml_load_file', array(
+      ts("PHP Configuration"),
+      ts("XML support"),
+      ts("XML support not included in PHP."),
+    ));
+
     // Check for JSON support
     $this->requireFunction('json_encode', array(
       ts("PHP Configuration"),

--- a/install/index.php
+++ b/install/index.php
@@ -708,8 +708,8 @@ class InstallRequirements {
     // Check for XML support
     $this->requireFunction('simplexml_load_file', array(
       ts("PHP Configuration"),
-      ts("XML support"),
-      ts("XML support not included in PHP."),
+      ts("SimpleXML support"),
+      ts("SimpleXML support not included in PHP."),
     ));
 
     // Check for JSON support


### PR DESCRIPTION
Overview
----------------------------------------
CiviCRM requires the PHP XML module. We should check for it as part of install requirements.

Before
----------------------------------------
CiviCRM installer will puke and leave an installation canary.  See: https://civicrm.stackexchange.com/questions/20239/wordpress-civi-install-keeps-puking-with-canary-and-simplexml-load-file-erro


After
----------------------------------------
Installation is blocked by the lack of XML module.

Comments
----------------------------------------
I tested this on Ubuntu with a buildkit instance by renaming `civicrm.settings.php`, uninstalling the XML module (`sudo apt remove php7.0-xml`), restarting Apache, and running the installer.  I reversed the changes when done.

---

 * [CRM-21142: Installation fails if PHP XML module isn't installed](https://issues.civicrm.org/jira/browse/CRM-21142)