### PR TITLE
CRM-21854 - Contribution start date and end dates are not respected

### DIFF
--- a/CRM/Contribute/Exception/FutureContributionPageException.php
+++ b/CRM/Contribute/Exception/FutureContributionPageException.php
@@ -1,0 +1,25 @@
+<?php
+
+class CRM_Contribute_Exception_FutureContributionPageException extends Exception {
+  private $id;
+
+  /**
+   * @param string $message
+   * @param int $id
+   */
+  public function __construct($message, $id) {
+    parent::__construct(ts($message));
+    $this->id = $id;
+    CRM_Core_Error::debug_log_message('Access to contribution page with start date in future attempted - page number ' . $id);
+  }
+
+  /**
+   * Get Contribution page ID.
+   *
+   * @return int
+   */
+  public function getID() {
+    return $this->id;
+  }
+
+}

--- a/CRM/Contribute/Exception/PastContributionPageException.php
+++ b/CRM/Contribute/Exception/PastContributionPageException.php
@@ -1,0 +1,25 @@
+<?php
+
+class CRM_Contribute_Exception_PastContributionPageException extends Exception {
+  private $id;
+
+  /**
+   * @param string $message
+   * @param int $id
+   */
+  public function __construct($message, $id) {
+    parent::__construct(ts($message));
+    $this->id = $id;
+    CRM_Core_Error::debug_log_message('Access to contribution page with past end date attempted - page number ' . $id);
+  }
+
+  /**
+   * Get Contribution page ID.
+   *
+   * @return int
+   */
+  public function getID() {
+    return $this->id;
+  }
+
+}

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -316,12 +316,12 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       $endDate = CRM_Utils_Date::processDate(CRM_Utils_Array::value('end_date', $this->_values));
       $now = date('YmdHis');
       if ($endDate && $endDate < $now) {
-        throw new CRM_Contribute_Exception_PastContributionPageException(ts('The page you requested has past its end date on '. CRM_Utils_Date::customFormat($endDate) ), $this->_id);
+        throw new CRM_Contribute_Exception_PastContributionPageException(ts('The page you requested has past its end date on ' . CRM_Utils_Date::customFormat($endDate)), $this->_id);
       }
 
       $startDate = CRM_Utils_Date::processDate(CRM_Utils_Array::value('start_date', $this->_values));
       if ($startDate && $startDate > $now) {
-        throw new CRM_Contribute_Exception_FutureContributionPageException(ts('The page you requested will be active from '. CRM_Utils_Date::customFormat($startDate)), $this->_id);
+        throw new CRM_Contribute_Exception_FutureContributionPageException(ts('The page you requested will be active from ' . CRM_Utils_Date::customFormat($startDate)), $this->_id);
       }
 
       $this->assignBillingType();

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -316,12 +316,12 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       $endDate = CRM_Utils_Date::processDate(CRM_Utils_Array::value('end_date', $this->_values));
       $now = date('YmdHis');
       if ($endDate && $endDate < $now) {
-        throw new Exception(ts('The page you requested has past its end date on '. CRM_Utils_Date::customFormat($endDate) ), $this->_id);
+        throw new CRM_Contribute_Exception_PastContributionPageException(ts('The page you requested has past its end date on '. CRM_Utils_Date::customFormat($endDate) ), $this->_id);
       }
 
       $startDate = CRM_Utils_Date::processDate(CRM_Utils_Array::value('start_date', $this->_values));
       if ($startDate && $startDate > $now) {
-        throw new Exception(ts('The page you requested will be active from '. CRM_Utils_Date::customFormat($startDate)), $this->_id);
+        throw new CRM_Contribute_Exception_FutureContributionPageException(ts('The page you requested will be active from '. CRM_Utils_Date::customFormat($startDate)), $this->_id);
       }
 
       $this->assignBillingType();

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -313,6 +313,17 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
         throw new CRM_Contribute_Exception_InactiveContributionPageException(ts('The page you requested is currently unavailable.'), $this->_id);
       }
 
+      $endDate = CRM_Utils_Date::processDate(CRM_Utils_Array::value('end_date', $this->_values));
+      $now = date('YmdHis');
+      if ($endDate && $endDate < $now) {
+        throw new Exception(ts('The page you requested has past its end date on '. CRM_Utils_Date::customFormat($endDate) ), $this->_id);
+      }
+
+      $startDate = CRM_Utils_Date::processDate(CRM_Utils_Array::value('start_date', $this->_values));
+      if ($startDate && $startDate > $now) {
+        throw new Exception(ts('The page you requested will be active from '. CRM_Utils_Date::customFormat($startDate)), $this->_id);
+      }
+
       $this->assignBillingType();
 
       // check for is_monetary status

--- a/CRM/Contribute/Form/ContributionPage.php
+++ b/CRM/Contribute/Form/ContributionPage.php
@@ -332,14 +332,6 @@ class CRM_Contribute_Form_ContributionPage extends CRM_Core_Form {
       if ($this->_priceSetID) {
         $defaults['price_set_id'] = $this->_priceSetID;
       }
-
-      if (!empty($defaults['end_date'])) {
-        list($defaults['end_date'], $defaults['end_date_time']) = CRM_Utils_Date::setDateDefaults($defaults['end_date']);
-      }
-
-      if (!empty($defaults['start_date'])) {
-        list($defaults['start_date'], $defaults['start_date_time']) = CRM_Utils_Date::setDateDefaults($defaults['start_date']);
-      }
     }
     else {
       $defaults['is_active'] = 1;
@@ -353,7 +345,7 @@ class CRM_Contribute_Form_ContributionPage extends CRM_Core_Form {
       ), '1');
     }
     else {
-      # CRM 10860
+      // CRM-10860
       $defaults['recur_frequency_unit'] = array('month' => 1);
     }
 

--- a/CRM/Contribute/Form/ContributionPage/Settings.php
+++ b/CRM/Contribute/Form/ContributionPage/Settings.php
@@ -223,8 +223,8 @@ class CRM_Contribute_Form_ContributionPage_Settings extends CRM_Contribute_Form_
     }
 
     // add optional start and end dates
-    $this->addDateTime('start_date', ts('Start Date'));
-    $this->addDateTime('end_date', ts('End Date'));
+    $this->add('datepicker', 'start_date', ts('Start Date'));
+    $this->add('datepicker', 'end_date', ts('End Date'));
 
     $this->addFormRule(array('CRM_Contribute_Form_ContributionPage_Settings', 'formRule'), $this);
 
@@ -334,10 +334,6 @@ class CRM_Contribute_Form_ContributionPage_Settings extends CRM_Contribute_Form_
     $params['is_credit_card_only'] = CRM_Utils_Array::value('is_credit_card_only', $params, FALSE);
     $params['honor_block_is_active'] = CRM_Utils_Array::value('honor_block_is_active', $params, FALSE);
     $params['is_for_organization'] = !empty($params['is_organization']) ? CRM_Utils_Array::value('is_for_organization', $params, FALSE) : 0;
-
-    $params['start_date'] = CRM_Utils_Date::processDate($params['start_date'], $params['start_date_time'], TRUE);
-    $params['end_date'] = CRM_Utils_Date::processDate($params['end_date'], $params['end_date_time'], TRUE);
-
     $params['goal_amount'] = CRM_Utils_Rule::cleanMoney($params['goal_amount']);
 
     if (!$params['honor_block_is_active']) {

--- a/templates/CRM/Contribute/Form/ContributionPage/Settings.tpl
+++ b/templates/CRM/Contribute/Form/ContributionPage/Settings.tpl
@@ -95,15 +95,11 @@
   </tr>
   <tr class="crm-contribution-contributionpage-settings-form-block-start_date">
       <td class ="label">{$form.start_date.label} {help id="id-start_date"}</td>
-      <td>
-          {include file="CRM/common/jcalendar.tpl" elementName=start_date}
-      </td>
+      <td>{$form.start_date.html}</td>
     </tr>
   <tr class="crm-contribution-contributionpage-settings-form-block-end_date">
       <td class ="label">{$form.end_date.label}</td>
-      <td>
-          {include file="CRM/common/jcalendar.tpl" elementName=end_date}
-      </td>
+      <td>{$form.end_date.html}</td>
     </tr>
   <tr class="crm-contribution-contributionpage-settings-form-block-honor_block_is_active">
       <td>&nbsp;</td><td>{$form.honor_block_is_active.html}{$form.honor_block_is_active.label} {help id="id-honoree_section"}</td>


### PR DESCRIPTION
Overview
----------------------------------------
_Steps to replicate :_


1. Create a contribution page with end date earlier than today.
2. Go to live mode, the page is still active and nothing changes.
3. Similarly, if the start date is set in future, that's also not disabling the page.

Before
----------------------------------------
able to access the contribution page

After
----------------------------------------
not able to access the contribution page


Comments
----------------------------------------
Users are getting confused as to why the contribution continued to accept payments after the end date. There is no way to set a contribution to end without manually going in to inactivate.

---

 * [CRM-21854: Contribution start date and end dates are not respected](https://issues.civicrm.org/jira/browse/CRM-21854)