### PR TITLE
CRM-21665 Fix check number toggle on Edit form when context is search

### DIFF
--- a/CRM/Contribute/BAO/Query.php
+++ b/CRM/Contribute/BAO/Query.php
@@ -927,8 +927,11 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
       FALSE, array('class' => 'crm-select2', 'multiple' => 'multiple', 'placeholder' => ts('- any -'))
     );
 
-    $form->addSelect('payment_instrument_id',
-      array('entity' => 'contribution', 'multiple' => 'multiple', 'label' => ts('Payment Method'), 'option_url' => NULL, 'placeholder' => ts('- any -'))
+    // use contribution_payment_instrument_id instead of payment_instrument_id
+    // Contribution Edit form (pop-up on contribution/Contact(display Result as Contribution) open on search form),
+    // then payment method change action not working properly because of same html ID present two time on one page
+    $form->addSelect('contribution_payment_instrument_id',
+      array('entity' => 'contribution', 'field' => 'payment_instrument_id', 'multiple' => 'multiple', 'label' => ts('Payment Method'), 'option_url' => NULL, 'placeholder' => ts('- any -'))
     );
 
     $form->add('select',

--- a/templates/CRM/Contribute/Form/Search/Common.tpl
+++ b/templates/CRM/Contribute/Form/Search/Common.tpl
@@ -40,8 +40,8 @@
 <tr>
   <td>
     <div class="float-left">
-      <label>{$form.payment_instrument_id.label}</label> <br />
-      {$form.payment_instrument_id.html|crmAddClass:twenty}
+      <label>{$form.contribution_payment_instrument_id.label}</label> <br />
+      {$form.contribution_payment_instrument_id.html|crmAddClass:twenty}
     </div>
     <div class="float-left" id="contribution_check_number_wrapper">
       {$form.contribution_check_number.label} <br />


### PR DESCRIPTION
Overview
----------------------------------------
Check Number toggle on Edit form not work when context is search

Before
----------------------------------------
Check Number show / hide not working when user search the contribution (Find Contribution) then Edit the contribution in pop up box.

It work on contribution dashboard and under 'Contribution' Tab for contact.

Reason for not working on Find Contribution page: we have two field with same html ID 'payment_instrument_id'

( 1st from find contribution from (payment method) and 2nd is from contribution form)

ID has to be uniq. Since its duplicate jQuery unable to handle show hide functionality when Payment Method changed in Contribution Form.


After
----------------------------------------
Check number field get toggled  when payment method change.

Technical Details
----------------------------------------
Same ID 'payment_instrument_id' present two times on page

---

 * [CRM-21665: Check Number show hide not working](https://issues.civicrm.org/jira/browse/CRM-21665)