### PR TITLE
CRM-20907 Ensure that contact_type is valid in deduperules

### DIFF
--- a/CRM/Contact/Form/DedupeRules.php
+++ b/CRM/Contact/Form/DedupeRules.php
@@ -58,7 +58,14 @@ class CRM_Contact_Form_DedupeRules extends CRM_Admin_Form {
     }
     $this->_options = CRM_Core_SelectValues::getDedupeRuleTypes();
     $this->_rgid = CRM_Utils_Request::retrieve('id', 'Positive', $this, FALSE, 0);
-    $this->_contactType = CRM_Utils_Request::retrieve('contact_type', 'String', $this, FALSE, 0);
+    $contactTypes = civicrm_api3('Contact', 'getOptions', array('field' => "contact_type"));
+    $contactType = CRM_Utils_Request::retrieve('contact_type', 'String', $this, FALSE, 0);
+    if (in_array($contactType, $contactTypes['values'])) {
+      $this->_contactType = $contactTypes['values'][$contactType];
+    }
+    else {
+      throw new CRM_Core_Exception('Contact Type is Not valid');
+    }
     if ($this->_rgid) {
       $rgDao = new CRM_Dedupe_DAO_RuleGroup();
       $rgDao->id = $this->_rgid;

--- a/CRM/Contact/Form/DedupeRules.php
+++ b/CRM/Contact/Form/DedupeRules.php
@@ -63,7 +63,7 @@ class CRM_Contact_Form_DedupeRules extends CRM_Admin_Form {
     if (in_array($contactType, $contactTypes['values'])) {
       $this->_contactType = $contactTypes['values'][$contactType];
     }
-    else {
+    elseif (!empty($contactType)) {
       throw new CRM_Core_Exception('Contact Type is Not valid');
     }
     if ($this->_rgid) {


### PR DESCRIPTION
Overview
----------------------------------------
Currently no validation happens to see if the contact_type is one of the known contact_types this fixes it

ping @jackrabbithanna @eileenmcnaughton @seanmadsen 

Testing this suggests it fixes it and I believe throwing the exception is correct. The other option would be to use statusBounce

---

 * [CRM-20907](https://issues.civicrm.org/jira/browse/CRM-20907)