### PR TITLE
[WIP] CRM-21712 Improve Fiscal Year date filter

### DIFF
--- a/CRM/Upgrade/Incremental/sql/5.2.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.2.alpha1.mysql.tpl
@@ -1,1 +1,26 @@
 {* file to handle db changes in 5.2.alpha1 during upgrade *}
+# CRM-19885 & https://lab.civicrm.org/dev/core/issues/36#note_3509
+UPDATE civicrm_action_schedule SET repetition_frequency_interval = 0 WHERE repetition_frequency_interval IS NULL;
+UPDATE civicrm_action_schedule SET start_action_offset = 0 WHERE start_action_offset IS NULL;
+UPDATE civicrm_action_schedule SET end_frequency_interval = 0 WHERE end_frequency_interval IS NULL;
+
+ALTER TABLE civicrm_action_schedule
+ALTER column repetition_frequency_interval SET DEFAULT 0,
+ALTER column start_action_offset SET DEFAULT 0,
+ALTER column  end_frequency_interval  SET DEFAULT 0;
+
+# CRM-21712 Insert aditional relative date filters for Fiscal Year
+SELECT @option_group_id_date_filter := max(id) from civicrm_option_group where name = 'relative_date_filters';
+INSERT INTO
+  `civicrm_option_value` (option_group_id, {localize field='label'}label{/localize}, value, name, grouping, filter, is_default, weight, description, is_optgroup, is_reserved, is_active, component_id, domain_id, visibility_id, icon, color)
+VALUES
+  (@option_group_id_date_filter, {localize}'{ts escape="sql"}This and previous 2 fiscal years{/ts}'{/localize}, 'this_2.fiscal_year', 'Within the last 2 fiscal years', NULL, 0, 0, 7,  NULL, 0, 0, 1, NULL, NULL, NULL, NULL, NULL),
+  (@option_group_id_date_filter, {localize}'{ts escape="sql"}This and previous fiscal year{/ts}'{/localize}, 'this_1.fiscal_year', 'This and previous fiscal year', NULL, 0, 0, 6,  NULL, 0, 0, 1, NULL, NULL, NULL, NULL, NULL),
+  (@option_group_id_date_filter, {localize}'{ts escape="sql"}Previous 2 fiscal years{/ts}'{/localize}, 'previous_2.fiscal_year', 'Previous 2 fiscal years', NULL, 0, 0, 61, NULL, 0, 0, 1, NULL, NULL, NULL, NULL, NULL),
+  (@option_group_id_date_filter, {localize}'{ts escape="sql"}Previous 3 fiscal years{/ts}'{/localize},'previous_3.fiscal_year', 'Previous 3 fiscal years', NULL, 0, 0, 62, NULL, 0, 0, 1, NULL, NULL, NULL, NULL, NULL),
+  (@option_group_id_date_filter, {localize}'{ts escape="sql"}Year prior to previous fiscal year{/ts}'{/localize}, 'previous_before.fiscal_year', 'Fiscal Year prior to previous Fiscal year', NULL, 0, 0, 68, NULL, 0, 0, 1, NULL, NULL, NULL, NULL, NULL),
+  (@option_group_id_date_filter, {localize}'{ts escape="sql"}Current fiscal year to-date{/ts}'{/localize}, 'current.fiscal_year', 'Current fiscal year to-date', NULL, 0, 0, 38, NULL, 0, 0, 1, NULL, NULL, NULL, NULL, NULL),
+  (@option_group_id_date_filter, {localize}'{ts escape="sql"}To end of previous fiscal year{/ts}'{/localize}, 'earlier.fiscal_year', 'To end of previous fiscal year', NULL, 0, 0, 44, NULL, 0, 0, 1, NULL, NULL, NULL, NULL, NULL),
+  (@option_group_id_date_filter, {localize}'{ts escape="sql"}From start of current fiscal year{/ts}'{/localize}, 'greater.fiscal_year', 'From start of current fiscal year', NULL, 0, 0, 50, NULL, 0, 0, 1, NULL, NULL, NULL, NULL, NULL),
+  (@option_group_id_date_filter, {localize}'{ts escape="sql"}To end of current fiscal year{/ts}'{/localize}, 'less.fiscal_year', 'To end of current fiscal year', NULL, 0, 0, 55, NULL, 0, 0, 1, NULL, NULL, NULL, NULL, NULL),
+  (@option_group_id_date_filter, {localize}'{ts escape="sql"}From end of previous fiscal year{/ts}'{/localize}, 'greater_previous.fiscal_year', 'From end of previous fiscal year', NULL, 0, 0, 73, NULL, 0, 0, 1, NULL, NULL, NULL, NULL, NULL);

--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -1167,7 +1167,15 @@ class CRM_Utils_Date {
             $from['Y'] = $fYear;
             $fiscalYear = mktime(0, 0, 0, $from['M'], $from['d'] - 1, $from['Y'] + 1);
             $fiscalEnd = explode('-', date("Y-m-d", $fiscalYear));
+            $to['d'] = $fiscalEnd['2'];
+            $to['M'] = $fiscalEnd['1'];
+            $to['Y'] = $fiscalEnd['0'];
+            break;
 
+          case 'previous_before':
+            $from['Y'] = $fYear - 2;
+            $fiscalYear = mktime(0, 0, 0, $from['M'], $from['d'] - 1, $from['Y'] + 1);
+            $fiscalEnd = explode('-', date("Y-m-d", $fiscalYear));
             $to['d'] = $fiscalEnd['2'];
             $to['M'] = $fiscalEnd['1'];
             $to['Y'] = $fiscalEnd['0'];
@@ -1182,9 +1190,84 @@ class CRM_Utils_Date {
             $to['Y'] = $fiscalEnd['0'];
             break;
 
+          case 'previous_2':
+            $from['Y'] = $fYear - 2;
+            $fiscalYear = mktime(0, 0, 0, $from['M'], $from['d'] - 1, $from['Y'] + 2);
+            $fiscalEnd = explode('-', date("Y-m-d", $fiscalYear));
+            $to['d'] = $fiscalEnd['2'];
+            $to['M'] = $fiscalEnd['1'];
+            $to['Y'] = $fiscalEnd['0'];
+            break;
+
+          case 'previous_3':
+            $from['Y'] = $fYear - 3;
+            $fiscalYear = mktime(0, 0, 0, $from['M'], $from['d'] - 1, $from['Y'] + 3);
+            $fiscalEnd = explode('-', date("Y-m-d", $fiscalYear));
+            $to['d'] = $fiscalEnd['2'];
+            $to['M'] = $fiscalEnd['1'];
+            $to['Y'] = $fiscalEnd['0'];
+            break;
+
+          case 'earlier':
+            $from['Y'] = $fYear - 1;
+            $fiscalYear = mktime(0, 0, 0, $from['M'], $from['d'] - 1, $from['Y'] + 1);
+            $fiscalEnd = explode('-', date("Y-m-d", $fiscalYear));
+            $to['d'] = $fiscalEnd['2'];
+            $to['M'] = $fiscalEnd['1'];
+            $to['Y'] = $fiscalEnd['0'];
+            unset($from);
+            break;
+
+          case 'greater':
+            $from['Y'] = $fYear;
+            unset($to);
+            break;
+
+          case 'greater_previous':
+            $from['Y'] = $fYear - 1;
+            unset($to);
+            break;
+
+          case 'current':
+            $from['Y'] = $fYear;
+            $to['d'] = $now['mday'];
+            $to['M'] = $now['mon'];
+            $to['Y'] = $now['year'];
+            $to['H'] = 23;
+            $to['i'] = $to['s'] = 59;
+            break;
+
+          case 'less':
+            $from['Y'] = $fYear;
+            $fiscalYear = mktime(0, 0, 0, $from['M'], $from['d'] - 1, $from['Y'] + 1);
+            $fiscalEnd = explode('-', date("Y-m-d", $fiscalYear));
+            $to['d'] = $fiscalEnd['2'];
+            $to['M'] = $fiscalEnd['1'];
+            $to['Y'] = $fiscalEnd['0'];
+            unset($from);
+            break;
+
           case 'next':
             $from['Y'] = $fYear + 1;
             $fiscalYear = mktime(0, 0, 0, $from['M'], $from['d'] - 1, $from['Y'] + 1);
+            $fiscalEnd = explode('-', date("Y-m-d", $fiscalYear));
+            $to['d'] = $fiscalEnd['2'];
+            $to['M'] = $fiscalEnd['1'];
+            $to['Y'] = $fiscalEnd['0'];
+            break;
+
+          case 'this_2':
+            $from['Y'] = $fYear - 2;
+            $fiscalYear = mktime(0, 0, 0, $from['M'], $from['d'] - 1, $from['Y'] + 3);
+            $fiscalEnd = explode('-', date("Y-m-d", $fiscalYear));
+            $to['d'] = $fiscalEnd['2'];
+            $to['M'] = $fiscalEnd['1'];
+            $to['Y'] = $fiscalEnd['0'];
+            break;
+
+          case 'this_3':
+            $from['Y'] = $fYear - 3;
+            $fiscalYear = mktime(0, 0, 0, $from['M'], $from['d'] - 1, $from['Y'] + 4);
             $fiscalEnd = explode('-', date("Y-m-d", $fiscalYear));
             $to['d'] = $fiscalEnd['2'];
             $to['M'] = $fiscalEnd['1'];
@@ -1745,7 +1828,7 @@ class CRM_Utils_Date {
    *   Fiscal Start Month.
    *
    * @return int
-   *   $fy       Current Fiscl Year
+   *   $fy       Current Fiscal Year
    */
   public static function calculateFiscalYear($fyDate, $fyMonth) {
     $date = date("Y-m-d");


### PR DESCRIPTION
Overview
----------------------------------------
Many organisations use a fiscal date period other than the calendar year. Our fiscal year starts october 1st and lasts until september 30th. CiviCRM supports setting a different fiscal year. Unfortunately the data filter support for fiscal year was very limited, that is why I created this PR.  

Before
----------------------------------------
Fiscal date filters only had 'this fiscal year', 'previous fiscal year' and 'next fiscal year' 

After
----------------------------------------
I added all other relevant filters for fiscal year.

Technical Details
----------------------------------------
NA

Comments
----------------------------------------
I know there is a wish to make the whole date filter mechanism more flexible. Partly it already is because the relative filters are in an option group nowadays. But waiting for another big overhaul I think this is a good way to support fiscal year support for organisations that need it.

---

 * [CRM-21712: Improve Fiscal Year filter for reports](https://issues.civicrm.org/jira/browse/CRM-21712)