### PR TITLE
code/dev/69: Change Approach For Setting state_province_name

### DIFF
--- a/CRM/Utils/Address.php
+++ b/CRM/Utils/Address.php
@@ -331,7 +331,6 @@ class CRM_Utils_Address {
       "city" => "billing_city-{$billingLocationTypeID}",
       "postal_code" => "billing_postal_code-{$billingLocationTypeID}",
       "state_province" => "state_province-{$billingLocationTypeID}",
-      "state_province_name" => "state_province-{$billingLocationTypeID}",
       "country" => "country-{$billingLocationTypeID}",
     );
 
@@ -349,12 +348,10 @@ class CRM_Utils_Address {
           $value = $params[$alternateName];
         }
       }
-      if (is_numeric($value) && ($name == 'state_province' || $name == 'state_province_name' || $name == 'country')) {
+      if (is_numeric($value) && ($name == 'state_province' || $name == 'country')) {
         if ($name == 'state_province') {
           $addressFields[$name] = CRM_Core_PseudoConstant::stateProvinceAbbreviation($value);
-        }
-        if ($name == 'state_province_name') {
-          $addressFields[$name] = CRM_Core_PseudoConstant::stateProvince($value);
+          $addressFields[$name . '_name'] = CRM_Core_PseudoConstant::stateProvince($value);
         }
         if ($name == 'country') {
           $addressFields[$name] = CRM_Core_PseudoConstant::countryIsoCode($value);

--- a/tests/phpunit/CRM/Utils/AddressTest.php
+++ b/tests/phpunit/CRM/Utils/AddressTest.php
@@ -33,4 +33,44 @@ class CRM_Utils_AddressTest extends CiviUnitTestCase {
     $this->assertTrue((bool) strstr($formatted_address, 'UNITED STATES'));
   }
 
+  /**
+   * Test state/province field's state_province_name token on getFormattedBillingAddressFieldsFromParameters
+   * and test using alternate names for state_province field
+   */
+  public function testStateProvinceFormattedBillingAddress() {
+    $params = array(
+      'billing_street_address-99' => '123 Happy Place',
+      'billing_city-99' => 'Miami',
+      'billing_postal_code-99' => 33101,
+      'state_province-99' => '1000', // 1000 => Alabama (AL)
+      'country-99' => 'United States',
+    );
+
+    // set address_format (we are only interested in state_province & state_province_name)
+    $addFormat = '{contact.state_province}';
+    Civi::settings()->set('address_format', $addFormat);
+    $formatted_address = CRM_Utils_Address::getFormattedBillingAddressFieldsFromParameters($params, '99');
+    $this->assertTrue((bool) $formatted_address == 'AL');
+
+    $addFormat = '{contact.state_province_name}';
+    Civi::settings()->set('address_format', $addFormat);
+    $formatted_address = CRM_Utils_Address::getFormattedBillingAddressFieldsFromParameters($params, '99');
+    $this->assertTrue((bool) $formatted_address == 'Alabama');
+
+    // test using alternate names for state/province field
+    unset($params['state_province-99']);
+    $params['billing_state_province-99'] = '1000'; // alternate name 1
+    $addFormat = '{contact.state_province_name}';
+    Civi::settings()->set('address_format', $addFormat);
+    $formatted_address = CRM_Utils_Address::getFormattedBillingAddressFieldsFromParameters($params, '99');
+    $this->assertTrue((bool) $formatted_address == 'Alabama');
+
+    unset($params['state_province-99']);
+    $params['billing_state_province_id-99'] = '1000'; // alternate name 2
+    $addFormat = '{contact.state_province_name}';
+    Civi::settings()->set('address_format', $addFormat);
+    $formatted_address = CRM_Utils_Address::getFormattedBillingAddressFieldsFromParameters($params, '99');
+    $this->assertTrue((bool) $formatted_address == 'Alabama');
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
This issue is related to this existing issue

https://issues.civicrm.org/jira/browse/CRM-21830

The PR for the above issue is here

https://github.com/civicrm/civicrm-core/pull/11776

Though this fixes the basic issue, it still doesn't work for all fields.

Before
----------------------------------------
If state_province field name is not of the form "state_province-{$billingLocationTypeID}", then state_province_name is empty. Which means field names of form 'billing_state_province-{#}' and 'billing_state_province_id-{#}' results in empty state_province_name when "state_province_name" token is used.

After
----------------------------------------
I have changed the way "state_province_name' is set and this is simple and works for all cases.


https://lab.civicrm.org/dev/core/issues/69