### PR TITLE
Fixed regression of CRM-16995.

### DIFF
--- a/ang/crmApp.js
+++ b/ang/crmApp.js
@@ -6,11 +6,19 @@
   crmApp.config(['$routeProvider',
     function($routeProvider) {
 
-      if (CRM.crmApp.defaultRoute) {
+      var route;
+      if (CRM.crmApp && CRM.crmApp.activeRoute) {
+        route = CRM.crmApp.activeRoute;
+      }
+      else if (CRM.crmApp && CRM.crmApp.defaultRoute) {
+        route = CRM.crmApp.defaultRoute;
+      }
+
+      if (route) {
         $routeProvider.when('/', {
           template: '<div></div>',
           controller: function($location) {
-            $location.path(CRM.crmApp.defaultRoute);
+            $location.path(route);
           }
         });
       }


### PR DESCRIPTION
The activeRoute parameter which allows setting the route which crmApp should immediately open was previously ignored.

With this code:

```php
$loader = new \Civi\Angular\AngularLoader();
$loader->setModules(array('crmExample'));
$loader->setPageName('civicrm/crmexample');
$loader->useApp(array(
  'defaultRoute' => '/list',
  'defaultRoute' => '/list/item/77',
));
$loader->load();
```

Before
----------------------------------------
Browsing /civicrm/crmexample lands the user at /civicrm/crmexample/#/list.

After
----------------------------------------
Browsing /civicrm/crmexample lands the user at /civicrm/crmexample/#/list/item/77.

---

 * [CRM-16995: Allow loading of Angular routes inside tabs](https://issues.civicrm.org/jira/browse/CRM-16995)