### PR TITLE
CRM-21685 Disable relationships when contact is trashed

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -984,6 +984,10 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
       $contact->delete();
     }
     else {
+       // CRM-21685 set relationships to disabled before trashing the contact
+      if (method_exists('CRM_Contact_BAO_Relationship', 'disableRelationshipsForContact')) {
+        CRM_Contact_BAO_Relationship::disableRelationshipsForContact($id);
+      }
       self::contactTrashRestore($contact);
     }
 

--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -2149,4 +2149,28 @@ AND cc.sort_name LIKE '%$name%'";
     return $relationshipsDT;
   }
 
+  /**
+   * Method to disable relationships of a specific contact
+   *
+   * @param $contactId
+   */
+  public static function disableRelationshipsForContact($contactId) {
+    try {
+      $result = civicrm_api3('Relationship', 'get', array(
+        'contact_id' => $contactId,
+        'is_active' => 1,
+        'options' => array('limit' => 0),
+      ));
+      foreach ($result['values'] as $relationshipId => $relationship) {
+        civicrm_api3('Relationship', 'create', array(
+          'id' => $relationshipId,
+          'is_active' => 0,
+        ));
+      }
+    }
+    catch (CiviCRM_API3_Exception $ex) {
+      CRM_Core_Error::debug_log_message('Unexpected error from API Relationship in ' .__METHOD__ . ', error message from API : ' . $ex->getMessage());
+    }
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Disable relationships when contact is trashed
Before
----------------------------------------
When contact is trashed relationships remain active (is_active = 1)

After
----------------------------------------
When contact is trashed relationships of the contact are disabled (is_active = 0)

Technical Details
----------------------------------------
Added method to CRM_Contact_BAO_Relationship, call method in CRM_Contact_BAO_Contact

Comments
----------------------------------------

---

 * [CRM-21685: Disable relationships on contact soft-delete](https://issues.civicrm.org/jira/browse/CRM-21685)