### PR TITLE
dev/core#61 Split Edit Message Templates Permission

### DIFF
--- a/CRM/Admin/Form/MessageTemplates.php
+++ b/CRM/Admin/Form/MessageTemplates.php
@@ -106,6 +106,7 @@ class CRM_Admin_Form_MessageTemplates extends CRM_Admin_Form {
     }
     else {
       $this->_workflow_id = CRM_Utils_Array::value('workflow_id', $this->_values);
+      $this->checkUserPermission($this->_workflow_id);
       $this->assign('workflow_id', $this->_workflow_id);
 
       if ($this->_workflow_id) {
@@ -211,6 +212,25 @@ class CRM_Admin_Form_MessageTemplates extends CRM_Admin_Form {
     if ($this->_action & CRM_Core_Action::VIEW) {
       $this->freeze();
       CRM_Utils_System::setTitle(ts('View System Default Message Template'));
+    }
+  }
+
+  /**
+   * Restrict users access based on permission
+   *
+   * @param int $workflowId
+   */
+  private function checkUserPermission($workflowId) {
+    if (isset($workflowId)) {
+      $canView = CRM_Core_Permission::check('edit system workflow message templates');
+    } else {
+      $canView = CRM_Core_Permission::check('edit user-driven message templates');
+    }
+
+    if (! $canView && ! CRM_Core_Permission::check('edit message templates')) {
+      CRM_Core_Session::setStatus(ts('You do not have permission to view requested page.'), ts('Access Denied'));
+      $url = CRM_Utils_System::url('civicrm/admin/messageTemplates', "reset=1");
+      CRM_Utils_System::redirect($url);
     }
   }
 

--- a/CRM/Admin/Form/MessageTemplates.php
+++ b/CRM/Admin/Form/MessageTemplates.php
@@ -223,11 +223,12 @@ class CRM_Admin_Form_MessageTemplates extends CRM_Admin_Form {
   private function checkUserPermission($workflowId) {
     if (isset($workflowId)) {
       $canView = CRM_Core_Permission::check('edit system workflow message templates');
-    } else {
+    }
+    else {
       $canView = CRM_Core_Permission::check('edit user-driven message templates');
     }
 
-    if (! $canView && ! CRM_Core_Permission::check('edit message templates')) {
+    if (!$canView && !CRM_Core_Permission::check('edit message templates')) {
       CRM_Core_Session::setStatus(ts('You do not have permission to view requested page.'), ts('Access Denied'));
       $url = CRM_Utils_System::url('civicrm/admin/messageTemplates', "reset=1");
       CRM_Utils_System::redirect($url);

--- a/CRM/Admin/Page/MessageTemplates.php
+++ b/CRM/Admin/Page/MessageTemplates.php
@@ -289,6 +289,9 @@ class CRM_Admin_Page_MessageTemplates extends CRM_Core_Page_Basic {
     );
 
     $this->assign('rows', $rows);
+    $this->assign('canEditSystemTemplates', CRM_Core_Permission::check('edit system workflow message templates'));
+    $this->assign('canEditMessageTemplates', CRM_Core_Permission::check('edit message templates'));
+    $this->assign('canEditUserDrivenMessageTemplates', CRM_Core_Permission::check('edit user-driven message templates'));
   }
 
 }

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -877,6 +877,12 @@ class CRM_Core_Permission {
       'edit message templates' => array(
         $prefix . ts('edit message templates'),
       ),
+      'edit system workflow message templates' => array(
+        $prefix . ts('edit system workflow message templates'),
+      ),
+      'edit user-driven message templates' => array(
+        $prefix . ts('edit user-driven message templates'),
+      ),
       'view my invoices' => array(
         $prefix . ts('view my invoices'),
         ts('Allow users to view/ download their own invoices'),
@@ -1459,8 +1465,8 @@ class CRM_Core_Permission {
 
     $permissions['message_template'] = array(
       'get' => array('access CiviCRM'),
-      'create' => array('edit message templates'),
-      'update' => array('edit message templates'),
+      'create' => array('edit message templates', 'edit user-driven message templates', 'edit system workflow message templates'),
+      'update' => array('edit message templates', 'edit user-driven message templates', 'edit system workflow message templates'),
     );
     return $permissions;
   }

--- a/CRM/Core/xml/Menu/Admin.xml
+++ b/CRM/Core/xml/Menu/Admin.xml
@@ -262,7 +262,7 @@
      <page_callback>CRM_Admin_Page_MessageTemplates</page_callback>
      <adminGroup>Communications</adminGroup>
      <icon>admin/small/template.png</icon>
-     <access_arguments>edit message templates</access_arguments>
+     <access_arguments>edit message templates;edit user-driven message templates;edit system workflow message templates</access_arguments>
      <weight>30</weight>
   </item>
   <item>
@@ -270,7 +270,7 @@
      <title>Message Templates</title>
      <desc>Add/Edit Message Templates</desc>
      <page_callback>CRM_Admin_Form_MessageTemplates</page_callback>
-     <access_arguments>edit message templates</access_arguments>
+     <access_arguments>edit message templates;edit user-driven message templates;edit system workflow message templates</access_arguments>
      <weight>262</weight>
   </item>
   <item>

--- a/CRM/Upgrade/Incremental/php/FiveTwo.php
+++ b/CRM/Upgrade/Incremental/php/FiveTwo.php
@@ -40,10 +40,14 @@ class CRM_Upgrade_Incremental_php_FiveTwo extends CRM_Upgrade_Incremental_Base {
    * @param null $currentVer
    */
   public function setPreUpgradeMessage(&$preUpgradeMessage, $rev, $currentVer = NULL) {
-    // Example: Generate a pre-upgrade message.
-    // if ($rev == '5.12.34') {
-    //   $preUpgradeMessage .= '<p>' . ts('A new permission has been added called %1 This Permission is now used to control access to the Manage Tags screen', array(1 => 'manage tags')) . '</p>';
-    // }
+    if ($rev == '5.2.alpha1') {
+      $params = array(
+        1 => 'edit user-driven message templates',
+        2 => 'edit system workflow message templates',
+        3 => 'edit message templates',
+      );
+      $preUpgradeMessage .= '<p>' . ts('New granular permissions called %1 and %2 have been added for %3 permission. These permissions help to limit user access per template', $params) . '</p>';
+    }
   }
 
   /**

--- a/CRM/Upgrade/Incremental/php/FiveTwo.php
+++ b/CRM/Upgrade/Incremental/php/FiveTwo.php
@@ -40,7 +40,7 @@ class CRM_Upgrade_Incremental_php_FiveTwo extends CRM_Upgrade_Incremental_Base {
    * @param null $currentVer
    */
   public function setPreUpgradeMessage(&$preUpgradeMessage, $rev, $currentVer = NULL) {
-    if ($rev == '5.2.alpha1') {
+    if ($rev == '5.3.0') {
       $params = array(
         1 => 'edit user-driven message templates',
         2 => 'edit system workflow message templates',

--- a/templates/CRM/Admin/Page/MessageTemplates.tpl
+++ b/templates/CRM/Admin/Page/MessageTemplates.tpl
@@ -89,12 +89,10 @@
 <div class="crm-content-block crm-block">
   <div id='mainTabContainer'>
     <ul>
-      {if call_user_func(array('CRM_Core_Permission','check'), 'edit user-driven message templates')
-      or call_user_func(array('CRM_Core_Permission','check'), 'edit message templates')}
-        <li id='tab_user'>    <a href='#user'     title='{ts}User-driven Messages{/ts}'>    {ts}User-driven Messages{/ts}    </a></li>
+      {if $canEditUserDrivenMessageTemplates or $canEditMessageTemplates}
+        <li id='tab_user'><a href='#user' title='{ts}User-driven Messages{/ts}'>{ts}User-driven Messages{/ts}</a></li>
       {/if}
-      {if call_user_func(array('CRM_Core_Permission','check'), 'edit system workflow message templates')
-      or call_user_func(array('CRM_Core_Permission','check'), 'edit message templates')}
+      {if $canEditSystemTemplates or $canEditMessageTemplates}
         <li id='tab_workflow'><a href='#workflow' title='{ts}System Workflow Messages{/ts}'>{ts}System Workflow Messages{/ts}</a></li>
       {/if}
     </ul>
@@ -104,14 +102,9 @@
     {include file="CRM/common/jsortable.tpl"}
     {foreach from=$rows item=template_row key=type}
       {if (
-        $type ne 'userTemplates' and (
-        call_user_func(array('CRM_Core_Permission','check'), 'edit system workflow message templates')
-        or call_user_func(array('CRM_Core_Permission','check'), 'edit message templates'))
-      ) or
-      (
-      $type eq 'userTemplates'and (
-      call_user_func(array('CRM_Core_Permission','check'), 'edit user-driven message templates')
-      or call_user_func(array('CRM_Core_Permission','check'), 'edit message templates'))
+        $type ne 'userTemplates' and ($canEditSystemTemplates or $canEditMessageTemplates)
+      ) or (
+        $type eq 'userTemplates'and ($canEditUserDrivenMessageTemplates or $canEditMessageTemplates)
       )}
       <div id="{if $type eq 'userTemplates'}user{else}workflow{/if}" class='ui-tabs-panel ui-widget-content ui-corner-bottom'>
           <div class="help">

--- a/templates/CRM/Admin/Page/MessageTemplates.tpl
+++ b/templates/CRM/Admin/Page/MessageTemplates.tpl
@@ -89,14 +89,30 @@
 <div class="crm-content-block crm-block">
   <div id='mainTabContainer'>
     <ul>
-      <li id='tab_user'>    <a href='#user'     title='{ts}User-driven Messages{/ts}'>    {ts}User-driven Messages{/ts}    </a></li>
-      <li id='tab_workflow'><a href='#workflow' title='{ts}System Workflow Messages{/ts}'>{ts}System Workflow Messages{/ts}</a></li>
+      {if call_user_func(array('CRM_Core_Permission','check'), 'edit user-driven message templates')
+      or call_user_func(array('CRM_Core_Permission','check'), 'edit message templates')}
+        <li id='tab_user'>    <a href='#user'     title='{ts}User-driven Messages{/ts}'>    {ts}User-driven Messages{/ts}    </a></li>
+      {/if}
+      {if call_user_func(array('CRM_Core_Permission','check'), 'edit system workflow message templates')
+      or call_user_func(array('CRM_Core_Permission','check'), 'edit message templates')}
+        <li id='tab_workflow'><a href='#workflow' title='{ts}System Workflow Messages{/ts}'>{ts}System Workflow Messages{/ts}</a></li>
+      {/if}
     </ul>
 
     {* create two selector tabs, first being the ‘user’ one, the second being the ‘workflow’ one *}
     {include file="CRM/common/enableDisableApi.tpl"}
     {include file="CRM/common/jsortable.tpl"}
     {foreach from=$rows item=template_row key=type}
+      {if (
+        $type ne 'userTemplates' and (
+        call_user_func(array('CRM_Core_Permission','check'), 'edit system workflow message templates')
+        or call_user_func(array('CRM_Core_Permission','check'), 'edit message templates'))
+      ) or
+      (
+      $type eq 'userTemplates'and (
+      call_user_func(array('CRM_Core_Permission','check'), 'edit user-driven message templates')
+      or call_user_func(array('CRM_Core_Permission','check'), 'edit message templates'))
+      )}
       <div id="{if $type eq 'userTemplates'}user{else}workflow{/if}" class='ui-tabs-panel ui-widget-content ui-corner-bottom'>
           <div class="help">
           {if $type eq 'userTemplates'}
@@ -160,6 +176,7 @@
             {/if}
          </div>
       </div>
+      {/if}
     {/foreach}
   </div>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
The `edit message templates` permission currently grants access to user-driven messages and system workflow message. The implication of this is that, there is no way of restricting a particular user to just user-driven messages or system workflow messages. 

This PR adds 2 new granular permissions called `edit user-driven message templates` and `edit system workflow message templates`. This helps to further limit which of the templates a user can view and edit, while retaining exiting `edit message templates` permission for backward compability.

Before
----------------------------------------
![before](https://user-images.githubusercontent.com/1507645/38738760-dcdb56c0-3f2a-11e8-9832-f0dba2a2d794.gif)


After
----------------------------------------
![after](https://user-images.githubusercontent.com/1507645/38738787-ed4a90d4-3f2a-11e8-8e0b-b067eac91302.gif)


Technical Details
----------------------------------------
New permissions were added to [existing ones](https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/Permission.php)
```php
      'edit system workflow message templates' => array(
        $prefix . ts('edit system workflow message templates'),
      ),
      'edit user-driven message templates' => array(
        $prefix . ts('edit user-driven message templates'),
      ),
```
and applied to [message template urls](https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/xml/Menu/Admin.xml#L258).
```php
<item>
     <path>civicrm/admin/messageTemplates</path>
     <title>Message Templates</title>
     <desc>Message templates allow you to save and re-use messages with layouts which you can use when sending email to one or more contacts.</desc>
     <page_callback>CRM_Admin_Page_MessageTemplates</page_callback>
     <adminGroup>Communications</adminGroup>
     <icon>admin/small/template.png</icon>
     <access_arguments>edit message templates;edit user-driven message templates;edit system workflow message templates</access_arguments>
     <weight>30</weight>
  </item>
```
Permission checks were applied on the [view page](https://github.com/civicrm/civicrm-core/blob/master/templates/CRM/Admin/Page/MessageTemplates.tpl), restricting tab access. Checks were also carried out while [building the form](https://github.com/civicrm/civicrm-core/blob/master/CRM/Admin/Form/MessageTemplates.php#L91) to ensure users with one permission, does not edit forms belonging to other permission group.
```php
  private function checkUserPermission($workflowId) {
    if (isset($workflowId)) {
      $canView = CRM_Core_Permission::check('edit system workflow message templates');
    } else {
      $canView = CRM_Core_Permission::check('edit user-driven message templates');
    }

    if (! $canView && ! CRM_Core_Permission::check('edit message templates')) {
      CRM_Core_Session::setStatus(ts('You do not have permission to view requested page.'), ts('Access Denied'));
      $url = CRM_Utils_System::url('civicrm/admin/messageTemplates', "reset=1");
      CRM_Utils_System::redirect($url);
    }
  }
```
For existing users to be aware of these changes, a pre-upgrade message notification was provided. This affords them the opportunity of deciding whether to upgrade existing user permissions or not.
```php
if ($rev == '5.2.alpha1') {
  $params = array(
    1 => 'edit user-driven message templates',
    2 => 'edit system workflow message templates',
    3 => 'edit message templates',
  );
  $preUpgradeMessage .= '<p>' . ts('New granular permissions called %1 and %2 have been added for %3 permission. These permissions help to limit user access per template', $params) . '</p>';
}
```