### PR TITLE
dev/core#2 Display Inbound Email: linefeed fixed

### DIFF
--- a/templates/CRM/Activity/Form/Activity.tpl
+++ b/templates/CRM/Activity/Form/Activity.tpl
@@ -158,7 +158,7 @@
       </td>
       {else}
       <td class="view-value">
-       {$form.details.html|crmStripAlternatives}
+       {$form.details.html|crmStripAlternatives|nl2br}
       </td>
     {/if}
   </tr>


### PR DESCRIPTION
Overview
----------------------------------------
When viewing an activity of type inbound email, the text is displayed in "details". However, although the database contains it in plain text and html, it is displayed as plain text without LFs, what makes it hardly readable.

Before
----------------------------------------
![screenshot 2018-02-12 18 16 11](https://user-images.githubusercontent.com/336308/36084306-feae55d8-1020-11e8-8aea-474b52b53806.png)

After 
----------------------------------------
![screenshot 2018-02-12 18 17 10](https://user-images.githubusercontent.com/336308/36084313-118129a6-1021-11e8-9937-7a8069b91da1.png)



Technical Details
----------------------------------------
Small change (maybe a typo in the original code)

Comments
----------------------------------------
cudos to @bgm for helping to find the bug, and instructing me to create the PR !

 
