### PR TITLE
Improvement to Relationship report: add address columsn dev/core/issues/62

### DIFF
--- a/CRM/Report/Form/Contact/Relationship.php
+++ b/CRM/Report/Form/Contact/Relationship.php
@@ -231,15 +231,15 @@ class CRM_Report_Form_Contact_Relationship extends CRM_Report_Form {
           'street_address_a' => array(
             'title' => ts('Street address (Contact A)'),
             'name' => 'street_address',
-					),
+          ),
           'city_a' => array(
             'title' => ts('City (Contact A)'),
-            'name' => 'city'
-					),
+            'name' => 'city',
+          ),
           'postal_code_a' => array(
             'title' => ts('Postal code (Contact A)'),
             'name' => 'postal_code',
-					),
+          ),
           'state_province_id_a' => array(
             'title' => ts('State/Province (Contact A)'),
             'name' => 'state_province_id',
@@ -254,15 +254,15 @@ class CRM_Report_Form_Contact_Relationship extends CRM_Report_Form {
           'street_address_b' => array(
             'title' => ts('Street address (Contact B)'),
             'name' => 'street_address',
-					),
+          ),
           'city_b' => array(
             'title' => ts('City (Contact B)'),
-            'name' => 'city'
-					),
+            'name' => 'city',
+          ),
           'postal_code_b' => array(
             'title' => ts('Postal code (Contact B)'),
             'name' => 'postal_code',
-					),
+          ),
           'state_province_id_b' => array(
             'title' => ts('State/Province (Contact B)'),
             'name' => 'state_province_id',
@@ -436,12 +436,12 @@ class CRM_Report_Form_Contact_Relationship extends CRM_Report_Form {
             if ($fieldName == 'phone_b') {
               $this->_phoneField_b = TRUE;
             }
-						if ($tableName == 'civicrm_address_a') {
-							$this->_addressField_a = TRUE;
-						}
-						if ($tableName == 'civicrm_address_b') {
-							$this->_addressField_b = TRUE;
-						}
+            if ($tableName == 'civicrm_address_a') {
+              $this->_addressField_a = TRUE;
+            }
+            if ($tableName == 'civicrm_address_b') {
+              $this->_addressField_b = TRUE;
+            }
             $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
             $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
             $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = CRM_Utils_Array::value('title', $field);
@@ -860,17 +860,17 @@ class CRM_Report_Form_Contact_Relationship extends CRM_Report_Form {
         $rows[$rowNum]['civicrm_relationship_relationship_id_hover'] = ts("Edit this relationship.");
         $entryFound = TRUE;
       }
-			
-			// Handle state province contact A
-			if (array_key_exists('civicrm_address_a_state_province_id_a', $row)) {
+
+      // Handle state province contact A
+      if (array_key_exists('civicrm_address_a_state_province_id_a', $row)) {
         if ($value = $row['civicrm_address_a_state_province_id_a']) {
           $rows[$rowNum]['civicrm_address_a_state_province_id_a'] = CRM_Core_PseudoConstant::stateProvince($value, FALSE);
         }
         $entryFound = TRUE;
       }
 
-			// Handle state province contact B
-			if (array_key_exists('civicrm_address_b_state_province_id_b', $row)) {
+      // Handle state province contact B
+      if (array_key_exists('civicrm_address_b_state_province_id_b', $row)) {
         if ($value = $row['civicrm_address_b_state_province_id_b']) {
           $rows[$rowNum]['civicrm_address_b_state_province_id_b'] = CRM_Core_PseudoConstant::stateProvince($value, FALSE);
         }

--- a/CRM/Report/Form/Contact/Relationship.php
+++ b/CRM/Report/Form/Contact/Relationship.php
@@ -39,6 +39,8 @@ class CRM_Report_Form_Contact_Relationship extends CRM_Report_Form {
   protected $_emailField_b = FALSE;
   protected $_phoneField_a = FALSE;
   protected $_phoneField_b = FALSE;
+  protected $_addressField_a = FALSE;
+  protected $_addressField_b = FALSE;
   protected $_customGroupExtends = array(
     'Relationship',
   );
@@ -222,6 +224,52 @@ class CRM_Report_Form_Contact_Relationship extends CRM_Report_Form {
         ),
         'grouping' => 'contact_b_fields',
       ),
+      'civicrm_address_a' => array(
+        'dao' => 'CRM_Core_DAO_Address',
+        'alias' => 'address_a',
+        'fields' => array(
+          'street_address_a' => array(
+            'title' => ts('Street address (Contact A)'),
+            'name' => 'street_address',
+					),
+          'city_a' => array(
+            'title' => ts('City (Contact A)'),
+            'name' => 'city'
+					),
+          'postal_code_a' => array(
+            'title' => ts('Postal code (Contact A)'),
+            'name' => 'postal_code',
+					),
+          'state_province_id_a' => array(
+            'title' => ts('State/Province (Contact A)'),
+            'name' => 'state_province_id',
+          ),
+        ),
+        'grouping' => 'contact_a_fields',
+      ),
+      'civicrm_address_b' => array(
+        'dao' => 'CRM_Core_DAO_Address',
+        'alias' => 'address_b',
+        'fields' => array(
+          'street_address_b' => array(
+            'title' => ts('Street address (Contact B)'),
+            'name' => 'street_address',
+					),
+          'city_b' => array(
+            'title' => ts('City (Contact B)'),
+            'name' => 'city'
+					),
+          'postal_code_b' => array(
+            'title' => ts('Postal code (Contact B)'),
+            'name' => 'postal_code',
+					),
+          'state_province_id_b' => array(
+            'title' => ts('State/Province (Contact B)'),
+            'name' => 'state_province_id',
+          ),
+        ),
+        'grouping' => 'contact_b_fields',
+      ),
       'civicrm_relationship_type' => array(
         'dao' => 'CRM_Contact_DAO_RelationshipType',
         'fields' => array(
@@ -388,6 +436,12 @@ class CRM_Report_Form_Contact_Relationship extends CRM_Report_Form {
             if ($fieldName == 'phone_b') {
               $this->_phoneField_b = TRUE;
             }
+						if ($tableName == 'civicrm_address_a') {
+							$this->_addressField_a = TRUE;
+						}
+						if ($tableName == 'civicrm_address_b') {
+							$this->_addressField_b = TRUE;
+						}
             $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
             $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
             $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = CRM_Utils_Array::value('title', $field);
@@ -460,6 +514,21 @@ class CRM_Report_Form_Contact_Relationship extends CRM_Report_Form {
                        ON ( {$this->_aliases['civicrm_contact_b']}.id =
                             {$this->_aliases['civicrm_phone_b']}.contact_id AND
                             {$this->_aliases['civicrm_phone_b']}.is_primary = 1 )";
+    }
+    // Include Address Field.
+    if ($this->_addressField_a) {
+      $this->_from .= "
+             LEFT JOIN civicrm_address {$this->_aliases['civicrm_address_a']}
+                       ON ( {$this->_aliases['civicrm_contact']}.id =
+                            {$this->_aliases['civicrm_address_a']}.contact_id AND
+                            {$this->_aliases['civicrm_address_a']}.is_primary = 1 )";
+    }
+    if ($this->_addressField_b) {
+      $this->_from .= "
+             LEFT JOIN civicrm_address {$this->_aliases['civicrm_address_b']}
+                       ON ( {$this->_aliases['civicrm_contact']}.id =
+                            {$this->_aliases['civicrm_address_b']}.contact_id AND
+                            {$this->_aliases['civicrm_address_b']}.is_primary = 1 )";
     }
   }
 
@@ -789,6 +858,22 @@ class CRM_Report_Form_Contact_Relationship extends CRM_Report_Form {
           $row['civicrm_relationship_relationship_id'];
         $rows[$rowNum]['civicrm_relationship_relationship_id_link'] = $url;
         $rows[$rowNum]['civicrm_relationship_relationship_id_hover'] = ts("Edit this relationship.");
+        $entryFound = TRUE;
+      }
+			
+			// Handle state province contact A
+			if (array_key_exists('civicrm_address_a_state_province_id_a', $row)) {
+        if ($value = $row['civicrm_address_a_state_province_id_a']) {
+          $rows[$rowNum]['civicrm_address_a_state_province_id_a'] = CRM_Core_PseudoConstant::stateProvince($value, FALSE);
+        }
+        $entryFound = TRUE;
+      }
+
+			// Handle state province contact B
+			if (array_key_exists('civicrm_address_b_state_province_id_b', $row)) {
+        if ($value = $row['civicrm_address_b_state_province_id_b']) {
+          $rows[$rowNum]['civicrm_address_b_state_province_id_b'] = CRM_Core_PseudoConstant::stateProvince($value, FALSE);
+        }
         $entryFound = TRUE;
       }
 

--- a/CRM/Report/Form/Contact/Relationship.php
+++ b/CRM/Report/Form/Contact/Relationship.php
@@ -526,7 +526,7 @@ class CRM_Report_Form_Contact_Relationship extends CRM_Report_Form {
     if ($this->_addressField_b) {
       $this->_from .= "
              LEFT JOIN civicrm_address {$this->_aliases['civicrm_address_b']}
-                       ON ( {$this->_aliases['civicrm_contact']}.id =
+                       ON ( {$this->_aliases['civicrm_contact_b']}.id =
                             {$this->_aliases['civicrm_address_b']}.contact_id AND
                             {$this->_aliases['civicrm_address_b']}.is_primary = 1 )";
     }


### PR DESCRIPTION
Added address fields to the Relationship report. So that a user can display the address of contact a or contact b.

See issue at gitlab: https://lab.civicrm.org/dev/core/issues/62