### PR TITLE
Fix fatal error when selecting a $0 price option in change fee selection

### DIFF
--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -766,7 +766,7 @@ WHERE li.contribution_id = %1";
           ));
           unset($updateFinancialItemInfoValues['financialTrxn']);
         }
-        elseif (!empty($updateFinancialItemInfoValues['link-financial-trxn'])) {
+        elseif (!empty($updateFinancialItemInfoValues['link-financial-trxn']) && $newFinancialItem->amount != 0) {
           civicrm_api3('EntityFinancialTrxn', 'create', array(
             'entity_id' => $newFinancialItem->id,
             'entity_table' => 'civicrm_financial_item',


### PR DESCRIPTION
Overview
----------------------------------------
Fix fatal error when changing event fee selection from a price option with a fee to a $0 option 

Before
----------------------------------------
Fatal error if I change option from tiny tots to 'none' in the first field

![screenshot 2018-04-04 17 59 17](https://user-images.githubusercontent.com/336308/38291060-21e2d040-3832-11e8-9dd7-194626703d1e.png)


After
----------------------------------------
Fatal error gone

Technical Details
----------------------------------------
The code for creating a new price option creates a new financial transaction but when choosing a $0  price option  it fails as the api does not accept $0. Skip creation if $0

Comments
----------------------------------------
@monishdeb I think we probably should push this into the rc - was trying to replicate CRM-17267 & hit this

---

 * [CRM-17267: 'Change event selections' impossible for sold out events](https://issues.civicrm.org/jira/browse/CRM-17267)