### PR TITLE
CRM-20397 Allow for up to 4 hours tollarence in setting the date as v…

### DIFF
--- a/ang/crmMailing/RadioDate.js
+++ b/ang/crmMailing/RadioDate.js
@@ -1,4 +1,17 @@
 (function(angular, $, _) {
+  // "YYYY-MM-DD hh:mm:ss" => Date()
+  function parseYmdHms(d) {
+    var parts = d.split(/[\-: ]/);
+    return new Date(parts[0], parts[1]-1, parts[2], parts[3], parts[4], parts[5]);
+  }
+
+  function isDateBefore(tgt, cutoff, tolerance) {
+    var ad = parseYmdHms(tgt), bd = parseYmdHms(cutoff);
+    // We'll allow a little leeway, where tgt is considered before cutoff
+    // even if technically misses the cutoff by a little.
+    return  ad < bd-tolerance;
+  }
+
   // Represent a datetime field as if it were a radio ('schedule.mode') and a datetime ('schedule.datetime').
   // example: <div crm-mailing-radio-date="mySchedule" ng-model="mailing.scheduled_date">...</div>
   angular.module('crmMailing').directive('crmMailingRadioDate', function(crmUiAlert) {
@@ -64,7 +77,7 @@
               date = [year, month, day].join('-');
               time = [hours, minutes, "00"].join(':');
               currentDate = date + ' ' + time;
-              var isInPast = ($(this).val().length && submittedDate < currentDate);
+              var isInPast = (submittedDate.length && submittedDate.match(/^[0-9\-]+ [0-9\:]+$/) && isDateBefore(submittedDate, currentDate, 4*60*60*1000));
               ngModel.$setValidity('dateTimeInThePast', !isInPast);
               if (lastAlert && lastAlert.isOpen) {
                 lastAlert.close();


### PR DESCRIPTION
…alid or not so that end user timezone issues aren't a factor

Overview
----------------------------------------
This allows for dates to be scheduled up to 4 hours prior to current. Tim and I discussed the issue around the need for some flexibility and agreed that we should reduce the tolerance down to 4 hours. This brings the rest of Tim's PR in https://github.com/civicrm/civicrm-core/pull/10291 but reduces tolerance to 4 hours which should fix issues where the users timezone has been making the form suggest they have a incorrect date

ping @totten @monishdeb @eileenmcnaughton 

This is my pick up of Tim's work and is an agreed compromise between Tim and I. It would be good if one of you could review it and make sure its still sensible