### PR TITLE
CRM-21140 extend support for custom data to Mailing api

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1409,7 +1409,11 @@ ORDER BY   civicrm_email.is_bulkmail DESC
    * @return CRM_Mailing_DAO_Mailing
    */
   public static function add(&$params, $ids = array()) {
-    $id = CRM_Utils_Array::value('mailing_id', $ids, CRM_Utils_Array::value('id', $params));
+    $id = CRM_Utils_Array::value('id', $params, CRM_Utils_Array::value('mailing_id', $ids));
+
+    if (empty($params['id']) && !empty($ids)) {
+      \Civi::log('Parameter $ids is no longer used by Mailing::add. Use the api or just pass $params', ['civi.tag' => 'deprecated']);
+    }
 
     if ($id) {
       CRM_Utils_Hook::pre('edit', 'Mailing', $id, $params);
@@ -1443,7 +1447,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
       $result->modified_date = $mailing->modified_date;
     }
 
-    if (!empty($ids['mailing'])) {
+    if ($id) {
       CRM_Utils_Hook::post('edit', 'Mailing', $mailing->id, $mailing);
     }
     else {
@@ -1482,15 +1486,16 @@ ORDER BY   civicrm_email.is_bulkmail DESC
    * @throws \Exception
    */
   public static function create(&$params, $ids = array()) {
-    // WTH $ids
-    if (empty($ids) && isset($params['id'])) {
-      $ids['mailing_id'] = $ids['id'] = $params['id'];
+
+    if (empty($params['id']) && (array_filter($ids) !== [])) {
+      $params['id'] = isset($ids['mailing_id']) ? $ids['mailing_id'] : $ids['id'];
+      \Civi::log('Parameter $ids is no longer used by Mailing::create. Use the api or just pass $params', ['civi.tag' => 'deprecated']);
     }
 
     // CRM-12430
     // Do the below only for an insert
     // for an update, we should not set the defaults
-    if (!isset($ids['id']) && !isset($ids['mailing_id'])) {
+    if (!isset($params['id'])) {
       // Retrieve domain email and name for default sender
       $domain = civicrm_api(
         'Domain',
@@ -1559,7 +1564,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
 
     $transaction = new CRM_Core_Transaction();
 
-    $mailing = self::add($params, $ids);
+    $mailing = self::add($params);
 
     if (is_a($mailing, 'CRM_Core_Error')) {
       $transaction->rollback();

--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -77,7 +77,7 @@ function civicrm_api3_mailing_create($params) {
 
   // FlexMailer is a refactoring of CiviMail which provides new hooks/APIs/docs. If the sysadmin has opted to enable it, then use that instead of CiviMail.
   $safeParams['_evil_bao_validator_'] = \CRM_Utils_Constant::value('CIVICRM_FLEXMAILER_HACK_SENDABLE', 'CRM_Mailing_BAO_Mailing::checkSendable');
-  $result = _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $safeParams);
+  $result = _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $safeParams, 'Mailing');
   return _civicrm_api3_mailing_get_formatResult($result);
 }
 

--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -271,6 +271,7 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
     $customDataEntities[] = ['UFGroup'];
     $customDataEntities[] = ['PriceSet'];
     $customDataEntities[] = ['PaymentToken'];
+    $customDataEntities[] = ['Mailing'];
     return $customDataEntities;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
With this PR it is possible (per previous on CRM-21440) to extend Mailing with Custom data. This is primarily for the benefit of extension writers

Before
----------------------------------------
Mailing api does not support custom data.

After
----------------------------------------
Mailing api supports custom data. 

Technical Details
----------------------------------------
Parameters more standardised. Deprecation on non-std params

Comments
----------------------------------------
There are a number of entities that are now possible but this is one that specifically failed tests due to mishandling of $ids.

---

 * [CRM-21140: Agree & \(if applicable\) implement approach to storing extension data for entities \/ tables](https://issues.civicrm.org/jira/browse/CRM-21140)
 * [CRM-21440: CMS-specific path variables](https://issues.civicrm.org/jira/browse/CRM-21440)