### PR TITLE
dev/translation#9 Create API Action to rebuild Multilingual Schema

### DIFF
--- a/api/v3/System.php
+++ b/api/v3/System.php
@@ -427,3 +427,21 @@ function civicrm_api3_system_createmissinglogtables() {
   }
   return civicrm_api3_create_success(1);
 }
+
+/**
+ * Rebuild Multilingual Schema
+ *
+ */
+function civicrm_api3_system_rebuildmultilingualschema() {
+  $domain = new CRM_Core_DAO_Domain();
+  $domain->find(TRUE);
+
+  if ($domain->locales) {
+    $locales = explode(CRM_Core_DAO::VALUE_SEPARATOR, $domain->locales);
+    CRM_Core_I18n_Schema::rebuildMultilingualSchema($locales);
+    return civicrm_api3_create_success(1);
+  }
+  else {
+    throw new API_Exception('Cannot call rebuild Multilingual schema on non Multilingual database');
+  }
+}


### PR DESCRIPTION
==OVERVIEW

This adds an api (system.rebuildmultilingualschema) which may be helpful for multilingual sites that experience DB errors after upgrading. 

The upgrade to 4.7.31 adds a new multilingual column civicrm_uf_group.frontend_title that exposes an ongoing underlying problem in our upgrade script dealing poorly with multilingual sites. 

Multilingual sites that hit this issue can run the update (e.g drush cvapi system.rebuildmultilingualschema or via api explorer) to help get past upgrade issues


ping @eileenmcnaughton @totten 