### PR TITLE
CRM-21489 document new constant in civicrm.settings.php

### DIFF
--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -421,6 +421,13 @@ if (!defined('CIVICRM_DB_CACHE_PREFIX')) {
 // }
 
 /**
+ * Define how many times to retry a transaction when the DB hits a deadlock
+ * (ie. the database is locked by another transaction). This is an
+ * advanced setting intended for high-traffic databases & experienced developers/ admins.
+ */
+define('CIVICRM_DEADLOCK_RETRIES', 3);
+
+/**
  * Configure MySQL to throw more errors when encountering unusual SQL expressions.
  *
  * If undefined, the value is determined automatically. For CiviCRM tarballs, it defaults


### PR DESCRIPTION
Overview
----------------------------------------
Document constant from https://github.com/civicrm/civicrm-packages/pull/197 in civicrm.settings.php

Comments
----------------------------------------
This is just signposting / documenting a change discussed elsewhere - ie. JIRA & the other PR

---

 * [CRM-21489: Deadlock retries have been accidentally blocked](https://issues.civicrm.org/jira/browse/CRM-21489)