### PR TITLE
CRM-21405 Allow "Outbound SMS" when Mobile is not primary phone number

### DIFF
--- a/CRM/Activity/Form/ActivityLinks.php
+++ b/CRM/Activity/Form/ActivityLinks.php
@@ -77,9 +77,22 @@ class CRM_Activity_Form_ActivityLinks extends CRM_Core_Form {
           continue;
         }
         // Check for existence of a mobile phone and ! do not SMS privacy setting
-        $mobileTypeID = CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_Phone', 'phone_type_id', 'Mobile');
-        list($name, $phone, $doNotSMS) = CRM_Contact_BAO_Contact_Location::getPhoneDetails($contactId, $mobileTypeID);
-        if (!$doNotSMS && $phone) {
+        try {
+          $phone = civicrm_api3('Phone', 'getsingle', array(
+            'contact_id' => $contactId,
+            'phone_type_id' => CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_Phone', 'phone_type_id', 'Mobile'),
+            'return' => array('phone', 'contact_id'),
+            'options' => array('limit' => 1, 'sort' => "is_primary DESC"),
+            'api.Contact.getsingle' => array(
+              'id' => '$value.contact_id',
+              'return' => 'do_not_sms',
+            ),
+          ));
+        }
+        catch (CiviCRM_API3_Exception $e) {
+          continue;
+        }
+        if (!$phone['api.Contact.getsingle']['do_not_sms'] && $phone['phone']) {
           $url = 'civicrm/activity/sms/add';
         }
         else {

--- a/CRM/Contact/BAO/Contact/Location.php
+++ b/CRM/Contact/BAO/Contact/Location.php
@@ -73,6 +73,7 @@ WHERE     civicrm_contact.id = %1";
   }
 
   /**
+   * @deprecated Not used anywhere, use the Phone API instead
    * Get the sms number and display name of a contact.
    *
    * @param int $id
@@ -84,6 +85,7 @@ WHERE     civicrm_contact.id = %1";
    *   tuple of display_name and sms if found, or (null,null)
    */
   public static function getPhoneDetails($id, $type = NULL) {
+    Civi::log()->warning('Deprecated function CRM_Contact_BAO_Contact_Location::getPhoneDetails, use Phone.get API instead', array('civi.tag' => 'deprecated'));
     if (!$id) {
       return array(NULL, NULL);
     }


### PR DESCRIPTION
Overview
----------------------------------------
Allow "Outbound SMS" when Mobile is not primary phone number

Before
----------------------------------------
When a contact has a mobile phone number but it is not the primary number the "Outbound SMS" action is removed from the contact actions.

After
----------------------------------------
When a contact has a mobile phone number but it is not the primary number the "Outbound SMS" action is allowed, and will use the first available mobile number from the contact.

---

 * [CRM-21405: Allow "Outbound SMS" when Mobile is not primary phone number](https://issues.civicrm.org/jira/browse/CRM-21405)