### PR TITLE
Fix Recurring contribution sql so that it doesen't use group by as th…

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -1446,11 +1446,10 @@ abstract class CRM_Core_Payment {
 
         case 'recur':
           $sql = "
-    SELECT con.contact_id
+    SELECT DISTINCT con.contact_id
       FROM civicrm_contribution_recur rec
 INNER JOIN civicrm_contribution con ON ( con.contribution_recur_id = rec.id )
-     WHERE rec.id = %1
-  GROUP BY rec.id";
+     WHERE rec.id = %1";
           $contactID = CRM_Core_DAO::singleValueQuery($sql, array(1 => array($entityID, 'Integer')));
           $entityArg = 'crid';
           break;


### PR DESCRIPTION
…ere doesn't appear to be a reason to do so given that we have a where id = x clause and we were grouping on the same field

Overview
----------------------------------------
This aims to fix the following test failure https://test.civicrm.org/job/CiviCRM-Core-Matrix/CIVIVER=4.7.28-rc,label=ubuntu1604/lastCompletedBuild/testReport/(root)/CRM_Core_Payment_AuthorizeNetIPNTest/testIPNPaymentRecurSuccess/

Before
----------------------------------------
Test fails

After
----------------------------------------
Test passes

@eileenmcnaughton i know you said before you felt like we could remove the join but i think its better kept in for consistency sake. Thoughts @monishdeb 