### PR TITLE
CRM-21411 Fix issue where unsubscribe group field would not show beca…

### DIFF
--- a/ang/crmMailing/BlockMailing.html
+++ b/ang/crmMailing/BlockMailing.html
@@ -61,7 +61,7 @@ It could perhaps be thinned by 30-60% by making more directives.
           ng-model="mailing.recipients.groups.base[0]"
           ng-required="true"
           >
-          <option ng-repeat="grp in crmMailingConst.groupNames | filter:{is_hidden:0} | orderBy:'title'" value="{{grp.id}}">{{grp.title}}</option>
+          <option ng-repeat="grp in crmMailingConst.testGroupNames | filter:{is_hidden:0} | orderBy:'title'" value="{{grp.id}}">{{grp.title}}</option>
         </select>
       </div>
     </span>

--- a/ang/crmMailing/EditUnsubGroupCtrl.js
+++ b/ang/crmMailing/EditUnsubGroupCtrl.js
@@ -3,14 +3,16 @@
   angular.module('crmMailing').controller('EditUnsubGroupCtrl', function EditUnsubGroupCtrl($scope) {
     // CRM.crmMailing.groupNames is a global constant - since it doesn't change, we can digest & cache.
     var mandatoryIds = [];
-    _.each(CRM.crmMailing.groupNames, function(grp) {
-      if (grp.is_hidden == "1") {
-        mandatoryIds.push(parseInt(grp.id));
-      }
-    });
 
     $scope.isUnsubGroupRequired = function isUnsubGroupRequired(mailing) {
-      return _.intersection(mandatoryIds, mailing.recipients.groups.include).length > 0;
+      if (!_.isEmpty(CRM.crmMailing.groupNames)) {
+        _.each(CRM.crmMailing.groupNames, function(grp) {
+          if (grp.is_hidden == "1") {
+            mandatoryIds.push(parseInt(grp.id));
+          }
+        });
+        return _.intersection(mandatoryIds, mailing.recipients.groups.include).length > 0;
+      }
     };
   });
 


### PR DESCRIPTION
…use CRM.crmMailing.groupNames was empty

Before
----------------------------------------
unsubscribe group field doesn't show

After
----------------------------------------
Now it does

Technical Details
----------------------------------------
because CRM.crmMailing.groupNames is now dynamically populated checking to see if it was set immediately as the JS loaded was causing scope.isUnsubGroupRequired to be set to false incorrectly and hence hiding the unsubscribe group section

Comments
----------------------------------------
@joannechester @KarinG @eileenmcnaughton could one of you please test this to test it create a CiviMailing from an advanced search and you should see the Unsubscribe Group field show. You may need to disable asset chaching under the debugging settings to ensure the updated code is used.
