### PR TITLE
EXT-56 - Add com.iatspayments.civicrm to tarballs

### DIFF
--- a/distmaker/dists/backdrop_php5.sh
+++ b/distmaker/dists/backdrop_php5.sh
@@ -23,6 +23,7 @@ dm_install_packages "$SRC/packages" "$TRG/packages"
 dm_install_vendor "$SRC/vendor" "$TRG/vendor"
 dm_install_bower "$SRC/bower_components" "$TRG/bower_components"
 dm_install_drupal "$SRC/backdrop" "$TRG/backdrop"
+dm_install_cvext com.iatspayments.civicrm "$TRG/ext/iatspayments"
 
 # gen tarball
 cd $TRG/..

--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -236,6 +236,13 @@ function dm_git_checkout() {
   popd
 }
 
+## Download a Civi extension
+## usage: dm_install_cvext <full-ext-key> <target-path>
+function dm_install_cvext() {
+  # cv dl -b '@https://civicrm.org/extdir/ver=4.7.25|cms=Drupal/com.iatspayments.civicrm.xml' --destination=$PWD/iatspayments
+  cv dl -b "@https://civicrm.org/extdir/ver=$DM_VERSION|cms=Drupal/$1.xml" --to="$2"
+}
+
 ## Edit a file by applying a regular expression.
 ## Note: We'd rather just call "sed", but it differs on GNU+BSD.
 ## usage: dm_preg_edit <search-pattern> <replacement-pattern> <file>

--- a/distmaker/dists/drupal6_php5.sh
+++ b/distmaker/dists/drupal6_php5.sh
@@ -23,6 +23,7 @@ dm_install_packages "$SRC/packages" "$TRG/packages"
 dm_install_vendor "$SRC/vendor" "$TRG/vendor"
 dm_install_bower "$SRC/bower_components" "$TRG/bower_components"
 dm_install_drupal "$SRC/drupal" "$TRG/drupal"
+dm_install_cvext com.iatspayments.civicrm "$TRG/ext/iatspayments"
 
 # gen tarball
 cd $TRG/..

--- a/distmaker/dists/drupal7_dir_php5.sh
+++ b/distmaker/dists/drupal7_dir_php5.sh
@@ -30,6 +30,7 @@ dm_install_packages $DM_PACKAGESDIR "$TRG/packages"
 dm_install_vendor "$SRC/vendor" "$TRG/vendor"
 dm_install_bower "$SRC/bower_components" "$TRG/bower_components"
 dm_install_drupal "$DM_DRUPALDIR" "$TRG/drupal"
+dm_install_cvext com.iatspayments.civicrm "$TRG/ext/iatspayments"
 
 # gen tarball
 cd $TRG

--- a/distmaker/dists/drupal_php5.sh
+++ b/distmaker/dists/drupal_php5.sh
@@ -23,6 +23,7 @@ dm_install_packages "$SRC/packages" "$TRG/packages"
 dm_install_vendor "$SRC/vendor" "$TRG/vendor"
 dm_install_bower "$SRC/bower_components" "$TRG/bower_components"
 dm_install_drupal "$SRC/drupal" "$TRG/drupal"
+dm_install_cvext com.iatspayments.civicrm "$TRG/ext/iatspayments"
 
 # gen tarball
 cd $TRG/..

--- a/distmaker/dists/drupal_sk_php5.sh
+++ b/distmaker/dists/drupal_sk_php5.sh
@@ -23,6 +23,7 @@ dm_install_packages "$SRC/packages" "$TRG/packages"
 dm_install_vendor "$SRC/vendor" "$TRG/vendor"
 dm_install_bower "$SRC/bower_components" "$TRG/bower_components"
 dm_install_drupal "$SRC/drupal" "$TRG/drupal"
+dm_install_cvext com.iatspayments.civicrm "$TRG/ext/iatspayments"
 
 # delete packages that distributions on Drupal.org repalce if present
 # also delete stuff that we dont really use and should not be included

--- a/distmaker/dists/joomla_php5.sh
+++ b/distmaker/dists/joomla_php5.sh
@@ -22,6 +22,7 @@ dm_install_core "$SRC" "$TRG"
 dm_install_packages "$SRC/packages" "$TRG/packages"
 dm_install_vendor "$SRC/vendor" "$TRG/vendor"
 dm_install_bower "$SRC/bower_components" "$TRG/bower_components"
+dm_install_cvext com.iatspayments.civicrm "$TRG/ext/iatspayments"
 
 ## WTF: It's so good we'll install it twice!
 ## (The first is probably extraneous, but there could be bugs dependent on it.)

--- a/distmaker/dists/wordpress_php5.sh
+++ b/distmaker/dists/wordpress_php5.sh
@@ -23,6 +23,7 @@ dm_install_packages "$SRC/packages" "$TRG/civicrm/civicrm/packages"
 dm_install_vendor "$SRC/vendor" "$TRG/civicrm/civicrm/vendor"
 dm_install_bower "$SRC/bower_components" "$TRG/civicrm/civicrm/bower_components"
 dm_install_wordpress "$SRC/WordPress" "$TRG/civicrm"
+dm_install_cvext com.iatspayments.civicrm "$TRG/civicrm/civicrm/ext/iatspayments"
 
 # gen tarball
 cd $TRG


### PR DESCRIPTION
Overview
----------------------------------------
iATS (http://home.iatspayments.com/) is a payment-processor that specializes
in the needs of non-profit organizations.  It has support in US, CA, UK, and
others.  The extension "com.iatspayments.civicrm" provides
payment-processing integration. 

More discussion -- including project background and review -- are presented
in the JIRA ticket:

https://issues.civicrm.org/jira/browse/EXT-56

Before
----------------------------------------
There are no third-party extensions included in tarballs.

After
----------------------------------------
The extension `com.iatspayments.civicrm` is included.

Technical Details
----------------------------------------
This patch relies on the new `cv` v0.1.30. This revision improves `cv dl`:

 * Support downloading into a specific folder. This allows us to place
   the extension in the build-tree for the tarball.
 * Support downloading without an active Civi site (`--bare`). This is
   useful for the build-bot.
 * Support downloading based on the URL of `info.xml` file.  In combination
   with `https://civicrm.org/extdir/...`, this allows us to download the
   latest stable zip -- without needing to fetch/cache/parse the full
   listing. (Low-overhead is ideal for `--bare`.)