### PR TITLE
dev/core#38 Show Recurring Contributions on Membership Modal View

### DIFF
--- a/CRM/Contribute/xml/Menu/Contribute.xml
+++ b/CRM/Contribute/xml/Menu/Contribute.xml
@@ -329,4 +329,10 @@
     <page_callback>CRM_Contribute_Page_ContributionRecurPayments</page_callback>
     <access_arguments>access CiviContribute</access_arguments>
   </item>
+  <item>
+    <path>civicrm/membership/recurring-contributions</path>
+    <title>Membership Recurring Contributions</title>
+    <page_callback>CRM_Member_Page_RecurringContributions</page_callback>
+    <access_arguments>access CiviContribute</access_arguments>
+  </item>
 </menu>

--- a/CRM/Member/Form/MembershipView.php
+++ b/CRM/Member/Form/MembershipView.php
@@ -35,7 +35,6 @@
 
 /**
  * This class generates form components for Payment-Instrument
- *
  */
 class CRM_Member_Form_MembershipView extends CRM_Core_Form {
 
@@ -45,6 +44,20 @@ class CRM_Member_Form_MembershipView extends CRM_Core_Form {
    * @var array
    */
   static $_links = NULL;
+
+  /**
+   * The id of the membership being viewed.
+   *
+   * @var int
+   */
+  private $membershipID;
+
+  /**
+   * Contact's ID.
+   *
+   * @var int
+   */
+  private $contactID;
 
   /**
    * Add context information at the end of a link.
@@ -148,16 +161,16 @@ class CRM_Member_Form_MembershipView extends CRM_Core_Form {
    * @return void
    */
   public function preProcess() {
-
     $values = array();
-    $id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
+    $this->membershipID = CRM_Utils_Request::retrieve('id', 'Positive', $this);
+    $this->contactID = CRM_Utils_Request::retrieve('cid', 'Positive', $this);
 
     // Make sure context is assigned to template for condition where we come here view civicrm/membership/view
     $context = CRM_Utils_Request::retrieve('context', 'String', $this);
     $this->assign('context', $context);
 
-    if ($id) {
-      $params = array('id' => $id);
+    if ($this->membershipID) {
+      $params = array('id' => $this->membershipID);
       CRM_Member_BAO_Membership::retrieve($params, $values);
       if (CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus()) {
         $finTypeId = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipType', $values['membership_type_id'], 'financial_type_id');
@@ -181,12 +194,12 @@ class CRM_Member_Form_MembershipView extends CRM_Core_Form {
       $this->assign('accessContribution', FALSE);
       if (CRM_Core_Permission::access('CiviContribute')) {
         $this->assign('accessContribution', TRUE);
-        CRM_Member_Page_Tab::associatedContribution($values['contact_id'], $id);
+        CRM_Member_Page_Tab::associatedContribution($values['contact_id'], $this->membershipID);
       }
 
       //Provide information about membership source when it is the result of a relationship (CRM-1901)
       $values['owner_membership_id'] = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_Membership',
-        $id,
+        $this->membershipID,
         'owner_membership_id'
       );
 
@@ -375,12 +388,12 @@ SELECT r.id, c.id as cid, c.display_name as name, c.job_title as comment,
 
       CRM_Member_Page_Tab::setContext($this, $values['contact_id']);
 
-      $memType = CRM_Core_DAO::getFieldValue("CRM_Member_DAO_Membership", $id, "membership_type_id");
+      $memType = CRM_Core_DAO::getFieldValue("CRM_Member_DAO_Membership", $this->membershipID, "membership_type_id");
 
-      $groupTree = CRM_Core_BAO_CustomGroup::getTree('Membership', NULL, $id, 0, $memType);
-      CRM_Core_BAO_CustomGroup::buildCustomDataView($this, $groupTree, FALSE, NULL, NULL, NULL, $id);
+      $groupTree = CRM_Core_BAO_CustomGroup::getTree('Membership', NULL, $this->membershipID, 0, $memType);
+      CRM_Core_BAO_CustomGroup::buildCustomDataView($this, $groupTree, FALSE, NULL, NULL, NULL, $this->membershipID);
 
-      $isRecur = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_Membership', $id, 'contribution_recur_id');
+      $isRecur = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_Membership', $this->membershipID, 'contribution_recur_id');
 
       $autoRenew = $isRecur ? TRUE : FALSE;
     }
@@ -389,7 +402,7 @@ SELECT r.id, c.id as cid, c.display_name as name, c.job_title as comment,
       $values['membership_type'] .= ' (test) ';
     }
 
-    $subscriptionCancelled = CRM_Member_BAO_Membership::isSubscriptionCancelled($id);
+    $subscriptionCancelled = CRM_Member_BAO_Membership::isSubscriptionCancelled($this->membershipID);
     $values['auto_renew'] = ($autoRenew && !$subscriptionCancelled) ? 'Yes' : 'No';
 
     //do check for campaigns

--- a/CRM/Member/Page/RecurringContributions.php
+++ b/CRM/Member/Page/RecurringContributions.php
@@ -1,0 +1,155 @@
+<?php
+
+/**
+ * Shows list of recurring contributions related to membership.
+ */
+class CRM_Member_Page_RecurringContributions extends CRM_Core_Page {
+
+  /**
+   * ID of the membership for which we need to see related recurring contributions.
+   *
+   * @var int
+   */
+  private $membershipID = NULL;
+
+  /**
+   * ID of the contact owner of the membership.
+   *
+   * @var int
+   */
+  public $contactID = NULL;
+
+  /**
+   * Builds list of recurring contributions associated to membership.
+   *
+   * @return null
+   */
+  public function run() {
+    $this->membershipID = CRM_Utils_Request::retrieve('membershipID', 'Positive', $this);
+    $this->contactID = CRM_Utils_Request::retrieve('cid', 'Positive', $this, TRUE);
+
+    $this->loadRecurringContributions();
+
+    return parent::run();
+  }
+
+  /**
+   * Loads recurring contributions and assigns them to the form, to be used on
+   * the template.
+   */
+  private function loadRecurringContributions() {
+    $recurringContributions = $this->getRecurContributions($this->membershipID);
+
+    if (!empty($recurringContributions)) {
+      $this->assign('recurRows', $recurringContributions);
+      $this->assign('recur', TRUE);
+    }
+  }
+
+  /**
+   * Obtains list of recurring contributions associated to a membership.
+   *
+   * @param int $membershipID
+   *
+   * @return array
+   */
+  private function getRecurContributions($membershipID) {
+    $result = civicrm_api3('MembershipPayment', 'get', array(
+      'sequential' => 1,
+      'contribution_id.contribution_recur_id.id' => ['IS NOT NULL' => TRUE],
+      'options' => ['limit' => 0],
+      'return' => array(
+        'contribution_id.contribution_recur_id.id',
+        'contribution_id.contribution_recur_id.contact_id',
+        'contribution_id.contribution_recur_id.start_date',
+        'contribution_id.contribution_recur_id.end_date',
+        'contribution_id.contribution_recur_id.next_sched_contribution_date',
+        'contribution_id.contribution_recur_id.amount',
+        'contribution_id.contribution_recur_id.currency',
+        'contribution_id.contribution_recur_id.frequency_unit',
+        'contribution_id.contribution_recur_id.frequency_interval',
+        'contribution_id.contribution_recur_id.installments',
+        'contribution_id.contribution_recur_id.contribution_status_id',
+        'contribution_id.contribution_recur_id.is_test',
+        'contribution_id.contribution_recur_id.payment_processor_id',
+      ),
+      'membership_id' => $membershipID,
+    ));
+    $recurringContributions = array();
+    $contributionStatuses = CRM_Contribute_PseudoConstant::contributionStatus();
+
+    foreach ($result['values'] as $payment) {
+      $recurringContributionID = $payment['contribution_id.contribution_recur_id.id'];
+      $alreadyProcessed = isset($recurringContributions[$recurringContributionID]);
+
+      if ($alreadyProcessed) {
+        continue;
+      }
+
+      foreach ($payment as $field => $value) {
+        $key = strtr($field, array('contribution_id.contribution_recur_id.' => ''));
+        $recurringContributions[$recurringContributionID][$key] = $value;
+      }
+
+      $contactID = $recurringContributions[$recurringContributionID]['contact_id'];
+      $contributionStatusID = $recurringContributions[$recurringContributionID]['contribution_status_id'];
+
+      $recurringContributions[$recurringContributionID]['id'] = $recurringContributionID;
+      $recurringContributions[$recurringContributionID]['contactId'] = $contactID;
+      $recurringContributions[$recurringContributionID]['contribution_status'] = CRM_Utils_Array::value($contributionStatusID, $contributionStatuses);
+
+      $this->setActionsForRecurringContribution($recurringContributionID, $recurringContributions[$recurringContributionID]);
+    }
+    return $recurringContributions;
+  }
+
+  /**
+   * Calculates and assigns the actions available for given recurring
+   * contribution.
+   *
+   * @param int $recurID
+   * @param array $recurringContribution
+   */
+  private function setActionsForRecurringContribution($recurID, &$recurringContribution) {
+    $action = array_sum(array_keys($this->recurLinks($recurID)));
+    // no action allowed if it's not active
+    $recurringContribution['is_active'] = ($recurringContribution['contribution_status_id'] != 3);
+    if ($recurringContribution['is_active']) {
+      $details = CRM_Contribute_BAO_ContributionRecur::getSubscriptionDetails($recurringContribution['id'], 'recur');
+      $hideUpdate = $details->membership_id & $details->auto_renew;
+      if ($hideUpdate || empty($details->processor_id)) {
+        $action -= CRM_Core_Action::UPDATE;
+      }
+      $recurringContribution['action'] = CRM_Core_Action::formLink(
+        $this->recurLinks($recurID),
+        $action,
+        array(
+          'cid' => $this->contactID,
+          'crid' => $recurID,
+          'cxt' => 'contribution',
+        ),
+        ts('more'),
+        FALSE,
+        'contribution.selector.recurring',
+        'Contribution',
+        $recurID
+      );
+    }
+  }
+
+  /**
+   * This method returns the links that are given for recur search row.
+   * currently the links added for each row are:
+   * - View
+   * - Edit
+   * - Cancel
+   *
+   * @param bool $id
+   *
+   * @return array
+   */
+  private function recurLinks($id) {
+    return CRM_Contribute_Page_Tab::recurLinks($id, 'contribution');
+  }
+
+}

--- a/Civi/Test/Api3TestTrait.php
+++ b/Civi/Test/Api3TestTrait.php
@@ -160,7 +160,7 @@ trait Api3TestTrait {
    * @param string $entity
    * @param array $params
    * @param null $count
-   * @throws Exception
+   * @throws \Exception
    * @return array|int
    */
   public function callAPISuccessGetCount($entity, $params, $count = NULL) {
@@ -170,7 +170,7 @@ trait Api3TestTrait {
     );
     $result = $this->civicrm_api($entity, 'getcount', $params);
     if (!is_int($result) || !empty($result['is_error']) || isset($result['values'])) {
-      throw new Exception('Invalid getcount result : ' . print_r($result, TRUE) . " type :" . gettype($result));
+      throw new \Exception('Invalid getcount result : ' . print_r($result, TRUE) . " type :" . gettype($result));
     }
     if (is_int($count)) {
       $this->assertEquals($count, $result, "incorrect count returned from $entity getcount");
@@ -193,7 +193,7 @@ trait Api3TestTrait {
    *   - array
    *   - object
    *
-   * @throws Exception
+   * @throws \Exception
    * @return array|int
    */
   public function callAPISuccessGetSingle($entity, $params, $checkAgainst = NULL) {

--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -224,7 +224,33 @@
       {if $accessContribution and $action eq 2 and $rows.0.contribution_id}
         <div class="crm-accordion-wrapper">
           <div class="crm-accordion-header">{ts}Related Contributions{/ts}</div>
-          <div class="crm-accordion-body">{include file="CRM/Contribute/Form/Selector.tpl" context="Search"}</div>
+          <div class="crm-accordion-body">
+            {include file="CRM/Contribute/Form/Selector.tpl" context="Search"}
+            <script type="text/javascript">
+              var membershipID = {$entityID};
+              var contactID = {$contactId};
+              {literal}
+              CRM.$(function($) {
+                CRM.loadPage(
+                  CRM.url(
+                    'civicrm/membership/recurring-contributions',
+                    {
+                      reset: 1,
+                      membershipID: membershipID,
+                      cid: contactID
+                    },
+                    'back'
+                  ),
+                  {
+                    target : '#membership-recurring-contributions',
+                    dialog : false
+                  }
+                );
+              });
+              {/literal}
+            </script>
+            <div id="membership-recurring-contributions"></div>
+          </div>
         </div>
       {/if}
       {if $softCredit}

--- a/templates/CRM/Member/Form/MembershipView.tpl
+++ b/templates/CRM/Member/Form/MembershipView.tpl
@@ -73,11 +73,41 @@
 
     {include file="CRM/Custom/Page/CustomDataView.tpl"}
 
-    {if $accessContribution and $rows.0.contribution_id}
-        <div class="crm-accordion-wrapper">
-              <div class="crm-accordion-header">{ts}Related Contributions{/ts}</div>
-              <div class="crm-accordion-body">{include file="CRM/Contribute/Form/Selector.tpl" context="Search"}</div>
+    {if $accessContribution}
+      <div class="crm-accordion-wrapper">
+        <div class="crm-accordion-header">
+          {ts}Related Contributions and Recurring Contributions{/ts}
         </div>
+        <div class="crm-accordion-body">
+          {if $rows.0.contribution_id}
+            {include file="CRM/Contribute/Form/Selector.tpl" context="Search"}
+          {/if}
+          <script type="text/javascript">
+            var membershipID = {$id};
+            var contactID = {$contactId};
+            {literal}
+            CRM.$(function($) {
+              CRM.loadPage(
+                CRM.url(
+                  'civicrm/membership/recurring-contributions',
+                  {
+                    reset: 1,
+                    membershipID: membershipID,
+                    cid: contactID
+                  },
+                  'back'
+                ),
+                {
+                  target : '#membership-recurring-contributions',
+                  dialog : false
+                }
+              );
+            });
+            {/literal}
+          </script>
+          <div id="membership-recurring-contributions"></div>
+        </div>
+      </div>
     {/if}
 
     {if $softCredit}

--- a/templates/CRM/Member/Page/RecurringContributions.tpl
+++ b/templates/CRM/Member/Page/RecurringContributions.tpl
@@ -1,0 +1,6 @@
+{if $recur}
+  <div class="solid-border-top">
+    <br /><label>{ts 1=$displayName}Recurring Contributions{/ts}</label>
+  </div>
+  {include file="CRM/Contribute/Page/ContributionRecur.tpl" action=16}
+{/if}


### PR DESCRIPTION
Overview
----------------------------------------
Currently, when viewing a membership from contact's detailed view (on memberships tab), it is hard to tell if a membership has any recurring contributions associated to it, even though you can see all payments done for the membership. It would be good if you could see both payments and recurring contributions associated to the membership, similar to how both are shown on Contact's contribution tab.

Before
----------------------------------------
Only payment contributions were shown on membership modal view.
![basw-78-before](https://user-images.githubusercontent.com/21999940/38143841-e18c6f84-3407-11e8-874e-6683ae29c87d.gif)

After
----------------------------------------
After the table with contributions done for the membership, a new table is shown, with recurring contributions ssociated to the membership.
![basw-78-after](https://user-images.githubusercontent.com/21999940/38143869-08823f06-3408-11e8-91c7-81becbf9d0cf.gif)

Technical Details
----------------------------------------
The same template used on Contact's Contributions tab is used to ensure the same table structure is used for the contributions shown on membership's view.

Comments
----------------------------------------
Issue was reported on gitlab:
https://lab.civicrm.org/dev/core/issues/38
