### PR TITLE
CRM-21383 - Inclusion of a directive to replace the existing select f…

### DIFF
--- a/ang/crmMailing/BlockMailing.html
+++ b/ang/crmMailing/BlockMailing.html
@@ -7,20 +7,7 @@ It could perhaps be thinned by 30-60% by making more directives.
 <div class="crm-block" ng-form="subform" crm-ui-id-scope>
   <div class="crm-group">
     <div crm-ui-field="{name: 'subform.msg_template_id', title: ts('Template')}">
-      <div ng-controller="MsgTemplateCtrl">
-        <select
-          crm-ui-id="subform.msg_template_id"
-          name="msg_template_id"
-          class="fa-clipboard"
-          crm-ui-select="{dropdownAutoWidth : true, allowClear: true, placeholder: ts('Message Template')}"
-          ng-model="mailing.msg_template_id"
-          ng-change="loadTemplate(mailing, mailing.msg_template_id)"
-          >
-          <option value=""></option>
-          <option ng-repeat="frm in crmMsgTemplates.getAll() | orderBy:'msg_title'" ng-value="frm.id">{{frm.msg_title}}</option>
-        </select>
-        <a crm-icon="fa-floppy-o" ng-if="checkPerm('edit message templates')" ng-click="saveTemplate(mailing)" class="crm-hover-button" title="{{ts('Save As')}}"></a>
-      </div>
+      <div crm-mailing-block-templates="{name: 'templates', id: 'subform.msg_template_id'}" crm-mailing="mailing"></div>
     </div>
     <div crm-ui-field="{name: 'subform.fromAddress', title: ts('From'), help: hs('from_email')}">
       <div ng-controller="EmailAddrCtrl" crm-mailing-from-address="fromPlaceholder" crm-mailing="mailing">

--- a/ang/crmMailing/BlockTemplates.html
+++ b/ang/crmMailing/BlockTemplates.html
@@ -1,0 +1,9 @@
+<div ng-controller="MsgTemplateCtrl" class="crm-mailing-templates-row">
+    <input 
+      type="hidden"
+      crm-mailing-templates
+      ng-model="mailing.msg_template_id"
+      crm-ui-id="{{crmMailingBlockTemplates.id}}"
+      name="{{crmMailingBlockTemplates.name}}" />
+  <a crm-icon="fa-floppy-o" ng-if="checkPerm('edit message templates')" ng-click="saveTemplate(mailing)" class="crm-hover-button" title="{{ts('Save As')}}"></a>
+</div>

--- a/ang/crmMailing/BlockTemplates.js
+++ b/ang/crmMailing/BlockTemplates.js
@@ -1,0 +1,5 @@
+(function(angular, $, _) {
+  angular.module('crmMailing').directive('crmMailingBlockTemplates', function(crmMailingSimpleDirective) {
+    return crmMailingSimpleDirective('crmMailingBlockTemplates', '~/crmMailing/BlockTemplates.html');
+  });
+})(angular, CRM.$, CRM._);

--- a/ang/crmMailing/MsgTemplateCtrl.js
+++ b/ang/crmMailing/MsgTemplateCtrl.js
@@ -33,6 +33,7 @@
     // @return Promise
     $scope.loadTemplate = function loadTemplate(mailing, id) {
       return crmMsgTemplates.get(id).then(function(tpl) {
+        mailing.msg_template_id = tpl.id;
         mailing.subject = tpl.msg_subject;
         mailing.body_text = tpl.msg_text;
         mailing.body_html = tpl.msg_html;

--- a/ang/crmMailing/Templates.js
+++ b/ang/crmMailing/Templates.js
@@ -30,7 +30,6 @@
             var rcpAjaxState = {
               input: '',
               entity: 'civicrm_msg_templates',
-              type: 'include',
               page_n: 0,
               page_i: 0,
             };
@@ -55,7 +54,7 @@
                         $(tlist.values).each(function(id, val) {
                           template.id = val.id;
                           template.text = val.label;
-                        })
+                        });
                       }
 
                       cb(template);
@@ -69,7 +68,6 @@
                       rcpAjaxState = {
                         input: input,
                         entity: 'civicrm_msg_templates',
-                        type: 'include',
                         page_n: 0,
                       };
                     }

--- a/ang/crmMailing/Templates.js
+++ b/ang/crmMailing/Templates.js
@@ -1,0 +1,134 @@
+(function(angular, $, _) {
+  // example <select crm-mailing-templates crm-mailing="mymailing"></select>
+  angular.module('crmMailing').directive('crmMailingTemplates', function(crmUiAlert) {
+      return {
+          restrict: 'AE',
+          require: 'ngModel',
+          scope: {
+            ngRequired: '@'
+          },
+          templateUrl: '~/crmMailing/Templates.html',
+          link: function(scope, element, attrs, ngModel) {
+            scope.template = ngModel.$viewValue;
+
+            var refreshUI = ngModel.$render = function refresuhUI() {
+              scope.template = ngModel.$viewValue;
+              if (ngModel.$viewValue) {
+                $(element).select2('val', ngModel.$viewValue);
+              }
+            };
+
+            // @return string HTML representing an option
+            function formatItem(item) {
+              if (!item.id) {
+                // return `text` for optgroup
+                return item.text;
+              }
+              return '<span class="crmMailing-template">' + item.text + '</span>';
+            }
+
+            var rcpAjaxState = {
+              input: '',
+              entity: 'civicrm_msg_templates',
+              type: 'include',
+              page_n: 0,
+              page_i: 0,
+            };
+
+            $(element).select2({
+              width: '36em',
+              placeholder: "<i class='fa fa-clipboard'></i> Mailing Templates",
+              formatResult: formatItem,
+              escapeMarkup: function(m) {
+                return m;
+              },
+              multiple: false,
+              initSelection: function(el, cb) {
+
+                  var value = el.val();
+
+                  CRM.api3('MessageTemplate', 'getlist', { params: { id: value }, label_field: 'msg_title' }).then(function(tlist) {
+
+                      var template = {};
+
+                      if (tlist.count) {
+                        $(tlist.values).each(function(id, val) {
+                          template.id = val.id;
+                          template.text = val.label;
+                        })
+                      }
+
+                      cb(template);
+                  });
+              },
+              ajax: {
+                  url: CRM.url('civicrm/ajax/rest'),
+                  quietMillis: 300,
+                  data: function(input, page_num) {
+                    if (page_num <= 1) {
+                      rcpAjaxState = {
+                        input: input,
+                        entity: 'civicrm_msg_templates',
+                        type: 'include',
+                        page_n: 0,
+                      };
+                    }
+
+                    rcpAjaxState.page_i = page_num - rcpAjaxState.page_n;
+                    var filterParams = { is_active: 1, workflow_id: { "IS NULL": 1 } };
+                    
+                    var params = {
+                      input: input,
+                      page_num: rcpAjaxState.page_i,
+                      label_field: 'msg_title',
+                      search_field: 'msg_title',
+                      params: filterParams,
+                    };
+                    return params;
+                  },
+                  transport: function(params) {
+                    CRM.api3('MessageTemplate', 'getlist', params.data).then(params.success, params.error);
+                  },
+                  results: function(data) {
+
+                    results = {
+                      children: $.map(data.values, function(obj) {
+                        return { id: obj.id, text: obj.label };
+                      })
+                    };
+
+                    if (rcpAjaxState.page_i == 1 && data.count) {
+                      results.text = ts('Message Templates');
+                    }
+
+                    more = data.more_results;
+
+                    if (more && !data.more_results) {
+                      rcpAjaxState.page_n += rcpAjaxState.page_i;
+                    }
+
+                    return { more: more, results: [ results ] };
+                  },
+                }
+            });
+
+            $(element).on('select2-selecting', function(e) {
+              // in here is where the template HTML should be loaded
+              var entity_id = parseInt(e.val);
+              ngModel.$viewValue = entity_id;
+
+              scope.$parent.loadTemplate(scope.$parent.$parent.mailing, entity_id);
+              scope.$apply();
+              $(element).select2('close');
+              e.preventDefault();
+            });
+
+
+            scope.$watchCollection("template", refreshUI);
+            setTimeout(refreshUI, 50);
+          }
+      };
+
+
+  });
+})(angular, CRM.$, CRM._);


### PR DESCRIPTION
…ield for loading Message templates on demand in the CiviMail compose UI

Overview
----------------------------------------
This is to replace the current selection field for choosing a message template in the CiviMail compose UI screen, so that templates are loaded on demand rather than on the initial state.

Before
----------------------------------------
Please see @davejenx comment regarding performance issues #on the following pull request https://github.com/civicrm/civicrm-core/pull/11091#issuecomment-340027758

After
----------------------------------------
Templates loaded on demand, with the ability to search for a specific template. ![civimailmessagetemplates](https://user-images.githubusercontent.com/2014068/32671145-4176556e-c63e-11e7-8a31-dadfe967284e.gif)


Technical Details
----------------------------------------
Removed the origin <select> field for the choosing of templates, this has now been written as a AngularJS directive.

Comments
----------------------------------------
I believe how I have included the LoadMessage template function is incorrect, I don't like how I am having to use the grandparent scope, but I couldn't see how to avoid this. Overall, I have seen good performance improvements. However, I have also noticed a slight delay in loading the field on the latest master (seen in the above GIF).
