### PR TITLE
CRM-20922 fix support for passing custom date values via url

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1726,19 +1726,7 @@ ORDER BY civicrm_custom_group.weight,
             }
           }
           elseif ($field['data_type'] == 'Date') {
-            if (!empty($value)) {
-              $time = NULL;
-              if (!empty($field['time_format'])) {
-                $time = CRM_Utils_Request::retrieve($fieldName .
-                  '_time', 'String', $form, FALSE, NULL, 'GET');
-              }
-              list($value, $time) = CRM_Utils_Date::setDateDefaults($value .
-                ' ' . $time);
-              if (!empty($field['time_format'])) {
-                $customValue[$fieldName . '_time'] = $time;
-              }
-            }
-            $valid = TRUE;
+            $valid = CRM_Utils_Rule::date($value);
           }
 
           if ($valid) {

--- a/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
@@ -613,4 +613,47 @@ class CRM_Core_BAO_CustomGroupTest extends CiviUnitTestCase {
     $this->customGroupDelete($customGroup['id']);
   }
 
+  /**
+   * Test that passed dates are extracted from the url when processing custom data.
+   */
+  public function testExtractGetParamsReturnsDates() {
+    // Create a custom group to contain the custom field.
+    $groupParams = array(
+      'title' => 'My Custom Group',
+      'name' => 'my_custom_group',
+      'extends' => 'Individual',
+      'is_active' => 1,
+      'collapse_display' => 1,
+    );
+    $customGroup = $this->customGroupCreate($groupParams);
+    $customGroupId = $customGroup['id'];
+
+    // Create teh custom field.
+    $fieldParams = array(
+      'custom_group_id' => $customGroupId,
+      'label' => 'My Custom Date Field',
+      'html_type' => 'Select Date',
+      'data_type' => 'Date',
+      'is_required' => 1,
+      'is_searchable' => 0,
+      'is_active' => 1,
+      'default_value' => '',
+    );
+    $customField = $this->customFieldCreate($fieldParams);
+    $customFieldId = $customField['id'];
+
+    // Create a form object. CRM_Core_BAO_CustomGroup::extractGetParams() will
+    // need this, along with the REQUEST_METHOD and controller too.
+    $form = new CRM_Contribute_Form_Contribution();
+    $_SERVER['REQUEST_METHOD'] = 'GET';
+    $form->controller = new CRM_Core_Controller();
+
+    // Set the value in $_GET, then extract query string params with
+    $fieldName = 'custom_' . $customFieldId;
+    $_GET[$fieldName] = '2017-06-13';
+    $extractedGetParams = CRM_Core_BAO_CustomGroup::extractGetParams($form, 'Individual');
+
+    $this->assertEquals($extractedGetParams[$fieldName], '2017-06-13');
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Re-instate support for passing custom date data via a url

Before
----------------------------------------
Passing a pre-fill value for a custom date via a url does not 'work'

eg.
http://dmaster.local/civicrm/contribute/transact?reset=1&id=1&custom_3=2010-09-03

After
----------------------------------------
Custom Date in url does work - from the url this has populated
![screenshot 2018-03-23 21 01 47](https://user-images.githubusercontent.com/336308/37817972-71f2f410-2edd-11e8-8324-dbc8457d9cfd.png)

(I tested with an invalid date & it didn't prefill)

Technical Details
----------------------------------------
@twomice  - this is a reviewer's cut of your PR #10702 - the key difference is I have re-instated support but only for the iso format in the url. This is simpler to maintain & after the big break in this working it feels Ok to change the format to something easier to support

Comments
----------------------------------------
I took your test & slightly tweaked it to use the different format. Please check you are OK with my tweaked version & I will merge based on your confirmation.

---

 * [CRM-20922: Can't set default value via URL query string, for custom date fields](https://issues.civicrm.org/jira/browse/CRM-20922)