### PR TITLE
CIVICRM-706: Making front-end CVV always required, regardless of the CVV required for back office option.

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -374,9 +374,19 @@ abstract class CRM_Core_Payment {
    * @return array
    *   field metadata
    */
-  public function getPaymentFormFieldsMetadata() {
+  public function getPaymentFormFieldsMetadata($isBackOffice = FALSE) {
     //@todo convert credit card type into an option value
     $creditCardType = array('' => ts('- select -')) + CRM_Contribute_PseudoConstant::creditCard();
+    $isCVVRequired = CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::CONTRIBUTE_PREFERENCES_NAME,
+      'cvv_backoffice_required',
+      NULL,
+      1
+    );
+
+    if (!$isBackOffice) {
+      $isCVVRequired = TRUE;
+    }
+
     return array(
       'credit_card_number' => array(
         'htmlType' => 'text',
@@ -401,11 +411,7 @@ abstract class CRM_Core_Payment {
           'maxlength' => 10,
           'autocomplete' => 'off',
         ),
-        'is_required' => CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::CONTRIBUTE_PREFERENCES_NAME,
-          'cvv_backoffice_required',
-          NULL,
-          1
-        ),
+        'is_required' => $isCVVRequired,
         'rules' => array(
           array(
             'rule_message' => ts('Please enter a valid value for your card security code. This is usually the last 3-4 digits on the card\'s signature panel.'),

--- a/CRM/Core/Payment/Form.php
+++ b/CRM/Core/Payment/Form.php
@@ -63,7 +63,7 @@ class CRM_Core_Payment_Form {
       $form->assign('paymentTypeName', $paymentTypeName);
       $form->assign('paymentTypeLabel', $paymentTypeLabel);
 
-      $form->billingFieldSets[$paymentTypeName]['fields'] = $form->_paymentFields = array_intersect_key(self::getPaymentFieldMetadata($processor), array_flip($paymentFields));
+      $form->billingFieldSets[$paymentTypeName]['fields'] = $form->_paymentFields = array_intersect_key(self::getPaymentFieldMetadata($processor, $isBackOffice), array_flip($paymentFields));
       if (in_array('cvv2', $paymentFields) && $isBackOffice) {
         if (!civicrm_api3('setting', 'getvalue', array('name' => 'cvv_backoffice_required', 'group' => 'Contribute Preferences'))) {
           $form->billingFieldSets[$paymentTypeName]['fields'][array_search('cvv2', $paymentFields)]['required'] = 0;
@@ -252,9 +252,9 @@ class CRM_Core_Payment_Form {
    *
    * @return array
    */
-  public static function getPaymentFieldMetadata($paymentProcessor) {
+  public static function getPaymentFieldMetadata($paymentProcessor, $isBackOffice = FALSE) {
     $paymentProcessorObject = CRM_Core_Payment::singleton(($paymentProcessor['is_test'] ? 'test' : 'live'), $paymentProcessor);
-    return $paymentProcessorObject->getPaymentFormFieldsMetadata();
+    return $paymentProcessorObject->getPaymentFormFieldsMetadata($isBackOffice);
   }
 
   /**

--- a/tests/phpunit/CRM/Core/PaymentTest.php
+++ b/tests/phpunit/CRM/Core/PaymentTest.php
@@ -48,4 +48,42 @@ class CRM_Core_PaymentTest extends CiviUnitTestCase {
     $this->assertEquals('payment_notification processor_name=Paypal', $log['values'][$log['id']]['message']);
   }
 
+  /**
+   * Test that CVV is always required for front facing pages.
+   */
+  public function testCVVSettingForContributionPages() {
+
+    CRM_Core_BAO_Setting::setItem(
+      0,
+      CRM_Core_BAO_Setting::CONTRIBUTE_PREFERENCES_NAME,
+      'cvv_backoffice_required'
+    );
+
+    $processor = NULL;
+    $dummyPayment = new CRM_Core_Payment_Dummy("test", $processor);
+    $paymentMetaData = $dummyPayment->getPaymentFormFieldsMetadata();
+    $this->assertEquals(1, $paymentMetaData["cvv2"]["is_required"], "CVV should be required for front office.");
+
+    $paymentMetaData = $dummyPayment->getPaymentFormFieldsMetadata(TRUE);
+    $this->assertEquals(0, $paymentMetaData["cvv2"]["is_required"], "CVV should not be required for back office.");
+
+    $paymentMetaData = $dummyPayment->getPaymentFormFieldsMetadata(FALSE);
+    $this->assertEquals(1, $paymentMetaData["cvv2"]["is_required"], "CVV should not be required for front office.");
+
+    CRM_Core_BAO_Setting::setItem(
+      1,
+      CRM_Core_BAO_Setting::CONTRIBUTE_PREFERENCES_NAME,
+      'cvv_backoffice_required'
+    );
+
+    $paymentMetaData = $dummyPayment->getPaymentFormFieldsMetadata();
+    $this->assertEquals(1, $paymentMetaData["cvv2"]["is_required"], "CVV should be required for front office.");
+
+    $paymentMetaData = $dummyPayment->getPaymentFormFieldsMetadata(TRUE);
+    $this->assertEquals(1, $paymentMetaData["cvv2"]["is_required"], "CVV should be required for back office.");
+
+    $paymentMetaData = $dummyPayment->getPaymentFormFieldsMetadata(FALSE);
+    $this->assertEquals(1, $paymentMetaData["cvv2"]["is_required"], "CVV should be required for front office.");
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Setting "CVV required for backoffice" to NO results in it setting all front facing forms to 'not require' CVV site wide, ie on all public facing contribution pages.

Before
----------------------------------------
A single setting was there to disable/enable CVV on front office and back office pages.

After
----------------------------------------
Now we don't consider back-office setting for front-end contribution pages by making CVV always required for front-end pages.

_Agileware Ref: CIVICRM-706_