### PR TITLE
Proposed fix for CRM-21444

### DIFF
--- a/CRM/Contact/Form/DedupeRules.php
+++ b/CRM/Contact/Form/DedupeRules.php
@@ -58,10 +58,12 @@ class CRM_Contact_Form_DedupeRules extends CRM_Admin_Form {
     }
     $this->_options = CRM_Core_SelectValues::getDedupeRuleTypes();
     $this->_rgid = CRM_Utils_Request::retrieve('id', 'Positive', $this, FALSE, 0);
+
+    // check if $contactType is valid
     $contactTypes = civicrm_api3('Contact', 'getOptions', array('field' => "contact_type"));
     $contactType = CRM_Utils_Request::retrieve('contact_type', 'String', $this, FALSE, 0);
     if (CRM_Utils_Array::value($contactType, $contactTypes['values'])) {
-      $this->_contactType = CRM_Utils_Array::value($contactType, $contactTypes['values']);
+      $this->_contactType = $contactType;
     }
     elseif (!empty($contactType)) {
       throw new CRM_Core_Exception('Contact Type is Not valid');


### PR DESCRIPTION
Overview
----------------------------------------
See https://issues.civicrm.org/jira/browse/CRM-21444

Before
----------------------------------------
The dedupe rule edit screen doesn't yield the fields in the dropdown, if the contact types' labels and names differ (e.g. in a localised environment).

After
----------------------------------------
The dedupe edit screen works again.

Technical Details
----------------------------------------
The code used the ``label`` where it should have used the ``name``.

