### PR TITLE
CRM-21534 - Fix invocation of test for MariaDB

### DIFF
--- a/CRM/Utils/SQL.php
+++ b/CRM/Utils/SQL.php
@@ -80,7 +80,7 @@ class CRM_Utils_SQL {
     // CRM-21455 MariaDB 10.2 does not support ANY_VALUE
     $version = CRM_Core_DAO::singleValueQuery('SELECT VERSION()');
 
-    if (stripos('mariadb', $version) !== FALSE) {
+    if (stripos($version, 'mariadb') !== FALSE) {
       return FALSE;
     }
 


### PR DESCRIPTION
Function call incorrect as the string being looked in is meant to be first param ping @mlutfy @totten

---

 * [CRM-21534: Key UI elements fail when fetching activity records from MariaDB](https://issues.civicrm.org/jira/browse/CRM-21534)