### PR TITLE
CRM-20800 fix fatal error up updating paypal contributions

### DIFF
--- a/CRM/Contribute/Form/UpdateSubscription.php
+++ b/CRM/Contribute/Form/UpdateSubscription.php
@@ -81,11 +81,12 @@ class CRM_Contribute_Form_UpdateSubscription extends CRM_Core_Form {
 
     $this->contributionRecurID = CRM_Utils_Request::retrieve('crid', 'Integer', $this, FALSE);
     if ($this->contributionRecurID) {
-      $this->_paymentProcessor = CRM_Contribute_BAO_ContributionRecur::getPaymentProcessor($this->contributionRecurID);
-      if (!$this->_paymentProcessor) {
+      try {
+        $this->_paymentProcessor = CRM_Financial_BAO_PaymentProcessor::getPaymentProcessorForRecurringContribution($this->contributionRecurID);
+      }
+      catch (CRM_Core_Exception $e) {
         CRM_Core_Error::statusBounce(ts('There is no valid processor for this subscription so it cannot be edited.'));
       }
-      $this->_paymentProcessorObj = $this->_paymentProcessor['object'];
       $this->_subscriptionDetails = CRM_Contribute_BAO_ContributionRecur::getSubscriptionDetails($this->contributionRecurID);
     }
 

--- a/CRM/Contribute/Form/UpdateSubscription.php
+++ b/CRM/Contribute/Form/UpdateSubscription.php
@@ -87,6 +87,7 @@ class CRM_Contribute_Form_UpdateSubscription extends CRM_Core_Form {
       catch (CRM_Core_Exception $e) {
         CRM_Core_Error::statusBounce(ts('There is no valid processor for this subscription so it cannot be edited.'));
       }
+      $this->_paymentProcessorObj = $this->_paymentProcessor['object'];
       $this->_subscriptionDetails = CRM_Contribute_BAO_ContributionRecur::getSubscriptionDetails($this->contributionRecurID);
     }
 

--- a/CRM/Financial/BAO/PaymentProcessor.php
+++ b/CRM/Financial/BAO/PaymentProcessor.php
@@ -508,6 +508,7 @@ INNER JOIN civicrm_contribution       con ON ( mp.contribution_id = con.id )
      WHERE con.id = %1";
     }
     elseif ($component == 'recur') {
+      // @deprecated - use getPaymentProcessorForRecurringContribution.
       $sql = "
     SELECT cr.payment_processor_id as ppID1, NULL as ppID2, cr.is_test
       FROM civicrm_contribution_recur cr
@@ -547,6 +548,21 @@ INNER JOIN civicrm_contribution       con ON ( mp.contribution_id = con.id )
       $result = Civi\Payment\System::singleton()->getByProcessor($paymentProcessor);
     }
     return $result;
+  }
+
+  /**
+   * Get the payment processor associated with a recurring contribution series.
+   *
+   * @param int $contributionRecurID
+   *
+   * @return \CRM_Core_Payment
+   */
+  public static function getPaymentProcessorForRecurringContribution($contributionRecurID) {
+    $paymentProcessorId = civicrm_api3('ContributionRecur', 'getvalue', array(
+      'id' => $contributionRecurID,
+      'return' => 'payment_processor_id',
+    ));
+    return Civi\Payment\System::singleton()->getById($paymentProcessorId);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fix for Paypal cancel link giving fatal errors in some circumstances,



Technical Details
----------------------------------------
I have not been able to replicate this but am hoping the reporter can fix this. The code is an improvement as it is loading the payment processor directly based on the recurring contribution id rather than using an indirect method that we should view as legacy

---

 * [CRM-20800: User Cannot Cancel Recurring Payment With Paypal ](https://issues.civicrm.org/jira/browse/CRM-20800)