### PR TITLE
CRM-21249 - GeocodeTest should warn hitting the Google limit

### DIFF
--- a/tests/phpunit/CRM/Utils/GeocodeTest.php
+++ b/tests/phpunit/CRM/Utils/GeocodeTest.php
@@ -68,6 +68,9 @@ class CRM_Utils_GeocodeTest extends CiviUnitTestCase {
       if ($e->getMessage() == 'A fatal error was triggered: Aborting batch geocoding. Hit the over query limit on geocoder.') {
         $this->markTestIncomplete('Job.geocode error_message: A fatal error was triggered: Aborting batch geocoding. Hit the over query limit on geocoder.');
       }
+      else {
+        throw $e;
+      }
     }
     $params_address_getsingle = array(
       'contact_id' => $contact_values['id'],

--- a/tests/phpunit/CRM/Utils/GeocodeTest.php
+++ b/tests/phpunit/CRM/Utils/GeocodeTest.php
@@ -16,6 +16,9 @@ class CRM_Utils_GeocodeTest extends CiviUnitTestCase {
   public function testStateProvinceFormat() {
     $params = array('state_province_id' => 1022, 'country' => 'U.S.A');
     $formatted = CRM_Utils_Geocode_Google::format($params);
+    if (isset($params['geo_code_error']) && $params['geo_code_error'] == 'OVER_QUERY_LIMIT') {
+      $this->markTestIncomplete('geo_code_error: OVER_QUERY_LIMIT');
+    }
     $this->assertTrue($formatted);
     $this->assertApproxEquals('46.72', $params['geo_code_1'], 1);
     $this->assertApproxEquals('-94.68', $params['geo_code_2'], 1);
@@ -27,7 +30,11 @@ class CRM_Utils_GeocodeTest extends CiviUnitTestCase {
       'geoProvider' => "Google",
     ));
 
-    // Save a contact without disabling geo coding.
+    // Set geocodeMethod to empty.
+    $config = CRM_Core_Config::singleton();
+    $config->geocodeMethod = '';
+
+    // Save a contact with geo coding disabled.
     $params = array(
       'first_name' => 'Abraham',
       'last_name' => 'Lincoln',
@@ -42,18 +49,33 @@ class CRM_Utils_GeocodeTest extends CiviUnitTestCase {
     $result = civicrm_api3('Contact', 'create', $params);
     $contact_values = array_pop($result['values']);
     $address_values = array_pop($contact_values['api.Address.create']['values']);
+
+    $this->assertArrayNotHasKey('geo_code_1', $address_values, 'No geocoding when geocodeMethod is empty');
+
+    // Run the geocode job on that specific contact
+    $config->geocodeMethod = 'CRM_Utils_Geocode_Google';
+
+    try {
+      $params_geocode = array(
+        'start' => $contact_values['id'],
+        'end' => $contact_values['id'] + 1,
+        'geocoding' => 1,
+        'parse' => 0,
+      );
+      $result_geocode = civicrm_api3('Job', 'geocode', $params_geocode);
+    }
+    catch (CiviCRM_API3_Exception $e) {
+      if ($e->getMessage() == 'A fatal error was triggered: Aborting batch geocoding. Hit the over query limit on geocoder.') {
+        $this->markTestIncomplete('Job.geocode error_message: A fatal error was triggered: Aborting batch geocoding. Hit the over query limit on geocoder.');
+      }
+    }
+    $params_address_getsingle = array(
+      'contact_id' => $contact_values['id'],
+    );
+    $result_address_getsingle = civicrm_api3('Address', 'getsingle', $params_address_getsingle);
+
     // We should get a geo code setting.
-    $this->assertApproxEquals('38.89', CRM_Utils_Array::value('geo_code_1', $address_values), 1);
-
-    // Set geocodeMethod to empty.
-    $config = CRM_Core_Config::singleton();
-    $config->geocodeMethod = '';
-
-    // Do it again. This time, we should not geocode.
-    $new_result = civicrm_api3('Contact', 'create', $params);
-    $new_contact_values = array_pop($new_result['values']);
-    $new_address_values = array_pop($new_contact_values['api.Address.create']['values']);
-    $this->assertArrayNotHasKey('geo_code_1', $new_address_values, 'No geocoding when geocodeMethod is empty');
+    $this->assertApproxEquals('38.89', CRM_Utils_Array::value('geo_code_1', $result_address_getsingle), 1);
   }
 
 }


### PR DESCRIPTION
instead of throwing an error

Overview
----------------------------------------
Running the `phpunit` `GeocodeTest` sometimes returns an error that the query limit on Google is reached, and the test fails on Jenkins.

Examples:
https://test.civicrm.org/job/CiviCRM-Core-PR/17391/
https://test.civicrm.org/job/CiviCRM-Core-PR/17415/

Before
----------------------------------------
```env CIVICRM_UF=UnitTests php `which phpunit4` tests/phpunit/CRM/Utils/GeocodeTest.php```

Sometimes:
```
...
There were 2 failures:
1) CRM_Utils_GeocodeTest::testStateProvinceFormat
Failed asserting that false is true.
...
2) CRM_Utils_GeocodeTest::testGeocodeMethodOff
approx-equals: expected=[38.890] actual=[0.000] tolerance=[1.000]
Failed asserting that false is true.
...
```

After
----------------------------------------
```env CIVICRM_UF=UnitTests php `which phpunit4` -v tests/phpunit/CRM/Utils/GeocodeTest.php```

Sometimes:
```
...
There were 2 incomplete test:
1) CRM_Utils_GeocodeTest::testStateProvinceFormat
geo_code_error: OVER_QUERY_LIMIT
...
2) CRM_Utils_GeocodeTest::testGeocodeMethodOff
Job.geocode error_message: A fatal error was triggered: Aborting batch geocoding. Hit the over query limit on geocoder.
... 
```

Technical Details
----------------------------------------
This PR:
- adds an if statement to `testStateProvinceFormat()`
- rewrites `testGeocodeMethodOff()` to trigger the `Geocode` job to update the address instead of just adding the address.

Comments
----------------------------------------
This will prevent Jenkins throwing an error out of the [Google-]blue once in a while.

---

 * [CRM-21249: Google Geocode limit breaks Jenkins test](https://issues.civicrm.org/jira/browse/CRM-21249)