### PR TITLE
CRM-21272: move definition of isPasswordUserGenerated to CMS classes

### DIFF
--- a/CRM/Core/BAO/CMSUser.php
+++ b/CRM/Core/BAO/CMSUser.php
@@ -127,7 +127,7 @@ class CRM_Core_BAO_CMSUser {
         $form->assign('isCMS', $required);
         if (!$userID || $action & CRM_Core_Action::PREVIEW || $action & CRM_Core_Action::PROFILE) {
           $form->add('text', 'cms_name', ts('Username'), NULL, $required);
-          if (($isDrupal && !variable_get('user_email_verification', TRUE)) OR ($isJoomla) OR ($isWordPress)) {
+          if ($config->userSystem->isPasswordUserGenerated()) {
             $form->add('password', 'cms_pass', ts('Password'));
             $form->add('password', 'cms_confirm_pass', ts('Confirm Password'));
           }
@@ -197,7 +197,7 @@ class CRM_Core_BAO_CMSUser {
         $errors[$emailName] = ts('Please specify a valid email address.');
       }
 
-      if (($isDrupal && !variable_get('user_email_verification', TRUE)) OR ($isJoomla) OR ($isWordPress)) {
+      if ($config->userSystem->isPasswordUserGenerated()) {
         if (empty($fields['cms_pass']) ||
           empty($fields['cms_confirm_pass'])
         ) {

--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -425,7 +425,7 @@ AND    u.status = 1
   /**
    * @inheritDoc
    */
-  function isPasswordUserGenerated() {
+  public function isPasswordUserGenerated() {
     if (config_get('system.core', 'user_email_verification') == TRUE) {
       return FALSE;
     }

--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -425,6 +425,16 @@ AND    u.status = 1
   /**
    * @inheritDoc
    */
+  function isPasswordUserGenerated() {
+    if (config_get('system.core', 'user_email_verification') == TRUE) {
+      return FALSE;
+    }
+    return TRUE;
+  }
+
+  /**
+   * @inheritDoc
+   */
   public function getUFLocale() {
     // return CiviCRM’s xx_YY locale that either matches Backdrop’s Chinese locale
     // (for CRM-6281), Backdrop’s xx_YY or is retrieved based on Backdrop’s xx

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -405,6 +405,15 @@ abstract class CRM_Utils_System_Base {
   }
 
   /**
+   * Check if user can create passwords or is initially assigned a system-generated one.
+   *
+   * @return bool
+   */
+  function isPasswordUserGenerated() {
+    return FALSE;
+  }
+
+  /**
    * Get user login URL for hosting CMS (method declared in each CMS system class)
    *
    * @param string $destination

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -409,7 +409,7 @@ abstract class CRM_Utils_System_Base {
    *
    * @return bool
    */
-  function isPasswordUserGenerated() {
+  public function isPasswordUserGenerated() {
     return FALSE;
   }
 

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -539,7 +539,7 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
   /**
    * @inheritDoc
    */
-  function isPasswordUserGenerated() {
+  public function isPasswordUserGenerated() {
     if (\Drupal::config('user.settings')->get('verify_mail') == TRUE) {
       return FALSE;
     }

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -539,6 +539,16 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
   /**
    * @inheritDoc
    */
+  function isPasswordUserGenerated() {
+    if (\Drupal::config('user.settings')->get('verify_mail') == TRUE) {
+      return FALSE;
+    }
+    return TRUE;
+  }
+
+  /**
+   * @inheritDoc
+   */
   public function getLoggedInUfID() {
     if ($id = \Drupal::currentUser()->id()) {
       return $id;

--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -427,6 +427,16 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
   /**
    * @inheritDoc
    */
+  function isPasswordUserGenerated() {
+    if (variable_get('user_email_verification', TRUE)) {
+      return FALSE;
+    }
+    return TRUE;
+  }
+
+  /**
+   * @inheritDoc
+   */
   public function updateCategories() {
     // copied this from profile.module. Seems a bit inefficient, but i don't know a better way
     cache_clear_all();
@@ -653,5 +663,4 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
       }
     }
   }
-
 }

--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -427,7 +427,7 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
   /**
    * @inheritDoc
    */
-  function isPasswordUserGenerated() {
+  public function isPasswordUserGenerated() {
     if (variable_get('user_email_verification', TRUE)) {
       return FALSE;
     }
@@ -663,4 +663,5 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
       }
     }
   }
+
 }

--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -592,7 +592,7 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
   /**
    * @inheritDoc
    */
-  function isPasswordUserGenerated() {
+  public function isPasswordUserGenerated() {
     return TRUE;
   }
 

--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -592,6 +592,13 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
   /**
    * @inheritDoc
    */
+  function isPasswordUserGenerated() {
+    return TRUE;
+  }
+
+  /**
+   * @inheritDoc
+   */
   public function getLoggedInUfID() {
     $user = JFactory::getUser();
     return ($user->guest) ? NULL : $user->id;

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -620,6 +620,13 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
   }
 
   /**
+   * @inheritDoc
+   */
+  function isPasswordUserGenerated() {
+    return TRUE;
+  }
+
+  /**
    * @return mixed
    */
   public function getLoggedInUserObject() {

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -622,7 +622,7 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
   /**
    * @inheritDoc
    */
-  function isPasswordUserGenerated() {
+  public function isPasswordUserGenerated() {
     return TRUE;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Follow-up to https://github.com/civicrm/civicrm-core/pull/11079 -- ensuring CMS logic in CMSUser.php is in CMS classes to keep it clean and extendable.

---

 * [CRM-21272: CMSUser has Drupal 6\/7 code that breaks when using with Drupal 8](https://issues.civicrm.org/jira/browse/CRM-21272)