### PR TITLE
CRM-17352 - Use Backbone.noConflict

### DIFF
--- a/CRM/UF/Page/ProfileEditor.php
+++ b/CRM/UF/Page/ProfileEditor.php
@@ -61,6 +61,7 @@ class CRM_UF_Page_ProfileEditor extends CRM_Core_Page {
       ->addScriptFile('civicrm', 'packages/backbone-forms/distribution/adapters/backbone.bootstrap-modal.min.js', 140, 'html-header', FALSE)
       ->addScriptFile('civicrm', 'packages/backbone-forms/distribution/editors/list.min.js', 140, 'html-header', FALSE)
       ->addStyleFile('civicrm', 'packages/backbone-forms/distribution/templates/default.css', 140, 'html-header')
+      ->addScript('CRM.BB = Backbone.noConflict();', 300, 'html-header')
       ->addScriptFile('civicrm', 'packages/jquery/plugins/jstree/jquery.jstree.js', 0, 'html-header', FALSE)
       ->addStyleFile('civicrm', 'packages/jquery/plugins/jstree/themes/default/style.css', 0, 'html-header')
       ->addStyleFile('civicrm', 'css/crm.designer.css', 140, 'html-header')

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -210,52 +210,6 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
   /**
    * @inheritDoc
    */
-  public function addScriptUrl($url, $region) {
-    static $weight = 0;
-
-    switch ($region) {
-      case 'html-header':
-        break;
-
-      default:
-        return FALSE;
-    }
-
-    $script = array(
-      '#tag' => 'script',
-      '#attributes' => array(
-        'src' => $url,
-      ),
-      '#weight' => $weight,
-    );
-    $weight++;
-    \Drupal::service('civicrm.page_state')->addJS($script);
-    return TRUE;
-  }
-
-  /**
-   * @inheritDoc
-   */
-  public function addScript($code, $region) {
-    switch ($region) {
-      case 'html-header':
-        break;
-
-      default:
-        return FALSE;
-    }
-
-    $script = array(
-      '#tag' => 'script',
-      '#value' => $code,
-    );
-    \Drupal::service('civicrm.page_state')->addJS($script);
-    return TRUE;
-  }
-
-  /**
-   * @inheritDoc
-   */
   public function addStyleUrl($url, $region) {
     if ($region != 'html-header') {
       return FALSE;

--- a/css/crm.designer.css
+++ b/css/crm.designer.css
@@ -209,6 +209,11 @@ button#crm-designer-add-custom-set {
   margin: 0 2em 0 0;
 }
 
+/* Hack for Drupal 8 for some reason was moving it around strange */
+.crm-designer-dialog .ui-resizable {
+  position: absolute;
+}
+
 .crm-designer-dialog .disabled .description {
   display: none;
 }

--- a/js/crm.backbone.js
+++ b/js/crm.backbone.js
@@ -1,4 +1,4 @@
-(function($, _) {
+(function($, _, Backbone) {
   if (!CRM.Backbone) CRM.Backbone = {};
 
   /**
@@ -569,4 +569,4 @@
       model.trigger('error', model, resp, options);
     };
   };
-})(CRM.$, CRM._);
+})(CRM.$, CRM._, CRM.BB);

--- a/js/crm.designerapp.js
+++ b/js/crm.designerapp.js
@@ -1,4 +1,4 @@
-(function ($, _) {
+(function ($, _, Backbone) {
   $(function () {
     /**
      * FIXME we depend on this being a global singleton, mainly to facilitate vents
@@ -30,4 +30,4 @@
       });
     };
   });
-})(CRM.$, CRM._);
+})(CRM.$, CRM._, CRM.BB);

--- a/js/view/crm.designer.js
+++ b/js/view/crm.designer.js
@@ -1,4 +1,4 @@
-(function($, _) {
+(function($, _, Backbone) {
   if (!CRM.Designer) CRM.Designer = {};
 
   /**
@@ -875,4 +875,4 @@
     }
   });
 
-})(CRM.$, CRM._);
+})(CRM.$, CRM._, CRM.BB);

--- a/js/view/crm.profile-selector.js
+++ b/js/view/crm.profile-selector.js
@@ -1,4 +1,4 @@
-(function($, _) {
+(function($, _, Backbone) {
   if (!CRM.ProfileSelector) CRM.ProfileSelector = {};
 
   CRM.ProfileSelector.Option = Backbone.Marionette.ItemView.extend({
@@ -185,4 +185,4 @@
       view.render();
     }
   });
-})(CRM.$, CRM._);
+})(CRM.$, CRM._, CRM.BB);


### PR DESCRIPTION
Overview
------
Fixes JS errors caused by the presence of other versions of Backbone (e.g. in Drupal 8 or certain WP extensions).

Before
-----
Profiles cannot be edited on the "Manage Event" screen etc. in D8 or certain WP sites.

After
------
Profile editing works normally regardless of other js plugins present.

Notes
----
This requires https://github.com/civicrm/civicrm-packages/pull/198 - use both PRs when testing.

* [CRM-17352: Backbone no-conflict](https://issues.civicrm.org/jira/browse/CRM-17352)