### PR TITLE
4.7.29 rc

### DIFF
--- a/CRM/Upgrade/Incremental/sql/4.7.29.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.7.29.mysql.tpl
@@ -1,0 +1,1 @@
+{* file to handle db changes in 4.7.29 during upgrade *}

--- a/CRM/Utils/SQL.php
+++ b/CRM/Utils/SQL.php
@@ -80,7 +80,7 @@ class CRM_Utils_SQL {
     // CRM-21455 MariaDB 10.2 does not support ANY_VALUE
     $version = CRM_Core_DAO::singleValueQuery('SELECT VERSION()');
 
-    if (stripos('mariadb', $version) !== FALSE) {
+    if (stripos($version, 'mariadb') !== FALSE) {
       return FALSE;
     }
 

--- a/sql/civicrm_generated.mysql
+++ b/sql/civicrm_generated.mysql
@@ -399,7 +399,7 @@ UNLOCK TABLES;
 
 LOCK TABLES `civicrm_domain` WRITE;
 /*!40000 ALTER TABLE `civicrm_domain` DISABLE KEYS */;
-INSERT INTO `civicrm_domain` (`id`, `name`, `description`, `config_backend`, `version`, `contact_id`, `locales`, `locale_custom_strings`) VALUES (1,'Default Domain Name',NULL,NULL,'4.7.28',1,NULL,'a:1:{s:5:\"en_US\";a:0:{}}');
+INSERT INTO `civicrm_domain` (`id`, `name`, `description`, `config_backend`, `version`, `contact_id`, `locales`, `locale_custom_strings`) VALUES (1,'Default Domain Name',NULL,NULL,'4.7.29',1,NULL,'a:1:{s:5:\"en_US\";a:0:{}}');
 /*!40000 ALTER TABLE `civicrm_domain` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/xml/version.xml
+++ b/xml/version.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="iso-8859-1" ?>
 <version>
-  <version_no>4.7.28</version_no>
+  <version_no>4.7.29</version_no>
 </version>


### PR DESCRIPTION
Overview
----------------------------------------
CRM-21571 - .htaccess for old and new Apache versions

Before
----------------------------------------
Files on newer Apache versions in secured folders (e.g. upload) can be accessed without proper authorization. 

After
----------------------------------------
Secured folders (e.g. upload) should be accessed with proper authorization, independent from the version of apache. 

Technical Details
----------------------------------------
The creation of .htaccess is changed. Based on specific Apache modules, the proper commands are discerned. 

Comments
----------------------------------------
This is taken from Drupal.

---

 * [CRM-21571: Create .htaccess supporting both Apache 2.4 and 2.0-2.2 versions](https://issues.civicrm.org/jira/browse/CRM-21571)