### PR TITLE
CRM-21777 - add ts to the message string

### DIFF
--- a/CRM/Admin/Form/Setting.php
+++ b/CRM/Admin/Form/Setting.php
@@ -153,7 +153,7 @@ class CRM_Admin_Form_Setting extends CRM_Core_Form {
       }
     }
     if (!empty($setStatus)) {
-      CRM_Core_Session::setStatus("Some fields are loaded as 'readonly' as they have been set (overridden) in civicrm.settings.php.", '', 'info', array('expires' => 0));
+      CRM_Core_Session::setStatus(ts("Some fields are loaded as 'readonly' as they have been set (overridden) in civicrm.settings.php."), '', 'info', array('expires' => 0));
     }
     // setting_description should be deprecated - see Mail.tpl for metadata based tpl.
     $this->assign('setting_descriptions', $descriptions);


### PR DESCRIPTION
Overview
----------------------------------------
follow up PR for https://github.com/civicrm/civicrm-core/pull/11680

Before
----------------------------------------
no ts() for the message string.

After
----------------------------------------
ts() added.

---

 * [CRM-21777: Improve the messaging related to Directories and Resources](https://issues.civicrm.org/jira/browse/CRM-21777)