### PR TITLE
fix dev/core#1: allow to search contributions that are in progress

### DIFF
--- a/CRM/Contribute/BAO/Query.php
+++ b/CRM/Contribute/BAO/Query.php
@@ -940,8 +940,6 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
       CRM_Contribute_PseudoConstant::pcPage(), FALSE, array('class' => 'crm-select2', 'multiple' => 'multiple', 'placeholder' => ts('- any -')));
 
     $statusValues = CRM_Core_PseudoConstant::get('CRM_Contribute_DAO_Contribution', 'contribution_status_id');
-    // Remove status values that are only used for recurring contributions or pledges (In Progress, Overdue).
-    unset($statusValues['5'], $statusValues['6']);
     $form->add('select', 'contribution_status_id',
       ts('Contribution Status'), $statusValues,
       FALSE, array('class' => 'crm-select2', 'multiple' => 'multiple')


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/issues/1

The search is hiding the status "in progress". However, some payment processor do use this status (eg the sepa one), so it is  in effect hiding contributions, and therefore makes the users very sad and confused

Fix:
allow to search on status "in progress". Worse case scenario, no contributions have this status, and it will return an empty list

