### PR TITLE
CRM-21001 E-notice in com_civicrm/civicrm/CRM/Core/BAO/SchemaHandler.php

### DIFF
--- a/CRM/Core/BAO/SchemaHandler.php
+++ b/CRM/Core/BAO/SchemaHandler.php
@@ -713,6 +713,7 @@ MODIFY      {$columnName} varchar( $length )
     $requiredSigs = $existingSigs = array();
     // Get the indices defined (originally) in the xml files
     $requiredIndices = CRM_Core_DAO_AllCoreTables::indices();
+    $reqSigs = array();
     foreach ($requiredIndices as $table => $indices) {
       $reqSigs[] = CRM_Utils_Array::collect('sig', $indices);
     }
@@ -720,6 +721,7 @@ MODIFY      {$columnName} varchar( $length )
 
     // Get the indices in the database
     $existingIndices = CRM_Core_BAO_SchemaHandler::getIndexes(array_keys($requiredIndices));
+    $extSigs = array();
     foreach ($existingIndices as $table => $indices) {
       CRM_Core_BAO_SchemaHandler::addIndexSignature($table, $indices);
       $extSigs[] = CRM_Utils_Array::collect('sig', $indices);
@@ -747,10 +749,12 @@ MODIFY      {$columnName} varchar( $length )
     $missingIndices = array();
     foreach ($missingSigs as $sig) {
       $sigParts = explode('::', $sig);
-      foreach ($requiredIndices[$sigParts[0]] as $index) {
-        if ($index['sig'] == $sig) {
-          $missingIndices[$sigParts[0]][] = $index;
-          continue;
+      if (array_key_exists($sigParts[0], $requiredIndices)) {
+        foreach ($requiredIndices[$sigParts[0]] as $index) {
+          if ($index['sig'] == $sig) {
+            $missingIndices[$sigParts[0]][] = $index;
+            continue;
+          }
         }
       }
     }


### PR DESCRIPTION
Overview
---------------------------------------
Undefined index error in SchemaHandler.php

Before
----------------------------------------
_The current status. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/
![schemhandlererror](https://user-images.githubusercontent.com/10037367/33093259-70e6f524-cef4-11e7-8bcd-8cfc1c0bedbe.PNG)
colinkeenan/silentcast)) where appropriate._

After
----------------------------------------
The error no longer appears.

Technical Details
----------------------------------------
Define two array variables before they are used.
Wrap the foreach loop in line 750 with an if statement checking for the existence of the index.

Comments
----------------------------------------
This probably addresses CRM-20749, CRM-21101  and CRM-20766

---

 * [CRM-21001: com_civicrm\/civicrm\/CRM\/Core\/BAO\/SchemaHandler.php on line 730](https://issues.civicrm.org/jira/browse/CRM-21001)
 * [CRM-20749: Undefined index in Core\/BAO\/SchemaHandler.php](https://issues.civicrm.org/jira/browse/CRM-20749)
 * [CRM-21101: Undefined index in CRM_Core_BAO_SchemaHandler::getMissingIndices\(\)](https://issues.civicrm.org/jira/browse/CRM-21101)
 * [CRM-20766: Civicrm Menu Error Wordpress: ...BAO\/SchemaHandler.php on line 730](https://issues.civicrm.org/jira/browse/CRM-20766)