### PR TITLE
CRM-16836 - make Basic Search form group select respect ACLs (4.6 version)

### DIFF
--- a/CRM/Contact/Form/Search/Basic.php
+++ b/CRM/Contact/Form/Search/Basic.php
@@ -78,12 +78,15 @@ class CRM_Contact_Form_Search_Basic extends CRM_Contact_Form_Search {
     }
 
     // add select for groups
+    // Get hierarchical listing of groups, respecting ACLs for CRM-16836.
+    $groupHierarchy = CRM_Contact_BAO_Group::getGroupsHierarchy($this->_group, NULL, '&nbsp;&nbsp;', TRUE);
     if (!empty($searchOptions['groups'])) {
       $this->addSelect('group', array(
           'entity' => 'group_contact',
           'label' => ts('in'),
           'context' => 'search',
           'placeholder' => ts('- any group -'),
+          'options' => $groupHierarchy,
         ));
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
This is the 4.6 equivalent of #11013. Full details there & at CRM-16836.

---

 * [CRM-16836: Basic Search form group select does not respect ACLs](https://issues.civicrm.org/jira/browse/CRM-16836)