### PR TITLE
Update test to NOT accept a failure in the api call.

### DIFF
--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -263,48 +263,44 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
     $mut->clearMessages();
     $form = new CRM_Contribute_Form_Contribution();
     $form->_mode = 'Live';
-    $error = FALSE;
-    try {
-      $form->testSubmit(array(
-        'total_amount' => 50,
-        'financial_type_id' => 1,
-        'contact_id' => $this->_individualId,
-        'contribution_status_id' => 1,
-        'credit_card_number' => 4444333322221111,
-        'cvv2' => 123,
-        'credit_card_exp_date' => array(
-          'M' => 9,
-          'Y' => 2025,
-        ),
-        'credit_card_type' => 'Visa',
-        'billing_first_name' => 'Junko',
-        'billing_middle_name' => '',
-        'billing_last_name' => 'Adams',
-        'billing_street_address-5' => '790L Lincoln St S',
-        'billing_city-5' => 'Maryknoll',
-        'billing_state_province_id-5' => 1031,
-        'billing_postal_code-5' => 10545,
-        'billing_country_id-5' => 1228,
-        'frequency_interval' => 1,
-        'frequency_unit' => 'month',
-        'installments' => '',
-        'hidden_AdditionalDetail' => 1,
-        'hidden_Premium' => 1,
-        'from_email_address' => '"civi45" <civi45@civicrm.com>',
-        'is_email_receipt' => TRUE,
-        'receipt_date' => '',
-        'receipt_date_time' => '',
-        'payment_processor_id' => $this->paymentProcessorID,
-        'currency' => 'USD',
-        'source' => 'bob sled race',
-      ), CRM_Core_Action::ADD);
-    }
-    catch (Civi\Payment\Exception\PaymentProcessorException $e) {
-      $error = TRUE;
-    }
+
+    $form->testSubmit(array(
+      'total_amount' => 50,
+      'financial_type_id' => 1,
+      'contact_id' => $this->_individualId,
+      'contribution_status_id' => 1,
+      'credit_card_number' => 4444333322221111,
+      'cvv2' => 123,
+      'credit_card_exp_date' => array(
+        'M' => 9,
+        'Y' => 2025,
+      ),
+      'credit_card_type' => 'Visa',
+      'billing_first_name' => 'Junko',
+      'billing_middle_name' => '',
+      'billing_last_name' => 'Adams',
+      'billing_street_address-5' => '790L Lincoln St S',
+      'billing_city-5' => 'Maryknoll',
+      'billing_state_province_id-5' => 1031,
+      'billing_postal_code-5' => 10545,
+      'billing_country_id-5' => 1228,
+      'frequency_interval' => 1,
+      'frequency_unit' => 'month',
+      'installments' => '',
+      'hidden_AdditionalDetail' => 1,
+      'hidden_Premium' => 1,
+      'from_email_address' => '"civi45" <civi45@civicrm.com>',
+      'is_email_receipt' => TRUE,
+      'receipt_date' => '',
+      'receipt_date_time' => '',
+      'payment_processor_id' => $this->paymentProcessorID,
+      'currency' => 'USD',
+      'source' => 'bob sled race',
+    ), CRM_Core_Action::ADD);
+
     $this->callAPISuccessGetCount('Contribution', array(
       'contact_id' => $this->_individualId,
-      'contribution_status_id' => $error ? 'Failed' : 'Completed',
+      'contribution_status_id' => 'Completed',
       'payment_instrument_id' => $this->callAPISuccessGetValue('PaymentProcessor', array(
         'return' => 'payment_instrument_id',
         'id' => $this->paymentProcessorID,


### PR DESCRIPTION
Overview
----------------------------------------
_A brief description of the pull request. Try to keep it non-technical._

Before
----------------------------------------
Test passes

After
----------------------------------------
Test passes

Technical Details
----------------------------------------
I believe the failure handling exists because this was copied from a test that
uses a real payment gateway's sandbox account, hence intermittant failure.

However, we don't need that for the Dummy processor & it's making debugging hard

Comments
----------------------------------------
@samuelsov I believe merging this will make it possible to make sense of test fail on #10377