### PR TITLE
CRM-21733: Set status override end date to null if no 'Override until selected date' is not selected

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -926,11 +926,29 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
     }
     // get the submitted form values.
     $this->_params = $this->controller->exportValues($this->_name);
-    $this->convertIsOverrideValue();
+    $this->prepareStatusOverrideValues();
 
     $this->submit();
 
     $this->setUserContext();
+  }
+
+  /**
+   * Prepares the values related to status override.
+   */
+  private function prepareStatusOverrideValues() {
+    $this->setOverrideDateValue();
+    $this->convertIsOverrideValue();
+  }
+
+  /**
+   * Sets status override end date to empty value if
+   * the selected override option is not 'until date'.
+   */
+  private function setOverrideDateValue() {
+    if (!CRM_Member_StatusOverrideTypes::isUntilDate($this->_params['is_override'])) {
+      $this->_params['status_override_end_date'] = '';
+    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This a complementary PR for this one https://github.com/civicrm/civicrm-core/pull/11622, it is to fix the issue mentioned here by @eileenmcnaughton  https://github.com/civicrm/civicrm-core/pull/11622#issuecomment-365033619 where changing the override type from "until date" to either "no" or "permanent" but 'until date' does not get changed to null and its value stay on the old date.


Before
----------------------------------------
Changing the membership **Status Override?**  field value from 'Override until selected date' to either **Override Permanently** or **No** will keep the **status override end date** value as is.

After
----------------------------------------
Changing the membership **Status Override?**  field value from 'Override until selected date' to either **Override Permanently** or **No** will set the **status override end date** to NULL (empty value).

---

 * [CRM-21733: Allow overriding membership status temporarily until specific date](https://issues.civicrm.org/jira/browse/CRM-21733)