### PR TITLE
CRM-16243 - Redundant extension installation should not throw error

### DIFF
--- a/CRM/Extension/Manager.php
+++ b/CRM/Extension/Manager.php
@@ -610,7 +610,7 @@ class CRM_Extension_Manager {
       $info = @$infos[$key];
 
       if ($this->getStatus($key) === self::STATUS_INSTALLED) {
-        $sorter->add($key, $info->requires);
+        $sorter->add($key, array());
       }
       elseif ($info && $info->requires) {
         $sorter->add($key, $info->requires);


### PR DESCRIPTION
Overview
----------------------------------------

Suppose we have two modules, `foo.core` and `foo.addon` (where `foo.addon`
depends on `foo.core`).

Now suppose you try to install `foo.addon` twice, e.g.

```
cv en foo.addon
cv en foo.addon
```

Before
----------------------------------------

The first installation succeeds (and enables both modules as expected).
However, the second installation throws an error: "Dependency foo.core not
found, required by foo.addon"


After
----------------------------------------

Both commands succeed.

Comments
----------------------------------------

This is a correction for the recently merged PR #11101, so I'm hoping to get it reviewed/merged before this goes to RC. 

Based on feedback from @mattwire on Mattermost. CC @JohnFF .

---

 * [CRM-16243: Dependency management for extensions](https://issues.civicrm.org/jira/browse/CRM-16243)