### PR TITLE
CRM-21769: Show 'unsupported locale for parsing' warning only when enabling address parsing

### DIFF
--- a/CRM/Admin/Form/Preferences/Address.php
+++ b/CRM/Admin/Form/Preferences/Address.php
@@ -184,6 +184,17 @@ class CRM_Admin_Form_Preferences_Address extends CRM_Admin_Form_Preferences {
           }
         }
       }
+
+      if ($title == ts('Street Address Parsing')) {
+        if (isset($this->_params['address_options']) &&
+          !empty($this->_params['address_options'][$key])
+        ) {
+          if (!CRM_Core_BAO_Address::isSupportedParsingLocale()) {
+            CRM_Core_Session::setStatus(ts('Unsupported default locale specified to parse Street Address. en_US locale will be used instead.'), ts('Unsupported Locale'), 'alert');
+          }
+
+        }
+      }
     }
 
     $this->postProcessCommon();

--- a/CRM/Admin/Form/Preferences/Address.php
+++ b/CRM/Admin/Form/Preferences/Address.php
@@ -179,7 +179,7 @@ class CRM_Admin_Form_Preferences_Address extends CRM_Admin_Form_Preferences {
     }
 
     // check that locale supports address parsing
-    if(
+    if (
       CRM_Utils_Array::value($addressOptions['Street Address Parsing'], $this->_params['address_options']) &&
       !CRM_Core_BAO_Address::isSupportedParsingLocale()
     ) {

--- a/CRM/Admin/Form/Preferences/Address.php
+++ b/CRM/Admin/Form/Preferences/Address.php
@@ -165,36 +165,27 @@ class CRM_Admin_Form_Preferences_Address extends CRM_Admin_Form_Preferences {
     }
 
     $this->_params = $this->controller->exportValues($this->_name);
+    $addressOptions = CRM_Core_OptionGroup::values('address_options', TRUE);
 
     // check if county option has been set
-    $options = CRM_Core_OptionGroup::values('address_options', FALSE, FALSE, TRUE);
-    foreach ($options as $key => $title) {
-      if ($title == ts('County')) {
-        // check if the $key is present in $this->_params
-        if (isset($this->_params['address_options']) &&
-          !empty($this->_params['address_options'][$key])
-        ) {
-          // print a status message to the user if county table seems small
-          $countyCount = CRM_Core_DAO::singleValueQuery("SELECT count(*) FROM civicrm_county");
-          if ($countyCount < 10) {
-            CRM_Core_Session::setStatus(ts('You have enabled the County option. Please ensure you populate the county table in your CiviCRM Database. You can find extensions to populate counties in the <a %1>CiviCRM Extensions Directory</a>.', array(1 => 'href="' . CRM_Utils_System::url('civicrm/admin/extensions', array('reset' => 1), TRUE, 'extensions-addnew') . '"')),
-              ts('Populate counties'),
-              "info"
-            );
-          }
-        }
+    if (CRM_Utils_Array::value($addressOptions['County'], $this->_params['address_options'])) {
+      $countyCount = CRM_Core_DAO::singleValueQuery("SELECT count(*) FROM civicrm_county");
+      if ($countyCount < 10) {
+        CRM_Core_Session::setStatus(ts('You have enabled the County option. Please ensure you populate the county table in your CiviCRM Database. You can find extensions to populate counties in the <a %1>CiviCRM Extensions Directory</a>.', array(1 => 'href="' . CRM_Utils_System::url('civicrm/admin/extensions', array('reset' => 1), TRUE, 'extensions-addnew') . '"')),
+          ts('Populate counties'),
+          "info"
+        );
       }
+    }
 
-      if ($title == ts('Street Address Parsing')) {
-        if (isset($this->_params['address_options']) &&
-          !empty($this->_params['address_options'][$key])
-        ) {
-          if (!CRM_Core_BAO_Address::isSupportedParsingLocale()) {
-            CRM_Core_Session::setStatus(ts('Unsupported default locale specified to parse Street Address. en_US locale will be used instead.'), ts('Unsupported Locale'), 'alert');
-          }
-
-        }
-      }
+    // check that locale supports address parsing
+    if(
+      CRM_Utils_Array::value($addressOptions['Street Address Parsing'], $this->_params['address_options']) &&
+      !CRM_Core_BAO_Address::isSupportedParsingLocale()
+    ) {
+      $config = CRM_Core_Config::singleton();
+      $locale = $config->lcMessages;
+      CRM_Core_Session::setStatus(ts('Default locale (%1) does not support street parsing. en_US locale will be used instead.', [1 => $locale]), ts('Unsupported Locale'), 'alert');
     }
 
     $this->postProcessCommon();

--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -714,25 +714,11 @@ ORDER BY civicrm_address.is_primary DESC, civicrm_address.location_type_id DESC,
    *   parsed fields values.
    */
   public static function parseStreetAddress($streetAddress, $locale = NULL) {
-    $config = CRM_Core_Config::singleton();
-
-    /* locales supported include:
-     *  en_US - http://pe.usps.com/cpim/ftp/pubs/pub28/pub28.pdf
-     *  en_CA - http://www.canadapost.ca/tools/pg/manual/PGaddress-e.asp
-     *  fr_CA - http://www.canadapost.ca/tools/pg/manual/PGaddress-f.asp
-     *          NB: common use of comma after street number also supported
-     *  default is en_US
-     */
-
-    $supportedLocalesForParsing = array('en_US', 'en_CA', 'fr_CA');
-    if (!$locale) {
-      $locale = $config->lcMessages;
-    }
-    // as different locale explicitly requested but is not available, display warning message and set $locale = 'en_US'
-    if (!in_array($locale, $supportedLocalesForParsing)) {
-      CRM_Core_Session::setStatus(ts('Unsupported locale specified to parseStreetAddress: %1. Proceeding with en_US locale.', array(1 => $locale)), ts('Unsupported Locale'), 'alert');
+    // use 'en_US' for address parsing if the requested locale is not supported.
+    if (!self::isSupportedParsingLocale($locale)) {
       $locale = 'en_US';
     }
+
     $emptyParseFields = $parseFields = array(
       'street_name' => '',
       'street_unit' => '',
@@ -874,6 +860,38 @@ ORDER BY civicrm_address.is_primary DESC, civicrm_address.location_type_id DESC,
     }
 
     return $parseFields;
+  }
+
+  /**
+   * Determines if the specified locale is
+   * supported by address parsing.
+   * If no locale is specified then it
+   * will check the default configured locale.
+   *
+   * locales supported include:
+   *  en_US - http://pe.usps.com/cpim/ftp/pubs/pub28/pub28.pdf
+   *  en_CA - http://www.canadapost.ca/tools/pg/manual/PGaddress-e.asp
+   *  fr_CA - http://www.canadapost.ca/tools/pg/manual/PGaddress-f.asp
+   *          NB: common use of comma after street number also supported
+   *
+   * @param string $locale
+   *   The locale to be checked
+   *
+   * @return boolean
+   */
+  public static function isSupportedParsingLocale($locale = NULL) {
+    if (!$locale) {
+      $config = CRM_Core_Config::singleton();
+      $locale = $config->lcMessages;
+    }
+
+    $parsingSupportedLocales = array('en_US', 'en_CA', 'fr_CA');
+
+    if (in_array($locale, $parsingSupportedLocales)) {
+      return TRUE;
+    }
+
+    return FALSE;
   }
 
   /**

--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -877,7 +877,7 @@ ORDER BY civicrm_address.is_primary DESC, civicrm_address.location_type_id DESC,
    * @param string $locale
    *   The locale to be checked
    *
-   * @return boolean
+   * @return bool
    */
   public static function isSupportedParsingLocale($locale = NULL) {
     if (!$locale) {

--- a/CRM/Utils/Check/Component/AddressParsing.php
+++ b/CRM/Utils/Check/Component/AddressParsing.php
@@ -1,0 +1,67 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2018                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2018
+ */
+class CRM_Utils_Check_Component_AddressParsing extends CRM_Utils_Check_Component {
+
+  public static function checkLocaleSupportsAddressParsing() {
+
+    $addressOptions = CRM_Core_BAO_Setting::valueOptions(
+      CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
+      'address_options'
+    );
+
+    $messages = [];
+
+    if ($addressOptions['street_address_parsing']) {
+      if (!CRM_Core_BAO_Address::isSupportedParsingLocale()) {
+        $config = CRM_Core_Config::singleton();
+        $messages[] = new CRM_Utils_Check_Message(
+          __FUNCTION__,
+          ts(
+            '<a href=' .
+            CRM_Utils_System::url('civicrm/admin/setting/preferences/address', 'reset=1') .
+            '">Street address parsing</a> is enabled but not supported by <a href="' .
+            CRM_Utils_System::url('civicrm/admin/setting/localization', 'reset=1') .
+            '">your locale</a> (%1).',
+            [1 => $config->lcMessages]
+          ),
+          ts('Street address parsing'),
+          \Psr\Log\LogLevel::WARNING,
+          'fa-address-card'
+        );
+      }
+    }
+
+    return $messages;
+  }
+
+}

--- a/tests/phpunit/CRM/Core/BAO/AddressTest.php
+++ b/tests/phpunit/CRM/Core/BAO/AddressTest.php
@@ -400,8 +400,7 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
 
   }
 
-  public function supportedAddressParsingLocales()
-  {
+  public function supportedAddressParsingLocales() {
     return array(
       'en_US',
       'en_CA',
@@ -426,8 +425,7 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
     $this->assertFalse($isNotSupported);
   }
 
-  public function sampleOFUnsupportedAddressParsingLocales()
-  {
+  public function sampleOFUnsupportedAddressParsingLocales() {
     return array(
       'en_GB',
       'af_ZA',

--- a/tests/phpunit/CRM/Core/BAO/AddressTest.php
+++ b/tests/phpunit/CRM/Core/BAO/AddressTest.php
@@ -383,6 +383,59 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
   }
 
   /**
+   * @dataProvider supportedAddressParsingLocales
+   */
+  public function testIsSupportedByAddressParsingReturnTrueForSupportedLocales($locale) {
+    $isSupported = CRM_Core_BAO_Address::isSupportedParsingLocale($locale);
+    $this->assertTrue($isSupported);
+  }
+
+  /**
+   * @dataProvider supportedAddressParsingLocales
+   */
+  public function testIsSupportedByAddressParsingReturnTrueForSupportedDefaultLocales($locale) {
+    CRM_Core_Config::singleton()->lcMessages = $locale;
+    $isSupported = CRM_Core_BAO_Address::isSupportedParsingLocale();
+    $this->assertTrue($isSupported);
+
+  }
+
+  public function supportedAddressParsingLocales()
+  {
+    return array(
+      'en_US',
+      'en_CA',
+      'fr_CA',
+    );
+  }
+
+  /**
+   * @dataProvider sampleOFUnsupportedAddressParsingLocales
+   */
+  public function testIsSupportedByAddressParsingReturnFalseForUnSupportedLocales($locale) {
+    $isNotSupported = CRM_Core_BAO_Address::isSupportedParsingLocale($locale);
+    $this->assertFalse($isNotSupported);
+  }
+
+  /**
+   * @dataProvider sampleOFUnsupportedAddressParsingLocales
+   */
+  public function testIsSupportedByAddressParsingReturnFalseForUnSupportedDefaultLocales($locale) {
+    CRM_Core_Config::singleton()->lcMessages = $locale;
+    $isNotSupported = CRM_Core_BAO_Address::isSupportedParsingLocale();
+    $this->assertFalse($isNotSupported);
+  }
+
+  public function sampleOFUnsupportedAddressParsingLocales()
+  {
+    return array(
+      'en_GB',
+      'af_ZA',
+      'da_DK',
+    );
+  }
+
+  /**
    * CRM-21214 - Ensure all child addresses are updated correctly - 1.
    * 1. First, create three contacts: A, B, and C
    * 2. Create an address for contact A

--- a/tests/phpunit/CRM/Core/BAO/AddressTest.php
+++ b/tests/phpunit/CRM/Core/BAO/AddressTest.php
@@ -402,9 +402,9 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
 
   public function supportedAddressParsingLocales() {
     return array(
-      'en_US',
-      'en_CA',
-      'fr_CA',
+      array('en_US'),
+      array('en_CA'),
+      array('fr_CA'),
     );
   }
 
@@ -427,9 +427,9 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
 
   public function sampleOFUnsupportedAddressParsingLocales() {
     return array(
-      'en_GB',
-      'af_ZA',
-      'da_DK',
+      array('en_GB'),
+      array('af_ZA'),
+      array('da_DK'),
     );
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Improving "Unsupported locale specified to parseStreetAddress" warning.

Before
----------------------------------------
1- Go to Administer >> Localization >> Languages, Currency, Locations.
2- Change the default Language to anything other than "English (United States)", "English (Canada)" or "French (Canada)", for example change it to "English (United Kingdom)" and save the settings.
3- Go Administer >> Localization >> Address Settings.
4- At "Address Editing" section, check "Street Address Parsing" option and hit save.
5- Now any time you try to edit a contact with street address, a warning says "Unsupported locale specified to parseStreetAddress en_GB, Proceeding with en_US locale." will appear.


![beforeee](https://user-images.githubusercontent.com/6275540/36259320-c89696d6-1255-11e8-93f0-9f0484f4f188.gif)

After
----------------------------------------

The above situation is not ideal for users, the warning now  does not appear each time you try to edit a user and it default to en_US silently if the locale is not supported, the warning above only appear when the admin enable "Street Address Parsing" (step 4 above) in case the default locale is not supported.

![afterrr](https://user-images.githubusercontent.com/6275540/36259325-d0c8ca54-1255-11e8-82ae-21b0539122e4.gif)


---

 * [CRM-21769: Show unsupported locale for parsing warning only when when enabling address parsing](https://issues.civicrm.org/jira/browse/CRM-21769)