### PR TITLE
CRM-20892 Create Opportunistic locking mechanism in the CiviMail API…

### DIFF
--- a/ang/crmMailing/services.js
+++ b/ang/crmMailing/services.js
@@ -277,6 +277,7 @@
           });
           delete params.recipients; // the content was merged in
           return qApi('Mailing', 'create', params).then(function(result) {
+            mailing.modified_date = result.values[result.id].modified_date;
             // changes rolled back, so we don't care about updating mailing
             return result.values[result.id]['api.Mailing.preview'].values;
           });
@@ -304,6 +305,7 @@
         delete params.recipients; // the content was merged in
         return qApi('Mailing', 'create', params).then(function (recipResult) {
           // changes rolled back, so we don't care about updating mailing
+          mailing.modified_date = recipResult.values[recipResult.id].modified_date;
           return recipResult.values[recipResult.id]['api.MailingRecipients.get'].values;
         });
       },
@@ -323,6 +325,7 @@
         delete params.recipients; // the content was merged in
         return qApi('Mailing', 'create', params).then(function (recipResult) {
           // changes rolled back, so we don't care about updating mailing
+          mailing.modified_date = recipResult.values[recipResult.id].modified_date;
           return recipResult.values[recipResult.id]['api.MailingRecipients.getcount'];
         });
       },
@@ -354,6 +357,7 @@
             mailing.id = result.id;
           }  // no rollback, so update mailing.id
           // Perhaps we should reload mailing based on result?
+          mailing.modified_date = result.values[result.id].modified_date;
           return mailing;
         });
       },
@@ -405,6 +409,7 @@
           if (result.id && !mailing.id) {
             mailing.id = result.id;
           }  // no rollback, so update mailing.id
+          mailing.modified_date = result.values[result.id].modified_date;
           return result.values[result.id]['api.Mailing.send_test'].values;
         });
       }

--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -67,7 +67,7 @@ function civicrm_api3_mailing_create($params) {
     $safeParams = $params;
   }
   $timestampCheck = TRUE;
-  if (!empty($params['id'])) {
+  if (!empty($params['id']) && !empty($params['modified_date'])) {
     $timestampCheck = _civicrm_api3_compare_timestamps($safeParams['modified_date'], $safeParams['id'], 'Mailing');
     unset($safeParams['modified_date']);
   }

--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -74,11 +74,9 @@ function civicrm_api3_mailing_create($params) {
   if (!$timestampCheck) {
     throw new API_Exception("Mailing has not been saved, Content maybe out of date, please refresh the page and try again");
   }
-  else {
-    $safeParams['_evil_bao_validator_'] = 'CRM_Mailing_BAO_Mailing::checkSendable';
-    $result = _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $safeParams);
-    return _civicrm_api3_mailing_get_formatResult($result);
-  }
+  $safeParams['_evil_bao_validator_'] = 'CRM_Mailing_BAO_Mailing::checkSendable';
+  $result = _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $safeParams);
+  return _civicrm_api3_mailing_get_formatResult($result);
 }
 
 /**

--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -66,10 +66,19 @@ function civicrm_api3_mailing_create($params) {
   else {
     $safeParams = $params;
   }
-  $safeParams['_evil_bao_validator_'] = 'CRM_Mailing_BAO_Mailing::checkSendable';
-  $result = _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $safeParams);
-  return _civicrm_api3_mailing_get_formatResult($result);
-
+  $timestampCheck = TRUE;
+  if (!empty($params['id'])) {
+    $timestampCheck = _civicrm_api3_compare_timestamps($safeParams['modified_date'], $safeParams['id'], 'Mailing');
+    unset($safeParams['modified_date']);
+  }
+  if (!$timestampCheck) {
+    throw new API_Exception("Mailing has not been saved, Content maybe out of date, please refresh the page and try again");
+  }
+  else {
+    $safeParams['_evil_bao_validator_'] = 'CRM_Mailing_BAO_Mailing::checkSendable';
+    $result = _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $safeParams);
+    return _civicrm_api3_mailing_get_formatResult($result);
+  }
 }
 
 /**

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -2504,3 +2504,20 @@ function _civicrm_api3_check_edit_permissions($bao_name, $params) {
     }
   }
 }
+
+/**
+ * Check if an entity has been modified since the last known modified_date
+ * @param string $modifiedDate Last knowm modified_date
+ * @param int $id Id of record to check
+ * @param string $entity API Entity
+ * @return bool
+ */
+function _civicrm_api3_compare_timestamps($modifiedDate, $id, $entity) {
+  $currentDbInfo = civicrm_api3($entity, 'getsingle', array('id' => $id));
+  drupal_set_message(json_encode(strtotime($currentDbInfo['modified_date'])));
+  drupal_set_message(json_encode(strtotime($modifiedDate)));
+  if (strtotime($currentDbInfo['modified_date']) <= strtotime($modifiedDate)) {
+    return TRUE;
+  }
+  return FALSE;
+}

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -2514,8 +2514,6 @@ function _civicrm_api3_check_edit_permissions($bao_name, $params) {
  */
 function _civicrm_api3_compare_timestamps($modifiedDate, $id, $entity) {
   $currentDbInfo = civicrm_api3($entity, 'getsingle', array('id' => $id));
-  drupal_set_message(json_encode(strtotime($currentDbInfo['modified_date'])));
-  drupal_set_message(json_encode(strtotime($modifiedDate)));
   if (strtotime($currentDbInfo['modified_date']) <= strtotime($modifiedDate)) {
     return TRUE;
   }

--- a/tests/phpunit/api/v3/MailingTest.php
+++ b/tests/phpunit/api/v3/MailingTest.php
@@ -879,4 +879,18 @@ SELECT event_queue_id, time_stamp FROM mail_{$type}_temp";
     $this->assertContains($unicodeURL, $url);
   }
 
+  /**
+   * CRM-20892 : Test if Mail.create API throws error on update,
+   *  if modified_date less then the date when the mail was last updated/created
+   */
+  public function testModifiedDateMismatchOnMailingUpdate() {
+    $mail = $this->callAPISuccess('mailing', 'create', $this->_params + array('modified_date' => 'now'));
+    try {
+      $this->callAPISuccess('mailing', 'create', $this->_params + array('id' => $mail['id'], 'modified_date' => '2 seconds ago'));
+    }
+    catch (Exception $e) {
+      $this->assertRegExp("/Failure in api call for mailing create:  Mailing has not been saved, Content maybe out of date, please refresh the page and try again/", $e->getMessage());
+    }
+  }
+
 }

--- a/tests/phpunit/api/v3/UtilsTest.php
+++ b/tests/phpunit/api/v3/UtilsTest.php
@@ -432,4 +432,15 @@ class api_v3_UtilsTest extends CiviUnitTestCase {
     ), $r3['values']);
   }
 
+  /**
+   * CRM-20892 Add Tests of new timestamp checking function
+   */
+  public function testTimeStampChecking() {
+    CRM_Core_DAO::executeQuery("INSERT INTO civicrm_mailing (id, modified_date) VALUES (25, '2016-06-30 12:52:52')");
+    $this->assertTrue(_civicrm_api3_compare_timestamps('2017-02-15 16:00:00', 25, 'Mailing'));
+    $this->callAPISuccess('Mailing', 'create', array('id' => 25, 'subject' => 'Test Subject'));
+    $this->assertFalse(_civicrm_api3_compare_timestamps('2017-02-15 16:00:00', 25, 'Mailing'));
+    $this->callAPISuccess('Mailing', 'delete', array('id' => 25));
+  }
+
 }


### PR DESCRIPTION
… and angular content to ensure that if content is editied in a separate tab it alerts the user

Overview
----------------------------------------
Previously CiviCRM Mailings could be edited from multiple tabs at the same time and Users wouldn't have any indication that the content may have changed. Now there is a check to see if the Mailing has become out of date and Alerts the user.

Before
----------------------------------------
Mailing could be edited in multiple tabs by different people without no notice

After
----------------------------------------
Message is displayed if the database has been altered since the mailing was last saved from that specific window

Technical Details
----------------------------------------
This adds opportunistic locking using the API. This is pedant on the PR https://github.com/civicrm/civicrm-core/pull/10953 

Comments
----------------------------------------
@JKingsnorth @eileenmcnaughton @totten @awzilkie I believe this will solve the problem in just a similar method to what was being proposed in #10864 However using the modifed_date which is added via PR #10953 

This also resolves a concern that was raised by Tim by not using Javascript time and dates and just uses information gained from the DAO. 
