### PR TITLE
CRM-20226 [NFC] add comment to warn coders about performance impact

### DIFF
--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -1017,6 +1017,13 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
       }
 
       // get group contact count using Contact.GetCount API
+      // CRM-20226 This has been added here in order to address a specific bug. However, a prior
+      // decision was to refresh group counts less aggressively, offering instead a button to
+      // refresh them to give users a better experience by loading pages quicker.
+      // For some sites this can be crazy slow even though only 25 sites resolve. Even for sites
+      // with relatively few smart groups it is not a good user experience.
+      // Adding comments here as I'm not going to tackle a fix this time around but want
+      // to warn people off making it worse.
       $values[$object->id]['count'] = civicrm_api3('Contact', 'getcount', array('group' => $object->id));
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Adds a code comment notifying devs about the risk of improving group resolution.

@monishdeb the line commented is a change you made. I've decided the performance issue is manageable for us after a group tidy up but can you read & merge for future.

---

 * [CRM-20226: Parent Group do not inherit child group contacts](https://issues.civicrm.org/jira/browse/CRM-20226)