### PR TITLE
When adding a repeating rule to a new Event or Activity - the first repeat time always shows as 12am

### DIFF
--- a/CRM/Core/Page/RecurringEntityPreview.php
+++ b/CRM/Core/Page/RecurringEntityPreview.php
@@ -60,7 +60,11 @@ class CRM_Core_Page_RecurringEntityPreview extends CRM_Core_Page {
       }
 
       // Get original entity
-      $original[$startDateColumnName] = CRM_Utils_Date::processDate($formValues['repetition_start_date']);
+      $entityStartDateTime = $formValues['repetition_start_date'];
+      if (isset($formValues['repetition_start_date_time'])) {
+        $entityStartDateTime .= " " . $formValues['repetition_start_date_time'];
+      }
+      $original[$startDateColumnName] = CRM_Utils_Date::processDate($entityStartDateTime);
       $daoName = CRM_Core_BAO_RecurringEntity::$_tableDAOMapper[$formValues['entity_table']];
       if ($parentEventId) {
         $startDate = $original[$startDateColumnName] = CRM_Core_DAO::getFieldValue($daoName, $parentEventId, $startDateColumnName);


### PR DESCRIPTION
Overview
----------------------------------------
When adding a repeating rule to a new Event or Activity - the first repeat time always shows as 12am.

When an Event or Activity is created with repeats the correct times are saved - it only appears to affect the display of the first time on this particular screen.

Steps to reproduce would be:

1. Create a new Event or Activity and fill in the required fields
2. In the case of an event, save the event, then navigate to the repeat screen
3. add repetitions with a time other than 12 am
4. attempt to save, note that the first entry is 12 am, no matter what other value is specified

Before
----------------------------------------
First repeat time is always 12 AM on Confirm dates screen.

After
----------------------------------------
Repeat time of first activity/event is same as selected time for repetition.

_Agileware Ref: CIVICRM-810_