### PR TITLE
CRM-21717 Allow for selecting multiple relationship types in Advanced Search

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -4050,17 +4050,27 @@ WHERE  $smartGroupClause
       }
     }
 
-    $rTypeValues = array();
+    $rTypeValues = $relTypes = array();
     if (!empty($relationType)) {
-      $rel = explode('_', $relationType[2]);
-      self::$_relType = $rel[1];
-      $params = array('id' => $rel[0]);
-      $rType = CRM_Contact_BAO_RelationshipType::retrieve($params, $rTypeValues);
+      $relationType[2] = (array) $relationType[2];
+      foreach ($relationType[2] as $relType) {
+        $rel = explode('_', $relType);
+        self::$_relType .= $rel[1];
+        $params = array('id' => $rel[0]);
+        $relTypes[] = $rel[0];
+        $typeValues = array();
+        $rTypeValues[] = CRM_Contact_BAO_RelationshipType::retrieve($params, $typeValues);
+      }
     }
-    if (!empty($rTypeValues) && $rTypeValues['name_a_b'] == $rTypeValues['name_b_a']) {
-      // if we don't know which end of the relationship we are dealing with we'll create a temp table
-      //@todo unless we are dealing with a target group
-      self::$_relType = 'reciprocal';
+    if (!empty($rTypeValues)) {
+      foreach ($rTypeValues as $rTypeValue) {
+        $rTypeValue = (array) $rTypeValue;
+        if ($rTypeValue['name_a_b'] == $rTypeValue['name_b_a']) {
+          // if we don't know which end of the relationship we are dealing with we'll create a temp table
+          //@todo unless we are dealing with a target group
+          self::$_relType = 'reciprocal';
+        }
+      }
     }
     // if we are creating a temp table we build our own where for the relationship table
     $relationshipTempTable = NULL;
@@ -4077,12 +4087,17 @@ WHERE  $smartGroupClause
         $where[$grouping][] = "( contact_b.sort_name $nameClause AND contact_b.id != contact_a.id )";
       }
     }
-
     $allRelationshipType = CRM_Contact_BAO_Relationship::getContactRelationshipType(NULL, 'null', NULL, NULL, TRUE);
-
     if ($nameClause || !$targetGroup) {
       if (!empty($relationType)) {
-        $this->_qill[$grouping][] = $allRelationshipType[$relationType[2]] . " $name";
+        $relQill = '';
+        foreach ($relationType[2] as $rel) {
+          if (!empty($relQill)) {
+            $relQill .= ' OR ';
+          }
+          $relQill .= $allRelationshipType[$rel];
+        }
+        $this->_qill[$grouping][] = 'Relationship Type(s) ' . $relQill . " $name";
       }
       else {
         $this->_qill[$grouping][] = $name;
@@ -4115,7 +4130,14 @@ WHERE  $smartGroupClause
         }
       }
       if (!empty($relationType)) {
-        $this->_qill[$grouping][] = $allRelationshipType[$relationType[2]] . " ( " . implode(", ", $qillNames) . " )";
+        $relQill = '';
+        foreach ($relationType[2] as $rel) {
+          if (!empty($relQill)) {
+            $relQill .= ' OR ';
+          }
+          $relQill .= $allRelationshipType[$rel];
+        }
+        $this->_qill[$grouping][] = 'Relationship Type(s) ' . $relQill . " ( " . implode(", ", $qillNames) . " )";
       }
       else {
         $this->_qill[$grouping][] = implode(", ", $qillNames);
@@ -4165,8 +4187,8 @@ civicrm_relationship.is_permission_a_b = 0
 
     $this->addRelationshipDateClauses($grouping, $where);
     $this->addRelationshipActivePeriodClauses($grouping, $where);
-    if (!empty($relationType) && !empty($rType) && isset($rType->id)) {
-      $where[$grouping][] = 'civicrm_relationship.relationship_type_id = ' . $rType->id;
+    if (!empty($relTypes)) {
+      $where[$grouping][] = 'civicrm_relationship.relationship_type_id IN (' . implode(',', $relTypes) . ')';
     }
     $this->_tables['civicrm_relationship'] = $this->_whereTables['civicrm_relationship'] = 1;
     $this->_useDistinct = TRUE;
@@ -4196,7 +4218,6 @@ civicrm_relationship.is_permission_a_b = 0
       ";
       CRM_Core_DAO::executeQuery($sql);
     }
-
   }
 
   /**

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -4050,16 +4050,20 @@ WHERE  $smartGroupClause
       }
     }
 
-    $rTypeValues = $relTypes = array();
+    $rTypeValues = $relTypes = $relTypesIds = array();
     if (!empty($relationType)) {
       $relationType[2] = (array) $relationType[2];
       foreach ($relationType[2] as $relType) {
         $rel = explode('_', $relType);
         self::$_relType .= $rel[1];
         $params = array('id' => $rel[0]);
-        $relTypes[] = $rel[0];
         $typeValues = array();
-        $rTypeValues[] = CRM_Contact_BAO_RelationshipType::retrieve($params, $typeValues);
+        $rTypeValue = CRM_Contact_BAO_RelationshipType::retrieve($params, $typeValues);
+        if (!empty($rTypeValue)) {
+          $rTypeValues[] = $rTypeValue;
+          $relTypesIds[] = $rel[0];
+          $relTypes[] = $relType;
+        }
       }
     }
     if (!empty($rTypeValues)) {
@@ -4091,7 +4095,7 @@ WHERE  $smartGroupClause
     if ($nameClause || !$targetGroup) {
       if (!empty($relationType)) {
         $relQill = '';
-        foreach ($relationType[2] as $rel) {
+        foreach ($relTypes as $rel) {
           if (!empty($relQill)) {
             $relQill .= ' OR ';
           }
@@ -4131,7 +4135,7 @@ WHERE  $smartGroupClause
       }
       if (!empty($relationType)) {
         $relQill = '';
-        foreach ($relationType[2] as $rel) {
+        foreach ($relTypes as $rel) {
           if (!empty($relQill)) {
             $relQill .= ' OR ';
           }
@@ -4188,7 +4192,7 @@ civicrm_relationship.is_permission_a_b = 0
     $this->addRelationshipDateClauses($grouping, $where);
     $this->addRelationshipActivePeriodClauses($grouping, $where);
     if (!empty($relTypes)) {
-      $where[$grouping][] = 'civicrm_relationship.relationship_type_id IN (' . implode(',', $relTypes) . ')';
+      $where[$grouping][] = 'civicrm_relationship.relationship_type_id IN (' . implode(',', $relTypesIds) . ')';
     }
     $this->_tables['civicrm_relationship'] = $this->_whereTables['civicrm_relationship'] = 1;
     $this->_useDistinct = TRUE;

--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -416,7 +416,7 @@ class CRM_Contact_Form_Search_Criteria {
 
     $allRelationshipType = array();
     $allRelationshipType = CRM_Contact_BAO_Relationship::getContactRelationshipType(NULL, NULL, NULL, NULL, TRUE);
-    $form->add('select', 'relation_type_id', ts('Relationship Type'), array('' => ts('- select -')) + $allRelationshipType, FALSE, array('class' => 'crm-select2'));
+    $form->add('select', 'relation_type_id', ts('Relationship Type'), array('' => ts('- select -')) + $allRelationshipType, FALSE, array('multiple' => TRUE, 'class' => 'crm-select2'));
     $form->addElement('text', 'relation_target_name', ts('Target Contact'), CRM_Core_DAO::getAttribute('CRM_Contact_DAO_Contact', 'sort_name'));
     // relation status
     $relStatusOption = array(ts('Active'), ts('Inactive'), ts('All'));

--- a/tests/phpunit/CRM/Contact/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTest.php
@@ -370,6 +370,63 @@ class CRM_Contact_BAO_QueryTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test Relationship Clause
+   */
+  public function testRelationshipClause() {
+    $today = date('Ymd');
+    $where1 = "WHERE  ( (
+civicrm_relationship.is_active = 1 AND
+( civicrm_relationship.end_date IS NULL OR civicrm_relationship.end_date >= {$today} ) AND
+( civicrm_relationship.start_date IS NULL OR civicrm_relationship.start_date <= {$today} )
+) AND (contact_b.is_deleted = 0) AND civicrm_relationship.relationship_type_id IN (8) )  AND (contact_a.is_deleted = 0)";
+    $where2 = "WHERE  ( (
+civicrm_relationship.is_active = 1 AND
+( civicrm_relationship.end_date IS NULL OR civicrm_relationship.end_date >= {$today} ) AND
+( civicrm_relationship.start_date IS NULL OR civicrm_relationship.start_date <= {$today} )
+) AND (contact_b.is_deleted = 0) AND civicrm_relationship.relationship_type_id IN (8,10) )  AND (contact_a.is_deleted = 0)";
+    // Test Traditional single select format
+    $params1 = array(array('relation_type_id', '=', '8_a_b', 0, 0));
+    $query1 = new CRM_Contact_BAO_Query(
+      $params1, array('contact_id'),
+      NULL, TRUE, FALSE, 1,
+      TRUE,
+      TRUE, FALSE
+    );
+    $sql1 = $query1->query(FALSE);
+    $this->assertEquals($where1, $sql1[2]);
+    // Test single relationship type selected in multiple select.
+    $params2 = array(array('relation_type_id', 'IN', array('8_a_b'), 0, 0));
+    $query2 = new CRM_Contact_BAO_Query(
+      $params2, array('contact_id'),
+      NULL, TRUE, FALSE, 1,
+      TRUE,
+      TRUE, FALSE
+    );
+    $sql2 = $query2->query(FALSE);
+    $this->assertEquals($where1, $sql2[2]);
+    // Test multiple relationship types selected.
+    $params3 = array(array('relation_type_id', 'IN', array('8_a_b', '10_a_b'), 0, 0));
+    $query3 = new CRM_Contact_BAO_Query(
+      $params3, array('contact_id'),
+      NULL, TRUE, FALSE, 1,
+      TRUE,
+      TRUE, FALSE
+    );
+    $sql3 = $query3->query(FALSE);
+    $this->assertEquals($where2, $sql3[2]);
+    // Test Multiple Relationship type selected where one doesn't actually exist.
+    $params4 = array(array('relation_type_id', 'IN', array('8_a_b', '10_a_b', '14_a_b'), 0, 0));
+    $query4 = new CRM_Contact_BAO_Query(
+      $params4, array('contact_id'),
+      NULL, TRUE, FALSE, 1,
+      TRUE,
+      TRUE, FALSE
+    );
+    $sql4 = $query4->query(FALSE);
+    $this->assertEquals($where2, $sql4[2]);
+  }
+
+  /**
    * Test the group contact clause does not contain an OR.
    *
    * The search should return 3 contacts - 2 households in the smart group of


### PR DESCRIPTION
Overview
----------------------------------------
This allows for users to select Multiple relationship types in the advanced search

Before
----------------------------------------
Only one relationship type can be selected in Advanced search

After
----------------------------------------
Multiple relationship types can now be selected in Advanced Search

ping @petednz @monishdeb @eileenmcnaughton i think this would be handy feature local testing suggests this should be ok but would appreciate feedback.

---

 * [CRM-21717: Allow for selecting multiple relationship types in advanced search](https://issues.civicrm.org/jira/browse/CRM-21717)