### PR TITLE
CRM-20164 Fix IPN notify URL with Joomla when derived from menu item

### DIFF
--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -264,7 +264,7 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
 
     if ($config->userFrameworkFrontend) {
       $script = 'index.php';
-      if (JRequest::getVar("Itemid")) {
+      if (JRequest::getVar("Itemid") && (strpos($path, 'civicrm/payment/ipn') === FALSE)) {
         $Itemid = "{$separator}Itemid=" . JRequest::getVar("Itemid");
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
In Joomla, menu items have an &Itemid=## param appended to URLs. If a contribution page is created as a menu item, all CiviCRM paths then have this value appended, and that value is carried through to any other URL constructions, including the notify_url passed to PayPal. It seems that the presence of that param throws off the IPN processing – I suspect that an Itemid lookup occurs to get the original menu parameters, which then override notify_url.

Before
----------------------------------------
Paypal IPN doesn't work when contribution page used via a Joomla menu item

After
----------------------------------------
Paypal IPN works when contribution page used via a Joomla menu item

@lcdservices Could you verify/review this please?