### PR TITLE
core/issues/80 - Current Employer is not reset after relationship is …

### DIFF
--- a/CRM/Contact/Form/Relationship.php
+++ b/CRM/Contact/Form/Relationship.php
@@ -417,10 +417,14 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
     $this->setEmploymentRelationship($params, $relationshipIds);
 
     // Refresh contact tabs which might have been affected
-    $this->ajaxResponse['updateTabs'] = array(
-      '#tab_member' => CRM_Contact_BAO_Contact::getCountComponent('membership', $this->_contactId),
-      '#tab_contribute' => CRM_Contact_BAO_Contact::getCountComponent('contribution', $this->_contactId),
+    $this->ajaxResponse = array(
+      'reloadBlocks' => array('#crm-contactinfo-content'),
+      'updateTabs' => array(
+        '#tab_member' => CRM_Contact_BAO_Contact::getCountComponent('membership', $this->_contactId),
+        '#tab_contribute' => CRM_Contact_BAO_Contact::getCountComponent('contribution', $this->_contactId),
+      ),
     );
+
   }
 
   /**
@@ -546,10 +550,7 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
       throw new CRM_Core_Exception('Relationship create error ' . $e->getMessage());
     }
 
-    $this->clearCurrentEmployer($params);
-
     $this->setMessage(array('saved' => TRUE));
-
     return array($params, array($this->_relationshipId));
   }
 
@@ -648,38 +649,19 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
    * @param array $relationshipIds
    */
   private function setEmploymentRelationship($params, $relationshipIds) {
-    if (
-      !empty($params['is_current_employer']) &&
-      $this->_allRelationshipNames[$params['relationship_type_id']]["name_a_b"] == 'Employee of') {
-      $employerParams = array();
-      foreach ($relationshipIds as $id) {
+    $employerParams = array();
+    foreach ($relationshipIds as $id) {
+      if (!CRM_Contact_BAO_Relationship::isCurrentEmployerNeedingToBeCleared($params, $id)
+        //don't think this is required to check again.
+        && $this->_allRelationshipNames[$params['relationship_type_id']]["name_a_b"] == 'Employee of') {
         // Fixme this is dumb why do we have to look this up again?
         $rel = CRM_Contact_BAO_Relationship::getRelationshipByID($id);
         $employerParams[$rel->contact_id_a] = $rel->contact_id_b;
       }
+    }
+    if (!empty($employerParams)) {
       // @todo this belongs in the BAO.
       CRM_Contact_BAO_Contact_Utils::setCurrentEmployer($employerParams);
-      // Refresh contact summary if in ajax mode
-      $this->ajaxResponse['reloadBlocks'] = array('#crm-contactinfo-content');
-    }
-  }
-
-  /**
-   * Clears the current employer if the relationship type
-   * get changed, disabled or 'current employer' checkbox get unchecked.
-   *
-   * @param $params
-   */
-  private function clearCurrentEmployer($params) {
-    // @todo this belongs in the BAO.
-    if ($this->_isCurrentEmployer) {
-      $relChanged = $params['relationship_type_id'] != $this->_values['relationship_type_id'];
-      if (!$params['is_active'] || !$params['is_current_employer'] || $relChanged) {
-        CRM_Contact_BAO_Contact_Utils::clearCurrentEmployer($this->_values['contact_id_a']);
-
-        // Refresh contact summary if in ajax mode
-        $this->ajaxResponse['reloadBlocks'] = array('#crm-contactinfo-content');
-      }
     }
   }
 


### PR DESCRIPTION
…updated

Overview
----------------------------------------
Current Employer is not reset after relationship is updated.

Before
----------------------------------------
On editing a relationship type from `Employer of` to some other value, current employer value is still shown for the contact.

After
----------------------------------------
Current Employer is deleted when relationship type is updated.

Technical Details
----------------------------------------
Moved the logic to BAO layer as commented on `CRM_Contact_Form_Relationship-> clearCurrentEmployer` function. 

Comments
----------------------------------------
Added unit test.

-----------

Gitlab issue - https://lab.civicrm.org/dev/core/issues/80