### PR TITLE
CRM-20569: Add priceset validation on a partial payment use-case and other improvements

### DIFF
--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -836,15 +836,16 @@ WHERE  id IN (" . implode(',', array_keys($priceFields)) . ')';
       list($componentName) = explode(':', $fields['_qf_default']);
       // now we have all selected amount in hand.
       $totalAmount = array_sum($selectedAmounts);
-      $actualTotalAmount = CRM_Utils_Array::value('partial_payment_total', $fields, CRM_Utils_Array::value('total_amount', $fields));
+      // The form offers a field to enter the amount paid. This may differ from the amount that is due to complete the purchase
+      $totalPaymentAmountEnteredOnForm = CRM_Utils_Array::value('partial_payment_total', $fields, CRM_Utils_Array::value('total_amount', $fields));
       if ($totalAmount < 0) {
         $error['_qf_default'] = ts('%1 amount can not be less than zero. Please select the options accordingly.', array(1 => $componentName));
       }
       elseif ($totalAmount > 0 &&
-        $actualTotalAmount >= $totalAmount && // if total amount is equal to all selected amount in hand
+        $totalPaymentAmountEnteredOnForm >= $totalAmount && // if total amount is equal to all selected amount in hand
         (CRM_Utils_Array::value('contribution_status_id', $fields) == CRM_Core_PseudoConstant::getKey('CRM_Contribute_DAO_Contribution', 'contribution_status_id', 'Partially paid'))
       ) {
-        $error['total_amount'] = ts('For partially paid contribution, amount must be less then the sum of all selected amount in hand');
+        $error['total_amount'] = ts('You have specified the status Partially Paid but have entered an amount that equals or exceeds the amount due. Please adjust the status of the payment or the amount');
       }
     }
     else {

--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -836,8 +836,15 @@ WHERE  id IN (" . implode(',', array_keys($priceFields)) . ')';
       list($componentName) = explode(':', $fields['_qf_default']);
       // now we have all selected amount in hand.
       $totalAmount = array_sum($selectedAmounts);
+      $actualTotalAmount = CRM_Utils_Array::value('partial_payment_total', $fields, CRM_Utils_Array::value('total_amount', $fields));
       if ($totalAmount < 0) {
         $error['_qf_default'] = ts('%1 amount can not be less than zero. Please select the options accordingly.', array(1 => $componentName));
+      }
+      elseif ($totalAmount > 0 &&
+        $actualTotalAmount >= $totalAmount && // if total amount is equal to all selected amount in hand
+        (CRM_Utils_Array::value('contribution_status_id', $fields) == CRM_Core_PseudoConstant::getKey('CRM_Contribute_DAO_Contribution', 'contribution_status_id', 'Partially paid'))
+      ) {
+        $error['total_amount'] = ts('For partially paid contribution, amount must be less then the sum of all selected amount in hand');
       }
     }
     else {

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -703,8 +703,8 @@ WHERE  id = %1";
     }
     if ($priceSetID) {
       $priceFields = self::filterPriceFieldsFromParams($priceSetID, $params);
-      if (count($priceFields) == 1 && !empty($params['total_amount'])) {
-        $amount_override = $params['total_amount'];
+      if (count($priceFields) == 1) {
+        $amount_override = CRM_Utils_Array::value('partial_payment_total', $params, CRM_Utils_Array::value('total_amount', $params));
       }
     }
     foreach ($fields as $id => $field) {
@@ -719,7 +719,7 @@ WHERE  id = %1";
         case 'Text':
           $firstOption = reset($field['options']);
           $params["price_{$id}"] = array($firstOption['id'] => $params["price_{$id}"]);
-          CRM_Price_BAO_LineItem::format($id, $params, $field, $lineItem);
+          CRM_Price_BAO_LineItem::format($id, $params, $field, $lineItem, CRM_Utils_Array::value('partial_payment_total', $params));
           $optionValueId = key($field['options']);
 
           if (CRM_Utils_Array::value('name', $field['options'][$optionValueId]) == 'contribution_amount') {
@@ -767,7 +767,7 @@ WHERE  id = %1";
           $params["price_{$id}"] = array($params["price_{$id}"] => 1);
           $optionValueId = CRM_Utils_Array::key(1, $params["price_{$id}"]);
 
-          CRM_Price_BAO_LineItem::format($id, $params, $field, $lineItem);
+          CRM_Price_BAO_LineItem::format($id, $params, $field, $lineItem, CRM_Utils_Array::value('partial_payment_total', $params));
           if (CRM_Utils_Array::value('tax_rate', $field['options'][$optionValueId])) {
             $lineItem = self::setLineItem($field, $lineItem, $optionValueId, $totalTax);
           }
@@ -783,7 +783,7 @@ WHERE  id = %1";
 
         case 'CheckBox':
 
-          CRM_Price_BAO_LineItem::format($id, $params, $field, $lineItem);
+          CRM_Price_BAO_LineItem::format($id, $params, $field, $lineItem, CRM_Utils_Array::value('partial_payment_total', $params));
           foreach ($params["price_{$id}"] as $optionId => $option) {
             if (CRM_Utils_Array::value('tax_rate', $field['options'][$optionId])) {
               $lineItem = self::setLineItem($field, $lineItem, $optionId, $totalTax);


### PR DESCRIPTION
Technical Details
----------------------------------------
Contain two necessary changes:
- Add a priceset validation where sum of the selected price options is GTE then the expected total amount if 'Partially paid' contribution status is chosen in backoffice form
- Consider ```partial_payment_total``` other then ```total_amount``` in ```CRM_Price_BAO_PriceSet::processAmount(...)``` 

Comments
----------------------------------------
This PR extracts some of the improvements from https://github.com/civicrm/civicrm-core/pull/10352

---

 * [CRM-20569: Record Payment for partially paid membership: update amt, fix deferred ](https://issues.civicrm.org/jira/browse/CRM-20569)