### PR TITLE
CRM-21477, fixed code to display buttons on Delete premium product form

### DIFF
--- a/CRM/Contribute/Page/ManagePremiums.php
+++ b/CRM/Contribute/Page/ManagePremiums.php
@@ -108,7 +108,7 @@ class CRM_Contribute_Page_ManagePremiums extends CRM_Core_Page_Basic {
     $id = $this->getIdAndAction();
 
     // what action to take ?
-    if ($this->_action & (CRM_Core_Action::UPDATE | CRM_Core_Action::ADD | CRM_Core_Action::PREVIEW)) {
+    if (!($this->_action & CRM_Core_Action::BROWSE)) {
       $this->edit($this->_action, $id, TRUE);
     }
     // finally browse the custom groups


### PR DESCRIPTION
----------------------------------------
* CRM-21477: Buttons missing on Delete Premium product form
  https://issues.civicrm.org/jira/browse/CRM-21477

Before
----------------------------------------
![screen shot 2017-11-24 at 3 53 19 pm](https://user-images.githubusercontent.com/2053075/33206277-b149a8ae-d12f-11e7-9f17-37595fc5315f.png)

After
----------------------------------------
![screen shot 2017-11-24 at 3 53 32 pm](https://user-images.githubusercontent.com/2053075/33206283-b5c28e3c-d12f-11e7-8ee8-d7f33aa25793.png)