### PR TITLE
Deduper - Pass arrays rather than strings to construct URLs

### DIFF
--- a/CRM/Contact/Page/AJAX.php
+++ b/CRM/Contact/Page/AJAX.php
@@ -808,9 +808,16 @@ LIMIT {$offset}, {$rowCount}
       $searchRows[$count]['weight'] = CRM_Utils_Array::value('weight', $pair);
 
       if (!empty($pairInfo['data']['canMerge'])) {
-        $mergeParams = "reset=1&cid={$pairInfo['entity_id1']}&oid={$pairInfo['entity_id2']}&action=update&rgid={$rgid}&limit=" . CRM_Utils_Request::retrieve('limit', 'Integer');
+        $mergeParams = [
+          'reset' => 1,
+            'cid' => $pairInfo['entity_id1'],
+            'oid' => $pairInfo['entity_id2'],
+            'action' => 'update',
+            'rgid' => $rgid,
+            'limit' => CRM_Utils_Request::retrieve('limit', 'Integer'),
+          ];
         if ($gid) {
-          $mergeParams .= "&gid={$gid}";
+          $mergeParams['gid'] = $gid;
         }
 
         $searchRows[$count]['actions']  = "<a class='crm-dedupe-flip' href='#' data-pnid={$pairInfo['prevnext_id']}>" . ts('flip') . "</a>&nbsp;|&nbsp;";

--- a/CRM/Contact/Page/DedupeFind.php
+++ b/CRM/Contact/Page/DedupeFind.php
@@ -142,7 +142,7 @@ class CRM_Contact_Page_DedupeFind extends CRM_Core_Page_Basic {
         $urlQry['selected'] = 1;
       }
 
-      $this->assign('sourceUrl', CRM_Utils_System::url('civicrm/ajax/dedupefind', $urlQry, FALSE, NULL, FALSE));
+      $this->assign('sourceUrl', CRM_Utils_System::url('civicrm/ajax/dedupefind', $urlQry));
 
       //reload from cache table
       $cacheKeyString = CRM_Dedupe_Merger::getMergeCacheKeyString($rgid, $gid, $criteria);


### PR DESCRIPTION
Overview
----------------------------------------
Minor code cleanup

Before
----------------------------------------
CRM_Utils_System::url() receiving $query as a string

After
----------------------------------------
CRM_Utils_System::url() receiving $query as an array

Technical Details
----------------------------------------
When we pass a query it is urlencoded and any quotes in the string are not subsequently htmlentity encoded plus I think the url construction code is generally cleaner when not constructing urls as strings


