### PR TITLE
CRM-21708: Fixed page structure by adding/removing classes

### DIFF
--- a/templates/CRM/Admin/Page/ConfigTaskList.tpl
+++ b/templates/CRM/Admin/Page/ConfigTaskList.tpl
@@ -26,7 +26,7 @@
 {capture assign="linkTitle"}{ts}Edit settings{/ts}{/capture}
 {capture assign="adminMenu"}{crmURL p="civicrm/admin" q="reset=1"}{/capture}
 
-<div id="help" class="description">
+<div class="help">
     {ts 1=$adminMenu}Use this checklist to review and complete configuration tasks for your site. You will be redirected back to this checklist after saving each setting. Settings which you have not yet reviewed will be <span class="status-overdue">displayed in red</span>. After you have visited a page, the links will <span class="status-pending">display in green</span>  (although you may still need to revisit the page to complete or update the settings). You can access this page again from the <a href="%1">Administer CiviCRM</a> menu at any time.{/ts}
 </div>
 

--- a/templates/CRM/Admin/Page/MessageTemplates.tpl
+++ b/templates/CRM/Admin/Page/MessageTemplates.tpl
@@ -81,7 +81,7 @@
     </div>
   </div>
 
-  <div id="crm-submit-buttons">{$form.buttons.html}</div>
+  <div id="crm-submit-buttons" class="crm-submit-buttons">{$form.buttons.html}</div>
   </fieldset>
 {/if}
 

--- a/templates/CRM/Contact/Form/Search/Builder.tpl
+++ b/templates/CRM/Contact/Form/Search/Builder.tpl
@@ -35,7 +35,7 @@
         {* Table for adding search criteria. *}
         {include file="CRM/Contact/Form/Search/table.tpl"}
         <div class="clear"></div>
-        <div id="crm-submit-buttons">
+        <div id="crm-submit-buttons" class="crm-submit-buttons">
           {$form.buttons.html}
         </div>
       </div>

--- a/templates/CRM/Event/Form/Registration/AdditionalParticipant.tpl
+++ b/templates/CRM/Event/Form/Registration/AdditionalParticipant.tpl
@@ -70,7 +70,7 @@
   {include file="CRM/UF/Form/Block.tpl" fields=$additionalCustomPost}
 </div>
 
-<div id="crm-submit-buttons">
+<div id="crm-submit-buttons" class="crm-submit-buttons">
     {include file="CRM/common/formButtons.tpl"}
 </div>
 </div>

--- a/templates/CRM/Event/Form/Registration/ParticipantConfirm.tpl
+++ b/templates/CRM/Event/Form/Registration/ParticipantConfirm.tpl
@@ -28,7 +28,7 @@
         {$statusMsg}
   </div>
 
-  <div id="crm-submit-buttons">
+  <div id="crm-submit-buttons" class="crm-submit-buttons">
   {include file="CRM/common/formButtons.tpl" location="bottom"}
   </div>
 </div>

--- a/templates/CRM/Event/Import/Form/MapField.tpl
+++ b/templates/CRM/Event/Import/Form/MapField.tpl
@@ -39,7 +39,7 @@
  <table class="form-layout">
    <tr>
      <td>
-  <div id="crm-submit-buttons" class="crm-submit-buttons">
+  <div class="crm-submit-buttons">
          {include file="CRM/common/formButtons.tpl" location="top"}
   </div>
      </td>
@@ -51,7 +51,7 @@
    </tr>
    <tr>
      <td>
-  <div id="crm-submit-buttons" class="crm-submit-buttons">
+  <div class="crm-submit-buttons">
          {include file="CRM/common/formButtons.tpl" location="bottom"}
   </div>
      </td>

--- a/templates/CRM/Event/Import/Form/MapField.tpl
+++ b/templates/CRM/Event/Import/Form/MapField.tpl
@@ -39,7 +39,7 @@
  <table class="form-layout">
    <tr>
      <td>
-  <div id="crm-submit-buttons">
+  <div id="crm-submit-buttons" class="crm-submit-buttons">
          {include file="CRM/common/formButtons.tpl" location="top"}
   </div>
      </td>
@@ -51,7 +51,7 @@
    </tr>
    <tr>
      <td>
-  <div id="crm-submit-buttons">
+  <div id="crm-submit-buttons" class="crm-submit-buttons">
          {include file="CRM/common/formButtons.tpl" location="bottom"}
   </div>
      </td>

--- a/templates/CRM/Export/Form/Select.tpl
+++ b/templates/CRM/Export/Form/Select.tpl
@@ -60,7 +60,7 @@
   <div class="crm-section crm-export-mergeOptions-section">
     <div class="label crm-label-mergeOptions">{ts}Merge Options{/ts} {help id="id-export_merge_options"}</div>
     <div class="content crm-content-mergeOptions">
-        &nbsp;{$form.mergeOption.html}
+      {$form.mergeOption.html}
     </div>
     <div id='greetings' class="content crm-content-greetings class='hiddenElement'">
       <table class="form-layout-compressed">

--- a/templates/CRM/Grant/Form/Selector.tpl
+++ b/templates/CRM/Grant/Form/Selector.tpl
@@ -30,7 +30,7 @@
 {strip}
 <table class="selector row-highlight">
   <thead class="sticky">
-  <tr class="columnheader">
+  <tr>
   {if ! $single and $context eq 'Search' }
      <th scope="col" title="Select Rows">{$form.toggleSelect.html}</th>
   {/if}


### PR DESCRIPTION
Overview
----------------------------------------
This PR fixes class structure for different pages to make it look better

Screenshots
----------------------------------------
Currently This PR is not having much of visual difference to see but, in future this can be crucial when given attention to common styling. (hence no screenshot)

---

 * [CRM-21708: Make structure proper by adding\/removing appropriate classes](https://issues.civicrm.org/jira/browse/CRM-21708)