### PR TITLE
Update minimum php version to 5.5

### DIFF
--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -50,7 +50,7 @@ class CRM_Upgrade_Form extends CRM_Core_Form {
   /**
    * Minimum php version required to run (equal to or lower than the minimum install version)
    */
-  const MINIMUM_PHP_VERSION = '5.4';
+  const MINIMUM_PHP_VERSION = '5.5';
 
   protected $_config;
 

--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -53,7 +53,7 @@ class CRM_Upgrade_Incremental_General {
    *
    * @see install/index.php
    */
-  const MIN_INSTALL_PHP_VER = '5.4';
+  const MIN_INSTALL_PHP_VER = '5.5';
 
   /**
    * Compute any messages which should be displayed before upgrade.


### PR DESCRIPTION
Overview
----
Bumping up the minimum version to follow the schedule laid out in https://civicrm.org/blog/totten/end-of-zombies-php-53-and-54

Technical Notes
----
This PR will fail testing until php has been upgraded on the CI server running the tests.

We should upgrade the server and merge this PR in time for the 4.7.32 release in March.