### PR TITLE
CRM-21553 : profile duplicate field validation for field with primary location type

### DIFF
--- a/CRM/Core/BAO/UFField.php
+++ b/CRM/Core/BAO/UFField.php
@@ -207,7 +207,13 @@ class CRM_Core_BAO_UFField extends CRM_Core_DAO_UFField {
     $ufField->field_type = $params['field_type'];
     $ufField->field_name = $params['field_name'];
     $ufField->website_type_id = CRM_Utils_Array::value('website_type_id', $params);
-    $ufField->location_type_id = CRM_Utils_Array::value('location_type_id', $params);
+    if (is_null(CRM_Utils_Array::value('location_type_id', $params, ''))) {
+      // primary location type have NULL value in DB
+      $ufField->whereAdd("location_type_id IS NULL");
+    }
+    else {
+      $ufField->location_type_id = CRM_Utils_Array::value('location_type_id', $params);
+    }
     $ufField->phone_type_id = CRM_Utils_Array::value('phone_type_id', $params);;
 
     if (!empty($params['id'])) {

--- a/CRM/UF/Form/Field.php
+++ b/CRM/UF/Form/Field.php
@@ -551,6 +551,10 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
         $apiFormattedParams['location_type_id'] = $params['field_name'][2];
       }
     }
+    elseif ($params['field_name'][2] == 0) {
+      // 0 is Primary location type
+      $apiFormattedParams['location_type_id'] = NULL;
+    }
     if (!empty($params['field_name'][3])) {
       $apiFormattedParams['phone_type_id'] = $params['field_name'][3];
     }


### PR DESCRIPTION
In Profile
Add email field with Primary Location Type
Add email field with Work Location Type

Then Edit primary email field and save with/o change.

you will get message

> Field Not Added
> The selected field already exists in this profile.

 
This is happening because when form submitted it check for duplicate field present in same profile. For primary location type field (location_type_id = NULL in DB and location_type_id = 0 in form)
During validation location_type_id get skipped, since there is already another email field with different location type found. Then above error message shown.

---

 * [CRM-21553: can not update primary location type field details if same field available for other location types](https://issues.civicrm.org/jira/browse/CRM-21553)