### PR TITLE
CRM-20972 Handle new type of exception in PHP7.1 when too few argumen…

### DIFF
--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -641,12 +641,21 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
 
   /**
    * @dataProvider entities
-   * @expectedException PHPUnit_Framework_Error
    * @param $Entity
    */
   public function testWithoutParam_get($Entity) {
     // should get php complaining that a param is missing
-    $result = civicrm_api($Entity, 'Get');
+    try {
+      $result = civicrm_api($Entity, 'Get');
+      $this->fail('Expected an exception. No exception was thrown.');
+    }
+    // As of php7.1 a new Exception is thrown by PHP ArgumentCountError when not enough params are passed.
+    catch (ArgumentCountError $e) {
+      /* ok */
+    }
+    catch (PHPUnit_Framework_Error $e) {
+      /* ok */
+    }
   }
 
   /**
@@ -1316,12 +1325,21 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
 
   /**
    * @dataProvider entities
-   * @expectedException PHPUnit_Framework_Error
    * @param $Entity
    */
   public function testWithoutParam_delete($Entity) {
-    // should delete php complaining that a param is missing
-    $result = civicrm_api($Entity, 'Delete');
+    // should get php complaining that a param is missing
+    try {
+      $result = civicrm_api($Entity, 'Delete');
+      $this->fail('Expected an exception. No exception was thrown.');
+    }
+    // As of php7.1 a new Exception is thrown by PHP ArgumentCountError when not enough params are passed.
+    catch (ArgumentCountError $e) {
+      /* ok */
+    }
+    catch (PHPUnit_Framework_Error $e) {
+      /* ok */
+    }
   }
 
   /**


### PR DESCRIPTION
…ts are passed in function

Overview
----------------------------------------
This handles a new Exception that is added in php7.1 which adds an exception when not enough params are passed in. 

Before
if you run the test on php7.1 error is shown

After
----------------------------------------
No Error and tests pass

ping @jackrabbithanna again this is a PHP7.1 specific issue but it only affects tests and its a direct port of https://github.com/civicrm/civicrm-core/pull/10772
