### PR TITLE
CRM-21594 - Add option to use traditional CiviMail in action list

### DIFF
--- a/CRM/Contact/Task.php
+++ b/CRM/Contact/Task.php
@@ -61,7 +61,8 @@ class CRM_Contact_Task {
     RESTORE = 23,
     DELETE_PERMANENTLY = 24,
     COMMUNICATION_PREFS = 25,
-    INDIVIDUAL_CONTACTS = 26;
+    INDIVIDUAL_CONTACTS = 26,
+    CREATE_MAILING_TRADITIONAL = 27;
 
   /**
    * The task array
@@ -273,6 +274,14 @@ class CRM_Contact_Task {
           'class' => 'CRM_Mailing_Form_Task_AdhocMailing',
           'result' => FALSE,
         );
+        $templateTypes = CRM_Mailing_BAO_Mailing::getTemplateTypes();
+        if (count($templateTypes) > 1) {
+          self::$_tasks[self::CREATE_MAILING_TRADITIONAL] = array(
+            'title' => ts('Email - schedule/send via traditional CiviMail'),
+            'class' => 'CRM_Mailing_Form_Task_AdhocMailing',
+            'result' => FALSE,
+          );
+        }
       }
 
       self::$_tasks += CRM_Core_Component::taskList();

--- a/CRM/Mailing/Form/Task/AdhocMailing.php
+++ b/CRM/Mailing/Form/Task/AdhocMailing.php
@@ -39,12 +39,18 @@ class CRM_Mailing_Form_Task_AdhocMailing extends CRM_Contact_Form_Task {
   public function preProcess() {
     parent::preProcess();
     $templateTypes = CRM_Mailing_BAO_Mailing::getTemplateTypes();
+    if ($this->_task == CRM_Contact_Task::CREATE_MAILING) {
+      $templateType = $templateTypes[0]['name'];
+    }
+    elseif ($this->_task == CRM_Contact_Task::CREATE_MAILING_TRADITIONAL) {
+      $templateType = $templateTypes[1]['name'];
+    }
     list ($groupId, $ssId) = $this->createHiddenGroup();
     $mailing = civicrm_api3('Mailing', 'create', array(
       'name' => "",
       'campaign_id' => NULL,
       'replyto_email' => "",
-      'template_type' => $templateTypes[0]['name'],
+      'template_type' => $templateType,
       'template_options' => array('nonce' => 1),
       'subject' => "",
       'body_html' => "",


### PR DESCRIPTION
Overview
----------------------------------------
When Mosaico extension is installed, the option to use traditional CiviMail is also available.
But when you Find Contacts, and use the Option 'Email - schedule/send via CiviMail' it uses Mosaico and there is no way to use tradition CiviMail from action list.

Before
----------------------------------------
![civimail_beore](https://user-images.githubusercontent.com/3455173/34300214-0fec7868-e74d-11e7-8e40-5068a7fb78cb.png)

After
----------------------------------------
![civimail_after](https://user-images.githubusercontent.com/3455173/34300219-147cfe84-e74d-11e7-810b-1ab11f57d92f.png)

---

 * [CRM-21594: Add option to use traditional CiviMail in action list](https://issues.civicrm.org/jira/browse/CRM-21594)