### PR TITLE
CRM-20545 - port extended reports metadata approach to adding columns

### DIFF
--- a/CRM/Report/Form/Contribute/Detail.php
+++ b/CRM/Report/Form/Contribute/Detail.php
@@ -67,65 +67,15 @@ class CRM_Report_Form_Contribute_Detail extends CRM_Report_Form {
       $this->activeCampaigns = $getCampaigns['campaigns'];
       asort($this->activeCampaigns);
     }
-    $this->_columns = array(
-      'civicrm_contact' => array(
-        'dao' => 'CRM_Contact_DAO_Contact',
-        'fields' => $this->getBasicContactFields(),
-        'filters' => array(
-          'sort_name' => array(
-            'title' => ts('Donor Name'),
-            'operator' => 'like',
-          ),
-          'id' => array(
-            'title' => ts('Contact ID'),
-            'no_display' => TRUE,
-            'type' => CRM_Utils_Type::T_INT,
-          ),
-          'gender_id' => array(
-            'title' => ts('Gender'),
-            'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-            'options' => CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'gender_id'),
-          ),
-          'birth_date' => array(
-            'title' => ts('Birth Date'),
-            'operatorType' => CRM_Report_Form::OP_DATE,
-          ),
-          'contact_type' => array(
-            'title' => ts('Contact Type'),
-          ),
-          'contact_sub_type' => array(
-            'title' => ts('Contact Subtype'),
-          ),
-        ),
-        'grouping' => 'contact-fields',
-        'order_bys' => array(
-          'sort_name' => array(
-            'title' => ts('Last Name, First Name'),
-            'default' => '1',
-            'default_weight' => '0',
-            'default_order' => 'ASC',
-          ),
-          'first_name' => array(
-            'name' => 'first_name',
-            'title' => ts('First Name'),
-          ),
-          'gender_id' => array(
-            'name' => 'gender_id',
-            'title' => ts('Gender'),
-          ),
-          'birth_date' => array(
-            'name' => 'birth_date',
-            'title' => ts('Birth Date'),
-          ),
-          'contact_type' => array(
-            'title' => ts('Contact Type'),
-          ),
-          'contact_sub_type' => array(
-            'title' => ts('Contact Subtype'),
-          ),
-        ),
 
-      ),
+    $this->_columns = array_merge($this->getColumns('Contact', array(
+      'order_bys_defaults' => array('sort_name' => 'ASC '),
+      'fields_defaults' => array('sort_name'),
+      'fields_excluded' => array('id'),
+      'fields_required' => array('id'),
+      'filters_defaults' => array('is_deleted' => FALSE),
+      'no_field_disambiguation' => TRUE,
+    )), array(
       'civicrm_email' => array(
         'dao' => 'CRM_Core_DAO_Email',
         'fields' => array(
@@ -358,7 +308,7 @@ class CRM_Report_Form_Contribute_Detail extends CRM_Report_Form {
           ),
         ),
       ),
-    ) + $this->addAddressFields(FALSE);
+    )) + $this->addAddressFields(FALSE);
     // The tests test for this variation of the sort_name field. Don't argue with the tests :-).
     $this->_columns['civicrm_contact']['fields']['sort_name']['title'] = ts('Donor Name');
     $this->_groupFilter = TRUE;

--- a/CRM/Report/Form/Contribute/HouseholdSummary.php
+++ b/CRM/Report/Form/Contribute/HouseholdSummary.php
@@ -43,8 +43,7 @@ class CRM_Report_Form_Contribute_HouseholdSummary extends CRM_Report_Form {
   protected $_summary = NULL;
 
   /**
-   */
-  /**
+   * Class constructor.
    */
   public function __construct() {
     self::validRelationships();
@@ -77,7 +76,13 @@ class CRM_Report_Form_Contribute_HouseholdSummary extends CRM_Report_Form {
           ),
         ),
         'filters' => array(
-          'household_name' => array('title' => ts('Household Name')),
+          'household_name' => array(
+            'title' => ts('Household Name'),
+          ),
+          'is_deleted' => array(
+            'default' => 0,
+            'type' => CRM_Utils_Type::T_BOOLEAN,
+          ),
         ),
         'grouping' => 'household-fields',
       ),

--- a/CRM/Report/Form/Contribute/OrganizationSummary.php
+++ b/CRM/Report/Form/Contribute/OrganizationSummary.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2017
- * $Id$
- *
  */
 class CRM_Report_Form_Contribute_OrganizationSummary extends CRM_Report_Form {
 
@@ -55,8 +53,7 @@ class CRM_Report_Form_Contribute_OrganizationSummary extends CRM_Report_Form {
   protected $otherContact;
 
   /**
-   */
-  /**
+   * Class constructor.
    */
   public function __construct() {
     self::validRelationships();
@@ -89,7 +86,13 @@ class CRM_Report_Form_Contribute_OrganizationSummary extends CRM_Report_Form {
           ),
         ),
         'filters' => array(
-          'organization_name' => array('title' => ts('Organization Name')),
+          'organization_name' => array(
+            'title' => ts('Organization Name'),
+          ),
+          'is_deleted' => array(
+            'default' => 0,
+            'type' => CRM_Utils_Type::T_BOOLEAN,
+          ),
         ),
         'grouping' => 'organization-fields',
       ),


### PR DESCRIPTION
Overview
----------------------------------------
Port extended reports approach to metadata for fields alternative to #11244. Note that the ticket suggested is_deleted filtering should be added - this does it but it can be unset. Filtering by is_deleted probably DOES make sense, but not by is_deceased

Before
----------------------------------------
Contribution detail report not filtered by is deleted or is_deceased

After
----------------------------------------
Contribution detail report not filtered by is deceased but is filtered by deleted - but that can be altered in the report by the user. Extended reports metadata method exists

Technical Details
----------------------------------------
@colemanw this is what the extended reports approach looks like - obviously it seems quite long but the idea is that on the individual reports you don't define all the fields - although you can define special treatment of them  - in this case overriding the default order by (display-name - although perhaps sort_name makes more sense), the default fields (to be the same as the existing report), to specify not to display id & to require it & to specify a filter. 

The no_field_disambiguation I added - normally a common error in reports is ambiguity between 2 reports fields - ie. 'status_id' on case and on activity or something. This causes a tonne of issues so normally I append a string to disambiguate, but it would change the saved field names, so erring on the side of existing behaviour.

Note this code is the basis for the reports allowing details about 2 contacts in one report - because of the 'prefix' stuff

```
($this->getColumns('Contact', array(
      'order_bys_defaults' => array('sort_name ASC'),
      'fields_defaults' => array('sort_name'),
      'fields_excluded' => array('id'),
      'fields_required' => array('id'),
      'filters_defaults' => array('is_deleted' => FALSE),
      'no_field_disambiguation' => TRUE,
    )

```
---

 * [CRM-20545: contact report lists contacts that have been 'soft' deleted \(placed in Trash\)](https://issues.civicrm.org/jira/browse/CRM-20545)