### PR TITLE
CRM-21279: Rebuild recipient list and calculate count on demand, store result in cache

### DIFF
--- a/CRM/Admin/Form/Preferences/Mailing.php
+++ b/CRM/Admin/Form/Preferences/Mailing.php
@@ -106,13 +106,13 @@ class CRM_Admin_Form_Preferences_Mailing extends CRM_Admin_Form_Preferences {
           'html_type' => 'checkbox',
           'title' => ts('Hashed Mailing URL\'s'),
           'weight' => 11,
-          'description' => 'If enabled, a randomized hash key will be used to reference the mailing URL in the mailing.viewUrl token, instead of the mailing ID',
+          'description' => ts('If enabled, a randomized hash key will be used to reference the mailing URL in the mailing.viewUrl token, instead of the mailing ID'),
         ),
         'auto_recipient_rebuild' => array(
           'html_type' => 'checkbox',
           'title' => ts('Enable automatic CiviMail recipient count display'),
           'weight' => 12,
-          'description' => 'Enable this setting to rebuild recipient list automatically during composing mail. Disable will allow you to rebuild recipient manually.',
+          'description' => ts('Enable this setting to rebuild recipient list automatically during composing mail. Disable will allow you to rebuild recipient manually.'),
         ),
       ),
     );

--- a/CRM/Admin/Form/Preferences/Mailing.php
+++ b/CRM/Admin/Form/Preferences/Mailing.php
@@ -108,6 +108,12 @@ class CRM_Admin_Form_Preferences_Mailing extends CRM_Admin_Form_Preferences {
           'weight' => 11,
           'description' => 'If enabled, a randomized hash key will be used to reference the mailing URL in the mailing.viewUrl token, instead of the mailing ID',
         ),
+        'auto_recipient_rebuild' => array(
+          'html_type' => 'checkbox',
+          'title' => ts('Enable automatic CiviMail recipient count display'),
+          'weight' => 12,
+          'description' => 'Enable this setting to rebuild recipient list automatically during composing mail. Disable will allow you to rebuild recipient manually.',
+        ),
       ),
     );
 

--- a/ang/crmMailing.css
+++ b/ang/crmMailing.css
@@ -111,13 +111,3 @@ input[name=preview_test_email]:-ms-input-placeholder {
   margin: 0.5em;
   color: red;
 }
-
-.crmMailing-outdated-count {
-  color: red;
-  font-weight: bold;
-}
-
-.crmMailing-latest-count {
-  color: green;
-  font-weight: bold;
-}

--- a/ang/crmMailing.css
+++ b/ang/crmMailing.css
@@ -111,3 +111,13 @@ input[name=preview_test_email]:-ms-input-placeholder {
   margin: 0.5em;
   color: red;
 }
+
+.crmMailing-outdated-count {
+  color: red;
+  font-weight: bold;
+}
+
+.crmMailing-latest-count {
+  color: green;
+  font-weight: bold;
+}

--- a/ang/crmMailing/BlockRecipients.html
+++ b/ang/crmMailing/BlockRecipients.html
@@ -8,12 +8,8 @@
     name="{{crmMailingBlockRecipients.name}}"
     ng-required="true" />
     <a crm-icon="fa-wrench" ng-click="editOptions(mailing)" class="crm-hover-button" title="{{ts('Edit Recipient Options')}}"></a>
-    <div>
-      <button ng-click="rebuildRecipients()" class="ng-binding crm-button" title="{{ts('Preview a List of Recipients')}}">{{getRecipientsEstimate()}}</button>
-      <a ng-click="previewRecipients()" class="crm-hover-button" title="{{ts('Click to refresh recipient count')}}">
-        <span class="{{((outdated || recipient == 0) ? 'crmMailing-outdated-count' : 'crmMailing-latest-count')}}">
-          {{getRecipientCount()}}
-        </span>
-      </a>
+    <div ng-style="{display: permitRecipientRebuild ? '' : 'inline-block'}">
+      <button ng-click="rebuildRecipients()" ng-show="permitRecipientRebuild" class="crm-button" title="{{ts('Click to refresh recipient count')}}">{{getRecipientsEstimate()}}</button>
+      <a ng-click="previewRecipients()" class="crm-hover-button" title="{{ts('Preview a List of Recipients')}}" style="font-weight: bold;">{{getRecipientCount()}}</a>
     </div>
 </div>

--- a/ang/crmMailing/BlockRecipients.html
+++ b/ang/crmMailing/BlockRecipients.html
@@ -1,9 +1,4 @@
 <div ng-controller="EditRecipCtrl" class="crm-mailing-recipients-row">
-  <div style="float: right;">
-    <div class="crmMailing-recip-est">
-      <a href="" ng-click="previewRecipients()" title="{{ts('Preview a List of Recipients')}}">{{getRecipientsEstimate()}}</a>
-    </div>
-  </div>
   <input
     type="hidden"
     crm-mailing-recipients
@@ -11,6 +6,14 @@
     crm-mandatory-groups="crmMailingConst.groupNames | filter:{is_hidden:1}"
     crm-ui-id="{{crmMailingBlockRecipients.id}}"
     name="{{crmMailingBlockRecipients.name}}"
-    ng-required="true"/>
-  <a crm-icon="fa-wrench" ng-click="editOptions(mailing)" class="crm-hover-button" title="{{ts('Edit Recipient Options')}}"></a>
+    ng-required="true" />
+    <a crm-icon="fa-wrench" ng-click="editOptions(mailing)" class="crm-hover-button" title="{{ts('Edit Recipient Options')}}"></a>
+    <div>
+      <button ng-click="rebuildRecipients()" class="ng-binding crm-button" title="{{ts('Preview a List of Recipients')}}">{{getRecipientsEstimate()}}</button>
+      <a ng-click="previewRecipients()" class="crm-hover-button" title="{{ts('Click to refresh recipient count')}}">
+        <span class="{{((outdated || recipient == 0) ? 'crmMailing-outdated-count' : 'crmMailing-latest-count')}}">
+          {{getRecipientCount()}}
+        </span>
+      </a>
+    </div>
 </div>

--- a/ang/crmMailing/EditRecipCtrl.js
+++ b/ang/crmMailing/EditRecipCtrl.js
@@ -35,10 +35,18 @@
 
     $scope.getRecipientCount = function() {
       var ts = $scope.ts;
-      if ($scope.recipients === 0 || $scope.outdated) {
-        return $scope.permitRecipientRebuild ? ts('(unknown)') : ts('No Recipients');
+      if ($scope.recipients === 0) {
+        return ts('No Recipients');
       }
-      return ($scope.recipients === 1) ? ts('~1 recipient') : ts('~%1 recipients', {1 : $scope.recipients});
+      else if ($scope.recipients > 0) {
+        return ts('~%1 recipients', {1 : $scope.recipients});
+      }
+      else if ($scope.outdated) {
+        return ts('(unknown)');
+      }
+      else {
+        return $scope.permitRecipientRebuild ? ts('(unknown)') : ts('Estimating...');
+      }
     };
 
     // We monitor four fields -- use debounce so that changes across the

--- a/ang/crmMailing/EditRecipCtrl.js
+++ b/ang/crmMailing/EditRecipCtrl.js
@@ -5,7 +5,7 @@
   // Scope members:
   //  - [input] mailing: object
   //  - [output] recipients: array of recipient records
-  angular.module('crmMailing').controller('EditRecipCtrl', function EditRecipCtrl($scope, dialogService, crmApi, crmMailingMgr, $q, crmMetadata, crmStatus) {
+  angular.module('crmMailing').controller('EditRecipCtrl', function EditRecipCtrl($scope, dialogService, crmApi, crmMailingMgr, $q, crmMetadata, crmStatus, crmMailingCache) {
     // Time to wait before triggering AJAX update to recipients list
     var RECIPIENTS_DEBOUNCE_MS = 100;
     var RECIPIENTS_PREVIEW_LIMIT = 50;
@@ -18,29 +18,36 @@
     };
 
     $scope.recipients = null;
+    $scope.outdated = null;
+
     $scope.getRecipientsEstimate = function() {
       var ts = $scope.ts;
       if ($scope.recipients === null) {
         return ts('(Estimating)');
       }
       if ($scope.recipients === 0) {
-        return ts('No recipients');
+        return ts('Estimate recipient count');
       }
-      if ($scope.recipients === 1) {
-        return ts('~1 recipient');
+      return ts('Refresh recipient count');
+    };
+
+    $scope.getRecipientCount = function() {
+      var ts = $scope.ts;
+      if ($scope.recipients === 0) {
+        return ts('(unknown)');
       }
-      return ts('~%1 recipients', {1: $scope.recipients});
+      return ($scope.recipients === 1) ? ts('~1 recipient') : ts('~%1 recipients', {1 : $scope.recipients});
     };
 
     // We monitor four fields -- use debounce so that changes across the
     // four fields can settle-down before AJAX.
     var refreshRecipients = _.debounce(function() {
       $scope.$apply(function() {
-        $scope.recipients = null;
         if (!$scope.mailing) {
           return;
         }
-        crmMailingMgr.previewRecipientCount($scope.mailing).then(function(recipients) {
+        crmMailingMgr.previewRecipientCount($scope.mailing, crmMailingCache, false).then(function(recipients) {
+          $scope.outdated = (_.difference($scope.mailing.recipients, crmMailingCache.get('mailing-' + $scope.mailing.id + '-recipient-params')) !== 0);
           $scope.recipients = recipients;
         });
       });
@@ -54,21 +61,36 @@
     $scope.$watchCollection("mailing.recipients.mailings.exclude", refreshRecipients);
 
     $scope.previewRecipients = function previewRecipients() {
-      return crmStatus({start: ts('Previewing...'), success: ''}, crmMailingMgr.previewRecipients($scope.mailing, RECIPIENTS_PREVIEW_LIMIT).then(function(recipients) {
-        var model = {
-          count: $scope.recipients,
-          sample: recipients,
-          sampleLimit: RECIPIENTS_PREVIEW_LIMIT
-        };
-        var options = CRM.utils.adjustDialogDefaults({
-          width: '40%',
-          autoOpen: false,
-          title: ts('Preview (%1)', {
-            1: $scope.getRecipientsEstimate()
-          })
-        });
-        dialogService.open('recipDialog', '~/crmMailing/PreviewRecipCtrl.html', model, options);
-      }));
+      var model = {
+        count: $scope.recipients,
+        sample: crmMailingCache.get('mailing-' + $scope.mailing.id + '-recipient-list'),
+        sampleLimit: RECIPIENTS_PREVIEW_LIMIT
+      };
+      var options = CRM.utils.adjustDialogDefaults({
+        width: '40%',
+        autoOpen: false,
+        title: ts('Preview (%1)', {1: $scope.getRecipientCount()})
+      });
+
+      // don't open preview dialog if there is no recipient to show.
+      if ($scope.recipients !== 0) {
+        if (!_.isEmpty(model.sample)) {
+          dialogService.open('recipDialog', '~/crmMailing/PreviewRecipCtrl.html', model, options);
+        }
+        else {
+          return crmStatus({start: ts('Previewing...'), success: ''}, crmMailingMgr.previewRecipients($scope.mailing, RECIPIENTS_PREVIEW_LIMIT).then(function(recipients) {
+            model.sample = recipients;
+            dialogService.open('recipDialog', '~/crmMailing/PreviewRecipCtrl.html', model, options);
+          }));
+        }
+      }
+    };
+
+    $scope.rebuildRecipients = function rebuildRecipients() {
+      return crmMailingMgr.previewRecipientCount($scope.mailing, crmMailingCache, true).then(function(recipients) {
+        $scope.outdated = (recipients === 0) ? true : false;
+        $scope.recipients = recipients;
+      });
     };
 
     // Open a dialog for editing the advanced recipient options.

--- a/ang/crmMailing/services.js
+++ b/ang/crmMailing/services.js
@@ -310,24 +310,46 @@
         });
       },
 
-      previewRecipientCount: function previewRecipientCount(mailing) {
-        // To get list of recipients, we tentatively save the mailing and
-        // get the resulting recipients -- then rollback any changes.
-        var params = angular.extend({}, mailing, mailing.recipients, {
-          name: 'placeholder', // for previewing recipients on new, incomplete mailing
-          subject: 'placeholder', // for previewing recipients on new, incomplete mailing
-          options: {force_rollback: 1},
-          'api.mailing_job.create': 1, // note: exact match to API default
-          'api.MailingRecipients.getcount': {
-            mailing_id: '$value.id'
+      previewRecipientCount: function previewRecipientCount(mailing, crmMailingCache, rebuild) {
+        var cachekey = 'mailing-' + mailing.id + '-recipient-count';
+        var recipientCount = crmMailingCache.get(cachekey);
+        if (rebuild || _.isEmpty(recipientCount)) {
+          // To get list of recipients, we tentatively save the mailing and
+          // get the resulting recipients -- then rollback any changes.
+          var params = angular.extend({}, mailing, mailing.recipients, {
+            name: 'placeholder', // for previewing recipients on new, incomplete mailing
+            subject: 'placeholder', // for previewing recipients on new, incomplete mailing
+            options: {force_rollback: 1},
+            'api.mailing_job.create': 1, // note: exact match to API default
+            'api.MailingRecipients.getcount': {
+              mailing_id: '$value.id'
+            }
+          });
+          // if this service is executed on rebuild then also fetch the recipients list
+          if (rebuild) {
+            params = angular.extend(params, {
+              'api.MailingRecipients.get': {
+                mailing_id: '$value.id',
+                options: {limit: 50},
+                'api.contact.getvalue': {'return': 'display_name'},
+                'api.email.getvalue': {'return': 'email'}
+              }
+            });
+            crmMailingCache.put('mailing-' + mailing.id + '-recipient-params', params.recipients);
           }
-        });
-        delete params.recipients; // the content was merged in
-        return qApi('Mailing', 'create', params).then(function (recipResult) {
-          // changes rolled back, so we don't care about updating mailing
-          mailing.modified_date = recipResult.values[recipResult.id].modified_date;
-          return recipResult.values[recipResult.id]['api.MailingRecipients.getcount'];
-        });
+          delete params.recipients; // the content was merged in
+          recipientCount = qApi('Mailing', 'create', params).then(function (recipResult) {
+            // changes rolled back, so we don't care about updating mailing
+            mailing.modified_date = recipResult.values[recipResult.id].modified_date;
+            if (rebuild) {
+              crmMailingCache.put('mailing-' + mailing.id + '-recipient-list', recipResult.values[recipResult.id]['api.MailingRecipients.get'].values);
+            }
+            return recipResult.values[recipResult.id]['api.MailingRecipients.getcount'];
+          });
+          crmMailingCache.put(cachekey, recipientCount);
+        }
+
+        return recipientCount;
       },
 
       // Save a (draft) mailing
@@ -554,5 +576,9 @@
       };
     };
   });
+
+  angular.module('crmMailing').factory('crmMailingCache', ['$cacheFactory', function($cacheFactory) {
+    return $cacheFactory('crmMailingCache');
+  }]);
 
 })(angular, CRM.$, CRM._);

--- a/settings/Mailing.setting.php
+++ b/settings/Mailing.setting.php
@@ -333,4 +333,17 @@ return array(
     'description' => 'The number of emails sendable via simple mail. Make sure you understand the implications for your spam reputation and legal requirements for bulk emails before editing. As there is some risk both to your spam reputation and the products if this is misused it is a hidden setting',
     'help_text' => 'CiviCRM forces users sending more than this number of mails to use CiviMails. CiviMails have additional precautions: not sending to contacts who do not want bulk mail, adding domain name and opt out links. You should familiarise yourself with the law relevant to you on bulk mailings if changing this setting. For the US https://en.wikipedia.org/wiki/CAN-SPAM_Act_of_2003 is a good place to start.',
   ),
+  'auto_recipient_rebuild' => array(
+    'group_name' => 'Mailing Preferences',
+    'group' => 'mailing',
+    'name' => 'auto_recipient_rebuild',
+    'type' => 'Boolean',
+    'quick_form_type' => 'YesNo',
+    'default' => '1',
+    'title' => 'Enable automatic CiviMail recipient count display',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => 'Enable this setting to rebuild recipient list automatically during composing mail. Disable will allow you to rebuild recipient manually.',
+    'help_text' => 'CiviMail automatically fetches recipient list and count whenever mailing groups are included or excluded while composing bulk mail. This phenomena may degrade performance for large sites, so disable this setting to build and fetch recipients for selected groups, manually.',
+  ),
 );


### PR DESCRIPTION
Overview
----------------------------------------
In CiviMail compose screen, there are few issues with how the recipient count and list are fetched, which are:
1. Every time mailing groups are included or excluded from recipient field, this causes a repetitive call to mailingRecipient.get API to fetch count and list of recipients.
2. Four mailing fields are constantly monitored at a timespan of 100ms and in the process, it call previewRecipientCount angular service which eventually triggers mailingRecipient.getcount API to calculate recipient count.


In order to avoid such repetitive API call, a new CiviMail component setting is introduced called ``` auto_recipient_rebuild``` which is set by default, that allows you to rebuild recipient data automatically or manually. Let me show you affect on mail screen if this new setting is enabled/disabled.

Auto recipient rebuild
----------------------------------------
![enable-setting](https://user-images.githubusercontent.com/3735621/31716087-fc512c1a-b423-11e7-801b-c6fbb0a37af5.gif)

Manual recipient rebuild
----------------------------------------
![disable-setting](https://user-images.githubusercontent.com/3735621/31716118-0e75f0a6-b424-11e7-9edd-26cf68cb4d1b.gif)

Technical Details
----------------------------------------
1. Created a angular service to enable $cacheFactory usage in 'EditRecipCtrl' controller. This factory constructs Cache objects and is persistent to current session 
2. If the new setting is disabled then it provides a recipient rebuild icon beside recipient count text as shown in above screenshot.
3. On clicking the rebuild icon, underlying angular service fetch and store recipient count and list in cache, and then used to reflect the latest count and recipient list on 'Preview recipients' page
4. Change in recipient count placement on basis of manual/auto mode.

The idea behind is to avoid the repetitive call to APIs and fetch recipient data on demand to improve performance, but this feature is controlled by setting ```` auto_recipient_rebuild```

---

 * [CRM-21279: Rebuild recipient list and calculate count on demand, store result in $cacheFactory](https://issues.civicrm.org/jira/browse/CRM-21279)