### PR TITLE
CRM-20078 - Fix activity file on case button

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -242,7 +242,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
       if (CRM_Contact_Form_Search::isSearchContext($this->_context)) {
         $this->_context = 'search';
       }
-      elseif (!in_array($this->_context, array('dashlet', 'dashletFullscreen'))
+      elseif (!in_array($this->_context, array('dashlet', 'case', 'dashletFullscreen'))
         && $this->_currentlyViewedContactId
       ) {
         $this->_context = 'activity';

--- a/CRM/Case/Form/ActivityToCase.php
+++ b/CRM/Case/Form/ActivityToCase.php
@@ -67,6 +67,12 @@ class CRM_Case_Form_ActivityToCase extends CRM_Core_Form {
 
     // If this contact has an open case, supply it as a default
     $cid = CRM_Utils_Request::retrieve('cid', 'Integer');
+    if (!$cid) {
+      $act = civicrm_api3('Activity', 'getsingle', array('id' => $this->_activityId, 'return' => 'target_contact_id'));
+      if (!empty($act['target_contact_id'])) {
+        $cid = $act['target_contact_id'][0];
+      }
+    }
     if ($cid) {
       $cases = civicrm_api3('CaseContact', 'get', array(
         'contact_id' => $cid,

--- a/templates/CRM/Activity/Form/Activity.tpl
+++ b/templates/CRM/Activity/Form/Activity.tpl
@@ -265,13 +265,13 @@
       <a href="{crmURL p='civicrm/contact/view/activity' q=$urlParams}" class="delete button" title="{ts}Delete{/ts}"><span><i class="crm-i fa-trash"></i> {ts}Delete{/ts}</span></a>
     {/if}
   {/if}
-  {if $action eq 4 and call_user_func(array('CRM_Case_BAO_Case','checkPermission'), $activityId, 'File On Case', $atype)}
+  {if $action eq 4 and $context != 'case' and call_user_func(array('CRM_Case_BAO_Case','checkPermission'), $activityId, 'File On Case', $atype)}
     <a href="#" onclick="fileOnCase('file', {$activityId}, null, this); return false;" class="cancel button" title="{ts}File On Case{/ts}"><span><i class="crm-i fa-clipboard"></i> {ts}File on Case{/ts}</span></a>
+    {include file="CRM/Case/Form/ActivityToCase.tpl"}
   {/if}
   {include file="CRM/common/formButtons.tpl" location="bottom"}
   </div>
 
-  {include file="CRM/Case/Form/ActivityToCase.tpl"}
 
   {if $action eq 1 or $action eq 2 or $context eq 'search' or $context eq 'smog'}
   {*include custom data js file*}


### PR DESCRIPTION
* Hides the "File on case" button when the activity is being viewed in the context of a case. 
* Fixes the default value of the case input when filing on a case (picks an open case for the activity target contact if available)
* Tidies up the template to not add a bunch of unneeded JS in other contexts.

* [CRM-20078: Activity card - General](https://issues.civicrm.org/jira/browse/CRM-20078)