### PR TITLE
CRM-21214 Fix crashes when 'null' string is passed in via API

### DIFF
--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -153,7 +153,7 @@ class CRM_Core_BAO_Address extends CRM_Core_DAO_Address {
     }
 
     // (prevent chaining 1 and 3) CRM-21214
-    if (CRM_Utils_Array::value('master_id', $params)) {
+    if (isset($params['master_id']) && !CRM_Utils_System::isNull($params['master_id'])) {
       self::fixSharedAddress($params);
     }
 
@@ -537,7 +537,7 @@ class CRM_Core_BAO_Address extends CRM_Core_DAO_Address {
       $values['display'] = $address->display;
       $values['display_text'] = $address->display_text;
 
-      if (is_numeric($address->master_id)) {
+      if (isset($address->master_id) && !CRM_Utils_System::isNull($address->master_id)) {
         $values['use_shared_address'] = 1;
       }
 
@@ -1031,7 +1031,7 @@ SELECT is_primary,
 
     // unset contact id
     $skipFields = array('is_primary', 'location_type_id', 'is_billing', 'contact_id');
-    if (CRM_Utils_Array::value('master_id', $params)) {
+    if (isset($params['master_id']) && !CRM_Utils_System::isNull($params['master_id'])) {
       // call the function to create a relationship for the new shared address
       self::processSharedAddressRelationship($params['master_id'], $params['contact_id']);
     }
@@ -1046,7 +1046,7 @@ SELECT is_primary,
     $addressDAO = new CRM_Core_DAO_Address();
     while ($dao->fetch()) {
       // call the function to update the relationship
-      if (CRM_Utils_Array::value('master_id', $params)) {
+      if (isset($params['master_id']) && !CRM_Utils_System::isNull($params['master_id'])) {
         self::processSharedAddressRelationship($params['master_id'], $dao->contact_id);
       }
       $addressDAO->copyValues($params);


### PR DESCRIPTION
Overview
----------------------------------------
This is a followup fix for the changes made in #11019.

Before
----------------------------------------
When using Address.create API with master_id = 'null' (string) CiviCRM crashes.

After
----------------------------------------
When using Address.create API with master_id = 'null' (string) CiviCRM does not crash.

Technical Details
----------------------------------------
The string 'null' is passed in via the CiviCRM API and we need to catch that otherwise SQL functions crash as they are expecting an integer.

@colemanw As merger of the original PR (#11019) could you take a look at this?

---

 * [CRM-21214: Chaining shared addresses doesn't work correctly](https://issues.civicrm.org/jira/browse/CRM-21214)