### PR TITLE
CRM-21412 Do not give fatal error on report when no fields selected

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -2396,6 +2396,11 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
       }
     }
 
+    if (empty($select)) {
+      // CRM-21412 Do not give fatal error on report when no fields selected
+      $select = array(1);
+    }
+
     $this->_selectClauses = $select;
     $this->_select = "SELECT " . implode(', ', $select) . " ";
   }


### PR DESCRIPTION
Overview
----------------------------------------
This is a trivial fix to ensure that when a report that inherits the main 'select' function is rendered with no fields selected there is no hard error - by adding SELECT 1 instead of leaving the select clause missing. 

Before
----------------------------------------
In some rare circumstances (especially when extension writers write reports) a report can be rendered with no fields selected for display. In this case a fatal db error occurs

After
----------------------------------------
Report shows empty rows but no hard fatal error

Technical Details
----------------------------------------
This is an upstream of a fix that has been in extended reports for some time. 

Comments
----------------------------------------
I don't know of an obvious way to replicate it but I feel there is no risk of harm here (reports that do weird things manage their own selects) and it helps people writing custom reports.

---

 * [CRM-21412: Do not give fatal error on report when no fields selected](https://issues.civicrm.org/jira/browse/CRM-21412)