### PR TITLE
Unit test fixes

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1616,9 +1616,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       }
       $params['line_item'] = $lineItem;
       $params['payment_processor_id'] = $params['payment_processor'] = CRM_Utils_Array::value('id', $this->_paymentProcessor);
-      if (isset($this->_values['tax_amount'])) {
-        $params['tax_amount'] = $this->_values['tax_amount'];
-      }
+      $params['tax_amount'] = CRM_Utils_Array::value('tax_amount', $submittedValues, CRM_Utils_Array::value('tax_amount', $this->_values));
       //create contribution.
       if ($isQuickConfig) {
         $params['is_quick_config'] = 1;


### PR DESCRIPTION
Overview
----------------------------------------
This PR fixes two of the UT failures:
1. CRM_Contribute_Form_ContributionTest::testReSubmitSaleTaxAlteredAmount with data set #0 ('.')
Failed asserting that '1000.00' matches expected 2000.

2. CRM_Contribute_Form_ContributionTest::testReSubmitSaleTaxAlteredAmount with data set #1 (',')
Failed asserting that '1000.00' matches expected 2000. 

Occurred after https://github.com/civicrm/civicrm-core/pull/11461 was merged, which is a bit strange that those 2 failures doesn't get picked up on its test build