### PR TITLE
dev/core#87 PayPal Pro missing parameters (add standard getters)

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -1229,6 +1229,11 @@ abstract class CRM_Core_Payment {
       return $result;
     }
 
+    // Set some "Standard" parameters for payment
+    $this->getIpAddress($params);
+    $this->getCountry($params);
+    $this->getStateProvince($params);
+
     if ($this->_paymentProcessor['billing_mode'] == 4) {
       $result = $this->doTransferCheckout($params, $component);
       if (is_array($result) && !isset($result['payment_status_id'])) {

--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -1012,6 +1012,54 @@ abstract class CRM_Core_Payment {
   }
 
   /**
+   * Get the IP address of the remote user
+   *
+   * @param $params
+   *
+   * @return string
+   */
+  protected function getIpAddress(&$params) {
+    if (empty($params['ip_address'])) {
+      $params['ip_address'] = CRM_Utils_System::ipAddress();
+    }
+    return $params['ip_address'];
+  }
+
+  /**
+   * Get the state_province name from the state_province id.
+   *
+   * @param $params
+   * @param bool $abbreviation Whether to return the abbreviated version or not
+   *
+   * @return array
+   */
+  protected function getStateProvince(&$params, $abbreviation = TRUE) {
+    if (!empty($params['state_province_id'])) {
+      if ($abbreviation) {
+        $params['state_province'] = CRM_Core_PseudoConstant::stateProvinceAbbreviation($params['state_province_id']);
+      }
+      else {
+        $params['state_province'] = CRM_Core_PseudoConstant::stateProvince($params['state_province_id']);
+      }
+    }
+    return CRM_Utils_Array::value('state_province', $params);
+  }
+
+  /**
+   * Get the country name from the country_id
+   *
+   * @param $params
+   *
+   * @return array|null
+   */
+  protected function getCountry(&$params) {
+    if (!empty($params['country_id'])) {
+      $params['country'] = CRM_Core_PseudoConstant::countryIsoCode($params['country_id']);
+    }
+    return CRM_Utils_Array::value('country', $params);
+  }
+
+  /**
    * Get url to return to after cancelled or failed transaction.
    *
    * @param string $qfKey


### PR DESCRIPTION
Overview
----------------------------------------
state_province, country and ip_address are not always set properly for paypal pro due to inconsistency with parameters being passed.
Ref: https://lab.civicrm.org/dev/core/issues/87

Before
----------------------------------------
state_province, country and ip_address may not be passed to payment processor.

After
----------------------------------------
This applies to ALL payment processors:
* If state_province and country were passed from the payment form in one way or another, they will be presented in a consistent format to the payment processor.
* Add client ip_address to the list of parameters so payment processors don't have to retrieve this manually if they require it (paypal pro wants it but was not retrieving it).

Technical Details
----------------------------------------
This PR adds three generic "getters" to CRM_Core_Payment per @eileenmcnaughton suggestion.  For compatibility, no parameters are removed but additional parameters may be set depending on what is passed in.  For example if only country_id is defined, then country will be set as well.

Comments
----------------------------------------
This fixes a real issue identified with the paypal pro processor in core, but the inconsistency of parameters passed affects other processors and means each processor has to do extra coding to make sure that the parameters are in the right format when they are passed in.
See for example https://civicrm.stackexchange.com/questions/24316/paypal-pro-billing-address-state-province-country-not-being-passed
