### PR TITLE
CRM-21470 Ensure we don't have an empty locale

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -391,7 +391,7 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
 
     // TODO: set language variable for others WordPress plugin
 
-    if (isset($language) && !empty($language)) {
+    if (!empty($language)) {
       return CRM_Core_I18n_PseudoConstant::longForShort(substr($language, 0, 2));
     }
     else {

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -391,7 +391,7 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
 
     // TODO: set language variable for others WordPress plugin
 
-    if (isset($language)) {
+    if (isset($language) && !empty($language)) {
       return CRM_Core_I18n_PseudoConstant::longForShort(substr($language, 0, 2));
     }
     else {


### PR DESCRIPTION
Overview
----------------------------------------
Related to https://github.com/civicrm/civicrm-core/pull/11312 which has been committed.

In admin pages, Polylang as an option to display "Show all languages" instead of forcing one language. When we do so, it gives some PHP notice errors because CiviCRM is not able to find corresponding locale.

Before
----------------------------------------
Notice: Undefined index: in /var/aegir/platforms/wordpress/wp-content/plugins/civicrm/civicrm/CRM/Core/I18n/PseudoConstant.php on line 44

![crm21470 - civicrm home wordpress](https://user-images.githubusercontent.com/372004/33290720-9b46e080-d391-11e7-9fb7-63bdd755f172.png)

After
----------------------------------------
No notices.

Technical Details
----------------------------------------
Use `!empty` instead of `isset`

---

 * [CRM-21470: Add support for WordPress Polylang plugin](https://issues.civicrm.org/jira/browse/CRM-21470)