### PR TITLE
dev/core#86 Notify admin when testing email if CIVICRM_MAIL_LOG_AND_SEND is set

### DIFF
--- a/CRM/Admin/Form/Setting/Smtp.php
+++ b/CRM/Admin/Form/Setting/Smtp.php
@@ -115,10 +115,9 @@ class CRM_Admin_Form_Setting_Smtp extends CRM_Admin_Form_Setting {
 
         $to = '"' . $toDisplayName . '"' . "<$toEmail>";
         $from = '"' . $domainEmailName . '" <' . $domainEmailAddress . '>';
-        $testMailStatusMsg = ts('Sending test email. FROM: %1 TO: %2.<br />', array(
-            1 => $domainEmailAddress,
-            2 => $toEmail,
-          ));
+        $testMailStatusMsg = ts('Sending test email') . ':<br />'
+          . ts('From: %1', array(1 => $domainEmailAddress)) . '<br />'
+          . ts('To: %1', array(1 => $toEmail)) . '<br />';
 
         $params = array();
         if ($formValues['outBound_option'] == CRM_Mailing_Config::OUTBOUND_OPTION_SMTP) {
@@ -170,7 +169,10 @@ class CRM_Admin_Form_Setting_Smtp extends CRM_Admin_Form_Setting {
         $errorScope = CRM_Core_TemporaryErrorScope::ignoreException();
         $result = $mailer->send($toEmail, $headers, $message);
         unset($errorScope);
-        if (defined('CIVICRM_MAIL_LOG')) {
+        if (defined('CIVICRM_MAIL_LOG') && defined('CIVICRM_MAIL_LOG_AND_SEND')) {
+          $testMailStatusMsg .= '<br />' . ts('You have defined CIVICRM_MAIL_LOG_AND_SEND - mail will be logged.') . '<br /><br />';
+        }
+        if (defined('CIVICRM_MAIL_LOG') && !defined('CIVICRM_MAIL_LOG_AND_SEND')) {
           CRM_Core_Session::setStatus($testMailStatusMsg . ts('You have defined CIVICRM_MAIL_LOG - no mail will be sent.  Your %1 settings have not been tested.', array(1 => strtoupper($mailerName))), ts("Mail not sent"), "warning");
         }
         elseif (!is_a($result, 'PEAR_Error')) {

--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -304,6 +304,13 @@ if (!defined('CIVICRM_MAIL_SMARTY')) {
 // define( 'CIVICRM_MAIL_LOG', '%%templateCompileDir%%/mail.log');
 // }
 
+/**
+ * This setting will only work if CIVICRM_MAIL_LOG is defined.  Mail will be logged and then sent.
+ */
+//if (!defined('CIVICRM_MAIL_LOG_AND_SEND')) {
+//  define( 'CIVICRM_MAIL_LOG_AND_SEND', 1);
+//}
+
 
 if (!defined('CIVICRM_DOMAIN_ID')) {
   define( 'CIVICRM_DOMAIN_ID', 1);


### PR DESCRIPTION
Overview
----------------------------------------
When CIVICRM_MAIL_LOG_AND_SEND is set the admin is not notified if it is set, but they are if CIVICRM_MAIL_LOG is set.  With this PR they are notified if either is set.

https://lab.civicrm.org/dev/core/issues/86

Before
----------------------------------------
No notification if CIVICRM_MAIL_LOG_AND_SEND is set.

After
----------------------------------------
![localhost_8000_civicrm_admin_setting_smtp__qf_smtp_display true qfkey 0bb739f2972c8a93320e2ab3b5b2e28f_2576 1](https://user-images.githubusercontent.com/2052161/39397715-dea66026-4afb-11e8-816a-f7b47c35cbc7.png)
