### PR TITLE
CRM-21838 strip html tags from alerts when crm-notification-container div is not present

### DIFF
--- a/js/Common.js
+++ b/js/Common.js
@@ -1260,7 +1260,8 @@ if (!CRM.vars) CRM.vars = {};
       if (title.length) {
         text = title + "\n" + text;
       }
-      alert(text);
+      // strip html tags as they are not parsed in standard alerts
+      alert($("<div/>").html(text).text());
       return null;
     }
   };


### PR DESCRIPTION
Strips html from CRM.alert when falling back to alert()

Overview
----------------------------------------
In certain contexts CRM.alert() falls back to using the standard JS alert() which does not parse HTML. So if there is any HTML in the text passed to CRM.alert() this change strips it out.

Before
----------------------------------------
Sometimes in a customised context the alert will show as a standard alert but with html in an the html tags will display as literals

After
----------------------------------------
It renders as plan text

Technical Details
----------------------------------------
When crm-notification-container div is not present it falls back to standard html. This PR alters the html in the part of the code that applies during fallback to strip html tags. Fallback occurs on a drupal page (in this example)

Comments
----------------------------------------
_Anything else you would like the reviewer to note_

---

 * [CRM-21838: When CRM.alert falls back to standard JS alert it should strip html](https://issues.civicrm.org/jira/browse/CRM-21838)