### PR TITLE
CRM-21744 fix proximity search to work with smart groups

### DIFF
--- a/CRM/Contact/Form/Search/Custom/Proximity.php
+++ b/CRM/Contact/Form/Search/Custom/Proximity.php
@@ -27,6 +27,9 @@
 
 /**
  *
+ * This search now functions as a subset of advanced search since at some point it
+ * was added to advanced search.
+ *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2017
  */
@@ -79,6 +82,15 @@ class CRM_Contact_Form_Search_Custom_Proximity extends CRM_Contact_Form_Search_C
       ts('State') => 'state_province',
       ts('Country') => 'country',
     );
+  }
+
+  /**
+   * Get the query object for this selector.
+   *
+   * @return CRM_Contact_BAO_Query
+   */
+  public function getQueryObj() {
+    return $this->_query;
   }
 
   /**
@@ -162,20 +174,7 @@ class CRM_Contact_Form_Search_Custom_Proximity extends CRM_Contact_Form_Search_C
     $offset = 0, $rowcount = 0, $sort = NULL,
     $includeContactIDs = FALSE, $justIDs = FALSE
   ) {
-    if ($justIDs) {
-      $selectClause = "contact_a.id as contact_id";
-    }
-    else {
-      $selectClause = "
-contact_a.id           as contact_id    ,
-contact_a.sort_name    as sort_name     ,
-address.street_address as street_address,
-address.city           as city          ,
-address.postal_code    as postal_code   ,
-state_province.name    as state_province,
-country.name           as country
-";
-    }
+    $selectClause = $justIDs ? "contact_a.id as contact_id" : NULL;
 
     return $this->sql($selectClause,
       $offset, $rowcount, $sort,
@@ -184,66 +183,79 @@ country.name           as country
   }
 
   /**
+   * Override sql() function to use the Query object rather than generating on the form.
+   *
+   * @param string $selectClause
+   * @param int $offset
+   * @param int $rowcount
+   * @param null $sort
+   * @param bool $includeContactIDs
+   * @param null $groupBy
+   *
+   * @return string
+   */
+  public function sql(
+    $selectClause,
+    $offset = 0,
+    $rowcount = 0,
+    $sort = NULL,
+    $includeContactIDs = FALSE,
+    $groupBy = NULL
+  ) {
+
+    $isCountOnly = FALSE;
+    if ($selectClause === 'count(distinct contact_a.id) as total') {
+      $isCountOnly = TRUE;
+    }
+
+    $searchParams = [
+      ['prox_distance_unit', '=', $this->_formValues['prox_distance_unit'], 0, 0],
+      ['prox_distance', '=', $this->_formValues['distance'], 0, 0],
+      ['prox_geo_code_1', '=', $this->_formValues['geo_code_1'], 0, 0],
+      ['prox_geo_code_2', '=', $this->_formValues['geo_code_2'], 0, 0],
+    ];
+    if (!empty($this->_formValues['group'])) {
+      $searchParams[] = ['group', '=', ['IN', (array) $this->_formValues['group']][1], 0, 0];
+    }
+    if (!empty($this->_formValues['tag'])) {
+      $searchParams[] = ['contact_tags', '=', ['IN', (array) $this->_formValues['tag']][1], 0, 0];
+    }
+
+    $display = array_fill_keys(['city', 'state_province', 'country', 'postal_code', 'street_address', 'display_name', 'sort_name'], 1);
+    if ($selectClause === 'contact_a.id as contact_id') {
+      // Not sure when this would happen but calling all with 'justIDs' gets us here.
+      $display = ['contact_id' => 1];
+    }
+
+    $this->_query = new CRM_Contact_BAO_Query($searchParams, $display);
+    return $this->_query->searchQuery(
+      $offset,
+      $rowcount,
+      $sort,
+      $isCountOnly,
+      $includeContactIDs,
+      FALSE,
+      $isCountOnly,
+      $returnQuery = TRUE
+    );
+
+  }
+
+  /**
    * @return string
    */
   public function from() {
-    $this->buildACLClause('contact_a');
-    $f = "
-FROM      civicrm_contact contact_a
-LEFT JOIN civicrm_address address ON ( address.contact_id       = contact_a.id AND
-                                       address.is_primary       = 1 )
-LEFT JOIN civicrm_state_province state_province ON state_province.id = address.state_province_id
-LEFT JOIN civicrm_country country               ON country.id        = address.country_id {$this->_aclFrom}
-";
-
-    // This prevents duplicate rows when contacts have more than one tag any you select "any tag"
-    if ($this->_tag) {
-      $f .= "
-LEFT JOIN civicrm_entity_tag t ON (t.entity_table='civicrm_contact' AND contact_a.id = t.entity_id)
-";
-    }
-    if ($this->_group) {
-      $f .= "
-LEFT JOIN civicrm_group_contact cgc ON ( cgc.contact_id = contact_a.id AND cgc.status = 'Added')
-";
-    }
-
-    return $f;
+    //unused
+    return '';
   }
-
   /**
    * @param bool $includeContactIDs
    *
    * @return string
    */
   public function where($includeContactIDs = FALSE) {
-    $params = array();
-    $clause = array();
-
-    $where = CRM_Contact_BAO_ProximityQuery::where($this->_latitude,
-      $this->_longitude,
-      $this->_distance,
-      'address'
-    );
-
-    if ($this->_tag) {
-      $where .= "
-AND t.tag_id = {$this->_tag}
-";
-    }
-    if ($this->_group) {
-      $where .= "
-AND cgc.group_id = {$this->_group}
- ";
-    }
-
-    $where .= " AND contact_a.is_deleted != 1 ";
-
-    if ($this->_aclWhere) {
-      $where .= " AND {$this->_aclWhere} ";
-    }
-
-    return $this->whereClause($where, $params);
+    //unused
+    return '';
   }
 
   /**
@@ -297,13 +309,6 @@ AND cgc.group_id = {$this->_group}
     else {
       CRM_Utils_System::setTitle(ts('Search'));
     }
-  }
-
-  /**
-   * @param string $tableAlias
-   */
-  public function buildACLClause($tableAlias = 'contact') {
-    list($this->_aclFrom, $this->_aclWhere) = CRM_Contact_BAO_Contact_Permission::cacheClause($tableAlias);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fix proximity search to work with smart groups

Before
----------------------------------------
When using the proximity search it allows a smart group to be selected, but if you DO select one then it returns 0 results

After
----------------------------------------
The proximity search appropriately filters by smart groups

Technical Details
----------------------------------------
On analysing the search I decided that the the functionality was created in the search & then later exposed in Advanced search / the main query object, leaving the proximity search as just a subset of the advanced search. I decided rather than recreate the smart group logic I would simply point it the main Query object & remove the wrangling from the Proximity search 

Comments
----------------------------------------
This is the last of my geocoding ones I think :-) Further work in an extension. I will rebase once #11643 & #11543 are merged

---

 * [CRM-21744: Fix proximity custom search to work with smart groups](https://issues.civicrm.org/jira/browse/CRM-21744)