### PR TITLE
CRM-21626 use right mailing object based on template type

### DIFF
--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -98,9 +98,10 @@ class CRM_Mailing_BAO_MailingJob extends CRM_Mailing_DAO_MailingJob {
 
     if (!empty($testParams)) {
       $query = "
-      SELECT *
-        FROM $jobTable
-       WHERE id = {$testParams['job_id']}";
+      SELECT j.*, m.template_type
+        FROM $jobTable j,
+        $mailingTable m
+       WHERE m.id = j.mailing_id AND j.id = {$testParams['job_id']}";
       $job->query($query);
     }
     else {
@@ -116,7 +117,7 @@ class CRM_Mailing_BAO_MailingJob extends CRM_Mailing_DAO_MailingJob {
       // Select the first child job that is scheduled
       // CRM-6835
       $query = "
-      SELECT   j.*
+      SELECT   j.*, m.template_type
         FROM   $jobTable     j,
            $mailingTable m
        WHERE   m.id = j.mailing_id AND m.domain_id = {$domainID}
@@ -194,7 +195,8 @@ class CRM_Mailing_BAO_MailingJob extends CRM_Mailing_DAO_MailingJob {
       }
 
       // Compose and deliver each child job
-      if (\CRM_Utils_Constant::value('CIVICRM_FLEXMAILER_HACK_DELIVER')) {
+      // send email through right channel, CIVICRM_FLEXMAILER_HACK_DELIVER always present when flexmailer extension is enabled.
+      if ($job->template_type !== 'traditional' && \CRM_Utils_Constant::value('CIVICRM_FLEXMAILER_HACK_DELIVER')) {
         $isComplete = Civi\Core\Resolver::singleton()->call(CIVICRM_FLEXMAILER_HACK_DELIVER, array($job, $mailer, $testParams));
       }
       else {


### PR DESCRIPTION
When FLEX MAILER extension enabled along with mosaico , we have option to choose traditional or new mosaico mailing.

But while sending email using traditional, mailing job uses Flex mailer functionality. instead it should use default civicrm functionality.

---

 * [CRM-21626: use right mailing object based on template type](https://issues.civicrm.org/jira/browse/CRM-21626)