### PR TITLE
CRM-21511 Fix template variable for contribution_recur_id

### DIFF
--- a/templates/CRM/Member/Form/MembershipView.tpl
+++ b/templates/CRM/Member/Form/MembershipView.tpl
@@ -65,7 +65,7 @@
           <tr>
             <td class="label">{ts}Recurring Contribution{/ts}</td>
             <td>
-              <a class="crm-hover-button" href='{crmURL p="civicrm/contact/view/contributionrecur" q="reset=1&id=`$recurContribution`&cid=`$contactId`&context=contribution"}'>View Recurring Contribution</a>
+              <a class="crm-hover-button" href='{crmURL p="civicrm/contact/view/contributionrecur" q="reset=1&id=`$contribution_recur_id`&cid=`$contactId`&context=contribution"}'>View Recurring Contribution</a>
             </td>
           </tr>
      {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Trivial fix for variable typo in previous PR #11365  (which has already been merged).  This stopped the link from membership view to recurring contribution from working as the recur ID was not set.

@colemanw Are you happy to merge?

---

 * [CRM-21511: Add recurring contribution to membership detail and contribution](https://issues.civicrm.org/jira/browse/CRM-21511)