### PR TITLE
Do not test international strings that rely on machine to pass

### DIFF
--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -175,8 +175,12 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    */
   public function getInternationalStrings() {
     $invocations = array();
-    $invocations[] = array('Scarabée');
-    $invocations[] = array('Iñtërnâtiônàlizætiøn');
+    // International string handling depends on the operating system.
+    // It is not handled in CiviCRM so we need to disable tests that do
+    // not pass across all machines. Note that this test was originally added
+    // as part of testing functionality, not as part of a fix.
+    //$invocations[] = array('Scarabée');
+    //$invocations[] = array('Iñtërnâtiônàlizætiøn');
     $invocations[] = array('これは日本語のテキストです。読めますか');
     $invocations[] = array('देखें हिन्दी कैसी नजर आती है। अरे वाह ये तो नजर आती है।');
     return $invocations;


### PR DESCRIPTION
Overview
----------------------------------------
Remove tests on international string handling that rely on the underlying machine

Before
----------------------------------------
Failing tests in ubuntu1604
```
api_v3_ContactTest::testInternationalStrings with data set #0 ('Scarabée')
Exception: Invalid getsingle resultArray
(
    [count] => 0
    [is_error] => 1
    [error_message] => Expected one Contact but found 0
)


/srv/buildkit/build/build-0/sites/all/modules/civicrm/Civi/Test/Api3TestTrait.php:205
/srv/buildkit/build/build-0/sites/all/modules/civicrm/tests/phpunit/api/v3/ContactTest.php:160
/srv/buildkit/build/build-0/sites/all/modules/civicrm/tests/phpunit/CiviTest/CiviUnitTestCase.php:182
/srv/buildkit/bin/phpunit4:545
```

After
----------------------------------------
Test skipped - this never passed on all machines so it doesn't make sense to test it.

Technical Details
----------------------------------------
Note the tests were added in 'investigation' rather than as part of a fix. The tests rely on the underlying machine's translation functionality

Comments
----------------------------------------
@seamuslee001 
