### PR TITLE
Revert "CRM-8140: Not possible to select fields for export when using Custom Searches"

### DIFF
--- a/CRM/Export/Form/Select.php
+++ b/CRM/Export/Form/Select.php
@@ -70,8 +70,6 @@ class CRM_Export_Form_Select extends CRM_Core_Form {
 
   public $_componentTable;
 
-  public $_customSearchID;
-
   /**
    * Build all the data structures needed to build the form.
    *
@@ -83,7 +81,13 @@ class CRM_Export_Form_Select extends CRM_Core_Form {
     $this->preventAjaxSubmit();
 
     //special case for custom search, directly give option to download csv file
-    $this->_customSearchID = $this->get('customSearchID');
+    $customSearchID = $this->get('customSearchID');
+    if ($customSearchID) {
+      CRM_Export_BAO_Export::exportCustom($this->get('customSearchClass'),
+        $this->get('formValues'),
+        $this->get(CRM_Utils_Sort::SORT_ORDER)
+      );
+    }
 
     $this->_selectAll = FALSE;
     $this->_exportMode = self::CONTACT_EXPORT;
@@ -95,11 +99,7 @@ class CRM_Export_Form_Select extends CRM_Core_Form {
     $isStandalone = $formName == 'CRM_Export_StateMachine_Standalone';
 
     // get the submitted values based on search
-    if ($this->_customSearchID) {
-      $values = $this->get('formValues');
-      $this->assign('exportCustomSearchField', TRUE);
-    }
-    elseif ($this->_action == CRM_Core_Action::ADVANCED) {
+    if ($this->_action == CRM_Core_Action::ADVANCED) {
       $values = $this->controller->exportValues('Advanced');
     }
     elseif ($this->_action == CRM_Core_Action::PROFILE) {
@@ -231,7 +231,7 @@ FROM   {$this->_componentTable}
     $exportOptions = $mergeOptions = $postalMailing = array();
     $exportOptions[] = $this->createElement('radio',
       NULL, NULL,
-      ts('Export %1 fields', array(1 => empty($this->_customSearchID) ? 'PRIMARY' : 'custom search')),
+      ts('Export PRIMARY fields'),
       self::EXPORT_ALL,
       array('onClick' => 'showMappingOption( );')
     );
@@ -396,28 +396,20 @@ FROM   {$this->_componentTable}
     }
 
     if ($exportOption == self::EXPORT_ALL) {
-      if ($this->_customSearchID) {
-        CRM_Export_BAO_Export::exportCustom($this->get('customSearchClass'),
-          $this->get('formValues'),
-          $this->get(CRM_Utils_Sort::SORT_ORDER)
-        );
-      }
-      else {
-        CRM_Export_BAO_Export::exportComponents($this->_selectAll,
-          $this->_componentIds,
-          (array) $this->get('queryParams'),
-          $this->get(CRM_Utils_Sort::SORT_ORDER),
-          NULL,
-          $this->get('returnProperties'),
-          $this->_exportMode,
-          $this->_componentClause,
-          $this->_componentTable,
-          $mergeSameAddress,
-          $mergeSameHousehold,
-          $exportParams,
-          $this->get('queryOperator')
-        );
-      }
+      CRM_Export_BAO_Export::exportComponents($this->_selectAll,
+        $this->_componentIds,
+        (array) $this->get('queryParams'),
+        $this->get(CRM_Utils_Sort::SORT_ORDER),
+        NULL,
+        $this->get('returnProperties'),
+        $this->_exportMode,
+        $this->_componentClause,
+        $this->_componentTable,
+        $mergeSameAddress,
+        $mergeSameHousehold,
+        $exportParams,
+        $this->get('queryOperator')
+      );
     }
 
     //reset map page

--- a/templates/CRM/Export/Form/Select.tpl
+++ b/templates/CRM/Export/Form/Select.tpl
@@ -28,7 +28,7 @@
 <div class="crm-block crm-form-block crm-export-form-block">
 
  <div class="help">
-    <p>{ts}<strong>Export {if $exportCustomSearchField}custom search{else}PRIMARY{/if} fields</strong> provides the most commonly used data values. This includes primary address information, preferred phone and email.{/ts}</p>
+    <p>{ts}<strong>Export PRIMARY fields</strong> provides the most commonly used data values. This includes primary address information, preferred phone and email.{/ts}</p>
     <p>{ts}Click <strong>Select fields for export</strong> and then <strong>Continue</strong> to choose a subset of fields for export. This option allows you to export multiple specific locations (Home, Work, etc.) as well as custom data. You can also save your selections as a 'field mapping' so you can use it again later.{/ts}</p>
  </div>
 


### PR DESCRIPTION
Overview
----------------------------------------
This reverts commit ce40afac219b38872fef1d8f052c38d85667db79. 

My testing showed that commit enabled the selection of fields for export from a custom search, but the exported rows included ALL rows in the DB. The 'where' from the custom search was not applied.

Before
----------------------------------------
Choosing export contacts takes user to a screen where they can choose columns to export or use defaults. If they choose the columns then the resulting export is NOT limited to the contacts from the search query

 (I have been using include exclude search. The default data set has groups of 'Newsletter subscribers and Summer programme volunteers that provide a good baseline)

After
----------------------------------------
Choosing export as an action results in an immediate export of the default rows.

Technical Details
----------------------------------------
@seamuslee001 don't suppose you'd be able to test the latest rc for this on an ACL'd user. My suspicion is that ACLs are still applied but I believe we should confirm

Comments
----------------------------------------
I believe exporting too many contacts is much more dangerous than not having the option to choose the fields to export (a long-missing feature)

@colemanw @monishdeb this reverts https://github.com/civicrm/civicrm-core/pull/11458 which you worked on. I believe revert is the best option for the rc & a full (tested) fix is the next step

---

 * [CRM-8140: Not possible to select fields for export when using Custom Searches](https://issues.civicrm.org/jira/browse/CRM-8140)