### PR TITLE
CRM-21422 - Fix handling of 0 timezone offset

### DIFF
--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -725,6 +725,11 @@ abstract class CRM_Utils_System_Base {
       $dateTime = new DateTime("now", $tzObj);
       $tz = $tzObj->getOffset($dateTime);
 
+      if ($tz == 0) {
+        // CRM-21422
+        return '+00:00';
+      }
+
       if (empty($tz)) {
         return FALSE;
       }

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -725,7 +725,7 @@ abstract class CRM_Utils_System_Base {
       $dateTime = new DateTime("now", $tzObj);
       $tz = $tzObj->getOffset($dateTime);
 
-      if ($tz == 0) {
+      if ($tz === 0) {
         // CRM-21422
         return '+00:00';
       }


### PR DESCRIPTION
Overview
----------------------------------------
Fix 'Timestamp Mismatch' warnings for servers with 0 timezone offset for UTC - eg Europe/London (when no daylight savings in effect), AND where the server timezone is different.

Before
----------------------------------------
Timestamp Mismatch warning

After
----------------------------------------
No Timestamp Mismatch warning

Technical Details
----------------------------------------
_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_

Comments
----------------------------------------
_Anything else you would like the reviewer to note_

---

 * [CRM-21422: TimeZone handling for Europe\/London fails](https://issues.civicrm.org/jira/browse/CRM-21422)