### PR TITLE
Fix report form isTableSelected to treat relative date filters as filters

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -3996,10 +3996,11 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
         }
         if (array_key_exists('filters', $table)) {
           foreach ($table['filters'] as $filterName => $filter) {
-            if (!empty($this->_params["{$filterName}_value"]) ||
-              CRM_Utils_Array::value("{$filterName}_op", $this->_params) ==
-              'nll' ||
-              CRM_Utils_Array::value("{$filterName}_op", $this->_params) ==
+            if (!empty($this->_params["{$filterName}_value"])
+              || !empty($this->_params["{$filterName}_relative"])
+              || CRM_Utils_Array::value("{$filterName}_op", $this->_params) ==
+              'nll'
+              || CRM_Utils_Array::value("{$filterName}_op", $this->_params) ==
               'nnll'
             ) {
               $this->_selectedTables[] = $tableName;


### PR DESCRIPTION
Overview
----------------------------------------
The function isTableSelected is used to determine whether a table is being referenced in field, filter, order by parameters etc. Fix it to detect relative date filters

Before
----------------------------------------
Despite selection of a  param like ['receive_date_relative'] => 'this.quarter' isTableSelected will return FALSE 

After
----------------------------------------
isTableSelected correctly returns TRUE

Technical Details
----------------------------------------
isTableSelected looks to see if the filter has been passed in. Without this it looks in ->_params[{}_value] &
for {}_op to be null or 'not null' but misses relative date filters.

Comments
----------------------------------------
This is pretty hard to replicate as it is a helper function, but, I think it's fairly easy to proof by reading the code. I also moved || to the start of the lines