### PR TITLE
CRM-21194 - ensure distinct count of clickable URLs works.

### DIFF
--- a/CRM/Mailing/Event/BAO/TrackableURLOpen.php
+++ b/CRM/Mailing/Event/BAO/TrackableURLOpen.php
@@ -144,8 +144,12 @@ class CRM_Mailing_Event_BAO_TrackableURLOpen extends CRM_Mailing_Event_DAO_Track
     $mailing = CRM_Mailing_BAO_Mailing::getTableName();
     $job = CRM_Mailing_BAO_MailingJob::getTableName();
 
+    $distinct = NULL;
+    if ($is_distinct) {
+      $distinct = 'DISTINCT ';
+    }
     $query = "
-            SELECT      COUNT($click.id) as opened
+            SELECT      COUNT($distinct $click.event_queue_id) as opened
             FROM        $click
             INNER JOIN  $queue
                     ON  $click.event_queue_id = $queue.id
@@ -166,10 +170,6 @@ class CRM_Mailing_Event_BAO_TrackableURLOpen extends CRM_Mailing_Event_DAO_Track
 
     if (!empty($url_id)) {
       $query .= " AND $click.trackable_url_id = " . CRM_Utils_Type::escape($url_id, 'Integer');
-    }
-
-    if ($is_distinct) {
-      $query .= " GROUP BY $queue.id ";
     }
 
     // query was missing
@@ -305,9 +305,16 @@ class CRM_Mailing_Event_BAO_TrackableURLOpen extends CRM_Mailing_Event_DAO_Track
     $query = "
             SELECT      $contact.display_name as display_name,
                         $contact.id as contact_id,
-                        $email.email as email,
-                        $click.time_stamp as date,
-                        $url.url as url
+                        $email.email as email,";
+
+    if ($is_distinct) {
+      $query .= "MIN($click.time_stamp) as date,";
+    }
+    else {
+      $query .= "$click.time_stamp as date,";
+    }
+
+    $query .= "$url.url as url
             FROM        $contact
             INNER JOIN  $queue
                     ON  $queue.contact_id = $contact.id
@@ -337,7 +344,7 @@ class CRM_Mailing_Event_BAO_TrackableURLOpen extends CRM_Mailing_Event_DAO_Track
     }
 
     if ($is_distinct) {
-      $query .= " GROUP BY $queue.id, $click.time_stamp, $url.url ";
+      $query .= " GROUP BY $queue.id, $url.url ";
     }
 
     $orderBy = "sort_name ASC, {$click}.time_stamp DESC";

--- a/tests/phpunit/CRM/Mailing/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Mailing/BAO/QueryTest.php
@@ -89,4 +89,27 @@ class CRM_Mailing_BAO_QueryTest extends CiviUnitTestCase {
     $this->assertEquals(4, count($totalOpenedMail));
   }
 
+  /**
+   * CRM-21194: Test accurate count for unique trackable URLs
+   */
+  public function testTrackableUrlMailingQuery() {
+    $op = new PHPUnit_Extensions_Database_Operation_Insert();
+    $op->execute($this->_dbconn,
+      $this->createFlatXMLDataSet(
+        dirname(__FILE__) . '/queryDataset.xml'
+      )
+    );
+
+    // ensure that total unique clicked mail count is same while
+    //   fetching rows and row count for mailing_id = 14 and
+    //   trackable_url_id 12
+    $totalDistinctTrackableUrlCount = CRM_Mailing_Event_BAO_TrackableURLOpen::getTotalCount(14, NULL, TRUE, 13);
+    $totalTrackableUrlCount = CRM_Mailing_Event_BAO_TrackableURLOpen::getTotalCount(14, NULL, FALSE, 13);
+    $totalTrackableUrlMail = CRM_Mailing_Event_BAO_TrackableURLOpen::getRows(14, NULL, TRUE, 13);
+
+    $this->assertEquals(3, $totalDistinctTrackableUrlCount, "Accurately display distinct count of unique trackable URLs");
+    $this->assertEquals(4, $totalTrackableUrlCount, "Accurately display count of unique trackable URLs");
+    $this->assertEquals(3, count($totalTrackableUrlMail), "Accurately display list of unique trackable URLs and who clicked them.");
+  }
+
 }

--- a/tests/phpunit/CRM/Mailing/BAO/queryDataset.xml
+++ b/tests/phpunit/CRM/Mailing/BAO/queryDataset.xml
@@ -12,7 +12,7 @@
   test05  109       n       y       n       n
   test06  110       n       y2      n       y
   test07  111       n       y       y[dc]   n
-  test08  112       n       y       y[c]    y
+  test08  112       n       y       y[c2]   y
 
   Mailing 15: Second Test Mailing Events, 2011-05-26
 
@@ -131,6 +131,7 @@
   <civicrm_mailing_event_trackable_url_open id="8" event_queue_id="51" trackable_url_id="12" time_stamp="2011-05-26 13:21:09"/>
   <civicrm_mailing_event_trackable_url_open id="9" event_queue_id="51" trackable_url_id="13" time_stamp="2011-05-26 13:21:13"/>
   <civicrm_mailing_event_trackable_url_open id="7" event_queue_id="52" trackable_url_id="13" time_stamp="2011-05-26 13:20:03"/>
+  <civicrm_mailing_event_trackable_url_open id="12" event_queue_id="52" trackable_url_id="13" time_stamp="2011-05-27 13:20:03"/>
   <civicrm_mailing_event_trackable_url_open id="10" event_queue_id="55" trackable_url_id="14" time_stamp="2011-05-26 13:23:54"/>
   <civicrm_mailing_event_trackable_url_open id="11" event_queue_id="55" trackable_url_id="15" time_stamp="2011-05-26 13:23:58"/>
 </dataset>


### PR DESCRIPTION
Overview
----------------------------------------
Ensure Mailing Report to display unique URL clicks in a mailing does not show the same person twice.

Before
----------------------------------------
Viewing the Mailing Report link provided in the mailing summary page to view a list of all unique URLs that were clicked displayed links that were clicked more than once by the same contact.

ie clicking on the distinct url in this screen shot

![screenshot 2018-04-16 17 11 28](https://user-images.githubusercontent.com/336308/38791160-3bc2ce7c-419a-11e8-8405-4feceb7079ea.png)

results in duplicate rows
![screenshot 2018-04-16 17 08 39](https://user-images.githubusercontent.com/336308/38791178-57120986-419a-11e8-8dd7-1dc2f0bc540b.png)


After
----------------------------------------
Now, the report only shows each contact/click.
![screenshot 2018-04-16 17 10 13](https://user-images.githubusercontent.com/336308/38791183-5d08197a-419a-11e8-9f44-a4783c4c6d07.png)


Technical Details
----------------------------------------
This is a regression caused by a 'mass-fix' of full full group by 'issues' in an early 4.7 release

https://github.com/civicrm/civicrm-core/pull/9428/files

@jitendrapurohit @monishdeb @lcdservices just an FYI on the regression - I think we have stopped fixing full group by 'bugs' en masse but we are still hitting regressions caused by them - mentioning this because I want to stop fixing full group by issues without a clear strategy - more discussion in #11954

Comments
----------------------------------------
None

---

 * [CRM-21194: Unique clicks in mailing report shows duplicates](https://issues.civicrm.org/jira/browse/CRM-21194)