### PR TITLE
CRM-21195: Improving menu item icon markup

### DIFF
--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -528,7 +528,7 @@ FROM civicrm_navigation WHERE domain_id = $domainID {$whereClause} ORDER BY pare
     }
 
     if (!empty($value['attributes']['icon'])) {
-      $menuIcon = sprintf('<span class="%s"></span>&nbsp;', $value['attributes']['icon']);
+      $menuIcon = sprintf('<span class="menu-item-icon %s"></span>', $value['attributes']['icon']);
       $name = $menuIcon . $name;
     }
 

--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -528,7 +528,7 @@ FROM civicrm_navigation WHERE domain_id = $domainID {$whereClause} ORDER BY pare
     }
 
     if (!empty($value['attributes']['icon'])) {
-      $menuIcon = sprintf('<span class="menu-item-icon %s"></span>', $value['attributes']['icon']);
+      $menuIcon = sprintf('<i class="%s"></i>', $value['attributes']['icon']);
       $name = $menuIcon . $name;
     }
 

--- a/css/civicrmNavigation.css
+++ b/css/civicrmNavigation.css
@@ -120,6 +120,9 @@ img.menu-item-arrow{
   right: 4px;
   top: 8px;
 }
+.menu-item-icon {
+  margin-right: 5px;
+}
 li.menu-separator{
   border-bottom: 1px solid #000;
   font-size: 0; /* for ie */

--- a/css/civicrmNavigation.css
+++ b/css/civicrmNavigation.css
@@ -120,7 +120,7 @@ img.menu-item-arrow{
   right: 4px;
   top: 8px;
 }
-.menu-item-icon {
+#civicrm-menu i {
   margin-right: 5px;
 }
 li.menu-separator{


### PR DESCRIPTION
Before
----------------------------------------
Menu item icon was generated like this : 

```html
<span class="fa fa-search"></span>&nbsp; Search
```

but there should be a CSS class that identfiy the menu item icon so it easy to style menu item icons in CSS.

After
----------------------------------------
Current the generated makrup will look like this : 

```html
<span class="menu-item-icon fa fa-search"></span>Search
```

So basically **menu-item-icon** class is added to all menu item icons and the non breaking space **&nbsp;** was removed and replace with right margin : 

```css
.menu-item-icon {
  margin-right: 5px;
}
```

---

 * [CRM-21195: Adding the ability to add icons to menu items](https://issues.civicrm.org/jira/browse/CRM-21195)