### PR TITLE
dev/financial#12 move soft credit item count to object property

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -204,6 +204,14 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
   protected $statusMessageTitle;
 
   /**
+   * @var int
+   *
+   * Max row count for soft credits. The value here is +1 the actual number of
+   * rows displayed.
+   */
+  public $_softCreditItemCount = 11;
+
+  /**
    * Explicitly declare the form context.
    */
   public function getDefaultContext() {

--- a/CRM/Contribute/Form/SoftCredit.php
+++ b/CRM/Contribute/Form/SoftCredit.php
@@ -68,7 +68,7 @@ class CRM_Contribute_Form_SoftCredit {
     }
 
     // by default generate 10 blocks
-    $item_count = 11;
+    $item_count = $form->_softCreditItemCount;
 
     $showSoftCreditRow = 2;
     if ($form->getAction() & CRM_Core_Action::UPDATE) {


### PR DESCRIPTION
Overview
----------------------------------------
Move the soft credit row count from a hardcoded variable to a class property that can be modified via hook.

Before
----------------------------------------
Soft credit row count was hardcoded and couldn't be modified except through an override file.

After
----------------------------------------
Row count is now a class property that can be modified with the preProcess hook.