### PR TITLE
dev/core#88 Make sure financial_type_id is set when contribution is created

### DIFF
--- a/CRM/Contribute/BAO/Contribution/Utils.php
+++ b/CRM/Contribute/BAO/Contribution/Utils.php
@@ -74,6 +74,8 @@ class CRM_Contribute_BAO_Contribution_Utils {
 
     // add some financial type details to the params list
     // if folks need to use it
+    //CRM-15297 deprecate contributionTypeID
+    $paymentParams['financial_type_id'] = $paymentParams['financialTypeID'] = $paymentParams['contributionTypeID'] = $financialType->id;
     //CRM-15297 - contributionType is obsolete - pass financial type as well so people can deprecate it
     $paymentParams['financialType_name'] = $paymentParams['contributionType_name'] = $form->_params['contributionType_name'] = $financialType->name;
     //CRM-11456
@@ -154,8 +156,6 @@ class CRM_Contribute_BAO_Contribution_Utils {
       }
 
       $paymentParams['contributionID'] = $contribution->id;
-      //CRM-15297 deprecate contributionTypeID
-      $paymentParams['financialTypeID'] = $paymentParams['contributionTypeID'] = $contribution->financial_type_id;
       $paymentParams['contributionPageID'] = $contribution->contribution_page_id;
       if (isset($paymentParams['contribution_source'])) {
         $paymentParams['source'] = $paymentParams['contribution_source'];

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -740,21 +740,18 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    *
    * Comments from previous refactor indicate doubt as to what was going on.
    *
-   * @param int $contributionTypeId
+   * @param int $financialTypeID
    *
    * @return null|string
    */
-  public function wrangleFinancialTypeID($contributionTypeId) {
-    if (isset($paymentParams['financial_type'])) {
-      $contributionTypeId = $paymentParams['financial_type'];
-    }
-    elseif (!empty($this->_values['pledge_id'])) {
-      $contributionTypeId = CRM_Core_DAO::getFieldValue('CRM_Pledge_DAO_Pledge',
+  public function wrangleFinancialTypeID($financialTypeID) {
+    if (empty($financialTypeID) && !empty($this->_values['pledge_id'])) {
+      $financialTypeID = CRM_Core_DAO::getFieldValue('CRM_Pledge_DAO_Pledge',
         $this->_values['pledge_id'],
         'financial_type_id'
       );
     }
-    return $contributionTypeId;
+    return $financialTypeID;
   }
 
   /**

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
@@ -120,16 +120,20 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
       'skipLineItem' => 0,
     );
 
-    $result = CRM_Contribute_BAO_Contribution_Utils::processConfirm($form,
+    $processConfirmResult = CRM_Contribute_BAO_Contribution_Utils::processConfirm($form,
       $form->_params,
       $contactID,
       $form->_values['financial_type_id'],
       0, FALSE
     );
+
+    // Make sure that certain parameters are set on return from processConfirm
+    $this->assertEquals($form->_values['financial_type_id'], $processConfirmResult['financial_type_id']);
+
     // Based on the processed contribution, complete transaction which update the contribution status based on payment result.
-    if (!empty($result['contribution'])) {
+    if (!empty($processConfirmResult['contribution'])) {
       $this->callAPISuccess('contribution', 'completetransaction', array(
-        'id' => $result['contribution']->id,
+        'id' => $processConfirmResult['contribution']->id,
         'trxn_date' => date('Y-m-d'),
         'payment_processor_id' => $paymentProcessorID,
       ));


### PR DESCRIPTION
Overview
----------------------------------------
When a contribution is created via a contribution page (with a confirmation page) the parameter `financial_type_id` is not set if the contribution is not being created with a recurring contribution.

https://lab.civicrm.org/dev/core/issues/88

Before
----------------------------------------
`financial_type_id` is not set when a non-recurring contribution is submitted via a contribution page (with a confirmation page).  But it is set when a recurring contribution is being created at the same time.

After
----------------------------------------
`financial_type_id` is always set for contribution params when submitted via a contribution page (with a confirmation page).
This makes it more consistent for use in payment processor extensions etc.
