### PR TITLE
CRM-21391 Refactor form search to use a base class, resolve issues with action …

### DIFF
--- a/CRM/Campaign/Form/Search.php
+++ b/CRM/Campaign/Form/Search.php
@@ -205,8 +205,7 @@ class CRM_Campaign_Form_Search extends CRM_Core_Form_Search {
         $this->addRowSelectors($rows);
       }
 
-      $permission = CRM_Core_Permission::getPermission();
-      $allTasks = CRM_Campaign_Task::permissionedTaskTitles($permission);
+      $allTasks = CRM_Campaign_Task::permissionedTaskTitles(CRM_Core_Permission::getPermission());
 
       //hack to serve right page to state machine.
       $taskMapping = array(

--- a/CRM/Campaign/Task.php
+++ b/CRM/Campaign/Task.php
@@ -36,22 +36,15 @@
  *
  * Used by the search forms.
  */
-class CRM_Campaign_Task {
-  const INTERVIEW = 1, RESERVE = 2, RELEASE = 3, PRINT_VOTERS = 4;
+class CRM_Campaign_Task extends CRM_Core_Task {
 
-  /**
-   * The task array
-   *
-   * @var array
-   */
-  static $_tasks = NULL;
+  const
+    // Campaign tasks
+    INTERVIEW = 601,
+    RESERVE = 602,
+    RELEASE = 603;
 
-  /**
-   * The optional task array
-   *
-   * @var array
-   */
-  static $_optionalTasks = NULL;
+  static $objectType = 'campaign';
 
   /**
    * These tasks are the core set of tasks that the user can perform
@@ -60,10 +53,10 @@ class CRM_Campaign_Task {
    * @return array
    *   the set of tasks for a group of voters.
    */
-  public static function &tasks() {
+  public static function tasks() {
     if (!(self::$_tasks)) {
       self::$_tasks = array(
-        1 => array(
+        self::INTERVIEW => array(
           'title' => ts('Record Respondents Interview'),
           'class' => array(
             'CRM_Campaign_Form_Task_Interview',
@@ -71,7 +64,7 @@ class CRM_Campaign_Task {
           ),
           'result' => FALSE,
         ),
-        2 => array(
+        self::RESERVE => array(
           'title' => ts('Reserve Respondents'),
           'class' => array(
             'CRM_Campaign_Form_Task_Reserve',
@@ -80,40 +73,22 @@ class CRM_Campaign_Task {
           ),
           'result' => FALSE,
         ),
-        3 => array(
+        self::RELEASE => array(
           'title' => ts('Release Respondents'),
           'class' => 'CRM_Campaign_Form_Task_Release',
           'result' => FALSE,
         ),
-        4 => array(
+        self::TASK_PRINT => array(
           'title' => ts('Print Respondents'),
           'class' => 'CRM_Campaign_Form_Task_Print',
           'result' => FALSE,
         ),
       );
 
-      CRM_Utils_Hook::searchTasks('campaign', self::$_tasks);
-      asort(self::$_tasks);
+      parent::tasks();
     }
 
     return self::$_tasks;
-  }
-
-  /**
-   * These tasks are the core set of task titles
-   * on voters.
-   *
-   * @return array
-   *   the set of task titles
-   */
-  public static function &taskTitles() {
-    self::tasks();
-    $titles = array();
-    foreach (self::$_tasks as $id => $value) {
-      $titles[$id] = $value['title'];
-    }
-
-    return $titles;
   }
 
   /**
@@ -121,13 +96,15 @@ class CRM_Campaign_Task {
    * of the user
    *
    * @param int $permission
+   * @param array $params
    *
    * @return array
    *   set of tasks that are valid for the user
    */
-  public static function &permissionedTaskTitles($permission) {
+  public static function permissionedTaskTitles($permission, $params = array()) {
     $tasks = self::taskTitles();
 
+    $tasks = parent::corePermissionedTaskTitles($tasks, $permission, $params);
     return $tasks;
   }
 
@@ -143,8 +120,8 @@ class CRM_Campaign_Task {
   public static function getTask($value) {
     self::tasks();
     if (!$value || !CRM_Utils_Array::value($value, self::$_tasks)) {
-      // make the interview task by default
-      $value = 1;
+      // Set the interview task as default
+      $value = self::INTERVIEW;
     }
 
     return array(

--- a/CRM/Case/Form/Search.php
+++ b/CRM/Case/Form/Search.php
@@ -174,15 +174,13 @@ class CRM_Case_Form_Search extends CRM_Core_Form_Search {
         $this->addRowSelectors($rows);
       }
 
-      $permission = CRM_Core_Permission::getPermission();
-
-      $tasks = CRM_Case_Task::permissionedTaskTitles($permission);
+      $tasks = CRM_Case_Task::permissionedTaskTitles(CRM_Core_Permission::getPermission());
 
       if (!empty($this->_formValues['case_deleted'])) {
-        unset($tasks[1]);
+        unset($tasks[CRM_Case_Task::DELETE]);
       }
       else {
-        unset($tasks[4]);
+        unset($tasks[CRM_Case_Task::RESTORE_CASES]);
       }
 
       $this->addTaskMenu($tasks);

--- a/CRM/Case/Task.php
+++ b/CRM/Case/Task.php
@@ -36,22 +36,13 @@
  *
  * Used by the search forms
  */
-class CRM_Case_Task {
-  const DELETE_CASES = 1, PRINT_CASES = 2, EXPORT_CASES = 3, RESTORE_CASES = 4;
+class CRM_Case_Task extends CRM_Core_Task {
 
-  /**
-   * The task array
-   *
-   * @var array
-   */
-  static $_tasks = NULL;
+  const
+    // Case tasks
+    RESTORE_CASES = 501;
 
-  /**
-   * The optional task array
-   *
-   * @var array
-   */
-  static $_optionalTasks = NULL;
+  static $objectType = 'case';
 
   /**
    * These tasks are the core set of tasks that the user can perform
@@ -60,20 +51,20 @@ class CRM_Case_Task {
    * @return array
    *   the set of tasks for a group of contacts
    */
-  public static function &tasks() {
+  public static function tasks() {
     if (!self::$_tasks) {
       self::$_tasks = array(
-        1 => array(
+        self::TASK_DELETE => array(
           'title' => ts('Delete cases'),
           'class' => 'CRM_Case_Form_Task_Delete',
           'result' => FALSE,
         ),
-        2 => array(
+        self::TASK_PRINT => array(
           'title' => ts('Print selected rows'),
           'class' => 'CRM_Case_Form_Task_Print',
           'result' => FALSE,
         ),
-        3 => array(
+        self::TASK_EXPORT => array(
           'title' => ts('Export cases'),
           'class' => array(
             'CRM_Export_Form_Select',
@@ -81,17 +72,17 @@ class CRM_Case_Task {
           ),
           'result' => FALSE,
         ),
-        4 => array(
+        self::RESTORE_CASES => array(
           'title' => ts('Restore cases'),
           'class' => 'CRM_Case_Form_Task_Restore',
           'result' => FALSE,
         ),
-        5 => array(
+        self::PDF_LETTER => array(
           'title' => ts('Print/merge Document'),
           'class' => 'CRM_Case_Form_Task_PDF',
           'result' => FALSE,
         ),
-        6 => array(
+        self::BATCH_UPDATE => array(
           'title' => ts('Update multiple cases'),
           'class' => array(
             'CRM_Case_Form_Task_PickProfile',
@@ -103,40 +94,13 @@ class CRM_Case_Task {
 
       //CRM-4418, check for delete
       if (!CRM_Core_Permission::check('delete in CiviCase')) {
-        unset(self::$_tasks[1]);
+        unset(self::$_tasks[self::TASK_DELETE]);
       }
 
-      CRM_Utils_Hook::searchTasks('case', self::$_tasks);
-      asort(self::$_tasks);
+      parent::tasks();
     }
 
     return self::$_tasks;
-  }
-
-  /**
-   * These tasks are the core set of task titles.
-   *
-   * @return array
-   *   the set of task titles
-   */
-  public static function &taskTitles() {
-    self::tasks();
-    $titles = array();
-    foreach (self::$_tasks as $id => $value) {
-      $titles[$id] = $value['title'];
-    }
-    return $titles;
-  }
-
-  /**
-   * These tasks get added based on the context the user is in.
-   *
-   * @return array
-   *   the set of optional tasks for a group of contacts
-   */
-  public static function &optionalTaskTitle() {
-    $tasks = array();
-    return $tasks;
   }
 
   /**
@@ -144,12 +108,12 @@ class CRM_Case_Task {
    * of the user
    *
    * @param int $permission
+   * @param array $params
    *
    * @return array
    *   set of tasks that are valid for the user
    */
-  public static function &permissionedTaskTitles($permission) {
-    $tasks = array();
+  public static function permissionedTaskTitles($permission, $params = array()) {
     if (($permission == CRM_Core_Permission::EDIT)
       || CRM_Core_Permission::check('access all cases and activities')
       || CRM_Core_Permission::check('access my cases and activities')
@@ -158,13 +122,15 @@ class CRM_Case_Task {
     }
     else {
       $tasks = array(
-        3 => self::$_tasks[3]['title'],
+        self::TASK_EXPORT => self::$_tasks[self::TASK_EXPORT]['title'],
       );
       //CRM-4418,
       if (CRM_Core_Permission::check('delete in CiviCase')) {
-        $tasks[1] = self::$_tasks[1]['title'];
+        $tasks[self::TASK_DELETE] = self::$_tasks[self::TASK_DELETE]['title'];
       }
     }
+
+    $tasks = parent::corePermissionedTaskTitles($tasks, $permission, $params);
     return $tasks;
   }
 
@@ -180,7 +146,7 @@ class CRM_Case_Task {
     self::tasks();
     if (!$value || !CRM_Utils_Array::value($value, self::$_tasks)) {
       // make the print task by default
-      $value = 2;
+      $value = self::TASK_PRINT;
     }
 
     return array(

--- a/CRM/Contact/Form/Task.php
+++ b/CRM/Contact/Form/Task.php
@@ -104,7 +104,7 @@ class CRM_Contact_Form_Task extends CRM_Core_Form {
     if ($isStandAlone) {
       list($form->_task, $title) = CRM_Contact_Task::getTaskAndTitleByClass(get_class($form));
       if (!array_key_exists($form->_task, CRM_Contact_Task::permissionedTaskTitles(CRM_Core_Permission::getPermission()))) {
-        CRM_Core_Error::fatal(ts('You do not have permission to access this page.'));
+        CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
       }
       $form->_contactIds = explode(',', CRM_Utils_Request::retrieve('cids', 'CommaSeparatedIntegers', $form, TRUE));
       if (empty($form->_contactIds)) {

--- a/CRM/Contact/Task.php
+++ b/CRM/Contact/Task.php
@@ -34,79 +34,48 @@
 /**
  * Class to represent the actions that can be performed on a group of contacts used by the search forms.
  */
-class CRM_Contact_Task {
+class CRM_Contact_Task extends CRM_Core_Task {
+
   const
-    GROUP_CONTACTS = 1,
-    REMOVE_CONTACTS = 2,
-    TAG_CONTACTS = 3,
-    REMOVE_TAGS = 4,
-    EXPORT_CONTACTS = 5,
-    EMAIL_CONTACTS = 6,
-    SMS_CONTACTS = 7,
-    DELETE_CONTACTS = 8,
-    HOUSEHOLD_CONTACTS = 9,
-    ORGANIZATION_CONTACTS = 10,
-    RECORD_CONTACTS = 11,
-    MAP_CONTACTS = 12,
-    SAVE_SEARCH = 13,
-    SAVE_SEARCH_UPDATE = 14,
-    PRINT_CONTACTS = 15,
-    LABEL_CONTACTS = 16,
-    BATCH_UPDATE = 17,
-    ADD_EVENT = 18,
-    PRINT_FOR_CONTACTS = 19,
-    CREATE_MAILING = 20,
-    MERGE_CONTACTS = 21,
-    EMAIL_UNHOLD = 22,
-    RESTORE = 23,
-    DELETE_PERMANENTLY = 24,
-    COMMUNICATION_PREFS = 25,
-    INDIVIDUAL_CONTACTS = 26,
-    ADD_TO_CASE = 27;
+    // Contact tasks
+    HOUSEHOLD_CONTACTS = 101,
+    ORGANIZATION_CONTACTS = 102,
+    RECORD_CONTACTS = 103,
+    MAP_CONTACTS = 104,
+    ADD_EVENT = 105,
+    MERGE_CONTACTS = 106,
+    EMAIL_UNHOLD = 107,
+    RESTORE = 108,
+    COMMUNICATION_PREFS = 109,
+    INDIVIDUAL_CONTACTS = 110,
+    ADD_TO_CASE = 111;
 
-  /**
-   * The task array
-   *
-   * @var array
-   */
-  static $_tasks = NULL;
-
-  /**
-   * The optional task array
-   *
-   * @var array
-   */
-  static $_optionalTasks = NULL;
+  static $objectType = 'contact';
 
   public static function tasks() {
-    self::initTasks();
-    return self::$_tasks;
-  }
-
-  public static function initTasks() {
     if (!self::$_tasks) {
       self::$_tasks = array(
-        self::GROUP_CONTACTS => array(
+        self::GROUP_ADD => array(
           'title' => ts('Group - add contacts'),
           'class' => 'CRM_Contact_Form_Task_AddToGroup',
           'url' => 'civicrm/task/add-to-group',
         ),
-        self::REMOVE_CONTACTS => array(
+        self::GROUP_REMOVE => array(
           'title' => ts('Group - remove contacts'),
           'class' => 'CRM_Contact_Form_Task_RemoveFromGroup',
           'url' => 'civicrm/task/remove-from-group',
         ),
-        self::TAG_CONTACTS => array(
+        self::TAG_ADD => array(
           'title' => ts('Tag - add to contacts'),
           'class' => 'CRM_Contact_Form_Task_AddToTag',
           'url' => 'civicrm/task/add-to-tag',
         ),
-        self::REMOVE_TAGS => array(
+        self::TAG_REMOVE => array(
           'title' => ts('Tag - remove from contacts'),
           'class' => 'CRM_Contact_Form_Task_RemoveFromTag',
           'url' => 'civicrm/task/remove-from-tag',
         ),
-        self::EXPORT_CONTACTS => array(
+        self::TASK_EXPORT => array(
           'title' => ts('Export contacts'),
           'class' => array(
             'CRM_Export_Form_Select',
@@ -114,13 +83,16 @@ class CRM_Contact_Task {
           ),
           'result' => FALSE,
         ),
-        self::EMAIL_CONTACTS => array(
-          'title' => ts('Email - send now (to %1 or less)', array(1 => Civi::settings()->get('simple_mail_limit'))),
+        self::TASK_EMAIL => array(
+          'title' => ts('Email - send now (to %1 or less)', array(
+            1 => Civi::settings()
+              ->get('simple_mail_limit'),
+          )),
           'class' => 'CRM_Contact_Form_Task_Email',
           'result' => TRUE,
           'url' => 'civicrm/task/send-email',
         ),
-        self::DELETE_CONTACTS => array(
+        self::TASK_DELETE => array(
           'title' => ts('Delete contacts'),
           'class' => 'CRM_Contact_Form_Task_Delete',
           'result' => FALSE,
@@ -140,7 +112,7 @@ class CRM_Contact_Task {
           'class' => 'CRM_Contact_Form_Task_SaveSearch_Update',
           'result' => TRUE,
         ),
-        self::PRINT_CONTACTS => array(
+        self::TASK_PRINT => array(
           'title' => ts('Print selected rows'),
           'class' => 'CRM_Contact_Form_Task_Print',
           'result' => FALSE,
@@ -160,7 +132,7 @@ class CRM_Contact_Task {
           'result' => TRUE,
           'url' => 'civicrm/task/pick-profile',
         ),
-        self::PRINT_FOR_CONTACTS => array(
+        self::PDF_LETTER => array(
           'title' => ts('Print/merge document'),
           'class' => 'CRM_Contact_Form_Task_PDF',
           'result' => TRUE,
@@ -191,7 +163,7 @@ class CRM_Contact_Task {
       //CRM-16329, if SMS provider is configured show sms action.
       $providersCount = CRM_SMS_BAO_Provider::activeProviderCount();
       if ($providersCount) {
-        self::$_tasks[self::SMS_CONTACTS] = array(
+        self::$_tasks[self::TASK_SMS] = array(
           'title' => ts('SMS - schedule/send'),
           'class' => 'CRM_Contact_Form_Task_SMS',
           'result' => TRUE,
@@ -238,7 +210,7 @@ class CRM_Contact_Task {
 
       //CRM-4418, check for delete
       if (!CRM_Core_Permission::check('delete contacts')) {
-        unset(self::$_tasks[self::DELETE_CONTACTS]);
+        unset(self::$_tasks[self::TASK_DELETE]);
       }
 
       //show map action only if map provider and geoprovider are set (Google doesn't need geoprovider)
@@ -284,42 +256,10 @@ class CRM_Contact_Task {
         );
       }
 
-      self::$_tasks += CRM_Core_Component::taskList();
-
-      CRM_Utils_Hook::searchTasks('contact', self::$_tasks);
-    }
-  }
-
-  /**
-   * These tasks are the core set of tasks that the user can perform
-   * on a contact / group of contacts
-   *
-   * @return array
-   *   the set of tasks for a group of contacts
-   */
-  public static function &taskTitles() {
-    self::initTasks();
-
-    $titles = array();
-    foreach (self::$_tasks as $id => $value) {
-      $titles[$id] = $value['title'];
+      parent::tasks();
     }
 
-    // hack unset update saved search
-    unset($titles[self::SAVE_SEARCH_UPDATE]);
-
-    if (!CRM_Utils_Mail::validOutBoundMail()) {
-      unset($titles[self::EMAIL_CONTACTS]);
-      unset($titles[self::CREATE_MAILING]);
-    }
-
-    // CRM-6806
-    if (!CRM_Core_Permission::check('access deleted contacts') ||
-      !CRM_Core_Permission::check('delete contacts')
-    ) {
-      unset($titles[self::DELETE_PERMANENTLY]);
-    }
-    return $titles;
+    return self::$_tasks;
   }
 
   /**
@@ -327,16 +267,19 @@ class CRM_Contact_Task {
    * of the user
    *
    * @param int $permission
-   * @param bool $deletedContacts
-   *   Are these tasks for operating on deleted contacts?.
+   * @param array $params
+   *             bool deletedContacts: Are these tasks for operating on deleted contacts?.
    *
    * @return array
    *   set of tasks that are valid for the user
    */
-  public static function &permissionedTaskTitles($permission, $deletedContacts = FALSE) {
-    self::initTasks();
+  public static function permissionedTaskTitles($permission, $params = array()) {
+    if (!isset($params['deletedContacts'])) {
+      $params['deletedContacts'] = FALSE;
+    }
+    self::tasks();
     $tasks = array();
-    if ($deletedContacts) {
+    if ($params['deletedContacts']) {
       if (CRM_Core_Permission::check('access deleted contacts')) {
         $tasks[self::RESTORE] = self::$_tasks[self::RESTORE]['title'];
         if (CRM_Core_Permission::check('delete contacts')) {
@@ -349,8 +292,8 @@ class CRM_Contact_Task {
     }
     else {
       $tasks = array(
-        self::EXPORT_CONTACTS => self::$_tasks[self::EXPORT_CONTACTS]['title'],
-        self::EMAIL_CONTACTS => self::$_tasks[self::EMAIL_CONTACTS]['title'],
+        self::TASK_EXPORT => self::$_tasks[self::TASK_EXPORT]['title'],
+        self::TASK_EMAIL => self::$_tasks[self::TASK_EMAIL]['title'],
         self::LABEL_CONTACTS => self::$_tasks[self::LABEL_CONTACTS]['title'],
       );
 
@@ -366,19 +309,8 @@ class CRM_Contact_Task {
         $tasks[self::CREATE_MAILING] = self::$_tasks[self::CREATE_MAILING]['title'];
       }
     }
-    return $tasks;
-  }
 
-  /**
-   * These tasks get added based on the context the user is in.
-   *
-   * @return array
-   *   the set of optional tasks for a group of contacts
-   */
-  public static function &optionalTaskTitle() {
-    $tasks = array(
-      self::SAVE_SEARCH_UPDATE => self::$_tasks[self::SAVE_SEARCH_UPDATE]['title'],
-    );
+    $tasks = parent::corePermissionedTaskTitles($tasks, $permission, $params);
     return $tasks;
   }
 
@@ -388,40 +320,13 @@ class CRM_Contact_Task {
    * @return array
    */
   public static function getTask($value) {
-    self::initTasks();
+    self::tasks();
 
     if (!CRM_Utils_Array::value($value, self::$_tasks)) {
       // make it the print task by default
-      $value = self::PRINT_CONTACTS;
+      $value = self::TASK_PRINT;
     }
-    return array(
-      CRM_Utils_Array::value('class', self::$_tasks[$value]),
-      CRM_Utils_Array::value('result', self::$_tasks[$value]),
-    );
-  }
-
-  /**
-   * Function to return the task information on basis of provided task's form name
-   *
-   * @param string $className
-   *
-   * @return array
-   */
-  public static function getTaskAndTitleByClass($className) {
-    self::initTasks();
-
-    foreach (self::$_tasks as $task => $value) {
-      if ((!empty($value['url']) || $task == self::EXPORT_CONTACTS) && (
-        (is_array($value['class']) && in_array($className, $value['class'])) ||
-         ($value['class'] == $className)
-        )
-      ) {
-        return array(
-          $task,
-          CRM_Utils_Array::value('title', $value),
-        );
-      }
-    }
+    return parent::getTask($value);
   }
 
 }

--- a/CRM/Core/Component.php
+++ b/CRM/Core/Component.php
@@ -406,21 +406,6 @@ class CRM_Core_Component {
   }
 
   /**
-   * FIXME: This function does not appear to do anything. The is_array() check runs on a bunch of objects and (always?) returns false
-   */
-  public static function &taskList() {
-    $info = self::_info();
-
-    $tasks = array();
-    foreach ($info as $name => $value) {
-      if (is_array($info[$name]) && isset($info[$name]['task'])) {
-        $tasks += $info[$name]['task'];
-      }
-    }
-    return $tasks;
-  }
-
-  /**
    * Handle table dependencies of components.
    *
    * @param array $tables

--- a/CRM/Grant/Form/Search.php
+++ b/CRM/Grant/Form/Search.php
@@ -170,9 +170,7 @@ class CRM_Grant_Form_Search extends CRM_Core_Form_Search {
         $this->addRowSelectors($rows);
       }
 
-      $permission = CRM_Core_Permission::getPermission();
-
-      $this->addTaskMenu(CRM_Grant_Task::permissionedTaskTitles($permission));
+      $this->addTaskMenu(CRM_Grant_Task::permissionedTaskTitles(CRM_Core_Permission::getPermission()));
     }
 
   }

--- a/CRM/Grant/Form/Task.php
+++ b/CRM/Grant/Form/Task.php
@@ -88,8 +88,11 @@ class CRM_Grant_Form_Task extends CRM_Core_Form {
     $values = $form->controller->exportValues('Search');
 
     $form->_task = $values['task'];
-    $grantTasks = CRM_Grant_Task::tasks();
-    $form->assign('taskName', $grantTasks[$form->_task]);
+    $tasks = CRM_Grant_Task::tasks();
+    if (!array_key_exists($form->_task, $tasks)) {
+      CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
+    }
+    $form->assign('taskName', $tasks[$form->_task]);
 
     $ids = array();
     if ($values['radio_ts'] == 'ts_sel') {

--- a/CRM/Grant/Task.php
+++ b/CRM/Grant/Task.php
@@ -38,22 +38,13 @@
  * used by the search forms
  *
  */
-class CRM_Grant_Task {
-  const DELETE_GRANTS = 1, PRINT_GRANTS = 2, EXPORT_GRANTS = 3, UPDATE_GRANTS = 4;
+class CRM_Grant_Task extends CRM_Core_Task {
 
-  /**
-   * The task array
-   *
-   * @var array
-   */
-  static $_tasks = NULL;
+  const
+    // Grant Tasks
+    UPDATE_GRANTS = 701;
 
-  /**
-   * The optional task array
-   *
-   * @var array
-   */
-  static $_optionalTasks = NULL;
+  static $objectType = 'grant';
 
   /**
    * These tasks are the core set of tasks that the user can perform
@@ -62,20 +53,20 @@ class CRM_Grant_Task {
    * @return array
    *   the set of tasks for a group of contacts
    */
-  public static function &tasks() {
+  public static function tasks() {
     if (!(self::$_tasks)) {
       self::$_tasks = array(
-        1 => array(
+        self::TASK_DELETE => array(
           'title' => ts('Delete grants'),
           'class' => 'CRM_Grant_Form_Task_Delete',
           'result' => FALSE,
         ),
-        2 => array(
+        self::TASK_PRINT => array(
           'title' => ts('Print selected rows'),
           'class' => 'CRM_Grant_Form_Task_Print',
           'result' => FALSE,
         ),
-        3 => array(
+        self::TASK_EXPORT => array(
           'title' => ts('Export grants'),
           'class' => array(
             'CRM_Export_Form_Select',
@@ -83,7 +74,7 @@ class CRM_Grant_Task {
           ),
           'result' => FALSE,
         ),
-        4 => array(
+        self::UPDATE_GRANTS => array(
           'title' => ts('Update grants'),
           'class' => 'CRM_Grant_Form_Task_Update',
           'result' => FALSE,
@@ -91,29 +82,13 @@ class CRM_Grant_Task {
       );
 
       if (!CRM_Core_Permission::check('delete in CiviGrant')) {
-        unset(self::$_tasks[1]);
+        unset(self::$_tasks[self::TASK_DELETE]);
       }
 
-      CRM_Utils_Hook::searchTasks('grant', self::$_tasks);
-      asort(self::$_tasks);
+      parent::tasks();
     }
 
     return self::$_tasks;
-  }
-
-  /**
-   * These tasks are the core set of task titles
-   *
-   * @return array
-   *   the set of task titles
-   */
-  public static function &taskTitles() {
-    self::tasks();
-    $titles = array();
-    foreach (self::$_tasks as $id => $value) {
-      $titles[$id] = $value['title'];
-    }
-    return $titles;
   }
 
   /**
@@ -121,12 +96,12 @@ class CRM_Grant_Task {
    * of the user
    *
    * @param int $permission
+   * @param array $params
    *
    * @return array
    *   set of tasks that are valid for the user
    */
-  public static function &permissionedTaskTitles($permission) {
-    $tasks = array();
+  public static function permissionedTaskTitles($permission, $params = array()) {
     if (($permission == CRM_Core_Permission::EDIT)
       || CRM_Core_Permission::check('edit grants')
     ) {
@@ -134,13 +109,15 @@ class CRM_Grant_Task {
     }
     else {
       $tasks = array(
-        3 => self::$_tasks[3]['title'],
+        self::TASK_EXPORT => self::$_tasks[self::TASK_EXPORT]['title'],
       );
       //CRM-4418,
       if (CRM_Core_Permission::check('delete in CiviGrant')) {
-        $tasks[1] = self::$_tasks[1]['title'];
+        $tasks[self::TASK_DELETE] = self::$_tasks[self::TASK_DELETE]['title'];
       }
     }
+
+    $tasks = parent::corePermissionedTaskTitles($tasks, $permission, $params);
     return $tasks;
   }
 
@@ -154,14 +131,12 @@ class CRM_Grant_Task {
    */
   public static function getTask($value) {
     self::tasks();
-    if (!$value || !CRM_Utils_Array::value($value, self::$_tasks)) {
-      // make the print task by default
-      $value = 2;
+
+    if (!CRM_Utils_Array::value($value, self::$_tasks)) {
+      // make it the print task by default
+      $value = self::TASK_PRINT;
     }
-    return array(
-      self::$_tasks[$value]['class'],
-      self::$_tasks[$value]['result'],
-    );
+    return parent::getTask($value);
   }
 
 }

--- a/CRM/Mailing/Task.php
+++ b/CRM/Mailing/Task.php
@@ -36,20 +36,9 @@
  * used by the search forms.
  *
  */
-class CRM_Mailing_Task {
-  /**
-   * The task array.
-   *
-   * @var array
-   */
-  static $_tasks = NULL;
+class CRM_Mailing_Task extends CRM_Core_Task {
 
-  /**
-   * The optional task array.
-   *
-   * @var array
-   */
-  static $_optionalTasks = NULL;
+  static $objectType = 'mailing';
 
   /**
    * These tasks are the core set of tasks that the user can perform
@@ -58,32 +47,20 @@ class CRM_Mailing_Task {
    * @return array
    *   the set of tasks for a group of contacts.
    */
-  public static function &tasks() {
+  public static function tasks() {
     if (!(self::$_tasks)) {
       self::$_tasks = array(
-        1 => array(
+        self::TASK_PRINT => array(
           'title' => ts('Print Mailing Recipients'),
           'class' => 'CRM_Mailing_Form_Task_Print',
           'result' => FALSE,
         ),
       );
 
-      CRM_Utils_Hook::searchTasks('mailing', self::$_tasks);
-      asort(self::$_tasks);
+      parent::tasks();
     }
 
     return self::$_tasks;
-  }
-
-  /**
-   * These tasks are the core set of task titles
-   * on mailing recipients.
-   *
-   * @return array
-   *   the set of task titles.
-   */
-  public static function &taskTitles() {
-    return array();
   }
 
   /**
@@ -91,13 +68,16 @@ class CRM_Mailing_Task {
    * of the user.
    *
    * @param int $permission
+   * @param array $params
    *
    * @return array
    *   set of tasks that are valid for the user
    */
-  public static function &permissionedTaskTitles($permission) {
-    $task = array();
-    return $task;
+  public static function permissionedTaskTitles($permission, $params = array()) {
+    $tasks = array();
+
+    $tasks = parent::corePermissionedTaskTitles($tasks, $permission, $params);
+    return $tasks;
   }
 
   /**
@@ -113,8 +93,9 @@ class CRM_Mailing_Task {
     self::tasks();
     if (!$value || !CRM_Utils_Array::value($value, self::$_tasks)) {
       // make the print task by default
-      $value = 1;
+      $value = self::TASK_PRINT;
     }
+
     return array(
       self::$_tasks[$value]['class'],
       self::$_tasks[$value]['result'],

--- a/CRM/Member/Form/Search.php
+++ b/CRM/Member/Form/Search.php
@@ -163,9 +163,7 @@ class CRM_Member_Form_Search extends CRM_Core_Form_Search {
         $this->addRowSelectors($rows);
       }
 
-      $permission = CRM_Core_Permission::getPermission();
-
-      $this->addTaskMenu(CRM_Member_Task::permissionedTaskTitles($permission));
+      $this->addTaskMenu(CRM_Member_Task::permissionedTaskTitles(CRM_Core_Permission::getPermission()));
     }
 
   }

--- a/CRM/Member/Form/Task.php
+++ b/CRM/Member/Form/Task.php
@@ -95,8 +95,11 @@ class CRM_Member_Form_Task extends CRM_Core_Form {
     $values = $form->controller->exportValues($form->get('searchFormName'));
 
     $form->_task = $values['task'];
-    $memberTasks = CRM_Member_Task::tasks();
-    $form->assign('taskName', $memberTasks[$form->_task]);
+    $tasks = CRM_Member_Task::permissionedTaskTitles(CRM_Core_Permission::getPermission());
+    if (!array_key_exists($form->_task, $tasks)) {
+      CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
+    }
+    $form->assign('taskName', $tasks[$form->_task]);
 
     $ids = array();
     if ($values['radio_ts'] == 'ts_sel') {

--- a/CRM/Member/Task.php
+++ b/CRM/Member/Task.php
@@ -39,22 +39,12 @@
  * used by the search forms
  *
  */
-class CRM_Member_Task {
-  const DELETE_MEMBERS = 1, PRINT_MEMBERS = 2, EXPORT_MEMBERS = 3, EMAIL_CONTACTS = 4, BATCH_MEMBERS = 5;
+class CRM_Member_Task extends CRM_Core_Task {
+  const
+    // Member tasks
+    LABEL_MEMBERS = 201;
 
-  /**
-   * The task array
-   *
-   * @var array
-   */
-  static $_tasks = NULL;
-
-  /**
-   * The optional task array
-   *
-   * @var array
-   */
-  static $_optionalTasks = NULL;
+  static $objectType = 'membership';
 
   /**
    * These tasks are the core set of tasks that the user can perform
@@ -63,20 +53,20 @@ class CRM_Member_Task {
    * @return array
    *   the set of tasks for a group of contacts
    */
-  public static function &tasks() {
-    if (!(self::$_tasks)) {
+  public static function tasks() {
+    if (!self::$_tasks) {
       self::$_tasks = array(
-        1 => array(
+        self::TASK_DELETE => array(
           'title' => ts('Delete memberships'),
           'class' => 'CRM_Member_Form_Task_Delete',
           'result' => FALSE,
         ),
-        2 => array(
+        self::TASK_PRINT => array(
           'title' => ts('Print selected rows'),
           'class' => 'CRM_Member_Form_Task_Print',
           'result' => FALSE,
         ),
-        3 => array(
+        self::TASK_EXPORT => array(
           'title' => ts('Export members'),
           'class' => array(
             'CRM_Export_Form_Select',
@@ -84,7 +74,7 @@ class CRM_Member_Task {
           ),
           'result' => FALSE,
         ),
-        4 => array(
+        self::TASK_EMAIL => array(
           'title' => ts('Email - send now (to %1 or less)', array(
             1 => Civi::settings()
               ->get('simple_mail_limit'),
@@ -92,7 +82,7 @@ class CRM_Member_Task {
           'class' => 'CRM_Member_Form_Task_Email',
           'result' => TRUE,
         ),
-        5 => array(
+        self::BATCH_UPDATE => array(
           'title' => ts('Update multiple memberships'),
           'class' => array(
             'CRM_Member_Form_Task_PickProfile',
@@ -100,14 +90,14 @@ class CRM_Member_Task {
           ),
           'result' => TRUE,
         ),
-        6 => array(
+        self::LABEL_MEMBERS => array(
           'title' => ts('Mailing labels - print'),
           'class' => array(
             'CRM_Member_Form_Task_Label',
           ),
           'result' => TRUE,
         ),
-        7 => array(
+        self::PDF_LETTER => array(
           'title' => ts('Print/merge document for memberships'),
           'class' => 'CRM_Member_Form_Task_PDFLetter',
           'result' => FALSE,
@@ -116,15 +106,14 @@ class CRM_Member_Task {
 
       //CRM-4418, check for delete
       if (!CRM_Core_Permission::check('delete in CiviMember')) {
-        unset(self::$_tasks[1]);
+        unset(self::$_tasks[self::TASK_DELETE]);
       }
       //CRM-12920 - check for edit permission
       if (!CRM_Core_Permission::check('edit memberships')) {
-        unset(self::$_tasks[5]);
+        unset(self::$_tasks[self::BATCH_UPDATE]);
       }
 
-      CRM_Utils_Hook::searchTasks('membership', self::$_tasks);
-      asort(self::$_tasks);
+      parent::tasks();
     }
 
     return self::$_tasks;
@@ -137,13 +126,8 @@ class CRM_Member_Task {
    * @return array
    *   the set of task titles
    */
-  public static function &taskTitles() {
-    self::tasks();
-    $titles = array();
-    foreach (self::$_tasks as $id => $value) {
-      $titles[$id] = $value['title'];
-    }
-    return $titles;
+  public static function taskTitles() {
+    return parent::taskTitles();
   }
 
   /**
@@ -151,12 +135,12 @@ class CRM_Member_Task {
    * of the user
    *
    * @param int $permission
+   * @param array $params
    *
    * @return array
    *   set of tasks that are valid for the user
    */
-  public static function &permissionedTaskTitles($permission) {
-    $tasks = array();
+  public static function permissionedTaskTitles($permission, $params = array()) {
     if (($permission == CRM_Core_Permission::EDIT)
       || CRM_Core_Permission::check('edit memberships')
     ) {
@@ -164,14 +148,16 @@ class CRM_Member_Task {
     }
     else {
       $tasks = array(
-        3 => self::$_tasks[3]['title'],
-        4 => self::$_tasks[4]['title'],
+        self::TASK_EXPORT => self::$_tasks[self::TASK_EXPORT]['title'],
+        self::TASK_EMAIL => self::$_tasks[self::TASK_EMAIL]['title'],
       );
       //CRM-4418,
       if (CRM_Core_Permission::check('delete in CiviMember')) {
-        $tasks[1] = self::$_tasks[1]['title'];
+        $tasks[self::TASK_DELETE] = self::$_tasks[self::TASK_DELETE]['title'];
       }
     }
+
+    $tasks = parent::corePermissionedTaskTitles($tasks, $permission, $params);
     return $tasks;
   }
 
@@ -187,13 +173,10 @@ class CRM_Member_Task {
   public static function getTask($value) {
     self::tasks();
     if (!$value || !CRM_Utils_Array::value($value, self::$_tasks)) {
-      // make the print task by default
-      $value = 2;
+      // Make the print task the default
+      $value = self::TASK_PRINT;
     }
-    return array(
-      self::$_tasks[$value]['class'],
-      self::$_tasks[$value]['result'],
-    );
+    return parent::getTask($value);
   }
 
 }

--- a/CRM/Pledge/Form/Search.php
+++ b/CRM/Pledge/Form/Search.php
@@ -155,9 +155,7 @@ class CRM_Pledge_Form_Search extends CRM_Core_Form_Search {
         $this->addRowSelectors($rows);
       }
 
-      $permission = CRM_Core_Permission::getPermission();
-
-      $this->addTaskMenu(CRM_Pledge_Task::permissionedTaskTitles($permission));
+      $this->addTaskMenu(CRM_Pledge_Task::permissionedTaskTitles(CRM_Core_Permission::getPermission()));
     }
 
   }

--- a/CRM/Pledge/Task.php
+++ b/CRM/Pledge/Task.php
@@ -34,22 +34,9 @@
  * class to represent the actions that can be performed on a group of contacts
  * used by the search forms.
  */
-class CRM_Pledge_Task {
-  const DELETE_PLEDGES = 1, PRINT_PLEDGES = 2, EXPORT_PLEDGES = 3;
+class CRM_Pledge_Task extends CRM_Core_Task {
 
-  /**
-   * The task array
-   *
-   * @var array
-   */
-  static $_tasks = NULL;
-
-  /**
-   * The optional task array
-   *
-   * @var array
-   */
-  static $_optionalTasks = NULL;
+  static $objectType = 'pledge';
 
   /**
    * These tasks are the core set of tasks that the user can perform
@@ -58,20 +45,20 @@ class CRM_Pledge_Task {
    * @return array
    *   the set of tasks for a group of contacts
    */
-  public static function &tasks() {
+  public static function tasks() {
     if (!self::$_tasks) {
       self::$_tasks = array(
-        1 => array(
+        self::TASK_DELETE => array(
           'title' => ts('Delete pledges'),
           'class' => 'CRM_Pledge_Form_Task_Delete',
           'result' => FALSE,
         ),
-        2 => array(
+        self::TASK_PRINT => array(
           'title' => ts('Print selected rows'),
           'class' => 'CRM_Pledge_Form_Task_Print',
           'result' => FALSE,
         ),
-        3 => array(
+        self::TASK_EXPORT => array(
           'title' => ts('Export pledges'),
           'class' => array(
             'CRM_Export_Form_Select',
@@ -83,40 +70,13 @@ class CRM_Pledge_Task {
 
       // CRM-4418, check for delete
       if (!CRM_Core_Permission::check('delete in CiviPledge')) {
-        unset(self::$_tasks[1]);
+        unset(self::$_tasks[self::TASK_DELETE]);
       }
 
-      CRM_Utils_Hook::searchTasks('pledge', self::$_tasks);
-      asort(self::$_tasks);
+      parent::tasks();
     }
 
     return self::$_tasks;
-  }
-
-  /**
-   * These tasks are the core set of task titles.
-   *
-   * @return array
-   *   the set of task titles
-   */
-  public static function &taskTitles() {
-    self::tasks();
-    $titles = array();
-    foreach (self::$_tasks as $id => $value) {
-      $titles[$id] = $value['title'];
-    }
-    return $titles;
-  }
-
-  /**
-   * These tasks get added based on the context the user is in.
-   *
-   * @return array
-   *   the set of optional tasks for a group of contacts
-   */
-  public static function &optionalTaskTitle() {
-    $tasks = array();
-    return $tasks;
   }
 
   /**
@@ -124,12 +84,12 @@ class CRM_Pledge_Task {
    * of the user
    *
    * @param int $permission
+   * @param array $params
    *
    * @return array
    *   set of tasks that are valid for the user
    */
-  public static function &permissionedTaskTitles($permission) {
-    $tasks = array();
+  public static function permissionedTaskTitles($permission, $params = array()) {
     if (($permission == CRM_Core_Permission::EDIT)
       || CRM_Core_Permission::check('edit pledges')
     ) {
@@ -137,13 +97,15 @@ class CRM_Pledge_Task {
     }
     else {
       $tasks = array(
-        3 => self::$_tasks[3]['title'],
+        self::TASK_EXPORT => self::$_tasks[self::TASK_EXPORT]['title'],
       );
       //CRM-4418,
       if (CRM_Core_Permission::check('delete in CiviPledge')) {
-        $tasks[1] = self::$_tasks[1]['title'];
+        $tasks[self::TASK_DELETE] = self::$_tasks[self::TASK_DELETE]['title'];
       }
     }
+
+    $tasks = parent::corePermissionedTaskTitles($tasks, $permission, $params);
     return $tasks;
   }
 
@@ -158,14 +120,12 @@ class CRM_Pledge_Task {
    */
   public static function getTask($value) {
     self::tasks();
-    if (!$value || !CRM_Utils_Array::value($value, self::$_tasks)) {
-      // make the print task by default
-      $value = 2;
+
+    if (!CRM_Utils_Array::value($value, self::$_tasks)) {
+      // make it the print task by default
+      $value = self::TASK_PRINT;
     }
-    return array(
-      self::$_tasks[$value]['class'],
-      self::$_tasks[$value]['result'],
-    );
+    return parent::getTask($value);
   }
 
 }


### PR DESCRIPTION
…list when changing the entity filter

Overview
----------------------------------------
Refactor all the component tasks so they are extend a new base class CRM_Core_Task.

Before
----------------------------------------
There were a number of issues with the "Advanced Search" when switching between component types where the task list would be populated with the wrong list of tasks, but the keys would trigger an action on the selected component and an unexpected action may occur.
Also there seemed to be a bug with saving group_type where mailing_list was always being checked.

After
----------------------------------------
This cleans up the code and uses shared code where possible.

Technical Details
----------------------------------------
Introduces a new base class CRM_Core_Task.

Comments
----------------------------------------
Further refactoring would be possible, also some tasks actually work in all contexts (eg. create/update smart group) and we could extend the lists to share these elements too.

