### PR TITLE
CRM-21568 - don't treat a string '0' as non-zero

### DIFF
--- a/Civi/Core/SettingsBag.php
+++ b/Civi/Core/SettingsBag.php
@@ -352,9 +352,10 @@ class SettingsBag {
     }
     $dao->find(TRUE);
 
-    // string comparison with 0 always return true, so to be ensure the type use ===
-    // ref - https://stackoverflow.com/questions/8671942/php-string-comparasion-to-0-integer-returns-true
-    if (isset($metadata['on_change']) && !($value === 0 && ($dao->value === NULL || unserialize($dao->value) == 0))) {
+    // string comparison with 0 always return true, but we must also evaluate a string of '0' to false
+    // ref - http://php.net/manual/en/types.comparisons.php
+    // The boolean logic here is: "If an on_change callback exists, and the old and new values are not both zero"
+    if (isset($metadata['on_change']) && ($value || !($dao->value === NULL || unserialize($dao->value) == 0))) {
       foreach ($metadata['on_change'] as $callback) {
         call_user_func(
           \Civi\Core\Resolver::singleton()->get($callback),


### PR DESCRIPTION
Overview
----------------------------------------
In Civi\Core/SettingsBag::setDb is a line of code that checks whether the setting in question has an on_change callback.  It should only run a callback if the old value and new value of the setting aren't both null/zero.

As part of CRM-18231, Monish Deb identified a problem.  The code was treating ANY strings as a zero.  However, in fixing it, they caused the string "0" to be evaluated as "non-zero".

This reintroduced the same symptoms seen in CRM-19610, which was the bug that caused the "don't run a callback if old and new values are null/zero" code to be introduced.

 
References:

https://chat.civicrm.org/civicrm/pl/brdi48bko3rqxy87eefqcnrrwe
https://civicrm.stackexchange.com/questions/21827/unable-to-update-search-preferences-after-upgrading-to-civicrm-4-7-28


Before
----------------------------------------
When saving Search Preferences and your MySQL user lacks SUPER privileges, you get a fatal error (see backtrace on SE link above).

After
----------------------------------------
Search Preferences can be saved successfully.

Comments
----------------------------------------
This is a regression introduced in 4.7.28 and should be merged to the rc IMO.

---

 * [CRM-21568: Change to Settings code results in regression of CRM-19610](https://issues.civicrm.org/jira/browse/CRM-21568)
 * [CRM-18231: Support safe migration from production to non-production instances](https://issues.civicrm.org/jira/browse/CRM-18231)
 * [CRM-19610: Fatal when creating InnoDB fts indexes](https://issues.civicrm.org/jira/browse/CRM-19610)