### PR TITLE
CRM-21815 - re-opening a civicase - Case Coordinator (and other roles…

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -840,12 +840,13 @@ SELECT case_status.label AS case_status, status_id, civicrm_case_type.title AS c
    * @param int $caseID
    *   Case id.
    * @param int $relationshipID
+   * @param bool $activeOnly
    *
    * @return array
    *   case role / relationships
    *
    */
-  public static function getCaseRoles($contactID, $caseID, $relationshipID = NULL) {
+  public static function getCaseRoles($contactID, $caseID, $relationshipID = NULL, $activeOnly = TRUE) {
     $query = '
     SELECT  rel.id as civicrm_relationship_id,
             con.sort_name as sort_name,
@@ -861,7 +862,11 @@ SELECT case_status.label AS case_status, status_id, civicrm_case_type.title AS c
  LEFT JOIN  civicrm_phone ON (civicrm_phone.contact_id = con.id AND civicrm_phone.is_primary = 1)
  LEFT JOIN  civicrm_email ON (civicrm_email.contact_id = con.id AND civicrm_email.is_primary = 1)
      WHERE  (rel.contact_id_a = %1 OR rel.contact_id_b = %1) AND rel.case_id = %2
-       AND  rel.is_active = 1 AND con.is_deleted = 0 AND (rel.end_date IS NULL OR rel.end_date > NOW())';
+       AND con.is_deleted = 0';
+
+    if ($activeOnly) {
+      $query .= ' AND rel.is_active = 1 AND (rel.end_date IS NULL OR rel.end_date > NOW())';
+    }
 
     $params = array(
       1 => array($contactID, 'Positive'),

--- a/CRM/Case/Form/Activity/ChangeCaseStatus.php
+++ b/CRM/Case/Form/Activity/ChangeCaseStatus.php
@@ -194,7 +194,7 @@ class CRM_Case_Form_Activity_ChangeCaseStatus {
 
       // Reopen case-specific relationships (roles)
       foreach ($params['target_contact_id'] as $cid) {
-        $rels = CRM_Case_BAO_Case::getCaseRoles($cid, $params['case_id']);
+        $rels = CRM_Case_BAO_Case::getCaseRoles($cid, $params['case_id'], NULL, FALSE);
         // FIXME: Is there an existing function?
         $query = 'UPDATE civicrm_relationship SET end_date=NULL WHERE id=%1';
         foreach ($rels as $relId => $relData) {

--- a/tests/phpunit/api/v3/CaseTest.php
+++ b/tests/phpunit/api/v3/CaseTest.php
@@ -185,6 +185,14 @@ class api_v3_CaseTest extends CiviCaseTestCase {
     foreach ($relationships['values'] as $key => $values) {
       $this->assertEquals($values['end_date'], date('Y-m-d'));
     }
+
+    //Verify there are no active relationships.
+    $activeCaseRelationships = CRM_Case_BAO_Case::getCaseRoles($result['values'][$id]['client_id'][1], $id);
+    $this->assertEquals(count($activeCaseRelationships), 0, "Checking for empty array");
+
+    //Check if getCaseRoles() is able to return inactive relationships.
+    $caseRelationships = CRM_Case_BAO_Case::getCaseRoles($result['values'][$id]['client_id'][1], $id, NULL, FALSE);
+    $this->assertEquals(count($caseRelationships), 1);
   }
 
   /**


### PR DESCRIPTION
…) are not reinstated

Overview
----------------------------------------
On re-opening a civicase - Case Coordinator (and other roles) are not reinstated

Before
----------------------------------------
SE question - https://civicrm.stackexchange.com/questions/22932/if-a-civicase-is-reopened-why-isnt-the-case-coordinator-and-other-roles-reins

Check Jira issue for replicating it.

After
----------------------------------------
End date of Case relationship is set to NULL which displays case roles in Active section.

Technical Details
----------------------------------------
`getCaseRoles ` function seems to be returning only active relationships, but if a case status is changed from `Resolved` to `Ongoing`, this function should be able to return all relationship to make them active again.

Comments
----------------------------------------
Added unit test.

---

 * [CRM-21815: On re-opening a civicase - Case Coordinator (and other roles) are not reinstated](https://issues.civicrm.org/jira/browse/CRM-21815)