### PR TITLE
Extract custom data edit template code to shared template

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -345,25 +345,17 @@
     <div id="customData" class="crm-contribution-form-block-customData"></div>
   {/if}
 
-  {*include custom data js file*}
-  {include file="CRM/common/customData.tpl"}
+  {include file="CRM/Custom/Form/Edit.tpl"}
 
-    {literal}
-    <script type="text/javascript">
-      CRM.$(function($) {
+  {literal}
+  <script type="text/javascript">
+    CRM.$(function($) {
     {/literal}
-    CRM.buildCustomData( '{$customDataType}' );
-    {if $customDataSubType}
-      CRM.buildCustomData( '{$customDataType}', {$customDataSubType} );
-    {/if}
-
-    {if $buildPriceSet}{literal}buildAmount( );{/literal}{/if}
+      {if $buildPriceSet}{literal}buildAmount();{/literal}{/if}
     {literal}
-    });
 
     // bind first click of accordion header to load crm-accordion-body with snippet
     // everything else taken care of by cj().crm-accordions()
-    CRM.$(function($) {
       cj('#adjust-option-type').hide();
       cj('.crm-ajax-accordion .crm-accordion-header').one('click', function() {
         loadPanes(cj(this).attr('id'));

--- a/templates/CRM/Custom/Form/Edit.tpl
+++ b/templates/CRM/Custom/Form/Edit.tpl
@@ -1,0 +1,16 @@
+{* Edit custom data on Edit entity forms *}
+{* Requires <div id="customData"></div> on the form *}
+{*include custom data js file*}
+{include file="CRM/common/customData.tpl"}
+{literal}
+<script type="text/javascript">
+  CRM.$(function($) {
+    {/literal}
+    CRM.buildCustomData( '{$customDataType}' );
+    {if $customDataSubType}
+    CRM.buildCustomData( '{$customDataType}', {$customDataSubType} );
+    {/if}
+    {literal}
+  });
+</script>
+{/literal}


### PR DESCRIPTION
Overview
----------------------------------------
Each form that edits custom data uses the same template code but it is duplicated rather than shared.  Extract custom data edit template code to a new shared template that can replace the duplication.

Ref #11899 #11910

Before
----------------------------------------
Duplicate template code.

After
----------------------------------------
Contribution edit form uses new shared template.

Technical Details
----------------------------------------
The custom data fields are built using a javascript function and AJAX.  That's what the template code is doing.

@eileenmcnaughton Extracted from #11910
