### PR TITLE
Fixing type (missing function call) in example for hook_civicrm_alterAngular

### DIFF
--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2133,7 +2133,7 @@ abstract class CRM_Utils_Hook {
    *
    * @code
    * function example_civicrm_alterAngular($angular) {
-   *   $changeSet = \Civi\Angular\ChangeSetChangeSet::create('mychanges')
+   *   $changeSet = \Civi\Angular\ChangeSet::create('mychanges')
    *     ->alterHtml('~/crmMailing/EditMailingCtrl/2step.html', function(phpQueryObject $doc) {
    *       $doc->find('[ng-form="crmMailingSubform"]')->attr('cat-stevens', 'ts(\'wild world\')');
    *     })

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2138,6 +2138,7 @@ abstract class CRM_Utils_Hook {
    *       $doc->find('[ng-form="crmMailingSubform"]')->attr('cat-stevens', 'ts(\'wild world\')');
    *     })
    *   );
+   *   $angular->add($changeSet);
    * }
    * @endCode
    */

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2133,7 +2133,7 @@ abstract class CRM_Utils_Hook {
    *
    * @code
    * function example_civicrm_alterAngular($angular) {
-   *   $angular->add(ChangeSet::create('mychanges')
+   *   $angular->add(\Civi\Angular\ChangeSetChangeSet::create('mychanges')
    *     ->alterHtml('~/crmMailing/EditMailingCtrl/2step.html', function(phpQueryObject $doc) {
    *       $doc->find('[ng-form="crmMailingSubform"]')->attr('cat-stevens', 'ts(\'wild world\')');
    *     })

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2133,7 +2133,7 @@ abstract class CRM_Utils_Hook {
    *
    * @code
    * function example_civicrm_alterAngular($angular) {
-   *   $angular->add(\Civi\Angular\ChangeSetChangeSet::create('mychanges')
+   *   $changeSet = \Civi\Angular\ChangeSetChangeSet::create('mychanges')
    *     ->alterHtml('~/crmMailing/EditMailingCtrl/2step.html', function(phpQueryObject $doc) {
    *       $doc->find('[ng-form="crmMailingSubform"]')->attr('cat-stevens', 'ts(\'wild world\')');
    *     })


### PR DESCRIPTION
I followed the example code. It didn't work. I found [another example that did work](https://github.com/civicrm/civicrm-core/pull/10085), so I am updating this example.