### PR TITLE
dev/core#85 On some servers mail() fails when 'Cc' or 'Bcc' headers are defined but empty

### DIFF
--- a/CRM/Utils/Mail.php
+++ b/CRM/Utils/Mail.php
@@ -203,8 +203,15 @@ class CRM_Utils_Mail {
       CRM_Utils_Array::value('toEmail', $params),
       FALSE
     );
-    $headers['Cc'] = CRM_Utils_Array::value('cc', $params);
-    $headers['Bcc'] = CRM_Utils_Array::value('bcc', $params);
+
+    // On some servers mail() fails when 'Cc' or 'Bcc' headers are defined but empty.
+    foreach (['Cc', 'Bcc'] as $optionalHeader) {
+      $headers[$optionalHeader] = CRM_Utils_Array::value(strtolower($optionalHeader), $params);
+      if (empty($headers[$optionalHeader])) {
+        unset($headers[$optionalHeader]);
+      }
+    }
+
     $headers['Subject'] = CRM_Utils_Array::value('subject', $params);
     $headers['Content-Type'] = $htmlMessage ? 'multipart/mixed; charset=utf-8' : 'text/plain; charset=utf-8';
     $headers['Content-Disposition'] = 'inline';


### PR DESCRIPTION
Overview
----------------------------------------
On some servers the PHP mail() function fails to send email if empty 'Cc' or 'Bcc' headers are set.

[dev/core#85](https://lab.civicrm.org/dev/core/issues/85)

Before
----------------------------------------
Mail cannot be sent, PHP mail() returns false (no error message).

After
----------------------------------------
Mail is sent, PHP mail() sends.

Technical Details
----------------------------------------
'Cc' and 'Bcc' headers are optional.  Most servers will just ignore them if empty but some seem to fail if they are present but have no email addresses.  So we unset them if empty.
