### PR TITLE
CRM-21627: Can't enable multilanguage support in Drupal

### DIFF
--- a/CRM/Admin/Form/Setting/Localization.php
+++ b/CRM/Admin/Form/Setting/Localization.php
@@ -205,6 +205,10 @@ class CRM_Admin_Form_Setting_Localization extends CRM_Admin_Form_Setting {
     // unset currencyLimit so we dont store there
     unset($values['currencyLimit']);
 
+    // CRM-21627: set default language setting before making multilingual changes,
+    //  otherwise it will lead to error due to blank locale fetched from this setting
+    Civi::settings()->set('lcMessages', CRM_Utils_Array::value('lcMessages', $values));
+
     // make the site multi-lang if requested
     if (!empty($values['makeMultilingual'])) {
       CRM_Core_I18n_Schema::makeMultilingual($values['lcMessages']);
@@ -230,10 +234,15 @@ class CRM_Admin_Form_Setting_Localization extends CRM_Admin_Form_Setting {
     $return = (bool) (CRM_Utils_Array::value('makeMultilingual', $values) or CRM_Utils_Array::value('addLanguage', $values));
 
     $filteredValues = $values;
-    unset($filteredValues['makeMultilingual']);
-    unset($filteredValues['makeSinglelingual']);
-    unset($filteredValues['addLanguage']);
-    unset($filteredValues['languageLimit']);
+    foreach (array(
+      'makeMultilingual',
+      'makeSinglelingual',
+      'addLanguage',
+      'languageLimit',
+      'lcMessages',
+    ) as $ignoreSetting) {
+      unset($filteredValues[$ignoreSetting]);
+    }
 
     Civi::settings()->set('languageLimit', CRM_Utils_Array::value('languageLimit', $values));
 


### PR DESCRIPTION
Overview
----------------------------------------
On a clean Drupal site (version 7.56 or 8.4.3), using CiviCRM 4.7.x (I have tested it with 4.7.27, 4.7.28 on both Drupal versions and 4.7.29 only with Drupal 7) is not possible to enable multilanguage support on CiviCRM (database error).

Before
----------------------------------------
Steps to reproduce on Drupal 7:

Install Drupal site (Drupal 7.56)
Install CiviCRM 4.7.29
Go to Settings - Localization
Check Enable Multiple Languages
Click Save

Steps to reproduce on Drupal 8:
Install Drupal site (Drupal 8.4.3)
Install CiviCRM 4.7.28 I followed this directions (manual process)
Go to Settings - Localization
Check Enable Multiple Languages
Click Save

No matter the Drupal version, you will always get a Database error.

After
----------------------------------------
Fixes the database error in both Drupal 7 and 8

---

 * [CRM-21627: Can't enable multilanguage support in Drupal ](https://issues.civicrm.org/jira/browse/CRM-21627)