### PR TITLE
CRM-21743: Fix creating new event template from existing one

### DIFF
--- a/templates/CRM/Event/Form/ManageEvent/EventInfo.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/EventInfo.tpl
@@ -175,7 +175,7 @@
     var $form = $('form.{/literal}{$form.formClass}{literal}');
     $('#template_id', $form).change(function() {
       $(this).closest('.crm-ajax-container, #crm-main-content-wrapper')
-        .crmSnippet({url: CRM.url('civicrm/event/add', {action: 'add', reset: 1, template_id: $(this).val()})})
+        .crmSnippet({url: CRM.url('civicrm/event/add', {action: 'add', reset: 1, template_id: $(this).val(), is_template: $("input[name='is_template']").val()})})
         .crmSnippet('refresh');
     })
   });


### PR DESCRIPTION
Overview
----------------------------------------
When trying to create an event template from an existing one, it end up creating a new event rather than a new event template.

Before
----------------------------------------
1) Go to new event template form at *civicrm/admin/eventTemplate?reset=1*
2) Click on 'add event template'
3) Choose any existing template from the 'from template' select box.
4) when you continue and save any information you have edited here, Civi creates a new event using those details rather than a new event template.

![before](https://user-images.githubusercontent.com/6275540/35893993-3d28aeb0-0bb9-11e8-91b8-2742213a069d.gif)


After
----------------------------------------
The above is fixed, now creating a new event template from existing one result in creating new event template as expected.

![after](https://user-images.githubusercontent.com/6275540/35894106-e4fe63dc-0bb9-11e8-93b6-704869f68052.gif)



Technical Details
----------------------------------------
Event templates are stored as events in civicrm_event table, but their is_template field = true and that's why they won't appear on event listing page but will appear in event template listing page and vice versa. 

When trying to create new template using the form, you can notice there is a hidden input with the name is_template and value=1 so creating new template work fine, but when you select an existing template as a base for your new template, the following on change listener  (inside CRM/Event/Form/ManageEvent/EventInfo.tpl) will get triggered : 

```
  CRM.$(function($) {
    var $form = $('form.{/literal}{$form.formClass}{literal}');
    $('#template_id', $form).change(function() {
      $(this).closest('.crm-ajax-container, #crm-main-content-wrapper')
        .crmSnippet({url: CRM.url('civicrm/event/add', {action: 'add', reset: 1, template_id: $(this).val()})})
        .crmSnippet('refresh');
    })
  });
```

which as you can see perform an ajax request against this URL : 
**civicrm/event/add**

with the template_id as a GET parameter, then it will refresh the form body with the existing template data, but because **civicrm/event/add** is a generic path and does not know if you are adding a template or an event without passing is_template parameter, it will think you are trying to add an event and the new refreshed form will not the hidden is_template field with empty value instead of 1 which will result in creating an event instead of a template when submitting the form.

I fixed the issue by passing is_template value whether it is 1 or empty string to the ajax call above so it can refresh the form correctly.

---

 * [CRM-21743: Creating an even template from existing one does not work](https://issues.civicrm.org/jira/browse/CRM-21743)