### PR TITLE
CRM-21431: Edit Group: fix removal of group types.

### DIFF
--- a/CRM/Group/Form/Edit.php
+++ b/CRM/Group/Form/Edit.php
@@ -378,6 +378,11 @@ WHERE  title = %1
         $params['group_organization'] = $this->_groupOrganizationID;
       }
 
+      // CRM-21431 If all group_type are unchecked, the change will not be saved otherwise.
+      if (!isset($params['group_type'])) {
+        $params['group_type'] = array();
+      }
+
       $params['is_reserved'] = CRM_Utils_Array::value('is_reserved', $params, FALSE);
 
       $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params,


### PR DESCRIPTION
Overview
----------------------------------------

When editing a group of type ACL and/or Mailing, it is not possible to un-check both types. The change does not get saved.

Example:

* Create a group of type "Mailing", save
* Edit group, un-check the type "Mailing" (and leave ACL unchecked), save

Result: the change is not saved. The group still shows as type "mailing".

This bug fixes a regression introduced by fb413e82fa814c7d6ab5f73b2802b8f7158758ef.

Before
----------------------------------------

![peek 19-12-2017 12-50](https://user-images.githubusercontent.com/254741/34171155-5f05a102-e4bb-11e7-8520-bdc0c166b2a1.gif)

Technical Details
----------------------------------------

Tiny patch.

Comments
----------------------------------------

moves #11435 to the 4.7.29-rc branch.

---

 * [CRM-21431: Can't remove group type form Group once a Group type has been selected ](https://issues.civicrm.org/jira/browse/CRM-21431)