### PR TITLE
WIP: Fix CRM-21239: Fatal error on Drupal /user and profile view

### DIFF
--- a/CRM/Profile/Page/Dynamic.php
+++ b/CRM/Profile/Page/Dynamic.php
@@ -151,7 +151,7 @@ class CRM_Profile_Page_Dynamic extends CRM_Core_Page {
     }
 
     $this->_activityId = CRM_Utils_Request::retrieve('aid', 'Positive', $this, FALSE, 0, 'GET');
-    if (is_numeric($this->_activityId)) {
+    if (is_numeric($this->_activityId) && !empty($this->_activityId)) {
       $latestRevisionId = CRM_Activity_BAO_Activity::getLatestActivityId($this->_activityId);
       if ($latestRevisionId) {
         $this->_activityId = $latestRevisionId;


### PR DESCRIPTION
Overview
----------------------------------------
The PR at https://github.com/civicrm/civicrm-core/pull/10435 introduces a regression whereby a fatal error appears on pages under /user in Drupal. That PR causes CRM_Utils_Request::retrieve() to (correctly, IMO) return the given default value in certain cases where before it was (wrongly, IMO) returning NULL.

As a result, the profile display on the Drupal user page, which is looking for an activity and finds none, proceeds to find out more about that non-existent activity instead of moving on to other things; thus the fatal error.

Before
----------------------------------------
Visit /user, and observe a CiviCRM fatal error.

After
----------------------------------------
Visit /user, and observe correct display of the page.

Technical Details
----------------------------------------
This fix is only for the specific issue described in CRM-21239. However, I'm concerned that other surprises may be lurking.  CRM_Utils_Request::retrieve() is very heavily used (in 322 files at present), and it seems overly hopeful to assume that none of those will be affected by the same issue.

---

 * [CRM-21239: Fatal error on Drupal \/user and \/user\/%](https://issues.civicrm.org/jira/browse/CRM-21239)