### PR TITLE
Version check test: in alphas don't test for site stats not provided for alphas

### DIFF
--- a/tests/phpunit/CRM/Utils/versionCheckTest.php
+++ b/tests/phpunit/CRM/Utils/versionCheckTest.php
@@ -275,59 +275,64 @@ class CRM_Utils_versionCheckTest extends CiviUnitTestCase {
 
     // Stats array should have correct elements.
     $this->assertArrayHasKey('version', $stats);
-    $this->assertArrayHasKey('hash', $stats);
-    $this->assertArrayHasKey('uf', $stats);
-    $this->assertArrayHasKey('lang', $stats);
-    $this->assertArrayHasKey('co', $stats);
-    $this->assertArrayHasKey('ufv', $stats);
-    $this->assertArrayHasKey('PHP', $stats);
-    $this->assertArrayHasKey('MySQL', $stats);
-    $this->assertArrayHasKey('communityMessagesUrl', $stats);
-    $this->assertArrayHasKey('domain_isoCode', $stats);
-    $this->assertArrayHasKey('PPTypes', $stats);
-    $this->assertArrayHasKey('entities', $stats);
-    $this->assertArrayHasKey('extensions', $stats);
-    $this->assertType('array', $stats['entities']);
-    $this->assertType('array', $stats['extensions']);
 
-    // Assert $stats['domain_isoCode'] is correct.
-    $this->assertEquals($country['iso_code'], $stats['domain_isoCode']);
+    // See CRM_Utils_VersionCheck::getSiteStats where alpha versions don't get
+    // full stats generated
+    if (array_key_exists('version', $stats) && strpos($stats['version'], 'alpha') !== FALSE) {
+      $this->assertArrayHasKey('hash', $stats);
+      $this->assertArrayHasKey('uf', $stats);
+      $this->assertArrayHasKey('lang', $stats);
+      $this->assertArrayHasKey('co', $stats);
+      $this->assertArrayHasKey('ufv', $stats);
+      $this->assertArrayHasKey('PHP', $stats);
+      $this->assertArrayHasKey('MySQL', $stats);
+      $this->assertArrayHasKey('communityMessagesUrl', $stats);
+      $this->assertArrayHasKey('domain_isoCode', $stats);
+      $this->assertArrayHasKey('PPTypes', $stats);
+      $this->assertArrayHasKey('entities', $stats);
+      $this->assertArrayHasKey('extensions', $stats);
+      $this->assertType('array', $stats['entities']);
+      $this->assertType('array', $stats['extensions']);
 
-    $entity_names = array();
-    foreach ($stats['entities'] as $entity) {
-      $entity_names[] = $entity['name'];
-      $this->assertType('int', $entity['size'], "Stats entity {$entity['name']} has integer size?");
+      // Assert $stats['domain_isoCode'] is correct.
+      $this->assertEquals($country['iso_code'], $stats['domain_isoCode']);
+
+      $entity_names = array();
+      foreach ($stats['entities'] as $entity) {
+        $entity_names[] = $entity['name'];
+        $this->assertType('int', $entity['size'], "Stats entity {$entity['name']} has integer size?");
+      }
+
+      $expected_entity_names = array(
+        'Activity',
+        'Case',
+        'Contact',
+        'Relationship',
+        'Campaign',
+        'Contribution',
+        'ContributionPage',
+        'ContributionProduct',
+        'Widget',
+        'Discount',
+        'PriceSetEntity',
+        'UFGroup',
+        'Event',
+        'Participant',
+        'Friend',
+        'Grant',
+        'Mailing',
+        'Membership',
+        'MembershipBlock',
+        'Pledge',
+        'PledgeBlock',
+        'Delivered',
+      );
+      sort($entity_names);
+      sort($expected_entity_names);
+      $this->assertEquals($expected_entity_names, $entity_names);
+
+      // TODO: Also test for enabled extensions.
     }
-
-    $expected_entity_names = array(
-      'Activity',
-      'Case',
-      'Contact',
-      'Relationship',
-      'Campaign',
-      'Contribution',
-      'ContributionPage',
-      'ContributionProduct',
-      'Widget',
-      'Discount',
-      'PriceSetEntity',
-      'UFGroup',
-      'Event',
-      'Participant',
-      'Friend',
-      'Grant',
-      'Mailing',
-      'Membership',
-      'MembershipBlock',
-      'Pledge',
-      'PledgeBlock',
-      'Delivered',
-    );
-    sort($entity_names);
-    sort($expected_entity_names);
-    $this->assertEquals($expected_entity_names, $entity_names);
-
-    // TODO: Also test for enabled extensions.
   }
 
 }

--- a/tests/phpunit/CRM/Utils/versionCheckTest.php
+++ b/tests/phpunit/CRM/Utils/versionCheckTest.php
@@ -278,7 +278,7 @@ class CRM_Utils_versionCheckTest extends CiviUnitTestCase {
 
     // See CRM_Utils_VersionCheck::getSiteStats where alpha versions don't get
     // full stats generated
-    if (array_key_exists('version', $stats) && strpos($stats['version'], 'alpha') !== FALSE) {
+    if (array_key_exists('version', $stats) && strpos($stats['version'], 'alpha') === FALSE) {
       $this->assertArrayHasKey('hash', $stats);
       $this->assertArrayHasKey('uf', $stats);
       $this->assertArrayHasKey('lang', $stats);


### PR DESCRIPTION
Overview
----------------------------------------
The version check test is failing on `master` because it asserts that certain stats should be there, but they aren't generated for versions with `alpha` in the name.

Before
----------------------------------------
The test `CRM_Utils_versionCheckTest::testGetSiteStats` will fail when run on an alpha

> Failed asserting that an array has the key 'hash'.

After
----------------------------------------
The test will not assert things that aren't true on an alpha.

Technical Details
----------------------------------------
This proposed change sidesteps the question of whether an alpha should have [these various statistics](https://github.com/civicrm/civicrm-core/blob/8c9251b398a29d9b82996ae21825c9d6478fa576/CRM/Utils/VersionCheck.php#L279) generated in CRM_Utils_VersionCheck::getSiteStats.  However, if anything changes over there in the condition, it should get a corresponding change in the test.

Comments
----------------------------------------
See the thread [starting with this post on Mattermost](https://chat.civicrm.org/civicrm/pl/b7myyp7ubfgiiyh6od51kpcccw)
