### PR TITLE
CRM-21504 Add membership to recurring contribution detail

### DIFF
--- a/CRM/Contribute/Page/ContributionRecur.php
+++ b/CRM/Contribute/Page/ContributionRecur.php
@@ -67,6 +67,16 @@ class CRM_Contribute_Page_ContributionRecur extends CRM_Core_Page {
         }
       }
 
+      // Add linked membership
+      $membership = civicrm_api3('Membership', 'get', array(
+        'contribution_recur_id' => $recur->id,
+      ));
+      if (!empty($membership['count'])) {
+        $membershipDetails = reset($membership['values']);
+        $values['membership_id'] = $membershipDetails['id'];
+        $values['membership_name'] = $membershipDetails['membership_name'];
+      }
+
       $this->assign('recur', $values);
     }
   }

--- a/templates/CRM/Contribute/Page/ContributionRecur.tpl
+++ b/templates/CRM/Contribute/Page/ContributionRecur.tpl
@@ -51,6 +51,11 @@
             {if $recur.payment_processor}<tr><td class="label">{ts}Payment Processor{/ts}</td><td>{$recur.payment_processor}</td></tr>{/if}
             {if $recur.financial_type}<tr><td class="label">{ts}Financial Type{/ts}</td><td>{$recur.financial_type}</td></tr>{/if}
             {if $recur.campaign}<tr><td class="label">{ts}Campaign{/ts}</td><td>{$recur.campaign}</td></tr>{/if}
+            {if $recur.membership_id}<tr>
+              <td class="label">{ts}Membership{/ts}</td>
+              <td><a class="crm-hover-button" href='{crmURL p="civicrm/contact/view/membership" q="action=view&reset=1&cid=`$contactId`&id=`$recur.membership_id`&context=membership&selectedChild=member"}'>{$recur.membership_name}</a></td>
+              </tr>
+            {/if}
           </table>
           <div class="crm-submit-buttons"><a class="button cancel crm-form-submit" href="{crmURL p='civicrm/contact/view' q='action=browse&selectedChild=contribute'}">{ts}Done{/ts}</a></div>
         </div>


### PR DESCRIPTION
Overview
----------------------------------------
It is not clear when viewing a recurring contribution whether it is linked to a membership.  This adds an extra row "Membership" which has a link to the actual membership record.

Before
----------------------------------------
No row for membership

After
----------------------------------------
Row and link to membership:
![localhost_8000_civicrm_contact_view_contributionrecur_reset 1 id 46 cid 203 context contribution](https://user-images.githubusercontent.com/2052161/33516898-1728a402-d772-11e7-8b74-ab431bd24b23.png)

---

 * [CRM-21504: Add membership to recurring contribution detail](https://issues.civicrm.org/jira/browse/CRM-21504)