### PR TITLE
CRM-21055 Revert change of "cancel" to "close" on backend contribution form

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -826,7 +826,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
         ),
         array(
           'type' => 'cancel',
-          'name' => ts('Close'),
+          'name' => ts('Cancel'),
         ),
       )
     );


### PR DESCRIPTION
The same as #11064 but for master branch.

---

 * [CRM-21055: Change label of cancel button](https://issues.civicrm.org/jira/browse/CRM-21055)