### PR TITLE
core/issues/64 - In custom searches, column headings are being ignored

### DIFF
--- a/CRM/Contact/StateMachine/Search.php
+++ b/CRM/Contact/StateMachine/Search.php
@@ -103,10 +103,13 @@ class CRM_Contact_StateMachine_Search extends CRM_Core_StateMachine {
     }
     $this->_controller->set('task', $value);
 
-    $componentMode = $this->_controller->get('component_mode');
-    $modeValue = CRM_Contact_Form_Search::getModeValue($componentMode);
-    $taskClassName = $modeValue['taskClassName'];
-    return $taskClassName::getTask($value);
+    if ($value) {
+      $componentMode = $this->_controller->get('component_mode');
+      $modeValue = CRM_Contact_Form_Search::getModeValue($componentMode);
+      $taskClassName = $modeValue['taskClassName'];
+      return $taskClassName::getTask($value);
+    }
+    return CRM_Contact_Task::getTask($value);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fix for column headers missing from almost all custom searches. Some of them are also missing the entire columns.

Before
----------------------------------------
Screenshot of Postal mailing custom search.

![image](https://user-images.githubusercontent.com/5929648/38991240-a0c50b34-43fa-11e8-9bc5-a25d5cf7a03e.png)

After
----------------------------------------

![image](https://user-images.githubusercontent.com/5929648/38991215-8b3bd3a6-43fa-11e8-9fb8-58db94cf29e0.png)


Technical Details
----------------------------------------
If `$value` is not set, `getModeValue()` will set the default selector to `CRM_Contact_Selector` which is then considered to display column headers and `$sort` criteria on the result page.

Comments
----------------------------------------
Regression from https://github.com/civicrm/civicrm-core/commit/eda34f9b15c494715e8fc54f09b5ea4308d16b17#diff-32fdf98c87aec5fc49db16d49ab1fabb

-----

Gitlab issue - https://lab.civicrm.org/dev/core/issues/64
