### PR TITLE
CRM-21533 : Outbound setting reverts in non-production sites on execu…

### DIFF
--- a/CRM/Core/JobManager.php
+++ b/CRM/Core/JobManager.php
@@ -149,6 +149,12 @@ class CRM_Core_JobManager {
     }
     $this->logEntry('Finished execution of ' . $job->name . ' with result: ' . $this->_apiResultToMessage($result));
     $this->currentJob = FALSE;
+
+    //Disable outBound option after executing the job.
+    $environment = CRM_Core_Config::environment(NULL, TRUE);
+    if ($environment != 'Production' && !empty($job->apiParams['runInNonProductionEnvironment'])) {
+      Civi::settings()->set('mailing_backend', array('outBound_option' => CRM_Mailing_Config::OUTBOUND_OPTION_DISABLED));
+    }
   }
 
   /**

--- a/tests/phpunit/api/v3/JobProcessMailingTest.php
+++ b/tests/phpunit/api/v3/JobProcessMailingTest.php
@@ -118,6 +118,10 @@ class api_v3_JobProcessMailingTest extends CiviUnitTestCase {
       'environment' => 'Staging',
     );
     $this->callAPISuccess('Setting', 'create', $params);
+    //Assert if outbound mail is disabled.
+    $mailingBackend = Civi::settings()->get('mailing_backend');
+    $this->assertEquals($mailingBackend['outBound_option'], CRM_Mailing_Config::OUTBOUND_OPTION_DISABLED);
+
     $this->createContactsInGroup(10, $this->_groupID);
     Civi::settings()->add(array(
       'mailerBatchLimit' => 2,
@@ -129,6 +133,21 @@ class api_v3_JobProcessMailingTest extends CiviUnitTestCase {
     // Test with runInNonProductionEnvironment param.
     $this->callAPISuccess('job', 'process_mailing', array('runInNonProductionEnvironment' => TRUE));
     $this->_mut->assertRecipients($this->getRecipients(1, 2));
+
+    $jobId = $this->callAPISuccessGetValue('Job', array(
+      'return' => "id",
+      'api_action' => "group_rebuild",
+    ));
+    $this->callAPISuccess('Job', 'create', array(
+      'id' => $jobId,
+      'parameters' => "runInNonProductionEnvironment=TRUE",
+    ));
+    $jobManager = new CRM_Core_JobManager();
+    $jobManager->executeJobById($jobId);
+
+    //Assert if outbound mail is still disabled.
+    $mailingBackend = Civi::settings()->get('mailing_backend');
+    $this->assertEquals($mailingBackend['outBound_option'], CRM_Mailing_Config::OUTBOUND_OPTION_DISABLED);
 
     // Test in production mode.
     $params = array(


### PR DESCRIPTION
…ting sched job

Overview
----------------------------------------
Disable outbound mail on non-production sites after executing schedule job.

Before
----------------------------------------
If a site is changed to development mode using the [newly added setting](http://dmaster.demo.civicrm.org/civicrm/admin/setting/debug?reset=1), outbound mail gets disabled in http://dmaster.demo.civicrm.org/civicrm/admin/setting/smtp?reset=1 (correct).

Now, when a scheduled job is executed using `runInNonProductionEnvironment` parameter, it reverts the outbound setting to `mail()`(or its original value). 

More details on the Jira issue of how to replicate etc.

After
----------------------------------------
Outbound mail setting is disabled after job execution is completed on non-production sites.

Comments
----------------------------------------
Unit test added.

https://issues.civicrm.org/jira/browse/CRM-21533