### PR TITLE
CRM-21643 : Profile confirmation page shows the wrong values for multi-value custom data

### DIFF
--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -995,6 +995,13 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
     if (!$details->fetch()) {
       return;
     }
+    else {
+      // CRM-21643 : when a profile have custom field that contain multi value,
+      //  then traverse and fetch the last DAO object that contain the latest value
+      while ($details->fetch()) {
+        continue;
+      }
+    }
     $query->convertToPseudoNames($details);
     $config = CRM_Core_Config::singleton();
 


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate:
1. Create a custom field set that allows multiple records (for an Individual, say) 
2. Create a field in this set 
3. Create a new contact record with test@test.com 
4. On this contact record, populate the custom field with an initial entry. Enter 'first data' or similar. 
5. Create a profile with a) an email address field b) this custom field 
6. Set the profile settings to 'update the matching contact' 
7. Go to the profile list on Civi, click 'more' and go to 'Use - Create mode' 
8. Enter 'test@test.com' and 'second data', and submit the form 
9. The confirmation page shows 'first data'. 
Expected: The custom field should show the last data entered i.e. 'second data'
Before
----------------------------------------
![test-multiple-before](https://user-images.githubusercontent.com/3735621/34991528-f03fab1e-faef-11e7-9058-3b128c2d0bdb.gif)


After
----------------------------------------
![test-multiple-after](https://user-images.githubusercontent.com/3735621/34991554-0a4a4a50-faf0-11e7-96fc-92e8451070a7.gif)

---

 * [CRM-21643: Profile confirmation page shows the wrong values for multi-value custom data](https://issues.civicrm.org/jira/browse/CRM-21643)