### PR TITLE
CRM-21001

### DIFF
--- a/CRM/Core/BAO/SchemaHandler.php
+++ b/CRM/Core/BAO/SchemaHandler.php
@@ -713,6 +713,7 @@ MODIFY      {$columnName} varchar( $length )
     $requiredSigs = $existingSigs = array();
     // Get the indices defined (originally) in the xml files
     $requiredIndices = CRM_Core_DAO_AllCoreTables::indices();
+    $reqSigs = array();
     foreach ($requiredIndices as $table => $indices) {
       $reqSigs[] = CRM_Utils_Array::collect('sig', $indices);
     }
@@ -720,6 +721,7 @@ MODIFY      {$columnName} varchar( $length )
 
     // Get the indices in the database
     $existingIndices = CRM_Core_BAO_SchemaHandler::getIndexes(array_keys($requiredIndices));
+    $extSigs = array();
     foreach ($existingIndices as $table => $indices) {
       CRM_Core_BAO_SchemaHandler::addIndexSignature($table, $indices);
       $extSigs[] = CRM_Utils_Array::collect('sig', $indices);
@@ -747,11 +749,13 @@ MODIFY      {$columnName} varchar( $length )
     $missingIndices = array();
     foreach ($missingSigs as $sig) {
       $sigParts = explode('::', $sig);
+      if (array_key_exists($sigParts[0], $requiredIndices)) {
       foreach ($requiredIndices[$sigParts[0]] as $index) {
         if ($index['sig'] == $sig) {
           $missingIndices[$sigParts[0]][] = $index;
           continue;
         }
+      }
       }
     }
     return $missingIndices;


### PR DESCRIPTION
Overview
----------------------------------------
Undefined index errors in SchemaHander.php

Before
----------------------------------------
_The current status. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._
![schemhandlererror](https://user-images.githubusercontent.com/10037367/33091950-86c4a2fa-cef0-11e7-8ddb-9f8f3d0d9bc3.PNG)
You get lots of these.

After
----------------------------------------
The errors do not appear.
Technical Details
----------------------------------------
Define two variables as arrays before they are used.
Wrap the foreach statement in line 750 with a check that the array key actually exists.
Comments
----------------------------------------
This covers several issues.

---

 * [CRM-21001: com_civicrm\/civicrm\/CRM\/Core\/BAO\/SchemaHandler.php on line 730](https://issues.civicrm.org/jira/browse/CRM-21001)