### PR TITLE
(dev/core/99) Search builder doesn't retain selected (boolean) option after searching

### DIFF
--- a/templates/CRM/Contact/Form/Search/Builder.js
+++ b/templates/CRM/Contact/Form/Search/Builder.js
@@ -285,7 +285,7 @@
     var initialFields = {}, fetchFields = false;
     $('select[id^=mapper][id$="_1"] option:selected', '#Builder').each(function() {
       var field = $(this).attr('value');
-      if (typeof(CRM.searchBuilder.fieldOptions[field]) == 'string') {
+      if (typeof(CRM.searchBuilder.fieldOptions[field]) == 'string' && CRM.searchBuilder.fieldOptions[field] !== 'yesno') {
         initialFields[field] = [CRM.searchBuilder.fieldOptions[field], 'getoptions', {field: field, sequential: 1}];
         fetchFields = true;
       }


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate:
1. Go to `Search Builder`
2. Choose Contact >> Do not email (or any other Boolean field) >> = >> Select `Yes`
3. Submit
See the BEFORE screencast where the select field is replaced by text field with value 1

Before
----------------------------------------
![test-multiple-before](https://user-images.githubusercontent.com/3735621/39573330-6617db96-4ef0-11e8-8b88-0e6829c0c69c.gif)


After
----------------------------------------
![test-multiple-after](https://user-images.githubusercontent.com/3735621/39573389-a6bcc77e-4ef0-11e8-8efb-7f0fc4b07e35.gif)


Technical Details
----------------------------------------
There was a miss at this condition https://github.com/civicrm/civicrm-core/commit/3eb318ac27bfce32ff5be4d77f698d848e585aee#diff-5d8eb408e278accc357ed18642ecfc94R246 where we also need to lookup for what value it holds as there might be two kinds of values for ```CRM.searchBuilder.fieldOptions[field]``` which is either ```yesno``` or entity value like ```membership```, ```group_contact``` etc. So we need to ensure that it always a entity string which is used in getoptions API to fetch options for a search field. The patch adds an extra condition for the same reason.
