### PR TITLE
(NFC) Add in section to the PR template about documentation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,10 @@ Technical Details
 ----------------------------------------
 _If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_
 
+Documentation
+---------------------------------------
+_Has there been a pull request made against either the user, sysadmin, or developer guides where necessary to update or add to the documentation._
+
 Comments
 ----------------------------------------
 _Anything else you would like the reviewer to note_


### PR DESCRIPTION
Overview
----------------------------------------
This adds a section onto the PR Template about have you opened documentation PR. The aim of this is to add a prompt to people about documentation

@totten @seanmadsen i think this is a useful step but would appreciate your thoughts on this