### PR TITLE
Fix bugs with hook params, functionality on contact searches

### DIFF
--- a/CRM/Core/Task.php
+++ b/CRM/Core/Task.php
@@ -82,7 +82,7 @@ abstract class CRM_Core_Task {
    *            ]
    */
   public static function tasks() {
-    CRM_Utils_Hook::searchTasks(self::$objectType, self::$_tasks);
+    CRM_Utils_Hook::searchTasks(static::$objectType, self::$_tasks);
     asort(self::$_tasks);
 
     return self::$_tasks;

--- a/CRM/Core/Task.php
+++ b/CRM/Core/Task.php
@@ -172,8 +172,8 @@ abstract class CRM_Core_Task {
     static::tasks();
 
     if (!CRM_Utils_Array::value($value, self::$_tasks)) {
-      // Children can specify a default task (eg. print), we don't here
-      return array();
+      // Children can specify a default task (eg. print), pick another if it is not valid.
+      $value = key(self::$_tasks);
     }
     return array(
       CRM_Utils_Array::value('class', self::$_tasks[$value]),


### PR DESCRIPTION
Overview
----------------------------------------
Fix issue with entity not passed to hook (also fixes CRM-21841 ).
Fix tangental issue where screen does not load if default task is removed  per https://github.com/civicrm/civicrm-core/pull/11596#issuecomment-374378686

Before
----------------------------------------
$objectType Not passed to hook civicrm_searchTasks

After
----------------------------------------
$objectType passed to hook civicrm_searchTasks

Technical Details
----------------------------------------
The self::objectType is passing NULL - the object type on the parent.

Switching to static::objectType uses the child.

https://stackoverflow.com/questions/1912902/what-exactly-are-late-static-bindings-in-php
Comments
----------------------------------------
@mattwire ping

---

 * [CRM-21841: objectType empty in hook_civicrm_searchTasks](https://issues.civicrm.org/jira/browse/CRM-21841)