### PR TITLE
CRM-21616 ensure sql metadata is available from api

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -1313,7 +1313,7 @@ class CRM_Report_Form extends CRM_Core_Form {
    *
    * @param string $sql
    */
-  protected function addToDeveloperTab($sql) {
+  public function addToDeveloperTab($sql) {
     if (!CRM_Core_Permission::check('view report sql')) {
       return;
     }

--- a/api/v3/ReportTemplate.php
+++ b/api/v3/ReportTemplate.php
@@ -152,6 +152,7 @@ function _civicrm_api3_report_template_getrows($params) {
   $reportInstance->setOffsetValue($options['offset']);
   $reportInstance->beginPostProcessCommon();
   $sql = $reportInstance->buildQuery();
+  $reportInstance->addToDeveloperTab($sql);
   $rows = $metadata = $requiredMetadata  = array();
   $reportInstance->buildRows($sql, $rows);
   $reportInstance->formatDisplay($rows);

--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -303,6 +303,15 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
     ));
 
     $this->assertEquals(2, $rows['count'], "Report failed - the sql used to generate the results was " . print_r($rows['metadata']['sql'], TRUE));
+
+    $this->assertContains('DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci
+      SELECT SQL_CALC_FOUND_ROWS contact_civireport.id as cid  FROM civicrm_contact contact_civireport    INNER JOIN civicrm_contribution contribution_civireport USE index (received_date) ON contribution_civireport.contact_id = contact_civireport.id
+         AND contribution_civireport.is_test = 0
+         AND contribution_civireport.receive_date BETWEEN \'20140701000000\' AND \'20150630235959\'
+       
+       LEFT JOIN civicrm_contribution cont_exclude ON cont_exclude.contact_id = contact_civireport.id
+         AND cont_exclude.receive_date BETWEEN \'2015-7-1\' AND \'20160630235959\' WHERE cont_exclude.id IS NULL AND 1 AND ( contribution_civireport.contribution_status_id IN (1) )
+      GROUP BY contact_civireport.id', $rows['metadata']['sql'][0]);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Ensure that sql metadata is returned from the report api if requested

Before
----------------------------------------
Api call    

 $rows = civicrm_api3('report_template', 'getrows', array(
      'report_id' => 'contribute/lybunt',
      'yid_value' => 2015,
      'yid_op' => 'fiscal',
      'options' => array('metadata' => array('sql')))
 
was getting NULL returned as the sql

After
----------------------------------------
The metadata returned now includes the sql array

Technical Details
----------------------------------------
This worked at some point in the past but broke. It is mostly used for debugging, esp with unit test issues. Test added this time

Comments
----------------------------------------
_Anything else you would like the reviewer to note_

---

 * [CRM-21616: sql metadata is being lost when calling the report from the api](https://issues.civicrm.org/jira/browse/CRM-21616)