### PR TITLE
CRM-21200: Pay Now payment overwrites the contribution

### DIFF
--- a/CRM/Contribute/BAO/Contribution/Utils.php
+++ b/CRM/Contribute/BAO/Contribution/Utils.php
@@ -143,7 +143,7 @@ class CRM_Contribute_BAO_Contribution_Utils {
 
       $paymentParams['item_name'] = $form->_params['description'];
 
-      $paymentParams['qfKey'] = $form->controller->_key;
+      $paymentParams['qfKey'] = empty($paymentParams['qfKey']) ? $form->controller->_key : $paymentParams['qfKey'];
       if ($paymentParams['skipLineItem']) {
         // We are not processing the line item here because we are processing a membership.
         // Do not continue with contribution processing in this function.

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
@@ -1,0 +1,155 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2017                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *  Test APIv3 civicrm_contribute_* functions
+ *
+ * @package CiviCRM_APIv3
+ * @subpackage API_Contribution
+ * @group headless
+ */
+class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
+
+  /**
+   * Clean up DB.
+   */
+  public function tearDown() {
+    $this->quickCleanUpFinancialEntities();
+  }
+
+  /**
+   * CRM-21200: Test that making online payment for pending contribution doesn't overwite the contribution details
+   */
+  public function testPaynowPayment() {
+    $contactID = $this->individualCreate();
+    $paymentProcessorID = $this->paymentProcessorCreate(array('payment_processor_type_id' => 'Dummy'));
+
+    // create a contribution page which is later used to make pay-later contribution
+    $result = $this->callAPISuccess('ContributionPage', 'create', array(
+      'title' => 'Test Contribution Page',
+      'financial_type_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'financial_type_id', 'Campaign Contribution'),
+      'currency' => 'USD',
+      'financial_account_id' => 1,
+      'payment_processor' => $paymentProcessorID,
+      'is_active' => 1,
+      'is_allow_other_amount' => 1,
+      'min_amount' => 20,
+      'max_amount' => 2000,
+    ));
+    $contributionPageID1 = $result['id'];
+    // create pending contribution
+    $contribution = $this->callAPISuccess('Contribution', 'create', array(
+      'contact_id' => $contactID,
+      'financial_type_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'financial_type_id', 'Campaign Contribution'),
+      'currency' => 'USD',
+      'total_amount' => 100.00,
+      'contribution_status_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Pending'),
+      'contribution_page_id' => $contributionPageID1,
+      'source' => 'backoffice pending contribution',
+    ));
+
+    // create a contribution page which is later used to make online payment for pending contribution
+    $result = $this->callAPISuccess('ContributionPage', 'create', array(
+      'title' => 'Test Contribution Page',
+      'financial_type_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'financial_type_id', 'Campaign Contribution'),
+      'currency' => 'USD',
+      'financial_account_id' => 1,
+      'payment_processor' => $paymentProcessorID,
+      'is_active' => 1,
+      'is_allow_other_amount' => 1,
+      'min_amount' => 10,
+      'max_amount' => 1000,
+    ));
+    $form = new CRM_Contribute_Form_Contribution_Confirm();
+    $contributionPageID2 = $result['id'];
+    $form->_id = $contributionPageID2;
+    $form->_values = $result['values'][$contributionPageID2];
+    $form->_paymentProcessor = array(
+      'id' => $paymentProcessorID,
+      'billing_mode' => CRM_Core_Payment::BILLING_MODE_FORM,
+      'object' => Civi\Payment\System::singleton()->getById($paymentProcessorID),
+      'is_recur' => FALSE,
+      'payment_instrument_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Credit card'),
+    );
+    $form->_params = array(
+      'qfKey' => 'donotcare',
+      'contribution_id' => $contribution['id'],
+      'credit_card_number' => 4111111111111111,
+      'cvv2' => 234,
+      'credit_card_exp_date' => array(
+        'M' => 2,
+        'Y' => 2021,
+      ),
+      'credit_card_type' => 'Visa',
+      'email-5' => 'test@test.com',
+      'total_amount' => 100.00,
+      'payment_processor_id' => $paymentProcessorID,
+      'amount' => 100,
+      'tax_amount' => 0.00,
+      'year' => 2021,
+      'month' => 2,
+      'currencyID' => 'USD',
+      'is_pay_later' => 0,
+      'invoiceID' => '6e443672a9bb2198cc12f076aed70e7a',
+      'is_quick_config' => 1,
+      'description' => $contribution['values'][$contribution['id']]['source'],
+      'skipLineItem' => 0,
+    );
+
+    $result = CRM_Contribute_BAO_Contribution_Utils::processConfirm($form,
+      $form->_params,
+      $contactID,
+      $form->_values['financial_type_id'],
+      0, FALSE
+    );
+    // Based on the processed contribution, complete transaction which update the contribution status based on payment result.
+    if (!empty($result['contribution'])) {
+      $this->callAPISuccess('contribution', 'completetransaction', array(
+        'id' => $result['contribution']->id,
+        'trxn_date' => date('Y-m-d'),
+        'payment_processor_id' => $paymentProcessorID,
+      ));
+    }
+
+    $contribution = $this->callAPISuccessGetSingle('Contribution', array(
+      'id' => $form->_params['contribution_id'],
+      'return' => array(
+        'contribution_page_id',
+        'contribution_status',
+        'contribution_source',
+      ),
+    ));
+
+    // check that contribution page ID isn't changed
+    $this->assertEquals($contributionPageID1, $contribution['contribution_page_id']);
+    // check that paid later information is present in contribution's source
+    $this->assertRegExp("/Paid later via page ID: $contributionPageID2/", $contribution['contribution_source']);
+    // check that contribution status is changed to 'Completed' from 'Pending'
+    $this->assertEquals('Completed', $contribution['contribution_status']);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Currently when we do a pay now contribution civicrm_contribution.contribution_page_id and civicrm_contribution.source is updated i.e the configured page for the later pay now payment overwrites the contribution info derived from the original creation of the pay later contribution. This should be a payment that is not overwriting 'reason' that the contribution was originally created.
To replicate:
1. Set Default invoice payment page in CiviContribute Setting (eg contribution page ID = 1|title = Help Support CiviCRM )
2. Add a pay later contribution using Contribution page(eg ID = 3)
3. Click on Pay Now button for a pay later contribution under user dashboard and complete the transaction

Before
----------------------------------------
Contribution detail like source, campaign_id and contribution_page_id overwritten. Screenshot:
![screen shot 2017-10-03 at 5 48 14 pm](https://user-images.githubusercontent.com/3735621/31124674-20ac93fa-a863-11e7-8197-2b2fc61245d2.png)


After
----------------------------------------
1. contribution.contribution_page_id is NOT overwritten.
2. contribution.campaign_id is NOT overwritten.
3. contribution.source is updated with 'Paid later via page ID: 1. Online Contribution: Help Support CiviCRM!'
Screenshot:
![screen shot 2017-10-03 at 5 55 15 pm](https://user-images.githubusercontent.com/3735621/31124926-1f2423b2-a864-11e7-8b43-d13eea4ade29.png)


---

 * [CRM-21200: Pay Now payment overwrites the contribution](https://issues.civicrm.org/jira/browse/CRM-21200)