### PR TITLE
CRM-21599: Added missing structure in templates

### DIFF
--- a/CRM/Event/Form/SearchEvent.php
+++ b/CRM/Event/Form/SearchEvent.php
@@ -64,7 +64,7 @@ class CRM_Event_Form_SearchEvent extends CRM_Core_Form {
    * @return void
    */
   public function buildQuickForm() {
-    $this->add('text', 'title', ts('Find'),
+    $this->add('text', 'title', ts('Event Name'),
       array(CRM_Core_DAO::getAttribute('CRM_Event_DAO_Event', 'title'))
     );
 

--- a/templates/CRM/Admin/Page/LocationType.tpl
+++ b/templates/CRM/Admin/Page/LocationType.tpl
@@ -30,6 +30,7 @@
     {ts}Location types provide convenient labels to differentiate contacts' location(s). Administrators may define as many additional types as appropriate for your constituents (examples might be Main Office, School, Vacation Home...).{/ts}
   </div>
 
+<div class="crm-block crm-content-block">
   {if $rows}
   <div id="ltype">
     {strip}
@@ -38,15 +39,15 @@
     {include file="CRM/common/jsortable.tpl"}
     <table id="options" class="display">
     <thead>
-    <tr>
-        <th id="sortable">{ts}Name{/ts}</th>
-        <th>{ts}Display Name{/ts}</th>
-        <th>{ts}vCard{/ts}</th>
-        <th id="nosort">{ts}Description{/ts}</th>
-        <th>{ts}Enabled?{/ts}</th>
-        <th>{ts}Default?{/ts}</th>
-        <th></th>
-    </tr>
+      <tr>
+          <th id="sortable">{ts}Name{/ts}</th>
+          <th>{ts}Display Name{/ts}</th>
+          <th>{ts}vCard{/ts}</th>
+          <th id="nosort">{ts}Description{/ts}</th>
+          <th>{ts}Enabled?{/ts}</th>
+          <th>{ts}Default?{/ts}</th>
+          <th></th>
+      </tr>
     </thead>
     {foreach from=$rows item=row}
     <tr id="location_type-{$row.id}"  data-action="setvalue" class="{cycle values="odd-row,even-row"} {$row.class} crm-entity {if NOT $row.is_active} disabled{/if}">
@@ -72,4 +73,5 @@
     {crmButton q="action=add&reset=1" id="newLocationType" icon="plus-circle"}{ts}Add Option{/ts}{/crmButton}
     {crmButton p="civicrm/admin" q="reset=1" class="cancel" icon="times"}{ts}Done{/ts}{/crmButton}
   </div>
+</div>
 {/if}

--- a/templates/CRM/Event/Form/SearchEvent.tpl
+++ b/templates/CRM/Event/Form/SearchEvent.tpl
@@ -27,11 +27,13 @@
  <h3>{ts}Find Events{/ts}</h3>
   <table class="form-layout">
     <tr class="crm-event-searchevent-form-block-title">
-        <td>{$form.title.html|crmAddClass:twenty}
-             <div class="description font-italic">
-                    {ts}Complete OR partial Event name.{/ts}
-             </div>
-             <div style="height: auto; vertical-align: bottom">{$form.eventsByDates.html}</div>
+        <td>
+          <label>{ts}Event Nanme{/ts}</label>
+          {$form.title.html|crmAddClass:twenty}
+          <div class="description font-italic">
+                 {ts}Complete OR partial Event name.{/ts}
+          </div>
+          <div style="height: auto; vertical-align: bottom">{$form.eventsByDates.html}</div>
         </td>
         <td rowspan="2"><label>{ts}Event Type{/ts}</label>
           {$form.event_type_id.html}

--- a/templates/CRM/Event/Form/SearchEvent.tpl
+++ b/templates/CRM/Event/Form/SearchEvent.tpl
@@ -28,7 +28,7 @@
   <table class="form-layout">
     <tr class="crm-event-searchevent-form-block-title">
         <td>
-          <label>{ts}Event Nanme{/ts}</label>
+          <label>{$form.title.label}</label>
           {$form.title.html|crmAddClass:twenty}
           <div class="description font-italic">
                  {ts}Complete OR partial Event name.{/ts}


### PR DESCRIPTION
Overview
----------------------------------------
This PR
- Adds missing HTML structure at `templates/CRM/Admin/Page/LocationType.tpl`
- Adds missing label `Event Name` of event at `templates/CRM/Event/Form/SearchEvent.tpl`

Before
----------------------------------------
![before](https://user-images.githubusercontent.com/26058635/34353830-84423a44-ea50-11e7-93a1-dedbc9c8d632.png)

After
----------------------------------------
![after](https://user-images.githubusercontent.com/26058635/34353834-859763ba-ea50-11e7-8aca-4b00070f5712.png)

Technical Details
----------------------------------------
Tabing and spacings are improved

---

 * [CRM-21599: Add missing structure in templates](https://issues.civicrm.org/jira/browse/CRM-21599)