### PR TITLE
CRM-21789: 'Find Case' group by issue

### DIFF
--- a/tests/phpunit/CRM/Contact/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTest.php
@@ -235,7 +235,7 @@ class CRM_Contact_BAO_QueryTest extends CiviUnitTestCase {
       'contact_sub_type' => 1,
       'sort_name' => 1,
     );
-    $expectedSQL = "SELECT contact_a.id as contact_id, contact_a.contact_type as `contact_type`, contact_a.contact_sub_type as `contact_sub_type`, contact_a.sort_name as `sort_name`, civicrm_address.id as address_id, civicrm_address.city as `city`  FROM civicrm_contact contact_a LEFT JOIN civicrm_address ON ( contact_a.id = civicrm_address.contact_id AND civicrm_address.is_primary = 1 ) WHERE  (  ( LOWER(civicrm_address.city) = 'cool city' )  )  AND (contact_a.is_deleted = 0)    ORDER BY `contact_a`.`sort_name` asc, `contact_a`.`id` ";
+    $expectedSQL = "SELECT contact_a.id as contact_id, contact_a.contact_type as `contact_type`, contact_a.contact_sub_type as `contact_sub_type`, contact_a.sort_name as `sort_name`, civicrm_address.id as address_id, civicrm_address.city as `city`  FROM civicrm_contact contact_a LEFT JOIN civicrm_address ON ( contact_a.id = civicrm_address.contact_id AND civicrm_address.is_primary = 1 ) WHERE  (  ( LOWER(civicrm_address.city) = 'cool city' )  )  AND (contact_a.is_deleted = 0)    ORDER BY `contact_a`.`sort_name` ASC, `contact_a`.`id` ";
     $queryObj = new CRM_Contact_BAO_Query($params, $returnProperties);
     try {
       $this->assertEquals($expectedSQL, $queryObj->searchQuery(0, 0, NULL,


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate:
1. Ensure that MySQL FULL_GROUP_BY_MODE is enabled
2. Empty submit the criteria of 'Find Cases' 

Before
----------------------------------------
The actual number of rows listed and the row count per page differs. In the screencast below, only 2 rows are listed despite having 10 counts per page:
![test-multiple-before](https://user-images.githubusercontent.com/3735621/36527489-f5a73e96-17d7-11e8-8ee3-86f6ea7589fb.gif)


After
----------------------------------------
The actual number of rows listed and the row count per page is equal now. In the screencast below, 10 rows are listed as per 10 counts per page:
![test-multiple-after](https://user-images.githubusercontent.com/3735621/36527555-343bbe2a-17d8-11e8-9c83-0d7f522d566c.gif)

---

 * [CRM-21789: 'Find Case' group by issue](https://issues.civicrm.org/jira/browse/CRM-21789)