### PR TITLE
CRM-21208 Fix version check on Joomla 3.8

### DIFF
--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -518,9 +518,15 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
     }
   }
 
+  /**
+   * Setup the base path related constant.
+   * @return mixed
+   */
   public function getBasePath() {
-    // Setup the base path related constant.
-    return dirname(dirname(dirname(dirname(dirname(dirname(dirname(dirname(__FILE__))))))));
+    global $civicrm_root;
+    $joomlaPath = explode('/administrator', $civicrm_root);
+    $joomlaBase = $joomlaPath[0];
+    return $joomlaBase;
   }
 
   /**

--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -362,12 +362,8 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
       $row = $users[0];
     }
 
-    $joomlaBase = dirname(dirname(dirname(dirname(dirname(dirname(dirname(dirname(__FILE__))))))));
-    if (!defined('JVERSION')) {
-      require $joomlaBase . '/libraries/cms/version/version.php';
-      $jversion = new JVersion();
-      define('JVERSION', $jversion->getShortVersion());
-    }
+    $joomlaBase = self::getBasePath();
+    self::getJVersion($joomlaBase);
 
     if (!empty($row)) {
       $dbPassword = $row->password;
@@ -507,6 +503,26 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
     }
   }
 
+  public function getJVersion($joomlaBase) {
+    // Files may be in different places depending on Joomla version
+    if (!defined('JVERSION')) {
+      // Joomla 3.8.0+
+      $versionPhp = $joomlaBase . '/libraries/src/Version.php';
+      if (!file_exists($versionPhp)) {
+        // Joomla < 3.8.0
+        $versionPhp = $joomlaBase . '/libraries/cms/version/version.php';
+      }
+      require $versionPhp;
+      $jversion = new JVersion();
+      define('JVERSION', $jversion->getShortVersion());
+    }
+  }
+
+  public function getBasePath() {
+    // Setup the base path related constant.
+    return dirname(dirname(dirname(dirname(dirname(dirname(dirname(dirname(__FILE__))))))));
+  }
+
   /**
    * Load joomla bootstrap.
    *
@@ -521,8 +537,7 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
    * @return bool
    */
   public function loadBootStrap($params = array(), $loadUser = TRUE, $throwError = TRUE, $realPath = NULL, $loadDefines = TRUE) {
-    // Setup the base path related constant.
-    $joomlaBase = dirname(dirname(dirname(dirname(dirname(dirname(dirname(dirname(__FILE__))))))));
+    $joomlaBase = self::getBasePath();
 
     // load BootStrap here if needed
     // We are a valid Joomla entry point.
@@ -541,12 +556,7 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
     require $joomlaBase . '/libraries/joomla/event/dispatcher.php';
     require $joomlaBase . '/configuration.php';
 
-    // Files may be in different places depending on Joomla version
-    if (!defined('JVERSION')) {
-      require $joomlaBase . '/libraries/cms/version/version.php';
-      $jversion = new JVersion();
-      define('JVERSION', $jversion->getShortVersion());
-    }
+    self::getJVersion($joomlaBase);
 
     if (version_compare(JVERSION, '3.0', 'lt')) {
       require $joomlaBase . '/libraries/joomla/environment/uri.php';
@@ -704,8 +714,7 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
     }
 
     list($url, $siteName, $siteRoot) = $this->getDefaultSiteSettings();
-    $includePath = "$siteRoot/libraries/cms/version";
-    if (file_exists("$includePath/version.php")) {
+    if (file_exists("$siteRoot/administrator/index.php")) {
       return $siteRoot;
     }
     return NULL;


### PR DESCRIPTION
The Administer > System Settings > Directories page fails to load on Joomla 3.8 installations.
An error is logged:
RuntimeException: Cannot resolve path using "cms.root.path" in /var/www/html/membership/administrator/components/com_civicrm/civicrm/Civi/Core/Paths.php on line 104
The problem lies in the cmsRootPath() function in CRM/Utils/System/Joomla.php. This code was added by CRM-18058 and as part of determining the Joomla root path it tests for the existence of a particular file, $siteRoot/libraries/cms/version/version.php.
    $includePath = "$siteRoot/libraries/cms/version";
    if (file_exists("$includePath/version.php")
In Joomla 3.8.0 that file doesn't exist; it's been moved to $siteRoot/libraries/src/Version.php

---

 * [CRM-21208: Directories configuration page broken on Joomla 3.8](https://issues.civicrm.org/jira/browse/CRM-21208)
 * [CRM-18058: CMS root path error in Directories page \(Joomla version\)](https://issues.civicrm.org/jira/browse/CRM-18058)