### PR TITLE
CRM-20610 make it possible to enable the payment form

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -237,6 +237,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     // Get the contribution id if update
     $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
     if (!empty($this->_id)) {
+      $this->assignPaymentInfoBlock();
       $this->assign('contribID', $this->_id);
     }
 
@@ -627,11 +628,13 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
 
     $paymentInstrument = FALSE;
     if (!$this->_mode) {
+      // payment_instrument isn't required in edit and will not be present when payment block is enabled.
+      $required = $this->_id ? FALSE : TRUE;
       $checkPaymentID = array_search('Check', CRM_Contribute_PseudoConstant::paymentInstrument('name'));
       $paymentInstrument = $this->add('select', 'payment_instrument_id',
         ts('Payment Method'),
         array('' => ts('- select -')) + CRM_Contribute_PseudoConstant::paymentInstrument(),
-        TRUE, array('onChange' => "return showHideByValue('payment_instrument_id','{$checkPaymentID}','checkNumber','table-row','select',false);")
+        $required, array('onChange' => "return showHideByValue('payment_instrument_id','{$checkPaymentID}','checkNumber','table-row','select',false);")
       );
     }
 

--- a/CRM/Financial/Form/PaymentEdit.php
+++ b/CRM/Financial/Form/PaymentEdit.php
@@ -71,7 +71,7 @@ class CRM_Financial_Form_PaymentEdit extends CRM_Core_Form {
 
     $this->_values = civicrm_api3('FinancialTrxn', 'getsingle', array('id' => $this->_id));
     if (!empty($this->_values['payment_processor_id'])) {
-      CRM_Core_Error::statusBounce(ts('You cannot update this payment'));
+      CRM_Core_Error::statusBounce(ts('You cannot update this payment as it is tied to a payment processor'));
     }
   }
 

--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -161,7 +161,7 @@
         {if $contribution_status_id eq 2}{if $is_pay_later }: {ts}Pay Later{/ts} {else}: {ts}Incomplete Transaction{/ts}{/if}{/if}
         </td>
         <td>
-        {if $contactId && $contribID && $contributionMode EQ null && $contribution_status_id eq 2}
+        {if !$isUsePaymentBlock && $contactId && $contribID && $contributionMode EQ null && $contribution_status_id eq 2}
           {capture assign=payNowLink}{crmURL p='civicrm/contact/view/contribution' q="reset=1&action=update&id=`$contribID`&cid=`$contactId`&context=`$context`&mode=live"}{/capture}
           <a class="open-inline action-item crm-hover-button" href="{$payNowLink}">&raquo; {ts}Pay with Credit Card{/ts}</a>
         {/if}
@@ -249,6 +249,9 @@
       <legend>
         {ts}Payment Details{/ts}
       </legend>
+      {if $isUsePaymentBlock}
+        {include file="CRM/Contribute/Form/PaymentInfoBlock.tpl"}
+      {else}
         <table class="form-layout-compressed" >
           <tr class="crm-contribution-form-block-payment_instrument_id">
             <td class="label">{$form.payment_instrument_id.label}</td>
@@ -260,10 +263,13 @@
             <td {$valueStyle}>{$form.trxn_id.html} {help id="id-trans_id"}</td>
           </tr>
         </table>
+      {/if}
       </fieldset>
   {/if}
 
-  {include file='CRM/Core/BillingBlockWrapper.tpl'}
+  {if !$isUsePaymentBlock}
+    {include file='CRM/Core/BillingBlockWrapper.tpl'}
+  {/if}
 
     <!-- start of soft credit -->
     {if !$payNow}


### PR DESCRIPTION
Overview
----------------------------------------
This makes is possible via hook or by changing core to switch to using the payment form for payments without actually making that change

Before
----------------------------------------
Contribution form is unchanged

After
----------------------------------------
Contribution form is unchanged UNLESS you use a hook or we agree to switch core to turn on the change by adding one additional tpl var - see https://github.com/civicrm/civicrm-core/pull/10776/files#diff-0573f78042d230ffc1d5e61c1749ae77R235

Technical Details
----------------------------------------
This is the material change from #10776 without resolving the decision as to whether we we 'turn this change on' - or allow people to opt in. One idea I have is that the LineItemEdit extension ALSO turn this on (by the above line to that extension). My feeling is that we should be moving towards a) shipping line item edit enabled in all dev builds with a view to doing so in core (or at least new installs) once we are comfortable and b) turning this on in all dev builds with a view to turning on for new installs once we are comfortable - ie. roll out to devs first & then work outwards. 

Both the line item edit form and the payment edit are IMHO very important for getting us out of our whackamole on bugs that relate to the contribution form & unfortunately I think stalling on #10766 cost us heavily but @monishdeb I think you can merge this & then we can discuss - with @JoeMurray @lcdservices @colemanw & others whether to add to line item edit or find another way to grandfather it in

Comments
----------------------------------------
Screenshots & detail are in the mentioned PR

---

 * [CRM-20610: Replace payment details block with editable payment list on 'Edit Contribution' form](https://issues.civicrm.org/jira/browse/CRM-20610)