### PR TITLE
CRM-21385 - Hide wp admin bar when maximizing ckeditor

### DIFF
--- a/js/crm.wordpress.js
+++ b/js/crm.wordpress.js
@@ -10,5 +10,12 @@ CRM.$(function($) {
         // Restore admin bar position
         $('#adminmenuwrap').css('z-index', '');
       }
+    })
+    .on('crmWysiwygCreate', function(e, type, editor) {
+      if (type === 'ckeditor') {
+        editor.on('maximize', function(e) {
+          $('#wpadminbar').toggle(e.data === 2);
+        });
+      }
     });
 });

--- a/js/wysiwyg/crm.ckeditor.js
+++ b/js/wysiwyg/crm.ckeditor.js
@@ -48,6 +48,7 @@
       editor.on('maximize', function (e) {
         $('#civicrm-menu').toggle(e.data === 2);
       });
+      $(editor.element.$).trigger('crmWysiwygCreate', ['ckeditor', editor]);
       deferred.resolve();
     }
     


### PR DESCRIPTION
* [CRM-21385: WordPress top nav bar blocks top row of WYSIWYG editor when maximized](https://issues.civicrm.org/jira/browse/CRM-21385)