### PR TITLE
CRM-21282 Improve ordering of click reporting

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -2231,7 +2231,8 @@ ORDER BY   civicrm_email.is_bulkmail DESC
                     ON  {$t['queue']}.job_id = {$t['job']}.id
             WHERE       {$t['url']}.mailing_id = $mailing_id
                     AND {$t['job']}.is_test = 0
-            GROUP BY    {$t['url']}.id");
+            GROUP BY    {$t['url']}.id
+            ORDER BY    unique_clicks DESC");
 
     $report['click_through'] = array();
 


### PR DESCRIPTION
Overview
----------------------------------------
The list of links on the click report summary, on the mailing overview page, didn't display links in a sensible order.

Before
----------------------------------------
The links are basically in a random order.

After
----------------------------------------
The links are ordered from highest clicks to lowest clicks.

Technical Details
----------------------------------------
Changes to the 'ORDER BY' clause in the SQL that builds the list.

---

 * [CRM-21282: Improve ordering of CiviMail click reporting](https://issues.civicrm.org/jira/browse/CRM-21282)