### PR TITLE
CRM-20430 - Permission 'save Report Criteria'.

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1470,6 +1470,9 @@ class CRM_Core_Permission {
       'create' => array('edit message templates', 'edit user-driven message templates', 'edit system workflow message templates'),
       'update' => array('edit message templates', 'edit user-driven message templates', 'edit system workflow message templates'),
     );
+
+    $permissions['report_template']['update'] = 'save Report Criteria';
+    $permissions['report_template']['create'] = 'save Report Criteria';
     return $permissions;
   }
 

--- a/CRM/Report/BAO/ReportInstance.php
+++ b/CRM/Report/BAO/ReportInstance.php
@@ -364,24 +364,35 @@ class CRM_Report_BAO_ReportInstance extends CRM_Report_DAO_ReportInstance {
    *  - general script-add.
    */
   public static function getActionMetadata() {
-    $actions = array(
-      'report_instance.save' => array('title' => ts('Save')),
-      'report_instance.copy' => array(
+    $actions = array();
+    if (CRM_Core_Permission::check('save Report Criteria')) {
+      $actions['report_instance.save'] = array('title' => ts('Save'));
+      $actions['report_instance.copy'] = array(
         'title' => ts('Save a Copy'),
         'data' => array(
           'is_confirm' => TRUE,
           'confirm_title' => ts('Save a copy...'),
           'confirm_refresh_fields' => json_encode(array(
-            'title' => array('selector' => '.crm-report-instanceForm-form-block-title', 'prepend' => ts('(Copy) ')),
-            'description' => array('selector' => '.crm-report-instanceForm-form-block-description', 'prepend' => ''),
-            'parent_id' => array('selector' => '.crm-report-instanceForm-form-block-parent_id', 'prepend' => ''),
+            'title' => array(
+              'selector' => '.crm-report-instanceForm-form-block-title',
+              'prepend' => ts('(Copy) '),
+            ),
+            'description' => array(
+              'selector' => '.crm-report-instanceForm-form-block-description',
+              'prepend' => '',
+            ),
+            'parent_id' => array(
+              'selector' => '.crm-report-instanceForm-form-block-parent_id',
+              'prepend' => '',
+            ),
           )),
         ),
-      ),
-      'report_instance.print' => array('title' => ts('Print Report')),
-      'report_instance.pdf' => array('title' => ts('Print to PDF')),
-      'report_instance.csv' => array('title' => ts('Export as CSV')),
-    );
+      );
+    }
+    $actions['report_instance.print'] = array('title' => ts('Print Report'));
+    $actions['report_instance.pdf'] = array('title' => ts('Print to PDF'));
+    $actions['report_instance.csv'] = array('title' => ts('Export as CSV'));
+
     if (CRM_Core_Permission::check('administer Reports')) {
       $actions['report_instance.delete'] = array(
         'title' => ts('Delete report'),

--- a/CRM/Report/Info.php
+++ b/CRM/Report/Info.php
@@ -87,6 +87,10 @@ class CRM_Report_Info extends CRM_Core_Component_Info {
         ts('access Report Criteria'),
         ts('Change report search criteria'),
       ),
+      'save Report Criteria' => array(
+        ts('save Report Criteria'),
+        ts('Save report search criteria'),
+      ),
       'administer private reports' => array(
         ts('administer private reports'),
         ts('Edit all private reports'),

--- a/CRM/Upgrade/Incremental/php/FiveFour.php
+++ b/CRM/Upgrade/Incremental/php/FiveFour.php
@@ -55,6 +55,7 @@ class CRM_Upgrade_Incremental_php_FiveFour extends CRM_Upgrade_Incremental_Base 
    *   an intermediate version; note that setPostUpgradeMessage is called repeatedly with different $revs.
    */
   public function setPostUpgradeMessage(&$postUpgradeMessage, $rev) {
+    $postUpgradeMessage .= '<p>' . ts('A new %1 permission has been added. It is not granted by default. If your users create reports, you may wish to review your permissions.', array(1 => 'save Report Criteria')) . '</p>';
     // Example: Generate a post-upgrade message.
     // if ($rev == '5.12.34') {
     //   $postUpgradeMessage .= '<br /><br />' . ts("By default, CiviCRM now disables the ability to import directly from SQL. To use this feature, you must explicitly grant permission 'import SQL datasource'.");

--- a/tools/drupal/modules/civicrm_webtest/civicrm_webtest.install
+++ b/tools/drupal/modules/civicrm_webtest/civicrm_webtest.install
@@ -43,6 +43,7 @@ function civicrm_webtest_enable() {
    'access deleted contacts',
    // 'access my cases and activities',
    'access Report Criteria',
+   'save Report Criteria',
    'access uploaded files',
    // 'add cases',
    'add contacts',


### PR DESCRIPTION
Overview
----------------------------------------
Nuance report permissions, adding a new save report criteria permission


Before
----------------------------------------
Without or with permission 
![screenshot 2018-05-10 18 27 38](https://user-images.githubusercontent.com/336308/39855394-da580ece-547f-11e8-9a62-c9e2ba1bef73.png)




After
----------------------------------------
Without permission 

![screenshot 2018-05-10 18 26 52](https://user-images.githubusercontent.com/336308/39855363-c205f930-547f-11e8-94e9-a9de4a650fdf.png)

With permission
![screenshot 2018-05-10 18 29 04](https://user-images.githubusercontent.com/336308/39855443-0ccb24a4-5480-11e8-9500-da27e6135239.png)

Technical Details
----------------------------------------
I am torn between renaming the perm to 'edit report_templates' for consistency with other entities or sticking with 'save Report Criteria' to be more consistent with other report perms - per original submitter

Comments
----------------------------------------
This is a recut of https://github.com/civicrm/civicrm-core/pull/10164 with the things that were blocking it tweaked. It does makes sense & has made sense to others - however, I won't keep this open if it is not merged by the time the 5.3 rc is recut that is it's 'last chance'

---

 * [CRM-20430: A permission 'save Report Criteria'](https://issues.civicrm.org/jira/browse/CRM-20430)