### PR TITLE
Fix API template

### DIFF
--- a/templates/CRM/Admin/Page/APIExplorer.tpl
+++ b/templates/CRM/Admin/Page/APIExplorer.tpl
@@ -25,10 +25,6 @@
 *}
 <style>
   {literal}
-  #mainTabContainer {
-    background: transparent;
-    border: 0 none;
-  }
   #mainTabContainer pre {
     line-height: 14px;
     font-size: 11px;
@@ -226,6 +222,7 @@
   {/literal}
 </style>
 
+<div class="crm-block crm-content-block">
 <div id="mainTabContainer">
   <ul>
     <li class="ui-corner-all" title="GUI to build and execute API calls">
@@ -240,7 +237,7 @@
   </ul>
 
   <div id="explorer-tab">
-
+    <div class="crm-block crm-form-block">
     <form id="api-explorer">
       <label for="api-entity">{ts}Entity{/ts}:</label>
       <select class="crm-form-select big required" id="api-entity" name="entity">
@@ -308,13 +305,16 @@
           <i class="crm-i fa-bolt"></i><input type="submit" value="{ts}Execute{/ts}" class="crm-form-submit" accesskey="S" title="{ts}Execute API call and display results{/ts}"/>
         </span>
       </div>
+
 <pre id="api-result" class="linenums">
 {ts}Results are displayed here.{/ts}
 </pre>
     </form>
   </div>
+  </div>
 
   <div id="examples-tab">
+    <div class="crm-block crm-form-block">
     <form id="api-examples">
       <label for="example-entity">{ts}Entity{/ts}:</label>
       <select class="crm-form-select big required" id="example-entity" name="entity">
@@ -335,8 +335,10 @@
 </pre>
     </form>
   </div>
+  </div>
 
   <div id="docs-tab">
+    <div class="crm-block crm-form-block">
     <form id="api-docs">
       <label for="doc-entity">{ts}Entity{/ts}:</label>
       <select class="crm-form-select big required" id="doc-entity" name="entity">
@@ -356,9 +358,10 @@
         {ts}Results are displayed here.{/ts}
       </div>
     </form>
+    </div>
   </div>
 </div>
-
+</div>
 {strip}
 <script type="text/template" id="api-param-tpl">
   <tr class="api-param-row">


### PR DESCRIPTION
Overview
----------------------------------------
This PR fixes structure and style of CiviCRM API explorer to make it look like other pages to give unified interface between screens.

Screenshots
----------------------------------------
**Before**
![image](https://user-images.githubusercontent.com/26058635/38667866-41c55a0c-3e60-11e8-8e9f-8d1e4d54f46d.png)
**After**
![image](https://user-images.githubusercontent.com/26058635/38666462-98f48162-3e5c-11e8-9cad-bbddcec73c25.png)

**Before**
![image](https://user-images.githubusercontent.com/26058635/38666739-4e047a4e-3e5d-11e8-89e7-3c07f90ac79f.png)
**After**
![image](https://user-images.githubusercontent.com/26058635/38666483-a6de15f4-3e5c-11e8-9bcd-9392dbea4ea6.png)

**Before**
![image](https://user-images.githubusercontent.com/26058635/38666678-1e1b54ba-3e5d-11e8-903a-61998d4339d6.png)
**After**
![image](https://user-images.githubusercontent.com/26058635/38666502-b455bc0a-3e5c-11e8-93a6-c45b6ead7c73.png)

Comments
----------------------------------------
This changes are BackstopJS tested to make sure that other pages are not harmed due to the changes