### PR TITLE
CRM-21498: Implement Option to Change Status of Linked Cases

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -2000,7 +2000,8 @@ SELECT civicrm_contact.id as casemanager_id,
     SELECT  relCase.id as id,
             civicrm_case_type.title as case_type,
             client.display_name as client_name,
-            client.id as client_id
+            client.id as client_id,
+            relCase.status_id
       FROM  civicrm_case relCase
  INNER JOIN  civicrm_case_contact relCaseContact ON ( relCase.id = relCaseContact.case_id )
  INNER JOIN  civicrm_contact      client         ON ( client.id = relCaseContact.contact_id )
@@ -2010,6 +2011,7 @@ SELECT civicrm_contact.id as casemanager_id,
     $dao = CRM_Core_DAO::executeQuery($query);
     $contactViewUrl = CRM_Utils_System::url("civicrm/contact/view", "reset=1&cid=");
     $hasViewContact = CRM_Core_Permission::giveMeAllACLs();
+    $statuses = CRM_Case_BAO_Case::buildOptions('status_id');
 
     while ($dao->fetch()) {
       $caseView = NULL;
@@ -2027,6 +2029,7 @@ SELECT civicrm_contact.id as casemanager_id,
         'case_id' => $dao->id,
         'case_type' => $dao->case_type,
         'client_name' => $clientView,
+        'case_status' => $statuses[$dao->status_id],
         'links' => $caseView,
       );
     }

--- a/CRM/Case/Form/Activity/ChangeCaseStatus.php
+++ b/CRM/Case/Form/Activity/ChangeCaseStatus.php
@@ -45,6 +45,12 @@ class CRM_Case_Form_Activity_ChangeCaseStatus {
     if (!isset($form->_caseId)) {
       CRM_Core_Error::fatal(ts('Case Id not found.'));
     }
+
+    $form->addElement('checkbox', 'updateLinkedCases', NULL, NULL, array('class' => 'select-row'));
+
+    $caseID = CRM_Utils_Array::first($form->_caseId);
+    $cases = CRM_Case_BAO_Case::getRelatedCases($caseID);
+    $form->assign('linkedCases', $cases);
   }
 
   /**
@@ -136,23 +142,33 @@ class CRM_Case_Form_Activity_ChangeCaseStatus {
   /**
    * Process the form submission.
    *
-   *
    * @param CRM_Core_Form $form
    * @param array $params
    */
   public static function beginPostProcess(&$form, &$params) {
     $params['id'] = CRM_Utils_Array::value('case_id', $params);
+
+    if ($params['updateLinkedCases'] === '1') {
+      $caseID = CRM_Utils_Array::first($form->_caseId);
+      $cases = CRM_Case_BAO_Case::getRelatedCases($caseID);
+
+      foreach ($cases as $currentCase) {
+        if ($currentCase['status_id'] != $params['case_status_id']) {
+          $form->_caseId[] = $currentCase['case_id'];
+        }
+      }
+    }
   }
 
   /**
    * Process the form submission.
-   *
    *
    * @param CRM_Core_Form $form
    * @param array $params
    * @param CRM_Activity_BAO_Activity $activity
    */
   public static function endPostProcess(&$form, &$params, $activity) {
+
     $groupingValues = CRM_Core_OptionGroup::values('case_status', FALSE, TRUE, FALSE, NULL, 'value');
 
     // Set case end_date if we're closing the case. Clear end_date if we're (re)opening it.

--- a/templates/CRM/Case/Form/Activity/ChangeCaseStatus.tpl
+++ b/templates/CRM/Case/Form/Activity/ChangeCaseStatus.tpl
@@ -24,14 +24,40 @@
  +--------------------------------------------------------------------+
 *}
 {* Template for "Change Case Status" activities. *}
-   <div class="crm-block crm-form-block crm-case-changecasestatus-form-block">
+  <div class="crm-block crm-form-block crm-case-changecasestatus-form-block">
     <tr class="crm-case-changecasestatus-form-block-case_status_id">
       <td class="label">{$form.case_status_id.label}</td>
-  <td>{$form.case_status_id.html}</td>
+      <td>{$form.case_status_id.html}</td>
     </tr>
+    {if sizeof($linkedCases) > 0}
+      <tr>
+        <td rowspan="2">{ts}Update Linked Cases Status?{/ts}</td>
+        <td>{$form.updateLinkedCases.html}</td>
+      </tr>
+      <tr>
+        <td>
+          <table>
+            <tr>
+              <th>ID</th>
+              <th>Case Client</th>
+              <th>Case Type</th>
+              <th>Status</th>
+            </tr>
+            {foreach from=$linkedCases item="linkedCase"}
+              <tr>
+                <td>{$linkedCase.case_id}</td>
+                <td>{$linkedCase.client_name}</td>
+                <td>{$linkedCase.case_type}</td>
+                <td>{$linkedCase.case_status}</td>
+              </tr>
+            {/foreach}
+          </table>
+        </td>
+      </tr>
+    {/if}
     {if $groupTree}
         <tr>
             <td colspan="2">{include file="CRM/Custom/Form/CustomData.tpl" noPostCustomButton=1}</td>
         </tr>
     {/if}
-   </div>
+  </div>


### PR DESCRIPTION
Overview
----------------------------------------
On some occasions, it might be useful when changing a case's status, to have all linked cases change status too.  For this, we could have a checkbox on the case status change form so that when it is checked, all related cases change to the same status.

We will only take into account directly linked cases (i.e. L1 link) and not the linked cases of the linked cases (i.e. ignore any nesting).

If the status of one or more linked cases is the same as the status the user is changing to (eg. the user is changing the status from ongoing to resolved and one of the linked cases is already resolved), we will still list the case in the case list, but there will be no action taken (ie. no activity should be created for the status change).

Before
----------------------------------------
When changing a case's status, if linked cases had to be changed too, you'd had to go to each case independently and change it's status manually.

![image](https://user-images.githubusercontent.com/21999940/33428728-04f5f158-d598-11e7-8fc6-329f78e5728d.png)

After
----------------------------------------
When changing a case's status, if it has any linked cases, a checkbox will appear on the form so the user can choose to update linked cases statuses too.

![image](https://user-images.githubusercontent.com/21999940/33428813-5569fb70-d598-11e7-85dc-de7b593a3e4f.png)

Comments
----------------------------------------
Changes to user documentation are being introduced in this PR:
https://github.com/civicrm/civicrm-user-guide/pull/244

---

 * [CRM-21498: Option to Change Status of Linked Cases](https://issues.civicrm.org/jira/browse/CRM-21498)