### PR TITLE
CRM-21524 - Fix merge contacts when one is deceased

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -1080,6 +1080,14 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
     if ($exportTempTable) {
       self::writeDetailsToTable($exportTempTable, $componentDetails, $sqlColumns);
 
+      // if postalMailing option is checked, exclude contacts who are deceased, have
+      // "Do not mail" privacy setting, or have no street address
+      if (isset($exportParams['postal_mailing_export']['postal_mailing_export']) &&
+        $exportParams['postal_mailing_export']['postal_mailing_export'] == 1
+      ) {
+        self::postalMailingFormat($exportTempTable, $headerRows, $sqlColumns, $exportMode);
+      }
+
       // do merge same address and merge same household processing
       if ($mergeSameAddress) {
         self::mergeSameAddress($exportTempTable, $headerRows, $sqlColumns, $exportParams);
@@ -1089,14 +1097,6 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
       if ($mergeSameHousehold) {
         self::mergeSameHousehold($exportTempTable, $headerRows, $sqlColumns, $relationKeyMOH);
         self::mergeSameHousehold($exportTempTable, $headerRows, $sqlColumns, $relationKeyHOH);
-      }
-
-      // if postalMailing option is checked, exclude contacts who are deceased, have
-      // "Do not mail" privacy setting, or have no street address
-      if (isset($exportParams['postal_mailing_export']['postal_mailing_export']) &&
-        $exportParams['postal_mailing_export']['postal_mailing_export'] == 1
-      ) {
-        self::postalMailingFormat($exportTempTable, $headerRows, $sqlColumns, $exportMode);
       }
 
       // call export hook


### PR DESCRIPTION
Overview
----------------------------------------
When exporting contacts and merge contacts with the same address is selected then contacts with the same address are still merged even though one is deceased.

---

 * [CRM-21524: CiviCRM exports \(postal\) mailing lists including Contacts clearly marked is_deceased in the database](https://issues.civicrm.org/jira/browse/CRM-21524)