### PR TITLE
Namespace exception in test

### DIFF
--- a/Civi/Test/Api3TestTrait.php
+++ b/Civi/Test/Api3TestTrait.php
@@ -202,7 +202,7 @@ trait Api3TestTrait {
     );
     $result = $this->civicrm_api($entity, 'getsingle', $params);
     if (!is_array($result) || !empty($result['is_error']) || isset($result['values'])) {
-      throw new Exception('Invalid getsingle result' . print_r($result, TRUE));
+      throw new \Exception('Invalid getsingle result' . print_r($result, TRUE));
     }
     if ($checkAgainst) {
       // @todo - have gone with the fn that unsets id? should we check id?


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a fatal I hit running only some tests without the full suite

Before
----------------------------------------
Fatal looking for \CiviUnitTestCase\Exception

After
----------------------------------------
No fatal

Technical Details
----------------------------------------
Perhaps a different exception makes more sense but this gets us past the fatal error & feels like a suitable scale of response


