### PR TITLE
CRM-21766 quash reload warning on dedupe conflicts screen

### DIFF
--- a/CRM/Contact/Form/DedupeFind.php
+++ b/CRM/Contact/Form/DedupeFind.php
@@ -37,6 +37,11 @@
 class CRM_Contact_Form_DedupeFind extends CRM_Admin_Form {
 
   /**
+   *  Indicate if this form should warn users of unsaved changes
+   */
+  protected $unsavedChangesWarn = FALSE;
+
+  /**
    * Pre processing.
    */
   public function preProcess() {


### PR DESCRIPTION
Overview
----------------------------------------
After doing a batch merge the results are shown with various button options. Ensure these buttons can be clicked without a warning message about losing data (there is no place to enter data here.)

Before
----------------------------------------
![screenshot 2018-02-15 14 30 07](https://user-images.githubusercontent.com/336308/36236771-d217e500-125c-11e8-90ff-1d3028f2b548.png)

![screenshot 2018-02-15 09 27 12](https://user-images.githubusercontent.com/336308/36236643-029dd758-125c-11e8-9aac-69b17e1109b0.png)

After
----------------------------------------
Buttons respond without message

Technical Details
----------------------------------------
This is an extension of the fix made in https://issues.civicrm.org/jira/browse/CRM-21304

Comments
----------------------------------------

---

 * [CRM-21766: Dedupe screen gives inappropriate confirm message when clicking on batch dedupe](https://issues.civicrm.org/jira/browse/CRM-21766)