### PR TITLE
WIP CRM-21256 Improve performance of payment processor load

### DIFF
--- a/CRM/Financial/BAO/PaymentProcessor.php
+++ b/CRM/Financial/BAO/PaymentProcessor.php
@@ -444,8 +444,13 @@ class CRM_Financial_BAO_PaymentProcessor extends CRM_Financial_DAO_PaymentProces
    * @return bool
    */
   public static function hasPaymentProcessorSupporting($capabilities = array()) {
-    $result = self::getPaymentProcessors($capabilities);
-    return (!empty($result)) ? TRUE : FALSE;
+    static $results;
+    $capabilitiesString = implode('', $capabilities);
+    if (!isset($results[$capabilitiesString])) {
+      $result = self::getPaymentProcessors($capabilities);
+      $results[$capabilitiesString] = (!empty($result)) ? TRUE : FALSE;
+    }
+    return $results[$capabilitiesString];
   }
 
   /**

--- a/CRM/Financial/BAO/PaymentProcessor.php
+++ b/CRM/Financial/BAO/PaymentProcessor.php
@@ -383,7 +383,7 @@ class CRM_Financial_BAO_PaymentProcessor extends CRM_Financial_DAO_PaymentProces
       $processors = self::getAllPaymentProcessors('all', TRUE, FALSE);
     }
     else {
-      $processors = self::getAllPaymentProcessors('all', TRUE);
+      $processors = self::getAllPaymentProcessors('live', TRUE, TRUE);
     }
 
     if (in_array('TestMode', $capabilities) && is_array($ids)) {


### PR DESCRIPTION
Overview
----------------------------------------
Improve performance of "Submit Credit Card Contribution" page load.

Before
----------------------------------------
CRM_Financial_BAO_PaymentProcessor::hasPaymentProcessorSupporting() is being called 4 times (3 for BackOffice, once for futurePayment capability) for a backoffice payment and having quite a noticeable performance impact on the "Submit Credit Card Contribution" form.

After
----------------------------------------
It's still being called 4 times, but we return the cached (via static var) result on each subsequent call.

Technical Details
----------------------------------------
1. Use a static variable in hasPaymentProcessorSupporting() so we only check once per request.
2. Don't load test processors when we don't need to in getPaymentProcessors()

Timings from a (slow) site:
Oct 03 17:07:06  [info] exec time old: 1.7639739513397
Oct 03 17:07:07  [info] exec time old: 1.2242529392242
Oct 03 17:07:15  [info] exec time old: 1.2430901527405
Oct 03 17:07:27  [info] exec time old: 1.2307901382446

Oct 03 17:08:27  [info] exec time new: 1.2210669517517
Oct 03 17:08:28  [info] exec time new: 0.72421288490295
Oct 03 17:08:34  [info] exec time new: 7.1525573730469E-6
Oct 03 17:08:44  [info] exec time new: 6.1988830566406E-6

---

 * [CRM-21256: Payment processor contribution page performance improvement](https://issues.civicrm.org/jira/browse/CRM-21256)