### PR TITLE
5.1.0 release notes: updated synopsis

### DIFF
--- a/release-notes/5.1.0.md
+++ b/release-notes/5.1.0.md
@@ -13,13 +13,13 @@ Released May 2, 2018
 
 | *Does this version...?*                                         |         |
 |:--------------------------------------------------------------- |:-------:|
-| Fix security vulnerabilities?                                   |         |
-| Change the database schema?                                     |         |
-| Alter the API?                                                  |         |
-| Require attention to configuration options?                     |         |
-| Fix problems installing or upgrading to a previous version?     |         |
-| Introduce features?                                             |         |
-| Fix bugs?                                                       |         |
+| Fix security vulnerabilities?                                   |   no    |
+| Change the database schema?                                     |   no    |
+| Alter the API?                                                  |   no    |
+| Require attention to configuration options?                     |   no    |
+| **Fix problems installing or upgrading to a previous version?** | **yes** |
+| **Introduce features?**                                         | **yes** |
+| **Fix bugs?**                                                   | **yes** |
 
 ## <a name="features"></a>Features
 


### PR DESCRIPTION
Overview
----------------------------------------
I forgot to fill the synopsis when writing the 5.1.0 release notes.

Before
----------------------------------------
The synopsis is empty.

After
----------------------------------------
The synopsis has information on the release.