### PR TITLE
CRM-21591 Fix issue when generating default MaxFileSize defaults due …

### DIFF
--- a/CRM/Core/Config/Defaults.php
+++ b/CRM/Core/Config/Defaults.php
@@ -81,6 +81,7 @@ class CRM_Core_Config_Defaults {
   public static function formatUnitSize($size, $checkForPostMax = FALSE) {
     if ($size) {
       $last = strtolower($size{strlen($size) - 1});
+      $size = (int) $size;
       switch ($last) {
         // The 'G' modifier is available since PHP 5.1.0
 

--- a/tests/phpunit/CRM/Core/Config/DefaultsTest.php
+++ b/tests/phpunit/CRM/Core/Config/DefaultsTest.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Class CRM_Core_Config_DefaultsTest
+ */
+class CRM_Core_Config_DefaultsTest extends CiviUnitTestCase {
+
+
+  public function sizeCases() {
+    $cases = [];
+    $cases[] = ['20M', '20971520'];
+    $cases[] = ['40G', '42949672960'];
+    return $cases;
+  }
+
+  /**
+   * @param $size
+   * @param $expectedValue
+   * @dataProvider sizeCases
+   */
+  public function testFormatUnitSize($size, $expectedValue) {
+    $this->assertEquals($expectedValue, CRM_Core_Config_Defaults::formatUnitSize($size));
+  }
+
+}


### PR DESCRIPTION
…ot non well formed numeric value error

Overview
----------------------------------------
This is a port of PRs https://github.com/civicrm/civicrm-core/pull/11447 and https://github.com/civicrm/civicrm-core/pull/11429 to fix the same issue in 4.6 where in PHP7.1 an error gets displayed because `$size` isn't confirmed to be numerical

Before
----------------------------------------
in PHP7.1 error is shown

After
----------------------------------------
No Error

ping @jackrabbithanna Mark whilst this specifically hits a php7.1 issue its a pretty simple fix and adds a unit test.