### PR TITLE
CRM-21621 - Provide ability to delete first website field

### DIFF
--- a/templates/CRM/Contact/Form/Edit/Website.tpl
+++ b/templates/CRM/Contact/Form/Edit/Website.tpl
@@ -41,7 +41,7 @@
 <tr id="Website_Block_{$blockId}">
     <td>{$form.website.$blockId.url.html|crmAddClass:url}&nbsp;</td>
     <td>{$form.website.$blockId.website_type_id.html}</td>
-    <td colspan="3">{if $blockId > 1} <a href="#" title="{ts}Delete Website Block{/ts}" onClick="removeBlock('Website','{$blockId}'); return false;">{ts}delete{/ts}</a>{/if}</td>
+    <td colspan="3"><a href="#" title="{ts}Delete Website Block{/ts}" onClick="removeBlock('Website','{$blockId}'); return false;">{ts}delete{/ts}</a></td>
 </tr>
 {if !$addBlock}
 <tr>

--- a/templates/CRM/Contact/Form/Inline/Website.tpl
+++ b/templates/CRM/Contact/Form/Inline/Website.tpl
@@ -50,11 +50,7 @@
     <tr id="Website_Block_{$blockId}" {if $blockId gt $actualBlockCount}class="hiddenElement"{/if}>
       <td>{$form.website.$blockId.url.html|crmAddClass:url}&nbsp;</td>
       <td>{$form.website.$blockId.website_type_id.html}</td>
-      <td>
-        {if $blockId > 1}
-          <a class="crm-delete-inline crm-hover-button action-item" href="#" title="{ts}Delete Website{/ts}"><span class="icon delete-icon"></span></a>
-        {/if}
-       </td>
+      <td><a class="crm-delete-inline crm-hover-button action-item" href="#" title="{ts}Delete Website{/ts}"><span class="icon delete-icon"></span></a></td>
     </tr>
     {/section}
 </table>


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate:
-------------------------
1. Create a contact with multiple website fields
2. Do an inline edit/edit, trash icon or link appears in front of all but first row.


Before
----------------------------------------
![inline_before](https://user-images.githubusercontent.com/3455173/34515496-4896b486-f098-11e7-80ea-908988091807.png)
![edit_before](https://user-images.githubusercontent.com/3455173/34515505-5229e540-f098-11e7-8086-3485dad19c59.png)


After
----------------------------------------
![inline_after](https://user-images.githubusercontent.com/3455173/34515514-61f9e682-f098-11e7-98a3-d5687b00e6d1.png)

![edit_after](https://user-images.githubusercontent.com/3455173/34515518-670e618e-f098-11e7-8f5e-8eeb616e3f4b.png)

Comments
----------------------------------------
There should be no reason for not deleting the first one -this may have been a continuation of what we do for other fields (im/phone/email etc) since the first row in those cases is primary.
For website there is no 'primary' field so safe to have the icon/link.

---

 * [CRM-21621: Provide ability to delete first website field](https://issues.civicrm.org/jira/browse/CRM-21621)