### PR TITLE
CRM-21781 Don't crash CiviCRM when missing contact ID

### DIFF
--- a/CRM/Contact/Page/View.php
+++ b/CRM/Contact/Page/View.php
@@ -85,7 +85,7 @@ class CRM_Contact_Page_View extends CRM_Core_Page {
     $gcid = CRM_Utils_Request::retrieve('gcid', 'Positive', $this);
 
     if (!$gcid) {
-      $this->_contactId = CRM_Utils_Request::retrieve('cid', 'Positive', $this, TRUE);
+      $this->_contactId = CRM_Utils_Request::retrieve('cid', 'Positive', $this);
     }
     else {
       $this->_contactId = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_GroupContact', $gcid, 'contact_id');


### PR DESCRIPTION
Overview
----------------------------------------
In various situations you end up at civicrm/contact/view without URL parameters (for example logging back in after session expiry).  Currently this crashes CiviCRM with a fatal error.

This PR changes it so that instead it bounces back to the Civi dashboard, improving the user experience.

Before
----------------------------------------
Browse to civicrm/contact/view and civi crashes

After
----------------------------------------
Browse to civicrm/contact/view and civi bounces back to the dashboard and gives a status message indicating that contact ID was not found.

---

 * [CRM-21781: Don't crash if contact ID not found when viewing contact](https://issues.civicrm.org/jira/browse/CRM-21781)