### PR TITLE
CRM-21591 A non well formed numeric value encountered

### DIFF
--- a/CRM/Utils/Number.php
+++ b/CRM/Utils/Number.php
@@ -88,32 +88,32 @@ class CRM_Utils_Number {
   public static function formatUnitSize($size, $checkForPostMax = FALSE) {
     if ($size) {
       $last = strtolower($size{strlen($size) - 1});
-      $_size = (int)$size;
+      $size = (int)$size;
       
       switch ($last) {
         // The 'G' modifier is available since PHP 5.1.0
 
         case 'g':
-          $_size *= 1024;
+          $size *= 1024;
         case 'm':
-          $_size *= 1024;
+          $size *= 1024;
         case 'k':
-          $_size *= 1024;
+          $size *= 1024;
       }
 
       if ($checkForPostMax) {
         $maxImportFileSize = self::formatUnitSize(ini_get('upload_max_filesize'));
         $postMaxSize = self::formatUnitSize(ini_get('post_max_size'));
-        if ($maxImportFileSize > $postMaxSize && $postMaxSize == $_size) {
+        if ($maxImportFileSize > $postMaxSize && $postMaxSize == $size) {
           CRM_Core_Session::setStatus(ts("Note: Upload max filesize ('upload_max_filesize') should not exceed Post max size ('post_max_size') as defined in PHP.ini, please check with your system administrator."), ts("Warning"), "alert");
         }
         // respect php.ini upload_max_filesize
-        if ($size > $maxImportFileSize && $_size !== $postMaxSize) {
-          $_size = $maxImportFileSize;
+        if ($size > $maxImportFileSize && $size !== $postMaxSize) {
+          $size = $maxImportFileSize;
           CRM_Core_Session::setStatus(ts("Note: Please verify your configuration for Maximum File Size (in MB) <a href='%1'>Administrator >> System Settings >> Misc</a>. It should support 'upload_max_size' as defined in PHP.ini.Please check with your system administrator.", array(1 => CRM_Utils_System::url('civicrm/admin/setting/misc', 'reset=1'))), ts("Warning"), "alert");
         }
       }
-      return $_size;
+      return $size;
     }
   }
 

--- a/CRM/Utils/Number.php
+++ b/CRM/Utils/Number.php
@@ -88,7 +88,7 @@ class CRM_Utils_Number {
   public static function formatUnitSize($size, $checkForPostMax = FALSE) {
     if ($size) {
       $last = strtolower($size{strlen($size) - 1});
-      $size = (int) $size;
+      $size = (int)$size;
       
       switch ($last) {
         // The 'G' modifier is available since PHP 5.1.0

--- a/CRM/Utils/Number.php
+++ b/CRM/Utils/Number.php
@@ -89,6 +89,7 @@ class CRM_Utils_Number {
     if ($size) {
       $last = strtolower($size{strlen($size) - 1});
       $_size = (int)$size;
+      
       switch ($last) {
         // The 'G' modifier is available since PHP 5.1.0
 

--- a/CRM/Utils/Number.php
+++ b/CRM/Utils/Number.php
@@ -89,7 +89,6 @@ class CRM_Utils_Number {
     if ($size) {
       $last = strtolower($size{strlen($size) - 1});
       $size = (int)$size;
-      
       switch ($last) {
         // The 'G' modifier is available since PHP 5.1.0
 

--- a/CRM/Utils/Number.php
+++ b/CRM/Utils/Number.php
@@ -88,30 +88,31 @@ class CRM_Utils_Number {
   public static function formatUnitSize($size, $checkForPostMax = FALSE) {
     if ($size) {
       $last = strtolower($size{strlen($size) - 1});
+      $_size = (int)$size;
       switch ($last) {
         // The 'G' modifier is available since PHP 5.1.0
 
         case 'g':
-          $size *= 1024;
+          $_size *= 1024;
         case 'm':
-          $size *= 1024;
+          $_size *= 1024;
         case 'k':
-          $size *= 1024;
+          $_size *= 1024;
       }
 
       if ($checkForPostMax) {
         $maxImportFileSize = self::formatUnitSize(ini_get('upload_max_filesize'));
         $postMaxSize = self::formatUnitSize(ini_get('post_max_size'));
-        if ($maxImportFileSize > $postMaxSize && $postMaxSize == $size) {
+        if ($maxImportFileSize > $postMaxSize && $postMaxSize == $_size) {
           CRM_Core_Session::setStatus(ts("Note: Upload max filesize ('upload_max_filesize') should not exceed Post max size ('post_max_size') as defined in PHP.ini, please check with your system administrator."), ts("Warning"), "alert");
         }
         // respect php.ini upload_max_filesize
-        if ($size > $maxImportFileSize && $size !== $postMaxSize) {
-          $size = $maxImportFileSize;
+        if ($size > $maxImportFileSize && $_size !== $postMaxSize) {
+          $_size = $maxImportFileSize;
           CRM_Core_Session::setStatus(ts("Note: Please verify your configuration for Maximum File Size (in MB) <a href='%1'>Administrator >> System Settings >> Misc</a>. It should support 'upload_max_size' as defined in PHP.ini.Please check with your system administrator.", array(1 => CRM_Utils_System::url('civicrm/admin/setting/misc', 'reset=1'))), ts("Warning"), "alert");
         }
       }
-      return $size;
+      return $_size;
     }
   }
 

--- a/CRM/Utils/Number.php
+++ b/CRM/Utils/Number.php
@@ -88,7 +88,7 @@ class CRM_Utils_Number {
   public static function formatUnitSize($size, $checkForPostMax = FALSE) {
     if ($size) {
       $last = strtolower($size{strlen($size) - 1});
-      $size = (int)$size;
+      $size = (int) $size;
       switch ($last) {
         // The 'G' modifier is available since PHP 5.1.0
 

--- a/CRM/Utils/Number.php
+++ b/CRM/Utils/Number.php
@@ -88,7 +88,7 @@ class CRM_Utils_Number {
   public static function formatUnitSize($size, $checkForPostMax = FALSE) {
     if ($size) {
       $last = strtolower($size{strlen($size) - 1});
-      $size = (int)$size;
+      $size = (int) $size;
       
       switch ($last) {
         // The 'G' modifier is available since PHP 5.1.0


### PR DESCRIPTION
PHP Notice: A non well formed numeric value encountered

WordPress Admin Area:
![ostfyn dev_wp-admin_admin php_page civicrm q civicrm 2525252fadmin 2525252fsetting 2525252fmisc reset 1 laptop with hidpi screen](https://user-images.githubusercontent.com/6892898/34102040-5cca3c3e-e3f0-11e7-9811-09b684655cd8.png)

---

 * [CRM-21591: PHP 7.1 issue Non well form numeric value encountered when viewing the misc settings screen](https://issues.civicrm.org/jira/browse/CRM-21591)