### PR TITLE
CRM-21719 Add a check in Civi/Install/Requirements to ensure that PHP…

### DIFF
--- a/Civi/Install/Requirements.php
+++ b/Civi/Install/Requirements.php
@@ -28,6 +28,7 @@ class Requirements {
     'checkServerVariables',
     'checkMysqlConnectExists',
     'checkJsonEncodeExists',
+    'checkMultibyteExists',
   );
 
   protected $database_checks = array(
@@ -211,6 +212,24 @@ class Requirements {
     if (!function_exists('json_encode')) {
       $results['severity'] = $this::REQUIREMENT_ERROR;
       $results['details'] = 'Function json_encode() does not exist';
+    }
+
+    return $results;
+  }
+
+  /**
+   * CHeck that PHP Multibyte functions are enabled.
+   * @return array
+   */
+  public function checkMultibyteExists() {
+    $results = array(
+      'title' => 'CiviCRM MultiByte encoding support',
+      'severity' => $this::REQUIREMENT_OK,
+      'details' => 'PHP Multibyte etension found',
+    );
+    if (!function_exists('mb_substr')) {
+      $results['severity'] = $this::REQUIREMENT_ERROR;
+      $results['details'] = 'PHP Multibyte extension has not been installed and enabled';
     }
 
     return $results;


### PR DESCRIPTION
… Multibyte functions are enabled on install

Overview
----------------------------------------
This follows on from the previous PR on the issue and adds the check into Civi/Install/Requirements.php as per comment from @totten 

ping @eileenmcnaughton @colemanw 