### PR TITLE
CRM-21325 - Cannot add membership fields to on behalf profile

### DIFF
--- a/CRM/UF/Form/Field.php
+++ b/CRM/UF/Form/Field.php
@@ -600,7 +600,7 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
    * @param array $errors
    *   List of errors to be posted back to the form.
    */
-  public static function formRuleSubType($fieldType, $groupType, &$errors) {
+  public static function formRuleSubType($fieldType, $groupType, &$errors, $self) {
     if (in_array($fieldType, array(
       'Participant',
       'Contribution',
@@ -620,7 +620,16 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
             'Formatting',
           ))
         ) {
-          $errors['field_name'] = ts('Cannot add or update profile field "%1" with combination of Household or Organization or any subtypes of Household or Organization.', array(1 => $fieldType));
+          $flag = TRUE;
+          $onbehalf = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_UFJoin', $self->_gid, 'module', 'uf_group_id');
+          //special case where in we allow membership/contribution + organization fields, for on behalf feature
+          if ($onbehalf == 'on_behalf' && $value == 'Organization' && in_array($fieldType, array('Membership', 'Contribution'))) {
+            $flag = FALSE;
+          }
+
+          if ($flag) {
+            $errors['field_name'] = ts('Cannot add or update profile field "%1" with combination of Household or Organization or any subtypes of Household or Organization.', array(1 => $fieldType));
+          }
           break;
         }
       }
@@ -844,7 +853,7 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
 
     switch ($fieldType) {
       case 'Contact':
-        self::formRuleSubType($fieldType, $groupType, $errors);
+        self::formRuleSubType($fieldType, $groupType, $errors, $self);
         break;
 
       case 'Individual':
@@ -863,7 +872,7 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
           }
         }
         else {
-          self::formRuleSubType($fieldType, $groupType, $errors);
+          self::formRuleSubType($fieldType, $groupType, $errors, $self);
         }
         break;
 
@@ -872,7 +881,7 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
           $errors['field_name'] = ts('Cannot add or update profile field type Household with combination of Individual or Organization or Activity');
         }
         else {
-          self::formRuleSubType($fieldType, $groupType, $errors);
+          self::formRuleSubType($fieldType, $groupType, $errors, $self);
         }
         break;
 
@@ -881,7 +890,7 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
           $errors['field_name'] = ts('Cannot add or update profile field type Organization with combination of Household or Individual or Activity');
         }
         else {
-          self::formRuleSubType($fieldType, $groupType, $errors);
+          self::formRuleSubType($fieldType, $groupType, $errors, $self);
         }
         break;
 
@@ -905,7 +914,7 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
           }
         }
         else {
-          self::formRuleSubType($fieldType, $groupType, $errors);
+          self::formRuleSubType($fieldType, $groupType, $errors, $self);
         }
 
         if ($isCustomField && !isset($errors['field_name'])) {
@@ -920,39 +929,34 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
           $errors['field_name'] = ts('Cannot add or update profile field type Participant with combination of Activity or Membership or Contribution or Household or Organization.');
         }
         else {
-          self::formRuleSubType($fieldType, $groupType, $errors);
+          self::formRuleSubType($fieldType, $groupType, $errors, $self);
         }
         break;
 
       case 'Contribution':
-        //special case where in we allow contribution + oganization fields, for on behalf feature
-        $profileId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_UFGroup',
-          'on_behalf_organization', 'id', 'name'
-        );
+        //special case where in we allow contribution + organization fields, for on behalf feature
+        $onbehalf = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_UFJoin', $self->_gid, 'module', 'uf_group_id');
 
         if (in_array('Participant', $groupType) || in_array('Membership', $groupType)
-          || ($profileId != $self->_gid && in_array('Organization', $groupType)) || in_array('Household', $groupType) || in_array('Activity', $groupType)
+          || ($onbehalf != 'on_behalf' && in_array('Organization', $groupType)) || in_array('Household', $groupType) || in_array('Activity', $groupType)
         ) {
           $errors['field_name'] = ts('Cannot add or update profile field type Contribution with combination of Activity or Membership or Participant or Household or Organization');
         }
         else {
-          self::formRuleSubType($fieldType, $groupType, $errors);
+          self::formRuleSubType($fieldType, $groupType, $errors, $self);
         }
         break;
 
       case 'Membership':
-        //special case where in we allow contribution + oganization fields, for on behalf feature
-        $profileId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_UFGroup',
-          'on_behalf_organization', 'id', 'name'
-        );
-
+        //special case where in we allow membership + organization fields, for on behalf feature
+        $onbehalf = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_UFJoin', $self->_gid, 'module', 'uf_group_id');
         if (in_array('Participant', $groupType) || in_array('Contribution', $groupType)
-          || ($profileId != $self->_gid && in_array('Organization', $groupType)) || in_array('Household', $groupType) || in_array('Activity', $groupType)
+          || ($onbehalf != 'on_behalf' && in_array('Organization', $groupType)) || in_array('Household', $groupType) || in_array('Activity', $groupType)
         ) {
           $errors['field_name'] = ts('Cannot add or update profile field type Membership with combination of Activity or Participant or Contribution or Household or Organization');
         }
         else {
-          self::formRuleSubType($fieldType, $groupType, $errors);
+          self::formRuleSubType($fieldType, $groupType, $errors, $self);
         }
         break;
 


### PR DESCRIPTION
Overview
----------------------------------------
Cannot add membership fields to on behalf profile
The code says that it needs to make special expection for allowing membership + organization fields for on behalf feature but does NOT handle properly. Also check for behalf profile is flawed.

Before
----------------------------------------
![membership_custom_error](https://user-images.githubusercontent.com/3455173/31703268-8a4910e4-b3f9-11e7-9d75-290626999629.png)


After
----------------------------------------
![membership_behalf_profile](https://user-images.githubusercontent.com/3455173/31703300-acd253aa-b3f9-11e7-92ed-83d5e59416a9.png)

---

 * [CRM-21325: Cannot add membership fields to on behalf profile](https://issues.civicrm.org/jira/browse/CRM-21325)