### PR TITLE
CRM-17647 fix for currency on batch entry

### DIFF
--- a/tests/phpunit/CRM/Batch/Form/EntryTest.php
+++ b/tests/phpunit/CRM/Batch/Form/EntryTest.php
@@ -83,7 +83,7 @@ class CRM_Batch_Form_EntryTest extends CiviUnitTestCase {
     $params = array(
       'name' => $this->_membershipTypeName,
       'description' => NULL,
-      'minimum_fee' => 10,
+      'minimum_fee' => 1500,
       'duration_unit' => 'year',
       'member_of_contact_id' => $this->_orgContactID,
       'period_type' => 'fixed',
@@ -156,9 +156,18 @@ class CRM_Batch_Form_EntryTest extends CiviUnitTestCase {
 
   /**
    *  Test Import.
+   *
+   * @param string $thousandSeparator
+   *
+   * @dataProvider getThousandSeparators
    */
-  public function testProcessMembership() {
+  public function testProcessMembership($thousandSeparator) {
+    $this->setCurrencySeparators($thousandSeparator);
+
     $form = new CRM_Batch_Form_Entry();
+    $profileID = $this->callAPISuccessGetValue('UFGroup', ['return' => 'id', 'name' => 'membership_batch_entry']);
+    $form->_fields = CRM_Core_BAO_UFGroup::getFields($profileID, FALSE, CRM_Core_Action::VIEW);
+
     $params = $this->getMembershipData();
     $this->assertTrue($form->testProcessMembership($params));
     $result = $this->callAPISuccess('membership', 'get', array());
@@ -184,6 +193,7 @@ class CRM_Batch_Form_EntryTest extends CiviUnitTestCase {
         'return' => 'line_total',
 
       )), $contribution['total_amount']);
+      $this->assertEquals(1500, $contribution['total_amount']);
       $this->assertEquals($params['field'][$key]['trxn_id'], $contribution['trxn_id']);
     }
   }
@@ -273,7 +283,7 @@ class CRM_Batch_Form_EntryTest extends CiviUnitTestCase {
           'membership_end_date' => NULL,
           'membership_source' => NULL,
           'financial_type' => 2,
-          'total_amount' => 1,
+          'total_amount' => $this->formatMoneyInput(1500),
           'receive_date' => '2013-07-24',
           'receive_date_time' => NULL,
           'payment_instrument' => 1,
@@ -288,7 +298,7 @@ class CRM_Batch_Form_EntryTest extends CiviUnitTestCase {
           'membership_end_date' => NULL,
           'membership_source' => NULL,
           'financial_type' => 2,
-          'total_amount' => 1,
+          'total_amount' => $this->formatMoneyInput(1500),
           'receive_date' => '2013-07-17',
           'receive_date_time' => NULL,
           'payment_instrument' => NULL,
@@ -304,7 +314,7 @@ class CRM_Batch_Form_EntryTest extends CiviUnitTestCase {
           'membership_end_date' => '2013-12-01',
           'membership_source' => NULL,
           'financial_type' => 2,
-          'total_amount' => 1,
+          'total_amount' => $this->formatMoneyInput(1500),
           'receive_date' => '2013-07-17',
           'receive_date_time' => NULL,
           'payment_instrument' => NULL,


### PR DESCRIPTION
Overview
----------------------------------------
#11539 identified that batch entry was also failing for thousand separator

Before
----------------------------------------
use of thousand separator resolved in missaved amounts

After
----------------------------------------
Amounts saved correctly, tests

Technical Details
----------------------------------------


Comments
----------------------------------------
See #11539

---

 * [CRM-17647: Recording payment truncates the amount after the comma \(whether thousands or decimal separator\)](https://issues.civicrm.org/jira/browse/CRM-17647)