### PR TITLE
Use mb_strlen() in ellipsify() to avoid excessive multibyte truncation

### DIFF
--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -657,13 +657,13 @@ class CRM_Utils_String {
    * @return string
    */
   public static function ellipsify($string, $maxLen) {
-    $len = strlen($string);
+    $len = mb_strlen($string, 'UTF-8');
     if ($len <= $maxLen) {
       return $string;
     }
     else {
       $end = $maxLen - 3;
-      while (strlen($string) > $maxLen - 3) {
+      while (mb_strlen($string, 'UTF-8') > $maxLen - 3) {
         $string = mb_substr($string, 0, $end, 'UTF-8');
         $end = $end - 1;
       }


### PR DESCRIPTION
Overview
----------------------------------------
CRM_Utils_String::ellipsify() truncates text to a max length. For languages with multibyte characters such as Thai, this method will excessively truncate due to use of strlen() which counts bytes rather than characters.

Before
----------------------------------------
```php
<?php echo CRM_Utils_String::ellipsify('มวยไทย', 8); ?>
ม...
```

After
----------------------------------------
```php
<?php echo CRM_Utils_String::ellipsify('มวยไทย', 8); ?>
มวยไทย
```

Technical Details
----------------------------------------
CRM_Utils_String::ellipsify() now outputs the specified number of characters rather than bytes.

Comments
----------------------------------------
In PHP 5.6 onwards, UTF-8 is the default encoding and it would not be necessary to specify here.  It might not be necessary even in older versions, because CRM_Core_BAO_ConfigSetting::applyLocale() sets mb_internal_encoding('UTF-8') - I'm just not sure whether or not this always preceeds CRM_Utils_String::ellipsify() being called.