### PR TITLE
CRM-21639 NOINDEX Event Info page when event is non-public or in the past

### DIFF
--- a/CRM/Contact/Form/Task/Map/Event.php
+++ b/CRM/Contact/Form/Task/Map/Event.php
@@ -50,6 +50,10 @@ class CRM_Contact_Form_Task_Map_Event extends CRM_Contact_Form_Task_Map {
     self::createMapXML($ids, $lid, $this, TRUE, $type);
     $this->assign('single', FALSE);
     $this->assign('skipLocationType', TRUE);
+
+    if ($is_public == 0) {
+      CRM_Utils_System::addHTMLHead('<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">');
+    }
   }
 
   /**

--- a/CRM/Event/Page/EventInfo.php
+++ b/CRM/Event/Page/EventInfo.php
@@ -80,6 +80,10 @@ class CRM_Event_Page_EventInfo extends CRM_Core_Page {
       return CRM_Utils_System::permissionDenied();
     }
 
+    if (!$values['event']['is_public']) {
+      CRM_Utils_System::addHTMLHead('<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">');
+    }
+
     if (!empty($values['event']['is_template'])) {
       // form is an Event Template
       CRM_Core_Error::fatal(ts('The page you requested is currently unavailable.'));


### PR DESCRIPTION
Overview
----------------------------------------
This patch makes sure the Event Info page gets the NOINDEX metatag in order for Search Engines to NOT index the page when the event is ~either in the past or~ non-public.

Before
----------------------------------------
Even when an event was ~closed (past event) or~ non-public it would still be indexed by google and other search engines.

After
----------------------------------------
With this patch the Event Info and the corresponding Map page page gets the NOINDEX,NOFOLLOW metatag

Technical Details
----------------------------------------
The NOINDEX,NOFOLLOW gets inserted into head when either the event is:
1. non-public
~2. past events~

Comments
----------------------------------------
This patch will not remove old event page info listings from google, but a ligitimate site owner can remove them using the Google Search Console. With the NOINDEX tag in place they will not be reindexed.

---

 * [CRM-21639: Event pages should be set to NoIndex when event is not public or closed](https://issues.civicrm.org/jira/browse/CRM-21639)