### PR TITLE
core/issues/72 fix payflow bug for amount

### DIFF
--- a/CRM/Core/Payment/PayflowPro.php
+++ b/CRM/Core/Payment/PayflowPro.php
@@ -102,7 +102,7 @@ class CRM_Core_Payment_PayflowPro extends CRM_Core_Payment {
       'CVV2' => $params['cvv2'],
       'EXPDATE' => urlencode(sprintf('%02d', (int) $params['month']) . substr($params['year'], 2, 2)),
       'ACCTTYPE' => urlencode($params['credit_card_type']),
-      'AMT' => urlencode($params['amount']),
+      'AMT' => urlencode($this->getAmount($params)),
       'CURRENCY' => urlencode($params['currency']),
       'FIRSTNAME' => $params['billing_first_name'],
       //credit card name
@@ -131,7 +131,7 @@ class CRM_Core_Payment_PayflowPro extends CRM_Core_Payment {
 
       $payflow_query_array['TRXTYPE'] = 'R';
       $payflow_query_array['OPTIONALTRX'] = 'S';
-      $payflow_query_array['OPTIONALTRXAMT'] = $params['amount'];
+      $payflow_query_array['OPTIONALTRXAMT'] = $this->getAmount($params);
       //Amount of the initial Transaction. Required
       $payflow_query_array['ACTION'] = 'A';
       //A for add recurring (M-modify,C-cancel,R-reactivate,I-inquiry,P-payment


### PR DESCRIPTION
Overview
----------------------------------------
PayflowPro throws error due to more than 4 decimal places


> Payment Processor Error message: 9013: Error - from payment processor: [4 Invalid amount] 
> 9013: Error - from payment processor: [4 Invalid amount]
> 
> 

This was introduced in 
https://github.com/civicrm/civicrm-core/pull/11016

where database changes supported decimal upto 9 places.



Before
----------------------------------------
![payflow_before](https://user-images.githubusercontent.com/3455173/39117808-6a2b3ed2-4705-11e8-9531-bcf5528a7a86.png)


After
----------------------------------------
![payflow_after](https://user-images.githubusercontent.com/3455173/39117830-74726cee-4705-11e8-9a6f-42172ebb78fc.png)


