### PR TITLE
CiviReport - Check for trueish values of the parameter 'required'

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -866,7 +866,7 @@ class CRM_Report_Form extends CRM_Core_Form {
       if (array_key_exists('fields', $table)) {
         foreach ($table['fields'] as $fieldName => $field) {
           if (empty($field['no_display'])) {
-            if (isset($field['required'])) {
+            if (!empty($field['required'])) {
               // set default
               $this->_defaults['fields'][$fieldName] = 1;
 


### PR DESCRIPTION
Overview
----------------------------------------
The value of the parameter `required` is not evaluated to define whether the field should be shown as required or not.

See previous discussion at: https://github.com/civicrm/civicrm-dev-docs/pull/480

Before
----------------------------------------
```
'id' => array(
  'title' => ts('CiviCRM ID'),
  'default' => TRUE,
  'required' => FALSE,
),
```
![grafik](https://user-images.githubusercontent.com/19712240/36721547-81f4c4e6-1bab-11e8-95df-7fb75f4de8f8.png)

After
----------------------------------------
```
'id' => array(
  'title' => ts('CiviCRM ID'),
  'default' => TRUE,
  'required' => FALSE,
),
```
![grafik](https://user-images.githubusercontent.com/19712240/36721587-9ebfda02-1bab-11e8-83ce-367fbce33800.png)