### PR TITLE
CRM-19920 - membership processing enhancements

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -2118,6 +2118,57 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = membership.contact_id AND 
   }
 
   /**
+   * Update the status of all deceased members to deceased.
+   *
+   * @return int
+   *   Count of updated contacts.
+   */
+  protected static function updateDeceasedMembersStatuses() {
+    $count = 0;
+    // 'create' context for buildOptions returns only if enabled.
+    $allStatus = self::buildOptions('status_id', 'create');
+    if (($deceasedStatusId = array_search('Deceased', $allStatus)) === FALSE) {
+      // Deceased status is an admin status & is required. We want to fail early if
+      // it is not present or active.
+      // We could make the case 'some databases just don't use deceased so we will check
+      // for the presence of a deceased contact in the DB before rejecting.
+      if (CRM_Core_DAO::singleValueQuery('
+        SELECT count(*) FROM civicrm_contact WHERE is_deceased = 0'
+      )) {
+        throw new CRM_Core_Exception(
+          ts("Deceased Membership status is missing or not active. <a href='%1'>Click here to check</a>.",
+            [1 => CRM_Utils_System::url('civicrm/admin/member/membershipStatus', 'reset=1')]
+          ));
+      }
+    }
+    $deceasedDAO = CRM_Core_DAO::executeQuery(
+      $baseQuery = "
+       SELECT membership.id as membership_id
+       FROM civicrm_membership membership
+       INNER JOIN civicrm_contact ON membership.contact_id = civicrm_contact.id
+       INNER JOIN civicrm_membership_type ON membership.membership_type_id = civicrm_membership_type.id
+         AND civicrm_membership_type.is_active = 1
+       WHERE membership.is_test = 0
+         AND civicrm_contact.is_deceased = 1
+         AND membership.status_id <> %1
+      ",
+      [1 => [$deceasedStatusId, 'Integer']]
+    );
+    while ($deceasedDAO->fetch()) {
+      civicrm_api3('membership', 'create', [
+        'id' => $deceasedDAO->membership_id,
+        'status_id' => $deceasedStatusId,
+        'createActivity' => TRUE,
+        'skipStatusCal' => TRUE,
+        'skipRecentView' => TRUE,
+      ]);
+      $count++;
+    }
+    $deceasedDAO->free();
+    return $count;
+  }
+
+  /**
    * Process price set and line items.
    *
    * @param int $membershipId
@@ -2183,14 +2234,14 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = membership.contact_id AND 
    * @return array
    */
   public static function updateAllMembershipStatus() {
+    // Tests for this function are in api_v3_JobTest. Please add tests for all updates.
 
-    //get all active statuses of membership, CRM-3984
-    $allStatus = CRM_Member_PseudoConstant::membershipStatus();
-    $statusLabels = CRM_Member_PseudoConstant::membershipStatus(NULL, NULL, 'label');
+    $updateCount = $processCount = self::updateDeceasedMembersStatuses();
+
     $allTypes = CRM_Member_PseudoConstant::membershipType();
 
-    // get only memberships with active membership types
-    $query = "
+    // This query retrieves ALL memberships of active types.
+    $baseQuery = "
 SELECT     civicrm_membership.id                    as membership_id,
            civicrm_membership.is_override           as is_override,
            civicrm_membership.membership_type_id    as membership_type_id,
@@ -2200,7 +2251,6 @@ SELECT     civicrm_membership.id                    as membership_id,
            civicrm_membership.end_date              as end_date,
            civicrm_membership.source                as source,
            civicrm_contact.id                       as contact_id,
-           civicrm_contact.is_deceased              as is_deceased,
            civicrm_membership.owner_membership_id   as owner_membership_id,
            civicrm_membership.contribution_recur_id as recur_id
 FROM       civicrm_membership
@@ -2209,19 +2259,12 @@ INNER JOIN civicrm_membership_type ON
   (civicrm_membership.membership_type_id = civicrm_membership_type.id AND civicrm_membership_type.is_active = 1)
 WHERE      civicrm_membership.is_test = 0";
 
-    $params = array();
-    $dao = CRM_Core_DAO::executeQuery($query, $params);
+    $dao = CRM_Core_DAO::executeQuery($baseQuery . " AND civicrm_contact.is_deceased = 0");
 
-    $processCount = 0;
-    $updateCount = 0;
-
-    $smarty = CRM_Core_Smarty::singleton();
-
+    $allStatus = self::buildOptions('status_id', 'create');
     while ($dao->fetch()) {
-      // echo ".";
       $processCount++;
 
-      // Put common parameters into array for easy access
       $memberParams = array(
         'id' => $dao->membership_id,
         'status_id' => $dao->status_id,
@@ -2235,43 +2278,6 @@ WHERE      civicrm_membership.is_test = 0";
         'skipStatusCal' => TRUE,
         'skipRecentView' => TRUE,
       );
-
-      $smarty->assign_by_ref('memberParams', $memberParams);
-
-      //update membership record to Deceased if contact is deceased
-      if ($dao->is_deceased) {
-        // check for 'Deceased' membership status, CRM-5636
-        $deceaseStatusId = array_search('Deceased', $allStatus);
-        if (!$deceaseStatusId) {
-          CRM_Core_Error::fatal(ts("Deceased Membership status is missing or not active. <a href='%1'>Click here to check</a>.", array(1 => CRM_Utils_System::url('civicrm/admin/member/membershipStatus', 'reset=1'))));
-        }
-
-        //process only when status change.
-        if ($dao->status_id != $deceaseStatusId) {
-          //take all params that need to save.
-          $deceasedMembership = $memberParams;
-          $deceasedMembership['status_id'] = $deceaseStatusId;
-          $deceasedMembership['createActivity'] = TRUE;
-          $deceasedMembership['version'] = 3;
-
-          //since there is change in status.
-          $statusChange = array('status_id' => $deceaseStatusId);
-          $smarty->append_by_ref('memberParams', $statusChange, TRUE);
-          unset(
-            $deceasedMembership['contact_id'],
-            $deceasedMembership['membership_type_id'],
-            $deceasedMembership['membership_type'],
-            $deceasedMembership['join_date'],
-            $deceasedMembership['start_date'],
-            $deceasedMembership['end_date'],
-            $deceasedMembership['source']
-          );
-
-          //process membership record.
-          civicrm_api('membership', 'create', $deceasedMembership);
-        }
-        continue;
-      }
 
       //we fetch related, since we need to check for deceased
       //now further processing is handle w/ main membership record.
@@ -2327,9 +2333,6 @@ WHERE      civicrm_membership.is_test = 0";
             $memParams['end_date'],
             $memParams['source']
           );
-          //since there is change in status.
-          $statusChange = array('status_id' => $statusId);
-          $smarty->append_by_ref('memberParams', $statusChange, TRUE);
 
           //process member record.
           civicrm_api('membership', 'create', $memParams);


### PR DESCRIPTION
Process deceased contacts first, remove smarty var that related to the old email
reminder process, add test.

Overview
----------------------------------------
Proposed partial replacement for #9723

Before
----------------------------------------
Less tests, worse code

After
----------------------------------------
more tests, better code, less memory usage when many deceased contacts present.

Technical Details
----------------------------------------
This is a partial of #9723. @johanv  I concluded that #9723 was a good change that was stalled because a) there were no unit tests and b) it was hard to review due to being a long refactor. I pulled out the first piece of logic - basically processing the deceased contacts first & then being able to exclude them from the main loop - into this PR.

Comments
----------------------------------------
The removal of the $smarty var reflects the fact emails are no longer sent from this function. Per @johanv earlier analysis, by processing deceased first & then dropping them from the main loop we can exclude the bulk of them via mysql rather than php-handling them.

---

 * [CRM-19920: Job.process_membership uses too much memory](https://issues.civicrm.org/jira/browse/CRM-19920)