### PR TITLE
CRM-21312 Fix display of 'Recent Items' when using a bootstrap theme

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -1073,6 +1073,7 @@ input.crm-form-entityref {
 #crm-recently-viewed ul {
   list-style-image: none;
   font-size: .9em;
+  padding: 0;
 }
 
 #crm-recently-viewed li.crm-recently-viewed {
@@ -1123,6 +1124,10 @@ input.crm-form-entityref {
 
 #crm-recently-viewed li.crm-recently-viewed:hover .crm-recentview-wrapper {
   display: block;
+}
+
+.crm-recentview-item {
+  overflow: hidden;
 }
 
 #crm-recently-viewed .crm-recentview-wrapper a:hover {

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -1128,6 +1128,7 @@ input.crm-form-entityref {
 
 .crm-recentview-item {
   overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 #crm-recently-viewed .crm-recentview-wrapper a:hover {

--- a/templates/CRM/Block/RecentlyViewed.tpl
+++ b/templates/CRM/Block/RecentlyViewed.tpl
@@ -25,30 +25,34 @@
 *}
 {* Displays recently viewed objects (contacts and other objects like groups, notes, etc. *}
 <div id="crm-recently-viewed" class="left crm-container">
-    <ul>
+  <ul>
     {foreach from=$recentlyViewed item=item}
-         <li class="crm-recently-viewed" ><a  href="{$item.url}" title="{$item.title|escape:'html'}">
-         {if $item.image_url}
-            <span class="icon crm-icon {if $item.subtype}{$item.subtype}{else}{$item.type}{/if}-icon" style="background: url('{$item.image_url}')"></span>
-         {else}
-            <span class="icon crm-icon {$item.type}{if $item.subtype}-subtype{/if}-icon"></span>
-         {/if}
-         {if $item.isDeleted}<del>{/if}{$item.title|mb_truncate:25:"..":true}{if $item.isDeleted}</del>{/if}</a>
-         <div class="crm-recentview-wrapper">
-           <a href='{$item.url}' class="crm-actions-view">{ts}View{/ts}</a>
-         {if $item.edit_url}<a href='{$item.edit_url}' class="crm-actions-edit">{ts}Edit{/ts}</a>{/if}
-       {if $item.delete_url}<a href='{$item.delete_url}' class="crm-actions-delete">{ts}Delete{/ts}</a>{/if}
-         </div>
-       </li>
+      <li class="crm-recently-viewed">
+        <div class="crm-recentview-item">
+          <a href="{$item.url}" title="{$item.title|escape:'html'}">
+            {if $item.image_url}
+              <span class="icon crm-icon {if $item.subtype}{$item.subtype}{else}{$item.type}{/if}-icon" style="background: url('{$item.image_url}')"></span>
+            {else}
+              <span class="icon crm-icon {$item.type}{if $item.subtype}-subtype{/if}-icon"></span>
+            {/if}
+            {if $item.isDeleted}<del>{/if}{$item.title}{if $item.isDeleted}</del>{/if}
+          </a>
+        </div>
+        <div class="crm-recentview-wrapper">
+          <a href='{$item.url}' class="crm-actions-view">{ts}View{/ts}</a>
+          {if $item.edit_url}<a href='{$item.edit_url}' class="crm-actions-edit">{ts}Edit{/ts}</a>{/if}
+          {if $item.delete_url}<a href='{$item.delete_url}' class="crm-actions-delete">{ts}Delete{/ts}</a>{/if}
+        </div>
+      </li>
     {/foreach}
-   </ul>
+  </ul>
 </div>
 {literal}
-<script type="text/javascript">
+  <script type="text/javascript">
     CRM.$(function($) {
       if ($('#crm-recently-viewed').offset().left > 150) {
         $('#crm-recently-viewed').removeClass('left').addClass('right');
       }
     });
-</script>
+  </script>
 {/literal}


### PR DESCRIPTION
Overview
----------------------------------------
Before this patch, recent items is messed up on bootstrap themes. Afterwards, it is not messed up!

Before
----------------------------------------
![crm-21312_civi_recentitems_bootstrap_before](https://user-images.githubusercontent.com/2052161/31576816-1a87daf2-b0fb-11e7-9f01-c2f96180c2dc.png)

After
----------------------------------------
![crm-21312_civi_recentitems_bootstrap_after](https://user-images.githubusercontent.com/2052161/31576817-1f60cdb8-b0fb-11e7-8100-f2b7c2ea8cb7.png)

Technical Details
----------------------------------------
Tested on Bartik, Adaptivetheme, bootstrap.  Works well on all of them.

---

 * [CRM-21312: Fix display of Recent Items when using a bootstrap theme](https://issues.civicrm.org/jira/browse/CRM-21312)