### PR TITLE
 CRM-17647 fix batch form & Online Event form to do money cleaning on the form

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1391,9 +1391,6 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       ) {
         unset($submittedValues['tax_amount']);
       }
-      // @todo - look to remove this line. I believe it relates to CRM-16460
-      // and possibly contributes to fixing the issue described there but
-      // would cause breakage for negative values in some cases.
       $submittedValues['total_amount'] = CRM_Utils_Array::value('amount', $submittedValues);
     }
 

--- a/tests/phpunit/CRM/Batch/Form/EntryTest.php
+++ b/tests/phpunit/CRM/Batch/Form/EntryTest.php
@@ -200,8 +200,13 @@ class CRM_Batch_Form_EntryTest extends CiviUnitTestCase {
 
   /**
    *  Test Contribution Import.
+   *
+   * @param $thousandSeparator
+   *
+   * @dataProvider getThousandSeparators
    */
-  public function testProcessContribution() {
+  public function testProcessContribution($thousandSeparator) {
+    $this->setCurrencySeparators($thousandSeparator);
     $this->offsetDefaultPriceSet();
     $form = new CRM_Batch_Form_Entry();
     $params = $this->getContributionData();
@@ -330,9 +335,11 @@ class CRM_Batch_Form_EntryTest extends CiviUnitTestCase {
   }
 
   /**
+   * @param $thousandSeparator
+   *
    * @return array
    */
-  public function getContributionData() {
+  public function getContributionData($thousandSeparator = '.') {
     return array(
       //'batch_id' => 4,
       'primary_profiles' => array(1 => NULL, 2 => NULL, 3 => NULL),
@@ -344,7 +351,7 @@ class CRM_Batch_Form_EntryTest extends CiviUnitTestCase {
       'field' => array(
         1 => array(
           'financial_type' => 1,
-          'total_amount' => 15,
+          'total_amount' =>  $this->formatMoneyInput(1500.15),
           'receive_date' => '2013-07-24',
           'receive_date_time' => NULL,
           'payment_instrument' => 1,
@@ -353,7 +360,7 @@ class CRM_Batch_Form_EntryTest extends CiviUnitTestCase {
         ),
         2 => array(
           'financial_type' => 1,
-          'total_amount' => 15,
+          'total_amount' => $this->formatMoneyInput(1500.15),
           'receive_date' => '2013-07-24',
           'receive_date_time' => NULL,
           'payment_instrument' => 1,
@@ -361,7 +368,7 @@ class CRM_Batch_Form_EntryTest extends CiviUnitTestCase {
           'contribution_status_id' => 1,
         ),
       ),
-      'actualBatchTotal' => 30,
+      'actualBatchTotal' => $this->formatMoneyInput(3000.30),
 
     );
   }

--- a/tests/phpunit/CRM/Batch/Form/EntryTest.php
+++ b/tests/phpunit/CRM/Batch/Form/EntryTest.php
@@ -351,7 +351,7 @@ class CRM_Batch_Form_EntryTest extends CiviUnitTestCase {
       'field' => array(
         1 => array(
           'financial_type' => 1,
-          'total_amount' =>  $this->formatMoneyInput(1500.15),
+          'total_amount' => $this->formatMoneyInput(1500.15),
           'receive_date' => '2013-07-24',
           'receive_date_time' => NULL,
           'payment_instrument' => 1,

--- a/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
+++ b/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
@@ -81,9 +81,14 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
   /**
    * Initial test of submit function for paid event.
    *
+   * @param string $thousandSeparator
+   *
+   * @dataProvider getThousandSeparators
+   *
    * @throws \Exception
    */
-  public function testPaidSubmit() {
+  public function testPaidSubmit($thousandSeparator) {
+    $this->setCurrencySeparators($thousandSeparator);
     $paymentProcessorID = $this->processorCreate();
     $params = array('is_monetary' => 1, 'financial_type_id' => 1);
     $event = $this->eventCreate($params);
@@ -93,7 +98,7 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
       'contributeMode' => 'direct',
       'registerByID' => $individualID,
       'paymentProcessorObj' => CRM_Financial_BAO_PaymentProcessor::getPayment($paymentProcessorID),
-      'totalAmount' => 800,
+      'totalAmount' => $this->formatMoneyInput(8000.67),
       'params' => array(
         array(
           'qfKey' => 'e6eb2903eae63d4c5c6cc70bfdda8741_2801',
@@ -133,7 +138,7 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
           'participant_role_id' => '1',
           'currencyID' => 'USD',
           'amount_level' => 'Tiny-tots (ages 5-8) - 1',
-          'amount' => '800.00',
+          'amount' => $this->formatMoneyInput(8000.67),
           'tax_amount' => NULL,
           'year' => '2019',
           'month' => '1',
@@ -147,6 +152,7 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
     ));
     $this->callAPISuccessGetCount('Participant', array(), 1);
     $contribution = $this->callAPISuccessGetSingle('Contribution', array());
+    $this->assertEquals(8000.67, $contribution['total_amount']);
     $lastFinancialTrxnId = CRM_Core_BAO_FinancialTrxn::getFinancialTrxnId($contribution['id'], 'DESC');
     $financialTrxn = $this->callAPISuccessGetSingle(
       'FinancialTrxn',

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -2594,7 +2594,8 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
   }
 
   public function restoreDefaultPriceSetConfig() {
-    CRM_Core_DAO::executeQuery('DELETE FROM civicrm_price_set WHERE id > 2');
+    CRM_Core_DAO::executeQuery("DELETE FROM civicrm_price_set WHERE name NOT IN('default_contribution_amount', 'default_membership_type_amount')");
+    CRM_Core_DAO::executeQuery("UPDATE civicrm_price_set SET id = 1 WHERE name ='default_contribution_amount'");
     CRM_Core_DAO::executeQuery("INSERT INTO `civicrm_price_field` (`id`, `price_set_id`, `name`, `label`, `html_type`, `is_enter_qty`, `help_pre`, `help_post`, `weight`, `is_display_amounts`, `options_per_line`, `is_active`, `is_required`, `active_on`, `expire_on`, `javascript`, `visibility_id`) VALUES (1, 1, 'contribution_amount', 'Contribution Amount', 'Text', 0, NULL, NULL, 1, 1, 1, 1, 1, NULL, NULL, NULL, 1)");
     CRM_Core_DAO::executeQuery("INSERT INTO `civicrm_price_field_value` (`id`, `price_field_id`, `name`, `label`, `description`, `amount`, `count`, `max_value`, `weight`, `membership_type_id`, `membership_num_terms`, `is_default`, `is_active`, `financial_type_id`, `non_deductible_amount`) VALUES (1, 1, 'contribution_amount', 'Contribution Amount', NULL, '1', NULL, NULL, 1, NULL, NULL, 0, 1, 1, 0.00)");
   }


### PR DESCRIPTION
Overview
----------------------------------------
Further fixes for handling of thousand separator. The batch form seems to be a real bug

Before
----------------------------------------
Thousand separator handled in BAO (not necessarily correctly)

After
----------------------------------------
Thousand separator handled close to form submission, more tests

Technical Details
----------------------------------------
This is one of the cases identified in #11539 

Comments
----------------------------------------
The batch one seems straight forward but event may need a little more testing. Backoffice & front end registration use this code path

---

 * [CRM-17647: Recording payment truncates the amount after the comma \(whether thousands or decimal separator\)](https://issues.civicrm.org/jira/browse/CRM-17647)