### PR TITLE
CRM-21364 Fix upgrades from 4.2.x for ONLY_FULL_GROUP_BY compatability

### DIFF
--- a/CRM/Upgrade/Incremental/php/FourThree.php
+++ b/CRM/Upgrade/Incremental/php/FourThree.php
@@ -762,7 +762,7 @@ INSERT INTO civicrm_financial_trxn
             (contribution_id, payment_instrument_id, currency, total_amount, net_amount, fee_amount, trxn_id, status_id, check_number,
              to_financial_account_id, from_financial_account_id, trxn_date, payment_processor_id, is_fee)
 
-SELECT con.id, ft.payment_instrument_id, ft.currency, ft.fee_amount, NULL, NULL, ft.trxn_id, %1 as status_id,
+SELECT DISTINCT con.id, ft.payment_instrument_id, ft.currency, ft.fee_amount, NULL, NULL, ft.trxn_id, %1 as status_id,
        ft.check_number, efaFT.financial_account_id as to_financial_account_id, CASE
          WHEN efaPP.financial_account_id IS NOT NULL THEN
               efaPP.financial_account_id
@@ -782,8 +782,7 @@ FROM   civicrm_contribution con
                    AND efaPP.account_relationship = {$assetAccountIs})
        LEFT  JOIN {$tempTableName1} tpi
                ON ft.payment_instrument_id = tpi.instrument_id
-WHERE  ft.fee_amount IS NOT NULL AND ft.fee_amount != 0 AND (con.contribution_status_id IN (%1, %3) OR (con.contribution_status_id =%2 AND con.is_pay_later = 1))
-GROUP  BY con.id";
+WHERE  ft.fee_amount IS NOT NULL AND ft.fee_amount != 0 AND (con.contribution_status_id IN (%1, %3) OR (con.contribution_status_id =%2 AND con.is_pay_later = 1))";
     CRM_Core_DAO::executeQuery($sql, $queryParams);
 
     //link financial_trxn to contribution

--- a/CRM/Upgrade/Incremental/php/FourTwo.php
+++ b/CRM/Upgrade/Incremental/php/FourTwo.php
@@ -613,7 +613,7 @@ LEFT JOIN civicrm_participant_payment cpp ON cc.id = cpp.contribution_id
 LEFT JOIN civicrm_price_set_entity cpse on cpse.entity_table = 'civicrm_contribution_page' AND cpse.entity_id = cc.contribution_page_id
 WHERE     (cc.id BETWEEN %1 AND %2)
 AND       cli.entity_id IS NULL AND cc.contribution_page_id IS NOT NULL AND cpp.contribution_id IS NULL
-GROUP BY  cc.id
+GROUP BY  cc.id, cmp.membership_id
 ";
     $result = CRM_Core_DAO::executeQuery($sql, $sqlParams);
 


### PR DESCRIPTION
Overview
Upgrades from 4.2.x fail because of issues with ONLY_FULL_GROUP_BY comparability. This fixes them. See https://test.civicrm.org/job/CiviCRM-Core-Matrix/CIVIVER=master,label=ubuntu1604/4347/testReport/junit/(root)/CivicrmUpgradeTest/4_2_0_setupsh_sql_bz2/ and https://test.civicrm.org/job/CiviCRM-Core-Matrix/CIVIVER=master,label=ubuntu1604/4347/testReport/junit/(root)/CivicrmUpgradeTest/4_2_16_setupsh_sql_bz2/ for evidence of failure. @monishdeb can i get you to review this because i'm not 100% sure about the financial stuff also ping @JoeMurray @eileenmcnaughton

---

 * [CRM-21364: Fix Tests which fail on ONLY_FULL_GROUP_BY](https://issues.civicrm.org/jira/browse/CRM-21364)