### PR TITLE
ensure pdfFilename is set

### DIFF
--- a/CRM/Contribute/Form/Task/Invoice.php
+++ b/CRM/Contribute/Form/Task/Invoice.php
@@ -494,7 +494,6 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
 
         list($sent, $subject, $message, $html) = CRM_Core_BAO_MessageTemplate::sendTemplate($sendTemplateParams);
         // functions call for adding activity with attachment
-        $pdfFileName = "{$invoiceNumber}.pdf";
         $fileName = self::putFile($html, $pdfFileName);
         self::addActivities($subject, $contribution->contact_id, $fileName, $params);
       }
@@ -509,7 +508,6 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
 
         list($sent, $subject, $message, $html) = CRM_Core_BAO_MessageTemplate::sendTemplate($sendTemplateParams);
         // functions call for adding activity with attachment
-        $pdfFileName = "{$invoiceNumber}.pdf";
         $fileName = self::putFile($html, $pdfFileName);
         self::addActivities($subject, $contribution->contact_id, $fileName, $params);
       }
@@ -521,7 +519,6 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
         return $html;
       }
       else {
-        $pdfFileName = "{$invoiceNumber}.pdf";
         CRM_Utils_PDF_Utils::html2pdf($messageInvoice, $pdfFileName, FALSE, array(
           'margin_top' => 10,
           'margin_left' => 65,


### PR DESCRIPTION
Avoid setting the filename to a non-existent variable.

Overview
----------------------------------------
When downloading a PDF file receipt, the name you are prompted to save it as is not properly set. If it simply set to: .pdf.

Before
----------------------------------------
![pdf-receipt-before](https://user-images.githubusercontent.com/4511942/36508493-e2a6a9a6-172a-11e8-8c87-f844d55c403a.png)

After
----------------------------------------
The downloaded file name is named after the invoice id.

Technical Details
----------------------------------------
The pdf filename is properly set in the file, but then overwritten in later, incorrect code. I have simply removed the incorrect code that overwrites the properly set variable.

