### PR TITLE
CRM-21473: Add new permission to add contact notes and prevent users without edit contact permission to edit or delete notes

### DIFF
--- a/CRM/Contact/Page/View/Note.php
+++ b/CRM/Contact/Page/View/Note.php
@@ -94,6 +94,8 @@ class CRM_Contact_Page_View_Note extends CRM_Core_Page {
     }
     $mask = CRM_Core_Action::mask($permissions);
 
+    $this->assign('canAddNotes', CRM_Core_Permission::check('add contact notes'));
+
     $values = array();
     $links = self::links();
     $action = array_sum(array_keys($links)) & $mask;
@@ -212,10 +214,27 @@ class CRM_Contact_Page_View_Note extends CRM_Core_Page {
     if ($this->_action & CRM_Core_Action::VIEW) {
       $this->view();
     }
-    elseif ($this->_action & (CRM_Core_Action::UPDATE | CRM_Core_Action::ADD)) {
+    elseif ($this->_action & CRM_Core_Action::ADD) {
+      if (
+        $this->_permission != CRM_Core_Permission::EDIT &&
+        !CRM_Core_Permission::check('add contact notes')
+        ) {
+        CRM_Core_Error::statusBounce(ts('You do not have access to add notes.'));
+      }
+
+      $this->edit();
+    }
+    elseif ($this->_action & CRM_Core_Action::UPDATE) {
+      if ($this->_permission != CRM_Core_Permission::EDIT) {
+        CRM_Core_Error::statusBounce(ts('You do not have access to edit this note.'));
+      }
+
       $this->edit();
     }
     elseif ($this->_action & CRM_Core_Action::DELETE) {
+      if ($this->_permission != CRM_Core_Permission::EDIT) {
+        CRM_Core_Error::statusBounce(ts('You do not have access to delete this note.'));
+      }
       // we use the edit screen the confirm the delete
       $this->edit();
     }

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -806,6 +806,10 @@ class CRM_Core_Permission {
         $prefix . ts('view all notes'),
         ts("View notes (for visible contacts) even if they're marked admin only"),
       ),
+      'add contact notes' => array(
+        $prefix . ts('add contact notes'),
+        ts("Create notes for contacts"),
+      ),
       'access AJAX API' => array(
         $prefix . ts('access AJAX API'),
         ts('Allow API access even if Access CiviCRM is not granted'),

--- a/templates/CRM/Contact/Page/View/Note.tpl
+++ b/templates/CRM/Contact/Page/View/Note.tpl
@@ -98,7 +98,7 @@
 
 {/if}
 
-{if $permission EQ 'edit' AND ($action eq 16)}
+{if ($permission EQ 'edit' OR $canAddNotes) AND ($action eq 16)}
    <div class="action-link">
    <a accesskey="N" href="{crmURL p='civicrm/contact/view/note' q="cid=`$contactId`&action=add"}" class="button medium-popup"><span><i class="crm-i fa-comment"></i> {ts}Add Note{/ts}</span></a>
    </div>


### PR DESCRIPTION
Overview
----------------------------------------
Add new permission to add contact notes and prevent users without edit contact permission to edit or delete notes

Before
----------------------------------------
Currently only users with ability to "edit" contact can see "add note" button in contact page notes tab, but if the add note link civicrm/contact/view/note?cid=CONTACT_ID&action=add was access directly by a user with no ability to "edit" the contact he will still be able to access the add note button, Also the user can still edit or delete the note by direct access using the URL.

Here is an example of user who only has "**view all contacts**" permission, this is how notes table will appear to him : 

<img width="830" alt="0" src="https://user-images.githubusercontent.com/6275540/33154525-95ff9fca-cff1-11e7-830e-f67d5d1df9fb.png">

And while there is not way to add, delete or edit any note from UI, you can still do it if you know which URL to use, here are some examples for each case for the same user : 

Add 
![1](https://user-images.githubusercontent.com/6275540/33154590-0a139b14-cff2-11e7-97e1-fa11542d700d.gif)

Edit
![2](https://user-images.githubusercontent.com/6275540/33154593-0fd94d82-cff2-11e7-930a-0a5a0821a3ab.gif)

Delete
![3](https://user-images.githubusercontent.com/6275540/33154600-19271112-cff2-11e7-9284-707acdb9e003.gif)


After
----------------------------------------
Now only users with "edit" ability can edit or delete notes, and a new permission is added called "**add contact notes**" so the user either need the ability to "edit" the contact or the new "**add contact notes**" permission to be able to add note for the currently viewed user.

So back to our user with only  "**view all contacts**" permission, the notes tab will still appear as before : 

<img width="830" alt="0" src="https://user-images.githubusercontent.com/6275540/33154525-95ff9fca-cff1-11e7-830e-f67d5d1df9fb.png">

But now the user cannot even use direct access to add,edit or delete a note : 

Add
![1](https://user-images.githubusercontent.com/6275540/33154759-5fb3a392-cff3-11e7-8091-429330e2e0b3.gif)

Edit 
![2](https://user-images.githubusercontent.com/6275540/33154760-62db86f2-cff3-11e7-8982-60945912aafa.gif)

Delete
![3](https://user-images.githubusercontent.com/6275540/33154764-6a27176e-cff3-11e7-9f0a-437378122182.gif)


But additionally, we can grant this user role "**add contact notes**" permission : 

<img width="911" alt="2017-11-23 02_12_35-people _ dmaster4" src="https://user-images.githubusercontent.com/6275540/33154816-d51fd9d4-cff3-11e7-8af6-c00bb341136e.png">

which will allow the user to add notes (only add, no edit or delete will be allowed) : 

![2111](https://user-images.githubusercontent.com/6275540/33154851-0422b2e2-cff4-11e7-9941-c087a5f816ac.gif)

 
---

 * [CRM-21473: Adding new permission for adding notes and fixing existing issues with notes permissions](https://issues.civicrm.org/jira/browse/CRM-21473)