### PR TITLE
Fix CRM-21589: "Repeat Contributions" report ignores sort.

### DIFF
--- a/CRM/Report/Form/Contribute/Repeat.php
+++ b/CRM/Report/Form/Contribute/Repeat.php
@@ -829,10 +829,11 @@ GROUP BY    currency
     $this->from();
     $this->where();
     $this->groupBy();
+    $this->orderBy();
     $this->limit();
 
     $count = 0;
-    $sql = "{$this->_select} {$this->_from} {$this->_where} {$this->_groupBy} {$this->_limit}";
+    $sql = "{$this->_select} {$this->_from} {$this->_where} {$this->_groupBy} {$this->_orderBy} {$this->_limit}";
     $dao = $this->executeReportQuery($sql);
     $rows = array();
     while ($dao->fetch()) {


### PR DESCRIPTION
Overview
----------------------------------------
The "Repeat contribution" report ignores the settings under the "Sort" tab.

Before
----------------------------------------
See overview.

After
----------------------------------------
The report honors the settings under the "Sort" tab.

Technical Details
----------------------------------------
This report has its own postProcess() method, which until now omits code to include an "ORDER BY" clause honoring the configured "Sort" options. This PR changes two lines to make sorting work.

---

 * [CRM-21589: "Repeat Contributions" report ignores sort](https://issues.civicrm.org/jira/browse/CRM-21589)