### PR TITLE
CRM-21267: Fixed call to undefined formatCustomDate method in Parser.

### DIFF
--- a/CRM/Contact/Import/Parser.php
+++ b/CRM/Contact/Import/Parser.php
@@ -844,7 +844,8 @@ abstract class CRM_Contact_Import_Parser extends CRM_Import_Parser {
       ) {
         //we should not update Date to null, CRM-4062
         if ($val && ($customFields[$customFieldID]['data_type'] == 'Date')) {
-          self::formatCustomDate($params, $formatted, $dateType, $key);
+	  //CRM-21267
+          CRM_Contact_Import_Parser_Contact::formatCustomDate($params, $formatted, $dateType, $key);
         }
         elseif ($customFields[$customFieldID]['data_type'] == 'Boolean') {
           if (empty($val) && !is_numeric($val) && $this->_onDuplicate == CRM_Import_Parser::DUPLICATE_FILL) {

--- a/CRM/Contact/Import/Parser.php
+++ b/CRM/Contact/Import/Parser.php
@@ -844,7 +844,7 @@ abstract class CRM_Contact_Import_Parser extends CRM_Import_Parser {
       ) {
         //we should not update Date to null, CRM-4062
         if ($val && ($customFields[$customFieldID]['data_type'] == 'Date')) {
-	  //CRM-21267
+          //CRM-21267
           CRM_Contact_Import_Parser_Contact::formatCustomDate($params, $formatted, $dateType, $key);
         }
         elseif ($customFields[$customFieldID]['data_type'] == 'Boolean') {


### PR DESCRIPTION
Overview
----------------------------------------
When performing a Contact import for a CSV which has a date field mapped to import to a custom date field, the following error is thrown and causes CiviCRM to white screen - error 500.

> PHP Fatal error:  Call to undefined method CRM_Contact_Import_Parser::formatCustomDate() in /home/www/public_html/sites/all/modules/civicrm/CRM/Contact/Import/Parser.php on line 847, referer: https://website.domain.com/civicrm/import/contact?_qf_Preview_display=true&qfKey=o83u4ruekruhvwk7hv37i3434

Before
----------------------------------------
Import was getting crashed on the final stage and contacts were not getting imported.

After
----------------------------------------
It now works as expected and all the contacts gets imported.

Technical Details
----------------------------------------
There was an undefined method getting called, we fixed it to call from right class.


_Agileware Ref: CIVICRM-542_

---

 * [CRM-21267: Error 500 - Call to undefined method CRM_Contact_Import_Parser::formatCustomDate](https://issues.civicrm.org/jira/browse/CRM-21267)

ping @agileware 