### PR TITLE
[ON HOLD] CRM-21320 Fix selection of mobile number in mass SMS

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -342,7 +342,8 @@ WHERE  c.group_id = {$groupDAO->id}
                         AND             $phone.phone IS NOT NULL
                         AND             $phone.phone != ''
                         AND             $mg.mailing_id = {$mailing_id}
-                        AND             X_$job_id.contact_id IS null";
+                        AND             X_$job_id.contact_id IS null
+                    ORDER BY $phone.is_primary ASC";
     }
     $mailingGroup->query($query);
 
@@ -396,7 +397,8 @@ WHERE  c.group_id = {$groupDAO->id}
                         AND             $contact.is_deceased <> 1
                         AND             $phone.phone_type_id = {$phoneTypes['Mobile']}
                         AND             $mg.mailing_id = {$mailing_id}
-                        AND             X_$job_id.contact_id IS null";
+                        AND             X_$job_id.contact_id IS null
+                    ORDER BY $phone.is_primary ASC";
     }
     $mailingGroup->query($query);
 
@@ -448,7 +450,8 @@ WHERE      gc.group_id = {$groupDAO->id}
   AND      c.is_opt_out = 0
   AND      c.is_deceased <> 1
   AND      p.phone_type_id = {$phoneTypes['Mobile']}
-  AND      X_$job_id.contact_id IS null";
+  AND      X_$job_id.contact_id IS null
+ORDER BY   p.is_primary ASC";
       }
       $mailingGroup->query($smartGroupInclude);
     }
@@ -520,7 +523,8 @@ AND    $mg.mailing_id = {$mailing_id}
                         AND             $contact.is_deceased <> 1
                         AND             $phone.phone_type_id = {$phoneTypes['Mobile']}
                         AND             $mg.mailing_id = {$mailing_id}
-                        AND             X_$job_id.contact_id IS null";
+                        AND             X_$job_id.contact_id IS null
+                    ORDER BY $phone.is_primary ASC";
     }
     $mailingGroup->query($query);
 

--- a/tests/phpunit/CRM/Mailing/BAO/MailingTest.php
+++ b/tests/phpunit/CRM/Mailing/BAO/MailingTest.php
@@ -1,0 +1,136 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2017                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Class CRM_Mailing_BAO_MailingTest
+ */
+class CRM_Mailing_BAO_MailingTest extends CiviUnitTestCase {
+
+  public function setUp() {
+    parent::setUp();
+  }
+
+  /**
+   * getRecipients test
+   */
+  public function testgetRecipients() {
+
+    // Tests for SMS bulk mailing recipients
+    // +CRM-21320 Ensure primary mobile number is selected over non-primary
+
+    // Setup
+    $group = $this->groupCreate();
+    $sms_provider = $this->callAPISuccess('SmsProvider', 'create', array(
+      'sequential' => 1,
+      'name' => 1,
+      'title' => "Test",
+      'username' => "Test",
+      'password' => "Test",
+      'api_type' => 1,
+      'is_active' => 1,
+    ));
+
+    // Contact 1
+    $contact_1 = $this->individualCreate(array(), 0);
+    $contact_1_primary = $this->callAPISuccess('Phone', 'create', array(
+      'contact_id' => $contact_1,
+      'phone' => "01 01",
+      'location_type_id' => "Home",
+      'phone_type_id' => "Mobile",
+      'is_primary' => 1,
+    ));
+    $contact_1_other = $this->callAPISuccess('Phone', 'create', array(
+      'contact_id' => $contact_1,
+      'phone' => "01 02",
+      'location_type_id' => "Work",
+      'phone_type_id' => "Mobile",
+      'is_primary' => 0,
+    ));
+    $this->callAPISuccess('GroupContact', 'Create', array(
+      'group_id' => $group,
+      'contact_id' => $contact_1,
+    ));
+
+    // Contact 2
+    $contact_2 = $this->individualCreate(array(), 1);
+    $contact_2_other = $this->callAPISuccess('Phone', 'create', array(
+      'contact_id' => $contact_2,
+      'phone' => "02 01",
+      'location_type_id' => "Home",
+      'phone_type_id' => "Mobile",
+      'is_primary' => 0,
+    ));
+    $contact_2_primary = $this->callAPISuccess('Phone', 'create', array(
+      'contact_id' => $contact_2,
+      'phone' => "02 02",
+      'location_type_id' => "Work",
+      'phone_type_id' => "Mobile",
+      'is_primary' => 1,
+    ));
+    $this->callAPISuccess('GroupContact', 'Create', array(
+      'group_id' => $group,
+      'contact_id' => $contact_2,
+    ));
+
+    // Prepare expected results
+    $check_ids = array(
+      $contact_1 => $contact_1_primary['id'],
+      $contact_2 => $contact_2_primary['id'],
+    );
+
+    // Create mailing
+    $mailing = $this->callAPISuccess('Mailing', 'create', array('sms_provider_id' => $sms_provider['id']));
+    $mailing_include_group = $this->callAPISuccess('MailingGroup', 'create', array(
+      'mailing_id' => $mailing['id'],
+      'group_type' => "Include",
+      'entity_table' => "civicrm_group",
+      'entity_id' => $group,
+    ));
+
+    // Populate the recipients table (job id doesn't matter)
+    CRM_Mailing_BAO_Mailing::getRecipients('123', $mailing['id'], TRUE, FALSE, 'sms');
+
+    // Get recipients
+    $recipients = $this->callAPISuccess('MailingRecipients', 'get', array('mailing_id' => $mailing['id']));
+
+    // Check the count is correct
+    $this->assertEquals(2, $recipients['count'], 'Check recipient count');
+
+    // Check we got the 'primary' mobile for both contacts
+    foreach ($recipients['values'] as $value) {
+      $this->assertEquals($value['phone_id'], $check_ids[$value['contact_id']], 'Check correct phone number for contact ' . $value['contact_id']);
+    }
+
+    // Tidy up
+    $this->deleteMailing($mailing['id']);
+    $this->callAPISuccess('SmsProvider', 'Delete', array('id' => $sms_provider['id']));
+    $this->groupDelete($group);
+    $this->contactDelete($contact_1);
+    $this->contactDelete($contact_2);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Fix the logic that selects a contact's phone number when using bulk SMS functionality in CiviCRM.

Before
----------------------------------------
The 'latest' mobile number associated with the contact was selected, regardless of whether the other number is 'primary'.

After
----------------------------------------
The primary mobile number on the contact is selected as a priority.

Technical Details
----------------------------------------

- Add ORDER BY to the phone number selection query, to ensure that primary information is 'preferred'; as already happens with the email selection query.
- Add a test!

Comments
----------------------------------------
This is my first ever test that I've written, please do let me know how to improve it! I was a bit horrified to see that there are no existing tests for the Mailing BAO. And there is a LOT of refactoring that could be done in the getRecipients method. But lets fix the current bugs first...

---

 * [CRM-21320: Mass SMS can select non-preferred mobile number](https://issues.civicrm.org/jira/browse/CRM-21320)