### PR TITLE
(dev/mail/7) On 'New Mailing' review page, it doesn't show recipients count

### DIFF
--- a/ang/crmMailing/BlockReview.html
+++ b/ang/crmMailing/BlockReview.html
@@ -11,7 +11,7 @@ Required vars: mailing, attachments
       <div crm-ui-field="{title: ts('Recipients')}">
         <div ng-controller="ViewRecipCtrl">
           <div ng-controller="EditRecipCtrl">
-            <div><a crm-icon="fa-users" class="crm-hover-button action-item" ng-click="previewRecipients()">{{getRecipientsEstimate()}}</a></div>
+            <div><a crm-icon="fa-users" class="crm-hover-button action-item" ng-click="previewRecipients()">{{getRecipientCount()}}</a></div>
             <div ng-show="getIncludesAsString(mailing)">
               (<strong>{{ts('Include:')}}</strong> {{getIncludesAsString(mailing)}})
             </div>


### PR DESCRIPTION
Overview
----------------------------------------
Simply visit the second page of ```New Mailing``` and you will notice that 'Recipients' section has an inappropriate message instead of recipient count.

Issue: https://lab.civicrm.org/dev/mail/issues/7

Before
----------------------------------------
![screen shot 2018-03-31 at 5 30 21 pm](https://user-images.githubusercontent.com/3735621/38162969-41cbdd7e-3509-11e8-8747-fbf0329781f0.png)

After
----------------------------------------
![screen shot 2018-03-31 at 5 29 15 pm](https://user-images.githubusercontent.com/3735621/38162964-25af8dca-3509-11e8-9030-edd8817c5148.png)


Technical Details
----------------------------------------
This is a regression caused by https://github.com/civicrm/civicrm-core/pull/11091 changes where two angular function was created where existing ```getRecipientsEstimate()``` is used to return placeholder message and new function ```getRecipientCount()``` fetches the recipient count. The regression was caused due to former function which is modified to fetch the placeholder message NOT count.
 
