### PR TITLE
HW-381: Added container block to wrap elements

### DIFF
--- a/ang/crmCaseType/edit.html
+++ b/ang/crmCaseType/edit.html
@@ -8,14 +8,6 @@ Required vars: caseType
   <div class="help">
     {{ts('Use this screen to define or update the Case Roles, Activity Types, and Timelines for a case type.')}} <a href="https://docs.civicrm.org/user/en/stable/case-management/set-up/" target="_blank">{{ts('Learn more...')}}</a>
   </div>
-  <div class="crm-submit-buttons">
-    <button crm-icon="fa-check" ng-click="editCaseTypeForm.$setPristine(); save()" ng-disabled="editCaseTypeForm.$invalid">
-      {{ts('Save')}}
-    </button>
-    <button crm-icon="fa-times" ng-click="editCaseTypeForm.$setPristine(); goto('caseType')">
-      {{ts('Cancel')}}
-    </button>
-  </div>
 
   <div ng-include="'~/crmCaseType/caseTypeDetails.html'"></div>
 

--- a/ang/crmCaseType/list.html
+++ b/ang/crmCaseType/list.html
@@ -4,72 +4,74 @@ Required vars: caseTypes
 -->
 <h1 crm-page-title>{{ts('Case Types')}}</h1>
 
-<div class="help">
-  {{ts('A Case Type describes a group of related tasks, interactions, or processes.')}}
-</div>
+<div class="crm-content-block crm-block">
+  <div class="help">
+    {{ts('A Case Type describes a group of related tasks, interactions, or processes.')}}
+  </div>
 
-<table class="display">
-  <thead>
-  <tr>
-    <th>{{ts('Title')}}</th>
-    <th>{{ts('Name')}}</th>
-    <th>{{ts('Description')}}</th>
-    <th>{{ts('Enabled?')}}</th>
-    <th></th>
-  </tr>
-  </thead>
-  <tbody>
-  <tr ng-repeat="caseType in caseTypes"
-      class="crm-entity"
-      ng-class-even="'even-row even'"
-      ng-class-odd="'odd-row odd'"
-      ng-class="{disabled: 0==caseType.is_active, forked: 1==caseType.is_forked}">
-    <td>{{caseType.title}}</td>
-    <td>{{caseType.name}}</td>
-    <td>{{caseType.description}}</td>
-    <td>{{caseType.is_active == 1 ? ts('Yes') : ts('No')}}</td>
-    <!-- FIXME: Can't figure out how styling in other tables gets the nowrap effect... in absence of a consistent fix, KISS -->
-    <td style="white-space: nowrap">
-      <span>
-        <a class="action-item crm-hover-button" ng-href="#/caseType/{{caseType.id}}">{{ts('Edit')}}</a>
+  <table class="display">
+    <thead>
+    <tr>
+      <th>{{ts('Title')}}</th>
+      <th>{{ts('Name')}}</th>
+      <th>{{ts('Description')}}</th>
+      <th>{{ts('Enabled?')}}</th>
+      <th></th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr ng-repeat="caseType in caseTypes"
+        class="crm-entity"
+        ng-class-even="'even-row even'"
+        ng-class-odd="'odd-row odd'"
+        ng-class="{disabled: 0==caseType.is_active, forked: 1==caseType.is_forked}">
+      <td>{{caseType.title}}</td>
+      <td>{{caseType.name}}</td>
+      <td>{{caseType.description}}</td>
+      <td>{{caseType.is_active == 1 ? ts('Yes') : ts('No')}}</td>
+      <!-- FIXME: Can't figure out how styling in other tables gets the nowrap effect... in absence of a consistent fix, KISS -->
+      <td style="white-space: nowrap">
+        <span>
+          <a class="action-item crm-hover-button" ng-href="#/caseType/{{caseType.id}}">{{ts('Edit')}}</a>
 
-        <span class="btn-slide crm-hover-button">
-          {{ts('more')}}
-          <ul class="panel" style="display: none;">
-            <li ng-hide="caseType.is_active">
-              <a class="action-item crm-hover-button" ng-click="toggleCaseType(caseType)">
-                {{ts('Enable')}}
-              </a>
-            </li>
-            <li ng-show="caseType.is_active">
-              <a class="action-item crm-hover-button"
-                 crm-confirm="{type: 'disable', obj: caseType}"
-                 on-yes="toggleCaseType(caseType)">
-                {{ts('Disable')}}
-              </a>
-            </li>
-            <li ng-show="caseType.is_forked">
-              <a class="action-item crm-hover-button"
-                 crm-confirm="{type: 'revert', obj: caseType}"
-                 on-yes="revertCaseType(caseType)">
-                {{ts('Revert')}}
-              </a>
-            </li>
-            <li>
-              <a class="action-item crm-hover-button"
-                 crm-confirm="{type: 'delete', obj: caseType}"
-                 on-yes="deleteCaseType(caseType)">
-                {{ts('Delete')}}
-              </a>
-            </li>
-          </ul>
+          <span class="btn-slide crm-hover-button">
+            {{ts('more')}}
+            <ul class="panel" style="display: none;">
+              <li ng-hide="caseType.is_active">
+                <a class="action-item crm-hover-button" ng-click="toggleCaseType(caseType)">
+                  {{ts('Enable')}}
+                </a>
+              </li>
+              <li ng-show="caseType.is_active">
+                <a class="action-item crm-hover-button"
+                   crm-confirm="{type: 'disable', obj: caseType}"
+                   on-yes="toggleCaseType(caseType)">
+                  {{ts('Disable')}}
+                </a>
+              </li>
+              <li ng-show="caseType.is_forked">
+                <a class="action-item crm-hover-button"
+                   crm-confirm="{type: 'revert', obj: caseType}"
+                   on-yes="revertCaseType(caseType)">
+                  {{ts('Revert')}}
+                </a>
+              </li>
+              <li>
+                <a class="action-item crm-hover-button"
+                   crm-confirm="{type: 'delete', obj: caseType}"
+                   on-yes="deleteCaseType(caseType)">
+                  {{ts('Delete')}}
+                </a>
+              </li>
+            </ul>
+          </span>
         </span>
-      </span>
-    </td>
-  </tr>
-  </tbody>
-</table>
+      </td>
+    </tr>
+    </tbody>
+  </table>
 
-<div class="crm-submit-buttons">
-  <a ng-href="#/caseType/new" class="button"><span><i class="crm-i fa-plus-circle"></i> {{ts('New Case Type')}}</span></a>
+  <div class="crm-submit-buttons">
+    <a ng-href="#/caseType/new" class="button"><span><i class="crm-i fa-plus-circle"></i> {{ts('New Case Type')}}</span></a>
+  </div>
 </div>

--- a/templates/CRM/Admin/Form/Setting/Case.tpl
+++ b/templates/CRM/Admin/Form/Setting/Case.tpl
@@ -55,5 +55,4 @@
     </tr>
   </table>
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
-  <div class="spacer"></div>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
This PR adds container block to wrap elements of page in proper structure

Before
----------------------------------------
1. Wrapper was missing
2. Case type setting page had buttons on top on bottom

After
----------------------------------------
1. Added wrapper <div class="crm-content-block crm-block">
2. Removed top buttons from the page of case type

Technical Details
----------------------------------------
All content of page should be wrapped in some wrapper div which can allow to hold and style inner elements or to target proper parent element. which is served here by <div class="crm-content-block crm-block">

Comments
----------------------------------------
The change is technical and not visible by screenshot by default except design by any theme. (e.g shoreditch gives shadow to this container to make it look better)
