### PR TITLE
CRM-21216 Remove api limit, make deprecated function more deprecated

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -851,6 +851,9 @@ INNER JOIN  civicrm_membership_type type ON ( type.id = membership.membership_ty
       if (CRM_Member_BAO_MembershipType::retrieve($params, $membershipType)) {
         $memberTypesSameParentOrg = civicrm_api3('MembershipType', 'get', array(
           'member_of_contact_id' => $membershipType['member_of_contact_id'],
+          'options' => array(
+            'limit' => 0,
+          ),
         ));
         $memberTypesSameParentOrgList = implode(',', array_keys(CRM_Utils_Array::value('values', $memberTypesSameParentOrg, array())));
         $dao->whereAdd('membership_type_id IN (' . $memberTypesSameParentOrgList . ')');

--- a/CRM/Member/BAO/MembershipType.php
+++ b/CRM/Member/BAO/MembershipType.php
@@ -620,15 +620,14 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
    *   array of the details of membership types
    */
   public static function getMembershipTypesByOrg($orgID) {
-    $membershipTypes = array();
-    $dao = new CRM_Member_DAO_MembershipType();
-    $dao->member_of_contact_id = $orgID;
-    $dao->find();
-    while ($dao->fetch()) {
-      $membershipTypes[$dao->id] = array();
-      CRM_Core_DAO::storeValues($dao, $membershipTypes[$dao->id]);
-    }
-    return $membershipTypes;
+    Civi::log()->warning('Deprecated function getMembershipTypesByOrg, please user membership_type api', array('civi.tag' => 'deprecated'));
+    $memberTypesSameParentOrg = civicrm_api3('MembershipType', 'get', array(
+      'member_of_contact_id' => $orgID,
+      'options' => array(
+        'limit' => 0,
+      ),
+    ));
+    return CRM_Utils_Array::value('values', $memberTypesSameParentOrg, array());
   }
 
   /**

--- a/CRM/Member/Page/Tab.php
+++ b/CRM/Member/Page/Tab.php
@@ -194,6 +194,9 @@ class CRM_Member_Page_Tab extends CRM_Core_Page {
     //with an Organization(CRM-2016)
     $membershipTypesResult = civicrm_api3('MembershipType', 'get', array(
       'member_of_contact_id' => $this->_contactId,
+      'options' => array(
+        'limit' => 0,
+      ),
     ));
     $membershipTypes = CRM_Utils_Array::value('values', $membershipTypesResult, NULL);
 

--- a/tests/phpunit/CRM/Member/BAO/MembershipTypeTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipTypeTest.php
@@ -360,12 +360,18 @@ class CRM_Member_BAO_MembershipTypeTest extends CiviUnitTestCase {
 
     $membershipTypesResult = civicrm_api3('MembershipType', 'get', array(
       'member_of_contact_id' => $this->_orgContactID,
+      'options' => array(
+        'limit' => 0,
+      ),
     ));
     $result = CRM_Utils_Array::value('values', $membershipTypesResult, NULL);
     $this->assertEquals(empty($result), FALSE, 'Verify membership types for organization.');
 
     $membershipTypesResult = civicrm_api3('MembershipType', 'get', array(
       'member_of_contact_id' => 501,
+      'options' => array(
+        'limit' => 0,
+      ),
     ));
     $result = CRM_Utils_Array::value('values', $membershipTypesResult, NULL);
     $this->assertEquals(empty($result), TRUE, 'Verify membership types for organization.');


### PR DESCRIPTION
Overview
----------------------------------------
Fixes based on comments from previous PR #11020.

Assuming this passes tests it should be merged as the previous patch inadvertently introduces a limit on 25 membership types.

@eileenmcnaughton thanks for the previous merge.  This one fixes the issues identified in comments.

---

 * [CRM-21216: Replace member_BAO_membershiptype_getMembershipTypesByOrg with API equivalent](https://issues.civicrm.org/jira/browse/CRM-21216)