### PR TITLE
CRM-21523 add form rule for repetition fields in scheduled reminder form

### DIFF
--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -349,6 +349,13 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
       $errors[$recipientKind[$fields['recipient']]['target_id']] = ts('If "Also include" or "Limit to" are selected, you must specify at least one %1', array(1 => $recipientKind[$fields['recipient']]['name']));
     }
 
+    //CRM-21523
+    if (!empty($fields['is_repeat']) &&
+      (empty($fields['repetition_frequency_interval']) || ($fields['end_frequency_interval'] == NULL))
+    ) {
+      $errors['is_repeat'] = ts('If you are enabling repetition you must indicate the frequency and ending term.');
+    }
+
     $actionSchedule = $self->parseActionSchedule($fields);
     if ($actionSchedule->mapping_id) {
       $mapping = CRM_Core_BAO_ActionSchedule::getMapping($actionSchedule->mapping_id);

--- a/templates/CRM/Admin/Form/ScheduleReminders.tpl
+++ b/templates/CRM/Admin/Form/ScheduleReminders.tpl
@@ -60,11 +60,11 @@
     <tr id="repeatFields" class="crm-scheduleReminder-form-block-repeatFields"><td></td><td>
         <table class="form-layout-compressed">
           <tr class="crm-scheduleReminder-form-block-repetition_frequency_interval">
-            <td class="label">{$form.repetition_frequency_interval.label}&nbsp;&nbsp;&nbsp;{$form.repetition_frequency_interval.html}</td>
+            <td class="label">{$form.repetition_frequency_interval.label} <span class="crm-marker">*</span>&nbsp;&nbsp;{$form.repetition_frequency_interval.html}</td>
           <td>{$form.repetition_frequency_unit.html}</td>
           </tr>
           <tr class="crm-scheduleReminder-form-block-repetition_frequency_interval">
-             <td class="label">{$form.end_frequency_interval.label}&nbsp;&nbsp;&nbsp;{$form.end_frequency_interval.html}
+             <td class="label">{$form.end_frequency_interval.label} <span class="crm-marker">*</span>&nbsp;&nbsp;{$form.end_frequency_interval.html}
            <td>{$form.end_frequency_unit.html}&nbsp;&nbsp;&nbsp;{$form.end_action.html}&nbsp;&nbsp;&nbsp;{$form.end_date.html}</td>
           </tr>
         </table>


### PR DESCRIPTION
Overview
----------------------------------------
Add form rule to schedule reminder form to require both frequency interval fields if repetition is enabled.

Before
----------------------------------------
Frequency interval fields were not required. If the value was left blank it caused an SQL error when the scheduled reminder job was triggered.

After
----------------------------------------
User must enter a value for both fields. No SQL error generated.

Technical Details
----------------------------------------
The rule is slightly different for the two fields. For repetition_frequency_interval we require a non-null/non-zero value as the frequency of the repetition must be a meaningful value. For end_frequency_interval (until...) we allow a zero value, as that is a valid use case.

---

 * [CRM-21523: scheduled reminders: when using repetition, require frequency intervals](https://issues.civicrm.org/jira/browse/CRM-21523)