### PR TITLE
CRM-21843 - Fix export of case activities

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -1906,13 +1906,8 @@ WHERE  {$whereClause}";
     elseif ($field == 'provider_id') {
       $headerRows[] = ts('IM Service Provider');
     }
-    elseif (substr($field, 0, 5) == 'case_') {
-      if ($query->_fields['case'][$field]['title']) {
-        $headerRows[] = $query->_fields['case'][$field]['title'];
-      }
-      elseif ($query->_fields['activity'][$field]['title']) {
-        $headerRows[] = $query->_fields['activity'][$field]['title'];
-      }
+    elseif (substr($field, 0, 5) == 'case_' && $query->_fields['case'][$field]['title']) {
+      $headerRows[] = $query->_fields['case'][$field]['title'];
     }
     elseif (array_key_exists($field, $contactRelationshipTypes)) {
       foreach ($value as $relationField => $relationValue) {


### PR DESCRIPTION
Overview
--------

To reproduce this bug:
- Go to "Find Cases"
- Select some cases and choose "Export" from the actions menu
- Export with standard fields
- Check the resulting spreadsheet. The last column will contain all activity fields jammed together.

Before
--------
![screenshot from 2018-04-09 09 15 01](https://user-images.githubusercontent.com/2874912/38499757-93b4980a-3bd6-11e8-81e6-c6d3445bbe8f.png)


After
-----
![screenshot from 2018-04-09 09 15 23](https://user-images.githubusercontent.com/2874912/38499773-99ad7542-3bd6-11e8-940d-66cadb6bb248.png)


* [CRM-21843: Case activities delimiter not working](https://issues.civicrm.org/jira/browse/CRM-21843)