### PR TITLE
dev/Core#53 Add in stats to AB tests and add in clickthrough and open…

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1997,12 +1997,16 @@ ORDER BY   civicrm_email.is_bulkmail DESC
         $row['bounce_rate'] = (100.0 * $mailing->bounce) / $mailing->queue;
         $row['unsubscribe_rate'] = (100.0 * $row['unsubscribe']) / $mailing->queue;
         $row['optout_rate'] = (100.0 * $row['optout']) / $mailing->queue;
+        $row['opened_rate'] = $mailing->delivered ? (($row['opened'] / $mailing->delivered) * 100.0) : 0;
+        $row['clickthrough_rate'] = $mailing->delivered ? (($mailing->url / $mailing->delivered) * 100.0) : 0;
       }
       else {
         $row['delivered_rate'] = 0;
         $row['bounce_rate'] = 0;
         $row['unsubscribe_rate'] = 0;
         $row['optout_rate'] = 0;
+        $row['opened_rate'] = 0;
+        $row['clickthrough_rate'] = 0;
       }
 
       $row['links'] = array(
@@ -2066,12 +2070,16 @@ ORDER BY   civicrm_email.is_bulkmail DESC
       $report['event_totals']['bounce_rate'] = (100.0 * $report['event_totals']['bounce']) / $report['event_totals']['queue'];
       $report['event_totals']['unsubscribe_rate'] = (100.0 * $report['event_totals']['unsubscribe']) / $report['event_totals']['queue'];
       $report['event_totals']['optout_rate'] = (100.0 * $report['event_totals']['optout']) / $report['event_totals']['queue'];
+      $report['event_totals']['opened_rate'] = !empty($report['event_totals']['delivered']) ? (($report['event_totals']['opened'] / $report['event_totals']['delivered']) * 100.0) : 0;
+      $report['event_totals']['clickthrough_rate'] = !empty($report['event_totals']['delivered']) ? (($report['event_totals']['url'] / $report['event_totals']['delivered']) * 100.0) : 0;
     }
     else {
       $report['event_totals']['delivered_rate'] = 0;
       $report['event_totals']['bounce_rate'] = 0;
       $report['event_totals']['unsubscribe_rate'] = 0;
       $report['event_totals']['optout_rate'] = 0;
+      $report['event_totals']['opened_rate'] = 0;
+      $report['event_totals']['clickthrough_rate'] = 0;
     }
 
     /* Get the click-through totals, grouped by URL */

--- a/ang/crmMailingAB/EditCtrl/report.html
+++ b/ang/crmMailingAB/EditCtrl/report.html
@@ -78,7 +78,7 @@
           class="crm-hover-button action-item"
           ng-href="{{statUrl(am.mailing, statType, 'events')}}"
           title="{{ts('Browse events of type \'%1\'', {1: statType.title})}}"
-          >{{stats[am.name][statType.name] || ts('n/a')}}</a>
+          >{{stats[am.name][statType.name] || ts('n/a')}} </a> {{stats[am.name][rateStats[statType.name]] || ' '}}
         <a
           class="crm-hover-button action-item"
           ng-href="{{statUrl(am.mailing, statType, 'report')}}"

--- a/ang/crmMailingAB/ReportCtrl.js
+++ b/ang/crmMailingAB/ReportCtrl.js
@@ -40,7 +40,11 @@
     }).then(function(stats) {
       $scope.stats = stats;
     });
-
+    $scope.rateStats = {
+      'Unique Clicks': 'clickthrough_rate',
+      'Delivered': 'delivered_rate',
+      'Opened': 'opened_rate',
+    };
     $scope.statTypes = crmMailingStats.getStatTypes();
     $scope.statUrl = function statUrl(mailing, statType, view) {
       return crmMailingStats.getUrl(mailing, statType, view, 'abtest/' + $scope.abtest.ab.id);

--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -769,6 +769,14 @@ function civicrm_api3_mailing_stats($params) {
         break;
     }
   }
+  $stats[$params['mailing_id']]['delivered_rate'] = $stats[$params['mailing_id']]['opened_rate'] = $stats[$params['mailing_id']]['clickthrough_rate'] = '0.00%';
+  if (!empty(CRM_Mailing_Event_BAO_Queue::getTotalCount($params['mailing_id'], $params['job_id']))) {
+    $stats[$params['mailing_id']]['delivered_rate'] = round((100.0 * $stats[$params['mailing_id']]['Delivered']) / CRM_Mailing_Event_BAO_Queue::getTotalCount($params['mailing_id'], $params['job_id']), 2) . '%';
+  }
+  if (!empty($stats[$params['mailing_id']]['Delivered'])) {
+    $stats[$params['mailing_id']]['opened_rate'] = round($stats[$params['mailing_id']]['Opened'] / $stats[$params['mailing_id']]['Delivered'] * 100.0, 2) . '%';
+    $stats[$params['mailing_id']]['clickthrough_rate'] = round($stats[$params['mailing_id']]['Unique Clicks'] / $stats[$params['mailing_id']]['Delivered'] * 100.0, 2) . '%';
+  }
   return civicrm_api3_create_success($stats);
 }
 

--- a/templates/CRM/Mailing/Page/Report.tpl
+++ b/templates/CRM/Mailing/Page/Report.tpl
@@ -36,7 +36,7 @@
         <td>{$report.event_totals.actionlinks.delivered}</td></tr>
   {if $report.mailing.open_tracking}
     <tr><td class="label"><a href="{$report.event_totals.links.opened}&distinct=1">{ts}Unique Opens{/ts}</a></td>
-        <td>{$report.event_totals.opened}</td>
+        <td>{$report.event_totals.opened} ({$report.event_totals.opened_rate|string_format:"%0.2f"}%)</td>
         <td>{$report.event_totals.actionlinks.opened}</td></tr>
     <tr><td class="label"><a href="{$report.event_totals.links.opened}">{ts}Total Opens{/ts}</a></td>
         <td>{$report.event_totals.total_opened}</td>
@@ -44,7 +44,7 @@
   {/if}
   {if $report.mailing.url_tracking}
     <tr><td class="label"><a href="{$report.event_totals.links.clicks}">{ts}Click-throughs{/ts}</a></td>
-        <td>{$report.event_totals.url}</td>
+        <td>{$report.event_totals.url} ({$report.event_totals.clickthrough_rate|string_format:"%0.2f"}%)</td>
         <td>{$report.event_totals.actionlinks.clicks}</td></tr>
   {/if}
   <tr><td class="label"><a href="{$report.event_totals.links.forward}">{ts}Forwards{/ts}</a></td>

--- a/tests/phpunit/api/v3/MailingTest.php
+++ b/tests/phpunit/api/v3/MailingTest.php
@@ -685,6 +685,9 @@ SELECT event_queue_id, time_stamp FROM mail_{$type}_temp";
       'Opened' => 20,
       'Unique Clicks' => 0,
       'Unsubscribers' => 20,
+      'delivered_rate' => '80%',
+      'opened_rate' => '25%',
+      'clickthrough_rate' => '0%',
     );
     $this->checkArrayEquals($expectedResult, $result['values'][$mail['id']]);
   }


### PR DESCRIPTION
…ed % stats to mailing reports

Overview
----------------------------------------
This adds Mailing delivery stat percentages to AB tests and also adds in new opened and clickthrough rate stats

Before
----------------------------------------
No AB testing % stats
![screenshot 2018-04-09 14 20 48](https://user-images.githubusercontent.com/336308/38476387-93dc6eea-3c01-11e8-82bc-0142894b5502.png)


After
----------------------------------------
AB Tests have % stats and rates. 

![screenshot 2018-04-09 14 23 05](https://user-images.githubusercontent.com/336308/38476393-99045da6-3c01-11e8-8159-6c90db2c23ce.png)


