### PR TITLE
Fix (unreleased) regression on report pager

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -2962,6 +2962,9 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
       CRM_Core_DAO::disableFullGroupByMode();
     }
     $dao = CRM_Core_DAO::executeQuery($sql);
+    if (stristr($this->_select, 'SQL_CALC_FOUND_ROWS')) {
+      $this->_rowsFound = CRM_Core_DAO::singleValueQuery('SELECT FOUND_ROWS()');
+    }
     CRM_Core_DAO::reenableFullGroupByMode();
     if (!is_array($rows)) {
       $rows = array();


### PR DESCRIPTION
Overview
----------------------------------------
5.2 rc exhibits a regression whereby reports are missing their pages - this fixes.

Before
----------------------------------------
![screenshot 2018-05-04 16 47 33](https://user-images.githubusercontent.com/336308/39613375-e49ea8b2-4fba-11e8-93b2-0ed4f74b896a.png)


After
----------------------------------------
![screenshot 2018-05-04 16 26 39](https://user-images.githubusercontent.com/336308/39613350-9896bb30-4fba-11e8-83fa-2c1fcb505fab.png)


Technical Details
----------------------------------------
We recently added a patch to disable full group by before some queries that were not
compliant with that standard. That patch broke the report pager because later code relied on the
last issued query ALWAYS being the one that determined how many rows are retrived by the main query,
however, we were doing a query to check sql mode after the main query.

I could make a case for storing sql mode data somewhere sensible at the start of the session.
However, I think this fix is the right fix for the bug as it calculates the rows retrieved
/ retrievable immediately after the retrieval query, rather than 'at some later date when
we hope no other queries have run'. If is in the same function as the enableFullGroupBy so
only reports that ALSO run that will hit the line (ie. not reports that override buildRows)

Comments
----------------------------------------
@seamuslee001 @monishdeb I checked other places in the code (including the unmerged #12070 and I don't believe any others are affected - using that query to retrieve calc rows is uncommon in our code base  & I see no other intersection between the places we do that & the places we check if group by is enabled)