### PR TITLE
CRM-21285 Buildkit Installs failing for WordPress

### DIFF
--- a/Civi/Core/Paths.php
+++ b/Civi/Core/Paths.php
@@ -57,7 +57,7 @@ class Paths {
         return \CRM_Core_Config::singleton()->userSystem->getDefaultFileStorage();
       })
       ->register('wp.frontend.base', function () {
-        return array('url' => CIVICRM_UF_BASEURL);
+        return array('url' => rtrim(CIVICRM_UF_BASEURL, '/') . '/');
       })
       ->register('wp.frontend', function () use ($paths) {
         $config = \CRM_Core_Config::singleton();
@@ -67,7 +67,7 @@ class Paths {
         );
       })
       ->register('wp.backend.base', function () {
-        return array('url' => CIVICRM_UF_BASEURL . 'wp-admin/');
+        return array('url' => rtrim(CIVICRM_UF_BASEURL, '/') . '/wp-admin/');
       })
       ->register('wp.backend', function () use ($paths) {
         return array(


### PR DESCRIPTION
https://github.com/civicrm/civicrm-core/pull/11031 Updated the way we define frontend and backend urls for WP.   Testing was done with manual installs before merge.   Buildkit installs are failing for WP.

Currently manual installs are succedding from nightly tarballs.   Manual upgrades are successful. Buildkit installs fail.

On Buildkit the backed url is defined as http://example.orgwp-admin  instead of http://example.org/wp-admin

https://github.com/civicrm/civicrm-core/pull/11031/files#diff-1544096e8e60bfe9fe73eeca2844804eR66  is the likely culprit.

---

 * [CRM-21285: Buildkit Installs failing for WordPress](https://issues.civicrm.org/jira/browse/CRM-21285)