### PR TITLE
CRM-19107 Fixed PayPal Express redirection issue.

### DIFF
--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -139,13 +139,15 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
   protected function addPaypalExpressCode(&$form) {
     // @todo use $this->isBackOffice() instead, test.
     if (empty($form->isBackOffice)) {
-      /*
-      if payment method selected using ajax call then form object is of 'CRM_Financial_Form_Payment',
-      instead of 'CRM_Contribute_Form_Contribution_Main' so it generate wrong button name
-      and then clicking on express button it redirect to confirm screen rather than PayPal Express form
-      */
+
+      /**
+       * if payment method selected using ajax call then form object is of 'CRM_Financial_Form_Payment',
+       * instead of 'CRM_Contribute_Form_Contribution_Main' so it generate wrong button name
+       * and then clicking on express button it redirect to confirm screen rather than PayPal Express form
+       */
+
       if ('CRM_Financial_Form_Payment' == get_class($form) && $form->_formName) {
-        $form->_expressButtonName = '_qf_'.$form->_formName.'_upload_express';
+        $form->_expressButtonName = '_qf_' . $form->_formName . '_upload_express';
       }
       else {
         $form->_expressButtonName = $form->getButtonName('upload', 'express');

--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -139,7 +139,17 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
   protected function addPaypalExpressCode(&$form) {
     // @todo use $this->isBackOffice() instead, test.
     if (empty($form->isBackOffice)) {
-      $form->_expressButtonName = $form->getButtonName('upload', 'express');
+      /*
+      if payment method selected using ajax call then form object is of 'CRM_Financial_Form_Payment',
+      instead of 'CRM_Contribute_Form_Contribution_Main' so it generate wrong button name
+      and then clicking on express button it redirect to confirm screen rather than PayPal Express form
+      */
+      if ('CRM_Financial_Form_Payment' == get_class($form) && $form->_formName) {
+        $form->_expressButtonName = '_qf_'.$form->_formName.'_upload_express';
+      }
+      else {
+        $form->_expressButtonName = $form->getButtonName('upload', 'express');
+      }
       $form->assign('expressButtonName', $form->_expressButtonName);
       $form->add(
         'image',

--- a/CRM/Financial/Form/Payment.php
+++ b/CRM/Financial/Form/Payment.php
@@ -51,10 +51,17 @@ class CRM_Financial_Form_Payment extends CRM_Core_Form {
   public $isBackOffice = FALSE;
 
   /**
+   * @var String
+   */
+  public $_formName = '';
+
+  /**
    * Set variables up before form is built.
    */
   public function preProcess() {
     parent::preProcess();
+
+    $this->_formName = CRM_Utils_Request::retrieve('formName', 'String', $this);
 
     $this->_values['custom_pre_id'] = CRM_Utils_Request::retrieve('pre_profile_id', 'Integer', $this);
 

--- a/templates/CRM/common/paymentBlock.tpl
+++ b/templates/CRM/common/paymentBlock.tpl
@@ -111,7 +111,7 @@
 
       var payment_instrument_id = $('#payment_instrument_id').val();
 
-      var dataUrl = "{crmURL p='civicrm/payment/form' h=0 q="&currency=`$currency`&`$urlPathVar``$isBackOfficePathVar``$profilePathVar``$contributionPageID``$preProfileID`processor_id="}" + type;
+      var dataUrl = "{crmURL p='civicrm/payment/form' h=0 q="&formName=`$form.formName`&currency=`$currency`&`$urlPathVar``$isBackOfficePathVar``$profilePathVar``$contributionPageID``$preProfileID`processor_id="}" + type;
       {literal}
       if (typeof(CRM.vars) != "undefined") {
         if (typeof(CRM.vars.coreForm) != "undefined") {


### PR DESCRIPTION
Overview
----------------------------------------
Failed to redirect on Paypal express when clicking on express button

Before
----------------------------------------
Online Donation/Event Registration page is configured with multiple payment option.
PayPal Pro payment processor show Express checkout option above credit card field.
Clicking on the Express checkout button, it redirect to confirm screen rather than Paypal site.

After
----------------------------------------
It will redirect to Paypal Express 

Technical Details
----------------------------------------
This issue only observed when we have multiple option for payment.
e.g Paypal Pro and check payment.
first click on check payment option then click on Paypal Pro option. This will load credit card form with billing details. its also show PayPal Express button.

Now fill all required field in civicrm profile if available then click on 'Paypal Express' button. it redirect o confirm screen. 

Then clicking on 'continue' button on confirm scree it show error message "Invalid Data This transaction cannot be processed. Please enter a valid credit card number and type."

Credit card form is loaded using ajax call, express button name ( _qf_Payment_upload_express ) is not same when it generated without ajax call ( _qf_Main_upload_express OR _qf_Register_upload_express ).

More details available in ticket

---

 * [CRM-19107: PayPal Button Error](https://issues.civicrm.org/jira/browse/CRM-19107)