### PR TITLE
Website api - fix nonstandard BAO delete method

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -3525,8 +3525,9 @@ LEFT JOIN civicrm_address add2 ON ( add1.master_id = add2.id )
     $obj = new $daoName();
     $obj->id = $id;
     $obj->find();
+    $hookParams = [];
     if ($obj->fetch()) {
-      CRM_Utils_Hook::pre('delete', $type, $id, CRM_Core_DAO::$_nullArray);
+      CRM_Utils_Hook::pre('delete', $type, $id, $hookParams);
       $contactId = $obj->contact_id;
       $obj->delete();
     }

--- a/CRM/Core/BAO/Website.php
+++ b/CRM/Core/BAO/Website.php
@@ -79,7 +79,7 @@ class CRM_Core_BAO_Website extends CRM_Core_DAO_Website {
         self::add($values);
       }
       elseif ($skipDelete && !empty($values['id'])) {
-        self::del(array($values['id']));
+        self::del($values['id']);
       }
     }
   }
@@ -87,15 +87,24 @@ class CRM_Core_BAO_Website extends CRM_Core_DAO_Website {
   /**
    * Delete website.
    *
-   * @param array $ids
-   *   Website ids.
+   * @param int $id
    *
    * @return bool
    */
-  public static function del($ids) {
-    $query = 'DELETE FROM civicrm_website WHERE id IN ( ' . implode(',', $ids) . ')';
-    CRM_Core_DAO::executeQuery($query);
-    // FIXME: we should return false if the del was unsuccessful
+  public static function del($id) {
+    $obj = new self();
+    $obj->id = $id;
+    $obj->find();
+    if ($obj->fetch()) {
+      $params = [];
+      CRM_Utils_Hook::pre('delete', 'Website', $id, $params);
+      $obj->delete();
+    }
+    else {
+      return FALSE;
+    }
+    CRM_Utils_Hook::post('delete', 'Website', $id, $obj);
+    $obj->free();
     return TRUE;
   }
 

--- a/api/v3/Website.php
+++ b/api/v3/Website.php
@@ -64,8 +64,6 @@ function _civicrm_api3_website_create_spec(&$params) {
 /**
  * Deletes an existing Website.
  *
- * @todo convert to using Basic delete - BAO function non standard
- *
  * @param array $params
  *
  * @return array
@@ -73,20 +71,7 @@ function _civicrm_api3_website_create_spec(&$params) {
  * @throws \API_Exception
  */
 function civicrm_api3_website_delete($params) {
-  //DO NOT USE THIS FUNCTION AS THE BASIS FOR A NEW API http://wiki.civicrm.org/confluence/display/CRM/API+Architecture+Standards
-  civicrm_api3_verify_mandatory($params, NULL, array('id'));
-  _civicrm_api3_check_edit_permissions('CRM_Core_BAO_Website', array('id' => $params['id']));
-  $websiteDAO = new CRM_Core_DAO_Website();
-  $websiteDAO->id = $params['id'];
-  if ($websiteDAO->find()) {
-    while ($websiteDAO->fetch()) {
-      $websiteDAO->delete();
-      return civicrm_api3_create_success(1, $params, 'Website', 'delete');
-    }
-  }
-  else {
-    throw new API_Exception('Could not delete Website with id ' . $params['id']);
-  }
+  return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
 }
 
 /**


### PR DESCRIPTION
Overview
----
Fix oddball BAO del function.

Before
---
Function did not conform to standards and hooks were not called when deleting a website.

After
----
Hooks are called when deleting a website. The BAO function follows conventions so the api can use it.

Technical Details
-----
This function was only called from one place. Even the api3 was not using it. So changing the function signature seems safe.