### PR TITLE
CRM-21831 & dev/report/issues/1 Fix regressions in contribution detail report relating to soft credits

### DIFF
--- a/CRM/Report/Form/Contribute/Detail.php
+++ b/CRM/Report/Form/Contribute/Detail.php
@@ -39,6 +39,8 @@ class CRM_Report_Form_Contribute_Detail extends CRM_Report_Form {
 
   protected $_softFrom = NULL;
 
+  protected $noDisplayContributionOrSoftColumn = FALSE;
+
   protected $_customGroupExtends = array(
     'Contact',
     'Individual',
@@ -341,10 +343,6 @@ class CRM_Report_Form_Contribute_Detail extends CRM_Report_Form {
     $this->_columnHeaders = array();
 
     parent::select();
-    //total_amount was affected by sum as it is considered as one of the stat field
-    //so it is been replaced with correct alias, CRM-13833
-    $this->_select = str_replace("sum({$this->_aliases['civicrm_contribution']}.total_amount)", "{$this->_aliases['civicrm_contribution']}.total_amount", $this->_select);
-    $this->_selectClauses = str_replace("sum({$this->_aliases['civicrm_contribution']}.total_amount)", "{$this->_aliases['civicrm_contribution']}.total_amount", $this->_selectClauses);
   }
 
   public function orderBy() {
@@ -721,7 +719,7 @@ UNION ALL
       }
 
       // Contribution amount links to viewing contribution
-      if (($value = CRM_Utils_Array::value('civicrm_contribution_total_amount_sum', $row)) &&
+      if (($value = CRM_Utils_Array::value('civicrm_contribution_total_amount', $row)) &&
         CRM_Core_Permission::check('access CiviContribute')
       ) {
         $url = CRM_Utils_System::url("civicrm/contact/view/contribution",
@@ -730,8 +728,8 @@ UNION ALL
           "&action=view&context=contribution&selectedChild=contribute",
           $this->_absoluteUrl
         );
-        $rows[$rowNum]['civicrm_contribution_total_amount_sum_link'] = $url;
-        $rows[$rowNum]['civicrm_contribution_total_amount_sum_hover'] = ts("View Details of this Contribution.");
+        $rows[$rowNum]['civicrm_contribution_total_amount_link'] = $url;
+        $rows[$rowNum]['civicrm_contribution_total_amount_hover'] = ts("View Details of this Contribution.");
         $entryFound = TRUE;
       }
 
@@ -750,7 +748,7 @@ UNION ALL
         array_key_exists('civicrm_contribution_contribution_id', $row)
       ) {
         $query = "
-SELECT civicrm_contact_id, civicrm_contact_sort_name, civicrm_contribution_total_amount_sum, civicrm_contribution_currency
+SELECT civicrm_contact_id, civicrm_contact_sort_name, civicrm_contribution_total_amount, civicrm_contribution_currency
 FROM   civireport_contribution_detail_temp2
 WHERE  civicrm_contribution_contribution_id={$row['civicrm_contribution_contribution_id']}";
         $dao = CRM_Core_DAO::executeQuery($query);
@@ -761,7 +759,7 @@ WHERE  civicrm_contribution_contribution_id={$row['civicrm_contribution_contribu
             $dao->civicrm_contact_id);
           $string = $string . ($string ? $separator : '') .
             "<a href='{$url}'>{$dao->civicrm_contact_sort_name}</a> " .
-            CRM_Utils_Money::format($dao->civicrm_contribution_total_amount_sum, $dao->civicrm_contribution_currency);
+            CRM_Utils_Money::format($dao->civicrm_contribution_total_amount, $dao->civicrm_contribution_currency);
         }
         $rows[$rowNum]['civicrm_contribution_soft_credits'] = $string;
       }
@@ -841,10 +839,10 @@ WHERE  civicrm_contribution_contribution_id={$row['civicrm_contribution_contribu
 
       $addtotals = '';
 
-      if (array_search("civicrm_contribution_total_amount_sum", $this->_selectAliases) !==
+      if (array_search("civicrm_contribution_total_amount", $this->_selectAliases) !==
         FALSE
       ) {
-        $addtotals = ", sum(civicrm_contribution_total_amount_sum) as sumcontribs";
+        $addtotals = ", sum(civicrm_contribution_total_amount) as sumcontribs";
         $showsumcontribs = TRUE;
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
This fixes 3 regressions in the contribution report, all of which relate to use of soft credits
1) a fatal error on soft credit fields https://lab.civicrm.org/dev/report/issues/1
2) total amount not displayed - https://issues.civicrm.org/jira/browse/CRM-21831
3) the total amount column no longer has a link

Before
----------------------------------------
1) when soft credit column is on display the report does not render with a fatal error
2) as described in https://github.com/civicrm/civicrm-core/pull/11897 ![](https://issues.civicrm.org/jira/secure/attachment/70071/screenshot-dmaster.demo.civicrm.org-2018.03.06-11-40-30.png)
3) no link on amount column

After
----------------------------------------
1) Note the soft credit column renders without error

![screenshot 2018-04-02 10 22 47](https://user-images.githubusercontent.com/336308/38178268-224f038a-3663-11e8-8cb2-409963d04c49.png)

2) The total amount is shown on the section break
![image](https://user-images.githubusercontent.com/355838/38066918-5988ca6a-32c7-11e8-8455-50000fe76d76.png)

3) Total amount link is re-instated
![screenshot 2018-04-02 10 56 28](https://user-images.githubusercontent.com/336308/38178323-7c9939d6-3664-11e8-9282-12bad1e4e8af.png)



Technical Details
----------------------------------------
Per @mlutfy investigation this line caused the regressions https://github.com/civicrm/civicrm-core/commit/4b885f843d4d00ea63ab8b331f05ad5ba1c0863f#diff-d355cdb00cea3915a3cf306c6c08f6a6R2314

The reason is that this line was causing the select query to be treated as a group by query when statistics were present. In this report stats were present but there is no group by tab or option (there is an option in the order by to do sections but that is a different concept from a code POV)

![screenshot 2018-04-02 10 59 35](https://user-images.githubusercontent.com/336308/38178342-e986ac4a-3664-11e8-912b-b2831ac97186.png)

At some early point the fact the addStatisticsToSelect was altering the column names to 'group by style' was adapted to, not by fixing the assumption, but by  series of hacks in the report code. This PR removes them.

@mlutfy @lcdservices @elgui02 - this takes #11897 fix & extends it to also address the fatal issue. As a recent regression I believe this needs to go into the rc - but it will need a quick turn-around on feedback for that

Comments
----------------------------------------
I checked to see what would happen in the soft credit rendering if a contact had more than one soft credit from the same contribution. It turned out to be UI blocked.
![screenshot 2018-04-02 10 22 32](https://user-images.githubusercontent.com/336308/38178264-0ec2d288-3663-11e8-949e-f72c8e14695e.png)
