### PR TITLE
CRM-21391 Convert Mailing to use core Task class

### DIFF
--- a/CRM/Mailing/Task.php
+++ b/CRM/Mailing/Task.php
@@ -36,20 +36,9 @@
  * used by the search forms.
  *
  */
-class CRM_Mailing_Task {
-  /**
-   * The task array.
-   *
-   * @var array
-   */
-  static $_tasks = NULL;
+class CRM_Mailing_Task extends CRM_Core_Task {
 
-  /**
-   * The optional task array.
-   *
-   * @var array
-   */
-  static $_optionalTasks = NULL;
+  static $objectType = 'mailing';
 
   /**
    * These tasks are the core set of tasks that the user can perform
@@ -58,32 +47,20 @@ class CRM_Mailing_Task {
    * @return array
    *   the set of tasks for a group of contacts.
    */
-  public static function &tasks() {
+  public static function tasks() {
     if (!(self::$_tasks)) {
       self::$_tasks = array(
-        1 => array(
+        self::TASK_PRINT => array(
           'title' => ts('Print Mailing Recipients'),
           'class' => 'CRM_Mailing_Form_Task_Print',
           'result' => FALSE,
         ),
       );
 
-      CRM_Utils_Hook::searchTasks('mailing', self::$_tasks);
-      asort(self::$_tasks);
+      parent::tasks();
     }
 
     return self::$_tasks;
-  }
-
-  /**
-   * These tasks are the core set of task titles
-   * on mailing recipients.
-   *
-   * @return array
-   *   the set of task titles.
-   */
-  public static function &taskTitles() {
-    return array();
   }
 
   /**
@@ -91,13 +68,16 @@ class CRM_Mailing_Task {
    * of the user.
    *
    * @param int $permission
+   * @param array $params
    *
    * @return array
    *   set of tasks that are valid for the user
    */
-  public static function &permissionedTaskTitles($permission) {
-    $task = array();
-    return $task;
+  public static function permissionedTaskTitles($permission, $params = array()) {
+    $tasks = array();
+
+    $tasks = parent::corePermissionedTaskTitles($tasks, $permission, $params);
+    return $tasks;
   }
 
   /**
@@ -113,8 +93,9 @@ class CRM_Mailing_Task {
     self::tasks();
     if (!$value || !CRM_Utils_Array::value($value, self::$_tasks)) {
       // make the print task by default
-      $value = 1;
+      $value = self::TASK_PRINT;
     }
+
     return array(
       self::$_tasks[$value]['class'],
       self::$_tasks[$value]['result'],


### PR DESCRIPTION
Overview
----------------------------------------
Refactor mailing task form to use base class

Before
----------------------------------------
Mailing tasks don't seem to be exposed anywhere in UI

After
----------------------------------------
Mailing tasks don't seem to be exposed anywhere in UI

Technical Details
----------------------------------------
details in #11240

Comments
----------------------------------------
This is a commit from #11240

In terms of review check that the code was a positive improvement and tested a couple of actions as well as checking the same number of actions were present

---

 * [CRM-21391: Refactor tasks to use a base class](https://issues.civicrm.org/jira/browse/CRM-21391)