### PR TITLE
CRM-21806: Fix issues is search form when FULL_GROUP_BY_MODE enabled

### DIFF
--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -240,6 +240,15 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
   }
 
   /**
+   * This method set cache key, later used in test environment
+   *
+   * @param string $key
+   */
+  public function setKey($key) {
+    $this->_key = $key;
+  }
+
+  /**
    * This method returns the links that are given for each search row.
    * currently the links added for each row are
    *
@@ -545,7 +554,6 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
    *   the total number of rows for this action
    */
   public function &getRows($action, $offset, $rowCount, $sort, $output = NULL) {
-
     if (($output == CRM_Core_Selector_Controller::EXPORT ||
         $output == CRM_Core_Selector_Controller::SCREEN
       ) &&

--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -1001,16 +1001,21 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
    * @param int $end
    */
   public function fillupPrevNextCache($sort, $cacheKey, $start = 0, $end = self::CACHE_SIZE) {
-    $coreSearch = TRUE;
+    $coreSearch = (!is_a($this, 'CRM_Contact_Selector_Custom')) ?: FALSE;
     // For custom searches, use the contactIDs method
-    if (is_a($this, 'CRM_Contact_Selector_Custom')) {
-      $sql = $this->_search->contactIDs($start, $end, $sort, TRUE);
-      $coreSearch = FALSE;
+    if (!$coreSearch) {
+      $sql = sprintf("
+      INSERT INTO civicrm_prevnext_cache ( entity_table, entity_id1, entity_id2, cacheKey, data )
+        SELECT DISTINCT 'civicrm_contact', contact_a.contact_id, contact_a.contact_id, '%s', cc.sort_name
+        FROM ( %s )  contact_a
+        INNER JOIN civicrm_contact cc ON contact_a.contact_id = cc.id ", $cacheKey, $this->_search->contactIDs($start, $end, $sort, TRUE));
     }
     // For core searches use the searchQuery method
     else {
-      $sql = $this->_query->searchQuery($start, $end, $sort, FALSE, $this->_query->_includeContactIds,
-        FALSE, TRUE, TRUE);
+      $sql = sprintf("
+      INSERT INTO civicrm_prevnext_cache ( entity_table, entity_id1, entity_id2, cacheKey, data )
+        SELECT DISTINCT 'civicrm_contact', contact_id, contact_id, '%s', sort_name
+        FROM ( %s ) contact_a ", $cacheKey, $this->_query->searchQuery($start, $end, $sort, FALSE, FALSE, FALSE, FALSE, TRUE));
     }
 
     // CRM-9096
@@ -1021,13 +1026,6 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
     // the prev next cache in this situation
     // the other alternative of running the FULL query will just be incredibly inefficient
     // and slow things down way too much on large data sets / complex queries
-
-    $insertSQL = "
-INSERT INTO civicrm_prevnext_cache ( entity_table, entity_id1, entity_id2, cacheKey, data )
-SELECT DISTINCT 'civicrm_contact', contact_a.id, contact_a.id, '$cacheKey', contact_a.sort_name
-";
-
-    $sql = str_replace(array("SELECT contact_a.id as contact_id", "SELECT contact_a.id as id"), $insertSQL, $sql);
     try {
       CRM_Core_DAO::executeQuery($sql);
     }

--- a/tests/phpunit/CRM/Contact/SelectorTest.php
+++ b/tests/phpunit/CRM/Contact/SelectorTest.php
@@ -80,6 +80,68 @@ class CRM_Contact_Form_SelectorTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test the civicrm_prevnext_cache entry if it correctly stores the search query result
+   */
+  public function testPrevNextCache() {
+    $contactID = $this->individualCreate(['email' => 'mickey@mouseville.com']);
+    $dataSet = array(
+      'description' => 'Normal default behaviour',
+      'class' => 'CRM_Contact_Selector',
+      'settings' => array(),
+      'form_values' => array('email' => 'mickey@mouseville.com'),
+      'params' => array(),
+      'return_properties' => NULL,
+      'context' => 'advanced',
+      'action' => CRM_Core_Action::ADVANCED,
+      'includeContactIds' => NULL,
+      'searchDescendentGroups' => FALSE,
+      'expected_query' => array(
+        0 => 'default',
+        1 => 'default',
+        2 => "WHERE  ( civicrm_email.email LIKE '%mickey@mouseville.com%' )  AND (contact_a.is_deleted = 0)",
+      ),
+    );
+    $params = CRM_Contact_BAO_Query::convertFormValues($dataSet['form_values'], 0, FALSE, NULL, array());
+
+    // create CRM_Contact_Selector instance and set desired query params
+    $selector = new CRM_Contact_Selector(
+      $dataSet['class'],
+      $dataSet['form_values'],
+      $params,
+      $dataSet['return_properties'],
+      $dataSet['action'],
+      $dataSet['includeContactIds'],
+      $dataSet['searchDescendentGroups'],
+      $dataSet['context']
+    );
+    // set cache key
+    $key = substr(sha1(rand()), 0, 7);
+    $selector->setKey($key);
+
+    // fetch row and check the result
+    $rows = $selector->getRows(CRM_Core_Action::VIEW, 0, TRUE, NULL);
+    $this->assertEquals(1, count($rows));
+    $this->assertEquals($contactID, key($rows));
+
+    // build cache key and use to it to fetch prev-next cache record
+    $cacheKey = 'civicrm search ' . $key;
+    $contacts = CRM_Utils_SQL_Select::from('civicrm_prevnext_cache')
+                  ->select(['entity_table', 'entity_id1', 'cacheKey'])
+                  ->where("cacheKey = '!key'")
+                  ->param('!key', $cacheKey)
+                  ->execute()
+                  ->fetchAll();
+    $this->assertEquals(1, count($contacts));
+    // check the prevNext record matches
+    $expectedEntry = [
+      'entity_table' => 'civicrm_contact',
+      'entity_id1' => $contactID,
+      'cacheKey' => $cacheKey,
+    ];
+    $this->checkArrayEquals($contacts[0], $expectedEntry);
+  }
+
+  /**
    * Data sets for testing.
    */
   public function querySets() {


### PR DESCRIPTION
Overview
----------------------------------------
On FULL_GROUP_BY_MODE enabled setup, doing any sort on Advance Search list, leads to DB error. 

Before
----------------------------------------
![test-multiple-before](https://user-images.githubusercontent.com/3735621/37849684-a8986a2e-2efe-11e8-90cc-a314600caf73.gif)


After
----------------------------------------
![test-multiple-after](https://user-images.githubusercontent.com/3735621/37849641-7ccf275c-2efe-11e8-910f-8b054e514515.gif)


Technical Details
----------------------------------------
The issue is on INSERT query when the ORDER BY column is not present in select clause when we perform any sort on the search list. Hence, the fix cannot be applied directly to the insert query as there must be a definite number of select columns to used for inserting values. Reason why in the patch we first fetch the records in intended order and store it in a temp table. Which is then used to populate ```prev_next_cache``` table.

---

 * [CRM-21806: Search builder returns no results](https://issues.civicrm.org/jira/browse/CRM-21806)