### PR TITLE
CRM-21568 - Move emptiness judgments from SettingsBag::setDb to InnoDBIndexer

### DIFF
--- a/CRM/Core/InnoDBIndexer.php
+++ b/CRM/Core/InnoDBIndexer.php
@@ -91,6 +91,10 @@ class CRM_Core_InnoDBIndexer {
    *   Specification of the setting (per *.settings.php).
    */
   public static function onToggleFts($oldValue, $newValue, $metadata) {
+    if (empty($oldValue) && empty($newValue)) {
+      return;
+    }
+
     $indexer = CRM_Core_InnoDBIndexer::singleton();
     $indexer->setActive($newValue);
     $indexer->fixSchemaDifferences();

--- a/Civi/Core/SettingsBag.php
+++ b/Civi/Core/SettingsBag.php
@@ -352,9 +352,11 @@ class SettingsBag {
     }
     $dao->find(TRUE);
 
-    // string comparison with 0 always return true, so to be ensure the type use ===
-    // ref - https://stackoverflow.com/questions/8671942/php-string-comparasion-to-0-integer-returns-true
-    if (isset($metadata['on_change']) && !($value === 0 && ($dao->value === NULL || unserialize($dao->value) == 0))) {
+    // Call 'on_change' listeners. It would be nice to only fire when there's
+    // a genuine change in the data. However, PHP developers have mixed
+    // expectations about whether 0, '0', '', NULL, and FALSE represent the same
+    // value, so there's no universal way to determine if a change is genuine.
+    if (isset($metadata['on_change'])) {
       foreach ($metadata['on_change'] as $callback) {
         call_user_func(
           \Civi\Core\Resolver::singleton()->get($callback),


### PR DESCRIPTION
Overview
----------------------------------------

The `SettingsBag::setDb()` function calls any `on_change` listeners.  It
originally used "dumb on change" behavior (where it calls the listeners
without comparing values).  CRM-19610 had an issue where the `InnoDBIndexer`
was running a bit too often, so they tried to resolve it by
making the `SettingsBag::setDb()` more clever.

Unfortunately, that's been a bit bouncy, and the cleverness depends on one's
particular interpretation of 0 vs '0' vs '' vs NULL vs FALSE.

Related discussion: https://github.com/civicrm/civicrm-core/pull/11417

Before
----------------------------------------
All on-change listeners may be skipped if there's particular mix of emptiness
in the old/new values.

After
----------------------------------------
The on-change listeners always fire. However, the specific listener
involved with CRM-19610 will now ignore some insignificant changes.


Comments
----------------------------------------
For `r-run` testing, I did the following:
 * Switch local mysqld to v5.5. Rebuild. Navigate to "Search Preferences" and save (without making changes).
 * Switch local mysqld to v5.7. Rebuild. Navigate to "Search Preferences". Perform several cycles of
   alternately updating values and reloading form.

---

 * [CRM-21568: Change to Settings code results in regression of CRM-19610](https://issues.civicrm.org/jira/browse/CRM-21568)
 * [CRM-19610: Fatal when creating InnoDB fts indexes](https://issues.civicrm.org/jira/browse/CRM-19610)