### PR TITLE
CRM-20787: For a repeating Event series. Changing price set of main event, it should be copied to all repeating events if we select 'Every event' mode.

### DIFF
--- a/CRM/Core/BAO/RecurringEntity.php
+++ b/CRM/Core/BAO/RecurringEntity.php
@@ -1179,4 +1179,64 @@ class CRM_Core_BAO_RecurringEntity extends CRM_Core_DAO_RecurringEntity {
     return $result;
   }
 
+  /**
+   * Update mode in civicrm_recurring_entity table for event related data and price set in civicrm_price_set_entity.
+   *
+   * @param int $entityId
+   *   Event id .
+   * @param string $entityTable
+   * @param string $mode
+   * @param string $linkedEntityTable
+   *   Linked entity table name for this event .
+   * @param string $priceSet
+   *   Price set of the event .
+   *
+   * @return array
+   */
+  public static function updateModeAndPriceSet($entityId, $entityTable, $mode, $linkedEntityTable, $priceSet) {
+    $finalResult = array();
+
+    if (!empty($linkedEntityTable)) {
+      $result = CRM_Core_BAO_RecurringEntity::updateModeLinkedEntity($entityId, $linkedEntityTable, $entityTable);
+    }
+
+    $dao = new CRM_Core_DAO_RecurringEntity();
+    if (!empty($result)) {
+      $dao->entity_id = $result['entityId'];
+      $dao->entity_table = $result['entityTable'];
+    }
+    else {
+      $dao->entity_id = $entityId;
+      $dao->entity_table = $entityTable;
+    }
+
+    if ($dao->find(TRUE)) {
+      $dao->mode = $mode;
+      $dao->save();
+
+      //CRM-20787 Fix
+      //I am not sure about other fields, if mode = 3 apply for an event then other fields
+      //should be save for all other series events or not so applying for price set only for now here.
+      if (CRM_Core_BAO_RecurringEntity::MODE_ALL_ENTITY_IN_SERIES === $mode) {
+
+        //Step-1: Get all events of series
+        $seriesEventRecords = CRM_Core_BAO_RecurringEntity::getEntitiesFor($entityId, $entityTable);
+        foreach ($seriesEventRecords as $event) {
+          //Step-3: Save price set in other series events
+          if (CRM_Price_BAO_PriceSet::removeFrom($event['table'], $event['id'])) {//Remove existing priceset
+            CRM_Core_BAO_Discount::del($event['id'], $event['table']);
+            CRM_Price_BAO_PriceSet::addTo($event['table'], $event['id'], $priceSet); //Add new price set
+          }
+        }
+      }
+      //CRM-20787 - Fix end
+      $finalResult['status'] = 'Done';
+    }
+    else {
+      $finalResult['status'] = 'Error';
+    }
+
+    return $finalResult;
+  }
+
 }

--- a/CRM/Core/BAO/RecurringEntity.php
+++ b/CRM/Core/BAO/RecurringEntity.php
@@ -126,6 +126,11 @@ class CRM_Core_BAO_RecurringEntity extends CRM_Core_DAO_RecurringEntity {
       ),
     );
 
+  //Define global CLASS CONSTANTS for recurring entity mode types
+  const MODE_THIS_ENTITY_ONLY = 1;
+  const MODE_NEXT_ALL_ENTITY = 2;
+  const MODE_ALL_ENTITY_IN_SERIES = 3;
+
   /**
    * Getter for status.
    *

--- a/CRM/Core/Page/AJAX/RecurringEntity.php
+++ b/CRM/Core/Page/AJAX/RecurringEntity.php
@@ -20,46 +20,8 @@ class CRM_Core_Page_AJAX_RecurringEntity {
       $entityId = CRM_Utils_Type::escape($_REQUEST['entityId'], 'Integer');
       $entityTable = CRM_Utils_Type::escape($_REQUEST['entityTable'], 'String');
       $priceSet = CRM_Utils_Type::escape($_REQUEST['priceSet'], 'String');
-
-      if (!empty($_REQUEST['linkedEntityTable'])) {
-        $result = CRM_Core_BAO_RecurringEntity::updateModeLinkedEntity($entityId, $_REQUEST['linkedEntityTable'], $entityTable);
-      }
-
-      $dao = new CRM_Core_DAO_RecurringEntity();
-      if (!empty($result)) {
-        $dao->entity_id = $result['entityId'];
-        $dao->entity_table = $result['entityTable'];
-      }
-      else {
-        $dao->entity_id = $entityId;
-        $dao->entity_table = $entityTable;
-      }
-
-      if ($dao->find(TRUE)) {
-        $dao->mode = $mode;
-        $dao->save();
-
-        //CRM-20787 Fix
-        //I am not sure about other fields, if mode = 3 apply for an event then other fields
-        //should be save for all other series events or not so applying for price set only for now here.
-        if (CRM_Core_BAO_RecurringEntity::MODE_ALL_ENTITY_IN_SERIES === $mode) {
-
-          //Step-1: Get all events of series
-          $seriesEventRecords = CRM_Core_BAO_RecurringEntity::getEntitiesFor($entityId, $entityTable);
-          foreach ($seriesEventRecords as $event) {
-            //Step-3: Save price set in other series events
-            if (CRM_Price_BAO_PriceSet::removeFrom($event['table'], $event['id'])) {//Remove existing priceset
-              CRM_Core_BAO_Discount::del($event['id'], $event['table']);
-              CRM_Price_BAO_PriceSet::addTo($event['table'], $event['id'], $priceSet); //Add new price set
-            }
-          }
-        }
-        //CRM-20787 - Fix end
-        $finalResult['status'] = 'Done';
-      }
-      else {
-        $finalResult['status'] = 'Error';
-      }
+      $linkedEntityTable = $_REQUEST['linkedEntityTable'];
+      $finalResult = CRM_Core_BAO_RecurringEntity::updateModeAndPriceSet($entityId, $entityTable, $mode, $linkedEntityTable, $priceSet);
     }
     CRM_Utils_JSON::output($finalResult);
   }

--- a/CRM/Core/Page/AJAX/RecurringEntity.php
+++ b/CRM/Core/Page/AJAX/RecurringEntity.php
@@ -14,11 +14,12 @@ class CRM_Core_Page_AJAX_RecurringEntity {
 
   public static function updateMode() {
     $finalResult = array();
-    if (CRM_Utils_Array::value('mode', $_REQUEST) && CRM_Utils_Array::value('entityId', $_REQUEST) && CRM_Utils_Array::value('entityTable', $_REQUEST)) {
+    if (CRM_Utils_Array::value('mode', $_REQUEST) && CRM_Utils_Array::value('entityId', $_REQUEST) && CRM_Utils_Array::value('entityTable', $_REQUEST) && CRM_Utils_Array::value('priceSet', $_REQUEST)) {
 
       $mode = CRM_Utils_Type::escape($_REQUEST['mode'], 'Integer');
       $entityId = CRM_Utils_Type::escape($_REQUEST['entityId'], 'Integer');
       $entityTable = CRM_Utils_Type::escape($_REQUEST['entityTable'], 'String');
+      $priceSet = CRM_Utils_Type::escape($_REQUEST['priceSet'], 'String');
 
       if (!empty($_REQUEST['linkedEntityTable'])) {
         $result = CRM_Core_BAO_RecurringEntity::updateModeLinkedEntity($entityId, $_REQUEST['linkedEntityTable'], $entityTable);
@@ -42,18 +43,16 @@ class CRM_Core_Page_AJAX_RecurringEntity {
         //I am not sure about other fields, if mode = 3 apply for an event then other fields
         //should be save for all other series events or not so applying for price set only for now here.
         if (CRM_Core_BAO_RecurringEntity::MODE_ALL_ENTITY_IN_SERIES === $mode) {
-            //Step-1: Get Price set for parent event
-            $currentEventPriceSet = CRM_Price_BAO_PriceSet::getPriceSetOfEntity($entityTable, $entityId);
 
-            //Step-2: Get all events of series
-            $seriesEventRecords = CRM_Core_BAO_RecurringEntity::getEntitiesFor($entityId, $entityTable);
-            foreach($seriesEventRecords as $event) {
-                //Step-3: Save price set in other series events
-                if (CRM_Price_BAO_PriceSet::removeFrom($event['table'], $event['id'])) { //Remove existing priceset
-                    CRM_Core_BAO_Discount::del($event['id'], $event['table']);
-                    CRM_Price_BAO_PriceSet::addTo($event['table'], $event['id'], $currentEventPriceSet['price_set_id']); //Add new price set
-                }
+          //Step-1: Get all events of series
+          $seriesEventRecords = CRM_Core_BAO_RecurringEntity::getEntitiesFor($entityId, $entityTable);
+          foreach ($seriesEventRecords as $event) {
+            //Step-3: Save price set in other series events
+            if (CRM_Price_BAO_PriceSet::removeFrom($event['table'], $event['id'])) {//Remove existing priceset
+              CRM_Core_BAO_Discount::del($event['id'], $event['table']);
+              CRM_Price_BAO_PriceSet::addTo($event['table'], $event['id'], $priceSet); //Add new price set
             }
+          }
         }
         //CRM-20787 - Fix end
         $finalResult['status'] = 'Done';

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -274,25 +274,6 @@ WHERE     cpf.price_set_id = %1";
   }
 
   /**
-    * Get price set for the given entity and id.
-    *
-    * @param string $entityTable
-    * @param int $entityId
-    *
-    * @return mixed
-    */
-  public static function getPriceSetOfEntity($entityTable, $entityId) {
-      $dao = new CRM_Price_DAO_PriceSetEntity();
-      $dao->entity_id = $entityId;
-      $dao->entity_table = $entityTable;
-      if ($dao->find(TRUE)) {
-          $entities['table'] = $dao->entity_table;
-          $entities['id'] = $dao->entity_id;
-          $entities['price_set_id'] = $dao->price_set_id;
-      }
-      return $entities;
-  }
-  /**
    * Delete price set for the given entity and id.
    *
    * @param string $entityTable

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -274,6 +274,25 @@ WHERE     cpf.price_set_id = %1";
   }
 
   /**
+    * Get price set for the given entity and id.
+    *
+    * @param string $entityTable
+    * @param int $entityId
+    *
+    * @return mixed
+    */
+  public static function getPriceSetOfEntity($entityTable, $entityId) {
+      $dao = new CRM_Price_DAO_PriceSetEntity();
+      $dao->entity_id = $entityId;
+      $dao->entity_table = $entityTable;
+      if ($dao->find(TRUE)) {
+          $entities['table'] = $dao->entity_table;
+          $entities['id'] = $dao->entity_id;
+          $entities['price_set_id'] = $dao->price_set_id;
+      }
+      return $entities;
+  }
+  /**
    * Delete price set for the given entity and id.
    *
    * @param string $entityTable

--- a/templates/CRM/Event/Form/ManageEvent/ConfirmRepeatMode.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/ConfirmRepeatMode.tpl
@@ -89,10 +89,11 @@
       function updateMode() {
         var mode = $('input[name=recur_mode]:checked', this).val(),
           entityID = parseInt('{/literal}{$entityID}{literal}'),
-          entityTable = '{/literal}{$entityTable}{literal}';
+          entityTable = '{/literal}{$entityTable}{literal}',
+	  priceSet = $('#price_set_id').val();
         if (entityID != "" && mode && mapper.hasOwnProperty(formClass) && entityTable !="") {
           $.getJSON(CRM.url("civicrm/ajax/recurringentity/update-mode",
-              {mode: mode, entityId: entityID, entityTable: entityTable, linkedEntityTable: mapper[formClass]})
+              {mode: mode, entityId: entityID, entityTable: entityTable, linkedEntityTable: mapper[formClass], priceSet: priceSet})
           ).done(function (result) {
               if (result.status != "" && result.status == 'Done') {
                 $form.submit();


### PR DESCRIPTION
Overview
----------------------------------------
For a repeating Event series. If we change the Price Set for a paid Event then this Price Set selection is not applied to all Events in the series even when apply to Every Event is selected.

Steps to reproduce:
1. Create Price set A
2. Create Price set B
1. Create event A with price set A
4. Open event A settings and Repeating tab
5. Create couple of repeating events.
6. Open event A settings and Fees tab
7. Change price set to B and select 'Every Event' mode.

Before
----------------------------------------
Updated price set is not applied to the Repeating events which is unexpected behaviour. 

After
----------------------------------------
It now works as expected. Price set is changed for repeating events too.

_Agileware Ref CIVICRM-152_

---

 * [CRM-20787: CIVICRM-152 For a repeating Event series. If change the Price Set for a paid Event then this Price Set selection is not applied to all Events in the series even when apply to Every Event is selected](https://issues.civicrm.org/jira/browse/CRM-20787)