### PR TITLE
core/issues/15 Line item fix with attempt to determine how it is hit

### DIFF
--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -455,8 +455,11 @@ WHERE li.contribution_id = %1";
           // CRM-19094: entity_table is set to civicrm_membership then ensure
           // the entityId is set to membership ID not contribution by default
           elseif ($line['entity_table'] == 'civicrm_membership' && !empty($line['entity_id']) && $line['entity_id'] == $contributionDetails->id) {
-            $membershipId = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipPayment', 'contribution_id', $line['entity_id'], 'membership_id');
-            $line['entity_id'] = $membershipId ? $membershipId : $line['entity_id'];
+            $membershipId = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipPayment', $contributionDetails->id, 'membership_id', 'contribution_id');
+            if ($membershipId && (int) $membershipId !== (int) $line['entity_id']) {
+              $line['entity_id'] = $membershipId;
+              Civi::log()->warning('Per https://lab.civicrm.org/dev/core/issues/15 this data fix should not be required. Please log a ticket at https://lab.civicrm.org/dev/core with steps to get this.', array('civi.tag' => 'deprecated'));
+            }
           }
         }
 


### PR DESCRIPTION
Overview
----------------------------------------
ANother try on #11804 - Trying the debug effort with more nuance

Before
----------------------------------------
A fix introduced for an odd data situation in CRM-19094 was incorrect & potentially was creating line items pointing to the wrong contribution (number 1 I expect) or at best just not working if hit.

After
----------------------------------------
The CRM-19094 fix has been corrected. 

Technical Details
----------------------------------------
We added a deprecation notice & I did identify one scenario where it is hit which I expect may occur in extensions but probably not in core. Creating a contribution with a membership by creating the membership, contribution and membership_payment records results in line items in the data base that do not correctly set the membership table & id in the entity_id & entity_table fields. If extensions are doing that this handling routine may be hit.


Comments
----------------------------------------

Fixed the test to create the line items correctly. While we recommend using the order api I actually struggled to get it to work used a blunter method. I think the input params requirements are rather trickier than they need be for that api.

---

 * [CRM-19094: cid=0 membership contribution form can overwrite data of an existing membership](https://issues.civicrm.org/jira/browse/CRM-19094)