### PR TITLE
CRM-21698 Format amount

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -999,6 +999,19 @@ abstract class CRM_Core_Payment {
   }
 
   /**
+   * Get the currency for the transaction.
+   *
+   * Handle any inconsistency about how it is passed in here.
+   *
+   * @param $params
+   *
+   * @return string
+   */
+  protected function getAmount($params) {
+    return CRM_Utils_Money::format($params['amount'], NULL, NULL, TRUE);
+  }
+
+  /**
    * Get url to return to after cancelled or failed transaction.
    *
    * @param string $qfKey

--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -488,7 +488,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
     $this->initialize($args, 'DoDirectPayment');
 
     $args['paymentAction'] = 'Sale';
-    $args['amt'] = $params['amount'];
+    $args['amt'] = $this->getAmount($params);
     $args['currencyCode'] = $this->getCurrency($params);
     $args['invnum'] = $params['invoiceID'];
     $args['ipaddress'] = $params['ip_address'];
@@ -524,7 +524,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
         $params['amount'] . " Per " .
         $params['frequency_interval'] . " " .
         $params['frequency_unit'];
-      $args['amt'] = $params['amount'];
+      $args['amt'] = $this->getAmount($params);
       $args['totalbillingcycles'] = CRM_Utils_Array::value('installments', $params);
       $args['version'] = 56.0;
       $args['PROFILEREFERENCE'] = "" .
@@ -727,7 +727,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
       $this->initialize($args, 'UpdateRecurringPaymentsProfile');
 
       $args['PROFILEID'] = $params['subscriptionId'];
-      $args['AMT'] = $params['amount'];
+      $args['AMT'] = $this->getAmount($params);
       $args['CURRENCYCODE'] = $config->defaultCurrency;
       $args['CREDITCARDTYPE'] = $params['credit_card_type'];
       $args['ACCT'] = $params['credit_card_number'];
@@ -765,7 +765,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
       $this->initialize($args, 'UpdateRecurringPaymentsProfile');
 
       $args['PROFILEID'] = $params['subscriptionId'];
-      $args['AMT'] = $params['amount'];
+      $args['AMT'] = $this->getAmount($params);
       $args['CURRENCYCODE'] = $config->defaultCurrency;
       $args['BILLINGFREQUENCY'] = $params['installments'];
 
@@ -909,7 +909,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
 
       $paypalParams += array(
         'cmd' => '_xclick-subscriptions',
-        'a3' => $params['amount'],
+        'a3' => $this->getAmount($params),
         'p3' => $params['frequency_interval'],
         't3' => ucfirst(substr($params['frequency_unit'], 0, 1)),
         'src' => 1,

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -838,9 +838,8 @@ WHERE  id = %1";
         $params['amount_level'] = CRM_Core_DAO::VALUE_SEPARATOR . implode(CRM_Core_DAO::VALUE_SEPARATOR, $amount_level) . $displayParticipantCount . CRM_Core_DAO::VALUE_SEPARATOR;
       }
     }
-    // @todo this was a fix for CRM-16460 but is too deep in the system for formatting
-    // and probably causes negative amounts to save as $0 depending on server config.
-    $params['amount'] = CRM_Utils_Money::format($totalPrice, NULL, NULL, TRUE);
+
+    $params['amount'] = $totalPrice;
     $params['tax_amount'] = $totalTax;
     if ($component) {
       foreach ($autoRenew as $dontCare => $eachAmount) {


### PR DESCRIPTION
Overview
----------------------------------------
Fix intermittent mis-recording on negative contributions.

Before
----------------------------------------
On some systems recording a negative contribution results in a $0 contribution due to an earlier 'mis-fix' - #5767. 

The testEnterNegativeContribution fails locally for me. When I add thousandSeparator testing testSubmitContributionPageWithPriceSet passes locally & fails remotely

After
----------------------------------------
locally the test & UI submission work for negative amounts & on testSubmitContributionPageWithPriceSet

Technical Details
----------------------------------------
The correct place to clean money is on submission & the correct place to format it is immediately prior to use. It was being formatted deep in the BAO - this moves it to the processor class.

Comments
----------------------------------------
@mattwire @adixon I think we should do this small fix rather than hang off for the big fix discussed on CRM-16460 - if we do a bigger fix we can call it from this function

Payment processor writers that rely on this code may need to ensure they are formatting the amounts or using the new function. Omnipay, IATS are not affected

---

 * [CRM-16460: PayPal Standard needs two digits of cents](https://issues.civicrm.org/jira/browse/CRM-16460)

---

 * [CRM-21698: On some systems recording a negative contribution results in a $0 contribution](https://issues.civicrm.org/jira/browse/CRM-21698)