### PR TITLE
CRM-21778 - Contact image uploaded from drupal webform don't render o…

### DIFF
--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -910,10 +910,16 @@ HTACCESS;
     $imageURL = CRM_Utils_String::unstupifyUrl($imageURL);
     parse_str(parse_url($imageURL, PHP_URL_QUERY), $query);
 
-    $path = CRM_Core_Config::singleton()->customFileUploadDir . $query['photo'];
+    $url = NULL;
+    if (!empty($query['photo'])) {
+      $path = CRM_Core_Config::singleton()->customFileUploadDir . $query['photo'];
+    }
+    else {
+      $path = $url = $imageURL;
+    }
     $mimeType = 'image/' . strtolower(pathinfo($path, PATHINFO_EXTENSION));
 
-    return self::getFileURL($path, $mimeType);
+    return self::getFileURL($path, $mimeType, $url);
   }
 
   /**


### PR DESCRIPTION
…n summary page

Overview
----------------------------------------
Fix display of contact image which is uploaded from a webform.

Before
----------------------------------------
Contact image uploaded from drupal webform doesn't render on the summary page.

![image](https://user-images.githubusercontent.com/5929648/36301604-765bdeea-132b-11e8-8e17-9a3f07b189e2.png)

After
----------------------------------------
Image loads correctly without any notice errors.

Technical Details
----------------------------------------
Image uploaded from a Drupal webform resides in its own webform directory placed at `sites/default/files/webform`. This PR extends `getImageURL()` to look for exact url image if it is not found in our `customFileUploadDir` path.

---

 * [CRM-21778: Contact image uploaded from drupal webform don't render on summary page](https://issues.civicrm.org/jira/browse/CRM-21778)