### PR TITLE
Standardise Address code in Contact summary report & enable links

### DIFF
--- a/CRM/Report/Form/Contact/Summary.php
+++ b/CRM/Report/Form/Contact/Summary.php
@@ -131,7 +131,7 @@ class CRM_Report_Form_Contact_Summary extends CRM_Report_Form {
         ),
         'grouping' => 'contact-fields',
       ),
-    ) + $this->getAddressColumns(array('group_by' => FALSE));
+    ) + $this->getAddressColumns(array('group_bys' => FALSE));
 
     $this->_groupFilter = TRUE;
     $this->_tagFilter = TRUE;
@@ -140,29 +140,6 @@ class CRM_Report_Form_Contact_Summary extends CRM_Report_Form {
 
   public function preProcess() {
     parent::preProcess();
-  }
-
-  public function select() {
-    $select = array();
-    $this->_columnHeaders = array();
-    foreach ($this->_columns as $tableName => $table) {
-      if (array_key_exists('fields', $table)) {
-        foreach ($table['fields'] as $fieldName => $field) {
-          if (!empty($field['required']) ||
-            !empty($this->_params['fields'][$fieldName])
-          ) {
-
-            $alias = "{$tableName}_{$fieldName}";
-            $select[] = "{$field['dbAlias']} as {$alias}";
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'];
-            $this->_selectAliases[] = $alias;
-          }
-        }
-      }
-    }
-
-    $this->_select = "SELECT " . implode(', ', $select) . " ";
   }
 
   /**
@@ -179,10 +156,8 @@ class CRM_Report_Form_Contact_Summary extends CRM_Report_Form {
 
   public function from() {
     $this->_from = "
-        FROM civicrm_contact {$this->_aliases['civicrm_contact']} {$this->_aclFrom}
-            LEFT JOIN civicrm_address {$this->_aliases['civicrm_address']}
-                   ON ({$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_address']}.contact_id AND
-                      {$this->_aliases['civicrm_address']}.is_primary = 1 ) ";
+        FROM civicrm_contact {$this->_aliases['civicrm_contact']} {$this->_aclFrom} ";
+    $this->joinAddressFromContact();
     $this->joinPhoneFromContact();
     $this->joinEmailFromContact();
     $this->joinCountryFromAddress();
@@ -229,20 +204,6 @@ class CRM_Report_Form_Contact_Summary extends CRM_Report_Form {
         );
         $rows[$rowNum]['civicrm_contact_sort_name_link'] = $url;
         $rows[$rowNum]['civicrm_contact_sort_name_hover'] = ts('View Contact Detail Report for this contact');
-        $entryFound = TRUE;
-      }
-
-      if (array_key_exists('civicrm_address_state_province_id', $row)) {
-        if ($value = $row['civicrm_address_state_province_id']) {
-          $rows[$rowNum]['civicrm_address_state_province_id'] = CRM_Core_PseudoConstant::stateProvince($value, FALSE);
-        }
-        $entryFound = TRUE;
-      }
-
-      if (array_key_exists('civicrm_address_country_id', $row)) {
-        if ($value = $row['civicrm_address_country_id']) {
-          $rows[$rowNum]['civicrm_address_country_id'] = CRM_Core_PseudoConstant::country($value, FALSE);
-        }
         $entryFound = TRUE;
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
Refactor of Address related code as part of a drive to get addresses for multiple contacts in one report (relationship).

Before
----------------------------------------
![screenshot 2018-04-18 22 00 33](https://user-images.githubusercontent.com/336308/38925519-fa032bd8-4353-11e8-873c-5dc3d1b1a783.png)


After
----------------------------------------
Click throughs on state & country (similar to other reports but there is some more sugar in some others we might incorporate later)
![screenshot 2018-04-18 22 01 14](https://user-images.githubusercontent.com/336308/38925544-0a91e098-4354-11e8-9930-4717e623b409.png)


Technical Details
----------------------------------------
This adds prefixing into the function used to add the columns. Approach is taken from extended reports

Comments
----------------------------------------

See https://lab.civicrm.org/dev/core/issues/66
