### PR TITLE
CRM-21476 Rename clicks to unique clicks in mailing summary report

### DIFF
--- a/CRM/Report/Form/Mailing/Summary.php
+++ b/CRM/Report/Form/Mailing/Summary.php
@@ -242,7 +242,7 @@ class CRM_Report_Form_Mailing_Summary extends CRM_Report_Form {
       'fields' => array(
         'click_count' => array(
           'name' => 'event_queue_id',
-          'title' => ts('Clicks'),
+          'title' => ts('Unique Clicks'),
         ),
         'CTR' => array(
           'title' => ts('Click through Rate'),
@@ -542,7 +542,7 @@ class CRM_Report_Form_Mailing_Summary extends CRM_Report_Form {
         'civicrm_mailing_event_bounce_bounce_count' => ts('Bounce'),
         'civicrm_mailing_event_opened_open_count' => ts('Total Opens'),
         'civicrm_mailing_event_opened_unique_open_count' => ts('Unique Opens'),
-        'civicrm_mailing_event_trackable_url_open_click_count' => ts('Clicks'),
+        'civicrm_mailing_event_trackable_url_open_click_count' => ts('Unique Clicks'),
         'civicrm_mailing_event_unsubscribe_unsubscribe_count' => ts('Unsubscribe'),
       ),
       'rate' => array(


### PR DESCRIPTION
Overview
----------------------------------------
Rename 'Clicks' to 'Unique Clicks' in mailing summary report. Because it's showing 'the number of people who have clicked on links in the mailing' - not the total number of clicks.

The logic is correct. Just tidying up the labeling.

Before
----------------------------------------
Column in mailing summary is called 'Clicks'.

After
----------------------------------------
Column in mailing summary is called 'Unique clicks'.

Technical Details
----------------------------------------
No technical changes. String changed.

---

 * [CRM-21476: Rename 'Clicks' to 'Unique Clicks' in mailing summary report](https://issues.civicrm.org/jira/browse/CRM-21476)