### PR TITLE
Use try catch when deleting groups (dev/core/issues/22 )

### DIFF
--- a/CRM/Group/Form/Edit.php
+++ b/CRM/Group/Form/Edit.php
@@ -106,7 +106,12 @@ class CRM_Group_Form_Edit extends CRM_Core_Form {
     if ($this->_action == CRM_Core_Action::DELETE) {
       if (isset($this->_id)) {
         $this->assign('title', $this->_title);
-        $this->assign('count', CRM_Contact_BAO_Group::memberCount($this->_id));
+        try {
+          $this->assign('count', CRM_Contact_BAO_Group::memberCount($this->_id));
+        }
+        catch (CRM_Core_Exception $e) {
+          // If the group is borked the query might fail but delete should be possible.
+        }
         CRM_Utils_System::setTitle(ts('Confirm Group Delete'));
       }
       if ($this->_groupValues['is_reserved'] == 1 && !CRM_Core_Permission::check('administer reserved groups')) {


### PR DESCRIPTION
Overview
----------------------------------------
Prevent fatal error on deleting broken smart group

Before
----------------------------------------
Error when deleting broken smart group

After
----------------------------------------
Presumable no error - see below.

Technical Details
----------------------------------------


Comments
----------------------------------------
@KarinG hit a bug when one of her customers could not delete broken smart groups. I suggested using the try-catch block on chat. However, Karin only tried commenting out this line so did not confirm whether the try-catch works. I was on the fence about putting this up as a PR since I don't think the bug rises to the level of it being an important use of volunteer time & I could not justify the time involved either for myself or a reviewer trying to replicate it.

OTOH I think it's pretty harmless & safe, and I had already sunk time into it on the support channel



