### PR TITLE
Revert 8837 - Fix "Membership Detail" regression

### DIFF
--- a/CRM/Report/Form/Member/Detail.php
+++ b/CRM/Report/Form/Member/Detail.php
@@ -513,14 +513,14 @@ class CRM_Report_Form_Member_Detail extends CRM_Report_Form {
     }
     $tempTable = CRM_Core_DAO::createTempTableName('civicrm_report_memcontr', TRUE);
     $sql = "
-      CREATE TEMPORARY TABLE $tempTable (INDEX (entity_id, contact_id, receive_date))
+      CREATE TEMPORARY TABLE $tempTable (index (contact_id, receive_date, entity_id))
       SELECT cc.contact_id, max(cc.receive_date) as receive_date, cmp.membership_id as entity_id
       FROM civicrm_membership_payment cmp
       INNER JOIN civicrm_contribution cc
       ON cc.id = cmp.contribution_id
       WHERE cc.is_test = 0
       $dateWhere
-      GROUP BY cmp.membership_id";
+      GROUP BY cc.contact_id";
     CRM_Core_DAO::executeQuery($sql);
     return $tempTable;
   }


### PR DESCRIPTION
Revert #8837.

While reviewing test results for 4.7.28-rc, we wanted to verify that the test regressions reported on Ubuntu 16.04 (MySQL 5.7) were either (a) true regressions or (b) false regressions. 

So I manually re-tested the following configurations:

```
mysql=5.7.20, civi=4.7.28-rc(aca380ddf), isDev=TRUE         "Membership Detail"=>Crashes
mysql=5.7.20, civi=4.7.28-rc(aca380ddf), isDev=FALSE        "Membership Detail"=>Crashes
mysql=5.7.20, civi=4.7.28-rc(revert 8837), isDev=TRUE     "Membership Detail"=>Works
mysql=5.7.20, civi=4.7.28-rc(revert 8837), isDev=FALSE    "Membership Detail"=>Works
mysql=5.7.20, civi=4.7.27, isDev=TRUE                     "Membership Detail"=>Works
mysql=5.7.20, civi=4.7.27, isDev=FALSE                    "Membership Detail"=>Works
```