### PR TITLE
CRM_Utils_Check - Generate a `notice` if MySQL doesn't support accents

### DIFF
--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -871,6 +871,28 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
   }
 
   /**
+   * Display a warning for site admins if they cannot store international strings.
+   *
+   * @return array
+   */
+  public function checkDbCharacterSet() {
+    $messages = array();
+
+    if (!CRM_Utils_SQL::supportStorageOfAccents()) {
+      $messages[] = new CRM_Utils_Check_Message(
+        __FUNCTION__,
+        ts('The default MySQL character-set for this database is not UTF-8. This could lead to irregularities in storing internationalized strings. Consider <a href="%1">changing the default MySQL character-set</a>.',
+          [1 => $this->createDocUrl('checkDbCharacterSet')]),
+        ts('International String Storage'),
+        \Psr\Log\LogLevel::NOTICE,
+        'fa-language'
+      );
+    }
+
+    return $messages;
+  }
+
+  /**
    * Check that the resource URL points to the correct location.
    * @return array
    */
@@ -900,6 +922,15 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
       );
     }
     return $messages;
+  }
+
+  /**
+   * @param $topic
+   *
+   * @return string
+   */
+  public function createDocUrl($topic) {
+    return CRM_Utils_System::getWikiBaseURL() . $topic;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Generate a `notice` if MySQL doesn't support storage of accents

Before
----------------------------------------
No warnings or notices.

After
----------------------------------------
The status-check generates a `notice`

![screen shot 2018-04-30 at 7 54 18 pm](https://user-images.githubusercontent.com/1336047/39459431-5efa91c4-4cb0-11e8-9605-2914f9fef565.png)

Comments
----------------------------------------
This is a follow-up to #12060.  I'm submitting it for discussion -- but I'm not
actually confident in the change, so please don't merge unless you affirmatively
agree.  Let me recount the context.

PR #12060 aimed to address an issue where `testInternationalStrings()` failed on
one system (`test-ubu1604-1`) but succeeded another (`test-ubu1204-5`).  The
content of `character_set_database` was suggested as a distinguishing
characteristic, and #12060 basically says, "Don't test if we don't expect it to work."
That's nice for developers because it reduces the noisiness of the test suite.

But it also reduces the impact of the `testInternationalStrings()` -- because a
non-working environment is considered passing.  Is it legit to say "it's not the
devteam's problem if some environments don't work"?  Yes, that's legit.  But if
we have to kick the ball over the sysadmin, then let's finish job and give them
a notice so they can fix the environment.

Both #12060 and this patch are premised on the correctness of
`supportStorageOfAccents()`.  I'm not really confident in it, though.  On my local
system, `supportStorageOfAccents()` returns `FALSE`, but I'm able to create and view
a contact with last name `Iñtërnâtiônàlizætiøn` -- via either web UI or CLI
(`cv api contact.create`). (Note: CLI displays JSON by default, and JSON converts to `\uXXX` notation. It's more readable with `--out=pretty`) That casts some doubt on `supportStorageOfAccents()`, but it's not decisive. (The check may be important for some other reason/use-case).

In short -- if `supportStorageOfAccents()` is working correctly, then we should
merge this and notify site-admins.  If `supportStorageOfAccents()` is not working
correctly, then we probably need something else to fix #12060.

Note: The hyperlink currently points to a wiki page (same ideas the notices in `CRM_Utils_Component_Security`) which could be implemented or redirected to docs when someone has steps to resolve. I don't have those steps (and I don't even know if the test is right!) -- but I'm submitting this PR because I think we should be logically consistent about the matter.