### PR TITLE
core/issues/75 - warning message after an activity is created

### DIFF
--- a/settings/Core.setting.php
+++ b/settings/Core.setting.php
@@ -974,6 +974,7 @@ return array(
     'type' => 'Array',
     'add' => '4.7',
     'is_domain' => 1,
+    'is_contact' => 0,
     'default' => array(),
     'title' => 'Do not notify assignees for',
     'help_text' => 'These activity types will be excluded from automated email notifications to assignees.',


### PR DESCRIPTION
Overview
----------------------------------------
Warning message displayed after an activity is created.

Before
----------------------------------------
Creating activities on [dmaster](http://dmaster.demo.civicrm.org/civicrm/activity?reset=1&action=add&context=standalone) generate the following warning message.

![image](https://user-images.githubusercontent.com/5929648/39228019-7d3208d8-4879-11e8-8b09-285c7c7d60c4.png)

After
----------------------------------------
Fixed.