### PR TITLE
ensure correct payment_instrument_id

### DIFF
--- a/CRM/Core/Payment/AuthorizeNetIPN.php
+++ b/CRM/Core/Payment/AuthorizeNetIPN.php
@@ -146,6 +146,7 @@ class CRM_Core_Payment_AuthorizeNetIPN extends CRM_Core_Payment_BaseIPN {
       $contribution->amount_level = $objects['contribution']->amount_level;
       $contribution->address_id = $objects['contribution']->address_id;
       $contribution->campaign_id = $objects['contribution']->campaign_id;
+      $contribution->_relatedObjects = $objects['contribution']->_relatedObjects;
 
       $objects['contribution'] = &$contribution;
     }

--- a/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
@@ -186,6 +186,9 @@ class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
         'sequential' => 1,
       ));
     $this->assertEquals(2, $contribution['count']);
+    // Ensure both contributions are coded as credit card contributions.
+    $this->assertEquals(1, $contribution['values'][0]['payment_instrument_id']);
+    $this->assertEquals(1, $contribution['values'][1]['payment_instrument_id']);
     $this->assertEquals('second_one', $contribution['values'][1]['trxn_id']);
     $this->callAPISuccessGetSingle('membership_payment', array('contribution_id' => $contribution['values'][1]['id']));
     $this->callAPISuccessGetSingle('line_item', array(


### PR DESCRIPTION
https://lab.civicrm.org/dev/core/issues/7

Otherwise, after first recurring contribution, contributions are coded
as check, not credit card.

Overview
----------------------------------------
Ensure the correct payment instrument is assigned to recurring authorize.net contributions (after the initial one).

Before
----------------------------------------
After the initial recurring contribution, subsequent contributions are coded as payment instrument check, instead of credit card.

After
----------------------------------------
Subsequent contributions are coded as payment instrument credit card.

Technical Details
----------------------------------------
I took the path of least resistance and I'm not sure it's the correct one. In particular I'm suspicious of the code in CRM/Contribute/BAO/Contribution.php on line 4571:

```
    // If paymentProcessor is not set then the payment_instrument_id would not be correct.
    // not clear when or if this would occur if you encounter this please fix here & add a unit test.
    if (empty($contributionParams['payment_instrument_id']) && isset($contribution->_relatedObjects['paymentProcessor']['payment_instrument_id'])) {
      $contributionParams['payment_instrument_id'] = $contribution->_relatedObjects['paymentProcessor']['payment_instrument_id'];
    }
```
Maybe this code should just check for $contribution->payment_instrument_id and use that value if present?
