### PR TITLE
CRM-20772 Add database changes to support > 2 decimal places

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -353,18 +353,18 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       if (!empty($defaults['tax_amount'])) {
         $componentDetails = CRM_Contribute_BAO_Contribution::getComponentDetails($this->_id);
         if (!(CRM_Utils_Array::value('membership', $componentDetails) || CRM_Utils_Array::value('participant', $componentDetails))) {
-          $defaults['total_amount'] = CRM_Utils_Money::format($defaults['total_amount'] - $defaults['tax_amount'], NULL, '%a');
+          $defaults['total_amount'] = CRM_Utils_Money::formatLocaleNumeric($defaults['total_amount'] - $defaults['tax_amount']);
         }
       }
       else {
-        $defaults['total_amount'] = CRM_Utils_Money::format($defaults['total_amount'], NULL, '%a');
+        $defaults['total_amount'] = CRM_Utils_Money::formatLocaleNumeric($defaults['total_amount']);
       }
     }
 
     $amountFields = array('non_deductible_amount', 'fee_amount', 'net_amount');
     foreach ($amountFields as $amt) {
       if (isset($defaults[$amt])) {
-        $defaults[$amt] = CRM_Utils_Money::format($defaults[$amt], NULL, '%a');
+        $defaults[$amt] = CRM_Utils_Money::formatLocaleNumeric($defaults[$amt]);
       }
     }
 

--- a/CRM/Member/Form/MembershipConfig.php
+++ b/CRM/Member/Form/MembershipConfig.php
@@ -83,7 +83,7 @@ class CRM_Member_Form_MembershipConfig extends CRM_Core_Form {
     }
 
     if (isset($defaults['minimum_fee'])) {
-      $defaults['minimum_fee'] = CRM_Utils_Money::format($defaults['minimum_fee'], NULL, '%a');
+      $defaults['minimum_fee'] = CRM_Utils_Money::formatLongDecimal($defaults['minimum_fee']);
     }
 
     if (isset($defaults['status'])) {

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -838,9 +838,7 @@ WHERE  id = %1";
         $params['amount_level'] = CRM_Core_DAO::VALUE_SEPARATOR . implode(CRM_Core_DAO::VALUE_SEPARATOR, $amount_level) . $displayParticipantCount . CRM_Core_DAO::VALUE_SEPARATOR;
       }
     }
-    // @todo this was a fix for CRM-16460 but is too deep in the system for formatting
-    // and probably causes negative amounts to save as $0 depending on server config.
-    $params['amount'] = CRM_Utils_Money::format($totalPrice, NULL, NULL, TRUE);
+    $params['amount'] = CRM_Utils_Money::formatLongDecimal($totalPrice);
     $params['tax_amount'] = $totalTax;
     if ($component) {
       foreach ($autoRenew as $dontCare => $eachAmount) {

--- a/templates/CRM/Price/Form/Field.tpl
+++ b/templates/CRM/Price/Form/Field.tpl
@@ -218,7 +218,7 @@
     var postUrl = "{/literal}{crmURL p='civicrm/ajax/memType' h=0}{literal}";
 
     cj.post( postUrl, {mtype: mtype}, function(data) {
-      cj("#option_amount_"+ row).val(data.total_amount);
+      cj("#option_amount_"+ row).val(data.total_amount_numeric);
       cj("#option_label_"+ row).val(data.name);
       cj("#option_financial_type_id_"+ row).val(data.financial_type_id);
       if (data.name) {

--- a/templates/CRM/Price/Form/Option.tpl
+++ b/templates/CRM/Price/Form/Option.tpl
@@ -115,7 +115,7 @@
         var mtype = cj("#membership_type_id").val();
         var postUrl = "{/literal}{crmURL p='civicrm/ajax/memType' h=0}{literal}";
         cj.post( postUrl, {mtype: mtype}, function( data ) {
-          cj("#amount").val( data.total_amount );
+          cj("#amount").val( data.total_amount_numeric );
           cj("#label").val( data.name );
 
         }, 'json');


### PR DESCRIPTION
Overview
----------------------------------------
_A brief description of the pull request. Try to keep it non-technical._

Before
----------------------------------------
Database fields used for calculations restrict amounts to 2 decimal places.

After
----------------------------------------
Database fields used for calculations are not restricted to 2 decimal places.

Technical Details
----------------------------------------
From dus
There are also currencies with more than two decimal places (https://en.wikipedia.org/wiki/ISO_4217#Active_codes) and bitcoin supports even more.

Now, the problem is that most amounts are stored in the DB as decimal(10,2) which means any precision greater than 2 decimal places is lost. For this particular issue (CRM-20772) I am only proposing changing a single field in MembershipType.minimum_fee as that is the only one that impacts on this issue (civicrm_price_field_value.amount is where most monetary values end up and is stored as varchar(512) (though probably shouldn't be)).

What I would like to identify, is what is a sensible datatype that I should change minimum_fee to, and that we should standardise on in future for monetary amounts?

Most fields holding monetary amounts in the db are decimal(10,2), some are decimal(20,2), tax_rate is decimal(10,8).
We should probably change civicrm_price_field_value.amount from varchar(512) to something more sensible - but that's probably too risky a change at this stage.
We should define a datatype that should be used to hold monetary amounts that supports more than the current two decimals.
The current datatype decimal(10,2) supports a maximum value of ten million: 10,000,000.00
Decimal(30,10) would support 10,000,000,000,000,000.0000000000
MySQL stores 9 decimal places in 4 bytes, decimals and fractions separately (https://dev.mysql.com/doc/refman/5.7/en/storage-requirements.html) meaning multiples of 9 are the most sensible values to use.
Currencies support up to 4 decimal places, bitcoin(BTC) apparently support 8 decimal places. So following GAAP accounting principals 10 decimal places gives the maximum required precision. So, 9 or 18 for decimal places?
For decimals, 9 gives 100,000,000 but we currently store 10, 18 gives 100,000,000,000,000,000 (one hundred thousand million million) which should be plenty?
So: decimal(18,9)?

Comments
----------------------------------------
This should be committed before other PRs on CRM-20772 as they are dependent on this one.

---

 * [CRM-20772: \(WIP\) Price set calculation precision when sales tax enabled](https://issues.civicrm.org/jira/browse/CRM-20772)