### PR TITLE
CRM-21207 Try page-body as the region rather than billing-block

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -361,7 +361,7 @@ WHERE  contribution_id = {$id}
       }
     }
     // CRM-21002: pass the default payment processor ID whose credit card type icons should be populated first
-    CRM_Financial_Form_Payment::addCreditCardJs($this->_paymentProcessor['id']);
+    CRM_Financial_Form_Payment::addCreditCardJs($this->_paymentProcessor['id'], 'billing-block', $this);
 
     $this->assign('recurringPaymentProcessorIds',
       empty($this->_recurPaymentProcessors) ? '' : implode(',', array_keys($this->_recurPaymentProcessors))

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -831,7 +831,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       else {
         $this->_paymentProcessor = array();
       }
-      CRM_Financial_Form_Payment::addCreditCardJs($this->_paymentProcessorID);
+      CRM_Financial_Form_Payment::addCreditCardJs($this->_paymentProcessorID, 'billing-block', $this);
     }
     $this->assign('paymentProcessorID', $this->_paymentProcessorID);
     // We save the fact that the profile 'billing' is required on the payment form.

--- a/CRM/Financial/Form/Payment.php
+++ b/CRM/Financial/Form/Payment.php
@@ -119,7 +119,7 @@ class CRM_Financial_Form_Payment extends CRM_Core_Form {
       ->addScriptFile('civicrm', 'templates/CRM/Core/BillingBlock.js', 10, $region, FALSE)
       // workaround for CRM-13634
       // ->addSetting(array('config' => array('creditCardTypes' => $creditCardTypes)));
-      ->addScript('CRM.config.creditCardTypes = ' . json_encode($creditCardTypes) . ';', '-9999', $region);
+      ->addScript('CRM.config.creditCardTypes = ' . json_encode($creditCardTypes) . ';', '-9999', 'page-header');
   }
 
 }

--- a/CRM/Financial/Form/Payment.php
+++ b/CRM/Financial/Form/Payment.php
@@ -72,7 +72,7 @@ class CRM_Financial_Form_Payment extends CRM_Core_Form {
 
     CRM_Core_Payment_ProcessorForm::preProcess($this);
 
-    self::addCreditCardJs($this->_paymentProcessorID);
+    self::addCreditCardJs($this->_paymentProcessorID, 'billing-block', $this);
 
     $this->assign('paymentProcessorID', $this->_paymentProcessorID);
     $this->assign('currency', $this->currency);
@@ -109,17 +109,17 @@ class CRM_Financial_Form_Payment extends CRM_Core_Form {
    *
    * @param int $paymentProcessorID
    * @param string $region
+   * @param CRM_Core_Form $form
    */
-  public static function addCreditCardJs($paymentProcessorID = NULL, $region = 'billing-block') {
+  public static function addCreditCardJs($paymentProcessorID = NULL, $region = 'billing-block', $form) {
     $creditCards = CRM_Financial_BAO_PaymentProcessor::getCreditCards($paymentProcessorID);
     $creditCardTypes = CRM_Core_Payment_Form::getCreditCardCSSNames($creditCards);
+    // workaround for CRM-1364 and CRM-20264 and CRM-20516
+    $form->assign('creditCardTypes', json_encode($creditCardTypes));
     CRM_Core_Resources::singleton()
       // CRM-20516: add BillingBlock script on billing-block region
       //  to support this feature in payment form snippet too.
-      ->addScriptFile('civicrm', 'templates/CRM/Core/BillingBlock.js', 10, $region, FALSE)
-      // workaround for CRM-13634
-      // ->addSetting(array('config' => array('creditCardTypes' => $creditCardTypes)));
-      ->addScript('CRM.config.creditCardTypes = ' . json_encode($creditCardTypes) . ';', '-9999', 'page-header');
+      ->addScriptFile('civicrm', 'templates/CRM/Core/BillingBlock.js', 10, $region, FALSE);
   }
 
 }

--- a/templates/CRM/Core/BillingBlock.tpl
+++ b/templates/CRM/Core/BillingBlock.tpl
@@ -25,6 +25,11 @@
 *}
 {crmRegion name="billing-block"}
 <div id="payment_information">
+  <script type="text/javascript">
+    {literal}
+    CRM.config.creditCardTypes = {/literal}{$creditCardTypes}{literal};
+  </script>
+  {/literal}
   {if $paymentFields|@count}
     <fieldset class="billing_mode-group {$paymentTypeName}_info-group">
       <legend>


### PR DESCRIPTION
Overview
----------------------------------------
Currently to make the credit card icons show up on the add a credit card contribution page or similar the js needs to go in billing-block. Trialing putting the credit card types in the page-body as the issue reported was that it didn't work in the billing-block causing java script errors. 

ping @eileenmcnaughton @monishdeb can one of you try testing this on a wordpress site. I tried installing but was failing on unzipping archive

---

 * [CRM-21207: JS error on payment processor fields in Wordpress](https://issues.civicrm.org/jira/browse/CRM-21207)