### PR TITLE
CRM-21499: Add filter for tagset page

### DIFF
--- a/templates/CRM/Tag/Page/Tag.tpl
+++ b/templates/CRM/Tag/Page/Tag.tpl
@@ -196,6 +196,7 @@
 
         if (tagset) {
           addHelp();
+          $panel.append('<input class="crm-form-text big" name="filter_tag_tree" placeholder="' + ts('Filter List') + '" allowclear="1"/>');
         }
 
         function moveTagDialog(e) {
@@ -279,6 +280,10 @@
               copy: false
             }
           });
+
+        $('input[name=filter_tag_tree]', $panel).on('keyup change', function() {
+          $(".tag-tree", $panel).jstree("search", $(this).val());
+        });
       }
 
       function newTagset() {
@@ -310,9 +315,6 @@
         });
 
       renderTree($('#tree'));
-      $('input[name=filter_tag_tree]').on('keyup change', function() {
-        $(".tag-tree").jstree("search", $(this).val());
-      });
 
       // Prevent the info box from scrolling offscreen
       $window.on('scroll resize', function () {

--- a/templates/CRM/Tag/Page/Tag.tpl
+++ b/templates/CRM/Tag/Page/Tag.tpl
@@ -54,6 +54,7 @@
         {ts}Organize the tag hierarchy by clicking and dragging. Shift-click to select multiple tags to merge/move/delete.{/ts}
       </div>
       <input class="crm-form-text big" name="filter_tag_tree" placeholder="{ts}Filter List{/ts}" allowclear="1"/>
+      <a class="crm-hover-button crm-clear-link" style="visibility:hidden;" title="{ts}Clear{/ts}"><i class="crm-i fa-times"></i></a>
     </div>
     {foreach from=$tagsets item=set}
       <div id="tagset-{$set.id}">
@@ -77,7 +78,7 @@
         noneSelectedTpl = _.template($('#noneSelectedTpl').html()),
         oneSelectedTpl = _.template($('#oneSelectedTpl').html()),
         moreSelectedTpl = _.template($('#moreSelectedTpl').html()),
-        tagsetHelpTpl = _.template($('#tagsetHelpTpl').html());
+        tagsetHeaderTpl = _.template($('#tagsetHeaderTpl').html());
 
       function formatTagSet(info) {
         info.date = CRM.utils.formatDate(info.created_date);
@@ -183,20 +184,20 @@
           tagSets[tagset].used_for = info.used_for;
           tagSets[tagset].is_reserved = info.is_reserved;
           formatTagSet(tagSets[tagset]);
-          $('.help', $panel).remove();
-          addHelp();
+          addTagsetHeader();
+          $(".tag-tree", $panel).jstree("search", '');
         }
 
-        function addHelp() {
-          $panel.prepend(tagsetHelpTpl(tagSets[tagset]));
+        function addTagsetHeader() {
+          $('.tagset-header', $panel).remove();
+          $panel.prepend(tagsetHeaderTpl(tagSets[tagset]));
           $("a[href='#tagset-" + tagset + "']").text(tagSets[tagset].name)
             .parent().toggleClass('is-reserved', tagSets[tagset].is_reserved == 1)
             .attr('title', ts('{/literal}{ts escape='js' 1='%1'}Tag Set for %1{/ts}{literal}', {'1': tagSets[tagset].used_for_label.join(', ')}));
         }
 
         if (tagset) {
-          addHelp();
-          $panel.append('<input class="crm-form-text big" name="filter_tag_tree" placeholder="' + ts('Filter List') + '" allowclear="1"/>');
+          addTagsetHeader();
         }
 
         function moveTagDialog(e) {
@@ -531,11 +532,15 @@
   </div>
 </script>
 
-<script type="text/template" id="tagsetHelpTpl">
-  <div class="help">
-    <% if(is_reserved == 1) {ldelim} %><strong>{ts}Reserved{/ts}</strong><% {rdelim} %>
-    <% if(undefined === display_name) {ldelim} var display_name = null; {rdelim} %>
-    {ts 1="<%= used_for_label.join(', ') %>" 2="<%= date %>" 3="<%= display_name %>"}Tag Set for %1 (created %2 by %3).{/ts}
-    <% if(typeof description === 'string' && description.length) {ldelim} %><p><em><%- description %></em></p><% {rdelim} %>
+<script type="text/template" id="tagsetHeaderTpl">
+  <div class="tagset-header">
+    <div class="help">
+      <% if(is_reserved == 1) {ldelim} %><strong>{ts}Reserved{/ts}</strong><% {rdelim} %>
+      <% if(undefined === display_name) {ldelim} var display_name = null; {rdelim} %>
+      {ts 1="<%= used_for_label.join(', ') %>" 2="<%= date %>" 3="<%= display_name %>"}Tag Set for %1 (created %2 by %3).{/ts}
+      <% if(typeof description === 'string' && description.length) {ldelim} %><p><em><%- description %></em></p><% {rdelim} %>
+    </div>
+    <input class="crm-form-text big" name="filter_tag_tree" placeholder="{ts}Filter List{/ts}" allowclear="1"/>
+    <a class="crm-hover-button crm-clear-link" style="visibility:hidden;" title="{ts}Clear{/ts}"><i class="crm-i fa-times"></i></a>
   </div>
 </script>


### PR DESCRIPTION
Overview
----------------------------------------
This is a followup PR of #11352 to add filter for TagSet forms too. 

After
----------------------------------------
![test-multiple-before](https://user-images.githubusercontent.com/3735621/33576034-96a9ae8a-d964-11e7-8574-84c1e4bf934b.gif)

---

 * [CRM-21499: Add filter to manage tags page](https://issues.civicrm.org/jira/browse/CRM-21499)