### PR TITLE
CRM-21398 - Fix fatal error when exporting cases

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -1322,19 +1322,7 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
     }
     else {
       if (substr($fieldName, -3, 3) == '_id') {
-        // for trxn_id and its variants use a longer buffer
-        // to accommodate different systems - CRM-13739
-        static $notRealIDFields = NULL;
-        if ($notRealIDFields == NULL) {
-          $notRealIDFields = array('trxn_id', 'componentpaymentfield_transaction_id', 'phone_type_id');
-        }
-
-        if (in_array($fieldName, $notRealIDFields)) {
-          $sqlColumns[$fieldName] = "$fieldName varchar(255)";
-        }
-        else {
-          $sqlColumns[$fieldName] = "$fieldName varchar(16)";
-        }
+        $sqlColumns[$fieldName] = "$fieldName varchar(255)";
       }
       elseif (substr($fieldName, -5, 5) == '_note') {
         $sqlColumns[$fieldName] = "$fieldName text";

--- a/templates/CRM/Case/Form/Selector.tpl
+++ b/templates/CRM/Case/Form/Selector.tpl
@@ -25,7 +25,7 @@
 *}
 {include file="CRM/common/pager.tpl" location="top"}
 {strip}
-<table class="caseSelector">
+<table class="caseSelector row-highlight">
   <tr class="columnheader">
 
   {if ! $single and $context eq 'Search' }


### PR DESCRIPTION
When exporting cases using the standard set of fields, I get a fatal error that a column is too small.

A little research on the subject suggests that there is no good reason to make columns small in mySql - it doesn't save disk space or increase efficiency. So this increases the limit for all columns in an export table, as opposed to the previous small whitelist.

* [CRM-21398: Error when exporting cases](https://issues.civicrm.org/jira/browse/CRM-21398)