### PR TITLE
CRM-21338 Pass through membership ID from search results so it can be used for …

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1528,12 +1528,20 @@ LEFT JOIN civicrm_activity_contact src ON (src.activity_id = ac.activity_id AND 
     }
 
     // get token details for contacts, call only if tokens are used
-    $details = array();
+    $details = $extraParams = array();
+    foreach ($contactDetails as $key => $detail) {
+      if (!empty($detail['membership_id'])) {
+        $extraParams = array_replace_recursive($extraParams, CRM_Member_Form_Task::setExtraTokenDetails(array($detail['membership_id'])));
+      }
+    }
+
     if (!empty($returnProperties) || !empty($tokens) || !empty($allTokens)) {
       list($details) = CRM_Utils_Token::getTokenDetails(
         $contactIds,
         $returnProperties,
-        NULL, NULL, FALSE,
+        NULL,
+        NULL,
+        $extraParams,
         $allTokens,
         'CRM_Activity_BAO_Activity'
       );

--- a/CRM/Member/Form/Task.php
+++ b/CRM/Member/Form/Task.php
@@ -162,6 +162,28 @@ class CRM_Member_Form_Task extends CRM_Core_Form {
   }
 
   /**
+   * Given an array of membership IDs, set 'membership_id' for each contact in extraParams.
+   *   This allows for membership tokens to be looked up later as the membership_id is available.
+   * @param array $memberIds
+   *
+   * @return array
+   */
+  public static function setExtraTokenDetails($memberIds) {
+    if (empty($memberIds)) {
+      return array();
+    }
+    $extraParams = array();
+    $memberships = CRM_Utils_Token::getMembershipTokenDetails($memberIds);
+    foreach ($memberIds as $membershipId) {
+      $membership = $memberships[$membershipId];
+      // get contact information
+      $contactId = $membership['contact_id'];
+      $extraParams['contact_details'][$contactId] = array('membership_id' => $membershipId);
+    }
+    return $extraParams;
+  }
+
+  /**
    * Simple shell that derived classes can call to add buttons to.
    * the form with a customized title for the main Submit
    *

--- a/CRM/Member/Form/Task/PDFLetterCommon.php
+++ b/CRM/Member/Form/Task/PDFLetterCommon.php
@@ -61,6 +61,8 @@ class CRM_Member_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDFLett
     $memberships = CRM_Utils_Token::getMembershipTokenDetails($membershipIDs);
     $html = array();
 
+    $extraParams = CRM_Member_Form_Task::setExtraTokenDetails($membershipIDs);
+
     foreach ($membershipIDs as $membershipID) {
       $membership = $memberships[$membershipID];
       // get contact information
@@ -73,7 +75,7 @@ class CRM_Member_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDFLett
         $returnProperties,
         $skipOnHold,
         $skipDeceased,
-        NULL,
+        $extraParams,
         $messageToken,
         'CRM_Contribution_Form_Task_PDFLetterCommon'
       );


### PR DESCRIPTION
…custom membership tokens

From the "Find Memberships" screen the membership_id is defined, but is dropped before the token code is executed meaning you can't use any custom membership tokens for any of the actions.  This patch passed that membership ID through so it can be used in custom membership token generation via the hook_civicrm_tokenValues hook.