### PR TITLE
dev/core#111 Allow creation of MembershipType custom data

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1799,6 +1799,9 @@ ORDER BY civicrm_custom_group.weight,
       case 'Membership':
         return 'civicrm_membership';
 
+      case 'MembershipType':
+        return 'civicrm_membership_type';
+
       case 'Participant':
       case 'ParticipantRole':
       case 'ParticipantEventName':

--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -223,6 +223,7 @@ class CRM_Core_SelectValues {
       'ContributionRecur' => ts('Recurring Contributions'),
       'Group' => ts('Groups'),
       'Membership' => ts('Memberships'),
+      'MembershipType' => ts('Membership Types'),
       'Event' => ts('Events'),
       'Participant' => ts('Participants'),
       'ParticipantRole' => ts('Participants (Role)'),


### PR DESCRIPTION
Overview
----------------------------------------
Basic changes required to support custom data on MembershipType entity (see #11794).
Alternative is to add via cg_extend_objects but this cannot be done via the UI.

Before
----------------------------------------
Cannot add custom data to MembershipType entity.

After
----------------------------------------
Can add custom data to MembershipType entity.