### PR TITLE
CRM-21622: Allow multiple parents to be created from 'New Group' form.

### DIFF
--- a/CRM/Group/Form/Edit.php
+++ b/CRM/Group/Form/Edit.php
@@ -458,7 +458,7 @@ WHERE  title = %1
       $potentialParentGroupIds = array_keys($groupNames);
     }
 
-    $parentGroupSelectValues = array('' => '- ' . ts('select group') . ' -');
+    $parentGroupSelectValues = array();
     foreach ($potentialParentGroupIds as $potentialParentGroupId) {
       if (array_key_exists($potentialParentGroupId, $groupNames)) {
         $parentGroupSelectValues[$potentialParentGroupId] = $groupNames[$potentialParentGroupId];
@@ -472,7 +472,7 @@ WHERE  title = %1
       else {
         $required = FALSE;
       }
-      $form->add('select', 'parents', ts('Add Parent'), $parentGroupSelectValues, $required, array('class' => 'crm-select2'));
+      $form->add('select', 'parents', ts('Add Parent'), $parentGroupSelectValues, $required, array('class' => 'crm-select2', 'multiple' => TRUE));
     }
 
     return $parentGroups;


### PR DESCRIPTION
Overview
----------------------------------------
Adds flexibility to add multiple parents to a group from `New Group` form.

Before
----------------------------------------
API's are able to create multiple parents during group creation. Eg the below api works fine.

    $result = civicrm_api3('Group', 'create', array(
        'title' => "testgrpfromapi",
        'parents' => array(1, 2),
    ));

But there is no way to select multiple parents on `New Group` form. You need to add a single parent and then click on settings link to add another parent.

After
----------------------------------------
Parent field is changed to `multiselect`. So, a group can be added with multiple parents in a single save.

---

 * [CRM-21622: Make the Add Parent Groups on Group Settings be a multiselect](https://issues.civicrm.org/jira/browse/CRM-21622)