### PR TITLE
CRM-21602 Fix javascript error on Campaign/petition pages

### DIFF
--- a/templates/CRM/Campaign/Form/Search/Petition.tpl
+++ b/templates/CRM/Campaign/Form/Search/Petition.tpl
@@ -198,7 +198,7 @@ function loadPetitionList( )
              "oLanguage":{"sEmptyTable"  : noRecordFoundMsg,
                  "sZeroRecords" : noRecordFoundMsg },
              "fnDrawCallback": function() {
-               $(this).trigger('crmLoad');
+               CRM.$(this).trigger('crmLoad');
              },
              "fnRowCallback": function( nRow, aData, iDisplayIndex ) {
 

--- a/templates/CRM/Campaign/Form/Search/Survey.tpl
+++ b/templates/CRM/Campaign/Form/Search/Survey.tpl
@@ -212,7 +212,7 @@ function loadSurveyList( )
              "oLanguage":{"sEmptyTable"  : noRecordFoundMsg,
                  "sZeroRecords" : noRecordFoundMsg },
              "fnDrawCallback": function() {
-               $(this).trigger('crmLoad');
+               CRM.$(this).trigger('crmLoad');
              },
              "fnRowCallback": function( nRow, aData, iDisplayIndex ) {
                // Crm-editable


### PR DESCRIPTION
Overview
----------------------------------------
Fixed the JavaScript error occurred when viewing and do actions on Campaigns page Campaigns/Surveys/Petitions. The bug report was continuous loading icon when enabling/disabling campaigns

Before
----------------------------------------
The loading icon did not disappear when enabling/disabling campaigns

After
----------------------------------------
The loading icon disappears when enabling/disabling campaigns

Technical Details
----------------------------------------
Added CRM.$ instead of $ for jQuery selectors where applicable.
Branch rebased to master.

Comments
----------------------------------------
There are 3 pages Campaign/Petition/Survey. The Campaign page uses 
(function($){
})(CRM.$)
hence within that function, $ can be used freely instead of CRM.$.
But other two pages Petition/Survey do not use that technique. Therefore CRM.$ needs to be used instead of $.

---

 * [CRM-21602: Disable\/Enable Campaign not working](https://issues.civicrm.org/jira/browse/CRM-21602)