### PR TITLE
Consolidate CustomData code into shared tpl

### DIFF
--- a/templates/CRM/Contact/Form/Edit/Address/CustomData.tpl
+++ b/templates/CRM/Contact/Form/Edit/Address/CustomData.tpl
@@ -31,17 +31,7 @@
             {$cd_edit.title}
         </div>
         <div>
-            {if $cd_edit.help_pre}
-                <div class="messages help">{$cd_edit.help_pre}</div>
-            {/if}
-            <table class="form-layout-compressed">
-                {foreach from=$cd_edit.fields item=element key=field_id}
-                  {assign var="element_name" value=$element.element_custom_name}
-                  {include file="CRM/Custom/Form/Edit/CustomField.tpl" formElement=$form.address.$blockId.$element_name}
-                {/foreach}
-            </table>
-            <div class="spacer"></div>
-            {if $cd_edit.help_post}<div class="messages help">{$cd_edit.help_post}</div>{/if}
+        {include file="CRM/Custom/Form/Edit/CustomData.tpl" customDataEntity='address'}
         </div>
     </div>
 

--- a/templates/CRM/Contact/Form/Edit/CustomData.tpl
+++ b/templates/CRM/Contact/Form/Edit/CustomData.tpl
@@ -38,21 +38,7 @@
     <div class="crm-accordion-header">
       {$cd_edit.title}
     </div>
-
     <div id="customData{$group_id}" class="crm-accordion-body">
-      {if $cd_edit.is_multiple eq 1}
-        {if $cd_edit.table_id}
-          <table class="no-border">
-            <tr>
-              <a href="#" class="crm-hover-button crm-custom-value-del" title="{ts 1=$cd_edit.title}Delete %1{/ts}"
-               data-post='{ldelim}"valueID": "{$tableID}", "groupID": "{$group_id}", "contactId": "{$contactId}", "key": "{crmKey name='civicrm/ajax/customvalue'}"{rdelim}'>
-                <span class="icon delete-icon"></span> {ts}Delete{/ts}
-              </a>
-              <!-- crm-submit-buttons -->
-            </tr>
-          </table>
-        {/if}
-      {/if}
       {include file="CRM/Custom/Form/CustomData.tpl" formEdit=true}
     </div>
     <!-- crm-accordion-body-->

--- a/templates/CRM/Custom/Form/CustomData.tpl
+++ b/templates/CRM/Custom/Form/CustomData.tpl
@@ -25,44 +25,18 @@
 *}
 {* Custom Data form*}
 {if $formEdit}
-  {if $cd_edit.help_pre}
-    <div class="messages help">{$cd_edit.help_pre}</div>
-  {/if}
-  <table class="form-layout-compressed">
-    {foreach from=$cd_edit.fields item=element key=field_id}
-      {assign var="element_name" value=$element.element_name}
-      {include file="CRM/Custom/Form/Edit/CustomField.tpl" formElement=$form.$element_name}
-    {/foreach}
-  </table>
-  <div class="spacer"></div>
-  {if $cd_edit.help_post}
-    <div class="messages help">{$cd_edit.help_post}</div>
-  {/if}
-  {if $cd_edit.is_multiple and ( ( $cd_edit.max_multiple eq '' )  or ( $cd_edit.max_multiple > 0 and $cd_edit.max_multiple > $cgCount ) ) }
-    <div id="add-more-link-{$cgCount}" class="add-more-link-{$group_id} add-more-link-{$group_id}-{$cgCount}">
-      <a href="#" class="crm-hover-button" onclick="CRM.buildCustomData('{$cd_edit.extends}',{if $cd_edit.subtype}'{$cd_edit.subtype}'{else}'{$cd_edit.extends_entity_column_id}'{/if}, '', {$cgCount}, {$group_id}, true ); return false;">
-        <i class="crm-i fa-plus-circle"></i>
-        {ts 1=$cd_edit.title}Another %1 record{/ts}
-      </a>
-    </div>
-  {/if}
+  {include file="CRM/Custom/Form/Edit/CustomData.tpl" customDataEntity=''}
 {else}
   {foreach from=$groupTree item=cd_edit key=group_id name=custom_sets}
     {if $cd_edit.is_multiple and $multiRecordDisplay eq 'single'}
+      {assign var="isSingleRecordEdit" value=TRUE}
+    {else}
+      {* always assign to prevent leakage*}
+      {assign var="isSingleRecordEdit" value=''}
+    {/if}
+    {if $isSingleRecordEdit}
       <div class="custom-group custom-group-{$cd_edit.name}">
-        {if $cd_edit.help_pre}
-          <div class="messages help">{$cd_edit.help_pre}</div>
-        {/if}
-        <table>
-          {foreach from=$cd_edit.fields item=element key=field_id}
-            {assign var="element_name" value=$element.element_name}
-            {include file="CRM/Custom/Form/Edit/CustomField.tpl" formElement=$form.$element_name}
-          {/foreach}
-        </table>
-        <div class="spacer"></div>
-        {if $cd_edit.help_post}
-          <div class="messages help">{$cd_edit.help_post}</div>
-        {/if}
+        {include file="CRM/Custom/Form/Edit/CustomData.tpl" customDataEntity=''}
       </div>
     {else}
      <div class="custom-group custom-group-{$cd_edit.name} crm-accordion-wrapper crm-custom-accordion {if $cd_edit.collapse_display and !$skipTitle}collapsed{/if}">
@@ -72,43 +46,9 @@
        </div><!-- /.crm-accordion-header -->
       {/if}
       <div class="crm-accordion-body">
-        {if $cd_edit.is_multiple eq 1 and $cd_edit.table_id and $contactId and !$skipTitle and $cd_edit.style eq 'Inline'}
-          {assign var=tableID value=$cd_edit.table_id}
-          <a href="#" class="crm-hover-button crm-custom-value-del" title="{ts 1=$cd_edit.title}Delete %1{/ts}"
-           data-post='{ldelim}"valueID": "{$tableID}", "groupID": "{$group_id}", "contactId": "{$contactId}", "key": "{crmKey name='civicrm/ajax/customvalue'}"{rdelim}'>
-            <span class="icon delete-icon"></span> {ts}Delete{/ts}
-          </a>
-        {/if}
-        {if $cd_edit.help_pre}
-          <div class="messages help">{$cd_edit.help_pre}</div>
-        {/if}
-        <table class="form-layout-compressed">
-          {foreach from=$cd_edit.fields item=element key=field_id}
-            {assign var="element_name" value=$element.element_name}
-            {include file="CRM/Custom/Form/Edit/CustomField.tpl" formElement=$form.$element_name}
-          {/foreach}
-        </table>
-        <div class="spacer"></div>
-        {if $cd_edit.help_post}
-          <div class="messages help">{$cd_edit.help_post}</div>
-        {/if}
+        {include file="CRM/Custom/Form/Edit/CustomData.tpl" customDataEntity=''}
       </div>
      </div>
-     {if $cd_edit.is_multiple and ( ( $cd_edit.max_multiple eq '' )  or ( $cd_edit.max_multiple > 0 and $cd_edit.max_multiple > $cgCount ) ) }
-      {if $skipTitle}
-        {* We don't yet support adding new records in inline-edit forms *}
-        <div class="messages help">
-          <em>{ts 1=$cd_edit.title}Click "Edit Contact" to add more %1 records{/ts}</em>
-        </div>
-      {else}
-        <div id="add-more-link-{$cgCount}" class="add-more-link-{$group_id} add-more-link-{$group_id}-{$cgCount}">
-          <a href="#" class="crm-hover-button" onclick="CRM.buildCustomData('{$cd_edit.extends}',{if $cd_edit.subtype}'{$cd_edit.subtype}'{else}'{$cd_edit.extends_entity_column_id}'{/if}, '', {$cgCount}, {$group_id}, true ); return false;">
-            <i class="crm-i fa-plus-circle"></i>
-            {ts 1=$cd_edit.title}Another %1 record{/ts}
-          </a>
-        </div>
-      {/if}
-    {/if}
     {/if}
     <div id="custom_group_{$group_id}_{$cgCount}"></div>
   {/foreach}

--- a/templates/CRM/Custom/Form/Edit/CustomData.tpl
+++ b/templates/CRM/Custom/Form/Edit/CustomData.tpl
@@ -1,0 +1,45 @@
+{if !$isSingleRecordEdit && $cd_edit.is_multiple eq 1 and $cd_edit.table_id and $contactId and !$skipTitle and $cd_edit.style eq 'Inline'}
+  {assign var=tableID value=$cd_edit.table_id}
+  <a href="#" class="crm-hover-button crm-custom-value-del" title="{ts 1=$cd_edit.title}Delete %1{/ts}"
+     data-post='{ldelim}"valueID": "{$tableID}", "groupID": "{$group_id}", "contactId": "{$contactId}", "key": "{crmKey name='civicrm/ajax/customvalue'}"{rdelim}'>
+    <span class="icon delete-icon"></span> {ts}Delete{/ts}
+  </a>
+{/if}
+
+{if $cd_edit.help_pre}
+  <div class="messages help">{$cd_edit.help_pre}</div>
+{/if}
+<table {if !$isSingleRecordEdit}class="form-layout-compressed"{/if}>
+  {foreach from=$cd_edit.fields item=element key=field_id}
+    {if $customDataEntity && $blockId}
+      {* custom data entity combined with blockId tells us we have an entity with mutliple blocks
+      such as address. Some risk of leakage on blockId so only set customDataEntity when using blocks*}
+      {assign var="element_name" value=$element.element_custom_name}
+      {assign var="formElement" value=$form.$customDataEntity.$blockId.$element_name}
+    {else}
+      {assign var="element_name" value=$element.element_name}
+      {assign var="formElement" value=$form.$element_name}
+    {/if}
+    {include file="CRM/Custom/Form/Edit/CustomField.tpl"}
+  {/foreach}
+</table>
+<div class="spacer"></div>
+{if $cd_edit.help_post}<div class="messages help">{$cd_edit.help_post}</div>{/if}
+{if !$isSingleRecordEdit && $cd_edit.is_multiple and ( ( $cd_edit.max_multiple eq '' )  or ( $cd_edit.max_multiple > 0 and $cd_edit.max_multiple > $cgCount ) ) }
+  {if $skipTitle}
+    {* We don't yet support adding new records in inline-edit forms *}
+    <div class="messages help">
+      <em>{ts 1=$cd_edit.title}Click "Edit Contact" to add more %1 records{/ts}</em>
+    </div>
+  {else}
+    <div id="add-more-link-{$cgCount}" class="add-more-link-{$group_id} add-more-link-{$group_id}-{$cgCount}">
+      <a href="#" class="crm-hover-button" onclick="CRM.buildCustomData('{$cd_edit.extends}',{if $cd_edit.subtype}'{$cd_edit.subtype}'{else}'{$cd_edit.extends_entity_column_id}'{/if}, '', {$cgCount}, {$group_id}, true ); return false;">
+        <i class="crm-i fa-plus-circle"></i>
+        {ts 1=$cd_edit.title}Another %1 record{/ts}
+      </a>
+    </div>
+  {/if}
+{/if}
+
+{*set customDataEntity to null to prevent leakage if this is called more than once*}
+{assign var='customDataEntity' value=''}


### PR DESCRIPTION
Overview
----------------------------------------
There is a lot of code replication rendering custom data fields. In preparation for exposing for more entities I am consolidating the template files 

Before
----------------------------------------


After
----------------------------------------
No change - but adding screenshots to show...
![screenshot 2018-03-22 19 34 01](https://user-images.githubusercontent.com/336308/37754829-07741cca-2e08-11e8-80f5-c32f0a502df0.png)
![screenshot 2018-03-22 19 34 41](https://user-images.githubusercontent.com/336308/37754853-1abc6f26-2e08-11e8-911f-cb3ffa0be21a.png)
![screenshot 2018-03-22 19 34 46](https://user-images.githubusercontent.com/336308/37754858-1f1109ec-2e08-11e8-8a8b-206598294cfa.png)
![screenshot 2018-03-22 19 35 55](https://user-images.githubusercontent.com/336308/37754900-4848568a-2e08-11e8-8758-e300ddfc101e.png)
![screenshot 2018-03-22 19 36 06](https://user-images.githubusercontent.com/336308/37754902-4c4042fc-2e08-11e8-8684-e963df6f3877.png)


Technical Details
----------------------------------------
 The only change that I found in function was that the delete icon was originally in a
 table on contact edit but afterwards it was not. However the UI looked the same - ie the table in got stripped - this shows up when using the contact edit form & there is a delete icon - ie the below is 'after'
```
-          <table class="no-border">
-            <tr>
-              <a href="#" class="crm-hover-button crm-custom-value-del" title="{ts 1=$cd_edit.title}Delete %1{/ts}"
-               data-post='{ldelim}"valueID": "{$tableID}", "groupID": "{$group_id}", "contactId": "{$contactId}", "key": "{crmKey name='civicrm/ajax/customvalue'}"{rdelim}'>
-                <span class="icon delete-icon"></span> {ts}Delete{/ts}
-              </a>
-              <!-- crm-submit-buttons -->
-            </tr>
-          </table>
```
![screenshot 2018-03-22 19 33 02](https://user-images.githubusercontent.com/336308/37754783-db282c7e-2e07-11e8-88ea-d487ca8cdbc2.png)

Comments
----------------------------------------
@jitendrapurohit @mattwire ping