### PR TITLE
(dev/core/56) Cancel Recurring Contribution activity should has a source record id

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -282,7 +282,7 @@ SELECT r.payment_processor_id
         }
         $activityParams = array(
           'source_contact_id' => $dao->contact_id,
-          'source_record_id' => CRM_Utils_Array::value('source_record_id', $activityParams),
+          'source_record_id' => $dao->recur_id,
           'activity_type_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Cancel Recurring Contribution'),
           'subject' => CRM_Utils_Array::value('subject', $activityParams, ts('Recurring contribution cancelled')),
           'details' => $details,


### PR DESCRIPTION
Overview
----------------------------------------
`Cancel Recurring Contribution` doesn't have a source record id but there should be a recurring contribution id

Before
----------------------------------------
civicrm_activity.record_source_id IS NULL

After
----------------------------------------
civicrm_activity.record_source_id has a recurring contribution id

Technical Details
----------------------------------------
```php
// current, invalid
'source_record_id' => CRM_Utils_Array::value('source_record_id', $activityParams),
// fixed
'source_record_id' => $dao->recur_id,
```

Comments
----------------------------------------
Link to gitlab https://lab.civicrm.org/dev/core/issues/56