### PR TITLE
CRM-21236 - Make contact custom fields available in Membership Detail report

### DIFF
--- a/CRM/Report/Form/Member/Detail.php
+++ b/CRM/Report/Form/Member/Detail.php
@@ -44,7 +44,15 @@ class CRM_Report_Form_Member_Detail extends CRM_Report_Form {
 
   protected $_summary = NULL;
 
-  protected $_customGroupExtends = array('Membership', 'Contribution');
+  protected $_customGroupExtends = array(
+    'Membership',
+    'Contribution',
+    'Contact',
+    'Individual',
+    'Household',
+    'Organization',
+  );
+
   protected $_customGroupGroupBy = FALSE;
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
On Membership Report (Detail), custom fields on memberships & contributions are available but not those on contacts. This improvement makes custom fields on contacts available here too.

Before
----------------------------------------
On Membership Report (Detail), custom fields on memberships & contributions are available but not those on contacts.

After
----------------------------------------
On Membership Report (Detail), custom fields on memberships, contributions & contacts are available, including custom fields defined on individuals, organizations & households.

---

 * [CRM-21236: Make contact custom fields available in Membership Detail report](https://issues.civicrm.org/jira/browse/CRM-21236)