### PR TITLE
CRM-21816 Fix Relative dates in search bug

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -1559,6 +1559,42 @@ class CRM_Contact_BAO_Query {
 
     self::filterCountryFromValuesIfStateExists($formValues);
 
+    // Handle relative dates first
+    foreach (array_keys($formValues) as $id) {
+      if (preg_match('/_date_relative$/', $id) ||
+        $id == 'event_relative' ||
+        $id == 'case_from_relative' ||
+        $id == 'case_to_relative' ||
+        $id == 'participant_relative'
+      ) {
+        if ($id == 'event_relative') {
+          $fromRange = 'event_start_date_low';
+          $toRange = 'event_end_date_high';
+        }
+        elseif ($id == 'participant_relative') {
+          $fromRange = 'participant_register_date_low';
+          $toRange = 'participant_register_date_high';
+        }
+        elseif ($id == 'case_from_relative') {
+          $fromRange = 'case_from_start_date_low';
+          $toRange = 'case_from_start_date_high';
+        }
+        elseif ($id == 'case_to_relative') {
+          $fromRange = 'case_to_end_date_low';
+          $toRange = 'case_to_end_date_high';
+        }
+        else {
+          $dateComponent = explode('_date_relative', $id);
+          $fromRange = "{$dateComponent[0]}_date_low";
+          $toRange = "{$dateComponent[0]}_date_high";
+        }
+
+        if (array_key_exists($fromRange, $formValues) && array_key_exists($toRange, $formValues)) {
+          CRM_Contact_BAO_Query::fixDateValues($formValues[$id], $formValues[$fromRange], $formValues[$toRange]);
+        }
+      }
+    }
+
     foreach ($formValues as $id => &$val) {
       // CRM-19374 - we don't want to change $val in $formValues.
       // Assign it to a temp variable which operates while iteration.
@@ -1618,39 +1654,8 @@ class CRM_Contact_BAO_Query {
         $id == 'case_to_relative' ||
         $id == 'participant_relative'
       ) {
-        if ($id == 'event_relative') {
-          $fromRange = 'event_start_date_low';
-          $toRange = 'event_end_date_high';
-        }
-        elseif ($id == 'participant_relative') {
-          $fromRange = 'participant_register_date_low';
-          $toRange = 'participant_register_date_high';
-        }
-        elseif ($id == 'case_from_relative') {
-          $fromRange = 'case_from_start_date_low';
-          $toRange = 'case_from_start_date_high';
-        }
-        elseif ($id == 'case_to_relative') {
-          $fromRange = 'case_to_end_date_low';
-          $toRange = 'case_to_end_date_high';
-        }
-        else {
-          $dateComponent = explode('_date_relative', $id);
-          $fromRange = "{$dateComponent[0]}_date_low";
-          $toRange = "{$dateComponent[0]}_date_high";
-        }
-
-        if (array_key_exists($fromRange, $formValues) && array_key_exists($toRange, $formValues)) {
-          // relative dates are not processed correctly as lower date value were ignored,
-          // to ensure both high and low date value got added IF there is relative date,
-          // we need to reset $formValues by unset and then adding again via CRM_Contact_BAO_Query::fixDateValues(...)
-          if (!empty($formValues[$id])) {
-            unset($formValues[$fromRange]);
-            unset($formValues[$toRange]);
-          }
-          CRM_Contact_BAO_Query::fixDateValues($formValues[$id], $formValues[$fromRange], $formValues[$toRange]);
-          continue;
-        }
+        // Already handled in previous loop
+        continue;
       }
       elseif (in_array($id, $entityReferenceFields) && !empty($values) && is_string($values) && (strpos($values, ',') !=
         FALSE)) {

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -1595,11 +1595,7 @@ class CRM_Contact_BAO_Query {
       }
     }
 
-    foreach ($formValues as $id => &$val) {
-      // CRM-19374 - we don't want to change $val in $formValues.
-      // Assign it to a temp variable which operates while iteration.
-      $values = $val;
-
+    foreach ($formValues as $id => $values) {
       if (self::isAlreadyProcessedForQueryFormat($values)) {
         $params[] = $values;
         continue;


### PR DESCRIPTION
Overview
----------------------------------------
Fix a bug in Advanced Search whereby using a relative date search condition (eg 'Next 60 days') could result in some other search conditions being ignored.

Before
----------------------------------------
You need to do a little setup work to see this:
- setup a membership type with related contacts
- setup 2 contacts with the specified relationship
- create a membership expiring within 60 days 

You should have 2 related contacts with a membership expiring within 60 days.  One is primary, one is not. 

 - In Advanced Search, open Membership, search for 'Primary Members' - should only show the primary member.
- Now search for 'Primary Members'  and set the Membership End Date to 'Next 60 days'.  If this shows you both contacts it demonstrates the bug - the 'primary member' condition is being ignored.

Note that this appears to be related to the version of PHP so you may not see it.  The problem was observed with PHP 5.6.32

After
----------------------------------------
The search should work correctly.

Technical Details
----------------------------------------
Using unset() within a foreach loop can cause problems and should be avoided.  See https://wiki.php.net/rfc/php7_foreach#introduction for a simple example.

Comments
----------------------------------------
The problem is not limited to memberships or to 'primary member'.  It it potentially triggered by any of the relative date fields.  Which conditions are skipped depends on the ordering within `$formValues`

---

 * [CRM-21816: Relative dates in searches cause some other conditions to be ignored](https://issues.civicrm.org/jira/browse/CRM-21816)