### PR TITLE
core/issues/78 - Incorrect Payment Processor for Recurring Payments

### DIFF
--- a/CRM/Core/Payment/AuthorizeNetIPN.php
+++ b/CRM/Core/Payment/AuthorizeNetIPN.php
@@ -77,6 +77,7 @@ class CRM_Core_Payment_AuthorizeNetIPN extends CRM_Core_Payment_BaseIPN {
         // processor id & the handleNotification function (which should call the completetransaction api & by-pass this
         // entirely). The only thing the IPN class should really do is extract data from the request, validate it
         // & call completetransaction or call fail? (which may not exist yet).
+        Civi::log()->warning('Unreliable method used for AuthNet IPN - this will cause problems if you have more than one instance');
         $paymentProcessorTypeID = CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_PaymentProcessorType',
           'AuthNet', 'id', 'name'
         );
@@ -90,6 +91,9 @@ class CRM_Core_Payment_AuthorizeNetIPN extends CRM_Core_Payment_BaseIPN {
 
       if (!$this->validateData($input, $ids, $objects, TRUE, $paymentProcessorID)) {
         return FALSE;
+      }
+      if (!empty($ids['paymentProcessor']) && $objects['contributionRecur']->payment_processor_id != $ids['paymentProcessor']) {
+        Civi::log()->warning('Payment Processor does not match the recurring processor id.', array('civi.tag' => 'deprecated'));
       }
 
       if ($component == 'contribute' && $ids['contributionRecur']) {

--- a/CRM/Core/Payment/AuthorizeNetIPN.php
+++ b/CRM/Core/Payment/AuthorizeNetIPN.php
@@ -67,20 +67,26 @@ class CRM_Core_Payment_AuthorizeNetIPN extends CRM_Core_Payment_BaseIPN {
       // load post ids in $ids
       $this->getIDs($ids, $input);
 
-      // This is an unreliable method as there could be more than one instance.
-      // Recommended approach is to use the civicrm/payment/ipn/xx url where xx is the payment
-      // processor id & the handleNotification function (which should call the completetransaction api & by-pass this
-      // entirely). The only thing the IPN class should really do is extract data from the request, validate it
-      // & call completetransaction or call fail? (which may not exist yet).
-      $paymentProcessorTypeID = CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_PaymentProcessorType',
-        'AuthNet', 'id', 'name'
-      );
-      $paymentProcessorID = (int) civicrm_api3('PaymentProcessor', 'getvalue', array(
-        'is_test' => 0,
-        'options' => array('limit' => 1),
-        'payment_processor_type_id' => $paymentProcessorTypeID,
-         'return' => 'id',
-      ));
+      // Attempt to get payment processor ID from URL
+      if (!empty($this->_inputParameters['processor_id'])) {
+        $paymentProcessorID = $this->_inputParameters['processor_id'];
+      }
+      else {
+        // This is an unreliable method as there could be more than one instance.
+        // Recommended approach is to use the civicrm/payment/ipn/xx url where xx is the payment
+        // processor id & the handleNotification function (which should call the completetransaction api & by-pass this
+        // entirely). The only thing the IPN class should really do is extract data from the request, validate it
+        // & call completetransaction or call fail? (which may not exist yet).
+        $paymentProcessorTypeID = CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_PaymentProcessorType',
+          'AuthNet', 'id', 'name'
+        );
+        $paymentProcessorID = (int) civicrm_api3('PaymentProcessor', 'getvalue', array(
+          'is_test' => 0,
+          'options' => array('limit' => 1),
+          'payment_processor_type_id' => $paymentProcessorTypeID,
+           'return' => 'id',
+        ));
+      }
 
       if (!$this->validateData($input, $ids, $objects, TRUE, $paymentProcessorID)) {
         return FALSE;


### PR DESCRIPTION
Overview
----------------------------------------
Incorrect Payment Processor assigned for Recurring Payments

Before
----------------------------------------
The issue arises due to there being two AuthNet payment processors, one for both A1 and A2. And the CiviCRM code is (naively) written assuming there'd be a maximum of one. So when AuthNet calls into CiviCRM to notify it of a successful recurring payment, for the A1 payments it is loading the A2 payment processor — and then failing

After
----------------------------------------
Information from the address that AuthNet posts its updates is used, which can signal which payment processor to use.


Technical Details
----------------------------------------
This patch uses the id from /civicrm/payments/ipn/{$id} to select the correct payment processor, before falling back to the old method of picking just the first, active, Authorize.net payment processor. It's possibly an edge case, but this is an issue for CiviCRM setups with multiple instances of the Authorize.net payment method.

Comments
----------------------------------------
Patch by @torrance 

----------

Gitlab Issue - https://lab.civicrm.org/dev/core/issues/78