### PR TITLE
CRM-21447: Relationship Report: move variable handling to beginPostProcessCommon

### DIFF
--- a/CRM/Report/Form/Contact/Relationship.php
+++ b/CRM/Report/Form/Contact/Relationship.php
@@ -646,9 +646,7 @@ class CRM_Report_Form_Contact_Relationship extends CRM_Report_Form {
     $this->_groupBy = CRM_Contact_BAO_Query::getGroupByFromSelectColumns($this->_selectClauses, $groupBy);
   }
 
-  public function postProcess() {
-    $this->beginPostProcess();
-
+  public function beginPostProcessCommon() {
     $originalRelationshipTypeIdValue = CRM_Utils_Array::value('relationship_type_id_value', $this->_params);
     if ($originalRelationshipTypeIdValue) {
       $relationshipTypes = array();
@@ -663,11 +661,16 @@ class CRM_Report_Form_Contact_Relationship extends CRM_Report_Form {
       $this->relationType = $direction[0];
       $this->_params['relationship_type_id_value'] = $relationshipTypes;
     }
+  }
+
+  public function postProcess() {
+    $this->beginPostProcess();
 
     $this->buildACLClause(array(
       $this->_aliases['civicrm_contact'],
       $this->_aliases['civicrm_contact_b'],
     ));
+
     $sql = $this->buildQuery();
     $this->buildRows($sql, $rows);
 


### PR DESCRIPTION
Overview
----------------------------------------

For 99.99% of users, this should not have an impact. However, for people accessing the report from the APIv3, this fixes using a report instance where the report filters on a `relationship_type_id`. It also fixes a bug when exporting report data with the [Export to Excel extension](https://github.com/mlutfy/ca.bidon.civiexportexcel/).

Before
----------------------------------------

fatal error   `Unknown column '11_b_a' in 'where clause'`

After
----------------------------------------

no fatal error 🌈 

Technical Details
----------------------------------------

I moved a hack from the `postProcess()` to `beginCommonPostProcess()`.

Comments
----------------------------------------

You can test from the API Explorer:

* Create a report instance of `contact/relationship` that has a filter on "relationship Type" = "<any relationship>"
* Take note of the `instance_id`
* Go to the API Explorer (`civicrm/api/explorer`), and run: `ReportTemplate.getrows` with variable: `instance_id=1234`  (where 1234 is your `instance_id` noted above).
