### PR TITLE
CRM-19273 / CRM-21390 fix fatal error when re-editing submitted price sets

### DIFF
--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -664,7 +664,6 @@ WHERE li.contribution_id = %1";
       CRM_Price_BAO_LineItem::create($lineItemToAlter);
     }
 
-    // the recordAdjustedAmt code would execute over here
     $count = 0;
     if ($entity == 'participant') {
       $count = count(CRM_Event_BAO_Participant::getParticipantIds($contributionId));
@@ -694,14 +693,15 @@ WHERE li.contribution_id = %1";
     }
     $trxn = $lineItemObj->recordAdjustedAmt($updatedAmount, $paidAmount, $contributionId, $taxAmount, $updateAmountLevel);
 
-    $contributionCompletedStatusID = CRM_Core_PseudoConstant::getKey('CRM_Contribute_DAO_Contribution', 'contribution_status_id', 'Completed');
+    $contributionStatus = CRM_Core_PseudoConstant::getName('CRM_Contribute_DAO_Contribution', 'contribution_status_id', CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $contributionId, 'contribution_status_id'));
+
     if (!empty($financialItemsArray)) {
       foreach ($financialItemsArray as $updateFinancialItemInfoValues) {
         $newFinancialItem = CRM_Financial_BAO_FinancialItem::create($updateFinancialItemInfoValues);
         // record reverse transaction only if Contribution is Completed because for pending refund or
         //   partially paid we are already recording the surplus owed or refund amount
-        if (!empty($updateFinancialItemInfoValues['financialTrxn']) && ($contributionCompletedStatusID ==
-          CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $contributionId, 'contribution_status_id'))
+        if (!empty($updateFinancialItemInfoValues['financialTrxn']) && ($contributionStatus == 'Completed'
+          )
         ) {
           $updateFinancialItemInfoValues = array_merge($updateFinancialItemInfoValues['financialTrxn'], array(
             'entity_id' => $newFinancialItem->id,

--- a/tests/phpunit/CRM/Event/BAO/CRM19273Test.php
+++ b/tests/phpunit/CRM/Event/BAO/CRM19273Test.php
@@ -224,15 +224,15 @@ class CRM_Event_BAO_CRM19273Test extends CiviUnitTestCase {
     $priceSetParams['price_1'] = 1;
     $lineItem = CRM_Price_BAO_LineItem::getLineItems($this->_participantId, 'participant');
 
-    // return here as the following lines will not work until the reset of PR 10962 has been merged.
-    return;
-
     CRM_Price_BAO_LineItem::changeFeeSelections($priceSetParams, $this->_participantId, 'participant', $this->_contributionId, $this->_feeBlock, $lineItem, $this->_expensiveFee);
+
     $this->balanceCheck($this->_expensiveFee);
 
     $priceSetParams['price_1'] = 3;
     $lineItem = CRM_Price_BAO_LineItem::getLineItems($this->_participantId, 'participant');
     CRM_Price_BAO_LineItem::changeFeeSelections($priceSetParams, $this->_participantId, 'participant', $this->_contributionId, $this->_feeBlock, $lineItem, $this->_expensiveFee);
+    // return here as the following lines will not work until the reset of PR 10962 has been merged.
+    return;
     $this->balanceCheck($this->_veryExpensive);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Subset of https://github.com/civicrm/civicrm-core/pull/10962 - this gets past the fatal errors on re-editing a line (per https://issues.civicrm.org/jira/browse/CRM-21390)

---

 * [CRM-19273: Changes to Event Selections on Pending \(Pay Later\) Contribution Not Creating Correct Financial Items Causing Imbalance in Accounting Batch Export](https://issues.civicrm.org/jira/browse/CRM-19273)