### PR TITLE
CRM-21469: Fix removal from all groups from Edit Contact

### DIFF
--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -943,11 +943,10 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
     // process shared contact address.
     CRM_Contact_BAO_Contact_Utils::processSharedAddress($params['address']);
 
-    if (!array_key_exists('TagsAndGroups', $this->_editOptions) && !empty($params['group'])) {
+    if (!array_key_exists('TagsAndGroups', $this->_editOptions)) {
       unset($params['group']);
     }
-
-    if (!empty($params['contact_id']) && ($this->_action & CRM_Core_Action::UPDATE) && !empty($params['group'])) {
+    elseif (!empty($params['contact_id']) && ($this->_action & CRM_Core_Action::UPDATE)) {
       // figure out which all groups are intended to be removed
       $contactGroupList = CRM_Contact_BAO_GroupContact::getContactGroup($params['contact_id'], 'Added');
       if (is_array($contactGroupList)) {


### PR DESCRIPTION
Overview
----------------------------------------

Caused by CRM-15830: when editing a contact record, it is not possible to remove all groups.

How to reproduce:

* Create a contact, add the contact to 1 group
* Edit the contact, remove the group from the list of groups for that contact (NB: not from the 'Group' tab, that works fine).

Result: the contact is still in the group.

When testing, also test that this works correctly even if "Groups and Tags" is disabled from the Contact Preferences (Admin > Customize screens > Display Preferences).

---

 * [CRM-21469: Cannot remove all groups\/tags when editing a contact](https://issues.civicrm.org/jira/browse/CRM-21469)
 * [CRM-15830: All groups removed from contact when editing](https://issues.civicrm.org/jira/browse/CRM-15830)