### PR TITLE
CRM-21784 Display custom data when viewing recurring contributions

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -323,7 +323,7 @@ SELECT r.payment_processor_id
   }
 
   /**
-   * Get list of recurring contribution of contact Ids.
+   * @deprecated Get list of recurring contribution of contact Ids.
    *
    * @param int $contactId
    *   Contact ID.
@@ -333,6 +333,7 @@ SELECT r.payment_processor_id
    *
    */
   public static function getRecurContributions($contactId) {
+    Civi::log()->warning('Deprecated function, use ContributionRecur.get API instead', array('civi.tag' => 'deprecated'));
     $params = array();
     $recurDAO = new CRM_Contribute_DAO_ContributionRecur();
     $recurDAO->contact_id = $contactId;

--- a/CRM/Contribute/Page/ContributionRecur.php
+++ b/CRM/Contribute/Page/ContributionRecur.php
@@ -75,6 +75,9 @@ class CRM_Contribute_Page_ContributionRecur extends CRM_Core_Page {
       $contributionRecur['membership_name'] = $membershipDetails['membership_name'];
     }
 
+    $groupTree = CRM_Core_BAO_CustomGroup::getTree('ContributionRecur', NULL, $contributionRecur['id']);
+    CRM_Core_BAO_CustomGroup::buildCustomDataView($this, $groupTree, FALSE, NULL, NULL, NULL, $contributionRecur['id']);
+
     $this->assign('recur', $contributionRecur);
   }
 

--- a/CRM/Contribute/Page/ContributionRecur.php
+++ b/CRM/Contribute/Page/ContributionRecur.php
@@ -44,45 +44,41 @@ class CRM_Contribute_Page_ContributionRecur extends CRM_Core_Page {
    * View details of a recurring contribution.
    */
   public function view() {
-    $recur = new CRM_Contribute_DAO_ContributionRecur();
-    $recur->id = $this->_id;
-    if ($recur->find(TRUE)) {
-      $values = array();
-      CRM_Core_DAO::storeValues($recur, $values);
-      // if there is a payment processor ID, get the name of the payment processor
-      if (!empty($values['payment_processor_id'])) {
-        $values['payment_processor'] = CRM_Core_DAO::getFieldValue(
-          'CRM_Financial_DAO_PaymentProcessor',
-          $values['payment_processor_id'],
-          'name'
-        );
-      }
-      $idFields = array('contribution_status_id', 'campaign_id');
-      if (CRM_Contribute_BAO_ContributionRecur::supportsFinancialTypeChange($values['id'])) {
-        $idFields[] = 'financial_type_id';
-      }
-      foreach ($idFields as $idField) {
-        if (!empty($values[$idField])) {
-          $values[substr($idField, 0, -3)] = CRM_Core_PseudoConstant::getLabel('CRM_Contribute_BAO_ContributionRecur', $idField, $values[$idField]);
-        }
-      }
-
-      // Add linked membership
-      $membership = civicrm_api3('Membership', 'get', array(
-        'contribution_recur_id' => $recur->id,
-      ));
-      if (!empty($membership['count'])) {
-        $membershipDetails = reset($membership['values']);
-        $values['membership_id'] = $membershipDetails['id'];
-        $values['membership_name'] = $membershipDetails['membership_name'];
-      }
-
-      $this->assign('recur', $values);
+    if (empty($this->_id)) {
+      CRM_Core_Error::statusBounce('Recurring contribution not found');
     }
+
+    try {
+      $contributionRecur = civicrm_api3('ContributionRecur', 'getsingle', array(
+        'id' => $this->_id,
+      ));
+    }
+    catch (Exception $e) {
+      CRM_Core_Error::statusBounce('Recurring contribution not found (ID: ' . $this->_id);
+    }
+
+    $contributionRecur['payment_processor'] = CRM_Financial_BAO_PaymentProcessor::getPaymentProcessorName($contributionRecur['payment_processor_id']);
+    $idFields = array('contribution_status_id', 'campaign_id', 'financial_type_id');
+    foreach ($idFields as $idField) {
+      if (!empty($contributionRecur[$idField])) {
+        $contributionRecur[substr($idField, 0, -3)] = CRM_Core_PseudoConstant::getLabel('CRM_Contribute_BAO_ContributionRecur', $idField, $contributionRecur[$idField]);
+      }
+    }
+
+    // Add linked membership
+    $membership = civicrm_api3('Membership', 'get', array(
+      'contribution_recur_id' => $contributionRecur['id'],
+    ));
+    if (!empty($membership['count'])) {
+      $membershipDetails = reset($membership['values']);
+      $contributionRecur['membership_id'] = $membershipDetails['id'];
+      $contributionRecur['membership_name'] = $membershipDetails['membership_name'];
+    }
+
+    $this->assign('recur', $contributionRecur);
   }
 
   public function preProcess() {
-    $context = CRM_Utils_Request::retrieve('context', 'String', $this);
     $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'view');
     $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
     $this->_contactId = CRM_Utils_Request::retrieve('cid', 'Positive', $this, TRUE);

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1961,7 +1961,7 @@ SELECT IF( EXISTS(SELECT name FROM civicrm_contact_type WHERE name like %1), 1, 
   /**
    * Build custom data view.
    *
-   * @param CRM_Core_Form $form
+   * @param CRM_Core_Form|CRM_Core_Page $form
    *   Page object.
    * @param array $groupTree
    * @param bool $returnCount
@@ -1972,6 +1972,7 @@ SELECT IF( EXISTS(SELECT name FROM civicrm_contact_type WHERE name like %1), 1, 
    * @param int $entityId
    *
    * @return array|int
+   * @throws \Exception
    */
   public static function buildCustomDataView(&$form, &$groupTree, $returnCount = FALSE, $gID = NULL, $prefix = NULL, $customValueId = NULL, $entityId = NULL) {
     $details = array();

--- a/CRM/Financial/BAO/PaymentProcessor.php
+++ b/CRM/Financial/BAO/PaymentProcessor.php
@@ -570,6 +570,26 @@ INNER JOIN civicrm_contribution       con ON ( mp.contribution_id = con.id )
   }
 
   /**
+   * Get the name of the payment processor
+   *
+   * @param $paymentProcessorId
+   *
+   * @return null|string
+   */
+  public static function getPaymentProcessorName($paymentProcessorId) {
+    try {
+      $paymentProcessor = civicrm_api3('PaymentProcessor', 'getsingle', array(
+        'return' => array('name'),
+        'id' => $paymentProcessorId,
+      ));
+      return $paymentProcessor['name'];
+    }
+    catch (Exception $e) {
+      return ts('Unknown') . ' (' . $paymentProcessorId . ')';
+    }
+  }
+
+  /**
    * Generate and assign an arbitrary value to a field of a test object.
    *
    * @param string $fieldName

--- a/templates/CRM/Contribute/Form/Selector.tpl
+++ b/templates/CRM/Contribute/Form/Selector.tpl
@@ -26,6 +26,7 @@
 {include file="CRM/common/pager.tpl" location="top"}
 
 {strip}
+  <div class="crm-contact-contribute-contributions">
   <table class="selector row-highlight">
     <thead class="sticky">
     <tr>
@@ -45,9 +46,6 @@
     </tr>
     </thead>
 
-    <p class="description">
-      {ts}Click arrow to view payment details.{/ts}
-    </p>
     {counter start=0 skip=1 print=false}
     {foreach from=$rows item=row}
       <tr id="rowid{$row.contribution_id}" class="{cycle values="odd-row,even-row"} {if $row.cancel_date} cancelled{/if} crm-contribution_{$row.contribution_id}">
@@ -107,6 +105,7 @@
     {/foreach}
 
   </table>
+  </div>
 {/strip}
 
 {include file="CRM/common/pager.tpl" location="bottom"}

--- a/templates/CRM/Contribute/Form/UpdateSubscription.tpl
+++ b/templates/CRM/Contribute/Form/UpdateSubscription.tpl
@@ -52,5 +52,18 @@
     {/if}
   </table>
 
+  <div id="customData"></div>
+  {*include custom data js file*}
+  {include file="CRM/common/customData.tpl"}
+  {literal}
+    <script type="text/javascript">
+      CRM.$(function($) {
+        {/literal}
+        CRM.buildCustomData( '{$customDataType}' );
+        {literal}
+      });
+    </script>
+  {/literal}
+
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 </div>

--- a/templates/CRM/Contribute/Page/ContributionRecur.tpl
+++ b/templates/CRM/Contribute/Page/ContributionRecur.tpl
@@ -72,7 +72,7 @@
             <th scope="col">{ts}Start Date{/ts}</th>
             <th scope="col">{ts}Installments{/ts}</th>
             <th scope="col">{ts}Status{/ts}</th>
-            <th scope="col">&nbsp;</th>
+            <th scope="col"></th>
         </tr>
 
         {foreach from=$recurRows item=row}
@@ -83,9 +83,7 @@
                 <td>{$row.start_date|crmDate}</td>
                 <td>{$row.installments}</td>
                 <td>{$row.contribution_status}</td>
-                <td>
-                    {$row.action|replace:'xx':$row.recurId}
-                </td>
+                <td>{$row.action|replace:'xx':$row.recurId}</td>
             </tr>
         {/foreach}
     </table>

--- a/templates/CRM/Contribute/Page/ContributionRecur.tpl
+++ b/templates/CRM/Contribute/Page/ContributionRecur.tpl
@@ -56,6 +56,8 @@
               <td><a class="crm-hover-button" href='{crmURL p="civicrm/contact/view/membership" q="action=view&reset=1&cid=`$contactId`&id=`$recur.membership_id`&context=membership&selectedChild=member"}'>{$recur.membership_name}</a></td>
               </tr>
             {/if}
+            {include file="CRM/Custom/Page/CustomDataView.tpl"}
+
           </table>
           <div class="crm-submit-buttons"><a class="button cancel crm-form-submit" href="{crmURL p='civicrm/contact/view' q='action=browse&selectedChild=contribute'}">{ts}Done{/ts}</a></div>
         </div>

--- a/templates/CRM/Contribute/Page/ContributionTotals.tpl
+++ b/templates/CRM/Contribute/Page/ContributionTotals.tpl
@@ -24,7 +24,7 @@
  +--------------------------------------------------------------------+
 *}
 {*Table displays contribution totals for a contact or search result-set *}
-{if $annual.count OR $contributionSummary}
+{if $annual.count OR $contributionSummary.total.count OR $contributionSummary.cancel.count OR $contributionSummary.soft_credit.count}
     <table class="form-layout-compressed">
 
     {if $annual.count}

--- a/templates/CRM/Contribute/Page/Tab.tpl
+++ b/templates/CRM/Contribute/Page/Tab.tpl
@@ -28,7 +28,7 @@
 {elseif $action eq 4}
     {include file="CRM/Contribute/Form/ContributionView.tpl"}
 {else}
-    <div class="view-content">
+    <div class="contact-summary-contribute-tab view-content">
         <div class="help">
             {if $permission EQ 'edit'}
               {capture assign=newContribURL}{crmURL p="civicrm/contact/view/contribution" q="reset=1&action=add&cid=`$contactId`&context=contribution"}{/capture}
@@ -52,13 +52,12 @@
                 {/if}
                 <br /><br />
             </div>
-      <div class='clear'> </div>
+          <div class='clear'></div>
         {/if}
-
 
         {if $rows}
             {include file="CRM/Contribute/Page/ContributionTotals.tpl" mode="view"}
-            <p> </p>
+          <div class='clear'></div>
             {include file="CRM/Contribute/Form/Selector.tpl"}
         {else}
             <div class="messages status no-popup">
@@ -68,19 +67,17 @@
         {/if}
 
         {if $recur}
-            <div class="solid-border-top">
-                <br /><label>{ts 1=$displayName}Recurring Contributions{/ts}</label>
-            </div>
+          <div class="crm-block crm-contact-contribute-recur">
+            <h3>{ts}Recurring Contributions{/ts}</h3>
             {include file="CRM/Contribute/Page/ContributionRecur.tpl"}
+          </div>
         {/if}
 
         {if $softCredit}
-            <div class="solid-border-top">
-                <br />
-                <div class="label">{ts}Soft credits{/ts} {help id="id-soft_credit"}</div>
-                <div class="spacer"></div>
-            </div>
+          <div class="crm-block crm-contact-contribute-softcredit">
+            <h3>{ts}Soft credits{/ts} {help id="id-soft_credit"}</h3>
             {include file="CRM/Contribute/Page/ContributionSoft.tpl"}
+          </div>
         {/if}
     </div>
 {/if}


### PR DESCRIPTION
Overview
----------------------------------------
You can add custom data fields to recurring contributions easily via the custom data admin UI.  However, it's not possible to view them anywhere except via the API.  This PR fixes that so they show up when viewing the recurring contribution.

Before
----------------------------------------
Custom data not visible.
![localhost_8000_civicrm_contact_view_contributionrecur_reset 1 id 64 cid 206 context contribution](https://user-images.githubusercontent.com/2052161/36439682-8ed905d2-1665-11e8-91f6-ddecd3f267b7.png)

![civitest1 mjw-consult co uk_civicrm_contact_view_reset 1 cid 5 selectedchild contribute](https://user-images.githubusercontent.com/2052161/36445451-3bc9b98e-1676-11e8-8f85-d9cdab4b9f31.png)

After
----------------------------------------
Custom data visible, using the same method as for other entities.
![localhost_8000_civicrm_contact_view_contributionrecur_reset 1 id 64 cid 206 context contribution 1](https://user-images.githubusercontent.com/2052161/36439691-93075ef6-1665-11e8-81a2-33bf4929e414.png)

Note: processor column is no longer visible and has been moved to a separate issue: https://lab.civicrm.org/dev/financial/issues/4

![civitest1 mjw-consult co uk_civicrm_contact_view_reset 1 cid 5 selectedchild contribute 1](https://user-images.githubusercontent.com/2052161/36445456-3e8c7472-1676-11e8-97c5-b5eea877c98f.png)

Technical Details
----------------------------------------
This PR does 3 things:
1. Switch the data source for the recurring contributions on the contribution tab to use the API instead of BAO/DAO functions.  This simplifies the code and makes all fields available to smarty so the tab can be easily customised by extensions (eg. to highlight ones with a particular custom field value).  This also has the side-benefit of deprecating a BAO function that is only used once.

2. Switch the data source for the "View recurring contribution" page to use the API instead of BAO/DAO functions.  This simplifies the code and makes all fields available so that the standard "view custom data" functions and smarty tpl can automatically display custom data in the standard format.  This also makes "financial_type" visible at all times even if it cannot be changed - it makes sense to stop it being edited but I don't think it makes sense to hide it from view by default as well.

3. Modify the "View recurring contribution" page smarty template to add in the standard custom data template and allow custom data to magically appear.
---

 * [CRM-21784: View custom data for recurring contributions](https://issues.civicrm.org/jira/browse/CRM-21784)