### PR TITLE
CRM-21759 Remove template variable as not needed and causing issues o…

### DIFF
--- a/ang/crmMailing/Templates.js
+++ b/ang/crmMailing/Templates.js
@@ -7,7 +7,6 @@
           scope: {
             ngRequired: '@'
           },
-          templateUrl: '~/crmMailing/Templates.html',
           link: function(scope, element, attrs, ngModel) {
             scope.template = ngModel.$viewValue;
 


### PR DESCRIPTION
…n Joomla in 4.7.30

Overview
----------------------------------------
in 4.7.30 there is a call to a non existent angular templates file. This means that the Message Templates section of a new mailing doesn't load. 

Before
----------------------------------------
Message Template section doesn't load on Joomla

After
----------------------------------------
Message Template section loads

ping @eileenmcnaughton @lcdservices @monishdeb 