### PR TITLE
Fix select2 value updation for crmAddName Directive

### DIFF
--- a/ang/crmCaseType.js
+++ b/ang/crmCaseType.js
@@ -103,7 +103,9 @@
         };
 
         $(input).crmSelect2({
-          data: scope[attrs.crmOptions],
+          data: function () {
+            return { results: scope[attrs.crmOptions] };
+          },
           createSearchChoice: function(term) {
             return {id: term, text: term + ' (' + ts('new') + ')'};
           },
@@ -115,11 +117,6 @@
           scope.$evalAsync(attrs.crmOnAdd);
           scope.$evalAsync('_resetSelection()');
           e.preventDefault();
-        });
-
-        scope.$watch(attrs.crmOptions, function(value) {
-          $(input).select2('data', scope[attrs.crmOptions]);
-          $(input).select2('val', '');
         });
       }
     };

--- a/tests/karma/unit/crmCaseTypeSpec.js
+++ b/tests/karma/unit/crmCaseTypeSpec.js
@@ -253,6 +253,34 @@ describe('crmCaseType', function() {
       expect(newSet.timeline).toBe('1');
       expect(newSet.label).toBe('Timeline #2');
     });
+  });
 
+  describe('crmAddName', function () {
+    var scope;
+    var element;
+
+    beforeEach(inject(function($rootScope, $compile) {
+      scope = $rootScope.$new();
+      scope.activityTypeOptions = [1, 2, 3];
+      element = '<span crm-add-name crm-options="activityTypeOptions"></span>';
+
+      spyOn(CRM.$.fn, 'crmSelect2').and.callThrough();
+
+      element = $compile(element)(scope);
+      scope.$digest();
+    }));
+
+    describe('when initialized', function () {
+      var returnValue;
+
+      beforeEach (function () {
+        var dataFunction = CRM.$.fn.crmSelect2.calls.argsFor(0)[0].data;
+        returnValue = dataFunction();
+      });
+
+      it('updates the UI with updated value of scope variable', function () {
+        expect(returnValue).toEqual({ results: scope.activityTypeOptions });
+      });
+    });
   });
 });


### PR DESCRIPTION
Overview
----------------------------------------
In `ang/crmCaseType.js`, `crmAddName` directive is present. But if the scope variable mentioned in `crm-options` is updated with new values, the select2 dropdown does not get updated with new values. 

This PR fixes the problem.

Before
----------------------------------------
The dropdown values does not update

After
----------------------------------------
The dropdown values updates

Technical Details
----------------------------------------
**How to reproduce?**
1. Go to https://github.com/civicrm/civicrm-core/blob/master/ang/crmCaseType.js#L128
2. And update the code in the following way 
```javascript
crmCaseType.controller('CaseTypeCtrl', function($scope, crmApi, apiCalls, $timeout) {
    ...
    $scope.activityTypeOptions = _.map(apiCalls.actTypes.values, formatActivityTypeOption);
    $timeout(function () {
      console.log('Scope variable updated');
      $scope.activityTypeOptions = [];
    }, 1000);
    ...
```
3. Open browser, see that in console `'Scope variable updated'` is printed but the dropdown values are not updated.

**Problem**
Previously the code used to update the the `select2` was ` $(input).select2('data', scope[attrs.crmOptions]);`, but it did not work.

**Solution**
Using a function instead of a variable inside the `data` object, solved the problem
Source: https://stackoverflow.com/a/17348414/2400594
```javascript
 data: function () {
   return { results: scope[attrs.crmOptions] };
 }
```
