### PR TITLE
dev/financial/5 If a currency has been disabled allow the form to be submitted

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -1804,6 +1804,10 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     $setDefaultCurrency = TRUE
   ) {
     $currencies = CRM_Core_OptionGroup::values('currencies_enabled');
+    if (!array_key_exists($defaultCurrency, $currencies)) {
+      Civi::log()->warning('addCurrency: Currency ' . $defaultCurrency . ' is disabled but still in use!');
+      $currencies[$defaultCurrency] = $defaultCurrency;
+    }
     $options = array('class' => 'crm-select2 eight');
     if (!$required) {
       $currencies = array('' => '') + $currencies;


### PR DESCRIPTION
See https://lab.civicrm.org/dev/financial/issues/5

Overview
----------------------------------------
If you have contributions / recurring contributions in a specific currency and subsequently disable that currency in CiviCRM settings it is no longer possible to submit forms with an "amount" element that add the currency as a frozen value (eg. recurring contribution updateSubscription).

Before
----------------------------------------
Cannot submit form.

After
----------------------------------------
Form can be submitted, record can be updated.  A warning is written to the log warning that the currency is disabled but still in use.