### PR TITLE
CRM-21362: followup PR which fixes duplicate mailing rows for each job

### DIFF
--- a/CRM/Report/Form/Mailing/Summary.php
+++ b/CRM/Report/Form/Mailing/Summary.php
@@ -117,9 +117,11 @@ class CRM_Report_Form_Mailing_Summary extends CRM_Report_Form {
       'fields' => array(
         'start_date' => array(
           'title' => ts('Start Date'),
+          'dbAlias' => 'MIN(mailing_job_civireport.start_date)',
         ),
         'end_date' => array(
           'title' => ts('End Date'),
+          'dbAlias' => 'MAX(mailing_job_civireport.end_date)',
         ),
       ),
       'filters' => array(


### PR DESCRIPTION
Overview
----------------------------------------
This is a followup PR of #11206 which fixes duplicate mailing rows for each job.

---

 * [CRM-21362: Mailing summary report group by MySQL 5.7 error](https://issues.civicrm.org/jira/browse/CRM-21362)