### PR TITLE
Crm 20856

### DIFF
--- a/CRM/Member/BAO/MembershipType.php
+++ b/CRM/Member/BAO/MembershipType.php
@@ -370,8 +370,9 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
       elseif ($membershipTypeDetails['duration_unit'] == 'month') {
         // Check if we are on or after rollover day of the month - CRM-10585
         // If so, set fixed_period_rollover TRUE so we increment end_date month below.
+        // Check as well if 'fixed_period_rollover_day' is null to prevent the increment of the month for issue CRM-20856
         $dateParts = explode('-', $actualStartDate);
-        if ($dateParts[2] >= $membershipTypeDetails['fixed_period_rollover_day']) {
+        if ($dateParts[2] >= $membershipTypeDetails['fixed_period_rollover_day'] && !is_null($membershipTypeDetails['fixed_period_rollover_day'])) {
           $fixed_period_rollover = TRUE;
         }
 

--- a/Civi/API/Request.php
+++ b/Civi/API/Request.php
@@ -73,7 +73,7 @@ class Request {
         return $apiRequest;
 
       case 4:
-        $callable = array("Civi\\Api4\\Entity\\$entity", $action);
+        $callable = array("Civi\\Api4\\$entity", $action);
         if (!is_callable($callable)) {
           throw new Exception\NotImplementedException("API ($entity, $action) does not exist (join the API team and implement it!)");
         }

--- a/tests/phpunit/CRM/Member/BAO/MembershipTypeTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipTypeTest.php
@@ -293,6 +293,43 @@ class CRM_Member_BAO_MembershipTypeTest extends CiviUnitTestCase {
   }
 
   /**
+   * check function getDatesForMembershipType( )
+   *
+   */
+  public function testGetDatesWithFixedPeriodForMembershipType() {
+    $ids = array();
+    $params = array(
+      'name' => 'General',
+      'description' => NULL,
+      'minimum_fee' => 100,
+      'join_date' => '20180205000000',  
+      'domain_id' => 1,
+      'duration_unit' => 'month',
+      'member_of_contact_id' => $this->_orgContactID,
+      'period_type' => 'fixed',
+      'duration_interval' => 1,
+      'financial_type_id' => $this->_financialTypeId,
+      'relationship_type_id' => $this->_relationshipTypeId,
+      'visibility' => 'Public',
+      'fixed_period_rollover_day' => null,
+      'is_active' => 1,
+    );
+    $membership = CRM_Member_BAO_MembershipType::add($params, $ids);    
+    $membershipDates = CRM_Member_BAO_MembershipType::getDatesForMembershipType($membership->id);
+    
+    //Generate end date with the logic it have in the CRM_Member_BAO_MembershipType::getDatesForMembershipType for fixed_period_rollover_day is null
+    $date = explode('-', $membershipDates['start_date']);
+    $year = $date[0];
+    $month = $date[1];
+    $day = $date[2];
+    $month = $month + (1 * $membershipDates['duration_interval']);
+    $extectedEndDate = $endDate = date('Y-m-d', mktime(0, 0, 0, $month, $day - 1, $year));
+    
+    $this->assertEquals($membershipDates['end_date'], $extectedEndDate, 'Verify membership types details.');
+    $this->membershipTypeDelete(array('id' => $membership->id));
+  }
+ 
+  /**
    * check function getRenewalDatesForMembershipType( )
    *
    */


### PR DESCRIPTION
For fixed period_type in the membershiptype, whenever the value of `fixed_period_rollover_day` is null then it's was also full filing the condition 

```if ($dateParts[2] >= $membershipTypeDetails['fixed_period_rollover_day']){
$fixed_period_rollover = TRUE;
}```

to increment the month value. So here i've added the extra condition like 

```if ($dateParts[2] >= $membershipTypeDetails['fixed_period_rollover_day'] && !is_null($membershipTypeDetails['fixed_period_rollover_day'])) {
          $fixed_period_rollover = TRUE;
        }``` 

And that condition fixed the issue.