### PR TITLE
CRM-8140: Not possible to select fields for export when using Custom Searches

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -1040,6 +1040,10 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
       $rows[] = $row;
     }
 
+    if (!empty($formValues['is_unit_test'])) {
+      return array($header, $rows);
+    }
+
     CRM_Core_Report_Excel::writeCSVFile(self::getExportFileName(), $header, $rows);
     CRM_Utils_System::civiExit();
   }

--- a/CRM/Export/Form/Map.php
+++ b/CRM/Export/Form/Map.php
@@ -234,6 +234,13 @@ class CRM_Export_Form_Map extends CRM_Core_Form {
       }
     }
 
+    if ($this->get('customSearchID')) {
+      CRM_Export_BAO_Export::exportCustom($this->get('customSearchClass'),
+        $this->get('formValues'),
+        $this->get(CRM_Utils_Sort::SORT_ORDER),
+        CRM_Export_BAO_Export::getReturnPropertiesFromChoosenField($mapperKeys, $this->get('exportMode'))
+      );
+    }
     //get the csv file
     CRM_Export_BAO_Export::exportComponents($this->get('selectAll'),
       $this->get('componentIds'),

--- a/CRM/Export/Form/Select.php
+++ b/CRM/Export/Form/Select.php
@@ -70,6 +70,8 @@ class CRM_Export_Form_Select extends CRM_Core_Form {
 
   public $_componentTable;
 
+  public $_customSearchID;
+
   /**
    * Build all the data structures needed to build the form.
    *
@@ -81,13 +83,7 @@ class CRM_Export_Form_Select extends CRM_Core_Form {
     $this->preventAjaxSubmit();
 
     //special case for custom search, directly give option to download csv file
-    $customSearchID = $this->get('customSearchID');
-    if ($customSearchID) {
-      CRM_Export_BAO_Export::exportCustom($this->get('customSearchClass'),
-        $this->get('formValues'),
-        $this->get(CRM_Utils_Sort::SORT_ORDER)
-      );
-    }
+    $this->_customSearchID = $this->get('customSearchID');
 
     $this->_selectAll = FALSE;
     $this->_exportMode = self::CONTACT_EXPORT;
@@ -99,7 +95,11 @@ class CRM_Export_Form_Select extends CRM_Core_Form {
     $isStandalone = $formName == 'CRM_Export_StateMachine_Standalone';
 
     // get the submitted values based on search
-    if ($this->_action == CRM_Core_Action::ADVANCED) {
+    if ($this->_customSearchID) {
+      $values = $this->get('formValues');
+      $this->assign('exportCustomSearchField', TRUE);
+    }
+    elseif ($this->_action == CRM_Core_Action::ADVANCED) {
       $values = $this->controller->exportValues('Advanced');
     }
     elseif ($this->_action == CRM_Core_Action::PROFILE) {
@@ -231,7 +231,7 @@ FROM   {$this->_componentTable}
     $exportOptions = $mergeOptions = $postalMailing = array();
     $exportOptions[] = $this->createElement('radio',
       NULL, NULL,
-      ts('Export PRIMARY fields'),
+      ts('Export %1 fields', array(1 => empty($this->_customSearchID) ? 'PRIMARY' : 'custom search')),
       self::EXPORT_ALL,
       array('onClick' => 'showMappingOption( );')
     );
@@ -396,6 +396,12 @@ FROM   {$this->_componentTable}
     }
 
     if ($exportOption == self::EXPORT_ALL) {
+      if ($this->_customSearchID) {
+        CRM_Export_BAO_Export::exportCustom($this->get('customSearchClass'),
+          $this->get('formValues'),
+          $this->get(CRM_Utils_Sort::SORT_ORDER)
+        );
+      }
       CRM_Export_BAO_Export::exportComponents($this->_selectAll,
         $this->_componentIds,
         (array) $this->get('queryParams'),

--- a/CRM/Export/Form/Select.php
+++ b/CRM/Export/Form/Select.php
@@ -231,7 +231,7 @@ FROM   {$this->_componentTable}
     $exportOptions = $mergeOptions = $postalMailing = array();
     $exportOptions[] = $this->createElement('radio',
       NULL, NULL,
-      ts('Export %1 fields', array(1 => empty($this->_customSearchID) ? 'PRIMARY' : 'custom search')),
+      empty($this->_customSearchID) ? ts('Export PRIMARY fields') : ts('Export custom search fields'),
       self::EXPORT_ALL,
       array('onClick' => 'showMappingOption( );')
     );

--- a/templates/CRM/Export/Form/Select.tpl
+++ b/templates/CRM/Export/Form/Select.tpl
@@ -28,7 +28,7 @@
 <div class="crm-block crm-form-block crm-export-form-block">
 
  <div class="help">
-    <p>{ts}<strong>Export PRIMARY fields</strong> provides the most commonly used data values. This includes primary address information, preferred phone and email.{/ts}</p>
+    <p>{ts}<strong>Export {if $exportCustomSearchField}custom search{else}PRIMARY{/if} fields</strong> provides the most commonly used data values. This includes primary address information, preferred phone and email.{/ts}</p>
     <p>{ts}Click <strong>Select fields for export</strong> and then <strong>Continue</strong> to choose a subset of fields for export. This option allows you to export multiple specific locations (Home, Work, etc.) as well as custom data. You can also save your selections as a 'field mapping' so you can use it again later.{/ts}</p>
  </div>
 


### PR DESCRIPTION
Overview
----------------------------------------
On custom searches (proximity search, include/exclude, activity search) and when you choose action "Export Contacts" and hit "Go", the .csv file downloads immediately. I was expecting to get to select fields, but I never even get to that screen. With this fix, you can either select all fields or can select fields on mapping page.

Before
----------------------------------------
It directly downloads the csv file on choosing the task.

After
----------------------------------------
1. If you decided to export all the primary fields then
![test-multiple-after](https://user-images.githubusercontent.com/3735621/34363452-3a90ec72-eaa2-11e7-8494-7abec80b11c6.gif)

2. If you decided to export selected fields then:
![test-multiple-before](https://user-images.githubusercontent.com/3735621/39092922-8fe297e6-4634-11e8-96ba-fa6ffe87dfd3.gif)

Exported CSV : 
[CiviCRM_Contact_Search (46).txt](https://github.com/civicrm/civicrm-core/files/1935330/CiviCRM_Contact_Search.46.txt)
NOTE: ```contact_type``` is not present in the list of custom search headers. So it's value is empty.

---

 * [CRM-8140: Not possible to select fields for export when using Custom Searches](https://issues.civicrm.org/jira/browse/CRM-8140)