### PR TITLE
More robust managed entity deletion

### DIFF
--- a/CRM/Core/ManagedEntities.php
+++ b/CRM/Core/ManagedEntities.php
@@ -191,6 +191,7 @@ class CRM_Core_ManagedEntities {
     $in = CRM_Core_DAO::escapeStrings(array_keys($this->moduleIndex[FALSE]));
     $dao = new CRM_Core_DAO_Managed();
     $dao->whereAdd("module in ($in)");
+    $dao->orderBy('id DESC');
     $dao->find();
     while ($dao->fetch()) {
       $this->disableEntity($dao);
@@ -215,6 +216,7 @@ class CRM_Core_ManagedEntities {
     if (!empty($knownModules)) {
       $in = CRM_Core_DAO::escapeStrings($knownModules);
       $dao->whereAdd("module NOT IN ($in)");
+      $dao->orderBy('id DESC');
     }
     $dao->find();
     while ($dao->fetch()) {

--- a/CRM/Core/ManagedEntities.php
+++ b/CRM/Core/ManagedEntities.php
@@ -340,11 +340,10 @@ class CRM_Core_ManagedEntities {
         if ($result['is_error']) {
           $this->onApiError($dao->entity_type, 'delete', $params, $result);
         }
-
-        CRM_Core_DAO::executeQuery('DELETE FROM civicrm_managed WHERE id = %1', array(
-          1 => array($dao->id, 'Integer'),
-        ));
       }
+      CRM_Core_DAO::executeQuery('DELETE FROM civicrm_managed WHERE id = %1', array(
+        1 => array($dao->id, 'Integer'),
+      ));
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes an issue that caused invalid orphan rows to be found in the `civicrm_managed` table upon uninstallation of an extension, which causes errors on subsequent attempts to enable / uninstall the extension.

Before
----------------------------------------
A entity could be removed from the database but still appear in the managed entities table. For example, an option value would be deleted when the option group is deleted but the associated row in civicrm_managed would not be deleted.

After
----------------------------------------
More robust invocations of removeStaleEntity() prevent this from happening.

Technical Details
----------------------------------------
First, I ensured that we always delete rows from civicrm_managed once we have established that they should be deleted. Previously this only happened after an additional check they they exist (which would fail if they have already been deleted by some other process.

Second, I ensured that the calls to removeStaleEntity() passed their IDs in descending ID order, which should ensure that dependents are removed before their dependencies, or in other words, in the reverse order that they were created.

