### PR TITLE
Dev/Core#90 Apply disabling Full Group By to reports

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -487,6 +487,12 @@ class CRM_Report_Form extends CRM_Core_Form {
    */
 
   protected $sqlArray;
+
+  /**
+   * Can this report use the sql mode ONLY_FULL_GROUP_BY.
+   * @var bool
+   */
+  public $optimisedForOnlyFullGroupBy = TRUE;
   /**
    * Class constructor.
    */
@@ -2952,7 +2958,11 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
    * @param array $rows
    */
   public function buildRows($sql, &$rows) {
+    if (!$this->optimisedForOnlyFullGroupBy) {
+      CRM_Core_DAO::disableFullGroupByMode();
+    }
     $dao = CRM_Core_DAO::executeQuery($sql);
+    CRM_Core_DAO::enableFullGroupByMode();
     if (!is_array($rows)) {
       $rows = array();
     }

--- a/CRM/Report/Form/Contribute/Lybunt.php
+++ b/CRM/Report/Form/Contribute/Lybunt.php
@@ -77,6 +77,7 @@ class CRM_Report_Form_Contribute_Lybunt extends CRM_Report_Form {
    * Class constructor.
    */
   public function __construct() {
+    $this->optimisedForOnlyFullGroupBy = FALSE;
     $this->_rollup = 'WITH ROLLUP';
     $this->_autoIncludeIndexedFieldsAsOrderBys = 1;
     $yearsInPast = 10;

--- a/CRM/Report/Form/Contribute/SoftCredit.php
+++ b/CRM/Report/Form/Contribute/SoftCredit.php
@@ -68,7 +68,7 @@ class CRM_Report_Form_Contribute_SoftCredit extends CRM_Report_Form {
   /**
    */
   public function __construct() {
-
+    $this->optimisedForOnlyFullGroupBy = FALSE;
     // Check if CiviCampaign is a) enabled and b) has active campaigns
     $config = CRM_Core_Config::singleton();
     $campaignEnabled = in_array("CiviCampaign", $config->enableComponents);

--- a/CRM/Report/Form/Mailing/Opened.php
+++ b/CRM/Report/Form/Mailing/Opened.php
@@ -68,6 +68,7 @@ class CRM_Report_Form_Mailing_Opened extends CRM_Report_Form {
    * Class constructor.
    */
   public function __construct() {
+    $this->optimisedForOnlyFullGroupBy = FALSE;
     $this->_columns = array();
 
     $this->_columns['civicrm_contact'] = array(


### PR DESCRIPTION
Overview
----------------------------------------
This applies the disabling of `ONLY_FULL_GROUP_BY` sql mode to reports to enable tests to run on MySQL5.7

Before
----------------------------------------
Tests fail 

After
----------------------------------------
Tests pass

ping @eileenmcnaughton @monishdeb this was the Reports parts that were split off as requested by Eileen