### PR TITLE
CRM-21495 - Visually freeze any settings overriden in civicrm.setting.php

### DIFF
--- a/CRM/Admin/Form/Setting.php
+++ b/CRM/Admin/Form/Setting.php
@@ -94,6 +94,7 @@ class CRM_Admin_Form_Setting extends CRM_Core_Form {
     );
 
     $descriptions = array();
+    global $civicrm_setting;
     $settingMetaData = $this->getSettingsMetaData();
     foreach ($settingMetaData as $setting => $props) {
       if (isset($props['quick_form_type'])) {
@@ -145,6 +146,10 @@ class CRM_Admin_Form_Setting extends CRM_Core_Form {
           $this->addRule('maxFileSize', ts('Value should be a positive number'), 'positiveInteger');
         }
 
+      }
+      // CRM-21495 (Respect settings override in civicrm.setting.php)
+      if (isset($civicrm_setting[$props['group_name']][$setting])) {
+        $this->getElement($setting)->freeze();
       }
     }
     // setting_description should be deprecated - see Mail.tpl for metadata based tpl.


### PR DESCRIPTION
Overview
----------------------------------------
Settings like turning logging on/off can be over-written in civicrm.setting.php but can be changed through UI as well as they are exposed.
The idea is to respect settings over-ridden in civicrm.setting.php. It can be achieved by checking if setting has been over-ridden then freeze it in the UI. This reduces the risk of accidentally having someone change the setting when it is not intended.

---

 * [CRM-21495: Respect settings over-ridden in civicrm.setting.php](https://issues.civicrm.org/jira/browse/CRM-21495)