### PR TITLE
CRM-21655, include contact sub type profile to be default contact search

### DIFF
--- a/CRM/Admin/Form/Setting/Search.php
+++ b/CRM/Admin/Form/Setting/Search.php
@@ -86,12 +86,12 @@ class CRM_Admin_Form_Setting_Search extends CRM_Admin_Form_Setting {
    * @return array
    */
   public static function getAvailableProfiles() {
-    return array('' => ts('- none -')) + CRM_Core_BAO_UFGroup::getProfiles(array(
+    return array('' => ts('- none -')) + CRM_Core_BAO_UFGroup::getProfiles(array_merge(array(
       'Contact',
       'Individual',
       'Organization',
       'Household',
-    ));
+    ), CRM_Contact_BAO_ContactType::subTypes()));
   }
 
   /**


### PR DESCRIPTION
----------------------------------------
* CRM-21655: Why can't subtype profile be used as default contact search ?
  https://issues.civicrm.org/jira/browse/CRM-21655

Before
----------------------------------------
![screen shot 2018-01-12 at 7 14 21 pm](https://user-images.githubusercontent.com/2053075/34878054-b44a93b8-f7ce-11e7-863e-2a1289d84431.png)

![screen shot 2018-01-12 at 7 30 01 pm](https://user-images.githubusercontent.com/2053075/34878123-09ad6a74-f7cf-11e7-9244-1a2ff9bd4baa.png)

After
----------------------------------------
![screen shot 2018-01-12 at 7 13 58 pm](https://user-images.githubusercontent.com/2053075/34878045-a9a30440-f7ce-11e7-8d03-caa5aa258541.png)

