### PR TITLE
Fix page layout for wordpress (dev/core/issues/21)

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -68,7 +68,7 @@
 
   {include file="CRM/common/TrackingFields.tpl"}
 
-  <div class="crm-contribution-page-id-{$contributionPageID} crm-block crm-form-block crm-contribution-main-form-block">
+  <div class="crm-contribution-page-id-{$contributionPageID} crm-block crm-contribution-main-form-block">
 
   {if $contact_id && !$ccid}
     <div class="messages status no-popup crm-not-you-message">


### PR DESCRIPTION
Overview
----------------------------------------
Reverse formatting change that caused a regression in 4.7.31 for the display of contribution pages in wordpress

Before
----------------------------------------
![screenshot 2018-03-19 14 19 59](https://user-images.githubusercontent.com/336308/37573987-3266567e-2b82-11e8-9cfd-a8830744c908.png)


After
----------------------------------------
![screenshot 2018-03-19 14 30 49](https://user-images.githubusercontent.com/336308/37573997-494d8330-2b82-11e8-9b34-2b3dbedb872c.png)




Technical Details
----------------------------------------
Change reverses a css change in https://github.com/civicrm/civicrm-core/commit/036aa39d9edeff4a2e582f6c0da75157cdc8fba9#diff-544215f9c296467a07bab9c92c448be0R71

Comments
----------------------------------------
I think this will cause something in PR #11396 to regress but that can be fixed in a more leisurely fashion later - this appears as a serious regression that needs to be fixed in the next code drop
