### PR TITLE
CRM-18231 - Cleanup `environment` example in `civicrm.settings.php.template`

### DIFF
--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -28,6 +28,7 @@
 /**
  * CiviCRM Configuration File.
  */
+global $civicrm_setting;
 
 /**
  * Content Management System (CMS) Host:
@@ -221,8 +222,6 @@ if (!defined('CIVICRM_UF_BASEURL')) {
  *
  * Uncomment and edit the below as appropriate.
  */
- // Add this line only once above any settings overrides.
- //  global $civicrm_setting;
 
  // Override the Temporary Files directory.
  // $civicrm_setting['Directory Preferences']['uploadDir'] = '/path/to/upload-dir' ;

--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -316,7 +316,7 @@ if (!defined('CIVICRM_DOMAIN_ID')) {
  * NB: defining a value for environment here prevents it from being set
  * via the browser. 
  */ 
-// $civicrm_setting[CRM_Core_BAO_Setting::DEVELOPER_PREFERENCES_NAME]['environment'] = 'Production'; 
+// $civicrm_setting['domain']['environment'] = 'Production'; 
 
 /**
  * Settings to enable external caching using a cache server.  This is an

--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -307,15 +307,15 @@ if (!defined('CIVICRM_DOMAIN_ID')) {
   define( 'CIVICRM_DOMAIN_ID', 1);
 }
 
-/** 
- * Setting to define the environment in which this CiviCRM instance is running. 
- * Note the setting here must be value from the option group 'Environment', 
- * (see Administration > System Settings > Option Groups, Options beside Environment) 
- * which by default has three option values: 'Production', 'Staging', 'Development'. 
+/**
+ * Setting to define the environment in which this CiviCRM instance is running.
+ * Note the setting here must be value from the option group 'Environment',
+ * (see Administration > System Settings > Option Groups, Options beside Environment)
+ * which by default has three option values: 'Production', 'Staging', 'Development'.
  * NB: defining a value for environment here prevents it from being set
- * via the browser. 
- */ 
-// $civicrm_setting['domain']['environment'] = 'Production'; 
+ * via the browser.
+ */
+// $civicrm_setting['domain']['environment'] = 'Production';
 
 /**
  * Settings to enable external caching using a cache server.  This is an


### PR DESCRIPTION
Overview
----------------------------------------
Update the `environment` example in `civicrm.settings.php.template`.

Before
----------------------------------------
 * If you uncomment and tweak the example `environment`, it crashes -- because class-constants don't make sense in this context.
 * If you fix that, then the setting still doesn't take effect -- because you need to uncomment the `global $civicrm_setting` declaration.

After
----------------------------------------
 * If you uncomment and tweak the example `environment`, it works.

Technical Details
----------------------------------------
To test this, I would iteratively edit the config file and then run

```
cv ev 'return [Civi::settings()->get("environment"), CRM_Core_Config::environment()];'
```

Ping @seamuslee001 @monishdeb @eileenmcnaughton .

---

 * [CRM-18231: Support safe migration from production to non-production instances](https://issues.civicrm.org/jira/browse/CRM-18231)