### PR TITLE
CRM-21472 - Allow FlexMailer to take over token validation

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -712,10 +712,12 @@ ORDER BY   {$orderBy}
   }
 
   /**
-   *
    * Prepares the text and html templates
    * for generating the emails and returns a copy of the
    * prepared templates
+   *
+   * @deprecated
+   *   This is used by CiviMail but will be made redundant by FlexMailer/TokenProcessor.
    */
   private function getPreparedTemplates() {
     if (!$this->preparedTemplates) {
@@ -1166,6 +1168,8 @@ ORDER BY   civicrm_email.is_bulkmail DESC
   /**
    * Compose a message.
    *
+   * @deprecated
+   *   This is used by CiviMail but will be made redundant by FlexMailer/TokenProcessor.
    * @param int $job_id
    *   ID of the Job associated with this message.
    * @param int $event_queue_id
@@ -1434,6 +1438,8 @@ ORDER BY   civicrm_email.is_bulkmail DESC
    *
    * Get mailing object and replaces subscribeInvite, domain and mailing tokens.
    *
+   * @deprecated
+   *   This is used by CiviMail but will be made redundant by FlexMailer/TokenProcessor.
    * @param CRM_Mailing_BAO_Mailing $mailing
    */
   public static function tokenReplace(&$mailing) {
@@ -1456,6 +1462,9 @@ ORDER BY   civicrm_email.is_bulkmail DESC
 
   /**
    * Get data to resolve tokens.
+   *
+   * @deprecated
+   *   This is used by CiviMail but will be made redundant by FlexMailer/TokenProcessor.
    *
    * @param array $token_a
    * @param bool $html
@@ -2672,6 +2681,8 @@ LEFT JOIN civicrm_mailing_group g ON g.mailing_id   = m.id
   }
 
   /**
+   * @deprecated
+   *   This is used by CiviMail but will be made redundant by FlexMailer/TokenProcessor.
    * @return array
    */
   public function getReturnProperties() {

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1817,6 +1817,8 @@ ORDER BY   civicrm_email.is_bulkmail DESC
   }
 
   /**
+   * @deprecated
+   *   This is used by CiviMail but will be made redundant by FlexMailer.
    * @param CRM_Mailing_DAO_Mailing $mailing
    *   The mailing which may or may not be sendable.
    * @return array

--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -498,10 +498,13 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
   /**
    * Send the mailing.
    *
+   * @deprecated
+   *   This is used by CiviMail but will be made redundant by FlexMailer.
    * @param object $mailer
    *   A Mail object to send the messages.
    *
    * @param array $testParams
+   * @return bool
    */
   public function deliver(&$mailer, $testParams = NULL) {
     if (\Civi::settings()->get('experimentalFlexMailerEngine')) {
@@ -583,6 +586,8 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
   }
 
   /**
+   * @deprecated
+   *   This is used by CiviMail but will be made redundant by FlexMailer.
    * @param array $fields
    *   List of intended recipients.
    *   Each recipient is an array with keys 'hash', 'contact_id', 'email', etc.

--- a/CRM/Mailing/Info.php
+++ b/CRM/Mailing/Info.php
@@ -129,6 +129,7 @@ class CRM_Mailing_Info extends CRM_Core_Component_Info {
     ));
     $enabledLanguages = CRM_Core_I18n::languages(TRUE);
     $isMultiLingual = (count($enabledLanguages) > 1);
+    $requiredTokens = defined('CIVICRM_FLEXMAILER_HACK_REQUIRED_TOKENS') ? Civi\Core\Resolver::singleton()->call(CIVICRM_FLEXMAILER_HACK_REQUIRED_TOKENS, array()) : CRM_Utils_Token::getRequiredTokens();
     CRM_Core_Resources::singleton()
       ->addSetting(array(
         'crmMailing' => array(
@@ -143,7 +144,7 @@ class CRM_Mailing_Info extends CRM_Core_Component_Info {
           'emailAdd' => $emailAdd['values'],
           'mailTokens' => $mailTokens['values'],
           'contactid' => $contactID,
-          'requiredTokens' => CRM_Utils_Token::getRequiredTokens(),
+          'requiredTokens' => $requiredTokens,
           'enableReplyTo' => (int) Civi::settings()->get('replyTo'),
           'disableMandatoryTokensCheck' => (int) Civi::settings()->get('disable_mandatory_tokens_check'),
           'fromAddress' => $fromAddress['values'],

--- a/CRM/Mailing/Info.php
+++ b/CRM/Mailing/Info.php
@@ -129,6 +129,7 @@ class CRM_Mailing_Info extends CRM_Core_Component_Info {
     ));
     $enabledLanguages = CRM_Core_I18n::languages(TRUE);
     $isMultiLingual = (count($enabledLanguages) > 1);
+    // FlexMailer is a refactoring of CiviMail which provides new hooks/APIs/docs. If the sysadmin has opted to enable it, then use that instead of CiviMail.
     $requiredTokens = defined('CIVICRM_FLEXMAILER_HACK_REQUIRED_TOKENS') ? Civi\Core\Resolver::singleton()->call(CIVICRM_FLEXMAILER_HACK_REQUIRED_TOKENS, array()) : CRM_Utils_Token::getRequiredTokens();
     CRM_Core_Resources::singleton()
       ->addSetting(array(

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -118,6 +118,7 @@ class CRM_Utils_Token {
    *    else an array of the missing tokens
    */
   public static function requiredTokens(&$str) {
+    // FlexMailer is a refactoring of CiviMail which provides new hooks/APIs/docs. If the sysadmin has opted to enable it, then use that instead of CiviMail.
     $requiredTokens = defined('CIVICRM_FLEXMAILER_HACK_REQUIRED_TOKENS') ? Civi\Core\Resolver::singleton()->call(CIVICRM_FLEXMAILER_HACK_REQUIRED_TOKENS, array()) : CRM_Utils_Token::getRequiredTokens();
 
     $missing = array();

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -118,7 +118,7 @@ class CRM_Utils_Token {
    *    else an array of the missing tokens
    */
   public static function requiredTokens(&$str) {
-    $requiredTokens = self::getRequiredTokens();
+    $requiredTokens = defined('CIVICRM_FLEXMAILER_HACK_REQUIRED_TOKENS') ? Civi\Core\Resolver::singleton()->call(CIVICRM_FLEXMAILER_HACK_REQUIRED_TOKENS, array()) : CRM_Utils_Token::getRequiredTokens();
 
     $missing = array();
     foreach ($requiredTokens as $token => $value) {

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -90,6 +90,8 @@ class CRM_Utils_Token {
 
 
   /**
+   * @deprecated
+   *   This is used by CiviMail but will be made redundant by FlexMailer.
    * @return array
    */
   public static function getRequiredTokens() {

--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -75,6 +75,7 @@ function civicrm_api3_mailing_create($params) {
     throw new API_Exception("Mailing has not been saved, Content maybe out of date, please refresh the page and try again");
   }
 
+  // FlexMailer is a refactoring of CiviMail which provides new hooks/APIs/docs. If the sysadmin has opted to enable it, then use that instead of CiviMail.
   $safeParams['_evil_bao_validator_'] = \CRM_Utils_Constant::value('CIVICRM_FLEXMAILER_HACK_SENDABLE', 'CRM_Mailing_BAO_Mailing::checkSendable');
   $result = _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $safeParams);
   return _civicrm_api3_mailing_get_formatResult($result);

--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -74,7 +74,8 @@ function civicrm_api3_mailing_create($params) {
   if (!$timestampCheck) {
     throw new API_Exception("Mailing has not been saved, Content maybe out of date, please refresh the page and try again");
   }
-  $safeParams['_evil_bao_validator_'] = 'CRM_Mailing_BAO_Mailing::checkSendable';
+
+  $safeParams['_evil_bao_validator_'] = \CRM_Utils_Constant::value('CIVICRM_FLEXMAILER_HACK_SENDABLE', 'CRM_Mailing_BAO_Mailing::checkSendable');
   $result = _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $safeParams);
   return _civicrm_api3_mailing_get_formatResult($result);
 }


### PR DESCRIPTION
Overview
----------------------------------------
By default, CiviMail checks for tokens (such as `{action.unsubscribeUrl}`) whose presence would help address anti-spam regulations.

FlexMailer (generally) and Mosaico (in particular) allow customization of the email template language. But tokens look different in those environments, which leads the validation to malfunction. (eg https://github.com/veda-consulting/uk.co.vedaconsulting.mosaico/issues/143 )

The logic for checking tokens should be hookable/alterable so that different template handlers can enforce different variants on this logic.

In keeping with the 'leap-by-extension', the refactoring/enhancement is primarily done in an extension. However, it requires a few small, conservative entry points.

Before
----------------------------------------
Token validation is entirely hard-coded.

After
----------------------------------------
Token validation can overloaded by FlexMailer. FlexMailer provides APIs/documentation enabling extensions to weigh-in on the token-validation.

Technical Details
----------------------------------------
Documentation and utilities can be reviewed in https://github.com/civicrm/org.civicrm.flexmailer/pull/9

The existing behaviors remain unchanged if you have a vanilla (non-FlexMailer) deployment.

---

 * [CRM-21472: Make CiviMail token validation extensible](https://issues.civicrm.org/jira/browse/CRM-21472)