### PR TITLE
Ignore errors when upgrade step already took place

### DIFF
--- a/CRM/Upgrade/Incremental/sql/4.7.28.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.7.28.mysql.tpl
@@ -1,7 +1,7 @@
-{* file to handle db changes in 4.7.27 during upgrade *}
+{* file to handle db changes in 4.7.28 during upgrade *}
 
 -- CRM-21268 Missing French overseas departments.
- INSERT INTO civicrm_state_province (id, country_id, abbreviation, name) VALUES
+ INSERT IGNORE INTO civicrm_state_province (id, country_id, abbreviation, name) VALUES
    (NULL, 1076, "WF", "Wallis-et-Futuna"),
    (NULL, 1076, "NC", "Nouvelle-Calédonie"),
 


### PR DESCRIPTION
Just ran into a hard fail in this upgrade step, so took a minute to fix it.
IMO it's best to do `INSERT IGNORE` when adding missing option values to avoid a hard-fail if that upgrade step has already happened.