### PR TITLE
dev/core#30 export of contact master_id name only if there is a master_id given (rebase)

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -3340,30 +3340,21 @@ AND       civicrm_openid.is_primary = 1";
    * @param int $masterAddressId
    *   Master id.
    * @param int $contactId
-   *   Contact id.
+   *   Contact id. (deprecated - do not use)
    *
    * @return string|null
    *   the found display name or null.
    */
   public static function getMasterDisplayName($masterAddressId = NULL, $contactId = NULL) {
     $masterDisplayName = NULL;
-    $sql = NULL;
-    if (!$masterAddressId && !$contactId) {
+    if (!$masterAddressId) {
       return $masterDisplayName;
     }
 
-    if ($masterAddressId) {
-      $sql = "
+    $sql = "
    SELECT display_name from civicrm_contact
 LEFT JOIN civicrm_address ON ( civicrm_address.contact_id = civicrm_contact.id )
     WHERE civicrm_address.id = " . $masterAddressId;
-    }
-    elseif ($contactId) {
-      $sql = "
-   SELECT display_name from civicrm_contact cc, civicrm_address add1
-LEFT JOIN civicrm_address add2 ON ( add1.master_id = add2.id )
-    WHERE cc.id = add2.contact_id AND add1.contact_id = " . $contactId;
-    }
 
     $masterDisplayName = CRM_Core_DAO::singleValueQuery($sql);
     return $masterDisplayName;

--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -806,7 +806,7 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
                 $masterAddressId = $iterationDAO->$field;
               }
               // get display name of contact that address is shared.
-              $fieldValue = CRM_Contact_BAO_Contact::getMasterDisplayName($masterAddressId, $iterationDAO->contact_id);
+              $fieldValue = CRM_Contact_BAO_Contact::getMasterDisplayName($masterAddressId);
             }
           }
 

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -27,6 +27,13 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
    */
   protected $activityIDs = [];
 
+  /**
+   * Master Address ID created for testing.
+   *
+   * @var int
+   */
+  protected $masterAddressID;
+
   public function tearDown() {
     $this->quickCleanup(['civicrm_contact', 'civicrm_email', 'civicrm_address']);
     $this->quickCleanUpFinancialEntities();
@@ -252,6 +259,7 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
       'location_type_id' => "Home",
       'master_id' => $addressId,
     ));
+    $this->masterAddressID = $addressId;
 
   }
 
@@ -392,7 +400,7 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
 
     //assert the exported result
     $masterName = CRM_Core_DAO::singleValueQuery("SELECT {$field} FROM {$tableName}");
-    $displayName = CRM_Contact_BAO_Contact::getMasterDisplayName(NULL, $this->contactIDs[1]);
+    $displayName = CRM_Contact_BAO_Contact::getMasterDisplayName($this->masterAddressID);
     $this->assertEquals($displayName, $masterName);
 
     // delete the export temp table and component table


### PR DESCRIPTION
Overview
----------------------------------------
Exporting "Master address contact" should give the master contact only if there is a master_id defined for this address but currently, if there is no master_id, the first master address id found for this contact is used.

Technical Details
----------------------------------------
There is only one place where the function getMasterDisplayName is used.

The test was the only place where contactId parameter was used instead of masterAddressId.

I'm not sure what to do with a deprecated parameter - throw an error, remove it from the definition or fail silently like we do here ?
