### PR TITLE
CRM-21456 : Relationship end date not set when creating resolved cases

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -92,6 +92,11 @@ class CRM_Case_BAO_Case extends CRM_Case_DAO_Case {
     // CRM-20958 - These fields are managed by MySQL triggers. Watch out for clients resaving stale timestamps.
     unset($params['created_date']);
     unset($params['modified_date']);
+    $caseStatus = CRM_Case_PseudoConstant::caseStatus('name');
+    // for resolved case the end date should set to now
+    if (!empty($params['status_id']) && $params['status_id'] == array_search('Closed', $caseStatus)) {
+      $params['end_date'] = date("Ymd");
+    }
 
     $transaction = new CRM_Core_Transaction();
 

--- a/CRM/Case/Form/Activity/OpenCase.php
+++ b/CRM/Case/Form/Activity/OpenCase.php
@@ -230,11 +230,6 @@ class CRM_Case_Form_Activity_OpenCase {
 
     // for open case start date should be set to current date
     $params['start_date'] = CRM_Utils_Date::processDate($params['start_date'], $params['start_date_time']);
-    $caseStatus = CRM_Case_PseudoConstant::caseStatus('name');
-    // for resolved case the end date should set to now
-    if ($params['status_id'] == array_search('Closed', $caseStatus)) {
-      $params['end_date'] = $params['now'];
-    }
 
     // rename activity_location param to the correct column name for activity DAO
     $params['location'] = CRM_Utils_Array::value('activity_location', $params);
@@ -329,6 +324,7 @@ class CRM_Case_Form_Activity_OpenCase {
       'duration' => CRM_Utils_Array::value('duration', $params),
       'medium_id' => $params['medium_id'],
       'details' => $params['activity_details'],
+      'relationship_end_date' => CRM_Utils_Array::value('end_date', $params),
     );
 
     if (array_key_exists('custom', $params) && is_array($params['custom'])) {

--- a/CRM/Case/XMLProcessor/Process.php
+++ b/CRM/Case/XMLProcessor/Process.php
@@ -237,6 +237,7 @@ class CRM_Case_XMLProcessor_Process extends CRM_Case_XMLProcessor {
         'is_active' => 1,
         'case_id' => $params['caseID'],
         'start_date' => date("Ymd"),
+        'end_date' => CRM_Utils_Array::value('relationship_end_date', $params),
       );
 
       if (!$this->createRelationship($relationshipParams)) {

--- a/api/v3/Case.php
+++ b/api/v3/Case.php
@@ -170,6 +170,7 @@ function _civicrm_api3_case_create_xmlProcessor($params, $caseBAO) {
     'medium_id' => CRM_Utils_Array::value('medium_id', $params),
     'details' => CRM_Utils_Array::value('details', $params),
     'custom' => array(),
+    'relationship_end_date' => CRM_Utils_Array::value('end_date', $params),
   );
 
   // Do it! :-D

--- a/tests/phpunit/api/v3/CaseTest.php
+++ b/tests/phpunit/api/v3/CaseTest.php
@@ -159,6 +159,35 @@ class api_v3_CaseTest extends CiviCaseTestCase {
   }
 
   /**
+   * Test create function with resolved status.
+   */
+  public function testCaseCreateWithResolvedStatus() {
+    $params = $this->_params;
+    // Test using label instead of value.
+    unset($params['case_type_id']);
+    $params['case_type'] = $this->caseType;
+    $params['status_id'] = 'Closed';
+    $result = $this->callAPISuccess('case', 'create', $params);
+    $id = $result['id'];
+
+    // Check result
+    $result = $this->callAPISuccess('case', 'get', array('id' => $id));
+    $this->assertEquals($result['values'][$id]['id'], $id);
+    $this->assertEquals($result['values'][$id]['case_type_id'], $this->caseTypeId);
+    $this->assertEquals($result['values'][$id]['subject'], $params['subject']);
+    $this->assertEquals($result['values'][$id]['end_date'], date('Y-m-d'));
+
+    //Check all relationship end dates are set to case end date.
+    $relationships = $this->callAPISuccess('Relationship', 'get', array(
+      'sequential' => 1,
+      'case_id' => $id,
+    ));
+    foreach ($relationships['values'] as $key => $values) {
+      $this->assertEquals($values['end_date'], date('Y-m-d'));
+    }
+  }
+
+  /**
    * Test case create with valid parameters and custom data.
    */
   public function testCaseCreateCustom() {


### PR DESCRIPTION
Overview
----------------------------------------
Set relationship end date while creating resolved cases.

Before
----------------------------------------
1. Relationship end date is not set when creating a new case with resolved status. 

2. When a Resolved case is created via api(through explorer or via webform). Case end date is not automatically stored. It is correctly set from the "New Case" form.

See more details in jira issue.

After
----------------------------------------
Both the above issues are fixed.

Technical Details
----------------------------------------
This PR migrates the case end date calculation from `Form` to `BAO` layer, so that it is executed from API too.

Comments
----------------------------------------
Added unit test

---

 * [CRM-21456: Relationship end date not set when creating resolved cases.](https://issues.civicrm.org/jira/browse/CRM-21456)