### PR TITLE
CRM-16836 - make Basic Search form group select respect ACLs

### DIFF
--- a/CRM/Contact/Form/Search/Basic.php
+++ b/CRM/Contact/Form/Search/Basic.php
@@ -64,11 +64,14 @@ class CRM_Contact_Form_Search_Basic extends CRM_Contact_Form_Search {
     }
 
     // add select for groups
+    // Get hierarchical listing of groups, respecting ACLs for CRM-16836.
+    $groupHierarchy = CRM_Contact_BAO_Group::getGroupsHierarchy($this->_group, NULL, '&nbsp;&nbsp;', TRUE);
     if (!empty($searchOptions['groups'])) {
       $this->addField('group', array(
           'entity' => 'group_contact',
           'label' => ts('in'),
           'placeholder' => ts('- any group -'),
+          'options' => $groupHierarchy,
         ));
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
See full description at [CRM-16836 Basic Search form group select does not respect ACLs](https://issues.civicrm.org/jira/browse/CRM-16836).
The group selector on the Basic Search form is showing all groups, for an ACL'd user who should only be able to see a restricted set of groups.
This was a regression between 4.4.14 and 4.6.4

Before
----------------------------------------
For an ACL'd user who should only be able to see a restricted set of groups, the group selector on the Basic Search form shows all groups.
![screen shot 2017-09-21 at 13 23 27](https://user-images.githubusercontent.com/5641482/30695500-49a982f0-9ed0-11e7-8105-472242b39681.png)

After
----------------------------------------
For an ACL'd user who should only be able to see a restricted set of groups, the group selector on the Basic Search form shows only the groups they are permitted to see.
![screen shot 2017-09-21 at 13 21 41](https://user-images.githubusercontent.com/5641482/30695586-8469cd5a-9ed0-11e7-93cc-58a57bdd0d52.png)

Technical Details
----------------------------------------
This is fixing a regression. The simplest way to fix was to revert the relevant part of [the commit that caused the issue](https://github.com/civicrm/civicrm-core/commit/76773c5a5191673e990d6e9ee4e8d2c9a664e819#diff-e8f2bd059a6e0b2434434982052bfca9), but discussion on JIRA seemed to favour retaining the change from
  $this->add('select', 'group', ...
to
  $this->addSelect('group', ...
So I followed @eileenmcnaughton's suggestion to specify 'options' in the call to addSelect(). I populated options using the same CRM_Contact_BAO_Group::getGroupsHierarchy() call that is used in Advanced Search, which respects ACLs.

Comments
----------------------------------------
See discussion in comments on JIRA.