### PR TITLE
dev/core#47 Add clone scheduled job functionality

### DIFF
--- a/CRM/Admin/Page/Job.php
+++ b/CRM/Admin/Page/Job.php
@@ -96,6 +96,12 @@ class CRM_Admin_Page_Job extends CRM_Core_Page_Basic {
           'qs' => 'action=delete&id=%%id%%',
           'title' => ts('Delete Scheduled Job'),
         ),
+        CRM_Core_Action::COPY => array(
+          'name' => ts('Copy'),
+          'url' => 'civicrm/admin/job',
+          'qs' => 'action=copy&id=%%id%%',
+          'title' => ts('Copy Scheduled Job'),
+        ),
       );
     }
     return self::$_links;
@@ -128,9 +134,23 @@ class CRM_Admin_Page_Job extends CRM_Core_Page_Basic {
       $this, FALSE, 0
     );
 
+    // FIXME: Why are we comparing an integer with a string here?
     if ($this->_action == 'export') {
       $session = CRM_Core_Session::singleton();
       $session->pushUserContext(CRM_Utils_System::url('civicrm/admin/job', 'reset=1'));
+    }
+
+    if (($this->_action & CRM_Core_Action::COPY) && (!empty($this->_id))) {
+      try {
+        $jobResult = civicrm_api3('Job', 'clone', array('id' => $this->_id));
+        if ($jobResult['count'] > 0) {
+          CRM_Core_Session::setStatus($jobResult['values'][$jobResult['id']]['name'], ts('Job copied successfully'), 'success');
+        }
+        CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/admin/job', 'reset=1'));
+      }
+      catch (Exception $e) {
+        CRM_Core_Session::setStatus(ts('Failed to copy job'), 'Error');
+      }
     }
 
     return parent::run();

--- a/CRM/Core/BAO/Job.php
+++ b/CRM/Core/BAO/Job.php
@@ -146,4 +146,25 @@ class CRM_Core_BAO_Job extends CRM_Core_DAO_Job {
     CRM_Core_DAO::executeQuery($query);
   }
 
+  /**
+   * Make a copy of a Job.
+   *
+   * @param int $id The job id to copy.
+   *
+   * @return CRM_Core_DAO
+   */
+  public static function copy($id, $params = array()) {
+    $fieldsFix = array(
+      'suffix' => array(
+        'name' => ' - ' . ts('Copy'),
+      ),
+      'replace' => $params,
+    );
+    $copy = &CRM_Core_DAO::copyGeneric('CRM_Core_DAO_Job', array('id' => $id), NULL, $fieldsFix);
+    $copy->save();
+    CRM_Utils_Hook::copy('Job', $copy);
+
+    return $copy;
+  }
+
 }

--- a/api/v3/Job.php
+++ b/api/v3/Job.php
@@ -62,6 +62,41 @@ function civicrm_api3_job_create($params) {
 }
 
 /**
+ * Adjust metadata for clone spec action.
+ *
+ * @param array $spec
+ */
+function _civicrm_api3_job_clone_spec(&$spec) {
+  $spec['id']['title'] = 'Job ID to clone';
+  $spec['id']['type'] = CRM_Utils_Type::T_INT;
+  $spec['id']['api.required'] = 1;
+  $spec['is_active']['title'] = 'Job is Active?';
+  $spec['is_active']['type'] = CRM_Utils_Type::T_BOOLEAN;
+  $spec['is_active']['api.required'] = 0;
+}
+
+/**
+ * Clone Job.
+ *
+ * @param array $params
+ *
+ * @return array
+ * @throws \API_Exception
+ * @throws \CiviCRM_API3_Exception
+ */
+function civicrm_api3_job_clone($params) {
+  if (empty($params['id'])) {
+    throw new API_Exception("Mandatory key(s) missing from params array: id field is required");
+  }
+  $id = $params['id'];
+  unset($params['id']);
+  $params['last_run'] = 'null';
+  $params['scheduled_run_date'] = 'null';
+  $newJobDAO = CRM_Core_BAO_Job::copy($id, $params);
+  return civicrm_api3('Job', 'get', array('id' => $newJobDAO->id));
+}
+
+/**
  * Retrieve one or more job.
  *
  * @param array $params

--- a/tests/phpunit/api/v3/JobTest.php
+++ b/tests/phpunit/api/v3/JobTest.php
@@ -122,6 +122,22 @@ class api_v3_JobTest extends CiviUnitTestCase {
   }
 
   /**
+   * Clone job
+   */
+  public function testClone() {
+    $createResult = $this->callAPISuccess('job', 'create', $this->_params);
+    $params = array('id' => $createResult['id']);
+    $cloneResult = $this->callAPIAndDocument('job', 'clone', $params, __FUNCTION__, __FILE__);
+    $clonedJob = $cloneResult['values'][$cloneResult['id']];
+    $this->assertEquals($this->_params['name'] . ' - Copy', $clonedJob['name']);
+    $this->assertEquals($this->_params['description'], $clonedJob['description']);
+    $this->assertEquals($this->_params['parameters'], $clonedJob['parameters']);
+    $this->assertEquals($this->_params['is_active'], $clonedJob['is_active']);
+    $this->assertArrayNotHasKey('last_run', $clonedJob);
+    $this->assertArrayNotHasKey('scheduled_run_date', $clonedJob);
+  }
+
+  /**
    * Check if required fields are not passed.
    */
   public function testDeleteWithoutRequired() {


### PR DESCRIPTION
Overview
----------------------------------------
This adds a "clone" or "copy" function to the scheduled jobs page.  It is implemented as an API (job.clone) which can be called via a link from the scheduled jobs listing.

Ref https://lab.civicrm.org/dev/core/issues/47

Before
----------------------------------------
You can't clone a scheduled job.  This means you have to manually copy parameters when setting up multiple similar jobs (eg. a geocoding job with different parameters).

After
----------------------------------------
You can easily clone a scheduled job.
![localhost_8000_civicrm_admin_job_reset 1](https://user-images.githubusercontent.com/2052161/38358468-3427a9a2-38bd-11e8-8c90-0ad83f08aa7f.png)


Technical Details
----------------------------------------
Implemented as a new API function Job.clone and a BAO function "copy".

Comments
----------------------------------------
I'm not sure what the preferred naming is, "clone" or "copy".  There's not much in core to be consistent with here.
