### PR TITLE
CRM-21363: Revert _supportFullGroupBy addition

### DIFF
--- a/tests/phpunit/CRM/Core/DAOTest.php
+++ b/tests/phpunit/CRM/Core/DAOTest.php
@@ -387,7 +387,7 @@ class CRM_Core_DAOTest extends CiviUnitTestCase {
     $sqlModes = CRM_Utils_SQL::getSqlModes();
     // assert we have strict trans
     $this->assertContains('STRICT_TRANS_TABLES', $sqlModes);
-    if ($this->_supportFullGroupBy) {
+    if (CRM_Utils_SQL::supportsFullGroupBy()) {
       $this->assertContains('ONLY_FULL_GROUP_BY', $sqlModes);
     }
   }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -65,11 +65,6 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
   private static $dbInit = FALSE;
 
   /**
-   * Does the current setup support ONLY_FULL_GROUP_BY mode
-   */
-  protected $_supportFullGroupBy;
-
-  /**
    *  Database connection.
    *
    * @var PHPUnit_Extensions_Database_DB_IDatabaseConnection
@@ -295,8 +290,6 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
 
     //  Get and save a connection to the database
     $this->_dbconn = $this->getConnection();
-
-    $this->_supportFullGroupBy = CRM_Utils_SQL::supportsFullGroupBy();
 
     // reload database before each test
     //        $this->_populateDB();


### PR DESCRIPTION
Overview
----------------------------------------
This patch reverts the addition of $_supportFullGroupBy in Civi unit test baseclass.

---

 * [CRM-21363: Ensure that tests run using ONLY_FULL_GROUP_BY sql_mode for mysql 5.7](https://issues.civicrm.org/jira/browse/CRM-21363)