### PR TITLE
CRM-21311 Credit card type is unset on submission causing credit card payment to fail with CVV validation error message

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -660,12 +660,7 @@ abstract class CRM_Core_Payment {
    *   field metadata
    */
   public function getPaymentFormFieldsMetadata() {
-    //@todo convert credit card type into an option value
-    $creditCardType = array('' => ts('- select -')) + CRM_Contribute_PseudoConstant::creditCard();
-    $isCVVRequired = Civi::settings()->get('cvv_backoffice_required');
-    if (!$this->isBackOffice()) {
-      $isCVVRequired = TRUE;
-    }
+    $creditCardType = array('' => ts('- select -')) + CRM_Core_Payment_Form::getCreditCardCSSNames();
     return array(
       'credit_card_number' => array(
         'htmlType' => 'text',

--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -661,6 +661,10 @@ abstract class CRM_Core_Payment {
    */
   public function getPaymentFormFieldsMetadata() {
     $creditCardType = array('' => ts('- select -')) + CRM_Contribute_PseudoConstant::creditCard();
+    $isCVVRequired = Civi::settings()->get('cvv_backoffice_required');
+    if (!$this->isBackOffice()) {
+      $isCVVRequired = TRUE;
+    }
     return array(
       'credit_card_number' => array(
         'htmlType' => 'text',

--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -660,7 +660,7 @@ abstract class CRM_Core_Payment {
    *   field metadata
    */
   public function getPaymentFormFieldsMetadata() {
-    $creditCardType = array('' => ts('- select -')) + CRM_Core_Payment_Form::getCreditCardCSSNames();
+    $creditCardType = array('' => ts('- select -')) + CRM_Contribute_PseudoConstant::creditCard();
     return array(
       'credit_card_number' => array(
         'htmlType' => 'text',

--- a/CRM/Financial/Form/Payment.php
+++ b/CRM/Financial/Form/Payment.php
@@ -117,7 +117,7 @@ class CRM_Financial_Form_Payment extends CRM_Core_Form {
    */
   public static function addCreditCardJs($paymentProcessorID = NULL, $region = 'billing-block') {
     $creditCards = CRM_Financial_BAO_PaymentProcessor::getCreditCards($paymentProcessorID);
-    $creditCardTypes = CRM_Core_Payment_Form::getCreditCardCSSNames($creditCards);
+    $creditCardTypes = CRM_Contribute_PseudoConstant::creditCard($creditCards);
     CRM_Core_Resources::singleton()
       // CRM-20516: add BillingBlock script on billing-block region
       //  to support this feature in payment form snippet too.

--- a/CRM/Upgrade/Incremental/php/FourSeven.php
+++ b/CRM/Upgrade/Incremental/php/FourSeven.php
@@ -456,6 +456,7 @@ class CRM_Upgrade_Incremental_php_FourSeven extends CRM_Upgrade_Incremental_Base
     $this->addTask('CRM-12167 - Add visibility column to civicrm_price_field_value', 'addColumn',
       'civicrm_price_field_value', 'visibility_id', 'int(10) unsigned DEFAULT 1 COMMENT "Implicit FK to civicrm_option_group with name = \'visibility\'"');
     $this->addTask('Remove broken Contribution_logging reports', 'removeContributionLoggingReports');
+    $this->addTask('CRM-21311 - Update option value name to lowercase', 'optionValueNameToLowercase');
   }
 
   /**
@@ -1385,6 +1386,15 @@ FROM `civicrm_dashboard_contact` JOIN `civicrm_contact` WHERE civicrm_dashboard_
       $dataType = 'datetime';
     }
     CRM_Core_DAO::executeQuery("ALTER TABLE civicrm_mailing CHANGE created_date created_date {$dataType} NULL DEFAULT NULL COMMENT 'Date and time this mailing was created.'");
+    return TRUE;
+  }
+
+  /**
+   * CRM-21311 Updating civicrm_option_value name to lowercase.
+   * @return bool
+   */
+  public static function optionValueNameToLowercase(CRM_Queue_TaskContext $ctx) {
+    CRM_Core_DAO::executeQuery("UPDATE civicrm_option_value v INNER JOIN civicrm_option_group g ON v.option_group_id = g.id AND g.name= 'accept_creditcard' SET v.name = lower(v.name), v.is_reserved = 1;");
     return TRUE;
   }
 

--- a/templates/CRM/Core/BillingBlock.js
+++ b/templates/CRM/Core/BillingBlock.js
@@ -60,18 +60,13 @@
   function civicrm_billingblock_set_card_type(ccnumber) {
     // Based on http://davidwalsh.name/validate-credit-cards
     // See also https://en.wikipedia.org/wiki/Credit_card_numbers
+    // @todo these patterns should be part of the credit card option group, instead of hard coded
     var card_types = {
-      'mastercard': '(5[1-5][0-9]{2}|2[3-6][0-9]{2}|22[3-9][0-9]|222[1-9]|27[0-1][0-9]|2720)[0-9]{12}',
-      'visa': '4(?:[0-9]{12}|[0-9]{15})',
-      'amex': '3[47][0-9]{13}',
-      'dinersclub': '3(?:0[0-5][0-9]{11}|[68][0-9]{12})',
-      'carteblanche': '3(?:0[0-5][0-9]{11}|[68][0-9]{12})',
-      'discover': '6011[0-9]{12}',
-      'jcb': '(?:3[0-9]{15}|(2131|1800)[0-9]{11})',
-      'unionpay': '62(?:[0-9]{14}|[0-9]{17})'
+      'MasterCard': '(5[1-5][0-9]{2}|2[3-6][0-9]{2}|22[3-9][0-9]|222[1-9]|27[0-1][0-9]|2720)[0-9]{12}',
+      'Visa': '4(?:[0-9]{12}|[0-9]{15})',
+      'Amex': '3[47][0-9]{13}',
+      'Discover': '6011[0-9]{12}',
     };
-
-    var card_values = CRM.config.creditCardTypes;
 
     $.each(card_types, function(card_type_key, pattern) {
       card_type_css = card_type_key.toLowerCase();

--- a/templates/CRM/Core/BillingBlock.js
+++ b/templates/CRM/Core/BillingBlock.js
@@ -9,14 +9,15 @@
    */
   function civicrm_billingblock_creditcard_helper() {
     $(function() {
-      $.each(CRM.config.creditCardTypes, function(key, val) {
-        var html = '<a href="#" title="' + val + '" class="crm-credit_card_type-icon-' + key + '"><span>' + val + '</span></a>';
+      $.each(CRM.config.creditCardTypes, function(card_type_key, val) {
+        card_type_css = card_type_key.toLowerCase();
+        var html = '<a href="#" title="' + val + '" class="crm-credit_card_type-icon-' + card_type_css + '"><span>' + val + '</span></a>';
         $('.crm-credit_card_type-icons').append(html);
 
-        $('.crm-credit_card_type-icon-' + key).click(function() {
-          $('#credit_card_type').val(val);
+        $('.crm-credit_card_type-icon-' + card_type_css).click(function() {
+          $('#credit_card_type').val(card_type_key);
           $('.crm-container .credit_card_type-section a').css('opacity', 0.25);
-          $('.crm-container .credit_card_type-section .crm-credit_card_type-icon-' + key).css('opacity', 1);
+          $('.crm-container .credit_card_type-section .crm-credit_card_type-icon-' + card_type_css).css('opacity', 1);
           return false;
         });
       });
@@ -27,13 +28,14 @@
       // set the card type value as default if any found
       var cardtype = $('#credit_card_type').val();
       if (cardtype) {
-        $.each(CRM.config.creditCardTypes, function(key, value) {
+        $.each(CRM.config.creditCardTypes, function(card_type_key, value) {
+          card_type_css = card_type_key.toLowerCase();
           // highlight the selected card type icon
-          if (value == cardtype) {
-            $('.crm-container .credit_card_type-section .crm-credit_card_type-icon-' + key).css('opacity', 1);
+          if (card_type_key == cardtype) {
+            $('.crm-container .credit_card_type-section .crm-credit_card_type-icon-' + card_type_css).css('opacity', 1);
           }
           else {
-            $('.crm-container .credit_card_type-section .crm-credit_card_type-icon-' + key).css('opacity', 0.25);
+            $('.crm-container .credit_card_type-section .crm-credit_card_type-icon-' + card_type_css).css('opacity', 0.25);
           }
         });
       }
@@ -71,11 +73,12 @@
 
     var card_values = CRM.config.creditCardTypes;
 
-    $.each(card_types, function(key, pattern) {
+    $.each(card_types, function(card_type_key, pattern) {
+      card_type_css = card_type_key.toLowerCase();
       if (ccnumber.match('^' + pattern + '$')) {
-            $('.crm-container .credit_card_type-section .crm-credit_card_type-icon-' + key).css('opacity', 1);
-            $('select#credit_card_type').val(key);
-            return false;
+        $('.crm-container .credit_card_type-section .crm-credit_card_type-icon-' + card_type_css).css('opacity', 1);
+        $('select#credit_card_type').val(card_type_key);
+        return false;
       }
     });
   }

--- a/templates/CRM/Core/BillingBlock.js
+++ b/templates/CRM/Core/BillingBlock.js
@@ -73,16 +73,9 @@
 
     $.each(card_types, function(key, pattern) {
       if (ccnumber.match('^' + pattern + '$')) {
-        var value = card_values[key];
-        //$.each(CRM.config.creditCardTypes, function(key2, val) {
-        //  if (value == val) {
             $('.crm-container .credit_card_type-section .crm-credit_card_type-icon-' + key).css('opacity', 1);
-            $('select#credit_card_type').val(value);
+            $('select#credit_card_type').val(key);
             return false;
-        //  }
-        //  else {
-        //    $
-       // });
       }
     });
   }

--- a/tests/phpunit/CRM/Financial/BAO/PaymentProcessorTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/PaymentProcessorTest.php
@@ -48,14 +48,14 @@ class CRM_Financial_BAO_PaymentProcessorTest extends CiviUnitTestCase {
       'domain_id' => 1,
       'accepted_credit_cards' => json_encode(array(
         'Visa' => 'Visa',
-        'Mastercard' => 'Mastercard',
+        'MasterCard' => 'Mastercard',
         'Amex' => 'American Express',
       )),
     );
     $paymentProcessor = CRM_Financial_BAO_PaymentProcessor::create($params);
     $expectedCards = array(
       'Visa' => 'Visa',
-      'Mastercard' => 'Mastercard',
+      'MasterCard' => 'Mastercard',
       'Amex' => 'American Express',
     );
     $cards = CRM_Financial_BAO_PaymentProcessor::getCreditCards($paymentProcessor->id);
@@ -73,7 +73,7 @@ class CRM_Financial_BAO_PaymentProcessorTest extends CiviUnitTestCase {
       'domain_id' => 1,
       'accepted_credit_cards' => json_encode(array(
         'Visa' => 'Visa',
-        'Mastercard' => 'Mastercard',
+        'MasterCard' => 'Mastercard',
         'Amex' => 'American Express',
       )),
     );
@@ -84,7 +84,7 @@ class CRM_Financial_BAO_PaymentProcessorTest extends CiviUnitTestCase {
     $Cards = CRM_Contribute_PseudoConstant::creditCard($cards);
     $expectedCards = array(
       'Visa' => 'Visa',
-      'Mastercard' => 'Mastercard',
+      'MasterCard' => 'Mastercard',
       'Amex' => 'American Express',
     );
     $this->assertEquals($Cards, $expectedCards, 'Verify correct credit card types are returned');
@@ -93,7 +93,7 @@ class CRM_Financial_BAO_PaymentProcessorTest extends CiviUnitTestCase {
     $Cards2 = CRM_Contribute_PseudoConstant::creditCard(array());
     $allCards = array(
       'Visa' => 'Visa',
-      'Mastercard' => 'Mastercard',
+      'MasterCard' => 'Mastercard',
       'Amex' => 'American Express',
       'Discover' => 'Discover', // Note: Discover is a default credit card type available, not assigned to a processor
     );

--- a/tests/phpunit/CRM/Financial/BAO/PaymentProcessorTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/PaymentProcessorTest.php
@@ -49,20 +49,20 @@ class CRM_Financial_BAO_PaymentProcessorTest extends CiviUnitTestCase {
       'accepted_credit_cards' => json_encode(array(
         'Visa' => 'Visa',
         'Mastercard' => 'Mastercard',
-        'Amex' => 'Amex',
+        'Amex' => 'American Express',
       )),
     );
     $paymentProcessor = CRM_Financial_BAO_PaymentProcessor::create($params);
     $expectedCards = array(
       'Visa' => 'Visa',
       'Mastercard' => 'Mastercard',
-      'Amex' => 'Amex',
+      'Amex' => 'American Express',
     );
     $cards = CRM_Financial_BAO_PaymentProcessor::getCreditCards($paymentProcessor->id);
     $this->assertEquals($cards, $expectedCards, 'Verify correct credit card types are returned');
   }
 
-  public function testCreditCardCSSName() {
+  public function testCreditCardType() {
     $params = array(
       'name' => 'API_Test_PP_Type',
       'title' => 'API Test Payment Processor Type',
@@ -74,26 +74,30 @@ class CRM_Financial_BAO_PaymentProcessorTest extends CiviUnitTestCase {
       'accepted_credit_cards' => json_encode(array(
         'Visa' => 'Visa',
         'Mastercard' => 'Mastercard',
-        'Amex' => 'Amex',
+        'Amex' => 'American Express',
       )),
     );
     $paymentProcessor = CRM_Financial_BAO_PaymentProcessor::create($params);
+
+    // Check what credit card types are available for the Test Payment Processor
     $cards = CRM_Financial_BAO_PaymentProcessor::getCreditCards($paymentProcessor->id);
-    $CSSCards = CRM_Core_Payment_Form::getCreditCardCSSNames($cards);
-    $expectedCSSCards = array(
-      'visa' => 'Visa',
-      'mastercard' => 'Mastercard',
-      'amex' => 'Amex',
+    $Cards = CRM_Contribute_PseudoConstant::creditCard($cards);
+    $expectedCards = array(
+      'Visa' => 'Visa',
+      'Mastercard' => 'Mastercard',
+      'Amex' => 'American Express',
     );
-    $this->assertEquals($CSSCards, $expectedCSSCards, 'Verify correct credit card types are returned');
-    $CSSCards2 = CRM_Core_Payment_Form::getCreditCardCSSNames(array());
+    $this->assertEquals($Cards, $expectedCards, 'Verify correct credit card types are returned');
+
+    // Check what credit card types are available with no payment processor specified - the default ones
+    $Cards2 = CRM_Contribute_PseudoConstant::creditCard(array());
     $allCards = array(
-      'visa' => 'Visa',
-      'mastercard' => 'MasterCard',
-      'amex' => 'Amex',
-      'discover' => 'Discover',
+      'Visa' => 'Visa',
+      'Mastercard' => 'Mastercard',
+      'Amex' => 'American Express',
+      'Discover' => 'Discover', // Note: Discover is a default credit card type available, not assigned to a processor
     );
-    $this->assertEquals($CSSCards2, $allCards, 'Verify correct credit card types are returned');
+    $this->assertEquals($Cards2, $allCards, 'Verify correct credit card types are returned');
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Credit card type is unset on submission causing credit card payment to fail with CVV validation error message. Regression bug introduced in PR #10774

Before
----------------------------------------
In CiviCRM, change default credit card name for "Amex" to "American Express".
Submit a test credit card transaction using an American Express test credit card number, 378282246310005
Contribution will fail with CVV validation error message.
Existing code does not set the credit card type on submission, causing the CVV not to be validated correctly. American Express uses 4 digit CVV.

After
----------------------------------------
Credit card type is set correctly, CVV is validated and submission succeeds.

Technical Details
----------------------------------------
Regression bug introduced in PR #10774 - See https://github.com/civicrm/civicrm-core/pull/10774/files#diff-31a6607a9f03e2336c412d8fad30d711R72

This function has a comment that it was created to be used only for CSS names.  Since PR #10774 it is being used to return a json string. Recommend refactor function name and remove comment - since it is not just being used for CSS anymore.

See CRM/Core/Payment/Form.php - public static function getCreditCardCSSNames

https://github.com/civicrm/civicrm-core/pull/10774/files#diff-31f2b294fac11671bf5ae72d8e6d7172R115

Comments
----------------------------------------
Who uses AMEX anyway?

---

 * [CRM-21311: CIVICRM-668 Credit card type is unset on submission causing credit card payment to fail with CVV validation error message](https://issues.civicrm.org/jira/browse/CRM-21311)