### PR TITLE
CRM-21227 Fix test following merge of PR #10435

### DIFF
--- a/CRM/Admin/Form/RelationshipType.php
+++ b/CRM/Admin/Form/RelationshipType.php
@@ -117,7 +117,7 @@ class CRM_Admin_Form_RelationshipType extends CRM_Admin_Form {
         $defaults['contact_types_a'] .= '__' . $defaults['contact_sub_type_a'];
       }
 
-      $defaults['contact_types_b'] = $defaults['contact_type_b'];
+      $defaults['contact_types_b'] = CRM_Utils_Array::value('contact_type_b', $defaults);
       if (!empty($defaults['contact_sub_type_b'])) {
         $defaults['contact_types_b'] .= '__' . $defaults['contact_sub_type_b'];
       }

--- a/CRM/Badge/Form/Layout.php
+++ b/CRM/Badge/Form/Layout.php
@@ -154,7 +154,7 @@ class CRM_Badge_Form_Layout extends CRM_Admin_Form {
   public function setDefaultValues() {
     if (isset($this->_id)) {
       $defaults = array_merge($this->_values,
-        CRM_Badge_BAO_Layout::getDecodedData($this->_values['data']));
+        CRM_Badge_BAO_Layout::getDecodedData(CRM_Utils_Array::value('data', $this->_values, '[]')));
     }
     else {
       for ($i = 1; $i <= self::FIELD_ROWCOUNT; $i++) {

--- a/CRM/Contact/Form/DedupeRules.php
+++ b/CRM/Contact/Form/DedupeRules.php
@@ -60,8 +60,8 @@ class CRM_Contact_Form_DedupeRules extends CRM_Admin_Form {
     $this->_rgid = CRM_Utils_Request::retrieve('id', 'Positive', $this, FALSE, 0);
     $contactTypes = civicrm_api3('Contact', 'getOptions', array('field' => "contact_type"));
     $contactType = CRM_Utils_Request::retrieve('contact_type', 'String', $this, FALSE, 0);
-    if (in_array($contactType, $contactTypes['values'])) {
-      $this->_contactType = $contactTypes['values'][$contactType];
+    if (CRM_Utils_Array::value($contactType, $contactTypes['values'])) {
+      $this->_contactType = CRM_Utils_Array::value($contactType, $contactTypes['values']);
     }
     elseif (!empty($contactType)) {
       throw new CRM_Core_Exception('Contact Type is Not valid');

--- a/CRM/Financial/Form/FinancialBatch.php
+++ b/CRM/Financial/Form/FinancialBatch.php
@@ -83,8 +83,7 @@ class CRM_Financial_Form_FinancialBatch extends CRM_Contribute_Form {
   public function buildQuickForm() {
     parent::buildQuickForm();
     $this->setPageTitle(ts('Financial Batch'));
-
-    if (isset($this->_id)) {
+    if (!empty($this->_id)) {
       $this->_title = CRM_Core_DAO::getFieldValue('CRM_Batch_DAO_Batch', $this->_id, 'title');
       CRM_Utils_System::setTitle($this->_title . ' - ' . ts('Accounting Batch'));
       $this->assign('batchTitle', $this->_title);


### PR DESCRIPTION
Overview
----------------------------------------
Test has started to fail i believe due to PR #10435 see https://test.civicrm.org/job/CiviCRM-Core-PR/17314/testReport/(root)/CRM_Core_Page_HookTest/testFormsCallBuildFormOnce/ as an example

Before
----------------------------------------
Test fails

After
----------------------------------------
Test passes

Technical Details
----------------------------------------
The PR made some changes to how `$defaults` is populated from requests which has made some cascading effects

ping @eileenmcnaughton @monishdeb

---

 * [CRM-21227: Fix issues in CRM_Core_Page_run test suite following merge of PR \#10435](https://issues.civicrm.org/jira/browse/CRM-21227)