### PR TITLE
avoid variable leakage on recurring contribution receipts

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -10,7 +10,7 @@ AGH Strategies - Andrew Hunt
 Agileware - Alok Patel
 Australian Greens - Seamus Lee
 CiviDesk - Yashodha Chaku
-CompuCorp - Mukesh Ram, Omar Abu Hussein, Vinu Varshith Sekar
+CompuCorp - Mukesh Ram, Omar Abu Hussein, René Olivo, Vinu Varshith Sekar
 Coop SymbioTIC - Samuel Vanhove
 Davis Media Access - Darrick Servis
 Fuzion - Jitendra Purohit
@@ -25,7 +25,6 @@ MJW Consulting - Matthew Wire
 myDropWizard - David Snopek
 Oxfam Germany - Thomas Schüttler
 Progressive Technology Project - Jamie McClelland
-René Olivo
 Systopia - Björn Endres
 Tadpole Collective - Kevin Cristiano
 Third Sector Design - Michael McAndrew

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,6 +1,37 @@
 The following people and organizations sponsored and/or contributed new and improved features to the project.
 
 ************************************************
+Key Contributors and Sponsors for 5.x
+************************************************
+
+CiviCRM - Coleman Watts, Tim Otten
+
+AGH Strategies - Andrew Hunt
+Agileware - Alok Patel
+Australian Greens - Seamus Lee
+CiviDesk - Yashodha Chaku
+CompuCorp - Mukesh Ram, Omar Abu Hussein, Vinu Varshith Sekar
+Coop SymbioTIC - Samuel Vanhove
+Davis Media Access - Darrick Servis
+Fuzion - Jitendra Purohit
+Ginkgo Street Labs - Frank Gómez
+JMA Consulting - Monish Deb
+John Kingsnorth
+Joinery - Allen Shaw
+Left Join Labs - Sean Madsen
+Lighthouse Design and Consulting - Brian Shaughnessy
+Łukasz Krutul
+MJW Consulting - Matthew Wire
+myDropWizard - David Snopek
+Oxfam Germany - Thomas Schüttler
+Progressive Technology Project - Jamie McClelland
+René Olivo
+Systopia - Björn Endres
+Tadpole Collective - Kevin Cristiano
+Third Sector Design - Michael McAndrew
+Wikimedia Foundation - Eileen McNaughton
+
+************************************************
 Key Contributors and Sponsors for 4.7
 ************************************************
 

--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -522,6 +522,17 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
     if ($this->_action & CRM_Core_Action::UPDATE) {
       CRM_Core_Form_RecurringEntity::preProcess('civicrm_activity');
     }
+
+    if ($this->_action & CRM_Core_Action::VIEW) {
+      $url = CRM_Utils_System::url(implode("/", $this->urlPath), "reset=1&id={$this->_activityId}&action=view&cid={$this->_values['source_contact_id']}");
+      CRM_Utils_Recent::add($this->_values['subject'],
+        $url,
+        $this->_values['id'],
+        'Activity',
+        $this->_values['source_contact_id'],
+        $this->_values['source_contact']
+      );
+    }
   }
 
   /**

--- a/CRM/Activity/Form/ActivityView.php
+++ b/CRM/Activity/Form/ActivityView.php
@@ -108,6 +108,15 @@ class CRM_Activity_Form_ActivityView extends CRM_Core_Form {
 
     $values['attachment'] = CRM_Core_BAO_File::attachmentInfo('civicrm_activity', $activityId);
     $this->assign('values', $values);
+
+    $url = CRM_Utils_System::url(implode("/", $this->urlPath), "reset=1&id={$activityId}&action=view&cid={$values['source_contact_id']}");
+    CRM_Utils_Recent::add($this->_values['subject'],
+      $url,
+      $values['id'],
+      'Activity',
+      $values['source_contact_id'],
+      $values['source_contact']
+    );
   }
 
   /**

--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -349,6 +349,13 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
       $errors[$recipientKind[$fields['recipient']]['target_id']] = ts('If "Also include" or "Limit to" are selected, you must specify at least one %1', array(1 => $recipientKind[$fields['recipient']]['name']));
     }
 
+    //CRM-21523
+    if (!empty($fields['is_repeat']) &&
+      (empty($fields['repetition_frequency_interval']) || ($fields['end_frequency_interval'] == NULL))
+    ) {
+      $errors['is_repeat'] = ts('If you are enabling repetition you must indicate the frequency and ending term.');
+    }
+
     $actionSchedule = $self->parseActionSchedule($fields);
     if ($actionSchedule->mapping_id) {
       $mapping = CRM_Core_BAO_ActionSchedule::getMapping($actionSchedule->mapping_id);

--- a/CRM/Admin/Page/Options.php
+++ b/CRM/Admin/Page/Options.php
@@ -151,6 +151,7 @@ class CRM_Admin_Page_Options extends CRM_Core_Page_Basic {
       $this->assign('showCounted', TRUE);
     }
     $this->assign('isLocked', self::$_isLocked);
+    $this->assign('allowLoggedIn', Civi::settings()->get('allow_mail_from_logged_in_contact'));
     $config = CRM_Core_Config::singleton();
     if (self::$_gName == 'activity_type') {
       $this->assign('showComponent', TRUE);

--- a/CRM/Case/Form/Task.php
+++ b/CRM/Case/Form/Task.php
@@ -41,9 +41,10 @@ class CRM_Case_Form_Task extends CRM_Core_Form_Task {
   static $entityShortname = 'case';
 
   /**
-   * The array that holds all the case ids
+   * Deprecated copy of $_entityIds
    *
    * @var array
+   * @deprecated
    */
   public $_caseIds;
 
@@ -111,6 +112,15 @@ class CRM_Case_Form_Task extends CRM_Core_Form_Task {
         $urlParams
       ));
     }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function setContactIDs() {
+    $this->_contactIds = CRM_Core_DAO::getContactIDsFromComponent($this->_entityIds,
+      'civicrm_case_contact', 'case_id'
+    );
   }
 
 }

--- a/CRM/Case/Form/Task.php
+++ b/CRM/Case/Form/Task.php
@@ -40,4 +40,77 @@ class CRM_Case_Form_Task extends CRM_Core_Form_Task {
   // Must be set to entity shortname (eg. event)
   static $entityShortname = 'case';
 
+  /**
+   * The array that holds all the case ids
+   *
+   * @var array
+   */
+  public $_caseIds;
+
+  /**
+   * Build all the data structures needed to build the form.
+   */
+  public function preProcess() {
+    self::preProcessCommon($this);
+  }
+
+  /**
+   * @param CRM_Core_Form $form
+   */
+  public static function preProcessCommon(&$form) {
+    $form->_caseIds = array();
+
+    $values = $form->controller->exportValues($form->get('searchFormName'));
+
+    $form->_task = $values['task'];
+    $caseTasks = CRM_Case_Task::tasks();
+    $form->assign('taskName', $caseTasks[$form->_task]);
+
+    $ids = array();
+    if ($values['radio_ts'] == 'ts_sel') {
+      foreach ($values as $name => $value) {
+        if (substr($name, 0, CRM_Core_Form::CB_PREFIX_LEN) == CRM_Core_Form::CB_PREFIX) {
+          $ids[] = substr($name, CRM_Core_Form::CB_PREFIX_LEN);
+        }
+      }
+    }
+    else {
+      $queryParams = $form->get('queryParams');
+      $query = new CRM_Contact_BAO_Query($queryParams, NULL, NULL, FALSE, FALSE,
+        CRM_Contact_BAO_Query::MODE_CASE
+      );
+      $query->_distinctComponentClause = " ( civicrm_case.id )";
+      $query->_groupByComponentClause = " GROUP BY civicrm_case.id ";
+      $result = $query->searchQuery(0, 0, NULL);
+      while ($result->fetch()) {
+        $ids[] = $result->case_id;
+      }
+    }
+
+    if (!empty($ids)) {
+      $form->_componentClause = ' civicrm_case.id IN ( ' . implode(',', $ids) . ' ) ';
+      $form->assign('totalSelectedCases', count($ids));
+    }
+
+    $form->_caseIds = $form->_entityIds = $form->_componentIds = $ids;
+
+    //set the context for redirection for any task actions
+    $qfKey = CRM_Utils_Request::retrieve('qfKey', 'String', $form);
+    $urlParams = 'force=1';
+    if (CRM_Utils_Rule::qfKey($qfKey)) {
+      $urlParams .= "&qfKey=$qfKey";
+    }
+
+    $session = CRM_Core_Session::singleton();
+    $searchFormName = strtolower($form->get('searchFormName'));
+    if ($searchFormName == 'search') {
+      $session->replaceUserContext(CRM_Utils_System::url('civicrm/case/search', $urlParams));
+    }
+    else {
+      $session->replaceUserContext(CRM_Utils_System::url("civicrm/contact/search/$searchFormName",
+        $urlParams
+      ));
+    }
+  }
+
 }

--- a/CRM/Case/Form/Task/PDF.php
+++ b/CRM/Case/Form/Task/PDF.php
@@ -86,7 +86,7 @@ class CRM_Case_Form_Task_PDF extends CRM_Case_Form_Task {
    */
   public function listTokens() {
     $tokens = CRM_Core_SelectValues::contactTokens();
-    foreach ($this->_caseIds as $key => $caseId) {
+    foreach ($this->_componentIds as $key => $caseId) {
       $caseTypeId = CRM_Core_DAO::getFieldValue('CRM_Case_DAO_Case', $caseId, 'case_type_id');
       $tokens += CRM_Core_SelectValues::caseTokens($caseTypeId);
     }

--- a/CRM/Contact/Page/DedupeFind.php
+++ b/CRM/Contact/Page/DedupeFind.php
@@ -63,8 +63,9 @@ class CRM_Contact_Page_DedupeFind extends CRM_Core_Page_Basic {
     $limit = CRM_Utils_Request::retrieve('limit', 'Integer', $this);
     $rgid = CRM_Utils_Request::retrieve('rgid', 'Positive', $this);
     $cid = CRM_Utils_Request::retrieve('cid', 'Positive', $this, FALSE, 0);
-    // Using a placeholder for criteria as it is intended to be able to pass this later.
-    $criteria = array();
+    $criteria = CRM_Utils_Request::retrieve('criteria', 'Json', $this, FALSE);
+    $this->assign('criteria', $criteria);
+
     $isConflictMode = ($context == 'conflicts');
     if ($cid) {
       $this->_cid = $cid;
@@ -79,8 +80,10 @@ class CRM_Contact_Page_DedupeFind extends CRM_Core_Page_Basic {
       'rgid' => $rgid,
       'gid' => $gid,
       'limit' => $limit,
+      'criteria' => $criteria,
     );
     $this->assign('urlQuery', CRM_Utils_System::makeQueryString($urlQry));
+    $criteria = json_decode($criteria, TRUE);
 
     if ($context == 'search') {
       $context = 'search';

--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -1029,7 +1029,10 @@ SELECT DISTINCT 'civicrm_contact', contact_a.id, contact_a.id, '$cacheKey', cont
 
     $sql = str_replace(array("SELECT contact_a.id as contact_id", "SELECT contact_a.id as id"), $insertSQL, $sql);
     try {
-      CRM_Core_DAO::executeQuery($sql);
+      $result = CRM_Core_DAO::executeQuery($sql, [], FALSE, NULL, FALSE, TRUE, TRUE);
+      if (is_a($result, 'DB_Error')) {
+        throw new CRM_Core_Exception($result->message);
+      }
     }
     catch (CRM_Core_Exception $e) {
       if ($coreSearch) {
@@ -1038,7 +1041,10 @@ SELECT DISTINCT 'civicrm_contact', contact_a.id, contact_a.id, '$cacheKey', cont
         $this->rebuildPreNextCache($start, $end, $sort, $cacheKey);
       }
       else {
-        CRM_Core_Session::setStatus(ts('Query Failed'));
+        // This will always show for CiviRules :-( as a) it orders by 'rule_label'
+        // which is not available in the query & b) it uses contact not contact_a
+        // as an alias.
+        // CRM_Core_Session::setStatus(ts('Query Failed'));
         return;
       }
     }

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2891,6 +2891,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    */
   public function _assignMessageVariablesToTemplate(&$values, $input, $returnMessageText = TRUE) {
     $template = CRM_Core_Smarty::singleton();
+    $template->clearTemplateVars();
     $template->assign('first_name', $this->_relatedObjects['contact']->first_name);
     $template->assign('last_name', $this->_relatedObjects['contact']->last_name);
     $template->assign('displayName', $this->_relatedObjects['contact']->display_name);

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2891,6 +2891,8 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    */
   public function _assignMessageVariablesToTemplate(&$values, $input, $returnMessageText = TRUE) {
     $template = CRM_Core_Smarty::singleton();
+    // Clear template variables to avoid leakage when processing multiple contributions.
+    // See https://lab.civicrm.org/dev/core/issues/35
     $template->clearTemplateVars();
     $template->assign('first_name', $this->_relatedObjects['contact']->first_name);
     $template->assign('last_name', $this->_relatedObjects['contact']->last_name);
@@ -2911,6 +2913,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
           'honor_profile_id' => CRM_Core_DAO::getFieldValue('CRM_Core_DAO_UFJoin', $values['id'], 'uf_group_id', 'entity_id'),
           'honor_id' => $softRecord['soft_credit'][1]['contact_id'],
         );
+        $values['honoree_profile_id'] = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_UFJoin', $values['id'], 'uf_group_id', 'entity_id');
 
         $template->assign('soft_credit_type', $softRecord['soft_credit'][1]['soft_credit_type_label']);
         $template->assign('honor_block_is_active', CRM_Core_DAO::getFieldValue('CRM_Core_DAO_UFJoin', $values['id'], 'is_active', 'entity_id'));

--- a/CRM/Contribute/BAO/ContributionSoft.php
+++ b/CRM/Contribute/BAO/ContributionSoft.php
@@ -186,6 +186,7 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
           ),
           'honor_id' => $honorId,
           'honor_profile_id' => $form->_values['honoree_profile_id'],
+          'honoree_profile_id' => $form->_values['honoree_profile_id'],
           'honor_profile_values' => $params['honor'],
         );
       }

--- a/CRM/Core/BAO/Email.php
+++ b/CRM/Core/BAO/Email.php
@@ -315,6 +315,7 @@ AND    reset_date IS NULL
       return $fromEmailValues;
     }
 
+    $contactFromEmails = [];
     // add logged in user's active email ids
     $contactID = CRM_Core_Session::singleton()->getLoggedInContactID();
     if ($contactID) {
@@ -332,10 +333,10 @@ AND    reset_date IS NULL
         if (!empty($emailVal['is_primary'])) {
           $fromEmailHtml .= ' ' . ts('(preferred)');
         }
-        $fromEmailValues[$emailId] = $fromEmailHtml;
+        $contactFromEmails[$fromEmail] = $fromEmailHtml;
       }
     }
-    return $fromEmailValues;
+    return CRM_Utils_Array::crmArrayMerge($contactFromEmails, $fromEmailValues);
   }
 
   /**

--- a/CRM/Core/BAO/FinancialTrxn.php
+++ b/CRM/Core/BAO/FinancialTrxn.php
@@ -486,7 +486,8 @@ WHERE ft.is_payment = 1
       if (!$ftTotalAmt) {
         $ftTotalAmt = 0;
       }
-      $value = $paymentVal = $lineItemTotal - $ftTotalAmt;
+      $currency = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $contributionId, 'currency');
+      $value = $paymentVal = CRM_Utils_Money::subtractCurrencies($lineItemTotal, $ftTotalAmt, $currency);
       if ($returnType) {
         $value = array();
         if ($paymentVal < 0) {

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1662,10 +1662,10 @@ FROM   civicrm_domain
    *
    * @param $componentIDs
    * @param string $tableName
-   *
+   * @param string $idField
    * @return array
    */
-  public static function &getContactIDsFromComponent(&$componentIDs, $tableName) {
+  public static function getContactIDsFromComponent($componentIDs, $tableName, $idField = 'id') {
     $contactIDs = array();
 
     if (empty($componentIDs)) {
@@ -1676,7 +1676,7 @@ FROM   civicrm_domain
     $query = "
 SELECT contact_id
   FROM $tableName
- WHERE id IN ( $IDs )
+ WHERE $idField IN ( $IDs )
 ";
 
     $dao = CRM_Core_DAO::executeQuery($query);

--- a/CRM/Core/Task.php
+++ b/CRM/Core/Task.php
@@ -82,7 +82,7 @@ abstract class CRM_Core_Task {
    *            ]
    */
   public static function tasks() {
-    CRM_Utils_Hook::searchTasks(self::$objectType, self::$_tasks);
+    CRM_Utils_Hook::searchTasks(static::$objectType, self::$_tasks);
     asort(self::$_tasks);
 
     return self::$_tasks;

--- a/CRM/Core/Task.php
+++ b/CRM/Core/Task.php
@@ -172,8 +172,8 @@ abstract class CRM_Core_Task {
     static::tasks();
 
     if (!CRM_Utils_Array::value($value, self::$_tasks)) {
-      // Children can specify a default task (eg. print), we don't here
-      return array();
+      // Children can specify a default task (eg. print), pick another if it is not valid.
+      $value = key(self::$_tasks);
     }
     return array(
       CRM_Utils_Array::value('class', self::$_tasks[$value]),

--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -1906,13 +1906,8 @@ WHERE  {$whereClause}";
     elseif ($field == 'provider_id') {
       $headerRows[] = ts('IM Service Provider');
     }
-    elseif (substr($field, 0, 5) == 'case_') {
-      if ($query->_fields['case'][$field]['title']) {
-        $headerRows[] = $query->_fields['case'][$field]['title'];
-      }
-      elseif ($query->_fields['activity'][$field]['title']) {
-        $headerRows[] = $query->_fields['activity'][$field]['title'];
-      }
+    elseif (substr($field, 0, 5) == 'case_' && $query->_fields['case'][$field]['title']) {
+      $headerRows[] = $query->_fields['case'][$field]['title'];
     }
     elseif (array_key_exists($field, $contactRelationshipTypes)) {
       foreach ($value as $relationField => $relationValue) {

--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -827,105 +827,7 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
           elseif (array_key_exists($field, $contactRelationshipTypes)) {
             $relDAO = CRM_Utils_Array::value($iterationDAO->contact_id, $allRelContactArray[$field]);
             $relationQuery[$field]->convertToPseudoNames($relDAO);
-            foreach ($value as $relationField => $relationValue) {
-              if (is_object($relDAO) && property_exists($relDAO, $relationField)) {
-                $fieldValue = $relDAO->$relationField;
-                if ($relationField == 'phone_type_id') {
-                  $fieldValue = $phoneTypes[$relationValue];
-                }
-                elseif ($relationField == 'provider_id') {
-                  $fieldValue = CRM_Utils_Array::value($relationValue, $imProviders);
-                }
-                // CRM-13995
-                elseif (is_object($relDAO) && in_array($relationField, array(
-                    'email_greeting',
-                    'postal_greeting',
-                    'addressee',
-                  ))
-                ) {
-                  //special case for greeting replacement
-                  $fldValue = "{$relationField}_display";
-                  $fieldValue = $relDAO->$fldValue;
-                }
-              }
-              elseif (is_object($relDAO) && $relationField == 'state_province') {
-                $fieldValue = CRM_Core_PseudoConstant::stateProvince($relDAO->state_province_id);
-              }
-              elseif (is_object($relDAO) && $relationField == 'country') {
-                $fieldValue = CRM_Core_PseudoConstant::country($relDAO->country_id);
-              }
-              else {
-                $fieldValue = '';
-              }
-              $field = $field . '_';
-
-              if (is_object($relDAO) && $relationField == 'id') {
-                $row[$field . $relationField] = $relDAO->contact_id;
-              }
-              elseif (is_array($relationValue) && $relationField == 'location') {
-                foreach ($relationValue as $ltype => $val) {
-                  foreach (array_keys($val) as $fld) {
-                    $type = explode('-', $fld);
-                    $fldValue = "{$ltype}-" . $type[0];
-                    if (!empty($type[1])) {
-                      $fldValue .= "-" . $type[1];
-                    }
-                    // CRM-3157: localise country, region (both have ‘country’ context)
-                    // and state_province (‘province’ context)
-                    switch (TRUE) {
-                      case (!is_object($relDAO)):
-                        $row[$field . '_' . $fldValue] = '';
-                        break;
-
-                      case in_array('country', $type):
-                      case in_array('world_region', $type):
-                        $row[$field . '_' . $fldValue] = $i18n->crm_translate($relDAO->$fldValue,
-                          array('context' => 'country')
-                        );
-                        break;
-
-                      case in_array('state_province', $type):
-                        $row[$field . '_' . $fldValue] = $i18n->crm_translate($relDAO->$fldValue,
-                          array('context' => 'province')
-                        );
-                        break;
-
-                      default:
-                        $row[$field . '_' . $fldValue] = $relDAO->$fldValue;
-                        break;
-                    }
-                  }
-                }
-              }
-              elseif (isset($fieldValue) && $fieldValue != '') {
-                //check for custom data
-                if ($cfID = CRM_Core_BAO_CustomField::getKeyID($relationField)) {
-                  $row[$field . $relationField] = CRM_Core_BAO_CustomField::displayValue($fieldValue, $cfID);
-                }
-                else {
-                  //normal relationship fields
-                  // CRM-3157: localise country, region (both have ‘country’ context) and state_province (‘province’ context)
-                  switch ($relationField) {
-                    case 'country':
-                    case 'world_region':
-                      $row[$field . $relationField] = $i18n->crm_translate($fieldValue, array('context' => 'country'));
-                      break;
-
-                    case 'state_province':
-                      $row[$field . $relationField] = $i18n->crm_translate($fieldValue, array('context' => 'province'));
-                      break;
-
-                    default:
-                      $row[$field . $relationField] = $fieldValue;
-                      break;
-                  }
-                }
-              }
-              else {
-                // if relation field is empty or null
-                $row[$field . $relationField] = '';
-              }
-            }
+            self::fetchRelationshipDetails($relDAO, $value, $field, $row);
           }
           elseif (isset($fieldValue) &&
             $fieldValue != ''
@@ -2160,6 +2062,119 @@ WHERE  {$whereClause}";
       }
     }
     return array($outputColumns, $headerRows, $sqlColumns, $metadata);
+  }
+
+  /**
+   * Get the values of linked household contact.
+   *
+   * @param CRM_Core_DAO $relDAO
+   * @param array $value
+   * @param string $field
+   * @param array $row
+   */
+  private static function fetchRelationshipDetails($relDAO, $value, $field, &$row) {
+    $phoneTypes = CRM_Core_PseudoConstant::get('CRM_Core_DAO_Phone', 'phone_type_id');
+    $imProviders = CRM_Core_PseudoConstant::get('CRM_Core_DAO_IM', 'provider_id');
+    $i18n = CRM_Core_I18n::singleton();
+    foreach ($value as $relationField => $relationValue) {
+      if (is_object($relDAO) && property_exists($relDAO, $relationField)) {
+        $fieldValue = $relDAO->$relationField;
+        if ($relationField == 'phone_type_id') {
+          $fieldValue = $phoneTypes[$relationValue];
+        }
+        elseif ($relationField == 'provider_id') {
+          $fieldValue = CRM_Utils_Array::value($relationValue, $imProviders);
+        }
+        // CRM-13995
+        elseif (is_object($relDAO) && in_array($relationField, array(
+            'email_greeting',
+            'postal_greeting',
+            'addressee',
+          ))
+        ) {
+          //special case for greeting replacement
+          $fldValue = "{$relationField}_display";
+          $fieldValue = $relDAO->$fldValue;
+        }
+      }
+      elseif (is_object($relDAO) && $relationField == 'state_province') {
+        $fieldValue = CRM_Core_PseudoConstant::stateProvince($relDAO->state_province_id);
+      }
+      elseif (is_object($relDAO) && $relationField == 'country') {
+        $fieldValue = CRM_Core_PseudoConstant::country($relDAO->country_id);
+      }
+      else {
+        $fieldValue = '';
+      }
+      $field = $field . '_';
+
+      if (is_object($relDAO) && $relationField == 'id') {
+        $row[$field . $relationField] = $relDAO->contact_id;
+      }
+      elseif (is_array($relationValue) && $relationField == 'location') {
+        foreach ($relationValue as $ltype => $val) {
+          foreach (array_keys($val) as $fld) {
+            $type = explode('-', $fld);
+            $fldValue = "{$ltype}-" . $type[0];
+            if (!empty($type[1])) {
+              $fldValue .= "-" . $type[1];
+            }
+            // CRM-3157: localise country, region (both have ‘country’ context)
+            // and state_province (‘province’ context)
+            switch (TRUE) {
+              case (!is_object($relDAO)):
+                $row[$field . '_' . $fldValue] = '';
+                break;
+
+              case in_array('country', $type):
+              case in_array('world_region', $type):
+                $row[$field . '_' . $fldValue] = $i18n->crm_translate($relDAO->$fldValue,
+                  array('context' => 'country')
+                );
+                break;
+
+              case in_array('state_province', $type):
+                $row[$field . '_' . $fldValue] = $i18n->crm_translate($relDAO->$fldValue,
+                  array('context' => 'province')
+                );
+                break;
+
+              default:
+                $row[$field . '_' . $fldValue] = $relDAO->$fldValue;
+                break;
+            }
+          }
+        }
+      }
+      elseif (isset($fieldValue) && $fieldValue != '') {
+        //check for custom data
+        if ($cfID = CRM_Core_BAO_CustomField::getKeyID($relationField)) {
+          $row[$field . $relationField] = CRM_Core_BAO_CustomField::displayValue($fieldValue, $cfID);
+        }
+        else {
+          //normal relationship fields
+          // CRM-3157: localise country, region (both have ‘country’ context) and state_province (‘province’ context)
+          switch ($relationField) {
+            case 'country':
+            case 'world_region':
+              $row[$field . $relationField] = $i18n->crm_translate($fieldValue, array('context' => 'country'));
+              break;
+
+            case 'state_province':
+              $row[$field . $relationField] = $i18n->crm_translate($fieldValue, array('context' => 'province'));
+              break;
+
+            default:
+              $row[$field . $relationField] = $fieldValue;
+              break;
+          }
+        }
+      }
+      else {
+        // if relation field is empty or null
+        $row[$field . $relationField] = '';
+      }
+    }
   }
 
 }

--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -770,27 +770,15 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
     $limitReached = FALSE;
     while (!$limitReached) {
       $limitQuery = "{$queryString} LIMIT {$offset}, {$rowCount}";
-      $dao = CRM_Core_DAO::executeQuery($limitQuery);
+      $iterationDAO = CRM_Core_DAO::executeQuery($limitQuery);
       // If this is less than our limit by the end of the iteration we do not need to run the query again to
       // check if some remain.
       $rowsThisIteration = 0;
 
-      while ($dao->fetch()) {
+      while ($iterationDAO->fetch()) {
         $count++;
         $rowsThisIteration++;
         $row = array();
-
-        //convert the pseudo constants
-        // CRM-14398 there is problem in this architecture that is not easily solved. For now we are using the cloned
-        // temporary iterationDAO object to get around it.
-        // the issue is that the convertToPseudoNames function is adding additional properties (e.g for campaign) to the DAO object
-        // these additional properties are NOT reset when the $dao cycles through the while loop
-        // nor are they overwritten as they are not in the loop
-        // the convertToPseudoNames will not adequately over-write them either as it doesn't 'kick-in' unless the
-        // relevant property is set.
-        // It may be that a long-term fix could be introduced there - however, it's probably necessary to figure out how to test the
-        // export class before tackling a better architectural fix
-        $iterationDAO = clone $dao;
         $query->convertToPseudoNames($iterationDAO);
 
         //first loop through output columns so that we return what is required, and in same order.
@@ -1070,7 +1058,6 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
           $componentDetails = array();
         }
       }
-      $dao->free();
       if ($rowsThisIteration < self::EXPORT_ROW_COUNT) {
         $limitReached = TRUE;
       }

--- a/CRM/Export/Form/Select.php
+++ b/CRM/Export/Form/Select.php
@@ -70,8 +70,6 @@ class CRM_Export_Form_Select extends CRM_Core_Form {
 
   public $_componentTable;
 
-  public $_customSearchID;
-
   /**
    * Build all the data structures needed to build the form.
    *
@@ -83,7 +81,13 @@ class CRM_Export_Form_Select extends CRM_Core_Form {
     $this->preventAjaxSubmit();
 
     //special case for custom search, directly give option to download csv file
-    $this->_customSearchID = $this->get('customSearchID');
+    $customSearchID = $this->get('customSearchID');
+    if ($customSearchID) {
+      CRM_Export_BAO_Export::exportCustom($this->get('customSearchClass'),
+        $this->get('formValues'),
+        $this->get(CRM_Utils_Sort::SORT_ORDER)
+      );
+    }
 
     $this->_selectAll = FALSE;
     $this->_exportMode = self::CONTACT_EXPORT;
@@ -95,11 +99,7 @@ class CRM_Export_Form_Select extends CRM_Core_Form {
     $isStandalone = $formName == 'CRM_Export_StateMachine_Standalone';
 
     // get the submitted values based on search
-    if ($this->_customSearchID) {
-      $values = $this->get('formValues');
-      $this->assign('exportCustomSearchField', TRUE);
-    }
-    elseif ($this->_action == CRM_Core_Action::ADVANCED) {
+    if ($this->_action == CRM_Core_Action::ADVANCED) {
       $values = $this->controller->exportValues('Advanced');
     }
     elseif ($this->_action == CRM_Core_Action::PROFILE) {
@@ -231,7 +231,7 @@ FROM   {$this->_componentTable}
     $exportOptions = $mergeOptions = $postalMailing = array();
     $exportOptions[] = $this->createElement('radio',
       NULL, NULL,
-      ts('Export %1 fields', array(1 => empty($this->_customSearchID) ? 'PRIMARY' : 'custom search')),
+      ts('Export PRIMARY fields'),
       self::EXPORT_ALL,
       array('onClick' => 'showMappingOption( );')
     );
@@ -396,28 +396,20 @@ FROM   {$this->_componentTable}
     }
 
     if ($exportOption == self::EXPORT_ALL) {
-      if ($this->_customSearchID) {
-        CRM_Export_BAO_Export::exportCustom($this->get('customSearchClass'),
-          $this->get('formValues'),
-          $this->get(CRM_Utils_Sort::SORT_ORDER)
-        );
-      }
-      else {
-        CRM_Export_BAO_Export::exportComponents($this->_selectAll,
-          $this->_componentIds,
-          (array) $this->get('queryParams'),
-          $this->get(CRM_Utils_Sort::SORT_ORDER),
-          NULL,
-          $this->get('returnProperties'),
-          $this->_exportMode,
-          $this->_componentClause,
-          $this->_componentTable,
-          $mergeSameAddress,
-          $mergeSameHousehold,
-          $exportParams,
-          $this->get('queryOperator')
-        );
-      }
+      CRM_Export_BAO_Export::exportComponents($this->_selectAll,
+        $this->_componentIds,
+        (array) $this->get('queryParams'),
+        $this->get(CRM_Utils_Sort::SORT_ORDER),
+        NULL,
+        $this->get('returnProperties'),
+        $this->_exportMode,
+        $this->_componentClause,
+        $this->_componentTable,
+        $mergeSameAddress,
+        $mergeSameHousehold,
+        $exportParams,
+        $this->get('queryOperator')
+      );
     }
 
     //reset map page

--- a/CRM/Financial/Form/FinancialBatch.php
+++ b/CRM/Financial/Form/FinancialBatch.php
@@ -114,10 +114,10 @@ class CRM_Financial_Form_FinancialBatch extends CRM_Contribute_Form {
     );
 
     if ($this->_action & CRM_Core_Action::UPDATE && $this->_id) {
-      $batchStatus = CRM_Core_PseudoConstant::get('CRM_Batch_DAO_Batch', 'status_id');
+      $batchStatus = CRM_Core_PseudoConstant::get('CRM_Batch_BAO_Batch', 'status_id');
 
       // unset exported status
-      $exportedStatusId = CRM_Utils_Array::key('Exported', $batchStatus);
+      $exportedStatusId = CRM_Core_PseudoConstant::getKey('CRM_Batch_BAO_Batch', 'status_id', 'Exported');
       unset($batchStatus[$exportedStatusId]);
       $this->add('select', 'status_id', ts('Batch Status'), array('' => ts('- select -')) + $batchStatus, TRUE);
       $this->freeze(array('status_id'));
@@ -196,7 +196,7 @@ class CRM_Financial_Form_FinancialBatch extends CRM_Contribute_Form {
   public function postProcess() {
     $session = CRM_Core_Session::singleton();
     $params = $this->exportValues();
-    $batchStatus = CRM_Core_PseudoConstant::get('CRM_Batch_DAO_Batch', 'status_id');
+    $closedStatusId = CRM_Core_PseudoConstant::getKey('CRM_Batch_BAO_Batch', 'status_id', 'Closed');
     if ($this->_id) {
       $params['id'] = $this->_id;
     }
@@ -209,9 +209,8 @@ class CRM_Financial_Form_FinancialBatch extends CRM_Contribute_Form {
     }
 
     if ($this->_action & CRM_Core_Action::ADD) {
-      $batchMode = CRM_Core_PseudoConstant::get('CRM_Batch_DAO_Batch', 'mode_id', array('labelColumn' => 'name'));
-      $params['mode_id'] = CRM_Utils_Array::key('Manual Batch', $batchMode);
-      $params['status_id'] = CRM_Utils_Array::key('Open', $batchStatus);
+      $params['mode_id'] = CRM_Core_PseudoConstant::getKey('CRM_Batch_BAO_Batch', 'mode_id', 'Manual Batch');
+      $params['status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Batch_BAO_Batch', 'status_id', 'Open');
       $params['created_date'] = date('YmdHis');
       if (empty($params['created_id'])) {
         $params['created_id'] = $session->get('userID');
@@ -221,25 +220,25 @@ class CRM_Financial_Form_FinancialBatch extends CRM_Contribute_Form {
     }
     elseif ($this->_action & CRM_Core_Action::UPDATE && $this->_id) {
       $details = "{$params['title']} batch has been edited by this contact.";
-      if (CRM_Utils_Array::value($params['status_id'], $batchStatus) == 'Closed') {
+      if ($params['status_id'] === $closedStatusId) {
         $details = "{$params['title']} batch has been closed by this contact.";
       }
       $activityTypeName = 'Edit Batch';
     }
+
+    // FIXME: What happens if we get to here and no activityType is defined?
 
     $batch = CRM_Batch_BAO_Batch::create($params);
 
     //set batch id
     $this->_id = $batch->id;
 
-    $activityTypes = CRM_Core_PseudoConstant::activityType(TRUE, FALSE, FALSE, 'name');
-
     // create activity.
     $activityParams = array(
-      'activity_type_id' => array_search($activityTypeName, $activityTypes),
+      'activity_type_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_DAO_Activity', 'activity_type_id', $activityTypeName),
       'subject' => $batch->title . "- Batch",
-      'status_id' => 2,
-      'priority_id' => 2,
+      'status_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_DAO_Activity', 'activity_status_id', 'Completed'),
+      'priority_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_DAO_Activity', 'priority_id', 'Normal'),
       'activity_date_time' => date('YmdHis'),
       'source_contact_id' => $session->get('userID'),
       'source_contact_qid' => $session->get('userID'),
@@ -262,7 +261,7 @@ class CRM_Financial_Form_FinancialBatch extends CRM_Contribute_Form {
       $session->replaceUserContext(CRM_Utils_System::url('civicrm/financial/batch',
         "reset=1&action=add"));
     }
-    elseif (CRM_Utils_Array::value($batch->status_id, $batchStatus) == 'Closed') {
+    elseif ($batch->status_id === $closedStatusId) {
       $session->replaceUserContext(CRM_Utils_System::url('civicrm', 'reset=1'));
     }
     elseif (($buttonName == $this->getButtonName('next') & $this->_action == CRM_Core_Action::UPDATE) ||

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -128,7 +128,7 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing {
     $recipientsGroup = $excludeSmartGroupIDs = $includeSmartGroupIDs = $priorMailingIDs = array();
     $dao = CRM_Utils_SQL_Select::from('civicrm_mailing_group')
              ->select('GROUP_CONCAT(entity_id SEPARATOR ",") as group_ids, group_type, entity_table')
-             ->where('mailing_id = #mailing_id AND entity_table IN ("!groupTableName", "civicrm_mailing")')
+             ->where('mailing_id = #mailing_id AND entity_table RLIKE "^civicrm_(group.*|mailing)$" ')
              ->groupBy(array('group_type', 'entity_table'))
              ->param('!groupTableName', CRM_Contact_BAO_Group::getTableName())
              ->param('#mailing_id', $mailingID)
@@ -138,7 +138,7 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing {
         $priorMailingIDs[$dao->group_type] = explode(',', $dao->group_ids);
       }
       else {
-        $recipientsGroup[$dao->group_type] = explode(',', $dao->group_ids);
+        $recipientsGroup[$dao->group_type] = empty($recipientsGroup[$dao->group_type]) ? explode(',', $dao->group_ids) : array_merge($recipientsGroup[$dao->group_type], explode(',', $dao->group_ids));
       }
     }
 

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1997,12 +1997,16 @@ ORDER BY   civicrm_email.is_bulkmail DESC
         $row['bounce_rate'] = (100.0 * $mailing->bounce) / $mailing->queue;
         $row['unsubscribe_rate'] = (100.0 * $row['unsubscribe']) / $mailing->queue;
         $row['optout_rate'] = (100.0 * $row['optout']) / $mailing->queue;
+        $row['opened_rate'] = $mailing->delivered ? (($row['opened'] / $mailing->delivered) * 100.0) : 0;
+        $row['clickthrough_rate'] = $mailing->delivered ? (($mailing->url / $mailing->delivered) * 100.0) : 0;
       }
       else {
         $row['delivered_rate'] = 0;
         $row['bounce_rate'] = 0;
         $row['unsubscribe_rate'] = 0;
         $row['optout_rate'] = 0;
+        $row['opened_rate'] = 0;
+        $row['clickthrough_rate'] = 0;
       }
 
       $row['links'] = array(
@@ -2066,12 +2070,16 @@ ORDER BY   civicrm_email.is_bulkmail DESC
       $report['event_totals']['bounce_rate'] = (100.0 * $report['event_totals']['bounce']) / $report['event_totals']['queue'];
       $report['event_totals']['unsubscribe_rate'] = (100.0 * $report['event_totals']['unsubscribe']) / $report['event_totals']['queue'];
       $report['event_totals']['optout_rate'] = (100.0 * $report['event_totals']['optout']) / $report['event_totals']['queue'];
+      $report['event_totals']['opened_rate'] = !empty($report['event_totals']['delivered']) ? (($report['event_totals']['opened'] / $report['event_totals']['delivered']) * 100.0) : 0;
+      $report['event_totals']['clickthrough_rate'] = !empty($report['event_totals']['delivered']) ? (($report['event_totals']['url'] / $report['event_totals']['delivered']) * 100.0) : 0;
     }
     else {
       $report['event_totals']['delivered_rate'] = 0;
       $report['event_totals']['bounce_rate'] = 0;
       $report['event_totals']['unsubscribe_rate'] = 0;
       $report['event_totals']['optout_rate'] = 0;
+      $report['event_totals']['opened_rate'] = 0;
+      $report['event_totals']['clickthrough_rate'] = 0;
     }
 
     /* Get the click-through totals, grouped by URL */

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -128,8 +128,9 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing {
     $recipientsGroup = $excludeSmartGroupIDs = $includeSmartGroupIDs = $priorMailingIDs = array();
     $dao = CRM_Utils_SQL_Select::from('civicrm_mailing_group')
              ->select('GROUP_CONCAT(entity_id SEPARATOR ",") as group_ids, group_type, entity_table')
-             ->where('mailing_id = #mailing_id AND entity_table IN ("civicrm_group", "civicrm_mailing")')
+             ->where('mailing_id = #mailing_id AND entity_table IN ("!groupTableName", "civicrm_mailing")')
              ->groupBy(array('group_type', 'entity_table'))
+             ->param('!groupTableName', CRM_Contact_BAO_Group::getTableName())
              ->param('#mailing_id', $mailingID)
              ->execute();
     while ($dao->fetch()) {
@@ -2876,25 +2877,6 @@ ORDER BY civicrm_mailing.name";
     }
 
     return $list;
-  }
-
-  /**
-   * @param int $mid
-   *
-   * @return null|string
-   */
-  public static function hiddenMailingGroup($mid) {
-    $sql = "
-SELECT     g.id
-FROM       civicrm_mailing m
-INNER JOIN civicrm_mailing_group mg ON mg.mailing_id = m.id
-INNER JOIN civicrm_group g ON mg.entity_id = g.id AND mg.entity_table = 'civicrm_group'
-WHERE      g.is_hidden = 1
-AND        mg.group_type = 'Include'
-AND        m.id = %1
-";
-    $params = array(1 => array($mid, 'Integer'));
-    return CRM_Core_DAO::singleValueQuery($sql, $params);
   }
 
   /**

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -2125,9 +2125,12 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = membership.contact_id AND 
    */
   protected static function updateDeceasedMembersStatuses() {
     $count = 0;
+
+    $deceasedStatusId = CRM_Core_PseudoConstant::getKey('CRM_Member_BAO_Membership', 'status_id', 'Deceased');
+
     // 'create' context for buildOptions returns only if enabled.
     $allStatus = self::buildOptions('status_id', 'create');
-    if (($deceasedStatusId = array_search('Deceased', $allStatus)) === FALSE) {
+    if (array_key_exists($deceasedStatusId, $allStatus) === FALSE) {
       // Deceased status is an admin status & is required. We want to fail early if
       // it is not present or active.
       // We could make the case 'some databases just don't use deceased so we will check

--- a/CRM/Member/Form/MembershipType.php
+++ b/CRM/Member/Form/MembershipType.php
@@ -109,6 +109,9 @@ class CRM_Member_Form_MembershipType extends CRM_Member_Form_MembershipConfig {
    * Build the form object.
    *
    * @return void
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
+   * @throws \HTML_QuickForm_Error
    */
   public function buildQuickForm() {
     parent::buildQuickForm();
@@ -133,7 +136,7 @@ class CRM_Member_Form_MembershipType extends CRM_Member_Form_MembershipConfig {
 
     $this->addSelect('duration_unit', array(), TRUE);
 
-    //period type
+    // period type
     $this->addSelect('period_type', array(), TRUE);
 
     $this->add('text', 'duration_interval', ts('Duration Interval'),
@@ -148,7 +151,7 @@ class CRM_Member_Form_MembershipType extends CRM_Member_Form_MembershipConfig {
       CRM_Core_SelectValues::date(NULL, 'M d'), FALSE
     );
 
-    //Auto-renew Option
+    // Auto-renew Option
     $paymentProcessor = CRM_Core_PseudoConstant::paymentProcessor(FALSE, FALSE, 'is_recur = 1');
     $isAuthorize = FALSE;
     $options = array();
@@ -160,7 +163,7 @@ class CRM_Member_Form_MembershipType extends CRM_Member_Form_MembershipConfig {
     $this->addRadio('auto_renew', ts('Auto-renew Option'), $options);
     $this->assign('authorize', $isAuthorize);
 
-    //rollover day
+    // rollover day
     $this->add('date', 'fixed_period_rollover_day', ts('Fixed Period Rollover Day'),
       CRM_Core_SelectValues::date(NULL, 'M d'), FALSE
     );
@@ -292,7 +295,6 @@ class CRM_Member_Form_MembershipType extends CRM_Member_Form_MembershipConfig {
   /**
    * Process the form submission.
    *
-   *
    * @return void
    */
   public function postProcess() {
@@ -333,7 +335,6 @@ class CRM_Member_Form_MembershipType extends CRM_Member_Form_MembershipConfig {
         $params[$fld] = CRM_Utils_Array::value($fld, $submitted, 'NULL');
       }
 
-      //clean money.
       if ($params['minimum_fee']) {
         $params['minimum_fee'] = CRM_Utils_Rule::cleanMoney($params['minimum_fee']);
       }

--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -769,7 +769,7 @@ WHERE li.contribution_id = %1";
           ));
           unset($updateFinancialItemInfoValues['financialTrxn']);
         }
-        elseif (!empty($updateFinancialItemInfoValues['link-financial-trxn'])) {
+        elseif (!empty($updateFinancialItemInfoValues['link-financial-trxn']) && $newFinancialItem->amount != 0) {
           civicrm_api3('EntityFinancialTrxn', 'create', array(
             'entity_id' => $newFinancialItem->id,
             'entity_table' => 'civicrm_financial_item',

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -4305,8 +4305,12 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
 
   /**
    * Add Address into From Table if required.
+   *
+   * @deprecated use joinAddressFromContact
+   * (left here in case extensions use it).
    */
   public function addAddressFromClause() {
+    Civi::log()->warning('Deprecated function addAddressFromClause. Use joinAddressFromContact.', array('civi.tag' => 'deprecated'));
     // include address field if address column is to be included
     if ((isset($this->_addressField) &&
         $this->_addressField
@@ -4323,8 +4327,13 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
 
   /**
    * Add Phone into From Table if required.
+   *
+   * @deprecated use joinPhoneFromContact
+   *  (left here in case extensions use it).
    */
   public function addPhoneFromClause() {
+
+    Civi::log()->warning('Deprecated function addPhoneFromClause. Use joinPhoneFromContact.', array('civi.tag' => 'deprecated'));
     // include address field if address column is to be included
     if ($this->isTableSelected('civicrm_phone')) {
       $this->_from .= "

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -1393,7 +1393,7 @@ class CRM_Report_Form extends CRM_Core_Form {
     foreach ($this->_columns as $tableName => $table) {
       if (array_key_exists('group_bys', $table)) {
         foreach ($table['group_bys'] as $fieldName => $field) {
-          if (!empty($field)) {
+          if (!empty($field) && empty($field['no_display'])) {
             $options[$field['title']] = $fieldName;
             if (!empty($field['frequency'])) {
               $freqElements[$field['title']] = $fieldName;
@@ -5291,45 +5291,45 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
    */
   protected function storeGroupByArray() {
 
-    if (CRM_Utils_Array::value('group_bys', $this->_params) &&
-      is_array($this->_params['group_bys']) &&
-      !empty($this->_params['group_bys'])
-    ) {
-      foreach ($this->_columns as $tableName => $table) {
-        $table = $this->_columns[$tableName];
-        if (array_key_exists('group_bys', $table)) {
-          foreach ($table['group_bys'] as $fieldName => $fieldData) {
-            $field = $this->_columns[$tableName]['metadata'][$fieldName];
-            if (!empty($this->_params['group_bys'][$fieldName])) {
-              if (!empty($field['chart'])) {
-                $this->assign('chartSupported', TRUE);
+    if (!CRM_Utils_Array::value('group_bys', $this->_params)
+      || !is_array($this->_params['group_bys'])) {
+      $this->_params['group_bys'] = [];
+    }
+
+    foreach ($this->_columns as $tableName => $table) {
+      $table = $this->_columns[$tableName];
+      if (array_key_exists('group_bys', $table)) {
+        foreach ($table['group_bys'] as $fieldName => $fieldData) {
+          $field = $this->_columns[$tableName]['metadata'][$fieldName];
+          if (!empty($this->_params['group_bys'][$fieldName]) || !empty($fieldData['required'])) {
+            if (!empty($field['chart'])) {
+              $this->assign('chartSupported', TRUE);
+            }
+
+            if (!empty($table['group_bys'][$fieldName]['frequency']) &&
+              !empty($this->_params['group_bys_freq'][$fieldName])
+            ) {
+
+              switch ($this->_params['group_bys_freq'][$fieldName]) {
+                case 'FISCALYEAR':
+                  $this->_groupByArray[$tableName . '_' . $fieldName . '_start'] = self::fiscalYearOffset($field['dbAlias']);
+
+                case 'YEAR':
+                  $this->_groupByArray[$tableName . '_' . $fieldName . '_start'] = " {$this->_params['group_bys_freq'][$fieldName]}({$field['dbAlias']})";
+
+                default:
+                  $this->_groupByArray[$tableName . '_' . $fieldName . '_start'] = "EXTRACT(YEAR_{$this->_params['group_bys_freq'][$fieldName]} FROM {$field['dbAlias']})";
+
               }
-
-              if (!empty($table['group_bys'][$fieldName]['frequency']) &&
-                !empty($this->_params['group_bys_freq'][$fieldName])
-              ) {
-
-                switch ($this->_params['group_bys_freq'][$fieldName]) {
-                  case 'FISCALYEAR':
-                    $this->_groupByArray[$tableName . '_' . $fieldName . '_start'] = self::fiscalYearOffset($field['dbAlias']);
-
-                  case 'YEAR':
-                    $this->_groupByArray[$tableName . '_' . $fieldName . '_start'] = " {$this->_params['group_bys_freq'][$fieldName]}({$field['dbAlias']})";
-
-                  default:
-                    $this->_groupByArray[$tableName . '_' . $fieldName . '_start'] = "EXTRACT(YEAR_{$this->_params['group_bys_freq'][$fieldName]} FROM {$field['dbAlias']})";
-
-                }
-              }
-              else {
-                if (!in_array($field['dbAlias'], $this->_groupByArray)) {
-                  $this->_groupByArray[$tableName . '_' . $fieldName] = $field['dbAlias'];
-                }
+            }
+            else {
+              if (!in_array($field['dbAlias'], $this->_groupByArray)) {
+                $this->_groupByArray[$tableName . '_' . $fieldName] = $field['dbAlias'];
               }
             }
           }
-
         }
+
       }
     }
   }

--- a/CRM/Report/Form/Contact/CurrentEmployer.php
+++ b/CRM/Report/Form/Contact/CurrentEmployer.php
@@ -252,17 +252,11 @@ FROM civicrm_contact {$this->_aliases['civicrm_contact']}
      LEFT JOIN civicrm_relationship {$this->_aliases['civicrm_relationship']}
           ON ( {$this->_aliases['civicrm_relationship']}.contact_id_a={$this->_aliases['civicrm_contact']}.id
               AND {$this->_aliases['civicrm_relationship']}.contact_id_b={$this->_aliases['civicrm_contact']}.employer_id
-              AND {$this->_aliases['civicrm_relationship']}.relationship_type_id={$relType})
-     LEFT JOIN civicrm_address {$this->_aliases['civicrm_address']}
-          ON ({$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_address']}.contact_id
-             AND {$this->_aliases['civicrm_address']}.is_primary = 1 )
+              AND {$this->_aliases['civicrm_relationship']}.relationship_type_id={$relType})  ";
 
-     LEFT JOIN  civicrm_phone {$this->_aliases['civicrm_phone']}
-          ON ({$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_phone']}.contact_id
-             AND {$this->_aliases['civicrm_phone']}.is_primary = 1)
-     LEFT JOIN  civicrm_email {$this->_aliases['civicrm_email']}
-          ON ({$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_email']}.contact_id
-             AND {$this->_aliases['civicrm_email']}.is_primary = 1) ";
+    $this->joinAddressFromContact();
+    $this->joinPhoneFromContact();
+    $this->joinEmailFromContact();
   }
 
   public function where() {

--- a/CRM/Report/Form/Contribute/Bookkeeping.php
+++ b/CRM/Report/Form/Contribute/Bookkeeping.php
@@ -31,9 +31,6 @@
  * @copyright CiviCRM LLC (c) 2004-2018
  */
 class CRM_Report_Form_Contribute_Bookkeeping extends CRM_Report_Form {
-  protected $_addressField = FALSE;
-
-  protected $_emailField = FALSE;
 
   protected $_summary = NULL;
 

--- a/CRM/Report/Form/Contribute/History.php
+++ b/CRM/Report/Form/Contribute/History.php
@@ -29,15 +29,10 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2018
- * $Id$
- *
  */
 class CRM_Report_Form_Contribute_History extends CRM_Report_Form {
   // Primary Contacts count limitCONSTROW_COUNT_LIMIT = 10;
 
-  protected $_addressField = FALSE;
-  protected $_emailField = FALSE;
-  protected $_phoneField = FALSE;
   protected $_relationshipColumns = array();
 
   protected $_customGroupExtends = array(
@@ -327,6 +322,7 @@ class CRM_Report_Form_Contribute_History extends CRM_Report_Form {
 
   public function select() {
     $select = array();
+    // @todo remove this & use parent (with maybe some override in this or better yet selectWhere fn)
     $this->_columnHeaders = array();
 
     foreach ($this->_columns as $tableName => $table) {
@@ -336,15 +332,6 @@ class CRM_Report_Form_Contribute_History extends CRM_Report_Form {
           if (!empty($field['required']) ||
             !empty($this->_params['fields'][$fieldName])
           ) {
-            if ($tableName == 'civicrm_address') {
-              $this->_addressField = TRUE;
-            }
-            if ($tableName == 'civicrm_email') {
-              $this->_emailField = TRUE;
-            }
-            if ($tableName == 'civicrm_phone') {
-              $this->_phoneField = TRUE;
-            }
             if ($tableName == 'civicrm_relationship') {
               $this->_relationshipColumns["{$tableName}_{$fieldName}"] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
               $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
@@ -398,23 +385,13 @@ class CRM_Report_Form_Contribute_History extends CRM_Report_Form {
                      ON {$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_contribution']}.contact_id AND
                         {$this->_aliases['civicrm_contribution']}.is_test = 0 ";
 
-    if ($this->_emailField) {
-      $this->_from .= " LEFT JOIN civicrm_email {$this->_aliases['civicrm_email']}
-                     ON ({$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_email']}.contact_id AND
-                        {$this->_aliases['civicrm_email']}.is_primary = 1) ";
-    }
-
-    if ($this->_phoneField) {
-      $this->_from .= " LEFT JOIN civicrm_phone {$this->_aliases['civicrm_phone']}
-                     ON ({$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_phone']}.contact_id AND
-                        {$this->_aliases['civicrm_phone']}.is_primary = 1) ";
-    }
-
     $relContacAlias = 'contact_relationship';
     $this->_relationshipFrom = " INNER JOIN civicrm_relationship {$this->_aliases['civicrm_relationship']}
                      ON (({$this->_aliases['civicrm_relationship']}.contact_id_a = {$relContacAlias}.id OR {$this->_aliases['civicrm_relationship']}.contact_id_b = {$relContacAlias}.id ) AND {$this->_aliases['civicrm_relationship']}.is_active = 1) ";
 
-    $this->addAddressFromClause();
+    $this->joinAddressFromContact();
+    $this->joinPhoneFromContact();
+    $this->joinEmailFromContact();
 
     // for credit card type
     $this->addFinancialTrxnFromClause();

--- a/CRM/Report/Form/Contribute/HouseholdSummary.php
+++ b/CRM/Report/Form/Contribute/HouseholdSummary.php
@@ -29,14 +29,8 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2018
- * $Id$
- *
  */
 class CRM_Report_Form_Contribute_HouseholdSummary extends CRM_Report_Form {
-
-  protected $_addressField = FALSE;
-
-  protected $_emailField = FALSE;
 
   public $_drilldownReport = array('contribute/detail' => 'Link to Detail Report');
 
@@ -232,11 +226,8 @@ class CRM_Report_Form_Contribute_HouseholdSummary extends CRM_Report_Form {
     parent::__construct();
   }
 
-  public function preProcess() {
-    parent::preProcess();
-  }
-
   public function select() {
+    // @todo remove this & use parent select.
     $this->_columnHeaders = $select = array();
     foreach ($this->_columns as $tableName => $table) {
       if (array_key_exists('fields', $table)) {
@@ -244,12 +235,6 @@ class CRM_Report_Form_Contribute_HouseholdSummary extends CRM_Report_Form {
           if (!empty($field['required']) ||
             !empty($this->_params['fields'][$fieldName])
           ) {
-            if ($tableName == 'civicrm_address') {
-              $this->_addressField = TRUE;
-            }
-            elseif ($tableName == 'civicrm_email') {
-              $this->_emailField = TRUE;
-            }
 
             if (!empty($field['statistics'])) {
               foreach ($field['statistics'] as $stat => $label) {
@@ -274,8 +259,6 @@ class CRM_Report_Form_Contribute_HouseholdSummary extends CRM_Report_Form {
   }
 
   public function from() {
-
-    $this->_from = NULL;
     $this->_from = "
         FROM  civicrm_relationship {$this->_aliases['civicrm_relationship']}
             LEFT  JOIN civicrm_contact {$this->_aliases['civicrm_contact_household']} ON
@@ -286,18 +269,8 @@ class CRM_Report_Form_Contribute_HouseholdSummary extends CRM_Report_Form {
             INNER JOIN civicrm_contribution {$this->_aliases['civicrm_contribution']} ON
                       ({$this->_aliases['civicrm_contribution']}.contact_id = {$this->_aliases['civicrm_relationship']}.$this->otherContact ) AND {$this->_aliases['civicrm_contribution']}.is_test = 0 ";
 
-    if ($this->_addressField) {
-      $this->_from .= "
-            LEFT JOIN civicrm_address  {$this->_aliases['civicrm_address']} ON
-                      {$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_address']}.contact_id AND
-                      {$this->_aliases['civicrm_address']}.is_primary = 1\n ";
-    }
-    if ($this->_emailField) {
-      $this->_from .= "
-            LEFT JOIN civicrm_email {$this->_aliases['civicrm_email']} ON
-                      {$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_email']}.contact_id AND
-                      {$this->_aliases['civicrm_email']}.is_primary = 1\n ";
-    }
+    $this->joinAddressFromContact();
+    $this->joinEmailFromContact();
 
     // for credit card type
     $this->addFinancialTrxnFromClause();

--- a/CRM/Report/Form/Contribute/Lybunt.php
+++ b/CRM/Report/Form/Contribute/Lybunt.php
@@ -345,19 +345,10 @@ class CRM_Report_Form_Contribute_Lybunt extends CRM_Report_Form {
           AND {$this->_aliases['civicrm_contribution']}.is_test = 0
         INNER JOIN civicrm_contact {$this->_aliases['civicrm_contact']}
           ON restricted_contacts.cid = {$this->_aliases['civicrm_contact']}.id";
-      if ($this->isTableSelected('civicrm_email')) {
-        $this->_from .= "
-          LEFT  JOIN civicrm_email  {$this->_aliases['civicrm_email']}
-            ON {$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_email']}.contact_id
-            AND {$this->_aliases['civicrm_email']}.is_primary = 1";
-      }
-      if ($this->isTableSelected('civicrm_phone')) {
-        $this->_from .= "
-          LEFT  JOIN civicrm_phone  {$this->_aliases['civicrm_phone']}
-            ON {$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_phone']}.contact_id
-            AND {$this->_aliases['civicrm_phone']}.is_primary = 1";
-      }
-      $this->addAddressFromClause();
+
+      $this->joinAddressFromContact();
+      $this->joinPhoneFromContact();
+      $this->joinEmailFromContact();
     }
     else {
       $this->setFromBase('civicrm_contact');

--- a/CRM/Report/Form/Contribute/OrganizationSummary.php
+++ b/CRM/Report/Form/Contribute/OrganizationSummary.php
@@ -32,10 +32,6 @@
  */
 class CRM_Report_Form_Contribute_OrganizationSummary extends CRM_Report_Form {
 
-  protected $_addressField = FALSE;
-
-  protected $_emailField = FALSE;
-
   public $_drilldownReport = array('contribute/detail' => 'Link to Detail Report');
 
   protected $_summary = NULL;
@@ -238,17 +234,12 @@ class CRM_Report_Form_Contribute_OrganizationSummary extends CRM_Report_Form {
   }
 
   public function select() {
+    // @todo remove this in favour of using parent function
     $this->_columnHeaders = $select = array();
     foreach ($this->_columns as $tableName => $table) {
       if (array_key_exists('fields', $table)) {
         foreach ($table['fields'] as $fieldName => $field) {
           if (!empty($field['required']) || !empty($this->_params['fields'][$fieldName])) {
-            if ($tableName == 'civicrm_address') {
-              $this->_addressField = TRUE;
-            }
-            elseif ($tableName == 'civicrm_email') {
-              $this->_emailField = TRUE;
-            }
 
             if (!empty($field['statistics'])) {
               foreach ($field['statistics'] as $stat => $label) {
@@ -285,18 +276,8 @@ class CRM_Report_Form_Contribute_OrganizationSummary extends CRM_Report_Form {
             INNER JOIN civicrm_contribution {$this->_aliases['civicrm_contribution']} ON
                       ({$this->_aliases['civicrm_contribution']}.contact_id = {$this->_aliases['civicrm_relationship']}.$this->otherContact ) AND {$this->_aliases['civicrm_contribution']}.is_test = 0  ";
 
-    if ($this->_addressField) {
-      $this->_from .= "
-            LEFT JOIN civicrm_address  {$this->_aliases['civicrm_address']} ON
-                      {$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_address']}.contact_id AND
-                      {$this->_aliases['civicrm_address']}.is_primary = 1\n ";
-    }
-    if ($this->_emailField) {
-      $this->_from .= "
-            LEFT JOIN civicrm_email {$this->_aliases['civicrm_email']} ON
-                      {$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_email']}.contact_id AND
-                      {$this->_aliases['civicrm_email']}.is_primary = 1\n ";
-    }
+    $this->joinAddressFromContact();
+    $this->joinEmailFromContact();
 
     // for credit card type
     $this->addFinancialTrxnFromClause();

--- a/CRM/Report/Form/Contribute/Recur.php
+++ b/CRM/Report/Form/Contribute/Recur.php
@@ -273,14 +273,9 @@ class CRM_Report_Form_Contribute_Recur extends CRM_Report_Form {
     $this->_from .= "
       LEFT JOIN civicrm_contribution  {$this->_aliases['civicrm_contribution']}
         ON {$this->_aliases['civicrm_contribution_recur']}.id = {$this->_aliases['civicrm_contribution']}.contribution_recur_id";
-    $this->_from .= "
-      LEFT JOIN civicrm_email  {$this->_aliases['civicrm_email']}
-        ON ({$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_email']}.contact_id AND
-        {$this->_aliases['civicrm_email']}.is_primary = 1)";
-    $this->_from .= "
-      LEFT  JOIN civicrm_phone {$this->_aliases['civicrm_phone']}
-        ON ({$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_phone']}.contact_id AND
-        {$this->_aliases['civicrm_phone']}.is_primary = 1)";
+
+    $this->joinPhoneFromContact();
+    $this->joinEmailFromContact();
 
     // for credit card type
     $this->addFinancialTrxnFromClause();

--- a/CRM/Report/Form/Contribute/RecurSummary.php
+++ b/CRM/Report/Form/Contribute/RecurSummary.php
@@ -94,14 +94,12 @@ class CRM_Report_Form_Contribute_RecurSummary extends CRM_Report_Form {
   }
 
   public function select() {
+    // @todo remove & only adjust parent with selectWhere fn (if needed)
     $select = array();
     $this->_columnHeaders = array();
     foreach ($this->_columns as $tableName => $table) {
       if (array_key_exists('group_bys', $table)) {
         foreach ($table['group_bys'] as $fieldName => $field) {
-          if ($tableName == 'civicrm_address') {
-            $this->_addressField = TRUE;
-          }
           if (!empty($this->_params['group_bys'][$fieldName])) {
             switch (CRM_Utils_Array::value($fieldName, $this->_params['group_bys_freq'])) {
               case 'YEARWEEK':
@@ -150,9 +148,6 @@ class CRM_Report_Form_Contribute_RecurSummary extends CRM_Report_Form {
 
       if (array_key_exists('fields', $table)) {
         foreach ($table['fields'] as $fieldName => $field) {
-          if ($tableName == 'civicrm_address') {
-            $this->_addressField = TRUE;
-          }
           if (!empty($field['required']) ||
             !empty($this->_params['fields'][$fieldName])
           ) {

--- a/CRM/Report/Form/Contribute/Summary.php
+++ b/CRM/Report/Form/Contribute/Summary.php
@@ -31,7 +31,6 @@
  * @copyright CiviCRM LLC (c) 2004-2018
  */
 class CRM_Report_Form_Contribute_Summary extends CRM_Report_Form {
-  protected $_addressField = FALSE;
 
   protected $_charts = array(
     '' => 'Tabular',
@@ -344,9 +343,6 @@ class CRM_Report_Form_Contribute_Summary extends CRM_Report_Form {
     foreach ($this->_columns as $tableName => $table) {
       if (array_key_exists('group_bys', $table)) {
         foreach ($table['group_bys'] as $fieldName => $field) {
-          if ($tableName == 'civicrm_address') {
-            $this->_addressField = TRUE;
-          }
           if (!empty($this->_params['group_bys'][$fieldName])) {
             switch (CRM_Utils_Array::value($fieldName, $this->_params['group_bys_freq'])) {
               case 'YEARWEEK':
@@ -411,9 +407,6 @@ class CRM_Report_Form_Contribute_Summary extends CRM_Report_Form {
 
       if (array_key_exists('fields', $table)) {
         foreach ($table['fields'] as $fieldName => $field) {
-          if ($tableName == 'civicrm_address') {
-            $this->_addressField = TRUE;
-          }
           if (!empty($field['required']) ||
             !empty($this->_params['fields'][$fieldName])
           ) {
@@ -515,15 +508,12 @@ class CRM_Report_Form_Contribute_Summary extends CRM_Report_Form {
              {$softCreditJoin}
              LEFT  JOIN civicrm_financial_type  {$this->_aliases['civicrm_financial_type']}
                      ON {$this->_aliases['civicrm_contribution']}.financial_type_id ={$this->_aliases['civicrm_financial_type']}.id
-             LEFT  JOIN civicrm_email {$this->_aliases['civicrm_email']}
-                     ON ({$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_email']}.contact_id AND
-                        {$this->_aliases['civicrm_email']}.is_primary = 1)
+             ";
 
-             LEFT  JOIN civicrm_phone {$this->_aliases['civicrm_phone']}
-                     ON ({$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_phone']}.contact_id AND
-                        {$this->_aliases['civicrm_phone']}.is_primary = 1)";
+    $this->joinAddressFromContact();
+    $this->joinPhoneFromContact();
+    $this->joinEmailFromContact();
 
-    $this->addAddressFromClause();
     //for contribution batches
     if ($this->isTableSelected('civicrm_batch')) {
       $this->_from .= "

--- a/CRM/Report/Form/Contribute/Sybunt.php
+++ b/CRM/Report/Form/Contribute/Sybunt.php
@@ -352,22 +352,13 @@ class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
                       ON {$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_contribution']}.contact_id
              {$this->_aclFrom}";
 
-    if ($this->isTableSelected('civicrm_email')) {
-      $this->_from .= "
-              LEFT  JOIN civicrm_email  {$this->_aliases['civicrm_email']}
-                      ON {$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_email']}.contact_id
-                     AND {$this->_aliases['civicrm_email']}.is_primary = 1";
-    }
-    if ($this->isTableSelected('civicrm_phone')) {
-      $this->_from .= "
-              LEFT  JOIN civicrm_phone  {$this->_aliases['civicrm_phone']}
-                      ON {$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_phone']}.contact_id AND
-                         {$this->_aliases['civicrm_phone']}.is_primary = 1";
-    }
+    $this->joinPhoneFromContact();
+    $this->joinEmailFromContact();
+
     // for credit card type
     $this->addFinancialTrxnFromClause();
 
-    $this->addAddressFromClause();
+    $this->joinAddressFromContact();
   }
 
   public function where() {

--- a/CRM/Report/Form/Contribute/TopDonor.php
+++ b/CRM/Report/Form/Contribute/TopDonor.php
@@ -253,17 +253,14 @@ class CRM_Report_Form_Contribute_TopDonor extends CRM_Report_Form {
         FROM civicrm_contact {$this->_aliases['civicrm_contact']} {$this->_aclFrom}
             INNER JOIN civicrm_contribution {$this->_aliases['civicrm_contribution']}
                 ON {$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_contribution']}.contact_id AND {$this->_aliases['civicrm_contribution']}.is_test = 0
-             LEFT  JOIN civicrm_email  {$this->_aliases['civicrm_email']}
-                         ON {$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_email']}.contact_id
-                         AND {$this->_aliases['civicrm_email']}.is_primary = 1
-             LEFT  JOIN civicrm_phone  {$this->_aliases['civicrm_phone']}
-                         ON {$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_phone']}.contact_id AND
-                            {$this->_aliases['civicrm_phone']}.is_primary = 1";
+       ";
 
     // for credit card type
     $this->addFinancialTrxnFromClause();
 
-    $this->addAddressFromClause();
+    $this->joinAddressFromContact();
+    $this->joinPhoneFromContact();
+    $this->joinEmailFromContact();
   }
 
   public function where() {

--- a/CRM/Report/Form/Contribute/TopDonor.php
+++ b/CRM/Report/Form/Contribute/TopDonor.php
@@ -104,12 +104,13 @@ class CRM_Report_Form_Contribute_TopDonor extends CRM_Report_Form {
           ),
         ),
         'filters' => $this->getBasicContactFilters(),
+        'group_bys' => ['contact_contact_id' => ['name' => 'id', 'required' => 1, 'no_display' => 1]],
       ),
       'civicrm_line_item' => array(
         'dao' => 'CRM_Price_DAO_LineItem',
       ),
     );
-    $this->_columns += $this->getAddressColumns();
+    $this->_columns += $this->getAddressColumns(['group_by' => FALSE]);
     $this->_columns += array(
       'civicrm_contribution' => array(
         'dao' => 'CRM_Contribute_DAO_Contribution',
@@ -159,6 +160,7 @@ class CRM_Report_Form_Contribute_TopDonor extends CRM_Report_Form {
             'default' => array(1),
           ),
         ),
+        'group_bys' => ['contribution_currency' => ['name' => 'currency', 'required' => 1, 'no_display' => 1]],
       ),
       'civicrm_financial_trxn' => array(
         'dao' => 'CRM_Financial_DAO_FinancialTrxn',
@@ -206,19 +208,6 @@ class CRM_Report_Form_Contribute_TopDonor extends CRM_Report_Form {
     $this->_tagFilter = TRUE;
     $this->_currencyColumn = 'civicrm_contribution_currency';
     parent::__construct();
-  }
-
-  public function preProcess() {
-    parent::preProcess();
-  }
-
-  /**
-   * Select only contact ID when adding to group.
-   *
-   * @todo consider moving that to parent to support AddToGroup in general.
-   */
-  public function select() {
-    parent::select();
   }
 
   /**
@@ -314,10 +303,6 @@ class CRM_Report_Form_Contribute_TopDonor extends CRM_Report_Form {
     if ($this->_aclWhere) {
       $this->_where .= " AND {$this->_aclWhere} ";
     }
-  }
-
-  public function groupBy() {
-    $this->_groupBy = CRM_Contact_BAO_Query::getGroupByFromSelectColumns($this->_selectClauses, array("{$this->_aliases['civicrm_contact']}.id", "{$this->_aliases['civicrm_contribution']}.currency"));
   }
 
   /**

--- a/CRM/Report/Form/Event/ParticipantListCount.php
+++ b/CRM/Report/Form/Event/ParticipantListCount.php
@@ -462,17 +462,12 @@ class CRM_Report_Form_Event_ParticipantListCount extends CRM_Report_Form_Event {
          {$this->_aclFrom}
          LEFT JOIN civicrm_contact {$this->_aliases['civicrm_employer']}
               ON ({$this->_aliases['civicrm_employer']}.id  = {$this->_aliases['civicrm_contact']}.employer_id  )
-         LEFT JOIN civicrm_address {$this->_aliases['civicrm_address']}
-              ON {$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_address']}.contact_id AND
-                {$this->_aliases['civicrm_address']}.is_primary = 1
-         LEFT JOIN  civicrm_email {$this->_aliases['civicrm_email']}
-              ON ({$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_email']}.contact_id AND
-                {$this->_aliases['civicrm_email']}.is_primary = 1)
-         LEFT  JOIN civicrm_phone  {$this->_aliases['civicrm_phone']}
-              ON {$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_phone']}.contact_id AND
-                {$this->_aliases['civicrm_phone']}.is_primary = 1
          LEFT JOIN civicrm_line_item {$this->_aliases['civicrm_line_item']}
               ON {$this->_aliases['civicrm_line_item']}.entity_table = 'civicrm_participant' AND {$this->_aliases['civicrm_participant']}.id ={$this->_aliases['civicrm_line_item']}.entity_id";
+
+    $this->joinAddressFromContact();
+    $this->joinPhoneFromContact();
+    $this->joinEmailFromContact();
   }
 
   public function storeWhereHavingClauseArray() {

--- a/CRM/Report/Form/Event/ParticipantListing.php
+++ b/CRM/Report/Form/Event/ParticipantListing.php
@@ -513,16 +513,12 @@ ORDER BY  cv.label
              LEFT JOIN civicrm_contact {$this->_aliases['civicrm_contact']}
                     ON ({$this->_aliases['civicrm_participant']}.contact_id  = {$this->_aliases['civicrm_contact']}.id  )
              {$this->_aclFrom}
-             LEFT JOIN civicrm_address {$this->_aliases['civicrm_address']}
-                    ON {$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_address']}.contact_id AND
-                       {$this->_aliases['civicrm_address']}.is_primary = 1
-             LEFT JOIN  civicrm_email {$this->_aliases['civicrm_email']}
-                    ON ({$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_email']}.contact_id AND
-                       {$this->_aliases['civicrm_email']}.is_primary = 1)
-             LEFT  JOIN civicrm_phone  {$this->_aliases['civicrm_phone']}
-                     ON {$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_phone']}.contact_id AND
-                         {$this->_aliases['civicrm_phone']}.is_primary = 1
       ";
+
+    $this->joinAddressFromContact();
+    $this->joinPhoneFromContact();
+    $this->joinEmailFromContact();
+
     if ($this->_contribField) {
       $this->_from .= "
              LEFT JOIN civicrm_participant_payment pp

--- a/CRM/Report/Form/Membership/Summary.php
+++ b/CRM/Report/Form/Membership/Summary.php
@@ -148,6 +148,7 @@ class CRM_Report_Form_Membership_Summary extends CRM_Report_Form {
    * Generate select clause.
    */
   public function select() {
+    // @todo remove this in favour of just using parent.
     $select = array();
     $this->_columnHeaders = array();
     foreach ($this->_columns as $tableName => $table) {
@@ -156,14 +157,6 @@ class CRM_Report_Form_Membership_Summary extends CRM_Report_Form {
           if (!empty($field['required']) ||
             !empty($this->_params['fields'][$fieldName])
           ) {
-            // to include optional columns address and email, only if checked
-            if ($tableName == 'civicrm_address') {
-              $this->_addressField = TRUE;
-              $this->_emailField = TRUE;
-            }
-            elseif ($tableName == 'civicrm_email') {
-              $this->_emailField = TRUE;
-            }
             $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
             $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'];
             $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'];
@@ -189,15 +182,8 @@ LEFT  JOIN civicrm_membership_type  {$this->_aliases['civicrm_membership_type']}
 LEFT  JOIN civicrm_contribution  {$this->_aliases['civicrm_contribution']}
        ON {$this->_aliases['civicrm_membership']}.contact_id = {$this->_aliases['civicrm_contribution']}.contact_id
 ";
-    // Include address table if address column is to be included.
-    if ($this->_addressField) {
-      $this->_from .= "LEFT JOIN civicrm_address {$this->_aliases['civicrm_address']} ON {$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_address']}.contact_id AND {$this->_aliases['civicrm_address']}.is_primary = 1\n";
-    }
-
-    // Include email table if email column is to be included.
-    if ($this->_emailField) {
-      $this->_from .= "LEFT JOIN civicrm_email {$this->_aliases['civicrm_email']} ON {$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_email']}.contact_id AND {$this->_aliases['civicrm_email']}.is_primary = 1\n";
-    }
+    $this->joinAddressFromContact();
+    $this->joinEmailFromContact();
   }
 
   /**

--- a/CRM/Report/Utils/Get.php
+++ b/CRM/Report/Utils/Get.php
@@ -113,6 +113,7 @@ class CRM_Report_Utils_Get {
       case 'ew':
       case 'nhas':
       case 'like':
+      case 'eq':
       case 'neq':
         $value = self::getTypedValue("{$fieldName}_value", CRM_Utils_Array::value('type', $field));
         if ($value !== NULL) {

--- a/CRM/Upgrade/Incremental/php/FiveTwo.php
+++ b/CRM/Upgrade/Incremental/php/FiveTwo.php
@@ -1,0 +1,87 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2017                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007.                                       |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License along with this program; if not, contact CiviCRM LLC       |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Upgrade logic for FiveTwo */
+class CRM_Upgrade_Incremental_php_FiveTwo extends CRM_Upgrade_Incremental_Base {
+
+  /**
+   * Compute any messages which should be displayed beforeupgrade.
+   *
+   * Note: This function is called iteratively for each upcoming
+   * revision to the database.
+   *
+   * @param string $preUpgradeMessage
+   * @param string $rev
+   *   a version number, e.g. '4.4.alpha1', '4.4.beta3', '4.4.0'.
+   * @param null $currentVer
+   */
+  public function setPreUpgradeMessage(&$preUpgradeMessage, $rev, $currentVer = NULL) {
+    // Example: Generate a pre-upgrade message.
+    // if ($rev == '5.12.34') {
+    //   $preUpgradeMessage .= '<p>' . ts('A new permission has been added called %1 This Permission is now used to control access to the Manage Tags screen', array(1 => 'manage tags')) . '</p>';
+    // }
+  }
+
+  /**
+   * Compute any messages which should be displayed after upgrade.
+   *
+   * @param string $postUpgradeMessage
+   *   alterable.
+   * @param string $rev
+   *   an intermediate version; note that setPostUpgradeMessage is called repeatedly with different $revs.
+   */
+  public function setPostUpgradeMessage(&$postUpgradeMessage, $rev) {
+    // Example: Generate a post-upgrade message.
+    // if ($rev == '5.12.34') {
+    //   $postUpgradeMessage .= '<br /><br />' . ts("By default, CiviCRM now disables the ability to import directly from SQL. To use this feature, you must explicitly grant permission 'import SQL datasource'.");
+    // }
+  }
+
+  /*
+   * Important! All upgrade functions MUST add a 'runSql' task.
+   * Uncomment and use the following template for a new upgrade version
+   * (change the x in the function name):
+   */
+
+  //  /**
+  //   * Upgrade function.
+  //   *
+  //   * @param string $rev
+  //   */
+  //  public function upgrade_5_0_x($rev) {
+  //    $this->addTask(ts('Upgrade DB to %1: SQL', array(1 => $rev)), 'runSql', $rev);
+  //    $this->addTask('Do the foo change', 'taskFoo', ...);
+  //    // Additional tasks here...
+  //    // Note: do not use ts() in the addTask description because it adds unnecessary strings to transifex.
+  //    // The above is an exception because 'Upgrade DB to %1: SQL' is generic & reusable.
+  //  }
+
+  // public static function taskFoo(CRM_Queue_TaskContext $ctx, ...) {
+  //   return TRUE;
+  // }
+
+}

--- a/CRM/Upgrade/Incremental/sql/5.1.beta1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.1.beta1.mysql.tpl
@@ -1,0 +1,1 @@
+{* file to handle db changes in 5.1.beta1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.2.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.2.alpha1.mysql.tpl
@@ -1,0 +1,1 @@
+{* file to handle db changes in 5.2.alpha1 during upgrade *}

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -413,7 +413,6 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
       'uploadDir' => ts('Temporary Files Directory'),
       'imageUploadDir' => ts('Images Directory'),
       'customFileUploadDir' => ts('Custom Files Directory'),
-      'extensionsDir' => ts('CiviCRM Extensions Directory'),
     );
 
     foreach ($directories as $directory => $label) {

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -581,10 +581,10 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
     elseif (!is_writable($basedir)) {
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
-        ts('Directory %1 is not writable.  Please change your file permissions.',
+        ts('Your extensions directory (%1) is read-only. If you would like perform downloads or upgrades, then change the file permissions.',
           array(1 => $basedir)),
-        ts('Directory not writable'),
-        \Psr\Log\LogLevel::ERROR,
+        ts('Read-Only Extensions'),
+        \Psr\Log\LogLevel::WARNING,
         'fa-plug'
       );
       return $messages;

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -581,7 +581,7 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
     elseif (!is_writable($basedir)) {
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
-        ts('Your extensions directory (%1) is read-only. If you would like perform downloads or upgrades, then change the file permissions.',
+        ts('Your extensions directory (%1) is read-only. If you would like to perform downloads or upgrades, then change the file permissions.',
           array(1 => $basedir)),
         ts('Read-Only Extensions'),
         \Psr\Log\LogLevel::WARNING,

--- a/CRM/Utils/Money.php
+++ b/CRM/Utils/Money.php
@@ -141,4 +141,17 @@ class CRM_Utils_Money {
     return 2;
   }
 
+  /**
+   * Subtract currencies using integers instead of floats, to preserve precision
+   *
+   * @return float
+   *   Result of subtracting $rightOp from $leftOp to the precision of $currency
+   */
+  public static function subtractCurrencies($leftOp, $rightOp, $currency) {
+    if (is_numeric($leftOp) && is_numeric($rightOp)) {
+      $precision = pow(10, self::getCurrencyPrecision($currency));
+      return (($leftOp * $precision) - ($rightOp * $precision)) / $precision;
+    }
+  }
+
 }

--- a/CRM/Utils/Rule.php
+++ b/CRM/Utils/Rule.php
@@ -814,6 +814,25 @@ class CRM_Utils_Rule {
   }
 
   /**
+   * Validate json string for xss
+   *
+   * @param string $value
+   *
+   * @return bool
+   *   False if invalid, true if valid / safe.
+   */
+  public static function json($value) {
+    if (!self::xssString($value)) {
+      return FALSE;
+    }
+    $array = json_decode($value, TRUE);
+    if (!$array || !is_array($array)) {
+      return FALSE;
+    }
+    return self::arrayValue($array);
+  }
+
+  /**
    * @param $path
    *
    * @return bool
@@ -938,6 +957,26 @@ class CRM_Utils_Rule {
   public static function checkExtesnionKeyIsValid($key = NULL) {
     if (!empty($key) && !preg_match('/^[0-9a-zA-Z._-]+$/', $key)) {
       return FALSE;
+    }
+    return TRUE;
+  }
+
+  /**
+   * Validate array recursively checking keys and  values.
+   *
+   * @param array $array
+   * @return bool
+   */
+  protected static function arrayValue($array) {
+    foreach ($array as $key => $item) {
+      if (is_array($item)) {
+        if (!self::xssString($key) || !self::arrayValue($item)) {
+          return FALSE;
+        }
+      }
+      if (!self::xssString($key) || !self::xssString($item)) {
+        return FALSE;
+      }
     }
     return TRUE;
   }

--- a/CRM/Utils/Rule.php
+++ b/CRM/Utils/Rule.php
@@ -954,7 +954,7 @@ class CRM_Utils_Rule {
    * @param string $key Extension Key to check
    * @return bool
    */
-  public static function checkExtesnionKeyIsValid($key = NULL) {
+  public static function checkExtensionKeyIsValid($key = NULL) {
     if (!empty($key) && !preg_match('/^[0-9a-zA-Z._-]+$/', $key)) {
       return FALSE;
     }

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -440,7 +440,7 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     CRM_Utils_Hook::config($config);
 
     if ($loadUser) {
-      if (!empty($params['uid']) && $username = \Drupal\user\Entity\User::load($uid)->getUsername()) {
+      if (!empty($params['uid']) && $username = \Drupal\user\Entity\User::load($params['uid'])->getUsername()) {
         $this->loadUser($username);
       }
       elseif (!empty($params['name']) && !empty($params['pass']) && \Drupal::service('user.auth')->authenticate($params['name'], $params['pass'])) {

--- a/CRM/Utils/Type.php
+++ b/CRM/Utils/Type.php
@@ -422,6 +422,7 @@ class CRM_Utils_Type {
       'MysqlOrderByDirection',
       'MysqlOrderBy',
       'ExtensionKey',
+      'Json',
     );
     if (!in_array($type, $possibleTypes)) {
       if ($isThrowException) {
@@ -527,6 +528,12 @@ class CRM_Utils_Type {
 
       case 'ExtensionKey':
         if (CRM_Utils_Rule::checkExtesnionKeyIsValid($data)) {
+          return $data;
+        }
+        break;
+
+      case 'Json':
+        if (CRM_Utils_Rule::json($data)) {
           return $data;
         }
         break;

--- a/CRM/Utils/Type.php
+++ b/CRM/Utils/Type.php
@@ -527,7 +527,7 @@ class CRM_Utils_Type {
         break;
 
       case 'ExtensionKey':
-        if (CRM_Utils_Rule::checkExtesnionKeyIsValid($data)) {
+        if (CRM_Utils_Rule::checkExtensionKeyIsValid($data)) {
           return $data;
         }
         break;

--- a/ang/crmMailing/BlockReview.html
+++ b/ang/crmMailing/BlockReview.html
@@ -11,7 +11,7 @@ Required vars: mailing, attachments
       <div crm-ui-field="{title: ts('Recipients')}">
         <div ng-controller="ViewRecipCtrl">
           <div ng-controller="EditRecipCtrl">
-            <div><a crm-icon="fa-users" class="crm-hover-button action-item" ng-click="previewRecipients()">{{getRecipientsEstimate()}}</a></div>
+            <div><a crm-icon="fa-users" class="crm-hover-button action-item" ng-click="previewRecipients()">{{getRecipientCount()}}</a></div>
             <div ng-show="getIncludesAsString(mailing)">
               (<strong>{{ts('Include:')}}</strong> {{getIncludesAsString(mailing)}})
             </div>

--- a/ang/crmMailing/services.js
+++ b/ang/crmMailing/services.js
@@ -275,6 +275,7 @@
               id: '$value.id'
             }
           });
+          delete params.scheduled_date;
           delete params.recipients; // the content was merged in
           params._skip_evil_bao_auto_recipients_ = 1; // skip recipient rebuild on mail preview
           return qApi('Mailing', 'create', params).then(function(result) {
@@ -300,6 +301,7 @@
             'api.email.getvalue': {'return': 'email'}
           }
         });
+        delete params.scheduled_date;
         delete params.recipients; // the content was merged in
         return qApi('Mailing', 'create', params).then(function (recipResult) {
           // changes rolled back, so we don't care about updating mailing
@@ -332,6 +334,7 @@
             });
             crmMailingCache.put('mailing-' + mailing.id + '-recipient-params', params.recipients);
           }
+          delete params.scheduled_date;
           delete params.recipients; // the content was merged in
           recipientCount = qApi('Mailing', 'create', params).then(function (recipResult) {
             // changes rolled back, so we don't care about updating mailing

--- a/ang/crmMailingAB/EditCtrl/report.html
+++ b/ang/crmMailingAB/EditCtrl/report.html
@@ -78,7 +78,7 @@
           class="crm-hover-button action-item"
           ng-href="{{statUrl(am.mailing, statType, 'events')}}"
           title="{{ts('Browse events of type \'%1\'', {1: statType.title})}}"
-          >{{stats[am.name][statType.name] || ts('n/a')}}</a>
+          >{{stats[am.name][statType.name] || ts('n/a')}} </a> {{stats[am.name][rateStats[statType.name]] || ' '}}
         <a
           class="crm-hover-button action-item"
           ng-href="{{statUrl(am.mailing, statType, 'report')}}"

--- a/ang/crmMailingAB/ReportCtrl.js
+++ b/ang/crmMailingAB/ReportCtrl.js
@@ -40,7 +40,11 @@
     }).then(function(stats) {
       $scope.stats = stats;
     });
-
+    $scope.rateStats = {
+      'Unique Clicks': 'clickthrough_rate',
+      'Delivered': 'delivered_rate',
+      'Opened': 'opened_rate',
+    };
     $scope.statTypes = crmMailingStats.getStatTypes();
     $scope.statUrl = function statUrl(mailing, statType, view) {
       return crmMailingStats.getUrl(mailing, statType, view, 'abtest/' + $scope.abtest.ab.id);

--- a/api/v3/Campaign.php
+++ b/api/v3/Campaign.php
@@ -58,6 +58,7 @@ function civicrm_api3_campaign_create($params) {
  */
 function _civicrm_api3_campaign_create_spec(&$params) {
   $params['title']['api.required'] = 1;
+  $params['is_active']['api.default'] = 1;
 }
 
 /**

--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -769,6 +769,14 @@ function civicrm_api3_mailing_stats($params) {
         break;
     }
   }
+  $stats[$params['mailing_id']]['delivered_rate'] = $stats[$params['mailing_id']]['opened_rate'] = $stats[$params['mailing_id']]['clickthrough_rate'] = '0.00%';
+  if (!empty(CRM_Mailing_Event_BAO_Queue::getTotalCount($params['mailing_id'], $params['job_id']))) {
+    $stats[$params['mailing_id']]['delivered_rate'] = round((100.0 * $stats[$params['mailing_id']]['Delivered']) / CRM_Mailing_Event_BAO_Queue::getTotalCount($params['mailing_id'], $params['job_id']), 2) . '%';
+  }
+  if (!empty($stats[$params['mailing_id']]['Delivered'])) {
+    $stats[$params['mailing_id']]['opened_rate'] = round($stats[$params['mailing_id']]['Opened'] / $stats[$params['mailing_id']]['Delivered'] * 100.0, 2) . '%';
+    $stats[$params['mailing_id']]['clickthrough_rate'] = round($stats[$params['mailing_id']]['Unique Clicks'] / $stats[$params['mailing_id']]['Delivered'] * 100.0, 2) . '%';
+  }
   return civicrm_api3_create_success($stats);
 }
 

--- a/contributor-key.yml
+++ b/contributor-key.yml
@@ -140,6 +140,9 @@
   organization: British Humanist Association
   jira        : awestbha
 
+- name        : Matthias Bärnthaler
+  jira        : baerm
+
 - github      : BorislavZlatanov
   name        : Borislav Zlatanov
   jira        : BorislavZlatanov
@@ -201,6 +204,10 @@
   name        : René Nieuwburg
   organization: Comunica2
   jira        : ñull
+
+- github      : cor73x
+  name        : Łukasz Krutul
+  jira        : n3o
 
 - github      : coolbit
   name        : Chandana Bandara
@@ -272,8 +279,9 @@
   name        : Arun Singh
   jira        : aruns6578
 
-- name        : Adam Kwiatkowski
-  organization: DevMate
+- github      : adam-devapp
+  name        : Adam Kwiatkowski
+  organization: DevApp
   jira        : devmate
 
 - github      : dlobo
@@ -682,6 +690,9 @@
   name        : Kevin Reynen
   jira        : kreynen
 
+- name        : Kristine Chan
+  jira        : KristineC
+
 - github      : kryptothesuperdog
   name        : Andrew West
   organization: British Humanist Association
@@ -750,6 +761,11 @@
 - github      : magnolia61
   name        : Richard van Oosterhout
   jira        : magnolia61
+
+- github      : maitrepylos
+  name        : Gérard Ernaelsten
+  organization: Formatux
+  jira        : maitrepylos
 
 - name        : Manish Zope
   jira        : manish
@@ -986,6 +1002,9 @@
   name        : Pradeep Nayak
   jira        : pradeep.nayak
 
+- name        : Paul Treadaway
+  jira        : ptreadaway
+
 - name        : Angela Cacciola
   organization: Canine Companions for Independence
   jira        : princessang417
@@ -1001,6 +1020,9 @@
 - name        : Renaee Churches
   organization: Play Australia
   jira        : Renz56c.o
+
+- github      : reneolivo
+  name        : René Olivo
 
 - name        : Robyn Perry
   organization: Progressive Technology Project
@@ -1245,7 +1267,12 @@
 
 - github      : varshith
   name        : Vinu Varshith Sekar
+  organization: CompuCorp
   jira        : varshith
+
+- github      : vinuvarshith
+  name        : Vinu Varshith Sekar
+  organization: CompuCorp
 
 - github      : VasanthaKaje
   name        : Vasantha Kaje

--- a/contributor-key.yml
+++ b/contributor-key.yml
@@ -1023,6 +1023,7 @@
 
 - github      : reneolivo
   name        : René Olivo
+  organization: CompuCorp
 
 - name        : Robyn Perry
   organization: Progressive Technology Project

--- a/release-notes.md
+++ b/release-notes.md
@@ -14,6 +14,17 @@ Other resources for identifying changes are:
     * https://github.com/civicrm/civicrm-joomla
     * https://github.com/civicrm/civicrm-wordpress
 
+## CiviCRM 5.0.0
+
+Released April 4, 2018
+
+- **[Synopsis](release-notes/5.0.0.md#synopsis)**
+- **[Features](release-notes/5.0.0.md#features)**
+- **[Bugs resolved](release-notes/5.0.0.md#bugs)**
+- **[Miscellany](release-notes/5.0.0.md#misc)**
+- **[Credits](release-notes/5.0.0.md#credits)**
+- **[Feedback](release-notes/5.0.0.md#feedback)**
+
 ## CiviCRM 4.7.31
 
 Released March 7, 2018

--- a/release-notes/5.0.0.md
+++ b/release-notes/5.0.0.md
@@ -485,6 +485,10 @@ Released April 4, 2018
 
 ### CiviCase
 
+- **[dev/core#8](https://lab.civicrm.org/dev/core/issues/8) Fatal error on
+  Print/Merge Document for Cases
+  ([11932](https://github.com/civicrm/civicrm-core/pull/11932))**
+
 - **[CRM-21789](https://issues.civicrm.org/jira/browse/CRM-21789) 'Find Case'
   group by issue ([11706](https://github.com/civicrm/civicrm-core/pull/11706))**
 

--- a/release-notes/5.0.0.md
+++ b/release-notes/5.0.0.md
@@ -755,15 +755,15 @@ This release was developed by the following code authors:
 
 AGH Strategies - Andrew Hunt; Agileware - Alok Patel; Australian Greens - Seamus
 Lee; CiviCRM - Coleman Watts, Tim Otten; CiviDesk - Yashodha Chaku; CompuCorp -
-Mukesh Ram, Omar Abu Hussein, Vinu Varshith Sekar; Coop SymbioTIC - Samuel
-Vanhove; Davis Media Access - Darrick Servis; Fuzion - Jitendra Purohit; Ginkgo
-Street Labs - Frank Gómez; JMA Consulting - Monish Deb; John Kingsnorth; Joinery -
-Allen Shaw; Left Join Labs - Sean Madsen; Lighthouse Design and Consulting -
-Brian Shaughnessy; Łukasz Krutul; MJW Consulting - Matthew Wire; myDropWizard -
-David Snopek; Oxfam Germany - Thomas Schüttler; Progressive Technology Project -
-Jamie McClelland; René Olivo; Systopia - Björn Endres; Tadpole Collective -
-Kevin Cristiano; Third Sector Design - Michael McAndrew; Wikimedia Foundation -
-Eileen McNaughton
+Mukesh Ram, Omar Abu Hussein, René Olivo, Vinu Varshith Sekar; Coop SymbioTIC -
+Samuel Vanhove; Davis Media Access - Darrick Servis; Fuzion - Jitendra Purohit;
+Ginkgo Street Labs - Frank Gómez; JMA Consulting - Monish Deb; John Kingsnorth;
+Joinery - Allen Shaw; Left Join Labs - Sean Madsen; Lighthouse Design and
+Consulting - Brian Shaughnessy; Łukasz Krutul; MJW Consulting - Matthew Wire;
+myDropWizard - David Snopek; Oxfam Germany - Thomas Schüttler; Progressive
+Technology Project - Jamie McClelland; Systopia - Björn Endres; Tadpole
+Collective - Kevin Cristiano; Third Sector Design - Michael McAndrew; Wikimedia
+Foundation - Eileen McNaughton
 
 Most authors also reviewed code for this release; in addition, the following
 reviewers contributed their comments:

--- a/release-notes/5.0.0.md
+++ b/release-notes/5.0.0.md
@@ -1,0 +1,779 @@
+# CiviCRM 5.0.0
+
+Released April 4, 2018
+
+- **[Synopsis](#synopsis)**
+- **[Features](#features)**
+- **[Bugs resolved](#bugs)**
+- **[Miscellany](#misc)**
+- **[Credits](#credits)**
+- **[Feedback](#feedback)**
+
+## <a name="synopsis"></a>Synopsis
+
+| *Does this version...?*                                         |         |
+|:--------------------------------------------------------------- |:-------:|
+| Fix security vulnerabilities?                                   |   no    |
+| Change the database schema?                                     |   no    |
+| **Alter the API?**                                              | **yes** |
+| **Require attention to configuration options?**                 | **yes** |
+| **Fix problems installing or upgrading to a previous version?** | **yes** |
+| **Introduce features?**                                         | **yes** |
+| **Fix bugs?**                                                   | **yes** |
+
+## <a name="features"></a>Features
+
+### Core CiviCRM
+
+- **[CRM-21659](https://issues.civicrm.org/jira/browse/CRM-21659) Add hook to
+  CRM_Utils_System::redirect ([11519](https://github.com/civicrm/civicrm-core/pull/11519))**
+
+  Adds a hook (hook_civicrm_alterRedirect) when the browser is being redirected. This allows extensions to
+  override the destination of an HTTP redirect.
+
+  The UriInterface from PSR-7 is included; the concrete implementation of Uri is loaded from Guzzle v6.3+.
+
+- **[civicrm/civicrm-setup#1](https://github.com/civicrm/civicrm-setup/issues/1)
+  Simplify SQL and translation pipeline (preliminary work)
+  [11699](https://github.com/civicrm/civicrm-core/pull/11699),
+  [11682](https://github.com/civicrm/civicrm-core/pull/11682), and
+  [11677](https://github.com/civicrm/civicrm-core/pull/11677)**
+
+  Along with a handful of supporting changes, these changes allow strings to be
+  translated without needing CiviCRM to be operating.  This sets the stage for
+  generating basic CiviCRM data in the appropriate language as part of the
+  CiviCRM installation process.
+
+- **Fix relationshipType, paymentProcessorType, Note & jobLog apis to support
+  custom data ([11721](https://github.com/civicrm/civicrm-core/pull/11721))**
+
+  Updates the relationshipType, paymentProcessorType & jobLog apis to support
+  custom data.
+
+- **Fix more entities to support custom fields (via api)
+  ([11688](https://github.com/civicrm/civicrm-core/pull/11688))**
+
+  This change moves us closer to the goal of being able to define custom data on 'any
+  entity'. It takes us from a limited list of entities that work to a longer list of
+  ones that still don't work
+
+- **[dev/core#12](https://lab.civicrm.org/dev/core/issues/12) Improvement: for
+  crmUiWizard-driven workflows, scroll back to top between steps
+  ([11790](https://github.com/civicrm/civicrm-core/pull/11790))**
+
+  Adds auto-scroll-up functionality between steps in a wizard-driven workflow.
+
+- **Fix style glitches ([11792](https://github.com/civicrm/civicrm-core/pull/11792))**
+
+  This change adds a space after the x between the form input for a phone number
+  and the form input for the extension to improve user experience.
+
+- **Update minimum php version to 5.5
+  ([11453](https://github.com/civicrm/civicrm-core/pull/11453))**
+
+  This change bumps up the minimum version to follow the schedule laid out in
+  https://civicrm.org/blog/totten/end-of-zombies-php-53-and-54
+
+- **Fixed template structure issues
+  ([11766](https://github.com/civicrm/civicrm-core/pull/11766))**
+
+  Moves help section outside block and adds missing label.
+
+- **[CRM-21823](https://issues.civicrm.org/jira/browse/CRM-21823) Change
+  position of help div and fix structure glitches
+  ([11750](https://github.com/civicrm/civicrm-core/pull/11750))**
+
+  This standardizes the markup structure for the date settings, localization,
+  and memberships admin pages so that the help section sits outside the form
+  block, inline CSS is removed, and buttons are wrapped with the correct wrapper
+  class.
+
+- **[CRM-21817](https://issues.civicrm.org/jira/browse/CRM-21817) Move help
+  section outside crm block as per other pages
+  ([11738](https://github.com/civicrm/civicrm-core/pull/11738))**
+
+  This change moves help section for word replacement page, outside crm block
+  to preserve consistency.
+
+- **CKEditor Advanced Options - Better validation of options
+  ([11752](https://github.com/civicrm/civicrm-core/pull/11752))**
+
+  In the "Advanced Options" of the CKEditor Configurator, API options can be
+  selected. This tweaks the UI to prevent the same option from being selected
+  twice, which would not make sense.
+
+- **Update to PHPWord 0.14.0
+  ([11696](https://github.com/civicrm/civicrm-core/pull/11696))**
+
+   Updates PHPWord from 0.13.0 to 0.14.0. PHPWord 0.14.0 fixes a number of bugs
+   and adds some new features, more information on PHPWord 0.14.0 can be found
+   [here](https://github.com/PHPOffice/PHPWord/releases/tag/0.14.0).
+
+- **[dev/release#1](https://lab.civicrm.org/dev/release/issues/1) 5.x - Update
+  version-numbering pattern
+  ([11731](https://github.com/civicrm/civicrm-core/pull/11731))**
+
+  The utility, tools/bin/scripts/set-version.php, is used to generate
+  boilerplate files for incremental updates. This change improves compatibility
+  with the version realignment (5.x.x).
+
+- **[CRM-21810](https://issues.civicrm.org/jira/browse/CRM-21810) improve
+  changelog search panel UI
+  ([11729](https://github.com/civicrm/civicrm-core/pull/11729))**
+
+  This change improves the change log panel in Advanced Search UI. It places the
+  added/modified radio buttons at the top and moves the two search fields side by
+  side to make the layout more logical and to make better use of the space.
+
+- **[CRM-21765](https://issues.civicrm.org/jira/browse/CRM-21765) Commit files
+  to git which are static but are generated from CodeGen like DAO files
+  ([11667](https://github.com/civicrm/civicrm-core/pull/11667))**
+
+  This change adds SchemaStructure.php and langs.php files (which are static but
+  generated from CodeGen) to git, reducing the need to run GenCode.
+
+### CiviCase
+
+- **[CRM-21558](https://issues.civicrm.org/jira/browse/CRM-21558) Add batch
+  update via profile to cases
+  ([11411](https://github.com/civicrm/civicrm-core/pull/11411))**
+
+  This change adds a "Update Multiple Cases" option to search tasks and allows
+  you to batch update multiple cases in the same way as other entities.
+
+### CiviContribute
+
+- **[CRM-20610](https://issues.civicrm.org/jira/browse/CRM-20610) Replace
+  payment details block with editable payment list on 'Edit Contribution' form
+  ([11748](https://github.com/civicrm/civicrm-core/pull/11748)) (preliminary
+  work)**
+
+  This change makes it possible via hook or by changing core to switch to using
+  the payment form on the 'Edit Contribution' form for payments without actually
+  making that change.
+
+- **Fix transaction template
+  ([11811](https://github.com/civicrm/civicrm-core/pull/11811))**
+
+  Updated transaction template to make them match other templates for
+  consistency.
+
+- **[CRM-21693](https://issues.civicrm.org/jira/browse/CRM-21693) show Display
+  Name in online pay now UI
+  ([11571](https://github.com/civicrm/civicrm-core/pull/11571))**
+
+  Before this change using the special constructed PayNow link it was not clear
+  which person the payment was for. This change makes it so the Online Pay Now
+  form shows the Display Name of the person the contribution belongs to.
+
+### CiviEvent
+
+- **[CRM-21803](https://issues.civicrm.org/jira/browse/CRM-21803) Standardise
+  ParticipantPayment api to support custom data
+  ([11718](https://github.com/civicrm/civicrm-core/pull/11718))**
+
+  The ParticipantPayment API now uses the standard api function, this has the
+  added bonus of allowing this api to support custom data.
+
+- **[CRM-21805](https://issues.civicrm.org/jira/browse/CRM-21805) Fix structure
+  for search pages in find participant
+  ([11723](https://github.com/civicrm/civicrm-core/pull/11723))**
+
+  This change restructures the Participant search pages so that the labels are
+  above the inputs for consistency and improved user experience.
+
+### CiviMail
+
+- **[CRM-21576](https://issues.civicrm.org/jira/browse/CRM-21576) Implement Send
+  SMS permission ([11590](https://github.com/civicrm/civicrm-core/pull/11590))**
+
+  This change adds a permission to Send SMS. More specifically, it: Adds the Send SMS
+  permission to CRM_Core_Permissions::getCorePermissions, ensures that all
+  navigation menu entries ('Find SMS' and 'New SMS') respect the new permission,
+  Ensures that all paths (civicrm/sms/send, civicrm/activity/sms/add,
+  civicrm/mailing) respect the new permission, Only show 'Outbound SMS' action
+  from the action menu on the contact screen to users with the send SMS
+  permission, and only shows 'SMS - schedule/send' from the advanced search
+  actions to users with the send SMS permission.
+
+- **[CRM-21140](https://issues.civicrm.org/jira/browse/CRM-21140) Agree & (if
+  applicable) implement approach to storing extension data for entities / tables
+  ([11608](https://github.com/civicrm/civicrm-core/pull/11608))**
+
+  This change makes it possible to extend Mailing with Custom data by making it
+  so the Mailing api supports custom data. This is primarily for the benefit of
+  extension writers.
+
+- **[CRM-21405](https://issues.civicrm.org/jira/browse/CRM-21405) Allow
+  "Outbound SMS" when Mobile is not primary phone number
+  ([11252](https://github.com/civicrm/civicrm-core/pull/11252))**
+
+  This change makes it so when a contact has a mobile phone number but it is not
+  the primary number the "Outbound SMS" action is allowed, and usees the first
+  available mobile number from the contact.
+
+- **Add 'huge' class to html textarea to match plaintext textarea
+  ([11770](https://github.com/civicrm/civicrm-core/pull/11770))**
+
+  This change makes it so that the HTML Format input and the Plain Text Format
+  input On the Message Template editor screen match.
+
+- **[CRM-21244](https://issues.civicrm.org/jira/browse/CRM-21244) Enhancements
+  to "FROM email addresses"
+  ([11914](https://github.com/civicrm/civicrm-core/pull/11914)) (continues
+  previous work)**
+
+  Help text now adjusts according to whether the logged-in user's email is
+  allowed as a From address option.
+
+### CiviMember
+
+- **[CRM-21733](https://issues.civicrm.org/jira/browse/CRM-21733) Allow
+  overriding membership status temporarily until specific date
+  ([11722](https://github.com/civicrm/civicrm-core/pull/11722) and
+  [11622](https://github.com/civicrm/civicrm-core/pull/11622))**
+
+  When overriding a membership status this change provides extra options to allow
+  a temporary status override.
+
+  Instead of having a checkbox called (Override Status?) in membership
+  add/edit/renew form, it is replaced with a select box that allow the user to
+  choose one of three options: No, Override Permanently or Override until selected
+  date.
+
+  If the first option is selected, then the membership will behave as if the old
+  (Override Status?) is *unchecked*, which means that the membership is subject to
+  membership status rules.
+
+  If the 2nd option is selected, then the membership will behave as if the old
+  (Override Status?) is *checked*, which mean that the membership status is
+  overridden and is not subject to the membership statues rules.
+
+  If the 3rd option is selected, then a new field will appear allowing the user to
+  choose a date, in this status, the membership will behave similar to option 2,
+  but when today date is equal or less than the selected date, then the "Update
+  Membership Statuses" scheduled job will automatically convert its status back to
+  *No*, which means that the membership status is overridden temporarily only for
+  the selected date and after that it will revert back and be subject to
+  membership status rules.
+
+### Drupal Integration
+
+- **[civicrm/civicrm-setup#11](https://github.com/civicrm/civicrm-setup/pull/11)
+  Implement D8 initialization for civicrm-setup
+  [11695](https://github.com/civicrm/civicrm-core/pull/11695)**
+
+  This removes references to `templates/CRM/common/version.tpl` which will not
+  be created as part of the new Drupal 8 installer.
+
+## <a name="bugs"></a>Bugs resolved
+
+### Core CiviCRM
+
+- **[CRM-21830](https://issues.civicrm.org/jira/browse/CRM-21830) State/Province
+  tokens are not working as expected in address settings for billing address
+  ([11776](https://github.com/civicrm/civicrm-core/pull/11776))**
+
+  When the 'state_province_name' token was used (in address settings), the
+  state/province was empty when 'Billing Address' was displayed. This change
+  makes it so when the 'state_province_name' token is used in address settings
+  the token is populated when the billing address is displayed
+
+- **[CRM-21781](https://issues.civicrm.org/jira/browse/CRM-21781) Don't crash if
+  contact ID not found when viewing contact
+  ([11690](https://github.com/civicrm/civicrm-core/pull/11690))**
+
+  In various situations if one ended up at civicrm/contact/view without URL
+  parameters (for example logging back in after session expiry) a fatal error was
+  thrown.
+
+  This change makes it so that instead of throwing a fatal error one is bounced
+  back to the Civi dashboard.
+
+- **[CRM-21826](https://issues.civicrm.org/jira/browse/CRM-21826) Default FROM
+  Email Address (for system-generated emails) link incorrect in System Status
+  Screen ([11756](https://github.com/civicrm/civicrm-core/pull/11756))**
+
+  This updates the System Status Screen to have separate links for Domain Name and From
+  Email Address.
+
+- **/civicrm/upgrade - On finish screen, display actual version number
+  ([11705](https://github.com/civicrm/civicrm-core/pull/11705))**
+
+  The upgrade finish screen was hard-coded to always display the message "Thank
+  you for upgrading to 4.7...". This change makes it dynamic, plugging in the
+  actual version number.
+
+- **Activity Form - Fix recently introduced warning
+  ([11815](https://github.com/civicrm/civicrm-core/pull/11815))**
+
+  Fixes a code warning thrown on the activity form.
+
+- **[CRM-21667](https://issues.civicrm.org/jira/browse/CRM-21667) Bad timezone
+  hand-off from CMS to CRM
+  ([11800](https://github.com/civicrm/civicrm-core/pull/11800))**
+
+  This change resolves errors resulting from representation of timezone data in different
+  formats. Now timezone data is converted from GMT offset in seconds to region
+  string, as expected by related methods. This fixes takes into account daylight
+  savings time.
+
+- **CKEditorConfig - Fix double-escaped slashes
+  ([11747](https://github.com/civicrm/civicrm-core/pull/11747))**
+
+  The "Advanced Options" section of the CKEditor configurator allows user-input
+  strings. Slashes were being escaped multiple times in that input. This fixes
+  it.
+
+- **CiviReport - Check for trueish values of the parameter 'required'
+  ([11725](https://github.com/civicrm/civicrm-core/pull/11725))**
+
+  The value of the parameter required is not evaluated to define whether the
+  field should be shown as required or not. See previous discussion at
+  [civicrm/civicrm-dev-docs#480](https://github.com/civicrm/civicrm-dev-docs/pull/480)
+
+- **Fix wrong tag defintion
+  ([11698](https://github.com/civicrm/civicrm-core/pull/11698))**
+
+  This change fixes some broken HTML in the Data Source help notification pop-up.
+
+- **Fix GroupNesting, GroupOrganization, Domain to work with singleValueAlter
+  ([11689](https://github.com/civicrm/civicrm-core/pull/11689))**
+
+  This change standardizes the apis for GroupNesting, GroupOrganization, and
+  Domain and extends unit testing to cover them
+
+- **composer.json - De-fork dependency, marcj/topsort
+  ([11687](https://github.com/civicrm/civicrm-core/pull/11687))**
+
+  When this dependency was originally added, we needed a few patches (for PHP
+  5.3 compatibility) and initially used a forked version of library. Of course,
+  it's undesirable to use a fork in the long term (e.g. harder to apply
+  upgrades; harder to merge into other build processes).
+
+  In the intervening period, upstream has merged the patches for PHP 5.3, and
+  we've politely asked downstream to get over PHP 5.3, so we're covered on both
+  ends. This change switches back to the mainline branch for marcj/topsort.
+
+- **Ignore errors when upgrade step already took place
+  ([11685](https://github.com/civicrm/civicrm-core/pull/11685))**
+
+- **Add/Edit Contact - Fix inconsistent capitalization
+  ([11675](https://github.com/civicrm/civicrm-core/pull/11675))**
+
+  On the "Add/Edit Contact" screen, there are several similar links: "Add another
+  phone number", "Add another IM", "Add another website". This change makes it so
+  that they are all capitalized according the same rules (e.g. standard sentence
+  case).
+
+- **[CRM-21708](https://issues.civicrm.org/jira/browse/CRM-21708) Make structure
+  proper by adding/removing appropriate classes
+  ([11585](https://github.com/civicrm/civicrm-core/pull/11585))**
+
+  This change fixes class structure for a handful of pages to make them
+  consistent in preparation for common styling and to improve user experience.
+
+- **[CRM-21391](https://issues.civicrm.org/jira/browse/CRM-21391) Refactor tasks
+  to use a base class
+  ([11808](https://github.com/civicrm/civicrm-core/pull/11808),
+  [11761](https://github.com/civicrm/civicrm-core/pull/11761),
+  [11762](https://github.com/civicrm/civicrm-core/pull/11762),
+  [11763](https://github.com/civicrm/civicrm-core/pull/11763),
+  [11760](https://github.com/civicrm/civicrm-core/pull/11760),
+  [11759](https://github.com/civicrm/civicrm-core/pull/11759),
+  [11758](https://github.com/civicrm/civicrm-core/pull/11758),
+  [11692](https://github.com/civicrm/civicrm-core/pull/11692), and
+  [11693](https://github.com/civicrm/civicrm-core/pull/11693))**
+
+  Refactors all the component tasks so they are extend a new base class
+  CRM_Core_Task.
+
+  This change cleans up the code and uses shared code where possible. It also
+  fixes a few bugs specifically, there were a number of issues with the "Advanced
+  Search" when switching between component types where the task list would be
+  populated with the wrong list of tasks, but the keys would trigger an action on
+  the selected component and an unexpected action may occur and there was also a
+  bug where when saving group_type mailing_list was always being checked.
+
+- **[CRM-21777](https://issues.civicrm.org/jira/browse/CRM-21777) Improve the
+  messaging related to Directories and Resources
+  ([11802](https://github.com/civicrm/civicrm-core/pull/11802) and
+  [11680](https://github.com/civicrm/civicrm-core/pull/11680))**
+
+  This change makes it so when on the admin page "Directory Preference" or
+  "Resource URL" fields initialized in civicrm.settings.php are loaded as
+  readonly. Prior to this change the fields were being loaded as editable but
+  the values were not being saved because they were being overridden by the
+  values in the civicrm.settings.php file). This change also adds a warning
+  which lets the user know that some fields are already set (overridden) in
+  settings file.
+
+- **[CRM-21837](https://issues.civicrm.org/jira/browse/CRM-21837) Missing states
+  for Gabon ([11793](https://github.com/civicrm/civicrm-core/pull/11793))**
+
+  This change adds missing states definition for Gabon based on current ISO
+  standard.
+
+- **[CRM-21766](https://issues.civicrm.org/jira/browse/CRM-21766) Dedupe screen
+  gives inappropriate confirm message when clicking on batch dedupe
+  ([11670](https://github.com/civicrm/civicrm-core/pull/11670))**
+
+  After doing a batch merge which resulted in a screen of conflicts, if you were
+  to click on 'refresh list' you got a 'Do you want to leave this site? Changes
+  you made may not be saved.' popup. This change removes that popup as there was
+  nothing to edit.
+
+- **[CRM-21773](https://issues.civicrm.org/jira/browse/CRM-21773) CRM-20858
+  breaks merging multi-value custom groups
+  ([11691](https://github.com/civicrm/civicrm-core/pull/11691))**
+
+  This change fixes a bug where Multi-value custom fields were being ignored
+  during the merge process, so that Multi-value fields are migrated if required.
+
+- **[CRM-20554](https://issues.civicrm.org/jira/browse/CRM-20554) Error when
+  running activity report
+  ([11630](https://github.com/civicrm/civicrm-core/pull/11630))**
+
+  On the Activity Detail report, a series of warnings and notices were being
+  thrown, this change fixes the parameters of the select and from function so that
+  no errors are thrown.
+
+- **[CRM-21809](https://issues.civicrm.org/jira/browse/CRM-21809) 'Advance
+  search' group by issue
+  ([11728](https://github.com/civicrm/civicrm-core/pull/11728))**
+
+  This fixes a bug where when doing an advanced search (with MySQL
+  FULL_GROUP_BY_MODE enabled), when one choose any activity type and searched the
+  actual number of rows listed and the row count per page differed so that the
+  count is now accurate.
+
+- **[CRM-21806](https://issues.civicrm.org/jira/browse/CRM-21806) Search builder
+  returns no results
+  ([11769](https://github.com/civicrm/civicrm-core/pull/11769),
+  [11751](https://github.com/civicrm/civicrm-core/pull/11751), and
+  [11746](https://github.com/civicrm/civicrm-core/pull/11746))**
+
+  This change fixes a bug when using a profile in Search Views and attempting to
+  search using one of the columns from the profile the advanced search
+  incorrectly showed no results.
+
+- **[CRM-21792](https://issues.civicrm.org/jira/browse/CRM-21792) Regression:
+  Extension API cannot filter on status in get request
+  ([11709](https://github.com/civicrm/civicrm-core/pull/11709))**
+
+- **[CRM-21841](https://issues.civicrm.org/jira/browse/CRM-21841) objectType
+  empty in hook_civicrm_searchTasks
+  ([11861](https://github.com/civicrm/civicrm-core/pull/11861))**
+
+- **Fix regression on CiviRules search due to exception handling
+  ([11829](https://github.com/civicrm/civicrm-core/pull/11829))**
+
+- **Revert "CRM-8140: Not possible to select fields for export when using Custom
+  Searches" ([11828](https://github.com/civicrm/civicrm-core/pull/11828))**
+
+### CiviCampaign
+
+- **Add pre and post hooks to the Survey entity
+  ([11813](https://github.com/civicrm/civicrm-core/pull/11813))**
+
+  This change makes it so `hook_civicrm_pre` and `hook_civicrm_post` are invoked
+  when a survey is saved.
+
+- **[CRM-21797](https://issues.civicrm.org/jira/browse/CRM-21797) Change
+  Structure for Campaign search forms
+  ([11714](https://github.com/civicrm/civicrm-core/pull/11714))**
+
+### CiviCase
+
+- **[CRM-21789](https://issues.civicrm.org/jira/browse/CRM-21789) 'Find Case'
+  group by issue ([11706](https://github.com/civicrm/civicrm-core/pull/11706))**
+
+  This ensures that when searching cases the count of cases found is accurate.
+
+- **Re Add CRM_Case_Form_Task::PreProcessCommon()
+  ([11928](https://github.com/civicrm/civicrm-core/pull/11928))**
+
+### CiviContribute
+
+- **Fix upgrade failures from zero value `trxn_date`
+  ([11745](https://github.com/civicrm/civicrm-core/pull/11745))**
+
+  Some longstanding CiviCRM installations would have upgrade failures going to
+  4.7.19 or higher with the database error: "Incorrect datetime value:
+  '0000-00-00 00:00:00' for column 'trxn_date'" This change fixes those values
+  to be NULL prior to the query that causes the problem.
+
+- **Add test for api money, fix net_amount calc
+  ([11801](https://github.com/civicrm/civicrm-core/pull/11801))**
+
+  Money values 5.000,77 & 5,000.77 were not being handled, they were being
+  converted to '5' by mysql insert. This change handles these values by cleaning
+  the money values in the api layer.
+
+- **[CRM-20608](https://issues.civicrm.org/jira/browse/CRM-20608) IPN
+  thinks Paypal Pro is Standard
+  ([11777](https://github.com/civicrm/civicrm-core/pull/11777))**
+
+  This fixes an issue where the CiviCRM interprets IPN messages from PayPal Pro
+  as if they're Paypal Standard, causing problems for recurring payments. The
+  fix makes it so that all incoming PayPal Pro IPN notifications for recurring
+  contributions are correctly recorded as payments in CiviCRM.
+
+- **[CRM-21756](https://issues.civicrm.org/jira/browse/CRM-21756) Editing
+  Contribution (total_amount) does -not- update LineItem (line_total)
+  ([11780](https://github.com/civicrm/civicrm-core/pull/11780))**
+
+  Before this fix when we change the total amount of membership payment (or
+  event registration), it doesn't update the corresponding line-item data,
+  causing a data integrity issue. This fix makes it so that when editing a
+  contribution for a membership payment or event registration the Total amount
+  field is frozen and there is help text beside this field that provides
+  instruction to perform the same task either by recreating the membership (or
+  participant record) or using Lineitem Editor.
+
+- **[CRM-21819](https://issues.civicrm.org/jira/browse/CRM-21819) Do not load
+  "Submit Credit Card Contribution" button for invalid processors.
+  ([11757](https://github.com/civicrm/civicrm-core/pull/11757))**
+
+  Fixes a recent regression where the 'submit credit card' shows back office when
+  it should not
+
+- **[dev/core#7](https://lab.civicrm.org/dev/core/issues/7) recurring authorize
+  IPN results in contribution with incorrect payment_instrument_id
+  ([11768](https://github.com/civicrm/civicrm-core/pull/11768))**
+
+- **ensure pdfFilename is set
+  ([11702](https://github.com/civicrm/civicrm-core/pull/11702))**
+
+  Before this change when downloading a PDF file receipt, the name you were
+  prompted to save it as is not properly set. If it simply set to `.pdf`.
+  This change makes it so the downloaded file name is named after the invoice id.
+
+- **Throw exception instead of using fatal
+  ([11719](https://github.com/civicrm/civicrm-core/pull/11719))**
+
+  This change makes it so an exception is thrown instead of a fatal error when
+  one starts doing a contribution, stops the browser half way through, and then
+  tries to re-submit.
+
+- **[dev/financial#5](https://lab.civicrm.org/dev/financial/issues/5) If a
+  currency has been disabled allow the form to be submitted
+  ([11795](https://github.com/civicrm/civicrm-core/pull/11795))**
+
+- **Fix fatal on topDonor report
+  ([11919](https://github.com/civicrm/civicrm-core/pull/11919))**
+
+- **[CRM-21831](https://issues.civicrm.org/jira/browse/CRM-21831) and
+  [dev/report#1](https://lab.civicrm.org/dev/report/issues/1) Fix regressions in
+  contribution detail report relating to soft credits
+  ([11917](https://github.com/civicrm/civicrm-core/pull/11917))**
+
+### CiviEvent
+
+- **[CRM-21764](https://issues.civicrm.org/jira/browse/CRM-21764) Recurring
+  Events without Price Set fail to save
+  ([11837](https://github.com/civicrm/civicrm-core/pull/11837))**
+
+- **[CRM-21639](https://issues.civicrm.org/jira/browse/CRM-21639) Event pages
+  should be set to NoIndex when event is not public or in the past
+  ([11496](https://github.com/civicrm/civicrm-core/pull/11496) and
+  [11498](https://github.com/civicrm/civicrm-core/pull/11498))**
+
+  This change makes it so that the CiviCRM Print Preview pages are not indexed
+  by search engines and this change makes sure Event Info pages are not indexed
+  by search engines when the event is not public.
+
+- **[CRM-21814](https://issues.civicrm.org/jira/browse/CRM-21814) Add proper
+  container to text
+  ([11735](https://github.com/civicrm/civicrm-core/pull/11735))**
+
+  This change adds wrapper to dangling text without any wrapper in event configure
+  tabs, there is no visual change for now.
+
+- **[CRM-21770](https://issues.civicrm.org/jira/browse/CRM-21770) Change
+  position of help div in export participants
+  ([11678](https://github.com/civicrm/civicrm-core/pull/11678))**
+
+  This changes the position of the help div on the Export page to be outside the
+  form block to be consistent with other pages.
+
+- **[CRM-21771](https://issues.civicrm.org/jira/browse/CRM-21771) error when
+  viewing event registration with linked contribution
+  ([11707](https://github.com/civicrm/civicrm-core/pull/11707))**
+
+  Fixes a fatal error on the Fees section of the View Event Registration Page.
+
+### CiviMail
+
+- **[CRM-21848](https://issues.civicrm.org/jira/browse/CRM-21848) Mailing no
+  longer filters out email addresses on hold from recipient group
+  ([11846](https://github.com/civicrm/civicrm-core/pull/11846) and
+  [11848](https://github.com/civicrm/civicrm-core/pull/11848))**
+
+- **[dev/mail#5](https://lab.civicrm.org/dev/mail/issues/5) "New Mailing"
+  prematurely schedules blasts
+  ([11904](https://github.com/civicrm/civicrm-core/pull/11904))**
+
+  This resolves a regression in 4.7.31 where previewing a mailing after setting
+  the scheduled date and time would end up actually scheduling the mailing.
+
+- **[dev/mail#7](https://lab.civicrm.org/dev/mail/issues/7) On 'New Mailing'
+  review page, it doesn't show recipients count
+  ([11911](https://github.com/civicrm/civicrm-core/pull/11911))**
+
+- **Ensure consistancy with previous behavior where user emails are first then
+  system from emails
+  ([11905](https://github.com/civicrm/civicrm-core/pull/11905))**
+
+  This resolves a regression in 4.7.31 where a user's own email would appear
+  below system From emails rather than as the first and default option.
+
+- **[dev/mail#6](https://lab.civicrm.org/dev/mail/issues/6) On multilingual
+  mode, choosing mailing group doesn't affect recipient count and list
+  ([11906](https://github.com/civicrm/civicrm-core/pull/11906))**
+
+### CiviMember
+
+- **[CRM-20421](https://issues.civicrm.org/jira/browse/CRM-20421) Inherited
+  memberships are converted to individual memberships when the "parent" for the
+  membership is merged with another contact
+  ([11154](https://github.com/civicrm/civicrm-core/pull/11154))**
+
+  This change fixes a bug where inherited memberships were being converted to
+  individual memberships when the "parent" for the membership was merged with
+  another contact so that inherited memberships get removed while merging the
+  contact if we chose not to transfer the memberships.
+
+- **CiviMember: use `fa-ban`, proper `crm-i` class for canceled auto-renew
+  [11775](https://github.com/civicrm/civicrm-core/pull/11775)**
+
+### Drupal Integration
+
+- **[CRM-21778](https://issues.civicrm.org/jira/browse/CRM-21778) Contact image
+  uploaded from drupal webform don't render on summary page
+  ([11681](https://github.com/civicrm/civicrm-core/pull/11681))**
+
+   This change fixes a bug where if a contact image was uploaded from a webform,
+   it was not displayed on the contact summary page and a notice was thrown so
+   that the image loads correctly without any notice errors.
+
+- **[CRM-21795](https://issues.civicrm.org/jira/browse/CRM-21795) Fatal error:
+  civicrm/CRM/Utils/System/Drupal.php on line 857
+  ([11712](https://github.com/civicrm/civicrm-core/pull/11712))**
+
+  Fixes fatal error - CRM/Utils/System/Drupal.php on line 857 that occurs on
+  error.log when navigating thru a Drupal site by adding a "onCiviExit()".
+
+### WordPress Integration
+
+- **[dev/core#21](https://lab.civicrm.org/dev/core/issues/21) Regression:
+  Public-facing contribution pages appearance changes on 4.7.31
+  ([11827](https://github.com/civicrm/civicrm-core/pull/11827))**
+
+  Reverses formatting change that caused a regression in 4.7.31 for the display
+  of contribution pages in wordpress.
+
+## <a name="misc"></a>Miscellany
+
+- **[dev/release/1](https://lab.civicrm.org/dev/release/issues/1) - Change
+  numbering to 5.x.x
+  ([11704](https://github.com/civicrm/civicrm-core/pull/11704))**
+
+- **[CRM-21720](https://issues.civicrm.org/jira/browse/CRM-21720) Cleanup search
+  classes to use enumerators instead of hardcoded values
+  ([11600](https://github.com/civicrm/civicrm-core/pull/11600))**
+
+- **Fix html template structure with classes, divs & tags
+  ([11796](https://github.com/civicrm/civicrm-core/pull/11796))**
+
+- **[CRM-21739](https://issues.civicrm.org/jira/browse/CRM-21739) Create unit
+  test for getRecipients include/exclude recipient groups
+  ([11642](https://github.com/civicrm/civicrm-core/pull/11642))**
+
+- **[CRM-21787](https://issues.civicrm.org/jira/browse/CRM-21787) Simplify
+  CRM_Utils_System::version() to fetch version directly from xml/version.xml
+  ([11700](https://github.com/civicrm/civicrm-core/pull/11700))**
+
+- **(NFC) Update copyright header for 2018
+  ([522](https://github.com/civicrm/civicrm-drupal/pull/522))**
+
+- **(NFC) Update copyright header for 2018
+  ([124](https://github.com/civicrm/civicrm-wordpress/pull/124))**
+
+- **(NFC) Update copyright header for 2018
+  ([45](https://github.com/civicrm/civicrm-joomla/pull/45))**
+
+- **(NFC) Remove redundant line, improve docblocks
+  ([11742](https://github.com/civicrm/civicrm-core/pull/11742))**
+
+- **(NFC) remove starting whitespace in ts about installments
+  ([11701](https://github.com/civicrm/civicrm-core/pull/11701))**
+
+- **(NFC) Rename fiterable fields param in _civicrm_api3_basic_array_get …
+  ([11711](https://github.com/civicrm/civicrm-core/pull/11711))**
+
+- **(NFC) Update copyright header for 2018
+  ([11713](https://github.com/civicrm/civicrm-core/pull/11713))**
+
+- **(NFC) MembershipRenewal.php - Fix civilint error
+  ([11717](https://github.com/civicrm/civicrm-core/pull/11717))**
+
+- **(NFC) Update `xml/templates/*` headers
+  ([11740](https://github.com/civicrm/civicrm-core/pull/11740))**
+
+- **NFC - Minor code cleanup in CKEditorConfig.php
+  ([11774](https://github.com/civicrm/civicrm-core/pull/11774))**
+
+- **Remove hacks from CRM_Core_Menu for old unsupported versions
+  ([11781](https://github.com/civicrm/civicrm-core/pull/11781))**
+
+- **E-notice fix.
+  ([11799](https://github.com/civicrm/civicrm-core/pull/11799))**
+
+- **Update test to NOT accept a failure in the api call.
+  ([11798](https://github.com/civicrm/civicrm-core/pull/11798))**
+
+- **Make template structure proper
+  ([11788](https://github.com/civicrm/civicrm-core/pull/11788))**
+
+- **Fix template structure
+  ([11779](https://github.com/civicrm/civicrm-core/pull/11779))**
+
+- **Move towards standardising website.create function.
+  ([11694](https://github.com/civicrm/civicrm-core/pull/11694))**
+
+- **Deduper - Pass arrays rather than strings to construct URLs
+  ([11671](https://github.com/civicrm/civicrm-core/pull/11671))**
+
+## <a name="credits"></a>Credits
+
+This release was developed by the following code authors:
+
+AGH Strategies - Andrew Hunt; Agileware - Alok Patel; Australian Greens - Seamus
+Lee; CiviCRM - Coleman Watts, Tim Otten; CiviDesk - Yashodha Chaku; CompuCorp -
+Mukesh Ram, Omar Abu Hussein, Vinu Varshith Sekar; Coop SymbioTIC - Samuel
+Vanhove; Davis Media Access - Darrick Servis; Fuzion - Jitendra Purohit; Ginkgo
+Street Labs - Frank Gómez; JMA Consulting - Monish Deb; John Kingsnorth; Joinery -
+Allen Shaw; Left Join Labs - Sean Madsen; Lighthouse Design and Consulting -
+Brian Shaughnessy; Łukasz Krutul; MJW Consulting - Matthew Wire; myDropWizard -
+David Snopek; Oxfam Germany - Thomas Schüttler; Progressive Technology Project -
+Jamie McClelland; René Olivo; Systopia - Björn Endres; Tadpole Collective -
+Kevin Cristiano; Third Sector Design - Michael McAndrew; Wikimedia Foundation -
+Eileen McNaughton
+
+Most authors also reviewed code for this release; in addition, the following
+reviewers contributed their comments:
+
+Agileware - Agileware Team; Artful Robot - Rich Lott; Blackfly Solutions - Alan
+Dixon; CiviDesk - Nicolas Ganivet; CompuCorp - Jamie Novick; Coop SymbioTIC -
+Mathieu Lutfy; Daniël van Vuuren; DevApp - Adam Kwiatkowski; Formatux - Gérard
+Ernaelsten; Freeform Solutions - Herb van den Dool; Fuzion - Peter Davis; JMA
+Consulting - Joe Murray; Kristine Chan; MC3 - Graham Mitchell; Matthias
+Bärnthaler; Megaphone Technology Consulting - Jon Goldberg; Paul Treadaway;
+Richard van Oosterhout; Semper IT - Karin Gerritsen
+
+## <a name="feedback"></a>Feedback
+
+These release notes are edited by Alice Frumin and Andrew Hunt.  If you'd like
+to provide feedback on them, please login to https://chat.civicrm.org/civicrm
+and contact `@agh1`.

--- a/sql/civicrm_generated.mysql
+++ b/sql/civicrm_generated.mysql
@@ -398,7 +398,7 @@ UNLOCK TABLES;
 
 LOCK TABLES `civicrm_domain` WRITE;
 /*!40000 ALTER TABLE `civicrm_domain` DISABLE KEYS */;
-INSERT INTO `civicrm_domain` (`id`, `name`, `description`, `config_backend`, `version`, `contact_id`, `locales`, `locale_custom_strings`) VALUES (1,'Default Domain Name',NULL,NULL,'5.1.beta1',1,NULL,'a:1:{s:5:\"en_US\";a:0:{}}');
+INSERT INTO `civicrm_domain` (`id`, `name`, `description`, `config_backend`, `version`, `contact_id`, `locales`, `locale_custom_strings`) VALUES (1,'Default Domain Name',NULL,NULL,'5.2.alpha1',1,NULL,'a:1:{s:5:\"en_US\";a:0:{}}');
 /*!40000 ALTER TABLE `civicrm_domain` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/sql/civicrm_generated.mysql
+++ b/sql/civicrm_generated.mysql
@@ -398,7 +398,7 @@ UNLOCK TABLES;
 
 LOCK TABLES `civicrm_domain` WRITE;
 /*!40000 ALTER TABLE `civicrm_domain` DISABLE KEYS */;
-INSERT INTO `civicrm_domain` (`id`, `name`, `description`, `config_backend`, `version`, `contact_id`, `locales`, `locale_custom_strings`) VALUES (1,'Default Domain Name',NULL,NULL,'5.1.alpha1',1,NULL,'a:1:{s:5:\"en_US\";a:0:{}}');
+INSERT INTO `civicrm_domain` (`id`, `name`, `description`, `config_backend`, `version`, `contact_id`, `locales`, `locale_custom_strings`) VALUES (1,'Default Domain Name',NULL,NULL,'5.1.beta1',1,NULL,'a:1:{s:5:\"en_US\";a:0:{}}');
 /*!40000 ALTER TABLE `civicrm_domain` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/templates/CRM/Admin/Form/ScheduleReminders.tpl
+++ b/templates/CRM/Admin/Form/ScheduleReminders.tpl
@@ -60,11 +60,11 @@
     <tr id="repeatFields" class="crm-scheduleReminder-form-block-repeatFields"><td></td><td>
         <table class="form-layout-compressed">
           <tr class="crm-scheduleReminder-form-block-repetition_frequency_interval">
-            <td class="label">{$form.repetition_frequency_interval.label}&nbsp;&nbsp;&nbsp;{$form.repetition_frequency_interval.html}</td>
+            <td class="label">{$form.repetition_frequency_interval.label} <span class="crm-marker">*</span>&nbsp;&nbsp;{$form.repetition_frequency_interval.html}</td>
           <td>{$form.repetition_frequency_unit.html}</td>
           </tr>
           <tr class="crm-scheduleReminder-form-block-repetition_frequency_interval">
-             <td class="label">{$form.end_frequency_interval.label}&nbsp;&nbsp;&nbsp;{$form.end_frequency_interval.html}
+             <td class="label">{$form.end_frequency_interval.label} <span class="crm-marker">*</span>&nbsp;&nbsp;{$form.end_frequency_interval.html}
            <td>{$form.end_frequency_unit.html}&nbsp;&nbsp;&nbsp;{$form.end_action.html}&nbsp;&nbsp;&nbsp;{$form.end_date.html}</td>
           </tr>
         </table>

--- a/templates/CRM/Admin/Page/Options.tpl
+++ b/templates/CRM/Admin/Page/Options.tpl
@@ -59,7 +59,11 @@
   {elseif $gName eq 'participant_status'}
     {ts}Define statuses for event participants here (e.g. Registered, Attended, Cancelled...). You can then assign statuses and search for participants by status.{/ts} {ts}"Counted?" controls whether a person with that status is counted as participant for the purpose of controlling the Maximum Number of Participants.{/ts}
   {elseif $gName eq 'from_email_address'}
-    {ts}By default, CiviCRM uses the primary email address of the logged in user as the FROM address when sending emails to contacts. However, you can use this page to define one or more general Email Addresses that can be selected as an alternative. EXAMPLE: <em>"Client Services" &lt;clientservices@example.org&gt;</em>{/ts}
+    {if $allowLoggedIn}
+      {ts}By default, CiviCRM uses the primary email address of the logged in user as the FROM address when sending emails to contacts. However, you can use this page to define one or more general Email Addresses that can be selected as an alternative. EXAMPLE: <em>"Client Services" &lt;clientservices@example.org&gt;</em>{/ts}
+    {else}
+      {ts}You can use this page to define one or more general Email Addresses that can be selected as the From Address. EXAMPLE: <em>"Client Services" &lt;clientservices@example.org&gt;</em>{/ts}
+    {/if}
   {elseif $isLocked}
     {ts}This option group is reserved for system use. You cannot add or delete options in this list.{/ts}
   {else}

--- a/templates/CRM/Contact/Form/Edit/Phone.tpl
+++ b/templates/CRM/Contact/Form/Edit/Phone.tpl
@@ -40,7 +40,7 @@
   </tr>
 {/if}
 <tr id="Phone_Block_{$blockId}">
-  <td>{$form.phone.$blockId.phone.html}&nbsp;&nbsp;{ts}ext.{/ts}&nbsp;{$form.phone.$blockId.phone_ext.html|crmAddClass:four}&nbsp;</td>
+  <td>{$form.phone.$blockId.phone.html} {ts context="phone_ext"}ext.{/ts}&nbsp;{$form.phone.$blockId.phone_ext.html|crmAddClass:four}&nbsp;</td>
   {if $className eq 'CRM_Contact_Form_Contact'}
   <td>{$form.phone.$blockId.location_type_id.html}</td>
   {/if}
@@ -60,4 +60,3 @@
   </td>
 </tr>
 {/if}
-

--- a/templates/CRM/Contact/Form/Inline/Phone.tpl
+++ b/templates/CRM/Contact/Form/Inline/Phone.tpl
@@ -47,7 +47,7 @@
     {section name='i' start=1 loop=$totalBlocks}
     {assign var='blockId' value=$smarty.section.i.index}
     <tr id="Phone_Block_{$blockId}" {if $blockId gt $actualBlockCount}class="hiddenElement"{/if}>
-        <td>{$form.phone.$blockId.phone.html}&nbsp;&nbsp;{ts}ext.{/ts}&nbsp;{$form.phone.$blockId.phone_ext.html|crmAddClass:four}&nbsp;</td>
+        <td>{$form.phone.$blockId.phone.html} {ts context="phone_ext"}ext.{/ts}&nbsp;{$form.phone.$blockId.phone_ext.html|crmAddClass:four}&nbsp;</td>
         <td>{$form.phone.$blockId.location_type_id.html}</td>
         <td>{$form.phone.$blockId.phone_type_id.html}</td>
         <td align="center" class="crm-phone-is_primary">{$form.phone.$blockId.is_primary.1.html}</td>

--- a/templates/CRM/Contact/Form/Task/Email.hlp
+++ b/templates/CRM/Contact/Form/Task/Email.hlp
@@ -27,10 +27,18 @@
   {ts}From Address{/ts}
 {/htxt}
 {htxt id="id-from_email"}
-<p>{ts}By default, CiviCRM uses the primary email address of the logged in user as the FROM address when sending emails to contacts. However, users with Administer CiviCRM permission can configure one or more general email addresses that can be selected as an alternative. EXAMPLE: "Client Services" &lt;clientservices@example.org&gt;{/ts}</p>
+{if $params.logged_in_email_setting == "1"}
+  <p>{ts}By default, CiviCRM uses the primary email address of the logged in user as the FROM address when sending emails to contacts. However, users with Administer CiviCRM permission can configure one or more general email addresses that can be selected as an alternative. EXAMPLE: "Client Services" &lt;clientservices@example.org&gt;{/ts}</p>
+{else}
+  <p>{ts}CiviCRM is currently configured to only use the defined From Email addresses. If you wish to be able to use the email address of the logged in user as the From Address you will need to set the setting "Allow mail from loged in contact" setting. Users with Administer CiviCRM can set this setting in the SMTP settings.{/ts}<p>
+  {if $params.isAdmin}
+    {capture assign="smtpUrl"}{crmURL p="civicrm/admin/setting/smtp" q="reset=1"}{/capture}
+    <p>{ts 1=$smtpUrl}Go to <a href='%1'>Settings - Outbound Mail</a> to enable the usage of the logged in contact's email address as the from email{/ts}</p>
+  {/if}
+{/if}
 {if $params.isAdmin}
-    {capture assign="fromConfig"}{crmURL p="civicrm/admin/options/from_email_address" q="reset=1"}{/capture}
-    <p>{ts 1=$fromConfig}Go to <a href='%1'>Administer CiviCRM &raquo; Communications &raquo; FROM Email Addresses</a> to add or edit general email addresses. Make sure these email addresses are valid email accounts with your email service provider.{/ts}</p>
+   {capture assign="fromConfig"}{crmURL p="civicrm/admin/options/from_email_address" q="reset=1"}{/capture}
+   <p>{ts 1=$fromConfig}Go to <a href='%1'>Administer CiviCRM &raquo; Communications &raquo; FROM Email Addresses</a> to add or edit general email addresses. Make sure these email addresses are valid email accounts with your email service provider.{/ts}</p>
 {/if}
 {/htxt}
 

--- a/templates/CRM/Contact/Form/Task/Email.tpl
+++ b/templates/CRM/Contact/Form/Task/Email.tpl
@@ -30,10 +30,11 @@
         <p>{ts count=$suppressedEmails plural='Email will NOT be sent to %count contacts - (no email address on file, or communication preferences specify DO NOT EMAIL, or contact is deceased).'}Email will NOT be sent to %count contact - (no email address on file, or communication preferences specify DO NOT EMAIL, or contact is deceased).{/ts}</p>
     </div>
 {/if}
+{crmSetting var="logged_in_email_setting" name="allow_mail_from_logged_in_contact"}
 <table class="form-layout-compressed">
   <tr id="selectEmailFrom" class="crm-contactEmail-form-block-fromEmailAddress crm-email-element">
     <td class="label">{$form.from_email_address.label}</td>
-    <td>{$form.from_email_address.html} {help id="id-from_email" file="CRM/Contact/Form/Task/Email.hlp" isAdmin=$isAdmin}</td>
+    <td>{$form.from_email_address.html} {help id="id-from_email" file="CRM/Contact/Form/Task/Email.hlp" isAdmin=$isAdmin logged_in_email_setting=$logged_in_email_setting}</td>
   </tr>
     <tr class="crm-contactEmail-form-block-recipient">
        <td class="label">{if $single eq false}{ts}Recipient(s){/ts}{else}{$form.to.label}{/if}</td>

--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -345,25 +345,17 @@
     <div id="customData" class="crm-contribution-form-block-customData"></div>
   {/if}
 
-  {*include custom data js file*}
-  {include file="CRM/common/customData.tpl"}
+  {include file="CRM/Custom/Form/Edit.tpl"}
 
-    {literal}
-    <script type="text/javascript">
-      CRM.$(function($) {
+  {literal}
+  <script type="text/javascript">
+    CRM.$(function($) {
     {/literal}
-    CRM.buildCustomData( '{$customDataType}' );
-    {if $customDataSubType}
-      CRM.buildCustomData( '{$customDataType}', {$customDataSubType} );
-    {/if}
-
-    {if $buildPriceSet}{literal}buildAmount( );{/literal}{/if}
+      {if $buildPriceSet}{literal}buildAmount();{/literal}{/if}
     {literal}
-    });
 
     // bind first click of accordion header to load crm-accordion-body with snippet
     // everything else taken care of by cj().crm-accordions()
-    CRM.$(function($) {
       cj('#adjust-option-type').hide();
       cj('.crm-ajax-accordion .crm-accordion-header').one('click', function() {
         loadPanes(cj(this).attr('id'));

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -98,7 +98,7 @@
     {else}
       <div class="display-block">
         <td class="label">{$form.total_amount.label}</td>
-        <td><span>{$form.total_amount.html|crmMoney}&nbsp;&nbsp;{if $taxAmount}(includes {$taxTerm} of {$taxAmount|crmMoney}){/if}</span></td>
+        <td><span>{$form.total_amount.html|crmMoney}&nbsp;&nbsp;{if $taxAmount}{ts 1=$taxTerm 2=$taxAmount|crmMoney}(includes %1 of %2){/ts}{/if}</span></td>
       </div>
     {/if}
   {else}

--- a/templates/CRM/Contribute/Form/ContributionPage/Widget.tpl
+++ b/templates/CRM/Contribute/Form/ContributionPage/Widget.tpl
@@ -66,7 +66,7 @@
                         {ts}Click <strong>Save & Preview</strong> to save your settings and preview the widget on this page.{/ts}<br />
                     </div>
                 {/if}
-                <div style="text-align: center;width:260px">{$form._qf_Widget_refresh.html}</div>
+                <div>{$form._qf_Widget_refresh.html}</div>
             </div>
             <div class="col2">
                 {* Include "get widget code" section if widget has been created for this page and is_active. *}

--- a/templates/CRM/Custom/Form/Edit.tpl
+++ b/templates/CRM/Custom/Form/Edit.tpl
@@ -1,0 +1,16 @@
+{* Edit custom data on Edit entity forms *}
+{* Requires <div id="customData"></div> on the form *}
+{*include custom data js file*}
+{include file="CRM/common/customData.tpl"}
+{literal}
+<script type="text/javascript">
+  CRM.$(function($) {
+    {/literal}
+    CRM.buildCustomData( '{$customDataType}' );
+    {if $customDataSubType}
+    CRM.buildCustomData( '{$customDataType}', {$customDataSubType} );
+    {/if}
+    {literal}
+  });
+</script>
+{/literal}

--- a/templates/CRM/Event/Form/ManageEvent/Location.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Location.tpl
@@ -71,11 +71,11 @@
     </tr>
     <tr>
       <td><label>{ts}Phone 1:{/ts}</label></td>
-      <td>{$form.phone.1.phone.html|crmAddClass:phone}&nbsp;x&nbsp;{$form.phone.1.phone_ext.html|crmAddClass:four}&nbsp;{$form.phone.1.phone_type_id.html}</td>
+      <td>{$form.phone.1.phone.html|crmAddClass:phone} {ts context="phone_ext"}ext.{/ts}&nbsp;{$form.phone.1.phone_ext.html|crmAddClass:four}&nbsp;{$form.phone.1.phone_type_id.html}</td>
     </tr>
     <tr>
       <td><label>{ts}Phone 2:{/ts}</label></td>
-      <td>{$form.phone.2.phone.html|crmAddClass:phone}&nbsp;x&nbsp;{$form.phone.2.phone_ext.html|crmAddClass:four}&nbsp;{$form.phone.2.phone_type_id.html}</td>
+      <td>{$form.phone.2.phone.html|crmAddClass:phone} {ts context="phone_ext"}ext.{/ts}&nbsp;{$form.phone.2.phone_ext.html|crmAddClass:four}&nbsp;{$form.phone.2.phone_type_id.html}</td>
     </tr>
   </table>
 
@@ -166,4 +166,3 @@
       {/literal}
     </script>
   {/if}
-

--- a/templates/CRM/Export/Form/Select.tpl
+++ b/templates/CRM/Export/Form/Select.tpl
@@ -28,7 +28,7 @@
 <div class="crm-block crm-form-block crm-export-form-block">
 
  <div class="help">
-    <p>{ts}<strong>Export {if $exportCustomSearchField}custom search{else}PRIMARY{/if} fields</strong> provides the most commonly used data values. This includes primary address information, preferred phone and email.{/ts}</p>
+    <p>{ts}<strong>Export PRIMARY fields</strong> provides the most commonly used data values. This includes primary address information, preferred phone and email.{/ts}</p>
     <p>{ts}Click <strong>Select fields for export</strong> and then <strong>Continue</strong> to choose a subset of fields for export. This option allows you to export multiple specific locations (Home, Work, etc.) as well as custom data. You can also save your selections as a 'field mapping' so you can use it again later.{/ts}</p>
  </div>
 

--- a/templates/CRM/Mailing/Page/Report.tpl
+++ b/templates/CRM/Mailing/Page/Report.tpl
@@ -36,7 +36,7 @@
         <td>{$report.event_totals.actionlinks.delivered}</td></tr>
   {if $report.mailing.open_tracking}
     <tr><td class="label"><a href="{$report.event_totals.links.opened}&distinct=1">{ts}Unique Opens{/ts}</a></td>
-        <td>{$report.event_totals.opened}</td>
+        <td>{$report.event_totals.opened} ({$report.event_totals.opened_rate|string_format:"%0.2f"}%)</td>
         <td>{$report.event_totals.actionlinks.opened}</td></tr>
     <tr><td class="label"><a href="{$report.event_totals.links.opened}">{ts}Total Opens{/ts}</a></td>
         <td>{$report.event_totals.total_opened}</td>
@@ -44,7 +44,7 @@
   {/if}
   {if $report.mailing.url_tracking}
     <tr><td class="label"><a href="{$report.event_totals.links.clicks}">{ts}Click-throughs{/ts}</a></td>
-        <td>{$report.event_totals.url}</td>
+        <td>{$report.event_totals.url} ({$report.event_totals.clickthrough_rate|string_format:"%0.2f"}%)</td>
         <td>{$report.event_totals.actionlinks.clicks}</td></tr>
   {/if}
   <tr><td class="label"><a href="{$report.event_totals.links.forward}">{ts}Forwards{/ts}</a></td>

--- a/templates/CRM/Price/Form/PriceSet.tpl
+++ b/templates/CRM/Price/Form/PriceSet.tpl
@@ -82,7 +82,7 @@
                           {$amount|crmMoney}
                         {elseif $displayOpt == 'Inclusive'}
                           {$amount|crmMoney}
-                          <span class='crm-price-amount-label'> (includes {$taxTerm} of {$option.tax_amount|crmMoney})</span>
+                          <span class='crm-price-amount-label'> {ts 1=$taxTerm 2=$option.tax_amount|crmMoney}(includes %1 of %2){/ts}</span>
                         {else}
                           {$option.amount|crmMoney}
                           <span class='crm-price-amount-label'> + {$option.tax_amount|crmMoney} {$taxTerm}</span>

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -222,30 +222,7 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
    * Create honor-contact method.
    */
   public function testCreateAndGetHonorContact() {
-    $firstName = 'John_' . substr(sha1(rand()), 0, 7);
-    $lastName = 'Smith_' . substr(sha1(rand()), 0, 7);
-    $email = "{$firstName}.{$lastName}@example.com";
-
-    //Get profile id of name honoree_individual used to create profileContact
-    $honoreeProfileId = NULL;
-    $ufGroupDAO = new CRM_Core_DAO_UFGroup();
-    $ufGroupDAO->name = 'honoree_individual';
-    if ($ufGroupDAO->find(TRUE)) {
-      $honoreeProfileId = $ufGroupDAO->id;
-    }
-
-    $params = array(
-      'prefix_id' => 3,
-      'first_name' => $firstName,
-      'last_name' => $lastName,
-      'email-1' => $email,
-    );
-    $softParam = array('soft_credit_type_id' => 1);
-
-    $honoreeContactId = CRM_Contact_BAO_Contact::createProfileContact($params, CRM_Core_DAO::$_nullArray,
-      NULL, NULL, $honoreeProfileId
-    );
-
+    $honoreeContactId = $this->getHonoreeContact();
     $this->assertDBCompareValue('CRM_Contact_DAO_Contact', $honoreeContactId, 'first_name', 'id', $firstName,
       'Database check for created honor contact record.'
     );

--- a/tests/phpunit/CRM/Core/BAO/EmailTest.php
+++ b/tests/phpunit/CRM/Core/BAO/EmailTest.php
@@ -149,4 +149,22 @@ class CRM_Core_BAO_EmailTest extends CiviUnitTestCase {
     $this->contactDelete($contactId);
   }
 
+  /**
+   * Test getting list of Emails for use in Receipts and Single Email sends
+   */
+  public function testGetFromEmail() {
+    $this->createLoggedInUser();
+    $fromEmails = CRM_Core_BAO_Email::getFromEmail();
+    $emails = array_values($fromEmails);
+    $this->assertContains("(preferred)", $emails[0]);
+    Civi::settings()->set("allow_mail_from_logged_in_contact", 0);
+    $this->callAPISuccess('system', 'flush', []);
+    $fromEmails = CRM_Core_BAO_Email::getFromEmail();
+    $emails = array_values($fromEmails);
+    $this->assertNotContains("(preferred)", $emails[0]);
+    $this->assertContains("info@EXAMPLE.ORG", $emails[0]);
+    Civi::settings()->set("allow_mail_from_logged_in_contact", 1);
+    $this->callAPISuccess('system', 'flush', []);
+  }
+
 }

--- a/tests/phpunit/CRM/Core/BAO/FinancialTrxnTest.php
+++ b/tests/phpunit/CRM/Core/BAO/FinancialTrxnTest.php
@@ -240,4 +240,32 @@ class CRM_Core_BAO_FinancialTrxnTest extends CiviUnitTestCase {
     $this->assertEquals($financialTrxn['pan_truncation'], 4567);
   }
 
+  /**
+   * Test getPartialPaymentWithType function.
+   */
+  public function testGetPartialPaymentWithType() {
+    //create the contribution that isn't paid yet
+    $contactId = $this->individualCreate();
+    $params = array(
+      'contact_id' => $contactId,
+      'currency' => 'USD',
+      'financial_type_id' => 1,
+      'contribution_status_id' => 8,
+      'payment_instrument_id' => 4,
+      'total_amount' => 300.00,
+      'fee_amount' => 0.00,
+      'net_amount' => 300.00,
+    );
+    $contribution = $this->callAPISuccess('Contribution', 'create', $params)['values'][7];
+    //make a payment one cent short
+    $params = array(
+      'contribution_id' => $contribution['id'],
+      'total_amount' => 299.99,
+    );
+    $this->callAPISuccess('Payment', 'create', $params);
+    //amount owed should be one cent
+    $amountOwed = CRM_Core_BAO_FinancialTrxn::getPartialPaymentWithType($contribution['id'], 'contribution')['amount_owed'];
+    $this->assertTrue(0.01 == $amountOwed, 'Amount does not match');
+  }
+
 }

--- a/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
@@ -204,6 +204,15 @@ class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
     $mut = new CiviMailUtils($this, TRUE);
     $this->setupMembershipRecurringPaymentProcessorTransaction(array('is_email_receipt' => TRUE));
     $this->addProfile('supporter_profile', $this->_contributionPageID);
+
+    $honoreeContactId = $this->getHonoreeContact();
+    $softParam['contact_id'] = $honoreeContactId;
+    $softParam['contribution_id'] = $this->_contributionID;
+    $softParam['amount'] = 200;
+
+    //Create Soft Contribution for honoree contact
+    CRM_Contribute_BAO_ContributionSoft::add($softParam);
+
     $IPN = new CRM_Core_Payment_AuthorizeNetIPN($this->getRecurTransaction());
     $IPN->main();
     $mut->checkAllMailLog(array(
@@ -215,6 +224,7 @@ class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
       'First Name: Anthony',
       'Last Name: Anderson',
       'Email Address: anthony_anderson@civicrm.org',
+      'Honor',
       'This membership will be automatically renewed every',
       'Dear Mr. Anthony Anderson II',
       'Thanks for your auto renew membership sign-up',
@@ -223,6 +233,8 @@ class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
     $this->_contactID = $this->individualCreate(array('first_name' => 'Antonia', 'prefix_id' => 'Mrs.', 'email' => 'antonia_anderson@civicrm.org'));
     $this->_invoiceID = uniqid();
 
+    // Note, the second contribution is not in honor of anyone and the
+    // receipt should not mention honor at all.
     $this->setupMembershipRecurringPaymentProcessorTransaction(array('is_email_receipt' => TRUE));
     $IPN = new CRM_Core_Payment_AuthorizeNetIPN($this->getRecurTransaction(array('x_trans_id' => 'hers')));
     $IPN->main();
@@ -243,6 +255,13 @@ class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
       'Thanks for your auto renew membership sign-up',
     ));
 
+    $shouldNotBeInMailing = array(
+      'Honor',
+    );
+    $mails = $mut->getAllMessages('raw');
+    foreach($mails as $mail) {
+      $mut->checkMailForStrings(array(), $shouldNotBeInMailing, '', $mail);
+    }
     $mut->stop();
     $mut->clearMessages();
   }

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -29,6 +29,7 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
 
   public function tearDown() {
     $this->quickCleanup(['civicrm_contact', 'civicrm_email', 'civicrm_address']);
+    $this->quickCleanUpFinancialEntities();
     parent::tearDown();
   }
 
@@ -203,7 +204,8 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
    */
   public function setUpContributionExportData() {
     $this->setUpContactExportData();
-    $this->contributionIDs[] = $this->contributionCreate(array('contact_id' => $this->contactIDs[0]));
+    $this->contributionIDs[] = $this->contributionCreate(array('contact_id' => $this->contactIDs[0], 'trxn_id' => 'null', 'invoice_id' => 'null'));
+    $this->contributionIDs[] = $this->contributionCreate(array('contact_id' => $this->contactIDs[1], 'trxn_id' => 'null', 'invoice_id' => 'null'));
   }
 
   /**
@@ -218,7 +220,7 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
    * Set up some data for us to do testing on.
    */
   public function setUpContactExportData() {
-    $this->contactIDs[] = $contactA = $this->individualCreate();
+    $this->contactIDs[] = $contactA = $this->individualCreate(['gender_id' => 'Female']);
     // Create address for contact A.
     $params = array(
       'contact_id' => $contactA,
@@ -298,6 +300,65 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
    */
   public function getPrimarySearchOptions() {
     return [[TRUE], [FALSE]];
+  }
+
+  /**
+   * Test that when exporting a pseudoField it is reset for NULL entries.
+   *
+   * ie. we have a contact WITH a gender & one without - make sure the latter one
+   * does NOT retain the gender of the former.
+   */
+  public function testExportPseudoField() {
+    $this->setUpContactExportData();
+    $selectedFields = [['Individual', 'gender_id']];
+    list($tableName, $sqlColumns) = CRM_Export_BAO_Export::exportComponents(
+      TRUE,
+      $this->contactIDs[1],
+      array(),
+      NULL,
+      $selectedFields,
+      NULL,
+      CRM_Export_Form_Select::CONTACT_EXPORT,
+      "contact_a.id IN (" . implode(",", $this->contactIDs) . ")",
+      NULL,
+      FALSE,
+      FALSE,
+      array(
+        'exportOption' => CRM_Export_Form_Select::CONTACT_EXPORT,
+        'suppress_csv_for_testing' => TRUE,
+      )
+    );
+    $this->assertEquals('Female,', CRM_Core_DAO::singleValueQuery("SELECT GROUP_CONCAT(gender_id) FROM {$tableName}"));
+  }
+
+  /**
+   * Test that when exporting a pseudoField it is reset for NULL entries.
+   *
+   * This is specific to the example in CRM-14398
+   */
+  public function testExportPseudoFieldCampaign() {
+    $this->setUpContributionExportData();
+    $campaign = $this->callAPISuccess('Campaign', 'create', ['title' => 'Big campaign']);
+    $this->callAPISuccess('Contribution', 'create', ['campaign_id' => 'Big_campaign', 'id' => $this->contributionIDs[0]]);
+    $selectedFields = [['Individual', 'gender_id'], ['Contribution', 'contribution_campaign_title']];
+    list($tableName, $sqlColumns) = CRM_Export_BAO_Export::exportComponents(
+      TRUE,
+      $this->contactIDs[1],
+      array(),
+      NULL,
+      $selectedFields,
+      NULL,
+      CRM_Export_Form_Select::CONTRIBUTE_EXPORT,
+      "contact_a.id IN (" . implode(",", $this->contactIDs) . ")",
+      NULL,
+      FALSE,
+      FALSE,
+      array(
+        'exportOption' => CRM_Export_Form_Select::CONTACT_EXPORT,
+        'suppress_csv_for_testing' => TRUE,
+      )
+    );
+    $this->assertEquals('Big campaign,', CRM_Core_DAO::singleValueQuery("SELECT GROUP_CONCAT(contribution_campaign_title) FROM {$tableName}"));
   }
 
   /**

--- a/tests/phpunit/CRM/Logging/SchemaTest.php
+++ b/tests/phpunit/CRM/Logging/SchemaTest.php
@@ -12,6 +12,10 @@ class CRM_Logging_SchemaTest extends CiviUnitTestCase {
 
   public function tearDown() {
     parent::tearDown();
+    $schema = new CRM_Logging_Schema();
+    $schema->disableLogging();
+    $schema->dropAllLogTables();
+    CRM_Core_DAO::executeQuery("DROP TABLE IF EXISTS civicrm_test_table");
   }
 
   public function queryExamples() {
@@ -37,8 +41,43 @@ class CRM_Logging_SchemaTest extends CiviUnitTestCase {
     while ($log_table->fetch()) {
       $this->assertRegexp('/ENGINE=ARCHIVE/', $log_table->Create_Table);
     }
-    $schema->disableLogging();
-    $schema->dropAllLogTables();
+  }
+
+  public function testAutoIncrementNonIdColumn() {
+    CRM_Core_DAO::executeQuery("CREATE TABLE `civicrm_test_table` (
+      test_id  int(10) unsigned NOT NULL AUTO_INCREMENT,
+      PRIMARY KEY (`test_id`)
+    )  ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci");
+    $schema = new CRM_Logging_Schema();
+    $schema->enableLogging();
+    $diffs = $schema->columnsWithDiffSpecs("civicrm_test_table", "log_civicrm_test_table");
+    // Test that just havving a non id nanmed column with Auto Increment doesn't create diffs
+    $this->assertTrue(empty($diffs['MODIFY']));
+    $this->assertTrue(empty($diffs['ADD']));
+    $this->assertTrue(empty($diffs['OBSOLETE']));
+    CRM_Core_DAO::executeQuery("ALTER TABLE civicrm_test_table ADD COLUMN test_varchar varchar(255) DEFAULT NULL");
+    \Civi::$statics['CRM_Logging_Schema']['columnSpecs'] = array();
+    // Check that it still picks up new columns added.
+    $diffs = $schema->columnsWithDiffSpecs("civicrm_test_table", "log_civicrm_test_table");
+    $this->assertTrue(!empty($diffs['ADD']));
+    $this->assertTrue(empty($diffs['MODIFY']));
+    $this->assertTrue(empty($diffs['OBSOLETE']));
+    $schema->fixSchemaDifferences();
+    CRM_Core_DAO::executeQuery("ALTER TABLE civicrm_test_table CHANGE COLUMN test_varchar test_varchar varchar(400) DEFAULT NULL");
+    // Check that it properly picks up modifications to columns.
+    \Civi::$statics['CRM_Logging_Schema']['columnSpecs'] = array();
+    $diffs = $schema->columnsWithDiffSpecs("civicrm_test_table", "log_civicrm_test_table");
+    $this->assertTrue(!empty($diffs['MODIFY']));
+    $this->assertTrue(empty($diffs['ADD']));
+    $this->assertTrue(empty($diffs['OBSOLETE']));
+    $schema->fixSchemaDifferences();
+    CRM_Core_DAO::executeQuery("ALTER TABLE civicrm_test_table CHANGE COLUMN test_varchar test_varchar varchar(300) DEFAULT NULL");
+    // Check that when we reduce the size of column that the log table doesn't shrink as well.
+    \Civi::$statics['CRM_Logging_Schema']['columnSpecs'] = array();
+    $diffs = $schema->columnsWithDiffSpecs("civicrm_test_table", "log_civicrm_test_table");
+    $this->assertTrue(empty($diffs['MODIFY']));
+    $this->assertTrue(empty($diffs['ADD']));
+    $this->assertTrue(empty($diffs['OBSOLETE']));
   }
 
 }

--- a/tests/phpunit/CRM/Mailing/BAO/MailingTest.php
+++ b/tests/phpunit/CRM/Mailing/BAO/MailingTest.php
@@ -34,6 +34,14 @@ class CRM_Mailing_BAO_MailingTest extends CiviUnitTestCase {
     parent::setUp();
   }
 
+  public function tearDown() {
+    global $dbLocale;
+    if ($dbLocale) {
+      CRM_Core_I18n_Schema::makeSinglelingual('en_US');
+    }
+    parent::tearDown();
+  }
+
   /**
    * Helper function to assert whether the calculated recipients of a mailing
    * match the expected list
@@ -71,7 +79,7 @@ class CRM_Mailing_BAO_MailingTest extends CiviUnitTestCase {
     return $this->callAPISuccess('MailingGroup', 'create', array(
       'mailing_id' => $mailingID,
       'group_type' => $type,
-      'entity_table' => "civicrm_group",
+      'entity_table' => CRM_Contact_BAO_Group::getTableName(),
       'entity_id' => $groupID,
     ));
   }
@@ -100,7 +108,6 @@ class CRM_Mailing_BAO_MailingTest extends CiviUnitTestCase {
    * contact 7 : smart 4 (inc)
    */
   public function testgetRecipientsEmailGroupIncludeExclude() {
-
     // Set up groups; 3 standard, 3 smart
     $groupIDs = array();
     for ($i = 0; $i < 6; $i++) {
@@ -172,6 +179,8 @@ class CRM_Mailing_BAO_MailingTest extends CiviUnitTestCase {
 
     // Check that we can include smart groups in the mailing too.
     // Expected: All contacts should be included.
+    // Also (dev/mail/6): Enable multilingual mode to check that restructing group doesn't affect recipient rebuilding
+    $this->enableMultilingual();
     $this->createMailingGroup($mailing['id'], $groupIDs[3]);
     $this->createMailingGroup($mailing['id'], $groupIDs[4]);
     $this->assertRecipientsCorrect($mailing['id'], $contactIDs);
@@ -198,7 +207,6 @@ class CRM_Mailing_BAO_MailingTest extends CiviUnitTestCase {
     foreach ($contactIDs as $contactID) {
       $this->contactDelete($contactID);
     }
-
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/MoneyTest.php
+++ b/tests/phpunit/CRM/Utils/MoneyTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Class CRM_Utils_RuleTest
+ * @group headless
+ */
+class CRM_Utils_MoneyTest extends CiviUnitTestCase {
+
+  public function setUp() {
+    parent::setUp();
+  }
+
+  /**
+   * @dataProvider subtractCurrenciesDataProvider
+   * @param $inputData
+   * @param $expectedResult
+   */
+  public function testSubtractCurrencies($leftOp, $rightOp, $currency, $expectedResult) {
+    $this->assertEquals($expectedResult, CRM_Utils_Money::subtractCurrencies($leftOp, $rightOp, $currency));
+  }
+
+  /**
+   * @return array
+   */
+  public function subtractCurrenciesDataProvider() {
+    return array(
+      array(number_format(300.00, 2), number_format(299.99, 2), USD, number_format(0.01, 2)),
+      array(2, 1, USD, 1),
+      array(0, 0, USD, 0),
+      array(1, 2, USD, -1),
+      array(number_format(19.99, 2), number_format(20.00, 2), USD, number_format(-0.01, 2)),
+      array('notanumber', 5.00, USD, NULL),
+    );
+  }
+
+}

--- a/tests/phpunit/CRM/Utils/RuleTest.php
+++ b/tests/phpunit/CRM/Utils/RuleTest.php
@@ -129,7 +129,7 @@ class CRM_Utils_RuleTest extends CiviUnitTestCase {
    * @dataProvider extenionKeyTests
    */
   public function testExtenionKeyValid($key, $expectedResult) {
-    $this->assertEquals($expectedResult, CRM_Utils_Rule::checkExtesnionKeyIsValid($key));
+    $this->assertEquals($expectedResult, CRM_Utils_Rule::checkExtensionKeyIsValid($key));
   }
 
 }

--- a/tests/phpunit/CRM/Utils/TypeTest.php
+++ b/tests/phpunit/CRM/Utils/TypeTest.php
@@ -74,6 +74,8 @@ class CRM_Utils_TypeTest extends CiviUnitTestCase {
       array('table.civicrm_column_name desc,other_column, another_column desc', 'MysqlOrderBy', 'table.civicrm_column_name desc,other_column, another_column desc'),
       array('table.`Home-street_address` asc, `table-alias`.`Home-street_address` desc,`table-alias`.column', 'MysqlOrderBy', 'table.`Home-street_address` asc, `table-alias`.`Home-street_address` desc,`table-alias`.column'),
       array('a string', 'String', 'a string'),
+      array('{"contact":{"contact_id":205}}', 'Json', '{"contact":{"contact_id":205}}'),
+      array('{"contact":{"contact_id":!n†rude®}}', 'Json', NULL),
     );
   }
 

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -2786,6 +2786,7 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
         'contribution_page_id' => $this->_contributionPageID,
         'payment_processor_id' => $this->_paymentProcessorID,
         'is_test' => 0,
+        'skipCleanMoney' => TRUE,
       ),
     ), $params));
     $this->_contributionRecurID = $contributionRecur['id'];

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3619,4 +3619,36 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
     $dbLocale = '_en_US';
   }
 
+
+  /**
+   *
+   * Create honoree contact
+   *
+   * Contact that can be used to test honor of contributions.
+   */
+  public function getHonoreeContact() {
+    $firstName = 'John_' . substr(sha1(rand()), 0, 7);
+    $lastName = 'Smith_' . substr(sha1(rand()), 0, 7);
+    $email = "{$firstName}.{$lastName}@example.com";
+
+    //Get profile id of name honoree_individual used to create profileContact
+    $honoreeProfileId = NULL;
+    $ufGroupDAO = new CRM_Core_DAO_UFGroup();
+    $ufGroupDAO->name = 'honoree_individual';
+    if ($ufGroupDAO->find(TRUE)) {
+      $honoreeProfileId = $ufGroupDAO->id;
+    }
+
+    $params = array(
+      'prefix_id' => 3,
+      'first_name' => $firstName,
+      'last_name' => $lastName,
+      'email-1' => $email,
+    );
+    $softParam = array('soft_credit_type_id' => 1);
+
+    return CRM_Contact_BAO_Contact::createProfileContact($params, CRM_Core_DAO::$_nullArray,
+      NULL, NULL, $honoreeProfileId
+    );
+  }
 }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3601,4 +3601,21 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
     return $contributionObj;
   }
 
+  /**
+   * Enable multilingual.
+   */
+  public function enableMultilingual() {
+    $this->callAPISuccess('Setting', 'create', array(
+      'lcMessages' => 'en_US',
+      'languageLimit' => array(
+        'en_US' => 1,
+      ),
+    ));
+
+    CRM_Core_I18n_Schema::makeMultilingual('en_US');
+
+    global $dbLocale;
+    $dbLocale = '_en_US';
+  }
+
 }

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -1185,6 +1185,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
         'invoice_id' => 67990,
         'source' => 'SSF',
         'contribution_status_id' => 1,
+        'skipCleanMoney' => 1,
       ),
       'api.website.create' => array(
         'url' => "http://civicrm.org",
@@ -1226,6 +1227,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
         'invoice_id' => 67890,
         'source' => 'SSF',
         'contribution_status_id' => 1,
+        'skipCleanMoney' => 1,
       ),
       'api.website.create' => array(
         array(
@@ -2283,6 +2285,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
         'net_amount' => 90.00,
         'source' => 'SSF',
         'contribution_status_id' => 1,
+        'skipCleanMoney' => 1,
       ),
       'api.contribution.create.1' => array(
         'receive_date' => '2011-01-01',
@@ -2294,6 +2297,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
         'net_amount' => 90.00,
         'source' => 'SSF',
         'contribution_status_id' => 1,
+        'skipCleanMoney' => 1,
       ),
       'api.website.create' => array(
         array(
@@ -2351,6 +2355,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
         'invoice_id' => 67890,
         'source' => 'SSF',
         'contribution_status_id' => 1,
+        'skipCleanMoney' => 1,
       ),
       'api.contribution.create.1' => array(
         'receive_date' => '2011-01-01',
@@ -2364,6 +2369,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
         'invoice_id' => 67830,
         'source' => 'SSF',
         'contribution_status_id' => 1,
+        'skipCleanMoney' => 1,
       ),
       'api.website.create' => array(
         array(

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -695,6 +695,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
 
     $params['total_amount'] = $this->formatMoneyInput(5000.77);
     $params['fee_amount'] = $this->formatMoneyInput(.77);
+    $params['skipCleanMoney'] = FALSE;
 
     $contribution = $this->callAPISuccess('contribution', 'create', $params);
     $contribution = $this->callAPISuccessGetSingle('contribution', array('id' => $contribution['id']));

--- a/tests/phpunit/api/v3/MailingTest.php
+++ b/tests/phpunit/api/v3/MailingTest.php
@@ -685,6 +685,9 @@ SELECT event_queue_id, time_stamp FROM mail_{$type}_temp";
       'Opened' => 20,
       'Unique Clicks' => 0,
       'Unsubscribers' => 20,
+      'delivered_rate' => '80%',
+      'opened_rate' => '25%',
+      'clickthrough_rate' => '0%',
     );
     $this->checkArrayEquals($expectedResult, $result['values'][$mail['id']]);
   }

--- a/tests/phpunit/api/v3/MultilingualTest.php
+++ b/tests/phpunit/api/v3/MultilingualTest.php
@@ -141,18 +141,4 @@ class api_v3_MultilingualTest extends CiviUnitTestCase {
     }
   }
 
-  public function enableMultilingual() {
-    $this->callAPISuccess('Setting', 'create', array(
-      'lcMessages' => 'en_US',
-      'languageLimit' => array(
-        'en_US' => 1,
-      ),
-    ));
-
-    CRM_Core_I18n_Schema::makeMultilingual('en_US');
-
-    global $dbLocale;
-    $dbLocale = '_en_US';
-  }
-
 }

--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -188,7 +188,6 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
   public static function getReportTemplates() {
     $reportsToSkip = array(
       'activity' => 'does not respect function signature on from clause',
-      'contribute/topDonor' => 'construction of query in postProcess makes inaccessible ',
       'event/income' => 'I do no understand why but error is Call to undefined method CRM_Report_Form_Event_Income::from() in CRM/Report/Form.php on line 2120',
       'logging/contact/summary' => '(likely to be test related) probably logging off Undefined index: Form/Contact/LoggingSummary.php(231): PHP',
       'logging/contribute/summary' => '(likely to be test related) probably logging off DB Error: no such table',

--- a/xml/version.xml
+++ b/xml/version.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="iso-8859-1" ?>
 <version>
-  <version_no>5.1.beta1</version_no>
+  <version_no>5.2.alpha1</version_no>
 </version>

--- a/xml/version.xml
+++ b/xml/version.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="iso-8859-1" ?>
 <version>
-  <version_no>5.1.alpha1</version_no>
+  <version_no>5.1.beta1</version_no>
 </version>


### PR DESCRIPTION
See https://lab.civicrm.org/dev/core/issues/35

Overview
----------------------------------------
This bug happens if you have more than one iATS recurring contribution and an earlier contribution is assigned to a soft credit, but one or more later contributions are not assigned to a soft credit.

The later contributions have the soft credit information inserted into their receipt because the email message template variables are not properly cleared.

iATS processes multiple recurring contributions in a single session via a cron job, so may be uniquely triggering this error (although the bug is with CiviCRM Core).

Before
----------------------------------------
Some (seemingly at random) recurring contribution receipts are sent out in which donors are credited with honoring people they have never heard of.

After
----------------------------------------
Receipts only honor people if the donor intended to honor them.

Technical Details
----------------------------------------
Most payment processors process each recurring contribution independently of each other - so there is no leakage of template variables.

However, since iATS processes them in one batch, we run into this error.

