### PR TITLE
CRM-21819 - Do not load 'Submit Credit Card Contribution' button for …

### DIFF
--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -460,7 +460,11 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
    * @return bool
    */
   public static function isEnabledBackOfficeCreditCardPayments() {
-    return CRM_Financial_BAO_PaymentProcessor::hasPaymentProcessorSupporting(array('BackOffice'));
+    $processors = CRM_Financial_BAO_PaymentProcessor::getPaymentProcessors(array('BackOffice'));
+    if (empty($processors) || array_keys($processors) === array(0)) {
+      return FALSE;
+    }
+    return TRUE;
   }
 
   /**


### PR DESCRIPTION
…invalid processors

Overview
----------------------------------------
Do not load 'Submit Credit Card Contribution' button for invalid processors.

Before
----------------------------------------
Submit Credit Card Contribution button always loads on the contribution tab even if there is no payment processor configured to support backoffice.

SE - https://civicrm.stackexchange.com/questions/22941/submit-credit-card-contribution-error-with-valid-payment-processor
MM - https://chat.civicrm.org/civicrm/pl/wmn84ab617rymcz386pkdnj7rc

After
----------------------------------------
Button is not loaded for invalid processor.

---

 * [CRM-21819: Do not load "Submit Credit Card Contribution" button for invalid processors](https://issues.civicrm.org/jira/browse/CRM-21819)