### PR TITLE
CRM-21424 Set receipt date when downloading pdf receipt

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4721,7 +4721,6 @@ WHERE eft.financial_trxn_id IN ({$trxnId}, {$baseTrxnId['financialTrxnId']})
     }
     $values['contribution_status'] = CRM_Core_PseudoConstant::getLabel('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $contribution->contribution_status_id);
     $return = $contribution->composeMessageArray($input, $ids, $values, $returnMessageText);
-    // Contribution ID should really always be set. But ?
     if ((!isset($input['receipt_update']) || $input['receipt_update']) && empty($contribution->receipt_date)) {
       civicrm_api3('Contribution', 'create', array('receipt_date' => 'now', 'id' => $contribution->id));
     }

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4722,7 +4722,7 @@ WHERE eft.financial_trxn_id IN ({$trxnId}, {$baseTrxnId['financialTrxnId']})
     $values['contribution_status'] = CRM_Core_PseudoConstant::getLabel('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $contribution->contribution_status_id);
     $return = $contribution->composeMessageArray($input, $ids, $values, $returnMessageText);
     // Contribution ID should really always be set. But ?
-    if (!$returnMessageText && (!isset($input['receipt_update']) || $input['receipt_update']) && empty($contribution->receipt_date)) {
+    if ((!isset($input['receipt_update']) || $input['receipt_update']) && empty($contribution->receipt_date)) {
       civicrm_api3('Contribution', 'create', array('receipt_date' => 'now', 'id' => $contribution->id));
     }
     return $return;


### PR DESCRIPTION
Overview
----------------------------------------
Set receipt date when downloading pdf receipt.

Before
----------------------------------------
Does not set de receipt date when downloading a receipt pdf.

After
----------------------------------------
Does set the receipt date when downloading the receipt pdf.

Technical Details
----------------------------------------
https://issues.civicrm.org/jira/browse/CRM-21424 contains an example to reproduce

Comments
----------------------------------------
issue was introduced with the fix for CRM-18166.

---

 * [CRM-18166: Complete transaction action not updating receipt_date when sent](https://issues.civicrm.org/jira/browse/CRM-18166)