### PR TITLE
Activity Form - Fix recently introduced warning

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -810,7 +810,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
 
     $this->addFormRule(array('CRM_Activity_Form_Activity', 'formRule'), $this);
 
-    $doNotNotifyAssigneeFor = Civi::settings()->get('do_not_notify_assignees_for');
+    $doNotNotifyAssigneeFor = (array) Civi::settings()->get('do_not_notify_assignees_for');
     if (($this->_activityTypeId && in_array($this->_activityTypeId, $doNotNotifyAssigneeFor)) || !Civi::settings()->get('activity_assignee_notification')) {
       $this->assign('activityAssigneeNotification', FALSE);
     }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a recently introduced (commit was mid Dec) code warning.

Before
----------------------------------------
![screenshot 2018-03-15 17 09 26](https://user-images.githubusercontent.com/336308/37444274-77a27188-2875-11e8-8d2b-8ed58942ea05.png)



After
----------------------------------------
![screenshot 2018-03-15 17 23 48](https://user-images.githubusercontent.com/336308/37444298-a2ce53a4-2875-11e8-8bab-bb9738edb59d.png)



Technical Details
----------------------------------------
We can see the value is NULL & is not being handled - casting to an array fixes

![screenshot 2018-03-15 17 20 36](https://user-images.githubusercontent.com/336308/37444266-730dd270-2875-11e8-83f8-b25055a78566.png)



Comments
----------------------------------------
This is trivial but would have been first released in Feb so would be nice to get into April release
