### PR TITLE
Send unhandled exceptions to error log

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -458,6 +458,11 @@ class CRM_Core_Error extends PEAR_ErrorStack {
     CRM_Core_Error::debug_var('Fatal Error Details', $vars, FALSE);
     CRM_Core_Error::backtrace('backTrace', TRUE);
 
+    // also send to default error log
+    foreach (explode("\n", self::formatTextException($exception)) as $line) {
+      error_log($line);
+    };
+
     // print to screen
     $template = CRM_Core_Smarty::singleton();
     $template->assign($vars);

--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -460,7 +460,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
 
     // also send to default error log
     foreach (explode("\n", self::formatTextException($exception)) as $line) {
-      error_log($line);
+      error_log("CiviCRM " . $line);
     };
 
     // print to screen


### PR DESCRIPTION
# Overview

My expectation was that unhandled exceptions would be handled by the "defined error handling routines" and end up in the same place as other PHP logworthy events.

# Before

::handleUnhandledException() was preventing this from happening.

# After

This PR ensures that they do end up in the logs by calling error_log(). It prefixes each line that it sends to the error log with CiviCRM. I thought this was good as a way of hinting that CiviCRM handled the exception.