### PR TITLE
CRM-21455 supportsFullGroupBy: MariaDB 10.2 does not support ANY_VALUE

### DIFF
--- a/CRM/Utils/SQL.php
+++ b/CRM/Utils/SQL.php
@@ -69,11 +69,22 @@ class CRM_Utils_SQL {
   }
 
   /**
-   * Does this System support the MYSQL mode ONLY_FULL_GROUP_BY
+   * Checks if this system enforce the MYSQL mode ONLY_FULL_GROUP_BY.
+   * This function should be named supportsAnyValueAndEnforcesFullGroupBY(),
+   * but should be deprecated instead.
+   *
    * @return mixed
+   * @deprecated
    */
   public static function supportsFullGroupBy() {
-    return version_compare(CRM_Core_DAO::singleValueQuery('SELECT VERSION()'), '5.7', '>=');
+    // CRM-21455 MariaDB 10.2 does not support ANY_VALUE
+    $version = CRM_Core_DAO::singleValueQuery('SELECT VERSION()');
+
+    if (stripos('mariadb', $version) !== NULL) {
+      return FALSE;
+    }
+
+    return version_compare($version, '5.7', '>=');
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
MariaDB 10.2 does not support ANY_VALUE, however, `SELECT VERSION()` returns `10.2.10-MariaDB-10.2.10+maria~stretch`, to the version_compare to 5.7 would return true.

To see the error: open civicase. (CRM-21455 has more details)

---

 * [CRM-21455: supportsFullGroupBy: MariaDB 10.2 does not support ANY_VALUE](https://issues.civicrm.org/jira/browse/CRM-21455)