### PR TITLE
CRM-21421 - Api case update should not re-save case contacts

### DIFF
--- a/api/v3/Case.php
+++ b/api/v3/Case.php
@@ -123,7 +123,7 @@ function civicrm_api3_case_create($params) {
     throw new API_Exception('Case not created. Please check input params.');
   }
 
-  if (isset($params['contact_id'])) {
+  if (isset($params['contact_id']) && !isset($params['id'])) {
     foreach ((array) $params['contact_id'] as $cid) {
       $contactParams = array('case_id' => $caseBAO->id, 'contact_id' => $cid);
       CRM_Case_BAO_CaseContact::create($contactParams);
@@ -217,6 +217,7 @@ function _civicrm_api3_case_create_spec(&$params) {
     'description' => 'Contact id of case client(s)',
     'api.required' => 1,
     'type' => CRM_Utils_Type::T_INT,
+    'FKApiName' => 'Contact',
   );
   $params['status_id']['api.default'] = 1;
   $params['status_id']['api.aliases'] = array('case_status');


### PR DESCRIPTION
Overview
----
Case api was generating an error when trying to re-save the case contacts in a case with the same values. This prevents it from doing so, as the caseContact api is intended for such operations.

* [CRM-21421: Cannot update existing CaseContact](https://issues.civicrm.org/jira/browse/CRM-21421)