### PR TITLE
CRM-21719 Require Multibyte PHP extension

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -727,6 +727,13 @@ class InstallRequirements {
       ts("JSON support not included in PHP."),
     ));
 
+    // check for Multibyte support such as mb_substr. Required for proper handling of Multilingual setups.
+    $this->requireFunction('mb_substr', array(
+      ts("PHP Configuration"),
+      ts("Multibyte support"),
+      ts("Multibyte support not enabled in PHP."),
+    ));
+
     // Check for xcache_isset and emit warning if exists
     $this->checkXCache(array(
       ts("PHP Configuration"),


### PR DESCRIPTION
Overview
----------------------------------------
Alters installation to require multibyte PHP functions

Before
----------------------------------------
`mb_` not required

After
----------------------------------------
`mb_` functions required for install

ping @totten @colemanw @mlutfy this i think would be needed to make `mb_` functions required on install. I think this makes sense to do given how often we use an `mb_` function in the codebase

---

 * [CRM-21719: Require Multibyte PHP Extension](https://issues.civicrm.org/jira/browse/CRM-21719)