### PR TITLE
CRM-21391 Convert Grant to use core Task class

### DIFF
--- a/CRM/Grant/Form/Search.php
+++ b/CRM/Grant/Form/Search.php
@@ -170,9 +170,7 @@ class CRM_Grant_Form_Search extends CRM_Core_Form_Search {
         $this->addRowSelectors($rows);
       }
 
-      $permission = CRM_Core_Permission::getPermission();
-
-      $this->addTaskMenu(CRM_Grant_Task::permissionedTaskTitles($permission));
+      $this->addTaskMenu(CRM_Grant_Task::permissionedTaskTitles(CRM_Core_Permission::getPermission()));
     }
 
   }

--- a/CRM/Grant/Form/Task.php
+++ b/CRM/Grant/Form/Task.php
@@ -88,8 +88,11 @@ class CRM_Grant_Form_Task extends CRM_Core_Form {
     $values = $form->controller->exportValues('Search');
 
     $form->_task = $values['task'];
-    $grantTasks = CRM_Grant_Task::tasks();
-    $form->assign('taskName', $grantTasks[$form->_task]);
+    $tasks = CRM_Grant_Task::tasks();
+    if (!array_key_exists($form->_task, $tasks)) {
+      CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
+    }
+    $form->assign('taskName', $tasks[$form->_task]);
 
     $ids = array();
     if ($values['radio_ts'] == 'ts_sel') {

--- a/CRM/Grant/Task.php
+++ b/CRM/Grant/Task.php
@@ -38,22 +38,13 @@
  * used by the search forms
  *
  */
-class CRM_Grant_Task {
-  const DELETE_GRANTS = 1, PRINT_GRANTS = 2, EXPORT_GRANTS = 3, UPDATE_GRANTS = 4;
+class CRM_Grant_Task extends CRM_Core_Task {
 
-  /**
-   * The task array
-   *
-   * @var array
-   */
-  static $_tasks = NULL;
+  const
+    // Grant Tasks
+    UPDATE_GRANTS = 701;
 
-  /**
-   * The optional task array
-   *
-   * @var array
-   */
-  static $_optionalTasks = NULL;
+  static $objectType = 'grant';
 
   /**
    * These tasks are the core set of tasks that the user can perform
@@ -62,20 +53,20 @@ class CRM_Grant_Task {
    * @return array
    *   the set of tasks for a group of contacts
    */
-  public static function &tasks() {
+  public static function tasks() {
     if (!(self::$_tasks)) {
       self::$_tasks = array(
-        1 => array(
+        self::TASK_DELETE => array(
           'title' => ts('Delete grants'),
           'class' => 'CRM_Grant_Form_Task_Delete',
           'result' => FALSE,
         ),
-        2 => array(
+        self::TASK_PRINT => array(
           'title' => ts('Print selected rows'),
           'class' => 'CRM_Grant_Form_Task_Print',
           'result' => FALSE,
         ),
-        3 => array(
+        self::TASK_EXPORT => array(
           'title' => ts('Export grants'),
           'class' => array(
             'CRM_Export_Form_Select',
@@ -83,7 +74,7 @@ class CRM_Grant_Task {
           ),
           'result' => FALSE,
         ),
-        4 => array(
+        self::UPDATE_GRANTS => array(
           'title' => ts('Update grants'),
           'class' => 'CRM_Grant_Form_Task_Update',
           'result' => FALSE,
@@ -91,29 +82,13 @@ class CRM_Grant_Task {
       );
 
       if (!CRM_Core_Permission::check('delete in CiviGrant')) {
-        unset(self::$_tasks[1]);
+        unset(self::$_tasks[self::TASK_DELETE]);
       }
 
-      CRM_Utils_Hook::searchTasks('grant', self::$_tasks);
-      asort(self::$_tasks);
+      parent::tasks();
     }
 
     return self::$_tasks;
-  }
-
-  /**
-   * These tasks are the core set of task titles
-   *
-   * @return array
-   *   the set of task titles
-   */
-  public static function &taskTitles() {
-    self::tasks();
-    $titles = array();
-    foreach (self::$_tasks as $id => $value) {
-      $titles[$id] = $value['title'];
-    }
-    return $titles;
   }
 
   /**
@@ -121,12 +96,12 @@ class CRM_Grant_Task {
    * of the user
    *
    * @param int $permission
+   * @param array $params
    *
    * @return array
    *   set of tasks that are valid for the user
    */
-  public static function &permissionedTaskTitles($permission) {
-    $tasks = array();
+  public static function permissionedTaskTitles($permission, $params = array()) {
     if (($permission == CRM_Core_Permission::EDIT)
       || CRM_Core_Permission::check('edit grants')
     ) {
@@ -134,13 +109,15 @@ class CRM_Grant_Task {
     }
     else {
       $tasks = array(
-        3 => self::$_tasks[3]['title'],
+        self::TASK_EXPORT => self::$_tasks[self::TASK_EXPORT]['title'],
       );
       //CRM-4418,
       if (CRM_Core_Permission::check('delete in CiviGrant')) {
-        $tasks[1] = self::$_tasks[1]['title'];
+        $tasks[self::TASK_DELETE] = self::$_tasks[self::TASK_DELETE]['title'];
       }
     }
+
+    $tasks = parent::corePermissionedTaskTitles($tasks, $permission, $params);
     return $tasks;
   }
 
@@ -154,14 +131,12 @@ class CRM_Grant_Task {
    */
   public static function getTask($value) {
     self::tasks();
-    if (!$value || !CRM_Utils_Array::value($value, self::$_tasks)) {
-      // make the print task by default
-      $value = 2;
+
+    if (!CRM_Utils_Array::value($value, self::$_tasks)) {
+      // make it the print task by default
+      $value = self::TASK_PRINT;
     }
-    return array(
-      self::$_tasks[$value]['class'],
-      self::$_tasks[$value]['result'],
-    );
+    return parent::getTask($value);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Refactor grant task form to use base class

Before
----------------------------------------
![localhost_8000_civicrm_grant_search__qf_search_display true qfkey ba2677113db474ebb920c4f93f0eb66f_5243 1](https://user-images.githubusercontent.com/2052161/36968568-cad654b4-205a-11e8-9306-261dfea3c78a.png)


After
----------------------------------------
![localhost_8000_civicrm_grant_search__qf_search_display true qfkey ba2677113db474ebb920c4f93f0eb66f_5243](https://user-images.githubusercontent.com/2052161/36968549-ba49aa2e-205a-11e8-9e04-d82b3cbd0461.png)


Technical Details
----------------------------------------
details in #11240

Comments
----------------------------------------
This is a commit from #11240

In terms of review check that the code was a positive improvement and tested a couple of actions as well as checking the same number of actions were present

---

 * [CRM-21391: Refactor tasks to use a base class](https://issues.civicrm.org/jira/browse/CRM-21391)