### PR TITLE
CRM-21388 Only throw execption if Extexsion Key is set in the url

### DIFF
--- a/CRM/Admin/Form/Extensions.php
+++ b/CRM/Admin/Form/Extensions.php
@@ -52,7 +52,7 @@ class CRM_Admin_Form_Extensions extends CRM_Admin_Form {
     $this->_key = CRM_Utils_Request::retrieve('key', 'String',
       $this, FALSE, 0
     );
-    if (!CRM_Utils_Type::validate($this->_key, 'ExtensionKey')) {
+    if (!CRM_Utils_Type::validate($this->_key, 'ExtensionKey') && !empty($this->_key)) {
       throw new CRM_Core_Exception('Extension Key does not match expected standard');
     }
     $session = CRM_Core_Session::singleton();


### PR DESCRIPTION
Overview
----------------------------------------
System will throw Exception if Extension key isn't passed through in the url and reset=1 isn't present. We should be only validating extension key if it is set

Before
----------------------------------------
Exception is thrown when key isn't set

After
----------------------------------------
Not Exception thrown

@monishdeb @eileenmcnaughton @seanmadsen does this look right to you. Putting this to rc as was introduced in .26

---

 * [CRM-21388: Extension Page should only throw exception if key is set](https://issues.civicrm.org/jira/browse/CRM-21388)