### PR TITLE
CRM-8140: Not possible to select fields for export when using Custom Searches

### DIFF
--- a/CRM/Export/Form/Select.php
+++ b/CRM/Export/Form/Select.php
@@ -70,6 +70,8 @@ class CRM_Export_Form_Select extends CRM_Core_Form {
 
   public $_componentTable;
 
+  public $_customSearchID;
+
   /**
    * Build all the data structures needed to build the form.
    *
@@ -81,13 +83,7 @@ class CRM_Export_Form_Select extends CRM_Core_Form {
     $this->preventAjaxSubmit();
 
     //special case for custom search, directly give option to download csv file
-    $customSearchID = $this->get('customSearchID');
-    if ($customSearchID) {
-      CRM_Export_BAO_Export::exportCustom($this->get('customSearchClass'),
-        $this->get('formValues'),
-        $this->get(CRM_Utils_Sort::SORT_ORDER)
-      );
-    }
+    $this->_customSearchID = $this->get('customSearchID');
 
     $this->_selectAll = FALSE;
     $this->_exportMode = self::CONTACT_EXPORT;
@@ -99,7 +95,11 @@ class CRM_Export_Form_Select extends CRM_Core_Form {
     $isStandalone = $formName == 'CRM_Export_StateMachine_Standalone';
 
     // get the submitted values based on search
-    if ($this->_action == CRM_Core_Action::ADVANCED) {
+    if ($this->_customSearchID) {
+      $values = $this->get('formValues');
+      $this->assign('exportCustomSearchField', TRUE);
+    }
+    elseif ($this->_action == CRM_Core_Action::ADVANCED) {
       $values = $this->controller->exportValues('Advanced');
     }
     elseif ($this->_action == CRM_Core_Action::PROFILE) {
@@ -231,7 +231,7 @@ FROM   {$this->_componentTable}
     $exportOptions = $mergeOptions = $postalMailing = array();
     $exportOptions[] = $this->createElement('radio',
       NULL, NULL,
-      ts('Export PRIMARY fields'),
+      ts('Export %1 fields', array(1 => empty($this->_customSearchID) ? 'PRIMARY' : 'custom search')),
       self::EXPORT_ALL,
       array('onClick' => 'showMappingOption( );')
     );
@@ -396,20 +396,28 @@ FROM   {$this->_componentTable}
     }
 
     if ($exportOption == self::EXPORT_ALL) {
-      CRM_Export_BAO_Export::exportComponents($this->_selectAll,
-        $this->_componentIds,
-        (array) $this->get('queryParams'),
-        $this->get(CRM_Utils_Sort::SORT_ORDER),
-        NULL,
-        $this->get('returnProperties'),
-        $this->_exportMode,
-        $this->_componentClause,
-        $this->_componentTable,
-        $mergeSameAddress,
-        $mergeSameHousehold,
-        $exportParams,
-        $this->get('queryOperator')
-      );
+      if ($this->_customSearchID) {
+        CRM_Export_BAO_Export::exportCustom($this->get('customSearchClass'),
+          $this->get('formValues'),
+          $this->get(CRM_Utils_Sort::SORT_ORDER)
+        );
+      }
+      else {
+        CRM_Export_BAO_Export::exportComponents($this->_selectAll,
+          $this->_componentIds,
+          (array) $this->get('queryParams'),
+          $this->get(CRM_Utils_Sort::SORT_ORDER),
+          NULL,
+          $this->get('returnProperties'),
+          $this->_exportMode,
+          $this->_componentClause,
+          $this->_componentTable,
+          $mergeSameAddress,
+          $mergeSameHousehold,
+          $exportParams,
+          $this->get('queryOperator')
+        );
+      }
     }
 
     //reset map page

--- a/templates/CRM/Export/Form/Select.tpl
+++ b/templates/CRM/Export/Form/Select.tpl
@@ -28,7 +28,7 @@
 <div class="crm-block crm-form-block crm-export-form-block">
 
  <div class="help">
-    <p>{ts}<strong>Export PRIMARY fields</strong> provides the most commonly used data values. This includes primary address information, preferred phone and email.{/ts}</p>
+    <p>{ts}<strong>Export {if $exportCustomSearchField}custom search{else}PRIMARY{/if} fields</strong> provides the most commonly used data values. This includes primary address information, preferred phone and email.{/ts}</p>
     <p>{ts}Click <strong>Select fields for export</strong> and then <strong>Continue</strong> to choose a subset of fields for export. This option allows you to export multiple specific locations (Home, Work, etc.) as well as custom data. You can also save your selections as a 'field mapping' so you can use it again later.{/ts}</p>
  </div>
 


### PR DESCRIPTION
Overview
----------------------------------------
On custom searches (proximity search, include/exclude, activity search) and when you choose action "Export Contacts" and hit "Go", the .csv file downloads immediately. I was expecting to get to select fields, but I never even get to that screen.


Before
----------------------------------------
It directly downloads the csv file on choosing the task

After
----------------------------------------
![test-multiple-after](https://user-images.githubusercontent.com/3735621/34363452-3a90ec72-eaa2-11e7-8494-7abec80b11c6.gif)


Technical Details
----------------------------------------
NOTE: The 'PRIMARY' text on the select screen is changed to 'custom search' if the export is for a custom search.


---

 * [CRM-8140: Not possible to select fields for export when using Custom Searches](https://issues.civicrm.org/jira/browse/CRM-8140)