### PR TITLE
CRM-21573 Allow to disable sending of email from activity source contact email for receipt

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -3196,7 +3196,9 @@ WHERE id IN (' . implode(',', $copiedActivityIds) . ')';
   public static function getReceiptFrom($activityID) {
     $name = $address = NULL;
 
-    if (!empty($activityID)) {
+    if (!empty($activityID) && (Civi::settings()->get('allow_mail_from_logged_in_contact'))) {
+      // This breaks SPF/DMARC if email is sent from an email address that the server is not authorised to send from.
+      //    so we can disable this behaviour with the "allow_mail_from_logged_in_contact" setting.
       // There is always a 'Added by' contact for a activity,
       //  so we can safely use ActivityContact.Getvalue API
       $sourceContactId = civicrm_api3('ActivityContact', 'getvalue', array(

--- a/CRM/Core/BAO/Domain.php
+++ b/CRM/Core/BAO/Domain.php
@@ -303,9 +303,14 @@ class CRM_Core_BAO_Domain extends CRM_Core_DAO_Domain {
     if (!empty($domain['domain_email'])) {
       return array($domain['name'], $domain['domain_email']);
     }
-    $userID = CRM_Core_Session::singleton()->getLoggedInContactID();
     $userName = '';
     $userEmail = '';
+
+    if (!Civi::settings()->get('allow_mail_from_logged_in_contact')) {
+      return array($userName, $userEmail);
+    }
+
+    $userID = CRM_Core_Session::singleton()->getLoggedInContactID();
     if (!empty($userID)) {
       list($userName, $userEmail) = CRM_Contact_BAO_Contact_Location::getEmailDetails($userID);
     }


### PR DESCRIPTION
Overview
----------------------------------------
When sending email receipts or changing activity assignees the default is to use the contact email address.  However this is not always desirable as it can break SPF/DMARC and lead to bounced/failed email delivery.

For reference, also see CRM-20308

---

 * [CRM-21573: Allow to disable sending of email from activity source contact email for receipt](https://issues.civicrm.org/jira/browse/CRM-21573)
 * [CRM-21244: Enhancements to "FROM email addresses"](https://issues.civicrm.org/jira/browse/CRM-21244)
 * [CRM-20308: Activity copy is always sent FROM logged in user's email ID](https://issues.civicrm.org/jira/browse/CRM-20308)