### PR TITLE
CRM-20870/CRM-20977: CiviCRM API - Membership get with join on Contact with Group/Tag/Country/State parameter returns incorrect results. Join parameters are ignored

### DIFF
--- a/api/v3/Membership.php
+++ b/api/v3/Membership.php
@@ -232,7 +232,12 @@ function civicrm_api3_membership_get($params) {
   if ($options['is_count']) {
     return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
   }
-  $membershipValues = _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params, FALSE, 'Membership');
+
+  $membershipValues = _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__),
+    $params, FALSE, 'Membership',
+    // returns a CRM_Utils_SQL_Select with JOINs and WHEREs based on $params values
+    _civicrm_api3_membership_get_extraFilters($params)
+  );
 
   $return = $options['return'];
   if (empty($membershipValues) ||
@@ -332,4 +337,70 @@ function _civicrm_api3_membership_relationsship_get_customv2behaviour(&$params, 
     }
   }
   return $members;
+}
+
+/**
+ * Support filters beyond what basic_get can do.
+ *
+ * @param array $params
+ * @throws \CiviCRM_API3_Exception
+ * @throws \Exception
+ *
+ * @return CRM_Utils_SQL_Select $sql
+ */
+function _civicrm_api3_membership_get_extraFilters($params = '') {
+  $sql = CRM_Utils_SQL_Select::fragment();
+  $rels = array(
+    'contact_id.group' => array(
+      'join' => '
+        !joinType civicrm_group_contact rgc ON (rgc.contact_id = a.contact_id)
+        !joinType civicrm_group rg ON (rg.id = rgc.group_id AND rgc.status = \'Added\')
+        !joinType civicrm_group_contact_cache sgc ON (sgc.contact_id = a.contact_id)
+        !joinType civicrm_group sg ON (sg.id = sgc.group_id)
+      ',
+      'column' => 'name',
+    ),
+    'contact_id.country_id' => array(
+      'join' => '
+        !joinType civicrm_address ca ON (ca.contact_id = a.contact_id)
+      ',
+      'alias' => 'ca.',
+      'column' => 'country_id',
+    ),
+    'contact_id.state_province_id' => array(
+      'join' => '
+        !joinType civicrm_address ca ON (ca.contact_id = a.contact_id)
+      ',
+      'alias' => 'ca.',
+      'column' => 'state_province_id',
+    ),
+    'contact_id.tag' => array(
+      'join' => '
+        !joinType civicrm_entity_tag et ON (et.entity_id = a.contact_id AND et.entity_table = \'civicrm_contact\')
+        !joinType civicrm_tag t ON (t.id = et.tag_id AND t.is_selectable = 1)
+      ',
+      'alias' => 't.',
+      'column' => 'name',
+    ),
+  );
+
+  foreach ($rels as $filter => $relSpec) {
+    if (!empty($params[$filter])) {
+      if (!is_array($params[$filter])) {
+        $params[$filter] = array('=' => $params[$filter]);
+      }
+      $sql->join($filter, $relSpec['join'], array('joinType' => 'LEFT JOIN'));
+      if ($filter == 'contact_id.group') {
+        $sql->where(sprintf("(%s OR %s)",
+          \CRM_Core_DAO::createSQLFilter("rg." . $relSpec['column'], $params[$filter]),
+          \CRM_Core_DAO::createSQLFilter("sg." . $relSpec['column'], $params[$filter]))
+        );
+      }
+      else {
+        $sql->where(\CRM_Core_DAO::createSQLFilter($relSpec['alias'] . $relSpec['column'], $params[$filter]));
+      }
+    }
+  }
+
+  return $sql;
 }

--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -227,9 +227,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     $membership = $this->callAPISuccess('membership', 'get', $params);
 
     $result = $membership['values'][$this->_membershipID];
-    $this->callAPISuccess('Membership', 'Delete', array(
-      'id' => $this->_membershipID,
-    ));
+
     $this->assertEquals($result['contact_id'], $this->_contactID, "In line " . __LINE__);
     $this->assertEquals($result['membership_type_id'], $this->_membershipTypeID, "In line " . __LINE__);
     $this->assertEquals($result['status_id'], $this->_membershipStatusID, "In line " . __LINE__);
@@ -238,6 +236,126 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     $this->assertEquals($result['end_date'], '2009-12-21', "In line " . __LINE__);
     $this->assertEquals($result['source'], 'Payment', "In line " . __LINE__);
     $this->assertEquals($result['is_override'], 1, "In line " . __LINE__);
+
+    $this->callAPISuccess('Membership', 'Delete', array(
+      'id' => $this->_membershipID,
+    ));
+  }
+
+  /**
+   * Test Membership.Get API with Country ID filter
+   */
+  public function testGetByCountryID() {
+
+    $contactid = $this->individualCreate();
+    $address = $this->callAPISuccess('Address', 'create', array(
+      'contact_id'        => $contactid,
+      'location_type_id'  => 'Home',
+      'country_id'        => "AU",
+    ));
+    $address = $address["values"][$address["id"]];
+    $this->_params["contact_id"] = $contactid;
+    $this->_membershipID = $this->contactMembershipCreate($this->_params);
+
+    $membership = $this->callAPISuccess('membership', 'get', array(
+      'contact_id.country_id' => $address["country_id"],
+    ));
+
+    $this->assertEquals(1, $membership['count']);
+    $this->assertEquals($contactid, $membership['values'][$this->_membershipID]['contact_id']);
+
+    // cleanup
+    $this->callAPISuccess('Membership', 'Delete', array(
+      'id' => $this->_membershipID,
+    ));
+  }
+
+  /**
+   * Test Membership.Get API with State ID filter
+   */
+  public function testGetByStateID() {
+
+    $contactid = $this->individualCreate();
+    $address = $this->callAPISuccess('Address', 'create', array(
+      'contact_id'        => $contactid,
+      'location_type_id'  => 'Home',
+      'state_province_id' => 'Australian Capital Territory',
+      'country_id'        => "AU",
+    ));
+
+    $address = $address["values"][$address["id"]];
+    $this->_params["contact_id"] = $contactid;
+    $this->_membershipID = $this->contactMembershipCreate($this->_params);
+
+    $membership = $this->callAPISuccess('membership', 'get', array(
+      'contact_id.state_province_id' => $address["state_province_id"],
+    ));
+
+    $this->assertEquals(1, $membership['count']);
+    $this->assertEquals($contactid, $membership['values'][$this->_membershipID]['contact_id']);
+
+    // cleanup
+    $this->callAPISuccess('Membership', 'Delete', array(
+      'id' => $this->_membershipID,
+    ));
+  }
+  /**
+   * Test Membership.Get API with group ID filter
+   */
+  public function testGetByGroupID() {
+    $this->_membershipID = $this->contactMembershipCreate($this->_params);
+
+    // Create group and add contact ID used in membership create
+    $groupName = uniqid();
+    $groupID = $this->groupCreate(array(
+      'name' => $groupName,
+      'title' => 'whatever',
+    ));
+    $this->callAPISuccess('GroupContact', 'create', array(
+      'group_id' => $groupID,
+      'contact_id' => $this->_contactID,
+      'status' => 'Added',
+    ));
+    // Search by Group name
+    $membership = $this->callAPISuccess('membership', 'get', array(
+      'contact_id.group' => $groupName,
+    ));
+    $this->assertEquals(1, $membership['count']);
+    $this->assertEquals($this->_contactID, $membership['values'][$this->_membershipID]['contact_id']);
+
+    // cleanup
+    $this->callAPISuccess('Membership', 'Delete', array(
+      'id' => $this->_membershipID,
+    ));
+  }
+
+  /**
+   * Test Membership.Get API with group ID filter
+   */
+  public function testGetByTag() {
+    $this->_membershipID = $this->contactMembershipCreate($this->_params);
+
+    // Create group and add contact ID used in membership create
+    $tagName = uniqid();
+    $tag = $this->tagCreate(array(
+      'name' => $tagName,
+      'used_for' => 'civicrm_contact',
+    ));
+    $this->callAPISuccess('EntityTag', 'create', array(
+      'entity_table' => 'civicrm_contact',
+      'entity_id' => $this->_contactID,
+      'tag_id' => $tag['id'],
+    ));
+    $membership = $this->callAPISuccess('membership', 'get', array(
+      'contact_id.tag' => $tagName,
+    ));
+    $this->assertEquals(1, $membership['count']);
+    $this->assertEquals($this->_contactID, $membership['values'][$this->_membershipID]['contact_id']);
+
+    // cleanup
+    $this->callAPISuccess('Membership', 'Delete', array(
+      'id' => $this->_membershipID,
+    ));
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
When using the CiviCRM API and Membership get with join on Contact, filtering on Group/Tag/Country/State returns incorrect results. Join Parameter filters are ignored.

Before
----------------------------------------
The join parameters were getting ignored and API were returning incorrect results.

After
----------------------------------------
It is now working as expected. Memberships get filtered based on Group/Tag/Country/State.

This PR is based on existing PR https://github.com/civicrm/civicrm-core/pull/10684 and just adds country and state supports in it along with unit tests. So the commits from previous PR(https://github.com/civicrm/civicrm-core/pull/10684) is in in this PR.

_Agileware Ref: CIVICRM-553_

---

 * [CRM-20870: CIVICRM-209 CiviCRM API - Membership get with join on Contact with Group parameter returns incorrect results. Group parameter is ignored](https://issues.civicrm.org/jira/browse/CRM-20870)
 * [CRM-20977: CIVICRM-233 CiviCRM API - Membership get with join on Contact, filtering on Primary Address returns incorrect results. Primary Address filter is ignored](https://issues.civicrm.org/jira/browse/CRM-20977)