### PR TITLE
CRM-21852-Membership report failure fix

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -2624,8 +2624,8 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
     $this->select();
     $this->from();
     $this->customDataFrom();
-    $this->buildPermissionClause();
     $this->where();
+    $this->buildPermissionClause();
     $this->groupBy();
     $this->orderBy();
 

--- a/CRM/Report/Form/Member/Detail.php
+++ b/CRM/Report/Form/Member/Detail.php
@@ -306,9 +306,9 @@ class CRM_Report_Form_Member_Detail extends CRM_Report_Form {
   public function postProcess() {
 
     $this->beginPostProcess();
-
+	// CRM-6181- commenting out the below as buildACLClause taking care in buildquery
     // get the acl clauses built before we assemble the query
-    $this->buildACLClause($this->_aliases['civicrm_contact']);
+    //$this->buildACLClause($this->_aliases['civicrm_contact']);
     $sql = $this->buildQuery(TRUE);
 
     $rows = array();

--- a/CRM/Report/Form/Member/Detail.php
+++ b/CRM/Report/Form/Member/Detail.php
@@ -306,7 +306,7 @@ class CRM_Report_Form_Member_Detail extends CRM_Report_Form {
   public function postProcess() {
 
     $this->beginPostProcess();
-	// CRM-6181- commenting out the below as buildACLClause taking care in buildquery
+    // CRM-6181- commenting out the below as buildACLClause taking care in buildquery
     // get the acl clauses built before we assemble the query
     //$this->buildACLClause($this->_aliases['civicrm_contact']);
     $sql = $this->buildQuery(TRUE);


### PR DESCRIPTION
Overview
----------------------------------------
Membership detail report error when ACL used (disable view all contacts)

Before
----------------------------------------
When a restricted user accesses the Membership Detail Form, an error is thrown.
![image](https://user-images.githubusercontent.com/5311759/38370744-72fd7d3c-3908-11e8-8b51-551acc569c25.png)
After
----------------------------------------
When a restricted user accesses the Membership Detail Form, the report should be displayed.
![image](https://user-images.githubusercontent.com/5311759/38370776-8726897a-3908-11e8-997a-8d0d721bac35.png)


Technical Details
----------------------------------------
buildACLClause has been used twice so I Just commented one as it's taking care in buildQuery, also buildPermissionClause has been used as it overriding buildQuery since buildQuery is deprecated(see in code)

Comments
----------------------------------------
As this is the fist time am writing code for Civicrm so I would appreciate if you could provide me feedback to improve myself better
