### PR TITLE
CRM-20459: Actively deprecate CRM_Core_OptionGroup::getValue[Sub PR 1]

### DIFF
--- a/CRM/Badge/BAO/Layout.php
+++ b/CRM/Badge/BAO/Layout.php
@@ -92,7 +92,7 @@ class CRM_Badge_BAO_Layout extends CRM_Core_DAO_PrintLabel {
     $params['is_default'] = CRM_Utils_Array::value('is_default', $params, FALSE);
     $params['is_reserved'] = CRM_Utils_Array::value('is_reserved', $params, FALSE);
 
-    $params['label_type_id'] = CRM_Core_OptionGroup::getValue('label_type', 'Event Badge', 'name');
+    $params['label_type_id'] = CRM_Core_PseudoConstant::getKey('CRM_Core_DAO_PrintLabel', 'label_type_id', 'Event Badge');
 
     // check if new layout is create, if so set the created_id (if not set)
     if (empty($params['id'])) {
@@ -162,7 +162,8 @@ class CRM_Badge_BAO_Layout extends CRM_Core_DAO_PrintLabel {
     $layoutParams = array('id' => $params['badge_id']);
     CRM_Badge_BAO_Layout::retrieve($layoutParams, $layoutInfo);
 
-    $formatProperties = CRM_Core_OptionGroup::getValue('name_badge', $layoutInfo['label_format_name'], 'name');
+    $formatProperties = CRM_Core_PseudoConstant::getKey('CRM_Core_DAO_PrintLabel', 'label_format_name', $layoutInfo['label_format_name']);
+
     $layoutInfo['format'] = json_decode($formatProperties, TRUE);
     $layoutInfo['data'] = CRM_Badge_BAO_Layout::getDecodedData($layoutInfo['data']);
     return $layoutInfo;

--- a/CRM/Campaign/BAO/Petition.php
+++ b/CRM/Campaign/BAO/Petition.php
@@ -94,7 +94,7 @@ INNER JOIN civicrm_option_group grp ON ( activity_type.option_group_id = grp.id 
 
     //we only have activity type as a
     //difference between survey and petition.
-    $petitionTypeID = CRM_Core_OptionGroup::getValue('activity_type', 'petition', 'name');
+    $petitionTypeID = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Petition');
     if ($petitionTypeID) {
       $where[] = "( petition.activity_type_id = %1 )";
       $queryParams[1] = array($petitionTypeID, 'Positive');
@@ -160,7 +160,7 @@ SELECT  petition.id                         as id,
   public static function getPetitionCount() {
     $whereClause = 'WHERE ( 1 )';
     $queryParams = array();
-    $petitionTypeID = CRM_Core_OptionGroup::getValue('activity_type', 'petition', 'name');
+    $petitionTypeID = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Petition');
     if ($petitionTypeID) {
       $whereClause = "WHERE ( petition.activity_type_id = %1 )";
       $queryParams[1] = array($petitionTypeID, 'Positive');

--- a/CRM/Campaign/BAO/Survey.php
+++ b/CRM/Campaign/BAO/Survey.php
@@ -167,7 +167,7 @@ INNER JOIN civicrm_option_group grp ON ( activity_type.option_group_id = grp.id 
 
     //we only have activity type as a
     //difference between survey and petition.
-    $petitionTypeID = CRM_Core_OptionGroup::getValue('activity_type', 'petition', 'name');
+    $petitionTypeID = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Petition');
     if ($petitionTypeID) {
       $where[] = "( survey.activity_type_id != %1 )";
       $queryParams[1] = array($petitionTypeID, 'Positive');

--- a/CRM/Campaign/Form/Survey/Results.php
+++ b/CRM/Campaign/Form/Survey/Results.php
@@ -434,7 +434,7 @@ class CRM_Campaign_Form_Survey_Results extends CRM_Campaign_Form_Survey {
         'street_unit',
         'survey_response',
       );
-      if (CRM_Core_OptionGroup::getValue('activity_type', 'WalkList') ==
+      if (CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'WalkList') ==
         $this->_values['activity_type_id']
       ) {
         $this->_params['order_bys'] = array(
@@ -456,14 +456,14 @@ class CRM_Campaign_Form_Survey_Results extends CRM_Campaign_Form_Survey {
           ),
         );
       }
-      elseif (CRM_Core_OptionGroup::getValue('activity_type', 'PhoneBank') ==
+      elseif (CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'PhoneBank') ==
         $this->_values['activity_type_id']
       ) {
         array_push($displayFields, 'phone');
       }
-      elseif ((CRM_Core_OptionGroup::getValue('activity_type', 'Survey') ==
+      elseif ((CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Survey') ==
           $this->_values['activity_type_id']) ||
-        (CRM_Core_OptionGroup::getValue('activity_type', 'Canvass') ==
+        (CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Canvass') ==
           $this->_values['activity_type_id'])
       ) {
         array_push($displayFields, 'phone', 'city', 'state_province_id', 'postal_code', 'email');

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -1127,10 +1127,10 @@ SELECT case_status.label AS case_status, status_id, civicrm_case_type.title AS c
       }
 
       if (!empty($dao->priority)) {
-        if ($dao->priority == CRM_Core_OptionGroup::getValue('priority', 'Urgent', 'name')) {
+        if ($dao->priority == CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'priority_id', 'Urgent')) {
           $caseActivity['DT_RowClass'] .= " priority-urgent ";
         }
-        elseif ($dao->priority == CRM_Core_OptionGroup::getValue('priority', 'Low', 'name')) {
+        elseif ($dao->priority == CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'priority_id', 'Low')) {
           $caseActivity['DT_RowClass'] .= " priority-low ";
         }
       }

--- a/CRM/Case/Form/Activity/ChangeCaseStartDate.php
+++ b/CRM/Case/Form/Activity/ChangeCaseStartDate.php
@@ -155,7 +155,7 @@ class CRM_Case_Form_Activity_ChangeCaseStartDate {
 
     $params['status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_status_id', 'Completed');
     $activity->status_id = $params['status_id'];
-    $params['priority_id'] = CRM_Core_OptionGroup::getValue('priority', 'Normal', 'name');
+    $params['priority_id'] = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'priority_id', 'Normal');
     $activity->priority_id = $params['priority_id'];
 
     // 1. save activity subject with new start date

--- a/CRM/Case/Form/Activity/ChangeCaseStatus.php
+++ b/CRM/Case/Form/Activity/ChangeCaseStatus.php
@@ -205,7 +205,7 @@ class CRM_Case_Form_Activity_ChangeCaseStatus {
     }
     $params['status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_status_id', 'Completed');
     $activity->status_id = $params['status_id'];
-    $params['priority_id'] = CRM_Core_OptionGroup::getValue('priority', 'Normal', 'name');
+    $params['priority_id'] = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'priority_id', 'Normal');
     $activity->priority_id = $params['priority_id'];
 
     foreach ($form->_oldCaseStatus as $statuskey => $statusval) {

--- a/CRM/Case/Form/Activity/ChangeCaseType.php
+++ b/CRM/Case/Form/Activity/ChangeCaseType.php
@@ -160,7 +160,7 @@ class CRM_Case_Form_Activity_ChangeCaseType {
 
     $params['status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_status_id', 'Completed');
     $activity->status_id = $params['status_id'];
-    $params['priority_id'] = CRM_Core_OptionGroup::getValue('priority', 'Normal', 'name');
+    $params['priority_id'] = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'priority_id', 'Normal');
     $activity->priority_id = $params['priority_id'];
 
     if ($activity->subject == 'null') {

--- a/CRM/Contribute/BAO/ContributionSoft.php
+++ b/CRM/Contribute/BAO/ContributionSoft.php
@@ -85,7 +85,7 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
       $softParams['pcp_display_in_roll'] = CRM_Utils_Array::value('pcp_display_in_roll', $pcp);
       $softParams['pcp_roll_nickname'] = CRM_Utils_Array::value('pcp_roll_nickname', $pcp);
       $softParams['pcp_personal_note'] = CRM_Utils_Array::value('pcp_personal_note', $pcp);
-      $softParams['soft_credit_type_id'] = CRM_Core_OptionGroup::getValue('soft_credit_type', 'pcp', 'name');
+      $softParams['soft_credit_type_id'] = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_ContributionSoft', 'soft_credit_type_id', 'pcp');
       $contributionSoft = self::add($softParams);
       //Send notification to owner for PCP
       if ($contributionSoft->pcp_id && empty($pcpId)) {
@@ -149,7 +149,7 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
       $honorId = NULL;
 
       // @todo fix use of deprecated function.
-      $contributionSoftParams['soft_credit_type_id'] = CRM_Core_OptionGroup::getValue('soft_credit_type', 'pcp', 'name');
+      $contributionSoftParams['soft_credit_type_id'] = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_ContributionSoft', 'soft_credit_type_id', 'pcp');
       //check if there is any duplicate contact
       // honoree should never be the donor
       $exceptKeys = array(


### PR DESCRIPTION
Overview
----------------------------------------
This function is deprecated and needs to be replaced by respective function in ```CRM_Core_Pseudoconstant```. This PR is all about this replacement.

This is a sub PR of https://github.com/civicrm/civicrm-core/pull/12041

---

 * [CRM-20459: Actively deprecate CRM_Core_OptionGroup::getValue](https://issues.civicrm.org/jira/browse/CRM-20459)