### PR TITLE
CRM-21687 fix issue with MariaDB 10.2 logging query writing due to cu…

### DIFF
--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -444,7 +444,7 @@ AND    (TABLE_NAME LIKE 'log_civicrm_%' $nonStandardTableNameString )
     $line = preg_grep("/^  `$col` /", $createQuery);
     $line = rtrim(array_pop($line), ',');
     // CRM-11179
-    $line = $this->fixTimeStampAndNotNullSQL($line);
+    $line = self::fixTimeStampAndNotNullSQL($line);
     return $line;
   }
 
@@ -484,9 +484,12 @@ AND    (TABLE_NAME LIKE 'log_civicrm_%' $nonStandardTableNameString )
    *
    * @return mixed
    */
-  public function fixTimeStampAndNotNullSQL($query) {
+  public static function fixTimeStampAndNotNullSQL($query) {
+    $query = str_ireplace("TIMESTAMP() NOT NULL", "TIMESTAMP NULL", $query);
     $query = str_ireplace("TIMESTAMP NOT NULL", "TIMESTAMP NULL", $query);
+    $query = str_ireplace("DEFAULT CURRENT_TIMESTAMP() ON UPDATE CURRENT_TIMESTAMP()", '', $query);
     $query = str_ireplace("DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP", '', $query);
+    $query = str_ireplace("DEFAULT CURRENT_TIMESTAMP()", '', $query);
     $query = str_ireplace("DEFAULT CURRENT_TIMESTAMP", '', $query);
     $query = str_ireplace("NOT NULL", '', $query);
     return $query;

--- a/tests/phpunit/CRM/Logging/SchemaTest.php
+++ b/tests/phpunit/CRM/Logging/SchemaTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Class CRM_Logging_SchmeaTest
+ * @group headless
+ */
+class CRM_Logging_SchemaTest extends CiviUnitTestCase {
+
+  public function setUp() {
+    parent::setUp();
+  }
+
+  public function tearDown() {
+    parent::tearDown();
+  }
+
+  public function queryExamples() {
+    $examples = [];
+    $examples[] = ["`modified_date` timestamp NULL DEFAULT current_timestamp() ON UPDATE current_timestamp() COMMENT 'When the mailing (or closely related entity) was created or modified or deleted.'", "`modified_date` timestamp NULL  COMMENT 'When the mailing (or closely related entity) was created or modified or deleted.'"];
+    $examples[] = ["`modified_date` timestamp NULL DEFAULT current_timestamp ON UPDATE current_timestamp COMMENT 'When the mailing (or closely related entity) was created or modified or deleted.'", "`modified_date` timestamp NULL  COMMENT 'When the mailing (or closely related entity) was created or modified or deleted.'"];
+    return $examples;
+  }
+
+  /**
+   * Tests the function fixTimeStampAndNotNullSQL in CRM_Logging_Schema
+   *
+   * @dataProvider queryExamples
+   */
+  public function testQueryRewrite($query, $expectedQuery) {
+    $this->assertEquals($expectedQuery, CRM_Logging_Schema::fixTimeStampAndNotNullSQL($query));
+  }
+
+}


### PR DESCRIPTION
…rrent_timestamp and timestamp getting () added on the end in Maria10.2

Overview
----------------------------------------
In MariaDB 10.2 CURRENT_TIMESTAMP and TIMESTAMP get () added on at the end of the definition. This is my take on it following testing locally on a 10.2 Maria DB. i used str_ireplace as it seemed safer and more consistent with our current practices. 

Before
----------------------------------------
Logging would not be able to be enabled on Maria10.2

After
----------------------------------------
Logging is able to be enabled

ping @gah242s @eileenmcnaughton @mlutfy @mattwire This has worked locally for me on a dmaster build. I have also tried added a unit test of the query writing hence the change to static function but that may have issues. 