### PR TITLE
Resolves regression issue with non-dynamic custom fields

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -2058,7 +2058,11 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
         }
         else {
           $customField['options'] = CRM_Core_BAO_CustomOption::getCustomOption($customField['id']);
-          $retValue = $customField['options'][$value]['label'];
+          foreach ($customField['options'] as $cf_key => $cf_values) {
+            if ($cf_values['value'] == $value) {
+              $retValue = $cf_values['label'];
+            }
+          }
           break;
         }
 


### PR DESCRIPTION
Overview
----------------------------------------
This is a fix for PR https://github.com/civicrm/civicrm-core/pull/9478 . After PR was merged, it was pointed that on various reports, the customfield of type 'select' did not render at all.

See issue: https://issues.civicrm.org/jira/browse/CRM-21402
