### PR TITLE
dev/core#108 reset address array when setting new event location

### DIFF
--- a/CRM/Event/Form/ManageEvent/Location.php
+++ b/CRM/Event/Form/ManageEvent/Location.php
@@ -225,6 +225,8 @@ class CRM_Event_Form_ManageEvent_Location extends CRM_Event_Form_ManageEvent {
       CRM_Core_DAO::setFieldValue('CRM_Event_DAO_Event', $this->_id,
         'loc_block_id', 'null'
       );
+
+      $this->_values['address'] = array();
     }
 
     // if 'create new loc' optioin is selected OR selected new loc is different


### PR DESCRIPTION
Overview
----------------------------------------
Allow setting a new location for an event without affecting other events that previously shared a location. See https://lab.civicrm.org/dev/core/issues/108

Before
----------------------------------------
If an event shared a location with other events and you chose to create a new location, all events linked to the previously selected location would be updated.

After
----------------------------------------
The new event location is created without impacting other events.

Technical Details
----------------------------------------
The address array must be reset.
