### PR TITLE
CRM-21617 Ensure that Regular Expressions aren't transformmed into lo…

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2332,7 +2332,7 @@ class CRM_Contact_BAO_Query {
         $this->_where[$grouping][] = CRM_Core_DAO::createSQLFilter($fieldName, $value, $type);
       }
       else {
-        if (!strpos($op, 'IN')) {
+        if (!strpos($op, 'IN') && $op !== 'RLIKE') {
           $value = $strtolower($value);
         }
         if ($wildcard) {
@@ -5644,7 +5644,12 @@ SELECT COUNT( conts.total_amount ) as cancel_count,
         $value = CRM_Utils_Type::escape($value, $dataType);
         // if we don't have a dataType we should assume
         if ($dataType == 'String' || $dataType == 'Text') {
-          $value = "'" . strtolower($value) . "'";
+          if ($op != 'RLIKE') {
+            $value = "'" . strtolower($value) . "'";
+          }
+          else {
+            $value = "BINARY '" . $value . "'";
+          }
         }
         return "$clause $value";
     }


### PR DESCRIPTION
…wer case and opperate on a Case Sensitve basis when run in the DB

Overview
----------------------------------------
Previously Regular Expressions were being transformed to lower case and RLIKE by default isn't case sensitive as per https://dev.mysql.com/doc/refman/5.5/en/regexp.html

Before
----------------------------------------
Regular Expression was mishandled

After
----------------------------------------
Is now correctly handled in search builder

ping @monishdeb @johntwyman @eileenmcnaughton @colemanw 

Monish, Eileen Coleman would one of you be able to review this?
