### PR TITLE
CRM-21360: Make 'Open Case' Activity Optional

### DIFF
--- a/ang/crmCaseType.js
+++ b/ang/crmCaseType.js
@@ -288,11 +288,7 @@
     };
 
     $scope.isActivityRemovable = function(activitySet, activity) {
-      if (activitySet.name == 'standard_timeline' && activity.name == 'Open Case') {
-        return false;
-      } else {
-        return true;
-      }
+      return true;
     };
 
     $scope.isValidName = function(name) {

--- a/ang/crmCaseType/timelineTable.html
+++ b/ang/crmCaseType/timelineTable.html
@@ -40,9 +40,9 @@ Required vars: activitySet
         ui-options="{dropdownAutoWidth : true}"
         ng-model="activity.reference_activity"
         ng-options="activityType.name as activityType.label for activityType in activitySet.activityTypes"
-        ng-hide="activity.name == 'Open Case'"
-        ng-required="activity.name != 'Open Case'"
+        ng-required="activity.name != ''"
         >
+        <option value="">-- Case Start --</option>
       </select>
     </td>
     <td>
@@ -51,8 +51,7 @@ Required vars: activitySet
         type="text"
         ng-pattern="/^-?[0-9]*$/"
         ng-model="activity.reference_offset"
-        ng-hide="activity.name == 'Open Case'"
-        ng-required="activity.name != 'Open Case'"
+        ng-required="activity.name != ''"
         >
     </td>
     <td>
@@ -61,8 +60,7 @@ Required vars: activitySet
         ui-options="{dropdownAutoWidth : true}"
         ng-model="activity.reference_select"
         ng-options="key as value for (key,value) in {newest: ts('Newest'), oldest: ts('Oldest')}"
-        ng-hide="activity.name == 'Open Case'"
-        ng-required="activity.name != 'Open Case'"
+        ng-required="activity.name != ''"
         >
       </select>
     </td>


### PR DESCRIPTION
Overview
----------------------------------------
For greater flexibility in cases, we want to make a change to CiviCase so that the first activity “Open Case” is no longer required for the standard timeline. Basically, there are workflows that you may want to create where the concept of “opening the case” is not relevant - e.g. prospecting or onboarding a new staff member. Given that we store the case start date in any case on the case record itself we would like to make it an optional activity.

Before
----------------------------------------
Currently in the standard case timeline, the first activity "Open Case” is always required, as it cannot be moved, edited or deleted.

After
----------------------------------------
Removed conditionals that made 'Open Case' activity on standard timeline mandatory on Case Type create and edit views. Also added a label to default Reference value so users can choose '-- Case Start --' as the reference for offsets.
