### PR TITLE
Fix for one cause of CRM-18300.

### DIFF
--- a/CRM/Upgrade/Incremental/sql/4.7.31.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.7.31.mysql.tpl
@@ -1,1 +1,12 @@
 {* file to handle db changes in 4.7.31 during upgrade *}
+
+-- CRM-18300 Remove "_[id]" suffix from name column for profiles referenced
+-- by name in core code.
+UPDATE IGNORE civicrm_uf_group SET name = 'new_individual' WHERE name = concat('new_individual_', id);
+UPDATE IGNORE civicrm_uf_group SET name = 'new_organization' WHERE name = concat('new_organization_', id);
+UPDATE IGNORE civicrm_uf_group SET name = 'new_household' WHERE name = concat('new_household_', id);
+UPDATE IGNORE civicrm_uf_group SET name = 'summary_overlay' WHERE name = concat('summary_overlay_', id);
+UPDATE IGNORE civicrm_uf_group SET name = 'contribution_batch_entry' WHERE name = concat('contribution_batch_entry_', id);
+UPDATE IGNORE civicrm_uf_group SET name = 'membership_batch_entry' WHERE name = concat('membership_batch_entry_', id);
+UPDATE IGNORE civicrm_uf_group SET name = 'shared_address' WHERE name = concat('shared_address_', id);
+UPDATE IGNORE civicrm_uf_group SET name = 'event_registration' WHERE name = concat('event_registration_', id);


### PR DESCRIPTION
Overview
----------------------------------------
Incorrect values for civicrm_uf_group.name cause spurious "Permission Denied" errors.

Before
----------------------------------------
On sites where this is an issue, the following steps will cause the error message

1. Inspect the `name` column in the `civicrm_uf_group` table. If there's a row with the value 'summary_overlay', you may not be able to reproduce the error on this installation. However, if such a row does not exist, you can surely reproduce the error. In my case, I notice all values in the `name` column are in the form 'title_with_underscores_[id]', so the value for the "Summary Overlay" profile is 'summary_overlay_7'.
2. Perform any contact search that will generate results.
3. In the search results, hover over the "contact type" icon (by default, an Individual, Organization, or Household icon) and observe that the summary overlay appears poorly formatted. (If you examine your browser console's Network tab, you'll observe a request to /civicrm/profile/view?reset=1&gid=&id=[contact_id]&snippet=4. Note the value for gid is empty.)
4. Reload the page or load any other civicrm page to see the error message: "Permission Denied: You do not have permission to view this contact record. Contact the site administrator if you need assistance."

After
----------------------------------------
This PR contains SQL UPDATE statements in the upgrade SQL script for version 4.7.31. For sites affected by this issue, after these SQL queries are applied, the repro steps above do not result in the error message described in step 4.

Technical Details
----------------------------------------
This PR fixes a particular cause of the error message, specifically: All records in `civicrm_uf_group` have their `name` column in the format 'title_with_underscores_[id]' instead of simply 'title_with_underscores'. For most profiles, this is fine, and is by design, as there was some effort to fix problems with non-unique values in the `name` column (for example issues CRM-15952 and CRM-15961). 

But for the specific profile 'summary_overlay', it is a problem. This profile is referenced by this exact name (without the '_[id]' suffix) in CiviCRM core code. The addition of this suffix is the cause of the error message in this case.

Further, there are other `name` values which are specifically referenced in CiviCRM core code. `name` values for those profiles are also addressed by this PR.

Comments
----------------------------------------
Comments in CRM-18300 indicate there are other causes of this error message. This PR is not expected to address those causes.

---

 * [CRM-18300: "Permission denied" message re contact on CiviCRM dashboard](https://issues.civicrm.org/jira/browse/CRM-18300)
 * [CRM-15952: Edit screen fails when user uf_group name is not unique](https://issues.civicrm.org/jira/browse/CRM-15952)
 * [CRM-15961: uf_group.name may not be a unique value for CiviCRM installs that started prior to 4.2](https://issues.civicrm.org/jira/browse/CRM-15961)