### PR TITLE
Minor api clean up.

### DIFF
--- a/api/v3/ContactType.php
+++ b/api/v3/ContactType.php
@@ -61,7 +61,7 @@ function civicrm_api3_contact_type_create($params) {
     $params['name'] = CRM_Utils_String::munge($params['name']);
   }
 
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'ContactType');
 }
 
 /**

--- a/api/v3/ContributionPage.php
+++ b/api/v3/ContributionPage.php
@@ -42,7 +42,7 @@
  *   api result array
  */
 function civicrm_api3_contribution_page_create($params) {
-  $result = _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  $result = _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'ContributionPage');
   CRM_Contribute_PseudoConstant::flush('contributionPageAll');
   CRM_Contribute_PseudoConstant::flush('contributionPageActive');
   return $result;

--- a/api/v3/Domain.php
+++ b/api/v3/Domain.php
@@ -139,7 +139,7 @@ function civicrm_api3_domain_create($params) {
   else {
     unset($params['version']);
   }
-  $result = _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  $result = _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'Domain');
 
   $result_value = CRM_Utils_Array::first($result['values']);
   if (isset($result_value['version'])) {

--- a/api/v3/Email.php
+++ b/api/v3/Email.php
@@ -41,7 +41,7 @@
  *   API result array
  */
 function civicrm_api3_email_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'Email');
 }
 
 /**

--- a/api/v3/EntityFinancialAccount.php
+++ b/api/v3/EntityFinancialAccount.php
@@ -39,7 +39,7 @@
  * @return array
  */
 function civicrm_api3_entity_financial_account_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'EntityFinancialAccount');
 }
 
 /**

--- a/api/v3/FinancialAccount.php
+++ b/api/v3/FinancialAccount.php
@@ -39,7 +39,7 @@
  * @return array
  */
 function civicrm_api3_financial_account_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'FinancialAccount');
 }
 
 /**

--- a/api/v3/FinancialTrxn.php
+++ b/api/v3/FinancialTrxn.php
@@ -43,7 +43,7 @@ function civicrm_api3_financial_trxn_create($params) {
     throw new API_Exception("Mandatory key(s) missing from params array: both contribution_id and entity_id are missing");
   }
 
-  return _civicrm_api3_basic_create('CRM_Core_BAO_FinancialTrxn', $params);
+  return _civicrm_api3_basic_create('CRM_Core_BAO_FinancialTrxn', $params, 'FinancialTrxn');
 }
 
 /**

--- a/api/v3/FinancialType.php
+++ b/api/v3/FinancialType.php
@@ -39,7 +39,7 @@
  * @return array
  */
 function civicrm_api3_financial_type_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'FinancialType');
 }
 
 /**

--- a/api/v3/Im.php
+++ b/api/v3/Im.php
@@ -39,7 +39,7 @@
  * @return array
  */
 function civicrm_api3_im_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'IM');
 }
 
 /**

--- a/api/v3/LineItem.php
+++ b/api/v3/LineItem.php
@@ -48,7 +48,7 @@ function civicrm_api3_line_item_create($params) {
   // do the work, and it should be in a tighter function. The below function is  not really
   // readable because it is handling contribution and line item together.
   $params = CRM_Contribute_BAO_Contribution::checkTaxAmount($params, TRUE);
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'LineItem');
 }
 
 /**

--- a/api/v3/Mapping.php
+++ b/api/v3/Mapping.php
@@ -40,7 +40,7 @@
  * @return array
  */
 function civicrm_api3_mapping_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'Mapping');
 }
 
 /**

--- a/api/v3/MembershipBlock.php
+++ b/api/v3/MembershipBlock.php
@@ -41,7 +41,7 @@
  *   API result array
  */
 function civicrm_api3_membership_block_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'MembershipBlock');
 }
 
 /**

--- a/api/v3/MembershipStatus.php
+++ b/api/v3/MembershipStatus.php
@@ -40,7 +40,7 @@
  * @return array
  */
 function civicrm_api3_membership_status_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'MembershipStatus');
 }
 
 /**

--- a/api/v3/PriceField.php
+++ b/api/v3/PriceField.php
@@ -46,7 +46,7 @@
  *   api result array
  */
 function civicrm_api3_price_field_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'PriceField');
 }
 
 /**

--- a/api/v3/RecurringEntity.php
+++ b/api/v3/RecurringEntity.php
@@ -66,7 +66,7 @@ function _civicrm_api3_recurring_entity_get_spec(&$params) {
  * @return array
  */
 function civicrm_api3_recurring_entity_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'RecurringEntity');
 }
 
 /**

--- a/api/v3/UFField.php
+++ b/api/v3/UFField.php
@@ -43,7 +43,7 @@
  *   Newly created $ufFieldArray
  */
 function civicrm_api3_uf_field_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'UFField');
 }
 
 /**


### PR DESCRIPTION
Overview
Minor api standardisation -Increase places where entity passed to 'basic_create'

Before
Api slightly more inconsistent in internal workings

After
Api slightly less inconsistent in internal workings

Technical Details
Correct api behaviour is to pass the entity through.

Comments