### PR TITLE
CRM-21427 - Allow to add website if website type is empty

### DIFF
--- a/CRM/Core/BAO/Website.php
+++ b/CRM/Core/BAO/Website.php
@@ -75,6 +75,13 @@ class CRM_Core_BAO_Website extends CRM_Core_DAO_Website {
 
     $ids = self::allWebsites($contactID);
     foreach ($params as $key => $values) { 
+      if (empty($values['id']) && is_array($ids) && !empty($ids)) {
+        foreach ($ids as $id => $value) {
+          if (($value['website_type_id'] == $values['website_type_id'])) {
+            // $values['id'] = $id;
+          }
+        }
+      }
       if (!empty($values['url'])) {
         $values['contact_id'] = $contactID;
         self::add($values);

--- a/CRM/Core/BAO/Website.php
+++ b/CRM/Core/BAO/Website.php
@@ -74,14 +74,7 @@ class CRM_Core_BAO_Website extends CRM_Core_DAO_Website {
     }
 
     $ids = self::allWebsites($contactID);
-    foreach ($params as $key => $values) {
-      if (empty($values['id']) && is_array($ids) && !empty($ids)) {
-        foreach ($ids as $id => $value) {
-          if (($value['website_type_id'] == $values['website_type_id'])) {
-            $values['id'] = $id;
-          }
-        }
-      }
+    foreach ($params as $key => $values) { 
       if (!empty($values['url'])) {
         $values['contact_id'] = $contactID;
         self::add($values);


### PR DESCRIPTION
Overview
For Adding Multiple Website if their type is empty and it allows to add multiple websites if their type is same for example if you want to add 2 facebook id's so with that change you can add

Before
Website will be removed if their website type is empty
 
![before](https://user-images.githubusercontent.com/6084640/36329932-96d3616c-1389-11e8-96d2-c653ba0d4d46.gif)


After
Now user can add if the website type is empty or same
 
![after](https://user-images.githubusercontent.com/6084640/36329936-9b6970a4-1389-11e8-902f-e5010cfeed44.gif)


Technical Details
This issue is happening because of the code where if the same website type appears then it will replace or delete them ... so removing that code allows us to add multi-website if the type is None or if the type is already in Records.
Before [ if there is already facebook type website exists and use insert another facebook type so they will replace the first one with new one ]
After [ user can add both of them as many as user want even if they have same website type ]

---

 * [CRM-21427: Websites are removed from the contact if their type is empty](https://issues.civicrm.org/jira/browse/CRM-21427)