### PR TITLE
CRM-21614 - Tag UI doesn't appear to respect reserved tags permission

### DIFF
--- a/templates/CRM/Tag/Page/Tag.tpl
+++ b/templates/CRM/Tag/Page/Tag.tpl
@@ -234,6 +234,16 @@
             });
         }
 
+        function isDraggable(nodes, event) {
+          var draggable = true;
+          _.each(nodes, function(node) {
+            if (node.data.is_reserved && !CRM.checkPerm('administer reserved tags')) {
+              draggable = false;
+            }
+          });
+          return draggable;
+        }
+
         $panel
           .append('<div class="tag-tree-wrapper"><div class="tag-tree"></div><div class="tag-info"></div></div>')
           .on('change', 'input[type=color]', changeColor)
@@ -283,6 +293,7 @@
             },
             plugins: plugins,
             dnd: {
+              is_draggable: isDraggable,
               copy: false
             }
           });
@@ -393,6 +404,14 @@
   li.is-reserved > a:after {
     content: ' *';
   }
+  {/literal}{if !call_user_func(array('CRM_Core_Permission', 'check'), 'administer reserved tags')}{literal}
+    #tree li.is-reserved > a.crm-tag-item {
+      cursor: not-allowed;
+    }
+    li.is-reserved > a:after {
+      color: #8A1F11;
+    }
+  {/literal}{/if}{literal}
   .tag-tree-wrapper ul {
     margin: 0;
     padding: 0;


### PR DESCRIPTION
Overview
----------------------------------------
If you don't have the reserved tags permission and try to move a reserved tag, it appears you are able to do that (the tag moves to a different branch), but you receive a permissions popup warning and the tag is not actually moved (if you reload it will return to its original location). Fix will need to adjust the UI so that you can't appear to move the tag at all.

Before
----------------------------------------
![test-multiple-before](https://user-images.githubusercontent.com/3735621/34446318-0ec54768-ed00-11e7-9c90-ab0bb86f5ac5.gif)

After
----------------------------------------
Tags cannot be moved without permission.


* [CRM-21614: Tag UI doesn't appear to respect reserved tags permission](https://issues.civicrm.org/jira/browse/CRM-21614)