### PR TITLE
CRM-21683 Standardise filter in mailing summary report

### DIFF
--- a/CRM/Report/Form/Mailing/Summary.php
+++ b/CRM/Report/Form/Mailing/Summary.php
@@ -85,12 +85,12 @@ class CRM_Report_Form_Mailing_Summary extends CRM_Report_Form {
           //'operator' => 'like',
           'default' => 1,
         ),
-        'mailing_name' => array(
-          'name' => 'name',
+        'mailing_id' => array(
+          'name' => 'id',
           'title' => ts('Mailing Name'),
           'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-          'type' => CRM_Utils_Type::T_STRING,
-          'options' => self::mailing_select(),
+          'type' => CRM_Utils_Type::T_INT,
+          'options' => CRM_Mailing_BAO_Mailing::getMailingsList(),
           'operator' => 'like',
         ),
         'mailing_subject' => array(
@@ -315,24 +315,6 @@ class CRM_Report_Form_Mailing_Summary extends CRM_Report_Form {
       );
     }
     parent::__construct();
-  }
-
-  /**
-   * @return array
-   */
-  public function mailing_select() {
-
-    $data = array();
-
-    $mailing = new CRM_Mailing_BAO_Mailing();
-    $query = "SELECT name FROM civicrm_mailing WHERE sms_provider_id IS NULL";
-    $mailing->query($query);
-
-    while ($mailing->fetch()) {
-      $data[CRM_Core_DAO::escapeString($mailing->name)] = $mailing->name;
-    }
-
-    return $data;
   }
 
   public function preProcess() {


### PR DESCRIPTION
Overview
----------------------------------------
You can't filter by mailings with an apostrophe in the 'mailing name' on the mailing summary report. Let's fix that.

Before
----------------------------------------
You can't filter by mailings with an apostrophe in the 'mailing name' on the mailing summary report, and the report uses a 'bespoke' way of getting a list of mailings to filter by.

After
----------------------------------------
You can filter by mailings with an apostrophe in the name, and the report uses the same method to build the list as all the other reports.

---

 * [CRM-21683: Mailing summary breaks on mailing names with apostrophes](https://issues.civicrm.org/jira/browse/CRM-21683)