### PR TITLE
CRM-21384 - Don't show deleted contacts in case relations

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -817,7 +817,7 @@ SELECT case_status.label AS case_status, status_id, civicrm_case_type.title AS c
  LEFT JOIN  civicrm_phone ON (civicrm_phone.contact_id = con.id AND civicrm_phone.is_primary = 1)
  LEFT JOIN  civicrm_email ON (civicrm_email.contact_id = con.id AND civicrm_email.is_primary = 1)
      WHERE  (rel.contact_id_a = %1 OR rel.contact_id_b = %1) AND rel.case_id = %2
-       AND  rel.is_active = 1 AND (rel.end_date IS NULL OR rel.end_date > NOW())';
+       AND  rel.is_active = 1 AND con.is_deleted = 0 AND (rel.end_date IS NULL OR rel.end_date > NOW())';
 
     $params = array(
       1 => array($contactID, 'Positive'),

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -336,7 +336,7 @@ WHERE civicrm_case.id = %1";
  LEFT JOIN  civicrm_case_contact ON civicrm_case_contact.contact_id = contact_a.id
  LEFT JOIN  civicrm_email ce ON ( ce.contact_id = contact_a.id AND ce.is_primary = 1)
  LEFT JOIN  civicrm_phone cp ON ( cp.contact_id = contact_a.id AND cp.is_primary = 1)
-     WHERE  civicrm_case_contact.case_id = %1
+     WHERE  contact_a.is_deleted = 0 AND civicrm_case_contact.case_id = %1
      ORDER BY civicrm_case_contact.id";
 
     $dao = CRM_Core_DAO::executeQuery($query,


### PR DESCRIPTION
Overview
-----------
Deleted contacts should be excluded from all views in CiviCase.

Before
--------
Deleted contacts were shown in case roles section of case view. They were also returned by the api.

After
------
Deleted contacts hidden from view and excluded from case roles in api calls.

Comments
--------------
The api change is important for the new CiviCase extension.

* [CRM-21384: Ensure deleted contacts are filtered out of CiviCase](https://issues.civicrm.org/jira/browse/CRM-21384)