### PR TITLE
CRM-21733: Ensure that overridden until date memberships get processed correctly

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -2286,23 +2286,22 @@ WHERE      civicrm_membership.is_test = 0";
         continue;
       }
 
-      self::processOverriddenUntilDateMembership($dao);
-
-      //update membership records where status is NOT - Pending OR Cancelled.
+      //update membership records where status is NOT  Pending OR Cancelled.
       //as well as membership is not override.
       //skipping Expired membership records -> reduced extra processing( kiran )
-      if (!$dao->is_override &&
-        !in_array($dao->status_id, array(
-          array_search('Pending', $allStatus),
-          // CRM-15475
-          array_search(
-            'Cancelled',
-            CRM_Member_PseudoConstant::membershipStatus(NULL, " name = 'Cancelled' ", 'name', FALSE, TRUE)
-          ),
-          array_search('Expired', $allStatus),
-        ))
-      ) {
+      $isOverrideUntilDateDueDate = self::isOverrideUntilDateDueDate($dao);
+      $shouldProcessTheMembership = $isOverrideUntilDateDueDate || (!$dao->is_override &&
+          !in_array($dao->status_id, array(
+            array_search('Pending', $allStatus),
+            // CRM-15475
+            array_search(
+              'Cancelled',
+              CRM_Member_PseudoConstant::membershipStatus(NULL, " name = 'Cancelled' ", 'name', FALSE, TRUE)
+            ),
+            array_search('Expired', $allStatus),
+          )));
 
+      if ($shouldProcessTheMembership) {
         // CRM-7248: added excludeIsAdmin param to the following fn call to prevent moving to admin statuses
         //get the membership status as per id.
         $newStatus = civicrm_api('membership_status', 'calc',
@@ -2313,6 +2312,14 @@ WHERE      civicrm_membership.is_test = 0";
           ), TRUE
         );
         $statusId = CRM_Utils_Array::value('id', $newStatus);
+
+        if ($isOverrideUntilDateDueDate) {
+          civicrm_api3('membership', 'create', array(
+            'id' => $dao->membership_id,
+            'is_override' => FALSE,
+            'status_override_end_date' => 'null',
+          ));
+        }
 
         //process only when status change.
         if ($statusId &&
@@ -2352,17 +2359,19 @@ WHERE      civicrm_membership.is_test = 0";
   }
 
   /**
-   * Set is_override for the 'overridden until date' membership to
-   * False and clears the 'until date' field in case the 'until date'
-   * is equal or after today date.
+   * Returns True if the membership status is
+   * overridden until date and its end date is after or
+   * equal today date, otherwise return False.
    *
    * @param CRM_Core_DAO $membership
    *   The membership to be processed
+   *
+   * @return bool
    */
-  private static function processOverriddenUntilDateMembership($membership) {
+  private static function isOverrideUntilDateDueDate($membership) {
     $isOverriddenUntilDate = !empty($membership->is_override) && !empty($membership->status_override_end_date);
     if (!$isOverriddenUntilDate) {
-      return;
+      return FALSE;
     }
 
     $todayDate = new DateTime();
@@ -2374,13 +2383,10 @@ WHERE      civicrm_membership.is_test = 0";
     $datesDifference = $todayDate->diff($overrideEndDate);
     $daysDifference = (int) $datesDifference->format('%R%a');
     if ($daysDifference <= 0) {
-      $params = array(
-        'id' => $membership->membership_id,
-        'is_override' => FALSE,
-        'status_override_end_date' => 'null',
-      );
-      civicrm_api3('membership', 'create', $params);
+      return TRUE;
     }
+
+    return FALSE;
   }
 
   /**


### PR DESCRIPTION
Before
----------------------------------------
Assume the following scenario : 


1- Create a membership with : 
- start date = 01/04/2017
-  end date = 31/03/2018
- Override until selected date =today date
- Membership Status = **Cancelled**

2- Run **Update Membership Statuses** Scheduled job.

3- The Status override setting will change to from  "Override until selected date" to "No" as expected but the Membership Status will remain **Cancelled** instead of getting changed to "Current".

The issue also happen if the override status is either 'Expired' or 'Pending'.

After
----------------------------------------
Do the same steps as above, The Status override setting will change to from  "Override until selected date" to "No" and the Membership status will change to 'Current'.

 
Technical Details
----------------------------------------
The Scheduled job code has a condition that prevent from processing any the status of any membership in either Pending, Cancelled or Expired statuses, so when a membership has an override end date = today and its status is Pending, Cancelled or Expired , it will get first changed to non overridden, but because its status is one of the 3 statuses mentioned before then its status will not get processed and changed to Current. 

What should happen in this case is : 

1- Add a condition that checks if the membership is overridden until date and its end date is today or less than today.
2- If yes then allow for this membership status to get processed and then change its is_override flag to False and the end date field to NULL.

---

 * [CRM-21733: Allow overriding membership status temporarily until specific date](https://issues.civicrm.org/jira/browse/CRM-21733)