### PR TITLE
CRM-17647: fix unit tests and backoffice/live event form to use skipCleanMoney

### DIFF
--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -513,7 +513,7 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
 
         $params['actualBatchTotal'] += $value['total_amount'];
         $value['batch_id'] = $this->_batchId;
-        $value['skipRecentView'] = TRUE;
+        $value['skipRecentView'] = $value['skipCleanMoney'] = TRUE;
 
         // build line item params
         $this->_priceSet['fields'][$priceFieldID]['options'][$priceFieldValueID]['amount'] = $value['total_amount'];

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -132,6 +132,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
     else {
       // @todo put a deprecated here - this should be done in the form layer.
       $params['skipCleanMoney'] = FALSE;
+      Civi::log()->warning('Deprecated code path. Money should always be clean before it hits the BAO.', array('civi.tag' => 'deprecated'));
     }
 
     foreach ($moneyFields as $field) {

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -985,8 +985,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       $params['total_amount'] = CRM_Utils_Rule::cleanMoney($params['total_amount']);
     }
     if ($this->_isPaidEvent) {
-
-      $contributionParams = array();
+      $contributionParams = array('skipCleanMoney' => TRUE);
       $lineItem = array();
       $additionalParticipantDetails = array();
       if (CRM_Contribute_BAO_Contribution::checkContributeSettings('deferred_revenue_enabled')) {

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -977,6 +977,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
       'campaign_id' => CRM_Utils_Array::value('campaign_id', $params),
       'card_type_id' => CRM_Utils_Array::value('card_type_id', $params),
       'pan_truncation' => CRM_Utils_Array::value('pan_truncation', $params),
+      'skipCleanMoney' => TRUE,
     );
 
     if ($paymentProcessor) {

--- a/tests/phpunit/CRM/Batch/Form/EntryTest.php
+++ b/tests/phpunit/CRM/Batch/Form/EntryTest.php
@@ -344,7 +344,7 @@ class CRM_Batch_Form_EntryTest extends CiviUnitTestCase {
       'field' => array(
         1 => array(
           'financial_type' => 1,
-          'total_amount' => 15,
+          'total_amount' => $this->formatMoneyInput(15.918),
           'receive_date' => '2013-07-24',
           'receive_date_time' => NULL,
           'payment_instrument' => 1,
@@ -353,7 +353,7 @@ class CRM_Batch_Form_EntryTest extends CiviUnitTestCase {
         ),
         2 => array(
           'financial_type' => 1,
-          'total_amount' => 15,
+          'total_amount' => $this->formatMoneyInput(15.278),
           'receive_date' => '2013-07-24',
           'receive_date_time' => NULL,
           'payment_instrument' => 1,

--- a/tests/phpunit/CRM/Core/Payment/AuthorizeNetTest.php
+++ b/tests/phpunit/CRM/Core/Payment/AuthorizeNetTest.php
@@ -59,7 +59,7 @@ class CRM_Core_Payment_AuthorizeNetTest extends CiviUnitTestCase {
     $contactId = $this->individualCreate($nameParams);
 
     $invoiceID = sha1(rand());
-    $amount = rand(100, 1000) . '.00';
+    $amount = $this->formatMoneyInput(rand(100, 1000) . '.00');
 
     $contributionRecurParams = array(
       'contact_id' => $contactId,

--- a/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
+++ b/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
@@ -93,7 +93,7 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
       'contributeMode' => 'direct',
       'registerByID' => $individualID,
       'paymentProcessorObj' => CRM_Financial_BAO_PaymentProcessor::getPayment($paymentProcessorID),
-      'totalAmount' => 800,
+      'totalAmount' => $this->formatMoneyInput(800.12),
       'params' => array(
         array(
           'qfKey' => 'e6eb2903eae63d4c5c6cc70bfdda8741_2801',
@@ -133,7 +133,7 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
           'participant_role_id' => '1',
           'currencyID' => 'USD',
           'amount_level' => 'Tiny-tots (ages 5-8) - 1',
-          'amount' => '800.00',
+          'amount' => $this->formatMoneyInput(800.12),
           'tax_amount' => NULL,
           'year' => '2019',
           'month' => '1',

--- a/tests/phpunit/CRM/Financial/BAO/FinancialAccountTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/FinancialAccountTest.php
@@ -138,14 +138,13 @@ class CRM_Financial_BAO_FinancialAccountTest extends CiviUnitTestCase {
     $result = CRM_Financial_BAO_FinancialAccount::retrieve($params, $defaults);
 
     $contactId = $this->individualCreate();
-    $contributionParams = array(
-      'total_amount' => 300,
+    $this->callAPISuccess('Contribution', 'create', array(
+      'total_amount' => $this->formatMoneyInput(300.123),
       'currency' => 'USD',
       'contact_id' => $contactId,
       'financial_type_id' => $financialType->id,
       'contribution_status_id' => 1,
-    );
-    $contributions = CRM_Contribute_BAO_Contribution::create($contributionParams);
+    ));
     CRM_Financial_BAO_FinancialAccount::del($result->id);
     $params = array('id' => $result->id);
     $result = CRM_Financial_BAO_FinancialAccount::retrieve($params, $defaults);

--- a/tests/phpunit/CRM/Financial/BAO/FinancialTypeTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/FinancialTypeTest.php
@@ -283,7 +283,7 @@ class CRM_Financial_BAO_FinancialTypeTest extends CiviUnitTestCase {
       );
     }
     $contributionParams['line_item'] = $lineItems;
-    $contributions = CRM_Contribute_BAO_Contribution::create($contributionParams);
+    $contribution = $this->callAPISuccess('Contribution', 'create', $contributionParams);
     CRM_Financial_BAO_FinancialType::$_statusACLFt = array();
     $this->setACL();
 
@@ -292,7 +292,7 @@ class CRM_Financial_BAO_FinancialTypeTest extends CiviUnitTestCase {
     ));
 
     try {
-      CRM_Financial_BAO_FinancialType::checkPermissionedLineItems($contributions->id, 'view');
+      CRM_Financial_BAO_FinancialType::checkPermissionedLineItems($contribution['id'], 'view');
       $this->fail("Missed expected exception");
     }
     catch (Exception $e) {
@@ -302,7 +302,7 @@ class CRM_Financial_BAO_FinancialTypeTest extends CiviUnitTestCase {
     $this->setPermissions(array(
       'view contributions of type Donation',
     ));
-    $perm = CRM_Financial_BAO_FinancialType::checkPermissionedLineItems($contributions->id, 'view');
+    $perm = CRM_Financial_BAO_FinancialType::checkPermissionedLineItems($contribution['id'], 'view');
     $this->assertEquals($perm, TRUE, 'Verify that lineitems now have permission.');
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
This is a followup PR to fix all the test failures encountered in https://github.com/civicrm/civicrm-core/pull/11539 which highlights the fact that Event backoffice forms / online event page  need skipCleanMoney attribute set in contribution params before financial processing. Also, fix other unit-tests to avoid using BAO fn to create contribution instead of API.

---

 * [CRM-17647: Recording payment truncates the amount after the comma \(whether thousands or decimal separator\)](https://issues.civicrm.org/jira/browse/CRM-17647)