### PR TITLE
CRM-21225 Changes to UI to implement the frontend_title field to allo…

### DIFF
--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -484,6 +484,7 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
       'name' => $name,
       'groupTitle' => $group->title,
       'groupName' => $group->name,
+      'groupDisplayTitle' => (!empty($group->frontend_title)) ? $group->frontend_title : $group->title,
       'groupHelpPre' => empty($group->help_pre) ? '' : $group->help_pre,
       'groupHelpPost' => empty($group->help_post) ? '' : $group->help_post,
       'title' => $title,
@@ -1673,9 +1674,13 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
   public static function getModuleUFGroup($moduleName = NULL, $count = 0, $skipPermission = TRUE, $op = CRM_Core_Permission::VIEW, $returnFields = NULL) {
     $selectFields = array('id', 'title', 'created_id', 'is_active', 'is_reserved', 'group_type');
 
-    if (!CRM_Core_Config::isUpgradeMode()) {
+    if (CRM_Core_DAO::checkFieldExists('civicrm_uf_group', 'description')) {
       // CRM-13555, since description field was added later (4.4), and to avoid any problems with upgrade
       $selectFields[] = 'description';
+    }
+
+    if (CRM_Core_DAO::checkFieldExists('civicrm_uf_group', 'frontend_title')) {
+      $selectFields[] = 'frontend_title';
     }
 
     if (!empty($returnFields)) {

--- a/CRM/UF/Form/Group.php
+++ b/CRM/UF/Form/Group.php
@@ -136,6 +136,7 @@ class CRM_UF_Form_Group extends CRM_Core_Form {
 
     // title
     $this->add('text', 'title', ts('Profile Name'), CRM_Core_DAO::getAttribute('CRM_Core_DAO_UFGroup', 'title'), TRUE);
+    $this->add('text', 'frontend_title', ts('Public Title'), CRM_Core_DAO::getAttribute('CRM_Core_DAO_UFGroup', 'frontend_title'));
     $this->add('textarea', 'description', ts('Description'), CRM_Core_DAO::getAttribute('CRM_Core_DAO_UFGroup', 'description'));
 
     //add checkboxes

--- a/CRM/UF/Page/Group.php
+++ b/CRM/UF/Page/Group.php
@@ -326,6 +326,7 @@ class CRM_UF_Page_Group extends CRM_Core_Page {
       $ufGroup[$id] = array();
       $ufGroup[$id]['id'] = $id;
       $ufGroup[$id]['title'] = $value['title'];
+      $ufGroup[$id]['frontend_title'] = $value['frontend_title'];
       $ufGroup[$id]['created_id'] = $value['created_id'];
       $ufGroup[$id]['created_by'] = CRM_Contact_BAO_Contact::displayName($value['created_id']);
       $ufGroup[$id]['description'] = $value['description'];

--- a/js/model/crm.uf.js
+++ b/js/model/crm.uf.js
@@ -491,6 +491,13 @@
         editorAttrs: {maxlength: 64},
         validators: ['required']
       },
+      'frontend_title': {
+        title: ts('Public Title'),
+        help: ts(''),
+        type: 'Text',
+        editorAttrs: {maxlength: 64},
+        validators: []
+      },
       'group_type': {
         // For a description of group_type, see CRM_Core_BAO_UFGroup::updateGroupTypes
         // title: ts(''),

--- a/js/view/crm.designer.js
+++ b/js/view/crm.designer.js
@@ -866,7 +866,7 @@
     initialize: function() {
       this.form = new Backbone.Form({
         model: this.model,
-        fields: ['title', 'help_pre', 'help_post', 'is_active']
+        fields: ['title', 'frontend_title', 'help_pre', 'help_post', 'is_active']
       });
       this.form.on('change', this.form.commit, this.form);
     },

--- a/templates/CRM/UF/Form/Fields.tpl
+++ b/templates/CRM/UF/Form/Fields.tpl
@@ -21,7 +21,7 @@
     {/if}
 
     {if $mode ne 8 && $action ne 1028 && $action ne 4 && !$hideFieldset}
-      <fieldset class="crm-profile crm-profile-id-{$field.group_id} crm-profile-name-{$field.groupName}"><legend>{$field.groupTitle}</legend>
+      <fieldset class="crm-profile crm-profile-id-{$field.group_id} crm-profile-name-{$field.groupName}"><legend>{$field.groupDisplayTitle}</legend>
     {/if}
 
     {if ($form.formName eq 'Confirm' OR $form.formName eq 'ThankYou') AND $prefix neq 'honor'}

--- a/templates/CRM/UF/Form/Group.tpl
+++ b/templates/CRM/UF/Form/Group.tpl
@@ -50,6 +50,10 @@
             <td class="label">{$form.title.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_uf_group' field='title' id=$gid}{/if}</td>
             <td class="html-adjust">{$form.title.html}</td>
         </tr>
+        <tr class="crm-uf_group-form-block-frontend_title">
+            <td class="label">{$form.frontend_title.label}</td>
+            <td class="html-adjust">{$form.frontend_title.html}</td>
+        </tr>
         <tr class="crm-uf_group-form-block-description">
             <td class="label">{$form.description.label} {help id='id-description' file="CRM/UF/Form/Group.hlp"}</td>
             <td class="html-adjust">{$form.description.html}</td>

--- a/templates/CRM/UF/Page/Group.tpl
+++ b/templates/CRM/UF/Page/Group.tpl
@@ -73,6 +73,7 @@
              <thead>
               <tr>
                 <th id="sortable">{ts}Profile Title{/ts}</th>
+                <th>{ts}Public Title{/ts}</th>
                 <th>{ts}Created By{/ts}</th>
                 <th>{ts}Description{/ts}</th>
                 <th>{ts}Type{/ts}</th>
@@ -86,6 +87,7 @@
             {if !$row.is_reserved }
               <tr id="UFGroup-{$row.id}" data-action="setvalue" class="crm-entity {$row.class}{if NOT $row.is_active} disabled{/if}">
                 <td class="crmf-title crm-editable">{$row.title}</td>
+                <td class="crmf-frontend_title crm-editable">{$row.frontend_title}</td>
                 <td>
                   {if $row.created_id && $row.created_by}
                     <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.created_id`"}">{ts}{$row.created_by}{/ts}</a>
@@ -116,6 +118,7 @@
              <thead>
               <tr>
                 <th id="sortable">{ts}Profile Title{/ts}</th>
+                <th>{ts}Public Title{/ts}</th>
                 <th>{ts}Created By{/ts}</th>
                 <th>{ts}Description{/ts}</th>
                 <th>{ts}Type{/ts}</th>
@@ -129,6 +132,7 @@
             {if $row.is_reserved}
               <tr id="UFGroup-{$row.id}" class="crm-entity {$row.class}{if NOT $row.is_active} disabled{/if}">
                 <td>{$row.title}</td>
+                <td>{$row.frontend_title}</td>
                 <td>
                   {if $row.created_id && $row.created_by}
                     <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.created_id`"}">{ts}{$row.created_by}{/ts}</a>


### PR DESCRIPTION
…w for overriding of the Profile title

Overview
----------------------------------------
The implements the necessary changes that are needed to allow for the overriding of the profile title for frontend pages 

Before
----------------------------------------
Previously there was only title 

After
----------------------------------------
Frontend title can be overwritten

ping @eileenmcnaughton @totten @agileware This implements the necessary changes to the admin forms. The DB upgrade PR has already been merged. Is someone able to test this. To test this Add a profile to a contribution page. Verify that the current title is outputted when nothing is set in the frontend_title field. Set a frontend title and verify on the contribution page it has changed but on the admin side the title is still used 