### PR TITLE
CRM-21093: Call ->initialize() on the CiviCRM service now that Drupal 8 module has changed

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -459,7 +459,7 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     \Drupal\Core\DrupalKernel::createFromRequest($request, $autoloader, 'prod')->prepareLegacyRequest($request);
 
     // Initialize Civicrm
-    \Drupal::service('civicrm');
+    \Drupal::service('civicrm')->initialize();
 
     // We need to call the config hook again, since we now know
     // all the modules that are listening on it (CRM-8655).


### PR DESCRIPTION
While working on something in `CRM_Util_System_Drupal8`, I noticed that the `::loadBootstrap()` method was getting the 'civicrm' service as a means to initialized CiviCRM, however, in https://github.com/civicrm/civicrm-drupal/pull/495 we moved actual initialization to the `initialize()` method. The joy of circular dependencies! :-)

This PR simply adds the `->initialize()` call. I searched for other instances that were missing this in civicrm-core, but couldn't find any

---

 * [CRM-21093: Move CiviCRM initialization out of service constructor \(in Drupal 8\) and into method](https://issues.civicrm.org/jira/browse/CRM-21093)