### PR TITLE
CRM-21749 fix obscure intra-rc regression :Mailing api no longer respecting '_skip_evil_bao_auto_schedule_'

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1630,7 +1630,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
 
     // Create parent job if not yet created.
     // Condition on the existence of a scheduled date.
-    if (!empty($params['scheduled_date']) && $params['scheduled_date'] != 'null') {
+    if (!empty($params['scheduled_date']) && $params['scheduled_date'] != 'null' && empty($params['_skip_evil_bao_auto_schedule_'])) {
       $job = new CRM_Mailing_BAO_MailingJob();
       $job->mailing_id = $mailing->id;
       // If we are creating a new Completed mailing (e.g. import from another system) set the job to completed.

--- a/tests/phpunit/api/v3/MailingTest.php
+++ b/tests/phpunit/api/v3/MailingTest.php
@@ -86,6 +86,18 @@ class api_v3_MailingTest extends CiviUnitTestCase {
   }
 
   /**
+   * Tes that the parameter _skip_evil_bao_auto_schedule_ is respected & prevents jobs being created.
+   */
+  public function testSkipAutoSchedule() {
+    $this->callAPISuccess('Mailing', 'create', array_merge($this->_params, [
+      '_skip_evil_bao_auto_schedule_' => TRUE,
+      'scheduled_date' => 'now'
+    ]));
+    $this->callAPISuccessGetCount('Mailing', [], 1);
+    $this->callAPISuccessGetCount('MailingJob', [], 0);
+  }
+
+  /**
    * Create a completed mailing (e.g when importing from a provider).
    */
   public function testMailerCreateCompleted() {


### PR DESCRIPTION
Overview
----------------------------------------
Reinstate support for obscure api param skip_evil_bao_auto_schedule_'

Before
----------------------------------------
_skip_evil_bao_auto_schedule_ ignored

After
----------------------------------------
_skip_evil_bao_auto_schedule_ results in mailing jobs not being created.

Technical Details
----------------------------------------
Test contract added since this param is being used via the api in at least one extension :-)

Comments
----------------------------------------
Mailing api supported 'skip_evil_bao_auto_schedule' as a way to ensure mailing jobs were not created but it was 'cleaned up' in CRM-21260.

Since it was not unit tested one could argue that's fine but we do need a way to control the way the api works & I think reinstating the way that previously worked & adding a unit test makes sense

---

 * [CRM-21749: \[obscure regression\] Mailing api no longer respecting '_skip_evil_bao_auto_schedule_'](https://issues.civicrm.org/jira/browse/CRM-21749)
 * [CRM-21260: CiviMail compose UI very slow to initialize when many mailing groups, past mailings and templates](https://issues.civicrm.org/jira/browse/CRM-21260)