### PR TITLE
CRM-21445 Fix divide by zero with contribution page discount

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -5687,15 +5687,17 @@ LIMIT 1;";
    * Create tax entry in civicrm_entity_financial_trxn table.
    *
    * @param array $entityParams
-   *
    * @param array $eftParams
    *
    */
   public static function createProportionalEntry($entityParams, $eftParams) {
-    $paid = $entityParams['line_item_amount'] * ($entityParams['trxn_total_amount'] / $entityParams['contribution_total_amount']);
-    // Record Entity Financial Trxn; CRM-20145
-    $eftParams['amount'] = CRM_Contribute_BAO_Contribution_Utils::formatAmount($paid);
-    civicrm_api3('EntityFinancialTrxn', 'create', $eftParams);
+    $contributionTotalAmount = (float) $entityParams['contribution_total_amount'];
+    if (!empty($contributionTotalAmount)) {
+      $paid = $entityParams['line_item_amount'] * ($entityParams['trxn_total_amount'] / $entityParams['contribution_total_amount']);
+      // Record Entity Financial Trxn; CRM-20145
+      $eftParams['amount'] = CRM_Contribute_BAO_Contribution_Utils::formatAmount($paid);
+      civicrm_api3('EntityFinancialTrxn', 'create', $eftParams);
+    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
When you apply a 100% discount you cannot submit the contribution page:
Fix divide by zero when amount is 0.

---

 * [CRM-21446](https://issues.civicrm.org/jira/browse/CRM-21446)

---

 * [CRM-21436: Fatal error on contribution page with only pay later enabled.](https://issues.civicrm.org/jira/browse/CRM-21436)

---

 * [CRM-21445: Contribution page issues with 100% discount](https://issues.civicrm.org/jira/browse/CRM-21445)