### PR TITLE
CRM-21795 - Avoid fatal error to be displayed in log files.

### DIFF
--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -853,10 +853,12 @@ AND    u.status = 1
    * Similar to drupal_exit().
    */
   public function onCiviExit() {
-    if (!defined('MAINTENANCE_MODE') || MAINTENANCE_MODE != 'update') {
-      module_invoke_all('exit');
+    if (function_exists('module_invoke_all')) {
+      if (!defined('MAINTENANCE_MODE') || MAINTENANCE_MODE != 'update') {
+        module_invoke_all('exit');
+      }
+      drupal_session_commit();
     }
-    drupal_session_commit();
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fix fatal error - CRM/Utils/System/Drupal.php on line 857

Before
----------------------------------------
This doesn't occur when we navigate through the site but are recorded silently in the error log files. Maybe, CMS isn't bootstrapped and some function call happens at the backend.

>[18-Feb-2018 11:15:00 Pacific/Auckland] PHP Fatal error: Call to undefined function module_invoke_all() in /srv/www/livingstreets/livingstreets.org.nz/sites/all/modules/civicrm/CRM/Utils/System/Drupal.php on line 857
>[17-Feb-2018 17:15:27 America/New_York] PHP Fatal error: Call to undefined function module_invoke_all() in /var/www/mainepeoplesalliance/www.mainepeoplesalliance.org/sites/all/modules/civicrm/CRM/Utils/System/Drupal.php on line 857

After
----------------------------------------
Added a safety check to `onCiviExit()` function which avoids the fatal error  to be recorded.

---

 * [CRM-21795: Fatal error: civicrm\/CRM\/Utils\/System\/Drupal.php on line 857](https://issues.civicrm.org/jira/browse/CRM-21795)