### PR TITLE
CRM-21539: Fixed structure for administrative pages

### DIFF
--- a/ang/crmCxn/ManageCtrl.html
+++ b/ang/crmCxn/ManageCtrl.html
@@ -84,6 +84,7 @@
 <div ng-show="hasAvailApps()">
   <span crm-ui-order="{var: 'availOrder', defaults: ['title']}"></span>
 
+<div class="crm-content-block crm-block crm-connection-block">
   <h3>{{ts('New Connections')}}</h3>
   <table class="display">
     <thead>
@@ -109,6 +110,8 @@
     </tr>
     </tbody>
   </table>
+</div>
+
 </div>
 
 <div ng-show="appMetas.length === 0" class="messages status no-popup">

--- a/templates/CRM/Admin/Form/Job.tpl
+++ b/templates/CRM/Admin/Form/Job.tpl
@@ -50,7 +50,7 @@
         <td class="label">{$form.run_frequency.label}</td><td>{$form.run_frequency.html}</td>
     </tr>
     <tr class="crm-job-form-block-api_action">
-        <td class="label">{ts}API call:{/ts}</td>
+        <td class="label"><label>{ts}API call:{/ts}</label></td>
         <td>
 
         <div id="fname"><br/>

--- a/templates/CRM/Admin/Form/Setting/UpdateConfigBackend.tpl
+++ b/templates/CRM/Admin/Form/Setting/UpdateConfigBackend.tpl
@@ -34,7 +34,7 @@
     {ts 1=$pathsURL 2=$urlsURL}The old paths and URLs may be retained in some database records. Use this form to clear caches or to reset paths to their defaults. If you need further customizations, then update the <a href="%1">Directories</a> and <a href="%2">Resource URLs</a>.{/ts}
     </p>
 </div>
-        <div>
+        <div class="crm-submit-buttons">
           <span class="crm-button crm-i-button">
             <i class="crm-i fa-undo"></i>
             {$form._qf_UpdateConfigBackend_next_cleanup.html}

--- a/templates/CRM/Admin/Page/Extensions.tpl
+++ b/templates/CRM/Admin/Page/Extensions.tpl
@@ -27,13 +27,14 @@
 {if $action eq 1 or $action eq 2 or $action eq 8 or $action eq 32 or $action eq 64}
     {include file="CRM/Admin/Form/Extensions.tpl"}
 {else}
+  <div class="crm-content-block crm-block">
     {if $action ne 1 and $action ne 2}
         {include file="CRM/Admin/Page/Extensions/Refresh.tpl"}
     {/if}
 
     {if $extDbUpgrades}
       <div class="messages warning">
-        <p>{ts 1=$extDbUpgradeUrl}Your extensions require database updates. Please <a href="%1">execute the updates</a>.{/ts}
+        <p>{ts 1=$extDbUpgradeUrl}Your extensions require database updates. Please <a href="%1">execute the updates</a>.{/ts}</p>
       </div>
     {/if}
 
@@ -79,7 +80,7 @@
     {if $action ne 1 and $action ne 2}
         {include file="CRM/Admin/Page/Extensions/Refresh.tpl"}
     {/if}
-
+  </div>
     {* Expand/Collapse *}
     {literal}
     <script type="text/javascript">

--- a/templates/CRM/Admin/Page/Job.tpl
+++ b/templates/CRM/Admin/Page/Job.tpl
@@ -32,7 +32,8 @@
    {include file="CRM/Admin/Form/Job.tpl"}
 {else}
 
-  {if $rows}
+<div class="crm-content-block crm-block">
+{if $rows}
 
       {if $action ne 1 and $action ne 2}
         <div class="action-link">
@@ -45,7 +46,7 @@
     {strip}
         {* handle enable/disable actions*}
        {include file="CRM/common/enableDisableApi.tpl"}
-        <br/><table class="selector row-highlight">
+        <table class="selector row-highlight">
         <tr class="columnheader">
             <th >{ts}Name (Frequency)/Description{/ts}</th>
             <th >{ts}Command/Parameters{/ts}</th>
@@ -86,4 +87,5 @@
      </div>
 
 {/if}
+</div>
 {/if}

--- a/templates/CRM/Admin/Page/JobLog.tpl
+++ b/templates/CRM/Admin/Page/JobLog.tpl
@@ -27,16 +27,18 @@
     {ts}This screen presents the list of most recent 1,000 scheduled jobs log entries.{/ts} {$docLink}
 </div>
 
+<div class="crm-content-block crm-block">
+
 {if $jobId}
-    <h1>{ts}List of log entries for:{/ts} {$jobName}</h1>
+    <h3>{ts}List of log entries for:{/ts} {$jobName}</h3>
 {/if}
 
-<div class="action-link">
-  <a href="{crmURL p='civicrm/admin/job' q="reset=1"}" id="jobsList-top" class="button"><span><i class="crm-i fa-chevron-left"></i> {ts}Back to Scheduled Jobs Listing{/ts}</span></a>
-</div>
+  <div class="action-link">
+    <a href="{crmURL p='civicrm/admin/job' q="reset=1"}" id="jobsList-top" class="button"><span><i class="crm-i fa-chevron-left"></i> {ts}Back to Scheduled Jobs Listing{/ts}</span></a>
+  </div>
 
 {if $rows}
-<div id="ltype">
+  <div id="ltype">
         {strip}
         {* handle enable/disable actions*}
    {include file="CRM/common/enableDisableApi.tpl"}
@@ -60,7 +62,7 @@
         </table>
         {/strip}
 
-</div>
+  </div>
 {elseif $action ne 1}
     <div class="messages status no-popup">
       <div class="icon inform-icon"></div>&nbsp;
@@ -72,6 +74,7 @@
      </div>
 {/if}
 
-<div class="action-link">
-  <a href="{crmURL p='civicrm/admin/job' q="reset=1"}" id="jobsList-bottom" class="button"><span><i class="crm-i fa-chevron-left"></i> {ts}Back to Scheduled Jobs Listing{/ts}</span></a>
+  <div class="action-link">
+    <a href="{crmURL p='civicrm/admin/job' q="reset=1"}" id="jobsList-bottom" class="button"><span><i class="crm-i fa-chevron-left"></i> {ts}Back to Scheduled Jobs Listing{/ts}</span></a>
+  </div>
 </div>

--- a/templates/CRM/Admin/Page/Mapping.tpl
+++ b/templates/CRM/Admin/Page/Mapping.tpl
@@ -26,9 +26,11 @@
 {if $action eq 1 or $action eq 2 or $action eq 8}
     {include file="CRM/Admin/Form/Mapping.tpl"}
 {else}
+
     <div class="help">
         {ts}Saved mappings allow you to easily run the same import or export job multiple times. Mappings are created and updated as part of an Import or Export task. This screen allows you to rename or delete existing mappings.{/ts}
     </div>
+    <div class="crm-content-block crm-block">
     {if $rows}
     <div id="mapping">
     <p></p>
@@ -59,4 +61,5 @@
             {ts}There are currently no saved import or export mappings. You create saved mappings as part of an Import or Export task.{/ts}
         </div>
     {/if}
+    </div>
 {/if}

--- a/templates/CRM/Admin/Page/ParticipantStatusType.tpl
+++ b/templates/CRM/Admin/Page/ParticipantStatusType.tpl
@@ -28,11 +28,11 @@
 {else}
   <div class="help">{ts}Manage event participant statuses below. Enable selected statuses to allow event waitlisting and/or participant approval.{/ts} {help id="id-disabled_statuses"}</div>
 
-<div class="crm-section participant-status">
+<div class="crm-block crm-content-block participant-status">
   {strip}
     {* handle enable/disable actions*}
     {include file="CRM/common/enableDisableApi.tpl"}
-    <table cellpadding="0" cellspacing="0" border="0">
+    <table cellpadding="0" cellspacing="0" border="0" class="row-highlight">
       <thead class="sticky">
         <th>{ts}Label{/ts}</th>
         <th>{ts}Name (Status ID){/ts}</th>

--- a/templates/CRM/Admin/Page/PaymentProcessor.tpl
+++ b/templates/CRM/Admin/Page/PaymentProcessor.tpl
@@ -31,6 +31,7 @@
    {include file="CRM/Admin/Form/PaymentProcessor.tpl"}
 {else}
 
+<div class="crm-content-block crm-block">
 {if $rows}
 <div id="ltype">
         {strip}
@@ -43,7 +44,7 @@
             <th >{ts}Description{/ts}</th>
             <th >{ts}Financial Account{/ts}</th>
             <th >{ts}Enabled?{/ts}</th>
-      <th >{ts}Default?{/ts}</th>
+            <th >{ts}Default?{/ts}</th>
             <th ></th>
         </tr>
         {foreach from=$rows item=row}
@@ -53,8 +54,10 @@
             <td class="crmf-description">{$row.description}</td>
             <td class="crmf-financial_account_id">{$row.financialAccount}</td>
             <td class="crmf-is_active">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-            <td class="crmf-is_default">{if $row.is_default eq 1}<img src="{$config->resourceBase}i/check.gif" alt="{ts}Default{/ts}" />{/if}&nbsp;</td>
-          <td>{$row.action|replace:'xx':$row.id}</td>
+            <td class="crmf-is_default">
+              {if $row.is_default eq 1}<img src="{$config->resourceBase}i/check.gif" alt="{ts}Default{/ts}"/>{/if}&nbsp;
+            </td>
+            <td>{$row.action|replace:'xx':$row.id}</td>
         </tr>
         {/foreach}
         </table>
@@ -75,4 +78,6 @@
        {crmButton p='civicrm/admin/paymentProcessor' q="action=add&reset=1&pp=$defaultPaymentProcessorType" id="newPaymentProcessor"  icon="plus-circle"}{ts}Add Payment Processor{/ts}{/crmButton}
      </div>
 {/if}
+</div>
+
 {/if}

--- a/templates/CRM/Badge/Page/Layout.tpl
+++ b/templates/CRM/Badge/Page/Layout.tpl
@@ -32,7 +32,7 @@
 {else}
 
   {if $rows}
-    <div id="badge-layout">
+    <div id="badge-layout" class="crm-content-block crm-block">
       {strip}
       {* handle enable/disable actions*}
         {include file="CRM/common/enableDisableApi.tpl"}

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -68,7 +68,7 @@
 
   {include file="CRM/common/TrackingFields.tpl"}
 
-  <div class="crm-contribution-page-id-{$contributionPageID} crm-block crm-contribution-main-form-block">
+  <div class="crm-contribution-page-id-{$contributionPageID} crm-block crm-form-block crm-contribution-main-form-block">
 
   {if $contact_id && !$ccid}
     <div class="messages status no-popup crm-not-you-message">

--- a/templates/CRM/Contribute/Form/SearchContribution.tpl
+++ b/templates/CRM/Contribute/Form/SearchContribution.tpl
@@ -31,7 +31,6 @@
             <div class="description font-italic">
                 {ts}Complete OR partial Contribution Page title.{/ts}
             </div>
-            <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl"}</div>
         </td>
 
         <td>
@@ -51,4 +50,5 @@
     campaignContext="componentSearch" campaignTrClass='' campaignTdClass=''}
 
  </table>
+ <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl"}</div>
 </div>

--- a/templates/CRM/Contribute/Page/ManagePremiums.tpl
+++ b/templates/CRM/Contribute/Page/ManagePremiums.tpl
@@ -37,9 +37,10 @@
 </div>
 
 {/if}
+
+<div class="crm-content-block crm-block">
 {if $rows}
 <div id="ltype">
-<p></p>
     {strip}
   {* handle enable/disable actions*}
    {include file="CRM/common/enableDisableApi.tpl"}
@@ -50,7 +51,7 @@
             <th id="sortable">{ts}Name{/ts}</th>
             <th>{ts}SKU{/ts}</th>
             <th>{ts}Market Value{/ts}</th>
-      <th>{ts}Financial Type{/ts}</th>
+            <th>{ts}Financial Type{/ts}</th>
             <th>{ts}Min Contribution{/ts}</th>
             <th>{ts}Active?{/ts}</th>
             <th></th>
@@ -60,12 +61,12 @@
         <tr id="product-{$row.id}" class="crm-entity {cycle values="odd-row,even-row"} {$row.class}{if NOT $row.is_active} disabled{/if}">
           <td class="crm-contribution-form-block-name crm-editable" data-field="name">{$row.name}</td>
           <td class="crm-contribution-form-block-sku crm-editable" data-field="sku">{$row.sku}</td>
-                <td class="crm-contribution-form-block-price">{$row.price }</td>
-    <td class="crm-contribution-form-block-financial_type">{$row.financial_type_id}</td>
+          <td class="crm-contribution-form-block-price">{$row.price }</td>
+          <td class="crm-contribution-form-block-financial_type">{$row.financial_type_id}</td>
           <td class="crm-contribution-form-block-min_contribution">{$row.min_contribution}</td>
           <td id="row_{$row.id}_status" >{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
           <td id={$row.id}>{$row.action|replace:'xx':$row.id}</td>
-          </tr>
+        </tr>
         {/foreach}
         </table>
     {/strip}
@@ -84,5 +85,6 @@
     </div>
     {/if}
 {/if}
+</div>
 {/if}
 {/if}

--- a/templates/CRM/Financial/Page/FinancialAccount.tpl
+++ b/templates/CRM/Financial/Page/FinancialAccount.tpl
@@ -32,6 +32,8 @@
     {capture assign="premiumLink"}{crmURL p="civicrm/admin/contribute/managePremiums" q="reset=1"}{/capture}
     <p>{ts 1=$typeLink 2=$paymentLink 3=$premiumLink}Financial accounts correspond to those in your accounting system.  <a href="%1">Financial types</a>, <a href="%2">payment methods</a>, and <a href="%3">premiums</a> are associated with financial accounts so that they can result in the proper double-entry transactions to export to your accounting system.{/ts}</p>
   </div>
+
+<div class="crm-content-block crm-block">
   {if $action ne 1 and $action ne 2}
     <div class="action-link">
       <a href="{crmURL q="action=add&reset=1"}" id="newFinancialAccount-top" class="button"><span><i class="crm-i fa-plus-circle"></i> {ts}Add Financial Account{/ts}</span></a>
@@ -47,7 +49,7 @@
       {* handle enable/disable actions*}
        {include file="CRM/common/enableDisableApi.tpl"}
       <table id="crm-financial_accounts" class="display">
-         <thead class="sticky">
+        <thead class="sticky">
           <th>{ts}Name{/ts}</th>
           <th>{ts}Description{/ts}</th>
           <th>{ts}Acctg Code{/ts}</th>
@@ -60,15 +62,15 @@
         </thead>
         {foreach from=$rows item=row}
         <tr id="financial_account-{$row.id}" class="crm-entity {cycle values="odd-row,even-row"} {$row.class}{if NOT $row.is_active} disabled{/if}">
-        <td class="crm-editable" data-field="name">{$row.name}</td>
-        <td class="crm-editable" data-field="description" data-type="textarea">{$row.description}</td>
-        <td class="crm-editable" data-field="accounting_code">{$row.accounting_code}</td>
-        <td>{$row.financial_account_type_id}{if $row.account_type_code} ({$row.account_type_code}){/if}</td>
-        <td>{if $row.is_deductible eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-        <td>{if $row.is_reserved eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-        <td>{if $row.is_default eq 1}<img src="{$config->resourceBase}i/check.gif" alt="{ts}Default{/ts}" /> {/if}</td>
-        <td id="row_{$row.id}_status">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-        <td>{$row.action|replace:'xx':$row.id}</td>
+          <td class="crm-editable" data-field="name">{$row.name}</td>
+          <td class="crm-editable" data-field="description" data-type="textarea">{$row.description}</td>
+          <td class="crm-editable" data-field="accounting_code">{$row.accounting_code}</td>
+          <td>{$row.financial_account_type_id}{if $row.account_type_code} ({$row.account_type_code}){/if}</td>
+          <td>{if $row.is_deductible eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
+          <td>{if $row.is_reserved eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
+          <td>{if $row.is_default eq 1}<img src="{$config->resourceBase}i/check.gif" alt="{ts}Default{/ts}" /> {/if}</td>
+          <td id="row_{$row.id}_status">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
+          <td>{$row.action|replace:'xx':$row.id}</td>
         </tr>
         {/foreach}
       </table>
@@ -88,4 +90,6 @@
       {ts 1=$crmURL}There are no Financial Account entered. You can <a href='%1'>add one</a>.{/ts}
     </div>
   {/if}
+</div>
+
 {/if}

--- a/templates/CRM/Financial/Page/FinancialType.tpl
+++ b/templates/CRM/Financial/Page/FinancialType.tpl
@@ -33,6 +33,7 @@
       <p>{ts 1=$acctLink}Each financial type relates to a number of <a href="%1">financial accounts</a> to track income, accounts receivable, and fees.</p>{/ts}
     </div>
 
+<div class="crm-content-block crm-block">
 {if $rows}
 <div id="ltype">
 <p></p>
@@ -41,11 +42,11 @@
   {* handle enable/disable actions*}
    {include file="CRM/common/enableDisableApi.tpl"}
    {include file="CRM/common/jsortable.tpl"}
-        <table cellpadding="0" cellspacing="0" border="0">
-           <thead class="sticky">
+        <table cellpadding="0" cellspacing="0" border="0" class="row-highlight">
+          <thead class="sticky">
             <th>{ts}Name{/ts}</th>
             <th>{ts}Description{/ts}</th>
-      <th>{ts}Financial Accounts{/ts}</th>
+            <th>{ts}Financial Accounts{/ts}</th>
             <th>{ts}Deductible?{/ts}</th>
             <th>{ts}Reserved?{/ts}</th>
             <th>{ts}Enabled?{/ts}</th>
@@ -78,4 +79,5 @@
       {crmButton p="civicrm/admin" q="reset=1" class="cancel" icon="times"}{ts}Done{/ts}{/crmButton}
     </div>
   {/if}
+</div>
 {/if}

--- a/templates/CRM/Member/Page/MembershipStatus.tpl
+++ b/templates/CRM/Member/Page/MembershipStatus.tpl
@@ -33,22 +33,23 @@
   </div>
 
   {if $rows}
+<div class="crm-content-block crm-block">
   <div id="ltype">
-  <p></p>
+    <p></p>
     <div id="membership_status_id">
         {strip}
         {* handle enable/disable actions*}
    {include file="CRM/common/enableDisableApi.tpl"}
-        <table cellpadding="0" cellspacing="0" border="0">
+        <table cellpadding="0" cellspacing="0" border="0" class="row-highlight">
         <thead class="sticky">
             <th>{ts}Status{/ts}</th>
             <th>{ts}Start Event{/ts}</th>
             <th>{ts}End Event{/ts}</th>
             <th>{ts}Member{/ts}</th>
             <th>{ts}Admin{/ts}</th>
-          <th>{ts}Order{/ts}</th>
-          <th>{ts}Reserved?{/ts}</th>
-          <th></th>
+            <th>{ts}Order{/ts}</th>
+            <th>{ts}Reserved?{/ts}</th>
+            <th></th>
         </thead>
         {foreach from=$rows item=row}
         <tr id="membership_status-{$row.id}" class="crm-entity {cycle values="odd-row,even-row"} {$row.class} {if NOT $row.is_active} disabled{/if} crmf">
@@ -60,7 +61,7 @@
           <td class="nowrap crmf-weight">{$row.weight}</td>
           <td class="crmf-is_reserved">{if $row.is_reserved eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
           <td>{$row.action|replace:'xx':$row.id}</td>
-          </tr>
+        </tr>
         {/foreach}
         </table>
         {/strip}
@@ -73,6 +74,7 @@
         {/if}
     </div>
   </div>
+</div>
   {else}
     {if $action ne 1}
       <div class="messages status no-popup">

--- a/templates/CRM/Member/Page/MembershipType.tpl
+++ b/templates/CRM/Member/Page/MembershipType.tpl
@@ -31,7 +31,7 @@
 </div>
 
 {if $rows}
-<div id="membership_type">
+<div id="membership_type" class="crm-content-block crm-block">
   {strip}
   {* handle enable/disable actions*}
   {include file="CRM/common/enableDisableApi.tpl"}

--- a/templates/CRM/PCP/Form/Campaign.tpl
+++ b/templates/CRM/PCP/Form/Campaign.tpl
@@ -27,7 +27,7 @@
     {ts}Personalize the contents and appearance of your personal campaign page here. You will be able to return to this page and make changes at any time.{/ts}
 </div>
 <fieldset class="crm-pcp-campaign-group">
-<div class="crm-block crm-contribution-campaign-form-block">
+<div class="crm-block crm-form-block crm-contribution-campaign-form-block">
 {crmRegion name="pcp-form-campaign"}
   <div class="crm-section crm-pcp-title-section crm-contribution-form-block-title">
     <div class="label">{$form.pcp_title.label}</div>
@@ -104,8 +104,8 @@
     <div class="clear"></div>
   </div>
 {/crmRegion}
+  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>  
 </div>
-<div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 </fieldset>
 <script type="text/javascript">
     // Always open attachment div by default for this form

--- a/templates/CRM/PCP/Form/PCPAccount.tpl
+++ b/templates/CRM/PCP/Form/PCPAccount.tpl
@@ -40,14 +40,16 @@
   <strong>{ts}Profile is not configured with Email address.{/ts}</strong>
 </div>
 {else}
-<div class="form-item">
+<div class="form-item crm-block crm-form-block">
 {include file="CRM/common/CMSUser.tpl"}
 {include file="CRM/UF/Form/Block.tpl" fields=$fields}
 {if $isCaptcha}
 {include file='CRM/common/ReCAPTCHA.tpl'}
 {/if}
-</div>
+
 <div class="crm-submit-buttons">
 {include file="CRM/common/formButtons.tpl" location="bottom"}
 </div>
+</div>
+
 {/if}

--- a/templates/CRM/Price/Page/Field.tpl
+++ b/templates/CRM/Price/Page/Field.tpl
@@ -43,6 +43,7 @@
 {/if}
 
 {if $action NEQ 8 and $priceField}
+<div class="crm-content-block crm-block">
   <div class="action-link">
     {if !$isReserved}
       {crmButton q="reset=1&action=add&sid=$sid" id="newPriceField"  icon="plus-circle"}{ts}Add Price Field{/ts}{/crmButton}
@@ -100,7 +101,7 @@
     {/if}
     {crmButton p="civicrm/admin/price" q="action=preview&sid=`$sid`&reset=1&context=field" icon="television"}{ts}Preview (all fields){/ts}{/crmButton}
   </div>
-
+</div>
 {else}
   {if $action eq 16}
     <div class="messages status no-popup crm-empty-table">

--- a/templates/CRM/Price/Page/Set.tpl
+++ b/templates/CRM/Price/Page/Set.tpl
@@ -49,8 +49,7 @@
     {/if}
 
     {if $rows}
-    <div id="price_set">
-    <p></p>
+    <div id="price_set" class="crm-content-block crm-block">
         {strip}
   {* handle enable/disable actions*}
    {include file="CRM/common/enableDisableApi.tpl"}

--- a/templates/CRM/SMS/Page/Provider.tpl
+++ b/templates/CRM/SMS/Page/Provider.tpl
@@ -31,13 +31,14 @@
     {ts}You can configure one or more SMS Providers for your CiviCRM installation. To learn more about the procedure to install SMS extension and Provider, refer{/ts} {$wikiLink}
   </div>
 
+<div class="crm-content-block crm-block">
   {if $rows}
 
   <div id="ltype">
     {strip}
         {* handle enable/disable actions*}
        {include file="CRM/common/enableDisableApi.tpl"}
-        <br/><table class="selector row-highlight">
+        <table class="selector row-highlight">
         <tr class="columnheader">
             <th >{ts}Provider Details{/ts}</th>
             <th >{ts}Username{/ts}</th>
@@ -70,4 +71,5 @@
   <div class="action-link">
     {crmButton p='civicrm/admin/sms/provider' q="action=add&reset=1" icon="plus-circle"}{ts}Add SMS Provider{/ts}{/crmButton}
   </div>
+</div>
 {/if}


### PR DESCRIPTION
Overview
----------------------------------------
This PR adds missing container classes in templates which are missing.

Screenshots
----------------------------------------
This PR does not modify anything of visual difference. The idea here is to allow any other theme (Shoreditch in this context or any other in future) to have unified UI/UX solution if they use such class.


Comments
----------------------------------------
This is tested with default styling of CiviCRM and custom theme Shoreditch

---

 * [CRM-21539: Add missing structure divs in templates](https://issues.civicrm.org/jira/browse/CRM-21539)