### PR TITLE
CRM-17647 fix ContributionForm to use skipCleanMoney on update & upda…

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1550,10 +1550,12 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
 
       // get the required field value only.
 
-      $params = $ids = array();
-
-      $params['contact_id'] = $this->_contactID;
-      $params['currency'] = $this->getCurrency($submittedValues);
+      $params = [
+        'contact_id' => $this->_contactID,
+        'currency' => $this->getCurrency($submittedValues),
+        'skipCleanMoney' => TRUE,
+        'id' => $this->_id,
+      ];
 
       //format soft-credit/pcp param first
       CRM_Contribute_BAO_ContributionSoft::formatSoftCreditParams($submittedValues, $this);
@@ -1573,10 +1575,6 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
         $params[$f] = CRM_Utils_Array::value($f, $formValues);
       }
 
-      // CRM-5740 if priceset is used, no need to cleanup money.
-      if ($priceSetId) {
-        $params['skipCleanMoney'] = 1;
-      }
       $params['revenue_recognition_date'] = NULL;
       if (!empty($formValues['revenue_recognition_date'])
         && count(array_filter($formValues['revenue_recognition_date'])) == 2
@@ -1609,8 +1607,6 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
         $params['is_pay_later'] = 0;
       }
 
-      $ids['contribution'] = $params['id'] = $this->_id;
-
       // Add Additional common information to formatted params.
       CRM_Contribute_Form_AdditionalInfo::postProcessCommon($formValues, $params, $this);
       if ($pId) {
@@ -1636,7 +1632,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       if (!empty($params['note']) && !empty($submittedValues['note'])) {
         unset($params['note']);
       }
-      $contribution = CRM_Contribute_BAO_Contribution::create($params, $ids);
+      $contribution = CRM_Contribute_BAO_Contribution::create($params);
 
       // process associated membership / participant, CRM-4395
       if ($contribution->id && $action & CRM_Core_Action::UPDATE) {

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -1040,7 +1040,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
 
     $contribParams['skipLineItem'] = 1;
     // create contribution record
-    $contribution = CRM_Contribute_BAO_Contribution::add($contribParams, $ids);
+    $contribution = CRM_Contribute_BAO_Contribution::add($contribParams);
     // CRM-11124
     CRM_Event_BAO_Participant::createDiscountTrxn($form->_eventId, $contribParams, NULL, CRM_Price_BAO_PriceSet::parseFirstPriceSetValueIDFromParams($params));
 


### PR DESCRIPTION
Overview
----------------------------------------
As part of resolving issues around currency separators this PR adds tests to submitting the contribution form in update mode. Identified instances of mis-recording amounts have been fixed but there may well be more & we need to fix the underlying issue.

Before
----------------------------------------
tests don't cover both separator variants, BAO is cleaning the values when they should be & are being cleaned in the form

After
----------------------------------------
Additional tests. BAO not being permitted to cleanMoney

Technical Details
----------------------------------------
The underlying issue  is the attempt to 'cleanMoney' in the Contribution_BAO is unreliable.  At some point it was determined that money might have already been cleaned before this point (true) & some unreliable extra handling was added (bad). 

To get back to reliability around handling numbers with a thousand separator we need to
1) ensure all amounts are cleaned close to the point where they are submitted on the form layer
2) remove all places where BAO or processing functions clean money - in order to do this we will
  a) make sure that all core places in code that call Contribute_BAO_Contribution::create pass 'skipCleanMoney' (the api already does)
  b) add a deprecation notice so that any code that calls it without skipCleanMoney gets a notice for a few versions
 c) remove cleaning money from the contribution BAO.

Comments
----------------------------------------
#11539 has tests identifying where the BAO is being allowed to attempt to clean money 