### PR TITLE
CRM-21730: postProcess() hook don't receive case id after submitting …

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -596,13 +596,6 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
 
     CRM_Contact_BAO_GroupContactCache::opportunisticCacheFlush();
 
-    if (!empty($params['id'])) {
-      CRM_Utils_Hook::post('edit', 'Activity', $activity->id, $activity);
-    }
-    else {
-      CRM_Utils_Hook::post('create', 'Activity', $activity->id, $activity);
-    }
-
     // if the subject contains a ‘[case #…]’ string, file that activity on the related case (CRM-5916)
     $matches = array();
     $subjectToMatch = CRM_Utils_Array::value('subject', $params);
@@ -625,6 +618,12 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
       else {
         self::logActivityAction($activity, "Case details for {$matches[1]} not found while recording an activity on case.");
       }
+    }
+    if (!empty($params['id'])) {
+      CRM_Utils_Hook::post('edit', 'Activity', $activity->id, $activity);
+    }
+    else {
+      CRM_Utils_Hook::post('create', 'Activity', $activity->id, $activity);
     }
 
     return $result;

--- a/CRM/Case/Form/Case.php
+++ b/CRM/Case/Form/Case.php
@@ -354,7 +354,7 @@ class CRM_Case_Form_Case extends CRM_Core_Form {
       $params['subject'] = $params['activity_subject'];
     }
     $caseObj = CRM_Case_BAO_Case::create($params);
-    $params['case_id'] = $caseObj->id;
+    $this->_caseId = $params['case_id'] = $caseObj->id;
     // unset any ids, custom data
     unset($params['id'], $params['custom']);
 


### PR DESCRIPTION
…New Case Form.

Overview
----------------------------------------
postProcess() hook don't receive case id after `New Case` Form is submitted.

Before
----------------------------------------
- No caseId found in postProcess hook after submitting `New Case` form.
- Activity post() hook is invoked before it is linked to a case.

After
----------------------------------------
- Case id is correctly assigned to `$form->_caseId` in postProcess() hook.
- post() hook for activity is invoked after it is recorded in `case_activity` table.