### PR TITLE
CRM-21806 Search builder NOT Empty does not work

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -1444,11 +1444,7 @@ class CRM_Contact_BAO_Query {
         }
       }
 
-      $select = "SELECT ";
-      if (isset($this->_distinctComponentClause)) {
-        $select .= "{$this->_distinctComponentClause}, ";
-      }
-      $select .= implode(', ', $this->_select);
+      $select = $this->getSelect();
       $from = $this->_fromClause;
     }
 
@@ -6540,6 +6536,20 @@ AND   displayRelType.is_active = 1
       return TRUE;
     }
     return FALSE;
+  }
+
+  /**
+   * Get Select Clause.
+   *
+   * @return string
+   */
+  public function getSelect() {
+    $select = "SELECT ";
+    if (isset($this->_distinctComponentClause)) {
+      $select .= "{$this->_distinctComponentClause}, ";
+    }
+    $select .= implode(', ', $this->_select);
+    return $select;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Incorrect empty results on Search builder search

Before
----------------------------------------
Steps to recreate the issue:
1) Go to Administer>Customize Data and Screens>Profiles. Add a new profile of the type "Search View"
2) Add several contact fields to the new profile.
3) Go to Search>Advanced Search and select the new profile in Search Views. Press Search.
4) Click on one of the contact fields in the search results to sort the column.
5) Observe that you are brought back to Advanced Search field selection screen and it displays that no records are found.

After
----------------------------------------
Results show

Technical Details
----------------------------------------
Replaces hacky method of guessing the select clause (which turned out to be wrong)

Comments
----------------------------------------
I took a look at this because it was marked critical but have not determined if it was a regression or a never worked. I'm also concious we probably need a unit test to make this mergeable but I'm also feeling unable to do that on this at the moment as my unfunded time is a bit tight (ie. I don't have any skin in this - I looked at it because it is a critical issue). I don't have an answer for that - ie. I don't think it should be merged without a test but don't know that a test is iminent

---

 * [CRM-21806: Search builder returns no results](https://issues.civicrm.org/jira/browse/CRM-21806)