### PR TITLE
Add contributionStatusName to invoice params so you don't have to use…

### DIFF
--- a/CRM/Contribute/Form/Task/Invoice.php
+++ b/CRM/Contribute/Form/Task/Invoice.php
@@ -421,6 +421,7 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
         'pendingStatusId' => $pendingStatusId,
         'cancelledStatusId' => $cancelledStatusId,
         'contribution_status_id' => $contribution->contribution_status_id,
+        'contributionStatusName' => CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $contribution->contribution_status_id),
         'subTotal' => $subTotal,
         'street_address' => CRM_Utils_Array::value('street_address', CRM_Utils_Array::value($contribution->contact_id, $billingAddress)),
         'supplemental_address_1' => CRM_Utils_Array::value('supplemental_address_1', CRM_Utils_Array::value($contribution->contact_id, $billingAddress)),


### PR DESCRIPTION
… hardcoded IDs in template

Overview
----------------------------------------
refundedStatusId, pendingStatusId, cancelledStatusId and contribution_status_id are all passed through as template params for the invoice but if you want to check another status (eg. completed) you have to hardcode the ID of that status.  By adding contributionStatusName as a template parameter we can use the contribution_status name instead of hardcoding IDs.

Before
----------------------------------------
You have to hardcode contribution_status_id values in the template (bad if someone changes the IDs).

After
----------------------------------------
You can use contribution status name in the template so your if statements don't break if someone changes the IDs.