### PR TITLE
Event Info: show waitinglist statusline only when registration is open

### DIFF
--- a/CRM/Event/Page/EventInfo.php
+++ b/CRM/Event/Page/EventInfo.php
@@ -270,8 +270,9 @@ class CRM_Event_Page_EventInfo extends CRM_Core_Page {
     );
 
     $allowRegistration = FALSE;
+    $isEventOpenForRegistration = CRM_Event_BAO_Event::validRegistrationRequest($values['event'], $this->_id);
     if (!empty($values['event']['is_online_registration'])) {
-      if (CRM_Event_BAO_Event::validRegistrationRequest($values['event'], $this->_id)) {
+      if ($isEventOpenForRegistration == 1) {
         // we always generate urls for the front end in joomla
         $action_query = $action === CRM_Core_Action::PREVIEW ? "&action=$action" : '';
         $url = CRM_Utils_System::url('civicrm/event/register',
@@ -337,8 +338,9 @@ class CRM_Event_Page_EventInfo extends CRM_Core_Page {
           $statusMessage = ts('Event is currently full, but you can register and be a part of waiting list.');
         }
       }
-
-      CRM_Core_Session::setStatus($statusMessage);
+      if ($isEventOpenForRegistration == 1) {
+        CRM_Core_Session::setStatus($statusMessage);
+      }
     }
     // we do not want to display recently viewed items, so turn off
     $this->assign('displayRecent', FALSE);


### PR DESCRIPTION
Overview
----------------------------------------
On the Event Info page do not show the waiting list and 'already registered' info when the event is in the past or registration is disabled.

Before
----------------------------------------
Even for events in the past, or events outside of their registration windows, the waitinglist and 'already registered' info would show. This is confusing for event that also mentions "Registration is closed for this event" on the next line. Text on top is our Dutch waitinglist text. The event is old and closed.
![screenshot from 2018-04-05 16-20-53](https://user-images.githubusercontent.com/2195908/38372271-b17c2da2-38ee-11e8-9df4-d8d08142275e.png)

After
----------------------------------------
Only the line "Registration is closed for this event" is shown on top of the Event Info page
![screenshot from 2018-04-05 16-21-19](https://user-images.githubusercontent.com/2195908/38372280-b49ba710-38ee-11e8-85b0-21bd3d6d3abc.png)

Technical Details
----------------------------------------
To show or not to show... The message gets a conditional.
```
if ($allowRegistration == 1) {
        CRM_Core_Session::setStatus($statusMessage);
      }
```
Comments
----------------------------------------