### PR TITLE
CRM-21849: Inline Relationship Type Edit

### DIFF
--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -539,7 +539,7 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
       $relationship->id = $relationshipId;
       if ($relationship->find(TRUE)) {
         $contact = new CRM_Contact_DAO_Contact();
-        $contact->id = ((int) $relationship->contact_id_a === $contactId) ? $relationship->contact_id_b : $relationship->contact_id_a;
+        $contact->id = ($relationship->contact_id_a == $contactId) ? $relationship->contact_id_b : $relationship->contact_id_a;
 
         if ($contact->find(TRUE)) {
           $otherContactType = $contact->contact_type;

--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -539,7 +539,7 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
       $relationship->id = $relationshipId;
       if ($relationship->find(TRUE)) {
         $contact = new CRM_Contact_DAO_Contact();
-        $contact->id = ($relationship->contact_id_a === $contactId) ? $relationship->contact_id_b : $relationship->contact_id_a;
+        $contact->id = ((int) $relationship->contact_id_a === $contactId) ? $relationship->contact_id_b : $relationship->contact_id_a;
 
         if ($contact->find(TRUE)) {
           $otherContactType = $contact->contact_type;

--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -2149,4 +2149,73 @@ AND cc.sort_name LIKE '%$name%'";
     return $relationshipsDT;
   }
 
+  /**
+   * @inheritdoc
+   */
+  public static function buildOptions($fieldName, $context = NULL, $props = array()) {
+    if ($fieldName === 'relationship_type_id') {
+      return self::buildRelationshipTypeOptions($props);
+    }
+
+    return parent::buildOptions($fieldName, $context, $props);
+  }
+
+  /**
+   * Builds a list of options available for relationship types
+   *
+   * @param array $params
+   *   - contact_type: Limits by contact type on the "A" side
+   *   - relationship_id: Used to find the value for contact type for "B" side.
+   *     If contact_a matches provided contact_id then type of contact_b will
+   *     be used. Otherwise uses type of contact_a. Must be used with contact_id
+   *   - contact_id: Limits by contact types of this contact on the "A" side
+   *   - is_form: Returns array with keys indexed for use in a quickform
+   *   - relationship_direction: For relationship types with duplicate names
+   *     on both sides, defines which option should be returned, a_b or b_a
+   *
+   * @return array
+   */
+  public static function buildRelationshipTypeOptions($params = array()) {
+    $contactId = CRM_Utils_Array::value('contact_id', $params);
+    $direction = CRM_Utils_Array::value('relationship_direction', $params, 'a_b');
+    $relationshipId = CRM_Utils_Array::value('relationship_id', $params);
+    $contactType = CRM_Utils_Array::value('contact_type', $params);
+    $isForm = CRM_Utils_Array::value('is_form', $params);
+    $showAll = FALSE;
+
+    // getContactRelationshipType will return an empty set if these are not set
+    if (!$contactId && !$relationshipId && !$contactType) {
+      $showAll = TRUE;
+    }
+
+    $labels = self::getContactRelationshipType(
+      $contactId,
+      $direction,
+      $relationshipId,
+      $contactType,
+      $showAll,
+      'label'
+    );
+
+    if ($isForm) {
+      return $labels;
+    }
+
+    $names = self::getContactRelationshipType(
+      $contactId,
+      $direction,
+      $relationshipId,
+      $contactType,
+      $showAll,
+      'name'
+    );
+
+    // ensure $names contains only entries in $labels
+    $names = array_intersect_key($names, $labels);
+
+    $nameToLabels = array_combine($names, $labels);
+
+    return $nameToLabels;
+  }
+
 }

--- a/CRM/Contact/Form/Relationship.php
+++ b/CRM/Contact/Form/Relationship.php
@@ -299,9 +299,6 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
     // Select list
     $relationshipList = CRM_Contact_BAO_Relationship::getContactRelationshipType($this->_contactId, $this->_rtype, $this->_relationshipId);
 
-    // Metadata needed on clientside
-    $this->assign('relationshipData', self::getRelationshipTypeMetadata($relationshipList));
-
     foreach ($this->_allRelationshipNames as $id => $vals) {
       if ($vals['name_a_b'] === 'Employee of') {
         $this->assign('employmentRelationship', $id);

--- a/CRM/Contact/Form/Relationship.php
+++ b/CRM/Contact/Form/Relationship.php
@@ -299,6 +299,8 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
     // Select list
     $relationshipList = CRM_Contact_BAO_Relationship::getContactRelationshipType($this->_contactId, $this->_rtype, $this->_relationshipId);
 
+    $this->assign('contactTypes', CRM_Contact_BAO_ContactType::contactTypeInfo(TRUE));
+
     foreach ($this->_allRelationshipNames as $id => $vals) {
       if ($vals['name_a_b'] === 'Employee of') {
         $this->assign('employmentRelationship', $id);

--- a/CRM/Contact/Form/Relationship.php
+++ b/CRM/Contact/Form/Relationship.php
@@ -309,7 +309,22 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
       }
     }
 
-    $this->addField('relationship_type_id', array('options' => array('' => ts('- select -')) + $relationshipList, 'class' => 'huge', 'placeholder' => '- select -'), TRUE);
+    $this->addField(
+      'relationship_type_id',
+      array(
+        'options' => array('' => ts('- select -')) + $relationshipList,
+        'class' => 'huge',
+        'placeholder' => '- select -',
+        'option_url' => 'civicrm/admin/reltype',
+        'option_context' => array(
+          'contact_id' => $this->_contactId,
+          'relationship_direction' => $this->_rtype,
+          'relationship_id' => $this->_relationshipId,
+          'is_form' => TRUE,
+        ),
+      ),
+      TRUE
+    );
 
     $label = $this->_action & CRM_Core_Action::ADD ? ts('Contact(s)') : ts('Contact');
     $contactField = $this->addField('related_contact_id', array('label' => $label, 'name' => 'contact_id_b', 'multiple' => TRUE, 'create' => TRUE), TRUE);

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -408,6 +408,12 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       }
     }
 
+    // Add context for the editing of option groups
+    if (isset($extra['option_context'])) {
+      $context = json_encode($extra['option_context']);
+      $element->setAttribute('data-option-edit-context', $context);
+    }
+
     return $element;
   }
 

--- a/api/v3/Generic.php
+++ b/api/v3/Generic.php
@@ -475,6 +475,13 @@ function _civicrm_api3_generic_getoptions_spec(&$params, $apiRequest) {
       }
     }
   }
+
+  $entityName = _civicrm_api_get_entity_name_from_camel($apiRequest['entity']);
+  $getOptionsSpecFunction = '_civicrm_api3_' . $entityName . '_getoptions_spec';
+
+  if (function_exists($getOptionsSpecFunction)) {
+    $getOptionsSpecFunction($params);
+  }
 }
 
 /**

--- a/api/v3/Relationship.php
+++ b/api/v3/Relationship.php
@@ -169,3 +169,53 @@ function civicrm_api3_relationship_setvalue($params) {
   }
   return $result;
 }
+
+function _civicrm_api3_relationship_getoptions_spec(&$params) {
+  $params['field']['options']['relationship_type_id'] = ts('Relationship Type ID');
+
+  // Add parameters for limiting relationship type ID
+  $relationshipTypePrefix = ts('(For relationship_type_id only) ');
+  $params['contact_id'] = [
+    'title' => ts('Contact ID'),
+    'description' => $relationshipTypePrefix . ts('Limits options to those'
+      . ' available to give contact'),
+    'type' => CRM_Utils_Type::T_INT,
+    'FKClassName' => 'CRM_Contact_DAO_Contact',
+    'FKApiName' => 'Contact',
+  ];
+  $params['relationship_direction'] = [
+    'title' => ts('Relationship Direction'),
+    'description' => $relationshipTypePrefix . ts('For relationships where the '
+      . 'name is the same for both sides (i.e. "Spouse Of") show the option '
+      . 'from "A" (origin) side or "B" (target) side of the relationship?'),
+    'type' => CRM_Utils_Type::T_STRING,
+    'options' => ['a_b' => 'a_b', 'b_a' => 'b_a'],
+    'api.default' => 'a_b',
+  ];
+  $params['relationship_id'] = [
+    'title' => ts('Reference Relationship ID'),
+    'description' => $relationshipTypePrefix . ts('If provided alongside '
+      . 'contact ID it will be used to establish the contact type of the "B" '
+      . 'side of the relationship and limit options based on it. If the '
+      . 'provided contact ID does not match the "A" side of this relationship '
+      . 'then the "A" side of this relationship will be used to limit options'),
+    'type' => CRM_Utils_Type::T_INT,
+    'FKClassName' => 'CRM_Contact_DAO_Relationship',
+    'FKApiName' => 'Relationship',
+  ];
+  $contactTypes = CRM_Contact_BAO_ContactType::contactTypes();
+  $params['contact_type'] = [
+    'title' => ts('Contact Type'),
+    'description' => $relationshipTypePrefix . ts('Limits options to those '
+    . 'available to this contact type. Overridden by the contact type of '
+    . 'contact ID (if provided)'),
+    'type' => CRM_Utils_Type::T_STRING,
+    'options' => array_combine($contactTypes, $contactTypes),
+  ];
+  $params['is_form'] = [
+    'title' => ts('Is Form?'),
+    'description' => $relationshipTypePrefix . ts('Formats the options for use'
+      . ' in a form if true. The format is &lt;id&gt;_a_b => &lt;label&gt;'),
+    'type' => CRM_Utils_Type::T_BOOLEAN
+  ];
+}

--- a/js/crm.optionEdit.js
+++ b/js/crm.optionEdit.js
@@ -30,10 +30,13 @@ jQuery(function($) {
    */
   function rebuildOptions($existing, rebuilder) {
     if ($existing.data('api-entity') && $existing.data('api-field')) {
-      CRM.api3($existing.data('api-entity'), 'getoptions', {
+      var params = {
         sequential: 1,
         field: $existing.data('api-field')
-      })
+      };
+      $.extend(params, $existing.data('option-edit-context'));
+
+      CRM.api3($existing.data('api-entity'), 'getoptions', params)
       .done(function(data) {
         rebuilder($existing, data.values);
       });

--- a/templates/CRM/Contact/Form/Relationship.tpl
+++ b/templates/CRM/Contact/Form/Relationship.tpl
@@ -185,7 +185,7 @@
             defer.resolve(relationshipData);
           }
 
-          CRM.api3("RelationshipType", "get")
+          CRM.api3("RelationshipType", "get", {"options": {"limit":0}})
             .done(function (data) {
               $.each(data.values, function (key, relType) {
                 // Loop over the suffixes for a relationship type

--- a/templates/CRM/Contact/Form/Relationship.tpl
+++ b/templates/CRM/Contact/Form/Relationship.tpl
@@ -146,7 +146,7 @@
           $form = $("form.{/literal}{$form.formClass}{literal}"),
           $relationshipTypeSelect = $('[name=relationship_type_id]', $form),
           relationshipData = {},
-          contactTypes = {};
+          contactTypes = {/literal}{$contactTypes|@json_encode}{literal};
 
         (function init () {
           // Refresh options if relationship types were edited
@@ -172,9 +172,7 @@
           // reset
           relationshipData = {};
 
-          return getContactTypes().then(function() {
-            return getRelationshipData();
-          });
+          return getRelationshipData();
         }
 
         /**
@@ -195,8 +193,8 @@
                   var subtype = relType["contact_subtype_" + suffix];
                   var type = subtype || relType["contact_type_" + suffix];
                   var label = getContactTypeLabel(type) || "Contact";
-                  var placeholder = "- select " + label.toLowerCase() + " -";
-                  relType["placeholder_" + suffix] = placeholder
+                  label = label.toLowerCase();
+                  relType["placeholder_" + suffix] = "- select " + label + " -";
                 });
 
                 relationshipData[relType["id"]] = relType;
@@ -223,23 +221,6 @@
           });
 
           return label;
-        }
-
-        /**
-         * Fetches contact types
-         */
-        function getContactTypes() {
-          var defer = $.Deferred();
-          if ($.isEmptyObject(contactTypes)) {
-            CRM.api3("ContactType", "get").done(function (data) {
-              contactTypes = data.values;
-              defer.resolve(contactTypes);
-            });
-          } else {
-            defer.resolve(contactTypes);
-          }
-
-          return defer.promise();
         }
 
         function updateSelect($select) {

--- a/templates/CRM/common/enableDisableApi.tpl
+++ b/templates/CRM/common/enableDisableApi.tpl
@@ -36,7 +36,13 @@
     }
 
     function refresh() {
-      $a.trigger('crmPopupFormSuccess');
+      // the opposite of the current status based on row class
+      var newStatus = $row.hasClass('disabled');
+      $a.trigger('crmPopupFormSuccess', {
+        'entity': info.entity,
+        'id': info.id,
+        'enabled': newStatus
+      });
       CRM.refreshParent($row);
     }
 

--- a/tests/phpunit/CRM/Contact/BAO/RelationshipTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/RelationshipTest.php
@@ -48,7 +48,100 @@ class CRM_Contact_BAO_RelationshipTest extends CiviUnitTestCase {
    * This method is called after a test is executed.
    */
   protected function tearDown() {
+    $this->quickCleanup([
+      'civicrm_relationship_type',
+      'civicrm_relationship',
+      'civicrm_contact'
+    ]);
+
     parent::tearDown();
+  }
+
+  public function testRelationshipTypeOptionsWillReturnSpecifiedType() {
+    $orgToOrgType = 'A_B_relationship';
+    $orgToOrgReverseType = 'B_A_relationship';
+    civicrm_api3('RelationshipType', 'create', [
+      'name_a_b' => $orgToOrgType,
+      'name_b_a' => $orgToOrgReverseType,
+      'contact_type_a' => 'Organization',
+      'contact_type_b' => 'Organization',
+    ]);
+
+    $result = CRM_Contact_BAO_Relationship::buildRelationshipTypeOptions(
+      ['contact_type' => 'Organization']
+    );
+    $this->assertContains($orgToOrgType, $result);
+    $this->assertContains($orgToOrgReverseType, $result);
+
+    $result = CRM_Contact_BAO_Relationship::buildRelationshipTypeOptions(
+      ['contact_type' => 'Individual']
+    );
+
+    $this->assertNotContains($orgToOrgType, $result);
+    $this->assertNotContains($orgToOrgReverseType, $result);
+  }
+
+  public function testContactIdAndRelationshipIdWillBeUsedInFilter() {
+    $individual = civicrm_api3('Contact', 'create', [
+      'display_name' => 'Individual A',
+      'contact_type' => 'Individual',
+    ]);
+    $organization = civicrm_api3('Contact', 'create', [
+      'organization_name' => 'Organization B',
+      'contact_type' => 'Organization',
+    ]);
+
+    $personToOrgType = 'A_B_relationship';
+    $orgToPersonType = 'B_A_relationship';
+
+    $orgToPersonTypeId = civicrm_api3('RelationshipType', 'create', [
+      'name_a_b' => $personToOrgType,
+      'name_b_a' => $orgToPersonType,
+      'contact_type_a' => 'Individual',
+      'contact_type_b' => 'Organization',
+    ])['id'];
+
+    $personToPersonType = 'A_B_alt_relationship';
+    $personToPersonReverseType = 'B_A_alt_relationship';
+
+    civicrm_api3('RelationshipType', 'create', [
+      'name_a_b' => $personToPersonType,
+      'name_b_a' => $personToPersonReverseType,
+      'contact_type_a' => 'Individual',
+      'contact_type_b' => 'Individual',
+    ]);
+
+    // create a relationship individual => organization
+    $relationship = civicrm_api3('Relationship', 'create', [
+      'contact_id_a' => $individual['id'],
+      'contact_id_b' => $organization['id'],
+      'relationship_type_id' => $orgToPersonTypeId,
+    ]);
+
+    $options = CRM_Contact_BAO_Relationship::buildRelationshipTypeOptions([
+      'relationship_id' => (string) $relationship['id'],
+       'contact_id' => $individual['id']
+    ]);
+
+    // for this relationship only individual=>organization is possible
+    $this->assertContains($personToOrgType, $options);
+    $this->assertNotContains($orgToPersonType, $options);
+
+    // by passing relationship ID we know that the "B" side is an organization
+    $this->assertNotContains($personToPersonType, $options);
+    $this->assertNotContains($personToPersonReverseType, $options);
+
+    $options = CRM_Contact_BAO_Relationship::buildRelationshipTypeOptions([
+      'contact_id' => $individual['id']
+    ]);
+
+    // for this result we only know that "A" must be an individual
+    $this->assertContains($personToOrgType, $options);
+    $this->assertNotContains($orgToPersonType, $options);
+
+    // unlike when we pass relationship type ID there is no filter by "B" type
+    $this->assertContains($personToPersonType, $options);
+    $this->assertContains($personToPersonReverseType, $options);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

To make it easier to edit relationship types this PR adds an icon to show a popup for inline editing of relationship types.

Before
----------------------------------------

It was not possible to edit relationship types inline. You had to go to the `civicrm/admin/reltype` screen

![image](https://user-images.githubusercontent.com/6374064/37725749-93b38d7a-2d2b-11e8-98f8-f125b21a1ca9.png)

Calls to `getoptions` for Relationship with field 'relationship_type_id` would result in:

```
{

    "is_error": 1,
    "error_message": "The field 'relationship_type_id' has no associated option list."
}
```

After
----------------------------------------

The relationship type dropdown has an icon to allow inline editing.

![peek 2018-03-21 17-13](https://user-images.githubusercontent.com/6374064/37725652-599f37f6-2d2b-11e8-95bd-164b1dde6a69.gif)

The Relationship `getoptions` endpoint supports `relationship_type_id`

![image](https://user-images.githubusercontent.com/6374064/37726504-72f4a7ac-2d2d-11e8-8e7d-5322d3574ce4.png)

Technical Details
----------------------------------------

- Spec functions for `getoptions` were ignored if the concrete spec function was not implemented. I wanted to modify the spec, but I didn't want to override the generic `getoptions` function. I modified the generic function to support custom spec functions.
- Relationship type comparison in the [Relationship BAO](https://github.com/civicrm/civicrm-core/compare/master...compucorp:CRM-21849-inline-relationship-type-edit#diff-7291ff5a1c2bb9adbc0da0929ae9f1d8R542) used strict comparison, even though one type was an int (according to doc-block) and the other (the BAO property) was a string, so I had to cast one to an int
- When refreshing the options for relationship types we can't show all types. The original list is added [here](https://github.com/civicrm/civicrm-core/blob/8c9251b398a29d9b82996ae21825c9d6478fa576/CRM/Contact/Form/Relationship.php#L300) and uses some parameters to filter it. In order to get the same list, I needed to pass these to the `getoptions` call done from [crm.optionEdit.js](https://github.com/civicrm/civicrm-core/blob/3ef93345f277ee729cec391e02c619d161f5caa7/js/crm.optionEdit.js#L31) so I introduced `option_context` to the elements. If it exists it will be set as a property of the element (along with the other metadata, such as `data-api-entity` and `data-api-field`, and it will be passed along to the `getoptions` call.
- The `relationshipData` was previously populated in the backend using `CRM_Contact_BAO_Relationship::getContactRelationshipType` but this means that it stays static. To allow dynamically recreating `relationshipData` (after editing etc.) the generation was switched to the frontend

---

 * [CRM-21849: Add Link To Edit Relationship Types](https://issues.civicrm.org/jira/browse/CRM-21849)