### PR TITLE
CRM-21445 ensure pay_later processor is set so we do not get a fatal …

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -292,7 +292,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     // lineItem isn't set until Register postProcess
     $this->_lineItem = $this->get('lineItem');
     $this->_ccid = $this->get('ccid');
-    $this->_paymentProcessor = $this->get('paymentProcessor');
+
     $this->_params = $this->controller->exportValues('Main');
     $this->_params['ip_address'] = CRM_Utils_System::ipAddress();
     $this->_params['amount'] = $this->get('amount');

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -294,6 +294,9 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
     $this->_fields = $this->get('fields');
     $this->_bltID = $this->get('bltID');
     $this->_paymentProcessor = $this->get('paymentProcessor');
+    if (!$this->_paymentProcessor) {
+      $this->_paymentProcessor = array('object' => Civi\Payment\System::singleton()->getById(0));
+    }
     $this->_priceSetId = $this->get('priceSetId');
     $this->_priceSet = $this->get('priceSet');
 


### PR DESCRIPTION
Overview
----------------------------------------
Under circumstances described in CRM-21445 & https://issues.civicrm.org/jira/browse/CRM-21436?focusedCommentId=111107&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-111107 the form is treated as 'monetary' but has no processor assigned when it tries to load the payment form fields. This ensures that the manual processor is loaded

Before
----------------------------------------
Fatal per above

After
----------------------------------------
Fatal gone

Technical Details
----------------------------------------
For reliability we should assign the Manual processor whenever building a form

Comments
----------------------------------------

