### PR TITLE
Fix Fatal error on membership detail report (with ACLs enabled) dev/core/#100

### DIFF
--- a/CRM/Report/Form/Member/Detail.php
+++ b/CRM/Report/Form/Member/Detail.php
@@ -303,22 +303,6 @@ class CRM_Report_Form_Member_Detail extends CRM_Report_Form {
     }
   }
 
-  public function postProcess() {
-
-    $this->beginPostProcess();
-
-    // get the acl clauses built before we assemble the query
-    $this->buildACLClause($this->_aliases['civicrm_contact']);
-    $sql = $this->buildQuery(TRUE);
-
-    $rows = array();
-    $this->buildRows($sql, $rows);
-
-    $this->formatDisplay($rows);
-    $this->doTemplateAssignment($rows);
-    $this->endPostProcess($rows);
-  }
-
   /**
    * Alter display of rows.
    *

--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -158,6 +158,27 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test api to get rows from reports with ACLs enabled.
+   *
+   * Checking for lack of fatal error at the moment.
+   *
+   * @dataProvider getReportTemplates
+   *
+   * @param $reportID
+   *
+   * @throws \PHPUnit_Framework_IncompleteTestError
+   */
+  public function testReportTemplateGetRowsAllReportsACL($reportID) {
+    if (stristr($reportID, 'has existing issues')) {
+      $this->markTestIncomplete($reportID);
+    }
+    $this->hookClass->setHook('civicrm_aclWhereClause', array($this, 'aclWhereHookNoResults'));
+    $this->callAPISuccess('report_template', 'getrows', array(
+      'report_id' => $reportID,
+    ));
+  }
+
+  /**
    * Test get statistics.
    *
    * @dataProvider getReportTemplates


### PR DESCRIPTION
Overview
----------------------------------------
Fix fatal error on membership detail report when acls enabled

Before
----------------------------------------
Fatal error 

After
----------------------------------------
no error

Technical Details
----------------------------------------
Alternative to #12077 and  #11948  - from my analysis this is the right fix because the ONLY thing the postProcess hook does is add a line that breaks stuff. If we merge one of the others then once someone finally goes 'lets remove this function that is an unnecessary override' the ACLs will break

Comments
----------------------------------------
