### PR TITLE
dev/civicrm-setup#1 CRM_Core_I18n - Don't require immediate bootstrap

### DIFF
--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -709,8 +709,8 @@ class CRM_Core_I18n {
  *   the translated string
  */
 function ts($text, $params = array()) {
-  static $config = NULL;
-  static $locale = NULL;
+  static $areSettingsAvailable = FALSE;
+  static $lastLocale = NULL;
   static $i18n = NULL;
   static $function = NULL;
 
@@ -718,17 +718,21 @@ function ts($text, $params = array()) {
     return '';
   }
 
-  if (!$config) {
-    $config = CRM_Core_Config::singleton();
+  // When the settings become available, lookup customTranslateFunction.
+  if (!$areSettingsAvailable) {
+    $areSettingsAvailable = (bool) \Civi\Core\Container::getBootService('settings_manager');
+    if ($areSettingsAvailable) {
+      $config = CRM_Core_Config::singleton();
+      if (isset($config->customTranslateFunction) and function_exists($config->customTranslateFunction)) {
+        $function = $config->customTranslateFunction;
+      }
+    }
   }
 
-  $tsLocale = CRM_Core_I18n::getLocale();
-  if (!$i18n or $locale != $tsLocale) {
+  $activeLocale = CRM_Core_I18n::getLocale();
+  if (!$i18n or $lastLocale != $activeLocale) {
     $i18n = CRM_Core_I18n::singleton();
-    $locale = $tsLocale;
-    if (isset($config->customTranslateFunction) and function_exists($config->customTranslateFunction)) {
-      $function = $config->customTranslateFunction;
-    }
+    $lastLocale = $activeLocale;
   }
 
   if ($function) {


### PR DESCRIPTION
Overview
----------------------------------------
For civicrm/civicrm-setup#1, the general goal is to allow installing the
database schema without needing to run `GenCode`.

The current draft is crashing because the SQL does translation using `ts()`.
But if you try to use `ts()` in a pre-boot environment, it will attempt to
boot automatically so that it can read `$config->customTranslateFunction`.

This is a chicken-egg situation.  We haven't yet reached the phase where the
installer can boot up Civi...  because we don't have the SQL...  but the SQL
can't be generated (translated) because Civi hasn't been booted.

The aim of this patch is to loosen the coupling between `ts()`
and `CRM_Core_Config` so that `ts()` can be used on its own.

> Aside: You might ask how this works today -- basically, `GenCode` does a
> database-less-boot, which placates `ts()`.  However, the `civicrm-setup`
> will eventually need to do full-boot, and AFAIK we don't have any
> situations where one transitions from database-less-boot to full-boot; I
> have a gut fear that such a transition would be its own slipper slope.

Before
----------------------------------------
* On first invocation, `ts()` calls `CRM_Core_Config::singleton()` to probe for `customTranslateFunction`. 
* Thereafter, it uses a short test on a `static` variable to avoid extra lookups.

After
----------------------------------------
* During the first `1..n` invocations (pre-boot), `ts()` calls `getBootService()` to see if we're ready. On the first successful result, it calls `CRM_Core_Config::singleton()` to probe for `customTranslateFunction`.
* Thereafter, it uses a short test on a `static` variable to avoid extra lookups.

Comments
----------------------------------------
For `r-run` testing, I've done a few things:
* Go to "Administer => Localization => Language". Change from `en_US` to `fr_FR` and observe UI displays the new language.
* Go to "Administer => Localization => Language". Enable multi-lingual (`en_US` and `fr_FR`) and enable CMS-language inheritance. In Drupal, setup user preferences. Observe that the active language in Civi tracks the user preference.
* Run `bin/setup.sh -g`. Spot-check `sql/civicrm_data.fr_FR.mysql` to ensure that it contains translated strings.
* In `civicrm.settings.php`, create a function `swedishchef($string)`. Go to "Administer => Localization => Language" and use `swedishchef` as the translation function. Observe that translations use this. 

```php
function swedishchef($string) {
  return "Bork, $string, bork";
}
```

(Note: UI elements in the dashboard are cached and require an explicit refresh to reflect changes in the language settings. The nav-menu gets translated most of the time, but it never seems to use custom-translation-function. However, that's not a new regression -- the same problem occurs without this patch.)
