### PR TITLE
CRM-21433: Optimize dupe checking in Recent Items stack

### DIFF
--- a/CRM/Utils/Recent.php
+++ b/CRM/Utils/Recent.php
@@ -116,7 +116,7 @@ class CRM_Utils_Recent {
 
     // make sure item is not already present in list
     for ($i = 0; $i < count(self::$_recent); $i++) {
-      if (self::$_recent[$i]['url'] == $url) {
+      if (self::$_recent[$i]['type'] === $type && self::$_recent[$i]['id'] === $id) {
         // delete item from array
         array_splice(self::$_recent, $i, 1);
         break;


### PR DESCRIPTION
Don't check for dupes by url beacause query params my change their order. Instead use type and id.

---

 * [CRM-21433: Optimize dupe checking in Recent Items stack](https://issues.civicrm.org/jira/browse/CRM-21433)