### PR TITLE
CRM-21756: Freeze total amount field on Edit Contribution if related to Membership or Event registration

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -97,6 +97,9 @@
       <td class="label">{$form.total_amount.label}</td>
       <td {$valueStyle}>
         <span id='totalAmount'>{$form.currency.html|crmAddClass:eight}&nbsp;{$form.total_amount.html|crmAddClass:eight}</span>
+        {if $freezeFinancialType}
+          {help id="id-total_amount"}
+        {/if}
         {if !$payNow}
           {if $hasPriceSets}
             <span id='totalAmountORPriceSet'> {ts}OR{/ts}</span>

--- a/templates/CRM/Contribute/Page/Tab.hlp
+++ b/templates/CRM/Contribute/Page/Tab.hlp
@@ -30,6 +30,13 @@
 {ts}Optional identifier for the contribution source (campaign name, event, mailer, etc.).{/ts}
 {/htxt}
 
+{htxt id="id-total_amount-title"}
+  {ts}Total Amount{/ts}
+{/htxt}
+{htxt id="id-total_amount"}
+{ts 1='target="_blank" href="https://civicrm.org/extensions/line-item-editor"'}You are not allowed to change the total amount as it will lead to incorrect line item entries. You can either delete or recreate or install <a %1>Line Item Editor</a>.{/ts}
+{/htxt}
+
 {htxt id="id-financial_type-title"}
   {ts}Financial Type{/ts}
 {/htxt}
@@ -78,7 +85,7 @@
 <p>
 {ts}When contributions are made via a Personal Campaign Page a soft credit (of type 'Personal Campaign Page') is automatically created and assigned to the 'owner' of the the Personal Campaign Page.{/ts}
 </p>
-{/htxt} 
+{/htxt}
 
 {htxt id="adjust-payment-amount-title"}
   {ts}Payment Amount{/ts}


### PR DESCRIPTION
Overview
----------------------------------------
Currently, when we change the total amount of membership payment, it doesn't update the corresponding line-item data. Instead, we can recreate the membership payment or we either use [Lineitem editor](https://civicrm.org/extensions/line-item-editor).

Before
----------------------------------------
Total amount field is editable and on change leads to outdated line-item entry.

After
----------------------------------------
Total amount field is frozen and there is help text beside this field that provides instruction to perform the same task either by recreating the membership or using Lineitem Editor.
![screen shot 2018-03-07 at 7 39 48 pm](https://user-images.githubusercontent.com/3735621/37096666-5bc2e876-223f-11e8-9be9-facc83b75af5.png)

---

 * [CRM-21756: Editing Contribution \(total_amount\) does -not- update LineItem \(line_total\)](https://issues.civicrm.org/jira/browse/CRM-21756)