### PR TITLE
dev/financial#11 email invoice fails with validation error

### DIFF
--- a/CRM/Contribute/Form/Task/Invoice.php
+++ b/CRM/Contribute/Form/Task/Invoice.php
@@ -458,12 +458,9 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
         'PDFFilename' => $pdfFileName,
       );
 
-      $fromEmail = CRM_Core_BAO_Email::getFromEmail();
-
       // from email address
-      if (isset($params['from_email_address'])) {
-        $fromEmailAddress = CRM_Utils_Array::value($params['from_email_address'], $fromEmail);
-      }
+      $fromEmailAddress = CRM_Utils_Array::value('from_email_address', $params);
+
       // condition to check for download PDF Invoice or email Invoice
       if ($invoiceElements['createPdf']) {
         list($sent, $subject, $message, $html) = CRM_Core_BAO_MessageTemplate::sendTemplate($sendTemplateParams);


### PR DESCRIPTION
Overview
----------------------------------------
When sending out an email invoice, email validation error is thrown.

Before
----------------------------------------
With invoicing enabled, view a contribution and choose to email invoice. Select a from address and submit the form. An error is returned indicating email verification failed.

After
----------------------------------------
The above works properly.

Technical Details
----------------------------------------
The from email address was set using the option list label instead of the value. The label is URL encoded for display on screen. The encoding triggered the validation failure. This patch retrieves the value instead of the label and sets a default value.
