### PR TITLE
Add DB default of 0 for custom_group.is_multiple - CRM-21853

### DIFF
--- a/CRM/Upgrade/Incremental/sql/5.3.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.3.alpha1.mysql.tpl
@@ -1,1 +1,4 @@
 {* file to handle db changes in 5.3.alpha1 during upgrade *}
+ALTER TABLE civicrm_custom_group ALTER column is_multiple SET DEFAULT 0;
+UPDATE civicrm_custom_group SET is_multiple = 0 WHERE is_multiple IS NULL;
+ALTER TABLE civicrm_custom_group ALTER column is_active SET DEFAULT 1;

--- a/xml/schema/Core/CustomGroup.xml
+++ b/xml/schema/Core/CustomGroup.xml
@@ -140,6 +140,7 @@
     <type>boolean</type>
     <title>Custom Group Is Active?</title>
     <comment>Is this property active?</comment>
+    <default>1</default>
     <add>1.1</add>
   </field>
   <field>
@@ -154,6 +155,7 @@
     <type>boolean</type>
     <title>Supports Multiple Records</title>
     <comment>Does this group hold multiple values?</comment>
+    <default>0</default>
     <add>2.0</add>
   </field>
   <field>


### PR DESCRIPTION
Overview
----------------------------------------
Make the civicrm_custom_group.is_multiple field DB default = 0 (to resolve https://github.com/civicrm/civicrm-core/pull/11877). I also set is_active to default to 1 while I was at it as it seemed broadly consistent with other tables

Before
----------------------------------------
No default for field civicrm_custom_group.is_multiple

After
----------------------------------------
Default is 0

Technical Details
----------------------------------------
Tests should pass on #11877 after this & it should be mergeable

Comments
----------------------------------------
@mickadoo this is to try to resolve an older PR of yours. I thought about closing it but decided the missing piece of work was relatively trivial

---

 * [CRM-21853: Edting CustomGroup always sets is_multiple to false by default](https://issues.civicrm.org/jira/browse/CRM-21853)