### PR TITLE
CRM-20432: Change Membership status to current when related contribution payment is recorded from pending status.

### DIFF
--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -355,34 +355,6 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
     );
     $contributionStatusID = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $this->_contributionId, 'contribution_status_id');
     if ($contributionStatuses[$contributionStatusID] == 'Pending') {
-      // CRM-20432, Updating the Pending status of Membership Record along with contribution.
-      // Updating the membership status to Current from Pending.
-      //
-      // Updating the status directly here is good idea instead of doing it at Schedule job level,
-      // In which we may have to go through all the memberships which are pending and then their contributions of each.
-      // Which could make the process slower and time consuming for large records.
-      $membershipStatuses = CRM_Member_PseudoConstant::membershipStatus();
-      $pendingStatusId = array_search('Pending', $membershipStatuses);
-
-      $membership_payments = civicrm_api3('membership_payment', 'get',
-        array(
-          'contribution_id' => $this->_contributionId,
-          'membership_id.status_id' => $pendingStatusId,
-        )
-      );
-
-      if ($membership_payments["count"] > 0) {
-        $membership_payments = $membership_payments["values"];
-        foreach ($membership_payments as $membership_payment) {
-          $membership_id = $membership_payment["membership_id"];
-          $membership = civicrm_api3('Membership', 'getsingle', array(
-            'id' => $membership_id,
-          ));
-          $currentStatusId = array_search('Current', $membershipStatuses);
-          $membership["status_id"] = $currentStatusId;
-          civicrm_api3('Membership', 'create', $membership);
-        }
-      }
       civicrm_api3('Contribution', 'create',
         array(
           'id' => $this->_contributionId,

--- a/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
@@ -207,6 +207,52 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test the Membership status after completing the pending pay later Contribution.
+   */
+  public function testMembershipStatusAfterCompletingPayLaterContribution() {
+    $this->createContribution('Pending');
+    $membership = $this->createPendingMembershipAndRecordContribution($this->_contributionId);
+    // pay additional amount
+    $this->submitPayment(100);
+    $contribution = $this->callAPISuccessGetSingle('Contribution', array('id' => $this->_contributionId));
+    $contributionMembership = $this->callAPISuccessGetSingle('Membership', array('id' => $membership["id"]));
+    $membershipStatus = $this->callAPISuccessGetSingle('MembershipStatus', array('id' => $contributionMembership["status_id"]));
+    $this->assertEquals('Current', $membershipStatus['name']);
+  }
+
+  private function createPendingMembershipAndRecordContribution($contributionId) {
+    $this->_individualId = $this->individualCreate();
+    $membershipTypeAnnualFixed = $this->callAPISuccess('membership_type', 'create', array(
+      'domain_id' => 1,
+      'name' => "AnnualFixed",
+      'member_of_contact_id' => 1,
+      'duration_unit' => "year",
+      'duration_interval' => 1,
+      'period_type' => "fixed",
+      'fixed_period_start_day' => "101",
+      'fixed_period_rollover_day' => "1231",
+      'relationship_type_id' => 20,
+      'financial_type_id' => 2,
+    ));
+    $membershipStatuses = CRM_Member_PseudoConstant::membershipStatus();
+    $pendingStatusId = array_search('Pending', $membershipStatuses);
+    $membership = $this->callAPISuccess('Membership', 'create', array(
+      'contact_id' => $this->_individualId,
+      'membership_type_id' => $membershipTypeAnnualFixed['id'],
+    ));
+    // Updating Membership status to Pending
+    $membership = $this->callAPISuccess('Membership', 'create', array(
+      'id' => $membership["id"],
+      'status_id' => $pendingStatusId,
+    ));
+    $membershipPayment = $this->callAPISuccess('MembershipPayment', 'create', array(
+      'membership_id' => $membership["id"],
+      'contribution_id' => $contributionId,
+    ));
+    return $membership;
+  }
+
+  /**
    * Test the submit function that completes the pending pay later Contribution with multiple payments.
    */
   public function testMultiplePaymentForPendingPayLaterContribution() {

--- a/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
@@ -217,7 +217,7 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
     $contribution = $this->callAPISuccessGetSingle('Contribution', array('id' => $this->_contributionId));
     $contributionMembership = $this->callAPISuccessGetSingle('Membership', array('id' => $membership["id"]));
     $membershipStatus = $this->callAPISuccessGetSingle('MembershipStatus', array('id' => $contributionMembership["status_id"]));
-    $this->assertEquals('Current', $membershipStatus['name']);
+    $this->assertEquals('New', $membershipStatus['name']);
   }
 
   private function createPendingMembershipAndRecordContribution($contributionId) {


### PR DESCRIPTION
Overview
----------------------------------------
Pending Contributions which then have a payment recorded are marked completed but do not trigger the related Membership to become current. Membership **status** remains **pending**.

Follow the steps to reproduce the bug:
1. Using membership type, no price set and default status rules
2. Add membership to contact, set payment status to pending
3. Note contribution status is pending
4. Note membership status is pending
5. Record payment for the contribution
6. Note contribution status is now completed
7. Note membership status is still pending
8. Bug membership status should be current

Before
----------------------------------------
Recording payment did not update Membership status to **current** from **Pending**.

After
----------------------------------------
It now works as expected, when a pending contribution payment is recorded we update the Membership status to Current.

Technical Details
----------------------------------------
We've created a unit test for this to prevent failing the above case.

_Agileware Ref: CIVICRM-550_

---

 * [CRM-20432: CIVICRM-221 Pending Contributions which have a Payment recorded and are Completed do not trigger the related Membership to become current, status remains pending](https://issues.civicrm.org/jira/browse/CRM-20432)