### PR TITLE
CRM-21482 Allow retrieving currency from  (as supplied by webform_civicrm)

### DIFF
--- a/CRM/Core/Payment/ProcessorForm.php
+++ b/CRM/Core/Payment/ProcessorForm.php
@@ -75,7 +75,10 @@ class CRM_Core_Payment_ProcessorForm {
     $currency = CRM_Utils_Array::value('currency', $form->_values);
     // For event forms, currency is in a different spot
     if (empty($currency)) {
-      $currency = CRM_Utils_Array::value('currency', $form->_values['event']);
+      $currency = CRM_Utils_Array::value('currency', CRM_Utils_Array::value('event', $form->_values));
+    }
+    if (empty($currency)) {
+      $currency = CRM_Utils_Request::retrieveValue('currency', 'String');
     }
     $form->assign('currency', $currency);
 


### PR DESCRIPTION
Currently a PHP notice is thrown because it looks for $form->_values['event'] which does not exist.
But currency does exist in the URL parameters ($_REQUEST) so we can grab it from there.

---

 * [CRM-21482: Allow retrieval of currency from $_REQUEST \(as supplied by webform_civicrm\)](https://issues.civicrm.org/jira/browse/CRM-21482)