### PR TITLE
CRM-21272 add definition of isUserRegistrationPermitted to Backdrop class

### DIFF
--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -415,6 +415,16 @@ AND    u.status = 1
   /**
    * @inheritDoc
    */
+  public function isUserRegistrationPermitted() {
+    if (config_get('system.core', 'user_register') == 'admin_only') {
+      return FALSE;
+    }
+    return TRUE;
+  }
+
+  /**
+   * @inheritDoc
+   */
   public function getUFLocale() {
     // return CiviCRM’s xx_YY locale that either matches Backdrop’s Chinese locale
     // (for CRM-6281), Backdrop’s xx_YY or is retrieved based on Backdrop’s xx


### PR DESCRIPTION
Overview
----------------------------------------
This PR https://github.com/civicrm/civicrm-core/pull/11079 missed definition of isUserRegistrationPermitted to Backdrop class while adding it for other CMSes. This adds it.

---

 * [CRM-21272: CMSUser has Drupal 6\/7 code that breaks when using with Drupal 8](https://issues.civicrm.org/jira/browse/CRM-21272)