### PR TITLE
CRM-21133: Price set error with NULL financial types

### DIFF
--- a/CRM/Core/Page/AJAX.php
+++ b/CRM/Core/Page/AJAX.php
@@ -113,8 +113,9 @@ class CRM_Core_Page_AJAX {
         $sql = "UPDATE
           civicrm_price_set cps
           INNER JOIN civicrm_discount cd ON cd.price_set_id = cps.id
-          SET cps.is_quick_config = 0
-          WHERE cd.entity_id = (%1) AND cd.entity_table = 'civicrm_event' ";
+          INNER JOIN civicrm_event ce ON cd.entity_id = ce.id AND cd.entity_table = 'civicrm_event'
+          SET cps.is_quick_config = 0, cps.financial_type_id = IF(cps.financial_type_id IS NULL, ce.financial_type_id, cps.financial_type_id)
+          WHERE cd.entity_id = (%1) ";
         $params = array(1 => array($id, 'Integer'));
         CRM_Core_DAO::executeQuery($sql, $params);
         CRM_Core_BAO_Discount::del($id, $context);


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate bug:
1. On a new site, go to the default rain forest event
2. on amount tab convert to price set
3. note that the price set is still not visible on manage event amount tab
4. check civicrm_price_set.financial_type_id & see no valuel.

Before
----------------------------------------
_Coverting a non-quick config price-options into Price Set under Event's fee section result redirects you to Manage price set page to edit the coverted Price set. But when you revisit the fee-section the price-set is no longer there. Underlying cause for this bug is price_set.financial_type is sets to NULL_

After
----------------------------------------
_After the fix the covereted price-set picks up the financial type of related event and now price-set field is visible under Event's Fee section_

---

 * [CRM-21133: Price set error with NULL financial types ](https://issues.civicrm.org/jira/browse/CRM-21133)