### PR TITLE
Fix Membership Detail and Contribution Detail Reports for ONLY_FULL_G…

### DIFF
--- a/CRM/Report/Form/Contribute/Detail.php
+++ b/CRM/Report/Form/Contribute/Detail.php
@@ -588,7 +588,7 @@ GROUP BY {$this->_aliases['civicrm_contribution']}.currency";
     $select = str_ireplace('contribution_civireport.total_amount', 'contribution_soft_civireport.amount', $this->_select);
     $select = str_ireplace("'Contribution' as", "'Soft Credit' as", $select);
     // We really don't want to join soft credit in if not required.
-    if (!empty($this->_groupBy) && !$this->noDisplayContributionOrSoftColumn) {
+    if (!empty($this->_groupBy) && $this->isTableSelected('contribution_soft_civireport')) {
       $this->_groupBy .= ', contribution_soft_civireport.amount';
     }
     // we inner join with temp1 to restrict soft contributions to those in temp1 table

--- a/CRM/Report/Form/Member/Detail.php
+++ b/CRM/Report/Form/Member/Detail.php
@@ -520,7 +520,7 @@ class CRM_Report_Form_Member_Detail extends CRM_Report_Form {
       ON cc.id = cmp.contribution_id
       WHERE cc.is_test = 0
       $dateWhere
-      GROUP BY cmp.membership_id";
+      GROUP BY cmp.membership_id, cc.contact_id";
     CRM_Core_DAO::executeQuery($sql);
     return $tempTable;
   }


### PR DESCRIPTION
…ROUP_BY SQL Mode

Overview
----------------------------------------
This PR aims to fix the following test failures caused by the ONLY_FULL_GROUP_BY sqlMode https://test.civicrm.org/job/CiviCRM-Core-Matrix/CIVIVER=4.7.28-rc,label=ubuntu1604/lastCompletedBuild/testReport/(root)/CRM_Report_Form_Contribute_DetailTest__testReportOutput/testReportOutput_with_data_set__0/ https://test.civicrm.org/job/CiviCRM-Core-Matrix/CIVIVER=4.7.28-rc,label=ubuntu1604/lastCompletedBuild/testReport/(root)/api_v3_ReportTemplateTest__testReportTemplateGetRowsAllReports/testReportTemplateGetRowsAllReports_with_data_set__15/

Before
----------------------------------------
Tests fail

After
----------------------------------------
Tests pass

Technical Details
----------------------------------------

ping @totten @eileenmcnaughton @monishdeb 