### PR TITLE
[REGRESSION] CRM-21806: Fix issues is search form when FULL_GROUP_BY_MODE enabled 

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -4890,7 +4890,10 @@ civicrm_relationship.is_permission_a_b = 0
     list($select, $from, $where, $having) = $this->query($count, $sortByChar, $groupContacts, $onlyDeleted);
 
     if (!empty($groupByCols)) {
-      $select = self::appendAnyValueToSelect($this->_select, $groupByCols, 'GROUP_CONCAT');
+      // It doesn't matter to include columns in SELECT clause, which are present in GROUP BY when we just want the contact IDs
+      if (!$groupContacts) {
+        $select = self::appendAnyValueToSelect($this->_select, $groupByCols, 'GROUP_CONCAT');
+      }
       $groupBy = " GROUP BY " . implode(', ', $groupByCols);
       if (!empty($order)) {
         // retrieve order by columns from ORDER BY clause

--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -1012,7 +1012,6 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
       $sql = $this->_query->searchQuery($start, $end, $sort, FALSE, $this->_query->_includeContactIds,
         FALSE, TRUE, TRUE);
     }
-    $replaceSQL = $this->_query->getSelect();
 
     // CRM-9096
     // due to limitations in our search query writer, the above query does not work
@@ -1025,10 +1024,10 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
 
     $insertSQL = "
 INSERT INTO civicrm_prevnext_cache ( entity_table, entity_id1, entity_id2, cacheKey, data )
-SELECT DISTINCT 'civicrm_contact', contact_a.id, contact_a.id, '$cacheKey', contact_a.display_name
+SELECT DISTINCT 'civicrm_contact', contact_a.id, contact_a.id, '$cacheKey', contact_a.sort_name
 ";
 
-    $sql = str_replace($replaceSQL, $insertSQL, $sql);
+    $sql = str_replace(array("SELECT contact_a.id as contact_id", "SELECT contact_a.id as id"), $insertSQL, $sql);
     try {
       CRM_Core_DAO::executeQuery($sql);
     }


### PR DESCRIPTION
Overview
----------------------------------------
This PR fixes the issues encountered after #11746 merge on Advanced Search and Custom search forms when `FULL_GROUP_BY_MODE` is enabled, those are listed under Before section


Before
----------------------------------------
1. Fatal Error on Custom Searches - 'undefined getSelect function'
2. A simple search via 'Advanced Search' form throws an error `unknown column civicrm_address.id` : 
![screen shot 2018-03-06 at 1 12 47 pm](https://user-images.githubusercontent.com/3735621/37019935-2338ba08-2140-11e8-993d-10907ec07c7e.png)


After
----------------------------------------
1. Fixed
2. Correctly return the rows:
![screen shot 2018-03-06 at 1 12 12 pm](https://user-images.githubusercontent.com/3735621/37019956-33500c7a-2140-11e8-911a-0fdb5f9b5d7d.png)


Technical Details
----------------------------------------
Thanks to the fix made [here](https://github.com/civicrm/civicrm-core/pull/11746/files#diff-143585e32dadc0e4857410eaad9206b4R1032) it now exposes any query failure while populating entries in prevnext table.

---

 * [CRM-21806: Search builder returns no results](https://issues.civicrm.org/jira/browse/CRM-21806)