### PR TITLE
CRM_Utils_Check - Soften messages for read-only extensionsDir

### DIFF
--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -413,7 +413,6 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
       'uploadDir' => ts('Temporary Files Directory'),
       'imageUploadDir' => ts('Images Directory'),
       'customFileUploadDir' => ts('Custom Files Directory'),
-      'extensionsDir' => ts('CiviCRM Extensions Directory'),
     );
 
     foreach ($directories as $directory => $label) {

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -581,10 +581,10 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
     elseif (!is_writable($basedir)) {
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
-        ts('Directory %1 is not writable.  Please change your file permissions.',
+        ts('Your extensions directory (%1) is read-only. If you would like perform downloads or upgrades, then change the file permissions.',
           array(1 => $basedir)),
-        ts('Directory not writable'),
-        \Psr\Log\LogLevel::ERROR,
+        ts('Read-Only Extensions'),
+        \Psr\Log\LogLevel::WARNING,
         'fa-plug'
       );
       return $messages;

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -581,7 +581,7 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
     elseif (!is_writable($basedir)) {
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
-        ts('Your extensions directory (%1) is read-only. If you would like perform downloads or upgrades, then change the file permissions.',
+        ts('Your extensions directory (%1) is read-only. If you would like to perform downloads or upgrades, then change the file permissions.',
           array(1 => $basedir)),
         ts('Read-Only Extensions'),
         \Psr\Log\LogLevel::WARNING,


### PR DESCRIPTION
Overview
----------------------------------------
The `extensionsDir` is a configurable folder where extension source-code can be written.

The folder may be managed with a few policies:

 * Web-writable -- Allow the web-based admin to perform download/upgrade functions. (Ex: A small NGO where the web designer also installed Civi.)
 * Read-only -- Allow a sysadmin/developer to manage the folder (with CLI/API/cv/git/etc), but don't allow web-based admin to perform download/upgrade functions. (Ex: A public demo site where visitors can preview the admin functionality -- but shouldn't be able to install their favorite crypto miner.)
 * Disable -- Don't allow any extensions to be loaded through this folder.

The web-writable policy is generally the default (because it's easier to get extensions and apply security updates), but it's no panacea. This PR improves messaging when someone has a different policy.

Before
----------------------------------------

There are redundant messages ("Directory not writeable"), and they strongly push the admin toward web-writable policy.

<img width="1023" alt="screen shot 2018-03-28 at 3 16 38 pm" src="https://user-images.githubusercontent.com/1336047/38059409-2ae71012-329b-11e8-9627-470fa1c7f508.png">

After
----------------------------------------

There is only one message ("Read-Only Extensions"). It still encourages web-writable policy, but it lowers the severity and presents it a choice ("if you want X, do Y").

<img width="1027" alt="screen shot 2018-03-28 at 3 35 49 pm" src="https://user-images.githubusercontent.com/1336047/38060016-bc291eec-329d-11e8-8c2e-5aa5e228e038.png">

Comments
----------------------------------------

A few folks have raised related conversations before. Please feel free to comment or thumbs-up/down. CC @xurizaemon @bgm @agh1 @MegaphoneJon 