### PR TITLE
CRM-21349: Increase timeout of status message after batch merge

### DIFF
--- a/CRM/Contact/Page/DedupeFind.php
+++ b/CRM/Contact/Page/DedupeFind.php
@@ -149,7 +149,7 @@ class CRM_Contact_Page_DedupeFind extends CRM_Core_Page_Basic {
 
       $stats = CRM_Dedupe_Merger::getMergeStatsMsg($cacheKeyString);
       if ($stats) {
-        CRM_Core_Session::setStatus($stats);
+        CRM_Core_Session::setStatus($stats, '', 'alert', array('expires' => 0));
         // reset so we not displaying same message again
         CRM_Dedupe_Merger::resetMergeStats($cacheKeyString);
       }

--- a/CRM/Contact/Page/DedupeFind.php
+++ b/CRM/Contact/Page/DedupeFind.php
@@ -147,9 +147,11 @@ class CRM_Contact_Page_DedupeFind extends CRM_Core_Page_Basic {
       //reload from cache table
       $cacheKeyString = CRM_Dedupe_Merger::getMergeCacheKeyString($rgid, $gid, $criteria);
 
-      $stats = CRM_Dedupe_Merger::getMergeStatsMsg($cacheKeyString);
+      $stats = CRM_Dedupe_Merger::getMergeStats($cacheKeyString);
       if ($stats) {
-        CRM_Core_Session::setStatus($stats, ts('Batch Complete'), 'alert', array('expires' => 0));
+        $message = CRM_Dedupe_Merger::getMergeStatsMsg($stats);
+        $status = empty($stats['skipped']) ? 'success' : 'alert';
+        CRM_Core_Session::setStatus($message, ts('Batch Complete'), $status, array('expires' => 0));
         // reset so we not displaying same message again
         CRM_Dedupe_Merger::resetMergeStats($cacheKeyString);
       }

--- a/CRM/Contact/Page/DedupeFind.php
+++ b/CRM/Contact/Page/DedupeFind.php
@@ -149,7 +149,7 @@ class CRM_Contact_Page_DedupeFind extends CRM_Core_Page_Basic {
 
       $stats = CRM_Dedupe_Merger::getMergeStatsMsg($cacheKeyString);
       if ($stats) {
-        CRM_Core_Session::setStatus($stats, '', 'alert', array('expires' => 0));
+        CRM_Core_Session::setStatus($stats, ts('Batch Complete'), 'alert', array('expires' => 0));
         // reset so we not displaying same message again
         CRM_Dedupe_Merger::resetMergeStats($cacheKeyString);
       }

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -746,10 +746,10 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
   public static function getMergeStatsMsg($stats) {
     $msg = '';
     if (!empty($stats['merged'])) {
-      $msg = '<p>' . ts('One contact merged.', array(1 => $stats['merged'], 'plural' => '%1 contacts merged.')) . '</p>';
+      $msg = '<p>' . ts('One contact merged.', array('count' => $stats['merged'], 'plural' => '%count contacts merged.')) . '</p>';
     }
     if (!empty($stats['skipped'])) {
-      $msg .= '<p>' . ts('One contact was skipped.', array(1 => $stats['skipped'], 'plural' => '%1 contacts were skipped.')) . '</p>';
+      $msg .= '<p>' . ts('One contact was skipped.', array('count' => $stats['skipped'], 'plural' => '%count contacts were skipped.')) . '</p>';
     }
     return $msg;
   }

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -739,18 +739,17 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
   /**
    * Get merge statistics message.
    *
-   * @param string $cacheKeyString
+   * @param array $stats
    *
    * @return string
    */
-  public static function getMergeStatsMsg($cacheKeyString) {
-    $msg   = '';
-    $stats = CRM_Dedupe_Merger::getMergeStats($cacheKeyString);
+  public static function getMergeStatsMsg($stats) {
+    $msg = '';
     if (!empty($stats['merged'])) {
-      $msg = "{$stats['merged']} " . ts('Contact(s) were merged.');
+      $msg = '<p>' . ts('One contact merged.', array(1 => $stats['merged'], 'plural' => '%1 contacts merged.')) . '</p>';
     }
     if (!empty($stats['skipped'])) {
-      $msg .= $stats['skipped'] . ts(' Contact(s) were skipped.');
+      $msg .= '<p>' . ts('One contact was skipped.', array(1 => $stats['skipped'], 'plural' => '%1 contacts were skipped.')) . '</p>';
     }
     return $msg;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Increase timeout of status message after batch merge process

Before
----------------------------------------
Batch merge process usually takes a longer time to complete and displays the status message on completion but it drops off the screen which is no of help as most likely the user won't be watching the screen every second to see when it ends.

After
----------------------------------------
timeout increased. User can see the message after merge process is complete.

---

 * [CRM-21349: Increase timeout of status message after batch merge.](https://issues.civicrm.org/jira/browse/CRM-21349)