### PR TITLE
CRM-21365 Fix Currency

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -2360,4 +2360,25 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     return $name;
   }
 
+  /**
+   * Get the currency for the form.
+   *
+   * @todo this should be overriden on the forms rather than having this
+   * historic, possible handling in here. As we clean that up we should
+   * add deprecation notices into here.
+   */
+  public function getCurrency() {
+    $currency = CRM_Utils_Array::value('currency', $this->_values);
+    // For event forms, currency is in a different spot
+    if (empty($currency)) {
+      $currency = CRM_Utils_Array::value('currency', CRM_Utils_Array::value('event', $this->_values));
+    }
+    if (empty($currency)) {
+      $currency = CRM_Utils_Request::retrieveValue('currency', 'String');
+    }
+    // @todo If empty there is a problem - we should probably put in a deprecation notice
+    // to warn if that seems to be happening.
+    return $currency;
+  }
+
 }

--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -986,6 +986,19 @@ abstract class CRM_Core_Payment {
   }
 
   /**
+   * Get the currency for the transaction.
+   *
+   * Handle any inconsistency about how it is passed in here.
+   *
+   * @param $params
+   *
+   * @return string
+   */
+  protected function getCurrency($params) {
+    return CRM_Utils_Array::value('currencyID', $params, CRM_Utils_Array::value('currency', $params));
+  }
+
+  /**
    * Get url to return to after cancelled or failed transaction.
    *
    * @param string $qfKey

--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -477,7 +477,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
 
     $args['paymentAction'] = 'Sale';
     $args['amt'] = $params['amount'];
-    $args['currencyCode'] = $params['currencyID'];
+    $args['currencyCode'] = $this->getCurrency($params);
     $args['invnum'] = $params['invoiceID'];
     $args['ipaddress'] = $params['ip_address'];
     $args['creditCardType'] = $params['credit_card_type'];

--- a/CRM/Core/Payment/ProcessorForm.php
+++ b/CRM/Core/Payment/ProcessorForm.php
@@ -72,11 +72,7 @@ class CRM_Core_Payment_ProcessorForm {
 
     $form->assign('suppressSubmitButton', $form->_paymentObject->isSuppressSubmitButtons());
 
-    $currency = CRM_Utils_Array::value('currency', $form->_values);
-    // For event forms, currency is in a different spot
-    if (empty($currency)) {
-      $currency = CRM_Utils_Array::value('currency', $form->_values['event']);
-    }
+    $currency = $form->getCurrency();
     $form->assign('currency', $currency);
 
     // also set cancel subscription url


### PR DESCRIPTION
Overview
----------------------------------------
Improve handling of currency

Comments
----------------------------------------
This is proposed as an alternative to #11210 and #11325

---

 * [CRM-21365: Currency code not passed to processor \(PayPal - Website Payments Pro\)](https://issues.civicrm.org/jira/browse/CRM-21365)