### PR TITLE
core/issues/26 - CRM-21847 On behalf form fails to create new organisation

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -334,7 +334,9 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     }
     // if onbehalf-of-organization
     if (!empty($this->_values['onbehalf_profile_id']) && !empty($this->_params['onbehalf']['organization_name'])) {
-      $this->_params['organization_id'] = CRM_Utils_Array::value('onbehalfof_id', $this->_params);
+      if (empty($this->_params['org_option']) && empty($this->_params['organization_id'])) {
+        $this->_params['organization_id'] = CRM_Utils_Array::value('onbehalfof_id', $this->_params);
+      }
       $this->_params['organization_name'] = $this->_params['onbehalf']['organization_name'];
       $addressBlocks = array(
         'street_address',


### PR DESCRIPTION
Overview
----------------------------------------
Fix onbehalf profile to create new organisation from a contribution page.

Before
----------------------------------------
New organisation not created from on_behalf profile on a contribution page.

After
----------------------------------------
Works fine.

---------------------------------------

Gitlab Issue - https://lab.civicrm.org/dev/core/issues/26

---

 * [CRM-21847: Existing Organization getting updated instead creating a new organization - Contribution pages \( On behalf of \)](https://issues.civicrm.org/jira/browse/CRM-21847)