### PR TITLE
CRM-21682 Membership Renewal Tests

### DIFF
--- a/tests/phpunit/CRM/Core/Payment/PayPalIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/PayPalIPNTest.php
@@ -145,7 +145,8 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
    * Test IPN response updates contribution_recur & contribution for first & second contribution.
    */
   public function testIPNPaymentMembershipRecurSuccess() {
-    $this->setupMembershipRecurringPaymentProcessorTransaction();
+    $durationUnit = 'year';
+    $this->setupMembershipRecurringPaymentProcessorTransaction(array('duration_unit' => $durationUnit, 'frequency_unit' => $durationUnit));
     $this->callAPISuccessGetSingle('membership_payment', array());
     $paypalIPN = new CRM_Core_Payment_PayPalIPN($this->getPaypalRecurTransaction());
     $paypalIPN->main();
@@ -159,7 +160,8 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
     $this->assertEquals(5, $contributionRecur['contribution_status_id']);
     $paypalIPN = new CRM_Core_Payment_PaypalIPN($this->getPaypalRecurSubsequentTransaction());
     $paypalIPN->main();
-    $this->assertEquals(strtotime('+ 1 year', strtotime($membershipEndDate)), strtotime($this->callAPISuccessGetValue('membership', array('return' => 'end_date'))));
+    $renewedMembershipEndDate = $this->membershipRenewalDate($durationUnit, $membershipEndDate);
+    $this->assertEquals($renewedMembershipEndDate, $this->callAPISuccessGetValue('membership', array('return' => 'end_date')));
     $contribution = $this->callAPISuccess('contribution', 'get', array(
         'contribution_recur_id' => $this->_contributionRecurID,
         'sequential' => 1,

--- a/tests/phpunit/CRM/Core/Payment/PayPalProIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/PayPalProIPNTest.php
@@ -102,7 +102,7 @@ class CRM_Core_Payment_PayPalProIPNTest extends CiviUnitTestCase {
    * Test IPN response updates contribution_recur & contribution for first & second contribution.
    */
   public function testIPNPaymentMembershipRecurSuccess() {
-    $this->setupMembershipRecurringPaymentProcessorTransaction();
+    $this->setupMembershipRecurringPaymentProcessorTransaction(array('duration_unit' => 'year', 'frequency_unit' => 'year'));
     $this->callAPISuccessGetSingle('membership_payment', array());
     $paypalIPN = new CRM_Core_Payment_PayPalProIPN($this->getPaypalProRecurTransaction());
     $paypalIPN->main();

--- a/tests/phpunit/CRM/Core/Payment/PayPalProIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/PayPalProIPNTest.php
@@ -102,7 +102,8 @@ class CRM_Core_Payment_PayPalProIPNTest extends CiviUnitTestCase {
    * Test IPN response updates contribution_recur & contribution for first & second contribution.
    */
   public function testIPNPaymentMembershipRecurSuccess() {
-    $this->setupMembershipRecurringPaymentProcessorTransaction(array('duration_unit' => 'year', 'frequency_unit' => 'year'));
+    $durationUnit = 'year';
+    $this->setupMembershipRecurringPaymentProcessorTransaction(array('duration_unit' => $durationUnit, 'frequency_unit' => $durationUnit));
     $this->callAPISuccessGetSingle('membership_payment', array());
     $paypalIPN = new CRM_Core_Payment_PayPalProIPN($this->getPaypalProRecurTransaction());
     $paypalIPN->main();
@@ -116,7 +117,9 @@ class CRM_Core_Payment_PayPalProIPNTest extends CiviUnitTestCase {
     $this->assertEquals(5, $contributionRecur['contribution_status_id']);
     $paypalIPN = new CRM_Core_Payment_PaypalProIPN($this->getPaypalProRecurSubsequentTransaction());
     $paypalIPN->main();
-    $this->assertEquals(strtotime('+ 1 year', strtotime($membershipEndDate)), strtotime($this->callAPISuccessGetValue('membership', array('return' => 'end_date'))));
+
+    $renewedMembershipEndDate = $this->membershipRenewalDate($durationUnit, $membershipEndDate);
+    $this->assertEquals($renewedMembershipEndDate, $this->callAPISuccessGetValue('membership', array('return' => 'end_date')));
     $contribution = $this->callAPISuccess('contribution', 'get', array(
         'contribution_recur_id' => $this->_contributionRecurID,
         'sequential' => 1,

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3202,9 +3202,19 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
 
   /**
    * We don't have a good way to set up a recurring contribution with a membership so let's just do one then alter it
+   *
+   * @param array $params Optionally modify params for membership/recur (duration_unit/frequency_unit)
    */
-  public function setupMembershipRecurringPaymentProcessorTransaction() {
-    $this->ids['membership_type'] = $this->membershipTypeCreate();
+  public function setupMembershipRecurringPaymentProcessorTransaction($params = array()) {
+    $membershipParams = $recurParams = array();
+    if (!empty($params['duration_unit'])) {
+      $membershipParams['duration_unit'] = $params['duration_unit'];
+    }
+    if (!empty($params['frequency_unit'])) {
+      $recurParams['frequency_unit'] = $params['frequency_unit'];
+    }
+
+    $this->ids['membership_type'] = $this->membershipTypeCreate($membershipParams);
     //create a contribution so our membership & contribution don't both have id = 1
     if ($this->callAPISuccess('Contribution', 'getcount', array()) == 0) {
       $this->contributionCreate(array(
@@ -3215,7 +3225,7 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
         'trxn_id' => 345,
       ));
     }
-    $this->setupRecurringPaymentProcessorTransaction();
+    $this->setupRecurringPaymentProcessorTransaction($recurParams);
 
     $this->ids['membership'] = $this->callAPISuccess('membership', 'create', array(
       'contact_id' => $this->_contactID,

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -1239,6 +1239,25 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
     $result = $this->callAPISuccess('MembershipStatus', 'Delete', array('id' => $membershipStatusID));
   }
 
+  public function membershipRenewalDate($durationUnit, $membershipEndDate) {
+    // We only have an end_date if frequency units match, otherwise membership won't be autorenewed and dates won't be calculated.
+    $renewedMembershipEndDate = new DateTime($membershipEndDate);
+    switch ($durationUnit) {
+      case 'year':
+        $renewedMembershipEndDate->add(new DateInterval('P1Y'));
+        break;
+
+      case 'month':
+        // We have to add 1 day first in case it's the end of the month, then subtract afterwards
+        // eg. 2018-02-28 should renew to 2018-03-31, if we just added 1 month we'd get 2018-03-28
+        $renewedMembershipEndDate->add(new DateInterval('P1D'));
+        $renewedMembershipEndDate->add(new DateInterval('P1M'));
+        $renewedMembershipEndDate->sub(new DateInterval('P1D'));
+        break;
+    }
+    return $renewedMembershipEndDate->format('Y-m-d');
+  }
+
   /**
    * @param array $params
    *

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -920,21 +920,8 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
     $renewedMembership = $this->callAPISuccessGetSingle('membership', array('id' => $membershipPayment['membership_id']));
     if ($durationUnit) {
       // We only have an end_date if frequency units match, otherwise membership won't be autorenewed and dates won't be calculated.
-      $renewedMembershipEndDate = new DateTime($membership['end_date']);
-      switch ($durationUnit) {
-        case 'year':
-          $renewedMembershipEndDate->add(new DateInterval('P1Y'));
-          break;
-
-        case 'month':
-          // We have to add 1 day first in case it's the end of the month, then subtract afterwards
-          // eg. 2018-02-28 should renew to 2018-03-31, if we just added 1 month we'd get 2018-03-28
-          $renewedMembershipEndDate->add(new DateInterval('P1D'));
-          $renewedMembershipEndDate->add(new DateInterval('P1M'));
-          $renewedMembershipEndDate->sub(new DateInterval('P1D'));
-          break;
-      }
-      $this->assertEquals($renewedMembershipEndDate->format('Y-m-d'), $renewedMembership['end_date']);
+      $renewedMembershipEndDate = $this->membershipRenewalDate($durationUnit, $membership['end_date']);
+      $this->assertEquals($renewedMembershipEndDate, $renewedMembership['end_date']);
     }
     $recurringContribution = $this->callAPISuccess('contribution_recur', 'getsingle', array('id' => $contribution['contribution_recur_id']));
     $this->assertEquals($processor['payment_instrument_id'], $recurringContribution['payment_instrument_id']);


### PR DESCRIPTION
Overview
----------------------------------------
Existing membership renewal tests are testing renewals where duration units don't match (ie. recur has a monthly interval but membership has a yearly interval).  This is an unlikely real-world scenario as it would lead to an annual membership being renewed by a year every month that the recurring contribution is renewed!

This PR updates the existing unit tests so they use matching frequencies for membership and recurring contributions.  It then extends those tests so the same tests can be run with different frequencies, improving overall test coverage.

Before
----------------------------------------
Tests are not testing a valid real-world scenario (It might be nice to pay in monthly installments for an annual membership but that's not what the code is testing and is not how it currently works).

After
----------------------------------------
Test coverage is improved.  Real-world renewal scenarios are tested.

Comments
----------------------------------------
Improve test coverage to support changes in #11556.

---

 * [CRM-21682: Automatic membership renewal fixes](https://issues.civicrm.org/jira/browse/CRM-21682)