### PR TITLE
CRM-21195: Improve menu items markup to make changes easier

### DIFF
--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -530,7 +530,7 @@ FROM civicrm_navigation WHERE domain_id = $domainID {$whereClause} ORDER BY pare
     $menuMarkup = sprintf('<span class="menu-label">%s</span>', $name);
 
     if (!empty($value['attributes']['icon'])) {
-      $menuIconMarkup = sprintf('<span class="menu-icon %s"></span>', $value['attributes']['icon']);
+      $menuIconMarkup = sprintf('<span class="menu-icon %s" aria-hidden="true"></span>', $value['attributes']['icon']);
       $menuMarkup = $menuIconMarkup . $menuMarkup;
     }
 

--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -527,22 +527,24 @@ FROM civicrm_navigation WHERE domain_id = $domainID {$whereClause} ORDER BY pare
       }
     }
 
+    $menuMarkup = sprintf('<span class="menumain-label">%s</span>', $name);
+
     if (!empty($value['attributes']['icon'])) {
-      $menuIcon = sprintf('<i class="%s"></i>', $value['attributes']['icon']);
-      $name = $menuIcon . $name;
+      $menuIconMarkup = sprintf('<span class="menumain-icon %s"></span>', $value['attributes']['icon']);
+      $menuMarkup = $menuIconMarkup . $menuMarkup;
     }
 
     if ($makeLink) {
       $url = CRM_Utils_System::evalUrl($url);
       if ($target) {
-        $name = "<a href=\"{$url}\" target=\"{$target}\">{$name}</a>";
+        $menuMarkup = "<a href=\"{$url}\" target=\"{$target}\">{$menuMarkup}</a>";
       }
       else {
-        $name = "<a href=\"{$url}\">{$name}</a>";
+        $menuMarkup = "<a href=\"{$url}\">{$menuMarkup}</a>";
       }
     }
 
-    return $name;
+    return $menuMarkup;
   }
 
   /**

--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -527,10 +527,10 @@ FROM civicrm_navigation WHERE domain_id = $domainID {$whereClause} ORDER BY pare
       }
     }
 
-    $menuMarkup = sprintf('<span class="menu-label">%s</span>', $name);
+    $menuMarkup = sprintf('<i class="menu-label">%s</i>', $name);
 
     if (!empty($value['attributes']['icon'])) {
-      $menuIconMarkup = sprintf('<span class="menu-icon %s" aria-hidden="true"></span>', $value['attributes']['icon']);
+      $menuIconMarkup = sprintf('<i class="menu-icon %s" aria-hidden="true"></i>', $value['attributes']['icon']);
       $menuMarkup = $menuIconMarkup . $menuMarkup;
     }
 

--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -527,10 +527,10 @@ FROM civicrm_navigation WHERE domain_id = $domainID {$whereClause} ORDER BY pare
       }
     }
 
-    $menuMarkup = sprintf('<span class="menumain-label">%s</span>', $name);
+    $menuMarkup = sprintf('<span class="menu-label">%s</span>', $name);
 
     if (!empty($value['attributes']['icon'])) {
-      $menuIconMarkup = sprintf('<span class="menumain-icon %s"></span>', $value['attributes']['icon']);
+      $menuIconMarkup = sprintf('<span class="menu-icon %s"></span>', $value['attributes']['icon']);
       $menuMarkup = $menuIconMarkup . $menuMarkup;
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Changing the menu items markup to make it easier to do modifications

Before
----------------------------------------
The menu item markup was look as following : 

```php
<li class="menumain">
<i class="crm-i fa-search"></i> Search
</li>
```

& 

```php
<div class="menu-item">
<a href="/civicrm/contact/search?reset=1">
<i class="crm-i fa-search"></i>Find Contacts
</a>
</div>
```
After
----------------------------------------
Now it look like : 

```php
<li class="menumain">
<i class="menu-icon crm-i fa-search"></i>
<i class="menu-label">Search</i>
Search
</li>
```

& 

```php
<div class="menu-item">
<a href="/civicrm/contact/search?reset=1">
<i class="menu-icon crm-i fa-search"></i >
<i class="menu-label">Find Contacts</i>
</a>
</div>
```

---

 * [CRM-21195: Adding the ability to add icons to menu items](https://issues.civicrm.org/jira/browse/CRM-21195)