### PR TITLE
CRM-21551 Add parameter to support skipping processing greetings when…

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -437,7 +437,12 @@ class CRM_Contact_BAO_Contact extends CRM_Contact_DAO_Contact {
       }
     }
 
-    self::processGreetings($contact);
+    // In order to prevent a series of expensive queries in intensive batch processing
+    // api calls may pass in skip_greeting_processing, probably doing it later via the
+    // scheduled job. CRM-21551
+    if (empty($params['skip_greeting_processing'])) {
+      self::processGreetings($contact);
+    }
 
     return $contact;
   }

--- a/api/v3/Contact.php
+++ b/api/v3/Contact.php
@@ -153,6 +153,12 @@ function _civicrm_api3_contact_create_spec(&$params) {
     'description' => 'Throw error if contact create matches dedupe rule',
     'type' => CRM_Utils_Type::T_BOOLEAN,
   );
+  $params['skip_greeting_processing'] = array(
+    'title' => 'Skip Greeting processing',
+    'description' => 'Do not process greetings, (these can be done by scheduled job and there may be a preference to do so for performance reasons)',
+    'type' => CRM_Utils_Type::T_BOOLEAN,
+    'api.default' => 0,
+  );
   $params['prefix_id']['api.aliases'] = array('individual_prefix', 'individual_prefix_id');
   $params['suffix_id']['api.aliases'] = array('individual_suffix', 'individual_suffix_id');
   $params['gender_id']['api.aliases'] = array('gender');


### PR DESCRIPTION
Overview
----------------------------------------
Add parameter to support skipping processing greetings when calling api contact.create

Before
----------------------------------------
Not possible to skip this often slow function when processing large batches.

After
----------------------------------------
Possible to skip greeting processing. Can be done later by scheduled job

Technical Details
----------------------------------------
We have a precedent for allowing intensive operations to be skipped when being called from the api - ie. currently geocoding and street parsing can be skipped and filled by offline jobs. There is a PR open to allow skipping the mystical and magical fixAddress function https://github.com/civicrm/civicrm-core/pull/11372/files and the processGreeting code is in a similar vein ie 1) expensive to run and 2) there is a job which can do it 'out of hours' if decided.

Adding another 'magic param' to the v3 api is not great but OTOH there is sufficient precedent IMHO