### PR TITLE
CRM-21665 Fix check number toggle on Edit form when context is search

### DIFF
--- a/CRM/Contact/Form/Search/Advanced.php
+++ b/CRM/Contact/Form/Search/Advanced.php
@@ -360,6 +360,7 @@ class CRM_Contact_Form_Search_Advanced extends CRM_Contact_Form_Search {
     $changeNames = array(
       'status_id' => 'activity_status_id',
       'priority_id' => 'activity_priority_id',
+      'payment_instrument_id' => 'payment_instrument',
     );
     CRM_Contact_BAO_Query::processSpecialFormValue($this->_formValues, $specialParams, $changeNames);
 

--- a/CRM/Contribute/BAO/Query.php
+++ b/CRM/Contribute/BAO/Query.php
@@ -927,7 +927,11 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
       FALSE, array('class' => 'crm-select2', 'multiple' => 'multiple', 'placeholder' => ts('- any -'))
     );
 
-    $form->addSelect('payment_instrument_id',
+    // use payment_instrument instead of payment_instrument_id
+    // Contribution Edit form (pop-up on contribution/Contact(display Result as Contribution) open on search form),
+    // then payment method change action not working properly because of same html ID present two time on one page
+    // To avoid this issue changing search form element name with out _id (suffix), then on search form, on submit assigning form value back to payment_instrument_id
+    $form->addSelect('payment_instrument',
       array('entity' => 'contribution', 'multiple' => 'multiple', 'label' => ts('Payment Method'), 'option_url' => NULL, 'placeholder' => ts('- any -'))
     );
 

--- a/CRM/Contribute/Form/Search.php
+++ b/CRM/Contribute/Form/Search.php
@@ -294,7 +294,11 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
         'payment_instrument_id',
         'contribution_batch_id',
       );
-      CRM_Contact_BAO_Query::processSpecialFormValue($this->_formValues, $specialParams);
+
+      $changeNames = array(
+        'payment_instrument_id' => 'payment_instrument',
+      );
+      CRM_Contact_BAO_Query::processSpecialFormValue($this->_formValues, $specialParams, $changeNames);
 
       $tags = CRM_Utils_Array::value('contact_tags', $this->_formValues);
       if ($tags && !is_array($tags)) {

--- a/templates/CRM/Contribute/Form/Search/Common.tpl
+++ b/templates/CRM/Contribute/Form/Search/Common.tpl
@@ -40,8 +40,8 @@
 <tr>
   <td>
     <div class="float-left">
-      <label>{$form.payment_instrument_id.label}</label> <br />
-      {$form.payment_instrument_id.html|crmAddClass:twenty}
+      <label>{$form.payment_instrument.label}</label> <br />
+      {$form.payment_instrument.html|crmAddClass:twenty}
     </div>
     <div class="float-left" id="contribution_check_number_wrapper">
       {$form.contribution_check_number.label} <br />


### PR DESCRIPTION
Overview
----------------------------------------
Check Number toggle on Edit form not work when context is search

Before
----------------------------------------
Check Number show / hide not working when user search the contribution (Find Contribution) then Edit the contribution in pop up box.

It work on contribution dashboard and under 'Contribution' Tab for contact.

Reason for not working on Find Contribution page: we have two field with same html ID 'payment_instrument_id'

( 1st from find contribution from (payment method) and 2nd is from contribution form)

ID has to be uniq. Since its duplicate jQuery unable to handle show hide functionality when Payment Method changed in Contribution Form.


After
----------------------------------------
Check number field get toggled  when payment method change.

Technical Details
----------------------------------------
Same ID 'payment_instrument_id' present two times on page

---

 * [CRM-21665: Check Number show hide not working](https://issues.civicrm.org/jira/browse/CRM-21665)