### PR TITLE
CRM-21777 - Set readonly for the fields initialised in civicrm_settings.php

### DIFF
--- a/CRM/Admin/Form/Setting.php
+++ b/CRM/Admin/Form/Setting.php
@@ -105,6 +105,11 @@ class CRM_Admin_Form_Setting extends CRM_Core_Form {
         else {
           $options = NULL;
         }
+        //Load input as readonly whose values are overridden in civicrm.settings.php.
+        if (Civi::settings()->getMandatory($setting)) {
+          $props['html_attributes']['readonly'] = TRUE;
+          $setStatus = TRUE;
+        }
 
         $add = 'add' . $props['quick_form_type'];
         if ($add == 'addElement') {
@@ -146,6 +151,9 @@ class CRM_Admin_Form_Setting extends CRM_Core_Form {
         }
 
       }
+    }
+    if (!empty($setStatus)) {
+      CRM_Core_Session::setStatus("Some fields are loaded as 'readonly' as they have been set (overridden) in civicrm.settings.php.", '', 'info', array('expires' => 0));
     }
     // setting_description should be deprecated - see Mail.tpl for metadata based tpl.
     $this->assign('setting_descriptions', $descriptions);


### PR DESCRIPTION
Overview
----------------------------------------
Load input fields as non-editable which have been initialized in `civicrm.settings.php`. 

Before
----------------------------------------
`Directory Preference` OR `Resource URL` settings initialized in civi settings file are shown as editable in `civicrm/admin/setting/path?reset=1` OR `civicrm/admin/setting/url?reset=1` form.  If a user tries to edit and update the path, it is not saved as value which is already set in civicrm.settings.php gets the preference. Check JIRA for more details.

After
----------------------------------------
Fields initialized in `civicrm.settings.php` are loaded as readonly as it is of no use to load them as editable. Also, a warning is displayed which lets the user know that some fields are already set (overridden) in settings file.

![image](https://user-images.githubusercontent.com/5929648/36300894-0168f2be-1329-11e8-8949-f251b67adf0e.png)

---

 * [CRM-21777: Improve the messaging related to Directories and Resources](https://issues.civicrm.org/jira/browse/CRM-21777)