### PR TITLE
CRM-20343: Override membership status when contribution is cancelled

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -1756,6 +1756,7 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
             );
 
             $membership->status_id = $newStatus;
+            $membership->is_override = TRUE;
             $membership->save();
             civicrm_api3('activity', 'create', $activityParam);
 
@@ -1803,6 +1804,7 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
           }
           if ($membership && $update) {
             $membership->status_id = array_search('Expired', $membershipStatuses);
+            $membership->is_override = TRUE;
             $membership->save();
 
             $updateResult['updatedComponents']['CiviMember'] = $membership->status_id;

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -1218,4 +1218,54 @@ Expires: ',
     $form->testSubmit($params);
   }
 
+  /**
+   * Test membership status overrides when contribution is cancelled.
+   */
+  public function testContributionFormStatusUpdate() {
+    $form = new CRM_Contribute_Form_Contribution();
+
+    //Create a membership with status = 'New'.
+    $this->_individualId = $this->createLoggedInUser();
+    $memParams = array(
+      'contact_id' => $this->_individualId,
+      'membership_type_id' => $this->membershipTypeAnnualFixedID,
+      'status_id' => array_search('New', CRM_Member_PseudoConstant::membershipStatus()),
+    );
+    $cancelledStatusId = $this->callAPISuccessGetValue('OptionValue', array(
+      'return' => "value",
+      'option_group_id' => "contribution_status",
+      'name' => "Cancelled",
+    ));
+    $params = array(
+      'total_amount' => 50,
+      'financial_type_id' => 2,
+      'contact_id' => $this->_individualId,
+      'payment_instrument_id' => array_search('Check', $this->paymentInstruments),
+      'contribution_status_id' => $cancelledStatusId,
+    );
+    $membershipId = $this->contactMembershipCreate($memParams);
+
+    $contriParams = array(
+      'membership_id' => $membershipId,
+      'total_amount' => 50,
+      'financial_type_id' => 2,
+      'contact_id' => $this->_individualId,
+    );
+    $contribution = CRM_Member_BAO_Membership::recordMembershipContribution($contriParams);
+
+    //Update Contribution to Cancelled.
+    $form->_id = $params['id'] = $contribution->id;
+    $form->_mode = NULL;
+    $form->_contactID = $this->_individualId;
+    $form->testSubmit($params, CRM_Core_Action::UPDATE);
+    $membership = $this->callAPISuccessGetSingle('Membership', array('contact_id' => $this->_individualId));
+
+    //Assert membership status overrides when the contribution cancelled.
+    $this->assertEquals($membership['is_override'], TRUE);
+    $this->assertEquals($membership['status_id'], $this->callAPISuccessGetValue('MembershipStatus', array(
+      'return' => "id",
+      'name' => "Cancelled",
+    )));
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Set `is_override` to true when membership contribution is updated to cancelled.

Before
----------------------------------------
see https://issues.civicrm.org/jira/browse/CRM-20343?focusedCommentId=109217&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-109217

After
----------------------------------------
`is_override` is correctly set when a contribution is updated.
