### PR TITLE
Fix empty payment processor check

### DIFF
--- a/Civi/Payment/System.php
+++ b/Civi/Payment/System.php
@@ -52,10 +52,10 @@ class System {
         require_once $ext->classToPath($paymentClass);
       }
       else {
-        $paymentClass = 'CRM_Core_' . $processor['class_name'];
-        if (empty($paymentClass)) {
+        if (empty($processor['class_name'])) {
           throw new \CRM_Core_Exception('no class provided');
         }
+        $paymentClass = 'CRM_Core_' . $processor['class_name'];
         require_once str_replace('_', DIRECTORY_SEPARATOR, $paymentClass) . '.php';
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
Obviously the string won't be empty if it has 'CRM_Core_' prepended to it first.

Before
----------------------------------------
The require_once would fail when given a blank processor.

After
----------------------------------------
The function throws a CRM_Core_Exception when given a blank processor.
