### PR TITLE
CRM-21585 - Fix erasing membership start_date when membership batch data entry

### DIFF
--- a/templates/CRM/Batch/Form/Entry.tpl
+++ b/templates/CRM/Batch/Form/Entry.tpl
@@ -372,6 +372,7 @@ function updateContactInfo(blockNo, prefix) {
             //get the information on membership type
             var membershipTypeId = data.values[0].membership_type_id;
             var membershipJoinDate = data.values[0].join_date;
+            var membershipStartDate = data.values[0].start_date;
             CRM.api('MembershipType', 'get', {
                 'sequential': '1',
                 'id': membershipTypeId
@@ -382,6 +383,7 @@ function updateContactInfo(blockNo, prefix) {
                 cj('select[id="field_' + blockNo + '_membership_type_0"]').val(memTypeContactId).change();
                 cj('select[id="field_' + blockNo + '_membership_type_1"]').val(membershipTypeId).change();
                 cj('#field_' + blockNo + '_' + 'join_date').val(membershipJoinDate).trigger('change');
+                cj('#field_' + blockNo + '_' + 'membership_start_date').val(membershipStartDate).trigger('change');
               }
               });
           }

--- a/templates/CRM/Batch/Form/Entry.tpl
+++ b/templates/CRM/Batch/Form/Entry.tpl
@@ -372,6 +372,8 @@ function updateContactInfo(blockNo, prefix) {
             //get the information on membership type
             var membershipTypeId = data.values[0].membership_type_id;
             var membershipJoinDate = data.values[0].join_date;
+            var membershipStartDate = data.values[0].start_date;
+
             CRM.api('MembershipType', 'get', {
                 'sequential': '1',
                 'id': membershipTypeId
@@ -382,6 +384,8 @@ function updateContactInfo(blockNo, prefix) {
                 cj('select[id="field_' + blockNo + '_membership_type_0"]').val(memTypeContactId).change();
                 cj('select[id="field_' + blockNo + '_membership_type_1"]').val(membershipTypeId).change();
                 cj('#field_' + blockNo + '_' + 'join_date').val(membershipJoinDate).trigger('change');
+                cj('#field_' + blockNo + '_' + 'membership_start_date').val(membershipStartDate).trigger('change');
+
               }
               });
           }


### PR DESCRIPTION
Overview
----------------------------------------
This PR fixes the issue of membership start date erasing issue when making batch membership data entry

Before
----------------------------------------
The input field for membership's starting date is empty in membership batch data entry

After
----------------------------------------
The input field for membership's starting date get populated with the member's existing membership starting date in membership batch data entry

Comments
----------------------------------------
Not sure if the initial functionality was intentional. I.e. not populating the membership's starting date.

---

 * [CRM-21585: Batch Date Entry Membership Renewal erases start date](https://issues.civicrm.org/jira/browse/CRM-21585)