### PR TITLE
CRM-21836: Word Replacement Not Working For CiviCase Page Titles

### DIFF
--- a/CRM/Case/Form/Case.php
+++ b/CRM/Case/Form/Case.php
@@ -151,7 +151,7 @@ class CRM_Case_Form_Case extends CRM_Core_Form {
 
     $details = CRM_Case_PseudoConstant::caseActivityType(FALSE);
 
-    CRM_Utils_System::setTitle($details[$this->_activityTypeId]['label']);
+    CRM_Utils_System::setTitle(ts($details[$this->_activityTypeId]['label']));
     $this->assign('activityType', $details[$this->_activityTypeId]['label']);
     $this->assign('activityTypeDescription', $details[$this->_activityTypeId]['description']);
 


### PR DESCRIPTION
Overview
----------------------------------------
Word replacements doesnt work for page titles for CiviCase when opening a new case.

Before
----------------------------------------
When adding a new case, the page title doesnt respect word replacements
![0abbdfee-87a0-4a47-915e-ee9c7f48e097](https://user-images.githubusercontent.com/36624620/37147495-1f142df0-22ed-11e8-8912-5c093b3bb118.png)


After
----------------------------------------
Page title for 'open case' page should respect word replacements if available

---

 * [CRM-21836: Word replacement not working for Civicase page title](https://issues.civicrm.org/jira/browse/CRM-21836)