### PR TITLE
CRM-21393: Event checkPermission should only check the specific event…

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -2066,23 +2066,24 @@ WHERE  ce.loc_block_id = $locBlockId";
     static $permissions = NULL;
 
     if (empty($permissions)) {
-      $result = civicrm_api3('Event', 'get', array(
+      $params = array(
         'check_permissions' => 1,
         'return' => 'title',
         'options' => array(
           'limit' => 0,
         ),
-      ));
+      );
+
+      if ($eventId) {
+        $params['id'] = $eventId;
+      }
+
+      $result = civicrm_api3('Event', 'get', $params);
       $allEvents = CRM_Utils_Array::collect('title', $result['values']);
 
-      $result = civicrm_api3('Event', 'get', array(
-        'check_permissions' => 1,
-        'return' => 'title',
-        'created_id' => 'user_contact_id',
-        'options' => array(
-          'limit' => 0,
-        ),
-      ));
+      // Search again, but only events created by the user.
+      $params['created_id'] = 'user_contact_id';
+      $result = civicrm_api3('Event', 'get', $params);
       $createdEvents = CRM_Utils_Array::collect('title', $result['values']);
 
       // Note: for a multisite setup, a user with edit all events, can edit all events


### PR DESCRIPTION
…, if eventId was passed (for performance).

(copied from JIRA):

On a fairly normal site, with 2500 events, I noticed that loading any Event > Location page took 8 seconds for the full page load, where as normally pages take up to 2 seconds to load. This is in great part caused by the XHR/AJAX loading of various bits on the screen, which each took about 2 seconds to load. Still, XHR requests are normally pretty quick (600 ms).

Using php-xdebug profiling, I narrowed it down to CRM_Event_BAO_Event::checkPermission(). 

![capture d ecran de 2017-11-03 23-34-49](https://user-images.githubusercontent.com/254741/32401912-9c149ab6-c0ef-11e7-8930-05787b34b282.png)