### PR TITLE
CRM-20996 fix db error when using the Copy function for profiles from…

### DIFF
--- a/js/model/crm.uf.js
+++ b/js/model/crm.uf.js
@@ -687,8 +687,17 @@
           return _.omit(ufFieldModel.toStrictJSON(), ['id', 'uf_group_id']);
         })
       );
-      var copyLabel = ' ' + ts('(Copy)');
-      copy.set('title', copy.get('title').slice(0, 64 - copyLabel.length) + copyLabel);
+      var new_id = 1;
+      CRM.api3('UFGroup', 'getsingle', {
+        "return": ["id"],
+        "options": {"limit": 1, "sort": "id DESC"}
+      }).done(function(result) {
+        new_id = Number(result.id) + 1;
+        var copyLabel = ' ' + ts('(Copy)');
+        var nameSuffix = '_' + new_id;
+        copy.set('title', copy.get('title').slice(0, 64 - copyLabel.length) + copyLabel);
+        copy.set('name', copy.get('name').slice(0, 64 - nameSuffix.length) + nameSuffix);
+      });
       return copy;
     },
     getModelClass: function(entity_name) {


### PR DESCRIPTION
… contribution or event pages

Overview
----------------------------------------
This fixes an issue with cloning profiles from the contribution / event pages. This is due to the the fact that the name isn't altered in the copy process and triggers a DB error.

Before
----------------------------------------
DB error generated

After
----------------------------------------
No db error and profile is saved 

Technical Details
----------------------------------------
This follows the similar idea of https://github.com/civicrm/civicrm-core/pull/8006 to put max id +1 into the name column to create a unique name

Comments
----------------------------------------
ping @JKingsnorth @eileenmcnaughton @colemanw 
