### PR TITLE
CRM-21763 Util to subtract currencies using integers for precision

### DIFF
--- a/CRM/Core/BAO/FinancialTrxn.php
+++ b/CRM/Core/BAO/FinancialTrxn.php
@@ -486,7 +486,8 @@ WHERE ft.is_payment = 1
       if (!$ftTotalAmt) {
         $ftTotalAmt = 0;
       }
-      $value = $paymentVal = $lineItemTotal - $ftTotalAmt;
+      $currency = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $contributionId, 'currency');
+      $value = $paymentVal = CRM_Utils_Money::subtractCurrencies($lineItemTotal, $ftTotalAmt, $currency);
       if ($returnType) {
         $value = array();
         if ($paymentVal < 0) {

--- a/CRM/Utils/Money.php
+++ b/CRM/Utils/Money.php
@@ -141,4 +141,17 @@ class CRM_Utils_Money {
     return 2;
   }
 
+  /**
+   * Subtract currencies using integers instead of floats, to preserve precision
+   *
+   * @return float
+   *   Result of subtracting $rightOp from $leftOp to the precision of $currency
+   */
+  public static function subtractCurrencies($leftOp, $rightOp, $currency) {
+    if (is_numeric($leftOp) && is_numeric($rightOp)) {
+      $precision = pow(10, self::getCurrencyPrecision($currency));
+      return (($leftOp * $precision) - ($rightOp * $precision)) / $precision;
+    }
+  }
+
 }

--- a/tests/phpunit/CRM/Core/BAO/FinancialTrxnTest.php
+++ b/tests/phpunit/CRM/Core/BAO/FinancialTrxnTest.php
@@ -240,4 +240,32 @@ class CRM_Core_BAO_FinancialTrxnTest extends CiviUnitTestCase {
     $this->assertEquals($financialTrxn['pan_truncation'], 4567);
   }
 
+  /**
+   * Test getPartialPaymentWithType function.
+   */
+  public function testGetPartialPaymentWithType() {
+    //create the contribution that isn't paid yet
+    $contactId = $this->individualCreate();
+    $params = array(
+      'contact_id' => $contactId,
+      'currency' => 'USD',
+      'financial_type_id' => 1,
+      'contribution_status_id' => 8,
+      'payment_instrument_id' => 4,
+      'total_amount' => 300.00,
+      'fee_amount' => 0.00,
+      'net_amount' => 300.00,
+    );
+    $contribution = $this->callAPISuccess('Contribution', 'create', $params)['values'][7];
+    //make a payment one cent short
+    $params = array(
+      'contribution_id' => $contribution['id'],
+      'total_amount' => 299.99,
+    );
+    $this->callAPISuccess('Payment', 'create', $params);
+    //amount owed should be one cent
+    $amountOwed = CRM_Core_BAO_FinancialTrxn::getPartialPaymentWithType($contribution['id'], 'contribution')['amount_owed'];
+    $this->assertTrue(0.01 == $amountOwed, 'Amount does not match');
+  }
+
 }

--- a/tests/phpunit/CRM/Utils/MoneyTest.php
+++ b/tests/phpunit/CRM/Utils/MoneyTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Class CRM_Utils_RuleTest
+ * @group headless
+ */
+class CRM_Utils_MoneyTest extends CiviUnitTestCase {
+
+  public function setUp() {
+    parent::setUp();
+  }
+
+  /**
+   * @dataProvider subtractCurrenciesDataProvider
+   * @param $inputData
+   * @param $expectedResult
+   */
+  public function testSubtractCurrencies($leftOp, $rightOp, $currency, $expectedResult) {
+    $this->assertEquals($expectedResult, CRM_Utils_Money::subtractCurrencies($leftOp, $rightOp, $currency));
+  }
+
+  /**
+   * @return array
+   */
+  public function subtractCurrenciesDataProvider() {
+    return array(
+      array(number_format(300.00, 2), number_format(299.99, 2), USD, number_format(0.01, 2)),
+      array(2, 1, USD, 1),
+      array(0, 0, USD, 0),
+      array(1, 2, USD, -1),
+      array(number_format(19.99, 2), number_format(20.00, 2), USD, number_format(-0.01, 2)),
+      array('notanumber', 5.00, USD, NULL),
+    );
+  }
+
+}


### PR DESCRIPTION
Ref CRM-21763. CRM_Core_BAO_FinancialTrxn::getPartialPaymentWithType currently subtracts currency floats without any helper functions, causing issues with precision in cents.

This PR adds a helper function to CRM_Utils_Money to allow subtracting currencies as integers and returning the float, while preserving the precision for the currency involved, and a unit test for the function. It also implements in CRM_Core_BAO_FinancialTrxn::getPartialPaymentWithType.

Thanks @mattwire for the helpful idea on mattermost!

---

 * [CRM-21763: Cannot record payment for only cents owed](https://issues.civicrm.org/jira/browse/CRM-21763)