### PR TITLE
core/issues/64 - In custom searches, column headings are being ignored

### DIFF
--- a/CRM/Contact/StateMachine/Search.php
+++ b/CRM/Contact/StateMachine/Search.php
@@ -103,10 +103,13 @@ class CRM_Contact_StateMachine_Search extends CRM_Core_StateMachine {
     }
     $this->_controller->set('task', $value);
 
-    $componentMode = $this->_controller->get('component_mode');
-    $modeValue = CRM_Contact_Form_Search::getModeValue($componentMode);
-    $taskClassName = $modeValue['taskClassName'];
-    return $taskClassName::getTask($value);
+    if ($value) {
+      $componentMode = $this->_controller->get('component_mode');
+      $modeValue = CRM_Contact_Form_Search::getModeValue($componentMode);
+      $taskClassName = $modeValue['taskClassName'];
+      return $taskClassName::getTask($value);
+    }
+    return CRM_Contact_Task::getTask($value);
   }
 
   /**


### PR DESCRIPTION
Port https://github.com/civicrm/civicrm-core/pull/12001 to 5.1 rc as it is a recent regression & should get a quick fix