### PR TITLE
CRM-21244 Update documetnation so it makes sense when setting is disabled

### DIFF
--- a/CRM/Admin/Page/Options.php
+++ b/CRM/Admin/Page/Options.php
@@ -151,6 +151,7 @@ class CRM_Admin_Page_Options extends CRM_Core_Page_Basic {
       $this->assign('showCounted', TRUE);
     }
     $this->assign('isLocked', self::$_isLocked);
+    $this->assign('allowLoggedIn', Civi::settings()->get('allow_mail_from_logged_in_contact'));
     $config = CRM_Core_Config::singleton();
     if (self::$_gName == 'activity_type') {
       $this->assign('showComponent', TRUE);

--- a/templates/CRM/Admin/Page/Options.tpl
+++ b/templates/CRM/Admin/Page/Options.tpl
@@ -59,7 +59,11 @@
   {elseif $gName eq 'participant_status'}
     {ts}Define statuses for event participants here (e.g. Registered, Attended, Cancelled...). You can then assign statuses and search for participants by status.{/ts} {ts}"Counted?" controls whether a person with that status is counted as participant for the purpose of controlling the Maximum Number of Participants.{/ts}
   {elseif $gName eq 'from_email_address'}
-    {ts}By default, CiviCRM uses the primary email address of the logged in user as the FROM address when sending emails to contacts. However, you can use this page to define one or more general Email Addresses that can be selected as an alternative. EXAMPLE: <em>"Client Services" &lt;clientservices@example.org&gt;</em>{/ts}
+    {if $allowLoggedIn}
+      {ts}By default, CiviCRM uses the primary email address of the logged in user as the FROM address when sending emails to contacts. However, you can use this page to define one or more general Email Addresses that can be selected as an alternative. EXAMPLE: <em>"Client Services" &lt;clientservices@example.org&gt;</em>{/ts}
+    {else}
+      {ts}You can use this page to define one or more general Email Addresses that can be selected as the From Address. EXAMPLE: <em>"Client Services" &lt;clientservices@example.org&gt;</em>{/ts}
+    {/if}
   {elseif $isLocked}
     {ts}This option group is reserved for system use. You cannot add or delete options in this list.{/ts}
   {else}

--- a/templates/CRM/Contact/Form/Task/Email.hlp
+++ b/templates/CRM/Contact/Form/Task/Email.hlp
@@ -27,10 +27,18 @@
   {ts}From Address{/ts}
 {/htxt}
 {htxt id="id-from_email"}
-<p>{ts}By default, CiviCRM uses the primary email address of the logged in user as the FROM address when sending emails to contacts. However, users with Administer CiviCRM permission can configure one or more general email addresses that can be selected as an alternative. EXAMPLE: "Client Services" &lt;clientservices@example.org&gt;{/ts}</p>
+{if $params.logged_in_email_setting == "1"}
+  <p>{ts}By default, CiviCRM uses the primary email address of the logged in user as the FROM address when sending emails to contacts. However, users with Administer CiviCRM permission can configure one or more general email addresses that can be selected as an alternative. EXAMPLE: "Client Services" &lt;clientservices@example.org&gt;{/ts}</p>
+{else}
+  <p>{ts}CiviCRM is currently configured to only use the defined From Email addresses. If you wish to be able to use the email address of the logged in user as the From Address you will need to set the setting "Allow mail from loged in contact" setting. Users with Administer CiviCRM can set this setting in the SMTP settings.{/ts}<p>
+  {if $params.isAdmin}
+    {capture assign="smtpUrl"}{crmURL p="civicrm/admin/setting/smtp" q="reset=1"}{/capture}
+    <p>{ts 1=$smtpUrl}Go to <a href='%1'>Settings - Outbound Mail</a> to enable the usage of the logged in contact's email address as the from email{/ts}</p>
+  {/if}
+{/if}
 {if $params.isAdmin}
-    {capture assign="fromConfig"}{crmURL p="civicrm/admin/options/from_email_address" q="reset=1"}{/capture}
-    <p>{ts 1=$fromConfig}Go to <a href='%1'>Administer CiviCRM &raquo; Communications &raquo; FROM Email Addresses</a> to add or edit general email addresses. Make sure these email addresses are valid email accounts with your email service provider.{/ts}</p>
+   {capture assign="fromConfig"}{crmURL p="civicrm/admin/options/from_email_address" q="reset=1"}{/capture}
+   <p>{ts 1=$fromConfig}Go to <a href='%1'>Administer CiviCRM &raquo; Communications &raquo; FROM Email Addresses</a> to add or edit general email addresses. Make sure these email addresses are valid email accounts with your email service provider.{/ts}</p>
 {/if}
 {/htxt}
 

--- a/templates/CRM/Contact/Form/Task/Email.tpl
+++ b/templates/CRM/Contact/Form/Task/Email.tpl
@@ -30,10 +30,11 @@
         <p>{ts count=$suppressedEmails plural='Email will NOT be sent to %count contacts - (no email address on file, or communication preferences specify DO NOT EMAIL, or contact is deceased).'}Email will NOT be sent to %count contact - (no email address on file, or communication preferences specify DO NOT EMAIL, or contact is deceased).{/ts}</p>
     </div>
 {/if}
+{crmSetting var="logged_in_email_setting" name="allow_mail_from_logged_in_contact"}
 <table class="form-layout-compressed">
   <tr id="selectEmailFrom" class="crm-contactEmail-form-block-fromEmailAddress crm-email-element">
     <td class="label">{$form.from_email_address.label}</td>
-    <td>{$form.from_email_address.html} {help id="id-from_email" file="CRM/Contact/Form/Task/Email.hlp" isAdmin=$isAdmin}</td>
+    <td>{$form.from_email_address.html} {help id="id-from_email" file="CRM/Contact/Form/Task/Email.hlp" isAdmin=$isAdmin logged_in_email_setting=$logged_in_email_setting}</td>
   </tr>
     <tr class="crm-contactEmail-form-block-recipient">
        <td class="label">{if $single eq false}{ts}Recipient(s){/ts}{else}{$form.to.label}{/if}</td>


### PR DESCRIPTION
Overview
----------------------------------------
This updates the help text so that it makes sense when the allow logged in user emails is disabled 

Before
----------------------------------------
Confusing help text

After
----------------------------------------
Less confusing help text

ping @Stoob @mattwire What do you think about these help text changes

---

 * [CRM-21244: Enhancements to "FROM email addresses"](https://issues.civicrm.org/jira/browse/CRM-21244)