### PR TITLE
CRM-21239 First batch of fixes to help with solving issues around non…

### DIFF
--- a/CRM/Admin/Form/Extensions.php
+++ b/CRM/Admin/Form/Extensions.php
@@ -43,9 +43,9 @@ class CRM_Admin_Form_Extensions extends CRM_Admin_Form {
     parent::preProcess();
 
     $this->_key = CRM_Utils_Request::retrieve('key', 'String',
-      $this, FALSE, 0
+      $this, FALSE, NULL
     );
-    if (!CRM_Utils_Type::validate($this->_key, 'ExtensionKey')) {
+    if (!empty($this->_key) && !CRM_Utils_Type::validate($this->_key, 'ExtensionKey')) {
       throw new CRM_Core_Exception('Extension Key does not match expected standard');
     }
     $session = CRM_Core_Session::singleton();

--- a/CRM/Admin/Page/ContactType.php
+++ b/CRM/Admin/Page/ContactType.php
@@ -97,7 +97,7 @@ class CRM_Admin_Page_ContactType extends CRM_Core_Page_Basic {
   public function run() {
     $action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 0);
     $this->assign('action', $action);
-    $id = CRM_Utils_Request::retrieve('id', 'Positive', $this, FALSE, 0);
+    $id = CRM_Utils_Request::retrieve('id', 'Positive', $this, FALSE, NULL);
     if (!$action) {
       $this->browse();
     }

--- a/CRM/Admin/Page/Job.php
+++ b/CRM/Admin/Page/Job.php
@@ -122,10 +122,10 @@ class CRM_Admin_Page_Job extends CRM_Core_Page_Basic {
     CRM_Utils_System::appendBreadCrumb($breadCrumb);
 
     $this->_id = CRM_Utils_Request::retrieve('id', 'String',
-      $this, FALSE, 0
+      $this, FALSE, NULL
     );
     $this->_action = CRM_Utils_Request::retrieve('action', 'String',
-      $this, FALSE, 0
+      $this, FALSE, NULL
     );
 
     if ($this->_action == 'export') {

--- a/CRM/Event/Page/EventInfo.php
+++ b/CRM/Event/Page/EventInfo.php
@@ -63,7 +63,7 @@ class CRM_Event_Page_EventInfo extends CRM_Core_Page {
     $this->assign('context', $context);
 
     // Sometimes we want to suppress the Event Full msg
-    $noFullMsg = CRM_Utils_Request::retrieve('noFullMsg', 'String', $this, FALSE, 'false');
+    $noFullMsg = CRM_Utils_Request::retrieve('noFullMsg', 'String', $this, FALSE, 'false') == 'false' ? 0 : 1;
 
     // set breadcrumb to append to 2nd layer pages
     $breadCrumbPath = CRM_Utils_System::url('civicrm/event/info',
@@ -312,10 +312,10 @@ class CRM_Event_Page_EventInfo extends CRM_Core_Page {
       'role_id' => CRM_Utils_Array::value('default_role_id', $values['event']),
     );
 
-    if ($eventFullMessage && ($noFullMsg == 'false') || CRM_Event_BAO_Event::checkRegistration($params)) {
+    if ($eventFullMessage && (!$noFullMsg) || CRM_Event_BAO_Event::checkRegistration($params)) {
       $statusMessage = $eventFullMessage;
       if (CRM_Event_BAO_Event::checkRegistration($params)) {
-        if ($noFullMsg == 'false') {
+        if (!$noFullMsg) {
           if ($values['event']['allow_same_participant_emails']) {
             $statusMessage = ts('It looks like you are already registered for this event.  You may proceed if you want to create an additional registration.');
           }

--- a/bin/ContributionProcessor.php
+++ b/bin/ContributionProcessor.php
@@ -264,9 +264,9 @@ class CiviContributeProcessor {
           CRM_Core_DAO::$_nullObject, FALSE, 31, 'REQUEST'
         );
         $end = CRM_Utils_Request::retrieve('end', 'String',
-          CRM_Core_DAO::$_nullObject, FALSE, 0, 'REQUEST'
+          CRM_Core_DAO::$_nullObject, FALSE, NULL, 'REQUEST'
         );
-        if ($start < $end) {
+        if (!empty($end) && $start < $end) {
           CRM_Core_Error::fatal("Start offset can't be less than End offset.");
         }
 


### PR DESCRIPTION
… truthy defaults in CRM_Utils_Request::retrieve

Overview
----------------------------------------
Since PR #10435 There have been issues where a non truthy default has been passed through in CRM_Utils_Request::retrieve. Previously this would have been ignored. Now we need to patch up files to fix up for those issues.

Technical Details
----------------------------------------
I have switched mostly to NULL but in one cased turned it into a proper boolean situation ping @twomice @GinkgoFJG @eileenmcnaughton. Does this look ok to you?

