### PR TITLE
CRM-21810 changelog panel UI tweaks

### DIFF
--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -396,9 +396,9 @@ class CRM_Contact_Form_Search_Criteria {
     $form->addElement('text', 'changed_by', ts('Modified By'), NULL);
 
     $dates = array(1 => ts('Added'), 2 => ts('Modified'));
-    $form->addRadio('log_date', NULL, $dates, array('allowClear' => TRUE), '<br />');
+    $form->addRadio('log_date', NULL, $dates, array('allowClear' => TRUE));
 
-    CRM_Core_Form_Date::buildDateRange($form, 'log_date', 1, '_low', '_high', ts('From'), FALSE, FALSE);
+    CRM_Core_Form_Date::buildDateRange($form, 'log_date', 1, '_low', '_high', ts('From:'), FALSE, FALSE);
   }
 
   /**

--- a/templates/CRM/Contact/Form/Search/Criteria/ChangeLog.tpl
+++ b/templates/CRM/Contact/Form/Search/Criteria/ChangeLog.tpl
@@ -26,24 +26,24 @@
 <div id="changelog" class="form-item">
   <table class="form-layout">
     <tr>
-      <td>
-        <span class="modifiedBy"><label>{ts}Modified By{/ts}</label></span>
-        <span class="hiddenElement addedBy"><label>{ts}Added By{/ts}</label></span>
-        <br/>
-        {$form.changed_by.html}
-      </td>
-      <td width="100%">
+      <td colspan="2">
         {$form.log_date.html}
-        <br/>
       </td>
     </tr>
     <tr>
+      <td width="30%">
+        <span class="modifiedBy"><label>{ts}Modified By{/ts}</label></span>
+        <span class="hiddenElement addedBy"><label>{ts}Added By{/ts}</label></span>
+      </td>
       <td>
         <span class="modifiedBy"><label>{ts}Modified Between{/ts}</label></span>
         <span class="hiddenElement addedBy"><label>{ts}Added Between{/ts}</label></span>
       </td>
     </tr>
     <tr>
+      <td>
+        {$form.changed_by.html}
+      </td>
       {include file="CRM/Core/DateRange.tpl" fieldName="log_date" from='_low' to='_high'}
     </tr>
   </table>


### PR DESCRIPTION
Overview
----------------------------------------
Improve the change log panel in Advanced Search UI. Place the added/modified radio buttons at the top and move the two search fields side by side to make the layout more logical and to make better use of the space.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/366478/36738994-e11082a2-1bac-11e8-972a-171eebfaeb61.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/366478/36739002-e85e2596-1bac-11e8-8edb-70680b06b3d7.png)

---

 * [CRM-21810: improve changelog search panel UI](https://issues.civicrm.org/jira/browse/CRM-21810)