### PR TITLE
Added trait to support Codeception tests

### DIFF
--- a/Civi/Codeception/CiviAcceptanceTesterTrait.php
+++ b/Civi/Codeception/CiviAcceptanceTesterTrait.php
@@ -21,7 +21,7 @@ trait CiviAcceptanceTesterTrait {
     else {
       $newPage = \CRM_Utils_System::url($params[0], $params[1], FALSE, NULL, FALSE);
     }
-    $this->amOnPage($newPage);
+    return $this->amOnPage($newPage);
   }
 
   /**
@@ -66,7 +66,7 @@ trait CiviAcceptanceTesterTrait {
    *   CiviCRM password for the login
    */
   public function loginToJoomla($username, $password) {
-    throw new CRM_Core_Exception("loginToJoomla is not implemented yet. Implement a corrosponding login function.");
+    throw new CRM_Core_Exception("loginToJoomla is not implemented yet. Implement a corresponding login function.");
   }
 
   /**
@@ -77,7 +77,7 @@ trait CiviAcceptanceTesterTrait {
    *   CiviCRM password for the login
    */
   public function loginToWordpress($username, $password) {
-    throw new CRM_Core_Exception("loginToWordpress is not implemented yet. Implement a corrosponding login function.");
+    throw new CRM_Core_Exception("loginToWordpress is not implemented yet. Implement a corresponding login function.");
   }
 
   /**
@@ -88,7 +88,7 @@ trait CiviAcceptanceTesterTrait {
    *   CiviCRM password for the login
    */
   public function loginToBackdrop($username, $password) {
-    throw new CRM_Core_Exception("loginToBackdrop is not implemented yet. Implement a corrosponding login function.");
+    throw new CRM_Core_Exception("loginToBackdrop is not implemented yet. Implement a corresponding login function.");
   }
 
   /**

--- a/Civi/Codeception/CiviAcceptanceTesterTrait.php
+++ b/Civi/Codeception/CiviAcceptanceTesterTrait.php
@@ -1,0 +1,110 @@
+<?php
+namespace Civi\Codeception;
+
+/**
+ * Trait CiviAcceptanceTesterTrait
+ * Trait for common functions used for Codeception Testing framework
+ * @package Civi\Codeception
+ */
+trait CiviAcceptanceTesterTrait {
+
+  /**
+   * Parse Parameters, and create generic Civi URL
+   * @param $page
+   *   The path and parameters of a CiviCRM page. Ex: "civicrm/dashboard?reset=1".
+   */
+  public function amOnRoute($page) {
+    $params = explode('?', $page);
+    if (empty($params[1])) {
+      $newPage = \CRM_Utils_System::url($page, NULL, FALSE, NULL, FALSE);
+    }
+    else {
+      $newPage = \CRM_Utils_System::url($params[0], $params[1], FALSE, NULL, FALSE);
+    }
+    $this->amOnPage($newPage);
+  }
+
+  /**
+   * Dispatcher for login to supported plattforms
+   * @param $username
+   *   CiviCRM username for the login
+   * @param $password
+   *   CiviCRM password for the login
+   */
+  public function login($username, $password) {
+    $config = \CRM_Core_Config::singleton();
+    $handler = array($this, 'loginTo' . $config->userFramework);
+    if (is_callable($handler)) {
+      call_user_func($handler, $username, $password);
+    }
+    else {
+      throw new CRM_Core_Exception("Framework {$config->userFramework} is not supported. Implement loginTo{$config->userFramework}.");
+    }
+  }
+
+  /**
+   * Login to Drupal
+   * @param $username
+   *   CiviCRM username for the login
+   * @param $password
+   *   CiviCRM password for the login
+   */
+  public function loginToDrupal($username, $password) {
+    $I = $this;
+    $I->amOnPage('/user');
+    $I->fillField("#edit-name", $username);
+    $I->fillField("#edit-pass", $password);
+    $I->click("#edit-submit");
+    $I->see("CiviCRM Home");
+  }
+
+  /**
+   * Login to Joomla
+   * @param $username
+   *   CiviCRM username for the login
+   * @param $password
+   *   CiviCRM password for the login
+   */
+  public function loginToJoomla($username, $password) {
+    throw new CRM_Core_Exception("loginToJoomla is not implemented yet. Implement a corrosponding login function.");
+  }
+
+  /**
+   * Login to Wordpress
+   * @param $username
+   *   CiviCRM username for the login
+   * @param $password
+   *   CiviCRM password for the login
+   */
+  public function loginToWordpress($username, $password) {
+    throw new CRM_Core_Exception("loginToWordpress is not implemented yet. Implement a corrosponding login function.");
+  }
+
+  /**
+   * Login to Backdrop
+   * @param $username
+   *   CiviCRM username for the login
+   * @param $password
+   *   CiviCRM password for the login
+   */
+  public function loginToBackdrop($username, $password) {
+    throw new CRM_Core_Exception("loginToBackdrop is not implemented yet. Implement a corrosponding login function.");
+  }
+
+  /**
+   * Login as Admin User
+   */
+  public function loginAsAdmin() {
+    global $_CV;
+    $this->login($_CV['ADMIN_USER'], $_CV['ADMIN_PASS']);
+  }
+
+  /**
+   * Login as Demo User
+   */
+  public function loginAsDemo() {
+    global $_CV;
+    $this->login($_CV['DEMO_USER'], $_CV['DEMO_PASS']);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
[Codeception](http://codeception.com/) is a PHP-based testing framework. The upshot of this particular tool is its breadth -- the test-runner/code-generator/documentation present three levels of testing (e2e/acceptance, functional/integration, and unit).

However, it does not have any built-in support for interacting with a CiviCRM installation, and it would be redundant for many extension authors to write their own Codeception helper integration functions. This patch defines a utility class which can be incorporated into other downstream tests.

We (Philipp B, Michael D, and Tim O) initiated this project at the sprint in Devon with the aim of supporting end-to-end extension testing. 

Before
----------------------------------------
No Codeception traits available

After
----------------------------------------
Codeception tests for extensions can now interact with CiviCRM if they use this trait. 

Technical Details
----------------------------------------

* Codeception's acceptance tests often use the helper `$I->amOnPage(...)`. However, the URL differences of Drupal/Backdrop/Joomla/WordPress make this difficult to use. The trait adds a similar function `$I->amOnRoute(...)`.
* The trait provides a CMS-independent login interface: `$I->login($user,$pass)`, `$I->loginAsAdmin()`, `$I->loginAsDemo()`.
* The main `login($user,$pass)` function needs to be adapted for different CMS's. This is implemented for D7, and it has placeholders for other CMSs.
* There's a parallel [update for `civix`](https://github.com/totten/civix/pull/111) to initialize an extension's Codeception configuration. It supports booting Civi and loading the `CiviAcceptanceTesterTrait` 


Comments
----------------------------------------
