### PR TITLE
Fix for CRM-21264 , corrected regular expression

### DIFF
--- a/CRM/Contribute/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contribute/Form/Task/PDFLetterCommon.php
@@ -186,7 +186,7 @@ class CRM_Contribute_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDF
   public static function isHtmlTokenInTableCell($token, $entity, $textToSearch) {
     $tokenToMatch = $entity . '.' . $token;
     $dontCare = array();
-    $within = preg_match_all("|<td.+?{" . $tokenToMatch . "}.+?</td|si", $textToSearch, $dontCare);
+    $within = preg_match_all("|<td.+?{" . $tokenToMatch . "}.*</td|si", $textToSearch, $dontCare);
     $total = preg_match_all("|{" . $tokenToMatch . "}|", $textToSearch, $dontCare);
     return ($within == $total);
   }


### PR DESCRIPTION
for printing the contribution token in tabular format when its group by contact. it uses regular expression to check token is with in 'table'.

Current regular expression failed to detect last TD for table.

---

 * [CRM-21264: print contribution in tabular format with group by contact not working](https://issues.civicrm.org/jira/browse/CRM-21264)