### PR TITLE
(NFC) Change use createMock in tests otherwise stick with getMock to fix deprecated warning…

### DIFF
--- a/tests/phpunit/CRM/Core/CommunityMessagesTest.php
+++ b/tests/phpunit/CRM/Core/CommunityMessagesTest.php
@@ -377,7 +377,8 @@ class CRM_Core_CommunityMessagesTest extends CiviUnitTestCase {
    * @return CRM_Utils_HttpClient|PHPUnit_Framework_MockObject_MockObject
    */
   protected function expectNoHttpRequest() {
-    $client = $this->createMock('CRM_Utils_HttpClient');
+    $mockFunction = $this->mockMethod;
+    $client = $this->$mockFunction('CRM_Utils_HttpClient');
     $client->expects($this->never())
       ->method('get');
     return $client;
@@ -391,7 +392,8 @@ class CRM_Core_CommunityMessagesTest extends CiviUnitTestCase {
    * @return CRM_Utils_HttpClient|PHPUnit_Framework_MockObject_MockObject
    */
   protected function expectOneHttpRequest($response) {
-    $client = $this->createMock('CRM_Utils_HttpClient');
+    $mockFunction = $this->mockMethod;
+    $client = $this->$mockFunction('CRM_Utils_HttpClient');
     $client->expects($this->once())
       ->method('get')
       ->will($this->returnValue($response));

--- a/tests/phpunit/CRM/Core/CommunityMessagesTest.php
+++ b/tests/phpunit/CRM/Core/CommunityMessagesTest.php
@@ -377,7 +377,7 @@ class CRM_Core_CommunityMessagesTest extends CiviUnitTestCase {
    * @return CRM_Utils_HttpClient|PHPUnit_Framework_MockObject_MockObject
    */
   protected function expectNoHttpRequest() {
-    $client = $this->getMock('CRM_Utils_HttpClient');
+    $client = $this->createMock('CRM_Utils_HttpClient');
     $client->expects($this->never())
       ->method('get');
     return $client;
@@ -391,7 +391,7 @@ class CRM_Core_CommunityMessagesTest extends CiviUnitTestCase {
    * @return CRM_Utils_HttpClient|PHPUnit_Framework_MockObject_MockObject
    */
   protected function expectOneHttpRequest($response) {
-    $client = $this->getMock('CRM_Utils_HttpClient');
+    $client = $this->createMock('CRM_Utils_HttpClient');
     $client->expects($this->once())
       ->method('get')
       ->will($this->returnValue($response));

--- a/tests/phpunit/CRM/Core/JobManagerTest.php
+++ b/tests/phpunit/CRM/Core/JobManagerTest.php
@@ -36,7 +36,8 @@ class CRM_Core_JobManagerTest extends CiviUnitTestCase {
   }
 
   public function testHookCron() {
-    $hook = $this->createMock('stdClass', array('civicrm_cron'));
+    $mockFunction = $this->mockMethod;
+    $hook = $this->$mockFunction('stdClass', array('civicrm_cron'));
     $hook->expects($this->once())
       ->method('civicrm_cron')
       ->with($this->isInstanceOf('CRM_Core_JobManager'));

--- a/tests/phpunit/CRM/Core/JobManagerTest.php
+++ b/tests/phpunit/CRM/Core/JobManagerTest.php
@@ -36,7 +36,7 @@ class CRM_Core_JobManagerTest extends CiviUnitTestCase {
   }
 
   public function testHookCron() {
-    $hook = $this->getMock('stdClass', array('civicrm_cron'));
+    $hook = $this->createMock('stdClass', array('civicrm_cron'));
     $hook->expects($this->once())
       ->method('civicrm_cron')
       ->with($this->isInstanceOf('CRM_Core_JobManager'));

--- a/tests/phpunit/CRM/Extension/ManagerTest.php
+++ b/tests/phpunit/CRM/Extension/ManagerTest.php
@@ -49,7 +49,8 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
    * @expectedException CRM_Extension_Exception
    */
   public function testInstallInvalidType() {
-    $testingTypeManager = $this->createMock('CRM_Extension_Manager_Interface');
+    $mockFunction = $this->mockMethod;
+    $testingTypeManager = $this->$mockFunction('CRM_Extension_Manager_Interface');
     $testingTypeManager->expects($this->never())
       ->method('onPreInstall');
     $manager = $this->_createManager(array(
@@ -66,7 +67,8 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
    * "the first row" or "all rows".
    */
   public function testInstall_Disable_Uninstall() {
-    $testingTypeManager = $this->createMock('CRM_Extension_Manager_Interface');
+    $mockFunction = $this->mockMethod;
+    $testingTypeManager = $this->$mockFunction('CRM_Extension_Manager_Interface');
     $manager = $this->_createManager(array(
       self::TESTING_TYPE => $testingTypeManager,
     ));
@@ -110,7 +112,8 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
    * @throws \CRM_Extension_Exception
    */
   public function test_InstallAuto_DisableDownstream_UninstallDownstream() {
-    $testingTypeManager = $this->createMock('CRM_Extension_Manager_Interface');
+    $mockFunction = $this->mockMethod;
+    $testingTypeManager = $this->$mockFunction('CRM_Extension_Manager_Interface');
     $manager = $this->_createManager(array(
       self::TESTING_TYPE => $testingTypeManager,
     ));
@@ -151,7 +154,8 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
    * @throws \CRM_Extension_Exception
    */
   public function testInstallAuto_Twice() {
-    $testingTypeManager = $this->createMock('CRM_Extension_Manager_Interface');
+    $mockFunction = $this->mockMethod;
+    $testingTypeManager = $this->$mockFunction('CRM_Extension_Manager_Interface');
     $manager = $this->_createManager(array(
       self::TESTING_TYPE => $testingTypeManager,
     ));
@@ -180,7 +184,8 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
   }
 
   public function test_InstallAuto_DisableUpstream() {
-    $testingTypeManager = $this->createMock('CRM_Extension_Manager_Interface');
+    $mockFunction = $this->mockMethod;
+    $testingTypeManager = $this->$mockFunction('CRM_Extension_Manager_Interface');
     $manager = $this->_createManager(array(
       self::TESTING_TYPE => $testingTypeManager,
     ));
@@ -223,7 +228,8 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
    * Subseuently disable and uninstall.
    */
   public function testInstall_DirtyRemove_Disable_Uninstall() {
-    $testingTypeManager = $this->createMock('CRM_Extension_Manager_Interface');
+    $mockFunction = $this->mockMethod;
+    $testingTypeManager = $this->$mockFunction('CRM_Extension_Manager_Interface');
     $manager = $this->_createManager(array(
       self::TESTING_TYPE => $testingTypeManager,
     ));
@@ -261,7 +267,8 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
    * Install an extension with a valid type name.
    */
   public function testInstall_Disable_Enable() {
-    $testingTypeManager = $this->createMock('CRM_Extension_Manager_Interface');
+    $mockFunction = $this->mockMethod;
+    $testingTypeManager = $this->$mockFunction('CRM_Extension_Manager_Interface');
     $manager = $this->_createManager(array(
       self::TESTING_TYPE => $testingTypeManager,
     ));
@@ -303,7 +310,8 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
    * Performing 'install' on a 'disabled' extension performs an 'enable'
    */
   public function testInstall_Disable_Install() {
-    $testingTypeManager = $this->createMock('CRM_Extension_Manager_Interface');
+    $mockFunction = $this->mockMethod;
+    $testingTypeManager = $this->$mockFunction('CRM_Extension_Manager_Interface');
     $manager = $this->_createManager(array(
       self::TESTING_TYPE => $testingTypeManager,
     ));
@@ -341,7 +349,8 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
    * Install an extension with a valid type name.
    */
   public function testEnableBare() {
-    $testingTypeManager = $this->createMock('CRM_Extension_Manager_Interface');
+    $mockFunction = $this->mockMethod;
+    $testingTypeManager = $this->$mockFunction('CRM_Extension_Manager_Interface');
     $manager = $this->_createManager(array(
       self::TESTING_TYPE => $testingTypeManager,
     ));
@@ -367,7 +376,8 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
    * Get the status of an unknown extension.
    */
   public function testStatusUnknownKey() {
-    $testingTypeManager = $this->createMock('CRM_Extension_Manager_Interface');
+    $mockFunction = $this->mockMethod;
+    $testingTypeManager = $this->$mockFunction('CRM_Extension_Manager_Interface');
     $testingTypeManager->expects($this->never())
       ->method('onPreInstall');
     $manager = $this->_createManager(array(
@@ -380,7 +390,8 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
    * Replace code for an extension that doesn't exist in the container
    */
   public function testReplace_Unknown() {
-    $testingTypeManager = $this->createMock('CRM_Extension_Manager_Interface');
+    $mockFunction = $this->mockMethod;
+    $testingTypeManager = $this->$mockFunction('CRM_Extension_Manager_Interface');
     $manager = $this->_createManager(array(
       self::TESTING_TYPE => $testingTypeManager,
     ));
@@ -406,7 +417,8 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
    * Replace code for an extension that doesn't exist in the container
    */
   public function testReplace_Uninstalled() {
-    $testingTypeManager = $this->createMock('CRM_Extension_Manager_Interface');
+    $mockFunction = $this->mockMethod;
+    $testingTypeManager = $this->$mockFunction('CRM_Extension_Manager_Interface');
     $manager = $this->_createManager(array(
       self::TESTING_TYPE => $testingTypeManager,
     ));
@@ -437,7 +449,8 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
    * file="oddball", and the upgrade has file="newextension".
    */
   public function testReplace_Installed() {
-    $testingTypeManager = $this->createMock('CRM_Extension_Manager_Interface');
+    $mockFunction = $this->mockMethod;
+    $testingTypeManager = $this->$mockFunction('CRM_Extension_Manager_Interface');
     $manager = $this->_createManager(array(
       self::TESTING_TYPE => $testingTypeManager,
     ));
@@ -474,7 +487,8 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
    * file="oddball", and the upgrade has file="newextension".
    */
   public function testReplace_InstalledMissing() {
-    $testingTypeManager = $this->createMock('CRM_Extension_Manager_Interface');
+    $mockFunction = $this->mockMethod;
+    $testingTypeManager = $this->$mockFunction('CRM_Extension_Manager_Interface');
     $manager = $this->_createManager(array(
       self::TESTING_TYPE => $testingTypeManager,
     ));

--- a/tests/phpunit/CRM/Extension/ManagerTest.php
+++ b/tests/phpunit/CRM/Extension/ManagerTest.php
@@ -49,7 +49,7 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
    * @expectedException CRM_Extension_Exception
    */
   public function testInstallInvalidType() {
-    $testingTypeManager = $this->getMock('CRM_Extension_Manager_Interface');
+    $testingTypeManager = $this->createMock('CRM_Extension_Manager_Interface');
     $testingTypeManager->expects($this->never())
       ->method('onPreInstall');
     $manager = $this->_createManager(array(
@@ -66,7 +66,7 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
    * "the first row" or "all rows".
    */
   public function testInstall_Disable_Uninstall() {
-    $testingTypeManager = $this->getMock('CRM_Extension_Manager_Interface');
+    $testingTypeManager = $this->createMock('CRM_Extension_Manager_Interface');
     $manager = $this->_createManager(array(
       self::TESTING_TYPE => $testingTypeManager,
     ));
@@ -110,7 +110,7 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
    * @throws \CRM_Extension_Exception
    */
   public function test_InstallAuto_DisableDownstream_UninstallDownstream() {
-    $testingTypeManager = $this->getMock('CRM_Extension_Manager_Interface');
+    $testingTypeManager = $this->createMock('CRM_Extension_Manager_Interface');
     $manager = $this->_createManager(array(
       self::TESTING_TYPE => $testingTypeManager,
     ));
@@ -151,7 +151,7 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
    * @throws \CRM_Extension_Exception
    */
   public function testInstallAuto_Twice() {
-    $testingTypeManager = $this->getMock('CRM_Extension_Manager_Interface');
+    $testingTypeManager = $this->createMock('CRM_Extension_Manager_Interface');
     $manager = $this->_createManager(array(
       self::TESTING_TYPE => $testingTypeManager,
     ));
@@ -180,7 +180,7 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
   }
 
   public function test_InstallAuto_DisableUpstream() {
-    $testingTypeManager = $this->getMock('CRM_Extension_Manager_Interface');
+    $testingTypeManager = $this->createMock('CRM_Extension_Manager_Interface');
     $manager = $this->_createManager(array(
       self::TESTING_TYPE => $testingTypeManager,
     ));
@@ -223,7 +223,7 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
    * Subseuently disable and uninstall.
    */
   public function testInstall_DirtyRemove_Disable_Uninstall() {
-    $testingTypeManager = $this->getMock('CRM_Extension_Manager_Interface');
+    $testingTypeManager = $this->createMock('CRM_Extension_Manager_Interface');
     $manager = $this->_createManager(array(
       self::TESTING_TYPE => $testingTypeManager,
     ));
@@ -261,7 +261,7 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
    * Install an extension with a valid type name.
    */
   public function testInstall_Disable_Enable() {
-    $testingTypeManager = $this->getMock('CRM_Extension_Manager_Interface');
+    $testingTypeManager = $this->createMock('CRM_Extension_Manager_Interface');
     $manager = $this->_createManager(array(
       self::TESTING_TYPE => $testingTypeManager,
     ));
@@ -303,7 +303,7 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
    * Performing 'install' on a 'disabled' extension performs an 'enable'
    */
   public function testInstall_Disable_Install() {
-    $testingTypeManager = $this->getMock('CRM_Extension_Manager_Interface');
+    $testingTypeManager = $this->createMock('CRM_Extension_Manager_Interface');
     $manager = $this->_createManager(array(
       self::TESTING_TYPE => $testingTypeManager,
     ));
@@ -341,7 +341,7 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
    * Install an extension with a valid type name.
    */
   public function testEnableBare() {
-    $testingTypeManager = $this->getMock('CRM_Extension_Manager_Interface');
+    $testingTypeManager = $this->createMock('CRM_Extension_Manager_Interface');
     $manager = $this->_createManager(array(
       self::TESTING_TYPE => $testingTypeManager,
     ));
@@ -367,7 +367,7 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
    * Get the status of an unknown extension.
    */
   public function testStatusUnknownKey() {
-    $testingTypeManager = $this->getMock('CRM_Extension_Manager_Interface');
+    $testingTypeManager = $this->createMock('CRM_Extension_Manager_Interface');
     $testingTypeManager->expects($this->never())
       ->method('onPreInstall');
     $manager = $this->_createManager(array(
@@ -380,7 +380,7 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
    * Replace code for an extension that doesn't exist in the container
    */
   public function testReplace_Unknown() {
-    $testingTypeManager = $this->getMock('CRM_Extension_Manager_Interface');
+    $testingTypeManager = $this->createMock('CRM_Extension_Manager_Interface');
     $manager = $this->_createManager(array(
       self::TESTING_TYPE => $testingTypeManager,
     ));
@@ -406,7 +406,7 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
    * Replace code for an extension that doesn't exist in the container
    */
   public function testReplace_Uninstalled() {
-    $testingTypeManager = $this->getMock('CRM_Extension_Manager_Interface');
+    $testingTypeManager = $this->createMock('CRM_Extension_Manager_Interface');
     $manager = $this->_createManager(array(
       self::TESTING_TYPE => $testingTypeManager,
     ));
@@ -437,7 +437,7 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
    * file="oddball", and the upgrade has file="newextension".
    */
   public function testReplace_Installed() {
-    $testingTypeManager = $this->getMock('CRM_Extension_Manager_Interface');
+    $testingTypeManager = $this->createMock('CRM_Extension_Manager_Interface');
     $manager = $this->_createManager(array(
       self::TESTING_TYPE => $testingTypeManager,
     ));
@@ -474,7 +474,7 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
    * file="oddball", and the upgrade has file="newextension".
    */
   public function testReplace_InstalledMissing() {
-    $testingTypeManager = $this->getMock('CRM_Extension_Manager_Interface');
+    $testingTypeManager = $this->createMock('CRM_Extension_Manager_Interface');
     $manager = $this->_createManager(array(
       self::TESTING_TYPE => $testingTypeManager,
     ));

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -140,6 +140,13 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
   public $setupIDs = array();
 
   /**
+   * PHPUnit Mock Mecthod to use.
+   *
+   * @var string
+   */
+  public $mockMethod = 'getMock';
+
+  /**
    *  Constructor.
    *
    *  Because we are overriding the parent class constructor, we
@@ -167,6 +174,9 @@ class CiviUnitTestCase extends PHPUnit_Extensions_Database_TestCase {
     if (function_exists('_civix_phpunit_setUp')) {
       // FIXME: loosen coupling
       _civix_phpunit_setUp();
+    }
+    if (version_compare(PHPUnit_Runner_Version::id(), '5', '>=')) {
+      $this->mockMethod = 'createMock';
     }
   }
 

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -2036,7 +2036,8 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     $this->assertTrue(is_numeric($ufMatch->id));
 
     // setup - mock the calls to CRM_Utils_System_*::getUfId
-    $userSystem = $this->createMock('CRM_Utils_System_UnitTests', array('getUfId'));
+    $mockFunction = $this->mockMethod;
+    $userSystem = $this->$mockFunction('CRM_Utils_System_UnitTests', array('getUfId'));
     $userSystem->expects($this->once())
       ->method('getUfId')
       ->with($this->equalTo('exampleUser'))
@@ -2111,7 +2112,8 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    */
   public function testContactGetByUnknownUsername() {
     // setup - mock the calls to CRM_Utils_System_*::getUfId
-    $userSystem = $this->createMock('CRM_Utils_System_UnitTests', array('getUfId'));
+    $mockFunction = $this->mockMethod;
+    $userSystem = $this->$mockFunction('CRM_Utils_System_UnitTests', array('getUfId'));
     $userSystem->expects($this->once())
       ->method('getUfId')
       ->with($this->equalTo('exampleUser'))

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -2036,7 +2036,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     $this->assertTrue(is_numeric($ufMatch->id));
 
     // setup - mock the calls to CRM_Utils_System_*::getUfId
-    $userSystem = $this->getMock('CRM_Utils_System_UnitTests', array('getUfId'));
+    $userSystem = $this->createMock('CRM_Utils_System_UnitTests', array('getUfId'));
     $userSystem->expects($this->once())
       ->method('getUfId')
       ->with($this->equalTo('exampleUser'))
@@ -2111,7 +2111,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    */
   public function testContactGetByUnknownUsername() {
     // setup - mock the calls to CRM_Utils_System_*::getUfId
-    $userSystem = $this->getMock('CRM_Utils_System_UnitTests', array('getUfId'));
+    $userSystem = $this->createMock('CRM_Utils_System_UnitTests', array('getUfId'));
     $userSystem->expects($this->once())
       ->method('getUfId')
       ->with($this->equalTo('exampleUser'))


### PR DESCRIPTION
… on getMock in phpunit5

Overview
----------------------------------------
In phpunit5 it reports a warning on the fact getMock is deprecated and should be replaced, this replaces it with createMock and in local testing hasn't shown any issues

Before
----------------------------------------
Deprecated warning shows running phpunit5 

After
----------------------------------------
No warning and tests pass

ping @eileenmcnaughton @totten 