### PR TITLE
CRM-21675: scheduled reminders: limit to group doesn't support parent groups

### DIFF
--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -1334,7 +1334,7 @@ WHERE {$whereClause}";
   public static function getChildGroupIds($regularGroupIDs) {
     $childGroupIDs = array();
 
-    foreach ($regularGroupIDs as $regularGroupID) {
+    foreach ((array) $regularGroupIDs as $regularGroupID) {
       // temporary store the child group ID(s) of regular group identified by $id,
       //   later merge with main child group array
       $tempChildGroupIDs = array();

--- a/Civi/ActionSchedule/RecipientBuilder.php
+++ b/Civi/ActionSchedule/RecipientBuilder.php
@@ -419,18 +419,31 @@ class RecipientBuilder {
     $actionSchedule = $this->actionSchedule;
 
     if ($actionSchedule->group_id) {
-      if ($this->isSmartGroup($actionSchedule->group_id)) {
-        // Check that the group is in place in the cache and up to date
-        \CRM_Contact_BAO_GroupContactCache::check($actionSchedule->group_id);
-        return \CRM_Utils_SQL_Select::fragment()
-          ->join('grp', "INNER JOIN civicrm_group_contact_cache grp ON {$contactIdField} = grp.contact_id")
-          ->where(" grp.group_id IN ({$actionSchedule->group_id})");
+      $regularGroupIDs = $smartGroupIDs = $groupWhereCLause = array();
+      $query = \CRM_Utils_SQL_Select::fragment();
+
+      // get child group IDs if any
+      $childGroupIDs = \CRM_Contact_BAO_Group::getChildGroupIds($actionSchedule->group_id);
+      foreach (array_merge(array($actionSchedule->group_id), $childGroupIDs) as $groupID) {
+        if ($this->isSmartGroup($groupID)) {
+          // Check that the group is in place in the cache and up to date
+          \CRM_Contact_BAO_GroupContactCache::check($groupID);
+          $smartGroupIDs[] = $groupID;
+        }
+        else {
+          $regularGroupIDs[] = $groupID;
+        }
       }
-      else {
-        return \CRM_Utils_SQL_Select::fragment()
-          ->join('grp', " INNER JOIN civicrm_group_contact grp ON {$contactIdField} = grp.contact_id AND grp.status = 'Added'")
-          ->where(" grp.group_id IN ({$actionSchedule->group_id})");
+
+      if (!empty($smartGroupIDs)) {
+        $query->join('sg', "LEFT JOIN civicrm_group_contact_cache sg ON {$contactIdField} = sg.contact_id");
+        $groupWhereCLause[] = " sg.group_id IN ( " . implode(', ', $smartGroupIDs) . " ) ";
       }
+      if (!empty($regularGroupIDs)) {
+        $query->join('rg', " LEFT JOIN civicrm_group_contact rg ON {$contactIdField} = rg.contact_id AND rg.status = 'Added'");
+        $groupWhereCLause[] = " rg.group_id IN ( " . implode(', ', $regularGroupIDs) . " ) ";
+      }
+      return $query->where(implode(" OR ", $groupWhereCLause));
     }
     elseif (!empty($actionSchedule->recipient_manual)) {
       $rList = \CRM_Utils_Type::escape($actionSchedule->recipient_manual, 'String');


### PR DESCRIPTION
Overview
----------------------------------------
Currently, you can not include recipients of parent group and its child group but can choose only 1 regular or smart group to limit recipients of schedule reminder. This fix extends the support to include all the recipients of parent and its child group(s).

Before
----------------------------------------
Doesn't include all recipients of parent and its child group(s)

After
----------------------------------------
Include all recipients of parent and its child group(s)


Technical Details
----------------------------------------
The PR got unit test for this fix

---

 * [CRM-21675: scheduled reminders: limit to group doesn't support smart groups](https://issues.civicrm.org/jira/browse/CRM-21675)