### PR TITLE
CRM-21448 Add a link to contact from contribution

### DIFF
--- a/templates/CRM/Contribute/Form/ContributionView.tpl
+++ b/templates/CRM/Contribute/Form/ContributionView.tpl
@@ -70,7 +70,7 @@
 <table class="crm-info-panel">
   <tr>
     <td class="label">{ts}From{/ts}</td>
-    <td class="bold">{$displayName}</td>
+    <td class="bold"><a href="{crmURL p='civicrm/contact/view' q="cid=$contact_id"}">{$displayName}</a></td>
   </tr>
   <tr>
     <td class="label">{ts}Financial Type{/ts}</td>


### PR DESCRIPTION
Before
----------------------------------------
No linked name in contribution record

After
----------------------------------------
See link in display name

![image](https://user-images.githubusercontent.com/4406809/32965960-468ac22a-cba6-11e7-8f57-a88fe9e532be.png)


---

 * [CRM-21448: Need a link from contribution record when there is no cid in the url](https://issues.civicrm.org/jira/browse/CRM-21448)