### PR TITLE
CRM-21791 Use name for comparison instead of label

### DIFF
--- a/CRM/Financial/Form/FinancialBatch.php
+++ b/CRM/Financial/Form/FinancialBatch.php
@@ -196,7 +196,7 @@ class CRM_Financial_Form_FinancialBatch extends CRM_Contribute_Form {
   public function postProcess() {
     $session = CRM_Core_Session::singleton();
     $params = $this->exportValues();
-    $batchStatus = CRM_Core_PseudoConstant::get('CRM_Batch_DAO_Batch', 'status_id');
+    $batchStatus = CRM_Core_PseudoConstant::get('CRM_Batch_DAO_Batch', 'status_id', array('labelColumn' => 'name'));
     if ($this->_id) {
       $params['id'] = $this->_id;
     }


### PR DESCRIPTION
Overview
----------------------------------------
Financial batch creation doesn't work properly with translated batch statuses.

Before
----------------------------------------
When creating a financial batch with some localized batch statuses, the status_id is 0 in the database which require the user to update the status before being able to add transactions to the batch.

---

 * [CRM-21791: Accounting batch closed by default when created in localized civicrm](https://issues.civicrm.org/jira/browse/CRM-21791)