### PR TITLE
CRM-20903 Improve ordering of dedupe rules

### DIFF
--- a/CRM/Contact/Page/DedupeRules.php
+++ b/CRM/Contact/Page/DedupeRules.php
@@ -132,7 +132,7 @@ class CRM_Contact_Page_DedupeRules extends CRM_Core_Page_Basic {
     // get all rule groups
     $ruleGroups = array();
     $dao = new CRM_Dedupe_DAO_RuleGroup();
-    $dao->orderBy('contact_type,used ASC');
+    $dao->orderBy('contact_type ASC, used ASC, id ASC');
     $dao->find();
 
     $dedupeRuleTypes = CRM_Core_SelectValues::getDedupeRuleTypes();


### PR DESCRIPTION
Overview
----------------------------------------
Dedupe rule ordering was ambiguous.

Before
----------------------------------------
On the list of dedupe rules, the rules could appear in basically a random order.

After
----------------------------------------
The order has been specified as a sensible default.

Technical Details
----------------------------------------
Changes to the ORDER BY clause that builds the list.

---

 * [CRM-20903: Improve ordering of dedupe rules](https://issues.civicrm.org/jira/browse/CRM-20903)