### PR TITLE
CRM-21618: Fix page structure

### DIFF
--- a/templates/CRM/Campaign/Form/Task/Interview.tpl
+++ b/templates/CRM/Campaign/Form/Task/Interview.tpl
@@ -42,7 +42,7 @@
 
     <div id='responseErrors' class = "hiddenElement messages crm-error"></div>
 
-    <div id='help' class='help'>
+    <div class='help'>
       {if $votingTab}
         {ts}Click <strong>record response</strong> button to update values for each respondent as needed.{/ts}
       {else}

--- a/templates/CRM/Campaign/Form/Task/Interview.tpl
+++ b/templates/CRM/Campaign/Form/Task/Interview.tpl
@@ -42,7 +42,7 @@
 
     <div id='responseErrors' class = "hiddenElement messages crm-error"></div>
 
-    <div id='help'>
+    <div id='help' class='help'>
       {if $votingTab}
         {ts}Click <strong>record response</strong> button to update values for each respondent as needed.{/ts}
       {else}
@@ -59,6 +59,7 @@
           <th></th>
           <th>{ts}Column{/ts}</th>
           <th>{ts}Order{/ts}</th>
+          <th></th>
         </tr>
 
         {section name=rowLoop start=1 loop=5}

--- a/templates/CRM/Report/Page/TemplateList.tpl
+++ b/templates/CRM/Report/Page/TemplateList.tpl
@@ -23,10 +23,12 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
+
+<div class="help">
+  {ts}Create reports for your users from any of the report templates listed below. Click on a template title to get started. Click Existing Report(s) to see any reports that have already been created from that template.{/ts}
+</div>
+
 <div class="crm-block crm-form-block crm-report-templateList-form-block">
-  <div class="help">
-    {ts}Create reports for your users from any of the report templates listed below. Click on a template title to get started. Click Existing Report(s) to see any reports that have already been created from that template.{/ts}
-  </div>
   {strip}
     {if $list}
       {counter start=0 skip=1 print=false}


### PR DESCRIPTION
Overview
----------------------------------------
This PR
- adds missing <th> tag in `templates/CRM/Campaign/Form/Task/Interview.tpl` file
- adds missing class 'help' in `templates/CRM/Campaign/Form/Task/Interview.tpl` file
- Moves help section  out side table containers as per other table page from `templates/CRM/Report/Page/TemplateList.tpl` file

Screenshots
----------------------------------------
_Visually ineffective changes._

---

 * [CRM-21618: Add missing structure in templates](https://issues.civicrm.org/jira/browse/CRM-21618)