### PR TITLE
CRM-21373 - Notice error on creating cases

### DIFF
--- a/CRM/Activity/Page/AJAX.php
+++ b/CRM/Activity/Page/AJAX.php
@@ -208,7 +208,7 @@ class CRM_Activity_Page_AJAX {
     foreach ($caseRelationships as $key => &$row) {
       $typeLabel = $row['relation'];
       // Add "<br />(Case Manager)" to label
-      if ($row['relation_type'] == $managerRoleId) {
+      if (!empty($row['relation_type']) && $row['relation_type'] == $managerRoleId) {
         $row['relation'] .= '<br />' . '(' . ts('Case Manager') . ')';
       }
       // view user links


### PR DESCRIPTION
Overview
----------------------------------------
This PR fixes a minor notice recorded while creating cases.

> Notice: Undefined index: relation_type in CRM_Activity_Page_AJAX::getCaseRoles() (line 211 of /Users/jitendra/src/civicrm/CRM/Activity/Page/AJAX.php

---

 * [CRM-21373: Notice error on creating cases](https://issues.civicrm.org/jira/browse/CRM-21373)