### PR TITLE
CRM-21403: Membership advanced search result fix when Current Member Input Field is NO

### DIFF
--- a/CRM/Member/Selector/Search.php
+++ b/CRM/Member/Selector/Search.php
@@ -372,6 +372,25 @@ class CRM_Member_Selector_Search extends CRM_Core_Selector_Base implements CRM_C
         }
       }
 
+      /*
+       * check if the contact has an active membership CRM-21403
+       */
+
+      //first, lets make sure the search is for not a current member
+      if (isset($_POST['membership_is_current_member']) &&
+          $_POST['membership_is_current_member'] == false) {
+
+          $hasAnActiveMembership = civicrm_api3('Membership', 'getcount', array(
+              'contact_id' => $result->contact_id,
+              'active_only' => 1,
+          ));
+
+          //skip the contact if there is an active membership
+          if ($hasAnActiveMembership == true) {
+              continue;
+          }
+      }
+
       //carry campaign on selectors.
       $row['campaign'] = CRM_Utils_Array::value($result->member_campaign_id, $allCampaigns);
       $row['campaign_id'] = $result->member_campaign_id;

--- a/CRM/Member/Selector/Search.php
+++ b/CRM/Member/Selector/Search.php
@@ -378,17 +378,17 @@ class CRM_Member_Selector_Search extends CRM_Core_Selector_Base implements CRM_C
 
       //first, lets make sure the search is for not a current member
       if (isset($_POST['membership_is_current_member']) &&
-          $_POST['membership_is_current_member'] == false) {
+          $_POST['membership_is_current_member'] == FALSE) {
 
-          $hasAnActiveMembership = civicrm_api3('Membership', 'getcount', array(
-              'contact_id' => $result->contact_id,
-              'active_only' => 1,
-          ));
+        $hasAnActiveMembership = civicrm_api3('Membership', 'getcount', array(
+            'contact_id' => $result->contact_id,
+            'active_only' => 1,
+        ));
 
-          //skip the contact if there is an active membership
-          if ($hasAnActiveMembership == true) {
-              continue;
-          }
+        //skip the contact if there is an active membership
+        if ($hasAnActiveMembership == TRUE) {
+          continue;
+        }
       }
 
       //carry campaign on selectors.

--- a/tests/phpunit/CRM/Member/Selector/SearchTest.php
+++ b/tests/phpunit/CRM/Member/Selector/SearchTest.php
@@ -69,9 +69,8 @@ class CRM_Member_Selector_SearchTest extends CiviUnitTestCase {
         'active_only' => 1,
     ));
 
-    $this->assertEquals($activeMembership, true);
+    $this->assertEquals($activeMembership, TRUE);
 
   }
-
 
 }

--- a/tests/phpunit/CRM/Member/Selector/SearchTest.php
+++ b/tests/phpunit/CRM/Member/Selector/SearchTest.php
@@ -8,51 +8,6 @@ class CRM_Member_Selector_SearchTest extends CiviUnitTestCase {
 
   public function setUp() {
     parent::setUp();
-
-    //here, we would create two memberships for the same contact, one expired and one current
-    $this->_indiviParams = array(
-      'first_name' => 'Foo',
-      'last_name' => 'Bar',
-      'contact_type' => 'Individual',
-    );
-
-    $this->_contactId = $this->individualCreate($this->_indiviParams);
-
-    $this->_membershipTypeID = $this->membershipTypeCreate(array('member_of_contact_id' => $this->_contactId));
-
-    $this->_membershipStatusID = $this->membershipStatusCreate('test status' . rand(1, 1000));
-
-    //expired membership
-    $expired_membership_params = array(
-      'contact_id' => $this->_contactId,
-      'membership_type_id' => $this->_membershipTypeID,
-      'join_date' => date('Ymd', strtotime('2007-03-21')),
-      'start_date' => date('Ymd', strtotime('2007-03-21')),
-      'end_date' => date('Ymd', strtotime('2007-12-21')),
-      'source' => 'Payment',
-      'is_override' => 1,
-      'status_id' => $this->_membershipStatusID,
-    );
-
-    //current membership
-    $current_membership_params = array(
-      'contact_id' => $this->_contactId,
-      'membership_type_id' => $this->_membershipTypeID,
-      'join_date' => date('Ymd', strtotime('2007-03-21')),
-      'start_date' => date('Ymd', strtotime('2007-03-21')),
-      'end_date' => date('Ymd', strtotime('+ 5 years')),
-      'source' => 'Payment',
-      'is_override' => 1,
-      'status_id' => $this->_membershipStatusID,
-    );
-
-    $ids = array();
-
-    //create expired membership
-    CRM_Member_BAO_Membership::create($expired_membership_params, $ids);
-
-    //create current membership
-    CRM_Member_BAO_Membership::create($current_membership_params, $ids);
   }
 
   public function tearDown() {
@@ -64,8 +19,47 @@ class CRM_Member_Selector_SearchTest extends CiviUnitTestCase {
    */
   public function testSearchMultipleMembershipWithAtLeastOneActive() {
 
+    //here, we would create two memberships for the same contact, one expired and one current
+    $_contactID = $this->individualCreate();
+
+    $_membershipTypeID = $this->membershipTypeCreate(array('member_of_contact_id' => $_contactID));
+
+    $_membershipStatusID = $this->membershipStatusCreate('test status' . rand(1, 1000));
+
+    //expired membership
+    $expired_membership_params = array(
+      'contact_id' => $_contactID,
+      'membership_type_id' => $_membershipTypeID,
+      'join_date' => date('Ymd', strtotime('2007-03-21')),
+      'start_date' => date('Ymd', strtotime('2007-03-21')),
+      'end_date' => date('Ymd', strtotime('2007-12-21')),
+      'source' => 'Payment',
+      'is_override' => 1,
+      'status_id' => $_membershipStatusID,
+    );
+
+    //current membership
+    $current_membership_params = array(
+      'contact_id' => $_contactID,
+      'membership_type_id' => $_membershipTypeID,
+      'join_date' => date('Ymd', strtotime('2007-03-21')),
+      'start_date' => date('Ymd', strtotime('2007-03-21')),
+      'end_date' => date('Ymd', strtotime('+ 5 years')),
+      'source' => 'Payment',
+      'is_override' => 1,
+      'status_id' => $_membershipStatusID,
+    );
+
+    $ids = array();
+
+    //create expired membership
+    CRM_Member_BAO_Membership::create($expired_membership_params, $ids);
+
+    //create current membership
+    CRM_Member_BAO_Membership::create($current_membership_params, $ids);
+
     $activeMembership = civicrm_api3('Membership', 'getcount', array(
-        'contact_id' => $this->_contactID,
+        'contact_id' => $_contactID,
         'active_only' => 1,
     ));
 

--- a/tests/phpunit/CRM/Member/Selector/SearchTest.php
+++ b/tests/phpunit/CRM/Member/Selector/SearchTest.php
@@ -10,7 +10,13 @@ class CRM_Member_Selector_SearchTest extends CiviUnitTestCase {
     parent::setUp();
 
     //here, we would create two memberships for the same contact, one expired and one current
-    $this->_contactId = $this->individualCreate();
+    $this->_indiviParams = array(
+      'first_name' => 'Foo',
+      'last_name' => 'Bar',
+      'contact_type' => 'Individual',
+    );
+
+    $this->_contactId = $this->individualCreate($this->_indiviParams);
 
     $this->_membershipTypeID = $this->membershipTypeCreate(array('member_of_contact_id' => $this->_contactId));
 

--- a/tests/phpunit/CRM/Member/Selector/SearchTest.php
+++ b/tests/phpunit/CRM/Member/Selector/SearchTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Class CRM_Member_Selector_SearchTest
+ * @group headless
+ */
+class CRM_Member_Selector_SearchTest extends CiviUnitTestCase {
+
+  public function setUp() {
+    parent::setUp();
+
+    //here, we would create two memberships for the same contact, one expired and one current
+    $this->_contactId = $this->individualCreate();
+
+    $this->_membershipTypeID = $this->membershipTypeCreate(array('member_of_contact_id' => $this->_contactId));
+
+    $this->_membershipStatusID = $this->membershipStatusCreate('test status' . rand(1, 1000));
+
+    //expired membership
+    $expired_membership_params = array(
+      'contact_id' => $this->_contactId,
+      'membership_type_id' => $this->_membershipTypeID,
+      'join_date' => date('Ymd', strtotime('2007-03-21')),
+      'start_date' => date('Ymd', strtotime('2007-03-21')),
+      'end_date' => date('Ymd', strtotime('2007-12-21')),
+      'source' => 'Payment',
+      'is_override' => 1,
+      'status_id' => $this->_membershipStatusID,
+    );
+
+    //current membership
+    $current_membership_params = array(
+      'contact_id' => $this->_contactId,
+      'membership_type_id' => $this->_membershipTypeID,
+      'join_date' => date('Ymd', strtotime('2007-03-21')),
+      'start_date' => date('Ymd', strtotime('2007-03-21')),
+      'end_date' => date('Ymd', strtotime('+ 5 years')),
+      'source' => 'Payment',
+      'is_override' => 1,
+      'status_id' => $this->_membershipStatusID,
+    );
+
+    $ids = array();
+
+    //create expired membership
+    CRM_Member_BAO_Membership::create($expired_membership_params, $ids);
+
+    //create current membership
+    CRM_Member_BAO_Membership::create($current_membership_params, $ids);
+  }
+
+  public function tearDown() {
+    parent::setUp();
+  }
+
+  /**
+   * Search where contact has multiple memberships but at least one is active
+   */
+  public function testSearchMultipleMembershipWithAtLeastOneActive() {
+
+    $activeMembership = civicrm_api3('Membership', 'getcount', array(
+        'contact_id' => $this->_contactID,
+        'active_only' => 1,
+    ));
+
+    $this->assertEquals($activeMembership, true);
+
+  }
+
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Membership advanced search no longer shows a contact with an active membership when the 'Current Member' input field is 'No'. 

Before
----------------------------------------
If a contact has multiple memberships where one is no longer active and the other is. 

![screenshot 2018-04-19 21 38 21](https://user-images.githubusercontent.com/336308/38984132-082095fe-441a-11e8-9fea-4808633f5fa9.png)


The contact appears in the Membership advanced search result when the 'Current Member' input field is checked as 'No'.

![screenshot 2018-04-19 21 37 54](https://user-images.githubusercontent.com/336308/38984143-0f494e98-441a-11e8-939f-93fa5217fe0a.png)
![screenshot 2018-04-19 21 38 11](https://user-images.githubusercontent.com/336308/38984157-1466d9b8-441a-11e8-9b13-7b26d067180b.png)

After
----------------------------------------
If the 'Current member' input field is checked as No. For as long as one of the contacts multiple memberships is active, the contact does not appear in the search result.

Technical Details
----------------------------------------
Within the loop of the contact result, there is a check to see if the specific contact has an active membership.

---

 * [CRM-21403: 'Current Member' field in searches does not perform as expected](https://issues.civicrm.org/jira/browse/CRM-21403)

https://lab.civicrm.org/dev/core/issues/132