### PR TITLE
CRM-21174: Do not try to write civicrm_menu.module_data if it doesn't exist yet

### DIFF
--- a/CRM/Core/Menu.php
+++ b/CRM/Core/Menu.php
@@ -329,9 +329,10 @@ class CRM_Core_Menu {
           }
         }
 
-        $menu->copyValues($item);
         $menu->module_data = serialize($module_data);
       }
+
+      $menu->copyValues($item);
 
       foreach (self::$_serializedElements as $element) {
         if (!isset($item[$element]) ||

--- a/CRM/Core/Menu.php
+++ b/CRM/Core/Menu.php
@@ -317,17 +317,21 @@ class CRM_Core_Menu {
 
       $menu->find(TRUE);
 
-      // Move unrecognized fields to $module_data.
-      $module_data = array();
-      foreach (array_keys($item) as $key) {
-        if (!isset($daoFields[$key])) {
-          $module_data[$key] = $item[$key];
-          unset($item[$key]);
+      if (!CRM_Core_Config::isUpgradeMode() ||
+        CRM_Core_DAO::checkFieldExists('civicrm_menu', 'module_data', FALSE)
+      ) {
+        // Move unrecognized fields to $module_data.
+        $module_data = array();
+        foreach (array_keys($item) as $key) {
+          if (!isset($daoFields[$key])) {
+            $module_data[$key] = $item[$key];
+            unset($item[$key]);
+          }
         }
-      }
 
-      $menu->copyValues($item);
-      $menu->module_data = serialize($module_data);
+        $menu->copyValues($item);
+        $menu->module_data = serialize($module_data);
+      }
 
       foreach (self::$_serializedElements as $element) {
         if (!isset($item[$element]) ||


### PR DESCRIPTION
Overview
----------------------------------------
Fix circular dependency during upgrade regarding introduction of `module_data` column to `civicrm_menu`.

Before
----------------------------------------
Upgrade via browser gives this message: 

> DB Error: no such field

After
----------------------------------------
Civi does not attempt to write to the `civicrm_menu.module_data` column during upgrade unless it already exists. The particular approach was recommended by @totten.

---

 * [CRM-21174: Circular dependency during upgrade: civicrm_menu.module_data](https://issues.civicrm.org/jira/browse/CRM-21174)