### PR TITLE
CRM-21183: Updating Partially paid contribution to Completed doesn't …

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -1832,18 +1832,16 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
       }
     }
     elseif ($contributionStatusId == array_search('Completed', $contributionStatuses)) {
-      $pending = array_search('Pending', $contributionStatuses);
-      $partaillyPaid = array_search('Partially paid', $contributionStatuses);
 
       // only pending contribution related object processed.
       if ($previousContriStatusId &&
-        (!in_array($previousContriStatusId, array($pending, $partaillyPaid)))
+        !in_array($contributionStatuses[$previousContriStatusId], array('Pending', 'Partially paid'))
       ) {
         // this is case when we already processed contribution object.
         return $updateResult;
       }
       elseif (!$previousContriStatusId &&
-        (!in_array($contribution->contribution_status_id, array($pending, $partaillyPaid)))
+        !in_array($contributionStatuses[$contribution->contribution_status_id], array('Pending', 'Partially paid'))
       ) {
         // this is case when we are going to process contribution object later.
         return $updateResult;

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -1832,16 +1832,18 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
       }
     }
     elseif ($contributionStatusId == array_search('Completed', $contributionStatuses)) {
+      $pending = array_search('Pending', $contributionStatuses);
+      $partaillyPaid = array_search('Partially paid', $contributionStatuses);
 
       // only pending contribution related object processed.
       if ($previousContriStatusId &&
-        ($previousContriStatusId != array_search('Pending', $contributionStatuses))
+        (!in_array($previousContriStatusId, array($pending, $partaillyPaid)))
       ) {
         // this is case when we already processed contribution object.
         return $updateResult;
       }
       elseif (!$previousContriStatusId &&
-        $contribution->contribution_status_id != array_search('Pending', $contributionStatuses)
+        (!in_array($contribution->contribution_status_id, array($pending, $partaillyPaid)))
       ) {
         // this is case when we are going to process contribution object later.
         return $updateResult;

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -883,7 +883,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
     //Update contribution to Partially paid.
     $prevContribution = $this->callAPISuccess('Contribution', 'create', array(
       'id' => $contribution['contribution_id'],
-      'contribution_status_id' => 8,
+      'contribution_status_id' => 'Partially paid',
     ));
     $prevContribution = $prevContribution['values'][1];
 
@@ -891,7 +891,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
     $form = new CRM_Contribute_Form_Contribution();
     $submitParams = array(
       'id' => $contribution['contribution_id'],
-      'contribution_status_id' => 1,
+      'contribution_status_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed'),
       'price_set_id' => 0,
     );
     $fields = array('total_amount', 'net_amount', 'financial_type_id', 'receive_date', 'contact_id', 'payment_instrument_id');


### PR DESCRIPTION
…update membership

Overview
----------------------------------------
Update membership when contribution is updated from partially paid to completed.

Before
----------------------------------------
Membership is unaffected when related contribution is updated from partially paid to completed.

After
----------------------------------------
Membership is updated to New or its calculated status in above case.

Technical Details
----------------------------------------
Current functionality handles the contribution status switch between `Pending -> Completed`. It should also consider `Partially paid` status.

Comments
----------------------------------------
Unit test added.

---

 * [CRM-21183: Updating Partially paid contribution to Completed doesn't update membership](https://issues.civicrm.org/jira/browse/CRM-21183)