### PR TITLE
dev/core#59 scheduled reminder email validation

### DIFF
--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -334,7 +334,9 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
         $errors['absolute_date'] = ts('Absolute date cannot be earlier than the current time.');
       }
     }
-
+    if (!CRM_Utils_Rule::email($fields['from_email'])) {
+      $errors['from_email'] = ts('Please enter a valid email address.');
+    }
     $recipientKind = array(
       'participant_role' => array(
         'name' => 'participant role',


### PR DESCRIPTION
Overview
----------------------------------------
The scheduled reminder form currently does not validate the email address field. As a result, a non-email value can be stored there which results in a silent failure.

Before
----------------------------------------
Non-email value can be stored in the email field.

After
----------------------------------------
Email is validated on form submission.
