### PR TITLE
Fix Core/Dev 18# where logging fails if the AUTO INCREMENT column is …

### DIFF
--- a/tests/phpunit/CRM/Logging/SchemaTest.php
+++ b/tests/phpunit/CRM/Logging/SchemaTest.php
@@ -12,6 +12,10 @@ class CRM_Logging_SchemaTest extends CiviUnitTestCase {
 
   public function tearDown() {
     parent::tearDown();
+    $schema = new CRM_Logging_Schema();
+    $schema->disableLogging();
+    $schema->dropAllLogTables();
+    CRM_Core_DAO::executeQuery("DROP TABLE IF EXISTS civicrm_test_table");
   }
 
   public function queryExamples() {
@@ -37,8 +41,43 @@ class CRM_Logging_SchemaTest extends CiviUnitTestCase {
     while ($log_table->fetch()) {
       $this->assertRegexp('/ENGINE=ARCHIVE/', $log_table->Create_Table);
     }
-    $schema->disableLogging();
-    $schema->dropAllLogTables();
+  }
+
+  public function testAutoIncrementNonIdColumn() {
+    CRM_Core_DAO::executeQuery("CREATE TABLE `civicrm_test_table` (
+      test_id  int(10) unsigned NOT NULL AUTO_INCREMENT,
+      PRIMARY KEY (`test_id`)
+    )  ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci");
+    $schema = new CRM_Logging_Schema();
+    $schema->enableLogging();
+    $diffs = $schema->columnsWithDiffSpecs("civicrm_test_table", "log_civicrm_test_table");
+    // Test that just havving a non id nanmed column with Auto Increment doesn't create diffs
+    $this->assertTrue(empty($diffs['MODIFY']));
+    $this->assertTrue(empty($diffs['ADD']));
+    $this->assertTrue(empty($diffs['OBSOLETE']));
+    CRM_Core_DAO::executeQuery("ALTER TABLE civicrm_test_table ADD COLUMN test_varchar varchar(255) DEFAULT NULL");
+    \Civi::$statics['CRM_Logging_Schema']['columnSpecs'] = array();
+    // Check that it still picks up new columns added.
+    $diffs = $schema->columnsWithDiffSpecs("civicrm_test_table", "log_civicrm_test_table");
+    $this->assertTrue(!empty($diffs['ADD']));
+    $this->assertTrue(empty($diffs['MODIFY']));
+    $this->assertTrue(empty($diffs['OBSOLETE']));
+    $schema->fixSchemaDifferences();
+    CRM_Core_DAO::executeQuery("ALTER TABLE civicrm_test_table CHANGE COLUMN test_varchar test_varchar varchar(400) DEFAULT NULL");
+    // Check that it properly picks up modifications to columns.
+    \Civi::$statics['CRM_Logging_Schema']['columnSpecs'] = array();
+    $diffs = $schema->columnsWithDiffSpecs("civicrm_test_table", "log_civicrm_test_table");
+    $this->assertTrue(!empty($diffs['MODIFY']));
+    $this->assertTrue(empty($diffs['ADD']));
+    $this->assertTrue(empty($diffs['OBSOLETE']));
+    $schema->fixSchemaDifferences();
+    CRM_Core_DAO::executeQuery("ALTER TABLE civicrm_test_table CHANGE COLUMN test_varchar test_varchar varchar(300) DEFAULT NULL");
+    // Check that when we reduce the size of column that the log table doesn't shrink as well.
+    \Civi::$statics['CRM_Logging_Schema']['columnSpecs'] = array();
+    $diffs = $schema->columnsWithDiffSpecs("civicrm_test_table", "log_civicrm_test_table");
+    $this->assertTrue(empty($diffs['MODIFY']));
+    $this->assertTrue(empty($diffs['ADD']));
+    $this->assertTrue(empty($diffs['OBSOLETE']));
   }
 
 }


### PR DESCRIPTION
…not named id and add tests

Overview
----------------------------------------
Previously if a table that was captured by the Log table creation regex that named its AUTO INCREMENT column something other than id there would be database errors generated as it tried to reconcile the log table schema with the current schema because it didn't do any proper handling for AUTO INCREMENT columns

Before
----------------------------------------
DB Errors generated when reconciling schema

After
----------------------------------------
No DB errors

ping @agileware @eileenmcnaughton @JoeMurray 

I think this makes sense the case that showed this up is enabling the civicrm membership role sync and then turning on detailed logging. Then proceeding to do a CiviCRM upgrade and it fails as it tries to reconcile the log tables to the main table and in this function unlike the  function that initially creates the tables there was no special handling for AUTO INCREMENT