### PR TITLE
CRM-21575 - Websites of same type are over-written

### DIFF
--- a/CRM/Core/BAO/Website.php
+++ b/CRM/Core/BAO/Website.php
@@ -73,15 +73,7 @@ class CRM_Core_BAO_Website extends CRM_Core_DAO_Website {
       return FALSE;
     }
 
-    $ids = self::allWebsites($contactID);
     foreach ($params as $key => $values) {
-      if (empty($values['id']) && is_array($ids) && !empty($ids)) {
-        foreach ($ids as $id => $value) {
-          if (($value['website_type_id'] == $values['website_type_id'])) {
-            $values['id'] = $id;
-          }
-        }
-      }
       if (!empty($values['url'])) {
         $values['contact_id'] = $contactID;
         self::add($values);


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate

 - Add website of same type to contact.
 - The second one overwrites the first one.

Before
----------------------------------------
Websites of same type are over-written.

After
----------------------------------------
Able to save websites of same type.

---

 * [CRM-21575: Websites of same type are over-written](https://issues.civicrm.org/jira/browse/CRM-21575)