### PR TITLE
CRM-20903 Order dedupe rules by title not ID

### DIFF
--- a/CRM/Contact/Page/DedupeRules.php
+++ b/CRM/Contact/Page/DedupeRules.php
@@ -132,7 +132,7 @@ class CRM_Contact_Page_DedupeRules extends CRM_Core_Page_Basic {
     // get all rule groups
     $ruleGroups = array();
     $dao = new CRM_Dedupe_DAO_RuleGroup();
-    $dao->orderBy('contact_type ASC, used ASC, id ASC');
+    $dao->orderBy('contact_type ASC, used ASC, title ASC');
     $dao->find();
 
     $dedupeRuleTypes = CRM_Core_SelectValues::getDedupeRuleTypes();


### PR DESCRIPTION
Follow-on from https://github.com/civicrm/civicrm-core/pull/11098

Order rules by their title instead of ID.

@eileenmcnaughton Sorry, minor fix to the thing you just merged.
@highfalutin Thanks for the review

---

 * [CRM-20903: Improve ordering of dedupe rules](https://issues.civicrm.org/jira/browse/CRM-20903)