### PR TITLE
[dev/core#51] Fix incorrect output of master address in contact export.

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -804,9 +804,9 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
               $masterAddressId = NULL;
               if (isset($iterationDAO->$field)) {
                 $masterAddressId = $iterationDAO->$field;
+                // get display name of contact that address is shared.
+                $fieldValue = CRM_Contact_BAO_Contact::getMasterDisplayName($masterAddressId, $iterationDAO->contact_id);
               }
-              // get display name of contact that address is shared.
-              $fieldValue = CRM_Contact_BAO_Contact::getMasterDisplayName($masterAddressId, $iterationDAO->contact_id);
             }
           }
 


### PR DESCRIPTION
Overview
----------------------------------------
When exporting contacts with multiple addresses, for every address there is a master (shared) address exported, although the shared address is not the master address for the selected criteria (location type or is_primary).

Before
----------------------------------------
[Selected fields for export](https://lab.civicrm.org/dev/core/uploads/e9453649f5cbf5e55523b08844102830/Export_Setting.png)
[Result](https://lab.civicrm.org/dev/core/uploads/6a8ef4b534681980a51d97a4a0ab8c62/Export_result.png)

After
----------------------------------------
The correct behavior is to only export a master address if there is one for the selected criteria.

Technical Details
----------------------------------------
Problem being that, if there is no `$masterAddressId` given as parameter, `CRM_Contact_BAO_Contact::getMasterDisplayName()` will return the first master address of any address connected with the given contact it finds. Thus, the field value for the master address should only be set using this method, if there is a master address ID retrieved previously.

Comments
----------------------------------------
Only tested for the export critera specified in the linked screenshots.
See issue [dev/core#51](https://lab.civicrm.org/dev/core/issues/51) for more details on the scenario.