### PR TITLE
CRM-21481: 4.7.28: call rebuildMultilingalSchema().

### DIFF
--- a/CRM/Upgrade/Incremental/php/FourSeven.php
+++ b/CRM/Upgrade/Incremental/php/FourSeven.php
@@ -480,6 +480,8 @@ class CRM_Upgrade_Incremental_php_FourSeven extends CRM_Upgrade_Incremental_Base
         $this->addTask($title, 'updateContributionInvoiceNumber', $startId, $endId, $invoicePrefix);
       }
     }
+
+    $this->addTask('Rebuild Multilingual Schema', 'rebuildMultilingalSchema');
   }
 
   /*


### PR DESCRIPTION
rebuildMultilingalSchema() because of the field that was added on profiles.

Otherwise: `[nativecode=1054 ** Unknown column 'a.cancel_button_text' in 'field list']"`

```
SELECT a.id as `id`, a.is_active as `is_active`, a.group_type as `group_type`, a.title as `title`, a.description as `description`, a.help_pre as `help_pre`, a.help_post as `help_post
`, a.limit_listings_group_id as `limit_listings_group_id`, a.post_URL as `post_URL`, a.add_to_group_id as `add_to_group_id`, a.add_captcha as `add_captcha`, a.is_map as `is_map`, a.is_edit_link as `is_e
dit_link`, a.is_uf_link as `is_uf_link`, a.is_update_dupe as `is_update_dupe`, a.cancel_URL as `cancel_URL`, a.is_cms_user as `is_cms_user`, a.notify as `notify`, a.is_reserved as `is_reserved`, a.name
as `name`, a.created_id as `created_id`, a.created_date as `created_date`, a.is_proximity_search as `is_proximity_search`, a.cancel_button_text as `cancel_button_text`, a.submit_button_text as `submit_b
utton_text`                                                                                        
FROM civicrm_uf_group_fr_CA a
WHERE (a.name IN ("new_individual", "new_organization", "new_household")) AND (a.is_active = "1")
LIMIT 25
OFFSET 0
```

---

 * [CRM-21481: 4.7.28-rc: needs to call rebuildMultilingualSchema\(\)](https://issues.civicrm.org/jira/browse/CRM-21481)