### PR TITLE
CRM-21613: Search issues on 'Manage Tag' page

### DIFF
--- a/CRM/Core/BAO/Tag.php
+++ b/CRM/Core/BAO/Tag.php
@@ -573,6 +573,17 @@ class CRM_Core_BAO_Tag extends CRM_Core_DAO_Tag {
               ->execute();
     while ($dao->fetch()) {
       $childTagIDs[$dao->parent_id] = (array) explode(',', $dao->child_id);
+      $parentID = $dao->parent_id;
+      if ($searchString) {
+        // recursively search for parent tag ID and it's child if any
+        while ($parentID) {
+          $newParentID = CRM_Core_DAO::singleValueQuery(" SELECT parent_id FROM civicrm_tag WHERE id = $parentID ");
+          if ($newParentID) {
+            $childTagIDs[$newParentID] = array($parentID);
+          }
+          $parentID = $newParentID;
+        }
+      }
     }
 
     // check if child tag has any childs, if found then include those child tags inside parent tag

--- a/templates/CRM/Tag/Page/Tag.tpl
+++ b/templates/CRM/Tag/Page/Tag.tpl
@@ -299,8 +299,9 @@
           });
 
         $('input[name=filter_tag_tree]', $panel).on('keyup change', function() {
-          if ($(this).val() == null) {
-            $('.tag-tree', $panel).jstree(true).refresh();
+          if ($(this).val() === '') {
+            $('.tag-tree', $panel).jstree("clear_search");
+            $('.tag-tree', $panel).jstree("refresh", true, true);
           }
           else {
             $(".tag-tree", $panel).jstree("search", $(this).val());


### PR DESCRIPTION
Overview
----------------------------------------
This PR fixes these two search issues:
1. Cannot search level 2 or greater child tags using tag filter
2. After any search, omitting/clearing search text by key doesn't restore the whole tag tree by stuck in old state

Before
----------------------------------------
![test-multiple-before](https://user-images.githubusercontent.com/3735621/34445888-dc08dd7e-ecfc-11e7-97ae-dd496779a610.gif)

After
----------------------------------------
![test-multiple-after](https://user-images.githubusercontent.com/3735621/34445893-e36d8204-ecfc-11e7-96c4-80cf54dc16d4.gif)

---

 * [CRM-21613: Search issues on 'Manage Tag' page](https://issues.civicrm.org/jira/browse/CRM-21613)