### PR TITLE
issue 63 clarify permission descriptions

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -736,7 +736,7 @@ class CRM_Core_Permission {
       ),
       'profile listings' => array(
         $prefix . ts('profile listings'),
-        ts('Warning: Give to trusted roles only; this permission has privacy implications. Access public searchable directories.')
+        ts('Warning: Give to trusted roles only; this permission has privacy implications. Access public searchable directories.'),
       ),
       'profile create' => array(
         $prefix . ts('profile create'),
@@ -748,7 +748,7 @@ class CRM_Core_Permission {
       ),
       'profile view' => array(
         $prefix . ts('profile view'),
-        ts('View data in a profile.')
+        ts('View data in a profile.'),
       ),
       'access all custom data' => array(
         $prefix . ts('access all custom data'),

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -724,7 +724,7 @@ class CRM_Core_Permission {
       ),
       'skip IDS check' => array(
         $prefix . ts('skip IDS check'),
-        ts('IDS system is bypassed for users with this permission. Prevents false errors for admin users.'),
+        ts('Warning: Give to trusted roles only; this permission has security implications. IDS system is bypassed for users with this permission. Prevents false errors for admin users.'),
       ),
       'access uploaded files' => array(
         $prefix . ts('access uploaded files'),
@@ -732,21 +732,23 @@ class CRM_Core_Permission {
       ),
       'profile listings and forms' => array(
         $prefix . ts('profile listings and forms'),
-        ts('Access the profile Search form and listings'),
+        ts('Warning: Give to trusted roles only; this permission has privacy implications. Add/edit data in online forms and access public searchable directories.'),
       ),
       'profile listings' => array(
         $prefix . ts('profile listings'),
+        ts('Warning: Give to trusted roles only; this permission has privacy implications. Access public searchable directories.')
       ),
       'profile create' => array(
         $prefix . ts('profile create'),
-        ts('Use profiles in Create mode'),
+        ts('Add data in a profile form.'),
       ),
       'profile edit' => array(
         $prefix . ts('profile edit'),
-        ts('Use profiles in Edit mode'),
+        ts('Edit data in a profile form.'),
       ),
       'profile view' => array(
         $prefix . ts('profile view'),
+        ts('View data in a profile.')
       ),
       'access all custom data' => array(
         $prefix . ts('access all custom data'),
@@ -760,8 +762,8 @@ class CRM_Core_Permission {
         $prefix . ts('Delete activities'),
       ),
       'access CiviCRM' => array(
-        $prefix . ts('access CiviCRM'),
-        ts('Master control for access to the main CiviCRM backend and API'),
+        $prefix . ts('access CiviCRM backend and API'),
+        ts('Master control for access to the main CiviCRM backend and API. Give to trusted roles only.'),
       ),
       'access Contact Dashboard' => array(
         $prefix . ts('access Contact Dashboard'),


### PR DESCRIPTION
Addresses https://lab.civicrm.org/dev/core/issues/63

Improve the clarity of certain permissions, including the profile permissions. Currently they either have no description, no warning if the permission has privacy implications, or the description is vague.
