### PR TITLE
CRM-21344 - Fix documentation links in installer error messages

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -223,7 +223,7 @@ if ($alreadyInstalled) {
   }
 
   $docLink = CRM_Utils_System::docURL2('Installation and Upgrades', FALSE, ts('Installation Guide'), NULL, NULL, "wiki");
-  $errorMsg = ts("CiviCRM has already been installed. <ul><li>To <strong>start over</strong>, you must delete or rename the existing CiviCRM settings file - <strong>civicrm.settings.php</strong> - from <strong>%1</strong>.</li><li>To <strong>upgrade an existing installation</strong>, <a href='%2'>refer to the online documentation</a>.</li></ul>", array(1 => $settings_directory, 2 => $docLink));
+  $errorMsg = ts("CiviCRM has already been installed. <ul><li>To <strong>start over</strong>, you must delete or rename the existing CiviCRM settings file - <strong>civicrm.settings.php</strong> - from <strong>%1</strong>.</li><li>To <strong>upgrade an existing installation</strong>, refer to the online documentation: %2.</li></ul>", array(1 => $settings_directory, 2 => $docLink));
   errorDisplayPage($errorTitle, $errorMsg, FALSE);
 }
 
@@ -1842,13 +1842,7 @@ function getSiteDir($cmsPath, $str) {
 function errorDisplayPage($errorTitle, $errorMsg, $showRefer = TRUE) {
   if ($showRefer) {
     $docLink = CRM_Utils_System::docURL2('Installation and Upgrades', FALSE, 'Installation Guide', NULL, NULL, "wiki");
-
-    if (function_exists('ts')) {
-      $errorMsg .= '<p>' . ts("<a %1>Refer to the online documentation for more information</a>", array(1 => "href='$docLink'")) . '</p>';
-    }
-    else {
-      $errorMsg .= '<p>' . sprintf("<a %s>Refer to the online documentation for more information</a>", "href='$docLink'") . '</p>';
-    }
+    $errorMsg .= '<p>' . ts("Refer to the online documentation for more information: ") . $docLink . '</p>';
   }
 
   include 'error.html';

--- a/install/index.php
+++ b/install/index.php
@@ -1840,9 +1840,19 @@ function getSiteDir($cmsPath, $str) {
  * @param $showRefer
  */
 function errorDisplayPage($errorTitle, $errorMsg, $showRefer = TRUE) {
+
+  // Add a link to the documentation
   if ($showRefer) {
-    $docLink = CRM_Utils_System::docURL2('Installation and Upgrades', FALSE, 'Installation Guide', NULL, NULL, "wiki");
-    $errorMsg .= '<p>' . ts("Refer to the online documentation for more information: ") . $docLink . '</p>';
+    if (is_callable(array('CRM_Utils_System', 'docURL2'))) {
+      $docLink = CRM_Utils_System::docURL2('Installation and Upgrades', FALSE, 'Installation Guide', NULL, NULL, "wiki");
+    }
+
+    if (function_exists('ts')) {
+      $errorMsg .= '<p>' . ts("Refer to the online documentation for more information: ") . $docLink . '</p>';
+    }
+    else {
+      $errorMsg .= '<p>' . 'Refer to the online documentation for more information: ' . $docLink . '</p>';
+    }
   }
 
   include 'error.html';

--- a/install/index.php
+++ b/install/index.php
@@ -1846,6 +1846,9 @@ function errorDisplayPage($errorTitle, $errorMsg, $showRefer = TRUE) {
     if (is_callable(array('CRM_Utils_System', 'docURL2'))) {
       $docLink = CRM_Utils_System::docURL2('Installation and Upgrades', FALSE, 'Installation Guide', NULL, NULL, "wiki");
     }
+    else {
+      $docLink = '';
+    }
 
     if (function_exists('ts')) {
       $errorMsg .= '<p>' . ts("Refer to the online documentation for more information: ") . $docLink . '</p>';


### PR DESCRIPTION
Overview
----------------------------------------
The installer produces error messages if anything goes wrong.  These messages include a helpful link to documentation.  Unfortunately this link is broken so you can't click on the link.   This PR fixes this so the links work correctly.

Before
----------------------------------------
If you click on the link to documentation in the error message you get a page not found error.

After
----------------------------------------
If you click on the link to documentation you go to the relevant page in the user guide.

Technical Details
----------------------------------------
Basically the code expects a URL but gets back HTML including the <a> tag.  I've changed the code so that it expects a fully formed link in HTML.

I've also simplified the code to remove a redundant check for the existence of the ts() function.  If ts() isn't defined then nor will docURL2().

---

 * [CRM-21344: Links to documentation from installer error messages are broken](https://issues.civicrm.org/jira/browse/CRM-21344)