### PR TITLE
CRM-21848 Fix issue where on_hold email addresses are not being filtered out of

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -249,6 +249,7 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing {
         $location_filter,
         "$entityTable.email IS NOT NULL",
         "$entityTable.email != ''",
+        "$entityTable.on_hold = 0",
         "mg.mailing_id = #mailingID",
         'temp.contact_id IS NULL',
       );


### PR DESCRIPTION
recipient list for mailings.

Overview
----------------------------------------
Email addresses on hold are not being filtered out of mailing group when mailing are created.

Before
----------------------------------------
Email addresses are not filtered out. 

After
----------------------------------------
Email addresses are filtered out.

---

 * [CRM-21848: Mailing no longer filters out email addresses on hold from recipient group](https://issues.civicrm.org/jira/browse/CRM-21848)