### PR TITLE
CRM-21492 - Don't reject recurring contributions whose amount is diff…

### DIFF
--- a/CRM/Core/Payment/AuthorizeNetIPN.php
+++ b/CRM/Core/Payment/AuthorizeNetIPN.php
@@ -118,14 +118,6 @@ class CRM_Core_Payment_AuthorizeNetIPN extends CRM_Core_Payment_BaseIPN {
       return FALSE;
     }
 
-    // At this point $object has first contribution loaded.
-    // Lets do a check to make sure this payment has the amount same as that of first contribution.
-    if ($objects['contribution']->total_amount != $input['amount']) {
-      CRM_Core_Error::debug_log_message("Subscription amount mismatch.");
-      echo "Failure: Subscription amount mismatch<p>";
-      return FALSE;
-    }
-
     $contributionStatus = CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name');
 
     $transaction = new CRM_Core_Transaction();


### PR DESCRIPTION
…erent from the initial amount

Overview
----------------------------------------
CiviCRM allows you to update the recurring payment amount, and successfully updates Authorize.Net - but IPNs are rejected because the code rejects any payment whose amount doesn't match the original amount.

Before
----------------------------------------
Submitting an IPN with an amount that doesn't match the initial amount results in no contribution being logged, and the CiviCRM log reports "Subscription amount mismatch".

After
----------------------------------------
The contribution is logged.

https://issues.civicrm.org/jira/browse/CRM-21492
