### PR TITLE
Remove hacks from CRM_Core_Menu for old unsupported versions

### DIFF
--- a/CRM/Core/Menu.php
+++ b/CRM/Core/Menu.php
@@ -307,7 +307,6 @@ class CRM_Core_Menu {
 
     self::build($menuArray);
 
-    $config = CRM_Core_Config::singleton();
     $daoFields = CRM_Core_DAO_Menu::fields();
 
     foreach ($menuArray as $path => $item) {
@@ -673,8 +672,6 @@ class CRM_Core_Menu {
     // return null if menu rebuild
     $config = CRM_Core_Config::singleton();
 
-    $params = array();
-
     $args = explode('/', $path);
 
     $elements = array();
@@ -687,22 +684,13 @@ class CRM_Core_Menu {
 
     $queryString = implode(', ', $elements);
     $domainID = CRM_Core_Config::domainID();
-    $domainWhereClause = " AND domain_id = $domainID ";
-    if ($config->isUpgradeMode() &&
-      !CRM_Core_DAO::checkFieldExists('civicrm_menu', 'domain_id')
-    ) {
-      //domain_id wouldn't be available for earlier version of
-      //3.0 and therefore can't be used as part of query for
-      //upgrade case
-      $domainWhereClause = "";
-    }
 
     $query = "
 (
   SELECT *
   FROM     civicrm_menu
   WHERE    path in ( $queryString )
-           $domainWhereClause
+           AND domain_id = $domainID
   ORDER BY length(path) DESC
   LIMIT    1
 )
@@ -714,7 +702,7 @@ UNION (
   SELECT *
   FROM   civicrm_menu
   WHERE  path IN ( 'navigation' )
-         $domainWhereClause
+         AND domain_id = $domainID
 )
 ";
     }
@@ -752,12 +740,6 @@ UNION (
       }
     }
 
-    // *FIXME* : hack for 2.1 -> 2.2 upgrades.
-    if ($path == 'civicrm/upgrade') {
-      $menuPath['page_callback'] = 'CRM_Upgrade_Page_Upgrade';
-      $menuPath['access_arguments'][0][] = 'administer CiviCRM';
-      $menuPath['access_callback'] = array('CRM_Core_Permission', 'checkMenu');
-    }
     // *FIXME* : hack for 4.1 -> 4.2 upgrades.
     if (preg_match('/^civicrm\/(upgrade\/)?queue\//', $path)) {
       CRM_Queue_Menu::alter($path, $menuPath);


### PR DESCRIPTION
Overview
----
Removes unused variables and old unsupported hacks that were needed in ancient times.

Before
-----
Clutter.

After
----
-18 lines of clutter.

Technical Notes
-------
Currently CiviCRM 4.7 does not support directly upgrading from any version prior to 4.1. So all upgrade code for previous versions should be removed. I had already gotten rid of most of it, here are few stragglers.