### PR TITLE
Adding 'Is not equal to' option to OP_SELECT (e.g. for CiviReport filters)

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -1663,6 +1663,7 @@ class CRM_Report_Form extends CRM_Core_Form {
       case CRM_Report_Form::OP_SELECT:
         $result = array(
           'eq' => ts('Is equal to'),
+          'neq' => ts('Is not equal to'),
         );
         return $result;
 


### PR DESCRIPTION
Adding 'Is not equal to' option to OP_SELECT (e.g. for CiviReport filters).

Overview
----------------------------------------
_The OP_SELECT option seems to be missing a "Is not equal to" option so the select only gives "Is equal to" as a choice._

Before
----------------------------------------
![screen shot 2018-03-07 at 12 24 06 pm](https://user-images.githubusercontent.com/871421/37110435-83cb65ec-2202-11e8-9ba1-3bde3fc930a2.jpg)

After
----------------------------------------
![screen shot 2018-03-07 at 12 25 48 pm](https://user-images.githubusercontent.com/871421/37110507-b95599bc-2202-11e8-89f3-9238eade344d.jpg)