### PR TITLE
Refactor setup.sh to install bower and node dependencies from composer itself

### DIFF
--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -142,33 +142,6 @@ if [ -n "$DO_DOWNLOAD" ]; then
   pushd "$CALLEDPATH/.."
     COMPOSER=$(pickcmd composer composer.phar)
     $COMPOSER install
-
-    if has_commands bower karma ; then
-      ## dev dependencies have been installed globally; don't force developer to redownload
-      npm install --production
-    else
-      npm install
-    fi
-
-    BOWER=$(pickcmd node_modules/bower/bin/bower bower)
-    if [ -f "$BOWER" ]; then
-      NODE=$(pickcmd node nodejs)
-      BOWER="$NODE $BOWER"
-    fi
-    # Without the force flag, bower may not check for new versions or verify that installed software matches version specified in bower.json
-    # With the force flag, bower will ignore all caches and download all deps.
-    if [ -n "$OFFLINE" ]; then
-      BOWER_OPT=
-    elif [ ! -f "bower_components/.setupsh.ts" ]; then
-      ## First run -- or cleanup from failed run
-      BOWER_OPT=-f
-    elif [ "bower.json" -nt "bower_components/.setupsh.ts" ]; then
-      ## Bower.json has changed since last run
-      BOWER_OPT=-f
-    fi
-    [ -f "bower_components/.setupsh.ts" ] && rm -f "bower_components/.setupsh.ts"
-    $BOWER install $BOWER_OPT
-    touch bower_components/.setupsh.ts
   popd
 fi
 
@@ -235,4 +208,3 @@ if [ -n "$DO_FLUSH" ]; then
 fi
 
 echo; echo "NOTE: Logout from your CMS to avoid session conflicts."
-

--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,8 @@
       "bash tools/scripts/composer/tcpdf-cleanup.sh",
       "bash tools/scripts/composer/pear-exception-fix.sh",
       "bash tools/scripts/composer/net-smtp-fix.sh",
-      "bash tools/scripts/composer/phpword-jquery.sh"
+      "bash tools/scripts/composer/phpword-jquery.sh",
+      "bash tools/scripts/composer/download-dependencies.sh"
     ],
     "post-update-cmd": [
       "bash tools/scripts/composer/dompdf-cleanup.sh",

--- a/tools/scripts/composer/download-dependencies.sh
+++ b/tools/scripts/composer/download-dependencies.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+## Install/Update the node and bower libraries which are deployed under civicrm
+
+source "bin/setup.lib.sh"
+
+set -x
+
+if has_commands bower karma ; then
+  ## dev dependencies have been installed globally; don't force developer to redownload
+  npm install --production
+else
+  npm install
+fi
+
+BOWER=$(pickcmd node_modules/bower/bin/bower bower);
+if [ -f "$BOWER" ]; then
+  NODE=$(pickcmd node nodejs)
+  BOWER="$NODE $BOWER"
+fi
+# Without the force flag, bower may not check for new versions or verify that installed software matches version specified in bower.json
+# With the force flag, bower will ignore all caches and download all deps.
+if [ -n "$OFFLINE" ]; then
+  BOWER_OPT=
+elif [ ! -f "bower_components/.setupsh.ts" ]; then
+  ## First run -- or cleanup from failed run
+  BOWER_OPT=-f
+elif [ "bower.json" -nt "bower_components/.setupsh.ts" ]; then
+  ## Bower.json has changed since last run
+  BOWER_OPT=-f
+fi
+[ -f "bower_components/.setupsh.ts" ] && rm -f "bower_components/.setupsh.ts"
+$BOWER install $BOWER_OPT
+touch bower_components/.setupsh.ts


### PR DESCRIPTION
Overview
----------------------------------------
This PR shifts the code which installs bower and node dependencies, into a separate shell script file ```tools/scripts/composer/download-dependencies.sh```. Later executed via composer on post install.

Before
----------------------------------------
Bower and node dependencies are installed via distmaker or on manual CLI execution.

After
----------------------------------------
Bower and node dependencies are installed via composer.
