### PR TITLE
CRM-21204 : Add progress bar for Contribution, membership and activity import

### DIFF
--- a/CRM/Activity/Import/Form/Preview.php
+++ b/CRM/Activity/Import/Form/Preview.php
@@ -94,6 +94,7 @@ class CRM_Activity_Import_Form_Preview extends CRM_Import_Form_Preview {
       'downloadConflictRecordsUrl',
       'downloadMismatchRecordsUrl',
     );
+    $this->setStatusUrl();
 
     foreach ($properties as $property) {
       $this->assign($property, $this->get($property));
@@ -151,7 +152,9 @@ class CRM_Activity_Import_Form_Preview extends CRM_Import_Form_Preview {
       $mapperFields,
       $skipColumnHeader,
       CRM_Import_Parser::MODE_IMPORT,
-      $onDuplicate
+      $onDuplicate,
+      $this->get('statusID'),
+      $this->get('totalRowCount')
     );
 
     // add all the necessary variables to the form

--- a/CRM/Activity/Import/Parser.php
+++ b/CRM/Activity/Import/Parser.php
@@ -73,7 +73,9 @@ abstract class CRM_Activity_Import_Parser extends CRM_Import_Parser {
     &$mapper,
     $skipColumnHeader = FALSE,
     $mode = self::MODE_PREVIEW,
-    $onDuplicate = self::DUPLICATE_SKIP
+    $onDuplicate = self::DUPLICATE_SKIP,
+    $statusID = NULL,
+    $totalRowCount = NULL
   ) {
     if (!is_array($fileName)) {
       CRM_Core_Error::fatal();
@@ -106,6 +108,10 @@ abstract class CRM_Activity_Import_Parser extends CRM_Import_Parser {
     }
     else {
       $this->_activeFieldCount = count($this->_activeFields);
+    }
+    if ($statusID) {
+      $this->progressImport($statusID);
+      $startTimestamp = $currTimestamp = $prevTimestamp = time();
     }
 
     while (!feof($fd)) {
@@ -148,6 +154,9 @@ abstract class CRM_Activity_Import_Parser extends CRM_Import_Parser {
       }
       elseif ($mode == self::MODE_IMPORT) {
         $returnCode = $this->import($onDuplicate, $values);
+        if ($statusID && (($this->_lineCount % 50) == 0)) {
+          $prevTimestamp = $this->progressImport($statusID, FALSE, $startTimestamp, $prevTimestamp, $totalRowCount);
+        }
       }
       else {
         $returnCode = self::ERROR;

--- a/CRM/Contact/Import/Form/Preview.php
+++ b/CRM/Contact/Import/Form/Preview.php
@@ -121,13 +121,7 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
       $this->assign($property, $this->get($property));
     }
 
-    $statusID = $this->get('statusID');
-    if (!$statusID) {
-      $statusID = md5(uniqid(rand(), TRUE));
-      $this->set('statusID', $statusID);
-    }
-    $statusUrl = CRM_Utils_System::url('civicrm/ajax/status', "id={$statusID}", FALSE, NULL, FALSE);
-    $this->assign('statusUrl', $statusUrl);
+    $this->setStatusUrl();
 
     $showColNames = TRUE;
     if ('CRM_Import_DataSource_CSV' == $this->get('dataSource') &&
@@ -193,7 +187,6 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
         'name' => ts('Import Now'),
         'spacing' => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
         'isDefault' => TRUE,
-        'js' => array('onclick' => "return verify( );"),
       ),
       array(
         'type' => 'cancel',

--- a/CRM/Contact/Import/Parser.php
+++ b/CRM/Contact/Import/Parser.php
@@ -167,20 +167,9 @@ abstract class CRM_Contact_Import_Parser extends CRM_Import_Parser {
     }
 
     if ($statusID) {
-      $skip = 50;
-      // $skip = 1;
-      $config = CRM_Core_Config::singleton();
-      $statusFile = "{$config->uploadDir}status_{$statusID}.txt";
-      $status = "<div class='description'>&nbsp; " . ts('No processing status reported yet.') . "</div>";
-
-      //do not force the browser to display the save dialog, CRM-7640
-      $contents = json_encode(array(0, $status));
-
-      file_put_contents($statusFile, $contents);
-
+      $this->progressImport($statusID);
       $startTimestamp = $currTimestamp = $prevTimestamp = time();
     }
-
     // get the contents of the temp. import table
     $query = "SELECT * FROM $tableName";
     if ($mode == self::MODE_IMPORT) {
@@ -215,39 +204,9 @@ abstract class CRM_Contact_Import_Parser extends CRM_Import_Parser {
       elseif ($mode == self::MODE_IMPORT) {
         //print "Running parser in import mode<br/>\n";
         $returnCode = $this->import($onDuplicate, $values, $doGeocodeAddress);
-        if ($statusID && (($this->_rowCount % $skip) == 0)) {
-          $currTimestamp = time();
-          $totalTime = ($currTimestamp - $startTimestamp);
-          $time = ($currTimestamp - $prevTimestamp);
-          $recordsLeft = $totalRowCount - $this->_rowCount;
-          if ($recordsLeft < 0) {
-            $recordsLeft = 0;
-          }
-          $estimatedTime = ($recordsLeft / $skip) * $time;
-          $estMinutes = floor($estimatedTime / 60);
-          $timeFormatted = '';
-          if ($estMinutes > 1) {
-            $timeFormatted = $estMinutes . ' ' . ts('minutes') . ' ';
-            $estimatedTime = $estimatedTime - ($estMinutes * 60);
-          }
-          $timeFormatted .= round($estimatedTime) . ' ' . ts('seconds');
-          $processedPercent = (int ) (($this->_rowCount * 100) / $totalRowCount);
-          $statusMsg = ts('%1 of %2 records - %3 remaining',
-            array(1 => $this->_rowCount, 2 => $totalRowCount, 3 => $timeFormatted)
-          );
-          $status = "
-<div class=\"description\">
-&nbsp; <strong>{$statusMsg}</strong>
-</div>
-";
-
-          $contents = json_encode(array($processedPercent, $status));
-
-          file_put_contents($statusFile, $contents);
-
-          $prevTimestamp = $currTimestamp;
+        if ($statusID && (($this->_rowCount % 50) == 0)) {
+          $prevTimestamp = $this->progressImport($statusID, FALSE, $startTimestamp, $prevTimestamp, $totalRowCount);
         }
-        // sleep(1);
       }
       else {
         $returnCode = self::ERROR;

--- a/CRM/Contribute/Import/Form/Preview.php
+++ b/CRM/Contribute/Import/Form/Preview.php
@@ -98,6 +98,7 @@ class CRM_Contribute_Import_Form_Preview extends CRM_Import_Form_Preview {
       'downloadConflictRecordsUrl',
       'downloadMismatchRecordsUrl',
     );
+    $this->setStatusUrl();
 
     foreach ($properties as $property) {
       $this->assign($property, $this->get($property));
@@ -148,7 +149,9 @@ class CRM_Contribute_Import_Form_Preview extends CRM_Import_Form_Preview {
       $skipColumnHeader,
       CRM_Import_Parser::MODE_IMPORT,
       $this->get('contactType'),
-      $onDuplicate
+      $onDuplicate,
+      $this->get('statusID'),
+      $this->get('totalRowCount')
     );
 
     // Add all the necessary variables to the form.

--- a/CRM/Contribute/Import/Parser.php
+++ b/CRM/Contribute/Import/Parser.php
@@ -125,7 +125,9 @@ abstract class CRM_Contribute_Import_Parser extends CRM_Import_Parser {
     $skipColumnHeader = FALSE,
     $mode = self::MODE_PREVIEW,
     $contactType = self::CONTACT_INDIVIDUAL,
-    $onDuplicate = self::DUPLICATE_SKIP
+    $onDuplicate = self::DUPLICATE_SKIP,
+    $statusID = NULL,
+    $totalRowCount = NULL
   ) {
     if (!is_array($fileName)) {
       CRM_Core_Error::fatal();
@@ -165,6 +167,10 @@ abstract class CRM_Contribute_Import_Parser extends CRM_Import_Parser {
     $this->_conflicts = array();
     $this->_pledgePaymentErrors = array();
     $this->_softCreditErrors = array();
+    if ($statusID) {
+      $this->progressImport($statusID);
+      $startTimestamp = $currTimestamp = $prevTimestamp = time();
+    }
 
     $this->_fileSize = number_format(filesize($fileName) / 1024.0, 2);
 
@@ -215,6 +221,9 @@ abstract class CRM_Contribute_Import_Parser extends CRM_Import_Parser {
       }
       elseif ($mode == self::MODE_IMPORT) {
         $returnCode = $this->import($onDuplicate, $values);
+        if ($statusID && (($this->_lineCount % 50) == 0)) {
+          $prevTimestamp = $this->progressImport($statusID, FALSE, $startTimestamp, $prevTimestamp, $totalRowCount);
+        }
       }
       else {
         $returnCode = self::ERROR;

--- a/CRM/Import/Form/Preview.php
+++ b/CRM/Import/Form/Preview.php
@@ -51,7 +51,6 @@ abstract class CRM_Import_Form_Preview extends CRM_Core_Form {
    * Build the form object.
    */
   public function buildQuickForm() {
-
     $this->addButtons(array(
         array(
           'type' => 'back',
@@ -69,6 +68,19 @@ abstract class CRM_Import_Form_Preview extends CRM_Core_Form {
         ),
       )
     );
+  }
+
+  /**
+   * Set status url for ajax.
+   */
+  public function setStatusUrl() {
+    $statusID = $this->get('statusID');
+    if (!$statusID) {
+      $statusID = md5(uniqid(rand(), TRUE));
+      $this->set('statusID', $statusID);
+    }
+    $statusUrl = CRM_Utils_System::url('civicrm/ajax/status', "id={$statusID}", FALSE, NULL, FALSE);
+    $this->assign('statusUrl', $statusUrl);
   }
 
 }

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -287,7 +287,10 @@ abstract class CRM_Import_Parser {
   }
 
   /**
+   * Add progress bar to the import process. Calculates time remaining, status etc.
+   *
    * @param $statusID
+   *   status id of the import process saved in $config->uploadDir.
    * @param bool $startImport
    *   True when progress bar is to be initiated.
    * @param $startTimestamp

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -287,6 +287,58 @@ abstract class CRM_Import_Parser {
   }
 
   /**
+   * @param $statusID
+   * @param bool $startImport
+   *   True when progress bar is to be initiated.
+   * @param $startTimestamp
+   *   Initial timstamp when the import was started.
+   * @param $prevTimestamp
+   *   Previous timestamp when this function was last called.
+   * @param $totalRowCount
+   *   Total number of rows in the import file.
+   *
+   * @return NULL|$currTimestamp
+   */
+  public function progressImport($statusID, $startImport = TRUE, $startTimestamp = NULL, $prevTimestamp = NULL, $totalRowCount = NULL) {
+    $config = CRM_Core_Config::singleton();
+    $statusFile = "{$config->uploadDir}status_{$statusID}.txt";
+
+    if ($startImport) {
+      $status = "<div class='description'>&nbsp; " . ts('No processing status reported yet.') . "</div>";
+      //do not force the browser to display the save dialog, CRM-7640
+      $contents = json_encode(array(0, $status));
+      file_put_contents($statusFile, $contents);
+    }
+    else {
+      $rowCount = isset($this->_rowCount) ? $this->_rowCount : $this->_lineCount;
+      $currTimestamp = time();
+      $totalTime = ($currTimestamp - $startTimestamp);
+      $time = ($currTimestamp - $prevTimestamp);
+      $recordsLeft = $totalRowCount - $rowCount;
+      if ($recordsLeft < 0) {
+        $recordsLeft = 0;
+      }
+      $estimatedTime = ($recordsLeft / 50) * $time;
+      $estMinutes = floor($estimatedTime / 60);
+      $timeFormatted = '';
+      if ($estMinutes > 1) {
+        $timeFormatted = $estMinutes . ' ' . ts('minutes') . ' ';
+        $estimatedTime = $estimatedTime - ($estMinutes * 60);
+      }
+      $timeFormatted .= round($estimatedTime) . ' ' . ts('seconds');
+      $processedPercent = (int ) (($rowCount * 100) / $totalRowCount);
+      $statusMsg = ts('%1 of %2 records - %3 remaining',
+        array(1 => $rowCount, 2 => $totalRowCount, 3 => $timeFormatted)
+      );
+      $status = "<div class=\"description\">&nbsp; <strong>{$statusMsg}</strong></div>";
+      $contents = json_encode(array($processedPercent, $status));
+
+      file_put_contents($statusFile, $contents);
+      return $currTimestamp;
+    }
+  }
+
+  /**
    * @return array
    */
   public function getSelectValues() {

--- a/CRM/Member/Import/Form/Preview.php
+++ b/CRM/Member/Import/Form/Preview.php
@@ -99,6 +99,7 @@ class CRM_Member_Import_Form_Preview extends CRM_Import_Form_Preview {
       'downloadConflictRecordsUrl',
       'downloadMismatchRecordsUrl',
     );
+    $this->setStatusUrl();
 
     foreach ($properties as $property) {
       $this->assign($property, $this->get($property));
@@ -161,14 +162,15 @@ class CRM_Member_Import_Form_Preview extends CRM_Import_Form_Preview {
       $skipColumnHeader,
       CRM_Import_Parser::MODE_IMPORT,
       $this->get('contactType'),
-      $onDuplicate
+      $onDuplicate,
+      $this->get('statusID'),
+      $this->get('totalRowCount')
     );
 
     // add all the necessary variables to the form
     $parser->set($this, CRM_Import_Parser::MODE_IMPORT);
 
     // check if there is any error occurred
-
     $errorStack = CRM_Core_Error::singleton();
     $errors = $errorStack->getErrors();
     $errorMessage = array();

--- a/CRM/Member/Import/Parser.php
+++ b/CRM/Member/Import/Parser.php
@@ -81,7 +81,9 @@ abstract class CRM_Member_Import_Parser extends CRM_Import_Parser {
     $skipColumnHeader = FALSE,
     $mode = self::MODE_PREVIEW,
     $contactType = self::CONTACT_INDIVIDUAL,
-    $onDuplicate = self::DUPLICATE_SKIP
+    $onDuplicate = self::DUPLICATE_SKIP,
+    $statusID = NULL,
+    $totalRowCount = NULL
   ) {
     if (!is_array($fileName)) {
       CRM_Core_Error::fatal();
@@ -128,6 +130,10 @@ abstract class CRM_Member_Import_Parser extends CRM_Import_Parser {
     else {
       $this->_activeFieldCount = count($this->_activeFields);
     }
+    if ($statusID) {
+      $this->progressImport($statusID);
+      $startTimestamp = $currTimestamp = $prevTimestamp = time();
+    }
 
     while (!feof($fd)) {
       $this->_lineCount++;
@@ -146,7 +152,6 @@ abstract class CRM_Member_Import_Parser extends CRM_Import_Parser {
       }
 
       /* trim whitespace around the values */
-
       $empty = TRUE;
       foreach ($values as $k => $v) {
         $values[$k] = trim($v, " \t\r\n");
@@ -168,6 +173,9 @@ abstract class CRM_Member_Import_Parser extends CRM_Import_Parser {
       }
       elseif ($mode == self::MODE_IMPORT) {
         $returnCode = $this->import($onDuplicate, $values);
+        if ($statusID && (($this->_lineCount % 50) == 0)) {
+          $prevTimestamp = $this->progressImport($statusID, FALSE, $startTimestamp, $prevTimestamp, $totalRowCount);
+        }
       }
       else {
         $returnCode = self::ERROR;

--- a/templates/CRM/Activity/Import/Form/Preview.tpl
+++ b/templates/CRM/Activity/Import/Form/Preview.tpl
@@ -51,6 +51,7 @@
     <p>{ts}Click 'Import Now' if you are ready to proceed.{/ts}</p>
  </div>
  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
+ {include file="CRM/common/importProgress.tpl"}
  {* Summary Preview (record counts) *}
  <table id="preview-counts" class="report">
     <tr><td class="label">{ts}Total Rows{/ts}</td>

--- a/templates/CRM/Contact/Import/Form/Preview.tpl
+++ b/templates/CRM/Contact/Import/Form/Preview.tpl
@@ -24,51 +24,6 @@
  +--------------------------------------------------------------------+
 *}
 <div class="crm-block crm-form-block crm-import-preview-form-block">
-
-{literal}
-<script type="text/javascript">
-function setIntermediate( ) {
-  var dataUrl = "{/literal}{$statusUrl}{literal}";
-  cj.getJSON( dataUrl, function( response ) {
-
-     var dataStr = response.toString();
-     var result  = dataStr.split(",");
-     cj("#intermediate").html( result[1] );
-           if( result[0] < 100 ){
-          cj("#importProgressBar .ui-progressbar-value").animate({width: result[0]+"%"}, 500);
-    cj("#status").text( result[0]+"% Completed");
-             }
-   });
-}
-
-function pollLoop( ){
-  setIntermediate( );
-  window.setTimeout( pollLoop, 10*1000 ); // 10 sec
-}
-
-function verify( ) {
-    if (! confirm('Backing up your database before importing is recommended, as there is no Undo for this. {/literal}{ts escape='js'}Are you sure you want to Import now{/ts}{literal}?') ) {
-        return false;
-    }
-
-  cj("#id-processing").show( ).dialog({
-    modal         : true,
-    width         : 350,
-    height        : 160,
-    resizable     : false,
-    draggable     : true,
-    closeOnEscape : false,
-    open          : function ( ) {
-        cj("#id-processing").dialog().parents(".ui-dialog").find(".ui-dialog-titlebar").remove();
-    }
-  });
-  cj("#importProgressBar" ).progressbar({value:0});
-      cj("#importProgressBar").show( );
-  pollLoop( );
-}
-</script>
-{/literal}
-
 {* Import Wizard - Step 3 (preview import results prior to actual data loading) *}
 {* @var $form Contains the array for the form elements and other form associated information assigned to the template by the controller *}
 
@@ -94,14 +49,7 @@ function verify( ) {
     <p>{ts}Click 'Import Now' if you are ready to proceed.{/ts}</p>
 </div>
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
-{* Import Progress Bar and Info *}
-<div id="id-processing" class="hiddenElement">
-  <h3>Importing records...</h3><br />
-       <div id="status" style="margin-left:6px;"></div>
-  <div class="progressBar" id="importProgressBar" style="margin-left:6px;display:none;"></div>
-  <div id="intermediate"></div>
-  <div id="error_status"></div>
-</div>
+{include file="CRM/common/importProgress.tpl"}
 
 <div id="preview-info">
  {* Summary Preview (record counts) *}

--- a/templates/CRM/Contribute/Import/Form/Preview.tpl
+++ b/templates/CRM/Contribute/Import/Form/Preview.tpl
@@ -50,6 +50,7 @@
     <p>{ts}Click 'Import Now' if you are ready to proceed.{/ts}</p>
  </div>
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
+ {include file="CRM/common/importProgress.tpl"}
  {* Summary Preview (record counts) *}
  <table id="preview-counts" class="report">
     <tr><td class="label">{ts}Total Rows{/ts}</td>

--- a/templates/CRM/Member/Import/Form/Preview.tpl
+++ b/templates/CRM/Member/Import/Form/Preview.tpl
@@ -51,6 +51,7 @@
     <p>{ts}Click 'Import Now' if you are ready to proceed.{/ts}</p>
  </div>
  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
+ {include file="CRM/common/importProgress.tpl"}
  {* Summary Preview (record counts) *}
  <table id="preview-counts" class="report">
     <tr><td class="label">{ts}Total Rows{/ts}</td>

--- a/templates/CRM/common/importProgress.tpl
+++ b/templates/CRM/common/importProgress.tpl
@@ -1,0 +1,81 @@
+{*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2017                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*}
+{literal}
+<script type="text/javascript">
+CRM.$(function($) {
+  $("form#Preview").on('submit', function (e) {
+    verify();
+  });
+  function setIntermediate() {
+    var dataUrl = "{/literal}{$statusUrl}{literal}";
+    $.getJSON(dataUrl, function(response) {
+      var dataStr = response.toString();
+      var result  = dataStr.split(",");
+      $("#intermediate").html(result[1]);
+      $("#importProgressBar .ui-progressbar-value").show();
+      if (result[0] < 100) {
+        $("#importProgressBar .ui-progressbar-value").animate({width: result[0] + "%"}, 500);
+        $("#status").text(result[0] + "% Completed");
+      }
+    });
+  }
+
+  function pollLoop() {
+    setIntermediate();
+    window.setTimeout(pollLoop, 10*1000); // 10 sec
+  }
+
+  function verify() {
+    if (!confirm('Backing up your database before importing is recommended, as there is no Undo for this. {/literal}{ts escape='js'}Are you sure you want to Import now{/ts}{literal}?')) {
+      return false;
+    }
+    $("#id-processing").show( ).dialog({
+      modal         : true,
+      width         : 450,
+      height        : 200,
+      resizable     : false,
+      draggable     : true,
+      closeOnEscape : false,
+      open          : function () {
+        $("#id-processing").dialog().parents(".ui-dialog").find(".ui-dialog-titlebar").remove();
+      }
+    });
+    $("#importProgressBar" ).progressbar({value:0});
+    $("#importProgressBar").show( );
+    pollLoop( );
+  }
+});
+</script>
+{/literal}
+
+{* Import Progress Bar and Info *}
+<div id="id-processing" class="hiddenElement">
+  <h3>Importing records...</h3><br />
+       <div id="status" style="margin-left:6px;"></div>
+  <div class="progressBar" id="importProgressBar" style="margin-left:6px;display:none;"></div>
+  <div id="intermediate"></div>
+  <div id="error_status"></div>
+</div>

--- a/templates/CRM/common/importProgress.tpl
+++ b/templates/CRM/common/importProgress.tpl
@@ -28,7 +28,12 @@
 CRM.$(function($) {
   var loop;
   $("form#Preview").on('submit', function (e) {
-    verify();
+    if (!confirm("{/literal}{ts escape='js'}Backing up your database before importing is recommended, as there is no Undo for this. Are you sure you want to import now?{/ts}{literal}")) {
+      e.preventDefault();
+    }
+    else {
+      showProgressBar();
+    }
   });
   function setIntermediate() {
     var dataUrl = "{/literal}{$statusUrl}{literal}";
@@ -41,13 +46,13 @@ CRM.$(function($) {
         $("#importProgressBar .ui-progressbar-value").animate({width: result[0] + "%"}, 500);
         $("#status").text(result[0] + "% Completed");
       }
+      else {
+        window.clearInterval(loop);
+      }
     });
   }
 
-  function verify() {
-    if (!confirm('Backing up your database before importing is recommended, as there is no Undo for this. {/literal}{ts escape='js'}Are you sure you want to Import now{/ts}{literal}?')) {
-      return false;
-    }
+  function showProgressBar() {
     $("#id-processing").show( ).dialog({
       modal         : true,
       width         : 450,

--- a/templates/CRM/common/importProgress.tpl
+++ b/templates/CRM/common/importProgress.tpl
@@ -26,6 +26,7 @@
 {literal}
 <script type="text/javascript">
 CRM.$(function($) {
+  var loop;
   $("form#Preview").on('submit', function (e) {
     verify();
   });
@@ -41,11 +42,6 @@ CRM.$(function($) {
         $("#status").text(result[0] + "% Completed");
       }
     });
-  }
-
-  function pollLoop() {
-    setIntermediate();
-    window.setTimeout(pollLoop, 10*1000); // 10 sec
   }
 
   function verify() {
@@ -65,7 +61,7 @@ CRM.$(function($) {
     });
     $("#importProgressBar" ).progressbar({value:0});
     $("#importProgressBar").show( );
-    pollLoop( );
+    loop = window.setInterval(setIntermediate, 5)
   }
 });
 </script>


### PR DESCRIPTION
Overview
----------------------------------------
This PR adds progress bar for activity, contribution and membership imports.

Before
----------------------------------------
- Progress bar is only shown for contact import.
- Color not shown to see the progress of the import.
- Improper width - need to scroll down within the tiny box to see the minutes remaining.

<img width="497" alt="image" src="https://user-images.githubusercontent.com/5929648/30683131-cb2217fe-9ec9-11e7-8637-31fb41a736cc.png">

After
----------------------------------------
Progress bar shown for Contribution, membership and activity imports with proper width and color.

<img width="528" alt="image" src="https://user-images.githubusercontent.com/5929648/30683431-11d159e8-9ecb-11e7-8eeb-f8dfc9976cf2.png">

---

 * [CRM-21204: Show Import Progress Bar for Activity, Contribution and Membership imports.](https://issues.civicrm.org/jira/browse/CRM-21204)