### PR TITLE
CRM-21224 reinstate use of limit on dedupe searches

### DIFF
--- a/CRM/Core/BAO/PrevNextCache.php
+++ b/CRM/Core/BAO/PrevNextCache.php
@@ -366,11 +366,16 @@ WHERE (pn.cacheKey $op %1 OR pn.cacheKey $op %2)
    * @param bool $checkPermissions
    *   Respect logged in user's permissions.
    *
+   * @param int $searchLimit
+   *  Limit for the number of contacts to be used for comparison.
+   *  The search methodology finds all matches for the searchedContacts so this limits
+   *  the number of searched contacts, not the matches found.
+   *
    * @return bool
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  public static function refillCache($rgid, $gid, $cacheKeyString, $criteria, $checkPermissions) {
+  public static function refillCache($rgid, $gid, $cacheKeyString, $criteria, $checkPermissions, $searchLimit = 0) {
     if (!$cacheKeyString && $rgid) {
       $cacheKeyString = CRM_Dedupe_Merger::getMergeCacheKeyString($rgid, $gid, $criteria, $checkPermissions);
     }
@@ -389,7 +394,7 @@ WHERE (pn.cacheKey $op %1 OR pn.cacheKey $op %2)
     // 2. FILL cache
     $foundDupes = array();
     if ($rgid && $gid) {
-      $foundDupes = CRM_Dedupe_Finder::dupesInGroup($rgid, $gid);
+      $foundDupes = CRM_Dedupe_Finder::dupesInGroup($rgid, $gid, $searchLimit);
     }
     elseif ($rgid) {
       $contactIDs = array();
@@ -397,7 +402,7 @@ WHERE (pn.cacheKey $op %1 OR pn.cacheKey $op %2)
         $contacts = civicrm_api3('Contact', 'get', array_merge(array('options' => array('limit' => 0), 'return' => 'id'), $criteria['contact']));
         $contactIDs = array_keys($contacts['values']);
       }
-      $foundDupes = CRM_Dedupe_Finder::dupes($rgid, $contactIDs, $checkPermissions);
+      $foundDupes = CRM_Dedupe_Finder::dupes($rgid, $contactIDs, $checkPermissions, $searchLimit);
     }
 
     if (!empty($foundDupes)) {

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1926,10 +1926,13 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
    * @param bool $checkPermissions
    *   Respect logged in user permissions.
    *
+   * @param int $searchLimit
+   *   Limit to searching for matches against this many contacts.
+   *
    * @return array
    *    Array of matches meeting the criteria.
    */
-  public static function getDuplicatePairs($rule_group_id, $group_id, $reloadCacheIfEmpty, $batchLimit, $isSelected, $orderByClause = '', $includeConflicts = TRUE, $criteria = array(), $checkPermissions = TRUE) {
+  public static function getDuplicatePairs($rule_group_id, $group_id, $reloadCacheIfEmpty, $batchLimit, $isSelected, $orderByClause = '', $includeConflicts = TRUE, $criteria = array(), $checkPermissions = TRUE, $searchLimit = 0) {
     $where = self::getWhereString($batchLimit, $isSelected);
     $cacheKeyString = self::getMergeCacheKeyString($rule_group_id, $group_id, $criteria, $checkPermissions);
     $join = self::getJoinOnDedupeTable();
@@ -1938,7 +1941,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
       // If we haven't found any dupes, probably cache is empty.
       // Try filling cache and give another try. We don't need to specify include conflicts here are there will not be any
       // until we have done some processing.
-      CRM_Core_BAO_PrevNextCache::refillCache($rule_group_id, $group_id, $cacheKeyString, $criteria, $checkPermissions);
+      CRM_Core_BAO_PrevNextCache::refillCache($rule_group_id, $group_id, $cacheKeyString, $criteria, $checkPermissions, $searchLimit);
       $dupePairs = CRM_Core_BAO_PrevNextCache::retrieve($cacheKeyString, $join, $where, 0, 0, array(), $orderByClause, $includeConflicts);
       return $dupePairs;
     }


### PR DESCRIPTION
Overview
----------------------------------------
For perfomance reasons a site might want to put limit=5000 in the url of dedupe find. This means only the first 5000 contacts will be checked for dupes & can prevent runaway queries. It can be used in conjunction with other critieria. It limits the number of contacts searched, not the number of matches found. A recent bug fix tidied up some function calls but did not include passing this parameter on appropriately

Before
----------------------------------------
limit in url is ignored - e.g civicrm/contact/dedupefind?reset=1&action=update&rgid=4&gid=&limit=50000&context=conflicts

After
----------------------------------------
Code loves & cares for limit paramter

Technical Details
----------------------------------------
#11030 got too complex - taken from there.

---

 * [CRM-21224: Dedupe searches dropping limit](https://issues.civicrm.org/jira/browse/CRM-21224)