### PR TITLE
CRM-16421 - Add civicrm-setup. Build civicrm-*-wporg.zip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *~
 *.bak
+.use-civicrm-setup
 backdrop/
 bower_components
 CRM/Case/xml/configuration

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,8 @@
     "civicrm/civicrm-cxn-rpc": "~0.17.07.01",
     "pear/Auth_SASL": "1.1.0",
     "pear/Net_SMTP": "1.6.*",
-    "pear/Net_socket": "1.0.*"
+    "pear/Net_socket": "1.0.*",
+    "civicrm/civicrm-setup": "~0.2.0"
   },
   "repositories": [
     {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "6abd711477a577550967549258a7aec0",
+    "content-hash": "3aaaa7a6146043643e9fe2cbc8030cca",
     "packages": [
         {
             "name": "civicrm/civicrm-cxn-rpc",
@@ -42,6 +42,43 @@
             ],
             "description": "RPC library for CiviConnect",
             "time": "2017-07-18T04:02:44+00:00"
+        },
+        {
+            "name": "civicrm/civicrm-setup",
+            "version": "v0.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/civicrm/civicrm-setup.git",
+                "reference": "e7991aff516c3fff952bed8f90832804a134358a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/civicrm/civicrm-setup/zipball/e7991aff516c3fff952bed8f90832804a134358a",
+                "reference": "e7991aff516c3fff952bed8f90832804a134358a",
+                "shasum": ""
+            },
+            "require": {
+                "psr/log": "~1.0",
+                "symfony/event-dispatcher": "^2.6.13 || ~3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "civicrm-setup-autoload.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "CiviCRM LLC",
+                    "email": "info@civicrm.org"
+                }
+            ],
+            "description": "CiviCRM installation library",
+            "time": "2018-01-23T06:26:55+00:00"
         },
         {
             "name": "dompdf/dompdf",

--- a/distmaker/dists/wordpress_php5.sh
+++ b/distmaker/dists/wordpress_php5.sh
@@ -29,5 +29,11 @@ dm_install_cvext com.iatspayments.civicrm "$TRG/civicrm/civicrm/ext/iatspayments
 cd $TRG
 ${DM_ZIP:-zip} -r -9 $DM_TARGETDIR/civicrm-$DM_VERSION-wordpress.zip *
 
+# gen wporg tarball
+touch "$TRG/civicrm/civicrm/.use-civicrm-setup"
+cp "$TRG/civicrm/civicrm/vendor/civicrm/civicrm-setup/plugins/blocks/opt-in.disabled.php" "$TRG/civicrm/civicrm/vendor/civicrm/civicrm-setup/plugins/blocks/opt-in.civi-setup.php"
+cd "$TRG"
+${DM_ZIP:-zip} -r -9 $DM_TARGETDIR/civicrm-$DM_VERSION-wporg.zip *
+
 # clean up
 rm -rf $TRG


### PR DESCRIPTION
Overview
----------------------------------------
This patch adds a new library, `civicrm-setup`, to the list of dependencies. The library is roughly akin to `civicrm/install/index.php`, but it provides a defined API, more documentation, and more readable/digestable files. (*Related*: Draft blog: https://gist.github.com/totten/4b8d0b447f89763fe7781d3fc31d3656 )

The library only operates on an opt-in basis: all the existing builds/installers should continue to work as before, unless they take some special action to use the new one. 

Before
----------------------------------------
* None of the installer tarballs/zipballs include a copy of `civicrm-setup`.
* `distmaker` generates `civicrm-X.Y.Z-wordpress.zip`, which uses the existing `civicrm/install/index.php`.

After
----------------------------------------
* All of the installer tarballs/zipballs include a copy of `civicrm-setup`.
* `distmaker` generates `civicrm-X.Y.Z-wordpress.zip`, which uses the existing `civicrm/install/index.php`. (Same as before.)
* `distmaker` generates `civicrm-X.Y.Z-wporg.zip`, which uses `civicrm-setup`. This ZIP file is identical, save for two changes:
    * It adds the file `.use-civicrm-setup` to activate the new installer.
    * It enables `plugin/blocks/opt-in`, which displays a set of "Opt-in" buttons on the install screen.
* All existing builds still use their old installers. The only ways to use the new one:
    * Download and activate `civicrm-*-wporg.zip` on WordPress, or...
    * Download the WordPress, D7, or Backdrop builds. Use the command `cv core:install` to perform installation.

Comments
----------------------------------------
This is a replacement for #11573 which aims to use a simpler distribution-channel.

Depends: https://github.com/civicrm/civicrm-wordpress/pull/122

To test, I did this on a local machine:
 * Manually ran `distmaker` to create tar/zip files.
 * Used `civihydra` to build new test sites and to extract all the tar/zip files.
 * Logged into each site and ran the web-based installer. 
 * (Tested with `*-wordpress.zip`, `*-wporg.zip`, `*-drupal.tar.gz`, `*-backdrop.tar.gz`, and `*-joomla.zip`),

As expected, the `*-wporg.zip` displayed the new installer, and all other packages used the old installer. All installer worked as expected locally.


---

 * [CRM-16421: Work to get CiviCRM for WordPress in WordPress' official Repository](https://issues.civicrm.org/jira/browse/CRM-16421)