### PR TITLE
(NFC) Fix use of undefined constant USD in MoneyTest

### DIFF
--- a/tests/phpunit/CRM/Utils/MoneyTest.php
+++ b/tests/phpunit/CRM/Utils/MoneyTest.php
@@ -24,12 +24,12 @@ class CRM_Utils_MoneyTest extends CiviUnitTestCase {
    */
   public function subtractCurrenciesDataProvider() {
     return array(
-      array(number_format(300.00, 2), number_format(299.99, 2), USD, number_format(0.01, 2)),
-      array(2, 1, USD, 1),
-      array(0, 0, USD, 0),
-      array(1, 2, USD, -1),
-      array(number_format(19.99, 2), number_format(20.00, 2), USD, number_format(-0.01, 2)),
-      array('notanumber', 5.00, USD, NULL),
+      array(number_format(300.00, 2), number_format(299.99, 2), 'USD', number_format(0.01, 2)),
+      array(2, 1, 'USD', 1),
+      array(0, 0, 'USD', 0),
+      array(1, 2, 'USD', -1),
+      array(number_format(19.99, 2), number_format(20.00, 2), 'USD', number_format(-0.01, 2)),
+      array('notanumber', 5.00, 'USD', NULL),
     );
   }
 


### PR DESCRIPTION
ping @eileenmcnaughton This just removes a warning i get running the full test suite on php7.2 