### PR TITLE
dev/financial#4 Add processor name to recurring contribution overview on Contribution tab

### DIFF
--- a/templates/CRM/Contribute/Page/ContributionRecur.tpl
+++ b/templates/CRM/Contribute/Page/ContributionRecur.tpl
@@ -72,6 +72,7 @@
             <th scope="col">{ts}Start Date{/ts}</th>
             <th scope="col">{ts}Installments{/ts}</th>
             <th scope="col">{ts}Status{/ts}</th>
+            <th scope="col">{ts}Processor{/ts}</th>
             <th scope="col"></th>
         </tr>
 
@@ -83,6 +84,7 @@
                 <td>{$row.start_date|crmDate}</td>
                 <td>{$row.installments}</td>
                 <td>{$row.contribution_status}</td>
+                <td>{$row.payment_processor}</td>
                 <td>{$row.action|replace:'xx':$row.recurId}</td>
             </tr>
         {/foreach}


### PR DESCRIPTION
Overview
----------------------------------------
Requires changes in https://issues.civicrm.org/jira/browse/CRM-21784 so data is available to smarty.

Ref https://lab.civicrm.org/dev/financial/issues/4

The recurring section could do with quite a bit of refactoring to allow things such as sorting, optional columns etc.  However, as it stands a two line change to the template allows us to add additional columns as it currently has less columns than the contribution tab.  This PR adds the "processor name" column as this is probably one of the more common bits of useful information that all processors use.
Use case: It allows you to see at a glance who has direct debits setup, who has recurring payments with paypal etc.  Currently this information is a bit awkward to find as you have to open each recurring contribution to look at the detail.

Before
----------------------------------------
![localhost_8000_civicrm_contact_view_reset 1 cid 206 1](https://user-images.githubusercontent.com/2052161/36971111-aa86e4a0-2062-11e8-824e-899b47e83297.png)


After
----------------------------------------
![localhost_8000_civicrm_contact_view_reset 1 cid 206](https://user-images.githubusercontent.com/2052161/36971115-b0cb73da-2062-11e8-8d5d-cf1bc942281f.png)


Technical Details
----------------------------------------
Changes to smarty template only.
