### PR TITLE
CRM-21803 Fix another entity to be standardised & support custom data

### DIFF
--- a/CRM/Event/BAO/ParticipantPayment.php
+++ b/CRM/Event/BAO/ParticipantPayment.php
@@ -41,14 +41,15 @@ class CRM_Event_BAO_ParticipantPayment extends CRM_Event_DAO_ParticipantPayment 
    * @param array $params
    *   of values to initialize the record with.
    * @param array $ids
-   *   with one values of id for this participantPayment record (for update).
+   *   deprecated array.
    *
    * @return object
    *   the partcipant payment record
    */
-  public static function create(&$params, &$ids) {
-    if (isset($ids['id'])) {
-      CRM_Utils_Hook::pre('edit', 'ParticipantPayment', $ids['id'], $params);
+  public static function create(&$params, $ids = []) {
+    $id = CRM_Utils_Array::value('id', $params, CRM_Utils_Array::value('id', $ids));
+    if ($id) {
+      CRM_Utils_Hook::pre('edit', 'ParticipantPayment', $id, $params);
     }
     else {
       CRM_Utils_Hook::pre('create', 'ParticipantPayment', NULL, $params);
@@ -56,16 +57,21 @@ class CRM_Event_BAO_ParticipantPayment extends CRM_Event_DAO_ParticipantPayment 
 
     $participantPayment = new CRM_Event_BAO_ParticipantPayment();
     $participantPayment->copyValues($params);
-    if (isset($ids['id'])) {
-      $participantPayment->id = CRM_Utils_Array::value('id', $ids);
+    if ($id) {
+      $participantPayment->id = $id;
     }
     else {
       $participantPayment->find(TRUE);
     }
     $participantPayment->save();
 
-    if (isset($ids['id'])) {
-      CRM_Utils_Hook::post('edit', 'ParticipantPayment', $ids['id'], $participantPayment);
+    if (empty($participantPayment->contribution_id)) {
+      // For an id update contribution_id may be unknown. We want it
+      // further down so perhaps get it before the hooks.
+      $participantPayment->find(TRUE);
+    }
+    if ($id) {
+      CRM_Utils_Hook::post('edit', 'ParticipantPayment', $id, $participantPayment);
     }
     else {
       CRM_Utils_Hook::post('create', 'ParticipantPayment', NULL, $participantPayment);

--- a/CRM/Event/Cart/Form/Checkout/Payment.php
+++ b/CRM/Event/Cart/Form/Checkout/Payment.php
@@ -86,8 +86,7 @@ class CRM_Event_Cart_Form_Checkout_Payment extends CRM_Event_Cart_Form_Cart {
         'participant_id' => $participant->id,
         'contribution_id' => $params['contributionID'],
       );
-      $ids = array();
-      CRM_Event_BAO_ParticipantPayment::create($payment_params, $ids);
+      CRM_Event_BAO_ParticipantPayment::create($payment_params);
     }
 
     $transaction->commit();

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1308,9 +1308,8 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
         'participant_id' => $participants[0]->id,
         'contribution_id' => $contribution->id,
       );
-      $ids = array();
 
-      CRM_Event_BAO_ParticipantPayment::create($paymentParticipant, $ids);
+      CRM_Event_BAO_ParticipantPayment::create($paymentParticipant);
       $this->_contactIds[] = $this->_contactId;
     }
     else {

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -761,8 +761,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
         'participant_id' => $participant->id,
         'contribution_id' => $contribution->id,
       );
-      $ids = array();
-      $paymentPartcipant = CRM_Event_BAO_ParticipantPayment::create($paymentParams, $ids);
+      $paymentPartcipant = CRM_Event_BAO_ParticipantPayment::create($paymentParams);
     }
 
     //set only primary participant's params for transfer checkout.

--- a/api/v3/ParticipantPayment.php
+++ b/api/v3/ParticipantPayment.php
@@ -43,17 +43,7 @@
  * @return array
  */
 function civicrm_api3_participant_payment_create($params) {
-
-  $ids = array();
-  if (!empty($params['id'])) {
-    $ids['id'] = $params['id'];
-  }
-  $participantPayment = CRM_Event_BAO_ParticipantPayment::create($params, $ids);
-
-  $payment = array();
-  _civicrm_api3_object_to_array($participantPayment, $payment[$participantPayment->id]);
-
-  return civicrm_api3_create_success($payment, $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'ParticipantPayment');
 }
 
 /**

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -748,8 +748,7 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
       'participant_id' => $participant->id,
       'contribution_id' => $contribution['id'],
     );
-    $ids = array();
-    CRM_Event_BAO_ParticipantPayment::create($paymentParticipant, $ids);
+    CRM_Event_BAO_ParticipantPayment::create($paymentParticipant);
 
     $contributionObject = new CRM_Contribute_BAO_Contribution();
     $contributionObject->id = $contribution['id'];

--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -393,7 +393,6 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
       'UFJoin',
       'UFField',
       'PriceFieldValue',
-      'Website',
       'JobLog',
       'GroupContact',
       'EntityTag',
@@ -401,7 +400,6 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
       'PaymentProcessorType',
       'Relationship',
       'RelationshipType',
-      'ParticipantPayment',
 
       // ones that are not real entities hence not extendable.
       'ActivityType',
@@ -466,7 +464,6 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
       'MailingContact',
       'EntityTag',
       'Participant',
-      'ParticipantPayment',
       'Setting',
       'SurveyRespondant',
       'MailingRecipients',
@@ -535,7 +532,6 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
       'GroupContact',
       'MembershipPayment',
       'Participant',
-      'ParticipantPayment',
       'LineItem',
       'PledgePayment',
       'ContributionPage',


### PR DESCRIPTION
Overview
----------------------------------------
Standardise participant payment api such that it supports custom data

Before
----------------------------------------
API  does not use standard api function

After
----------------------------------------
Api does use standard api function

Technical Details
----------------------------------------
This is a minor tidy up

Comments
----------------------------------------

I did not find any places where $ids is passed into this function populated. We could deprecate it more actively with a deprecation message

---

 * [CRM-21803: Standardise ParticipantPayment api to support custom data](https://issues.civicrm.org/jira/browse/CRM-21803)