### PR TITLE
CRM-21624 - Not able to save contribution if total and net amounts ar…

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -883,7 +883,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
 
     if (!empty($fields['total_amount']) && (!empty($fields['net_amount']) || !empty($fields['fee_amount']))) {
       $sum = CRM_Utils_Rule::cleanMoney($fields['net_amount']) + CRM_Utils_Rule::cleanMoney($fields['fee_amount']);
-      if (CRM_Utils_Rule::cleanMoney($fields['total_amount']) != $sum) {
+      if (round(CRM_Utils_Rule::cleanMoney($fields['total_amount'])) != round($sum)) {
         $errors['total_amount'] = ts('The sum of fee amount and net amount must be equal to total amount');
       }
     }


### PR DESCRIPTION
…e in decimal

Overview
----------------------------------------
Steps to replicate:
------------------------
1. Create a contribution with total amount = 1,022.22 and fee amount = 22.79
2. Click save and you get the form rule error :
The sum of fee amount and net amount must be equal to total amount

Before
----------------------------------------
![fee](https://user-images.githubusercontent.com/3455173/34552000-8e5d9c26-f144-11e7-87ce-e68cbac56998.png)

After
----------------------------------------
![save](https://user-images.githubusercontent.com/3455173/34552019-cb3fd9e2-f144-11e7-8ac4-fd1d365e782d.png)
