### PR TITLE
Increase minimum php version requirements

### DIFF
--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -48,9 +48,9 @@ class CRM_Upgrade_Form extends CRM_Core_Form {
   const MINIMUM_UPGRADABLE_VERSION = '4.0.8';
 
   /**
-   * Minimum php version we support
+   * Minimum php version required to run (equal to or lower than the minimum install version)
    */
-  const MINIMUM_PHP_VERSION = '5.3.4';
+  const MINIMUM_PHP_VERSION = '5.4';
 
   protected $_config;
 

--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -67,10 +67,10 @@ class CRM_Upgrade_Incremental_General {
     $dateFormat = Civi::Settings()->get('dateformatshortdate');
     if (version_compare(phpversion(), self::MIN_RECOMMENDED_PHP_VER) < 0) {
       $preUpgradeMessage .= '<p>';
-      $preUpgradeMessage .= ts('You may proceed with the upgrade and CiviCRM %1 will continue working normally, but future releases will require PHP %2 or above. We recommend php version %3.', array(
+      $preUpgradeMessage .= ts('You may proceed with the upgrade and CiviCRM %1 will continue working normally, but future releases will require PHP %2 or above. We recommend PHP version %3.', array(
          1 => $latestVer,
          2 => self::MIN_RECOMMENDED_PHP_VER,
-         2 => self::RECOMMENDED_PHP_VER,
+         3 => self::RECOMMENDED_PHP_VER,
       ));
       $preUpgradeMessage .= '</p>';
     }

--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -41,25 +41,19 @@ class CRM_Upgrade_Incremental_General {
   /**
    * The recommended PHP version.
    */
-  const MIN_RECOMMENDED_PHP_VER = '5.6';
+  const RECOMMENDED_PHP_VER = '7.0';
 
   /**
    * The previous recommended PHP version.
    */
-  const PREVIOUS_MIN_RECOMMENDED_PHP_VER = '5.5';
+  const MIN_RECOMMENDED_PHP_VER = '5.6';
 
   /**
    * The minimum PHP version required to install Civi.
    *
    * @see install/index.php
    */
-  const MIN_INSTALL_PHP_VER = '5.3.4';
-
-  /**
-   * The minimum PHP version required to avoid known
-   * limits or defects.
-   */
-  const MIN_DEFECT_PHP_VER = '5.3.23';
+  const MIN_INSTALL_PHP_VER = '5.4';
 
   /**
    * Compute any messages which should be displayed before upgrade.
@@ -73,25 +67,11 @@ class CRM_Upgrade_Incremental_General {
     $dateFormat = Civi::Settings()->get('dateformatshortdate');
     if (version_compare(phpversion(), self::MIN_RECOMMENDED_PHP_VER) < 0) {
       $preUpgradeMessage .= '<p>';
-      // CRM-20941 PHP 5.3 end date of End of 2017, PHP 5.4 End date End of Feb 2018 Recommend anyone on PHP 5.5 to move up to 5.6 or later e.g. 7.0
-      if (version_compare(phpversion(), self::PREVIOUS_MIN_RECOMMENDED_PHP_VER) >= 0) {
-        $preUpgradeMessage .= ts('You may proceed with the upgrade and CiviCRM %1 will continue working normally, but future releases will require PHP %2 or above. We recommend you use the most recent php version you can.', array(
-           1 => $latestVer,
-           2 => self::MIN_RECOMMENDED_PHP_VER,
-        ));
-      }
-      elseif (version_compare(phpversion(), 5.5) < 0) {
-        $date = CRM_Utils_Date::customFormat('2018-02-28', $dateFormat);
-        if (version_compare(phpversion(), 5.4) < 0) {
-          $date = CRM_Utils_Date::customFormat('2017-12-31', $dateFormat);
-        }
-        $preUpgradeMessage .= ts('You may proceed with the upgrade and CiviCRM %1 will continue working normally, but PHP %2 will not work in releases published after %3. We recommend you use the most recent php version you can. For more explanation see <a href="%4">the announcement</a>.', array(
-          1 => $currentVer,
-          2 => phpversion(),
-          3 => $date,
-          4 => 'https://civicrm.org/blog/totten/end-of-zombies-php-53-and-54',
-        ));
-      }
+      $preUpgradeMessage .= ts('You may proceed with the upgrade and CiviCRM %1 will continue working normally, but future releases will require PHP %2 or above. We recommend php version %3.', array(
+         1 => $latestVer,
+         2 => self::MIN_RECOMMENDED_PHP_VER,
+         2 => self::RECOMMENDED_PHP_VER,
+      ));
       $preUpgradeMessage .= '</p>';
     }
 

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -37,54 +37,59 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
    */
   public function checkPhpVersion() {
     $messages = array();
+    $phpVersion = phpversion();
 
-    if (version_compare(phpversion(), CRM_Upgrade_Incremental_General::MIN_RECOMMENDED_PHP_VER) >= 0) {
+    if (version_compare($phpVersion, CRM_Upgrade_Incremental_General::RECOMMENDED_PHP_VER) >= 0) {
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
-        ts('This system uses PHP version %1 which meets or exceeds the minimum recommendation of %2.',
+        ts('This system uses PHP version %1 which meets or exceeds the recommendation of %2.',
           array(
-            1 => phpversion(),
-            2 => CRM_Upgrade_Incremental_General::MIN_RECOMMENDED_PHP_VER,
+            1 => $phpVersion,
+            2 => CRM_Upgrade_Incremental_General::RECOMMENDED_PHP_VER,
           )),
         ts('PHP Up-to-Date'),
         \Psr\Log\LogLevel::INFO,
         'fa-server'
       );
     }
-    elseif (version_compare(phpversion(), CRM_Upgrade_Incremental_General::PREVIOUS_MIN_RECOMMENDED_PHP_VER) >= 0) {
+    elseif (version_compare($phpVersion, CRM_Upgrade_Incremental_General::MIN_RECOMMENDED_PHP_VER) >= 0) {
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
-        ts('This system uses PHP version %1. While this meets the minimum requirements for CiviCRM to function, upgrading to PHP version %2 or newer is recommended for maximum compatibility.',
+        ts('This system uses PHP version %1. This meets the minimum recommendations and you do not need to upgrade immediately, but the preferred version is %2.',
           array(
-            1 => phpversion(),
-            2 => CRM_Upgrade_Incremental_General::MIN_RECOMMENDED_PHP_VER,
-            3 => CRM_Upgrade_Incremental_General::MIN_DEFECT_PHP_VER,
+            1 => $phpVersion,
+            2 => CRM_Upgrade_Incremental_General::RECOMMENDED_PHP_VER,
           )),
         ts('PHP Out-of-Date'),
         \Psr\Log\LogLevel::NOTICE,
         'fa-server'
       );
     }
-    else {
-      $date = '';
-      $dateFormat = Civi::Settings()->get('dateformatshortdate');
-      if (version_compare(phpversion(), 5.4) < 0) {
-        $date = CRM_Utils_Date::customFormat('2017-12-31', $dateFormat);
-      }
-      elseif (version_compare(phpversion(), 5.5) < 0) {
-        $date = CRM_Utils_Date::customFormat('2018-02-28', $dateFormat);
-      }
+    elseif (version_compare($phpVersion, CRM_Upgrade_Incremental_General::MIN_INSTALL_PHP_VER) >= 0) {
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
-        ts('This system uses PHP version %1. CiviCRM can be installed on this version. However PHP version %1 will not work in releases published after %2, and version %3 is recommended. For more explanation see <a href="%4"> the announcement</a>',
+        ts('This system uses PHP version %1. This meets the minimum requirements for CiviCRM to function but is not recommended. At least PHP version %2 is recommended; the preferrred version is %3.',
           array(
-            1 => phpversion(),
-            2 => $date,
-            3 => CRM_Upgrade_Incremental_General::MIN_RECOMMENDED_PHP_VER,
-            4 => 'https://civicrm.org/blog/totten/end-of-zombies-php-53-and-54',
+            1 => $phpVersion,
+            2 => CRM_Upgrade_Incremental_General::MIN_RECOMMENDED_PHP_VER,
+            3 => CRM_Upgrade_Incremental_General::RECOMMENDED_PHP_VER,
           )),
         ts('PHP Out-of-Date'),
         \Psr\Log\LogLevel::WARNING,
+        'fa-server'
+      );
+    }
+    else {
+      $messages[] = new CRM_Utils_Check_Message(
+        __FUNCTION__,
+        ts('This system uses PHP version %1. To ensure the continued operation of CiviCRM, upgrade your server now. At least PHP version %2 is recommended; the preferrred version is %3.',
+          array(
+            1 => $phpVersion,
+            2 => CRM_Upgrade_Incremental_General::MIN_RECOMMENDED_PHP_VER,
+            3 => CRM_Upgrade_Incremental_General::RECOMMENDED_PHP_VER,
+          )),
+        ts('PHP Out-of-Date'),
+        \Psr\Log\LogLevel::ERROR,
         'fa-server'
       );
     }

--- a/install/index.php
+++ b/install/index.php
@@ -595,12 +595,9 @@ class InstallRequirements {
 
     $this->errors = NULL;
 
-    // See also: CRM_Upgrade_Incremental_General::MIN_INSTALL_PHP_VER
-    $this->requirePHPVersion('5.3.4', array(
+    $this->requirePHPVersion(array(
       ts("PHP Configuration"),
       ts("PHP5 installed"),
-      NULL,
-      ts("PHP version %1", array(1 => phpversion())),
     ));
 
     // Check that we can identify the root folder successfully
@@ -860,36 +857,30 @@ class InstallRequirements {
   }
 
   /**
-   * @param $minVersion
-   * @param $testDetails
-   * @param null $maxVersion
+   * @param array $testDetails
+   * @return bool
    */
-  public function requirePHPVersion($minVersion, $testDetails, $maxVersion = NULL) {
+  public function requirePHPVersion($testDetails) {
 
     $this->testing($testDetails);
 
     $phpVersion = phpversion();
-    $aboveMinVersion = version_compare($phpVersion, $minVersion) >= 0;
-    $belowMaxVersion = $maxVersion ? version_compare($phpVersion, $maxVersion) < 0 : TRUE;
+    $aboveMinVersion = version_compare($phpVersion, CRM_Upgrade_Incremental_General::MIN_INSTALL_PHP_VER) >= 0;
 
-    if ($aboveMinVersion && $belowMaxVersion) {
+    if ($aboveMinVersion) {
       if (version_compare(phpversion(), CRM_Upgrade_Incremental_General::MIN_RECOMMENDED_PHP_VER) < 0) {
-        $testDetails[2] = ts('This webserver is running an outdated version of PHP (%1). It is strongly recommended to upgrade to PHP %2 or later, as older versions can present a security risk.', array(
+        $testDetails[2] = ts('This webserver is running an outdated version of PHP (%1). It is strongly recommended to upgrade to PHP %2 or later, as older versions can present a security risk. The preferred version is %3.', array(
           1 => phpversion(),
           2 => CRM_Upgrade_Incremental_General::MIN_RECOMMENDED_PHP_VER,
+          3 => CRM_Upgrade_Incremental_General::RECOMMENDED_PHP_VER,
         ));
         $this->warning($testDetails);
       }
       return TRUE;
     }
 
-    if (!$testDetails[2]) {
-      if (!$aboveMinVersion) {
-        $testDetails[2] = ts("You need PHP version %1 or later, only %2 is installed. Please upgrade your server, or ask your web-host to do so.", array(1 => $minVersion, 2 => $phpVersion));
-      }
-      else {
-        $testDetails[2] = ts("PHP version %1 is not supported. PHP version earlier than %2 is required. You might want to downgrade your server, or ask your web-host to do so.", array(1 => $maxVersion, 2 => $phpVersion));
-      }
+    if (empty($testDetails[2])) {
+      $testDetails[2] = ts("You need PHP version %1 or later, only %2 is installed. Please upgrade your server, or ask your web-host to do so.", array(1 => CRM_Upgrade_Incremental_General::MIN_INSTALL_PHP_VER, 2 => $phpVersion));
     }
 
     $this->error($testDetails);

--- a/install/index.php
+++ b/install/index.php
@@ -868,9 +868,9 @@ class InstallRequirements {
     $aboveMinVersion = version_compare($phpVersion, CRM_Upgrade_Incremental_General::MIN_INSTALL_PHP_VER) >= 0;
 
     if ($aboveMinVersion) {
-      if (version_compare(phpversion(), CRM_Upgrade_Incremental_General::MIN_RECOMMENDED_PHP_VER) < 0) {
+      if (version_compare($phpVersion, CRM_Upgrade_Incremental_General::MIN_RECOMMENDED_PHP_VER) < 0) {
         $testDetails[2] = ts('This webserver is running an outdated version of PHP (%1). It is strongly recommended to upgrade to PHP %2 or later, as older versions can present a security risk. The preferred version is %3.', array(
-          1 => phpversion(),
+          1 => $phpVersion,
           2 => CRM_Upgrade_Incremental_General::MIN_RECOMMENDED_PHP_VER,
           3 => CRM_Upgrade_Incremental_General::RECOMMENDED_PHP_VER,
         ));


### PR DESCRIPTION
Overview
--------

As promised in our [blog post](https://civicrm.org/blog/totten/end-of-zombies-php-53-and-54) we are incrementing the minimum php requirements for CiviCRM.

Issue is here: https://lab.civicrm.org/infrastructure/ops/issues/818

Before/After
----

|  | Before | After |
-- | -- | -- |
| Min to run | 5.3 | 5.4 |
| Min to install | 5.3 | 5.4* |
| Min recommended ver | 5.5 | 5.6 |
| Recommended ver | 5.6 | 7.0 |

\* We'll bump this to 5.5 in the following release as promised.