### PR TITLE
CRM-21760: Manager Name is missing in 'Find Cases' search list

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -1890,6 +1890,7 @@ SELECT case_status.label AS case_status, status_id, civicrm_case_type.title AS c
     }
 
     $caseManagerContact = array();
+    $caseManagerName = '---';
     $xmlProcessor = new CRM_Case_XMLProcessor_Process();
 
     $managerRoleId = $xmlProcessor->getCaseManagerRoleId($caseType);
@@ -1910,12 +1911,14 @@ SELECT civicrm_contact.id as casemanager_id,
 
       $dao = CRM_Core_DAO::executeQuery($managerRoleQuery, $managerRoleParams);
       if ($dao->fetch()) {
-        return sprintf('<a href="%s">%s</a>',
+        $caseManagerName = sprintf('<a href="%s">%s</a>',
           CRM_Utils_System::url('civicrm/contact/view', array('cid' => $dao->casemanager_id)),
           $dao->casemanager
         );
       }
     }
+
+    return $caseManagerName;
   }
 
   /**

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -1889,7 +1889,6 @@ SELECT case_status.label AS case_status, status_id, civicrm_case_type.title AS c
       return NULL;
     }
 
-    $caseManagerContact = array();
     $caseManagerName = '---';
     $xmlProcessor = new CRM_Case_XMLProcessor_Process();
 

--- a/CRM/Case/Selector/Search.php
+++ b/CRM/Case/Selector/Search.php
@@ -349,12 +349,7 @@ class CRM_Case_Selector_Search extends CRM_Core_Selector_Base {
 
       //adding case manager to case selector.CRM-4510.
       $caseType = CRM_Case_BAO_Case::getCaseType($result->case_id, 'name');
-      $caseManagerContact = CRM_Case_BAO_Case::getCaseManagerContact($caseType, $result->case_id);
-
-      if (!empty($caseManagerContact)) {
-        $row['casemanager_id'] = CRM_Utils_Array::value('casemanager_id', $caseManagerContact);
-        $row['casemanager'] = CRM_Utils_Array::value('casemanager', $caseManagerContact);
-      }
+      $row['casemanager'] = CRM_Case_BAO_Case::getCaseManagerContact($caseType, $result->case_id);
 
       if (isset($result->case_status_id) &&
         array_key_exists($result->case_status_id, $caseStatus)

--- a/templates/CRM/Case/Form/Selector.tpl
+++ b/templates/CRM/Case/Form/Selector.tpl
@@ -66,7 +66,7 @@
     <td class="{$row.class} crm-case-status_{$row.case_status}">{$row.case_status}</td>
     <td class="crm-case-case_type">{$row.case_type}</td>
     <td class="crm-case-case_role">{if $row.case_role}{$row.case_role}{else}---{/if}</td>
-    <td class="crm-case-case_manager">{if $row.casemanager_id}<a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.casemanager_id`"}">{$row.casemanager}</a>{else}---{/if}</td>
+    <td class="crm-case-case_manager">{$row.casemanager}</td>
     <td class="crm-case-case_recent_activity_type">{if $row.case_recent_activity_type}
   {$row.case_recent_activity_type}<br />{$row.case_recent_activity_date|crmDate}{else}---{/if}</td>
     <td class="crm-case-case_scheduled_activity_type">{if $row.case_scheduled_activity_type}


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate:
1. Got to 'Find Cases'
2. Simply search and populate the result

Result: In place of manager name, we got '—' for all cases
Expected: Linkable manger name

Before
----------------------------------------
![screen shot 2018-02-12 at 12 12 07 am](https://user-images.githubusercontent.com/3735621/36076960-b886d89c-0f89-11e8-9222-6814d367e842.png)


After
----------------------------------------
![screen shot 2018-02-12 at 12 13 58 am](https://user-images.githubusercontent.com/3735621/36076964-c3f9fe52-0f89-11e8-9eb7-fe01dcab8bd2.png)


Comments
----------------------------------------
This is a regression due improvement made in https://github.com/civicrm/civicrm-core/pull/11304 where now ```getCaseManagerContact()``` return the Case Manager name in HTML format.