### PR TITLE
CRM-21298 System check: bypass missing indices check until update indices works

### DIFF
--- a/CRM/Utils/Check/Component/Schema.php
+++ b/CRM/Utils/Check/Component/Schema.php
@@ -37,6 +37,11 @@ class CRM_Utils_Check_Component_Schema extends CRM_Utils_Check_Component {
    */
   public function checkIndices() {
     $messages = array();
+
+    // CRM-21298: The "Update Indices" tool that this check suggests is
+    // unreliable. Bypass this check until CRM-20817 and CRM-20533 are resolved.
+    return $messages;
+
     $missingIndices = CRM_Core_BAO_SchemaHandler::getMissingIndices();
     if ($missingIndices) {
       $html = '';


### PR DESCRIPTION
Overview
----------------------------------------
The "Performance warning: Missing indices" system check should be bypassed until the "Update Indices" task works reliably.

*This is the same as #11114 but for `master`.*

Before
----------------------------------------
Users of many sites (including as one example a demo site where 4.7.17 was installed and then upgraded to 4.7.25) are presented with a `WARNING` level message in the system check stating that they have missing indices.  An Update Indices button is in the message.  Clicking the button (for many sites) causes a database error as documented in [CRM-20817](https://issues.civicrm.org/jira/browse/CRM-20817).

After
----------------------------------------
The system check will never produce the "Performance warning: Missing indices" message.

Technical Details
----------------------------------------
I left all the code in there to run the check and update the indices.  The `checkIndices()` function just returns an empty array before getting to that point.  This allows for easy removal for testing and when the update tool is actually reliable.

---

 * [CRM-21298: Don't offer to fix indices until we can do it right](https://issues.civicrm.org/jira/browse/CRM-21298)