### PR TITLE
 CRM-21343: Add cancel filters for Contribution search

### DIFF
--- a/CRM/Contribute/BAO/Query.php
+++ b/CRM/Contribute/BAO/Query.php
@@ -186,7 +186,7 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
       case 'contribution_date_high_time':
         // process to / from date
         $query->dateQueryBuilder($values,
-          'civicrm_contribution', 'contribution_date', 'receive_date', 'Contribution Date'
+          'civicrm_contribution', 'contribution_date', 'receive_date', ts('Contribution Date')
         );
         return;
 
@@ -225,6 +225,17 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
         }
         $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause("civicrm_contribution.receipt_date", $op);
         $query->_tables['civicrm_contribution'] = $query->_whereTables['civicrm_contribution'] = 1;
+        return;
+
+      case 'contribution_cancel_date':
+      case 'contribution_cancel_date_low':
+      case 'contribution_cancel_date_low_time':
+      case 'contribution_cancel_date_high':
+      case 'contribution_cancel_date_high_time':
+        // process to / from date
+        $query->dateQueryBuilder($values,
+          'civicrm_contribution', 'contribution_cancel_date', 'cancel_date', ts('Cancelled / Refunded Date')
+        );
         return;
 
       case 'financial_type_id':
@@ -905,6 +916,11 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
     $form->add('text', 'contribution_amount_high', ts('To'), array('size' => 8, 'maxlength' => 8));
     $form->addRule('contribution_amount_high', ts('Please enter a valid money value (e.g. %1).', array(1 => CRM_Utils_Money::format('99.99', ' '))), 'money');
 
+    // Adding Cancelled Contribution fields -- CRM-21343
+    $form->add('text', 'contribution_cancel_reason', ts('Cancellation / Refund Reason'), array('size' => 40));
+    CRM_Core_Form_Date::buildDateRange($form, 'contribution_cancel_date', 1, '_low', '_high', ts('From:'), FALSE);
+    $form->addElement('hidden', 'contribution_cancel_date_range_error');
+
     // Adding select option for curreny type -- CRM-4711
     $form->add('select', 'contribution_currency_type',
       ts('Currency Type'),
@@ -1082,11 +1098,12 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
   public static function formRule($fields, $files, $form) {
     $errors = array();
 
-    if (empty($fields['contribution_date_high']) || empty($fields['contribution_date_low'])) {
-      return TRUE;
+    if (!empty($fields['contribution_date_high']) && !empty($fields['contribution_date_low'])) {
+      CRM_Utils_Rule::validDateRange($fields, 'contribution_date', $errors, ts('Date Received'));
     }
-
-    CRM_Utils_Rule::validDateRange($fields, 'contribution_date', $errors, ts('Date Received'));
+    if (!empty($fields['contribution_cancel_date_high']) && !empty($fields['contribution_cancel_date_low'])) {
+      CRM_Utils_Rule::validDateRange($fields, 'contribution_cancel_date', $errors, ts('Cancel Date'));
+    }
 
     return empty($errors) ? TRUE : $errors;
   }

--- a/templates/CRM/Contribute/Form/Search/Common.tpl
+++ b/templates/CRM/Contribute/Form/Search/Common.tpl
@@ -39,6 +39,18 @@
 </tr>
 <tr>
   <td>
+    <label>{ts}Currency{/ts}</label> <br />
+    {$form.contribution_currency_type.html|crmAddClass:twenty}
+  </td>
+  {if $form.contribution_batch_id.html }
+    <td>
+      {$form.contribution_batch_id.label}<br />
+      {$form.contribution_batch_id.html}
+    </td>
+  {/if}
+</tr>
+<tr>
+  <td>
     <div class="float-left">
       <label>{$form.contribution_payment_instrument_id.label}</label> <br />
       {$form.contribution_payment_instrument_id.html|crmAddClass:twenty}
@@ -146,22 +158,27 @@
     {include file="CRM/Contribute/Form/PCP.js.tpl"}
   </td>
   <td>
+    {$form.contribution_cancel_reason.label}<br />
+    {$form.contribution_cancel_reason.html}
+  </td>
+</tr>
+<tr>
+  <td>
     {$form.contribution_pcp_display_in_roll.label}
     {$form.contribution_pcp_display_in_roll.html}
   </td>
-</tr>
-
-<tr>
   <td>
-    <label>{ts}Currency{/ts}</label> <br />
-    {$form.contribution_currency_type.html|crmAddClass:twenty}
+    <table style="width:auto">
+      <tr>
+        <td>
+          <label>{ts}Cancelled / Refunded Date{/ts}</label>
+        </td>
+      </tr>
+      <tr>
+        {include file="CRM/Core/DateRange.tpl" fieldName="contribution_cancel_date" from='_low' to='_high'}
+      </tr>
+    </table>
   </td>
-  {if $form.contribution_batch_id.html }
-    <td>
-      {$form.contribution_batch_id.label}<br />
-      {$form.contribution_batch_id.html}
-    </td>
-  {/if}
 </tr>
 
 {* campaign in contribution search *}

--- a/tests/phpunit/CRM/Contribute/Form/SearchTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/SearchTest.php
@@ -487,7 +487,8 @@ class CRM_Contribute_Form_SearchTest extends CiviUnitTestCase {
       $this->assertEquals($case['expected_qill'], $qill);
     }
   }
-    /**
+
+  /**
    *  CRM-21343: Test CRM_Contribute_Form_Search Cancelled filters
    */
   public function testCancelledFilter() {
@@ -527,7 +528,6 @@ class CRM_Contribute_Form_SearchTest extends CiviUnitTestCase {
       'cancel_reason' => 'Invalid Credit Card Number',
       'contact_id' => $contactID1,
     ));
-
 
     $useCases = array(
       // Case 1: Search for Cancelled Date
@@ -573,4 +573,5 @@ class CRM_Contribute_Form_SearchTest extends CiviUnitTestCase {
       $this->assertEquals($case['expected_qill'], $qill);
     }
   }
+
 }

--- a/tests/phpunit/CRM/Contribute/Form/SearchTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/SearchTest.php
@@ -487,5 +487,90 @@ class CRM_Contribute_Form_SearchTest extends CiviUnitTestCase {
       $this->assertEquals($case['expected_qill'], $qill);
     }
   }
+    /**
+   *  CRM-21343: Test CRM_Contribute_Form_Search Cancelled filters
+   */
+  public function testCancelledFilter() {
+    $this->quickCleanup($this->_tablesToTruncate);
+    $contactID1 = $this->individualCreate(array(), 1);
+    $contactID2 = $this->individualCreate(array(), 2);
+    $Contribution1 = $this->callAPISuccess('Contribution', 'create', array(
+      'financial_type_id' => 1,
+      'total_amount' => 100,
+      'receive_date' => date('Ymd'),
+      'receive_date_time' => NULL,
+      'payment_instrument' => 1,
+      'contribution_status_id' => 3,
+      'cancel_date' => date('Ymd'),
+      'cancel_reason' => 'Insufficient funds',
+      'contact_id' => $contactID1,
+    ));
+    $Contribution2 = $this->callAPISuccess('Contribution', 'create', array(
+      'financial_type_id' => 1,
+      'total_amount' => 150,
+      'receive_date' => date('Ymd', strtotime(date('Y-m-d') . ' - 1 days')),
+      'receive_date_time' => NULL,
+      'payment_instrument' => 1,
+      'contribution_status_id' => 3,
+      'cancel_date' => date('Ymd', strtotime(date('Y-m-d') . ' - 1 days')),
+      'cancel_reason' => 'Insufficient funds',
+      'contact_id' => $contactID2,
+    ));
+    $Contribution3 = $this->callAPISuccess('Contribution', 'create', array(
+      'financial_type_id' => 1,
+      'total_amount' => 200,
+      'receive_date' => date('Ymd'),
+      'receive_date_time' => NULL,
+      'payment_instrument' => 1,
+      'contribution_status_id' => 3,
+      'cancel_date' => date('Ymd'),
+      'cancel_reason' => 'Invalid Credit Card Number',
+      'contact_id' => $contactID1,
+    ));
 
+
+    $useCases = array(
+      // Case 1: Search for Cancelled Date
+      array(
+        'form_value' => array('cancel_date' => date('Y-m-d')),
+        'expected_count' => 2,
+        'expected_contribution' => array($Contribution1['id'], $Contribution3['id']),
+        'expected_qill' => "Cancel Date Like '%" . date('Y-m-d') . "%'",
+      ),
+      // Case 2: Search for Cancelled Reason
+      array(
+        'form_value' => array('cancel_reason' => 'Invalid Credit Card Number'),
+        'expected_count' => 1,
+        'expected_contribution' => array($Contribution3['id']),
+        'expected_qill' => "Cancel Reason Like '%Invalid Credit Card Number%'",
+      ),
+      // Case 3: Search for Cancelled Date and Cancelled Reason
+      array(
+        'form_value' => array('cancel_date' => date('Y-m-d'), 'cancel_reason' => 'Insufficient funds'),
+        'expected_count' => 1,
+        'expected_contribution' => array($Contribution1['id']),
+        'expected_qill' => "Cancel Date Like '%" . date('Y-m-d') . "%'ANDCancel Reason Like '%Insufficient funds%'",
+      ),
+    );
+
+    foreach ($useCases as $case) {
+      $fv = $case['form_value'];
+      CRM_Contact_BAO_Query::processSpecialFormValue($fv, array('cancel_date', 'cancel_reason'));
+      $query = new CRM_Contact_BAO_Query(CRM_Contact_BAO_Query::convertFormValues($fv));
+      list($select, $from, $where, $having) = $query->query();
+
+      // get and assert contribution count
+      $contributions = CRM_Core_DAO::executeQuery(sprintf('SELECT DISTINCT civicrm_contribution.id %s %s AND civicrm_contribution.id IS NOT NULL AND civicrm_contribution.contribution_status_id = 3', $from, $where))->fetchAll();
+      foreach ($contributions as $key => $value) {
+        $contributions[$key] = $value['id'];
+      }
+      // assert the contribution count
+      $this->assertEquals($case['expected_count'], count($contributions));
+      // assert the contribution IDs
+      $this->checkArrayEquals($case['expected_contribution'], $contributions);
+      // get and assert qill string
+      $qill = trim(implode($query->getOperator(), CRM_Utils_Array::value(0, $query->qill())));
+      $this->assertEquals($case['expected_qill'], $qill);
+    }
+  }
 }


### PR DESCRIPTION
Overview
----------------------------------------
Add cancel reason and cancel date filters in Contribution search form
https://issues.civicrm.org/jira/browse/CRM-21343

Before
----------------------------------------
No cancel reason or cancel date fields in the form to be used as contribution filters

After
----------------------------------------
![screenshot](https://user-images.githubusercontent.com/2589799/31940989-7017acf0-b8c0-11e7-9c6c-12ebbbda2323.png)


old PR reference --> https://github.com/civicrm/civicrm-core/pull/11189