### PR TITLE
CRM-21285 Buildkit Installs failing for WordPress

### DIFF
--- a/Civi/Core/Paths.php
+++ b/Civi/Core/Paths.php
@@ -57,7 +57,7 @@ class Paths {
         return \CRM_Core_Config::singleton()->userSystem->getDefaultFileStorage();
       })
       ->register('wp.frontend.base', function () {
-        return array('url' => CIVICRM_UF_BASEURL . '/');
+        return array('url' => rtrim(CIVICRM_UF_BASEURL, '/') . '/');
       })
       ->register('wp.frontend', function () use ($paths) {
         $config = \CRM_Core_Config::singleton();
@@ -67,7 +67,7 @@ class Paths {
         );
       })
       ->register('wp.backend.base', function () {
-        return array('url' => CIVICRM_UF_BASEURL . '/wp-admin/');
+        return array('url' => rtrim(CIVICRM_UF_BASEURL, '/') . '/wp-admin/');
       })
       ->register('wp.backend', function () use ($paths) {
         return array(


### PR DESCRIPTION
As detailed here: https://github.com/civicrm/civicrm-core/pull/11105#pullrequestreview-68388364

We can cover both cases of CIVICRM_UF_BASEURL with this patch.

---

 * [CRM-21285: Buildkit Installs failing for WordPress](https://issues.civicrm.org/jira/browse/CRM-21285)