### PR TITLE
CRM-21704: Do not allow Reserved Case Types to be Disabled/Deleted

### DIFF
--- a/ang/crmCaseType/list.html
+++ b/ang/crmCaseType/list.html
@@ -43,7 +43,7 @@ Required vars: caseTypes
                   {{ts('Enable')}}
                 </a>
               </li>
-              <li ng-show="caseType.is_active">
+              <li ng-show="caseType.is_active && !caseType.is_reserved">
                 <a class="action-item crm-hover-button"
                    crm-confirm="{type: 'disable', obj: caseType}"
                    on-yes="toggleCaseType(caseType)">
@@ -57,7 +57,7 @@ Required vars: caseTypes
                   {{ts('Revert')}}
                 </a>
               </li>
-              <li>
+              <li ng-show="!caseType.is_reserved">
                 <a class="action-item crm-hover-button"
                    crm-confirm="{type: 'delete', obj: caseType}"
                    on-yes="deleteCaseType(caseType)">


### PR DESCRIPTION
Overview
----------------------------------------
On the Case Types listing page (Url: /civicrm/a/#/caseType), Case types that are reserved in the database can be Disabled or Deleted. This should not be allowed because similarly, option group values that are reserved in the database cannot be deleted or disabled.

Before
----------------------------------------
A case type that is reserved in the database is allowed to be disabled or deleted on the case Types listing page(civicrm/a/#/caseType)

After
----------------------------------------
A case type that is reserved in the database is NOT be allowed to be disabled or deleted on the case Types listing page(civicrm/a/#/caseType)

---

 * [CRM-21704: Do Not allow a case type that is reserved to be deleted or disabled.](https://issues.civicrm.org/jira/browse/CRM-21704)