### PR TITLE
CRM-21284: Update documentation link for setting up default mailbox

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -2915,9 +2915,9 @@ WHERE  civicrm_mailing_job.id = %1
     $config = CRM_Core_Config::singleton();
 
     if ($mode == NULL && CRM_Core_BAO_MailSettings::defaultDomain() == "EXAMPLE.ORG") {
-      throw new CRM_Core_Exception(ts('The <a href="%1">default mailbox</a> has not been configured. You will find <a href="%2">more info in the online user and administrator guide</a>', array(
+      throw new CRM_Core_Exception(ts('The <a href="%1">default mailbox</a> has not been configured. You will find <a href="%2">more info in the online system administrator guide</a>', array(
             1 => CRM_Utils_System::url('civicrm/admin/mailSettings', 'reset=1'),
-            2 => "http://book.civicrm.org/user/advanced-configuration/email-system-configuration/",
+            2 => "https://docs.civicrm.org/sysadmin/en/latest/setup/civimail/",
           )));
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Update documentation link for setting up default mailbox.

Before
----------------------------------------
When mail fails to send because the default mailbox has not been configured, Civi provides a link to documentation. The link is out of date.

After
----------------------------------------
The link points to the latest version of the documentation

---

 * [CRM-21284: Outdated link to mail setup documentation](https://issues.civicrm.org/jira/browse/CRM-21284)