### PR TITLE
CRM-21416: Add reset link beside 'Search' button below Advance Search form

### DIFF
--- a/templates/CRM/Contact/Form/Search/AdvancedCriteria.tpl
+++ b/templates/CRM/Contact/Form/Search/AdvancedCriteria.tpl
@@ -146,7 +146,15 @@ CRM.$(function($) {
 
   <table class="form-layout">
     <tr>
-      <td>{include file="CRM/common/formButtons.tpl" location="botton"}</td>
+      <td>
+        {include file="CRM/common/formButtons.tpl" location="bottom"}
+        <div class="crm-submit-buttons reset-advanced-search">
+          <a href="{crmURL p='civicrm/contact/search/advanced' q='reset=1'}" id="resetAdvancedSearch" class="crm-hover-button" title="{ts}Clear all search criteria{/ts}">
+            <i class="crm-i fa-undo"></i>
+            &nbsp;{ts}Reset Form{/ts}
+          </a>
+        </div>
+      </td>
     </tr>
   </table>
 {/strip}


### PR DESCRIPTION
Overview
----------------------------------------
Add 'Reset Form' link beside 'Search' button below Advance Search form

Before
----------------------------------------
![screen shot 2017-11-09 at 1 38 48 pm](https://user-images.githubusercontent.com/3735621/32594955-012ecdf0-c554-11e7-996a-d2cfa0245985.png)

After
----------------------------------------
![screen shot 2017-11-09 at 1 37 31 pm](https://user-images.githubusercontent.com/3735621/32594963-09a69fbc-c554-11e7-9c07-85d9c323b3c9.png)

---

 * [CRM-21416: Add reset link beside 'Search' button below Advance Search form](https://issues.civicrm.org/jira/browse/CRM-21416)