### PR TITLE
CRM-21853: Do not change 'is_multiple' unless included in the params

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -128,8 +128,8 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup {
       $fields[] = 'is_public';
     }
     foreach ($fields as $field) {
-      if (isset($params[$field]) || $field == 'is_multiple') {
-        $group->$field = CRM_Utils_Array::value($field, $params, FALSE);
+      if (isset($params[$field])) {
+        $group->$field = $params[$field];
       }
     }
     $group->max_multiple = isset($params['is_multiple']) ? (isset($params['max_multiple']) &&


### PR DESCRIPTION
Overview
----------------------------------------

Starting with [this commit](https://github.com/civicrm/civicrm-core/commit/21586e85e83765db7d737c765ff07336c2f1c867#diff-d9f1be3fcfd7cea0a4864a21997c258aR126) all edits to a CustomGroup would set `is_multiple` to FALSE unless `is_multiple` was explicitly included in the parameters. The commit mentions that it fixes tests, but the logic for making it always default to FALSE isn't described.

Before
----------------------------------------

Editing fields on a custom group updates `is_multiple` to FALSE unless it is included in the request parameters.

![peek 2018-03-26 11-35](https://user-images.githubusercontent.com/6374064/37902847-b41443d2-30ed-11e8-8c63-ca7bed407da4.gif)

After
----------------------------------------

Editing fields on a custom group will not change `is_multiple` unless it is explicitly included in the request 
parameters. 

![peek 2018-03-26 12-05](https://user-images.githubusercontent.com/6374064/37902983-29ef6456-30ee-11e8-8640-9b7f7fa32107.gif)

Comments
----------------------------------------

I'm guessing since the original change was to fix tests that some tests will fail, I'd prefer to deal with the cause of that and find another solution as I don't think the current `is_multiple` default is logical.

---

 * [CRM-21853: Edting CustomGroup always sets is_multiple to false by default](https://issues.civicrm.org/jira/browse/CRM-21853)