### PR TITLE
CRM-21198 Update membership status appropriately when adding a payment

### DIFF
--- a/tests/phpunit/CRM/Core/Payment/PayPalPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/PayPalPNTest.php
@@ -76,8 +76,8 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
   public function testInvoiceSentOnIPNPaymentSuccess() {
     $this->enableTaxAndInvoicing();
 
-    $pendingStatusID = CRM_Core_OptionGroup::getValue('contribution_status', 'Pending', 'name');
-    $completedStatusID = CRM_Core_OptionGroup::getValue('contribution_status', 'Completed', 'name');
+    $pendingStatusID = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Pending');
+    $completedStatusID = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed');
     $params = array(
       'payment_processor_id' => $this->_paymentProcessorID,
       'contact_id' => $this->_contactID,


### PR DESCRIPTION
Overview
----------------------------------------
Per #10999 this updates a membership when a payment is added to the contribution, leading to the contribution being completed. 

Before
----------------------------------------
Adding a payment to a partially paid contribution with a membership will cause the membership to be completed but the membership will remain pending. Screencast:
![p-membership-before](https://user-images.githubusercontent.com/3735621/30850413-1d13975c-a2c3-11e7-9868-e3c7516685f8.gif)


After
----------------------------------------
The membership will be updated to 'new' (as appropriate) when the contribution is completed via the record payment form. This is happening in the BAO so the (underused) payment api would also be fixed in this scenario. Screencast:
![p-membership-after](https://user-images.githubusercontent.com/3735621/30850444-2fe26b10-a2c3-11e7-8e3c-968d4a68b217.gif)

Technical Details
----------------------------------------
This is primarily an extraction of code from completeOrder which is then also used for this path. Hopefully, over time we will consolidate further but we have been extracting & tidying up completeOrder & adding testing since 4.2 so it is not straightforward

Comments
----------------------------------------
@monishdeb -this is now a replacement for the previous PR - it holds the collaborated changes + the test with the parts that relate to not-yet-reviewed fixes commented out

---

 * [CRM-21198: Completing payment for partially paid membership doesn't change membership status](https://issues.civicrm.org/jira/browse/CRM-21198)