### PR TITLE
CRM-21190 - Warning message on Thankyou page on pay later membership pr…

### DIFF
--- a/CRM/Contribute/Form/Contribution/ThankYou.php
+++ b/CRM/Contribute/Form/Contribution/ThankYou.php
@@ -54,6 +54,7 @@ class CRM_Contribute_Form_Contribution_ThankYou extends CRM_Contribute_Form_Cont
 
     $this->_params = $this->get('params');
     $this->_lineItem = $this->get('lineItem');
+    $this->_useForMember = $this->get('useForMember');
     $is_deductible = $this->get('is_deductible');
     $this->assign('is_deductible', $is_deductible);
     $this->assign('thankyou_title', CRM_Utils_Array::value('thankyou_title', $this->_values));

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -1084,7 +1084,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
    * @param bool $isContributionMainPage
    *   Is this the main page? If so add form input fields.
    *   (or better yet don't have this functionality in a function shared with forms that don't share it).
-   * @param int $selectedMembershipTypeID
+   * @param int|array $selectedMembershipTypeID
    *   Selected membership id.
    * @param bool $thankPage
    *   Thank you page.
@@ -1240,7 +1240,9 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
 
       // Assign autorenew option (0:hide,1:optional,2:required) so we can use it in confirmation etc.
       $autoRenewOption = CRM_Price_BAO_PriceSet::checkAutoRenewForPriceSet($this->_priceSetId);
-      if (isset($membershipTypeValues[$selectedMembershipTypeID]['auto_renew'])) {
+      //$selectedMembershipTypeID is retrieved as an array for membership priceset if multiple
+      //options for different organisation is selected on the contribution page.
+      if (is_numeric($selectedMembershipTypeID) && isset($membershipTypeValues[$selectedMembershipTypeID]['auto_renew'])) {
         $this->assign('autoRenewOption', $membershipTypeValues[$selectedMembershipTypeID]['auto_renew']);
       }
       else {


### PR DESCRIPTION
…iceset

Overview
----------------------------------------
Fix warning message on thankyou page.

Before
----------------------------------------
When a membership priceset is used on a pay later contribution page - the thankyou screen displays a warning message.
> Warning: Illegal offset type in CRM_Contribute_Form_ContributionBase->buildMembershipBlock() (line 1229 of /Users/jitendra/www/civi-master/sites/all/modules/civicrm/CRM/Contribute/Form/ContributionBase.php).

After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
`$selectedMembershipTypeID` is an array in case of a priceset due to which PHP errors on `$membershipTypeValues[$selectedMembershipTypeID]` call.

---

 * [CRM-21190: Warning error on Thankyou page on pay later membership priceset.](https://issues.civicrm.org/jira/browse/CRM-21190)
