### PR TITLE
fix select SMS recipients query

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -224,7 +224,7 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing {
     if ($isSMSmode) {
       $phone = CRM_Core_DAO_Phone::getTableName();
       CRM_Utils_SQL_Select::from($phone)
-        ->select(" DISTINCT $phone.id as phone_id ")
+        ->select(" DISTINCT $phone.contact_id, $phone.id as phone_id ")
         ->join($contact, " INNER JOIN $contact ON $phone.contact_id = $contact.id ")
         ->join('gc', " INNER JOIN civicrm_group_contact gc ON $contact.id = gc.contact_id ")
         ->join('mg', " INNER JOIN civicrm_mailing_group mg ON gc.group_id = mg.entity_id AND mg.entity_table = 'civicrm_group' ")


### PR DESCRIPTION
Sending a mass SMS is currently broken due to an error in the CRM_Mailing_BAO_Mailing::getRecipients query, which I think happened [in this commit](https://github.com/civicrm/civicrm-core/commit/6dd717a6572e06770dd7b518ba5b8f264c05944e).

@monishdeb - you might want to take a look at the change.

I'm happy to write a test to accompany this if someone wants to give me a pointer on an appropriate unit to test.