### PR TITLE
CRM-21468: mailing recipients field limits how many groups can be selected

### DIFF
--- a/ang/crmMailing/Recipients.js
+++ b/ang/crmMailing/Recipients.js
@@ -146,9 +146,9 @@
               }
             }
 
-            CRM.api3('Group', 'getlist', { params: { id: { IN: gids } }, extra: ["is_hidden"] }).then(
+            CRM.api3('Group', 'getlist', { params: { id: { IN: gids }, options: { limit: 0 } }, extra: ["is_hidden"] } ).then(
               function(glist) {
-                CRM.api3('Mailing', 'getlist', { params: { id: { IN: mids } } }).then(
+                CRM.api3('Mailing', 'getlist', { params: { id: { IN: mids }, options: { limit: 0 } } }).then(
                   function(mlist) {
                     var datamap = [];
 


### PR DESCRIPTION
Overview
----------------------------------------
When creating a mailing, the mailing recipients group currently limits how many groups (or mailings) can be selected. It appears that the option in search preferences for "autocomplete results" is not only determining how many records appear in the search result dropdown at a time, but also limits how many options can be selected. It should not be doing that. We should also do a bit of investigation to see if that behavior is impacting other instances of the Select2 widget.

Before
----------------------------------------
Based on count set for "autocomplete results" say 2, you can select only two recipient groups in 'New Mailing' screen. 

After
----------------------------------------
Irrespective of count set for "autocomplete results", you can choose any number of recipient groups.

Technical Details
----------------------------------------
Issue encountered due to changes made to getlist API where it took the default value for limit from ```search_autocomplete_count``` setting and this is [point](https://github.com/civicrm/civicrm-core/blob/master/api/v3/Generic/Getlist.php#L110). As per the fix, we are overriding limit with 0/unlimited.

---

 * [CRM-21468: mailing recipients field limits how many groups can be selected](https://issues.civicrm.org/jira/browse/CRM-21468)