### PR TITLE
Fix mock test data for PaymentProcessor object.

### DIFF
--- a/CRM/Financial/BAO/PaymentProcessor.php
+++ b/CRM/Financial/BAO/PaymentProcessor.php
@@ -565,4 +565,21 @@ INNER JOIN civicrm_contribution       con ON ( mp.contribution_id = con.id )
     return Civi\Payment\System::singleton()->getById($paymentProcessorId);
   }
 
+  /**
+   * Generate and assign an arbitrary value to a field of a test object.
+   *
+   * @param string $fieldName
+   * @param array $fieldDef
+   * @param int $counter
+   *   The globally-unique ID of the test object.
+   */
+  protected function assignTestValue($fieldName, &$fieldDef, $counter) {
+    if ($fieldName === 'class_name') {
+      $this->class_name = 'Payment_Dummy';
+    }
+    else {
+      parent::assignTestValue($fieldName, $fieldDef, $counter);
+    }
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
This only affects unit tests. When dummy data is generated for a PaymentProcessor it will be more
usable

Before
----------------------------------------
Tests pass

After
----------------------------------------
Tests pass 

Technical Details
----------------------------------------
This improves the data created during testing when calling CRM_Core_DAO::createTestObject()

Comments
----------------------------------------
No impact outside unit tests