### PR TITLE
CRM-21788 Clean URLs in WordPress

### DIFF
--- a/CRM/Core/QuickForm/Action/Jump.php
+++ b/CRM/Core/QuickForm/Action/Jump.php
@@ -74,6 +74,9 @@ class CRM_Core_QuickForm_Action_Jump extends CRM_Core_QuickForm_Action {
     }
     // generate the URL for the page 'display' event and redirect to it
     $action = $current->getAttribute('action');
+    // prevent URLs that end in ? from causing redirects
+    $action = rtrim($action, '?');
+    // FIXME: this should be passed through CRM_Utils_System::url()
     $url = $action . (FALSE === strpos($action, '?') ? '?' : '&') . $current->getButtonName('display') . '=true' . '&qfKey=' . $page->get('qfKey');
 
     CRM_Utils_System::redirect($url);

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -208,6 +208,7 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
     $fragment = isset($fragment) ? ('#' . $fragment) : '';
 
     $path = CRM_Utils_String::stripPathChars($path);
+    $basepage = FALSE;
 
     //this means wp function we are trying to use is not available,
     //so load bootStrap
@@ -215,14 +216,18 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
     if (!function_exists('get_option')) {
       $this->loadBootStrap();
     }
+
     if ($config->userFrameworkFrontend) {
+      global $post;
       if (get_option('permalink_structure') != '') {
-        global $post;
         $script = get_permalink($post->ID);
       }
-
+      if ($config->wpBasePage == $post->post_name) {
+        $basepage = TRUE;
+      }
       // when shortcode is included in page
       // also make sure we have valid query object
+      // FIXME: $wpPageParam has no effect and is only set on the *basepage*
       global $wp_query;
       if (method_exists($wp_query, 'get')) {
         if (get_query_var('page_id')) {
@@ -251,18 +256,54 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
     }
 
     $queryParts = array();
-    if (isset($path)) {
-      $queryParts[] = 'page=CiviCRM';
-      $queryParts[] = "q={$path}";
-    }
-    if ($wpPageParam) {
-      $queryParts[] = $wpPageParam;
-    }
-    if (isset($query)) {
-      $queryParts[] = $query;
+
+    // CRM_Core_Payment::getReturnSuccessUrl() passes $query as an array
+    if (isset($query) && is_array($query)) {
+      $query = implode($separator, $query);
     }
 
-    return $base . '?' . implode($separator, $queryParts) . $fragment;
+    if (
+      !$config->cleanURL // not using clean URLs
+      || ((is_admin() && !$frontend) || $forceBackend) // requesting an admin URL
+      || (!$basepage && $script != '') // is shortcode
+    ) {
+
+      // pre-existing logic
+      if (isset($path)) {
+        $queryParts[] = 'page=CiviCRM';
+        $queryParts[] = "q={$path}";
+      }
+      if ($wpPageParam) {
+        $queryParts[] = $wpPageParam;
+      }
+      if (isset($query)) {
+        $queryParts[] = $query;
+      }
+
+      $final = $base . '?' . implode($separator, $queryParts) . $fragment;
+
+    }
+    else {
+
+      // clean URLs
+      if (isset($path)) {
+        $base = trailingslashit($base) . str_replace('civicrm/', '', $path) . '/';
+      }
+      if (isset($query)) {
+        $query = ltrim($query, '=?&');
+        $queryParts[] = $query;
+      }
+
+      if (!empty($queryParts)) {
+        $final = $base . '?' . implode($separator, $queryParts) . $fragment;
+      }
+      else {
+        $final = $base . $fragment;
+      }
+
+    }
+
+    return $final;
   }
 
   /**

--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -457,6 +457,9 @@ if (!defined('CIVICRM_CLEANURL')) {
   elseif ( function_exists('config_get') && config_get('system.core', 'clean_url') != 0) {
     define('CIVICRM_CLEANURL', 1 );
   }
+  elseif( function_exists('get_option') && get_option('permalink_structure') != '' ) {
+    define('CIVICRM_CLEANURL', 1);
+  }
   else {
     define('CIVICRM_CLEANURL', 0);
   }

--- a/templates/CRM/common/paymentBlock.tpl
+++ b/templates/CRM/common/paymentBlock.tpl
@@ -111,7 +111,7 @@
 
       var payment_instrument_id = $('#payment_instrument_id').val();
 
-      var dataUrl = "{crmURL p='civicrm/payment/form' h=0 q="&formName=`$form.formName`&currency=`$currency`&`$urlPathVar``$isBackOfficePathVar``$profilePathVar``$contributionPageID``$preProfileID`processor_id="}" + type;
+      var dataUrl = "{crmURL p='civicrm/payment/form' h=0 q="formName=`$form.formName`&currency=`$currency`&`$urlPathVar``$isBackOfficePathVar``$profilePathVar``$contributionPageID``$preProfileID`processor_id="}" + type;
       {literal}
       if (typeof(CRM.vars) != "undefined") {
         if (typeof(CRM.vars.coreForm) != "undefined") {


### PR DESCRIPTION
Overview
----------------------------------------
This PR accompanies - and is dependent on - [this PR on the CiviCRM WordPress repo](https://github.com/civicrm/civicrm-wordpress/pull/123) to implement clean URLs in WordPress.

Before
----------------------------------------
URLs in WordPress are of the form:
`https://civicrm.latest/civicrm/?page=CiviCRM&q=civicrm/contribute/transact&reset=1&id=1`

After
----------------------------------------
URLs in WordPress have the same structure as those in Drupal, e.g.:
`https://civicrm.standalone.latest/civicrm/contribute/transact/?reset=1&id=1`

Technical Details
----------------------------------------
I have kept these commits separate because each probably merits discussion in its own right. I'll leave the discussion to the comment thread.

Comments
----------------------------------------
Of particular note may be cea37e0 since it was only by fixing this that I got hit by (and solved) the dreaded "Could not find valid value for id” error page. This is one of the most common errors reported on Stack Exchange:

https://civicrm.stackexchange.com/search?q=Could+not+find+valid+value+for+id

It occurs when URLs are malformed like so:

`https://civicrm.latest/civicrm/event/register/?&_qf_ThankYou_display=true&qfKey=a3f542cba021a05df18f477f691f8c97_7747`

Note the `?&` which is the result of the `perform()` method incorrectly handling (perfectly valid) URLs that end with an ampersand. I wonder if this is the root cause of this slippery issue?
