### PR TITLE
CRM-21391 Convert Activity to use core Task class

### DIFF
--- a/CRM/Activity/Form/Search.php
+++ b/CRM/Activity/Form/Search.php
@@ -170,9 +170,7 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
         $this->addRowSelectors($rows);
       }
 
-      $permission = CRM_Core_Permission::getPermission();
-
-      $this->addTaskMenu(CRM_Activity_Task::permissionedTaskTitles($permission));
+      $this->addTaskMenu(CRM_Activity_Task::permissionedTaskTitles(CRM_Core_Permission::getPermission()));
     }
 
   }

--- a/CRM/Activity/Task.php
+++ b/CRM/Activity/Task.php
@@ -33,28 +33,9 @@
 /**
  * Class to represent the actions that can be performed on a group of contacts used by the search forms.
  */
-class CRM_Activity_Task {
-  const
-    DELETE_ACTIVITIES = 1,
-    PRINT_ACTIVITIES = 2,
-    EXPORT_ACTIVITIES = 3,
-    BATCH_ACTIVITIES = 4,
-    EMAIL_CONTACTS = 5,
-    EMAIL_SMS = 6;
+class CRM_Activity_Task extends CRM_Core_Task {
 
-  /**
-   * The task array.
-   *
-   * @var array
-   */
-  static $_tasks = NULL;
-
-  /**
-   * The optional task array.
-   *
-   * @var array
-   */
-  static $_optionalTasks = NULL;
+  static $objectType = 'activity';
 
   /**
    * These tasks are the core set of tasks that the user can perform
@@ -63,20 +44,20 @@ class CRM_Activity_Task {
    * @return array
    *   the set of tasks for a group of contacts
    */
-  public static function &tasks() {
+  public static function tasks() {
     if (!(self::$_tasks)) {
       self::$_tasks = array(
-        1 => array(
+        self::TASK_DELETE => array(
           'title' => ts('Delete activities'),
           'class' => 'CRM_Activity_Form_Task_Delete',
           'result' => FALSE,
         ),
-        2 => array(
+        self::TASK_PRINT => array(
           'title' => ts('Print selected rows'),
           'class' => 'CRM_Activity_Form_Task_Print',
           'result' => FALSE,
         ),
-        3 => array(
+        self::TASK_EXPORT => array(
           'title' => ts('Export activities'),
           'class' => array(
             'CRM_Export_Form_Select',
@@ -84,7 +65,7 @@ class CRM_Activity_Task {
           ),
           'result' => FALSE,
         ),
-        4 => array(
+        self::BATCH_UPDATE => array(
           'title' => ts('Update multiple activities'),
           'class' => array(
             'CRM_Activity_Form_Task_PickProfile',
@@ -92,7 +73,7 @@ class CRM_Activity_Task {
           ),
           'result' => FALSE,
         ),
-        5 => array(
+        self::TASK_EMAIL => array(
           'title' => ts('Email - send now (to %1 or less)', array(
             1 => Civi::settings()
               ->get('simple_mail_limit'),
@@ -103,17 +84,17 @@ class CRM_Activity_Task {
           ),
           'result' => FALSE,
         ),
-        6 => array(
+        self::TASK_SMS => array(
           'title' => ts('SMS - send reply'),
           'class' => 'CRM_Activity_Form_Task_SMS',
           'result' => FALSE,
         ),
-        7 => array(
+        self::TAG_ADD => array(
           'title' => ts('Tag - add to activities'),
           'class' => 'CRM_Activity_Form_Task_AddToTag',
           'result' => FALSE,
         ),
-        8 => array(
+        self::TAG_REMOVE => array(
           'title' => ts('Tag - remove from activities'),
           'class' => 'CRM_Activity_Form_Task_RemoveFromTag',
           'result' => FALSE,
@@ -125,7 +106,7 @@ class CRM_Activity_Task {
         if (CRM_Core_Permission::check('access all cases and activities') ||
           CRM_Core_Permission::check('access my cases and activities')
         ) {
-          self::$_tasks[6] = array(
+          self::$_tasks[self::TASK_SMS] = array(
             'title' => ts('File on case'),
             'class' => 'CRM_Activity_Form_Task_FileOnCase',
             'result' => FALSE,
@@ -135,54 +116,40 @@ class CRM_Activity_Task {
 
       // CRM-4418, check for delete
       if (!CRM_Core_Permission::check('delete activities')) {
-        unset(self::$_tasks[1]);
+        unset(self::$_tasks[self::TASK_DELETE]);
       }
 
-      CRM_Utils_Hook::searchTasks('activity', self::$_tasks);
-      asort(self::$_tasks);
+      parent::tasks();
     }
 
     return self::$_tasks;
   }
 
   /**
-   * These tasks are the core set of task titles on activity.
-   *
-   * @return array
-   *   the set of task titles
-   */
-  public static function &taskTitles() {
-    self::tasks();
-    $titles = array();
-    foreach (self::$_tasks as $id => $value) {
-      $titles[$id] = $value['title'];
-    }
-    return $titles;
-  }
-
-  /**
    * Show tasks selectively based on the permission level of the user.
    *
    * @param int $permission
+   * @param array $params
    *
    * @return array
    *   set of tasks that are valid for the user
    */
-  public static function &permissionedTaskTitles($permission) {
-    $tasks = array();
+  public static function permissionedTaskTitles($permission, $params = array()) {
     if ($permission == CRM_Core_Permission::EDIT) {
       $tasks = self::taskTitles();
     }
     else {
       $tasks = array(
-        3 => self::$_tasks[3]['title'],
+        self::TASK_EXPORT => self::$_tasks[self::TASK_EXPORT]['title'],
       );
 
       //CRM-4418,
       if (CRM_Core_Permission::check('delete activities')) {
-        $tasks[1] = self::$_tasks[1]['title'];
+        $tasks[self::TASK_DELETE] = self::$_tasks[self::TASK_DELETE]['title'];
       }
     }
+
+    $tasks = parent::corePermissionedTaskTitles($tasks, $permission, $params);
     return $tasks;
   }
 
@@ -198,8 +165,9 @@ class CRM_Activity_Task {
     self::tasks();
     if (!$value || !CRM_Utils_Array::value($value, self::$_tasks)) {
       // make the print task by default
-      $value = 2;
+      $value = self::TASK_PRINT;
     }
+
     return array(
       self::$_tasks[$value]['class'],
       self::$_tasks[$value]['result'],


### PR DESCRIPTION
Overview
----------------------------------------
Refactor activity form to use base class

Before
----------------------------------------
![screenshot 2018-02-20 11 09 30](https://user-images.githubusercontent.com/336308/36399031-e797323e-162e-11e8-88d7-0f0a8f2a9092.png)


After
----------------------------------------
No change - this is the desired outcome 
![screenshot 2018-02-20 11 10 37](https://user-images.githubusercontent.com/336308/36399036-eca75e98-162e-11e8-8f5e-55ee36b89cb0.png)


Technical Details
----------------------------------------
details in #11240 

Comments
----------------------------------------
This is a commit from #11240 that I have reviewed & am merging. As there is a lot in that PR I am trying to chip away at the review.

In terms of review I checked that the code was a positive improvement and tested a couple of actions as well as checking the same number of actions were present

---

 * [CRM-21391: Refactor tasks to use a base class](https://issues.civicrm.org/jira/browse/CRM-21391)