### PR TITLE
CRM-21110 Get Total relationships without need for extra table

### DIFF
--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -1279,25 +1279,23 @@ LEFT JOIN  civicrm_country ON (civicrm_address.country_id = civicrm_country.id)
     }
 
     // building the query string
-    CRM_Core_DAO::executeQuery("CREATE TEMPORARY TABLE civicrm_contact_relationships " . $select1 . $from1 . $where1 . $select2 . $from2 . $where2);
-    $queryString = "SELECT * FROM civicrm_contact_relationships " . $order . $limit;
+    $queryString = $select1 . $from1 . $where1 . $select2 . $from2 . $where2;
 
     $relationship = new CRM_Contact_DAO_Relationship();
 
-    $relationship->query($queryString);
+    $relationship->query($queryString . $order . $limit);
     $row = array();
     if ($count) {
       $relationshipCount = 0;
       while ($relationship->fetch()) {
         $relationshipCount += $relationship->cnt1 + $relationship->cnt2;
       }
-      CRM_Core_DAO::executeQuery("DROP TEMPORARY TABLE IF EXISTS civicrm_contact_relationships");
       return $relationshipCount;
     }
     else {
 
       if ($includeTotalCount) {
-        $values['total_relationships'] = CRM_Core_DAO::singleValueQuery("SELECT count(*) FROM civicrm_contact_relationships");
+        $values['total_relationships'] = CRM_Core_DAO::singleValueQuery("SELECT count(*) FROM ({$queryString}) AS r");
       }
 
       $mask = NULL;
@@ -1445,7 +1443,6 @@ LEFT JOIN  civicrm_country ON (civicrm_address.country_id = civicrm_country.id)
       }
 
       $relationship->free();
-      CRM_Core_DAO::executeQuery("DROP TEMPORARY TABLE IF EXISTS civicrm_contact_relationships");
       return $values;
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
This improves on the patch for CRM-21110 from #10907 by keeping the total_relationships array key but getting that value without the need for a separate table

@eileenmcnaughton @monishdeb I have deployed this version of the patch to AUG prod at the moment and @ineffyble does report that the relationships tab feels snappier and i think this is better because it means no temporary table

---

 * [CRM-21110: Relationships tab on contact summary runs query twice](https://issues.civicrm.org/jira/browse/CRM-21110)