### PR TITLE
Mail#1 - Add pause/resume functionality to civicrm bulk mailing

### DIFF
--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -837,6 +837,49 @@ AND    status IN ( 'Scheduled', 'Running', 'Paused' )
   }
 
   /**
+   * Pause a mailing
+   */
+  public static function pause($mailingID) {
+    $sql = "
+      UPDATE civicrm_mailing_job
+      SET status = 'Paused'
+      WHERE mailing_id = %1
+      AND is_test = 0
+      AND status IN ('Scheduled', 'Running')
+    ";
+    CRM_Core_DAO::executeQuery($sql, array(1 => array($mailingID, 'Integer')));
+
+    CRM_Core_Session::setStatus(ts('The mailing has been paused.'), ts('Paused'), 'success');
+  }
+
+  /**
+   * Resume a mailing
+   */
+  public static function resume($mailingID) {
+    $sql = "
+      UPDATE civicrm_mailing_job
+      SET status = 'Scheduled'
+      WHERE mailing_id = %1
+      AND is_test = 0
+      AND start_date IS NULL
+      AND status = 'Paused'
+    ";
+    CRM_Core_DAO::executeQuery($sql, array(1 => array($mailingID, 'Integer')));
+
+    $sql = "
+      UPDATE civicrm_mailing_job
+      SET status = 'Running'
+      WHERE mailing_id = %1
+      AND is_test = 0
+      AND start_date IS NOT NULL
+      AND status = 'Paused'
+    ";
+    CRM_Core_DAO::executeQuery($sql, array(1 => array($mailingID, 'Integer')));
+
+    CRM_Core_Session::setStatus(ts('The mailing has been resumed.'), ts('Resumed'), 'success');
+  }
+
+  /**
    * Return a translated status enum string.
    *
    * @param string $status

--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -831,13 +831,14 @@ AND    status IN ( 'Scheduled', 'Running', 'Paused' )
         2 => array(date('YmdHis'), 'Timestamp'),
       );
       CRM_Core_DAO::executeQuery($sql, $params);
-
-      CRM_Core_Session::setStatus(ts('The mailing has been canceled.'), ts('Canceled'), 'success');
     }
   }
 
   /**
    * Pause a mailing
+   *
+   * @param int $mailingID
+   *   The id of the mailing to be paused.
    */
   public static function pause($mailingID) {
     $sql = "
@@ -848,12 +849,13 @@ AND    status IN ( 'Scheduled', 'Running', 'Paused' )
       AND status IN ('Scheduled', 'Running')
     ";
     CRM_Core_DAO::executeQuery($sql, array(1 => array($mailingID, 'Integer')));
-
-    CRM_Core_Session::setStatus(ts('The mailing has been paused.'), ts('Paused'), 'success');
   }
 
   /**
    * Resume a mailing
+   *
+   * @param int $mailingID
+   *   The id of the mailing to be resumed.
    */
   public static function resume($mailingID) {
     $sql = "
@@ -875,8 +877,6 @@ AND    status IN ( 'Scheduled', 'Running', 'Paused' )
       AND status = 'Paused'
     ";
     CRM_Core_DAO::executeQuery($sql, array(1 => array($mailingID, 'Integer')));
-
-    CRM_Core_Session::setStatus(ts('The mailing has been resumed.'), ts('Resumed'), 'success');
   }
 
   /**

--- a/CRM/Mailing/Form/Browse.php
+++ b/CRM/Mailing/Form/Browse.php
@@ -82,6 +82,7 @@ class CRM_Mailing_Form_Browse extends CRM_Core_Form {
     }
     elseif ($this->_action & CRM_Core_Action::DISABLE) {
       CRM_Mailing_BAO_MailingJob::cancel($this->_mailingId);
+      CRM_Core_Session::setStatus(ts('The mailing has been canceled.'), ts('Canceled'), 'success');
     }
     elseif ($this->_action & CRM_Core_Action::RENEW) {
       //set is_archived to 1

--- a/CRM/Mailing/Form/Search.php
+++ b/CRM/Mailing/Form/Search.php
@@ -92,7 +92,7 @@ class CRM_Mailing_Form_Search extends CRM_Core_Form {
       $defaults['status_unscheduled'] = 1;
     }
     if ($parent->get('scheduled')) {
-      $statusVals = array('Scheduled', 'Complete', 'Running', 'Canceled');
+      $statusVals = array('Scheduled', 'Complete', 'Running', 'Paused', 'Canceled');
       $defaults['is_archived'] = 0;
     }
     if ($parent->get('archived')) {

--- a/CRM/Mailing/Form/Search.php
+++ b/CRM/Mailing/Form/Search.php
@@ -92,7 +92,7 @@ class CRM_Mailing_Form_Search extends CRM_Core_Form {
       $defaults['status_unscheduled'] = 1;
     }
     if ($parent->get('scheduled')) {
-      $statusVals = array('Scheduled', 'Complete', 'Running', 'Paused', 'Canceled');
+      $statusVals = array_keys(CRM_Core_SelectValues::getMailingJobStatus());
       $defaults['is_archived'] = 0;
     }
     if ($parent->get('archived')) {

--- a/CRM/Mailing/Page/Browse.php
+++ b/CRM/Mailing/Page/Browse.php
@@ -165,6 +165,7 @@ class CRM_Mailing_Page_Browse extends CRM_Core_Page {
     if ($this->_action & CRM_Core_Action::DISABLE) {
       if (CRM_Utils_Request::retrieve('confirmed', 'Boolean', $this)) {
         CRM_Mailing_BAO_MailingJob::cancel($this->_mailingId);
+        CRM_Core_Session::setStatus(ts('The mailing has been canceled.'), ts('Canceled'), 'success');
         CRM_Utils_System::redirect($context);
       }
       else {
@@ -181,6 +182,7 @@ class CRM_Mailing_Page_Browse extends CRM_Core_Page {
         CRM_Core_Error::fatal(ts('You do not have permission to access this page.'));
       }
       CRM_Mailing_BAO_MailingJob::pause($this->_mailingId);
+      CRM_Core_Session::setStatus(ts('The mailing has been paused.'), ts('Paused'), 'success');
       CRM_Utils_System::redirect($context);
     }
     elseif ($this->_action & CRM_Core_Action::REOPEN) {
@@ -188,6 +190,7 @@ class CRM_Mailing_Page_Browse extends CRM_Core_Page {
         CRM_Core_Error::fatal(ts('You do not have permission to access this page.'));
       }
       CRM_Mailing_BAO_MailingJob::resume($this->_mailingId);
+      CRM_Core_Session::setStatus(ts('The mailing has been resumed.'), ts('Resumed'), 'success');
       CRM_Utils_System::redirect($context);
     }
     elseif ($this->_action & CRM_Core_Action::DELETE) {

--- a/CRM/Mailing/Page/Browse.php
+++ b/CRM/Mailing/Page/Browse.php
@@ -176,6 +176,20 @@ class CRM_Mailing_Page_Browse extends CRM_Core_Page {
         $controller->run();
       }
     }
+    elseif ($this->_action & CRM_Core_Action::CLOSE) {
+      if (!CRM_Core_Permission::checkActionPermission('CiviMail', CRM_Core_Action::CLOSE)) {
+        CRM_Core_Error::fatal(ts('You do not have permission to access this page.'));
+      }
+      CRM_Mailing_BAO_MailingJob::pause($this->_mailingId);
+      CRM_Utils_System::redirect($context);
+    }
+    elseif ($this->_action & CRM_Core_Action::REOPEN) {
+      if (!CRM_Core_Permission::checkActionPermission('CiviMail', CRM_Core_Action::CLOSE)) {
+        CRM_Core_Error::fatal(ts('You do not have permission to access this page.'));
+      }
+      CRM_Mailing_BAO_MailingJob::resume($this->_mailingId);
+      CRM_Utils_System::redirect($context);
+    }
     elseif ($this->_action & CRM_Core_Action::DELETE) {
       if (CRM_Utils_Request::retrieve('confirmed', 'Boolean', $this)) {
 

--- a/CRM/Mailing/Selector/Browse.php
+++ b/CRM/Mailing/Selector/Browse.php
@@ -294,6 +294,18 @@ LEFT JOIN  civicrm_contact scheduledContact ON ( $mailing.scheduled_id = schedul
           'extra' => 'onclick="if (confirm(\'' . $archiveExtra . '\')) this.href+=\'&amp;confirmed=1\'; else return false;"',
           'title' => ts('Archive Mailing'),
         ),
+        CRM_Core_Action::REOPEN => array(
+          'name' => ts('Resume'),
+          'url' => 'civicrm/mailing/browse',
+          'qs' => 'action=reopen&mid=%%mid%%&reset=1',
+          'title' => ts('Resume mailing'),
+        ),
+        CRM_Core_Action::CLOSE => array(
+          'name' => ts('Pause'),
+          'url' => 'civicrm/mailing/browse',
+          'qs' => 'action=close&mid=%%mid%%&reset=1',
+          'title' => ts('Pause mailing'),
+        ),
       );
     }
 
@@ -389,6 +401,12 @@ LEFT JOIN  civicrm_contact scheduledContact ON ( $mailing.scheduled_id = schedul
           ) {
 
             $actionMask |= CRM_Core_Action::DISABLE;
+            if ($row['status'] == "Paused") {
+              $actionMask |= CRM_Core_Action::REOPEN;
+            }
+            else {
+              $actionMask |= CRM_Core_Action::CLOSE;
+            }
           }
           if ($row['status'] == 'Scheduled' &&
             empty($row['approval_status_id'])
@@ -550,7 +568,7 @@ LEFT JOIN  civicrm_contact scheduledContact ON ( $mailing.scheduled_id = schedul
     if (!$isFormSubmitted && $this->_parent->get('scheduled')) {
       // mimic default behavior for scheduled screen
       $isArchived = 0;
-      $mailingStatus = array('Scheduled' => 1, 'Complete' => 1, 'Running' => 1, 'Canceled' => 1);
+      $mailingStatus = array('Scheduled' => 1, 'Complete' => 1, 'Running' => 1, 'Paused' => 1, 'Canceled' => 1);
     }
     if (!$isFormSubmitted && $this->_parent->get('archived')) {
       // mimic default behavior for archived screen

--- a/tests/phpunit/api/v3/JobProcessMailingTest.php
+++ b/tests/phpunit/api/v3/JobProcessMailingTest.php
@@ -116,17 +116,21 @@ class api_v3_JobProcessMailingTest extends CiviUnitTestCase {
     Civi::settings()->add(array(
       'mailerBatchLimit' => 2,
     ));
+    $this->_mut->clearMessages();
     //Create a test mailing and check if the status is set to Scheduled.
     $result = $this->callAPISuccess('mailing', 'create', $this->_params);
     $jobs = $this->callAPISuccess('mailing_job', 'get', array('mailing_id' => $result['id']));
     $this->assertEquals('Scheduled', $jobs['values'][$jobs['id']]['status']);
 
+    //Pause the mailing.
     CRM_Mailing_BAO_MailingJob::pause($result['id']);
     $jobs = $this->callAPISuccess('mailing_job', 'get', array('mailing_id' => $result['id']));
     $this->assertEquals('Paused', $jobs['values'][$jobs['id']]['status']);
 
     //Verify if Paused mailing isn't considered in process_mailing job.
     $this->callAPISuccess('job', 'process_mailing', array());
+    //Check if mail log is empty.
+    $this->_mut->assertMailLogEmpty();
     $jobs = $this->callAPISuccess('mailing_job', 'get', array('mailing_id' => $result['id']));
     $this->assertEquals('Paused', $jobs['values'][$jobs['id']]['status']);
 
@@ -134,6 +138,10 @@ class api_v3_JobProcessMailingTest extends CiviUnitTestCase {
     CRM_Mailing_BAO_MailingJob::resume($result['id']);
     $jobs = $this->callAPISuccess('mailing_job', 'get', array('mailing_id' => $result['id']));
     $this->assertEquals('Scheduled', $jobs['values'][$jobs['id']]['status']);
+
+    //Execute the job and it should send the mailing to the recipients now.
+    $this->callAPISuccess('job', 'process_mailing', array());
+    $this->_mut->assertRecipients($this->getRecipients(1, 2));
   }
 
   /**

--- a/tests/phpunit/api/v3/JobProcessMailingTest.php
+++ b/tests/phpunit/api/v3/JobProcessMailingTest.php
@@ -109,6 +109,34 @@ class api_v3_JobProcessMailingTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test pause and resume on Mailing.
+   */
+  public function testPauseAndResumeMailing() {
+    $this->createContactsInGroup(10, $this->_groupID);
+    Civi::settings()->add(array(
+      'mailerBatchLimit' => 2,
+    ));
+    //Create a test mailing and check if the status is set to Scheduled.
+    $result = $this->callAPISuccess('mailing', 'create', $this->_params);
+    $jobs = $this->callAPISuccess('mailing_job', 'get', array('mailing_id' => $result['id']));
+    $this->assertEquals('Scheduled', $jobs['values'][$jobs['id']]['status']);
+
+    CRM_Mailing_BAO_MailingJob::pause($result['id']);
+    $jobs = $this->callAPISuccess('mailing_job', 'get', array('mailing_id' => $result['id']));
+    $this->assertEquals('Paused', $jobs['values'][$jobs['id']]['status']);
+
+    //Verify if Paused mailing isn't considered in process_mailing job.
+    $this->callAPISuccess('job', 'process_mailing', array());
+    $jobs = $this->callAPISuccess('mailing_job', 'get', array('mailing_id' => $result['id']));
+    $this->assertEquals('Paused', $jobs['values'][$jobs['id']]['status']);
+
+    //Resume should set the status back to Scheduled.
+    CRM_Mailing_BAO_MailingJob::resume($result['id']);
+    $jobs = $this->callAPISuccess('mailing_job', 'get', array('mailing_id' => $result['id']));
+    $this->assertEquals('Scheduled', $jobs['values'][$jobs['id']]['status']);
+  }
+
+  /**
    * Test mail when in non-production environment.
    *
    */


### PR DESCRIPTION
Overview
----------------------------------------
Provide pause/resume functionality to CiviCRM bulk mailing

Before
----------------------------------------
Scenario -

Site admin is sending out a big blast but want to send out a press release without waiting for first job to end.

Mailing is created and Scheduled. There is no way to pause this mailing for a while and do some other stuff.

After
----------------------------------------
User can now pause a specific mailing and resume when it is required.

Pause a mailing using the `Pause` action from the more link.

![image](https://user-images.githubusercontent.com/5929648/37399815-ea448cee-27a8-11e8-962d-488c97c9a555.png)

Resume a paused mailing via

![image](https://user-images.githubusercontent.com/5929648/37399856-0217b29c-27a9-11e8-915a-5bb089d1e809.png)


Comments
----------------------------------------
Added unit test.


----------------------------------------
Issue created - https://lab.civicrm.org/dev/mail/issues/1