### PR TITLE
Fix regression whereby relationship types option no longer in adv search

### DIFF
--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -209,6 +209,7 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
           'resultFile' => 'CRM/Contact/Form/Selector.tpl',
           'resultContext' => NULL,
           'taskClassName' => 'CRM_Contact_Task',
+          'component' => '',
         ),
         CRM_Contact_BAO_Query::MODE_CONTRIBUTE => array(
           'selectorName' => 'CRM_Contribute_Selector_Search',
@@ -218,6 +219,7 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
           'resultFile' => 'CRM/Contribute/Form/Selector.tpl',
           'resultContext' => 'Search',
           'taskClassName' => 'CRM_Contribute_Task',
+          'component' => 'CiviContribute',
         ),
         CRM_Contact_BAO_Query::MODE_EVENT => array(
           'selectorName' => 'CRM_Event_Selector_Search',
@@ -227,6 +229,7 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
           'resultFile' => 'CRM/Event/Form/Selector.tpl',
           'resultContext' => 'Search',
           'taskClassName' => 'CRM_Event_Task',
+          'component' => 'CiviEvent',
         ),
         CRM_Contact_BAO_Query::MODE_ACTIVITY => array(
           'selectorName' => 'CRM_Activity_Selector_Search',
@@ -236,6 +239,7 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
           'resultFile' => 'CRM/Activity/Form/Selector.tpl',
           'resultContext' => 'Search',
           'taskClassName' => 'CRM_Activity_Task',
+          'component' => 'activity',
         ),
         CRM_Contact_BAO_Query::MODE_MEMBER => array(
           'selectorName' => 'CRM_Member_Selector_Search',
@@ -245,6 +249,7 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
           'resultFile' => 'CRM/Member/Form/Selector.tpl',
           'resultContext' => 'Search',
           'taskClassName' => 'CRM_Member_Task',
+          'component' => 'CiviMember',
         ),
         CRM_Contact_BAO_Query::MODE_CASE => array(
           'selectorName' => 'CRM_Case_Selector_Search',
@@ -254,6 +259,7 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
           'resultFile' => 'CRM/Case/Form/Selector.tpl',
           'resultContext' => 'Search',
           'taskClassName' => 'CRM_Case_Task',
+          'component' => 'CiviCase',
         ),
         CRM_Contact_BAO_Query::MODE_CONTACTSRELATED => array(
           'selectorName' => self::$_selectorName,
@@ -263,6 +269,7 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
           'resultFile' => 'CRM/Contact/Form/Selector.tpl',
           'resultContext' => NULL,
           'taskClassName' => 'CRM_Contact_Task',
+          'component' => 'related_contact',
         ),
         CRM_Contact_BAO_Query::MODE_MAILING => array(
           'selectorName' => 'CRM_Mailing_Selector_Search',
@@ -272,6 +279,7 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
           'resultFile' => 'CRM/Mailing/Form/Selector.tpl',
           'resultContext' => 'Search',
           'taskClassName' => 'CRM_Mailing_Task',
+          'component' => 'CiviMail',
         ),
       );
     }
@@ -290,6 +298,24 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
     }
 
     return self::$_modeValues[$mode];
+  }
+
+  /**
+   * Get a mapping of modes to components.
+   *
+   * This will map the integers to the components. Contact has an empty component
+   * an pseudo-components exist for activity & related_contact.
+   *
+   * @return array
+   */
+  public static function getModeToComponentMapping() {
+    $mapping = [];
+    self::setModeValues();
+
+    foreach (self::$_modeValues as $id => $metadata) {
+      $mapping[$id] = $metadata['component'];
+    }
+    return $mapping;
   }
 
   /**

--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -158,6 +158,7 @@ class CRM_Contact_Form_Search_Criteria {
     );
 
     $componentModes = CRM_Contact_Form_Search::getModeSelect();
+    $form->assign('component_mappings', json_encode(CRM_Contact_Form_Search::getModeToComponentMapping()));
     if (count($componentModes) > 1) {
       $form->add('select',
         'component_mode',

--- a/templates/CRM/Contact/Form/Search/AdvancedCriteria.tpl
+++ b/templates/CRM/Contact/Form/Search/AdvancedCriteria.tpl
@@ -56,14 +56,7 @@ CRM.$(function($) {
     return false;
   });
   // TODO: Why are the modes numeric? If they used the string there would be no need for this map
-  var modes = {
-    '2': 'CiviContribute',
-    '3': 'CiviEvent',
-    '4': 'activity',
-    '5': 'CiviMember',
-    '6': 'CiviCase',
-    '8': 'CiviMail'
-  };
+  var modes = {/literal}{$component_mappings}{literal};
   // Handle change of results mode
   $('#component_mode').change(function() {
     // Reset task dropdown
@@ -73,7 +66,7 @@ CRM.$(function($) {
       $('.crm-' + mode + '-accordion.collapsed').crmAccordionToggle();
       loadPanes(mode);
     }
-    if ($('#component_mode').val() == '7') {
+    if ('related_contact' === modes[$('#component_mode').val()]) {
       $('#crm-display_relationship_type').show();
     }
     else {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes regression whereby relationship type option no longer loaded

Top screenshot shows how it should be - lower shows regressed version
![reinstated](https://lab.civicrm.org/dev/core/uploads/997a28922c4fa511cfbcab647f5789c8/Related_Contacts_in_Advanced_Search.jpg)

Technical Details
----------------------------------------
Our code was hard-coding 'random' numbers for the components.  Altering this line
https://github.com/civicrm/civicrm-core/commit/eda34f9b15c494715e8fc54f09b5ea4308d16b17#diff-b57fde1a4b0ec86d2f8a154d328876edL258 meant '7' was no longer correct.

Comments
----------------------------------------
@mattwire ping

https://lab.civicrm.org/dev/core/issues/83