### PR TITLE
CRM-21400 Add a static var to hold the trxn_id so it can be accessed …

### DIFF
--- a/CRM/Contribute/Form/Contribution/ThankYou.php
+++ b/CRM/Contribute/Form/Contribution/ThankYou.php
@@ -42,6 +42,11 @@ class CRM_Contribute_Form_Contribution_ThankYou extends CRM_Contribute_Form_Cont
   public $_useForMember;
 
   /**
+   * Tranxaaction Id of the current contribution
+   */
+  public $_trxnId;
+
+  /**
    * Set variables up before form is built.
    */
   public function preProcess() {
@@ -214,11 +219,10 @@ class CRM_Contribute_Form_Contribution_ThankYou extends CRM_Contribute_Form_Cont
       $this->buildCustom($this->_values['onbehalf_profile_id'], 'onbehalfProfile', TRUE, 'onbehalf', $fieldTypes);
     }
 
-    $this->assign('trxn_id',
-      CRM_Utils_Array::value('trxn_id',
-        $this->_params
-      )
-    );
+    $this->_trxnId = CRM_Utils_Array::value('trxn_id', $this->_params);
+
+    $this->assign('trxn_id', $this->_trxnId);
+
     $this->assign('receive_date',
       CRM_Utils_Date::mysqlToIso(CRM_Utils_Array::value('receive_date', $this->_params))
     );


### PR DESCRIPTION
…through hook_civicrm_buildForm

Overview
----------------------------------------
This is very straight forward adds a static var to the ThankYou.php which allows for the transaction_id to be access from hook_civicrm_buildForm. This is consistent with the events see https://github.com/civicrm/civicrm-core/blob/master/CRM/Event/Form/Registration/ThankYou.php#L55

ping @eileenmcnaughton @monishdeb thoughts? @johntwyman