### PR TITLE
Fix access to scheduled reminders for admins without event access

### DIFF
--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -60,6 +60,9 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
     $this->_mappingID = $mappingID = NULL;
     $providersCount = CRM_SMS_BAO_Provider::activeProviderCount();
     $this->context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    if ($this->context == 'event') {
+      $this->_compId = CRM_Utils_Request::retrieve('compId', 'Integer', $this);
+    }
 
     //CRM-16777: Don't provide access to administer schedule reminder page, with user that does not have 'administer CiviCRM' permission
     if (!$this->context && !CRM_Core_Permission::check('administer CiviCRM')) {
@@ -68,7 +71,6 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
     //CRM-16777: When user have ACLs 'edit' permission for specific event, do not give access to add, delete & updtae
     //schedule reminder for other events.
     else {
-      $this->_compId = CRM_Utils_Request::retrieve('compId', 'Integer', $this);
       if (!CRM_Event_BAO_Event::checkPermission($this->_compId, CRM_Core_Permission::EDIT)) {
         CRM_Core_Error::fatal(ts('You do not have permission to access this page.'));
       }
@@ -76,20 +78,13 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
 
     if ($this->_action & (CRM_Core_Action::DELETE)) {
       $reminderName = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_ActionSchedule', $this->_id, 'title');
-      if ($this->context == 'event') {
-        $this->_compId = CRM_Utils_Request::retrieve('compId', 'Integer', $this);
-      }
       $this->assign('reminderName', $reminderName);
       return;
     }
     elseif ($this->_action & (CRM_Core_Action::UPDATE)) {
       $this->_mappingID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_ActionSchedule', $this->_id, 'mapping_id');
-      if ($this->context == 'event') {
-        $this->_compId = CRM_Utils_Request::retrieve('compId', 'Integer', $this);
-      }
     }
     if ($this->context == 'event') {
-      $this->_compId = CRM_Utils_Request::retrieve('compId', 'Integer', $this);
       $isTemplate = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event', $this->_compId, 'is_template');
       $mapping = CRM_Utils_Array::first(CRM_Core_BAO_ActionSchedule::getMappings(array(
         'id' => $isTemplate ? CRM_Event_ActionMapping::EVENT_TPL_MAPPING_ID : CRM_Event_ActionMapping::EVENT_NAME_MAPPING_ID,

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -180,6 +180,29 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
   public $urlPath = array();
 
   /**
+   * Context of the form being loaded.
+   *
+   * 'event' or null
+   *
+   * @var string
+   */
+  protected $context;
+
+  /**
+   * @return string
+   */
+  public function getContext() {
+    return $this->context;
+  }
+
+  /**
+   * Set context variable.
+   */
+  public function setContext() {
+    $this->context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
+  }
+
+  /**
    * @var CRM_Core_Controller
    */
   public $controller;


### PR DESCRIPTION
Overview
----------------------------------------
Fix access to scheduled reminders for admins without event access

Before
----------------------------------------
Someone with 'Administer CiviCRM' but not 'Manage Events' gets an error trying to create a non-event scheduled reminder

After
----------------------------------------
Access works

Technical Details
----------------------------------------
Fix access to scheduled reminders form.

The current logic is that if the context is not event (empty) and the user does not
have administer CiviCRM they get bounced. if they pass that check they are then
passed into the check that should only be applied when the context IS event. This results
in a bounce for a user without any manage event access.

Comments
----------------------------------------
Most of the changes are tidy ups (2 distinct ones in separate commits). Actual change is the 3rd commit & on this line https://github.com/civicrm/civicrm-core/compare/master...eileenmcnaughton:sched?expand=1#diff-e179caac63281aad4b5df3aab2e370e2R73
