### PR TITLE
"hold_date" not updated if civimail_multiple_bulk_emails is true + test

### DIFF
--- a/CRM/Core/BAO/Email.php
+++ b/CRM/Core/BAO/Email.php
@@ -237,7 +237,9 @@ ORDER BY e.is_primary DESC, email_id ASC ";
    *   Email object.
    */
   public static function holdEmail(&$email) {
-    $email->on_hold = intval($email->on_hold);
+    if (!($email->on_hold === 'null' || $email->on_hold === NULL)) {
+      $email->on_hold = intval($email->on_hold);
+    }
     //check for update mode
     if ($email->id) {
       $params = array(1 => array($email->id, 'Integer'));

--- a/CRM/Core/BAO/Email.php
+++ b/CRM/Core/BAO/Email.php
@@ -237,6 +237,7 @@ ORDER BY e.is_primary DESC, email_id ASC ";
    *   Email object.
    */
   public static function holdEmail(&$email) {
+    $email->on_hold = intval($email->on_hold);
     //check for update mode
     if ($email->id) {
       $params = array(1 => array($email->id, 'Integer'));

--- a/tests/phpunit/api/v3/EmailTest.php
+++ b/tests/phpunit/api/v3/EmailTest.php
@@ -376,4 +376,38 @@ class api_v3_EmailTest extends CiviUnitTestCase {
     $this->assertEquals('1-2@example.com', $get['values'][$emailID]['email']);
   }
 
+  public function testEmailOnHold() {
+    $params = array();
+    $params_change = array();
+    $params = array(
+      'contact_id' => $this->_contactID,
+      'email' => 'api@a-team.com',
+      'on_hold' => '2',
+    );
+    $result = $this->callAPIAndDocument('email', 'create', $params, __FUNCTION__, __FILE__);
+    $this->assertEquals(1, $result['count']);
+    $this->assertNotNull($result['id']);
+    $this->assertNotNull($result['values'][$result['id']]['id']);
+    $this->assertEquals(2, $result['values'][$result['id']]['on_hold']);
+    $this->assertEquals(date('Y-m-d H:i'), date('Y-m-d H:i', strtotime($result['values'][$result['id']]['hold_date'])));
+
+    // set on_hold is '0'
+    // if isMultipleBulkMail is active, the value in On-hold select is string
+    $params_change = array(
+      'id' => $result['id'],
+      'contact_id' => $this->_contactID,
+      'email' => 'api@a-team.com',
+      'is_primary' => 1,
+      'on_hold' => '0',
+    );
+    $result_change = $this->callAPISuccess('email', 'create', $params_change + array('action' => 'get'));
+    $this->assertEquals(1, $result_change['count']);
+    $this->assertEquals($result['id'], $result_change['id']);
+    $this->assertEmpty($result_change['values'][$result_change['id']]['on_hold']);
+    $this->assertEquals(date('Y-m-d H:i'), date('Y-m-d H:i', strtotime($result_change['values'][$result_change['id']]['reset_date'])));
+    $this->assertEmpty($result_change['values'][$result_change['id']]['hold_date']);
+
+    $delresult = $this->callAPISuccess('email', 'delete', array('id' => $result['id']));
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
"hold_date" not updated correctly, please see https://lab.civicrm.org/dev/core/issues/16

Before
----------------------------------------
"hold_date" not updated if civimail_multiple_bulk_emails is true

After
----------------------------------------
"hold_date" will be updated on request

Technical Details
----------------------------------------
the string '0' is not 'null', convert the string value into integer + untitest 
