### PR TITLE
CRM-21486: Support multiple test mail

### DIFF
--- a/ang/crmMailing/BlockPreview.html
+++ b/ang/crmMailing/BlockPreview.html
@@ -30,11 +30,12 @@ Vars: mailing:obj, testContact:obj, testGroup:obj, crmMailing:FormController
     <div>
       <input
         name="preview_test_email"
-        type="email"
+        type="text"
         class="crm-form-text"
         ng-model="testContact.email"
         placeholder="example@example.org"
-        />
+        crm-multiple-email
+      />
     </div>
     <button crm-icon="fa-paper-plane" title="{{crmMailing.$invalid || !testContact.email ? ts('Complete all required fields first') : ts('Send test message to %1', {1: testContact.email})}}" ng-disabled="crmMailing.$invalid || !testContact.email" ng-click="doSend({email: testContact.email})">{{ts('Send test')}}</button>
   </div>

--- a/ang/crmMailing/services.js
+++ b/ang/crmMailing/services.js
@@ -517,7 +517,7 @@
             return crmLegacy.url('civicrm/contact/search/advanced',
               'force=1&mailing_id=' + mailing.id + statType.searchFilter);
           case 'report':
-            var reportIds = CRM.crmMailing.reportIds; 
+            var reportIds = CRM.crmMailing.reportIds;
             return crmLegacy.url('civicrm/report/instance/' + reportIds[statType.reportType],
                 'reset=1&mailing_id_value=' + mailing.id + statType.reportFilter);
           default:

--- a/ang/crmUi.js
+++ b/ang/crmUi.js
@@ -675,6 +675,38 @@
       };
     })
 
+    // validate multiple email text
+    // usage: <input crm-multiple-email type="text" ng-model="myobj.field" />
+    .directive('crmMultipleEmail', function ($parse, $timeout) {
+      return {
+        require: 'ngModel',
+        link: function(scope, element, attrs, ctrl) {
+          ctrl.$parsers.unshift(function(viewValue) {
+            // if empty value provided simply bypass validation
+            if (_.isEmpty(viewValue)) {
+              ctrl.$setValidity('crmMultipleEmail', true);
+              return viewValue;
+            }
+
+            // split email string on basis of comma
+            var emails = viewValue.split(',');
+            // regex pattern for single email
+            var emailRegex = /\S+@\S+\.\S+/;
+
+            var validityArr = emails.map(function(str){
+              return emailRegex.test(str.trim());
+            });
+
+            if ($.inArray(false, validityArr) > -1) {
+              ctrl.$setValidity('crmMultipleEmail', false);
+            } else {
+              ctrl.$setValidity('crmMultipleEmail', true);
+            }
+            return viewValue;
+          });
+        }
+      };
+    })
     // example <div crm-ui-tab id="tab-1" crm-title="ts('My Title')" count="3">...content...</div>
     // WISHLIST: use a full Angular component instead of an incomplete jQuery wrapper
     .directive('crmUiTab', function($parse) {


### PR DESCRIPTION
Overview
----------------------------------------
In the old version, you could add multiple email addresses in the test email window as long as they were separated by commas. This issue is about retaining this old behavior.

Before
----------------------------------------
![test-multiple-before](https://user-images.githubusercontent.com/3735621/33278945-fc738e04-d3c2-11e7-9c90-263c427e438c.gif)

After
----------------------------------------
![test-multiple](https://user-images.githubusercontent.com/3735621/33278970-0957315c-d3c3-11e7-8c99-948a402cf8f5.gif)

Technical Details
----------------------------------------
Theres still work going on to support multiple email field in angularJs, [see](https://github.com/angular/angular.js/pull/8987). So I have introduced directive ```crm-multiple-email``` to support comma separated multiple emails.

 * [CRM-21486: Support multiple test mail](https://issues.civicrm.org/jira/browse/CRM-21486)