### PR TITLE
Escape custom group title.

### DIFF
--- a/templates/CRM/Profile/Page/MultipleRecordFieldsListing.tpl
+++ b/templates/CRM/Profile/Page/MultipleRecordFieldsListing.tpl
@@ -49,7 +49,7 @@
               {literal}
               <script type="text/javascript">
                 (function($) {
-                  var ZeroRecordText = {/literal}'{ts 1=$customGroupTitle}No records of type \'%1\' found.{/ts}'{literal};
+                  var ZeroRecordText = {/literal}'{ts 1=$customGroupTitle|escape}No records of type \'%1\' found.{/ts}'{literal};
                   var $table = $('#records-' + {/literal}'{$customGroupId}'{literal});
                   $('table.crm-multifield-selector').data({
                     "ajax": {


### PR DESCRIPTION
If the custom group title has an appostrophe then the js will break without this

Overview
----------------------------------------
Fixes a *very* obscure bug : when the Custom Group Title has an apostrophe in it the multiple tab display fails on a js error

Before
----------------------------------------

![screenshot 2018-03-22 13 20 52](https://user-images.githubusercontent.com/336308/37744409-dd9bf226-2dd3-11e8-9d00-17979538b7d5.png)


After
----------------------------------------
![screenshot 2018-03-22 13 21 47](https://user-images.githubusercontent.com/336308/37744432-003c61bc-2dd4-11e8-98e0-3ba22d9dbc49.png)


Technical Details
----------------------------------------
Smarty escaping escapes the appostrophe

Comments
----------------------------------------

