### PR TITLE
CRM-21336: Custom file fields should display file name without hash

### DIFF
--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -890,7 +890,7 @@ HTACCESS;
         break;
 
       default:
-        $url = sprintf('<a href="%s">%s</a>', $url, basename($path));
+        $url = sprintf('<a href="%s">%s</a>', $url, self::cleanFileName(basename($path)));
         break;
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Create a custom dataset and add a file type field. Go to the contact and upload a file. Note that in the display, the hash is exposed. The hash should be stripped from the display so that only the original file name is exposed.

Before
----------------------------------------
![screen shot 2017-10-20 at 10 55 34 am](https://user-images.githubusercontent.com/3735621/31806410-40aff686-b585-11e7-8a97-a1dad300bfaa.png)

After
----------------------------------------
![screen shot 2017-10-20 at 10 53 54 am](https://user-images.githubusercontent.com/3735621/31806392-190a07fc-b585-11e7-8745-52f052b57cc4.png)

---

 * [CRM-21336: Custom file fields should display file name without hash](https://issues.civicrm.org/jira/browse/CRM-21336)