### PR TITLE
CRM-21499: Add filter to manage tags page

### DIFF
--- a/templates/CRM/Tag/Page/Tag.tpl
+++ b/templates/CRM/Tag/Page/Tag.tpl
@@ -53,6 +53,7 @@
       <div class="help">
         {ts}Organize the tag hierarchy by clicking and dragging. Shift-click to select multiple tags to merge/move/delete.{/ts}
       </div>
+      <input class="crm-form-text big" name="filter_tag_tree" placeholder="{ts}Filter List{/ts}" allowclear="1"/>
     </div>
     {foreach from=$tagsets item=set}
       <div id="tagset-{$set.id}">
@@ -250,7 +251,7 @@
             }
           });
 
-        plugins = ['wholerow', 'changed'];
+        plugins = ['wholerow', 'changed', 'search'];
         if (!tagset) {
           // Allow drag-n-drop nesting of the tag tree
           plugins.push('dnd');
@@ -268,6 +269,10 @@
                 }
               },
               check_callback: true
+            },
+            'search': {
+              'case_insensitive' : true,
+              'show_only_matches': true
             },
             plugins: plugins,
             dnd: {
@@ -305,6 +310,9 @@
         });
 
       renderTree($('#tree'));
+      $('input[name=filter_tag_tree]').on('keyup change', function() {
+        $(".tag-tree").jstree("search", $(this).val());
+      });
 
       // Prevent the info box from scrolling offscreen
       $window.on('scroll resize', function () {


### PR DESCRIPTION
Overview
----------------------------------------
This PR is about adding filter box in 'Manage Tag' screen as we have under Tag tab on contact summary page.

Before
----------------------------------------
![screen shot 2017-11-30 at 6 56 36 pm](https://user-images.githubusercontent.com/3735621/33433121-650875da-d600-11e7-86d8-47c060d275ad.png)



After
----------------------------------------
![test-multiple-before](https://user-images.githubusercontent.com/3735621/33433025-1bcb94a6-d600-11e7-9e2a-0e88b6178255.gif)

---

 * [CRM-21499: Add filter to manage tags page](https://issues.civicrm.org/jira/browse/CRM-21499)