### PR TITLE
Fix upgrade failures from zero value `trxn_date`

### DIFF
--- a/CRM/Upgrade/Incremental/sql/4.7.19.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/4.7.19.mysql.tpl
@@ -41,6 +41,12 @@ INSERT INTO
 VALUES
   (@option_group_id_adOpt, {localize}'{ts escape="sql"}Supplemental Address 3{/ts}'{/localize}, (SELECT @max_val := @max_val + 1), 'supplemental_address_3', NULL, 0, NULL, (SELECT @supp2_wt := @supp2_wt + 1), {localize}''{/localize}, 0, 0, 1, NULL, NULL, NULL);
 
+-- Some legacy sites have `0000-00-00 00:00:00` values in
+-- `civicrm_financial_trxn.trxn_date` which correspond to the same value in
+-- `civicrm_contribution.receive_date`
+UPDATE civicrm_financial_trxn SET trxn_date = NULL WHERE trxn_date = '0000-00-00 00:00:00';
+UPDATE civicrm_contribution SET receive_date = NULL WHERE receive_date = '0000-00-00 00:00:00';
+
 -- CRM-20439 rename card_type to card_type_id of civicrm_financial_trxn table (IIDA-126)
 ALTER TABLE `civicrm_financial_trxn` CHANGE `card_type` `card_type_id` INT(10) UNSIGNED NULL DEFAULT NULL COMMENT 'FK to accept_creditcard option group values';
 


### PR DESCRIPTION
Overview
----------------------------------------
Some longstanding CiviCRM installations would have upgrade failures going to 4.7.19 or higher with the database error,

> Incorrect datetime value: '0000-00-00 00:00:00' for column 'trxn_date'

This change fixes those values to be `NULL` prior to the query that causes the problem.

Before
----------------------------------------
Certain sites with legacy data (canceled event registrations, potentially among other things, from around 2013) have `trxn_date` values of `0000-00-00 00:00:00` in the `civicrm_financial_trxn` table.  This is not an allowable value for a `datetime` field, and an upgrade step on the way to 4.7.19 will cause the error,

>  ALTER TABLE civicrm_financial_trxn CHANGE pan_truncation pan_truncation VARCHAR( 4 ) NULL DEFAULT NULL COMMENT 'Last 4 digits of credit card' [nativecode=1292 ** Incorrect datetime value: '0000-00-00 00:00:00' for column 'trxn_date' at row XXX]

After
----------------------------------------
Before that query executes, all `0000-00-00 00:00:00` values in `civicrm_financial_trxn.trxn_date` are set to `NULL`.  Meanwhile, those values seem to be always also occur in the `receive_date` field of the corresponding `civicrm_contribution` row.  The upgrade now sets those values to `NULL` as well.

Technical Details
----------------------------------------
This shouldn't affect most users.

Comments
----------------------------------------
@KarinG @JoeMurray @eileenmcnaughton I suspect this is the legacy of some bug fixed in 4.3 or 4.4, but I couldn't easily find it.

Also, while I believe `NULL` is an improvement over `0000-00-00 00:00:00` since it's at least an acceptable value, those rows are now the only ones with null dates.  Theoretically, this could cause problems in pages or functions that make use of the dates.
