### PR TITLE
(NFC) Fix logging test for multilingual on MySQL5.7

### DIFF
--- a/tests/phpunit/CRM/Logging/LoggingTest.php
+++ b/tests/phpunit/CRM/Logging/LoggingTest.php
@@ -14,6 +14,7 @@ class CRM_Logging_LoggingTest extends CiviUnitTestCase {
     CRM_Core_I18n_Schema::makeSinglelingual('en_US');
     $logging = new CRM_Logging_Schema();
     $logging->dropAllLogTables();
+    \Civi::$statics['CRM_Logging_Schema']['columnSpecs'] = array();
     parent::tearDown();
   }
 
@@ -40,15 +41,26 @@ class CRM_Logging_LoggingTest extends CiviUnitTestCase {
     $logging->enableLogging();
     $value = CRM_Core_DAO::singleValueQuery("SELECT id FROM log_civicrm_contact LIMIT 1", array(), FALSE, FALSE);
     $this->assertNotNull($value, 'Logging not enabled successfully');
-    $logging->disableLogging();
-    CRM_Core_DAO::executeQuery("ALTER TABLE `civicrm_option_value` ADD COLUMN `logging_test` INT DEFAULT NULL", array(), FALSE, NULL, FALSE, FALSE);
+    CRM_Core_DAO::executeQuery("ALTER TABLE `civicrm_option_value` ADD COLUMN `logging_test` INT DEFAULT '0'", array(), FALSE, NULL, FALSE, FALSE);
     CRM_Core_I18n_Schema::rebuildMultilingualSchema(array('en_US'));
-    $logging->enableLogging();
+    \Civi::$statics['CRM_Logging_Schema']['columnSpecs'] = array();
+    $logging->fixSchemaDifferencesFor('civicrm_option_value', array(), TRUE);
     $query = CRM_Core_DAO::executeQuery("SHOW CREATE TABLE `log_civicrm_option_value`", array(), TRUE, NULL, FALSE, FALSE);
     $query->fetch();
+    $query->free();
+    $create = explode("\n", $query->Create_Table);
+    $this->assertTrue(in_array("  `logging_test` int(11) DEFAULT '0'", $create));
     $create = explode("\n", $query->Create_Table);
     CRM_Core_DAO::executeQuery("ALTER TABLE `civicrm_option_value` DROP COLUMN `logging_test`", array(), FALSE, NULL, FALSE, FALSE);
-    $this->assertTrue(in_array("  `logging_test` int(11) DEFAULT NULL", $create));
+    $query = CRM_Core_DAO::executeQuery("SHOW CREATE TABLE `log_civicrm_option_value`", array(), TRUE, NULL, FALSE, FALSE);
+    $query->fetch();
+    $domain = new CRM_Core_DAO_Domain();
+    $domain->find(TRUE);
+    $locales = explode(CRM_Core_DAO::VALUE_SEPARATOR, $domain->locales);
+    \Civi::$statics['CRM_Logging_Schema']['columnSpecs'] = array();
+    CRM_Core_I18n_Schema::rebuildMultilingualSchema($locales);
+    $logging->fixSchemaDifferencesFor('civicrm_option_value', array(), TRUE);
+    $this->assertTrue(in_array("  `logging_test` int(11) DEFAULT '0'", $create));
     $logging->disableLogging();
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
At present CRM_Logging_LoggingTest is failing on Ubu1604 which runs MySQL 5.7. This is because the multilingual view is still referencing a column that has now been deleted from the base table and MySQL 5.7 is a bit more stricter on this. This fixes the test and improves the test a little.

Before
----------------------------------------
Test fails on ubu1604-1

After
----------------------------------------
Test passes on MySQL 5.7

ping @mlutfy @totten @eileenmcnaughton 