### PR TITLE
CRM-21652: Without using 'finally' clause

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -81,12 +81,11 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
 
     try {
       $account->save();
+      $config->inCiviCRM = FALSE;
     }
     catch (\Drupal\Core\Entity\EntityStorageException $e) {
+      $config->inCiviCRM = FALSE;
       return FALSE;
-    }
-    finally {
-      $config->inCiviCRM = TRUE;
     }
 
     // Send off any emails as required.


### PR DESCRIPTION
Follow-up to https://github.com/civicrm/civicrm-core/pull/11507 removing `finally` clause

---

 * [CRM-21652: Numerous issues with anonymous users registering accounts on Drupal 8 \(especially from contribution pages\)](https://issues.civicrm.org/jira/browse/CRM-21652)