### PR TITLE
CRM-21281: Fix potential e-notice

### DIFF
--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -70,8 +70,8 @@ class CRM_Price_BAO_LineItem extends CRM_Price_DAO_LineItem {
     // unset entity table and entity id in $params
     // we never update the entity table and entity id during update mode
     if ($id) {
-      $entity_id = $params['entity_id'];
-      $entity_table = $params['entity_table'];
+      $entity_id = CRM_Utils_Array::value('entity_id', $params);
+      $entity_table = CRM_Utils_Array::value('entity_table', $params);
       unset($params['entity_id'], $params['entity_table']);
     }
     else {


### PR DESCRIPTION
Additional fix for CRM-21281

---

 * [CRM-21281: Post Hook for LineItem does not receive entity_id and entity_table ](https://issues.civicrm.org/jira/browse/CRM-21281)