### PR TITLE
CRM-21246 - Double chaining problem

### DIFF
--- a/api/api.php
+++ b/api/api.php
@@ -129,6 +129,10 @@ function _civicrm_api_get_camel_name($entity) {
  */
 function _civicrm_api_replace_variables(&$params, &$parentResult, $separator = '.') {
   foreach ($params as $field => &$value) {
+    if (substr($field, 0, 4) == 'api.') {
+      // CRM-21246 - Leave nested calls alone.
+      continue;
+    }
     if (is_string($value) && substr($value, 0, 6) == '$value') {
       $value = _civicrm_api_replace_variable($value, $parentResult, $separator);
     }

--- a/tests/phpunit/api/v3/RelationshipTest.php
+++ b/tests/phpunit/api/v3/RelationshipTest.php
@@ -783,7 +783,7 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
    */
   public function testRelationshipGetWithChainedCall() {
     // Create a relationship.
-    $createResult = $this->callAPISuccess('relationship',  'create', $this->_params);
+    $createResult = $this->callAPISuccess('relationship', 'create', $this->_params);
     $id = $createResult['id'];
 
     // Try to retrieve it using chaining.
@@ -809,7 +809,7 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
    */
   public function testRelationshipGetInChainedCall() {
     // Create a relationship.
-    $this->callAPISuccess('relationship',  'create', $this->_params);
+    $this->callAPISuccess('relationship', 'create', $this->_params);
 
     // Try to retrieve it using chaining.
     $params = array(

--- a/tests/phpunit/api/v3/RelationshipTest.php
+++ b/tests/phpunit/api/v3/RelationshipTest.php
@@ -779,6 +779,61 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
   }
 
   /**
+   * Chain Relationship.get and to Contact.get.
+   */
+  public function testRelationshipGetWithChainedCall() {
+    // Create a relationship.
+    $createResult = $this->callAPISuccess('relationship',  'create', $this->_params);
+    $id = $createResult['id'];
+
+    // Try to retrieve it using chaining.
+    $params = array(
+      'relationship_type_id' => $this->_relTypeID,
+      'id' => $id,
+      'api.Contact.get' => array(
+        'id' => '$value.contact_id_b',
+      ),
+    );
+
+    $result = $this->callAPISuccess('relationship', 'get', $params);
+
+    $this->assertEquals(1, $result['count']);
+    $relationship = CRM_Utils_Array::first($result['values']);
+    $this->assertEquals(1, $relationship['api.Contact.get']['count']);
+    $contact = CRM_Utils_Array::first($relationship['api.Contact.get']['values']);
+    $this->assertEquals($this->_cId_b, $contact['id']);
+  }
+
+  /**
+   * Chain Contact.get to Relationship.get and again to Contact.get.
+   */
+  public function testRelationshipGetInChainedCall() {
+    // Create a relationship.
+    $this->callAPISuccess('relationship',  'create', $this->_params);
+
+    // Try to retrieve it using chaining.
+    $params = array(
+      'id' => $this->_cId_a,
+      'api.Relationship.get' => array(
+        'relationship_type_id' => $this->_relTypeID,
+        'contact_id_a' => '$value.id',
+        'api.Contact.get' => array(
+          'id' => '$value.contact_id_b',
+        ),
+      ),
+    );
+
+    $result = $this->callAPISuccess('contact', 'get', $params);
+    $this->assertEquals(1, $result['count']);
+    $contact = CRM_Utils_Array::first($result['values']);
+    $this->assertEquals(1, $contact['api.Relationship.get']['count']);
+    $relationship = CRM_Utils_Array::first($contact['api.Relationship.get']['values']);
+    $this->assertEquals(1, $relationship['api.Contact.get']['count']);
+    $contact = CRM_Utils_Array::first($relationship['api.Contact.get']['values']);
+    $this->assertEquals($this->_cId_b, $contact['id']);
+  }
+
+  /**
    * Check with valid params array.
    * (The get function will behave differently without 'contact_id' passed
    */


### PR DESCRIPTION
Overview
----------------------------------------
Fix bug when chaining using the $value syntax

Before
----------------------------------------
```
 $result = $this->callAPISuccess('contact', 'get',  array(
       'id' => $this->_cId_a,
       'api.Relationship.get' => array(
         'relationship_type_id' => 1,
         'contact_id_a' => '$value.id',
         'api.Contact.get' => array(
           'id' => '$value.contact_id_b',
         ),
       ),
     );
```
fails to retrieve contact B

After
----------------------------------------
Contact B retrieved, as demonstrated by unit test

Technical Details
---------------------------------------
Adds an exception for the api chaining specific string when doing api chaining replacements to stop the chain ending too soon. Unit test


 * [CRM-21246: Problem chaining Contact.get - Relationship.get - Contact.get](https://issues.civicrm.org/jira/browse/CRM-21246)