### PR TITLE
dev/civicrm-setup#11 Remove templates/CRM/common/version.tpl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ sql/civicrm_data.mysql
 sql/civicrm_drop.mysql
 sql/civicrm_navigation.mysql
 sql/civicrm_sample.mysql
-templates/CRM/common/version.tpl
 tests/phpunit/CiviTest/CiviSeleniumSettings.php
 tests/phpunit/CiviTest/civicrm.settings.php
 tools/stats/config.php

--- a/CRM/Core/CodeGen/Version.php
+++ b/CRM/Core/CodeGen/Version.php
@@ -7,8 +7,6 @@ class CRM_Core_CodeGen_Version extends CRM_Core_CodeGen_BaseTask {
   public function run() {
     echo "Generating civicrm-version file\n";
 
-    file_put_contents($this->config->tplCodePath . "/CRM/common/version.tpl", $this->config->db_version);
-
     $template = new CRM_Core_CodeGen_Util_Template('php');
     $template->assign('db_version', $this->config->db_version);
     $template->assign('cms', ucwords($this->config->cms));

--- a/CRM/Utils/Check/Component/Source.php
+++ b/CRM/Utils/Check/Component/Source.php
@@ -50,6 +50,7 @@ class CRM_Utils_Check_Component_Source extends CRM_Utils_Check_Component {
     $files[] = '[civicrm.vendor]/pear/net_smtp/tests';
     $files[] = '[civicrm.vendor]/pear/net_smtp/phpdoc.sh';
     $files[] = '[civicrm.vendor]/phpoffice/phpword/samples';
+    $files[] = '[civicrm.root]/templates/CRM/common/version.tpl';
 
     return $files;
   }

--- a/xml/templates/civicrm_version.tpl
+++ b/xml/templates/civicrm_version.tpl
@@ -3,11 +3,6 @@
  * Get the CiviCRM version.
  */
 function civicrmVersion( ) {ldelim}
-{include file="../../templates/CRM/common/version.tpl" assign=svnrevision}
   return array( 'version'  => '{$db_version}',
-                'cms'      => '{$cms}',
-                'revision' => '{$svnrevision}', );
+                'cms'      => '{$cms}', );
 {rdelim}
-
-
-


### PR DESCRIPTION
Overview
----------------------------------------
For https://github.com/civicrm/civicrm-setup/issues/11, the aim is to install the database schema without needing to run `GenCode` --  and `templates/CRM/common/version.tpl` is generated to by `GenCode` as an intermediate step toward producing `civicrm-version.php` (`revision`). This PR removes `templates/CRM/common/version.tpl`.

If you grep universe, no other projects reference `CRM/common/version.tpl`. It's only used to hold the Civi version later assigned to `$svnversion`/`revision`. In turn,  no other projects reference the `revision` field.

Before
----------------------------------------
* `CRM_Core_CodeGen_Version` writes the Civi version to `templates/CRM/common/version.tpl`
*  Then `CRM_Core_CodeGen_Version` evaluates `xml/civicrm_version.tpl` and `templates/CRM/common/version.tpl` -- and writes the content to `civicrm-version.php`.

After
----------------------------------------
* The file `templates/CRM/common/version.tpl` has been thoroughly removed:
    * `CRM_Core_CodeGen_Version` does **not** write the Civi version to `templates/CRM/common/version.tpl`
    *  `xml/civicrm_version.tpl` does **not** consume `templates/CRM/common/version.tpl` or output an `$svnVersion`/`revision`. (The `revision` is not referenced elsewhere in `universe`.)
    *  `CRM_Utils_Check_Component_Source::getRemovedFiles()` ensures that the file is no longer present in the codebase.
    * Removed the path reference from `.gitignore` 
* The file `civicrm-version.php` is still available for consumption by `CRM_Utils_System::version()` and others.