### PR TITLE
CRM-21374 - Quick fix - D8 doesn't support regions

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -215,7 +215,6 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
 
     switch ($region) {
       case 'html-header':
-      case 'page-footer':
         break;
 
       default:
@@ -240,7 +239,6 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
   public function addScript($code, $region) {
     switch ($region) {
       case 'html-header':
-      case 'page-footer':
         break;
 
       default:


### PR DESCRIPTION
* [CRM-21374: D8 footer resources get added to the header](https://issues.civicrm.org/jira/browse/CRM-21374)