### PR TITLE
CRM-21335: CiviMail recipient field isn't marked as required

### DIFF
--- a/ang/crmUi.js
+++ b/ang/crmUi.js
@@ -256,6 +256,11 @@
           var init = function (retries, retryDelay) {
             var input = $('#' + id);
             if (input.length === 0) {
+              // CRM-21335 : there is no other way to fetch the 'ng-required' property of a subform (here recipients),
+              // so better to provide requiredness on basis of name which is a hackish fix for now.
+              if (attrs.crmUiFor === 'subform.recipients') {
+                scope.crmIsRequired = true;
+              }
               if (retries) {
                 $timeout(function(){
                   init(retries-1, retryDelay);


### PR DESCRIPTION
Overview
----------------------------------------
The recipient field isn't marked as required in CiviMail compose screen

Before
----------------------------------------
![screen shot 2017-10-20 at 1 18 42 am](https://user-images.githubusercontent.com/3735621/31790934-b10b27e4-b534-11e7-8a76-de8ba8dba22a.png)


After
----------------------------------------
![screen shot 2017-10-20 at 1 19 27 am](https://user-images.githubusercontent.com/3735621/31790960-c65a5b56-b534-11e7-873d-977cacb218e3.png)

---

 * [CRM-21335: CiviMail recipient field isn't marked as required](https://issues.civicrm.org/jira/browse/CRM-21335)