### PR TITLE
CRM-21258 support long display names.

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -179,6 +179,12 @@ class CRM_Contact_BAO_Contact extends CRM_Contact_DAO_Contact {
         $contact->display_name = $contact->sort_name = CRM_Utils_Array::value('organization_name', $params, '');
       }
     }
+    if (strlen($contact->display_name) > 128) {
+      $contact->display_name = substr($contact->display_name, 0, 128);
+    }
+    if (strlen($contact->sort_name) > 128) {
+      $contact->sort_name = substr($contact->sort_name, 0, 128);
+    }
 
     $privacy = CRM_Utils_Array::value('privacy', $params);
     if ($privacy &&

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -2361,6 +2361,21 @@ class api_v3_ContactTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test long display names.
+   *
+   * CRM-21258
+   */
+  public function testContactCreateLongDisplayName() {
+    $result = $this->callAPISuccess('Contact', 'Create', array(
+      'first_name' => str_pad('a', 64, 'a'),
+      'last_name' => str_pad('a', 64, 'a'),
+      'contact_type' => 'Individual',
+    ));
+    $this->assertEquals('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', $result['values'][$result['id']]['display_name']);
+    $this->assertEquals('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', $result['values'][$result['id']]['sort_name']);
+  }
+
+  /**
    * Test Single Entity format.
    */
   public function testContactGetSingleEntityArray() {


### PR DESCRIPTION
Overview
----------------------------------------
Gracefully truncate rather than hard-error if calculated field display_name field exceeds DB chars

Before
----------------------------------------
If you create a contact & the length of the calculated display name (e.g. first_name + " " +  last_name) exceeds 128 chars you get a DB error

After
----------------------------------------
Display field & sort field are truncated rather than a hard error

Comments
----------------------------------------
This is pretty edge case & likely to be bad data but a db error on a calculated field being too long seems inappropriate

---

 * [CRM-21258: Display name fatal error if names are too long](https://issues.civicrm.org/jira/browse/CRM-21258)