### PR TITLE
dev/membership#2 - Add membership start date and registration start/end date to schedule reminder

### DIFF
--- a/CRM/Event/ActionMapping.php
+++ b/CRM/Event/ActionMapping.php
@@ -61,8 +61,6 @@ class CRM_Event_ActionMapping extends \Civi\ActionSchedule\Mapping {
       'entity_value_label' => ts('Event Type'),
       'entity_status' => 'civicrm_participant_status_type',
       'entity_status_label' => ts('Participant Status'),
-      'entity_date_start' => 'event_start_date',
-      'entity_date_end' => 'event_end_date',
     )));
     $registrations->register(CRM_Event_ActionMapping::create(array(
       'id' => CRM_Event_ActionMapping::EVENT_NAME_MAPPING_ID,
@@ -72,8 +70,6 @@ class CRM_Event_ActionMapping extends \Civi\ActionSchedule\Mapping {
       'entity_value_label' => ts('Event Name'),
       'entity_status' => 'civicrm_participant_status_type',
       'entity_status_label' => ts('Participant Status'),
-      'entity_date_start' => 'event_start_date',
-      'entity_date_end' => 'event_end_date',
     )));
     $registrations->register(CRM_Event_ActionMapping::create(array(
       'id' => CRM_Event_ActionMapping::EVENT_TPL_MAPPING_ID,
@@ -83,9 +79,22 @@ class CRM_Event_ActionMapping extends \Civi\ActionSchedule\Mapping {
       'entity_value_label' => ts('Event Template'),
       'entity_status' => 'civicrm_participant_status_type',
       'entity_status_label' => ts('Participant Status'),
-      'entity_date_start' => 'event_start_date',
-      'entity_date_end' => 'event_end_date',
     )));
+  }
+
+  /**
+   * Get a list of available date fields.
+   *
+   * @return array
+   *   Array(string $fieldName => string $fieldLabel).
+   */
+  public function getDateFields() {
+    return array(
+      'start_date' => ts('Event Start Date'),
+      'end_date' => ts('Event End Date'),
+      'registration_start_date' => ts('Registration Start Date'),
+      'registration_end_date' => ts('Registration End Date'),
+    );
   }
 
   /**

--- a/CRM/Member/ActionMapping.php
+++ b/CRM/Member/ActionMapping.php
@@ -58,9 +58,21 @@ class CRM_Member_ActionMapping extends \Civi\ActionSchedule\Mapping {
       'entity_value_label' => ts('Membership Type'),
       'entity_status' => 'auto_renew_options',
       'entity_status_label' => ts('Auto Renew Options'),
-      'entity_date_start' => 'membership_join_date',
-      'entity_date_end' => 'membership_end_date',
     )));
+  }
+
+  /**
+   * Get a list of available date fields.
+   *
+   * @return array
+   *   Array(string $fieldName => string $fieldLabel).
+   */
+  public function getDateFields() {
+    return array(
+      'join_date' => ts('Membership Join Date'),
+      'start_date' => ts('Membership Start Date'),
+      'end_date' => ts('Membership End Date'),
+    );
   }
 
   /**

--- a/tests/phpunit/CRM/Core/BAO/ActionScheduleTest.php
+++ b/tests/phpunit/CRM/Core/BAO/ActionScheduleTest.php
@@ -965,40 +965,43 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
   // TODO // function testActivityDateTime_NonMatch() { }
 
   /**
-   * For contacts/members which match schedule based on join date,
+   * For contacts/members which match schedule based on join/start date,
    * an email should be sent.
    */
-  public function testMembershipJoinDateMatch() {
-    $membership = $this->createTestObject('CRM_Member_DAO_Membership', array_merge($this->fixtures['rolling_membership'], array('status_id' => 1)));
-    $this->assertTrue(is_numeric($membership->id));
-    $result = $this->callAPISuccess('Email', 'create', array(
-      'contact_id' => $membership->contact_id,
-      'email' => 'test-member@example.com',
-      'location_type_id' => 1,
-    ));
-    $this->assertAPISuccess($result);
+  public function testMembershipDateMatch() {
+    foreach (['membership_join_date', 'membership_start_date'] as $date) {
+      $membership = $this->createTestObject('CRM_Member_DAO_Membership', array_merge($this->fixtures['rolling_membership'], array('status_id' => 1)));
+      $this->assertTrue(is_numeric($membership->id));
+      $result = $this->callAPISuccess('Email', 'create', array(
+        'contact_id' => $membership->contact_id,
+        'email' => 'test-member@example.com',
+        'location_type_id' => 1,
+      ));
+      $this->assertAPISuccess($result);
 
-    $this->callAPISuccess('contact', 'create', array_merge($this->fixtures['contact'], array('contact_id' => $membership->contact_id)));
-    $actionSchedule = $this->fixtures['sched_membership_join_2week'];
-    $actionSchedule['entity_value'] = $membership->membership_type_id;
-    $actionScheduleDao = CRM_Core_BAO_ActionSchedule::add($actionSchedule);
-    $this->assertTrue(is_numeric($actionScheduleDao->id));
+      $this->callAPISuccess('contact', 'create', array_merge($this->fixtures['contact'], array('contact_id' => $membership->contact_id)));
+      $actionSchedule = $this->fixtures['sched_membership_join_2week'];
+      $actionSchedule['start_action_date'] = $date;
+      $actionSchedule['entity_value'] = $membership->membership_type_id;
+      $actionScheduleDao = CRM_Core_BAO_ActionSchedule::add($actionSchedule);
+      $this->assertTrue(is_numeric($actionScheduleDao->id));
 
-    // start_date=2012-03-15 ; schedule is 2 weeks after start_date
-    $this->assertCronRuns(array(
-      array(
-        // Before the 2-week mark, no email.
-        'time' => '2012-03-28 01:00:00',
-        'recipients' => array(),
-        'subjects' => array(),
-      ),
-      array(
-        // After the 2-week mark, send an email.
-        'time' => '2012-03-29 01:00:00',
-        'recipients' => array(array('test-member@example.com')),
-        'subjects' => array('subject sched_membership_join_2week (joined March 15th, 2012)'),
-      ),
-    ));
+      // start_date=2012-03-15 ; schedule is 2 weeks after start_date
+      $this->assertCronRuns(array(
+        array(
+          // Before the 2-week mark, no email.
+          'time' => '2012-03-28 01:00:00',
+          'recipients' => array(),
+          'subjects' => array(),
+        ),
+        array(
+          // After the 2-week mark, send an email.
+          'time' => '2012-03-29 01:00:00',
+          'recipients' => array(array('test-member@example.com')),
+          'subjects' => array('subject sched_membership_join_2week (joined March 15th, 2012)'),
+        ),
+      ));
+    }
   }
 
 
@@ -1667,6 +1670,48 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
     $this->callAPISuccess('custom_group', 'delete', array('id' => $createGroup['id']));
   }
 
+  /**
+   * Test sched reminder set via registration date.
+   */
+  public function testEventTypeRegistrationDate() {
+    //Create contact
+    $contactParams = array(
+      'email' => 'test-event@example.com',
+    );
+    $contact = $this->individualCreate($contactParams);
+    //Add it as a participant to an event ending registration - 7 days from now.
+    $params = array(
+      'start_date' => date('Ymd', strtotime('-5 day')),
+      'end_date' => date('Ymd', strtotime('+7 day')),
+      'registration_start_date' => date('Ymd', strtotime('-5 day')),
+      'registration_end_date' => date('Ymd', strtotime('+7 day')),
+    );
+    $event = $this->eventCreate($params);
+    $this->participantCreate(array('contact_id' => $contact, 'event_id' => $event['id']));
+
+    //Create a scheduled reminder to send email 7 days before registration date.
+    $actionSchedule = $this->fixtures['sched_eventtype_start_1week_before'];
+    $actionSchedule['start_action_offset'] = 7;
+    $actionSchedule['start_action_unit'] = 'day';
+    $actionSchedule['start_action_date'] = 'registration_end_date';
+    $actionSchedule['entity_value'] = $event['values'][$event['id']]['event_type_id'];
+    $actionSchedule['entity_status'] = $this->callAPISuccessGetValue('ParticipantStatusType', array(
+      'return' => "id",
+      'name' => "Attended",
+    ));
+    $this->callAPISuccess('action_schedule', 'create', $actionSchedule);
+    //Run the cron and verify if an email was sent.
+    $this->assertCronRuns(array(
+      array(
+        'time' => date('Y-m-d'),
+        'recipients' => array(array('test-event@example.com')),
+      ),
+    ));
+  }
+
+  /**
+   * Test sched reminder set via start date.
+   */
   public function testEventTypeStartDate() {
     // Create event+participant with start_date = 20120315, end_date = 20120615.
     $participant = $this->createTestObject('CRM_Event_DAO_Participant', array_merge($this->fixtures['participant'], array('status_id' => 2)));


### PR DESCRIPTION
Overview
----------------------------------------
Add membership start date and event registration start/end date to schedule reminder.

Before
----------------------------------------
No membership start date OR event registration start/end date available on the form

**Membership** -
![image](https://user-images.githubusercontent.com/5929648/39921582-10dcd808-5539-11e8-95f2-4a243c1ca632.png)

**Event** -
![image](https://user-images.githubusercontent.com/5929648/39921552-f90e7b46-5538-11e8-8a76-1befe4a2b9f0.png)

After
----------------------------------------
Available and working.

**Membership** -
![image](https://user-images.githubusercontent.com/5929648/39921596-1fd4ab88-5539-11e8-9c9e-20623d07d0f0.png)

**Event** -
![image](https://user-images.githubusercontent.com/5929648/39921510-d5537b16-5538-11e8-81ab-df0e6f736d28.png)

--------

Gitlab Issue - https://lab.civicrm.org/dev/membership/issues/2