### PR TITLE
dev/civicrm-setup#1: Facilitate more direct installation

### DIFF
--- a/CRM/Core/CodeGen/Specification.php
+++ b/CRM/Core/CodeGen/Specification.php
@@ -16,19 +16,25 @@ class CRM_Core_CodeGen_Specification {
    * @param string $buildVersion
    *   Which version of the schema to build.
    */
-  public function parse($schemaPath, $buildVersion) {
+  public function parse($schemaPath, $buildVersion, $verbose = TRUE) {
     $this->buildVersion = $buildVersion;
 
-    echo "Parsing schema description " . $schemaPath . "\n";
+    if ($verbose) {
+      echo "Parsing schema description " . $schemaPath . "\n";
+    }
     $dbXML = CRM_Core_CodeGen_Util_Xml::parse($schemaPath);
 
-    echo "Extracting database information\n";
+    if ($verbose) {
+      echo "Extracting database information\n";
+    }
     $this->database = &$this->getDatabase($dbXML);
 
     $this->classNames = array();
 
     # TODO: peel DAO-specific stuff out of getTables, and spec reading into its own class
-    echo "Extracting table information\n";
+    if ($verbose) {
+      echo "Extracting table information\n";
+    }
     $this->tables = $this->getTables($dbXML, $this->database);
 
     $this->resolveForeignKeys($this->tables, $this->classNames);
@@ -231,8 +237,6 @@ class CRM_Core_CodeGen_Specification {
       $this->getPrimaryKey($tableXML->primaryKey, $fields, $table);
     }
 
-    // some kind of refresh?
-    CRM_Core_Config::singleton(FALSE);
     if ($this->value('index', $tableXML)) {
       $index = array();
       foreach ($tableXML->index as $indexXML) {

--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -65,7 +65,7 @@ function dm_install_core() {
   local repo="$1"
   local to="$2"
 
-  for dir in ang css i js PEAR templates bin CRM api extern Reports install settings Civi partials release-notes ; do
+  for dir in ang css i js PEAR templates bin CRM api extern Reports install settings Civi partials release-notes xml ; do
     [ -d "$repo/$dir" ] && dm_install_dir "$repo/$dir" "$to/$dir"
   done
 

--- a/xml/GenCode.php
+++ b/xml/GenCode.php
@@ -1,4 +1,9 @@
 <?php
+
+if (PHP_SAPI !== 'cli') {
+  die("GenCode can only be run from command line.");
+}
+
 ini_set('include_path', '.' . PATH_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'packages' . PATH_SEPARATOR . '..');
 // make sure the memory_limit is at least 512 MB
 $memLimitString = trim(ini_get('memory_limit'));


### PR DESCRIPTION
Overview
----------------------------------------
For https://github.com/civicrm/civicrm-setup/issues/1, the general goal is to allow
installing the database schema without needing to run `GenCode`. This PR
includes a handful of supporting changes.

Before
----------------------------------------
* `CRM_Core_CodeGen_Specification` prematurely boots the rest of Civi
* `CRM_Core_CodeGen_Specification` generates extra output that's inappropriate when used in other media (e.g. headless installations or web-based installations)
* `xml/schema`, `xml/templates`, etc are not always available -- so they can't always be read by an installer
* If `xml/GenCode.php` exists, it can be (sorta) called via web (depending on the filesystem setup), so it's not safe to distribute broadly

After
----------------------------------------
* `CRM_Core_CodeGen_Specification` does not need to boot the rest of Civi
* `CRM_Core_CodeGen_Specification` can be silent
* `xml/schema`, `xml/templates`, etc are always available -- so they can always be read by an installer
* `xml/GenCode.php` cannot be executed via web, so it is safe to distribute broadly