### PR TITLE
[NFC] CRM-21548 Remove unused variable and param from CRM_Utils_Address::format

### DIFF
--- a/CRM/Contact/BAO/Individual.php
+++ b/CRM/Contact/BAO/Individual.php
@@ -216,14 +216,14 @@ class CRM_Contact_BAO_Individual extends CRM_Contact_DAO_Contact {
       //build the sort name.
       $format = Civi::settings()->get('sort_name_format');
       $sortName = CRM_Utils_Address::format($formatted, $format,
-        FALSE, FALSE, TRUE, $tokenFields
+        FALSE, FALSE, $tokenFields
       );
       $sortName = trim($sortName);
 
       //build the display name.
       $format = Civi::settings()->get('display_name_format');
       $displayName = CRM_Utils_Address::format($formatted, $format,
-        FALSE, FALSE, TRUE, $tokenFields
+        FALSE, FALSE, $tokenFields
       );
       $displayName = trim($displayName);
     }

--- a/CRM/Contact/Form/Task/Label.php
+++ b/CRM/Contact/Form/Task/Label.php
@@ -333,7 +333,7 @@ class CRM_Contact_Form_Task_Label extends CRM_Contact_Form_Task {
         $row['preferred_communication_method'] = implode(', ', $temp);
       }
       $row['id'] = $id;
-      $formatted = CRM_Utils_Address::format($row, 'mailing_format', FALSE, TRUE, $individualFormat, $tokenFields);
+      $formatted = CRM_Utils_Address::format($row, 'mailing_format', FALSE, TRUE, $tokenFields);
 
       // CRM-2211: UFPDF doesn't have bidi support; use the PECL fribidi package to fix it.
       // On Ubuntu (possibly Debian?) be aware of http://pecl.php.net/bugs/bug.php?id=12366

--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -1083,7 +1083,7 @@ SELECT is_primary,
         'individual_prefix' => $rows[$rowID]['individual_prefix'],
       );
       $format = Civi::settings()->get('display_name_format');
-      $firstNameWithPrefix = CRM_Utils_Address::format($formatted, $format, FALSE, FALSE, TRUE);
+      $firstNameWithPrefix = CRM_Utils_Address::format($formatted, $format, FALSE, FALSE);
       $firstNameWithPrefix = trim($firstNameWithPrefix);
 
       // fill uniqueAddress array with last/first name tree

--- a/CRM/Member/Form/Task/Label.php
+++ b/CRM/Member/Form/Task/Label.php
@@ -122,7 +122,7 @@ class CRM_Member_Form_Task_Label extends CRM_Member_Form_Task {
         $row['preferred_communication_method'] = implode(', ', $temp);
       }
       $row['id'] = $id;
-      $formatted = CRM_Utils_Address::format($row, 'mailing_format', FALSE, TRUE, $individualFormat, $tokenFields);
+      $formatted = CRM_Utils_Address::format($row, 'mailing_format', FALSE, TRUE, $tokenFields);
       $rows[$id] = array($formatted);
     }
     if ($isPerMembership) {

--- a/CRM/Utils/Address.php
+++ b/CRM/Utils/Address.php
@@ -39,6 +39,9 @@ class CRM_Utils_Address {
    * Format an address basing on the address fields provided.
    * Use Setting's address_format if there's no format specified.
    *
+   * This function is also used to generate a contact's display_name and
+   * sort_name.
+   *
    * @param array $fields
    *   The address fields.
    * @param string $format
@@ -47,9 +50,6 @@ class CRM_Utils_Address {
    *   If true indicates, the address to be built in hcard-microformat standard.
    * @param bool $mailing
    *   If true indicates, the call has been made from mailing label.
-   * @param bool $individualFormat
-   *   If true indicates, the call has been made for the contact of type 'individual'.
-   *
    * @param null $tokenFields
    *
    * @return string
@@ -61,7 +61,6 @@ class CRM_Utils_Address {
     $format = NULL,
     $microformat = FALSE,
     $mailing = FALSE,
-    $individualFormat = FALSE,
     $tokenFields = NULL
   ) {
     static $config = NULL;
@@ -112,20 +111,6 @@ class CRM_Utils_Address {
       }
       else {
         $fields['country'] = mb_convert_case($fields['country'], MB_CASE_UPPER, "UTF-8");
-      }
-    }
-
-    $contactName = CRM_Utils_Array::value('display_name', $fields);
-    if (!$individualFormat) {
-      if (isset($fields['id'])) {
-        $type = CRM_Contact_BAO_Contact::getContactType($fields['id']);
-      }
-      else {
-        $type = 'Individual';
-      }
-
-      if ($type == 'Individual') {
-        $contactName = CRM_Utils_Array::value('addressee_display', $fields);
       }
     }
 

--- a/tools/bin/scripts/updateNameCache.php
+++ b/tools/bin/scripts/updateNameCache.php
@@ -109,10 +109,10 @@ class CRM_UpdateNameCache {
       $params['individual_prefix'] = $prefixes[$dao->prefix_id];
       $params['individual_suffix'] = $suffixes[$dao->suffix_id];
 
-      $sortName = CRM_Utils_Address::format($params, $sortFormat, FALSE, FALSE, TRUE, $tokenFields);
+      $sortName = CRM_Utils_Address::format($params, $sortFormat, FALSE, FALSE, $tokenFields);
       $sortName = trim(CRM_Core_DAO::escapeString($sortName));
 
-      $displayName = CRM_Utils_Address::format($params, $displayFormat, FALSE, FALSE, TRUE, $tokenFields);
+      $displayName = CRM_Utils_Address::format($params, $displayFormat, FALSE, FALSE, $tokenFields);
       $displayName = trim(CRM_Core_DAO::escapeString($displayName));
 
       //check for email


### PR DESCRIPTION
Overview
----------------------------------------
The $contactName variable in this function was un-used.
The logic that created it is therefore unused.
Removing that meant that one of the parameters in the method was unused.

This should be a non-functional change. But areas to test are
* display_name generation
* address format generation (eg: displayed on a contact, labels)

Before
----------------------------------------
Addresses and contact display names were formatting correctly.

After
----------------------------------------
Addresses and contact display names are formatting correctly.

Technical Details
----------------------------------------
n/a

Comments
----------------------------------------
n/a

---

 * [CRM-21548: Remove unused variables from \CRM_Utils_Address::format](https://issues.civicrm.org/jira/browse/CRM-21548)