### PR TITLE
CRM-21155 - Hook batchItems does not change the csv export

### DIFF
--- a/CRM/Financial/BAO/ExportFormat/CSV.php
+++ b/CRM/Financial/BAO/ExportFormat/CSV.php
@@ -231,8 +231,8 @@ class CRM_Financial_BAO_ExportFormat_CSV extends CRM_Financial_BAO_ExportFormat 
 
       CRM_Utils_Hook::batchItems($queryResults, $batchItems);
 
-      $financialItems['headers'] = self::formatHeaders($financialItems);
-      self::export($financialItems);
+      $batchItems['headers'] = self::formatHeaders($batchItems);
+      self::export($batchItems);
     }
     parent::initiateDownload();
   }

--- a/CRM/Financial/BAO/ExportFormat/CSV.php
+++ b/CRM/Financial/BAO/ExportFormat/CSV.php
@@ -182,7 +182,6 @@ class CRM_Financial_BAO_ExportFormat_CSV extends CRM_Financial_BAO_ExportFormat 
       $financialItems = array();
       $this->_batchIds = $batchId;
 
-      $batchItems = array();
       $queryResults = array();
 
       while ($dao->fetch()) {
@@ -225,14 +224,13 @@ class CRM_Financial_BAO_ExportFormat_CSV extends CRM_Financial_BAO_ExportFormat 
         );
 
         end($financialItems);
-        $batchItems[] = &$financialItems[key($financialItems)];
         $queryResults[] = get_object_vars($dao);
       }
 
-      CRM_Utils_Hook::batchItems($queryResults, $batchItems);
+      CRM_Utils_Hook::batchItems($queryResults, $financialItems);
 
-      $batchItems['headers'] = self::formatHeaders($batchItems);
-      self::export($batchItems);
+      $financialItems['headers'] = self::formatHeaders($financialItems);
+      self::export($financialItems);
     }
     parent::initiateDownload();
   }


### PR DESCRIPTION
Change to use results of hook when exporting.

Overview
----------------------------------------
_A brief description of the pull request. Try to keep it non-technical._

Before
----------------------------------------
_The current status. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._

After
----------------------------------------
_What has been changed. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._

Technical Details
----------------------------------------
_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_

Comments
----------------------------------------
@ErikHommel was too busy drinking warm beer to fill in the pr template
Not anymore, he had been busy for too long drinking warm beer

---

 * [CRM-21155: Hook batchItems does not change the csv export](https://issues.civicrm.org/jira/browse/CRM-21155)