### PR TITLE
CRM-21327 - Not able to change Payment Processor in event fees

### DIFF
--- a/CRM/Event/Form/ManageEvent/Fee.php
+++ b/CRM/Event/Form/ManageEvent/Fee.php
@@ -228,12 +228,12 @@ class CRM_Event_Form_ManageEvent_Fee extends CRM_Event_Form_ManageEvent {
     }
     $this->_showHide->addToTemplate();
     $this->assign('inDate', $this->_inDate);
-
     if (!empty($defaults['payment_processor'])) {
-      $defaults['payment_processor'] = str_replace(CRM_Core_DAO::VALUE_SEPARATOR, ',',
+      $defaults['payment_processor'] = array_fill_keys(explode(CRM_Core_DAO::VALUE_SEPARATOR,
         $defaults['payment_processor']
-      );
+      ), '1');
     }
+
     return $defaults;
   }
 
@@ -255,15 +255,11 @@ class CRM_Event_Form_ManageEvent_Fee extends CRM_Event_Form_ManageEvent {
     $paymentProcessor = CRM_Core_PseudoConstant::paymentProcessor();
 
     $this->assign('paymentProcessor', $paymentProcessor);
-
-    $this->addEntityRef('payment_processor', ts('Payment Processor'), array(
-      'entity' => 'PaymentProcessor',
-      'multiple' => TRUE,
-      'api' => array(
-        'params' => array('domain_id' => CRM_Core_Config::domainID()),
-      ),
-      'select' => array('minimumInputLength' => 0),
-    ));
+    $this->addCheckBox('payment_processor', ts('Payment Processor'),
+      array_flip($paymentProcessor),
+      NULL, NULL, NULL, NULL,
+      array('&nbsp;&nbsp;', '&nbsp;&nbsp;', '&nbsp;&nbsp;', '<br/>')
+    );
 
     // financial type
     if (!CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus() ||
@@ -564,7 +560,7 @@ class CRM_Event_Form_ManageEvent_Fee extends CRM_Event_Form_ManageEvent {
     }
 
     if (!empty($params['payment_processor'])) {
-      $params['payment_processor'] = str_replace(',', CRM_Core_DAO::VALUE_SEPARATOR, $params['payment_processor']);
+      $params['payment_processor'] = implode(CRM_Core_DAO::VALUE_SEPARATOR, array_keys($params['payment_processor']));
     }
     else {
       $params['payment_processor'] = 'null';


### PR DESCRIPTION
Overview
----------------------------------------

Steps to replicate :

1. Create a user with permission to edit all events but do NOT give administer CiviCRM
2. Login with this user and go to Fee page of Event.
3. Try to change Payment Processor, it does NOT list any of the payment processors.
Let's try to keep it consistent with contribution pages.


Before
----------------------------------------
![payment_processor](https://user-images.githubusercontent.com/3455173/31711298-49232fde-b415-11e7-91b8-947a755ee126.png)

After
----------------------------------------
![payment_processor_after](https://user-images.githubusercontent.com/3455173/31711309-4f2f4dae-b415-11e7-8e68-7eaa4285fec6.png)

---

 * [CRM-21327: Not able to change Payment Processor in event fees](https://issues.civicrm.org/jira/browse/CRM-21327)