### PR TITLE
CRM-21745 Fix for customised addressee field

### DIFF
--- a/CRM/Contact/Form/Edit/CommunicationPreferences.php
+++ b/CRM/Contact/Form/Edit/CommunicationPreferences.php
@@ -131,11 +131,13 @@ class CRM_Contact_Form_Edit_CommunicationPreferences {
 
     $greetings = self::getGreetingFields($self->_contactType);
     foreach ($greetings as $greeting => $details) {
-      $customizedValue = CRM_Core_PseudoConstant::getKey('CRM_Contact_BAO_Contact', $details['field'], 'Customized');
-      if (CRM_Utils_Array::value($details['field'], $fields) == $customizedValue && empty($fields[$details['customField']])) {
-        $errors[$details['customField']] = ts('Custom  %1 is a required field if %1 is of type Customized.',
-          array(1 => $details['label'])
-        );
+      if ($details['field'] == 'Customized') {
+        $customizedValue = CRM_Core_PseudoConstant::getKey('CRM_Contact_BAO_Contact', $details['field'], 'Customized');
+        if (CRM_Utils_Array::value($details['field'], $fields) == $customizedValue && empty($fields[$details['customField']])) {
+          $errors[$details['customField']] = ts('Custom  %1 is a required field if %1 is of type Customized.',
+            array(1 => $details['label'])
+          );
+        }
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
With this fix user will be able to edit Addressee field in Communication Preferences once it is saved as Customized.

Before
----------------------------------------
Throws error while editing the "Addressee" field in "Communication Preferences" after it changed to "- select -" from "Customize".

After
----------------------------------------
Will not throw any error while selecting "- select -" under field "Addressee"

Technical Details
----------------------------------------
Alter the formRule which will be invoked only when user selects "Customize" under "Addressee" field.

---

 * [CRM-21745: Customised Addressee field issue in Communication Preferences](https://issues.civicrm.org/jira/browse/CRM-21745)