### PR TITLE
CRM-17647 test fixes to avoid calling Contribution::create without sk…

### DIFF
--- a/tests/phpunit/CRM/Financial/BAO/FinancialItemTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/FinancialItemTest.php
@@ -47,29 +47,26 @@ class CRM_Financial_BAO_FinancialItemTest extends CiviUnitTestCase {
    * Check method add()
    */
   public function testAdd() {
-    $firstName = 'Shane';
-    $lastName = 'Whatson';
-    $params = array(
-      'first_name' => $firstName,
-      'last_name' => $lastName,
+    $params = [
+      'first_name' => 'Shane',
+      'last_name' => 'Whatson',
       'contact_type' => 'Individual',
-    );
+    ];
 
-    $contact = CRM_Contact_BAO_Contact::add($params);
+    $contact = $this->callAPISuccess('Contact', 'create', $params);
 
     $price = 100;
-    $cParams = array(
-      'contact_id' => $contact->id,
+    $cParams = [
+      'contact_id' => $contact['id'],
       'total_amount' => $price,
       'financial_type_id' => 1,
       'is_active' => 1,
       'skipLineItem' => 1,
-    );
+    ];
 
-    $defaults = array();
-    $contribution = CRM_Contribute_BAO_Contribution::add($cParams, $defaults);
+    $contribution = $this->callAPISuccess('Contribution', 'create', $cParams);
     $lParams = array(
-      'entity_id' => $contribution->id,
+      'entity_id' => $contribution['id'],
       'entity_table' => 'civicrm_contribution',
       'price_field_id' => 1,
       'qty' => 1,
@@ -81,7 +78,9 @@ class CRM_Financial_BAO_FinancialItemTest extends CiviUnitTestCase {
     );
 
     $lineItem = CRM_Price_BAO_LineItem::create($lParams);
-    CRM_Financial_BAO_FinancialItem::add($lineItem, $contribution);
+    $contributionObj = $this->getContributionObject($contribution['id']);
+
+    CRM_Financial_BAO_FinancialItem::add($lineItem, $contributionObj);
     $result = $this->assertDBNotNull(
       'CRM_Financial_DAO_FinancialItem',
       $lineItem->id,
@@ -96,28 +95,25 @@ class CRM_Financial_BAO_FinancialItemTest extends CiviUnitTestCase {
    * Check method retrive()
    */
   public function testRetrieve() {
-    $firstName = 'Shane';
-    $lastName = 'Whatson';
-    $params = array(
-      'first_name' => $firstName,
-      'last_name' => $lastName,
+    $params = [
+      'first_name' => 'Shane',
+      'last_name' => 'Whatson',
       'contact_type' => 'Individual',
-    );
+    ];
 
-    $contact = CRM_Contact_BAO_Contact::add($params);
+    $contact = $this->callAPISuccess('Contact', 'create', $params);
     $price = 100.00;
-    $cParams = array(
-      'contact_id' => $contact->id,
+    $cParams = [
+      'contact_id' => $contact['id'],
       'total_amount' => $price,
       'financial_type_id' => 1,
       'is_active' => 1,
       'skipLineItem' => 1,
-    );
+    ];
 
-    $defaults = array();
-    $contribution = CRM_Contribute_BAO_Contribution::add($cParams, $defaults);
+    $contribution = $this->callAPISuccess('Contribution', 'create', $cParams);
     $lParams = array(
-      'entity_id' => $contribution->id,
+      'entity_id' => $contribution['id'],
       'entity_table' => 'civicrm_contribution',
       'price_field_id' => 1,
       'qty' => 1,
@@ -128,8 +124,9 @@ class CRM_Financial_BAO_FinancialItemTest extends CiviUnitTestCase {
       'financial_type_id' => 1,
     );
 
+    $contributionObj = $this->getContributionObject($contribution['id']);
     $lineItem = CRM_Price_BAO_LineItem::create($lParams);
-    CRM_Financial_BAO_FinancialItem::add($lineItem, $contribution);
+    CRM_Financial_BAO_FinancialItem::add($lineItem, $contributionObj);
     $values = array();
     $fParams = array(
       'entity_id' => $lineItem->id,
@@ -143,28 +140,25 @@ class CRM_Financial_BAO_FinancialItemTest extends CiviUnitTestCase {
    * Check method create()
    */
   public function testCreate() {
-    $firstName = 'Shane';
-    $lastName = 'Whatson';
-    $params = array(
-      'first_name' => $firstName,
-      'last_name' => $lastName,
+    $params = [
+      'first_name' => 'Shane',
+      'last_name' => 'Whatson',
       'contact_type' => 'Individual',
-    );
+    ];
 
-    $contact = CRM_Contact_BAO_Contact::add($params);
+    $contact = $this->callAPISuccess('Contact', 'create', $params);
     $price = 100.00;
     $cParams = array(
-      'contact_id' => $contact->id,
+      'contact_id' => $contact['id'],
       'total_amount' => $price,
       'financial_type_id' => 1,
       'is_active' => 1,
       'skipLineItem' => 1,
     );
 
-    $defaults = array();
-    $contribution = CRM_Contribute_BAO_Contribution::add($cParams, $defaults);
+    $contribution = $this->callAPISuccess('Contribution', 'create', $cParams);
     $lParams = array(
-      'entity_id' => $contribution->id,
+      'entity_id' => $contribution['id'],
       'entity_table' => 'civicrm_contribution',
       'price_field_id' => 1,
       'qty' => 1,
@@ -177,7 +171,7 @@ class CRM_Financial_BAO_FinancialItemTest extends CiviUnitTestCase {
 
     $lineItem = CRM_Price_BAO_LineItem::create($lParams);
     $fParams = array(
-      'contact_id' => $contact->id,
+      'contact_id' => $contact['id'],
       'description' => 'Contribution Amount',
       'amount' => $price,
       'financial_account_id' => 1,
@@ -190,7 +184,7 @@ class CRM_Financial_BAO_FinancialItemTest extends CiviUnitTestCase {
     CRM_Financial_BAO_FinancialItem::create($fParams);
     $entityTrxn = new CRM_Financial_DAO_EntityFinancialTrxn();
     $entityTrxn->entity_table = 'civicrm_contribution';
-    $entityTrxn->entity_id = $contribution->id;
+    $entityTrxn->entity_id = $contribution['id'];
     $entityTrxn->amount = $price;
     if ($entityTrxn->find(TRUE)) {
       $entityId = $entityTrxn->entity_id;
@@ -356,6 +350,20 @@ class CRM_Financial_BAO_FinancialItemTest extends CiviUnitTestCase {
       'financial_account_id' => '1',
     );
     $this->callAPISuccessGetSingle('FinancialItem', $params, $checkAgainst);
+  }
+
+  /**
+   * Get the contribution object.
+   *
+   * @param int $contributionID
+   *
+   * @return \CRM_Contribute_BAO_Contribution
+   */
+  protected function getContributionObject($contributionID) {
+    $contributionObj = new CRM_Contribute_BAO_Contribution();
+    $contributionObj->id = $contributionID;
+    $contributionObj->find(TRUE);
+    return $contributionObj;
   }
 
 }


### PR DESCRIPTION

Test tidy up only - no functional change but it works towards never calling Contribution::create (or add) without skipCleanMoney - in practice 'use the api'