### PR TITLE
CRM-21409 Don't bypass hooks when updating contribution receipt/thankyou date

### DIFF
--- a/CRM/Contribute/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contribute/Form/Task/PDFLetterCommon.php
@@ -89,19 +89,18 @@ class CRM_Contribute_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDF
         }
         $contact['is_sent'][$groupBy][$groupByID] = TRUE;
       }
-      // update dates (do it for each contribution including grouped recurring contribution)
-      //@todo - the 2 calls below bypass all hooks. Using the api would possibly be slower than one call but not than 2
+      // Update receipt/thankyou dates
+      $contributionParams = array('id' => $contributionId);
       if ($receipt_update) {
-        $result = CRM_Core_DAO::setFieldValue('CRM_Contribute_DAO_Contribution', $contributionId, 'receipt_date', $nowDate);
-        if ($result) {
-          $receipts++;
-        }
+        $contributionParams['receipt_date'] = $nowDate;
       }
       if ($thankyou_update) {
-        $result = CRM_Core_DAO::setFieldValue('CRM_Contribute_DAO_Contribution', $contributionId, 'thankyou_date', $nowDate);
-        if ($result) {
-          $thanks++;
-        }
+        $contributionParams['thankyou_date'] = $nowDate;
+      }
+      if ($receipt_update || $thankyou_update) {
+        civicrm_api3('Contribution', 'create', $contributionParams);
+        $receipts = ($receipt_update ? $receipts + 1 : $receipts);
+        $thanks = ($thankyou_update ? $thanks + 1 : $thanks);
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Use the API instead of directly accessing DAO object.  This fixes a "todo" in the code and means that the entity changes will trigger any necessary hooks instead of bypassing them.

---

 * [CRM-21409: Don't bypass hooks when updating thankyou_sent\/receipt_sent fields via PDF letter action](https://issues.civicrm.org/jira/browse/CRM-21409)