### PR TITLE
Adjust creation of markup for Open Flash Chart

### DIFF
--- a/templates/CRM/common/openFlashChart.tpl
+++ b/templates/CRM/common/openFlashChart.tpl
@@ -45,7 +45,8 @@
              image: function(src) { return "<img src='data:image/png;base64," + $('#'+src)[0].get_img_binary() + "' />"},
              popup: function(src) {
              var img_win = window.open('', 'Save Chart as Image');
-           img_win.document.write('<html><head><title>Save Chart as Image<\/title><\/head><body>' + OFC.jquery.image(src) + ' <\/body><\/html>');
+             var html = 'html', head = 'head', body = 'body';             
+           img_win.document.write('<' + html + '><' + head + '><title>Save Chart as Image<\/title><\/' + head + '><' + body + '>' + OFC.jquery.image(src) + ' <\/' + body + '><\/' + html + '>');
            img_win.document.close();
                        }
                  }

--- a/templates/CRM/common/openFlashChart.tpl
+++ b/templates/CRM/common/openFlashChart.tpl
@@ -45,7 +45,8 @@
              image: function(src) { return "<img src='data:image/png;base64," + $('#'+src)[0].get_img_binary() + "' />"},
              popup: function(src) {
              var img_win = window.open('', 'Save Chart as Image');
-             var html = 'html', head = 'head', body = 'body';             
+             // HTML, HEAD, and BODY tags in JS literals obfuscated to avoid being parsed as DOM elements.
+             var html = 'html', head = 'head', body = 'body';
            img_win.document.write('<' + html + '><' + head + '><title>Save Chart as Image<\/title><\/' + head + '><' + body + '>' + OFC.jquery.image(src) + ' <\/' + body + '><\/' + html + '>');
            img_win.document.close();
                        }


### PR DESCRIPTION
Overview
----------------------------------------
Certain JS libraries don't play nice with the `<html>`, `<head>`, and `<body>` tags within the string literals. For instance, New Relic's browser side monitoring automatically initializes itself based on the structure of the DOM, and with these "tags" found duplicated within the page, things don't end well.

Before
----------------------------------------
When using in environments where New Relic is utilized, the charts do not initialize. The following errors are thrown in the JS console:

Firefox: `SyntaxError: unterminated string literal`
Chrome: `Invalid or unexpected token`

After
----------------------------------------
The charts initialize as expected, no JS errors.

Technical Details
----------------------------------------
The only change is to break up the string literals that are getting parsed as tags, and concatenating the string together.