### PR TITLE
Test fixes, towards CRM-17647

### DIFF
--- a/tests/phpunit/CRM/Event/BAO/AdditionalPaymentTest.php
+++ b/tests/phpunit/CRM/Event/BAO/AdditionalPaymentTest.php
@@ -91,7 +91,6 @@ class CRM_Event_BAO_AdditionalPaymentTest extends CiviUnitTestCase {
       'total_amount' => $actualPaidAmt,
       'source' => 'Fall Fundraiser Dinner: Offline registration',
       'currency' => 'USD',
-      'non_deductible_amount' => 'null',
       'receipt_date' => date('Y-m-d') . " 00:00:00",
       'contact_id' => $this->_contactId,
       'financial_type_id' => 4,
@@ -103,8 +102,8 @@ class CRM_Event_BAO_AdditionalPaymentTest extends CiviUnitTestCase {
       'partial_amount_to_pay' => $actualPaidAmt,
     );
 
-    $contribution = CRM_Contribute_BAO_Contribution::create($contributionParams);
-    $contributionId = $contribution->id;
+    $contribution = $this->callAPISuccess('Contribution', 'create', $contributionParams);
+    $contributionId = $contribution['id'];
     $participant = $this->callAPISuccessGetSingle('participant', array('id' => $participant['id']));
 
     // add participant payment entry
@@ -125,11 +124,11 @@ class CRM_Event_BAO_AdditionalPaymentTest extends CiviUnitTestCase {
       $params, $lineItem
     );
     $lineItemVal[$priceSetId] = $lineItem;
-    CRM_Price_BAO_LineItem::processPriceSet($participant['id'], $lineItemVal, $contribution, 'civicrm_participant');
+    CRM_Price_BAO_LineItem::processPriceSet($participant['id'], $lineItemVal, $this->getContributionObject($contributionId), 'civicrm_participant');
 
     return array(
       'participant' => $participant,
-      'contribution' => $contribution,
+      'contribution' => $contribution['values'][$contribution['id']],
       'lineItem' => $templineItems,
       'params' => $tempParams,
       'feeBlock' => $feeBlock,
@@ -155,7 +154,7 @@ class CRM_Event_BAO_AdditionalPaymentTest extends CiviUnitTestCase {
 
     // status checking
     $this->assertEquals($participant['participant_status_id'], 14, 'Status record is not proper for participant');
-    $this->assertEquals($contribution->contribution_status_id, 8, 'Status record is not proper for contribution');
+    $this->assertEquals($result['contribution']['contribution_status_id'], 8, 'Status record is not proper for contribution');
   }
 
   /**
@@ -165,6 +164,7 @@ class CRM_Event_BAO_AdditionalPaymentTest extends CiviUnitTestCase {
     $feeAmt = 100;
     $amtPaid = 80;
     $result = $this->addParticipantWithPayment($feeAmt, $amtPaid);
+    $contributionID = $result['contribution']['id'];
     extract($result);
 
     //Complete the partial payment.
@@ -172,15 +172,15 @@ class CRM_Event_BAO_AdditionalPaymentTest extends CiviUnitTestCase {
       'total_amount' => 20,
       'payment_instrument_id' => 3,
     );
-    CRM_Contribute_BAO_Contribution::recordAdditionalPayment($contribution->id, $submittedValues, 'owed', $participant['id']);
+    CRM_Contribute_BAO_Contribution::recordAdditionalPayment($contributionID, $submittedValues, 'owed', $participant['id']);
 
     //Change selection to a lower amount.
     $params['price_2'] = 50;
-    CRM_Price_BAO_LineItem::changeFeeSelections($params, $participant['id'], 'participant', $contribution->id, $feeBlock, $lineItem, $feeAmt);
+    CRM_Price_BAO_LineItem::changeFeeSelections($params, $participant['id'], 'participant', $contributionID, $feeBlock, $lineItem, $feeAmt);
 
     //Record a refund of the remaining amount.
     $submittedValues['total_amount'] = 50;
-    CRM_Contribute_BAO_Contribution::recordAdditionalPayment($contribution->id, $submittedValues, 'refund', $participant['id']);
+    CRM_Contribute_BAO_Contribution::recordAdditionalPayment($contributionID, $submittedValues, 'refund', $participant['id']);
     $paymentInfo = CRM_Contribute_BAO_Contribution::getPaymentInfo($participant['id'], 'event', TRUE);
     $transaction = $paymentInfo['transaction'];
 

--- a/tests/phpunit/CRM/Event/BAO/ChangeFeeSelectionTest.php
+++ b/tests/phpunit/CRM/Event/BAO/ChangeFeeSelectionTest.php
@@ -205,7 +205,6 @@ class CRM_Event_BAO_ChangeFeeSelectionTest extends CiviUnitTestCase {
       'total_amount' => $actualPaidAmt,
       'source' => 'Testset with information',
       'currency' => 'USD',
-      'non_deductible_amount' => 'null',
       'receipt_date' => date('Y-m-d') . " 00:00:00",
       'contact_id' => $this->_contactId,
       'financial_type_id' => 4,
@@ -217,8 +216,8 @@ class CRM_Event_BAO_ChangeFeeSelectionTest extends CiviUnitTestCase {
       'partial_amount_to_pay' => $actualPaidAmt,
     );
 
-    $contribution = CRM_Contribute_BAO_Contribution::create($contributionParams);
-    $this->_contributionId = $contribution->id;
+    $contribution = $this->callAPISuccess('Contribution', 'create', $contributionParams);
+    $this->_contributionId = $contribution['id'];
 
     $this->callAPISuccess('participant_payment', 'create', array(
       'participant_id'  => $this->_participantId,
@@ -229,7 +228,7 @@ class CRM_Event_BAO_ChangeFeeSelectionTest extends CiviUnitTestCase {
     $lineItem = CRM_Price_BAO_LineItem::getLineItems($this->_participantId, 'participant');
     CRM_Price_BAO_PriceSet::processAmount($this->_feeBlock, $priceSetParams, $lineItem);
     $lineItemVal[$this->_priceSetID] = $lineItem;
-    CRM_Price_BAO_LineItem::processPriceSet($participant['id'], $lineItemVal, $contribution, 'civicrm_participant');
+    CRM_Price_BAO_LineItem::processPriceSet($participant['id'], $lineItemVal, $this->getContributionObject($contribution['id']), 'civicrm_participant');
     $this->balanceCheck($this->_expensiveFee);
   }
 
@@ -346,7 +345,6 @@ class CRM_Event_BAO_ChangeFeeSelectionTest extends CiviUnitTestCase {
       'total_amount' => 10,
       'source' => 'Testset with information',
       'currency' => 'USD',
-      'non_deductible_amount' => 'null',
       'receipt_date' => date('Y-m-d') . " 00:00:00",
       'contact_id' => $this->_contactId,
       'financial_type_id' => 4,
@@ -356,8 +354,8 @@ class CRM_Event_BAO_ChangeFeeSelectionTest extends CiviUnitTestCase {
       'skipLineItem' => 1,
     );
 
-    $contribution = CRM_Contribute_BAO_Contribution::create($contributionParams);
-    $this->_contributionId = $contribution->id;
+    $contribution = $this->callAPISuccess('Contribution', 'create', $contributionParams);
+    $this->_contributionId = $contribution['id'];
 
     $this->callAPISuccess('participant_payment', 'create', array(
       'participant_id'  => $this->_participantId,
@@ -369,7 +367,7 @@ class CRM_Event_BAO_ChangeFeeSelectionTest extends CiviUnitTestCase {
     $lineItem = CRM_Price_BAO_LineItem::getLineItems($this->_participantId, 'participant');
     CRM_Price_BAO_PriceSet::processAmount($this->_feeBlock, $priceSetParams, $lineItem);
     $lineItemVal[$this->_priceSetID] = $lineItem;
-    CRM_Price_BAO_LineItem::processPriceSet($this->_participantId, $lineItemVal, $contribution, 'civicrm_participant');
+    CRM_Price_BAO_LineItem::processPriceSet($this->_participantId, $lineItemVal, $this->getContributionObject($contribution['id']), 'civicrm_participant');
 
     // CASE 2: Choose text price qty 3 (x$10 = $30 amount)
     $priceSetParams['price_1'] = 3;

--- a/tests/phpunit/CRM/Financial/BAO/FinancialItemTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/FinancialItemTest.php
@@ -352,18 +352,4 @@ class CRM_Financial_BAO_FinancialItemTest extends CiviUnitTestCase {
     $this->callAPISuccessGetSingle('FinancialItem', $params, $checkAgainst);
   }
 
-  /**
-   * Get the contribution object.
-   *
-   * @param int $contributionID
-   *
-   * @return \CRM_Contribute_BAO_Contribution
-   */
-  protected function getContributionObject($contributionID) {
-    $contributionObj = new CRM_Contribute_BAO_Contribution();
-    $contributionObj->id = $contributionID;
-    $contributionObj->find(TRUE);
-    return $contributionObj;
-  }
-
 }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3983,4 +3983,19 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
     return CRM_Utils_Money::format($amount, NULL, '%a');
   }
 
+
+  /**
+   * Get the contribution object.
+   *
+   * @param int $contributionID
+   *
+   * @return \CRM_Contribute_BAO_Contribution
+   */
+  protected function getContributionObject($contributionID) {
+    $contributionObj = new CRM_Contribute_BAO_Contribution();
+    $contributionObj->id = $contributionID;
+    $contributionObj->find(TRUE);
+    return $contributionObj;
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Test fixes towards never calling Contribution::Create without skipCleanMoney

Before
----------------------------------------
tests pass

After
----------------------------------------
tests pass. Less places where Contribution::create called without skipCleanMoney (via the api)

Technical Details
----------------------------------------
Towards #11539

Comments

---

 * [CRM-17647: Recording payment truncates the amount after the comma \(whether thousands or decimal separator\)](https://issues.civicrm.org/jira/browse/CRM-17647)