### PR TITLE
CRM-21159: Address fields cause DB errors when adding contacts to group from Search Builder

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2142,6 +2142,7 @@ class CRM_Contact_BAO_Query {
       }
 
       $this->_where[$grouping][] = self::buildClause($where, $op, $value);
+      $this->_tables[$aName] = $this->_whereTables[$aName] = 1;
       list($qillop, $qillVal) = self::buildQillForFieldValue('CRM_Core_DAO_Address', "state_province_id", $value, $op);
       $this->_qill[$grouping][] = ts("%1 %2 %3", array(1 => $field['title'], 2 => $qillop, 3 => $qillVal));
     }
@@ -2170,8 +2171,9 @@ class CRM_Contact_BAO_Query {
       }
 
       $this->_where[$grouping][] = self::buildClause($where, $op, $value, 'Positive');
+      $this->_tables[$aName] = $this->_whereTables[$aName] = 1;
 
-      list($qillop, $qillVal) = CRM_Contact_BAO_Query::buildQillForFieldValue(NULL, $name, $value, $op);
+        list($qillop, $qillVal) = CRM_Contact_BAO_Query::buildQillForFieldValue(NULL, $name, $value, $op);
       $this->_qill[$grouping][] = ts("%1 %2 %3", array(1 => $field['title'], 2 => $qillop, 3 => $qillVal));
     }
     elseif ($name === 'world_region') {

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2173,7 +2173,7 @@ class CRM_Contact_BAO_Query {
       $this->_where[$grouping][] = self::buildClause($where, $op, $value, 'Positive');
       $this->_tables[$aName] = $this->_whereTables[$aName] = 1;
 
-        list($qillop, $qillVal) = CRM_Contact_BAO_Query::buildQillForFieldValue(NULL, $name, $value, $op);
+      list($qillop, $qillVal) = CRM_Contact_BAO_Query::buildQillForFieldValue(NULL, $name, $value, $op);
       $this->_qill[$grouping][] = ts("%1 %2 %3", array(1 => $field['title'], 2 => $qillop, 3 => $qillVal));
     }
     elseif ($name === 'world_region') {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes for problem with Address fields causing DB errors when adding contacts to group from Search Builder.
![Alt text](https://monosnap.com/file/pbUcK0IAHhsWEElGEvTQglvNgWGZBe.png)

Before
----------------------------------------
The "DB Error: no such field" screen appears directly after clicking or selecting "Group - add contacts." when the Search Builder is used to create a search that includes an address field ( State and Country) 
![Alt text](https://monosnap.com/file/qyt7QALylQj8sXR2MMv0wBmsIUk41I.png)

After
----------------------------------------
The page now loads properly with all required fields resolved.
![Alt text](https://monosnap.com/file/Tnh9iLay1SBfuiH9QB2xRWcEocQTTA.png)


Technical Details
----------------------------------------
Join statement was missing in the generated query. Only reference to the table alias was added to the where clause.

---

 * [CRM-21159: Address fields cause DB errors when adding contacts to group from Search Builder](https://issues.civicrm.org/jira/browse/CRM-21159)