### PR TITLE
CRM-21580 - fix exporting financial batch fails when label of batch statuses changed

### DIFF
--- a/CRM/Financial/Form/Export.php
+++ b/CRM/Financial/Form/Export.php
@@ -89,8 +89,7 @@ class CRM_Financial_Form_Export extends CRM_Core_Form {
       $this->_batchIds = $this->_id;
     }
 
-    $allBatchStatus = CRM_Core_PseudoConstant::get('CRM_Batch_DAO_Batch', 'status_id');
-    $this->_exportStatusId = CRM_Utils_Array::key('Exported', $allBatchStatus);
+    $this->_exportStatusId = CRM_Core_PseudoConstant::getKey('CRM_Batch_DAO_Batch', 'status_id', 'Exported');
 
     // check if batch status is valid, do not allow exported batches to export again
     $batchStatus = CRM_Batch_BAO_Batch::getBatchStatuses($this->_batchIds);


### PR DESCRIPTION
Overview
----------------------------------------
Only batches with the exported staus could be exported. The check wether a batch had the status exported was done based on the label of the batch status. I changed this to use the name (which shouldn't change) of the status

Before
----------------------------------------
Batches couldn't be exported if the label of the exported state has changed.

After
----------------------------------------
Batches can be exported if the label of the exported state has changed.

---

 * [CRM-21580: exporting financial batch fails when label of batch statuses changed](https://issues.civicrm.org/jira/browse/CRM-21580)