### PR TITLE
RM385-65: Membership end date incremented twice by duration when pending contribution with amount 0.0

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -2377,16 +2377,16 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = membership.contact_id AND 
   public static function extractFormValues($form, $changeToday, $membershipTypeDetails, $pending = FALSE) {
     //@todo this is a BAO function & should not inspect the form - the form should do this
     // & pass required params to the BAO
-    if (CRM_Utils_Array::value('minimum_fee', $membershipTypeDetails) > 0.0) {
-      if (((isset($form->_contributeMode) && $form->_contributeMode == 'notify') || !empty($form->_params['is_pay_later'])
-        ) &&
-        (($form->_values['is_monetary'] && $form->_amount > 0.0) ||
+
+    if (((isset($form->_contributeMode) && $form->_contributeMode == 'notify') || !empty($form->_params['is_pay_later'])
+      ) &&
+        (($form->_values['is_monetary']) ||
           CRM_Utils_Array::value('record_contribution', $form->_params)
         )
       ) {
-        $pending = TRUE;
-      }
+      $pending = TRUE;
     }
+
     $contributionRecurID = isset($form->_params['contributionRecurID']) ? $form->_params['contributionRecurID'] : NULL;
 
     //we renew expired membership, CRM-6277


### PR DESCRIPTION
Overview
----------------------------------------
When a membership has a minimum fee of $0.00 and an admin renews their membership with a pending contribution, the membership end date is incremented by duration both when the pending contribution is created and after the contribution is marked as completed.

Steps to reproduce:
1. Find any contact in Civicrm
2. View the contact
3. Click MemberShips
4. Add a membership with a minimum fee of $0.00 - not lifetime
5. Click More -> Renew next to membership
6. Tick Record renewal Payment
7. Mark renewal contribution as pending and submit payment
8. Note that the membership end date has incremented by the duration outlined in the membership type
9. Navigate to Contributions section
10. Mark newly created contribution as complete
11. Refresh and navigate to Memberships page, note that membership end date has incremented again

Before
----------------------------------------
Membership period were incremented twice both when contribution is created and after the contribution is marked as completed.

After
----------------------------------------
Membership period gets incremented only once when the contribution is marked as completed.

_Agileware Ref: RM385-65_
