### PR TITLE
CRM-21742 Proximity search validation improvement

### DIFF
--- a/CRM/Contact/Form/Search/Custom.php
+++ b/CRM/Contact/Form/Search/Custom.php
@@ -83,12 +83,21 @@ class CRM_Contact_Form_Search_Custom extends CRM_Contact_Form_Search {
     // instantiate the new class
     $this->_customClass = new $this->_customSearchClass($this->_formValues);
 
+    $this->addFormRule(array($this->_customClass, 'formRule'), $this);
+
     // CRM-12747
     if (isset($this->_customClass->_permissionedComponent) &&
       !self::isPermissioned($this->_customClass->_permissionedComponent)
     ) {
       CRM_Utils_System::permissionDenied();
     }
+  }
+
+  /**
+   * Add local and global form rules.
+   */
+  public function addRules() {
+    $this->addFormRule(array($this->_customClass, 'formRule'));
   }
 
   /**

--- a/CRM/Contact/Form/Search/Custom/Base.php
+++ b/CRM/Contact/Form/Search/Custom/Base.php
@@ -257,4 +257,18 @@ class CRM_Contact_Form_Search_Custom_Base {
     }
   }
 
+  /**
+   * Validate form input.
+   *
+   * @param array $fields
+   * @param array $files
+   * @param CRM_Core_Form $self
+   *
+   * @return array
+   *   Input errors from the form.
+   */
+  public function formRule($fields, $files, $self) {
+    return [];
+  }
+
 }

--- a/CRM/Contact/Form/Search/Custom/Proximity.php
+++ b/CRM/Contact/Form/Search/Custom/Proximity.php
@@ -55,24 +55,7 @@ class CRM_Contact_Form_Search_Custom_Proximity extends CRM_Contact_Form_Search_C
 
     if (!empty($this->_formValues)) {
       // add the country and state
-      if (!empty($this->_formValues['country_id'])) {
-        $this->_formValues['country'] = CRM_Core_PseudoConstant::country($this->_formValues['country_id']);
-      }
-
-      if (!empty($this->_formValues['state_province_id'])) {
-        $this->_formValues['state_province'] = CRM_Core_PseudoConstant::stateProvince($this->_formValues['state_province_id']);
-      }
-
-      // use the address to get the latitude and longitude
-      CRM_Core_BAO_Address::addGeocoderData($this->_formValues);
-
-      if (!is_numeric(CRM_Utils_Array::value('geo_code_1', $this->_formValues)) ||
-        !is_numeric(CRM_Utils_Array::value('geo_code_2', $this->_formValues)) ||
-        !isset($this->_formValues['distance'])
-      ) {
-        throw new CRM_Core_Exception(ts('Could not geocode input'));
-      }
-
+      self::addGeocodingData($this->_formValues);
       $this->_latitude = $this->_formValues['geo_code_1'];
       $this->_longitude = $this->_formValues['geo_code_2'];
 
@@ -318,6 +301,45 @@ AND cgc.group_id = {$this->_group}
    */
   public function buildACLClause($tableAlias = 'contact') {
     list($this->_aclFrom, $this->_aclWhere) = CRM_Contact_BAO_Contact_Permission::cacheClause($tableAlias);
+  }
+
+  /**
+   * Validate form input.
+   *
+   * @param array $fields
+   * @param array $files
+   * @param CRM_Core_Form $self
+   *
+   * @return array
+   *   Input errors from the form.
+   */
+  public function formRule($fields, $files, $self) {
+    $this->addGeocodingData($fields);
+
+    if (!is_numeric(CRM_Utils_Array::value('geo_code_1', $fields)) ||
+      !is_numeric(CRM_Utils_Array::value('geo_code_2', $fields)) ||
+      !isset($fields['distance'])
+    ) {
+      $errorMessage = ts('Could not determine co-ordinates for provided data');
+      return array_fill_keys(['street_address', 'city', 'postal_code', 'country_id', 'state_province_id'], $errorMessage);
+    }
+    return [];
+  }
+
+  /**
+   * Add the geocoding data to the fields supplied.
+   *
+   * @param array $fields
+   */
+  protected function addGeocodingData(&$fields) {
+    if (!empty($fields['country_id'])) {
+      $fields['country'] = CRM_Core_PseudoConstant::country($fields['country_id']);
+    }
+
+    if (!empty($fields['state_province_id'])) {
+      $fields['state_province'] = CRM_Core_PseudoConstant::stateProvince($fields['state_province_id']);
+    }
+    CRM_Core_BAO_Address::addGeocoderData($fields);
   }
 
 }

--- a/CRM/Report/Form/Contribute/Repeat.php
+++ b/CRM/Report/Form/Contribute/Repeat.php
@@ -513,9 +513,9 @@ LEFT JOIN $this->tempTableRepeat2 {$this->_aliases['civicrm_contribution']}2
   }
 
   /**
-   * @param $fields
-   * @param $files
-   * @param $self
+   * @param array $fields
+   * @param array $files
+   * @param CRM_Core_Form $self
    *
    * @return array
    */

--- a/CRM/Report/Form/Contribute/SoftCredit.php
+++ b/CRM/Report/Form/Contribute/SoftCredit.php
@@ -417,9 +417,9 @@ class CRM_Report_Form_Contribute_SoftCredit extends CRM_Report_Form {
   }
 
   /**
-   * @param $fields
-   * @param $files
-   * @param $self
+   * @param array $fields
+   * @param array $files
+   * @param CRM_Core_Form $self
    *
    * @return array
    */


### PR DESCRIPTION
Overview
----------------------------------------
Change hard error to form validation message for invalid/ ungeocodable  data entered in the proximity search.

Before
----------------------------------------
![screenshot 2018-02-07 13 56 26](https://user-images.githubusercontent.com/336308/35892550-b67e4ef0-0c0e-11e8-9282-5b1de0605ba6.png)


After
----------------------------------------
![screenshot 2018-02-07 13 51 55](https://user-images.githubusercontent.com/336308/35892442-2eeec212-0c0e-11e8-96ea-1f2253626eb8.png)


Technical Details
----------------------------------------
The PR introduces a rule for the custom searches which they can override to perform validation. 

Comments
----------------------------------------
I will rebase this once #11540 is merged

---

 * [CRM-21742: Use form validation rather than Exception handling for proximity seach](https://issues.civicrm.org/jira/browse/CRM-21742)