### PR TITLE
CRM-21434: Add activities to recent items stack

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -522,6 +522,17 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
     if ($this->_action & CRM_Core_Action::UPDATE) {
       CRM_Core_Form_RecurringEntity::preProcess('civicrm_activity');
     }
+
+    if ($this->_action & CRM_Core_Action::VIEW) {
+      $url = CRM_Utils_System::url(implode("/", $this->urlPath), "reset=1&id={$this->_activityId}&action=view&cid={$this->_values['source_contact_id']}");
+      CRM_Utils_Recent::add($this->_values['subject'],
+        $url,
+        $this->_values['id'],
+        'Activity',
+        $this->_values['source_contact_id'],
+        $this->_values['source_contact']
+      );
+    }
   }
 
   /**

--- a/CRM/Activity/Form/ActivityView.php
+++ b/CRM/Activity/Form/ActivityView.php
@@ -108,6 +108,15 @@ class CRM_Activity_Form_ActivityView extends CRM_Core_Form {
 
     $values['attachment'] = CRM_Core_BAO_File::attachmentInfo('civicrm_activity', $activityId);
     $this->assign('values', $values);
+
+    $url = CRM_Utils_System::url(implode("/", $this->urlPath), "reset=1&id={$activityId}&action=view&cid={$values['source_contact_id']}");
+    CRM_Utils_Recent::add($this->_values['subject'],
+      $url,
+      $values['id'],
+      'Activity',
+      $values['source_contact_id'],
+      $values['source_contact']
+    );
   }
 
   /**


### PR DESCRIPTION
When viewing activities push them to the recent items stack.

    CRM-21434: Add activities to recent items on view and edit

Successor of messed #11280

---

 * [CRM-21434: Add activities to recent items on view and edit](https://issues.civicrm.org/jira/browse/CRM-21434)