### PR TITLE
CRM-21335: CiviMail - Make recipient appear as required

### DIFF
--- a/ang/crmMailing/BlockMailing.html
+++ b/ang/crmMailing/BlockMailing.html
@@ -49,8 +49,8 @@ It could perhaps be thinned by 30-60% by making more directives.
         </select>
       </div>
     </div>
-    <div crm-ui-field="{name: 'subform.recipients', title: ts('Recipients')}">
-      <div crm-mailing-block-recipients="{name: 'recipients', id: 'subform.recipients'}" crm-mailing="mailing"></div>
+    <div crm-ui-field="{name: 'subform.recipients', title: ts('Recipients'), required: true}">
+      <div crm-mailing-block-recipients="{name: 'recipients', id: 'subform.recipients'}" crm-mailing="mailing" cm-ui-id="subform.recipients"></div>
     </div>
     <span ng-controller="EditUnsubGroupCtrl">
       <div crm-ui-field="{name: 'subform.baseGroup', title: ts('Unsubscribe Group')}" ng-if="isUnsubGroupRequired(mailing)">

--- a/ang/crmUi.js
+++ b/ang/crmUi.js
@@ -124,7 +124,7 @@
     // example: <div crm-ui-field="{title: ts('My Field')}"> {{mydata}} </div>
     // example: <div crm-ui-field="{name: 'subform.myfield', title: ts('My Field')}"> <input crm-ui-id="subform.myfield" name="myfield" /> </div>
     // example: <div crm-ui-field="{name: 'subform.myfield', title: ts('My Field')}"> <input crm-ui-id="subform.myfield" name="myfield" required /> </div>
-    // example: <div crm-ui-field="{name: 'subform.myfield', title: ts('My Field'), help: hs('help_field_name')}"> {{mydata}} </div>
+    // example: <div crm-ui-field="{name: 'subform.myfield', title: ts('My Field'), help: hs('help_field_name'), required: true}"> {{mydata}} </div>
     .directive('crmUiField', function() {
       // Note: When writing new templates, the "label" position is particular. See/patch "var label" below.
       var templateUrls = {
@@ -255,12 +255,17 @@
           // immediately for initialization. Use retries/retryDelay to initialize such elements.
           var init = function (retries, retryDelay) {
             var input = $('#' + id);
-            if (input.length === 0) {
+            if (input.length === 0 && !attrs.crmUiForceRequired) {
               if (retries) {
                 $timeout(function(){
                   init(retries-1, retryDelay);
                 }, retryDelay);
               }
+              return;
+            }
+
+            if (attrs.crmUiForceRequired) {
+              scope.crmIsRequired = true;
               return;
             }
 

--- a/ang/crmUi/field.html
+++ b/ang/crmUi/field.html
@@ -1,5 +1,5 @@
 <div class="label">
-  <label crm-ui-for="{{crmUiField.name}}" crm-depth="1">{{crmUiField.title}}</label>
+  <label crm-ui-for="{{crmUiField.name}}" crm-depth="1" crm-ui-force-required="{{crmUiField.required}}">{{crmUiField.title}}</label>
   <a crm-ui-help="help" ng-if="help"></a>
 </div>
 <div class="content" ng-transclude></div>


### PR DESCRIPTION
Overview
----------------------------------------
The recipient field isn't marked as required in CiviMail compose screen

Before
----------------------------------------
![screen shot 2017-10-20 at 1 18 42 am](https://user-images.githubusercontent.com/3735621/31790934-b10b27e4-b534-11e7-8a76-de8ba8dba22a.png)


After
----------------------------------------
![screen shot 2017-10-20 at 1 19 27 am](https://user-images.githubusercontent.com/3735621/31790960-c65a5b56-b534-11e7-873d-977cacb218e3.png)

Technical Details
----------------------------------------
This revision adds a new option to make the `crm-ui-field` *render* as required even if there's no underlying form `ngModel` element. Example:

```html
<div crm-ui-field="{name: 'subform.recipients', title: ts('Recipients'), required: true}">
  ...
</div>
```


---

 * [CRM-21335: CiviMail recipient field isn't marked as required](https://issues.civicrm.org/jira/browse/CRM-21335)