### PR TITLE
CRM-21819 - Do not load 'Submit Credit Card Contribution' button if only pseudo-manual processor exists

### DIFF
--- a/CRM/Financial/BAO/PaymentProcessor.php
+++ b/CRM/Financial/BAO/PaymentProcessor.php
@@ -447,7 +447,7 @@ class CRM_Financial_BAO_PaymentProcessor extends CRM_Financial_DAO_PaymentProces
     $capabilitiesString = implode('', $capabilities);
     if (!isset(\Civi::$statics[__CLASS__]['supported_capabilities'][$capabilitiesString])) {
       $result = self::getPaymentProcessors($capabilities);
-      \Civi::$statics[__CLASS__]['supported_capabilities'][$capabilitiesString] = (!empty($result)) ? TRUE : FALSE;
+      \Civi::$statics[__CLASS__]['supported_capabilities'][$capabilitiesString] = (!empty($result) && array_keys($result) !== array(0)) ? TRUE : FALSE;
     }
     return \Civi::$statics[__CLASS__]['supported_capabilities'][$capabilitiesString];
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a recent regression where the 'submit credit card' shows back office when it should not

Before
----------------------------------------
Submit credit card shows regardless of whether it works

After
----------------------------------------
Submit credit card only shows if it should

Technical Details
----------------------------------------
getPaymentProcessors has started to return the manual pay later processor so it evaluates to not empty when only the manual pay later processor exists. We need to change it so it only shows true if a true processor exists (a true processor being on that has an entry in civicrm_payment_processor table - it *could* be an instance of the Manual processor if people want to do offline recurring for manual payments)

Comments
----------------------------------------
Replaces #11743

---

 * [CRM-21819: Do not load "Submit Credit Card Contribution" button for invalid processors.](https://issues.civicrm.org/jira/browse/CRM-21819)