### PR TITLE
CRM-21321 - Membership fields not loading in 'On behalf of' profile

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -938,6 +938,9 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
         }
 
         $fieldTypes = array('Contact', 'Organization');
+        if (!empty($form->_membershipBlock)) {
+          $fieldTypes = array_merge($fieldTypes, array('Membership'));
+        }
         $contactSubType = CRM_Contact_BAO_ContactType::subTypes('Organization');
         $fieldTypes = array_merge($fieldTypes, $contactSubType);
 


### PR DESCRIPTION
Overview
----------------------------------------
Membership fields not loading in 'On behalf of' profile

Before
----------------------------------------
![behalf_before](https://user-images.githubusercontent.com/3455173/31667546-60ba1ea8-b36d-11e7-8f8a-7c0e2851fc20.png)


After
----------------------------------------
![membership_behalf](https://user-images.githubusercontent.com/3455173/31667447-1e4498f0-b36d-11e7-8927-91ad2d4f917b.png)

---

 * [CRM-21321: Membership fields not loading in 'On behalf of' profile](https://issues.civicrm.org/jira/browse/CRM-21321)