### PR TITLE
ApiExplorer - Output short array syntax

### DIFF
--- a/templates/CRM/Admin/Page/APIExplorer.js
+++ b/templates/CRM/Admin/Page/APIExplorer.js
@@ -585,13 +585,13 @@
       $.each(val, function(k, v) {
         ret += (ret ? ', ' : '') + "'" + k + "' => " + phpFormat(v);
       });
-      return 'array(' + ret + ')';
+      return '[' + ret + ']';
     }
     if ($.isArray(val)) {
       $.each(val, function(k, v) {
         ret += (ret ? ', ' : '') + phpFormat(v);
       });
-      return 'array(' + ret + ')';
+      return '[' + ret + ']';
     }
     return JSON.stringify(val).replace(/\$/g, '\\$');
   }
@@ -716,7 +716,7 @@
         js = key === 'return' && action !== 'getvalue' ? JSON.stringify(evaluate(value, true)) : json,
         php = key === 'return' && action !== 'getvalue' ? phpFormat(evaluate(value, true)) : phpFormat(value);
       if (!(i++)) {
-        q.php += ", array(\n";
+        q.php += ", [\n";
         q.json += ", {\n";
       } else {
         q.json += ",\n";
@@ -733,10 +733,10 @@
       q.wpcli += key + '=' + json + ' ';
     });
     if (i) {
-      q.php += ")";
+      q.php += "]";
       q.json += "\n}";
     }
-    q.php += ");";
+    q.php += "];";
     q.json += ").done(function(result) {\n  // do something\n});";
     q.smarty += "}\n{foreach from=$result.values item=" + entity.toLowerCase() + "}\n  {$" + entity.toLowerCase() + ".some_field}\n{/foreach}";
     if (!_.includes(action, 'get')) {


### PR DESCRIPTION
Overview
----------------------------------------
Now that CiviCRM requires PHP 5.4, we can encourage developers to use the new array syntax in their api code.

Before
----------------------------------------
![screenshot from 2018-05-10 11 14 29](https://user-images.githubusercontent.com/2874912/39877312-a467e3fc-5443-11e8-986a-e594c11638b0.png)


After
----------------------------------------
![screenshot from 2018-05-10 11 13 47](https://user-images.githubusercontent.com/2874912/39877322-aa5ef5c0-5443-11e8-8a2f-975e4c5622e7.png)

