### PR TITLE
CRM-21262 - Add a system check for the resource URL

### DIFF
--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -889,6 +889,10 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
    */
   public function checkResourceUrl() {
     $messages = array();
+    // Skip when run during unit tests, you can't check without a CMS.
+    if (CRM_Core_Config::singleton()->userFramework == 'UnitTests') {
+      return $messages;
+    }
     // Does arrow.png exist where we expect it?
     $arrowUrl = CRM_Core_Config::singleton()->userFrameworkResourceURL . 'packages/jquery/css/images/arrow.png';
     $headers = get_headers($arrowUrl);

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -883,4 +883,27 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
     return $messages;
   }
 
+  /**
+   * Check that the resource URL points to the correct location.
+   * @return array
+   */
+  public function checkResourceUrl() {
+    $messages = array();
+    // Does arrow.png exist where we expect it?
+    $arrowUrl = CRM_Core_Config::singleton()->userFrameworkResourceURL . 'packages/jquery/css/images/arrow.png';
+    $headers = get_headers($arrowUrl);
+    $fileExists = stripos($headers[0], "200 OK") ? 1 : 0;
+    if (!$fileExists) {
+      $messages[] = new CRM_Utils_Check_Message(
+        __FUNCTION__,
+        ts('The Resource URL is not set correctly. Please set the <a href="%1">CiviCRM Resource URL</a>.',
+          array(1 => CRM_Utils_System::url('civicrm/admin/setting/url', 'reset=1'))),
+        ts('Incorrect Resource URL'),
+        \Psr\Log\LogLevel::ERROR,
+        'fa-server'
+      );
+    }
+    return $messages;
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
This adds a system check to ensure that the Resource URL is correct.

Before
----------------------------------------
If the resource URL was incorrect, you'd have to know that broken arrow icons in the CiviCRM menus were a symptom of that.

After
----------------------------------------
You'll now be informed via the System Check when a Resource URL is incorrect.

---

 * [CRM-21262: Add a check for incorrect Resource URL](https://issues.civicrm.org/jira/browse/CRM-21262)