### PR TITLE
CRM-21461: Case Dashlet enhancement

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -699,14 +699,8 @@ LEFT JOIN civicrm_option_group aog ON aog.name='activity_type'
       $casesList[$key]['case_status'] = in_array($case['case_status'], $caseStatus) ? sprintf('<strong>%s</strong>', strtoupper($case['case_status'])) : $case['case_status'];
       $casesList[$key]['case_type'] = $case['case_type'];
       $casesList[$key]['case_role'] = CRM_Utils_Array::value('case_role', $case, '---');
+      $casesList[$key]['manager'] = self::getCaseManagerContact($caseTypes[$case['case_type_id']], $case['case_id']);
 
-      $caseManagerContact = self::getCaseManagerContact($caseTypes[$case['case_type_id']], $case['case_id']);
-      if (!empty($caseManagerContact)) {
-        $casesList[$key]['manager'] = sprintf('<a href="%s">%s</a>',
-          CRM_Utils_System::url('civicrm/contact/view', array('cid' => CRM_Utils_Array::value('casemanager_id', $caseManagerContact))),
-          CRM_Utils_Array::value('casemanager', $caseManagerContact)
-        );
-      }
       $casesList[$key]['date'] = $case[$caseActivityTypeColumn];
       if (($actId = CRM_Utils_Array::value('case_scheduled_activity_id', $case)) ||
         ($actId = CRM_Utils_Array::value('case_recent_activity_id', $case))
@@ -1886,8 +1880,8 @@ SELECT case_status.label AS case_status, status_id, civicrm_case_type.title AS c
    * @param int $caseId
    *   Case id.
    *
-   * @return array
-   *   array of contact on success otherwise empty
+   * @return string
+   *   html hyperlink of manager contact view page
    *
    */
   public static function getCaseManagerContact($caseType, $caseId) {
@@ -1916,12 +1910,12 @@ SELECT civicrm_contact.id as casemanager_id,
 
       $dao = CRM_Core_DAO::executeQuery($managerRoleQuery, $managerRoleParams);
       if ($dao->fetch()) {
-        $caseManagerContact['casemanager_id'] = $dao->casemanager_id;
-        $caseManagerContact['casemanager'] = $dao->casemanager;
+        return sprintf('<a href="%s">%s</a>',
+          CRM_Utils_System::url('civicrm/contact/view', array('cid' => $dao->casemanager_id)),
+          $dao->casemanager
+        );
       }
     }
-
-    return $caseManagerContact;
   }
 
   /**

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -407,50 +407,63 @@ WHERE cc.contact_id = %1 AND civicrm_case_type.name = '{$caseType}'";
    *
    * @return string
    */
-  public static function getCaseActivityQuery($type = 'upcoming', $userID = NULL, $condition = NULL) {
-    if (!$userID) {
-      $session = CRM_Core_Session::singleton();
-      $userID = $session->get('userID');
-    }
+  public static function getCaseActivityCountQuery($type = 'upcoming', $userID, $condition = NULL) {
+    return sprintf(" SELECT COUNT(*) FROM (%s) temp ", self::getCaseActivityQuery($type, $userID, $condition));
+  }
 
-    $query = "SELECT
-civicrm_case.id as case_id,
-civicrm_case.subject as case_subject,
-civicrm_contact.id as contact_id,
-civicrm_contact.sort_name as sort_name,
-civicrm_phone.phone as phone,
-civicrm_contact.contact_type as contact_type,
-civicrm_contact.contact_sub_type as contact_sub_type,
-t_act.activity_type_id,
-c_type.title as case_type,
-civicrm_case.case_type_id as case_type_id,
-cov_status.label as case_status,
-cov_status.label as case_status_name,
-t_act.status_id,
-civicrm_case.start_date as case_start_date,
-case_relation_type.label_b_a as case_role, ";
+  /**
+   * @param string $type
+   * @param int $userID
+   * @param string $condition
+   * @param string $limit
+   *
+   * @return string
+   */
+  public static function getCaseActivityQuery($type = 'upcoming', $userID, $condition = NULL, $limit = NULL, $order = NULL) {
+    $selectClauses = array(
+      'civicrm_case.id as case_id',
+      'civicrm_case.subject as case_subject',
+      'civicrm_contact.id as contact_id',
+      'civicrm_contact.sort_name as sort_name',
+      'civicrm_phone.phone as phone',
+      'civicrm_contact.contact_type as contact_type',
+      'civicrm_contact.contact_sub_type as contact_sub_type',
+      't_act.activity_type_id',
+      'c_type.title as case_type',
+      'civicrm_case.case_type_id as case_type_id',
+      'cov_status.label as case_status',
+      'cov_status.label as case_status_name',
+      't_act.status_id',
+      'civicrm_case.start_date as case_start_date',
+      'case_relation_type.label_b_a as case_role',
+    );
 
     if ($type == 'upcoming') {
-      $query .= "
-t_act.desired_date as case_scheduled_activity_date,
-t_act.id as case_scheduled_activity_id,
-t_act.act_type_name as case_scheduled_activity_type_name,
-t_act.act_type AS case_scheduled_activity_type ";
+      $selectClauses = array_merge($selectClauses, array(
+        't_act.desired_date as case_scheduled_activity_date',
+        't_act.id as case_scheduled_activity_id',
+        't_act.act_type_name as case_scheduled_activity_type_name',
+        't_act.act_type AS case_scheduled_activity_type',
+      ));
     }
     elseif ($type == 'recent') {
-      $query .= "
-t_act.desired_date as case_recent_activity_date,
-t_act.id as case_recent_activity_id,
-t_act.act_type_name as case_recent_activity_type_name,
-t_act.act_type AS case_recent_activity_type ";
+      $selectClauses = array_merge($selectClauses, array(
+        't_act.desired_date as case_recent_activity_date',
+        't_act.id as case_recent_activity_id',
+        't_act.act_type_name as case_recent_activity_type_name',
+        't_act.act_type AS case_recent_activity_type',
+      ));
     }
     elseif ($type == 'any') {
-      $query .= "
-t_act.desired_date as case_activity_date,
-t_act.id as case_activity_id,
-t_act.act_type_name as case_activity_type_name,
-t_act.act_type AS case_activity_type ";
+      $selectClauses = array_merge($selectClauses, array(
+        't_act.desired_date as case_activity_date',
+        't_act.id as case_activity_id',
+        't_act.act_type_name as case_activity_type_name',
+        't_act.act_type AS case_activity_type',
+      ));
     }
+
+    $query = CRM_Contact_BAO_Query::appendAnyValueToSelect($selectClauses, 'case_id');
 
     $query .= " FROM civicrm_case
                   INNER JOIN civicrm_case_contact ON civicrm_case.id = civicrm_case_contact.case_id
@@ -535,17 +548,27 @@ LEFT JOIN civicrm_option_group aog ON aog.name='activity_type'
 
     if ($condition) {
       // CRM-8749 backwards compatibility - callers of this function expect to start $condition with "AND"
-      $query .= " WHERE (1) $condition ";
+      $query .= " WHERE (1) AND $condition ";
+    }
+    $query .= " GROUP BY case_id ";
+
+    if ($order) {
+      $query .= $order;
+    }
+    else {
+      if ($type == 'upcoming') {
+        $query .= " ORDER BY case_scheduled_activity_date ASC ";
+      }
+      elseif ($type == 'recent') {
+        $query .= " ORDER BY case_recent_activity_date ASC ";
+      }
+      elseif ($type == 'any') {
+        $query .= " ORDER BY case_activity_date ASC ";
+      }
     }
 
-    if ($type == 'upcoming') {
-      $query .= " ORDER BY case_scheduled_activity_date ASC ";
-    }
-    elseif ($type == 'recent') {
-      $query .= " ORDER BY case_recent_activity_date ASC ";
-    }
-    elseif ($type == 'any') {
-      $query .= " ORDER BY case_activity_date ASC ";
+    if ($limit) {
+      $query .= $limit;
     }
 
     return $query;
@@ -555,29 +578,37 @@ LEFT JOIN civicrm_option_group aog ON aog.name='activity_type'
    * Retrieve cases related to particular contact or whole contact used in Dashboard and Tab.
    *
    * @param bool $allCases
-   *
-   * @param int $userID
-   *
-   * @param string $type
-   *   /upcoming,recent,all/.
-   *
+   * @param array $params
    * @param string $context
+   * @param bool $getCount
    *
    * @return array
    *   Array of Cases
    */
-  public static function getCases($allCases = TRUE, $userID = NULL, $type = 'upcoming', $context = 'dashboard') {
+  public static function getCases($allCases = TRUE, $params = array(), $context = 'dashboard', $getCount = FALSE) {
     $condition = NULL;
     $casesList = array();
 
     //validate access for own cases.
     if (!self::accessCiviCase()) {
-      return $casesList;
+      return $getCount ? 0 : $casesList;
     }
 
-    if (!$userID) {
-      $session = CRM_Core_Session::singleton();
-      $userID = $session->get('userID');
+    $type = CRM_Utils_Array::value('type', $params, 'upcoming');
+    $userID = CRM_Core_Session::singleton()->get('userID');
+
+    $caseActivityTypeColumn = 'case_activity_type_name';
+    $caseActivityDateColumn = 'case_activity_date';
+    $caseActivityIDColumn = 'case_activity_id';
+    if ($type == 'upcoming') {
+      $caseActivityDateColumn = 'case_scheduled_activity_date';
+      $caseActivityTypeColumn = 'case_scheduled_activity_type';
+      $caseActivityIDColumn = 'case_scheduled_activity_id';
+    }
+    elseif ($type == 'recent') {
+      $caseActivityDateColumn = 'case_recent_activity_date';
+      $caseActivityTypeColumn = 'case_recent_activity_type';
+      $caseActivityIDColumn = 'case_recent_activity_id';
     }
 
     //validate access for all cases.
@@ -585,61 +616,49 @@ LEFT JOIN civicrm_option_group aog ON aog.name='activity_type'
       $allCases = FALSE;
     }
 
-    $condition = " AND civicrm_case.is_deleted = 0 AND civicrm_contact.is_deleted <> 1";
+    $whereClauses = array('civicrm_case.is_deleted = 0 AND civicrm_contact.is_deleted <> 1');
 
     if (!$allCases) {
-      $condition .= " AND case_relationship.contact_id_b = {$userID} ";
+      $whereClauses[] .= " case_relationship.contact_id_b = {$userID} ";
     }
-    if ($type == 'upcoming' || $type == 'any') {
-      $closedId = CRM_Core_PseudoConstant::getKey('CRM_Case_BAO_Case', 'case_status_id', 'Closed');
-      $condition .= "
-AND civicrm_case.status_id != $closedId";
+    if (empty($params['status_id']) && ($type == 'upcoming' || $type == 'any')) {
+      $whereClauses[] = " civicrm_case.status_id != " . CRM_Core_PseudoConstant::getKey('CRM_Case_BAO_Case', 'case_status_id', 'Closed');
     }
 
-    $query = self::getCaseActivityQuery($type, $userID, $condition);
+    foreach (array('case_type_id', 'status_id') as $column) {
+      if (!empty($params[$column])) {
+        $whereClauses[] = sprintf("civicrm_case.%s IN (%s)", $column, $params[$column]);
+      }
+    }
+    $condition = implode(' AND ', $whereClauses);
 
-    $queryParams = array();
-    $result = CRM_Core_DAO::executeQuery($query,
-      $queryParams
-    );
+    $totalCount = CRM_Core_DAO::singleValueQuery(self::getCaseActivityCountQuery($type, $userID, $condition));
+    if ($getCount) {
+      return $totalCount;
+    }
+    $casesList['total'] = $totalCount;
+
+    $limit = '';
+    if (!empty($params['rp'])) {
+      $params['offset'] = ($params['page'] - 1) * $params['rp'];
+      $params['rowCount'] = $params['rp'];
+      if (!empty($params['rowCount']) && $params['rowCount'] > 0) {
+        $limit = " LIMIT {$params['offset']}, {$params['rowCount']} ";
+      }
+    }
+
+    $order = NULL;
+    if (!empty($params['sortBy'])) {
+      if (strstr($params['sortBy'], 'date ')) {
+        $params['sortBy'] = str_replace('date', $caseActivityDateColumn, $params['sortBy']);
+      }
+      $order = "ORDER BY " . $params['sortBy'];
+    }
+
+    $query = self::getCaseActivityQuery($type, $userID, $condition, $limit, $order);
+    $result = CRM_Core_DAO::executeQuery($query);
 
     $caseStatus = CRM_Core_OptionGroup::values('case_status', FALSE, FALSE, FALSE, " AND v.name = 'Urgent' ");
-
-    $resultFields = array(
-      'contact_id',
-      'contact_type',
-      'sort_name',
-      'phone',
-      'case_id',
-      'case_subject',
-      'case_type',
-      'case_type_id',
-      'status_id',
-      'case_status',
-      'case_status_name',
-      'activity_type_id',
-      'case_start_date',
-      'case_role',
-    );
-
-    if ($type == 'upcoming') {
-      $resultFields[] = 'case_scheduled_activity_date';
-      $resultFields[] = 'case_scheduled_activity_type_name';
-      $resultFields[] = 'case_scheduled_activity_type';
-      $resultFields[] = 'case_scheduled_activity_id';
-    }
-    elseif ($type == 'recent') {
-      $resultFields[] = 'case_recent_activity_date';
-      $resultFields[] = 'case_recent_activity_type_name';
-      $resultFields[] = 'case_recent_activity_type';
-      $resultFields[] = 'case_recent_activity_id';
-    }
-    elseif ($type == 'any') {
-      $resultFields[] = 'case_activity_date';
-      $resultFields[] = 'case_activity_type_name';
-      $resultFields[] = 'case_activity_type';
-      $resultFields[] = 'case_activity_id';
-    }
 
     // we're going to use the usual actions, so doesn't make sense to duplicate definitions
     $actions = CRM_Case_Selector_Search::links();
@@ -656,55 +675,80 @@ AND civicrm_case.status_id != $closedId";
     }
     $mask = CRM_Core_Action::mask($permissions);
 
-    while ($result->fetch()) {
-      foreach ($resultFields as $donCare => $field) {
-        $casesList[$result->case_id][$field] = $result->$field;
-        if ($field == 'contact_type') {
-          $casesList[$result->case_id]['contact_type_icon'] = CRM_Contact_BAO_Contact_Utils::getImage($result->contact_sub_type ? $result->contact_sub_type : $result->contact_type
-          );
-          $casesList[$result->case_id]['action'] = CRM_Core_Action::formLink($actions['primaryActions'], $mask,
-            array(
-              'id' => $result->case_id,
-              'cid' => $result->contact_id,
-              'cxt' => $context,
-            ),
-            ts('more'),
-            FALSE,
-            'case.actions.primary',
-            'Case',
-            $result->case_id
-          );
-        }
-        elseif ($field == 'case_status') {
-          if (in_array($result->$field, $caseStatus)) {
-            $casesList[$result->case_id]['class'] = "status-urgent";
+    $caseTypes = CRM_Case_PseudoConstant::caseType('name');
+    foreach ($result->fetchAll() as $key => $case) {
+      $casesList[$key] = array();
+      $casesList[$key]['DT_RowId'] = $case['case_id'];
+      $casesList[$key]['DT_RowAttr'] = array('data-entity' => 'case', 'data-id' => $case['case_id']);
+      $casesList[$key]['DT_RowClass'] = "crm-entity";
+
+      $casesList[$key]['activity_list'] = sprintf('<a title="%s" class="crm-expand-row" href="%s"></a>',
+        ts('Activities'),
+        CRM_Utils_System::url('civicrm/case/details', array('caseid' => $case['case_id'], 'cid' => $case['contact_id'], 'type' => $type))
+      );
+
+      $phone = empty($case['phone']) ? '' : '<br /><span class="description">' . $case['phone'] . '</span>';
+      $casesList[$key]['contact_id'] = sprintf('<a href="%s">%s</a>%s<br /><span class="description">%s: %d</span>',
+        CRM_Utils_System::url('civicrm/contact/view', array('cid' => $case['contact_id'])),
+        $case['sort_name'],
+        $phone,
+        ts('Case ID'),
+        $case['case_id']
+      );
+      $casesList[$key]['subject'] = $case['case_subject'];
+      $casesList[$key]['case_status'] = in_array($case['case_status'], $caseStatus) ? sprintf('<strong>%s</strong>', strtoupper($case['case_status'])) : $case['case_status'];
+      $casesList[$key]['case_type'] = $case['case_type'];
+      $casesList[$key]['case_role'] = CRM_Utils_Array::value('case_role', $case, '---');
+
+      $caseManagerContact = self::getCaseManagerContact($caseTypes[$case['case_type_id']], $case['case_id']);
+      if (!empty($caseManagerContact)) {
+        $casesList[$key]['manager'] = sprintf('<a href="%s">%s</a>',
+          CRM_Utils_System::url('civicrm/contact/view', array('cid' => CRM_Utils_Array::value('casemanager_id', $caseManagerContact))),
+          CRM_Utils_Array::value('casemanager', $caseManagerContact)
+        );
+      }
+      $casesList[$key]['date'] = $case[$caseActivityTypeColumn];
+      if (($actId = CRM_Utils_Array::value('case_scheduled_activity_id', $case)) ||
+        ($actId = CRM_Utils_Array::value('case_recent_activity_id', $case))
+      ) {
+        if (self::checkPermission($actId, 'view', $case['activity_type_id'], $userID)) {
+          if ($type == 'recent') {
+            $casesList[$key]['date'] = sprintf('<a class="action-item crm-hover-button" href="%s" title="%s">%s</a>',
+              CRM_Utils_System::url('civicrm/case/activity/view', array('reset' => 1, 'cid' => $case['contact_id'], 'aid' => $case[$caseActivityIDColumn])),
+              ts('View activity'),
+              $case[$caseActivityTypeColumn]
+            );
           }
           else {
-            $casesList[$result->case_id]['class'] = "status-normal";
+            $status = CRM_Utils_Date::overdue($case[$caseActivityDateColumn]) ? 'status-overdue' : 'status-scheduled';
+            $casesList[$key]['date'] = sprintf('<a class="crm-popup %s" href="%s" title="%s">%s</a> &nbsp;&nbsp;',
+             $status,
+              CRM_Utils_System::url('civicrm/case/activity/view', array('reset' => 1, 'cid' => $case['contact_id'], 'aid' => $case[$caseActivityIDColumn])),
+              ts('View activity'),
+              $case[$caseActivityTypeColumn]
+            );
           }
         }
+        if (self::checkPermission($actId, 'edit', $case['activity_type_id'], $userID)) {
+          $casesList[$key]['date'] .= sprintf('<a class="action-item crm-hover-button" href="%s" title="%s"><i class="crm-i fa-pencil"></i></a>',
+            CRM_Utils_System::url('civicrm/case/activity', array('reset' => 1, 'cid' => $case['contact_id'], 'caseid' => $case['case_id'], 'action' => 'update')),
+            ts('Edit activity')
+          );
+        }
       }
-      //CRM-4510.
-      $caseTypes = CRM_Case_PseudoConstant::caseType('name');
-      $caseManagerContact = self::getCaseManagerContact($caseTypes[$result->case_type_id], $result->case_id);
-      if (!empty($caseManagerContact)) {
-        $casesList[$result->case_id]['casemanager_id'] = CRM_Utils_Array::value('casemanager_id', $caseManagerContact);
-        $casesList[$result->case_id]['casemanager'] = CRM_Utils_Array::value('casemanager', $caseManagerContact);
-      }
-
-      //do check user permissions for edit/view activity.
-      if (($actId = CRM_Utils_Array::value('case_scheduled_activity_id', $casesList[$result->case_id])) ||
-        ($actId = CRM_Utils_Array::value('case_recent_activity_id', $casesList[$result->case_id]))
-      ) {
-        $casesList[$result->case_id]["case_{$type}_activity_editable"] = self::checkPermission($actId,
-          'edit',
-          $casesList[$result->case_id]['activity_type_id'], $userID
-        );
-        $casesList[$result->case_id]["case_{$type}_activity_viewable"] = self::checkPermission($actId,
-          'view',
-          $casesList[$result->case_id]['activity_type_id'], $userID
-        );
-      }
+      $casesList[$key]['date'] .= "<br/>" . CRM_Utils_Date::customFormat($case[$caseActivityDateColumn]);
+      $casesList[$key]['links'] = CRM_Core_Action::formLink($actions['primaryActions'], $mask,
+        array(
+          'id' => $case['case_id'],
+          'cid' => $case['contact_id'],
+          'cxt' => $context,
+        ),
+        ts('more'),
+        FALSE,
+        'case.actions.primary',
+        'Case',
+        $case['case_id']
+      );
     }
 
     return $casesList;
@@ -714,16 +758,17 @@ AND civicrm_case.status_id != $closedId";
    * Get the summary of cases counts by type and status.
    *
    * @param bool $allCases
-   * @param int $userID
    * @return array
    */
-  public static function getCasesSummary($allCases = TRUE, $userID) {
+  public static function getCasesSummary($allCases = TRUE) {
     $caseSummary = array();
 
     //validate access for civicase.
     if (!self::accessCiviCase()) {
       return $caseSummary;
     }
+
+    $userID = CRM_Core_Session::singleton()->get('userID');
 
     //validate access for all cases.
     if ($allCases && !CRM_Core_Permission::check('access all cases and activities')) {
@@ -1545,8 +1590,7 @@ SELECT case_status.label AS case_status, status_id, civicrm_case_type.title AS c
     $caseID = implode(',', $cases['case_id']);
     $contactID = implode(',', $cases['contact_id']);
 
-    $condition = "
- AND civicrm_case_contact.contact_id IN( {$contactID} )
+    $condition = " civicrm_case_contact.contact_id IN( {$contactID} )
  AND civicrm_case.id IN( {$caseID})
  AND civicrm_case.is_deleted     = {$cases['case_deleted']}";
 
@@ -1980,8 +2024,7 @@ SELECT civicrm_contact.id as casemanager_id,
     $doFilterCases = FALSE;
     if (!CRM_Core_Permission::check('access all cases and activities')) {
       $doFilterCases = TRUE;
-      $session = CRM_Core_Session::singleton();
-      $filterCases = CRM_Case_BAO_Case::getCases(FALSE, $session->get('userID'));
+      $filterCases = CRM_Case_BAO_Case::getCases(FALSE);
     }
 
     //2. fetch the details of related cases.

--- a/CRM/Case/BAO/Query.php
+++ b/CRM/Case/BAO/Query.php
@@ -729,10 +729,7 @@ case_relation_type.id = case_relationship.relationship_type_id )";
 
     self::addCustomFormFields($form, array('Case'));
 
-    $form->setDefaults(array(
-      'case_owner' => 1,
-      'upcoming' => 1,
-    ));
+    $form->setDefaults(array('case_owner' => 1));
   }
 
   /**

--- a/CRM/Case/BAO/Query.php
+++ b/CRM/Case/BAO/Query.php
@@ -698,6 +698,9 @@ case_relation_type.id = case_relationship.relationship_type_id )";
       $accessAllCases = TRUE;
       $caseOwner = array(1 => ts('Search All Cases'), 2 => ts('Only My Cases'));
       $form->addRadio('case_owner', ts('Cases'), $caseOwner);
+      if ($form->get('context') != 'dashboard') {
+        $form->add('checkbox', 'upcoming', ts('Search Cases with Upcoming Activities'));
+      }
     }
     $form->assign('accessAllCases', $accessAllCases);
 
@@ -726,7 +729,10 @@ case_relation_type.id = case_relationship.relationship_type_id )";
 
     self::addCustomFormFields($form, array('Case'));
 
-    $form->setDefaults(array('case_owner' => 1));
+    $form->setDefaults(array(
+      'case_owner' => 1,
+      'upcoming' => 1,
+    ));
   }
 
   /**

--- a/CRM/Case/Form/Activity.php
+++ b/CRM/Case/Form/Activity.php
@@ -100,8 +100,8 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
     if ($this->_caseId &&
       !CRM_Core_Permission::check('access all cases and activities')
     ) {
-      $session = CRM_Core_Session::singleton();
-      $allCases = CRM_Case_BAO_Case::getCases(TRUE, $session->get('userID'), 'any');
+      $params = array('type' => 'any');
+      $allCases = CRM_Case_BAO_Case::getCases(TRUE, $params);
       if (count(array_intersect($this->_caseId, array_keys($allCases))) == 0) {
         CRM_Core_Error::fatal(ts('You are not authorized to access this page.'));
       }

--- a/CRM/Case/Page/AJAX.php
+++ b/CRM/Case/Page/AJAX.php
@@ -186,4 +186,30 @@ class CRM_Case_Page_AJAX {
     CRM_Utils_System::civiExit();
   }
 
+  public static function getCases() {
+    $requiredParameters = array(
+      'type' => 'String',
+    );
+    $optionalParameters = array(
+      'case_type_id' => 'String',
+      'status_id' => 'String',
+      'all' => 'Positive',
+    );
+    $params = CRM_Core_Page_AJAX::defaultSortAndPagerParams();
+    $params += CRM_Core_Page_AJAX::validateParams($requiredParameters, $optionalParameters);
+
+    $allCases = (bool) $params['all'];
+
+    $cases = CRM_Case_BAO_Case::getCases($allCases, $params);
+
+    $casesDT = array(
+      'recordsFiltered' => $cases['total'],
+      'recordsTotal' => $cases['total'],
+    );
+    unset($cases['total']);
+    $casesDT['data'] = $cases;
+
+    CRM_Utils_JSON::output($casesDT);
+  }
+
 }

--- a/CRM/Case/Page/DashBoard.php
+++ b/CRM/Case/Page/DashBoard.php
@@ -58,7 +58,7 @@ class CRM_Case_Page_DashBoard extends CRM_Core_Page {
     }
 
     $session = CRM_Core_Session::singleton();
-    $allCases = CRM_Utils_Request::retrieve('all', 'Positive', $session);
+    $allCases = CRM_Utils_Request::retrieve('all', 'Positive', $this);
 
     CRM_Utils_System::setTitle(ts('CiviCase Dashboard'));
 
@@ -66,9 +66,10 @@ class CRM_Case_Page_DashBoard extends CRM_Core_Page {
 
     //validate access for all cases.
     if ($allCases && !CRM_Core_Permission::check('access all cases and activities')) {
-      $allCases = FALSE;
+      $allCases = 0;
       CRM_Core_Session::setStatus(ts('You are not authorized to access all cases and activities.'), ts('Sorry'), 'error');
     }
+    $this->assign('all', $allCases);
     if (!$allCases) {
       $this->assign('myCases', TRUE);
     }
@@ -82,22 +83,27 @@ class CRM_Case_Page_DashBoard extends CRM_Core_Page {
     ) {
       $this->assign('newClient', TRUE);
     }
-    $summary = CRM_Case_BAO_Case::getCasesSummary($allCases, $userID);
-    $upcoming = CRM_Case_BAO_Case::getCases($allCases, $userID, 'upcoming');
-    $recent = CRM_Case_BAO_Case::getCases($allCases, $userID, 'recent');
+    $summary = CRM_Case_BAO_Case::getCasesSummary($allCases);
+    $upcoming = CRM_Case_BAO_Case::getCases($allCases, array(), 'dashboard', TRUE);
+    $recent = CRM_Case_BAO_Case::getCases($allCases, array('type' => 'recent'), 'dashboard', TRUE);
 
-    foreach ($upcoming as $key => $value) {
-      if (strtotime($value['case_scheduled_activity_date']) < time()) {
-        $upcoming[$key]['activity_status'] = 'status-overdue';
-      }
-    }
     $this->assign('casesSummary', $summary);
     if (!empty($upcoming)) {
-      $this->assign('upcomingCases', $upcoming);
+      $this->assign('upcomingCases', TRUE);
     }
     if (!empty($recent)) {
-      $this->assign('recentCases', $recent);
+      $this->assign('recentCases', TRUE);
     }
+
+    $controller = new CRM_Core_Controller_Simple('CRM_Case_Form_Search',
+      ts('Case'), CRM_Core_Action::BROWSE,
+      NULL,
+      FALSE, FALSE, TRUE
+    );
+    $controller->set('context', 'dashboard');
+    $controller->setEmbedded(TRUE);
+    $controller->process();
+    $controller->run();
   }
 
   /**

--- a/CRM/Case/Page/Tab.php
+++ b/CRM/Case/Page/Tab.php
@@ -67,8 +67,7 @@ class CRM_Case_Page_Tab extends CRM_Core_Page {
       if ($this->_id && ($this->_action & CRM_Core_Action::VIEW)) {
         //user might have special permissions to view this case, CRM-5666
         if (!CRM_Core_Permission::check('access all cases and activities')) {
-          $session = CRM_Core_Session::singleton();
-          $userCases = CRM_Case_BAO_Case::getCases(FALSE, $session->get('userID'), 'any');
+          $userCases = CRM_Case_BAO_Case::getCases(FALSE, array('type' => 'any'));
           if (!array_key_exists($this->_id, $userCases)) {
             CRM_Core_Error::fatal(ts('You are not authorized to access this page.'));
           }

--- a/CRM/Case/xml/Menu/Case.xml
+++ b/CRM/Case/xml/Menu/Case.xml
@@ -136,4 +136,8 @@
     <path>civicrm/ajax/delcaserole</path>
     <page_callback>CRM_Case_Page_AJAX::deleteCaseRoles</page_callback>
   </item>
+  <item>
+    <path>civicrm/ajax/get-cases</path>
+    <page_callback>CRM_Case_Page_AJAX::getCases</page_callback>
+  </item>
 </menu>

--- a/CRM/Dashlet/Page/AllCases.php
+++ b/CRM/Dashlet/Page/AllCases.php
@@ -53,12 +53,17 @@ class CRM_Dashlet_Page_AllCases extends CRM_Core_Page {
       CRM_Core_Error::fatal(ts('You are not authorized to access this page.'));
     }
 
-    $session = CRM_Core_Session::singleton();
-    $userID = $session->get('userID');
-    $upcoming = CRM_Case_BAO_Case::getCases(TRUE, $userID, 'upcoming', $context);
+    $controller = new CRM_Core_Controller_Simple('CRM_Case_Form_Search',
+      ts('Case'), CRM_Core_Action::BROWSE,
+      NULL,
+      FALSE, FALSE, TRUE
+    );
+    $controller->setEmbedded(TRUE);
+    $controller->process();
+    $controller->run();
 
-    if (!empty($upcoming)) {
-      $this->assign('AllCases', $upcoming);
+    if (CRM_Case_BAO_Case::getCases(TRUE, array('type' => 'any'), 'dashboard', TRUE)) {
+      $this->assign('casePresent', TRUE);
     }
     return parent::run();
   }

--- a/CRM/Dashlet/Page/CaseDashboard.php
+++ b/CRM/Dashlet/Page/CaseDashboard.php
@@ -45,15 +45,12 @@ class CRM_Dashlet_Page_CaseDashboard extends CRM_Core_Page {
    * @return void
    */
   public function run() {
-
     //check for civicase access.
     if (!CRM_Case_BAO_Case::accessCiviCase()) {
       CRM_Core_Error::fatal(ts('You are not authorized to access this page.'));
     }
 
-    $session = &CRM_Core_Session::singleton();
-    $userID = $session->get('userID');
-    $summary = CRM_Case_BAO_Case::getCasesSummary(TRUE, $userID);
+    $summary = CRM_Case_BAO_Case::getCasesSummary(TRUE);
 
     if (!empty($summary)) {
       $this->assign('casesSummary', $summary);

--- a/CRM/Dashlet/Page/MyCases.php
+++ b/CRM/Dashlet/Page/MyCases.php
@@ -53,12 +53,17 @@ class CRM_Dashlet_Page_MyCases extends CRM_Core_Page {
       CRM_Core_Error::fatal(ts('You are not authorized to access this page.'));
     }
 
-    $session = CRM_Core_Session::singleton();
-    $userID = $session->get('userID');
-    $upcoming = CRM_Case_BAO_Case::getCases(FALSE, $userID, 'upcoming', $context);
+    $controller = new CRM_Core_Controller_Simple('CRM_Case_Form_Search',
+      ts('Case'), CRM_Core_Action::BROWSE,
+      NULL,
+      FALSE, FALSE, TRUE
+    );
+    $controller->setEmbedded(TRUE);
+    $controller->process();
+    $controller->run();
 
-    if (!empty($upcoming)) {
-      $this->assign('upcomingCases', $upcoming);
+    if (CRM_Case_BAO_Case::getCases(FALSE, array('type' => 'any'), $context, TRUE)) {
+      $this->assign('casePresent', TRUE);
     }
     return parent::run();
   }

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -1634,11 +1634,6 @@ input.crm-form-entityref {
   clear: both;
 }
 
-#crm-container table.caseSelector td.status-urgent {
-  font-weight: bold;
-  text-transform: uppercase;
-}
-
 .crm-container .crm-clearfix:after {
   clear: both;
   content: ".";

--- a/templates/CRM/Case/Form/CaseFilter.tpl
+++ b/templates/CRM/Case/Form/CaseFilter.tpl
@@ -23,14 +23,29 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-{if $casePresent}
-  {include file="CRM/Case/Form/CaseFilter.tpl" context="$context" list="all-cases" all="1"}
-  <div class="form-item">
-    {include file="CRM/Case/Page/DashboardSelector.tpl" context="$context" list="all-cases" all="1"}
-  </div>
-{else}
-    <div class="messages status no-popup">
-     {capture assign="findCasesURL"}{crmURL p='civicrm/case/search' q='reset=1'}{/capture}
-     {ts 1=$findCasesURL}There are no Cases. Use <a href="%1">Find Cases</a> to expand your search.{/ts}
-    </div>
-{/if}
+<div class="crm-case-filter-{$list}">
+  <div class="crm-accordion-wrapper crm-search_filters-accordion">
+    <div class="crm-accordion-header">
+    {ts}Filter by Case{/ts}</a>
+    </div><!-- /.crm-accordion-header -->
+    <div class="crm-accordion-body">
+      <table class="no-border form-layout-compressed case-search-options-{$list}">
+        <tr>
+          <td class="crm-contact-form-block-case_type_id crm-inline-edit-field">
+            {$form.case_type_id.label}<br /> {$form.case_type_id.html}
+          </td>
+          <td class="crm-contact-form-block-case_status_id crm-inline-edit-field">
+            {$form.case_status_id.label}<br /> {$form.case_status_id.html}
+          </td>
+          {if $accessAllCases && $form.upcoming}
+            <td class="crm-case-dashboard-switch-view-buttons">
+              <br/>
+              {$form.upcoming.html}&nbsp;{$form.upcoming.label}
+            </td>
+          {/if}
+        </tr>
+      </table>
+    </div><!-- /.crm-accordion-body -->
+  </div><!-- /.crm-accordion-wrapper -->
+</div>
+<div class="spacer"></div>

--- a/templates/CRM/Case/Page/DashBoard.tpl
+++ b/templates/CRM/Case/Page/DashBoard.tpl
@@ -40,18 +40,17 @@
 
     <div class="crm-case-dashboard-switch-view-buttons">
         {if $myCases}
-            {* check for access all cases and activities *}
-            {if call_user_func(array('CRM_Core_Permission','check'), 'access all cases and activities')}
-                <div><input name="allupcoming" type="radio" class="radio" onClick='window.location.replace("{crmURL p="civicrm/case" q="reset=1&all=1"}")' value="1"><span>{ts}All Cases with Upcoming Activities{/ts}</span></input></div>
-                <div><input name="allupcoming" checked type="radio" class="radio" onClick='window.location.replace("{crmURL p="civicrm/case" q="reset=1&all=0"}")' value="0"><span>{ts}My Cases with Upcoming Activities{/ts}</span></input></div>
-            {/if}
+          {* check for access all cases and activities *}
+          {if call_user_func(array('CRM_Core_Permission','check'), 'access all cases and activities')}
+            <div><input name="allupcoming" type="radio" class="radio" onClick='window.location.replace("{crmURL p="civicrm/case" q="reset=1&all=1"}")' value="1"><span>{ts}All Cases with Upcoming Activities{/ts}</span></input></div>
+            <div><input name="allupcoming" checked type="radio" class="radio" onClick='window.location.replace("{crmURL p="civicrm/case" q="reset=1&all=0"}")' value="0"><span>{ts}My Cases with Upcoming Activities{/ts}</span></input></div>
+          {/if}
         {else}
-                <div><input name="allupcoming" checked type="radio" class="radio" onClick='window.location.replace("{crmURL p="civicrm/case" q="reset=1&all=1"}")' value="1"><span>{ts}All Cases with Upcoming Activities{/ts}</span></input></div>
-                <div><input name="allupcoming" type="radio" class="radio" onClick='window.location.replace("{crmURL p="civicrm/case" q="reset=1&all=0"}")' value="0"><span>{ts}My Cases with Upcoming Activities{/ts}</span></input></div>
+          <div><input name="allupcoming" checked type="radio" class="radio" onClick='window.location.replace("{crmURL p="civicrm/case" q="reset=1&all=1"}")' value="1"><span>{ts}All Cases with Upcoming Activities{/ts}</span></input></div>
+          <div><input name="allupcoming" type="radio" class="radio" onClick='window.location.replace("{crmURL p="civicrm/case" q="reset=1&all=0"}")' value="0"><span>{ts}My Cases with Upcoming Activities{/ts}</span></input></div>
         {/if}
     </div>
 </div>
-
 
 <h3>
 {if $myCases}
@@ -88,8 +87,9 @@
 <div class="spacer"></div>
     <h3>{if $myCases}{ts}My Cases With Upcoming Activities{/ts}{else}{ts}All Cases With Upcoming Activities{/ts}{/if}</h3>
     {if $upcomingCases}
+    {include file="CRM/Case/Form/CaseFilter.tpl" context="$context" list="upcoming"}
     <div class="form-item">
-        {include file="CRM/Case/Page/DashboardSelector.tpl" context="dashboard" list="upcoming" rows=$upcomingCases}
+        {include file="CRM/Case/Page/DashboardSelector.tpl" context="dashboard" list="upcoming" all="$all"}
     </div>
     {else}
         <div class="messages status no-popup">
@@ -100,13 +100,15 @@
 <div class="spacer"></div>
     <h3>{if $myCases}{ts}My Cases With Recently Performed Activities{/ts}{else}{ts}All Cases With Recently Performed Activities{/ts}{/if}</h3>
     {if $recentCases}
+    {include file="CRM/Case/Form/CaseFilter.tpl" context="$context" list="recent"}
     <div class="form-item">
-        {include file="CRM/Case/Page/DashboardSelector.tpl" context="dashboard" list="recent" rows=$recentCases}
+        {include file="CRM/Case/Page/DashboardSelector.tpl" context="dashboard" list="recent" all="$all"}
     </div>
     {else}
         <div class="messages status no-popup">
       {ts 1=$findCasesURL}There are no cases with activities scheduled in the past two weeks. Use %1 to expand your search.{/ts}
         </div>
     {/if}
+</div>
 {/if}
 </div>

--- a/templates/CRM/Case/Page/DashboardSelector.tpl
+++ b/templates/CRM/Case/Page/DashboardSelector.tpl
@@ -25,74 +25,49 @@
 *}
 {capture assign=expandIconURL}<img src="{$config->resourceBase}i/TreePlus.gif" alt="{ts}open section{/ts}"/>{/capture}
 {strip}
-<table class="caseSelector">
-  <tr class="columnheader">
-    <th></th>
-    <th>{ts}Contact{/ts}</th>
-    <th>{ts}Subject{/ts}</th>
-    <th>{ts}Status{/ts}</th>
-    <th>{ts}Type{/ts}</th>
-    <th>{ts}My Role{/ts}</th>
-    <th>{ts}Manager{/ts}</th>
-    <th>{if $list EQ 'upcoming'}{ts}Next Sched.{/ts}{elseif $list EQ 'recent'}{ts}Most Recent{/ts}{/if}</th>
-    <th></th>
+<table class="case-selector-{$list} crm-ajax-table" data-page-length='10'>
+<thead>
+  <tr>
+    <th data-data="activity_list" data-orderable="false" class="crm-case-activity_list"></th>
+    <th data-data="contact_id" class="crm-case-contact">{ts}Contact{/ts}</th>
+    <th data-data="subject" cell-class="crmf-subject crm-editable" class="crm-case-subject">{ts}Subject{/ts}</th>
+    <th data-data="case_status" class="crm-case-status">{ts}Status{/ts}</th>
+    <th data-data="case_type" class="crm-case-type">{ts}Type{/ts}</th>
+    <th data-data="case_role" class="crm-case-role">{ts}My Role{/ts}</th>
+    <th data-data="manager" data-orderable="false" class="crm-case-manager">{ts}Manager{/ts}</th>
+    <th data-data="date" cell-class="crm-case-date">{if $list EQ 'upcoming'}{ts}Next Sched.{/ts}{elseif $list EQ 'recent'}{ts}Most Recent{/ts}{/if}</th>
+    <th data-data="links" data-orderable="false" class="crm-case-links">&nbsp;</th>
   </tr>
-
-  {counter start=0 skip=1 print=false}
-  {foreach from=$rows item=row}
-
-  <tr id='{$context}-{$list}-rowid-{$row.case_id}' class="crm-case crm-case_{$row.case_id}">
-  <td>
-    <a title="{ts}Activities{/ts}" class="crm-expand-row" href="{crmURL p='civicrm/case/details' q="caseId=`$row.case_id`&cid=`$row.contact_id`&type=$list"}"></a>
-  </td>
-
-    <td class="crm-case-phone"><a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.contact_id`"}">{$row.sort_name}</a>{if $row.phone}<br /><span class="description">{$row.phone}</span>{/if}<br /><span class="description">{ts}Case ID{/ts}: {$row.case_id}</span></td>
-    <td class="crm-case-case_subject">{$row.case_subject}</td>
-    <td class="{$row.class} crm-case-case_status">{$row.case_status}</td>
-    <td class="crm-case-case_type">{$row.case_type}</td>
-    <td class="crm-case-case_role">{if $row.case_role}{$row.case_role}{else}---{/if}</td>
-    <td class="crm-case-casemanager">{if $row.casemanager_id}<a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.casemanager_id`"}">{$row.casemanager}</a>{else}---{/if}</td>
-    {if $list eq 'upcoming'}
-       <td class="crm-case-case_scheduled_activity">
-     {if $row.case_upcoming_activity_viewable}
-        <a class="crm-popup {$row.activity_status}" href="{crmURL p='civicrm/case/activity/view' h=0 q="cid="}{$row.contact_id}&aid={$row.case_scheduled_activity_id}" title="{ts}View activity{/ts}">{$row.case_scheduled_activity_type}</a>
-     {else}
-        {$row.case_scheduled_activity_type}
-     {/if}
-       &nbsp;&nbsp;
-     {if $row.case_upcoming_activity_editable}
-       <a class="action-item crm-hover-button" href="{crmURL p="civicrm/case/activity" q="reset=1&cid=`$row.contact_id`&caseid=`$row.case_id`&action=update&id=`$row.case_scheduled_activity_id`"}" title="{ts}Edit activity{/ts}"><i class="crm-i fa-pencil"></i></a>
-     {/if}
-     <br />
-     {$row.case_scheduled_activity_date|crmDate}
-         </td>
-
-    {elseif $list eq 'recent'}
-       <td class="crm-case-case_recent_activity">
-   {if $row.case_recent_activity_viewable}
-       <a class="action-item crm-hover-button" href="{crmURL p='civicrm/case/activity/view' h=0 q="cid="}{$row.contact_id}&aid={$row.case_recent_activity_id}" title="{ts}View activity{/ts}">{$row.case_recent_activity_type}</a>
-    {else}
-       {$row.case_recent_activity_type}
-    {/if}
-    {if $row.case_recent_activity_editable and $row.case_recent_activity_type_name != 'Inbound Email' && $row.case_recent_activity_type_name != 'Email'}&nbsp;&nbsp;<a href="{crmURL p="civicrm/case/activity" q="reset=1&cid=`$row.contact_id`&caseid=`$row.case_id`&action=update&id=`$row.case_recent_activity_id`"}" title="{ts}Edit activity{/ts}" class="crm-hover-button crm-popup"><i class="crm-i fa-pencil"></i></a>
-    {/if}<br />
-          {$row.case_recent_activity_date|crmDate}
-   </td>
-    {/if}
-
-    <td>{$row.action}{$row.moreActions}</td>
-   </tr>
-  {/foreach}
-
-    {* Dashboard only lists 10 most recent casess. *}
-    {if $context EQ 'dashboard' and $limit and $pager->_totalItems GT $limit }
-      <tr class="even-row">
-        <td colspan="10"><a href="{crmURL p='civicrm/case/search' q='reset=1'}">&raquo; {ts}Find more cases{/ts}... </a></td>
-      </tr>
-    {/if}
-
+</thead>
 </table>
 
-{/strip}
+{literal}
+  <script type="text/javascript">
+    (function($) {
+      var list =  {/literal}"{$list}"{literal};
+      var selectorClass = '.case-selector-' + list;
+      var filterClass = '.case-search-options-' + list;
 
+      CRM.$('table' + selectorClass).data({
+        "ajax": {
+          "url": {/literal}'{crmURL p="civicrm/ajax/get-cases" h=0 q="snippet=4&all=`$all`"}'{literal},
+          "data": function (d) {
+            d.type = (!$("input[name='upcoming']").length) ? list : $("input[name='upcoming']").prop('checked') ? 'upcoming' : 'any';
+            d.case_type_id = $(filterClass + ' select#case_type_id').val() || [];
+            d.case_type_id = d.case_type_id.join(',');
+            d.status_id = $(filterClass + ' select#case_status_id').val() || [];
+            d.status_id = d.status_id.join(',');
+          }
+        }
+      });
+      $(function($) {
+        $(filterClass + ' :input').change(function() {
+          CRM.$('table' + selectorClass).DataTable().draw();
+        });
+      });
+    })(CRM.$);
+  </script>
+{/literal}
+
+{/strip}
 {crmScript file='js/crm.expandRow.js'}

--- a/templates/CRM/Dashlet/Page/MyCases.tpl
+++ b/templates/CRM/Dashlet/Page/MyCases.tpl
@@ -23,10 +23,11 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-{if $upcomingCases}
-   <div class="form-item">
-       {include file="CRM/Case/Page/DashboardSelector.tpl" context="$context" list="upcoming" rows=$upcomingCases}
-   </div>
+{if $casePresent}
+  {include file="CRM/Case/Form/CaseFilter.tpl" context="$context" list="my-cases" all="0"}
+  <div class="form-item">
+    {include file="CRM/Case/Page/DashboardSelector.tpl" context="$context" list="my-cases" all="0"}
+  </div>
 {else}
     <div class="messages status no-popup">
      {capture assign="findCasesURL"}{crmURL p='civicrm/case/search' q='reset=1'}{/capture}


### PR DESCRIPTION
Overview
----------------------------------------
1. Convert Case dashlets 'All Cases'/'My Cases' with AJAX selectors to use DataTable for listing
2. Add Case filters for search cases by status, type and 'Search Cases with Upcoming Activities' checkbox (unchecking will show cases with 'any' activities)
3. Supported sorting by contact, subject, date, status, type and role.
4. Editable Case subject.

Before
----------------------------------------
Case Dashboard:
![screen shot 2017-11-28 at 11 20 31 am](https://user-images.githubusercontent.com/3735621/33304534-6f8ca562-d42f-11e7-971e-6d55ac237829.png)

Case Dashlets:
![screen shot 2017-11-28 at 11 20 16 am](https://user-images.githubusercontent.com/3735621/33304501-438e62a2-d42f-11e7-9f58-a17844daff63.png)


After
----------------------------------------
Case Dashboard:
![screen shot 2017-11-28 at 11 18 20 am](https://user-images.githubusercontent.com/3735621/33304511-4eeab6f0-d42f-11e7-8757-1ccce3192e9c.png)


Case Dashlets:
![screen shot 2017-11-28 at 11 17 30 am](https://user-images.githubusercontent.com/3735621/33304452-f33e3b88-d42e-11e7-8d0b-7670b1862f75.png)

---

 * [CRM-21461: Case Dashlet enhancement](https://issues.civicrm.org/jira/browse/CRM-21461)