### PR TITLE
CRM-21656: Backend Membership with Priceset applies taxes twice to line_item

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1382,7 +1382,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     // as a point of fragility rather than a logical 'if' clause.
     if ($priceSetId) {
       CRM_Price_BAO_PriceSet::processAmount($this->_priceSet['fields'],
-        $submittedValues, $lineItem[$priceSetId]);
+        $submittedValues, $lineItem[$priceSetId], NULL, $priceSetId);
       // Unset tax amount for offline 'is_quick_config' contribution.
       // @todo WHY  - quick config was conceived as a quick way to configure contribution forms.
       // this is an example of 'other' functionality being hung off it.

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1991,7 +1991,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
     $priceFields = $priceFields[$priceSetID]['fields'];
     $lineItems = array();
-    CRM_Price_BAO_PriceSet::processAmount($priceFields, $paramsProcessedForForm, $lineItems, 'civicrm_contribution');
+    CRM_Price_BAO_PriceSet::processAmount($priceFields, $paramsProcessedForForm, $lineItems, 'civicrm_contribution', $priceSetID);
     $form->_lineItem = array($priceSetID => $lineItems);
     $membershipPriceFieldIDs = array();
     foreach ((array) $lineItems as $lineItem) {

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -1165,7 +1165,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
         $component = 'membership';
       }
 
-      CRM_Price_BAO_PriceSet::processAmount($this->_values['fee'], $params, $lineItem[$priceSetId], $component);
+      CRM_Price_BAO_PriceSet::processAmount($this->_values['fee'], $params, $lineItem[$priceSetId], $component, $priceSetId);
       if ($params['tax_amount']) {
         $this->set('tax_amount', $params['tax_amount']);
       }

--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -645,17 +645,16 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
    *   array of options
    */
   public static function getOptions($fieldId, $inactiveNeeded = FALSE, $reset = FALSE, $isDefaultContributionPriceSet = FALSE) {
-    static $options = array();
-    if ($reset) {
-      $options = array();
+    if ($reset || !isset(Civi::$statics[__CLASS__]['priceOptions'])) {
+      Civi::$statics[__CLASS__]['priceOptions'] = array();
       // This would happen if the function was only called to clear the cache.
       if (empty($fieldId)) {
         return array();
       }
     }
 
-    if (empty($options[$fieldId])) {
-      $values = array();
+    if (empty(Civi::$statics[__CLASS__]['priceOptions'][$fieldId])) {
+      $values = $options = array();
       CRM_Price_BAO_PriceFieldValue::getValues($fieldId, $values, 'weight', !$inactiveNeeded);
       $options[$fieldId] = $values;
       $taxRates = CRM_Core_PseudoConstant::getTaxRates();
@@ -669,9 +668,10 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
           $options[$fieldId][$priceFieldId]['tax_amount'] = $taxAmount['tax_amount'];
         }
       }
+      Civi::$statics[__CLASS__]['priceOptions'][$fieldId] = $options[$fieldId];
     }
 
-    return $options[$fieldId];
+    return Civi::$statics[__CLASS__]['priceOptions'][$fieldId];
   }
 
   /**

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -747,7 +747,7 @@ WHERE  id = %1";
           CRM_Price_BAO_LineItem::format($id, $params, $field, $lineItem, $amount_override);
           if (CRM_Utils_Array::value('tax_rate', $field['options'][$optionValueId])) {
             $lineItem = self::setLineItem($field, $lineItem, $optionValueId, $totalTax);
-            if (CRM_Utils_Array::value('field_title', $lineItem[$optionValueId]) == 'Membership Amount') {
+            if ($amount_override) {
               $lineItem[$optionValueId]['line_total'] = $lineItem[$optionValueId]['unit_price'] = CRM_Utils_Rule::cleanMoney($lineItem[$optionValueId]['line_total'] - $lineItem[$optionValueId]['tax_amount']);
             }
           }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3742,6 +3742,9 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
    * Enable Tax and Invoicing
    */
   protected function disableTaxAndInvoicing($params = array()) {
+    if (!empty(\Civi::$statics['CRM_Core_PseudoConstant']) && isset(\Civi::$statics['CRM_Core_PseudoConstant']['taxRates'])) {
+      unset(\Civi::$statics['CRM_Core_PseudoConstant']['taxRates']);
+    }
     // Enable component contribute setting
     $contributeSetting = array_merge($params,
       array(
@@ -3773,6 +3776,9 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
       'entity_id' => $financialTypeId,
       'account_relationship' => key(CRM_Core_PseudoConstant::accountOptionValues('account_relationship', NULL, " AND v.name LIKE 'Sales Tax Account is' ")),
     );
+
+    // set tax rate (as 10) for provided financial type ID to static variable, later used to fetch tax rates of all financial types
+    \Civi::$statics['CRM_Core_PseudoConstant']['taxRates'][$financialTypeId] = 10;
 
     //CRM-20313: As per unique index added in civicrm_entity_financial_account table,
     //  first check if there's any record on basis of unique key (entity_table, account_relationship, entity_id)


### PR DESCRIPTION
Overview
----------------------------------------
Steps to reproduce:

Enable Taxes, Add a tax account with a 10% tax
1. Add the tax account to the Membership financial type
2. Create a new priceset for memberships, with radio options for the main membership options.
3. From a contact record, add a new membership for that contact, select an option from the priceset.

Notice how to total amount is OK, but when we view the contribution, the line
item shows a unit_price with the tax_amount included, so then the total_line
ends up adding the taxes again.

Before
----------------------------------------
![test-multiple-before](https://user-images.githubusercontent.com/3735621/34943109-4a3a438e-fa20-11e7-949d-d1941cb58b56.gif)


After
----------------------------------------
![test-multiple-after](https://user-images.githubusercontent.com/3735621/34943150-77014142-fa20-11e7-96bf-9a9920a053b3.gif)


Technical Details
----------------------------------------
Also, there is a minor change in contribution backoffice form, where earlier the fn responsible to fetch line-item, got missing parameter $priceSetID.



---

 * [CRM-21656: Backend Membership with Priceset applies taxes twice to line_item](https://issues.civicrm.org/jira/browse/CRM-21656)