### PR TITLE
Run master tests using phpunit5

### DIFF
--- a/Civi/Test/CiviTestListener.php
+++ b/Civi/Test/CiviTestListener.php
@@ -176,8 +176,8 @@ class CiviTestListener extends \PHPUnit_Framework_BaseTestListener {
     }
 
     $blurb = "Tip: Run the headless tests and end-to-end tests separately, e.g.\n"
-      . "  $ phpunit4 --group headless\n"
-      . "  $ phpunit4 --group e2e  \n";
+      . "  $ phpunit5 --group headless\n"
+      . "  $ phpunit5 --group e2e  \n";
 
     if (!empty($byInterface['HeadlessInterface']) && CIVICRM_UF !== 'UnitTests') {
       $testNames = implode(', ', array_keys($byInterface['HeadlessInterface']));

--- a/tools/scripts/phpunit
+++ b/tools/scripts/phpunit
@@ -13,8 +13,12 @@
 if (PHP_SAPI !== 'cli') {
   die("phpunit can only be run from command line.");
 }
-
-$phpunit = findCommand('phpunit5');
+if (version_compare(PHP_VERSION, '5.6', '>=')) {
+  $phpunit = findCommand('phpunit5');
+}
+else {
+  $phpunit = findCommand('phpunit4');
+}
 if (!$phpunit) {
   $phpunit = findCommand('phpunit');
 }

--- a/tools/scripts/phpunit
+++ b/tools/scripts/phpunit
@@ -14,7 +14,7 @@ if (PHP_SAPI !== 'cli') {
   die("phpunit can only be run from command line.");
 }
 
-$phpunit = findCommand('phpunit4');
+$phpunit = findCommand('phpunit5');
 if (!$phpunit) {
   $phpunit = findCommand('phpunit');
 }


### PR DESCRIPTION
Overview
----------------------------------------
This would mean we would run the unit tests using phpunit5 not phpunit4 

ping @totten @eileenmcnaughton I have execed into 1604-1 and 1204-5 and downloaded latest civibuild kit for jenkins and run the civi-download-tools but not sure about the other matrix box