### PR TITLE
CRM-21754: Duplicate rows in Activity Details report when address fields are displayed

### DIFF
--- a/CRM/Report/Form/Activity.php
+++ b/CRM/Report/Form/Activity.php
@@ -468,9 +468,10 @@ class CRM_Report_Form_Activity extends CRM_Report_Form {
           strstr($clause, 'civicrm_email_contact_source_email') ||
           strstr($clause, 'civicrm_email_contact_assignee_email') ||
           strstr($clause, 'civicrm_email_contact_target_email') ||
-          strstr($clause, 'civicrm_phone_contact_target_phone')
+          strstr($clause, 'civicrm_phone_contact_target_phone') ||
+          strstr($clause, 'civicrm_address_')
         ) {
-          $this->_selectClauses[$key] = "GROUP_CONCAT($clause SEPARATOR ';') as $clause";
+          $this->_selectClauses[$key] = "GROUP_CONCAT(DISTINCT $clause SEPARATOR ';') as $clause";
         }
       }
     }
@@ -1088,7 +1089,7 @@ GROUP BY civicrm_activity_id $having {$this->_orderBy}";
         }
       }
 
-      $entryFound = $this->alterDisplayAddressFields($row, $rows, $rowNum, 'activity', 'List all activities for this ') ? TRUE : $entryFound;
+      $entryFound = $this->alterDisplayAddressFields($row, $rows, $rowNum, 'activity', 'List all activities for this', ';') ? TRUE : $entryFound;
 
       if (!$entryFound) {
         break;

--- a/CRM/Report/Form/Activity.php
+++ b/CRM/Report/Form/Activity.php
@@ -436,7 +436,8 @@ class CRM_Report_Form_Activity extends CRM_Report_Form {
           strstr($clause, 'civicrm_email_target.') ||
           strstr($clause, 'civicrm_email_source.') ||
           strstr($clause, 'civicrm_phone_target.') ||
-          strstr($clause, 'civicrm_phone_source.')
+          strstr($clause, 'civicrm_phone_source.') ||
+          strstr($clause, 'civicrm_address_')
         ) {
           $removeKeys[] = $key;
           unset($this->_selectClauses[$key]);
@@ -450,7 +451,8 @@ class CRM_Report_Form_Activity extends CRM_Report_Form {
           strstr($clause, 'civicrm_email_target.') ||
           strstr($clause, 'civicrm_email_assignee.') ||
           strstr($clause, 'civicrm_phone_target.') ||
-          strstr($clause, 'civicrm_phone_assignee.')
+          strstr($clause, 'civicrm_phone_assignee.') ||
+          strstr($clause, 'civicrm_address_')
         ) {
           $removeKeys[] = $key;
           unset($this->_selectClauses[$key]);
@@ -481,7 +483,7 @@ class CRM_Report_Form_Activity extends CRM_Report_Form {
         unset($this->_selectAliases[$key]);
       }
 
-      if ($recordType != 'final') {
+      if ($recordType == 'target') {
         foreach ($this->_columns['civicrm_address']['order_bys'] as $fieldName => $field) {
           $orderByFld = $this->_columns['civicrm_address']['order_bys'][$fieldName];
           $fldInfo = $this->_columns['civicrm_address']['fields'][$fieldName];


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate: 
1. MySql 5.7 + sql mode = ONLY_FULL_GROUP_BY
2. Select any address field e.g. city, State, Country to display
3. Create an Activity of any type and select 3 contacts as target, assignee and source. Make sure that each contact has different address field(s).
4. Run Activity Details report

Result: 3 duplicate rows due to three different address field values
Expected: 1 row with merged address field values

Before
----------------------------------------
![screen shot 2018-02-08 at 10 14 56 pm](https://user-images.githubusercontent.com/3735621/35985849-95df4c34-0d1d-11e8-8be0-65e5b37f64fe.png)


After
----------------------------------------
![screen shot 2018-02-08 at 10 14 14 pm](https://user-images.githubusercontent.com/3735621/35985860-9ec00870-0d1d-11e8-87a6-d16e30bb2b31.png)


---

 * [CRM-21754: Duplicate rows in Activity Details report when address fields are displayed ](https://issues.civicrm.org/jira/browse/CRM-21754)