### PR TITLE
CRM-21171 - Cron failing on Update Membership Statuses and Send Renew…

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -630,6 +630,11 @@ INNER JOIN  civicrm_membership_type type ON ( type.id = membership.membership_ty
     $memValues = array();
     $memberships = self::getValues($params, $memValues);
 
+    // check membership exists before deleting it
+    if (empty($memberships[$membershipId])) {
+      return;
+    }
+
     $membership = $memberships[$membershipId];
 
     CRM_Utils_Hook::pre('delete', 'Membership', $membershipId, $memValues);


### PR DESCRIPTION
…al Reminders

Overview
----------------------------------------
Encountered this error PHP Fatal error: Call to a member function delete() on null in /var/www/html/civicrm-stable-4.7/CRM/Member/BAO/Membership.php on line 665 caused by a membership-related scheduled job. 
Also refer: https://civicrm.stackexchange.com/questions/19219/cron-failing-on-update-membership-statuses-and-send-renewal-reminders

