### PR TITLE
CRM-21148 - Refactor two near-identical functions into one

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -2041,21 +2041,8 @@ class CRM_Report_Form extends CRM_Core_Form {
    *
    * @return array
    */
-  public function getFromTo($relative, $from, $to, $fromTime = NULL, $toTime = NULL) {
-    if (empty($toTime)) {
-      $toTime = '235959';
-    }
-    //FIX ME not working for relative
-    if ($relative) {
-      list($term, $unit) = CRM_Utils_System::explode('.', $relative, 2);
-      $dateRange = CRM_Utils_Date::relativeToAbsolute($term, $unit);
-      $from = substr($dateRange['from'], 0, 8);
-      //Take only Date Part, Sometime Time part is also present in 'to'
-      $to = substr($dateRange['to'], 0, 8);
-    }
-    $from = CRM_Utils_Date::processDate($from, $fromTime);
-    $to = CRM_Utils_Date::processDate($to, $toTime);
-    return array($from, $to);
+  public function getFromTo($relative, $from, $to, $fromTime = NULL, int $toTime = 235959) {
+    return CRM_Utils_Date::getFromTo($relative, $from, $to, $fromTime, $toTime);
   }
 
   /**

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -1996,14 +1996,14 @@ class CRM_Report_Form extends CRM_Core_Form {
    * @param string $from
    * @param string $to
    * @param string $type
-   * @param string $fromTime
-   * @param string $toTime
+   * @param int $fromTime
+   * @param int $toTime
    *
    * @return null|string
    */
   public function dateClause(
     $fieldName,
-    $relative, $from, $to, $type = NULL, $fromTime = NULL, $toTime = NULL
+    $relative, $from, $to, $type = NULL, $fromTime = NULL, $toTime = 235959
   ) {
     $clauses = array();
     if (in_array($relative, array_keys($this->getOperationPair(CRM_Report_Form::OP_DATE)))) {
@@ -2459,7 +2459,7 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
               $from = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
               $to = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
               $fromTime = CRM_Utils_Array::value("{$fieldName}_from_time", $this->_params);
-              $toTime = CRM_Utils_Array::value("{$fieldName}_to_time", $this->_params);
+              $toTime = CRM_Utils_Array::value("{$fieldName}_to_time", $this->_params, 235959);
               $clause = $this->dateClause($field['dbAlias'], $relative, $from, $to, $field['type'], $fromTime, $toTime);
             }
           }
@@ -2963,7 +2963,7 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
                 CRM_Utils_Array::value("{$fieldName}_from", $this->_params),
                 CRM_Utils_Array::value("{$fieldName}_to", $this->_params),
                 CRM_Utils_Array::value("{$fieldName}_from_time", $this->_params),
-                CRM_Utils_Array::value("{$fieldName}_to_time", $this->_params)
+                CRM_Utils_Array::value("{$fieldName}_to_time", $this->_params, 235959)
               );
             $from_time_format = !empty($this->_params["{$fieldName}_from_time"]) ? 'h' : 'd';
             $from = CRM_Utils_Date::customFormat($from, NULL, array($from_time_format));

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -2036,12 +2036,12 @@ class CRM_Report_Form extends CRM_Core_Form {
    * @param bool $relative
    * @param string $from
    * @param string $to
-   * @param string $fromTime
-   * @param string $toTime
+   * @param int $fromTime
+   * @param int $toTime
    *
    * @return array
    */
-  public function getFromTo($relative, $from, $to, $fromTime = NULL, int $toTime = 235959) {
+  public function getFromTo($relative, $from, $to, $fromTime = NULL, $toTime = 235959) {
     return CRM_Utils_Date::getFromTo($relative, $from, $to, $fromTime, $toTime);
   }
 

--- a/CRM/Report/Form/ActivitySummary.php
+++ b/CRM/Report/Form/ActivitySummary.php
@@ -700,7 +700,7 @@ class CRM_Report_Form_ActivitySummary extends CRM_Report_Form {
               = $this->getFromTo(
                 CRM_Utils_Array::value("activity_date_time_relative", $this->_params),
                 CRM_Utils_Array::value("activity_date_time_from", $this->_params),
-                CRM_Utils_Array::value("activity_date_time_to", $this->_params)
+                CRM_Utils_Array::value("activity_date_time_to", $this->_params, 235959)
                 );
             $url[] = "activity_date_time_from={$from}&activity_date_time_to={$to}";
             break;

--- a/CRM/Report/Form/Contact/Relationship.php
+++ b/CRM/Report/Form/Contact/Relationship.php
@@ -830,8 +830,8 @@ class CRM_Report_Form_Contact_Relationship extends CRM_Report_Form {
    */
   public function activeClause(
     $fieldName,
-    $relative, $from, $to, $type = NULL, $fromTime = NULL, $toTime = NULL
-    ) {
+    $relative, $from, $to, $type = NULL, $fromTime = NULL, $toTime = 235959
+  ) {
     $clauses = array();
     if (in_array($relative, array_keys($this->getOperationPair(CRM_Report_Form::OP_DATE)))) {
       return NULL;

--- a/CRM/Report/Form/Contribute/Recur.php
+++ b/CRM/Report/Form/Contribute/Recur.php
@@ -316,7 +316,7 @@ class CRM_Report_Form_Contribute_Recur extends CRM_Report_Form {
         $start_date_db_alias = $this->_columns['civicrm_contribution_recur']['filters']['start_date']['dbAlias'];
 
         // The end date clause is simple to construct
-        $end_date_clause = $this->dateClause($end_date_db_alias, $relative, $from, $to, $end_date_type, NULL, NULL);
+        $end_date_clause = $this->dateClause($end_date_db_alias, $relative, $from, $to, $end_date_type);
 
         // NOTE: For the calculation based on installment, there doesn't
         // seem to be a way to include the interval unit (e.g. month,
@@ -325,22 +325,22 @@ class CRM_Report_Form_Contribute_Recur extends CRM_Report_Form {
 
         $this->_where .= 'AND (' .
           $this->dateClause("DATE_ADD($start_date_db_alias, INTERVAL $installments_db_alias * COALESCE($frequency_interval_db_alias,1) month)",
-            $relative, $from, $to, $start_date_type, NULL, NULL);
+            $relative, $from, $to, $start_date_type);
         $this->_where .= " AND $frequency_unit_db_alias = 'month' ) OR \n";
 
         $this->_where .= '(' .
           $this->dateClause("DATE_ADD($start_date_db_alias, INTERVAL $installments_db_alias * COALESCE($frequency_interval_db_alias,1) day)",
-            $relative, $from, $to, $start_date_type, NULL, NULL);
+            $relative, $from, $to, $start_date_type);
         $this->_where .= " AND $frequency_unit_db_alias = 'day' ) OR \n";
 
         $this->_where .= '(' .
           $this->dateClause("DATE_ADD($start_date_db_alias, INTERVAL $installments_db_alias * COALESCE($frequency_interval_db_alias, 1) week)",
-            $relative, $from, $to, $start_date_type, NULL, NULL);
+            $relative, $from, $to, $start_date_type);
         $this->_where .= " AND $frequency_unit_db_alias = 'week' ) OR \n";
 
         $this->_where .= '(' .
           $this->dateClause("DATE_ADD($start_date_db_alias, INTERVAL $installments_db_alias * COALESCE($frequency_interval_db_alias, 1) year)",
-            $relative, $from, $to, $start_date_type, NULL, NULL);
+            $relative, $from, $to, $start_date_type);
         $this->_where .= " AND $frequency_unit_db_alias = 'year' )
    AND (($end_date_db_alias IS NOT NULL AND $end_date_clause)
     OR ($installments_db_alias IS NOT NULL))

--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -802,7 +802,7 @@ class CRM_Utils_Date {
    * @return array
    *   start date, end date
    */
-  public static function getFromTo($relative, $from, $to, $fromTime = NULL, int $toTime = 235959) {
+  public static function getFromTo($relative, $from, $to, $fromTime = NULL, $toTime = 235959) {
     if ($relative) {
       list($term, $unit) = CRM_Utils_System::explode('.', $relative, 2);
       $dateRange = self::relativeToAbsolute($term, $unit);

--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -796,21 +796,23 @@ class CRM_Utils_Date {
    *
    * @param $from
    * @param $to
+   * @param int $fromTime
+   * @param int $toTime
    *
    * @return array
    *   start date, end date
    */
-  public static function getFromTo($relative, $from, $to) {
+  public static function getFromTo($relative, $from, $to, $fromTime = NULL, int $toTime = 235959) {
     if ($relative) {
-      list($term, $unit) = explode('.', $relative);
+      list($term, $unit) = CRM_Utils_System::explode('.', $relative, 2);
       $dateRange = self::relativeToAbsolute($term, $unit);
-      $from = $dateRange['from'];
+      $from = substr($dateRange['from'], 0, 8);
       //Take only Date Part, Sometime Time part is also present in 'to'
       $to = substr($dateRange['to'], 0, 8);
     }
 
-    $from = self::processDate($from);
-    $to = self::processDate($to, '235959');
+    $from = self::processDate($from, $fromTime);
+    $to = self::processDate($to, $toTime);
 
     return array($from, $to);
   }

--- a/tests/phpunit/CRM/Report/FormTest.php
+++ b/tests/phpunit/CRM/Report/FormTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+  +--------------------------------------------------------------------+
+  | CiviCRM version 4.7                                                |
+  +--------------------------------------------------------------------+
+  | Copyright CiviCRM LLC (c) 2004-2017                                |
+  +--------------------------------------------------------------------+
+  | This file is a part of CiviCRM.                                    |
+  |                                                                    |
+  | CiviCRM is free software; you can copy, modify, and distribute it  |
+  | under the terms of the GNU Affero General Public License           |
+  | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+  |                                                                    |
+  | CiviCRM is distributed in the hope that it will be useful, but     |
+  | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+  | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+  | See the GNU Affero General Public License for more details.        |
+  |                                                                    |
+  | You should have received a copy of the GNU Affero General Public   |
+  | License and the CiviCRM Licensing Exception along                  |
+  | with this program; if not, contact CiviCRM LLC                     |
+  | at info[AT]civicrm[DOT]org. If you have questions about the        |
+  | GNU Affero General Public License or the licensing of CiviCRM,     |
+  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+  +--------------------------------------------------------------------+
+ */
+
+/**
+ *  File for the FormTest class
+ *
+ *  (PHP 5)
+ *
+ * @author Jon Goldberg <jon@megaphonetech.com>
+ */
+
+/**
+ *  Test CRM_Report_Form functions.
+ *
+ * @package   CiviCRM
+ * @group headless
+ */
+class CRM_Report_FormTest extends CiviUnitTestCase {
+
+  public function setUp() {
+    // There are only unit tests here at present, we can skip database loading.
+    return TRUE;
+  }
+
+  public function tearDown() {
+    // There are only unit tests here at present, we can skip database loading.
+    return TRUE;
+  }
+
+  public function fromToData() {
+    $cases = array();
+    // Absolute dates
+    $cases[] = array('20170901000000', '20170913235959', 0, '09/01/2017', '09/13/2017');
+    // "Today" relative date filter
+    $date = new DateTime();
+    $expectedFrom = $date->format('Ymd') . '000000';
+    $expectedTo = $date->format('Ymd') . '235959';
+    $cases[] = array($expectedFrom, $expectedTo, 'this.day', '', '');
+    // "yesterday" relative date filter
+    $date = new DateTime();
+    $date->sub(new DateInterval('P1D'));
+    $expectedFrom = $date->format('Ymd') . '000000';
+    $expectedTo = $date->format('Ymd') . '235959';
+    $cases[] = array($expectedFrom, $expectedTo, 'previous.day', '', '');
+    return $cases;
+  }
+
+  /**
+   * Test that getFromTo returns the correct dates.
+   *
+   * @dataProvider fromToData
+   * @param $expectedFrom
+   * @param $expectedTo
+   * @param $relative
+   * @param $from
+   * @param $to
+   */
+  public function testGetFromTo($expectedFrom, $expectedTo, $relative, $from, $to) {
+    $obj = new CRM_Report_Form();
+    list($calculatedFrom, $calculatedTo) = $obj->getFromTo($relative, $from, $to);
+    $this->assertEquals($expectedFrom, $calculatedFrom);
+    $this->assertEquals($expectedTo, $calculatedTo);
+  }
+
+}

--- a/tests/phpunit/CRM/Utils/DateTest.php
+++ b/tests/phpunit/CRM/Utils/DateTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+  +--------------------------------------------------------------------+
+  | CiviCRM version 4.7                                                |
+  +--------------------------------------------------------------------+
+  | Copyright CiviCRM LLC (c) 2004-2017                                |
+  +--------------------------------------------------------------------+
+  | This file is a part of CiviCRM.                                    |
+  |                                                                    |
+  | CiviCRM is free software; you can copy, modify, and distribute it  |
+  | under the terms of the GNU Affero General Public License           |
+  | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+  |                                                                    |
+  | CiviCRM is distributed in the hope that it will be useful, but     |
+  | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+  | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+  | See the GNU Affero General Public License for more details.        |
+  |                                                                    |
+  | You should have received a copy of the GNU Affero General Public   |
+  | License and the CiviCRM Licensing Exception along                  |
+  | with this program; if not, contact CiviCRM LLC                     |
+  | at info[AT]civicrm[DOT]org. If you have questions about the        |
+  | GNU Affero General Public License or the licensing of CiviCRM,     |
+  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+  +--------------------------------------------------------------------+
+ */
+
+/**
+ *  File for the DateTest class
+ *
+ *  (PHP 5)
+ *
+ * @author Jon Goldberg <jon@megaphonetech.com>
+ */
+
+/**
+ *  Test CRM_Utils_Date functions.
+ *
+ * @package   CiviCRM
+ * @group headless
+ */
+class CRM_Utils_DateTest extends CiviUnitTestCase {
+
+  public function setUp() {
+    // There are only unit tests here at present, we can skip database loading.
+    return TRUE;
+  }
+
+  public function tearDown() {
+    // There are only unit tests here at present, we can skip database loading.
+    return TRUE;
+  }
+
+  public function fromToData() {
+    $cases = array();
+    // Absolute dates
+    $cases[] = array('20170901000000', '20170913235959', 0, '09/01/2017', '09/13/2017');
+    // "Today" relative date filter
+    $date = new DateTime();
+    $expectedFrom = $date->format('Ymd') . '000000';
+    $expectedTo = $date->format('Ymd') . '235959';
+    $cases[] = array($expectedFrom, $expectedTo, 'this.day', '', '');
+    // "yesterday" relative date filter
+    $date = new DateTime();
+    $date->sub(new DateInterval('P1D'));
+    $expectedFrom = $date->format('Ymd') . '000000';
+    $expectedTo = $date->format('Ymd') . '235959';
+    $cases[] = array($expectedFrom, $expectedTo, 'previous.day', '', '');
+    return $cases;
+  }
+
+  /**
+   * Test that getFromTo returns the correct dates.
+   *
+   * @dataProvider fromToData
+   * @param $expectedFrom
+   * @param $expectedTo
+   * @param $relative
+   * @param $from
+   * @param $to
+   */
+  public function testGetFromTo($expectedFrom, $expectedTo, $relative, $from, $to) {
+    $obj = new CRM_Utils_Date();
+    list($calculatedFrom, $calculatedTo) = $obj->getFromTo($relative, $from, $to);
+    $this->assertEquals($expectedFrom, $calculatedFrom);
+    $this->assertEquals($expectedTo, $calculatedTo);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
At some point, a method was copy-pasted, then modified.  This reconciles the differences and reduces code duplication.

Before
----------------------------------------
`CRM_Utils_Date::getFromTo()` and `CRM_Report_Form::getFromTo()` contain almost identical code.

After
----------------------------------------
`CRM_Report_Form::getFromTo()` wraps `CRM_Utils_Date::getFromTo()`.

Comments
----------------------------------------
My unit tests bypass the normal `setUp()` and `tearDown()` methods, which cuts the time to run down considerably.  These are unit tests and not functional tests; there's no need to load the database.  Is this a kosher technique?  My thinking is that if someone adds functional tests later, it'll be obvious that this needs changing - but that a Utils subclass probably never needs functional tests.

---

 * [CRM-21148: Refactor "getFromTo\(\)" functions](https://issues.civicrm.org/jira/browse/CRM-21148)