### PR TITLE
CRM-20697 - Online pay now anomalies (contribution transfer to new contact)

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -1300,6 +1300,9 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     if (empty($this->_ccid)) {
       return;
     }
+    if (!$this->getContactID()) {
+      CRM_Core_Error::statusBounce(ts("Returning since there is no contact attached to this contribution id."));
+    }
 
     $payment = CRM_Contribute_BAO_Contribution::getPaymentInfo($this->_ccid, 'contribution');
     //bounce if the contribution is not pending.


### PR DESCRIPTION
Overview
----------------------------------------
Avoid contribution to be logged under new contact when "pay now" is done anonymously.

Before
----------------------------------------
- Pay now functionality does not contain any authentication on the main page.
- Contribution gets recorded under new contact when paid as anonymous.

After
----------------------------------------
- Checksum is added to the pay now link so that it is bounced back when no contact is found on the main page.
- As cid is checked and assigned on the main page, contribution is recorded for the correct contact.

---

 * [CRM-20697: Online pay now anomalies \(contribution transfer to new contact\) ](https://issues.civicrm.org/jira/browse/CRM-20697)