### PR TITLE
CRM-21055 Revert change of "cancel" to "close" on backend contribution form

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -828,7 +828,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
         ),
         array(
           'type' => 'cancel',
-          'name' => ts('Close'),
+          'name' => ts('Cancel'),
         ),
       )
     );


### PR DESCRIPTION
This reverts commit 35c930c1921ad45ae3da24b2e0bdad7470ed7b49.

The change was done in isolation, leading to inconsistency with other forms
that have the Save / Save and New / Cancel pattern.

@totten @colemanw please take a look before shipping 4.7.25--I just noticed #10845 as I was writing up the release notes and I'm very concerned about it.  See [the explanation on JIRA](https://issues.civicrm.org/jira/browse/CRM-21055?focusedCommentId=108600&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-108600)

Basically, either all instances of this pattern should say "Close" or all should say "Cancel".  In the meantime, we shouldn't be shipping it with the one exception, especially since it changes longstanding behavior.

@eileenmcnaughton @pradpnayak @monishdeb @lcdservices