### PR TITLE
CRM-21753 add pass-through support for criteria in urls on dedupe pages

### DIFF
--- a/CRM/Contact/Form/Merge.php
+++ b/CRM/Contact/Form/Merge.php
@@ -45,6 +45,11 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
   var $_contactType = NULL;
 
   /**
+   * @var array
+   */
+  public $criteria = array();
+
+  /**
    * Query limit to be retained in the urls.
    *
    * @var int
@@ -74,8 +79,9 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
       $this->_gid = $gid = CRM_Utils_Request::retrieve('gid', 'Positive', $this, FALSE);
       $this->_mergeId = CRM_Utils_Request::retrieve('mergeId', 'Positive', $this, FALSE);
       $this->limit = CRM_Utils_Request::retrieve('limit', 'Positive', $this, FALSE);
+      $this->criteria = CRM_Utils_Request::retrieve('criteria', 'Json', $this, FALSE, '{}');
 
-      $urlParams = ['reset' => 1, 'rgid' => $this->_rgid, 'gid' => $this->_gid, 'limit' => $this->limit];
+      $urlParams = ['reset' => 1, 'rgid' => $this->_rgid, 'gid' => $this->_gid, 'limit' => $this->limit, 'criteria' => $this->criteria];
 
       $this->bounceIfInvalid($this->_cid, $this->_oid);
 
@@ -100,7 +106,7 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
         CRM_Core_Session::singleton()->pushUserContext($browseUrl);
       }
 
-      $cacheKey = CRM_Dedupe_Merger::getMergeCacheKeyString($this->_rgid, $gid);
+      $cacheKey = CRM_Dedupe_Merger::getMergeCacheKeyString($this->_rgid, $gid, json_decode($this->criteria, TRUE));
 
       $join = CRM_Dedupe_Merger::getJoinOnDedupeTable();
       $where = "de.id IS NULL";
@@ -300,7 +306,7 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
     $message = '<ul><li>' . ts('%1 has been updated.', array(1 => $name)) . '</li><li>' . ts('Contact ID %1 has been deleted.', array(1 => $this->_oid)) . '</li></ul>';
     CRM_Core_Session::setStatus($message, ts('Contacts Merged'), 'success');
 
-    $urlParams = ['reset' => 1, 'cid' => $this->_cid, 'rgid' => $this->_rgid, 'gid' => $this->_gid, 'limit' => $this->limit];
+    $urlParams = ['reset' => 1, 'cid' => $this->_cid, 'rgid' => $this->_rgid, 'gid' => $this->_gid, 'limit' => $this->limit, 'criteria' => $this->criteria];
     $contactViewUrl = CRM_Utils_System::url('civicrm/contact/view', ['reset' => 1, 'cid' => $this->_cid]);
 
     if (!empty($formValues['_qf_Merge_submit'])) {
@@ -314,7 +320,7 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
     }
 
     if ($this->next && $this->_mergeId) {
-      $cacheKey = CRM_Dedupe_Merger::getMergeCacheKeyString($this->_rgid, $this->_gid);
+      $cacheKey = CRM_Dedupe_Merger::getMergeCacheKeyString($this->_rgid, $this->_gid, json_decode($this->criteria, TRUE));
 
       $join = CRM_Dedupe_Merger::getJoinOnDedupeTable();
       $where = "de.id IS NULL";

--- a/CRM/Contact/Page/AJAX.php
+++ b/CRM/Contact/Page/AJAX.php
@@ -646,13 +646,16 @@ LIMIT {$offset}, {$rowCount}
 
     $gid = CRM_Utils_Request::retrieve('gid', 'Positive');
     $rgid = CRM_Utils_Request::retrieve('rgid', 'Positive');
+    $null = NULL;
+    $criteria = CRM_Utils_Request::retrieve('criteria', 'Json', $null, FALSE, '{}');
     $selected    = isset($_REQUEST['selected']) ? CRM_Utils_Type::escape($_REQUEST['selected'], 'Integer') : 0;
     if ($rowCount < 0) {
       $rowCount = 0;
     }
 
     $whereClause = $orderByClause = '';
-    $cacheKeyString   = CRM_Dedupe_Merger::getMergeCacheKeyString($rgid, $gid);
+    $cacheKeyString   = CRM_Dedupe_Merger::getMergeCacheKeyString($rgid, $gid, json_decode($criteria, TRUE));
+
     $searchRows       = array();
 
     $searchParams = self::getSearchOptionsFromRequest();
@@ -814,6 +817,7 @@ LIMIT {$offset}, {$rowCount}
             'oid' => $pairInfo['entity_id2'],
             'action' => 'update',
             'rgid' => $rgid,
+            'criteria' => $criteria,
             'limit' => CRM_Utils_Request::retrieve('limit', 'Integer'),
           ];
         if ($gid) {
@@ -1014,8 +1018,9 @@ LIMIT {$offset}, {$rowCount}
     $gid  = CRM_Utils_Type::escape($_REQUEST['gid'], 'Integer');
     $pnid = $_REQUEST['pnid'];
     $isSelected = CRM_Utils_Type::escape($_REQUEST['is_selected'], 'Boolean');
+    $criteria = CRM_Utils_Request::retrieve('criteria', 'Json', $null, FALSE, '{}');
 
-    $cacheKeyString = CRM_Dedupe_Merger::getMergeCacheKeyString($rgid, $gid);
+    $cacheKeyString = CRM_Dedupe_Merger::getMergeCacheKeyString($rgid, $gid, json_decode($criteria, TRUE));
 
     $params = array(
       1 => array($isSelected, 'Boolean'),

--- a/CRM/Contact/Page/DedupeFind.php
+++ b/CRM/Contact/Page/DedupeFind.php
@@ -63,7 +63,8 @@ class CRM_Contact_Page_DedupeFind extends CRM_Core_Page_Basic {
     $limit = CRM_Utils_Request::retrieve('limit', 'Integer', $this);
     $rgid = CRM_Utils_Request::retrieve('rgid', 'Positive', $this);
     $cid = CRM_Utils_Request::retrieve('cid', 'Positive', $this, FALSE, 0);
-    $criteria = CRM_Utils_Request::retrieve('criteria', 'Json', $this, FALSE);
+
+    $criteria = CRM_Utils_Request::retrieve('criteria', 'Json', $this, FALSE, '{}');
     $this->assign('criteria', $criteria);
 
     $isConflictMode = ($context == 'conflicts');

--- a/CRM/Contact/Page/DedupeMerge.php
+++ b/CRM/Contact/Page/DedupeMerge.php
@@ -52,13 +52,13 @@ class CRM_Contact_Page_DedupeMerge extends CRM_Core_Page {
    * Build a queue of tasks by dividing dupe pairs in batches.
    */
   public static function getRunner() {
+
     $rgid = CRM_Utils_Request::retrieveValue('rgid', 'Positive');
     $gid  = CRM_Utils_Request::retrieveValue('gid', 'Positive');
     $limit = CRM_Utils_Request::retrieveValue('limit', 'Positive');
     $action = CRM_Utils_Request::retrieveValue('action', 'String');
     $mode = CRM_Utils_Request::retrieveValue('mode', 'String', 'safe');
-
-    $cacheKeyString = CRM_Dedupe_Merger::getMergeCacheKeyString($rgid, $gid);
+    $criteria = CRM_Utils_Request::retrieve('criteria', 'Json', $null, FALSE, '{}');
 
     $urlQry = array(
       'reset' => 1,
@@ -66,7 +66,11 @@ class CRM_Contact_Page_DedupeMerge extends CRM_Core_Page {
       'rgid' => $rgid,
       'gid' => $gid,
       'limit' => $limit,
+      'criteria' => $criteria,
     );
+
+    $criteria = json_decode($criteria, TRUE);
+    $cacheKeyString = CRM_Dedupe_Merger::getMergeCacheKeyString($rgid, $gid, $criteria);
 
     if ($mode == 'aggressive' && !CRM_Core_Permission::check('force merge duplicate contacts')) {
       CRM_Core_Session::setStatus(ts('You do not have permission to force merge duplicate contact records'), ts('Permission Denied'), 'error');
@@ -101,7 +105,7 @@ class CRM_Contact_Page_DedupeMerge extends CRM_Core_Page {
     for ($i = 1; $i <= ceil($total / self::BATCHLIMIT); $i++) {
       $task  = new CRM_Queue_Task(
         array('CRM_Contact_Page_DedupeMerge', 'callBatchMerge'),
-        array($rgid, $gid, $mode, self::BATCHLIMIT, $isSelected),
+        array($rgid, $gid, $mode, self::BATCHLIMIT, $isSelected, $criteria),
         "Processed " . $i * self::BATCHLIMIT . " pair of duplicates out of " . $total
       );
 
@@ -131,11 +135,12 @@ class CRM_Contact_Page_DedupeMerge extends CRM_Core_Page {
    *   'safe' mode or 'force' mode.
    * @param int $batchLimit
    * @param int $isSelected
+   * @param array $criteria
    *
    * @return int
    */
-  public static function callBatchMerge(CRM_Queue_TaskContext $ctx, $rgid, $gid, $mode = 'safe', $batchLimit, $isSelected) {
-    CRM_Dedupe_Merger::batchMerge($rgid, $gid, $mode, $batchLimit, $isSelected);
+  public static function callBatchMerge(CRM_Queue_TaskContext $ctx, $rgid, $gid, $mode = 'safe', $batchLimit, $isSelected, $criteria) {
+    CRM_Dedupe_Merger::batchMerge($rgid, $gid, $mode, $batchLimit, $isSelected, $criteria);
     return CRM_Queue_Task::TASK_SUCCESS;
   }
 

--- a/templates/CRM/Contact/Page/DedupeFind.tpl
+++ b/templates/CRM/Contact/Page/DedupeFind.tpl
@@ -324,6 +324,9 @@
       var is_selected = CRM.$('.crm-dedupe-select-all').prop('checked') ? 1 : 0;
     }
 
+    var criteria = {/literal}'{$criteria|escape}'{literal};
+    criteria  = criteria.length > 0 ? criteria : 0;
+
     var dataUrl = {/literal}"{crmURL p='civicrm/ajax/toggleDedupeSelect' h=0 q='snippet=4'}"{literal};
     var rgid = {/literal}"{$rgid}"{literal};
     var gid = {/literal}"{$gid}"{literal};
@@ -331,7 +334,7 @@
     rgid = rgid.length > 0 ? rgid : 0;
     gid  = gid.length > 0 ? gid : 0;
 
-    CRM.$.post(dataUrl, {pnid: id, rgid: rgid, gid: gid, is_selected: is_selected}, function (data) {
+    CRM.$.post(dataUrl, {pnid: id, rgid: rgid, gid: gid, is_selected: is_selected, criteria : criteria}, function (data) {
       // nothing to do for now
     }, 'json');
   }


### PR DESCRIPTION
Overview
----------------------------------------
Permit (but not at this stage promote) criteria in the dedupe params to be respected as they are for batch dedupe finding

Before
----------------------------------------
civicrm/contact/dedupefind?reset=1&rgid=4&gid=&limit=&criteria={"contact":{"contact_id":205}}&action=update does nothing

After
----------------------------------------
civicrm/contact/dedupefind?reset=1&rgid=4&gid=&limit=&criteria={"contact":{"contact_id":205}}&action=update and similarly constructed urls pass criteria through to the underlying function that finds duplicates and limits those found

Technical Details
----------------------------------------
Originally when deduping was added it was too intensive for some DBs. The idea of adding a group filter was hit upon & putting gid into the url will limit to matches of members of the group. When we wanted to add more filtering options to batch dedupe we decided that it was too restrictive & decided to accept parameters that could be passed to the api (rather than iterate on 'things we come up with).

This PR passes the url contents through so they can be used but does not promote the use of them. We have been using this patch with extensions that create urls with list of contact ids or other criteria to find dedupes for for a while now & I see this as a step on the path to generalising & extensionising this code.

An example of how we are using this is we have a 'Fishing Net' rule which 'casts a wide net' finding duplicates. We have an action to 'Find duplicates using Fishing Net' in the contact menu that redirects to a url similar to above

Comments
----------------------------------------
I have a concern about data validation. Is it possible to put xss in a valid json string? Should we add a rule validateJSON that unpacks it & checks each key  or value against our XSS rule? @totten @seamuslee001 @seanmadsen 

I did something a bit like that here 
https://github.com/civicrm/civicrm-core/commit/4b02a1c432b10994c47b7d135eef850cdc214c6a#diff-3076917760efeb467459726ebb6af282

UPDATE: I added the validation rule per the other PR. The criteria array is never used for sql - it is passed to an api call so it is validated at that point. My concern is to ensure the criteria var appended to urls is safe. The buttons on this form all carry a bunch of parameters in the urls that are required for the next action (perhaps that's bad design but this does not exacerbate that & I feel that an angular rewrite would be the way to tackle that)

@JKingsnorth would love your review on the other aspects of this

---

 * [CRM-21753: Support 'criteria' in url on batch merge form](https://issues.civicrm.org/jira/browse/CRM-21753)