### PR TITLE
CRM-21217 fix issues preventing E2E tests running for backdrop

### DIFF
--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -334,7 +334,9 @@ class CRM_Utils_System_Backdrop extends CRM_Utils_System_DrupalBase {
       // SOAP cannot load Backdrop bootstrap and hence we do it the old way
       // Contact CiviSMTP folks if we run into issues with this :)
       $cmsPath = $this->cmsRootPath();
-      define(BACKDROP_ROOT, $cmsPath);
+      if (!defined('BACKDROP_ROOT')) {
+        define(BACKDROP_ROOT, $cmsPath);
+      }
       require_once "$cmsPath/core/includes/bootstrap.inc";
       require_once "$cmsPath/core/includes/password.inc";
 

--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -334,7 +334,7 @@ class CRM_Utils_System_Backdrop extends CRM_Utils_System_DrupalBase {
       // SOAP cannot load Backdrop bootstrap and hence we do it the old way
       // Contact CiviSMTP folks if we run into issues with this :)
       $cmsPath = $this->cmsRootPath();
-
+      define(BACKDROP_ROOT, $cmsPath);
       require_once "$cmsPath/core/includes/bootstrap.inc";
       require_once "$cmsPath/core/includes/password.inc";
 
@@ -527,6 +527,7 @@ AND    u.status = 1
       }
     }
     require_once "$cmsPath/core/includes/bootstrap.inc";
+    require_once "$cmsPath/core/includes/config.inc";
     backdrop_bootstrap(BACKDROP_BOOTSTRAP_FULL);
 
     // Explicitly setting error reporting, since we cannot handle Backdrop


### PR DESCRIPTION
Overview
----------------------------------------
Previous phpunit E2E tests could not work on backdrop due to errors in the tests

Before
----------------------------------------
When bootstrapping backdrop it was struggling to load necessary backdrop files

After
----------------------------------------
correctly loads backdrop core files and E2E tests pass locally

Technical Details
----------------------------------------
The key things here was `BACKDROP_ROOT` wasn't getting defined properly and the config file wasn't getting loaded

Comments
----------------------------------------
To test this checkout the code in backdrop then run `civi-test-run -b <buildname> -j ~/junit phpunit-e2e` verify no errors are found @herbdool @totten does this look right to both of you?

---

 * [CRM-21217: Enable E2E tests for Backdrop CMS](https://issues.civicrm.org/jira/browse/CRM-21217)