### PR TITLE
CRM-21527 - Add default to extra address::create param

### DIFF
--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -134,7 +134,7 @@ class CRM_Core_BAO_Address extends CRM_Core_DAO_Address {
    *
    * @return CRM_Core_BAO_Address|null
    */
-  public static function add(&$params, $fixAddress) {
+  public static function add(&$params, $fixAddress = FALSE) {
 
     $address = new CRM_Core_DAO_Address();
     $checkPermissions = isset($params['check_permissions']) ? $params['check_permissions'] : TRUE;


### PR DESCRIPTION
NFC to improve standardization across BAOs. Most BAO::create() functions require only 1 param. Address was an oddball; now less so.

* [CRM-21527: Add default to extra address::create param](https://issues.civicrm.org/jira/browse/CRM-21527)