### PR TITLE
dev/core#128 Add deprecated warning helper function

### DIFF
--- a/CRM/Contact/BAO/Contact/Location.php
+++ b/CRM/Contact/BAO/Contact/Location.php
@@ -75,7 +75,7 @@ class CRM_Contact_BAO_Contact_Location {
    *   tuple of display_name and sms if found, or (null,null)
    */
   public static function getPhoneDetails($id, $type = NULL) {
-    Civi::log()->warning('Deprecated function CRM_Contact_BAO_Contact_Location::getPhoneDetails, use Phone.get API instead', array('civi.tag' => 'deprecated'));
+    CRM_Utils_System::deprecatedFunctionWarning('Phone.get API instead');
     if (!$id) {
       return array(NULL, NULL);
     }

--- a/CRM/Contact/Form/Task/EmailCommon.php
+++ b/CRM/Contact/Form/Task/EmailCommon.php
@@ -48,7 +48,7 @@ class CRM_Contact_Form_Task_EmailCommon {
    * @return array $domainEmails;
    */
   public static function domainEmails() {
-    Civi::log()->warning('Deprecated function, use CRM_Core_BAO_Email::domainEmails()', array('civi.tag' => 'deprecated'));
+    CRM_Utils_System::deprecatedFunctionWarning('CRM_Core_BAO_Email::domainEmails()');
     return CRM_Core_BAO_Email::domainEmails();
   }
 

--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -333,7 +333,7 @@ SELECT r.payment_processor_id
    *
    */
   public static function getRecurContributions($contactId) {
-    Civi::log()->warning('Deprecated function, use ContributionRecur.get API instead', array('civi.tag' => 'deprecated'));
+    CRM_Utils_System::deprecatedFunctionWarning('ContributionRecur.get API instead');
     $params = array();
     $recurDAO = new CRM_Contribute_DAO_ContributionRecur();
     $recurDAO->contact_id = $contactId;

--- a/CRM/Core/OptionGroup.php
+++ b/CRM/Core/OptionGroup.php
@@ -342,7 +342,7 @@ WHERE  v.option_group_id = g.id
    * @return null
    */
   public static function getLabel($groupName, $value, $onlyActiveValue = TRUE) {
-    Civi::log()->warning('Deprecated function CRM_Core_OptionGroup::getLabel, use CRM_Core_PseudoConstant::getLabel', array('civi.tag' => 'deprecated'));
+    CRM_Utils_System::deprecatedFunctionWarning('CRM_Core_PseudoConstant::getLabel');
     if (empty($groupName) ||
       empty($value)
     ) {
@@ -396,7 +396,7 @@ WHERE  v.option_group_id = g.id
       return NULL;
     }
 
-    Civi::log()->warning('Deprecated function CRM_Core_OptionGroup::getValue, use CRM_Core_PseudoConstant::getKey', array('civi.tag' => 'deprecated'));
+    CRM_Utils_System::deprecatedFunctionWarning('CRM_Core_PseudoConstant::getKey');
 
     $query = "
 SELECT  v.label as label ,v.{$valueField} as value

--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -579,7 +579,6 @@ class CRM_Core_PseudoConstant {
    * Flush given pseudoconstant so it can be reread from db.
    * nex time it's requested.
    *
-   *
    * @param bool|string $name pseudoconstant to be flushed
    */
   public static function flush($name = 'cache') {
@@ -606,6 +605,7 @@ class CRM_Core_PseudoConstant {
    *   array reference of all activity types.
    */
   public static function &activityType() {
+    CRM_Utils_System::deprecatedFunctionWarning('buildOptions() method in the appropriate BAO object');
     $args = func_get_args();
     $all = CRM_Utils_Array::value(0, $args, TRUE);
     $includeCaseActivities = CRM_Utils_Array::value(1, $args, FALSE);
@@ -931,6 +931,7 @@ WHERE  id = %1";
    *   array reference of all groups.
    */
   public static function allGroup($groupType = NULL, $excludeHidden = TRUE) {
+    CRM_Utils_System::deprecatedFunctionWarning('buildOptions() method in the appropriate BAO object');
     if ($groupType === 'validate') {
       // validate gets passed through from getoptions. Handle in the deprecated
       // fn rather than change the new pattern.
@@ -1142,6 +1143,7 @@ WHERE  id = %1";
    *   array of all payment processors
    */
   public static function paymentProcessor($all = FALSE, $test = FALSE, $additionalCond = NULL) {
+    CRM_Utils_System::deprecatedFunctionWarning('buildOptions() method in the appropriate BAO object');
     $condition = "is_test = ";
     $condition .= ($test) ? '1' : '0';
 
@@ -1177,6 +1179,7 @@ WHERE  id = %1";
    *   array of all payment processor types
    */
   public static function &paymentProcessorType($all = FALSE, $id = NULL, $return = 'title') {
+    CRM_Utils_System::deprecatedFunctionWarning('buildOptions() method in the appropriate BAO object');
     $cacheKey = $id . '_' . $return;
     if (empty(self::$paymentProcessorType[$cacheKey])) {
       self::populate(self::$paymentProcessorType[$cacheKey], 'CRM_Financial_DAO_PaymentProcessorType', $all, $return, 'is_active', NULL, "is_default, $return", 'id');
@@ -1227,6 +1230,7 @@ WHERE  id = %1";
    *   array reference of all activity statuses
    */
   public static function &activityStatus($column = 'label') {
+    CRM_Utils_System::deprecatedFunctionWarning('buildOptions() method in the appropriate BAO object');
     if (NULL === self::$activityStatus) {
       self::$activityStatus = array();
     }
@@ -1253,6 +1257,7 @@ WHERE  id = %1";
    *   array reference of all Visibility levels.
    */
   public static function &visibility($column = 'label') {
+    CRM_Utils_System::deprecatedFunctionWarning('buildOptions() method in the appropriate BAO object');
     if (!isset(self::$visibility)) {
       self::$visibility = array();
     }

--- a/CRM/Member/BAO/MembershipType.php
+++ b/CRM/Member/BAO/MembershipType.php
@@ -622,7 +622,7 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
    *   array of the details of membership types
    */
   public static function getMembershipTypesByOrg($orgID) {
-    Civi::log()->warning('Deprecated function getMembershipTypesByOrg, please user membership_type api', array('civi.tag' => 'deprecated'));
+    CRM_Utils_System::deprecatedFunctionWarning('membership_type api');
     $memberTypesSameParentOrg = civicrm_api3('MembershipType', 'get', array(
       'member_of_contact_id' => $orgID,
       'options' => array(

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -4513,7 +4513,7 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
    * (left here in case extensions use it).
    */
   public function addAddressFromClause() {
-    Civi::log()->warning('Deprecated function addAddressFromClause. Use joinAddressFromContact.', array('civi.tag' => 'deprecated'));
+    CRM_Utils_System::deprecatedFunctionWarning('CRM_Report_Form::joinAddressFromContact');
     // include address field if address column is to be included
     if ((isset($this->_addressField) &&
         $this->_addressField
@@ -4535,8 +4535,7 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
    *  (left here in case extensions use it).
    */
   public function addPhoneFromClause() {
-
-    Civi::log()->warning('Deprecated function addPhoneFromClause. Use joinPhoneFromContact.', array('civi.tag' => 'deprecated'));
+    CRM_Utils_System::deprecatedFunctionWarning('CRM_Report_Form::joinPhoneFromContact');
     // include address field if address column is to be included
     if ($this->isTableSelected('civicrm_phone')) {
       $this->_from .= "

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2009,7 +2009,7 @@ abstract class CRM_Utils_Hook {
     // are expected to be called externally.
     // It's really really unlikely anyone uses this - but let's add deprecations for a couple
     // of releases first.
-    Civi::log()->warning('Deprecated function CRM_Utils_Hook::alterMail, use CRM_Utils_Hook::alterMailer', array('civi.tag' => 'deprecated'));
+    CRM_Utils_System::deprecatedFunctionWarning('CRM_Utils_Hook::alterMailer');
     return CRM_Utils_Hook::alterMailer($mailer, $driver, $params);
   }
 

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1840,4 +1840,17 @@ class CRM_Utils_System {
     return NULL;
   }
 
+  /**
+   * Output a deprecated function warning to log file.  Deprecated class:function is automatically generated from calling function.
+   *
+   * @param $newMethod
+   *   description of new method (eg. "buildOptions() method in the appropriate BAO object").
+   */
+  public static function deprecatedFunctionWarning($newMethod) {
+    $dbt = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
+    $callerFunction = isset($dbt[1]['function']) ? $dbt[1]['function'] : NULL;
+    $callerClass = isset($dbt[1]['class']) ? $dbt[1]['class'] : NULL;
+    Civi::log()->warning("Deprecated function $callerClass::$callerFunction, use $newMethod.", array('civi.tag' => 'deprecated'));
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
This adds a standard method to log a deprecated function warning.

Before
----------------------------------------
Deprecated function warnings were inconsistent and you have to put too much detail in the log line.

After
----------------------------------------
One simple function that autogenerates the log message based on caller.

Comments from previous PR #12007
----------------------------------------

@totten:
>    I think @totten tried to enhance deprecated output at some point

Probably this: https://chat.civicrm.org/civicrm/pl/cf1p7hgkkprp9kthkosq98qrer

@mattwire
> A standalone helper function is more pithy than the Civi::log...civi.tag=>deprecated.... Pithy is good.
    From r-code perspective, I don't like having that helper in CRM_Utils_System. That class is too heavy already, and deprecatedFunctionWarning() is qualitatively different from every other function in the class.

Yes, I agree.  I wasn't sure where to "dump" the function.  Maybe `CRM/Core/Error/Log.php` would be a better place for it?

> My main hesitation with cf1p7hgkkprp9kthkosq98qrer was that findNonLogCaller() felt a little heavy-handed. It's nice how deprecatedFunctionWarning() doesn't have to dig as far back into the callstack.
> On the other hand, it's nice how cf1p7hgkkprp9kthkosq98qrer works with the existing coding convention.

We don't actually log deprecated very much so I don't think it's a big change to convention.
