### PR TITLE
Handle eq (equals) operator in the report url

### DIFF
--- a/CRM/Report/Utils/Get.php
+++ b/CRM/Report/Utils/Get.php
@@ -113,6 +113,7 @@ class CRM_Report_Utils_Get {
       case 'ew':
       case 'nhas':
       case 'like':
+      case 'eq':
       case 'neq':
         $value = self::getTypedValue("{$fieldName}_value", CRM_Utils_Array::value('type', $field));
         if ($value !== NULL) {


### PR DESCRIPTION
Overview
----------------------------------------
Permit usage of 'eq' (equals operator) in url when calling a report

Before
----------------------------------------
civicrm/report/contribute/detail?sort_name_op=eq&sort_name_value=Mickey 
does NOT result in the filter 'sort name = Mickey'

BUT

civicrm/report/contribute/detail?sort_name_op=neq&sort_name_value=Mickey
 results in the filter 'sort name <> Mickey'

After
----------------------------------------
civicrm/report/contribute/detail?sort_name_op=eq&sort_name_value=Mickey 
results in the filter 'sort name = Mickey'
(neq unchanged)

Technical Details
----------------------------------------
Super trivial -  this just seems like oversight


