### PR TITLE
(release/1) Allow set-version.php to generate upgraders for major/minor increments

### DIFF
--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -69,24 +69,6 @@ class CRM_Upgrade_Form extends CRM_Core_Form {
   public $locales;
 
   /**
-   * Number to string mapper.
-   *
-   * @var array
-   */
-  static $_numberMap = array(
-    0 => 'Zero',
-    1 => 'One',
-    2 => 'Two',
-    3 => 'Three',
-    4 => 'Four',
-    5 => 'Five',
-    6 => 'Six',
-    7 => 'Seven',
-    8 => 'Eight',
-    9 => 'Nine',
-  );
-
-  /**
    * Constructor for the basic form page.
    *
    * We should not use QuickForm directly. This class provides a lot
@@ -137,7 +119,7 @@ class CRM_Upgrade_Form extends CRM_Core_Form {
     static $incrementalPhpObject = array();
 
     $versionParts = explode('.', $version);
-    $versionName = self::$_numberMap[$versionParts[0]] . self::$_numberMap[$versionParts[1]];
+    $versionName = CRM_Utils_EnglishNumber::toCamelCase($versionParts[0]) . CRM_Utils_EnglishNumber::toCamelCase($versionParts[1]);
 
     if (!array_key_exists($versionName, $incrementalPhpObject)) {
       $className = "CRM_Upgrade_Incremental_php_{$versionName}";

--- a/CRM/Upgrade/Incremental/php/Template.php
+++ b/CRM/Upgrade/Incremental/php/Template.php
@@ -1,0 +1,93 @@
+<?php
+if (PHP_SAPI !== 'cli') {
+  die("This template is only valid on CLI.");
+}
+echo "<?php\n";
+?>
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2017                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007.                                       |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License along with this program; if not, contact CiviCRM LLC       |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Upgrade logic for <?php echo $camelNumber; ?>
+ */
+class CRM_Upgrade_Incremental_php_<?php echo $camelNumber; ?> extends CRM_Upgrade_Incremental_Base {
+
+  /**
+   * Compute any messages which should be displayed beforeupgrade.
+   *
+   * Note: This function is called iteratively for each upcoming
+   * revision to the database.
+   *
+   * @param string $preUpgradeMessage
+   * @param string $rev
+   *   a version number, e.g. '4.4.alpha1', '4.4.beta3', '4.4.0'.
+   * @param null $currentVer
+   */
+  public function setPreUpgradeMessage(&$preUpgradeMessage, $rev, $currentVer = NULL) {
+    // Example: Generate a pre-upgrade message.
+    // if ($rev == '5.12.34') {
+    //   $preUpgradeMessage .= '<p>' . ts('A new permission has been added called %1 This Permission is now used to control access to the Manage Tags screen', array(1 => 'manage tags')) . '</p>';
+    // }
+  }
+
+  /**
+   * Compute any messages which should be displayed after upgrade.
+   *
+   * @param string $postUpgradeMessage
+   *   alterable.
+   * @param string $rev
+   *   an intermediate version; note that setPostUpgradeMessage is called repeatedly with different $revs.
+   */
+  public function setPostUpgradeMessage(&$postUpgradeMessage, $rev) {
+    // Example: Generate a post-upgrade message.
+    // if ($rev == '5.12.34') {
+    //   $postUpgradeMessage .= '<br /><br />' . ts("By default, CiviCRM now disables the ability to import directly from SQL. To use this feature, you must explicitly grant permission 'import SQL datasource'.");
+    // }
+  }
+
+  /*
+   * Important! All upgrade functions MUST add a 'runSql' task.
+   * Uncomment and use the following template for a new upgrade version
+   * (change the x in the function name):
+   */
+
+  //  /**
+  //   * Upgrade function.
+  //   *
+  //   * @param string $rev
+  //   */
+  //  public function upgrade_5_0_x($rev) {
+  //    $this->addTask(ts('Upgrade DB to %1: SQL', array(1 => $rev)), 'runSql', $rev);
+  //    $this->addTask('Do the foo change', 'taskFoo', ...);
+  //    // Additional tasks here...
+  //    // Note: do not use ts() in the addTask description because it adds unnecessary strings to transifex.
+  //    // The above is an exception because 'Upgrade DB to %1: SQL' is generic & reusable.
+  //  }
+
+  // public static function taskFoo(CRM_Queue_TaskContext $ctx, ...) {
+  //   return TRUE;
+  // }
+
+}

--- a/CRM/Utils/EnglishNumber.php
+++ b/CRM/Utils/EnglishNumber.php
@@ -1,0 +1,143 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2017                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2017
+ * $Id$
+ *
+ * Utilities for rendering numbers as English.
+ *
+ * Note: This file may be used in a standalone environment. Please ensure it
+ * remains self-sufficient (without needing any external services).
+ */
+class CRM_Utils_EnglishNumber {
+
+  protected static $lowNumbers = array(
+    'Zero',
+    'One',
+    'Two',
+    'Three',
+    'Four',
+    'Five',
+    'Six',
+    'Seven',
+    'Eight',
+    'Nine',
+    'Ten',
+    'Eleven',
+    'Twelve',
+    'Thirteen',
+    'Fourteen',
+    'Fifteen',
+    'Sixteen',
+    'Seventeen',
+    'Eighteen',
+    'Nineteen',
+  );
+
+  protected static $intervalsOfTen = array(
+    9 => 'Ninety',
+    8 => 'Eighty',
+    7 => 'Seventy',
+    6 => 'Sixty',
+    5 => 'Fifty',
+    4 => 'Forty',
+    3 => 'Thirty',
+    2 => 'Twenty',
+  );
+
+  /**
+   * @param int $num
+   *   Ex: 12 or 54.
+   * @param mixed $default
+   *   The default value to return if we cannot determine an English representation.
+   *   If omitted or NULL, throws an exception.
+   *   Tip: If you want to support high values as numerals, just pass the number again.
+   * @return string
+   *   Ex: 'Twelve' or 'FiftyFour'.
+   */
+  public static function toCamelCase($num, $default = NULL) {
+    if (isset(self::$lowNumbers[$num])) {
+      return self::$lowNumbers[$num];
+    }
+
+    $tens = (int) ($num / 10);
+    $last = $num % 10;
+    if (isset(self::$intervalsOfTen[$tens])) {
+      if ($last == 0) {
+        return self::$intervalsOfTen[$tens];
+      }
+      else {
+        return self::$intervalsOfTen[$tens] . self::$lowNumbers[$last];
+      }
+    }
+
+    if ($default === NULL) {
+      throw new \RuntimeException("Cannot convert number to English: " . (int) $num);
+    }
+    else {
+      return $default;
+    }
+  }
+
+  /**
+   * @param int $num
+   *   Ex: 12 or 54.
+   * @param mixed $default
+   *   The default value to return if we cannot determine an English representation.
+   *   If omitted or NULL, throws an exception.
+   *   Tip: If you want to support high values as numerals, just pass the number again.
+   * @return string
+   *   Ex: 'twelve' or 'fifty-four'.
+   */
+  public static function toHyphen($num, $default = NULL) {
+    if (isset(self::$lowNumbers[$num])) {
+      return strtolower(self::$lowNumbers[$num]);
+    }
+
+    $tens = (int) ($num / 10);
+    $last = $num % 10;
+    if (isset(self::$intervalsOfTen[$tens])) {
+      if ($last == 0) {
+        return strtolower(self::$intervalsOfTen[$tens]);
+      }
+      else {
+        return strtolower(self::$intervalsOfTen[$tens]) . '-' . strtolower(self::$lowNumbers[$last]);
+      }
+    }
+
+    if ($default === NULL) {
+      throw new \RuntimeException("Cannot convert number to English: " . (int) $num);
+    }
+    else {
+      return $default;
+    }
+  }
+
+}

--- a/tools/bin/scripts/set-version.php
+++ b/tools/bin/scripts/set-version.php
@@ -41,7 +41,21 @@ switch (@$argv[2]) {
 /* *********************************************************************** */
 /* Main */
 
-echo "Updating from $oldVersion to $newVersion...\n";
+echo "Changing version from $oldVersion to $newVersion...\n";
+
+$verName = makeVerName($newVersion);
+$phpFile = initFile("CRM/Upgrade/Incremental/php/{$verName}.php", function() use ($verName) {
+  ob_start();
+  global $camelNumber;
+  $camelNumber = $verName;
+  require 'CRM/Upgrade/Incremental/php/Template.php';
+  unset($camelNumber);
+  return ob_get_clean();
+});
+
+$sqlFile = initFile("CRM/Upgrade/Incremental/sql/{$newVersion}.mysql.tpl", function() use ($newVersion) {
+  return "{* file to handle db changes in $newVersion during upgrade *}\n";
+});
 
 updateFile("xml/version.xml", function ($content) use ($newVersion, $oldVersion) {
   return str_replace($oldVersion, $newVersion, $content);
@@ -51,14 +65,8 @@ updateFile("sql/civicrm_generated.mysql", function ($content) use ($newVersion, 
   return str_replace($oldVersion, $newVersion, $content);
 });
 
-$sqlFile = "CRM/Upgrade/Incremental/sql/{$newVersion}.mysql.tpl";
-if (!file_exists($sqlFile)) {
-  echo "Create \"$sqlFile\"\n";
-  file_put_contents($sqlFile, "{* file to handle db changes in $newVersion during upgrade *}\n");
-}
-
 if ($doCommit) {
-  $files = "xml/version.xml sql/civicrm_generated.mysql " . escapeshellarg($sqlFile);
+  $files = "xml/version.xml sql/civicrm_generated.mysql " . escapeshellarg($phpFile) . ' ' . escapeshellarg($sqlFile);
   passthru("git add $files");
   passthru("git commit $files -m " . escapeshellarg("Set version to $newVersion"));
 }
@@ -66,6 +74,13 @@ if ($doCommit) {
 /* *********************************************************************** */
 /* Helper functions */
 
+/**
+ * Update the content of a file.
+ *
+ * @param string $file
+ * @param callable $callback
+ *   Function(string $originalContent) => string $newContent.
+ */
 function updateFile($file, $callback) {
   if (!file_exists($file)) {
     die("File does not exist: $file\n");
@@ -74,6 +89,38 @@ function updateFile($file, $callback) {
   $content = file_get_contents($file);
   $content = $callback($content);
   file_put_contents($file, $content);
+}
+
+/**
+ * Initialize a file (if it doesn't already exist).
+ * @param string $file
+ * @param callable $callback
+ *   Function() => string $newContent.
+ */
+function initFile($file, $callback) {
+  if (file_exists($file)) {
+    echo "File \"$file\" already exists.\n";
+  }
+  else {
+    echo "Initialize \"$file\"\n";
+    $content = $callback();
+    file_put_contents($file, $content);
+  }
+  return $file;
+}
+
+/**
+ * Render a pretty string for a major/minor version number.
+ *
+ * @param string $version
+ *   Ex: '5.10.alpha1'
+ * @return string
+ *   Ex: 'FiveTen'.
+ */
+function makeVerName($version) {
+  list ($a, $b) = explode('.', $version);
+  require_once 'CRM/Utils/EnglishNumber.php';
+  return CRM_Utils_EnglishNumber::toCamelCase($a) . CRM_Utils_EnglishNumber::toCamelCase($b);
 }
 
 function isVersionValid($v) {

--- a/tools/bin/scripts/set-version.php
+++ b/tools/bin/scripts/set-version.php
@@ -61,6 +61,10 @@ updateFile("xml/version.xml", function ($content) use ($newVersion, $oldVersion)
   return str_replace($oldVersion, $newVersion, $content);
 });
 
+updateFile("civicrm-version.php", function ($content) use ($newVersion, $oldVersion) {
+  return str_replace($oldVersion, $newVersion, $content);
+});
+
 updateFile("sql/civicrm_generated.mysql", function ($content) use ($newVersion, $oldVersion) {
   return str_replace($oldVersion, $newVersion, $content);
 });


### PR DESCRIPTION
Overview
----------------------------------------
The utility, `tools/bin/scripts/set-version.php`, is used to generate
boilerplate files for incremental updates. This change improves
compatibility with the [version realignment](https://lab.civicrm.org/dev/release/issues/1).


Before
----------------------------------------
The `set-version.php` script supports incrementing the third digit *only*.

Specifically, it:

* Sets the current version number in `xml/version.xml` (etal). (*This is required for all version bumps.*)
* Generates an incremental SQL upgrade file. (*This is required for all version bumps.*)

After
----------------------------------------
The `set-version.php` script supports incrementing the first, second, and/or third digit.

Specifically, it generates the same files as before, *and*:
 * Generates an incremental PHP upgrade file. (*This is only required when increasing the first or second digit.*)

Comments
----------------------------------------
To test this, I locally produced a series of upgrade steps:

```
./tools/bin/scripts/set-version.php 5.0.alpha1 --no-commit
./tools/bin/scripts/set-version.php 5.0.alpha2 --no-commit
./tools/bin/scripts/set-version.php 5.0.0 --no-commit
./tools/bin/scripts/set-version.php 5.0.1 --no-commit
./tools/bin/scripts/set-version.php 5.1.alpha1 --no-commit
./tools/bin/scripts/set-version.php 5.1.beta1 --no-commit
```

Then, I ran [`cv upgrade:db -vvv`](https://github.com/civicrm/cv/pull/2) (as
both dry-run and normal-run) and verified that the expected upgrade steps
were used.