### PR TITLE
Remove php 5.3 shim for json formatting

### DIFF
--- a/CRM/Utils/REST.php
+++ b/CRM/Utils/REST.php
@@ -146,6 +146,7 @@ class CRM_Utils_REST {
     if (!empty($requestParams['json'])) {
       if (!empty($requestParams['prettyprint'])) {
         // Don't set content-type header for api explorer output
+        return json_encode(array_merge($result), JSON_PRETTY_PRINT + JSON_UNESCAPED_SLASHES + JSON_UNESCAPED_UNICODE);
         return self::jsonFormated(array_merge($result));
       }
       CRM_Utils_System::setHttpHeader('Content-Type', 'application/json');
@@ -179,100 +180,6 @@ class CRM_Utils_REST {
 
     $xml .= "</ResultSet>\n";
     return $xml;
-  }
-
-  /**
-   * @param $data
-   *
-   * @deprecated - switch to native JSON_PRETTY_PRINT when we drop support for php 5.3
-   *
-   * @return string
-   */
-  public static function jsonFormated($data) {
-    // If php is 5.4+ we can use the native method
-    if (defined('JSON_PRETTY_PRINT')) {
-      return json_encode($data, JSON_PRETTY_PRINT + JSON_UNESCAPED_SLASHES + JSON_UNESCAPED_UNICODE);
-    }
-
-    // PHP 5.3 shim
-    $json = str_replace('\/', '/', json_encode($data));
-    $tabcount = 0;
-    $result = '';
-    $inquote = FALSE;
-    $inarray = FALSE;
-    $ignorenext = FALSE;
-
-    $tab = "\t";
-    $newline = "\n";
-
-    for ($i = 0; $i < strlen($json); $i++) {
-      $char = $json[$i];
-
-      if ($ignorenext) {
-        $result .= $char;
-        $ignorenext = FALSE;
-      }
-      else {
-        switch ($char) {
-          case '{':
-            if ($inquote) {
-              $result .= $char;
-            }
-            else {
-              $inarray = FALSE;
-              $tabcount++;
-              $result .= $char . $newline . str_repeat($tab, $tabcount);
-            }
-            break;
-
-          case '}':
-            if ($inquote) {
-              $result .= $char;
-            }
-            else {
-              $tabcount--;
-              $result = trim($result) . $newline . str_repeat($tab, $tabcount) . $char;
-            }
-            break;
-
-          case ',':
-            if ($inquote || $inarray) {
-              $result .= $char;
-            }
-            else {
-              $result .= $char . $newline . str_repeat($tab, $tabcount);
-            }
-            break;
-
-          case '"':
-            $inquote = !$inquote;
-            $result .= $char;
-            break;
-
-          case '\\':
-            if ($inquote) {
-              $ignorenext = TRUE;
-            }
-            $result .= $char;
-            break;
-
-          case '[':
-            $inarray = TRUE;
-            $result .= $char;
-            break;
-
-          case ']':
-            $inarray = FALSE;
-            $result .= $char;
-            break;
-
-          default:
-            $result .= $char;
-        }
-      }
-    }
-
-    return $result;
   }
 
   /**


### PR DESCRIPTION
Overview
---

This function is only used for outputting to the api explorer, and it was only invoked in php < 5.4. Now that we've dropped php 5.3 support, we can get rid of it.