### PR TITLE
Fix fatal error on logging tab when hook alters logging tables.

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -169,7 +169,7 @@ class CRM_Core_DAO extends DB_DataObject {
    */
   public static function disableFullGroupByMode() {
     $currentModes = CRM_Utils_SQL::getSqlModes();
-    if (CRM_Utils_SQL::supportsFullGroupBy() && in_array('ONLY_FULL_GROUP_BY', $currentModes) && CRM_Utils_SQL::isGroupByModeInDefault()) {
+    if (in_array('ONLY_FULL_GROUP_BY', $currentModes) && CRM_Utils_SQL::isGroupByModeInDefault()) {
       $key = array_search('ONLY_FULL_GROUP_BY', $currentModes);
       unset($currentModes[$key]);
       CRM_Core_DAO::executeQuery("SET SESSION sql_mode = %1", array(1 => array(implode(',', $currentModes), 'String')));
@@ -181,7 +181,7 @@ class CRM_Core_DAO extends DB_DataObject {
    */
   public static function reenableFullGroupByMode() {
     $currentModes = CRM_Utils_SQL::getSqlModes();
-    if (CRM_Utils_SQL::supportsFullGroupBy() && !in_array('ONLY_FULL_GROUP_BY', $currentModes) && CRM_Utils_SQL::isGroupByModeInDefault()) {
+    if (!in_array('ONLY_FULL_GROUP_BY', $currentModes) && CRM_Utils_SQL::isGroupByModeInDefault()) {
       $currentModes[] = 'ONLY_FULL_GROUP_BY';
       CRM_Core_DAO::executeQuery("SET SESSION sql_mode = %1", array(1 => array(implode(',', $currentModes), 'String')));
     }

--- a/CRM/Logging/ReportSummary.php
+++ b/CRM/Logging/ReportSummary.php
@@ -232,26 +232,6 @@ class CRM_Logging_ReportSummary extends CRM_Report_Form {
     $this->_where .= " AND (entity_log_civireport.log_action != 'Initialization')";
   }
 
-  public function postProcess() {
-    $this->beginPostProcess();
-    $rows = array();
-
-    $this->buildTemporaryTables();
-    $sql = $this->buildQuery();
-
-    $this->buildRows($sql, $rows);
-    $this->addToDeveloperTab($sql);
-
-    // format result set.
-    $this->formatDisplay($rows);
-
-    // assign variables to templates
-    $this->doTemplateAssignment($rows);
-
-    // do print / pdf / instance stuff if needed
-    $this->endPostProcess($rows);
-  }
-
   /**
    * Get log type.
    *

--- a/CRM/Logging/ReportSummary.php
+++ b/CRM/Logging/ReportSummary.php
@@ -39,13 +39,6 @@ class CRM_Logging_ReportSummary extends CRM_Report_Form {
   protected $loggingDB;
 
   /**
-   * The log table currently being processed.
-   *
-   * @var string
-   */
-  protected $currentLogTable;
-
-  /**
    * Clause used in the final run of buildQuery but not when doing preliminary work.
    *
    * (We do this to all the api to run this report since it doesn't call postProcess).
@@ -53,6 +46,13 @@ class CRM_Logging_ReportSummary extends CRM_Report_Form {
    * @var string
    */
   protected $logTypeTableClause;
+
+  /**
+   * The log table currently being processed.
+   *
+   * @var string
+   */
+  protected $currentLogTable;
 
   /**
    * Class constructor.
@@ -236,84 +236,7 @@ class CRM_Logging_ReportSummary extends CRM_Report_Form {
     $this->beginPostProcess();
     $rows = array();
 
-    $tempColumns = "id int(10),  log_civicrm_entity_log_grouping varchar(32)";
-    if (!empty($this->_params['fields']['log_action'])) {
-      $tempColumns .= ", log_action varchar(64)";
-    }
-    $tempColumns .= ", log_type varchar(64), log_user_id int(10), log_date timestamp";
-    if (!empty($this->_params['fields']['altered_contact'])) {
-      $tempColumns .= ", altered_contact varchar(128)";
-    }
-    $tempColumns .= ", altered_contact_id int(10), log_conn_id varchar(17), is_deleted tinyint(4)";
-    if (!empty($this->_params['fields']['display_name'])) {
-      $tempColumns .= ", display_name varchar(128)";
-    }
-
-    // temp table to hold all altered contact-ids
-    $sql = "CREATE TEMPORARY TABLE civicrm_temp_civireport_logsummary ( {$tempColumns} ) ENGINE=HEAP";
-    CRM_Core_DAO::executeQuery($sql);
-    $this->addToDeveloperTab($sql);
-
-    $logTypes = CRM_Utils_Array::value('log_type_value', $this->_params);
-    unset($this->_params['log_type_value']);
-    if (empty($logTypes)) {
-      foreach (array_keys($this->_logTables) as $table) {
-        $type = $this->getLogType($table);
-        $logTypes[$type] = $type;
-      }
-    }
-
-    $this->logTypeTableClause = '(1)';
-    if ($logTypeTableValue = CRM_Utils_Array::value("log_type_table_value", $this->_params)) {
-      $this->logTypeTableClause = $this->whereClause($this->_columns['log_civicrm_entity']['filters']['log_type_table'],
-        $this->_params['log_type_table_op'], $logTypeTableValue, NULL, NULL);
-      unset($this->_params['log_type_table_value']);
-    }
-
-    foreach ($this->_logTables as $entity => $detail) {
-      if ((in_array($this->getLogType($entity), $logTypes) &&
-          CRM_Utils_Array::value('log_type_op', $this->_params) == 'in') ||
-        (!in_array($this->getLogType($entity), $logTypes) &&
-          CRM_Utils_Array::value('log_type_op', $this->_params) == 'notin')
-      ) {
-        $this->currentLogTable = $entity;
-        $sql = $this->buildQuery(FALSE);
-        $sql = str_replace("entity_log_civireport.log_type as", "'{$entity}' as", $sql);
-        $sql = "INSERT IGNORE INTO civicrm_temp_civireport_logsummary {$sql}";
-        CRM_Core_DAO::executeQuery($sql);
-        $this->addToDeveloperTab($sql);
-      }
-    }
-
-    $this->currentLogTable = '';
-
-    // add computed log_type column so that we can do a group by after that, which will help
-    // alterDisplay() counts sync with pager counts
-    $sql = "SELECT DISTINCT log_type FROM civicrm_temp_civireport_logsummary";
-    $dao = CRM_Core_DAO::executeQuery($sql);
-    $this->addToDeveloperTab($sql);
-    $replaceWith = array();
-    while ($dao->fetch()) {
-      $type = $this->getLogType($dao->log_type);
-      if (!array_key_exists($type, $replaceWith)) {
-        $replaceWith[$type] = array();
-      }
-      $replaceWith[$type][] = $dao->log_type;
-    }
-    foreach ($replaceWith as $type => $tables) {
-      if (!empty($tables)) {
-        $replaceWith[$type] = implode("','", $tables);
-      }
-    }
-
-    $sql = "ALTER TABLE civicrm_temp_civireport_logsummary ADD COLUMN log_civicrm_entity_log_type_label varchar(64)";
-    CRM_Core_DAO::executeQuery($sql);
-    $this->addToDeveloperTab($sql);
-    foreach ($replaceWith as $type => $in) {
-      $sql = "UPDATE civicrm_temp_civireport_logsummary SET log_civicrm_entity_log_type_label='{$type}', log_date=log_date WHERE log_type IN('$in')";
-      CRM_Core_DAO::executeQuery($sql);
-      $this->addToDeveloperTab($sql);
-    }
+    $this->buildTemporaryTables();
     $sql = $this->buildQuery();
 
     $this->buildRows($sql, $rows);
@@ -434,6 +357,101 @@ WHERE  log_date <= %1 AND id = %2 ORDER BY log_date DESC LIMIT 1";
   }
 
   /**
+   * Build the temporary tables for the query.
+   */
+  protected function buildTemporaryTables() {
+    $tempColumns = "id int(10),  log_civicrm_entity_log_grouping varchar(32)";
+    if (!empty($this->_params['fields']['log_action'])) {
+      $tempColumns .= ", log_action varchar(64)";
+    }
+    $tempColumns .= ", log_type varchar(64), log_user_id int(10), log_date timestamp";
+    if (!empty($this->_params['fields']['altered_contact'])) {
+      $tempColumns .= ", altered_contact varchar(128)";
+    }
+    $tempColumns .= ", altered_contact_id int(10), log_conn_id varchar(17), is_deleted tinyint(4)";
+    if (!empty($this->_params['fields']['display_name'])) {
+      $tempColumns .= ", display_name varchar(128)";
+    }
+
+    // temp table to hold all altered contact-ids
+    $sql = "CREATE TEMPORARY TABLE civicrm_temp_civireport_logsummary ( {$tempColumns} ) ENGINE=HEAP";
+    CRM_Core_DAO::executeQuery($sql);
+    $this->addToDeveloperTab($sql);
+
+    $logTypes = CRM_Utils_Array::value('log_type_value', $this->_params);
+    unset($this->_params['log_type_value']);
+    if (empty($logTypes)) {
+      foreach (array_keys($this->_logTables) as $table) {
+        $type = $this->getLogType($table);
+        $logTypes[$type] = $type;
+      }
+    }
+
+    $logTypeTableClause = '(1)';
+    if ($logTypeTableValue = CRM_Utils_Array::value("log_type_table_value", $this->_params)) {
+      $logTypeTableClause = $this->whereClause($this->_columns['log_civicrm_entity']['filters']['log_type_table'],
+        $this->_params['log_type_table_op'], $logTypeTableValue, NULL, NULL);
+      unset($this->_params['log_type_table_value']);
+    }
+
+    foreach ($this->_logTables as $entity => $detail) {
+      if ((in_array($this->getLogType($entity), $logTypes) &&
+          CRM_Utils_Array::value('log_type_op', $this->_params) == 'in') ||
+        (!in_array($this->getLogType($entity), $logTypes) &&
+          CRM_Utils_Array::value('log_type_op', $this->_params) == 'notin')
+      ) {
+        $this->currentLogTable = $entity;
+        $sql = $this->buildQuery(FALSE);
+        $sql = str_replace("entity_log_civireport.log_type as", "'{$entity}' as", $sql);
+        $sql = "INSERT IGNORE INTO civicrm_temp_civireport_logsummary {$sql}";
+        CRM_Core_DAO::disableFullGroupByMode();
+        CRM_Core_DAO::executeQuery($sql);
+        CRM_Core_DAO::reenableFullGroupByMode();
+        $this->addToDeveloperTab($sql);
+      }
+    }
+
+    $this->currentLogTable = '';
+
+    // add computed log_type column so that we can do a group by after that, which will help
+    // alterDisplay() counts sync with pager counts
+    $sql = "SELECT DISTINCT log_type FROM civicrm_temp_civireport_logsummary";
+    $dao = CRM_Core_DAO::executeQuery($sql);
+    $this->addToDeveloperTab($sql);
+    $replaceWith = array();
+    while ($dao->fetch()) {
+      $type = $this->getLogType($dao->log_type);
+      if (!array_key_exists($type, $replaceWith)) {
+        $replaceWith[$type] = array();
+      }
+      $replaceWith[$type][] = $dao->log_type;
+    }
+    foreach ($replaceWith as $type => $tables) {
+      if (!empty($tables)) {
+        $replaceWith[$type] = implode("','", $tables);
+      }
+    }
+
+    $sql = "ALTER TABLE civicrm_temp_civireport_logsummary ADD COLUMN log_civicrm_entity_log_type_label varchar(64)";
+    CRM_Core_DAO::executeQuery($sql);
+    $this->addToDeveloperTab($sql);
+    foreach ($replaceWith as $type => $in) {
+      $sql = "UPDATE civicrm_temp_civireport_logsummary SET log_civicrm_entity_log_type_label='{$type}', log_date=log_date WHERE log_type IN('$in')";
+      CRM_Core_DAO::executeQuery($sql);
+      $this->addToDeveloperTab($sql);
+    }
+    $this->logTypeTableClause = $logTypeTableClause;
+  }
+
+  /**
+   * Common processing, also via api/unit tests.
+   */
+  public function beginPostProcessCommon() {
+    parent::beginPostProcessCommon();
+    $this->buildTemporaryTables();
+  }
+
+  /**
    * Build the report query.
    *
    * We override this in order to be able to run from the api.
@@ -462,6 +480,18 @@ GROUP BY log_civicrm_entity_log_date, log_civicrm_entity_log_type_label, log_civ
       'altered_by_contact_civireport.',
     ), 'entity_log_civireport.', $sql);
     return $sql;
+  }
+
+  /**
+   * Build output rows.
+   *
+   * @param string $sql
+   * @param array $rows
+   */
+  public function buildRows($sql, &$rows) {
+    parent::buildRows($sql, $rows);
+    // Clean up the temp table - mostly for the unit test.
+    CRM_Core_DAO::executeQuery('DROP TEMPORARY TABLE IF EXISTS civicrm_temp_civireport_logsummary');
   }
 
 }

--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -200,7 +200,11 @@ AND    (TABLE_NAME LIKE 'log_civicrm_%' $nonStandardTableNameString )
     $customGroupDAO = CRM_Core_BAO_CustomGroup::getAllCustomGroupsByBaseEntity($extends);
     $customGroupDAO->find();
     while ($customGroupDAO->fetch()) {
-      $customGroupTables[$customGroupDAO->table_name] = $this->logs[$customGroupDAO->table_name];
+      // logging is disabled for the table (e.g by hook) then $this->logs[$customGroupDAO->table_name]
+      // will be empty.
+      if (!empty($this->logs[$customGroupDAO->table_name])) {
+        $customGroupTables[$customGroupDAO->table_name] = $this->logs[$customGroupDAO->table_name];
+      }
     }
     return $customGroupTables;
   }

--- a/CRM/Report/Form/Contact/LoggingSummary.php
+++ b/CRM/Report/Form/Contact/LoggingSummary.php
@@ -31,6 +31,8 @@
  * @copyright CiviCRM LLC (c) 2004-2018
  */
 class CRM_Report_Form_Contact_LoggingSummary extends CRM_Logging_ReportSummary {
+
+  public $optimisedForOnlyFullGroupBy = FALSE;
   /**
    * Class constructor.
    */
@@ -299,6 +301,10 @@ class CRM_Report_Form_Contact_LoggingSummary extends CRM_Logging_ReportSummary {
    * Generate From Clause.
    */
   public function from() {
+    if (!$this->currentLogTable) {
+      // From has already been built in this case.
+      return;
+    }
     $entity = $this->currentLogTable;
 
     $detail = $this->_logTables[$entity];

--- a/CRM/Utils/SQL.php
+++ b/CRM/Utils/SQL.php
@@ -112,9 +112,6 @@ class CRM_Utils_SQL {
    * @return bool
    */
   public static function isGroupByModeInDefault() {
-    if (!self::supportsFullGroupBy()) {
-      return FALSE;
-    }
     $sqlModes = explode(',', CRM_Core_DAO::singleValueQuery('SELECT @@global.sql_mode'));
     if (!in_array('ONLY_FULL_GROUP_BY', $sqlModes)) {
       return FALSE;

--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -140,7 +140,7 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
   }
 
   /**
-   * Tet api to get rows from reports.
+   * Test api to get rows from reports.
    *
    * @dataProvider getReportTemplates
    *
@@ -149,12 +149,20 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
    * @throws \PHPUnit_Framework_IncompleteTestError
    */
   public function testReportTemplateGetRowsAllReports($reportID) {
+    //$reportID = 'logging/contact/summary';
     if (stristr($reportID, 'has existing issues')) {
       $this->markTestIncomplete($reportID);
     }
+    if (substr($reportID, 0, '7') === 'logging') {
+      Civi::settings()->set('logging', 1);
+    }
+
     $this->callAPISuccess('report_template', 'getrows', array(
       'report_id' => $reportID,
     ));
+    if (substr($reportID, 0, '7') === 'logging') {
+      Civi::settings()->set('logging', 0);
+    }
   }
 
   /**
@@ -189,8 +197,6 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
     $reportsToSkip = array(
       'activity' => 'does not respect function signature on from clause',
       'event/income' => 'I do no understand why but error is Call to undefined method CRM_Report_Form_Event_Income::from() in CRM/Report/Form.php on line 2120',
-      'logging/contact/summary' => '(likely to be test related) probably logging off Undefined index: Form/Contact/LoggingSummary.php(231): PHP',
-      'logging/contribute/summary' => '(likely to be test related) probably logging off DB Error: no such table',
       'contribute/history' => 'Declaration of CRM_Report_Form_Contribute_History::buildRows() should be compatible with CRM_Report_Form::buildRows($sql, &$rows)',
       'activitySummary' => 'We use temp tables for the main query generation and name are dynamic. These names are not available in stats() when called directly.',
     );


### PR DESCRIPTION
Overview
----------------------------------------
The logging tag of a contact fails to load if logging is enabled and a custom table has been excluded by hook. This is especially appropriate for custom tables with only calculated values (ping @jmcclelland )

Before
----------------------------------------
Logging report fails if a hook like this is in play

```
/**
 * Implements hook_alterLogTables().
 *
 * @param array $logTableSpec
 */
function mymodule_civicrm_alterLogTables(&$logTableSpec) {
  unset($logTableSpec['civicrm_value_calculated_custom_table']
}
```

After
----------------------------------------
Report loads

Technical Details
----------------------------------------
When a custom table is removed from logged tables by hook (e.g a calculated table like a summary table) the logging report
still tries to include it but fails with a fatal error.

This patch excludes it from the list of customDataEnabled logging tables

Comments
----------------------------------------
Adding a unit test for this relies on the report being testable - will rebase one #12065 is merged