### PR TITLE
Fix ajax error on rendering multi custom data tab when field limit reached

### DIFF
--- a/CRM/Profile/Page/MultipleRecordFieldsListing.php
+++ b/CRM/Profile/Page/MultipleRecordFieldsListing.php
@@ -199,10 +199,10 @@ class CRM_Profile_Page_MultipleRecordFieldsListing extends CRM_Core_Page_Basic {
     elseif ($this->_pageViewType == 'customDataView') {
       // require custom group id for _pageViewType of customDataView
       $customGroupId = $this->_customGroupId;
+      $this->assign('customGroupId', $customGroupId);
       $reached = CRM_Core_BAO_CustomGroup::hasReachedMaxLimit($customGroupId, $this->_contactId);
       if (!$reached) {
         $this->assign('contactId', $this->_contactId);
-        $this->assign('customGroupId', $customGroupId);
         $this->assign('ctype', $this->_contactType);
       }
       $this->assign('reachedMax', $reached);


### PR DESCRIPTION
Overview
----------------------------------------
Multiple Custom data fields permit a limit to be set. When this limit is set and a contact has that many rows entered an ajax error will prevent the custom data tab from rendering


Before
----------------------------------------
![screenshot 2018-03-22 13 52 13](https://user-images.githubusercontent.com/336308/37747028-f152ec4e-2de1-11e8-8fdd-9524ee7ba632.png)


After
----------------------------------------
![screenshot 2018-03-22 14 24 15](https://user-images.githubusercontent.com/336308/37747034-f6ce6022-2de1-11e8-9874-88a6bf6874e2.png)


Technical Details
----------------------------------------
CRM_Contact_Page_View_CustomData::run() calls CRM_Profile_Page_MultipleRecordFieldsListing::run(). The latter function currently only assigns customGroupId to the tpl if the limit of rows to display has not been reached.

However, if the var is a required parameter for the ajax call that follow
s and without it the page does not render. There is no clue as to why it
is wrapped in the  if and changing it does
not cause problems in the follow on ajax call

CRM_Custom_Page_AJAX::getMultiRecordFieldList

The only other place this is called from is
CRM_Profile_Form::preProcess when
mode is not EDIT and gid is set

I managed to test this flow but creating a profile with a multiple field & using the url
http://dmaster.local/civicrm/profile/edit?gid=15&reset=1&contactId=5
However, I concluded it was broken with and without this patch - ie. despite records existing I see
![screenshot 2018-03-22 14 58 10](https://user-images.githubusercontent.com/336308/37746932-74e331f0-2de1-11e8-8895-fa934c006628.png)


Comments
----------------------------------------
_Anything else you would like the reviewer to note_
