### PR TITLE
Tweak layout on contribution view screen to make payments clearer

### DIFF
--- a/CRM/Contribute/Form/ContributionView.php
+++ b/CRM/Contribute/Form/ContributionView.php
@@ -249,6 +249,7 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
       $this->assign('componentId', $id);
       $this->assign('component', 'contribution');
     }
+    $this->assignPaymentInfoBlock($id);
   }
 
   /**
@@ -264,6 +265,29 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
         'isDefault' => TRUE,
       ),
     ));
+  }
+
+  /**
+   * Assign the values to build the payment info block.
+   *
+   * @todo - this is a bit too much copy & paste from AbstractEditPayment
+   * (justifying on the basis it's 'pretty short' and in a different inheritance
+   * tree. I feel like traits are probably the longer term answer).
+   *
+   * @param int $id
+   *
+   * @return string $title
+   *   Block title.
+   */
+  protected function assignPaymentInfoBlock($id) {
+    // component is used in getPaymentInfo primarily to retrieve the contribution id, we
+    // already have that.
+    $paymentInfo = CRM_Contribute_BAO_Contribution::getPaymentInfo($id, 'contribution', TRUE);
+    $title = ts('View Payment');
+    $this->assign('transaction', TRUE);
+    $this->assign('payments', $paymentInfo['transaction']);
+    $this->assign('paymentLinks', $paymentInfo['payment_links']);
+    return $title;
   }
 
 }

--- a/templates/CRM/Contribute/Form/ContributionView.tpl
+++ b/templates/CRM/Contribute/Form/ContributionView.tpl
@@ -90,10 +90,7 @@
   {else}
     <tr>
       <td class="label">{ts}Total Amount{/ts}</td>
-      <td><strong><a class="nowrap bold crm-expand-row" title="{ts}view payments{/ts}"
-        href="{crmURL p='civicrm/payment' q="view=transaction&component=contribution&action=browse&cid=`$contact_id`&id=`$contribution_id`&selector=1"}">
-               &nbsp; {$total_amount|crmMoney:$currency}
-            </strong></a>&nbsp;
+      <td><strong>{$total_amount|crmMoney:$currency}</strong>
         {if $contribution_recur_id}
           <a class="crm-hover-button" href='{crmURL p="civicrm/contact/view/contributionrecur" q="reset=1&id=`$contribution_recur_id`&cid=`$contact_id`&context=contribution"}'>
             <strong>{ts}Recurring Contribution{/ts}</strong>
@@ -239,9 +236,13 @@
       <td>{$thankyou_date|crmDate}</td>
     </tr>
   {/if}
+  <tr>
+    <td class="label">{ts}Payment Details{/ts}</td>
+    <td>{include file="CRM/Contribute/Form/PaymentInfoBlock.tpl"}</td>
+  </tr>
   {if $addRecordPayment}
     <tr>
-      <td class='label'>{ts}Fees{/ts}</td>
+      <td class='label'>{ts}Payment Summary{/ts}</td>
       <td id='payment-info'></td>
     </tr>
   {/if}

--- a/templates/CRM/Contribute/Page/PaymentInfo.tpl
+++ b/templates/CRM/Contribute/Page/PaymentInfo.tpl
@@ -55,7 +55,7 @@ CRM.$(function($) {
     {if $component eq "event"}
       <th>{ts}Total Fee(s){/ts}</th>
     {else}
-      <th>{ts}Contribution Amount(s){/ts}</th>
+      <th>{ts}Contribution Total{/ts}</th>
     {/if}
     <th class="right">{ts}Total Paid{/ts}</th>
     <th class="right">{ts}Balance{/ts}</th>


### PR DESCRIPTION
Overview
----------------------------------------
Per discussion on dev - move payment block within the view screen to clarify payments vs line items

Before
----------------------------------------
![screenshot 2018-03-23 01 54 20](https://user-images.githubusercontent.com/336308/37771694-3bb5e812-2e3d-11e8-9a31-7deb21d5ab12.png)
![screenshot 2018-03-23 01 54 32](https://user-images.githubusercontent.com/336308/37771697-41f84512-2e3d-11e8-8575-5ec5d8819bdb.png)



After
----------------------------------------
![screenshot 2018-03-23 01 57 49](https://user-images.githubusercontent.com/336308/37771806-9e75038e-2e3d-11e8-87fb-1831258874ce.png)




Technical Details
----------------------------------------
This is just a re-organisation of existing blocks on the screen

Comments
----------------------------------------
I also tried ....
![screenshot 2018-03-23 01 41 59](https://user-images.githubusercontent.com/336308/37771853-c0622c56-2e3d-11e8-8390-153064b600f2.png)

