### PR TITLE
CRM-21334: Fire hooks on Contact Image Deletion

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -946,11 +946,12 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
     if (!$id) {
       return FALSE;
     }
-    $query = "
-UPDATE civicrm_contact
-SET image_URL=NULL
-WHERE id={$id}; ";
-    CRM_Core_DAO::executeQuery($query);
+
+    $contact = new self();
+    $contact->id = $id;
+    $contact->image_URL = 'null';
+    $contact->save();
+
     return TRUE;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
When deleting a contact image from the profile overview page the contact image is removed and hooks are fired.

Before
----------------------------------------
No hooks are fired when the contact image is deleted.

After
----------------------------------------
postUpdate and postSave hooks are fired.

---

 * [CRM-21334: Fire hooks on contact image deletion](https://issues.civicrm.org/jira/browse/CRM-21334)