### PR TITLE
CRM-21609 - Correctly handle PayPalPro recurring payments whose amoun…

### DIFF
--- a/CRM/Core/Payment/PayPalProIPN.php
+++ b/CRM/Core/Payment/PayPalProIPN.php
@@ -537,6 +537,7 @@ INNER JOIN civicrm_membership_payment mp ON m.id = mp.membership_id AND mp.contr
     $input['net_amount'] = self::retrieve('settle_amount', 'Money', 'POST', FALSE);
     $input['trxn_id'] = self::retrieve('txn_id', 'String', 'POST', FALSE);
     $input['payment_date'] = $input['receive_date'] = self::retrieve('payment_date', 'String', 'POST', FALSE);
+    $input['total_amount'] = $input['amount'];
   }
 
   /**


### PR DESCRIPTION
…t doesn't match the initial contribution

Overview
----------------------------------------
If you make a recurring contribution of, say, $10/month with PayPal Pro, then change the amount to a different amount ($12/month), the card will be charged $12 but recorded as $10 in CiviCRM.

Before
----------------------------------------
See above.

After
----------------------------------------
Payment is recorded for the correct amount.

Technical Details
----------------------------------------
The `Contribution.repeattransaction` API passes through the `$input[total_amount]` value to the contribution create method.  However, the value is stored in `$input[amount]`, not `$input[total_amount]` for PayPal Pro.

Comments
----------------------------------------
I realize this could be more concise by initializing `$input[total_amount]` when we initialize $input['amount'].  However, I have a private patch to support failed PayPal recurring payments that I'd like to pass upstream that would be affected.
