### PR TITLE
 CRM-21729 exclude vendor .idea, test-cases, unit-test from deployment

### DIFF
--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -162,7 +162,8 @@ function dm_install_vendor() {
   local to="$2"
 
   local excludes_rsync=""
-  for exclude in .git .svn {T,t}est{,s} {D,d}oc{,s} {E,e}xample{,s} ; do
+  ## CRM-21729 - .idea test-cases unit-test come from phpquery package.
+  for exclude in .git .svn {T,t}est{,s} {D,d}oc{,s} {E,e}xample{,s} .idea test-cases unit-test; do
     excludes_rsync="--exclude=${exclude} ${excludes_rsync}"
   done
 


### PR DESCRIPTION
Overview
----------------------------------------
Exclude some (more) vendor test files from our deployment

Before
----------------------------------------
unit-tests, test-cases & .idea folder from phpquery package are in our deployment

After
----------------------------------------
Above test files do not ship with our product

Technical Details
----------------------------------------
This came to my attention because one of the files is not passing lint. We are already excluding other similar folders

Comments
----------------------------------------
Upstream PR https://github.com/electrolinux/phpquery/pull/13

---

 * [CRM-21729: Exclude \(non-lintable\) vendor test cases from deply](https://issues.civicrm.org/jira/browse/CRM-21729)