### PR TITLE
CRM-21169 - Fix broken inline edit for profiles

### DIFF
--- a/js/view/crm.designer.js
+++ b/js/view/crm.designer.js
@@ -376,7 +376,7 @@
       }).bind('loaded.jstree', function () {
         $('.crm-designer-palette-field', this).draggable({
           appendTo: '.crm-designer',
-          zIndex: $(this.$el).zIndex() + 5000,
+          zIndex: $(this.$el).css("zIndex") + 5000,
           helper: 'clone',
           connectToSortable: '.crm-designer-fields' // FIXME: tight canvas/palette coupling
         });


### PR DESCRIPTION
Overview
----------------------------------------
Drag and drop UI for profiles is rendered useless because of this


Before
----------------------------------------
![civi_profile](https://user-images.githubusercontent.com/3455173/30260307-37a245ea-96e4-11e7-8342-058a467f4801.png)

After
----------------------------------------
You should now be able to drag and drop the fields.
![civi_after_patch](https://user-images.githubusercontent.com/3455173/30260311-3dc46386-96e4-11e7-8ca6-4b5b56d761d2.png)

---

 * [CRM-21169: Fix broken inline edit for profiles](https://issues.civicrm.org/jira/browse/CRM-21169)