### PR TITLE
CRM-21560 - CRM_Event_Form_Task fatal error

### DIFF
--- a/CRM/Event/Form/Task.php
+++ b/CRM/Event/Form/Task.php
@@ -127,7 +127,7 @@ class CRM_Event_Form_Task extends CRM_Core_Form {
     //set the context for redirection for any task actions
     $session = CRM_Core_Session::singleton();
 
-    $qfKey = CRM_Utils_Request::retrieve('qfKey', 'String', $this);
+    $qfKey = CRM_Utils_Request::retrieve('qfKey', 'String', $form);
     $urlParams = 'force=1';
     if (CRM_Utils_Rule::qfKey($qfKey)) {
       $urlParams .= "&qfKey=$qfKey";


### PR DESCRIPTION
Fatal error: Uncaught Error: Using $this when not in object context

![wp-admin_admin_php_page_civicrm](https://user-images.githubusercontent.com/6892898/33996234-476a000e-e0e9-11e7-83ac-8ca178d0354a.png)

---

 * [CRM-21560: CRM_Event_Form_Task fatal error](https://issues.civicrm.org/jira/browse/CRM-21560)