### PR TITLE
CRM-21728 Prevent intermittant fail on pcp api calls.

### DIFF
--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -1235,7 +1235,7 @@ function formatCheckBoxField(&$checkboxFieldValue, $customFieldLabel, $entity) {
  * @return array
  */
 function _civicrm_api3_basic_get($bao_name, $params, $returnAsSuccess = TRUE, $entity = "", $sql = NULL, $uniqueFields = FALSE) {
-  $entity = CRM_Core_DAO_AllCoreTables::getBriefName(str_replace('_BAO_', '_DAO_', $bao_name));
+  $entity = $entity ?: CRM_Core_DAO_AllCoreTables::getBriefName(str_replace('_BAO_', '_DAO_', $bao_name));
   $options = _civicrm_api3_get_options_from_params($params);
 
   $query = new \Civi\API\Api3SelectQuery($entity, CRM_Utils_Array::value('check_permissions', $params, FALSE));


### PR DESCRIPTION
Overview
----------------------------------------
Fix for fatal errors on Mac to do with loading of Pcp.php file when it gets confused about casing. Unlikely to affect live sites as does not fail on jenkins


Before
----------------------------------------
Tests pass on Mac when SyntaxConformance::singleValueAlter run in isolation

After
----------------------------------------
Tests pass on Mac when SyntaxConformance::singleValueAlter run in isolation

Technical Details
----------------------------------------
When I run the SyntaxConformance tests locally I get a fatal error because it tries
to include api_v3_pcp.php after having included api_v3_PCP.php & thinks they are 2 files.
This is a Mac so obviously the handling is different to the jenkins method. Not overwriting the
 param if passed in works locally

Comments
----------------------------------------

---

 * [CRM-21728: Intermittant fatal on pcp.create api](https://issues.civicrm.org/jira/browse/CRM-21728)