### PR TITLE
CRM-21289 Implementation

### DIFF
--- a/CRM/Campaign/BAO/Campaign.php
+++ b/CRM/Campaign/BAO/Campaign.php
@@ -72,6 +72,9 @@ class CRM_Campaign_BAO_Campaign extends CRM_Campaign_DAO_Campaign {
 
     $campaign = new CRM_Campaign_DAO_Campaign();
     $campaign->copyValues($params);
+
+    CRM_Utils_Hook::generateIdentifier($campaign->external_identifier, 'campaign_external_identifier', $campaign);
+
     $campaign->save();
 
     if (!empty($params['id'])) {

--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -211,6 +211,9 @@ class CRM_Contact_BAO_Contact extends CRM_Contact_DAO_Contact {
     $employerId = empty($contact->id) ? NULL : CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $contact->id, 'employer_id');
 
     if (!$allNull) {
+      // see if somebody wants to generate/manipulate the external_identifier
+      CRM_Utils_Hook::generateIdentifier($contact->external_identifier, 'contact_external_identifier', $contact);
+
       $contact->save();
 
       CRM_Core_BAO_Log::register($contact->id,

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -150,6 +150,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
       ) {
         if (empty($params['creditnote_id']) || $params['creditnote_id'] == "null") {
           $params['creditnote_id'] = self::createCreditNoteId();
+          CRM_Utils_Hook::generateIdentifier($params['creditnote_id'], 'creditnote_id', $params);
         }
       }
     }
@@ -499,6 +500,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
       ) {
         if (empty($params['creditnote_id']) || $params['creditnote_id'] == "null") {
           $params['creditnote_id'] = self::createCreditNoteId();
+          CRM_Utils_Hook::generateIdentifier($params['creditnote_id'], 'creditnote_id', $params);
         }
       }
     }
@@ -3509,6 +3511,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
         $params['trxnParams']['total_amount'] = -$params['total_amount'];
         if (empty($params['contribution']->creditnote_id) || $params['contribution']->creditnote_id == "null") {
           $creditNoteId = self::createCreditNoteId();
+          CRM_Utils_Hook::generateIdentifier($creditNoteId, 'creditnote_id', $params['contribution']);
           CRM_Core_DAO::setFieldValue('CRM_Contribute_DAO_Contribution', $params['contribution']->id, 'creditnote_id', $creditNoteId);
         }
       }
@@ -3524,6 +3527,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
           $params['trxnParams']['total_amount'] = -$params['total_amount'];
           if (is_null($params['contribution']->creditnote_id) || $params['contribution']->creditnote_id == "null") {
             $creditNoteId = self::createCreditNoteId();
+            CRM_Utils_Hook::generateIdentifier($creditNoteId, 'creditnote_id', $params['contribution']);
             CRM_Core_DAO::setFieldValue('CRM_Contribute_DAO_Contribution', $params['contribution']->id, 'creditnote_id', $creditNoteId);
           }
         }

--- a/CRM/Contribute/Form/Task/Invoice.php
+++ b/CRM/Contribute/Form/Task/Invoice.php
@@ -311,6 +311,7 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
         }
         else {
           $creditNoteId = $contribution->creditnote_id;
+          CRM_Utils_Hook::generateIdentifier($creditNoteId, 'creditnote_id', $contribution);
         }
       }
       $invoiceNumber = CRM_Utils_Array::value('invoice_prefix', $prefixValue) . "" . $contribution->id;

--- a/CRM/Contribute/Form/Task/Invoice.php
+++ b/CRM/Contribute/Form/Task/Invoice.php
@@ -306,6 +306,7 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
       if ($contribution->contribution_status_id == $refundedStatusId || $contribution->contribution_status_id == $cancelledStatusId) {
         if (is_null($contribution->creditnote_id)) {
           $creditNoteId = CRM_Contribute_BAO_Contribution::createCreditNoteId();
+          CRM_Utils_Hook::generateIdentifier($creditNoteId, 'creditnote_id', $contribution);
           CRM_Core_DAO::setFieldValue('CRM_Contribute_DAO_Contribution', $contribution->id, 'creditnote_id', $creditNoteId);
         }
         else {
@@ -313,6 +314,7 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
         }
       }
       $invoiceNumber = CRM_Utils_Array::value('invoice_prefix', $prefixValue) . "" . $contribution->id;
+      CRM_Utils_Hook::generateIdentifier($invoiceNumber, 'invoice_number', $contribution);
 
       //to obtain due date for PDF invoice
       $contributionReceiveDate = date('F j,Y', strtotime(date($input['receive_date'])));

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2387,8 +2387,8 @@ abstract class CRM_Utils_Hook {
    * It has to be ensured, though, that existing ids are preserved.
    * This is a generic
    *
-   * @param String $identifier  the identifier about to be used
-   * @param String $context     currently one of 'invoice_id', 'creditnote_id', 'contact_external_identifier', 'campaign_external_identifier'
+   * @param string $identifier  the identifier about to be used
+   * @param string $context     currently one of 'invoice_id', 'creditnote_id', 'contact_external_identifier', 'campaign_external_identifier'
    * @param Object $object      depends on $context, e.g. Contact BAO, Contribution BAO, Campaign BAO
    * @return mixed
    */

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2383,8 +2383,11 @@ abstract class CRM_Utils_Hook {
   }
 
   /**
-   * TODO
-   * @param String $identifier  blabla
+   * This hook allows overwriting the automatically generated ones.
+   * It has to be ensured, though, that existing ids are preserved.
+   * This is a generic
+   *
+   * @param String $identifier  the identifier about to be used
    * @param String $context     currently one of 'invoice_id', 'creditnote_id', 'contact_external_identifier', 'campaign_external_identifier'
    * @param Object $object      depends on $context, e.g. Contact BAO, Contribution BAO, Campaign BAO
    * @return mixed

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2390,7 +2390,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function generateIdentifier(&$identifier, $context, $object) {
-    return self::singleton()->invoke($identifier, $context, $object, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_generateIdentifier');
+    return self::singleton()->invoke(array('identifier', 'context', 'object'), $identifier, $context, $object, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_generateIdentifier');
   }
 
 }

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2382,4 +2382,15 @@ abstract class CRM_Utils_Hook {
     return self::singleton()->invoke(array('message'), $message, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_inboundSMS');
   }
 
+  /**
+   * TODO
+   * @param String $identifier  blabla
+   * @param String $context     currently one of 'invoice_id', 'creditnote_id', 'contact_external_identifier', 'campaign_external_identifier'
+   * @param Object $object      depends on $context, e.g. Contact BAO, Contribution BAO, Campaign BAO
+   * @return mixed
+   */
+  public static function generateIdentifier(&$identifier, $context, $object) {
+    return self::singleton()->invoke($identifier, $context, $object, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_generateIdentifier');
+  }
+
 }

--- a/tests/phpunit/CRM/Utils/Hook/GenerateIdentifierTest.php
+++ b/tests/phpunit/CRM/Utils/Hook/GenerateIdentifierTest.php
@@ -1,7 +1,9 @@
 <?php
-
 /**
  * Class CRM_Utils_Hook_Generate_Identifier_Test
+ *
+ * Tests the civicrm_generateIdentifier hook (see CRM-21289)
+ *
  * @group headless
  */
 class CRM_Utils_Hook_Generate_Identifier_Test extends CiviUnitTestCase {

--- a/tests/phpunit/CRM/Utils/Hook/GenerateIdentifierTest.php
+++ b/tests/phpunit/CRM/Utils/Hook/GenerateIdentifierTest.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * Class CRM_Utils_Hook_Generate_Identifier_Test
+ * @group headless
+ */
+class CRM_Utils_Hook_Generate_Identifier_Test extends CiviUnitTestCase {
+
+  protected $_last_context = '';
+
+  public function setUp() {
+    $this->_last_context = '';
+    parent::setUp();
+  }
+
+  public function tearDown() {
+    parent::tearDown();
+  }
+
+
+  /**
+   * Verify the generateIdentifier hook for contact's external_identifier
+   */
+  public function testContactExternalIdentifierHook() {
+    $contactA = civicrm_api3('Contact', 'create', array(
+      'first_name'   => 'Captain',
+      'last_name'    => 'Hook',
+      'contact_type' => 'Individual'
+    ));
+    $this->assertAPISuccess($contactA);
+    $contactA = civicrm_api3('Contact', 'getsingle', array('id' => $contactA['id']));
+    $this->assertEquals('', $contactA['external_identifier'], "A new contact should not have an external identifier");
+
+    // now register the hook
+    $this->hookClass->setHook('civicrm_generateIdentifier', array($this, 'hooktest_civicrm_generateIdentifier'));
+
+    // ...and try again
+    $contactB = civicrm_api3('Contact', 'create', array(
+      'first_name'   => 'Jake',
+      'last_name'    => 'Hook',
+      'contact_type' => 'Individual'
+    ));
+    $this->assertAPISuccess($contactB);
+    $contactB = civicrm_api3('Contact', 'getsingle', array('id' => $contactB['id']));
+    $this->assertEquals('HOOKAH', $contactB['external_identifier'], "Hook did not set external_identifier");
+    $this->assertEquals('contact_external_identifier', $this->_last_context, "Hook was not called with the right context");
+
+    $this->hookClass->reset();
+  }
+
+  /**
+   * Verify the generateIdentifier hook for campaign's external_identifier
+   */
+  public function testCampaignExternalIdentifierHook() {
+    $campaignA = civicrm_api3('Campaign', 'create', array(
+      'title' => 'Hooking Up',
+    ));
+    $this->assertNotNull($campaignA);
+    $this->assertAPISuccess($campaignA);
+    $campaignA = civicrm_api3('Campaign', 'getsingle', array('id' => $campaignA['id']));
+    $this->assertEquals('', CRM_Utils_Array::value('external_identifier', $campaignA), "A new campaign should not have an external identifier");
+
+    // now register the hook
+    $this->hookClass->setHook('civicrm_generateIdentifier', array($this, 'hooktest_civicrm_generateIdentifier'));
+
+    // ...and try again
+    $campaignB = civicrm_api3('Campaign', 'create', array(
+      'title' => 'Hookie Day',
+    ));
+    $this->assertAPISuccess($campaignB);
+    $campaignB = civicrm_api3('Campaign', 'getsingle', array('id' => $campaignB['id']));
+    $this->assertEquals('HOOKAH', CRM_Utils_Array::value('external_identifier', $campaignB), "A new campaign should not have an external identifier");
+    $this->assertEquals('campaign_external_identifier', $this->_last_context, "Hook was not called with the right context");
+
+    $this->hookClass->reset();
+  }
+
+  /**
+   * Verify the generateIdentifier hook for contribution's creditnote_id
+   */
+  public function testCreditnoteHook() {
+    // TODO: test create + cancel
+
+    // TODO: test create refunded
+  }
+
+  /**
+   * Verify the generateIdentifier hook for contribution's invoice ID
+   */
+  public function testInvoiceIDHook() {
+    // TODO: create contribution
+
+    // TODO: verify: no invoice id
+
+    // TODO: create invoice
+
+    // TODO: verify: invoice id
+  }
+
+  /**
+   * Helper hook implementation
+   */
+  public function hooktest_civicrm_generateIdentifier(&$identifier, $context, $object) {
+    // store the context for evaluation
+    $this->_last_context = $context;
+
+    // set the identifiert to HOOKAH
+    $identifier = "HOOKAH";
+  }
+}

--- a/tests/phpunit/CRM/Utils/Hook/GenerateIdentifierTest.php
+++ b/tests/phpunit/CRM/Utils/Hook/GenerateIdentifierTest.php
@@ -88,13 +88,30 @@ class CRM_Utils_Hook_Generate_Identifier_Test extends CiviUnitTestCase {
    * Verify the generateIdentifier hook for contribution's invoice ID
    */
   public function testInvoiceIDHook() {
-    // TODO: create contribution
+    $this->hookClass->setHook('civicrm_generateIdentifier', array($this, 'hooktest_civicrm_generateIdentifier'));
 
-    // TODO: verify: no invoice id
+    // create contribution
+    $this->callAPISuccess('Contribution', 'create', array(
+      'total_amount'           => '11.11',
+      'financial_type_id'      => 1,
+      'contact_id'             => 1,
+      'payment_instrument_id'  => 1,
+      'contribution_status_id' => 1,
+      'trxn_id'                => 'HOOKAH'
+    ));
+    $contribution = $this->callAPISuccess('Contribution', 'getsingle', array('trxn_id' => 'HOOKAH'));
 
-    // TODO: create invoice
+    // verify: no invoice number
+    $this->assertEquals('', CRM_Utils_Array::value('invoice_number', $contribution), "A new contribution should not have an invoice ID");
 
-    // TODO: verify: invoice id
+    // create invoice
+    $params = array('forPage' => 1, 'output' => 'pdf_invoice');
+    CRM_Contribute_Form_Task_Invoice::printPDF(array($contribution['id']), $params, array($contribution['contact_id']));
+    $this->assertEquals('invoice_number', $this->_last_context, "Hook was not called with the right context");
+
+    // verify: invoice number
+    $contribution = $this->callAPISuccess('Contribution', 'getsingle', array('trxn_id' => 'HOOKAH', 'return' => 'invoice_number'));
+    $this->assertEquals('HOOKAH', CRM_Utils_Array::value('invoice_number', $contribution), "The invoice number should be ours");
   }
 
   /**
@@ -106,5 +123,12 @@ class CRM_Utils_Hook_Generate_Identifier_Test extends CiviUnitTestCase {
 
     // set the identifiert to HOOKAH
     $identifier = "HOOKAH";
+
+    if ($context == 'invoice_number') {
+      // there is a bug in CiviCRM: the invoice_number doesn't get stored!
+      if (empty($object->invoice_number)) {
+        CRM_Core_DAO::setFieldValue('CRM_Contribute_DAO_Contribution', $object->id, 'invoice_number', $identifier);
+      }
+    }
   }
 }

--- a/tests/phpunit/CRM/Utils/Hook/GenerateIdentifierTest.php
+++ b/tests/phpunit/CRM/Utils/Hook/GenerateIdentifierTest.php
@@ -27,7 +27,7 @@ class CRM_Utils_Hook_Generate_Identifier_Test extends CiviUnitTestCase {
     $contactA = civicrm_api3('Contact', 'create', array(
       'first_name'   => 'Captain',
       'last_name'    => 'Hook',
-      'contact_type' => 'Individual'
+      'contact_type' => 'Individual',
     ));
     $this->assertAPISuccess($contactA);
     $contactA = civicrm_api3('Contact', 'getsingle', array('id' => $contactA['id']));
@@ -40,7 +40,7 @@ class CRM_Utils_Hook_Generate_Identifier_Test extends CiviUnitTestCase {
     $contactB = civicrm_api3('Contact', 'create', array(
       'first_name'   => 'Jake',
       'last_name'    => 'Hook',
-      'contact_type' => 'Individual'
+      'contact_type' => 'Individual',
     ));
     $this->assertAPISuccess($contactB);
     $contactB = civicrm_api3('Contact', 'getsingle', array('id' => $contactB['id']));
@@ -90,7 +90,7 @@ class CRM_Utils_Hook_Generate_Identifier_Test extends CiviUnitTestCase {
       'contact_id'             => 1,
       'payment_instrument_id'  => 1,
       'contribution_status_id' => 1,
-      'trxn_id'                => 'HOOKAH2'
+      'trxn_id'                => 'HOOKAH2',
     ));
     // reload
     $contribution = $this->callAPISuccess('Contribution', 'getsingle', array('trxn_id' => 'HOOKAH2', 'return' => 'creditnote_id'));
@@ -123,7 +123,7 @@ class CRM_Utils_Hook_Generate_Identifier_Test extends CiviUnitTestCase {
       'contact_id'             => 1,
       'payment_instrument_id'  => 1,
       'contribution_status_id' => 1,
-      'trxn_id'                => 'HOOKAH'
+      'trxn_id'                => 'HOOKAH',
     ));
     $contribution = $this->callAPISuccess('Contribution', 'getsingle', array('trxn_id' => 'HOOKAH', 'return' => 'invoice_number'));
 
@@ -139,8 +139,6 @@ class CRM_Utils_Hook_Generate_Identifier_Test extends CiviUnitTestCase {
     $contribution = $this->callAPISuccess('Contribution', 'getsingle', array('trxn_id' => 'HOOKAH', 'return' => 'invoice_number'));
     $this->assertEquals('HOOKAH', CRM_Utils_Array::value('invoice_number', $contribution), "The invoice number should be ours");
   }
-
-
 
 
   /**
@@ -160,4 +158,5 @@ class CRM_Utils_Hook_Generate_Identifier_Test extends CiviUnitTestCase {
       }
     }
   }
+
 }

--- a/tests/phpunit/CRM/Utils/Hook/GenerateIdentifierTest.php
+++ b/tests/phpunit/CRM/Utils/Hook/GenerateIdentifierTest.php
@@ -111,7 +111,7 @@ class CRM_Utils_Hook_Generate_Identifier_Test extends CiviUnitTestCase {
   }
 
   /**
-   * Verify the generateIdentifier hook for contribution's invoice ID
+   * Verify the generateIdentifier hook for contribution's invoice number
    */
   public function testInvoiceIDHook() {
     $this->hookClass->setHook('civicrm_generateIdentifier', array($this, 'hooktest_civicrm_generateIdentifier'));
@@ -128,7 +128,7 @@ class CRM_Utils_Hook_Generate_Identifier_Test extends CiviUnitTestCase {
     $contribution = $this->callAPISuccess('Contribution', 'getsingle', array('trxn_id' => 'HOOKAH', 'return' => 'invoice_number'));
 
     // verify: no invoice number
-    $this->assertEquals('', CRM_Utils_Array::value('invoice_number', $contribution), "A new contribution should not have an invoice ID");
+    $this->assertEquals('', CRM_Utils_Array::value('invoice_number', $contribution), "A new contribution should not have an invoice number");
 
     // create invoice
     $params = array('forPage' => 1, 'output' => 'pdf_invoice');


### PR DESCRIPTION
Overview
----------------------------------------
This PR implements the new hook outlined in [CRM-21289](https://issues.civicrm.org/jira/browse/CRM-21289), along with some unit tests. We'll create a PR to the documentation as soon as this is accepted.

Before
----------------------------------------
Hook doesn't exist.

After
----------------------------------------
Hook does exist :)

Technical Details
----------------------------------------
The hook can be used to create any custom generated ID (i.e. non DB related). We also plan to use it with extensions (e.g. mandate references in CiviSEPA). Currently it has four applications:
 * ``invoice_number`` in CiviContribute
 * ``creditnote_id`` in CiviContribute
 * ``external_identfier`` for contacts
 * ``external_identfier`` for campaigns


Comments
----------------------------------------
One of the main triggers for the creation of this hook was the incomplete implementation of invoice ids (always equals the contribution id), which violates several requirements for invoicing - at least in Germany and Belgium.