### PR TITLE
CRM-21507 Fix error when creating case activities

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -119,6 +119,23 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
 
   protected $unsavedWarn = TRUE;
 
+  /*
+   * Is it possible to create separate activities with this form?
+   *
+   * When TRUE, the form will ask whether the user wants to create separate
+   * activities (if the user has specified multiple contacts in the "with"
+   * field).
+   *
+   * When FALSE, the form will create one activity with all contacts together
+   * and won't ask the user anything.
+   *
+   * Note: This is a class property so that child classes can turn off this
+   * behavior (e.g. in CRM_Case_Form_Activity)
+   *
+   * @var boolean
+   */
+  protected $supportsActivitySeparation = TRUE;
+
   /**
    * Explicitly declare the entity api name.
    *
@@ -839,12 +856,16 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
     if ((!empty($fields['followup_activity_subject']) || !empty($fields['followup_date'])) && empty($fields['followup_activity_type_id'])) {
       $errors['followup_activity_subject'] = ts('Follow-up Activity type is a required field.');
     }
+
+    // Check that a value has been set for the "activity separation" field if needed
+    $separationIsPossible = $self->supportsActivitySeparation;
     $actionIsAdd = $self->_action == CRM_Core_Action::ADD;
     $hasMultipleTargetContacts = !empty($fields['target_contact_id']) && strpos($fields['target_contact_id'], ',') !== FALSE;
     $separationFieldIsEmpty = empty($fields['separation']);
-    if ($actionIsAdd && $hasMultipleTargetContacts && $separationFieldIsEmpty) {
+    if ($separationIsPossible && $actionIsAdd && $hasMultipleTargetContacts && $separationFieldIsEmpty) {
       $errors['separation'] = ts('Activity Separation is a required field.');
     }
+
     return $errors;
   }
 

--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -719,8 +719,10 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
     }
     $this->assign('surveyActivity', $this->_isSurveyActivity);
 
-    // this option should be available only during add mode
-    if ($this->_action != CRM_Core_Action::UPDATE) {
+    // Add the "Activity Separation" field
+    $actionIsAdd = $this->_action != CRM_Core_Action::UPDATE;
+    $separationIsPossible = $this->supportsActivitySeparation;
+    if ($actionIsAdd && $separationIsPossible) {
       $this->addRadio(
         'separation',
         ts('Activity Separation'),

--- a/CRM/Case/Form/Activity.php
+++ b/CRM/Case/Form/Activity.php
@@ -197,6 +197,11 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
       }
     }
 
+    // Turn off the prompt which asks the user if they want to create separate
+    // activities when specifying multiple contacts "with" a new activity.
+    // Instead, always create one activity with all contacts together.
+    $this->supportsActivitySeparation = FALSE;
+
     $session = CRM_Core_Session::singleton();
     $session->pushUserContext($url);
   }

--- a/templates/CRM/Activity/Form/Activity.tpl
+++ b/templates/CRM/Activity/Form/Activity.tpl
@@ -81,7 +81,7 @@
     </td>
   </tr>
 
-  {if $action eq 1 or $single eq false}
+  {if $form.separation }
     <tr class="crm-activity-form-block-separation crm-is-multi-activity-wrapper">
       <td class="label">{$form.separation.label}</td>
       <td>{$form.separation.html} {help id="separation"}</td>


### PR DESCRIPTION
## Overview

This PR fixes a recent regression from #11264 as [described](https://github.com/civicrm/civicrm-core/pull/11264#issuecomment-344903418) by @jitendrapurohit where the user is unable to create new case activities.

## Before

When adding a new activity to a case, an error message "Activity Separation is a required field" appears and prevents the user from submitting the form. There is no way to get around this error.

## After

The user can create case activities without hitting this error message. Also the error still displays as expected when creating non-case activities that have multiple target contacts.

## Technical details

I wasn't entirely sure of the best way to implement this fix. I considered several different ways and weighed downsides of each. I'm open to other suggestions and further discussion here. 

## Comments

Sorry for the delay in getting this fix made! I think it'd be good if we could get this change reviewed/merged before cutting the RC. Otherwise we'll need to change this PR to the RC branch to avoid releasing a regression. 

* Ping @totten since you reviewed #11264 and thus are already familiar with this topic.

---

 * [CRM-21507: Unable to add multiple target contacts to a new case activity](https://issues.civicrm.org/jira/browse/CRM-21507)