### PR TITLE
CRM-21365: Ensure currency param passed via api.Contribution.transact is passed to processor

### DIFF
--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -477,7 +477,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
 
     $args['paymentAction'] = 'Sale';
     $args['amt'] = $params['amount'];
-    $args['currencyCode'] = $params['currencyID'];
+    $args['currencyCode'] = CRM_Utils_Array::value('currencyID', $params, CRM_Utils_Array::value('currency', $params));
     $args['invnum'] = $params['invoiceID'];
     $args['ipaddress'] = $params['ip_address'];
     $args['creditCardType'] = $params['credit_card_type'];


### PR DESCRIPTION
Overview
----------------------------------------
Fixes currency bug [CRM-21365](https://issues.civicrm.org/jira/browse/CRM-21365) for PayPal - Website Payments Pro.

Before
----------------------------------------
`currency` parameter passed to `api.Contribution.transact` is lost in translation; an empty string is passed to the processor instead.

After
----------------------------------------
`currency` parameter passed to `api.Contribution.transact` is correctly passed to the processor.

Technical Details
----------------------------------------
Not knowing why the code expects the parameter to be called `currencyID`, I didn't want to change it, so I made checking the value of `currency` a fallback in case the former is not supplied.

Comments
----------------------------------------
Not sure how to write tests for a payment processor. Would be happy to pair with someone to do so if they can provide some guidance.
