### PR TITLE
Add pre and post hooks to the Survey entity

### DIFF
--- a/CRM/Campaign/BAO/Survey.php
+++ b/CRM/Campaign/BAO/Survey.php
@@ -61,15 +61,12 @@ class CRM_Campaign_BAO_Survey extends CRM_Campaign_DAO_Survey {
   }
 
   /**
-   * Takes an associative array and creates a Survey object.
-   *
-   * the function extract all the params it needs to initialize the create a
-   * survey object.
-   *
+   * Takes an associative array and creates a Survey object based on the
+   * supplied values.
    *
    * @param array $params
    *
-   * @return CRM_Survey_DAO_Survey
+   * @return bool|CRM_Campaign_DAO_Survey
    */
   public static function create(&$params) {
     if (empty($params)) {
@@ -90,11 +87,23 @@ class CRM_Campaign_BAO_Survey extends CRM_Campaign_DAO_Survey {
       if (!(CRM_Utils_Array::value('created_date', $params))) {
         $params['created_date'] = date('YmdHis');
       }
+
+      CRM_Utils_Hook::pre('create', 'Survey', NULL, $params);
+    }
+    else {
+      CRM_Utils_Hook::pre('edit', 'Survey', $params['id'], $params);
     }
 
     $dao = new CRM_Campaign_DAO_Survey();
     $dao->copyValues($params);
     $dao->save();
+
+    if (!empty($params['id'])) {
+      CRM_Utils_Hook::post('edit', 'Survey', $dao->id, $dao);
+    }
+    else {
+      CRM_Utils_Hook::post('create', 'Survey', $dao->id, $dao);
+    }
 
     if (!empty($params['custom']) &&
       is_array($params['custom'])


### PR DESCRIPTION
## Before

* When a survey is saved, neither [`hook_civicrm_pre`](https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_pre/) nor [`hook_civicrm_post`](https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_post/) are fired. 

## After

* Both hooks fire :fireworks: 

## Also

* Minor (and unrelated) improvements to the docblock of the containing function.
