### PR TITLE
CRM-21656: Fix Backend Membership with Priceset Applies Taxes Twice

### DIFF
--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -696,12 +696,13 @@ WHERE  id = %1";
     // This seems to only affect radio link items as that is the use case for the 'quick config'
     // set up (which allows a free form field).
     $amount_override = NULL;
+    $isQuick = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $priceSetID, 'is_quick_config');
 
     if ($component) {
       $autoRenew = array();
       $autoRenew[0] = $autoRenew[1] = $autoRenew[2] = 0;
     }
-    if ($priceSetID) {
+    if ($priceSetID && $isQuick) {
       $priceFields = self::filterPriceFieldsFromParams($priceSetID, $params);
       if (count($priceFields) == 1) {
         $amount_override = CRM_Utils_Array::value('partial_payment_total', $params, CRM_Utils_Array::value('total_amount', $params));


### PR DESCRIPTION
Overview
----------------------------------------

Steps to reproduce:

- Enable Taxes, Add a tax account with a 10% tax
- Add the tax account to the Membership financial type
- Create a new priceset for memberships, with radio options for the main membership options.
- From a contact record, add a new membership for that contact, select an option from the priceset.

Notice how to total amount is OK, but when we view the contribution, the line
item shows a unit_price with the tax_amount included, so then the total_line
ends up adding the taxes again.

This was caused by a hack for entering backend memberships using the default
dropdown options (not a priceset), which makes it possible to enter an arbitrary
total_amount directly.

(the JIRA issue has screenshots and rainbows)

Comments
----------------------------------------

I tested creating a new membership using a priceset, as well as without a priceset, and with entering an arbitrary total_amount.

---

 * [CRM-21656: Backend Membership with Priceset applies taxes twice to line_item](https://issues.civicrm.org/jira/browse/CRM-21656)