### PR TITLE
CRM-21177: Fix for wrong recurring payment schedule when number of membership terms is specified in priceFieldValue

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1995,6 +1995,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       }
     }
     $form->set('memberPriceFieldIDS', $membershipPriceFieldIDs);
+    $form->setRecurringMembershipParams();
     $form->processFormSubmission(CRM_Utils_Array::value('contact_id', $params));
   }
 

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1514,8 +1514,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     }
     //@todo it should no longer be possible for it to get to this point & membership to not be an array
     if (is_array($membershipTypeIDs) && !empty($membershipContributionID)) {
-      $typesTerms = CRM_Utils_Array::value('types_terms', $membershipParams, array());
-
       $membershipLines = $nonMembershipLines = array();
       foreach ($unprocessedLineItems as $priceSetID => $lines) {
         foreach ($lines as $line) {
@@ -1536,6 +1534,8 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
           $membershipLineItems = $unprocessedLineItems;
         }
         $i++;
+
+        $typesTerms = CRM_Utils_Array::value('types_terms', $membershipParams, array());
         $numTerms = CRM_Utils_Array::value($memType, $typesTerms, 1);
         if (!empty($membershipContribution)) {
           $pendingStatus = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Pending');

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -2395,19 +2395,8 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
     if (!empty($priceFieldIds)) {
       $membershipParams['financial_type_id'] = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $priceFieldIds['id'], 'financial_type_id');
-      unset($priceFieldIds['id']);
-      $membershipTypeIds = array();
-      $membershipTypeTerms = array();
-      foreach ($priceFieldIds as $priceFieldId) {
-        $membershipTypeId = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceFieldValue', $priceFieldId, 'membership_type_id');
-        if ($membershipTypeId) {
-          $membershipTypeIds[] = $membershipTypeId;
-          $term = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceFieldValue', $priceFieldId, 'membership_num_terms') ? : 1;
-          $membershipTypeTerms[$membershipTypeId] = ($term > 1) ? $term : 1;
-        }
-      }
-      $membershipParams['selectMembership'] = $membershipTypeIds;
-      $membershipParams['types_terms'] = $membershipTypeTerms;
+      $membershipParams['types_terms'] = $this->getMembershipRecurringDetails();
+      $membershipParams['selectMembership'] = array_keys($membershipParams['types_terms']);
     }
     if (!empty($membershipParams['selectMembership'])) {
       // CRM-12233

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1536,7 +1536,8 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         $i++;
 
         $typesTerms = CRM_Utils_Array::value('types_terms', $membershipParams, array());
-        $numTerms = CRM_Utils_Array::value($memType, $typesTerms, 1);
+        $termDetails = CRM_Utils_Array::value($memType, $typesTerms);
+        $numTerms = CRM_Utils_Array::value('qty', $termDetails, 1);
         if (!empty($membershipContribution)) {
           $pendingStatus = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Pending');
           $pending = ($membershipContribution->contribution_status_id == $pendingStatus) ? TRUE : FALSE;
@@ -2395,7 +2396,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
     if (!empty($priceFieldIds)) {
       $membershipParams['financial_type_id'] = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $priceFieldIds['id'], 'financial_type_id');
-      $membershipParams['types_terms'] = $this->getMembershipRecurringDetails();
+      $membershipParams['types_terms'] = $this->getMembershipTermDetails();
       $membershipParams['selectMembership'] = array_keys($membershipParams['types_terms']);
     }
     if (!empty($membershipParams['selectMembership'])) {

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -2393,26 +2393,19 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $priceFieldIds = $this->get('memberPriceFieldIDS');
 
     if (!empty($priceFieldIds)) {
-      $financialTypeID = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $priceFieldIds['id'], 'financial_type_id');
+      $membershipParams['financial_type_id'] = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $priceFieldIds['id'], 'financial_type_id');
       unset($priceFieldIds['id']);
       $membershipTypeIds = array();
       $membershipTypeTerms = array();
       foreach ($priceFieldIds as $priceFieldId) {
-        if ($id = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceFieldValue', $priceFieldId, 'membership_type_id')) {
-          $membershipTypeIds[] = $id;
-          //@todo the value for $term is immediately overwritten. It is unclear from the code whether it was intentional to
-          // do this or a double = was intended (this ambiguity is the reason many IDEs complain about 'assignment in condition'
-          $term = 1;
-          if ($term = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceFieldValue', $priceFieldId, 'membership_num_terms')) {
-            $membershipTypeTerms[$id] = ($term > 1) ? $term : 1;
-          }
-          else {
-            $membershipTypeTerms[$id] = 1;
-          }
+        $membershipTypeId = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceFieldValue', $priceFieldId, 'membership_type_id');
+        if ($membershipTypeId) {
+          $membershipTypeIds[] = $membershipTypeId;
+          $term = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceFieldValue', $priceFieldId, 'membership_num_terms') ? : 1;
+          $membershipTypeTerms[$membershipTypeId] = ($term > 1) ? $term : 1;
         }
       }
       $membershipParams['selectMembership'] = $membershipTypeIds;
-      $membershipParams['financial_type_id'] = $financialTypeID;
       $membershipParams['types_terms'] = $membershipTypeTerms;
     }
     if (!empty($membershipParams['selectMembership'])) {

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -1282,12 +1282,12 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
   }
 
   /**
-   * Uses form properties to determine recurring details for memberships.
+   * Uses form properties to determine term details for memberships.
    *
    * @return array
    *   Term length keyed by membership type ID.
    */
-  protected function getMembershipRecurringDetails() {
+  protected function getMembershipTermDetails() {
     $membershipTypeTerms = array();
 
     $priceFieldIds = $this->get('memberPriceFieldIDS');
@@ -1297,8 +1297,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
     foreach ($priceFieldIds as $priceFieldId) {
       $membershipTypeId = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceFieldValue', $priceFieldId, 'membership_type_id');
       if ($membershipTypeId) {
-        $term = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceFieldValue', $priceFieldId, 'membership_num_terms') ? : 1;
-        $membershipTypeTerms[$membershipTypeId] = ($term > 1) ? $term : 1;
+        $membershipTypeTerms[$membershipTypeId] = CRM_Price_BAO_PriceFieldValue::getMembershipTermDetails($priceFieldId);
       }
     }
 

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -1282,6 +1282,30 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
   }
 
   /**
+   * Uses form properties to determine recurring details for memberships.
+   *
+   * @return array
+   *   Term length keyed by membership type ID.
+   */
+  protected function getMembershipRecurringDetails() {
+    $membershipTypeTerms = array();
+
+    $priceFieldIds = $this->get('memberPriceFieldIDS');
+    // The price set ID is irrelevant here; drop it.
+    unset($priceFieldIds['id']);
+
+    foreach ($priceFieldIds as $priceFieldId) {
+      $membershipTypeId = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceFieldValue', $priceFieldId, 'membership_type_id');
+      if ($membershipTypeId) {
+        $term = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceFieldValue', $priceFieldId, 'membership_num_terms') ? : 1;
+        $membershipTypeTerms[$membershipTypeId] = ($term > 1) ? $term : 1;
+      }
+    }
+
+    return $membershipTypeTerms;
+  }
+
+  /**
    * Determine if recurring parameters need to be added to the form parameters.
    *
    *  - is_recur

--- a/CRM/Price/BAO/PriceFieldValue.php
+++ b/CRM/Price/BAO/PriceFieldValue.php
@@ -226,7 +226,7 @@ class CRM_Price_BAO_PriceFieldValue extends CRM_Price_DAO_PriceFieldValue {
     $dao = CRM_Core_DAO::executeQuery($query, $params);
     $dao->fetch();
 
-    $details['qty'] = $dao->membership_num_terms ? : 1;
+    $details['qty'] = $dao->membership_num_terms ?: 1;
     $details['interval'] = $dao->duration_interval;
     $details['unit'] = $dao->duration_unit;
 

--- a/CRM/Price/BAO/PriceFieldValue.php
+++ b/CRM/Price/BAO/PriceFieldValue.php
@@ -202,6 +202,38 @@ class CRM_Price_BAO_PriceFieldValue extends CRM_Price_DAO_PriceFieldValue {
   }
 
   /**
+   * Retrieve membership term information associated with a price field value.
+   *
+   * @param int $id
+   *   PriceFieldValue ID.
+   *
+   * @return array
+   *   - unit: how a membership term is measured (month, year, etc.)
+   *   - interval: quantity of units in a term (e.g., ONE month)
+   *   - qty: how many terms the price field value purchases (e.g., THREE
+   *     one-month terms)
+   */
+  public static function getMembershipTermDetails($id) {
+    $details = array();
+
+    $query = 'SELECT p.membership_num_terms, m.duration_interval, m.duration_unit
+            FROM civicrm_price_field_value p
+            INNER JOIN civicrm_membership_type m
+            ON p.membership_type_id = m.id
+            WHERE p.id = %1 LIMIT 1';
+
+    $params = array(1 => array($id, 'Integer'));
+    $dao = CRM_Core_DAO::executeQuery($query, $params);
+    $dao->fetch();
+
+    $details['qty'] = $dao->membership_num_terms ? : 1;
+    $details['interval'] = $dao->duration_interval;
+    $details['unit'] = $dao->duration_unit;
+
+    return $details;
+  }
+
+  /**
    * Get the price field option label.
    *
    * @param int $id

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -1438,28 +1438,6 @@ GROUP BY     mt.member_of_contact_id ";
   }
 
   /**
-   * Retrieve auto renew frequency and interval.
-   *
-   * @param int $priceSetId
-   *   Price set id.
-   *
-   * @return array
-   *   associate array of frequency interval and unit
-   */
-  public static function getRecurDetails($priceSetId) {
-    $query = 'SELECT mt.duration_interval, mt.duration_unit
-            FROM civicrm_price_field_value pfv
-            INNER JOIN civicrm_membership_type mt ON pfv.membership_type_id = mt.id
-            INNER JOIN civicrm_price_field pf ON pfv.price_field_id = pf.id
-            WHERE pf.price_set_id = %1 LIMIT 1';
-
-    $params = array(1 => array($priceSetId, 'Integer'));
-    $dao = CRM_Core_DAO::executeQuery($query, $params);
-    $dao->fetch();
-    return array($dao->duration_interval, $dao->duration_unit);
-  }
-
-  /**
    * @return object
    */
   public static function eventPriceSetDomainID() {

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -1445,6 +1445,103 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
     $this->_ids['contribution_page'] = $contributionPageResult['id'];
   }
 
+  /**
+   * Helper function to set up contribution page which can be used to purchase a
+   * membership type for different intervals.
+   */
+  public function setUpMultiIntervalMembershipContributionPage() {
+    $this->setupPaymentProcessor();
+    $contributionPage = $this->callAPISuccess($this->_entity, 'create', $this->params);
+    $this->_ids['contribution_page'] = $contributionPage['id'];
+
+    $this->_ids['membership_type'] = $this->membershipTypeCreate(array(
+      'auto_renew' => 2, // force auto-renew
+      'duration_unit' => 'month',
+    ));
+
+    $priceSet = civicrm_api3('PriceSet', 'create', array(
+      'is_quick_config' => 0,
+      'extends' => 'CiviMember',
+      'financial_type_id' => 'Member Dues',
+      'title' => 'CRM-21177',
+    ));
+    $this->_ids['price_set'] = $priceSet['id'];
+
+    $priceField = $this->callAPISuccess('price_field', 'create', array(
+      'price_set_id' => $this->_ids['price_set'],
+      'name' => 'membership_type',
+      'label' => 'Membership Type',
+      'html_type' => 'Radio',
+    ));
+    $this->_ids['price_field'] = $priceField['id'];
+
+    $priceFieldValueMonthly = $this->callAPISuccess('price_field_value', 'create', array(
+      'name' => 'CRM-21177_Monthly',
+      'label' => 'CRM-21177 - Monthly',
+      'amount' => 20,
+      'membership_num_terms' => 1,
+      'membership_type_id' => $this->_ids['membership_type'],
+      'price_field_id' => $this->_ids['price_field'],
+      'financial_type_id' => 'Member Dues',
+    ));
+    $this->_ids['price_field_value_monthly'] = $priceFieldValueMonthly['id'];
+
+    $priceFieldValueYearly = $this->callAPISuccess('price_field_value', 'create', array(
+      'name' => 'CRM-21177_Yearly',
+      'label' => 'CRM-21177 - Yearly',
+      'amount' => 200,
+      'membership_num_terms' => 12,
+      'membership_type_id' => $this->_ids['membership_type'],
+      'price_field_id' => $this->_ids['price_field'],
+      'financial_type_id' => 'Member Dues',
+    ));
+    $this->_ids['price_field_value_yearly'] = $priceFieldValueYearly['id'];
+
+    CRM_Price_BAO_PriceSet::addTo('civicrm_contribution_page', $this->_ids['contribution_page'], $this->_ids['price_set']);
+
+    $this->callAPISuccess('membership_block', 'create', array(
+      'entity_id' => $this->_ids['contribution_page'],
+      'entity_table' => 'civicrm_contribution_page',
+      'is_required' => TRUE,
+      'is_separate_payment' => FALSE,
+      'is_active' => TRUE,
+      'membership_type_default' => $this->_ids['membership_type'],
+    ));
+  }
+
+  /**
+   * Test submit with a membership block in place.
+   */
+  public function testSubmitMultiIntervalMembershipContributionPage() {
+    $this->setUpMultiIntervalMembershipContributionPage();
+    $submitParams = array(
+      'price_' . $this->_ids['price_field'] => $this->_ids['price_field_value_monthly'],
+      'id' => (int) $this->_ids['contribution_page'],
+      'amount' => 20,
+      'first_name' => 'Billy',
+      'last_name' => 'Gruff',
+      'email' => 'billy@goat.gruff',
+      'payment_processor_id' => $this->_ids['payment_processor'],
+      'credit_card_number' => '4111111111111111',
+      'credit_card_type' => 'Visa',
+      'credit_card_exp_date' => array('M' => 9, 'Y' => 2040),
+      'cvv2' => 123,
+      'auto_renew' => 1,
+    );
+    $this->callAPISuccess('contribution_page', 'submit', $submitParams);
+
+    $submitParams['price_' . $this->_ids['price_field']] = $this->_ids['price_field_value_yearly'];
+    $this->callAPISuccess('contribution_page', 'submit', $submitParams);
+
+    $contribution = $this->callAPISuccess('Contribution', 'get', array(
+      'contribution_page_id' => $this->_ids['contribution_page'],
+      'sequential' => 1,
+      'api.ContributionRecur.getsingle' => array(),
+    ));
+    $this->assertEquals(1, $contribution['values'][0]['api.ContributionRecur.getsingle']['frequency_interval']);
+    $this->assertEquals(12, $contribution['values'][1]['api.ContributionRecur.getsingle']['frequency_interval']);
+  }
+
   public static function setUpBeforeClass() {
     // put stuff here that should happen before all tests in this unit
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fix for wrong recurring payment schedule when number of membership terms is specified in price field value.

I might create a membership type "Student" with an interval of 1 and unit of month to give members more purchasing options without making my reporting unnecessarily complicated. For example, I might create a price field with two options: 1 term (i.e., 1 month) at $20, or 12 terms (i.e., 1 year) at $200.

Before
----------------------------------------
Selecting the second option will create a recurring contribution schedule where the member is charged $200/mo instead of $200/year.

After
----------------------------------------
Recurring contribution schedules are created correctly.

Technical Details
----------------------------------------
* This PR brings the api.ContributionPage.submit method into closer alignment with the UI behavior; a unit test couldn't be written for this issue before.
* Recurrence schedule is now calculated from price fields rather than the mysterious and inconsistent selectMembership form parameter.
* Payment schedule now takes both the interval and the quantity of membership terms into account.

---

 * [CRM-21177: Wrong interval of recurring payment for auto-renewing membership](https://issues.civicrm.org/jira/browse/CRM-21177)