### PR TITLE
CRM-21460 Add job execution hooks

### DIFF
--- a/CRM/Core/JobManager.php
+++ b/CRM/Core/JobManager.php
@@ -141,12 +141,15 @@ class CRM_Core_JobManager {
       $params = $job->apiParams;
     }
 
+    CRM_Utils_Hook::preJob($job, $params);
     try {
       $result = civicrm_api($job->api_entity, $job->api_action, $params);
     }
     catch (Exception$e) {
       $this->logEntry('Error while executing ' . $job->name . ': ' . $e->getMessage());
+      $result = $e;
     }
+    CRM_Utils_Hook::postJob($job, $params, $result);
     $this->logEntry('Finished execution of ' . $job->name . ' with result: ' . $this->_apiResultToMessage($result));
     $this->currentJob = FALSE;
   }

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2396,4 +2396,36 @@ abstract class CRM_Utils_Hook {
     );
   }
 
+  /**
+   * This hook is called before a scheduled job is executed
+   *
+   * @param CRM_Core_DAO_Job $job
+   *   The job to be executed
+   * @param array $params
+   *   The arguments to be given to the job
+   */
+  public static function preJob($job, $params) {
+    return self::singleton()->invoke(array('job', 'params'), $job, $params,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      'civicrm_preJob'
+    );
+  }
+
+  /**
+   * This hook is called after a scheduled job is executed
+   *
+   * @param CRM_Core_DAO_Job $job
+   *   The job that was executed
+   * @param array $params
+   *   The arguments given to the job
+   * @param array $result
+   *   The result of the API call, or the thrown exception if any
+   */
+  public static function postJob($job, $params, $result) {
+    return self::singleton()->invoke(array('job', 'params', 'result'), $job, $params, $result,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      'civicrm_postJob'
+    );
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Implements the solution suggested in [CRM-21460](https://issues.civicrm.org/jira/browse/CRM-21460) to allow monitoring / storing the scheduled job execution results, assuming this is the right direction.

Before
----------------------------------------
At the moment the job log does not store any structured information about the execution status, only a message in a freetext format. One would have to parse localized messages to extract whether jobs have succeeded or not.

After
----------------------------------------
Two new hooks: `preJob` and `postJob` called right before and after the execution of a scheduled job. Rather than storing new info in the log table, hooks let implementers chose what to do with the info, and whether they want to store it or immediately act upon it.

Technical Details
----------------------------------------
Having both a pre and a post hook is mostly to measure execution time or detect stuck jobs. The pre hook doesn't give the job and params objects by reference, so the hook is not meant to alter the job before its execution.
In the post hook, the result can also be an exception object when the job execution was interrupted by an exception.

Comments
----------------------------------------
See [Sencivity](https://github.com/WeMoveEU/sencivity/blob/master/sencivity.php#L116) for an example of how these hooks can be used.
