### PR TITLE
CRM-21497 - crmRouteBinder: add deep comparison option

### DIFF
--- a/ang/crmRouteBinder.js
+++ b/ang/crmRouteBinder.js
@@ -51,6 +51,9 @@
 
         options.format = options.format || 'json';
         var fmt = formats[options.format];
+        if (options.deep) {
+          fmt.watcher = '$watch';
+        }
         if (options.default === undefined) {
           options.default = fmt.default;
         }
@@ -85,7 +88,7 @@
             activeTimer = null;
             ignorable = {};
           }, 50);
-        });
+        }, options.deep);
       };
 
       return $delegate;

--- a/ang/crmRouteBinder.md
+++ b/ang/crmRouteBinder.md
@@ -30,16 +30,18 @@ Things to try out:
 
 ## Functions
 
- * `$scope.$bindToRoute(options)`
-   * The `options` object should contain keys:
-     * `expr` (string): The name of a scoped variable to sync.
-     * `param` (string): The name of a query-parameter to sync. (If the `param` is included in the URL, it will initialize the expr.)
-     * `format` (string): The type of data to put in `param`. May be one of:
-       * `json` (default): The `param` is JSON, and the `expr` is a decoded object.
-       * `raw`: The `param` is string, and the `expr` is a string.
-       * `int`: the `param` is an integer-like string, and the expr is an integer.
-       * `bool`: The `param` is '0'/'1', and the `expr` is false/true.
-     * `default` (object): The default data. (If the `param` is not included in the URL, it will initialize the expr.)
+**`$scope.$bindToRoute(options)`**
+*The `options` object should contain keys:*
+
+ * `expr` (string): The name of a scoped variable to sync.
+ * `param` (string): The name of a query-parameter to sync. (If the `param` is included in the URL, it will initialize the expr.)
+ * `format` (string): The type of data to put in `param`. May be one of:
+    * `json` (default): The `param` is JSON, and the `expr` is a decoded object.
+    * `raw`: The `param` is string, and the `expr` is a string.
+    * `int`: the `param` is an integer-like string, and the expr is an integer.
+    * `bool`: The `param` is '0'/'1', and the `expr` is false/true.
+ * `default` (object): The default data. (If the `param` is not included in the URL, it will initialize the expr.)
+ * `deep` (boolean): By default the json format will be watched using a shallow comparison. For nested objects and arrays enable this option.
 
 ## Suggested Usage
 


### PR DESCRIPTION
Overview
----
This PR updates the crmRouteBinder angular directive to optionally perform deep comparisons on collections. It updates the docs as well.

Before
----
`$watchCollection` was used to watch arrays and objects which does not detect changes more than 1 level deep.

After
----
Optionally passing `deep: true` will use `$watch` in strict comparison mode. This is more memory intensive but the only way to keep track of nested objects.

* [CRM-21497: crmRouteBinder: add deep comparison option](https://issues.civicrm.org/jira/browse/CRM-21497)