### PR TITLE
CRM-21595 re-fix CRM-21445

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -294,9 +294,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
     $this->_fields = $this->get('fields');
     $this->_bltID = $this->get('bltID');
     $this->_paymentProcessor = $this->get('paymentProcessor');
-    if (!$this->_paymentProcessor) {
-      $this->_paymentProcessor = array('object' => Civi\Payment\System::singleton()->getById(0));
-    }
+
     $this->_priceSetId = $this->get('priceSetId');
     $this->_priceSet = $this->get('priceSet');
 
@@ -581,9 +579,10 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
 
     // The concept of contributeMode is deprecated.
     // The payment processor object can provide info about the fields it shows.
-    if ($isMonetary) {
+    if ($isMonetary && is_a($this->_paymentProcessor['object'], 'CRM_Core_Payment')) {
       /** @var  $paymentProcessorObject \CRM_Core_Payment */
       $paymentProcessorObject = $this->_paymentProcessor['object'];
+
       $paymentFields = $paymentProcessorObject->getPaymentFormFields();
       foreach ($paymentFields as $index => $paymentField) {
         if (!isset($this->_params[$paymentField])) {


### PR DESCRIPTION
Overview
----------------------------------------
Revert https://github.com/civicrm/civicrm-core/pull/11427/files
Add additional check for pay later fatal


#11454 against 4.7.30 - due to the criticality of this I am merging to 4.7.30 & up to master now - although I still advocate replacing the 4.7.29 release ASAP

---

 * [CRM-21595: Regression: Contribution page no longer works when configured with PayPal Pro and pay later](https://issues.civicrm.org/jira/browse/CRM-21595)
 * [CRM-21445: Contribution page issues with 100% discount](https://issues.civicrm.org/jira/browse/CRM-21445)