### PR TITLE
CRM-21165 - Fix uf_baseurl in installer for Pantheon

### DIFF
--- a/install/civicrm.php
+++ b/install/civicrm.php
@@ -305,14 +305,17 @@ function civicrm_cms_base() {
     $url = 'http://' . $_SERVER['HTTP_HOST'];
   }
 
-  $baseURL = $_SERVER['SCRIPT_NAME'];
+  $baseURL = str_replace('//', '/', $_SERVER['SCRIPT_NAME']);
 
   if ($installType == 'drupal' || $installType == 'backdrop') {
     //don't assume 6 dir levels, as civicrm
     //may or may not be in sites/all/modules/
     //lets allow to install in custom dir. CRM-6840
     global $cmsPath;
-    $crmDirLevels = str_replace($cmsPath, '', str_replace('\\', '/', $_SERVER['SCRIPT_FILENAME']));
+
+    // Clean up the filepath.
+    $script_filename = str_replace('//', '/', $_SERVER['SCRIPT_FILENAME']);
+    $crmDirLevels = str_replace($cmsPath, '', str_replace('\\', '/', $script_filename));
     $baseURL = str_replace($crmDirLevels, '', str_replace('\\', '/', $baseURL));
   }
   elseif ($installType == 'wordpress') {


### PR DESCRIPTION
Overview
----------------------------------------
When installing CiviCRM on Pantheon, instead of using the base url such as https://www.MYWEBSITE.org it is writing the path to the installer https://www.MYWEBSITE.org/profiles/civicrm_starterkit/modules/civicrm/install/index.php/ to CIVICRM_UF_BASEURL which is incorrect.

Addresses https://issues.civicrm.org/jira/browse/CRM-21165

Before
----------------------------------------
When installing CiviCRM on Pantheon the installer is writing the install path https://www.MYWEBSITE.org/profiles/civicrm_starterkit/modules/civicrm/install/index.php/ to CIVICRM_UF_BASEURL

After
----------------------------------------
CIVICRM_UF_BASEURL is like https://www.MYWEBSITE.org

Technical Details
----------------------------------------
_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
