### PR TITLE
CRM-21218 Improve component statics flushing

### DIFF
--- a/CRM/Core/Component.php
+++ b/CRM/Core/Component.php
@@ -139,7 +139,7 @@ class CRM_Core_Component {
   }
 
   static public function flushEnabledComponents() {
-    self::getEnabledComponents(TRUE);
+    unset(Civi::$statics[__CLASS__]);
   }
 
   /**


### PR DESCRIPTION
Without this I'm seeing it try to rebuild when it should just be flushing.

Overview
----------------------------------------
This fixes test failures on the extended report extension which enables components in it's setup. It is hitting problems with the newly enabled components still being excluded in some static caches. These show up on our nightly test matrix


Before
----------------------------------------
Test failures in ExtendedReports due to Civi::$statics['CRM_Core_Component]['info'] not holding info for all components

After
----------------------------------------
Tests work. I don't believe changes should affect elsewhere, although I flush the caches slightly more thoroughly is is on an rare action.

Technical Details
----------------------------------------
The 'onChange' callback for settings are called BEFORE they are saved. Currently CRM_Core_Components::flushEnabledComponents is called & it causes the components to be reloaded. However, the reload should happen AFTER the setting is saved. This changes that function to simply flush the static & not to reload, allowing a better reload later. 

There are a few places where that class static is used & I opted for flushing the whole class. It feels safer to clear all cached vars relating to the thing we are changing, and I don't believe this is an action where any performance cost is important.

Comments
----------------------------------------
@totten can you review this.

---

 * [CRM-21218: Improve component statics flushing](https://issues.civicrm.org/jira/browse/CRM-21218)