### PR TITLE
(dev/core/issues/70) On any custom search 'Print selected rows' action doesn't retain columns/values

### DIFF
--- a/CRM/Contact/Form/Task/Print.php
+++ b/CRM/Contact/Form/Task/Print.php
@@ -82,8 +82,9 @@ class CRM_Contact_Form_Task_Print extends CRM_Contact_Form_Task {
     $selectorName = $this->controller->selectorName();
     require_once str_replace('_', DIRECTORY_SEPARATOR, $selectorName) . '.php';
 
-    $returnP = isset($returnPropeties) ? $returnPropeties : "";
+    $returnP = isset($returnProperties) ? $returnProperties : "";
     $customSearchClass = $this->get('customSearchClass');
+    $this->assign('customSearchID', $this->get('customSearchID'));
     $selector = new $selectorName($customSearchClass,
       $fv,
       $params,

--- a/CRM/Contact/Selector/Custom.php
+++ b/CRM/Contact/Selector/Custom.php
@@ -227,11 +227,14 @@ class CRM_Contact_Selector_Custom extends CRM_Contact_Selector {
    */
   public function &getColumnHeaders($action = NULL, $output = NULL) {
     $columns = $this->_search->columns();
-    if ($output == CRM_Core_Selector_Controller::EXPORT) {
-      return array_keys($columns);
+    $headers = array();
+    if ($output == CRM_Core_Selector_Controller::EXPORT || $output == CRM_Core_Selector_Controller::SCREEN) {
+      foreach ($columns as $name => $key) {
+        $headers[$key] = $name;
+      }
+      return $headers;
     }
     else {
-      $headers = array();
       foreach ($columns as $name => $key) {
         if (!empty($name)) {
           $headers[] = array(

--- a/templates/CRM/Contact/Form/Task/Print.tpl
+++ b/templates/CRM/Contact/Form/Task/Print.tpl
@@ -32,7 +32,7 @@
 <br />
 <table>
   <tr class="columnheader">
-{if $id}
+{if $id OR $customSearchID}
   {foreach from=$columnHeaders item=header}
      <th>{$header}</th>
   {/foreach}
@@ -63,13 +63,16 @@
 {foreach from=$rows item=row}
     <tr class="{cycle values="odd-row,even-row"}">
 {if $id}
-        <td>{$row.sort_name}</td>
-         {foreach from=$row item=value key=key}
-           {if ($key neq "checkbox") and ($key neq "action") and ($key neq "contact_type") and ($key neq "status") and ($key neq "contact_id") and ($key neq "sort_name")}
-              <td>{$value}</td>
-           {/if}
-         {/foreach}
-
+  <td>{$row.sort_name}</td>
+  {foreach from=$row item=value key=key}
+    {if ($key neq "checkbox") and ($key neq "action") and ($key neq "contact_type") and ($key neq "status") and ($key neq "contact_id") and ($key neq "sort_name")}
+      <td>{$value}</td>
+    {/if}
+  {/foreach}
+{elseif $customSearchID}
+  {foreach from=$columnHeaders item=header key=name}
+    <td>{$row.$name}</td>
+  {/foreach}
 {else}
         <td>{$row.sort_name}</td>
         {if !empty($columnHeaders.street_address)}


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate:
*  Go to any custom search
*  Choose any or all record
*  Then choose 'Print selected rows' 

**Actual Result**: There are different headers and except name all values are empty
**Expected Result**: The print screen should the headers chosen for that Custom search and its corresponding values under it

Issue : https://lab.civicrm.org/dev/core/issues/70

Before
----------------------------------------
![test-multiple-before](https://user-images.githubusercontent.com/3735621/39072940-be72c45e-4509-11e8-92dc-54eb383a2875.gif)


After
----------------------------------------
![test-multiple-after](https://user-images.githubusercontent.com/3735621/39072963-d1de0396-4509-11e8-9878-3165c1d24c6a.gif)

