### PR TITLE
CRM-21667: Fixed timezone handoff from Drupal6.

### DIFF
--- a/CRM/Utils/System/Drupal6.php
+++ b/CRM/Utils/System/Drupal6.php
@@ -758,9 +758,18 @@ class CRM_Utils_System_Drupal6 extends CRM_Utils_System_DrupalBase {
     else {
       $timezone = variable_get('date_default_timezone', NULL);
     }
+
+    // Retrieved timezone will be represented as GMT offset in seconds but, according
+    // to the doc for the overridden method, ought to be returned as a region string
+    // (e.g., America/Havana).
+    if (strlen($timezone)) {
+      $timezone = timezone_name_from_abbr("", (int) $timezone, 0);
+    }
+
     if (!$timezone) {
       $timezone = parent::getTimeZoneString();
     }
+
     return $timezone;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Resolves errors resulting from representation of timezone data in different formats.

Before
----------------------------------------
One place this error can manifest is on the status screen (civicrm/a/#/status). The Angular frame will load with no content.

The error can also be reproduced by visiting the API explorer and doing api.system.check. The output will be something like:

> Error: DateTimeZone::__construct: Unknown or bad timezone (-14400)

After
----------------------------------------
Timezone data is converted from GMT offset in seconds to region string, as expected by related methods.

Technical Details
----------------------------------------
Nothing noteworthy here.

---

 * [CRM-21667: Bad timezone hand-off from CMS to CRM](https://issues.civicrm.org/jira/browse/CRM-21667)