### PR TITLE
CRM-19484 Contribution amount when set to 0 hides payment block

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -502,7 +502,7 @@
       });
       priceSetTotal = currentTotal;
       cj('.price-set-option-content input, .other_amount-content input').on('input', function () {
-        currentTotal = cj(this).is('[data-amount]') ? cj(this).attr('data-amount').replace(/[^\/\d]/g,'') : (cj(this).val() ? cj(this).val().replace(/[^\/\d]/g : 0);
+        currentTotal = cj(this).is('[data-amount]') ? cj(this).attr('data-amount').replace(/[^\/\d]/g,'') : (cj(this).val() ? cj(this).val().replace(/[^\/\d]/g,'') : 0);
         currentTotal = currentTotal + priceSetTotal;
         if (currentTotal == 0 ) {
           flag = true;


### PR DESCRIPTION
fixing syntax to allow selection of contribution amounts on the page

Overview
----------------------------------------
the prior fix to this introduced another error that broke one of our contribution pages

Before
----------------------------------------
console shows `Uncaught SyntaxError: missing ) after argument list` (replicated on demo)

After
----------------------------------------
just closed the needed replace statement & it seemed to work

----------------------------------------
sorry about the bad formatting of this PR and for any confusion caused as a result, it was kinda late when I was messing with this.

---

 * [CRM-19484: Contribution amount when set to £0 hides payment block](https://issues.civicrm.org/jira/browse/CRM-19484)