### PR TITLE
CRM-21835 Gracefully switch Log Table Engines if Archive is not avali…

### DIFF
--- a/tests/phpunit/CRM/Logging/SchemaTest.php
+++ b/tests/phpunit/CRM/Logging/SchemaTest.php
@@ -30,4 +30,15 @@ class CRM_Logging_SchemaTest extends CiviUnitTestCase {
     $this->assertEquals($expectedQuery, CRM_Logging_Schema::fixTimeStampAndNotNullSQL($query));
   }
 
+  public function testLogEngine() {
+    $schema = new CRM_Logging_Schema();
+    $schema->enableLogging();
+    $log_table = CRM_Core_DAO::executeQuery("SHOW CREATE TABLE log_civicrm_acl");
+    while ($log_table->fetch()) {
+      $this->assertRegexp('/ENGINE=ARCHIVE/', $log_table->Create_Table);
+    }
+    $schema->disableLogging();
+    $schema->dropAllLogTables();
+  }
+
 }


### PR DESCRIPTION
…able

Overview
----------------------------------------
Since MariaDB 10.1 The archive engine is not automatically enabled. This can cause problems when enabling detailed logging as it will try to create the tables using the Archive Engine. Some users maybe able to enable the Archive Engine but for others especially on shared hosting this may not be available as an option. So lets gracefully fall over to INNODB. 

Before
----------------------------------------
If you enable logging when the `ARCHIVE` engine is unavailable, it generates a fatal error.

After
----------------------------------------
If you enable logging when the `ARCHIVE` engine is unavailable, it falls back to InnoDB.

Comments
----------------------------------------
ping @eileenmcnaughton @totten @agileware . This was raised to me by Agileware and i think it makes sense to just gracefully handle it rather than try and get people to install the archive extension. This set up also keeps the status quo of if Archive is available use it. 