### PR TITLE
CRM-21214 -  Fix address sharing

### DIFF
--- a/CRM/Contact/BAO/Contact/Utils.php
+++ b/CRM/Contact/BAO/Contact/Utils.php
@@ -832,6 +832,14 @@ INNER JOIN civicrm_contact contact_target ON ( contact_target.id = act.contact_i
       $masterAddress->id = CRM_Utils_Array::value('master_id', $values);
       $masterAddress->find(TRUE);
 
+      //if address master address is shared, use its master (prevent chaining)
+      if ($masterAddress->master_id > 0) {
+        $values['master_id'] = $masterAddress->master_id;
+        $masterAddress = new CRM_Core_BAO_Address();
+        $masterAddress->id = CRM_Utils_Array::value('master_id', $values);
+        $masterAddress->find(TRUE);
+      }
+
       // 4. modify submitted params and update it with shared contact address
       // make sure you preserve specific form values like location type, is_primary_ is_billing, master_id
       // CRM-10336: Also empty any fields from the existing address block if they don't exist in master (otherwise they will persist)


### PR DESCRIPTION
Overview
----------------------------------------
With versions 4.7.24 and older, you can create a chain while sharing addresses.
Changing the head of the chain only changes the addresses 2nd in line.

Proposed fix:
Prevent chaining addresses ad infinitum, and prevent sharing an address with itself.
When changing a shared address, change the sharing too.

Before
----------------------------------------
Example 1
using an address from a contact that uses a shared address

Steps to reproduce:
1. First, create three contacts: A, B, and C
2. Create an address for contact A
3. Use contact A's address for contact B
4. Use contact B's address for contact C
5. Change contact A's address

Result:
Contact C's address is not changed

Example 2
using an shared address for a contact that shares its address

Steps to reproduce:
1. First, create three contacts: A, B, and C
2. Create an address for contact A
3. Create a different address for contact B
4. Use contact A's address for contact C
5. Use contact B's address for contact A

Result:
Contact C's address is not changed

After
----------------------------------------
Example 1
Using contact B's address for contact A changes its own address AND contact C's address

Example 2
Changing contact A's address changes contact B's AND C's addresses

Comments
----------------------------------------
This is my first pull request to core, I hope that I am following the coding style.
Am not sure if I am handling translations [ts()] correctly.

---

 * [CRM-21214: Chaining shared addresses doesn't work correctly](https://issues.civicrm.org/jira/browse/CRM-21214)