### PR TITLE
CRM-21511 Add recurring contribution link to membership and contribution detail

### DIFF
--- a/CRM/Member/Form/MembershipView.php
+++ b/CRM/Member/Form/MembershipView.php
@@ -163,7 +163,7 @@ class CRM_Member_Form_MembershipView extends CRM_Core_Form {
         $finTypeId = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipType', $values['membership_type_id'], 'financial_type_id');
         $finType = CRM_Contribute_PseudoConstant::financialType($finTypeId);
         if (!CRM_Core_Permission::check('view contributions of type ' . $finType)) {
-          CRM_Core_Error::fatal(ts('You do not have permission to access this page.'));
+          CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
         }
       }
       else {

--- a/templates/CRM/Contribute/Form/ContributionView.tpl
+++ b/templates/CRM/Contribute/Form/ContributionView.tpl
@@ -95,7 +95,9 @@
                &nbsp; {$total_amount|crmMoney:$currency}
             </strong></a>&nbsp;
         {if $contribution_recur_id}
-          <strong>{ts}Recurring Contribution{/ts}</strong>
+          <a class="crm-hover-button" href='{crmURL p="civicrm/contact/view/contributionrecur" q="reset=1&id=`$contribution_recur_id`&cid=`$contact_id`&context=contribution"}'>
+            <strong>{ts}Recurring Contribution{/ts}</strong>
+          </a>
           <br/>
           {ts}Installments{/ts}: {if $recur_installments}{$recur_installments}{else}{ts}(ongoing){/ts}{/if}, {ts}Interval{/ts}: {$recur_frequency_interval} {$recur_frequency_unit}(s)
         {/if}

--- a/templates/CRM/Member/Form/MembershipView.tpl
+++ b/templates/CRM/Member/Form/MembershipView.tpl
@@ -61,6 +61,14 @@
         <tr><td class="label">{ts}Start date{/ts}</td><td>{$start_date|crmDate}</td></tr>
         <tr><td class="label">{ts}End date{/ts}</td><td>{$end_date|crmDate}</td></tr>
         <tr><td class="label">{ts}Auto-renew{/ts}</td><td>{$auto_renew}</td></tr>
+     {if $contribution_recur_id}
+          <tr>
+            <td class="label">{ts}Recurring Contribution{/ts}</td>
+            <td>
+              <a class="crm-hover-button" href='{crmURL p="civicrm/contact/view/contributionrecur" q="reset=1&id=`$recurContribution`&cid=`$contactId`&context=contribution"}'>View Recurring Contribution</a>
+            </td>
+          </tr>
+     {/if}
     </table>
 
     {include file="CRM/Custom/Page/CustomDataView.tpl"}


### PR DESCRIPTION
Overview
----------------------------------------
Follow-on from CRM-21504.  Add link to recurring contribution from membership detail and contribution detail.

Before
----------------------------------------
Not easy to see/access recurring contribution from membership detail/contribution detail.

After
----------------------------------------
(Note: screenshots are from a shoreditch theme so do not look perfect!)

Added "Recurring Contribution" line:
![localhost_8000_civicrm_contact_view_membership_action view reset 1 cid 203 id 42 context membership selectedchild member](https://user-images.githubusercontent.com/2052161/33550853-4d071f42-d8e7-11e7-8767-09bd28f19211.png)

"Recurring contribution" is now a link:
![localhost_8000_civicrm_contact_view_contribution](https://user-images.githubusercontent.com/2052161/33550854-4d2ad4c8-d8e7-11e7-9f06-bf4585b06441.png)

---

 * [CRM-21511: Add recurring contribution to membership detail and contribution](https://issues.civicrm.org/jira/browse/CRM-21511)
 * [CRM-21504: Add membership to recurring contribution detail](https://issues.civicrm.org/jira/browse/CRM-21504)