### PR TITLE
CRM-21674 allow lat & long to be pre-calculated for proximity query / search

### DIFF
--- a/CRM/Contact/BAO/ProximityQuery.php
+++ b/CRM/Contact/BAO/ProximityQuery.php
@@ -273,6 +273,8 @@ ACOS(
       'state_province' => 0,
       'country' => 0,
       'distance_unit' => 0,
+      'geo_code_1' => 0,
+      'geo_code_2' => 0,
     );
 
     $proximityAddress = array();
@@ -335,8 +337,10 @@ ACOS(
 
     $query->_tables['civicrm_address'] = $query->_whereTables['civicrm_address'] = 1;
 
-    if (!CRM_Core_BAO_Address::addGeocoderData($proximityAddress)) {
-      throw new CRM_Core_Exception(ts('Proximity searching requires you to set a valid geocoding provider'));
+    if (empty($proximityAddress['geo_code_1']) || empty($proximityAddress['geo_code_2'])) {
+      if (!CRM_Core_BAO_Address::addGeocoderData($proximityAddress)) {
+        throw new CRM_Core_Exception(ts('Proximity searching requires you to set a valid geocoding provider'));
+      }
     }
 
     if (

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2002,6 +2002,8 @@ class CRM_Contact_BAO_Query {
       case 'prox_postal_code':
       case 'prox_state_province_id':
       case 'prox_country_id':
+      case 'prox_geo_code_1':
+      case 'prox_geo_code_2':
         // handled by the proximity_distance clause
         return;
 

--- a/CRM/Contact/Form/Search/Custom/Proximity.php
+++ b/CRM/Contact/Form/Search/Custom/Proximity.php
@@ -135,6 +135,9 @@ class CRM_Contact_Form_Search_Custom_Proximity extends CRM_Contact_Form_Search_C
     $country = array('' => ts('- select -')) + CRM_Core_PseudoConstant::country();
     $form->add('select', 'country_id', ts('Country'), $country, TRUE, array('class' => 'crm-select2'));
 
+    $form->add('text', 'geo_code_1', ts('Latitude'));
+    $form->add('text', 'geo_code_2', ts('Longitude'));
+
     $group = array('' => ts('- any group -')) + CRM_Core_PseudoConstant::nestedGroup();
     $form->addElement('select', 'group', ts('Group'), $group, array('class' => 'crm-select2 huge'));
 

--- a/templates/CRM/Contact/Form/Search/Custom/Proximity.tpl
+++ b/templates/CRM/Contact/Form/Search/Custom/Proximity.tpl
@@ -35,13 +35,17 @@
         <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
         <table class="form-layout-compressed">
            <tr><td class="label">{$form.distance.label}</td><td>{$form.distance.html|crmAddClass:four} {$form.prox_distance_unit.html}</td></tr>
-           <tr><td class="label">FROM...</td><td></td></tr>
+           <tr><td class="label">{ts}FROM...{/ts}</td><td></td></tr>
            <tr><td class="label">{$form.street_address.label}</td><td>{$form.street_address.html}</td></tr>
            <tr><td class="label">{$form.city.label}</td><td>{$form.city.html}</td></tr>
            <tr><td class="label">{$form.postal_code.label}</td><td>{$form.postal_code.html}</td></tr>
            <tr><td class="label">{$form.country_id.label}</td><td>{$form.country_id.html}</td></tr>
            <tr><td class="label" style="white-space: nowrap;">{$form.state_province_id.label}</td><td>{$form.state_province_id.html}</td></tr>
-           <tr><td class="label">AND ...</td><td></td></tr>
+           <tr><td class="label">{ts}OR enter lattitude and longitude if you already know it{/ts}.</td><td></td></tr>
+           <tr><td class="label" style="white-space: nowrap;">{$form.geo_code_1.label}</td><td>{$form.geo_code_1.html}</td></tr>
+           <tr><td class="label" style="white-space: nowrap;">{$form.geo_code_2.label}</td><td>{$form.geo_code_2.html}</td></tr>
+           <tr><td class="label">{ts}AND ...{/ts}</td><td></td></tr>
+           <tr><td class="label">{ts}Restrict results by ...{/ts}</td><td></td></tr>
            <tr><td class="label">{$form.group.label}</td><td>{$form.group.html}</td></tr>
            <tr><td class="label">{$form.tag.label}</td><td>{$form.tag.html}</td></tr>
         </table>

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -3524,6 +3524,34 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     $this->callAPISuccess('contact', 'delete', array('id' => $created_contact_id, 'skip_undelete' => TRUE));
   }
 
+  /**
+   * Test the prox_distance functionality works.
+   *
+   * This is primarily testing functionality in the BAO_Query object that 'happens to be'
+   * accessible via the api.
+   */
+  public function testContactGetProximity() {
+    CRM_Core_Config::singleton()->geocodeMethod = 'CRM_Utils_MockGeocoder';
+    $this->individualCreate();
+    $contactID = $this->individualCreate();
+    $this->callAPISuccess('Address', 'create', [
+      'contact_id' => $contactID,
+      'is_primary' => 1,
+      'city' => 'Whangarei',
+      'street_address' => 'Dent St',
+      'geo_code_1' => '-35.8743325',
+      'geo_code_2' => '174.4567136',
+      'location_type_id' => 'Home',
+    ]);
+    $contact = $this->callAPISuccess('Contact', 'get', [
+      'prox_distance' => 100,
+      'prox_geo_code_1' => '-35.72192',
+      'prox_geo_code_2' => '174.32034',
+    ]);
+    $this->assertEquals(1, $contact['count']);
+    $this->assertEquals($contactID, $contact['id']);
+  }
+
   public function testLoggedInUserAPISupportToken() {
     $description = "Get contact id of the current logged in user";
     $subFile = "ContactIDOfLoggedInUserContactAPI";


### PR DESCRIPTION
Overview
----------------------------------------
Allow calling function to calculate the lat & long before calling proximity query and allow that to be entered in the proximity custom search

Before
----------------------------------------
civicrm_api3('Contact', 'get', ['prox_distance' => 4]);
required address fields like 'prox_city' to calculate the centre point

Proximity search:
![screenshot 2018-02-07 15 15 46](https://user-images.githubusercontent.com/336308/35894897-cf062654-0c19-11e8-8fa4-6d5e86ec009b.png)


After
----------------------------------------
'prox_geo_code_1' & 'prox_geo_code_2' can be passed in instead of address fields

If people know the geoco-ordinates they can self enter them.

![screenshot 2018-02-07 15 16 32](https://user-images.githubusercontent.com/336308/35894917-e93786e4-0c19-11e8-8f64-6aaa500316ca.png)


Technical Details
----------------------------------------
The BAO (& by extension api) supports parameters in contact.get for proximity searching. prox_distance is a required param for this & if submitted the following parameters are used to calculate the centre point


'prox_street_address' 
'prox_city' 
'prox_postal_code' 
'prox_state_province_id'
'prox_country_id' 
'prox_state_province' ,
'prox_country' 
'prox_distance_unit' ,

I wish to make it such that those parameters are optional & not used if 'prox_geo_code_1' & 'prox_geo_code_2' are supplied. 

Comments
----------------------------------------
The immediate use case is to get a unit test added & allow people to search if their geocoder won't accurately find their co-ordinates

Later I also want this toimprove the code in the custom proximity search so that it can use the main group filter (currently smart groups don't work)

b) add the UI option of specifying lat & long rather than an address where preferred (not all coordinates have an address!)

- This depends on #11540 so I'll rebase once that is merged. Once agreed I can do a PR to add these (previously working but undocumented params) to the api doc - although perhaps only as they have unit tests working

---

 * [CRM-21674: Allow proximity search to accept lat & long at the BAO\/api level](https://issues.civicrm.org/jira/browse/CRM-21674)