### PR TITLE
CRM-21813 : Parameter list mismatch

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3465,8 +3465,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     ) {
       $eventID = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Participant', $entityId, 'event_id');
       $feeLevel[] = str_replace('', '', $params['prevContribution']->amount_level);
-      $priceFieldValueId = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_LineItem', $params['id'], 'price_field_value_id', 'contribution_id');
-      CRM_Event_BAO_Participant::createDiscountTrxn($eventID, $params, $feeLevel, $priceFieldValueId);
+      CRM_Event_BAO_Participant::createDiscountTrxn($eventID, $params, $feeLevel);
     }
     unset($params['line_item']);
     self::$_trxnIDs = NULL;

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3465,7 +3465,8 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     ) {
       $eventID = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Participant', $entityId, 'event_id');
       $feeLevel[] = str_replace('', '', $params['prevContribution']->amount_level);
-      CRM_Event_BAO_Participant::createDiscountTrxn($eventID, $params, $feeLevel, CRM_Price_BAO_PriceSet::parseFirstPriceSetValueIDFromParams($params));
+      $priceFieldValueId = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_LineItem', $params['id'], 'price_field_value_id', 'contribution_id');
+      CRM_Event_BAO_Participant::createDiscountTrxn($eventID, $params, $feeLevel, $priceFieldValueId);
     }
     unset($params['line_item']);
     self::$_trxnIDs = NULL;

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3465,7 +3465,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     ) {
       $eventID = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Participant', $entityId, 'event_id');
       $feeLevel[] = str_replace('', '', $params['prevContribution']->amount_level);
-      CRM_Event_BAO_Participant::createDiscountTrxn($eventID, $params, $feeLevel);
+      CRM_Event_BAO_Participant::createDiscountTrxn($eventID, $params, $feeLevel, CRM_Price_BAO_PriceSet::parseFirstPriceSetValueIDFromParams($params));
     }
     unset($params['line_item']);
     self::$_trxnIDs = NULL;

--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -1845,7 +1845,7 @@ WHERE    civicrm_participant.contact_id = {$contactID} AND
    * @param int $discountedPriceFieldOptionID
    *   ID of the civicrm_price_field_value field for the discount id.
    */
-  public static function createDiscountTrxn($eventID, $contributionParams, $feeLevel, $discountedPriceFieldOptionID) {
+  public static function createDiscountTrxn($eventID, $contributionParams, $feeLevel, $discountedPriceFieldOptionID = NULL) {
     $financialTypeID = $contributionParams['contribution']->financial_type_id;
     $total_amount = $contributionParams['total_amount'];
 


### PR DESCRIPTION
Overview
----------------------------------------
A mismatch of parameter list result in a error 

Before
----------------------------------------
It's a AJAX error 

After
----------------------------------------
Ajax Error gone and execution continues 

Technical Details
----------------------------------------
Just 1 addition in the parameter list to match the footprint of the function.

---

 * [CRM-21813: Function parameter list mismatch doesn't allow save](https://issues.civicrm.org/jira/browse/CRM-21813)