### PR TITLE
CRM-21779 - ang\crmMailing - Fix adding empty mailing to recipients field

### DIFF
--- a/ang/crmMailing/Recipients.js
+++ b/ang/crmMailing/Recipients.js
@@ -229,6 +229,11 @@
                 page_num: rcpAjaxState.page_i,
                 params: filterParams,
               };
+
+              if('civicrm_mailing' === rcpAjaxState.entity) {
+                params["api.MailingRecipients.getcount"] = {};
+              }
+
               return params;
             },
             transport: function(params) {
@@ -246,12 +251,18 @@
             results: function(data) {
               results = {
                 children: $.map(data.values, function(obj) {
-                  return {   id: obj.id + ' ' + rcpAjaxState.entity + ' ' + rcpAjaxState.type,
-                             text: obj.label };
+                  if('civicrm_mailing' === rcpAjaxState.entity) {
+                    return obj["api.MailingRecipients.getcount"] > 0 ? {   id: obj.id + ' ' + rcpAjaxState.entity + ' ' + rcpAjaxState.type,
+                               text: obj.label } : '';
+                  }
+                  else {
+                    return {   id: obj.id + ' ' + rcpAjaxState.entity + ' ' + rcpAjaxState.type,
+                               text: obj.label };
+                  }
                 })
               };
 
-              if (rcpAjaxState.page_i == 1 && data.count) {
+              if (rcpAjaxState.page_i == 1 && data.count && results.children.length > 0) {
                 results.text = ts((rcpAjaxState.type == 'include'? 'Include ' : 'Exclude ') +
                   (rcpAjaxState.entity == 'civicrm_group'? 'Group' : 'Mailing'));
               }


### PR DESCRIPTION
Overview
----------------------------------------
This PR prevents CiviMail from adding mailing lists including draft and unscheduled mailings that do not have any recipients

Before
----------------------------------------
![crm-21779](https://user-images.githubusercontent.com/14212201/36680922-34e948ee-1b28-11e8-95ac-79731b60d944.jpg)

After
----------------------------------------
![crm-21779 2](https://user-images.githubusercontent.com/14212201/36681076-9e8d41b0-1b28-11e8-9f88-d4d77c6f27ed.jpg)

Technical Details
----------------------------------------
Add chain rule to Mailing getlist api call to include MailingRecipients getcount then filter civicrm_mailing options by api.MailingRecipients.getcount

Comments
----------------------------------------
_Anything else you would like the reviewer to note_

---

 * [CRM-21779: Civimail allows adding current draft mailing recipients to recipients field](https://issues.civicrm.org/jira/browse/CRM-21779)