### PR TITLE
CRM-21840: Show Options Edit Link for Radio and Checkbox Groups

### DIFF
--- a/CRM/Core/Form/Renderer.php
+++ b/CRM/Core/Form/Renderer.php
@@ -138,7 +138,10 @@ class CRM_Core_Form_Renderer extends HTML_QuickForm_Renderer_ArraySmarty {
     }
     // Active form elements
     else {
-      if ($element->getType() == 'select' && $element->getAttribute('data-option-edit-path')) {
+      $typesToShowEditLink = array('select', 'group');
+      $hasEditPath = NULL !== $element->getAttribute('data-option-edit-path');
+
+      if (in_array($element->getType(), $typesToShowEditLink) && $hasEditPath) {
         $this->addOptionsEditLink($el, $element);
       }
 

--- a/js/crm.optionEdit.js
+++ b/js/crm.optionEdit.js
@@ -5,12 +5,162 @@ jQuery(function($) {
     .on('click', 'a.crm-option-edit-link', CRM.popup)
     .on('crmPopupFormSuccess', 'a.crm-option-edit-link', function() {
       $(this).trigger('crmOptionsEdited');
-      var $elects = $('select[data-option-edit-path="' + $(this).data('option-edit-path') + '"]');
-      if ($elects.data('api-entity') && $elects.data('api-field')) {
-        CRM.api3($elects.data('api-entity'), 'getoptions', {sequential: 1, field: $elects.data('api-field')})
-          .done(function (data) {
-            CRM.utils.setOptions($elects, data.values);
-          });
+      var optionEditPath = $(this).data('option-edit-path');
+      var $selects = $('select[data-option-edit-path="' + optionEditPath + '"]');
+      var $inputs = $('input[data-option-edit-path="' + optionEditPath + '"]');
+      var $radios = $inputs.filter('[type=radio]');
+      var $checkboxes = $inputs.filter('[type=checkbox]');
+
+      if ($selects.length > 0) {
+        rebuildOptions($selects, CRM.utils.setOptions);
+      }
+      else if ($radios.length > 0) {
+        rebuildOptions($radios, rebuildRadioOptions);
+      }
+      else if ($checkboxes.length > 0) {
+        rebuildOptions($checkboxes, rebuildCheckboxOptions);
       }
     });
+
+  /**
+   * Fetches options using metadata from the existing ones and calls the
+   * function to rebuild them
+   * @param $existing {object} The existing options, used as metadata store
+   * @param rebuilder {function} Function to be called to rebuild the options
+   */
+  function rebuildOptions($existing, rebuilder) {
+    if ($existing.data('api-entity') && $existing.data('api-field')) {
+      CRM.api3($existing.data('api-entity'), 'getoptions', {
+        sequential: 1,
+        field: $existing.data('api-field')
+      })
+      .done(function(data) {
+        rebuilder($existing, data.values);
+      });
+    }
+  }
+
+  /**
+   * Rebuild checkbox input options, overwriting the existing options
+   *
+   * @param $existing {object} the existing checkbox options
+   * @param newOptions {array} in format returned by api.getoptions
+   */
+  function rebuildCheckboxOptions($existing, newOptions) {
+    var $parent = $existing.first().parent(),
+      $firstExisting = $existing.first(),
+      optionName = $firstExisting.attr('name'),
+      optionAttributes =
+        'data-option-edit-path =' + $firstExisting.data('option-edit-path') +
+        ' data-api-entity = ' + $firstExisting.data('api-entity') +
+        ' data-api-field = ' + $firstExisting.data('api-field');
+
+    var prefix = optionName.substr(0, optionName.lastIndexOf("["));
+
+    var checkedBoxes = [];
+    $parent.find('input:checked').each(function() {
+      checkedBoxes.push($(this).attr('id'));
+    });
+
+    // remove existing checkboxes
+    $parent.find('input[type=checkbox]').remove();
+
+    // find existing labels for the checkboxes
+    var $checkboxLabels = $parent.find('label').filter(function() {
+      var forAttr = $(this).attr('for') || '';
+
+      return forAttr.indexOf(prefix) !== -1;
+    });
+
+    // find what is used to separate the elements; spaces or linebreaks
+    var $elementAfterLabel = $checkboxLabels.first().next();
+    var separator = $elementAfterLabel.is('br') ? '<br/>' : '&nbsp;';
+
+    // remove existing labels
+    $checkboxLabels.remove();
+
+    // remove linebreaks in container
+    $parent.find('br').remove();
+
+    // remove separator whitespace in container
+    $parent.html(function (i, html) {
+      return html.replace(/&nbsp;/g, '');
+    });
+
+    var renderedOptions = '';
+    // replace missing br at start of element
+    if (separator === '<br/>') {
+      $parent.prepend(separator);
+      renderedOptions = separator;
+    }
+
+    newOptions.forEach(function(option) {
+      var optionId = prefix + '_' + option.key,
+        checked = '';
+
+      if ($.inArray(optionId, checkedBoxes) !== -1) {
+        checked = ' checked="checked"';
+      }
+
+      renderedOptions += '<input type="checkbox" ' +
+        ' value="1"' +
+        ' id="' + optionId + '"' +
+        ' name="' + prefix + '[' + option.key +']' + '"' +
+        checked +
+        ' class="crm-form-checkbox"' +
+        optionAttributes +
+        '><label for="' + optionId + '">' + option.value + '</label>' +
+        separator;
+    });
+
+    // remove final separator
+    renderedOptions = renderedOptions.substring(0, renderedOptions.lastIndexOf(separator));
+
+    var $editLink = $parent.find('.crm-option-edit-link');
+
+    // try to insert before the edit link to maintain structure
+    if ($editLink.length > 0) {
+      $(renderedOptions).insertBefore($editLink);
+    }
+    else {
+      $parent.append(renderedOptions);
+    }
+  }
+
+  /**
+   * Rebuild radio input options, overwriting the existing options
+   *
+   * @param $existing {object} the existing input options
+   * @param newOptions {array} in format returned by api.getoptions
+   */
+  function rebuildRadioOptions($existing, newOptions) {
+    var $parent = $existing.first().parent(),
+      $firstExisting = $existing.first(),
+      optionName = $firstExisting.attr('name'),
+      renderedOptions = '',
+      checkedValue = parseInt($parent.find('input:checked').attr('value')),
+      optionAttributes =
+        'data-option-edit-path =' + $firstExisting.attr('data-option-edit-path') +
+        ' data-api-entity = ' + $firstExisting.attr('data-api-entity') +
+        ' data-api-field = ' + $firstExisting.attr('data-api-field');
+
+    // remove existing radio inputs and labels
+    $parent.find('input, label').remove();
+
+    newOptions.forEach(function(option) {
+      var optionId = 'CIVICRM_QFID_' + option.key + '_' + optionName,
+        checked = (option.key === checkedValue) ? ' checked="checked"' : '';
+
+      renderedOptions += '<input type="radio" ' +
+        ' value=' + option.key +
+        ' id="' + optionId +'"' +
+        ' name="' + optionName + '"' +
+        checked +
+        ' class="crm-form-radio"' +
+        optionAttributes +
+        '><label for="' + optionId + '">' + option.value + '</label> ';
+    });
+
+    $parent.prepend(renderedOptions);
+  }
 });


### PR DESCRIPTION
Overview
----------------------------------------

A tool icon is provided to allow editing of option groups, however this icon is only shown for `select` input types. 

To make it easier to edit option groups this PR will also display the edit link for `radio` and `checkbox` input types.

Before
----------------------------------------

The edit link is only shown for `select` input types

![image](https://user-images.githubusercontent.com/6374064/37465927-64f3235a-2854-11e8-924d-a4546601b20f.png)

![image](https://user-images.githubusercontent.com/6374064/37465971-827d2b28-2854-11e8-80e1-f01ef8d5b6c7.png)


After
----------------------------------------

The edit link is also shown for radio groups.

![image](https://user-images.githubusercontent.com/6374064/37465871-413b19a4-2854-11e8-8f18-cbddda6e1096.png)

The same is true for radio options belonging to custom fields

![image](https://user-images.githubusercontent.com/6374064/37469772-f3e407ce-285d-11e8-9668-c9b0e1da58ab.png)

It is also shown for checkbox groups.

#### Radio button edit example

![peek 2018-03-19 15-29](https://user-images.githubusercontent.com/6374064/37656033-cdf18458-2c3e-11e8-9f83-1d211f0a3fe4.gif)

#### Checkbox group edit example

![peek 2018-03-20 12-58](https://user-images.githubusercontent.com/6374064/37655963-949d4ce6-2c3e-11e8-96c9-9d0bd10dcc07.gif)

---

 * [CRM-21840: Show Tool Icon For Radio Button Groups](https://issues.civicrm.org/jira/browse/CRM-21840)