### PR TITLE
karma.conf.js - Switch singleRun back to `false` default

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -67,6 +67,6 @@ module.exports = function(config) {
       outputFile: 'tests/output/karma.xml',
       suite: ''
     },
-    singleRun: true
+    singleRun: false
   });
 };


### PR DESCRIPTION
Overview
----------------------------------------
It's useful to have two ways of running the Karma test suite:

* For continuous integration, run once and report back with an XML file.
  (This has been `karma start --browsers PhantomJS --single-run --reporters dots,junit`.)
* For local dev, run in a watch mode which auto-runs any time you edit the JS code. (This has been `karma start`)

This partially reverts a recent change so that the second one works the same way as before.

Before
----------------------------------------
`karma start` (with no more options) does a single run.

After
----------------------------------------
`karma start` (with no more options) goes into live/auto-run mode.

