### PR TITLE
CRM-21216 Replace member_BAO_membershiptype_getMembershipTypesByOrg with API eq…

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -849,8 +849,10 @@ INNER JOIN  civicrm_membership_type type ON ( type.id = membership.membership_ty
       $params = array('id' => $memType);
       $membershipType = array();
       if (CRM_Member_BAO_MembershipType::retrieve($params, $membershipType)) {
-        $memberTypesSameParentOrg = CRM_Member_BAO_MembershipType::getMembershipTypesByOrg($membershipType['member_of_contact_id']);
-        $memberTypesSameParentOrgList = implode(',', array_keys($memberTypesSameParentOrg));
+        $memberTypesSameParentOrg = civicrm_api3('MembershipType', 'get', array(
+          'member_of_contact_id' => $membershipType['member_of_contact_id'],
+        ));
+        $memberTypesSameParentOrgList = implode(',', array_keys(CRM_Utils_Array::value('values', $memberTypesSameParentOrg, array())));
         $dao->whereAdd('membership_type_id IN (' . $memberTypesSameParentOrgList . ')');
       }
     }

--- a/CRM/Member/BAO/MembershipType.php
+++ b/CRM/Member/BAO/MembershipType.php
@@ -610,8 +610,8 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
   }
 
   /**
-   * Retrieve all Membership Types associated.
-   * with an Organization
+   * @deprecated Please use the Membership API
+   * Retrieve all Membership Types associated with an Organization
    *
    * @param int $orgID
    *   Id of Organization.

--- a/CRM/Member/Page/Tab.php
+++ b/CRM/Member/Page/Tab.php
@@ -192,7 +192,11 @@ class CRM_Member_Page_Tab extends CRM_Core_Page {
 
     //Below code gives list of all Membership Types associated
     //with an Organization(CRM-2016)
-    $membershipTypes = CRM_Member_BAO_MembershipType::getMembershipTypesByOrg($this->_contactId);
+    $membershipTypesResult = civicrm_api3('MembershipType', 'get', array(
+      'member_of_contact_id' => $this->_contactId,
+    ));
+    $membershipTypes = CRM_Utils_Array::value('values', $membershipTypesResult, NULL);
+
     foreach ($membershipTypes as $key => $value) {
       $membershipTypes[$key]['action'] = CRM_Core_Action::formLink(self::membershipTypeslinks(),
         $mask,

--- a/tests/phpunit/CRM/Member/BAO/MembershipTypeTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipTypeTest.php
@@ -358,10 +358,16 @@ class CRM_Member_BAO_MembershipTypeTest extends CiviUnitTestCase {
     );
     $membershipType = CRM_Member_BAO_MembershipType::add($params, $ids);
 
-    $result = CRM_Member_BAO_MembershipType::getMembershipTypesByOrg($this->_orgContactID);
+    $membershipTypesResult = civicrm_api3('MembershipType', 'get', array(
+      'member_of_contact_id' => $this->_orgContactID,
+    ));
+    $result = CRM_Utils_Array::value('values', $membershipTypesResult, NULL);
     $this->assertEquals(empty($result), FALSE, 'Verify membership types for organization.');
 
-    $result = CRM_Member_BAO_MembershipType::getMembershipTypesByOrg(501);
+    $membershipTypesResult = civicrm_api3('MembershipType', 'get', array(
+      'member_of_contact_id' => 501,
+    ));
+    $result = CRM_Utils_Array::value('values', $membershipTypesResult, NULL);
     $this->assertEquals(empty($result), TRUE, 'Verify membership types for organization.');
 
     $this->membershipTypeDelete(array('id' => $membershipType->id));


### PR DESCRIPTION
…uivalent

Overview
----------------------------------------
Replace the BAO function getMembershipTypesByOrg with generic API function.

Before
----------------------------------------
Custom code that does the same as the API

After
----------------------------------------
Generic API is used to retrieve the same information in the same format.

Technical Details
----------------------------------------
The API supports the necessary parameters to retrieve the information that is being retrieved by the custom function.
