### PR TITLE
CRM-21195: Updating navigation menu item icon field help text

### DIFF
--- a/templates/CRM/Admin/Form/Navigation.hlp
+++ b/templates/CRM/Admin/Form/Navigation.hlp
@@ -34,7 +34,7 @@
   {ts}Icon{/ts}
 {/htxt}
 {htxt id="id-menu_icon"}
-{ts}The CSS class for the menu item icon, for example to add a (Font Awesome) phone icon you need to set this value to (fa fa-phone).{/ts}
+{ts}Select an icon to appear to the left side of the navigation menu item.{/ts}
 {/htxt}
 
 {htxt id="id-parent-title"}


### PR DESCRIPTION
Updating the navigation menu item add/edit form help text for the icon field since it is no longer accurate after this PR get merged :  https://github.com/civicrm/civicrm-core/pull/11025

---

 * [CRM-21195: Adding the ability to add icons to menu items](https://issues.civicrm.org/jira/browse/CRM-21195)