### PR TITLE
Make Send SMS permission independent of Edit Contact permission

### DIFF
--- a/CRM/Contact/Task.php
+++ b/CRM/Contact/Task.php
@@ -297,18 +297,17 @@ class CRM_Contact_Task extends CRM_Core_Task {
         self::LABEL_CONTACTS => self::$_tasks[self::LABEL_CONTACTS]['title'],
       );
 
-      if (isset(self::$_tasks[self::MAP_CONTACTS]) &&
-        !empty(self::$_tasks[self::MAP_CONTACTS]['title'])
-      ) {
-        $tasks[self::MAP_CONTACTS] = self::$_tasks[self::MAP_CONTACTS]['title'];
+      foreach ([
+        self::MAP_CONTACTS,
+        self::CREATE_MAILING,
+        self::TASK_SMS
+      ] as $task) {
+        if (isset(self::$_tasks[$task]) &&
+          !empty(self::$_tasks[$task]['title'])
+        ) {
+          $tasks[$task] = self::$_tasks[$task]['title'];
+        }
       }
-
-      if (isset(self::$_tasks[self::CREATE_MAILING]) &&
-        !empty(self::$_tasks[self::CREATE_MAILING]['title'])
-      ) {
-        $tasks[self::CREATE_MAILING] = self::$_tasks[self::CREATE_MAILING]['title'];
-      }
-
     }
 
     $tasks = parent::corePermissionedTaskTitles($tasks, $permission, $params);


### PR DESCRIPTION
Overview
----------------------------------------
A (presumably fairly trivial) follow on from https://github.com/civicrm/civicrm-core/pull/11590.

Most of the tasks listed in `CRM_Contact_Task::tasks()` also require the edit contact permission but a few do not. The ones that do not are mentioned in the final else of `::permissionedTaskTitles()`.

We want people to be able to Send SMS without having the edit contacts permission. Therefore, we need to mention it in this final else clause.

Before
---------

You needed an *Edit contact* permission AND the *send SMS* permission to send SMS

After
------
You only need the *send SMS* permission to send SMS.
