### PR TITLE
[NFC] Cleanup on ActivityTest class.

### DIFF
--- a/api/v3/Activity.php
+++ b/api/v3/Activity.php
@@ -635,7 +635,7 @@ function civicrm_api3_activity_delete($params) {
     return civicrm_api3_create_success(1, $params, 'Activity', 'delete');
   }
   else {
-    throw new API_Exception('Could not delete Activity');
+    throw new API_Exception('Could not delete Activity: ' . (int) $params['id']);
   }
 }
 

--- a/tests/phpunit/api/v3/ActivityTest.php
+++ b/tests/phpunit/api/v3/ActivityTest.php
@@ -47,6 +47,12 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
   protected $_apiversion = 3;
   protected $test_activity_type_value;
   protected $_contactID;
+  /**
+   * Activity type id created for use in this test class.
+   *
+   * @var int
+   */
+  protected $test_activity_type_id;
 
   /**
    * Test setup for every test.
@@ -232,7 +238,7 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
    * Check with incorrect required fields.
    */
   public function testActivityCreateWithUnknownActivityTypeId() {
-    $params = array(
+    $this->callAPIFailure('activity', 'create', [
       'source_contact_id' => $this->_contactID,
       'subject' => 'Make-it-Happen Meeting',
       'activity_date_time' => date('Ymd'),
@@ -241,9 +247,7 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
       'details' => 'a test activity',
       'status_id' => 1,
       'activity_type_id' => 699,
-    );
-
-    $result = $this->callAPIFailure('activity', 'create', $params);
+    ]);
   }
 
   public function testActivityCreateWithInvalidPriority() {
@@ -921,42 +925,17 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
   }
 
   /**
-   * Check activity deletion with empty params.
-   */
-  public function testDeleteActivityForEmptyParams() {
-    $params = array('version' => $this->_apiversion);
-    $this->callAPIFailure('activity', 'delete', $params);
-  }
-
-  /**
    * Check activity deletion without activity id.
    */
   public function testDeleteActivityWithoutId() {
-    $params = array(
-      'activity_name' => 'Meeting',
-      'version' => $this->_apiversion,
-    );
-    $result = $this->callAPIFailure('activity', 'delete', $params);
+    $this->callAPIFailure('activity', 'delete', ['activity_name' => 'Meeting'], 'Mandatory key(s) missing from params array: id');
   }
 
   /**
    * Check activity deletion without activity type.
    */
-  public function testDeleteActivityWithoutActivityType() {
-    $params = array('id' => 1);
-    $result = $this->callAPIFailure('activity', 'delete', $params);
-  }
-
-  /**
-   * Check activity deletion with incorrect data.
-   */
-  public function testDeleteActivityWithIncorrectActivityType() {
-    $params = array(
-      'id' => 1,
-      'activity_name' => 'Test Activity',
-    );
-
-    $result = $this->callAPIFailure('activity', 'delete', $params);
+  public function testDeleteActivityWithInvalidID() {
+    $this->callAPIFailure('activity', 'delete', ['id' => 1], 'Could not delete Activity: 1');
   }
 
   /**
@@ -964,11 +943,7 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
    */
   public function testDeleteActivity() {
     $result = $this->callAPISuccess('activity', 'create', $this->_params);
-    $params = array(
-      'id' => $result['id'],
-      'version' => $this->_apiversion,
-    );
-
+    $params = ['id' => $result['id']];
     $this->callAPIAndDocument('activity', 'delete', $params, __FUNCTION__, __FILE__);
   }
 
@@ -976,12 +951,10 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
    * Check if required fields are not passed.
    */
   public function testActivityUpdateWithoutRequired() {
-    $params = array(
+    $this->callAPIFailure('activity', 'create', [
       'subject' => 'this case should fail',
       'scheduled_date_time' => date('Ymd'),
-    );
-
-    $result = $this->callAPIFailure('activity', 'create', $params);
+    ]);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Remove some functions that were not testing what they said they were & clarify others. Improve
formatting & declaration of unused vars

Before
----------------------------------------
no change

After
----------------------------------------
no change

Technical Details
----------------------------------------
The delete tests were mostly failing (ie. where they were expected to fail) because id is a required field that there were not providing or it was invalid - test names like testDeleteActivityWithoutActivityType
were actually passing an invalid id & hence the (expected) api fail was because of that rather than the thing the fn name said. 

Comments
----------------------------------------
testDeleteActivityForEmptyParams is covered by SyntaxConformance