### PR TITLE
Add rule for separation

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -742,6 +742,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
           'combined' => ts('Create one activity with all contacts together'),
         )
       );
+      $this->addRule('separation', ts('Activity separation is a required field'), 'required');
     }
 
     $this->addRule('duration',


### PR DESCRIPTION
Issue CRM-21859
Form for adding activities doesn't validate field Activity Separation when is called from list of contacts

Overview
----------------------------------------
Resolve issue when create an activity from contact search and can make a separation this separation isn't required

Before
----------------------------------------

Open page "Find Contacts" and click "Search"
Select first 50 records
Click on "Actions" field and choose "Add activity" (Selected contacts are in With contacts field)
Choose Meeting, clear Date and Time fields
Click Save button
Effect: The form doesn't validate the field "Activity Separation" and activity is created. There should be a warning "Activity Separation is a required field"

After
----------------------------------------

Open page "Find Contacts" and click "Search"
Select first 50 rekords
Click on "Actions" field and choose "Add activity" (Selected contacts are in With contacts field)
Choose Meeting, clear Date and Time fields
Click Save button
Effect: The form validate the field "Activity Separation" and activity is created and show a warning "Activity Separation is a required field"

Technical Details
----------------------------------------
Just add a rule for make required a separation when this is created

---

 * [CRM-21859: Form for adding activities doesn't validate field Activity Separation when is called from list of contacts](https://issues.civicrm.org/jira/browse/CRM-21859)