### PR TITLE
CRM-21707 increase api testing / use of serialization metadata. Add depre…

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -647,6 +647,9 @@ class CRM_Core_DAO extends DB_DataObject {
           $allNull = FALSE;
         }
         else {
+          if (!$serializeArrays && is_array($pValue) && !empty($value['serialize'])) {
+            Civi::log()->warning(ts('use copyParams to serialize arrays (' . __CLASS__ . '.' . $name . ')'), ['civi.tag' => 'deprecated']);
+          }
           $this->$dbName = $pValue;
           $allNull = FALSE;
         }

--- a/CRM/Member/BAO/MembershipBlock.php
+++ b/CRM/Member/BAO/MembershipBlock.php
@@ -53,7 +53,7 @@ class CRM_Member_BAO_MembershipBlock extends CRM_Member_DAO_MembershipBlock {
     $hook = empty($params['id']) ? 'create' : 'edit';
     CRM_Utils_Hook::pre($hook, 'MembershipBlock', CRM_Utils_Array::value('id', $params), $params);
     $dao = new CRM_Member_DAO_MembershipBlock();
-    $dao->copyValues($params);
+    $dao->copyValues($params, TRUE);
     $dao->id = CRM_Utils_Array::value('id', $params);
     $dao->save();
     CRM_Utils_Hook::post($hook, 'MembershipBlock', $dao->id, $dao);

--- a/CRM/Report/BAO/ReportInstance.php
+++ b/CRM/Report/BAO/ReportInstance.php
@@ -78,7 +78,7 @@ class CRM_Report_BAO_ReportInstance extends CRM_Report_DAO_ReportInstance {
     }
 
     $instance = new CRM_Report_DAO_ReportInstance();
-    $instance->copyValues($params);
+    $instance->copyValues($params, TRUE);
 
     if (CRM_Core_Config::singleton()->userFramework == 'Joomla') {
       $instance->permission = 'null';

--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -1356,6 +1356,9 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
         'id' => $entity['id'],
         $field => isset($entity[$field]) ? $entity[$field] : NULL,
       );
+      if (!empty($specs['serialize'])) {
+        $updateParams[$field] = $entity[$field] = (array) $specs['serialize'];
+      }
       if (isset($updateParams['financial_type_id']) && in_array($entityName, array('Grant'))) {
         //api has special handling on these 2 fields for backward compatibility reasons
         $entity['contribution_type_id'] = $updateParams['financial_type_id'];
@@ -1377,6 +1380,10 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
       );
 
       $checkEntity = $this->callAPISuccess($entityName, 'getsingle', $checkParams);
+      if (!empty($specs['serialize']) && !is_array($checkEntity[$field])) {
+        // Put into serialized format for comparison if 'get' has not returned serialized.
+        $entity[$field] = CRM_Core_DAO::serializeField($checkEntity[$field], $specs['serialize']);
+      }
 
       $this->assertAPIArrayComparison($entity, $checkEntity, array(), "checking if $fieldName was correctly updated\n" . print_r(array(
             'update-params' => $updateParams,


### PR DESCRIPTION
…cated when bypassed

Overview
----------------------------------------
Extend api use of metadata to store serialised data.

Before
----------------------------------------
Less use of metadata

After
----------------------------------------
Use of metadata on 3 additional entities that use serialisation, unit test. Deprecation notice if some thing that could be handled by metadata but isn't hits the copyValues function

Technical Details
----------------------------------------
The copyValues function can now handle serialization of arrays. It requires an extra param as a precaution. This PR adds a deprecated in the cases (if any) where the existance of that param is preventing something from being metadata-handled. At some point we would remove that param

Comments
----------------------------------------
@colemanw here is a list of fields that I found using serialize. I have adjusted 3 that are unit tested for those fields to use the new functionality

Contact | contact_sub_type
Contact | preferred_communication_method
PaymentProcessor | accepted_credit_cards
CustomGroup | extends_entity_column_value
ContributionPage | recur_frequency_unit
UFGroup | group_type
Domain | config_backend
Domain | locale_custom_strings
SavedSearch | form_values
SavedSearch | select_tables
SavedSearch | where_tables
Participant | role_id
Participant | fee_level
Group | select_tables
Group | where_tables
Group | group_type
ReportInstance | form_values| tested
PrintLabel | data| tested
Cxn | options
PrevNextCache | data
UFJoin | module_data
Setting | value
QueueItem | data
MembershipBlock | membership_types| tested
PledgeBlock | pledge_frequency_unit


