### PR TITLE
CRM-21178 - Make custom field of type Link clickable

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1266,6 +1266,10 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
         }
         break;
 
+      case 'Link':
+        $display = $display ? "<a href=\"$display\" target=\"_blank\">$display</a>" : $display;
+        break;
+
       case 'TextArea':
         $display = nl2br($display);
         break;


### PR DESCRIPTION
* [CRM-21178: Custom fields of type "Link" are no longer clickable](https://issues.civicrm.org/jira/browse/CRM-21178)