### PR TITLE
CKEditorConfig - Fix double-escaped slashes

### DIFF
--- a/CRM/Admin/Page/CKEditorConfig.php
+++ b/CRM/Admin/Page/CKEditorConfig.php
@@ -132,7 +132,7 @@ class CRM_Admin_Page_CKEditorConfig extends CRM_Core_Page {
       $val = trim($val);
       if (strpos($key, 'config_') === 0 && strlen($val)) {
         if ($val != 'true' && $val != 'false' && $val != 'null' && $val[0] != '{' && $val[0] != '[' && !is_numeric($val)) {
-          $val = json_encode($val);
+          $val = json_encode($val, JSON_UNESCAPED_SLASHES);
         }
         $pos = strrpos($config, '};');
         $key = preg_replace('/^config_/', 'config.', $key);


### PR DESCRIPTION
Overview
------
The "Advanced Options" section of the CKEditor configurator allows user-input strings. Slashes were being escaped multiple times in that input. This fixes it.

To reproduce the bug:
- Add an advanced option and enter a string containing slashes.
- Click "Save"
- Observe on reloading the form the string has changed, adding extra escaping slashes that should not be there.

Before
-----
![screenshot from 2018-03-01 20 55 46](https://user-images.githubusercontent.com/2874912/36879712-18c30d4a-1d93-11e8-986a-6737b886e7d3.png)

After
-----
![screenshot from 2018-03-01 20 55 16](https://user-images.githubusercontent.com/2874912/36879718-1f28e06a-1d93-11e8-91cb-09bfc006713d.png)
