### PR TITLE
CRM-21512 Remove restriction on 'Update Subscription' when a recurring contribu…

### DIFF
--- a/CRM/Contribute/Form/UpdateSubscription.php
+++ b/CRM/Contribute/Form/UpdateSubscription.php
@@ -107,7 +107,17 @@ class CRM_Contribute_Form_UpdateSubscription extends CRM_Core_Form {
     }
 
     if ($this->_subscriptionDetails->membership_id && $this->_subscriptionDetails->auto_renew) {
-      CRM_Core_Error::statusBounce(ts('You cannot update the subscription.'));
+      // Add Membership details to form
+      $membership = civicrm_api3('Membership', 'get', array(
+        'contribution_recur_id' => $this->contributionRecurID,
+      ));
+      if (!empty($membership['count'])) {
+        $membershipDetails = reset($membership['values']);
+        $values['membership_id'] = $membershipDetails['id'];
+        $values['membership_name'] = $membershipDetails['membership_name'];
+      }
+      $this->assign('recurMembership', $values);
+      $this->assign('contactId', $this->_subscriptionDetails->contact_id);
     }
 
     if (!CRM_Core_Permission::check('edit contributions')) {

--- a/templates/CRM/Contribute/Form/UpdateSubscription.tpl
+++ b/templates/CRM/Contribute/Form/UpdateSubscription.tpl
@@ -27,7 +27,12 @@
   {if $changeHelpText}
     <div class="help">
       {$changeHelpText}
-  </div>
+      {if $recurMembership}
+        <br/><strong> {ts}'WARNING: This recurring contribution is linked to membership:{/ts}
+        <a class="crm-hover-button" href='{crmURL p="civicrm/contact/view/membership" q="action=view&reset=1&cid=`$contactId`&id=`$recurMembership.membership_id`&context=membership&selectedChild=member"}'>{$recurMembership.membership_name}</a>
+        </strong>
+      {/if}
+    </div>
   {/if}
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
   <table class="form-layout">


### PR DESCRIPTION
…tion has a linked membership

Overview
----------------------------------------
Currently the "Update Subscription" (ie. Edit Recurring Contribution) is not allowed when the recurring contribution is linked to a membership.
This is inconsistent with the "Change Billing Details" option which is allowed at all times and is unclear as to why it is not allowed (as it works fine with a supported payment processor).

Before
----------------------------------------
Error message when you click "Edit" on a recurring contribution from the contact summary - "You cannot update the subscription".

After
----------------------------------------
You can update the subscription.  A warning is shown on the "Update Subscription" form to show that it is linked to a membership:
![localhost_8000_civicrm_contact_view_reset 1 cid 203](https://user-images.githubusercontent.com/2052161/33551186-6fe97cfc-d8e8-11e7-8e4e-abd48ccb531d.png)

Comments
----------------------------------------
This is a (non-breaking) change in behaviour so should be flagged clearly in the release notes.
