### PR TITLE
(NFC) Fix Warnings When Updating Custom Entities

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -193,21 +193,14 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
     }
 
     $transaction = new CRM_Core_Transaction();
+
+    $htmlType = CRM_Utils_Array::value('html_type', $params);
+    $dataType = CRM_Utils_Array::value('data_type', $params);
+    $allowedOptionTypes = array('String', 'Int', 'Float', 'Money');
+
     // create any option group & values if required
-    if ($params['html_type'] != 'Text' &&
-      in_array($params['data_type'], array(
-        'String',
-        'Int',
-        'Float',
-        'Money',
-      ))
+    if ($htmlType != 'Text' && in_array($dataType, $allowedOptionTypes)
     ) {
-
-      $tableName = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup',
-        $params['custom_group_id'],
-        'table_name'
-      );
-
       //CRM-16659: if option_value then create an option group for this custom field.
       if ($params['option_type'] == 1 && (empty($params['option_group_id']) || !empty($params['option_value']))) {
         // first create an option group for this custom group
@@ -215,7 +208,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
         $optionGroup->name = "{$columnName}_" . date('YmdHis');
         $optionGroup->title = $params['label'];
         $optionGroup->is_active = 1;
-        $optionGroup->data_type = $params['data_type'];
+        $optionGroup->data_type = $dataType;
         $optionGroup->save();
         $params['option_group_id'] = $optionGroup->id;
         if (!empty($params['option_value']) && is_array($params['option_value'])) {
@@ -225,7 +218,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
               $optionValue->option_group_id = $optionGroup->id;
               $optionValue->label = $params['option_label'][$k];
               $optionValue->name = CRM_Utils_String::titleToVar($params['option_label'][$k]);
-              switch ($params['data_type']) {
+              switch ($dataType) {
                 case 'Money':
                   $optionValue->value = CRM_Utils_Rule::cleanMoney($v);
                   break;
@@ -262,7 +255,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
       if (empty($params['default_value'])) {
         //don't insert only value separator as default value, CRM-4579
         $defaultValue = self::getOptionGroupDefault($params['option_group_id'],
-          $params['html_type']
+          $htmlType
         );
 
         if (!CRM_Utils_System::isNull(explode(CRM_Core_DAO::VALUE_SEPARATOR,
@@ -275,7 +268,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
     }
 
     // since we need to save option group id :)
-    if (!isset($params['attributes']) && strtolower($params['html_type']) == 'textarea') {
+    if (!isset($params['attributes']) && strtolower($htmlType) == 'textarea') {
       $params['attributes'] = 'rows=4, cols=60';
     }
 

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -60,37 +60,37 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup {
       $group->title = $params['title'];
     }
 
-    if (in_array($params['extends'][0],
-      array(
-        'ParticipantRole',
-        'ParticipantEventName',
-        'ParticipantEventType',
-      )
-    )) {
+    $extends = CRM_Utils_Array::value('extends', $params, []);
+    $extendsEntity = CRM_Utils_Array::value(0, $extends);
+
+    $participantEntities = array(
+      'ParticipantRole',
+      'ParticipantEventName',
+      'ParticipantEventType',
+    );
+
+    if (in_array($extendsEntity, $participantEntities)) {
       $group->extends = 'Participant';
     }
     else {
-      $group->extends = $params['extends'][0];
+      $group->extends = $extendsEntity;
     }
 
     $group->extends_entity_column_id = 'null';
-    if (
-      $params['extends'][0] == 'ParticipantRole' ||
-      $params['extends'][0] == 'ParticipantEventName' ||
-      $params['extends'][0] == 'ParticipantEventType'
+    if (in_array($extendsEntity, $participantEntities)
     ) {
-      $group->extends_entity_column_id = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionValue', $params['extends'][0], 'value', 'name');
+      $group->extends_entity_column_id = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionValue', $extendsEntity, 'value', 'name');
     }
 
     //this is format when form get submit.
-    $extendsChildType = CRM_Utils_Array::value(1, $params['extends']);
+    $extendsChildType = CRM_Utils_Array::value(1, $extends);
     //lets allow user to pass direct child type value, CRM-6893
     if (!empty($params['extends_entity_column_value'])) {
       $extendsChildType = $params['extends_entity_column_value'];
     }
     if (!CRM_Utils_System::isNull($extendsChildType)) {
       $extendsChildType = implode(CRM_Core_DAO::VALUE_SEPARATOR, $extendsChildType);
-      if (CRM_Utils_Array::value(0, $params['extends']) == 'Relationship') {
+      if (CRM_Utils_Array::value(0, $extends) == 'Relationship') {
         $extendsChildType = str_replace(array('_a_b', '_b_a'), array(
           '',
           '',
@@ -211,7 +211,7 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup {
         $params['id'],
         'table_name'
       );
-      CRM_Core_BAO_SchemaHandler::changeFKConstraint($table, self::mapTableName($params['extends'][0]));
+      CRM_Core_BAO_SchemaHandler::changeFKConstraint($table, self::mapTableName($extendsEntity));
     }
     $transaction->commit();
 

--- a/tests/phpunit/api/v3/CustomFieldTest.php
+++ b/tests/phpunit/api/v3/CustomFieldTest.php
@@ -544,6 +544,17 @@ class api_v3_CustomFieldTest extends CiviUnitTestCase {
     $this->assertEquals($attachment['id'], $result[$cfId]);
   }
 
+  public function testUpdateCustomField() {
+    $customGroup = $this->customGroupCreate(array('extends' => 'Individual'));
+    $params = array('id' => $customGroup['id'], 'is_active' => 0);
+    $result = $this->callAPISuccess('CustomGroup', 'create', $params);
+    $result = array_shift($result['values']);
+
+    $this->assertEquals(0, $result['is_active']);
+
+    $this->customGroupDelete($customGroup['id']);
+  }
+
   /**
    * @param $getFieldsResult
    *

--- a/tests/phpunit/api/v3/CustomGroupTest.php
+++ b/tests/phpunit/api/v3/CustomGroupTest.php
@@ -373,4 +373,17 @@ class api_v3_CustomGroupTest extends CiviUnitTestCase {
     }
   }
 
+  public function testUpdateCustomGroup() {
+    $customGroup = $this->customGroupCreate();
+    $customGroupId = $customGroup['id'];
+
+    //update is_active
+    $params = ['id' => $customGroupId, 'is_active' => 0];
+    $result = $this->callAPISuccess('CustomGroup', 'create', $params);
+    $result = array_shift($result['values']);
+
+    $this->assertEquals(0, $result['is_active']);
+    $this->customGroupDelete($customGroupId);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------

Trying to update a custom group or field worked, but it produced warnings about missing indices. This PR fixes those warnings.

Before
----------------------------------------

Updating an existing `CustomGroup` or `CustomField` would work, but produce warnings. This caused some PHPUnit tests to fail if they were updating a `CustomGroup` or `CustomField`.

For example:

```
$params = ['id' => 1, 'is_active' => 0];
civicrm_api3('CustomField', 'create', $params);
```

Will produce a warning (from a test I wrote for this):

```
Failure in api call for CustomGroup create:  Undefined index: extends
#0 /repos/civicrm-core/CRM/Core/BAO/CustomGroup.php(64): PHPUnit_Util_ErrorHandler::handleError(8, 'Undefined index...', '/repos/civicrm-...', 64, Array)
```

After
----------------------------------------

No warnings are produced.

After
----------------------------------------

I did some minor cleanup, replacing some arrays with variables and trying to shorten lines. I also deleted one unused variable, `$tableName`