### PR TITLE
CRM-21598 - Case Activity issues with custom Completed Status Type

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -1041,7 +1041,10 @@ SELECT case_status.label AS case_status, status_id, civicrm_case_type.title AS c
 
     // define statuses which are handled like Completed status (others are assumed to be handled like Scheduled status)
     $compStatusValues = array();
-    $compStatusNames = array('Completed', 'Left Message', 'Cancelled', 'Unreachable', 'Not Required');
+    $compStatusNames = array_merge(
+      array('Completed', 'Left Message', 'Cancelled', 'Unreachable', 'Not Required'),
+      CRM_Activity_BAO_Activity::getStatusesByType(CRM_Activity_BAO_Activity::COMPLETED)
+    );
     foreach ($compStatusNames as $name) {
       $compStatusValues[] = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_status_id', $name);
     }

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -1039,13 +1039,10 @@ SELECT case_status.label AS case_status, status_id, civicrm_case_type.title AS c
 
     $caseDeleted = CRM_Core_DAO::getFieldValue('CRM_Case_DAO_Case', $caseID, 'is_deleted');
 
-    // define statuses which are handled like Completed status (others are assumed to be handled like Scheduled status)
-    $compStatusValues = array();
-    $compStatusNames = array('Left Message', 'Cancelled', 'Unreachable', 'Not Required');
-    foreach ($compStatusNames as $name) {
-      $compStatusValues[] = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_status_id', $name);
-    }
-    $compStatusValues = array_merge($compStatusValues, array_keys(CRM_Activity_BAO_Activity::getStatusesByType(CRM_Activity_BAO_Activity::COMPLETED)));
+    $compStatusValues = array_keys(
+      CRM_Activity_BAO_Activity::getStatusesByType(CRM_Activity_BAO_Activity::COMPLETED) +
+      CRM_Activity_BAO_Activity::getStatusesByType(CRM_Activity_BAO_Activity::CANCELLED)
+    );
 
     $contactViewUrl = CRM_Utils_System::url("civicrm/contact/view", "reset=1&cid=", FALSE, NULL, FALSE);
     $hasViewContact = CRM_Core_Permission::giveMeAllACLs();

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -1041,13 +1041,11 @@ SELECT case_status.label AS case_status, status_id, civicrm_case_type.title AS c
 
     // define statuses which are handled like Completed status (others are assumed to be handled like Scheduled status)
     $compStatusValues = array();
-    $compStatusNames = array_merge(
-      array('Completed', 'Left Message', 'Cancelled', 'Unreachable', 'Not Required'),
-      CRM_Activity_BAO_Activity::getStatusesByType(CRM_Activity_BAO_Activity::COMPLETED)
-    );
+    $compStatusNames = array('Left Message', 'Cancelled', 'Unreachable', 'Not Required');
     foreach ($compStatusNames as $name) {
       $compStatusValues[] = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_status_id', $name);
     }
+    $compStatusValues = array_merge($compStatusValues, array_keys(CRM_Activity_BAO_Activity::getStatusesByType(CRM_Activity_BAO_Activity::COMPLETED)));
 
     $contactViewUrl = CRM_Utils_System::url("civicrm/contact/view", "reset=1&cid=", FALSE, NULL, FALSE);
     $hasViewContact = CRM_Core_Permission::giveMeAllACLs();

--- a/Civi/CCase/SequenceListener.php
+++ b/Civi/CCase/SequenceListener.php
@@ -48,7 +48,7 @@ class SequenceListener implements CaseChangeListener {
     }
 
     $actTypes = array_flip(\CRM_Core_PseudoConstant::activityType(TRUE, TRUE, FALSE, 'name'));
-    $actStatuses = array_flip(\CRM_Core_PseudoConstant::activityStatus('name'));
+    $actStatuses = array_flip(\CRM_Activity_BAO_Activity::getStatusesByType(\CRM_Activity_BAO_Activity::COMPLETED));
 
     $actIndex = $analyzer->getActivityIndex(array('activity_type_id', 'status_id'));
 
@@ -59,7 +59,7 @@ class SequenceListener implements CaseChangeListener {
         $this->createActivity($analyzer, $actTypeXML);
         return;
       }
-      elseif (empty($actIndex[$actTypeId][$actStatuses['Completed']])) {
+      elseif (!in_array(key($actIndex[$actTypeId]), $actStatuses)) {
         // Haven't gotten past this step yet!
         return;
       }
@@ -68,7 +68,7 @@ class SequenceListener implements CaseChangeListener {
     //CRM-17452 - Close the case only if all the activities are complete
     $activities = $analyzer->getActivities();
     foreach ($activities as $activity) {
-      if ($activity['status_id'] != $actStatuses['Completed']) {
+      if (!in_array($activity['status_id'], $actStatuses)) {
         return;
       }
     }

--- a/Civi/CCase/SequenceListener.php
+++ b/Civi/CCase/SequenceListener.php
@@ -33,6 +33,10 @@ class SequenceListener implements CaseChangeListener {
   }
 
   /**
+   * Triggers next case activity in sequence if current activity status is updated
+   * to type=COMPLETED(See CRM-21598). The adjoining activity is created according
+   * to the sequence configured in case type.
+   *
    * @param \Civi\CCase\Event\CaseChangeEvent $event
    *
    * @throws \CiviCRM_API3_Exception

--- a/tests/phpunit/Civi/CCase/SequenceListenerTest.php
+++ b/tests/phpunit/Civi/CCase/SequenceListenerTest.php
@@ -16,6 +16,12 @@ class SequenceListenerTest extends \CiviCaseTestCase {
       'subject' => 'Test case',
       'contact_id' => 17,
     );
+    //Add an activity status with Type = Completed
+    $this->callAPISuccess('OptionValue', 'create', array(
+      'option_group_id' => "activity_status",
+      'filter' => \CRM_Activity_BAO_Activity::COMPLETED,
+      'label' => "Skip Activity",
+    ));
   }
 
   public function testSequence() {
@@ -60,18 +66,18 @@ class SequenceListenerTest extends \CiviCaseTestCase {
     $this->assertEquals($actStatuses['Scheduled'], self::ag($analyzer->getSingleActivity('Mental health evaluation'), 'status_id'));
     $this->assertFalse($analyzer->hasActivity('Secure temporary housing'));
 
-    // Complete second activity; schedule third
+    //Complete second activity using "Skip Activity"(Completed); schedule third
     \CRM_Utils_Time::setTime('2013-11-30 03:00:00');
     $this->callApiSuccess('Activity', 'create', array(
       'id' => self::ag($analyzer->getSingleActivity('Mental health evaluation'), 'id'),
-      'status_id' => $actStatuses['Completed'],
+      'status_id' => $actStatuses['Skip Activity'],
     ));
     $analyzer->flush();
     $this->assertEquals($caseStatuses['Open'], self::ag($analyzer->getCase(), 'status_id'));
     $this->assertApproxTime('2013-11-30 01:00:00', self::ag($analyzer->getSingleActivity('Medical evaluation'), 'activity_date_time'));
     $this->assertEquals($actStatuses['Completed'], self::ag($analyzer->getSingleActivity('Medical evaluation'), 'status_id'));
     $this->assertApproxTime('2013-11-30 02:00:00', self::ag($analyzer->getSingleActivity('Mental health evaluation'), 'activity_date_time'));
-    $this->assertEquals($actStatuses['Completed'], self::ag($analyzer->getSingleActivity('Mental health evaluation'), 'status_id'));
+    $this->assertEquals($actStatuses['Skip Activity'], self::ag($analyzer->getSingleActivity('Mental health evaluation'), 'status_id'));
     $this->assertApproxTime('2013-11-30 03:00:00', self::ag($analyzer->getSingleActivity('Secure temporary housing'), 'activity_date_time'));
     $this->assertEquals($actStatuses['Scheduled'], self::ag($analyzer->getSingleActivity('Secure temporary housing'), 'status_id'));
 
@@ -88,7 +94,7 @@ class SequenceListenerTest extends \CiviCaseTestCase {
     $this->assertApproxTime('2013-11-30 01:00:00', self::ag($analyzer->getSingleActivity('Medical evaluation'), 'activity_date_time'));
     $this->assertEquals($actStatuses['Completed'], self::ag($analyzer->getSingleActivity('Medical evaluation'), 'status_id'));
     $this->assertApproxTime('2013-11-30 02:00:00', self::ag($analyzer->getSingleActivity('Mental health evaluation'), 'activity_date_time'));
-    $this->assertEquals($actStatuses['Completed'], self::ag($analyzer->getSingleActivity('Mental health evaluation'), 'status_id'));
+    $this->assertEquals($actStatuses['Skip Activity'], self::ag($analyzer->getSingleActivity('Mental health evaluation'), 'status_id'));
     $this->assertApproxTime('2013-11-30 03:00:00', self::ag($analyzer->getSingleActivity('Secure temporary housing'), 'activity_date_time'));
     $this->assertEquals($actStatuses['Scheduled'], self::ag($analyzer->getSingleActivity('Secure temporary housing'), 'status_id'));
     $this->assertApproxTime('2013-11-30 04:00:00', self::ag($analyzer->getSingleActivity('Follow up'), 'activity_date_time'));
@@ -104,7 +110,7 @@ class SequenceListenerTest extends \CiviCaseTestCase {
     $this->assertApproxTime('2013-11-30 01:00:00', self::ag($analyzer->getSingleActivity('Medical evaluation'), 'activity_date_time'));
     $this->assertEquals($actStatuses['Completed'], self::ag($analyzer->getSingleActivity('Medical evaluation'), 'status_id'));
     $this->assertApproxTime('2013-11-30 02:00:00', self::ag($analyzer->getSingleActivity('Mental health evaluation'), 'activity_date_time'));
-    $this->assertEquals($actStatuses['Completed'], self::ag($analyzer->getSingleActivity('Mental health evaluation'), 'status_id'));
+    $this->assertEquals($actStatuses['Skip Activity'], self::ag($analyzer->getSingleActivity('Mental health evaluation'), 'status_id'));
     $this->assertApproxTime('2013-11-30 03:00:00', self::ag($analyzer->getSingleActivity('Secure temporary housing'), 'activity_date_time'));
     $this->assertEquals($actStatuses['Completed'], self::ag($analyzer->getSingleActivity('Secure temporary housing'), 'status_id'));
     $this->assertApproxTime('2013-11-30 04:00:00', self::ag($analyzer->getSingleActivity('Follow up'), 'activity_date_time'));
@@ -121,7 +127,7 @@ class SequenceListenerTest extends \CiviCaseTestCase {
     $this->assertApproxTime('2013-11-30 01:00:00', self::ag($analyzer->getSingleActivity('Medical evaluation'), 'activity_date_time'));
     $this->assertEquals($actStatuses['Completed'], self::ag($analyzer->getSingleActivity('Medical evaluation'), 'status_id'));
     $this->assertApproxTime('2013-11-30 02:00:00', self::ag($analyzer->getSingleActivity('Mental health evaluation'), 'activity_date_time'));
-    $this->assertEquals($actStatuses['Completed'], self::ag($analyzer->getSingleActivity('Mental health evaluation'), 'status_id'));
+    $this->assertEquals($actStatuses['Skip Activity'], self::ag($analyzer->getSingleActivity('Mental health evaluation'), 'status_id'));
     $this->assertApproxTime('2013-11-30 03:00:00', self::ag($analyzer->getSingleActivity('Secure temporary housing'), 'activity_date_time'));
     $this->assertEquals($actStatuses['Completed'], self::ag($analyzer->getSingleActivity('Secure temporary housing'), 'status_id'));
     $this->assertApproxTime('2013-11-30 04:00:00', self::ag($analyzer->getSingleActivity('Follow up'), 'activity_date_time'));


### PR DESCRIPTION
Overview
----------------------------------------
Case Activity issues with Completed status types created by the user

Before
----------------------------------------
Two issues noticed when a new activity status eg "Skip Activity" is created with "Status Type" = `Completed`.

1/ Case Activity still shown as red when it is updated to the newly created "Skip Activity" status.
2/ Case activity sequence is not updated when status is changed to the Completed(Skip Activity).

Check JIRA to replicate them.

After
----------------------------------------
works fine.

Comments
----------------------------------------
Updated unit test to check for user-created `Completed` status.

---

 * [CRM-21598: Case Activity issues with custom Completed Status Type.](https://issues.civicrm.org/jira/browse/CRM-21598)