### PR TITLE
CRM-21479: Syntax fix for updateContributionInvoiceNumber().

### DIFF
--- a/CRM/Upgrade/Incremental/php/FourSeven.php
+++ b/CRM/Upgrade/Incremental/php/FourSeven.php
@@ -627,7 +627,7 @@ class CRM_Upgrade_Incremental_php_FourSeven extends CRM_Upgrade_Incremental_Base
       UPDATE `civicrm_contribution` SET `invoice_number` = CONCAT(%1, `id`)
        WHERE `id` BETWEEN (%2 AND %3) AND `invoice_number` IS NOT NULL ",
       array(
-        1 => array($invoicePrefix, 'string'),
+        1 => array($invoicePrefix, 'String'),
         2 => array($startID, 'Integer'),
         3 => array($endID, 'Integer'),
       )


### PR DESCRIPTION
Overview
----------------------------------------

This error causes the 4.7.28 (RC) upgrade to fail, if invoicing is enabled.

---

 * [CRM-21479: 4.7.28-rc: updateContributionInvoiceNumber\(\) syntax error](https://issues.civicrm.org/jira/browse/CRM-21479)