### PR TITLE
Remove usage of deprecated paymentProcessorType function

### DIFF
--- a/CRM/Contribute/Form/ContributionPage/Amount.php
+++ b/CRM/Contribute/Form/ContributionPage/Amount.php
@@ -430,7 +430,6 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
           $paymentProcessorID,
           'payment_processor_type_id'
         );
-        $paymentProcessorType = CRM_Core_PseudoConstant::paymentProcessorType(FALSE, $paymentProcessorTypeId, 'name');
       }
     }
 

--- a/CRM/Financial/BAO/PaymentProcessor.php
+++ b/CRM/Financial/BAO/PaymentProcessor.php
@@ -218,34 +218,6 @@ class CRM_Financial_BAO_PaymentProcessor extends CRM_Financial_DAO_PaymentProces
   public static function getPayment($paymentProcessorID, $mode = 'based_on_id') {
     $capabilities = ($mode == 'test') ? array('TestMode') : array();
     $processors = self::getPaymentProcessors($capabilities, array($paymentProcessorID));
-    $processor = $processors[$paymentProcessorID];
-    $fields = array(
-      'id',
-      'name',
-      'payment_processor_type_id',
-      'user_name',
-      'password',
-      'signature',
-      'url_site',
-      'url_api',
-      'url_recur',
-      'url_button',
-      'subject',
-      'class_name',
-      'is_recur',
-      'billing_mode',
-      'is_test',
-      'payment_type',
-      'is_default',
-    );
-    // Just to prevent e-Notices elsewhere we set all fields.
-    foreach ($fields as $name) {
-      if (!isset($processor)) {
-        $processor[$name] = NULL;
-      }
-    }
-    $processor['payment_processor_type'] = CRM_Core_PseudoConstant::paymentProcessorType(FALSE,
-      $processor['payment_processor_type_id'], 'name');
     return $processors[$paymentProcessorID];
   }
 
@@ -326,7 +298,25 @@ class CRM_Financial_BAO_PaymentProcessor extends CRM_Financial_DAO_PaymentProces
 
     $processors = civicrm_api3('payment_processor', 'get', $retrievalParameters);
     foreach ($processors['values'] as $processor) {
-      $fieldsToProvide = array('user_name', 'password', 'signature', 'subject', 'is_recur');
+      $fieldsToProvide = array(
+        'id',
+        'name',
+        'payment_processor_type_id',
+        'user_name',
+        'password',
+        'signature',
+        'url_site',
+        'url_api',
+        'url_recur',
+        'url_button',
+        'subject',
+        'class_name',
+        'is_recur',
+        'billing_mode',
+        'is_test',
+        'payment_type',
+        'is_default',
+      );
       foreach ($fieldsToProvide as $field) {
         // Prevent e-notices in processor classes when not configured.
         if (!isset($processor[$field])) {
@@ -548,7 +538,8 @@ INNER JOIN civicrm_contribution       con ON ( mp.contribution_id = con.id )
         // The function looks to load the payment processor ID from the contribution page, which
         // can support multiple processors.
       }
-      $paymentProcessor['payment_processor_type'] = CRM_Core_PseudoConstant::paymentProcessorType(FALSE, $paymentProcessor['payment_processor_type_id'], 'name');
+
+      $paymentProcessor['payment_processor_type'] = CRM_Core_PseudoConstant::getName('CRM_Financial_BAO_PaymentProcessor', 'payment_processor_type_id', $paymentProcessor['payment_processor_type_id']);
       $result = Civi\Payment\System::singleton()->getByProcessor($paymentProcessor);
     }
     return $result;

--- a/CRM/Utils/VersionCheck.php
+++ b/CRM/Utils/VersionCheck.php
@@ -179,11 +179,10 @@ class CRM_Utils_VersionCheck {
     $dao->find();
     $ppTypes = array();
 
-    // Get title and id for all processor types
-    $ppTypeNames = CRM_Core_PseudoConstant::paymentProcessorType();
-
+    // Get title for all processor types
+    // FIXME: This should probably be getName, but it has always returned translated label so we stick with that for now as it would affect stats
     while ($dao->fetch()) {
-      $ppTypes[] = $ppTypeNames[$dao->payment_processor_type_id];
+      $ppTypes[] = CRM_Core_PseudoConstant::getLabel('CRM_Financial_BAO_PaymentProcessor', 'payment_processor_type_id', $dao->payment_processor_type_id);
     }
     // add the .-separated list of the processor types
     $this->stats['PPTypes'] = implode(',', array_unique($ppTypes));


### PR DESCRIPTION
Overview
----------------------------------------
This cleans up and removes usage of deprecated CRM_Core_PseudoConstant::paymentProcessorType in favour of standard getKey/getName functions. Duplicated code from getPayment is also removed and consolidated into a single function.

Before
----------------------------------------
Duplicated code and usage of deprecated function.

After
----------------------------------------
Removed duplicated code and usage of deprecated function.