### PR TITLE
(accessibility/misc-core-fixes/issues/3) Add accessible labels

### DIFF
--- a/CRM/Pledge/BAO/PledgeBlock.php
+++ b/CRM/Pledge/BAO/PledgeBlock.php
@@ -281,11 +281,11 @@ class CRM_Pledge_BAO_PledgeBlock extends CRM_Pledge_DAO_PledgeBlock {
       $form->addRadio('is_pledge', ts('Pledge Frequency Interval'), $pledgeOptions,
         NULL, array('<br/>')
       );
-      $form->addElement('text', 'pledge_installments', ts('Installments'), array('size' => 3));
+      $form->addElement('text', 'pledge_installments', ts('Installments'), array('size' => 3, 'aria-label' => ts('Pledge Installments')));
 
       if (!empty($pledgeBlock['is_pledge_interval'])) {
         $form->assign('is_pledge_interval', CRM_Utils_Array::value('is_pledge_interval', $pledgeBlock));
-        $form->addElement('text', 'pledge_frequency_interval', NULL, array('size' => 3));
+        $form->addElement('text', 'pledge_frequency_interval', NULL, array('size' => 3, 'aria-label' => ts('Pledge Frequency Interval')));
       }
       else {
         $form->add('hidden', 'pledge_frequency_interval', 1);
@@ -299,7 +299,7 @@ class CRM_Pledge_BAO_PledgeBlock extends CRM_Pledge_DAO_PledgeBlock {
           $freqUnits[$val] = !empty($pledgeBlock['is_pledge_interval']) ? "{$frequencyUnits[$val]}(s)" : $frequencyUnits[$val];
         }
       }
-      $form->addElement('select', 'pledge_frequency_unit', NULL, $freqUnits);
+      $form->addElement('select', 'pledge_frequency_unit', NULL, $freqUnits, array('aria-label' => ts('Pledge Frequency Unit')));
       // CRM-18854
       if (CRM_Utils_Array::value('is_pledge_start_date_visible', $pledgeBlock)) {
         if (CRM_Utils_Array::value('pledge_start_date', $pledgeBlock)) {

--- a/templates/CRM/Core/BillingBlock.tpl
+++ b/templates/CRM/Core/BillingBlock.tpl
@@ -79,6 +79,7 @@
     </fieldset>
   {/if}
 </div>
+
 {if $profileAddressFields}
   <script type="text/javascript">
     {literal}
@@ -207,15 +208,18 @@
   </script>
   {/literal}
 {/if}
-{if $suppressSubmitButton}
 {literal}
   <script type="text/javascript">
     CRM.$(function($) {
-      $('.crm-submit-buttons', $('#billing-payment-block').closest('form')).hide();
+      {/literal}{if $suppressSubmitButton}{literal}
+        $('.crm-submit-buttons', $('#billing-payment-block').closest('form')).hide();
+      {/literal}{/if}{literal}
+
+      $('#credit_card_exp_date_M').attr('aria-label', ts('Expiration Month'));
+      $('#credit_card_exp_date_Y').attr('aria-label', ts('Expiration Year'));
     });
   </script>
 {/literal}
-{/if}
 {/crmRegion}
 {crmRegion name="billing-block-post"}
   {* Payment processors sometimes need to append something to the end of the billing block. We create a region for

--- a/templates/CRM/Event/Page/EventInfo.tpl
+++ b/templates/CRM/Event/Page/EventInfo.tpl
@@ -115,7 +115,7 @@
   {/if}
   <div class="clear"></div>
   <div class="crm-section event_date_time-section">
-      <div class="label"><label>{ts}When{/ts}</label></div>
+      <div class="label">{ts}When{/ts}</div>
       <div class="content">
             <abbr class="dtstart" title="{$event.event_start_date|crmDate}">
             {$event.event_start_date|crmDate}</abbr>
@@ -140,7 +140,7 @@
 
         {if $location.address.1}
             <div class="crm-section event_address-section">
-                <div class="label"><label>{ts}Location{/ts}</label></div>
+                <div class="label">{ts}Location{/ts}</div>
                 <div class="content">{$location.address.1.display|nl2br}</div>
                 <div class="clear"></div>
             </div>
@@ -164,7 +164,7 @@
 
   {if $location.phone.1.phone || $location.email.1.email}
       <div class="crm-section event_contact-section">
-          <div class="label"><label>{ts}Contact{/ts}</label></div>
+          <div class="label">{ts}Contact{/ts}</div>
           <div class="content">
               {* loop on any phones and emails for this event *}
               {foreach from=$location.phone item=phone}
@@ -186,7 +186,7 @@
 
   {if $event.is_monetary eq 1 && $feeBlock.value}
       <div class="crm-section event_fees-section">
-          <div class="label"><label>{$event.fee_label}</label></div>
+          <div class="label">{$event.fee_label}</div>
           <div class="content">
               <table class="form-layout-compressed fee_block-table">
                   {foreach from=$feeBlock.value name=fees item=value}


### PR DESCRIPTION
Overview
----------------------------------------
This PR is about adding accessible labels where it is missing in Civi to all kind of fields/links.
Ticket: https://lab.civicrm.org/accessibility/misc-core-fixes/issues/3

Before
----------------------------------------
_The current status. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._

After
----------------------------------------
List of fixes made on following pages:
1. Add ```aria-label``` to expiry month and year select field.
2. Print icons + additional improvement where replace all the cms native template files with a common template, because they all share the same code

Technical Details
----------------------------------------
_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
