### PR TITLE
CRM-21457: Setting receipt date to current date when requesting a receipt to be emailed on Credit card contribution form.

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -191,6 +191,11 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     if ($paymentProcessorOutcome) {
       $contributionParams['payment_processor'] = CRM_Utils_Array::value('payment_processor', $paymentProcessorOutcome);
     }
+    if (!empty($params["is_email_receipt"])) {
+      $contributionParams += array(
+        'receipt_date' => $receiptDate,
+      );
+    }
     if (!$pending && $paymentProcessorOutcome) {
       $contributionParams += array(
         'fee_amount' => CRM_Utils_Array::value('fee_amount', $paymentProcessorOutcome),

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -232,14 +232,18 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
       $error = TRUE;
     }
 
-    $this->callAPISuccessGetCount('Contribution', array(
+    $contribution = $this->callAPISuccess('Contribution', 'get', array(
       'contact_id' => $this->_individualId,
       'contribution_status_id' => $error ? 'Failed' : 'Completed',
       'payment_instrument_id' => $this->callAPISuccessGetValue('PaymentProcessor', array(
         'return' => 'payment_instrument_id',
         'id' => $paymentProcessorID,
        )),
-    ), 1);
+    ));
+
+    $this->assertEquals(1, $contribution["count"], "Contribution count should be one.");
+    $this->assertTrue(!empty($contribution["values"][$contribution["id"]]["receipt_date"]), "Receipt date should not be blank.");
+
     $contact = $this->callAPISuccessGetSingle('Contact', array('id' => $this->_individualId));
     $this->assertTrue(empty($contact['source']));
     if (!$error) {


### PR DESCRIPTION
When submitting a credit card payment through the back-end, and requesting a receipt to be emailed, the payment is processed and receipt is sent successfully, but the receipt date is not being updated.

Steps to reproduce:
----------------------------------------
1. Go to contact record -> Contribution tab
2. Click Submit Credit Card Contribution
3. Fill in detail
4. Send Receipt is enabled
5. Payment processor is Credit card
6. Click Save
7. When click Edit that contribution record, Receipt date not showing up

Before
----------------------------------------
Receipt date was left blank.

After
----------------------------------------
Now we set receipt date to current datetime if user is requesting a receipt to be emailed.

_Agileware Ref: CIVICRM-741_

---

 * [CRM-21457: CIVICRM-741 Receipt date not updated when submitting a credit card payment from the back-end \(Contribution\)](https://issues.civicrm.org/jira/browse/CRM-21457)