### PR TITLE
dev/core#105 Manage PCP URL Wrong for the notification email under wo…

### DIFF
--- a/CRM/PCP/Form/Campaign.php
+++ b/CRM/PCP/Form/Campaign.php
@@ -307,7 +307,7 @@ class CRM_PCP_Form_Campaign extends CRM_Core_Form {
       $managePCPUrl = CRM_Utils_System::url('civicrm/admin/pcp',
         "reset=1",
         TRUE, NULL, FALSE,
-        FALSE
+        FALSE, TRUE
       );
       $this->assign('managePCPUrl', $managePCPUrl);
 


### PR DESCRIPTION
…rdpress

Overview
----------------------------------------
Manage PCP URL Wrong for the notification email under wordpress

Before
----------------------------------------
https://domain/civi/?page=CiviCRM&q=civicrm/admin/pcp&reset=1

After
----------------------------------------
https://domain/wp-admin/admin.php?page=CiviCRM&q=civicrm/admin/pcp&reset=1

Technical Details
----------------------------------------
Just setting backend to true


