### PR TITLE
CRM-19885 / dev/core/issues/36 fix fatal error on scheduled reminders due to no default

### DIFF
--- a/CRM/Upgrade/Incremental/sql/5.2.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.2.alpha1.mysql.tpl
@@ -1,1 +1,10 @@
 {* file to handle db changes in 5.2.alpha1 during upgrade *}
+# CRM-19885 & https://lab.civicrm.org/dev/core/issues/36#note_3509
+UPDATE civicrm_action_schedule SET repetition_frequency_interval = 0 WHERE repetition_frequency_interval IS NULL;
+UPDATE civicrm_action_schedule SET start_action_offset = 0 WHERE start_action_offset IS NULL;
+UPDATE civicrm_action_schedule SET end_frequency_interval = 0 WHERE end_frequency_interval IS NULL;
+
+ALTER TABLE civicrm_action_schedule
+ALTER column repetition_frequency_interval SET DEFAULT 0,
+ALTER column start_action_offset SET DEFAULT 0,
+ALTER column  end_frequency_interval  SET DEFAULT 0;

--- a/xml/schema/Core/ActionSchedule.xml
+++ b/xml/schema/Core/ActionSchedule.xml
@@ -64,6 +64,7 @@
     <name>start_action_offset</name>
     <type>int unsigned</type>
     <comment>Reminder Interval.</comment>
+    <default>0</default>
     <add>3.4</add>
   </field>
   <field>
@@ -116,6 +117,7 @@
   <field>
     <name>repetition_frequency_interval</name>
     <type>int unsigned</type>
+    <default>0</default>
     <comment>Time interval for repeating the reminder.</comment>
     <add>3.4</add>
   </field>
@@ -137,6 +139,7 @@
     <type>int unsigned</type>
     <comment>Time interval till repeating the reminder.</comment>
     <add>3.4</add>
+    <default>0</default>
   </field>
   <field>
     <name>end_action</name>


### PR DESCRIPTION
Overview
----------------------------------------
Fix fatal error causing fatal error

Before
----------------------------------------
Fatal error per https://lab.civicrm.org/dev/core/issues/36#note_3509

After
----------------------------------------
No fatal error - note the logger / tester refers to there still being an error - but it appears to be a separate issue & is not fleshed out. per David Tarrant comment here https://issues.civicrm.org/jira/browse/CRM-19885?focusedCommentId=109335&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-109335 this fatal is blocking the scheduled job entirely so even if this just mitigates it is seems better

Technical Details
----------------------------------------
Previous PR by @twomice & discussion #9686 

The mysql commands have been tested & improve the situation per comments on https://lab.civicrm.org/dev/core/issues/36#note_3509

Comments
----------------------------------------
Is this correct for the upgrade commands in new system @totten ?
