### PR TITLE
Params to assertGreaterThanOrEqual in api_v3_CaseTest were in wrong order

### DIFF
--- a/tests/phpunit/api/v3/CaseTest.php
+++ b/tests/phpunit/api/v3/CaseTest.php
@@ -225,9 +225,8 @@ class api_v3_CaseTest extends CiviCaseTestCase {
     // Verify that updated case is equal to the original with new subject.
     $result = $this->callAPISuccessGetSingle('Case', array('case_id' => $id));
     // Modification dates are likely to differ by 0-2 sec. Check manually.
-    $this->assertGreaterThanOrEqual($result['modified_date'], $case['modified_date']);
-    unset($result['modified_date']);
-    unset($case['modified_date']);
+    $this->assertGreaterThanOrEqual($case['modified_date'], $result['modified_date']);
+    unset($result['modified_date'], $case['modified_date']);
     // Everything else should be identical.
     $this->assertAPIArrayComparison($result, $case);
   }
@@ -252,9 +251,8 @@ class api_v3_CaseTest extends CiviCaseTestCase {
     // Verify that updated case is equal to the original with new subject.
     $result = $this->callAPISuccessGetSingle('Case', array('case_id' => $id));
     // Modification dates are likely to differ by 0-2 sec. Check manually.
-    $this->assertGreaterThanOrEqual($result['modified_date'], $case['modified_date']);
-    unset($result['modified_date']);
-    unset($case['modified_date']);
+    $this->assertGreaterThanOrEqual($case['modified_date'], $result['modified_date']);
+    unset($result['modified_date'], $case['modified_date']);
     // Everything else should be identical.
     $this->assertAPIArrayComparison($result, $case);
   }


### PR DESCRIPTION
Overview
-----
There was a sporadic failure in `api_v3_CaseTest`. Checking [the manual](https://phpunit.de/manual/current/en/appendixes.assertions.html#appendixes.assertions.assertGreaterThanOrEqual) it looks like params to function `assertGreaterThanOrEqual` were being passed in the wrong order. The second param is supposed to be greater or equal to the first.

Before
---
Occasional test failure

After
----
Fingers crossed.