### PR TITLE
CRM-21244 Ensure consistancy with previous behavior where user emails …

### DIFF
--- a/CRM/Core/BAO/Email.php
+++ b/CRM/Core/BAO/Email.php
@@ -304,6 +304,7 @@ AND    reset_date IS NULL
       return $fromEmailValues;
     }
 
+    $contactFromEmails = [];
     // add logged in user's active email ids
     $contactID = CRM_Core_Session::singleton()->getLoggedInContactID();
     if ($contactID) {
@@ -321,10 +322,10 @@ AND    reset_date IS NULL
         if (!empty($emailVal['is_primary'])) {
           $fromEmailHtml .= ' ' . ts('(preferred)');
         }
-        $fromEmailValues[$emailId] = $fromEmailHtml;
+        $contactFromEmails[$fromEmail] = $fromEmailHtml;
       }
     }
-    return $fromEmailValues;
+    return CRM_Utils_Array::crmArrayMerge($contactFromEmails, $fromEmailValues);
   }
 
   /**

--- a/tests/phpunit/CRM/Core/BAO/EmailTest.php
+++ b/tests/phpunit/CRM/Core/BAO/EmailTest.php
@@ -149,4 +149,22 @@ class CRM_Core_BAO_EmailTest extends CiviUnitTestCase {
     $this->contactDelete($contactId);
   }
 
+  /**
+   * Test getting list of Emails for use in Receipts and Single Email sends
+   */
+  public function testGetFromEmail() {
+    $this->createLoggedInUser();
+    $fromEmails = CRM_Core_BAO_Email::getFromEmail();
+    $emails = array_values($fromEmails);
+    $this->assertContains("(preferred)", $emails[0]);
+    Civi::settings()->set("allow_mail_from_logged_in_contact", 0);
+    $this->callAPISuccess('system', 'flush', []);
+    $fromEmails = CRM_Core_BAO_Email::getFromEmail();
+    $emails = array_values($fromEmails);
+    $this->assertNotContains("(preferred)", $emails[0]);
+    $this->assertContains("info@EXAMPLE.ORG", $emails[0]);
+    Civi::settings()->set("allow_mail_from_logged_in_contact", 1);
+    $this->callAPISuccess('system', 'flush', []);
+  }
+
 }


### PR DESCRIPTION
…are first then system from emails.

Overview
----------------------------------------
This ensures consistency that @Stoob stumbled upon. User emails should be first then the system from emails. 

Before
----------------------------------------
system from emails first user emails second

![send_email_before](https://user-images.githubusercontent.com/6799125/38159834-069d96f4-34fd-11e8-8b61-88f8fa5d3235.jpg)


After
----------------------------------------
Previous behavior restored user emails then system from emails.
![send_email_after](https://user-images.githubusercontent.com/6799125/38159837-0cddc9d0-34fd-11e8-9147-7cfae4be49fb.jpg)


ping @Stoob @eileenmcnaughton @mattwire I think this restores the previous behavior.
