### PR TITLE
core-34 Add 'edit related contacts' permission

### DIFF
--- a/CRM/Contact/BAO/Contact/Permission.php
+++ b/CRM/Contact/BAO/Contact/Permission.php
@@ -113,12 +113,16 @@ WHERE contact_id IN ({$contact_id_list})
     }
 
     // if some have been rejected, double check for permissions inherited by relationship
-    if (count($result_set) < count($contact_ids)) {
-      $rejected_contacts       = array_diff_key($contact_ids, $result_set);
-      // @todo consider storing these to the acl cache for next time, since we have fetched.
-      $allowed_by_relationship = self::relationshipList($rejected_contacts);
-      foreach ($allowed_by_relationship as $contact_id) {
-        $result_set[(int) $contact_id] = TRUE;
+    // if the logged in user has the appropriate permission
+    if ($type == CRM_Core_Permission::VIEW
+     || ($type == CRM_Core_Permission::EDIT && CRM_Core_Permission::check('edit related contacts'))) {
+      if (count($result_set) < count($contact_ids)) {
+        $rejected_contacts       = array_diff_key($contact_ids, $result_set);
+        // @todo consider storing these to the acl cache for next time, since we have fetched.
+        $allowed_by_relationship = self::relationshipList($rejected_contacts);
+        foreach ($allowed_by_relationship as $contact_id) {
+          $result_set[(int) $contact_id] = TRUE;
+        }
       }
     }
 
@@ -161,8 +165,11 @@ WHERE contact_id IN ({$contact_id_list})
     }
 
     // check permission based on relationship, CRM-2963
-    if (self::relationshipList(array($id))) {
-      return TRUE;
+    if ($type == CRM_Core_Permission::VIEW
+     || ($type == CRM_Core_Permission::EDIT && CRM_Core_Permission::check('edit related contacts'))) {
+      if (self::relationshipList(array($id))) {
+        return TRUE;
+      }
     }
 
     // We should probably do a cheap check whether it's in the cache first.

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -699,6 +699,10 @@ class CRM_Core_Permission {
       'edit my contact' => array(
         $prefix . ts('edit my contact'),
       ),
+      'edit related contacts' => array(
+        $prefix . ts('edit related contacts'),
+        ts('Edit contacts with a permissioned relationship'),
+      ),
       'delete contacts' => array(
         $prefix . ts('delete contacts'),
       ),

--- a/tests/phpunit/CRM/ACL/ListTest.php
+++ b/tests/phpunit/CRM/ACL/ListTest.php
@@ -119,7 +119,12 @@ class CRM_ACL_ListTest extends CiviUnitTestCase {
       sort($result);
 
       $this->assertNotContains($contacts[0], $result, "User[0] should NOT have $permission_label permission on contact[0].");
-      $this->assertContains($contacts[1], $result, "User[0] should have $permission_label permission on contact[1].");
+      if ($permission == CRM_Core_Permission::VIEW) {
+        $this->assertContains($contacts[1], $result, "User[0] should have $permission_label permission on contact[1].");
+      }
+      else {
+        $this->assertNotContains($contacts[1], $result, "User[0] should NOT have $permission_label permission on contact[1].");
+      }
       $this->assertNotContains($contacts[2], $result, "User[0] should NOT have $permission_label permission on contact[2].");
       $this->assertNotContains($contacts[3], $result, "User[0] should NOT have $permission_label permission on contact[3].");
       $this->assertNotContains($contacts[4], $result, "User[0] should NOT have $permission_label permission on contact[4].");
@@ -133,10 +138,39 @@ class CRM_ACL_ListTest extends CiviUnitTestCase {
       sort($result);
 
       $this->assertNotContains($contacts[0], $result, "User[0] should NOT have $permission_label permission on contact[0].");
-      $this->assertContains($contacts[1], $result, "User[0] should have $permission_label permission on contact[1].");
-      $this->assertContains($contacts[2], $result, "User[0] should have second degree $permission_label permission on contact[2].");
+      if ($permission == CRM_Core_Permission::VIEW) {
+        $this->assertContains($contacts[1], $result, "User[0] should have $permission_label permission on contact[1].");
+        $this->assertContains($contacts[2], $result, "User[0] should have second degree $permission_label permission on contact[2].");
+      }
+      else {
+        $this->assertNotContains($contacts[1], $result, "User[0] should NOT have $permission_label permission on contact[1].");
+        $this->assertNotContains($contacts[2], $result, "User[0] should NOT have second degree $permission_label permission on contact[2].");
+      }
       $this->assertNotContains($contacts[3], $result, "User[0] should NOT have $permission_label permission on contact[3].");
       $this->assertNotContains($contacts[4], $result, "User[0] should NOT have $permission_label permission on contact[4].");
+    }
+
+    // run tests with 'edit related contacts'
+    $config->userPermissionClass->permissions = array('edit related contacts');
+
+    // simple relations
+    $config->secondDegRelPermissions = FALSE;
+    $this->assertFalse($config->secondDegRelPermissions);
+    foreach ($permissions_to_check as $permission => $permission_label) {
+      $result = CRM_Contact_BAO_Contact_Permission::allowList($contacts, $permission);
+      sort($result);
+      $this->assertContains($contacts[1], $result, "User[0] should have $permission_label permission on contact[1].");
+      $this->assertNotContains($contacts[2], $result, "User[0] should NOT have $permission_label permission on contact[2].");
+    }
+
+    // second degree relations
+    $config->secondDegRelPermissions = TRUE;
+    $this->assertTrue($config->secondDegRelPermissions);
+    foreach ($permissions_to_check as $permission => $permission_label) {
+      $result = CRM_Contact_BAO_Contact_Permission::allowList($contacts, $permission);
+      sort($result);
+      $this->assertContains($contacts[1], $result, "User[0] should have $permission_label permission on contact[1].");
+      $this->assertContains($contacts[2], $result, "User[0] should have second degree $permission_label permission on contact[2].");
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Currently permissioned relationships provide 'view' and 'edit' access to the related contact.  This changes the default to 'view' and adds a user permission 'edit related contacts' that can be granted to users who need it.

Before
----------------------------------------
If a user (A) has "permissioned relationship" with contact (B), then A can view and edit contact B. 

After
----------------------------------------
If a user (A) has "permissioned relationship" with contact (B), then A can view contact B.  If A also has 'edit related contacts' permission then A can edit contact B.

Technical Details
----------------------------------------
Notable change is that it introduces a new user permission and changes the default behaviour.

It would be simple to also add a 'view related contacts' permission that would requires the user to have that permission as well as a permissioned relationship existing. Obviously if neither view nor edit is required, then the relationship could be de-permissioned, but with the 'relatedpermissions' extension, it is possible to automatically set relationship types as permissioned and a view permission could be useful linked to that. 

@eileenmcnaughton 's relatedpermissions extension will need modification to stay in sync with this change.  PR can be provided if this is accepted.

Comments
----------------------------------------
This is a change of default behaviour for permissioned relationships.  The old behaviour is easily restored by adding the 'edit related contacts' permission to appropriate users (roles).  How best to communicate this to upgraders?


