### PR TITLE
CRM-21304 quash form reload message when refreshing

### DIFF
--- a/CRM/Contact/Form/Merge.php
+++ b/CRM/Contact/Form/Merge.php
@@ -230,6 +230,7 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
   }
 
   public function buildQuickForm() {
+    $this->unsavedChangesWarn = FALSE;
     CRM_Utils_System::setTitle(ts('Merge %1 contacts', array(1 => $this->_contactType)));
     $buttons = array();
 

--- a/templates/CRM/Contact/Page/DedupeFind.tpl
+++ b/templates/CRM/Contact/Page/DedupeFind.tpl
@@ -176,6 +176,7 @@
 {literal}
 <script type="text/javascript">
   (function($) {
+    $('[data-warn-changes=true]').attr('data-warn-changes', 'false');
     CRM.$('table#dupePairs').data({
       "ajax": {
         "url": {/literal}'{$sourceUrl}'{literal}
@@ -195,10 +196,6 @@
       }
     });
     $(function($) {
-      $('.button').click(function() {
-        // no unsaved changes confirmation dialogs
-        $('[data-warn-changes=true]').attr('data-warn-changes', 'false');
-      });
 
       var sourceUrl = {/literal}'{$sourceUrl}'{literal};
       var context   = {/literal}'{$context}'{literal};

--- a/templates/CRM/Contact/Page/DedupeFind.tpl
+++ b/templates/CRM/Contact/Page/DedupeFind.tpl
@@ -176,7 +176,6 @@
 {literal}
 <script type="text/javascript">
   (function($) {
-    $('[data-warn-changes=true]').attr('data-warn-changes', 'false');
     CRM.$('table#dupePairs').data({
       "ajax": {
         "url": {/literal}'{$sourceUrl}'{literal}


### PR DESCRIPTION
Overview
----------------------------------------
Says huuuush to this message
![screenshot 2017-10-12 18 01 33](https://user-images.githubusercontent.com/336308/31480157-a821b448-af78-11e7-9835-a80ff98f08c1.png)


Before
----------------------------------------
Above message suppressed when navigating away from the dedupe find screen by clicking a button (actually a redirect)

After
----------------------------------------
Above message also suppressed when reloaded or otherwise navigating away

Comments
----------------------------------------
There is no information stored on this page/form that would be worrisome to lose. Treat as a page, not a form

---

 * [CRM-21304: Dedupe usablity, quash refresh message in more cases](https://issues.civicrm.org/jira/browse/CRM-21304)