### PR TITLE
CRM-21281: Restore entity reference in case the post hook needs it

### DIFF
--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -70,6 +70,8 @@ class CRM_Price_BAO_LineItem extends CRM_Price_DAO_LineItem {
     // unset entity table and entity id in $params
     // we never update the entity table and entity id during update mode
     if ($id) {
+      $entity_id = $params['entity_id'];
+      $entity_table = $params['entity_table'];
       unset($params['entity_id'], $params['entity_table']);
     }
     else {
@@ -102,6 +104,9 @@ class CRM_Price_BAO_LineItem extends CRM_Price_DAO_LineItem {
     }
 
     if ($id) {
+      // CRM-21281: Restore entity reference in case the post hook needs it
+      $lineItemBAO->entity_id = $entity_id;
+      $lineItemBAO->entity_table = $entity_table;
       CRM_Utils_Hook::post('edit', 'LineItem', $id, $lineItemBAO);
     }
     else {


### PR DESCRIPTION
Overview
----------------------------------------
In the POST hook for the LineItem entity, the entity_id and entity_table attributes are blank if the operation is edit (but have a value on create). Yet this information could be useful in all circumstances for the business logic implemented in this hook.

Before
----------------------------------------
The post hook would receive &$objectRef as an instance of CRM_Price_BAO_LineItem that has the attibutes entity_id and entity_name blanks even though they have a value in the database.

After
----------------------------------------
Both attributes have the same value as saved in the database.

Technical Details
----------------------------------------
 CRM_Price_BAO_LineItem::create() did unset the attributes before saving to the database in order not to overwrite these, but did not restore their value before calling the hook.

Comments
----------------------------------------
Trivial change, I would be very surprised if there are any side effect on any existing extension since these attributes had no value before. Extension developers should use the $op argument to the hook to see if this is a create or edit operation.

---

 * [CRM-21281: Post Hook for LineItem does not receive entity_id and entity_table ](https://issues.civicrm.org/jira/browse/CRM-21281)