### PR TITLE
CRM-21798 updates CRM_Event_BAO_Event::checkPermission so it can be called repeatedly to check permissions on a list of even

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -2075,10 +2075,8 @@ WHERE  ce.loc_block_id = $locBlockId";
         ),
       );
 
-      if ($eventId) {
-        $params['id'] = $eventId;
-      }
-
+      // CRM-21798 removed setting the ID as a parameter as this meant we only
+      // got the first event for which to check permissions.
       $result = civicrm_api3('Event', 'get', $params);
       $allEvents = CRM_Utils_Array::collect('title', $result['values']);
 


### PR DESCRIPTION
Removed setting the ID as a parameter before getting the list of events as this meant we only got the first event for which to check permissions.

Overview
----------------------------------------
This pull request updates CRM_Event_BAO_Event::checkPermission so it can be called repeatedly to check permissions on a list of event.

Before
----------------------------------------
When CRM_Event_BAO_Event::checkPermission(<id>) is called repeatedly, it only checks permissions for the first event.  All other events are set to have no permissions.
After
----------------------------------------
When CRM_Event_BAO_Event::checkPermission(<id>) is called repeatedly, it checks the permissions for each event and returns them.

Technical Details
----------------------------------------
   if ($eventId) {
        $params['id'] = $eventId;
   }
in lines 2078ff before getting the result meant that the function only remembered the permissions of the first event checked.  Deleting this statement means that all relevant events are checked. The permission on a specific event is checked later on.


Comments
----------------------------------------
_Anything else you would like the reviewer to note_

---

 * [CRM-21798: CRM_Event_BAO_Event::checkPermission\($dao-\>id\) only works with the first ID when called repeatedly.](https://issues.civicrm.org/jira/browse/CRM-21798)