### PR TITLE
CRM-21738 fix transfer of view_only custom data.

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1528,9 +1528,20 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
     CRM_Core_OptionGroup::lookupValues($submitted, $names, TRUE);
 
     // fix custom fields so they're edible by createProfileContact()
-    static $treeCache = array();
+    $treeCache = array();
     if (!array_key_exists($migrationInfo['main_details']['contact_type'], $treeCache)) {
-      $treeCache[$migrationInfo['main_details']['contact_type']] = CRM_Core_BAO_CustomGroup::getTree($migrationInfo['main_details']['contact_type'], NULL, NULL, -1);
+      $treeCache[$migrationInfo['main_details']['contact_type']] = CRM_Core_BAO_CustomGroup::getTree(
+        $migrationInfo['main_details']['contact_type'],
+        NULL,
+        NULL,
+        -1,
+        array(),
+        NULL,
+        TRUE,
+        NULL,
+        FALSE,
+        FALSE
+      );
     }
 
     $cFields = array();
@@ -1696,12 +1707,12 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
     // move view only custom fields CRM-5362
     $viewOnlyCustomFields = array();
     foreach ($submitted as $key => $value) {
-      $fid = (int) substr($key, 7);
-      if (array_key_exists($fid, $cFields) && !empty($cFields[$fid]['attributes']['is_view'])) {
+      $fid = CRM_Core_BAO_CustomField::getKeyID($key);
+      if ($fid && array_key_exists($fid, $cFields) && !empty($cFields[$fid]['attributes']['is_view'])
+      ) {
         $viewOnlyCustomFields[$key] = $value;
       }
     }
-
     // special case to set values for view only, CRM-5362
     if (!empty($viewOnlyCustomFields)) {
       $viewOnlyCustomFields['entityID'] = $mainId;

--- a/tests/phpunit/api/v3/JobTest.php
+++ b/tests/phpunit/api/v3/JobTest.php
@@ -883,6 +883,28 @@ class api_v3_JobTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test the batch merge copes with view only custom data field.
+   */
+  public function testBatchMergeCustomDataViewOnlyField() {
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = array('access CiviCRM', 'edit my contact');
+    $mouseParams = ['first_name' => 'Mickey', 'last_name' => 'Mouse', 'email' => 'tha_mouse@mouse.com'];
+    $this->individualCreate($mouseParams);
+
+    $customGroup = $this->CustomGroupCreate();
+    $customField = $this->customFieldCreate(array('custom_group_id' => $customGroup['id'], 'is_view' => 1));
+    $this->individualCreate(array_merge($mouseParams, ['custom_' . $customField['id'] => 'blah']));
+
+    $result = $this->callAPISuccess('Job', 'process_batch_merge', array('check_permissions' => 0, 'mode' => 'safe'));
+    $this->assertEquals(1, count($result['values']['merged']));
+    $mouseParams['return'] = 'custom_' . $customField['id'];
+    $mouse = $this->callAPISuccess('Contact', 'getsingle', $mouseParams);
+    $this->assertEquals('blah', $mouse['custom_' . $customField['id']]);
+
+    $this->customFieldDelete($customGroup['id']);
+    $this->customGroupDelete($customGroup['id']);
+  }
+
+  /**
    * Test the batch merge function actually works!
    *
    * @dataProvider getMergeSets


### PR DESCRIPTION
Overview
----------------------------------------

Fix bug whereby view only custom data was not being transferred during the merge despite code in order to achieve that. 

Before
----------------------------------------
When view only custom fields were populates the data was not transferred & hence lost when batch merging (& presumably UI merging too but I didn't focus on that)

After
----------------------------------------
View only custom field data transferred on batch merge. I was able to replicate in a unit test so fix is locked in - since it has clearly been fixed at least once before.

Technical Details
----------------------------------------
The reason was the metadata was being used from the (hateful)
getGroupTree function, but without passing $permissions = FALSE it was not
returning viewOnly fields. Note that this metadata retrieval function is a bad place for
filtering - they should be in separate functions.

Comments
----------------------------------------
This may be the reason for https://issues.civicrm.org/jira/browse/CRM-17843 to fail too

---

 * [CRM-21738: Merges not copying viewOnly data \(regression but not recent\)](https://issues.civicrm.org/jira/browse/CRM-21738)