### PR TITLE
CRM-20769 Rebuild multilingual structure based on DAOs after adding c…

### DIFF
--- a/CRM/Upgrade/Incremental/Base.php
+++ b/CRM/Upgrade/Incremental/Base.php
@@ -228,4 +228,19 @@ class CRM_Upgrade_Incremental_Base {
     return TRUE;
   }
 
+  /**
+   * Rebuild Multilingual Schema.
+   * @param CRM_Queue_TaskContext $ctx
+   * @return bool
+   */
+  public static function rebuildMultilingalSchema($ctx) {
+    $domain = new CRM_Core_DAO_Domain();
+    $domain->find(TRUE);
+    if ($domain->locales) {
+      $locales = explode(CRM_Core_DAO::VALUE_SEPARATOR, $domain->locales);
+      CRM_Core_I18n_Schema::rebuildMultilingualSchema($locales);
+    }
+    return TRUE;
+  }
+
 }

--- a/CRM/Upgrade/Incremental/php/FourSeven.php
+++ b/CRM/Upgrade/Incremental/php/FourSeven.php
@@ -427,6 +427,7 @@ class CRM_Upgrade_Incremental_php_FourSeven extends CRM_Upgrade_Incremental_Base
       'civicrm_case', 'created_date', "timestamp NULL  DEFAULT NULL COMMENT 'When was the case was created.'");
     $this->addTask('CRM-20958 - Add modified_date to civicrm_case', 'addColumn',
       'civicrm_case', 'modified_date', "timestamp NULL  DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'When was the case (or closely related entity) was created or modified or deleted.'");
+    $this->addTask('Rebuild Multilingual Schema', 'rebuildMultilingalSchema');
   }
 
 


### PR DESCRIPTION
…olumns to table

Overview
----------------------------------------
Following report from @litespeedmarc it seems the multilingual views aren't probably being re-generated after adding the new columns. This triggers a multilingual rebuild without caring if we are in upgrade mode so builds of the DAOs

@litespeedmarc are you able to test this on your install also pinging @mlutfy @eileenmcnaughton 