### PR TITLE
CRM-21294 js error when selecting & unselecting merge contacts

### DIFF
--- a/templates/CRM/Contact/Page/DedupeFind.tpl
+++ b/templates/CRM/Contact/Page/DedupeFind.tpl
@@ -334,8 +334,10 @@
     else {
       var id = [];
       CRM.$(element).each(function() {
-        var sth = CRM.$('input.crm-dedupe-select', this);
-        id.push(CRM.$(sth).prop('name').substr(5));
+        var pnName = CRM.$('input.crm-dedupe-select', this).prop('name');
+        if (pnName !== undefined) {
+          id.push(pnName.substr(5));
+        }
       });
       var is_selected = CRM.$('.crm-dedupe-select-all').prop('checked') ? 1 : 0;
     }


### PR DESCRIPTION
Overview
----------------------------------------
Adds conditional on find dedupe results screen to avoid a js error

Before
----------------------------------------
If you load a find duplicates screen & select a contact and then click to select all you get a js error. It might be hidden but the outcome of the query SELECT count(*) FROM civicrm_prevnext_cache WHERE is_selected=1 stops being correct

After
----------------------------------------
Error is dead. Long live the error

Technical Details
----------------------------------------
For some reason the selector starts to find an additional element with a bit of clickery. The element has no name & hence when the iteration handles it's name property an error arises.

---

 * [CRM-21294: js error when selecting & unselecting merge contacts](https://issues.civicrm.org/jira/browse/CRM-21294)