### PR TITLE
CRM-21693 show Display Name in online pay now UI

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -91,7 +91,7 @@
   {elseif !empty($ccid)}
     {if $lineItem && $priceSetID && !$is_quick_config}
       <div class="header-dark">
-        {ts}Contribution Information{/ts}
+        {ts}Contribution Information{/ts}{if $display_name} &ndash; {$display_name}{/if}
       </div>
       {assign var="totalAmount" value=$pendingAmount}
       {include file="CRM/Price/Page/LineItem.tpl" context="Contribution"}


### PR DESCRIPTION
Overview
----------------------------------------
Show the Display Name in the Online Pay Now UI
JIRA: https://issues.civicrm.org/jira/browse/CRM-21693

Before
----------------------------------------
Using the special constructed PayNow link it was not clear for which person the payment was for. This, In our case, especially confused parents who needed to make a payment and had been mailed several payment links. 
![screenshot from 2018-01-22 21-07-28](https://user-images.githubusercontent.com/2195908/35249467-71669ab8-ffd2-11e7-86cc-393191e95ef2.png)

After
----------------------------------------
The Online Pay Now form is still extremely basic but shows the Display Name that belongs to the person the contribution belongs to.
![screenshot from 2018-01-22 21-05-32](https://user-images.githubusercontent.com/2195908/35249475-7a7a1238-ffd2-11e7-904b-9ca62ee9c9a3.png)

Technical Details
----------------------------------------
Just inserted the display name in case !empty($ccid)

Comments
----------------------------------------
Currently the price set of the contribution is shown. All other fields (name, email) are hidden.
Ideally the form UI should also show the 'reason' for the contribution.
For an event that would be the event name, for a membership the membership type.
This gives the person who is about to pay the confidence that all details of the payment are correct which means he or she is more likely to proceed.
