### PR TITLE
CRM-21470 Add support for WordPress Polylang plugin

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -380,8 +380,12 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
    * @inheritDoc
    */
   public function getUFLocale() {
+    // Polylang plugin
+    if (function_exists('pll_current_language')) {
+      $language = pll_current_language();
+    }
     // WPML plugin
-    if (defined('ICL_LANGUAGE_CODE')) {
+    elseif (defined('ICL_LANGUAGE_CODE')) {
       $language = ICL_LANGUAGE_CODE;
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
For multilingual sites, CiviCRM has a useful setting to inherit the language from the CMS language.
Unfortunately, in WordPress, there is no unified way to deal with multilingual site so for each i18n plugins, we need to add some code in CiviCRM to support it.

This PR adds support for WordPress Polylang plugin => https://fr.wordpress.org/plugins/polylang/

To reproduce the problem : 
1. Install Polylang and configure at least 2 languages
![polylang - languages config wordpress](https://user-images.githubusercontent.com/372004/33148916-ab6d7112-cf9b-11e7-90d6-d31c1643f535.png)

2. Configure CiviCRM in multiligual mode with 2 languages and set "Inherit CMS Language"
![settings - localization wordpress](https://user-images.githubusercontent.com/372004/33148616-7f0a50f0-cf9a-11e7-9bd8-c5be1a88a5d8.png)

3. In civicrm.settings.php, uncomment as needed lines like : `define('CIVICRM_LANGUAGE_MAPPING_xx_XX')`  (to resolve ambiguity between language short 'fr' and language long form 'fr_FR' or 'fr_CA')
4. Create a contribution page and translate at least the title
5. Add a page with the shortcode to the contribution page and translate it to the second language
![edit page shortcode and language wordpress](https://user-images.githubusercontent.com/372004/33148615-7ef8faf8-cf9a-11e7-96a5-3752990735ca.png)



Before
----------------------------------------
When visiting the new page and switching language, the form is not translated (CiviCRM default language) - see title and submit button for example.



After
----------------------------------------
The form is properly translated.

---

 * [CRM-21470: Add support for WordPress Polylang plugin](https://issues.civicrm.org/jira/browse/CRM-21470)