### PR TITLE
Drupal8 loadBootStrap: fix user variable

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -440,7 +440,7 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     CRM_Utils_Hook::config($config);
 
     if ($loadUser) {
-      if (!empty($params['uid']) && $username = \Drupal\user\Entity\User::load($uid)->getUsername()) {
+      if (!empty($params['uid']) && $username = \Drupal\user\Entity\User::load($params['uid'])->getUsername()) {
         $this->loadUser($username);
       }
       elseif (!empty($params['name']) && !empty($params['pass']) && \Drupal::service('user.auth')->authenticate($params['name'], $params['pass'])) {


### PR DESCRIPTION
Overview
----------------------------------------

I was receiving "error 500" while sending requests to the REST API endpoint.

```
PHP message: Error: Call to a member function getUsername() on null
in /var/aegir/platforms/civicrm-d8/vendor/civicrm/civicrm-core/CRM/Utils/System/Drupal8.php on line 443
#0 /var/aegir/platforms/civicrm-d8/vendor/civicrm/civicrm-core/CRM/Utils/System.php(1457): CRM_Utils_System_Drupal8->loadBootStrap(Array, true, false, NULL)
```

Technical Details
----------------------------------------

There was an incorrectly referenced variable in the code.

Note: there is another bug when doing REST calls to CiviCRM on Drupal8. I will open a separate PR, but this seems like a simple/obvious fix.

cc @jackrabbithanna @dsnopek 