### PR TITLE
CRM-21817: Move help section outside form block

### DIFF
--- a/templates/CRM/Admin/Form/WordReplacements.tpl
+++ b/templates/CRM/Admin/Form/WordReplacements.tpl
@@ -36,10 +36,10 @@
 
 {else}
   {* this template is used for adding/editing string overrides  *}
+  <div class="help">
+    {ts}Use <strong>Word Replacements</strong> to change all occurrences of a word or phrase in CiviCRM screens (e.g. replace all occurrences of 'Contribution' with 'Donation').{/ts} {help id="id-word_replace"}
+  </div>
   <div class="crm-form crm-form-block crm-string_override-form-block">
-    <div class="help">
-      {ts}Use <strong>Word Replacements</strong> to change all occurrences of a word or phrase in CiviCRM screens (e.g. replace all occurrences of 'Contribution' with 'Donation').{/ts} {help id="id-word_replace"}
-    </div>
     <div class="crm-submit-buttons">
       {include file="CRM/common/formButtons.tpl" location='top'}
     </div>


### PR DESCRIPTION
Overview
----------------------------------------
This PR moves help section for word replacement page, outside crm block

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/26058635/36789630-37aabb58-1cb8-11e8-9872-615b72f67866.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/26058635/36789589-1d4a375c-1cb8-11e8-9066-b6dc4f2aab42.png)

---

 * [CRM-21817: Move help section outside crm block as per other pages](https://issues.civicrm.org/jira/browse/CRM-21817)