### PR TITLE
CRM-21538: Field not found when sorting report by Case Type as a section header

### DIFF
--- a/CRM/Report/Form/Case/Detail.php
+++ b/CRM/Report/Form/Case/Detail.php
@@ -549,6 +549,9 @@ class CRM_Report_Form_Case_Detail extends CRM_Report_Form {
 
     if ($this->_caseTypeNameOrderBy) {
       $this->_orderBy = str_replace('case_civireport.case_type_name', 'civireport_case_types.title', $this->_orderBy);
+      if (isset($this->_sections['civicrm_case_case_type_name'])) {
+        $this->_sections['civicrm_case_case_type_name']['dbAlias'] = 'civireport_case_types.title';
+      }
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Attempting to create a Case Detail report sorted by the field Case Type with the option "Section Header" checked does not work.

Before
----------------------------------------

Creating a case detail report with this sorting configuration:

![obraz](https://user-images.githubusercontent.com/34529299/34069089-80584752-e249-11e7-9d4b-68e783fa7181.png)

causes application to crash. The error is:

`Unknown column 'case_civireport.case_type_name' in 'field list'`

After
----------------------------------------

With this small change report generates as expected.


Comments
----------------------------------------

It appears that this field (added in [CRM-20368](https://github.com/civicrm/civicrm-core/pull/10087) PR) requires special handling.

---

 * [CRM-21538: CiviReport: Field not found when sorting by Case Type as a section header](https://issues.civicrm.org/jira/browse/CRM-21538)
 * [CRM-20368: report templates: don't hard-code order bys](https://issues.civicrm.org/jira/browse/CRM-20368)