### PR TITLE
CiviMail: Fix logic for handling SMTP socket errors, temporary failures and permanent failures

### DIFF
--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -685,17 +685,7 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
       if (is_a($result, 'PEAR_Error') && !$mailing->sms_provider_id) {
         // CRM-9191
         $message = $result->getMessage();
-        // SMTP response code is buried in the message.
-        $code = preg_match('/ \(code: (.+), response: /', $message, $matches) ? $matches[1] : '';
-        if (
-          strpos($message, 'Failed to write to socket') !== FALSE ||
-          ((
-            strpos($message, 'Failed to set sender') !== FALSE ||
-            strpos($message, 'Failed to add recipient') !== FALSE ||
-            strpos($message, 'Failed to send data') !== FALSE
-          // Register 5xx SMTP response code (permanent failure) as bounce.
-          ) && substr($code, 0, 1) !== '5')
-        ) {
+        if ($this->isTemporaryError($message)) {
           // lets log this message and code
           $code = $result->getCode();
           CRM_Core_Error::debug_log_message("SMTP Socket Error or failed to set sender error. Message: $message, Code: $code");
@@ -794,6 +784,43 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
     );
 
     return $result;
+  }
+
+  /**
+   * Determine if an SMTP error is temporary or permanent.
+   *
+   * @param string $message
+   *   PEAR error message.
+   * @return bool
+   *   TRUE - Temporary/retriable error
+   *   FALSE - Permanent/non-retriable error
+   */
+  protected function isTemporaryError($message) {
+    // SMTP response code is buried in the message.
+    $code = preg_match('/ \(code: (.+), response: /', $message, $matches) ? $matches[1] : '';
+
+    if (strpos($message, 'Failed to write to socket') !== FALSE) {
+      return TRUE;
+    }
+
+    // Register 5xx SMTP response code (permanent failure) as bounce.
+    if ($code{0} === '5') {
+      return FALSE;
+    }
+
+    if (strpos($message, 'Failed to set sender') !== FALSE) {
+      return TRUE;
+    }
+
+    if (strpos($message, 'Failed to add recipient') !== FALSE) {
+      return TRUE;
+    }
+
+    if (strpos($message, 'Failed to send data') !== FALSE) {
+      return TRUE;
+    }
+
+    return FALSE;
   }
 
   /**

--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -804,7 +804,7 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
     }
 
     // Register 5xx SMTP response code (permanent failure) as bounce.
-    if ($code{0} === '5') {
+    if (isset($code{0}) && $code{0} === '5') {
       return FALSE;
     }
 

--- a/tests/phpunit/CRM/Mailing/BAO/MailingJobTest.php
+++ b/tests/phpunit/CRM/Mailing/BAO/MailingJobTest.php
@@ -1,0 +1,67 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5.4                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2018                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Class CRM_Mailing_BAO_MailingTest
+ * @group headless
+ */
+class CRM_Mailing_BAO_MailingJobTest extends CiviUnitTestCase {
+
+  /**
+   * Calls a protected method.
+   */
+  public static function callMethod($obj, $name, $args) {
+    $class = new ReflectionClass($obj);
+    $method = $class->getMethod($name);
+    $method->setAccessible(TRUE);
+    return $method->invokeArgs($obj, $args);
+  }
+
+  /**
+   * Tests CRM_Mailing_BAO_MailingJob::isTemporaryError() method.
+   */
+  public function testIsTemporaryError() {
+    $testcases[] = ['return' => TRUE, 'message' => 'Failed to set sender: test@example.org [SMTP: Invalid response code received from SMTP server while sending email. This is often caused by a misconfiguration in Outbound Email settings. Please verify the settings at Administer CiviCRM >> Global Settings >> Outbound Email (SMTP). (code: 421, response: Timeout waiting for data from client.)]'];
+    $testcases[] = ['return' => TRUE, 'message' => 'Failed to send data [SMTP: Invalid response code received from SMTP server while sending email. This is often caused by a misconfiguration in Outbound Email settings. Please verify the settings at Administer CiviCRM >> Global Settings >> Outbound Email (SMTP). (code: 454, response: Throttling failure: Maximum sending rate exceeded.)]'];
+    $testcases[] = ['return' => TRUE, 'message' => 'Failed to set sender: test@example.org [SMTP: Failed to write to socket: not connected (code: -1, response: )]'];
+    // @fixme: These errors also seem to be temporary, but are not yet handled as temporary.
+    $testcases[] = ['return' => FALSE, 'message' => 'Failed to connect to email.example.com:587 [SMTP: Failed to connect socket: Connection timed out (code: -1, response: )]'];
+    $testcases[] = ['return' => FALSE, 'message' => 'Failed to send data [SMTP: Invalid response code received from SMTP server while sending email. This is often caused by a misconfiguration in Outbound Email settings. Please verify the settings at Administer CiviCRM >> Global Settings >> Outbound Email (SMTP). (code: 554, response: Message rejected: Sending suspended for this account. For more information, please check the inbox of the email address associated with your AWS account.)]'];
+    $testcases[] = ['return' => FALSE, 'message' => 'authentication failure [SMTP: Invalid response code received from SMTP server while sending email.  This is often caused by a misconfiguration in Outbound Email settings. Please verify the settings at Administer CiviCRM >> Global Settings >> Outbound Email (SMTP). (code: 454, response: Temporary authentication failure)]'];
+    $object = new CRM_Mailing_BAO_MailingJob();
+    foreach ($testcases as $testcase) {
+      $isTemporaryError = self::callMethod($object, 'isTemporaryError', [$testcase['message']]);
+      if ($testcase['return']) {
+        $this->assertTrue($isTemporaryError);
+      }
+      else {
+        $this->assertFalse($isTemporaryError);
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Fixes support for sending mail directly to AWS SES via SMTP by detecting additional temporary failure modes.

Before
----------------------------------------
If the AWS account's SES rate limit is exceeded, SES responds with code: 454, response: "Throttling failure: Maximum sending rate exceeded," and CiviMail considers this message to have "bounced."

After
----------------------------------------
CiviMail will interpret non-5xx response not as a bounce, but rather as a temporary failure (logged and skipped). A 5xx response code, on the other hand, will be respected as a permanent failure and message will be considered bounced.

Technical Details
----------------------------------------
This is an extension of the logic provided by https://issues.civicrm.org/jira/browse/CRM-14799 and https://issues.civicrm.org/jira/browse/CRM-9191