### PR TITLE
CRM-14834 - fix activity export when relationship in export fields

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -286,6 +286,10 @@ class CRM_Export_BAO_Export {
    * @param array $exportParams
    * @param string $queryOperator
    *
+   * @return array|null
+   *   An array can be requested from within a unit test.
+   *
+   * @throws \CRM_Core_Exception
    */
   public static function exportComponents(
     $selectAll,
@@ -385,7 +389,6 @@ class CRM_Export_BAO_Export {
           }
         }
 
-        $contactType = CRM_Utils_Array::value(0, $value);
         $locTypeId = CRM_Utils_Array::value(2, $value);
 
         if ($relationField) {
@@ -609,10 +612,12 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
         }
         elseif ($exportMode == CRM_Export_Form_Select::ACTIVITY_EXPORT) {
           $sourceID = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_ActivityContact', 'record_type_id', 'Activity Source');
-          $query = "SELECT contact_id FROM civicrm_activity_contact
-                              WHERE activity_id IN ( " . implode(',', $ids) . ") AND
-                              record_type_id = {$sourceID}";
-          $dao = CRM_Core_DAO::executeQuery($query);
+          $dao = CRM_Core_DAO::executeQuery("
+            SELECT contact_id FROM civicrm_activity_contact
+            WHERE activity_id IN ( " . implode(',', $ids) . ") AND
+            record_type_id = {$sourceID}
+          ");
+
           while ($dao->fetch()) {
             $relIDs[] = $dao->contact_id;
           }
@@ -1114,7 +1119,7 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
       CRM_Utils_System::civiExit();
     }
     else {
-      CRM_Core_Error::fatal(ts('No records to export'));
+      throw new CRM_Core_Exception(ts('No records to export'));
     }
   }
 

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -11,14 +11,21 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
    *
    * @var array
    */
-  protected $contactIDs = array();
+  protected $contactIDs = [];
 
   /**
    * Contribution IDs created for testing.
    *
    * @var array
    */
-  protected $contributionIDs = array();
+  protected $contributionIDs = [];
+
+  /**
+   * Contribution IDs created for testing.
+   *
+   * @var array
+   */
+  protected $activityIDs = [];
 
   /**
    * Basic test to ensure the exportComponents function completes without error.
@@ -86,6 +93,40 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
     $sql = "DROP TABLE IF EXISTS {$tableName}";
     CRM_Core_DAO::executeQuery($sql);
   }
+
+  /**
+   * Basic test to ensure the exportComponents function can export selected fields for contribution.
+   */
+  public function testExportComponentsActivity() {
+    $this->setUpActivityExportData();
+    $selectedFields = array(
+      array('Individual', 'display_name'),
+      array('Individual', '5_a_b', 'display_name'),
+    );
+
+    list($tableName) = CRM_Export_BAO_Export::exportComponents(
+      FALSE,
+      $this->activityIDs,
+      array(),
+      '`activity_date_time` desc',
+      $selectedFields,
+      NULL,
+      CRM_Export_Form_Select::ACTIVITY_EXPORT,
+      'civicrm_activity.id IN ( ' . implode(',', $this->activityIDs) . ')',
+      NULL,
+      FALSE,
+      FALSE,
+      array(
+        'exportOption' => CRM_Export_Form_Select::ACTIVITY_EXPORT,
+        'suppress_csv_for_testing' => TRUE,
+      )
+    );
+
+    // delete the export temp table and component table
+    $sql = "DROP TABLE IF EXISTS {$tableName}";
+    CRM_Core_DAO::executeQuery($sql);
+  }
+
   /**
    * Test the function that extracts the arrays used to structure the output.
    *
@@ -158,6 +199,14 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
   public function setUpContributionExportData() {
     $this->setUpContactExportData();
     $this->contributionIDs[] = $this->contributionCreate(array('contact_id' => $this->contactIDs[0]));
+  }
+
+  /**
+   * Set up some data for us to do testing on.
+   */
+  public function setUpActivityExportData() {
+    $this->setUpContactExportData();
+    $this->activityIDs[] = $this->activityCreate(array('contact_id' => $this->contactIDs[0]))['id'];
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Per JIRA activity export fails if  a relationship field is selected

Before
----------------------------------------
Fatal error when exporting activities from advanced search with a relationship field selected - per screenshot.
![screenshot 2018-01-16 12 35 37](https://user-images.githubusercontent.com/336308/34967065-008ed650-fac5-11e7-9f9e-14ff2f0e468c.png)


After
----------------------------------------
Export succeeds

Technical Details
----------------------------------------
Error was a really dumb bit of code - re-using the variable $query for a temp sql string.

Comments
----------------------------------------
I was able to replicate it in a unit test

---

 * [CRM-14834: Activity Export with Relationships incurs fatal error](https://issues.civicrm.org/jira/browse/CRM-14834)