### PR TITLE
core/issues/74 - 'Price Set Details for Event Participants' gives DB …

### DIFF
--- a/CRM/Contact/Form/Search/Custom/PriceSet.php
+++ b/CRM/Contact/Form/Search/Custom/PriceSet.php
@@ -146,12 +146,14 @@ ORDER BY c.id, l.price_field_value_id;
 
     foreach (array_keys($rows) as $participantID) {
       $values = implode(',', $rows[$participantID]);
-      $sql = "
+      if ($values) {
+        $sql = "
 UPDATE {$this->_tableName}
 SET $values
 WHERE participant_id = $participantID;
 ";
-      CRM_Core_DAO::executeQuery($sql);
+        CRM_Core_DAO::executeQuery($sql);
+      }
     }
   }
 


### PR DESCRIPTION
…error if the price fields are disabled.

Overview
----------------------------------------
_Steps to replicate:_


1. Create a price set and associate with an event.
2. Register a participant with the event.
3. Disable the price fields.
4. Go to  Custom Searches > Price Set Details for Event Participants, search with the said event.

It throws DB error

Before
----------------------------------------
![price_before](https://user-images.githubusercontent.com/3455173/39169273-d3c9e438-47b4-11e8-8058-c02f3737bcd5.png)


After
----------------------------------------
![price_after](https://user-images.githubusercontent.com/3455173/39169283-da46e658-47b4-11e8-97d4-73673439d4aa.png)

https://lab.civicrm.org/dev/core/issues/74