### PR TITLE
CRM-21701 - ensure street addresses are parsed

### DIFF
--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -350,33 +350,32 @@ class CRM_Core_BAO_Address extends CRM_Core_DAO_Address {
       $params['country_id'] == 1228
     ) {
       CRM_Utils_Address_USPS::checkAddress($params);
+    }
+    // do street parsing again if enabled, since street address might have changed
+    $parseStreetAddress = CRM_Utils_Array::value(
+      'street_address_parsing',
+      CRM_Core_BAO_Setting::valueOptions(
+        CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
+        'address_options'
+      ),
+      FALSE
+    );
 
-      // do street parsing again if enabled, since street address might have changed
-      $parseStreetAddress = CRM_Utils_Array::value(
-        'street_address_parsing',
-        CRM_Core_BAO_Setting::valueOptions(
-          CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-          'address_options'
-        ),
-        FALSE
-      );
-
-      if ($parseStreetAddress && !empty($params['street_address'])) {
-        foreach (array(
-                   'street_number',
-                   'street_name',
-                   'street_unit',
-                   'street_number_suffix',
-                 ) as $fld) {
-          unset($params[$fld]);
-        }
-        // main parse string.
-        $parseString = CRM_Utils_Array::value('street_address', $params);
-        $parsedFields = CRM_Core_BAO_Address::parseStreetAddress($parseString);
-
-        // merge parse address in to main address block.
-        $params = array_merge($params, $parsedFields);
+    if ($parseStreetAddress && !empty($params['street_address'])) {
+      foreach (array(
+                 'street_number',
+                 'street_name',
+                 'street_unit',
+                 'street_number_suffix',
+               ) as $fld) {
+        unset($params[$fld]);
       }
+      // main parse string.
+      $parseString = CRM_Utils_Array::value('street_address', $params);
+      $parsedFields = CRM_Core_BAO_Address::parseStreetAddress($parseString);
+
+      // merge parse address in to main address block.
+      $params = array_merge($params, $parsedFields);
     }
 
     // check if geocode should be skipped (can be forced with an optional parameter through the api)


### PR DESCRIPTION
Even if USPS street parsing is disabled.

Overview
----------------------------------------
Ensure that when addresses are saved, the component parts (street number, street name, apartment, etc) are properly parsed. Also ensures that the address that is displayed on the summary screen matches the address displayed when you click to edit the address.

Before
----------------------------------------
If your install did have street address parsing enabled, but did not have the USPS parsing enabled, then when an address was saved, it was not parsed into it's component parts.

If updating an address, it means that the previous address's component parts were still saved in the component part fields, but the new address was saved in the "street_address" field and displayed on the summary page.

After
----------------------------------------
With this patch, the address is always properly parsed (providing address parsing is enabled).

Technical Details
----------------------------------------
Note: if you ignore white space, the code change is quite minimal -it just adjusts where the closing brace for the USPS if / then statement ends.

Comments
----------------------------------------

---

 * [CRM-21701: street addresses are not reliably parsed](https://issues.civicrm.org/jira/browse/CRM-21701)