### PR TITLE
dev/core#12: Added auto-scroll-up functionality between steps to crmUiWizard

### DIFF
--- a/ang/crmUi.js
+++ b/ang/crmUi.js
@@ -875,6 +875,20 @@
         },
         link: function (scope, element, attrs) {
           scope.ts = CRM.ts(null);
+
+          element.find('.crm-wizard-buttons button').click(function () {
+            // These values are captured inside the click handler to ensure the
+            // positions/sizes of the elements are captured at the time of the
+            // click vs. at the time this directive is initialized.
+            var topOfWizard = element.offset().top;
+            var heightOfMenu = $('#civicrm-menu').height() || 0;
+
+            $('html')
+              // stop any other animations that might be happening...
+              .stop()
+              // gracefully slide the user to the top of the wizard
+              .animate({scrollTop: topOfWizard - heightOfMenu}, 1000);
+          });
         }
       };
     })


### PR DESCRIPTION
Overview
----------------------------------------
Adds auto-scroll-up functionality between steps in a wizard-driven workflow.

Before
----------------------------------------
See https://lab.civicrm.org/dev/core/issues/12.

After
----------------------------------------
![anim](https://user-images.githubusercontent.com/871819/37176463-6f0a2696-22ea-11e8-96b4-28306a9f82e1.gif)

Technical Details
----------------------------------------
Simply leverages the link function of the crmUiWizard directive to add onClick behavior to the wizard's buttons.

Comments
----------------------------------------
Tested in both a vanilla CiviCRM instance as an admin (on the CiviMail UI, as pictured) as well as on a custom Angular basepage (where users cannot see the CiviCRM menu).