### PR TITLE
CRM-21651 - Activity_Email/SMS_Add - Fix loading failed when no conta…

### DIFF
--- a/CRM/Contact/Page/AJAX.php
+++ b/CRM/Contact/Page/AJAX.php
@@ -388,6 +388,7 @@ class CRM_Contact_Page_AJAX {
       }
 
       if ($queryString) {
+        $result = array();
         $offset = CRM_Utils_Array::value('offset', $_GET, 0);
         $rowCount = Civi::settings()->get('search_autocomplete_count');
 
@@ -450,9 +451,7 @@ LIMIT {$offset}, {$rowCount}
             );
           }
         }
-        if ($result) {
-          CRM_Utils_JSON::output($result);
-        }
+        CRM_Utils_JSON::output($result);
       }
     }
     CRM_Utils_System::civiExit();
@@ -483,6 +482,7 @@ LIMIT {$offset}, {$rowCount}
     }
 
     if ($queryString) {
+      $result = array();
       $offset = CRM_Utils_Array::value('offset', $_GET, 0);
       $rowCount = CRM_Utils_Array::value('rowcount', $_GET, 20);
 
@@ -519,9 +519,6 @@ LIMIT {$offset}, {$rowCount}
           'id' => (CRM_Utils_Array::value('id', $_GET)) ? "{$dao->id}::{$dao->phone}" : '"' . $dao->name . '" <' . $dao->phone . '>',
         );
       }
-    }
-
-    if ($result) {
       CRM_Utils_JSON::output($result);
     }
     CRM_Utils_System::civiExit();


### PR DESCRIPTION
…ct is found

Overview
----------------------------------------
There is no json output when no contact is found.

Before
----------------------------------------
![before_email_loading_failed](https://user-images.githubusercontent.com/19712240/34826807-5ddadcc8-f6d8-11e7-94ac-2edd219f97b8.png)
![before_sms_loading_failed](https://user-images.githubusercontent.com/19712240/34826808-5df707b8-f6d8-11e7-80c3-84bb998be9a9.png)

After
----------------------------------------
![after_email_no_results](https://user-images.githubusercontent.com/19712240/34826834-6b289f64-f6d8-11e7-9802-b034cb611b26.png)

Comments
----------------------------------------
It still seems odd that there is a path where those function will not echo some json results. I left this untouched as I don't know where they are used with a `cid` parameter in the `$_GET` request.
