### PR TITLE
Add custom data UI support to MembershipType entity

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1813,6 +1813,9 @@ ORDER BY civicrm_custom_group.weight,
       case 'Membership':
         return 'civicrm_membership';
 
+      case 'MembershipType':
+        return 'civicrm_membership_type';
+
       case 'Participant':
       case 'ParticipantRole':
       case 'ParticipantEventName':

--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -223,6 +223,7 @@ class CRM_Core_SelectValues {
       'ContributionRecur' => ts('Recurring Contributions'),
       'Group' => ts('Groups'),
       'Membership' => ts('Memberships'),
+      'MembershipType' => ts('Membership Types'),
       'Event' => ts('Events'),
       'Participant' => ts('Participants'),
       'ParticipantRole' => ts('Participants (Role)'),

--- a/templates/CRM/Member/Form/MembershipType.tpl
+++ b/templates/CRM/Member/Form/MembershipType.tpl
@@ -150,6 +150,19 @@
       </div>
     </fieldset>
 
+    <div id="customData"></div>
+    {*include custom data js file*}
+    {include file="CRM/common/customData.tpl"}
+  {literal}
+    <script type="text/javascript">
+      CRM.$(function($) {
+        {/literal}
+        CRM.buildCustomData( '{$customDataType}' );
+        {literal}
+      });
+    </script>
+  {/literal}
+
     <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
   {/if}
     <div class="spacer"></div>


### PR DESCRIPTION
Overview
----------------------------------------
This PR adds custom data support to the MembershipType entity in the UI.

Before
----------------------------------------
Not displayed in edit Membership Type, not displayed as entity type in "Add custom fields"

After
----------------------------------------
Displayed in edit Membership Type:
![localhost_8000_civicrm_admin_member_membershiptype_reset 1](https://user-images.githubusercontent.com/2052161/37363448-e3f237b0-26ef-11e8-8a0a-9dd6e8f122b3.png)

Displayed in Add custom fields:
![localhost_8000_civicrm_admin_custom_group_action add reset 1](https://user-images.githubusercontent.com/2052161/37363504-08a5397c-26f0-11e8-8ee6-0a19b058ae1b.png)


Technical Details
----------------------------------------
Adds support via the option group cg_extend_objects and adds necessary boilerplate code to MembershipType UI elements.
