### PR TITLE
CRM-21287: Add Financial Type column and filter.

### DIFF
--- a/CRM/Report/Form/Contribute/HouseholdSummary.php
+++ b/CRM/Report/Form/Contribute/HouseholdSummary.php
@@ -138,6 +138,9 @@ class CRM_Report_Form_Contribute_HouseholdSummary extends CRM_Report_Form {
             'required' => TRUE,
             'no_display' => TRUE,
           ),
+          'financial_type_id' => array(
+            'title' => ts('Financial Type'),
+          ),
           'trxn_id' => NULL,
           'receive_date' => array('default' => TRUE),
           'receipt_date' => NULL,
@@ -157,6 +160,11 @@ class CRM_Report_Form_Contribute_HouseholdSummary extends CRM_Report_Form {
             'operatorType' => CRM_Report_Form::OP_MULTISELECT,
             'options' => CRM_Contribute_PseudoConstant::contributionStatus(),
             'default' => array(1),
+          ),
+          'financial_type_id' => array(
+            'title' => ts('Financial Type'),
+            'operatorType' => CRM_Report_Form::OP_MULTISELECT,
+            'options' => CRM_Contribute_PseudoConstant::financialType(),
           ),
         ),
         'grouping' => 'contri-fields',
@@ -523,6 +531,12 @@ class CRM_Report_Form_Contribute_HouseholdSummary extends CRM_Report_Form {
       if (array_key_exists('civicrm_contribution_contribution_status_id', $row)) {
         if ($value = $row['civicrm_contribution_contribution_status_id']) {
           $rows[$rowNum]['civicrm_contribution_contribution_status_id'] = CRM_Contribute_PseudoConstant::contributionStatus($value);
+        }
+      }
+
+      if (array_key_exists('civicrm_contribution_financial_type_id', $row)) {
+        if ($value = $row['civicrm_contribution_financial_type_id']) {
+          $rows[$rowNum]['civicrm_contribution_financial_type_id'] = CRM_Contribute_PseudoConstant::financialType($value);
         }
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
This report shows one contribution per row. This PR adds the option to display the contribution's Financial Type, and to filter by Financial Type.

Before
----------------------------------------
Couldn't do it.

After
----------------------------------------
Now you can.

Technical Details
----------------------------------------
None.

Comments
----------------------------------------
None.

---

 * [CRM-21287: Add Financial Type to "Contributions by Household" report](https://issues.civicrm.org/jira/browse/CRM-21287)