### PR TITLE
CRM-21245: Incorrect Contribution status 'Pending Refund'

### DIFF
--- a/CRM/Event/Form/ParticipantFeeSelection.php
+++ b/CRM/Event/Form/ParticipantFeeSelection.php
@@ -239,7 +239,7 @@ class CRM_Event_Form_ParticipantFeeSelection extends CRM_Core_Form {
 
     $feeBlock = $this->_values['fee'];
     $lineItems = $this->_values['line_items'];
-    CRM_Price_BAO_LineItem::changeFeeSelections($params, $this->_participantId, 'participant', $this->_contributionId, $feeBlock, $lineItems, $this->_paidAmount);
+    CRM_Price_BAO_LineItem::changeFeeSelections($params, $this->_participantId, 'participant', $this->_contributionId, $feeBlock, $lineItems);
     $this->contributionAmt = CRM_Core_DAO::getFieldValue('CRM_Contribute_BAO_Contribution', $this->_contributionId, 'total_amount');
     // email sending
     if (!empty($params['send_receipt'])) {

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1730,8 +1730,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
 
       // add price field information in $inputParams
       self::addPriceFieldByMembershipType($inputParams, $priceSetDetails['fields'], $membership->membership_type_id);
-      // paid amount
-      $paidAmount = CRM_Utils_Array::value('paid', CRM_Contribute_BAO_Contribution::getPaymentInfo($membership->id, 'membership'));
+
       // update related contribution and financial records
       CRM_Price_BAO_LineItem::changeFeeSelections(
         $inputParams,
@@ -1739,7 +1738,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
         'membership',
         $contributionID,
         $priceSetDetails['fields'],
-        $lineItems, $paidAmount
+        $lineItems
       );
       CRM_Core_Session::setStatus(ts('Associated contribution is updated on membership type change.'), ts('Success'), 'success');
     }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -552,7 +552,7 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
     $expectedValue, $message
   ) {
     $value = CRM_Core_DAO::getFieldValue($daoName, $searchValue, $returnColumn, $searchColumn, TRUE);
-    $this->assertEquals($value, $expectedValue, $message);
+    $this->assertEquals($expectedValue, $value, $message);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate: 
If the participant is registered to an event by admin in backend and event has 3 selections:
1. 1st  - $1500.00
2. 2nd - $1200.00
At first '1st' selection was made and partial payment of $500.00 was made, then event participation summary is viewed, it shows correct status. Screenshot: http://prntscr.com/gsfokn
Now when selection is changed to '2nd' still contact owes $700 but system says the payment status to be "Pending refund". Screenshot: http://prntscr.com/gsfpgg  

Before
----------------------------------------
Contribution status is updated to 'Pending Refund' - Incorrect.
https://www.screencast.com/t/cOfGhsHgQJe

After
----------------------------------------
Contribution status is retained to 'Partially Paid' - Correct.
![event-pending-refund-after](https://user-images.githubusercontent.com/3735621/31277125-06d00604-aabd-11e7-9ba6-3464a7146822.gif)

---

 * [CRM-21245: Incorrect Contribution status "Pending Refund"](https://issues.civicrm.org/jira/browse/CRM-21245)