### PR TITLE
Add you are already subscribed functionality

### DIFF
--- a/CRM/Core/DAO/UFGroup.php
+++ b/CRM/Core/DAO/UFGroup.php
@@ -351,6 +351,18 @@ class CRM_Core_DAO_UFGroup extends CRM_Core_DAO {
           'bao' => 'CRM_Core_BAO_UFGroup',
           'localizable' => 0,
         ) ,
+         'for_duplicate_URL' => array(
+             'name' => 'for_duplicate_URL',
+             'type' => CRM_Utils_Type::T_STRING,
+             'title' => ts('Duplicate Url'),
+             'description' => 'For duplicate URL.',
+             'maxlength' => 255,
+             'size' => CRM_Utils_Type::HUGE,
+             'table_name' => 'civicrm_uf_group',
+             'entity' => 'UFGroup',
+             'bao' => 'CRM_Core_BAO_UFGroup',
+             'localizable' => 0,
+         ) ,
         'add_to_group_id' => array(
           'name' => 'add_to_group_id',
           'type' => CRM_Utils_Type::T_INT,

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -2388,4 +2388,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     return $currency;
   }
 
+    public function changePostURL() {
+        throw new Exception("This is just a stub! Find an implementation for this method");
+    }
 }

--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -946,7 +946,12 @@ class CRM_Profile_Form extends CRM_Core_Form {
         $form->_ruleGroupID
       );
       if ($ids) {
-        if ($form->_isUpdateDupe == 2) {
+          if($form->_isUpdateDupe == 1 && $form->_ufGroup['add_to_group_id'] != NULL) {
+              $form->changePostURL();
+              if (!$form->_id) {
+                  $form->_id = $ids[0];
+              }
+          } else if ($form->_isUpdateDupe == 2) {
           CRM_Core_Session::setStatus(ts('Note: this contact may be a duplicate of an existing record.'), ts('Possible Duplicate Detected'), 'alert');
         }
         elseif ($form->_isUpdateDupe == 1) {

--- a/CRM/Profile/Form/Edit.php
+++ b/CRM/Profile/Form/Edit.php
@@ -43,6 +43,7 @@
 class CRM_Profile_Form_Edit extends CRM_Profile_Form {
   protected $_postURL = NULL;
   protected $_cancelURL = NULL;
+  protected $_for_duplicateURL = NULL;
   protected $_errorURL = NULL;
   protected $_context;
   protected $_blockNo;
@@ -170,6 +171,7 @@ SELECT module,is_reserved
     if ($this->_context != 'dialog') {
       $this->_postURL = $this->_ufGroup['post_URL'];
       $this->_cancelURL = $this->_ufGroup['cancel_URL'];
+      $this->_for_duplicateURL = $this->_ufGroup['for_duplicate_URL'];
 
       $gidString = $this->_gid;
       if (!empty($this->_profileIds)) {
@@ -202,6 +204,7 @@ SELECT module,is_reserved
       // we do this gross hack since qf also does entity replacement
       $this->_postURL = str_replace('&amp;', '&', $this->_postURL);
       $this->_cancelURL = str_replace('&amp;', '&', $this->_cancelURL);
+      $this->_for_duplicateURL = str_replace('&amp;', '&', $this->_for_duplicateURL);
 
       // also retain error URL if set
       $this->_errorURL = CRM_Utils_Array::value('errorURL', $_POST);
@@ -359,4 +362,10 @@ SELECT module,is_reserved
     return $errors;
   }
 
+   public function changePostURL()
+   {
+       if(!empty($this->_for_duplicateURL)){
+           $this->_postURL = $this->_for_duplicateURL;
+       }
+   }
 }

--- a/CRM/UF/Form/AdvanceSetting.php
+++ b/CRM/UF/Form/AdvanceSetting.php
@@ -35,6 +35,10 @@ class CRM_UF_Form_AdvanceSetting extends CRM_UF_Form_Group {
   /**
    * Build the form object for Advanced Settings.
    *
+   * ALTER TABLE `civicrm_uf_group`
+  ADD COLUMN `for_duplicate_URL` VARCHAR(255) DEFAULT NULL AFTER `post_URL`;
+   *
+   *
    * @param CRM_Core_Form $form
    */
   public static function buildAdvanceSetting(&$form) {
@@ -50,6 +54,7 @@ class CRM_UF_Form_AdvanceSetting extends CRM_UF_Form_Group {
     $form->addGroup($options, 'is_update_dupe', ts('What to do upon duplicate match'));
     // we do not have any url checks to allow relative urls
     $form->addElement('text', 'post_URL', ts('Redirect URL'), CRM_Core_DAO::getAttribute('CRM_Core_DAO_UFGroup', 'post_URL'));
+    $form->addElement('text', 'for_duplicate_URL', ts('Duplicate Redirect URL'), CRM_Core_DAO::getAttribute('CRM_Core_DAO_UFGroup', 'for_duplicate_URL'));
     $form->addElement('text', 'cancel_URL', ts('Cancel Redirect URL'), CRM_Core_DAO::getAttribute('CRM_Core_DAO_UFGroup', 'cancel_URL'));
     $form->addElement('text', 'cancel_button_text', ts('Cancel Button Text'), CRM_Core_DAO::getAttribute('CRM_Core_DAO_UFGroup', 'cancel_button_text'));
     $form->addElement('text', 'submit_button_text', ts('Submit Button Text'), CRM_Core_DAO::getAttribute('CRM_Core_DAO_UFGroup', 'submit_button_text'));

--- a/CRM/UF/Form/AdvanceSetting.php
+++ b/CRM/UF/Form/AdvanceSetting.php
@@ -35,10 +35,6 @@ class CRM_UF_Form_AdvanceSetting extends CRM_UF_Form_Group {
   /**
    * Build the form object for Advanced Settings.
    *
-   * ALTER TABLE `civicrm_uf_group`
-  ADD COLUMN `for_duplicate_URL` VARCHAR(255) DEFAULT NULL AFTER `post_URL`;
-   *
-   *
    * @param CRM_Core_Form $form
    */
   public static function buildAdvanceSetting(&$form) {

--- a/CRM/Upgrade/Incremental/php/FourSeven.php
+++ b/CRM/Upgrade/Incremental/php/FourSeven.php
@@ -428,6 +428,9 @@ class CRM_Upgrade_Incremental_php_FourSeven extends CRM_Upgrade_Incremental_Base
       'civicrm_uf_group', 'cancel_button_text', "varchar(64) COLLATE utf8_unicode_ci DEFAULT NULL COMMENT 'Custom Text to display on the cancel button when used in create or edit mode'", TRUE);
     $this->addTask('Add Submit button text column to civicrm_uf_group', 'addColumn',
       'civicrm_uf_group', 'submit_button_text', "varchar(64) COLLATE utf8_unicode_ci DEFAULT NULL COMMENT 'Custom Text to display on the submit button on profile edit/create screens'", TRUE);
+    $this->addTask('Add For duplicate url column to civicrm_uf_group', 'addColumn',
+          'civicrm_uf_group', 'for_duplicate_URL',
+          "varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL COMMENT 'In this field you can specify a URL to which the user will be redirected if the email address they entered already exists in CiviCRM'");
 
     $this->addTask('CRM-20958 - Add created_date to civicrm_activity', 'addColumn',
       'civicrm_activity', 'created_date', "timestamp NULL  DEFAULT NULL COMMENT 'When was the activity was created.'");

--- a/templates/CRM/UF/Form/AdvanceSetting.tpl
+++ b/templates/CRM/UF/Form/AdvanceSetting.tpl
@@ -80,6 +80,11 @@
             <td>{$form.is_update_dupe.html} {help id='id-is_update_dupe' file="CRM/UF/Form/Group.hlp"}</td>
         </tr>
 
+        <tr class="crm-uf-advancesetting-form-block-for_duplicate_URL" id="for_duplicate_URL_block">
+            <td class="label">{$form.for_duplicate_URL.label}</td>
+            <td>{$form.for_duplicate_URL.html} {help id='id-for_duplicate_URL' file="CRM/UF/Form/Group.hlp"}</td>
+        </tr>
+
         <tr class="crm-uf-advancesetting-form-block-is_proximity_search">
             <td class="label">{$form.is_proximity_search.label}</td>
             <td>{$form.is_proximity_search.html} {help id='id-is_proximity_search' file="CRM/UF/Form/Group.hlp"}</td></tr>
@@ -102,3 +107,26 @@
     </div><!-- / .crm-block -->
   </div><!-- /.crm-accordion-body -->
 </div><!-- /.crm-accordion-wrapper -->
+
+<script type="text/javascript">
+    {literal}
+    var updateDupeInputs = document.getElementsByName("is_update_dupe");
+    var duplicateURLInput = document.getElementById("for_duplicate_URL_block");
+
+    updateDupeInputs.forEach(function (checkbox, index) {
+        checkbox.addEventListener('change', confirmCheck);
+        if(index == 1)
+            checkbox.dispatchEvent(new Event('change'));
+    });
+
+    function confirmCheck() {
+        if (this.checked && this.value == 1) {
+            console.log("show input");
+            duplicateURLInput.style.display = '';
+        } else if(window.getComputedStyle(duplicateURLInput).display !== 'none') {
+            console.log("hide input");
+            duplicateURLInput.style.display = 'none';
+        }
+    }
+    {/literal}
+</script>

--- a/templates/CRM/UF/Form/AdvanceSetting.tpl
+++ b/templates/CRM/UF/Form/AdvanceSetting.tpl
@@ -110,22 +110,20 @@
 
 <script type="text/javascript">
     {literal}
-    var updateDupeInputs = document.getElementsByName("is_update_dupe");
-    var duplicateURLInput = document.getElementById("for_duplicate_URL_block");
-
-    updateDupeInputs.forEach(function (checkbox, index) {
-        checkbox.addEventListener('change', confirmCheck);
-        if(index == 1)
-            checkbox.dispatchEvent(new Event('change'));
+    CRM.$(function () {
+        CRM.$("[name=is_update_dupe]").each(function () {
+            this.addEventListener('change', confirmCheck);
+            if (CRM.$(this).attr('checked'))
+                this.dispatchEvent(new Event('change'));
+        });
     });
 
     function confirmCheck() {
-        if (this.checked && this.value == 1) {
-            console.log("show input");
-            duplicateURLInput.style.display = '';
-        } else if(window.getComputedStyle(duplicateURLInput).display !== 'none') {
-            console.log("hide input");
-            duplicateURLInput.style.display = 'none';
+        var duplicateURLInput = CRM.$("#for_duplicate_URL_block");
+        if (CRM.$(this).attr('checked') && CRM.$(this).val() == 1) {
+            duplicateURLInput.css('display', '');
+        } else if (duplicateURLInput.css('display') !== 'none') {
+            duplicateURLInput.css('display', 'none');
         }
     }
     {/literal}

--- a/templates/CRM/UF/Form/AdvanceSetting.tpl
+++ b/templates/CRM/UF/Form/AdvanceSetting.tpl
@@ -110,21 +110,17 @@
 
 <script type="text/javascript">
     {literal}
-    CRM.$(function () {
-        CRM.$("[name=is_update_dupe]").each(function () {
-            this.addEventListener('change', confirmCheck);
-            if (CRM.$(this).attr('checked'))
-                this.dispatchEvent(new Event('change'));
-        });
-    });
+    CRM.$(function ($) {
+        $("[name=is_update_dupe]").change(confirmCheck).filter(':checked').each(confirmCheck);
 
-    function confirmCheck() {
-        var duplicateURLInput = CRM.$("#for_duplicate_URL_block");
-        if (CRM.$(this).attr('checked') && CRM.$(this).val() == 1) {
-            duplicateURLInput.css('display', '');
-        } else if (duplicateURLInput.css('display') !== 'none') {
-            duplicateURLInput.css('display', 'none');
+        function confirmCheck() {
+            var duplicateURLInput = $("#for_duplicate_URL_block");
+            if ($(this).attr('checked') && $(this).val() == 1) {
+                duplicateURLInput.css('display', '');
+            } else if (duplicateURLInput.css('display') !== 'none') {
+                duplicateURLInput.css('display', 'none');
+            }
         }
-    }
+    });
     {/literal}
 </script>

--- a/templates/CRM/UF/Form/Group.hlp
+++ b/templates/CRM/UF/Form/Group.hlp
@@ -96,25 +96,18 @@
 {ts}If you are using this profile as a contact signup or edit form, and want to redirect the user to a static URL after they've submitted the form, you can also use contact tokens in URL - enter the complete URL here. If this field is left blank, the built-in Profile form will be redisplayed with a generic status message - 'Your contact information has been saved.'{/ts}
 {/htxt}
 
+{htxt id='id-for_duplicate_URL-title'}
+  {ts}Duplicate Redirect URL{/ts}
+{/htxt}
+{htxt id='id-for_duplicate_URL'}
+{ts}In this field you can specify a URL to which the user will be redirected if the email address they entered already exists in CiviCRM. This is useful if you want to provide different instructions to these users. For example, if you have a newsletter signup form and a user who is already subscribed to your newsletter submits it, you can redirect that user to a page that instructs them what to do (e.g. contact you to work out why they might not be receiving your newsletters){/ts}
+{/htxt}
+
 {htxt id='id-cancel_URL-title'}
   {ts}Cancel Redirect{/ts}
 {/htxt}
 {htxt id='id-cancel_URL'}
 {ts}If you are using this profile as a contact signup or edit form, and want to redirect the user to a static URL if they click the Cancel button - enter the complete URL here. If this field is left blank, the built-in Profile form will be redisplayed.{/ts}
-{/htxt}
-
-{htxt id='id-cancel_button_text-title'}
-  {ts}Cancel Button Text{/ts}
-{/htxt}
-{htxt id='id-cancel_button_text'}
-  {ts}Override the default button text for the cancel button for this profile{/ts}
-{/htxt}
-
-{htxt id='id-submit_button_text-title'}
-  {ts}Submit Button Text{/ts}
-{/htxt}
-{htxt id='id-submit_button_text'}
-  {ts}Override the default button text for the submit button for this profile{/ts}
 {/htxt}
 
 {htxt id='id-add_captcha-title'}

--- a/templates/CRM/UF/Form/Group.hlp
+++ b/templates/CRM/UF/Form/Group.hlp
@@ -110,6 +110,19 @@
 {ts}If you are using this profile as a contact signup or edit form, and want to redirect the user to a static URL if they click the Cancel button - enter the complete URL here. If this field is left blank, the built-in Profile form will be redisplayed.{/ts}
 {/htxt}
 
+{htxt id='id-cancel_button_text-title'}
+  {ts}Cancel Button Text{/ts}
+{/htxt}
+{htxt id='id-cancel_button_text'}
+  {ts}Override the default button text for the cancel button for this profile{/ts}
+{/htxt}
+{htxt id='id-submit_button_text-title'}
+  {ts}Submit Button Text{/ts}
+{/htxt}
+{htxt id='id-submit_button_text'}
+  {ts}Override the default button text for the submit button for this profile{/ts}
+{/htxt}
+
 {htxt id='id-add_captcha-title'}
   {ts}reCaptcha{/ts}
 {/htxt}

--- a/xml/schema/Core/UFGroup.xml
+++ b/xml/schema/Core/UFGroup.xml
@@ -273,4 +273,11 @@
     <localizable>true</localizable>
     <add>4.7</add>
   </field>
+  <field>
+    <name>for_duplicate_URL</name>
+    <type>varchar</type>
+    <length>255</length>
+    <comment>Duplicate Redirect URL</comment>
+    <add>4.7</add>
+  </field>
 </table>

--- a/xml/schema/Core/UFGroup.xml
+++ b/xml/schema/Core/UFGroup.xml
@@ -277,7 +277,7 @@
     <name>for_duplicate_URL</name>
     <type>varchar</type>
     <length>255</length>
-    <comment>Duplicate Redirect URL</comment>
+    <comment>In this field you can specify a URL to which the user will be redirected if the email address they entered already exists in CiviCRM</comment>
     <add>4.7</add>
   </field>
 </table>


### PR DESCRIPTION
Overview
----------------------------------------
This code change is required in order to notify user that he is already subscribed.
Hence he will be redirected to the $duplicateUrl(some page with appropriate information) rather than $postUrl(misleading step in our case), like it was before.

Here is the related  question from stackexchange : https://civicrm.stackexchange.com/questions/12258/you-are-already-subscribed-to-our-newsletter-message

Also we've added a new field inside Administer=>Customize Data And Screens=>Profiles => advanced settings

In this field you can specify a URL to which the user will be redirected if the email address they entered already exists in CiviCRM. This is useful if you want to provide different instructions to these users. For example, if you have a newsletter signup form and a user who is already subscribed to your newsletter submits it, you can redirect that user to a page that instructs them what to do (e.g. contact you to work out why they might not be receiving your newsletters).

Before
----------------------------------------
_The current status. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._

After
----------------------------------------
_What has been changed. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._

Technical Details
----------------------------------------
_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_

Comments
----------------------------------------
_Anything else you would like the reviewer to note_

  
  