### PR TITLE
 CRM-21677 reduce unnecessary joins in Case, Grant, Survey reports

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -4373,7 +4373,10 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
    */
   protected function joinCountryFromAddress($prefix = '', $extra = array()) {
     // include country field if country column is to be included
-    if ($this->isTableSelected($prefix . 'civicrm_country')) {
+    if ($this->isTableSelected($prefix . 'civicrm_country') || $this->isTableSelected($prefix . 'civicrm_worldregion')) {
+      if (empty($this->_aliases[$prefix . 'civicrm_country'])) {
+        $this->_aliases[$prefix . 'civicrm_country'] = $prefix . '_report_country';
+      }
       $this->_from .= "
             LEFT JOIN civicrm_country {$this->_aliases[$prefix . 'civicrm_country']}
                    ON {$this->_aliases[$prefix . 'civicrm_address']}.country_id = {$this->_aliases[$prefix . 'civicrm_country']}.id AND

--- a/CRM/Report/Form/Campaign/SurveyDetails.php
+++ b/CRM/Report/Form/Campaign/SurveyDetails.php
@@ -291,19 +291,9 @@ class CRM_Report_Form_Campaign_SurveyDetails extends CRM_Report_Form {
     $this->_from .= " INNER JOIN civicrm_activity_contact activity_contact_civireport ON
                       ( {$this->_aliases['civicrm_activity']}.id = activity_contact_civireport.activity_id  AND activity_contact_civireport.record_type_id = {$assigneeID} )\n";
 
-    //get the address table.
-    $this->_from .= " LEFT JOIN civicrm_address {$this->_aliases['civicrm_address']} ON
-                      {$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_address']}.contact_id AND {$this->_aliases['civicrm_address']}.is_primary = 1\n";
-
-    if ($this->_emailField) {
-      $this->_from .= "LEFT JOIN civicrm_email {$this->_aliases['civicrm_email']} ON
-                       {$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_email']}.contact_id AND {$this->_aliases['civicrm_email']}.is_primary = 1\n";
-    }
-
-    if ($this->_phoneField) {
-      $this->_from .= "LEFT JOIN civicrm_phone {$this->_aliases['civicrm_phone']} ON
-                       {$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_phone']}.contact_id AND {$this->_aliases['civicrm_phone']}.is_primary = 1\n";
-    }
+    $this->joinAddressFromContact();
+    $this->joinPhoneFromContact();
+    $this->joinEmailFromContact();
 
     if ($this->_locationBasedPhoneField) {
       foreach ($this->_surveyResponseFields as $key => $value) {

--- a/CRM/Report/Form/Case/Demographics.php
+++ b/CRM/Report/Form/Case/Demographics.php
@@ -313,19 +313,9 @@ where (cg.extends='Contact' OR cg.extends='Individual' OR cg.extends_entity_colu
       }
     }
 
-    if ($this->_emailField) {
-      $this->_from .= "
-            LEFT JOIN  civicrm_email {$this->_aliases['civicrm_email']}
-                   ON ({$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_email']}.contact_id AND
-                      {$this->_aliases['civicrm_email']}.is_primary = 1) ";
-    }
+    $this->joinPhoneFromContact();
+    $this->joinEmailFromContact();
 
-    if ($this->_phoneField) {
-      $this->_from .= "
-            LEFT JOIN civicrm_phone {$this->_aliases['civicrm_phone']}
-                   ON {$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_phone']}.contact_id AND
-                      {$this->_aliases['civicrm_phone']}.is_primary = 1 ";
-    }
   }
 
   public function where() {

--- a/CRM/Report/Form/Case/Detail.php
+++ b/CRM/Report/Form/Case/Detail.php
@@ -36,13 +36,7 @@ class CRM_Report_Form_Case_Detail extends CRM_Report_Form {
 
   protected $_relField = FALSE;
 
-  protected $_addressField = FALSE;
-
-  protected $_emailField = FALSE;
-
-  protected $_phoneField = FALSE;
-
-  protected $_worldRegionField = FALSE;
+  protected $_addressField = TRUE;
 
   protected $_activityLast = FALSE;
 
@@ -344,19 +338,10 @@ class CRM_Report_Form_Case_Detail extends CRM_Report_Form {
     foreach ($this->_columns as $tableName => $table) {
       if (array_key_exists('fields', $table)) {
         foreach ($table['fields'] as $fieldName => $field) {
-          if ($tableName == 'civicrm_address') {
-            $this->_addressField = TRUE;
-          }
           if (!empty($field['required']) ||
             !empty($this->_params['fields'][$fieldName])
           ) {
-            if ($tableName == 'civicrm_email') {
-              $this->_emailField = TRUE;
-            }
-            elseif ($tableName == 'civicrm_phone') {
-              $this->_phoneField = TRUE;
-            }
-            elseif ($tableName == 'civicrm_relationship') {
+            if ($tableName == 'civicrm_relationship') {
               $this->_relField = TRUE;
             }
             if ($fieldName == 'sort_name') {
@@ -414,25 +399,11 @@ class CRM_Report_Form_Case_Detail extends CRM_Report_Form {
 ";
     }
 
-    if ($this->_addressField) {
-      $this->_from .= "
-             LEFT JOIN civicrm_address {$this->_aliases['civicrm_address']}
-                    ON {$conact}.id = {$this->_aliases['civicrm_address']}.contact_id AND
-                       {$this->_aliases['civicrm_address']}.is_primary = 1 ";
-    }
-    if ($this->_emailField) {
-      $this->_from .= "
-             LEFT JOIN civicrm_email {$this->_aliases['civicrm_email']}
-                   ON {$conact}.id = {$this->_aliases['civicrm_email']}.contact_id AND
-                       {$this->_aliases['civicrm_email']}.is_primary = 1 ";
-    }
-    if ($this->_phoneField) {
-      $this->_from .= "
-             LEFT JOIN  civicrm_phone {$this->_aliases['civicrm_phone']}
-                       ON ( {$conact}.id = {$this->_aliases['civicrm_phone']}.contact_id AND
-                          {$this->_aliases['civicrm_phone']}.is_primary = 1) ";
-    }
-    if ($this->_worldRegionField) {
+    $this->joinAddressFromContact();
+    $this->joinPhoneFromContact();
+    $this->joinEmailFromContact();
+
+    if ($this->isTableSelected('civicrm_worldregion')) {
       $this->_from .= "
              LEFT JOIN civicrm_country {$this->_aliases['civicrm_country']}
                    ON {$this->_aliases['civicrm_country']}.id ={$this->_aliases['civicrm_address']}.country_id
@@ -601,13 +572,6 @@ class CRM_Report_Form_Case_Detail extends CRM_Report_Form {
   }
 
   public function checkEnabledFields() {
-    if (isset($this->_params['worldregion_id_value']) &&
-      !empty($this->_params['worldregion_id_value'])
-    ) {
-      $this->_addressField = TRUE;
-      $this->_worldRegionField = TRUE;
-    }
-
     if (isset($this->_params['case_role_value'])
       && !empty($this->_params['case_role_value'])
     ) {

--- a/CRM/Report/Form/Grant/Detail.php
+++ b/CRM/Report/Form/Grant/Detail.php
@@ -32,8 +32,6 @@
  */
 class CRM_Report_Form_Grant_Detail extends CRM_Report_Form {
 
-  protected $_addressField = FALSE;
-
   protected $_customGroupExtends = array(
     'Grant',
   );
@@ -212,13 +210,11 @@ class CRM_Report_Form_Grant_Detail extends CRM_Report_Form {
   }
 
   public function select() {
+    // @todo remove this override - seems to do nothing parent doesn't.
     $select = array();
 
     $this->_columnHeaders = array();
     foreach ($this->_columns as $tableName => $table) {
-      if ($tableName == 'civicrm_address') {
-        $this->_addressField = TRUE;
-      }
       if (array_key_exists('fields', $table)) {
         foreach ($table['fields'] as $fieldName => $field) {
           if (!empty($field['required']) ||
@@ -242,16 +238,11 @@ class CRM_Report_Form_Grant_Detail extends CRM_Report_Form {
         FROM civicrm_grant {$this->_aliases['civicrm_grant']}
                         LEFT JOIN civicrm_contact {$this->_aliases['civicrm_contact']}
                     ON ({$this->_aliases['civicrm_grant']}.contact_id  = {$this->_aliases['civicrm_contact']}.id  ) ";
-    if ($this->_addressField) {
-      $this->_from .= "
-                  LEFT JOIN civicrm_address {$this->_aliases['civicrm_address']}
-                         ON {$this->_aliases['civicrm_contact']}.id =
-                            {$this->_aliases['civicrm_address']}.contact_id AND
-                            {$this->_aliases['civicrm_address']}.is_primary = 1\n";
-    }
+    $this->joinAddressFromContact();
   }
 
   public function where() {
+    // @todo this function appears to do nothing more than parent, test & remove
     $clauses = array();
     $this->_where = '';
     foreach ($this->_columns as $tableName => $table) {
@@ -291,6 +282,7 @@ class CRM_Report_Form_Grant_Detail extends CRM_Report_Form {
   }
 
   public function groupBy() {
+    // @todo this function appears to do nothing more than parent, test & remove
     $this->_groupBy = "";
     if (!empty($this->_params['group_bys']) &&
       is_array($this->_params['group_bys']) &&

--- a/CRM/Report/Form/Grant/Statistics.php
+++ b/CRM/Report/Form/Grant/Statistics.php
@@ -32,8 +32,6 @@
  */
 class CRM_Report_Form_Grant_Statistics extends CRM_Report_Form {
 
-  protected $_addressField = FALSE;
-
   protected $_customGroupExtends = array('Grant');
 
   protected $_add2groupSupported = FALSE;
@@ -163,7 +161,7 @@ class CRM_Report_Form_Grant_Statistics extends CRM_Report_Form {
         ),
         'grouping' => 'contact-fields',
       ),
-      'civicrm_world_region' => array(
+      'civicrm_worldregion' => array(
         'dao' => 'CRM_Core_DAO_Worldregion',
         'fields' => array(
           'id' => array(
@@ -210,13 +208,6 @@ class CRM_Report_Form_Grant_Statistics extends CRM_Report_Form {
 
     $this->_columnHeaders = array();
     foreach ($this->_columns as $tableName => $table) {
-      if (in_array($tableName, array(
-        'civicrm_address',
-        'civicrm_world_region',
-      ))) {
-        $this->_addressField = TRUE;
-      }
-
       if (array_key_exists('fields', $table)) {
         foreach ($table['fields'] as $fieldName => $field) {
           if (!empty($field['required']) ||
@@ -241,18 +232,14 @@ class CRM_Report_Form_Grant_Statistics extends CRM_Report_Form {
         FROM civicrm_grant {$this->_aliases['civicrm_grant']}
                         LEFT JOIN civicrm_contact {$this->_aliases['civicrm_contact']}
                     ON ({$this->_aliases['civicrm_grant']}.contact_id  = {$this->_aliases['civicrm_contact']}.id  ) ";
-    if ($this->_addressField) {
+
+    $this->joinAddressFromContact();
+    $this->joinCountryFromAddress();
+    if ($this->isTableSelected('civicrm_worldregion')) {
       $this->_from .= "
-                  LEFT JOIN civicrm_address {$this->_aliases['civicrm_address']}
-                         ON {$this->_aliases['civicrm_contact']}.id =
-                            {$this->_aliases['civicrm_address']}.contact_id AND
-                            {$this->_aliases['civicrm_address']}.is_primary = 1\n
-                  LEFT JOIN civicrm_country country
-                         ON {$this->_aliases['civicrm_address']}.country_id =
-                            country.id
-                  LEFT JOIN civicrm_worldregion {$this->_aliases['civicrm_world_region']}
-                         ON country.region_id =
-                            {$this->_aliases['civicrm_world_region']}.id";
+                  LEFT JOIN civicrm_worldregion {$this->_aliases['civicrm_worldregion']}
+                         ON {$this->_aliases['civicrm_country']}.region_id =
+                            {$this->_aliases['civicrm_worldregion']}.id";
     }
   }
 
@@ -416,11 +403,11 @@ SELECT COUNT({$this->_aliases['civicrm_grant']}.id) as count ,
         );
       }
 
-      if (array_key_exists('civicrm_world_region_name', $values)) {
-        $region = CRM_Utils_Array::value('civicrm_world_region_name', $values);
+      if (array_key_exists('civicrm_worldregion_name', $values)) {
+        $region = CRM_Utils_Array::value('civicrm_worldregion_name', $values);
         $region = ($region) ? $region : 'Unassigned';
-        $grantStatistics['civicrm_world_region_name']['title'] = ts('By Region');
-        self::getStatistics($grantStatistics['civicrm_world_region_name'], $region, $values,
+        $grantStatistics['civicrm_worldregion_name']['title'] = ts('By Region');
+        self::getStatistics($grantStatistics['civicrm_worldregion_name'], $region, $values,
           $awardedGrants, $awardedGrantsAmount
         );
       }


### PR DESCRIPTION
Overview
----------------------------------------
Reviewers cut of #11550 - reduce unnecessary joins to address tables in reports
Campaign/SurveyDetails
Case/Demographics
Case/Detail
Grant/Detail
Grant/Statistics

Before
----------------------------------------
unnecessary joins to phone, email and address tables

After
----------------------------------------
join only when needed, code standardised

Technical Details
----------------------------------------
This also aligns the approach with that used in the extended report extension - there might be some notices as I have updated the extension where the signature differs from core but will need to drop a new release & people will need to be on it.

Comments
----------------------------------------
@yashodha back to you :-) This takes us down to 15 reports

---

 * [CRM-21677: Report improvements](https://issues.civicrm.org/jira/browse/CRM-21677)