### PR TITLE
Dev/Core 25 Wrap the mailing split_job function in a transaction to e…

### DIFF
--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -375,11 +375,11 @@ class CRM_Mailing_BAO_MailingJob extends CRM_Mailing_DAO_MailingJob {
         continue;
       }
 
+      $transaction = new CRM_Core_Transaction();
+
       $job->split_job($offset);
 
       // update the status of the parent job
-      $transaction = new CRM_Core_Transaction();
-
       $saveJob = new CRM_Mailing_DAO_MailingJob();
       $saveJob->id = $job->id;
       $saveJob->start_date = date('YmdHis');
@@ -437,6 +437,7 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
         CRM_Core_DAO::executeQuery($sql, $params);
       }
     }
+
   }
 
   /**


### PR DESCRIPTION
…nsure that there is no possibility of duplicate maiing jobs created

Overview
----------------------------------------
AUG ran into an issue where the split_job function was being run but subsequent process mailing jobs started processing the child jobs causing locks on the table which then created duplicate child jobs for the mailing. The aim of this is by wrapping it in a transaction other processes won't be able to block it / any errors will trigger a roll back. 

ping @eileenmcnaughton @monishdeb would one of you be able to review this please?