### PR TITLE
CRM-21832 - Recurring activities don't carry over custom data and tags

### DIFF
--- a/CRM/Core/BAO/RecurringEntity.php
+++ b/CRM/Core/BAO/RecurringEntity.php
@@ -596,6 +596,14 @@ class CRM_Core_BAO_RecurringEntity extends CRM_Core_DAO_RecurringEntity {
       $object->find(TRUE);
 
       CRM_Core_BAO_RecurringEntity::quickAdd($object->id, $newObject->id, $entityTable);
+      CRM_Core_DAO::copyCustomFields($object->id, $newObject->id, $entityTable);
+      CRM_Core_DAO::copyGeneric('CRM_Core_DAO_EntityTag',
+        array(
+          'entity_id' => $object->id,
+          'entity_table' => $entityTable,
+        ),
+        array('entity_id' => $newObject->id)
+      );
     }
     return $newObject;
   }

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1612,6 +1612,60 @@ FROM   civicrm_domain
   }
 
   /**
+   * Method that copies custom fields values from an old event to a new one. Fixes bug CRM-19302,
+   * where if a custom field of File type was present, left both events using the same file,
+   * breaking download URL's for the old event.
+   *
+   * @param int $oldID
+   * @param int $newID
+   * @param string $entityTable
+   */
+  public static function copyCustomFields($oldID, $newID, $entityTable) {
+    $entity = ucwords(substr($entityTable, 8, strlen($entityTable)));
+
+    // Obtain custom values for old entity
+    $customParams = $htmlType = array();
+    $customValues = CRM_Core_BAO_CustomValueTable::getEntityValues($oldID, $entity);
+
+    // If custom values present, we copy them
+    if (!empty($customValues)) {
+      // Get Field ID's and identify File type attributes, to handle file copying.
+      $fieldIds = implode(', ', array_keys($customValues));
+      $sql = "SELECT id FROM civicrm_custom_field WHERE html_type = 'File' AND id IN ( {$fieldIds} )";
+      $result = CRM_Core_DAO::executeQuery($sql);
+
+      // Build array of File type fields
+      while ($result->fetch()) {
+        $htmlType[] = $result->id;
+      }
+
+      // Build params array of custom values
+      foreach ($customValues as $field => $value) {
+        if ($value !== NULL) {
+          // Handle File type attributes
+          if (in_array($field, $htmlType)) {
+            $fileValues = CRM_Core_BAO_File::path($value, $oldID);
+            $customParams["custom_{$field}_-1"] = array(
+              'name' => CRM_Utils_File::duplicate($fileValues[0]),
+              'type' => $fileValues[1],
+            );
+          }
+          // Handle other types
+          else {
+            $customParams["custom_{$field}_-1"] = $value;
+          }
+        }
+      }
+
+      // Save Custom Fields for new Entity
+      CRM_Core_BAO_CustomValueTable::postProcess($customParams, $entityTable, $newID, $entity);
+    }
+
+    // copy activity attachments ( if any )
+    CRM_Core_BAO_File::copyEntityFile($entityTable, $oldID, $entityTable, $newID);
+  }
+
+  /**
    * Cascade update through related entities.
    *
    * @param string $daoName

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1002,7 +1002,7 @@ WHERE civicrm_event.is_active = 1
 
     if (!$afterCreate) {
       // CRM-19302
-      self::copyCustomFields($id, $copyEvent->id);
+      CRM_Core_DAO::copyCustomFields($id, $copyEvent->id, 'civicrm_event');
     }
 
     $copyEvent->save();
@@ -1012,57 +1012,6 @@ WHERE civicrm_event.is_active = 1
       CRM_Utils_Hook::copy('Event', $copyEvent);
     }
     return $copyEvent;
-  }
-
-  /**
-   * Method that copies custom fields values from an old event to a new one. Fixes bug CRM-19302,
-   * where if a custom field of File type was present, left both events using the same file,
-   * breaking download URL's for the old event.
-   *
-   * @param int $oldEventID
-   * @param int $newCopyID
-   */
-  public static function copyCustomFields($oldEventID, $newCopyID) {
-    // Obtain custom values for old event
-    $customParams = $htmlType = array();
-    $customValues = CRM_Core_BAO_CustomValueTable::getEntityValues($oldEventID, 'Event');
-
-    // If custom values present, we copy them
-    if (!empty($customValues)) {
-      // Get Field ID's and identify File type attributes, to handle file copying.
-      $fieldIds = implode(', ', array_keys($customValues));
-      $sql = "SELECT id FROM civicrm_custom_field WHERE html_type = 'File' AND id IN ( {$fieldIds} )";
-      $result = CRM_Core_DAO::executeQuery($sql);
-
-      // Build array of File type fields
-      while ($result->fetch()) {
-        $htmlType[] = $result->id;
-      }
-
-      // Build params array of custom values
-      foreach ($customValues as $field => $value) {
-        if ($value !== NULL) {
-          // Handle File type attributes
-          if (in_array($field, $htmlType)) {
-            $fileValues = CRM_Core_BAO_File::path($value, $oldEventID);
-            $customParams["custom_{$field}_-1"] = array(
-              'name' => CRM_Utils_File::duplicate($fileValues[0]),
-              'type' => $fileValues[1],
-            );
-          }
-          // Handle other types
-          else {
-            $customParams["custom_{$field}_-1"] = $value;
-          }
-        }
-      }
-
-      // Save Custom Fields for new Event
-      CRM_Core_BAO_CustomValueTable::postProcess($customParams, 'civicrm_event', $newCopyID, 'Event');
-    }
-
-    // copy activity attachments ( if any )
-    CRM_Core_BAO_File::copyEntityFile('civicrm_event', $oldEventID, 'civicrm_event', $newCopyID);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Recurring activities don't carry over custom data and tags

Before
----------------------------------------
custom fields and tags on activity are not carried over the repeat activity.

After
----------------------------------------
custom fields and tags on activity are carried over all the repeat activity.

Comments
----------------------------------------
it looks like an oversight to have missed this.

---

 * [CRM-21832: Recurring activities don't carry over custom data and tags](https://issues.civicrm.org/jira/browse/CRM-21832)