### PR TITLE
Navigation - Fix serialization error

### DIFF
--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -608,7 +608,8 @@ FROM civicrm_navigation WHERE domain_id = $domainID {$whereClause} ORDER BY pare
   public static function resetNavigation($contactID = NULL) {
     $newKey = CRM_Utils_String::createRandom(self::CACHE_KEY_STRLEN, CRM_Utils_String::ALPHANUMERIC);
     if (!$contactID) {
-      $query = "UPDATE civicrm_setting SET value = '$newKey' WHERE name='navigation' AND contact_id IS NOT NULL";
+      $ser = serialize($newKey);
+      $query = "UPDATE civicrm_setting SET value = '$ser' WHERE name='navigation' AND contact_id IS NOT NULL";
       CRM_Core_DAO::executeQuery($query);
       CRM_Core_BAO_Cache::deleteGroup('navigation');
     }


### PR DESCRIPTION
Overview
----------------------------------------
The navigation subsystem stores per-user data in the table
`civicrm_setting`.  Most access to this table goes through
`CRM_Core_BAO_Setting` or `Civi\Core\SettingsBag`.  However, certain
edge-cases produce a warning about a serialization error because
`CRM_Core_BAO_Navigation` does not participate.

Before
----------------------------------------
`CRM_Core_BAO_Navigation::resetNavigation()` generates malformed
records which cannot be read via `CRM_Core_BAO_Setting` or
`Civi\Core\SettingsBag`.

After
----------------------------------------
`CRM_Core_BAO_Navigation::resetNavigation()` generates well-formed
records which can be read via `CRM_Core_BAO_Setting` or
`Civi\Core\SettingsBag`.