### PR TITLE
dev/core#107: Add default assignee when creating cases

### DIFF
--- a/CRM/Core/BAO/OptionValue.php
+++ b/CRM/Core/BAO/OptionValue.php
@@ -547,16 +547,23 @@ class CRM_Core_BAO_OptionValue extends CRM_Core_DAO_OptionValue {
    * that an option value exists, without hitting an error if it already exists.
    *
    * This is sympathetic to sites who might pre-add it.
+   *
+   * @param array $params the option value attributes.
+   * @return array the option value attributes.
    */
   public static function ensureOptionValueExists($params) {
-    $existingValues = civicrm_api3('OptionValue', 'get', array(
+    $result = civicrm_api3('OptionValue', 'get', array(
       'option_group_id' => $params['option_group_id'],
       'name' => $params['name'],
-      'return' => 'id',
+      'return' => ['id', 'value'],
+      'sequential' => 1,
     ));
-    if (!$existingValues['count']) {
-      civicrm_api3('OptionValue', 'create', $params);
+
+    if (!$result['count']) {
+      $result = civicrm_api3('OptionValue', 'create', $params);
     }
+
+    return CRM_Utils_Array::first($result['values']);
   }
 
 }

--- a/CRM/Upgrade/Incremental/php/FiveFour.php
+++ b/CRM/Upgrade/Incremental/php/FiveFour.php
@@ -73,6 +73,42 @@ class CRM_Upgrade_Incremental_php_FiveFour extends CRM_Upgrade_Incremental_Base 
       'civicrm_uf_group', 'add_cancel_button', "tinyint DEFAULT '1' COMMENT 'Should a Cancel button be included in this Profile form.'");
     $this->addTask('Add location_id if missing to group_contact table (affects some older installs CRM-20711)', 'addColumn',
       'civicrm_group_contact', 'location_id', "int(10) unsigned DEFAULT NULL COMMENT 'Optional location to associate with this membership'");
+    $this->addTask('dev/core#107 - Add Activity\'s default assignee options', 'addActivityDefaultAssigneeOptions');
+  }
+
+  /**
+   * This task adds the default assignee option values that can be selected when
+   * creating or editing a new workflow's activity.
+   *
+   * @return bool
+   */
+  public static function addActivityDefaultAssigneeOptions() {
+    // Add option group for activity default assignees:
+    CRM_Core_BAO_OptionGroup::ensureOptionGroupExists(array(
+      'name' => 'activity_default_assignee',
+      'title' => ts('Activity default assignee'),
+      'is_reserved' => 1,
+    ));
+
+    // Add option values for activity default assignees:
+    $options = array(
+      array('name' => 'NONE', 'label' => ts('None'), 'is_default' => 1),
+      array('name' => 'BY_RELATIONSHIP', 'label' => ts('By relationship to case client')),
+      array('name' => 'SPECIFIC_CONTACT', 'label' => ts('Specific contact')),
+      array('name' => 'USER_CREATING_THE_CASE', 'label' => ts('User creating the case')),
+    );
+
+    foreach ($options as $option) {
+      CRM_Core_BAO_OptionValue::ensureOptionValueExists(array(
+        'option_group_id' => 'activity_default_assignee',
+        'name' => $option['name'],
+        'label' => $option['label'],
+        'is_default' => CRM_Utils_Array::value('is_default', $option, 0),
+        'is_active' => TRUE,
+      ));
+    }
+
+    return TRUE;
   }
 
   /*

--- a/ang/crmCaseType.js
+++ b/ang/crmCaseType.js
@@ -264,9 +264,32 @@
       $scope.relationshipTypeOptions = _.map(apiCalls.relTypes.values, function(type) {
         return {id: type[REL_TYPE_CNAME], text: type.label_b_a};
       });
+      $scope.defaultRelationshipTypeOptions = getDefaultRelationshipTypeOptions();
       // stores the default assignee values indexed by their option name:
       $scope.defaultAssigneeTypeValues = _.chain($scope.defaultAssigneeTypes)
         .indexBy('name').mapValues('value').value();
+    }
+
+    /// Returns the default relationship type options. If the relationship is
+    /// bidirectional (Ex: Spouse of) it adds a single option otherwise it adds
+    /// two options representing the relationship type directions
+    /// (Ex: Employee of, Employer is)
+    function getDefaultRelationshipTypeOptions() {
+      return _.transform(apiCalls.relTypes.values, function(result, relType) {
+        var isBidirectionalRelationship = relType.label_a_b === relType.label_b_a;
+
+        result.push({
+          label: relType.label_b_a,
+          value: relType.id + '_b_a'
+        });
+
+        if (!isBidirectionalRelationship) {
+          result.push({
+            label: relType.label_a_b,
+            value: relType.id + '_a_b'
+          });
+        }
+      }, []);
     }
 
     /// initializes the case type object

--- a/ang/crmCaseType/timelineTable.html
+++ b/ang/crmCaseType/timelineTable.html
@@ -76,7 +76,7 @@ Required vars: activitySet
           ui-jq="select2"
           ui-options="{dropdownAutoWidth: true}"
           ng-model="activity.default_assignee_relationship"
-          ng-options="option.id as option.text for option in relationshipTypeOptions"
+          ng-options="option.value as option.label for option in defaultRelationshipTypeOptions"
           required
         ></select>
       </p>

--- a/ang/crmCaseType/timelineTable.html
+++ b/ang/crmCaseType/timelineTable.html
@@ -11,6 +11,7 @@ Required vars: activitySet
     <th>{{ts('Reference')}}</th>
     <th>{{ts('Offset')}}</th>
     <th>{{ts('Select')}}</th>
+    <th>{{ts('Default assignee')}}</th>
     <th></th>
   </tr>
   </thead>
@@ -21,13 +22,13 @@ Required vars: activitySet
       <i class="crm-i fa-arrows grip-n-drag"></i>
     </td>
     <td>
-      <i class="crm-i {{ activityTypes[activity.name].icon }}"></i>
-      {{ activity.label }}
+      <i class="crm-i {{activityTypes[activity.name].icon}}"></i>
+      {{activity.label}}
     </td>
     <td>
       <select
         ui-jq="select2"
-        ui-options="{dropdownAutoWidth : true}"
+        ui-options="{dropdownAutoWidth: true}"
         ng-model="activity.status"
         ng-options="actStatus.name as actStatus.label for actStatus in activityStatuses|orderBy:'label'"
         >
@@ -37,7 +38,7 @@ Required vars: activitySet
     <td>
       <select
         ui-jq="select2"
-        ui-options="{dropdownAutoWidth : true}"
+        ui-options="{dropdownAutoWidth: true}"
         ng-model="activity.reference_activity"
         ng-options="activityType.name as activityType.label for activityType in caseType.definition.timelineActivityTypes"
         >
@@ -55,11 +56,40 @@ Required vars: activitySet
     <td>
       <select
         ui-jq="select2"
-        ui-options="{dropdownAutoWidth : true}"
+        ui-options="{dropdownAutoWidth: true}"
         ng-model="activity.reference_select"
         ng-options="key as value for (key,value) in {newest: ts('Newest'), oldest: ts('Oldest')}"
         >
       </select>
+    </td>
+    <td>
+      <select
+        ui-jq="select2"
+        ui-options="{dropdownAutoWidth: true}"
+        ng-model="activity.default_assignee_type"
+        ng-options="option.value as option.label for option in defaultAssigneeTypes"
+        ng-change="clearActivityDefaultAssigneeValues(activity)"
+      ></select>
+
+      <p ng-if="activity.default_assignee_type === defaultAssigneeTypeValues.BY_RELATIONSHIP">
+        <select
+          ui-jq="select2"
+          ui-options="{dropdownAutoWidth: true}"
+          ng-model="activity.default_assignee_relationship"
+          ng-options="option.id as option.text for option in relationshipTypeOptions"
+          required
+        ></select>
+      </p>
+
+      <p ng-if="activity.default_assignee_type === defaultAssigneeTypeValues.SPECIFIC_CONTACT">
+        <input
+          type="text"
+          ng-model="activity.default_assignee_contact"
+          placeholder="- Select contact -"
+          crm-entityref="{ entity: 'Contact' }"
+          data-create-links="true"
+          required />
+      </p>
     </td>
     <td>
       <a class="crm-hover-button"
@@ -74,7 +104,7 @@ Required vars: activitySet
 
   <tfoot>
   <tr class="addRow">
-    <td colspan="6">
+    <td colspan="8">
       <span crm-add-name=""
            crm-options="activityTypeOptions"
            crm-var="newActivity"

--- a/tests/karma/unit/crmCaseTypeSpec.js
+++ b/tests/karma/unit/crmCaseTypeSpec.js
@@ -11,6 +11,7 @@ describe('crmCaseType', function() {
   var apiCalls;
   var ctrl;
   var compile;
+  var defaultAssigneeDefaultValue;
   var scope;
 
   beforeEach(function() {
@@ -231,8 +232,65 @@ describe('crmCaseType', function() {
               }
             ]
           }
+        },
+        defaultAssigneeTypes: {
+          values: [
+              {
+                "id": "1174",
+                "option_group_id": "152",
+                "label": "None",
+                "value": "1",
+                "name": "NONE",
+                "filter": "0",
+                "is_default": "1",
+                "weight": "1",
+                "is_optgroup": "0",
+                "is_reserved": "0",
+                "is_active": "1"
+              },
+              {
+                "id": "1175",
+                "option_group_id": "152",
+                "label": "By relationship to workflow client",
+                "value": "2",
+                "name": "BY_RELATIONSHIP",
+                "filter": "0",
+                "is_default": "0",
+                "weight": "2",
+                "is_optgroup": "0",
+                "is_reserved": "0",
+                "is_active": "1"
+              },
+              {
+                "id": "1176",
+                "option_group_id": "152",
+                "label": "Specific contact",
+                "value": "3",
+                "name": "SPECIFIC_CONTACT",
+                "filter": "0",
+                "is_default": "0",
+                "weight": "3",
+                "is_optgroup": "0",
+                "is_reserved": "0",
+                "is_active": "1"
+              },
+              {
+                "id": "1177",
+                "option_group_id": "152",
+                "label": "User creating the workflow",
+                "value": "4",
+                "name": "USER_CREATING_THE_CASE",
+                "filter": "0",
+                "is_default": "0",
+                "weight": "4",
+                "is_optgroup": "0",
+                "is_reserved": "0",
+                "is_active": "1"
+              }
+          ]
         }
       };
+      defaultAssigneeDefaultValue = _.find(apiCalls.defaultAssigneeTypes.values, { is_default: '1' });
       scope = $rootScope.$new();
       ctrl = $controller('CaseTypeCtrl', {$scope: scope, apiCalls: apiCalls});
     });
@@ -243,6 +301,17 @@ describe('crmCaseType', function() {
 
     it('should load activity types', function() {
       expect(scope.activityTypes['ADC referral']).toEqualData(apiCalls.actTypes.values[0]);
+    });
+
+    it('should store the default assignee types', function() {
+      expect(scope.defaultAssigneeTypes).toBe(apiCalls.defaultAssigneeTypes.values);
+    });
+
+    it('should store the default assignee types values indexed by name', function() {
+      var defaultAssigneeTypeValues = _.chain(apiCalls.defaultAssigneeTypes.values)
+        .indexBy('name').mapValues('value').value();
+
+      expect(scope.defaultAssigneeTypeValues).toEqual(defaultAssigneeTypeValues);
     });
 
     it('addActivitySet should add an activitySet to the case type', function() {
@@ -262,6 +331,75 @@ describe('crmCaseType', function() {
       expect(newSet.name).toBe('timeline_2');
       expect(newSet.timeline).toBe('1');
       expect(newSet.label).toBe('Timeline #2');
+    });
+
+    describe('when clearing the activity\'s default assignee type values', function() {
+      var activity;
+
+      beforeEach(function() {
+        activity = {
+          default_assignee_relationship: 1,
+          default_assignee_contact: 2
+        };
+
+        scope.clearActivityDefaultAssigneeValues(activity);
+      });
+
+      it('clears the default assignee relationship for the activity', function() {
+        expect(activity.default_assignee_relationship).toBe(null);
+      });
+
+      it('clears the default assignee contact for the activity', function() {
+        expect(activity.default_assignee_contact).toBe(null);
+      });
+    });
+
+    describe('when adding a new activity to a set', function() {
+      var activitySet;
+
+      beforeEach(function() {
+        activitySet = { activityTypes: [] };
+        scope.activityTypes = { comment: { label: 'Add a new comment' } };
+
+        scope.addActivity(activitySet, 'comment');
+      });
+
+      it('adds a new Comment activity to the set', function() {
+        expect(activitySet.activityTypes[0]).toEqual({
+          name: 'comment',
+          label: scope.activityTypes.comment.label,
+          status: 'Scheduled',
+          reference_activity: 'Open Case',
+          reference_offset: '1',
+          reference_select: 'newest',
+          default_assignee_type: defaultAssigneeDefaultValue.value
+        });
+      });
+    });
+
+    describe('when creating a new workflow', function() {
+      beforeEach(inject(function ($controller) {
+        apiCalls.caseType = null;
+
+        ctrl = $controller('CaseTypeCtrl', {$scope: scope, apiCalls: apiCalls});
+      }));
+
+      it('sets default values for the case type title, name, and active status', function() {
+        expect(scope.caseType).toEqual(jasmine.objectContaining({
+          title: '',
+          name: '',
+          is_active: '1'
+        }));
+      });
+
+      it('adds an Open Case activty to the default activty set', function() {
+        expect(scope.caseType.definition.activitySets[0].activityTypes).toEqual([{
+          name: 'Open Case',
+          label: 'Open Case',
+          status: 'Completed',
+          default_assignee_type: defaultAssigneeDefaultValue.value
+        }]);
+      });
     });
   });
 

--- a/tests/karma/unit/crmCaseTypeSpec.js
+++ b/tests/karma/unit/crmCaseTypeSpec.js
@@ -188,6 +188,18 @@ describe('crmCaseType', function() {
               "contact_type_b": "Individual",
               "is_reserved": "0",
               "is_active": "1"
+            },
+            {
+              "id": "2",
+              "name_a_b": "Spouse of",
+              "label_a_b": "Spouse of",
+              "name_b_a": "Spouse of",
+              "label_b_a": "Spouse of",
+              "description": "Spousal relationship.",
+              "contact_type_a": "Individual",
+              "contact_type_b": "Individual",
+              "is_reserved": "0",
+              "is_active": "1"
             }
           ]
         },
@@ -312,6 +324,26 @@ describe('crmCaseType', function() {
         .indexBy('name').mapValues('value').value();
 
       expect(scope.defaultAssigneeTypeValues).toEqual(defaultAssigneeTypeValues);
+    });
+
+    it('should store the default assignee relationship type options', function() {
+      var defaultRelationshipTypeOptions = _.transform(apiCalls.relTypes.values, function(result, relType) {
+        var isBidirectionalRelationship = relType.label_a_b === relType.label_b_a;
+
+        result.push({
+          label: relType.label_b_a,
+          value: relType.id + '_b_a'
+        });
+
+        if (!isBidirectionalRelationship) {
+          result.push({
+            label: relType.label_a_b,
+            value: relType.id + '_a_b'
+          });
+        }
+      }, []);
+
+      expect(scope.defaultRelationshipTypeOptions).toEqual(defaultRelationshipTypeOptions);
     });
 
     it('addActivitySet should add an activitySet to the case type', function() {

--- a/tests/phpunit/CRM/Case/XMLProcessor/ProcessTest.php
+++ b/tests/phpunit/CRM/Case/XMLProcessor/ProcessTest.php
@@ -1,0 +1,173 @@
+<?php
+require_once 'CiviTest/CiviCaseTestCase.php';
+
+/**
+ * Class CRM_Case_PseudoConstantTest
+ * @group headless
+ */
+class CRM_Case_XMLProcessor_ProcessTest extends CiviCaseTestCase {
+
+  public function setUp() {
+    parent::setUp();
+
+    $this->defaultAssigneeOptionsValues = [];
+    $this->assigneeContactId = $this->individualCreate();
+    $this->targetContactId = $this->individualCreate();
+
+    $this->setUpDefaultAssigneeOptions();
+    $this->setUpRelationship();
+
+    $activityTypeXml = '<activity-type><name>Open Case</name></activity-type>';
+    $this->activityTypeXml = new SimpleXMLElement($activityTypeXml);
+    $this->params = [
+      'activity_date_time' => date('Ymd'),
+      'caseID' => $this->caseTypeId,
+      'clientID' => $this->targetContactId,
+      'creatorID' => $this->_loggedInUser,
+    ];
+
+    $this->process = new CRM_Case_XMLProcessor_Process();
+  }
+
+  /**
+   * Adds the default assignee group and options to the test database.
+   * It also stores the IDs of the options in an index.
+   */
+  protected function setUpDefaultAssigneeOptions() {
+    $options = [
+      'NONE', 'BY_RELATIONSHIP', 'SPECIFIC_CONTACT', 'USER_CREATING_THE_CASE'
+    ];
+
+    CRM_Core_BAO_OptionGroup::ensureOptionGroupExists([
+      'name' => 'activity_default_assignee'
+    ]);
+
+    foreach ($options as $option) {
+      $optionValue = CRM_Core_BAO_OptionValue::ensureOptionValueExists([
+        'option_group_id' => 'activity_default_assignee',
+        'name' => $option,
+        'label' => $option
+      ]);
+
+      $this->defaultAssigneeOptionsValues[$option] = $optionValue['value'];
+    }
+  }
+
+  /**
+   * Adds a relationship between the activity's target contact and default assignee.
+   */
+  protected function setUpRelationship() {
+    $this->assignedRelationshipType = 'Instructor of';
+    $this->unassignedRelationshipType = 'Employer of';
+
+    $assignedRelationshipTypeId = $this->relationshipTypeCreate([
+      'contact_type_a' => 'Individual',
+      'contact_type_b' => 'Individual',
+      'name_a_b' => 'Pupil of',
+      'name_b_a' => $this->assignedRelationshipType,
+    ]);
+    $this->relationshipTypeCreate([
+      'name_a_b' => 'Employee of',
+      'name_b_a' => $this->unassignedRelationshipType,
+    ]);
+    $this->callAPISuccess('Relationship', 'create', [
+      'contact_id_a' => $this->assigneeContactId,
+      'contact_id_b' => $this->targetContactId,
+      'relationship_type_id' => $assignedRelationshipTypeId
+    ]);
+  }
+
+  /**
+   * Tests the creation of activities with default assignee by relationship.
+   */
+  public function testCreateActivityWithDefaultContactByRelationship() {
+    $this->activityTypeXml->default_assignee_type = $this->defaultAssigneeOptionsValues['BY_RELATIONSHIP'];
+    $this->activityTypeXml->default_assignee_relationship = $this->assignedRelationshipType;
+
+    $this->process->createActivity($this->activityTypeXml, $this->params);
+    $this->assertActivityAssignedToContactExists($this->assigneeContactId);
+  }
+
+  /**
+   * Tests the creation of activities with default assignee by relationship,
+   * but the target contact doesn't have any relationship of the selected type.
+   */
+  public function testCreateActivityWithDefaultContactByRelationButTheresNoRelationship() {
+    $this->activityTypeXml->default_assignee_type = $this->defaultAssigneeOptionsValues['BY_RELATIONSHIP'];
+    $this->activityTypeXml->default_assignee_relationship = $this->unassignedRelationshipType;
+
+    $this->process->createActivity($this->activityTypeXml, $this->params);
+    $this->assertActivityAssignedToContactExists(NULL);
+  }
+
+  /**
+   * Tests the creation of activities with default assignee set to a specific contact.
+   */
+  public function testCreateActivityAssignedToSpecificContact() {
+    $this->activityTypeXml->default_assignee_type = $this->defaultAssigneeOptionsValues['SPECIFIC_CONTACT'];
+    $this->activityTypeXml->default_assignee_contact = $this->assigneeContactId;
+
+    $this->process->createActivity($this->activityTypeXml, $this->params);
+    $this->assertActivityAssignedToContactExists($this->assigneeContactId);
+  }
+
+  /**
+   * Tests the creation of activities with default assignee set to a specific contact,
+   * but the contact does not exist.
+   */
+  public function testCreateActivityAssignedToNonExistantSpecificContact() {
+    $this->activityTypeXml->default_assignee_type = $this->defaultAssigneeOptionsValues['SPECIFIC_CONTACT'];
+    $this->activityTypeXml->default_assignee_contact = 987456321;
+
+    $this->process->createActivity($this->activityTypeXml, $this->params);
+    $this->assertActivityAssignedToContactExists(NULL);
+  }
+
+  /**
+   * Tests the creation of activities with the default assignee being the one
+   * creating the case's activity.
+   */
+  public function testCreateActivityAssignedToUserCreatingTheCase() {
+    $this->activityTypeXml->default_assignee_type = $this->defaultAssigneeOptionsValues['USER_CREATING_THE_CASE'];
+
+    $this->process->createActivity($this->activityTypeXml, $this->params);
+    $this->assertActivityAssignedToContactExists($this->_loggedInUser);
+  }
+
+  /**
+   * Tests the creation of activities when the default assignee is set to NONE.
+   */
+  public function testCreateActivityAssignedNoUser() {
+    $this->activityTypeXml->default_assignee_type = $this->defaultAssigneeOptionsValues['NONE'];
+
+    $this->process->createActivity($this->activityTypeXml, $this->params);
+    $this->assertActivityAssignedToContactExists(NULL);
+  }
+
+  /**
+   * Tests the creation of activities when the default assignee is set to NONE.
+   */
+  public function testCreateActivityWithNoDefaultAssigneeOption() {
+    $this->process->createActivity($this->activityTypeXml, $this->params);
+    $this->assertActivityAssignedToContactExists(NULL);
+  }
+
+  /**
+   * Asserts that an activity was created where the assignee was the one related
+   * to the target contact.
+   *
+   * @param int|null $assigneeContactId the ID of the expected assigned contact or NULL if expected to be empty.
+   */
+  protected function assertActivityAssignedToContactExists($assigneeContactId) {
+    $expectedContact = $assigneeContactId === NULL ? [] : [$assigneeContactId];
+    $result = $this->callAPISuccess('Activity', 'get', [
+      'target_contact_id' => $this->targetContactId,
+      'return' => ['assignee_contact_id']
+    ]);
+    $activity = CRM_Utils_Array::first($result['values']);
+
+    $this->assertNotNull($activity, 'Target contact has no activities assigned to them');
+    $this->assertEquals($expectedContact, $activity['assignee_contact_id'], 'Activity is not assigned to expected contact');
+  }
+
+}

--- a/tests/phpunit/CRM/Core/BAO/OptionValueTest.php
+++ b/tests/phpunit/CRM/Core/BAO/OptionValueTest.php
@@ -72,12 +72,15 @@ class CRM_Core_BAO_OptionValueTest extends CiviUnitTestCase {
    * decision to disable it & leaving it in that state.
    */
   public function testEnsureOptionValueExistsDisabled() {
-    CRM_Core_BAO_OptionValue::ensureOptionValueExists(array('name' => 'Crashed', 'option_group_id' => 'contribution_status', 'is_active' => 0));
+    $optionValue = CRM_Core_BAO_OptionValue::ensureOptionValueExists(array('name' => 'Crashed', 'option_group_id' => 'contribution_status', 'is_active' => 0));
     $value = $this->callAPISuccessGetSingle('OptionValue', array('name' => 'Crashed', 'option_group_id' => 'contribution_status'));
     $this->assertEquals(0, $value['is_active']);
-    CRM_Core_BAO_OptionValue::ensureOptionValueExists(array('name' => 'Crashed', 'option_group_id' => 'contribution_status'));
+    $this->assertEquals($value['id'], $optionValue['id']);
+
+    $optionValue = CRM_Core_BAO_OptionValue::ensureOptionValueExists(array('name' => 'Crashed', 'option_group_id' => 'contribution_status'));
     $value = $this->callAPISuccessGetSingle('OptionValue', array('name' => 'Crashed', 'option_group_id' => 'contribution_status'));
     $this->assertEquals(0, $value['is_active']);
+    $this->assertEquals($value['id'], $optionValue['id']);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
This PR allows admins to configure default assignees for cases. The default assignees can be selected as follows:

* By relationship to case client.
* User creating the case.
* Specific contact.
* No default assignee.

Before
----------------------------------------

### Configuring the default assignee
![screenshot 2018-04-18 22 05 15](https://user-images.githubusercontent.com/1642119/38967563-9456ca4a-4355-11e8-93e8-17374e7c4e77.png)


### Creating a new case
![dr barry adams ii housing support hr17 9100 1](https://user-images.githubusercontent.com/1642119/37811552-64a2ce36-2e31-11e8-94c3-342af4a52e92.png)
No contact assigned to activities.


After
----------------------------------------

### Configuring the default assignee
![anim](https://user-images.githubusercontent.com/1642119/38967200-f9c8b958-4353-11e8-8ae7-1b99a8a7b26d.gif)

### Creating a new case
![anim](https://user-images.githubusercontent.com/1642119/38967841-ef1524bc-4356-11e8-9eec-5604898794e4.gif)


Technical Details
----------------------------------------
### Inserting the default assignee options in the database

A new upgrader was added targeting version 5.0.1, a hypothetical version that branches off from 5.0.0, which is a new version in development. The upgrader reads as follows:

```php
public function upgrade_5_0_1($rev) {
  $this->addTask(ts('Upgrade DB to %1: SQL', array(1 => $rev)), 'runSql', $rev);

  // Add option group for activity default assignees:
  CRM_Core_BAO_OptionGroup::ensureOptionGroupExists(array(
    'name' => 'activity_default_assignee',
    'title' => ts('Activity default assignee'),
    'is_reserved' => 1,
  ));

  // Add option values for activity default assignees:
  $options = array(
    array('name' => 'NONE', 'label' => ts('None')),
    array('name' => 'BY_RELATIONSHIP', 'label' => ts('By relationship to case client')),
    array('name' => 'SPECIFIC_CONTACT', 'label' => ts('Specific contact')),
    array('name' => 'USER_CREATING_THE_CASE', 'label' => ts('User creating the case'))
  );

  foreach ($options as $option) {
    CRM_Core_BAO_OptionValue::ensureOptionValueExists(array(
      'option_group_id' => 'activity_default_assignee',
      'name' => $option['name'],
      'label' => $option['label'],
      'is_active' => TRUE
    ));
  }
}
```

### Displaying the default assignee options

The default assignee options are requested in the `apiCalls` for the `CaseTypeCtrl` controller:
```js
$routeProvider.when('/caseType/:id', {
  // ...
  controller: 'CaseTypeCtrl',
  resolve: {
    apiCalls: function($route, crmApi) {
      var reqs = {};
      // ...

      reqs.defaultAssigneeTypes = ['OptionValue', 'get', {
        option_group_id: 'activity_default_assignee',
        sequential: 1,
        options: {
          limit: 0
        }
      }];

      // ...
    }
  }
});

crmCaseType.controller('CaseTypeCtrl', function($scope, crmApi, apiCalls) {
  // ...
  $scope.defaultAssigneeTypes = apiCalls.defaultAssigneeTypes.values;
  // this index is used to determine which option was chosen and to display companion fields accordingly:
  $scope.defaultAssigneeTypeValues = _.chain($scope.defaultAssigneeTypes)
        .indexBy('name').mapValues('value').value();
  // ...
});
```
The fields are displayed in the form by editing the timelineTable.html as this:
```html
<td>
  <select
    ui-jq="select2"
    ui-options="{dropdownAutoWidth : true}"
    ng-model="activity.default_assignee_type"
    ng-options="option.value as option.label for option in defaultAssigneeTypes"
    ng-change="clearActivityDefaultAssigneeValues(activity)"
  ></select>

  <p ng-if="activity.default_assignee_type === defaultAssigneeTypeValues.BY_RELATIONSHIP">
    <select
      ui-jq="select2"
      ui-options="{dropdownAutoWidth : true}"
      ng-model="activity.default_assignee_relationship"
      ng-options="option.id as option.text for option in relationshipTypeOptions"
      required
    ></select>
  </p>

  <p ng-if="activity.default_assignee_type === defaultAssigneeTypeValues.SPECIFIC_CONTACT">
    <input
      type="text"
      ng-model="activity.default_assignee_contact"
      placeholder="- select contact -"
      crm-entityref="{ entity: 'Contact' }"
      data-create-links="true"
      required />
  </p>
</td>
```

### Default assignee for new cases

For new cases the default assignee is set to NONE:

```js
if (apiCalls.caseType) {
  // edit case type
  $scope.caseType = apiCalls.caseType;
} else {
  // new case type
  $scope.caseType = _.cloneDeep(newCaseTypeTemplate);
  $scope.caseType.definition.activitySets[0].activityTypes[0]
    .default_assignee_type = $scope.defaultAssigneeTypeValues.NONE;
}
```

### Selecting the assignee

The default assignee is selected when creating the activity at the `CRM_Case_XMLProcessor_Process::createActivity` function since this one has most of the information we need to select the assignee:

```php
public function createActivity($activityTypeXML, &$params) {
  // ...
  $activityParams['assignee_contact_id'] = $this->getDefaultAssigneeForActivity($activityParams, $activityTypeXML);
  // ...
}

protected function getDefaultAssigneeForActivity($activityParams, $activityTypeXML) {
  if (!isset($activityTypeXML->default_assignee_type)) {
    return NULL;
  }

  // fetches the default assignee types to see which strategy to choose for the default assignee
  $defaultAssigneeOptionsValues = $this->getDefaultAssigneeOptionValues();

  switch($activityTypeXML->default_assignee_type) {
    case $defaultAssigneeOptionsValues['BY_RELATIONSHIP']:
      return $this->getDefaultAssigneeByRelationship($activityParams, $activityTypeXML);
      break;
    case $defaultAssigneeOptionsValues['SPECIFIC_CONTACT']:
      return $this->getDefaultAssigneeBySpecificContact($activityTypeXML);
      break;
    case $defaultAssigneeOptionsValues['USER_CREATING_THE_CASE']:
      return $activityParams['source_contact_id'];
      break;
    case $defaultAssigneeOptionsValues['NONE']:
    default:
      return NULL;
  }
}
```

`getDefaultAssigneeByRelationship` is the strategy for selecting an assignee by the relationship to the target contact:
```php
protected function getDefaultAssigneeByRelationship($activityParams, $activityTypeXML) {
  if (!isset($activityTypeXML->default_assignee_relationship)) {
    return NULL;
  }

  $targetContactId = is_array($activityParams['target_contact_id'])
    ? CRM_Utils_Array::first($activityParams['target_contact_id'])
    : $activityParams['target_contact_id'];

  $relationships = civicrm_api3('Relationship', 'get', [
    'contact_id_b' => $targetContactId,
    'relationship_type_id.name' => $activityTypeXML->default_assignee_relationship,
    'is_active' => 1,
    'sequential' => 1
  ]);

  if ($relationships['count']) {
    return $relationships['values'][0]['contact_id_a'];
  } else {
    return NULL;
  }
}
```

`getDefaultAssigneeBySpecificContact` is the strategy when choosing a specific contact. It returns the ID only if the contact exists in case the contact were to be deleted at a later time:
```php
protected function getDefaultAssigneeBySpecificContact($activityTypeXML) {
  if (!$activityTypeXML->default_assignee_contact) {
    return NULL;
  }

  $contact = civicrm_api3('Contact', 'get', [
    'id' => $activityTypeXML->default_assignee_contact
  ]);

  if ($contact['count'] == 1) {
    return $activityTypeXML->default_assignee_contact;
  }

  return NULL;
}
```

Comments
------------------------------
* PHP and JS tests were added to cover for the new functionality.
* Added some missing JS tests for the `crmCaseType` controller.
* The `CRM_Case_XMLProcessor_Process` class was missing a test file so a new was created at:
`tests/phpunit/CRM/Case/XMLProcessor/ProcessTest.php`, but only tests related to the default assignee selections were added.
* `CRM_Core_BAO_OptionValue::ensureOptionValueExists` had to be enhanced to return the option value id whether it finds the value or creates a new one.

----------

Gitlab Issue:
https://lab.civicrm.org/dev/core/issues/107