### PR TITLE
CRM-21037 activity sendsms unittests

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1656,6 +1656,10 @@ LEFT JOIN civicrm_activity_contact src ON (src.activity_id = ac.activity_id AND 
     &$contactIds = NULL,
     $sourceContactId = NULL
   ) {
+    if (!CRM_Core_Permission::check('send SMS')) {
+      throw new CRM_Core_Exception("You do not have the 'send SMS' permission");
+    }
+
     if (!isset($contactDetails) && !isset($contactIds)) {
       Throw new CRM_Core_Exception('You must specify either $contactDetails or $contactIds');
     }
@@ -1674,10 +1678,6 @@ LEFT JOIN civicrm_activity_contact src ON (src.activity_id = ac.activity_id AND 
       foreach ($contactDetails as $contact) {
         $contactIds[] = $contact['contact_id'];
       }
-    }
-
-    if (!CRM_Core_Permission::check('send SMS')) {
-      throw new CRM_Core_Exception("You do not have the 'send SMS' permission");
     }
 
     // Get logged in User Id

--- a/CRM/SMS/Provider.php
+++ b/CRM/SMS/Provider.php
@@ -76,11 +76,11 @@ abstract class CRM_SMS_Provider {
         require_once "{$providerClass}.php";
       }
       else {
-        // If we are running unit tests we simulate an SMS provider with the name "testSmsProvider"
-        if ($providerName !== 'testSmsProvider') {
+        // If we are running unit tests we simulate an SMS provider with the name "CiviTestSMSProvider"
+        if ($providerName !== 'CiviTestSMSProvider') {
           CRM_Core_Error::fatal("Could not locate extension for {$providerName}.");
         }
-        $providerClass = 'testSmsProvider';
+        $providerClass = 'CiviTestSMSProvider';
       }
 
       self::$_singleton[$cacheKey] = $providerClass::singleton($providerParams, $force);

--- a/CRM/SMS/Provider.php
+++ b/CRM/SMS/Provider.php
@@ -72,14 +72,18 @@ abstract class CRM_SMS_Provider {
     if (!isset(self::$_singleton[$cacheKey]) || $force) {
       $ext = CRM_Extension_System::singleton()->getMapper();
       if ($ext->isExtensionKey($providerName)) {
-        $paymentClass = $ext->keyToClass($providerName);
-        require_once "{$paymentClass}.php";
+        $providerClass = $ext->keyToClass($providerName);
+        require_once "{$providerClass}.php";
       }
       else {
-        CRM_Core_Error::fatal("Could not locate extension for {$providerName}.");
+        // If we are running unit tests we simulate an SMS provider with the name "testSmsProvider"
+        if ($providerName !== 'testSmsProvider') {
+          CRM_Core_Error::fatal("Could not locate extension for {$providerName}.");
+        }
+        $providerClass = 'testSmsProvider';
       }
 
-      self::$_singleton[$cacheKey] = $paymentClass::singleton($providerParams, $force);
+      self::$_singleton[$cacheKey] = $providerClass::singleton($providerParams, $force);
     }
     return self::$_singleton[$cacheKey];
   }
@@ -158,12 +162,11 @@ INNER JOIN civicrm_mailing_job mj ON mj.mailing_id = m.id AND mj.id = %1";
       return FALSE;
     }
 
-    $activityTypeID = CRM_Core_OptionGroup::getValue('activity_type', 'SMS delivery', 'name');
     // note: lets not pass status here, assuming status will be updated by callback
     $activityParams = array(
       'source_contact_id' => $sourceContactID,
       'target_contact_id' => $headers['contact_id'],
-      'activity_type_id' => $activityTypeID,
+      'activity_type_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'SMS delivery'),
       'activity_date_time' => date('YmdHis'),
       'details' => $message,
       'result' => $apiMsgID,
@@ -186,7 +189,7 @@ INNER JOIN civicrm_mailing_job mj ON mj.mailing_id = m.id AND mj.id = %1";
       FALSE, $default, $location
     );
     if ($abort && $value === NULL) {
-      CRM_Core_Error::debug_log_message("Could not find an entry for $name in $location");
+      Civi::log()->warning("Could not find an entry for $name in $location");
       echo "Failure: Missing Parameter<p>";
       exit();
     }
@@ -259,16 +262,13 @@ INNER JOIN civicrm_mailing_job mj ON mj.mailing_id = m.id AND mj.id = %1";
     }
 
     if ($message->fromContactID) {
-      $actStatusIDs = array_flip(CRM_Core_OptionGroup::values('activity_status'));
-      $activityTypeID = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Inbound SMS');
-
       // note: lets not pass status here, assuming status will be updated by callback
       $activityParams = array(
         'source_contact_id' => $message->toContactID,
         'target_contact_id' => $message->fromContactID,
-        'activity_type_id' => $activityTypeID,
+        'activity_type_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Inbound SMS'),
         'activity_date_time' => date('YmdHis'),
-        'status_id' => $actStatusIDs['Completed'],
+        'status_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_status_id', 'Completed'),
         'details' => $message->body,
         'phone_number' => $message->from,
       );
@@ -277,7 +277,7 @@ INNER JOIN civicrm_mailing_job mj ON mj.mailing_id = m.id AND mj.id = %1";
       }
 
       $result = CRM_Activity_BAO_Activity::create($activityParams);
-      CRM_Core_Error::debug_log_message("Inbound SMS recorded for cid={$message->fromContactID}.");
+      Civi::log()->info("Inbound SMS recorded for cid={$message->fromContactID}.");
       return $result;
     }
   }

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1157,7 +1157,7 @@ class CRM_Utils_Token {
    * Gives required details of contacts in an indexed array format so we
    * can iterate in a nice loop and do token evaluation
    *
-   * @param $contactIDs
+   * @param array $contactIDs
    * @param array $returnProperties
    *   Of required properties.
    * @param bool $skipOnHold Don't return on_hold contact info also.
@@ -1186,7 +1186,7 @@ class CRM_Utils_Token {
   ) {
 
     $params = array();
-    foreach ($contactIDs as $key => $contactID) {
+    foreach ($contactIDs as $contactID) {
       $params[] = array(
         CRM_Core_Form::CB_PREFIX . $contactID,
         '=',
@@ -1215,7 +1215,7 @@ class CRM_Utils_Token {
       $fields = array_merge(array_keys(CRM_Contact_BAO_Contact::exportableFields()),
         array('display_name', 'checksum', 'contact_id')
       );
-      foreach ($fields as $key => $val) {
+      foreach ($fields as $val) {
         // The unavailable fields are not available as tokens, do not have a one-2-one relationship
         // with contacts and are expensive to resolve.
         // @todo see CRM-17253 - there are some other fields (e.g note) that should be excluded
@@ -1239,12 +1239,12 @@ class CRM_Utils_Token {
 
     $contactDetails = &$details[0];
 
-    foreach ($contactIDs as $key => $contactID) {
+    foreach ($contactIDs as $contactID) {
       if (array_key_exists($contactID, $contactDetails)) {
         if (!empty($contactDetails[$contactID]['preferred_communication_method'])
         ) {
           $communicationPreferences = array();
-          foreach ($contactDetails[$contactID]['preferred_communication_method'] as $key => $val) {
+          foreach ($contactDetails[$contactID]['preferred_communication_method'] as $val) {
             if ($val) {
               $communicationPreferences[$val] = CRM_Core_PseudoConstant::getLabel('CRM_Contact_DAO_Contact', 'preferred_communication_method', $val);
             }

--- a/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
@@ -1265,16 +1265,17 @@ $text
     $activityParams['sms_text_message'] = __FUNCTION__ . ' text';
     $activityParams['activity_subject'] = __FUNCTION__ . ' subject';
 
-    // ActivityParams is overwritten by sendSms but we need it for results
-    $activityParamsCopy = $activityParams;
-
     // Get a "logged in" user to set as source of Sms.
     $session = CRM_Core_Session::singleton();
     $sourceContactId = $session->get('userID');
 
-    // Create a user, then a phone number
+    // Create a user
     $this->_testSmsContactId = $this->createLoggedInUser();
-    // Create phone number
+
+    // Give user permission to 'send SMS'
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = array('access CiviCRM', 'send SMS');
+
+    // Create a phone number
     switch ($phoneType) {
       case 0:
         // No phone number

--- a/tests/phpunit/CRM/SMS/ProviderTest.php
+++ b/tests/phpunit/CRM/SMS/ProviderTest.php
@@ -32,6 +32,8 @@
  * @subpackage API_Contribution
  * @group headless
  */
+require_once 'CiviTest/CiviTestSMSProvider.php';
+
 class CRM_SMS_ProviderTest extends CiviUnitTestCase {
 
   /**
@@ -57,7 +59,7 @@ class CRM_SMS_ProviderTest extends CiviUnitTestCase {
    */
   public function testProcessInbound() {
     $testSourceContact = $this->individualCreate(array('phone' => array(1 => array('phone_type_id' => 'Phone', 'location_type_id' => 'Home', 'phone' => '+61487654321'))));
-    $provider = new testSMSProvider();
+    $provider = new CiviTestSMSProvider('CiviTestSMSProvider');
     $result = $provider->processInbound('+61412345678', 'This is a test message', '+61487654321');
     $this->assertEquals('This is a test message', $result->details);
     $this->assertEquals('+61412345678', $result->phone_number);
@@ -67,7 +69,7 @@ class CRM_SMS_ProviderTest extends CiviUnitTestCase {
    * CRM-20238 Add test of processInbound function where no To is passed into the function
    */
   public function testProcessInboundNoTo() {
-    $provider = new testSMSProvider();
+    $provider = new CiviTestSMSProvider('CiviTestSMSProvider');
     $result = $provider->processInbound('+61412345678', 'This is a test message', NULL, '12345');
     $this->assertEquals('This is a test message', $result->details);
     $this->assertEquals('+61412345678', $result->phone_number);
@@ -83,7 +85,7 @@ class CRM_SMS_ProviderTest extends CiviUnitTestCase {
    * CRM-20238 Add test of ProcessInbound function where no To number is passed into the function but the toContactId gets set in a hook
    */
   public function testProcessInboundSetToContactIDUsingHook() {
-    $provider = new testSMSProvider();
+    $provider = new CiviTestSMSProvider('CiviTestSMSProvider');
     $this->hookClass->setHook('civicrm_inboundSMS', array($this, 'smsHookTest'));
     $result = $provider->processInbound('+61412345678', 'This is a test message', NULL, '12345');
     $this->assertEquals('This is a test message', $result->details);
@@ -98,17 +100,6 @@ class CRM_SMS_ProviderTest extends CiviUnitTestCase {
   public function smsHookTest(&$message) {
     $testSourceContact = $this->individualCreate(array('phone' => array(1 => array('phone' => '+61487654321'))));
     $message->toContactID = $testSourceContact;
-  }
-
-}
-
-/**
- * Test SMS provider to allow for testing
- */
-class testSMSProvider extends CRM_SMS_Provider {
-
-  public function send($recipients, $header, $message, $dncID = NULL) {
-    parent::send($recipients, $header, $message, $dncID);
   }
 
 }

--- a/tests/phpunit/CiviTest/CiviTestSMSProvider.php
+++ b/tests/phpunit/CiviTest/CiviTestSMSProvider.php
@@ -1,0 +1,64 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2017                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License along with this program; if not, contact CiviCRM LLC       |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+ /**
+  * Test SMS provider to allow for testing
+  */
+class CiviTestSMSProvider extends CRM_SMS_Provider {
+  protected $_providerInfo = array();
+  protected $_id = 0;
+  static private $_singleton = array();
+
+  public function __construct($provider, $skipAuth = TRUE) {
+    $this->provider = $provider;
+  }
+
+  public static function &singleton($providerParams = array(), $force = FALSE) {
+    if (isset($providerParams['provider'])) {
+      $providers = CRM_SMS_BAO_Provider::getProviders(NULL, array('name' => $providerParams['provider']));
+      $provider = current($providers);
+      $providerID = $provider['id'];
+    }
+    else {
+      $providerID = CRM_Utils_Array::value('provider_id', $providerParams);
+    }
+    $skipAuth   = $providerID ? FALSE : TRUE;
+    $cacheKey   = (int) $providerID;
+
+    if (!isset(self::$_singleton[$cacheKey]) || $force) {
+      $provider = array();
+      if ($providerID) {
+        $provider = CRM_SMS_BAO_Provider::getProviderInfo($providerID);
+      }
+      self::$_singleton[$cacheKey] = new CiviTestSMSProvider($provider, $skipAuth);
+    }
+    return self::$_singleton[$cacheKey];
+  }
+
+  public function send($recipients, $header, $message, $dncID = NULL) {
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Add unit tests for Send SMS functionality in core.

Before
----------------------------------------
No test coverage.

After
----------------------------------------
Test coverage for Activity BAO functions.

Technical Notes
----------------------------------------
This adds special code to handle unit tests in CRM/Sms/Provider.php for a provider with name "testSmsProvider".  The core code expects ALL SMS providers to be extensions, the unit test one is not and we would get a fatal error if we didn't modify core here.

Comments
----------------------------------------
Some variables renamed, function cleanup, more CRM_Core_Pseudoconstant.  Unit test should be run before applying the rest of the changes and again afterwards to demonstrate there are no changes.

---

 * [CRM-21037: Add unit tests for Activity sendSMS functions](https://issues.civicrm.org/jira/browse/CRM-21037)