### PR TITLE
CRM-21725 - From Address default should be respected

### DIFF
--- a/CRM/Contact/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contact/Form/Task/PDFLetterCommon.php
@@ -225,6 +225,7 @@ class CRM_Contact_Form_Task_PDFLetterCommon {
   public static function setDefaultValues() {
     $defaultFormat = CRM_Core_BAO_PdfFormat::getDefaultValues();
     $defaultFormat['format_id'] = $defaultFormat['id'];
+    $defaultFormat['from_email_address'] = key(CRM_Core_OptionGroup::values('from_email_address', TRUE, FALSE, FALSE, ' AND is_default = 1'));
     return $defaultFormat;
   }
 

--- a/CRM/Contact/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contact/Form/Task/PDFLetterCommon.php
@@ -225,7 +225,7 @@ class CRM_Contact_Form_Task_PDFLetterCommon {
   public static function setDefaultValues() {
     $defaultFormat = CRM_Core_BAO_PdfFormat::getDefaultValues();
     $defaultFormat['format_id'] = $defaultFormat['id'];
-    $defaultFormat['from_email_address'] = key(CRM_Core_OptionGroup::values('from_email_address', TRUE, FALSE, FALSE, ' AND is_default = 1'));
+    $defaultFormat['from_email_address'] = CRM_Core_BAO_Email::getDefaultFromEmailAddress();
     return $defaultFormat;
   }
 

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -442,7 +442,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       $defaults['campaign_id'] = $this->_pledgeValues['campaign_id'];
     }
 
-    $defaults['from_email_address'] = key(CRM_Core_OptionGroup::values('from_email_address', TRUE, FALSE, FALSE, ' AND is_default = 1'));
+    $defaults['from_email_address'] = CRM_Core_BAO_Email::getDefaultFromEmailAddress();
     $this->_defaults = $defaults;
     return $defaults;
   }

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -442,6 +442,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       $defaults['campaign_id'] = $this->_pledgeValues['campaign_id'];
     }
 
+    $defaults['from_email_address'] = key(CRM_Core_OptionGroup::values('from_email_address', TRUE, FALSE, FALSE, ' AND is_default = 1'));
     $this->_defaults = $defaults;
     return $defaults;
   }

--- a/CRM/Contribute/Form/Task/PDF.php
+++ b/CRM/Contribute/Form/Task/PDF.php
@@ -142,7 +142,11 @@ AND    {$this->_componentClause}";
    */
   public function setDefaultValues() {
     $defaultFormat = CRM_Core_BAO_PdfFormat::getDefaultValues();
-    return array('pdf_format_id' => $defaultFormat['id'], 'receipt_update' => 1, 'override_privacy' => 0);
+    $defaults['pdf_format_id'] = $defaultFormat['id'];
+    $defaults['receipt_update'] = 1;
+    $defaults['override_privacy'] = 0;
+    $defaults['from_email_address'] = CRM_Core_BAO_Email::getDefaultFromEmailAddress();
+    return $defaults;
   }
 
   /**

--- a/CRM/Core/BAO/Email.php
+++ b/CRM/Core/BAO/Email.php
@@ -359,4 +359,5 @@ AND    reset_date IS NULL
     ));
     return $defaultFromAddress;
   }
+
 }

--- a/CRM/Core/BAO/Email.php
+++ b/CRM/Core/BAO/Email.php
@@ -345,4 +345,18 @@ AND    reset_date IS NULL
     return CRM_Contact_BAO_Contact::deleteObjectWithPrimary('Email', $id);
   }
 
+  /**
+   * For use with setDefaultValues on forms that implement a select element for choosing "From Email Address"
+   * Usage: $defaults['from_email_address'] = CRM_Core_BAO_Email::getDefaultFromEmailAddress()
+   *
+   * @return int
+   */
+  public static function getDefaultFromEmailAddress() {
+    $defaultFromAddress = civicrm_api3('OptionValue', 'getvalue', array(
+      'return' => 'label',
+      'option_group_id' => 'from_email_address',
+      'is_default' => 1,
+    ));
+    return $defaultFromAddress;
+  }
 }

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -382,6 +382,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
       $this->assign('endDate', $defaults['membership_end_date']);
     }
 
+    $defaults['from_email_address'] = CRM_Core_BAO_Email::getDefaultFromEmailAddress();
     return $defaults;
   }
 

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -220,6 +220,8 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
     if ($this->_mode) {
       $defaults = $this->getBillingDefaults($defaults);
     }
+
+    $defaults['from_email_address'] = CRM_Core_BAO_Email::getDefaultFromEmailAddress();
     return $defaults;
   }
 

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -240,7 +240,8 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
 
     $allMembershipInfo = array();
 
-    if (is_array($defaults['membership_type_id'])) { //CRM-21485
+    if (is_array($defaults['membership_type_id'])) {
+      //CRM-21485
       $defaults['membership_type_id'] = $defaults['membership_type_id'][1];
     }
 

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -240,8 +240,8 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
 
     $allMembershipInfo = array();
 
+    //CRM-21485
     if (is_array($defaults['membership_type_id'])) {
-      //CRM-21485
       $defaults['membership_type_id'] = $defaults['membership_type_id'][1];
     }
 

--- a/CRM/Pledge/Form/Pledge.php
+++ b/CRM/Pledge/Form/Pledge.php
@@ -200,6 +200,7 @@ class CRM_Pledge_Form_Pledge extends CRM_Core_Form {
     // custom data set defaults
     $defaults += CRM_Custom_Form_CustomData::setDefaultValues($this);
 
+    $defaults['from_email_address'] = CRM_Core_BAO_Email::getDefaultFromEmailAddress();
     return $defaults;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------

Steps to replicate:

1. Create multiple From Addresses and set one to default.
2. Edit a contribution and check Receipt From under Send Receipt? does NOT respect #1 setting.
3. Find Contribution, do Print/Merge Document, From Email Address does NOT respect #1 setting.

Before
----------------------------------------
From Address is not respected.

After
----------------------------------------
From Address is respected.

---

 * [CRM-21725: From Address default should be respected](https://issues.civicrm.org/jira/browse/CRM-21725)