### PR TITLE
CRM-21071 - Fix event location saving

### DIFF
--- a/CRM/Contact/Form/Location.php
+++ b/CRM/Contact/Form/Location.php
@@ -81,7 +81,6 @@ class CRM_Contact_Form_Location {
 
     //build 1 instance of all blocks, without using ajax ...
     foreach ($form->_blocks as $blockName => $label) {
-      require_once str_replace('_', DIRECTORY_SEPARATOR, 'CRM_Contact_Form_Edit_' . $blockName) . '.php';
       $name = strtolower($blockName);
 
       $instances = array(1);

--- a/CRM/Event/Form/ManageEvent/Location.php
+++ b/CRM/Event/Form/ManageEvent/Location.php
@@ -147,16 +147,13 @@ class CRM_Event_Form_ManageEvent_Location extends CRM_Event_Form_ManageEvent {
    * Function to build location block.
    */
   public function buildQuickForm() {
-    //load form for child blocks
-    if ($this->_addBlockName) {
-      $className = "CRM_Contact_Form_Edit_{$this->_addBlockName}";
-      return $className::buildQuickForm($this);
-    }
+    CRM_Contact_Form_Edit_Address::buildQuickForm($this, 1);
+    CRM_Contact_Form_Edit_Email::buildQuickForm($this, 1);
+    CRM_Contact_Form_Edit_Email::buildQuickForm($this, 2);
+    CRM_Contact_Form_Edit_Phone::buildQuickForm($this, 1);
+    CRM_Contact_Form_Edit_Phone::buildQuickForm($this, 2);
 
     $this->applyFilter('__ALL__', 'trim');
-
-    //build location blocks.
-    CRM_Contact_Form_Location::buildQuickForm($this);
 
     //fix for CRM-1971
     $this->assign('action', $this->_action);
@@ -184,7 +181,6 @@ class CRM_Event_Form_ManageEvent_Location extends CRM_Event_Form_ManageEvent {
       $locationEvents = array_unique($locationEvents);
     }
 
-    $events = array();
     if (!empty($locationEvents)) {
       $this->assign('locEvents', TRUE);
       $optionTypes = array(

--- a/CRM/Event/Form/ManageEvent/Location.php
+++ b/CRM/Event/Form/ManageEvent/Location.php
@@ -252,6 +252,9 @@ class CRM_Event_Form_ManageEvent_Location extends CRM_Event_Form_ManageEvent {
           $values['is_primary'] = 1;
         }
         $values['location_type_id'] = ($defaultLocationType->id) ? $defaultLocationType->id : 1;
+        if (isset($this->_values[$block][$count])) {
+          $values['id'] = $this->_values[$block][$count]['id'];
+        }
       }
     }
 

--- a/templates/CRM/Event/Form/ManageEvent/Location.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Location.tpl
@@ -24,21 +24,16 @@
  +--------------------------------------------------------------------+
 *}
 {* this template used to build location block *}
-{if !$addBlock}
-   <div class="help">
-        {ts}Use this form to configure the location and optional contact information for the event. This information will be displayed on the Event Information page. It will also be included in online registration pages and confirmation emails if these features are enabled.{/ts}
-    </div>
-{/if}
-
-{if $addBlock}
-{include file="CRM/Contact/Form/Edit/$blockName.tpl"}
-{else}
-<div class="crm-block crm-form-block crm-event-manage-location-form-block">
-<div class="crm-submit-buttons">
-   {include file="CRM/common/formButtons.tpl" location="top"}
+<div class="help">
+  {ts}Use this form to configure the location and optional contact information for the event. This information will be displayed on the Event Information page. It will also be included in online registration pages and confirmation emails if these features are enabled.{/ts}
 </div>
-    {if $locEvents}
-      <table class="form-layout-compressed">
+
+<div class="crm-block crm-form-block crm-event-manage-location-form-block">
+  <div class="crm-submit-buttons">
+    {include file="CRM/common/formButtons.tpl" location="top"}
+  </div>
+  {if $locEvents}
+    <table class="form-layout-compressed">
       <tr id="optionType" class="crm-event-manage-location-form-block-location_option">
         <td class="labels">
           {$form.location_option.label}
@@ -46,9 +41,9 @@
         {foreach from=$form.location_option key=key item =item}
           {if $key|is_numeric}
             <td class="value"><strong>{$item.html}</strong></td>
-            {/if}
-                {/foreach}
-       </tr>
+          {/if}
+        {/foreach}
+      </tr>
       <tr id="existingLoc" class="crm-event-manage-location-form-block-loc_event_id">
         <td class="labels">
           {$form.loc_event_id.label}
@@ -61,146 +56,114 @@
         <td id="locUsedMsg" colspan="3">
         </td>
       </tr>
-
     </table>
-    {/if}
+  {/if}
 
-
-
-    <div id="newLocation">
-      <h3>Address</h3>
-    {* Display the address block *}
-    {include file="CRM/Contact/Form/Edit/Address.tpl"}
+  {include file="CRM/Contact/Form/Edit/Address.tpl" blockId=1}
   <table class="form-layout-compressed">
-    {* Display the email block(s) *}
-    {include file="CRM/Contact/Form/Edit/Email.tpl"}
-
-    {* Display the phone block(s) *}
-    {include file="CRM/Contact/Form/Edit/Phone.tpl"}
-    </table>
-   <table class="form-layout-compressed">
-   <tr class="crm-event-is_show_location">
-    <td colspan="2">{$form.is_show_location.label}</td>
-    <td colspan="2">
-      {$form.is_show_location.html}<br />
-      <span class="description">{ts}Uncheck this box if you want to HIDE the event Address on Event Information and Registration pages as well as on email confirmations.{/ts}
-    </td>
-  </tr>
+    <tr>
+      <td><label>{ts}Email 1:{/ts}</label></td>
+      <td>{$form.email.1.email.html|crmAddClass:email}</td>
+    </tr>
+    <tr>
+      <td><label>{ts}Email 2:{/ts}</label></td>
+      <td>{$form.email.2.email.html|crmAddClass:email}</td>
+    </tr>
+    <tr>
+      <td><label>{ts}Phone 1:{/ts}</label></td>
+      <td>{$form.phone.1.phone.html|crmAddClass:phone}&nbsp;x{$form.phone.1.phone_ext.html|crmAddClass:four}&nbsp;{$form.phone.1.phone_type_id.html}</td>
+    </tr>
+    <tr>
+      <td><label>{ts}Phone 2:{/ts}</label></td>
+      <td>{$form.phone.2.phone.html|crmAddClass:phone}&nbsp;x{$form.phone.2.phone_ext.html|crmAddClass:four}&nbsp;{$form.phone.2.phone_type_id.html}</td>
+    </tr>
   </table>
-<div class="crm-submit-buttons">
-   {include file="CRM/common/formButtons.tpl" location="bottom"}
-</div>
-</div>
 
-{* Include Javascript to hide and display the appropriate blocks as directed by the php code *}
-{*include file="CRM/common/showHide.tpl"*}
-{if $locEvents}
-  {* include common additional blocks tpl *}
-  {include file="CRM/common/additionalBlocks.tpl"}
+  {if $locEvents}
 
-<script type="text/javascript">
-{literal}
-CRM.$(function($) {
-  //FIX ME: by default load 2 blocks and hide add and delete links
-  //we should make additional block function more flexible to set max block limit
-  buildBlocks('Email');
-  buildBlocks('Phone');
+    <script type="text/javascript">
+      {literal}
+      CRM.$(function($) {
+        var $form = $('form.{/literal}{$form.formClass}{literal}'),
+          locBlockId = {/literal}"{$form.loc_event_id.value.0}"{literal};
 
-  var $form = $('form.{/literal}{$form.formClass}{literal}'),
-    locBlockId = {/literal}"{$form.loc_event_id.value.0}"{literal};
+        displayMessage({/literal}{$locUsed}{literal});
 
-  displayMessage({/literal}{$locUsed}{literal});
-
-  // build blocks only if it is not built
-  function buildBlocks(element) {
-    if (!$('[id='+ element +'_Block_2]').length) {
-      buildAdditionalBlocks(element, 'CRM_Event_Form_ManageEvent_Location');
-    }
-  }
-
-  hideAddDeleteLinks('Email');
-  hideAddDeleteLinks('Phone');
-  function hideAddDeleteLinks(element) {
-    $('#add'+ element, $form).hide();
-    $('[id='+ element +'_Block_2] a:last', $form).hide();
-  }
-
-  $('#loc_event_id', $form).change(function() {
-    $.ajax({
-      url: CRM.url('civicrm/ajax/locBlock', 'reset=1'),
-      data: {'lbid': $(this).val()},
-      dataType: 'json',
-      success: function(data) {
-        var selectLocBlockId = $('#loc_event_id').val();
-        // Only change state when options are loaded
-        if (data.address_1_state_province_id) {
-          var defaultState = data.address_1_state_province_id;
-          $('#address_1_state_province_id', $form).one('crmOptionsUpdated', function() {
-            $(this).val(defaultState).change();
-          });
-          delete data.address_1_state_province_id;
-        }
-        for(i in data) {
-          if ( i == 'count_loc_used' ) {
-            if ( ((selectLocBlockId == locBlockId) && data.count_loc_used > 1) ||
-                 ((selectLocBlockId != locBlockId) && data.count_loc_used > 0) ) {
-              displayMessage(data.count_loc_used);
-            } else {
-              displayMessage(0);
+        $('#loc_event_id', $form).change(function() {
+          $.ajax({
+            url: CRM.url('civicrm/ajax/locBlock', 'reset=1'),
+            data: {'lbid': $(this).val()},
+            dataType: 'json',
+            success: function(data) {
+              var selectLocBlockId = $('#loc_event_id').val();
+              // Only change state when options are loaded
+              if (data.address_1_state_province_id) {
+                var defaultState = data.address_1_state_province_id;
+                $('#address_1_state_province_id', $form).one('crmOptionsUpdated', function() {
+                  $(this).val(defaultState).change();
+                });
+                delete data.address_1_state_province_id;
+              }
+              for(i in data) {
+                if ( i == 'count_loc_used' ) {
+                  if ( ((selectLocBlockId == locBlockId) && data.count_loc_used > 1) ||
+                    ((selectLocBlockId != locBlockId) && data.count_loc_used > 0) ) {
+                    displayMessage(data.count_loc_used);
+                  } else {
+                    displayMessage(0);
+                  }
+                } else {
+                  $('#'+i, $form).val(data[i]).change();
+                }
+              }
             }
+          });
+          return false;
+        });
+
+        function showLocFields(clear) {
+          var createNew = document.getElementsByName("location_option")[0].checked;
+          if (createNew) {
+            $('#existingLoc', $form).hide();
+            //clear all location fields values.
+            if (clear !== false) {
+              $(":input[id *= 'address_1_'], :input[id *= 'email_1_'], :input[id *= 'phone_1_']", $form).val("").change();
+              {/literal}{if $config->defaultContactCountry}
+              {if $config->defaultContactStateProvince}
+              // Set default state once options are loaded
+              var defaultState = {$config->defaultContactStateProvince}
+              {literal}
+                $('#address_1_state_province_id', $form).one('crmOptionsUpdated', function() {
+                  $(this).val(defaultState).change();
+                });
+              {/literal}
+              {/if}
+              // Set default country
+              $('#address_1_country_id', $form).val({$config->defaultContactCountry}).change();
+              {/if}{literal}
+            }
+            displayMessage(0);
           } else {
-            $('#'+i, $form).val(data[i]).change();
+            $('#existingLoc', $form).show();
+            if (clear !== false) {
+              $('#loc_event_id', $form).change();
+            }
           }
         }
-      }
-    });
-    return false;
-  });
 
-  function showLocFields(clear) {
-    var createNew = document.getElementsByName("location_option")[0].checked;
-    if (createNew) {
-      $('#existingLoc', $form).hide();
-      //clear all location fields values.
-      if (clear !== false) {
-        $(":input[id *= 'address_1_'], :input[id *= 'email_1_'], :input[id *= 'phone_1_']", $form).val("").change();
-        {/literal}{if $config->defaultContactCountry}
-          {if $config->defaultContactStateProvince}
-            // Set default state once options are loaded
-            var defaultState = {$config->defaultContactStateProvince}
-            {literal}
-              $('#address_1_state_province_id', $form).one('crmOptionsUpdated', function() {
-                $(this).val(defaultState).change();
-              });
-            {/literal}
-          {/if}
-          // Set default country
-          $('#address_1_country_id', $form).val({$config->defaultContactCountry}).change();
-        {/if}{literal}
-      }
-      displayMessage(0);
-    } else {
-      $('#existingLoc', $form).show();
-      if (clear !== false) {
-        $('#loc_event_id', $form).change();
-      }
-    }
-  }
+        $('input[name=location_option]').click(showLocFields);
+        showLocFields(false);
 
-  $('input[name=location_option]').click(showLocFields);
-  showLocFields(false);
+        function displayMessage(count) {
+          if (count) {
+            var msg = {/literal}'{ts escape="js" 1="%1"}This location is used by %1 other events. Modifying location information will change values for all events.{/ts}'{literal};
+            $('#locUsedMsg', $form).text(ts(msg, {1: count})).addClass('status');
+          } else {
+            $('#locUsedMsg', $form).text(' ').removeClass('status');
+          }
+        }
+      });
+      {/literal}
+    </script>
+  {/if}
 
-  function displayMessage(count) {
-    if (count) {
-      var msg = {/literal}'{ts escape="js" 1="%1"}This location is used by %1 other events. Modifying location information will change values for all events.{/ts}'{literal};
-      $('#locUsedMsg', $form).text(ts(msg, {1: count})).addClass('status');
-    } else {
-      $('#locUsedMsg', $form).text(' ').removeClass('status');
-    }
-  }
-});
-{/literal}
-</script>
-{/if}
-
-{/if} {* add block if end*}


### PR DESCRIPTION
Overview
In the Location tab (when configuring an event), saving more than one email address will give unexpected results, sometimes overwriting, sometimes duplicating the existing email address.

Before
----------------------------------------
Second address unreliably saved

After
----------------------------------------
Second address reliably saved

Technical Details
----------------------------------------
@colemanw  - this is my reviewers cut of #11356 - I thought the Block::create fix was risky & this variant fixes it more appropriately on the form

Comments
----------------------------------------

---

 * [CRM-21071: Event Location Tab: Second Email and Phone fields broken](https://issues.civicrm.org/jira/browse/CRM-21071)