### PR TITLE
(dev/core/100) Membership Detail report throw DB error

### DIFF
--- a/CRM/Report/Form/Member/Detail.php
+++ b/CRM/Report/Form/Member/Detail.php
@@ -281,7 +281,6 @@ class CRM_Report_Form_Member_Detail extends CRM_Report_Form {
   public function from() {
     $this->setFromBase('civicrm_contact');
     $this->_from .= "
-         {$this->_aclFrom}
                INNER JOIN civicrm_membership {$this->_aliases['civicrm_membership']}
                           ON {$this->_aliases['civicrm_contact']}.id =
                              {$this->_aliases['civicrm_membership']}.contact_id AND {$this->_aliases['civicrm_membership']}.is_test = 0


### PR DESCRIPTION
Overview
----------------------------------------
Membership Detail report throw DB error

Before
----------------------------------------
DB error appears as aclFrom clause is applied again in _setFromBase_ function here https://github.com/civicrm/civicrm-core/blob/master/CRM/Report/Form.php#L5071

After
----------------------------------------
Results appear as expected.

