### PR TITLE
NFC code tidy up preparatory to CRM-19273

### DIFF
--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -829,12 +829,11 @@ WHERE li.contribution_id = %1";
   GROUP BY li.entity_table, li.entity_id, price_field_value_id, fi.id
     ";
     $updateFinancialItemInfoDAO = CRM_Core_DAO::executeQuery($updateFinancialItem);
+    $financialItemResult = $updateFinancialItemInfoDAO->fetchAll();
 
     $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
     $taxTerm = CRM_Utils_Array::value('tax_term', $invoiceSettings);
-    $updateFinancialItemInfoValues = array();
-    while ($updateFinancialItemInfoDAO->fetch()) {
-      $updateFinancialItemInfoValues = (array) $updateFinancialItemInfoDAO;
+    foreach ($financialItemResult as $updateFinancialItemInfoValues) {
       $updateFinancialItemInfoValues['transaction_date'] = date('YmdHis');
       // the below params are not needed
       $previousFinancialItemID = $updateFinancialItemInfoValues['id'];


### PR DESCRIPTION
Overview
----------------------------------------
Code cleanup to remove the Non functional changes from  #10962  to facilitate code review. 

Before
----------------------------------------
Code is less pretty

After
----------------------------------------
Code is more pretty (marginally). Code changes in #10962 can be reduced

Technical Details
----------------------------------------
As part of reducing https://github.com/civicrm/civicrm-core/pull/10962/files easier to parse this makes some small
code tidy ups
1) renames functions to not use the deprecated convention of leading underscore
2) renames function to getLineItemsToAlter rather than 'to add & update'
 (later changes will cause this array to include 'to_cancel' & 'to_resurrect')
3) changes the array return format for that function to be an array of requiredChanges
4) rename function _getFinancialItemsToRecord to getReverseFinancialItemsToRecord to
reflect the fact it is generating an array of reversals to perform

---

 * [CRM-19273: Changes to Event Selections on Pending \(Pay Later\) Contribution Not Creating Correct Financial Items Causing Imbalance in Accounting Batch Export](https://issues.civicrm.org/jira/browse/CRM-19273)