### PR TITLE
(WIP) CRM-21828: Modify Civi Contribution Imports; Include Membership Id an…

### DIFF
--- a/CRM/Contribute/Import/Form/MapField.php
+++ b/CRM/Contribute/Import/Form/MapField.php
@@ -42,6 +42,16 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
    */
   public function preProcess() {
     $this->_mapperFields = $this->get('fields');
+
+    // Check if CiviMember is enabled
+    $config = CRM_Core_Config::singleton();
+    $memberEnabled = in_array("CiviMember", $config->enableComponents);
+    if ($memberEnabled) {
+      // Add membership_id and external_membership_id fields
+      $this->_mapperFields['membership_id'] = ts('Membership ID');
+      $this->_mapperFields['external_membership_id'] = ts('Membership ID (External)');
+    }
+
     asort($this->_mapperFields);
 
     $this->_columnCount = $this->get('columnCount');
@@ -66,7 +76,7 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
     //CRM-2219 removing other required fields since for updation only
     //invoice id or trxn id or contribution id is required.
     if ($this->_onDuplicate == CRM_Import_Parser::DUPLICATE_UPDATE) {
-      $remove = array('contribution_contact_id', 'email', 'first_name', 'last_name', 'external_identifier');
+      $remove = array('contribution_contact_id', 'email', 'first_name', 'last_name', 'external_identifier', 'membership_id', 'external_membership_id');
       foreach ($remove as $value) {
         unset($this->_mapperFields[$value]);
       }
@@ -447,7 +457,6 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
    */
   public function postProcess() {
     $params = $this->controller->exportValues('MapField');
-
     //reload the mapfield if load mapping is pressed
     if (!empty($params['savedMapping'])) {
       $this->set('savedMapping', $params['savedMapping']);

--- a/CRM/Contribute/Import/Form/Preview.php
+++ b/CRM/Contribute/Import/Form/Preview.php
@@ -137,6 +137,15 @@ class CRM_Contribute_Import_Form_Preview extends CRM_Import_Form_Preview {
 
     $mapFields = $this->get('fields');
 
+    // Check if CiviMember is enabled
+    $config = CRM_Core_Config::singleton();
+    $memberEnabled = in_array("CiviMember", $config->enableComponents);
+    if ($memberEnabled) {
+      // Add membership_id and external_membership_id fields
+      $mapFields['membership_id'] = ts('Membership ID');
+      $mapFields['external_membership_id'] = ts('Membership ID (External)');
+    }
+
     foreach ($mapper as $key => $value) {
       $header = array();
       if (isset($mapFields[$mapper[$key][0]])) {


### PR DESCRIPTION
Overview
----------------------------------------
Contribution imports do not have a linked membership ID (while importing) and so when you import contributions, they don't currently pertain to a particular membership. As a build up to this, we have already created a new field called Membership External ID (CRM-21827; PR: https://github.com/civicrm/civicrm-core/pull/11783)
We now have to add this new field as well as the Civi membership ID to the import selection dropdown

Before
----------------------------------------
When importing contributions there is no way to link that contribution to an existing membership (even if we know the membership id)

After
----------------------------------------
When importing contributions, it should be possible to import a membership id and external membership id(CRM-21827) so that the imported contribution is matched/linked to the corresponding membership.

Comments
----------------------------------------
This PR depends on this PR: https://github.com/civicrm/civicrm-core/pull/11783

