### PR TITLE
CRM-20459: Actively deprecate CRM_Core_OptionGroup::getValue

### DIFF
--- a/CRM/Event/Page/ParticipantListing.php
+++ b/CRM/Event/Page/ParticipantListing.php
@@ -74,13 +74,13 @@ class CRM_Event_Page_ParticipantListing extends CRM_Core_Page {
     $this->preProcess();
 
     // get the class name from the participantListingID
-    $className = CRM_Core_OptionGroup::getValue('participant_listing',
-      $this->_participantListingID,
-      'value',
-      'Integer',
-      'description'
+    $className = CRM_Utils_Array::value($this->_participantListingID,
+      CRM_Core_PseudoConstant::get(
+        'CRM_Event_BAO_Event',
+        'participant_listing_id',
+        ['keyColumn' => 'value', 'labelColumn' => 'description']
+      )
     );
-
     if ($className == 'CRM_Event_Page_ParticipantListing') {
       CRM_Core_Error::fatal(ts("Participant listing code file cannot be '%1'",
         array(1 => $className)

--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -872,10 +872,7 @@ AND    status IN ( 'Scheduled', 'Running', 'Paused' )
     // add an additional check and only process
     // jobs that are approved
     if (CRM_Mailing_Info::workflowEnabled()) {
-      $approveOptionID = CRM_Core_OptionGroup::getValue('mail_approval_status',
-        'Approved',
-        'name'
-      );
+      $approveOptionID = CRM_Core_PseudoConstant::getKey('CRM_Mailing_BAO_Mailing', 'approval_status_id', 'Approved');
       if ($approveOptionID) {
         return " AND m.approval_status_id = $approveOptionID ";
       }

--- a/CRM/Mailing/Form/Approve.php
+++ b/CRM/Mailing/Form/Approve.php
@@ -93,13 +93,10 @@ class CRM_Mailing_Form_Approve extends CRM_Core_Form {
 
     $this->addElement('textarea', 'approval_note', ts('Approve/Reject Note'));
 
-    $mailApprovalStatus = CRM_Core_OptionGroup::values('mail_approval_status');
+    $mailApprovalStatus = CRM_Core_PseudoConstant::get('CRM_Mailing_BAO_Mailing', 'approval_status_id');
 
     // eliminate the none option
-    $noneOptionID = CRM_Core_OptionGroup::getValue('mail_approval_status',
-      'None',
-      'name'
-    );
+    $noneOptionID = CRM_Core_PseudoConstant::getKey('CRM_Mailing_BAO_Mailing', 'approval_status_id', 'None');
     if ($noneOptionID) {
       unset($mailApprovalStatus[$noneOptionID]);
     }
@@ -164,10 +161,7 @@ class CRM_Mailing_Form_Approve extends CRM_Core_Form {
     $params['approval_date'] = date('YmdHis');
 
     // if rejected, then we need to reset the scheduled date and scheduled id
-    $rejectOptionID = CRM_Core_OptionGroup::getValue('mail_approval_status',
-      'Rejected',
-      'name'
-    );
+    $rejectOptionID = CRM_Core_PseudoConstant::getKey('CRM_Mailing_BAO_Mailing', 'approval_status_id', 'Rejected');
     if ($rejectOptionID &&
       $params['approval_status_id'] == $rejectOptionID
     ) {

--- a/CRM/PCP/BAO/PCP.php
+++ b/CRM/PCP/BAO/PCP.php
@@ -477,7 +477,8 @@ WHERE pcp.id = %1 AND cc.contribution_status_id =1 AND cc.is_test = 0";
       return FALSE;
     }
 
-    $pcpStatus = CRM_Core_OptionGroup::values("pcp_status");
+    $pcpStatus = CRM_Core_PseudoConstant::get('CRM_PCP_BAO_PCP', 'status_id');
+    $approvedId = array_search('Approved', $pcpStatus);
 
     $params = array('id' => $pcpId);
     CRM_Core_DAO::commonRetrieve('CRM_PCP_DAO_PCP', $params, $pcpInfo);

--- a/CRM/PCP/Form/Campaign.php
+++ b/CRM/PCP/Form/Campaign.php
@@ -135,7 +135,7 @@ class CRM_PCP_Form_Campaign extends CRM_Core_Form {
     if ($this->_pageId) {
       $params = array('id' => $this->_pageId);
       CRM_Core_DAO::commonRetrieve('CRM_PCP_DAO_PCP', $params, $pcpInfo);
-      $owner_notification_option = CRM_Core_DAO::getFieldValue('CRM_PCP_DAO_PCPBlock', $pcpInfo['pcp_block_id'], 'owner_notify_id');
+      $owner_notification_option = CRM_Core_DAO::getFieldValue('CRM_PCP_BAO_PCPBlock', $pcpInfo['pcp_block_id'], 'owner_notify_id');
     }
     else {
       $owner_notification_option = CRM_PCP_BAO_PCP::getOwnerNotificationId($this->controller->get('component_page_id'), $this->_component ? $this->_component : 'contribute');

--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -1051,7 +1051,7 @@ class CRM_Profile_Form extends CRM_Core_Form {
     }
     foreach (CRM_Contact_BAO_Contact::$_greetingTypes as $greeting) {
       if ($greetingType = CRM_Utils_Array::value($greeting, $fields)) {
-        $customizedValue = CRM_Core_OptionGroup::getValue($greeting, 'Customized', 'name');
+        $customizedValue = CRM_Core_PseudoConstant::getKey('CRM_Contact_BAO_Contact', $greeting . '_id', 'Customized');
         if ($customizedValue == $greetingType && empty($fields[$greeting . '_custom'])) {
           $errors[$greeting . '_custom'] = ts('Custom  %1 is a required field if %1 is of type Customized.',
             array(1 => ucwords(str_replace('_', ' ', $greeting)))

--- a/CRM/Upgrade/Incremental/php/FourFour.php
+++ b/CRM/Upgrade/Incremental/php/FourFour.php
@@ -216,11 +216,11 @@ WHERE ceft.entity_table = 'civicrm_contribution' AND cft.payment_instrument_id I
     // CRM-13698 - add 'Available' and 'No-show' activity statuses
     $insertStatus = array();
     $nsinc = $avinc = $inc = 0;
-    if (!CRM_Core_OptionGroup::getValue('activity_status', 'Available', 'name')) {
+    if (!CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'status_id', 'Available')) {
       $insertStatus[] = "(%1, 'Available', %2, 'Available',  NULL, 0, NULL, %3, 0, 0, 1, NULL, NULL)";
       $avinc = $inc = 1;
     }
-    if (!CRM_Core_OptionGroup::getValue('activity_status', 'No_show', 'name')) {
+    if (!CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'status_id', 'No_show')) {
       $insertStatus[] = "(%1, 'No-show', %4, 'No_show',  NULL, 0, NULL, %5, 0, 0, 1, NULL, NULL)";
       $nsinc = $inc + 1;
     }

--- a/CRM/Utils/DeprecatedUtils.php
+++ b/CRM/Utils/DeprecatedUtils.php
@@ -242,16 +242,16 @@ function _civicrm_api3_deprecated_formatted_param($params, &$values, $create = F
         break;
 
       case 'payment_instrument':
-        require_once 'CRM/Core/OptionGroup.php';
-        $values['payment_instrument_id'] = CRM_Core_OptionGroup::getValue('payment_instrument', $value);
+        require_once 'CRM/Core/PseudoConstant.php';
+        $values['payment_instrument_id'] = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', $value);
         if (empty($values['payment_instrument_id'])) {
           return civicrm_api3_create_error("Payment Instrument is not valid: $value");
         }
         break;
 
       case 'contribution_status_id':
-        require_once 'CRM/Core/OptionGroup.php';
-        if (!$values['contribution_status_id'] = CRM_Core_OptionGroup::getValue('contribution_status', $value)) {
+        require_once 'CRM/Core/PseudoConstant.php';
+        if (!$values['contribution_status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $value)) {
           return civicrm_api3_create_error("Contribution Status is not valid: $value");
         }
         break;


### PR DESCRIPTION
Overview
----------------------------------------
This function is deprecated and needs to be replaced by respective function in ```CRM_Core_Pseudoconstant```. This PR is all about this replacement.

Before
----------------------------------------
The total number of such occurrences:
```
$ grep -irn "CRM_Core_OptionGroup::getValue(" CRM|wc -l
       46
```

After
----------------------------------------
```
$ grep -irn "CRM_Core_OptionGroup::getValue(" CRM|wc -l
       1
```

---

 * [CRM-20459: Actively deprecate CRM_Core_OptionGroup::getValue](https://issues.civicrm.org/jira/browse/CRM-20459)