### PR TITLE
CRM-20907

### DIFF
--- a/CRM/Contact/Form/DedupeRules.php
+++ b/CRM/Contact/Form/DedupeRules.php
@@ -57,7 +57,14 @@ class CRM_Contact_Form_DedupeRules extends CRM_Admin_Form {
     }
     $this->_options = CRM_Core_SelectValues::getDedupeRuleTypes();
     $this->_rgid = CRM_Utils_Request::retrieve('id', 'Positive', $this, FALSE, 0);
-    $this->_contactType = CRM_Utils_Request::retrieve('contact_type', 'String', $this, FALSE, 0);
+    $contactTypes = civicrm_api3('Contact', 'getOptions', array('field' => "contact_type"));
+    $contactType = CRM_Utils_Request::retrieve('contact_type', 'String', $this, FALSE, 0);
+    if (in_array($contactType, $contactTypes['values'])) {
+      $this->_contactType = $contactTypes['values'][$contactType];
+    }
+    elseif (!empty($contactType)) {
+      throw new CRM_Core_Exception('Contact Type is Not valid');
+    }
     if ($this->_rgid) {
       $rgDao = new CRM_Dedupe_DAO_RuleGroup();
       $rgDao->id = $this->_rgid;


### PR DESCRIPTION
Followed steps to reproduce and verified condition exists in 4.6
After patch, an invalid contact type in the url parameter will throw an exception.
Existing contact type values continue to work as expected

backported PR for #10992

---

 * [CRM-20907](https://issues.civicrm.org/jira/browse/CRM-20907)