### PR TITLE
Prevent hard-fail when section header / group by option chosen on logging report

### DIFF
--- a/CRM/Report/Form/Contact/LoggingSummary.php
+++ b/CRM/Report/Form/Contact/LoggingSummary.php
@@ -352,4 +352,11 @@ LEFT  JOIN civicrm_contact altered_by_contact_civireport
     return $row;
   }
 
+  /**
+   * Calculate section totals.
+   *
+   * Override to do nothing as this does not work / make sense on this report.
+   */
+  public function sectionTotals() {}
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Prevent hard-fail when section header / group by option chosen on logging report

The contact logging summary report permits 'Section Header / Group By' in the order by tab but it doesn't work, badly.

![screenshot 2018-04-06 12 30 41](https://user-images.githubusercontent.com/336308/38398303-c58e31c0-3996-11e8-807d-665271e70561.png)


Before
----------------------------------------
![screenshot 2018-04-06 12 30 29](https://user-images.githubusercontent.com/336308/38398345-0bc92b18-3997-11e8-9b29-239c59b35b59.png)


After
----------------------------------------

![screenshot 2018-04-06 12 31 00](https://user-images.githubusercontent.com/336308/38398353-1447d35c-3997-11e8-8e6b-e833ce76f35d.png)

Or by contact
![screenshot 2018-04-06 12 37 20](https://user-images.githubusercontent.com/336308/38398383-4bec2fe2-3997-11e8-97e8-f55ae6cdefbe.png)



Technical Details
----------------------------------------
I'm not convinced the option is terribly valid /important in this report but if chosen it should not give a fatal error. I tested 2 criteria & both gave a fatal. This is just a quick fix to prevent that. It does not populate the count - hence the empty brackets but I see that as low priority - perhaps no-one will ever care level of issue


