### PR TITLE
Limit number of characters one can type in PCP Personal Note

### DIFF
--- a/CRM/PCP/BAO/PCP.php
+++ b/CRM/PCP/BAO/PCP.php
@@ -453,7 +453,7 @@ WHERE pcp.id = %1 AND cc.contribution_status_id =1 AND cc.is_test = 0";
       $page->_defaults['pcp_is_anonymous'] = 0;
 
       $page->add('text', 'pcp_roll_nickname', ts('Name'), array('maxlength' => 30));
-      $page->add('textarea', "pcp_personal_note", ts('Personal Note'), array('style' => 'height: 3em; width: 40em;'));
+      $page->add('textarea', "pcp_personal_note", ts('Personal Note'), array('maxlength' => '250', 'style' => 'height: 3em; width: 40em;'));
     }
     else {
       $page->assign('is_honor_roll', FALSE);


### PR DESCRIPTION
Overview
----------------------------------------
Textarea must have a limit - as the database field is only a varchar(255)

Before
----------------------------------------
CiviCRM throws a fatal error
[nativecode=1406 ** Data too long for column 'pcp_personal_note' at row 1]
if donor types in more than 255 characters; donation processes but page throws a fatal error before receipt is dispatched - so donor does not now monies went through - tries again. 

After
----------------------------------------
A very simple addition of maxlength attribute to textarea field prevents this; Note that this was already in place for pcp_roll_nickname (maxlength="30"); that is wasn't in place for pcp_personal_note is most likely a simple oversight;

Steps to reproduce
----------------------------------------
Set up an Event in CiviCRM (or use an existing one)

in Event Configuration -> under Personal Campaigns tab -> check box: Enable
Select a Supporter Profile (it's a required field)

under Online Registration tab -> enabled Online Registration
no need to send Emails

Create your Personal Campaign page:
civicrm/contribute/campaign?action=add&reset=1&pageId=[id_of_event_just_created]&component=event 

on dmaster -> having enabled Personal Campaigns for Fall Fundraiser:
http://dmaster.demo.civicrm.org/civicrm/contribute/campaign?action=add&reset=1&pageId=1&component=event

Click through / fill out Title etc. -> enable checkbox -> Honor roll

To now test the page -> find the PCP page you just created under -> Events -> Personal Campaign Pages -> and Approve it (if it needs approval)


Click on Page title -> Contribute now

click checkbox Show my support in public honor roll
click on include my name and message
add lots of text to message - this will do it:

> Lorem ipsum is a pseudo-Latin text used in web design, typography, layout, and printing in place of English to emphasise design elements over content. It's also called placeholder (or filler) text. It's a convenient tool for mock-ups. It helps to outline the visual elements of a document or presentation, eg typography, font, or layout. Lorem ipsum is mostly a part of a Latin text by the classical author and philosopher Cicero. Its words and letters have been changed by addition or removal, so to deliberately render its content nonsensical; it's not genuine, correct, or comprehensible Latin anymore. While lorem ipsum's still resembles classical Latin, it actually has no meaning whatsoever. As Cicero's text doesn't contain the letters K, W, or Z, alien to latin, these, and others are often inserted randomly to mimic the typographic appearence of European languages, as are digraphs not to be found in the original.

on dmaster: http://dmaster.demo.civicrm.org/civicrm/event/register?id=1&pcpId=2&reset=1

![image](https://user-images.githubusercontent.com/5340555/39412691-bb19d77c-4bdd-11e8-80fe-8d6854244c73.png)

Results in:
![image](https://user-images.githubusercontent.com/5340555/39412697-d7eeba84-4bdd-11e8-91c7-bc332a917e29.png)

Check ConfigAndLog -> for message
[nativecode=1406 ** Data too long for column 'pcp_personal_note' at row 1]

Comments
----------------------------------------
In production of live site;