### PR TITLE
CRM-21672 fix intra-rc regression, fatal when deleting participants

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -2388,4 +2388,24 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     return $currency;
   }
 
+  /**
+   * Is the form in view or edit mode.
+   *
+   * The 'addField' function relies on the form action being one of a set list
+   * of actions. Checking for these allows for an early return.
+   *
+   * @return bool
+   */
+  protected function isFormInViewOrEditMode() {
+    return in_array($this->_action, [
+      CRM_Core_Action::UPDATE,
+      CRM_Core_Action::ADD,
+      CRM_Core_Action::VIEW,
+      CRM_Core_Action::BROWSE,
+      CRM_Core_Action::BASIC,
+      CRM_Core_Action::ADVANCED,
+      CRM_Core_Action::PREVIEW,
+    ]);
+  }
+
 }

--- a/CRM/Core/Form/Search.php
+++ b/CRM/Core/Form/Search.php
@@ -203,6 +203,9 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
    * Add generic fields that specify the contact.
    */
   protected function addContactSearchFields() {
+    if (!$this->isFormInViewOrEditMode()) {
+      return;
+    }
     $this->addSortNameField();
 
     $this->_group = CRM_Core_PseudoConstant::nestedGroup();


### PR DESCRIPTION
Overview
----------------------------------------
Follow up fix to recent merged change. Fixes fatal when deleting a participant

Before
----------------------------------------
Fatal error prevents deleting a participant

After
----------------------------------------
Screen works

Technical Details
----------------------------------------
The issue is the addField function relies on the form having a specific action. Instead of just not adding the field when a form is used in delete rather than view/create mode it fatals. I've never been terribly sold on re-using view/create forms for delete & I'm not convinced addField should fail so hard. However, here I've fixed it by doing an early return based on form action.

Comments
----------------------------------------
This was caused by a patch merged in the last few days

---

 * [CRM-21672: Intra-rc regression - fatal error on deleting participant](https://issues.civicrm.org/jira/browse/CRM-21672)