### PR TITLE
CRM-21614: Tag UI doesn't appear to respect reserved tags permission

### DIFF
--- a/templates/CRM/Tag/Page/Tag.tpl
+++ b/templates/CRM/Tag/Page/Tag.tpl
@@ -167,7 +167,12 @@
 
         function moveTag(e, data) {
           if (data.parent != data.old_parent) {
-            CRM.api3('Tag', 'create', {id: data.node.id, parent_id: data.parent.replace('#', '')}, true);
+            CRM.api3('Tag', 'create', {id: data.node.id, parent_id: data.parent.replace('#', '')}, true)
+            .done(function (result) {
+              if (result.is_error === 1) {
+                $('.tag-tree', $panel).jstree(true).refresh();
+              }
+            });
           }
         }
 


### PR DESCRIPTION
Overview
----------------------------------------
If you don't have the reserved tags permission and try to move a reserved tag, it appears you are able to do that (the tag moves to a different branch), but you receive a permissions popup warning and the tag is not actually moved (if you reload it will return to its original location). Fix will need to adjust the UI so that you can't appear to move the tag at all.

Before
----------------------------------------
![test-multiple-before](https://user-images.githubusercontent.com/3735621/34446318-0ec54768-ed00-11e7-9c90-ab0bb86f5ac5.gif)

After
----------------------------------------
![test-multiple-after](https://user-images.githubusercontent.com/3735621/34446324-1a6f3a7e-ed00-11e7-9722-a4751717da2b.gif)

---

 * [CRM-21614: Tag UI doesn't appear to respect reserved tags permission](https://issues.civicrm.org/jira/browse/CRM-21614)