### PR TITLE
Dev/Core#90 Disable Only Full Group By sql mode on specific queries t…

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -165,6 +165,29 @@ class CRM_Core_DAO extends DB_DataObject {
   }
 
   /**
+   * Disables usage of the ONLY_FULL_GROUP_BY Mode if necessary
+   */
+  public static function disableFullGroupByMode() {
+    $currentModes = CRM_Utils_SQL::getSqlModes();
+    if (CRM_Utils_SQL::supportsFullGroupBy() && in_array('ONLY_FULL_GROUP_BY', $currentModes) && CRM_Utils_SQL::isGroupByModeInDefault()) {
+      $key = array_search('ONLY_FULL_GROUP_BY', $currentModes);
+      unset($currentModes[$key]);
+      CRM_Core_DAO::executeQuery("SET SESSION sql_mode = %1", array(1 => array(implode(',', $currentModes), 'String')));
+    }
+  }
+
+  /**
+   * Enables ONLY_FULL_GROUP_BY sql_mode as necessary..
+   */
+  public static function enableFullGroupByMode() {
+    $currentModes = CRM_Utils_SQL::getSqlModes();
+    if (CRM_Utils_SQL::supportsFullGroupBy() && !in_array('ONLY_FULL_GROUP_BY', $currentModes) && CRM_Utils_SQL::isGroupByModeInDefault()) {
+      $currentModes[] = 'ONLY_FULL_GROUP_BY';
+      CRM_Core_DAO::executeQuery("SET SESSION sql_mode = %1", array(1 => array(implode(',', $currentModes), 'String')));
+    }
+  }
+
+  /**
    * @param string $fieldName
    * @param $fieldDef
    * @param array $params

--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -204,6 +204,9 @@ class CRM_Export_BAO_Export {
     }
 
     if (!empty($groupBy)) {
+      if (!Civi::settings()->get('searchPrimaryDetailsOnly')) {
+        CRM_Core_DAO::disableFullGroupByMode();
+      }
       $groupBy = CRM_Contact_BAO_Query::getGroupByFromSelectColumns($query->_select, $groupBy);
     }
 
@@ -1004,10 +1007,11 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
       // delete the export temp table and component table
       $sql = "DROP TABLE IF EXISTS {$exportTempTable}";
       CRM_Core_DAO::executeQuery($sql);
-
+      CRM_Core_DAO::enableFullGroupByMode();
       CRM_Utils_System::civiExit();
     }
     else {
+      CRM_Core_DAO::enableFullGroupByMode();
       throw new CRM_Core_Exception(ts('No records to export'));
     }
   }
@@ -1309,7 +1313,6 @@ FROM   $tableName
 INSERT INTO $tableName $sqlColumnString
 VALUES $sqlValueString
 ";
-
     CRM_Core_DAO::executeQuery($sql);
   }
 

--- a/CRM/Mailing/Event/BAO/TrackableURLOpen.php
+++ b/CRM/Mailing/Event/BAO/TrackableURLOpen.php
@@ -364,9 +364,9 @@ class CRM_Mailing_Event_BAO_TrackableURLOpen extends CRM_Mailing_Event_DAO_Track
       //Added "||$rowCount" to avoid displaying all records on first page
       $query .= ' LIMIT ' . CRM_Utils_Type::escape($offset, 'Integer') . ', ' . CRM_Utils_Type::escape($rowCount, 'Integer');
     }
-
+    CRM_Core_DAO::disableFullGroupByMode();
     $dao->query($query);
-
+    CRM_Core_DAO::enableFullGroupByMode();
     $results = array();
 
     while ($dao->fetch()) {


### PR DESCRIPTION
…o get tests to pass so we can switch to using MySQL 5.7 for PR Tests

Overview
----------------------------------------
This disables the `ONLY_FULL_GROUP_BY` sql mode on specific queries to get the failed tests here https://test.civicrm.org/job/CiviCRM-Core-Matrix/CIVIVER=master,label=ubuntu1604/lastCompletedBuild/testReport/ to pass

Before
----------------------------------------
Tests fail on MySQL 5.7

After
----------------------------------------
Tests Pass

ping @eileenmcnaughton @monishdeb @totten 