### PR TITLE
CRM-21576 Add a 'send SMS' permission

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1659,7 +1659,9 @@ LEFT JOIN civicrm_activity_contact src ON (src.activity_id = ac.activity_id AND 
     if ($userID == NULL) {
       $userID = CRM_Core_Session::getLoggedInContactID();
     }
-
+    if (!CRM_Core_Permission::check('send SMS')) {
+      throw new CRM_Core_Exception("You do not have the 'send SMS' permission");
+    }
     $text = &$activityParams['sms_text_message'];
 
     // CRM-4575

--- a/CRM/Activity/Form/ActivityLinks.php
+++ b/CRM/Activity/Form/ActivityLinks.php
@@ -73,7 +73,7 @@ class CRM_Activity_Form_ActivityLinks extends CRM_Core_Form {
         }
       }
       elseif ($act['name'] == 'SMS') {
-        if (!$contactId || !CRM_SMS_BAO_Provider::activeProviderCount()) {
+        if (!$contactId || !CRM_SMS_BAO_Provider::activeProviderCount() || !CRM_Core_Permission::check('send SMS')) {
           continue;
         }
         // Check for existence of a mobile phone and ! do not SMS privacy setting

--- a/CRM/Contact/Task.php
+++ b/CRM/Contact/Task.php
@@ -162,7 +162,7 @@ class CRM_Contact_Task extends CRM_Core_Task {
 
       //CRM-16329, if SMS provider is configured show sms action.
       $providersCount = CRM_SMS_BAO_Provider::activeProviderCount();
-      if ($providersCount) {
+      if ($providersCount && CRM_Core_Permission::check('send SMS')) {
         self::$_tasks[self::TASK_SMS] = array(
           'title' => ts('SMS - schedule/send'),
           'class' => 'CRM_Contact_Form_Task_SMS',
@@ -308,6 +308,7 @@ class CRM_Contact_Task extends CRM_Core_Task {
       ) {
         $tasks[self::CREATE_MAILING] = self::$_tasks[self::CREATE_MAILING]['title'];
       }
+
     }
 
     $tasks = parent::corePermissionedTaskTitles($tasks, $permission, $params);

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -889,6 +889,10 @@ class CRM_Core_Permission {
         $prefix . ts('edit own api keys'),
         ts('Edit user\'s own API keys'),
       ),
+      'send SMS' => array(
+        $prefix . ts('send SMS'),
+        ts('Send an SMS'),
+      ),
     );
 
     return $permissions;

--- a/CRM/Core/xml/Menu/Admin.xml
+++ b/CRM/Core/xml/Menu/Admin.xml
@@ -711,7 +711,7 @@
      <path>civicrm/sms/send</path>
      <title>New Mass SMS</title>
      <page_callback>CRM_SMS_Controller_Send</page_callback>
-     <access_arguments>administer CiviCRM</access_arguments>
+     <access_arguments>send SMS</access_arguments>
      <page_type>1</page_type>
      <weight>610</weight>
   </item>

--- a/CRM/Core/xml/Menu/Contact.xml
+++ b/CRM/Core/xml/Menu/Contact.xml
@@ -401,6 +401,7 @@
   <path_arguments>action=add</path_arguments>
   <title>Activities</title>
   <page_callback>CRM_Contact_Form_Task_SMS</page_callback>
+  <access_arguments>send SMS</access_arguments>
 </item>
   <item>
     <path>civicrm/ajax/contactrelationships</path>

--- a/CRM/Mailing/Page/Browse.php
+++ b/CRM/Mailing/Page/Browse.php
@@ -83,6 +83,22 @@ class CRM_Mailing_Page_Browse extends CRM_Core_Page {
     $this->_unscheduled = $this->_archived = $archiveLinks = FALSE;
     $this->_mailingId = CRM_Utils_Request::retrieve('mid', 'Positive', $this);
     $this->_sms = CRM_Utils_Request::retrieve('sms', 'Positive', $this);
+
+    if ($this->_sms) {
+      // if this is an SMS page, check that the user has permission to browse SMS
+      if (!CRM_Core_Permission::check('send SMS')) {
+        CRM_Core_Error::fatal(ts('You do not have permission to send SMS'));
+      }
+    }
+    else {
+      // If this is not an SMS page, check that the user has an appropriate
+      // permission (specific permissions have been copied from
+      // CRM/Mailing/xml/Menu/Mailing.xml)
+      if (!CRM_Core_Permission::check(array(array('access CiviMail', 'approve mailings', 'create mailings', 'schedule mailings')))) {
+        CRM_Core_Error::fatal(ts('You do not have permission to view this page.'));
+      }
+    }
+
     $this->assign('sms', $this->_sms);
     // check that the user has permission to access mailing id
     CRM_Mailing_BAO_Mailing::checkPermission($this->_mailingId);

--- a/CRM/Mailing/xml/Menu/Mailing.xml
+++ b/CRM/Mailing/xml/Menu/Mailing.xml
@@ -5,7 +5,7 @@
     <path>civicrm/mailing</path>
     <title>CiviMail</title>
     <page_callback>CRM_Mailing_Page_Browse</page_callback>
-    <access_arguments>access CiviMail;create mailings</access_arguments>
+    <access_arguments>access CiviMail;create mailings;send SMS</access_arguments>
     <page_type>1</page_type>
     <weight>600</weight>
     <component>CiviMail</component>
@@ -71,7 +71,7 @@
     <title>Find Mailings</title>
     <path_arguments>scheduled=true</path_arguments>
     <page_callback>CRM_Mailing_Page_Browse</page_callback>
-    <access_arguments>access CiviMail;approve mailings;create mailings;schedule mailings</access_arguments>
+    <access_arguments>access CiviMail;approve mailings;create mailings;schedule mailings;send SMS</access_arguments>
     <page_type>1</page_type>
     <weight>620</weight>
   </item>

--- a/CRM/Upgrade/Incremental/php/FourSeven.php
+++ b/CRM/Upgrade/Incremental/php/FourSeven.php
@@ -82,6 +82,9 @@ class CRM_Upgrade_Incremental_php_FourSeven extends CRM_Upgrade_Incremental_Base
       );
       $preUpgradeMessage .= '<p>' . ts('A new set of batch permissions has been added called "%1", "%2", "%3" and "%4". These permissions are now used to control access to the Accounting Batches tasks. If your users need to be able to Reopen or Close batches you may need to give them additional permissions. <a href=%5>Read more</a>', $params) . '</p>';
     }
+    if ($rev == '4.7.32') {
+      $preUpgradeMessage .= '<p>' . ts('A new %1 permission has been added. It is not granted by default. If you use SMS, you may wish to review your permissions.', array(1 => 'send SMS')) . '</p>';
+    }
   }
 
   /**

--- a/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
@@ -1135,4 +1135,23 @@ $text
     $this->assertEquals($activity['campaign_id'], $campaign_id, 'Activity campaign_id does not match.');
   }
 
+  /**
+   * @expectedException CRM_Core_Exception
+   * @expectedExceptionMessage You do not have the 'send SMS' permission
+   */
+  public function testSendSMSWithoutPermission() {
+    $dummy = NULL;
+    $session = CRM_Core_Session::singleton();
+    $config = &CRM_Core_Config::singleton();
+    $config->userPermissionClass->permissions = array('access CiviCRM');
+
+    CRM_Activity_BAO_Activity::sendSMS(
+      $dummy,
+      $dummy,
+      $dummy,
+      $dummy,
+      $session->get('userID')
+    );
+  }
+
 }

--- a/xml/templates/civicrm_navigation.tpl
+++ b/xml/templates/civicrm_navigation.tpl
@@ -187,7 +187,7 @@ VALUES
 INSERT INTO civicrm_navigation
     ( domain_id, url, label, name, permission, permission_operator, parent_id, is_active, has_separator, weight )
 VALUES
-    ( @domainID, NULL, '{ts escape="sql" skip="true"}Mailings{/ts}', 'Mailings', 'access CiviMail,create mailings,approve mailings,schedule mailings', 'OR', NULL, '1', NULL, 50 );
+    ( @domainID, NULL, '{ts escape="sql" skip="true"}Mailings{/ts}', 'Mailings', 'access CiviMail,create mailings,approve mailings,schedule mailings,send SMS', 'OR', NULL, '1', NULL, 50 );
 
 SET @mailinglastID:=LAST_INSERT_ID();
 INSERT INTO civicrm_navigation
@@ -201,8 +201,8 @@ VALUES
     ( @domainID, 'civicrm/admin/component?reset=1',                         '{ts escape="sql" skip="true"}Headers, Footers, and Automated Messages{/ts}', 'Headers, Footers, and Automated Messages', 'access CiviMail,administer CiviCRM', 'AND', @mailinglastID, '1', NULL, 6 ),
     ( @domainID, 'civicrm/admin/messageTemplates?reset=1',                  '{ts escape="sql" skip="true"}Message Templates{/ts}', 'Message Templates',                 'edit message templates', '', @mailinglastID, '1', NULL, 7 ),
     ( @domainID, 'civicrm/admin/options/from_email_address?reset=1', '{ts escape="sql" skip="true"}From Email Addresses{/ts}', 'From Email Addresses', 'administer CiviCRM', '', @mailinglastID, '1', 1, 8 ),
-    ( @domainID, 'civicrm/sms/send?reset=1',  '{ts escape="sql" skip="true"}New SMS{/ts}', 'New SMS', 'administer CiviCRM', NULL, @mailinglastID, '1', NULL, 9 ),
-    ( @domainID, 'civicrm/mailing/browse?reset=1&sms=1', '{ts escape="sql" skip="true"}Find Mass SMS{/ts}', 'Find Mass SMS', 'administer CiviCRM', NULL, @mailinglastID, '1', 1, 10 ),
+    ( @domainID, 'civicrm/sms/send?reset=1',  '{ts escape="sql" skip="true"}New SMS{/ts}', 'New SMS', 'send SMS', NULL, @mailinglastID, '1', NULL, 9 ),
+    ( @domainID, 'civicrm/mailing/browse?reset=1&sms=1', '{ts escape="sql" skip="true"}Find Mass SMS{/ts}', 'Find Mass SMS', 'send SMS', NULL, @mailinglastID, '1', 1, 10 ),
     ( @domainID, 'civicrm/a/#/abtest/new',                                  '{ts escape="sql" skip="true"}New A/B Test{/ts}', 'New A/B Test',                                        'access CiviMail', '', @mailinglastID, '1', NULL, 15 ),
     ( @domainID, 'civicrm/a/#/abtest',                                      '{ts escape="sql" skip="true"}Manage A/B Tests{/ts}', 'Manage A/B Tests',                                'access CiviMail', '', @mailinglastID, '1', 1, 16 );
 


### PR DESCRIPTION
This PR adds a permission to Send SMS. More specifically, it:

* Adds a permission to CRM_Core_Permissions::getCorePermissions
* Ensures that all navigation menu entries ('Find SMS' and 'New SMS') respect the new permission
* Ensures that all paths (civicrm/sms/send, civicrm/activity/sms/add, civicrm/mailing) respect the new permission
* Only show 'Outbound SMS' action from the action menu on the contact screen to users with the send SMS permission
* Only show 'SMS - schedule/send' from the advanced search actions to users with the send SMS permission

All CRM/SMS tests pass (there are only 6 of them!). I am awaiting results from the full (`tests/phpunit --group headless`) test suite but thought I would post this in the meantime.

This is a WIP. A couple of things left to do:
* add an upgrade message (I couldn't see any instructions on how to do that here: https://docs.civicrm.org/dev/en/latest/framework/upgrade/)
* write a test or two (anyone have any pointers on permissions tests?)
* some feedback from the client on whether this is working as expected

Feedback welcome, especially thoughts on stuff I might have overlooked.

---

 * [CRM-21576: Implement Send SMS permission](https://issues.civicrm.org/jira/browse/CRM-21576)