### PR TITLE
Mark Accent String Tests as incomplete if on a database that is not utf8

### DIFF
--- a/CRM/Utils/SQL.php
+++ b/CRM/Utils/SQL.php
@@ -122,4 +122,17 @@ class CRM_Utils_SQL {
     return TRUE;
   }
 
+  /**
+   * Is the Database set up to handle acceents.
+   * @return bool
+   */
+  public static function supportStorageOfAccents() {
+    $charSetDB = CRM_Core_DAO::executeQuery("SHOW VARIABLES LIKE 'character_set_database'")->fetchAll();
+    $charSet = $charSetDB[0]['Value'];
+    if ($charSet == 'utf8') {
+      return TRUE;
+    }
+    return FALSE;
+  }
+
 }

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -144,19 +144,27 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   /**
    * Test for international string acceptance (CRM-10210).
+   * Requires the databsase to be in utf8.
    *
    * @dataProvider getInternationalStrings
    *
    * @param string $string
    *   String to be tested.
+   * @param bool $checkCharSet
+   *   Bool to see if we should check charset.
    *
    * @throws \Exception
    */
-  public function testInternationalStrings($string) {
+  public function testInternationalStrings($string, $checkCharSet = FALSE) {
     $this->callAPISuccess('Contact', 'create', array_merge(
       $this->_params,
       array('first_name' => $string)
     ));
+    if ($checkCharSet) {
+      if (!CRM_Utils_SQL::supportStorageOfAccents()) {
+        $this->markTestIncomplete('Database is not Charset UTF8 therefore can not store accented strings properly');
+      }
+    }
     $result = $this->callAPISuccessGetSingle('Contact', array('first_name' => $string));
     $this->assertEquals($string, $result['first_name']);
 
@@ -175,8 +183,8 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    */
   public function getInternationalStrings() {
     $invocations = array();
-    $invocations[] = array('Scarabée');
-    $invocations[] = array('Iñtërnâtiônàlizætiøn');
+    $invocations[] = array('Scarabée', TRUE);
+    $invocations[] = array('Iñtërnâtiônàlizætiøn', TRUE);
     $invocations[] = array('これは日本語のテキストです。読めますか');
     $invocations[] = array('देखें हिन्दी कैसी नजर आती है। अरे वाह ये तो नजर आती है।');
     return $invocations;


### PR DESCRIPTION
Overview
----------------------------------------
Storage of internationalised strings with accents requires utf8 encoding, At present on the ubunu1604 the default is latin1. This is as per https://stackoverflow.com/questions/17798119/write-to-mysql-db-from-bash-in-utf-8. This allows for the tests to still run on the boxes we got where the DB is utf8 but on the latin1 boxes it will just mark it as incomplete rather than completely skipping it. 

Before
----------------------------------------
Tests completely fail on latin1 test boxes

After
----------------------------------------
Tests are marked as incomplete rather than skipped

ping @eileenmcnaughton @totten @mlutfy 

A better solution IMO would be to set the charset to be utf8 on our test boxes and adding a status check to let people know their dbs may not be right.