### PR TITLE
CRM-21623 - Smart Group Relative Date not saving for some fields in A…

### DIFF
--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -92,6 +92,17 @@ class CRM_Contact_BAO_SavedSearch extends CRM_Contact_DAO_SavedSearch {
    *   the values of the posted saved search used as default values in various Search Form
    */
   public static function getFormValues($id) {
+    $specialDateFields = array(
+      'event_start_date_low' => 'event_date_low',
+      'event_end_date_high' => 'event_date_high',
+      'participant_register_date_low' => 'participant_date_low',
+      'participant_register_date_high' => 'participant_date_high',
+      'case_from_start_date_low' => 'case_from_date_low',
+      'case_from_start_date_high' => 'case_from_date_high',
+      'case_to_end_date_low' => 'case_to_date_low',
+      'case_to_end_date_high' => 'case_to_date_high',
+    );
+
     $fv = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_SavedSearch', $id, 'form_values');
     $result = NULL;
     if ($fv) {
@@ -118,6 +129,11 @@ class CRM_Contact_BAO_SavedSearch extends CRM_Contact_DAO_SavedSearch {
           if (!empty($result['relative_dates']) && array_key_exists($entityName, $result['relative_dates'])) {
             $result[$id] = NULL;
             $result["{$entityName}_date_relative"] = $result['relative_dates'][$entityName];
+          }
+          elseif (!empty($specialDateFields[$id])) {
+            $entityName = strstr($specialDateFields[$id], '_date', TRUE);
+            $result[$id] = NULL;
+            $result["{$entityName}_relative"] = $result['relative_dates'][$entityName];
           }
           else {
             $result[$id] = $value;
@@ -411,9 +427,13 @@ LEFT JOIN civicrm_email ON (contact_a.id = civicrm_email.contact_id AND civicrm_
    */
   public static function saveRelativeDates(&$queryParams, $formValues) {
     $relativeDates = array('relative_dates' => array());
+    $specialDateFields = array('event_relative', 'case_from_relative', 'case_to_relative', 'participant_relative');
     foreach ($formValues as $id => $value) {
-      if (preg_match('/_date_relative$/', $id) && !empty($value)) {
+      if ((preg_match('/_date_relative$/', $id) || in_array($id, $specialDateFields)) && !empty($value)) {
         $entityName = strstr($id, '_date', TRUE);
+        if (empty($entityName)) {
+          $entityName = strstr($id, '_relative', TRUE);
+        }
         $relativeDates['relative_dates'][$entityName] = $value;
       }
     }

--- a/tests/phpunit/CRM/Contact/BAO/SavedSearchTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/SavedSearchTest.php
@@ -97,6 +97,36 @@ class CRM_Contact_BAO_SavedSearchTest extends CiviUnitTestCase {
     }
   }
 
+  /**
+   * Test if relative dates are stored correctly
+   * in civicrm_saved_search table.
+   */
+  public function testRelativeDateValues() {
+    $savedSearch = new CRM_Contact_BAO_SavedSearch();
+    $formValues = array(
+      'operator' => 'AND',
+      'event_relative' => 'this.month',
+      'participant_relative' => 'today',
+      'contribution_date_relative' => 'this.week',
+      'participant_test' => 0,
+      'title' => 'testsmart',
+      'radio_ts' => 'ts_all',
+    );
+    $queryParams = array();
+    CRM_Contact_BAO_SavedSearch::saveRelativeDates($queryParams, $formValues);
+    CRM_Contact_BAO_SavedSearch::saveSkippedElement($queryParams, $formValues);
+    $savedSearch->form_values = serialize($queryParams);
+    $savedSearch->save();
+
+    $result = CRM_Contact_BAO_SavedSearch::getFormValues(CRM_Core_DAO::singleValueQuery('SELECT LAST_INSERT_ID()'));
+    $expectedResult = array(
+      'event' => 'this.month',
+      'participant' => 'today',
+      'contribution' => 'this.week',
+    );
+    $this->checkArrayEquals($result['relative_dates'], $expectedResult);
+  }
+
 
   /**
    * Get variants of the fields we want to test.


### PR DESCRIPTION
…dvance Search

Overview
----------------------------------------
Fix Smart groups to save relative dates correctly.

Before
----------------------------------------
Some relative_date fields on the Advance search are not saved correctly in `civicrm_saved_search` table. Event Pane is broken after returning from the smart group form.

![image](https://user-images.githubusercontent.com/5929648/34560702-e97f24e4-f16c-11e7-962b-77295944e50c.png)

After
----------------------------------------
works fine. Event dates correctly stored as form_values in `civicrm_saved_search` table.

Comments
----------------------------------------
Added unit test.

---

 * [CRM-21623: Smart Group Relative Date not saving for some fields in Advance Search](https://issues.civicrm.org/jira/browse/CRM-21623)