### PR TITLE
CRM-17647 improve testing on the thousand separator.

### DIFF
--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -204,16 +204,14 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
       'trxn_id' => '33ereerwww322323',
       'invoice_id' => '33ed39c9e9ee6ef6031621ce0eafe6da70',
       'thankyou_date' => '20080522',
+      'sequential' => TRUE,
     );
 
-    $contribution = CRM_Contribute_BAO_Contribution::create($params);
+    $contribution = $this->callAPISuccess('Contribution', 'create', $params)['values'][0];
 
-    $this->assertEquals($params['trxn_id'], $contribution->trxn_id, 'Check for transcation id creation.');
-    $this->assertEquals($contactId, $contribution->contact_id, 'Check for contact id  creation.');
+    CRM_Contribute_BAO_Contribution::deleteContribution($contribution['id']);
 
-    CRM_Contribute_BAO_Contribution::deleteContribution($contribution->id);
-
-    $this->assertDBNull('CRM_Contribute_DAO_Contribution', $contribution->trxn_id,
+    $this->assertDBNull('CRM_Contribute_DAO_Contribution', $contribution['trxn_id'],
       'id', 'trxn_id', 'Database check for deleted Contribution.'
     );
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fix test to use the api

Before
----------------------------------------
Test calls CRM_Contribute_BAO_Contribution::create

After
----------------------------------------
Test calls $this->callAPISuccess()

Technical Details
----------------------------------------
As part of fixing thousand separator issues we can use the deprecated flag to identify when the
BAO_Contribution::create is called without skip_clean_money as we want to move all cleaning to
close to submit. First, however, we need to stop calling that function directly in the test suite
(or only call with skip_clean_money if we are specifically testing it).



Comments
----------------------------------------
Am checking how jenkins likes this format (which was no good on 5.3) & will change others if cheerful

---

 * [CRM-17647: Recording payment truncates the amount after the comma \(whether thousands or decimal separator\)](https://issues.civicrm.org/jira/browse/CRM-17647)