### PR TITLE
CRM-21229 - don't regenerate smart groups on manage groups

### DIFF
--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -1017,31 +1017,10 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
       }
 
       // By default, we try to get a count of the contacts in each group
-      // to display to the user on the Manage Group page.
-      $skip_getcount = FALSE;
-      // If it's a smart group AND the contacts aren't cached, don't try to
-      // generate a count, it will take forever.
-      if ($object->saved_search_id) {
-        if (is_null($object->cache_date)) {
-          $skip_getcount = TRUE;
-        }
-        else {
-          // We have a cache_date - see if it is expired.
-          $params['name'] = 'smartGroupCacheTimeout';
-          $timeout = civicrm_api3('Setting', 'getvalue', $params);
-          $cache_expires = date('Y-m-d H:i:s', time() - (intval($timeout) * 60));
-          if ($cache_expires > $object->cache_date) {
-            $skip_getcount = TRUE;
-          }
-        }
-      }
-      if ($object->children) {
-        // If there are children, any of the children could be expired
-        // smart groups.
-        $skip_getcount = TRUE;
-      }
-
-      if ($skip_getcount) {
+      // to display to the user on the Manage Group page. However, if
+      // that will result in the cache being regenerated, then dipslay
+      // "unknown" instead to avoid a long wait for the user.
+      if (CRM_Contact_BAO_GroupContactCache::shouldGroupBeRefreshed($object->id)) {
         $values[$object->id]['count'] = ts('unknown');
       }
       else {

--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -1016,15 +1016,16 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
         $values[$object->id]['created_by'] = "<a href='{$contactUrl}'>{$object->created_by}</a>";
       }
 
-      // get group contact count using Contact.GetCount API
-      // CRM-20226 This has been added here in order to address a specific bug. However, a prior
-      // decision was to refresh group counts less aggressively, offering instead a button to
-      // refresh them to give users a better experience by loading pages quicker.
-      // For some sites this can be crazy slow even though only 25 sites resolve. Even for sites
-      // with relatively few smart groups it is not a good user experience.
-      // Adding comments here as I'm not going to tackle a fix this time around but want
-      // to warn people off making it worse.
-      $values[$object->id]['count'] = civicrm_api3('Contact', 'getcount', array('group' => $object->id));
+      // If it's a smart group AND the contacts aren't cached, don't try to
+      // generate a count, it will take forever.
+      if ($object->saved_search_id && is_null($object->cache_date)) {
+        $values[$object->id]['count'] = ts('unknown');
+      }
+      else {
+        // If it's not a smart group or we have them cached, then
+        // populate the count.
+        $values[$object->id]['count'] = civicrm_api3('Contact', 'getcount', array('group' => $object->id));
+      }
     }
 
     // CRM-16905 - Sort by count cannot be done with sql

--- a/tests/phpunit/CRM/Group/Page/AjaxTest.php
+++ b/tests/phpunit/CRM/Group/Page/AjaxTest.php
@@ -26,6 +26,10 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
 
   public function setUp() {
     parent::setUp();
+    // CRM_Contact_BAO_Group::getPermissionClause sets a static variable.
+    // Ensure it is reset before each run.
+    $force = TRUE;
+    CRM_Contact_BAO_Group::getPermissionClause($force);
     $this->_params = array(
       'page' => 1,
       'rp' => 50,


### PR DESCRIPTION
It takes too long.

Overview
----------------------------------------
The Manage Groups page has a button allowing you to refresh the smart group cache to get accurate counts so that the Manage Group page can load quickly under normal circumstances. That behavior changed with CRM-20226, resulting in group cache regeneration everytime the Manage Group page was accessed and a smart group listed had an empty cache. This is painfully slow.

Before
----------------------------------------
Accessing the Manage Group page is painfully slow if you have smart groups with empty caches. Same is true if you search for a smart group - you have to wait for the contacts to be populated before the group is displayed.

After
----------------------------------------
The Manage Group page does not regenerate expired smart group caches to get the accurate count. Instead, it displays "unknown".

---

 * [CRM-21229: Manage Group page is slow if you have smart groups](https://issues.civicrm.org/jira/browse/CRM-21229)
 * [CRM-20226: Parent Group do not inherit child group contacts](https://issues.civicrm.org/jira/browse/CRM-20226)