### PR TITLE
CRM-20358: Fix WordPress Access Control table

### DIFF
--- a/CRM/ACL/Form/WordPress/Permissions.php
+++ b/CRM/ACL/Form/WordPress/Permissions.php
@@ -41,20 +41,19 @@ class CRM_ACL_Form_WordPress_Permissions extends CRM_Core_Form {
    */
   public function buildQuickForm() {
 
-    CRM_Utils_System::setTitle('Wordpress Access Control');
+    CRM_Utils_System::setTitle('WordPress Access Control');
 
     // Get the core permissions array
     $permissionsArray = self::getPermissionArray();
     $permissionsDesc = self::getPermissionArray(TRUE);
 
-    // Get the wordpress roles, default capabilities and assign to the form
-    // TODO: Create a new wordpress role (Anonymous user) and define capabilities in Wordpress Access Control
+    // Get the WordPress roles, default capabilities and assign to the form
     global $wp_roles;
     if (!isset($wp_roles)) {
       $wp_roles = new WP_Roles();
     }
     foreach ($wp_roles->role_names as $role => $name) {
-      // Dont show the permissions options for administrator, as they have all permissions
+      // Don't show the permissions options for administrator, as they have all permissions
       if ($role !== 'administrator') {
         $roleObj = $wp_roles->get_role($role);
         if (!empty($roleObj->capabilities)) {
@@ -84,7 +83,36 @@ class CRM_ACL_Form_WordPress_Permissions extends CRM_Core_Form {
         $descArray[$perm] = $attr[1];
       }
     }
-    $this->assign('permDesc', $descArray);
+
+    // build table rows by merging role perms
+    $rows = array();
+    foreach ($rolePerms as $role => $perms) {
+      foreach ($perms as $name => $title) {
+        $rows[$name] = $title;
+      }
+    }
+
+    // Build array keyed by permission
+    $table = array();
+    foreach ($rows as $perm => $label) {
+
+      // Init row with permission label
+      $table[$perm] = array(
+        'label' => $label,
+        'roles' => array(),
+      );
+
+      // Add permission description and role names
+      foreach ($roles as $key => $label) {
+        if (isset($descArray[$perm])) {
+          $table[$perm]['desc'] = $descArray[$perm];
+        }
+        $table[$perm]['roles'][] = $key;
+      }
+
+    }
+
+    $this->assign('table', $table);
     $this->assign('rolePerms', $rolePerms);
     $this->assign('roles', $roles);
 

--- a/templates/CRM/ACL/Form/WordPress/Permissions.tpl
+++ b/templates/CRM/ACL/Form/WordPress/Permissions.tpl
@@ -23,52 +23,56 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-{* this template is used for adding/editing Wordpress Access Control  *}
+{* this template is used for adding/editing WordPress Access Control *}
 <div class="help">
-    <p>{ts}Use this form to Grant access to CiviCRM components and other CiviCRM permissions to WordPress roles.{/ts}<br /><br />
-  {ts}<strong>NOTE: Super Admin</strong> and <strong>Administrator</strong> roles will have all permissions in CiviCRM.{/ts}
-  </p>
+  <p>{ts}Use this form to Grant access to CiviCRM components and other CiviCRM permissions to WordPress roles.{/ts}</p>
+  <p>{ts}<strong>NOTE: Super Admin</strong> and <strong>Administrator</strong> roles will have all permissions in CiviCRM.{/ts}</p>
 </div>
-<div class="crm-block crm-form-block crm-export-form-block">
-<div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
-<table>
-     <tr>
-        {assign var="i" value=1}
-      {foreach from=$roles key=role_name item=role_value }
-      <td style="padding:0;">
-          <table border="0" cellpadding="0" cellspacing="0">
-          <tr>
-                <td class="label">&nbsp;</td>
-                <td align="center"><b>{$role_value}</b><br /></td>
-          </tr>
-          {assign var="j" value=0}
-          {foreach from=$rolePerms.$role_name key=name item=value }
-            {if $j mod 2 eq 1}
-                <tr style="background-color: #E6E6DC;">
-            {else}
-                <tr style="background-color: #FFFFFF;">
-            {/if}
-                <td style="height:3em;">
-                {if $i eq 1}
-                  {$form.$role_name.$name.label}
-                  {if $permDesc.$name}
-                    <br/><span class="description">{$permDesc.$name}</span>
-                  {/if}
-                {/if}
-                </td>
-                <td align="center">{$form.$role_name.$name.html}<br /></td>
-              </tr>
-          {assign var="j" value=$j+1}
-          {/foreach}
-          </table>
-          </td>
-          {assign var="i" value=$i+1}
-      {/foreach}
-     </tr>
-</table>
 
-<div class="crm-submit-buttons">
-  {include file="CRM/common/formButtons.tpl" location="bottom"}
-</div>
+<div class="crm-block crm-form-block crm-export-form-block">
+
+  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
+
+  <table>
+
+    <tr>
+      <td class="label">&nbsp;</td>
+      {assign var="num" value=0}
+      {foreach from=$roles key=role_name item=role_value}
+        <td align="center"><strong>{$role_value}</strong></td>
+        {assign var="num" value=$num+1}
+      {/foreach}
+    </tr>
+
+    {assign var="x" value=0}
+    {foreach from=$table key=perm_name item=row}
+      {if $x mod 2 eq 1}
+        <tr style="background-color: #E6E6DC;">
+      {else}
+        <tr style="background-color: #FFFFFF;">
+      {/if}
+
+      <td style="height: 2.6em;">
+        {$row.label}
+        {if $row.desc}
+          <br/><span class="description">{$row.desc}</span>
+        {/if}
+      </td>
+
+      {foreach from=$row.roles key=index item=role_name}
+        <td align="center" style="padding-top: 0.6em;">
+          {$form.$role_name.$perm_name.html}
+        </td>
+      {/foreach}
+
+      </tr>
+      {assign var="x" value=$x+1}
+    {/foreach}
+
+  </table>
+
+  <div class="crm-submit-buttons">
+    {include file="CRM/common/formButtons.tpl" location="bottom"}
+  </div>
 
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
Unifies the separate tables on the WordPress Access Control page into a single table. This fixes [CRM-20358](https://issues.civicrm.org/jira/browse/CRM-20358) by ensuring that the table rows line up.

Before
----------------------------------------
<img width="750" alt="table-before" src="https://user-images.githubusercontent.com/726936/32548903-5f96632e-c47f-11e7-94a7-9942e265cbd3.png">

After
----------------------------------------
<img width="749" alt="table-after" src="https://user-images.githubusercontent.com/726936/32548915-68c1b598-c47f-11e7-9feb-6fa62ab960ce.png">