### PR TITLE
Fix regression on CiviRules search due to exception handling

### DIFF
--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -1029,7 +1029,10 @@ SELECT DISTINCT 'civicrm_contact', contact_a.id, contact_a.id, '$cacheKey', cont
 
     $sql = str_replace(array("SELECT contact_a.id as contact_id", "SELECT contact_a.id as id"), $insertSQL, $sql);
     try {
-      CRM_Core_DAO::executeQuery($sql);
+      $result = CRM_Core_DAO::executeQuery($sql, [], FALSE, NULL, FALSE, TRUE, TRUE);
+      if (is_a($result, 'DB_Error')) {
+        throw new CRM_Core_Exception($result->message);
+      }
     }
     catch (CRM_Core_Exception $e) {
       if ($coreSearch) {
@@ -1038,7 +1041,10 @@ SELECT DISTINCT 'civicrm_contact', contact_a.id, contact_a.id, '$cacheKey', cont
         $this->rebuildPreNextCache($start, $end, $sort, $cacheKey);
       }
       else {
-        CRM_Core_Session::setStatus(ts('Query Failed'));
+        // This will always show for CiviRules :-( as a) it orders by 'rule_label'
+        // which is not available in the query & b) it uses contact not contact_a
+        // as an alias.
+        // CRM_Core_Session::setStatus(ts('Query Failed'));
         return;
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
CiviRules is currently giving a fatal error on the civirules custom search. This is an Intra-rc regression found by @DanielvV https://github.com/civicrm/civicrm-core/pull/11746#issuecomment-373402081

Before
----------------------------------------
Fatal error on civirules custom search

After
----------------------------------------
custom search succeeds

Technical Details
----------------------------------------
When running CiviRules there is an incorrect sql query that runs in fillupPrevNextCache - a change in exception handling turned this into a fatal error. I've used the trapException parameter to make it non-fatal again. 

Comments
----------------------------------------
I would prefer to have some sort of notice / deprecation warning when an invalid query is run here. If this were fixed in CiviRules then I think we could add that (seems like a bad idea when we know it will confuse rules users). 

The issues with the query are
a) the alias for the contact table is contact not the usual (in our search framework) contact_a
b) it tries to order by `rule_label` and that fails (not quite sure why, I didn't dig).

ping @jaapjansma @ErikHommel  - 

Huge thanks for @DanielvV for identifying the issue while in the rc stage
