### PR TITLE
CRM-18236: Broadened selection criteria so that contacts who...

### DIFF
--- a/Civi/ActionSchedule/RecipientBuilder.php
+++ b/Civi/ActionSchedule/RecipientBuilder.php
@@ -176,13 +176,10 @@ class RecipientBuilder {
    * @param string $entityTableAlias
    * @return string
    */
-  protected function previousRunsToday($entityTableAlias) {
-    return "SELECT log.contact_id
+  protected function previousRunsToday() {
+    return "SELECT DISTINCT log.contact_id
       FROM civicrm_action_log log
-      WHERE log.contact_id = $entityTableAlias.contact_id
-      AND log.entity_id = $entityTableAlias.id
-      AND log.entity_table = '!casMappingEntity'
-      AND log.action_schedule_id = #casActionScheduleId
+      WHERE  log.action_schedule_id = #casActionScheduleId
       AND log.action_date_time > DATE_SUB(!casNow, INTERVAL 1 DAY)";
   }
 
@@ -225,7 +222,7 @@ class RecipientBuilder {
     if (empty($referenceReminderIDs)) {
       $firstQuery = $query->copy()
         ->merge($this->selectIntoActionLog(self::PHASE_RELATION_FIRST, $query))
-        ->where("e.contact_id NOT IN ({$this->previousRunsToday('e')})")
+        ->where("!casContactIdField NOT IN ({$this->previousRunsToday()})")
         ->where($startDateClauses)
         ->strict()
         ->toSQL();
@@ -260,7 +257,7 @@ class RecipientBuilder {
     $insertAdditionalSql = \CRM_Utils_SQL_Select::from("civicrm_contact c")
       ->merge($query, array('params'))
       ->merge($this->selectIntoActionLog(self::PHASE_ADDITION_FIRST, $query))
-      ->where("e.contact_id NOT IN ({$this->previousRunsToday('e')})")
+      ->where("grp.contact_id NOT IN ({$this->previousRunsToday()})")
       ->where("c.is_deleted = 0 AND c.is_deceased = 0")
       ->merge($this->prepareAddlFilter('c.id'))
       ->where("c.id NOT IN (

--- a/Civi/ActionSchedule/RecipientBuilder.php
+++ b/Civi/ActionSchedule/RecipientBuilder.php
@@ -173,7 +173,6 @@ class RecipientBuilder {
    * sends, e.g. $myQuery->where("e.contact_id NOT IN ({$this->previousRunsToday('e')})").
    * See CRM-18236.
    *
-   * @param string $entityTableAlias
    * @return string
    */
   protected function previousRunsToday() {


### PR DESCRIPTION
Overview
----------------------------------------
Broadened selection criteria so that contacts who have
received a non-recurring reminder in the past (e.g., for LAST year's
membership) can be included. Necessitated adding protection against
multiple sends in the same day.

Before
----------------------------------------
See symptoms reported on the bug. Additionally, we found that the second year in an annual membership expiration reminder under-sent, excluding contacts reminded last year.

After
----------------------------------------
Made the logic smarter so we could both include the inappropriately excluded contacts and prevent multiple sends in the same day (in case someone configures the scheduled job to run more than once daily).

Comments
----------------------------------------
Patch made against RC branch as we feel this is a regression introduced by pull requests which sought to solve duplicate sends.

---

 * [CRM-18236: Scheduled reminder sends multiple reminders when reference date has changed](https://issues.civicrm.org/jira/browse/CRM-18236)