### PR TITLE
CRM-21237: Activity search reset default values when using force=1

### DIFF
--- a/CRM/Activity/BAO/Query.php
+++ b/CRM/Activity/BAO/Query.php
@@ -421,6 +421,7 @@ class CRM_Activity_BAO_Query {
    * @param CRM_Core_Form $form
    */
   public static function buildSearchForm(&$form) {
+    $form->addElement('hidden', 'contact_id');
     $form->addSelect('activity_type_id',
       array('entity' => 'activity', 'label' => ts('Activity Type(s)'), 'multiple' => 'multiple', 'option_url' => NULL, 'placeholder' => ts('- any -'))
     );

--- a/CRM/Activity/Form/Search.php
+++ b/CRM/Activity/Form/Search.php
@@ -156,6 +156,41 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
   }
 
   /**
+   * Returns an array containing final defaults for Activity Search Form
+   * that we want to be set by CRM_Core_Form::setDefaults() method.
+   *
+   * This method is executed by CRM_Core_Form::buildForm() method
+   * after a call to buildQuickForm() method is done. So at this place
+   * any Form's default values are already set.
+   *
+   * While doing Activity Search with force=1 we don't want to use any
+   * default values so we reset currently existing defaults (setting
+   * their values to '').
+   *
+   * However some of defaults shouldn't be reseted (such as any '*_operator'
+   * or 'q' field) so we do a check against each field's name before we 'reset'
+   * its default value.
+   *
+   * Finally we return an array of reseted defaults merged with submit values.
+   *
+   * @return array|NULL
+   */
+  public function setDefaultValues() {
+    if (!$this->_force) {
+      return NULL;
+    }
+
+    $defaults = $this->_defaultValues;
+    foreach ($defaults as $fieldName => $value) {
+      if ($fieldName !== 'q' && !CRM_Utils_String::endsWith($fieldName, '_operator')) {
+        $defaults[$fieldName] = '';
+      }
+    }
+
+    return array_merge($defaults, $this->_submitValues);
+  }
+
+  /**
    * Build the form object.
    */
   public function buildQuickForm() {


### PR DESCRIPTION
Overview
----------------------------------------
This is a supplement to https://issues.civicrm.org/jira/projects/CRM/issues/CRM-20630.

Before
----------------------------------------
When doing Activity Search with force=1 mode we are able to pass URL parameters into search form. However some of fields have their defaults set which are populated into the form in case we don't pass their values by URL parameters (for example 'activity_role' is set to "with" and 'activity_status' is set to "Scheduled" and "Completed" by default).

![crm-21237-before](https://user-images.githubusercontent.com/8986209/31077004-28f1a2f8-a77d-11e7-9748-6fbc8c567032.png)


We don't want to populate default values when using force=1. We assume that there shouldn't be any of value set if it it is not specified in URL parameter.

After
----------------------------------------
We fix this issue implementing setDefaultValues() method in CRM_Activity_Form_Search class. This method is called in parent class (CRM_Core_Form::buildForm()) after form's default values are set. So we are able to reset them if force=1 mode is used.

![crm-21237-after](https://user-images.githubusercontent.com/8986209/31077077-72f55b10-a77d-11e7-96bc-f5d88913d867.png)


Comments
----------------------------------------
Additionally, the PR adds 'contact_id' form's hidden field to allow passing Contact ID parameter to the form. It's handled automatically and allow searching for Activities of specified Contact. Previously the 'contact_id' parameter worked but didn't get passed further when re-submitting search form.

---

 * [CRM-21237: Activity Search: reset default values when using force=1](https://issues.civicrm.org/jira/browse/CRM-21237)
 * [CRM-20630: Find Activities: search criteria passing with URL parameters](https://issues.civicrm.org/jira/browse/CRM-20630)