### PR TITLE
dev/core/17 Convert interview task to use Pseudoconstants

### DIFF
--- a/CRM/Campaign/Form/Task/Interview.php
+++ b/CRM/Campaign/Form/Task/Interview.php
@@ -100,10 +100,11 @@ class CRM_Campaign_Form_Task_Interview extends CRM_Campaign_Form_Task {
 
     $orderClause = FALSE;
     $buttonName = $this->controller->getButtonName();
+    $walkListActivityId = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'WalkList');
     if ($buttonName == '_qf_Interview_submit_orderBy' && !empty($_POST['order_bys'])) {
       $orderByParams = CRM_Utils_Array::value('order_bys', $_POST);
     }
-    elseif (CRM_Core_OptionGroup::getValue('activity_type', 'WalkList') == $this->_surveyDetails['activity_type_id']) {
+    elseif ($walkListActivityId == $this->_surveyDetails['activity_type_id']) {
       $orderByParams
         = array(
           1 => array(
@@ -170,8 +171,7 @@ WHERE {$clause}
       $this->_contactIds,
       $this->_interviewerId
     );
-    $activityStatus = CRM_Core_PseudoConstant::activityStatus('name');
-    $scheduledStatusId = array_search('Scheduled', $activityStatus);
+    $scheduledStatusId = CRM_Core_PseudoConstant::getKey('CRM_Activity_DAO_Activity', 'activity_status_id', 'Scheduled');
 
     $activityIds = array();
     foreach ($this->_contactIds as $key => $voterId) {
@@ -248,9 +248,9 @@ WHERE {$clause}
     }
 
     //set the title.
-    $activityTypes = CRM_Core_PseudoConstant::activityType(FALSE, TRUE, FALSE, 'label', TRUE);
     $this->_surveyTypeId = CRM_Utils_Array::value('activity_type_id', $this->_surveyValues);
-    CRM_Utils_System::setTitle(ts('Record %1 Responses', array(1 => $activityTypes[$this->_surveyTypeId])));
+    $surveyTypeLabel = CRM_Core_PseudoConstant::getLabel('CRM_Activity_BAO_Activity', 'activity_type_id', $this->_surveyTypeId);
+    CRM_Utils_System::setTitle(ts('Record %1 Responses', array(1 => $surveyTypeLabel)));
   }
 
   public function validateIds() {
@@ -387,7 +387,7 @@ WHERE {$clause}
     foreach ($this->_surveyFields as $name => $field) {
       $acceptable_types = CRM_Contact_BAO_ContactType::basicTypes();
       $acceptable_types[] = 'Contact';
-      if (in_array($field['field_type'], $acceptable_types)) {
+      if (isset($field['field_type']) && (in_array($field['field_type'], $acceptable_types))) {
         $contactFields[$name] = $field;
       }
     }
@@ -397,7 +397,8 @@ WHERE {$clause}
       }
     }
 
-    if (CRM_Core_OptionGroup::getValue('activity_type', 'WalkList') == $this->_surveyDetails['activity_type_id']) {
+    $walkListActivityId = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'WalkList');
+    if ($walkListActivityId == $this->_surveyDetails['activity_type_id']) {
       $defaults['order_bys']
         = array(
           1 => array(
@@ -480,7 +481,7 @@ WHERE {$clause}
 
     static $statusId;
     if (!$statusId) {
-      $statusId = array_search('Completed', CRM_Core_PseudoConstant::activityStatus('name'));
+      $statusId = CRM_Core_PseudoConstant::getKey('CRM_Activity_DAO_Activity', 'activity_status_id', 'Completed');
     }
 
     //format custom fields.
@@ -580,11 +581,7 @@ WHERE {$clause}
     $this->_contactIds = $this->get('contactIds');
     if (!is_array($this->_contactIds)) {
       //get the survey activities.
-      $activityStatus = CRM_Core_PseudoConstant::activityStatus('name');
-      $statusIds = array();
-      if ($statusId = array_search('Scheduled', $activityStatus)) {
-        $statusIds[] = $statusId;
-      }
+      $statusIds[] = CRM_Core_PseudoConstant::getKey('CRM_Activity_DAO_Activity', 'activity_status_id', 'Scheduled');
       $surveyActivities = CRM_Campaign_BAO_Survey::getSurveyVoterInfo($this->_surveyId,
         $this->_interviewerId,
         $statusIds

--- a/CRM/Core/OptionGroup.php
+++ b/CRM/Core/OptionGroup.php
@@ -342,7 +342,7 @@ WHERE  v.option_group_id = g.id
    * @return null
    */
   public static function getLabel($groupName, $value, $onlyActiveValue = TRUE) {
-    Civi::log()->warning('Deprecated function, use CRM_Core_PseudoConstant::getLabel', array('civi.tag' => 'deprecated'));
+    Civi::log()->warning('Deprecated function CRM_Core_OptionGroup::getLabel, use CRM_Core_PseudoConstant::getLabel', array('civi.tag' => 'deprecated'));
     if (empty($groupName) ||
       empty($value)
     ) {
@@ -396,7 +396,7 @@ WHERE  v.option_group_id = g.id
       return NULL;
     }
 
-    Civi::log()->warning('Deprecated function, use CRM_Core_PseudoConstant::getKey', array('civi.tag' => 'deprecated'));
+    Civi::log()->warning('Deprecated function CRM_Core_OptionGroup::getValue, use CRM_Core_PseudoConstant::getKey', array('civi.tag' => 'deprecated'));
 
     $query = "
 SELECT  v.label as label ,v.{$valueField} as value


### PR DESCRIPTION
Overview
----------------------------------------
Remove deprecated CRM_Core_OptionGroup and replace with CRM_Core_PseudoConstant.  Fix PHP notices.

Ref https://lab.civicrm.org/dev/core/issues/17

@eileenmcnaughton One of your favourites?