### PR TITLE
CRM-21314 Credit card block missing from membership payment form:

### DIFF
--- a/templates/CRM/Member/Form/MembershipCommon.tpl
+++ b/templates/CRM/Member/Form/MembershipCommon.tpl
@@ -107,4 +107,9 @@
     <td class="label">{$form.payment_processor_id.label}</td>
     <td>{$form.payment_processor_id.html}</td>
   </tr>
+  <tr class="crm-membership-form-block-billing">
+    <td colspan="2">
+      {include file='CRM/Core/BillingBlockWrapper.tpl'}
+    </td>
+  </tr>
 {/if}


### PR DESCRIPTION
Overview
Credit card section has gone missing from the backoffice renew membership by credit card page, this re-instates

Before
----------------------------------------
Space to enter credit card missing

After
----------------------------------------
block re-instated

@monishdeb

---

 * [CRM-21314: Credit card block missing from membership payment form](https://issues.civicrm.org/jira/browse/CRM-21314)