### PR TITLE
CRM-21584: Add CrmRegion Tag to Contact Actions menu template

### DIFF
--- a/templates/CRM/Contact/Page/Inline/Actions.tpl
+++ b/templates/CRM/Contact/Page/Inline/Actions.tpl
@@ -29,40 +29,42 @@
   {crmButton id="crm-contact-actions-link" href="#" icon="bars"}
     {ts}Actions{/ts}
   {/crmButton}
-    <div class="ac_results" id="crm-contact-actions-list">
-      <div class="crm-contact-actions-list-inner">
-        <div class="crm-contact_activities-list">
-        {include file="CRM/Activity/Form/ActivityLinks.tpl" as_select=false}
-        </div>
-        <div class="crm-contact_print-list">
-          <ul class="contact-print">
-            {foreach from=$actionsMenuList.otherActions item='row'}
-              {if !empty($row.href) or !empty($row.tab)}
-              <li class="crm-contact-{$row.ref}">
-                <a href="{if !empty($row.href)}{$row.href}{if strstr($row.href, '?')}&cid={$contactId}{/if}{else}#{/if}" title="{$row.title|escape}" data-tab="{$row.tab}" {if !empty($row.class)}class="{$row.class}"{/if}>
-                  <span><i {if !empty($row.icon)}class="{$row.icon}"{/if}></i> {$row.title}</span>
-                </a>
-              </li>
-              {/if}
-            {/foreach}
-        </ul>
-        </div>
-        <div class="crm-contact_actions-list">
-        <ul class="contact-actions">
-          {foreach from=$actionsMenuList.moreActions item='row'}
-          {if !empty($row.href) or !empty($row.tab)}
-          <li class="crm-action-{$row.ref}">
-            <a href="{if !empty($row.href)}{$row.href}{if strstr($row.href, '?')}&cid={$contactId}{/if}{else}#{/if}" title="{$row.title|escape}" data-tab="{$row.tab}" {if !empty($row.class)}class="{$row.class}"{/if}>{$row.title}</a>
-          </li>
-          {/if}
-        {/foreach}
-              </ul>
-              </div>
+    {crmRegion name="contact-page-inline-actions"}
+      <div class="ac_results" id="crm-contact-actions-list">
+        <div class="crm-contact-actions-list-inner">
+          <div class="crm-contact_activities-list">
+          {include file="CRM/Activity/Form/ActivityLinks.tpl" as_select=false}
+          </div>
+          <div class="crm-contact_print-list">
+            <ul class="contact-print">
+              {foreach from=$actionsMenuList.otherActions item='row'}
+                {if !empty($row.href) or !empty($row.tab)}
+                <li class="crm-contact-{$row.ref}">
+                  <a href="{if !empty($row.href)}{$row.href}{if strstr($row.href, '?')}&cid={$contactId}{/if}{else}#{/if}" title="{$row.title|escape}" data-tab="{$row.tab}" {if !empty($row.class)}class="{$row.class}"{/if}>
+                    <span><i {if !empty($row.icon)}class="{$row.icon}"{/if}></i> {$row.title}</span>
+                  </a>
+                </li>
+                {/if}
+              {/foreach}
+          </ul>
+          </div>
+          <div class="crm-contact_actions-list">
+          <ul class="contact-actions">
+            {foreach from=$actionsMenuList.moreActions item='row'}
+            {if !empty($row.href) or !empty($row.tab)}
+            <li class="crm-action-{$row.ref}">
+              <a href="{if !empty($row.href)}{$row.href}{if strstr($row.href, '?')}&cid={$contactId}{/if}{else}#{/if}" title="{$row.title|escape}" data-tab="{$row.tab}" {if !empty($row.class)}class="{$row.class}"{/if}>{$row.title}</a>
+            </li>
+            {/if}
+          {/foreach}
+                </ul>
+                </div>
 
 
-        <div class="clear"></div>
+          <div class="clear"></div>
+        </div>
       </div>
-    </div>
+    {/crmRegion}
   </div>
 {literal}
 {/literal}


### PR DESCRIPTION
Overview
----------------------------------------
This PR adds a `{crmRegion}` tag to `templates/CRM/Contact/Page/Inline/Actions.tpl` so that it will be easy to inject custom content or markup for anyone that wants to make changes to the Contact actions menu.

Before
----------------------------------------
There was no `{crmRegion}` tag in the `templates/CRM/Contact/Page/Inline/Actions.tpl` template file.

After
----------------------------------------
A `{crmRegion}` tag was added to the `templates/CRM/Contact/Page/Inline/Actions.tpl` template file.

Technical Details
----------------------------------------
- The `crmRegion` tag was named in such a way as to follow the naming convention as advised [here](https://docs.civicrm.org/dev/en/latest/framework/region/#naming-conventions)
```php
{crmRegion name="contact-page-inline-actions"}
    < existing html >
{/crmRegion}
```

---

 * [CRM-21584: Add CrmRegion Tag to Contact Actions menu template](https://issues.civicrm.org/jira/browse/CRM-21584)