### PR TITLE
CRM-21323 : Fix backend credit card payment processor selection

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -355,6 +355,11 @@ WHERE  contribution_id = {$id}
     elseif (empty($this->_paymentProcessors) || array_keys($this->_paymentProcessors) === array(0)) {
       throw new CRM_Core_Exception(ts('You will need to configure the %1 settings for your Payment Processor before you can submit a credit card transactions.', array(1 => $this->_mode)));
     }
+    //Assign submitted processor value if it is different from the loaded one.
+    if (!empty($this->_submitValues['payment_processor_id'])
+      && $this->_paymentProcessor['id'] != $this->_submitValues['payment_processor_id']) {
+      $this->_paymentProcessor = CRM_Financial_BAO_PaymentProcessor::getPayment($this->_submitValues['payment_processor_id']);
+    }
     $this->_processors = array();
     foreach ($this->_paymentProcessors as $id => $processor) {
       // @todo review this. The inclusion of this IF was to address test processors being incorrectly loaded.


### PR DESCRIPTION
Overview
----------------------------------------
Alternate fix for https://github.com/civicrm/civicrm-core/pull/11149

Before
----------------------------------------
Payment processor loads to a wrong value when a validation error is thrown on backend forms.

After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
the submitted processor wasn't attached to the Contribution/Event form object due to which it loaded the wrong processor on validation error.

---

 * [CRM-21323: Fix backend credit card payment processor selection](https://issues.civicrm.org/jira/browse/CRM-21323)