### PR TITLE
HW-382: Moved help section outside of block

### DIFF
--- a/ang/crmCaseType/edit.html
+++ b/ang/crmCaseType/edit.html
@@ -3,11 +3,13 @@ Controller: CaseTypeCtrl
 Required vars: caseType
 -->
 <h1 crm-page-title>{{caseType.title || ts('New Case Type')}}</h1>
+
+<div class="help">
+  {{ts('Use this screen to define or update the Case Roles, Activity Types, and Timelines for a case type.')}} <a href="https://docs.civicrm.org/user/en/stable/case-management/set-up/" target="_blank">{{ts('Learn more...')}}</a>
+</div>
+
 <form name="editCaseTypeForm" unsaved-warning-form>
 <div class="crm-block crm-form-block crmCaseType">
-  <div class="help">
-    {{ts('Use this screen to define or update the Case Roles, Activity Types, and Timelines for a case type.')}} <a href="https://docs.civicrm.org/user/en/stable/case-management/set-up/" target="_blank">{{ts('Learn more...')}}</a>
-  </div>
 
   <div ng-include="'~/crmCaseType/caseTypeDetails.html'"></div>
 


### PR DESCRIPTION
Overview
----------------------------------------
This PR moves help section out side of container to prevent standard structuring

Before
----------------------------------------
![before](https://user-images.githubusercontent.com/26058635/32262557-306e9578-befb-11e7-9ccd-ee895ed19572.png)


After
----------------------------------------
![after](https://user-images.githubusercontent.com/26058635/32262534-2058d5fe-befb-11e7-93ca-72fec427223a.png)

