### PR TITLE
CRM-20892 Fix up issue where created_date may not have yet been conve…

### DIFF
--- a/CRM/Upgrade/Incremental/sql/4.7.27.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.7.27.mysql.tpl
@@ -1,4 +1,1 @@
 {* file to handle db changes in 4.7.27 during upgrade *}
-
--- CRM-20892 Change created_date default so that we can add a modified_date column
-ALTER TABLE civicrm_mailing CHANGE created_date created_date timestamp NULL  DEFAULT NULL COMMENT 'Date and time this mailing was created.';


### PR DESCRIPTION
…rted to timestamp so should stay as datetime in upgrade

Overview
----------------------------------------
Previously the upgrade would just set the column datatype to be timestamp which may or may not be 100% correct as the end user may or may not have run the doctor when conversion yet. This re-uses some of the doctorWhen status notice stuff to check if it is a datetime or timestamp column and then uses that in the altertable statement

@totten @eileenmcnaughton Tim i believe this will address your concerns raised at the sprint. putting this against the RC as its an issue in 4.7.27 due to be released in November