### PR TITLE
core/19 - enables exporting optionvalues who have been disabled

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -390,7 +390,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
         FALSE,
         FALSE,
         'label',
-        !($context == 'validate' || $context == 'get')
+        !($context == 'validate' || $context == 'get' || $context == 'export')
       );
     }
     elseif ($this->data_type === 'StateProvince') {
@@ -1146,7 +1146,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
    * @return string
    * @throws \Exception
    */
-  public static function displayValue($value, $field, $entityId = NULL) {
+  public static function displayValue($value, $field, $entityId = NULL, $context = NULL) {
     $field = is_array($field) ? $field['id'] : $field;
     $fieldId = is_object($field) ? $field->id : (int) str_replace('custom_', '', $field);
 
@@ -1158,7 +1158,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
       $field = self::getFieldObject($fieldId);
     }
 
-    $fieldInfo = array('options' => $field->getOptions()) + (array) $field;
+    $fieldInfo = array('options' => $field->getOptions($context = $context)) + (array) $field;
 
     return self::formatDisplayValue($value, $fieldInfo, $entityId);
   }

--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -944,7 +944,7 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
           ) {
             //check for custom data
             if ($cfID = CRM_Core_BAO_CustomField::getKeyID($field)) {
-              $row[$field] = CRM_Core_BAO_CustomField::displayValue($fieldValue, $cfID);
+              $row[$field] = CRM_Core_BAO_CustomField::displayValue($fieldValue, $cfID, NULL, 'get');
             }
 
             elseif (in_array($field, array(


### PR DESCRIPTION
this enables exporting optionvalues who have been disabled

Overview
----------------------------------------
a participant field has a custom field containing option values. Participants choose one of these option values. The option value that the participants chose gets disabled after they chose it. In a participant export containing this custom field the  participants who chose for the disabled option will have a blanc space in the table on that location. Expected is having the option they chose over there, all-tough it has been disabled, and isn't available to choose any more.

Before
----------------------------------------
disabled option values don't show up in the participant export

After
----------------------------------------
disabled optionvalues do show up in the participant export