### PR TITLE
Fix GroupNesting, GroupOrganization, Domain to work with singleValueAlter

### DIFF
--- a/CRM/Contact/BAO/ContactType.php
+++ b/CRM/Contact/BAO/ContactType.php
@@ -654,12 +654,11 @@ WHERE name = %1";
     }
 
     if (!empty($params['id'])) {
-      $params = array('name' => "New $contactName");
       $newParams = array(
         'label' => "New $contact",
         'is_active' => $active,
       );
-      CRM_Core_BAO_Navigation::processUpdate($params, $newParams);
+      CRM_Core_BAO_Navigation::processUpdate(['name' => "New $contactName"], $newParams);
     }
     else {
       $name = self::getBasicType($contactName);

--- a/CRM/Contact/BAO/GroupNesting.php
+++ b/CRM/Contact/BAO/GroupNesting.php
@@ -34,6 +34,28 @@
 class CRM_Contact_BAO_GroupNesting extends CRM_Contact_DAO_GroupNesting {
 
   /**
+   * Add Dashboard.
+   *
+   * @param array $params
+   *   Values.
+   *
+   *
+   * @return object
+   */
+  public static function create($params) {
+    $hook = empty($params['id']) ? 'create' : 'edit';
+    CRM_Utils_Hook::pre($hook, 'GroupNesting', CRM_Utils_Array::value('id', $params), $params);
+    $dao = new CRM_Contact_BAO_GroupNesting();
+    $dao->copyValues($params);
+    if (empty($params['id'])) {
+      $dao->find(TRUE);
+    }
+    $dao->save();
+    CRM_Utils_Hook::post($hook, 'GroupNesting', $dao->id, $dao);
+    return $dao;
+  }
+
+  /**
    * Adds a new group nesting record.
    *
    * @param int $parentID

--- a/CRM/Contact/BAO/GroupOrganization.php
+++ b/CRM/Contact/BAO/GroupOrganization.php
@@ -48,41 +48,22 @@ class CRM_Contact_BAO_GroupOrganization extends CRM_Contact_DAO_GroupOrganizatio
    * @return CRM_Contact_DAO_GroupOrganization
    */
   public static function add(&$params) {
-    $formattedValues = array();
-    self::formatValues($params, $formattedValues);
-    $dataExists = self::dataExists($formattedValues);
-    if (!$dataExists) {
+    if (!empty($params['group_organization'])) {
+      $params['id'] = $params['group_organization'];
+    }
+    $dataExists = self::dataExists($params);
+    if (!$dataExists && empty($params['id'])) {
       return NULL;
     }
     $groupOrganization = new CRM_Contact_DAO_GroupOrganization();
-    $groupOrganization->copyValues($formattedValues);
-    // we have ensured we have group_id & organization_id so we can do a find knowing that
-    // this can only find a matching record
-    $groupOrganization->find(TRUE);
+    $groupOrganization->copyValues($params);
+    if (!isset($params['id'])) {
+      // we have ensured we have group_id & organization_id so we can do a find knowing that
+      // this can only find a matching record
+      $groupOrganization->find(TRUE);
+    }
     $groupOrganization->save();
     return $groupOrganization;
-  }
-
-  /**
-   * Format the params.
-   *
-   * @param array $params
-   *   (reference ) an assoc array of name/value pairs.
-   * @param array $formatedValues
-   *   (reference ) an assoc array of name/value pairs.
-   */
-  public static function formatValues(&$params, &$formatedValues) {
-    if (!empty($params['group_organization'])) {
-      $formatedValues['id'] = $params['group_organization'];
-    }
-
-    if (!empty($params['group_id'])) {
-      $formatedValues['group_id'] = $params['group_id'];
-    }
-
-    if (!empty($params['organization_id'])) {
-      $formatedValues['organization_id'] = $params['organization_id'];
-    }
   }
 
   /**

--- a/CRM/Core/BAO/Domain.php
+++ b/CRM/Core/BAO/Domain.php
@@ -142,7 +142,7 @@ class CRM_Core_BAO_Domain extends CRM_Core_DAO_Domain {
    */
   public static function create($params) {
     $domain = new CRM_Core_DAO_Domain();
-    $domain->copyValues($params);
+    $domain->copyValues($params, TRUE);
     $domain->save();
     return $domain;
   }

--- a/api/v3/Batch.php
+++ b/api/v3/Batch.php
@@ -39,7 +39,7 @@
  * @return array
  */
 function civicrm_api3_batch_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'Batch');
 }
 
 /**

--- a/api/v3/ContactType.php
+++ b/api/v3/ContactType.php
@@ -75,7 +75,6 @@ function civicrm_api3_contact_type_create($params) {
  *   Array of matching contact_types
  */
 function civicrm_api3_contact_type_get($params) {
-  civicrm_api3_verify_mandatory($params);
   return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
 }
 

--- a/api/v3/Country.php
+++ b/api/v3/Country.php
@@ -42,7 +42,7 @@
  * @throws \API_Exception
  */
 function civicrm_api3_country_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_DAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_DAO(__FUNCTION__), $params, 'Country');
 }
 
 /**

--- a/api/v3/FinancialItem.php
+++ b/api/v3/FinancialItem.php
@@ -39,7 +39,7 @@
  * @return array
  */
 function civicrm_api3_financial_item_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'FinancialItem');
 }
 
 /**

--- a/api/v3/GroupNesting.php
+++ b/api/v3/GroupNesting.php
@@ -55,15 +55,10 @@ function civicrm_api3_group_nesting_get($params) {
  *   Parameters array - allowed array keys include:.
  *
  * @return array
- *   TBD
- * @todo Work out the return value.
+ *   API success array
  */
 function civicrm_api3_group_nesting_create($params) {
-  CRM_Contact_BAO_GroupNesting::add($params['parent_group_id'], $params['child_group_id']);
-
-  // FIXME: CRM_Contact_BAO_GroupNesting requires some work
-  $result = array('is_error' => 0);
-  return civicrm_api3_create_success($result, $params, 'GroupNesting');
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'GroupNesting');
 }
 
 /**

--- a/api/v3/GroupOrganization.php
+++ b/api/v3/GroupOrganization.php
@@ -55,14 +55,7 @@ function civicrm_api3_group_organization_get($params) {
  */
 function civicrm_api3_group_organization_create($params) {
 
-  $groupOrgBAO = CRM_Contact_BAO_GroupOrganization::add($params);
-
-  if (is_null($groupOrgBAO)) {
-    return civicrm_api3_create_error("group organization not created");
-  }
-
-  _civicrm_api3_object_to_array($groupOrgBAO, $values);
-  return civicrm_api3_create_success($values, $params, 'GroupOrganization', 'get', $groupOrgBAO);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'GroupOrganization');
 }
 
 /**

--- a/api/v3/MembershipType.php
+++ b/api/v3/MembershipType.php
@@ -47,7 +47,7 @@ function civicrm_api3_membership_type_create($params) {
       $params[$field] = implode(CRM_Core_DAO::VALUE_SEPARATOR, $params[$field]);
     }
   }
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'Membership_type');
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'MembershipType');
 }
 
 /**

--- a/api/v3/StatusPreference.php
+++ b/api/v3/StatusPreference.php
@@ -39,7 +39,7 @@
  * @return array
  */
 function civicrm_api3_status_preference_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'StatusPreference');
 }
 
 /**

--- a/api/v3/Tag.php
+++ b/api/v3/Tag.php
@@ -48,7 +48,7 @@
  *   API result array
  */
 function civicrm_api3_tag_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'Tag');
 }
 
 /**

--- a/api/v3/WordReplacement.php
+++ b/api/v3/WordReplacement.php
@@ -55,7 +55,7 @@ function civicrm_api3_word_replacement_get($params) {
  * @return array
  */
 function civicrm_api3_word_replacement_create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'WordReplacement');
 }
 
 /**

--- a/tests/phpunit/api/v3/GroupOrganizationTest.php
+++ b/tests/phpunit/api/v3/GroupOrganizationTest.php
@@ -80,7 +80,7 @@ class api_v3_GroupOrganizationTest extends CiviUnitTestCase {
       'sequential' => 1,
     );
     $getResult = $this->callAPISuccess('group_organization', 'get', $getParams);
-    $this->assertEquals($createResult['values'], $getResult['values'][0]);
+    $this->assertEquals($createResult['values'][$createResult['id']], $getResult['values'][0]);
   }
 
   /**

--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -438,7 +438,6 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
       'Constant',
       'Entity',
       'Location',
-      'Domain',
       'Profile',
       'CustomValue',
       'SurveyRespondant',
@@ -452,8 +451,6 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
       'OptionGroup',
       'Membership',
       'Group',
-      'GroupOrganization',
-      'GroupNesting',
       'File',
       'EntityTag',
       'CustomField',
@@ -573,6 +570,7 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
           'definition',
         ),
       ),
+      'Domain' => ['cant_update' => ['domain_version']],
       'MembershipBlock' => array(
         'cant_update' => array(
           // The fake/auto-generated values leave us unable to properly cleanup fake data


### PR DESCRIPTION
Overview
----------------------------------------
Standardise apis for GroupNesting, GroupOrganization, Domain and extend unit testing to cover them

Before
----------------------------------------
per overview

After
----------------------------------------
per overview


Technical Details
----------------------------------------
ContactType - $params was being overwritten (passed by reference) for no good reason
Group Nesting - did not support 'id' as a parameter. I added a create function which takes predecence over add in the api
GroupOrganization - did not really support id as a parameter. Did weird things when passed incl e-notice
Domain - now using dao metadata serialization handling

Comments
----------------------------------------
The GroupOrganization api test needed to be altered, indicating the return array was originally not correctly formatted. I feel Ok about fixing this as the format is so clearly established in general.
