### PR TITLE
CRM-21408 - Api explorer - better defaults for sequential checkbox

### DIFF
--- a/templates/CRM/Admin/Page/APIExplorer.js
+++ b/templates/CRM/Admin/Page/APIExplorer.js
@@ -278,6 +278,8 @@
     fields = [];
     joins = [];
     getFieldData = {};
+    // Sequential doesn't make sense in getsingle context, and is only a sensible default for get
+    $('label[for=sequential-checkbox]').toggle(action !== 'getsingle').find('input').prop('checked', action === 'get').change();
     // Special case for getfields
     if (action === 'getfields') {
       fields.push({


### PR DESCRIPTION
Overview
-------
The sequential param probably should not be default at all, but this at least hides the option for getsingle (which would make no sense) and sets it as default only for get.

Before
-----
People were likely to misuse the 'sequential' option in places where it doesn't belong, like 'getsingle'.

After
----
Hides the option for 'getsingle', and unchecks the option by default for all actions other than get.

* [CRM-21408: Api explorer - better defaults for sequential checkbox](https://issues.civicrm.org/jira/browse/CRM-21408)