### PR TITLE
CRM-20166: Making CVV always required for front-end pages.

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -662,6 +662,10 @@ abstract class CRM_Core_Payment {
   public function getPaymentFormFieldsMetadata() {
     //@todo convert credit card type into an option value
     $creditCardType = array('' => ts('- select -')) + CRM_Contribute_PseudoConstant::creditCard();
+    $isCVVRequired = Civi::settings()->get('cvv_backoffice_required');
+    if (!$this->isBackOffice()) {
+      $isCVVRequired = TRUE;
+    }
     return array(
       'credit_card_number' => array(
         'htmlType' => 'text',
@@ -686,7 +690,7 @@ abstract class CRM_Core_Payment {
           'maxlength' => 10,
           'autocomplete' => 'off',
         ),
-        'is_required' => Civi::settings()->get('cvv_backoffice_required'),
+        'is_required' => $isCVVRequired,
         'rules' => array(
           array(
             'rule_message' => ts('Please enter a valid value for your card security code. This is usually the last 3-4 digits on the card\'s signature panel.'),

--- a/tests/phpunit/CRM/Core/PaymentTest.php
+++ b/tests/phpunit/CRM/Core/PaymentTest.php
@@ -46,6 +46,32 @@ class CRM_Core_PaymentTest extends CiviUnitTestCase {
     $this->assertEquals('payment_notification processor_name=Paypal', $log['values'][$log['id']]['message']);
   }
 
+  /**
+   * Test that CVV is always required for front facing pages.
+   */
+  public function testCVVSettingForContributionPages() {
+    Civi::settings()->set('cvv_backoffice_required', 0);
+    $processor = NULL;
+    $dummyPayment = new CRM_Core_Payment_Dummy("test", $processor);
+    $dummyPayment->setBackOffice(TRUE);
+    $paymentMetaData = $dummyPayment->getPaymentFormFieldsMetadata();
+    $this->assertEquals(0, $paymentMetaData["cvv2"]["is_required"], "CVV should be non required for back office.");
+
+    $dummyPayment->setBackOffice(FALSE);
+    $paymentMetaData = $dummyPayment->getPaymentFormFieldsMetadata();
+    $this->assertEquals(1, $paymentMetaData["cvv2"]["is_required"], "CVV should always be required for front office.");
+
+    Civi::settings()->set('cvv_backoffice_required', 1);
+
+    $dummyPayment->setBackOffice(TRUE);
+    $paymentMetaData = $dummyPayment->getPaymentFormFieldsMetadata();
+    $this->assertEquals(1, $paymentMetaData["cvv2"]["is_required"], "CVV should be required for back office.");
+
+    $dummyPayment->setBackOffice(FALSE);
+    $paymentMetaData = $dummyPayment->getPaymentFormFieldsMetadata();
+    $this->assertEquals(1, $paymentMetaData["cvv2"]["is_required"], "CVV should always be required for front office.");
+  }
+
   public function testSettingUrl() {
     /** @var CRM_Core_Payment_Dummy $processor */
     $processor = \Civi\Payment\System::singleton()->getById($this->processorCreate());


### PR DESCRIPTION
Overview
----------------------------------------
Setting "CVV required for backoffice" to NO results in it setting all front facing forms to 'not require' CVV site wide, ie on all public facing contribution pages.

Before
----------------------------------------
A single setting was there to disable/enable CVV on front office and back office pages.

After
----------------------------------------
Now we don't consider back-office setting for front-end contribution pages by making CVV always required for front-end pages.

_Agileware Ref: CIVICRM-689_

---

 * [CRM-20166: Setting CVV is 'not required for backend' affects all front facing forms](https://issues.civicrm.org/jira/browse/CRM-20166)