### PR TITLE
CRM-20459: Actively deprecate CRM_Core_OptionGroup::getValue[Sub PR 2]

### DIFF
--- a/CRM/Contribute/Form/Task/Status.php
+++ b/CRM/Contribute/Form/Task/Status.php
@@ -196,7 +196,7 @@ AND    co.id IN ( $contribIDs )";
       if ((strpos($name, 'check_number_') !== FALSE) && $value) {
         $contribID = substr($name, 13);
 
-        if ($fields["payment_instrument_id_{$contribID}"] != CRM_Core_OptionGroup::getValue('payment_instrument', 'Check', 'name')) {
+        if ($fields["payment_instrument_id_{$contribID}"] != CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Check')) {
           $errors["payment_instrument_id_{$contribID}"] = ts("Payment Method should be Check when a check number is entered for a contribution.");
         }
       }

--- a/CRM/Contribute/Form/UpdateBilling.php
+++ b/CRM/Contribute/Form/UpdateBilling.php
@@ -335,17 +335,15 @@ class CRM_Contribute_Form_UpdateBilling extends CRM_Core_Form {
 
       $activityParams = array(
         'source_contact_id' => $this->_subscriptionDetails->contact_id,
-        'activity_type_id' => CRM_Core_OptionGroup::getValue('activity_type',
-          'Update Recurring Contribution Billing Details',
-          'name'
+        'activity_type_id' => CRM_Core_PseudoConstant::getKey(
+          'CRM_Activity_BAO_Activity',
+          'activity_type_id',
+          'Update Recurring Contribution Billing Details'
         ),
         'subject' => ts('Recurring Contribution Billing Details Updated'),
         'details' => $message,
         'activity_date_time' => date('YmdHis'),
-        'status_id' => CRM_Core_OptionGroup::getValue('activity_status',
-          'Completed',
-          'name'
-        ),
+        'status_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'status_id', 'Completed'),
       );
       $session = CRM_Core_Session::singleton();
       $cid = $session->get('userID');

--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -569,7 +569,7 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Contribute_Import_Pa
   public function processPledgePayments(&$formatted) {
     if (!empty($formatted['pledge_payment_id']) && !empty($formatted['pledge_id'])) {
       //get completed status
-      $completeStatusID = CRM_Core_OptionGroup::getValue('contribution_status', 'Completed', 'name');
+      $completeStatusID = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed');
 
       //need to update payment record to map contribution_id
       CRM_Core_DAO::setFieldValue('CRM_Pledge_DAO_PledgePayment', $formatted['pledge_payment_id'],

--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -563,7 +563,7 @@ FROM civicrm_action_schedule cas
       'activity_date_time' => date('YmdHis'),
       'subject' => $messageSubject,
       'details' => $sms_body_text,
-      'status_id' => CRM_Core_OptionGroup::getValue('activity_status', 'Completed', 'name'),
+      'status_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'status_id', 'Completed'),
     );
 
     $activity = CRM_Activity_BAO_Activity::create($activityParams);

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -2161,7 +2161,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
       //else (for contribution), use configured SCT default value
       $SCTDefaultValue = CRM_Core_OptionGroup::getDefaultValue("soft_credit_type");
       if ($field['field_type'] == 'Membership') {
-        $SCTDefaultValue = CRM_Core_OptionGroup::getValue('soft_credit_type', 'Gift', 'name');
+        $SCTDefaultValue = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_ContributionSoft', 'soft_credit_type_id', 'gift');
       }
       $form->addElement('hidden', 'sct_default_id', $SCTDefaultValue, array('id' => 'sct_default_id'));
     }

--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -1586,10 +1586,7 @@ UPDATE  civicrm_participant
           'subject' => $subject,
           'source_contact_id' => $contactId,
           'source_record_id' => $participantId,
-          'activity_type_id' => CRM_Core_OptionGroup::getValue('activity_type',
-            $activityType,
-            'name'
-          ),
+          'activity_type_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', $activityType),
           'activity_date_time' => CRM_Utils_Date::isoToMysql($now),
           'due_date_time' => CRM_Utils_Date::isoToMysql($participantValues['register_date']),
           'is_test' => $participantValues['is_test'],

--- a/CRM/Event/Cart/Form/Checkout/Payment.php
+++ b/CRM/Event/Cart/Form/Checkout/Payment.php
@@ -521,11 +521,11 @@ class CRM_Event_Cart_Form_Checkout_Payment extends CRM_Event_Cart_Form_Cart {
     $contribution_statuses = CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name');
     $params['payment_instrument_id'] = NULL;
     if (!empty($params['is_pay_later'])) {
-      $params['payment_instrument_id'] = CRM_Core_OptionGroup::getValue('payment_instrument', 'Check', 'name');
+      $params['payment_instrument_id'] = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Check');
       $trxn_prefix = 'CK';
     }
     else {
-      $params['payment_instrument_id'] = CRM_Core_OptionGroup::getValue('payment_instrument', 'Credit Card', 'name');
+      $params['payment_instrument_id'] = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Credit Card');
     }
     if ($this->is_pay_later && empty($params['payment_completed'])) {
       $params['contribution_status_id'] = array_search('Pending', $contribution_statuses);


### PR DESCRIPTION
Overview
----------------------------------------
This function is deprecated and needs to be replaced by respective function in ```CRM_Core_Pseudoconstant```. This PR is all about this replacement.

This is a sub PR of https://github.com/civicrm/civicrm-core/pull/12041

---

 * [CRM-20459: Actively deprecate CRM_Core_OptionGroup::getValue](https://issues.civicrm.org/jira/browse/CRM-20459)