### PR TITLE
CRM-21355 - don't let a anomaly in the CiviCRM rss feed show an error notification.

### DIFF
--- a/CRM/Dashlet/Page/Blog.php
+++ b/CRM/Dashlet/Page/Blog.php
@@ -141,6 +141,12 @@ class CRM_Dashlet_Page_Blog extends CRM_Core_Page {
         );
         foreach ($channel->item as $item) {
           $item = (array) $item;
+          if (!is_string($item['title'])) {
+            // Some items seem to mess up the dashlet (CRM-21355).
+            // I have no clue what exactly is going on, but if the title is
+            // no string, just ignore the item.
+            continue;
+          }
           $item['title'] = strip_tags($item['title']);
           // Clean up description - remove tags & styles that would break dashboard layout
           $description = preg_replace('#<h[1-3][^>]*>(.+?)</h[1-3][^>]*>#s', '<h4>$1</h4>', $item['description']);


### PR DESCRIPTION
A quick and dirty workaround for CRM-21355.

I have no clue about what's going on, but this patch works around
the issue.

Overview
----------------------------------------
An anomaly in one of the CiviCRM rss-feeds causes a notification.

Before
----------------------------------------
I reproduced this on the demo site dmaster. The error shows when you add the CiviCRM blog dashlet to the dashboard.
![screenshot from 2017-10-25 22-08-50](https://user-images.githubusercontent.com/586145/32020672-460db3e8-b9d1-11e7-86e9-f3f8d1405693.png)

After
----------------------------------------
The error does not show, and the feed items that don't cause any troubles are shown.
![screenshot from 2017-10-25 22-11-27](https://user-images.githubusercontent.com/586145/32020740-7c754734-b9d1-11e7-81da-a5dc53c5071c.png)


Technical Details
----------------------------------------
I have no clue what is wrong. But when a feed item is not correctly converted into an array of strings, I just skip it.

Comments
----------------------------------------

---

 * [CRM-21355: Particular blog post on civicrm.org causes blog dashlet to display error message](https://issues.civicrm.org/jira/browse/CRM-21355)