### PR TITLE
CRM-21797: Fixed structure for campaign search pages

### DIFF
--- a/templates/CRM/Campaign/Form/Search/Common.tpl
+++ b/templates/CRM/Campaign/Form/Search/Common.tpl
@@ -60,16 +60,25 @@
           <td class="font-size12pt">
             {$form.sort_name.label}
           </td>
-          <td>
+          <td colspan="3">
             {$form.sort_name.html|crmAddClass:'twenty'}
           </td>
-          <td><label>{ts}Contact Type(s){/ts}</label><br />
+        </tr>
+        <tr>
+          <td>
+            <label>{ts}Contact Type(s){/ts}</label>
+          </td>
+          <td>
             {$form.contact_type.html}
           </td>
-          <td><label>{ts}Group(s){/ts}</label>
+          <td>
+            <label>{ts}Group(s){/ts}</label>
+          </td>
+          <td >
             {$form.group.html}
           </td>
         </tr>
+
         <tr>
           <td class="font-size12pt">
             {$form.street_address.label}


### PR DESCRIPTION
Overview
----------------------------------------
This PR fixes structure for Campaign search pages.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/26058635/36586987-afcc22ce-18a9-11e8-8090-cac018d268c1.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/26058635/36587012-c64b7c8e-18a9-11e8-8aa1-16bb3535ce97.png)

---

 * [CRM-21797: Change Structure for Campaign search forms](https://issues.civicrm.org/jira/browse/CRM-21797)