### PR TITLE
CRM-19151: Add the ability to merge memberships without data loss

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -322,6 +322,7 @@ class CRM_Dedupe_Merger {
         // Empty array == do nothing - this table is handled by mergeGroupContact
         'civicrm_subscription_history' => array(),
         'civicrm_relationship' => array('CRM_Contact_BAO_Relationship' => 'mergeRelationships'),
+        'civicrm_membership' => array('CRM_Member_BAO_Membership' => 'mergeMemberships'),
       );
     }
     return $tables;

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -518,7 +518,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
       // Call custom processing function for objects that require it
       if (isset($cpTables[$table])) {
         foreach ($cpTables[$table] as $className => $fnName) {
-          $className::$fnName($mainId, $otherId, $sqls);
+          $className::$fnName($mainId, $otherId, $sqls, $tables, $tableOperations);
         }
         // Skip normal processing
         continue;


### PR DESCRIPTION
Overview
----------------------------------------
Adds the ability to merge memberships without losing data.

With the current code, if you merge the two contact (without checking the “add new” checkbox), you will loose some information on the final membership: `join_date`, `start_date` and `end_date` will be overridden and the contributions from the final contact won’t be associated to the final membership.

Related issue: https://issues.civicrm.org/jira/browse/CRM-19151

Before
----------------------------------------
Currently CiviCRM can’t merge memberships and can result in data loss (contributions).

After
----------------------------------------
Really merge memberships by moving related contributions to the final membership and move memberships data to the new one (if relevant).

General idea is to merge memberships in regards to their type. We move the other contact’s contributions to the main contact’s membership which has the same type (if any) and then we update membership to avoid loosing `join_date`, `end_date`, etc.

Technical Details
----------------------------------------
Add a new custom processing function `mergeMemberships()` in `CRM_Member_BAO_Membership` that allows to merge memberships.

Links
----------------------------------------

This patch solve [CRM-19151](https://issues.civicrm.org/jira/browse/CRM-19151). This issue was also discussed on StackExchange:
- [Merging memberships issue](https://civicrm.stackexchange.com/questions/15156/merging-memberships-issue/)
- [How can I merge two memberships in the same contact (without losing contribution info, etc)?](https://civicrm.stackexchange.com/questions/799/how-can-i-merge-two-memberships-in-the-same-contact-without-losing-contribution)