### PR TITLE
CRM-21764: Recurring Events without Price Set fail to save

### DIFF
--- a/CRM/Core/Page/AJAX/RecurringEntity.php
+++ b/CRM/Core/Page/AJAX/RecurringEntity.php
@@ -14,12 +14,21 @@ class CRM_Core_Page_AJAX_RecurringEntity {
 
   public static function updateMode() {
     $finalResult = array();
-    if (CRM_Utils_Array::value('mode', $_REQUEST) && CRM_Utils_Array::value('entityId', $_REQUEST) && CRM_Utils_Array::value('entityTable', $_REQUEST) && CRM_Utils_Array::value('priceSet', $_REQUEST)) {
-
+    if (CRM_Utils_Array::value('mode', $_REQUEST) && CRM_Utils_Array::value('entityId', $_REQUEST) && CRM_Utils_Array::value('entityTable', $_REQUEST)) {
       $mode = CRM_Utils_Type::escape($_REQUEST['mode'], 'Integer');
       $entityId = CRM_Utils_Type::escape($_REQUEST['entityId'], 'Integer');
       $entityTable = CRM_Utils_Type::escape($_REQUEST['entityTable'], 'String');
       $priceSet = CRM_Utils_Type::escape($_REQUEST['priceSet'], 'String');
+
+      // CRM-21764 fix
+      // Retrieving existing priceset if price set id is not passed
+      if ($priceSet == "") {
+        $priceSetEntity = new CRM_Price_DAO_PriceSetEntity();
+        $priceSetEntity->entity_id = $entityId;
+        $priceSetEntity->entity_table = $entityTable;
+        $priceSetEntity->find(TRUE);
+        $priceSet = $priceSetEntity->price_set_id;
+      }
       $linkedEntityTable = $_REQUEST['linkedEntityTable'];
       $finalResult = CRM_Core_BAO_RecurringEntity::updateModeAndPriceSet($entityId, $entityTable, $mode, $linkedEntityTable, $priceSet);
     }


### PR DESCRIPTION
Overview
----------------------------------------
**Steps to reproduce:**

1. Create a recurring event with a bit of recurrence
2. Edit a specific event, update any field, such as the event description text field
3. Save, select "only this event"

Before
----------------------------------------
Nothing happens, Event is not really saved. CRM/Core/Page/AJAX/RecurringEntity.php::updateModeAndPriceSet fails because it returns an empty array, causing the save action to fail without any errors or notices.

After
----------------------------------------
We update price set only if we have any which results in expected response from  updateModeAndPriceSet of CRM/Core/Page/AJAX/RecurringEntity.php. Now event details are getting saved as expected.

_Agileware Ref: CIVICRM-831_

---

 * [CRM-21764: Recurring Events without Price Set fail to save](https://issues.civicrm.org/jira/browse/CRM-21764)