### PR TITLE
CRM-21559 - Save button in Case Type not clickable

### DIFF
--- a/ang/crmCaseType/timelineTable.html
+++ b/ang/crmCaseType/timelineTable.html
@@ -40,7 +40,6 @@ Required vars: activitySet
         ui-options="{dropdownAutoWidth : true}"
         ng-model="activity.reference_activity"
         ng-options="activityType.name as activityType.label for activityType in activitySet.activityTypes"
-        ng-required="activity.name != ''"
         >
         <option value="">-- Case Start --</option>
       </select>
@@ -51,7 +50,6 @@ Required vars: activitySet
         type="text"
         ng-pattern="/^-?[0-9]*$/"
         ng-model="activity.reference_offset"
-        ng-required="activity.name != ''"
         >
     </td>
     <td>
@@ -60,7 +58,6 @@ Required vars: activitySet
         ui-options="{dropdownAutoWidth : true}"
         ng-model="activity.reference_select"
         ng-options="key as value for (key,value) in {newest: ts('Newest'), oldest: ts('Oldest')}"
-        ng-required="activity.name != ''"
         >
       </select>
     </td>


### PR DESCRIPTION
Overview
----------------------------------------
Save button in Case Type not clickable

Before
----------------------------------------
Save button on case type form remains disabled even after filling all the required fields. See more at https://github.com/civicrm/civicrm-core/pull/11204#issuecomment-353927227

After
----------------------------------------
`Save` button fixed. User is able to add/edit a case type.

---

 * [CRM-21559: Save button in Case Type not clickable](https://issues.civicrm.org/jira/browse/CRM-21559)