### PR TITLE
core/issues/73 - Add invoice number to bookkeeping report

### DIFF
--- a/CRM/Report/Form/Contribute/Bookkeeping.php
+++ b/CRM/Report/Form/Contribute/Bookkeeping.php
@@ -291,8 +291,11 @@ class CRM_Report_Form_Contribute_Bookkeeping extends CRM_Report_Form {
             'default' => TRUE,
           ),
           'invoice_id' => array(
-            'title' => ts('Invoice ID'),
+            'title' => ts('Invoice Reference'),
             'default' => TRUE,
+          ),
+          'invoice_number' => array(
+            'title' => ts('Invoice Number'),
           ),
           'contribution_status_id' => array(
             'title' => ts('Contribution Status'),


### PR DESCRIPTION
Overview
----------------------------------------
Add invoice number to bookkeeping report

Before
----------------------------------------
Only Invoice ID was shown as a column in bookkeeping report

After
----------------------------------------
Invoice Number and Invoice Reference are both exposed in bookkeeping report
