### PR TITLE
WIP dev/core#48 Fix PDF Letter only generates a single letter when multip…

### DIFF
--- a/CRM/Contact/Form/Task/EmailCommon.php
+++ b/CRM/Contact/Form/Task/EmailCommon.php
@@ -69,8 +69,11 @@ class CRM_Contact_Form_Task_EmailCommon {
 
     $form->_emails = array();
 
-    $contactID = CRM_Core_Session::singleton()->getLoggedInContactID();
-    $form->_contactIds = array($contactID);
+    // If we don't have any contact IDs, use the logged in contact ID
+    if (empty($form->_contactIds)) {
+      $contactID = CRM_Core_Session::singleton()->getLoggedInContactID();
+      $form->_contactIds = array($contactID);
+    }
 
     $fromEmailValues = CRM_Core_BAO_Email::getFromEmail();
 


### PR DESCRIPTION
…le contact IDs are specified

Overview
----------------------------------------
Ref https://lab.civicrm.org/dev/core/issues/48
When multiple contact IDs are specified via print/merge task the PDFLetterCommon code overwrites them with a single contact ID of the logged in user.  This means that only a single PDF letter is printed/generated.
This PR only uses the logged in contact ID if not contact IDs have been specified.

Before
----------------------------------------
Only a single PDF letter was being generated by print/merge document.

After
----------------------------------------
Multiple PDF letters are generated by print/merge document.

Comments
----------------------------------------
It is possible that this issue was introduced by changes in #11411 which introduced a CRM_Core_Form_Task class but looking at the code and the proposed changes here I'm not sure how Print/Merge ever printed multiple documents as the code I'm changing here hasn't changed for more than 5 years!
