### PR TITLE
CRM-21647 - Fatal error on deleting any contribution record

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -450,6 +450,23 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
    * Build the form object.
    */
   public function buildQuickForm() {
+    if ($this->_action & CRM_Core_Action::DELETE) {
+      $this->addButtons(array(
+          array(
+            'type' => 'next',
+            'name' => ts('Delete'),
+            'spacing' => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
+            'isDefault' => TRUE,
+          ),
+          array(
+            'type' => 'cancel',
+            'name' => ts('Cancel'),
+          ),
+        )
+      );
+      return;
+    }
+
     // FIXME: This probably needs to be done in preprocess
     if (CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus()
       && $this->_action & CRM_Core_Action::UPDATE
@@ -581,23 +598,6 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     }
 
     $this->applyFilter('__ALL__', 'trim');
-
-    if ($this->_action & CRM_Core_Action::DELETE) {
-      $this->addButtons(array(
-          array(
-            'type' => 'next',
-            'name' => ts('Delete'),
-            'spacing' => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
-            'isDefault' => TRUE,
-          ),
-          array(
-            'type' => 'cancel',
-            'name' => ts('Cancel'),
-          ),
-        )
-      );
-      return;
-    }
 
     //need to assign custom data type and subtype to the template
     $this->assign('customDataType', 'Contribution');


### PR DESCRIPTION
Overview
----------------------------------------
Fix fatal error on delete contribution form.

Before
----------------------------------------
Fatal error is displayed on `Delete Contribution` form.

![image](https://user-images.githubusercontent.com/5929648/34767302-c09e558a-f61d-11e7-9603-0cee6a04020a.png)


After
----------------------------------------
Fixed. User is able to delete any contribution record.

Technical Details
----------------------------------------
It seems it was rendering the whole form where it needs to only display the delete button. This change forces the buildForm() function to return much before in case of a delete action.

Comments
----------------------------------------
The change of addField() was done recently in https://github.com/civicrm/civicrm-core/pull/10841

---

 * [CRM-21647: Fatal error on deleting any contribution record](https://issues.civicrm.org/jira/browse/CRM-21647)