### PR TITLE
CRM-21645 fixing initialization of entityId for LineItem::getLineItems

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3172,6 +3172,9 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
 
     if (CRM_Utils_Array::value('contribution_mode', $params) == 'membership') {
       $isRelatedId = TRUE;
+      // CRM-21645: isRelatedId means we will check the id against the civicrm_contribution table
+      // so ensure we have a proper entityID
+      $entityId = $params['contribution']->id;
     }
 
     $entityID[] = $entityId;


### PR DESCRIPTION
Overview
----------------------------------------
When activating extension like org.civicoop.membershippayment that add a contribution_id in the contribution form submitted values, the DB can be corrupted by updating the wrong line item.

Before
----------------------------------------
Before updating:
```
mysql> 
SELECT id, entity_table, entity_id, contribution_id, price_field_id, label 
FROM civicrm_line_item 
WHERE  contribution_id = 40;
+----+--------------------+-----------+-----------------+----------------+--------+
| id | entity_table       | entity_id | contribution_id | price_field_id | label  |
+----+--------------------+-----------+-----------------+----------------+--------+
| 44 | civicrm_membership |        25 |              40 |             13 | aaaaa2 |
+----+--------------------+-----------+-----------------+----------------+--------+
1 rows in set (0.00 sec)
```

Editing contribution id=40 with extension  org.civicoop.membershippayment enabled (see Adhesion field = Membership).

![crm-21645 - before - edit](https://user-images.githubusercontent.com/372004/35424359-1ee9e03c-0221-11e8-8223-774b4c8cb6b5.png)


After updating:
```
mysql> 
SELECT id, entity_table, entity_id, contribution_id, price_field_id, label 
FROM civicrm_line_item 
WHERE  contribution_id = 40;
+----+--------------------+-----------+-----------------+----------------+--------+
| id | entity_table       | entity_id | contribution_id | price_field_id | label  |
+----+--------------------+-----------+-----------------+----------------+--------+
| 28 | civicrm_membership |         1 |              40 |              2 | aaa    |   <-- wrong !
| 44 | civicrm_membership |        25 |              40 |             13 | aaaaa2 |
+----+--------------------+-----------+-----------------+----------------+--------+
2 rows in set (0.00 sec)
```


After
----------------------------------------
No new line item is added to the contribution

Technical Details
----------------------------------------
If you have membership_id added to the contribution form, which can be done with a simple hook, CiviCRM seems to be lost and end up calling CRM_Price_BAO_LineItem::getLineItems with $entity_id = MEMBERSHIP_ID / $entity = 'membership' and $relatedEntity = TRUE (which means that we do a join on the contribution_id).

```
public static function getLineItems($entityId, $entity = 'participant', $isQuick = FALSE, $isQtyZero = TRUE, $relatedEntity = FALSE, $invoice = FALSE) {
  ...
  $condition = "li.entity_id = %2.id AND li.entity_table = 'civicrm_%2'";

  if ($relatedEntity) {
    $condition = "li.contribution_id = %2.id ";
  }
  ...
}

```

I have identified only one case that leads to this strange behavior and the PR is avoiding this situation to happen. 

We need to be careful because, I have not investigated enough to understand what this code relate to:
https://github.com/civicrm/civicrm-core/blob/master/CRM/Contribute/BAO/Contribution.php#L3173
`if (CRM_Utils_Array::value('contribution_mode', $params) == 'membership') {`



Comments
----------------------------------------
I have put quite a bit of details in https://issues.civicrm.org/jira/browse/CRM-21645 also if needed.
