### PR TITLE
CRM-21117: Line item not shown when paying later using membership priceset

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1664,6 +1664,8 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
     $emailValues = array_merge($membershipParams, $form->_values);
     $emailValues['membership_assign'] = 1;
+    $emailValues['useForMember'] = !empty($form->_useForMember);
+
     // Finally send an email receipt for pay-later scenario (although it might sometimes be caught above!)
     if ($totalAmount == 0) {
       // This feels like a bizarre hack as the variable name doesn't seem to be directly connected to it's use in the template.

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -435,6 +435,34 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test submit with a pay later abnd check line item in mails.
+   */
+  public function testSubmitMembershipBlockIsSeparatePaymentPayLaterWithEmail() {
+    $mut = new CiviMailUtils($this, TRUE);
+    $this->setUpMembershipContributionPage();
+    $submitParams = array(
+      'price_' . $this->_ids['price_field'][0] => reset($this->_ids['price_field_value']),
+      'id' => (int) $this->_ids['contribution_page'],
+      'amount' => 10,
+      'billing_first_name' => 'Billy',
+      'billing_middle_name' => 'Goat',
+      'billing_last_name' => 'Gruff',
+      'is_pay_later' => 1,
+      'selectMembership' => $this->_ids['membership_type'],
+      'email-Primary' => 'billy-goat@the-bridge.net',
+    );
+
+    $this->callAPISuccess('contribution_page', 'submit', $submitParams);
+    $contribution = $this->callAPISuccess('contribution', 'getsingle', array('contribution_page_id' => $this->_ids['contribution_page']));
+    $this->callAPISuccess('membership_payment', 'getsingle', array('contribution_id' => $contribution['id']));
+    $mut->checkMailLog(array(
+      'Membership Amount -...             $ 2.00',
+    ));
+    $mut->stop();
+    $mut->clearMessages();
+  }
+
+  /**
    * Test submit with a membership block in place.
    */
   public function testSubmitMembershipBlockIsSeparatePayment() {


### PR DESCRIPTION
Overview
----------------------------------------
Line item not shown when paying later using membership priceset.

Before
----------------------------------------
No line item displayed in mails with below steps.

1/ Create a membership priceset with one select and one text field. Add this to a contribution page.
2/ Signup using pay later 
3/ No line item is displayed in invoice received.

After
----------------------------------------
Line items are shown correctly.

Comments
----------------------------------------
Added unit test.

---

 * [CRM-21117: Line item not shown in mails when paying later for membership priceset](https://issues.civicrm.org/jira/browse/CRM-21117)