### PR TITLE
CRM-21667: Fix for timezone handoff from Drupal6 should take DST into account.

### DIFF
--- a/CRM/Utils/System/Drupal6.php
+++ b/CRM/Utils/System/Drupal6.php
@@ -763,7 +763,7 @@ class CRM_Utils_System_Drupal6 extends CRM_Utils_System_DrupalBase {
     // to the doc for the overridden method, ought to be returned as a region string
     // (e.g., America/Havana).
     if (strlen($timezone)) {
-      $timezone = timezone_name_from_abbr("", (int) $timezone, 0);
+      $timezone = timezone_name_from_abbr("", (int) $timezone);
     }
 
     if (!$timezone) {


### PR DESCRIPTION
Overview
----------------------------------------
See #11534. Fix did not take daylight savings time into account.

Before
----------------------------------------
When daylight savings time took effect, my site in America/NewYork reported it was in America/Halifax, resulting in a timezone mismatch notice. (Prior to DST, it reported its timezone correctly.)

After
----------------------------------------
Site correctly reports it is in America/NewYork.

Technical Details
----------------------------------------
See documentation of [`timezone_name_from_abbr()`](http://php.net/manual/en/function.timezone-name-from-abbr.php). The value of the `isdst` parameter defaults to -1, which means that whether the time zone has daylight saving or not is not taken into consideration when searching. In other words, the search is more inclusive.

---

 * [CRM-21667: Bad timezone hand-off from CMS to CRM](https://issues.civicrm.org/jira/browse/CRM-21667)