### PR TITLE
CRM-20685: Fix a bug on repeatTransaction in specific circumstance and his unitTest on ContributionRecurTest, cal…

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -897,7 +897,8 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
    * @return array
    */
   public static function calculateRecurLineItems($recurId, $total_amount, $financial_type_id) {
-    $originalContribution = civicrm_api3('Contribution', 'getsingle', array('contribution_recur_id' => $recurId,
+    $originalContribution = civicrm_api3('Contribution', 'getsingle', array(
+    'contribution_recur_id' => $recurId,
     'contribution_test' => '',
     'return' => ['id', 'financial_type_id'],
     ));

--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -897,7 +897,10 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
    * @return array
    */
   public static function calculateRecurLineItems($recurId, $total_amount, $financial_type_id) {
-    $originalContribution = civicrm_api3('Contribution', 'getsingle', array('contribution_recur_id' => $recurId));
+    $originalContribution = civicrm_api3('Contribution', 'getsingle', array('contribution_recur_id' => $recurId,
+    'contribution_test' => '',
+    'return' => ['id', 'financial_type_id'],
+    ));
     $lineItems = CRM_Price_BAO_LineItem::getLineItemsByContributionID($originalContribution['id']);
     $lineSets = array();
     if (count($lineItems) == 1) {

--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -900,6 +900,7 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
     $originalContribution = civicrm_api3('Contribution', 'getsingle', array(
     'contribution_recur_id' => $recurId,
     'contribution_test' => '',
+    'options' => ['limit' => 1],
     'return' => ['id', 'financial_type_id'],
     ));
     $lineItems = CRM_Price_BAO_LineItem::getLineItemsByContributionID($originalContribution['id']);

--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -897,11 +897,15 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
    * @return array
    */
   public static function calculateRecurLineItems($recurId, $total_amount, $financial_type_id) {
-    $originalContributionID = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $recurId, 'id', 'contribution_recur_id');
-    $lineItems = CRM_Price_BAO_LineItem::getLineItemsByContributionID($originalContributionID);
+    $originalContribution = civicrm_api3('Contribution', 'getsingle', array('contribution_recur_id' => $recurId));
+    $lineItems = CRM_Price_BAO_LineItem::getLineItemsByContributionID($originalContribution['id']);
     $lineSets = array();
     if (count($lineItems) == 1) {
       foreach ($lineItems as $index => $lineItem) {
+        if ($lineItem['financial_type_id'] != $originalContribution['financial_type_id']) {
+          // CRM-20685, Repeattransaction produces incorrect Financial Type ID (in specific circumstance) - if number of lineItems = 1, So this conditional will set the financial_type_id as the original if line_item and contribution comes with different data.
+          $financial_type_id = $lineItem['financial_type_id'];
+        }
         if ($financial_type_id) {
           // CRM-17718 allow for possibility of changed financial type ID having been set prior to calling this.
           $lineItem['financial_type_id'] = $financial_type_id;


### PR DESCRIPTION

Overview
----------------------------------------
When a contribution has been created such that the (single) line item has a different financial type than the contribution the contribution financial type is imposed on the line item in subsequent transactions.

*Repeattransaction produces incorrect Financial Type ID (in specific circumstance) - if number of lineItems = 1*

Before
----------------------------------------
Bug
Status: Reopened
Priority: Critical
Affects Version/s:
4.7.20

After
----------------------------------------
No bug now!

Comments
----------------------------------------
The testRepeatTransactionUpdatedFinancialTypeAndNotEquals update the line_item.financial_type_id to reproduce the behaviour.


