### PR TITLE
dev/core#24 Passing an array for contact_id/client_id to Case.Create API when updating an existing case causes case to be "reassigned"

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -274,16 +274,16 @@ WHERE civicrm_case.id = %1";
    *   ID of the case.
    *
    * @param int $contactID
+   * @param int $startArrayAt This is to support legacy calls to Case.Get API which may rely on the first array index being set to 1
    *
    * @return array
    */
-  public static function retrieveContactIdsByCaseId($caseId, $contactID = NULL) {
+  public static function retrieveContactIdsByCaseId($caseId, $contactID = NULL, $startArrayAt = 0) {
     $caseContact = new CRM_Case_DAO_CaseContact();
     $caseContact->case_id = $caseId;
     $caseContact->find();
     $contactArray = array();
-    // FIXME: Why does this return a 1-based array?
-    $count = 1;
+    $count = $startArrayAt;
     while ($caseContact->fetch()) {
       if ($contactID != $caseContact->contact_id) {
         $contactArray[$count] = $caseContact->contact_id;
@@ -1087,7 +1087,6 @@ SELECT case_status.label AS case_status, status_id, civicrm_case_type.title AS c
 
     $contactViewUrl = CRM_Utils_System::url("civicrm/contact/view", "reset=1&cid=", FALSE, NULL, FALSE);
     $hasViewContact = CRM_Core_Permission::giveMeAllACLs();
-    $clientIds = self::retrieveContactIdsByCaseId($caseID);
 
     if (!$userID) {
       $session = CRM_Core_Session::singleton();


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/issues/24

The contact_id/client_id for the case supports multiple ids.  It can be passed to the case.create API either as a single value or as an array.  However, the code is inconsistent in it's handling of contact_id and expects it to be both an array and a single value.  The result is that if an array is passed in it will fail to detect that an existing case contact_id already matches and it will "reassign" the case to the default contact id (1).  This issue was identified because of inconsistent behaviour when submitting case/activity updates via webform_civicrm.

The proposed solution is to ensure that contact_id is always an array, and then check the first element against the original contact id.

Before
----------------------------------------
If an array is passed in for contact_id the case is reassigned to contact ID 1.

After
----------------------------------------
Case is not reassigned to contact ID 1.  Activities are correctly filed on existing case.

Technical Details
----------------------------------------
For historical reasons retrieveContactIDsByCaseId() returns a 1-based array.  The only place it needs to be 1-based is in the Case.Get API otherwise the API return values change (and it's possible that someone relies on those return values being 1-based).  Ideally they should be coding to retrieve the first array element, instead of a hardcoded ID.

This PR for webform_civicrm removes the 1-based requirement from webform_civicrm: https://github.com/colemanw/webform_civicrm/pull/118
