### PR TITLE
CRM-21199, removed JS to hide invoice page setting

### DIFF
--- a/templates/CRM/Admin/Form/Preferences/Contribute.tpl
+++ b/templates/CRM/Admin/Form/Preferences/Contribute.tpl
@@ -24,21 +24,3 @@
  +--------------------------------------------------------------------+
 *}
 {include file="CRM/Form/basicForm.tpl"}
-{literal}
-  <script type="text/javascript">
-    CRM.$(function($) {
-      showHideElement('deferred_revenue_enabled', 'default_invoice_page');
-      $("#deferred_revenue_enabled").click(function() {
-        showHideElement('deferred_revenue_enabled', 'default_invoice_page');
-      });
-      function showHideElement(checkEle, toHide) {
-        if ($('#' + checkEle).prop('checked')) {
-          $("tr.crm-preferences-form-block-" + toHide).show();
-        }
-        else {
-          $("tr.crm-preferences-form-block-" + toHide).hide();
-        }
-      }
-    });
-  </script>
-{/literal}


### PR DESCRIPTION
----------------------------------------
* CRM-21199: Remove dependancy for  'Default invoice payment page'
  https://issues.civicrm.org/jira/browse/CRM-21199

Overview
---------------------------------------
Currently 'Default invoice payment page' setting under CiviContribute Settings shows up when 'Enable Deferred Revenue' is enabled. These two settings are independent of each other. We should remove the dependency on Enable Deferred Revenue since there is no logical link. People not using deferred revenue could benefit from this functionality.

Before
----------------------------------------
![screen shot 2017-09-20 at 4 28 17 am](https://user-images.githubusercontent.com/2053075/30619289-466695b6-9dbc-11e7-8729-018dcfb9af19.png)


After
----------------------------------------
![screen shot 2017-09-20 at 4 28 49 am](https://user-images.githubusercontent.com/2053075/30619302-4fe517de-9dbc-11e7-8671-491a7495857c.png)

