### PR TITLE
Throw exception instead of using fatal

### DIFF
--- a/CRM/Event/Cart/Form/Checkout/Payment.php
+++ b/CRM/Event/Cart/Form/Checkout/Payment.php
@@ -670,10 +670,7 @@ class CRM_Event_Cart_Form_Checkout_Payment extends CRM_Event_Cart_Form_Cart {
       $contribParams['payment_processor'] = $this->_paymentProcessor['id'];
     }
 
-    $contribution = &CRM_Contribute_BAO_Contribution::add($contribParams);
-    if (is_a($contribution, 'CRM_Core_Error')) {
-      CRM_Core_Error::fatal(ts("There was an error creating a contribution record for your event. Please report this error to the webmaster. Details: %1", array(1 => $contribution->getMessages($contribution))));
-    }
+    $contribution = CRM_Contribute_BAO_Contribution::add($contribParams);
     $mer_participant->contribution_id = $contribution->id;
     $params['contributionID'] = $contribution->id;
 


### PR DESCRIPTION
Overview
----------------------------------------
Minor code improvement - use exception rather than fatal

Before
----------------------------------------
CRM_Core_Error::fatal($message); shows the below regardless of whether debugging is enabled
![screenshot 2018-02-26 13 29 14](https://user-images.githubusercontent.com/336308/36650848-705254d4-1b0a-11e8-810a-81417d4c6586.png)


After
----------------------------------------
![screenshot 2018-02-26 18 52 28](https://user-images.githubusercontent.com/336308/36655235-36bdc750-1b26-11e8-80c9-b7dc37b0ac09.png)



Technical Details
----------------------------------------
In general we are working towards deprecating 'fatal' - in this case we can convert it to an exception & add handling to the exception to improve user experience

Comments
---------------------------------------
Note that I replicate this error when debugging but have not seen the duplicate contribution error 'out in the wild' - to replicate in debugging start doing a contribution, kill half way through & then re-submit.

@colemanw @seamuslee001 @monishdeb would be good to get your thoughts on this (ps. I bet @mattwire has hit this error!)