### PR TITLE
CRM-20866: Soft credit appearance inconsistent in contribution search

### DIFF
--- a/CRM/Contribute/BAO/Query.php
+++ b/CRM/Contribute/BAO/Query.php
@@ -730,8 +730,11 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
    *
    * The default return properties array returns far too many fields for 'everyday use. Every field you add to this array
    * kills a small kitten so add carefully.
+   *
+   * @param array $queryParams
+   * @return array
    */
-  public static function selectorReturnProperties() {
+  public static function selectorReturnProperties($queryParams) {
     $properties = array(
       'contact_type' => 1,
       'contact_sub_type' => 1,
@@ -758,7 +761,7 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
       'cancel_date' => 1,
       'contribution_recur_id' => 1,
     );
-    if (self::isSoftCreditOptionEnabled()) {
+    if (self::isSoftCreditOptionEnabled($queryParams)) {
       $properties = array_merge($properties, self::softCreditReturnProperties());
     }
 

--- a/CRM/Contribute/Selector/Search.php
+++ b/CRM/Contribute/Selector/Search.php
@@ -179,7 +179,7 @@ class CRM_Contribute_Selector_Search extends CRM_Core_Selector_Base implements C
 
     // type of selector
     $this->_action = $action;
-    $returnProperties = CRM_Contribute_BAO_Query::selectorReturnProperties();
+    $returnProperties = CRM_Contribute_BAO_Query::selectorReturnProperties($this->_queryParams);
     $this->_includeSoftCredits = CRM_Contribute_BAO_Query::isSoftCreditOptionEnabled($this->_queryParams);
     $this->_query = new CRM_Contact_BAO_Query(
       $this->_queryParams,

--- a/tests/phpunit/CRM/Contribute/Selector/SearchTest.php
+++ b/tests/phpunit/CRM/Contribute/Selector/SearchTest.php
@@ -1,0 +1,57 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2017                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *  Class CRM_Contribute_Selector_SearchTest
+ *
+ * @package CiviCRM
+ */
+class CRM_Contribute_Selector_SearchTest extends CiviUnitTestCase {
+
+  /**
+   * CRM-20866 - Soft credit appearance inconsistent in contribution search
+   */
+  public function testSoftCreditFieldsSelected() {
+    $queryParams = array(array('contribution_or_softcredits', '=', 'both_related', 0, 0));
+    $searchSelector = new CRM_Contribute_Selector_Search($queryParams, CRM_Core_Action::VIEW);
+
+    list($select, $from, $where, $having) = $searchSelector->getQuery()->query();
+    self::assertContains('civicrm_contribution_soft.amount', $select);
+  }
+
+  /**
+   * CRM-20866 - Soft credit appearance inconsistent in contribution search
+   */
+  public function testSoftCreditFieldNotSelected() {
+    $queryParams = array(array('contribution_or_softcredits', '=', 'only_contribs', 0, 0));
+    $searchSelector = new CRM_Contribute_Selector_Search($queryParams, CRM_Core_Action::VIEW);
+
+    list($select, $from, $where, $having) = $searchSelector->getQuery()->query();
+    self::assertNotContains('civicrm_contribution_soft.amount', $select);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
First search for contributions with field "Contributions OR Soft Credits?" set to "Soft Credits Only" does not show soft credit data. Columns "Soft Credit Amount", "Soft Credit For" and "Soft Credit Type" are empty. Thus, soft credits appear as regular contributions.

Subsequent searches include data for those columns.

Before
----------------------------------------
![contribution_soft_data](https://user-images.githubusercontent.com/34529299/34141590-8c62ccbc-e482-11e7-8ef0-e79143396fa4.gif)

After
----------------------------------------
With this fix all searches for soft credits include that data.

Technical Details
----------------------------------------
There's a static variable `CRM_Contribute_BAO_Query::$_contribOrSoftCredit` that causes this inconsistent behaviour. It only works under certain conditions (when form values are already in `$_SESSION` data during `CRM_Contribute_Form_Search::preProcess`). I've decided to add additional parameter to `CRM_Contribute_BAO_Query::selectorReturnProperties`, so that it wouldn't rely on static variable being set beforehand.

I've included a small unit test, which asserts that the soft data fields are added to SELECT statement.

---

 * [CRM-20866: Soft credit appearance inconsistent in contribution search](https://issues.civicrm.org/jira/browse/CRM-20866)