### PR TITLE
CRM-21494 trigger pre hook on mailing bounce

### DIFF
--- a/CRM/Mailing/Event/BAO/Bounce.php
+++ b/CRM/Mailing/Event/BAO/Bounce.php
@@ -61,6 +61,8 @@ class CRM_Mailing_Event_BAO_Bounce extends CRM_Mailing_Event_DAO_Bounce {
     $bounce = new CRM_Mailing_Event_BAO_Bounce();
     $bounce->time_stamp = date('YmdHis');
 
+    CRM_Utils_Hook::pre('create', 'MailingEventBounce', NULL, $params);
+
     // if we dont have a valid bounce type, we should set it
     // to bounce_type_id 11 which is Syntax error. this allows such email
     // addresses to be bounce a few more time before being put on hold

--- a/CRM/Mailing/Event/BAO/Bounce.php
+++ b/CRM/Mailing/Event/BAO/Bounce.php
@@ -61,7 +61,8 @@ class CRM_Mailing_Event_BAO_Bounce extends CRM_Mailing_Event_DAO_Bounce {
     $bounce = new CRM_Mailing_Event_BAO_Bounce();
     $bounce->time_stamp = date('YmdHis');
 
-    CRM_Utils_Hook::pre('create', 'MailingEventBounce', NULL, $params);
+    $action = empty($params['id']) ? 'create' : 'edit';
+    CRM_Utils_Hook::pre($action, 'MailingEventBounce', NULL, $params);
 
     // if we dont have a valid bounce type, we should set it
     // to bounce_type_id 11 which is Syntax error. this allows such email
@@ -81,6 +82,8 @@ class CRM_Mailing_Event_BAO_Bounce extends CRM_Mailing_Event_DAO_Bounce {
 
     $bounce->copyValues($params);
     $bounce->save();
+
+    CRM_Utils_Hook::post($action, 'MailingEventBounce', $bounce->id, $bounce);
 
     if ($q->email_id) {
       self::putEmailOnHold($q->email_id);

--- a/CRM/Mailing/Event/BAO/Bounce.php
+++ b/CRM/Mailing/Event/BAO/Bounce.php
@@ -62,7 +62,7 @@ class CRM_Mailing_Event_BAO_Bounce extends CRM_Mailing_Event_DAO_Bounce {
     $bounce->time_stamp = date('YmdHis');
 
     $action = empty($params['id']) ? 'create' : 'edit';
-    CRM_Utils_Hook::pre($action, 'MailingEventBounce', NULL, $params);
+    CRM_Utils_Hook::pre($action, 'MailingEventBounce', CRM_Utils_Array::value('id', $params), $params);
 
     // if we dont have a valid bounce type, we should set it
     // to bounce_type_id 11 which is Syntax error. this allows such email


### PR DESCRIPTION
Overview
----------------------------------------
This triggers the pre hook when a mailing bounce is processed, allowing you to modify the bounce type, parse the bounce reason in a custom manner, or perform other follow-up actions.

Implementation example
----------------------------------------
https://github.com/mountev/com.example.myextension/blob/master/myextension.php#L136

---

 * [CRM-21494: trigger pre hook on mailing bounce](https://issues.civicrm.org/jira/browse/CRM-21494)