### PR TITLE
CRM-19345: use event.description HTML, don't escape it, in scheduled …

### DIFF
--- a/CRM/Event/Tokens.php
+++ b/CRM/Event/Tokens.php
@@ -139,6 +139,14 @@ LEFT JOIN civicrm_phone phone ON phone.id = lb.phone_id
     elseif ($field == 'fee_amount') {
       $row->tokens($entity, $field, \CRM_Utils_Money::format($actionSearchResult->$field));
     }
+    elseif ($field == 'description') {
+      $description_html = $actionSearchResult->description;
+      $description_text = CRM_Utils_String::htmlToText($description_html);
+      $original_format = $row->format;
+      $row->format('text/html')->tokens($entity, $field, $description_html);
+      $row->format('text/plain')->tokens($entity, $field, $description_text);
+      $row->format($original_format);
+    }
     elseif (isset($actionSearchResult->$field)) {
       $row->tokens($entity, $field, $actionSearchResult->$field);
     }


### PR DESCRIPTION
Overview
----------------------------------------
When including the `event.description` token in a scheduled reminder email, pass through (don't escape) any HTML markup to the email's text/html part. Also generate a plain-text-friendly version of the event description token to be used in the email's text/plain part.

Before
----------------------------------------
When you included the `event.description` token in a scheduled reminder email, the field was assumed to be plain text, and thus it was processed through `htmlentities()` in `Civi\Token\TokenRow->fill()` in order to render the token, resulting in emails containing stuff like `&lt;table&gt;` where `<table>` was intended.

After
----------------------------------------
When you include the `event.description` token in a scheduled reminder email, the rendered HTML version of the token uses the content of the field as-is, and the rendered text version of token uses `CRM_Utils_String::htmlToText`. 

This PR takes a different approach than a previous PR, [#9056](https://github.com/civicrm/civicrm-core/pull/9056)