### PR TITLE
CRM-20276, fixed code to store correct value in financial item table …

### DIFF
--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -1185,9 +1185,8 @@ Price Field - Price Field 1        1   $ 100.00      $ 100.00
 
     $this->assertEquals(100, $items['values'][0]['amount']);
     $this->assertEquals(10, $items['values'][1]['amount']);
-    // @todo currently its $110 which is incorrect, the proper value should be $200
-    // $this->assertEquals(200, $items['values'][2]['amount']);
-    $this->assertEquals(20, $items['values'][3]['amount']);
+    $this->assertEquals(100, $items['values'][2]['amount']);
+    $this->assertEquals(10, $items['values'][3]['amount']);
   }
 
   /**


### PR DESCRIPTION
…for amount when contribution amount is changed

----------------------------------------
* CRM-20276: When editing a contribution the value in civicrm_financial_item_amount is not updated
  https://issues.civicrm.org/jira/browse/CRM-20276

Overview
----------------------------------------
This PR fixes the code for storing amount in financial item when there is change in contribution with tax. 

Before
----------------------------------------
SS for db entries

civicrm_financial_trxn
![beforeft](https://user-images.githubusercontent.com/2053075/30276445-81c2cb66-9722-11e7-9aaf-c48134a96e84.png)

civicrm_financial_item
![beforefi](https://user-images.githubusercontent.com/2053075/30276456-88ba2374-9722-11e7-95ee-e6a51416e6b3.png)

civicrm_entity_financial_trxn
![beforeeft](https://user-images.githubusercontent.com/2053075/30276462-90421cd2-9722-11e7-8948-ce0b2cab3c30.png)

After
----------------------------------------

civicrm_financial_trxn
![afterft](https://user-images.githubusercontent.com/2053075/30276473-970caf46-9722-11e7-948a-c8824b935554.png)

civicrm_financial_item
![afterfi](https://user-images.githubusercontent.com/2053075/30276483-9edb5420-9722-11e7-98d7-a93722a06227.png)

civicrm_entity_financial_trxn
![aftereft](https://user-images.githubusercontent.com/2053075/30276495-a54486d8-9722-11e7-85ba-e250f59a5180.png)

