### PR TITLE
CRM-21531 - replace regex with POSIX-compliant alternative for MariaD…

### DIFF
--- a/CRM/Core/BAO/CustomQuery.php
+++ b/CRM/Core/BAO/CustomQuery.php
@@ -360,7 +360,7 @@ SELECT f.id, f.label, f.data_type,
               if ($isSerialized && !CRM_Utils_System::isNull($value) && !strstr($op, 'NULL') && !strstr($op, 'LIKE')) {
                 $sp = CRM_Core_DAO::VALUE_SEPARATOR;
                 $value = str_replace(",", "$sp|$sp", $value);
-                $value = str_replace(array('[:comma:]', '(', ')'), array(',', '[[.left-parenthesis.]]', '[[.right-parenthesis.]]'), $value);
+                $value = str_replace(array('[:comma:]', '(', ')'), array(',', '[(]', '[)]'), $value);
 
                 $op = (strstr($op, '!') || strstr($op, 'NOT')) ? 'NOT RLIKE' : 'RLIKE';
                 $value = $sp . $value . $sp;


### PR DESCRIPTION
…B compatibility

Overview
----------------------------------------
MySQL and MariaDB use different regex libraries. Certain non-POSIX regex statements will cause MariaDB to fail to execute a query, crashing CiviCRM. See https://jira.mariadb.org/browse/MDEV-7127 for details.

Before
----------------------------------------
Searching for a multi-select custom field value that contained a parenthesis would succeed on MySQL and fails on MariaDB with the error: "POSIX collating elements are not supported".

After
----------------------------------------
The search succeeds on both MySQL and MariaDB.
