### PR TITLE
Fix failure to render dedupe page

### DIFF
--- a/CRM/Contact/Page/DedupeFind.php
+++ b/CRM/Contact/Page/DedupeFind.php
@@ -145,7 +145,7 @@ class CRM_Contact_Page_DedupeFind extends CRM_Core_Page_Basic {
         $urlQry['selected'] = 1;
       }
 
-      $this->assign('sourceUrl', CRM_Utils_System::url('civicrm/ajax/dedupefind', $urlQry));
+      $this->assign('sourceUrl', CRM_Utils_System::url('civicrm/ajax/dedupefind', $urlQry, FALSE, NULL, FALSE));
 
       //reload from cache table
       $cacheKeyString = CRM_Dedupe_Merger::getMergeCacheKeyString($rgid, $gid, $criteria);


### PR DESCRIPTION
Overview
----------------------------------------
5.1rc / master version of #11975 

Technical details
---------------------------------------
The issue was that in the patch & it drupal testing it appeared unnecessary to by-pass the html_entities function if the url query was passed to the url function as an array. The url_encode function encodes quotes so the html_entities function can no longer 'hurt' them.

However, the above testing was on drupal & it was not picked up that on wordpress the ajax POST to the url was failing because the ampersand was being encoded. Presumably drupal has some handling that disguised it on drupal.

This re-instates the html_entities bypass when generating the url passed to the template. The use of the array means they are still getting url_encoded which should be adequate to secure any pass-through params in links