### PR TITLE
WIP: CRM-21180: Inline changes to custom fields aren't reflected in custom greetings

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -2630,6 +2630,114 @@ AND       civicrm_openid.is_primary = 1";
   }
 
   /**
+   * Check whether greetings for this contact contain tokens for the given
+   * custom field.
+   *
+   * @param object $contact Contact object.
+   * @param int $customFieldId System ID of the custom field.
+   * @return bool
+   */
+  public static function checkGreetingsUseCustomFieldToken($contact, $customFieldId) {
+    $greetingStrings = self::getGreetingStrings($contact, FALSE);
+    foreach ($greetingStrings as $greetingString) {
+      if (strpos($greetingString, ".custom_{$customFieldId}}") !== FALSE) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+  /**
+   * Get an array of template strings for greeting fields.
+   *
+   * @param object $contact Contact object.
+   * @param bool $useDefaults If TRUE, use system default greeting values;
+   *    otherwise, use values for this specific contact.
+   * @return Array of greeting strings, with keys: 'email', 'postal', 'addressee'.
+   */
+  public static function getGreetingStrings($contact, $useDefaults = FALSE) {
+    static $greetingStrings = array();
+    if (!array_key_exists($contact->id, $greetingStrings)) {
+      if ($useDefaults) {
+        //retrieve default greetings
+        $defaultGreetings = CRM_Core_PseudoConstant::greetingDefaults();
+        $contactDefaults = $defaultGreetings[$contact->contact_type];
+      }
+
+      $greetingStrings[$contact->id] = array(
+        'email' => NULL,
+        'postal' => NULL,
+        'addressee' => NULL,
+      );
+
+      //cache email and postal greeting to greeting display
+      if ($contact->email_greeting_custom != 'null' && $contact->email_greeting_custom) {
+        $greetingStrings[$contact->id]['email'] = $contact->email_greeting_custom;
+      }
+      elseif ($contact->email_greeting_id != 'null' && $contact->email_greeting_id) {
+        // the filter value for Individual contact type is set to 1
+        $filter = array(
+          'contact_type' => $contact->contact_type,
+          'greeting_type' => 'email_greeting',
+        );
+
+        $emailGreeting = CRM_Core_PseudoConstant::greeting($filter);
+        $greetingStrings[$contact->id]['email'] = $emailGreeting[$contact->email_greeting_id];
+      }
+      else {
+        if ($useDefaults) {
+          reset($contactDefaults['email_greeting']);
+          $emailGreetingID = key($contactDefaults['email_greeting']);
+          $greetingStrings[$contact->id]['email'] = $contactDefaults['email_greeting'][$emailGreetingID];
+        }
+      }
+
+      //postal greetings
+      if ($contact->postal_greeting_custom != 'null' && $contact->postal_greeting_custom) {
+        $greetingStrings[$contact->id]['postal'] = $contact->postal_greeting_custom;
+      }
+      elseif ($contact->postal_greeting_id != 'null' && $contact->postal_greeting_id) {
+        $filter = array(
+          'contact_type' => $contact->contact_type,
+          'greeting_type' => 'postal_greeting',
+        );
+        $postalGreeting = CRM_Core_PseudoConstant::greeting($filter);
+        $greetingStrings[$contact->id]['postal'] = $postalGreeting[$contact->postal_greeting_id];
+      }
+      else {
+        if ($useDefaults) {
+          reset($contactDefaults['postal_greeting']);
+          $postalGreetingID = key($contactDefaults['postal_greeting']);
+          $greetingStrings[$contact->id]['postal'] = $contactDefaults['postal_greeting'][$postalGreetingID];
+        }
+      }
+
+      // addressee
+      if ($contact->addressee_custom != 'null' && $contact->addressee_custom) {
+        $greetingStrings[$contact->id]['addressee'] = $contact->addressee_custom;
+      }
+      elseif ($contact->addressee_id != 'null' && $contact->addressee_id) {
+        $filter = array(
+          'contact_type' => $contact->contact_type,
+          'greeting_type' => 'addressee',
+        );
+
+        $addressee = CRM_Core_PseudoConstant::greeting($filter);
+        $greetingStrings[$contact->id]['addressee'] = $addressee[$contact->addressee_id];
+      }
+      else {
+        if ($useDefaults) {
+          reset($contactDefaults['addressee']);
+          $addresseeID = key($contactDefaults['addressee']);
+          $greetingStrings[$contact->id]['addressee'] = $contactDefaults['addressee'][$addresseeID];
+        }
+      }
+    }
+
+    return $greetingStrings[$contact->id];
+  }
+
+  /**
    * Process greetings and cache.
    *
    * @param object $contact

--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -2656,15 +2656,16 @@ AND       civicrm_openid.is_primary = 1";
    * @return Array of greeting strings, with keys: 'email', 'postal', 'addressee'.
    */
   public static function getGreetingStrings($contact, $useDefaults = FALSE) {
-    static $greetingStrings = array();
-    if (!array_key_exists($contact->id, $greetingStrings)) {
+    Civi::$statics[__CLASS__]['greeting_strings'] = array();
+
+    if (!array_key_exists($contact->id, Civi::$statics[__CLASS__]['greeting_strings'])) {
       if ($useDefaults) {
         //retrieve default greetings
         $defaultGreetings = CRM_Core_PseudoConstant::greetingDefaults();
         $contactDefaults = $defaultGreetings[$contact->contact_type];
       }
 
-      $greetingStrings[$contact->id] = array(
+      Civi::$statics[__CLASS__]['greeting_strings'][$contact->id] = array(
         'email' => NULL,
         'postal' => NULL,
         'addressee' => NULL,
@@ -2672,7 +2673,7 @@ AND       civicrm_openid.is_primary = 1";
 
       //cache email and postal greeting to greeting display
       if ($contact->email_greeting_custom != 'null' && $contact->email_greeting_custom) {
-        $greetingStrings[$contact->id]['email'] = $contact->email_greeting_custom;
+        Civi::$statics[__CLASS__]['greeting_strings'][$contact->id]['email'] = $contact->email_greeting_custom;
       }
       elseif ($contact->email_greeting_id != 'null' && $contact->email_greeting_id) {
         // the filter value for Individual contact type is set to 1
@@ -2682,19 +2683,19 @@ AND       civicrm_openid.is_primary = 1";
         );
 
         $emailGreeting = CRM_Core_PseudoConstant::greeting($filter);
-        $greetingStrings[$contact->id]['email'] = $emailGreeting[$contact->email_greeting_id];
+        Civi::$statics[__CLASS__]['greeting_strings'][$contact->id]['email'] = $emailGreeting[$contact->email_greeting_id];
       }
       else {
         if ($useDefaults) {
           reset($contactDefaults['email_greeting']);
           $emailGreetingID = key($contactDefaults['email_greeting']);
-          $greetingStrings[$contact->id]['email'] = $contactDefaults['email_greeting'][$emailGreetingID];
+          Civi::$statics[__CLASS__]['greeting_strings'][$contact->id]['email'] = $contactDefaults['email_greeting'][$emailGreetingID];
         }
       }
 
       //postal greetings
       if ($contact->postal_greeting_custom != 'null' && $contact->postal_greeting_custom) {
-        $greetingStrings[$contact->id]['postal'] = $contact->postal_greeting_custom;
+        Civi::$statics[__CLASS__]['greeting_strings'][$contact->id]['postal'] = $contact->postal_greeting_custom;
       }
       elseif ($contact->postal_greeting_id != 'null' && $contact->postal_greeting_id) {
         $filter = array(
@@ -2702,19 +2703,19 @@ AND       civicrm_openid.is_primary = 1";
           'greeting_type' => 'postal_greeting',
         );
         $postalGreeting = CRM_Core_PseudoConstant::greeting($filter);
-        $greetingStrings[$contact->id]['postal'] = $postalGreeting[$contact->postal_greeting_id];
+        Civi::$statics[__CLASS__]['greeting_strings'][$contact->id]['postal'] = $postalGreeting[$contact->postal_greeting_id];
       }
       else {
         if ($useDefaults) {
           reset($contactDefaults['postal_greeting']);
           $postalGreetingID = key($contactDefaults['postal_greeting']);
-          $greetingStrings[$contact->id]['postal'] = $contactDefaults['postal_greeting'][$postalGreetingID];
+          Civi::$statics[__CLASS__]['greeting_strings'][$contact->id]['postal'] = $contactDefaults['postal_greeting'][$postalGreetingID];
         }
       }
 
       // addressee
       if ($contact->addressee_custom != 'null' && $contact->addressee_custom) {
-        $greetingStrings[$contact->id]['addressee'] = $contact->addressee_custom;
+        Civi::$statics[__CLASS__]['greeting_strings'][$contact->id]['addressee'] = $contact->addressee_custom;
       }
       elseif ($contact->addressee_id != 'null' && $contact->addressee_id) {
         $filter = array(
@@ -2723,18 +2724,18 @@ AND       civicrm_openid.is_primary = 1";
         );
 
         $addressee = CRM_Core_PseudoConstant::greeting($filter);
-        $greetingStrings[$contact->id]['addressee'] = $addressee[$contact->addressee_id];
+        Civi::$statics[__CLASS__]['greeting_strings'][$contact->id]['addressee'] = $addressee[$contact->addressee_id];
       }
       else {
         if ($useDefaults) {
           reset($contactDefaults['addressee']);
           $addresseeID = key($contactDefaults['addressee']);
-          $greetingStrings[$contact->id]['addressee'] = $contactDefaults['addressee'][$addresseeID];
+          Civi::$statics[__CLASS__]['greeting_strings'][$contact->id]['addressee'] = $contactDefaults['addressee'][$addresseeID];
         }
       }
     }
 
-    return $greetingStrings[$contact->id];
+    return Civi::$statics[__CLASS__]['greeting_strings'][$contact->id];
   }
 
   /**

--- a/CRM/Core/BAO/CustomQuery.php
+++ b/CRM/Core/BAO/CustomQuery.php
@@ -179,6 +179,7 @@ SELECT f.id, f.label, f.data_type,
     while ($dao->fetch()) {
       // get the group dao to figure which class this custom field extends
       $extends = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $dao->custom_group_id, 'extends');
+      $extendsTable = '';
       if (array_key_exists($extends, self::$extendsMap)) {
         $extendsTable = self::$extendsMap[$extends];
       }

--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -46,6 +46,8 @@ class CRM_Core_BAO_CustomValueTable {
       return;
     }
 
+    $paramFieldsExtendContactForEntities = array();
+
     foreach ($customParams as $tableName => $tables) {
       foreach ($tables as $index => $fields) {
         $sqlOP = NULL;
@@ -227,6 +229,17 @@ class CRM_Core_BAO_CustomValueTable {
             $params[$count] = array($value, $type);
             $count++;
           }
+
+          $fieldExtends = CRM_Utils_Array::value('extends', $field);
+          if (
+            CRM_Utils_Array::value('entity_table', $field) == 'civicrm_contact'
+            || $fieldExtends == 'Contact'
+            || $fieldExtends == 'Individual'
+            || $fieldExtends == 'Organization'
+            || $fieldExtends == 'Household'
+          ) {
+            $paramFieldsExtendContactForEntities[$entityID][] = CRM_Utils_Array::value('custom_field_id', $field);
+          }
         }
 
         if (!empty($set)) {
@@ -259,6 +272,18 @@ class CRM_Core_BAO_CustomValueTable {
             $entityID,
             $fields
           );
+        }
+      }
+    }
+
+    foreach ($paramFieldsExtendContactForEntities as $entityID => $fieldIds) {
+      $contact = new CRM_Contact_DAO_Contact();
+      $contact->id = $entityID;
+      $contact->find(TRUE);
+      foreach ($fieldIds as $fieldId) {
+        if (CRM_Contact_BAO_Contact::checkGreetingsUseCustomFieldToken($contact, $fieldId)) {
+          CRM_Contact_BAO_Contact::processGreetings($contact);
+          continue;
         }
       }
     }
@@ -560,6 +585,7 @@ AND    $cond
 SELECT cg.table_name  as table_name ,
        cg.id          as cg_id      ,
        cg.is_multiple as is_multiple,
+       cg.extends     as extends,
        cf.column_name as column_name,
        cf.id          as cf_id      ,
        cf.data_type   as data_type
@@ -616,6 +642,7 @@ AND    cf.id IN ( $fieldIDList )
           'table_name' => $dao->table_name,
           'column_name' => $dao->column_name,
           'is_multiple' => $dao->is_multiple,
+          'extends' => $dao->extends,
         );
 
         if ($cvParam['type'] == 'File') {

--- a/templates/CRM/Contact/Page/View/CustomDataFieldView.tpl
+++ b/templates/CRM/Contact/Page/View/CustomDataFieldView.tpl
@@ -23,7 +23,7 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-<div id="custom-set-content-{$customGroupId}" {if $permission EQ 'edit'} class="crm-inline-edit" data-edit-params='{ldelim}"cid": "{$contactId}", "class_name": "CRM_Contact_Form_Inline_CustomData", "groupID": "{$customGroupId}", "customRecId": "{$customRecId}", "cgcount" : "{$cgcount}"{rdelim}'{/if}>
+<div id="custom-set-content-{$customGroupId}" {if $permission EQ 'edit'} class="crm-inline-edit" data-edit-params='{ldelim}"cid": "{$contactId}", "class_name": "CRM_Contact_Form_Inline_CustomData", "groupID": "{$customGroupId}", "customRecId": "{$customRecId}", "cgcount" : "{$cgcount}"{rdelim}' data-dependent-fields='["#crm-communication-pref-content"]'{/if}>
   <div class="crm-clear crm-inline-block-content" {if $permission EQ 'edit'}title="{ts}Edit{/ts}"{/if}>
     {if $permission EQ 'edit'}
       <div class="crm-edit-help">


### PR DESCRIPTION
Inline changes to custom fields aren't reflected in custom greetings.

Overview
----------------------------------------
In all cases (that I know of), changes to first_name (and various other fields) are automatically reflected in contact greetings. However, in various cases, changes to custom fields are not immediately reflected in greetings, even if the greetings contain custom field references (e.g., {contact.custom_1}). 

This lack of immediate change is especially visible in the Summary tab of a contact record.

Before
----------------------------------------
Steps to reproduce:

1. Note the system ID of an existing custom field. In this example we'll use Most Important Issue, custom field ID=1, options: Education; Environment; Social Justice.
1. Find any existing contact and set a value in the custom field, e.g., "Education"
1. Edit a contact's "Addressee" field to "Customized", with the value "{contact.custom_1}" and save the contact; note that the Addressee field now says "Education".
1. Change the value of this custom field via the appropriate inline editing or tab for the custom field group; alternatively, use the CustomValue.create API like so: 
cv api CustomValue.create sequential=1 entity_id=N entity_table="civicrm_contact" custom_1="Env"  
NOTE: This repro recipe will not work if you change this field value by using the "Edit" button for the contact (i.e., by navigating to to /civicrm/contact/add?reset=1&action=update&cid=[N]); or by using the Contact.create API)
1. Observe that the Addressee field value is NOT updated to reflect the new custom field value.

After
----------------------------------------
Repeating the steps above, in the last step, the Addressee field value IS updated to reflect the new custom field value.

Technical Details
----------------------------------------
This PR now takes a more nuanced approach than it did previously, by rebuilding the greetings on change of any custom field, only if that custom field is used in the contact's greetings. This limits the increase in execution time to only those situations where it's needed. (See profiling results in the ticket comment: https://issues.civicrm.org/jira/browse/CRM-21180?focusedCommentId=109114&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-109114)

Comments
----------------------------------------
[none]

---

 * [CRM-21180: Inline changes to custom fields aren't reflected in custom greetings](https://issues.civicrm.org/jira/browse/CRM-21180)