### PR TITLE
CRM-21684 contact subtype fields prevent inclusion in profile/receipt…

### DIFF
--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -1758,6 +1758,11 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
 
       if (CRM_Contact_BAO_ContactType::isaSubType($profileType)) {
         $profileType = CRM_Contact_BAO_ContactType::getBasicType($profileType);
+
+        //in some cases getBasicType() returns a cached array instead of string. Example: array ('sponsor' => 'organization')
+        if (is_array($profileType)) {
+          $profileType = array_shift($profileType);
+        }
       }
 
       //allow special mix profiles for Contribution and Participant


### PR DESCRIPTION
**Steps to replicate the issue** 
1. Create a custom data set for orgs and limit to a subtype (create a contact subtype for orgs if you don't already have one). Add a field.
2. Create a new profile or just use the "new organization" profile and add this field to it.
3. Create a contrib page and use the "on behalf of" feature with the profile in the previous step. setup the contrib page to send receipts.
4. Use the contrib page and review the email you received.

If no contact subtype restricted field is part of the profile, the email will include the on behalf of fields. but the presence of that subtype field prevents ALL fields from the on behalf of profile from being included in the email.

This PR addresses the above issue.

JIRA ticket: https://issues.civicrm.org/jira/browse/CRM-21684 