### PR TITLE
Fix for check number no longer exposed dev/core/issues/60

### DIFF
--- a/CRM/Event/Form/EventFees.php
+++ b/CRM/Event/Form/EventFees.php
@@ -30,8 +30,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC (c) 2004-2018
- * $Id$
- *
  */
 
 /**

--- a/templates/CRM/Event/Form/EventFees.tpl
+++ b/templates/CRM/Event/Form/EventFees.tpl
@@ -24,6 +24,7 @@
  +--------------------------------------------------------------------+
 *}
 {assign var=isRecordPayment value=1 }
+{assign var=isShowBillingBlock value=($action neq 2)}
 {if $paid} {* We retrieve this tpl when event is selected - keep it empty if event is not paid *}
     <table class="form-layout">
     {if $priceSet}
@@ -68,6 +69,7 @@
  {/if}
 
     {if $accessContribution and ! $participantMode and ($action neq 2 or !$rows.0.contribution_id or $onlinePendingContributionId) and $isRecordPayment and ! $registeredByParticipantId }
+      {assign var=isShowBillingBlock value=true}
         <tr class="crm-event-eventfees-form-block-record_contribution">
             <td class="label">{$form.record_contribution.label}</td>
             <td>{$form.record_contribution.html}<br />
@@ -87,11 +89,11 @@
                     <td class="label" >{$form.receive_date.label}</td>
                     <td>{include file="CRM/common/jcalendar.tpl" elementName=receive_date}</td>
                 </tr>
-                <tr class="crm-event-eventfees-form-block-payment_instrument_id"><td class="label">{$form.payment_instrument_id.label}<span class="crm-marker"> *</span></td><td>{$form.payment_instrument_id.html} {help id="payment_instrument_id" file="CRM/Contribute/Page/Tab.hlp"}</td></tr>
                 {if $showTransactionId }
                     <tr class="crm-event-eventfees-form-block-trxn_id"><td class="label">{$form.trxn_id.label}</td><td>{$form.trxn_id.html}</td></tr>
                 {/if}
                 <tr class="crm-event-eventfees-form-block-contribution_status_id"><td class="label">{$form.contribution_status_id.label}</td><td>{$form.contribution_status_id.html}</td></tr>
+               <tr class="crm-event-eventfees-form-block-payment_instrument_id"><td class="label">{$form.payment_instrument_id.label}<span class="crm-marker"> *</span></td><td>{$form.payment_instrument_id.html} {help id="payment_instrument_id" file="CRM/Contribute/Page/Tab.hlp"}</td></tr>
              </table>
            </fieldset>
            </td>
@@ -101,7 +103,7 @@
 
 {/if}
 
-{if $action neq 2}
+{if $isShowBillingBlock}
   {include file='CRM/Core/BillingBlockWrapper.tpl'}
 {/if}
 


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/issues/60

"Check number" isn't shown on Pay Later event registrations when edited
This happens to me with an event registration that comes through 'webform_civicrm' as a "Pending (Pay Later)". When I try to edit the participant record to record a payment, the "Check Number" field never shows up despite "Check" being selected as the payment instrument.

I was able to reproduce on a demo server by doing the following:

Create a registration, marking it as "Pending (Pay Later)" and unchecking "Record Payment"
Edit the new participant you just created, check "Record Payment" and make sure "Check" is selected as the payment instrument.
No "Check Number" field is shown.

Before
----------------------------------------
!missing(https://lab.civicrm.org/dev/core/uploads/02f92e016aa97074be80d410ca596db1/Screen_Shot_2018-04-11_at_3.52.02_PM.jpg)

After
----------------------------------------
![screenshot 2018-04-30 20 36 46](https://user-images.githubusercontent.com/336308/39419928-39b9b3c6-4cb6-11e8-83bd-a5905d9d3c63.png)


Technical Details
----------------------------------------


Comments
----------------------------------------
I also noticed that the record payment checkbox is not checked when it really should be - but I think that is unrelated to this issue.  I noticed other clunkiness but think it is just that flow IS clunky
