### PR TITLE
CRM-21160 - Make event_type_id available in event message templates

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1532,7 +1532,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       $this->assign('module', 'Event Registration');
       //use of the message template below requires variables in different format
       $event = $events = array();
-      $returnProperties = array('fee_label', 'start_date', 'end_date', 'is_show_location', 'title');
+      $returnProperties = array('event_type_id', 'fee_label', 'start_date', 'end_date', 'is_show_location', 'title');
 
       //get all event details.
       CRM_Core_DAO::commonRetrieveAll('CRM_Event_DAO_Event', 'id', $params['event_id'], $events, $returnProperties);


### PR DESCRIPTION
Overview
----------------------------------------
Expose `$event.event_type_id` in offline participant mail.

Before
----------------------------------------
`$event.event_type_id` in `event_offline_receipt` is not calculated.

After
----------------------------------------
`$event.event_type_id` can be used as a token in offline receipt for participant.

Comments
----------------------------------------
Added unit test.

---

 * [CRM-21160: Make event_type_id available in event message templates.](https://issues.civicrm.org/jira/browse/CRM-21160)