### PR TITLE
Fix trigger generation for modified_date on custom data

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1259,6 +1259,10 @@ ORDER BY civicrm_custom_group.weight,
    */
   private static function _addWhereAdd(&$customGroupDAO, $entityType, $entityID = NULL, $allSubtypes = FALSE) {
     $addSubtypeClause = FALSE;
+    // This function isn't really accessible with user data but since the string
+    // is not passed as a param to the query CRM_Core_DAO::escapeString seems like a harmless
+    // precaution.
+    $entityType = CRM_Core_DAO::escapeString($entityType);
 
     switch ($entityType) {
       case 'Contact':
@@ -1281,13 +1285,7 @@ ORDER BY civicrm_custom_group.weight,
         }
         break;
 
-      case 'Case':
-      case 'Location':
-      case 'Address':
-      case 'Activity':
-      case 'Contribution':
-      case 'Membership':
-      case 'Participant':
+      default:
         $customGroupDAO->whereAdd("extends IN ('$entityType')");
         break;
     }


### PR DESCRIPTION
In 4.7.25 https://github.com/civicrm/civicrm-core/pull/10754/commits introduced
some modifications to the generation of triggers to update the modified date field.

It basically derived the entity being extended by a table and then if that entity had a
modified_date field then a trigger would be created to update that field.

However, a bug in the CRM_Core_BAO_CustomGroup::getAllCustomGroupsByBaseEntity function
meant that incorrect additional tables are also being updated for custom fields.

For entities extending contact the contact table AND the mailing table are updated. e.g
```
CREATE TRIGGER {mycustomtable}...
UPDATE civicrm_contact SET modified_date = CURRENT_TIMESTAMP WHERE id = NEW.entity_id;

UPDATE civicrm_mailing SET modified_date = CURRENT_TIMESTAMP WHERE id = NEW.entity_id;
```

For entities that extend tables that should not attract a trigger ONLY
the mailing table is updated.

The bug in CRM_Core_BAO_CustomGroup::getAllCustomGroupsByBaseEntity is that it adds the
WHERE clause 'AND extends IN ($entityType)' ONLY if $entityType is in a whitelist.

Invalid entities result in no filtering.

As a fix using a whitelist is no longer valid - we support any entity that might
be configured now so simply filtering on the entity makes sense.

Other paths to this function seem unlikely to pass in invalid entities & hence trigger this bug.

Overview
----------------------------------------
_A brief description of the pull request. Try to keep it non-technical._

Before
----------------------------------------
_The current status. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._

After
----------------------------------------
_What has been changed. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._

Technical Details
----------------------------------------
_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
