### PR TITLE
CRM-21123 Ensure that the selectedChild on message templates is one o…

### DIFF
--- a/CRM/Admin/Page/MessageTemplates.php
+++ b/CRM/Admin/Page/MessageTemplates.php
@@ -199,9 +199,10 @@ class CRM_Admin_Page_MessageTemplates extends CRM_Core_Page_Basic {
 
       CRM_Core_BAO_MessageTemplate::revert($id);
     }
-
-    $this->assign('selectedChild', CRM_Utils_Request::retrieve('selectedChild', 'String', $this));
-
+    $selectedChild = CRM_Utils_Request::retrieve('selectedChild', 'String', $this);
+    if (in_array($selectedChild, array('user', 'workflow'))) {
+      $this->assign('selectedChild', $selectedChild);
+    }
     return parent::run($args, $pageArgs, $sort);
   }
 


### PR DESCRIPTION
…f allowed types

Overview
----------------------------------------
Previously any slectedChild was just assigned to the Smarty template, Now only if its workflow or user

ping @jackrabbithanna @seanmadsen @totten @eileenmcnaughton 