### PR TITLE
CRM-21389 Added pre and post regions to each entitys userdashboard

### DIFF
--- a/templates/CRM/Activity/Page/UserDashboard.tpl
+++ b/templates/CRM/Activity/Page/UserDashboard.tpl
@@ -23,6 +23,8 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
+{crmRegion name="crm-activity-userdashboard-pre"}
+{/crmRegion}
 <div class="view-content">
     {if $activity_rows}
         {strip}
@@ -67,3 +69,5 @@ q="action=view&reset=1&id=`$row.activity_id`&cid=`$row.contact_id`&context=dashb
         </div>
     {/if}
 </div>
+{crmRegion name="crm-activity-userdashboard-post"}
+{/crmRegion}

--- a/templates/CRM/Contact/Page/View/RelationshipSelector.tpl
+++ b/templates/CRM/Contact/Page/View/RelationshipSelector.tpl
@@ -24,6 +24,8 @@
  +--------------------------------------------------------------------+
 *}
 {* relationship selector *}
+{crmRegion name="crm-contact-relationshipselector-pre"}
+{/crmRegion}
 <div class="crm-contact-relationship-{$context}">
   <table
     class="crm-contact-relationship-selector-{$context} crm-ajax-table"
@@ -43,3 +45,5 @@
     </thead>
   </table>
 </div>
+{crmRegion name="crm-contact-relationshipselector-post"}
+{/crmRegion}

--- a/templates/CRM/Contact/Page/View/UserDashBoard/GroupContact.tpl
+++ b/templates/CRM/Contact/Page/View/UserDashBoard/GroupContact.tpl
@@ -23,6 +23,8 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
+{crmRegion name="crm-contact-userdashboard-groupcontact-pre"}
+{/crmRegion}
 <div id="groupContact">
     <div class="view-content">
         {if $groupCount eq 0 }
@@ -131,3 +133,5 @@
         {/if}
     </div>
 </div>
+{crmRegion name="crm-contact-userdashboard-groupcontact-post"}
+{/crmRegion}

--- a/templates/CRM/Contribute/Page/PcpUserDashboard.tpl
+++ b/templates/CRM/Contribute/Page/PcpUserDashboard.tpl
@@ -23,6 +23,8 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
+{crmRegion name="crm-contribute-pcp-userdashboard-pre"}
+{/crmRegion}
 <div class="view-content">
 
 {if $pcpInfo}
@@ -88,3 +90,5 @@
 {/if}
 
 </div>
+{crmRegion name="crm-contribute-pcp-userdashboard-post"}
+{/crmRegion}

--- a/templates/CRM/Contribute/Page/UserDashboard.tpl
+++ b/templates/CRM/Contribute/Page/UserDashboard.tpl
@@ -23,6 +23,8 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
+{crmRegion name="crm-contribute-userdashboard-pre"}
+{/crmRegion}
 <div class="view-content">
     {if $contribute_rows}
         {strip}
@@ -158,3 +160,5 @@
         {/if}
     {/if}
 </div>
+{crmRegion name="crm-contribute-userdashboard-post"}
+{/crmRegion}

--- a/templates/CRM/Event/Page/UserDashboard.tpl
+++ b/templates/CRM/Event/Page/UserDashboard.tpl
@@ -23,6 +23,8 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
+{crmRegion name="crm-event-userdashboard-pre"}
+{/crmRegion}
 <div class="view-content">
     {if $event_rows}
         {strip}
@@ -70,3 +72,5 @@
         </div>
     {/if}
 </div>
+{crmRegion name="crm-event-userdashboard-post"}
+{/crmRegion}

--- a/templates/CRM/Member/Page/UserDashboard.tpl
+++ b/templates/CRM/Member/Page/UserDashboard.tpl
@@ -23,6 +23,8 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
+{crmRegion name="crm-member-userdashboard-pre"}
+{/crmRegion}
 <div class="view-content">
 {if $activeMembers}
 <div id="memberships">
@@ -92,3 +94,5 @@
    </div>
 {/if}
 </div>
+{crmRegion name="crm-member-userdashboard-post"}
+{/crmRegion}

--- a/templates/CRM/Pledge/Page/UserDashboard.tpl
+++ b/templates/CRM/Pledge/Page/UserDashboard.tpl
@@ -23,6 +23,8 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
+{crmRegion name="crm-pledge-userdashboard-pre"}
+{/crmRegion}
 {if $context eq 'user'}
 <div class="view-content">
 {if $pledge_rows}
@@ -99,3 +101,5 @@
 </div>
 {* main if close*}
 {/if}
+{crmRegion name="crm-pledge-userdashboard-post"}
+{/crmRegion}


### PR DESCRIPTION
Overview
----------------------------------------
Adds pre and post regions to each entity's userdashboard for developer injection

Before
----------------------------------------
NA

After
----------------------------------------
NA

Technical Details
----------------------------------------
Example:
File `civicrm/templates/CRM/Contribute/Page/PcpUserDashboard.tpl`
```
{crmRegion name="crm-contribute-pcp-userdashboard-pre"}
{/crmRegion}
```

Comments
----------------------------------------
Doubt: Do smarty templates require an empty line at the end of them?

---

 * [CRM-21389: Add Regions to Contact UserDashBoard](https://issues.civicrm.org/jira/browse/CRM-21389)