### PR TITLE
 CRM-21264 - Fix tabular formatting of contributions in merged letters grouped by contact

### DIFF
--- a/CRM/Contribute/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contribute/Form/Task/PDFLetterCommon.php
@@ -195,8 +195,8 @@ class CRM_Contribute_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDF
    * @return bool
    */
   public static function isHtmlTokenInTableCell($token, $entity, $textToSearch) {
-    $tokenToMatch = $entity . '.' . $token;
-    $pattern = '|<td.+?{' . $tokenToMatch . '}.+?</td|si';
+    $tokenToMatch = $entity . '\.' . $token;
+    $pattern = '|<td(?![\w-])((?!</td>).)*\{' . $tokenToMatch . '\}.*?</td>|si';
     $within = preg_match_all($pattern, $textToSearch);
     $total = preg_match_all("|{" . $tokenToMatch . "}|", $textToSearch);
     return ($within == $total);

--- a/CRM/Contribute/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contribute/Form/Task/PDFLetterCommon.php
@@ -188,17 +188,17 @@ class CRM_Contribute_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDF
    * Check that the token only appears in a table cell. The '</td><td>' separator cannot otherwise work
    * Calculate the number of times it appears IN the cell & the number of times it appears - should be the same!
    *
-   * @param $token
-   * @param $entity
-   * @param $textToSearch
+   * @param string $token
+   * @param string $entity
+   * @param string $textToSearch
    *
    * @return bool
    */
   public static function isHtmlTokenInTableCell($token, $entity, $textToSearch) {
     $tokenToMatch = $entity . '.' . $token;
-    $dontCare = array();
-    $within = preg_match_all("|<td.+?{" . $tokenToMatch . "}.+?</td|si", $textToSearch, $dontCare);
-    $total = preg_match_all("|{" . $tokenToMatch . "}|", $textToSearch, $dontCare);
+    $pattern = '|<td.+?{' . $tokenToMatch . '}.+?</td|si';
+    $within = preg_match_all($pattern, $textToSearch);
+    $total = preg_match_all("|{" . $tokenToMatch . "}|", $textToSearch);
     return ($within == $total);
   }
 

--- a/tests/phpunit/CRM/Contribute/Form/Task/PDFLetterCommonTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Task/PDFLetterCommonTest.php
@@ -376,4 +376,78 @@ value=$contact_aggregate+$contribution.total_amount}
     }
   }
 
+  /**
+   * @param string $token
+   * @param string $entity
+   * @param string $textToSearch
+   * @param bool $expected
+   *
+   * @dataProvider isHtmlTokenInTableCellProvider
+   */
+  public function testIsHtmlTokenInTableCell($token, $entity, $textToSearch, $expected) {
+    $this->assertEquals($expected,
+      CRM_Contribute_Form_Task_PDFLetterCommon::isHtmlTokenInTableCell($token, $entity, $textToSearch)
+    );
+  }
+
+  public function isHtmlTokenInTableCellProvider() {
+    return [
+
+      'simplest TRUE' => [
+        'token',
+        'entity',
+        '<td>{entity.token}</td>',
+        TRUE,
+      ],
+
+      'simplest FALSE' => [
+        'token',
+        'entity',
+        '{entity.token}',
+        FALSE,
+      ],
+
+      'token between two tables' => [
+        'token',
+        'entity',
+        ' <table><tr><td>Top</td></tr></table>
+          {entity.token}
+          <table><tr><td>Bottom</td></tr></table>',
+        FALSE,
+      ],
+
+      'token in two tables' => [
+        'token',
+        'entity',
+        ' <table><tr><td>{entity.token}</td></tr><tr><td>foo</td></tr></table>
+          <table><tr><td>{entity.token}</td></tr><tr><td>foo</td></tr></table>',
+        TRUE,
+      ],
+
+      'token outside of table and inside of table' => [
+        'token',
+        'entity',
+        ' {entity.token}
+          <table><tr><td>{entity.token}</td></tr><tr><td>foo</td></tr></table>',
+        FALSE,
+      ],
+
+      'token inside more complicated table' => [
+        'token',
+        'entity',
+        ' <table><tr><td class="foo"><em>{entity.token}</em></td></tr></table>',
+        TRUE,
+      ],
+
+      'token inside something that looks like table cell' => [
+        'token',
+        'entity',
+        ' <tdata>{entity.token}</tdata>
+          <table><tr><td>Bottom</td></tr></table>',
+        FALSE,
+      ],
+
+    ];
+  }
+
 }


### PR DESCRIPTION
## Overview

This change makes it easier for users to generate PDF thank-you letters for contributions that are grouped by contact with details of multiple contributions in one page, displayed in table cells

## Before

PDFs generated with these [repro steps](https://issues.civicrm.org/jira/browse/CRM-21264) didn't display contribution fields within table cells.

<img width="239" alt="image" src="https://user-images.githubusercontent.com/42411/37471956-4b9e98e8-2841-11e8-9a23-3dd927d3e4ac.png">

## After

The table cells in the PDF display as expected.

<img width="239" alt="image" src="https://user-images.githubusercontent.com/42411/37471931-3e1ee98e-2841-11e8-9422-85c1e6a12048.png">

## Technical Details

* Tests added which fail before the fix is made and pass afterwards
* More notes about regex in commit message

## Comments

* This PR intends to replace #11069 by using an improved regular expression. 
* Ping @eileenmcnaughton since you're the [original author](https://github.com/civicrm/civicrm-core/commit/045bdb9339a6de34518a095915e8d9a2bd528880#diff-4485e0384a4384e0475f81ea1235b40aR167) of the logic here; and  @sunilpawar since you're the author of #11069 . Would either of you like to review this?