### PR TITLE
CRM-19704: mailing body stripped if image only

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -796,7 +796,7 @@ ORDER BY   {$orderBy}
       }
 
       // To check for an html part strip tags
-      if (trim(strip_tags($this->body_html))) {
+      if (trim(strip_tags($this->body_html, '<img>'))) {
 
         $template = array();
         if ($this->header) {


### PR DESCRIPTION
Overview
----------------------------------------
Adding an image only in mailing HTML content and on preview its show null.

Before
----------------------------------------
![screen shot 2017-12-12 at 9 33 28 pm](https://user-images.githubusercontent.com/3735621/33894599-586dee3a-df84-11e7-82f5-3210624a9fbe.png)

After
----------------------------------------
Adds image correctly

Technical Details
----------------------------------------
This is a regression due to https://github.com/civicrm/civicrm-core/pull/8145 fix, where it strips all html tags. As per fix I have allowed ```<img>```

---

 * [CRM-19704: Image-only emails fail to send](https://issues.civicrm.org/jira/browse/CRM-19704)