### PR TITLE
CRM-17647 test fixes towards ensuring we never rely on the BAO to cle…

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4940,7 +4940,7 @@ WHERE eft.financial_trxn_id IN ({$trxnId}, {$baseTrxnId['financialTrxnId']})
     $contributionStatus = CRM_Core_PseudoConstant::get('CRM_Contribute_DAO_Contribution', 'contribution_status_id', array(
       'labelColumn' => 'name',
     ));
-    foreach ($contributions as $k => $contribution) {
+    foreach ($contributions as $contribution) {
       if (!($contributionStatus[$contribution->contribution_status_id] == 'Partially paid'
         || CRM_Utils_Array::value($contributionStatusId, $contributionStatus) == 'Partially paid')
       ) {

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -61,22 +61,23 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
       'trxn_id' => '22ereerwww444444',
       'invoice_id' => '86ed39c9e9ee6ef6031621ce0eafe7eb81',
       'thankyou_date' => '20080522',
+      'sequential' => TRUE,
     );
 
-    $contribution = CRM_Contribute_BAO_Contribution::create($params);
+    $contribution = $this->callAPISuccess('Contribution', 'create', $params)['values'][0];
 
-    $this->assertEquals($params['trxn_id'], $contribution->trxn_id, 'Check for transaction id creation.');
-    $this->assertEquals($contactId, $contribution->contact_id, 'Check for contact id  creation.');
+    $this->assertEquals($params['trxn_id'], $contribution['trxn_id'], 'Check for transaction id creation.');
+    $this->assertEquals($contactId, $contribution['contact_id'], 'Check for contact id  creation.');
 
     //update contribution amount
-    $ids = array('contribution' => $contribution->id);
+    $params['id'] = $contribution['id'];
     $params['fee_amount'] = 10;
     $params['net_amount'] = 190;
 
-    $contribution = CRM_Contribute_BAO_Contribution::create($params, $ids);
+    $contribution = $this->callAPISuccess('Contribution', 'create', $params)['values'][0];
 
-    $this->assertEquals($params['trxn_id'], $contribution->trxn_id, 'Check for transcation id .');
-    $this->assertEquals($params['net_amount'], $contribution->net_amount, 'Check for Amount updation.');
+    $this->assertEquals($params['trxn_id'], $contribution['trxn_id'], 'Check for transcation id .');
+    $this->assertEquals($params['net_amount'], $contribution['net_amount'], 'Check for Amount updation.');
   }
 
   /**
@@ -116,6 +117,7 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
       'trxn_id' => '22ereerwww322323',
       'invoice_id' => '22ed39c9e9ee6ef6031621ce0eafe6da70',
       'thankyou_date' => '20080522',
+      'skipCleanMoney' => TRUE,
     );
 
     $params['custom'] = array(
@@ -175,8 +177,8 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
       'invoice_id' => '22ed39c9e9ee6ef6031621ce0eafe6da70',
       'thankyou_date' => '20080522',
     );
-    $contribution = CRM_Contribute_BAO_Contribution::create($params);
-    $testResult = $this->callAPISuccess('financial_type', 'create', array('is_active' => 0, 'id' => $finType['id']));
+    $this->callAPISuccess('Contribution', 'create', $params);
+    $this->callAPISuccess('financial_type', 'create', array('is_active' => 0, 'id' => $finType['id']));
     $contributionCount = CRM_Contribute_BAO_Contribution::contributionCount($contactId);
     $this->assertEquals(1, $contributionCount);
   }
@@ -258,14 +260,15 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
       'contribution_status_id' => 1,
       'receive_date' => date('Ymd'),
       'total_amount' => 66,
+      'sequential' => 1,
     );
 
-    $contribution = CRM_Contribute_BAO_Contribution::create($param);
-    $id = $contribution->id;
+    $contribution = $this->callAPISuccess('Contribution', 'create', $param)['values'][0];
+    $id = $contribution['id'];
     $softParam['contact_id'] = $honoreeContactId;
     $softParam['contribution_id'] = $id;
-    $softParam['currency'] = $contribution->currency;
-    $softParam['amount'] = $contribution->total_amount;
+    $softParam['currency'] = $contribution['currency'];
+    $softParam['amount'] = $contribution['total_amount'];
 
     //Create Soft Contribution for honoree contact
     CRM_Contribute_BAO_ContributionSoft::add($softParam);
@@ -296,8 +299,7 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
     //get annual contribution information
     $annual = CRM_Contribute_BAO_Contribution::annual($contactId);
 
-    $config = CRM_Core_Config::singleton();
-    $currencySymbol = CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_Currency', $config->defaultCurrency, 'symbol', 'name');
+    $currencySymbol = CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_Currency', CRM_Core_Config::singleton()->defaultCurrency, 'symbol', 'name');
     $this->assertDBCompareValue('CRM_Contribute_DAO_Contribution', $id, 'total_amount',
       'id', ltrim($annual[2], $currencySymbol), 'Check DB for total amount of the contribution'
     );
@@ -321,9 +323,6 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
     $this->assertInstanceOf('CRM_Contact_DAO_Contact', $contact, 'Check for created object');
 
     $contactId = $contact->id;
-
-    $ids = array('contribution' => NULL);
-
     $param = array(
       'contact_id' => $contactId,
       'currency' => 'USD',
@@ -341,15 +340,16 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
       'trxn_id' => '22ereerwww323',
       'invoice_id' => '22ed39c9e9ee621ce0eafe6da70',
       'thankyou_date' => '20080522',
+      'sequential' => TRUE,
     );
 
-    $contribution = CRM_Contribute_BAO_Contribution::create($param, $ids);
+    $contribution = $this->callAPISuccess('Contribution', 'create', $param)['values'][0];
 
-    $this->assertEquals($param['trxn_id'], $contribution->trxn_id, 'Check for transcation id creation.');
-    $this->assertEquals($contactId, $contribution->contact_id, 'Check for contact id  creation.');
+    $this->assertEquals($param['trxn_id'], $contribution['trxn_id'], 'Check for transcation id creation.');
+    $this->assertEquals($contactId, $contribution['contact_id'], 'Check for contact id  creation.');
 
     //display sort name during Update multiple contributions
-    $sortName = CRM_Contribute_BAO_Contribution::sortName($contribution->id);
+    $sortName = CRM_Contribute_BAO_Contribution::sortName($contribution['id']);
 
     $this->assertEquals('Whatson, Shane', $sortName, 'Check for sort name.');
   }
@@ -380,8 +380,6 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
 
     $this->assertEquals('TEST Premium', $premium->name, 'Check for premium  name.');
 
-    $ids = array('contribution' => NULL);
-
     $param = array(
       'contact_id' => $contactId,
       'currency' => 'USD',
@@ -399,17 +397,17 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
       'trxn_id' => '33erdfrwvw434',
       'invoice_id' => '98ed34f7u9hh672ce0eafe8fb92',
       'thankyou_date' => '20080522',
+      'sequential' => TRUE,
     );
+    $contribution = $this->callAPISuccess('Contribution', 'create', $param)['values'][0];
 
-    $contribution = CRM_Contribute_BAO_Contribution::create($param, $ids);
-
-    $this->assertEquals($param['trxn_id'], $contribution->trxn_id, 'Check for transcation id creation.');
-    $this->assertEquals($contactId, $contribution->contact_id, 'Check for contact id  creation.');
+    $this->assertEquals($param['trxn_id'], $contribution['trxn_id'], 'Check for transcation id creation.');
+    $this->assertEquals($contactId, $contribution['contact_id'], 'Check for contact id  creation.');
 
     //parameter for adding premium to contribution
     $data = array(
       'product_id' => $premium->id,
-      'contribution_id' => $contribution->id,
+      'contribution_id' => $contribution['id'],
       'product_option' => NULL,
       'quantity' => 1,
     );
@@ -448,19 +446,20 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
       'trxn_id' => '76ereeswww835',
       'invoice_id' => '93ed39a9e9hd621bs0eafe3da82',
       'thankyou_date' => '20080522',
+      'sequential' => TRUE,
     );
 
-    $contribution = CRM_Contribute_BAO_Contribution::create($param);
+    $contribution = $this->callAPISuccess('Contribution', 'create', $param)['values'][0];
 
-    $this->assertEquals($param['trxn_id'], $contribution->trxn_id, 'Check for transcation id creation.');
-    $this->assertEquals($contactId, $contribution->contact_id, 'Check for contact id  creation.');
+    $this->assertEquals($param['trxn_id'], $contribution['trxn_id'], 'Check for transcation id creation.');
+    $this->assertEquals($contactId, $contribution['contact_id'], 'Check for contact id  creation.');
     $data = array(
-      'id' => $contribution->id,
-      'trxn_id' => $contribution->trxn_id,
-      'invoice_id' => $contribution->invoice_id,
+      'id' => $contribution['id'],
+      'trxn_id' => $contribution['trxn_id'],
+      'invoice_id' => $contribution['invoice_id'],
     );
     $contributionID = CRM_Contribute_BAO_Contribution::checkDuplicateIds($data);
-    $this->assertEquals($contributionID, $contribution->id, 'Check for duplicate transcation id .');
+    $this->assertEquals($contributionID, $contribution['id'], 'Check for duplicate transcation id .');
   }
 
   /**
@@ -488,12 +487,13 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
       'trxn_id' => '76ereeswww835',
       'invoice_id' => '93ed39a9e9hd621bs0eafe3da82',
       'thankyou_date' => '20080522',
+      'sequential' => TRUE,
     );
 
     $creditNoteId = CRM_Contribute_BAO_Contribution::createCreditNoteId();
-    $contribution = CRM_Contribute_BAO_Contribution::create($param);
-    $this->assertEquals($contactId, $contribution->contact_id, 'Check for contact id  creation.');
-    $this->assertEquals($creditNoteId, $contribution->creditnote_id, 'Check if credit note id is created correctly.');
+    $contribution = $this->callAPISuccess('Contribution', 'create', $param)['values'][0];
+    $this->assertEquals($contactId, $contribution['contact_id'], 'Check for contact id  creation.');
+    $this->assertEquals($creditNoteId, $contribution['creditnote_id'], 'Check if credit note id is created correctly.');
   }
 
   /**
@@ -502,7 +502,7 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
   public function testIsPaymentFlag() {
     $contactId = $this->individualCreate();
 
-    $params = array(
+    $params = [
       'contact_id' => $contactId,
       'currency' => 'USD',
       'financial_type_id' => 1,
@@ -518,12 +518,12 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
       'trxn_id' => '22ereerwww4444xx',
       'invoice_id' => '86ed39c9e9ee6ef6541621ce0eafe7eb81',
       'thankyou_date' => '20080522',
-    );
+      'sequential' => TRUE,
+    ];
+    $contribution = $this->callAPISuccess('Contribution', 'create', $params)['values'][0];
 
-    $contribution = CRM_Contribute_BAO_Contribution::create($params);
-
-    $this->assertEquals($params['trxn_id'], $contribution->trxn_id, 'Check for transcation id creation.');
-    $this->assertEquals($contactId, $contribution->contact_id, 'Check for contact id  creation.');
+    $this->assertEquals($params['trxn_id'], $contribution['trxn_id'], 'Check for transcation id creation.');
+    $this->assertEquals($contactId, $contribution['contact_id'], 'Check for contact id  creation.');
 
     $trxnArray = array(
       'trxn_id' => $params['trxn_id'],
@@ -533,13 +533,12 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
     $financialTrxn = CRM_Core_BAO_FinancialTrxn::retrieve($trxnArray, $defaults);
     $this->assertEquals(1, $financialTrxn->N, 'Mismatch count for is payment flag.');
     //update contribution amount
-    $ids = array('contribution' => $contribution->id);
+    $params['id'] = $contribution['id'];
     $params['total_amount'] = 150;
+    $contribution = $this->callAPISuccess('Contribution', 'create', $params)['values'][0];
 
-    $contribution = CRM_Contribute_BAO_Contribution::create($params, $ids);
-
-    $this->assertEquals($params['trxn_id'], $contribution->trxn_id, 'Check for transcation id .');
-    $this->assertEquals($params['total_amount'], $contribution->total_amount, 'Check for Amount updation.');
+    $this->assertEquals($params['trxn_id'], $contribution['trxn_id'], 'Check for transcation id .');
+    $this->assertEquals($params['total_amount'], $contribution['total_amount'], 'Check for Amount updation.');
     $trxnArray = array(
       'trxn_id' => $params['trxn_id'],
       'is_payment' => 1,
@@ -575,12 +574,13 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
       'trxn_id' => '22ereerwww4444yy',
       'invoice_id' => '86ed39c9e9yy6ef6541621ce0eafe7eb81',
       'thankyou_date' => '20080522',
+      'sequential' => TRUE,
     );
 
-    $contribution = CRM_Contribute_BAO_Contribution::create($params);
+    $contribution = $this->callAPISuccess('Contribution', 'create', $params)['values'][0];
 
-    $this->assertEquals($params['trxn_id'], $contribution->trxn_id, 'Check for transcation id creation.');
-    $this->assertEquals($contactId, $contribution->contact_id, 'Check for contact id  creation.');
+    $this->assertEquals($params['trxn_id'], $contribution['trxn_id'], 'Check for transaction id creation.');
+    $this->assertEquals($contactId, $contribution['contact_id'], 'Check for contact id  creation.');
 
     $trxnArray = array(
       'trxn_id' => $params['trxn_id'],
@@ -593,13 +593,13 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
     $financialTrxn = CRM_Core_BAO_FinancialTrxn::retrieve($trxnArray, $defaults);
     $this->assertEquals(NULL, $financialTrxn, 'Mismatch count for is payment flag.');
     //update contribution amount
-    $ids = array('contribution' => $contribution->id);
+    $params['id'] = $contribution['id'];
     $params['contribution_status_id'] = 1;
 
-    $contribution = CRM_Contribute_BAO_Contribution::create($params, $ids);
+    $contribution = $this->callAPISuccess('Contribution', 'create', $params)['values'][0];
 
-    $this->assertEquals($params['trxn_id'], $contribution->trxn_id, 'Check for transcation id .');
-    $this->assertEquals($params['contribution_status_id'], $contribution->contribution_status_id, 'Check for status updation.');
+    $this->assertEquals($params['trxn_id'], $contribution['trxn_id'], 'Check for transcation id .');
+    $this->assertEquals($params['contribution_status_id'], $contribution['contribution_status_id'], 'Check for status updation.');
     $trxnArray = array(
       'trxn_id' => $params['trxn_id'],
       'is_payment' => 1,
@@ -617,7 +617,7 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
    */
   public function testAddPayments() {
     list($lineItems, $contribution) = $this->addParticipantWithContribution();
-    CRM_Contribute_BAO_Contribution::addPayments(array($contribution));
+    CRM_Contribute_BAO_Contribution::addPayments([$contribution]);
     $this->checkItemValues($contribution);
   }
 
@@ -726,6 +726,7 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
       'partial_amount_to_pay' => 150,
       'contribution_mode' => 'participant',
       'participant_id' => $participant->id,
+      'sequential' => TRUE,
     );
 
     foreach ($priceFields['values'] as $key => $priceField) {
@@ -741,16 +742,20 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
       );
     }
     $contributionParams['line_item'] = $lineItems;
-    $contributions = CRM_Contribute_BAO_Contribution::create($contributionParams);
+    $contribution = $this->callAPISuccess('Contribution', 'create', $contributionParams)['values'][0];
 
     $paymentParticipant = array(
       'participant_id' => $participant->id,
-      'contribution_id' => $contributions->id,
+      'contribution_id' => $contribution['id'],
     );
     $ids = array();
     CRM_Event_BAO_ParticipantPayment::create($paymentParticipant, $ids);
 
-    return array($lineItems, $contributions);
+    $contributionObject = new CRM_Contribute_BAO_Contribution();
+    $contributionObject->id = $contribution['id'];
+    $contributionObject->find(TRUE);
+
+    return array($lineItems, $contributionObject);
   }
 
   /**
@@ -822,37 +827,37 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
       'trxn_id' => '22ereerwww444444',
       'invoice_id' => '86ed39c9e9ee6ef6031621ce0eafe7eb81',
       'thankyou_date' => '20160519',
+      'sequential' => 1,
     );
 
-    $contribution = CRM_Contribute_BAO_Contribution::create($params);
+    $contribution = $this->callAPISuccess('Contribution', 'create', $params)['values'][0];
 
-    $this->assertEquals($params['total_amount'], $contribution->total_amount, 'Check for total amount in contribution.');
-    $this->assertEquals($contactId, $contribution->contact_id, 'Check for contact id  creation.');
+    $this->assertEquals($params['total_amount'], $contribution['total_amount'], 'Check for total amount in contribution.');
+    $this->assertEquals($contactId, $contribution['contact_id'], 'Check for contact id  creation.');
 
     // Check amount in activity.
     $activityParams = array(
-      'source_record_id' => $contribution->id,
+      'source_record_id' => $contribution['id'],
       'activity_type_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Contribution'),
     );
     // @todo use api instead.
     $activity = CRM_Activity_BAO_Activity::retrieve($activityParams, $defaults);
 
-    $this->assertEquals($contribution->id, $activity->source_record_id, 'Check for activity associated with contribution.');
+    $this->assertEquals($contribution['id'], $activity->source_record_id, 'Check for activity associated with contribution.');
     $this->assertEquals("$ 100.00 - STUDENT", $activity->subject, 'Check for total amount in activity.');
 
-    // Update contribution amount.
-    $ids = array('contribution' => $contribution->id);
+    $params['id'] = $contribution['id'];
     $params['total_amount'] = 200;
 
-    $contribution = CRM_Contribute_BAO_Contribution::create($params, $ids);
+    $contribution = $this->callAPISuccess('Contribution', 'create', $params)['values'][0];
 
-    $this->assertEquals($params['total_amount'], $contribution->total_amount, 'Check for total amount in contribution.');
-    $this->assertEquals($contactId, $contribution->contact_id, 'Check for contact id  creation.');
+    $this->assertEquals($params['total_amount'], $contribution['total_amount'], 'Check for total amount in contribution.');
+    $this->assertEquals($contactId, $contribution['contact_id'], 'Check for contact id  creation.');
 
     // Retrieve activity again.
     $activity = CRM_Activity_BAO_Activity::retrieve($activityParams, $defaults);
 
-    $this->assertEquals($contribution->id, $activity->source_record_id, 'Check for activity associated with contribution.');
+    $this->assertEquals($contribution['id'], $activity->source_record_id, 'Check for activity associated with contribution.');
     $this->assertEquals("$ 200.00 - STUDENT", $activity->subject, 'Check for total amount in activity.');
   }
 
@@ -1053,8 +1058,8 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
       'partial_amount_to_pay' => '8,000.00',
     );
 
-    $contribution = CRM_Contribute_BAO_Contribution::create($params);
-    $lastFinancialTrxnId = CRM_Core_BAO_FinancialTrxn::getFinancialTrxnId($contribution->id, 'DESC');
+    $contribution = $this->callAPISuccess('Contribution', 'create', $params);
+    $lastFinancialTrxnId = CRM_Core_BAO_FinancialTrxn::getFinancialTrxnId($contribution['id'], 'DESC');
     $financialTrxn = $this->callAPISuccessGetSingle(
       'FinancialTrxn',
       array(

--- a/tests/phpunit/CRM/Financial/BAO/FinancialItemTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/FinancialItemTest.php
@@ -295,15 +295,15 @@ class CRM_Financial_BAO_FinancialItemTest extends CiviUnitTestCase {
       'invoice_id' => '86ed39c9e9ee6ef6031621ce0eafe7eb81',
     );
 
-    $contribution = CRM_Contribute_BAO_Contribution::create($params);
+    $contribution = $this->callAPISuccess('Contribution', 'create', $params);
 
     $params = array(
-      'id' => $contribution->id,
+      'id' => $contribution['id'],
       'total_amount' => 300.00,
     );
 
-    $contribution = CRM_Contribute_BAO_Contribution::create($params);
-    $financialItem = CRM_Financial_BAO_FinancialItem::getPreviousFinancialItem($contribution->id);
+    $contribution = $this->callAPISuccess('Contribution', 'create', $params);
+    $financialItem = CRM_Financial_BAO_FinancialItem::getPreviousFinancialItem($contribution['id']);
     $params = array('id' => $financialItem['id']);
     $financialItem = $this->callAPISuccess('FinancialItem', 'get', $params);
     $this->assertEquals(200.00, $financialItem['values'][$financialItem['id']]['amount'], "The amounts do not match.");


### PR DESCRIPTION
Overview
----------------------------------------
We need to deprecate out BAO cleaning of money. Test fixes ensure we use the (safe) api rather than BAO::create - no functional change

Before
----------------------------------------
tests call CRM_Contribute_BAO_Contribution::create

After
----------------------------------------
tests call $this-callApiSuccess('Contribution', 'create', $params);
In the one instance it felt the BAO method should be tested (arguable since the api tests it anyway) I used 'skipCleanMoney'

Technical Details
----------------------------------------
per above

Comments
----------------------------------------
test changes only
