### PR TITLE
(dev/core/91) Search Builder Improvements

### DIFF
--- a/CRM/Contact/Form/Search/Builder.php
+++ b/CRM/Contact/Form/Search/Builder.php
@@ -91,18 +91,22 @@ class CRM_Contact_Form_Search_Builder extends CRM_Contact_Form_Search {
    */
   public function buildQuickForm() {
     $fields = self::fields();
-    // Get fields of type date
-    // FIXME: This is a hack until our fields contain this meta-data
-    $dateFields = array();
-    $stringFields = array();
     $searchByLabelFields = array();
+    // This array contain list of available fields and their corresponding data type,
+    //  later assigned as json string, to be used to filter list of mysql operators
+    $fieldNameTypes = [];
+    $dataType = [
+      CRM_Utils_Type::T_STRING => 'String',
+      CRM_Utils_Type::T_TEXT => 'String',
+      CRM_Utils_Type::T_LONGTEXT => 'String',
+      CRM_Utils_Type::T_BOOLEAN => 'Boolean',
+      CRM_Utils_Type::T_DATE => 'Date',
+      CRM_Utils_Type::T_TIMESTAMP => 'Date',
+    ];
     foreach ($fields as $name => $field) {
-      if (strpos($name, '_date') || CRM_Utils_Array::value('data_type', $field) == 'Date') {
-        $dateFields[] = $name;
-      }
-      // it's necessary to know which of the fields are from string data type
-      if (isset($field['type']) && $field['type'] === CRM_Utils_Type::T_STRING) {
-        $stringFields[] = $name;
+      // Assign date type to respective field name, which will be later used to modify operator list
+      if (isset($field['type']) && array_key_exists($field['type'], $dataType)) {
+        $fieldNameTypes[$name] = $dataType[$field['type']];
       }
       // it's necessary to know which of the fields are searchable by label
       if (isset($field['searchByLabel']) && $field['searchByLabel']) {
@@ -116,12 +120,10 @@ class CRM_Contact_Form_Search_Builder extends CRM_Contact_Form_Search {
         'searchBuilder' => array(
           // Index of newly added/expanded block (1-based index)
           'newBlock' => $this->get('newBlock'),
-          'dateFields' => $dateFields,
           'fieldOptions' => self::fieldOptions(),
-          'stringFields' => $stringFields,
           'searchByLabelFields' => $searchByLabelFields,
+          'fieldTypes' => $fieldNameTypes,
           'generalOperators' => array('' => ts('-operator-')) + CRM_Core_SelectValues::getSearchBuilderOperators(),
-          'stringOperators' => array('' => ts('-operator-')) + CRM_Core_SelectValues::getSearchBuilderOperators(CRM_Utils_Type::T_STRING),
         ),
       ));
     //get the saved search mapping id

--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -896,7 +896,7 @@ class CRM_Core_SelectValues {
    * @return array
    */
   public static function getSearchBuilderOperators($fieldType = NULL) {
-    $builderOperators = array(
+    return [
       '=' => '=',
       '!=' => '≠',
       '>' => '>',
@@ -912,18 +912,7 @@ class CRM_Core_SelectValues {
       'IS NOT EMPTY' => ts('Not Empty'),
       'IS NULL' => ts('Is Null'),
       'IS NOT NULL' => ts('Not Null'),
-    );
-    if ($fieldType) {
-      switch ($fieldType) {
-        case CRM_Utils_Type::T_STRING:
-          unset($builderOperators['>']);
-          unset($builderOperators['<']);
-          unset($builderOperators['>=']);
-          unset($builderOperators['<=']);
-          break;
-      }
-    }
-    return $builderOperators;
+    ];
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Earlier there was a requirement where we need to remove specific MySQL operators which are not valid for specific data type e.g. String type doesn't work with >, <, <= and >= operators. And here's the fix https://github.com/civicrm/civicrm-core/commit/759094bdfa40531e4ec0cf0a644d9edd6b9247cf done earlier as per which it is fetching all columns which are String type and passing them into a separate JSON string identified as ```stringFields``` and another formatted list of valid string operators as ```stringOperators```. Similarly to identify date fields and to do a specific operation on such fields we are passing another variable ```dateFields```. These JSON object in JS are later used to specific operations. Now on the other hand, recently, I encountered another issue where the Boolean type columns don't work with IS EMPTY/IS NOT EMPTY operator and eventually leads to DB syntax error. So if I follow the same approach I need to assign another JSON string, which won't be an ideal fix. This lead me to do following 3 changes to improve the code:
1. Assign a single list of all data columns which are either Boolean, String or Date (as currently, these are the only kind that needs attention)
2. Use this list (as ```fieldTypes```) in JS to filter the operator or do field specific operations like covert a input search field to datepicker if the chosen search field is date kind.
3. Reduce list of variable assignment.

Before
----------------------------------------
 Using IS EMPTY/IS NOT EMPTY operator against Boolean fields lead to DB Error:
![test-multiple-before](https://user-images.githubusercontent.com/3735621/39418790-efb54128-4c79-11e8-9852-e576649f77f5.gif)

After
----------------------------------------
Apart from fixing the error there are other scenarios shown in this screencast like datepicker toggle when field/operator is changed to ensure that this doesn't break the existing workflow. 
![test-multiple-after](https://user-images.githubusercontent.com/3735621/39418864-6b88363e-4c7a-11e8-82e6-2de697657f70.gif)
