### PR TITLE
CRM-19798 fix memory leak on EntityTag.get

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -1000,10 +1000,6 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
       CRM_Utils_Hook::post('delete', $contactType, $contact->id, $contact);
     }
 
-    // also reset the DB_DO global array so we can reuse the memory
-    // http://issues.civicrm.org/jira/browse/CRM-4387
-    CRM_Core_DAO::freeResult();
-
     return TRUE;
   }
 

--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -575,9 +575,7 @@ class CRM_Core_I18n {
    *   True if CiviCRM is in multilingual mode.
    */
   public static function isMultilingual() {
-    $domain = new CRM_Core_DAO_Domain();
-    $domain->find(TRUE);
-    return (bool) $domain->locales;
+    return (bool) CRM_Core_DAO::singleValueQuery("SELECT locales FROM civicrm_domain");
   }
 
   /**

--- a/CRM/Extension/Manager.php
+++ b/CRM/Extension/Manager.php
@@ -444,6 +444,7 @@ class CRM_Extension_Manager {
           $this->statuses[$dao->full_name] = $codeExists ? self::STATUS_DISABLED : self::STATUS_DISABLED_MISSING;
         }
       }
+      $dao->free();
     }
     return $this->statuses;
   }

--- a/tests/phpunit/api/v3/EntityTagTest.php
+++ b/tests/phpunit/api/v3/EntityTagTest.php
@@ -140,6 +140,19 @@ class api_v3_EntityTagTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test memory usage does not escalate crazily.
+   */
+  public function testMemoryLeak() {
+    $start = memory_get_usage();
+    for ($i = 0; $i < 100; $i++) {
+      $this->callAPISuccess('EntityTag', 'get', []);
+      $memUsage = memory_get_usage();
+    }
+    $max = $start + 2000000;
+    $this->assertTrue($memUsage < $max, "mem usage ( $memUsage ) should be less than $max (start was $start) ");
+  }
+
+  /**
    * Test tag can be added to a household.
    */
   public function testHouseholdEntityCreate() {


### PR DESCRIPTION
Overview
----------------------------------------
Fix memory leak that manifests in EntityTag.get api

Before
----------------------------------------
Memory leak on multilingual as the global $_DB_DATAOBJECT['RESULTS'] gets a new entry every iteration

Memory in use before & after 100 iterations of EntityTag.get 


Start :'49,864,896'
End :'53,503,264'


After
----------------------------------------
Switching from DAO->find() to CRM_Core_DAO::singleValueQuery results in the entry being unset each time. 

Memory in use before & after 100 iterations of EntityTag.get 

Start :'49,851,680'
End:'49,852,168'

Technical Details
----------------------------------------
I dug fairly heavily into the way the DAO cache is being used. It builds up queries in the global 
$_DB_DATAOBJECT['RESULTS'];
From my investigations these are used for iterating through a result set rather than caching the results of a query. ie. in the case of this function
```
function demonstrate() {
  $dao = new CRM_Core_DAO_Domain();
  $dao->find(TRUE)
  return $dao->locales;
}
```
there will be an entry remaining in 
$_DB_DATAOBJECT['RESULTS'] 
representing the mysql results - but it can only be used from that $dao. Once we have left the function the $dao will be destroyed but the object to retrieve the result set will remain in the global, unusable but memory hogging. If the $dao is freed before it's time then $dao->fetch() will no longer retrieve results - potentially causing unpredictable errors (this is the risk of calling CRM_Core_DAO::freeResult()) as an outer loop may be disbanded.

There are some code paths that handle freeing the result global:

- the api
- the Utils_Select object
- Core_DAO::singleValueQuery
- $dao->save()
- $dao->delete()
- Core_DAO::executeQuery FOR INSERT, DELETE, UPDATE actions

What this means is that if you retrieve results using either 
```
Core_DAO::executeQuery 
```
or 
```
$dao->find(TRUE)*
```
  or a retrieve function (e.g 
```
CRM_Core_BAO_LocationType::retrieve())
```
 you need to do a $dao->free() before the DAO object is disbanded. retrieveValues functions are unreliable.

* - note $dao->find(FALSE); does not need to be freed

Comments
----------------------------------------
I don't know if the test is valid in all cases - it certain fails without & passes with but memory increase may not always be such across systems. However, if it passes I'm inclined to put it in.

Further fixes could cache this result in \Civi::$statics & reduce queries also. The path by which this was being frequently called is CRM_Core_DAO_AllCoreTables::getClassForTable(). I would prefer to consider caching as a follow up & keep this to the specific memory issue.

The code that led me into this was test failures caused by CRM_Core_DAO::freeResult(); - my digging also revealed that there is no good reason to use this function - or if there ever is it should be done from the context of the outer wrapper, not deep in core. Calling it from deep in the BAO risks intermittent loss of outer loops - per @michaelmcandrew analysis here https://github.com/civicrm/civicrm-core/pull/10844 and also causes test failures in (obscure) phpunit configs that manage globals.

---

 * [CRM-19798: Memory leak in API3 EntityTag get operations](https://issues.civicrm.org/jira/browse/CRM-19798)