### PR TITLE
CRM-21277: Suppress warnings while finding install directory.

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -464,7 +464,7 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
    */
   public function validInstallDir($dir) {
     $includePath = "$dir/wp-includes";
-    if (file_exists("$includePath/version.php")) {
+    if (@file_exists("$includePath/version.php")) {
       return TRUE;
     }
     return FALSE;


### PR DESCRIPTION
Prevents log spam when e.g. open_basedir restrictions are in effect.

----------------------------------------
* CRM-21277: CRM_Utils_System_WordPress::validInstallDir spams log with warnings when open_basedir restriction is in effect
  https://issues.civicrm.org/jira/browse/CRM-21277

Overview
----------------------------------------
_Suppress warnings while finding install directory._

Before
----------------------------------------
_Error log can be spammed during Wordpress CiviCRM bootstrap by PHP warnings about non-fatal reasons the directories can't be opened_

After
----------------------------------------
_These warning are now suppresed by the @ operator_