### PR TITLE
API change: CRM-21127 - Fix return properties in api.Event.get

### DIFF
--- a/api/v3/Event.php
+++ b/api/v3/Event.php
@@ -131,16 +131,16 @@ function civicrm_api3_event_get($params) {
   }
 
   $events = _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params, FALSE, 'Event', $sql, TRUE);
-  $options = _civicrm_api3_get_options_from_params($params);
+  $options = _civicrm_api3_get_options_from_params($params, TRUE);
   if ($options['is_count']) {
     return civicrm_api3_create_success($events, $params, 'Event', 'get');
   }
   foreach ($events as $id => $event) {
-    if (!empty($params['return.is_full'])) {
+    if (!empty($options['return']['is_full'])) {
       _civicrm_api3_event_getisfull($events, $id);
     }
     _civicrm_api3_event_get_legacy_support_42($events, $id);
-    if (!empty($options['return'])) {
+    if (!empty($options['return']['price_set_id'])) {
       $events[$id]['price_set_id'] = CRM_Price_BAO_PriceSet::getFor('civicrm_event', $id);
     }
   }


### PR DESCRIPTION
* [CRM-21127: Event API return request params format is partially outdated](https://issues.civicrm.org/jira/browse/CRM-21127)