### PR TITLE
Fix the contact merge form on Drupal 8

### DIFF
--- a/CRM/Contact/Form/Merge.php
+++ b/CRM/Contact/Form/Merge.php
@@ -120,16 +120,9 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
       $mainUfId = CRM_Core_BAO_UFMatch::getUFId($this->_cid);
       $mainUser = NULL;
       if ($mainUfId) {
-        // d6 compatible
-        if ($config->userSystem->is_drupal == '1') {
-          $mainUser = user_load($mainUfId);
-        }
-        elseif ($config->userFramework == 'Joomla') {
-          $mainUser = JFactory::getUser($mainUfId);
-        }
-
+        $mainUser = $config->userSystem->getUser($this->_cid);
         $this->assign('mainUfId', $mainUfId);
-        $this->assign('mainUfName', $mainUser ? $mainUser->name : NULL);
+        $this->assign('mainUfName', $mainUser ? $mainUser['name'] : NULL);
       }
       $flipParams = array_merge($urlParams, ['action' => 'update', 'cid' => $this->_oid, 'oid' => $this->_cid]);
       if (!$flip) {
@@ -164,16 +157,9 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
       $otherUser = NULL;
 
       if ($otherUfId) {
-        // d6 compatible
-        if ($config->userSystem->is_drupal == '1') {
-          $otherUser = user_load($otherUfId);
-        }
-        elseif ($config->userFramework == 'Joomla') {
-          $otherUser = JFactory::getUser($otherUfId);
-        }
-
+        $otherUser = $config->userSystem->getUser($this->_oid);
         $this->assign('otherUfId', $otherUfId);
-        $this->assign('otherUfName', $otherUser ? $otherUser->name : NULL);
+        $this->assign('otherUfName', $otherUser ? $otherUser['name'] : NULL);
       }
 
       $cmsUser = ($mainUfId && $otherUfId) ? TRUE : FALSE;

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -572,6 +572,16 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
   /**
    * @inheritDoc
    */
+  public function getUser($contactID) {
+    $user_details = parent::getUser($contactID);
+    $user_details['name'] = $user_details['name']->value;
+    $user_details['email'] = $user_details['email']->value;
+    return $user_details;
+  }
+
+  /**
+   * @inheritDoc
+   */
   public function getUniqueIdentifierFromUserObject($user) {
     return $user->get('mail')->value;
   }

--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -641,6 +641,16 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
   /**
    * @inheritDoc
    */
+  public function getUser($contactID) {
+    $user_details = parent::getUser($contactID);
+    $user = JFactory::getUser($user_details['id']);
+    $user_details['name'] = $user->name;
+    return $user_details;
+  }
+
+  /**
+   * @inheritDoc
+   */
   public function getUserIDFromUserObject($user) {
     return !empty($user->id) ? $user->id : NULL;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Attempting to merge contacts which are associated with Drupal users will result in a fatal error.

Before
----------------------------------------

The steps to reproduce are basically:

1. Create two new contacts with the same name
2. Go to Search -> Find contacts and search for that name
3. Select both and click "Merge contacts"
4. Get a recoverable fatal error!

Here's the stack trace we get:

> Recoverable fatal error: Object of class Drupal\Core\Field\FieldItemList could not be converted to string in include() (line 222 of /srv/bindings/4e16373a1b93425ab737c843ea127734/files/private/civicrm/templates_c/en_US/%%8B/8B3/8B3565BB%%Merge.tpl.php)
> #0 /srv/bindings/4e16373a1b93425ab737c843ea127734/code/web/core/includes/bootstrap.inc(566): _drupal_error_handler_real(4096, &#039;Object of class...&#039;, &#039;/srv/bindings/4...&#039;, 222, Array)
> #1 /srv/bindings/4e16373a1b93425ab737c843ea127734/files/private/civicrm/templates_c/en_US/%%8B/8B3/8B3565BB%%Merge.tpl.php(222): _drupal_error_handler(4096, &#039;Object of class...&#039;, &#039;/srv/bindings/4...&#039;, 222, Array)
> #2 /srv/bindings/4e16373a1b93425ab737c843ea127734/code/vendor/civicrm/civicrm-core/packages/Smarty/Smarty.class.php(1911): include(&#039;/srv/bindings/4...&#039;)
> #3 /srv/bindings/4e16373a1b93425ab737c843ea127734/files/private/civicrm/templates_c/en_US/%%0C/0CB/0CBEC124%%default.tpl.php(19): Smarty-&gt;_smarty_include(Array)
> #4 /srv/bindings/4e16373a1b93425ab737c843ea127734/code/vendor/civicrm/civicrm-core/packages/Smarty/Smarty.class.php(1911): include(&#039;/srv/bindings/4...&#039;)
> #5 /srv/bindings/4e16373a1b93425ab737c843ea127734/files/private/civicrm/templates_c/en_US/%%2B/2BD/2BD99720%%drupal8.tpl.php(56): Smarty-&gt;_smarty_include(Array)
> #6 /srv/bindings/4e16373a1b93425ab737c843ea127734/code/vendor/civicrm/civicrm-core/packages/Smarty/Smarty.class.php(1270): include(&#039;/srv/bindings/4...&#039;)
> #7 /srv/bindings/4e16373a1b93425ab737c843ea127734/code/vendor/civicrm/civicrm-core/CRM/Core/Smarty.php(197): Smarty-&gt;fetch(&#039;CRM/common/drup...&#039;, NULL, NULL, false)
> #8 /srv/bindings/4e16373a1b93425ab737c843ea127734/code/vendor/civicrm/civicrm-core/CRM/Core/QuickForm/Action/Display.php(133): CRM_Core_Smarty-&gt;fetch(&#039;CRM/common/drup...&#039;)
> #9 /srv/bindings/4e16373a1b93425ab737c843ea127734/code/vendor/civicrm/civicrm-core/CRM/Core/QuickForm/Action/Display.php(99): CRM_Core_QuickForm_Action_Display-&gt;renderForm(Object(CRM_Contact_Form_Merge))
> #10 /srv/bindings/4e16373a1b93425ab737c843ea127734/code/vendor/civicrm/civicrm-core/packages/HTML/QuickForm/Controller.php(203): CRM_Core_QuickForm_Action_Display-&gt;perform(Object(CRM_Contact_Form_Merge), &#039;display&#039;)
> #11 /srv/bindings/4e16373a1b93425ab737c843ea127734/code/vendor/civicrm/civicrm-core/packages/HTML/QuickForm/Page.php(103): HTML_QuickForm_Controller-&gt;handle(Object(CRM_Contact_Form_Merge), &#039;display&#039;)
> #12 /srv/bindings/4e16373a1b93425ab737c843ea127734/code/vendor/civicrm/civicrm-core/CRM/Core/Controller.php(351): HTML_QuickForm_Page-&gt;handle(&#039;display&#039;)
> #13 /srv/bindings/4e16373a1b93425ab737c843ea127734/code/vendor/civicrm/civicrm-core/CRM/Utils/Wrapper.php(113): CRM_Core_Controller-&gt;run()
> #14 /srv/bindings/4e16373a1b93425ab737c843ea127734/code/vendor/civicrm/civicrm-core/CRM/Core/Invoke.php(282): CRM_Utils_Wrapper-&gt;run(&#039;CRM_Contact_For...&#039;, &#039;Merge Contact&#039;, Array)
> #15 /srv/bindings/4e16373a1b93425ab737c843ea127734/code/vendor/civicrm/civicrm-core/CRM/Core/Invoke.php(84): CRM_Core_Invoke::runItem(Array)
> #16 /srv/bindings/4e16373a1b93425ab737c843ea127734/code/vendor/civicrm/civicrm-core/CRM/Core/Invoke.php(52): CRM_Core_Invoke::_invoke(Array)
> #17 /srv/bindings/4e16373a1b93425ab737c843ea127734/code/web/modules/contrib/civicrm/src/Civicrm.php(68): CRM_Core_Invoke::invoke(Array)
> #18 /srv/bindings/4e16373a1b93425ab737c843ea127734/code/web/modules/contrib/civicrm/src/Controller/CivicrmController.php(47): Drupal\civicrm\Civicrm-&gt;invoke(Array)
> #19 [internal function]: Drupal\civicrm\Controller\CivicrmController-&gt;main(Array, &#039;&#039;)
> #20 /srv/bindings/4e16373a1b93425ab737c843ea127734/code/web/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php(123): call_user_func_array(Array, Array)
> #21 /srv/bindings/4e16373a1b93425ab737c843ea127734/code/web/core/lib/Drupal/Core/Render/Renderer.php(582): Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber-&gt;Drupal\Core\EventSubscriber\{closure}()
> #22 /srv/bindings/4e16373a1b93425ab737c843ea127734/code/web/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php(124): Drupal\Core\Render\Renderer-&gt;executeInRenderContext(Object(Drupal\Core\Render\RenderContext), Object(Closure))
> #23 /srv/bindings/4e16373a1b93425ab737c843ea127734/code/web/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php(97): Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber-&gt;wrapControllerExecutionInRenderContext(Array, Array)
> #24 [internal function]: Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber-&gt;Drupal\Core\EventSubscriber\{closure}()
> #25 /srv/bindings/4e16373a1b93425ab737c843ea127734/code/vendor/symfony/http-kernel/HttpKernel.php(153): call_user_func_array(Object(Closure), Array)
> #26 /srv/bindings/4e16373a1b93425ab737c843ea127734/code/vendor/symfony/http-kernel/HttpKernel.php(68): Symfony\Component\HttpKernel\HttpKernel-&gt;handleRaw(Object(Symfony\Component\HttpFoundation\Request), 1)
> #27 /srv/bindings/4e16373a1b93425ab737c843ea127734/code/web/core/lib/Drupal/Core/StackMiddleware/Session.php(57): Symfony\Component\HttpKernel\HttpKernel-&gt;handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
> #28 /srv/bindings/4e16373a1b93425ab737c843ea127734/code/web/core/lib/Drupal/Core/StackMiddleware/KernelPreHandle.php(47): Drupal\Core\StackMiddleware\Session-&gt;handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
> #29 /srv/bindings/4e16373a1b93425ab737c843ea127734/code/web/core/modules/page_cache/src/StackMiddleware/PageCache.php(99): Drupal\Core\StackMiddleware\KernelPreHandle-&gt;handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
> #30 /srv/bindings/4e16373a1b93425ab737c843ea127734/code/web/core/modules/page_cache/src/StackMiddleware/PageCache.php(78): Drupal\page_cache\StackMiddleware\PageCache-&gt;pass(Object(Symfony\Component\HttpFoundation\Request), 1, true)
> #31 /srv/bindings/4e16373a1b93425ab737c843ea127734/code/web/core/lib/Drupal/Core/StackMiddleware/ReverseProxyMiddleware.php(47): Drupal\page_cache\StackMiddleware\PageCache-&gt;handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
> #32 /srv/bindings/4e16373a1b93425ab737c843ea127734/code/web/core/lib/Drupal/Core/StackMiddleware/NegotiationMiddleware.php(50): Drupal\Core\StackMiddleware\ReverseProxyMiddleware-&gt;handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
> #33 /srv/bindings/4e16373a1b93425ab737c843ea127734/code/vendor/stack/builder/src/Stack/StackedHttpKernel.php(23): Drupal\Core\StackMiddleware\NegotiationMiddleware-&gt;handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
> #34 /srv/bindings/4e16373a1b93425ab737c843ea127734/code/web/core/lib/Drupal/Core/DrupalKernel.php(664): Stack\StackedHttpKernel-&gt;handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
> #35 /srv/bindings/4e16373a1b93425ab737c843ea127734/code/web/index.php(19): Drupal\Core\DrupalKernel-&gt;handle(Object(Symfony\Component\HttpFoundation\Request))
> #36 {main}.

After
----------------------------------------

The form works as expected!

Technical Details
----------------------------------------

The problematic code is basically two instances of this:

```
       if ($config->userSystem->is_drupal == '1') {
         $mainUser = user_load($mainUfId);
       }
       elseif ($config->userFramework == 'Joomla') {
         $mainUser = JFactory::getUser($mainUfId);
       }
       $this->assign('mainUfName', $mainUser ? $mainUser->name : NULL);
```

While `user_load()` will actually work in Drupal 8, the name field is accessed like `$mainUser->name->value` (because in Drupal 8 all entity properties are fields).

Instead of directly using Drupal-specific code, this PR changes to using a pre-existing method: `$config->userSystem->getUser()`

However, it updates the Drupal 8 implementation to actually work, and also adds a Joomla one to make sure the name is set the same way as the original code. I don't know anything about Joomla and didn't test that, so I'll need some advice on if that was the right thing to do!

But the Drupal 8 is good, and tested :-)
