### PR TITLE
Payflow Pro not payflo

### DIFF
--- a/CRM/Core/Payment/PayflowPro.php
+++ b/CRM/Core/Payment/PayflowPro.php
@@ -637,7 +637,10 @@ class CRM_Core_Payment_PayflowPro extends CRM_Core_Payment {
       $nvpArray[$keyval] = $valval;
       $result = substr($result, $valuepos + 1, strlen($result));
     }
-    // get the result code to validate.
+
+    // @TODO Function is named getRecurringTransactionStatus() which
+    // suggests it returns a result. It sets a $result_code but doesn't return
+    // it, printing output instead?
     $result_code = $nvpArray['RESULT'];
     print_r($responseData);
 

--- a/CRM/Core/Payment/PayflowPro.php
+++ b/CRM/Core/Payment/PayflowPro.php
@@ -57,7 +57,7 @@ class CRM_Core_Payment_PayflowPro extends CRM_Core_Payment {
    */
   public function doDirectPayment(&$params) {
     if (!defined('CURLOPT_SSLCERT')) {
-      CRM_Core_Error::fatal(ts('PayFlowPro requires curl with SSL support'));
+      CRM_Core_Error::fatal(ts('Payflow Pro requires curl with SSL support'));
     }
 
     /*
@@ -504,7 +504,7 @@ class CRM_Core_Payment_PayflowPro extends CRM_Core_Payment {
       }
     }
     if ($responseHeaders['http_code'] != 200) {
-      return self::errorExit(9015, "Error connecting to the payflo API server.");
+      return self::errorExit(9015, "Error connecting to the Payflow Pro API server.");
     }
 
     /*
@@ -575,7 +575,7 @@ class CRM_Core_Payment_PayflowPro extends CRM_Core_Payment {
    */
   public function getRecurringTransactionStatus($recurringProfileID, $processorID) {
     if (!defined('CURLOPT_SSLCERT')) {
-      CRM_Core_Error::fatal(ts('PayFlowPro requires curl with SSL support'));
+      CRM_Core_Error::fatal(ts('Payflow Pro requires curl with SSL support'));
     }
 
     /*

--- a/CRM/Core/Payment/PayflowPro.php
+++ b/CRM/Core/Payment/PayflowPro.php
@@ -1,7 +1,7 @@
 <?php
 /*
    +----------------------------------------------------------------------------+
-   | PayflowPro Core Payment Module for CiviCRM version 5                       |
+   | Payflow Pro Core Payment Module for CiviCRM version 5                      |
    +----------------------------------------------------------------------------+
    | Licensed to CiviCRM under the Academic Free License version 3.0            |
    |                                                                            |
@@ -303,7 +303,7 @@ class CRM_Core_Payment_PayflowPro extends CRM_Core_Payment {
 
         /*******************************************************
          * Success !
-         * This is a successful transaction. PayFlow Pro does return further information
+         * This is a successful transaction. Payflow Pro does return further information
          * about transactions to help you identify fraud including whether they pass
          * the cvv check, the avs check. This is stored in
          * CiviCRM as part of the transact
@@ -344,10 +344,9 @@ class CRM_Core_Payment_PayflowPro extends CRM_Core_Payment {
     return self::errorExit(9014, "Check the code - all transactions should have been headed off before they got here. Something slipped through the net");
   }
 
-  /*
-   * Produces error message and returns from class
-   */
   /**
+   * Produces error message and returns from class
+   *
    * @param null $errorCode
    * @param null $errorMessage
    *
@@ -365,10 +364,9 @@ class CRM_Core_Payment_PayflowPro extends CRM_Core_Payment {
   }
 
 
-  /*
-   * NOTE: 'doTransferCheckout' not implemented
-   */
   /**
+   * NOTE: 'doTransferCheckout' not implemented
+   *
    * @param array $params
    * @param $component
    *
@@ -378,28 +376,14 @@ class CRM_Core_Payment_PayflowPro extends CRM_Core_Payment {
     CRM_Core_Error::fatal(ts('This function is not implemented'));
   }
 
-  /*
+  /**
    * This public function checks to see if we have the right processor config values set
    *
    * NOTE: Called by Events and Contribute to check config params are set prior to trying
    *  register any credit card details
    *
-   * @param string $mode
-   *   The mode we are operating in (live or test) - not used.
-   *
-   * returns string $errorMsg if any errors found - null if OK
-   */
-
-  //  function checkConfig( $mode )          // CiviCRM V1.9 Declaration
-
-  /**
-   * CiviCRM V2.0 Declaration
-   * This function checks to see if we have the right config values
-   *
-   * @internal param string $mode the mode we are operating in (live or test)
-   *
-   * @return string
-   *   the error message if any
+   * @return string|null
+   *   the error message if any, null if OK
    */
   public function checkConfig() {
     $errorMsg = array();
@@ -418,12 +402,10 @@ class CRM_Core_Payment_PayflowPro extends CRM_Core_Payment {
       return NULL;
     }
   }
-  //end check config
 
-  /*
-   * convert to a name/value pair (nvp) string
-   */
   /**
+   * convert to a name/value pair (nvp) string
+   *
    * @param $payflow_query_array
    *
    * @return array|string
@@ -437,22 +419,15 @@ class CRM_Core_Payment_PayflowPro extends CRM_Core_Payment {
     return $payflow_query;
   }
 
-  /*
-   * Submit transaction using CuRL
-   * @submiturl string Url to direct HTTPS GET to
-   * @payflow_query value string to be posted
-   */
   /**
-   * @param $submiturl
-   * @param $payflow_query
+   * Submit transaction using cURL
+   *
+   * @param string $submiturl Url to direct HTTPS GET to
+   * @param $payflow_query value string to be posted
    *
    * @return mixed|object
    */
   public function submit_transaction($submiturl, $payflow_query) {
-    /*
-     * Submit transaction using CuRL
-     */
-
     // get data ready for API
     $user_agent = $_SERVER['HTTP_USER_AGENT'];
     // Here's your custom headers; adjust appropriately for your setup:
@@ -467,7 +442,7 @@ class CRM_Core_Payment_PayflowPro extends CRM_Core_Payment {
     $headers[] = "X-VPS-Timeout: 45";
     //random unique number  - the transaction is retried using this transaction ID
     // in this function but if that doesn't work and it is re- submitted
-    // it is treated as a new attempt. PayflowPro doesn't allow
+    // it is treated as a new attempt. Payflow Pro doesn't allow
     // you to change details (e.g. card no) when you re-submit
     // you can only try the same details
     $headers[] = "X-VPS-Request-ID: " . rand(1, 1000000000);
@@ -591,7 +566,6 @@ class CRM_Core_Payment_PayflowPro extends CRM_Core_Payment {
     curl_close($ch);
     return $responseData;
   }
-  //end submit_transaction
 
   /**
    * @param int $recurringProfileID


### PR DESCRIPTION
Overview
----------------------------------------
Honestly, I just wanted to correct the typing of "payflo" in one error message (because it refers to [a different payment processor](https://www.payflo.com/)). Using the right words / terms :arrow_forward: less confusion for users.

Before
----------------------------------------
Error message refers to "payflo"

After
----------------------------------------
Error message refers to "Payflow Pro", the payment processor in question.

Technical Details
----------------------------------------

* This changes some error messages to the consistent naming (may be implications for translation).
* Also some comment cleanups.
* Also notes that there's a getFoo() function which doesn't seem to return a value, printing instead.

