### PR TITLE
CRM-21663: Fix Campaign Search and result structure

### DIFF
--- a/templates/CRM/Campaign/Form/Search.tpl
+++ b/templates/CRM/Campaign/Form/Search.tpl
@@ -27,29 +27,37 @@
 {include file='CRM/Campaign/Form/Search/Common.tpl' context='search'}
 
 {if $rowsEmpty || $rows}
-<div class="crm-content-block">
+<div class="crm-content-block crm-search-form-block">
 {if $rowsEmpty}
+<div class="crm-content-block">
+  <div class="crm-results-block crm-results-block-empty">
     {include file="CRM/Campaign/Form/Search/EmptyResults.tpl"}
+  </div>
+</div>
 {/if}
 
 {if $rows}
+<div class="crm-content-block">
+  <div class="crm-results-block">
     {* Search request has returned 1 or more matching rows. Display results and collapse the search criteria fieldset. *}
     {assign var="showBlock" value="'searchForm_show'"}
     {assign var="hideBlock" value="'searchForm'"}
 
     {* Search request has returned 1 or more matching rows. *}
     <fieldset>
-
+      <div class="crm-search-tasks">
        {* This section handles form elements for action task select and submit *}
        {include file="CRM/common/searchResultTasks.tpl" context="Campaign"}
-
+      </div>
+      <div class="crm-search-results">
        {* This section displays the rows along and includes the paging controls *}
        <p></p>
        {include file="CRM/Campaign/Form/Selector.tpl" context="Search"}
-
+      </div>
     </fieldset>
     {* END Actions/Results section *}
-
+  </div>
+</div>
 {/if}
 </div>
 {/if}

--- a/templates/CRM/Campaign/Form/Search/Common.tpl
+++ b/templates/CRM/Campaign/Form/Search/Common.tpl
@@ -30,9 +30,8 @@
 {if $searchVoterFor}
   {assign var='searchForm' value="search_form_$searchVoterFor"}
 {/if}
-
   <div id="{$searchForm}" class="crm-accordion-wrapper crm-contribution_search_form-accordion {if $rows}collapsed{/if}">
-    <div class="crm-accordion-header crm-master-accordion-header">
+    <div class="crm-accordion-header {if !$votingTab} crm-master-accordion-header{/if}">
     {ts}Edit Search Criteria{/ts}
     </div><!-- /.crm-accordion-header -->
 

--- a/templates/CRM/Campaign/Form/Selector.tpl
+++ b/templates/CRM/Campaign/Form/Selector.tpl
@@ -34,6 +34,7 @@
     {if !$single and $context eq 'Search' }
         <th scope="col" title="Select Rows">{$form.toggleSelect.html}</th>
     {/if}
+    <th scope="col"></th>
     {foreach from=$columnHeaders item=header}
 
         <th scope="col">
@@ -56,16 +57,17 @@
           {assign var=cbName value=$row.checkbox}
           <td>{$form.$cbName.html}</td>
    {/if}
-    <td>{$row.contact_type} &nbsp;<a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.contact_id`"}">{$row.sort_name}</a></td>
-  <td>{$row.street_number}</td>
-  <td>{$row.street_name}</td>
-  <td>{$row.street_address}</td>
-  <td>{$row.city}</td>
-  <td>{$row.postal_code}</td>
-  <td>{$row.state_province}</td>
-  <td>{$row.country}</td>
-  <td>{$row.email}</td>
-  <td>{$row.phone}</td>
+    <td>{$row.contact_type}</td>
+    <td><a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.contact_id`"}">{$row.sort_name}</a></td>
+    <td>{$row.street_number}</td>
+    <td>{$row.street_name}</td>
+    <td>{$row.street_address}</td>
+    <td>{$row.city}</td>
+    <td>{$row.postal_code}</td>
+    <td>{$row.state_province}</td>
+    <td>{$row.country}</td>
+    <td>{$row.email}</td>
+    <td>{$row.phone}</td>
     {/if}
   </tr>
   {/foreach}


### PR DESCRIPTION
Overview
----------------------------------------
This  PR fixes HTML structure of search pages to make it unified to other search pages

Before
----------------------------------------
![before](https://user-images.githubusercontent.com/26058635/34989717-9d2a950c-fae9-11e7-9841-c0be666d995a.png)

After
----------------------------------------
![after](https://user-images.githubusercontent.com/26058635/34989723-9ee8ec2c-fae9-11e7-9389-764a3233c837.png)

---

 * [CRM-21663: Fix Campaign Search and result structure](https://issues.civicrm.org/jira/browse/CRM-21663)