### PR TITLE
Add a test for CRM-17151 (test scenario's are documented in the test)

### DIFF
--- a/tests/phpunit/CRM/Event/BAO/CRM19273Test.php
+++ b/tests/phpunit/CRM/Event/BAO/CRM19273Test.php
@@ -3,7 +3,7 @@
  * Class CRM_Event_BAO_AdditionalPaymentTest
  * @group headless
  */
-class CRM_Event_BAO_CRM19273 extends CiviUnitTestCase {
+class CRM_Event_BAO_CRM19273Test extends CiviUnitTestCase {
 
   protected $_priceSetID;
   protected $_cheapFee = 80;


### PR DESCRIPTION
Overview
----------------------------------------
_Adds a test for CRM-17151_

Before
----------------------------------------
Bug described at _https://issues.civicrm.org/jira/browse/CRM-17151_

Test scenario

Short story. It is possible to change the event selections in such a way that the balance becomes 0. The associated contribution status should go to 'Completed', but it moved instead to 'Pending refund.' Fix: make the contribution status change to 'Completed' in this context.

To reproduce:

I configured an event with no payment processors and the pay later option enabled. This is typical for a small Dutch conference, payments are done with electronic bank transfer and registered manual. The event has price set configured with one mandatory and one optional component.

Now I execute the following actions:

A participant registers online for only the mandatory component.In CiviCRM a registration is created with the status "Pending from pay later" and a connected Contribution with the status "Pending (Pay Later)"Now the payment is recorded in the back-office by using the "Edit Event Registration Screen" -> Pay Later Option.

I set the payment status to completed I get a confirmation screen and I agree. The associated contribution also moves to 'completed'. The participant status is still "Pending from Pay later" but I manually change it to Registered. So far, so good.

But now I change the selection of the registration to add the optional component of the event.
In the production situation this the processing of an email that the participant also wants the optional component. (Or even a bank transfer, wherein the remark field the optional component is selected).
The Event Registration gets now the status partially paid, and the same happens for the contribution. bug CRM-16868 is fixed.

The participant however, has regret. He does not want the extra component (maybe a mistake in the communication). So it is deselected again and the balance returns to 0.

But the status of the Contribution does _not return to 'completed'.

After
----------------------------------------
_No functional change_ Only a test that checks if the bug is still active.

Comments
----------------------------------------
_This pull request will fail on Jenkins (it supplies a test for an existing bug). The test is included in the test for CRM-1715 because it benefits from the same test scenario.

---

 * [CRM-16868: Incorrect "Pending Refund Status" for Contribution after Change Selections in Participation](https://issues.civicrm.org/jira/browse/CRM-16868)