### PR TITLE
CRM-21554 Offline Credit Card Membership Renewal not showing any error message on failure

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -149,6 +149,9 @@ class CRM_Core_Error extends PEAR_ErrorStack {
       $message = implode($separator, $message);
       return $message;
     }
+    elseif (is_a($error, 'Civi\Payment\Exception\PaymentProcessorException')) {
+      return $error->getMessage();
+    }
     return NULL;
   }
 

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1417,7 +1417,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
           // Assign amount to template if payment was successful.
           $this->assign('amount', $params['total_amount']);
         }
-        catch (PaymentProcessorException $e) {
+        catch (\Civi\Payment\Exception\PaymentProcessorException $e) {
           if (!empty($paymentParams['contributionID'])) {
             CRM_Contribute_BAO_Contribution::failPayment($paymentParams['contributionID'], $this->_contactID,
               $e->getMessage());
@@ -1426,9 +1426,9 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
             CRM_Contribute_BAO_ContributionRecur::deleteRecurContribution($paymentParams['contributionRecurID']);
           }
 
-          CRM_Core_Error::displaySessionError($result);
+          CRM_Core_Error::displaySessionError($e);
           CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/contact/view/membership',
-            "reset=1&action=add&cid={$this->_contactID}&context=&mode={$this->_mode}"
+            "reset=1&action=add&cid={$this->_contactID}&context=membership&mode={$this->_mode}"
           ));
 
         }

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1426,7 +1426,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
             CRM_Contribute_BAO_ContributionRecur::deleteRecurContribution($paymentParams['contributionRecurID']);
           }
 
-          CRM_Core_Error::displaySessionError($e);
+          CRM_Core_Session::singleton()->setStatus($e->getMessage());
           CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/contact/view/membership',
             "reset=1&action=add&cid={$this->_contactID}&context=membership&mode={$this->_mode}"
           ));

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -469,7 +469,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
       return $statusMsg;
     }
     catch (\Civi\Payment\Exception\PaymentProcessorException $e) {
-      CRM_Core_Error::displaySessionError($e);
+      CRM_Core_Session::singleton()->setStatus($e->getMessage());
       CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/contact/view/membership',
         "reset=1&action=renew&cid={$this->_contactID}&id={$this->_id}&context=membership&mode={$this->_mode}"
       ));

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -469,7 +469,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
       return $statusMsg;
     }
     catch (\Civi\Payment\Exception\PaymentProcessorException $e) {
-      CRM_Core_Error::displaySessionError($e->getMessage());
+      CRM_Core_Error::displaySessionError($e);
       CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/contact/view/membership',
         "reset=1&action=renew&cid={$this->_contactID}&id={$this->_id}&context=membership&mode={$this->_mode}"
       ));


### PR DESCRIPTION
Offline Credit Card Membership Renewal not showing any error message on failure

Function CRM_Core_Error::getMessages() check Exception is of  'CRM_Core_Error' class while it is from class 'Civi\Payment\Exception\PaymentProcessorException'
Hence unable to show the Error message received from Payment gateway.

So added additional check for ' 'Civi\Payment\Exception\PaymentProcessorException'

---

 * [CRM-21554: Offline Credit Card Membership Renewal not showing any error message on failure ](https://issues.civicrm.org/jira/browse/CRM-21554)