### PR TITLE
CRM-21613:  'Manage Tag' page Improvements

### DIFF
--- a/templates/CRM/Tag/Page/Tag.tpl
+++ b/templates/CRM/Tag/Page/Tag.tpl
@@ -245,7 +245,7 @@
         }
 
         $panel
-          .append('<div class="search-box" style="display: none;"><img src="{/literal}{$config->resourceBase}i/loading.gif{literal}" alt="{/literal}{ts escape='js'}searching{/ts}{literal}" />&nbsp;{/literal}{ts escape='js'}Searching{/ts}{literal}...</div><div class="tag-tree-wrapper"><div class="tag-tree"></div><div class="tag-info"></div></div>')
+          .append('<div class="tag-tree-wrapper"><div class="tag-tree"></div><div class="tag-info"></div></div>')
           .on('change', 'input[type=color]', changeColor)
           .on('change', 'input[name=used_for]', changeUsedFor)
           .on('click', '.clear-tag-selection', clearSelection)
@@ -276,7 +276,7 @@
           .on('changed.jstree loaded.jstree', changeSelection)
           .on('move_node.jstree', moveTag)
           .on('search.jstree', function() {
-            $("div.search-box").hide();
+            $(this).unblock();
           })
           .jstree({
             core: {
@@ -311,7 +311,7 @@
                 $('.tag-tree', $panel).jstree("refresh", true, true);
               }
               else {
-                $("div.search-box").show();
+                $('.tag-tree', $panel).block();
                 $(".tag-tree", $panel).jstree("search", searchString);
                 delete window.searchedString;
               }
@@ -383,19 +383,6 @@
   div.tag-tree-wrapper {
     position: relative;
     min-height: 250px;
-  }
-  div.search-box {
-    margin: auto;
-    position: absolute;
-    top: 0px; left: 0px;
-    bottom: 0px; right: 0px;
-    background-color: grey;
-    color: white;
-    text-align: center;
-    vertical-align: middle;
-    line-height: 350px;
-    font-weight: bold;
-    opacity: .6;
   }
   div.tag-tree {
     width: 59%;


### PR DESCRIPTION
Overview
----------------------------------------
1. Bring a visual indicator to show search in progress while searching for a tag.
2. Don't try to fetch the tag ids on basis of each character typed on search box, rather than delay by 1sec and fetch the ids on basis of string entered. This will improve performance for sites which have >1k tags.

Before
----------------------------------------
![test-multiple-before](https://user-images.githubusercontent.com/3735621/34872040-8991f2c4-f7b5-11e7-9c5a-28b0f16c4e5d.gif)

After
----------------------------------------
![test-multiple-after](https://user-images.githubusercontent.com/3735621/34872054-92227878-f7b5-11e7-9c6a-f0515eab8223.gif)

---

 * [CRM-21613: Search issues on 'Manage Tag' page](https://issues.civicrm.org/jira/browse/CRM-21613)