### PR TITLE
CRM-21574 Allow to disable sending of email from source contact for tell a friend on pcp

### DIFF
--- a/CRM/Friend/BAO/Friend.php
+++ b/CRM/Friend/BAO/Friend.php
@@ -29,15 +29,22 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2018
- * $Id$
  *
  */
 
 /**
- * This class contains the funtions for Friend
+ * This class contains the functions for Friend
  *
  */
 class CRM_Friend_BAO_Friend extends CRM_Friend_DAO_Friend {
+
+  /**
+   * Tell a friend id in db.
+   *
+   * @var int
+   */
+  public $_friendId;
+
   /**
    */
   public function __construct() {
@@ -74,13 +81,9 @@ class CRM_Friend_BAO_Friend extends CRM_Friend_DAO_Friend {
    */
   public static function retrieve(&$params, &$values) {
     $friend = new CRM_Friend_DAO_Friend();
-
     $friend->copyValues($params);
-
     $friend->find(TRUE);
-
     CRM_Core_DAO::storeValues($friend, $values);
-
     return $values;
   }
 
@@ -88,15 +91,17 @@ class CRM_Friend_BAO_Friend extends CRM_Friend_DAO_Friend {
    * Takes an associative array and creates a friend object.
    *
    * @param array $params
-   *   (reference ) an assoc array of name/value pairs.
+   *   (reference) an assoc array of name/value pairs.
    *
-   * @return void
+   * @throws \CRM_Core_Exception
    */
   public static function create(&$params) {
     $transaction = new CRM_Core_Transaction();
 
     $mailParams = array();
-    //create contact corresponding to each friend
+    $contactParams = array();
+
+    // create contact corresponding to each friend
     foreach ($params['friend'] as $key => $details) {
       if ($details["first_name"]) {
         $contactParams[$key] = array(
@@ -111,14 +116,15 @@ class CRM_Friend_BAO_Friend extends CRM_Friend_DAO_Friend {
       }
     }
 
-    $frndParams = array();
-    $frndParams['entity_id'] = $params['entity_id'];
-    $frndParams['entity_table'] = $params['entity_table'];
-    self::getValues($frndParams);
+    $friendParams = [
+      'entity_id' => $params['entity_id'],
+      'entity_table' => $params['entity_table'],
+    ];
+    self::getValues($friendParams);
 
     $activityTypeId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionValue', 'Tell a Friend', 'value', 'name');
 
-    //create activity
+    // create activity
     $activityParams = array(
       'source_contact_id' => $params['source_contact_id'],
       'source_record_id' => NULL,
@@ -127,20 +133,19 @@ class CRM_Friend_BAO_Friend extends CRM_Friend_DAO_Friend {
       'activity_date_time' => date("YmdHis"),
       'subject' => ts('Tell a Friend') . ": {$params['title']}",
       'details' => $params['suggested_message'],
-      'status_id' => 2,
+      'status_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_status_id', 'Completed'),
       'is_test' => $params['is_test'],
       'campaign_id' => CRM_Utils_Array::value('campaign_id', $params),
     );
 
-    //activity creation
+    // activity creation
     $activity = CRM_Activity_BAO_Activity::create($activityParams);
     $activityContacts = CRM_Activity_BAO_ActivityContact::buildOptions('record_type_id', 'validate');
     $targetID = CRM_Utils_Array::key('Activity Targets', $activityContacts);
 
-    //friend contacts creation
+    // friend contacts creation
     foreach ($contactParams as $key => $value) {
-
-      //create contact only if it does not exits in db
+      // create contact only if it does not exits in db
       $value['email'] = $value['email-Primary'];
       $contactID = CRM_Contact_BAO_Contact::getFirstDuplicateContact($value, 'Individual', 'Supervised', array(), FALSE);
 
@@ -167,28 +172,27 @@ class CRM_Friend_BAO_Friend extends CRM_Friend_DAO_Friend {
 
     $transaction->commit();
 
-    //process sending of mails
+    // Process sending of mails
     $mailParams['title'] = CRM_Utils_Array::value('title', $params);
-    $mailParams['general_link'] = CRM_Utils_Array::value('general_link', $frndParams);
+    $mailParams['general_link'] = CRM_Utils_Array::value('general_link', $friendParams);
     $mailParams['message'] = CRM_Utils_Array::value('suggested_message', $params);
 
-    // get domain
-    $domainDetails = CRM_Core_BAO_Domain::getNameAndEmail();
-    list($username, $mailParams['domain']) = explode('@', $domainDetails[1]);
+    // Default "from email address" is default domain address.
+    list($_, $mailParams['email_from']) = CRM_Core_BAO_Domain::getNameAndEmail();
+    list($username, $mailParams['domain']) = explode('@', $mailParams['email_from']);
 
     $default = array();
     $findProperties = array('id' => $params['entity_id']);
 
     if ($params['entity_table'] == 'civicrm_contribution_page') {
-
       $returnProperties = array('receipt_from_email', 'is_email_receipt');
       CRM_Core_DAO::commonRetrieve('CRM_Contribute_DAO_ContributionPage',
         $findProperties,
         $default,
         $returnProperties
       );
-      //if is_email_receipt is set then take receipt_from_email
-      //as from_email
+
+      // if is_email_receipt is set then take receipt_from_email as from_email
       if (!empty($default['is_email_receipt']) && !empty($default['receipt_from_email'])) {
         $mailParams['email_from'] = $default['receipt_from_email'];
       }
@@ -197,7 +201,6 @@ class CRM_Friend_BAO_Friend extends CRM_Friend_DAO_Friend {
       $mailParams['module'] = 'contribute';
     }
     elseif ($params['entity_table'] == 'civicrm_event') {
-
       $returnProperties = array('confirm_from_email', 'is_email_confirm');
       CRM_Core_DAO::commonRetrieve('CRM_Event_DAO_Event',
         $findProperties,
@@ -205,10 +208,7 @@ class CRM_Friend_BAO_Friend extends CRM_Friend_DAO_Friend {
         $returnProperties
       );
 
-      $mailParams['email_from'] = $domainDetails['1'];
-
-      //if is_email_confirm is set then take confirm_from_email
-      //as from_email
+      // if is_email_confirm is set then take confirm_from_email as from_email
       if (!empty($default['is_email_confirm']) && !empty($default['confirm_from_email'])) {
         $mailParams['email_from'] = $default['confirm_from_email'];
       }
@@ -217,23 +217,25 @@ class CRM_Friend_BAO_Friend extends CRM_Friend_DAO_Friend {
       $mailParams['module'] = 'event';
     }
     elseif ($params['entity_table'] == 'civicrm_pcp') {
-      $mailParams['email_from'] = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Email', $params['source_contact_id'],
-        'email', 'contact_id'
-      );
+      if (Civi::settings()->get('allow_mail_from_logged_in_contact')) {
+        $mailParams['email_from'] = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Email', $params['source_contact_id'],
+          'email', 'contact_id'
+        );
+      }
       $urlPath = 'civicrm/pcp/info';
       $mailParams['module'] = 'contribute';
     }
 
     $mailParams['page_url'] = CRM_Utils_System::url($urlPath, "reset=1&id={$params['entity_id']}", TRUE, NULL, FALSE, TRUE);
 
-    //send mail
+    // Send the email
     self::sendMail($params['source_contact_id'], $mailParams);
   }
 
   /**
    * Build the form object.
    *
-   * @param CRM_Core_Form $form
+   * @param CRM_Friend_Form $form
    *   Form object.
    *
    * @return void
@@ -263,12 +265,12 @@ class CRM_Friend_BAO_Friend extends CRM_Friend_DAO_Friend {
   }
 
   /**
-   * The function sets the deafult values of the form.
+   * The function sets the default values of the form.
    *
    * @param array $defaults
    *   (reference) the default values.
    *
-   * @return booelan
+   * @return bool
    *   whether anything was found
    */
   public static function getValues(&$defaults) {
@@ -283,7 +285,7 @@ class CRM_Friend_BAO_Friend extends CRM_Friend_DAO_Friend {
   }
 
   /**
-   * Process that send tell a friend e-mails
+   * Process that sends tell a friend e-mails
    *
    * @param int $contactID
    * @param array $values
@@ -297,33 +299,34 @@ class CRM_Friend_BAO_Friend extends CRM_Friend_DAO_Friend {
       $fromName = $email;
     }
 
-    // use contact email, CRM-4963
-    if (empty($values['email_from'])) {
-      $values['email_from'] = $email;
+    if (Civi::settings()->get('allow_mail_from_logged_in_contact')) {
+      // use contact email, CRM-4963
+      if (empty($values['email_from'])) {
+        $values['email_from'] = $email;
+      }
     }
+
+    $templateParams = array(
+      'groupName' => 'msg_tpl_workflow_friend',
+      'valueName' => 'friend',
+      'contactId' => $contactID,
+      'tplParams' => array(
+        $values['module'] => $values['module'],
+        'senderContactName' => $fromName,
+        'title' => $values['title'],
+        'generalLink' => $values['general_link'],
+        'pageURL' => $values['page_url'],
+        'senderMessage' => $values['message'],
+      ),
+      'from' => "$fromName (via {$values['domain']}) <{$values['email_from']}>",
+      'replyTo' => $email,
+    );
 
     foreach ($values['email'] as $displayName => $emailTo) {
       if ($emailTo) {
-        // FIXME: factor the below out of the foreach loop
-        CRM_Core_BAO_MessageTemplate::sendTemplate(
-          array(
-            'groupName' => 'msg_tpl_workflow_friend',
-            'valueName' => 'friend',
-            'contactId' => $contactID,
-            'tplParams' => array(
-              $values['module'] => $values['module'],
-              'senderContactName' => $fromName,
-              'title' => $values['title'],
-              'generalLink' => $values['general_link'],
-              'pageURL' => $values['page_url'],
-              'senderMessage' => $values['message'],
-            ),
-            'from' => "$fromName (via {$values['domain']}) <{$values['email_from']}>",
-            'toName' => $displayName,
-            'toEmail' => $emailTo,
-            'replyTo' => $email,
-          )
-        );
+        $templateParams['toName'] = $displayName;
+        $templateParams['toEmail'] = $emailTo;
+        CRM_Core_BAO_MessageTemplate::sendTemplate($templateParams);
       }
     }
   }
@@ -336,16 +339,14 @@ class CRM_Friend_BAO_Friend extends CRM_Friend_DAO_Friend {
    * pairs
    *
    * @param array $params
-   *   (reference ) an assoc array of name/value pairs.
+   *   (reference) an assoc array of name/value pairs.
    *
-   * @return CRM_Friend_BAO_Friend
+   * @return CRM_Friend_DAO_Friend
    */
   public static function addTellAFriend(&$params) {
     $friendDAO = new CRM_Friend_DAO_Friend();
-
     $friendDAO->copyValues($params);
     $friendDAO->is_active = CRM_Utils_Array::value('is_active', $params, FALSE);
-
     $friendDAO->save();
 
     return $friendDAO;

--- a/CRM/Friend/Form.php
+++ b/CRM/Friend/Form.php
@@ -45,14 +45,21 @@ class CRM_Friend_Form extends CRM_Core_Form {
   const NUM_OPTION = 3;
 
   /**
-   * The id of the entity that we are proceessing.
+   * The id of the entity that we are processing.
    *
    * @var int
    */
   protected $_entityId;
 
   /**
-   * The table name of the entity that we are proceessing.
+   * Tell a friend id in db.
+   *
+   * @var int
+   */
+  public $_friendId;
+
+  /**
+   * The table name of the entity that we are processing.
    *
    * @var string
    */


### PR DESCRIPTION
Overview
----------------------------------------
**I've pulled out the NFC changes in this PR into #12355 which should be reviewed/merged first.**

When sending emails for personal campaign pages and enabling the "Tell a Friend" functionality it tries to send email from the contact IDs email address.  However this is not always desirable as it can break SPF/DMARC and lead to bounced/failed email delivery.

@bgm I think you might be interested in - as it's not something I actually use :-) But thought I'd take a quick look as I needed to for activity assignees

---

 * [CRM-21574: Allow to disable sending of email from source contact for tell a friend on pcp](https://issues.civicrm.org/jira/browse/CRM-21574)
 * [CRM-21244: Enhancements to "FROM email addresses"](https://issues.civicrm.org/jira/browse/CRM-21244)