### PR TITLE
CRM-21391 Convert Member to use core Task class

### DIFF
--- a/CRM/Member/Form/Search.php
+++ b/CRM/Member/Form/Search.php
@@ -163,9 +163,7 @@ class CRM_Member_Form_Search extends CRM_Core_Form_Search {
         $this->addRowSelectors($rows);
       }
 
-      $permission = CRM_Core_Permission::getPermission();
-
-      $this->addTaskMenu(CRM_Member_Task::permissionedTaskTitles($permission));
+      $this->addTaskMenu(CRM_Member_Task::permissionedTaskTitles(CRM_Core_Permission::getPermission()));
     }
 
   }

--- a/CRM/Member/Form/Task.php
+++ b/CRM/Member/Form/Task.php
@@ -95,8 +95,11 @@ class CRM_Member_Form_Task extends CRM_Core_Form {
     $values = $form->controller->exportValues($form->get('searchFormName'));
 
     $form->_task = $values['task'];
-    $memberTasks = CRM_Member_Task::tasks();
-    $form->assign('taskName', $memberTasks[$form->_task]);
+    $tasks = CRM_Member_Task::permissionedTaskTitles(CRM_Core_Permission::getPermission());
+    if (!array_key_exists($form->_task, $tasks)) {
+      CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
+    }
+    $form->assign('taskName', $tasks[$form->_task]);
 
     $ids = array();
     if ($values['radio_ts'] == 'ts_sel') {

--- a/CRM/Member/Task.php
+++ b/CRM/Member/Task.php
@@ -39,22 +39,12 @@
  * used by the search forms
  *
  */
-class CRM_Member_Task {
-  const DELETE_MEMBERS = 1, PRINT_MEMBERS = 2, EXPORT_MEMBERS = 3, EMAIL_CONTACTS = 4, BATCH_MEMBERS = 5;
+class CRM_Member_Task extends CRM_Core_Task {
+  const
+    // Member tasks
+    LABEL_MEMBERS = 201;
 
-  /**
-   * The task array
-   *
-   * @var array
-   */
-  static $_tasks = NULL;
-
-  /**
-   * The optional task array
-   *
-   * @var array
-   */
-  static $_optionalTasks = NULL;
+  static $objectType = 'membership';
 
   /**
    * These tasks are the core set of tasks that the user can perform
@@ -63,20 +53,20 @@ class CRM_Member_Task {
    * @return array
    *   the set of tasks for a group of contacts
    */
-  public static function &tasks() {
-    if (!(self::$_tasks)) {
+  public static function tasks() {
+    if (!self::$_tasks) {
       self::$_tasks = array(
-        1 => array(
+        self::TASK_DELETE => array(
           'title' => ts('Delete memberships'),
           'class' => 'CRM_Member_Form_Task_Delete',
           'result' => FALSE,
         ),
-        2 => array(
+        self::TASK_PRINT => array(
           'title' => ts('Print selected rows'),
           'class' => 'CRM_Member_Form_Task_Print',
           'result' => FALSE,
         ),
-        3 => array(
+        self::TASK_EXPORT => array(
           'title' => ts('Export members'),
           'class' => array(
             'CRM_Export_Form_Select',
@@ -84,7 +74,7 @@ class CRM_Member_Task {
           ),
           'result' => FALSE,
         ),
-        4 => array(
+        self::TASK_EMAIL => array(
           'title' => ts('Email - send now (to %1 or less)', array(
             1 => Civi::settings()
               ->get('simple_mail_limit'),
@@ -92,7 +82,7 @@ class CRM_Member_Task {
           'class' => 'CRM_Member_Form_Task_Email',
           'result' => TRUE,
         ),
-        5 => array(
+        self::BATCH_UPDATE => array(
           'title' => ts('Update multiple memberships'),
           'class' => array(
             'CRM_Member_Form_Task_PickProfile',
@@ -100,14 +90,14 @@ class CRM_Member_Task {
           ),
           'result' => TRUE,
         ),
-        6 => array(
+        self::LABEL_MEMBERS => array(
           'title' => ts('Mailing labels - print'),
           'class' => array(
             'CRM_Member_Form_Task_Label',
           ),
           'result' => TRUE,
         ),
-        7 => array(
+        self::PDF_LETTER => array(
           'title' => ts('Print/merge document for memberships'),
           'class' => 'CRM_Member_Form_Task_PDFLetter',
           'result' => FALSE,
@@ -116,15 +106,14 @@ class CRM_Member_Task {
 
       //CRM-4418, check for delete
       if (!CRM_Core_Permission::check('delete in CiviMember')) {
-        unset(self::$_tasks[1]);
+        unset(self::$_tasks[self::TASK_DELETE]);
       }
       //CRM-12920 - check for edit permission
       if (!CRM_Core_Permission::check('edit memberships')) {
-        unset(self::$_tasks[5]);
+        unset(self::$_tasks[self::BATCH_UPDATE]);
       }
 
-      CRM_Utils_Hook::searchTasks('membership', self::$_tasks);
-      asort(self::$_tasks);
+      parent::tasks();
     }
 
     return self::$_tasks;
@@ -137,13 +126,8 @@ class CRM_Member_Task {
    * @return array
    *   the set of task titles
    */
-  public static function &taskTitles() {
-    self::tasks();
-    $titles = array();
-    foreach (self::$_tasks as $id => $value) {
-      $titles[$id] = $value['title'];
-    }
-    return $titles;
+  public static function taskTitles() {
+    return parent::taskTitles();
   }
 
   /**
@@ -151,12 +135,12 @@ class CRM_Member_Task {
    * of the user
    *
    * @param int $permission
+   * @param array $params
    *
    * @return array
    *   set of tasks that are valid for the user
    */
-  public static function &permissionedTaskTitles($permission) {
-    $tasks = array();
+  public static function permissionedTaskTitles($permission, $params = array()) {
     if (($permission == CRM_Core_Permission::EDIT)
       || CRM_Core_Permission::check('edit memberships')
     ) {
@@ -164,14 +148,16 @@ class CRM_Member_Task {
     }
     else {
       $tasks = array(
-        3 => self::$_tasks[3]['title'],
-        4 => self::$_tasks[4]['title'],
+        self::TASK_EXPORT => self::$_tasks[self::TASK_EXPORT]['title'],
+        self::TASK_EMAIL => self::$_tasks[self::TASK_EMAIL]['title'],
       );
       //CRM-4418,
       if (CRM_Core_Permission::check('delete in CiviMember')) {
-        $tasks[1] = self::$_tasks[1]['title'];
+        $tasks[self::TASK_DELETE] = self::$_tasks[self::TASK_DELETE]['title'];
       }
     }
+
+    $tasks = parent::corePermissionedTaskTitles($tasks, $permission, $params);
     return $tasks;
   }
 
@@ -187,13 +173,10 @@ class CRM_Member_Task {
   public static function getTask($value) {
     self::tasks();
     if (!$value || !CRM_Utils_Array::value($value, self::$_tasks)) {
-      // make the print task by default
-      $value = 2;
+      // Make the print task the default
+      $value = self::TASK_PRINT;
     }
-    return array(
-      self::$_tasks[$value]['class'],
-      self::$_tasks[$value]['result'],
-    );
+    return parent::getTask($value);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Refactor member task form to use base class

Before
----------------------------------------
![localhost_8000_civicrm_member_search__qf_search_display true qfkey 7dd0602c2407d318bfea3325a42d4e13_1263 1](https://user-images.githubusercontent.com/2052161/36969203-c504c51e-205c-11e8-9d56-1276444b1736.png)


After
----------------------------------------
![localhost_8000_civicrm_member_search__qf_search_display true qfkey 7dd0602c2407d318bfea3325a42d4e13_1263](https://user-images.githubusercontent.com/2052161/36969165-9ff2c802-205c-11e8-80e3-4b7ef22d0240.png)


Technical Details
----------------------------------------
details in #11240

Comments
----------------------------------------
This is a commit from #11240

In terms of review check that the code was a positive improvement and tested a couple of actions as well as checking the same number of actions were present

---

 * [CRM-21391: Refactor tasks to use a base class](https://issues.civicrm.org/jira/browse/CRM-21391)