### PR TITLE
Call hook_civicrm_export when exporting custom searches.

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -1210,6 +1210,7 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
     else {
       require_once $ext->classToPath($customSearchClass);
     }
+    /** @var \CRM_Contact_Form_Search_Interface $search */
     $search = new $customSearchClass($formValues);
 
     $includeContactIDs = FALSE;
@@ -1221,15 +1222,48 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
 
     $columns = $search->columns();
 
-    $header = array_keys($columns);
+    // Create arrays for export hook
+    $sqlColumns = [];
+    $headerRows = [];
+    foreach ($columns as $description => $columnName) {
+      // FIXME: This is why you cannot have two columns with the same field name
+      // in your custom search, even if they're qualified with an alias.
+      $unqualified_field = CRM_Utils_Array::First(array_slice(explode('.', $columnName), -1));
+      // I just put 'varchar(255)' in there; this is not ideal, but it might
+      // work if you're just exporting to csv. The values of $sqlColumns are
+      // never used in plain CiviCRM, but they might be used in a hook
+      // implementation, so it is tricky.
+      $sqlColumns[$unqualified_field] = "$unqualified_field varchar(255)";
+      // Who invented the name headerRows for column headers? ;-)
+      $headerRows[] = $description;
+    }
+    $exportMode = CRM_Export_Form_Select::CONTACT_EXPORT;
+
+    if (!method_exists($search, 'alterRow')) {
+      // If there is no alterRow, this might work:
+      $exportTempTable = CRM_Core_DAO::createTempTableName('civicrm_export', TRUE);
+      $createAndInsertQuery = "CREATE TABLE $exportTempTable AS ($sql)";
+
+      CRM_Core_DAO::executeQuery($createAndInsertQuery);
+      CRM_Utils_Hook::export($exportTempTable, $headerRows, $sqlColumns, $exportMode);
+      self::writeCSVFromTable($exportTempTable, $headerRows, $sqlColumns, $exportMode);
+      CRM_Core_DAO::executeQuery("DROP TABLE IF EXISTS $exportTempTable");
+      CRM_Utils_System::civiExit();
+    }
+
+    // Create temporary table with results.
+    $exportTempTable = self::createTempTable($sqlColumns);
+    $dropExportTable = "DROP TABLE IF EXISTS $exportTempTable";
+
     $fields = array_values($columns);
 
     $rows = array();
     $dao = CRM_Core_DAO::executeQuery($sql);
-    $alterRow = FALSE;
-    if (method_exists($search, 'alterRow')) {
-      $alterRow = TRUE;
-    }
+
+    // I just copied this from the 'ordinary' 'exportComponents'.
+    $tempRowCount = 100;
+    $count = 0;
+
     while ($dao->fetch()) {
       $row = array();
 
@@ -1237,13 +1271,20 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
         $unqualified_field = CRM_Utils_Array::First(array_slice(explode('.', $field), -1));
         $row[$field] = $dao->$unqualified_field;
       }
-      if ($alterRow) {
-        $search->alterRow($row);
-      }
+      $search->alterRow($row);
       $rows[] = $row;
+      if ((++$count) == $tempRowCount) {
+        self::writeDetailsToTable($exportTempTable, $rows, $sqlColumns);
+        $count = 0;
+        $rows = [];
+      }
     }
+    $dao->free();
 
-    CRM_Core_Report_Excel::writeCSVFile(self::getExportFileName(), $header, $rows);
+    self::writeDetailsToTable($exportTempTable, $rows, $sqlColumns);
+    CRM_Utils_Hook::export($exportTempTable, $headerRows, $sqlColumns, $exportMode);
+    self::writeCSVFromTable($exportTempTable, $headerRows, $sqlColumns, $exportMode);
+    CRM_Core_DAO::executeQuery($dropExportTable);
     CRM_Utils_System::civiExit();
   }
 

--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -1903,7 +1903,9 @@ LIMIT $offset, $limit
         $row = array();
 
         foreach ($sqlColumns as $column => $dontCare) {
-          $row[$column] = $dao->$column;
+          if (isset($dao->column)) {
+            $row[$column] = $dao->$column;
+          }
         }
         $componentDetails[] = $row;
       }

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -20,6 +20,11 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
    */
   protected $contributionIDs = array();
 
+
+
+  /** @var boolean */
+  private $hookConfirmation = false;
+
   /**
    * Basic test to ensure the exportComponents function completes without error.
    */
@@ -150,6 +155,36 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
       }
     }
 
+  }
+
+  public function testExportCustomShouldCallHook() {
+    $customSearchClass = "CRM_Contact_Form_Search_Custom_Basic";
+    $formValues = array(
+      'csid' => '3',
+      'qfKey' => 'da118c92c7f2aea92f3610ab46bbc7b3_4234',
+      'entryURL' => 'http://localhost/index.php?q=civicrm/contact/search/custom&amp;csid=3&amp;reset=1',
+      'contact_type' => 'Organization',
+      'group' => '',
+      'tag' => '',
+      'sort_name' => '',
+      'task' => '5',
+      'radio_ts' => 'ts_all',
+      'customSearchID' => '3',
+      'customSearchClass' => 'CRM_Contact_Form_Search_Custom_Basic',
+      'component_mode' => 1,
+      'operator' => 1,
+    );
+    $order = "`sort_name` asc";
+
+    $this->hookClass->setHook('civicrm_export', array($this, 'confirmHookWasCalled'));
+
+    $this->hookConfirmation = false;
+    CRM_Export_BAO_Export::exportCustom($customSearchClass, $formValues, $order);
+    $this->assertTrue($this->hookConfirmation);
+  }
+
+  public function confirmHookWasCalled(&$exportTempTable, &$headerRows, &$sqlColumns, &$exportMode) {
+    $this->hookConfirmation = true;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
CRM-21657: hook_civicrm_export is not called when exporting custom search results. Since CRM-8140 was fixed, the problem only shows if you export the custom search fields, not if you make a field selection yourself. 

Before
----------------------------------------
E.g.:
* Click 'search', 'custom searches'
* Click 'basic search' (or any other custom search)
* Click 'search'
* Click 'Select records: All 203 records'
* Click 'Actions', 'Export contacts'
* (Click 'Export custom search fields', and 'Continue' if you are using CiviCRM 4.7.20 or later; this option is not available in earlier versions of CiviCRM.)
* An export is created without calling hook_civicrm_export. 

After
----------------------------------------
E.g.:
* Click 'search', 'custom searches'
* Click 'basic search' (or any other custom search)
* Click 'search'
* Click 'Select records: All 203 records'
* Click 'Actions', 'Export contacts'
* (Click 'Export custom search fields', and 'Continue' if you are using CiviCRM 4.7.20 or later; this option is not available in earlier versions of CiviCRM.)
* An export is created after calling hook_civicrm_export. 

Technical Details
----------------------------------------
Exports of 'ordinary' searches create a temporary table, and pass that table to hook_civicrm_export. Exports of custom searches create a CSV file based on in-memory data.
So I changed the latter so that it also creates a temporary table, and passes it to the hook implementations.

Comments
----------------------------------------
The column definitions that are passed to the hook, are not correct. I say that all columns are varchar(255), which is obviously not true. This might cause troubles if specific hook implementations rely on this.
But I guess you look at the source code to see what I've exactly changed ;-)

---

 * [CRM-21657: hook_civicrm_export is not called when exporting a custom search](https://issues.civicrm.org/jira/browse/CRM-21657)
 * [CRM-8140: Not possible to select fields for export when using Custom Searches](https://issues.civicrm.org/jira/browse/CRM-8140)