### PR TITLE
CRM-21669 Consistent wording of Email - Send Now task

### DIFF
--- a/CRM/Activity/Task.php
+++ b/CRM/Activity/Task.php
@@ -93,7 +93,10 @@ class CRM_Activity_Task {
           'result' => FALSE,
         ),
         5 => array(
-          'title' => ts('Email - send now'),
+          'title' => ts('Email - send now (to %1 or less)', array(
+            1 => Civi::settings()
+              ->get('simple_mail_limit'),
+          )),
           'class' => array(
             'CRM_Activity_Form_Task_PickOption',
             'CRM_Activity_Form_Task_Email',

--- a/CRM/Contribute/Task.php
+++ b/CRM/Contribute/Task.php
@@ -90,7 +90,10 @@ class CRM_Contribute_Task {
           'result' => TRUE,
         ),
         5 => array(
-          'title' => ts('Email - send now'),
+          'title' => ts('Email - send now (to %1 or less)', array(
+            1 => Civi::settings()
+              ->get('simple_mail_limit'),
+          )),
           'class' => 'CRM_Contribute_Form_Task_Email',
           'result' => TRUE,
         ),

--- a/CRM/Event/Task.php
+++ b/CRM/Event/Task.php
@@ -101,7 +101,10 @@ class CRM_Event_Task {
           'result' => FALSE,
         ),
         6 => array(
-          'title' => ts('Email - send now'),
+          'title' => ts('Email - send now (to %1 or less)', array(
+            1 => Civi::settings()
+              ->get('simple_mail_limit'),
+          )),
           'class' => 'CRM_Event_Form_Task_Email',
           'result' => TRUE,
         ),

--- a/CRM/Member/Task.php
+++ b/CRM/Member/Task.php
@@ -85,7 +85,10 @@ class CRM_Member_Task {
           'result' => FALSE,
         ),
         4 => array(
-          'title' => ts('Email - send now'),
+          'title' => ts('Email - send now (to %1 or less)', array(
+            1 => Civi::settings()
+              ->get('simple_mail_limit'),
+          )),
           'class' => 'CRM_Member_Form_Task_Email',
           'result' => TRUE,
         ),


### PR DESCRIPTION
Overview
----------------------------------------
Recently a patch was merged to change the wording of the contact task "Email - Send Now" to "Email - Send Now (to 50 or less)".  However, this change should also have been made for Activity, Contribute, Event, Member tasks.

Technical Details
----------------------------------------
String changes only

---

 * [CRM-21669: Consistent wording for "Email - Send now" task](https://issues.civicrm.org/jira/browse/CRM-21669)