### PR TITLE
CRM-21552 Dedupe rule form : get contact type name instead of label for validation

### DIFF
--- a/CRM/Contact/Form/DedupeRules.php
+++ b/CRM/Contact/Form/DedupeRules.php
@@ -58,7 +58,7 @@ class CRM_Contact_Form_DedupeRules extends CRM_Admin_Form {
     }
     $this->_options = CRM_Core_SelectValues::getDedupeRuleTypes();
     $this->_rgid = CRM_Utils_Request::retrieve('id', 'Positive', $this, FALSE, 0);
-    $contactTypes = civicrm_api3('Contact', 'getOptions', array('field' => "contact_type"));
+    $contactTypes = civicrm_api3('Contact', 'getOptions', array('field' => "contact_type", 'context' => "validate"));
     $contactType = CRM_Utils_Request::retrieve('contact_type', 'String', $this, FALSE, 0);
     if (CRM_Utils_Array::value($contactType, $contactTypes['values'])) {
       $this->_contactType = CRM_Utils_Array::value($contactType, $contactTypes['values']);


### PR DESCRIPTION
when contact type label is not default provided by civicrm (updated) or civicrm default installation is non english then to validate the contact type use name instead of label.

---

 * [CRM-21552: Dedupe Rule : get contact type name instead of label](https://issues.civicrm.org/jira/browse/CRM-21552)