### PR TITLE
CRM-21328: Remove '-select-' Option From Visibility

### DIFF
--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -594,8 +594,12 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
             continue;
           }
           elseif ($hideAdminValues && !in_array($className, $formClasses)) {
+            $publicVisibilityID = CRM_Price_BAO_PriceField::getVisibilityOptionID('public');
+            $adminVisibilityID = CRM_Price_BAO_PriceField::getVisibilityOptionID('admin');
+
             foreach ($options as $key => $currentOption) {
-              if ($currentOption['visibility_id'] == CRM_Price_BAO_PriceField::getVisibilityOptionID('admin')) {
+              $optionVisibility = CRM_Utils_Array::value('visibility_id', $currentOption, $publicVisibilityID);
+              if ($optionVisibility == $adminVisibilityID) {
                 unset($options[$key]);
               }
             }

--- a/CRM/Price/Form/Field.php
+++ b/CRM/Price/Form/Field.php
@@ -308,7 +308,7 @@ class CRM_Price_Form_Field extends CRM_Core_Form {
       // is active ?
       $this->add('checkbox', 'option_status[' . $i . ']', ts('Active?'));
 
-      $this->add('select', 'option_visibility_id[' . $i . ']', ts('Visibility'), array('' => ts('- select -')) + $visibilityType);
+      $this->add('select', 'option_visibility_id[' . $i . ']', ts('Visibility'), $visibilityType);
       $defaultOption[$i] = $this->createElement('radio', NULL, NULL, NULL, $i);
 
       //for checkbox handling of default option


### PR DESCRIPTION
Overview
----------------------------------------
Since CRM-12167 we can make price options 'Public' or 'Admin.  However, this 'visibility_id' field is not mandatory when creating the options, so a user can choose to leave it empty (by choosing the '-select-' value) and save the field. This causes a PHP notice to be issued:

> Notice: Undefined index: visibility_id in CRM_Event_Form_Registration_Register::buildAmount() (line 598 of /srv/buildkit/build/dmaster/sites/all/modules/civicrm/CRM/Event/Form/Registration/Register.php).

Before
----------------------------------------
As the visibility per option field is not mandatory, the user can choose the empty option and save the field. This caused some PHP notices to be issued on event registration forms that used the field, caused when it tried to use a unexistent key (visibility_id) to access the array.

After
----------------------------------------
Removed the empty option from the visibility per option select field.

---

 * [CRM-21328: Remove 'Select' option from price option visibility drop-down \(undefined index visibility_id error\)](https://issues.civicrm.org/jira/browse/CRM-21328)
 * [CRM-12167: Add support for admin-only fee \/ price field value options](https://issues.civicrm.org/jira/browse/CRM-12167)