### PR TITLE
CRM-21751: Move SMS provider ID to 'Select Recipients' page from 'SMS content'

### DIFF
--- a/CRM/SMS/BAO/Provider.php
+++ b/CRM/SMS/BAO/Provider.php
@@ -83,7 +83,7 @@ class CRM_SMS_BAO_Provider extends CRM_SMS_DAO_Provider {
     $dao->find();
     while ($dao->fetch()) {
       CRM_Core_DAO::storeValues($dao, $temp);
-      $providers[] = $temp;
+      $providers[$dao->id] = $temp;
     }
     return $providers;
   }

--- a/CRM/SMS/Form/Group.php
+++ b/CRM/SMS/Form/Group.php
@@ -46,6 +46,10 @@ class CRM_SMS_Form_Group extends CRM_Contact_Form_Task {
 
     $session = CRM_Core_Session::singleton();
     $session->replaceUserContext(CRM_Utils_System::url('civicrm/mailing/browse', 'reset=1&sms=1'));
+
+    if (CRM_Core_Permission::check('administer CiviCRM')) {
+      $this->assign('isAdmin', 1);
+    }
   }
 
   /**
@@ -104,6 +108,12 @@ class CRM_SMS_Form_Group extends CRM_Contact_Form_Task {
 
     $this->add('text', 'name', ts('Name Your SMS'),
       CRM_Core_DAO::getAttribute('CRM_Mailing_DAO_Mailing', 'name'),
+      TRUE
+    );
+
+    $this->add('select', 'sms_provider_id',
+      ts('Select SMS Provider'),
+      CRM_Utils_Array::collect('title', CRM_SMS_BAO_Provider::getProviders()),
       TRUE
     );
 
@@ -183,9 +193,14 @@ class CRM_SMS_Form_Group extends CRM_Contact_Form_Task {
       'name',
       'group_id',
       'is_sms',
+      'sms_provider_id',
     ) as $n) {
       if (!empty($values[$n])) {
         $params[$n] = $values[$n];
+        if ($n == 'sms_provider_id') {
+          // Get the from Name.
+          $params['from_name'] = CRM_Core_DAO::getFieldValue('CRM_SMS_DAO_Provider', $params['sms_provider_id'], 'username');
+        }
       }
     }
 

--- a/CRM/SMS/Form/Upload.php
+++ b/CRM/SMS/Form/Upload.php
@@ -39,9 +39,6 @@ class CRM_SMS_Form_Upload extends CRM_Core_Form {
 
   public function preProcess() {
     $this->_mailingID = $this->get('mailing_id');
-    if (CRM_Core_Permission::check('administer CiviCRM')) {
-      $this->assign('isAdmin', 1);
-    }
   }
 
   /**
@@ -126,25 +123,6 @@ class CRM_SMS_Form_Upload extends CRM_Core_Form {
     // this seems so hacky, not sure what we are doing here and why. Need to investigate and fix
     $session->getVars($options,
       "CRM_SMS_Controller_Send_{$this->controller->_key}"
-    );
-
-    $providers = CRM_SMS_BAO_Provider::getProviders(array('id', 'title'));
-
-    if (empty($providers)) {
-      //redirect user to configure sms provider.
-      $url = CRM_Utils_System::url('civicrm/admin/sms/provider', 'action=add&reset=1');
-      $status = ts("There is no SMS Provider Configured. You can add here <a href='%1'>Add SMS Provider</a>", array(1 => $url));
-      $session->setStatus($status);
-    }
-    else {
-      $providerSelect[''] = '- select -';
-      foreach ($providers as $provider) {
-        $providerSelect[$provider['id']] = $provider['title'];
-      }
-    }
-
-    $this->add('select', 'sms_provider_id',
-      ts('SMS Provider'), $providerSelect, TRUE
     );
 
     $attributes = array('onclick' => "showHideUpload();");
@@ -271,12 +249,6 @@ class CRM_SMS_Form_Upload extends CRM_Core_Form {
     }
 
     $ids['mailing_id'] = $this->_mailingID;
-
-    // Get the from email address.
-    $params['sms_provider_id'] = $formValues['sms_provider_id'];
-
-    // Get the from Name.
-    $params['from_name'] = CRM_Core_DAO::getFieldValue('CRM_SMS_DAO_Provider', $params['sms_provider_id'], 'username');
 
     // Build SMS in mailing table.
     CRM_Mailing_BAO_Mailing::create($params, $ids);

--- a/templates/CRM/SMS/Form/Group.hlp
+++ b/templates/CRM/SMS/Form/Group.hlp
@@ -62,3 +62,16 @@
 {htxt id="exclude-mailings"}
 <p>{ts}If you have sent other Mass SMS - you can additionally Include (or Exclude) contacts who received those Mass SMS. CiviCRM will eliminate any duplications so that contacts who are in an Included Group AND were recipients of an Included Mailing will only be sent one copy of this SMS.{/ts}</p>
 {/htxt}
+
+{htxt id ="id-sms_provider-title"}
+  {ts}SMS Provider{/ts}
+{/htxt}
+{htxt id ="id-sms_provider"}
+<p>{ts}Select the SMS provider for this mass message from the dropdown list.{/ts}</p>
+{if $params.isAdmin}
+    {capture assign="fromConfig"}{crmURL p="civicrm/admin/sms/provider" q="reset=1"}{/capture}
+    <p>{ts 1=$fromConfig}Go to <a href='%1'>Administer CiviCRM &raquo; System Settings &raquo; SMS Providers</a> to add or edit SMS Provider.{/ts}</p>
+{else}
+    {ts}Contact your site administrator if you need to use a SMS Provider which is not in the dropdown list.{/ts}
+{/if}
+{/htxt}

--- a/templates/CRM/SMS/Form/Group.tpl
+++ b/templates/CRM/SMS/Form/Group.tpl
@@ -34,6 +34,7 @@
 
   <table class="form-layout">
    <tr class="crm-mailing-group-form-block-name"><td class="label">{$form.name.label}</td><td>{$form.name.html} {help id="sms-name"}</td></tr>
+   <tr class="crm-mailing-upload-form-block-sms_provider_id"><td class="label">{$form.sms_provider_id.label}</td><td>{$form.sms_provider_id.html}  {help id ="id-sms_provider" isAdmin=$isAdmin}</td></tr>
   </table>
 
 

--- a/templates/CRM/SMS/Form/Upload.hlp
+++ b/templates/CRM/SMS/Form/Upload.hlp
@@ -23,19 +23,6 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-{htxt id ="id-sms_provider-title"}
-  {ts}SMS Provider{/ts}
-{/htxt}
-{htxt id ="id-sms_provider"}
-<p>{ts}Select the SMS provider for this mass message from the dropdown list.{/ts}</p>
-{if $params.isAdmin}
-    {capture assign="fromConfig"}{crmURL p="civicrm/admin/sms/provider" q="reset=1"}{/capture}
-    <p>{ts 1=$fromConfig}Go to <a href='%1'>Administer CiviCRM &raquo; System Settings &raquo; SMS Providers</a> to add or edit SMS Provider.{/ts}</p>
-{else}
-    {ts}Contact your site administrator if you need to use a SMS Provider which is not in the dropdown list.{/ts}
-{/if}
-{/htxt}
-
 {htxt id="content-intro-title"}
   {ts}Message Formats{/ts}
 {/htxt}

--- a/templates/CRM/SMS/Form/Upload.tpl
+++ b/templates/CRM/SMS/Form/Upload.tpl
@@ -33,10 +33,6 @@
 {include file="CRM/Mailing/Form/Count.tpl"}
 
 <table class="form-layout-compressed">
-    <tr class="crm-mailing-upload-form-block-sms_provider_id"><td class="label">{$form.sms_provider_id.label}</td>
-        <td>{$form.sms_provider_id.html} {help id ="id-sms_provider" isAdmin=$isAdmin}</td>
-    </tr>
-
     <tr class="crm-mailing-upload-form-block-template">
       <td class="label">{$form.SMStemplate.label}</td>
   <td>{$form.SMStemplate.html}</td>


### PR DESCRIPTION
Overview
----------------------------------------
The need of this improvement is because of refactoring changes made in CRM_Mailing_BAO_Mailing::getRecipients() (under ticket CRM-21316) as per which we now rely on sms_provider_id to decide whether to fetch recipients for SMS or mailing. But this has caused regression to SMS compose UI where we used to fetch recipients before sms_provider_id is added to mailing record. The reason why getRecipients() operates as per mailing mode, which is wrong.

This ticket is about moving the sms_provider_id field 'Select Recipients' screen from 'SMS content'. This will allow us to set sms_provider_id before the getRecipients() got executed.

Before
----------------------------------------
'Select Recipient' screen:
![screen shot 2018-02-08 at 12 24 39 pm](https://user-images.githubusercontent.com/3735621/35959356-46547f9c-0ccb-11e8-8c96-690451d2e4ac.png)

'SMS content' screen:
![screen shot 2018-02-08 at 12 25 44 pm](https://user-images.githubusercontent.com/3735621/35959364-4d7fc736-0ccb-11e8-84e9-07eeafe32164.png)

After
----------------------------------------
'Select Recipient' screen:
![screen shot 2018-02-08 at 12 22 06 pm](https://user-images.githubusercontent.com/3735621/35959232-be5af468-0cca-11e8-8173-95ec36001064.png)

'SMS content' screen:
![screen shot 2018-02-08 at 12 23 25 pm](https://user-images.githubusercontent.com/3735621/35959286-f1d9b716-0cca-11e8-9eab-27b0684f9d36.png)


Technical Details
----------------------------------------
There was an alternative solution https://github.com/civicrm/civicrm-core/pull/11628 by setting the default sms_provider_id at the backend to resolve the regression, but I think it won't be right to set the provider id without the consent of end-user.

---

 * [CRM-21751: Move SMS provider ID to 'Select Recipients' page from 'SMS content'](https://issues.civicrm.org/jira/browse/CRM-21751)
 * [CRM-21316: Refactor getRecipients fn by creating a new fn getMailRecipients, that will be used ONLY to fetch and store mail recipients](https://issues.civicrm.org/jira/browse/CRM-21316)