### PR TITLE
CRM-21362: Mailing summary report group by MySQL 5.7 error

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -4703,11 +4703,11 @@ civicrm_relationship.is_permission_a_b = 0
    *
    */
   public static function getGroupByFromOrderBy(&$groupBy, $orderBys) {
-    if (!CRM_Utils_SQL::disableFullGroupByMode()) {
+    if (CRM_Utils_SQL::disableFullGroupByMode()) {
       foreach ($orderBys as $orderBy) {
         $orderBy = str_replace(array(' DESC', ' ASC'), '', $orderBy); // remove sort syntax from ORDER BY clauses if present
         // if ORDER BY column is not present in GROUP BY then append it to end
-        if (!strstr($groupBy, $orderBy)) {
+        if (preg_match('/(MAX|MIN)\(/i', trim($orderBy)) !== 1 && !strstr($groupBy, $orderBy)) {
           $groupBy .= ", {$orderBy}";
         }
       }

--- a/CRM/Report/Form/Mailing/Summary.php
+++ b/CRM/Report/Form/Mailing/Summary.php
@@ -149,11 +149,13 @@ class CRM_Report_Form_Mailing_Summary extends CRM_Report_Form {
       'order_bys' => array(
         'start_date' => array(
           'title' => ts('Start Date'),
+          'dbAlias' => 'MIN(mailing_job_civireport.start_date)',
         ),
         'end_date' => array(
           'title' => ts('End Date'),
           'default_weight' => '1',
           'default_order' => 'DESC',
+          'dbAlias' => 'MAX(mailing_job_civireport.end_date)',
         ),
       ),
       'grouping' => 'mailing-fields',

--- a/CRM/Report/Form/Mailing/Summary.php
+++ b/CRM/Report/Form/Mailing/Summary.php
@@ -500,10 +500,6 @@ class CRM_Report_Form_Mailing_Summary extends CRM_Report_Form {
     else {
       $this->_where = "WHERE " . implode(' AND ', $clauses);
     }
-
-    // if ( $this->_aclWhere ) {
-    // $this->_where .= " AND {$this->_aclWhere} ";
-    // }
   }
 
   public function groupBy() {
@@ -511,6 +507,11 @@ class CRM_Report_Form_Mailing_Summary extends CRM_Report_Form {
       "{$this->_aliases['civicrm_mailing']}.id",
     );
     $this->_groupBy = CRM_Contact_BAO_Query::getGroupByFromSelectColumns($this->_selectClauses, $groupBy);
+  }
+
+  public function orderBy() {
+    parent::orderBy();
+    CRM_Contact_BAO_Query::getGroupByFromOrderBy($this->_groupBy, $this->_orderByArray);
   }
 
   public function postProcess() {

--- a/CRM/Utils/SQL.php
+++ b/CRM/Utils/SQL.php
@@ -76,4 +76,24 @@ class CRM_Utils_SQL {
     return version_compare(CRM_Core_DAO::singleValueQuery('SELECT VERSION()'), '5.7', '>=');
   }
 
+  /**
+   * Disable ONLY_FULL_GROUP_BY for MySQL versions lower then 5.7
+   *
+   * @return bool
+   */
+  public static function disableFullGroupByMode() {
+    $sqlModes = self::getSqlModes();
+
+    // Disable only_full_group_by mode for lower sql versions.
+    if (!self::supportsFullGroupBy() || (!empty($sqlModes) && !in_array('ONLY_FULL_GROUP_BY', $sqlModes))) {
+      if ($key = array_search('ONLY_FULL_GROUP_BY', $sqlModes)) {
+        unset($sqlModes[$key]);
+        CRM_Core_DAO::executeQuery("SET SESSION sql_mode = '" . implode(',', $sqlModes) . "'");
+      }
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate the error:

1. Go to Mailing Summary Report (template/instance)
2. Ensure that 'End Date' is not selected in Columns section.
3. Select 'End Date' in under Sorting form
4. Submit the Criteria

Before
----------------------------------------
Throw ```DB Error: unknown error```
 _nativecode=1055 ** Expression #1 of ORDER BY clause is not in GROUP BY clause and contains nonaggregated column 'civicrm_db.mailing_job_civireport.end_date' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by|#1 of ORDER BY clause is not in GROUP BY clause and contains nonaggregated column 'civicrm_db.mailing_job_civireport.end_date' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by_

After
----------------------------------------
Fixes the error, but note that chosen ORDER column is now appended in GROUP BY clause

Technical Details
----------------------------------------
You need MySQL 5.7 setup to test this. Also, this patch has some additional optimisation changes

Comments
----------------------------------------
This might be affecting other Reports where nonaggregated ORDER BY columns were not present in GROUP BY.

---

 * [CRM-21362: Mailing summary report group by MySQL 5.7 error](https://issues.civicrm.org/jira/browse/CRM-21362)