### PR TITLE
Send an 500 http response code when an exception is encountered.

### DIFF
--- a/CRM/Contact/Page/AJAX.php
+++ b/CRM/Contact/Page/AJAX.php
@@ -61,7 +61,7 @@ class CRM_Contact_Page_AJAX {
     $cf = array();
     CRM_Core_DAO::commonRetrieve('CRM_Core_DAO_CustomField', $params, $cf, $returnProperties);
     if (!$cf['id'] || !$cf['is_active'] || $cf['data_type'] != 'ContactReference') {
-      CRM_Utils_System::civiExit('error');
+      CRM_Utils_System::civiExit(1);
     }
 
     if (!empty($cf['filter'])) {
@@ -70,7 +70,7 @@ class CRM_Contact_Page_AJAX {
 
       $action = CRM_Utils_Array::value('action', $filterParams);
       if (!empty($action) && !in_array($action, array('get', 'lookup'))) {
-        CRM_Utils_System::civiExit('error');
+        CRM_Utils_System::civiExit(1);
       }
 
       if (!empty($filterParams['group'])) {
@@ -136,7 +136,7 @@ class CRM_Contact_Page_AJAX {
     $contact = civicrm_api('Contact', 'Get', $params);
 
     if (!empty($contact['is_error'])) {
-      CRM_Utils_System::civiExit('error');
+      CRM_Utils_System::civiExit(1);
     }
 
     $contactList = array();

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1397,7 +1397,7 @@ class CRM_Utils_System {
    */
   public static function civiExit($status = 0) {
 
-    if($status > 0){
+    if ($status > 0) {
       http_response_code(500);
     }
     // move things to CiviCRM cache as needed

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1396,6 +1396,10 @@ class CRM_Utils_System {
    *   (optional) Code with which to exit.
    */
   public static function civiExit($status = 0) {
+
+    if($status > 0){
+      http_response_code(500);
+    }
     // move things to CiviCRM cache as needed
     CRM_Core_Session::storeSessionObjects();
 


### PR DESCRIPTION
Overview
----------------------------------------
When we exit with a non zero exit code, we should generate an appropriate http repsonse code. `500 internal server error` seems most appropriate.

This is useful, for example when callbacks are trying to communicate with CiviCRM.

Lets say an exception occurs. If we send a 200 along with this exception, the 3rd party will have no idea something went wrong. If we send a 500, they will know something is up and be able to take appropriate action (try again later, alert the admin, etc.)

Before
----------------------------------------
We always exited with 200.

After
----------------------------------------
When CRM_Utils_System is called with a status > 0, we exit with 500.

I grepped for CRM_Utils_System::civiExit and saw that a couple of calls to ::civiExit were passing 'error'. I have switched these to 1.

