### PR TITLE
core-54 - Activity created for case role relationship is not assigned…

### DIFF
--- a/CRM/Contact/Page/AJAX.php
+++ b/CRM/Contact/Page/AJAX.php
@@ -261,8 +261,11 @@ class CRM_Contact_Page_AJAX {
       }
       // Save activity only for the primary (first) client
       if ($i == 0 && empty($result['is_error'])) {
-        CRM_Case_BAO_Case::createCaseRoleActivity($caseID, $result['id'], $relContactID);
+        CRM_Case_BAO_Case::createCaseRoleActivity($caseID, $result['id'], $relContactID, $sourceContactID);
       }
+    }
+    if (!empty($_REQUEST['is_unit_test'])) {
+      return $ret;
     }
 
     CRM_Utils_JSON::output($ret);


### PR DESCRIPTION
… to correct contact

Overview
----------------------------------------
Activity created for case role relationship is not assigned to correct contact.

Before
----------------------------------------
Add a role for a case. The activity created is assigned to the client instead of the relationship contact. Details on the issue link.

After
----------------------------------------
Activity is created for correct contact.

Comments
----------------------------------------
Added unit test.

--------

GitLab Issue - https://lab.civicrm.org/dev/core/issues/54