### PR TITLE
CRM-21688 Use fontawesome check for membership auto-renew status

### DIFF
--- a/CRM/Member/Page/Tab.php
+++ b/CRM/Member/Page/Tab.php
@@ -156,11 +156,14 @@ class CRM_Member_Page_Tab extends CRM_Core_Page {
         );
       }
 
-      //does membership have auto renew CRM-7137.
-      if (!empty($membership[$dao->id]['contribution_recur_id']) &&
-        !CRM_Member_BAO_Membership::isSubscriptionCancelled($membership[$dao->id]['membership_id'])
-      ) {
-        $membership[$dao->id]['auto_renew'] = 1;
+      // Display Auto-renew status on page (0=disabled, 1=enabled, 2=enabled, but error
+      if (!empty($membership[$dao->id]['contribution_recur_id'])) {
+        if (CRM_Member_BAO_Membership::isSubscriptionCancelled($membership[$dao->id]['membership_id'])) {
+          $membership[$dao->id]['auto_renew'] = 2;
+        }
+        else {
+          $membership[$dao->id]['auto_renew'] = 1;
+        }
       }
       else {
         $membership[$dao->id]['auto_renew'] = 0;

--- a/CRM/Member/Selector/Search.php
+++ b/CRM/Member/Selector/Search.php
@@ -316,7 +316,7 @@ class CRM_Member_Selector_Search extends CRM_Core_Selector_Base implements CRM_C
    * @param string $output
    *   What should the result set include (web/email/csv).
    *
-   * @return int
+   * @return array
    *   the total number of rows for this action
    */
   public function &getRows($action, $offset, $rowCount, $sort, $output = NULL) {
@@ -441,14 +441,18 @@ class CRM_Member_Selector_Search extends CRM_Core_Selector_Base implements CRM_C
         );
       }
 
-      //does membership have auto renew CRM-7137.
-      $autoRenew = FALSE;
-      if (isset($result->membership_recur_id) && $result->membership_recur_id &&
-        !CRM_Member_BAO_Membership::isSubscriptionCancelled($row['membership_id'])
-      ) {
-        $autoRenew = TRUE;
+      // Display Auto-renew status on page (0=disabled, 1=enabled, 2=enabled, but error
+      if (!empty($result->membership_recur_id)) {
+        if (CRM_Member_BAO_Membership::isSubscriptionCancelled($row['membership_id'])) {
+          $row['auto_renew'] = 2;
+        }
+        else {
+          $row['auto_renew'] = 1;
+        }
       }
-      $row['auto_renew'] = $autoRenew;
+      else {
+        $row['auto_renew'] = 0;
+      }
 
       $row['contact_type'] = CRM_Contact_BAO_Contact_Utils::getImage($result->contact_sub_type ? $result->contact_sub_type : $result->contact_type, FALSE, $result->contact_id
       );

--- a/templates/CRM/Member/Form/Selector.tpl
+++ b/templates/CRM/Member/Form/Selector.tpl
@@ -67,7 +67,13 @@
     <td class="crm-membership-end_date">{$row.membership_end_date|truncate:10:''|crmDate}</td>
     <td class="crm-membership-source">{$row.membership_source}</td>
     <td class="crm-membership-status crm-membership-status_{$row.membership_status}">{$row.membership_status}</td>
-    <td class="crm-membership-auto_renew">{if $row.auto_renew}<img src="{$config->resourceBase}i/check.gif" alt="{ts}Auto-renew{/ts}" /> {/if}</td>
+    <td class="crm-membership-auto_renew">
+      {if $row.auto_renew eq 1}
+        <i class="fa fa-check" aria-hidden="true" title="{ts}Auto-renew active{/ts}"></i>
+      {elseif $row.auto_renew eq 2}
+        <i class="fa fa-exclamation" aria-hidden="true" title="{ts}Auto-renew error{/ts}"></i>
+      {/if}
+    </td>
     <td>
         {$row.action|replace:'xx':$row.membership_id}
         {if $row.owner_membership_id}

--- a/templates/CRM/Member/Page/Tab.tpl
+++ b/templates/CRM/Member/Page/Tab.tpl
@@ -94,7 +94,13 @@
                 <td class="crm-membership-end_date" data-order="{$activeMember.end_date}">{$activeMember.end_date|crmDate}</td>
                 <td class="crm-membership-status">{$activeMember.status}</td>
                 <td class="crm-membership-source">{$activeMember.source}</td>
-                <td class="crm-membership-auto_renew">{if $activeMember.auto_renew}<img src="{$config->resourceBase}i/check.gif" alt="{ts}Auto-renew{/ts}" /> {/if}</td>
+                <td class="crm-membership-auto_renew">
+                  {if $activeMember.auto_renew eq 1}
+                      <i class="fa fa-check" aria-hidden="true" title="{ts}Auto-renew active{/ts}"></i>
+                  {elseif $activeMember.auto_renew eq 2}
+                      <i class="fa fa-exclamation" aria-hidden="true" title="{ts}Auto-renew error{/ts}"></i>
+                  {/if}
+                </td>
                 <td class="crm-membership-related_count">{$activeMember.related_count}</td>
     <td>
                     {$activeMember.action|replace:'xx':$activeMember.id}
@@ -137,7 +143,13 @@
                 <td class="crm-membership-end_date" data-order="{$inActiveMember.end_date}">{$inActiveMember.end_date|crmDate}</td>
                 <td class="crm-membership-status">{$inActiveMember.status}</td>
                 <td class="crm-membership-source">{$inActiveMember.source}</td>
-                <td class="crm-membership-auto_renew">{if $inActiveMember.auto_renew}<img src="{$config->resourceBase}i/check.gif" alt="{ts}Auto-renew{/ts}" /> {/if}</td>
+                <td class="crm-membership-auto_renew">
+                  {if $inActiveMember.auto_renew eq 1}
+                    <i class="fa fa-check" aria-hidden="true" title="{ts}Auto-renew active{/ts}"></i>
+                  {elseif $inActiveMember.auto_renew eq 2}
+                    <i class="fa fa-exclamation" aria-hidden="true" title="{ts}Auto-renew error{/ts}"></i>
+                  {/if}
+                </td>
     <td>{$inActiveMember.action|replace:'xx':$inActiveMember.id}
     {if $inActiveMember.owner_membership_id}
       <a href="{crmURL p='civicrm/membership/view' q="reset=1&id=`$inActiveMember.owner_membership_id`&action=view&context=membership&selectedChild=member"}" title="{ts}View Primary member record{/ts}" class="crm-hover-button action-item">{ts}View Primary{/ts}


### PR DESCRIPTION
Overview
----------------------------------------
This changes the membership tab to use fontawesome for the auto-renew "tick" and adds an exclamation mark when auto-renew is enabled but the subscription has been cancelled.

Before
----------------------------------------
Before, a membership with cancelled recurring contribution looked like it had no auto-renew enabled, but in reality it did.
![localhost_8000_civicrm_contact_view_reset 1 cid 203 2](https://user-images.githubusercontent.com/2052161/35179641-e8b22b0e-fdd0-11e7-8d64-08f67ed67246.png)

After
----------------------------------------
Now an exclamation mark shows that it is different from a membership that has no linked recurring contribution.
![localhost_8000_civicrm_contact_view_reset 1 cid 203 1](https://user-images.githubusercontent.com/2052161/35179643-ed6dd2e2-fdd0-11e7-93f5-86dd0e462b32.png)

---

 * [CRM-21688: Use fontawesome to show membership auto-renew status and and error indicator](https://issues.civicrm.org/jira/browse/CRM-21688)