### PR TITLE
CRM-21654: Support custom file field on Batch Entry Profile

### DIFF
--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -153,11 +153,8 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
 
     // remove file type field and then limit fields
     $suppressFields = FALSE;
-    $removehtmlTypes = array('File');
     foreach ($this->_fields as $name => $field) {
-      if ($cfID = CRM_Core_BAO_CustomField::getKeyID($name) &&
-        in_array($this->_fields[$name]['html_type'], $removehtmlTypes)
-      ) {
+      if ($cfID = CRM_Core_BAO_CustomField::getKeyID($name) && $this->_fields[$name]['html_type'] == 'Autocomplete-Select') {
         $suppressFields = TRUE;
         unset($this->_fields[$name]);
       }

--- a/templates/CRM/Batch/Form/Entry.tpl
+++ b/templates/CRM/Batch/Form/Entry.tpl
@@ -118,7 +118,12 @@
                {/if}
              </div>
           {else}
-            <div class="compressed crm-grid-cell">{$form.field.$rowNumber.$n.html}</div>
+            <div class="compressed crm-grid-cell">
+              {$form.field.$rowNumber.$n.html}
+              {if $fields.$n.html_type eq 'File' && !empty($form.field.$rowNumber.$fieldName.value.size)}
+                {ts}Attached{/ts}: {$form.field.$rowNumber.$fieldName.value.name}
+              {/if}
+            </div>
           {/if}
         {/foreach}
       </div>


### PR DESCRIPTION
Overview
----------------------------------------
There is two issue with batch entry profile related to custom file field:
1. It doesn't support Autocomplete-select and File field and there is a restriction placed in backend form. Which doesn't make sense for file, as allowing file field in batch entry allows us to upload a file.
2. Validation error on batch entry form wipes out the uploaded file information.

The screenshot share below highlights the 2nd fix. 

Before
----------------------------------------
![screen shot 2018-01-15 at 11 22 57 am](https://user-images.githubusercontent.com/3735621/34929017-5b49ab9e-f9e7-11e7-9811-1bf9fcf032fa.png)

After
----------------------------------------
![screen shot 2018-01-15 at 11 23 35 am](https://user-images.githubusercontent.com/3735621/34929036-78855c76-f9e7-11e7-9d81-1b3054d1fe2e.png)


Technical Details
----------------------------------------
#2 is an issue for all other file fields in Civi. And doing the minor change in tpl we can atleast show the uploaded filename against that field.

---

 * [CRM-21654: Support custom file field on Batch Entry Profile](https://issues.civicrm.org/jira/browse/CRM-21654)