### PR TITLE
Add test for api money, fix net_amount calc

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -122,7 +122,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
 
     //if priceset is used, no need to cleanup money
     if (!empty($params['skipCleanMoney'])) {
-      unset($moneyFields[0]);
+      $moneyFields = [];
     }
     else {
       // @todo put a deprecated here - this should be done in the form layer.

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -47,6 +47,13 @@ function civicrm_api3_contribution_create(&$params) {
   $params = array_merge($params, $values);
   // The BAO should not clean money - it should be done in the form layer & api wrapper
   // (although arguably the api should expect pre-cleaned it seems to do some cleaning.)
+  if (empty($params['skipCleanMoney'])) {
+    foreach (['total_amount', 'net_amount', 'fee_amount'] as $field) {
+      if (isset($params[$field])) {
+        $params[$field] = CRM_Utils_Rule::cleanMoney($params[$field]);
+      }
+    }
+  }
   $params['skipCleanMoney'] = TRUE;
 
   if (CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus()) {

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -682,15 +682,26 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
 
   /**
    * Create test with unique field name on source.
+   *
+   * @param string $thousandSeparator
+   *   punctuation used to refer to thousands.
+   *
+   * @dataProvider getThousandSeparators
    */
-  public function testCreateDefaultNow() {
-
+  public function testCreateDefaultNow($thousandSeparator) {
+    $this->setCurrencySeparators($thousandSeparator);
     $params = $this->_params;
-    unset($params['receive_date']);
+    unset($params['receive_date'], $params['net_amount']);
+
+    $params['total_amount'] = $this->formatMoneyInput(5000.77);
+    $params['fee_amount'] = $this->formatMoneyInput(.77);
 
     $contribution = $this->callAPISuccess('contribution', 'create', $params);
     $contribution = $this->callAPISuccessGetSingle('contribution', array('id' => $contribution['id']));
     $this->assertEquals(date('Y-m-d'), date('Y-m-d', strtotime($contribution['receive_date'])));
+    $this->assertEquals(5000.77, $contribution['total_amount'], 'failed to handle ' . $this->formatMoneyInput(5000.77));
+    $this->assertEquals(.77, $contribution['fee_amount']);
+    $this->assertEquals(5000, $contribution['net_amount']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Go back to cleaning api money input -in the api layer
 
Before
----------------------------------------
money values 5.000,77 & 5,000.77 not handled & they are converted to '5' by mysql insert.

After
----------------------------------------
These values are handled. However, risk is added that double cleaning could mess them up.

Technical Details
----------------------------------------
This is problematic because if values are cleaned (converted to 5000.77) twice then they will be incorrect. The code that used to do a reasonable 'guess' at whether it was already cleaned stopped working once we messed with precision (a few point releases ago).

The fix is that all parameters should be cleaned as close to input as possible. When I last analysed the api I thought it was only accepting clean values but I now think I was wrong. This puts us back to the api doing cleaning, but at risk that it could double clean if skipCleanMoney not used. I can't quite figure out how to find the light at the end of this now because by putting this back we put back the potential for on ongoing whack-a-mole, but not sure we can justify NOT putting it back by default. 

One BIG thing that has happened since this whole issue originally blew up is the addition of a LOT of unit tests - grep for     $this->setCurrencySeparators($thousandSeparator); - so that might give some confidence (maybe) the form layer is not cleaning the values & then passing to the api which re-cleans / breaks them

Comments
----------------------------------------