### PR TITLE
dev/core#94 Advanced Search "Display Results As" always displays contact tasks on first search

### DIFF
--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -286,13 +286,20 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
   }
 
   /**
+   * Get the metadata for the query mode (this includes task class names)
+   *
    * @param int $mode
    *
-   * @return mixed
+   * @return array
+   * @throws \CRM_Core_Exception
    */
   public static function getModeValue($mode = CRM_Contact_BAO_Query::MODE_CONTACTS) {
-    self::setModeValues();
+    $searchPane = CRM_Utils_Request::retrieve('searchPane', 'String');
+    if (!empty($searchPane)) {
+      $mode = array_search($searchPane, self::getModeToComponentMapping());
+    }
 
+    self::setModeValues();
     if (!array_key_exists($mode, self::$_modeValues)) {
       $mode = CRM_Contact_BAO_Query::MODE_CONTACTS;
     }

--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -199,90 +199,88 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
   }
 
   public static function setModeValues() {
-    if (!self::$_modeValues) {
-      self::$_modeValues = array(
-        CRM_Contact_BAO_Query::MODE_CONTACTS => array(
-          'selectorName' => self::$_selectorName,
-          'selectorLabel' => ts('Contacts'),
-          'taskFile' => 'CRM/Contact/Form/Search/ResultTasks.tpl',
-          'taskContext' => NULL,
-          'resultFile' => 'CRM/Contact/Form/Selector.tpl',
-          'resultContext' => NULL,
-          'taskClassName' => 'CRM_Contact_Task',
-          'component' => '',
-        ),
-        CRM_Contact_BAO_Query::MODE_CONTRIBUTE => array(
-          'selectorName' => 'CRM_Contribute_Selector_Search',
-          'selectorLabel' => ts('Contributions'),
-          'taskFile' => 'CRM/common/searchResultTasks.tpl',
-          'taskContext' => 'Contribution',
-          'resultFile' => 'CRM/Contribute/Form/Selector.tpl',
-          'resultContext' => 'Search',
-          'taskClassName' => 'CRM_Contribute_Task',
-          'component' => 'CiviContribute',
-        ),
-        CRM_Contact_BAO_Query::MODE_EVENT => array(
-          'selectorName' => 'CRM_Event_Selector_Search',
-          'selectorLabel' => ts('Event Participants'),
-          'taskFile' => 'CRM/common/searchResultTasks.tpl',
-          'taskContext' => NULL,
-          'resultFile' => 'CRM/Event/Form/Selector.tpl',
-          'resultContext' => 'Search',
-          'taskClassName' => 'CRM_Event_Task',
-          'component' => 'CiviEvent',
-        ),
-        CRM_Contact_BAO_Query::MODE_ACTIVITY => array(
-          'selectorName' => 'CRM_Activity_Selector_Search',
-          'selectorLabel' => ts('Activities'),
-          'taskFile' => 'CRM/common/searchResultTasks.tpl',
-          'taskContext' => NULL,
-          'resultFile' => 'CRM/Activity/Form/Selector.tpl',
-          'resultContext' => 'Search',
-          'taskClassName' => 'CRM_Activity_Task',
-          'component' => 'activity',
-        ),
-        CRM_Contact_BAO_Query::MODE_MEMBER => array(
-          'selectorName' => 'CRM_Member_Selector_Search',
-          'selectorLabel' => ts('Memberships'),
-          'taskFile' => "CRM/common/searchResultTasks.tpl",
-          'taskContext' => NULL,
-          'resultFile' => 'CRM/Member/Form/Selector.tpl',
-          'resultContext' => 'Search',
-          'taskClassName' => 'CRM_Member_Task',
-          'component' => 'CiviMember',
-        ),
-        CRM_Contact_BAO_Query::MODE_CASE => array(
-          'selectorName' => 'CRM_Case_Selector_Search',
-          'selectorLabel' => ts('Cases'),
-          'taskFile' => "CRM/common/searchResultTasks.tpl",
-          'taskContext' => NULL,
-          'resultFile' => 'CRM/Case/Form/Selector.tpl',
-          'resultContext' => 'Search',
-          'taskClassName' => 'CRM_Case_Task',
-          'component' => 'CiviCase',
-        ),
-        CRM_Contact_BAO_Query::MODE_CONTACTSRELATED => array(
-          'selectorName' => self::$_selectorName,
-          'selectorLabel' => ts('Related Contacts'),
-          'taskFile' => 'CRM/Contact/Form/Search/ResultTasks.tpl',
-          'taskContext' => NULL,
-          'resultFile' => 'CRM/Contact/Form/Selector.tpl',
-          'resultContext' => NULL,
-          'taskClassName' => 'CRM_Contact_Task',
-          'component' => 'related_contact',
-        ),
-        CRM_Contact_BAO_Query::MODE_MAILING => array(
-          'selectorName' => 'CRM_Mailing_Selector_Search',
-          'selectorLabel' => ts('Mailings'),
-          'taskFile' => "CRM/common/searchResultTasks.tpl",
-          'taskContext' => NULL,
-          'resultFile' => 'CRM/Mailing/Form/Selector.tpl',
-          'resultContext' => 'Search',
-          'taskClassName' => 'CRM_Mailing_Task',
-          'component' => 'CiviMail',
-        ),
-      );
-    }
+    self::$_modeValues = array(
+      CRM_Contact_BAO_Query::MODE_CONTACTS => array(
+        'selectorName' => self::$_selectorName,
+        'selectorLabel' => ts('Contacts'),
+        'taskFile' => 'CRM/Contact/Form/Search/ResultTasks.tpl',
+        'taskContext' => NULL,
+        'resultFile' => 'CRM/Contact/Form/Selector.tpl',
+        'resultContext' => NULL,
+        'taskClassName' => 'CRM_Contact_Task',
+        'component' => '',
+      ),
+      CRM_Contact_BAO_Query::MODE_CONTRIBUTE => array(
+        'selectorName' => 'CRM_Contribute_Selector_Search',
+        'selectorLabel' => ts('Contributions'),
+        'taskFile' => 'CRM/common/searchResultTasks.tpl',
+        'taskContext' => 'Contribution',
+        'resultFile' => 'CRM/Contribute/Form/Selector.tpl',
+        'resultContext' => 'Search',
+        'taskClassName' => 'CRM_Contribute_Task',
+        'component' => 'CiviContribute',
+      ),
+      CRM_Contact_BAO_Query::MODE_EVENT => array(
+        'selectorName' => 'CRM_Event_Selector_Search',
+        'selectorLabel' => ts('Event Participants'),
+        'taskFile' => 'CRM/common/searchResultTasks.tpl',
+        'taskContext' => NULL,
+        'resultFile' => 'CRM/Event/Form/Selector.tpl',
+        'resultContext' => 'Search',
+        'taskClassName' => 'CRM_Event_Task',
+        'component' => 'CiviEvent',
+      ),
+      CRM_Contact_BAO_Query::MODE_ACTIVITY => array(
+        'selectorName' => 'CRM_Activity_Selector_Search',
+        'selectorLabel' => ts('Activities'),
+        'taskFile' => 'CRM/common/searchResultTasks.tpl',
+        'taskContext' => NULL,
+        'resultFile' => 'CRM/Activity/Form/Selector.tpl',
+        'resultContext' => 'Search',
+        'taskClassName' => 'CRM_Activity_Task',
+        'component' => 'activity',
+      ),
+      CRM_Contact_BAO_Query::MODE_MEMBER => array(
+        'selectorName' => 'CRM_Member_Selector_Search',
+        'selectorLabel' => ts('Memberships'),
+        'taskFile' => "CRM/common/searchResultTasks.tpl",
+        'taskContext' => NULL,
+        'resultFile' => 'CRM/Member/Form/Selector.tpl',
+        'resultContext' => 'Search',
+        'taskClassName' => 'CRM_Member_Task',
+        'component' => 'CiviMember',
+      ),
+      CRM_Contact_BAO_Query::MODE_CASE => array(
+        'selectorName' => 'CRM_Case_Selector_Search',
+        'selectorLabel' => ts('Cases'),
+        'taskFile' => "CRM/common/searchResultTasks.tpl",
+        'taskContext' => NULL,
+        'resultFile' => 'CRM/Case/Form/Selector.tpl',
+        'resultContext' => 'Search',
+        'taskClassName' => 'CRM_Case_Task',
+        'component' => 'CiviCase',
+      ),
+      CRM_Contact_BAO_Query::MODE_CONTACTSRELATED => array(
+        'selectorName' => self::$_selectorName,
+        'selectorLabel' => ts('Related Contacts'),
+        'taskFile' => 'CRM/Contact/Form/Search/ResultTasks.tpl',
+        'taskContext' => NULL,
+        'resultFile' => 'CRM/Contact/Form/Selector.tpl',
+        'resultContext' => NULL,
+        'taskClassName' => 'CRM_Contact_Task',
+        'component' => 'related_contact',
+      ),
+      CRM_Contact_BAO_Query::MODE_MAILING => array(
+        'selectorName' => 'CRM_Mailing_Selector_Search',
+        'selectorLabel' => ts('Mailings'),
+        'taskFile' => "CRM/common/searchResultTasks.tpl",
+        'taskContext' => NULL,
+        'resultFile' => 'CRM/Mailing/Form/Selector.tpl',
+        'resultContext' => 'Search',
+        'taskClassName' => 'CRM_Mailing_Task',
+        'component' => 'CiviMail',
+      ),
+    );
   }
 
   /**
@@ -690,9 +688,8 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
     if (!isset($this->_componentMode)) {
       $this->_componentMode = CRM_Contact_BAO_Query::MODE_CONTACTS;
     }
-    self::setModeValues();
-
     self::$_selectorName = $this->_modeValue['selectorName'];
+    self::setModeValues();
 
     $setDynamic = FALSE;
     if (strpos(self::$_selectorName, 'CRM_Contact_Selector') !== FALSE) {

--- a/CRM/Contact/StateMachine/Search.php
+++ b/CRM/Contact/StateMachine/Search.php
@@ -103,13 +103,11 @@ class CRM_Contact_StateMachine_Search extends CRM_Core_StateMachine {
     }
     $this->_controller->set('task', $value);
 
-    if ($value) {
-      $componentMode = $this->_controller->get('component_mode');
-      $modeValue = CRM_Contact_Form_Search::getModeValue($componentMode);
-      $taskClassName = $modeValue['taskClassName'];
-      return $taskClassName::getTask($value);
-    }
-    return CRM_Contact_Task::getTask($value);
+    $componentMode = $this->_controller->get('component_mode');
+
+    $modeValue = CRM_Contact_Form_Search::getModeValue($componentMode);
+    $taskClassName = $modeValue['taskClassName'];
+    return $taskClassName::getTask($value);
   }
 
   /**

--- a/CRM/Contact/StateMachine/Search.php
+++ b/CRM/Contact/StateMachine/Search.php
@@ -104,7 +104,6 @@ class CRM_Contact_StateMachine_Search extends CRM_Core_StateMachine {
     $this->_controller->set('task', $value);
 
     $componentMode = $this->_controller->get('component_mode');
-
     $modeValue = CRM_Contact_Form_Search::getModeValue($componentMode);
     $taskClassName = $modeValue['taskClassName'];
     return $taskClassName::getTask($value);


### PR DESCRIPTION
Overview
----------------------------------------
To reproduce:

1. Open Advanced Search.
1. Select "Display Results As" = Memberships (anything other than "Contacts").
1. Search.
1. Task list shows tasks for contacts.

Task list should show tasks for memberships, it will do the second time it is loaded but it ignores the "searchPane" parameter that is passed in via $_REQUEST which is needed to identify the entity type on first load.

https://lab.civicrm.org/dev/core/issues/94

Before
----------------------------------------
Wrong task list is loaded if first advanced search is not displaying results as contacts.

After
----------------------------------------
Correct task list is loaded each time.

Technical Details
----------------------------------------
Because the "Display Results As" parameter is being ignored it is loading the default task which is contacts.