### PR TITLE
CRM-20625 Don't crash if we can't find the payment processor class.

### DIFF
--- a/CRM/Admin/Form/PaymentProcessor.php
+++ b/CRM/Admin/Form/PaymentProcessor.php
@@ -41,7 +41,12 @@ class CRM_Admin_Form_PaymentProcessor extends CRM_Admin_Form {
 
   protected $_fields = NULL;
 
-  protected $_ppDAO;
+  protected $_paymentProcessorDAO;
+
+  /**
+   * @var int $_paymentProcessorType Payment processor Type ID
+   */
+  protected $_paymentProcessorType;
 
   /**
    * Get the name of the base entity being edited.
@@ -56,30 +61,30 @@ class CRM_Admin_Form_PaymentProcessor extends CRM_Admin_Form {
     parent::preProcess();
 
     if ($this->_id) {
-      $this->_ppType = CRM_Utils_Request::retrieve('pp', 'String', $this, FALSE, NULL);
-      if (!$this->_ppType) {
-        $this->_ppType = CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_PaymentProcessor',
+      $this->_paymentProcessorType = CRM_Utils_Request::retrieve('pp', 'String', $this, FALSE, NULL);
+      if (!$this->_paymentProcessorType) {
+        $this->_paymentProcessorType = CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_PaymentProcessor',
           $this->_id,
           'payment_processor_type_id'
         );
       }
-      $this->set('pp', $this->_ppType);
+      $this->set('pp', $this->_paymentProcessorType);
     }
     else {
-      $this->_ppType = CRM_Utils_Request::retrieve('pp', 'String', $this, TRUE, NULL);
+      $this->_paymentProcessorType = CRM_Utils_Request::retrieve('pp', 'String', $this, TRUE, NULL);
     }
 
-    $this->assign('ppType', $this->_ppType);
+    $this->assign('ppType', $this->_paymentProcessorType);
     $ppTypeName = CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_PaymentProcessorType',
-      $this->_ppType,
+      $this->_paymentProcessorType,
       'name'
     );
     $this->assign('ppTypeName', $ppTypeName);
 
-    $this->_ppDAO = new CRM_Financial_DAO_PaymentProcessorType();
-    $this->_ppDAO->id = $this->_ppType;
+    $this->_paymentProcessorDAO = new CRM_Financial_DAO_PaymentProcessorType();
+    $this->_paymentProcessorDAO->id = $this->_paymentProcessorType;
 
-    $this->_ppDAO->find(TRUE);
+    $this->_paymentProcessorDAO->find(TRUE);
 
     if ($this->_id) {
       $refreshURL = CRM_Utils_System::url('civicrm/admin/paymentProcessor',
@@ -104,24 +109,24 @@ class CRM_Admin_Form_PaymentProcessor extends CRM_Admin_Form {
     $this->refreshURL = $refreshURL;
     $this->assign('refreshURL', $refreshURL);
 
-    $this->assign('is_recur', $this->_ppDAO->is_recur);
+    $this->assign('is_recur', $this->_paymentProcessorDAO->is_recur);
 
     $this->_fields = array(
       array(
         'name' => 'user_name',
-        'label' => $this->_ppDAO->user_name_label,
+        'label' => $this->_paymentProcessorDAO->user_name_label,
       ),
       array(
         'name' => 'password',
-        'label' => $this->_ppDAO->password_label,
+        'label' => $this->_paymentProcessorDAO->password_label,
       ),
       array(
         'name' => 'signature',
-        'label' => $this->_ppDAO->signature_label,
+        'label' => $this->_paymentProcessorDAO->signature_label,
       ),
       array(
         'name' => 'subject',
-        'label' => $this->_ppDAO->subject_label,
+        'label' => $this->_paymentProcessorDAO->subject_label,
       ),
       array(
         'name' => 'url_site',
@@ -131,7 +136,7 @@ class CRM_Admin_Form_PaymentProcessor extends CRM_Admin_Form {
       ),
     );
 
-    if ($this->_ppDAO->is_recur) {
+    if ($this->_paymentProcessorDAO->is_recur) {
       $this->_fields[] = array(
         'name' => 'url_recur',
         'label' => ts('Recurring Payments URL'),
@@ -140,7 +145,7 @@ class CRM_Admin_Form_PaymentProcessor extends CRM_Admin_Form {
       );
     }
 
-    if (!empty($this->_ppDAO->url_button_default)) {
+    if (!empty($this->_paymentProcessorDAO->url_button_default)) {
       $this->_fields[] = array(
         'name' => 'url_button',
         'label' => ts('Button URL'),
@@ -149,7 +154,7 @@ class CRM_Admin_Form_PaymentProcessor extends CRM_Admin_Form {
       );
     }
 
-    if (!empty($this->_ppDAO->url_api_default)) {
+    if (!empty($this->_paymentProcessorDAO->url_api_default)) {
       $this->_fields[] = array(
         'name' => 'url_api',
         'label' => ts('API URL'),
@@ -188,8 +193,11 @@ class CRM_Admin_Form_PaymentProcessor extends CRM_Admin_Form {
       $attributes['description']
     );
 
-    $types = CRM_Core_PseudoConstant::paymentProcessorType();
-    $this->add('select', 'payment_processor_type_id', ts('Payment Processor Type'), $types, TRUE,
+    $this->add('select',
+      'payment_processor_type_id',
+      ts('Payment Processor Type'),
+      CRM_Financial_BAO_PaymentProcessor::buildOptions('payment_processor_type_id'),
+      TRUE,
       array('onchange' => "reload(true)")
     );
 
@@ -306,18 +314,18 @@ class CRM_Admin_Form_PaymentProcessor extends CRM_Admin_Form {
 
     if (!$this->_id) {
       $defaults['is_active'] = $defaults['is_default'] = 1;
-      $defaults['url_site'] = $this->_ppDAO->url_site_default;
-      $defaults['url_api'] = $this->_ppDAO->url_api_default;
-      $defaults['url_recur'] = $this->_ppDAO->url_recur_default;
-      $defaults['url_button'] = $this->_ppDAO->url_button_default;
-      $defaults['test_url_site'] = $this->_ppDAO->url_site_test_default;
-      $defaults['test_url_api'] = $this->_ppDAO->url_api_test_default;
-      $defaults['test_url_recur'] = $this->_ppDAO->url_recur_test_default;
-      $defaults['test_url_button'] = $this->_ppDAO->url_button_test_default;
-      $defaults['payment_instrument_id'] = $this->_ppDAO->payment_instrument_id;
+      $defaults['url_site'] = $this->_paymentProcessorDAO->url_site_default;
+      $defaults['url_api'] = $this->_paymentProcessorDAO->url_api_default;
+      $defaults['url_recur'] = $this->_paymentProcessorDAO->url_recur_default;
+      $defaults['url_button'] = $this->_paymentProcessorDAO->url_button_default;
+      $defaults['test_url_site'] = $this->_paymentProcessorDAO->url_site_test_default;
+      $defaults['test_url_api'] = $this->_paymentProcessorDAO->url_api_test_default;
+      $defaults['test_url_recur'] = $this->_paymentProcessorDAO->url_recur_test_default;
+      $defaults['test_url_button'] = $this->_paymentProcessorDAO->url_button_test_default;
+      $defaults['payment_instrument_id'] = $this->_paymentProcessorDAO->payment_instrument_id;
       // When user changes payment processor type, it is passed in via $this->_ppType so update defaults array.
-      if ($this->_ppType) {
-        $defaults['payment_processor_type_id'] = $this->_ppType;
+      if ($this->_paymentProcessorType) {
+        $defaults['payment_processor_type_id'] = $this->_paymentProcessorType;
       }
       return $defaults;
     }
@@ -331,10 +339,16 @@ class CRM_Admin_Form_PaymentProcessor extends CRM_Admin_Form {
     }
 
     CRM_Core_DAO::storeValues($dao, $defaults);
-    // When user changes payment processor type, it is passed in via $this->_ppType so update defaults array.
-    if ($this->_ppType) {
-      $defaults['payment_processor_type_id'] = $this->_ppType;
+    // If payment processor ID does not exist, $paymentProcessorName will be FALSE
+    $paymentProcessorName = CRM_Core_PseudoConstant::getName('CRM_Financial_BAO_PaymentProcessor', 'payment_processor_type_id', $this->_paymentProcessorType);
+    if ($this->_paymentProcessorType && $paymentProcessorName) {
+      // When user changes payment processor type, it is passed in via $this->_ppType so update defaults array.
+      $defaults['payment_processor_type_id'] = $this->_paymentProcessorType;
     }
+    else {
+      CRM_Core_Session::setStatus('Payment Processor Type (ID=' . $this->_paymentProcessorType . ') not found. Did you disable the payment processor extension?', 'Missing Payment Processor', 'alert');
+    }
+
     $cards = json_decode(CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_PaymentProcessor',
           $this->_id,
           'accepted_credit_cards'
@@ -384,6 +398,13 @@ class CRM_Admin_Form_PaymentProcessor extends CRM_Admin_Form {
       CRM_Core_DAO::executeQuery($query);
     }
 
+    if ($this->_paymentProcessorType !== $values['payment_processor_type_id']) {
+      // If we changed the payment processor type, need to update the object as well
+      $this->_paymentProcessorType = $values['payment_processor_type_id'];
+      $this->_paymentProcessorDAO = new CRM_Financial_DAO_PaymentProcessorType();
+      $this->_paymentProcessorDAO->id = $values['payment_processor_type_id'];
+      $this->_paymentProcessorDAO->find(TRUE);
+    }
     $this->updatePaymentProcessor($values, $domainID, FALSE);
     $this->updatePaymentProcessor($values, $domainID, TRUE);
 
@@ -432,11 +453,11 @@ class CRM_Admin_Form_PaymentProcessor extends CRM_Admin_Form {
       'is_test' => $test,
       'is_active' => 0,
       'is_default' => 0,
-      'is_recur' => $this->_ppDAO->is_recur,
-      'billing_mode' => $this->_ppDAO->billing_mode,
-      'class_name' => $this->_ppDAO->class_name,
-      'payment_type' => $this->_ppDAO->payment_type,
-      'payment_instrument_id' => $this->_ppDAO->payment_instrument_id,
+      'is_recur' => $this->_paymentProcessorDAO->is_recur,
+      'billing_mode' => $this->_paymentProcessorDAO->billing_mode,
+      'class_name' => $this->_paymentProcessorDAO->class_name,
+      'payment_type' => $this->_paymentProcessorDAO->payment_type,
+      'payment_instrument_id' => $this->_paymentProcessorDAO->payment_instrument_id,
       'financial_account_id' => $values['financial_account_id'],
       'accepted_credit_cards' => $creditCards,
     ), $values);

--- a/CRM/Contribute/PseudoConstant.php
+++ b/CRM/Contribute/PseudoConstant.php
@@ -132,12 +132,13 @@ class CRM_Contribute_PseudoConstant extends CRM_Core_PseudoConstant {
 
   /**
    * @deprecated. Please use the buildOptions() method in the appropriate BAO object.
+   * TODO: buildOptions() doesn't replace this as it doesn't support filtering, which is used with this function.
    *
-   * Get all the financial Accounts
+   * Get all/filtered array of the financial Accounts
    *
    *
    * @param int $id
-   * @param int $financialAccountTypeId
+   * @param int $financialAccountTypeId Optional filer to return only financial accounts of type
    * @param string $retrieveColumn
    * @param string $key
    *

--- a/Civi/Payment/System.php
+++ b/Civi/Payment/System.php
@@ -53,18 +53,17 @@ class System {
       }
       else {
         $paymentClass = 'CRM_Core_' . $processor['class_name'];
-        if (empty($paymentClass)) {
+        if (empty($processor['class_name'])) {
           throw new \CRM_Core_Exception('no class provided');
         }
-        require_once str_replace('_', DIRECTORY_SEPARATOR, $paymentClass) . '.php';
       }
 
-      $processorObject = new $paymentClass(!empty($processor['is_test']) ? 'test' : 'live', $processor);
-      if (!$force && $processorObject->checkConfig()) {
-        $processorObject = NULL;
-      }
-      else {
-        $processorObject->setPaymentProcessor($processor);
+      $processorObject = NULL;
+      if (class_exists($paymentClass)) {
+        $processorObject = new $paymentClass(!empty($processor['is_test']) ? 'test' : 'live', $processor);
+        if ($force || !$processorObject->checkConfig()) {
+          $processorObject->setPaymentProcessor($processor);
+        }
       }
       $this->cache[$id] = $processorObject;
     }


### PR DESCRIPTION
Overview
----------------------------------------
If the payment processor doesn't exist CiviCRM crashes horribly and you can't do anything (via the UI).  This can happen for a couple of reasons:
1. Extension path is changed (so enabled payment processor is now missing).
2. Payment processor extension is disabled.

Before
----------------------------------------
CiviCRM crashes and you can't restore the extension (except via CLI wizardry).

After
----------------------------------------
CiviCRM does not crash.
Any payment processor with missing class is not loaded (the same as if it had an invalid config).
If you edit payment processors you get a warning message if the payment processor no longer exists and you can change it to another type if desired.

Technical Details
----------------------------------------
CiviCRM was not checking for payment processor classes before trying to use them.
Also identified a bug where the first time you save after changing a payment processor, the values of the previous payment processor are still saved - we need to reload the payment processor object before saving if the type has changed.

---

 * [CRM-20625: Better Payment Processor extension error handling](https://issues.civicrm.org/jira/browse/CRM-20625)