### PR TITLE
Add missing case type tests

### DIFF
--- a/ang/crmCaseType.js
+++ b/ang/crmCaseType.js
@@ -377,7 +377,6 @@
       })
         .then(function (data) {
           delete caseTypes.values[caseType.id];
-          $scope.$digest();
         });
     };
     $scope.revertCaseType = function (caseType) {

--- a/tests/karma/unit/crmCaseTypeSpec.js
+++ b/tests/karma/unit/crmCaseTypeSpec.js
@@ -347,5 +347,49 @@ describe('crmCaseType', function() {
         });
       });
     });
+
+    describe('deleteCaseType', function() {
+      var caseType = { id: _.uniqueId() };
+
+      beforeEach(function() {
+        crmApiSpy.and.returnValue($q.resolve(caseType));
+        scope.caseTypes[caseType.id] = caseType;
+
+        scope.deleteCaseType(caseType);
+        scope.$digest();
+      });
+
+      describe('when the case type can be deleted', function() {
+        it('deletes the case from the api', function() {
+          expect(crmApiSpy).toHaveBeenCalledWith('CaseType', 'delete', { id: caseType.id }, jasmine.any(Object));
+        });
+
+        it('removes the case type from the list', function() {
+          expect(scope.caseTypes[caseType.id]).toBeUndefined();
+        });
+      });
+
+      describe('when the case type cannot be delted', function() {
+        var error = { error_message: 'Error Message' };
+
+        beforeEach(function() {
+          var errorHandler;
+
+          crmApiSpy.and.returnValue($q.reject(error));
+          scope.caseTypes[caseType.id] = caseType;
+
+          spyOn(CRM, 'alert');
+          scope.deleteCaseType(caseType);
+          scope.$digest();
+
+          errorHandler = crmApiSpy.calls.mostRecent().args[3].error;
+          errorHandler(error);
+        });
+
+        it('displays the error message', function() {
+          expect(CRM.alert).toHaveBeenCalledWith(error.error_message, ts('Error'), 'error');
+        });
+      });
+    });
   });
 });

--- a/tests/karma/unit/crmCaseTypeSpec.js
+++ b/tests/karma/unit/crmCaseTypeSpec.js
@@ -1,6 +1,14 @@
 'use strict';
 
 describe('crmCaseType', function() {
+  var $controller;
+  var $compile;
+  var $httpBackend;
+  var $rootScope;
+  var apiCalls;
+  var ctrl;
+  var compile;
+  var scope;
 
   beforeEach(function() {
     CRM.resourceUrls = {
@@ -17,19 +25,15 @@ describe('crmCaseType', function() {
     });
   });
 
-  describe('CaseTypeCtrl', function() {
-    var apiCalls;
-    var ctrl;
-    var compile;
-    var $httpBackend;
-    var scope;
-    var timeout;
+  beforeEach(inject(function(_$controller_, _$compile_, _$httpBackend_, _$rootScope_) {
+    $controller = _$controller_;
+    $compile = _$compile_;
+    $httpBackend = _$httpBackend_;
+    $rootScope = _$rootScope_;
+  }));
 
-    beforeEach(inject(function(_$httpBackend_, $rootScope, $controller, $compile, $timeout) {
-      $httpBackend = _$httpBackend_;
-      scope = $rootScope.$new();
-      compile = $compile;
-      timeout = $timeout;
+  describe('CaseTypeCtrl', function() {
+    beforeEach(function () {
       apiCalls = {
         actStatuses: {
           values: [
@@ -224,8 +228,9 @@ describe('crmCaseType', function() {
           }
         }
       };
+      scope = $rootScope.$new();
       ctrl = $controller('CaseTypeCtrl', {$scope: scope, apiCalls: apiCalls});
-    }));
+    });
 
     it('should load activity statuses', function() {
       expect(scope.activityStatuses).toEqualData(apiCalls.actStatuses.values);
@@ -259,7 +264,7 @@ describe('crmCaseType', function() {
     var scope;
     var element;
 
-    beforeEach(inject(function($rootScope, $compile) {
+    beforeEach(function() {
       scope = $rootScope.$new();
       scope.activityTypeOptions = [1, 2, 3];
       element = '<span crm-add-name crm-options="activityTypeOptions"></span>';
@@ -268,7 +273,7 @@ describe('crmCaseType', function() {
 
       element = $compile(element)(scope);
       scope.$digest();
-    }));
+    });
 
     describe('when initialized', function () {
       var returnValue;

--- a/tests/karma/unit/crmCaseTypeSpec.js
+++ b/tests/karma/unit/crmCaseTypeSpec.js
@@ -390,6 +390,28 @@ describe('crmCaseType', function() {
           expect(CRM.alert).toHaveBeenCalledWith(error.error_message, ts('Error'), 'error');
         });
       });
+
+      describe('revertCaseType', function() {
+        var caseType = {
+          id: _.uniqueId(),
+          definition: {},
+          is_forked: '1'
+        };
+
+        describe('when reverting a case type', function() {
+          beforeEach(function() {
+            scope.revertCaseType(caseType);
+          });
+
+          it('resets the case type information using the api', function() {
+            expect(crmApiSpy).toHaveBeenCalledWith('CaseType', 'create', jasmine.objectContaining({
+              id: caseType.id,
+              definition: 'null',
+              is_forked: '0'
+            }), true);
+          });
+        });
+      });
     });
   });
 });

--- a/tests/karma/unit/crmCaseTypeSpec.js
+++ b/tests/karma/unit/crmCaseTypeSpec.js
@@ -1,3 +1,4 @@
+/* global $, _, CRM:true */
 'use strict';
 
 describe('crmCaseType', function() {
@@ -387,7 +388,7 @@ describe('crmCaseType', function() {
         });
 
         it('displays the error message', function() {
-          expect(CRM.alert).toHaveBeenCalledWith(error.error_message, ts('Error'), 'error');
+          expect(CRM.alert).toHaveBeenCalledWith(error.error_message, 'Error', 'error');
         });
       });
 

--- a/tests/karma/unit/crmCaseTypeSpec.js
+++ b/tests/karma/unit/crmCaseTypeSpec.js
@@ -261,7 +261,6 @@ describe('crmCaseType', function() {
   });
 
   describe('crmAddName', function () {
-    var scope;
     var element;
 
     beforeEach(function() {
@@ -286,6 +285,29 @@ describe('crmCaseType', function() {
       it('updates the UI with updated value of scope variable', function () {
         expect(returnValue).toEqual({ results: scope.activityTypeOptions });
       });
+    });
+  });
+
+  describe('CaseTypeListCtrl', function () {
+    var caseTypes;
+
+    beforeEach(function () {
+      caseTypes = {
+        values: {
+          1: { id: 1 },
+          2: { id: 2 },
+          3: { id: 3 }
+        }
+      };
+      scope = $rootScope.$new();
+      ctrl = $controller('CaseTypeListCtrl', {
+        $scope: scope,
+        caseTypes: caseTypes
+      });
+    });
+
+    it('should store an index of case types', function() {
+      expect(scope.caseTypes).toEqual(caseTypes.values);
     });
   });
 });

--- a/tests/karma/unit/crmCaseTypeSpec.js
+++ b/tests/karma/unit/crmCaseTypeSpec.js
@@ -4,6 +4,7 @@ describe('crmCaseType', function() {
   var $controller;
   var $compile;
   var $httpBackend;
+  var $q;
   var $rootScope;
   var apiCalls;
   var ctrl;
@@ -25,10 +26,11 @@ describe('crmCaseType', function() {
     });
   });
 
-  beforeEach(inject(function(_$controller_, _$compile_, _$httpBackend_, _$rootScope_) {
+  beforeEach(inject(function(_$controller_, _$compile_, _$httpBackend_, _$q_, _$rootScope_) {
     $controller = _$controller_;
     $compile = _$compile_;
     $httpBackend = _$httpBackend_;
+    $q = _$q_;
     $rootScope = _$rootScope_;
   }));
 
@@ -288,10 +290,10 @@ describe('crmCaseType', function() {
     });
   });
 
-  describe('CaseTypeListCtrl', function () {
-    var caseTypes;
+  describe('CaseTypeListCtrl', function() {
+    var caseTypes, crmApiSpy;
 
-    beforeEach(function () {
+    beforeEach(function() {
       caseTypes = {
         values: {
           1: { id: 1 },
@@ -299,15 +301,51 @@ describe('crmCaseType', function() {
           3: { id: 3 }
         }
       };
+      crmApiSpy = jasmine.createSpy('crmApi').and.returnValue($q.resolve());
       scope = $rootScope.$new();
       ctrl = $controller('CaseTypeListCtrl', {
         $scope: scope,
-        caseTypes: caseTypes
+        caseTypes: caseTypes,
+        crmApi: crmApiSpy
       });
     });
 
     it('should store an index of case types', function() {
       expect(scope.caseTypes).toEqual(caseTypes.values);
+    });
+
+    describe('toggleCaseType', function() {
+      var caseType = { id: _.uniqueId() };
+
+      describe('when the case is active', function() {
+        beforeEach(function() {
+          caseType.is_active = '1';
+
+          scope.toggleCaseType(caseType);
+        });
+
+        it('sets the case type as inactive', function() {
+          expect(crmApiSpy).toHaveBeenCalledWith('CaseType', 'create', jasmine.objectContaining({
+            id: caseType.id,
+            is_active: '0'
+          }), true);
+        });
+      });
+
+      describe('when the case is inactive', function() {
+        beforeEach(function() {
+          caseType.is_active = '0';
+
+          scope.toggleCaseType(caseType);
+        });
+
+        it('sets the case type as active', function() {
+          expect(crmApiSpy).toHaveBeenCalledWith('CaseType', 'create', jasmine.objectContaining({
+            id: caseType.id,
+            is_active: '1'
+          }), true);
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
Overview
----------------------------------------
This PR adds a few tests that are missing for the `caseTypeListCtrl` controller.


Technical Details
----------------------------------------
Common dependencies were moved to the top of the test file so they can be shared between the `CaseTypeCtrl` controller, the `crmAddName` directive, and the `CaseTypeListCtrl` controller:

```js
describe('crmCaseType', function() {
  var $controller;
  var $compile;
  var $httpBackend;
  var $q;
  var $rootScope;
  var apiCalls;
  var ctrl;
  var compile;
  var scope;

  // ...

  beforeEach(inject(function(_$controller_, _$compile_, _$httpBackend_, _$q_, _$rootScope_) {
    $controller = _$controller_;
    $compile = _$compile_;
    $httpBackend = _$httpBackend_;
    $q = _$q_;
    $rootScope = _$rootScope_;
  }));
});
```

The tests were split as follows:

* Testing the storage of case types passed by the route resolver:
https://github.com/civicrm/civicrm-core/blob/b4e42693d7359088b9ff6645aeb2dddaaaeab500/tests/karma/unit/crmCaseTypeSpec.js#L313-L315
* When a case type is toggled from active to inactive:
https://github.com/civicrm/civicrm-core/blob/b4e42693d7359088b9ff6645aeb2dddaaaeab500/tests/karma/unit/crmCaseTypeSpec.js#L320-L333
* When a case type is toggled from inactive to active:
https://github.com/civicrm/civicrm-core/blob/b4e42693d7359088b9ff6645aeb2dddaaaeab500/tests/karma/unit/crmCaseTypeSpec.js#L335-L349
* Deleting a case type:
https://github.com/civicrm/civicrm-core/blob/b4e42693d7359088b9ff6645aeb2dddaaaeab500/tests/karma/unit/crmCaseTypeSpec.js#L362-L370
* Displaying an error message in case the case type could not be deleted:
https://github.com/civicrm/civicrm-core/blob/b4e42693d7359088b9ff6645aeb2dddaaaeab500/tests/karma/unit/crmCaseTypeSpec.js#L389-L391
* Reverting a case type:
https://github.com/civicrm/civicrm-core/blob/b4e42693d7359088b9ff6645aeb2dddaaaeab500/tests/karma/unit/crmCaseTypeSpec.js#L401-L414


Comments
----------------------------------------
* A `scope.$digest()` was removed from the `CaseTypeListCtrl` controller since it was not needed. When case types are deleted the list is updated successfully without this statement.