### PR TITLE
CIVICRM-836: PR 11580 backported which fixes logging not be able to be enabled on Maria10.2

### DIFF
--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -288,7 +288,7 @@ AND    TABLE_NAME LIKE 'log_civicrm_%'
     $line = preg_grep("/^  `$col` /", $createQuery);
     $line = rtrim(array_pop($line), ',');
     // CRM-11179
-    $line = $this->fixTimeStampAndNotNullSQL($line);
+    $line = self::fixTimeStampAndNotNullSQL($line);
     return $line;
   }
 
@@ -325,9 +325,12 @@ AND    TABLE_NAME LIKE 'log_civicrm_%'
    *
    * @return mixed
    */
-  public function fixTimeStampAndNotNullSQL($query) {
+  public static function fixTimeStampAndNotNullSQL($query) {
+    $query = str_ireplace("TIMESTAMP() NOT NULL", "TIMESTAMP NULL", $query);
     $query = str_ireplace("TIMESTAMP NOT NULL", "TIMESTAMP NULL", $query);
+    $query = str_ireplace("DEFAULT CURRENT_TIMESTAMP() ON UPDATE CURRENT_TIMESTAMP()", '', $query);
     $query = str_ireplace("DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP", '', $query);
+    $query = str_ireplace("DEFAULT CURRENT_TIMESTAMP()", '', $query);
     $query = str_ireplace("DEFAULT CURRENT_TIMESTAMP", '', $query);
     $query = str_ireplace("NOT NULL", '', $query);
     return $query;

--- a/tests/phpunit/CRM/Logging/SchemaTest.php
+++ b/tests/phpunit/CRM/Logging/SchemaTest.php
@@ -1,0 +1,34 @@
+<?php
+require_once 'CiviTest/CiviUnitTestCase.php';
+
+/**
+ * Class CRM_Logging_SchmeaTest
+ * @group headless
+ */
+class CRM_Logging_SchemaTest extends CiviUnitTestCase {
+
+  public function setUp() {
+    parent::setUp();
+  }
+
+  public function tearDown() {
+    parent::tearDown();
+  }
+
+  public function queryExamples() {
+    $examples = [];
+    $examples[] = ["`modified_date` timestamp NULL DEFAULT current_timestamp() ON UPDATE current_timestamp() COMMENT 'When the mailing (or closely related entity) was created or modified or deleted.'", "`modified_date` timestamp NULL  COMMENT 'When the mailing (or closely related entity) was created or modified or deleted.'"];
+    $examples[] = ["`modified_date` timestamp NULL DEFAULT current_timestamp ON UPDATE current_timestamp COMMENT 'When the mailing (or closely related entity) was created or modified or deleted.'", "`modified_date` timestamp NULL  COMMENT 'When the mailing (or closely related entity) was created or modified or deleted.'"];
+    return $examples;
+  }
+
+  /**
+   * Tests the function fixTimeStampAndNotNullSQL in CRM_Logging_Schema
+   *
+   * @dataProvider queryExamples
+   */
+  public function testQueryRewrite($query, $expectedQuery) {
+    $this->assertEquals($expectedQuery, CRM_Logging_Schema::fixTimeStampAndNotNullSQL($query));
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
This is duplicate of #11580 for CiviCRM 4.6, PR for 4.7 is already merged.