### PR TITLE
CRM-21348: Don't hide the "edit" link from logged-in users in profile listings in joomla front-end

### DIFF
--- a/CRM/Profile/Selector/Listings.php
+++ b/CRM/Profile/Selector/Listings.php
@@ -506,7 +506,7 @@ class CRM_Profile_Selector_Listings extends CRM_Core_Selector_Base implements CR
     if ($editLink && ($mask & CRM_Core_Permission::EDIT)) {
       // do not allow edit for anon users in joomla frontend, CRM-4668
       $config = CRM_Core_Config::singleton();
-      if (!$config->userFrameworkFrontend) {
+      if (!$config->userFrameworkFrontend || CRM_Core_Session::singleton()->getLoggedInContactID()) {
         $this->_editLink = TRUE;
       }
     }


### PR DESCRIPTION
Don't hide the "edit" link from logged-in users in profile listings in joomla front-end.

Overview
----------------------------------------
CiviCRM hides the "edit" link in profile search results for logged in users, if in the Joomla front end.  Seems like if the user is logged in, and has permissions to access the "edit" link, we should allow it.

For example, this image shows the settings form for the profile "Supporter Profile"; note that the "Include profile edit links in search results?" setting is enabled . (This profile is also otherwise configured for use as a search listing.)

---
![profile-settings](https://user-images.githubusercontent.com/759449/32064307-0de9e57c-ba3f-11e7-8bde-dc2ae9cebab4.png)


Before
----------------------------------------
Signed in on the Joomla frontend, a user navigates to this profile's "listing mode" search form (http://example.com/index.php?option=com_civicrm&task=civicrm/profile&gid=[GID]&reset=1), performs a search, and sees the results; we would expect to see an "Edit" link next to the "View" link for each result row, but that Edit link is missing.

---
![profile-listing-without-link](https://user-images.githubusercontent.com/759449/32064366-3a4c7f8a-ba3f-11e7-8f98-0be4203bdadb.png)


After
----------------------------------------
Signed in on the Joomla frontend, a user navigates to this profile's "listing mode" search form (http://example.com/index.php?option=com_civicrm&task=civicrm/profile&gid=[GID]&reset=1), performs a search, and sees the results; the expected "Edit" link now appears next to the "View" link for each result row.

---
![profile-listing-with-link](https://user-images.githubusercontent.com/759449/32064406-603a5ba4-ba3f-11e7-8578-de368cb27640.png)



Technical Details
----------------------------------------
None.

Comments
----------------------------------------
None.

---

 * [CRM-21348: Don't hide the "edit" link from logged-in users in profile listings in joomla front-end.](https://issues.civicrm.org/jira/browse/CRM-21348)