### PR TITLE
CRM-18048: keep civicrm_value table names to a minimum length to avoid report errors

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -189,7 +189,7 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup {
     $group->save();
     if (!isset($params['id'])) {
       if (!isset($params['table_name'])) {
-        $munged_title = strtolower(CRM_Utils_String::munge($group->title, '_', 42));
+        $munged_title = strtolower(CRM_Utils_String::munge($group->title, '_', 13));
         $tableName = "civicrm_value_{$munged_title}_{$group->id}";
       }
       $group->table_name = $tableName;

--- a/tests/phpunit/CRM/Report/Form/ActivityTest.php
+++ b/tests/phpunit/CRM/Report/Form/ActivityTest.php
@@ -1,0 +1,85 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2017                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *  Test Activity report outcome
+ *
+ * @package CiviCRM
+ */
+class CRM_Report_Form_ActivityTest extends CiviReportTestCase {
+  protected $_tablesToTruncate = array(
+    'civicrm_contact',
+    'civicrm_email',
+    'civicrm_phone',
+    'civicrm_address',
+    'civicrm_contribution',
+  );
+
+  public function setUp() {
+    parent::setUp();
+    $this->quickCleanup($this->_tablesToTruncate);
+  }
+
+  public function tearDown() {
+    parent::tearDown();
+    CRM_Core_DAO::executeQuery('DROP TEMPORARY TABLE IF EXISTS civireport_contribution_detail_temp1');
+    CRM_Core_DAO::executeQuery('DROP TEMPORARY TABLE IF EXISTS civireport_contribution_detail_temp2');
+    CRM_Core_DAO::executeQuery('DROP TEMPORARY TABLE IF EXISTS civireport_contribution_detail_temp3');
+  }
+
+  /**
+   * Ensure long custom field names don't result in errors.
+   */
+  public function testLongCustomFieldNames() {
+    // Create custom group with long name and custom field with long name.
+    $long_name = 'this is a very very very very long name with 65 characters in it';
+    $group_params = array(
+      'title' => $long_name,
+      'extends' => 'Activity',
+    );
+    $result = $this->customGroupCreate($group_params);
+    $custom_group_id = $result['id'];
+    $field_params = array(
+      'custom_group_id' => $custom_group_id,
+      'label' => $long_name,
+    );
+    $result = $this->customFieldCreate($field_params);
+    $custom_field_id = $result['id'];
+    $input = array(
+      'fields' => array(
+        'custom_' . $custom_field_id,
+      ),
+    );
+    $obj = $this->getReportObject('CRM_Report_Form_Activity', $input);
+    //$params = $obj->_params;
+    //$params['fields'] = array('custom_' . $custom_field_id);
+    //$obj->setParams($params);
+    $obj->getResultSet();
+    $this->assertTrue(TRUE, "Testo");
+  }
+
+}

--- a/tests/phpunit/CiviTest/CiviReportTestCase.php
+++ b/tests/phpunit/CiviTest/CiviReportTestCase.php
@@ -52,6 +52,28 @@ class CiviReportTestCase extends CiviUnitTestCase {
    * @throws Exception
    */
   public function getReportOutputAsCsv($reportClass, $inputParams) {
+
+    $reportObj = $this->getReportObject($reportClass, $inputParams);
+    try {
+      $rows = $reportObj->getResultSet();
+      $tmpFile = $this->createTempDir() . CRM_Utils_File::makeFileName('CiviReport.csv');
+      $csvContent = CRM_Report_Utils_Report::makeCsv($reportObj, $rows);
+      file_put_contents($tmpFile, $csvContent);
+    }
+    catch (Exception $e) {
+      throw $e;
+    }
+    return $tmpFile;
+  }
+
+  /**
+   * @param $reportClass
+   * @param array $inputParams
+   *
+   * @return array
+   * @throws Exception
+   */
+  public function getReportObject($reportClass, $inputParams) {
     $config = CRM_Core_Config::singleton();
     $config->keyDisable = TRUE;
     $controller = new CRM_Core_Controller_Simple($reportClass, ts('some title'));
@@ -83,11 +105,6 @@ class CiviReportTestCase extends CiviUnitTestCase {
     try {
       $reportObj->storeResultSet();
       $reportObj->buildForm();
-      $rows = $reportObj->getResultSet();
-
-      $tmpFile = $this->createTempDir() . CRM_Utils_File::makeFileName('CiviReport.csv');
-      $csvContent = CRM_Report_Utils_Report::makeCsv($reportObj, $rows);
-      file_put_contents($tmpFile, $csvContent);
     }
     catch (Exception $e) {
       // print_r($e->getCause()->getUserInfo());
@@ -96,7 +113,7 @@ class CiviReportTestCase extends CiviUnitTestCase {
     }
     CRM_Utils_GlobalStack::singleton()->pop();
 
-    return $tmpFile;
+    return $reportObj;
   }
 
   /**

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -2074,10 +2074,6 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
 
     $params = array_merge($defaults, $params);
 
-    if (strlen($params['title']) > 13) {
-      $params['title'] = substr($params['title'], 0, 13);
-    }
-
     //have a crack @ deleting it first in the hope this will prevent derailing our tests
     $this->callAPISuccess('custom_group', 'get', array(
       'title' => $params['title'],


### PR DESCRIPTION
Overview
----------------------------------------
The Activity Detail report was failing because a custom group table name exceeded the length limit allowed to be used in a temporary table.

Rather than fix the report, I'm proposing we enforce a limit on the length of custom value table names. 

This will fix this problem moving forward but not fix the problem for already existing custom value tables.

Before
----------------------------------------
If you run an Activity Report and select a custom field from a custom table with a table name that is too long you get a trace back.

After
----------------------------------------
The activity report works fine.


Technical Details
----------------------------------------
There are significant and questionable changes here. 

First - I removed code from the test suite that truncates custom group names to 13 characters. I don't know why we had this before. And, it was masking the problem with the report. I've removed it.

Second, I've added code to truncate the "name" part of the a custom group table to just 13 characters (it was 42 characters). This limit was previously aimed at preventing table names longer than 64 characters (I presume). I'm drastically reducing it because some reports autogenerate field names in temporary tables based on a combination of a custom table name and custom field name.

Since all custom table names should end with an underscore and and id of the custom data group, we should not end up with duplicates.

Comments
----------------------------------------
Also, I refactored more test code so I can grab and run a report without generating a temp file with the CSV results.

---

 * [CRM-18048: Activity Report fatal error when including custom field set with long name](https://issues.civicrm.org/jira/browse/CRM-18048)