### PR TITLE
CRM-21300: Addressed notices due to unexpected NULL from Joomla DB object.

### DIFF
--- a/CRM/Core/Permission/Joomla.php
+++ b/CRM/Core/Permission/Joomla.php
@@ -181,8 +181,9 @@ class CRM_Core_Permission_Joomla extends CRM_Core_Permission_Base {
 
     $db->setQuery($query);
 
-    // Load the result as a stdClass object, decoding JSON on the way
-    return json_decode($db->loadObject()->rules);
+    // Joomla gotcha: loadObject returns NULL in the case of no matches.
+    $result = $db->loadObject();
+    return $result ? json_decode($result->rules) : (object) array();
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Prevent notices described in CRM-21300 from being raised.

Before
----------------------------------------
See CRM-21300.

After
----------------------------------------
No more notices or warnings (needs validation).

Technical Details
----------------------------------------
The Joomla DB object returns NULL in some cases, which was not immediately obvious from the documentation. This PR ensures that the DBO-wrapping method always has a consistent return type.

---

 * [CRM-21300: Joomla: Trying to get property of non-object in CRM\/Core\/Permission\/Joomla.php](https://issues.civicrm.org/jira/browse/CRM-21300)