### PR TITLE
CRM-21535: Custom file upload field not showing up when Viewing Activity from Case Report.

### DIFF
--- a/CRM/Case/XMLProcessor/Report.php
+++ b/CRM/Case/XMLProcessor/Report.php
@@ -558,7 +558,7 @@ WHERE      a.id = %1
             $value = $dao->$columnName;
           }
           else {
-            $value = CRM_Core_BAO_CustomField::displayValue($dao->$columnName, $typeValue['fieldID']);
+            $value = CRM_Core_BAO_CustomField::displayValue($dao->$columnName, $typeValue['fieldID'], $activityDAO->id);
           }
 
           if ($value) {
@@ -571,10 +571,6 @@ WHERE      a.id = %1
               CRM_Utils_Array::value('type', $typeValue) == 'Memo'
             ) {
               $value = $this->redact($value);
-            }
-            elseif (CRM_Utils_Array::value('type', $typeValue) == 'File') {
-              $tableName = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_EntityFile', $typeValue, 'entity_table');
-              $value = CRM_Core_BAO_File::attachmentInfo($tableName, $activityDAO->id);
             }
             elseif (CRM_Utils_Array::value('type', $typeValue) == 'Link') {
               $value = CRM_Utils_System::formatWikiURL($value);

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1141,12 +1141,12 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
   /**
    * @param string|int|array|null $value
    * @param CRM_Core_BAO_CustomField|int|array|string $field
-   * @param $contactId
+   * @param int $entityId
    *
    * @return string
    * @throws \Exception
    */
-  public static function displayValue($value, $field, $contactId = NULL) {
+  public static function displayValue($value, $field, $entityId = NULL) {
     $field = is_array($field) ? $field['id'] : $field;
     $fieldId = is_object($field) ? $field->id : (int) str_replace('custom_', '', $field);
 
@@ -1160,7 +1160,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
 
     $fieldInfo = array('options' => $field->getOptions()) + (array) $field;
 
-    return self::formatDisplayValue($value, $fieldInfo, $contactId);
+    return self::formatDisplayValue($value, $fieldInfo, $entityId);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Steps to reproduce the bug:

1. Create two custom fields, both of type file (Attachments) that use for Activities
2. Create new case and upload files in those couple of fields.
3. Open("View") the Last activity of type "Open Case"
4. In the recent builds you can see the files, but two files are listed under both custom fields. Which is not correct, we should only see single file in front of each custom field. In previous builds the values doesn't show up at all.
5. Click on edit activity icon, you can see both the files are attached separably on each custom field. 

Before
----------------------------------------
Files displays multiple times or doesn't display at all, where as when viewing same activity from activity search page It's working as expected.

After
----------------------------------------
Files for each custom field gets display in front of them.

_Agileware Ref: CIVICRM-754_

---

 * [CRM-21535: CIVICRM-754: Custom file upload field not showing up when Viewing Activity from Case Report](https://issues.civicrm.org/jira/browse/CRM-21535)