### PR TITLE
CRM-21303 fix:dedupe conflicts screen, not all rows visible

### DIFF
--- a/CRM/Core/BAO/PrevNextCache.php
+++ b/CRM/Core/BAO/PrevNextCache.php
@@ -366,11 +366,16 @@ WHERE (pn.cacheKey $op %1 OR pn.cacheKey $op %2)
    * @param bool $checkPermissions
    *   Respect logged in user's permissions.
    *
+   * @param int $searchLimit
+   *  Limit for the number of contacts to be used for comparison.
+   *  The search methodology finds all matches for the searchedContacts so this limits
+   *  the number of searched contacts, not the matches found.
+   *
    * @return bool
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  public static function refillCache($rgid, $gid, $cacheKeyString, $criteria, $checkPermissions) {
+  public static function refillCache($rgid, $gid, $cacheKeyString, $criteria, $checkPermissions, $searchLimit = 0) {
     if (!$cacheKeyString && $rgid) {
       $cacheKeyString = CRM_Dedupe_Merger::getMergeCacheKeyString($rgid, $gid, $criteria, $checkPermissions);
     }
@@ -389,7 +394,7 @@ WHERE (pn.cacheKey $op %1 OR pn.cacheKey $op %2)
     // 2. FILL cache
     $foundDupes = array();
     if ($rgid && $gid) {
-      $foundDupes = CRM_Dedupe_Finder::dupesInGroup($rgid, $gid);
+      $foundDupes = CRM_Dedupe_Finder::dupesInGroup($rgid, $gid, $searchLimit);
     }
     elseif ($rgid) {
       $contactIDs = array();
@@ -397,7 +402,7 @@ WHERE (pn.cacheKey $op %1 OR pn.cacheKey $op %2)
         $contacts = civicrm_api3('Contact', 'get', array_merge(array('options' => array('limit' => 0), 'return' => 'id'), $criteria['contact']));
         $contactIDs = array_keys($contacts['values']);
       }
-      $foundDupes = CRM_Dedupe_Finder::dupes($rgid, $contactIDs, $checkPermissions);
+      $foundDupes = CRM_Dedupe_Finder::dupes($rgid, $contactIDs, $checkPermissions, $searchLimit);
     }
 
     if (!empty($foundDupes)) {

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1926,10 +1926,13 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
    * @param bool $checkPermissions
    *   Respect logged in user permissions.
    *
+   * @param int $searchLimit
+   *   Limit to searching for matches against this many contacts.
+   *
    * @return array
    *    Array of matches meeting the criteria.
    */
-  public static function getDuplicatePairs($rule_group_id, $group_id, $reloadCacheIfEmpty, $batchLimit, $isSelected, $orderByClause = '', $includeConflicts = TRUE, $criteria = array(), $checkPermissions = TRUE) {
+  public static function getDuplicatePairs($rule_group_id, $group_id, $reloadCacheIfEmpty, $batchLimit, $isSelected, $orderByClause = '', $includeConflicts = TRUE, $criteria = array(), $checkPermissions = TRUE, $searchLimit = 0) {
     $where = self::getWhereString($batchLimit, $isSelected);
     $cacheKeyString = self::getMergeCacheKeyString($rule_group_id, $group_id, $criteria, $checkPermissions);
     $join = self::getJoinOnDedupeTable();
@@ -1938,7 +1941,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
       // If we haven't found any dupes, probably cache is empty.
       // Try filling cache and give another try. We don't need to specify include conflicts here are there will not be any
       // until we have done some processing.
-      CRM_Core_BAO_PrevNextCache::refillCache($rule_group_id, $group_id, $cacheKeyString, $criteria, $checkPermissions);
+      CRM_Core_BAO_PrevNextCache::refillCache($rule_group_id, $group_id, $cacheKeyString, $criteria, $checkPermissions, $searchLimit);
       $dupePairs = CRM_Core_BAO_PrevNextCache::retrieve($cacheKeyString, $join, $where, 0, 0, array(), $orderByClause, $includeConflicts);
       return $dupePairs;
     }

--- a/templates/CRM/Contact/Page/DedupeFind.tpl
+++ b/templates/CRM/Contact/Page/DedupeFind.tpl
@@ -181,6 +181,8 @@
         "url": {/literal}'{$sourceUrl}'{literal}
       },
       "retrieve": true,
+      "processing": true,
+      "serverSide": true,
       rowCallback: function (row, data) {
         // Set the checked state of the checkbox in the table
         $('input.crm-dedupe-select', row).prop('checked', data.is_selected == 1);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a datatables issue where not all rows are rendered on the conflicts screen 

Before
----------------------------------------
To replicate 
1) have more than 25 conflicted dedupe matches in the db (in this case 27)
2) go to dedupe find screen, select all and batch merge selected contacts.
3) observe that on the conflicts screen you can only access 25 (the rowCount) not all 27
 
This can be fixed at the jquery level by telling it the server is holding back information with the parameters
        "processing": true,
        "serverSide": true,
https://datatables.net/examples/data_sources/server_side.html
![screenshot 2017-10-12 17 53 22](https://user-images.githubusercontent.com/336308/31479984-9e150456-af77-11e7-9daa-2ee75679cd73.png)


After
----------------------------------------
shows 10 of 27 as it should

Technical Details
----------------------------------------
We tell ajax to respect the returned rowValues from the server by using the above parameters
https://datatables.net/examples/data_sources/server_side.html

---

 * [CRM-21303: Dedupe datatable incorrectly calculates rows](https://issues.civicrm.org/jira/browse/CRM-21303)