### PR TITLE
Fix release notes for 5.0.x

### DIFF
--- a/CRM/Upgrade/Incremental/sql/5.0.2.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.0.2.mysql.tpl
@@ -1,0 +1,1 @@
+{* file to handle db changes in 5.0.2 during upgrade *}

--- a/release-notes/5.0.1.md
+++ b/release-notes/5.0.1.md
@@ -2,5 +2,5 @@
 
 Released Apr 18, 2018
 
-- **Backport: Dedupe - Fix for recent regression causing dedupe screen to fail on WordPress. ([11975](https://github.com/civicrm/civicrm-core/pull/11975)**
+- **Backport: Dedupe - Fix for recent regression causing dedupe screen to fail on WordPress. ([11975](https://github.com/civicrm/civicrm-core/pull/11975))**
 - **Backport: VersionCheck - Get more nuanced messages from latest.civicrm.org. ([11991](https://github.com/civicrm/civicrm-core/pull/11991))**

--- a/release-notes/5.0.1.md
+++ b/release-notes/5.0.1.md
@@ -1,0 +1,6 @@
+# CiviCRM 5.0.1
+
+Released Apr 18, 2018
+
+- **Backport: Dedupe - Fix for recent regression causing dedupe screen to fail on WordPress. ([11975](https://github.com/civicrm/civicrm-core/pull/11975)**
+- **Backport: VersionCheck - Get more nuanced messages from latest.civicrm.org. ([11991](https://github.com/civicrm/civicrm-core/pull/11991))**

--- a/release-notes/5.0.2.md
+++ b/release-notes/5.0.2.md
@@ -1,0 +1,6 @@
+# CiviCRM 5.0.2
+
+Released Apr 25, 2018
+
+- **Backport: Use current formula for hyperlinking release notes ([12008](https://github.com/civicrm/civicrm-core/pull/12008))**
+- **Add missing release notes for 5.0.1**

--- a/sql/civicrm_generated.mysql
+++ b/sql/civicrm_generated.mysql
@@ -398,7 +398,7 @@ UNLOCK TABLES;
 
 LOCK TABLES `civicrm_domain` WRITE;
 /*!40000 ALTER TABLE `civicrm_domain` DISABLE KEYS */;
-INSERT INTO `civicrm_domain` (`id`, `name`, `description`, `config_backend`, `version`, `contact_id`, `locales`, `locale_custom_strings`) VALUES (1,'Default Domain Name',NULL,NULL,'5.0.1',1,NULL,'a:1:{s:5:\"en_US\";a:0:{}}');
+INSERT INTO `civicrm_domain` (`id`, `name`, `description`, `config_backend`, `version`, `contact_id`, `locales`, `locale_custom_strings`) VALUES (1,'Default Domain Name',NULL,NULL,'5.0.2',1,NULL,'a:1:{s:5:\"en_US\";a:0:{}}');
 /*!40000 ALTER TABLE `civicrm_domain` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/templates/CRM/common/footer.tpl
+++ b/templates/CRM/common/footer.tpl
@@ -31,7 +31,7 @@
 
   <div class="crm-footer" id="civicrm-footer">
     {crmVersion assign=version}
-    {ts}Powered by CiviCRM{/ts} <a href="https://github.com/civicrm/civicrm-core/blob/{$version}/release-notes/{$version}.md">{$version}</a>.
+    {ts}Powered by CiviCRM{/ts} <a href="https://download.civicrm.org/about/{$version}">{$version}</a>.
     {if !empty($footer_status_severity)}
       <span class="status{if $footer_status_severity gt 3} crm-error{elseif $footer_status_severity gt 2} crm-warning{else} crm-ok{/if}">
       <a href="{crmURL p='civicrm/a/#/status'}">{$footer_status_message}</a>

--- a/xml/version.xml
+++ b/xml/version.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="iso-8859-1" ?>
 <version>
-  <version_no>5.0.1</version_no>
+  <version_no>5.0.2</version_no>
 </version>


### PR DESCRIPTION
Overview
----------------------------------------
Version 5.0.1 was the first `PATCH` release since the numbering was realigned. Unfortunately, the revised release process didn't account for `release-notes`. Consequently, the footer link in the admin UI broke. This patch generally cleans up the situation by adding notes and backporting a preventive measure from 5.1.

Before
----------------------------------------
* `5.0` does not have `release-notes` for `5.0.1` or `5.0.2`.
* `5.0` links to release notes with the URL `https://github.com/civicrm/civicrm-core/blob/{$version}/release-notes/{$version}.md`. Because the URL is tied to a `git` tag, it's impossible to fix without doing a new release (or without changing history).

After
----------------------------------------
* `5.0` has `release-notes` for both `5.0.1` and `5.0.2`
* `5.0` links to release notes with the URL `https://download.civicrm.org/about/{$version}`. This redirects to the best available release notes. (See [AboutController](https://github.com/civicrm/civicrm-dist-manager/blob/master/src/CiviDistManagerBundle/Controller/AboutController.php#L13).)

Comments
----------------------------------------
* Separately, we've also updated the release process for 5.x `PATCH` releases to include a pre-flight check on the release notes. (https://lab.civicrm.org/dev/release/commit/cacaaba61decc3a7a6ef0a6ee5414f831570518b)
* Separately, I'm updating the version-check backend so that `5.0.2` can be displayed as a `notice` instead of a `warning`. (https://github.com/civicrm/civicrm-pingback/commit/68f896b57577df4086cbb5985837f87d73b3b8bd)
* This is kinda unfortunate from a political perspective, because the importance of the fix is really debateable. On one hand, it's a superficial adminy thing (release notes don't open). On the other hand, it is a regression (footer link stopped working) and it affects release mechanics (which are sorta release-critical by definition).