### PR TITLE
CRM-21826:  Update System Checks to separate links to Domain Address …

### DIFF
--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -208,14 +208,19 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
     $messages = array();
 
     list($domainEmailName, $domainEmailAddress) = CRM_Core_BAO_Domain::getNameAndEmail(TRUE);
-    $domain = CRM_Core_BAO_Domain::getDomain();
-    $domainName = $domain->name;
-    $fixEmailUrl = CRM_Utils_System::url("civicrm/admin/domain", "action=update&reset=1");
+    $domain        = CRM_Core_BAO_Domain::getDomain();
+    $domainName    = $domain->name;
+    $fixEmailUrl   = CRM_Utils_System::url("civicrm/admin/options/from_email_address", "&reset=1");
+    $fixDomainName = CRM_Utils_System::url("civicrm/admin/domain", "action=update&reset=1");
 
     if (!$domainEmailAddress || $domainEmailAddress == 'info@EXAMPLE.ORG') {
       if (!$domainName || $domainName == 'Default Domain Name') {
-        $msg = ts("Please enter your organization's <a href=\"%1\">name, primary address, and default FROM Email Address</a> (for system-generated emails).",
-          array(1 => $fixEmailUrl));
+        $msg = ts("Please enter your organization's <a href=\"%1\">name, primary address </a> and <a href=\"%2\">default FROM Email Address </a> (for system-generated emails).",
+          array(
+            1 => $fixDomainName,
+            2 => $fixEmailUrl,
+          )
+        );
       }
       else {
         $msg = ts('Please enter a <a href="%1">default FROM Email Address</a> (for system-generated emails).',
@@ -224,7 +229,7 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
     }
     elseif (!$domainName || $domainName == 'Default Domain Name') {
       $msg = ts("Please enter your organization's <a href=\"%1\">name and primary address</a>.",
-        array(1 => $fixEmailUrl));
+        array(1 => $fixDomainName));
     }
 
     if (!empty($msg)) {


### PR DESCRIPTION
…and From Email Address settings pages

----------------------------------------
* CRM-21826: Default FROM Email Address (for system-generated emails) link incorrect in System Status Screen
  https://issues.civicrm.org/jira/browse/CRM-21826

Overview
----------------------------------------
Update System Status Screen to have separate links for Domain Name and From Email Address

Before
----------------------------------------
https://github.com/civicrm/civicrm-core/pull/11047 removed the default FROM Email Address from the Domaon Organizational Contact Screen.  The system check did not reflect this

After
----------------------------------------
Now the system check will link to the proper pages based on the status

Technical Details
----------------------------------------
None

Comments
----------------------------------------

