### PR TITLE
CRM-21109 Add test & consolidate code controlling cache clearing, specific improvement on cli imports

### DIFF
--- a/CRM/ACL/BAO/Cache.php
+++ b/CRM/ACL/BAO/Cache.php
@@ -142,6 +142,9 @@ WHERE contact_id = %1
    * Deletes all the cache entries.
    */
   public static function resetCache() {
+    if (!CRM_Core_Config::isPermitCacheFlushMode()) {
+      return;
+    }
     // reset any static caching
     self::$_cache = NULL;
 

--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -425,13 +425,7 @@ class CRM_Contact_BAO_Contact extends CRM_Contact_DAO_Contact {
       'name'
     );
 
-    if (!$config->doNotResetCache) {
-      // Note: doNotResetCache flag is currently set by import contact process and merging,
-      // since resetting and
-      // rebuilding cache could be expensive (for many contacts). We might come out with better
-      // approach in future.
-      CRM_Contact_BAO_Contact_Utils::clearContactCaches($contact->id);
-    }
+    CRM_Contact_BAO_Contact_Utils::clearContactCaches();
 
     if ($invokeHooks) {
       if ($isEdit) {

--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -351,9 +351,7 @@ class CRM_Contact_BAO_Contact extends CRM_Contact_DAO_Contact {
     //add website
     CRM_Core_BAO_Website::create($params['website'], $contact->id, $skipDelete);
 
-    //get userID from session
-    $session = CRM_Core_Session::singleton();
-    $userID = $session->get('userID');
+    $userID = CRM_Core_Session::singleton()->get('userID');
     // add notes
     if (!empty($params['note'])) {
       if (is_array($params['note'])) {

--- a/CRM/Contact/BAO/Contact/Utils.php
+++ b/CRM/Contact/BAO/Contact/Utils.php
@@ -897,18 +897,21 @@ INNER JOIN civicrm_contact contact_target ON ( contact_target.id = act.contact_i
    * caches, but are backing off from this with every release. Compromise between ease of coding versus
    * performance versus being accurate at that very instant
    *
-   * @param $contactID
-   *   The contactID that was edited / deleted.
+   * @param bool $isEmptyPrevNextTable
+   *   Should the civicrm_prev_next table be cleared of any contact entries.
+   *   This is currently done from import but not other places and would
+   *   likely affect user experience in unexpected ways. Existing behaviour retained
+   *   ... reluctantly.
    */
-  public static function clearContactCaches($contactID = NULL) {
-    // clear acl cache if any.
-    CRM_ACL_BAO_Cache::resetCache();
-
-    if (empty($contactID)) {
-      // also clear prev/next dedupe cache - if no contactID passed in
+  public static function clearContactCaches($isEmptyPrevNextTable = FALSE) {
+    if (!CRM_Core_Config::isPermitCacheFlushMode()) {
+      return;
+    }
+    if ($isEmptyPrevNextTable) {
       CRM_Core_BAO_PrevNextCache::deleteItem();
     }
-
+    // clear acl cache if any.
+    CRM_ACL_BAO_Cache::resetCache();
     CRM_Contact_BAO_GroupContactCache::opportunisticCacheFlush();
   }
 

--- a/CRM/Contact/BAO/GroupContact.php
+++ b/CRM/Contact/BAO/GroupContact.php
@@ -143,15 +143,7 @@ class CRM_Contact_BAO_GroupContact extends CRM_Contact_DAO_GroupContact {
     list($numContactsAdded, $numContactsNotAdded)
       = self::bulkAddContactsToGroup($contactIds, $groupId, $method, $status, $tracking);
 
-    // also reset the acl cache
-    $config = CRM_Core_Config::singleton();
-    if (!$config->doNotResetCache) {
-      CRM_ACL_BAO_Cache::resetCache();
-    }
-
-    // reset the group contact cache for all group(s)
-    // if this group is being used as a smart group
-    CRM_Contact_BAO_GroupContactCache::opportunisticCacheFlush();
+    CRM_Contact_BAO_Contact_Utils::clearContactCaches();
 
     CRM_Utils_Hook::post('create', 'GroupContact', $groupId, $contactIds);
 
@@ -245,21 +237,7 @@ class CRM_Contact_BAO_GroupContact extends CRM_Contact_DAO_GroupContact {
       }
     }
 
-    // also reset the acl cache
-    $config = CRM_Core_Config::singleton();
-    if (!$config->doNotResetCache) {
-      CRM_ACL_BAO_Cache::resetCache();
-    }
-
-    // reset the group contact cache for all group(s)
-    // if this group is being used as a smart group
-    // @todo consider what to do here - it feels like we should either
-    // 1) just invalidate the specific group's cache(& perhaps any parents) & let cron do it's thing or
-    // possibly clear this specific groups cache, or just call opportunisticCacheFlush() - which would have the
-    // same effect as the remove call. The reservation about that is that it is no more aggressive for the group that
-    // we know is altered than for all the others, or perhaps, more the point with it's parents & groups that use it in
-    // their criteria.
-    CRM_Contact_BAO_GroupContactCache::remove();
+    CRM_Contact_BAO_Contact_Utils::clearContactCaches();
 
     CRM_Utils_Hook::post($op, 'GroupContact', $groupId, $contactIds);
 

--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -211,22 +211,19 @@ AND    g.refresh_date IS NULL
   }
 
   /**
-   * Build the smart group cache for a given group.
+   * Build the smart group cache for given groups.
    *
-   * @param int $groupID
+   * @param array $groupIDs
    */
-  public static function add($groupID) {
-    // first delete the current cache
-    self::remove($groupID);
-    if (!is_array($groupID)) {
-      $groupID = array($groupID);
-    }
+  public static function add($groupIDs) {
+    $groupIDs = (array) $groupIDs;
 
-    $returnProperties = array('contact_id');
-    foreach ($groupID as $gid) {
-      $params = array(array('group', 'IN', array($gid), 0, 0));
+    foreach ($groupIDs as $groupID) {
+      // first delete the current cache
+      self::clearGroupContactCache($groupID);
+      $params = array(array('group', 'IN', array($groupID), 0, 0));
       // the below call updates the cache table as a byproduct of the query
-      CRM_Contact_BAO_Query::apiQuery($params, $returnProperties, NULL, NULL, 0, 0, FALSE);
+      CRM_Contact_BAO_Query::apiQuery($params, array('contact_id'), NULL, NULL, 0, 0, FALSE);
     }
   }
 
@@ -236,10 +233,10 @@ AND    g.refresh_date IS NULL
    * @todo review use of INSERT IGNORE. This function appears to be slower that inserting
    * with a left join. Also, 200 at once seems too little.
    *
-   * @param int $groupID
+   * @param array $groupID
    * @param array $values
    */
-  public static function store(&$groupID, &$values) {
+  public static function store($groupID, &$values) {
     $processed = FALSE;
 
     // sort the values so we put group IDs in front and hence optimize
@@ -286,111 +283,20 @@ WHERE  id IN ( $groupIDs )
   }
 
   /**
-   * Removes all the cache entries pertaining to a specific group.
+   * @deprecated function - the best function to call is
+   * CRM_Contact_BAO_Contact::updateContactCache at the moment, or api job.group_cache_flush
+   * to really force a flush.
    *
-   * If no groupID is passed in, removes cache entries for all groups
-   * Has an optimization to bypass repeated invocations of this function.
-   * Note that this function is an advisory, i.e. the removal respects the
-   * cache date, i.e. the removal is not done if the group was recently
-   * loaded into the cache.
+   * Remove this function altogether by mid 2018.
    *
-   * In fact it turned out there is little overlap between the code when group is passed in
-   * and group is not so it makes more sense as separate functions.
-   *
-   * @todo enforce groupID as an array & remove non group handling.
-   * Use flushCaches when no group id provided.
-   *
-   * @param int $groupIDs
-   *   the groupID to delete cache entries, NULL for all groups.
-   * @param bool $onceOnly
-   *   run the function exactly once for all groups.
+   * However, if updating code outside core to use this (or any BAO function) it is recommended that
+   * you add an api call to lock in into our contract. Currently there is not really a supported
+   * method for non core functions.
    */
-  public static function remove($groupIDs = NULL, $onceOnly = TRUE) {
-    if (!is_array($groupIDs)) {
-      Civi::log()
-        ->warning('Deprecated code. This function should not be called without groupIDs. Extensions can use the api job.group_cache_flush', array('civi.tag' => 'deprecated'));
-      return;
-    }
-    if (!isset(Civi::$statics[__CLASS__]['remove_invoked'])) {
-      Civi::$statics[__CLASS__] = array('remove_invoked' => FALSE);
-    }
-
-    // typically this needs to happy only once per instance
-    // this is especially TRUE in import, where we don't need
-    // to do this all the time
-    // this optimization is done only when no groupID is passed
-    // i.e. cache is reset for all groups
-    if (
-      $onceOnly &&
-      Civi::$statics[__CLASS__]['remove_invoked'] &&
-      $groupIDs == NULL
-    ) {
-      return;
-    }
-
-    if ($groupIDs == NULL) {
-      Civi::$statics[__CLASS__]['remove_invoked'] = TRUE;
-    }
-    elseif (is_array($groupIDs)) {
-      foreach ($groupIDs as $gid) {
-        unset(self::$_alreadyLoaded[$gid]);
-      }
-    }
-    elseif ($groupIDs && array_key_exists($groupIDs, self::$_alreadyLoaded)) {
-      unset(self::$_alreadyLoaded[$groupIDs]);
-    }
-
-    $refresh = NULL;
-    $smartGroupCacheTimeout = self::smartGroupCacheTimeout();
-    $params = array(
-      1 => array(self::getCacheInvalidDateTime(), 'String'),
-      2 => array(self::getRefreshDateTime(), 'String'),
-    );
-
-    if (!isset($groupIDs)) {
-      if ($smartGroupCacheTimeout == 0) {
-        $query = "
-DELETE FROM civicrm_group_contact_cache
-";
-        $update = "
-UPDATE civicrm_group g
-SET    cache_date = null,
-       refresh_date = null
-";
-      }
-      else {
-        $query = "
-DELETE     gc
-FROM       civicrm_group_contact_cache gc
-INNER JOIN civicrm_group g ON g.id = gc.group_id
-WHERE      g.cache_date <= %1
-";
-        $update = "
-UPDATE civicrm_group g
-SET    cache_date = null,
-       refresh_date = null
-WHERE  g.cache_date <= %1
-";
-        $refresh = "
-UPDATE civicrm_group g
-SET    refresh_date = %2
-WHERE  g.cache_date < %1
-AND    refresh_date IS NULL
-";
-      }
-
-      CRM_Core_DAO::executeQuery($query, $params);
-      if ($refresh) {
-        CRM_Core_DAO::executeQuery($refresh, $params);
-      }
-      // also update the cache_date for these groups
-      CRM_Core_DAO::executeQuery($update, $params);
-    }
-    else {
-      foreach ((array) $groupIDs as $groupID) {
-        self::clearGroupContactCache($groupID);
-      }
-    }
+  public static function remove() {
+    Civi::log()
+      ->warning('Deprecated code. This function should not be called without groupIDs. Extensions can use the api job.group_cache_flush for a hard flush or add an api option for soft flush', array('civi.tag' => 'deprecated'));
+    CRM_Contact_BAO_GroupContactCache::opportunisticCacheFlush();
   }
 
   /**
@@ -419,6 +325,7 @@ AND    refresh_date IS NULL
     CRM_Core_DAO::executeQuery($query, $params);
     // also update the cache_date for these groups
     CRM_Core_DAO::executeQuery($update, $params);
+    unset(self::$_alreadyLoaded[$groupID]);
 
     $transaction->commit();
   }
@@ -677,8 +584,8 @@ FROM   civicrm_group_contact
 WHERE  civicrm_group_contact.status = 'Added'
   AND  civicrm_group_contact.group_id = $groupID ";
 
-    $groupIDs = array($groupID);
-    self::remove($groupIDs);
+    self::clearGroupContactCache($groupID);
+
     $processed = FALSE;
     $tempTable = 'civicrm_temp_group_contact_cache' . rand(0, 2000);
     foreach (array($sql, $sqlB) as $selectSql) {
@@ -695,7 +602,7 @@ WHERE  civicrm_group_contact.status = 'Added'
       CRM_Core_DAO::executeQuery(" DROP TEMPORARY TABLE $tempTable");
     }
 
-    self::updateCacheTime($groupIDs, $processed);
+    self::updateCacheTime(array($groupID), $processed);
 
     if ($group->children) {
 
@@ -723,7 +630,7 @@ AND  civicrm_group_contact.group_id = $groupID ";
           $values[] = "({$groupID},{$contactID})";
         }
 
-        self::store($groupIDs, $values);
+        self::store(array($groupID), $values);
       }
     }
 

--- a/CRM/Contact/Form/Merge.php
+++ b/CRM/Contact/Form/Merge.php
@@ -108,7 +108,7 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
 
       // get user info of main contact.
       $config = CRM_Core_Config::singleton();
-      $config->doNotResetCache = 1;
+      CRM_Core_Config::setPermitCacheFlushMode(FALSE);
 
       $mainUfId = CRM_Core_BAO_UFMatch::getUFId($this->_cid);
       $mainUser = NULL;

--- a/CRM/Contact/Import/Form/Preview.php
+++ b/CRM/Contact/Import/Form/Preview.php
@@ -306,7 +306,7 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
 
     // Clear all caches, forcing any searches to recheck the ACLs or group membership as the import
     // may have changed it.
-    CRM_Contact_BAO_Contact_Utils::clearContactCaches();
+    CRM_Contact_BAO_Contact_Utils::clearContactCaches(TRUE);
 
     // add all the necessary variables to the form
     $importJob->setFormVariables($this);

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -1716,11 +1716,10 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
         $this->formatParams($formatted, $onDuplicate, (int) $contactId);
       }
 
-      // pass doNotResetCache flag since resetting and rebuilding cache could be expensive.
-      $config = CRM_Core_Config::singleton();
-      $config->doNotResetCache = 1;
+      // Resetting and rebuilding cache could be expensive.
+      CRM_Core_Config::setPermitCacheFlushMode(FALSE);
       $cid = CRM_Contact_BAO_Contact::createProfileContact($formatted, $contactFields, $contactId, NULL, NULL, $formatted['contact_type']);
-      $config->doNotResetCache = 0;
+      CRM_Core_Config::setPermitCacheFlushMode(TRUE);
 
       $contact = array(
         'contact_id' => $cid,

--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -568,4 +568,24 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
     Civi::settings()->set('installed', 1);
   }
 
+  /**
+   * Is the system permitted to flush caches at the moment.
+   */
+  static public function isPermitCacheFlushMode() {
+    return !CRM_Core_Config::singleton()->doNotResetCache;
+  }
+
+  /**
+   * Set cache clearing to enabled or disabled.
+   *
+   * This might be enabled at the start of a long running process
+   * such as an import in order to delay clearing caches until the end.
+   *
+   * @param bool $enabled
+   *   If true then caches can be cleared at this time.
+   */
+  static public function setPermitCacheFlushMode($enabled) {
+    CRM_Core_Config::singleton()->doNotResetCache = $enabled ? 0 : 1;
+  }
+
 }

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -783,9 +783,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
     $resultStats = array('merged' => array(), 'skipped' => array());
 
     // we don't want dupe caching to get reset after every-merge, and therefore set the
-    // doNotResetCache flag
-    $config = CRM_Core_Config::singleton();
-    $config->doNotResetCache = 1;
+    CRM_Core_Config::setPermitCacheFlushMode(FALSE);
     $deletedContacts = array();
 
     while (!empty($dupePairs)) {

--- a/bin/cli.class.php
+++ b/bin/cli.class.php
@@ -99,6 +99,7 @@ class civicrm_cli {
   public function callApi() {
     require_once 'api/api.php';
 
+    CRM_Core_Config::setPermitCacheFlushMode(FALSE);
     //  CRM-9822 -'execute' action always goes thru Job api and always writes to log
     if ($this->_action != 'execute' && $this->_joblog) {
       require_once 'CRM/Core/JobManager.php';
@@ -111,6 +112,8 @@ class civicrm_cli {
       $this->_params['auth'] = FALSE;
       $result = civicrm_api($this->_entity, $this->_action, $this->_params);
     }
+    CRM_Core_Config::setPermitCacheFlushMode(TRUE);
+    CRM_Contact_BAO_Contact_Utils::clearContactCaches();
 
     if (!empty($result['is_error'])) {
       $this->_log($result['error_message']);

--- a/tests/phpunit/CRM/Contact/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTest.php
@@ -385,7 +385,7 @@ class CRM_Contact_BAO_QueryTest extends CiviUnitTestCase {
     $this->callAPISuccess('GroupContact', 'create', array('group_id' => $groupID, 'contact_id' => $householdID, 'status' => 'Added'));
 
     // Refresh the cache for test purposes. It would be better to alter to alter the GroupContact add function to add contacts to the cache.
-    CRM_Contact_BAO_GroupContactCache::remove($groupID, FALSE);
+    CRM_Contact_BAO_GroupContactCache::clearGroupContactCache($groupID);
 
     $sql = CRM_Contact_BAO_Query::getQuery(
       array(array('group', 'IN', array($groupID), 0, 0)),

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -83,6 +83,10 @@ class api_v3_ContactTest extends CiviUnitTestCase {
       'civicrm_acl_contact_cache',
       'civicrm_activity_contact',
       'civicrm_activity',
+      'civicrm_group',
+      'civicrm_group_contact',
+      'civicrm_saved_search',
+      'civicrm_group_contact_cache',
     );
 
     $this->quickCleanup($tablesToTruncate, TRUE);
@@ -132,8 +136,10 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
     // Rinse & repeat, but with the option.
     $this->putGroupContactCacheInClearableState($groupID, $contact);
-    $this->callAPISuccess('contact', 'create', array('id' => $contact['id'], 'options' => array('do_not_reset_cache' => 1)));
+    CRM_Core_Config::setPermitCacheFlushMode(FALSE);
+    $this->callAPISuccess('contact', 'create', array('id' => $contact['id']));
     $this->assertEquals(1, CRM_Core_DAO::singleValueQuery("SELECT count(*) FROM civicrm_group_contact_cache"));
+    CRM_Core_Config::setPermitCacheFlushMode(TRUE);
   }
 
   /**

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -3516,7 +3516,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    * @param $contact
    */
   protected function putGroupContactCacheInClearableState($groupID, $contact) {
-// We need to force the situation where there is invalid data in the cache and it
+    // We need to force the situation where there is invalid data in the cache and it
     // is due to be cleared.
     CRM_Core_DAO::executeQuery("
       INSERT INTO civicrm_group_contact_cache (group_id, contact_id)

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -116,6 +116,27 @@ class api_v3_ContactTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test that it is possible to prevent cache clearing via option.
+   *
+   * Cache clearing is bypassed if 'options' => array('do_not_reset_cache' => 1 is used.
+   */
+  public function testCreateIndividualNoCacheClear() {
+
+    $contact = $this->callAPISuccess('contact', 'create', $this->_params);
+    $groupID = $this->groupCreate();
+
+    $this->putGroupContactCacheInClearableState($groupID, $contact);
+
+    $this->callAPISuccess('contact', 'create', array('id' => $contact['id']));
+    $this->assertEquals(0, CRM_Core_DAO::singleValueQuery("SELECT count(*) FROM civicrm_group_contact_cache"));
+
+    // Rinse & repeat, but with the option.
+    $this->putGroupContactCacheInClearableState($groupID, $contact);
+    $this->callAPISuccess('contact', 'create', array('id' => $contact['id'], 'options' => array('do_not_reset_cache' => 1)));
+    $this->assertEquals(1, CRM_Core_DAO::singleValueQuery("SELECT count(*) FROM civicrm_group_contact_cache"));
+  }
+
+  /**
    * Test for international string acceptance (CRM-10210).
    *
    * @dataProvider getInternationalStrings
@@ -3488,6 +3509,22 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     $cid = $this->createLoggedInUser();
     $contact = $this->callAPIAndDocument('contact', 'get', array('id' => 'user_contact_id'), __FUNCTION__, __FILE__, $description, $subFile);
     $this->assertEquals($cid, $contact['id']);
+  }
+
+  /**
+   * @param $groupID
+   * @param $contact
+   */
+  protected function putGroupContactCacheInClearableState($groupID, $contact) {
+// We need to force the situation where there is invalid data in the cache and it
+    // is due to be cleared.
+    CRM_Core_DAO::executeQuery("
+      INSERT INTO civicrm_group_contact_cache (group_id, contact_id)
+      VALUES ({$groupID}, {$contact['id']})
+    ");
+    CRM_Core_DAO::executeQuery("UPDATE civicrm_group SET cache_date = '2017-01-01'");
+    // Reset so it does not skip.
+    Civi::$statics['CRM_Contact_BAO_GroupContactCache']['is_refresh_init'] = FALSE;
   }
 
 }

--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -42,7 +42,7 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
    */
   public function tearDown() {
     $this->quickCleanUpFinancialEntities();
-    $this->quickCleanup(array('civicrm_group', 'civicrm_saved_search', 'civicrm_group_contact'));
+    $this->quickCleanup(array('civicrm_group', 'civicrm_saved_search', 'civicrm_group_contact', 'civicrm_group_contact_cache', 'civicrm_group'));
     parent::tearDown();
   }
 
@@ -123,7 +123,7 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
     $result = $this->callAPIAndDocument('report_template', 'getrows', array(
       'report_id' => 'contact/summary',
       'options' => array('metadata' => array('labels', 'title')),
-    ), __FUNCTION__, __FILE__, $description, 'Getrows', 'getrows');
+    ), __FUNCTION__, __FILE__, $description, 'Getrows');
     $this->assertEquals('Contact Name', $result['metadata']['labels']['civicrm_contact_sort_name']);
 
     //the second part of this test has been commented out because it relied on the db being reset to
@@ -470,7 +470,7 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
     }
 
     // Refresh the cache for test purposes. It would be better to alter to alter the GroupContact add function to add contacts to the cache.
-    CRM_Contact_BAO_GroupContactCache::remove($groupID, FALSE);
+    CRM_Contact_BAO_GroupContactCache::clearGroupContactCache($groupID);
     return $groupID;
   }
 
@@ -510,7 +510,7 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
     }
 
     // Refresh the cache for test purposes. It would be better to alter to alter the GroupContact add function to add contacts to the cache.
-    CRM_Contact_BAO_GroupContactCache::remove($groupID, FALSE);
+    CRM_Contact_BAO_GroupContactCache::clearGroupContactCache($groupID);
 
     if ($returnAddedContact) {
       return array($groupID, $individualID);


### PR DESCRIPTION
Overview
----------------------------------------
Add test, & consolidate code controlling cache clearance via the api. An alternate approach to  #10905 by @MegaphoneJon. This also achieves Jon's original goal of less frequent cache clearing during cli imports

Before
----------------------------------------
CLI imports clear group cache once per line. No test

After
----------------------------------------
CLI imports clear group cache once. Test exists. 

This also has the impact ok making cache clearing more consistent & overall slightly less as the
$config->doNotReset is respected by acl cache & group membership changes now too

Technical Details
----------------------------------------
CRM-21109 references a specific area of concern to reduce clearing of caches when running a CLI import & @MegaphoneJon has created #10905 to suggest that we set $config->doNotReset when looking into this.

My initial feeling was that we should allow 'cache instructions' to be passed in via api calls - ie. if you are doing a long running process then it should be possible to quash cache-clearing somewhat during this. As it turns out looking at the code it may also make sense to request more aggressive cache clearing in some (as yet undreamt) circumstances.

Comments
----------------------------------------
Looking at  the code I have a number of notes - mostly due to refreshing my memory.

- There are 3 caches that are potentially cleared when editing a contact: 
  - group_contact_cache
  -  acl_contact_cache (& acl_cache which is less important)
  - prevnext_cache

- The prevnext_cache never seems to be a performance concern

**- The group contact cache goes through a number of checks before clearing**

 1) is $config->doNotReset set (this is not centralised so there may be bypasses). Import uses this.
 2) is the civicrm setting 'smart_group_cache_refresh_mode' set to 'opportunistic' (the default). 
 3) it then checks a php static variable that makes sure the cache is not cleared more than once in a process (I wasn't clear about this - in the case of an import it means that if they are cleared at the start they probably won't be at the beginning
4) it then checks for a mysql lock from another process. This is something that is not 100% reliable at the moment but could be made reliable for 5.7.5+ / MariaDB 10.0.2 + fairly trivially. The lock is released once the cache is cleared
-5) after all this it will clear the cache, removing entries based on the timestamp of the group & the smartGroupCacheTimeout . There is an opportunity for optimisation in this query.


Based on the above I suspect it is more likely that if there is a WMF problem with the cache clearing it is the query running slow rather than it being too frequent


**Opportunistic**

To alter that setting & not clear the smart group in-process it is necessary to set the setting-  potentially in civicrm.settings.php with the following:

```
global $civicrm_setting;
$civicrm_setting['CiviCRM Preferences']['smart_group_cache_refresh_mode'] = 'deterministic'; 
```
It is also necessary to set up a cron to clear the caches outside of processes (calling api job.group_cache_flush). If the smart group cache time out is set to 0 TRUNCATE will be used in the cron (rather then DELETE FROM). This is faster for many sites, but not WMF

**optimisation**

-  There was a patch in 4.7.23 (not on WMF yet) that related to group_contact_cache performance https://issues.civicrm.org/jira/browse/CRM-20722
 - the join on the cache clear query could be eliminated. This should reduce locking.

**Acl_contact_cache**
- the only check done before clearing this is the doNotClearCache setting

**This problem**

Most of the above is by way of background. Specifically to this PR is the question 

> Should we allow the api to pass in parameters regarding how aggressively caches should be cleared, and if so what format. ie. do we want granular control over the 3 caches or simply a boolean whether to clear or not. 

I realise there was some push back on cache management via the api in discussions about v4 api - but my sense is that was more about whether the api should do caching, rather than whether it should be able to tune-down  cache clearing.

@totten @colemanw @xurizaemon @MegaphoneJon @ejegg ping

---

 * [CRM-21109: Creating contacts is slow, part 2 of 2: Smart group caching](https://issues.civicrm.org/jira/browse/CRM-21109)