### PR TITLE
CRM-21612: Membership Payment not recorded for recurring contribution…

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -1158,7 +1158,7 @@ abstract class CRM_Core_Payment {
    */
   public function doPayment(&$params, $component = 'contribute') {
     $this->_component = $component;
-    $statuses = CRM_Contribute_BAO_Contribution::buildOptions('contribution_status_id');
+    $statuses = CRM_Contribute_BAO_Contribution::buildOptions('contribution_status_id', 'validate');
 
     // If we have a $0 amount, skip call to processor and set payment_status to Completed.
     // Conceivably a processor might override this - perhaps for setting up a token - but we don't

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -689,6 +689,17 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
    * Test the submit function of the membership form.
    */
   public function testSubmitRecur() {
+    $pendingVal = $this->callAPISuccessGetValue('OptionValue', array(
+      'return' => "id",
+      'option_group_id' => "contribution_status",
+      'label' => "Pending",
+    ));
+    //Update label for Pending contribution status.
+    $this->callAPISuccess('OptionValue', 'create', array(
+      'id' => $pendingVal,
+      'label' => "PendingEdited",
+    ));
+
     $form = $this->getForm();
 
     $this->callAPISuccess('MembershipType', 'create', array(
@@ -710,6 +721,12 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
       'contact_id' => $this->_individualId,
       'is_test' => TRUE,
     ));
+
+    //Check if Membership Payment is recorded.
+    $this->callAPISuccessGetCount('MembershipPayment', array(
+      'membership_id' => $membership['id'],
+      'contribution_id' => $contribution['id'],
+    ), 1);
 
     // CRM-16992.
     $this->callAPISuccessGetCount('LineItem', array(


### PR DESCRIPTION
… when status label is changed

Overview
----------------------------------------
Membership Payment not recorded for recurring contribution when contribution status is changed.

Before
----------------------------------------
When a Pending contribution label is changed, recurring contribution done through a payment processor does not link to the membership.

After
----------------------------------------
Membership Payment is recorded correctly.

Technical Details
----------------------------------------
Due to label present in `$statuses`, the returned `$result` does not contain a value for `payment_status_id`, which do not create any membership contribution for the contact.

Comments
----------------------------------------
Added unit test.

---

 * [CRM-21612: Membership Payment not recorded for recurring contribution when status label is changed.](https://issues.civicrm.org/jira/browse/CRM-21612)