### PR TITLE
dev/financial#14 Fix enotices & inability to cancel recurring on paypal express

### DIFF
--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -412,7 +412,6 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
    */
   public function createRecurringPayments(&$params) {
     $args = array();
-    // @todo this function is riddled with enotices - perhaps use $this->mapPaypalParamsToCivicrmParams($fieldMap, $result)
     $this->initialize($args, 'CreateRecurringPaymentsProfile');
 
     $start_time = strtotime(date('m/d/Y'));
@@ -424,15 +423,12 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
     $args['currencyCode'] = $params['currencyID'];
     $args['payerID'] = $params['payer_id'];
     $args['invnum'] = $params['invoiceID'];
-    $args['returnURL'] = $params['returnURL'];
-    $args['cancelURL'] = $params['cancelURL'];
     $args['profilestartdate'] = $start_date;
     $args['method'] = 'CreateRecurringPaymentsProfile';
     $args['billingfrequency'] = $params['frequency_interval'];
     $args['billingperiod'] = ucwords($params['frequency_unit']);
     $args['desc'] = $params['amount'] . " Per " . $params['frequency_interval'] . " " . $params['frequency_unit'];
-    //$args['desc']           = 'Recurring Contribution';
-    $args['totalbillingcycles'] = $params['installments'];
+    $args['totalbillingcycles'] = CRM_Utils_Array::value('installments', $params);
     $args['version'] = '56.0';
     $args['profilereference'] = "i={$params['invoiceID']}" .
       "&m=" .
@@ -450,16 +446,19 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
       return $result;
     }
 
-    /* Success */
-    $params['trxn_id'] = $result['transactionid'];
-    $params['gross_amount'] = $result['amt'];
-    $params['fee_amount'] = $result['feeamt'];
-    $params['net_amount'] = $result['settleamt'];
-    if ($params['net_amount'] == 0 && $params['fee_amount'] != 0) {
-      $params['net_amount'] = number_format(($params['gross_amount'] - $params['fee_amount']), 2);
-    }
-    $params['payment_status'] = $result['paymentstatus'];
-    $params['pending_reason'] = $result['pendingreason'];
+    /* Success - result looks like"
+     * array (
+     * 'profileid' => 'I-CP1U0PLG91R2',
+     * 'profilestatus' => 'ActiveProfile',
+     * 'timestamp' => '2018-05-07T03:55:52Z',
+     * 'correlationid' => 'e717999e9bf62',
+     * 'ack' => 'Success',
+     * 'version' => '56.0',
+     * 'build' => '39949200',)
+    */
+
+    $params['trxn_id'] = $result['profileid'];
+    $params['payment_status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Pending');
 
     return $params;
   }

--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -455,8 +455,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
      * 'ack' => 'Success',
      * 'version' => '56.0',
      * 'build' => '39949200',)
-    */
-
+     */
     $params['trxn_id'] = $result['profileid'];
     $params['payment_status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Pending');
 

--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -721,7 +721,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
    * @throws \Civi\Payment\Exception\PaymentProcessorException
    */
   public function cancelSubscription(&$message = '', $params = array()) {
-    if ($this->isPayPalType($this::PAYPAL_PRO)) {
+    if ($this->isPayPalType($this::PAYPAL_PRO) || $this->isPayPalType($this::PAYPAL_EXPRESS)) {
       $args = array();
       $this->initialize($args, 'ManageRecurringPaymentsProfileStatus');
 

--- a/tests/phpunit/CRM/Core/Payment/PayPalProIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/PayPalProIPNTest.php
@@ -285,7 +285,7 @@ class CRM_Core_Payment_PayPalProIPNTest extends CiviUnitTestCase {
       'amount_per_cycle' => '5.00',
       'payer_status' => 'unverified',
       'currency_code' => 'USD',
-      'business' => 'mpa@mainepeoplesalliance.org',
+      'business' => 'mpa@example.com',
       'address_country' => 'UNITED STATES',
       'address_city' => 'Limestone',
       'verify_sign' => 'AXi4DULbes8quzIiq2YNsdTJH5ciPPPzG9PcQvkQg4BjfvWi8aY9GgDb',
@@ -297,7 +297,7 @@ class CRM_Core_Payment_PayPalProIPNTest extends CiviUnitTestCase {
       'payment_type' => 'instant',
       'last_name' => 'Morrissette',
       'address_state' => 'ME',
-      'receiver_email' => 'info@civicrm.org',
+      'receiver_email' => 'info@example.com',
       'payment_fee' => '0.41',
       'receiver_id' => 'GTH8P7UQWWTY6',
       'txn_type' => 'recurring_payment',
@@ -369,6 +369,60 @@ class CRM_Core_Payment_PayPalProIPNTest extends CiviUnitTestCase {
    */
   public function getPaypalProRecurSubsequentTransaction() {
     return array_merge($this->getPaypalProRecurTransaction(), array('txn_id' => 'secondone'));
+  }
+
+  /**
+   * Test IPN response update for a paypal express profile creation confirmation.
+   */
+  public function testIPNPaymentExpressRecurSuccess() {
+    $this->setupRecurringPaymentProcessorTransaction(['processor_id' => '']);
+    $paypalIPN = new CRM_Core_Payment_PayPalProIPN($this->getPaypalExpressRecurSubscriptionConfirmation());
+    $paypalIPN->main();
+    $contributionRecur = $this->callAPISuccess('contribution_recur', 'getsingle', array('id' => $this->_contributionRecurID));
+    $this->assertEquals('I-JW77S1PY2032', $contributionRecur['processor_id']);
+  }
+
+  /**
+   * Get response consistent with creating a new profile.
+   *
+   * @return array
+   */
+  public function getPaypalExpressRecurSubscriptionConfirmation() {
+    return [
+      'payment_cycle' => 'Monthly',
+      'txn_type' => 'recurring_payment_profile_created',
+      'last_name' => 'buyer',
+      'next_payment_date' => '03:00:00 May 09, 2018 PDT',
+      'residence_country' => 'GB',
+      'initial_payment_amount' => '0.00',
+      'rp_invoice_id' => 'i=' . $this->_invoiceID
+        . '&m=&c=' . $this->_contributionID
+        . '&r=' . $this->_contributionRecurID
+        . '&b=' . $this->_contactID
+        . '&p=' . $this->_contributionPageID,
+      'currency_code' => 'GBP',
+      'time_created' => '12:39:01 May 09, 2018 PDT',
+      'verify_sign' => 'AUg223oCjn4HgJXKkrICawXQ3fyUA2gAd1.f1IPJ4r.9sln-nWcB-EJG',
+      'period_type' => 'Regular',
+      'payer_status' => 'verified',
+      'test_ipn' => '1',
+      'tax' => '0.00',
+      'payer_email' => 'payer@example.com',
+      'first_name' => 'test',
+      'receiver_email' => 'shop@example.com',
+      'payer_id' => 'BWXXXM8111HDS',
+      'product_type' => 1,
+      'shipping' => '0.00',
+      'amount_per_cycle' => '6.00',
+      'profile_status' => 'Active',
+      'charset' => 'windows-1252',
+      'notify_version' => '3.9',
+      'amount' => '6.00',
+      'outstanding_balance' => '0.00',
+      'recurring_payment_id' => 'I-JW77S1PY2032',
+      'product_name' => '6 Per 1 month',
+      'ipn_track_id' => '6255554274055',
+    ];
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Enotices when doing a recurring contribution using paypal express. Also apply changes to permit cancelling paypal express contributions

Before
----------------------------------------

![](https://lab.civicrm.org/dev/financial/uploads/845953fb6cc9bab874c5dc75498de776/image.png)


After
----------------------------------------
notices fixed

Technical Details
----------------------------------------
For background - Paypal Express was not originally supported for recurring. It kind of snuck
in the back door since it was actually not possible to block in when configuring paypal pro
and people kept adding little fixes since they assumed it was broken rather than deliberately
missing functionality. Somewhere along the line this function was probably copied & extracted
from the main function - but it still contained a bunch of lines not
required for paypal express. I took a look at what data is actually available in this function
and removed reference to unavailable fields.

This is from https://developer.paypal.com/docs/classic/api/merchant/CreateRecurringPaymentsProfile_API_Operation_NVP/ and from testing and from https://lab.civicrm.org/dev/financial/issues/14

I also added the 2 one line changes from the reporter here https://lab.civicrm.org/dev/financial/issues/15 - I couldn't really test this but I could confirm that from a code POV they made sense and were simply removing blocks on Paypal Express.


Comments
----------------------------------------

The one are where I differed from logic from @carbar1103
  is the trxn_id - I retained the profile id which I think is consistent with use for other processsors, but needs testing - which I requested on the gitlab issue

I tested the flow of doing a recurring contribution from a contribution page - which I think is the only relevant flow.

Note that this is more or less a reviewer's commit as all changes were suggested by the reporter in gitlab - there is one minor difference - on the trxn_id - so if the originally reviewer retests & confirms I will merge based on that
