### PR TITLE
CRM-18011 improve lock handling for mysql 5.7.5+

### DIFF
--- a/CRM/Core/Lock.php
+++ b/CRM/Core/Lock.php
@@ -177,7 +177,7 @@ class CRM_Core_Lock implements \Civi\Core\Lock\LockInterface {
    */
   public function acquire($timeout = NULL) {
     if (!$this->_hasLock) {
-      if (self::$jobLog && CRM_Core_DAO::singleValueQuery("SELECT IS_USED_LOCK( '" . self::$jobLog . "')")) {
+      if (!CRM_Utils_SQL::supportsMultipleLocks() && self::$jobLog && CRM_Core_DAO::singleValueQuery("SELECT IS_USED_LOCK( '" . self::$jobLog . "')")) {
         return $this->hackyHandleBrokenCode(self::$jobLog);
       }
 

--- a/CRM/Utils/SQL.php
+++ b/CRM/Utils/SQL.php
@@ -78,7 +78,7 @@ class CRM_Utils_SQL {
    */
   public static function supportsFullGroupBy() {
     // CRM-21455 MariaDB 10.2 does not support ANY_VALUE
-    $version = CRM_Core_DAO::singleValueQuery('SELECT VERSION()');
+    $version = self::getDatabaseVersion();
 
     if (stripos($version, 'mariadb') !== FALSE) {
       return FALSE;
@@ -120,6 +120,29 @@ class CRM_Utils_SQL {
       return FALSE;
     }
     return TRUE;
+  }
+
+  /**
+   * Does the database support multiple Locks.
+   *
+   * https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_get-lock
+   */
+  public static function supportsMultipleLocks() {
+    $version = self::getDatabaseVersion();
+    if (stripos($version, 'mariadb') !== FALSE) {
+      return FALSE;
+    }
+
+    return version_compare($version, '5.7.5', '>=');
+  }
+
+  /**
+   * Get the version string for the database.
+   *
+   * @return string
+   */
+  public static function getDatabaseVersion() {
+    return CRM_Core_DAO::singleValueQuery('SELECT VERSION()');
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Improve mysql lock support for mysql 5.7.5

Before
----------------------------------------
Prior to mysql 5.7.5 GETting a mysql LOCK will release other locks held by the process. In order to not do that for the (all important) civimail worker lock we bypass calling GET LOCK if that process has already got a lock. 

After
----------------------------------------
We only bypass getting the lock for maria DB & mysql versions prior to 5.7.5.

Technical Details
----------------------------------------
From https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_get-lock

Before 5.7.5, only a single simultaneous lock can be acquired and GET_LOCK() releases any existing lock.

In MySQL 5.7.5, GET_LOCK() was reimplemented using the metadata locking (MDL) subsystem and its capabilities were extended. Multiple simultaneous locks can be acquired and GET_LOCK() does not release any existing locks. It is even possible for a given session to acquire multiple locks for the same name. Other sessions cannot acquire a lock with that name until the acquiring session releases all its locks for the name.

Comments
----------------------------------------
Also from the documentation (but outside scope of this change)

"GET_LOCK() is unsafe for statement-based replication. A warning is logged if you use this function when binlog_format is set to STATEMENT."

---

 * [CRM-18011: Mailer CRON job limit does not work](https://issues.civicrm.org/jira/browse/CRM-18011)