### PR TITLE
CRM-21164 membership inheritance co-opted

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1851,7 +1851,21 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = membership.contact_id AND 
     $currentMembership = CRM_Member_BAO_Membership::getContactMembership($contactID, $membershipTypeID,
       $is_test, $membershipID, TRUE
     );
+
+    // CRM-21164 check if existing membership is inherited and new membership type does not support one
+    $membershipDifferentOwner = FALSE;
     if ($currentMembership) {
+      $ownerMemberId = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_Membership',
+        $currentMembership['id'],
+        'owner_membership_id', 'id'
+      );
+
+      if ($ownerMemberId && empty($membershipTypeDetails['relationship_type_id'])) {
+        $membershipDifferentOwner = TRUE;
+      }
+    }
+
+    if ($currentMembership && !$membershipDifferentOwner) {
       $renewalMode = TRUE;
 
       // Do NOT do anything.


### PR DESCRIPTION
Overview
----------------------------------------
Check if existing membership and renewing membership have the same owner before renewing.

Before
----------------------------------------
An existing inherited membership could be co-opted by a new membership that does not support inheritance.

After
----------------------------------------
A new membership will be created if this condition is found.

Comments
----------------------------------------
It may be worth discussing if this check should be broader in scope. It currently is geared toward a specific use case.

---

 * [CRM-21164: inherited membership co-opted by new signup](https://issues.civicrm.org/jira/browse/CRM-21164)