### PR TITLE
Support hooks for MembershipType entity

### DIFF
--- a/CRM/Member/BAO/MembershipType.php
+++ b/CRM/Member/BAO/MembershipType.php
@@ -91,12 +91,24 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
    * @param array $ids
    *   Array contains the id (deprecated).
    *
-   *
-   * @return object
+   * @return \CRM_Member_DAO_MembershipType
+   * @throws \CiviCRM_API3_Exception
    */
   public static function add(&$params, $ids = array()) {
-    $id = CRM_Utils_Array::value('id', $params, CRM_Utils_Array::value('membershipType', $ids));
-    if (!$id) {
+    // DEPRECATED Check if membershipType ID was passed in via $ids
+    if (empty($params['id'])) {
+      if (isset($ids['membershipType'])) {
+        Civi::log()->warning('Deprecated: Passing membershipType by $ids array in CRM_Member_BAO_MembershipType::add');
+      }
+      $params['id'] = CRM_Utils_Array::value('membershipType', $ids);
+    }
+
+    $hook = empty($params['id']) ? 'create' : 'edit';
+    CRM_Utils_Hook::pre($hook, 'MembershipType', CRM_Utils_Array::value('id', $params), $params);
+
+    $membershipTypeId = CRM_Utils_Array::value('id', $params);
+
+    if (!$membershipTypeId) {
       if (!isset($params['is_active'])) {
         // do we need this?
         $params['is_active'] = FALSE;
@@ -106,28 +118,30 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
       }
     }
 
+    // $previousID is the old organization id for membership type i.e 'member_of_contact_id'. This is used when an organization is changed.
+    $previousID = NULL;
+    if ($membershipTypeId) {
+      $previousID = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipType', $membershipTypeId, 'member_of_contact_id');
+    }
+
     // action is taken depending upon the mode
     $membershipType = new CRM_Member_DAO_MembershipType();
     $membershipType->copyValues($params);
-    $membershipType->id = $id;
-
-    // $previousID is the old organization id for membership type i.e 'member_of_contact_id'. This is used when an organization is changed.
-    $previousID = NULL;
-    if ($id) {
-      $previousID = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipType', $id, 'member_of_contact_id');
-    }
-
     $membershipType->save();
-    if ($id) {
+
+    if ($membershipTypeId) {
       // on update we may need to retrieve some details for the price field function - otherwise we get e-notices on attempts to retrieve
       // name etc - the presence of previous id tells us this is an update
       $params = array_merge(civicrm_api3('membership_type', 'getsingle', array('id' => $membershipType->id)), $params);
     }
     self::createMembershipPriceField($params, $previousID, $membershipType->id);
     // update all price field value for quick config when membership type is set CRM-11718
-    if ($id) {
-      self::updateAllPriceFieldValue($id, $params);
+    if ($membershipTypeId) {
+      self::updateAllPriceFieldValue($membershipTypeId, $params);
     }
+
+    CRM_Utils_Hook::post($hook, 'MembershipType', $membershipType->id, $membershipType);
+
     self::flush();
     return $membershipType;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Basic changes required to support pre/post hooks on MembershipType entity (see #11794).

Before
----------------------------------------
- pre/post hooks not triggered on edit/create.

After
----------------------------------------
- pre/post hooks triggered on edit/create.
