### PR TITLE
SUP-4115: Fix contribution_recur.id being compared to a string.

### DIFF
--- a/CRM/Contribute/BAO/Query.php
+++ b/CRM/Contribute/BAO/Query.php
@@ -385,7 +385,7 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
         return;
 
       case 'contribution_recur_payment_made':
-        $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause("civicrm_contribution_recur.id", 'IS NOT EMPTY');
+        $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause("civicrm_contribution_recur.id", 'IS NOT NULL');
         if ($value == 2) {
           $query->_qill[$grouping][] = ts("Recurring contributions with at least one payment");
           self::$_contribRecurPayment = TRUE;


### PR DESCRIPTION
Overview
----------------------------------------
Saved Searches based on Advanced search with "All recurring contributions" would crash smart group cache building.  This fixes the incorrect string comparison that causes it.

Before
----------------------------------------
DB Error on smart group cache build.

After
----------------------------------------
Smart group cache now builds correctly
