### PR TITLE
CRM-21244 Enhancements to "FROM email addresses"

### DIFF
--- a/CRM/Admin/Form/Setting/Smtp.php
+++ b/CRM/Admin/Form/Setting/Smtp.php
@@ -52,6 +52,7 @@ class CRM_Admin_Form_Setting_Smtp extends CRM_Admin_Form_Setting {
     $this->addRadio('outBound_option', ts('Select Mailer'), $outBoundOption);
 
     CRM_Utils_System::setTitle(ts('Settings - Outbound Mail'));
+    $this->add('checkbox', 'allow_mail_from_logged_in_contact', ts('Allow Mail to be sent from logged in contact\'s email address'));
     $this->add('text', 'sendmail_path', ts('Sendmail Path'));
     $this->add('text', 'sendmail_args', ts('Sendmail Argument'));
     $this->add('text', 'smtpServer', ts('SMTP Server'));
@@ -78,6 +79,9 @@ class CRM_Admin_Form_Setting_Smtp extends CRM_Admin_Form_Setting {
     CRM_Utils_System::flushCache();
 
     $formValues = $this->controller->exportValues($this->_name);
+
+    Civi::settings()->set('allow_mail_from_logged_in_contact', (!empty($formValues['allow_mail_from_logged_in_contact'])));
+    unset($formValues['allow_mail_from_logged_in_contact']);
 
     $buttonName = $this->controller->getButtonName();
     // check if test button
@@ -259,6 +263,7 @@ class CRM_Admin_Form_Setting_Smtp extends CRM_Admin_Form_Setting {
         }
       }
     }
+    $this->_defaults['allow_mail_from_logged_in_contact'] = Civi::settings()->get('allow_mail_from_logged_in_contact');
     return $this->_defaults;
   }
 

--- a/CRM/Contact/BAO/Contact/Location.php
+++ b/CRM/Contact/BAO/Contact/Location.php
@@ -45,29 +45,19 @@ class CRM_Contact_BAO_Contact_Location {
    *   Array of display_name, email, location type and location id if found, or (null,null,null, null)
    */
   public static function getEmailDetails($id, $isPrimary = TRUE, $locationTypeID = NULL) {
-    $primaryClause = NULL;
+    $params = array(
+      'location_type_id' => $locationTypeID,
+      'contact_id' => $id,
+      'return' => array('contact_id.display_name', 'email', 'location_type_id', 'id'),
+    );
     if ($isPrimary) {
-      $primaryClause = " AND civicrm_email.is_primary = 1";
+      $params['is_primary'] = 1;
     }
+    $emails = civicrm_api3('Email', 'get', $params);
 
-    $locationClause = NULL;
-    if ($locationTypeID) {
-      $locationClause = " AND civicrm_email.location_type_id = $locationTypeID";
-    }
-
-    $sql = "
-SELECT    civicrm_contact.display_name,
-          civicrm_email.email,
-          civicrm_email.location_type_id,
-          civicrm_email.id
-FROM      civicrm_contact
-LEFT JOIN civicrm_email ON ( civicrm_contact.id = civicrm_email.contact_id {$primaryClause} {$locationClause} )
-WHERE     civicrm_contact.id = %1";
-
-    $params = array(1 => array($id, 'Integer'));
-    $dao = CRM_Core_DAO::executeQuery($sql, $params);
-    if ($dao->fetch()) {
-      return array($dao->display_name, $dao->email, $dao->location_type_id, $dao->id);
+    if ($emails['count'] > 0) {
+      $email = reset($emails['values']);
+      return array($email['contact_id.display_name'], $email['email'], $email['location_type_id'], $email['id']);
     }
     return array(NULL, NULL, NULL, NULL);
   }

--- a/CRM/Contact/Form/Domain.php
+++ b/CRM/Contact/Form/Domain.php
@@ -118,19 +118,6 @@ class CRM_Contact_Form_Domain extends CRM_Core_Form {
       $params['id'] = $this->_id;
       CRM_Core_BAO_Domain::retrieve($params, $domainDefaults);
       $this->_contactId = $domainDefaults['contact_id'];
-      //get the default domain from email address. fix CRM-3552
-      $optionValues = array();
-      $grpParams['name'] = 'from_email_address';
-      CRM_Core_OptionValue::getValues($grpParams, $optionValues);
-      foreach ($optionValues as $Id => $value) {
-        if ($value['is_default'] && $value['is_active']) {
-          $this->_fromEmailId = $Id;
-          $list = explode('"', $value['label']);
-          $domainDefaults['email_name'] = CRM_Utils_Array::value(1, $list);
-          $domainDefaults['email_address'] = CRM_Utils_Mail::pluckEmailFromHeader($value['label']);
-          break;
-        }
-      }
 
       unset($params['id']);
       $locParams = array('contact_id' => $domainDefaults['contact_id']);
@@ -156,9 +143,6 @@ class CRM_Contact_Form_Domain extends CRM_Core_Form {
   public function buildQuickForm() {
     $this->addField('name', array('label' => ts('Organization Name')), TRUE);
     $this->addField('description', array('label' => ts('Description'), 'size' => 30));
-    $this->add('text', 'email_name', ts('FROM Name'), CRM_Core_DAO::getAttribute('CRM_Core_DAO_Email', 'email'), TRUE);
-    $this->add('text', 'email_address', ts('FROM Email Address'), CRM_Core_DAO::getAttribute('CRM_Core_DAO_Email', 'email'), TRUE);
-    $this->addRule('email_address', ts('Domain Email Address must use a valid email address format (e.g. \'info@example.org\').'), 'email');
 
     //build location blocks.
     CRM_Contact_Form_Location::buildQuickForm($this);
@@ -207,16 +191,6 @@ class CRM_Contact_Form_Domain extends CRM_Core_Form {
       $errors = array();
     }
 
-    //fix for CRM-3552,
-    //as we use "fromName"<emailaddresss> format for domain email.
-    if (strpos($fields['email_name'], '"') !== FALSE) {
-      $errors['email_name'] = ts('Double quotes are not allow in from name.');
-    }
-
-    // Check for default from email address and organization (domain) name. Force them to change it.
-    if ($fields['email_address'] == 'info@EXAMPLE.ORG') {
-      $errors['email_address'] = ts('Please enter a valid default FROM email address for system-generated emails.');
-    }
     if ($fields['name'] == 'Default Domain Name') {
       $errors['name'] = ts('Please enter the name of the organization or entity which owns this CiviCRM site.');
     }
@@ -274,36 +248,6 @@ class CRM_Contact_Form_Domain extends CRM_Core_Form {
     CRM_Core_BAO_Location::create($params, TRUE);
 
     CRM_Core_BAO_Domain::edit($params, $this->_id);
-
-    //set domain from email address, CRM-3552
-    $emailName = '"' . $params['email_name'] . '" <' . $params['email_address'] . '>';
-
-    $emailParams = array(
-      'label' => $emailName,
-      'description' => $params['description'],
-      'is_active' => 1,
-      'is_default' => 1,
-    );
-
-    $groupParams = array('name' => 'from_email_address');
-
-    //get the option value wt.
-    if ($this->_fromEmailId) {
-      $action = $this->_action;
-      $emailParams['weight'] = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionValue', $this->_fromEmailId, 'weight');
-    }
-    else {
-      //add from email address.
-      $action = CRM_Core_Action::ADD;
-      $grpId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', 'from_email_address', 'id', 'name');
-      $fieldValues = array('option_group_id' => $grpId);
-      $emailParams['weight'] = CRM_Utils_Weight::getDefaultWeight('CRM_Core_DAO_OptionValue', $fieldValues);
-    }
-
-    //reset default within domain.
-    $emailParams['reset_default_for'] = array('domain_id' => CRM_Core_Config::domainID());
-
-    CRM_Core_OptionValue::addOptionValue($emailParams, $groupParams, $action, $this->_fromEmailId);
 
     CRM_Core_Session::setStatus(ts("Domain information for '%1' has been saved.", array(1 => $domain->name)), ts('Saved'), 'success');
     $session = CRM_Core_Session::singleton();

--- a/CRM/Contact/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contact/Form/Task/PDFLetterCommon.php
@@ -58,6 +58,7 @@ class CRM_Contact_Form_Task_PDFLetterCommon {
    * @param CRM_Core_Form $form
    */
   public static function preProcess(&$form) {
+    CRM_Contact_Form_Task_EmailCommon::preProcessFromAddress($form);
     $messageText = array();
     $messageSubject = array();
     $dao = new CRM_Core_BAO_MessageTemplate();
@@ -103,6 +104,8 @@ class CRM_Contact_Form_Task_PDFLetterCommon {
       array('size' => 45, 'maxlength' => 255),
       FALSE
     );
+
+    $form->add('select', 'from_email_address', ts('From Email Address'), $form->_fromEmails, TRUE);
 
     $form->add('static', 'pdf_format_header', NULL, ts('Page Format: %1', array(1 => '<span class="pdf-format-header-label"></span>')));
     $form->addSelect('format_id', array(

--- a/CRM/Contact/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contact/Form/Task/PDFLetterCommon.php
@@ -105,8 +105,6 @@ class CRM_Contact_Form_Task_PDFLetterCommon {
       FALSE
     );
 
-    $form->add('select', 'from_email_address', ts('From Email Address'), $form->_fromEmails, TRUE);
-
     $form->add('static', 'pdf_format_header', NULL, ts('Page Format: %1', array(1 => '<span class="pdf-format-header-label"></span>')));
     $form->addSelect('format_id', array(
       'label' => ts('Select Format'),

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4736,7 +4736,7 @@ WHERE eft.financial_trxn_id IN ({$trxnId}, {$baseTrxnId['financialTrxnId']})
    * @return array
    */
   public static function generateFromEmailAndName($input, $contribution) {
-    // Use input valuse if supplied.
+    // Use input value if supplied.
     if (!empty($input['receipt_from_email'])) {
       return array(CRM_Utils_array::value('receipt_from_name', $input, ''), $input['receipt_from_email']);
     }

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1685,7 +1685,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
         $formValues += CRM_Contribute_BAO_ContributionSoft::getSoftContribution($contribution->id);
 
         // to get 'from email id' for send receipt
-        $this->fromEmailId = $formValues['from_email_address'];
+        $this->fromEmailId = CRM_Utils_Array::value('from_email_address', $formValues);
         if (CRM_Contribute_Form_AdditionalInfo::emailReceipt($this, $formValues)) {
           $this->statusMessage[] = ts('A receipt has been emailed to the contributor.');
         }

--- a/CRM/Contribute/Form/Task/PDF.php
+++ b/CRM/Contribute/Form/Task/PDF.php
@@ -119,7 +119,7 @@ AND    {$this->_componentClause}";
     $this->add('checkbox', 'receipt_update', ts('Update receipt dates for these contributions'), FALSE);
     $this->add('checkbox', 'override_privacy', ts('Override privacy setting? (Do not email / Do not mail)'), FALSE);
 
-    $this->add('select', 'fromEmailAddress', ts('From Email'), $this->_fromEmails, FALSE, array('class' => 'crm-select2 huge'));
+    $this->add('select', 'from_email_address', ts('From Email'), $this->_fromEmails, FALSE);
 
     $this->addButtons(array(
         array(
@@ -197,11 +197,9 @@ AND    {$this->_componentClause}";
       $objects['contribution']->receive_date = CRM_Utils_Date::isoToMysql($objects['contribution']->receive_date);
 
       $values = array();
-      if (isset($params['fromEmailAddress']) && !$elements['createPdf']) {
+      if (isset($params['from_email_address']) && !$elements['createPdf']) {
         // CRM-19129 Allow useres the choice of From Email to send the receipt from.
-        $fromEmail = $params['fromEmailAddress'];
-        $from = CRM_Utils_Array::value($fromEmail, $this->_emails);
-        $fromDetails = explode(' <', $from);
+        $fromDetails = explode(' <', $params['from_email_address']);
         $input['receipt_from_email'] = substr(trim($fromDetails[1]), 0, -1);
         $input['receipt_from_name'] = str_replace('"', '', $fromDetails[0]);
       }

--- a/CRM/Contribute/Form/Task/PDF.php
+++ b/CRM/Contribute/Form/Task/PDF.php
@@ -109,7 +109,9 @@ AND    {$this->_componentClause}";
         document.getElementById('selectEmailFrom').style.display = 'block';")
     );
     $this->addElement('radio', 'output', NULL, ts('PDF Receipts'), 'pdf_receipt',
-      array('onClick' => "document.getElementById('selectPdfFormat').style.display = 'block';")
+      array(
+        'onClick' => "document.getElementById('selectPdfFormat').style.display = 'block';
+        document.getElementById('selectEmailFrom').style.display = 'none';")
     );
     $this->addRule('output', ts('Selection required'), 'required');
 

--- a/CRM/Contribute/Form/Task/PDFLetter.php
+++ b/CRM/Contribute/Form/Task/PDFLetter.php
@@ -108,8 +108,8 @@ class CRM_Contribute_Form_Task_PDFLetter extends CRM_Contribute_Form_Task {
     //enable form element
     $this->assign('suppressForm', FALSE);
 
-    // use contact form as a base
-    CRM_Contact_Form_Task_PDFLetterCommon::buildQuickForm($this);
+    // Build common form elements
+    CRM_Contribute_Form_Task_PDFLetterCommon::buildQuickForm($this);
 
     // specific need for contributions
     $this->add('static', 'more_options_header', NULL, ts('Thank-you Letter Options'));

--- a/CRM/Contribute/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contribute/Form/Task/PDFLetterCommon.php
@@ -7,6 +7,17 @@
 class CRM_Contribute_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDFLetterCommon {
 
   /**
+   * Build the form object.
+   *
+   * @var CRM_Core_Form $form
+   */
+  public static function buildQuickForm(&$form) {
+    // Contribute PDF tasks allow you to email as well, so we need to add email address to those forms
+    $form->add('select', 'from_email_address', ts('From Email Address'), $form->_fromEmails, TRUE);
+    parent::buildQuickForm($form);
+  }
+
+  /**
    * Process the form after the input has been submitted and validated.
    *
    * @param CRM_Contribute_Form_Task $form
@@ -22,7 +33,8 @@ class CRM_Contribute_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDF
     if (!empty($formValues['email_options'])) {
       $returnProperties['email'] = $returnProperties['on_hold'] = $returnProperties['is_deceased'] = $returnProperties['do_not_email'] = 1;
       $emailParams = array(
-        'subject' => $formValues['subject'],
+        'subject' => CRM_Utils_Array::value('subject', $formValues),
+        'from' => CRM_Utils_Array::value('from_email_address', $formValues),
       );
       // We need display_name for emailLetter() so add to returnProperties here
       $returnProperties['display_name'] = 1;

--- a/CRM/Contribute/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contribute/Form/Task/PDFLetterCommon.php
@@ -368,6 +368,9 @@ class CRM_Contribute_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDF
         $emails = array_keys($emails);
         $defaults['from'] = array_pop($emails);
       }
+      else {
+        $defaults['from'] = $params['from'];
+      }
       if (!empty($params['subject'])) {
         $defaults['subject'] = $params['subject'];
       }

--- a/CRM/Contribute/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contribute/Form/Task/PDFLetterCommon.php
@@ -12,6 +12,9 @@ class CRM_Contribute_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDF
    * @var CRM_Core_Form $form
    */
   public static function buildQuickForm(&$form) {
+    // use contact form as a base
+    CRM_Contact_Form_Task_PDFLetterCommon::buildQuickForm($form);
+
     // Contribute PDF tasks allow you to email as well, so we need to add email address to those forms
     $form->add('select', 'from_email_address', ts('From Email Address'), $form->_fromEmails, TRUE);
     parent::buildQuickForm($form);

--- a/CRM/Core/BAO/Domain.php
+++ b/CRM/Core/BAO/Domain.php
@@ -169,9 +169,13 @@ class CRM_Core_BAO_Domain extends CRM_Core_DAO_Domain {
    *   name & email for domain
    * @throws Exception
    */
-  public static function getNameAndEmail($skipFatal = FALSE) {
+  public static function getNameAndEmail($skipFatal = FALSE, $returnString = FALSE) {
     $fromEmailAddress = CRM_Core_OptionGroup::values('from_email_address', NULL, NULL, NULL, ' AND is_default = 1');
     if (!empty($fromEmailAddress)) {
+      if ($returnString) {
+        // Return a string like: "Demonstrators Anonymous" <info@example.org>
+        return $fromEmailAddress;
+      }
       foreach ($fromEmailAddress as $key => $value) {
         $email = CRM_Utils_Mail::pluckEmailFromHeader($value);
         $fromArray = explode('"', $value);
@@ -180,12 +184,13 @@ class CRM_Core_BAO_Domain extends CRM_Core_DAO_Domain {
       }
       return array($fromName, $email);
     }
-    elseif ($skipFatal) {
-      return array('', '');
+
+    if ($skipFatal) {
+      return array(NULL, NULL);
     }
 
-    $url = CRM_Utils_System::url('civicrm/admin/domain',
-      'action=update&reset=1'
+    $url = CRM_Utils_System::url('civicrm/admin/options/from_email_address',
+      'reset=1'
     );
     $status = ts("There is no valid default from email address configured for the domain. You can configure here <a href='%1'>Configure From Email Address.</a>", array(1 => $url));
 
@@ -287,8 +292,8 @@ class CRM_Core_BAO_Domain extends CRM_Core_DAO_Domain {
 
   /**
    * CRM-20308 & CRM-19657
-   * Return domain information / user information for the useage in receipts
-   * Try default from adress then fall back to using logged in user details
+   * Return domain information / user information for the usage in receipts
+   * Try default from address then fall back to using logged in user details
    */
   public static function getDefaultReceiptFrom() {
     $domain = civicrm_api3('domain', 'getsingle', array('id' => CRM_Core_Config::domainID()));

--- a/CRM/Event/Cart/Form/Checkout/Payment.php
+++ b/CRM/Event/Cart/Form/Checkout/Payment.php
@@ -329,16 +329,6 @@ class CRM_Event_Cart_Form_Checkout_Payment extends CRM_Event_Cart_Form_Cart {
   }
 
   /**
-   * Get default from address.
-   *
-   * @return mixed
-   */
-  public function getDefaultFrom() {
-    $values = CRM_Core_OptionGroup::values('from_email_address');
-    return $values[1];
-  }
-
-  /**
    * Send email receipt.
    *
    * @param array $events_in_cart
@@ -362,7 +352,7 @@ class CRM_Event_Cart_Form_Checkout_Payment extends CRM_Event_Cart_Form_Cart {
     $send_template_params = array(
       'table' => 'civicrm_msg_template',
       'contactId' => $this->payer_contact_id,
-      'from' => $this->getDefaultFrom(),
+      'from' => CRM_Core_BAO_Domain::getNameAndEmail(TRUE, TRUE),
       'groupName' => 'msg_tpl_workflow_event',
       'isTest' => FALSE,
       'toEmail' => $contact_details[1],

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1717,7 +1717,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
 
       // Get the default from email address, if not provided.
       if (empty($defaults['from_email'])) {
-        $defaultAddress = CRM_Core_OptionGroup::values('from_email_address', NULL, NULL, NULL, ' AND is_default = 1');
+        $defaultAddress = CRM_Core_BAO_Domain::getNameAndEmail(TRUE, TRUE);
         foreach ($defaultAddress as $id => $value) {
           if (preg_match('/"(.*)" <(.*)>/', $value, $match)) {
             $defaults['from_email'] = $match[2];

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -936,7 +936,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
    */
   public static function emailReceipt(&$form, &$formValues, &$membership) {
     // retrieve 'from email id' for acknowledgement
-    $receiptFrom = $formValues['from_email_address'];
+    $receiptFrom = CRM_Utils_Array::value('from_email_address', $formValues);
 
     if (!empty($formValues['payment_instrument_id'])) {
       $paymentInstrument = CRM_Contribute_PseudoConstant::paymentInstrument();

--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -160,7 +160,7 @@ function _civicrm_api3_mailing_create_spec(&$params) {
   $params['resubscribe_id']['api.default'] = CRM_Mailing_PseudoConstant::defaultComponent('Resubscribe', '');
   $params['unsubscribe_id']['api.default'] = CRM_Mailing_PseudoConstant::defaultComponent('Unsubscribe', '');
   $params['mailing_type']['api.default'] = 'standalone';
-  $defaultAddress = CRM_Core_OptionGroup::values('from_email_address', NULL, NULL, NULL, ' AND is_default = 1');
+  $defaultAddress = CRM_Core_BAO_Domain::getNameAndEmail(TRUE, TRUE);
   foreach ($defaultAddress as $value) {
     if (preg_match('/"(.*)" <(.*)>/', $value, $match)) {
       $params['from_email']['api.default'] = $match[2];

--- a/settings/Mailing.setting.php
+++ b/settings/Mailing.setting.php
@@ -346,4 +346,17 @@ return array(
     'description' => 'Enable this setting to rebuild recipient list automatically during composing mail. Disable will allow you to rebuild recipient manually.',
     'help_text' => 'CiviMail automatically fetches recipient list and count whenever mailing groups are included or excluded while composing bulk mail. This phenomena may degrade performance for large sites, so disable this setting to build and fetch recipients for selected groups, manually.',
   ),
+  'allow_mail_from_logged_in_contact' => array(
+    'group_name' => 'Mailing Preferences',
+    'group' => 'mailing',
+    'name' => 'allow_mail_from_logged_in_contact',
+    'type' => 'Boolean',
+    'quick_form_type' => 'YesNo',
+    'default' => 1,
+    'title' => 'Allow mail from logged in contact',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => 'Allow sending email from the logged in contact\'s email address',
+    'help_text' => 'CiviCRM allows you to send email from the domain from email addresses and the logged in contact id addresses by default. Disable this if you only want to allow the domain from addresses to be used.',
+  ),
 );

--- a/templates/CRM/Admin/Form/Setting/Smtp.hlp
+++ b/templates/CRM/Admin/Form/Setting/Smtp.hlp
@@ -1,0 +1,31 @@
+{*--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2017                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +-------------------------------------------------------------------*}
+
+{htxt id='allow_mail_contact_email'}
+{capture assign=adminFromEmailURL}{crmURL p="civicrm/admin/options/from_email_address" q="reset=1"}{/capture}
+{ts 1=$adminFromEmailURL}If this is enabled a logged in user can send email from their own email address as well as the configured
+  <a href="%1"><strong>FROM Email addresses</strong></a>.  This applies to actions such as send Email, Email invoice.. If this setting
+  is disabled then only the system configured FROM Email addresses will be available for selection.{/ts}
+{/htxt}
+

--- a/templates/CRM/Admin/Form/Setting/Smtp.tpl
+++ b/templates/CRM/Admin/Form/Setting/Smtp.tpl
@@ -24,13 +24,24 @@
  +--------------------------------------------------------------------+
 *}
 <div class="crm-block crm-form-block crm-smtp-form-block">
-<div class="help">
-  <p>{ts}CiviCRM offers several options to send emails. The default option should work fine on linux systems. If you are using windows, you probably need to enter settings for your SMTP/Sendmail server. You can send a test email to check your settings by clicking "Save and Send Test Email". If you're unsure of the correct values, check with your system administrator, ISP or hosting provider.{/ts}</p>
-  <p>{ts}If you do not want users to send outbound mail from CiviCRM, select "Disable Outbound Email". NOTE: If you disable outbound email, and you are using Online Contribution pages or online Event Registration - you will need to disable automated receipts and registration confirmations.{/ts}</p>
-  <p>{ts}If you choose Redirect to Database, all emails will be recorded as archived mailings instead of being sent out. They can be found in the civicrm_mailing_spool table in the CiviCRM database.{/ts}</p>
-
-</div>
+  <div>
+  <h3>{ts}General{/ts}</h3>
      <table class="form-layout-compressed">
+       <tr class="crm-smtp-form-block-allow_mail_from_logged_in_contact">
+         <td class="label">{$form.allow_mail_from_logged_in_contact.html}</td>
+         <td>{$form.allow_mail_from_logged_in_contact.label} {help id=allow_mail_contact_email}</td>
+       </tr>
+     </table>
+  </div>
+  {crmRegion name="smtp-mailer-config"}
+  <div class="crm-smtp-mailer-form-block">
+  <h3>{ts}Mailer Configuration{/ts}</h3>
+  <div class="help">
+    <p>{ts}CiviCRM offers several options to send emails. You can send a test email to check your settings by clicking "Save and Send Test Email". If you're unsure of the correct values, check with your system administrator, ISP or hosting provider.{/ts}</p>
+    <p>{ts}If you do not want users to send outbound mail from CiviCRM, select "Disable Outbound Email". NOTE: If you disable outbound email, and you are using Online Contribution pages or online Event Registration - you will need to disable automated receipts and registration confirmations.{/ts}</p>
+    <p>{ts}If you choose Redirect to Database, all emails will be recorded as archived mailings instead of being sent out. They can be found in the civicrm_mailing_spool table in the CiviCRM database.{/ts}</p>
+  </div>
+     <table>
            <tr class="crm-smtp-form-block-outBound_option">
               <td class="label">{$form.outBound_option.label}</td>
               <td>{$form.outBound_option.html}</td>
@@ -92,7 +103,6 @@
         <div class="crm-submit-buttons">
             {include file="CRM/common/formButtons.tpl"}
         </div>
-</div>
 
 {literal}
 <script type="text/javascript">
@@ -142,3 +152,6 @@
 
 </script>
 {/literal}
+  </div>
+  {/crmRegion}
+</div>

--- a/templates/CRM/Contact/Form/Domain.hlp
+++ b/templates/CRM/Contact/Form/Domain.hlp
@@ -30,21 +30,6 @@
 {ts 1='&#123;domain.name&#125;'}Enter the name of the organization or entity which owns this CiviCRM domain. Use the %1 token to include this value in mailing content. It is used in the default Opt-out Message.{/ts}
 {/htxt}
 
-
-{htxt id="from-name-title"}
-{ts}From Name{/ts}
-{/htxt}
-{htxt id="from-name"}
-{ts}The FROM Name and Email Address are used when automated emails are sent from this domain (e.g. subscribe and unsubscribe confirmations...). This Name and Email Address are also used as the default 'sender' values when you create a new CiviMail Mailing.{/ts}
-{/htxt}
-
-{htxt id="from-email-title"}
-{ts}From Address{/ts}
-{/htxt}
-{htxt id="from-email"}
-{ts}The FROM Name and Email Address are used when automated emails are sent from this domain (e.g. subscribe and unsubscribe confirmations...). This Name and Email Address are also used as the default 'sender' values when you create a new CiviMail Mailing.{/ts}
-{/htxt}
-
 {htxt id="return-path-title"}
 {ts}Return Path{/ts}
 {/htxt}

--- a/templates/CRM/Contact/Form/Domain.tpl
+++ b/templates/CRM/Contact/Form/Domain.tpl
@@ -44,20 +44,6 @@
         </td>
     </tr>
     </table>
-  <h3>{ts}System-generated Mail Settings{/ts}</h3>
-    <table class="form-layout-compressed">
-    <tr>
-      <td>
-        {$form.email_name.label} {help id="from-name"}<br />
-        {$form.email_name.html}
-      </td>
-      <td class="">
-        {$form.email_address.label} {help id="from-email"}<br />
-        {$form.email_address.html}
-           <br /><span class="description">(info@example.org)</span>
-      </td>
-    </tr>
-    </table>
 
     <h3>{ts}Default Organization Address{/ts}</h3>
         <div class="description">{ts 1=&#123;domain.address&#125;}CiviMail mailings must include the sending organization's address. This is done by putting the %1 token in either the body or footer of the mailing. This token may also be used in regular 'Email - send now' messages and in other Message Templates. The token is replaced by the address entered below when the message is sent.{/ts}</div>

--- a/templates/CRM/Contact/Form/Task/Email.tpl
+++ b/templates/CRM/Contact/Form/Task/Email.tpl
@@ -31,10 +31,10 @@
     </div>
 {/if}
 <table class="form-layout-compressed">
-    <tr class="crm-contactEmail-form-block-fromEmailAddress">
-       <td class="label">{$form.fromEmailAddress.label}</td>
-       <td>{$form.fromEmailAddress.html} {help id="id-from_email" file="CRM/Contact/Form/Task/Email.hlp" isAdmin=$isAdmin}</td>
-    </tr>
+  <tr id="selectEmailFrom" class="crm-contactEmail-form-block-fromEmailAddress crm-email-element">
+    <td class="label">{$form.from_email_address.label}</td>
+    <td>{$form.from_email_address.html} {help id="id-from_email" file="CRM/Contact/Form/Task/Email.hlp" isAdmin=$isAdmin}</td>
+  </tr>
     <tr class="crm-contactEmail-form-block-recipient">
        <td class="label">{if $single eq false}{ts}Recipient(s){/ts}{else}{$form.to.label}{/if}</td>
        <td>

--- a/templates/CRM/Contact/Form/Task/PDFLetterCommon.tpl
+++ b/templates/CRM/Contact/Form/Task/PDFLetterCommon.tpl
@@ -35,6 +35,10 @@
         {$form.template.html} {ts}OR{/ts} {$form.document_file.html}
       </td>
     </tr>
+    <tr id="fromEmail" class="crm-contactEmail-form-block-fromEmailAddress crm-email-element">
+      <td class="label">{$form.from_email_address.label}</td>
+      <td>{$form.from_email_address.html} {help id="id-from_email" file="CRM/Contact/Form/Task/Email.hlp" isAdmin=$isAdmin}</td>
+    </tr>
     <tr>
       <td class="label-left">{$form.subject.label}</td>
       <td>{$form.subject.html}</td>

--- a/templates/CRM/Contact/Form/Task/PDFLetterCommon.tpl
+++ b/templates/CRM/Contact/Form/Task/PDFLetterCommon.tpl
@@ -35,10 +35,6 @@
         {$form.template.html} {ts}OR{/ts} {$form.document_file.html}
       </td>
     </tr>
-    <tr id="fromEmail" class="crm-contactEmail-form-block-fromEmailAddress crm-email-element">
-      <td class="label">{$form.from_email_address.label}</td>
-      <td>{$form.from_email_address.html} {help id="id-from_email" file="CRM/Contact/Form/Task/Email.hlp" isAdmin=$isAdmin}</td>
-    </tr>
     <tr>
       <td class="label-left">{$form.subject.label}</td>
       <td>{$form.subject.html}</td>

--- a/templates/CRM/Contribute/Form/AdditionalPayment.tpl
+++ b/templates/CRM/Contribute/Form/AdditionalPayment.tpl
@@ -77,7 +77,7 @@
         </tr>
         <tr id="fromEmail" class="crm-payment-form-block-from_email_address" style="display:none;">
           <td class="label">{$form.from_email_address.label}</td>
-          <td>{$form.from_email_address.html}</td>
+          <td>{$form.from_email_address.html} {help id="id-from_email" file="CRM/Contact/Form/Task/Email.hlp" isAdmin=$isAdmin}</td>
         </tr>
       {/if}
       {if $contributionMode}

--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -231,7 +231,7 @@
     {/if}
     <tr id="fromEmail" class="crm-contribution-form-block-receipt_date" style="display:none;">
       <td class="label">{$form.from_email_address.label}</td>
-      <td>{$form.from_email_address.html}</td>
+      <td>{$form.from_email_address.html} {help id="id-from_email" file="CRM/Contact/Form/Task/Email.hlp" isAdmin=$isAdmin}</td>
     </tr>
     <tr id="receiptDate" class="crm-contribution-form-block-receipt_date">
       <td class="label">{$form.receipt_date.label}</td>

--- a/templates/CRM/Contribute/Form/Task/Invoice.hlp
+++ b/templates/CRM/Contribute/Form/Task/Invoice.hlp
@@ -26,16 +26,6 @@
 {htxt id ="id-from_email-title"}
   {ts}From Address{/ts}
 {/htxt}
-{htxt id ="id-from_email"}
-<p>{ts}Select the "FROM" Email Address for this mailing from the dropdown list. Available email addresses are configurable by users with Administer CiviCRM permission. EXAMPLE: "Client Services" &lt;clientservices@example.org&gt;{/ts}</p>
-{if $params.isAdmin}
-    {capture assign="fromConfig"}{crmURL p="civicrm/admin/options/from_email_address" q="reset=1"}{/capture}
-    <p>{ts 1=$fromConfig}Go to <a href='%1'>Administer CiviCRM &raquo; Communications &raquo; FROM Email Addresses</a> to add or edit email addresses. Make sure these email addresses are valid email accounts with your email service provider.{/ts}</p>
-{else}
-    {ts}Contact your site administrator if you need to use a "FROM" Email Address which is not in the dropdown list.{/ts}
-{/if}
-{/htxt}
-
 {htxt id="content-intro-title"}
   {ts}Message Formats{/ts}
 {/htxt}

--- a/templates/CRM/Contribute/Form/Task/Invoice.tpl
+++ b/templates/CRM/Contribute/Form/Task/Invoice.tpl
@@ -36,22 +36,27 @@
 <table class="form-layout-compressed">
   {if $selectedOutput ne 'email'}
     <tr>
+      <td class="label">{$form.output.email_invoice.label}</td>
       <td>{$form.output.email_invoice.html}</td>
     </tr>
   {/if}
-  <tr class="crm-email-element">
-    <td>{$form.from_email_address.label}{$form.from_email_address.html}{help id ="id-from_email" isAdmin=$isAdmin}</td>
+  <tr id="selectEmailFrom" style="display: none" class="crm-contactEmail-form-block-fromEmailAddress crm-email-element">
+    <td class="label">{$form.from_email_address.label}</td>
+    <td>{$form.from_email_address.html} {help id="id-from_email" file="CRM/Contact/Form/Task/Email.hlp" isAdmin=$isAdmin}</td>
   </tr>
   <tr class="crm-email-element">
-    <td>{$form.email_comment.label}{$form.email_comment.html}</td>
+    <td class="label">{$form.email_comment.label}</td>
+    <td>{$form.email_comment.html}</td>
   </tr>
   {if $selectedOutput ne 'email'}
     <tr>
+      <td class="label">{$form.output.pdf_invoice.label}</td>
       <td>{$form.output.pdf_invoice.html}</td>
     </tr>
   {/if}
   <tr class="crm-pdf-element">
-    <td>{$form.pdf_format_id.html} {$form.pdf_format_id.label} </td>
+    <td class="label">{$form.pdf_format_id.label}</td>
+    <td>{$form.pdf_format_id.html}</td>
   </tr>
 </table>
 

--- a/templates/CRM/Contribute/Form/Task/PDF.tpl
+++ b/templates/CRM/Contribute/Form/Task/PDF.tpl
@@ -35,8 +35,9 @@
   <tr>
     <td>{$form.output.email_receipt.html}</td>
   </tr>
-  <tr id="selectEmailFrom" style="display: none">
-    <td>{$form.fromEmailAddress.label}: {$form.fromEmailAddress.html}</td>
+  <tr id="selectEmailFrom" style="display: none" class="crm-contactEmail-form-block-fromEmailAddress crm-email-element">
+    <td class="label">{$form.from_email_address.label}</td>
+    <td>{$form.from_email_address.html} {help id="id-from_email" file="CRM/Contact/Form/Task/Email.hlp" isAdmin=$isAdmin}</td>
   </tr>
   <tr>
     <td>{$form.output.pdf_receipt.html}</td>

--- a/templates/CRM/Contribute/Form/Task/PDFLetter.tpl
+++ b/templates/CRM/Contribute/Form/Task/PDFLetter.tpl
@@ -50,7 +50,7 @@
         <td>{$form.email_options.html}</td>
       </tr>
       <tr>
-        <td class="label-left">{$form.from_email_address.label} {help id="id-from_email"}</td>
+        <td class="label-left">{$form.from_email_address.label} {help id="id-from_email" file="CRM/Contact/Form/Task/Email.hlp" isAdmin=$isAdmin}</td>
         <td>{$form.from_email_address.html}</td>
       </tr>
     </table>

--- a/templates/CRM/Contribute/Form/Task/PDFLetter.tpl
+++ b/templates/CRM/Contribute/Form/Task/PDFLetter.tpl
@@ -49,6 +49,10 @@
         <td class="label-left">{$form.email_options.label} {help id="id-contribution-email-print"}</td>
         <td>{$form.email_options.html}</td>
       </tr>
+      <tr>
+        <td class="label-left">{$form.from_email_address.label} {help id="id-from_email"}</td>
+        <td>{$form.from_email_address.html}</td>
+      </tr>
     </table>
   </div><!-- /.crm-accordion-body -->
 </div><!-- /.crm-accordion-wrapper -->

--- a/templates/CRM/Event/Form/EventFees.tpl
+++ b/templates/CRM/Event/Form/EventFees.tpl
@@ -119,7 +119,7 @@
         </tr>
   <tr id="from-email" class="crm-event-eventfees-form-block-from_email_address">
             <td class="label">{$form.from_email_address.label}</td>
-            <td>{$form.from_email_address.html} {help id ="id-from_email" file="CRM/Contact/Form/Task/Email.hlp"}</td>
+            <td>{$form.from_email_address.html} {help id="id-from_email" file="CRM/Contact/Form/Task/Email.hlp" isAdmin=$isAdmin}</td>
       </tr>
         <tr id='notice' class="crm-event-eventfees-form-block-receipt_text">
        <td class="label">{$form.receipt_text.label}</td>
@@ -146,7 +146,7 @@
         </tr>
   <tr id="from-email" class="crm-event-eventfees-form-block-from_email_address">
             <td class="label">{$form.from_email_address.label}</td>
-            <td>{$form.from_email_address.html} {help id ="id-from_email" file="CRM/Contact/Form/Task/Email.hlp"}</td>
+            <td>{$form.from_email_address.html} {help id="id-from_email" file="CRM/Contact/Form/Task/Email.hlp" isAdmin=$isAdmin}</td>
       </tr>
         <tr id='notice' class="crm-event-eventfees-form-block-receipt_text">
         <td class="label">{$form.receipt_text.label}</td>

--- a/templates/CRM/Event/Form/ParticipantFeeSelection.tpl
+++ b/templates/CRM/Event/Form/ParticipantFeeSelection.tpl
@@ -159,7 +159,7 @@ CRM.$(function($) {
        </tr>
        <tr id="from-email" class="crm-event-eventfees-form-block-from_email_address">
          <td class="label">{$form.from_email_address.label}</td>
-         <td>{$form.from_email_address.html} {help id ="id-from_email" file="CRM/Contact/Form/Task/Email.hlp"}</td>
+         <td>{$form.from_email_address.html} {help id="id-from_email" file="CRM/Contact/Form/Task/Email.hlp" isAdmin=$isAdmin}</td>
        </tr>
        <tr id='notice' class="crm-event-eventfees-form-block-receipt_text">
          <td class="label">{$form.receipt_text.label}</td>

--- a/templates/CRM/Mailing/Form/Upload.tpl
+++ b/templates/CRM/Mailing/Form/Upload.tpl
@@ -34,7 +34,7 @@
 
 <table class="form-layout-compressed">
     <tr class="crm-mailing-upload-form-block-from_email_address"><td class="label">{$form.from_email_address.label}</td>
-        <td>{$form.from_email_address.html} {help id ="id-from_email" isAdmin=$isAdmin}</td>
+        <td>{$form.from_email_address.html} {help id ="id-from_email" file="CRM/Contact/Form/Task/Email.hlp" isAdmin=$isAdmin}</td>
     </tr>
     {if $trackReplies}
     <tr class="crm-mailing-upload-form-block-reply_to_address">

--- a/templates/CRM/Member/Form/Membership.hlp
+++ b/templates/CRM/Member/Form/Membership.hlp
@@ -36,3 +36,12 @@
     </ul>
   {/if}
 {/htxt}
+{htxt id ="id-from_email"}
+  <p>{ts}Select the "FROM" Email Address for this mailing from the dropdown list. Available email addresses are configurable by users with Administer CiviCRM permission. EXAMPLE: "Client Services" &lt;clientservices@example.org&gt;{/ts}</p>
+{if $params.isAdmin}
+  {capture assign="fromConfig"}{crmURL p="civicrm/admin/options/from_email_address" q="reset=1"}{/capture}
+  <p>{ts 1=$fromConfig}Go to <a href='%1'>Administer CiviCRM &raquo; Communications &raquo; FROM Email Addresses</a> to add or edit email addresses. Make sure these email addresses are valid email accounts with your email service provider.{/ts}</p>
+{else}
+  {ts}Contact your site administrator if you need to use a "FROM" Email Address which is not in the dropdown list.{/ts}
+{/if}
+{/htxt}

--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -190,9 +190,9 @@
             <span class="auto-renew-text">{ts}For auto-renewing memberships the emails are sent when each payment is received{/ts}</span>
           </tr>
         {/if}
-        <tr id="fromEmail" style="display:none;">
+        <tr id="fromEmail" style="display: none" class="crm-contactEmail-form-block-fromEmailAddress crm-email-element">
           <td class="label">{$form.from_email_address.label}</td>
-          <td>{$form.from_email_address.html}</td>
+          <td>{$form.from_email_address.html} {help id="id-from_email" file="CRM/Contact/Form/Task/Email.hlp" isAdmin=$isAdmin}</td>
         </tr>
         <tr id='notice' style="display:none;">
           <td class="label">{$form.receipt_text.label}</td>

--- a/templates/CRM/Member/Form/MembershipRenewal.tpl
+++ b/templates/CRM/Member/Form/MembershipRenewal.tpl
@@ -129,7 +129,7 @@
         </tr>
         <tr id="fromEmail">
           <td class="label">{$form.from_email_address.label}</td>
-          <td>{$form.from_email_address.html} {help id="id-from_email" isAdmin=$isAdmin}</td>
+          <td>{$form.from_email_address.html} {help id="id-from_email" file="CRM/Contact/Form/Task/Email.hlp" isAdmin=$isAdmin}</td>
         </tr>
         <tr id="notice" class="crm-member-membershiprenew-form-block-receipt_text_renewal">
           <td class="label">{$form.receipt_text_renewal.label}</td>

--- a/templates/CRM/Member/Form/MembershipRenewal.tpl
+++ b/templates/CRM/Member/Form/MembershipRenewal.tpl
@@ -129,7 +129,7 @@
         </tr>
         <tr id="fromEmail">
           <td class="label">{$form.from_email_address.label}</td>
-          <td>{$form.from_email_address.html}</td>
+          <td>{$form.from_email_address.html} {help id="id-from_email" isAdmin=$isAdmin}</td>
         </tr>
         <tr id="notice" class="crm-member-membershiprenew-form-block-receipt_text_renewal">
           <td class="label">{$form.receipt_text_renewal.label}</td>

--- a/templates/CRM/Pledge/Form/Pledge.tpl
+++ b/templates/CRM/Pledge/Form/Pledge.tpl
@@ -118,7 +118,7 @@
         {/if}
         <tr id="fromEmail" style="display:none;">
             <td class="label">{$form.from_email_address.label}</td>
-            <td>{$form.from_email_address.html}</td>
+            <td>{$form.from_email_address.html} {help id="id-from_email" file="CRM/Contact/Form/Task/Email.hlp" isAdmin=$isAdmin}</td>
         </tr>
         <tr id="acknowledgeDate">
       <td class="label" class="crm-pledge-form-block-acknowledge_date">{$form.acknowledge_date.label}</td>

--- a/tests/phpunit/CRM/Contact/Form/Task/EmailCommonTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/EmailCommonTest.php
@@ -46,7 +46,7 @@ class CRM_Contact_Form_Task_EmailCommonTest extends CiviUnitTestCase {
    * Test generating domain emails
    */
   public function testDomainEmailGeneration() {
-    $emails = CRM_Contact_Form_Task_EmailCommon::domainEmails();
+    $emails = CRM_Core_BAO_Email::domainEmails();
     $this->assertNotEmpty($emails);
     $optionValue = $this->callAPISuccess('OptionValue', 'Get', array(
       'id' => $this->_optionValue['id'],

--- a/tests/phpunit/CRM/Contribute/Form/Task/PDFLetterCommonTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Task/PDFLetterCommonTest.php
@@ -206,6 +206,7 @@ class CRM_Contribute_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
       'html_message' => $htmlMessage,
       'email_options' => 'both',
       'subject' => 'Testy test test',
+      'from' => 'info@example.com',
     );
 
     $contributionIDs = array();


### PR DESCRIPTION
Overview
----------------------------------------
This was developed from a client requirement to only allow sending email from the organisation from addresses, not from individual logged in account email addresses.  Initially I used the extension https://github.com/CiviCooP/org.civicoop.protectfromaddress to do this.  However, it became clear that this only works on certain forms.  Extending the list of forms (to around 20) helps in most cases but not all.  I then investigated the code in core and discovered a number of places where the same code was basically duplicated instead of being shared.  So this patch does the following:
1) Clean up all duplicated "FROM email address" code into a shared function in CRM_Core_BAO_Email.
2) Add a setting in that shared function that decides whether to load logged in contact email addresses or not.  (Currently setting is located in "Outbound Email", but don't really mind where it goes if there's a better place).
3) Remove "FROM email address" setting from organizational contact settings as it just gets/sets the first one listed in "FROM email addresses" settings page and it's always confused me as to what the difference was (there is no difference).
4) Add "FROM email address" select to the PDF letter task (for consistency with all other tasks, previously this one was hardcoded to take the first address in the generated array of FROM addresses).

---

 * [CRM-21244: Enhancements to "FROM email addresses"](https://issues.civicrm.org/jira/browse/CRM-21244)