### PR TITLE
CRM-21639 NOINDEX on print preview pages

### DIFF
--- a/templates/CRM/common/print.tpl
+++ b/templates/CRM/common/print.tpl
@@ -30,6 +30,7 @@
 <head>
   <title>{if $pageTitle}{$pageTitle|strip_tags}{else}{ts}Printer-Friendly View{/ts} | {ts}CiviCRM{/ts}{/if}</title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta name="ROBOTS" content="NOINDEX, NOFOLLOW">
   {crmRegion name='html-header' allowCmsOverride=0}{/crmRegion}
   <style type="text/css" media="print">@import url({$config->resourceBase}css/print.css);</style>
 </head>


### PR DESCRIPTION
Overview
----------------------------------------
CiviCRM Print Preview pages should not be indexed by search engines 

Before
----------------------------------------
Print preview pages (snippets) are indexed by google and cause confusion and possible worse than possible rankings.

After
----------------------------------------
Print Preview pages do not get indexed by compliant search engines

Technical Details
----------------------------------------
The PR adds META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW" to the head of the Print Preview

Comments
----------------------------------------
This patch will not remove old print preview pages from google, but a legitimate site owner can remove them using the Google Search Console. With the NOINDEX tag in place they will not be re-indexed.

---

 * [CRM-21639: Event pages should be set to NoIndex when event is not public or in the past](https://issues.civicrm.org/jira/browse/CRM-21639)