### PR TITLE
(dev/mail/8) Using ACL to restrict mailing recipients leads to fatal error

### DIFF
--- a/CRM/Contact/BAO/Contact/Permission.php
+++ b/CRM/Contact/BAO/Contact/Permission.php
@@ -199,9 +199,12 @@ WHERE contact_a.id = %1 AND $permission
     //   that somebody might flush the cache away from under our feet,
     //   but the alternative would be a SQL call every time this is called,
     //   and a complete rebuild if the result was an empty set...
-    static $_processed = array(
-      CRM_Core_Permission::VIEW => array(),
-      CRM_Core_Permission::EDIT => array());
+    if (!isset(Civi::$statics[__CLASS__]['processed'])) {
+      Civi::$statics[__CLASS__]['processed'] = [
+        CRM_Core_Permission::VIEW => [],
+        CRM_Core_Permission::EDIT => [],
+      ];
+    }
 
     if ($type == CRM_Core_Permission::VIEW) {
       $operationClause = " operation IN ( 'Edit', 'View' ) ";
@@ -215,7 +218,7 @@ WHERE contact_a.id = %1 AND $permission
 
     if (!$force) {
       // skip if already calculated
-      if (!empty($_processed[$type][$userID])) {
+      if (!empty(Civi::$statics[__CLASS__]['processed'][$type][$userID])) {
         return;
       }
 
@@ -228,7 +231,7 @@ AND    $operationClause
 ";
       $count = CRM_Core_DAO::singleValueQuery($sql, $queryParams);
       if ($count > 0) {
-        $_processed[$type][$userID] = 1;
+        Civi::$statics[__CLASS__]['processed'][$type][$userID] = 1;
         return;
       }
     }
@@ -257,7 +260,7 @@ AND ac.user_id IS NULL
         CRM_Core_DAO::executeQuery("INSERT INTO civicrm_acl_contact_cache ( user_id, contact_id, operation ) VALUES(%1, %1, '{$operation}')", $queryParams);
       }
     }
-    $_processed[$type][$userID] = 1;
+    Civi::$statics[__CLASS__]['processed'][$type][$userID] = 1;
   }
 
   /**

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -335,7 +335,7 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing {
 
     $query = $query->select($selectClause)->orderBy($orderBy);
     if (!CRM_Utils_System::isNull($aclFrom)) {
-      $query = $query->from('acl', $aclFrom);
+      $query = $query->join('acl', $aclFrom);
     }
     if (!CRM_Utils_System::isNull($aclWhere)) {
       $query = $query->where($aclWhere);

--- a/tests/phpunit/CRM/Mailing/BAO/MailingTest.php
+++ b/tests/phpunit/CRM/Mailing/BAO/MailingTest.php
@@ -30,6 +30,8 @@
  */
 class CRM_Mailing_BAO_MailingTest extends CiviUnitTestCase {
 
+  protected $allowedContactId = 0;
+
   public function setUp() {
     parent::setUp();
   }
@@ -82,6 +84,64 @@ class CRM_Mailing_BAO_MailingTest extends CiviUnitTestCase {
       'entity_table' => CRM_Contact_BAO_Group::getTableName(),
       'entity_id' => $groupID,
     ));
+  }
+
+  /**
+   * Test to ensure that using ACL permitted contacts are correctly fetched for bulk mailing
+   */
+  public function testgetRecipientsUsingACL() {
+    $this->prepareForACLs();
+    $this->createLoggedInUser();
+    // create hook to build ACL where clause which choses $this->allowedContactId as the only contact to be considered as mail recipient
+    $this->hookClass->setHook('civicrm_aclWhereClause', array($this, 'aclWhereAllowedOnlyOne'));
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = array('access CiviCRM', 'view my contact');
+
+    // Create dummy group and assign 2 contacts
+    $name = 'Test static group ' . substr(sha1(rand()), 0, 7);
+    $groupID = $this->groupCreate([
+      'name' => $name,
+      'title' => $name,
+      'is_active' => 1,
+    ]);
+    // Create 2 contacts where one of them identified as $this->allowedContactId will be used in ACL where clause
+    $contactID1 = $this->individualCreate(array(), 0);
+    $this->allowedContactId = $this->individualCreate(array(), 1);
+    $this->callAPISuccess('GroupContact', 'Create', array(
+      'group_id' => $groupID,
+      'contact_id' => $contactID1,
+    ));
+    $this->callAPISuccess('GroupContact', 'Create', array(
+      'group_id' => $groupID,
+      'contact_id' => $this->allowedContactId,
+    ));
+
+    // Create dummy mailing
+    $mailingID = $this->callAPISuccess('Mailing', 'create', array())['id'];
+    $this->createMailingGroup($mailingID, $groupID);
+
+    // Check that the desired contact (identified as Contact ID - $this->allowedContactId) is the only
+    //  contact chosen as mail recipient
+    $expectedContactIDs = [$this->allowedContactId];
+    $this->assertRecipientsCorrect($mailingID, $expectedContactIDs);
+
+    $this->cleanUpAfterACLs();
+    $this->contactDelete($contactID1);
+    $this->contactDelete($this->allowedContactId);
+  }
+
+  /**
+   * Build ACL where clause
+   *
+   * @implements CRM_Utils_Hook::aclWhereClause
+   *
+   * @param string $type
+   * @param array $tables
+   * @param array $whereTables
+   * @param int $contactID
+   * @param string $where
+   */
+  public function aclWhereAllowedOnlyOne($type, &$tables, &$whereTables, &$contactID, &$where) {
+    $where = " contact_a.id = " . $this->allowedContactId;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate:
1. Assign an ACL permission for one or more contacts
2. Compose a mailing and select a recipient group. Ensure that those contacts are included in that group
3. Submit and Send Mailing immediately

Issue link - https://lab.civicrm.org/dev/mail/issues/8

Before
----------------------------------------
Result into fatal error - https://pastebin.com/aMa2KYy0

After
----------------------------------------
Fixed the error.
