### PR TITLE
CRM-19273 extract code to get financial items and filter those already cancelled.

### DIFF
--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -37,7 +37,6 @@
  *
  * @package CRM
  * @author Marshal Newrock <marshal@idealso.com>
- * $Id$
  */
 
 /**
@@ -823,8 +822,6 @@ WHERE li.contribution_id = %1";
 
     $financialItemResult = $this->getNonCancelledFinancialItems($entityID, $entityTable);
 
-    $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
-    $taxTerm = CRM_Utils_Array::value('tax_term', $invoiceSettings);
     foreach ($financialItemResult as $updateFinancialItemInfoValues) {
       $updateFinancialItemInfoValues['transaction_date'] = date('YmdHis');
       // the below params are not needed
@@ -839,7 +836,7 @@ WHERE li.contribution_id = %1";
         $updateFinancialItemInfoValues['financialTrxn'] = $this->getRelatedCancelFinancialTrxn($previousFinancialItemID);
         if ($previousLineItems[$updateFinancialItemInfoValues['entity_id']]['tax_amount']) {
           $updateFinancialItemInfoValues['tax']['amount'] = -($previousLineItems[$updateFinancialItemInfoValues['entity_id']]['tax_amount']);
-          $updateFinancialItemInfoValues['tax']['description'] = $taxTerm;
+          $updateFinancialItemInfoValues['tax']['description'] = $this->getSalesTaxTerm();
           if ($updateFinancialItemInfoValues['financial_type_id']) {
             $updateFinancialItemInfoValues['tax']['financial_account_id'] = CRM_Contribute_BAO_Contribution::getFinancialAccountId($updateFinancialItemInfoValues['financial_type_id']);
           }
@@ -855,7 +852,7 @@ WHERE li.contribution_id = %1";
           isset($lineItemsToUpdate[$updateFinancialItemInfoValues['price_field_value_id']]['tax_amount'])
         ) {
           $updateFinancialItemInfoValues['tax']['amount'] = $lineItemsToUpdate[$updateFinancialItemInfoValues['price_field_value_id']]['tax_amount'];
-          $updateFinancialItemInfoValues['tax']['description'] = $taxTerm;
+          $updateFinancialItemInfoValues['tax']['description'] = $this->getSalesTaxTerm();
           if ($lineItemsToUpdate[$updateFinancialItemInfoValues['price_field_value_id']]['financial_type_id']) {
             $updateFinancialItemInfoValues['tax']['financial_account_id'] = CRM_Contribute_BAO_Contribution::getFinancialAccountId($lineItemsToUpdate[$updateFinancialItemInfoValues['price_field_value_id']]['financial_type_id']);
           }
@@ -1248,6 +1245,15 @@ WHERE li.contribution_id = %1";
 
     }
     return $financialItemResult;
+  }
+
+  /**
+   * Get the string used to describe the sales tax (eg. VAT, GST).
+   *
+   * @return string
+   */
+  protected function getSalesTaxTerm() {
+    return CRM_Contribute_BAO_Contribution::checkContributeSettings('tax_term');
   }
 
 }

--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -755,10 +755,7 @@ WHERE li.contribution_id = %1";
       }
     }
 
-    $trxnId = array();
-    if (!empty($trxn->id)) {
-      $trxnId['id'] = $trxn->id;
-    }
+    $trxnId = !empty($trxn->id) ? array('id' => $trxn->id) : array();
     $lineItemObj->addFinancialItemsOnLineItemsChange($requiredChanges['line_items_to_add'], $entityID, $entityTable, $contributionId, $trxnId);
 
     // update participant fee_amount column


### PR DESCRIPTION
Overview
----------------------------------------
This is the first of the broken-out changes in https://github.com/civicrm/civicrm-core/pull/10962 that results in
an actual functionality change. The code that retrieves the relevant financial items is separated into
it's own function. But then a php loop iterates through and eliminates any items that have
already been reversed. This is a scenario identified in the unit tests on 10962 and occurs when
the the option value has is changed and then changed again - the items from the first change
should not be re-changed.

Before
----------------------------------------
When an item is changed to a value & changed again the financial item for the reversal will be identified both times

After
----------------------------------------
Already reversed items are filtered out.

Technical Details
----------------------------------------
This is a stand-alone part of #10962 and due to the complexity of that PR I have been breaking out small chunks for review. However, the test that demonstrates this can only be run once all parts of that PR are merged, and I don't think this chunk can be UI tested since there are a range of other bugs going on in the overall code until it is all merged. The loop through $financialItemResult  looks at each row to check if it was already reversed

---

 * [CRM-19273: Changes to Event Selections on Pending \(Pay Later\) Contribution Not Creating Correct Financial Items Causing Imbalance in Accounting Batch Export](https://issues.civicrm.org/jira/browse/CRM-19273)