### PR TITLE
CRM-21324 - Support 'null' on date fields in the api

### DIFF
--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -1685,6 +1685,12 @@ function _civicrm_api3_validate_date(&$params, &$fieldName, &$fieldInfo) {
   if (strpos($op, 'NULL') !== FALSE || strpos($op, 'EMPTY') !== FALSE) {
     return;
   }
+
+  if ($fieldValue === 'null' && empty($fieldInfo['api.required'])) {
+    // This is the wierd & wonderful way PEAR sets null.
+    return;
+  }
+
   //should we check first to prevent it from being copied if they have passed in sql friendly format?
   if (!empty($params[$fieldInfo['name']])) {
     $fieldValue = _civicrm_api3_getValidDate($fieldValue, $fieldInfo['name'], $fieldInfo['type']);

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -681,6 +681,23 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
   /**
    * Create test with unique field name on source.
    */
+  public function testCreateContributionNullOutThankyouDate() {
+
+    $params = $this->_params;
+    $params['thankyou_date'] = 'yesterday';
+
+    $contribution = $this->callAPISuccess('contribution', 'create', $params);
+    $contribution = $this->callAPISuccessGetSingle('contribution', array('id' => $contribution['id']));
+    $this->assertEquals(date('Y-m-d', strtotime('yesterday')), date('Y-m-d', strtotime($contribution['thankyou_date'])));
+
+    $params['thankyou_date'] = 'null';
+    $contribution = $this->callAPISuccess('contribution', 'create', $params);
+    $contribution = $this->assertTrue(empty($contribution['thankyou_date']));
+  }
+
+  /**
+   * Create test with unique field name on source.
+   */
   public function testCreateContributionSourceInvalidContact() {
 
     $params = array(


### PR DESCRIPTION
Overview
----------------------------------------
Fixes api to allow setting 'null' on datefields as per other field types

Before
----------------------------------------
setting a field to 'null' via the api sets it to NULL on non-date fields but errors out on a datefield

After
----------------------------------------
Date fields are the same as other fields

Technical Details
----------------------------------------
Replicated in unit test

---

 * [CRM-21324: Support 'null' on date fields in the api](https://issues.civicrm.org/jira/browse/CRM-21324)