### PR TITLE
CRM-21395 make patch safe for multiple composer runs

### DIFF
--- a/tools/scripts/composer/dompdf-cleanup.sh
+++ b/tools/scripts/composer/dompdf-cleanup.sh
@@ -130,4 +130,6 @@ make_font_readme > vendor/dompdf/dompdf/lib/fonts/README.DejaVuFonts.txt
 # Remove debug_print_backtrace(), which can leak system details. Put backtrace in log.
 simple_replace vendor/dompdf/dompdf/lib/html5lib/TreeBuilder.php 'debug_print_backtrace();' 'CRM_Core_Error::backtrace("backTrace", TRUE);'
 
-patch vendor/dompdf/dompdf/src/Dompdf.php < tools/scripts/composer/patches/dompdf_no_block_level_parent_fix.patch
+if ! grep -q 'CRM-21395' vendor/dompdf/dompdf/src/Dompdf.php; then
+  patch vendor/dompdf/dompdf/src/Dompdf.php < tools/scripts/composer/patches/dompdf_no_block_level_parent_fix.patch
+fi

--- a/tools/scripts/composer/patches/dompdf_no_block_level_parent_fix.patch
+++ b/tools/scripts/composer/patches/dompdf_no_block_level_parent_fix.patch
@@ -18,7 +18,7 @@ index 40329063..bfb1c2b1 100644
              $doc->loadHTML($str);
              $doc->encoding = $encoding;
  
-+            // Remove #text children nodes in nodes that shouldn't have
++            // Remove #text children nodes in nodes that shouldn't have #CRM-21395
 +            $tag_names = array("html", "table", "tbody", "thead", "tfoot", "tr");
 +            foreach ($tag_names as $tag_name) {
 +                $nodes = $doc->getElementsByTagName($tag_name);


### PR DESCRIPTION
Overview
----------------------------------------
This just adds in a test to ensure we don't patch multiple times ping @mattwire @eileenmcnaughton @totten

---

 * [CRM-21395: DOMPDF produces either white screen or No-Block-Level parent found error in some circumstances blocking invoice production](https://issues.civicrm.org/jira/browse/CRM-21395)