### PR TITLE
CRM-21776: Ensure from clause adds custom table when search query is …

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -6418,6 +6418,15 @@ AND   displayRelType.is_active = 1
           break;
 
         default:
+          $cfID = CRM_Core_BAO_CustomField::getKeyID($field);
+          // add to cfIDs array if not present
+          if (!empty($cfID) && !array_key_exists($cfID, $this->_cfIDs)) {
+            $this->_cfIDs[$cfID] = array();
+            $this->_customQuery = new CRM_Core_BAO_CustomQuery($this->_cfIDs, TRUE, $this->_locationSpecificCustomFields);
+            $this->_customQuery->query();
+            $this->_select = array_merge($this->_select, $this->_customQuery->_select);
+            $this->_tables = array_merge($this->_tables, $this->_customQuery->_tables);
+          }
           foreach ($this->_pseudoConstantsSelect as $key => $pseudoConstantMetadata) {
             // By replacing the join to the option value table with the mysql construct
             // ORDER BY field('contribution_status_id', 2,1,4)

--- a/tests/phpunit/CRM/Contact/SelectorTest.php
+++ b/tests/phpunit/CRM/Contact/SelectorTest.php
@@ -174,6 +174,59 @@ class CRM_Contact_Form_SelectorTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test if custom table is added in from clause when
+   * search results are ordered by a custom field.
+   */
+  public function testSelectorQueryOrderByCustomField() {
+    //Search for any params.
+    $params = [[
+      0 => 'country-1',
+      1 => '=',
+      2 => '1228',
+      3 => 1,
+      4 => 0,
+    ]];
+
+    //Create a test custom group and field.
+    $customGroup = $this->callAPISuccess('CustomGroup', 'create', array(
+      'title' => "test custom group",
+      'extends' => "Individual",
+    ));
+    $cgTableName = $customGroup['values'][$customGroup['id']]['table_name'];
+    $customField = $this->callAPISuccess('CustomField', 'create', array(
+      'custom_group_id' => $customGroup['id'],
+      'label' => "test field",
+      'html_type' => "Text",
+    ));
+    $customFieldId = $customField['id'];
+
+    //Sort by the custom field created above.
+    $sortParams = array(
+      1 => array(
+        'name' => 'test field',
+        'sort' => "custom_{$customFieldId}",
+      ),
+    );
+    $sort = new CRM_Utils_Sort($sortParams, '1_d');
+
+    //Form a query to order by a custom field.
+    $query = new CRM_Contact_BAO_Query($params,
+      CRM_Contact_BAO_Query::NO_RETURN_PROPERTIES,
+      NULL, FALSE, FALSE, 1,
+      FALSE, TRUE, TRUE, NULL,
+      'AND'
+    );
+    $query->searchQuery(0, 0, $sort,
+      FALSE, FALSE, FALSE,
+      FALSE, FALSE
+    );
+    //Check if custom table is included in $query->_tables.
+    $this->assertTrue(in_array($cgTableName, array_keys($query->_tables)));
+    //Assert if from clause joins the custom table.
+    $this->assertTrue(strpos($query->_fromClause, $cgTableName) !== FALSE);
+  }
+
+  /**
    * Get the default select string since this is generally consistent.
    */
   public function getDefaultSelectString() {


### PR DESCRIPTION
…ordered by a custom field

Overview
----------------------------------------
Fix DB error displayed after performing any task on advanced search results sorted by custom field

Before
----------------------------------------
Performing any task on Advanced Search returns DB error when the search results are sorted by a custom field. To replicate - See [JIRA issue](https://issues.civicrm.org/jira/browse/CRM-21776) description.

After
----------------------------------------
DB error is fixed. All tasks are performed correctly.

Technical Details
----------------------------------------
Custom table is not included as no return property is sent from the selector to improve the performance in https://github.com/civicrm/civicrm-core/pull/7566.  The function `prepareOrderBy()` seems to be correctly adding specific table values to `$this->_tables[]`. This misses the assignment for custom tables which is added in this PR. 

Comments
----------------------------------------
Added unit test.

---

 * [CRM-21776: DB Error when printing advanced search results sorted by custom field](https://issues.civicrm.org/jira/browse/CRM-21776)