### PR TITLE
Fix for CRM-21485 - Tax not added when renewing membership in backend

### DIFF
--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -230,8 +230,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
 
     parent::buildQuickForm();
 
-    //CRM-21485
-    $defaults = self::setDefaultValues();
+    $defaults = parent::setDefaultValues();
     $this->assign('customDataType', 'Membership');
     $this->assign('customDataSubType', $this->_memType);
     $this->assign('entityID', $this->_id);
@@ -239,13 +238,13 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
 
     $allMembershipInfo = array();
 
-    //CRM-16950
-    $taxRates = CRM_Core_PseudoConstant::getTaxRates();
-    $taxRate = CRM_Utils_Array::value($defaults['financial_type_id'], $taxRates);//CRM-21485
-
     if (is_array($defaults['membership_type_id'])) { //CRM-21485
       $defaults['membership_type_id'] = $defaults['membership_type_id'][1];
     }
+
+    //CRM-16950
+    $taxRates = CRM_Core_PseudoConstant::getTaxRates();
+    $taxRate = CRM_Utils_Array::value($this->allMembershipTypeDetails[$defaults['membership_type_id']]['financial_type_id'], $taxRates);
 
     $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
 
@@ -276,7 +275,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
         //CRM-16950
         $taxAmount = NULL;
         $totalAmount = CRM_Utils_Array::value('minimum_fee', $values);
-        if (CRM_Utils_Array::value($defaults['financial_type_id'], $taxRates)) { //CRM-21485
+        if (CRM_Utils_Array::value($values['financial_type_id'], $taxRates)) {
           $taxAmount = ($taxRate / 100) * CRM_Utils_Array::value('minimum_fee', $values);
           $totalAmount = $totalAmount + $taxAmount;
         }
@@ -295,6 +294,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
         }
       }
     }
+
 
     $this->assign('allMembershipInfo', json_encode($allMembershipInfo));
 

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -243,6 +243,10 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
     $taxRates = CRM_Core_PseudoConstant::getTaxRates();
     $taxRate = CRM_Utils_Array::value($defaults['financial_type_id'], $taxRates);//CRM-21485
 
+    if (is_array($defaults['membership_type_id'])) { //CRM-21485
+      $defaults['membership_type_id'] = $defaults['membership_type_id'][1];
+    }
+
     $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
 
     // auto renew options if enabled for the membership

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -295,7 +295,6 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
       }
     }
 
-
     $this->assign('allMembershipInfo', json_encode($allMembershipInfo));
 
     if ($this->_memType) {

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -230,7 +230,8 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
 
     parent::buildQuickForm();
 
-    $defaults = parent::setDefaultValues();
+    //CRM-21485
+    $defaults = self::setDefaultValues();
     $this->assign('customDataType', 'Membership');
     $this->assign('customDataSubType', $this->_memType);
     $this->assign('entityID', $this->_id);
@@ -240,7 +241,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
 
     //CRM-16950
     $taxRates = CRM_Core_PseudoConstant::getTaxRates();
-    $taxRate = CRM_Utils_Array::value($this->allMembershipTypeDetails[$defaults['membership_type_id']]['financial_type_id'], $taxRates);
+    $taxRate = CRM_Utils_Array::value($defaults['financial_type_id'], $taxRates);//CRM-21485
 
     $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
 
@@ -271,7 +272,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
         //CRM-16950
         $taxAmount = NULL;
         $totalAmount = CRM_Utils_Array::value('minimum_fee', $values);
-        if (CRM_Utils_Array::value($values['financial_type_id'], $taxRates)) {
+        if (CRM_Utils_Array::value($defaults['financial_type_id'], $taxRates)) { //CRM-21485
           $taxAmount = ($taxRate / 100) * CRM_Utils_Array::value('minimum_fee', $values);
           $totalAmount = $totalAmount + $taxAmount;
         }


### PR DESCRIPTION
Overview
----------------------------------------
_This fix is for CRM-21485 - Tax not added when renewing membership in backend_

Before
----------------------------------------
_
Tax are added for a new membership but while renewing tax are not added
![image-2017-11-27-12-56-10-931](https://user-images.githubusercontent.com/4673159/34378565-6f3e0b24-eb1c-11e7-9a8f-1199b058b40c.png)
![image-2017-11-27-12-55-10-718](https://user-images.githubusercontent.com/4673159/34378534-3effda8c-eb1c-11e7-9f3a-cb01cf52b094.png) _

After
----------------------------------------
_
Now tax are added for both new membership and renewing.
![2017-12-27_1545](https://user-images.githubusercontent.com/4673159/34378709-50c168de-eb1d-11e7-9416-f19059188fa0.png)
![2017-12-27_1546](https://user-images.githubusercontent.com/4673159/34378710-5350539e-eb1d-11e7-83fe-b714c526dbc9.png)_

Technical Details
----------------------------------------
_ In PR https://github.com/civicrm/civicrm-core/commit/f525ec1f1766facf8a5c6300b19762a20d6b4072#diff-349ca8bcf1ef264bf3ca9acc2593aa54 the default functions are consolidated to shared class so financial_type_id is no longer accessed from parent class. So changed the code to get the financial_type_id from CRM_Member_Form_MembershipRenewal class._

---

 * [CRM-21485: Tax not added when renewing membership in backend](https://issues.civicrm.org/jira/browse/CRM-21485)