### PR TITLE
CRM-21635 - Expose contact custom data on contribution summary report

### DIFF
--- a/CRM/Report/Form/Contribute/Summary.php
+++ b/CRM/Report/Form/Contribute/Summary.php
@@ -38,7 +38,7 @@ class CRM_Report_Form_Contribute_Summary extends CRM_Report_Form {
     'barChart' => 'Bar Chart',
     'pieChart' => 'Pie Chart',
   );
-  protected $_customGroupExtends = array('Contribution');
+  protected $_customGroupExtends = array('Contribution', 'Contact', 'Individual');
   protected $_customGroupGroupBy = TRUE;
 
   public $_drilldownReport = array('contribute/detail' => 'Link to Detail Report');


### PR DESCRIPTION
Overview
----------------------------------------
Expose contact custom data on contribution summary report

Before
----------------------------------------
![summary_before](https://user-images.githubusercontent.com/3455173/34712667-a1e9bd7a-f549-11e7-89d8-c24e2be99ed9.png)


After
----------------------------------------
![summary_after](https://user-images.githubusercontent.com/3455173/34712672-a7986bea-f549-11e7-90a1-5d07111bec24.png)

---

 * [CRM-21635: Expose contact custom data on contribution summary report](https://issues.civicrm.org/jira/browse/CRM-21635)