### PR TITLE
CRM-19346 Ensure Option Values do not share same value

### DIFF
--- a/CRM/Admin/Form/Options.php
+++ b/CRM/Admin/Form/Options.php
@@ -170,8 +170,8 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
       CRM_Core_DAO::getAttribute('CRM_Core_DAO_OptionValue', 'label'),
       TRUE
     );
-    $domainSpecificOptionGroups = array('from_email_address');
-    $this->_domainSpecific = in_array($this->_gName, $domainSpecificOptionGroups) ? TRUE : FALSE;
+
+    $this->_domainSpecific = in_array($this->_gName, CRM_Core_OptionGroup::$_domainIDGroups) ? TRUE : FALSE;
     if ($this->_gName != 'activity_type') {
       $this->add('text',
         'value',

--- a/CRM/Admin/Form/Options.php
+++ b/CRM/Admin/Form/Options.php
@@ -80,6 +80,7 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
       'name'
     );
     $this->_gLabel = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', $this->_gid, 'title');
+    $this->_domainSpecific = in_array($this->_gName, CRM_Core_OptionGroup::$_domainIDGroups);
     $url = "civicrm/admin/options/{$this->_gName}";
     $params = "reset=1";
 
@@ -171,7 +172,6 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
       TRUE
     );
 
-    $this->_domainSpecific = in_array($this->_gName, CRM_Core_OptionGroup::$_domainIDGroups) ? TRUE : FALSE;
     if ($this->_gName != 'activity_type') {
       $this->add('text',
         'value',

--- a/CRM/Admin/Form/Options.php
+++ b/CRM/Admin/Form/Options.php
@@ -51,6 +51,12 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
   protected $_gLabel;
 
   /**
+   * Is this Option Group Domain Specific
+   * @var bool
+   */
+  protected $_domainSpecific = FALSE;
+
+  /**
    * Pre-process
    */
   public function preProcess() {
@@ -164,13 +170,19 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
       CRM_Core_DAO::getAttribute('CRM_Core_DAO_OptionValue', 'label'),
       TRUE
     );
-
+    $domainSpecificOptionGroups = array('from_email_address');
+    $this->_domainSpecific = in_array($this->_gName, $domainSpecificOptionGroups) ? TRUE : FALSE;
     if ($this->_gName != 'activity_type') {
       $this->add('text',
         'value',
         ts('Value'),
         CRM_Core_DAO::getAttribute('CRM_Core_DAO_OptionValue', 'value'),
         TRUE
+      );
+      $this->addRule('value',
+        ts('This Value already exists in the database for this option group. Please select a different Value.'),
+        'optionExists',
+        array('CRM_Core_DAO_OptionValue', $this->_id, $this->_gid, 'value', $this->_domainSpecific)
       );
     }
     else {
@@ -187,12 +199,10 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
         'addressee',
       )) && !$isReserved
     ) {
-      $domainSpecificOptionGroups = array('from_email_address');
-      $domainSpecific = in_array($this->_gName, $domainSpecificOptionGroups) ? TRUE : FALSE;
       $this->addRule('label',
-        ts('This Label already exists in the database for this option group. Please select a different Value.'),
+        ts('This Label already exists in the database for this option group. Please select a different Label.'),
         'optionExists',
-        array('CRM_Core_DAO_OptionValue', $this->_id, $this->_gid, 'label', $domainSpecific)
+        array('CRM_Core_DAO_OptionValue', $this->_id, $this->_gid, 'label', $this->_domainSpecific)
       );
     }
 

--- a/CRM/Core/BAO/OptionValue.php
+++ b/CRM/Core/BAO/OptionValue.php
@@ -219,6 +219,15 @@ class CRM_Core_BAO_OptionValue extends CRM_Core_DAO_OptionValue {
     $groupName = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup',
       $groupId, 'name', 'id'
     );
+    if (empty($ids['optionValue']) && empty($params['id']) && !empty($params['value'])) {
+      $domainSpecifc = in_array($groupName, CRM_Core_OptionGroup::$_domainIDGroups) ? TRUE : FALSE;
+      $dao = new CRM_Core_DAO_OptionValue();
+      $dao->value = $params['value'];
+      $dao->option_group_id = $groupId;
+      if ($dao->find(TRUE)) {
+        throw new CRM_Core_Exception('Value already exists in the database');
+      }
+    }
     if (in_array($groupName, CRM_Core_OptionGroup::$_domainIDGroups)) {
       $optionValue->domain_id = CRM_Utils_Array::value('domain_id', $params, CRM_Core_Config::domainID());
     }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3003,6 +3003,12 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
 
     CRM_Core_Config::singleton()->userPermissionClass->permissions = array('access CiviCRM');
     $optionGroupID = $this->callAPISuccessGetValue('option_group', array('return' => 'id', 'name' => 'acl_role'));
+    $ov = new CRM_Core_DAO_OptionValue();
+    $ov->option_group_id = $optionGroupID;
+    $ov->value = 55;
+    if ($ov->find(TRUE)) {
+      CRM_Core_DAO::executeQuery("DELETE FROM civicrm_option_value WHERE id = {$ov->id}");
+    }
     $optionValue = $this->callAPISuccess('option_value', 'create', array(
       'option_group_id' => $optionGroupID,
       'label' => 'pick me',


### PR DESCRIPTION
Overview
----------------------------------------
At present Option Values can be added with the same value as one that is already there in the option group. This now stops this from happening both at the form level and at the API level. This is designed as a replacement for https://github.com/civicrm/civicrm-core/pull/9014 and a more generic solution and more across the board solution

@colemanw @elisseck @ineffyble I believe this is a better solution than suggested in 9014. I tried adding it to the global form rule but wasn't having much joy with it but this achieves the end goal.

---

 * [CRM-19346: gender_id uniqueness not enforced on option groups edit form](https://issues.civicrm.org/jira/browse/CRM-19346)