### PR TITLE
CRM-20632: Exporting Contacts using "Export PRIMARY fields" and "Merge Household  Members into their Households" produces db error

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -4713,10 +4713,11 @@ civicrm_relationship.is_permission_a_b = 0
    * @param array $selectClauses
    * @param array $groupBy - Columns already included in GROUP By clause.
    * @param string $aggregateFunction
+   * @param bool $appendAlias - Append select column alias as it's name itself
    *
    * @return string
    */
-  public static function appendAnyValueToSelect($selectClauses, $groupBy, $aggregateFunction = 'ANY_VALUE') {
+  public static function appendAnyValueToSelect($selectClauses, $groupBy, $aggregateFunction = 'ANY_VALUE', $appendAlias = FALSE) {
     if (!CRM_Utils_SQL::disableFullGroupByMode()) {
       $groupBy = array_map('trim', (array) $groupBy);
       $aggregateFunctions = '/(ROUND|AVG|COUNT|GROUP_CONCAT|SUM|MAX|MIN|IF)[[:blank:]]*\(/i';
@@ -4727,6 +4728,7 @@ civicrm_relationship.is_permission_a_b = 0
           $val = ($aggregateFunction == 'GROUP_CONCAT') ?
             str_replace($selectColumn, "$aggregateFunction(DISTINCT {$selectColumn})", $val) :
             str_replace($selectColumn, "$aggregateFunction({$selectColumn})", $val);
+          $val .= $appendAlias ? " as $selectColumn " : '';
         }
       }
     }

--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -2048,8 +2048,6 @@ WHERE  {$whereClause}";
       else {
         $fieldValue = '';
       }
-      $field = $field . '_';
-      $relPrefix = $field . $relationField;
 
       if (is_object($relDAO) && $relationField == 'id') {
         $row[$relPrefix][$relationField] = $relDAO->contact_id;
@@ -2066,7 +2064,7 @@ WHERE  {$whereClause}";
             // and state_province (‘province’ context)
             switch (TRUE) {
               case (!is_object($relDAO)):
-                $row[$relPrefix . '_' . $fldValue] = '';
+                $row[$relPrefix][$fldValue] = '';
                 break;
 
               case in_array('country', $type):

--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -567,6 +567,8 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
     $query->_sort = $order;
     list($select, $from, $where, $having) = $query->query();
 
+    $allRelContactArray = $relationQuery = $relationType = array();
+
     if ($mergeSameHousehold == 1) {
       if (empty($returnProperties['id'])) {
         $returnProperties['id'] = 1;
@@ -575,6 +577,10 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
       //also merge Head of Household
       $relationKeyMOH = CRM_Utils_Array::key('Household Member of', $contactRelationshipTypes);
       $relationKeyHOH = CRM_Utils_Array::key('Head of Household for', $contactRelationshipTypes);
+      $relationType = [
+        $relationKeyMOH => NULL,
+        $relationKeyHOH => NULL,
+      ];
 
       foreach ($returnProperties as $key => $value) {
         if (!array_key_exists($key, $contactRelationshipTypes)) {
@@ -588,8 +594,6 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
       unset($returnProperties[$relationKeyHOH]['location_type']);
       unset($returnProperties[$relationKeyHOH]['im_provider']);
     }
-
-    $allRelContactArray = $relationQuery = array();
 
     foreach ($contactRelationshipTypes as $rel => $dnt) {
       if ($relationReturnProperties = CRM_Utils_Array::value($rel, $returnProperties)) {
@@ -784,7 +788,6 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
 
         //first loop through output columns so that we return what is required, and in same order.
         foreach ($outputColumns as $field => $value) {
-
           // add im_provider to $dao object
           if ($field == 'im_provider' && property_exists($iterationDAO, 'provider_id')) {
             $iterationDAO->im_provider = $iterationDAO->provider_id;
@@ -826,6 +829,9 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
             $row[$field] = $iterationDAO->pledge_next_pay_amount + $iterationDAO->pledge_outstanding_amount;
           }
           elseif (array_key_exists($field, $contactRelationshipTypes)) {
+            if (!array_key_exists($field, $relationType)) {
+              $relationType[$field] = NULL;
+            }
             $relDAO = CRM_Utils_Array::value($iterationDAO->contact_id, $allRelContactArray[$field]);
             $relationQuery[$field]->convertToPseudoNames($relDAO);
             self::fetchRelationshipDetails($relDAO, $value, $field, $row);
@@ -922,6 +928,9 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
 
         if ($setHeader) {
           $exportTempTable = self::createTempTable($sqlColumns);
+          foreach ($relationType as $type => &$dontCare) {
+            $relationType[$type] = self::createTempTable($sqlColumns);
+          }
         }
 
         //build header only once
@@ -957,7 +966,7 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
 
         // output every $tempRowCount rows
         if ($count % $tempRowCount == 0) {
-          self::writeDetailsToTable($exportTempTable, $componentDetails, $sqlColumns);
+          self::writeDetailsToTable($exportTempTable, $componentDetails, $sqlColumns, $relationType, $returnProperties);
           $componentDetails = array();
         }
       }
@@ -968,7 +977,7 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
     }
 
     if ($exportTempTable) {
-      self::writeDetailsToTable($exportTempTable, $componentDetails, $sqlColumns);
+      self::writeDetailsToTable($exportTempTable, $componentDetails, $sqlColumns, $relationType, $returnProperties);
 
       // if postalMailing option is checked, exclude contacts who are deceased, have
       // "Do not mail" privacy setting, or have no street address
@@ -985,8 +994,7 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
 
       // merge the records if they have corresponding households
       if ($mergeSameHousehold) {
-        self::mergeSameHousehold($exportTempTable, $headerRows, $sqlColumns, $relationKeyMOH);
-        self::mergeSameHousehold($exportTempTable, $headerRows, $sqlColumns, $relationKeyHOH);
+        self::mergeSameHousehold($exportTempTable, $sqlColumns, $relationType);
       }
 
       // call export hook
@@ -1269,10 +1277,12 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
 
   /**
    * @param string $tableName
-   * @param $details
-   * @param $sqlColumns
+   * @param array $details
+   * @param array $sqlColumns
+   * @param array $relationTypes
+   * @param array $returnProperties
    */
-  public static function writeDetailsToTable($tableName, &$details, &$sqlColumns) {
+  public static function writeDetailsToTable($tableName, &$details, &$sqlColumns, $relationTypes, $returnProperties) {
     if (empty($details)) {
       return;
     }
@@ -1289,10 +1299,35 @@ FROM   $tableName
 
     $sqlClause = array();
 
+    $sqlColumnString = '(id, ' . implode(',', array_keys($sqlColumns)) . ')';
+
     foreach ($details as $dontCare => $row) {
       $id++;
       $valueString = array($id);
-      foreach ($row as $dontCare => $value) {
+      foreach ($row as $key1 => $value) {
+        if (array_key_exists($key1, $relationTypes)) {
+          // consider only those entries to pass, which have linked relationship contact
+          if (!empty($row[$key1]) && !empty($row[$key1]['id'])) {
+            $values = [$row['id']];
+            foreach ($row[$key1] as $key2 => $value) {
+              if ($key2 == 'id') {
+                continue;
+              }
+              else {
+                $values[] = is_null($value) ? '' : "'" . CRM_Core_DAO::escapeString($value) . "'";
+              }
+            }
+            $values[] = $row[$key1]['id'];
+            $sql = sprintf(" INSERT INTO %s (%s, civicrm_primary_id) VALUES ( %s ) ",
+              $relationTypes[$key1],
+              implode(',', array_keys($returnProperties[$key1])),
+              implode(",\n", $values)
+            );
+            CRM_Core_DAO::executeQuery($sql);
+          }
+          unset($row[$key1]);
+          continue;
+        }
         if (empty($value)) {
           $valueString[] = "''";
         }
@@ -1302,8 +1337,6 @@ FROM   $tableName
       }
       $sqlClause[] = '(' . implode(',', $valueString) . ')';
     }
-
-    $sqlColumnString = '(id, ' . implode(',', array_keys($sqlColumns)) . ')';
 
     $sqlValueString = implode(",\n", $sqlClause);
 
@@ -1647,83 +1680,56 @@ WHERE  id IN ( $deleteIDString )
    *
    * @param string $exportTempTable
    *   Temporary temp table that stores the records.
-   * @param array $headerRows
-   *   Array of headers for the export file.
    * @param array $sqlColumns
    *   Array of names of the table columns of the temp table.
-   * @param string $prefix
-   *   Name of the relationship type that is prefixed to the table columns.
+   * @param array $relationTempTables
+   *   Name of the temp tables that holds the relationship records
    */
-  public static function mergeSameHousehold($exportTempTable, &$headerRows, &$sqlColumns, $prefix) {
-    $prefixColumn = $prefix . '_';
+  public static function mergeSameHousehold($exportTempTable, &$sqlColumns, $relationTempTables) {
     $allKeys = array_keys($sqlColumns);
     $replaced = array();
-    $headerRows = array_values($headerRows);
 
-    // name map of the non standard fields in header rows & sql columns
-    $mappingFields = array(
-      'civicrm_primary_id' => 'id',
-      'contact_source' => 'source',
-      'current_employer_id' => 'employer_id',
-      'contact_is_deleted' => 'is_deleted',
-      'name' => 'address_name',
-      'provider_id' => 'im_service_provider',
-      'phone_type_id' => 'phone_type',
-    );
-
-    //figure out which columns are to be replaced by which ones
-    foreach ($sqlColumns as $columnNames => $dontCare) {
-      if ($rep = CRM_Utils_Array::value($columnNames, $mappingFields)) {
-        $replaced[$columnNames] = CRM_Utils_String::munge($prefixColumn . $rep, '_', 64);
-      }
-      else {
-        $householdColName = CRM_Utils_String::munge($prefixColumn . $columnNames, '_', 64);
-
-        if (!empty($sqlColumns[$householdColName])) {
-          $replaced[$columnNames] = $householdColName;
+    foreach ($relationTempTables as $relationType => $tempTable) {
+      foreach ($sqlColumns as $columnNames => $dontCare) {
+        if (!empty($sqlColumns[$columnNames])) {
+          $replaced["temp." . $columnNames] = "$relationType.$columnNames";
         }
       }
-    }
-    $query = "UPDATE $exportTempTable SET ";
 
-    $clause = array();
-    foreach ($replaced as $from => $to) {
-      $clause[] = "$from = $to ";
-      unset($sqlColumns[$to]);
-      if ($key = CRM_Utils_Array::key($to, $allKeys)) {
-        unset($headerRows[$key]);
+      $query = "UPDATE $exportTempTable temp
+       INNER JOIN $tempTable $relationType ON $relationType.id = temp.civicrm_primary_id
+      SET ";
+      $clause = array();
+      foreach ($replaced as $from => $to) {
+        $clause[] = "$from = $to ";
       }
+      $query .= implode(",\n", $clause);
+      $query .= " WHERE temp.civicrm_primary_id != '' ";
+
+      CRM_Core_DAO::executeQuery($query);
+
+      $sql = "DROP TABLE IF EXISTS $tempTable";
+      CRM_Core_DAO::executeQuery($sql);
     }
-    $query .= implode(",\n", $clause);
-    $query .= " WHERE {$replaced['civicrm_primary_id']} != ''";
-
-    CRM_Core_DAO::executeQuery($query);
-
-    //drop the table columns that store redundant household info
-    $dropQuery = "ALTER TABLE $exportTempTable ";
-    foreach ($replaced as $householdColumns) {
-      $dropClause[] = " DROP $householdColumns ";
-    }
-    $dropQuery .= implode(",\n", $dropClause);
-
-    CRM_Core_DAO::executeQuery($dropQuery);
 
     // also drop the temp table if exists
     $sql = "DROP TABLE IF EXISTS {$exportTempTable}_temp";
     CRM_Core_DAO::executeQuery($sql);
 
     // clean up duplicate records
+    $select = CRM_Contact_BAO_Query::appendAnyValueToSelect($allKeys, "civicrm_primary_id", 'GROUP_CONCAT', TRUE);
     $query = "
-CREATE TABLE {$exportTempTable}_temp SELECT *
+CREATE TABLE {$exportTempTable}_temp
+$select
 FROM {$exportTempTable}
 GROUP BY civicrm_primary_id ";
-
     CRM_Core_DAO::executeQuery($query);
 
     $query = "DROP TABLE $exportTempTable";
     CRM_Core_DAO::executeQuery($query);
 
     $query = "ALTER TABLE {$exportTempTable}_temp RENAME TO {$exportTempTable}";
+
     CRM_Core_DAO::executeQuery($query);
   }
 
@@ -1910,73 +1916,12 @@ WHERE  {$whereClause}";
     elseif (substr($field, 0, 5) == 'case_' && $query->_fields['case'][$field]['title']) {
       $headerRows[] = $query->_fields['case'][$field]['title'];
     }
-    elseif (array_key_exists($field, $contactRelationshipTypes)) {
-      foreach ($value as $relationField => $relationValue) {
-        // below block is same as primary block (duplicate)
-        if (isset($relationQuery[$field]->_fields[$relationField]['title'])) {
-          if ($relationQuery[$field]->_fields[$relationField]['name'] == 'name') {
-            $headerName = $field . '-' . $relationField;
-          }
-          else {
-            if ($relationField == 'current_employer') {
-              $headerName = $field . '-' . 'current_employer';
-            }
-            else {
-              $headerName = $field . '-' . $relationQuery[$field]->_fields[$relationField]['name'];
-            }
-          }
-
-          $headerRows[] = $headerName;
-
-          self::sqlColumnDefn($query, $sqlColumns, $headerName);
-        }
-        elseif ($relationField == 'phone_type_id') {
-          $headerName = $field . '-' . 'Phone Type';
-          $headerRows[] = $headerName;
-          self::sqlColumnDefn($query, $sqlColumns, $headerName);
-        }
-        elseif ($relationField == 'provider_id') {
-          $headerName = $field . '-' . 'Im Service Provider';
-          $headerRows[] = $headerName;
-          self::sqlColumnDefn($query, $sqlColumns, $headerName);
-        }
-        elseif ($relationField == 'state_province_id') {
-          $headerName = $field . '-' . 'state_province_id';
-          $headerRows[] = $headerName;
-          self::sqlColumnDefn($query, $sqlColumns, $headerName);
-        }
-        elseif (is_array($relationValue) && $relationField == 'location') {
-          // fix header for location type case
-          foreach ($relationValue as $ltype => $val) {
-            foreach (array_keys($val) as $fld) {
-              $type = explode('-', $fld);
-
-              $hdr = "{$ltype}-" . $relationQuery[$field]->_fields[$type[0]]['title'];
-
-              if (!empty($type[1])) {
-                if (CRM_Utils_Array::value(0, $type) == 'phone') {
-                  $hdr .= "-" . CRM_Utils_Array::value($type[1], $phoneTypes);
-                }
-                elseif (CRM_Utils_Array::value(0, $type) == 'im') {
-                  $hdr .= "-" . CRM_Utils_Array::value($type[1], $imProviders);
-                }
-              }
-              $headerName = $field . '-' . $hdr;
-              $headerRows[] = $headerName;
-              self::sqlColumnDefn($query, $sqlColumns, $headerName);
-            }
-          }
-        }
-      }
-      self::manipulateHeaderRows($headerRows, $contactRelationshipTypes);
-    }
     elseif ($selectedPaymentFields && array_key_exists($field, self::componentPaymentFields())) {
       $headerRows[] = CRM_Utils_Array::value($field, self::componentPaymentFields());
     }
     else {
       $headerRows[] = $field;
     }
-
     self::sqlColumnDefn($query, $sqlColumns, $field);
 
     return array($headerRows, $sqlColumns);
@@ -2061,17 +2006,18 @@ WHERE  {$whereClause}";
   }
 
   /**
-   * Get the values of linked household contact.
+   * Get the values of linked household contact
    *
-   * @param CRM_Core_DAO $relDAO
+   * @param obj $relDAO
    * @param array $value
-   * @param string $field
+   * @param string $relPrefix
    * @param array $row
    */
-  private static function fetchRelationshipDetails($relDAO, $value, $field, &$row) {
+  public static function fetchRelationshipDetails($relDAO, $value, $relPrefix, &$row) {
+    $row[$relPrefix] = [];
+    $i18n = CRM_Core_I18n::singleton();
     $phoneTypes = CRM_Core_PseudoConstant::get('CRM_Core_DAO_Phone', 'phone_type_id');
     $imProviders = CRM_Core_PseudoConstant::get('CRM_Core_DAO_IM', 'provider_id');
-    $i18n = CRM_Core_I18n::singleton();
     foreach ($value as $relationField => $relationValue) {
       if (is_object($relDAO) && property_exists($relDAO, $relationField)) {
         $fieldValue = $relDAO->$relationField;
@@ -2106,7 +2052,7 @@ WHERE  {$whereClause}";
       $relPrefix = $field . $relationField;
 
       if (is_object($relDAO) && $relationField == 'id') {
-        $row[$relPrefix] = $relDAO->contact_id;
+        $row[$relPrefix][$relationField] = $relDAO->contact_id;
       }
       elseif (is_array($relationValue) && $relationField == 'location') {
         foreach ($relationValue as $ltype => $val) {
@@ -2120,24 +2066,24 @@ WHERE  {$whereClause}";
             // and state_province (‘province’ context)
             switch (TRUE) {
               case (!is_object($relDAO)):
-                $row[$field . '_' . $fldValue] = '';
+                $row[$relPrefix . '_' . $fldValue] = '';
                 break;
 
               case in_array('country', $type):
               case in_array('world_region', $type):
-                $row[$field . '_' . $fldValue] = $i18n->crm_translate($relDAO->$fldValue,
+                $row[$relPrefix][$fldValue] = $i18n->crm_translate($relDAO->$fldValue,
                   array('context' => 'country')
                 );
                 break;
 
               case in_array('state_province', $type):
-                $row[$field . '_' . $fldValue] = $i18n->crm_translate($relDAO->$fldValue,
+                $row[$relPrefix][$fldValue] = $i18n->crm_translate($relDAO->$fldValue,
                   array('context' => 'province')
                 );
                 break;
 
               default:
-                $row[$field . '_' . $fldValue] = $relDAO->$fldValue;
+                $row[$relPrefix][$fldValue] = $relDAO->$fldValue;
                 break;
             }
           }
@@ -2146,7 +2092,7 @@ WHERE  {$whereClause}";
       elseif (isset($fieldValue) && $fieldValue != '') {
         //check for custom data
         if ($cfID = CRM_Core_BAO_CustomField::getKeyID($relationField)) {
-          $row[$relPrefix] = CRM_Core_BAO_CustomField::displayValue($fieldValue, $cfID);
+          $row[$relPrefix][$relationField] = CRM_Core_BAO_CustomField::displayValue($fieldValue, $cfID);
         }
         else {
           //normal relationship fields
@@ -2154,22 +2100,22 @@ WHERE  {$whereClause}";
           switch ($relationField) {
             case 'country':
             case 'world_region':
-              $row[$relPrefix] = $i18n->crm_translate($fieldValue, array('context' => 'country'));
+              $row[$relPrefix][$relationField] = $i18n->crm_translate($fieldValue, array('context' => 'country'));
               break;
 
             case 'state_province':
-              $row[$relPrefix] = $i18n->crm_translate($fieldValue, array('context' => 'province'));
+              $row[$relPrefix][$relationField] = $i18n->crm_translate($fieldValue, array('context' => 'province'));
               break;
 
             default:
-              $row[$relPrefix] = $fieldValue;
+              $row[$relPrefix][$relationField] = $fieldValue;
               break;
           }
         }
       }
       else {
         // if relation field is empty or null
-        $row[$relPrefix] = '';
+        $row[$relPrefix][$relationField] = '';
       }
     }
   }

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -55,7 +55,7 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
       NULL,
       NULL,
       FALSE,
-      FALSE,
+      TRUE,
       array(
         'exportOption' => 1,
         'suppress_csv_for_testing' => TRUE,

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -68,6 +68,51 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test to ensure that 'Merge Household Members into their Households' works on export.
+   */
+  public function testMergeHouseholdMemberOnExport() {
+    // Here's how this test case works - 3 contacts are created A, B and C where A and B are individual contacts.
+    //  C is a household contact whose member is contact A. These 3 contacts are selected for export with 'Merge Household Members into their Households' = TRUE
+    //  And at the end export table contain only 2 contacts i.e. is B and C as B is not a member of C and A is a member of C reason why it is merged with it.
+    $this->setUpContactExportData();
+    $householdID = $this->householdCreate();
+    $this->callAPISuccess('relationship', 'create', [
+      'contact_id_a' => $this->contactIDs[0],
+      'contact_id_b' => $householdID,
+      'relationship_type_id' => CRM_Core_DAO::getFieldValue('CRM_Contact_BAO_RelationshipType', 'Household Member of', 'id', 'name_a_b'),
+    ]);
+
+    $contactIDs = array_merge($this->contactIDs, [$householdID]);
+    $params = ['contact_id' => $contactIDs];
+    list($tableName, $sqlColumns) = CRM_Export_BAO_Export::exportComponents(
+      FALSE,
+      $contactIDs,
+      CRM_Contact_BAO_Query::convertFormValues($params),
+      NULL,
+      NULL,
+      NULL,
+      CRM_Export_Form_Select::CONTACT_EXPORT,
+      NULL,
+      NULL,
+      FALSE,
+      TRUE,
+      array(
+        'exportOption' => 1,
+        'suppress_csv_for_testing' => TRUE,
+      )
+    );
+
+    $exportedRows = CRM_Utils_SQL_Select::from($tableName)->execute()->fetchAll();
+    $this->assertEquals(2, count($exportedRows));
+    // the result should contain contact B and C, as A being a household member merged with C.
+    $this->assertEquals([$this->contactIDs[1], $householdID], CRM_Utils_Array::collect('civicrm_primary_id', $exportedRows));
+
+    // delete the export temp table and component table
+    $sql = "DROP TABLE IF EXISTS {$tableName}";
+    CRM_Core_DAO::executeQuery($sql);
+  }
+
+  /**
    * Basic test to ensure the exportComponents function can export selected fields for contribution.
    */
   public function testExportComponentsContribution() {


### PR DESCRIPTION
Overview
----------------------------------------
Exporting Contacts using the settings "Export PRIMARY fields" and "Merge Household Members into their Households" produces db error: "Database Error Code: Row size too large (> 8126). Changing some columns to TEXT or BLOB may help. In current row format, BLOB prefix of 0 bytes is stored inline., 1118"

Before
----------------------------------------
![screen shot 2018-03-23 at 2 34 28 pm](https://user-images.githubusercontent.com/3735621/37820664-61d2933c-2ea7-11e8-830d-a26365d8aa11.png)


After
----------------------------------------
It fixes this error, also the patch is tested in  5.7 on FULL_GROUP_BY_MODE enabled.

Technical Details
----------------------------------------
Fix need a minor modification in ```appendAnyValueToSelect(...)``` to support alias when there isn't any and when select column is used in aggregate fn. On the other hand, modified the existing UT to include ```mergeSameHousehold = TRUE``` criteria.

---

 * [CRM-20632: Exporting Contacts using "Export PRIMARY fields" and "Merge Household Members into their Households" produces db error](https://issues.civicrm.org/jira/browse/CRM-20632)