### PR TITLE
Bug Fix: CRM-21356 Membership Status is not updated after disabling a membership type

### DIFF
--- a/CRM/Member/PseudoConstant.php
+++ b/CRM/Member/PseudoConstant.php
@@ -81,6 +81,28 @@ class CRM_Member_PseudoConstant extends CRM_Core_PseudoConstant {
   }
 
   /**
+   *  Bug Fix: CRM-21356 Membership Status is not updated after disabling a membership type
+   */
+  public static function allMembershipType($id = NULL, $force = TRUE) {
+    if (!self::$membershipType || $force) {
+      CRM_Core_PseudoConstant::populate(self::$membershipType,
+        'CRM_Member_DAO_MembershipType',
+        TRUE, 'name', 'is_active', NULL, 'weight', 'id', TRUE
+      );
+    }
+    if ($id) {
+      if (array_key_exists($id, self::$membershipType)) {
+        return self::$membershipType[$id];
+      }
+      else {
+        $result = NULL;
+        return $result;
+      }
+    }
+    return self::$membershipType;
+  }
+
+  /**
    * Get all the membership statuss.
    *
    *
@@ -107,6 +129,36 @@ class CRM_Member_PseudoConstant extends CRM_Core_PseudoConstant {
       CRM_Core_PseudoConstant::populate(self::$membershipStatus[$cacheKey],
         'CRM_Member_DAO_MembershipStatus',
         $allStatus, $column, 'is_active', $cond, 'weight'
+      );
+    }
+
+    $value = NULL;
+    if ($id) {
+      $value = CRM_Utils_Array::value($id, self::$membershipStatus[$cacheKey]);
+    }
+    else {
+      $value = self::$membershipStatus[$cacheKey];
+    }
+
+    return $value;
+  }
+
+  /**
+   *  Bug Fix: CRM-21356 Membership Status is not updated after disabling a membership type
+   */
+  public static function &allMembershipStatus($id = NULL, $cond = NULL, $column = 'name', $force = FALSE, $allStatus = FALSE) {
+    if (self::$membershipStatus === NULL) {
+      self::$membershipStatus = array();
+    }
+
+    $cacheKey = $column;
+    if ($cond) {
+      $cacheKey .= "_{$cond}";
+    }
+    if (!isset(self::$membershipStatus[$cacheKey]) || $force) {
+      CRM_Core_PseudoConstant::populate(self::$membershipStatus[$cacheKey],
+        'CRM_Member_DAO_MembershipStatus',
+        TRUE, $column, 'is_active', $cond, 'weight'
       );
     }
 

--- a/templates/CRM/Member/Page/Tab.tpl
+++ b/templates/CRM/Member/Page/Tab.tpl
@@ -86,7 +86,7 @@
             {foreach from=$activeMembers item=activeMember}
             <tr id="crm-membership_{$activeMember.id}" class="{cycle values="odd-row,even-row"} {$activeMember.class} crm-membership">
                 <td class="crm-membership-membership_type">
-                    {$activeMember.membership_type}
+                    {$activeMember.membership_type} {$activeMember.is_active}
                     {if $activeMember.owner_membership_id}<br />({ts}by relationship{/ts}){/if}
                 </td>
                 <td class="crm-membership-join_date" data-order="{$activeMember.join_date}">{$activeMember.join_date|crmDate}</td>
@@ -135,7 +135,7 @@
             </thead>
             {foreach from=$inActiveMembers item=inActiveMember}
             <tr id="crm-membership_{$inActiveMember.id}" class="{cycle values="odd-row,even-row"} {$inActiveMember.class} crm-membership">
-                <td class="crm-membership-membership_type">{$inActiveMember.membership_type}
+                <td class="crm-membership-membership_type">{$inActiveMember.membership_type} {$inActiveMember.is_active}
         {if $inActiveMember.owner_membership_id}<br />({ts}by relationship{/ts}){/if}
     </td>
                 <td class="crm-membership-join_date" data-order="{$inActiveMember.join_date}">{$inActiveMember.join_date|crmDate}</td>


### PR DESCRIPTION
Overview
----------------------------------------
I have tried to fix this bug as a task, part of a job interview. I am a beginner on civicrm so I would appreciate some constructive comments if anything is poorly written, or possibly broken

Before
----------------------------------------
If a membership for a contact is created with end date Today, and membership type Student and afterwards the membership type Student is disabled, when the  Scheduled Job "Update Membership Statuses" the membership status is not updated. Also while this membership is shown in a search it isn't shown at the membership tab.

After
----------------------------------------
The membership statuses for membership that have disabled types are updated. And the membership is shown at the membership tab. When a type is disabled the on the membership tab, on the membership table under Membership it will show "Membership Type (DISABLED)"

Comments
----------------------------------------
I would really like to get  some constructive criticism as to what I did right or wrong.

---

 * [CRM-21356: Membership status is not updated after disabling a membership type](https://issues.civicrm.org/jira/browse/CRM-21356)