### PR TITLE
CRM-21611: Logging summary report with FULL_GROUP_BY on Mysql 5.7

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -2245,11 +2245,6 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
    * @param bool $pager
    */
   public function formatDisplay(&$rows, $pager = TRUE) {
-    // set pager based on if any limit was applied in the query.
-    if ($pager) {
-      $this->setPager();
-    }
-
     // allow building charts if any
     if (!empty($this->_params['charts']) && !empty($rows)) {
       $this->buildChart($rows);
@@ -2324,6 +2319,11 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
 
     // use this method for formatting custom rows for display purpose.
     $this->alterCustomDataDisplay($rows);
+
+    // set pager based on if any limit was applied in the query.
+    if ($pager) {
+      $this->setPager();
+    }
   }
 
   /**

--- a/CRM/Utils/SQL.php
+++ b/CRM/Utils/SQL.php
@@ -93,13 +93,13 @@ class CRM_Utils_SQL {
    * @return bool
    */
   public static function disableFullGroupByMode() {
-    $sqlModes = self::getSqlModes();
+    $sqlModes = array_flip(self::getSqlModes());
 
     // Disable only_full_group_by mode for lower sql versions.
-    if (!self::supportsFullGroupBy() || (!empty($sqlModes) && !in_array('ONLY_FULL_GROUP_BY', $sqlModes))) {
-      if ($key = array_search('ONLY_FULL_GROUP_BY', $sqlModes)) {
-        unset($sqlModes[$key]);
-        CRM_Core_DAO::executeQuery("SET SESSION sql_mode = '" . implode(',', $sqlModes) . "'");
+    if (!self::supportsFullGroupBy() || (!empty($sqlModes) && !array_key_exists('ONLY_FULL_GROUP_BY', $sqlModes))) {
+      if (array_key_exists('ONLY_FULL_GROUP_BY', $sqlModes)) {
+        unset($sqlModes['ONLY_FULL_GROUP_BY']);
+        CRM_Core_DAO::executeQuery("SET SESSION sql_mode = '" . implode(',', array_keys($sqlModes)) . "'");
       }
       return TRUE;
     }


### PR DESCRIPTION
Overview
----------------------------------------
When FULL_GROUP_BY_MODE is enabled, on simple search/sorting by column of logging summary report tends to throw error. Also there is rowcount mismatch with actual number of rows listed on the report. This PR addresses all this issue.

Before
----------------------------------------
DB Error:
![screen shot 2018-02-28 at 3 42 22 pm](https://user-images.githubusercontent.com/3735621/36782156-0f2cb312-1c9e-11e8-8e35-3816f68786fa.png)

Pagination count mismatch:
![screen shot 2018-02-28 at 3 55 49 pm](https://user-images.githubusercontent.com/3735621/36782759-ec90172a-1c9f-11e8-8a6e-c3f28bda2d1d.png)

After
----------------------------------------
- Group by errors got fixed.
- Pagination matches with actual number of rows listed:
![screen shot 2018-02-28 at 3 57 18 pm](https://user-images.githubusercontent.com/3735621/36782843-4019a42e-1ca0-11e8-889f-e70f4a83f21f.png)


---

 * [CRM-21611: Logging summary report with FULL_GROUP_BY on Mysql 5.7](https://issues.civicrm.org/jira/browse/CRM-21611)