### PR TITLE
WIP CRM-21682 automatic membership renewal cleanup

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -5445,6 +5445,12 @@ LEFT JOIN  civicrm_contribution on (civicrm_contribution.contact_id = civicrm_co
     // Loop through all found memberships and update status/renew
     foreach ($memberships as $membershipId => $membership) {
       if ($membership) {
+        if ((!empty($contribution->contribution_recur_id))
+          && (!CRM_Member_BAO_Membership::isRecurFrequencyEqualToMembershipType($membership['membership_type_id'], $membership['contribution_recur_id']))) {
+          Civi::log()->warning('You have enabled auto-renew on membership (id=' . $membership['id'] . ') but the frequencies do not match! The membership will not be auto-renewed.');
+          continue;
+        }
+
         $membershipParams = array(
           'id' => $membership['id'],
           'contact_id' => $membership['contact_id'],

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -5465,18 +5465,14 @@ LEFT JOIN  civicrm_contribution on (civicrm_contribution.contact_id = civicrm_co
         );
 
         // Does the contact have a "current" membership (ie. not expired/pending etc).
-        $currentMembership = CRM_Member_BAO_Membership::getContactMembership($membershipParams['contact_id'],
-          $membershipParams['membership_type_id'],
-          $membershipParams['is_test'],
-          $membershipParams['id']
-        );
-        if ($currentMembership) {
+        if (!empty($membership['status_id.is_current_member'])) {
           /*
            * Fixed FOR CRM-4433
            * In BAO/Membership.php(renewMembership function), we skip the extend membership date and status
            * when Contribution mode is notify and membership is for renewal )
+           * FIXME: Is this still required?
            */
-          CRM_Member_BAO_Membership::fixMembershipStatusBeforeRenew($currentMembership, $changeDate);
+          CRM_Member_BAO_Membership::fixMembershipStatusBeforeRenew($membership, $changeDate);
         }
 
         // Tell the Membership BAO to calculate membership status.

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3930,6 +3930,7 @@ WHERE eft.entity_table = 'civicrm_contribution'
           }
         }
 
+        // update membership details
         self::updateMembershipBasedOnCompletionOfContribution(
           $contributionDAO,
           $contributionId,
@@ -5406,60 +5407,63 @@ LEFT JOIN  civicrm_contribution on (civicrm_contribution.contact_id = civicrm_co
    * @param int $primaryContributionID
    * @param string $changeDate
    *
-   * @throws \CRM_Core_Exception
-   * @throws \CiviCRM_API3_Exception
    */
   protected static function updateMembershipBasedOnCompletionOfContribution($contribution, $primaryContributionID, $changeDate) {
-    $contribution->loadRelatedMembershipObjects();
-    if (empty($contribution->_relatedObjects['membership'])) {
-      return;
+    // Load memberships from contribution info. There may be multiple memberships (or none)
+    $membershipFields = array('id', 'contact_id', 'is_test', 'membership_type_id', 'contribution_recur_id', 'status_id.is_current_member',
+      'start_date', 'join_date', 'end_date', 'status_id');
+    $memberships = array();
+    if (!empty($contribution->contribution_recur_id)) {
+      // Load memberships associated with recurring contribution
+      $membershipResult = civicrm_api3('Membership', 'get', array(
+        'contribution_recur_id' => $contribution->contribution_recur_id,
+        'return' => $membershipFields,
+        'options' => ['limit' => 0],
+      ));
     }
-    $memberships = $contribution->_relatedObjects['membership'];
-    foreach ($memberships as $membershipTypeIdKey => $membership) {
+    elseif (!empty($primaryContributionID)) {
+      // Load membership associated with original contribution
+      $membershipPaymentResult = civicrm_api3('MembershipPayment', 'get', array(
+        'contribution_id' => $primaryContributionID,
+        'options' => ['limit' => 0],
+      ));
+      if (!empty($membershipPaymentResult['count'])) {
+        foreach ($membershipPaymentResult['values'] as $payment) {
+          $membershipIDs[] = $payment['membership_id'];
+        }
+        $membershipResult = civicrm_api3('Membership', 'get', array(
+          'id' => array('IN' => $membershipIDs),
+          'return' => $membershipFields,
+          'options' => ['limit' => 0],
+        ));
+      }
+    }
+    if (isset($membershipResult) && !empty($membershipResult['count'])) {
+      $memberships = $membershipResult['values'];
+    }
+
+    // Loop through all found memberships and update status/renew
+    foreach ($memberships as $membershipId => $membership) {
       if ($membership) {
         $membershipParams = array(
-          'id' => $membership->id,
-          'contact_id' => $membership->contact_id,
-          'is_test' => $membership->is_test,
-          'membership_type_id' => $membership->membership_type_id,
+          'id' => $membership['id'],
+          'contact_id' => $membership['contact_id'],
+          'is_test' => $membership['is_test'],
+          'membership_type_id' => $membership['membership_type_id'],
           'membership_activity_status' => 'Completed',
         );
-
-        $currentMembership = CRM_Member_BAO_Membership::getContactMembership($membershipParams['contact_id'],
-          $membershipParams['membership_type_id'],
-          $membershipParams['is_test'],
-          $membershipParams['id']
-        );
-
-        // CRM-8141 update the membership type with the value recorded in log when membership created/renewed
-        // this picks up membership type changes during renewals
-        // @todo this is almost certainly an obsolete sql call, the pre-change
-        // membership is accessible via $this->_relatedObjects
-        $sql = "
-SELECT    membership_type_id
-FROM      civicrm_membership_log
-WHERE     membership_id={$membershipParams['id']}
-ORDER BY  id DESC
-LIMIT 1;";
-        $dao = CRM_Core_DAO::executeQuery($sql);
-        if ($dao->fetch()) {
-          if (!empty($dao->membership_type_id)) {
-            $membershipParams['membership_type_id'] = $dao->membership_type_id;
-          }
-        }
-        $dao->free();
 
         $membershipParams['num_terms'] = $contribution->getNumTermsByContributionAndMembershipType(
           $membershipParams['membership_type_id'],
           $primaryContributionID
         );
-        // @todo remove all this stuff in favour of letting the api call further down handle in
-        // (it is a duplication of what the api does).
-        $dates = array_fill_keys(array(
-          'join_date',
-          'start_date',
-          'end_date',
-        ), NULL);
+
+        // Does the contact have a "current" membership (ie. not expired/pending etc).
+        $currentMembership = CRM_Member_BAO_Membership::getContactMembership($membershipParams['contact_id'],
+          $membershipParams['membership_type_id'],
+          $membershipParams['is_test'],
+          $membershipParams['id']
+        );
         if ($currentMembership) {
           /*
            * Fixed FOR CRM-4433
@@ -5467,38 +5471,20 @@ LIMIT 1;";
            * when Contribution mode is notify and membership is for renewal )
            */
           CRM_Member_BAO_Membership::fixMembershipStatusBeforeRenew($currentMembership, $changeDate);
-
-          // @todo - we should pass membership_type_id instead of null here but not
-          // adding as not sure of testing
-          $dates = CRM_Member_BAO_MembershipType::getRenewalDatesForMembershipType($membershipParams['id'],
-            $changeDate, NULL, $membershipParams['num_terms']
-          );
-          $dates['join_date'] = $currentMembership['join_date'];
         }
 
-        //get the status for membership.
-        $calcStatus = CRM_Member_BAO_MembershipStatus::getMembershipStatusByDate($dates['start_date'],
-          $dates['end_date'],
-          $dates['join_date'],
-          'today',
-          TRUE,
-          $membershipParams['membership_type_id'],
-          $membershipParams
-        );
-
-        unset($dates['end_date']);
-        $membershipParams['status_id'] = CRM_Utils_Array::value('id', $calcStatus, 'New');
-        //we might be renewing membership,
-        //so make status override false.
+        // Tell the Membership BAO to calculate membership status.
+        $membershipParams['skipStatusCal'] = 0;
+        $membershipParams['exclude_is_admin'] = TRUE;
         $membershipParams['is_override'] = FALSE;
         $membershipParams['status_override_end_date'] = 'null';
-
-        //CRM-17723 - reset static $relatedContactIds array()
-        // @todo move it to Civi Statics.
-        $var = TRUE;
-        CRM_Member_BAO_Membership::createRelatedMemberships($var, $var, TRUE);
-        civicrm_api3('Membership', 'create', $membershipParams);
       }
+
+      //CRM-17723 - reset static $relatedContactIds array()
+      // @todo move it to Civi Statics.
+      $var = TRUE;
+      CRM_Member_BAO_Membership::createRelatedMemberships($var, $var, TRUE);
+      civicrm_api3('Membership', 'create', $membershipParams);
     }
   }
 

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1164,10 +1164,8 @@ AND civicrm_membership.is_test = %2";
       $currentMembership
     );
 
-    if (empty($status) ||
-      empty($status['id'])
-    ) {
-      CRM_Core_Error::fatal(ts('Oops, it looks like there is no valid membership status corresponding to the membership start and end dates for this membership. Contact the site administrator for assistance.'));
+    if (empty($status) || empty($status['id'])) {
+      throw new CRM_Core_Exception(ts('Oops, it looks like there is no valid membership status corresponding to the membership start and end dates for this membership. Contact the site administrator for assistance.'));
     }
 
     $currentMembership['today_date'] = $today;

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1706,6 +1706,34 @@ LEFT JOIN civicrm_membership mem ON ( cr.id = mem.contribution_recur_id )
   }
 
   /**
+   * Check if the membership type has the same frequency as the recurring contribution
+   * @param $membershipTypeId
+   * @param $contributionRecurId
+   *
+   * @return bool
+   */
+  public static function isRecurFrequencyEqualToMembershipType($membershipTypeId, $contributionRecurId) {
+    try {
+      $membershipType = civicrm_api3('MembershipType', 'getsingle', array(
+        'return' => array("duration_unit", "duration_interval"),
+        'id' => $membershipTypeId,
+      ));
+      $contributionRecur = civicrm_api3('ContributionRecur', 'getsingle', array(
+        'return' => array("frequency_unit", "frequency_interval"),
+        'id' => $contributionRecurId,
+      ));
+      if (($membershipType['duration_unit'] === $contributionRecur['frequency_unit'])
+        && ($membershipType['duration_interval'] === $contributionRecur['frequency_interval'])) {
+        return TRUE;
+      }
+    }
+    catch (CiviCRM_API3_Exception $e) {
+      return FALSE;
+    }
+    return FALSE;
+  }
+
+  /**
    * Get membership joins for a specified membership type.
    *
    * Specifically, retrieves a count of still current memberships whose

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -838,9 +838,9 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
    * - the first creates a new membership, completed contribution, in progress recurring. Check these
    * - create another - end date should be extended
    */
-  //public function testSubmitMembershipPriceSetPaymentPaymentProcessorRecurInstantPaymentDifferentFrequency() {
-  //  $this->doSubmitMembershipPriceSetPaymentPaymentProcessorRecurInstantPayment(array('duration_unit' => 'year', 'recur_frequency_unit' => 'month'));
-  //}
+  public function testSubmitMembershipPriceSetPaymentPaymentProcessorRecurInstantPaymentDifferentFrequency() {
+    $this->doSubmitMembershipPriceSetPaymentPaymentProcessorRecurInstantPayment(array('duration_unit' => 'year', 'recur_frequency_unit' => 'month'));
+  }
 
   /**
    * Helper function for testSubmitMembershipPriceSetPaymentProcessorRecurInstantPayment*


### PR DESCRIPTION
Overview
----------------------------------------
**WORK IN PROGRESS** Parts of this are gradually being extracted into smaller, easier to review PRs.  Once this is fully reviewed and merged documentation will also need updating.
Ref: #12315 

This is mostly code cleanup and an attempt to understand exactly what happens when a membership is automatically renewed!

Fixes (and this needs adding to Civi docs somewhere as it's currently undocumented and unclear what it does):
Before
----------------------------------------
* Membership will be renewed when contribution is in ANY state except "Pending."
* All parameters of recurring contribution are ignored, ie installments, frequency mismatch (eg. monthly recurring, annual membership) so every new contribution will trigger a membership renewal.
* When repeattransaction is called ONLY the membership linked to the original contribution will be renewed (if the contribution is in the correct state (ie. Completed - see Before/After)). loadRelatedObjects only loads one membership but the code is expected all memberships to be loaded so does handle multiple memberships if passed in.

After
----------------------------------------
* Membership will be renewed ONLY when contribution is in state "Completed".
* Membership will be renewed ONLY if the recurring and membership type frequencies match.  Installments parameter has no effect.
* When repeattransaction is called: If the contribution has a recurring contribution ID then ALL memberships linked to that recurring contribution will be renewed.  If the contribution has no recurring contribution then the membership linked to the original contribution will be renewed (if the contribution is in the correct state (ie. Completed - see Before/After) AND the other conditions are met (ie. state, frequency)).

Documentation (After)
----------------------------------------
* Membership will be renewed ONLY when contribution is in state "Completed" - #12315 (5.5.0)
* Membership will be renewed ONLY if the recurring and membership type frequencies match (Installments are ignored).
* When repeattransaction is called any linked memberships will be renewed if the contribution is in the correct state.  If there is a recurring contribution then the frequencies must also match (installments are ignored).
* A recurring contribution can be linked to multiple memberships and all memberships will be updated/renewed if all other conditions are met - #12542 (pending merge)

---

 * [CRM-21682: Automatic membership renewal fixes](https://issues.civicrm.org/jira/browse/CRM-21682)