### PR TITLE
CRM-21530 - Call post hook after linking activity to the case

### DIFF
--- a/CRM/Activity/Page/AJAX.php
+++ b/CRM/Activity/Page/AJAX.php
@@ -381,10 +381,11 @@ class CRM_Activity_Page_AJAX {
     $caseActivity->activity_id = $mainActivityId;
     $caseActivity->save();
     $error_msg = $caseActivity->_lastError;
-    $caseActivity->free();
 
     $params['mainActivityId'] = $mainActivityId;
     CRM_Activity_BAO_Activity::copyExtendedActivityData($params);
+    CRM_Utils_Hook::post('create', 'CaseActivity', $caseActivity->id, $caseActivity);
+    $caseActivity->free();
 
     return (array('error_msg' => $error_msg, 'newId' => $mainActivity->id));
   }


### PR DESCRIPTION
Overview
----------------------------------------
Call post hook after "File on Case" task is performed on a non-case activity.

Before
----------------------------------------
DB insert is done which creates the activity and links it with the case. This does not invoke any post hook.

After
----------------------------------------
Post hook is called and works fine.

https://issues.civicrm.org/jira/browse/CRM-21530