### PR TITLE
 CRM-21753 add json validation for incoming criteria

### DIFF
--- a/CRM/Contact/Page/DedupeFind.php
+++ b/CRM/Contact/Page/DedupeFind.php
@@ -63,8 +63,9 @@ class CRM_Contact_Page_DedupeFind extends CRM_Core_Page_Basic {
     $limit = CRM_Utils_Request::retrieve('limit', 'Integer', $this);
     $rgid = CRM_Utils_Request::retrieve('rgid', 'Positive', $this);
     $cid = CRM_Utils_Request::retrieve('cid', 'Positive', $this, FALSE, 0);
-    // Using a placeholder for criteria as it is intended to be able to pass this later.
-    $criteria = array();
+    $criteria = CRM_Utils_Request::retrieve('criteria', 'Json', $this, FALSE);
+    $this->assign('criteria', $criteria);
+
     $isConflictMode = ($context == 'conflicts');
     if ($cid) {
       $this->_cid = $cid;
@@ -79,8 +80,10 @@ class CRM_Contact_Page_DedupeFind extends CRM_Core_Page_Basic {
       'rgid' => $rgid,
       'gid' => $gid,
       'limit' => $limit,
+      'criteria' => $criteria,
     );
     $this->assign('urlQuery', CRM_Utils_System::makeQueryString($urlQry));
+    $criteria = json_decode($criteria, TRUE);
 
     if ($context == 'search') {
       $context = 'search';

--- a/CRM/Utils/Rule.php
+++ b/CRM/Utils/Rule.php
@@ -814,6 +814,25 @@ class CRM_Utils_Rule {
   }
 
   /**
+   * Validate json string for xss
+   *
+   * @param string $value
+   *
+   * @return bool
+   *   False if invalid, true if valid / safe.
+   */
+  public static function json($value) {
+    if (!self::xssString($value)) {
+      return FALSE;
+    }
+    $array = json_decode($value, TRUE);
+    if (!$array || !is_array($array)) {
+      return FALSE;
+    }
+    return self::arrayValue($array);
+  }
+
+  /**
    * @param $path
    *
    * @return bool
@@ -938,6 +957,26 @@ class CRM_Utils_Rule {
   public static function checkExtesnionKeyIsValid($key = NULL) {
     if (!empty($key) && !preg_match('/^[0-9a-zA-Z._-]+$/', $key)) {
       return FALSE;
+    }
+    return TRUE;
+  }
+
+  /**
+   * Validate array recursively checking keys and  values.
+   *
+   * @param array $array
+   * @return bool
+   */
+  protected static function arrayValue($array) {
+    foreach ($array as $key => $item) {
+      if (is_array($item)) {
+        if (!self::xssString($key) || !self::arrayValue($item)) {
+          return FALSE;
+        }
+      }
+      if (!self::xssString($key) || !self::xssString($item)) {
+        return FALSE;
+      }
     }
     return TRUE;
   }

--- a/CRM/Utils/Type.php
+++ b/CRM/Utils/Type.php
@@ -422,6 +422,7 @@ class CRM_Utils_Type {
       'MysqlOrderByDirection',
       'MysqlOrderBy',
       'ExtensionKey',
+      'Json',
     );
     if (!in_array($type, $possibleTypes)) {
       if ($isThrowException) {
@@ -527,6 +528,12 @@ class CRM_Utils_Type {
 
       case 'ExtensionKey':
         if (CRM_Utils_Rule::checkExtesnionKeyIsValid($data)) {
+          return $data;
+        }
+        break;
+
+      case 'Json':
+        if (CRM_Utils_Rule::json($data)) {
           return $data;
         }
         break;

--- a/tests/phpunit/CRM/Utils/TypeTest.php
+++ b/tests/phpunit/CRM/Utils/TypeTest.php
@@ -74,6 +74,8 @@ class CRM_Utils_TypeTest extends CiviUnitTestCase {
       array('table.civicrm_column_name desc,other_column, another_column desc', 'MysqlOrderBy', 'table.civicrm_column_name desc,other_column, another_column desc'),
       array('table.`Home-street_address` asc, `table-alias`.`Home-street_address` desc,`table-alias`.column', 'MysqlOrderBy', 'table.`Home-street_address` asc, `table-alias`.`Home-street_address` desc,`table-alias`.column'),
       array('a string', 'String', 'a string'),
+      array('{"contact":{"contact_id":205}}', 'Json', '{"contact":{"contact_id":205}}'),
+      array('{"contact":{"contact_id":!n†rude®}}', 'Json', NULL),
     );
   }
 


### PR DESCRIPTION
This is an adjunct to #11658 & intended to clarify discussion of the potential security aspect of processing input from the url. I will add the decision to that PR

the dedupe code has a mechanism to handle a nuanced array of criteria.

This PR is purely to discuss the passing of that criteria through the UI, with
a proposed validation rule.

The criteria in the url might look like

criteria={"contact" : {"first_name" :{"IN" : ["Peter", "Paul", "Mary"]]]}

This is passed to the contact api to limit the contacts to look for matches
for, prior to applying permissions (which is done when actually finding the
matches.

My specific concern is that the criteria is passed back to the template and
used in constructed urls - so I am looking to validate it on the way in
for xss in this PR.

---

 * [CRM-21753: Support 'criteria' in url on batch merge form](https://issues.civicrm.org/jira/browse/CRM-21753)