### PR TITLE
Remove cloning hack from export and add unit tests

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -770,27 +770,15 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
     $limitReached = FALSE;
     while (!$limitReached) {
       $limitQuery = "{$queryString} LIMIT {$offset}, {$rowCount}";
-      $dao = CRM_Core_DAO::executeQuery($limitQuery);
+      $iterationDAO = CRM_Core_DAO::executeQuery($limitQuery);
       // If this is less than our limit by the end of the iteration we do not need to run the query again to
       // check if some remain.
       $rowsThisIteration = 0;
 
-      while ($dao->fetch()) {
+      while ($iterationDAO->fetch()) {
         $count++;
         $rowsThisIteration++;
         $row = array();
-
-        //convert the pseudo constants
-        // CRM-14398 there is problem in this architecture that is not easily solved. For now we are using the cloned
-        // temporary iterationDAO object to get around it.
-        // the issue is that the convertToPseudoNames function is adding additional properties (e.g for campaign) to the DAO object
-        // these additional properties are NOT reset when the $dao cycles through the while loop
-        // nor are they overwritten as they are not in the loop
-        // the convertToPseudoNames will not adequately over-write them either as it doesn't 'kick-in' unless the
-        // relevant property is set.
-        // It may be that a long-term fix could be introduced there - however, it's probably necessary to figure out how to test the
-        // export class before tackling a better architectural fix
-        $iterationDAO = clone $dao;
         $query->convertToPseudoNames($iterationDAO);
 
         //first loop through output columns so that we return what is required, and in same order.
@@ -1070,7 +1058,6 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
           $componentDetails = array();
         }
       }
-      $dao->free();
       if ($rowsThisIteration < self::EXPORT_ROW_COUNT) {
         $limitReached = TRUE;
       }

--- a/api/v3/Campaign.php
+++ b/api/v3/Campaign.php
@@ -58,6 +58,7 @@ function civicrm_api3_campaign_create($params) {
  */
 function _civicrm_api3_campaign_create_spec(&$params) {
   $params['title']['api.required'] = 1;
+  $params['is_active']['api.default'] = 1;
 }
 
 /**

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -29,6 +29,7 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
 
   public function tearDown() {
     $this->quickCleanup(['civicrm_contact', 'civicrm_email', 'civicrm_address']);
+    $this->quickCleanUpFinancialEntities();
     parent::tearDown();
   }
 
@@ -203,7 +204,8 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
    */
   public function setUpContributionExportData() {
     $this->setUpContactExportData();
-    $this->contributionIDs[] = $this->contributionCreate(array('contact_id' => $this->contactIDs[0]));
+    $this->contributionIDs[] = $this->contributionCreate(array('contact_id' => $this->contactIDs[0], 'trxn_id' => 'null', 'invoice_id' => 'null'));
+    $this->contributionIDs[] = $this->contributionCreate(array('contact_id' => $this->contactIDs[1], 'trxn_id' => 'null', 'invoice_id' => 'null'));
   }
 
   /**
@@ -218,7 +220,7 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
    * Set up some data for us to do testing on.
    */
   public function setUpContactExportData() {
-    $this->contactIDs[] = $contactA = $this->individualCreate();
+    $this->contactIDs[] = $contactA = $this->individualCreate(['gender_id' => 'Female']);
     // Create address for contact A.
     $params = array(
       'contact_id' => $contactA,
@@ -298,6 +300,65 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
    */
   public function getPrimarySearchOptions() {
     return [[TRUE], [FALSE]];
+  }
+
+  /**
+   * Test that when exporting a pseudoField it is reset for NULL entries.
+   *
+   * ie. we have a contact WITH a gender & one without - make sure the latter one
+   * does NOT retain the gender of the former.
+   */
+  public function testExportPseudoField() {
+    $this->setUpContactExportData();
+    $selectedFields = [['Individual', 'gender_id']];
+    list($tableName, $sqlColumns) = CRM_Export_BAO_Export::exportComponents(
+      TRUE,
+      $this->contactIDs[1],
+      array(),
+      NULL,
+      $selectedFields,
+      NULL,
+      CRM_Export_Form_Select::CONTACT_EXPORT,
+      "contact_a.id IN (" . implode(",", $this->contactIDs) . ")",
+      NULL,
+      FALSE,
+      FALSE,
+      array(
+        'exportOption' => CRM_Export_Form_Select::CONTACT_EXPORT,
+        'suppress_csv_for_testing' => TRUE,
+      )
+    );
+    $this->assertEquals('Female,', CRM_Core_DAO::singleValueQuery("SELECT GROUP_CONCAT(gender_id) FROM {$tableName}"));
+  }
+
+  /**
+   * Test that when exporting a pseudoField it is reset for NULL entries.
+   *
+   * This is specific to the example in CRM-14398
+   */
+  public function testExportPseudoFieldCampaign() {
+    $this->setUpContributionExportData();
+    $campaign = $this->callAPISuccess('Campaign', 'create', ['title' => 'Big campaign']);
+    $this->callAPISuccess('Contribution', 'create', ['campaign_id' => 'Big_campaign', 'id' => $this->contributionIDs[0]]);
+    $selectedFields = [['Individual', 'gender_id'], ['Contribution', 'contribution_campaign_title']];
+    list($tableName, $sqlColumns) = CRM_Export_BAO_Export::exportComponents(
+      TRUE,
+      $this->contactIDs[1],
+      array(),
+      NULL,
+      $selectedFields,
+      NULL,
+      CRM_Export_Form_Select::CONTRIBUTE_EXPORT,
+      "contact_a.id IN (" . implode(",", $this->contactIDs) . ")",
+      NULL,
+      FALSE,
+      FALSE,
+      array(
+        'exportOption' => CRM_Export_Form_Select::CONTACT_EXPORT,
+        'suppress_csv_for_testing' => TRUE,
+      )
+    );
+    $this->assertEquals('Big campaign,', CRM_Core_DAO::singleValueQuery("SELECT GROUP_CONCAT(contribution_campaign_title) FROM {$tableName}"));
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Remove a hacky & obsolete fix from the code base and add unit tests

Before
----------------------------------------
DAO is being cloned in order to address a former bug in export. No tests

After
----------------------------------------
DAO cloning removed, tests added.

Technical Details
----------------------------------------
Back in 4.4 a bug (CRM-14398) was addressed by cloning the DAO. This causes an issue in conjunction with #11615 (which adds a __destruct to the DAO in place of $dao->free being needed & in place of the damaging freeResult() calls & resolves a memory leak). In UI and unit test testing I found that the cloning hack is no longer required (pseudoConstant handling was fairly new when it was added but has matured now).

Comments
----------------------------------------
I also set a default of is_active=1 on the campaign api, which is consistent with other api & was useful for the unit test

---

 * [CRM-14398: Fatal error exporting contributions with campaigns, if campaign name \> 16 chars](https://issues.civicrm.org/jira/browse/CRM-14398)