### PR TITLE
Add 'huge' class to html textarea to match plaintext textarea

### DIFF
--- a/templates/CRM/Admin/Form/MessageTemplates.tpl
+++ b/templates/CRM/Admin/Form/MessageTemplates.tpl
@@ -96,7 +96,7 @@
            </div>
                 <div class="clear"></div>
                 <div class='html'>
-                    {$form.msg_html.html}
+                    {$form.msg_html.html|crmAddClass:huge}
                     <div class="description">{ts}An HTML formatted version of this message will be sent to contacts whose Email Format preference is 'HTML' or 'Both'.{/ts} {ts 1=$tokenDocsRepeated}Tokens may be included (%1).{/ts}</div>
                 </div>
         </div><!-- /.crm-accordion-body -->


### PR DESCRIPTION
Overview
----------------------------------------
Fix display of MessageTemplate editor.

Before
----------------------------------------
![www som org uk_civicrm_admin_messagetemplates_add_action update id 9 reset 1](https://user-images.githubusercontent.com/2052161/37026261-bac3cf0e-2125-11e8-81bd-1dfe618332d7.png)


After
----------------------------------------
![www som org uk_civicrm_admin_messagetemplates_add_action update id 9 reset 1 1](https://user-images.githubusercontent.com/2052161/37026267-be6a79dc-2125-11e8-858b-ea97a8378c15.png)


Technical Details
----------------------------------------
Add class "huge" to smarty template.

Comments
----------------------------------------
As we are transitioning to gitlab, not sure if I should be creating an issue or not, and if so on jira or gitlab?
