### PR TITLE
Fixed template structure issues

### DIFF
--- a/templates/CRM/Admin/Form/Setting/Component.tpl
+++ b/templates/CRM/Admin/Form/Setting/Component.tpl
@@ -23,10 +23,10 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-<div class="crm-block crm-form-block crm-component-form-block">
 <div class="help">
     {ts}CiviCRM includes several optional components which give you more tools to connect with and engage your constituents.{/ts}{help id="components"}
 </div>
+<div class="crm-block crm-form-block crm-component-form-block">
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
 {$form.enableComponents.html}
 <p class="description">

--- a/templates/CRM/Admin/Form/Setting/Debugging.tpl
+++ b/templates/CRM/Admin/Form/Setting/Debugging.tpl
@@ -23,10 +23,10 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-<div class="crm-block crm-form-block crm-debugging-form-block">
 <div class="help">
     {ts}In addition to the settings on this screen, there are a number of settings you can add to your sites's settings file (civicrm.settings.php) to provide additional debugging information.{/ts} {docURL page="Debugging for developers" resource="wiki"}
 </div>
+<div class="crm-block crm-form-block crm-debugging-form-block">
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
          <table class="form-layout">
             {if $form.userFrameworkLogging}

--- a/templates/CRM/Admin/Form/Setting/Mapping.tpl
+++ b/templates/CRM/Admin/Form/Setting/Mapping.tpl
@@ -23,10 +23,10 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-<div class="crm-block crm-form-block crm-map-form-block">
 <div class="help">
     {ts}CiviCRM includes plugins for several mapping and geocoding web services. When your users save a contact or event location address, a geocoding service will convert the address into geographical coordinates, which are required for mapping. Yahoo&rsquo;s geocoder will also automatically populate the postal code field. Mapping services allow your users to display addresses on a map.{/ts} {help id='map-intro-id'}
 </div>
+<div class="crm-block crm-form-block crm-map-form-block">
     <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
     <table class="form-layout-compressed">
          <tr class="crm-map-form-block-mapProvider">

--- a/templates/CRM/Admin/Form/Setting/Path.tpl
+++ b/templates/CRM/Admin/Form/Setting/Path.tpl
@@ -23,8 +23,7 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-<div class="crm-block crm-form-block crm-path-form-block">
-  <div class="help">
+<div class="help">
     <p>
       {ts}You may configure these upload directories using absolute paths or path variables.{/ts}
       {help id='id-path_vars'}
@@ -32,8 +31,8 @@
     <p>
       {ts}If you modify the defaults, make sure that your web server has write access to the directories.{/ts}
     </p>
-
-  </div>
+</div>
+<div class="crm-block crm-form-block crm-path-form-block">
  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
            <table class="form-layout">
             <tr class="crm-path-form-block-uploadDir">

--- a/templates/CRM/Admin/Form/Setting/UF.tpl
+++ b/templates/CRM/Admin/Form/Setting/UF.tpl
@@ -23,10 +23,10 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-<div class="crm-block crm-form-block crm-uf-form-block">
 <div class="help">
     {ts}These settings define the CMS variables that are used with CiviCRM.{/ts}
 </div>
+<div class="crm-block crm-form-block crm-uf-form-block">
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
       <table class="form-layout-compressed">
          <tr class="crm-uf-form-block-userFrameworkUsersTableName">

--- a/templates/CRM/Admin/Form/Setting/UpdateConfigBackend.tpl
+++ b/templates/CRM/Admin/Form/Setting/UpdateConfigBackend.tpl
@@ -23,7 +23,6 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-<div class="crm-block crm-form-block crm-config-backend-form-block">
 <div class="help">
     <p>
     {ts}When migrating a site to a new server, the paths and URLs of your CiviCRM installation may change. {/ts}
@@ -34,6 +33,7 @@
     {ts 1=$pathsURL 2=$urlsURL}The old paths and URLs may be retained in some database records. Use this form to clear caches or to reset paths to their defaults. If you need further customizations, then update the <a href="%1">Directories</a> and <a href="%2">Resource URLs</a>.{/ts}
     </p>
 </div>
+<div class="crm-block crm-form-block crm-config-backend-form-block">
         <div class="crm-submit-buttons">
           <span class="crm-button crm-i-button">
             <i class="crm-i fa-undo"></i>

--- a/templates/CRM/Admin/Form/Setting/Url.tpl
+++ b/templates/CRM/Admin/Form/Setting/Url.tpl
@@ -23,7 +23,6 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-<div class="crm-block crm-form-block crm-url-form-block">
 <div class="help">
   <p>
     {ts}These settings define the URLs used to access CiviCRM resources (CSS files, Javascript files, images, etc.).{/ts}
@@ -32,8 +31,8 @@
     {ts}You may configure these settings using absolute URLs or URL variables.{/ts}
     {help id='id-url_vars'}
   </p>
-
 </div>
+<div class="crm-block crm-form-block crm-url-form-block">
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
 <table class="form-layout">
     <tr class="crm-url-form-block-userFrameworkResourceURL">

--- a/templates/CRM/Badge/Form/Layout.tpl
+++ b/templates/CRM/Badge/Form/Layout.tpl
@@ -109,7 +109,7 @@
         </td>
       </tr>
       <tr class="crm-badge-layout-form-block-elements">
-        <td class="label">{ts}Elements{/ts}</td>
+        <td class="label"><label>{ts}Elements{/ts}</label></td>
         <td>
           <table class="form-layout-compressed">
             <tr>


### PR DESCRIPTION
Overview
----------------------------------------
This PR 
- moves help section outside block
- adds missing label

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/26058635/36973290-64e6817c-2098-11e8-89ef-880e7276d277.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/26058635/36973265-4e4dde88-2098-11e8-9748-2eb83789b2a8.png)

Comments
----------------------------------------
All pages have same effect screenshot is sample for one page