### PR TITLE
CRM-19850 - Add a offline membership without 'record payment' option,…

### DIFF
--- a/CRM/Contribute/Form/Search.php
+++ b/CRM/Contribute/Form/Search.php
@@ -248,7 +248,7 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
 
     $this->_done = TRUE;
 
-    if (!empty($_POST)) {
+    if (!empty($_POST) && !$this->_force) {
       $this->_formValues = $this->controller->exportValues($this->_name);
     }
 

--- a/templates/CRM/Member/Form/MembershipCommon.tpl
+++ b/templates/CRM/Member/Form/MembershipCommon.tpl
@@ -1,5 +1,5 @@
 {if !$membershipMode}
-  {if $accessContribution && $action != 2}
+  {if $accessContribution && ($action != 2 or (!$rows.0.contribution_id AND !$softCredit) or $onlinePendingContributionId)}
     <table>
       <tr class="crm-{$formClass}-form-block-contribution-contact">
         <td class="label">{$form.is_different_contribution_contact.label}</td>


### PR DESCRIPTION
… later edit the membership and saving with 'record payment' option

Overview
----------------------------------------
1) Visit any contact, and click on membership tab.
2) Click on 'Add Membership', select the desired membership, and uncheck 'record payment' option, save it.
3) Now, edit the same membership, and this time check the 'record payment' checkbox, the payment details form doesn't appear.
4) Trying to save this screen, results in 'Please select Financial Type' form error message.

Before
----------------------------------------
![membership_contri_edit](https://user-images.githubusercontent.com/3455173/31326194-8be05ee4-ace2-11e7-90c6-4c3ae80b88b1.png)

