### PR TITLE
(NFC) remove starting whitespace in ts about installments

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -489,10 +489,10 @@ abstract class CRM_Core_Payment {
         if (array_keys($params) == array('is_recur_installments', 'is_email_receipt')) {
           $gotText = ts('Your recurring contribution will be processed automatically.');
           if ($params['is_recur_installments']) {
-            $gotText .= ts(' You can specify the number of installments, or you can leave the number of installments blank if you want to make an open-ended commitment. In either case, you can choose to cancel at any time.');
+            $gotText .= ' ' . ts('You can specify the number of installments, or you can leave the number of installments blank if you want to make an open-ended commitment. In either case, you can choose to cancel at any time.');
           }
           if ($params['is_email_receipt']) {
-            $gotText .= ts(' You will receive an email receipt for each recurring contribution.');
+            $gotText .= ' ' . ts('You will receive an email receipt for each recurring contribution.');
           }
         }
         break;


### PR DESCRIPTION
Overview
----------------------------------------
Fix some ts() that starts with a space and are not properly translated in transifex.