### PR TITLE
CRM-17647 fix for submitting payment with thousand separator

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -222,6 +222,15 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
   public $billingFieldSets = array();
 
   /**
+   * Monetary fields that may be submitted.
+   *
+   * These should get a standardised format in the beginPostProcess function.
+   *
+   * These fields are common to many forms. Some may override this.
+   */
+  protected $submittableMoneyFields = ['total_amount', 'net_amount', 'non_deductible_amount', 'fee_amount'];
+
+  /**
    * Pre process function with common actions.
    */
   public function preProcess() {
@@ -562,6 +571,11 @@ WHERE  contribution_id = {$id}
     $this->_params['ip_address'] = CRM_Utils_System::ipAddress();
 
     self::formatCreditCardDetails($this->_params);
+    foreach ($this->submittableMoneyFields as $moneyField) {
+      if (isset($this->_params[$moneyField])) {
+        $this->_params[$moneyField] = CRM_Utils_Rule::cleanMoney($this->_params[$moneyField]);
+      }
+    }
   }
 
   /**

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -204,6 +204,13 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
   protected $statusMessageTitle;
 
   /**
+   * Explicitly declare the form context.
+   */
+  public function getDefaultContext() {
+    return 'create';
+  }
+
+  /**
    * Set variables up before form is built.
    */
   public function preProcess() {
@@ -1420,6 +1427,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       // would cause breakage for negative values in some cases.
       $submittedValues['total_amount'] = CRM_Utils_Array::value('amount', $submittedValues);
     }
+
     if ($this->_id) {
       if ($this->_compId) {
         if ($this->_context == 'participant') {

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -2400,6 +2400,7 @@ WHERE      civicrm_membership.is_test = 0";
     $contributionParams['receipt_date'] = (CRM_Utils_Array::value('receipt_date', $params)) ? $params['receipt_date'] : 'null';
     $contributionParams['source'] = CRM_Utils_Array::value('contribution_source', $params);
     $contributionParams['non_deductible_amount'] = 'null';
+    $contributionParams['skipCleanMoney'] = TRUE;
     $contributionParams['payment_processor'] = CRM_Utils_Array::value('payment_processor_id', $params);
     $contributionSoftParams = CRM_Utils_Array::value('soft_credit', $params);
     $recordContribution = array(

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -143,11 +143,16 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
 
   /**
    * Test the submit function on the contribution page.
+   *
+   * @param string $thousandSeparator
+   *
+   * @dataProvider getThousandSeparators
    */
-  public function testSubmit() {
+  public function testSubmit($thousandSeparator) {
+    $this->setCurrencySeparators($thousandSeparator);
     $form = new CRM_Contribute_Form_Contribution();
     $form->testSubmit(array(
-      'total_amount' => 50,
+      'total_amount' => $this->formatMoneyInput(1234),
       'financial_type_id' => 1,
       'receive_date' => '04/21/2015',
       'receive_date_time' => '11:27PM',
@@ -158,6 +163,8 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
       CRM_Core_Action::ADD);
     $contribution = $this->callAPISuccessGetSingle('Contribution', array('contact_id' => $this->_individualId));
     $this->assertEmpty($contribution['amount_level']);
+    $this->assertEquals(1234, $contribution['total_amount']);
+    $this->assertEquals(1234, $contribution['net_amount']);
   }
 
   /**

--- a/tests/phpunit/CRM/Event/Form/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Form/ParticipantTest.php
@@ -176,8 +176,13 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
 
   /**
    * Test offline participant mail.
+   *
+   * @param string $thousandSeparator
+   *
+   * @dataProvider getThousandSeparators
    */
-  public function testParticipantOfflineReceipt() {
+  public function testParticipantOfflineReceipt($thousandSeparator) {
+    $this->setCurrencySeparators($thousandSeparator);
     $mut = new CiviMailUtils($this, TRUE);
 
     //Get workflow id of event_offline receipt.
@@ -202,11 +207,12 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
       'msg_html' => $newMsg,
     ));
 
-    $this->testSubmitWithPayment();
+    $this->testSubmitWithPayment($thousandSeparator);
     //Check if type is correctly populated in mails.
-    $mail = $mut->checkMailLog(array(
+    $mail = $mut->checkMailLog([
         '<p>Test event type - 1</p>',
-      )
+        $this->formatMoneyInput(1550.55),
+      ]
     );
   }
 

--- a/tests/phpunit/CRM/Event/Form/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Form/ParticipantTest.php
@@ -119,9 +119,14 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
   /**
    * Initial test of submit function.
    *
+   * @param string $thousandSeparator
+   *
+   * @dataProvider getThousandSeparators
+   *
    * @throws \Exception
    */
-  public function testSubmitWithPayment() {
+  public function testSubmitWithPayment($thousandSeparator) {
+    $this->setCurrencySeparators($thousandSeparator);
     $form = $this->getForm(array('is_monetary' => 1, 'financial_type_id' => 1));
     $form->_mode = 'Live';
     $form->_quickConfig = TRUE;
@@ -156,8 +161,8 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
         13 => 1,
       ),
       'amount_level' => 'Too much',
-      'fee_amount' => 55,
-      'total_amount' => 55,
+      'fee_amount' => $this->formatMoneyInput(1550.55),
+      'total_amount' => $this->formatMoneyInput(1550.55),
       'from_email_address' => 'abc@gmail.com',
       'send_receipt' => 1,
       'receipt_text' => '',
@@ -165,7 +170,7 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
     $participants = $this->callAPISuccess('Participant', 'get', array());
     $this->assertEquals(1, $participants['count']);
     $contribution = $this->callAPISuccessGetSingle('Contribution', array());
-    $this->assertEquals(55, $contribution['total_amount']);
+    $this->assertEquals(1550.55, $contribution['total_amount']);
     $this->assertEquals('Debit Card', $contribution['payment_instrument']);
   }
 

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -430,8 +430,13 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
 
   /**
    * Test the submit function of the membership form.
+   *
+   * @param string $thousandSeparator
+   *
+   * @dataProvider getThousandSeparators
    */
-  public function testSubmit() {
+  public function testSubmit($thousandSeparator) {
+    $this->setCurrencySeparators($thousandSeparator);
     $form = $this->getForm();
     $form->preProcess();
     $this->mut = new CiviMailUtils($this, TRUE);
@@ -448,7 +453,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
       'max_related' => '',
       'num_terms' => '1',
       'source' => '',
-      'total_amount' => '50.00',
+      'total_amount' => $this->formatMoneyInput(1234.56),
       'financial_type_id' => '2', //Member dues, see data.xml
       'soft_credit_type_id' => '',
       'soft_credit_contact_id' => '',
@@ -500,7 +505,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
 
     $this->_checkFinancialRecords(array(
       'id' => $contribution['id'],
-      'total_amount' => 50,
+      'total_amount' => 1234.56,
       'financial_account_id' => 2,
       'payment_instrument_id' => $this->callAPISuccessGetValue('PaymentProcessor', array(
         'id' => $this->_paymentProcessorID,
@@ -508,7 +513,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
       )),
     ), 'online');
     $this->mut->checkMailLog(array(
-      '50',
+      CRM_Utils_Money::format('1234.56'),
       'Receipt text',
     ));
     $this->mut->stop();


### PR DESCRIPTION
Overview
----------------------------------------
rc version of #11539

Note this does not cover all instances of mishandling the thousand separator - I believe they are well identified in #18839 but I am working through them
---

 * [CRM-17647: Recording payment truncates the amount after the comma \(whether thousands or decimal separator\)](https://issues.civicrm.org/jira/browse/CRM-17647)