### PR TITLE
CRM-21391 Convert Pledge to use core Task class

### DIFF
--- a/CRM/Pledge/Form/Search.php
+++ b/CRM/Pledge/Form/Search.php
@@ -155,9 +155,7 @@ class CRM_Pledge_Form_Search extends CRM_Core_Form_Search {
         $this->addRowSelectors($rows);
       }
 
-      $permission = CRM_Core_Permission::getPermission();
-
-      $this->addTaskMenu(CRM_Pledge_Task::permissionedTaskTitles($permission));
+      $this->addTaskMenu(CRM_Pledge_Task::permissionedTaskTitles(CRM_Core_Permission::getPermission()));
     }
 
   }

--- a/CRM/Pledge/Task.php
+++ b/CRM/Pledge/Task.php
@@ -34,22 +34,9 @@
  * class to represent the actions that can be performed on a group of contacts
  * used by the search forms.
  */
-class CRM_Pledge_Task {
-  const DELETE_PLEDGES = 1, PRINT_PLEDGES = 2, EXPORT_PLEDGES = 3;
+class CRM_Pledge_Task extends CRM_Core_Task {
 
-  /**
-   * The task array
-   *
-   * @var array
-   */
-  static $_tasks = NULL;
-
-  /**
-   * The optional task array
-   *
-   * @var array
-   */
-  static $_optionalTasks = NULL;
+  static $objectType = 'pledge';
 
   /**
    * These tasks are the core set of tasks that the user can perform
@@ -58,20 +45,20 @@ class CRM_Pledge_Task {
    * @return array
    *   the set of tasks for a group of contacts
    */
-  public static function &tasks() {
+  public static function tasks() {
     if (!self::$_tasks) {
       self::$_tasks = array(
-        1 => array(
+        self::TASK_DELETE => array(
           'title' => ts('Delete pledges'),
           'class' => 'CRM_Pledge_Form_Task_Delete',
           'result' => FALSE,
         ),
-        2 => array(
+        self::TASK_PRINT => array(
           'title' => ts('Print selected rows'),
           'class' => 'CRM_Pledge_Form_Task_Print',
           'result' => FALSE,
         ),
-        3 => array(
+        self::TASK_EXPORT => array(
           'title' => ts('Export pledges'),
           'class' => array(
             'CRM_Export_Form_Select',
@@ -83,40 +70,13 @@ class CRM_Pledge_Task {
 
       // CRM-4418, check for delete
       if (!CRM_Core_Permission::check('delete in CiviPledge')) {
-        unset(self::$_tasks[1]);
+        unset(self::$_tasks[self::TASK_DELETE]);
       }
 
-      CRM_Utils_Hook::searchTasks('pledge', self::$_tasks);
-      asort(self::$_tasks);
+      parent::tasks();
     }
 
     return self::$_tasks;
-  }
-
-  /**
-   * These tasks are the core set of task titles.
-   *
-   * @return array
-   *   the set of task titles
-   */
-  public static function &taskTitles() {
-    self::tasks();
-    $titles = array();
-    foreach (self::$_tasks as $id => $value) {
-      $titles[$id] = $value['title'];
-    }
-    return $titles;
-  }
-
-  /**
-   * These tasks get added based on the context the user is in.
-   *
-   * @return array
-   *   the set of optional tasks for a group of contacts
-   */
-  public static function &optionalTaskTitle() {
-    $tasks = array();
-    return $tasks;
   }
 
   /**
@@ -124,12 +84,12 @@ class CRM_Pledge_Task {
    * of the user
    *
    * @param int $permission
+   * @param array $params
    *
    * @return array
    *   set of tasks that are valid for the user
    */
-  public static function &permissionedTaskTitles($permission) {
-    $tasks = array();
+  public static function permissionedTaskTitles($permission, $params = array()) {
     if (($permission == CRM_Core_Permission::EDIT)
       || CRM_Core_Permission::check('edit pledges')
     ) {
@@ -137,13 +97,15 @@ class CRM_Pledge_Task {
     }
     else {
       $tasks = array(
-        3 => self::$_tasks[3]['title'],
+        self::TASK_EXPORT => self::$_tasks[self::TASK_EXPORT]['title'],
       );
       //CRM-4418,
       if (CRM_Core_Permission::check('delete in CiviPledge')) {
-        $tasks[1] = self::$_tasks[1]['title'];
+        $tasks[self::TASK_DELETE] = self::$_tasks[self::TASK_DELETE]['title'];
       }
     }
+
+    $tasks = parent::corePermissionedTaskTitles($tasks, $permission, $params);
     return $tasks;
   }
 
@@ -158,14 +120,12 @@ class CRM_Pledge_Task {
    */
   public static function getTask($value) {
     self::tasks();
-    if (!$value || !CRM_Utils_Array::value($value, self::$_tasks)) {
-      // make the print task by default
-      $value = 2;
+
+    if (!CRM_Utils_Array::value($value, self::$_tasks)) {
+      // make it the print task by default
+      $value = self::TASK_PRINT;
     }
-    return array(
-      self::$_tasks[$value]['class'],
-      self::$_tasks[$value]['result'],
-    );
+    return parent::getTask($value);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Refactor pledge task form to use base class

Before
----------------------------------------
![localhost_8000_civicrm_pledge_search__qf_search_display true qfkey 97509ea2c695ec64b701943e64b445f7_6404](https://user-images.githubusercontent.com/2052161/36969293-00509b02-205d-11e8-80f1-051f4d32c4c7.png)


After
----------------------------------------
![localhost_8000_civicrm_pledge_search__qf_search_display true qfkey 97509ea2c695ec64b701943e64b445f7_6404 1](https://user-images.githubusercontent.com/2052161/36969320-0edb2cf0-205d-11e8-9758-e007ed1d350d.png)


Technical Details
----------------------------------------
details in #11240

Comments
----------------------------------------
This is a commit from #11240.

In terms of review check that the code was a positive improvement and tested a couple of actions as well as checking the same number of actions were present

---

 * [CRM-21391: Refactor tasks to use a base class](https://issues.civicrm.org/jira/browse/CRM-21391)