### PR TITLE
CRM - 21340 using civi function to get contact id because it is cms agnostic

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1603,8 +1603,7 @@ class CRM_Core_Permission {
    *   invoices permission and the invoice author is the current user.
    */
   public static function checkDownloadInvoice() {
-    global $user;
-    $cid = CRM_Core_BAO_UFMatch::getContactId($user->uid);
+    $cid = CRM_Core_Session::getLoggedInContactID();
     if (CRM_Core_Permission::check('access CiviContribute') ||
       (CRM_Core_Permission::check('view my invoices') && $_GET['cid'] == $cid)
     ) {


### PR DESCRIPTION
Overview
----------------------------------------
attempting to download an invoice was throwing a permission error in wordpress for users with the "view my invoices" permission enabled.

Before
----------------------------------------
I was getting a permission error in wordpress when trying to download an invoice (for a contribution that is pending pay later) as a logged in user with the "view my invoices" permission and without the "access CiviContribute" permission enabled. This error can be recreated by from:

+ the civicrm user dashboard (when the logged in contact has the  "CiviCRM: access Contact Dashboard" permission and the dashboard is set up to show the print invoice button) 

+ or by going to a url that looks like  http://{url}/civicrm/?page=CiviCRM&q=civicrm/contribute/invoice&reset=1&id={contributionId}&cid={loggedInContactID} 

After
----------------------------------------
No longer get a permission error

Technical Details
----------------------------------------
The function to check if the user has permission to view the invoice was relying on the global $user which does not work for wordpress
