### PR TITLE
CRM-21351: fix deceased_date format on contact record page.

### DIFF
--- a/templates/CRM/Contact/Page/Inline/Demographics.tpl
+++ b/templates/CRM/Contact/Page/Inline/Demographics.tpl
@@ -48,7 +48,8 @@
           <div class="crm-summary-row">
             <div class="crm-label">{ts}Date Deceased{/ts}</div>
             <div class="crm-content crm-contact-deceased_date_display">
-              {$deceased_date}
+              {assign var="date_format" value = $fields.birth_date.smarty_view_format}
+              {$deceased_date|crmDate:$date_format}
             </div>
           </div>
         {else}


### PR DESCRIPTION
Overview
----------------------------------------

Fixes for the deceased_date format on the contact record (page). See CRM-21351.

---

 * [CRM-21351: Contact deceased date does not respect the localisation date format](https://issues.civicrm.org/jira/browse/CRM-21351)