### PR TITLE
CRM-21718: Don't choose 'print_contacts' as default task if it is not there

### DIFF
--- a/CRM/Contact/Task.php
+++ b/CRM/Contact/Task.php
@@ -393,6 +393,11 @@ class CRM_Contact_Task {
     if (!CRM_Utils_Array::value($value, self::$_tasks)) {
       // make it the print task by default
       $value = self::PRINT_CONTACTS;
+      // CRM-21718: If there is no print task, just choose the first one. If any.
+      if (!self::$_tasks[$value]) {
+        $value = CRM_Utils_Array::first(array_keys(self::$_tasks));
+        // FIXME: I have no clue about what will happen if there are no tasks.
+      }
     }
     return array(
       CRM_Utils_Array::value('class', self::$_tasks[$value]),


### PR DESCRIPTION
Overview
----------------------------------------
If you remove 'print contacts' from the search tasks by implementing hook_civicrm_searchTasks, every search form stops working.

Before
----------------------------------------
If you remove 'print contacts' from the search tasks by implementing hook_civicrm_searchTasks, every search form stops working.
![screenshot from 2018-01-27 20-33-30](https://user-images.githubusercontent.com/586145/35475583-70b49bc4-03a1-11e8-94f5-3d75c01528a0.png)

After
----------------------------------------
Now it works.
![screenshot from 2018-01-27 20-36-23](https://user-images.githubusercontent.com/586145/35475603-c631416a-03a1-11e8-84b8-b4256d46bc60.png)

Technical Details
----------------------------------------
It seems that in some part of the code for some reason the 'print contacts' is selected as default action, which causes troubles if it is not there.

---

 * [CRM-21718: If you remove 'Print selected rows' using hook_civicrm_searchTasks, search forms stop working](https://issues.civicrm.org/jira/browse/CRM-21718)