### PR TITLE
CRM-19752 Improve performance for non-ACL users on summaryQuery

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -5040,9 +5040,8 @@ SELECT COUNT( conts.total_amount ) as total_count,
       $where .= " AND contact_a.is_deleted = 0 ";
     }
 
-    $query = $this->getSummaryQuery($where, $from);
-    $where = $query[0];
-    $from  = $query[1];
+    $query = $this->appendFinancialTypeWhereAndFromToQueryStrings($where, $from);
+
     // make sure contribution is completed - CRM-4989
     $completedWhere = $where . " AND civicrm_contribution.contribution_status_id = 1 ";
 
@@ -5173,16 +5172,14 @@ SELECT COUNT( conts.total_amount ) as cancel_count,
   }
 
   /**
-   * Function for getting the SummaryQuery of the respective financial type
+   * Append financial ACL limits to the query from & where clauses, if applicable.
    *
-   * @param $where
-   * @param $from
-   *
-   * @return array
+   * @param string $where
+   * @param string $from
    */
-  public function getSummaryQuery($where, $from) {
-    if (CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus()) {
-      $financialTypes = CRM_Contribute_PseudoConstant::financialType();
+  public function appendFinancialTypeWhereAndFromToQueryStrings(&$where, &$from) {
+    if (!CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus()) {
+      return;
     }
     CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes($financialTypes);
     if (!empty($financialTypes)) {
@@ -5194,7 +5191,6 @@ SELECT COUNT( conts.total_amount ) as cancel_count,
     else {
       $where .= " AND civicrm_contribution.financial_type_id IN (0)";
     }
-    return array($where, $from, $financialTypes);
   }
 
   /**

--- a/CRM/Core/ClassLoader.php
+++ b/CRM/Core/ClassLoader.php
@@ -205,7 +205,7 @@ class CRM_Core_ClassLoader {
     if (
       // Only load classes that clearly belong to CiviCRM.
       // Note: api/v3 does not use classes, but api_v3's test-suite does
-      (0 === strncmp($class, 'CRM_', 4) || 0 === strncmp($class, 'api_v3_', 7) || 0 === strncmp($class, 'WebTest_', 8) || 0 === strncmp($class, 'E2E_', 4)) &&
+      (0 === strncmp($class, 'CRM_', 4) || 0 === strncmp($class, 'CRMTraits', 9) || 0 === strncmp($class, 'api_v3_', 7) || 0 === strncmp($class, 'WebTest_', 8) || 0 === strncmp($class, 'E2E_', 4)) &&
       // Do not load PHP 5.3 namespaced classes.
       // (in a future version, maybe)
       FALSE === strpos($class, '\\')

--- a/CRM/Financial/BAO/FinancialType.php
+++ b/CRM/Financial/BAO/FinancialType.php
@@ -304,18 +304,17 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType {
       CRM_Core_Action::ADD => 'add',
       CRM_Core_Action::DELETE => 'delete',
     );
-    // check cached value
-    if (CRM_Utils_Array::value($action, self::$_availableFinancialTypes) && !$resetCache) {
-      $financialTypes = self::$_availableFinancialTypes[$action];
-      return self::$_availableFinancialTypes[$action];
-    }
-    foreach ($financialTypes as $finTypeId => $type) {
-      if (!CRM_Core_Permission::check($actions[$action] . ' contributions of type ' . $type)) {
-        unset($financialTypes[$finTypeId]);
+
+    if (!isset(\Civi::$statics[__CLASS__]['available_types_' . $action])) {
+      foreach ($financialTypes as $finTypeId => $type) {
+        if (!CRM_Core_Permission::check($actions[$action] . ' contributions of type ' . $type)) {
+          unset($financialTypes[$finTypeId]);
+        }
       }
+      \Civi::$statics[__CLASS__]['available_types_' . $action] = $financialTypes;
     }
-    self::$_availableFinancialTypes[$action] = $financialTypes;
-    return $financialTypes;
+    $financialTypes = \Civi::$statics[__CLASS__]['available_types_' . $action];
+    return \Civi::$statics[__CLASS__]['available_types_' . $action];
   }
 
   /**
@@ -459,15 +458,14 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType {
    * @return bool
    */
   public static function isACLFinancialTypeStatus() {
-    if (array_key_exists('acl_financial_type', self::$_statusACLFt)) {
-      return self::$_statusACLFt['acl_financial_type'];
+    if (!isset(\Civi::$statics[__CLASS__]['is_acl_enabled'])) {
+      \Civi::$statics[__CLASS__]['is_acl_enabled'] = FALSE;
+      $contributeSettings = Civi::settings()->get('contribution_invoice_settings');
+      if (CRM_Utils_Array::value('acl_financial_type', $contributeSettings)) {
+        \Civi::$statics[__CLASS__]['is_acl_enabled'] = TRUE;
+      }
     }
-    $contributeSettings = Civi::settings()->get('contribution_invoice_settings');
-    self::$_statusACLFt['acl_financial_type'] = FALSE;
-    if (CRM_Utils_Array::value('acl_financial_type', $contributeSettings)) {
-      self::$_statusACLFt['acl_financial_type'] = TRUE;
-    }
-    return self::$_statusACLFt['acl_financial_type'];
+    return \Civi::$statics[__CLASS__]['is_acl_enabled'];
   }
 
 }

--- a/tests/phpunit/CRMTraits/Financial/FinancialACLTrait.php
+++ b/tests/phpunit/CRMTraits/Financial/FinancialACLTrait.php
@@ -1,0 +1,109 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2017                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Trait FinancialACLTrait
+ *
+ * Trait for working with Financial ACLs in tests
+ */
+trait CRMTraits_Financial_FinancialACLTrait {
+
+  /**
+   * Enable financial ACLs.
+   */
+  protected function enableFinancialACLs() {
+    $contributeSettings = Civi::settings()->get('contribution_invoice_settings');
+    $this->callAPISuccess('Setting', 'create', [
+      'contribution_invoice_settings' => array_merge($contributeSettings, ['acl_financial_type' => TRUE])
+    ]);
+    unset(\Civi::$statics['CRM_Financial_BAO_FinancialType']);
+  }
+
+  /**
+   * Disable financial ACLs.
+   */
+  protected function disableFinancialACLs() {
+    $contributeSettings = Civi::settings()->get('contribution_invoice_settings');
+    $this->callAPISuccess('Setting', 'create', [
+      'contribution_invoice_settings' => array_merge($contributeSettings, ['acl_financial_type' => FALSE])
+    ]);
+    unset(\Civi::$statics['CRM_Financial_BAO_FinancialType']);
+  }
+
+  /**
+   * Create a logged in user limited by ACL permissions.
+   *
+   * @param array $aclPermissions
+   *   Array of ACL permissions in the format
+   *   [[$action, $financialType], [$action, $financialType])
+   */
+  protected function createLoggedInUserWithFinancialACL($aclPermissions = [['view', 'Donation']]) {
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM'];
+    $this->createLoggedInUser();
+    $this->addFinancialAclPermissions($aclPermissions);
+  }
+
+  /**
+   * Add a permission to the financial ACLs.
+   *
+   * @param array $aclPermissions
+   *   Array of ACL permissions in the format
+   *   [[$action, $financialType], [$action, $financialType])
+   */
+  protected function addFinancialAclPermissions($aclPermissions) {
+    $permissions = CRM_Core_Config::singleton()->userPermissionClass->permissions;
+    foreach ($aclPermissions as $aclPermission) {
+      $permissions[] = $aclPermission[0] . ' contributions of type ' . $aclPermission[1];
+    }
+    $this->setPermissions($permissions);
+  }
+
+  /**
+   * Add a permission to the permissions array.
+   *
+   * @param array $permissions
+   *   Array of permissions to add - e.g. ['access CiviCRM','access CiviContribute'],
+   */
+  protected function addPermissions($permissions) {
+    $permissions = array_merge(CRM_Core_Config::singleton()->userPermissionClass->permissions, $permissions);
+    $this->setPermissions($permissions);
+  }
+
+  /**
+   * Set ACL permissions, overwriting any existing ones.
+   *
+   * @param array $permissions
+   *   Array of permissions e.g ['access CiviCRM','access CiviContribute'],
+   */
+  protected function setPermissions($permissions) {
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = $permissions;
+    if (isset(\Civi::$statics['CRM_Financial_BAO_FinancialType'])) {
+      unset(\Civi::$statics['CRM_Financial_BAO_FinancialType']);
+    }
+  }
+
+}

--- a/tests/phpunit/api/v3/EventTest.php
+++ b/tests/phpunit/api/v3/EventTest.php
@@ -773,7 +773,7 @@ class api_v3_EventTest extends CiviUnitTestCase {
       'title' => 'le cake is a tie',
       'check_permissions' => TRUE,
     );
-    $config = &CRM_Core_Config::singleton();
+    $config = CRM_Core_Config::singleton();
     $config->userPermissionClass->permissions = array('access CiviCRM');
     $result = $this->callAPIFailure('event', 'create', $params);
     $this->assertEquals('API permission check failed for Event/create call; insufficient permission: require access CiviCRM and access CiviEvent and edit all events', $result['error_message'], 'lacking permissions should not be enough to create an event');

--- a/tests/phpunit/api/v3/FinancialTypeACLTest.php
+++ b/tests/phpunit/api/v3/FinancialTypeACLTest.php
@@ -33,6 +33,8 @@
  */
 class api_v3_FinancialTypeACLTest extends CiviUnitTestCase {
 
+  use CRMTraits_Financial_FinancialACLTrait;
+
   /**
    * Assume empty database with just civicrm_data.
    */
@@ -109,29 +111,14 @@ class api_v3_FinancialTypeACLTest extends CiviUnitTestCase {
   public function tearDown() {
     $this->quickCleanUpFinancialEntities();
     $this->quickCleanup(array('civicrm_uf_match'));
-    CRM_Financial_BAO_FinancialType::$_availableFinancialTypes = array();
-    CRM_Financial_BAO_FinancialType::$_statusACLFt = array();
-    $params = array(
-      'domain_id' => 1,
-      'contribution_invoice_settings' => array('acl_financial_type' => 0),
-    );
-  }
-
-  public function setACL() {
-    CRM_Financial_BAO_FinancialType::$_availableFinancialTypes = array();
-    CRM_Financial_BAO_FinancialType::$_statusACLFt = array();
-    $params = array(
-      'domain_id' => 1,
-      'contribution_invoice_settings' => array('acl_financial_type' => 1),
-    );
-    $this->callAPISuccess('setting', 'create', $params);
+    $this->disableFinancialACLs();
   }
 
   /**
    * Test Get.
    */
   public function testCreateACLContribution() {
-    $this->setACL();
+    $this->enableFinancialACLs();
     $p = array(
       'contact_id' => $this->_individualId,
       'receive_date' => '2010-01-20',
@@ -146,28 +133,29 @@ class api_v3_FinancialTypeACLTest extends CiviUnitTestCase {
       'contribution_status_id' => 1,
       'check_permissions' => TRUE,
     );
-    $config = &CRM_Core_Config::singleton();
-    $config->userPermissionClass->permissions = array(
+
+    $this->setPermissions([
       'access CiviCRM',
       'access CiviContribute',
       'edit contributions',
-    );
+    ]);
     $result = $this->callAPIFailure('contribution', 'create', $p);
     $this->assertEquals('You do not have permission to create this contribution', $result['error_message']);
-    $config->userPermissionClass->permissions[] = 'add contributions of type Donation';
+    $this->addFinancialAclPermissions([['add', 'Donation']]);
+
     $contribution = $this->callAPISuccess('contribution', 'create', $p);
 
     $params = array(
       'contribution_id' => $contribution['id'],
     );
 
-    $config->userPermissionClass->permissions = array(
+    $this->setPermissions([
       'access CiviCRM',
       'access CiviContribute',
       'edit contributions',
       'view contributions of type Donation',
       'delete contributions of type Donation',
-    );
+    ]);
 
     $contribution = $this->callAPISuccess('contribution', 'get', $params);
 
@@ -191,14 +179,14 @@ class api_v3_FinancialTypeACLTest extends CiviUnitTestCase {
    * Test that acl contributions can be retrieved.
    */
   public function testGetACLContribution() {
-    $this->setACL();
-    $config = &CRM_Core_Config::singleton();
-    $config->userPermissionClass->permissions = array(
+    $this->enableFinancialACLs();
+
+    $this->setPermissions([
       'access CiviCRM',
       'access CiviContribute',
       'view all contacts',
       'add contributions of type Donation',
-    );
+    ]);
     $contribution = $this->callAPISuccess('Contribution', 'create', $this->_params);
 
     $params = array(
@@ -208,9 +196,7 @@ class api_v3_FinancialTypeACLTest extends CiviUnitTestCase {
     $contribution = $this->callAPISuccess('contribution', 'get', $params);
     $this->assertEquals($contribution['count'], 0);
 
-    CRM_Financial_BAO_FinancialType::$_availableFinancialTypes = NULL;
-
-    $config->userPermissionClass->permissions[3] = 'view contributions of type Donation';
+    $this->addFinancialAclPermissions([['view', 'Donation']]);
     $contribution = $this->callAPISuccess('contribution', 'get', $params);
 
     $this->assertEquals($contribution['count'], 1);
@@ -220,7 +206,7 @@ class api_v3_FinancialTypeACLTest extends CiviUnitTestCase {
    * Test checks that passing in line items suppresses the create mechanism.
    */
   public function testCreateACLContributionChainedLineItems() {
-    $this->setACL();
+    $this->enableFinancialACLs();
     $params = array(
       'contact_id' => $this->_individualId,
       'receive_date' => '20120511',
@@ -251,30 +237,26 @@ class api_v3_FinancialTypeACLTest extends CiviUnitTestCase {
       ),
     );
 
-    $config = CRM_Core_Config::singleton();
-    $config->userPermissionClass->permissions = array(
+    $this->setPermissions([
       'access CiviCRM',
       'access CiviContribute',
       'edit contributions',
       'delete in CiviContribute',
       'add contributions of type Donation',
       'delete contributions of type Donation',
-    );
+    ]);
     $this->callAPIFailure('contribution', 'create', $params, 'Error in call to LineItem_create : You do not have permission to create this line item');
 
     // Check that the entire contribution has rolled back.
     $contribution = $this->callAPISuccess('contribution', 'get', array());
     $this->assertEquals(0, $contribution['count']);
 
-    CRM_Financial_BAO_FinancialType::$_availableFinancialTypes = NULL;
-
-    $config = CRM_Core_Config::singleton();
-    $config->userPermissionClass->permissions = array_merge($config->userPermissionClass->permissions, array(
-      'add contributions of type Member Dues',
-      'view contributions of type Donation',
-      'view contributions of type Member Dues',
-      'delete contributions of type Member Dues',
-    ));
+    $this->addFinancialAclPermissions([
+      ['add', 'Member Dues'],
+      ['view', 'Donation'],
+      ['view', 'Member Dues'],
+      ['delete', 'Member Dues'],
+    ]);
     $contribution = $this->callAPISuccess('contribution', 'create', $params);
 
     $lineItemParams = array(
@@ -299,7 +281,7 @@ class api_v3_FinancialTypeACLTest extends CiviUnitTestCase {
    * Test that acl contributions can be edited.
    */
   public function testEditACLContribution() {
-    $this->setACL();
+    $this->enableFinancialACLs();
     $contribution = $this->callAPISuccess('Contribution', 'create', $this->_params);
 
     $params = array(
@@ -307,16 +289,16 @@ class api_v3_FinancialTypeACLTest extends CiviUnitTestCase {
       'check_permissions' => TRUE,
       'total_amount' => 200.00,
     );
-    $config = CRM_Core_Config::singleton();
-    $config->userPermissionClass->permissions = array(
+
+    $this->setPermissions([
       'access CiviCRM',
       'access CiviContribute',
       'edit contributions',
       'view contributions of type Donation',
-    );
+    ]);
     $this->callAPIFailure('Contribution', 'create', $params);
 
-    $config->userPermissionClass->permissions[] = 'edit contributions of type Donation';
+    $this->addFinancialAclPermissions([['edit', 'Donation']]);
     $contribution = $this->callAPISuccess('Contribution', 'create', $params);
 
     $this->assertEquals($contribution['values'][$contribution['id']]['total_amount'], 200.00);
@@ -326,24 +308,24 @@ class api_v3_FinancialTypeACLTest extends CiviUnitTestCase {
    * Test that acl contributions can be deleted.
    */
   public function testDeleteACLContribution() {
-    $this->setACL();
-    $config = CRM_Core_Config::singleton();
-    $config->userPermissionClass->permissions = array(
+    $this->enableFinancialACLs();
+
+    $this->setPermissions([
       'access CiviCRM',
       'access CiviContribute',
       'view all contacts',
       'add contributions of type Donation',
-    );
+    ]);
     $contribution = $this->callAPISuccess('Contribution', 'create', $this->_params);
 
     $params = array(
       'contribution_id' => $contribution['id'],
       'check_permissions' => TRUE,
     );
-    $config->userPermissionClass->permissions[3] = 'delete in CiviContribute';
+    $this->addPermissions(['delete in CiviContribute']);
     $this->callAPIFailure('Contribution', 'delete', $params);
 
-    $config->userPermissionClass->permissions[] = 'delete contributions of type Donation';
+    $this->addFinancialAclPermissions([['delete', 'Donation']]);
     $contribution = $this->callAPISuccess('Contribution', 'delete', $params);
 
     $this->assertEquals($contribution['count'], 1);


### PR DESCRIPTION
Overview
----------------------------------------
When loading contribution summary (and other queries not addressed) an extra join to the line item table is added & extra criteria to faclitiate financial acls regardless of whether financial ACLs are enabled. This is an unnecessary performance hit & this adds a check before adding those joins

Before
----------------------------------------
ContributionSummary query slowed to apply financial ACLs, regardless of their existance.

After
----------------------------------------
Financial ACL joins not added if financial ACLs not enabled

Technical Details
----------------------------------------
Mostly this is obvious stuff building on #9746 & fixing the caching (partially - I can still see flaws in it but they are not worsened) to allow testing.

However @totten @colemanw there IS something new & notable here - I have used a TRAIT file in the unit test. I think the most debatable part of this is where I put it & how I edited ClassLoader

Comments
----------------------------------------
@monishdeb can you review the main part of the PR (aside from the trait conversation)

---

 * [CRM-19752: Slow query created by financial type acls](https://issues.civicrm.org/jira/browse/CRM-19752)