### PR TITLE
Upgrade Fails at ALTER TABLE `civicrm_price_field_value` when Amount is empty

### DIFF
--- a/CRM/Contribute/BAO/Contribution/Utils.php
+++ b/CRM/Contribute/BAO/Contribution/Utils.php
@@ -114,6 +114,9 @@ class CRM_Contribute_BAO_Contribution_Utils {
         $contributionParams['payment_instrument_id'] = $paymentParams['payment_instrument_id'] = $form->_paymentProcessor['payment_instrument_id'];
       }
 
+      // @todo this is the wrong place for this - it should be done as close to form submission
+      // as possible
+      $paymentParams['amount'] = CRM_Utils_Rule::cleanMoney($paymentParams['amount']);
       $contribution = CRM_Contribute_Form_Contribution_Confirm::processFormContribution(
         $form,
         $paymentParams,
@@ -468,15 +471,24 @@ LIMIT 1
    *   Amount of field.
    * @param float $taxRate
    *   Tax rate of selected financial account for field.
+   * @param bool $ugWeDoNotKnowIfItNeedsCleaning_Help
+   *   This should ALWAYS BE FALSE and then be removed. A 'clean' money string uses a standardised format
+   *   such as '1000.99' for one thousand $/Euro/CUR and ninety nine cents/units.
+   *   However, we are in the habit of not necessarily doing that so need to grandfather in
+   *   the new expectation.
    *
    * @return array
    *   array of tax amount
    *
    */
-  public static function calculateTaxAmount($amount, $taxRate) {
+  public static function calculateTaxAmount($amount, $taxRate, $ugWeDoNotKnowIfItNeedsCleaning_Help = FALSE) {
     $taxAmount = array();
+    if ($ugWeDoNotKnowIfItNeedsCleaning_Help) {
+      Civi::log()->warning('Deprecated function, make sure money is in usable format before calling this.', array('civi.tag' => 'deprecated'));
+      $amount = CRM_Utils_Rule::cleanMoney($amount);
+    }
     // There can not be any rounding at this stage - as this is prior to quantity multiplication
-    $taxAmount['tax_amount'] = ($taxRate / 100) * CRM_Utils_Rule::cleanMoney($amount);
+    $taxAmount['tax_amount'] = ($taxRate / 100) * $amount;
 
     return $taxAmount;
   }

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -158,7 +158,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    *
    * @param array $params
    * @param int $financialTypeID
-   * @param float $nonDeductibleAmount
    * @param bool $pending
    * @param array $paymentProcessorOutcome
    * @param string $receiptDate
@@ -167,13 +166,11 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    * @return array
    */
   public static function getContributionParams(
-    $params, $financialTypeID, $nonDeductibleAmount, $pending,
+    $params, $financialTypeID, $pending,
     $paymentProcessorOutcome, $receiptDate, $recurringContributionID) {
     $contributionParams = array(
       'financial_type_id' => $financialTypeID,
       'receive_date' => (CRM_Utils_Array::value('receive_date', $params)) ? CRM_Utils_Date::processDate($params['receive_date']) : date('YmdHis'),
-      'non_deductible_amount' => $nonDeductibleAmount,
-      'total_amount' => $params['amount'],
       'tax_amount' => CRM_Utils_Array::value('tax_amount', $params),
       'amount_level' => CRM_Utils_Array::value('amount_level', $params),
       'invoice_id' => $params['invoiceID'],
@@ -201,10 +198,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         'trxn_result_code' => CRM_Utils_Array::value('trxn_result_code', $paymentProcessorOutcome),
       );
     }
-
-    // CRM-4038: for non-en_US locales, CRM_Contribute_BAO_Contribution::add() expects localised amounts
-    $contributionParams['non_deductible_amount'] = trim(CRM_Utils_Money::format($contributionParams['non_deductible_amount'], ' '));
-    $contributionParams['total_amount'] = trim(CRM_Utils_Money::format($contributionParams['total_amount'], ' '));
 
     if ($recurringContributionID) {
       $contributionParams['contribution_recur_id'] = $recurringContributionID;
@@ -950,7 +943,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $params['is_recur'] = $isRecur;
     $params['payment_instrument_id'] = CRM_Utils_Array::value('payment_instrument_id', $contributionParams);
     $recurringContributionID = self::processRecurringContribution($form, $params, $contactID, $financialType);
-    $nonDeductibleAmount = self::getNonDeductibleAmount($params, $financialType, $online, $form);
 
     $now = date('YmdHis');
     $receiptDate = CRM_Utils_Array::value('receipt_date', $params);
@@ -960,10 +952,15 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
     if (isset($params['amount'])) {
       $contributionParams = array_merge(self::getContributionParams(
-        $params, $financialType->id, $nonDeductibleAmount, TRUE,
+        $params, $financialType->id, TRUE,
         $result, $receiptDate,
         $recurringContributionID), $contributionParams
       );
+      $contributionParams['non_deductible_amount'] = self::getNonDeductibleAmount($params, $financialType, $online, $form);
+      $contributionParams['skipCleanMoney'] = TRUE;
+      // @todo this is the wrong place for this - it should be done as close to form submission
+      // as possible
+      $contributionParams['total_amount'] = $params['amount'];
       $contribution = CRM_Contribute_BAO_Contribution::add($contributionParams);
 
       $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
@@ -1988,6 +1985,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     }
 
     $priceFields = $priceFields[$priceSetID]['fields'];
+    $lineItems = array();
     CRM_Price_BAO_PriceSet::processAmount($priceFields, $paramsProcessedForForm, $lineItems, 'civicrm_contribution');
     $form->_lineItem = array($priceSetID => $lineItems);
     $membershipPriceFieldIDs = array();

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -292,7 +292,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     // lineItem isn't set until Register postProcess
     $this->_lineItem = $this->get('lineItem');
     $this->_ccid = $this->get('ccid');
-    $this->_paymentProcessor = $this->get('paymentProcessor');
+
     $this->_params = $this->controller->exportValues('Main');
     $this->_params['ip_address'] = CRM_Utils_System::ipAddress();
     $this->_params['amount'] = $this->get('amount');

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -294,6 +294,9 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
     $this->_fields = $this->get('fields');
     $this->_bltID = $this->get('bltID');
     $this->_paymentProcessor = $this->get('paymentProcessor');
+    if (!$this->_paymentProcessor) {
+      $this->_paymentProcessor = array('object' => Civi\Payment\System::singleton()->getById(0));
+    }
     $this->_priceSetId = $this->get('priceSetId');
     $this->_priceSet = $this->get('priceSet');
 

--- a/CRM/Core/InnoDBIndexer.php
+++ b/CRM/Core/InnoDBIndexer.php
@@ -91,6 +91,10 @@ class CRM_Core_InnoDBIndexer {
    *   Specification of the setting (per *.settings.php).
    */
   public static function onToggleFts($oldValue, $newValue, $metadata) {
+    if (empty($oldValue) && empty($newValue)) {
+      return;
+    }
+
     $indexer = CRM_Core_InnoDBIndexer::singleton();
     $indexer->setActive($newValue);
     $indexer->fixSchemaDifferences();

--- a/CRM/Group/Form/Edit.php
+++ b/CRM/Group/Form/Edit.php
@@ -378,6 +378,11 @@ WHERE  title = %1
         $params['group_organization'] = $this->_groupOrganizationID;
       }
 
+      // CRM-21431 If all group_type are unchecked, the change will not be saved otherwise.
+      if (!isset($params['group_type'])) {
+        $params['group_type'] = array();
+      }
+
       $params['is_reserved'] = CRM_Utils_Array::value('is_reserved', $params, FALSE);
 
       $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params,

--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -341,6 +341,11 @@ WHERE li.contribution_id = %1";
    *   this is
    *                          lineItem array)
    * @param string $amount_override
+   *   Amount override must be in format 1000.00 - ie no thousand separator & if
+   *   a decimal point is used it should be a decimal
+   *
+   * @todo - this parameter is only used for partial payments. It's unclear why a partial
+   *  payment would change the line item price.
    */
   public static function format($fid, $params, $fields, &$values, $amount_override = NULL) {
     if (empty($params["price_{$fid}"])) {
@@ -363,10 +368,6 @@ WHERE li.contribution_id = %1";
 
     foreach ($params["price_{$fid}"] as $oid => $qty) {
       $price = $amount_override === NULL ? $options[$oid]['amount'] : $amount_override;
-
-      // lets clean the price in case it is not yet cleant
-      // CRM-10974
-      $price = CRM_Utils_Rule::cleanMoney($price);
 
       $participantsPerField = CRM_Utils_Array::value('count', $options[$oid], 0);
 

--- a/CRM/Price/Page/Field.php
+++ b/CRM/Price/Page/Field.php
@@ -149,7 +149,7 @@ class CRM_Price_Page_Field extends CRM_Core_Page {
           $getTaxDetails = TRUE;
         }
         if (isset($priceField[$priceFieldBAO->id]['tax_rate'])) {
-          $taxAmount = CRM_Contribute_BAO_Contribution_Utils::calculateTaxAmount($priceField[$priceFieldBAO->id]['price'], $priceField[$priceFieldBAO->id]['tax_rate']);
+          $taxAmount = CRM_Contribute_BAO_Contribution_Utils::calculateTaxAmount($priceField[$priceFieldBAO->id]['price'], $priceField[$priceFieldBAO->id]['tax_rate'], TRUE);
           $priceField[$priceFieldBAO->id]['tax_amount'] = $taxAmount['tax_amount'];
         }
       }

--- a/CRM/Price/Page/Option.php
+++ b/CRM/Price/Page/Option.php
@@ -158,7 +158,7 @@ class CRM_Price_Page_Option extends CRM_Core_Page {
         if ($invoicing && isset($customOption[$id]['tax_rate'])) {
           $getTaxDetails = TRUE;
         }
-        $taxAmount = CRM_Contribute_BAO_Contribution_Utils::calculateTaxAmount($customOption[$id]['amount'], $customOption[$id]['tax_rate']);
+        $taxAmount = CRM_Contribute_BAO_Contribution_Utils::calculateTaxAmount($customOption[$id]['amount'], $customOption[$id]['tax_rate'], TRUE);
         $customOption[$id]['tax_amount'] = $taxAmount['tax_amount'];
       }
       if (!empty($values['financial_type_id'])) {

--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -48,9 +48,9 @@ class CRM_Upgrade_Form extends CRM_Core_Form {
   const MINIMUM_UPGRADABLE_VERSION = '4.0.8';
 
   /**
-   * Minimum php version we support
+   * Minimum php version required to run (equal to or lower than the minimum install version)
    */
-  const MINIMUM_PHP_VERSION = '5.3.4';
+  const MINIMUM_PHP_VERSION = '5.4';
 
   protected $_config;
 

--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -67,10 +67,10 @@ class CRM_Upgrade_Incremental_General {
     $dateFormat = Civi::Settings()->get('dateformatshortdate');
     if (version_compare(phpversion(), self::MIN_RECOMMENDED_PHP_VER) < 0) {
       $preUpgradeMessage .= '<p>';
-      $preUpgradeMessage .= ts('You may proceed with the upgrade and CiviCRM %1 will continue working normally, but future releases will require PHP %2 or above. We recommend php version %3.', array(
+      $preUpgradeMessage .= ts('You may proceed with the upgrade and CiviCRM %1 will continue working normally, but future releases will require PHP %2 or above. We recommend PHP version %3.', array(
          1 => $latestVer,
          2 => self::MIN_RECOMMENDED_PHP_VER,
-         2 => self::RECOMMENDED_PHP_VER,
+         3 => self::RECOMMENDED_PHP_VER,
       ));
       $preUpgradeMessage .= '</p>';
     }

--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -41,25 +41,19 @@ class CRM_Upgrade_Incremental_General {
   /**
    * The recommended PHP version.
    */
-  const MIN_RECOMMENDED_PHP_VER = '5.6';
+  const RECOMMENDED_PHP_VER = '7.0';
 
   /**
    * The previous recommended PHP version.
    */
-  const PREVIOUS_MIN_RECOMMENDED_PHP_VER = '5.5';
+  const MIN_RECOMMENDED_PHP_VER = '5.6';
 
   /**
    * The minimum PHP version required to install Civi.
    *
    * @see install/index.php
    */
-  const MIN_INSTALL_PHP_VER = '5.3.4';
-
-  /**
-   * The minimum PHP version required to avoid known
-   * limits or defects.
-   */
-  const MIN_DEFECT_PHP_VER = '5.3.23';
+  const MIN_INSTALL_PHP_VER = '5.4';
 
   /**
    * Compute any messages which should be displayed before upgrade.
@@ -73,25 +67,11 @@ class CRM_Upgrade_Incremental_General {
     $dateFormat = Civi::Settings()->get('dateformatshortdate');
     if (version_compare(phpversion(), self::MIN_RECOMMENDED_PHP_VER) < 0) {
       $preUpgradeMessage .= '<p>';
-      // CRM-20941 PHP 5.3 end date of End of 2017, PHP 5.4 End date End of Feb 2018 Recommend anyone on PHP 5.5 to move up to 5.6 or later e.g. 7.0
-      if (version_compare(phpversion(), self::PREVIOUS_MIN_RECOMMENDED_PHP_VER) >= 0) {
-        $preUpgradeMessage .= ts('You may proceed with the upgrade and CiviCRM %1 will continue working normally, but future releases will require PHP %2 or above. We recommend you use the most recent php version you can.', array(
-           1 => $latestVer,
-           2 => self::MIN_RECOMMENDED_PHP_VER,
-        ));
-      }
-      elseif (version_compare(phpversion(), 5.5) < 0) {
-        $date = CRM_Utils_Date::customFormat('2018-02-28', $dateFormat);
-        if (version_compare(phpversion(), 5.4) < 0) {
-          $date = CRM_Utils_Date::customFormat('2017-12-31', $dateFormat);
-        }
-        $preUpgradeMessage .= ts('You may proceed with the upgrade and CiviCRM %1 will continue working normally, but PHP %2 will not work in releases published after %3. We recommend you use the most recent php version you can. For more explanation see <a href="%4">the announcement</a>.', array(
-          1 => $currentVer,
-          2 => phpversion(),
-          3 => $date,
-          4 => 'https://civicrm.org/blog/totten/end-of-zombies-php-53-and-54',
-        ));
-      }
+      $preUpgradeMessage .= ts('You may proceed with the upgrade and CiviCRM %1 will continue working normally, but future releases will require PHP %2 or above. We recommend php version %3.', array(
+         1 => $latestVer,
+         2 => self::MIN_RECOMMENDED_PHP_VER,
+         2 => self::RECOMMENDED_PHP_VER,
+      ));
       $preUpgradeMessage .= '</p>';
     }
 

--- a/CRM/Upgrade/Incremental/sql/4.7.29.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.7.29.mysql.tpl
@@ -1,0 +1,1 @@
+{* file to handle db changes in 4.7.29 during upgrade *}

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -37,54 +37,59 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
    */
   public function checkPhpVersion() {
     $messages = array();
+    $phpVersion = phpversion();
 
-    if (version_compare(phpversion(), CRM_Upgrade_Incremental_General::MIN_RECOMMENDED_PHP_VER) >= 0) {
+    if (version_compare($phpVersion, CRM_Upgrade_Incremental_General::RECOMMENDED_PHP_VER) >= 0) {
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
-        ts('This system uses PHP version %1 which meets or exceeds the minimum recommendation of %2.',
+        ts('This system uses PHP version %1 which meets or exceeds the recommendation of %2.',
           array(
-            1 => phpversion(),
-            2 => CRM_Upgrade_Incremental_General::MIN_RECOMMENDED_PHP_VER,
+            1 => $phpVersion,
+            2 => CRM_Upgrade_Incremental_General::RECOMMENDED_PHP_VER,
           )),
         ts('PHP Up-to-Date'),
         \Psr\Log\LogLevel::INFO,
         'fa-server'
       );
     }
-    elseif (version_compare(phpversion(), CRM_Upgrade_Incremental_General::PREVIOUS_MIN_RECOMMENDED_PHP_VER) >= 0) {
+    elseif (version_compare($phpVersion, CRM_Upgrade_Incremental_General::MIN_RECOMMENDED_PHP_VER) >= 0) {
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
-        ts('This system uses PHP version %1. While this meets the minimum requirements for CiviCRM to function, upgrading to PHP version %2 or newer is recommended for maximum compatibility.',
+        ts('This system uses PHP version %1. This meets the minimum recommendations and you do not need to upgrade immediately, but the preferred version is %2.',
           array(
-            1 => phpversion(),
-            2 => CRM_Upgrade_Incremental_General::MIN_RECOMMENDED_PHP_VER,
-            3 => CRM_Upgrade_Incremental_General::MIN_DEFECT_PHP_VER,
+            1 => $phpVersion,
+            2 => CRM_Upgrade_Incremental_General::RECOMMENDED_PHP_VER,
           )),
         ts('PHP Out-of-Date'),
         \Psr\Log\LogLevel::NOTICE,
         'fa-server'
       );
     }
-    else {
-      $date = '';
-      $dateFormat = Civi::Settings()->get('dateformatshortdate');
-      if (version_compare(phpversion(), 5.4) < 0) {
-        $date = CRM_Utils_Date::customFormat('2017-12-31', $dateFormat);
-      }
-      elseif (version_compare(phpversion(), 5.5) < 0) {
-        $date = CRM_Utils_Date::customFormat('2018-02-28', $dateFormat);
-      }
+    elseif (version_compare($phpVersion, CRM_Upgrade_Incremental_General::MIN_INSTALL_PHP_VER) >= 0) {
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
-        ts('This system uses PHP version %1. CiviCRM can be installed on this version. However PHP version %1 will not work in releases published after %2, and version %3 is recommended. For more explanation see <a href="%4"> the announcement</a>',
+        ts('This system uses PHP version %1. This meets the minimum requirements for CiviCRM to function but is not recommended. At least PHP version %2 is recommended; the preferrred version is %3.',
           array(
-            1 => phpversion(),
-            2 => $date,
-            3 => CRM_Upgrade_Incremental_General::MIN_RECOMMENDED_PHP_VER,
-            4 => 'https://civicrm.org/blog/totten/end-of-zombies-php-53-and-54',
+            1 => $phpVersion,
+            2 => CRM_Upgrade_Incremental_General::MIN_RECOMMENDED_PHP_VER,
+            3 => CRM_Upgrade_Incremental_General::RECOMMENDED_PHP_VER,
           )),
         ts('PHP Out-of-Date'),
         \Psr\Log\LogLevel::WARNING,
+        'fa-server'
+      );
+    }
+    else {
+      $messages[] = new CRM_Utils_Check_Message(
+        __FUNCTION__,
+        ts('This system uses PHP version %1. To ensure the continued operation of CiviCRM, upgrade your server now. At least PHP version %2 is recommended; the preferrred version is %3.',
+          array(
+            1 => $phpVersion,
+            2 => CRM_Upgrade_Incremental_General::MIN_RECOMMENDED_PHP_VER,
+            3 => CRM_Upgrade_Incremental_General::RECOMMENDED_PHP_VER,
+          )),
+        ts('PHP Out-of-Date'),
+        \Psr\Log\LogLevel::ERROR,
         'fa-server'
       );
     }

--- a/CRM/Utils/Rule.php
+++ b/CRM/Utils/Rule.php
@@ -502,9 +502,15 @@ class CRM_Utils_Rule {
   }
 
   /**
-   * @param $value
+   * Strip thousand separator from a money string.
    *
-   * @return mixed
+   * Note that this should be done at the form layer. Once we are processing
+   * money at the BAO or processor layer we should be working with something that
+   * is already in a normalised format.
+   *
+   * @param string $value
+   *
+   * @return string
    */
   public static function cleanMoney($value) {
     // first remove all white space

--- a/CRM/Utils/SQL.php
+++ b/CRM/Utils/SQL.php
@@ -80,7 +80,7 @@ class CRM_Utils_SQL {
     // CRM-21455 MariaDB 10.2 does not support ANY_VALUE
     $version = CRM_Core_DAO::singleValueQuery('SELECT VERSION()');
 
-    if (stripos('mariadb', $version) !== FALSE) {
+    if (stripos($version, 'mariadb') !== FALSE) {
       return FALSE;
     }
 

--- a/Civi/Core/SettingsBag.php
+++ b/Civi/Core/SettingsBag.php
@@ -352,9 +352,11 @@ class SettingsBag {
     }
     $dao->find(TRUE);
 
-    // string comparison with 0 always return true, so to be ensure the type use ===
-    // ref - https://stackoverflow.com/questions/8671942/php-string-comparasion-to-0-integer-returns-true
-    if (isset($metadata['on_change']) && !($value === 0 && ($dao->value === NULL || unserialize($dao->value) == 0))) {
+    // Call 'on_change' listeners. It would be nice to only fire when there's
+    // a genuine change in the data. However, PHP developers have mixed
+    // expectations about whether 0, '0', '', NULL, and FALSE represent the same
+    // value, so there's no universal way to determine if a change is genuine.
+    if (isset($metadata['on_change'])) {
       foreach ($metadata['on_change'] as $callback) {
         call_user_func(
           \Civi\Core\Resolver::singleton()->get($callback),

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -45,6 +45,9 @@ function civicrm_api3_contribution_create(&$params) {
   $values = array();
   _civicrm_api3_custom_format_params($params, $values, 'Contribution');
   $params = array_merge($params, $values);
+  // The BAO should not clean money - it should be done in the form layer & api wrapper
+  // (although arguably the api should expect pre-cleaned it seems to do some cleaning.)
+  $params['skipCleanMoney'] = TRUE;
 
   if (CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus()) {
     if (empty($params['id'])) {

--- a/install/index.php
+++ b/install/index.php
@@ -595,12 +595,9 @@ class InstallRequirements {
 
     $this->errors = NULL;
 
-    // See also: CRM_Upgrade_Incremental_General::MIN_INSTALL_PHP_VER
-    $this->requirePHPVersion('5.3.4', array(
+    $this->requirePHPVersion(array(
       ts("PHP Configuration"),
       ts("PHP5 installed"),
-      NULL,
-      ts("PHP version %1", array(1 => phpversion())),
     ));
 
     // Check that we can identify the root folder successfully
@@ -860,36 +857,30 @@ class InstallRequirements {
   }
 
   /**
-   * @param $minVersion
-   * @param $testDetails
-   * @param null $maxVersion
+   * @param array $testDetails
+   * @return bool
    */
-  public function requirePHPVersion($minVersion, $testDetails, $maxVersion = NULL) {
+  public function requirePHPVersion($testDetails) {
 
     $this->testing($testDetails);
 
     $phpVersion = phpversion();
-    $aboveMinVersion = version_compare($phpVersion, $minVersion) >= 0;
-    $belowMaxVersion = $maxVersion ? version_compare($phpVersion, $maxVersion) < 0 : TRUE;
+    $aboveMinVersion = version_compare($phpVersion, CRM_Upgrade_Incremental_General::MIN_INSTALL_PHP_VER) >= 0;
 
-    if ($aboveMinVersion && $belowMaxVersion) {
+    if ($aboveMinVersion) {
       if (version_compare(phpversion(), CRM_Upgrade_Incremental_General::MIN_RECOMMENDED_PHP_VER) < 0) {
-        $testDetails[2] = ts('This webserver is running an outdated version of PHP (%1). It is strongly recommended to upgrade to PHP %2 or later, as older versions can present a security risk.', array(
+        $testDetails[2] = ts('This webserver is running an outdated version of PHP (%1). It is strongly recommended to upgrade to PHP %2 or later, as older versions can present a security risk. The preferred version is %3.', array(
           1 => phpversion(),
           2 => CRM_Upgrade_Incremental_General::MIN_RECOMMENDED_PHP_VER,
+          3 => CRM_Upgrade_Incremental_General::RECOMMENDED_PHP_VER,
         ));
         $this->warning($testDetails);
       }
       return TRUE;
     }
 
-    if (!$testDetails[2]) {
-      if (!$aboveMinVersion) {
-        $testDetails[2] = ts("You need PHP version %1 or later, only %2 is installed. Please upgrade your server, or ask your web-host to do so.", array(1 => $minVersion, 2 => $phpVersion));
-      }
-      else {
-        $testDetails[2] = ts("PHP version %1 is not supported. PHP version earlier than %2 is required. You might want to downgrade your server, or ask your web-host to do so.", array(1 => $maxVersion, 2 => $phpVersion));
-      }
+    if (empty($testDetails[2])) {
+      $testDetails[2] = ts("You need PHP version %1 or later, only %2 is installed. Please upgrade your server, or ask your web-host to do so.", array(1 => CRM_Upgrade_Incremental_General::MIN_INSTALL_PHP_VER, 2 => $phpVersion));
     }
 
     $this->error($testDetails);

--- a/install/index.php
+++ b/install/index.php
@@ -868,9 +868,9 @@ class InstallRequirements {
     $aboveMinVersion = version_compare($phpVersion, CRM_Upgrade_Incremental_General::MIN_INSTALL_PHP_VER) >= 0;
 
     if ($aboveMinVersion) {
-      if (version_compare(phpversion(), CRM_Upgrade_Incremental_General::MIN_RECOMMENDED_PHP_VER) < 0) {
+      if (version_compare($phpVersion, CRM_Upgrade_Incremental_General::MIN_RECOMMENDED_PHP_VER) < 0) {
         $testDetails[2] = ts('This webserver is running an outdated version of PHP (%1). It is strongly recommended to upgrade to PHP %2 or later, as older versions can present a security risk. The preferred version is %3.', array(
-          1 => phpversion(),
+          1 => $phpVersion,
           2 => CRM_Upgrade_Incremental_General::MIN_RECOMMENDED_PHP_VER,
           3 => CRM_Upgrade_Incremental_General::RECOMMENDED_PHP_VER,
         ));

--- a/release-notes.md
+++ b/release-notes.md
@@ -14,6 +14,16 @@ Other resources for identifying changes are:
     * https://github.com/civicrm/civicrm-joomla
     * https://github.com/civicrm/civicrm-wordpress
 
+## CiviCRM 4.7.29
+
+Released December 20, 2017
+
+- **[Synopsis](release-notes/4.7.29.md#synopsis)**
+- **[Features](release-notes/4.7.29.md#features)**
+- **[Bugs resolved](release-notes/4.7.29.md#bugs)**
+- **[Credits](release-notes/4.7.29.md#credits)**
+- **[Feedback](release-notes/4.7.29.md#feedback)**
+
 ## CiviCRM 4.7.28
 
 Released December 6, 2017

--- a/release-notes/4.7.29.md
+++ b/release-notes/4.7.29.md
@@ -59,42 +59,18 @@ Released December 20, 2017
 
   Fixes an issue where the check to see if the MySQL server was a MariaDB instance wasn't working right. This lead to hard crashes as queries were being incorrectly re-written
 
-
 ## <a name="credits"></a>Credits
 
 This release was developed by the following code authors:
 
-AGH Strategies - Alice Frumin, Andrew Hunt; Agileware - Alok Patel, Justin
-Freeman; Australian Greens - Seamus Lee; Christian Wach; Circle Interactive -
-Dave Jenkins; CiviCoop - Klaas Eikelboom; CiviCRM - Coleman Watts, Tim Otten;
-CiviDesk - Nicolas Ganivet, Yashodha Chaku; CiviFirst - John Kirk; Community IT
-Academy - William Mortada; CompuCorp - Michael Devery, Mukesh Ram, Omar Abu
-Hussein; Coop SymbioTIC - Mathieu Lutfy; Daniël van Vuuren; Deepak Srivastava;
-Freeform Solutions - Herb van den Dool; Fuzion - Jitendra Purohit; JMA
-Consulting - Edsel Lopez, Monish Deb, Pradeep Nayak; John Kingsnorth; Joinery -
-Allen Shaw; Lemniscus - Noah Miller; Megaphone Technology Consulting - Jon
-Goldberg; MJW Consulting - Matthew Wire; Olivier Hertrich; Pawel Nowak; PowDevel -
-Beto Aveiga; Progressive Technology Project - Jamie McClelland; Tadpole
-Collective - Kevin Cristiano; Wikimedia Foundation - Eileen McNaughton, Maggie
-Epps
+Australian Greens - Seamus Lee; CiviCRM - Coleman Watts, Tim Otten;
+Coop SymbioTIC - Mathieu Lutfy; Wikimedia Foundation - Eileen McNaughton
 
 Most authors also reviewed code for this release; in addition, the following
 reviewers contributed their comments:
 
-Adam Zilkie; AGH Strategies - Josh Corlew; Agileware - Agileware Team; Andrew
-Thompson; Blackfly Solutions - Alan Dixon; British Humanist Association -
-William Gordon; CiviDesk - Sunil Pawar; CompuCorp - Anna Kovalova, Guanhuan
-Chen, Mirela Stanila; DevMate - Adam Kwiatkowski; Effy Elden; Electronic
-Frontier Foundation - Mark Burdett; Ginkgo Street Labs - Frank Gómez; JMA
-Consulting - Joe Murray; Joanne Chester; Johan Vervloet; Jonathan Richardson;
-Korlon - Stuart Gaston; Left Join Labs - Sean Madsen; Levity - Kevin Levie;
-Lighthouse Design and Consulting - Brian Shaughnessy; Lorenzo Ardizzone; MC3 -
-Graham Mitchell; Marcello Gribaudo; Mohamed Ziada; myDropWizard - David Snopek;
-Neil Zampella; Nicol Wistreich; Responsive Development Technologies - Thomas
-Nilefalk; Richard Edgar; Semper IT - Karin Gerritsen; SEN Magazine - Jeremy
-Nicholls; Skvare - Mark Hanna; small biz; Spry Digital - Ellen Hendricks;
-Squiffle Consulting - Aidan Saunders; Stevel; Systopia - Björn Endres; Tech To
-The People - Xavier Dutoit; Victor Huang; Web Access - Kurund Jalmi
+Ben Mango; JMA Consulting - Monish Deb; Megaphone Technology Consulting - Jon
+Goldberg; Richard van Oosterhout
 
 ## <a name="feedback"></a>Feedback
 

--- a/release-notes/4.7.29.md
+++ b/release-notes/4.7.29.md
@@ -25,7 +25,7 @@ Released December 20, 2017
 
 ### Core CiviCRM
 
-- **[CRM-20941](https://issues.civicrm.org/jira/browse/CRM-20941) Increase Minimum PHP required to install CiviCRM
+- **[CRM-20941](https://issues.civicrm.org/jira/browse/CRM-20941) Increase minimum PHP required to install CiviCRM
   ([11416](https://github.com/civicrm/civicrm-core/pull/11416))**
 
   Increases the minimum PHP version required to install CiviCRM 4.7.29 to be 5.4 as per the [announcement blog post](https://civicrm.org/blog/totten/end-of-zombies-php-53-and-54)
@@ -34,18 +34,18 @@ Released December 20, 2017
 
 ### Core CiviCRM
 
-- **[CRM-21445](https://issues.civicrm.org/jira/browse/CRM-20941) Ensure Pay Later Processor is set so a fatal isn't thrown
+- **[CRM-21445](https://issues.civicrm.org/jira/browse/CRM-20941) Ensure "Pay Later" processor is set so a fatal isn't thrown
   ([11427](https://github.com/civicrm/civicrm-core/pull/11427))**
 
-  Ensures that the pay later payment Processor is set to that a fatal error isn't thrown
+  Ensures that the pay later payment processor is set to that a fatal error isn't thrown
 
-- **[CRM-21431](https://issues.civicrm.org/jira/browse/CRM-21431) Fix Removing of group types
+- **[CRM-21431](https://issues.civicrm.org/jira/browse/CRM-21431) Fix removing of group types
   ([11436](https://github.com/civicrm/civicrm-core/pull/11436))**
 
   Fixes an issue where unchecking both the ACL and Mailing list box when editing a group didn't actually remove those types
 
 - **[CRM-21568](https://issues.civicrm.org/jira/browse/CRM-21568) Move the determination of values of empty from settingsbag to InnodbIndxer
-  ([11423[(https://github.com/civicrm/civicrm-core/pull/11423))**
+  ([11423](https://github.com/civicrm/civicrm-core/pull/11423))**
 
   Fixes an issue where string '0' wasn't being treated as false. So the checking of whether there is an empty value is now done in the on change listener for the full text search switcher
 

--- a/release-notes/4.7.29.md
+++ b/release-notes/4.7.29.md
@@ -1,0 +1,103 @@
+# CiviCRM 4.7.29
+
+Released December 20, 2017
+
+- **[Synopsis](#synopsis)**
+- **[Features](#features)**
+- **[Bugs resolved](#bugs)**
+- **[Miscellany](#misc)**
+- **[Credits](#credits)**
+- **[Feedback](#feedback)**
+
+## <a name="synopsis"></a>Synopsis
+
+| *Does this version...?*                                     |         |
+|:----------------------------------------------------------- |:-------:|
+| Fix security vulnerabilities?                               |   no    |
+| Change the database schema?                                 |   no    |
+| Alter the API?                                              |   no    |
+| Require attention to configuration options?                 |   no    |
+| Fix problems installing or upgrading to a previous version? |   no    |
+| **Introduce features?**                                     | **yes** |
+| **Fix bugs?**                                               | **yes** |
+
+## <a name="features"></a>Features
+
+### Core CiviCRM
+
+- **[CRM-20941](https://issues.civicrm.org/jira/browse/CRM-20941) Increase Minimum PHP required to install CiviCRM
+  ([11416](https://github.com/civicrm/civicrm-core/pull/11416))**
+
+  Increases the minimum PHP version required to install CiviCRM 4.7.29 to be 5.4 as per the [announcement blog post](https://civicrm.org/blog/totten/end-of-zombies-php-53-and-54)
+
+## <a name="bugs"></a>Bugs resolved
+
+### Core CiviCRM
+
+- **[CRM-21445](https://issues.civicrm.org/jira/browse/CRM-20941) Ensure Pay Later Processor is set so a fatal isn't thrown
+  ([11427](https://github.com/civicrm/civicrm-core/pull/11427))**
+
+  Ensures that the pay later payment Processor is set to that a fatal error isn't thrown
+
+- **[CRM-21431](https://issues.civicrm.org/jira/browse/CRM-21431) Fix Removing of group types
+  ([11436](https://github.com/civicrm/civicrm-core/pull/11436))**
+
+  Fixes an issue where unchecking both the ACL and Mailing list box when editing a group didn't actually remove those types
+
+- **[CRM-21568](https://issues.civicrm.org/jira/browse/CRM-21568) Move the determination of values of empty from settingsbag to InnodbIndxer
+  ([11423[(https://github.com/civicrm/civicrm-core/pull/11423))**
+
+  Fixes an issue where string '0' wasn't being treated as false. So the checking of whether there is an empty value is now done in the on change listener for the full text search switcher
+
+- **[CRM-21562](https://issues.civicrm.org/jira/browse/CRM-21562) Fix line item mis-saving when using a ',' as the thousand separator
+  ([11412](https://github.com/civicrm/civicrm-core/pull/11412))**
+
+  Fixes an issue for currencies which use a ',' as the thousand separator the line item was being incorrectly saved by a significant margin.
+
+- **[CRM-21534](https://issues.civicrm.org/jira/browse/CRM-21534) Fix issue where checking if server was a MariaDB server wasn't working correctly
+  ([11413](https://github.com/civicrm/civicrm-core/pull/11413))**
+
+  Fixes an issue where the check to see if the MySQL server was a MariaDB instance wasn't working right. This lead to hard crashes as queries were being incorrectly re-written
+
+
+## <a name="credits"></a>Credits
+
+This release was developed by the following code authors:
+
+AGH Strategies - Alice Frumin, Andrew Hunt; Agileware - Alok Patel, Justin
+Freeman; Australian Greens - Seamus Lee; Christian Wach; Circle Interactive -
+Dave Jenkins; CiviCoop - Klaas Eikelboom; CiviCRM - Coleman Watts, Tim Otten;
+CiviDesk - Nicolas Ganivet, Yashodha Chaku; CiviFirst - John Kirk; Community IT
+Academy - William Mortada; CompuCorp - Michael Devery, Mukesh Ram, Omar Abu
+Hussein; Coop SymbioTIC - Mathieu Lutfy; Daniël van Vuuren; Deepak Srivastava;
+Freeform Solutions - Herb van den Dool; Fuzion - Jitendra Purohit; JMA
+Consulting - Edsel Lopez, Monish Deb, Pradeep Nayak; John Kingsnorth; Joinery -
+Allen Shaw; Lemniscus - Noah Miller; Megaphone Technology Consulting - Jon
+Goldberg; MJW Consulting - Matthew Wire; Olivier Hertrich; Pawel Nowak; PowDevel -
+Beto Aveiga; Progressive Technology Project - Jamie McClelland; Tadpole
+Collective - Kevin Cristiano; Wikimedia Foundation - Eileen McNaughton, Maggie
+Epps
+
+Most authors also reviewed code for this release; in addition, the following
+reviewers contributed their comments:
+
+Adam Zilkie; AGH Strategies - Josh Corlew; Agileware - Agileware Team; Andrew
+Thompson; Blackfly Solutions - Alan Dixon; British Humanist Association -
+William Gordon; CiviDesk - Sunil Pawar; CompuCorp - Anna Kovalova, Guanhuan
+Chen, Mirela Stanila; DevMate - Adam Kwiatkowski; Effy Elden; Electronic
+Frontier Foundation - Mark Burdett; Ginkgo Street Labs - Frank Gómez; JMA
+Consulting - Joe Murray; Joanne Chester; Johan Vervloet; Jonathan Richardson;
+Korlon - Stuart Gaston; Left Join Labs - Sean Madsen; Levity - Kevin Levie;
+Lighthouse Design and Consulting - Brian Shaughnessy; Lorenzo Ardizzone; MC3 -
+Graham Mitchell; Marcello Gribaudo; Mohamed Ziada; myDropWizard - David Snopek;
+Neil Zampella; Nicol Wistreich; Responsive Development Technologies - Thomas
+Nilefalk; Richard Edgar; Semper IT - Karin Gerritsen; SEN Magazine - Jeremy
+Nicholls; Skvare - Mark Hanna; small biz; Spry Digital - Ellen Hendricks;
+Squiffle Consulting - Aidan Saunders; Stevel; Systopia - Björn Endres; Tech To
+The People - Xavier Dutoit; Victor Huang; Web Access - Kurund Jalmi
+
+## <a name="feedback"></a>Feedback
+
+These release notes are edited by Andrew Hunt.  If you'd like to provide
+feedback on them, please login to https://chat.civicrm.org/civicrm and contact
+`@agh1`.

--- a/sql/civicrm_generated.mysql
+++ b/sql/civicrm_generated.mysql
@@ -399,7 +399,7 @@ UNLOCK TABLES;
 
 LOCK TABLES `civicrm_domain` WRITE;
 /*!40000 ALTER TABLE `civicrm_domain` DISABLE KEYS */;
-INSERT INTO `civicrm_domain` (`id`, `name`, `description`, `config_backend`, `version`, `contact_id`, `locales`, `locale_custom_strings`) VALUES (1,'Default Domain Name',NULL,NULL,'4.7.28',1,NULL,'a:1:{s:5:\"en_US\";a:0:{}}');
+INSERT INTO `civicrm_domain` (`id`, `name`, `description`, `config_backend`, `version`, `contact_id`, `locales`, `locale_custom_strings`) VALUES (1,'Default Domain Name',NULL,NULL,'4.7.29',1,NULL,'a:1:{s:5:\"en_US\";a:0:{}}');
 /*!40000 ALTER TABLE `civicrm_domain` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -1084,8 +1084,14 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
 
   /**
    * Test for function createProportionalEntry().
+   *
+   * @param string $thousandSeparator
+   *   punctuation used to refer to thousands.
+   *
+   * @dataProvider getThousandSeparators
    */
-  public function testcreateProportionalEntry() {
+  public function testCreateProportionalEntry($thousandSeparator) {
+    $this->setCurrencySeparators($thousandSeparator);
     list($contribution, $financialAccount) = $this->createContributionWithTax();
     $params = array(
       'total_amount' => 55,

--- a/tests/phpunit/CRM/Financial/BAO/FinancialItemTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/FinancialItemTest.php
@@ -311,8 +311,14 @@ class CRM_Financial_BAO_FinancialItemTest extends CiviUnitTestCase {
 
   /**
    * Check method getPreviousFinancialItem() with tax entry.
+   *
+   * @param string $thousandSeparator
+   *   punctuation used to refer to thousands.
+   *
+   * @dataProvider getThousandSeparators
    */
-  public function testGetPreviousFinancialItemHavingTax() {
+  public function testGetPreviousFinancialItemHavingTax($thousandSeparator) {
+    $this->setCurrencySeparators($thousandSeparator);
     $contactId = $this->individualCreate();
     $this->enableTaxAndInvoicing();
     $this->relationForFinancialTypeWithFinancialAccount(1);

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -610,8 +610,14 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
 
   /**
    * Test the submit function of the membership form for partial payment.
+   *
+   * @param string $thousandSeparator
+   *   punctuation used to refer to thousands.
+   *
+   * @dataProvider getThousandSeparators
    */
-  public function testSubmitPartialPayment() {
+  public function testSubmitPartialPayment($thousandSeparator) {
+    $this->setCurrencySeparators($thousandSeparator);
     // Step 1: submit a partial payment for a membership via backoffice
     $form = $this->getForm();
     $form->preProcess();
@@ -629,7 +635,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
       // This format reflects the 23 being the organisation & the 25 being the type.
       'membership_type_id' => array(23, $this->membershipTypeAnnualFixedID),
       'record_contribution' => 1,
-      'total_amount' => $partiallyPaidAmount,
+      'total_amount' => $this->formatMoneyInput($partiallyPaidAmount),
       'receive_date' => date('m/d/Y', time()),
       'receive_date_time' => '08:36PM',
       'payment_instrument_id' => array_search('Check', $this->paymentInstruments),
@@ -655,7 +661,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
     $submitParams = array(
       'contribution_id' => $contribution['contribution_id'],
       'contact_id' => $this->_individualId,
-      'total_amount' => $partiallyPaidAmount,
+      'total_amount' => $this->formatMoneyInput($partiallyPaidAmount),
       'currency' => 'USD',
       'financial_type_id' => 2,
       'receive_date' => '04/21/2015',
@@ -676,7 +682,6 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
       'contact_id' => $this->_individualId,
     ));
     $this->assertEquals('Completed', $contribution['contribution_status']);
-    // $this->assertEquals(50.00, $contribution['total_amount']);
     // $this->assertEquals(50.00, $contribution['net_amount']);
   }
 

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -2577,6 +2577,8 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
     $var = TRUE;
     CRM_Member_BAO_Membership::createRelatedMemberships($var, $var, TRUE);
     $this->disableTaxAndInvoicing();
+    $this->setCurrencySeparators(',');
+    CRM_Core_PseudoConstant::flush('taxRates');
     System::singleton()->flushProcessors();
   }
 
@@ -3927,6 +3929,37 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
     $_SERVER['REQUEST_METHOD'] = 'GET';
     $form->controller = new CRM_Core_Controller();
     return $form;
+  }
+
+  /**
+   * Get possible thousand separators.
+   *
+   * @return array
+   */
+  public function getThousandSeparators() {
+    return array(array('.'), array(','));
+  }
+
+  /**
+   * Set the separators for thousands and decimal points.
+   *
+   * @param string $thousandSeparator
+   */
+  protected function setCurrencySeparators($thousandSeparator) {
+    Civi::settings()->set('monetaryThousandSeparator', $thousandSeparator);
+    Civi::settings()
+      ->set('monetaryDecimalPoint', ($thousandSeparator === ',' ? '.' : ','));
+  }
+
+  /**
+   * Format money as it would be input.
+   *
+   * @param string $amount
+   *
+   * @return string
+   */
+  protected function formatMoneyInput($amount) {
+    return CRM_Utils_Money::format($amount, NULL, '%a');
   }
 
 }

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -122,6 +122,18 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
   public function tearDown() {
     $this->quickCleanUpFinancialEntities();
     $this->quickCleanup(array('civicrm_uf_match'));
+    $financialAccounts = $this->callAPISuccess('FinancialAccount', 'get', array());
+    foreach ($financialAccounts['values'] as $financialAccount) {
+      if ($financialAccount['name'] == 'Test Tax financial account ' || $financialAccount['name'] == 'Test taxable financial Type') {
+        $entityFinancialTypes = $this->callAPISuccess('EntityFinancialAccount', 'get', array(
+          'financial_account_id' => $financialAccount['id'],
+        ));
+        foreach ($entityFinancialTypes['values'] as $entityFinancialType) {
+          $this->callAPISuccess('EntityFinancialAccount', 'delete', array('id' => $entityFinancialType['id']));
+        }
+        $this->callAPISuccess('FinancialAccount', 'delete', array('id' => $financialAccount['id']));
+      }
+    }
   }
 
   /**
@@ -1929,9 +1941,15 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
   }
 
   /**
-   * CRM-19126 Add test to verify when complete transaction is called tax amount is not changed
+   * CRM-19126 Add test to verify when complete transaction is called tax amount is not changed.
+   *
+   * @param string $thousandSeparator
+   *   punctuation used to refer to thousands.
+   *
+   * @dataProvider getThousandSeparators
    */
-  public function testCheckTaxAmount() {
+  public function testCheckTaxAmount($thousandSeparator) {
+    $this->setCurrencySeparators($thousandSeparator);
     $contact = $this->createLoggedInUser();
     $financialType = $this->callAPISuccess('financial_type', 'create', array(
       'name' => 'Test taxable financial Type',

--- a/xml/version.xml
+++ b/xml/version.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="iso-8859-1" ?>
 <version>
-  <version_no>4.7.28</version_no>
+  <version_no>4.7.29</version_no>
 </version>


### PR DESCRIPTION
Overview
----------------------------------------
_A brief description of the pull request. Try to keep it non-technical._
The upgrade scriptfor "4.7.28" runs the following:
ALTER TABLE `civicrm_price_field_value` CHANGE `amount` `amount` DECIMAL(18,9) NOT NULL COMMENT 'Price field option amount'
If any of the amounts are empty strings then the query will fail with

 [nativecode=1366 ** Incorrect DECIMAL value: '0' for column '' at row -1]
We had several rows with empty values for the amount. Setting them to 0 allowed the query to complete. 

I ended up running a query to update all rows where the amount = '' to amount = 0.
Before
----------------------------------------
_The current status. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._

After
----------------------------------------
_What has been changed. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._

Technical Details
----------------------------------------
_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
