### PR TITLE
CRM-21591 Add Test of formatUnitSize Function

### DIFF
--- a/tests/phpunit/CRM/Utils/NumberTest.php
+++ b/tests/phpunit/CRM/Utils/NumberTest.php
@@ -67,4 +67,20 @@ class CRM_Utils_NumberTest extends CiviUnitTestCase {
     );
   }
 
+  public function sizeCases() {
+    $cases = [];
+    $cases[] = ['20M', '20971520'];
+    $cases[] = ['40G', '42949672960'];
+    return $cases;
+  }
+
+  /**
+   * @param $size
+   * @param $expectedValue
+   * @dataProvider sizeCases
+   */
+  public function testFormatUnitSize($size, $expectedValue) {
+    $this->assertEquals($expectedValue, CRM_Utils_Number::formatUnitSize($size));
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
This adds a unit test of the function CRM_Utils_Number::formatUnitSize. It aims to validate the fix for CRM-21591 in this PR https://github.com/civicrm/civicrm-core/pull/11429/files

Before
----------------------------------------
Function not tested

After
----------------------------------------
Function tested

ping @colemanw @eileenmcnaughton @totten

---

 * [CRM-21591: PHP 7.1 issue Non well form numeric value encountered when viewing the misc settings screen](https://issues.civicrm.org/jira/browse/CRM-21591)