### PR TITLE
[nfc] Add test for thousand separators on import

### DIFF
--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -256,14 +256,8 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Contribute_Import_Pa
     }
 
     $params = &$this->getActiveFieldParams();
-    $formatted = array('version' => 3);
-
-    // don't add to recent items, CRM-4399
-    $formatted['skipRecentView'] = TRUE;
-
-    //for date-Formats
-    $session = CRM_Core_Session::singleton();
-    $dateType = $session->get('dateTypes');
+    $formatted = ['version' => 3, 'skipRecentView' => TRUE, 'skipCleanMoney' => FALSE];
+    $dateType = CRM_Core_Session::singleton()->get('dateTypes');
 
     $customDataType = !empty($params['contact_type']) ? $params['contact_type'] : 'Contribution';
     $customFields = CRM_Core_BAO_CustomField::getFields($customDataType);

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
@@ -99,7 +99,7 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
    */
   public function testSupportFinancialTypeChange() {
     $contributionRecur = $this->callAPISuccess('contribution_recur', 'create', $this->_params);
-    $this->callAPISuccess('contribution', 'create', array(
+    $this->callAPISuccess('Contribution', 'create', array(
       'contribution_recur_id' => $contributionRecur['id'],
       'total_amount' => '3.00',
       'financial_type_id' => 1,

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -22,9 +22,14 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
    *
    * In this case primary contact and secondary contact both are identified by external identifier.
    *
+   * @dataProvider getThousandSeparators
+   *
+   * @param string $thousandSeparator
+   *
    * @throws \Exception
    */
-  public function testImportParserWithSoftCreditsByExternalIdentifier() {
+  public function testImportParserWithSoftCreditsByExternalIdentifier($thousandSeparator) {
+    $this->setCurrencySeparators($thousandSeparator);
     $contact1Params = array(
       'first_name' => 'Contact',
       'last_name' => 'One',
@@ -40,7 +45,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
     $contact1Id = $this->individualCreate($contact1Params);
     $contact2Id = $this->individualCreate($contact2Params);
     $values = array(
-      "total_amount" => 10,
+      "total_amount" => $this->formatMoneyInput(1230.99),
       "financial_type" => "Donation",
       "external_identifier" => "ext-1",
       "soft_credit" => "ext-2",
@@ -53,6 +58,10 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
     );
     $values = array();
     $contributionsOfMainContact = CRM_Contribute_BAO_Contribution::retrieve($params, $values, $values);
+    $this->assertEquals(1230.99, $contributionsOfMainContact->total_amount);
+    $this->assertEquals(1230.99, $contributionsOfMainContact->net_amount);
+    $this->assertEquals(0, $contributionsOfMainContact->fee_amount);
+
     $params["contact_id"] = $contact2Id;
     $contributionsOfSoftContact = CRM_Contribute_BAO_ContributionSoft::retrieve($params, $values);
     $this->assertEquals(1, count($contributionsOfMainContact), 'Contribution not added for primary contact');


### PR DESCRIPTION
Overview
----------------------------------------
Add unit test to ensure thousand separators are parsed on import correctly

Before
----------------------------------------
No test

After
----------------------------------------
Test

Technical Details
----------------------------------------
There are no functional changes outside the test. SkipCleanMoney is declared explicitly - which is my current recommendation for the Contribution api.

Comments
----------------------------------------

