### PR TITLE
CRM-21508 Fix column Information for civicrm_mailing.created_date pas…

### DIFF
--- a/CRM/Utils/Check/Component/Timestamps.php
+++ b/CRM/Utils/Check/Component/Timestamps.php
@@ -122,7 +122,7 @@ class CRM_Utils_Check_Component_Timestamps extends CRM_Utils_Check_Component {
       array('table' => 'civicrm_mailing_event_subscribe', 'column' => 'time_stamp', 'changed' => '4.7.20', 'default' => 'CURRENT_TIMESTAMP', 'jira' => 'CRM-9683', 'comment' => 'When this subscription event occurred.'),
       array('table' => 'civicrm_mailing_event_trackable_url_open', 'column' => 'time_stamp', 'changed' => '4.7.20', 'default' => 'CURRENT_TIMESTAMP', 'jira' => 'CRM-9683', 'comment' => 'When this trackable URL open occurred.'),
       array('table' => 'civicrm_mailing_event_unsubscribe', 'column' => 'time_stamp', 'changed' => '4.7.20', 'default' => 'CURRENT_TIMESTAMP', 'jira' => 'CRM-9683', 'comment' => 'When this delivery event occurred.'),
-      array('table' => 'civicrm_mailing', 'column' => 'created_date', 'changed' => '4.7.20', 'default' => 'CURRENT_TIMESTAMP', 'jira' => 'CRM-9683', 'comment' => 'Date and time this mailing was created.'),
+      array('table' => 'civicrm_mailing', 'column' => 'created_date', 'changed' => '4.7.20', 'jira' => 'CRM-9683', 'comment' => 'Date and time this mailing was created.'),
       array('table' => 'civicrm_mailing', 'column' => 'scheduled_date', 'changed' => '4.7.20', 'jira' => 'CRM-9683', 'comment' => 'Date and time this mailing was scheduled.'),
       array('table' => 'civicrm_mailing', 'column' => 'approval_date', 'changed' => '4.7.20', 'jira' => 'CRM-9683', 'comment' => 'Date and time this mailing was approved.'),
       array('table' => 'civicrm_mailing_abtest', 'column' => 'created_date', 'changed' => '4.7.20', 'default' => 'CURRENT_TIMESTAMP', 'jira' => 'CRM-9683', 'comment' => 'When was this item created'),


### PR DESCRIPTION
…sed to Docker When

Overview
----------------------------------------
When there was locking mechanisms attached to the civicrm_mailing table to prevent duplicate windows editing mailings. the created_date column was changed to default to NULL to satisfy older MySQL versions. This was not properly updated in the Docker When information array. 

Before
----------------------------------------
Docker When Fails to convert tables

After
----------------------------------------
Tables convert correctly

Technical Details
----------------------------------------
As part of 4.7.27 We converted the created_date column to be DEFAULT NULL so we could have a modified_date column which was ON UPDATE CURRENT_TIMESTAMP see https://github.com/civicrm/civicrm-core/blob/master/CRM/Upgrade/Incremental/php/FourSeven.php#L449 and https://github.com/civicrm/civicrm-core/blob/master/CRM/Upgrade/Incremental/php/FourSeven.php#L1382 However in the Timestamps.php array the default of CURRENT_TIMESTAMP was still set which caused this issue https://github.com/civicrm/org.civicrm.doctorwhen/issues/10

Comments
----------------------------------------
ping @totten @eileenmcnaughton @MegaphoneJon  I believe this is the solution to the problem, I have put it against the RC as it was a bug in 4.7.27

- [CRM-21508 civicrm_mailing.created_date information passed to Doctor When is incorrect](https://issues.civicrm.org/jira/browse/CRM-21508)