### PR TITLE
Fix: Batch update participants with checkboxes fails

### DIFF
--- a/CRM/Activity/Form/Task/Batch.php
+++ b/CRM/Activity/Form/Task/Batch.php
@@ -242,6 +242,9 @@ class CRM_Activity_Form_Task_Batch extends CRM_Activity_Form_Task {
         $activityId = civicrm_api3('activity', 'create', $value);
 
         // @todo this would be done by the api call above if the parames were passed through.
+        // @todo extract submit functions &
+        // extend CRM_Event_Form_Task_BatchTest::testSubmit with a data provider to test
+        // handling of custom data, specifically checkbox fields.
         if (!empty($value['custom']) &&
           is_array($value['custom'])
         ) {

--- a/CRM/Case/Form/Task/Batch.php
+++ b/CRM/Case/Form/Task/Batch.php
@@ -98,6 +98,9 @@ class CRM_Case_Form_Task_Batch extends CRM_Core_Form_Task_Batch {
         );
       }
       //check for custom data
+      // @todo extract submit functions &
+      // extend CRM_Event_Form_Task_BatchTest::testSubmit with a data provider to test
+      // handling of custom data, specifically checkbox fields.
       $value['custom'] = CRM_Core_BAO_CustomField::postProcess($params['field'][$key],
         $key,
         'Case',

--- a/CRM/Contact/Form/Task/Batch.php
+++ b/CRM/Contact/Form/Task/Batch.php
@@ -217,6 +217,9 @@ class CRM_Contact_Form_Task_Batch extends CRM_Contact_Form_Task {
   public function postProcess() {
     $params = $this->exportValues();
 
+    // @todo extract submit functions &
+    // extend CRM_Event_Form_Task_BatchTest::testSubmit with a data provider to test
+    // handling of custom data, specifically checkbox fields.
     $ufGroupId = $this->get('ufGroupId');
     $notify = NULL;
     $inValidSubtypeCnt = 0;

--- a/CRM/Contribute/Form/Task/Batch.php
+++ b/CRM/Contribute/Form/Task/Batch.php
@@ -206,6 +206,9 @@ class CRM_Contribute_Form_Task_Batch extends CRM_Contribute_Form_Task {
    */
   public function postProcess() {
     $params = $this->exportValues();
+    // @todo extract submit functions &
+    // extend CRM_Event_Form_Task_BatchTest::testSubmit with a data provider to test
+    // handling of custom data, specifically checkbox fields.
     if (isset($params['field'])) {
       foreach ($params['field'] as $contributionID => $value) {
 

--- a/CRM/Event/Form/Task/Batch.php
+++ b/CRM/Event/Form/Task/Batch.php
@@ -478,6 +478,8 @@ class CRM_Event_Form_Task_Batch extends CRM_Event_Form_Task {
           // Unset the original custom field now that it has been formatting to the 'custom'
           // array as it may not be in the right format for the api as is (notably for
           // multiple checkbox values).
+          // @todo extract submit functions on other Batch update classes &
+          // extend CRM_Event_Form_Task_BatchTest::testSubmit with a data provider to test them.
           if (substr($fieldName, 0, 7) === 'custom_') {
             unset($value[$fieldName]);
           }

--- a/CRM/Member/Form/Task/Batch.php
+++ b/CRM/Member/Form/Task/Batch.php
@@ -29,8 +29,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2018
- * $Id$
- *
  */
 
 /**
@@ -208,6 +206,9 @@ class CRM_Member_Form_Task_Batch extends CRM_Member_Form_Task {
    */
   public function postProcess() {
     $params = $this->exportValues();
+    // @todo extract submit functions &
+    // extend CRM_Event_Form_Task_BatchTest::testSubmit with a data provider to test
+    // handling of custom data, specifically checkbox fields.
     $dates = array(
       'join_date',
       'membership_start_date',

--- a/tests/phpunit/CRM/Event/Form/Task/BatchTest.php
+++ b/tests/phpunit/CRM/Event/Form/Task/BatchTest.php
@@ -8,6 +8,11 @@
  */
 class CRM_Event_Form_Task_BatchTest extends CiviUnitTestCase {
 
+  /**
+   * Test the the submit function on the event participant submit function.
+   *
+   * @todo extract submit functions on other Batch update classes, use dataprovider to test on all.
+   */
   public function testSubmit() {
     $group = $this->CustomGroupCreate(['extends' => 'Participant', 'title' => 'Participant']);
     $field = $this->customFieldCreate(['custom_group_id' => $group['id'], 'html_type' => 'CheckBox', 'option_values' => ['two' => 'A couple', 'three' => 'A few', 'four' => 'Too Many']]);


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/issues/89
Fix error when trying to use batch update with custom checkboxes

Before
----------------------------------------
Does not submit

After
----------------------------------------
Does submit, unit tested

Technical Details
----------------------------------------
For readability I will rebase once https://github.com/civicrm/civicrm-core/pull/12048 is merged - the actual changes for this are quite minor

Comments
----------------------------------------
I suspect other batch updates may have a similar bug :-(
