### PR TITLE
CRM-21830: Add 'state_province_name' token and set appropriate value …

### DIFF
--- a/CRM/Utils/Address.php
+++ b/CRM/Utils/Address.php
@@ -331,6 +331,7 @@ class CRM_Utils_Address {
       "city" => "billing_city-{$billingLocationTypeID}",
       "postal_code" => "billing_postal_code-{$billingLocationTypeID}",
       "state_province" => "state_province-{$billingLocationTypeID}",
+      "state_province_name" => "state_province-{$billingLocationTypeID}",
       "country" => "country-{$billingLocationTypeID}",
     );
 
@@ -348,9 +349,12 @@ class CRM_Utils_Address {
           $value = $params[$alternateName];
         }
       }
-      if (is_numeric($value) && ($name == 'state_province' || $name == 'country')) {
+      if (is_numeric($value) && ($name == 'state_province' || $name == 'state_province_name' || $name == 'country')) {
         if ($name == 'state_province') {
           $addressFields[$name] = CRM_Core_PseudoConstant::stateProvinceAbbreviation($value);
+        }
+        if ($name == 'state_province_name') {
+          $addressFields[$name] = CRM_Core_PseudoConstant::stateProvince($value);
         }
         if ($name == 'country') {
           $addressFields[$name] = CRM_Core_PseudoConstant::countryIsoCode($value);


### PR DESCRIPTION
…to it so that it is not empty for billing address

Overview
----------------------------------------
When 'state_province_name' token is used(in address settings), the state/province is empty when 'Billing Address' is displayed(example, during Event registration on confirmation page)

Before
----------------------------------------
Using state_province_name in address settings gave empty results when displaying billing address.
![image-2018-03-01-10-35-12-231](https://user-images.githubusercontent.com/36624620/37071561-0a279cfc-21e3-11e8-9dbd-20f03845591f.png)


After
----------------------------------------
Billing addresses now displays state_province_name token as expected