### PR TITLE
CRM-21446 - Allow case id as well as hash in inbound email processing…

### DIFF
--- a/tests/phpunit/api/v3/ActivityCaseTest.php
+++ b/tests/phpunit/api/v3/ActivityCaseTest.php
@@ -49,6 +49,28 @@ class api_v3_ActivityCaseTest extends CiviCaseTestCase {
     ));
   }
 
+  /**
+   * Test activity creation on case based
+   * on id or hash present in case subject.
+   */
+  public function testActivityCreateOnCase() {
+    $hash = substr(sha1(CIVICRM_SITE_KEY . $this->_case['id']), 0, 7);
+    $subjectArr = array(
+      "[case #{$this->_case['id']}] test activity recording under case with id",
+      "[case #{$hash}] test activity recording under case with id",
+    );
+    foreach ($subjectArr as $subject) {
+      $activity = $this->callAPISuccess('Activity', 'create', array(
+        'source_contact_id' => $this->_cid,
+        'activity_type_id' => 'Phone Call',
+        'subject' => $subject,
+      ));
+      $case = $this->callAPISuccessGetSingle('Activity', array('return' => array("case_id"), 'id' => $activity['id']));
+      //Check if case id is present for the activity.
+      $this->assertEquals($this->_case['id'], $case['case_id'][0]);
+    }
+  }
+
   public function testGet() {
     $this->assertTrue(is_numeric($this->_case['id']));
     $this->assertTrue(is_numeric($this->_otherActivity['id']));


### PR DESCRIPTION
… to autofill emails on cases

Overview
----------------------------------------
Allow case id as well as hash in inbound email processing

Before
----------------------------------------
Only hash is supported for linking activities with cases. See JIRA and https://civicrm.stackexchange.com/questions/21407/how-to-expose-the-civicase-hashed-value-that-gets-sent-in-subject-when-sending-a

After
----------------------------------------
if the subject contains a text with case id `[case #123]` - it will be recorded on the case.

Comments
----------------------------------------
Added unit test to check for hash as well as for case id.

https://issues.civicrm.org/jira/browse/CRM-21446