### PR TITLE
Towards CRM-21140, support at api level for custom data on any entity.

### DIFF
--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -1111,7 +1111,7 @@ function _civicrm_api3_custom_format_params($params, &$values, $extends, $entity
 function _civicrm_api3_format_params_for_create(&$params, $entity) {
   $nonGenericEntities = array('Contact', 'Individual', 'Household', 'Organization');
 
-  $customFieldEntities = array_diff_key(CRM_Core_BAO_CustomQuery::$extendsMap, array_fill_keys($nonGenericEntities, 1));
+  $customFieldEntities = array_diff_key(CRM_Core_SelectValues::customGroupExtends(), array_fill_keys($nonGenericEntities, 1));
   if (!array_key_exists($entity, $customFieldEntities)) {
     return;
   }
@@ -1311,6 +1311,11 @@ function _civicrm_api3_basic_create($bao_name, &$params, $entity = NULL) {
     throw new API_Exception($msg);
   }
   else {
+    // If we have custom fields the BAO may have taken care of it or we may have to.
+    // $extendsMap provides a pretty good hard-coded list of BAOs that take care of the custom data.
+    if (isset($params['custom']) && empty(CRM_Core_BAO_CustomQuery::$extendsMap[$entity])) {
+      CRM_Core_BAO_CustomValueTable::store($params['custom'], CRM_Core_DAO_AllCoreTables::getTableForClass(CRM_Core_DAO_AllCoreTables::getFullName($entity)), $bao->id);
+    }
     $values = array();
     _civicrm_api3_object_to_array($bao, $values[$bao->id]);
     return civicrm_api3_create_success($values, $params, $entity, 'create', $bao);

--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -262,6 +262,19 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
   }
 
   /**
+   * Add a smattering of entities that don't normally have custom data.
+   *
+   * @return array
+   */
+  public static function custom_data_incl_non_std_entities_get() {
+    $customDataEntities = self::custom_data_entities();
+    $customDataEntities[] = ['UFGroup'];
+    $customDataEntities[] = ['PriceSet'];
+    $customDataEntities[] = ['PaymentToken'];
+    return $customDataEntities;
+  }
+
+  /**
    * Get entities to be skipped on get tests.
    *
    * @param bool $sequential
@@ -768,11 +781,20 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
   }
 
   /**
-   * @dataProvider custom_data_entities_get
+   * @dataProvider custom_data_incl_non_std_entities_get
    * @param $entityName
    */
   public function testCustomDataGet($entityName) {
     $this->createLoggedInUser();// so subsidiary activities are created
+
+    if (!isset(CRM_Core_BAO_CustomQuery::$extendsMap[$entityName])) {
+      $createdValue = $this->callAPISuccess('OptionValue', 'create', [
+        'option_group_id' => 'cg_extend_objects',
+        'label' => $entityName,
+        'value' => $entityName,
+        'name' => CRM_Core_DAO_AllCoreTables::getTableForClass(CRM_Core_DAO_AllCoreTables::getFullName($entityName)),
+      ]);
+    }
     // We are not passing 'check_permissions' so the the more limited permissions *should* be
     // ignored but per CRM-17700 there is a history of custom data applying permissions when it shouldn't.
     CRM_Core_Config::singleton()->userPermissionClass->permissions = array('access CiviCRM', 'view my contact');
@@ -784,12 +806,15 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
 
     $getParams = array('id' => $result['id'], 'return' => array($customFieldName));
     $check = $this->callAPISuccess($entityName, 'get', $getParams);
-    $this->assertEquals("custom string", $check['values'][$check['id']][$customFieldName]);
+    $this->assertEquals("custom string", $check['values'][$check['id']][$customFieldName], 'Custom data not present for ' . $entityName);
 
     $this->customFieldDelete($ids['custom_field_id']);
     $this->customGroupDelete($ids['custom_group_id']);
     $this->callAPISuccess($entityName, 'delete', array('id' => $result['id']));
     $this->quickCleanup(array('civicrm_uf_match'));
+    if (!empty($createdValue)) {
+      $this->callAPISuccess('OptionValue', 'delete', ['id' => $createdValue['id']]);
+    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This extends the ability to support additional entities for custom data by
adding them to the OptionGroup 'cg_extends'. At this stage there
are 2 additional tested (supported) entities - UFGroup, PriceSet, PaymentToken.

Note this 'feature' is expected to be available for the March release (5.0.0.0 I think) so that extension writers can target 5.x for custom data on any entity. This is just progress towards that goal

Will add more next iteration

Before
----------------------------------------
Not possible to extend entities for custom data outside hard-coded core ones.

After
----------------------------------------
UFGroup, PriceSet, PaymentToken now possible & tested/supported. 

Technical Details
----------------------------------------


Comments
----------------------------------------
I will follow up with the next ones I can test later

---

 * [CRM-21140: Agree & \(if applicable\) implement approach to storing extension data for entities \/ tables](https://issues.civicrm.org/jira/browse/CRM-21140)