### PR TITLE
CRM-21162: Case start/end date should be of type datetime.

### DIFF
--- a/xml/schema/Case/Case.xml
+++ b/xml/schema/Case/Case.xml
@@ -129,7 +129,7 @@
     <uniqueName>case_start_date</uniqueName>
     <title>Case Start Date</title>
     <import>true</import>
-    <type>date</type>
+    <type>datetime</type>
     <comment>Date on which given case starts.</comment>
     <html>
       <type>Select Date</type>
@@ -141,7 +141,7 @@
     <uniqueName>case_end_date</uniqueName>
     <title>Case End Date</title>
     <import>true</import>
-    <type>date</type>
+    <type>datetime</type>
     <comment>Date on which given case ends.</comment>
     <html>
       <type>Select Date</type>


### PR DESCRIPTION
Overview
----------------------------------------
This patch changes the Case metadata for field definitions so that the start_date and end_date fields use the `datetime` format, instead of just `date`.

Before
----------------------------------------

![civicrm-case-create-time](https://user-images.githubusercontent.com/254741/30221759-93f7f42e-9492-11e7-913d-196aab5bf9ec.jpg)

After
----------------------------------------

The date time is not truncated.

Technical Details
----------------------------------------

In api/v3/utils.php, _civicrm_api3_getValidDate() checks the field type, and according to the XML, the type is 'date' instead of 'datetime', so getValidDate will use `Ymd000000` instead of `YmdHis`.

Comments
----------------------------------------

After applying the patch, I also tested creating a new case from the UI, and editing the start date.

---

 * [CRM-21162: Case.create API truncates the start_date time](https://issues.civicrm.org/jira/browse/CRM-21162)