### PR TITLE
CRM-21466 - Fix (obscure) enotice when updating greeting for contact,…

### DIFF
--- a/CRM/Core/OptionGroup.php
+++ b/CRM/Core/OptionGroup.php
@@ -676,6 +676,12 @@ WHERE  v.option_group_id = g.id
     );
   }
 
+  /**
+   * Flush all the places where option values are cached.
+   *
+   * Note that this is called from CRM_Core_PseudoConstant::flush() so we should resist
+   * the intuitive urge to flush that class.
+   */
   public static function flushAll() {
     self::$_values = array();
     self::$_cache = array();

--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -588,6 +588,9 @@ class CRM_Core_PseudoConstant {
     }
     if ($name == 'cache') {
       CRM_Core_OptionGroup::flushAll();
+      if (isset(\Civi::$statics[__CLASS__])) {
+        unset(\Civi::$statics[__CLASS__]);
+      }
     }
   }
 

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -660,17 +660,14 @@ class CRM_Utils_Token {
     $returnBlankToken = FALSE,
     $escapeSmarty = FALSE
   ) {
+    // Refresh contact tokens in case they have changed. There is heavy caching
+    // in exportable fields so there is no benefit in doing this conditionally.
+    self::$_tokens['contact'] = array_merge(
+      array_keys(CRM_Contact_BAO_Contact::exportableFields('All')),
+      array('checksum', 'contact_id')
+    );
+
     $key = 'contact';
-    if (self::$_tokens[$key] == NULL) {
-      // This should come from UF
-
-      self::$_tokens[$key]
-        = array_merge(
-          array_keys(CRM_Contact_BAO_Contact::exportableFields('All')),
-          array('checksum', 'contact_id')
-        );
-    }
-
     // here we intersect with the list of pre-configured valid tokens
     // so that we remove anything we do not recognize
     // I hope to move this step out of here soon and

--- a/api/v3/Contact.php
+++ b/api/v3/Contact.php
@@ -618,7 +618,6 @@ function _civicrm_api3_greeting_format_params($params) {
 
     $nullValue = FALSE;
     $filter = array(
-      'contact_type' => $params['contact_type'],
       'greeting_type' => "{$key}{$greeting}",
     );
 

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -3582,4 +3582,23 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     $this->assertEquals($communicationStyle['value'], $result['communication_style_id']);
   }
 
+  /**
+   * Test that creating a contact with various contact greetings works.
+   */
+  public function testContactGreetingsCreate() {
+    $contact = $this->callAPISuccess('Contact', 'create', array('first_name' => 'Alan', 'last_name' => 'MouseMouse', 'contact_type' => 'Individual'));
+    $contact = $this->callAPISuccessGetSingle('Contact', array('id' => $contact['id'], 'return' => 'postal_greeting'));
+    $this->assertEquals('Dear Alan', $contact['postal_greeting_display']);
+
+    $contact = $this->callAPISuccess('Contact', 'create', array('id' => $contact['id'], 'postal_greeting_id' => 2));
+    $contact = $this->callAPISuccessGetSingle('Contact', array('id' => $contact['id'], 'return' => 'postal_greeting'));
+    $this->assertEquals('Dear Alan MouseMouse', $contact['postal_greeting_display']);
+
+    $contact = $this->callAPISuccess('Contact', 'create', array('organization_name' => 'Alan\'s Show', 'contact_type' => 'Organization'));
+    $contact = $this->callAPISuccessGetSingle('Contact', array('id' => $contact['id'], 'return' => 'postal_greeting, addressee, email_greeting'));
+    $this->assertEquals('', $contact['postal_greeting_display']);
+    $this->assertEquals('', $contact['email_greeting_display']);
+    $this->assertEquals('Alan\'s Show', $contact['addressee_display']);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
If I try to update the greeting template on an existing contact I get an e-notice when trying to call 
 
 ```
$contact = $this->callAPISuccess('Contact', 'create', array(
{{  'id' => $contact['id'], }}
  'postal_greeting_id' => 2,
));
```

Before
----------------------------------------
e-notice

After
----------------------------------------
resolved. Tests added and caching issues that are blockers to tests fixed

Technical Details
----------------------------------------
The issue occurs when calling
{{CRM_Core_PseudoConstant::greeting($filter); }}
with a filter for contact_type.
 
Contact type is unknown at this point. Further passing it in makes the code LESS efficient rather than MORE efficient. The code loads possible values to a static index. If it returns too many options no harm is done because the calling code is only looking for the one option for which it has an ID. If, however, it does filter it then it means it stores one static var for household, one for individual & one for organisation, resulting in marginally more queries running. (I think the performance is marginal in both scenarios but just trying to explore what reason, if any, there is for the filter.)
 
