### PR TITLE
Add API parameter for fix_address

### DIFF
--- a/api/v3/Address.php
+++ b/api/v3/Address.php
@@ -76,11 +76,15 @@ function civicrm_api3_address_create(&$params) {
     $params['check_permissions'] = 0;
   }
 
+  if (!isset($params['fix_address'])) {
+    $params['fix_address'] = TRUE;
+  }
+
   /**
    * Create array for BAO (expects address params in as an
    * element in array 'address'
    */
-  $addressBAO = CRM_Core_BAO_Address::add($params, TRUE);
+  $addressBAO = CRM_Core_BAO_Address::add($params, $params['fix_address']);
   if (empty($addressBAO)) {
     return civicrm_api3_create_error("Address is not created or updated ");
   }
@@ -109,6 +113,12 @@ function _civicrm_api3_address_create_spec(&$params) {
     'description' => 'Optional param to indicate you want to skip geocoding (useful when importing a lot of addresses
       at once, the job \'Geocode and Parse Addresses\' can execute this task after the import)',
     'type' => CRM_Utils_Type::T_BOOLEAN,
+  );
+  $params['fix_address'] = array(
+    'title' => ts('Fix address'),
+    'description' => ts('When true, apply various fixes to the address before insert. Default true.'),
+    'type' => CRM_Utils_Type::T_BOOLEAN,
+    'api.default' => TRUE,
   );
   $params['world_region'] = array(
     'title' => ts('World Region'),


### PR DESCRIPTION
Overview
----------------------------------------
Expose fix_address parameter in mailing address creation API call

Before
----------------------------------------
Every address created via API has fixes applied to it, adding potentially unnecessary database overhead.

After
----------------------------------------
Address creation API calls can include 'fix_address' => FALSE to skip fixes.

Technical Details
----------------------------------------
Simply exposes the existing second parameter to CRM_Core_BAO_Address::add.

Comments
----------------------------------------
Already in use at the Wikimedia Foundation, seems to be working fine.
