### PR TITLE
CRM-21421 Fix to allow updating an existing CaseContact record

### DIFF
--- a/tests/phpunit/api/v3/CaseContactTest.php
+++ b/tests/phpunit/api/v3/CaseContactTest.php
@@ -9,6 +9,7 @@ class api_v3_CaseContactTest extends CiviCaseTestCase {
   protected $_params;
   protected $_entity;
   protected $_cid;
+  protected $_cid2;
   /**
    * Activity ID of created case.
    *
@@ -28,12 +29,18 @@ class api_v3_CaseContactTest extends CiviCaseTestCase {
     parent::setUp();
 
     $this->_cid = $this->individualCreate();
+    $this->_cid2 = $this->individualCreate(array(), 1);
 
     $this->_case = $this->callAPISuccess('case', 'create', array(
       'case_type_id' => $this->caseTypeId,
       'subject' => __CLASS__,
       'contact_id' => $this->_cid,
     ));
+
+    $this->_params = array(
+      'case_id' => $this->_case['id'],
+      'contact_id' => $this->_cid2,
+    );
   }
 
   public function testCaseContactGet() {
@@ -41,6 +48,20 @@ class api_v3_CaseContactTest extends CiviCaseTestCase {
       'contact_id' => $this->_cid,
     ), __FUNCTION__, __FILE__);
     $this->assertEquals($this->_case['id'], $result['id']);
+  }
+
+  /**
+   * Test create function with valid parameters.
+   */
+  public function testCaseContactCreate() {
+    $params = $this->_params;
+    $result = $this->callAPIAndDocument('CaseContact', 'create', $params, __FUNCTION__, __FILE__);
+    $id = $result['id'];
+
+    // Check result
+    $result = $this->callAPISuccess('CaseContact', 'get', array('id' => $id));
+    $this->assertEquals($result['values'][$id]['case_id'], $params['case_id']);
+    $this->assertEquals($result['values'][$id]['contact_id'], $params['contact_id']);
   }
 
 }

--- a/tests/phpunit/api/v3/CaseTest.php
+++ b/tests/phpunit/api/v3/CaseTest.php
@@ -204,6 +204,33 @@ class api_v3_CaseTest extends CiviCaseTestCase {
   }
 
   /**
+   * Test update (create with id) function with valid parameters.
+   */
+  public function testCaseUpdateWithExistingCaseContact() {
+    $params = $this->_params;
+    // Test using name instead of value
+    unset($params['case_type_id']);
+    $params['case_type'] = $this->caseType;
+    $result = $this->callAPISuccess('case', 'create', $params);
+    $id = $result['id'];
+    $case = $this->callAPISuccess('case', 'getsingle', array('id' => $id));
+
+    // Update Case, we specify existing case ID and existing contact ID to verify that CaseContact.create is not called
+    $params = $this->_params;
+    $params['id'] = $id;
+    $this->callAPISuccess('case', 'create', $params);
+
+    // Verify that updated case is equal to the original with new subject.
+    $result = $this->callAPISuccessGetSingle('Case', array('case_id' => $id));
+    // Modification dates are likely to differ by 0-2 sec. Check manually.
+    $this->assertGreaterThanOrEqual($result['modified_date'], $case['modified_date']);
+    unset($result['modified_date']);
+    unset($case['modified_date']);
+    // Everything else should be identical.
+    $this->assertAPIArrayComparison($result, $case);
+  }
+
+  /**
    * Test case update with custom data
    */
   public function testCaseUpdateCustom() {


### PR DESCRIPTION
Overview
----------------------------------------
Found during a webform submission that updates a case status, but easy to replicate using the Case.Create API.

The function CRM_Case_BAO_CaseContact::create requires that you either specify a CaseContact ID or it will try and add a new one.  However, the database index UI_case_contact_id has recently been changed to be UNIQUE and was causing the function CRM_Case_BAO_CaseContact::create to crash.  The change has been in CiviCRM since 4.7.20 but the change to the database would have been made at some point after CiviCRM started warning when indexes were inconsistent.

Before
----------------------------------------
It is not possible to update cases via the API once the UI_case_contact_id index has been updated to "UNIQUE".

After
----------------------------------------
It is possible to update cases via the API once the UI_case_contact_id index has been updated to "UNIQUE".

Technical Details
----------------------------------------
Adds an API call to CRM_Case_BAO_CaseContact which calls CaseContact.getsingle with contact_id and case_id as parameters.  If an existing CaseContact.id is found that is used instead of trying to create a new one.

Comments
----------------------------------------
@colemanw I'm not sure if the way I've fixed this is the right way, ie. using the API, and I'm not sure why it appears that it was previously creating new CaseContact entries every time it was updating a case?
When you get a minute, would you mind reviewing this PR and advising what the correct fix should be?

---

 * [CRM-21421: Cannot update existing CaseContact](https://issues.civicrm.org/jira/browse/CRM-21421)