### PR TITLE
CRM-21501 bounce report date filter type fix

### DIFF
--- a/CRM/Report/Form/Mailing/Bounce.php
+++ b/CRM/Report/Form/Mailing/Bounce.php
@@ -171,7 +171,7 @@ class CRM_Report_Form_Mailing_Bounce extends CRM_Report_Form {
         'time_stamp' => array(
           'title' => ts('Bounce Date'),
           'operatorType' => CRM_Report_Form::OP_DATE,
-          'type' => CRM_Utils_Type::T_DATE,
+          'type' => CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME,
         ),
       ),
       'order_bys' => array(


### PR DESCRIPTION
Overview
----------------------------------------
In the Mailing Bounce report, if you filter by the bounce date, the query construction only includes the date – no time value. As a result, the end date is not inclusive. To reproduce, filter on the relative date "Today."

Before
----------------------------------------
Filter by bounce date = Today. No records are returned. Analysis of the Developer tab confirms the date range is constructed without time values.

After
----------------------------------------
Time values included in the query where clause. Results are returned.

Technical Details
----------------------------------------
The filter declaration for this field needs to include both date and time.
