### PR TITLE
CRM-21478 Using contribution status id instead of label in if statement

### DIFF
--- a/templates/CRM/Contribute/Page/UserDashboard.tpl
+++ b/templates/CRM/Contribute/Page/UserDashboard.tpl
@@ -65,7 +65,7 @@
                                 <a class="button no-popup nowrap"
                                    href="{crmURL p='civicrm/contribute/invoice' q=$urlParams}">
                                     <i class="crm-i fa-print"></i>
-                                    {if $row.contribution_status != 'Refunded' && $row.contribution_status != 'Cancelled' }
+                                    {if $row.contribution_status_id != 7 && $row.contribution_status_id != 3 }
                                         <span>{ts}Print Invoice{/ts}</span>
                                     {else}
                                         <span>{ts}Print Invoice and Credit Note{/ts}</span>
@@ -74,7 +74,7 @@
                             {/if}
                           </td>
                         {/if}
-                        {if $defaultInvoicePage && $row.contribution_status == 'Pending (Pay Later)'}
+                        {if $defaultInvoicePage && $row.contribution_status_id == 2}
                           <td>
                             {assign var='id' value=$row.contribution_id}
                             {capture assign=payNowLink}{crmURL p='civicrm/contribute/transact' q="reset=1&id=`$defaultInvoicePage`&ccid=`$id`"}{/capture}

--- a/templates/CRM/Contribute/Page/UserDashboard.tpl
+++ b/templates/CRM/Contribute/Page/UserDashboard.tpl
@@ -65,7 +65,7 @@
                                 <a class="button no-popup nowrap"
                                    href="{crmURL p='civicrm/contribute/invoice' q=$urlParams}">
                                     <i class="crm-i fa-print"></i>
-                                    {if $row.contribution_status_id != 7 && $row.contribution_status_id != 3 }
+                                    {if $row.contribution_status_name != 'Refunded' && $row.contribution_status_name != 'Cancelled' }
                                         <span>{ts}Print Invoice{/ts}</span>
                                     {else}
                                         <span>{ts}Print Invoice and Credit Note{/ts}</span>
@@ -74,7 +74,7 @@
                             {/if}
                           </td>
                         {/if}
-                        {if $defaultInvoicePage && $row.contribution_status_id == 2}
+                        {if $defaultInvoicePage && $row.contribution_status_name == 'Pending' }
                           <td>
                             {assign var='id' value=$row.contribution_id}
                             {capture assign=payNowLink}{crmURL p='civicrm/contribute/transact' q="reset=1&id=`$defaultInvoicePage`&ccid=`$id`"}{/capture}


### PR DESCRIPTION
Overview
----------------------------------------
On localized site with payment status translated, the dashboard fail to display some useful information.

Before
----------------------------------------

- When payment is pending, it's not possible to see the "Pay Now" button
- If taxes and receipting is enabled, when payment is canceled or refund, "Print Invoice" is displayed instead of "Print Invoice and Credit Note"

![crm-21478 - user dashboard - before](https://user-images.githubusercontent.com/372004/33219652-7a24a1ee-d111-11e7-8784-8c9faa758a0e.png)

After
----------------------------------------

![crm-21478 - user dashboard - after](https://user-images.githubusercontent.com/372004/33219654-8215c720-d111-11e7-8b32-5792763f162a.png)

Comments
----------------------------------------
Really minor changes that only impact this screen.

---

 * [CRM-21478: Pay Now on user dashboard only works in english](https://issues.civicrm.org/jira/browse/CRM-21478)