### PR TITLE
Fix for CRM-21319

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -355,7 +355,7 @@
     }
     else {
       cj('#recurHelp').hide();
-      cj('#amount_sum_label').text('{/literal}{ts escape='js'}Total amount{/ts}{literal}');
+      cj('#amount_sum_label').text('{/literal}{ts escape='js'}Total Amount{/ts}{literal}');
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
When a contribution page is generated for another language the Total Amount is not translated.

Before
----------------------------------------
Total amount is not translated

After
----------------------------------------
Total amount is translated

Technical Details
----------------------------------------
In Main.tpl the total amount is adapted by a toggleRecur() javascript function. In this function "Total amount" is written in different cases as in the normal smarty templates.
 
Fix: change case

---

 * [CRM-21319: Total Amount not translated on Contribution Page](https://issues.civicrm.org/jira/browse/CRM-21319)