### PR TITLE
CRM-21341 Drupal 8 Hook Support

### DIFF
--- a/CRM/Utils/Hook/Drupal8.php
+++ b/CRM/Utils/Hook/Drupal8.php
@@ -32,4 +32,13 @@
  */
 class CRM_Utils_Hook_Drupal8 extends CRM_Utils_Hook_DrupalBase {
 
+  /**
+   * {@inheritdoc}
+   */
+  protected function getDrupalModules() {
+    if (class_exists('\Drupal')) {
+      return array_keys(\Drupal::moduleHandler()->getModuleList());
+    }
+  }
+
 }

--- a/CRM/Utils/Hook/Drupal8.php
+++ b/CRM/Utils/Hook/Drupal8.php
@@ -36,7 +36,7 @@ class CRM_Utils_Hook_Drupal8 extends CRM_Utils_Hook_DrupalBase {
    * {@inheritdoc}
    */
   protected function getDrupalModules() {
-    if (class_exists('\Drupal')) {
+    if (class_exists('\Drupal') && \Drupal::hasContainer()) {
       return array_keys(\Drupal::moduleHandler()->getModuleList());
     }
   }

--- a/CRM/Utils/Hook/DrupalBase.php
+++ b/CRM/Utils/Hook/DrupalBase.php
@@ -91,10 +91,7 @@ class CRM_Utils_Hook_DrupalBase extends CRM_Utils_Hook {
   public function buildModuleList() {
     if ($this->isBuilt === FALSE) {
       if ($this->drupalModules === NULL) {
-        if (function_exists('module_list')) {
-          // copied from user_module_invoke
-          $this->drupalModules = module_list();
-        }
+        $this->drupalModules = $this->getDrupalModules();
       }
 
       if ($this->civiModules === NULL) {
@@ -125,6 +122,20 @@ class CRM_Utils_Hook_DrupalBase extends CRM_Utils_Hook {
         // both CRM and CMS have bootstrapped, so this is the final list
         $this->isBuilt = TRUE;
       }
+    }
+  }
+
+  /**
+   * Gets modules installed on the Drupal site.
+   *
+   * @return array|null
+   *   The machine names of the modules installed in Drupal, or NULL if unable
+   *   to determine the modules.
+   */
+  protected function getDrupalModules() {
+    if (function_exists('module_list')) {
+      // copied from user_module_invoke
+      return module_list();
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
This PR adds support for calling CiviCRM hooks provided by Drupal modules in a Drupal 8 installation.

Before
----------------------------------------
Code for CiviCRM hooks provided by Drupal 8 modules never gets called.

After
----------------------------------------
Code for CiviCRM hooks provided by Drupal 8 modules now gets called after adding the appropriate code to make CiviCRM aware of the Drupal 8 modules.

Technical Details
----------------------------------------
I've refactored `\CRM_Utils_Hook_DrupalBase` to include a `::getDrupalModules` method that calls the existing Drupal code for obtaining the module list. Then I built out `\CRM_Utils_Hook_Drupal8` class to override the method with the Drupal 8 equivalent code for obtaining the list of modules.

---

 * [CRM-21341: Drupal 8 Hook Support](https://issues.civicrm.org/jira/browse/CRM-21341)