### PR TITLE
Core#15 - Wrong parameter passing in LineItem.php

### DIFF
--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -454,9 +454,14 @@ WHERE li.contribution_id = %1";
           }
           // CRM-19094: entity_table is set to civicrm_membership then ensure
           // the entityId is set to membership ID not contribution by default
-          elseif ($line['entity_table'] == 'civicrm_membership' && !empty($line['entity_id']) && $line['entity_id'] == $contributionDetails->id) {
-            $membershipId = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipPayment', 'contribution_id', $line['entity_id'], 'membership_id');
-            $line['entity_id'] = $membershipId ? $membershipId : $line['entity_id'];
+          // we don't update entity table and entity id during update mode, so
+          // no need to worry about the value of $line['entity_id'] while updating.
+          elseif (!$update && $line['entity_table'] == 'civicrm_membership' && !empty($line['entity_id']) && $line['entity_id'] == $contributionDetails->id) {
+            $membershipId = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipPayment', $contributionDetails->id, 'membership_id', 'contribution_id');
+            if (!empty($membershipId) && $line['entity_id'] != $membershipId) {
+              Civi::log()->warning('Per https://lab.civicrm.org/dev/core/issues/15 this data fix should not be required. Please log a ticket at https://lab.civicrm.org/dev/core with steps to get this.', array('civi.tag' => 'deprecated'));
+              $line['entity_id'] = $membershipId;
+            }
           }
         }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix function parameters fed to getFieldValue() function.

Before
----------------------------------------
Wrong parameter supplied in https://github.com/civicrm/civicrm-core/blob/master/CRM/Price/BAO/LineItem.php#L458-

After
----------------------------------------
Corrected getFieldValue() function parameters

Technical Details
----------------------------------------
I've not replicated the issue CRM-19094 as it doesn't seem straight-forward to recreate on a local instance, just created a PR as it looked incorrect. Looking at the history, it looks like this code was added in https://github.com/civicrm/civicrm-core/pull/8717 and a recent comment on the [JIRA issue](https://issues.civicrm.org/jira/browse/CRM-19094?focusedCommentId=93215&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-93215) seems like the reporter wasn't finding it to behave correctly in the fixed version.

`contribution_id` is a search_column which should be passed as a 4th parameter to the function instead of 2nd.  ping @monishdeb 

----------------------------------------

Issue raised here - https://lab.civicrm.org/dev/core/issues/15