### PR TITLE
Correct spelling.

### DIFF
--- a/CRM/Core/BAO/Setting.php
+++ b/CRM/Core/BAO/Setting.php
@@ -200,7 +200,7 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
 
     foreach ($fieldsToSet as $settingField => &$settingValue) {
       if (empty($fields['values'][$settingField])) {
-        Civi::log()->warning('Deprcated Path There is a setting (' . $settingField . ') not correctly defined. You may see unpredictabilitiy due to this, CRM_Core_Setting::setItems', array('civi.tag' => 'deprecated'));
+        Civi::log()->warning('Deprecated Path: There is a setting (' . $settingField . ') not correctly defined. You may see unpredictability due to this. CRM_Core_Setting::setItems', array('civi.tag' => 'deprecated'));
         $fields['values'][$settingField] = array();
       }
       self::validateSetting($settingValue, $fields['values'][$settingField]);


### PR DESCRIPTION
Spelling in warning message.

CRM-20962

---

 * [CRM-20962: Issue in api_v3_SettingTest where string being used but needs to be array for php7.1](https://issues.civicrm.org/jira/browse/CRM-20962)