### PR TITLE
CRM-21406 - Standalone export form

### DIFF
--- a/CRM/Contact/Form/Task.php
+++ b/CRM/Contact/Form/Task.php
@@ -100,13 +100,13 @@ class CRM_Contact_Form_Task extends CRM_Core_Form {
     $form->_contactIds = array();
     $form->_contactTypes = array();
 
-    $isStandAlone = in_array('task', $form->urlPath);
+    $isStandAlone = in_array('task', $form->urlPath) || in_array('standalone', $form->urlPath);
     if ($isStandAlone) {
       list($form->_task, $title) = CRM_Contact_Task::getTaskAndTitleByClass(get_class($form));
       if (!array_key_exists($form->_task, CRM_Contact_Task::permissionedTaskTitles(CRM_Core_Permission::getPermission()))) {
         CRM_Core_Error::fatal(ts('You do not have permission to access this page.'));
       }
-      $form->_contactIds = explode(',', CRM_Utils_Request::retrieve('cids', 'String', $form, TRUE));
+      $form->_contactIds = explode(',', CRM_Utils_Request::retrieve('cids', 'CommaSeparatedIntegers', $form, TRUE));
       if (empty($form->_contactIds)) {
         CRM_Core_Error::statusBounce(ts('No Contacts Selected'));
       }

--- a/CRM/Contact/Task.php
+++ b/CRM/Contact/Task.php
@@ -77,6 +77,11 @@ class CRM_Contact_Task {
    */
   static $_optionalTasks = NULL;
 
+  public static function tasks() {
+    self::initTasks();
+    return self::$_tasks;
+  }
+
   public static function initTasks() {
     if (!self::$_tasks) {
       self::$_tasks = array(
@@ -398,7 +403,7 @@ class CRM_Contact_Task {
     self::initTasks();
 
     foreach (self::$_tasks as $task => $value) {
-      if (!empty($value['url']) && (
+      if ((!empty($value['url']) || $task == self::EXPORT_CONTACTS) && (
         (is_array($value['class']) && in_array($className, $value['class'])) ||
          ($value['class'] == $className)
         )

--- a/CRM/Core/xml/Menu/Misc.xml
+++ b/CRM/Core/xml/Menu/Misc.xml
@@ -18,6 +18,11 @@
      <weight>0</weight>
   </item>
   <item>
+    <path>civicrm/export/standalone</path>
+    <title>Export</title>
+    <page_callback>CRM_Export_Controller_Standalone</page_callback>
+  </item>
+  <item>
      <path>civicrm/admin/options/acl_role</path>
      <title>ACL Roles</title>
      <page_callback>CRM_Admin_Page_Options</page_callback>

--- a/CRM/Export/Controller/Standalone.php
+++ b/CRM/Export/Controller/Standalone.php
@@ -1,0 +1,94 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2017                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Class CRM_Export_Controller_Standalone
+ */
+class CRM_Export_Controller_Standalone extends CRM_Core_Controller {
+
+  /**
+   * Class constructor.
+   *
+   * @param string $title
+   * @param bool|int $action
+   * @param bool $modal
+   */
+  public function __construct($title = NULL, $action = CRM_Core_Action::NONE, $modal = TRUE) {
+
+    parent::__construct($title, $modal);
+
+    $entity = ucfirst(CRM_Utils_Request::retrieve('entity', 'String', $this, TRUE));
+    $this->set('entity', $entity);
+    $id = explode(',', CRM_Utils_Request::retrieve('id', 'CommaSeparatedIntegers', $this, TRUE));
+
+    // Check permissions
+    $perm = civicrm_api3($entity, 'get', array(
+      'return' => 'id',
+      'options' => array('limit' => 0),
+      'check_permissions' => 1,
+      'id' => array('IN' => $id),
+    ));
+
+    $this->set('id', implode(',', array_keys($perm['values'])));
+    if ($entity == 'Contact') {
+      $this->set('cids', implode(',', array_keys($perm['values'])));
+    }
+
+    $this->_stateMachine = new CRM_Export_StateMachine_Standalone($this, $action);
+
+    // create and instantiate the pages
+    $this->addPages($this->_stateMachine, $action);
+
+    // add all the actions
+    $this->addActions();
+  }
+
+  /**
+   *
+   *
+   * @param string $pageName
+   * @return array
+   */
+  public function exportValues($pageName = NULL) {
+    $values = parent::exportValues();
+    $values['radio_ts'] = 'ts_sel';
+    foreach (explode(',', $this->get('id')) as $id) {
+      if ($id) {
+        $values[CRM_Core_Form::CB_PREFIX . $id] = 1;
+      }
+    }
+    $className = 'CRM_' . $this->get('entity') . '_Task';
+    foreach ($className::tasks() as $taskId => $task) {
+      $taskForm = (array) $task['class'];
+      if ($taskForm[0] == 'CRM_Export_Form_Select') {
+        $values['task'] = $taskId;
+      }
+    }
+    return $values;
+  }
+
+}

--- a/CRM/Export/Form/Map.php
+++ b/CRM/Export/Form/Map.php
@@ -237,7 +237,7 @@ class CRM_Export_Form_Map extends CRM_Core_Form {
     //get the csv file
     CRM_Export_BAO_Export::exportComponents($this->get('selectAll'),
       $this->get('componentIds'),
-      $this->get('queryParams'),
+      (array) $this->get('queryParams'),
       $this->get(CRM_Utils_Sort::SORT_ORDER),
       $mapperKeys,
       $this->get('returnProperties'),

--- a/CRM/Export/Form/Select.php
+++ b/CRM/Export/Form/Select.php
@@ -78,6 +78,8 @@ class CRM_Export_Form_Select extends CRM_Core_Form {
    * @return void
    */
   public function preProcess() {
+    $this->preventAjaxSubmit();
+
     //special case for custom search, directly give option to download csv file
     $customSearchID = $this->get('customSearchID');
     if ($customSearchID) {

--- a/CRM/Export/Form/Select.php
+++ b/CRM/Export/Form/Select.php
@@ -92,6 +92,10 @@ class CRM_Export_Form_Select extends CRM_Core_Form {
     $this->_componentIds = array();
     $this->_componentClause = NULL;
 
+    $stateMachine = $this->controller->getStateMachine();
+    $formName = CRM_Utils_System::getClassName($stateMachine);
+    $isStandalone = $formName == 'CRM_Export_StateMachine_Standalone';
+
     // get the submitted values based on search
     if ($this->_action == CRM_Core_Action::ADVANCED) {
       $values = $this->controller->exportValues('Advanced');
@@ -104,45 +108,17 @@ class CRM_Export_Form_Select extends CRM_Core_Form {
     }
     else {
       // we need to determine component export
-      $stateMachine = $this->controller->getStateMachine();
-
-      $formName = CRM_Utils_System::getClassName($stateMachine);
       $componentName = explode('_', $formName);
       $components = array('Contribute', 'Member', 'Event', 'Pledge', 'Case', 'Grant', 'Activity');
 
+      if ($isStandalone) {
+        $componentName = array('CRM', $this->controller->get('entity'));
+      }
+
       if (in_array($componentName[1], $components)) {
-        switch ($componentName[1]) {
-          case 'Contribute':
-            $this->_exportMode = self::CONTRIBUTE_EXPORT;
-            break;
-
-          case 'Member':
-            $this->_exportMode = self::MEMBER_EXPORT;
-            break;
-
-          case 'Event':
-            $this->_exportMode = self::EVENT_EXPORT;
-            break;
-
-          case 'Pledge':
-            $this->_exportMode = self::PLEDGE_EXPORT;
-            break;
-
-          case 'Case':
-            $this->_exportMode = self::CASE_EXPORT;
-            break;
-
-          case 'Grant':
-            $this->_exportMode = self::GRANT_EXPORT;
-            break;
-
-          case 'Activity':
-            $this->_exportMode = self::ACTIVITY_EXPORT;
-            break;
-        }
-
+        $this->_exportMode = constant('CRM_Export_Form_Select::' . strtoupper($componentName[1]) . '_EXPORT');
         $className = "CRM_{$componentName[1]}_Form_Task";
-        $className::preProcessCommon($this, TRUE);
+        $className::preProcessCommon($this, !$isStandalone);
         $values = $this->controller->exportValues('Search');
       }
       else {
@@ -167,31 +143,31 @@ class CRM_Export_Form_Select extends CRM_Core_Form {
     $componentMode = $this->get('component_mode');
     switch ($componentMode) {
       case 2:
-        CRM_Contribute_Form_Task::preProcessCommon($this, TRUE);
+        CRM_Contribute_Form_Task::preProcessCommon($this, !$isStandalone);
         $this->_exportMode = self::CONTRIBUTE_EXPORT;
         $componentName = array('', 'Contribute');
         break;
 
       case 3:
-        CRM_Event_Form_Task::preProcessCommon($this, TRUE);
+        CRM_Event_Form_Task::preProcessCommon($this, !$isStandalone);
         $this->_exportMode = self::EVENT_EXPORT;
         $componentName = array('', 'Event');
         break;
 
       case 4:
-        CRM_Activity_Form_Task::preProcessCommon($this, TRUE);
+        CRM_Activity_Form_Task::preProcessCommon($this, !$isStandalone);
         $this->_exportMode = self::ACTIVITY_EXPORT;
         $componentName = array('', 'Activity');
         break;
 
       case 5:
-        CRM_Member_Form_Task::preProcessCommon($this, TRUE);
+        CRM_Member_Form_Task::preProcessCommon($this, !$isStandalone);
         $this->_exportMode = self::MEMBER_EXPORT;
         $componentName = array('', 'Member');
         break;
 
       case 6:
-        CRM_Case_Form_Task::preProcessCommon($this, TRUE);
+        CRM_Case_Form_Task::preProcessCommon($this, !$isStandalone);
         $this->_exportMode = self::CASE_EXPORT;
         $componentName = array('', 'Case');
         break;
@@ -202,7 +178,7 @@ class CRM_Export_Form_Select extends CRM_Core_Form {
       $contactTasks = CRM_Contact_Task::taskTitles();
       $taskName = $contactTasks[$this->_task];
       $component = FALSE;
-      CRM_Contact_Form_Task::preProcessCommon($this, TRUE);
+      CRM_Contact_Form_Task::preProcessCommon($this, !$isStandalone);
     }
     else {
       $this->assign('taskName', "Export $componentName[1]");
@@ -420,7 +396,7 @@ FROM   {$this->_componentTable}
     if ($exportOption == self::EXPORT_ALL) {
       CRM_Export_BAO_Export::exportComponents($this->_selectAll,
         $this->_componentIds,
-        $this->get('queryParams'),
+        (array) $this->get('queryParams'),
         $this->get(CRM_Utils_Sort::SORT_ORDER),
         NULL,
         $this->get('returnProperties'),

--- a/CRM/Export/StateMachine/Standalone.php
+++ b/CRM/Export/StateMachine/Standalone.php
@@ -1,0 +1,68 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2017                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2017
+ */
+class CRM_Export_StateMachine_Standalone extends CRM_Core_StateMachine {
+
+  /**
+   * Class constructor.
+   *
+   * @param object $controller
+   * @param \const|int $action
+   */
+  public function __construct($controller, $action = CRM_Core_Action::NONE) {
+    parent::__construct($controller, $action);
+
+    $this->_pages = array(
+      'CRM_Export_Form_Select' => NULL,
+      'CRM_Export_Form_Map' => NULL,
+    );
+
+    $this->addSequentialPages($this->_pages, $action);
+  }
+
+  /**
+   * @todo So far does nothing.
+   *
+   * @return string
+   */
+  public function getTaskFormName() {
+    return '';
+  }
+
+  /**
+   * @todo not sure if this is needed
+   */
+  public function shouldReset() {
+    return FALSE;
+  }
+
+}


### PR DESCRIPTION
Overview
----------
CiviCRM export is tightly coupled to the search forms.
This adds a standalone export form which can be called directly from the url, e.g. `civicrm/export/standalone?entity=Case&id=12,34,56`

Notes
------
This is for use by the CiviCase extension, but will be suitable for many other purposes too. All entities are supported.

* [CRM-21406: Create Standalone Export Form](https://issues.civicrm.org/jira/browse/CRM-21406)