### PR TITLE
CRM-17860, CRM-18231 - JobProcessMailingTest - Re-remove require_once

### DIFF
--- a/tests/phpunit/api/v3/JobProcessMailingTest.php
+++ b/tests/phpunit/api/v3/JobProcessMailingTest.php
@@ -36,9 +36,6 @@
  *
  */
 
-//@todo - why doesn't class loader find these (I tried renaming)
-require_once 'CiviTest/CiviMailUtils.php';
-
 /**
  * Class api_v3_JobTest
  * @group headless


### PR DESCRIPTION
Overview
----------------------------------------
Remove an unnecessary line from test suite.

This was previously removed by CRM-17860. I *think* it got up incidentally in a long-running PR for CRM-18231 and then re-added (unnecessarily, IMHO).

Before
----------------------------------------
The test worked when executed as part of the `api_v3` suite, but it failed
when run individually (because the `require_once` doesn't work).  Moreover,
the tests for `org.civicrm.flexmailer` failed for the same reason.

After
----------------------------------------
The tests work on their own.

Comments
----------------------------------------
This change deals entirely with the packaging/framing of a test-case.  It
neither (a) involves the runtime behavior of the application nor (b) the
semantics/behavior of the test.  Consequently, it should be safe to merge as
long as the test-runner remains happy.

---

 * [CRM-17860: More consistent, flexible handling of tests for extensions](https://issues.civicrm.org/jira/browse/CRM-17860)
 * [CRM-18231: Support safe migration from production to non-production instances](https://issues.civicrm.org/jira/browse/CRM-18231)