### PR TITLE
CRM-21787 : Simplify CRM_Utils_System::version() to fetch version directly from xml/version.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ sql/civicrm_data.mysql
 sql/civicrm_drop.mysql
 sql/civicrm_navigation.mysql
 sql/civicrm_sample.mysql
-templates/CRM/common/version.tpl
 tests/phpunit/CiviTest/CiviSeleniumSettings.php
 tests/phpunit/CiviTest/civicrm.settings.php
 tools/stats/config.php

--- a/CRM/Core/CodeGen/Version.php
+++ b/CRM/Core/CodeGen/Version.php
@@ -7,8 +7,6 @@ class CRM_Core_CodeGen_Version extends CRM_Core_CodeGen_BaseTask {
   public function run() {
     echo "Generating civicrm-version file\n";
 
-    file_put_contents($this->config->tplCodePath . "/CRM/common/version.tpl", $this->config->db_version);
-
     $template = new CRM_Core_CodeGen_Util_Template('php');
     $template->assign('db_version', $this->config->db_version);
     $template->assign('cms', ucwords($this->config->cms));

--- a/CRM/Utils/Check/Component/Source.php
+++ b/CRM/Utils/Check/Component/Source.php
@@ -50,6 +50,7 @@ class CRM_Utils_Check_Component_Source extends CRM_Utils_Check_Component {
     $files[] = '[civicrm.vendor]/pear/net_smtp/tests';
     $files[] = '[civicrm.vendor]/pear/net_smtp/phpdoc.sh';
     $files[] = '[civicrm.vendor]/phpoffice/phpword/samples';
+    $files[] = '[civicrm.root]/templates/CRM/common/version.tpl';
 
     return $files;
   }

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1074,25 +1074,12 @@ class CRM_Utils_System {
 
     if (!$version) {
       $verFile = implode(DIRECTORY_SEPARATOR,
-        array(dirname(__FILE__), '..', '..', 'civicrm-version.php')
+        array(dirname(__FILE__), '..', '..', 'xml', 'version.xml')
       );
       if (file_exists($verFile)) {
-        require_once $verFile;
-        if (function_exists('civicrmVersion')) {
-          $info = civicrmVersion();
-          $version = $info['version'];
-        }
-      }
-      else {
-        // svn installs don't have version.txt by default. In that case version.xml should help -
-        $verFile = implode(DIRECTORY_SEPARATOR,
-          array(dirname(__FILE__), '..', '..', 'xml', 'version.xml')
-        );
-        if (file_exists($verFile)) {
-          $str = file_get_contents($verFile);
-          $xmlObj = simplexml_load_string($str);
-          $version = (string) $xmlObj->version_no;
-        }
+        $str = file_get_contents($verFile);
+        $xmlObj = simplexml_load_string($str);
+        $version = (string) $xmlObj->version_no;
       }
 
       // pattern check

--- a/xml/templates/civicrm_version.tpl
+++ b/xml/templates/civicrm_version.tpl
@@ -3,11 +3,6 @@
  * Get the CiviCRM version.
  */
 function civicrmVersion( ) {ldelim}
-{include file="../../templates/CRM/common/version.tpl" assign=svnrevision}
   return array( 'version'  => '{$db_version}',
-                'cms'      => '{$cms}',
-                'revision' => '{$svnrevision}', );
+                'cms'      => '{$cms}', );
 {rdelim}
-
-
-


### PR DESCRIPTION
Overview
----------------------------------------
This patch simplifies `CRM_Utils_System::version() ` by removing a level of indirection -- instead of reading `xml/version.xml` indirectly (by way of `civicrm-version.php` and `GenCode`), it reads `xml/version.xml` directly.

This change is valid now that `xml/version.xml` is included with tarballs (04e5df15fbe2ecebd288e100750fa548816d25c7).

Before
----------------------------------------
`CRM_Utils_System::version()` reads `civicrm-version.php` OR `xml/version.xml`. 

After
----------------------------------------
 `CRM_Utils_System::version()` reads `xml/version.xml`.

Technical Details
----------------------------------------
~~To avoid `CRM_Core_CodeGen_Version` dependency to generate `civicrm-version.php` is to make this file independent, to retrieve the cms and version on its own. For version, it's possible to directly use `xml/version.xml` but for cms we need to rely on php constant CIVICRM_UF. Then we can easily remove `CRM_Core_CodeGen_Version`.~~ (*Outside scope of this PR.*)

Comments
----------------------------------------
This PR contains commits of https://github.com/civicrm/civicrm-core/pull/11695

---

 * [CRM-21787: Keep `civicrm-version.php` up-to-date without running GenCode on all builds](https://issues.civicrm.org/jira/browse/CRM-21787)