### PR TITLE
CRM-21391 Convert Case to use core Task class

### DIFF
--- a/CRM/Case/Form/Search.php
+++ b/CRM/Case/Form/Search.php
@@ -174,15 +174,13 @@ class CRM_Case_Form_Search extends CRM_Core_Form_Search {
         $this->addRowSelectors($rows);
       }
 
-      $permission = CRM_Core_Permission::getPermission();
-
-      $tasks = CRM_Case_Task::permissionedTaskTitles($permission);
+      $tasks = CRM_Case_Task::permissionedTaskTitles(CRM_Core_Permission::getPermission());
 
       if (!empty($this->_formValues['case_deleted'])) {
-        unset($tasks[1]);
+        unset($tasks[CRM_Case_Task::DELETE]);
       }
       else {
-        unset($tasks[4]);
+        unset($tasks[CRM_Case_Task::RESTORE_CASES]);
       }
 
       $this->addTaskMenu($tasks);

--- a/CRM/Case/Task.php
+++ b/CRM/Case/Task.php
@@ -36,22 +36,13 @@
  *
  * Used by the search forms
  */
-class CRM_Case_Task {
-  const DELETE_CASES = 1, PRINT_CASES = 2, EXPORT_CASES = 3, RESTORE_CASES = 4;
+class CRM_Case_Task extends CRM_Core_Task {
 
-  /**
-   * The task array
-   *
-   * @var array
-   */
-  static $_tasks = NULL;
+  const
+    // Case tasks
+    RESTORE_CASES = 501;
 
-  /**
-   * The optional task array
-   *
-   * @var array
-   */
-  static $_optionalTasks = NULL;
+  static $objectType = 'case';
 
   /**
    * These tasks are the core set of tasks that the user can perform
@@ -60,20 +51,20 @@ class CRM_Case_Task {
    * @return array
    *   the set of tasks for a group of contacts
    */
-  public static function &tasks() {
+  public static function tasks() {
     if (!self::$_tasks) {
       self::$_tasks = array(
-        1 => array(
+        self::TASK_DELETE => array(
           'title' => ts('Delete cases'),
           'class' => 'CRM_Case_Form_Task_Delete',
           'result' => FALSE,
         ),
-        2 => array(
+        self::TASK_PRINT => array(
           'title' => ts('Print selected rows'),
           'class' => 'CRM_Case_Form_Task_Print',
           'result' => FALSE,
         ),
-        3 => array(
+        self::TASK_EXPORT => array(
           'title' => ts('Export cases'),
           'class' => array(
             'CRM_Export_Form_Select',
@@ -81,17 +72,17 @@ class CRM_Case_Task {
           ),
           'result' => FALSE,
         ),
-        4 => array(
+        self::RESTORE_CASES => array(
           'title' => ts('Restore cases'),
           'class' => 'CRM_Case_Form_Task_Restore',
           'result' => FALSE,
         ),
-        5 => array(
+        self::PDF_LETTER => array(
           'title' => ts('Print/merge Document'),
           'class' => 'CRM_Case_Form_Task_PDF',
           'result' => FALSE,
         ),
-        6 => array(
+        self::BATCH_UPDATE => array(
           'title' => ts('Update multiple cases'),
           'class' => array(
             'CRM_Case_Form_Task_PickProfile',
@@ -103,40 +94,13 @@ class CRM_Case_Task {
 
       //CRM-4418, check for delete
       if (!CRM_Core_Permission::check('delete in CiviCase')) {
-        unset(self::$_tasks[1]);
+        unset(self::$_tasks[self::TASK_DELETE]);
       }
 
-      CRM_Utils_Hook::searchTasks('case', self::$_tasks);
-      asort(self::$_tasks);
+      parent::tasks();
     }
 
     return self::$_tasks;
-  }
-
-  /**
-   * These tasks are the core set of task titles.
-   *
-   * @return array
-   *   the set of task titles
-   */
-  public static function &taskTitles() {
-    self::tasks();
-    $titles = array();
-    foreach (self::$_tasks as $id => $value) {
-      $titles[$id] = $value['title'];
-    }
-    return $titles;
-  }
-
-  /**
-   * These tasks get added based on the context the user is in.
-   *
-   * @return array
-   *   the set of optional tasks for a group of contacts
-   */
-  public static function &optionalTaskTitle() {
-    $tasks = array();
-    return $tasks;
   }
 
   /**
@@ -144,12 +108,12 @@ class CRM_Case_Task {
    * of the user
    *
    * @param int $permission
+   * @param array $params
    *
    * @return array
    *   set of tasks that are valid for the user
    */
-  public static function &permissionedTaskTitles($permission) {
-    $tasks = array();
+  public static function permissionedTaskTitles($permission, $params = array()) {
     if (($permission == CRM_Core_Permission::EDIT)
       || CRM_Core_Permission::check('access all cases and activities')
       || CRM_Core_Permission::check('access my cases and activities')
@@ -158,13 +122,15 @@ class CRM_Case_Task {
     }
     else {
       $tasks = array(
-        3 => self::$_tasks[3]['title'],
+        self::TASK_EXPORT => self::$_tasks[self::TASK_EXPORT]['title'],
       );
       //CRM-4418,
       if (CRM_Core_Permission::check('delete in CiviCase')) {
-        $tasks[1] = self::$_tasks[1]['title'];
+        $tasks[self::TASK_DELETE] = self::$_tasks[self::TASK_DELETE]['title'];
       }
     }
+
+    $tasks = parent::corePermissionedTaskTitles($tasks, $permission, $params);
     return $tasks;
   }
 
@@ -180,7 +146,7 @@ class CRM_Case_Task {
     self::tasks();
     if (!$value || !CRM_Utils_Array::value($value, self::$_tasks)) {
       // make the print task by default
-      $value = 2;
+      $value = self::TASK_PRINT;
     }
 
     return array(


### PR DESCRIPTION
Overview
----------------------------------------
Refactor case task form to use base class

Before
----------------------------------------
![localhost_8000_civicrm_case_search__qf_search_display true qfkey 45cb1c9a5c8aef3e5c13be1dfa0ceaae_2825 1](https://user-images.githubusercontent.com/2052161/36968406-53166810-205a-11e8-9e73-ca386d6f768a.png)


After
----------------------------------------
![localhost_8000_civicrm_case_search__qf_search_display true qfkey 45cb1c9a5c8aef3e5c13be1dfa0ceaae_2825](https://user-images.githubusercontent.com/2052161/36968362-38818a02-205a-11e8-9386-9fa2e7f442e0.png)


Technical Details
----------------------------------------
details in #11240

Comments
----------------------------------------
This is a commit from #11240

In terms of review check that the code was a positive improvement and tested a couple of actions as well as checking the same number of actions were present

---

 * [CRM-21391: Refactor tasks to use a base class](https://issues.civicrm.org/jira/browse/CRM-21391)