### PR TITLE
CRM-21229 improve static var management in group permission clause

### DIFF
--- a/CRM/ACL/BAO/ACL.php
+++ b/CRM/ACL/BAO/ACL.php
@@ -881,6 +881,7 @@ SELECT g.*
       $cache = CRM_Utils_Cache::singleton();
       $ids = $cache->get($cacheKey);
       if (!$ids) {
+        $ids = array();
         $query = "
 SELECT   a.operation, a.object_id
   FROM   civicrm_acl_cache c, civicrm_acl a

--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -602,16 +602,11 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
 
   /**
    * Get permission relevant clauses.
-   * CRM-12209
-   *
-   * @param bool $force
    *
    * @return array
    */
-  public static function getPermissionClause($force = FALSE) {
-    static $clause = 1;
-    static $retrieved = FALSE;
-    if (!$retrieved || $force) {
+  public static function getPermissionClause() {
+    if (!isset(Civi::$statics[__CLASS__]['permission_clause'])) {
       if (CRM_Core_Permission::check('view all contacts') || CRM_Core_Permission::check('edit all contacts')) {
         $clause = 1;
       }
@@ -626,9 +621,9 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
           $clause = '1 = 0';
         }
       }
+      Civi::$statics[__CLASS__]['permission_clause'] = $clause;
     }
-    $retrieved = TRUE;
-    return $clause;
+    return Civi::$statics[__CLASS__]['permission_clause'];
   }
 
   /**
@@ -642,6 +637,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
       'CRM_Core_PseudoConstant' => 'groups',
       'CRM_ACL_API' => 'group_permission',
       'CRM_ACL_BAO_ACL' => 'permissioned_groups',
+      'CRM_Contact_BAO_Group' => 'permission_clause',
     );
     foreach ($staticCaches as $class => $key) {
       if (isset(Civi::$statics[$class][$key])) {

--- a/tests/phpunit/CRM/Group/Page/AjaxTest.php
+++ b/tests/phpunit/CRM/Group/Page/AjaxTest.php
@@ -26,10 +26,6 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
 
   public function setUp() {
     parent::setUp();
-    // CRM_Contact_BAO_Group::getPermissionClause sets a static variable.
-    // Ensure it is reset before each run.
-    $force = TRUE;
-    CRM_Contact_BAO_Group::getPermissionClause($force);
     $this->_params = array(
       'page' => 1,
       'rp' => 50,
@@ -79,7 +75,6 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
   public function setHookAndRequest($permission, $hook) {
     CRM_Core_Config::singleton()->userPermissionClass->permissions = (array) $permission;
     $this->hookClass->setHook('civicrm_aclGroup', array($this, $hook));
-    CRM_Contact_BAO_Group::getPermissionClause(TRUE);
     global $_REQUEST;
     $_REQUEST = $this->_params;
   }
@@ -253,7 +248,7 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
    */
   public function testGroupListAccessCiviCRM() {
     $this->setPermissionAndRequest('access CiviCRM');
-    $permissionClause = CRM_Contact_BAO_Group::getPermissionClause(TRUE);
+    $permissionClause = CRM_Contact_BAO_Group::getPermissionClause();
     $this->assertEquals('1 = 0', $permissionClause);
     $params = $this->_params;
     $groups = CRM_Contact_BAO_Group::getGroupListSelector($params);

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3092,7 +3092,6 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
     if (!$isProfile) {
       //flush cache
       CRM_ACL_BAO_Cache::resetCache();
-      CRM_Contact_BAO_Group::getPermissionClause(TRUE);
       CRM_ACL_API::groupPermission('whatever', 9999, NULL, 'civicrm_saved_search', NULL, NULL, TRUE);
     }
   }
@@ -3572,7 +3571,6 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
   protected function setPermissions($permissions) {
     CRM_Core_Config::singleton()->userPermissionClass->permissions = $permissions;
     $this->flushFinancialTypeStatics();
-    CRM_Contact_BAO_Group::getPermissionClause(TRUE);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Improve management of static vars

Before
----------------------------------------
Static var in CRM_Contact_BAO_Group::getPermissionClause persists over test runs 

After
----------------------------------------
Static var resets

Technical Details
----------------------------------------
@jmcclelland this is the way we are eliminating those static var issues

---

 * [CRM-21229: Manage Group page is slow if you have smart groups](https://issues.civicrm.org/jira/browse/CRM-21229)