### PR TITLE
CRM-16421 - distmaker - Set version in WP zip files

### DIFF
--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -193,6 +193,8 @@ function dm_install_wordpress() {
     --exclude=civicrm \
     "$repo/./"  "$to/./"
   ## Need --exclude=civicrm for self-building on WP site
+
+  dm_preg_edit '/^Version: [0-9\.]+/m' "Version: $DM_VERSION" "$to/civicrm.php"
 }
 
 
@@ -238,4 +240,13 @@ function dm_git_checkout() {
     git checkout .
     git checkout "$2"
   popd
+}
+
+## Edit a file by applying a regular expression.
+## Note: We'd rather just call "sed", but it differs on GNU+BSD.
+## usage: dm_preg_edit <search-pattern> <replacement-pattern> <file>
+## example: '/version = \([0-9]*\.x-\)[1-9.]*/' 'version = \1$DM_VERSION'
+function dm_preg_edit() {
+  env RPAT="$1" RREPL="$2" RFILE="$3" \
+    php -r '$c = file_get_contents(getenv("RFILE")); $c = preg_replace(getenv("RPAT"), getenv("RREPL"), $c); file_put_contents(getenv("RFILE"), $c);'
 }

--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -119,13 +119,7 @@ function dm_install_drupal() {
   # Set full version in .info files. See CRM-15768.
   local MODULE_DIRS=`find "$to" -type f -name "*.info"`
   for INFO in $MODULE_DIRS; do
-    if [ $(uname) = "Darwin" ]; then
-      ## BSD sed
-      sed -i '' "s/version = \([0-9]*\.x-\)[1-9.]*/version = \1$DM_VERSION/g" $INFO
-    else
-      ## GNU sed
-      sed -i'' "s/version = \([0-9]*\.x-\)[1-9.]*/version = \1$DM_VERSION/g" $INFO
-    fi
+    dm_preg_edit '/version = ([0-9]*\.x)-[1-9.]*/m' "version = \$1-$DM_VERSION" "$INFO"
   done
 
   for f in "$to/.gitignore" "$to/.toxic.json" ; do


### PR DESCRIPTION
Overview
----------------------------------------
When preparing zip files for WordPress, the `Version:` header should specify the actual version.

Before
----------------------------------------
The file `civicrm.php` always has `Version: 4.7`.

After
----------------------------------------
While building the zip file, `civicrm.php` is filtered to specify `Version: 4.7.29` (or `Version: 4.7.30` or similar).

Technical Details
----------------------------------------
This uses the same technique as the Drupal build (wherein `*.info` files are tweaked to match the actual version).

Due to the minor differences between GNU and BSD tool chains, the Drupal build script was sketchy. I rewrote that bit as a helper function (`dm_preg_edit`).

To test this, I ran the `distmaker.sh` locally for both the WordPress and D7 builds -- then inspected the resulting files to ensure that versions were correctly updated.

There isn't much to `r-run` on this patch -- just calling `distmaker.sh`. Alas, many folks aren't comfortable with that script. But there are automated builds on http://download.civicrm.org/latest . In lieu of `r-run` QA, perhaps we could merge and then have someone look at the new automated build? (We can quickly revert if the automated build fails.)

---

 * [CRM-16241: Activity details truncated in activity report](https://issues.civicrm.org/jira/browse/CRM-16241)

---

 * [CRM-16421: Work to get CiviCRM for WordPress in WordPress' official Repository](https://issues.civicrm.org/jira/browse/CRM-16421)