### PR TITLE
(NFC) CRM-21358 - Remove `current` from docs URLs

### DIFF
--- a/templates/CRM/ACL/Page/ACL.tpl
+++ b/templates/CRM/ACL/Page/ACL.tpl
@@ -25,7 +25,7 @@
 *}
 {capture assign=erURL}{crmURL p='civicrm/acl/entityrole' q='reset=1'}{/capture}
 {capture assign=rolesURL}{crmURL p='civicrm/admin/options/acl_role' q='reset=1'}{/capture}
-{capture assign=docLink}{docURL page='user/current/initial-set-up/permissions-and-access-control/' text='Access Control Documentation'}{/capture}
+{capture assign=docLink}{docURL page='user/initial-set-up/permissions-and-access-control/' text='Access Control Documentation'}{/capture}
 
 
 {if $action eq 1 or $action eq 2 or $action eq 8}

--- a/templates/CRM/ACL/Page/ACLBasic.tpl
+++ b/templates/CRM/ACL/Page/ACLBasic.tpl
@@ -25,7 +25,7 @@
 *}
 {capture assign=erURL}{crmURL p='civicrm/acl/entityrole' q='reset=1'}{/capture}
 {capture assign=rolesURL}{crmURL p='civicrm/admin/options/acl_role' q='reset=1'}{/capture}
-{capture assign=docLink}{docURL page='user/current/initial-set-up/permissions-and-access-control/' text='Access Control Documentation'}{/capture}
+{capture assign=docLink}{docURL page='user/initial-set-up/permissions-and-access-control/' text='Access Control Documentation'}{/capture}
 
 <div id="help">
     <p>{ts 1=$docLink}ACLs allow you control access to CiviCRM data. An ACL consists of an <strong>Operation</strong> (e.g. 'View' or 'Edit'), a <strong>set of data</strong> that the operation can be performed on (e.g. a group of contacts, a profile or a set of custom fields), and a <strong>Role</strong> that has permission to do this operation. Refer to the %1 for more info.{/ts}</p>

--- a/templates/CRM/ACL/Page/EntityRole.tpl
+++ b/templates/CRM/ACL/Page/EntityRole.tpl
@@ -25,7 +25,7 @@
 *}
 {capture assign=aclURL}{crmURL p='civicrm/acl' q='reset=1'}{/capture}
 {capture assign=rolesURL}{crmURL p='civicrm/admin/options/acl_role' q='reset=1'}{/capture}
-{capture assign=docLink}{docURL page='user/current/initial-set-up/permissions-and-access-control/' text='Access Control Documentation'}{/capture}
+{capture assign=docLink}{docURL page='user/initial-set-up/permissions-and-access-control/' text='Access Control Documentation'}{/capture}
 
 <div id="help" class="crm-block">
     <p>{ts 1=$docLink}ACLs allow you control access to CiviCRM data. An ACL consists of an <strong>Operation</strong> (e.g. 'View' or 'Edit'), a <strong>set of data</strong> that the operation can be performed on (e.g. a group of contacts), and a <strong>Role</strong> that has permission to do this operation. Refer to the %1 for more info.{/ts}</p>

--- a/templates/CRM/Admin/Page/Access.tpl
+++ b/templates/CRM/Admin/Page/Access.tpl
@@ -23,7 +23,7 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-{capture assign=docLink}{docURL page="user/current/initial-set-up/permissions-and-access-control/" text="Access Control Documentation"}{/capture}
+{capture assign=docLink}{docURL page="user/initial-set-up/permissions-and-access-control/" text="Access Control Documentation"}{/capture}
 <div id="help">
     <p>{ts 1=$docLink}ACLs (Access Control Lists) allow you control access to CiviCRM data. An ACL consists of an <strong>Operation</strong> (e.g. 'View' or 'Edit'), a <strong>set of Data</strong> that the operation can be performed on (e.g. a group of contacts), and a <strong>Role</strong> that has permission to do this operation. Refer to the %1 for more info.{/ts}
     {if $config->userSystem->is_drupal EQ '1'}{ts}Note that a CiviCRM ACL Role is not related to the Drupal Role.{/ts}{/if}</p>

--- a/templates/CRM/Admin/Page/MessageTemplates.hlp
+++ b/templates/CRM/Admin/Page/MessageTemplates.hlp
@@ -24,7 +24,7 @@
  +--------------------------------------------------------------------+
 *}
 {capture assign=tokenDocLink}{docURL page="user/common-workflows/tokens-and-mail-merge"}{/capture}
-{capture assign=schedRemindersDocLink}{docURL page="user/current/email/scheduled-reminders/"}{/capture}
+{capture assign=schedRemindersDocLink}{docURL page="user/email/scheduled-reminders/"}{/capture}
 {capture assign=schedRemURL}{crmURL p='civicrm/admin/scheduleReminders' q="reset=1"}{/capture}
 {capture assign=upgradeTemplatesDocLink}{docURL page="Updating System Workflow Message Templates after Upgrades - method 1 - kdiff" resource="wiki"}{/capture}
 {htxt id="id-intro-title"}

--- a/templates/CRM/Admin/Page/Options.tpl
+++ b/templates/CRM/Admin/Page/Options.tpl
@@ -50,7 +50,7 @@
     {ts}The following credit card options will be offered to contributors using Online Contribution pages. You will need to verify which cards are accepted by your chosen Payment Processor and update these entries accordingly.{/ts}<br /><br />
     {ts}IMPORTANT: This page does NOT control credit card/payment method choices for sites and/or contributors using the PayPal Express service (e.g. where billing information is collected on the Payment Processor's website).{/ts}
   {elseif $gName eq "acl_role"}
-    {capture assign=docLink}{docURL page="user/current/initial-set-up/permissions-and-access-control/" text="Access Control Documentation"}{/capture}
+    {capture assign=docLink}{docURL page="user/initial-set-up/permissions-and-access-control/" text="Access Control Documentation"}{/capture}
     {capture assign=aclURL}{crmURL p='civicrm/acl' q='reset=1'}{/capture}
     {capture assign=erURL}{crmURL p='civicrm/acl/entityrole' q='reset=1'}{/capture}
     {ts 1=$docLink}ACLs allow you control access to CiviCRM data. An ACL consists of an <strong>Operation</strong> (e.g. 'View' or 'Edit'), a <strong>set of data</strong> that the operation can be performed on (e.g. a group of contacts), and a <strong>Role</strong> that has permission to do this operation. Refer to the %1 for more info.{/ts}<br /><br />

--- a/templates/CRM/Admin/Page/ScheduleReminders.tpl
+++ b/templates/CRM/Admin/Page/ScheduleReminders.tpl
@@ -35,7 +35,7 @@
   {* include wysiwyg related files*}
   {include file="CRM/common/wysiwyg.tpl" includeWysiwygEditor=true}
   {if !$component}
-    {capture assign=schedRemindersDocLink}{docURL page="user/current/email/scheduled-reminders/"}{/capture}
+    {capture assign=schedRemindersDocLink}{docURL page="user/email/scheduled-reminders/"}{/capture}
     <div class="help">
       {ts}Scheduled reminders allow you to automatically send messages to contacts regarding their memberships, participation in events, or other activities.{/ts} {$schedRemindersDocLink}
     </div>

--- a/templates/CRM/Contact/Form/Search/Advanced.hlp
+++ b/templates/CRM/Contact/Form/Search/Advanced.hlp
@@ -64,7 +64,7 @@
 {ts}Search Views{/ts}
 {/htxt}
 {htxt id="id-search-views"}
-    <p>{ts}You can modify the columns displayed in your search results by creating a Profile containing a different set of contact fields and then selecting that Profile here. For example you may want to include columns for Gender and Date of Birth, while eliminating Country.{/ts} {docURL page="user/current/organising-your-data/profiles"}</p>
+    <p>{ts}You can modify the columns displayed in your search results by creating a Profile containing a different set of contact fields and then selecting that Profile here. For example you may want to include columns for Gender and Date of Birth, while eliminating Country.{/ts} {docURL page="user/organising-your-data/profiles"}</p>
 {/htxt}
 
 {htxt id="id-search-operator-title"}

--- a/templates/CRM/Contact/Form/Task/SaveSearch.tpl
+++ b/templates/CRM/Contact/Form/Task/SaveSearch.tpl
@@ -39,7 +39,7 @@
       </ul>
     </div>
     {/if}
-    <p>{docURL page='user/current/organising-your-data/smart-groups/'}</p>
+    <p>{docURL page='user/organising-your-data/smart-groups/'}</p>
   </div>
   <table class="form-layout-compressed">
     <tr class="crm-contact-task-createsmartgroup-form-block-title">

--- a/templates/CRM/Event/Form/Task/SaveSearch.tpl
+++ b/templates/CRM/Event/Form/Task/SaveSearch.tpl
@@ -41,7 +41,7 @@
         </ul>
       </div>
     {/if}
-    <p>{docURL page='user/current/organising-your-data/smart-groups/'}</p>
+    <p>{docURL page='user/organising-your-data/smart-groups/'}</p>
   </div>
 
  <table class="form-layout-compressed">

--- a/templates/CRM/Group/Page/Group.hlp
+++ b/templates/CRM/Group/Page/Group.hlp
@@ -37,7 +37,7 @@
   {ts}Group Type{/ts}
 {/htxt}
 {htxt id="id-group-type"}
-{capture assign=docLinkAccess}{docURL page="user/current/initial-set-up/permissions-and-access-control/"}{/capture}
+{capture assign=docLinkAccess}{docURL page="user/initial-set-up/permissions-and-access-control/"}{/capture}
 {capture assign=docLinkMail}{docURL page="user/email/what-is-civimail" text="CiviMail component"}{/capture}
 <p>{if $config->userFramework neq 'Joomla'}{ts 1=$docLinkAccess}Check 'Access Control' if you want to use this group to assign access permissions to a set of contacts. %1{/ts}{/if} {ts 1=$docLinkMail}Check 'Mailing List' if you are using this group as a mailing list in the %1.{/ts}</p>
 {/htxt} 


### PR DESCRIPTION
## Overview

This PR fixes several broken documentation links in the 4.6 UI.

## Before

In CiviCRM 4.6, several places in the UI point users to incorrect URLs for documentation pages. These URLs are incorrect because they have `current` in the URL and should not. The URL should not have `current` in it because (a) this is the 4.6 branch, and (b) the version shouldn't be specified for each URL since the `docURL` function handles that.

(Steps to reproduce are given in [CRM-21358](https://issues.civicrm.org/jira/browse/CRM-21358))

## After

Users can click on these docs URLs and arrive at the intended documentation pages.

## Related issues

* https://lab.civicrm.org/documentation/docs-publisher/issues/83 - `docs-publisher` should give a 404 response for requests like this instead of a 301

## Comments

* Unfortunately I'm unable to test this myself because I don't have a local 4.6 installation (due to my running PHP 7 and not yet having spent the time get another PHP version running on my system). I'm pretty confident this will work though. :grimacing: 
* @wmortada reported this [in Mattermost](https://chat.civicrm.org/civicrm/pl/ehiameh3oin8881s14ciwshsaa). William, would you care to test this out and see if it fixes the issue you observed?

