### PR TITLE
Resolve issue CRM-21831 on https://issues.civicrm.org/jira/browse/CRM-21831

### DIFF
--- a/CRM/Report/Form/Contribute/Detail.php
+++ b/CRM/Report/Form/Contribute/Detail.php
@@ -839,14 +839,18 @@ WHERE  civicrm_contribution_contribution_id={$row['civicrm_contribution_contribu
        * overriding this method in the report class.
        */
 
-      $addtotals = '';
+       /**
+        * Bug: https://issues.civicrm.org/jira/browse/CRM-21831
+        * Alias civicrm_contribution_total_amount is DEPRECATED
+        */
+       $addtotals = '';
+       $showsumcontribs = FALSE;
 
-      if (array_search("civicrm_contribution_total_amount_sum", $this->_selectAliases) !==
-        FALSE
-      ) {
-        $addtotals = ", sum(civicrm_contribution_total_amount_sum) as sumcontribs";
-        $showsumcontribs = TRUE;
-      }
+       if (array_search("civicrm_contribution_total_amount", $this->_selectAliases) !== FALSE ) {
+         $addtotals = ", sum(civicrm_contribution_total_amount) as sumcontribs";
+         $showsumcontribs = TRUE;
+       }
+
 
       $query = $this->_select .
         "$addtotals, count(*) as ct from civireport_contribution_detail_temp3 group by " .

--- a/CRM/Report/Form/Contribute/Detail.php
+++ b/CRM/Report/Form/Contribute/Detail.php
@@ -844,35 +844,35 @@ WHERE  civicrm_contribution_contribution_id={$row['civicrm_contribution_contribu
       $showsumcontribs = FALSE;
 
       if (array_search("civicrm_contribution_total_amount", $this->_selectAliases) !== FALSE) {
-          $addtotals = ", sum(civicrm_contribution_total_amount) as sumcontribs";
-          $showsumcontribs = TRUE;
+        $addtotals = ", sum(civicrm_contribution_total_amount) as sumcontribs";
+        $showsumcontribs = TRUE;
       }
-        $query = $this->_select .
-        "$addtotals, count(*) as ct from civireport_contribution_detail_temp3 group by " .
-        implode(", ", $sectionAliases);
-        // initialize array of total counts
-        $sumcontribs = $totals = array();
-        $dao = CRM_Core_DAO::executeQuery($query);
-        while ($dao->fetch()) {
+      $query = $this->_select .
+      "$addtotals, count(*) as ct from civireport_contribution_detail_temp3 group by " .
+      implode(", ", $sectionAliases);
+      // initialize array of total counts
+      $sumcontribs = $totals = array();
+      $dao = CRM_Core_DAO::executeQuery($query);
+      while ($dao->fetch()) {
 
-          // let $this->_alterDisplay translate any integer ids to human-readable values.
-          // $rows[0] = $dao->toArray();
-          $this->alterDisplay($rows);
-          $row = $rows[0];
+        // let $this->_alterDisplay translate any integer ids to human-readable values.
+        // $rows[0] = $dao->toArray();
+        $this->alterDisplay($rows);
+        $row = $rows[0];
 
-          // add totals for all permutations of section values
-          $values = array();
-          $i = 1;
-          $aliasCount = count($sectionAliases);
-          foreach ($sectionAliases as $alias) {
-            $values[] = $row[$alias];
-            $key = implode(CRM_Core_DAO::VALUE_SEPARATOR, $values);
-            if ($i == $aliasCount) {
-              // the last alias is the lowest-level section header; use count as-is
-              $totals[$key] = $dao->ct;
-              if ($showsumcontribs) {
-                $sumcontribs[$key] = $dao->sumcontribs;
-              }
+        // add totals for all permutations of section values
+        $values = array();
+        $i = 1;
+        $aliasCount = count($sectionAliases);
+        foreach ($sectionAliases as $alias) {
+          $values[] = $row[$alias];
+          $key = implode(CRM_Core_DAO::VALUE_SEPARATOR, $values);
+          if ($i == $aliasCount) {
+            // the last alias is the lowest-level section header; use count as-is
+            $totals[$key] = $dao->ct;
+            if ($showsumcontribs) {
+              $sumcontribs[$key] = $dao->sumcontribs;
+            }
           }
           else {
             // other aliases are higher level; roll count into their total

--- a/CRM/Report/Form/Contribute/Detail.php
+++ b/CRM/Report/Form/Contribute/Detail.php
@@ -837,21 +837,16 @@ WHERE  civicrm_contribution_contribution_id={$row['civicrm_contribution_contribu
       /* Group (un-limited) report by all aliases and get counts. This might
        * be done more efficiently when the contents of $sql are known, ie. by
        * overriding this method in the report class.
+       * Bug: https://issues.civicrm.org/jira/browse/CRM-21831
+       * Alias civicrm_contribution_total_amount is DEPRECATED
        */
+      $addtotals = '';
+      $showsumcontribs = FALSE;
 
-       /**
-        * Bug: https://issues.civicrm.org/jira/browse/CRM-21831
-        * Alias civicrm_contribution_total_amount is DEPRECATED
-        */
-       $addtotals = '';
-       $showsumcontribs = FALSE;
-
-       if (array_search("civicrm_contribution_total_amount", $this->_selectAliases) !== FALSE ) {
-         $addtotals = ", sum(civicrm_contribution_total_amount) as sumcontribs";
-         $showsumcontribs = TRUE;
+       if (array_search("civicrm_contribution_total_amount", $this->_selectAliases) !== FALSE) {
+           $addtotals = ", sum(civicrm_contribution_total_amount) as sumcontribs";
+           $showsumcontribs = TRUE;
        }
-
-
       $query = $this->_select .
         "$addtotals, count(*) as ct from civireport_contribution_detail_temp3 group by " .
         implode(", ", $sectionAliases);

--- a/CRM/Report/Form/Contribute/Detail.php
+++ b/CRM/Report/Form/Contribute/Detail.php
@@ -843,36 +843,36 @@ WHERE  civicrm_contribution_contribution_id={$row['civicrm_contribution_contribu
       $addtotals = '';
       $showsumcontribs = FALSE;
 
-       if (array_search("civicrm_contribution_total_amount", $this->_selectAliases) !== FALSE) {
-           $addtotals = ", sum(civicrm_contribution_total_amount) as sumcontribs";
-           $showsumcontribs = TRUE;
-       }
-      $query = $this->_select .
+      if (array_search("civicrm_contribution_total_amount", $this->_selectAliases) !== FALSE) {
+          $addtotals = ", sum(civicrm_contribution_total_amount) as sumcontribs";
+          $showsumcontribs = TRUE;
+      }
+        $query = $this->_select .
         "$addtotals, count(*) as ct from civireport_contribution_detail_temp3 group by " .
         implode(", ", $sectionAliases);
-      // initialize array of total counts
-      $sumcontribs = $totals = array();
-      $dao = CRM_Core_DAO::executeQuery($query);
-      while ($dao->fetch()) {
+        // initialize array of total counts
+        $sumcontribs = $totals = array();
+        $dao = CRM_Core_DAO::executeQuery($query);
+        while ($dao->fetch()) {
 
-        // let $this->_alterDisplay translate any integer ids to human-readable values.
-        $rows[0] = $dao->toArray();
-        $this->alterDisplay($rows);
-        $row = $rows[0];
+          // let $this->_alterDisplay translate any integer ids to human-readable values.
+          // $rows[0] = $dao->toArray();
+          $this->alterDisplay($rows);
+          $row = $rows[0];
 
-        // add totals for all permutations of section values
-        $values = array();
-        $i = 1;
-        $aliasCount = count($sectionAliases);
-        foreach ($sectionAliases as $alias) {
-          $values[] = $row[$alias];
-          $key = implode(CRM_Core_DAO::VALUE_SEPARATOR, $values);
-          if ($i == $aliasCount) {
-            // the last alias is the lowest-level section header; use count as-is
-            $totals[$key] = $dao->ct;
-            if ($showsumcontribs) {
-              $sumcontribs[$key] = $dao->sumcontribs;
-            }
+          // add totals for all permutations of section values
+          $values = array();
+          $i = 1;
+          $aliasCount = count($sectionAliases);
+          foreach ($sectionAliases as $alias) {
+            $values[] = $row[$alias];
+            $key = implode(CRM_Core_DAO::VALUE_SEPARATOR, $values);
+            if ($i == $aliasCount) {
+              // the last alias is the lowest-level section header; use count as-is
+              $totals[$key] = $dao->ct;
+              if ($showsumcontribs) {
+                $sumcontribs[$key] = $dao->sumcontribs;
+              }
           }
           else {
             // other aliases are higher level; roll count into their total


### PR DESCRIPTION
Overview
----------------------------------------
Resolve issue "When grouping contribution details report by payment method, the group heading is no longer showing the contribution total, only row count"


Before
----------------------------------------

![](https://issues.civicrm.org/jira/secure/attachment/70071/screenshot-dmaster.demo.civicrm.org-2018.03.06-11-40-30.png)


After
----------------------------------------
![image](https://user-images.githubusercontent.com/355838/38066918-5988ca6a-32c7-11e8-8455-50000fe76d76.png)


Technical Details
----------------------------------------
Before the code search for the civicrm_contribution_total_amount_sum on aliases but this alias change to civicrm_contribution_total_amount same case with sum column

---

 * [CRM-21831: When grouping contribution details report by payment method, the group heading is no longer showing the contribution total, only row count](https://issues.civicrm.org/jira/browse/CRM-21831)