### PR TITLE
CRM-21482 follow up notice fix - sync function signatures on getCurrency

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -375,11 +375,11 @@ WHERE  contribution_id = {$id}
   /**
    * Get current currency from DB or use default currency.
    *
-   * @param $submittedValues
+   * @param array $submittedValues
    *
-   * @return mixed
+   * @return string
    */
-  public function getCurrency($submittedValues) {
+  public function getCurrency($submittedValues = array()) {
     $config = CRM_Core_Config::singleton();
 
     $currentCurrency = CRM_Utils_Array::value('currency',

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -2366,8 +2366,15 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    * @todo this should be overriden on the forms rather than having this
    * historic, possible handling in here. As we clean that up we should
    * add deprecation notices into here.
+   *
+   * @param array $submittedValues
+   *   Array allowed so forms inheriting this class do not break.
+   *   Ideally we would make a clear standard around how submitted values
+   *   are stored (is $this->_values consistently doing that?).
+   *
+   * @return string
    */
-  public function getCurrency() {
+  public function getCurrency($submittedValues = array()) {
     $currency = CRM_Utils_Array::value('currency', $this->_values);
     // For event forms, currency is in a different spot
     if (empty($currency)) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a warning by syncing function signatures

Before
----------------------------------------
On back office contribution:

Warning: Declaration of CRM_Contribute_Form_AbstractEditPayment::getCurrency($submittedValues) should be compatible with CRM_Core_Form::getCurrency() in require_once() (line 48 of /Users/emcnaughton/buildkit/build/dmaster/sites/all/modules/civicrm/CRM/Contribute/Form/AbstractEditPayment.php).

After
----------------------------------------
Msg fixed

Technical Details
----------------------------------------
I'd really have liked to removed $submittedValues from the AbstractEditPayment class
but it felt too risky since there are a lot of unpredictable params in there.

Only CRM_Contribute_Form_Contribution actually calls that line.

Comments
----------------------------------------
@colemanw follow up on the patch you merged the other day

---

 * [CRM-21482: Allow retrieval of currency from $_REQUEST \(as supplied by webform_civicrm\)](https://issues.civicrm.org/jira/browse/CRM-21482)