### PR TITLE
CRM-21449 - add location field to activity report.

### DIFF
--- a/CRM/Report/Form/Activity.php
+++ b/CRM/Report/Form/Activity.php
@@ -253,6 +253,10 @@ class CRM_Report_Form_Activity extends CRM_Report_Form {
             'title' => ts('Duration'),
             'type' => CRM_Utils_Type::T_INT,
           ),
+          'location' => array(
+            'title' => ts('Location'),
+            'type' => CRM_Utils_Type::T_STRING,
+          ),
           'details' => array(
             'title' => ts('Activity Details'),
           ),
@@ -278,6 +282,10 @@ class CRM_Report_Form_Activity extends CRM_Report_Form {
             'type' => CRM_Utils_Type::T_STRING,
             'operatorType' => CRM_Report_Form::OP_MULTISELECT,
             'options' => CRM_Core_PseudoConstant::activityStatus(),
+          ),
+          'location' => array(
+            'title' => ts('Location'),
+            'type' => CRM_Utils_Type::T_TEXT,
           ),
           'details' => array(
             'title' => ts('Activity Details'),


### PR DESCRIPTION
Overview
----------------------------------------
Add a new field - activity location - to the activity report.

Before
----------------------------------------
You could not search by location or display location in the report results.

After
----------------------------------------
You can now search by location and choose to include the location field in the results.

---

 * [CRM-21449: Add location field to Activity Report](https://issues.civicrm.org/jira/browse/CRM-21449)