### PR TITLE
CRM-21805: Fixed fields and labels in find participants

### DIFF
--- a/templates/CRM/Contact/Form/Search/ContactSearchFields.tpl
+++ b/templates/CRM/Contact/Form/Search/ContactSearchFields.tpl
@@ -1,12 +1,16 @@
 <tr>
   <td class="font-size12pt">
-    {$form.sort_name.label}&nbsp;&nbsp;{$form.sort_name.html|crmAddClass:'twenty'}
+    {$form.sort_name.label}
+    <br>
+    {$form.sort_name.html|crmAddClass:'twenty'}
   </td>
   <td>{$form.buttons.html}</td>
 </tr>
 <tr>
   {if $form.contact_tags}
-    <td><label>{$form.contact_tags.label}</label>
+    <td>
+      <label>{$form.contact_tags.label}</label>
+      <br>
       {$form.contact_tags.html}
     </td>
   {else}
@@ -14,7 +18,9 @@
   {/if}
 
   {if $form.group}
-    <td><label>{$form.group.label}</label>
+    <td>
+      <label>{$form.group.label}</label>
+      <br>
       {$form.group.html}
     </td>
   {else}
@@ -22,7 +28,11 @@
   {/if}
 </tr>
 <tr class="crm-event-search-form-block-deleted_contacts">
-  <td>{$form.contact_type.label}&nbsp;&nbsp;{$form.contact_type.html}<br></td>
+  <td>
+    {$form.contact_type.label}
+    <br>
+    {$form.contact_type.html}
+  </td>
   <td>
     {if $form.deleted_contacts}
       {$form.deleted_contacts.html}&nbsp;&nbsp;{$form.deleted_contacts.label}

--- a/templates/CRM/Event/Form/Search/Common.tpl
+++ b/templates/CRM/Event/Form/Search/Common.tpl
@@ -33,16 +33,10 @@
   <td class="crm-event-form-block-event_type_id"> {$form.event_type_id.label}<br />{$form.event_type_id.html} </td>
 </tr>
 <tr>
-  <td colspan="2"><label>{ts}Event Dates{/ts}</label></td>
+  {include file="CRM/Core/DateRange.tpl" fieldName="event" from='_start_date_low' to='_end_date_high' label="<label>Event Dates</label>"}
 </tr>
 <tr>
-{include file="CRM/Core/DateRange.tpl" fieldName="event" from='_start_date_low' to='_end_date_high'}
-</tr>
-<tr>
-  <td><label>{ts}Registration Date{/ts}</label></td>
-</tr>
-<tr>
-{include file="CRM/Core/DateRange.tpl" fieldName="participant" from='_register_date_low' to='_register_date_high'}
+  {include file="CRM/Core/DateRange.tpl" fieldName="participant" from='_register_date_low' to='_register_date_high' label="<label>Registration Date</label>"}
 </tr>
 <tr>
   <td class="crm-event-form-block-participant_status"><label>{$form.participant_status_id.label}</label>


### PR DESCRIPTION
Overview
----------------------------------------
This PR fixes participant page structure and common templates

Before
----------------------------------------
![before](https://user-images.githubusercontent.com/26058635/36672095-0c178b00-1b24-11e8-89bc-d328de8fa8d2.png)

After
----------------------------------------
![after](https://user-images.githubusercontent.com/26058635/36672026-cea7a840-1b23-11e8-8f10-1ae9ae715832.png)

Comments
----------------------------------------
- BackstopJS testing is done to make sure other forms using common template looks fine and works without breaking.

---

 * [CRM-21805: Fix structure for search pages in find participant](https://issues.civicrm.org/jira/browse/CRM-21805)