### PR TITLE
CIVICRM-807: Request nethod in Mark selection of contact search changed to POST.

### DIFF
--- a/js/crm.searchForm.js
+++ b/js/crm.searchForm.js
@@ -63,7 +63,7 @@
         params.name = $('input.select-row').map(function() {return $(this).attr('id');}).get().join('-');
       }
     }
-    $.getJSON(url, params, function(data) {
+    $.post(url, params, function(data) {
       if (data && data.getCount !== undefined) {
         selected = data.getCount;
         displayCount();


### PR DESCRIPTION
Overview
----------------------------------------
For CiviCRM 4.6, Search results cause "Empty Query" DB Error.
Steps to reproduce,

1. Execute a CiviCRM contact search with more than 50 results
2. Leave the page size at the default
3. Use the "Select all" checkbox in the top right
4. Checkboxes are all selected, but count is not updated and actions are unavailable
5. AJAX response is an error page about an unknown DB error. Error log reveal this is an "Empty Query" generated by CRM_Core_CAO_PrevNextCache

Before
----------------------------------------
AJAX request method was GET and due to length limit, there was an issue in fetching **name** parameter. Which results in empty DB query.

After
----------------------------------------
Now the method has been updated to POST, and the AJAX request works fine.

_Agileware Ref: CIVICRM-807_