### PR TITLE
Amount and source could exceed max length of subject column

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -2198,7 +2198,8 @@ WHERE      activity.id IN ($activityIds)";
           $subject .= " - {$entityObj->source}";
         }
 
-        return $subject;
+        // Amount and source could exceed max length of subject column.
+        return CRM_Utils_String::ellipsify($subject, 255);
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Amount and contribution source are used to create the activity subject.  If contribution source was truncated to its max length of 255 characters, then the length of activity subject would exceed its max length.

Before
----------------------------------------
Currently there is a DB_Error Data too long for column 'subject' if MySQL is running in strict mode.

After
----------------------------------------
Activity subject will be truncated to 255 bytes by ellipsify function.

Technical Details
----------------------------------------
Contribution source will no longer exactly match activity subject, but that seems better than having an unclear upper bound on source length.

Comments
----------------------------------------
See also #11594 re: truncating characters instead of bytes.