### PR TITLE
CRM-21436 - Fix fatal error on pay later

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -328,13 +328,11 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
         }
       }
 
-      if ($isMonetary &&
-        ($isPayLater || !empty($this->_values['payment_processor']))
-      ) {
-        $this->_paymentProcessorIDs = explode(
+      if ($isMonetary) {
+        $this->_paymentProcessorIDs = array_filter(explode(
           CRM_Core_DAO::VALUE_SEPARATOR,
           CRM_Utils_Array::value('payment_processor', $this->_values)
-        );
+        ));
 
         $this->assignPaymentProcessor($isPayLater);
       }
@@ -567,20 +565,20 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
     }
 
     //fix for CRM-3767
-    $assignCCInfo = FALSE;
+    $isMonetary = FALSE;
     if ($this->_amount > 0.0) {
-      $assignCCInfo = TRUE;
+      $isMonetary = TRUE;
     }
     elseif (!empty($this->_params['selectMembership'])) {
       $memFee = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipType', $this->_params['selectMembership'], 'minimum_fee');
       if ($memFee > 0.0) {
-        $assignCCInfo = TRUE;
+        $isMonetary = TRUE;
       }
     }
 
     // The concept of contributeMode is deprecated.
     // The payment processor object can provide info about the fields it shows.
-    if ($assignCCInfo && $this->_paymentProcessor) {
+    if ($isMonetary) {
       /** @var  $paymentProcessorObject \CRM_Core_Payment */
       $paymentProcessorObject = $this->_paymentProcessor['object'];
       $paymentFields = $paymentProcessorObject->getPaymentFormFields();

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -329,7 +329,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       }
 
       if ($isMonetary &&
-        (!$isPayLater || !empty($this->_values['payment_processor']))
+        ($isPayLater || !empty($this->_values['payment_processor']))
       ) {
         $this->_paymentProcessorIDs = explode(
           CRM_Core_DAO::VALUE_SEPARATOR,
@@ -580,7 +580,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
 
     // The concept of contributeMode is deprecated.
     // The payment processor object can provide info about the fields it shows.
-    if ($assignCCInfo) {
+    if ($assignCCInfo && $this->_paymentProcessor) {
       /** @var  $paymentProcessorObject \CRM_Core_Payment */
       $paymentProcessorObject = $this->_paymentProcessor['object'];
       $paymentFields = $paymentProcessorObject->getPaymentFormFields();


### PR DESCRIPTION
Overview
----------------------------------------
This PR fixes fatal error on pay later contribution page regressed from previous versions.

Before
----------------------------------------
Errors with the message
> Fatal error: Call to a member function getPaymentFormFields() on null in /Users/jitendra/src/civicrm/CRM/Contribute/Form/ContributionBase.php on line 589

After
----------------------------------------
works fine

Technical Details
----------------------------------------
This change adds pay later processor to `$this->_paymentProcessors` object. [Git blame](https://github.com/civicrm/civicrm-core/blame/master/CRM/Contribute/Form/ContributionBase.php#L332) of this line shows it has not been changed from a very long time. So, it was never assigned, but it came to our notice after [changes made in CRM-21134.
](https://github.com/civicrm/civicrm-core/commit/9f7f8a503cf2a8985ce6d0e96a3e25ed922758f8#diff-2b6ae932269516c2f04429d8866ccec7R583)

Comments
----------------------------------------
Can this be considered for 4.7.2-rc merge?

---

 * [CRM-21436: Fatal error on contribution page with only pay later enabled.](https://issues.civicrm.org/jira/browse/CRM-21436)

---

 * [CRM-21134: e-notice errors when using a processor extension](https://issues.civicrm.org/jira/browse/CRM-21134)