### PR TITLE
CRM-21329 - fix the description sent to the payment processor to resp…

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1088,7 +1088,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     // CRM_Price_BAO_PriceSet::processAmount. Extend the unit tests in CRM_Price_BAO_PriceSetTest
     // to cover all variants.
     $this->_params['amount_level'] = 0;
-    $this->_params['description'] = ts("Contribution submitted by a staff person using contributor's credit card");
+    $this->_params['description'] = $this->_params['source'] ? $this->_params['source'] : ts("Contribution submitted by a staff person using contributor's credit card");
     $this->_params['currencyID'] = CRM_Utils_Array::value('currency',
       $this->_params,
       CRM_Core_Config::singleton()->defaultCurrency


### PR DESCRIPTION
…ect contribution source

Overview
----------------------------------------
If you Submit Credit Card Contribution from backoffice and enter Source as well, the payment processor notification ignores that in the description instead has a standard text which is confusing to the users.

Before
----------------------------------------

![payment_processor_receipt](https://user-images.githubusercontent.com/3455173/31715799-cb32bd70-b422-11e7-8452-bb997288ab0b.png)
