### PR TITLE
CRM-21175 fix fatal error on multiple custom field import.

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -1147,8 +1147,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
    * @param null $relationships
    */
   public static function isErrorInCustomData($params, &$errorMessage, $csType = NULL, $relationships = NULL) {
-    $session = CRM_Core_Session::singleton();
-    $dateType = $session->get("dateTypes");
+    $dateType = CRM_Core_Session::singleton()->get("dateTypes");
 
     if (!empty($params['contact_sub_type'])) {
       $csType = CRM_Utils_Array::value('contact_sub_type', $params);

--- a/CRM/Core/BAO/Mapping.php
+++ b/CRM/Core/BAO/Mapping.php
@@ -131,6 +131,40 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping {
   }
 
   /**
+   * Get the mappings array, creating if it does not exist.
+   *
+   * @param string $mappingType
+   *   Mapping type name.
+   *
+   * @return array
+   *   Array of mapping names, keyed by id.
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  public static function getCreateMappingValues($mappingType) {
+    try {
+      return CRM_Core_BAO_Mapping::getMappings($mappingType);
+    }
+    catch (CiviCRM_API3_Exception $e) {
+      // Having a valid mapping_type_id is now enforced. However, rather than error let's
+      // add it. This is required for Multi value which could be done by upgrade script, but
+      // it feels like there could be other instances so this is safer.
+      $errorParams = $e->getExtraParams();
+      if ($errorParams['error_field'] === 'mapping_type_id') {
+        $mappingValues = civicrm_api3('Mapping', 'getoptions', array('field' => 'mapping_type_id'));
+        civicrm_api3('OptionValue', 'create', array(
+          'option_group_id' => 'mapping_type',
+          'label' => $mappingType,
+          'value' => max(array_keys($mappingValues['values'])) + 1,
+          'is_reserved' => 1,
+        ));
+        return CRM_Core_BAO_Mapping::getMappings($mappingType);
+      }
+      throw $e;
+    }
+  }
+
+  /**
    * Get the mapping fields.
    *
    * @param int $mappingId

--- a/CRM/Import/Form/DataSource.php
+++ b/CRM/Import/Form/DataSource.php
@@ -79,9 +79,8 @@ abstract class CRM_Import_Form_DataSource extends CRM_Core_Form {
 
     $this->add('text', 'fieldSeparator', ts('Import Field Separator'), array('size' => 2), TRUE);
     $this->setDefaults(array('fieldSeparator' => $config->fieldSeparator));
+    $mappingArray = CRM_Core_BAO_Mapping::getCreateMappingValues('Import ' . static::IMPORT_ENTITY);
 
-    //get the saved mapping details
-    $mappingArray = CRM_Core_BAO_Mapping::getMappings('Import ' . static::IMPORT_ENTITY);
     $this->assign('savedMapping', $mappingArray);
     $this->add('select', 'savedMapping', ts('Mapping Option'), array('' => ts('- select -')) + $mappingArray);
 

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -303,6 +303,20 @@ class CRM_Contact_Imports_Parser_ContactTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test the determination of whether a custom field is valid.
+   */
+  public function testCustomFieldValidation() {
+    $errorMessage = array();
+    $customGroup = $this->customGroupCreate(array('extends' => 'Contact', 'title' => 'ABC'));
+    $customField = $this->customFieldOptionValueCreate($customGroup, 'fieldABC', array('html_type' => 'Multi-Select'));
+    $params = array(
+      'custom_' . $customField['id'] => 'Label1|Label2',
+    );
+    CRM_Contact_Import_Parser_Contact::isErrorInCustomData($params, $errorMessage);
+    $this->assertEquals(array(), $errorMessage);
+  }
+
+  /**
    * Run the import parser.
    *
    * @param array $originalValues

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -2431,10 +2431,12 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
    * @param array $customGroup
    * @param string $name
    *   Name of custom field.
+   * @param array $extraParams
+   *   Additional parameters to pass through.
    *
    * @return array|int
    */
-  public function customFieldOptionValueCreate($customGroup, $name) {
+  public function customFieldOptionValueCreate($customGroup, $name, $extraParams = array()) {
     $fieldParams = array(
       'custom_group_id' => $customGroup['id'],
       'name' => 'test_custom_group',
@@ -2461,7 +2463,7 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
       'option_status' => 1,
     );
 
-    $params = array_merge($fieldParams, $optionGroup, $optionValue);
+    $params = array_merge($fieldParams, $optionGroup, $optionValue, $extraParams);
 
     return $this->callAPISuccess('custom_field', 'create', $params);
   }


### PR DESCRIPTION
Additional test is tangental....

Overview
----------------------------------------
Fixes fatal error on attempting to import multiple custom data values

Before
----------------------------------------
civicrm/import/custom returns CiviCRM_API3_Exception: "'Import Multi value custom data' is not a valid option for field mapping_type_id"

After
----------------------------------------
Page loads correctly

Technical Details
----------------------------------------
Recent changes caused this to go from silent weird behaviour to a hard fail. I have gone with an ad-hoc creating of the option rather than in import in case other imports (including external) are impacted.

---

 * [CRM-21175: Fatal error on multiple custom field import](https://issues.civicrm.org/jira/browse/CRM-21175)