### PR TITLE
Add test for DB error on search add to group CRM-21159

### DIFF
--- a/CRM/Contact/Form/Task.php
+++ b/CRM/Contact/Form/Task.php
@@ -298,11 +298,9 @@ class CRM_Contact_Form_Task extends CRM_Core_Form {
     }
 
     $selectorName = $this->controller->selectorName();
-    require_once str_replace('_', DIRECTORY_SEPARATOR, $selectorName) . '.php';
 
     $fv = $this->get('formValues');
     $customClass = $this->get('customSearchClass');
-    require_once 'CRM/Core/BAO/Mapping.php';
     $returnProperties = CRM_Core_BAO_Mapping::returnProperties(self::$_searchFormValues);
 
     $selector = new $selectorName($customClass, $fv, NULL, $returnProperties);
@@ -318,7 +316,7 @@ class CRM_Contact_Form_Task extends CRM_Core_Form {
     if (!$queryOperator) {
       $queryOperator = 'AND';
     }
-    $dao = $selector->contactIDQuery($params, $this->_action, $sortID,
+    $dao = $selector->contactIDQuery($params, $sortID,
       CRM_Utils_Array::value('display_relationship_type', $fv),
       $queryOperator
     );

--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -1182,14 +1182,13 @@ SELECT DISTINCT 'civicrm_contact', contact_a.id, contact_a.id, '$cacheKey', cont
 
   /**
    * @param array $params
-   * @param $action
    * @param int $sortID
    * @param null $displayRelationshipType
    * @param string $queryOperator
    *
    * @return CRM_Contact_DAO_Contact
    */
-  public function contactIDQuery($params, $action, $sortID, $displayRelationshipType = NULL, $queryOperator = 'AND') {
+  public function contactIDQuery($params, $sortID, $displayRelationshipType = NULL, $queryOperator = 'AND') {
     $sortOrder = &$this->getSortOrder($this->_action);
     $sort = new CRM_Utils_Sort($sortOrder, $sortID);
 

--- a/CRM/Contact/Selector/Custom.php
+++ b/CRM/Contact/Selector/Custom.php
@@ -424,7 +424,7 @@ class CRM_Contact_Selector_Custom extends CRM_Contact_Selector {
    *
    * @return Object
    */
-  public function contactIDQuery($params, $action, $sortID, $displayRelationshipType = NULL, $queryOperator = 'AND') {
+  public function contactIDQuery($params, $sortID, $displayRelationshipType = NULL, $queryOperator = 'AND') {
     // $action, $displayRelationshipType and $queryOperator are unused. I have
     // no idea why they are there.
 

--- a/tests/phpunit/CRM/Contact/SelectorTest.php
+++ b/tests/phpunit/CRM/Contact/SelectorTest.php
@@ -158,6 +158,22 @@ class CRM_Contact_Form_SelectorTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test the contact ID query does not fail on country search.
+   */
+  public function testContactIDQuery() {
+    $params = [[
+      0 => 'country-1',
+      1 => '=',
+      2 => '1228',
+      3 => 1,
+      4 => 0,
+    ]];
+
+    $searchOBJ = new CRM_Contact_Selector(NULL);
+    $searchOBJ->contactIDQuery($params, '1_u');
+  }
+
+  /**
    * Get the default select string since this is generally consistent.
    */
   public function getDefaultSelectString() {


### PR DESCRIPTION
Overview
----------------------------------------
Unit test for fix in #11422 

Before
----------------------------------------
No test

After
----------------------------------------
test

Technical Details
----------------------------------------
I've also removed an unused parameter & a couple of require_once calls


Comments
----------------------------------------
This is part of the review on #11422 - I replicated it in a test & then merged #11422 - this is the test

---

 * [CRM-21159: Address fields cause DB errors when adding contacts to group from Search Builder](https://issues.civicrm.org/jira/browse/CRM-21159)