### PR TITLE
Issue 35b

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2891,6 +2891,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    */
   public function _assignMessageVariablesToTemplate(&$values, $input, $returnMessageText = TRUE) {
     $template = CRM_Core_Smarty::singleton();
+    $template->clearTemplateVars();
     $template->assign('first_name', $this->_relatedObjects['contact']->first_name);
     $template->assign('last_name', $this->_relatedObjects['contact']->last_name);
     $template->assign('displayName', $this->_relatedObjects['contact']->display_name);

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2891,6 +2891,8 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    */
   public function _assignMessageVariablesToTemplate(&$values, $input, $returnMessageText = TRUE) {
     $template = CRM_Core_Smarty::singleton();
+    // Clear template variables to avoid leakage when processing multiple contributions.
+    // See https://lab.civicrm.org/dev/core/issues/35
     $template->clearTemplateVars();
     $template->assign('first_name', $this->_relatedObjects['contact']->first_name);
     $template->assign('last_name', $this->_relatedObjects['contact']->last_name);
@@ -2911,6 +2913,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
           'honor_profile_id' => CRM_Core_DAO::getFieldValue('CRM_Core_DAO_UFJoin', $values['id'], 'uf_group_id', 'entity_id'),
           'honor_id' => $softRecord['soft_credit'][1]['contact_id'],
         );
+        $values['honoree_profile_id'] = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_UFJoin', $values['id'], 'uf_group_id', 'entity_id');
 
         $template->assign('soft_credit_type', $softRecord['soft_credit'][1]['soft_credit_type_label']);
         $template->assign('honor_block_is_active', CRM_Core_DAO::getFieldValue('CRM_Core_DAO_UFJoin', $values['id'], 'is_active', 'entity_id'));

--- a/CRM/Contribute/BAO/ContributionSoft.php
+++ b/CRM/Contribute/BAO/ContributionSoft.php
@@ -186,6 +186,7 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
           ),
           'honor_id' => $honorId,
           'honor_profile_id' => $form->_values['honoree_profile_id'],
+          'honoree_profile_id' => $form->_values['honoree_profile_id'],
           'honor_profile_values' => $params['honor'],
         );
       }

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -222,30 +222,7 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
    * Create honor-contact method.
    */
   public function testCreateAndGetHonorContact() {
-    $firstName = 'John_' . substr(sha1(rand()), 0, 7);
-    $lastName = 'Smith_' . substr(sha1(rand()), 0, 7);
-    $email = "{$firstName}.{$lastName}@example.com";
-
-    //Get profile id of name honoree_individual used to create profileContact
-    $honoreeProfileId = NULL;
-    $ufGroupDAO = new CRM_Core_DAO_UFGroup();
-    $ufGroupDAO->name = 'honoree_individual';
-    if ($ufGroupDAO->find(TRUE)) {
-      $honoreeProfileId = $ufGroupDAO->id;
-    }
-
-    $params = array(
-      'prefix_id' => 3,
-      'first_name' => $firstName,
-      'last_name' => $lastName,
-      'email-1' => $email,
-    );
-    $softParam = array('soft_credit_type_id' => 1);
-
-    $honoreeContactId = CRM_Contact_BAO_Contact::createProfileContact($params, CRM_Core_DAO::$_nullArray,
-      NULL, NULL, $honoreeProfileId
-    );
-
+    $honoreeContactId = $this->getHonoreeContact();
     $this->assertDBCompareValue('CRM_Contact_DAO_Contact', $honoreeContactId, 'first_name', 'id', $firstName,
       'Database check for created honor contact record.'
     );

--- a/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
@@ -259,7 +259,7 @@ class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
       'Honor',
     );
     $mails = $mut->getAllMessages('raw');
-    foreach($mails as $mail) {
+    foreach ($mails as $mail) {
       $mut->checkMailForStrings(array(), $shouldNotBeInMailing, '', $mail);
     }
     $mut->stop();

--- a/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
@@ -204,6 +204,15 @@ class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
     $mut = new CiviMailUtils($this, TRUE);
     $this->setupMembershipRecurringPaymentProcessorTransaction(array('is_email_receipt' => TRUE));
     $this->addProfile('supporter_profile', $this->_contributionPageID);
+
+    $honoreeContactId = $this->getHonoreeContact();
+    $softParam['contact_id'] = $honoreeContactId;
+    $softParam['contribution_id'] = $this->_contributionID;
+    $softParam['amount'] = 200;
+
+    //Create Soft Contribution for honoree contact
+    CRM_Contribute_BAO_ContributionSoft::add($softParam);
+
     $IPN = new CRM_Core_Payment_AuthorizeNetIPN($this->getRecurTransaction());
     $IPN->main();
     $mut->checkAllMailLog(array(
@@ -215,6 +224,7 @@ class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
       'First Name: Anthony',
       'Last Name: Anderson',
       'Email Address: anthony_anderson@civicrm.org',
+      'Honor',
       'This membership will be automatically renewed every',
       'Dear Mr. Anthony Anderson II',
       'Thanks for your auto renew membership sign-up',
@@ -223,6 +233,8 @@ class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
     $this->_contactID = $this->individualCreate(array('first_name' => 'Antonia', 'prefix_id' => 'Mrs.', 'email' => 'antonia_anderson@civicrm.org'));
     $this->_invoiceID = uniqid();
 
+    // Note, the second contribution is not in honor of anyone and the
+    // receipt should not mention honor at all.
     $this->setupMembershipRecurringPaymentProcessorTransaction(array('is_email_receipt' => TRUE));
     $IPN = new CRM_Core_Payment_AuthorizeNetIPN($this->getRecurTransaction(array('x_trans_id' => 'hers')));
     $IPN->main();
@@ -243,6 +255,13 @@ class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
       'Thanks for your auto renew membership sign-up',
     ));
 
+    $shouldNotBeInMailing = array(
+      'Honor',
+    );
+    $mails = $mut->getAllMessages('raw');
+    foreach($mails as $mail) {
+      $mut->checkMailForStrings(array(), $shouldNotBeInMailing, '', $mail);
+    }
     $mut->stop();
     $mut->clearMessages();
   }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3619,4 +3619,36 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
     $dbLocale = '_en_US';
   }
 
+
+  /**
+   *
+   * Create honoree contact
+   *
+   * Contact that can be used to test honor of contributions.
+   */
+  public function getHonoreeContact() {
+    $firstName = 'John_' . substr(sha1(rand()), 0, 7);
+    $lastName = 'Smith_' . substr(sha1(rand()), 0, 7);
+    $email = "{$firstName}.{$lastName}@example.com";
+
+    //Get profile id of name honoree_individual used to create profileContact
+    $honoreeProfileId = NULL;
+    $ufGroupDAO = new CRM_Core_DAO_UFGroup();
+    $ufGroupDAO->name = 'honoree_individual';
+    if ($ufGroupDAO->find(TRUE)) {
+      $honoreeProfileId = $ufGroupDAO->id;
+    }
+
+    $params = array(
+      'prefix_id' => 3,
+      'first_name' => $firstName,
+      'last_name' => $lastName,
+      'email-1' => $email,
+    );
+    $softParam = array('soft_credit_type_id' => 1);
+
+    return CRM_Contact_BAO_Contact::createProfileContact($params, CRM_Core_DAO::$_nullArray,
+      NULL, NULL, $honoreeProfileId
+    );
+  }
 }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3651,4 +3651,5 @@ AND    ( TABLE_NAME LIKE 'civicrm_value_%' )
       NULL, NULL, $honoreeProfileId
     );
   }
+
 }


### PR DESCRIPTION
 See https://lab.civicrm.org/dev/core/issues/35

Overview
----------------------------------------
This bug happens if you have more than one iATS recurring contribution and an earlier contribution is assigned to a soft credit, but one or more later contributions are not assigned to a soft credit.

The later contributions have the soft credit information inserted into their receipt because the email message template variables are not properly cleared.

iATS processes multiple recurring contributions in a single session via a cron job, so may be uniquely triggering this error (although the bug is with CiviCRM Core).

Before
----------------------------------------
Some (seemingly at random) recurring contribution receipts are sent out in which donors are credited with honoring people they have never heard of.

After
----------------------------------------
Receipts only honor people if the donor intended to honor them.

Technical Details
----------------------------------------
Most payment processors process each recurring contribution independently of each other - so there is no leakage of template variables.

However, since iATS processes them in one batch, we run into this error.

