### PR TITLE
CRM-21465 - avoid fatal error when clicking through pledge email.

### DIFF
--- a/CRM/Pledge/BAO/PledgeBlock.php
+++ b/CRM/Pledge/BAO/PledgeBlock.php
@@ -202,7 +202,6 @@ class CRM_Pledge_BAO_PledgeBlock extends CRM_Pledge_DAO_PledgeBlock {
         'scheduled_date',
         'scheduled_amount',
         'currency',
-        'pledge_start_date',
       );
       CRM_Core_DAO::commonRetrieveAll('CRM_Pledge_DAO_PledgePayment', 'pledge_id',
         $form->_values['pledge_id'], $allPayments, $returnProperties


### PR DESCRIPTION
Overview
----------------------------------------
When setting up a pledge, an email message is sent with a link you can use to make a contribution against your pledge. When you click on this link, you get a backtrace.

Before
----------------------------------------
When clicking on the pledge link, you get a back trace.

After
----------------------------------------
When clicking on the link, you get a form to fill in your contribution amount.

Technical Details
----------------------------------------

This is a start - if I'm not missing anything obvious I can add a test. But for now, it seems that calling CRM_Core_DAO::commonRetrieveAll against a table with returnProperties set to a field that is not in the table shouldn't wor.

---

 * [CRM-21465: clicking on pledge link in email returns fatal error](https://issues.civicrm.org/jira/browse/CRM-21465)