### PR TITLE
Move towards standardising website.create function.

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -349,8 +349,9 @@ class CRM_Contact_BAO_Contact extends CRM_Contact_DAO_Contact {
       $skipDelete = TRUE;
     }
 
-    //add website
-    CRM_Core_BAO_Website::create($params['website'], $contact->id, $skipDelete);
+    if (isset($params['website'])) {
+      CRM_Core_BAO_Website::process($params['website'], $contact->id, $skipDelete);
+    }
 
     $userID = CRM_Core_Session::singleton()->get('userID');
     // add notes

--- a/CRM/Contact/Form/Inline/Website.php
+++ b/CRM/Contact/Form/Inline/Website.php
@@ -122,7 +122,7 @@ class CRM_Contact_Form_Inline_Website extends CRM_Contact_Form_Inline {
       }
     }
     // Process / save websites
-    CRM_Core_BAO_Website::create($params['website'], $this->_contactId, TRUE);
+    CRM_Core_BAO_Website::process($params['website'], $this->_contactId, TRUE);
 
     $this->log();
     $this->response();

--- a/api/v3/Website.php
+++ b/api/v3/Website.php
@@ -38,15 +38,9 @@
  *
  * @return array
  *   API result array
- * @todo convert to using basic create - BAO function non-std
  */
 function civicrm_api3_website_create($params) {
-  //DO NOT USE THIS FUNCTION AS THE BASIS FOR A NEW API http://wiki.civicrm.org/confluence/display/CRM/API+Architecture+Standards
-  _civicrm_api3_check_edit_permissions('CRM_Core_BAO_Website', $params);
-  $websiteBAO = CRM_Core_BAO_Website::add($params);
-  $values = array();
-  _civicrm_api3_object_to_array($websiteBAO, $values[$websiteBAO->id]);
-  return civicrm_api3_create_success($values, $params, 'Website', 'get');
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'Website');
 }
 
 /**


### PR DESCRIPTION
Overview
----------------------------------------
Standardisation of website create function

Before
----------------------------------------
Website create function is highly specific & rather alarmingly includes deletion within create

After
----------------------------------------
The customised function is renamed to process & the places in the code identified to call it are changed to call the 'process' function. 

Technical Details
----------------------------------------
To prevent hard-breakage a 'create' function still exists and if the calling code appears to be calling the 'old' create then process will be called. This is determined by the passed params as the old function took an array of website arrays & had 2 optional params. the api WILL pass an $ids array so we check if param 2 is empty or an array while deciding.


Comments
----------------------------------------
We've seen a string of fixes & regressions like these #11683 #11634 #11428 and I think we need to 
a) get a sensible BAO / api working
b) determine if we agree that website type is optional & need not be unique - there could be flow on impacts on searches , reports & joins if they are not unique 
c) handle what needs to be done with form input in a form function & remove the BAO process as & when we can

@yashodha @agh1 you have both been involved in previous patches around attempts to fix https://github.com/civicrm/civicrm-core/pull/11683 & may have opinions
