### PR TITLE
Add New API Call To Get All Unique Fields For Given Entity

### DIFF
--- a/api/v3/Generic/Getunique.php
+++ b/api/v3/Generic/Getunique.php
@@ -1,0 +1,56 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2017                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * @package CiviCRM_APIv3
+ */
+
+/**
+ * Generic api wrapper used to get all unique fields for a given entity.
+ *
+ * @param array $apiRequest
+ *
+ * @return mixed
+ */
+function civicrm_api3_generic_getUnique($apiRequest) {
+  $entity = _civicrm_api_get_entity_name_from_camel($apiRequest['entity']);
+  $uniqueFields = array();
+
+  $baoName = _civicrm_api3_get_BAO($entity);
+  $bao = new $baoName();
+  $_entityTable = $bao->tableName();
+
+  $sql = 'SHOW INDEX FROM '.$_entityTable.' WHERE Non_unique = 0';
+  $uFields = CRM_Core_DAO::executeQuery($sql)->fetchAll();
+  foreach($uFields as $field) {
+    // group by Key_name to handle combination indexes
+    $uniqueFields[$field['Key_name']][] = $field['Column_name'];
+  }
+
+  return civicrm_api3_create_success($uniqueFields);
+}
+

--- a/api/v3/Generic/Getunique.php
+++ b/api/v3/Generic/Getunique.php
@@ -40,15 +40,14 @@ function civicrm_api3_generic_getUnique($apiRequest) {
   $entity = _civicrm_api_get_entity_name_from_camel($apiRequest['entity']);
   $uniqueFields = array();
 
-  $baoName = _civicrm_api3_get_BAO($entity);
-  $bao = new $baoName();
-  $_entityTable = $bao->tableName();
+  $dao = _civicrm_api3_get_DAO($entity);
+  $uFields = $dao::indices();
 
-  $sql = 'SHOW INDEX FROM '.$_entityTable.' WHERE Non_unique = 0';
-  $uFields = CRM_Core_DAO::executeQuery($sql)->fetchAll();
-  foreach($uFields as $field) {
-    // group by Key_name to handle combination indexes
-    $uniqueFields[$field['Key_name']][] = $field['Column_name'];
+  foreach($uFields as $fieldKey => $field) {
+    if(!isset($field['unique']) || !$field['unique']) {
+      continue;
+    }
+    $uniqueFields[$fieldKey] = $field['field'];
   }
 
   return civicrm_api3_create_success($uniqueFields);

--- a/api/v3/Generic/Getunique.php
+++ b/api/v3/Generic/Getunique.php
@@ -36,7 +36,7 @@
  *
  * @return mixed
  */
-function civicrm_api3_generic_getUnique($apiRequest) {
+function civicrm_api3_generic_getunique($apiRequest) {
   $entity = _civicrm_api_get_entity_name_from_camel($apiRequest['entity']);
   $uniqueFields = array();
 

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -3763,4 +3763,13 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     $this->customGroupDelete($ids['custom_group_id']);
   }
 
+  /**
+   * Test getunique api call for Contact entity
+   */
+  public function testContactGetUnique() {
+    $result = $this->callAPIAndDocument($this->_entity, 'getunique', array(), __FUNCTION__, __FILE__);
+    $this->assertEquals(1, $result['count']);
+    $this->assertEquals(array('external_identifier'), $result['values']['UI_external_identifier']);
+  }
+
 }

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -4130,4 +4130,14 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     return array_merge(CRM_Financial_BAO_FinancialItem::retrieveEntityFinancialTrxn($trxnParams, FALSE, array()));
   }
 
+  /**
+   * Test getunique api call for Contribution entity
+   */
+  public function testContributionGetUnique() {
+    $result = $this->callAPIAndDocument($this->_entity, 'getunique', array(), __FUNCTION__, __FILE__);
+    $this->assertEquals(2, $result['count']);
+    $this->assertEquals(array('trxn_id'), $result['values']['UI_contrib_trxn_id']);
+    $this->assertEquals(array('invoice_id'), $result['values']['UI_contrib_invoice_id']);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
This is a new api that will go through the indexes of an entity table and return all unique fields (including combination indexes).
This feature was proposed in a disscusion here
https://github.com/eileenmcnaughton/nz.co.fuzion.csvimport/issues/13

Before
----------------------------------------
It's not currently possible to get a list of unique fields (or combinations) for a given entity.

After
----------------------------------------
A new api is added to get a list of all unique fields for a given entity.

Technical Details
----------------------------------------
Sample API call using 'Contribution' entity:
`$result = civicrm_api3('Contribution', 'getunique');`

Result:
```
{
    "is_error": 0,
    "version": 3,
    "count": 2,
    "values": {
        "UI_contrib_trxn_id": [
            "trxn_id"
        ],
        "UI_contrib_invoice_id": [
            "invoice_id"
        ]
    }
}
```