### PR TITLE
CRM-21771: error when viewing event registration with linked contribu…

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4108,7 +4108,7 @@ WHERE eft.financial_trxn_id IN ({$trxnId}, {$baseTrxnId['financialTrxnId']})
     }
 
     $paymentBalance = CRM_Core_BAO_FinancialTrxn::getPartialPaymentWithType($id, $entity, FALSE, $total);
-    $contribution = civicrm_api3('Contribution', 'getsingle', array('id' => $id, 'return' => array('is_pay_later', 'contribution_status_id', 'financial_type_id')));
+    $contribution = civicrm_api3('Contribution', 'getsingle', array('id' => $contributionId, 'return' => array('is_pay_later', 'contribution_status_id', 'financial_type_id')));
 
     $info['payLater'] = $contribution['is_pay_later'];
     $info['contribution_status'] = $contribution['contribution_status'];

--- a/tests/phpunit/api/v3/ParticipantPaymentTest.php
+++ b/tests/phpunit/api/v3/ParticipantPaymentTest.php
@@ -123,6 +123,27 @@ class api_v3_ParticipantPaymentTest extends CiviUnitTestCase {
     $this->contributionDelete($contributionID);
   }
 
+  /**
+   * Test getPaymentInfo() returns correct
+   * information of the participant payment
+   */
+  public function testPaymentInfoForEvent() {
+    //Create Contribution & get contribution ID
+    $contributionID = $this->contributionCreate(array('contact_id' => $this->_contactID));
+
+    //Create Participant Payment record With Values
+    $params = array(
+      'participant_id' => $this->_participantID4,
+      'contribution_id' => $contributionID,
+    );
+    $this->callAPISuccess('participant_payment', 'create', $params);
+
+    //Check if participant payment is correctly retrieved.
+    $paymentInfo = CRM_Contribute_BAO_Contribution::getPaymentInfo($this->_participantID4, 'event');
+    $this->assertEquals('Completed', $paymentInfo['contribution_status']);
+    $this->assertEquals('100.00', $paymentInfo['total']);
+  }
+
 
   ///////////////// civicrm_participant_payment_create methods
 


### PR DESCRIPTION
…tion

Overview
----------------------------------------
Fix fatal error on View Event Registration Page.

Before
----------------------------------------
Fees section displays fatal error when the event page is viewed.

![image](https://user-images.githubusercontent.com/5929648/36528410-fdd7d5fa-17da-11e8-89e7-a218f5a83386.png)


After
----------------------------------------
Fees section loads correctly with participant payment details.

Comments
----------------------------------------
Added unit test.

---

 * [CRM-21771: error when viewing event registration with linked contribution](https://issues.civicrm.org/jira/browse/CRM-21771)