### PR TITLE
CRM-21275: Fatal error without message should recommend bug-reporting page, instead of the deprecated forum

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -343,7 +343,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
     }
 
     if (!$message) {
-      $message = ts('We experienced an unexpected error. Please post a detailed description and the backtrace on the CiviCRM forums: %1', array(1 => 'http://forum.civicrm.org/'));
+      $message = ts('We experienced an unexpected error. You may have found a bug. For more information on how to provide a bug report, please read: %1', array(1 => 'https://civicrm.org/bug-reporting'));
     }
 
     if (php_sapi_name() == "cli") {
@@ -423,7 +423,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
       'exception' => $exception,
     );
     if (!$vars['message']) {
-      $vars['message'] = ts('We experienced an unexpected error. Please post a detailed description and the backtrace on the CiviCRM forums: %1', array(1 => 'http://forum.civicrm.org/'));
+      $vars['message'] = ts('We experienced an unexpected error. You may have found a bug. For more information on how to provide a bug report, please read: %1', array(1 => 'https://civicrm.org/bug-reporting'));
     }
 
     // Case A: CLI


### PR DESCRIPTION
Overview
----------------------------------------

The forum has long been deprecated. While running into a programming error (which was my fault), I stumbled on this deprecated message:

```
-      $vars['message'] = ts('We experienced an unexpected error. Please post a detailed description and the backtrace on the CiviCRM forums: %1', array(1 => 'http://forum.civicrm.org/'));
+      $vars['message'] = ts('We experienced an unexpected error. You may have found a bug. For more information on how to provide a bug report, please read: %1', array(1 => 'https://civicrm.org/bug-reporting'));
```

Before
----------------------------------------

![capture d ecran de 2017-10-08 12-11-01](https://user-images.githubusercontent.com/254741/31318574-c942fa0a-ac22-11e7-8ef3-e6b75d6e46ca.png)

After
----------------------------------------

![capture d ecran de 2017-10-08 12-15-00](https://user-images.githubusercontent.com/254741/31318573-b980f4f0-ac22-11e7-8af7-d5f7a240f5f0.png)

Technical Details
----------------------------------------

Inverted the flux capacitor then reset the hull polarity.

Comments
----------------------------------------

cc @seanmadsen (since it's a documentation issue)

---

 * [CRM-21275: Fatal error without message should recommend bug-reporting page, instead of deprecated forum](https://issues.civicrm.org/jira/browse/CRM-21275)