### PR TITLE
dev/financial/#16 Paypal unreliable getting payment processor type

### DIFF
--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -718,7 +718,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
    * @throws \Civi\Payment\Exception\PaymentProcessorException
    */
   public function cancelSubscription(&$message = '', $params = array()) {
-    if ($this->isPayPalType($this::PAYPAL_PRO)) {
+    if ($this->isPayPalType($this::PAYPAL_PRO) || $this->isPayPalType($this::PAYPAL_EXPRESS)) {
       $args = array();
       $this->initialize($args, 'ManageRecurringPaymentsProfileStatus');
 


### PR DESCRIPTION
Overview
----------------------------------------
The standard _paymentProcessor array does not include the type name (payment_processor_type) but does include the payment processor type id (payment_processor_type_id).  However, paypal pro is expecting it to be there (it is passed in via a standard online contribution page).

Before
----------------------------------------
PHP notice on some payment submissions (eg. via webform_civicrm) and use of "non-standard" param.

After
----------------------------------------
No PHP notice and uses standard parameter so it works with all payment submissions that use standard methods to populate the payment processor array ($this->_paymentProcessor).

Related: #12091 
