### PR TITLE
CRM-21593: New order by options for WalkList Report

### DIFF
--- a/CRM/Report/Form/Walklist/Walklist.php
+++ b/CRM/Report/Form/Walklist/Walklist.php
@@ -99,6 +99,13 @@ class CRM_Report_Form_Walklist_Walklist extends CRM_Report_Form {
           'country_id' => array(
             'title' => ts('Country'),
           ),
+          'odd_street_number' => array(
+            'title' => ts('Odd/Even Street Number'),
+            'type' => CRM_Utils_Type::T_INT,
+            'no_display' => TRUE,
+            'required' => TRUE,
+            'dbAlias' => '(address_civireport.street_number % 2)',
+          ),
         ),
         'filters' => array(
           'street_number' => array(
@@ -108,6 +115,18 @@ class CRM_Report_Form_Walklist_Walklist extends CRM_Report_Form {
           ),
           'street_address' => NULL,
           'city' => NULL,
+        ),
+        'order_bys' => array(
+          'street_name' => array(
+            'title' => ts('Street Name'),
+          ),
+          'street_number' => array(
+            'title' => ts('Street Number'),
+          ),
+          'odd_street_number' => array(
+            'title' => ts('Odd/Even Street Number'),
+            'dbAlias' => 'civicrm_address_odd_street_number',
+          ),
         ),
         'grouping' => 'location-fields',
       ),


### PR DESCRIPTION
Overview
----------------------------------------
This PR is about adding 3 order by options to WalkList Report, which are:
1. Street Name
2. Street Number
3. Odd/Even Street Number

After
----------------------------------------
This is an example of fetching even street numbers in ascending order:
![screen shot 2017-12-22 at 6 50 08 pm](https://user-images.githubusercontent.com/3735621/34299572-bd16715a-e749-11e7-9b04-d7f544edb66a.png)

---

 * [CRM-21593: New order by options for WalkList Report](https://issues.civicrm.org/jira/browse/CRM-21593)