### PR TITLE
CRM-21419 Prevent users from accidentally creating a single activity when they want multiple

### DIFF
--- a/templates/CRM/Activity/Form/Activity.hlp
+++ b/templates/CRM/Activity/Form/Activity.hlp
@@ -23,11 +23,12 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-{htxt id="id-is_multi_activity-title"}
-  {ts}Create Separate Activity Records?{/ts}
+{htxt id="separation-title"}
+  {ts}Activity Separation{/ts}
 {/htxt}
-{htxt id="id-is_multi_activity"}
-  <p>{ts}By default a single activity record will be created and linked to all the contacts listed above. However, if you think you might be editing the activity later - and entering different information for different contacts - check this box to create separate activity records.{/ts}</p>
+{htxt id="separation"}
+  <p>{ts}With separate activities, you can enter different activity information for different contacts after creating the activities.{/ts}</p>
+  <p>{ts}With a single activity, the activity information cannot be customized for each contact.{/ts}</p>
 {/htxt}
 
 {htxt id="assignee_contact_id"}

--- a/templates/CRM/Activity/Form/Activity.tpl
+++ b/templates/CRM/Activity/Form/Activity.tpl
@@ -78,13 +78,15 @@
   <td class="label">{$form.target_contact_id.label}</td>
     <td class="view-value">
       {$form.target_contact_id.html}
-      {if $action eq 1 or $single eq false}
-      <div class="crm-is-multi-activity-wrapper">
-        {$form.is_multi_activity.html}&nbsp;{$form.is_multi_activity.label} {help id="id-is_multi_activity"}
-      </div>
-      {/if}
     </td>
   </tr>
+
+  {if $action eq 1 or $single eq false}
+    <tr class="crm-activity-form-block-separation crm-is-multi-activity-wrapper">
+      <td class="label">{$form.separation.label}</td>
+      <td>{$form.separation.html} {help id="separation"}</td>
+    </tr>
+  {/if}
 
   <tr class="crm-activity-form-block-assignee_contact_id">
       <td class="label">


### PR DESCRIPTION
## Overview

When creating a new activity with multiple contacts, CiviCRM offers a checkbox to "Create a separate activity for each contact". This is good.

But the "separate activity" use case is common enough, that missing the checkbox can lead to users accidentally creating combined activities. This mistake is bad because it prevents users from being able to make independent edits to those activities for different contacts.

## Before

* Users commonly want this box checked, but it's easy to forget to check it.
    
    ![before](https://user-images.githubusercontent.com/42411/32617512-2da13c3a-c543-11e7-84d3-bc1c9d36b926.png)

## After

* "Activity Separation" is a required field, which prompts the user to make an intentional choice.

    ![after](https://user-images.githubusercontent.com/42411/32617521-310104aa-c543-11e7-8ebd-187558ee9c1c.png)

* "Activity Separation" only appears when multiple contacts are chosen (just like the checkbox did).

* If you submit the form with multiple contacts but nothing selected for "Activity Separation", then the form does not validate.

    ![error](https://user-images.githubusercontent.com/42411/32622873-59335478-c552-11e7-8288-0cc41921baa5.png)

    * And if you don't choose multiple contacts, then the form won't complain.

---

 * [CRM-21419: Prevent users from accidentally creating a single activity when they want multiple activities](https://issues.civicrm.org/jira/browse/CRM-21419)