### PR TITLE
CRM-21364 Fix Dedupe fillTable Query when running in full groupBy Mode

### DIFF
--- a/CRM/Dedupe/BAO/RuleGroup.php
+++ b/CRM/Dedupe/BAO/RuleGroup.php
@@ -196,13 +196,13 @@ class CRM_Dedupe_BAO_RuleGroup extends CRM_Dedupe_DAO_RuleGroup {
     if ($this->params && !$this->noRules) {
       $tempTableQuery = "CREATE TEMPORARY TABLE dedupe (id1 int, weight int, UNIQUE UI_id1 (id1)) ENGINE=InnoDB";
       $insertClause = "INSERT INTO dedupe (id1, weight)";
-      $groupByClause = "GROUP BY id1";
+      $groupByClause = "GROUP BY id1, weight";
       $dupeCopyJoin = " JOIN dedupe_copy ON dedupe_copy.id1 = t1.column WHERE ";
     }
     else {
       $tempTableQuery = "CREATE TEMPORARY TABLE dedupe (id1 int, id2 int, weight int, UNIQUE UI_id1_id2 (id1, id2)) ENGINE=InnoDB";
       $insertClause = "INSERT INTO dedupe (id1, id2, weight)";
-      $groupByClause = "GROUP BY id1, id2";
+      $groupByClause = "GROUP BY id1, id2, weight";
       $dupeCopyJoin = " JOIN dedupe_copy ON dedupe_copy.id1 = t1.column AND dedupe_copy.id2 = t2.column WHERE ";
     }
     $patternColumn = '/t1.(\w+)/';


### PR DESCRIPTION
Overview
----------------------------------------
This fixes test failures experienced due to issues with the ONLY_FULL_GROUP_BY sqlMode. For examples of test failures see https://test.civicrm.org/job/CiviCRM-Core-Matrix/CIVIVER=4.7.28-rc,label=ubuntu1604/lastCompletedBuild/testReport/(root)/CRM_Dedupe_DedupeFinderTest/testCustomRule/

Before
----------------------------------------
Tests failed on stock MySQL 5.7 with ONLY_FULL_GROUP_BY mode set

After
----------------------------------------
Tests pass

Technical Details
----------------------------------------
because weight isn't dependant on anything it needs to be added to the group By Clause

Comments
----------------------------------------
@monishdeb @eileenmcnaughton any thoughts on this one. I have pulled this out separately from the other fixes and put this against the RC as its started failing in 4.7.28

---

 * [CRM-21364: Fix Tests which fail on ONLY_FULL_GROUP_BY](https://issues.civicrm.org/jira/browse/CRM-21364)