### PR TITLE
(dev/mail/6) Fix recipient calculation when system has mixed records. Add multilingual test.

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -128,7 +128,7 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing {
     $recipientsGroup = $excludeSmartGroupIDs = $includeSmartGroupIDs = $priorMailingIDs = array();
     $dao = CRM_Utils_SQL_Select::from('civicrm_mailing_group')
              ->select('GROUP_CONCAT(entity_id SEPARATOR ",") as group_ids, group_type, entity_table')
-             ->where('mailing_id = #mailing_id AND entity_table IN ("!groupTableName", "civicrm_mailing")')
+             ->where('mailing_id = #mailing_id AND entity_table RLIKE "^civicrm_(group.*|mailing)$" ')
              ->groupBy(array('group_type', 'entity_table'))
              ->param('!groupTableName', CRM_Contact_BAO_Group::getTableName())
              ->param('#mailing_id', $mailingID)
@@ -138,7 +138,7 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing {
         $priorMailingIDs[$dao->group_type] = explode(',', $dao->group_ids);
       }
       else {
-        $recipientsGroup[$dao->group_type] = explode(',', $dao->group_ids);
+        $recipientsGroup[$dao->group_type] = empty($recipientsGroup[$dao->group_type]) ? explode(',', $dao->group_ids) : array_merge($recipientsGroup[$dao->group_type], explode(',', $dao->group_ids));
       }
     }
 

--- a/tests/phpunit/CRM/Mailing/BAO/MailingTest.php
+++ b/tests/phpunit/CRM/Mailing/BAO/MailingTest.php
@@ -34,6 +34,14 @@ class CRM_Mailing_BAO_MailingTest extends CiviUnitTestCase {
     parent::setUp();
   }
 
+  public function tearDown() {
+    global $dbLocale;
+    if ($dbLocale) {
+      CRM_Core_I18n_Schema::makeSinglelingual('en_US');
+    }
+    parent::tearDown();
+  }
+
   /**
    * Helper function to assert whether the calculated recipients of a mailing
    * match the expected list
@@ -71,7 +79,7 @@ class CRM_Mailing_BAO_MailingTest extends CiviUnitTestCase {
     return $this->callAPISuccess('MailingGroup', 'create', array(
       'mailing_id' => $mailingID,
       'group_type' => $type,
-      'entity_table' => "civicrm_group",
+      'entity_table' => CRM_Contact_BAO_Group::getTableName(),
       'entity_id' => $groupID,
     ));
   }
@@ -100,7 +108,6 @@ class CRM_Mailing_BAO_MailingTest extends CiviUnitTestCase {
    * contact 7 : smart 4 (inc)
    */
   public function testgetRecipientsEmailGroupIncludeExclude() {
-
     // Set up groups; 3 standard, 3 smart
     $groupIDs = array();
     for ($i = 0; $i < 6; $i++) {
@@ -172,6 +179,8 @@ class CRM_Mailing_BAO_MailingTest extends CiviUnitTestCase {
 
     // Check that we can include smart groups in the mailing too.
     // Expected: All contacts should be included.
+    // Also (dev/mail/6): Enable multilingual mode to check that restructing group doesn't affect recipient rebuilding
+    $this->enableMultilingual();
     $this->createMailingGroup($mailing['id'], $groupIDs[3]);
     $this->createMailingGroup($mailing['id'], $groupIDs[4]);
     $this->assertRecipientsCorrect($mailing['id'], $contactIDs);
@@ -198,7 +207,6 @@ class CRM_Mailing_BAO_MailingTest extends CiviUnitTestCase {
     foreach ($contactIDs as $contactID) {
       $this->contactDelete($contactID);
     }
-
   }
 
   /**

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3999,4 +3999,21 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
     return $contributionObj;
   }
 
+  /**
+   * Enable multilingual.
+   */
+  public function enableMultilingual() {
+    $this->callAPISuccess('Setting', 'create', array(
+      'lcMessages' => 'en_US',
+      'languageLimit' => array(
+        'en_US' => 1,
+      ),
+    ));
+
+    CRM_Core_I18n_Schema::makeMultilingual('en_US');
+
+    global $dbLocale;
+    $dbLocale = '_en_US';
+  }
+
 }

--- a/tests/phpunit/api/v3/MultilingualTest.php
+++ b/tests/phpunit/api/v3/MultilingualTest.php
@@ -141,18 +141,4 @@ class api_v3_MultilingualTest extends CiviUnitTestCase {
     }
   }
 
-  public function enableMultilingual() {
-    $this->callAPISuccess('Setting', 'create', array(
-      'lcMessages' => 'en_US',
-      'languageLimit' => array(
-        'en_US' => 1,
-      ),
-    ));
-
-    CRM_Core_I18n_Schema::makeMultilingual('en_US');
-
-    global $dbLocale;
-    $dbLocale = '_en_US';
-  }
-
 }


### PR DESCRIPTION
Overview
----------------------------------------
This PR contains an additional fix to make a query more generic, which is responsible to fetch recipient mailing groups for a given mailing (identified by ID). Generic in way that toggling multilingual setting won't affect the normal workflow to build recipients and to ensure that I have extended a UT. 


Before
----------------------------------------
Doesn't populate some recipients when ```civicrm_mailing_group.entity_table``` has a mix of group table names (e.g. `civicrm_group` and `civicrm_group_fr_FR`).

After
----------------------------------------
Fixed it + added unit-test for recipients in multilingual mode.

Comments
-----------------------------------------
This is a followup to [#11906](https://github.com/civicrm/civicrm-core/pull/11906#discussion_r178655726).