### PR TITLE
composer.json - De-fork dependency, marcj/topsort

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
     "totten/ca-config": "~17.05",
     "zetacomponents/base": "1.7.*",
     "zetacomponents/mail": "dev-1.7-civi",
-    "marcj/topsort": "dev-1.0-php53",
+    "marcj/topsort": "~1.1",
     "phpoffice/phpword": "^0.13.0",
     "pear/Validate_Finance_CreditCard": "dev-master",
     "civicrm/civicrm-cxn-rpc": "~0.17.07.01",
@@ -60,10 +60,6 @@
     {
       "type": "git",
       "url": "https://github.com/civicrm/zetacomponents-mail.git"
-    },
-    {
-      "type": "git",
-      "url": "https://github.com/totten/topsort.php.git"
     }
   ],
   "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "3aaaa7a6146043643e9fe2cbc8030cca",
+    "content-hash": "a278afcb51b1e87282f6373cdc313769",
     "packages": [
         {
             "name": "civicrm/civicrm-cxn-rpc",
@@ -184,14 +184,20 @@
         },
         {
             "name": "marcj/topsort",
-            "version": "dev-1.0-php53",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/totten/topsort.php.git",
-                "reference": "2765723d36f0e536d987e42cbc60de52209212bd"
+                "url": "https://github.com/marcj/topsort.php.git",
+                "reference": "387086c2db60ee0a27ac5df588c0f0b30c6bdc4b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/marcj/topsort.php/zipball/387086c2db60ee0a27ac5df588c0f0b30c6bdc4b",
+                "reference": "387086c2db60ee0a27ac5df588c0f0b30c6bdc4b",
+                "shasum": ""
             },
             "require": {
-                "php": ">=5.3"
+                "php": ">=5.4"
             },
             "require-dev": {
                 "codeclimate/php-test-reporter": "dev-master",
@@ -205,6 +211,7 @@
                     "MJS\\TopSort\\Tests\\": "tests/Tests/"
                 }
             },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -220,7 +227,7 @@
                 "topological sort",
                 "topsort"
             ],
-            "time": "2016-03-25 21:38:05"
+            "time": "2016-11-19T14:58:11+00:00"
         },
         {
             "name": "pclzip/pclzip",
@@ -522,7 +529,7 @@
                 }
             ],
             "description": "Validation class for credit cards.",
-            "time": "2016-09-12 08:01:21"
+            "time": "2016-09-12T08:01:21+00:00"
         },
         {
             "name": "phenx/php-font-lib",
@@ -1636,7 +1643,7 @@
             ],
             "description": "The component allows you construct and/or parse Mail messages conforming to  the mail standard. It has support for attachments, multipart messages and HTML  mail. It also interfaces with SMTP to send mail or IMAP, POP3 or mbox to  retrieve e-mail.",
             "homepage": "https://github.com/zetacomponents",
-            "time": "2017-03-14 06:51:24"
+            "time": "2017-03-14T06:51:24+00:00"
         }
     ],
     "packages-dev": [],
@@ -1644,7 +1651,6 @@
     "minimum-stability": "stable",
     "stability-flags": {
         "zetacomponents/mail": 20,
-        "marcj/topsort": 20,
         "pear/validate_finance_creditcard": 20
     },
     "prefer-stable": false,


### PR DESCRIPTION
Overview
----------------------------------------
When this dependency was originally added, we needed a few patches (for PHP 5.3 compatibility)
and initially used a forked version of library. Of course, it's undesirable to use a fork
in the long term (e.g. harder to apply upgrades; harder to merge into other build processes).

In the intervening period, upstream has merged the patches for PHP 5.3, and
we've politely asked downstream to get over PHP 5.3, so we're covered on
both ends.  Let's get back on the mainline branch!

Before
----------------------------------------
`civicrm-core` pulls in a forked build of `marcj/topsort`.

After
----------------------------------------
`civicrm-core` pulls in a conventional build of `marcj/topsort`.

Comments
----------------------------------------
There should be test-coverage in `tests/phpunit/CRM/Extension/` which
touches on core's use of this library.