### PR TITLE
CRM-21540 - Add support for auto-complete fields in the batch entry f…

### DIFF
--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -146,7 +146,7 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
 
     // remove file type field and then limit fields
     $suppressFields = FALSE;
-    $removehtmlTypes = array('File', 'Autocomplete-Select');
+    $removehtmlTypes = array('File');
     foreach ($this->_fields as $name => $field) {
       if ($cfID = CRM_Core_BAO_CustomField::getKeyID($name) &&
         in_array($this->_fields[$name]['html_type'], $removehtmlTypes)
@@ -270,7 +270,7 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
     $buttonName = $this->controller->getButtonName('submit');
 
     if ($suppressFields && $buttonName != '_qf_Entry_next') {
-      CRM_Core_Session::setStatus(ts("File or Autocomplete-Select type field(s) in the selected profile are not supported for Update multiple records."), ts('Some Fields Excluded'), 'info');
+      CRM_Core_Session::setStatus(ts("File type field(s) in the selected profile are not supported for Update multiple records."), ts('Some Fields Excluded'), 'info');
     }
   }
 


### PR DESCRIPTION
…orms

Overview
----------------------------------------
Steps to replicate:

1. Create custom data of type Autocomplete-Select for membership/contribution
2. Add the field to reserved profile for Contribution/Membership Bulk Entry
3. Click on Contribution >> Batch Data Entry >> New Data Entry Batch an error "File or Autocomplete-Select type field(s) in the selected profile are not supported for Update multiple records."

Before
----------------------------------------
![auto_before](https://user-images.githubusercontent.com/3455173/33871717-ae2c8fe8-df39-11e7-8c6b-e258bc866e64.png)


After
----------------------------------------
![batch_after](https://user-images.githubusercontent.com/3455173/33871645-61ae2424-df39-11e7-8db4-88f726d49933.png)



Comments
----------------------------------------
This is similar to https://github.com/civicrm/civicrm-core/pull/11290
