### PR TITLE
(dev/core/98) Searching by any Address fields with location type other than primary throw DB error

### DIFF
--- a/tests/phpunit/CRM/Contact/SelectorTest.php
+++ b/tests/phpunit/CRM/Contact/SelectorTest.php
@@ -72,9 +72,12 @@ class CRM_Contact_Form_SelectorTest extends CiviUnitTestCase {
     }
     // Ensure that search builder return individual contact as per criteria
     if (!empty($dataSet['context'] == 'builder')) {
-      $contactID = $this->individualCreate();
+      $contactID = $this->individualCreate(['first_name' => 'James', 'last_name' => 'Bond']);
       $rows = $selector->getRows(CRM_Core_Action::VIEW, 0, 50, '');
       $this->assertEquals(1, count($rows));
+      $sortChar = $selector->alphabetQuery()->fetchAll();
+      // sort name is stored in '<last_name>, <first_name>' format, as per which the first character would be B of Bond
+      $this->assertEquals('B', $sortChar[0]['sort_name']);
       $this->assertEquals($contactID, key($rows));
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate:
1. Go to `Search Builder`
2. Choose Contact >> Street Address (or any address field) >> Home (as location type) >> NOT EMPTY (or any other operator)
3. Submit
See the result under BEFORE

Before
----------------------------------------
![test-multiple-before](https://user-images.githubusercontent.com/3735621/39561924-70752730-4ec6-11e8-8886-a40f6f99d03f.gif)


After
----------------------------------------
![test-multiple-after](https://user-images.githubusercontent.com/3735621/39561996-c76e4c42-4ec6-11e8-8ea3-2670ff8fe6b3.gif)


Technical Details
----------------------------------------
I would say this is a regression due to this change https://github.com/civicrm/civicrm-core/commit/fbbd2be102a810a5fadb712965806177e2a4bfab#diff-e54381bfdf51e31cab376c71ca0d66ffR4895
The change was earlier made to fix FGB error as per which SELECT columns must have all those column(s) that are present in GROUP BY clause. But in certain case, we only want a predefined set of (formatted) column like in this case ```UPPER(LEFT(contact_a.sort_name, 1)) as sort_name``` irrespective of what's there in GROUP BY, we need to disable FGB to allow such query to pass.


