### PR TITLE
CRM-21855 - Clean up and standardize relationshipType BAO

### DIFF
--- a/CRM/Admin/Form/RelationshipType.php
+++ b/CRM/Admin/Form/RelationshipType.php
@@ -137,14 +137,12 @@ class CRM_Admin_Form_RelationshipType extends CRM_Admin_Form {
       CRM_Core_Session::setStatus(ts('Selected Relationship type has been deleted.'), ts('Record Deleted'), 'success');
     }
     else {
-      $ids = array();
-
       // store the submitted values in an array
       $params = $this->exportValues();
       $params['is_active'] = CRM_Utils_Array::value('is_active', $params, FALSE);
 
       if ($this->_action & CRM_Core_Action::UPDATE) {
-        $ids['relationshipType'] = $this->_id;
+        $params['id'] = $this->_id;
       }
 
       $cTypeA = CRM_Utils_System::explode('__',
@@ -162,7 +160,15 @@ class CRM_Admin_Form_RelationshipType extends CRM_Admin_Form {
       $params['contact_sub_type_a'] = $cTypeA[1] ? $cTypeA[1] : 'NULL';
       $params['contact_sub_type_b'] = $cTypeB[1] ? $cTypeB[1] : 'NULL';
 
-      $result = CRM_Contact_BAO_RelationshipType::add($params, $ids);
+      // if label B to A is blank, insert the value label A to B for it
+      if (!strlen(trim(CRM_Utils_Array::value('name_b_a', $params)))) {
+        $params['name_b_a'] = CRM_Utils_Array::value('name_a_b', $params);
+      }
+      if (!strlen(trim(CRM_Utils_Array::value('label_b_a', $params)))) {
+        $params['label_b_a'] = CRM_Utils_Array::value('label_a_b', $params);
+      }
+
+      $result = CRM_Contact_BAO_RelationshipType::add($params);
 
       $this->ajaxResponse['relationshipType'] = $result->toArray();
 

--- a/CRM/Contact/BAO/RelationshipType.php
+++ b/CRM/Contact/BAO/RelationshipType.php
@@ -79,26 +79,20 @@ class CRM_Contact_BAO_RelationshipType extends CRM_Contact_DAO_RelationshipType 
    * Add the relationship type in the db.
    *
    * @param array $params
-   *   (reference ) an assoc array of name/value pairs.
-   * @param array $ids
-   *   The array that holds all the db ids.
    *
    * @return CRM_Contact_DAO_RelationshipType
    */
-  public static function add(&$params, $ids = []) {
-    $params['id'] = CRM_Utils_Array::value('id', $params, CRM_Utils_Array::value('relationshipType', $ids));
-    //to change name, CRM-3336
-    if (empty($params['label_a_b']) && !empty($params['name_a_b'])) {
-      $params['label_a_b'] = $params['name_a_b'];
-    }
+  public static function add($params) {
+    if (empty($params['id'])) {
+      // Set name to label if not set
+      if (empty($params['label_a_b']) && !empty($params['name_a_b'])) {
+        $params['label_a_b'] = $params['name_a_b'];
+      }
+      if (empty($params['label_b_a']) && !empty($params['name_b_a'])) {
+        $params['label_b_a'] = $params['name_b_a'];
+      }
 
-    if (empty($params['label_b_a']) && !empty($params['name_b_a'])) {
-      $params['label_b_a'] = $params['name_b_a'];
-    }
-
-    // set label to name if it's not set - but *only* for
-    // ADD action. CRM-3336 as part from (CRM-3522)
-    if (!$params['id']) {
+      // set label to name if it's not set
       if (empty($params['name_a_b']) && !empty($params['label_a_b'])) {
         $params['name_a_b'] = $params['label_a_b'];
       }
@@ -110,22 +104,18 @@ class CRM_Contact_BAO_RelationshipType extends CRM_Contact_DAO_RelationshipType 
     // action is taken depending upon the mode
     $relationshipType = new CRM_Contact_DAO_RelationshipType();
 
+    $hook = empty($params['id']) ? 'create' : 'edit';
+    CRM_Utils_Hook::pre($hook, 'RelationshipType', CRM_Utils_Array::value('id', $params), $params);
+
     $relationshipType->copyValues($params);
+    $relationshipType->save();
 
-    // if label B to A is blank, insert the value label A to B for it
-    if (!strlen(trim($strName = CRM_Utils_Array::value('name_b_a', $params)))) {
-      $relationshipType->name_b_a = CRM_Utils_Array::value('name_a_b', $params);
-    }
-    if (!strlen(trim($strName = CRM_Utils_Array::value('label_b_a', $params)))) {
-      $relationshipType->label_b_a = CRM_Utils_Array::value('label_a_b', $params);
-    }
-
-    $result = $relationshipType->save();
+    CRM_Utils_Hook::post($hook, 'RelationshipType', $relationshipType->id, $relationshipType);
 
     CRM_Core_PseudoConstant::relationshipType('label', TRUE);
     CRM_Core_PseudoConstant::relationshipType('name', TRUE);
     CRM_Case_XMLProcessor::flushStaticCaches();
-    return $result;
+    return $relationshipType;
   }
 
   /**

--- a/tests/phpunit/CRM/Contact/BAO/ContactType/RelationshipTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ContactType/RelationshipTest.php
@@ -101,8 +101,7 @@ DELETE FROM civicrm_contact_type
       'contact_type_b' => 'Individual',
       'contact_sub_type_b' => $this->parent,
     );
-    $ids = array();
-    $result = CRM_Contact_BAO_RelationshipType::add($params, $ids);
+    $result = CRM_Contact_BAO_RelationshipType::add($params);
     $this->assertEquals($result->name_a_b, 'indivToparent');
     $this->assertEquals($result->contact_type_a, 'Individual');
     $this->assertEquals($result->contact_type_b, 'Individual');
@@ -119,8 +118,7 @@ DELETE FROM civicrm_contact_type
       'contact_sub_type_a' => $this->sponsor,
       'contact_type_b' => 'Individual',
     );
-    $ids = array();
-    $result = CRM_Contact_BAO_RelationshipType::add($params, $ids);
+    $result = CRM_Contact_BAO_RelationshipType::add($params);
     $this->assertEquals($result->name_a_b, 'SponsorToIndiv');
     $this->assertEquals($result->contact_type_a, 'Organization');
     $this->assertEquals($result->contact_sub_type_a, $this->sponsor);
@@ -138,8 +136,7 @@ DELETE FROM civicrm_contact_type
       'contact_type_b' => 'Organization',
       'contact_sub_type_b' => $this->sponsor,
     );
-    $ids = array();
-    $result = CRM_Contact_BAO_RelationshipType::add($params, $ids);
+    $result = CRM_Contact_BAO_RelationshipType::add($params);
     $this->assertEquals($result->name_a_b, 'StudentToSponser');
     $this->assertEquals($result->contact_type_a, 'Individual');
     $this->assertEquals($result->contact_sub_type_a, $this->student);
@@ -160,8 +157,7 @@ DELETE FROM civicrm_contact_type
       'contact_type_b' => 'Individual',
       'contact_sub_type_b' => $this->parent,
     );
-    $relTypeIds = array();
-    $relType = CRM_Contact_BAO_RelationshipType::add($relTypeParams, $relTypeIds);
+    $relType = CRM_Contact_BAO_RelationshipType::add($relTypeParams);
     $params = array(
       'relationship_type_id' => $relType->id . '_a_b',
       'contact_check' => array($this->indivi_student => 1),
@@ -187,8 +183,7 @@ DELETE FROM civicrm_contact_type
       'contact_sub_type_a' => $this->sponsor,
       'contact_type_b' => 'Individual',
     );
-    $relTypeIds = array();
-    $relType = CRM_Contact_BAO_RelationshipType::add($relTypeParams, $relTypeIds);
+    $relType = CRM_Contact_BAO_RelationshipType::add($relTypeParams);
     $params = array(
       'relationship_type_id' => $relType->id . '_a_b',
       'contact_check' => array($this->individual => 1),
@@ -212,8 +207,7 @@ DELETE FROM civicrm_contact_type
       'contact_type_b' => 'Organization',
       'contact_sub_type_b' => 'Sponser',
     );
-    $relTypeIds = array();
-    $relType = CRM_Contact_BAO_RelationshipType::add($relTypeParams, $relTypeIds);
+    $relType = CRM_Contact_BAO_RelationshipType::add($relTypeParams);
     $params = array(
       'relationship_type_id' => $relType->id . '_a_b',
       'contact_check' => array($this->individual => 1),
@@ -240,8 +234,7 @@ DELETE FROM civicrm_contact_type
       'contact_type_b' => 'Individual',
       'contact_sub_type_b' => $this->parent,
     );
-    $relTypeIds = array();
-    $relType = CRM_Contact_BAO_RelationshipType::add($relTypeParams, $relTypeIds);
+    $relType = CRM_Contact_BAO_RelationshipType::add($relTypeParams);
     $params = array(
       'relationship_type_id' => $relType->id . '_a_b',
       'is_active' => 1,
@@ -268,8 +261,7 @@ DELETE FROM civicrm_contact_type
       'contact_sub_type_a' => $this->sponsor,
       'contact_type_b' => 'Individual',
     );
-    $relTypeIds = array();
-    $relType = CRM_Contact_BAO_RelationshipType::add($relTypeParams, $relTypeIds);
+    $relType = CRM_Contact_BAO_RelationshipType::add($relTypeParams);
     $params = array(
       'relationship_type_id' => $relType->id . '_a_b',
       'is_active' => 1,
@@ -293,8 +285,7 @@ DELETE FROM civicrm_contact_type
       'contact_type_b' => 'Organization',
       'contact_sub_type_b' => $this->sponsor,
     );
-    $relTypeIds = array();
-    $relType = CRM_Contact_BAO_RelationshipType::add($relTypeParams, $relTypeIds);
+    $relType = CRM_Contact_BAO_RelationshipType::add($relTypeParams);
     $params = array(
       'relationship_type_id' => $relType->id . '_a_b',
       'is_active' => 1,


### PR DESCRIPTION
Overview
---------
This solves a bug in saving relationship types using inline-editing, by cleaning up old code.

Before
--------
Oddities in the old code were resulting in unwanted changes to the B side of a label when editing the A side.
![Image](https://issues.civicrm.org/jira/secure/attachment/70672/70672_image-2018-03-27-15-11-54-181.png)

After
-----
The form still handles saving correctly if the B side is left blank, but inline-edit and API calls are no longer affected.

Technical Notes
------
I added missing hook calls, and removed the deprecated `$ids` param which was superfluous.

* [CRM-21855: Editing "A" side of relationship copies values to "B" side](https://issues.civicrm.org/jira/browse/CRM-21855)