### PR TITLE
CRM-21201: Tax recalculated when pay later contribution is completed using Pay Now

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -98,7 +98,7 @@
     {else}
       <div class="display-block">
         <td class="label">{$form.total_amount.label}</td>
-        <td><span>{$form.total_amount.html|crmMoney}</span></td>
+        <td><span>{$form.total_amount.html|crmMoney}&nbsp;&nbsp;{if $taxAmount}(includes {$taxTerm} of {$taxAmount|crmMoney}){/if}</span></td>
       </div>
     {/if}
   {else}


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate:
1. Add contribution with tax i.e 100 + 10 (tax) = $110 with status as Pending(pay later)
2. On user dashboard click on Pay Now and complete the transaction


Before
----------------------------------------
The confirm and thank you page shows correct amount i.e $110 but contribution total amount is updated to $121.00(i.e tax is recalculated for $110 + 11 = $121) and also there is unbalance transaction recorded in financial table.

After
----------------------------------------
1. The contribution amount is correctly set to $110
2. At online registration page, besides total amount field, it tells about the included tax amount.
![image](https://user-images.githubusercontent.com/3735621/30800042-603fabaa-a1fc-11e7-9f56-34d3481675d1.png)


Technical Details
----------------------------------------
Moved the form variable assignment into a separate function that also calculates and set tax amount unlike earlier. Unfortunately, cannot add a unit test to assert the contribution details updated after ```CRM_Contribute_Form_Contribution_Confirm``` form submission as per 'Pay Now' workflow.

---

 * [CRM-21201: Tax recalculated when pay later contribution is completed using Pay Now](https://issues.civicrm.org/jira/browse/CRM-21201)