### PR TITLE
CRM-14343 - Remove limit of downloading only 250 errors during CSV import

### DIFF
--- a/CRM/Activity/Import/Parser.php
+++ b/CRM/Activity/Import/Parser.php
@@ -171,14 +171,12 @@ abstract class CRM_Activity_Import_Parser extends CRM_Import_Parser {
 
       if ($returnCode & self::ERROR) {
         $this->_invalidRowCount++;
-        if ($this->_invalidRowCount < $this->_maxErrorCount) {
-          $recordNumber = $this->_lineCount;
-          if ($this->_haveColumnHeader) {
-            $recordNumber--;
-          }
-          array_unshift($values, $recordNumber);
-          $this->_errors[] = $values;
+        $recordNumber = $this->_lineCount;
+        if ($this->_haveColumnHeader) {
+          $recordNumber--;
         }
+        array_unshift($values, $recordNumber);
+        $this->_errors[] = $values;
       }
 
       if ($returnCode & self::CONFLICT) {

--- a/CRM/Contact/Import/Parser.php
+++ b/CRM/Contact/Import/Parser.php
@@ -271,10 +271,8 @@ abstract class CRM_Contact_Import_Parser extends CRM_Import_Parser {
 
       if ($returnCode & self::ERROR) {
         $this->_invalidRowCount++;
-        if ($this->_invalidRowCount < $this->_maxErrorCount) {
-          array_unshift($values, $this->_rowCount);
-          $this->_errors[] = $values;
-        }
+        array_unshift($values, $this->_rowCount);
+        $this->_errors[] = $values;
       }
 
       if ($returnCode & self::CONFLICT) {

--- a/CRM/Contribute/Import/Parser.php
+++ b/CRM/Contribute/Import/Parser.php
@@ -256,38 +256,32 @@ abstract class CRM_Contribute_Import_Parser extends CRM_Import_Parser {
 
       if ($returnCode == self::ERROR) {
         $this->_invalidRowCount++;
-        if ($this->_invalidRowCount < $this->_maxErrorCount) {
-          $recordNumber = $this->_lineCount;
-          if ($this->_haveColumnHeader) {
-            $recordNumber--;
-          }
-          array_unshift($values, $recordNumber);
-          $this->_errors[] = $values;
+        $recordNumber = $this->_lineCount;
+        if ($this->_haveColumnHeader) {
+          $recordNumber--;
         }
+        array_unshift($values, $recordNumber);
+        $this->_errors[] = $values;
       }
 
       if ($returnCode == self::PLEDGE_PAYMENT_ERROR) {
         $this->_invalidPledgePaymentRowCount++;
-        if ($this->_invalidPledgePaymentRowCount < $this->_maxErrorCount) {
-          $recordNumber = $this->_lineCount;
-          if ($this->_haveColumnHeader) {
-            $recordNumber--;
-          }
-          array_unshift($values, $recordNumber);
-          $this->_pledgePaymentErrors[] = $values;
+        $recordNumber = $this->_lineCount;
+        if ($this->_haveColumnHeader) {
+          $recordNumber--;
         }
+        array_unshift($values, $recordNumber);
+        $this->_pledgePaymentErrors[] = $values;
       }
 
       if ($returnCode == self::SOFT_CREDIT_ERROR) {
         $this->_invalidSoftCreditRowCount++;
-        if ($this->_invalidSoftCreditRowCount < $this->_maxErrorCount) {
-          $recordNumber = $this->_lineCount;
-          if ($this->_haveColumnHeader) {
-            $recordNumber--;
-          }
-          array_unshift($values, $recordNumber);
-          $this->_softCreditErrors[] = $values;
+        $recordNumber = $this->_lineCount;
+        if ($this->_haveColumnHeader) {
+          $recordNumber--;
         }
+        array_unshift($values, $recordNumber);
+        $this->_softCreditErrors[] = $values;
       }
 
       if ($returnCode == self::CONFLICT) {

--- a/CRM/Custom/Import/Parser.php
+++ b/CRM/Custom/Import/Parser.php
@@ -191,14 +191,12 @@ abstract class CRM_Custom_Import_Parser extends CRM_Contact_Import_Parser {
 
       if ($returnCode & self::ERROR) {
         $this->_invalidRowCount++;
-        if ($this->_invalidRowCount < $this->_maxErrorCount) {
-          $recordNumber = $this->_lineCount;
-          if ($this->_haveColumnHeader) {
-            $recordNumber--;
-          }
-          array_unshift($values, $recordNumber);
-          $this->_errors[] = $values;
+        $recordNumber = $this->_lineCount;
+        if ($this->_haveColumnHeader) {
+          $recordNumber--;
         }
+        array_unshift($values, $recordNumber);
+        $this->_errors[] = $values;
       }
 
       if ($returnCode & self::CONFLICT) {

--- a/CRM/Event/Import/Parser.php
+++ b/CRM/Event/Import/Parser.php
@@ -192,14 +192,12 @@ abstract class CRM_Event_Import_Parser extends CRM_Import_Parser {
 
       if ($returnCode & self::ERROR) {
         $this->_invalidRowCount++;
-        if ($this->_invalidRowCount < $this->_maxErrorCount) {
-          $recordNumber = $this->_lineCount;
-          if ($this->_haveColumnHeader) {
-            $recordNumber--;
-          }
-          array_unshift($values, $recordNumber);
-          $this->_errors[] = $values;
+        $recordNumber = $this->_lineCount;
+        if ($this->_haveColumnHeader) {
+          $recordNumber--;
         }
+        array_unshift($values, $recordNumber);
+        $this->_errors[] = $values;
       }
 
       if ($returnCode & self::CONFLICT) {

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -34,7 +34,7 @@ abstract class CRM_Import_Parser {
   /**
    * Settings
    */
-  const MAX_ERRORS = 250, MAX_WARNINGS = 25, DEFAULT_TIMEOUT = 30;
+  const MAX_WARNINGS = 25, DEFAULT_TIMEOUT = 30;
 
   /**
    * Return codes
@@ -78,11 +78,6 @@ abstract class CRM_Import_Parser {
    * @var int
    */
   protected $_maxLinesToProcess;
-
-  /**
-   * Maximum number of invalid rows to store
-   */
-  protected $_maxErrorCount;
 
   /**
    * Array of error lines, bounded by MAX_ERROR
@@ -192,7 +187,6 @@ abstract class CRM_Import_Parser {
    */
   public function __construct() {
     $this->_maxLinesToProcess = 0;
-    $this->_maxErrorCount = self::MAX_ERRORS;
   }
 
   /**

--- a/CRM/Member/Import/Parser.php
+++ b/CRM/Member/Import/Parser.php
@@ -191,11 +191,9 @@ abstract class CRM_Member_Import_Parser extends CRM_Import_Parser {
 
       if ($returnCode & self::ERROR) {
         $this->_invalidRowCount++;
-        if ($this->_invalidRowCount < $this->_maxErrorCount) {
-          $recordNumber = $this->_lineCount;
-          array_unshift($values, $recordNumber);
-          $this->_errors[] = $values;
-        }
+        $recordNumber = $this->_lineCount;
+        array_unshift($values, $recordNumber);
+        $this->_errors[] = $values;
       }
 
       if ($returnCode & self::CONFLICT) {


### PR DESCRIPTION
## Before

When you download the CSV errors from your CSV import, you only get 250 error rows even if the import has more than 250 errors.

## After

There is no limit to the number of errors you can download.

## Comments

See [CRM-14343](https://issues.civicrm.org/jira/browse/CRM-14343) for more details including

* straightforward steps to reproduce
* the results of a performance test suggesting that removing this limit does not adversely affect performance
* opinions from other people supporting this change


