### PR TITLE
CiviMail: If SMTP connection error is detected, disconnect so we can reconnect and retry

### DIFF
--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -608,6 +608,7 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
     $returnProperties = $mailing->getReturnProperties();
     $params = $targetParams = $deliveredParams = array();
     $count = 0;
+    $retryGroup = FALSE;
 
     // CRM-15702: Sending bulk sms to contacts without e-mail address fails.
     // Solution is to skip checking for on hold
@@ -694,9 +695,11 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
           CRM_Core_Error::debug_log_message("SMTP Socket Error or failed to set sender error. Message: $message, Code: $code");
 
           // these are socket write errors which most likely means smtp connection errors
-          // lets skip them
+          // lets skip them and reconnect.
           $smtpConnectionErrors++;
           if ($smtpConnectionErrors <= 5) {
+            $mailer->disconnect();
+            $retryGroup = TRUE;
             continue;
           }
 
@@ -785,6 +788,10 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
       $mailing,
       $job_date
     );
+
+    if ($retryGroup) {
+      return FALSE;
+    }
 
     return $result;
   }


### PR DESCRIPTION
Overview
----------------------------------------
If an SMTP connection error is detected, then we should disconnect so that a reconnect is possible. In addition, we'll need to retry any deliveries that had an SMTP error later on. Fixes https://issues.civicrm.org/jira/browse/CRM-20320

Before
----------------------------------------
Currently, if there is an SMTP timeout, multiple errors are logged (initially code: 421, response: Timeout waiting for data from client; followed by SMTP: Failed to write to socket: unknown error). After 6 such errors, CiviMail gives up sending mail.

After
----------------------------------------
When an SMTP connection error is detected, CiviMail should disconnect the SMTP connection so that a reconnect is possible on the next attempt. We also need to record the delivery group as not completed so it can be retried later.

Technical Details
----------------------------------------
With this change, Mailer Batch Limit can be set to 0, allowing mailings to be delivered continously as fast as possible, rather than stopping with an error condition and waiting for a new cron job to start.