### PR TITLE
CRM-21436: Fix exception on pay later contribution page.

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -129,7 +129,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    *
    * @var int
    */
-  protected $_is_pay_later_enabled;
+  protected $isPayLaterEnabled;
 
   /**
    * The renderer used for this form
@@ -724,20 +724,20 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    *
    * It would be good to sync it with the back-end function on abstractEditPayment & use one everywhere.
    *
-   * @param bool $is_pay_later_enabled
+   * @param bool $isPayLaterEnabled
    *
    * @throws \CRM_Core_Exception
    */
-  protected function assignPaymentProcessor($is_pay_later_enabled) {
+  protected function assignPaymentProcessor($isPayLaterEnabled) {
     $this->_paymentProcessors = CRM_Financial_BAO_PaymentProcessor::getPaymentProcessors(
       array(ucfirst($this->_mode) . 'Mode'),
       $this->_paymentProcessorIDs
     );
+    if ($isPayLaterEnabled) {
+      $this->_paymentProcessors[0] = CRM_Financial_BAO_PaymentProcessor::getPayment(0);
+    }
 
     if (!empty($this->_paymentProcessors)) {
-      if ($is_pay_later_enabled) {
-        $this->_paymentProcessors[0] = CRM_Financial_BAO_PaymentProcessor::getPayment(0);
-      }
       foreach ($this->_paymentProcessors as $paymentProcessorID => $paymentProcessorDetail) {
         if (empty($this->_paymentProcessor) && $paymentProcessorDetail['is_default'] == 1 || (count($this->_paymentProcessors) == 1)
         ) {

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -129,7 +129,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    *
    * @var int
    */
-  protected $isPayLaterEnabled;
+  protected $_is_pay_later_enabled;
 
   /**
    * The renderer used for this form

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -138,7 +138,7 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
    */
   public function tearDown() {
     $this->quickCleanUpFinancialEntities();
-    $this->quickCleanup(array('civicrm_note', 'civicrm_uf_match', 'civicrm_address'));
+    $this->quickCleanup(array('civicrm_note', 'civicrm_uf_match', 'civicrm_address', 'civicrm_contribution_page'));
   }
 
   /**
@@ -1365,7 +1365,9 @@ Price Field - Price Field 1        1   $ 100.00      $ 100.00
     }
     catch (CRM_Core_Exception $e) {
       $this->assertContains("A payment processor configured for this page might be disabled (contact the site administrator for assistance).", $e->getMessage());
+      return;
     }
+    $this->fail('Exception was expected');
   }
 
   /**

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -138,7 +138,7 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
    */
   public function tearDown() {
     $this->quickCleanUpFinancialEntities();
-    $this->quickCleanup(array('civicrm_note', 'civicrm_uf_match', 'civicrm_address', 'civicrm_contribution_page'));
+    $this->quickCleanup(array('civicrm_note', 'civicrm_uf_match', 'civicrm_address'));
   }
 
   /**
@@ -1322,52 +1322,6 @@ Price Field - Price Field 1        1   $ 100.00      $ 100.00
     );
     $this->assertEquals(CRM_Utils_Array::value('card_type_id.label', $financialTrxn), 'Visa');
     $this->assertEquals(CRM_Utils_Array::value('pan_truncation', $financialTrxn), 4567);
-  }
-
-  /**
-   * Check payment processor is correctly assigned for a contribution page.
-   */
-  public function testContributionBasePreProcess() {
-    //Create contribution page with only pay later enabled.
-    $params = array(
-      'title' => "Test Contribution Page",
-      'financial_type_id' => 1,
-      'currency' => 'NZD',
-      'goal_amount' => 100,
-      'is_pay_later' => 1,
-      'is_monetary' => TRUE,
-      'is_active' => TRUE,
-      'is_email_receipt' => TRUE,
-      'receipt_from_email' => 'yourconscience@donate.com',
-      'receipt_from_name' => 'Ego Freud',
-    );
-
-    $page1 = $this->callAPISuccess("contribution_page", 'create', $params);
-
-    //Execute CRM_Contribute_Form_ContributionBase preProcess
-    //and check the assignment of payment processors
-    $form = new CRM_Contribute_Form_ContributionBase();
-    $form->controller = new CRM_Core_Controller();
-    $form->set('id', $page1['id']);
-    $form->preProcess();
-    $this->assertEquals($form->_paymentProcessor['name'], 'pay_later');
-
-    //Disable all the payment processor for the contribution page.
-    $params['is_pay_later'] = 0;
-    $page2 = $this->callAPISuccess("contribution_page", 'create', $params);
-
-    //Assert an exception is thrown on loading the contribution page.
-    $form = new CRM_Contribute_Form_ContributionBase();
-    $form->controller = new CRM_Core_Controller();
-    $form->set('id', $page2['id']);
-    try {
-      $form->preProcess();
-    }
-    catch (CRM_Core_Exception $e) {
-      $this->assertContains("A payment processor configured for this page might be disabled (contact the site administrator for assistance).", $e->getMessage());
-      return;
-    }
-    $this->fail('Exception was expected');
   }
 
   /**

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -1325,6 +1325,50 @@ Price Field - Price Field 1        1   $ 100.00      $ 100.00
   }
 
   /**
+   * Check payment processor is correctly assigned for a contribution page.
+   */
+  public function testContributionBasePreProcess() {
+    //Create contribution page with only pay later enabled.
+    $params = array(
+      'title' => "Test Contribution Page",
+      'financial_type_id' => 1,
+      'currency' => 'NZD',
+      'goal_amount' => 100,
+      'is_pay_later' => 1,
+      'is_monetary' => TRUE,
+      'is_active' => TRUE,
+      'is_email_receipt' => TRUE,
+      'receipt_from_email' => 'yourconscience@donate.com',
+      'receipt_from_name' => 'Ego Freud',
+    );
+
+    $page1 = $this->callAPISuccess("contribution_page", 'create', $params);
+
+    //Execute CRM_Contribute_Form_ContributionBase preProcess
+    //and check the assignment of payment processors
+    $form = new CRM_Contribute_Form_ContributionBase();
+    $form->controller = new CRM_Core_Controller();
+    $form->set('id', $page1['id']);
+    $form->preProcess();
+    $this->assertEquals($form->_paymentProcessor['name'], 'pay_later');
+
+    //Disable all the payment processor for the contribution page.
+    $params['is_pay_later'] = 0;
+    $page2 = $this->callAPISuccess("contribution_page", 'create', $params);
+
+    //Assert an exception is thrown on loading the contribution page.
+    $form = new CRM_Contribute_Form_ContributionBase();
+    $form->controller = new CRM_Core_Controller();
+    $form->set('id', $page2['id']);
+    try {
+      $form->preProcess();
+    }
+    catch (CRM_Core_Exception $e) {
+      $this->assertContains("A payment processor configured for this page might be disabled (contact the site administrator for assistance).", $e->getMessage());
+    }
+  }
+
+  /**
    * function to test card_type and pan truncation.
    */
   public function testCardTypeAndPanTruncationLiveMode() {


### PR DESCRIPTION
Overview
----------------------------------------
This is an extension of https://github.com/civicrm/civicrm-core/pull/11286 and fixes exception on a pay later contribution page.

Before
----------------------------------------
If no payment processor is selected, [contribution page](http://dmaster.demo.civicrm.org/civicrm/admin/contribute/amount?action=update&reset=1&id=1) displays the following exception.

>A payment processor configured for this page might be disabled (contact the site administrator for assistance).


After
----------------------------------------
Contribution page loads fine with pay later processor. 

Technical Details
----------------------------------------
Assignment of pay_later was done after checking if there are any processors enabled on the contribution page. This PR assigns paylater processor just before the check so that it gets assigned correctly even if none of the payment processor is configured. 

Comments
----------------------------------------
Added unit test.

---

 * [CRM-21436: Fatal error on contribution page with only pay later enabled.](https://issues.civicrm.org/jira/browse/CRM-21436)