### PR TITLE
CRM-21808 Install custom group for Contribution or ContributioRecur s…

### DIFF
--- a/CRM/Utils/Migrate/Import.php
+++ b/CRM/Utils/Migrate/Import.php
@@ -242,6 +242,15 @@ WHERE      v.option_group_id = %1
             elseif (in_array($customGroup->extends, array('Individual', 'Organization', 'Household'))) {
               $valueIDs = $optionValues;
             }
+            elseif (in_array($customGroup->extends, array('Contribution', 'ContributionRecur'))) {
+              $sql = "SELECT id
+                      FROM civicrm_financial_type
+                      WHERE name IN ('{$optValues}')";
+              $dao = &CRM_Core_DAO::executeQuery($sql);
+              while ($dao->fetch()) {
+                $valueIDs[] = $dao->id;
+              }
+            }
             else {
               $sql = "
 SELECT     v.value


### PR DESCRIPTION
…ubtypes based on XML file
https://issues.civicrm.org/jira/browse/CRM-21808

Overview
----------------------------------------
It will be useful to create custom group by XML file also for subtypes of Contribution or ContributionRecur entities.

Before
----------------------------------------
It's not possible to properly install custom group for Contribution or ContributionRecur entity with particular subtype (financial type)

After
----------------------------------------
There is a possibility to create custom group for Contribution or ContributionRecur by *install.xml file or during upgrade step of extension by executeCustomDataFileByAbsPath(./my_contrib_custom.xml).

Technical Details
----------------------------------------
Add to CustomGroup XML element those options:

    <extends_entity_column_value_option_group >FinancialType</extends_entity_column_value_option_group>
    <extends_entity_column_value>Donation</extends_entity_column_value> 