### PR TITLE
Changed getPatterns function

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -635,7 +635,7 @@ ORDER BY   i.contact_id, i.{$tempColumn}
     $punc = '.:?\-';
     $any = "{$letters}{$gunk}{$punc}";
     if ($onlyHrefs) {
-      $pattern = "\\bhref[ ]*=[ ]*([\"'])?(($protos:[$any]+?(?=[$punc]*[^$any]|$)))([\"'])?";
+      $pattern = "\\bhref[ ]*=[ ]*([\"'])?(($protos:[$any]+[$punc]*?(?=[$punc]*[^$any]|$)))([\"'])?";
     }
     else {
       $pattern = "\\b($protos:[$any]+?(?=[$punc]*[^$any]|$))";


### PR DESCRIPTION
URL's ending with a "-" are now parsed correctly.

Overview
----------------------------------------
URL's ending in a dash aren't parsed correctly. The ending dash is ignored and you end up with a URL that doesn't work.

An example URL: 
https://www.acco.be/nl-be/items/9789463440189/Je-kind-zindelijk-krijgen--Dat-doe-je-zo-
 
A dash is typically used for substituting spaces or other characters not allowed in URL's. In this case the ending exclamation mark.

Before
----------------------------------------
The output of the getPatterns function: 

- href="https://www.acco.be/nl-be/items/9789463440189/Je-kind-zindelijk-krijgen--Dat-doe-je-zo"
- "
- https://www.acco.be/nl-be/items/9789463440189/Je-kind-zindelijk-krijgen--Dat-doe-je-zo
- https://www.acco.be/nl-be/items/9789463440189/Je-kind-zindelijk-krijgen--Dat-doe-je-zo
- https
- "

After
----------------------------------------
The output of the getPatterns function: 

- href="https://www.acco.be/nl-be/items/9789463440189/Je-kind-zindelijk-krijgen--Dat-doe-je-zo-"
- "
- https://www.acco.be/nl-be/items/9789463440189/Je-kind-zindelijk-krijgen--Dat-doe-je-zo-
- https://www.acco.be/nl-be/items/9789463440189/Je-kind-zindelijk-krijgen--Dat-doe-je-zo-
- https
- "

Technical Details
----------------------------------------
To test this I used: [http://phpfiddle.org/lite](http://phpfiddle.org/lite)
with the following code sample:
<pre>
&lt;?php   
function getPatterns($onlyHrefs = FALSE) {
     $patterns = array();
     $protos = '(https?|ftp|mailto)';
     $letters = '\w';
     $gunk = '\{\}/#~:.?+=&amp;;%@!\,\-\|\(\)\*';
     $punc = '.:?\-';
     $any = &quot;{$letters}{$gunk}{$punc}&quot;;
     if ($onlyHrefs) {
       $pattern = &quot;\\bhref[ ]*=[ ]*([\&quot;'])?(($protos:[$any]+[$punc]*?(?=[$punc]*[^$any]|$)))([\&quot;'])?&quot;;
     }
     else {
       $pattern = &quot;\\b($protos:[$any]+?(?=[$punc]*[^$any]|$))&quot;;
     }
     $patterns[] = $pattern;
     $patterns[] = '\\\\\{\w+\.\w+\\\\\}|\{\{\w+\.\w+\}\}';
     $patterns[] = '\{\w+\.\w+\}';
     $patterns = '{' . implode('|', $patterns) . '}imu';
    return $patterns;
  }
    
    preg_match_all(getPatterns(TRUE), &quot;kfflsjldlllfjls&lt;a href=\&quot;https://www.acco.be/nl-be/items/9789463440189/Je-kind-zindelijk-krijgen--Dat-doe-je-zo-\&quot;&gt;linkje&lt;/a&gt;hhhdhdhd&quot;, $matches);

foreach ($matches as $value)
{
    foreach ($value as $value2)
{
echo($value2);
        echo(&quot;&lt;br/&gt;&quot;);
    }
}
?&gt;
</pre>