### PR TITLE
CRM-21061: Fixing CiviReport crashing issue for column alias greater then 64 characters.

### DIFF
--- a/tests/phpunit/CRM/Report/Form/ActivityTest.php
+++ b/tests/phpunit/CRM/Report/Form/ActivityTest.php
@@ -1,0 +1,77 @@
+<?php
+
+ /*
+   --------------------------------------------------------------------
+  | CiviCRM version 4.7                                                |
+   --------------------------------------------------------------------
+  | Copyright CiviCRM LLC (c) 2004-2017                                |
+   --------------------------------------------------------------------
+  | This file is a part of CiviCRM.                                    |
+  |                                                                    |
+  | CiviCRM is free software; you can copy, modify, and distribute it  |
+  | under the terms of the GNU Affero General Public License           |
+  | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+  |                                                                    |
+  | CiviCRM is distributed in the hope that it will be useful, but     |
+  | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+  | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+  | See the GNU Affero General Public License for more details.        |
+  |                                                                    |
+  | You should have received a copy of the GNU Affero General Public   |
+  | License and the CiviCRM Licensing Exception along                  |
+  | with this program; if not, contact CiviCRM LLC                     |
+  | at info[AT]civicrm[DOT]org. If you have questions about the        |
+  | GNU Affero General Public License or the licensing of CiviCRM,     |
+  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+   --------------------------------------------------------------------
+ */
+
+ /**
+  * Test Activity Report
+  * @package CiviCRM
+  * @group headless
+  */
+class CRM_Report_Form_ActivityTest extends CiviReportTestCase {
+
+  public function setUp() {
+    parent::setUp();
+  }
+
+  public function tearDown() {
+    parent::tearDown();
+  }
+
+  /**
+   * @return array
+   */
+  public function dataProvider() {
+    return array(
+      'report_class' => 'CRM_Report_Form_Activity',
+      'input_params' => array(
+        'fields' => array(
+          'contact_target',
+        ),
+      ),
+    );
+  }
+
+  /**
+   * Test to check the report with custom fields with larger group name. (e.g. >64 characters)
+   * Generating report will throw PEAR_Exception without fix with Unknown DB error,
+   * which is getting trgigger because of long group names.
+   * Exception will be thrown during generting SQL and creating temp table, so it will fail without any data.
+   */
+  public function testAliasNamesLength() {
+    try {
+      $ids = $this->CustomGroupMultipleCreateWithFields(array('title' => 'Professional qualifications and Work Practice', 'extends' => 'Activity'));
+      $dataProvider = $this->dataProvider();
+      $dataProvider['input_params']['fields'][] = 'custom_' . $ids['custom_group_id']; // Adding custom field as param in output.
+      $this->getReportOutputAsCsv($dataProvider['report_class'], $dataProvider['input_params']);
+      $this->assertTrue(TRUE); // CSV is created, so test is successful.
+    }
+    catch(PEAR_Exception $e) {
+      $this->fail('PEAR_Exception occured: ' . $e->getMessage()); // If exception caught test is failing.
+    }
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Steps to reproduce the issue:
1. Create a field group for individuals with very big name. (at least 40-45 chars)
2. Create fields in this group with again big names (at least 15-20 characters)
3. Expose these fields to be part of CiviReport.
4. Generate CiviReport for activities with selecting Custom contact fields.
5. Click on Preview Report.

Above case throw following error message.

> Database Error Code: Incorrect column name  

This happens because the final name of the column with it's table name becomes very big (more then 64 characters) and maximum length of MySQL column is 64 characters. 

Before
----------------------------------------
Report was not getting generated due to the maximum length error of the column.

After
----------------------------------------
It now works as expected, and show the Report result with correct data.

Technical Details
----------------------------------------
We're trimming the length of both alias and column header before executing the SQL, this would prevent database level error. We've also written a unit test to prevent this from failing in future.

_Agileware Ref: CIVICRM-555_

---

 * [CRM-21061: Fix rare CiviReport error relating to long report names](https://issues.civicrm.org/jira/browse/CRM-21061)