### PR TITLE
CRM-21509 - Add to Group in Top Donors report fails with DB error

### DIFF
--- a/CRM/Report/Form/Contribute/TopDonor.php
+++ b/CRM/Report/Form/Contribute/TopDonor.php
@@ -384,8 +384,8 @@ class CRM_Report_Form_Contribute_TopDonor extends CRM_Report_Form {
     //set the variable value rank, rows = 0
     $setVariable = " SET @rows:=0, @rank=0 ";
     CRM_Core_DAO::singleValueQuery($setVariable);
-
-    $sql = "SELECT * FROM ( {$this->_select} {$this->_from}  {$this->_where} {$this->_groupBy}
+    $select = str_ireplace('SELECT SQL_CALC_FOUND_ROWS ', 'SELECT ', $this->_select);
+    $sql = "SELECT * FROM ( {$select} {$this->_from}  {$this->_where} {$this->_groupBy}
                      ORDER BY civicrm_contribution_total_amount_sum DESC
                  ) as abc {$this->_outerCluase} $this->_limit
                ";
@@ -417,7 +417,7 @@ class CRM_Report_Form_Contribute_TopDonor extends CRM_Report_Form {
       $sql = "
 {$this->_select} {$this->_from}  {$this->_where} {$this->_groupBy}
 ORDER BY civicrm_contribution_total_amount_sum DESC
-) as abc {$this->_groupLimit}";
+  {$this->_groupLimit}";
       $dao = CRM_Core_DAO::executeQuery($sql);
 
       $contact_ids = array();


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate:

1. Go to Top Donors report and search for results
2. Add contacts to any group and you get this error

Before
----------------------------------------
![error](https://user-images.githubusercontent.com/3455173/33535334-0bec453c-d8d3-11e7-8f1a-23084ecddf57.png)

After
----------------------------------------
![top_donor](https://user-images.githubusercontent.com/3455173/33535533-2236eed6-d8d4-11e7-8919-957c1de9a864.png)

---

 * [CRM-21509: Add to Group in Top Donors report fails with DB error](https://issues.civicrm.org/jira/browse/CRM-21509)