### PR TITLE
CRM-20608: IPN thinks Paypal Pro is Standard.

### DIFF
--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -707,7 +707,12 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
       'id' => $params['processor_id'],
       'api.PaymentProcessorType.getvalue' => array('return' => "name"),
     ));
-    switch ($result['values'][0]['api.PaymentProcessorType.getvalue']) {
+    if (!$result['count']) {
+      throw new CRM_Core_Exception("Could not find a processor with the given processor_id value '{$params['processor_id']}'.");
+    }
+
+    $paymentProcessorType = CRM_Utils_Array::value('api.PaymentProcessorType.getvalue', $result['values'][0]);
+    switch ($paymentProcessorType) {
       case 'PayPal':
         // "PayPal - Website Payments Pro"
         $paypalIPN = new CRM_Core_Payment_PayPalProIPN($params);
@@ -721,9 +726,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
       default:
         // If we don't have PayPal Standard or PayPal Pro, something's wrong.
         // Log an error and exit.
-        CRM_Core_Error::debug_log_message("The processor_id value '{$params['processor_id']}' is for a processor of type '{$result['values'][0]['api.PaymentProcessorType.getvalue']}', which is invalid in this context.");
-        echo "Failure: Invalid processor: " . CRM_Utils_Type::escape($params['processor_id'], 'String');
-        exit();
+        throw new CRM_Core_Exception("The processor_id value '{$params['processor_id']}' is for a processor of type '{$paymentProcessorType}', which is invalid in this context.");
     }
 
     $paypalIPN->main();


### PR DESCRIPTION
Overview
----------------------------------------
As described in the ticket, regardless of whether the old way (extern/ipn.php) or new way (civicrm/payment/ipn/#) is used, the IPN interprets the IPN message as if it's Paypal Standard. As a result, IPN notifications for recurring payments are not processed properly.

Before
----------------------------------------
All incoming PayPal Pro IPN notifications for recurring contributions are successfully recorded in civicrm_system_log, but never make it as far as being recorded as payments in CiviCRM.

After
----------------------------------------
All incoming PayPal Pro IPN notifications for recurring contributions are correctly recorded as payments in CiviCRM.

Technical Details
----------------------------------------
As far as I can see, the existing code gets it backwards when asking "is this paypal pro or standard?". This PR reframes the question by querying the API for the given payment processor and testing against paymentprocessor.name instead of the slightly less clearly meaningful paymentprocessor.class_name.

Comments
----------------------------------------
I guess we want unit tests for this?

---

 * [CRM-20608: IPN thinks Paypal Pro is Standard](https://issues.civicrm.org/jira/browse/CRM-20608)