### PR TITLE
CRM-21255 - PDFLetterCommon - Detect buttons in new popup style

### DIFF
--- a/CRM/Contact/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contact/Form/Task/PDFLetterCommon.php
@@ -363,8 +363,12 @@ class CRM_Contact_Form_Task_PDFLetterCommon {
     $skipDeceased = isset($form->skipDeceased) ? $form->skipDeceased : TRUE;
     $html = $activityIds = array();
 
+    // CRM-21255 - Hrm, CiviCase 4+5 seem to report buttons differently...
+    $c = $form->controller->container();
+    $isLiveMode = ($buttonName == '_qf_PDF_upload') || isset($c['values']['PDF']['buttons']['_qf_PDF_upload']);
+
     // CRM-16725 Skip creation of activities if user is previewing their PDF letter(s)
-    if ($buttonName == '_qf_PDF_upload') {
+    if ($isLiveMode) {
 
       // This seems silly, but the old behavior was to first check `_cid`
       // and then use the provided `$contactIds`. Probably not even necessary,
@@ -418,7 +422,7 @@ class CRM_Contact_Form_Task_PDFLetterCommon {
     }
 
     $tee = NULL;
-    if (Civi::settings()->get('recordGeneratedLetters') === 'combined-attached') {
+    if ($isLiveMode && Civi::settings()->get('recordGeneratedLetters') === 'combined-attached') {
       if (count($activityIds) !== 1) {
         throw new CRM_Core_Exception("When recordGeneratedLetters=combined-attached, there should only be one activity.");
       }


### PR DESCRIPTION
Overview
--------------

Suppose you enable the extension `org.civicrm.civicase`, set the option
`recordGeneratedLetters=combined-attached`, and create a PDF based on the
instructions in [CRM-21255](https://issues.civicrm.org/jira/browse/CRM-21255).

The PDF generator tries to [determine](https://github.com/civicrm/civicrm-core/blob/4.7.27-rc/CRM/Contact/Form/Task/PDFLetterCommon.php#L367) whether they clicked the button
"Preview" or "Download Document". This worked correctly with the CiviCase 4 popup
mechanism, but in the CiviCase 5 popup mechanism it didn't work.

Before
--------------

When you click the "Download Document" button, it operates in a
quasi-preview mode and fails to create any activities. This eventually
leads to a crash because the expected activities are missing.

After
--------------

The controller uses a more accurate check which correctly differentiates
"Preview" and "Download Document" on both CiviCase 4+5.

Comments
--------------

I'm not a huge fan of this patch, but it helps demonstrate the
problem+solution.  @colemanw, perhaps there's a better way to make
the buttons function consistently in CiviCase 4+5?
