### PR TITLE
CRM-21339 Fix fatal js error on cart checkout when pay later not enabled

### DIFF
--- a/templates/CRM/Event/Cart/Form/Checkout/Payment.tpl
+++ b/templates/CRM/Event/Cart/Form/Checkout/Payment.tpl
@@ -155,20 +155,28 @@
 {/if}
 
 <script type="text/javascript">
+{if $form.is_pay_later.name}
 var pay_later_sel = "input#{$form.is_pay_later.name}";
+{/if}
 {literal}
 CRM.$(function($) {
+
   function refresh() {
+    {/literal}{if $form.is_pay_later.name}{literal}
     var is_pay_later = $(pay_later_sel).prop("checked");
+    {/literal}{else}
+    var is_pay_later = false;
+    {/if}{literal}
     $(".credit_card_info-group").toggle(!is_pay_later);
     $(".pay-later-instructions").toggle(is_pay_later);
     $("div.billingNameInfo-section .description").html(is_pay_later ? "Enter the billing address at which you can be invoiced." : "Enter the name as shown on your credit or debit card, and the billing address for this card.");
   }
-  $("input#source").prop('disabled', true);
-
+  {/literal}{if $form.is_pay_later.name}{literal}
   $(pay_later_sel).change(function() {
     refresh();
   });
+  {/literal}{/if}{literal}
+  $("input#source").prop('disabled', true);
   $(".payment_type-section :radio").change(function() {
     var sel = $(this).attr("id");
     $(".check_number-section").toggle(


### PR DESCRIPTION
When pay later is not enabled a jquery selector gets defined as "input#" which causes a javascript fatal error (in chrome) and causes any further javascript functions to fail.

---

 * [CRM-21339: Fix fatal js error on cart checkout when pay later not enabled](https://issues.civicrm.org/jira/browse/CRM-21339)