### PR TITLE
CRM-21629 System Check: Set User Agent to security filters accept check

### DIFF
--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -898,6 +898,11 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
     if (CRM_Core_Config::singleton()->userFramework == 'UnitTests') {
       return $messages;
     }
+    // CRM-21629 Set User Agent to avoid being blocked by filters
+    stream_context_set_default(array(
+      'http' => array('user_agent' => 'CiviCRM'),
+    ));
+
     // Does arrow.png exist where we expect it?
     $arrowUrl = CRM_Core_Config::singleton()->userFrameworkResourceURL . 'packages/jquery/css/images/arrow.png';
     $headers = get_headers($arrowUrl);


### PR DESCRIPTION
Overview
----------------------------------------

Set User Agent for the code that performs System Check of Resource URL. Security filters often block clients with blank User Agents. This code set the User Agent to CiviCRM. 

Before
----------------------------------------
Current checks show up as user agent "-". Which results in a blocked connection on some sites, and results in a false positive check.  

After
----------------------------------------
The check goes through as it should if filters are in place.


 * [CRM-21629: Resource URL status check gets false positive when blank user agents are blocked](https://issues.civicrm.org/jira/browse/CRM-21629)