### PR TITLE
Fix for mysql 5.7 crash due to not adding ANY_VALUE

### DIFF
--- a/CRM/Utils/SQL.php
+++ b/CRM/Utils/SQL.php
@@ -80,7 +80,7 @@ class CRM_Utils_SQL {
     // CRM-21455 MariaDB 10.2 does not support ANY_VALUE
     $version = CRM_Core_DAO::singleValueQuery('SELECT VERSION()');
 
-    if (stripos('mariadb', $version) !== NULL) {
+    if (stripos('mariadb', $version) !== FALSE) {
       return FALSE;
     }
 


### PR DESCRIPTION
ping @mlutfy @eileenmcnaughton i updated my local 5.7 test site and found it was crashing because it was no longer adding in the ANY_VALUE because it wasn't being treated as supporting full group by when it should.

According to http://php.net/manual/en/function.stripos.php stripos returns FALSE when it doesn't find it and the only issue here would be is if mariadb was at the very front of the string which i suspect it may not but not sure. Mathieu can you test on your mariadb
