### PR TITLE
Fix more entities to support custom fields (via api)

### DIFF
--- a/api/v3/AclRole.php
+++ b/api/v3/AclRole.php
@@ -40,7 +40,7 @@
  *   API result array
  */
 function civicrm_api3_acl_role_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'AclRole');
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'EntityRole');
 }
 
 /**

--- a/api/v3/CaseContact.php
+++ b/api/v3/CaseContact.php
@@ -39,7 +39,7 @@
  * @return array
  */
 function civicrm_api3_case_contact_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'CaseContact');
 }
 
 /**

--- a/api/v3/ContributionProduct.php
+++ b/api/v3/ContributionProduct.php
@@ -43,7 +43,7 @@
  * @return array
  */
 function civicrm_api3_contribution_product_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'ContributionProduct');
 }
 
 /**

--- a/api/v3/ContributionSoft.php
+++ b/api/v3/ContributionSoft.php
@@ -41,7 +41,7 @@
  *   API result array
  */
 function civicrm_api3_contribution_soft_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'ContributionSoft');
 }
 
 /**

--- a/api/v3/Dashboard.php
+++ b/api/v3/Dashboard.php
@@ -73,11 +73,7 @@ function _civicrm_api3_dashboard_create_spec(&$params) {
  * @return array
  */
 function civicrm_api3_dashboard_get($params) {
-  // NEVER COPY THIS. No idea why a newish api would not use basic_get.
-  $bao = new CRM_Core_BAO_Dashboard();
-  _civicrm_api3_dao_set_filter($bao, $params, TRUE);
-  $dashlets = _civicrm_api3_dao_to_array($bao, $params, TRUE, 'Dashboard');
-  return civicrm_api3_create_success($dashlets, $params, 'Dashboard', 'get', $bao);
+  return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
 }
 
 /**

--- a/api/v3/DashboardContact.php
+++ b/api/v3/DashboardContact.php
@@ -51,7 +51,7 @@ function civicrm_api3_dashboard_contact_create($params) {
   if ($errors !== NULL) {
     return $errors;
   }
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'DashboardContact');
 }
 
 /**

--- a/api/v3/EntityBatch.php
+++ b/api/v3/EntityBatch.php
@@ -66,7 +66,7 @@ function _civicrm_api3_entity_batch_create_spec(&$params) {
  * @return array
  */
 function civicrm_api3_entity_batch_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'EntityBatch');
 }
 
 /**

--- a/api/v3/EntityFinancialTrxn.php
+++ b/api/v3/EntityFinancialTrxn.php
@@ -39,7 +39,7 @@
  * @return array
  */
 function civicrm_api3_entity_financial_trxn_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'EntityFinancialTrxn');
 }
 
 /**

--- a/api/v3/Im.php
+++ b/api/v3/Im.php
@@ -39,7 +39,7 @@
  * @return array
  */
 function civicrm_api3_im_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'IM');
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'Im');
 }
 
 /**

--- a/api/v3/Job.php
+++ b/api/v3/Job.php
@@ -58,7 +58,7 @@ function _civicrm_api3_job_create_spec(&$params) {
  * @return array
  */
 function civicrm_api3_job_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'Job');
 }
 
 /**

--- a/api/v3/LocationType.php
+++ b/api/v3/LocationType.php
@@ -45,7 +45,7 @@ function civicrm_api3_location_type_create($params) {
     $params['display_name'] = $params['name'];
   }
 
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'LocationType');
 }
 
 /**

--- a/api/v3/MailSettings.php
+++ b/api/v3/MailSettings.php
@@ -41,7 +41,7 @@
  *   API result array.
  */
 function civicrm_api3_mail_settings_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'MailSettings');
 }
 
 /**

--- a/api/v3/MailingAB.php
+++ b/api/v3/MailingAB.php
@@ -50,7 +50,7 @@ function _civicrm_api3_mailing_a_b_create_spec(&$spec) {
  *   API Success Array
  */
 function civicrm_api3_mailing_a_b_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'MailingAB');
 }
 
 /**

--- a/api/v3/MailingComponent.php
+++ b/api/v3/MailingComponent.php
@@ -41,7 +41,7 @@
  *   API result array.
  */
 function civicrm_api3_mailing_component_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'Component');
 }
 
 

--- a/api/v3/MailingEventQueue.php
+++ b/api/v3/MailingEventQueue.php
@@ -50,7 +50,7 @@ function civicrm_api3_mailing_event_queue_create($params) {
     array('job_id', 'contact_id'),
     FALSE
   );
-  return _civicrm_api3_basic_create('CRM_Mailing_Event_BAO_Queue', $params);
+  return _civicrm_api3_basic_create('CRM_Mailing_Event_BAO_Queue', $params, 'Queue');
 }
 
 /**

--- a/api/v3/MappingField.php
+++ b/api/v3/MappingField.php
@@ -40,7 +40,7 @@
  * @return array
  */
 function civicrm_api3_mapping_field_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'MappingField');
 }
 
 /**

--- a/api/v3/MembershipLog.php
+++ b/api/v3/MembershipLog.php
@@ -41,7 +41,7 @@
  *   API result array.
  */
 function civicrm_api3_membership_log_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'MembershipLog');
 }
 
 /**

--- a/api/v3/MembershipPayment.php
+++ b/api/v3/MembershipPayment.php
@@ -42,7 +42,7 @@
  *   API result array.
  */
 function civicrm_api3_membership_payment_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'MembershipPayment');
 }
 
 /**

--- a/api/v3/MessageTemplate.php
+++ b/api/v3/MessageTemplate.php
@@ -40,7 +40,7 @@
  * @throws \API_Exception
  */
 function civicrm_api3_message_template_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'MessageTemplate');
 }
 
 /**

--- a/api/v3/Navigation.php
+++ b/api/v3/Navigation.php
@@ -109,7 +109,7 @@ function _civicrm_api3_navigation_create_spec(&$params) {
  */
 function civicrm_api3_navigation_create($params) {
   civicrm_api3_verify_one_mandatory($params, NULL, array('name', 'label'));
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'Navigation');
 }
 
 /**

--- a/api/v3/Note.php
+++ b/api/v3/Note.php
@@ -44,7 +44,7 @@
  *   API result array
  */
 function civicrm_api3_note_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'Note');
 }
 
 /**

--- a/api/v3/OpenID.php
+++ b/api/v3/OpenID.php
@@ -40,7 +40,7 @@
  *   API result array
  */
 function civicrm_api3_open_i_d_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'OpenID');
 }
 
 /**

--- a/api/v3/OptionGroup.php
+++ b/api/v3/OptionGroup.php
@@ -53,7 +53,7 @@ function civicrm_api3_option_group_get($params) {
  * @return array
  */
 function civicrm_api3_option_group_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'OptionGroup');
 }
 
 /**

--- a/api/v3/OptionValue.php
+++ b/api/v3/OptionValue.php
@@ -42,7 +42,7 @@
  *   API result array
  */
 function civicrm_api3_option_value_get($params) {
-  return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'OptionValue');
 }
 
 /**

--- a/api/v3/ParticipantStatusType.php
+++ b/api/v3/ParticipantStatusType.php
@@ -45,7 +45,7 @@
  *   participant_status array
  */
 function civicrm_api3_participant_status_type_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'ParticipantStatusType');
 }
 
 /**

--- a/api/v3/Premium.php
+++ b/api/v3/Premium.php
@@ -44,7 +44,7 @@
  * @return array
  */
 function civicrm_api3_premium_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'Premium');
 }
 
 /**

--- a/api/v3/PrintLabel.php
+++ b/api/v3/PrintLabel.php
@@ -39,7 +39,7 @@
  * @return array
  */
 function civicrm_api3_print_label_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'PrintLabel');
 }
 
 /**

--- a/api/v3/Product.php
+++ b/api/v3/Product.php
@@ -43,7 +43,7 @@
  * @return array
  */
 function civicrm_api3_product_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'Product');
 }
 
 /**

--- a/api/v3/ReportInstance.php
+++ b/api/v3/ReportInstance.php
@@ -53,7 +53,7 @@ function civicrm_api3_report_instance_get($params) {
  *   API result array
  */
 function civicrm_api3_report_instance_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'ReportInstance');
 }
 
 /**

--- a/api/v3/RuleGroup.php
+++ b/api/v3/RuleGroup.php
@@ -43,7 +43,7 @@
  *   API result array
  */
 function civicrm_api3_rule_group_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'RuleGroup');
 }
 
 /**

--- a/api/v3/SavedSearch.php
+++ b/api/v3/SavedSearch.php
@@ -60,7 +60,7 @@ function civicrm_api3_saved_search_create($params) {
     }
   }
 
-  $result = _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  $result = _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'SavedSearch');
   _civicrm_api3_saved_search_result_cleanup($result);
   return $result;
 }

--- a/api/v3/SmsProvider.php
+++ b/api/v3/SmsProvider.php
@@ -39,7 +39,7 @@
  * @return array
  */
 function civicrm_api3_sms_provider_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'Provider');
 }
 
 /**

--- a/api/v3/StateProvince.php
+++ b/api/v3/StateProvince.php
@@ -42,7 +42,7 @@
  * @throws \API_Exception
  */
 function civicrm_api3_state_province_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_DAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_DAO(__FUNCTION__), $params, 'StateProvince');
 }
 
 /**


### PR DESCRIPTION
Overview
----------------------------------------
This moves us closer to the goal of being able to define custom data on 'any entity'. It takes us from a limited list of ones that work to a longer list of ones that still don't work

Before
----------------------------------------
Small list of entities that can have custom data added.

After
----------------------------------------
Most entities can have custom data added

Technical Details
----------------------------------------
I would really like to be able to say 'custom data works on any entity in 5.0.0.0' when it is released in April. However, per the list in the test there are still a few that don't work (about 10-15% I think).

Comments
----------------------------------------

Am also adding a fix to GroupOrganization so it supports 'update with id' as this BAO needed some tweaks