### PR TITLE
CRM-21379: Remove hard-coded Activity status set as 'Scheduled' in query for listing activities in Activity dashlet

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -706,10 +706,6 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
       ),
     );
 
-    if ($params['context'] != 'activity') {
-      $activityParams['status_id'] = CRM_Core_PseudoConstant::getKey(__CLASS__, 'status_id', 'Scheduled');
-    }
-
     // activity type ID clause
     if (!empty($params['activity_type_id'])) {
       if (is_array($params['activity_type_id'])) {
@@ -1258,9 +1254,6 @@ LEFT JOIN   civicrm_case_activity ON ( civicrm_case_activity.activity_id = tbl.a
 
     if (!empty($input['activity_status_id'])) {
       $commonClauses[] = sprintf("civicrm_activity.status_id IN (%s)", $input['activity_status_id']);
-    }
-    elseif ($input['context'] != 'activity') {
-      $commonClauses[] = "civicrm_activity.status_id = 1";
     }
 
     // Filter on component IDs.

--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -757,13 +757,7 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
       }
     }
 
-    if (empty($order)) {
-      // context = 'activity' in Activities tab.
-      $activityParams['options']['sort'] = (CRM_Utils_Array::value('context', $params) == 'activity') ? "activity_date_time DESC" : "status_id ASC, activity_date_time ASC";
-    }
-    else {
-      $activityParams['options']['sort'] = str_replace('activity_type ', 'activity_type_id.label ', $order);
-    }
+    $activityParams['options']['sort'] = empty($order) ? "activity_date_time DESC" : str_replace('activity_type ', 'activity_type_id.label ', $order);
 
     //TODO :
     // 1. we should use Activity.Getcount for fetching count only, but  in order to check that
@@ -955,7 +949,7 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
 
     if (empty($order)) {
       // context = 'activity' in Activities tab.
-      $order = (CRM_Utils_Array::value('context', $input) == 'activity') ? " ORDER BY tbl.activity_date_time desc " : " ORDER BY tbl.status_id asc, tbl.activity_date_time asc ";
+      $order = " ORDER BY tbl.activity_date_time desc ";
     }
 
     if (!empty($input['rowCount']) &&

--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -722,6 +722,10 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
       $activityParams['activity_type_id'] = array('IN' => array_keys($activityTypes));
     }
 
+    if (!empty($params['activity_status_id'])) {
+      $activityParams['activity_status_id'] = array('IN' => explode(',', $params['activity_status_id']));
+    }
+
     $excludeActivityIDs = array();
     if (!empty($params['activity_type_exclude_id'])) {
       if (is_array($params['activity_type_exclude_id'])) {

--- a/CRM/Activity/Form/ActivityFilter.php
+++ b/CRM/Activity/Form/ActivityFilter.php
@@ -72,6 +72,10 @@ class CRM_Activity_Form_ActivityFilter extends CRM_Core_Form {
         ->getBagByContact(NULL, $userID)
         ->get('activity_tab_filter');
     }
+    // set Activity status 'Scheduled' by default only for dashlet
+    elseif (strstr(CRM_Utils_Array::value('q', $_GET), 'dashlet')) {
+      $defaults['status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'status_id', 'Scheduled');
+    }
     return $defaults;
   }
 

--- a/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
@@ -974,6 +974,7 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
       'caseId' => NULL,
       'context' => 'home',
       'activity_type_id' => NULL,
+      'activity_status_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'status_id', 'Scheduled'), // for dashlet the Scheduled status is set by default
       'offset' => 0,
       'rowCount' => 0,
       'sort' => NULL,

--- a/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
@@ -310,6 +310,7 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
       'caseId' => NULL,
       'context' => 'home',
       'activity_type_id' => NULL,
+      'activity_status_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'status_id', 'Scheduled'), // for dashlet the Scheduled status is set by default
       'offset' => 0,
       'rowCount' => 0,
       'sort' => NULL,
@@ -496,6 +497,7 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
       'caseId' => NULL,
       'context' => 'home',
       'activity_type_id' => NULL,
+      'activity_status_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'status_id', 'Scheduled'), // for dashlet the Scheduled status is set by default
       'offset' => 0,
       'rowCount' => 0,
       'sort' => NULL,


### PR DESCRIPTION
Overview
----------------------------------------
If you go to Activity dashlet, by default, there is no activity status set in 'Filter by Activity' form. Also default sort order doesn't place latest activities on top.

Before
----------------------------------------
List 'Scheduled' activities and notice that there is no status set.
![dashlet-before](https://user-images.githubusercontent.com/3735621/32266527-c29af646-bf0d-11e7-9721-005e24477fcc.gif)


After
----------------------------------------
Expected result: List activities of any status.
![dashlet-after](https://user-images.githubusercontent.com/3735621/32266543-cc746ca6-bf0d-11e7-8af7-dd87a3e85d56.gif)


Technical Details
----------------------------------------
Bug: The underlying SQL query responsible to fetch activities has hard-coded value set for Activity Status [here](https://github.com/civicrm/civicrm-core/blob/master/CRM/Activity/BAO/Activity.php#L1263) to 'Scheduled' if $context is 'dashlet'. So this s not affecting Activity tab on Contact summary page but only dashlet. So as per fix I have removed the hardcoded filter in SQL and setting the 'Scheduled' as status_id default

Comments
----------------------------------------
Refresh the dashboard to after applying the patch.

---

 * [CRM-21379: Remove hard-coded Activity status set as 'Scheduled' in query for listing activities in Activity dashlet](https://issues.civicrm.org/jira/browse/CRM-21379)