### PR TITLE
CRM-21547: Add UI order by options to Contact logging summary report

### DIFF
--- a/CRM/Logging/ReportSummary.php
+++ b/CRM/Logging/ReportSummary.php
@@ -303,11 +303,13 @@ class CRM_Logging_ReportSummary extends CRM_Report_Form {
 
     // note the group by columns are same as that used in alterDisplay as $newRows - $key
     $this->limit();
+    $this->orderBy();
     $sql = "{$this->_select}
 FROM civicrm_temp_civireport_logsummary entity_log_civireport
 WHERE {$logTypeTableClause}
 GROUP BY log_civicrm_entity_log_date, log_civicrm_entity_log_type_label, log_civicrm_entity_log_conn_id, log_civicrm_entity_log_user_id, log_civicrm_entity_altered_contact_id, log_civicrm_entity_log_grouping
-ORDER BY log_civicrm_entity_log_date DESC {$this->_limit}";
+{$this->_orderBy}
+{$this->_limit} ";
     $sql = str_replace('modified_contact_civireport.display_name', 'entity_log_civireport.altered_contact', $sql);
     $sql = str_replace('modified_contact_civireport.id', 'entity_log_civireport.altered_contact_id', $sql);
     $sql = str_replace(array(

--- a/CRM/Report/Form/Contact/LoggingSummary.php
+++ b/CRM/Report/Form/Contact/LoggingSummary.php
@@ -142,6 +142,19 @@ class CRM_Report_Form_Contact_LoggingSummary extends CRM_Logging_ReportSummary {
             'type' => CRM_Utils_Type::T_INT,
           ),
         ),
+        'order_bys' => array(
+          'log_date' => array(
+            'title' => ts('Log Date (When)'),
+            'default' => TRUE,
+            'default_weight' => '0',
+            'default_order' => 'DESC',
+          ),
+          'altered_contact' => array(
+            'name' => 'display_name',
+            'title' => ts('Altered Contact'),
+            'alias' => 'modified_contact_civireport',
+          ),
+        ),
       ),
       'altered_by_contact' => array(
         'dao' => 'CRM_Contact_DAO_Contact',
@@ -158,6 +171,12 @@ class CRM_Report_Form_Contact_LoggingSummary extends CRM_Logging_ReportSummary {
             'name' => 'display_name',
             'title' => ts('Altered By'),
             'type' => CRM_Utils_Type::T_STRING,
+          ),
+        ),
+        'order_bys' => array(
+          'altered_by_contact' => array(
+            'name' => 'display_name',
+            'title' => ts('Altered by'),
           ),
         ),
       ),


### PR DESCRIPTION
Overview
----------------------------------------
Add 3 order options to Contact Logging Summary Report :
1. Log Date (When) [log_civicrm_entity.log_date]
2. Altered Contact [log_civicrm_entity.display_name]
3. Altered By [altered_by_contact.display_name]

---

 * [CRM-21547: Add UI order by options to Contact logging summary report](https://issues.civicrm.org/jira/browse/CRM-21547)