### PR TITLE
CRM-21297 - Automatically fill database details in Drupal installer

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -1708,12 +1708,13 @@ class Installer extends InstallRequirements {
         $output .= "<li>" . ts("Use the <a %1>Configuration Checklist</a> to review and configure settings for your new site", array(1 => "target='_blank' href='$cmsURL'")) . "</li>";
         $output .= $commonOutputMessage;
 
-        echo '</ul>';
-        echo '</div>';
+        $output .= '</ul>';
+        $output .= '</div>';
+        echo $output;
 
         $c = CRM_Core_Config::singleton(FALSE);
         $c->free();
-        $wpInstallRedirect = admin_url("?page=CiviCRM&q=civicrm&reset=1");
+        $wpInstallRedirect = admin_url('admin.php?page=CiviCRM&q=civicrm&reset=1');
         echo "<script>
          window.location = '$wpInstallRedirect';
         </script>";

--- a/install/index.php
+++ b/install/index.php
@@ -267,6 +267,9 @@ if ($installType == 'drupal') {
     }
   }
 
+  // Bootstrap Drupal to get settings
+  drupal_bootstrap(DRUPAL_BOOTSTRAP_CONFIGURATION);
+
   if (!defined('VERSION') or version_compare(VERSION, '6.0') < 0) {
     $errorTitle = ts("Oops! Incorrect Drupal version");
     $errorMsg = ts("This version of CiviCRM can only be used with Drupal 6.x or 7.x. Please ensure that '%1' exists if you are running Drupal 7.0 and over.", array(1 => implode("' or '", $drupalVersionFiles)));
@@ -345,10 +348,10 @@ if ($installType == 'drupal') {
     }
     else {
         $drupalConfig = array(
-            "server" => "localhost",
-            "username" => "drupal",
-            "password" => "",
-            "database" => "drupal",
+            "server" => $databases['default']['default']['host'],
+            "username" => $databases['default']['default']['username'],
+            "password" => $databases['default']['default']['password'],
+            "database" => $databases['default']['default']['database'],
         );
     }
 }

--- a/install/index.php
+++ b/install/index.php
@@ -318,12 +318,12 @@ if (isset($_POST['mysql'])) {
   $databaseConfig = $_POST['mysql'];
 }
 else {
-  $databaseConfig = [
+  $databaseConfig = array(
     "server" => "localhost",
     "username" => "civicrm",
     "password" => "",
     "database" => "civicrm",
-  ];
+  );
 }
 
 if ($installType == 'wordpress') {
@@ -332,12 +332,12 @@ if ($installType == 'wordpress') {
     $databaseConfig = $_POST['mysql'];
   }
   else {
-    $databaseConfig = [
+    $databaseConfig = array(
       "server" => DB_HOST,
       "username" => DB_USER,
       "password" => DB_PASSWORD,
       "database" => DB_NAME,
-    ];
+    );
   }
 }
 
@@ -347,12 +347,12 @@ if ($installType == 'drupal') {
     $drupalConfig = $_POST['drupal'];
   }
   else {
-    $drupalConfig = [
+    $drupalConfig = array(
       "server" => $databases['default']['default']['host'],
       "username" => $databases['default']['default']['username'],
       "password" => $databases['default']['default']['password'],
       "database" => $databases['default']['default']['database'],
-    ];
+    );
   }
 }
 
@@ -362,12 +362,12 @@ if ($installType == 'backdrop') {
     $backdropConfig = $_POST['backdrop'];
   }
   else {
-    $backdropConfig = [
+    $backdropConfig = array(
       "server" => "localhost",
       "username" => "backdrop",
       "password" => "",
       "database" => "backdrop",
-    ];
+    );
   }
 }
 

--- a/install/index.php
+++ b/install/index.php
@@ -257,8 +257,20 @@ if ($installType == 'drupal') {
     }
   }
 
-  // Bootstrap Drupal to get settings
-  drupal_bootstrap(DRUPAL_BOOTSTRAP_CONFIGURATION);
+  // Bootstrap Drupal to get settings and user
+  $base_root = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') ? 'https' : 'http';
+  $base_root .= '://' . $_SERVER['HTTP_HOST'];
+  $base_url = $base_root;
+  drupal_bootstrap(DRUPAL_BOOTSTRAP_FULL);
+
+  // Check that user is logged in and has administrative permissions
+  // This is necessary because the script exposes the database settings in the form and these could be viewed by unauthorised users
+  if ((!function_exists('user_access')) || (!user_access('administer site configuration'))) {
+    $errorTitle = ts("You don't have permission to access this page");
+    $errorMsg = ts("The installer can only be run by a user with the permission to administer site configuration.");
+    errorDisplayPage($errorTitle, $errorMsg);
+    exit();
+  }
 
   if (!defined('VERSION') or version_compare(VERSION, '6.0') < 0) {
     $errorTitle = ts("Oops! Incorrect Drupal version");

--- a/install/index.php
+++ b/install/index.php
@@ -313,17 +313,9 @@ elseif ($installType == 'wordpress') {
   }
 }
 
-// Load civicrm database config
+// Load CiviCRM database config
 if (isset($_POST['mysql'])) {
   $databaseConfig = $_POST['mysql'];
-}
-else {
-  $databaseConfig = array(
-    "server" => "localhost",
-    "username" => "civicrm",
-    "password" => "",
-    "database" => "civicrm",
-  );
 }
 
 if ($installType == 'wordpress') {
@@ -368,6 +360,16 @@ if ($installType == 'backdrop') {
       "password" => "",
       "database" => "backdrop",
     );
+  }
+}
+
+// By default set CiviCRM database to be same as CMS database
+if (!isset($databaseConfig)) {
+  if (($installType == 'drupal') && (isset($drupalConfig))) {
+    $databaseConfig = $drupalConfig;
+  }
+  if (($installType == 'backdrop') && (isset($backdropConfig))) {
+    $databaseConfig = $backdropConfig;
   }
 }
 

--- a/install/index.php
+++ b/install/index.php
@@ -339,8 +339,12 @@ if ($installType == 'drupal') {
     $drupalConfig = $_POST['drupal'];
   }
   else {
+    $dbServer = $databases['default']['default']['host'];
+    if (!empty($databases['default']['default']['port'])) {
+      $dbServer .= ':' . $databases['default']['default']['port'];
+    }
     $drupalConfig = array(
-      "server" => $databases['default']['default']['host'] . ':' . $databases['default']['default']['port'],
+      "server" => $dbServer,
       "username" => $databases['default']['default']['username'],
       "password" => $databases['default']['default']['password'],
       "database" => $databases['default']['default']['database'],

--- a/install/index.php
+++ b/install/index.php
@@ -104,64 +104,6 @@ $pkgPath = $crmPath . DIRECTORY_SEPARATOR . 'packages';
 require_once $crmPath . '/CRM/Core/ClassLoader.php';
 CRM_Core_ClassLoader::singleton()->register();
 
-// Load civicrm database config
-if (isset($_POST['mysql'])) {
-  $databaseConfig = $_POST['mysql'];
-}
-else {
-  $databaseConfig = array(
-    "server"   => "localhost",
-    "username" => "civicrm",
-    "password" => "",
-    "database" => "civicrm",
-  );
-}
-
-if ($installType == 'wordpress') {
-  // Load WP database config
-  if (isset($_POST['mysql'])) {
-    $databaseConfig = $_POST['mysql'];
-  }
-  else {
-    $databaseConfig = array(
-      "server"   => DB_HOST,
-      "username" => DB_USER,
-      "password" => DB_PASSWORD,
-      "database" => DB_NAME,
-    );
-  }
-}
-
-if ($installType == 'drupal') {
-  // Load drupal database config
-  if (isset($_POST['drupal'])) {
-    $drupalConfig = $_POST['drupal'];
-  }
-  else {
-    $drupalConfig = array(
-      "server" => "localhost",
-      "username" => "drupal",
-      "password" => "",
-      "database" => "drupal",
-    );
-  }
-}
-
-if ($installType == 'backdrop') {
-  // Load backdrop database config
-  if (isset($_POST['backdrop'])) {
-    $backdropConfig = $_POST['backdrop'];
-  }
-  else {
-    $backdropConfig = array(
-      "server" => "localhost",
-      "username" => "backdrop",
-      "password" => "",
-      "database" => "backdrop",
-    );
-  }
-}
-
 $loadGenerated = 0;
 if (isset($_POST['loadGenerated'])) {
   $loadGenerated = 1;
@@ -366,6 +308,64 @@ elseif ($installType == 'wordpress') {
     $errorMsg = ts("This installer can only be used for the WordPress version of CiviCRM.");
     errorDisplayPage($errorTitle, $errorMsg);
   }
+}
+
+// Load civicrm database config
+if (isset($_POST['mysql'])) {
+    $databaseConfig = $_POST['mysql'];
+}
+else {
+    $databaseConfig = array(
+        "server"   => "localhost",
+        "username" => "civicrm",
+        "password" => "",
+        "database" => "civicrm",
+    );
+}
+
+if ($installType == 'wordpress') {
+    // Load WP database config
+    if (isset($_POST['mysql'])) {
+        $databaseConfig = $_POST['mysql'];
+    }
+    else {
+        $databaseConfig = array(
+            "server"   => DB_HOST,
+            "username" => DB_USER,
+            "password" => DB_PASSWORD,
+            "database" => DB_NAME,
+        );
+    }
+}
+
+if ($installType == 'drupal') {
+    // Load drupal database config
+    if (isset($_POST['drupal'])) {
+        $drupalConfig = $_POST['drupal'];
+    }
+    else {
+        $drupalConfig = array(
+            "server" => "localhost",
+            "username" => "drupal",
+            "password" => "",
+            "database" => "drupal",
+        );
+    }
+}
+
+if ($installType == 'backdrop') {
+    // Load backdrop database config
+    if (isset($_POST['backdrop'])) {
+        $backdropConfig = $_POST['backdrop'];
+    }
+    else {
+        $backdropConfig = array(
+            "server" => "localhost",
+            "username" => "backdrop",
+            "password" => "",
+            "database" => "backdrop",
+        );
+    }
 }
 
 // Check requirements

--- a/install/index.php
+++ b/install/index.php
@@ -315,60 +315,60 @@ elseif ($installType == 'wordpress') {
 
 // Load civicrm database config
 if (isset($_POST['mysql'])) {
-    $databaseConfig = $_POST['mysql'];
+  $databaseConfig = $_POST['mysql'];
 }
 else {
-    $databaseConfig = array(
-        "server"   => "localhost",
-        "username" => "civicrm",
-        "password" => "",
-        "database" => "civicrm",
-    );
+  $databaseConfig = [
+    "server" => "localhost",
+    "username" => "civicrm",
+    "password" => "",
+    "database" => "civicrm",
+  ];
 }
 
 if ($installType == 'wordpress') {
-    // Load WP database config
-    if (isset($_POST['mysql'])) {
-        $databaseConfig = $_POST['mysql'];
-    }
-    else {
-        $databaseConfig = array(
-            "server"   => DB_HOST,
-            "username" => DB_USER,
-            "password" => DB_PASSWORD,
-            "database" => DB_NAME,
-        );
-    }
+  // Load WP database config
+  if (isset($_POST['mysql'])) {
+    $databaseConfig = $_POST['mysql'];
+  }
+  else {
+    $databaseConfig = [
+      "server" => DB_HOST,
+      "username" => DB_USER,
+      "password" => DB_PASSWORD,
+      "database" => DB_NAME,
+    ];
+  }
 }
 
 if ($installType == 'drupal') {
-    // Load drupal database config
-    if (isset($_POST['drupal'])) {
-        $drupalConfig = $_POST['drupal'];
-    }
-    else {
-        $drupalConfig = array(
-            "server" => $databases['default']['default']['host'],
-            "username" => $databases['default']['default']['username'],
-            "password" => $databases['default']['default']['password'],
-            "database" => $databases['default']['default']['database'],
-        );
-    }
+  // Load drupal database config
+  if (isset($_POST['drupal'])) {
+    $drupalConfig = $_POST['drupal'];
+  }
+  else {
+    $drupalConfig = [
+      "server" => $databases['default']['default']['host'],
+      "username" => $databases['default']['default']['username'],
+      "password" => $databases['default']['default']['password'],
+      "database" => $databases['default']['default']['database'],
+    ];
+  }
 }
 
 if ($installType == 'backdrop') {
-    // Load backdrop database config
-    if (isset($_POST['backdrop'])) {
-        $backdropConfig = $_POST['backdrop'];
-    }
-    else {
-        $backdropConfig = array(
-            "server" => "localhost",
-            "username" => "backdrop",
-            "password" => "",
-            "database" => "backdrop",
-        );
-    }
+  // Load backdrop database config
+  if (isset($_POST['backdrop'])) {
+    $backdropConfig = $_POST['backdrop'];
+  }
+  else {
+    $backdropConfig = [
+      "server" => "localhost",
+      "username" => "backdrop",
+      "password" => "",
+      "database" => "backdrop",
+    ];
+  }
 }
 
 // Check requirements

--- a/install/index.php
+++ b/install/index.php
@@ -54,35 +54,25 @@ else {
   define('CIVICRM_WINDOWS', 0);
 }
 
-// set installation type - drupal
-if (!session_id()) {
-  if (defined('PANTHEON_ENVIRONMENT')) {
-    ini_set('session.save_handler', 'files');
-  }
-  session_start();
-}
-
-// unset civicrm session if any
-if (array_key_exists('CiviCRM', $_SESSION)) {
-  unset($_SESSION['CiviCRM']);
-}
-
-if (isset($_GET['civicrm_install_type'])) {
-  $_SESSION['civicrm_install_type'] = $_GET['civicrm_install_type'];
-}
-else {
-  if (!isset($_SESSION['civicrm_install_type'])) {
-    $_SESSION['civicrm_install_type'] = "drupal";
-  }
-}
-
 global $installType;
 global $crmPath;
 global $pkgPath;
 global $installDirPath;
 global $installURLPath;
 
-$installType = strtolower($_SESSION['civicrm_install_type']);
+// Set the install type
+// this is sent as a query string when the page is first loaded
+// and subsequently posted to the page as a hidden field
+if (isset($_POST['civicrm_install_type'])) {
+  $installType = $_POST['civicrm_install_type'];
+}
+elseif (isset($_GET['civicrm_install_type'])) {
+  $installType = strtolower($_GET['civicrm_install_type']);
+}
+else {
+  // default value if not set
+  $installType = "drupal";
+}
 
 if ($installType == 'drupal' || $installType == 'backdrop') {
   $crmPath = dirname(dirname($_SERVER['SCRIPT_FILENAME']));

--- a/install/index.php
+++ b/install/index.php
@@ -348,7 +348,7 @@ if ($installType == 'drupal') {
   }
   else {
     $drupalConfig = array(
-      "server" => $databases['default']['default']['host'],
+      "server" => $databases['default']['default']['host'] . ':' . $databases['default']['default']['port'],
       "username" => $databases['default']['default']['username'],
       "password" => $databases['default']['default']['password'],
       "database" => $databases['default']['default']['database'],

--- a/install/template.html
+++ b/install/template.html
@@ -22,6 +22,8 @@ if ($text_direction == 'rtl') {
 
 <form name="civicrm_form" method="post" action="<?php echo str_replace( '%7E', '~', $_SERVER['REQUEST_URI']); ?>">
 
+  <input type="hidden" name="civicrm_install_type" value="<?php echo $installType; ?>" />
+
 <?php if (isset($hasErrorOtherThanDatabase)) { ?>
   <p class="error"><?php echo ts('We are not able to install the software. Please <a href="#requirements">see below</a> for details.'); ?></p>
 <?php } else { ?>


### PR DESCRIPTION
Overview
----------------------------------------
The installer should obtain the database settings and populate these fields in the installer when installing on Drupal.

Before
----------------------------------------
The installer for WordPress automatically completes the database settings.  This isn't currently the case for Drupal.

After
----------------------------------------
 * The database fields in the installer are automatically populated.
 * The installer requires that the user be logged in as a Drupal administrator (`administer site configuration`).

---

 * [CRM-21297: Automatically fill database details in installer for Drupal](https://issues.civicrm.org/jira/browse/CRM-21297)