### PR TITLE
CRM-21231: On CiviMail screen make 'Review and Schedule' tab active if required fields are filled

### DIFF
--- a/ang/crmUi.js
+++ b/ang/crmUi.js
@@ -793,11 +793,7 @@
           };
           this.isSelectable = function(step) {
             if (step.selected) return false;
-            var result = false;
-            angular.forEach(steps, function(otherStep, otherKey) {
-              if (step === otherStep && otherKey <= maxVisited) result = true;
-            });
-            return result;
+            return this.$validStep();
           };
 
           /*** @param Object step the $scope of the step */


### PR DESCRIPTION
Overview
----------------------------------------
The Review and Schedule tab selector becomes active after the user first visits the Review and Schedule screen by clicking the Next button on the Define Mailing screen. It would be preferable for the tab to behave like the next button - become active when all the required fields are completed.

Before
----------------------------------------
The second tab is disabled even if all required fields are filled. Screencast:
![civimail-before](https://user-images.githubusercontent.com/3735621/30965077-a40acca8-a471-11e7-8416-5a63590c6cc3.gif)

After
----------------------------------------
The second tab is enabled after all required fields are filled.
![civimail-after](https://user-images.githubusercontent.com/3735621/30965017-625ec868-a471-11e7-9016-55c3aa4b51d2.gif)

NOTE: Clear cache before testing.

---

 * [CRM-21231: On CiviMail screen make 'Review and Schedule' tab active if required fields are filled](https://issues.civicrm.org/jira/browse/CRM-21231)