### PR TITLE
CRM-21322: create hook to modify entityRef fields

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -1865,15 +1865,16 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     }
     $props['select'] = CRM_Utils_Array::value('select', $props, array()) + $defaults;
 
-    $this->formatReferenceFieldAttributes($props);
+    $this->formatReferenceFieldAttributes($props, get_class($this));
     return $this->add('text', $name, $label, $props, $required);
   }
 
   /**
-   * @param $props
+   * @param array $props
+   * @param string $formName
    */
-  private function formatReferenceFieldAttributes(&$props) {
-    CRM_Utils_Hook::alterEntityRefParams($props);
+  private function formatReferenceFieldAttributes(&$props, $formName) {
+    CRM_Utils_Hook::alterEntityRefParams($props, $formName);
     $props['data-select-params'] = json_encode($props['select']);
     $props['data-api-params'] = $props['api'] ? json_encode($props['api']) : NULL;
     $props['data-api-entity'] = $props['entity'];

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -1873,6 +1873,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    * @param $props
    */
   private function formatReferenceFieldAttributes(&$props) {
+    CRM_Utils_Hook::alterEntityRefParams($props);
     $props['data-select-params'] = json_encode($props['select']);
     $props['data-api-params'] = $props['api'] ? json_encode($props['api']) : NULL;
     $props['data-api-entity'] = $props['entity'];

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2389,8 +2389,8 @@ abstract class CRM_Utils_Hook {
    *
    * @return mixed
    */
-  public static function alterEntityRefParams(&$params) {
-    return self::singleton()->invoke(array('params'), $params, self::$_nullObject,
+  public static function alterEntityRefParams(&$params, $formName) {
+    return self::singleton()->invoke(array('params', 'formName'), $params, $formName,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_alterEntityRefParams'
     );

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2382,4 +2382,18 @@ abstract class CRM_Utils_Hook {
     return self::singleton()->invoke(array('message'), $message, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_inboundSMS');
   }
 
+  /**
+   * This hook is called to modify api params of EntityRef form field
+   *
+   * @param array $params
+   *
+   * @return mixed
+   */
+  public static function alterEntityRefParams(&$params) {
+    return self::singleton()->invoke(array('params'), $params, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      'civicrm_alterEntityRefParams'
+    );
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Create a hook to modify the parameters passed to entityRef fields. This will allow developers to do things like define custom api entities for tagset lookups.

After
----------------------------------------
Introduce hook ```hook_civicrm_alterEntityRefParams(&$params)```

---

 * [CRM-21322: create hook to modify entityRef fields](https://issues.civicrm.org/jira/browse/CRM-21322)