### PR TITLE
footer.tpl - Change the URL formula pointing to the release notes

### DIFF
--- a/templates/CRM/common/footer.tpl
+++ b/templates/CRM/common/footer.tpl
@@ -31,7 +31,7 @@
 
   <div class="crm-footer" id="civicrm-footer">
     {crmVersion assign=version}
-    {ts}Powered by CiviCRM{/ts} <a href="https://github.com/civicrm/civicrm-core/blob/{$version}/release-notes/{$version}.md">{$version}</a>.
+    {ts}Powered by CiviCRM{/ts} <a href="https://download.civicrm.org/about/{$version}">{$version}</a>.
     {if !empty($footer_status_severity)}
       <span class="status{if $footer_status_severity gt 3} crm-error{elseif $footer_status_severity gt 2} crm-warning{else} crm-ok{/if}">
       <a href="{crmURL p='civicrm/a/#/status'}">{$footer_status_message}</a>


### PR DESCRIPTION
Overview
----------------------------------------
The release notes URL should be more maintainable.

Before
----------------------------------------
The formula was `https://github.com/civicrm/civicrm-core/blob/{$version}/release-notes/{$version}.md`. Because the URL
points to a tag on Github, it's hard to make any corrections if something has changed or gone wrong.

After
----------------------------------------
The formula is `https://download.civicrm.org/about/{$version}`, which corresponds to
[civicrm-dist-manager's AboutController](https://github.com/civicrm/civicrm-dist-manager/blob/master/src/CiviDistManagerBundle/Controller/AboutController.php).
