### PR TITLE
CRM-21041: Respect default 'Communication Style' when creating a …

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -306,6 +306,11 @@ class CRM_Contact_BAO_Contact extends CRM_Contact_DAO_Contact {
           }
         }
       }
+
+      // CRM-21041: set default 'Communication Style' if unset when creating a contact.
+      if (empty($params['communication_style_id'])) {
+        $params['communication_style_id'] = array_pop(CRM_Core_OptionGroup::values('communication_style', TRUE, NULL, NULL, 'AND is_default = 1'));
+      }
     }
 
     $transaction = new CRM_Core_Transaction();

--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -309,7 +309,8 @@ class CRM_Contact_BAO_Contact extends CRM_Contact_DAO_Contact {
 
       // CRM-21041: set default 'Communication Style' if unset when creating a contact.
       if (empty($params['communication_style_id'])) {
-        $params['communication_style_id'] = array_pop(CRM_Core_OptionGroup::values('communication_style', TRUE, NULL, NULL, 'AND is_default = 1'));
+        $defaultCommunicationStyleId = CRM_Core_OptionGroup::values('communication_style', TRUE, NULL, NULL, 'AND is_default = 1');
+        $params['communication_style_id'] = array_pop($defaultCommunicationStyleId);
       }
     }
 

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -3548,4 +3548,38 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     Civi::$statics['CRM_Contact_BAO_GroupContactCache']['is_refresh_init'] = FALSE;
   }
 
+  /**
+   * CRM-21041 Test if 'communication style' is set to site default if not passed.
+   */
+  public function testCreateCommunicationStyleUnset() {
+    $this->callAPISuccess('Contact', 'create', array(
+      'first_name' => 'John',
+      'last_name' => 'Doe',
+      'contact_type' => 'Individual')
+    );
+    $result = $this->callAPISuccessGetSingle('Contact', array('last_name' => 'Doe'));
+    $this->assertEquals(1, $result['communication_style_id']);
+  }
+  
+  /**
+   * CRM-21041 Test if 'communication style' is set if value is passed.
+   */
+  public function testCreateCommunicationStylePassed() {
+    $this->callAPISuccess('Contact', 'create', array(
+      'first_name' => 'John',
+      'last_name' => 'Doe',
+      'contact_type' => 'Individual',
+      'communication_style_id' => 'Familiar',
+    ));
+    $result = $this->callAPISuccessGetSingle('Contact', array('last_name' => 'Doe'));
+    $params = array(
+      'option_group_id' => 'communication_style',
+      'label' => 'Familiar',
+      'return' => 'value',
+    );
+    $optionResult = civicrm_api3('OptionValue', 'get', $params);
+    $communicationStyle = reset($optionResult['values']);
+    $this->assertEquals($communicationStyle['value'], $result['communication_style_id']);
+  }
+
 }

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -3560,7 +3560,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     $result = $this->callAPISuccessGetSingle('Contact', array('last_name' => 'Doe'));
     $this->assertEquals(1, $result['communication_style_id']);
   }
-  
+
   /**
    * CRM-21041 Test if 'communication style' is set if value is passed.
    */


### PR DESCRIPTION
...Contact via API

Overview
----------------------------------------
Respect default 'Communication Style' when creating a Contact through the API

Before
----------------------------------------
When creating a contact via the API, the default 'Communication Style' is not used and the contact has no value set for Communication Style.

After
----------------------------------------
Now when a contact is created via the API, the default 'Communication Style' is set for that contact.
