### PR TITLE
CRM-21221 fix logic precedence error when finding contribution record

### DIFF
--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -525,8 +525,7 @@ function civicrm_api3_contribution_completetransaction(&$params) {
   }
   $contribution = new CRM_Contribute_BAO_Contribution();
   $contribution->id = $params['id'];
-  $contribution->find(TRUE);
-  if (!$contribution->id == $params['id']) {
+  if (!$contribution->find(TRUE)) {
     throw new API_Exception('A valid contribution ID is required', 'invalid_data');
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
CiviContribute does not properly check the correct Contribution record was fetched in the completetransaction API call. 

After
----------------------------------------
It now determines the success of the find() call by looking at the return value, instead of comparing a property.

Technical Details
----------------------------------------
Probably doesn't make one bit of difference, but no point having duff code in there, eh?!

---

 * [CRM-21221: Precedence order logic bug in Contribution.completetransaction ](https://issues.civicrm.org/jira/browse/CRM-21221)