### PR TITLE
Add/Edit Contact - Fix inconsistent capitalization

### DIFF
--- a/templates/CRM/Contact/Form/Edit/Phone.tpl
+++ b/templates/CRM/Contact/Form/Edit/Phone.tpl
@@ -56,7 +56,7 @@
 {if !$addBlock}
 <tr>
   <td colspan="4">
-  &nbsp;&nbsp;<a id='addPhone' href="#" title={ts}Add{/ts} onClick="buildAdditionalBlocks( 'Phone', '{$className}');return false;">{ts}Add another Phone number{/ts}</a>
+  &nbsp;&nbsp;<a id='addPhone' href="#" title={ts}Add{/ts} onClick="buildAdditionalBlocks( 'Phone', '{$className}');return false;">{ts}Add another phone number{/ts}</a>
   </td>
 </tr>
 {/if}


### PR DESCRIPTION
Overview
----------------------------------------
In the "Add/Edit Contact" screen, there are several similar links: "Add another phone number", "Add another IM", "Add another website". They should all be capitalized according the same rules (e.g. standard sentence case).

Before
----------------------------------------

<img width="288" alt="screen shot 2018-02-15 at 10 05 43 am" src="https://user-images.githubusercontent.com/1336047/36273057-28349fb6-1238-11e8-9bf0-445796e30e84.png">

After
----------------------------------------

<img width="289" alt="screen shot 2018-02-15 at 10 07 58 am" src="https://user-images.githubusercontent.com/1336047/36273058-284e55b4-1238-11e8-9ec9-d5833e1e6cca.png">

Technical Details
----------------------------------------
Grammar. Because.
