### PR TITLE
CRM-21807 - Deleted contacts included by default in Membership and co…

### DIFF
--- a/CRM/Report/Form/Contribute/Detail.php
+++ b/CRM/Report/Form/Contribute/Detail.php
@@ -73,7 +73,7 @@ class CRM_Report_Form_Contribute_Detail extends CRM_Report_Form {
       'fields_defaults' => array('sort_name'),
       'fields_excluded' => array('id'),
       'fields_required' => array('id'),
-      'filters_defaults' => array('is_deleted' => FALSE),
+      'filters_defaults' => array('is_deleted' => 0),
       'no_field_disambiguation' => TRUE,
     )), array(
       'civicrm_email' => array(

--- a/CRM/Report/Form/Member/Detail.php
+++ b/CRM/Report/Form/Member/Detail.php
@@ -81,6 +81,11 @@ class CRM_Report_Form_Member_Detail extends CRM_Report_Form {
             'title' => ts('Contact Name'),
             'operator' => 'like',
           ),
+          'is_deleted' => array(
+            'title' => ts('Is Deleted'),
+            'default' => 0,
+            'type' => CRM_Utils_Type::T_BOOLEAN,
+          ),
           'id' => array('no_display' => TRUE),
         ),
         'order_bys' => array(


### PR DESCRIPTION
…ntribution detail report

Overview
----------------------------------------
Add `is_deleted` filter on contribution and membership report and set it to 0 by default.

Before
----------------------------------------
Deleted contacts included by default in Membership and contribution detail report.

After
----------------------------------------
Deleted contacts not listed in these reports unless specified explicitly in filters.

---

 * [CRM-21807: Deleted contacts included by default in Membership and contribution detail report](https://issues.civicrm.org/jira/browse/CRM-21807)