### PR TITLE
CRM-21627: makeMultilingual: update dbLocale to avoid fatal if lcMessages was not set

### DIFF
--- a/CRM/Core/I18n/Schema.php
+++ b/CRM/Core/I18n/Schema.php
@@ -107,6 +107,9 @@ class CRM_Core_I18n_Schema {
     // update civicrm_domain.locales
     $domain->locales = $locale;
     $domain->save();
+
+    // CRM-21627 Updates the $dbLocale
+    CRM_Core_BAO_ConfigSetting::applyLocale(Civi::settings($domain->id), $domain->locales);
   }
 
   /**

--- a/tests/phpunit/CRM/Logging/LoggingTest.php
+++ b/tests/phpunit/CRM/Logging/LoggingTest.php
@@ -41,13 +41,13 @@ class CRM_Logging_LoggingTest extends CiviUnitTestCase {
     $value = CRM_Core_DAO::singleValueQuery("SELECT id FROM log_civicrm_contact LIMIT 1", array(), FALSE, FALSE);
     $this->assertNotNull($value, 'Logging not enabled successfully');
     $logging->disableLogging();
-    CRM_Core_DAO::executeQuery("ALTER TABLE `civicrm_option_value` ADD COLUMN `logging_test` INT DEFAULT NULL", array(), FALSE, NULL, FALSE, TRUE);
+    CRM_Core_DAO::executeQuery("ALTER TABLE `civicrm_option_value` ADD COLUMN `logging_test` INT DEFAULT NULL", array(), FALSE, NULL, FALSE, FALSE);
     CRM_Core_I18n_Schema::rebuildMultilingualSchema(array('en_US'));
     $logging->enableLogging();
     $query = CRM_Core_DAO::executeQuery("SHOW CREATE TABLE `log_civicrm_option_value`", array(), TRUE, NULL, FALSE, FALSE);
     $query->fetch();
     $create = explode("\n", $query->Create_Table);
-    CRM_Core_DAO::executeQuery("ALTER TABLE `civicrm_option_value` DROP COLUMN `logging_test`", array(), FALSE, NULL, FALSE, TRUE);
+    CRM_Core_DAO::executeQuery("ALTER TABLE `civicrm_option_value` DROP COLUMN `logging_test`", array(), FALSE, NULL, FALSE, FALSE);
     $this->assertTrue(in_array("  `logging_test` int(11) DEFAULT NULL", $create));
     $logging->disableLogging();
   }


### PR DESCRIPTION
Overview
----------------------------------------

Alternative PR to #11489. Fixes enabling of multilingual on 4.7.x.

Before
----------------------------------------

(copied from #11489)

- Install Drupal site (Drupal 7.56)
- Install CiviCRM 4.7.29
- Go to Settings - Localization
- Check Enable Multiple Languages
- Click Save

Result: Fatal error.

NB: this only happens if we enable multi-lingual right away. It does not fatal if we first save the settings form, then enable multi-lingual.

After
----------------------------------------

Works as expected.

Technical Details
----------------------------------------

`makeMultilingual` should call `applyLocale` so that the `dbLocale` is set correctly. Otherwise we get "DB error: no such field" because CiviCRM looks for `civicrm_option_value.label`, but it should instead be looking for `civicrm_option_value.label_xx_XX` (where  `xx_XX`  is the default locale, such as `en_US`).

Comments
----------------------------------------

I tested:

* Enabling multi-lingual
* Reverting back to unilingual
* Re-enabling multi-lingual
* Adding a second language (this requires `civicrm-l10n.tar.gz` to be installed).

---

 * [CRM-21627: Can't enable multilanguage support in Drupal ](https://issues.civicrm.org/jira/browse/CRM-21627)