### PR TITLE
CRM-21357: Batch Data Entry: Added default start date on membership batch entry form

### DIFF
--- a/templates/CRM/Batch/Form/Entry.tpl
+++ b/templates/CRM/Batch/Form/Entry.tpl
@@ -372,6 +372,7 @@ function updateContactInfo(blockNo, prefix) {
             //get the information on membership type
             var membershipTypeId = data.values[0].membership_type_id;
             var membershipJoinDate = data.values[0].join_date;
+            var membershipStartDate = data.values[0].start_date;
             CRM.api('MembershipType', 'get', {
                 'sequential': '1',
                 'id': membershipTypeId
@@ -382,6 +383,7 @@ function updateContactInfo(blockNo, prefix) {
                 cj('select[id="field_' + blockNo + '_membership_type_0"]').val(memTypeContactId).change();
                 cj('select[id="field_' + blockNo + '_membership_type_1"]').val(membershipTypeId).change();
                 cj('#field_' + blockNo + '_' + 'join_date').val(membershipJoinDate).trigger('change');
+                cj('#field_' + blockNo + '_' + 'membership_start_date').val(membershipStartDate).trigger('change');
               }
               });
           }


### PR DESCRIPTION
----------------------------------------
* CRM-21357: Start date is NULL when membership batch entry is processed
  https://issues.civicrm.org/jira/browse/CRM-21357

Overview
----------------------------------------
This PR adds a default start date to the membership bulk entry form when the contact is selected.

Before
----------------------------------------
Start date is set to NULL

After
----------------------------------------
Start date is retained.
