### PR TITLE
Move help section outside the container

### DIFF
--- a/templates/CRM/Contact/Form/DedupeFind.tpl
+++ b/templates/CRM/Contact/Form/DedupeFind.tpl
@@ -23,13 +23,13 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-<div class="crm-block crm-form-block crm-dedupe-find-form-block">
 <div class="help">
     {ts}You can search all contacts for duplicates or limit the results for better performance.
       If you limit by group then it will look for matches with that group both inside and outside of the group.
       You can also limit the contacts in the group to be matched by specifying the number of contacts to match. This can be done in conjunction with a group or separately and is recommended for performance reasons.
     {/ts}
 </div>
+<div class="crm-block crm-form-block crm-dedupe-find-form-block">
    <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
    <table class="form-layout-compressed">
      <tr class="crm-dedupe-find-form-block-group_id">


### PR DESCRIPTION
Overview
----------------------------------------
This PR moves help section outside of container to preserve consistency among other screens

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/26058635/39302311-d9db4fbc-496f-11e8-8aa0-f5a6bc75a416.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/26058635/39302292-c5e18ef4-496f-11e8-8d3d-3b654dd11bbe.png)
