### PR TITLE
dev/core/#101: Allow further customization of search form in hooks

### DIFF
--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -35,6 +35,7 @@ class CRM_Contact_Form_Search_Criteria {
    * @param CRM_Core_Form $form
    */
   public static function basic(&$form) {
+    self::setBasicSearchFields($form);
     $form->addElement('hidden', 'hidden_basic', 1);
 
     if ($form->_searchOptions['contactType']) {
@@ -69,7 +70,7 @@ class CRM_Contact_Form_Search_Criteria {
       $contactTags = CRM_Core_BAO_Tag::getTags();
 
       if ($contactTags) {
-        $form->add('select', 'contact_tags', ts('Tags'), $contactTags, FALSE,
+        $form->add('select', 'contact_tags', ts('Select Tag(s)'), $contactTags, FALSE,
           array('id' => 'contact_tags', 'multiple' => 'multiple', 'class' => 'crm-select2', 'style' => 'width: 100%;')
         );
       }
@@ -99,10 +100,10 @@ class CRM_Contact_Form_Search_Criteria {
     }
 
     // add text box for last name, first name, street name, city
-    $form->addElement('text', 'sort_name', ts('Find...'), CRM_Core_DAO::getAttribute('CRM_Contact_DAO_Contact', 'sort_name'));
+    $form->addElement('text', 'sort_name', ts('Complete OR Partial Name'), CRM_Core_DAO::getAttribute('CRM_Contact_DAO_Contact', 'sort_name'));
 
     // add text box for last name, first name, street name, city
-    $form->add('text', 'email', ts('Contact Email'), CRM_Core_DAO::getAttribute('CRM_Contact_DAO_Contact', 'sort_name'));
+    $form->add('text', 'email', ts('Complete OR Partial Email'), CRM_Core_DAO::getAttribute('CRM_Contact_DAO_Contact', 'sort_name'));
 
     //added contact source
     $form->add('text', 'contact_source', ts('Contact Source'), CRM_Core_DAO::getAttribute('CRM_Contact_DAO_Contact', 'contact_source'));
@@ -246,6 +247,74 @@ class CRM_Contact_Form_Search_Criteria {
     $phoneType = CRM_Core_PseudoConstant::get('CRM_Core_DAO_Phone', 'phone_type_id');
     $form->add('select', 'phone_location_type_id', ts('Phone Location'), array('' => ts('- any -')) + $locationType, FALSE, array('class' => 'crm-select2'));
     $form->add('select', 'phone_phone_type_id', ts('Phone Type'), array('' => ts('- any -')) + $phoneType, FALSE, array('class' => 'crm-select2'));
+  }
+
+  /**
+   * Defines the fields that can be displayed for the basic search section.
+   *
+   * @param CRM_Core_Form $form
+   */
+  protected static function setBasicSearchFields($form) {
+    $userFramework = CRM_Core_Config::singleton()->userFramework;
+
+    $form->assign('basicSearchFields', [
+      'sort_name' => ['name' => 'sort_name'],
+      'email' => ['name' => 'email'],
+      'contact_type' => ['name' => 'contact_type'],
+      'group' => [
+        'name' => 'group',
+        'template' => 'CRM/Contact/Form/Search/Criteria/Fields/group.tpl',
+      ],
+      'contact_tags' => ['name' => 'contact_tags'],
+      'tag_types_text' => ['name' => 'tag_types_text'],
+      'tag_search' => [
+        'name' => 'tag_search',
+        'help' => ['id' => 'id-all-tags'],
+      ],
+      'tag_set' => [
+        'name' => 'tag_set',
+        'is_custom' => TRUE,
+        'template' => 'CRM/Contact/Form/Search/Criteria/Fields/tag_set.tpl',
+      ],
+      'all_tag_types' => [
+        'name' => 'all_tag_types',
+        'class' => 'search-field__span-3 search-field__checkbox',
+        'help' => ['id' => 'id-all-tag-types']
+      ],
+      'phone_numeric' => [
+        'name' => 'phone_numeric',
+        'description' => ts('Punctuation and spaces are ignored.'),
+      ],
+      'phone_location_type_id' => ['name' => 'phone_location_type_id'],
+      'phone_phone_type_id' => ['name' => 'phone_phone_type_id'],
+      'privacy_toggle' => [
+        'name' => 'privacy_toggle',
+        'class' => 'search-field__span-2',
+        'template' => 'CRM/Contact/Form/Search/Criteria/Fields/privacy_toggle.tpl',
+      ],
+      'preferred_communication_method' => [
+        'name' => 'preferred_communication_method',
+        'template' => 'CRM/Contact/Form/Search/Criteria/Fields/preferred_communication_method.tpl',
+      ],
+      'contact_source' => [
+        'name' => 'contact_source',
+        'help' => ['id' => 'id-source', 'file' => 'CRM/Contact/Form/Contact'],
+      ],
+      'job_title' => ['name' => 'job_title'],
+      'preferred_language' => ['name' => 'preferred_language'],
+      'contact_id' => [
+        'name' => 'contact_id',
+        'help' => ['id' => 'id-contact-id', 'file' => 'CRM/Contact/Form/Contact'],
+      ],
+      'external_identifier' => [
+        'name' => 'external_identifier',
+        'help' => ['id' => 'id-external-id', 'file' => 'CRM/Contact/Form/Contact'],
+      ],
+      'uf_user' => [
+        'name' => 'uf_user',
+        'description' => ts('Does the contact have a %1 Account?', [$userFramework]),
+      ],
+    ]);
   }
 
 

--- a/css/searchForm.css
+++ b/css/searchForm.css
@@ -62,3 +62,32 @@
   color: #41477E;
   font-weight: bold;
 }
+
+.advanced-search-fields {
+  display: grid;
+  grid-template-columns: [col] repeat(3, calc(100% / 3 - 10px));
+  width: 100%;
+}
+
+.advanced-search-fields .search-field {
+  padding: 5px;
+}
+
+.advanced-search-fields .search-field__span-2 {
+  grid-column: col / span 2;
+}
+.advanced-search-fields .search-field__span-3 {
+  grid-column: col / span 3;
+}
+
+.advanced-search-fields .search-field__checkbox {
+  display: flex;
+}
+
+.advanced-search-fields .search-field__checkbox input[type="checkbox"] {
+  order: -1;
+}
+
+.advanced-search-fields .search-field__checkbox label {
+  padding-right: 5px;
+}

--- a/templates/CRM/Contact/Form/Search/Criteria/Basic.tpl
+++ b/templates/CRM/Contact/Form/Search/Criteria/Basic.tpl
@@ -23,170 +23,31 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-<table class="form-layout">
-  <tr>
-    <td><label>{ts}Complete OR Partial Name{/ts}</label><br />
-      {$form.sort_name.html}
-    </td>
-    <td>
-      <label>{ts}Complete OR Partial Email{/ts}</label><br />
-      {$form.email.html}
-    </td>
-    {if $form.contact_type}
-      <td><label>{ts}Contact Type(s){/ts}</label><br />
-        {$form.contact_type.html}
-      </td>
-    {else}
-      <td>&nbsp;</td>
-    {/if}
-  </tr>
-  <tr>
-  {if $form.group}
-    <td>
-      <div id='groupselect'><label>{ts}Group(s){/ts} <span class="description">(<a href="#" id='searchbygrouptype'>{ts}search by group type{/ts}</a>)</span></label>
-        <br />
-        {$form.group.html}
-    </div>
-    <div id='grouptypeselect'>
-      <label>{ts}Group Type(s){/ts} <span class="description"> (<a href="#" id='searchbygroup'>{ts}search by group{/ts}</a>)</span></label>
-      <br />
-      {$form.group_type.html}
-        {literal}
-        <script type="text/javascript">
-        CRM.$(function($) {
-          function showGroupSearch() {
-            $('#grouptypeselect').hide();
-            $('#groupselect').show();
-            $('#group_type').select2('val', '');
-            return false;
-          }
-          function showGroupTypeSearch() {
-            $('#groupselect').hide();
-            $('#grouptypeselect').show();
-            $('#group').select2('val', '');
-            return false;
-          }
-          $('#searchbygrouptype').click(showGroupTypeSearch);
-          $('#searchbygroup').click(showGroupSearch);
-
-          if ($('#group_type').val() ) {
-            showGroupTypeSearch();
-          }
-          else {
-            showGroupSearch();
-          }
-
-        });
-        </script>
-        {/literal}
-    </div>
-    </td>
-  {else}
-    <td>&nbsp;</td>
-  {/if}
-    {if $form.contact_tags}
-      <td><label>{ts}Select Tag(s){/ts}</label>
-        {$form.contact_tags.html}
-      </td>
-    {else}
-      <td>&nbsp;</td>
-    {/if}
-    {if $isTagset}
-      <td colspan="2">{include file="CRM/common/Tagset.tpl"}</td>
-    {/if}
-    <td>{$form.tag_search.label}  {help id="id-all-tags"}<br />{$form.tag_search.html}</td>
-    {if ! $isTagset}
-      <td colspan="2">&nbsp;</td>
-    {/if}
-    <td>&nbsp;</td>
-  </tr>
-  {if $form.all_tag_types}
-    <tr>
-      <td colspan="5">
-          {$form.all_tag_types.html} {$form.all_tag_types.label} {help id="id-all-tag-types"}
-      </td>
-    </tr>
-  {/if}
-  <tr>
-    <td>
-      <div>
-        {$form.phone_numeric.label}<br />{$form.phone_numeric.html}
+<div class="advanced-search-fields basic-fields form-layout">
+  {foreach from=$basicSearchFields item=fieldSpec}
+    {assign var=field value=$form[$fieldSpec.name]}
+    {if $field}
+      <div class="search-field {$fieldSpec.class|escape}">
+        {if $fieldSpec.template}
+          {include file=$fieldSpec.template}
+        {else}
+          {$field.label}
+          {if $fieldSpec.help}
+            {assign var=help value=$fieldSpec.help}
+            {capture assign=helpFile}{if $fieldSpec.help}{$fieldSpec.help}{else}''{/if}{/capture}
+            {help id=$help.id file=$help.file}
+          {/if}
+          <br />
+          {$field.html}
+          {if $fieldSpec.description}
+            <div class="description font-italic">
+              {$fieldSpec.description}
+            </div>
+          {/if}
+        {/if}
       </div>
-      <div class="description font-italic">
-        {ts}Punctuation and spaces are ignored.{/ts}
-      </div>
-    </td>
-    <td>{$form.phone_location_type_id.label}<br />{$form.phone_location_type_id.html}</td>
-    <td>{$form.phone_phone_type_id.label}<br />{$form.phone_phone_type_id.html}</td>
-  </tr>
-  <tr>
-    <td colspan="2">
-      <table class="form-layout-compressed">
-      <tr>
-        <td colspan="2">
-            {$form.privacy_toggle.html} {help id="id-privacy"}
-        </td>
-      </tr>
-      <tr>
-        <td>
-            {$form.privacy_options.html}
-        </td>
-        <td style="vertical-align:middle">
-            <div id="privacy-operator-wrapper">{$form.privacy_operator.html} {help id="privacy-operator"}</div>
-        </td>
-      </tr>
-      </table>
-      {literal}
-        <script type="text/javascript">
-          cj("select#privacy_options").change(function() {
-            if (cj(this).val() && cj(this).val().length > 1) {
-              cj('#privacy-operator-wrapper').show();
-            } else {
-              cj('#privacy-operator-wrapper').hide();
-            }
-          }).change();
-        </script>
-      {/literal}
-    </td>
-    <td colspan="3">
-      {$form.preferred_communication_method.label}<br />
-      {$form.preferred_communication_method.html}<br />
-      <div class="spacer"></div>
-      {$form.email_on_hold.html} {$form.email_on_hold.label}
-    </td>
-  </tr>
-  <tr>
-    <td>
-      {$form.contact_source.label} {help id="id-source" file="CRM/Contact/Form/Contact"}<br />
-      {$form.contact_source.html}
-    </td>
-    <td>
-      {$form.job_title.label}<br />
-      {$form.job_title.html}
-    </td>
-    <td colspan="3">
-      {$form.preferred_language.label}<br />
-      {$form.preferred_language.html}
-    </td>
-  </tr>
-  <tr>
-    <td>
-       {$form.contact_id.label} {help id="id-internal-id" file="CRM/Contact/Form/Contact"}<br />
-       {$form.contact_id.html}
-    </td>
-    <td>
-       {$form.external_identifier.label} {help id="id-external-id" file="CRM/Contact/Form/Contact"}<br />
-       {$form.external_identifier.html}
-    </td>
-    <td>
-      {if $form.uf_user}
-        {$form.uf_user.label} {$form.uf_user.html}
-        <div class="description font-italic">
-          {ts 1=$config->userFramework}Does the contact have a %1 Account?{/ts}
-        </div>
-      {else}
-        &nbsp;
-      {/if}
-    </td>
-  </tr>
-</table>
+    {elseif $fieldSpec.is_custom}
+      {include file=$fieldSpec.template}
+    {/if}
+  {/foreach}
+</div>

--- a/templates/CRM/Contact/Form/Search/Criteria/Fields/group.tpl
+++ b/templates/CRM/Contact/Form/Search/Criteria/Fields/group.tpl
@@ -1,0 +1,49 @@
+<div id='groupselect'>
+  <label>{ts}Group(s){/ts}
+    <span class="description">
+      (<a href="#" id='searchbygrouptype'>{ts}search by group type{/ts}</a>)
+    </span>
+  </label>
+  <br/>
+  {$form.group.html}
+</div>
+<div id='grouptypeselect'>
+  <label>
+    {ts}Group Type(s){/ts}
+    <span class="description">
+      (<a href="#" id='searchbygroup'>{ts}search by group{/ts}</a>)
+    </span>
+  </label>
+  <br/>
+  {$form.group_type.html}
+  {literal}
+    <script type="text/javascript">
+      CRM.$(function ($) {
+        function showGroupSearch() {
+          $('#grouptypeselect').hide();
+          $('#groupselect').show();
+          $('#group_type').select2('val', '');
+          return false;
+        }
+
+        function showGroupTypeSearch() {
+          $('#groupselect').hide();
+          $('#grouptypeselect').show();
+          $('#group').select2('val', '');
+          return false;
+        }
+
+        $('#searchbygrouptype').click(showGroupTypeSearch);
+        $('#searchbygroup').click(showGroupSearch);
+
+        if ($('#group_type').val()) {
+          showGroupTypeSearch();
+        }
+        else {
+          showGroupSearch();
+        }
+
+      });
+    </script>
+  {/literal}
+</div>

--- a/templates/CRM/Contact/Form/Search/Criteria/Fields/preferred_communication_method.tpl
+++ b/templates/CRM/Contact/Form/Search/Criteria/Fields/preferred_communication_method.tpl
@@ -1,0 +1,10 @@
+{$form.preferred_communication_method.label}
+<br/>
+{$form.preferred_communication_method.html}
+<br/>
+
+{if $form.email_on_hold}
+  <div class="spacer"></div>
+  {$form.email_on_hold.html}
+  {$form.email_on_hold.label}
+{/if}

--- a/templates/CRM/Contact/Form/Search/Criteria/Fields/privacy_toggle.tpl
+++ b/templates/CRM/Contact/Form/Search/Criteria/Fields/privacy_toggle.tpl
@@ -1,0 +1,28 @@
+<table class="form-layout-compressed">
+  <tr>
+    <td colspan="2">
+      {$form.privacy_toggle.html} {help id="id-privacy"}
+    </td>
+  </tr>
+  <tr>
+    <td>
+      {$form.privacy_options.html}
+    </td>
+    <td style="vertical-align:middle">
+      <div id="privacy-operator-wrapper">
+        {$form.privacy_operator.html} {help id="privacy-operator"}
+      </div>
+    </td>
+  </tr>
+</table>
+{literal}
+  <script type="text/javascript">
+    cj("select#privacy_options").change(function () {
+      if (cj(this).val() && cj(this).val().length > 1) {
+        cj('#privacy-operator-wrapper').show();
+      } else {
+        cj('#privacy-operator-wrapper').hide();
+      }
+    }).change();
+  </script>
+{/literal}

--- a/templates/CRM/Contact/Form/Search/Criteria/Fields/tag_set.tpl
+++ b/templates/CRM/Contact/Form/Search/Criteria/Fields/tag_set.tpl
@@ -1,0 +1,5 @@
+{if $isTagset}
+  <div class="search-field search-field__span-2">
+    {include file="CRM/common/Tagset.tpl"}
+  </div>
+{/if}


### PR DESCRIPTION
Overview
----------------------------------------

The contact search form uses the template `templates/CRM/Contact/Form/Search/Criteria/Basic.tpl`. In the template there are already some conditionals to hide certain fields, such as

```
{if $form.group}
  <td>
  ...
{/if}
```

However only some fields are covered. For an extension developer who wants to hide more fields here it is difficult without causing warnings or breaking the layout.

To make it easier conditionals should be applied to each form element.

Before
----------------------------------------

Form conditionals were only available for some form elements in the `templates/CRM/Contact/Form/Search/Criteria/Basic.tpl` template

##### What it looked like before:

![before](https://user-images.githubusercontent.com/6374064/39587762-30706eca-4ef2-11e8-8169-dd8e952e52ef.png)

After
----------------------------------------

Form conditionals are available for all form elements in the `templates/CRM/Contact/Form/Search/Criteria/Basic.tpl` template

##### What it looked like after (with no fields changed, should be the same as "Before")

![after_with_all_options](https://user-images.githubusercontent.com/6374064/39587800-4b3d4ea8-4ef2-11e8-9d2f-a9561364adc3.png)

##### What it looked like after with the following fields removed

- email
- job_title
- external_identifier
- privacy_toggle
- email_on_hold
- preferred_communication_method

![after_without_fields](https://user-images.githubusercontent.com/6374064/39587823-5fa77918-4ef2-11e8-949d-685aed382dfb.png)

Notes
----------------------------------------

I reformatted the code a bit, fixing warnings from the IDE. I also changed some existing conditionals to not output anything if the element wasn't set. As it was before they would still show an empty `td` element leading to gaps in the form like:

![conditional_tds](https://user-images.githubusercontent.com/6374064/39587900-8b2b4934-4ef2-11e8-9ac2-29cb23d4ca15.png)

Without these empty `td` elements the gaps are filled:

![conditional_elements](https://user-images.githubusercontent.com/6374064/39587931-965b9f3e-4ef2-11e8-93b4-736c07675015.png)

Gitlab Issue
---
https://lab.civicrm.org/dev/core/issues/101
