### PR TITLE
(dev/core/45) show image files inline when clicked instead of download

### DIFF
--- a/CRM/Core/Page/File.php
+++ b/CRM/Core/Page/File.php
@@ -55,6 +55,7 @@ class CRM_Core_Page_File extends CRM_Core_Page {
       list($path, $mimeType) = CRM_Core_BAO_File::path($id, $eid, NULL, $quest);
     }
 
+    $disposition = strpos($mimeType, 'image') === FALSE ? 'download' : 'inline';
     if (!$path) {
       CRM_Core_Error::statusBounce('Could not retrieve the file');
     }


### PR DESCRIPTION
Overview
----------------------------------------
show image files inline when clicked instead of download


Before
----------------------------------------
Steps to replicate:

1. Create a note with an attached image file.
2. View the note and click the file.
3. It directly downloads the file.

After
----------------------------------------
Clicking the image file shows the file inline

