### PR TITLE
CRM-21768_NOFOLLOW_links_in_public_online_view_of_mailings

### DIFF
--- a/CRM/Mailing/BAO/TrackableURL.php
+++ b/CRM/Mailing/BAO/TrackableURL.php
@@ -97,7 +97,7 @@ class CRM_Mailing_BAO_TrackableURL extends CRM_Mailing_DAO_TrackableURL {
     $returnUrl = "{$urlCache[$mailing_id . $url]}&qid={$queue_id}";
 
     if ($hrefExists) {
-      $returnUrl = "href='{$returnUrl}'";
+      $returnUrl = "href='{$returnUrl}' rel='nofollow'";
     }
 
     return $returnUrl;


### PR DESCRIPTION
Overview
----------------------------------------
This patch makes sure the trackable url links in the public view of mailings get the nofollow tag so Google will not index urls with a syntax like: https://abc.xyz/sites/all/modules/civicrm/extern/url.php?u=1234&qid=4321

Before
----------------------------------------
Currently Google (and possibly other search engines) index the trackable urls, so url's like:
https://abc.xyz/sites/all/modules/civicrm/extern/url.php?u=1234&qid=4321
end up in the search index.
![screenshot from 2018-02-15 12-06-33](https://user-images.githubusercontent.com/2195908/36259563-dd64717e-125e-11e8-9734-85bda6638287.png)

After
----------------------------------------
Trackable urls get the tag rel='NOFOLLOW', which means Google will not follow the links, which could only happen in a situation of a public viewable mailing anyway. The mailing itself is still able to get indexed. Note: this does not 100% prevent Google from indexing, others means like robots.txt are more robust for that. But this patch at least prevents the strange indexed urls for default configurations.

Technical Details
----------------------------------------
adding rel='NOFOLLOW' to trackable urls to TrackableURL.php does the trick so far.

Comments
----------------------------------------
(Another option would have been to insert a metatag in the head of CRM/Mailing/Page/View.php)
