### PR TITLE
CRM-21350 - Dummy payment processor throws error with different decim…

### DIFF
--- a/CRM/Core/Payment/Dummy.php
+++ b/CRM/Core/Payment/Dummy.php
@@ -120,7 +120,8 @@ class CRM_Core_Payment_Dummy extends CRM_Core_Payment {
     }
     $params['gross_amount'] = $params['amount'];
     // Add a fee_amount so we can make sure fees are handled properly in underlying classes.
-    $params['fee_amount'] = 1.50;
+    // using a whole number here
+    $params['fee_amount'] = 1;
     $params['net_amount'] = $params['gross_amount'] - $params['fee_amount'];
 
     return $params;


### PR DESCRIPTION
…al delimitor than .

Overview
----------------------------------------
Dummy payment processor throws error with different decimal delimitor than .

Before
----------------------------------------

**Steps to replicate:**

In localisation setting, use comma as Decimal Delimiter
On thank you page the contribution fails with following error
![contribution_error](https://user-images.githubusercontent.com/3455173/31991231-e782fedc-b994-11e7-8f6a-e5314a12dd52.png)

 
After
----------------------------------------
![contri_works](https://user-images.githubusercontent.com/3455173/31991378-40e8f47c-b995-11e7-9e62-46d53216354f.png)

