### PR TITLE
CRM-21855 comment code in BAO/RelationshipType 

### DIFF
--- a/CRM/Contact/BAO/RelationshipType.php
+++ b/CRM/Contact/BAO/RelationshipType.php
@@ -113,12 +113,12 @@ class CRM_Contact_BAO_RelationshipType extends CRM_Contact_DAO_RelationshipType 
     $relationshipType->copyValues($params);
 
     // if label B to A is blank, insert the value label A to B for it
-    if (!strlen(trim($strName = CRM_Utils_Array::value('name_b_a', $params)))) {
-      $relationshipType->name_b_a = CRM_Utils_Array::value('name_a_b', $params);
-    }
-    if (!strlen(trim($strName = CRM_Utils_Array::value('label_b_a', $params)))) {
-      $relationshipType->label_b_a = CRM_Utils_Array::value('label_a_b', $params);
-    }
+    // if (!strlen(trim($strName = CRM_Utils_Array::value('name_b_a', $params)))) {
+    //   $relationshipType->name_b_a = CRM_Utils_Array::value('name_a_b', $params);
+    // }
+    // if (!strlen(trim($strName = CRM_Utils_Array::value('label_b_a', $params)))) {
+    //   $relationshipType->label_b_a = CRM_Utils_Array::value('label_a_b', $params);
+    // }
 
     $result = $relationshipType->save();
 

--- a/js/jquery/jquery.crmEditable.js
+++ b/js/jquery/jquery.crmEditable.js
@@ -148,6 +148,26 @@
         else {
           params[info.field] = value;
         }
+
+        /*
+        * Additional Extends Edit editable
+         * This new functionality extends the ... to add several additional columns and send it by ajax
+         * additional-class-name-save: is a data-additional-class-name-save name name of the class  that the value
+         * will be taken.
+         *  column-name: is a data-column-name: Is the name of column
+         *
+        */
+         if($i.data('additional-class-name-save') !== "undefined"){
+                var class_name_additional =$i.data('additional-class-name-save');
+                var name_column =$i.data('column-name');
+                if(name_column  !== "undefined"){
+                 var values_name_column =  $("."+class_name_additional).children().html();
+                 params[name_column] =  values_name_column;
+            }
+
+          }
+          /**EndParche**/
+
         CRM.api3(info.entity, action, params, {error: null})
           .done(function(data) {
             if (data.is_error) {

--- a/templates/CRM/Admin/Page/RelationshipType.tpl
+++ b/templates/CRM/Admin/Page/RelationshipType.tpl
@@ -61,8 +61,11 @@
         </thead>
         {foreach from=$rows item=row}
         <tr id="relationship_type-{$row.id}" class="crm-entity {cycle values="odd-row,even-row"} {$row.class}{if NOT $row.is_active} disabled{/if} crm-relationship">
-            <td class="crm-relationship-label_a_b crm-editable" data-field="label_a_b">{$row.label_a_b}</td>
-            <td class="crm-relationship-label_b_a crm-editable" data-field="label_b_a">{$row.label_b_a}</td>
+
+          <!--   Additional Extends Edit editable -->
+            <td class="crm-relationship-label_a_b crm-editable" data-column-name="label_b_a" data-additional-class-name-save="additional_label_b_a" data-field="label_a_b">{$row.label_a_b}</td>
+            <td class="crm-relationship-label_b_a crm-editable additional_label_b_a"  data-field="label_b_a">{$row.label_b_a}
+            </td>
             <td class="crm-relationship-contact_type_a_display">
                 {if $row.contact_type_a_display} {$row.contact_type_a_display}
                 {if $row.contact_sub_type_a} - {$row.contact_sub_type_a} {/if}{else} {ts}All Contacts{/ts} {/if} </td>


### PR DESCRIPTION
Overview
----------------------------------------
Comment if label B to A is blank, insert the value label A to B for it

When editing the "A" side of a relationship from 'civicrm/admin/reltype' the values entered in the "Relationship A to B" column are copied to the "Relationship B to A" column. The reverse is not true.
Go to civicrm/admin/reltype

Edit anything in the "Relationship A to B" column
Save and refresh the page
The "Relationship B to A" column has also been updated

https://issues.civicrm.org/jira/secure/attachment/70672/70672_image-2018-03-27-15-11-54-181.png

![](ps://issues.civicrm.org/jira/secure/attachment/70672/70672_image-2018-03-27-15-11-54-181.png)

---

 * [CRM-21855: Editing "A" side of relationship copies values to "B" side](https://issues.civicrm.org/jira/browse/CRM-21855)