### PR TITLE
Fix paypal to round amount to 2 decimal places before passing to gateway

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -999,9 +999,24 @@ abstract class CRM_Core_Payment {
   }
 
   /**
-   * Get the currency for the transaction.
+   * Get the amount to be processed, rounded to the proscribed decimal places.
    *
-   * Handle any inconsistency about how it is passed in here.
+   * The amount value should always be 'clean' (using dot separator) by the time it reaches this
+   * function as we are cleaning close to point of submit, so only rounding takes place here.
+   *
+   * @param array $params
+   * @param int $decimalPlaces
+   * @return float
+   */
+  protected function getAmountDotDecimalSeparator($params, $decimalPlaces = 2) {
+    return round($params['amount'], $decimalPlaces);
+  }
+
+  /**
+   * Get the amount for the transaction formatted using system/ locale separators.
+   *
+   * This should be used for display purposes as it may add locale specific
+   * formatting.
    *
    * @param $params
    *

--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -212,7 +212,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
     $this->initialize($args, 'SetExpressCheckout');
 
     $args['paymentAction'] = 'Sale';
-    $args['amt'] = $params['amount'];
+    $args['amt'] = $this->getAmountDotDecimalSeparator($params);
     $args['currencyCode'] = $params['currencyID'];
     $args['desc'] = CRM_Utils_Array::value('description', $params);
     $args['invnum'] = $params['invoiceID'];
@@ -224,7 +224,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
     if (!empty($params['is_recur'])) {
       $args['L_BILLINGTYPE0'] = 'RecurringPayments';
       //$args['L_BILLINGAGREEMENTDESCRIPTION0'] = 'Recurring Contribution';
-      $args['L_BILLINGAGREEMENTDESCRIPTION0'] = $params['amount'] . " Per " . $params['frequency_interval'] . " " . $params['frequency_unit'];
+      $args['L_BILLINGAGREEMENTDESCRIPTION0'] = $this->getAmount($params) . " Per " . $params['frequency_interval'] . " " . $params['frequency_unit'];
       $args['L_PAYMENTTYPE0'] = 'Any';
     }
 
@@ -321,7 +321,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
     $this->initialize($args, 'DoExpressCheckoutPayment');
     $args['token'] = $params['token'];
     $args['paymentAction'] = 'Sale';
-    $args['amt'] = $params['amount'];
+    $args['amt'] = $this->getAmountDotDecimalSeparator($params);
     $args['currencyCode'] = $params['currencyID'];
     $args['payerID'] = $params['payer_id'];
     $args['invnum'] = $params['invoiceID'];
@@ -376,7 +376,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
 
     $args['token'] = $params['token'];
     $args['paymentAction'] = 'Sale';
-    $args['amt'] = $params['amount'];
+    $args['amt'] = $this->getAmountDotDecimalSeparator($params);
     $args['currencyCode'] = $params['currencyID'];
     $args['payerID'] = $params['payer_id'];
     $args['invnum'] = $params['invoiceID'];
@@ -386,7 +386,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
     $args['method'] = 'CreateRecurringPaymentsProfile';
     $args['billingfrequency'] = $params['frequency_interval'];
     $args['billingperiod'] = ucwords($params['frequency_unit']);
-    $args['desc'] = $params['amount'] . " Per " . $params['frequency_interval'] . " " . $params['frequency_unit'];
+    $args['desc'] = $this->getAmount($params) . " Per " . $params['frequency_interval'] . " " . $params['frequency_unit'];
     //$args['desc']           = 'Recurring Contribution';
     $args['totalbillingcycles'] = $params['installments'];
     $args['version'] = '56.0';
@@ -521,7 +521,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
       $args['profilestartdate'] = $start_date;
       $args['desc'] = "" .
         $params['description'] . ": " .
-        $params['amount'] . " Per " .
+        $this->getAmount($params) . " Per " .
         $params['frequency_interval'] . " " .
         $params['frequency_unit'];
       $args['amt'] = $this->getAmount($params);
@@ -940,7 +940,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
     else {
       $paypalParams += array(
         'cmd' => '_xclick',
-        'amount' => $params['amount'],
+        'amount' => $this->getAmountDotDecimalSeparator($params),
       );
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Per https://lab.civicrm.org/dev/core/issues/72

Before
----------------------------------------
payment failure per gitlab issue

After
----------------------------------------
payment works

Technical Details
----------------------------------------
Adds a function to the parent class for getting the number in a rounded format.

Comments
----------------------------------------
@yashodha @mattwire can you test this - I think we should aim to merge fairly urgently
