### PR TITLE
CRM-17647 fix for submitting payment with thousand separator

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -132,6 +132,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
     else {
       // @todo put a deprecated here - this should be done in the form layer.
       $params['skipCleanMoney'] = FALSE;
+      Civi::log()->warning('Deprecated code path. Money should always be clean before it hits the BAO.', array('civi.tag' => 'deprecated'));
     }
 
     foreach ($moneyFields as $field) {

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -986,7 +986,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
     }
     if ($this->_isPaidEvent) {
 
-      $contributionParams = array();
+      $contributionParams = array('skipCleanMoney' => TRUE);
       $lineItem = array();
       $additionalParticipantDetails = array();
       if (CRM_Contribute_BAO_Contribution::checkContributeSettings('deferred_revenue_enabled')) {

--- a/tests/phpunit/CRM/Core/Payment/AuthorizeNetTest.php
+++ b/tests/phpunit/CRM/Core/Payment/AuthorizeNetTest.php
@@ -88,7 +88,7 @@ class CRM_Core_Payment_AuthorizeNetTest extends CiviUnitTestCase {
       'is_test' => 1,
       'contribution_status_id' => 2,
     );
-    $contribution = CRM_Contribute_BAO_Contribution::add($contributionParams);
+    $contribution = $this->callAPISuccess('Contribution', 'create', $contributionParams);
 
     $params = array(
       'qfKey' => '08ed21c7ca00a1f7d32fff2488596ef7_4454',

--- a/tests/phpunit/CRM/Financial/BAO/FinancialAccountTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/FinancialAccountTest.php
@@ -145,7 +145,7 @@ class CRM_Financial_BAO_FinancialAccountTest extends CiviUnitTestCase {
       'financial_type_id' => $financialType->id,
       'contribution_status_id' => 1,
     );
-    $contributions = CRM_Contribute_BAO_Contribution::create($contributionParams);
+    $this->callAPISuccess('Contribution', 'create', $contributionParams);
     CRM_Financial_BAO_FinancialAccount::del($result->id);
     $params = array('id' => $result->id);
     $result = CRM_Financial_BAO_FinancialAccount::retrieve($params, $defaults);

--- a/tests/phpunit/CRM/Financial/BAO/FinancialTypeTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/FinancialTypeTest.php
@@ -268,6 +268,7 @@ class CRM_Financial_BAO_FinancialTypeTest extends CiviUnitTestCase {
       'contact_id' => $contactId,
       'financial_type_id' => 1,
       'contribution_status_id' => 1,
+      'skipCleanMoney' => TRUE,
     );
 
     foreach ($priceFields['values'] as $key => $priceField) {


### PR DESCRIPTION
Overview
----------------------------------------
Fix for truncation of amount when a payment separator is used

Before
----------------------------------------
Amount mis-recorded

After
----------------------------------------
Amount correctly recorded

Technical Details
----------------------------------------
The general fix for this is to convert amounts ASAP after form submission & not try to handle them in the BAO which does not know if they are already converted

Comments
----------------------------------------
Unfortunately there are a few places this can happen - we have a way of adding them to unit tests - I replicated one variant from the ticket in a test but not the other.

---

 * [CRM-17647: Recording payment truncates the amount after the comma \(whether thousands or decimal separator\)](https://issues.civicrm.org/jira/browse/CRM-17647)