### PR TITLE
CRM-21391 Convert Contribute to use core Task class

### DIFF
--- a/CRM/Contribute/Form/Search.php
+++ b/CRM/Contribute/Form/Search.php
@@ -179,11 +179,11 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
       $permission = CRM_Core_Permission::getPermission();
 
       $queryParams = $this->get('queryParams');
-      $softCreditFiltering = FALSE;
+      $taskParams['softCreditFiltering'] = FALSE;
       if (!empty($queryParams)) {
-        $softCreditFiltering = CRM_Contribute_BAO_Query::isSoftCreditOptionEnabled($queryParams);
+        $taskParams['softCreditFiltering'] = CRM_Contribute_BAO_Query::isSoftCreditOptionEnabled($queryParams);
       }
-      $tasks = CRM_Contribute_Task::permissionedTaskTitles($permission, $softCreditFiltering);
+      $tasks = CRM_Contribute_Task::permissionedTaskTitles($permission, $taskParams);
       $this->addTaskMenu($tasks);
     }
 

--- a/CRM/Contribute/Task.php
+++ b/CRM/Contribute/Task.php
@@ -36,22 +36,16 @@
  *
  * Used by the search forms.
  */
-class CRM_Contribute_Task {
-  const DELETE_CONTRIBUTIONS = 1, PRINT_CONTRIBUTIONS = 2, EXPORT_CONTRIBUTIONS = 3, BATCH_CONTRIBUTIONS = 4, EMAIL_CONTACTS = 5, UPDATE_STATUS = 6, PDF_RECEIPT = 7;
+class CRM_Contribute_Task extends CRM_Core_Task {
 
-  /**
-   * The task array
-   *
-   * @var array
-   */
-  static $_tasks = NULL;
+  const
+    // Contribution tasks
+    UPDATE_STATUS = 401,
+    PDF_RECEIPT = 402,
+    PDF_THANKYOU = 403,
+    PDF_INVOICE = 404;
 
-  /**
-   * The optional task array
-   *
-   * @var array
-   */
-  static $_optionalTasks = NULL;
+  static $objectType = 'contribution';
 
   /**
    * These tasks are the core set of tasks that the user can perform
@@ -63,17 +57,17 @@ class CRM_Contribute_Task {
   public static function tasks() {
     if (!(self::$_tasks)) {
       self::$_tasks = array(
-        1 => array(
+        self::TASK_DELETE => array(
           'title' => ts('Delete contributions'),
           'class' => 'CRM_Contribute_Form_Task_Delete',
           'result' => FALSE,
         ),
-        2 => array(
+        self::TASK_PRINT => array(
           'title' => ts('Print selected rows'),
           'class' => 'CRM_Contribute_Form_Task_Print',
           'result' => FALSE,
         ),
-        3 => array(
+        self::TASK_EXPORT => array(
           'title' => ts('Export contributions'),
           'class' => array(
             'CRM_Export_Form_Select',
@@ -81,7 +75,7 @@ class CRM_Contribute_Task {
           ),
           'result' => FALSE,
         ),
-        4 => array(
+        self::BATCH_UPDATE => array(
           'title' => ts('Update multiple contributions'),
           'class' => array(
             'CRM_Contribute_Form_Task_PickProfile',
@@ -89,7 +83,7 @@ class CRM_Contribute_Task {
           ),
           'result' => TRUE,
         ),
-        5 => array(
+        self::TASK_EMAIL => array(
           'title' => ts('Email - send now (to %1 or less)', array(
             1 => Civi::settings()
               ->get('simple_mail_limit'),
@@ -97,22 +91,22 @@ class CRM_Contribute_Task {
           'class' => 'CRM_Contribute_Form_Task_Email',
           'result' => TRUE,
         ),
-        6 => array(
+        self::UPDATE_STATUS => array(
           'title' => ts('Update pending contribution status'),
           'class' => 'CRM_Contribute_Form_Task_Status',
           'result' => TRUE,
         ),
-        7 => array(
+        self::PDF_RECEIPT => array(
           'title' => ts('Receipts - print or email'),
           'class' => 'CRM_Contribute_Form_Task_PDF',
           'result' => FALSE,
         ),
-        8 => array(
+        self::PDF_THANKYOU => array(
           'title' => ts('Thank-you letters - print or email'),
           'class' => 'CRM_Contribute_Form_Task_PDFLetter',
           'result' => FALSE,
         ),
-        9 => array(
+        self::PDF_INVOICE => array(
           'title' => ts('Invoices - print or email'),
           'class' => 'CRM_Contribute_Form_Task_Invoice',
           'result' => FALSE,
@@ -121,41 +115,24 @@ class CRM_Contribute_Task {
 
       //CRM-4418, check for delete
       if (!CRM_Core_Permission::check('delete in CiviContribute')) {
-        unset(self::$_tasks[1]);
+        unset(self::$_tasks[self::TASK_DELETE]);
       }
       //CRM-12920 - check for edit permission
       if (!CRM_Core_Permission::check('edit contributions')) {
-        unset(self::$_tasks[4], self::$_tasks[6]);
+        unset(self::$_tasks[self::BATCH_UPDATE], self::$_tasks[self::UPDATE_STATUS]);
       }
 
       // remove action "Invoices - print or email"
       $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
       $invoicing = CRM_Utils_Array::value('invoicing', $invoiceSettings);
       if (!$invoicing) {
-        unset(self::$_tasks[9]);
+        unset(self::$_tasks[self::PDF_INVOICE]);
       }
 
-      CRM_Utils_Hook::searchTasks('contribution', self::$_tasks);
-      asort(self::$_tasks);
+      parent::tasks();
     }
 
     return self::$_tasks;
-  }
-
-  /**
-   * These tasks are the core set of task titles
-   * on contributors
-   *
-   * @return array
-   *   the set of task titles
-   */
-  public static function &taskTitles() {
-    self::tasks();
-    $titles = array();
-    foreach (self::$_tasks as $id => $value) {
-      $titles[$id] = $value['title'];
-    }
-    return $titles;
   }
 
   /**
@@ -164,13 +141,16 @@ class CRM_Contribute_Task {
    *
    * @param int $permission
    *
-   * @param bool $softCreditFiltering
+   * @param array $params
+   *              bool softCreditFiltering: derived from CRM_Contribute_BAO_Query::isSoftCreditOptionEnabled
    *
    * @return array
    *   set of tasks that are valid for the user
    */
-  public static function &permissionedTaskTitles($permission, $softCreditFiltering = FALSE) {
-    $tasks = array();
+  public static function permissionedTaskTitles($permission, $params = array()) {
+    if (!isset($params['softCreditFiltering'])) {
+      $params['softCreditFiltering'] = FALSE;
+    }
     if (($permission == CRM_Core_Permission::EDIT)
       || CRM_Core_Permission::check('edit contributions')
     ) {
@@ -178,19 +158,21 @@ class CRM_Contribute_Task {
     }
     else {
       $tasks = array(
-        3 => self::$_tasks[3]['title'],
-        5 => self::$_tasks[5]['title'],
-        7 => self::$_tasks[7]['title'],
+        self::TASK_EXPORT => self::$_tasks[self::TASK_EXPORT]['title'],
+        self::TASK_EMAIL => self::$_tasks[self::TASK_EMAIL]['title'],
+        self::PDF_RECEIPT => self::$_tasks[self::PDF_RECEIPT]['title'],
       );
 
       //CRM-4418,
       if (CRM_Core_Permission::check('delete in CiviContribute')) {
-        $tasks[1] = self::$_tasks[1]['title'];
+        $tasks[self::TASK_DELETE] = self::$_tasks[self::TASK_DELETE]['title'];
       }
     }
-    if ($softCreditFiltering) {
-      unset($tasks[4], $tasks[7]);
+    if ($params['softCreditFiltering']) {
+      unset($tasks[self::BATCH_UPDATE], $tasks[self::PDF_RECEIPT]);
     }
+
+    $tasks = parent::corePermissionedTaskTitles($tasks, $permission, $params);
     return $tasks;
   }
 
@@ -207,17 +189,9 @@ class CRM_Contribute_Task {
     self::tasks();
     if (!$value || !CRM_Utils_Array::value($value, self::$_tasks)) {
       // make the print task by default
-      $value = 2;
+      $value = self::TASK_PRINT;
     }
-    // this is possible since hooks can inject a task
-    // CRM-13697
-    if (!isset(self::$_tasks[$value]['result'])) {
-      self::$_tasks[$value]['result'] = NULL;
-    }
-    return array(
-      self::$_tasks[$value]['class'],
-      self::$_tasks[$value]['result'],
-    );
+    return parent::getTask($value);
   }
 
 }

--- a/CRM/Core/Task.php
+++ b/CRM/Core/Task.php
@@ -120,7 +120,7 @@ abstract class CRM_Core_Task {
   /**
    * Show tasks selectively based on the permission level
    * of the user
-   * This function should be call parent::corePermissionedTaskTitles
+   * This function should be overridden by the child class which would normally call parent::corePermissionedTaskTitles
    *
    * @param int $permission
    * @param array $params
@@ -129,7 +129,9 @@ abstract class CRM_Core_Task {
    * @return array
    *   set of tasks that are valid for the user
    */
-  abstract public static function permissionedTaskTitles($permission, $params);
+  public static function permissionedTaskTitles($permission, $params) {
+    return self::corePermissionedTaskTitles(self::tasks(), $permission, $params);
+  }
 
   /**
    * Show tasks selectively based on the permission level


### PR DESCRIPTION
Overview
----------------------------------------
Refactor contribute task form to use base class

Before
----------------------------------------
![screenshot 2018-02-20 11 22 17](https://user-images.githubusercontent.com/336308/36399412-a63e1904-1630-11e8-834c-a075eb0ab5f8.png)


After
----------------------------------------
![screenshot 2018-02-20 11 22 53](https://user-images.githubusercontent.com/336308/36399414-ae3028a0-1630-11e8-99cb-eb1b10e86461.png)


Technical Details
----------------------------------------
details in #11240

Comments
----------------------------------------
This is a commit from #11240 that I have reviewed & am merging. As there is a lot in that PR I am trying to chip away at the review.

In terms of review I checked that the code was a positive improvement and tested a couple of actions as well as checking the same number of actions were present

---

 * [CRM-21391: Refactor tasks to use a base class](https://issues.civicrm.org/jira/browse/CRM-21391)