### PR TITLE
CiviMember: use `fa-ban`, proper `crm-i` class for canceled auto-renew

### DIFF
--- a/templates/CRM/Member/Form/Selector.tpl
+++ b/templates/CRM/Member/Form/Selector.tpl
@@ -69,9 +69,9 @@
     <td class="crm-membership-status crm-membership-status_{$row.membership_status}">{$row.membership_status}</td>
     <td class="crm-membership-auto_renew">
       {if $row.auto_renew eq 1}
-        <i class="fa fa-check" aria-hidden="true" title="{ts}Auto-renew active{/ts}"></i>
+        <i class="crm-i fa-check" aria-hidden="true" title="{ts}Auto-renew active{/ts}"></i>
       {elseif $row.auto_renew eq 2}
-        <i class="fa fa-exclamation" aria-hidden="true" title="{ts}Auto-renew error{/ts}"></i>
+        <i class="crm-i fa-ban" aria-hidden="true" title="{ts}Auto-renew error{/ts}"></i>
       {/if}
     </td>
     <td>

--- a/templates/CRM/Member/Page/Tab.tpl
+++ b/templates/CRM/Member/Page/Tab.tpl
@@ -96,9 +96,9 @@
                 <td class="crm-membership-source">{$activeMember.source}</td>
                 <td class="crm-membership-auto_renew">
                   {if $activeMember.auto_renew eq 1}
-                      <i class="fa fa-check" aria-hidden="true" title="{ts}Auto-renew active{/ts}"></i>
+                      <i class="crm-i fa-check" aria-hidden="true" title="{ts}Auto-renew active{/ts}"></i>
                   {elseif $activeMember.auto_renew eq 2}
-                      <i class="fa fa-exclamation" aria-hidden="true" title="{ts}Auto-renew error{/ts}"></i>
+                      <i class="crm-i fa-ban" aria-hidden="true" title="{ts}Auto-renew error{/ts}"></i>
                   {/if}
                 </td>
                 <td class="crm-membership-related_count">{$activeMember.related_count}</td>
@@ -145,9 +145,9 @@
                 <td class="crm-membership-source">{$inActiveMember.source}</td>
                 <td class="crm-membership-auto_renew">
                   {if $inActiveMember.auto_renew eq 1}
-                    <i class="fa fa-check" aria-hidden="true" title="{ts}Auto-renew active{/ts}"></i>
+                    <i class="crm-i fa-check" aria-hidden="true" title="{ts}Auto-renew active{/ts}"></i>
                   {elseif $inActiveMember.auto_renew eq 2}
-                    <i class="fa fa-exclamation" aria-hidden="true" title="{ts}Auto-renew error{/ts}"></i>
+                    <i class="crm-i fa-ban" aria-hidden="true" title="{ts}Auto-renew error{/ts}"></i>
                   {/if}
                 </td>
     <td>{$inActiveMember.action|replace:'xx':$inActiveMember.id}


### PR DESCRIPTION
Overview
----------------------------------------
In CRM-21688, icons display the status of auto-renew for memberships.  This uses the proper class for CiviCRM's implementation of Font Awesome and changes the icon for canceled auto-renewals.

Before
----------------------------------------
The icons use the `fa` class, which is the standard class for Font Awesome icons.  However, this could result in problems with CMS themes that have their own implementations of Font Awesome.

Also, the icon for canceled auto-renewals is [`fa-exclamation`](https://fontawesome.com/v4.7.0/icon/exclamation/), which implies that something has gone wrong with the autorenewal and needs immediate attention.

After
----------------------------------------
The icons use the `crm-i` class, which explicitly uses CiviCRM's Font Awesome library.

The icon for canceled auto-renewals is [`fa-ban`](https://fontawesome.com/v4.7.0/icon/ban/), an icon that more closely expresses that the member has canceled their autorenewal.

Comments
----------------------------------------
~~I'm not sure, but I don't think that CiviCRM's Font Awesome responds to the `fa` class at all, which means that the icons would be missing if a site lacks a separate Font Awesome implementation.  @colemanw do you know?  If that's the case, I think this might need to be a last-minute merge to the 4.7.31 RC.~~ Never mind, I just checked and it appears okay on dmaster.

---

 * [CRM-21688: Use fontawesome to show membership auto-renew status and and error indicator](https://issues.civicrm.org/jira/browse/CRM-21688)