### PR TITLE
CRM-21842 - Fix links to documentation

### DIFF
--- a/templates/CRM/Contact/Form/Contact.hlp
+++ b/templates/CRM/Contact/Form/Contact.hlp
@@ -160,7 +160,7 @@
   {ts}Geocoding{/ts}
 {/htxt}
 {htxt id="id-geo-code"}
-{capture assign=docLink}{docURL page="user/initial-set-up/installation-and-basic-setup" text="(Refer to the Mapping and Geocoding section in the Installation and Basic Setup Chapter)"}{/capture}
+{capture assign=docLink}{docURL page="user/initial-set-up/installation-and-basic-set-up" text="(Refer to the Mapping and Geocoding section in the Installation and Basic Setup Chapter)"}{/capture}
 <p>{ts}Latitude and longitude may be automatically populated by enabling a Mapping Provider.{/ts} {$docLink}</p>
 {/htxt}
 

--- a/templates/CRM/Contact/Form/OnBehalfOf.tpl
+++ b/templates/CRM/Contact/Form/OnBehalfOf.tpl
@@ -187,7 +187,7 @@
             <div class="content">{$form.address.$index.geo_code_1.html}, {$form.address.$index.geo_code_2.html}
                 <br class="spacer"/>
                 <span class="description">
-                    {ts}Latitude and longitude may be automatically populated by enabling a Mapping Provider.{/ts} {docURL page="user/initial-set-up/installation-and-basic-setup" text="(Refer to the Mapping and Geocoding section in the Installation and Basic Setup Chapter)"}</span>
+                    {ts}Latitude and longitude may be automatically populated by enabling a Mapping Provider.{/ts} {docURL page="user/initial-set-up/installation-and-basic-set-up" text="(Refer to the Mapping and Geocoding section in the Installation and Basic Setup Chapter)"}</span>
             </div>
             <div class="clear"></div>
         </div>


### PR DESCRIPTION
Overview
----------------------------------------
This fixes broken links to the documentation.

Before
----------------------------------------
Links to: https://docs.civicrm.org/user/en/stable/initial-set-up/installation-and-basic-setup

After
----------------------------------------
Links to: https://docs.civicrm.org/user/en/stable/initial-set-up/installation-and-basic-set-up

---

 * [CRM-21842: broken link](https://issues.civicrm.org/jira/browse/CRM-21842)