### PR TITLE
CRM-21301 fix conflicts screen redirect to reflect 'selected' option.

### DIFF
--- a/CRM/Contact/Page/DedupeFind.php
+++ b/CRM/Contact/Page/DedupeFind.php
@@ -63,6 +63,8 @@ class CRM_Contact_Page_DedupeFind extends CRM_Core_Page_Basic {
     $limit = CRM_Utils_Request::retrieve('limit', 'Integer', $this);
     $rgid = CRM_Utils_Request::retrieve('rgid', 'Positive', $this);
     $cid = CRM_Utils_Request::retrieve('cid', 'Positive', $this, FALSE, 0);
+    $isSelected = CRM_Utils_Request::retrieve('selected', 'Int', $this, FALSE, 0);
+
     // Using a placeholder for criteria as it is intended to be able to pass this later.
     $criteria = array();
     $isConflictMode = ($context == 'conflicts');
@@ -138,10 +140,9 @@ class CRM_Contact_Page_DedupeFind extends CRM_Core_Page_Basic {
       $this->action = CRM_Core_Action::UPDATE;
 
       $urlQry['snippet'] = 4;
-      if ($isConflictMode) {
-        $urlQry['selected'] = 1;
+      if ($isSelected) {
+        $urlQry['selected'] = $isSelected;
       }
-
       $this->assign('sourceUrl', CRM_Utils_System::url('civicrm/ajax/dedupefind', $urlQry, FALSE, NULL, FALSE));
 
       //reload from cache table
@@ -180,6 +181,9 @@ class CRM_Contact_Page_DedupeFind extends CRM_Core_Page_Basic {
           ));
         }
         else {
+          if ($isSelected == 1) {
+            $urlQry['selected'] = 1;
+          }
           CRM_Core_Session::singleton()->pushUserContext(CRM_Utils_System::url('civicrm/contact/dedupefind',
             $urlQry
           ));

--- a/CRM/Contact/Page/DedupeMerge.php
+++ b/CRM/Contact/Page/DedupeMerge.php
@@ -55,15 +55,25 @@ class CRM_Contact_Page_DedupeMerge extends CRM_Core_Page {
    * Build a queue of tasks by dividing dupe pairs in batches.
    */
   public static function getRunner() {
+    $null = NULL;
     $rgid = CRM_Utils_Request::retrieve('rgid', 'Positive');
     $gid  = CRM_Utils_Request::retrieve('gid', 'Positive');
     $limit  = CRM_Utils_Request::retrieve('limit', 'Positive');
     $action = CRM_Utils_Request::retrieve('action', 'String');
-    $mode   = CRM_Utils_Request::retrieve('mode', 'String', CRM_Core_DAO::$_nullObject, FALSE, 'safe');
+    $mode   = CRM_Utils_Request::retrieve('mode', 'String', $null, FALSE, 'safe');
 
-    $cacheKeyString = CRM_Dedupe_Merger::getMergeCacheKeyString($rgid, $gid);
+    // Using a placeholder for criteria as it is intended to be able to pass this later.
+    $criteria = array();
 
-    $urlQry = "reset=1&action=update&rgid={$rgid}&gid={$gid}&limit={$limit}";
+    $cacheKeyString = CRM_Dedupe_Merger::getMergeCacheKeyString($rgid, $gid, $criteria);
+
+    $urlQry = array(
+      'reset' => 1,
+      'action' => 'update',
+      'rgid' => $rgid,
+      'gid' => $gid,
+      'limit' => $limit,
+    );
 
     if ($mode == 'aggressive' && !CRM_Core_Permission::check('force merge duplicate contacts')) {
       CRM_Core_Session::setStatus(ts('You do not have permission to force merge duplicate contact records'), ts('Permission Denied'), 'error');
@@ -79,11 +89,7 @@ class CRM_Contact_Page_DedupeMerge extends CRM_Core_Page {
     $where = NULL;
     if ($action == CRM_Core_Action::MAP) {
       $where = "pn.is_selected = 1";
-      $isSelected = 1;
-    }
-    else {
-      // else merge all (2)
-      $isSelected = 2;
+      $urlQry['selected'] = 1;
     }
 
     $total  = CRM_Core_BAO_PrevNextCache::getCount($cacheKeyString, NULL, $where);
@@ -98,7 +104,7 @@ class CRM_Contact_Page_DedupeMerge extends CRM_Core_Page {
     for ($i = 1; $i <= ceil($total / self::BATCHLIMIT); $i++) {
       $task  = new CRM_Queue_Task(
         array('CRM_Contact_Page_DedupeMerge', 'callBatchMerge'),
-        array($rgid, $gid, $mode, self::BATCHLIMIT, $isSelected),
+        array($rgid, $gid, $mode, self::BATCHLIMIT, CRM_Utils_Array::value('selected', $urlQry)),
         "Processed " . $i * self::BATCHLIMIT . " pair of duplicates out of " . $total
       );
 
@@ -107,7 +113,7 @@ class CRM_Contact_Page_DedupeMerge extends CRM_Core_Page {
     }
 
     // Setup the Runner
-    $urlQry .= "&context=conflicts";
+    $urlQry['context'] = "conflicts";
     $runner = new CRM_Queue_Runner(array(
       'title'     => ts('Merging Duplicates..'),
       'queue'     => $queue,


### PR DESCRIPTION
When doing a batch merge you can either merge 'selected' or 'all' - on the latter the screen you redirect to
should not be limited to 25 selected contacts

Overview
----------------------------------------
If you select some contacts & then choose to batch dedupe all contacts then all contacts are merged but at the end you are passed to a screen with only those selected displayed. Since you didn't choose to action the selection this is confusing

Before
----------------------------------------
Redirect enforces only displaying selected on conflict screen

After
----------------------------------------
Redirect respects whether you chose to merge all or only selected

Technical Details
----------------------------------------
_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_

Comments
----------------------------------------
In the retrieval queries $selected=0 or $selected=1 will be appended to the query. Anything else is not. The underlying code used 2 as  a default to refer to 'not specified' but respects NULL which I think is more logical so I think we should start migrating to that

---

 * [CRM-21301: When doing a batch merge from find contacts the batch merge screen implements 'is_selected' erroneously](https://issues.civicrm.org/jira/browse/CRM-21301)